### PR TITLE
Add Gemini 2.5 flash model

### DIFF
--- a/api/utils/aiModels.ts
+++ b/api/utils/aiModels.ts
@@ -22,8 +22,8 @@ export const getModelInstance = (model: SupportedModel): LanguageModelV1 => {
       return openai("gpt-4.1-mini");
     case "gemini-2.5-flash":
       return google("gemini-2.5-flash");
-    case "gemini-2.5-pro-preview-05-06":
-      return google("gemini-2.5-pro-preview-05-06");
+    case "gemini-2.5-pro":
+      return google("gemini-2.5-pro");
     case "claude-4":
       return anthropic("claude-4-sonnet-20250514");
     case "claude-3.7":

--- a/src/types/aiModels.ts
+++ b/src/types/aiModels.ts
@@ -6,7 +6,7 @@ export const AI_MODELS = {
     name: "gemini-2.5-flash",
     provider: "Google",
   },
-  "gemini-2.5-pro-preview-05-06": {
+  "gemini-2.5-pro": {
     name: "gemini-2.5-pro",
     provider: "Google",
   },


### PR DESCRIPTION
Add Gemini 2.5 Flash model, update Gemini 2.5 Pro to stable, and set Gemini 2.5 Flash as the new default model.