### PR TITLE
Align xp 98 desktop icons from left

### DIFF
--- a/src/apps/finder/components/FileIcon.tsx
+++ b/src/apps/finder/components/FileIcon.tsx
@@ -2,6 +2,7 @@ import { useSound, Sounds } from "@/hooks/useSound";
 import { useEffect, useState, useRef } from "react";
 import { isMobileDevice } from "@/utils/device";
 import { useLongPress } from "@/hooks/useLongPress";
+import { useThemeStore } from "@/stores/useThemeStore";
 
 interface FileIconProps {
   name: string;
@@ -33,6 +34,9 @@ export function FileIcon({
   className,
 }: FileIconProps) {
   const { play: playClick } = useSound(Sounds.BUTTON_CLICK, 0.3);
+  const currentTheme = useThemeStore((state) => state.current);
+  const isXpTheme = currentTheme === "xp" || currentTheme === "win98";
+  const isMacOSXTheme = currentTheme === "macosx";
   const [imgSrc, setImgSrc] = useState<string | undefined>(contentUrl);
   const [fallbackToIcon, setFallbackToIcon] = useState(false);
   const attemptedUrlsRef = useRef<Set<string>>(new Set());
@@ -253,9 +257,18 @@ export function FileIcon({
           sizes.text
         } ${
           isSelected || (isDropTarget && isDirectory)
-            ? "bg-black text-white"
-            : "bg-white text-black"
+            ? (isXpTheme || isMacOSXTheme) 
+              ? "bg-black text-white"
+              : "bg-black text-white"
+            : (isXpTheme || isMacOSXTheme)
+              ? "bg-transparent text-white"
+              : "bg-white text-black"
         }`}
+        style={
+          !isSelected && !(isDropTarget && isDirectory) && (isXpTheme || isMacOSXTheme)
+            ? { textShadow: "1px 1px 2px rgba(0, 0, 0, 0.8)" }
+            : {}
+        }
       >
         {name}
       </span>

--- a/src/apps/finder/components/FileIcon.tsx
+++ b/src/apps/finder/components/FileIcon.tsx
@@ -35,7 +35,8 @@ export function FileIcon({
 }: FileIconProps) {
   const { play: playClick } = useSound(Sounds.BUTTON_CLICK, 0.3);
   const currentTheme = useThemeStore((state) => state.current);
-  const isXpTheme = currentTheme === "xp" || currentTheme === "win98";
+  const isXpTheme = currentTheme === "xp";
+  const isWin98Theme = currentTheme === "win98";
   const isMacOSXTheme = currentTheme === "macosx";
   const [imgSrc, setImgSrc] = useState<string | undefined>(contentUrl);
   const [fallbackToIcon, setFallbackToIcon] = useState(false);
@@ -257,12 +258,12 @@ export function FileIcon({
           sizes.text
         } ${
           isSelected || (isDropTarget && isDirectory)
-            ? (isXpTheme || isMacOSXTheme) 
-              ? "bg-black text-white"
-              : "bg-black text-white"
-            : (isXpTheme || isMacOSXTheme)
-              ? "bg-transparent text-white"
-              : "bg-white text-black"
+            ? "bg-black text-white"
+            : isWin98Theme
+              ? "bg-white text-black"
+              : (isXpTheme || isMacOSXTheme)
+                ? "bg-transparent text-white"
+                : "bg-white text-black"
         }`}
         style={
           !isSelected && !(isDropTarget && isDirectory) && (isXpTheme || isMacOSXTheme)

--- a/src/components/layout/Desktop.tsx
+++ b/src/components/layout/Desktop.tsx
@@ -275,9 +275,9 @@ export function Desktop({
       }`}>
         <div className="flex flex-col flex-wrap-reverse justify-start gap-1 content-start h-full">
           <FileIcon
-            name="Macintosh HD"
+            name={isXpTheme ? "My Computer" : "Macintosh HD"}
             isDirectory={true}
-            icon="/icons/disk.png"
+            icon={isXpTheme ? "/icons/pc.png" : "/icons/disk.png"}
             onClick={(e) => {
               e.stopPropagation();
               setSelectedAppId("macintosh-hd");

--- a/src/components/layout/Desktop.tsx
+++ b/src/components/layout/Desktop.tsx
@@ -268,10 +268,10 @@ export function Desktop({
           display: isVideoWallpaper ? "block" : "none",
         }}
       />
-      <div className={`p-4 flex flex-col items-end relative z-[1] ${
+      <div className={`p-4 flex flex-col relative z-[1] ${
         isXpTheme 
-          ? "pt-4 h-[calc(100%-2.5rem)]" // Account for bottom taskbar (40px = 2.5rem)
-          : "pt-8 h-[calc(100%-2rem)]"   // Account for top menubar
+          ? "items-start pt-4 h-[calc(100%-2.5rem)]" // Account for bottom taskbar (40px = 2.5rem) - start from left for XP/98
+          : "items-end pt-8 h-[calc(100%-2rem)]"     // Account for top menubar - keep right alignment for other themes
       }`}>
         <div className="flex flex-col flex-wrap-reverse justify-start gap-1 content-start h-full">
           <FileIcon

--- a/src/components/layout/MenuBar.tsx
+++ b/src/components/layout/MenuBar.tsx
@@ -694,10 +694,12 @@ export function MenuBar({ children, inWindowFrame = false }: MenuBarProps) {
               isXpTheme ? "" : "px-2"
             }`}
             style={{
-              color: isXpTheme ? "#ffffff" : "#000000",
+              color: currentTheme === "win98" ? "#000000" : isXpTheme ? "#ffffff" : "#000000",
               textShadow:
-                currentTheme === "xp" || currentTheme === "win98"
+                currentTheme === "xp"
                   ? "1px 1px 1px rgba(0,0,0,0.5)"
+                  : currentTheme === "win98"
+                  ? "none"
                   : currentTheme === "macosx"
                   ? "0 1px 0 rgba(255, 255, 255, 0.5)"
                   : "none",


### PR DESCRIPTION
Align desktop icons to the left and update label styling for XP/98 and macOS themes to match authentic OS appearance.

---

[Open in Web](https://www.cursor.com/agents?id=bc-1050f245-7fd8-4561-a8e7-d50bc35e394c) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-1050f245-7fd8-4561-a8e7-d50bc35e394c)