### PR TITLE
Fix textedit launch and save issues

### DIFF
--- a/src/apps/chats/hooks/useAiChat.ts
+++ b/src/apps/chats/hooks/useAiChat.ts
@@ -312,6 +312,18 @@ export function useAiChat() {
               launchOptions.initialData = { url, year: year || "current" };
             }
 
+            if (id === "textedit") {
+              const appStore = useAppStore.getState();
+              const existing = appStore
+                .getInstancesByAppId("textedit")
+                .find((inst) => inst.isOpen);
+
+              if (existing) {
+                appStore.bringInstanceToForeground(existing.instanceId);
+                return `${appName} is already open.`;
+              }
+            }
+
             launchApp(id as AppId, launchOptions);
 
             let confirmationMessage = `Launched ${appName}.`;

--- a/src/apps/textedit/components/TextEditAppComponent.tsx
+++ b/src/apps/textedit/components/TextEditAppComponent.tsx
@@ -572,7 +572,7 @@ export function TextEditAppComponent({
     }
   };
 
-  const handleSave = () => {
+  const handleSave = async () => {
     if (!editor) return;
 
     if (!currentFilePath) {
@@ -596,7 +596,7 @@ export function TextEditAppComponent({
       setSaveFileName(`${firstLine || "Untitled"}.md`);
     } else {
       // Use shared utility to save as markdown, passing the saveFile hook
-      const { jsonContent } = saveAsMarkdown(
+      const { jsonContent } = await saveAsMarkdown(
         editor,
         {
           name: currentFilePath.split("/").pop() || "Untitled",
@@ -615,7 +615,7 @@ export function TextEditAppComponent({
     }
   };
 
-  const handleSaveSubmit = (fileName: string) => {
+  const handleSaveSubmit = async (fileName: string) => {
     if (!editor) return;
 
     const filePath = `/Documents/${fileName}${
@@ -623,7 +623,7 @@ export function TextEditAppComponent({
     }`;
 
     // Use shared utility to save as markdown, passing the saveFile hook
-    const { jsonContent } = saveAsMarkdown(
+    const { jsonContent } = await saveAsMarkdown(
       editor,
       {
         name: fileName,
@@ -801,7 +801,7 @@ export function TextEditAppComponent({
     );
   };
 
-  const handleCloseSave = (fileName: string) => {
+  const handleCloseSave = async (fileName: string) => {
     if (!editor) return;
 
     const filePath = `/Documents/${fileName}${
@@ -809,7 +809,7 @@ export function TextEditAppComponent({
     }`;
 
     // Use shared utility to save as markdown
-    const { jsonContent } = saveAsMarkdown(
+    const { jsonContent } = await saveAsMarkdown(
       editor,
       {
         name: fileName,

--- a/src/utils/markdown/saveUtils.ts
+++ b/src/utils/markdown/saveUtils.ts
@@ -144,7 +144,7 @@ export const createHtmlRenderer = (content: TiptapJSON) => {
  * Saves editor content as markdown
  * Works with either a real Tiptap editor or JSON content
  */
-export const saveAsMarkdown = (
+export const saveAsMarkdown = async (
   editor: TiptapEditor | TiptapJSON,
   file: {
     name: string;
@@ -173,7 +173,7 @@ export const saveAsMarkdown = (
   
   // Call the saveFile hook directly
   console.log(`[saveAsMarkdown] Calling saveFile hook for: ${file.path}`);
-  saveFileHook({
+  await saveFileHook({
     name: file.name,
     path: file.path,
     content: markdownContent, // Save as Markdown


### PR DESCRIPTION
## Summary
- when Chat calls launchApp on TextEdit, bring an existing instance to the foreground instead of always opening a new window
- make `saveAsMarkdown` async and await saving to disk
- await saving in TextEdit when saving or closing a document

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: 26 errors)*