### PR TITLE
Update toast message for video playback

### DIFF
--- a/src/apps/videos/components/VideosAppComponent.tsx
+++ b/src/apps/videos/components/VideosAppComponent.tsx
@@ -669,7 +669,13 @@ export function VideosAppComponent({
         `[Videos] Processing initialData.videoId on mount: ${videoIdToProcess}`
       );
       
-      toast.info("Opening shared video...");
+      toast.info(
+        <>
+          Opened shared video. Press{' '}
+          <span className="font-chicago">⏯</span>
+          {' '}to start playing.
+        </>
+      );
       
       // Process immediately without delay and with better error handling
       processVideoId(videoIdToProcess)
@@ -720,7 +726,13 @@ export function VideosAppComponent({
           `[Videos] Received updateApp event with videoId: ${videoId}`
         );
         bringToForeground("videos");
-        toast.info("Opening shared video...");
+        toast.info(
+          <>
+            Opened shared video. Press{' '}
+            <span className="font-chicago">⏯</span>
+            {' '}to start playing.
+          </>
+        );
         processVideoId(videoId).catch((error) => {
           console.error(
             `[Videos] Error processing videoId ${videoId} from updateApp event:`,

--- a/src/apps/videos/components/VideosAppComponent.tsx
+++ b/src/apps/videos/components/VideosAppComponent.tsx
@@ -593,7 +593,7 @@ export function VideosAppComponent({
     const youtubeUrl = `https://www.youtube.com/watch?v=${videoId}`;
     try {
       await addVideo(youtubeUrl); // addVideo sets current index and plays
-              showStatus(`Added and playing video`);
+              showStatus("VIDEO ADDED");
     } catch (error) {
       console.error(
         `[Videos] Error adding video for videoId ${videoId}:`,

--- a/src/apps/videos/components/VideosAppComponent.tsx
+++ b/src/apps/videos/components/VideosAppComponent.tsx
@@ -593,7 +593,6 @@ export function VideosAppComponent({
     const youtubeUrl = `https://www.youtube.com/watch?v=${videoId}`;
     try {
       await addVideo(youtubeUrl); // addVideo sets current index and plays
-              showStatus("VIDEO ADDED");
     } catch (error) {
       console.error(
         `[Videos] Error adding video for videoId ${videoId}:`,


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Update shared video toast message in Videos app and remove redundant status message.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The toast message for opening shared videos now matches the iPod app's pattern, instructing users to press ⏯ to play. The `Added and playing video` status message was removed from the shared video load path to prevent duplicate notifications, ensuring only one toast appears for successful shared video loads.