### PR TITLE
fix: Add Firefox-specific CSS for textedit

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -276,3 +276,19 @@
     opacity: 0.05;
   }
 }
+
+/* Firefox-specific fixes for text editor */
+@-moz-document url-prefix() {
+  .ProseMirror {
+    cursor: text !important;
+  }
+
+  .ProseMirror * {
+    user-select: text !important;
+    -moz-user-select: text !important;
+  }
+
+  .ProseMirror p {
+    line-height: 1.5 !important;
+  }
+}


### PR DESCRIPTION
- Resolves cursor up and down arrow behavior and text selection issues in firefox

video: https://screen.studio/share/apBJbYRx