### PR TITLE
Implement cut, copy, and paste functionality

### DIFF
--- a/src/apps/finder/components/FinderMenuBar.tsx
+++ b/src/apps/finder/components/FinderMenuBar.tsx
@@ -41,6 +41,12 @@ export interface FinderMenuBarProps {
   canCreateFolder?: boolean;
   rootFolders?: FileItem[];
   onNewWindow?: () => void;
+  onCut?: () => void;
+  onCopy?: () => void;
+  onPaste?: () => void;
+  canCut?: boolean;
+  canCopy?: boolean;
+  canPaste?: boolean;
 }
 
 export function FinderMenuBar({
@@ -69,6 +75,12 @@ export function FinderMenuBar({
   canCreateFolder = false,
   rootFolders,
   onNewWindow,
+  onCut,
+  onCopy,
+  onPaste,
+  canCut = false,
+  canCopy = false,
+  canPaste = false,
 }: FinderMenuBarProps) {
   const canMoveToTrash =
     selectedFile &&
@@ -181,13 +193,25 @@ export function FinderMenuBar({
             Undo
           </DropdownMenuItem>
           <DropdownMenuSeparator className="h-[2px] bg-black my-1" />
-          <DropdownMenuItem className="text-md h-6 px-3 active:bg-gray-900 active:text-white">
+          <DropdownMenuItem
+            onClick={onCut}
+            disabled={!canCut}
+            className="text-md h-6 px-3 active:bg-gray-900 active:text-white disabled:opacity-50 disabled:cursor-not-allowed"
+          >
             Cut
           </DropdownMenuItem>
-          <DropdownMenuItem className="text-md h-6 px-3 active:bg-gray-900 active:text-white">
+          <DropdownMenuItem
+            onClick={onCopy}
+            disabled={!canCopy}
+            className="text-md h-6 px-3 active:bg-gray-900 active:text-white disabled:opacity-50 disabled:cursor-not-allowed"
+          >
             Copy
           </DropdownMenuItem>
-          <DropdownMenuItem className="text-md h-6 px-3 active:bg-gray-900 active:text-white">
+          <DropdownMenuItem
+            onClick={onPaste}
+            disabled={!canPaste}
+            className="text-md h-6 px-3 active:bg-gray-900 active:text-white disabled:opacity-50 disabled:cursor-not-allowed"
+          >
             Paste
           </DropdownMenuItem>
           <DropdownMenuItem className="text-md h-6 px-3 active:bg-gray-900 active:text-white">


### PR DESCRIPTION
Full Cut, Copy, and Paste functionality has been implemented in Finder.

*   **File System Store (`src/stores/useFilesStore.ts`)**: A global `clipboard` state was introduced to `useFilesStore`, along with `setClipboard` and `clearClipboard` actions, to manage file system clipboard operations. The store version was incremented to ensure persistence and proper migration of this new state.
*   **Finder Application Logic (`src/apps/finder/components/FinderAppComponent.tsx`)**:
    *   `handleCut`, `handleCopy`, and `handlePaste` functions were implemented to manage the core logic.
    *   An `isEditable` helper function was added to determine if a selected item can be cut or copied, preventing operations on system folders like `/Trash` or `/Applications`.
    *   The paste logic handles unique naming for duplicated items and recursively copies folder contents, including associated IndexedDB data (Documents, Images), generating new UUIDs for copied files.
    *   `canCut`, `canCopy`, and `canPaste` flags were implemented to reflect the current operational possibilities.
*   **Finder UI (`src/apps/finder/components/FinderMenuBar.tsx`)**: The `FinderMenuBar` component was updated to accept `onCut`, `onCopy`, `onPaste` handlers and `canCut`, `canCopy`, `canPaste` flags. The Cut, Copy, and Paste menu items are now dynamically enabled or disabled based on these flags, providing appropriate user feedback.

This enables users to perform cut, copy, and paste operations on editable files and folders, with content and metadata correctly handled, including recursive duplication for directories.