### PR TITLE
Refactor dialogs for macosx theme

### DIFF
--- a/src/apps/chats/components/CreateRoomDialog.tsx
+++ b/src/apps/chats/components/CreateRoomDialog.tsx
@@ -422,47 +422,39 @@ export function CreateRoomDialog({
     </div>
   );
 
-  if (isXpTheme) {
-    return (
-      <Dialog open={isOpen} onOpenChange={onOpenChange}>
-        <DialogContent
-          className={cn(
-            "p-0 overflow-hidden max-w-[400px] border-0", // Remove border but keep box-shadow
-            currentTheme === "xp" ? "window" : "window" // Use window class for both themes
-          )}
-          style={{
-            fontSize: "11px",
-          }}
-        >
-          <div
-            className="title-bar"
-            style={currentTheme === "xp" ? { minHeight: "30px" } : undefined}
-          >
-            <div className="title-bar-text">New Chat</div>
-            <div className="title-bar-controls">
-              <button aria-label="Close" onClick={() => onOpenChange(false)} />
-            </div>
-          </div>
-          <div className="window-body">{dialogContent}</div>
-        </DialogContent>
-      </Dialog>
-    );
-  }
-
   return (
     <Dialog open={isOpen} onOpenChange={onOpenChange}>
-      <DialogContent className="bg-os-window-bg border-[length:var(--os-metrics-border-width)] border-os-window rounded-os shadow-os-window">
-        <DialogHeader>
-          <DialogTitle className="font-normal text-[16px]">
-            New Chat
-          </DialogTitle>
-          <DialogDescription className="sr-only">
-            {isAdmin
-              ? "Create a public chat room or start a private conversation"
-              : "Start a private conversation"}
-          </DialogDescription>
-        </DialogHeader>
-        {dialogContent}
+      <DialogContent
+        className={cn(
+          "max-w-[400px]",
+          isXpTheme && "p-0 overflow-hidden"
+        )}
+        style={
+          isXpTheme
+            ? { fontSize: "11px" }
+            : undefined
+        }
+      >
+        {isXpTheme ? (
+          <>
+            <DialogHeader>New Chat</DialogHeader>
+            <div className="window-body">{dialogContent}</div>
+          </>
+        ) : (
+          <>
+            <DialogHeader>
+              <DialogTitle className="font-normal text-[16px]">
+                New Chat
+              </DialogTitle>
+              <DialogDescription className="sr-only">
+                {isAdmin
+                  ? "Create a public chat room or start a private conversation"
+                  : "Start a private conversation"}
+              </DialogDescription>
+            </DialogHeader>
+            {dialogContent}
+          </>
+        )}
       </DialogContent>
     </Dialog>
   );

--- a/src/apps/chats/components/CreateRoomDialog.tsx
+++ b/src/apps/chats/components/CreateRoomDialog.tsx
@@ -440,6 +440,11 @@ export function CreateRoomDialog({
             <DialogHeader>New Chat</DialogHeader>
             <div className="window-body">{dialogContent}</div>
           </>
+        ) : currentTheme === "macosx" ? (
+          <>
+            <DialogHeader>New Chat</DialogHeader>
+            {dialogContent}
+          </>
         ) : (
           <>
             <DialogHeader>

--- a/src/components/dialogs/AboutDialog.tsx
+++ b/src/components/dialogs/AboutDialog.tsx
@@ -90,45 +90,37 @@ export function AboutDialog({
     </div>
   );
 
-  if (isXpTheme) {
-    return (
-      <Dialog open={isOpen} onOpenChange={onOpenChange}>
-        <DialogContent
-          className={cn(
-            "p-0 overflow-hidden max-w-[240px] border-0", // Remove border but keep box-shadow
-            currentTheme === "xp" ? "window" : "window" // Use window class for both themes
-          )}
-          style={{
-            fontSize: "11px",
-          }}
-        >
-          <div
-            className="title-bar"
-            style={currentTheme === "xp" ? { minHeight: "30px" } : undefined}
-          >
-            <div className="title-bar-text">About</div>
-            <div className="title-bar-controls">
-              <button aria-label="Close" onClick={() => onOpenChange(false)} />
-            </div>
-          </div>
-          <div className={`window-body ${isXpTheme ? "p-2 px-4" : "p-4"}`}>
-            {dialogContent}
-          </div>
-        </DialogContent>
-      </Dialog>
-    );
-  }
-
   return (
     <Dialog open={isOpen} onOpenChange={onOpenChange}>
-      <DialogContent className="bg-os-window-bg border-[length:var(--os-metrics-border-width)] border-os-window rounded-os shadow-os-window max-w-[280px]">
-        <DialogHeader>
-          <DialogTitle className="font-normal text-[16px]">About</DialogTitle>
-          <DialogDescription className="sr-only">
-            Information about the application
-          </DialogDescription>
-        </DialogHeader>
-        {dialogContent}
+      <DialogContent
+        className={cn(
+          "max-w-[280px]",
+          isXpTheme && "p-0 overflow-hidden"
+        )}
+        style={
+          isXpTheme
+            ? { fontSize: "11px" }
+            : undefined
+        }
+      >
+        {isXpTheme ? (
+          <>
+            <DialogHeader>About</DialogHeader>
+            <div className={`window-body ${isXpTheme ? "p-2 px-4" : "p-4"}`}>
+              {dialogContent}
+            </div>
+          </>
+        ) : (
+          <>
+            <DialogHeader>
+              <DialogTitle className="font-normal text-[16px]">About</DialogTitle>
+              <DialogDescription className="sr-only">
+                Information about the application
+              </DialogDescription>
+            </DialogHeader>
+            {dialogContent}
+          </>
+        )}
       </DialogContent>
     </Dialog>
   );

--- a/src/components/dialogs/AboutDialog.tsx
+++ b/src/components/dialogs/AboutDialog.tsx
@@ -110,6 +110,11 @@ export function AboutDialog({
               {dialogContent}
             </div>
           </>
+        ) : currentTheme === "macosx" ? (
+          <>
+            <DialogHeader>About</DialogHeader>
+            {dialogContent}
+          </>
         ) : (
           <>
             <DialogHeader>

--- a/src/components/dialogs/AboutFinderDialog.tsx
+++ b/src/components/dialogs/AboutFinderDialog.tsx
@@ -184,6 +184,11 @@ export function AboutFinderDialog({
             <DialogHeader>About This Computer</DialogHeader>
             <div className="window-body">{dialogContent}</div>
           </>
+        ) : currentTheme === "macosx" ? (
+          <>
+            <DialogHeader>About This Computer</DialogHeader>
+            {dialogContent}
+          </>
         ) : (
           <>
             <DialogHeader>

--- a/src/components/dialogs/AboutFinderDialog.tsx
+++ b/src/components/dialogs/AboutFinderDialog.tsx
@@ -166,45 +166,37 @@ export function AboutFinderDialog({
     </div>
   );
 
-  if (isXpTheme) {
-    return (
-      <Dialog open={isOpen} onOpenChange={onOpenChange}>
-        <DialogContent
-          className={cn(
-            "p-0 overflow-hidden max-w-[400px] border-0", // Remove border but keep box-shadow
-            currentTheme === "xp" ? "window" : "window" // Use window class for both themes
-          )}
-          style={{
-            fontSize: "11px",
-          }}
-        >
-          <div
-            className="title-bar"
-            style={currentTheme === "xp" ? { minHeight: "30px" } : undefined}
-          >
-            <div className="title-bar-text">About This Computer</div>
-            <div className="title-bar-controls">
-              <button aria-label="Close" onClick={() => onOpenChange(false)} />
-            </div>
-          </div>
-          <div className="window-body">{dialogContent}</div>
-        </DialogContent>
-      </Dialog>
-    );
-  }
-
   return (
     <Dialog open={isOpen} onOpenChange={onOpenChange}>
-      <DialogContent className="bg-os-window-bg border-[length:var(--os-metrics-border-width)] border-os-window rounded-os shadow-os-window max-w-[400px] focus:outline-none">
-        <DialogHeader>
-          <DialogTitle className="font-normal text-[16px]">
-            About This Computer
-          </DialogTitle>
-          <DialogDescription className="sr-only">
-            Information about ryOS on this computer
-          </DialogDescription>
-        </DialogHeader>
-        {dialogContent}
+      <DialogContent
+        className={cn(
+          "max-w-[400px]",
+          isXpTheme && "p-0 overflow-hidden"
+        )}
+        style={
+          isXpTheme
+            ? { fontSize: "11px" }
+            : undefined
+        }
+      >
+        {isXpTheme ? (
+          <>
+            <DialogHeader>About This Computer</DialogHeader>
+            <div className="window-body">{dialogContent}</div>
+          </>
+        ) : (
+          <>
+            <DialogHeader>
+              <DialogTitle className="font-normal text-[16px]">
+                About This Computer
+              </DialogTitle>
+              <DialogDescription className="sr-only">
+                Information about ryOS on this computer
+              </DialogDescription>
+            </DialogHeader>
+            {dialogContent}
+          </>
+        )}
       </DialogContent>
     </Dialog>
   );

--- a/src/components/dialogs/ConfirmDialog.tsx
+++ b/src/components/dialogs/ConfirmDialog.tsx
@@ -130,6 +130,11 @@ export function ConfirmDialog({
             <DialogHeader>{title}</DialogHeader>
             <div className="window-body">{dialogContent}</div>
           </>
+        ) : currentTheme === "macosx" ? (
+          <>
+            <DialogHeader>{title}</DialogHeader>
+            {dialogContent}
+          </>
         ) : (
           <>
             <DialogHeader>

--- a/src/components/dialogs/ConfirmDialog.tsx
+++ b/src/components/dialogs/ConfirmDialog.tsx
@@ -108,53 +108,39 @@ export function ConfirmDialog({
     </div>
   );
 
-  if (isXpTheme) {
-    return (
-      <Dialog open={isOpen} onOpenChange={onOpenChange}>
-        <DialogContent
-          className={cn(
-            "p-0 overflow-hidden max-w-[400px] border-0", // Remove border but keep box-shadow
-            currentTheme === "xp" ? "window" : "window" // Use window class for both themes
-          )}
-          style={{
-            fontSize: "11px",
-          }}
-          onOpenAutoFocus={(e) => {
-            e.preventDefault();
-            confirmButtonRef.current?.focus();
-          }}
-        >
-          <div
-            className="title-bar"
-            style={currentTheme === "xp" ? { minHeight: "30px" } : undefined}
-          >
-            <div className="title-bar-text">{title}</div>
-            <div className="title-bar-controls">
-              <button aria-label="Close" onClick={() => onOpenChange(false)} />
-            </div>
-          </div>
-          <div className="window-body">{dialogContent}</div>
-        </DialogContent>
-      </Dialog>
-    );
-  }
-
   return (
     <Dialog open={isOpen} onOpenChange={onOpenChange}>
       <DialogContent
-        className="bg-os-window-bg border-[length:var(--os-metrics-border-width)] border-os-window rounded-os shadow-os-window"
+        className={cn(
+          "max-w-[400px]",
+          isXpTheme && "p-0 overflow-hidden"
+        )}
+        style={
+          isXpTheme
+            ? { fontSize: "11px" }
+            : undefined
+        }
         onOpenAutoFocus={(e) => {
           e.preventDefault();
           confirmButtonRef.current?.focus();
         }}
       >
-        <DialogHeader>
-          <DialogTitle className="font-normal text-[16px]">{title}</DialogTitle>
-          <DialogDescription className="sr-only">
-            {description}
-          </DialogDescription>
-        </DialogHeader>
-        {dialogContent}
+        {isXpTheme ? (
+          <>
+            <DialogHeader>{title}</DialogHeader>
+            <div className="window-body">{dialogContent}</div>
+          </>
+        ) : (
+          <>
+            <DialogHeader>
+              <DialogTitle className="font-normal text-[16px]">{title}</DialogTitle>
+              <DialogDescription className="sr-only">
+                {description}
+              </DialogDescription>
+            </DialogHeader>
+            {dialogContent}
+          </>
+        )}
       </DialogContent>
     </Dialog>
   );

--- a/src/components/dialogs/EmojiDialog.tsx
+++ b/src/components/dialogs/EmojiDialog.tsx
@@ -288,6 +288,11 @@ export function EmojiDialog({
             <DialogHeader>Set Emoji</DialogHeader>
             <div className="window-body">{dialogContent}</div>
           </>
+        ) : currentTheme === "macosx" ? (
+          <>
+            <DialogHeader>Set Emoji</DialogHeader>
+            {dialogContent}
+          </>
         ) : (
           <>
             <DialogHeader>

--- a/src/components/dialogs/EmojiDialog.tsx
+++ b/src/components/dialogs/EmojiDialog.tsx
@@ -270,45 +270,37 @@ export function EmojiDialog({
     </div>
   );
 
-  if (isXpTheme) {
-    return (
-      <Dialog open={isOpen} onOpenChange={onOpenChange}>
-        <DialogContent
-          className={cn(
-            "p-0 overflow-hidden max-w-[500px] border-0", // Remove border but keep box-shadow
-            currentTheme === "xp" ? "window" : "window" // Use window class for both themes
-          )}
-          style={{
-            fontSize: "11px",
-          }}
-        >
-          <div
-            className="title-bar"
-            style={currentTheme === "xp" ? { minHeight: "30px" } : undefined}
-          >
-            <div className="title-bar-text">Set Emoji</div>
-            <div className="title-bar-controls">
-              <button aria-label="Close" onClick={() => onOpenChange(false)} />
-            </div>
-          </div>
-          <div className="window-body">{dialogContent}</div>
-        </DialogContent>
-      </Dialog>
-    );
-  }
-
   return (
     <Dialog open={isOpen} onOpenChange={onOpenChange}>
-      <DialogContent className="bg-os-window-bg border-[length:var(--os-metrics-border-width)] border-os-window rounded-os shadow-os-window">
-        <DialogHeader>
-          <DialogTitle className="font-normal text-[16px]">
-            Set Emoji
-          </DialogTitle>
-          <DialogDescription className="sr-only">
-            Choose an emoji for this sound slot
-          </DialogDescription>
-        </DialogHeader>
-        {dialogContent}
+      <DialogContent
+        className={cn(
+          "max-w-[500px]",
+          isXpTheme && "p-0 overflow-hidden"
+        )}
+        style={
+          isXpTheme
+            ? { fontSize: "11px" }
+            : undefined
+        }
+      >
+        {isXpTheme ? (
+          <>
+            <DialogHeader>Set Emoji</DialogHeader>
+            <div className="window-body">{dialogContent}</div>
+          </>
+        ) : (
+          <>
+            <DialogHeader>
+              <DialogTitle className="font-normal text-[16px]">
+                Set Emoji
+              </DialogTitle>
+              <DialogDescription className="sr-only">
+                Choose an emoji for this sound slot
+              </DialogDescription>
+            </DialogHeader>
+            {dialogContent}
+          </>
+        )}
       </DialogContent>
     </Dialog>
   );

--- a/src/components/dialogs/HelpDialog.tsx
+++ b/src/components/dialogs/HelpDialog.tsx
@@ -99,43 +99,35 @@ export function HelpDialog({
     </div>
   );
 
-  if (isXpTheme) {
-    return (
-      <Dialog open={isOpen} onOpenChange={onOpenChange}>
-        <DialogContent
-          className={cn(
-            "p-0 overflow-hidden max-w-[600px] border-0", // Remove border but keep box-shadow
-            currentTheme === "xp" ? "window" : "window" // Use window class for both themes
-          )}
-          style={{
-            fontSize: "11px",
-          }}
-        >
-          <div
-            className="title-bar"
-            style={currentTheme === "xp" ? { minHeight: "30px" } : undefined}
-          >
-            <div className="title-bar-text">Help</div>
-            <div className="title-bar-controls">
-              <button aria-label="Close" onClick={() => onOpenChange(false)} />
-            </div>
-          </div>
-          <div className="window-body">{dialogContent}</div>
-        </DialogContent>
-      </Dialog>
-    );
-  }
-
   return (
     <Dialog open={isOpen} onOpenChange={onOpenChange}>
-      <DialogContent className="bg-os-window-bg border-[length:var(--os-metrics-border-width)] border-os-window rounded-os shadow-os-window max-w-[600px]">
-        <DialogHeader>
-          <DialogTitle className="font-normal text-[16px]">Help</DialogTitle>
-          <DialogDescription className="sr-only">
-            Help and documentation for {appName}
-          </DialogDescription>
-        </DialogHeader>
-        {dialogContent}
+      <DialogContent
+        className={cn(
+          "max-w-[600px]",
+          isXpTheme && "p-0 overflow-hidden"
+        )}
+        style={
+          isXpTheme
+            ? { fontSize: "11px" }
+            : undefined
+        }
+      >
+        {isXpTheme ? (
+          <>
+            <DialogHeader>Help</DialogHeader>
+            <div className="window-body">{dialogContent}</div>
+          </>
+        ) : (
+          <>
+            <DialogHeader>
+              <DialogTitle className="font-normal text-[16px]">Help</DialogTitle>
+              <DialogDescription className="sr-only">
+                Help and documentation for {appName}
+              </DialogDescription>
+            </DialogHeader>
+            {dialogContent}
+          </>
+        )}
       </DialogContent>
     </Dialog>
   );

--- a/src/components/dialogs/HelpDialog.tsx
+++ b/src/components/dialogs/HelpDialog.tsx
@@ -117,6 +117,11 @@ export function HelpDialog({
             <DialogHeader>Help</DialogHeader>
             <div className="window-body">{dialogContent}</div>
           </>
+        ) : currentTheme === "macosx" ? (
+          <>
+            <DialogHeader>Help</DialogHeader>
+            {dialogContent}
+          </>
         ) : (
           <>
             <DialogHeader>

--- a/src/components/dialogs/InputDialog.tsx
+++ b/src/components/dialogs/InputDialog.tsx
@@ -199,47 +199,36 @@ export function InputDialog({
     </div>
   );
 
-  if (isXpTheme) {
-    return (
-      <Dialog open={isOpen} onOpenChange={onOpenChange}>
-        <DialogContent
-          className={cn(
-            "p-0 overflow-hidden max-w-[500px] border-0", // Remove border but keep box-shadow
-            currentTheme === "xp" ? "window" : "window" // Use window class for both themes
-          )}
-          style={{
-            fontSize: "11px",
-          }}
-          onKeyDown={(e: React.KeyboardEvent) => e.stopPropagation()}
-        >
-          <div
-            className="title-bar"
-            style={currentTheme === "xp" ? { minHeight: "30px" } : undefined}
-          >
-            <div className="title-bar-text">{title}</div>
-            <div className="title-bar-controls">
-              <button aria-label="Close" onClick={() => onOpenChange(false)} />
-            </div>
-          </div>
-          <div className="window-body">{dialogContent}</div>
-        </DialogContent>
-      </Dialog>
-    );
-  }
-
   return (
     <Dialog open={isOpen} onOpenChange={onOpenChange}>
       <DialogContent
-        className="bg-os-window-bg border-[length:var(--os-metrics-border-width)] border-os-window rounded-os shadow-os-window"
+        className={cn(
+          "max-w-[500px]",
+          isXpTheme && "p-0 overflow-hidden"
+        )}
+        style={
+          isXpTheme
+            ? { fontSize: "11px" }
+            : undefined
+        }
         onKeyDown={(e: React.KeyboardEvent) => e.stopPropagation()}
       >
-        <DialogHeader>
-          <DialogTitle className="font-normal text-[16px]">{title}</DialogTitle>
-          <DialogDescription className="sr-only">
-            {description}
-          </DialogDescription>
-        </DialogHeader>
-        {dialogContent}
+        {isXpTheme ? (
+          <>
+            <DialogHeader>{title}</DialogHeader>
+            <div className="window-body">{dialogContent}</div>
+          </>
+        ) : (
+          <>
+            <DialogHeader>
+              <DialogTitle className="font-normal text-[16px]">{title}</DialogTitle>
+              <DialogDescription className="sr-only">
+                {description}
+              </DialogDescription>
+            </DialogHeader>
+            {dialogContent}
+          </>
+        )}
       </DialogContent>
     </Dialog>
   );

--- a/src/components/dialogs/InputDialog.tsx
+++ b/src/components/dialogs/InputDialog.tsx
@@ -218,6 +218,11 @@ export function InputDialog({
             <DialogHeader>{title}</DialogHeader>
             <div className="window-body">{dialogContent}</div>
           </>
+        ) : currentTheme === "macosx" ? (
+          <>
+            <DialogHeader>{title}</DialogHeader>
+            {dialogContent}
+          </>
         ) : (
           <>
             <DialogHeader>

--- a/src/components/dialogs/LoginDialog.tsx
+++ b/src/components/dialogs/LoginDialog.tsx
@@ -389,51 +389,40 @@ export function LoginDialog({
     </div>
   );
 
-  if (isXpTheme) {
-    return (
-      <Dialog open={isOpen} onOpenChange={onOpenChange}>
-        <DialogContent
-          className={cn(
-            "p-0 overflow-hidden max-w-[400px] border-0", // Remove border but keep box-shadow
-            currentTheme === "xp" ? "window" : "window" // Use window class for both themes
-          )}
-          style={{
-            fontSize: "11px",
-          }}
-          onKeyDown={(e: React.KeyboardEvent) => e.stopPropagation()}
-        >
-          <div
-            className="title-bar"
-            style={currentTheme === "xp" ? { minHeight: "30px" } : undefined}
-          >
-            <div className="title-bar-text">ryOS Login</div>
-            <div className="title-bar-controls">
-              <button aria-label="Close" onClick={() => onOpenChange(false)} />
-            </div>
-          </div>
-          <div className="window-body">{dialogContent}</div>
-        </DialogContent>
-      </Dialog>
-    );
-  }
-
   return (
     <Dialog open={isOpen} onOpenChange={onOpenChange}>
       <DialogContent
-        className="bg-os-window-bg border-[length:var(--os-metrics-border-width)] border-os-window rounded-os shadow-os-window max-w-[400px]"
+        className={cn(
+          "max-w-[400px]",
+          isXpTheme && "p-0 overflow-hidden"
+        )}
+        style={
+          isXpTheme
+            ? { fontSize: "11px" }
+            : undefined
+        }
         onKeyDown={(e: React.KeyboardEvent) => e.stopPropagation()}
       >
-        <DialogHeader>
-          <DialogTitle className="font-normal text-[16px]">
-            ryOS Login
-          </DialogTitle>
-          <DialogDescription className="sr-only">
-            {activeTab === "login"
-              ? "Log in to your account"
-              : "Create an account to access chat rooms and save your settings"}
-          </DialogDescription>
-        </DialogHeader>
-        {dialogContent}
+        {isXpTheme ? (
+          <>
+            <DialogHeader>ryOS Login</DialogHeader>
+            <div className="window-body">{dialogContent}</div>
+          </>
+        ) : (
+          <>
+            <DialogHeader>
+              <DialogTitle className="font-normal text-[16px]">
+                ryOS Login
+              </DialogTitle>
+              <DialogDescription className="sr-only">
+                {activeTab === "login"
+                  ? "Log in to your account"
+                  : "Create an account to access chat rooms and save your settings"}
+              </DialogDescription>
+            </DialogHeader>
+            {dialogContent}
+          </>
+        )}
       </DialogContent>
     </Dialog>
   );

--- a/src/components/dialogs/LoginDialog.tsx
+++ b/src/components/dialogs/LoginDialog.tsx
@@ -408,6 +408,11 @@ export function LoginDialog({
             <DialogHeader>ryOS Login</DialogHeader>
             <div className="window-body">{dialogContent}</div>
           </>
+        ) : currentTheme === "macosx" ? (
+          <>
+            <DialogHeader>ryOS Login</DialogHeader>
+            {dialogContent}
+          </>
         ) : (
           <>
             <DialogHeader>

--- a/src/components/layout/AppleMenu.tsx
+++ b/src/components/layout/AppleMenu.tsx
@@ -11,6 +11,8 @@ import { AboutFinderDialog } from "@/components/dialogs/AboutFinderDialog";
 import { AnyApp } from "@/apps/base/types";
 import { AppId } from "@/config/appRegistry";
 import { useLaunchApp } from "@/hooks/useLaunchApp";
+import { useThemeStore } from "@/stores/useThemeStore";
+import { cn } from "@/lib/utils";
 
 interface AppleMenuProps {
   apps: AnyApp[];
@@ -19,6 +21,8 @@ interface AppleMenuProps {
 export function AppleMenu({ apps }: AppleMenuProps) {
   const [aboutFinderOpen, setAboutFinderOpen] = useState(false);
   const launchApp = useLaunchApp();
+  const currentTheme = useThemeStore((state) => state.current);
+  const isMacOsxTheme = currentTheme === "macosx";
 
   const handleAppClick = (appId: string) => {
     // Simply launch the app - the instance system will handle focus if already open
@@ -32,7 +36,10 @@ export function AppleMenu({ apps }: AppleMenuProps) {
           <Button
             variant="ghost"
             size="default"
-            className="h-6 text-md px-3 py-1 border-none hover:bg-black/10 active:bg-black/20 focus-visible:ring-0"
+            className={cn(
+              "border-none hover:bg-black/10 active:bg-black/20 focus-visible:ring-0",
+              isMacOsxTheme ? "h-8 text-lg px-4 py-2" : "h-6 text-md px-3 py-1"
+            )}
             style={{ color: "inherit" }}
           >
             

--- a/src/components/layout/AppleMenu.tsx
+++ b/src/components/layout/AppleMenu.tsx
@@ -37,8 +37,8 @@ export function AppleMenu({ apps }: AppleMenuProps) {
             variant="ghost"
             size="default"
             className={cn(
-              "border-none hover:bg-black/10 active:bg-black/20 focus-visible:ring-0",
-              isMacOsxTheme ? "h-8 text-lg px-4 py-2" : "h-6 text-md px-3 py-1"
+              "h-6 px-3 py-1 border-none hover:bg-black/10 active:bg-black/20 focus-visible:ring-0",
+              isMacOsxTheme ? "text-xl" : "text-md"
             )}
             style={{ color: "inherit" }}
           >

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -82,7 +82,7 @@ const DialogContent = React.forwardRef<
     if (isMacOsxTheme) {
       return cn(
         "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-0 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 origin-center",
-        "bg-os-window-bg border-[length:var(--os-metrics-border-width)] border-os-window shadow-os-window",
+        "bg-os-window-bg border-[length:var(--os-metrics-border-width)] border-os-window shadow-os-window macosx-dialog",
         className
       );
     }
@@ -105,7 +105,6 @@ const DialogContent = React.forwardRef<
           isMacOsxTheme
             ? {
                 backgroundImage: `var(--os-pinstripe-window), var(--os-color-window-bg)`,
-                borderRadius: "0.45rem",
               }
             : undefined
         }
@@ -155,11 +154,10 @@ const DialogHeader = ({
     return (
       <div
         className={cn(
-          "flex items-center shrink-0 h-6 min-h-[1.25rem] mx-0 mb-0 px-[0.1rem] py-[0.1rem] select-none cursor-move user-select-none z-50 draggable-area",
+          "flex items-center shrink-0 h-6 min-h-[1.25rem] mx-0 mb-0 px-[0.1rem] py-[0.1rem] select-none cursor-move user-select-none z-50 draggable-area macosx-dialog-header",
           className
         )}
         style={{
-          borderRadius: "0.45rem 0.45rem 0px 0px",
           background: theme.colors.titleBar.activeBg,
           borderBottom: `1px solid ${theme.colors.titleBar.borderBottom || theme.colors.titleBar.border || "rgba(0, 0, 0, 0.1)"}`,
         }}

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -82,7 +82,7 @@ const DialogContent = React.forwardRef<
     if (isMacOsxTheme) {
       return cn(
         "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-0 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 origin-center",
-        "bg-os-window-bg border-[length:var(--os-metrics-border-width)] border-os-window rounded-t-lg shadow-os-window",
+        "bg-os-window-bg border-[length:var(--os-metrics-border-width)] border-os-window shadow-os-window",
         className
       );
     }
@@ -105,6 +105,7 @@ const DialogContent = React.forwardRef<
           isMacOsxTheme
             ? {
                 backgroundImage: `var(--os-pinstripe-window), var(--os-color-window-bg)`,
+                borderRadius: "var(--os-metrics-radius)",
               }
             : undefined
         }
@@ -158,7 +159,7 @@ const DialogHeader = ({
           className
         )}
         style={{
-          borderRadius: "8px 8px 0px 0px",
+          borderRadius: "var(--os-metrics-radius) var(--os-metrics-radius) 0px 0px",
           background: theme.colors.titleBar.activeBg,
           borderBottom: `1px solid ${theme.colors.titleBar.borderBottom || theme.colors.titleBar.border || "rgba(0, 0, 0, 0.1)"}`,
         }}

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -3,6 +3,8 @@ import * as DialogPrimitive from "@radix-ui/react-dialog";
 import { cn } from "@/lib/utils";
 import { useSound, Sounds } from "@/hooks/useSound";
 import { useVibration } from "@/hooks/useVibration";
+import { useThemeStore } from "@/stores/useThemeStore";
+import { getTheme } from "@/themes";
 
 const Dialog = ({ children, onOpenChange, ...props }: DialogPrimitive.DialogProps) => {
   const { play: playWindowOpen } = useSound(Sounds.WINDOW_OPEN);
@@ -51,6 +53,11 @@ const DialogContent = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
 >(({ className, children, ...props }, ref) => {
+  const currentTheme = useThemeStore((state) => state.current);
+  const isXpTheme = currentTheme === "xp" || currentTheme === "win98";
+  const isMacOsxTheme = currentTheme === "macosx";
+  const theme = getTheme(currentTheme);
+
   // Function to clean up pointer-events
   const cleanupPointerEvents = React.useCallback(() => {
     // Use RAF to ensure this runs after animations complete
@@ -64,15 +71,44 @@ const DialogContent = React.forwardRef<
     return () => cleanupPointerEvents();
   }, [cleanupPointerEvents]);
 
+  const getDialogContentClasses = () => {
+    if (isXpTheme) {
+      return cn(
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 p-0 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 origin-center",
+        "window", // Use xp.css window class
+        className
+      );
+    }
+
+    if (isMacOsxTheme) {
+      return cn(
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-0 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 origin-center",
+        "bg-os-window-bg border-[length:var(--os-metrics-border-width)] border-os-window rounded-t-lg shadow-os-window",
+        className
+      );
+    }
+
+    // Default System 7 style
+    return cn(
+      "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-0 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 origin-center",
+      "bg-os-window-bg border-[length:var(--os-metrics-border-width)] border-os-window rounded-os shadow-os-window",
+      className
+    );
+  };
+
   return (
     <DialogPortal>
       <DialogPrimitive.Overlay className="fixed inset-0 z-50 bg-black/30 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0" />
       <DialogPrimitive.Content
         ref={ref}
-        className={cn(
-          "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-0 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 origin-center sm:rounded-lg",
-          className
-        )}
+        className={getDialogContentClasses()}
+        style={
+          isMacOsxTheme
+            ? {
+                backgroundImage: `var(--os-pinstripe-window), var(--os-color-window-bg)`,
+              }
+            : undefined
+        }
         onEscapeKeyDown={cleanupPointerEvents}
         onPointerDownOutside={cleanupPointerEvents}
         onCloseAutoFocus={cleanupPointerEvents}
@@ -89,21 +125,117 @@ const DialogHeader = ({
   className,
   children,
   ...props
-}: React.HTMLAttributes<HTMLDivElement>) => (
-  <div
-    className={cn(
-      "flex items-center h-6 mx-0 my-[0.1rem] px-[0.1rem] py-[0.2rem] bg-[linear-gradient(#000_50%,transparent_0)] bg-clip-content bg-[length:6.6666666667%_13.3333333333%] border-b-[2px] border-black",
-      className
-    )}
-    {...props}
-  >
-    <DialogPrimitive.Close className="ml-2 w-4 h-4 bg-white border-2 border-black hover:bg-gray-200 active:bg-gray-300 flex items-center justify-center shadow-[0_0_0_1px_white] focus:outline-none focus:ring-0" />
-    <div className="select-none mx-auto bg-white px-2 py-0 h-full flex items-center justify-center">
-      {children}
+}: React.HTMLAttributes<HTMLDivElement>) => {
+  const currentTheme = useThemeStore((state) => state.current);
+  const isXpTheme = currentTheme === "xp" || currentTheme === "win98";
+  const isMacOsxTheme = currentTheme === "macosx";
+  const theme = getTheme(currentTheme);
+
+  if (isXpTheme) {
+    return (
+      <div
+        className={cn(
+          "title-bar",
+          className
+        )}
+        style={currentTheme === "xp" ? { minHeight: "30px" } : undefined}
+        {...props}
+      >
+        <div className="title-bar-text">{children}</div>
+        <div className="title-bar-controls">
+          <DialogPrimitive.Close asChild>
+            <button aria-label="Close" />
+          </DialogPrimitive.Close>
+        </div>
+      </div>
+    );
+  }
+
+  if (isMacOsxTheme) {
+    return (
+      <div
+        className={cn(
+          "flex items-center shrink-0 h-6 min-h-[1.25rem] mx-0 mb-0 px-[0.1rem] py-[0.1rem] select-none cursor-move user-select-none z-50 draggable-area",
+          className
+        )}
+        style={{
+          borderRadius: "8px 8px 0px 0px",
+          background: theme.colors.titleBar.activeBg,
+          borderBottom: `1px solid ${theme.colors.titleBar.borderBottom || theme.colors.titleBar.border || "rgba(0, 0, 0, 0.1)"}`,
+        }}
+        {...props}
+      >
+        {/* Traffic Light Buttons */}
+        <div className="flex items-center gap-1.5 ml-1.5">
+          {/* Close Button (Red) */}
+          <DialogPrimitive.Close asChild>
+            <button
+              className="w-3 h-3 rounded-full relative transition-all duration-150 hover:brightness-110 active:brightness-90"
+              style={{
+                background: theme.colors.trafficLights?.close || "rgba(255, 96, 87, 1)",
+                border: `1px solid ${theme.colors.trafficLights?.closeHover || "rgba(225, 70, 64, 1)"}`,
+              }}
+              aria-label="Close"
+            />
+          </DialogPrimitive.Close>
+          {/* Minimize Button (Yellow) */}
+          <button
+            className="w-3 h-3 rounded-full relative transition-all duration-150 hover:brightness-110 active:brightness-90"
+            style={{
+              background: theme.colors.trafficLights?.minimize || "rgba(255, 189, 46, 1)",
+              border: `1px solid ${theme.colors.trafficLights?.minimizeHover || "rgba(223, 161, 35, 1)"}`,
+            }}
+            aria-label="Minimize"
+          />
+          {/* Maximize Button (Green) */}
+          <button
+            className="w-3 h-3 rounded-full relative transition-all duration-150 hover:brightness-110 active:brightness-90"
+            style={{
+              background: theme.colors.trafficLights?.maximize || "rgba(39, 201, 63, 1)",
+              border: `1px solid ${theme.colors.trafficLights?.maximizeHover || "rgba(29, 173, 43, 1)"}`,
+            }}
+            aria-label="Maximize"
+          />
+        </div>
+
+        {/* Title */}
+        <span
+          className="select-none mx-auto px-2 py-0 h-full flex items-center whitespace-nowrap overflow-hidden text-ellipsis max-w-[80%] text-[12px] text-os-titlebar-active-text"
+          style={{
+            textShadow: "0 1px 0 rgba(255, 255, 255, 0.5)",
+          }}
+        >
+          <span className="truncate">{children}</span>
+        </span>
+
+        {/* Spacer to balance the traffic lights */}
+        <div className="mr-2 w-12 h-4" />
+      </div>
+    );
+  }
+
+  // Default System 7 style
+  return (
+    <div
+      className={cn(
+        "flex items-center shrink-0 h-os-titlebar min-h-[1.5rem] mx-0 my-[0.1rem] mb-0 px-[0.1rem] py-[0.2rem] select-none cursor-move border-b-[1.5px] user-select-none z-50 draggable-area bg-os-titlebar-active-bg bg-os-titlebar-pattern bg-clip-content bg-[length:6.6666666667%_13.3333333333%] border-b-os-window",
+        className
+      )}
+      {...props}
+    >
+      <DialogPrimitive.Close asChild>
+        <div className="relative ml-2 w-4 h-4 cursor-default select-none">
+          <div className="absolute inset-0 -m-2" />
+          <div className="w-4 h-4 bg-os-button-face shadow-[0_0_0_1px_var(--os-color-button-face)] border-2 border-os-window hover:bg-gray-200 active:bg-gray-300 flex items-center justify-center" />
+        </div>
+      </DialogPrimitive.Close>
+      <div className="select-none mx-auto bg-os-button-face px-2 py-0 h-full flex items-center justify-center text-os-titlebar-active-text">
+        {children}
+      </div>
+      <div className="mr-2 w-4 h-4" />
     </div>
-    <div className="mr-2 w-4 h-4" />
-  </div>
-);
+  );
+};
 DialogHeader.displayName = "DialogHeader";
 
 const DialogFooter = ({

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -56,7 +56,6 @@ const DialogContent = React.forwardRef<
   const currentTheme = useThemeStore((state) => state.current);
   const isXpTheme = currentTheme === "xp" || currentTheme === "win98";
   const isMacOsxTheme = currentTheme === "macosx";
-  const theme = getTheme(currentTheme);
 
   // Function to clean up pointer-events
   const cleanupPointerEvents = React.useCallback(() => {
@@ -129,7 +128,6 @@ const DialogHeader = ({
   const currentTheme = useThemeStore((state) => state.current);
   const isXpTheme = currentTheme === "xp" || currentTheme === "win98";
   const isMacOsxTheme = currentTheme === "macosx";
-  const theme = getTheme(currentTheme);
 
   if (isXpTheme) {
     return (
@@ -152,6 +150,7 @@ const DialogHeader = ({
   }
 
   if (isMacOsxTheme) {
+    const theme = getTheme(currentTheme);
     return (
       <div
         className={cn(

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -90,7 +90,7 @@ const DialogContent = React.forwardRef<
     // Default System 7 style
     return cn(
       "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-0 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 origin-center",
-      "bg-os-window-bg border-[length:var(--os-metrics-border-width)] border-os-window rounded-os shadow-os-window",
+      "bg-os-window-bg border-[length:var(--os-metrics-border-width)] border-os-window shadow-os-window",
       className
     );
   };
@@ -105,7 +105,7 @@ const DialogContent = React.forwardRef<
           isMacOsxTheme
             ? {
                 backgroundImage: `var(--os-pinstripe-window), var(--os-color-window-bg)`,
-                borderRadius: "var(--os-metrics-radius)",
+                borderRadius: "0.45rem",
               }
             : undefined
         }
@@ -159,7 +159,7 @@ const DialogHeader = ({
           className
         )}
         style={{
-          borderRadius: "var(--os-metrics-radius) var(--os-metrics-radius) 0px 0px",
+          borderRadius: "0.45rem 0.45rem 0px 0px",
           background: theme.colors.titleBar.activeBg,
           borderBottom: `1px solid ${theme.colors.titleBar.borderBottom || theme.colors.titleBar.border || "rgba(0, 0, 0, 0.1)"}`,
         }}

--- a/src/styles/themes.css
+++ b/src/styles/themes.css
@@ -721,3 +721,12 @@
 :root[data-os-theme="macosx"] .shadow-os-window:not(.is-foreground) {
   box-shadow: 0 4px 15px rgba(0, 0, 0, 0.2);
 }
+
+/* macOS Theme Dialog Styling */
+:root[data-os-theme="macosx"] .macosx-dialog {
+  border-radius: 7.2px !important;
+}
+
+:root[data-os-theme="macosx"] .macosx-dialog-header {
+  border-radius: 7.2px 7.2px 0px 0px !important;
+}


### PR DESCRIPTION
Refactor dialog components to natively support macOS theme with traffic lights and title bar styles.

This refactoring centralizes theme-specific rendering for dialog headers and content into the base `DialogHeader` and `DialogContent` components. This eliminates duplicated theme logic in individual dialogs, ensuring consistent visual behavior and better maintainability across all themes, particularly for the new macOS theme.

---

[Open in Web](https://www.cursor.com/agents?id=bc-e270733c-26e3-4423-a82d-bc69148aa5e9) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-e270733c-26e3-4423-a82d-bc69148aa5e9)