### PR TITLE
Remove inner scrolling from WallpaperPicker

### DIFF
--- a/src/apps/control-panels/components/WallpaperPicker.tsx
+++ b/src/apps/control-panels/components/WallpaperPicker.tsx
@@ -7,7 +7,6 @@ import {
   SelectValue,
   SelectSeparator,
 } from "@/components/ui/select";
-import { ScrollArea } from "@/components/ui/scroll-area";
 import { useWallpaper } from "@/hooks/useWallpaper";
 import { useSound, Sounds } from "@/hooks/useSound";
 import { DisplayMode } from "@/utils/displayMode";
@@ -368,7 +367,7 @@ export function WallpaperPicker({ onSelect }: WallpaperPickerProps) {
         />
       )}
 
-      <ScrollArea className="flex-1 h-[200px]">
+      <div className="flex-1">
         <div
           className={`grid gap-2 p-1 ${
             selectedCategory === "tiles" ? "grid-cols-8" : "grid-cols-3"
@@ -435,7 +434,7 @@ export function WallpaperPicker({ onSelect }: WallpaperPickerProps) {
             </div>
           )}
         </div>
-      </ScrollArea>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
Remove inner scrolling from WallpaperPicker to allow content to expand within its parent container.

---

[Open in Web](https://cursor.com/agents?id=bc-16572cb5-5cab-4152-83c7-67db5b89e9f0) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-16572cb5-5cab-4152-83c7-67db5b89e9f0) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)