### PR TITLE
Fix videos app title size for old themes

### DIFF
--- a/public/css/98-custom.css
+++ b/public/css/98-custom.css
@@ -701,21 +701,4 @@ ul.tree-view {
   font-synthesis: none;
 }
 
-/* Fix for videos app title font size in Win98 theme */
-.font-geneva-12.text-\[10px\] {
-  font-size: 10px !important;
-}
 
-/* Ensure videos app title maintains correct size */
-[data-os-theme="win98"] .font-geneva-12.text-\[10px\] {
-  font-size: 10px !important;
-}
-
-/* Override any global font-size inheritance for videos app */
-[data-os-theme="win98"] .font-geneva-12 {
-  font-size: inherit;
-}
-
-[data-os-theme="win98"] .font-geneva-12.text-\[10px\] {
-  font-size: 10px !important;
-}

--- a/public/css/98-custom.css
+++ b/public/css/98-custom.css
@@ -700,3 +700,22 @@ ul.tree-view {
   -webkit-font-smoothing: antialiased;
   font-synthesis: none;
 }
+
+/* Fix for videos app title font size in Win98 theme */
+.font-geneva-12.text-\[10px\] {
+  font-size: 10px !important;
+}
+
+/* Ensure videos app title maintains correct size */
+[data-os-theme="win98"] .font-geneva-12.text-\[10px\] {
+  font-size: 10px !important;
+}
+
+/* Override any global font-size inheritance for videos app */
+[data-os-theme="win98"] .font-geneva-12 {
+  font-size: inherit;
+}
+
+[data-os-theme="win98"] .font-geneva-12.text-\[10px\] {
+  font-size: 10px !important;
+}

--- a/public/css/xp-custom.css
+++ b/public/css/xp-custom.css
@@ -1435,3 +1435,22 @@ progress:not([value])::-moz-progress-bar:not([value]) {
   -webkit-font-smoothing: antialiased;
   font-synthesis: none;
 }
+
+/* Fix for videos app title font size in XP theme */
+.font-geneva-12.text-\[10px\] {
+  font-size: 10px !important;
+}
+
+/* Ensure videos app title maintains correct size */
+[data-os-theme="xp"] .font-geneva-12.text-\[10px\] {
+  font-size: 10px !important;
+}
+
+/* Override any global font-size inheritance for videos app */
+[data-os-theme="xp"] .font-geneva-12 {
+  font-size: inherit;
+}
+
+[data-os-theme="xp"] .font-geneva-12.text-\[10px\] {
+  font-size: 10px !important;
+}

--- a/public/css/xp-custom.css
+++ b/public/css/xp-custom.css
@@ -1436,21 +1436,4 @@ progress:not([value])::-moz-progress-bar:not([value]) {
   font-synthesis: none;
 }
 
-/* Fix for videos app title font size in XP theme */
-.font-geneva-12.text-\[10px\] {
-  font-size: 10px !important;
-}
 
-/* Ensure videos app title maintains correct size */
-[data-os-theme="xp"] .font-geneva-12.text-\[10px\] {
-  font-size: 10px !important;
-}
-
-/* Override any global font-size inheritance for videos app */
-[data-os-theme="xp"] .font-geneva-12 {
-  font-size: inherit;
-}
-
-[data-os-theme="xp"] .font-geneva-12.text-\[10px\] {
-  font-size: 10px !important;
-}

--- a/src/apps/videos/components/VideosAppComponent.tsx
+++ b/src/apps/videos/components/VideosAppComponent.tsx
@@ -127,7 +127,7 @@ function AnimatedTitle({
                   }
             }
             className={cn(
-              "shrink-0 font-geneva-12 px-2 transition-colors duration-300",
+              "shrink-0 font-geneva-12 text-[12px] px-2 transition-colors duration-300",
               isPlaying ? "text-[#ff00ff]" : "text-gray-600",
               !isPlaying && "opacity-50"
             )}
@@ -150,7 +150,7 @@ function AnimatedTitle({
                   }
             }
             className={cn(
-              "shrink-0 font-geneva-12 px-2 transition-colors duration-300",
+              "shrink-0 font-geneva-12 text-[12px] px-2 transition-colors duration-300",
               isPlaying ? "text-[#ff00ff]" : "text-gray-600",
               !isPlaying && "opacity-50"
             )}


### PR DESCRIPTION
Ensure consistent 12px font size for Videos app LCD display title across all themes.

Previously, the title inherited smaller global font sizes in XP and 98 themes, causing it to appear smaller than intended. Explicitly setting `text-[12px]` on the `AnimatedTitle` component resolves this inheritance issue.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-f00d5dd7-ca8e-42d1-a0b8-bda0379d8204) · [Cursor](https://cursor.com/background-agent?bcId=bc-f00d5dd7-ca8e-42d1-a0b8-bda0379d8204)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)