### PR TITLE
Fix camera stream cleanup on Photo Booth close

### DIFF
--- a/src/apps/photo-booth/components/PhotoBoothComponent.tsx
+++ b/src/apps/photo-booth/components/PhotoBoothComponent.tsx
@@ -163,11 +163,12 @@ export function PhotoBoothComponent({
       }
     }
 
-    // Only clean up when window actually closes
+    // Always clean up the camera stream when the component unmounts or the
+    // effect re-runs. This guarantees that the webcam is released even if the
+    // component unmounts immediately after `isWindowOpen` becomes false,
+    // preventing lingering active streams on mobile browsers like iOS.
     return () => {
-      if (!isWindowOpen) {
-        stopCamera();
-      }
+      stopCamera();
     };
   }, [isWindowOpen, isForeground, stream]);
 


### PR DESCRIPTION
## Summary
- always stop the webcam stream when the Photo Booth component unmounts

## Testing
- `npm run lint` *(fails: prefer-const, no-explicit-any, etc.)*