### PR TITLE
Sync player position during fullscreen toggle

### DIFF
--- a/src/apps/ipod/components/IpodAppComponent.tsx
+++ b/src/apps/ipod/components/IpodAppComponent.tsx
@@ -306,6 +306,13 @@ export function IpodAppComponent({
     setElapsedTime(0);
   }, [currentIndex]);
 
+  // Sync playback position when entering or exiting full screen
+  useEffect(() => {
+    if (playerRef.current) {
+      playerRef.current.seekTo(elapsedTime, "seconds");
+    }
+  }, [isFullScreen]);
+
   useEffect(() => {
     return () => {
       if (statusTimeoutRef.current) {


### PR DESCRIPTION
## Summary
- keep player position in sync when toggling the iPod fullscreen portal

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*