### PR TITLE
Fix auth token handling in Terminal

### DIFF
--- a/src/apps/chats/hooks/useAiChat.ts
+++ b/src/apps/chats/hooks/useAiChat.ts
@@ -235,7 +235,13 @@ const getAssistantVisibleText = (message: Message): string => {
 };
 
 export function useAiChat(onPromptSetUsername?: () => void) {
-  const { aiMessages, setAiMessages, username } = useChatsStore();
+  const {
+    aiMessages,
+    setAiMessages,
+    username,
+    authToken,
+    ensureAuthToken,
+  } = useChatsStore();
   const launchApp = useLaunchApp();
   const closeApp = useAppStore((state) => state.closeApp);
   const aiModel = useAppStore((state) => state.aiModel);
@@ -273,6 +279,15 @@ export function useAiChat(onPromptSetUsername?: () => void) {
       }
     });
   }, [aiMessages]);
+
+  // Ensure auth token exists when username is present
+  useEffect(() => {
+    if (username && !authToken) {
+      ensureAuthToken().catch((err) => {
+        console.error("[useAiChat] Failed to generate auth token", err);
+      });
+    }
+  }, [username, authToken, ensureAuthToken]);
 
   // Queue-based TTS – speaks chunks as they arrive
   const { speak, stop: stopTts, isSpeaking } = useTtsQueue();

--- a/src/apps/terminal/components/TerminalAppComponent.tsx
+++ b/src/apps/terminal/components/TerminalAppComponent.tsx
@@ -93,7 +93,7 @@ const getAppName = (id?: string): string => {
 // Minimal system state for AI chat requests
 const getSystemState = () => {
   const appStore = useAppStore.getState();
-  const { username } = useChatsStore.getState();
+  const { username, authToken } = useChatsStore.getState();
   const ieStore = useInternetExplorerStore.getState();
   const videoStore = useVideoStore.getState();
   const ipodStore = useIpodStore.getState();
@@ -185,6 +185,7 @@ const getSystemState = () => {
     // Keep legacy apps for backward compatibility, but mark that instances are preferred
     apps: appStore.apps,
     username,
+    authToken,
     userLocalTime: {
       timeString: userTimeString,
       dateString: userDateString,


### PR DESCRIPTION
## Summary
- send auth token with Terminal's system state so API requests authenticate correctly

## Testing
- `npm run lint` *(fails: many existing lint errors)*