### PR TITLE
Sync ipod player controls with ref player state

### DIFF
--- a/src/apps/ipod/components/IpodAppComponent.tsx
+++ b/src/apps/ipod/components/IpodAppComponent.tsx
@@ -605,14 +605,30 @@ function FullScreenPortal({
                 e.stopPropagation();
                 registerActivity();
                 togglePlay();
-                showStatus(isPlaying ? "⏸" : "▶");
+                // Use actual player state for status message
+                const internalPlayer = fullScreenPlayerRef?.current?.getInternalPlayer?.();
+                let actuallyPlaying = false;
+                if (internalPlayer && typeof internalPlayer.getPlayerState === 'function') {
+                  const playerState = internalPlayer.getPlayerState();
+                  actuallyPlaying = playerState === 1;
+                }
+                showStatus(actuallyPlaying ? "⏸" : "▶");
               }}
               aria-label="Play/Pause"
               className="w-9 h-9 md:w-12 md:h-12 flex items-center justify-center rounded-full text-white/70 hover:text-white hover:bg-white/10 transition-colors focus:outline-none"
               title="Play/Pause"
             >
               <span className="text-[18px] md:text-[22px]">
-                {isPlaying ? "⏸" : "▶"}
+                {(() => {
+                  // Use actual player state for button display
+                  const internalPlayer = fullScreenPlayerRef?.current?.getInternalPlayer?.();
+                  let actuallyPlaying = false;
+                  if (internalPlayer && typeof internalPlayer.getPlayerState === 'function') {
+                    const playerState = internalPlayer.getPlayerState();
+                    actuallyPlaying = playerState === 1;
+                  }
+                  return actuallyPlaying ? "⏸" : "▶";
+                })()}
               </span>
             </button>
 

--- a/src/apps/ipod/components/IpodAppComponent.tsx
+++ b/src/apps/ipod/components/IpodAppComponent.tsx
@@ -465,11 +465,20 @@ function FullScreenPortal({
           setHasUserInteracted(true);
         }
         
+        // Get the actual playing state from the fullscreen player
+        let actuallyPlaying = false;
+        const internalPlayer = fullScreenPlayerRef?.current?.getInternalPlayer?.();
+        if (internalPlayer && typeof internalPlayer.getPlayerState === 'function') {
+          const playerState = internalPlayer.getPlayerState();
+          // YouTube player states: -1 (unstarted), 0 (ended), 1 (playing), 2 (paused), 3 (buffering), 5 (video cued)
+          actuallyPlaying = playerState === 1;
+        }
+        
         // On mobile Safari, when not playing and after first interaction,
         // disable tap-to-play to let YouTube player be interactive
-        const shouldDisableClick = isMobileSafariDevice && !isPlaying && hasUserInteracted;
+        const shouldDisableClick = isMobileSafariDevice && !actuallyPlaying && hasUserInteracted;
         
-        if (!shouldDisableClick && !isPlaying) {
+        if (!shouldDisableClick && !actuallyPlaying) {
           const handlers = handlersRef.current;
           handlers.registerActivity();
           handlers.togglePlay();
@@ -480,7 +489,6 @@ function FullScreenPortal({
         // but the fullscreen player hasn't started yet, allow tap to start playback
         if (isMobileSafariDevice && isPlaying && hasUserInteracted) {
           // Check if the fullscreen player is actually playing
-          const internalPlayer = fullScreenPlayerRef?.current?.getInternalPlayer?.();
           if (internalPlayer && typeof internalPlayer.getPlayerState === 'function') {
             const playerState = internalPlayer.getPlayerState();
             // YouTube player states: -1 (unstarted), 0 (ended), 1 (playing), 2 (paused), 3 (buffering), 5 (video cued)


### PR DESCRIPTION
Synchronize full screen player play/pause controls with the actual player state to prevent out-of-sync issues.

---

[Open in Web](https://cursor.com/agents?id=bc-c80a4043-8408-4aaa-bdea-48dec9eb9d4a) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-c80a4043-8408-4aaa-bdea-48dec9eb9d4a) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)