### PR TITLE
Fix clearing lyrics when skipping tracks

### DIFF
--- a/src/apps/ipod/components/IpodAppComponent.tsx
+++ b/src/apps/ipod/components/IpodAppComponent.tsx
@@ -566,6 +566,9 @@ export function IpodAppComponent({
 
   useEffect(() => {
     setElapsedTime(0);
+    // Clear any previously fetched lyrics immediately when the track changes
+    // so the AI chat doesn't use lyrics from the previous song as context
+    useIpodStore.setState({ currentLyrics: null });
   }, [currentIndex]);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- clear lyrics in store whenever the current track index changes so skipped songs don't leak lyrics to AI context

## Testing
- `npm run lint` *(fails: prefer-const etc.)*