### PR TITLE
Match select trigger height to input on ie macosx

### DIFF
--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -64,7 +64,7 @@ const SelectTrigger = React.forwardRef<
           : undefined,
         fontSize: isXpTheme ? "11px" : isMacOSTheme ? "14px" : undefined,
         ...(isMacOSTheme && {
-          height: "22px",
+          height: "28px", // Match Input h-7 height for macOS theme
           lineHeight: 1,
           minWidth: "60px",
           borderRadius: "6px",


### PR DESCRIPTION
Adjust SelectTrigger height to match Input component for macOS theme.

---

[Open in Web](https://www.cursor.com/agents?id=bc-941bf48a-964e-4f41-b5ba-56c07d557820) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-941bf48a-964e-4f41-b5ba-56c07d557820)