### PR TITLE
Add demo video to default playlist

### DIFF
--- a/src/stores/useVideoStore.ts
+++ b/src/stores/useVideoStore.ts
@@ -117,6 +117,12 @@ export const DEFAULT_VIDEOS: Video[] = [
     title: "iPhone 4 Introduction (2010)",
     artist: "Steve Jobs",
   },
+  {
+    id: "ZmWOtf4Ziso",
+    url: "https://youtu.be/ZmWOtf4Ziso",
+    title: "Computer Chronicles - Macintosh Demo (1984)",
+    artist: "Computer Chronicles",
+  },
 ];
 
 interface VideoStoreState {


### PR DESCRIPTION
## Summary
- update the default video playlist with a Computer Chronicles demo

## Testing
- `npm run lint` *(fails: 30 errors, 74 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_683dacb492688324a2d1078ce165931c