### PR TITLE
Fix video toggle order in iPod screen

### DIFF
--- a/src/apps/ipod/components/IpodScreen.tsx
+++ b/src/apps/ipod/components/IpodScreen.tsx
@@ -581,12 +581,13 @@ export function IpodScreen({
                 if (!menuMode && currentTrack) {
                   registerActivity();
                   if (!isPlaying) {
-                    // Resume playback first
-                    handlePlay();
-                    // If the video is currently hidden, show it
+                    // If the video is currently hidden, show it first so the
+                    // user gesture also applies to the player element.
                     if (!showVideo) {
                       onToggleVideo();
                     }
+                    // Resume playback
+                    handlePlay();
                   } else {
                     // Already playing — simply toggle video visibility
                     onToggleVideo();


### PR DESCRIPTION
## Summary
- ensure video display is enabled before attempting to play when tapping the Now Playing screen

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*