### PR TITLE
Apply theme fonts for file icon labels

### DIFF
--- a/src/apps/finder/components/FileIcon.tsx
+++ b/src/apps/finder/components/FileIcon.tsx
@@ -261,7 +261,7 @@ export function FileIcon({
         {renderIcon()}
       </div>
       <span
-        className={`text-center px-1 font-geneva-12 break-words truncate ${
+        className={`text-center px-1 file-icon-label break-words truncate ${
           sizes.text
         } ${isMacOSXTheme && !isFinderContext ? "font-bold" : ""} ${
           isSelected || (isDropTarget && isDirectory)

--- a/src/index.css
+++ b/src/index.css
@@ -405,6 +405,10 @@ button.piano-key.piano-key[class*="bg-[#ff33ff]"] {
     font-smooth: always;
   }
 
+  .file-icon-label {
+    font-family: var(--os-font-ui);
+  }
+
   .font-apple-garamond {
     font-family: "Apple Garamond", "Georgia", "Palatino", serif;
     -webkit-font-smoothing: antialiased;

--- a/src/styles/themes.css
+++ b/src/styles/themes.css
@@ -117,9 +117,9 @@
 
 /* Windows 98 Theme */
 :root[data-os-theme="win98"] {
-  --os-font-ui: Tahoma, "MS Sans Serif", sans-serif;
+  --os-font-ui: Tahoma, "MS Sans Serif", "ArkPixel", "SerenityOS-Emoji", sans-serif;
   --os-font-mono: Consolas, "Courier New", monospace;
-  --font-ms-sans: "Pixelated MS Sans Serif", "MS Sans Serif", sans-serif;
+  --font-ms-sans: "Pixelated MS Sans Serif", "MS Sans Serif", "ArkPixel", "SerenityOS-Emoji", system-ui, sans-serif;
   --os-color-window-bg: #c0c0c0;
   --os-color-menubar-bg: #c0c0c0;
   --os-color-menubar-border: #808080;
@@ -147,9 +147,9 @@
 
 /* Windows XP Theme */
 :root[data-os-theme="xp"] {
-  --os-font-ui: Tahoma, Segoe UI, sans-serif;
+  --os-font-ui: Tahoma, Segoe UI, "ArkPixel", "SerenityOS-Emoji", sans-serif;
   --os-font-mono: Consolas, Courier New, monospace;
-  --font-ms-sans: "Pixelated MS Sans Serif", "MS Sans Serif", sans-serif;
+  --font-ms-sans: "Pixelated MS Sans Serif", "MS Sans Serif", "ArkPixel", "SerenityOS-Emoji", system-ui, sans-serif;
   --os-color-window-bg: #ece9d8;
   --os-color-menubar-bg: linear-gradient(to bottom, #245edc, #1941a5);
   --os-color-menubar-border: #0a246a;


### PR DESCRIPTION
## Summary
- reuse `--os-font-ui` for desktop icon labels
- add `ArkPixel` and `SerenityOS-Emoji` fallbacks to Windows 98/XP fonts
- drop unused `--file-icon-font` CSS variable
- remove font smoothing from `.file-icon-label`

## Testing
- `bun run lint` *(fails: 10 errors, 77 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_688280c03ac8832481fce376f35b1508