### PR TITLE
Disable long press on FileIcon images

### DIFF
--- a/src/apps/finder/components/FileIcon.tsx
+++ b/src/apps/finder/components/FileIcon.tsx
@@ -162,6 +162,8 @@ export function FileIcon({
             alt={name}
             className={`object-cover ${sizes.image} rounded`}
             onError={handleImageError}
+            onContextMenu={(e) => e.preventDefault()}
+            draggable={false}
           />
         </div>
       );
@@ -173,6 +175,8 @@ export function FileIcon({
         alt={isDirectory ? "Directory" : "File"}
         className={`object-contain ${sizes.image} ${isDirectory && isDropTarget ? "invert" : ""}`}
         style={{ imageRendering: "pixelated" }}
+        onContextMenu={(e) => e.preventDefault()}
+        draggable={false}
       />
     );
   };


### PR DESCRIPTION
## Summary
- prevent browser context menu when holding file icon images on mobile

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `bun run lint` *(fails: Cannot find package '@eslint/js')*