### PR TITLE
Add BoA and BIGBANG tracks

### DIFF
--- a/src/stores/useIpodStore.ts
+++ b/src/stores/useIpodStore.ts
@@ -362,6 +362,20 @@ export const IPOD_DEFAULT_VIDEOS = [
     lyricOffset: 2000,
   },
   {
+    id: "D3IDK_R1LTg",
+    url: "https://www.youtube.com/watch?v=D3IDK_R1LTg",
+    title: "Every Heart-ミンナノキモチ-",
+    artist: "BoA",
+    lyricOffset: -3200,
+  },
+  {
+    id: "bjTEMBB-mjY",
+    url: "https://www.youtube.com/watch?v=bjTEMBB-mjY",
+    title: "WE BELONG TOGETHER",
+    artist: "BIGBANG",
+    lyricOffset: -3900,
+  },
+  {
     id: "4j7Umwfx60Q",
     url: "https://www.youtube.com/watch?v=4j7Umwfx60Q",
     title: "4 Walls",


### PR DESCRIPTION
## Summary
- add BoA and BIGBANG songs after Sweet Life in useIpodStore

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: 44 errors, 76 warnings)*