### PR TITLE
Fix ConfirmDialog mobile button order

### DIFF
--- a/src/components/dialogs/ConfirmDialog.tsx
+++ b/src/components/dialogs/ConfirmDialog.tsx
@@ -61,11 +61,10 @@ export function ConfirmDialog({
               {description}
             </p>
           </div>
-          <DialogFooter className="mt-4 flex flex-col gap-1 sm:flex-row">
+          <DialogFooter className="mt-4 gap-1">
             <Button
               variant="retro"
               onClick={() => onOpenChange(false)}
-              className="order-last sm:order-first"
             >
               Cancel
             </Button>


### PR DESCRIPTION
## Summary
- ensure ConfirmDialog buttons stack vertically in the same order as the desktop layout

## Testing
- `npm run lint` *(fails: Unexpected any, etc.)*