### PR TITLE
Fix @ryo chat messages with user tokens

### DIFF
--- a/api/chat-rooms.js
+++ b/api/chat-rooms.js
@@ -422,11 +422,17 @@ export async function POST(request) {
         body.username &&
         body.username.toLowerCase() !== username?.toLowerCase()
       ) {
-        logInfo(
-          requestId,
-          `Auth mismatch: body username (${body.username}) != auth username (${username})`
-        );
-        return createErrorResponse("Username mismatch", 401);
+        const allowedRyoProxy =
+          action === "sendMessage" &&
+          body.username.toLowerCase() === "ryo" &&
+          username;
+        if (!allowedRyoProxy) {
+          logInfo(
+            requestId,
+            `Auth mismatch: body username (${body.username}) != auth username (${username})`
+          );
+          return createErrorResponse("Username mismatch", 401);
+        }
       }
 
       // Validate authentication

--- a/src/apps/chats/hooks/useRyoChat.ts
+++ b/src/apps/chats/hooks/useRyoChat.ts
@@ -119,9 +119,8 @@ export function useRyoChat({
         // Send as a regular message to the room
         // We'll need to call the API directly since we want it to appear from 'ryo'
         const { authToken, username } = useChatsStore.getState();
-        const headers: HeadersInit = {
-          "Content-Type": "application/json",
-        };
+        const headers: HeadersInit = { "Content-Type": "application/json" };
+
         if (authToken && username) {
           headers["Authorization"] = `Bearer ${authToken}`;
           headers["X-Username"] = username;


### PR DESCRIPTION
## Summary
- allow users to send `@ryo` messages using their own auth token
- remove unused environment variable from docs
- bypass username mismatch when proxying through `ryo`

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: 30 errors, 74 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_683bc93446788324baf778dedefa0f99