### PR TITLE
Fix: Ensure correct song titles for ipodAddAndPlaySong

### DIFF
--- a/api/chat.ts
+++ b/api/chat.ts
@@ -514,27 +514,12 @@ export default async function handler(req: Request) {
         },
         ipodAddAndPlaySong: {
           description:
-            "Adds a song to the iPod library and plays it. The iPod app will be launched if it's not already open. Requires a YouTube video ID and URL.",
-          parameters: z
-            .object({
-              id: z
-                .string()
-                .describe("The YouTube video ID of the song to add and play."),
-              url: z.string().describe("The YouTube video URL of the song."),
-              title: z.string().describe("The title of the song."),
-              artist: z
-                .string()
-                .optional()
-                .describe("The artist of the song."),
-              album: z
-                .string()
-                .optional()
-                .describe("The album of the song."),
-            })
-            .refine((data) => data.id && data.url && data.title, {
-              message:
-                "Parameters 'id', 'url', and 'title' are mandatory and must be provided.",
-            }),
+            "Adds a song to the iPod library by its YouTube video ID and plays it. The system will automatically fetch title, artist, and album information. The iPod app will be launched if it's not already open.",
+          parameters: z.object({
+            id: z
+              .string()
+              .describe("The YouTube video ID of the song to add and play."),
+          }),
         },
         ipodNextTrack: {
           description:

--- a/src/apps/chats/hooks/useAiChat.ts
+++ b/src/apps/chats/hooks/useAiChat.ts
@@ -569,20 +569,8 @@ export function useAiChat() {
             return `Playing ${trackDesc}.`;
           }
           case "ipodAddAndPlaySong": {
-            const { id, url, title, artist, album } = toolCall.args as {
-              id: string;
-              url: string;
-              title: string;
-              artist?: string;
-              album?: string;
-            };
-            console.log("[ToolCall] ipodAddAndPlaySong:", {
-              id,
-              url,
-              title,
-              artist,
-              album,
-            });
+            const { id } = toolCall.args as { id: string };
+            console.log("[ToolCall] ipodAddAndPlaySong:", { id });
 
             // Ensure iPod app is open
             const appState = useAppStore.getState();
@@ -590,10 +578,15 @@ export function useAiChat() {
               launchApp("ipod");
             }
 
-            const { addTrack } = useIpodStore.getState();
-            addTrack({ id, url, title, artist, album }); // addTrack will also play it
+            const addedTrack = await useIpodStore
+              .getState()
+              .addTrackFromVideoId(id);
 
-            return `Added '${title}' to iPod and started playing.`;
+            if (addedTrack) {
+              return `Added '${addedTrack.title}' to iPod and started playing.`;
+            } else {
+              return `Failed to add song with ID ${id} to iPod.`;
+            }
           }
           case "ipodNextTrack": {
             console.log("[ToolCall] ipodNextTrack");


### PR DESCRIPTION
The ipodAddAndPlaySong feature was previously relying on me to provide the title, artist, and album for a song. This could lead to incorrect metadata if my information was outdated or poorly formatted.

This commit addresses the issue by:
1. Modifying the `ipodAddAndPlaySong` feature schema in `api/chat.ts` to only require the YouTube video `id` as input from me. The `url` is derived, and `title`, `artist`, `album` are no longer accepted as direct inputs from me for this feature.

2. Introducing a new store action `addTrackFromVideoId(videoId)` in `src/stores/useIpodStore.ts`. This action encapsulates the logic for:
    - Fetching oEmbed data for the given `videoId` to get an initial raw title.
    - Calling the `/api/parse-title` service with the raw title to obtain refined title, artist, and album information.
    - Adding the track with the refined metadata to the iPod store.

3. Updating the client-side handler for the `ipodAddAndPlaySong` feature in `src/apps/chats/hooks/useAiChat.ts` to call the new `addTrackFromVideoId` store action.

This ensures that when a song is added via the `ipodAddAndPlaySong` feature, its metadata is consistently fetched and processed by the system, leveraging the `parse-title` API for accuracy, rather than relying on potentially incorrect information from me.

Note: Interactive testing of this change was blocked by an `npm install` error ("Invalid Version"). The changes are
based on logical correctness and direct implementation of the approved plan.