### PR TITLE
Update iPod player UI elements

### DIFF
--- a/src/apps/ipod/components/IpodAppComponent.tsx
+++ b/src/apps/ipod/components/IpodAppComponent.tsx
@@ -569,7 +569,7 @@ function FullScreenPortal({
             )}
           >
             <span className="text-[16px] md:text-[20px]">
-              {currentKoreanDisplay === "romanized" ? "HAN" : "한"}
+              {currentKoreanDisplay === "romanized" ? "KO" : "한"}
             </span>
           </button>
 

--- a/src/apps/ipod/components/IpodAppComponent.tsx
+++ b/src/apps/ipod/components/IpodAppComponent.tsx
@@ -353,7 +353,7 @@ function FullScreenPortal({
       } else if (e.key === " ") {
         e.preventDefault(); // Prevent scrolling if space is pressed
         handlers.togglePlay();
-        handlers.showStatus(isPlaying ? "❙ ❙" : "▶");
+        handlers.showStatus(isPlaying ? "⏸" : "▶");
       } else if (e.key === "ArrowLeft") {
         // Seek backward instead of previous track
         handlers.seekTime(-5);
@@ -446,7 +446,7 @@ function FullScreenPortal({
               e.stopPropagation();
               registerActivity();
               togglePlay();
-              showStatus(isPlaying ? "❙ ❙" : "▶");
+              showStatus(isPlaying ? "⏸" : "▶");
             }}
             aria-label="Play/Pause"
             className={cn(
@@ -455,7 +455,7 @@ function FullScreenPortal({
             title="Play/Pause"
           >
             <span className="text-[18px] md:text-[24px]">
-              {isPlaying ? "❙ ❙" : "▶"}
+              {isPlaying ? "⏸" : "▶"}
             </span>
           </button>
 

--- a/src/apps/ipod/components/IpodMenuBar.tsx
+++ b/src/apps/ipod/components/IpodMenuBar.tsx
@@ -374,7 +374,7 @@ export function IpodMenuBar({
                     koreanDisplay !== KoreanDisplay.Original && "pl-4"
                   )}
                 >
-                  {koreanDisplay === KoreanDisplay.Original ? "✓ 한글" : "한글"}
+                  {koreanDisplay === KoreanDisplay.Original ? "✓ KO" : "KO"}
                 </span>
               </DropdownMenuItem>
 

--- a/src/apps/ipod/components/IpodMenuBar.tsx
+++ b/src/apps/ipod/components/IpodMenuBar.tsx
@@ -374,7 +374,7 @@ export function IpodMenuBar({
                     koreanDisplay !== KoreanDisplay.Original && "pl-4"
                   )}
                 >
-                  {koreanDisplay === KoreanDisplay.Original ? "✓ KO" : "KO"}
+                  {koreanDisplay === KoreanDisplay.Original ? "✓ 한글" : "한글"}
                 </span>
               </DropdownMenuItem>
 


### PR DESCRIPTION
Update iPod full-screen player: replace pause button with glyph and change 'HAN' to 'KO' for Korean display.

---

[Open in Web](https://cursor.com/agents?id=bc-8ea2a078-a639-4b9f-bdc9-6df80a71bccf) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-8ea2a078-a639-4b9f-bdc9-6df80a71bccf) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)