### PR TITLE
Fix user search API for chat rooms

### DIFF
--- a/api/chat-rooms.js
+++ b/api/chat-rooms.js
@@ -1722,7 +1722,12 @@ async function handleGetUsers(requestId) {
     }
 
     const usersData = await redis.mget(...keys);
-    const users = usersData.map((user) => user).filter(Boolean);
+    const users = usersData
+      .map((userData) => {
+        if (!userData) return null;
+        return parseUserData(userData);
+      })
+      .filter(Boolean);
 
     return new Response(JSON.stringify({ users }), {
       headers: { "Content-Type": "application/json" },


### PR DESCRIPTION
Replace `redis.keys()` with `redis.scan()` to fix user search API failure with large datasets.

The user search API was failing because `redis.keys()` returned an "ERR too many keys to fetch" error when the Redis database contained a large number of user keys. This PR resolves the issue by implementing `redis.scan()` for iterating through user keys in batches, ensuring the API works reliably regardless of the database size. The `broadcastRoomsUpdated` function was also updated to use `redis.scan()` to prevent similar issues.