### PR TITLE
Disable text selection on window controls

### DIFF
--- a/src/components/layout/WindowFrame.tsx
+++ b/src/components/layout/WindowFrame.tsx
@@ -609,7 +609,7 @@ export function WindowFrame({
               onClick={handleClose}
               onMouseDown={(e) => e.stopPropagation()}
               onTouchStart={(e) => e.stopPropagation()}
-              className="relative ml-2 w-4 h-4 cursor-default"
+              className="relative ml-2 w-4 h-4 cursor-default select-none"
             >
               <div className="absolute inset-0 -m-2" />{" "}
               {/* Larger click area */}


### PR DESCRIPTION
## Summary
- prevent selecting text on the window close button

## Testing
- `bunx eslint .` *(fails: Cannot find package '@eslint/js')*
- `bunx tsc -b` *(fails: many missing type declarations)*