### PR TITLE
Update toast when opening shared track

### DIFF
--- a/src/apps/ipod/components/IpodAppComponent.tsx
+++ b/src/apps/ipod/components/IpodAppComponent.tsx
@@ -1060,7 +1060,13 @@ export function IpodAppComponent({
       const shouldAutoplay = !(isIOS || isSafari);
 
       if (existingTrackIndex !== -1) {
-        toast.info("Opening shared track...");
+        toast.info(
+          <>
+            Opened shared track. Press{' '}
+            <span className="font-chicago">⏯</span>
+            {' '}to start playing.
+          </>
+        );
         console.log(`[iPod] Video ID ${videoId} found in tracks. Playing.`);
         setCurrentIndex(existingTrackIndex);
         if (shouldAutoplay) {


### PR DESCRIPTION
## Summary
- change toast text when loading an existing shared track in the iPod component to use the ⏯ icon in Chicago font

## Testing
- `npm run lint` *(fails: 31 errors, 73 warnings)*
- `npm test` *(fails: no test script)*

------
https://chatgpt.com/codex/tasks/task_e_683ec5c236c48324bd14e6989b421c88