### PR TITLE
Add U2 iPod theme

### DIFF
--- a/src/apps/ipod/components/IpodAppComponent.tsx
+++ b/src/apps/ipod/components/IpodAppComponent.tsx
@@ -494,9 +494,15 @@ export function IpodAppComponent({
   }, [toggleBacklight, showStatus, registerActivity, setLastActivityTime]);
 
   const memoizedChangeTheme = useCallback(
-    (newTheme: "classic" | "black") => {
+    (newTheme: "classic" | "black" | "u2") => {
       setTheme(newTheme);
-      showStatus(newTheme === "classic" ? "Theme: Classic" : "Theme: Black");
+      showStatus(
+        newTheme === "classic"
+          ? "Theme: Classic"
+          : newTheme === "black"
+          ? "Theme: Black"
+          : "Theme: U2"
+      );
       registerActivity();
     },
     [setTheme, showStatus, registerActivity]
@@ -534,7 +540,12 @@ export function IpodAppComponent({
 
   const memoizedHandleThemeChange = useCallback(() => {
     const currentTheme = useIpodStore.getState().theme;
-    const nextTheme = currentTheme === "classic" ? "black" : "classic";
+    const nextTheme =
+      currentTheme === "classic"
+        ? "black"
+        : currentTheme === "black"
+        ? "u2"
+        : "classic";
     memoizedChangeTheme(nextTheme);
   }, [memoizedChangeTheme]);
 
@@ -729,7 +740,12 @@ export function IpodAppComponent({
         label: "Theme",
         action: memoizedHandleThemeChange,
         showChevron: false,
-        value: currentTheme === "classic" ? "Classic" : "Black",
+        value:
+          currentTheme === "classic"
+            ? "Classic"
+            : currentTheme === "black"
+            ? "Black"
+            : "U2",
       },
     ];
   }, [

--- a/src/apps/ipod/components/IpodMenuBar.tsx
+++ b/src/apps/ipod/components/IpodMenuBar.tsx
@@ -458,6 +458,14 @@ export function IpodMenuBar({
               {currentTheme === "black" ? "✓ Black" : "Black"}
             </span>
           </DropdownMenuItem>
+          <DropdownMenuItem
+            onClick={() => setTheme("u2")}
+            className="text-md h-6 px-3 active:bg-gray-900 active:text-white"
+          >
+            <span className={cn(currentTheme !== "u2" && "pl-4")}>
+              {currentTheme === "u2" ? "✓ U2" : "U2"}
+            </span>
+          </DropdownMenuItem>
 
           <DropdownMenuSeparator className="h-[2px] bg-black my-1" />
 

--- a/src/apps/ipod/components/IpodWheel.tsx
+++ b/src/apps/ipod/components/IpodWheel.tsx
@@ -225,7 +225,11 @@ export function IpodWheel({
     <div
       className={cn(
         "mt-6 relative w-[180px] h-[180px] rounded-full flex items-center justify-center select-none",
-        theme === "classic" ? "bg-gray-300/60" : "bg-neutral-800/50"
+        theme === "classic"
+          ? "bg-gray-300/60"
+          : theme === "u2"
+          ? "bg-red-700/60"
+          : "bg-neutral-800/50"
       )}
     >
       {/* Center button */}
@@ -233,7 +237,9 @@ export function IpodWheel({
         onClick={() => onWheelClick("center")}
         className={cn(
           "absolute w-16 h-16 rounded-full z-10 flex items-center justify-center",
-          theme === "classic" ? "bg-white/30" : "bg-black/40"
+          theme === "classic"
+            ? "bg-white/30"
+            : "bg-black/40"
         )}
       />
 

--- a/src/stores/useIpodStore.ts
+++ b/src/stores/useIpodStore.ts
@@ -328,7 +328,7 @@ interface IpodData {
   isPlaying: boolean;
   showVideo: boolean;
   backlightOn: boolean;
-  theme: "classic" | "black";
+  theme: "classic" | "black" | "u2";
   lcdFilterOn: boolean;
   showLyrics: boolean;
   lyricsAlignment: LyricsAlignment;
@@ -370,7 +370,7 @@ export interface IpodState extends IpodData {
   toggleBacklight: () => void;
   toggleLcdFilter: () => void;
   toggleFullScreen: () => void;
-  setTheme: (theme: "classic" | "black") => void;
+  setTheme: (theme: "classic" | "black" | "u2") => void;
   addTrack: (track: Track) => void;
   clearLibrary: () => void;
   resetLibrary: () => void;


### PR DESCRIPTION
## Summary
- introduce "u2" theme with red wheel
- update theme cycle and menu items for U2
- handle red click wheel styling
- keep center button black for U2 wheel

## Testing
- `npm run lint` *(fails: Unexpected any etc.)*
- `npm run build`
