### PR TITLE
Remove midnight mirage from iPod

### DIFF
--- a/public/data/ipod-videos.json
+++ b/public/data/ipod-videos.json
@@ -15,14 +15,6 @@
       "lyricOffset": 1800
     },
     {
-      "id": "lNmBNXR5mKk",
-      "url": "https://www.youtube.com/watch?v=lNmBNXR5mKk",
-      "title": "Midnight Mirage",
-      "artist": "RIIZE",
-      "album": "ODYSSEY - The 1st Album",
-      "lyricOffset": 1200
-    },
-    {
       "id": "JFoevPP8hxY",
       "url": "https://www.youtube.com/watch?v=JFoevPP8hxY",
       "title": "I'll Be Good",


### PR DESCRIPTION
Remove "Midnight Mirage" from `ipod-videos.json` as requested by the user.