### PR TITLE
Add Claude 4 model

### DIFF
--- a/api/utils/aiModels.ts
+++ b/api/utils/aiModels.ts
@@ -20,10 +20,12 @@ export const getModelInstance = (model: SupportedModel): LanguageModelV1 => {
       return openai("gpt-4.1");
     case "gpt-4.1-mini":
       return openai("gpt-4.1-mini");
-    case "gemini-2.5-pro-preview-05-06":
-      return google("gemini-2.5-pro-preview-05-06");
-    case "claude-3.7":
-      return anthropic("claude-3-7-sonnet-20250219");
+      case "gemini-2.5-pro-preview-05-06":
+        return google("gemini-2.5-pro-preview-05-06");
+      case "claude-4":
+        return anthropic("claude-4-sonnet-20250514");
+      case "claude-3.7":
+        return anthropic("claude-3-7-sonnet-20250219");
     case "claude-3.5":
       return anthropic("claude-3-5-sonnet-20241022");
     default:

--- a/src/types/aiModels.ts
+++ b/src/types/aiModels.ts
@@ -14,6 +14,10 @@ export const AI_MODELS = {
     name: "claude-3.5",
     provider: "Anthropic",
   },
+  "claude-4": {
+    name: "claude-4",
+    provider: "Anthropic",
+  },
   "gpt-4o": {
     name: "gpt-4o",
     provider: "OpenAI",
@@ -50,4 +54,4 @@ export const AI_MODEL_METADATA: AIModelInfo[] = Object.entries(AI_MODELS).map(
 );
 
 // Default model
-export const DEFAULT_AI_MODEL: SupportedModel = "claude-3.7"; 
+export const DEFAULT_AI_MODEL: SupportedModel = "claude-4";


### PR DESCRIPTION
## Summary
- support the new `claude-4-sonnet-20250514` Anthropic model
- make Claude 4 the default model used by the API
- expose Claude 4 in the Control Panels debug menu

## Testing
- `npm run lint` *(fails: many existing lint errors)*
- `npm test` *(fails: no test script)*