### PR TITLE
Adjust macosx select radius to 6

### DIFF
--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -67,7 +67,7 @@ const SelectTrigger = React.forwardRef<
           height: "28px", // Match Input h-7 height for macOS theme
           lineHeight: 1,
           minWidth: "60px",
-          borderRadius: "4px", // Changed from 6px to 4px to match Input styling
+          borderRadius: "6px", // macOS should use 6px radius
           position: "relative",
           overflow: "hidden",
           cursor: "default",
@@ -179,7 +179,7 @@ const SelectContent = React.forwardRef<
         style={{
           ...(isMacOSTheme && {
             border: "none",
-            borderRadius: "4px",
+            borderRadius: "6px",
             backgroundColor: "rgba(255, 255, 255, 0.7)",
             backdropFilter: "blur(20px)",
             WebkitBackdropFilter: "blur(20px)",
@@ -270,7 +270,7 @@ const SelectItem = React.forwardRef<
         ...(isMacOSTheme && {
           WebkitFontSmoothing: "antialiased",
           fontSmooth: "auto",
-          borderRadius: "4px",
+          borderRadius: "6px",
           padding: "4px 12px",
           margin: "1px 0",
           minHeight: "24px",


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Update select component border radius to 6px for macOS theme.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
This change aligns the select component's border radius with macOS design specifications, overriding the previous 4px radius that was set to match general input styling.

---

[Open in Web](https://www.cursor.com/agents?id=bc-e442367e-e8a4-468d-918a-00412650b1eb) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-e442367e-e8a4-468d-918a-00412650b1eb)