### PR TITLE
Fix selection across iPod UI

### DIFF
--- a/src/apps/ipod/components/IpodAppComponent.tsx
+++ b/src/apps/ipod/components/IpodAppComponent.tsx
@@ -254,7 +254,10 @@ function FullScreenPortal({
   }, [isPlaying]); // Only isPlaying as dependency
 
   return createPortal(
-    <div ref={containerRef} className="fixed inset-0 z-[9999] bg-black">
+    <div
+      ref={containerRef}
+      className="fixed inset-0 z-[9999] bg-black select-none"
+    >
       <div className="absolute top-6 right-6 z-[10001] pointer-events-auto">
         <button
           onClick={onClose}

--- a/src/apps/ipod/components/IpodScreen.tsx
+++ b/src/apps/ipod/components/IpodScreen.tsx
@@ -368,7 +368,7 @@ export function IpodScreen({
   return (
     <div
       className={cn(
-        "relative w-full h-[160px] border border-black border-2 rounded-[2px] overflow-hidden transition-all duration-500",
+        "relative w-full h-[160px] border border-black border-2 rounded-[2px] overflow-hidden transition-all duration-500 select-none",
         lcdFilterOn ? "lcd-screen" : "",
         backlightOn
           ? "bg-[#c5e0f5] bg-gradient-to-b from-[#d1e8fa] to-[#e0f0fc]"

--- a/src/index.css
+++ b/src/index.css
@@ -144,6 +144,8 @@
   }
   body {
     @apply bg-background text-foreground;
+    user-select: none;
+    -webkit-user-select: none;
     font-family: "ChicagoKare", "ArkPixel", "SerenityOS-Emoji", system-ui,
       -apple-system, sans-serif;
     -webkit-font-smoothing: none;


### PR DESCRIPTION
## Summary
- add `select-none` to iPod fullscreen portal
- prevent selection on iPod screen container
- explicitly disable text selection for the `body` element

## Testing
- `bun run lint` *(fails: Unexpected any and other lint errors)*