### PR TITLE
Fix login dialog auto-close issue

### DIFF
--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -137,6 +137,8 @@ export function useAuth() {
             });
             setVerifyDialogOpen(false);
             setVerifyPasswordInput("");
+            // Also close the sign-up/username dialog if it happens to be open
+            setIsUsernameDialogOpen(false);
           }
         } else {
           // For token login, clear any existing user data to prevent token mixing
@@ -189,6 +191,8 @@ export function useAuth() {
           });
           setVerifyDialogOpen(false);
           setVerifyTokenInput("");
+          // Also close the sign-up/username dialog if it happens to be open
+          setIsUsernameDialogOpen(false);
         }
       } catch (err) {
         console.error("[useAuth] Error verifying:", err);


### PR DESCRIPTION
Close the login/signup dialog automatically after successful user authentication.

Previously, after a successful password or token login, the `useAuth` hook only closed the verification dialog (`isVerifyDialogOpen`) but not the username/signup dialog (`isUsernameDialogOpen`), causing it to remain open.