### PR TITLE
Remove cache control from dynamic system message

### DIFF
--- a/api/chat.ts
+++ b/api/chat.ts
@@ -570,7 +570,6 @@ export default async function handler(req: Request) {
       {
         role: "system",
         content: generateDynamicSystemPrompt(systemState),
-        ...CACHE_CONTROL_OPTIONS,
       },
     ];
 


### PR DESCRIPTION
## Summary
- stop applying cache control on the dynamic system prompt in `api/chat.ts`

## Testing
- `npm run lint` *(fails: many existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_683ecfebb4c88324a8240384b9617b5e