### PR TITLE
Refactor chat API system prompt usage

### DIFF
--- a/api/chat.ts
+++ b/api/chat.ts
@@ -561,20 +561,13 @@ export default async function handler(req: Request) {
     const approxTokens = staticSystemPrompt.length / 4; // rough estimate
     log(`Approximate prompt tokens: ${Math.round(approxTokens)}`);
 
-    const systemMessages = [
-      {
-        role: "system",
-        content: staticSystemPrompt,
-        ...CACHE_CONTROL_OPTIONS,
-      },
-      {
-        role: "system",
-        content: generateDynamicSystemPrompt(systemState),
-        ...CACHE_CONTROL_OPTIONS,
-      },
-    ];
+    const dynamicSystemMessage = {
+      role: "system",
+      content: generateDynamicSystemPrompt(systemState),
+      ...CACHE_CONTROL_OPTIONS,
+    };
 
-    const enrichedMessages = [...systemMessages, ...messages];
+    const enrichedMessages = [dynamicSystemMessage, ...messages];
 
     // Log all messages right before model call (as per user preference)
     enrichedMessages.forEach((msg, index) => {
@@ -585,6 +578,7 @@ export default async function handler(req: Request) {
 
     const result = streamText({
       model: selectedModel,
+      system: staticSystemPrompt,
       messages: enrichedMessages,
       tools: {
         launchApp: {


### PR DESCRIPTION
## Summary
- set `system` parameter on the chat API instead of sending static system prompt in the messages
- keep dynamic system state as a system message

## Testing
- `npm run lint` *(fails: various existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_683ed57180188324b7f66c1ac09f04d9