### PR TITLE
Fix iPod backlight toggle

### DIFF
--- a/src/apps/ipod/components/IpodAppComponent.tsx
+++ b/src/apps/ipod/components/IpodAppComponent.tsx
@@ -150,9 +150,19 @@ export function IpodAppComponent({
 
   const memoizedToggleBacklight = useCallback(() => {
     toggleBacklight();
-    showStatus(useIpodStore.getState().backlightOn ? "Light ON" : "Light OFF");
-    registerActivity();
-  }, [toggleBacklight, showStatus, registerActivity]);
+    const isOn = useIpodStore.getState().backlightOn;
+    showStatus(isOn ? "Light ON" : "Light OFF");
+
+    // Only call registerActivity when turning the backlight on to avoid
+    // immediately re-enabling it after the user turns it off via the menu.
+    if (isOn) {
+      registerActivity();
+    } else {
+      // Mimic the parts of registerActivity that update activity tracking
+      setLastActivityTime(Date.now());
+      userHasInteractedRef.current = true;
+    }
+  }, [toggleBacklight, showStatus, registerActivity, setLastActivityTime]);
 
   const memoizedChangeTheme = useCallback(
     (newTheme: "classic" | "black") => {
@@ -165,10 +175,14 @@ export function IpodAppComponent({
 
   const handleMenuItemAction = useCallback(
     (action: () => void) => {
-      registerActivity();
-      action();
+      if (action === memoizedToggleBacklight) {
+        action();
+      } else {
+        registerActivity();
+        action();
+      }
     },
-    [registerActivity]
+    [registerActivity, memoizedToggleBacklight]
   );
 
   const memoizedToggleRepeat = useCallback(() => {


### PR DESCRIPTION
## Summary
- make Backlight menu option correctly toggle when off

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: TS2307 Cannot find module 'wavesurfer.js')*