### PR TITLE
load ipod tracks from json

### DIFF
--- a/public/ipod-videos.json
+++ b/public/ipod-videos.json
@@ -1,0 +1,404 @@
+{
+  "videos": [
+    {
+      "id": "nBoV9ZJeSp8",
+      "url": "https://www.youtube.com/watch?v=nBoV9ZJeSp8",
+      "title": "SLOW FADE",
+      "artist": "Christian Kuria",
+      "lyricOffset": 1000
+    },
+    {
+      "id": "XnbsIl2BnWw",
+      "url": "https://www.youtube.com/watch?v=XnbsIl2BnWw",
+      "title": "Chanel",
+      "artist": "Frank Ocean",
+      "lyricOffset": 1950
+    },
+    {
+      "id": "SNq4zqTN_DQ",
+      "url": "https://www.youtube.com/watch?v=SNq4zqTN_DQ",
+      "title": "Last Summer Whisper",
+      "artist": "Anri",
+      "lyricOffset": 1200
+    },
+    {
+      "id": "txroGbuRt_w",
+      "url": "https://www.youtube.com/watch?v=txroGbuRt_w",
+      "title": "Thirsty (Bad Boy Remix)",
+      "artist": "aespa",
+      "lyricOffset": 800
+    },
+    {
+      "id": "ablEaBQd3lU",
+      "url": "https://www.youtube.com/watch?v=ablEaBQd3lU",
+      "title": "Honestly",
+      "artist": "RIIZE",
+      "lyricOffset": 1200
+    },
+    {
+      "id": "jKnLSg83Nqc",
+      "url": "https://youtu.be/jKnLSg83Nqc?si=0mX3pYk0q98Ndoui",
+      "title": "ㅠ.ㅠ (You)",
+      "artist": "Crush",
+      "album": "wonderego",
+      "lyricOffset": 1000
+    },
+    {
+      "id": "hCg9tezGBWE",
+      "url": "https://youtu.be/hCg9tezGBWE?si=4KFJNVTDm6OA2kK8",
+      "title": "Magnetic",
+      "artist": "ILLIT",
+      "album": "SUPER REAL ME",
+      "lyricOffset": -1000
+    },
+    {
+      "id": "Dlz_XHeUUis",
+      "url": "https://youtu.be/Dlz_XHeUUis?si=R7MDtk9W8suZcQDW",
+      "title": "White Ferrari",
+      "artist": "Frank Ocean",
+      "album": "Blonde",
+      "lyricOffset": 1450
+    },
+    {
+      "id": "Q3K0TOvTOno",
+      "url": "https://youtu.be/Q3K0TOvTOno?si=_VbKas8ZYd9jpXiA",
+      "title": "How Sweet",
+      "artist": "NewJeans",
+      "album": "How Sweet",
+      "lyricOffset": -10500
+    },
+    {
+      "id": "ft70sAYrFyY",
+      "url": "https://youtu.be/ft70sAYrFyY?si=SJXlm-KRfgrMIODE",
+      "title": "Bubble Gum",
+      "artist": "NewJeans",
+      "album": "How Sweet",
+      "lyricOffset": -9150
+    },
+    {
+      "id": "-nEGVrzPaiU",
+      "url": "https://www.youtube.com/watch?v=-nEGVrzPaiU",
+      "title": "Tick-Tack",
+      "artist": "ILLIT",
+      "album": "I'll Like You",
+      "lyricOffset": -16350
+    },
+    {
+      "id": "lXd1GHJPx-A",
+      "url": "https://www.youtube.com/watch?v=lXd1GHJPx-A",
+      "title": "Promise",
+      "artist": "Jagged Edge",
+      "album": "JE Heartbreak (Explicit)",
+      "lyricOffset": -6200
+    },
+    {
+      "id": "Y_AxRCNFT2g",
+      "url": "https://www.youtube.com/watch?v=Y_AxRCNFT2g",
+      "title": "Supernova (House Remix)",
+      "artist": "aespa",
+      "album": "Armageddon",
+      "lyricOffset": -5200
+    },
+    {
+      "id": "yP8nAoFi6JY",
+      "url": "https://www.youtube.com/watch?v=yP8nAoFi6JY",
+      "title": "Supernatural (Miami Bass Remix)",
+      "artist": "NewJeans",
+      "album": "Supernatural",
+      "lyricOffset": 22400
+    },
+    {
+      "id": "1FNI1i7H1Kc",
+      "url": "https://www.youtube.com/watch?v=1FNI1i7H1Kc",
+      "title": "The Chase (R&B Remix)",
+      "artist": "Hearts2Hearts",
+      "album": "The Chase",
+      "lyricOffset": -6600
+    },
+    {
+      "id": "LVLOwwGVVZ0",
+      "url": "https://www.youtube.com/watch?v=LVLOwwGVVZ0",
+      "title": "Right Now (R&B Remix)",
+      "artist": "NewJeans",
+      "album": "Supernatural",
+      "lyricOffset": -2850
+    },
+    {
+      "id": "AGaTzDTnYGY",
+      "url": "https://www.youtube.com/watch?v=AGaTzDTnYGY",
+      "title": "How Sweet (UK Garage Remix)",
+      "artist": "NewJeans",
+      "album": "How Sweet",
+      "lyricOffset": 2500
+    },
+    {
+      "id": "XJWqHmY-g9U",
+      "url": "https://www.youtube.com/watch?v=XJWqHmY-g9U",
+      "title": "Telephone Number",
+      "artist": "大橋純子",
+      "album": "MAGICAL",
+      "lyricOffset": 2200
+    },
+    {
+      "id": "f3zVbOMyzgE",
+      "url": "https://www.youtube.com/watch?v=f3zVbOMyzgE",
+      "title": "UP&DOWN",
+      "artist": "임지수",
+      "album": "UP&DOWN",
+      "lyricOffset": 1650
+    },
+    {
+      "id": "zt0Me5qyK4g",
+      "url": "https://www.youtube.com/watch?v=zt0Me5qyK4g",
+      "title": "춤 (Dance)",
+      "artist": "OFFONOFF",
+      "album": "boy.",
+      "lyricOffset": 2200
+    },
+    {
+      "id": "T6YVgEpRU6Q",
+      "url": "https://www.youtube.com/watch?v=T6YVgEpRU6Q",
+      "title": "LEFT RIGHT",
+      "artist": "XG",
+      "album": "NEW DNA",
+      "lyricOffset": -5050
+    },
+    {
+      "id": "QiYOkmrI1jg",
+      "url": "https://www.youtube.com/watch?v=QiYOkmrI1jg",
+      "title": "IYKYK",
+      "artist": "XG",
+      "album": "IYKYK",
+      "lyricOffset": 1250
+    },
+    {
+      "id": "_wgeHqXr4Hc",
+      "url": "https://www.youtube.com/watch?v=_wgeHqXr4Hc",
+      "title": "나를 위해 (For Days to Come)",
+      "artist": "Crush",
+      "album": "wonderego",
+      "lyricOffset": 1200
+    },
+    {
+      "id": "zzDpTWCGofU",
+      "url": "https://www.youtube.com/watch?v=zzDpTWCGofU",
+      "title": "Nirvana Blues",
+      "artist": "Colde",
+      "album": "YIN",
+      "lyricOffset": 1800
+    },
+    {
+      "id": "6vDi9S2ZDYA",
+      "url": "https://www.youtube.com/watch?v=6vDi9S2ZDYA",
+      "title": "ETA (R&B Remix)",
+      "artist": "NewJeans",
+      "album": "NewJeans 2nd EP 'Get Up'",
+      "lyricOffset": -4000
+    },
+    {
+      "id": "5tcBJCouOmE",
+      "url": "https://youtu.be/5tcBJCouOmE",
+      "title": "Hype Boy",
+      "artist": "DEAN",
+      "album": "New Jeans",
+      "lyricOffset": 19400
+    },
+    {
+      "id": "PO8",
+      "url": "https://www.youtube.com/watch?v=HB4Rp2KKeu4",
+      "title": "野子",
+      "artist": "PO8",
+      "album": "野子",
+      "lyricOffset": 2600
+    },
+    {
+      "id": "z-xfGoabprU",
+      "url": "https://www.youtube.com/watch?v=z-xfGoabprU",
+      "title": "BEBE",
+      "artist": "STAYC",
+      "album": "BEBE",
+      "lyricOffset": 1650
+    },
+    {
+      "id": "aFrQIJ5cbRc",
+      "url": "https://www.youtube.com/watch?v=aFrQIJ5cbRc",
+      "title": "Know About Me",
+      "artist": "NMIXX",
+      "album": "Fe3O4: FORWARD - EP",
+      "lyricOffset": -1500
+    },
+    {
+      "id": "hJ9Wp3PO3c8",
+      "url": "https://www.youtube.com/watch?v=hJ9Wp3PO3c8",
+      "title": "Butterflies",
+      "artist": "Hearts2Hearts",
+      "album": "The Chase - Single",
+      "lyricOffset": -6900
+    },
+    {
+      "id": "dKMHchXVS6k",
+      "url": "https://youtu.be/dKMHchXVS6k?si=D9A7ui__4D5k_kAc",
+      "title": "Damn Right",
+      "artist": "JENNIE",
+      "album": "Ruby",
+      "lyricOffset": 1000
+    },
+    {
+      "id": "osNYssIep5w",
+      "url": "https://www.youtube.com/watch?v=osNYssIep5w",
+      "title": "Mantra (House Remix)",
+      "artist": "JENNIE",
+      "album": "Ruby",
+      "lyricOffset": 2400
+    },
+    {
+      "id": "DskqpUrvlmw",
+      "url": "https://www.youtube.com/watch?v=DskqpUrvlmw",
+      "title": "GPT",
+      "artist": "STAYC",
+      "album": "GPT - Single",
+      "lyricOffset": -1450
+    },
+    {
+      "id": "Rk6aQvlmsWo",
+      "url": "https://www.youtube.com/watch?v=Rk6aQvlmsWo",
+      "title": "Dandelion (feat. Ruel)",
+      "artist": "grentperez",
+      "album": "Backflips in a Restaurant",
+      "lyricOffset": -8400
+    },
+    {
+      "id": "36wVOzmsywo",
+      "url": "https://www.youtube.com/watch?v=36wVOzmsywo",
+      "title": "오래오래 (FRR)",
+      "artist": "george",
+      "album": "FRR",
+      "lyricOffset": -3600
+    },
+    {
+      "id": "FonjL7DQAUQ",
+      "url": "https://www.youtube.com/watch?v=FonjL7DQAUQ",
+      "title": "海浪 (Waves)",
+      "artist": "deca joins",
+      "album": "Go Slow",
+      "lyricOffset": -7000
+    },
+    {
+      "id": "3SoYkCAzMBk",
+      "url": "https://www.youtube.com/watch?v=3SoYkCAzMBk",
+      "title": "Can We Talk",
+      "artist": "Tevin Campbell",
+      "album": "I'm Ready",
+      "lyricOffset": -300
+    },
+    {
+      "id": "ZncbtRo7RXs",
+      "url": "https://www.youtube.com/watch?v=ZncbtRo7RXs",
+      "title": "Supernatural (Part.1)",
+      "artist": "NewJeans",
+      "album": "Supernatural",
+      "lyricOffset": 1600
+    },
+    {
+      "id": "hgNJ_qy6LCw",
+      "url": "https://www.youtube.com/watch?v=hgNJ_qy6LCw",
+      "title": "ASAP",
+      "artist": "NJZ",
+      "album": "NewJeans 2nd EP 'Get Up'",
+      "lyricOffset": 4400
+    },
+    {
+      "id": "YYyskjq1vSc",
+      "url": "https://www.youtube.com/watch?v=YYyskjq1vSc",
+      "title": "New Jeans (2025)",
+      "artist": "NJZ",
+      "album": "NewJeans 2nd EP 'Get Up'",
+      "lyricOffset": -29800
+    },
+    {
+      "id": "WpqXjRrZqa0",
+      "url": "https://www.youtube.com/watch?v=WpqXjRrZqa0",
+      "title": "Cool with You (2025)",
+      "artist": "NJZ",
+      "album": "NewJeans 2nd EP 'Get Up'",
+      "lyricOffset": 16200
+    },
+    {
+      "id": "In7e1knX7rQ",
+      "url": "https://www.youtube.com/watch?v=In7e1knX7rQ",
+      "title": "ETA (feat. E SENS 이센스)",
+      "artist": "NJZ",
+      "album": "NewJeans 2nd EP 'Get Up'",
+      "lyricOffset": -7850
+    },
+    {
+      "id": "tbDGl7jEazA",
+      "url": "https://www.youtube.com/watch?v=tbDGl7jEazA",
+      "title": "Cherish (My Love)",
+      "artist": "ILLIT",
+      "lyricOffset": -10250
+    },
+    {
+      "id": "pQg7doFpC5k",
+      "url": "https://www.youtube.com/watch?v=pQg7doFpC5k",
+      "title": "Sweet Life",
+      "artist": "Joo Young",
+      "lyricOffset": 2000
+    },
+    {
+      "id": "D3IDK_R1LTg",
+      "url": "https://www.youtube.com/watch?v=D3IDK_R1LTg",
+      "title": "Every Heart-ミンナノキモチ-",
+      "artist": "BoA",
+      "lyricOffset": -3200
+    },
+    {
+      "id": "bjTEMBB-mjY",
+      "url": "https://www.youtube.com/watch?v=bjTEMBB-mjY",
+      "title": "WE BELONG TOGETHER",
+      "artist": "BIGBANG",
+      "lyricOffset": -3900
+    },
+    {
+      "id": "4j7Umwfx60Q",
+      "url": "https://www.youtube.com/watch?v=4j7Umwfx60Q",
+      "title": "4 Walls",
+      "artist": "f(x)",
+      "lyricOffset": 1000
+    },
+    {
+      "id": "V9Wsm0hlLUI",
+      "url": "https://www.youtube.com/watch?v=V9Wsm0hlLUI",
+      "title": "Sour Grapes",
+      "artist": "LE SSERAFIM",
+      "lyricOffset": 1250
+    },
+    {
+      "id": "jWQx2f-CErU",
+      "url": "https://www.youtube.com/watch?v=jWQx2f-CErU",
+      "title": "Whiplash",
+      "artist": "aespa",
+      "lyricOffset": 1100
+    },
+    {
+      "id": "Yc4gp6oeN7k",
+      "url": "https://www.youtube.com/watch?v=Yc4gp6oeN7k",
+      "title": "Skrr",
+      "artist": "GISELLE",
+      "lyricOffset": 1000
+    },
+    {
+      "id": "3JWTaaS7LdU",
+      "url": "https://www.youtube.com/watch?v=3JWTaaS7LdU",
+      "title": "I Will Always Love You",
+      "artist": "Whitney Houston"
+    },
+    {
+      "id": "bX33UI9ZPLk",
+      "url": "https://www.youtube.com/watch?v=bX33UI9ZPLk",
+      "title": "黑色毛衣",
+      "artist": "周杰倫",
+      "lyricOffset": 4500
+    }
+  ]
+}

--- a/src/apps/ipod/components/IpodAppComponent.tsx
+++ b/src/apps/ipod/components/IpodAppComponent.tsx
@@ -371,8 +371,15 @@ export function IpodAppComponent({
   const setTheme = useIpodStore((s) => s.setTheme);
   const clearLibrary = useIpodStore((s) => s.clearLibrary);
   const resetLibrary = useIpodStore((s) => s.resetLibrary);
+  const initializeLibrary = useIpodStore((s) => s.initializeLibrary);
   const nextTrack = useIpodStore((s) => s.nextTrack);
   const previousTrack = useIpodStore((s) => s.previousTrack);
+
+  useEffect(() => {
+    if (tracks.length === 0) {
+      initializeLibrary();
+    }
+  }, [tracks.length, initializeLibrary]);
 
   // Add fullscreen change event handler
   useEffect(() => {
@@ -1892,7 +1899,7 @@ export function IpodAppComponent({
           isOpen={isConfirmResetOpen}
           onOpenChange={setIsConfirmResetOpen}
           onConfirm={() => {
-            resetLibrary();
+            void resetLibrary();
             setIsConfirmResetOpen(false);
             showStatus("Library Reset");
           }}

--- a/src/apps/ipod/components/IpodAppComponent.tsx
+++ b/src/apps/ipod/components/IpodAppComponent.tsx
@@ -371,31 +371,8 @@ export function IpodAppComponent({
   const setTheme = useIpodStore((s) => s.setTheme);
   const clearLibrary = useIpodStore((s) => s.clearLibrary);
   const resetLibrary = useIpodStore((s) => s.resetLibrary);
-  const initializeLibrary = useIpodStore((s) => s.initializeLibrary);
   const nextTrack = useIpodStore((s) => s.nextTrack);
   const previousTrack = useIpodStore((s) => s.previousTrack);
-
-  useEffect(() => {
-    if (tracks.length === 0) {
-      initializeLibrary();
-    }
-  }, [tracks.length, initializeLibrary]);
-
-  // Add fullscreen change event handler
-  useEffect(() => {
-    const handleFullscreenChange = () => {
-      // If browser fullscreen is exited (e.g. by pressing Escape)
-      // and our app thinks we're still in fullscreen mode, update the app state
-      if (!document.fullscreenElement && isFullScreen) {
-        toggleFullScreen();
-      }
-    };
-
-    document.addEventListener("fullscreenchange", handleFullscreenChange);
-    return () => {
-      document.removeEventListener("fullscreenchange", handleFullscreenChange);
-    };
-  }, [isFullScreen, toggleFullScreen]);
 
   const [lastActivityTime, setLastActivityTime] = useState(Date.now());
   const backlightTimerRef = useRef<NodeJS.Timeout | null>(null);
@@ -1628,6 +1605,22 @@ export function IpodAppComponent({
     },
     [showStatus]
   );
+
+  // Add fullscreen change event handler
+  useEffect(() => {
+    const handleFullscreenChange = () => {
+      // If browser fullscreen is exited (e.g. by pressing Escape)
+      // and our app thinks we're still in fullscreen mode, update the app state
+      if (!document.fullscreenElement && isFullScreen) {
+        toggleFullScreen();
+      }
+    };
+
+    document.addEventListener("fullscreenchange", handleFullscreenChange);
+    return () => {
+      document.removeEventListener("fullscreenchange", handleFullscreenChange);
+    };
+  }, [isFullScreen, toggleFullScreen]);
 
   if (!isWindowOpen) return null;
 

--- a/src/stores/useIpodStore.ts
+++ b/src/stores/useIpodStore.ts
@@ -14,421 +14,6 @@ export interface Track {
   lyricOffset?: number;
 }
 
-// Original video collection moved here
-export const IPOD_DEFAULT_VIDEOS = [
-  {
-    id: "nBoV9ZJeSp8",
-    url: "https://www.youtube.com/watch?v=nBoV9ZJeSp8",
-    title: "SLOW FADE",
-    artist: "Christian Kuria",
-    lyricOffset: 1000,
-  },
-  {
-    id: "XnbsIl2BnWw",
-    url: "https://www.youtube.com/watch?v=XnbsIl2BnWw",
-    title: "Chanel",
-    artist: "Frank Ocean",
-    lyricOffset: 1950,
-  },
-  {
-    id: "SNq4zqTN_DQ",
-    url: "https://www.youtube.com/watch?v=SNq4zqTN_DQ",
-    title: "Last Summer Whisper",
-    artist: "Anri",
-    lyricOffset: 1200,
-  },
-  {
-    id: "txroGbuRt_w",
-    url: "https://www.youtube.com/watch?v=txroGbuRt_w",
-    title: "Thirsty (Bad Boy Remix)",
-    artist: "aespa",
-    lyricOffset: 800,
-  },
-  {
-    id: "ablEaBQd3lU",
-    url: "https://www.youtube.com/watch?v=ablEaBQd3lU",
-    title: "Honestly",
-    artist: "RIIZE",
-    lyricOffset: 1200,
-  },
-  {
-    id: "jKnLSg83Nqc",
-    url: "https://youtu.be/jKnLSg83Nqc?si=0mX3pYk0q98Ndoui",
-    title: "ㅠ.ㅠ (You)",
-    artist: "Crush",
-    album: "wonderego",
-    lyricOffset: 1000,
-  },
-  {
-    id: "hCg9tezGBWE",
-    url: "https://youtu.be/hCg9tezGBWE?si=4KFJNVTDm6OA2kK8",
-    title: "Magnetic",
-    artist: "ILLIT",
-    album: "SUPER REAL ME",
-    lyricOffset: -1000,
-  },
-  {
-    id: "Dlz_XHeUUis",
-    url: "https://youtu.be/Dlz_XHeUUis?si=R7MDtk9W8suZcQDW",
-    title: "White Ferrari",
-    artist: "Frank Ocean",
-    album: "Blonde",
-    lyricOffset: 1450,
-  },
-  {
-    id: "Q3K0TOvTOno",
-    url: "https://youtu.be/Q3K0TOvTOno?si=_VbKas8ZYd9jpXiA",
-    title: "How Sweet",
-    artist: "NewJeans",
-    album: "How Sweet",
-    lyricOffset: -10500,
-  },
-  {
-    id: "ft70sAYrFyY",
-    url: "https://youtu.be/ft70sAYrFyY?si=SJXlm-KRfgrMIODE",
-    title: "Bubble Gum",
-    artist: "NewJeans",
-    album: "How Sweet",
-    lyricOffset: -9150,
-  },
-  {
-    id: "-nEGVrzPaiU",
-    url: "https://www.youtube.com/watch?v=-nEGVrzPaiU",
-    title: "Tick-Tack",
-    artist: "ILLIT",
-    album: "I'll Like You",
-    lyricOffset: -16350,
-  },
-  {
-    id: "lXd1GHJPx-A",
-    url: "https://www.youtube.com/watch?v=lXd1GHJPx-A",
-    title: "Promise",
-    artist: "Jagged Edge",
-    album: "JE Heartbreak (Explicit)",
-    lyricOffset: -6200,
-  },
-  {
-    id: "Y_AxRCNFT2g",
-    url: "https://www.youtube.com/watch?v=Y_AxRCNFT2g",
-    title: "Supernova (House Remix)",
-    artist: "aespa",
-    album: "Armageddon",
-    lyricOffset: -5200,
-  },
-  {
-    id: "yP8nAoFi6JY",
-    url: "https://www.youtube.com/watch?v=yP8nAoFi6JY",
-    title: "Supernatural (Miami Bass Remix)",
-    artist: "NewJeans",
-    album: "Supernatural",
-    lyricOffset: 22400,
-  },
-  {
-    id: "1FNI1i7H1Kc",
-    url: "https://www.youtube.com/watch?v=1FNI1i7H1Kc",
-    title: "The Chase (R&B Remix)",
-    artist: "Hearts2Hearts",
-    album: "The Chase",
-    lyricOffset: -6600,
-  },
-  {
-    id: "LVLOwwGVVZ0",
-    url: "https://www.youtube.com/watch?v=LVLOwwGVVZ0",
-    title: "Right Now (R&B Remix)",
-    artist: "NewJeans",
-    album: "Supernatural",
-    lyricOffset: -2850,
-  },
-  {
-    id: "AGaTzDTnYGY",
-    url: "https://www.youtube.com/watch?v=AGaTzDTnYGY",
-    title: "How Sweet (UK Garage Remix)",
-    artist: "NewJeans",
-    album: "How Sweet",
-    lyricOffset: 2500,
-  },
-  {
-    id: "XJWqHmY-g9U",
-    url: "https://www.youtube.com/watch?v=XJWqHmY-g9U",
-    title: "Telephone Number",
-    artist: "大橋純子",
-    album: "MAGICAL",
-    lyricOffset: 2200,
-  },
-  {
-    id: "f3zVbOMyzgE",
-    url: "https://www.youtube.com/watch?v=f3zVbOMyzgE",
-    title: "UP&DOWN",
-    artist: "임지수",
-    album: "UP&DOWN",
-    lyricOffset: 1650,
-  },
-  {
-    id: "zt0Me5qyK4g",
-    url: "https://www.youtube.com/watch?v=zt0Me5qyK4g",
-    title: "춤 (Dance)",
-    artist: "OFFONOFF",
-    album: "boy.",
-    lyricOffset: 2200,
-  },
-  {
-    id: "T6YVgEpRU6Q",
-    url: "https://www.youtube.com/watch?v=T6YVgEpRU6Q",
-    title: "LEFT RIGHT",
-    artist: "XG",
-    album: "NEW DNA",
-    lyricOffset: -5050,
-  },
-  {
-    id: "QiYOkmrI1jg",
-    url: "https://www.youtube.com/watch?v=QiYOkmrI1jg",
-    title: "IYKYK",
-    artist: "XG",
-    album: "IYKYK",
-    lyricOffset: 1250,
-  },
-  {
-    id: "_wgeHqXr4Hc",
-    url: "https://www.youtube.com/watch?v=_wgeHqXr4Hc",
-    title: "나를 위해 (For Days to Come)",
-    artist: "Crush",
-    album: "wonderego",
-    lyricOffset: 1200,
-  },
-  {
-    id: "zzDpTWCGofU",
-    url: "https://www.youtube.com/watch?v=zzDpTWCGofU",
-    title: "Nirvana Blues",
-    artist: "Colde",
-    album: "YIN",
-    lyricOffset: 1800,
-  },
-  {
-    id: "6vDi9S2ZDYA",
-    url: "https://www.youtube.com/watch?v=6vDi9S2ZDYA",
-    title: "ETA (R&B Remix)",
-    artist: "NewJeans",
-    album: "NewJeans 2nd EP 'Get Up'",
-    lyricOffset: -4000,
-  },
-  {
-    id: "5tcBJCouOmE",
-    url: "https://youtu.be/5tcBJCouOmE",
-    title: "Hype Boy",
-    artist: "DEAN",
-    album: "New Jeans",
-    lyricOffset: 19400,
-  },
-  {
-    id: "PO8",
-    url: "https://www.youtube.com/watch?v=HB4Rp2KKeu4",
-    title: "野子",
-    artist: "PO8",
-    album: "野子",
-    lyricOffset: 2600,
-  },
-  {
-    id: "z-xfGoabprU",
-    url: "https://www.youtube.com/watch?v=z-xfGoabprU",
-    title: "BEBE",
-    artist: "STAYC",
-    album: "BEBE",
-    lyricOffset: 1650,
-  },
-  {
-    id: "aFrQIJ5cbRc",
-    url: "https://www.youtube.com/watch?v=aFrQIJ5cbRc",
-    title: "Know About Me",
-    artist: "NMIXX",
-    album: "Fe3O4: FORWARD - EP",
-    lyricOffset: -1500,
-  },
-  {
-    id: "hJ9Wp3PO3c8",
-    url: "https://www.youtube.com/watch?v=hJ9Wp3PO3c8",
-    title: "Butterflies",
-    artist: "Hearts2Hearts",
-    album: "The Chase - Single",
-    lyricOffset: -6900,
-  },
-  {
-    id: "dKMHchXVS6k",
-    url: "https://youtu.be/dKMHchXVS6k?si=D9A7ui__4D5k_kAc",
-    title: "Damn Right",
-    artist: "JENNIE",
-    album: "Ruby",
-    lyricOffset: 1000,
-  },
-  {
-    id: "osNYssIep5w",
-    url: "https://www.youtube.com/watch?v=osNYssIep5w",
-    title: "Mantra (House Remix)",
-    artist: "JENNIE",
-    album: "Ruby",
-    lyricOffset: 2400,
-  },
-  {
-    id: "DskqpUrvlmw",
-    url: "https://www.youtube.com/watch?v=DskqpUrvlmw",
-    title: "GPT",
-    artist: "STAYC",
-    album: "GPT - Single",
-    lyricOffset: -1450,
-  },
-  {
-    id: "Rk6aQvlmsWo",
-    url: "https://www.youtube.com/watch?v=Rk6aQvlmsWo",
-    title: "Dandelion (feat. Ruel)",
-    artist: "grentperez",
-    album: "Backflips in a Restaurant",
-    lyricOffset: -8400,
-  },
-  {
-    id: "36wVOzmsywo",
-    url: "https://www.youtube.com/watch?v=36wVOzmsywo",
-    title: "오래오래 (FRR)",
-    artist: "george",
-    album: "FRR",
-    lyricOffset: -3600,
-  },
-  {
-    id: "FonjL7DQAUQ",
-    url: "https://www.youtube.com/watch?v=FonjL7DQAUQ",
-    title: "海浪 (Waves)",
-    artist: "deca joins",
-    album: "Go Slow",
-    lyricOffset: -7000,
-  },
-  {
-    id: "3SoYkCAzMBk",
-    url: "https://www.youtube.com/watch?v=3SoYkCAzMBk",
-    title: "Can We Talk",
-    artist: "Tevin Campbell",
-    album: "I'm Ready",
-    lyricOffset: -300,
-  },
-  {
-    id: "ZncbtRo7RXs",
-    url: "https://www.youtube.com/watch?v=ZncbtRo7RXs",
-    title: "Supernatural (Part.1)",
-    artist: "NewJeans",
-    album: "Supernatural",
-    lyricOffset: 1600,
-  },
-  {
-    id: "hgNJ_qy6LCw",
-    url: "https://www.youtube.com/watch?v=hgNJ_qy6LCw",
-    title: "ASAP",
-    artist: "NJZ",
-    album: "NewJeans 2nd EP 'Get Up'",
-    lyricOffset: 4400,
-  },
-  {
-    id: "YYyskjq1vSc",
-    url: "https://www.youtube.com/watch?v=YYyskjq1vSc",
-    title: "New Jeans (2025)",
-    artist: "NJZ",
-    album: "NewJeans 2nd EP 'Get Up'",
-    lyricOffset: -29800,
-  },
-  {
-    id: "WpqXjRrZqa0",
-    url: "https://www.youtube.com/watch?v=WpqXjRrZqa0",
-    title: "Cool with You (2025)",
-    artist: "NJZ",
-    album: "NewJeans 2nd EP 'Get Up'",
-    lyricOffset: 16200,
-  },
-  {
-    id: "In7e1knX7rQ",
-    url: "https://www.youtube.com/watch?v=In7e1knX7rQ",
-    title: "ETA (feat. E SENS 이센스)",
-    artist: "NJZ",
-    album: "NewJeans 2nd EP 'Get Up'",
-    lyricOffset: -7850,
-  },
-  {
-    id: "tbDGl7jEazA",
-    url: "https://www.youtube.com/watch?v=tbDGl7jEazA",
-    title: "Cherish (My Love)",
-    artist: "ILLIT",
-    lyricOffset: -10250,
-  },
-  {
-    id: "pQg7doFpC5k",
-    url: "https://www.youtube.com/watch?v=pQg7doFpC5k",
-    title: "Sweet Life",
-    artist: "Joo Young",
-    lyricOffset: 2000,
-  },
-  {
-    id: "D3IDK_R1LTg",
-    url: "https://www.youtube.com/watch?v=D3IDK_R1LTg",
-    title: "Every Heart-ミンナノキモチ-",
-    artist: "BoA",
-    lyricOffset: -3200,
-  },
-  {
-    id: "bjTEMBB-mjY",
-    url: "https://www.youtube.com/watch?v=bjTEMBB-mjY",
-    title: "WE BELONG TOGETHER",
-    artist: "BIGBANG",
-    lyricOffset: -3900,
-  },
-  {
-    id: "4j7Umwfx60Q",
-    url: "https://www.youtube.com/watch?v=4j7Umwfx60Q",
-    title: "4 Walls",
-    artist: "f(x)",
-    lyricOffset: 1000,
-  },
-  {
-    id: "V9Wsm0hlLUI",
-    url: "https://www.youtube.com/watch?v=V9Wsm0hlLUI",
-    title: "Sour Grapes",
-    artist: "LE SSERAFIM",
-    lyricOffset: 1250,
-  },
-  {
-    id: "jWQx2f-CErU",
-    url: "https://www.youtube.com/watch?v=jWQx2f-CErU",
-    title: "Whiplash",
-    artist: "aespa",
-    lyricOffset: 1100,
-  },
-  {
-    id: "Yc4gp6oeN7k",
-    url: "https://www.youtube.com/watch?v=Yc4gp6oeN7k",
-    title: "Skrr",
-    artist: "GISELLE",
-    lyricOffset: 1000,
-  },
-  {
-    id: "3JWTaaS7LdU",
-    url: "https://www.youtube.com/watch?v=3JWTaaS7LdU",
-    title: "I Will Always Love You",
-    artist: "Whitney Houston",
-  },
-  {
-    id: "bX33UI9ZPLk",
-    url: "https://www.youtube.com/watch?v=bX33UI9ZPLk",
-    title: "黑色毛衣",
-    artist: "周杰倫",
-    lyricOffset: 4500,
-  },
-];
-
-// Map default videos to tracks for the initial iPod state
-const DEFAULT_TRACKS: Track[] = IPOD_DEFAULT_VIDEOS.map((video) => ({
-  id: video.id,
-  url: video.url,
-  title: video.title,
-  artist: video.artist,
-  album: video.album ?? "", // Retain album if provided
-  // Ensure lyricOffset is carried over if present in the default video list
-  lyricOffset: (video as Partial<Track>).lyricOffset,
-}));
-
 interface IpodData {
   tracks: Track[];
   currentIndex: number;
@@ -449,8 +34,30 @@ interface IpodData {
   isFullScreen: boolean;
 }
 
+async function loadDefaultTracks(): Promise<Track[]> {
+  try {
+    const res = await fetch("/ipod-videos.json");
+    const data = await res.json();
+    const videos: unknown[] = data.videos || data;
+    return videos.map((v) => {
+      const video = v as Record<string, unknown>;
+      return {
+        id: video.id as string,
+        url: video.url as string,
+        title: video.title as string,
+        artist: video.artist as string | undefined,
+        album: (video.album as string | undefined) ?? "",
+        lyricOffset: video.lyricOffset as number | undefined,
+      };
+    });
+  } catch (err) {
+    console.error("Failed to load ipod-videos.json", err);
+    return [];
+  }
+}
+
 const initialIpodData: IpodData = {
-  tracks: DEFAULT_TRACKS,
+  tracks: [],
   currentIndex: 0,
   loopCurrent: false,
   loopAll: true,
@@ -483,7 +90,7 @@ export interface IpodState extends IpodData {
   setTheme: (theme: "classic" | "black" | "u2") => void;
   addTrack: (track: Track) => void;
   clearLibrary: () => void;
-  resetLibrary: () => void;
+  resetLibrary: () => Promise<void>;
   nextTrack: () => void;
   previousTrack: () => void;
   setShowVideo: (show: boolean) => void;
@@ -507,6 +114,8 @@ export interface IpodState extends IpodData {
   exportLibrary: () => string;
   /** Adds a track from a YouTube video ID or URL, fetching metadata automatically */
   addTrackFromVideoId: (urlOrId: string) => Promise<Track | null>;
+  /** Load the default library if no tracks exist */
+  initializeLibrary: () => Promise<void>;
 }
 
 const CURRENT_IPOD_STORE_VERSION = 17; // Incremented version for new state
@@ -546,13 +155,15 @@ export const useIpodStore = create<IpodState>()(
           isPlaying: false,
           lyricsTranslationRequest: null,
         }),
-      resetLibrary: () =>
+      resetLibrary: async () => {
+        const tracks = await loadDefaultTracks();
         set({
-          tracks: DEFAULT_TRACKS,
-          currentIndex: 0,
+          tracks,
+          currentIndex: tracks.length > 0 ? 0 : -1,
           isPlaying: false,
           lyricsTranslationRequest: null,
-        }),
+        });
+      },
       nextTrack: () =>
         set((state) => {
           if (state.tracks.length === 0)
@@ -646,6 +257,13 @@ export const useIpodStore = create<IpodState>()(
       exportLibrary: () => {
         const { tracks } = get();
         return JSON.stringify(tracks, null, 2);
+      },
+      initializeLibrary: async () => {
+        const current = get().tracks;
+        if (current.length === 0) {
+          const tracks = await loadDefaultTracks();
+          set({ tracks, currentIndex: tracks.length > 0 ? 0 : -1 });
+        }
       },
       addTrackFromVideoId: async (urlOrId: string): Promise<Track | null> => {
         // Extract video ID from various URL formats
@@ -795,16 +413,15 @@ export const useIpodStore = create<IpodState>()(
         let state = persistedState as IpodState; // Type assertion
 
         // If the persisted version is older than the current version, update defaults
-        if (version < CURRENT_IPOD_STORE_VERSION) {
-          console.log(
-            `Migrating iPod store from version ${version} to ${CURRENT_IPOD_STORE_VERSION}`
-          );
-          state = {
-            ...state, // Keep other persisted state
-            tracks: DEFAULT_TRACKS, // Update to new defaults
-            currentIndex: 0, // Reset index
-            // Reset other potentially conflicting state if necessary
-            isPlaying: false,
+          if (version < CURRENT_IPOD_STORE_VERSION) {
+            console.log(
+              `Migrating iPod store from version ${version} to ${CURRENT_IPOD_STORE_VERSION}`
+            );
+            state = {
+              ...state,
+              tracks: [],
+              currentIndex: 0,
+              isPlaying: false,
             isShuffled: state.isShuffled, // Keep shuffle preference maybe? Or reset? Let's keep it for now.
             showLyrics: state.showLyrics ?? true, // Add default for migration
             lyricsAlignment:
@@ -835,6 +452,16 @@ export const useIpodStore = create<IpodState>()(
         };
 
         return partializedState as IpodState; // Return the potentially migrated state
+      },
+      onRehydrateStorage: () => {
+        return (state, error) => {
+          if (error) {
+            console.error("Error rehydrating iPod store:", error);
+          } else if (state && (!state.tracks || state.tracks.length === 0)) {
+            Promise.resolve(state.initializeLibrary())
+              .catch((err) => console.error("Initialization failed on rehydrate", err));
+          }
+        };
       },
     }
   )


### PR DESCRIPTION
## Summary
- move default iPod video list to `public/ipod-videos.json`
- update `useIpodStore` to fetch the list on initialization
- add `initializeLibrary` action and use it from the iPod app
- adapt reset library workflow

## Testing
- `npm run lint` *(fails: Unexpected any and other existing lint errors)*
- `npm run build`