### PR TITLE
Disable long press on FileIcon images

### DIFF
--- a/src/apps/finder/components/FileIcon.tsx
+++ b/src/apps/finder/components/FileIcon.tsx
@@ -160,8 +160,10 @@ export function FileIcon({
           <img
             src={imgSrc}
             alt={name}
-            className={`object-cover ${sizes.image} rounded`}
+            className={`no-touch-callout object-cover ${sizes.image} rounded`}
             onError={handleImageError}
+            onContextMenu={(e) => e.preventDefault()}
+            draggable={false}
           />
         </div>
       );
@@ -171,8 +173,10 @@ export function FileIcon({
       <img
         src={getIconPath()}
         alt={isDirectory ? "Directory" : "File"}
-        className={`object-contain ${sizes.image} ${isDirectory && isDropTarget ? "invert" : ""}`}
+        className={`no-touch-callout object-contain ${sizes.image} ${isDirectory && isDropTarget ? "invert" : ""}`}
         style={{ imageRendering: "pixelated" }}
+        onContextMenu={(e) => e.preventDefault()}
+        draggable={false}
       />
     );
   };

--- a/src/index.css
+++ b/src/index.css
@@ -138,6 +138,10 @@
     user-select: none;
     -webkit-user-select: none;
   }
+
+  .no-touch-callout {
+    -webkit-touch-callout: none;
+  }
   body {
     @apply bg-background text-foreground;
     font-family: "ChicagoKare", "ArkPixel", "SerenityOS-Emoji", system-ui,


### PR DESCRIPTION
## Summary
- prevent image hold menu via `-webkit-touch-callout: none`
- apply new class to FileIcon images

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `bun run lint` *(fails: Cannot find package '@eslint/js')*