### PR TITLE
Disable overscroll

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -142,6 +142,9 @@
   .no-touch-callout {
     -webkit-touch-callout: none;
   }
+  html {
+    overscroll-behavior: none;
+  }
   body {
     @apply bg-background text-foreground;
     user-select: none;


### PR DESCRIPTION
## Summary
- disable browser overscroll behavior on Android Chrome

## Testing
- `npm run lint` *(fails: '@typescript-eslint/no-unused-vars' and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_68463971c6dc83248a96771bbd3e9312