### PR TITLE
Fix mobile theme resizer overlap

### DIFF
--- a/src/components/layout/WindowFrame.tsx
+++ b/src/components/layout/WindowFrame.tsx
@@ -562,7 +562,9 @@ export function WindowFrame({
               resizeType?.includes("n")
                 ? "top-[-100px] h-[200px]"
                 : isMobile
-                ? "top-0 h-8"
+                ? isXpTheme
+                  ? "top-[22px] h-6" // Position below title bar for XP/98 themes (XP: 21px, 98: 22px)
+                  : "top-0 h-8"
                 : "top-1 h-2"
             )}
             onMouseDown={(e) =>


### PR DESCRIPTION
Adjust mobile top resizer position for XP and Win98 themes to prevent it from covering the title bar and making buttons inaccessible.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-23299dc7-1ea2-4cfb-be87-ccebfd24dce3) · [Cursor](https://cursor.com/background-agent?bcId=bc-23299dc7-1ea2-4cfb-be87-ccebfd24dce3)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)