### PR TITLE
Fix mobile swipe navigation

### DIFF
--- a/src/apps/chats/components/ChatsAppComponent.tsx
+++ b/src/apps/chats/components/ChatsAppComponent.tsx
@@ -36,6 +36,9 @@ export function ChatsAppComponent({
   onClose,
   isForeground,
   skipInitialSound,
+  instanceId,
+  onNavigateNext,
+  onNavigatePrevious,
 }: AppProps) {
   const { aiMessages } = useChatsStore();
   const {
@@ -326,6 +329,9 @@ export function ChatsAppComponent({
         isForeground={isForeground}
         appId="chats"
         skipInitialSound={skipInitialSound}
+        instanceId={instanceId}
+        onNavigateNext={onNavigateNext}
+        onNavigatePrevious={onNavigatePrevious}
         isShaking={isShaking}
       >
         <div ref={containerRef} className="relative h-full w-full">

--- a/src/apps/control-panels/components/ControlPanelsAppComponent.tsx
+++ b/src/apps/control-panels/components/ControlPanelsAppComponent.tsx
@@ -162,6 +162,9 @@ export function ControlPanelsAppComponent({
   isForeground,
   skipInitialSound,
   initialData,
+  instanceId,
+  onNavigateNext,
+  onNavigatePrevious,
 }: AppProps<ControlPanelsInitialData>) {
   const [isHelpDialogOpen, setIsHelpDialogOpen] = useState(false);
   const [isAboutDialogOpen, setIsAboutDialogOpen] = useState(false);
@@ -1225,6 +1228,9 @@ export function ControlPanelsAppComponent({
         isForeground={isForeground}
         appId="control-panels"
         skipInitialSound={skipInitialSound}
+        instanceId={instanceId}
+        onNavigateNext={onNavigateNext}
+        onNavigatePrevious={onNavigatePrevious}
       >
         <div className="flex flex-col h-full bg-[#E3E3E3] p-4 w-full">
           <Tabs

--- a/src/apps/finder/components/FinderAppComponent.tsx
+++ b/src/apps/finder/components/FinderAppComponent.tsx
@@ -79,6 +79,8 @@ export function FinderAppComponent({
   skipInitialSound,
   instanceId,
   initialData,
+  onNavigateNext,
+  onNavigatePrevious,
 }: AppProps) {
   const [isHelpDialogOpen, setIsHelpDialogOpen] = useState(false);
   const [isAboutDialogOpen, setIsAboutDialogOpen] = useState(false);
@@ -715,6 +717,8 @@ export function FinderAppComponent({
         onClose={onClose}
         isForeground={isForeground}
         skipInitialSound={skipInitialSound}
+        onNavigateNext={onNavigateNext}
+        onNavigatePrevious={onNavigatePrevious}
       >
         <div
           className={`flex flex-col h-full w-full bg-white relative ${

--- a/src/apps/internet-explorer/components/InternetExplorerAppComponent.tsx
+++ b/src/apps/internet-explorer/components/InternetExplorerAppComponent.tsx
@@ -313,6 +313,8 @@ export function InternetExplorerAppComponent({
   helpItems,
   initialData,
   instanceId,
+  onNavigateNext,
+  onNavigatePrevious,
 }: AppProps<InternetExplorerInitialData>) {
   const debugMode = useAppStore((state) => state.debugMode);
   const terminalSoundsEnabled = useAppStore(
@@ -2080,6 +2082,9 @@ export function InternetExplorerAppComponent({
         isForeground={isForeground}
         appId="internet-explorer"
         skipInitialSound={skipInitialSound}
+        instanceId={instanceId}
+        onNavigateNext={onNavigateNext}
+        onNavigatePrevious={onNavigatePrevious}
       >
         <div className="flex flex-col h-full w-full relative">
           <div className="flex flex-col gap-1 p-1 bg-gray-100 border-b border-black">

--- a/src/apps/ipod/components/IpodAppComponent.tsx
+++ b/src/apps/ipod/components/IpodAppComponent.tsx
@@ -324,6 +324,8 @@ export function IpodAppComponent({
   skipInitialSound,
   initialData,
   instanceId,
+  onNavigateNext,
+  onNavigatePrevious,
 }: AppProps<IpodInitialData>) {
   const { play: playClickSound } = useSound(Sounds.BUTTON_CLICK);
   const { play: playScrollSound } = useSound(Sounds.MENU_OPEN);
@@ -1703,6 +1705,9 @@ export function IpodAppComponent({
         appId="ipod"
         transparentBackground
         skipInitialSound={skipInitialSound}
+        instanceId={instanceId}
+        onNavigateNext={onNavigateNext}
+        onNavigatePrevious={onNavigatePrevious}
       >
         <div
           ref={containerRef}

--- a/src/apps/minesweeper/components/MinesweeperAppComponent.tsx
+++ b/src/apps/minesweeper/components/MinesweeperAppComponent.tsx
@@ -134,6 +134,9 @@ export function MinesweeperAppComponent({
   onClose,
   isForeground,
   skipInitialSound,
+  instanceId,
+  onNavigateNext,
+  onNavigatePrevious,
 }: AppProps) {
   const [isHelpDialogOpen, setIsHelpDialogOpen] = useState(false);
   const [isAboutDialogOpen, setIsAboutDialogOpen] = useState(false);
@@ -373,6 +376,9 @@ export function MinesweeperAppComponent({
         isForeground={isForeground}
         appId="minesweeper"
         skipInitialSound={skipInitialSound}
+        instanceId={instanceId}
+        onNavigateNext={onNavigateNext}
+        onNavigatePrevious={onNavigatePrevious}
         windowConstraints={{
           minWidth: 270,
           maxWidth: 270,

--- a/src/apps/paint/components/PaintAppComponent.tsx
+++ b/src/apps/paint/components/PaintAppComponent.tsx
@@ -28,6 +28,9 @@ export const PaintAppComponent: React.FC<AppProps<PaintInitialData>> = ({
   isForeground = false,
   skipInitialSound,
   initialData,
+  instanceId,
+  onNavigateNext,
+  onNavigatePrevious,
 }) => {
   const [selectedTool, setSelectedTool] = useState<string>("pencil");
   const [selectedPattern, setSelectedPattern] = useState<string>("pattern-1");
@@ -435,6 +438,9 @@ export const PaintAppComponent: React.FC<AppProps<PaintInitialData>> = ({
         isForeground={isForeground}
         appId="paint"
         skipInitialSound={skipInitialSound}
+        instanceId={instanceId}
+        onNavigateNext={onNavigateNext}
+        onNavigatePrevious={onNavigatePrevious}
       >
         <div
           className="flex flex-col h-full w-full min-h-0 p-2"

--- a/src/apps/pc/components/PcAppComponent.tsx
+++ b/src/apps/pc/components/PcAppComponent.tsx
@@ -15,6 +15,9 @@ export function PcAppComponent({
   onClose,
   isForeground,
   skipInitialSound,
+  instanceId,
+  onNavigateNext,
+  onNavigatePrevious,
 }: AppProps) {
   const [isHelpDialogOpen, setIsHelpDialogOpen] = useState(false);
   const [isAboutDialogOpen, setIsAboutDialogOpen] = useState(false);
@@ -253,6 +256,9 @@ export function PcAppComponent({
         isForeground={isForeground}
         appId="pc"
         skipInitialSound={skipInitialSound}
+        instanceId={instanceId}
+        onNavigateNext={onNavigateNext}
+        onNavigatePrevious={onNavigatePrevious}
       >
         <div className="flex flex-col h-full w-full bg-[#1a1a1a]">
           <div className="flex-1 relative h-full">

--- a/src/apps/photo-booth/components/PhotoBoothComponent.tsx
+++ b/src/apps/photo-booth/components/PhotoBoothComponent.tsx
@@ -98,6 +98,9 @@ export function PhotoBoothComponent({
   onClose,
   isForeground,
   skipInitialSound,
+  instanceId,
+  onNavigateNext,
+  onNavigatePrevious,
 }: AppProps) {
   const [showHelp, setShowHelp] = useState(false);
   const [showAbout, setShowAbout] = useState(false);
@@ -779,6 +782,9 @@ export function PhotoBoothComponent({
         isForeground={isForeground}
         appId="photo-booth"
         skipInitialSound={skipInitialSound}
+        instanceId={instanceId}
+        onNavigateNext={onNavigateNext}
+        onNavigatePrevious={onNavigatePrevious}
       >
         <div className="flex flex-col w-full h-full bg-neutral-500 max-h-full overflow-hidden">
           {/* Camera view area - takes available space but doesn't overflow */}

--- a/src/apps/soundboard/components/SoundboardAppComponent.tsx
+++ b/src/apps/soundboard/components/SoundboardAppComponent.tsx
@@ -32,6 +32,9 @@ export function SoundboardAppComponent({
   isForeground,
   helpItems = [],
   skipInitialSound,
+  instanceId,
+  onNavigateNext,
+  onNavigatePrevious,
 }: AppProps) {
   const {
     boards,
@@ -344,6 +347,9 @@ export function SoundboardAppComponent({
         isForeground={isForeground}
         appId="soundboard"
         skipInitialSound={skipInitialSound}
+        instanceId={instanceId}
+        onNavigateNext={onNavigateNext}
+        onNavigatePrevious={onNavigatePrevious}
       >
         <div className="flex-1 flex items-center justify-center">
           {!hasInitialized
@@ -384,6 +390,9 @@ export function SoundboardAppComponent({
         isForeground={isForeground}
         appId="soundboard"
         skipInitialSound={skipInitialSound}
+        instanceId={instanceId}
+        onNavigateNext={onNavigateNext}
+        onNavigatePrevious={onNavigatePrevious}
         windowConstraints={{
           minHeight: window.innerWidth >= 768 ? 475 : 625,
         }}

--- a/src/apps/synth/components/SynthAppComponent.tsx
+++ b/src/apps/synth/components/SynthAppComponent.tsx
@@ -164,6 +164,9 @@ export function SynthAppComponent({
   onClose,
   isForeground,
   skipInitialSound,
+  instanceId,
+  onNavigateNext,
+  onNavigatePrevious,
 }: AppProps) {
   // References and synth state
   const synthRef = useRef<Tone.PolySynth | null>(null);
@@ -814,6 +817,9 @@ export function SynthAppComponent({
         onClose={onClose}
         isForeground={isForeground}
         skipInitialSound={skipInitialSound}
+        instanceId={instanceId}
+        onNavigateNext={onNavigateNext}
+        onNavigatePrevious={onNavigatePrevious}
       >
         <div
           ref={appContainerRef}

--- a/src/apps/terminal/components/TerminalAppComponent.tsx
+++ b/src/apps/terminal/components/TerminalAppComponent.tsx
@@ -559,6 +559,9 @@ export function TerminalAppComponent({
   isWindowOpen,
   isForeground = true,
   skipInitialSound,
+  instanceId,
+  onNavigateNext,
+  onNavigatePrevious,
 }: AppProps) {
   const [isHelpDialogOpen, setIsHelpDialogOpen] = useState(false);
   const [isAboutDialogOpen, setIsAboutDialogOpen] = useState(false);
@@ -3317,6 +3320,9 @@ assistant
         isForeground={isForeground}
         transparentBackground={true}
         skipInitialSound={skipInitialSound}
+        instanceId={instanceId}
+        onNavigateNext={onNavigateNext}
+        onNavigatePrevious={onNavigatePrevious}
       >
         <motion.div
           className="flex flex-col h-full w-full bg-black/80 backdrop-blur-lg text-white antialiased font-monaco p-2 overflow-hidden select-text"

--- a/src/apps/textedit/components/TextEditAppComponent.tsx
+++ b/src/apps/textedit/components/TextEditAppComponent.tsx
@@ -116,6 +116,8 @@ export function TextEditAppComponent({
   initialData,
   instanceId,
   title: customTitle,
+  onNavigateNext,
+  onNavigatePrevious,
 }: AppProps) {
   const [isHelpDialogOpen, setIsHelpDialogOpen] = useState(false);
   const [isAboutDialogOpen, setIsAboutDialogOpen] = useState(false);
@@ -1092,6 +1094,8 @@ export function TextEditAppComponent({
         skipInitialSound={skipInitialSound}
         instanceId={instanceId}
         interceptClose={true}
+        onNavigateNext={onNavigateNext}
+        onNavigatePrevious={onNavigatePrevious}
       >
         <div className="flex flex-col h-full w-full">
           <div

--- a/src/apps/videos/components/VideosAppComponent.tsx
+++ b/src/apps/videos/components/VideosAppComponent.tsx
@@ -305,6 +305,8 @@ export function VideosAppComponent({
   skipInitialSound,
   initialData,
   instanceId,
+  onNavigateNext,
+  onNavigatePrevious,
 }: AppProps<VideosInitialData>) {
   const { play: playVideoTape } = useSound(Sounds.VIDEO_TAPE);
   const { play: playButtonClick } = useSound(Sounds.BUTTON_CLICK);
@@ -852,6 +854,9 @@ export function VideosAppComponent({
         isForeground={isForeground}
         appId="videos"
         skipInitialSound={skipInitialSound}
+        instanceId={instanceId}
+        onNavigateNext={onNavigateNext}
+        onNavigatePrevious={onNavigatePrevious}
       >
         <div className="flex flex-col w-full h-full bg-[#1a1a1a] text-white">
           <div className="flex-1 relative">

--- a/src/components/layout/WindowFrame.tsx
+++ b/src/components/layout/WindowFrame.tsx
@@ -111,26 +111,12 @@ export function WindowFrame({
     onSwipeLeft: () => {
       playWindowMoveStop();
       vibrateSwap();
-      if (instanceId && onNavigateNext) {
-        onNavigateNext();
-      } else {
-        // Fallback for legacy non-instance apps - shouldn't happen in instance-only system
-        console.warn(
-          `[WindowFrame] No instance navigation available for ${appId}`
-        );
-      }
+      onNavigateNext?.();
     },
     onSwipeRight: () => {
       playWindowMoveStop();
       vibrateSwap();
-      if (instanceId && onNavigatePrevious) {
-        onNavigatePrevious();
-      } else {
-        // Fallback for legacy non-instance apps - shouldn't happen in instance-only system
-        console.warn(
-          `[WindowFrame] No instance navigation available for ${appId}`
-        );
-      }
+      onNavigatePrevious?.();
     },
     threshold: 100,
   });


### PR DESCRIPTION
## Summary
- pass instance navigation callbacks to every app's `WindowFrame`
- simplify swipe handlers in `WindowFrame`

## Testing
- `npm run lint` *(fails: 26 errors)*