### PR TITLE
Update fonts in Windows themes

### DIFF
--- a/src/styles/themes.css
+++ b/src/styles/themes.css
@@ -117,7 +117,7 @@
 
 /* Windows 98 Theme */
 :root[data-os-theme="win98"] {
-  --os-font-ui: Tahoma, "MS Sans Serif", "ArkPixel", "SerenityOS-Emoji", sans-serif;
+  --os-font-ui: Tahoma, "Pixelated MS Sans Serif", "MS Sans Serif", "ArkPixel", "SerenityOS-Emoji", sans-serif;
   --os-font-mono: Consolas, "Courier New", monospace;
   --font-ms-sans: "Pixelated MS Sans Serif", "MS Sans Serif", "ArkPixel", "SerenityOS-Emoji", system-ui, sans-serif;
   --os-color-window-bg: #c0c0c0;
@@ -147,7 +147,7 @@
 
 /* Windows XP Theme */
 :root[data-os-theme="xp"] {
-  --os-font-ui: Tahoma, Segoe UI, "ArkPixel", "SerenityOS-Emoji", sans-serif;
+  --os-font-ui: Tahoma, Segoe UI, "Pixelated MS Sans Serif", "MS Sans Serif", "ArkPixel", "SerenityOS-Emoji", sans-serif;
   --os-font-mono: Consolas, Courier New, monospace;
   --font-ms-sans: "Pixelated MS Sans Serif", "MS Sans Serif", "ArkPixel", "SerenityOS-Emoji", system-ui, sans-serif;
   --os-color-window-bg: #ece9d8;


### PR DESCRIPTION
## Summary
- include `Pixelated MS Sans Serif` before `MS Sans Serif` for the `win98` and `xp` themes

## Testing
- `yarn lint` *(fails: 10 errors, 77 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68828e97954083248ef00e590c656ce6