### PR TITLE
Investigate user credential restoration issue

### DIFF
--- a/src/apps/control-panels/components/ControlPanelsAppComponent.tsx
+++ b/src/apps/control-panels/components/ControlPanelsAppComponent.tsx
@@ -423,12 +423,23 @@ export function ControlPanelsAppComponent({
   };
 
   const performReset = () => {
-    // Preserve file metadata store while clearing everything else
+    // Preserve critical recovery keys while clearing everything else
     const fileMetadataStore = localStorage.getItem("ryos:files");
+    const usernameRecovery = localStorage.getItem("_usr_recovery_key_");
+    const authTokenRecovery = localStorage.getItem("_auth_recovery_key_");
+
     clearAllAppStates();
+
     if (fileMetadataStore) {
       localStorage.setItem("ryos:files", fileMetadataStore);
     }
+    if (usernameRecovery) {
+      localStorage.setItem("_usr_recovery_key_", usernameRecovery);
+    }
+    if (authTokenRecovery) {
+      localStorage.setItem("_auth_recovery_key_", authTokenRecovery);
+    }
+
     window.location.reload();
   };
 


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Restore username and auth token after resetting settings by preserving recovery keys.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
Previously, the "Reset All Settings" flow would clear all `localStorage` entries, including `_usr_recovery_key_` and `_auth_recovery_key_`. This prevented the `ChatsStore` from recovering user information after a reset.