### PR TITLE
Move dynamic system state message after conversation

### DIFF
--- a/api/chat.ts
+++ b/api/chat.ts
@@ -567,7 +567,7 @@ export default async function handler(req: Request) {
       ...CACHE_CONTROL_OPTIONS,
     };
 
-    const enrichedMessages = [dynamicSystemMessage, ...messages];
+    const enrichedMessages = [...messages, dynamicSystemMessage];
 
     // Log all messages right before model call (as per user preference)
     enrichedMessages.forEach((msg, index) => {


### PR DESCRIPTION
## Summary
- adjust message ordering in `api/chat.ts` by appending the dynamic system state message at the end

## Testing
- `npm run lint` *(fails: lots of lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_683ed957f560832485957bb7591419a8