### PR TITLE
Avoid persisting editor JSON

### DIFF
--- a/src/stores/useTextEditStore.ts
+++ b/src/stores/useTextEditStore.ts
@@ -258,8 +258,16 @@ export const useTextEditStore = create<TextEditStoreState>()(
         return persistedState;
       },
       partialize: (state) => ({
-        instances: state.instances,
-        // Don't persist legacy fields anymore
+        instances: Object.fromEntries(
+          Object.entries(state.instances).map(([id, inst]) => [
+            id,
+            {
+              ...inst,
+              contentJson: null, // don't persist editor JSON
+            },
+          ])
+        ),
+        // Don't persist legacy fields
       }),
     }
   )


### PR DESCRIPTION
## Summary
- skip persisting contentJson in text editor store

## Testing
- `npm run lint` *(fails: @typescript-eslint/no-explicit-any etc.)*
- `npm run build`