### PR TITLE
Implement private direct messaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ A modern web-based desktop environment inspired by classic macOS, built with a c
 - **Chats**: AI-powered chat with speech & tool calling
   - Natural conversation with Ryo AI
   - Join public chat rooms with @ryo mentions
+  - Start private chats with selected users
   - Push-to-talk voice messages with real-time transcription
   - Text-to-speech for AI responses with word highlighting
   - Control apps and edit documents via chat commands

--- a/src/apps/chats/components/ChatRoomSidebar.tsx
+++ b/src/apps/chats/components/ChatRoomSidebar.tsx
@@ -10,7 +10,7 @@ interface ChatRoomSidebarProps {
   rooms: ChatRoom[];
   currentRoom: ChatRoom | null;
   onRoomSelect: (room: ChatRoom | null) => void;
-  onAddRoom: () => void;
+  onAddRoom?: () => void;
   onDeleteRoom?: (room: ChatRoom) => void;
   isVisible: boolean;
   isAdmin: boolean;
@@ -46,7 +46,7 @@ export const ChatRoomSidebar: React.FC<ChatRoomSidebarProps> = ({
           <div className="flex items-baseline gap-1.5">
             <h2 className="text-[14px] pl-1">Chats</h2>
           </div>
-          {isAdmin && (
+          {onAddRoom && (
             <Button
               variant="ghost"
               size="sm"

--- a/src/apps/chats/components/ChatsAppComponent.tsx
+++ b/src/apps/chats/components/ChatsAppComponent.tsx
@@ -6,6 +6,7 @@ import { HelpDialog } from "@/components/dialogs/HelpDialog";
 import { AboutDialog } from "@/components/dialogs/AboutDialog";
 import { ConfirmDialog } from "@/components/dialogs/ConfirmDialog";
 import { InputDialog } from "@/components/dialogs/InputDialog";
+import { PrivateRoomDialog } from "@/components/dialogs/PrivateRoomDialog";
 import { helpItems, appMetadata } from "..";
 import { useChatRoom } from "../hooks/useChatRoom";
 import { useAiChat } from "../hooks/useAiChat";
@@ -101,6 +102,8 @@ export function ChatsAppComponent({
     setIsNewRoomDialogOpen,
     newRoomName,
     setNewRoomName,
+    newRoomUsers,
+    setNewRoomUsers,
     isCreatingRoom,
     roomError,
     submitNewRoomDialog,
@@ -598,19 +601,33 @@ export function ChatsAppComponent({
           isLoading={isSettingUsername}
           errorMessage={usernameError}
         />
-        <InputDialog
-          isOpen={isNewRoomDialogOpen}
-          onOpenChange={setIsNewRoomDialogOpen}
-          onSubmit={submitNewRoomDialog}
-          title="Create New Room"
-          description="Enter a name for the new chat room"
-          value={newRoomName}
-          onChange={(value) => {
-            setNewRoomName(value);
-          }}
-          isLoading={isCreatingRoom}
-          errorMessage={roomError}
-        />
+        {isAdmin ? (
+          <InputDialog
+            isOpen={isNewRoomDialogOpen}
+            onOpenChange={setIsNewRoomDialogOpen}
+            onSubmit={submitNewRoomDialog}
+            title="Create New Room"
+            description="Enter a name for the new chat room"
+            value={newRoomName}
+            onChange={(value) => {
+              setNewRoomName(value);
+            }}
+            isLoading={isCreatingRoom}
+            errorMessage={roomError}
+          />
+        ) : (
+          <PrivateRoomDialog
+            isOpen={isNewRoomDialogOpen}
+            onOpenChange={setIsNewRoomDialogOpen}
+            onSubmit={submitNewRoomDialog}
+            roomName={newRoomName}
+            onRoomNameChange={setNewRoomName}
+            users={newRoomUsers}
+            onUsersChange={setNewRoomUsers}
+            isLoading={isCreatingRoom}
+            errorMessage={roomError}
+          />
+        )}
         <ConfirmDialog
           isOpen={isDeleteRoomDialogOpen}
           onOpenChange={setIsDeleteRoomDialogOpen}

--- a/src/components/dialogs/PrivateRoomDialog.tsx
+++ b/src/components/dialogs/PrivateRoomDialog.tsx
@@ -1,0 +1,96 @@
+import React from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogFooter,
+  DialogTitle,
+  DialogDescription,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+
+interface PrivateRoomDialogProps {
+  isOpen: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSubmit: () => void;
+  roomName: string;
+  onRoomNameChange: (value: string) => void;
+  users: string;
+  onUsersChange: (value: string) => void;
+  isLoading?: boolean;
+  errorMessage?: string | null;
+}
+
+export function PrivateRoomDialog({
+  isOpen,
+  onOpenChange,
+  onSubmit,
+  roomName,
+  onRoomNameChange,
+  users,
+  onUsersChange,
+  isLoading = false,
+  errorMessage = null,
+}: PrivateRoomDialogProps) {
+  return (
+    <Dialog open={isOpen} onOpenChange={onOpenChange}>
+      <DialogContent
+        className="bg-system7-window-bg border-2 border-black rounded-lg shadow-[2px_2px_0px_0px_rgba(0,0,0,0.5)]"
+        onKeyDown={(e: React.KeyboardEvent) => e.stopPropagation()}
+      >
+        <DialogHeader>
+          <DialogTitle className="font-normal text-[16px]">
+            Create Private Chat
+          </DialogTitle>
+          <DialogDescription className="sr-only">
+            Create a new private chat room
+          </DialogDescription>
+        </DialogHeader>
+        <div className="p-4 px-6 space-y-2">
+          <div>
+            <p className="text-gray-500 mb-1 text-[12px] font-geneva-12">
+              Room Name
+            </p>
+            <Input
+              value={roomName}
+              onChange={(e) => onRoomNameChange(e.target.value)}
+              className="shadow-none font-geneva-12 text-[12px]"
+              disabled={isLoading}
+            />
+          </div>
+          <div>
+            <p className="text-gray-500 mb-1 text-[12px] font-geneva-12">
+              Users (comma separated)
+            </p>
+            <Input
+              value={users}
+              onChange={(e) => onUsersChange(e.target.value)}
+              className="shadow-none font-geneva-12 text-[12px]"
+              disabled={isLoading}
+            />
+          </div>
+          {errorMessage && (
+            <p className="text-red-600 text-sm mt-1">{errorMessage}</p>
+          )}
+          <DialogFooter className="mt-4 flex gap-2 justify-end">
+            <Button
+              variant="retro"
+              onClick={() => onOpenChange(false)}
+              disabled={isLoading}
+            >
+              Cancel
+            </Button>
+            <Button
+              variant="retro"
+              onClick={onSubmit}
+              disabled={isLoading}
+            >
+              {isLoading ? "Adding..." : "Create"}
+            </Button>
+          </DialogFooter>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -9,9 +9,17 @@ export type ChatMessage = {
 export type ChatRoom = {
   id: string;
   name: string;
+  /**
+   * Room visibility type. Public rooms are visible to all users while
+   * private rooms are only returned for members specified in `members`.
+   */
+  type?: "public" | "private";
   createdAt: number;
   userCount: number;
+  /** Current active users in the room */
   users?: string[];
+  /** Allowed participants for private rooms */
+  members?: string[];
 };
 
 export type User = {


### PR DESCRIPTION
## Summary
- allow creating private chat rooms
- expose UI dialog for private room creation
- show add-room button for all users
- secure API to restrict access to private rooms
- document private chats in README

## Testing
- `npm run lint` *(fails: 31 errors)*

------
https://chatgpt.com/codex/tasks/task_e_683cd60b698c8324b4968bb0b0f0eda9