### PR TITLE
Add song to iPod playlist

### DIFF
--- a/public/data/ipod-videos.json
+++ b/public/data/ipod-videos.json
@@ -1,6 +1,13 @@
 {
   "videos": [
     {
+      "id": "11cta61wi0g",
+      "url": "https://www.youtube.com/watch?v=11cta61wi0g",
+      "title": "Hype Boy",
+      "artist": "NewJeans",
+      "lyricOffset": 1000
+    },
+    {
     "id": "cmlERpyGmYI",
     "url": "https://www.youtube.com/watch?v=cmlERpyGmYI",
     "title": "COME DANCE",


### PR DESCRIPTION
A new song entry was added to the `videos` array within the `public/data/ipod-videos.json` file.

*   The new entry was inserted at the beginning of the array to ensure it appears at the top of the playlist.
*   The added song object includes:
    *   `id`: "11cta61wi0g"
    *   `url`: "https://www.youtube.com/watch?v=11cta61wi0g"
    *   `title`: "Hype Boy"
    *   `artist`: "NewJeans"
    *   `lyricOffset`: 1000

This modification ensures "Hype Boy" is the first song in the iPod playlist.