### PR TITLE
Fix YouTube link preview video ID validation

### DIFF
--- a/api/link-preview.ts
+++ b/api/link-preview.ts
@@ -2,10 +2,6 @@ export const config = {
   runtime: "edge",
 };
 
-interface LinkPreviewRequest {
-  url: string;
-}
-
 interface LinkMetadata {
   title?: string;
   description?: string;
@@ -74,7 +70,7 @@ export default async function handler(req: Request) {
     let parsedUrl: URL;
     try {
       parsedUrl = new URL(url);
-    } catch (error) {
+    } catch {
       return new Response(JSON.stringify({ error: "Invalid URL format" }), {
         status: 400,
         headers: { "Content-Type": "application/json" },

--- a/src/apps/ipod/components/IpodScreen.tsx
+++ b/src/apps/ipod/components/IpodScreen.tsx
@@ -18,8 +18,10 @@ function BatteryIndicator({ backlightOn }: { backlightOn: boolean }) {
     // Try to get battery information (deprecated API, may not work in all browsers)
     const getBattery = async () => {
       try {
-        if ("getBattery" in navigator) {
-          const battery = await (navigator as any).getBattery();
+          if ("getBattery" in navigator) {
+            const battery = await (
+              navigator as unknown as { getBattery: () => Promise<BatteryManager> }
+            ).getBattery();
           setBatteryLevel(battery.level);
           setIsCharging(battery.charging);
 

--- a/src/components/shared/LinkPreview.tsx
+++ b/src/components/shared/LinkPreview.tsx
@@ -35,32 +35,35 @@ export function LinkPreview({ url, className = "" }: LinkPreviewProps) {
   // Helper function to extract YouTube video ID
   const extractYouTubeVideoId = (url: string): string | null => {
     try {
+      const validateId = (id: string | null) =>
+        id && /^[a-zA-Z0-9_-]{11}$/.test(id) ? id : null;
+
       // Handle youtu.be links
-      if (url.includes('youtu.be/')) {
+      if (url.includes("youtu.be/")) {
         const match = url.match(/youtu\.be\/([^&\n?#]+)/);
-        return match ? match[1] : null;
+        return validateId(match ? match[1] : null);
       }
-      
+
       // Handle youtube.com links
-      if (url.includes('youtube.com/')) {
+      if (url.includes("youtube.com/")) {
         const urlObj = new URL(url);
-        
+
         // Handle /watch?v= format
-        if (urlObj.pathname === '/watch') {
-          const videoId = urlObj.searchParams.get('v');
-          return videoId;
+        if (urlObj.pathname === "/watch") {
+          const videoId = urlObj.searchParams.get("v");
+          return validateId(videoId);
         }
-        
+
         // Handle /embed/ format
-        if (urlObj.pathname.startsWith('/embed/')) {
+        if (urlObj.pathname.startsWith("/embed/")) {
           const match = urlObj.pathname.match(/\/embed\/([^&\n?#]+)/);
-          return match ? match[1] : null;
+          return validateId(match ? match[1] : null);
         }
       }
-      
+
       return null;
     } catch (error) {
-      console.error('Error extracting YouTube video ID:', error);
+      console.error("Error extracting YouTube video ID:", error);
       return null;
     }
   };

--- a/src/utils/device.ts
+++ b/src/utils/device.ts
@@ -10,7 +10,10 @@ export function isMobileDevice(): boolean {
   const isMobileScreen = window.innerWidth < 768;
   
   // User agent check for mobile devices
-  const userAgent = navigator.userAgent || navigator.vendor || (window as any).opera;
+  const userAgent =
+    navigator.userAgent ||
+    navigator.vendor ||
+    (window as unknown as { opera?: string }).opera || "";
   const isMobileUserAgent = /android|blackberry|iemobile|ipad|iphone|ipod|opera mini|webos/i.test(userAgent);
   
   // Touch capability check
@@ -32,7 +35,10 @@ export function isTouchDevice(): boolean {
  */
 export function isTabletDevice(): boolean {
   const isLargeScreen = window.innerWidth >= 768 && window.innerWidth <= 1024;
-  const userAgent = navigator.userAgent || navigator.vendor || (window as any).opera;
+  const userAgent =
+    navigator.userAgent ||
+    navigator.vendor ||
+    (window as unknown as { opera?: string }).opera || "";
   const isTabletUserAgent = /ipad|tablet|playbook|silk/i.test(userAgent);
   
   return (isLargeScreen && isTouchDevice()) || isTabletUserAgent;


### PR DESCRIPTION
## Summary
- validate YouTube IDs in LinkPreview to prevent corrupt state
- fix lint issues in link preview API
- use typed navigator access in Ipod screen battery check
- remove `any` casts from device utilities

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6872ca3427308324ac5c6df259b1db74