### PR TITLE
Simplify video add and play flow

### DIFF
--- a/src/apps/chats/hooks/useAiChat.ts
+++ b/src/apps/chats/hooks/useAiChat.ts
@@ -36,7 +36,7 @@ const getSystemState = () => {
   const textEditStore = useTextEditStore.getState();
   const chatsStore = useChatsStore.getState();
 
-  const currentVideo = videoStore.videos[videoStore.currentIndex];
+  const currentVideo = videoStore.getCurrentVideo();
   const currentTrack =
     ipodStore.tracks &&
     ipodStore.currentIndex >= 0 &&

--- a/src/apps/chats/hooks/useRyoChat.ts
+++ b/src/apps/chats/hooks/useRyoChat.ts
@@ -14,7 +14,7 @@ const getSystemState = () => {
   const ipodStore = useIpodStore.getState();
   const chatsStore = useChatsStore.getState();
 
-  const currentVideo = videoStore.videos[videoStore.currentIndex];
+  const currentVideo = videoStore.getCurrentVideo();
   const currentTrack = ipodStore.tracks[ipodStore.currentIndex];
 
   // Use new instance-based model

--- a/src/apps/finder/hooks/useFileSystem.ts
+++ b/src/apps/finder/hooks/useFileSystem.ts
@@ -378,7 +378,7 @@ export function useFileSystem(
   } = useIpodStore();
   const {
     videos: videoTracks,
-    setCurrentIndex: setVideoIndex,
+    setCurrentVideoId: setVideoIndex,
     setIsPlaying: setVideoPlaying,
   } = useVideoStore();
   const internetExplorerStore = useInternetExplorerStore();
@@ -609,7 +609,6 @@ export function useFileSystem(
 
         // Display all videos for this artist
         displayFiles = artistVideos.map((video) => {
-          const globalIndex = videoTracks.findIndex((v) => v.id === video.id);
           return {
             name: `${video.title}.mov`,
             isDirectory: false,
@@ -617,7 +616,7 @@ export function useFileSystem(
             icon: "/icons/video-tape.png",
             appId: "videos",
             type: "Video",
-            data: { index: globalIndex },
+            data: { videoId: video.id },
           };
         });
       } else if (currentPath.startsWith("/Sites")) {
@@ -940,9 +939,9 @@ export function useFileSystem(
           setIpodIndex(trackIndex);
           setIpodPlaying(true);
           launchApp("ipod");
-        } else if (file.appId === "videos" && file.data?.index !== undefined) {
-          // Videos uses data directly, no change needed here for initialData
-          setVideoIndex(file.data.index);
+        } else if (file.appId === "videos" && file.data?.videoId) {
+          // Videos uses video ID directly
+          setVideoIndex(file.data.videoId);
           setVideoPlaying(true);
           launchApp("videos");
         } else if (file.type === "site-link" && file.data?.url) {

--- a/src/apps/terminal/components/TerminalAppComponent.tsx
+++ b/src/apps/terminal/components/TerminalAppComponent.tsx
@@ -120,7 +120,7 @@ const getSystemState = () => {
   const ipodStore = useIpodStore.getState();
   const textEditStore = useTextEditStore.getState();
 
-  const currentVideo = videoStore.videos[videoStore.currentIndex];
+  const currentVideo = videoStore.getCurrentVideo();
   const currentTrack =
     ipodStore.tracks &&
     ipodStore.currentIndex >= 0 &&

--- a/src/apps/videos/components/VideosAppComponent.tsx
+++ b/src/apps/videos/components/VideosAppComponent.tsx
@@ -641,7 +641,7 @@ export function VideosAppComponent({
         throw error; // Re-throw to let caller handle
       }
     },
-    [setCurrentIndex, setIsPlaying, handleAddAndPlayVideoById, showStatus]
+    [safeSetCurrentVideoId, setIsPlaying, handleAddAndPlayVideoById, showStatus]
   );
 
   // --- Simplified: Effect for initial data on mount ---
@@ -809,7 +809,7 @@ export function VideosAppComponent({
 
   // --- NEW: Handler to open share dialog ---
   const handleShareVideo = () => {
-    if (videos.length > 0 && currentIndex >= 0) {
+    if (videos.length > 0 && currentVideoId) {
       setIsShareDialogOpen(true);
     }
   };
@@ -837,9 +837,9 @@ export function VideosAppComponent({
         onShowHelp={() => setIsHelpDialogOpen(true)}
         onShowAbout={() => setIsAboutDialogOpen(true)}
         videos={videos}
-        currentIndex={currentIndex}
-        onPlayVideo={(index) => {
-          safeSetCurrentIndex(index);
+        currentVideoId={currentVideoId}
+        onPlayVideo={(videoId) => {
+          safeSetCurrentVideoId(videoId);
           setIsPlaying(true);
         }}
         onClearPlaylist={() => {
@@ -854,22 +854,8 @@ export function VideosAppComponent({
         onTogglePlay={() => {
           togglePlay();
         }}
-        onNext={() => {
-          if (currentIndex < videos.length - 1) {
-            playButtonClick();
-            safeSetCurrentIndex(currentIndex + 1);
-            setIsPlaying(true);
-            showStatus("NEXT ⏭");
-          }
-        }}
-        onPrevious={() => {
-          if (currentIndex > 0) {
-            playButtonClick();
-            safeSetCurrentIndex(currentIndex - 1);
-            setIsPlaying(true);
-            showStatus("PREV ⏮");
-          }
-        }}
+        onNext={nextVideo}
+        onPrevious={previousVideo}
         onAddVideo={() => setIsAddDialogOpen(true)}
         onOpenVideo={() => {
           setIsAddDialogOpen(true);
@@ -901,7 +887,7 @@ export function VideosAppComponent({
                 >
                   <ReactPlayer
                     ref={playerRef}
-                    url={videos[currentIndex].url}
+                    url={getCurrentVideo()?.url || ""}
                     playing={isPlaying}
                     controls={false}
                     width="100%"
@@ -992,7 +978,7 @@ export function VideosAppComponent({
                 >
                   <div>Track</div>
                   <div className="text-xl">
-                    <AnimatedNumber number={currentIndex + 1} />
+                    <AnimatedNumber number={getCurrentIndex() + 1} />
                   </div>
                 </div>
                 <div
@@ -1018,9 +1004,9 @@ export function VideosAppComponent({
                   <div className="relative overflow-hidden">
                     <AnimatedTitle
                       title={
-                        videos[currentIndex].artist
-                          ? `${videos[currentIndex].title} - ${videos[currentIndex].artist}`
-                          : videos[currentIndex].title
+                        getCurrentVideo()?.artist
+                          ? `${getCurrentVideo()?.title} - ${getCurrentVideo()?.artist}`
+                          : getCurrentVideo()?.title || ""
                       }
                       direction={animationDirection}
                       isPlaying={isPlaying}
@@ -1150,7 +1136,7 @@ export function VideosAppComponent({
           onOpenChange={setIsConfirmClearOpen}
           onConfirm={() => {
             setVideos([]);
-            safeSetCurrentIndex(0);
+            safeSetCurrentVideoId(null);
             setIsPlaying(false);
             setIsConfirmClearOpen(false);
           }}
@@ -1162,7 +1148,7 @@ export function VideosAppComponent({
           onOpenChange={setIsConfirmResetOpen}
           onConfirm={() => {
             setVideos(DEFAULT_VIDEOS);
-            safeSetCurrentIndex(0);
+            safeSetCurrentVideoId(DEFAULT_VIDEOS.length > 0 ? DEFAULT_VIDEOS[0].id : null);
             setIsPlaying(false);
             setOriginalOrder(DEFAULT_VIDEOS);
             setIsConfirmResetOpen(false);
@@ -1186,9 +1172,9 @@ export function VideosAppComponent({
           isOpen={isShareDialogOpen}
           onClose={() => setIsShareDialogOpen(false)}
           itemType="Video"
-          itemIdentifier={videos[currentIndex]?.id || ""}
-          title={videos[currentIndex]?.title}
-          details={videos[currentIndex]?.artist}
+          itemIdentifier={getCurrentVideo()?.id || ""}
+          title={getCurrentVideo()?.title}
+          details={getCurrentVideo()?.artist}
           generateShareUrl={videosGenerateShareUrl}
         />
       </WindowFrame>

--- a/src/apps/videos/components/VideosMenuBar.tsx
+++ b/src/apps/videos/components/VideosMenuBar.tsx
@@ -26,8 +26,8 @@ interface VideosMenuBarProps {
   onShowHelp: () => void;
   onShowAbout: () => void;
   videos: Video[];
-  currentIndex: number;
-  onPlayVideo: (index: number) => void;
+  currentVideoId: string | null;
+  onPlayVideo: (videoId: string) => void;
   onClearPlaylist: () => void;
   onShufflePlaylist: () => void;
   onToggleLoopAll: () => void;
@@ -51,7 +51,7 @@ export function VideosMenuBar({
   onShowHelp,
   onShowAbout,
   videos,
-  currentIndex,
+  currentVideoId,
   onPlayVideo,
   onClearPlaylist,
   onShufflePlaylist,
@@ -71,13 +71,13 @@ export function VideosMenuBar({
   onShareVideo,
 }: VideosMenuBarProps) {
   // Group videos by artist
-  const videosByArtist = videos.reduce<Record<string, { video: Video; index: number }[]>>(
-    (acc, video, index) => {
+  const videosByArtist = videos.reduce<Record<string, Video[]>>(
+    (acc, video) => {
       const artist = video.artist || 'Unknown Artist';
       if (!acc[artist]) {
         acc[artist] = [];
       }
-      acc[artist].push({ video, index });
+      acc[artist].push(video);
       return acc;
     },
     {}
@@ -222,23 +222,23 @@ export function VideosMenuBar({
                   </div>
                 </DropdownMenuSubTrigger>
                 <DropdownMenuSubContent className="px-0 max-w-[180px] sm:max-w-[220px]">
-                  {videos.map((video, index) => (
+                  {videos.map((video) => (
                     <DropdownMenuItem
                       key={`all-${video.id}`}
-                      onClick={() => onPlayVideo(index)}
+                      onClick={() => onPlayVideo(video.id)}
                       className={cn(
                         "text-md h-6 px-3 active:bg-gray-900 active:text-white max-w-[220px] truncate",
-                        index === currentIndex && "bg-gray-200"
+                        video.id === currentVideoId && "bg-gray-200"
                       )}
                     >
                       <div className="flex items-center w-full">
                         <span
                           className={cn(
                             "flex-none whitespace-nowrap",
-                            index === currentIndex ? "mr-1" : "pl-5"
+                            video.id === currentVideoId ? "mr-1" : "pl-5"
                           )}
                         >
-                          {index === currentIndex ? "♪ " : ""}
+                          {video.id === currentVideoId ? "♪ " : ""}
                         </span>
                         <span className="truncate min-w-0">{video.title}</span>
                       </div>
@@ -256,23 +256,23 @@ export function VideosMenuBar({
                     </div>
                   </DropdownMenuSubTrigger>
                   <DropdownMenuSubContent className="px-0 max-w-[180px] sm:max-w-[220px]">
-                    {videosByArtist[artist].map(({ video, index }) => (
+                    {videosByArtist[artist].map((video) => (
                       <DropdownMenuItem
                         key={`${artist}-${video.id}`}
-                        onClick={() => onPlayVideo(index)}
+                        onClick={() => onPlayVideo(video.id)}
                         className={cn(
                           "text-md h-6 px-3 active:bg-gray-900 active:text-white max-w-[160px] sm:max-w-[200px] truncate",
-                          index === currentIndex && "bg-gray-200"
+                          video.id === currentVideoId && "bg-gray-200"
                         )}
                       >
                         <div className="flex items-center w-full">
                           <span
                             className={cn(
                               "flex-none whitespace-nowrap",
-                              index === currentIndex ? "mr-1" : "pl-5"
+                              video.id === currentVideoId ? "mr-1" : "pl-5"
                             )}
                           >
-                            {index === currentIndex ? "♪ " : ""}
+                            {video.id === currentVideoId ? "♪ " : ""}
                           </span>
                           <span className="truncate min-w-0">{video.title}</span>
                         </div>

--- a/src/stores/useVideoStore.ts
+++ b/src/stores/useVideoStore.ts
@@ -121,19 +121,22 @@ export const DEFAULT_VIDEOS: Video[] = [
 
 interface VideoStoreState {
   videos: Video[];
-  currentIndex: number;
+  currentVideoId: string | null;
   loopAll: boolean;
   loopCurrent: boolean;
   isShuffled: boolean;
   isPlaying: boolean;
   // actions
   setVideos: (videos: Video[] | ((prev: Video[]) => Video[])) => void;
-  setCurrentIndex: (index: number) => void;
+  setCurrentVideoId: (videoId: string | null) => void;
   setLoopAll: (val: boolean) => void;
   setLoopCurrent: (val: boolean) => void;
   setIsShuffled: (val: boolean) => void;
   togglePlay: () => void;
   setIsPlaying: (val: boolean) => void;
+  // derived state helpers
+  getCurrentIndex: () => number;
+  getCurrentVideo: () => Video | null;
 }
 
 const CURRENT_VIDEO_STORE_VERSION = 6; // Increment version to force migration
@@ -141,32 +144,44 @@ const CURRENT_VIDEO_STORE_VERSION = 6; // Increment version to force migration
 // Safe state validation function
 const validateState = (state: Partial<VideoStoreState>): VideoStoreState => {
   const videos = Array.isArray(state.videos) ? state.videos : DEFAULT_VIDEOS;
-  const currentIndex = typeof state.currentIndex === 'number' ? state.currentIndex : 0;
   
-  // Ensure currentIndex is within bounds
-  const safeCurrentIndex = Math.max(0, Math.min(currentIndex, videos.length - 1));
+  // Handle migration from old currentIndex to currentVideoId
+  let currentVideoId = state.currentVideoId;
+  if (currentVideoId === undefined && typeof (state as Partial<VideoStoreState> & { currentIndex?: number }).currentIndex === 'number') {
+    // Migrate from old currentIndex to currentVideoId
+    const currentIndex = (state as Partial<VideoStoreState> & { currentIndex?: number }).currentIndex!;
+    const safeIndex = Math.max(0, Math.min(currentIndex, videos.length - 1));
+    currentVideoId = videos[safeIndex]?.id || null;
+  }
+  
+  // Ensure currentVideoId is valid
+  if (currentVideoId && !videos.find(v => v.id === currentVideoId)) {
+    currentVideoId = videos.length > 0 ? videos[0].id : null;
+  }
   
   return {
     videos,
-    currentIndex: safeCurrentIndex,
+    currentVideoId: currentVideoId || (videos.length > 0 ? videos[0].id : null),
     loopAll: typeof state.loopAll === 'boolean' ? state.loopAll : true,
     loopCurrent: typeof state.loopCurrent === 'boolean' ? state.loopCurrent : false,
     isShuffled: typeof state.isShuffled === 'boolean' ? state.isShuffled : false,
     isPlaying: false, // Always start with not playing
     // Include all required methods (they'll be added by the create function)
     setVideos: (() => {}) as any,
-    setCurrentIndex: (() => {}) as any,
+    setCurrentVideoId: (() => {}) as any,
     setLoopAll: (() => {}) as any,
     setLoopCurrent: (() => {}) as any,
     setIsShuffled: (() => {}) as any,
     togglePlay: (() => {}) as any,
     setIsPlaying: (() => {}) as any,
+    getCurrentIndex: (() => {}) as any,
+    getCurrentVideo: (() => {}) as any,
   };
 };
 
 const getInitialState = () => ({
   videos: DEFAULT_VIDEOS,
-  currentIndex: 0,
+  currentVideoId: DEFAULT_VIDEOS.length > 0 ? DEFAULT_VIDEOS[0].id : null,
   loopAll: true,
   loopCurrent: false,
   isShuffled: false,
@@ -175,7 +190,7 @@ const getInitialState = () => ({
 
 export const useVideoStore = create<VideoStoreState>()(
   persist(
-    (set) => ({
+    (set, get) => ({
       ...getInitialState(),
 
       setVideos: (videosOrUpdater) => {
@@ -185,25 +200,38 @@ export const useVideoStore = create<VideoStoreState>()(
               ? (videosOrUpdater as (prev: Video[]) => Video[])(state.videos)
               : videosOrUpdater;
           
-          // Validate currentIndex when videos change
-          const safeCurrentIndex = Math.max(0, Math.min(state.currentIndex, newVideos.length - 1));
+          // Validate currentVideoId when videos change
+          let currentVideoId = state.currentVideoId;
+          if (currentVideoId && !newVideos.find(v => v.id === currentVideoId)) {
+            currentVideoId = newVideos.length > 0 ? newVideos[0].id : null;
+          }
           
           return { 
             videos: newVideos,
-            currentIndex: safeCurrentIndex
-          } as Partial<VideoStoreState>;
+            currentVideoId
+          };
         });
       },
-      setCurrentIndex: (index) => set((state) => {
-        // Ensure index is within bounds
-        const safeIndex = Math.max(0, Math.min(index, state.videos.length - 1));
-        return { currentIndex: safeIndex };
+      setCurrentVideoId: (videoId) => set((state) => {
+        // Ensure videoId exists in videos array
+        const validVideoId = videoId && state.videos.find(v => v.id === videoId) ? videoId : null;
+        return { currentVideoId: validVideoId };
       }),
       setLoopAll: (val) => set({ loopAll: val }),
       setLoopCurrent: (val) => set({ loopCurrent: val }),
       setIsShuffled: (val) => set({ isShuffled: val }),
       togglePlay: () => set((state) => ({ isPlaying: !state.isPlaying })),
       setIsPlaying: (val) => set({ isPlaying: val }),
+      
+      // Derived state helpers
+      getCurrentIndex: () => {
+        const state = get();
+        return state.currentVideoId ? state.videos.findIndex(v => v.id === state.currentVideoId) : -1;
+      },
+      getCurrentVideo: () => {
+        const state = get();
+        return state.currentVideoId ? state.videos.find(v => v.id === state.currentVideoId) || null : null;
+      },
     }),
     {
       name: "ryos:videos",
@@ -221,7 +249,7 @@ export const useVideoStore = create<VideoStoreState>()(
           if (version < CURRENT_VIDEO_STORE_VERSION) {
             return {
               videos: DEFAULT_VIDEOS,
-              currentIndex: 0,
+              currentVideoId: DEFAULT_VIDEOS.length > 0 ? DEFAULT_VIDEOS[0].id : null,
               loopAll: validatedState.loopAll,
               loopCurrent: validatedState.loopCurrent,
               isShuffled: validatedState.isShuffled,
@@ -234,10 +262,10 @@ export const useVideoStore = create<VideoStoreState>()(
           return getInitialState();
         }
       },
-      // Persist videos array to prevent index out of bounds errors
+      // Persist videos array to prevent ID-based errors
       partialize: (state) => ({
         videos: state.videos,
-        currentIndex: state.currentIndex,
+        currentVideoId: state.currentVideoId,
         loopAll: state.loopAll,
         loopCurrent: state.loopCurrent,
         isShuffled: state.isShuffled,


### PR DESCRIPTION
Refactor video playback to use stable video IDs instead of array indices to eliminate race conditions.

Previously, video playback relied on array indices (`currentIndex`). This led to race conditions where asynchronous operations (like adding a video from LinkPreview) could modify the video array, causing the `currentIndex` to point to the wrong video or an out-of-bounds index. This PR switches to using unique video IDs, ensuring that the currently playing video is always correctly identified, even if the playlist order changes.