### PR TITLE
Add airbrush-style spray tool to Paint app

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,10 @@ A modern web-based desktop environment inspired by classic macOS, built with a c
   - Automatic instance management and document tracking
   - Smart file opening with existing window detection
 - **MacPaint**: Classic bitmap graphics editor
-  - Drawing tools (pencil, brush, eraser)
+  - Drawing tools (pencil, brush, spray, eraser)
   - Shape tools (rectangle, oval, line)
   - Fill patterns and colors
+  - Spray tool simulates a dithered airbrush
   - Selection and move tools
   - Undo/redo support
   - Image file import/export support

--- a/src/apps/paint/components/PaintAppComponent.tsx
+++ b/src/apps/paint/components/PaintAppComponent.tsx
@@ -48,6 +48,13 @@ export const PaintAppComponent: React.FC<AppProps<PaintInitialData>> = ({
   const [canvasWidth, setCanvasWidth] = useState(589);
   const [canvasHeight, setCanvasHeight] = useState(418);
   const [error, setError] = useState<string | null>(null);
+
+  const handleToolSelect = (tool: string) => {
+    if (tool === "spray" && strokeWidth < 10) {
+      setStrokeWidth(10);
+    }
+    setSelectedTool(tool);
+  };
   const canvasRef = useRef<{
     undo: () => void;
     redo: () => void;
@@ -455,7 +462,7 @@ export const PaintAppComponent: React.FC<AppProps<PaintInitialData>> = ({
               <div className="bg-white border border-black w-full shadow-[2px_2px_0px_0px_rgba(0,0,0,0.5)]">
                 <PaintToolbar
                   selectedTool={selectedTool}
-                  onToolSelect={setSelectedTool}
+                  onToolSelect={handleToolSelect}
                 />
               </div>
               <div className="bg-white border-2 border-black shadow-[2px_2px_0px_0px_rgba(0,0,0,0.5)]">

--- a/src/apps/paint/components/PaintCanvas.tsx
+++ b/src/apps/paint/components/PaintCanvas.tsx
@@ -344,6 +344,24 @@ export const PaintCanvas = forwardRef<PaintCanvasRef, PaintCanvasProps>(
       }
     }, [strokeWidth]);
 
+    const sprayAtPoint = useCallback(
+      (point: Point) => {
+        if (!contextRef.current) return;
+
+        const radius = strokeWidth * 2;
+        const density = radius * 2;
+
+        for (let i = 0; i < density; i++) {
+          const angle = Math.random() * Math.PI * 2;
+          const r = Math.random() * radius;
+          const x = point.x + r * Math.cos(angle);
+          const y = point.y + r * Math.sin(angle);
+          contextRef.current.fillRect(x, y, 1, 1);
+        }
+      },
+      [strokeWidth]
+    );
+
     const saveToHistory = useCallback(() => {
       const canvas = canvasRef.current;
       if (!canvas || !contextRef.current) return;
@@ -981,12 +999,17 @@ export const PaintCanvas = forwardRef<PaintCanvasRef, PaintCanvasProps>(
               );
               if (pattern) {
                 contextRef.current.strokeStyle = pattern;
+                contextRef.current.fillStyle = pattern;
               }
             }
           }
 
           contextRef.current.beginPath();
-          contextRef.current.moveTo(point.x, point.y);
+          if (selectedTool !== "spray") {
+            contextRef.current.moveTo(point.x, point.y);
+          } else {
+            sprayAtPoint(point);
+          }
         }
 
         isDrawing.current = true;
@@ -1112,8 +1135,12 @@ export const PaintCanvas = forwardRef<PaintCanvasRef, PaintCanvasProps>(
 
           contextRef.current.stroke();
         } else if (!["line", "rectangle", "oval"].includes(selectedTool)) {
-          contextRef.current.lineTo(point.x, point.y);
-          contextRef.current.stroke();
+          if (selectedTool === "spray") {
+            sprayAtPoint(point);
+          } else {
+            contextRef.current.lineTo(point.x, point.y);
+            contextRef.current.stroke();
+          }
         }
       },
       [selectedTool, isDraggingSelection, selection, setSelection]


### PR DESCRIPTION
## Summary
- implement `sprayAtPoint` drawing method for PaintCanvas
- default spray size is bigger when selecting the spray tool
- update README to mention spray tool

## Testing
- `npx eslint src/apps/paint/components/PaintCanvas.tsx src/apps/paint/components/PaintAppComponent.tsx`