### PR TITLE
Override Finder label font in System 7 theme

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -409,6 +409,12 @@ button.piano-key.piano-key[class*="bg-[#ff33ff]"] {
     font-family: var(--os-font-ui);
   }
 
+  :root[data-os-theme="system7"] .file-icon-label {
+    font-family: var(--font-geneva-12);
+    -webkit-font-smoothing: antialiased;
+    font-smooth: always;
+  }
+
   .font-apple-garamond {
     font-family: "Apple Garamond", "Georgia", "Palatino", serif;
     -webkit-font-smoothing: antialiased;


### PR DESCRIPTION
## Summary
- use `font-geneva-12` for `.file-icon-label` under System 7 theme

## Testing
- `bun run lint` *(fails: 10 errors, 77 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68828873d9248324a717afde55b6c995