### PR TITLE
Fix mobile swipe navigation

### DIFF
--- a/src/apps/finder/components/FinderAppComponent.tsx
+++ b/src/apps/finder/components/FinderAppComponent.tsx
@@ -79,6 +79,8 @@ export function FinderAppComponent({
   skipInitialSound,
   instanceId,
   initialData,
+  onNavigateNext,
+  onNavigatePrevious,
 }: AppProps) {
   const [isHelpDialogOpen, setIsHelpDialogOpen] = useState(false);
   const [isAboutDialogOpen, setIsAboutDialogOpen] = useState(false);
@@ -715,6 +717,8 @@ export function FinderAppComponent({
         onClose={onClose}
         isForeground={isForeground}
         skipInitialSound={skipInitialSound}
+        onNavigateNext={onNavigateNext}
+        onNavigatePrevious={onNavigatePrevious}
       >
         <div
           className={`flex flex-col h-full w-full bg-white relative ${

--- a/src/apps/textedit/components/TextEditAppComponent.tsx
+++ b/src/apps/textedit/components/TextEditAppComponent.tsx
@@ -116,6 +116,8 @@ export function TextEditAppComponent({
   initialData,
   instanceId,
   title: customTitle,
+  onNavigateNext,
+  onNavigatePrevious,
 }: AppProps) {
   const [isHelpDialogOpen, setIsHelpDialogOpen] = useState(false);
   const [isAboutDialogOpen, setIsAboutDialogOpen] = useState(false);
@@ -1092,6 +1094,8 @@ export function TextEditAppComponent({
         skipInitialSound={skipInitialSound}
         instanceId={instanceId}
         interceptClose={true}
+        onNavigateNext={onNavigateNext}
+        onNavigatePrevious={onNavigatePrevious}
       >
         <div className="flex flex-col h-full w-full">
           <div


### PR DESCRIPTION
## Summary
- pass instance navigation handlers from Finder and TextEdit components to `WindowFrame`
- allow `WindowFrame` swipe gestures to work again when switching between instances

## Testing
- `npm run lint` *(fails: 26 errors)*