### PR TITLE
Fix iPod wheel glyphs

### DIFF
--- a/src/apps/ipod/components/IpodWheel.tsx
+++ b/src/apps/ipod/components/IpodWheel.tsx
@@ -266,13 +266,13 @@ export function IpodWheel({
           MENU
         </div>
         <div className="absolute right-3 top-1/2 transform -translate-y-1/2 font-chicago text-[9px] text-white cursor-default select-none">
-          ▶︎▶︎
+          ⏭
         </div>
         <div className="absolute bottom-3 left-1/2 transform -translate-x-1/2 font-chicago text-[9px] text-white cursor-default select-none">
-          ▶︎❙❙
+          ⏯
         </div>
         <div className="absolute left-3 top-1/2 transform -translate-y-1/2 font-chicago text-[9px] text-white cursor-default select-none">
-          ◀︎◀︎
+          ⏮
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- use proper unicode glyphs for next/prev/play

## Testing
- `bun run lint` *(fails: many existing lint errors)*
- `bun run build`
