### PR TITLE
Add context menu options for Finder

### DIFF
--- a/src/apps/finder/components/FileIcon.tsx
+++ b/src/apps/finder/components/FileIcon.tsx
@@ -9,6 +9,7 @@ interface FileIconProps {
   content?: string | Blob;
   contentUrl?: string;
   onDoubleClick?: (event: React.MouseEvent<HTMLDivElement>) => void;
+  onContextMenu?: (event: React.MouseEvent<HTMLDivElement>) => void;
   isSelected?: boolean;
   isDropTarget?: boolean;
   onClick?: (event: React.MouseEvent<HTMLDivElement>) => void;
@@ -23,6 +24,7 @@ export function FileIcon({
   content,
   contentUrl,
   onDoubleClick,
+  onContextMenu,
   isSelected,
   isDropTarget,
   onClick,
@@ -206,6 +208,7 @@ export function FileIcon({
       className={`flex flex-col items-center justify-start cursor-pointer gap-1 ${sizes.container} ${className}`}
       onDoubleClick={handleDoubleClick}
       onClick={handleClick}
+      onContextMenu={onContextMenu}
     >
       <div
         className={`flex items-center justify-center ${sizes.icon} ${

--- a/src/apps/finder/components/FileIcon.tsx
+++ b/src/apps/finder/components/FileIcon.tsx
@@ -1,6 +1,7 @@
 import { useSound, Sounds } from "@/hooks/useSound";
 import { useEffect, useState, useRef } from "react";
 import { isMobileDevice } from "@/utils/device";
+import { useLongPress } from "@/hooks/useLongPress";
 
 interface FileIconProps {
   name: string;
@@ -203,12 +204,28 @@ export function FileIcon({
     }
   };
 
+  // Add long-press support for context menu on mobile
+  const longPressHandlers = useLongPress((touchEvent) => {
+    if (onContextMenu) {
+      const touch = touchEvent.touches[0];
+      const syntheticEvent = {
+        preventDefault: () => {},
+        stopPropagation: () => {},
+        clientX: touch.clientX,
+        clientY: touch.clientY,
+      } as unknown as React.MouseEvent<HTMLDivElement>;
+      onContextMenu(syntheticEvent);
+    }
+  });
+
   return (
     <div
       className={`flex flex-col items-center justify-start cursor-pointer gap-1 ${sizes.container} ${className}`}
       onDoubleClick={handleDoubleClick}
       onClick={handleClick}
       onContextMenu={onContextMenu}
+      data-desktop-icon="true"
+      {...longPressHandlers}
     >
       <div
         className={`flex items-center justify-center ${sizes.icon} ${

--- a/src/apps/finder/components/FileList.tsx
+++ b/src/apps/finder/components/FileList.tsx
@@ -303,6 +303,7 @@ export function FileList({
         onDragLeave={handleDragLeave}
         onDrop={(e) => handleDrop(e, file)}
         onDragEnd={handleDragEnd}
+        data-file-item="true"
         {...longPressHandlers}
       >
         <TableCell className="flex items-center gap-2">
@@ -382,6 +383,7 @@ export function FileList({
             onItemContextMenu(file, e);
           }
         }}
+        data-file-item="true"
         {...longPressHandlers}
       >
         <FileIcon

--- a/src/apps/finder/components/FinderAppComponent.tsx
+++ b/src/apps/finder/components/FinderAppComponent.tsx
@@ -682,6 +682,13 @@ export function FinderAppComponent({
 
   // ------------------ Mobile long-press support (blank area) ------------------
   const blankLongPressHandlers = useLongPress((e) => {
+    // Check if the target is within a file item - if so, don't show blank context menu
+    const target = e.target as HTMLElement;
+    const fileItem = target.closest('[data-file-item]');
+    if (fileItem) {
+      return; // Let the file item handle its own context menu
+    }
+    
     const touch = e.touches[0];
     setContextMenuPos({ x: touch.clientX, y: touch.clientY });
     setContextMenuFile(null);

--- a/src/apps/finder/components/FinderAppComponent.tsx
+++ b/src/apps/finder/components/FinderAppComponent.tsx
@@ -711,6 +711,8 @@ export function FinderAppComponent({
   ];
 
   const fileMenuItems = (file: FileItem): MenuItem[] => [
+    { type: "item", label: "Open", onSelect: () => handleFileOpen(file) },
+    { type: "separator" },
     { type: "item", label: "Rename…", onSelect: handleRename },
     { type: "item", label: "Duplicate", onSelect: handleDuplicate },
     {

--- a/src/components/layout/Desktop.tsx
+++ b/src/components/layout/Desktop.tsx
@@ -44,8 +44,16 @@ export function Desktop({
   // ------------------ Mobile long-press support ------------------
   // Show the desktop context menu after the user holds for 500 ms.
   const longPressHandlers = useLongPress((e) => {
+    // Check if the target is within an icon - if so, don't show desktop context menu
+    const target = e.target as HTMLElement;
+    const iconContainer = target.closest('[data-desktop-icon]');
+    if (iconContainer) {
+      return; // Let the icon handle its own context menu
+    }
+    
     const touch = e.touches[0];
     setContextMenuPos({ x: touch.clientX, y: touch.clientY });
+    setContextMenuAppId(null);
   });
 
   // Add visibility change and focus handlers to resume video playback

--- a/src/components/layout/Desktop.tsx
+++ b/src/components/layout/Desktop.tsx
@@ -39,6 +39,7 @@ export function Desktop({
     x: number;
     y: number;
   } | null>(null);
+  const [contextMenuAppId, setContextMenuAppId] = useState<string | null>(null);
 
   // ------------------ Mobile long-press support ------------------
   // Show the desktop context menu after the user holds for 500 ms.
@@ -154,6 +155,28 @@ export function Desktop({
     setSelectedAppId(null);
   };
 
+  const handleIconContextMenu = (appId: string, e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setContextMenuPos({ x: e.clientX, y: e.clientY });
+    setContextMenuAppId(appId);
+    setSelectedAppId(appId);
+  };
+
+  const handleOpenApp = (appId: string) => {
+    if (appId === "macintosh-hd") {
+      localStorage.setItem("app_finder_initialPath", "/");
+      const finderApp = apps.find((app) => app.id === "finder");
+      if (finderApp) {
+        toggleApp(finderApp.id);
+      }
+    } else {
+      toggleApp(appId as AppId);
+    }
+    setSelectedAppId(null);
+    setContextMenuPos(null);
+  };
+
   // Compute sorted apps based on selected sort type
   const sortedApps = [...apps]
     .filter((app) => app.id !== "finder" && app.id !== "control-panels")
@@ -168,29 +191,43 @@ export function Desktop({
       }
     });
 
-  const desktopMenuItems: MenuItem[] = [
-    {
-      type: "submenu",
-      label: "Sort By",
-      items: [
+  const getContextMenuItems = (): MenuItem[] => {
+    if (contextMenuAppId) {
+      // Icon-specific context menu
+      return [
         {
-          type: "radioGroup",
-          value: sortType,
-          onChange: (val) => setSortType(val as SortType),
+          type: "item",
+          label: "Open",
+          onSelect: () => handleOpenApp(contextMenuAppId),
+        },
+      ];
+    } else {
+      // Blank desktop context menu
+      return [
+        {
+          type: "submenu",
+          label: "Sort By",
           items: [
-            { label: "Name", value: "name" },
-            { label: "Kind", value: "kind" },
+            {
+              type: "radioGroup",
+              value: sortType,
+              onChange: (val) => setSortType(val as SortType),
+              items: [
+                { label: "Name", value: "name" },
+                { label: "Kind", value: "kind" },
+              ],
+            },
           ],
         },
-      ],
-    },
-    { type: "separator" },
-    {
-      type: "item",
-      label: "Set Wallpaper…",
-      onSelect: () => toggleApp("control-panels"),
-    },
-  ];
+        { type: "separator" },
+        {
+          type: "item",
+          label: "Set Wallpaper…",
+          onSelect: () => toggleApp("control-panels"),
+        },
+      ];
+    }
+  };
 
   return (
     <div
@@ -199,6 +236,7 @@ export function Desktop({
       onContextMenu={(e) => {
         e.preventDefault();
         setContextMenuPos({ x: e.clientX, y: e.clientY });
+        setContextMenuAppId(null);
       }}
       style={finalStyles}
       {...longPressHandlers}
@@ -228,6 +266,7 @@ export function Desktop({
               setSelectedAppId("macintosh-hd");
             }}
             onDoubleClick={handleFinderOpen}
+            onContextMenu={(e: React.MouseEvent<HTMLDivElement>) => handleIconContextMenu("macintosh-hd", e)}
             isSelected={selectedAppId === "macintosh-hd"}
             size="large"
           />
@@ -243,6 +282,7 @@ export function Desktop({
                 toggleApp(app.id);
                 setSelectedAppId(null);
               }}
+              onContextMenu={(e: React.MouseEvent<HTMLDivElement>) => handleIconContextMenu(app.id, e)}
               isSelected={selectedAppId === app.id}
               size="large"
             />
@@ -251,8 +291,11 @@ export function Desktop({
       </div>
       <RightClickMenu
         position={contextMenuPos}
-        onClose={() => setContextMenuPos(null)}
-        items={desktopMenuItems}
+        onClose={() => {
+          setContextMenuPos(null);
+          setContextMenuAppId(null);
+        }}
+        items={getContextMenuItems()}
       />
     </div>
   );


### PR DESCRIPTION
Add 'Open' to right-click context menus for desktop icons and Finder file list items, enhancing user workflow.