### PR TITLE
Manage iPod player gestures for YouTube interactivity

### DIFF
--- a/src/apps/ipod/components/IpodAppComponent.tsx
+++ b/src/apps/ipod/components/IpodAppComponent.tsx
@@ -318,7 +318,7 @@ function FullScreenPortal({
 
   // Auto-hide controls after inactivity (desktop and mobile). Always visible when paused.
   useEffect(() => {
-    const handleActivity = (e?: Event) => {
+    const handleActivity = () => {
       // Track user interaction
       if (!hasUserInteracted) {
         setHasUserInteracted(true);

--- a/src/apps/ipod/components/IpodAppComponent.tsx
+++ b/src/apps/ipod/components/IpodAppComponent.tsx
@@ -154,6 +154,12 @@ function FullScreenPortal({
 
   // Stable event handlers using refs (no dependencies to avoid re-rendering)
   const handleTouchStart = useCallback((e: TouchEvent) => {
+    // Don't handle touches on toolbar elements
+    const target = e.target as HTMLElement;
+    if (target.closest('[data-toolbar]')) {
+      return;
+    }
+    
     // Track user interaction
     if (!hasUserInteracted) {
       setHasUserInteracted(true);
@@ -169,6 +175,13 @@ function FullScreenPortal({
 
   const handleTouchEnd = useCallback((e: TouchEvent) => {
     if (!touchStartRef.current) return;
+
+    // Don't handle touches on toolbar elements
+    const target = e.target as HTMLElement;
+    if (target.closest('[data-toolbar]')) {
+      touchStartRef.current = null;
+      return;
+    }
 
     // On mobile Safari, when not playing and after first interaction, 
     // disable gesture handling to let YouTube player be interactive
@@ -321,7 +334,12 @@ function FullScreenPortal({
 
   // Auto-hide controls after inactivity (desktop and mobile). Always visible when paused.
   useEffect(() => {
-    const handleActivity = () => {
+    const handleActivity = (e?: Event) => {
+      // Don't handle activity from toolbar elements
+      if (e && e.target && (e.target as HTMLElement).closest('[data-toolbar]')) {
+        return;
+      }
+      
       // Track user interaction
       if (!hasUserInteracted) {
         setHasUserInteracted(true);
@@ -435,7 +453,13 @@ function FullScreenPortal({
     <div
       ref={containerRef}
       className="ipod-force-font fixed inset-0 z-[9999] bg-black select-none flex flex-col"
-      onClick={() => {
+      onClick={(e) => {
+        // Don't handle clicks that originate from toolbar elements
+        const target = e.target as HTMLElement;
+        if (target.closest('[data-toolbar]')) {
+          return;
+        }
+        
         // Track user interaction
         if (!hasUserInteracted) {
           setHasUserInteracted(true);
@@ -524,6 +548,7 @@ function FullScreenPortal({
 
       {/* Inline toolbar below lyrics, centered */}
       <div
+        data-toolbar
         className={cn(
           "w-full flex justify-center z-[10001] transition-opacity duration-200",
           showControls || isLangMenuOpen || !isPlaying
@@ -533,6 +558,10 @@ function FullScreenPortal({
         style={{
           paddingBottom:
             "calc(max(env(safe-area-inset-bottom), 0.75rem) + clamp(1rem, 6dvh, 4rem))",
+        }}
+        onClick={(e) => {
+          // Ensure toolbar clicks don't bubble up to container
+          e.stopPropagation();
         }}
       >
         <div className="relative">

--- a/src/utils/device.ts
+++ b/src/utils/device.ts
@@ -31,6 +31,20 @@ export function isTouchDevice(): boolean {
 }
 
 /**
+ * Check if the current device is mobile Safari
+ */
+export function isMobileSafari(): boolean {
+  if (typeof navigator === "undefined") return false;
+  
+  const userAgent = navigator.userAgent;
+  return (
+    /Safari/.test(userAgent) &&
+    /Mobile|iP(hone|ad|od)/.test(userAgent) &&
+    !/CriOS|FxiOS|EdgiOS/.test(userAgent)
+  );
+}
+
+/**
  * Check if the device is a tablet (larger mobile device)
  */
 export function isTabletDevice(): boolean {


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Disable iPod full screen player tap gestures on mobile Safari when paused to allow YouTube player interaction.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
This change ensures that on mobile Safari, when the iPod full screen player is paused, its tap and swipe gestures are disabled, allowing users to interact directly with the embedded YouTube player controls. This behavior is only enabled after the user has first interacted with the iPod app to prevent unintended initial blocking.

---

[Open in Web](https://cursor.com/agents?id=bc-ec9c0e47-6219-4604-8919-fef7de3d73cf) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-ec9c0e47-6219-4604-8919-fef7de3d73cf) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)