### PR TITLE
Fix video toggle order in iPod screen

### DIFF
--- a/src/apps/ipod/components/IpodScreen.tsx
+++ b/src/apps/ipod/components/IpodScreen.tsx
@@ -581,11 +581,18 @@ export function IpodScreen({
                 if (!menuMode && currentTrack) {
                   registerActivity();
                   if (!isPlaying) {
-                    // Resume playback first
-                    handlePlay();
-                    // If the video is currently hidden, show it
+                    // If the video is currently hidden, show it first so the
+                    // user gesture also applies to the player element.
                     if (!showVideo) {
                       onToggleVideo();
+                      // Give React a moment to render the player before
+                      // resuming playback so the gesture is linked.
+                      setTimeout(() => {
+                        handlePlay();
+                      }, 100);
+                    } else {
+                      // Resume playback immediately when video already visible
+                      handlePlay();
                     }
                   } else {
                     // Already playing — simply toggle video visibility


### PR DESCRIPTION
## Summary
- ensure video display is enabled before attempting to play when tapping the Now Playing screen
- add a short delay so playback starts after the video element renders

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*