### PR TITLE
Disable pull down gestures in Chrome

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,6 +19,9 @@
     />
     <meta name="theme-color" content="#000000" />
     <meta http-equiv="Permissions-Policy" content="camera=(self)" />
+    <!-- Disable pull-to-refresh and overscroll behaviors on mobile -->
+    <meta name="format-detection" content="telephone=no" />
+    <meta name="msapplication-tap-highlight" content="no" />
 
     <!-- Cache control -->
     <meta http-equiv="Cache-Control" content="max-age=86400" />

--- a/src/components/layout/WindowFrame.tsx
+++ b/src/components/layout/WindowFrame.tsx
@@ -546,7 +546,7 @@ export function WindowFrame({
           {/* Top resize handle */}
           <div
             className={cn(
-              "absolute left-1 right-0 cursor-n-resize pointer-events-auto transition-[top,height] select-none",
+              "absolute left-1 right-0 cursor-n-resize pointer-events-auto transition-[top,height] select-none resize-handle",
               debugMode && "bg-red-500/50",
               resizeType?.includes("n")
                 ? "top-[-100px] h-[200px]"
@@ -566,7 +566,7 @@ export function WindowFrame({
           {/* Bottom resize handle */}
           <div
             className={cn(
-              "absolute left-0 right-0 cursor-s-resize pointer-events-auto transition-[bottom,height] select-none",
+              "absolute left-0 right-0 cursor-s-resize pointer-events-auto transition-[bottom,height] select-none resize-handle",
               debugMode && "bg-red-500/50",
               resizeType?.includes("s")
                 ? "bottom-[-100px] h-[200px]"
@@ -586,7 +586,7 @@ export function WindowFrame({
           {/* Left resize handle */}
           <div
             className={cn(
-              "absolute top-3 cursor-w-resize pointer-events-auto transition-[left,width] select-none",
+              "absolute top-3 cursor-w-resize pointer-events-auto transition-[left,width] select-none resize-handle",
               debugMode && "bg-red-500/50",
               resizeType?.includes("w")
                 ? "left-[-100px] w-[200px]"
@@ -604,7 +604,7 @@ export function WindowFrame({
           {/* Right resize handle */}
           <div
             className={cn(
-              "absolute top-6 cursor-e-resize pointer-events-auto transition-[right,width] select-none",
+              "absolute top-6 cursor-e-resize pointer-events-auto transition-[right,width] select-none resize-handle",
               debugMode && "bg-red-500/50",
               resizeType?.includes("e")
                 ? "right-[-100px] w-[200px]"
@@ -622,7 +622,7 @@ export function WindowFrame({
           {/* Corner resize handles */}
           <div
             className={cn(
-              "absolute cursor-ne-resize pointer-events-auto transition-all select-none",
+              "absolute cursor-ne-resize pointer-events-auto transition-all select-none resize-handle",
               debugMode && "bg-red-500/50",
               isMobile && "hidden",
               resizeType === "ne"
@@ -639,7 +639,7 @@ export function WindowFrame({
 
           <div
             className={cn(
-              "absolute cursor-sw-resize pointer-events-auto transition-all select-none",
+              "absolute cursor-sw-resize pointer-events-auto transition-all select-none resize-handle",
               debugMode && "bg-red-500/50",
               isMobile && "hidden",
               resizeType === "sw"
@@ -656,7 +656,7 @@ export function WindowFrame({
 
           <div
             className={cn(
-              "absolute cursor-se-resize pointer-events-auto transition-all select-none",
+              "absolute cursor-se-resize pointer-events-auto transition-all select-none resize-handle",
               debugMode && "bg-red-500/50",
               isMobile && "hidden",
               resizeType === "se"
@@ -683,7 +683,7 @@ export function WindowFrame({
           {/* Title bar */}
           <div
             className={cn(
-              "flex items-center shrink-0 h-6 min-h-6 mx-0 my-[0.1rem] mb-0 px-[0.1rem] py-[0.2rem] select-none cursor-move border-b-[1.5px] user-select-none z-50",
+              "flex items-center shrink-0 h-6 min-h-6 mx-0 my-[0.1rem] mb-0 px-[0.1rem] py-[0.2rem] select-none cursor-move border-b-[1.5px] user-select-none z-50 draggable-area",
               transparentBackground && "mt-0 h-6.5",
               isForeground
                 ? transparentBackground

--- a/src/index.css
+++ b/src/index.css
@@ -146,6 +146,12 @@
   }
   html {
     overscroll-behavior: none;
+    overscroll-behavior-x: none;
+    overscroll-behavior-y: none;
+    /* Disable pull-to-refresh and back gestures on Android Chrome */
+    -webkit-overscroll-behavior: none;
+    -webkit-overscroll-behavior-x: none;
+    -webkit-overscroll-behavior-y: none;
   }
   body {
     @apply bg-background text-foreground;
@@ -158,6 +164,16 @@
     overflow: hidden;
     position: fixed;
     inset: 0;
+    /* Additional mobile gesture prevention */
+    overscroll-behavior: none;
+    overscroll-behavior-x: none;
+    overscroll-behavior-y: none;
+    -webkit-overscroll-behavior: none;
+    -webkit-overscroll-behavior-x: none;
+    -webkit-overscroll-behavior-y: none;
+    /* Prevent touch scrolling behaviors */
+    touch-action: none;
+    -ms-touch-action: none;
   }
 }
 
@@ -333,6 +349,30 @@
 
   .animate-highlight {
     animation: highlight-bg-opacity 1.5s ease-in-out infinite;
+  }
+
+  /* Draggable area styles - prevents browser gestures on touch devices */
+  .draggable-area {
+    touch-action: none !important;
+    -ms-touch-action: none !important;
+    -webkit-touch-callout: none !important;
+    -webkit-user-select: none !important;
+    -moz-user-select: none !important;
+    -ms-user-select: none !important;
+    user-select: none !important;
+    /* Prevent default touch behaviors */
+    -webkit-touch-callout: none !important;
+    /* Disable context menu on long press */
+    -webkit-context-menu-trigger: none !important;
+    /* Prevent text selection highlighting */
+    -webkit-tap-highlight-color: transparent !important;
+  }
+
+  /* Resize handle styles - ensures proper touch handling */
+  .resize-handle {
+    touch-action: none !important;
+    -ms-touch-action: none !important;
+    -webkit-touch-callout: none !important;
   }
 }
 


### PR DESCRIPTION
Disable Android Chrome's pull-to-refresh and back gestures to prevent conflicts with window dragging.

These gestures were interfering with the custom window dragging and resizing functionality, leading to an undesirable user experience on Android Chrome.