### PR TITLE
Enlarge traffic light tap targets

### DIFF
--- a/src/components/layout/WindowFrame.tsx
+++ b/src/components/layout/WindowFrame.tsx
@@ -848,7 +848,7 @@ export function WindowFrame({
               }}
             >
               {/* Traffic Light Buttons */}
-              <div className="flex items-center gap-2 ml-1.5">
+              <div className="flex items-center gap-0 ml-0">
                 {/* Close Button (Red) */}
                 <button
                   onClick={(e) => {
@@ -857,19 +857,20 @@ export function WindowFrame({
                   }}
                   onMouseDown={(e) => e.stopPropagation()}
                   onTouchStart={(e) => e.stopPropagation()}
-                  className="cursor-default outline-none flex items-center justify-center relative"
+                  className="cursor-default outline-none flex items-center justify-center relative z-10"
                   style={{
                     width: "24px",
                     height: "24px",
                     margin: "-5.5px 0",
+                    marginRight: "-4px",
                   }}
                   aria-label="Close"
                 >
                   {/* Debug tap target overlay */}
-                  {process.env.NODE_ENV === 'development' && (
+                  {debugMode && (
                     <div
                       className="absolute inset-0 bg-red-500/20 border border-red-500/50 rounded"
-                      style={{ pointerEvents: 'none' }}
+                      style={{ pointerEvents: "none" }}
                     />
                   )}
                   <div
@@ -885,33 +886,33 @@ export function WindowFrame({
                         : "0 2px 3px rgba(0, 0, 0, 0.2), 0 1px 1px rgba(0, 0, 0, 0.3), inset 0 0 0 0.5px rgba(0, 0, 0, 0.3), inset 0 1px 2px rgba(0, 0, 0, 0.4), inset 0 2px 3px 1px #bbbbbb",
                     }}
                   >
-                  {/* Top shine */}
-                  <div
-                    className="absolute left-1/2 transform -translate-x-1/2 pointer-events-none"
-                    style={{
-                      height: "28%",
-                      background:
-                        "linear-gradient(rgba(255, 255, 255, 0.9), rgba(255, 255, 255, 0.3))",
-                      width: "calc(100% - 6px)",
-                      borderRadius: "6px 6px 0 0",
-                      top: "1px",
-                      filter: "blur(0.2px)",
-                      zIndex: 2,
-                    }}
-                  />
-                  {/* Bottom glow */}
-                  <div
-                    className="absolute left-1/2 transform -translate-x-1/2 pointer-events-none"
-                    style={{
-                      height: "33%",
-                      background:
-                        "linear-gradient(rgba(255, 255, 255, 0.2), rgba(255, 255, 255, 0.5))",
-                      width: "calc(100% - 3px)",
-                      borderRadius: "0 0 6px 6px",
-                      bottom: "1px",
-                      filter: "blur(0.3px)",
-                    }}
-                  />
+                    {/* Top shine */}
+                    <div
+                      className="absolute left-1/2 transform -translate-x-1/2 pointer-events-none"
+                      style={{
+                        height: "28%",
+                        background:
+                          "linear-gradient(rgba(255, 255, 255, 0.9), rgba(255, 255, 255, 0.3))",
+                        width: "calc(100% - 6px)",
+                        borderRadius: "6px 6px 0 0",
+                        top: "1px",
+                        filter: "blur(0.2px)",
+                        zIndex: 2,
+                      }}
+                    />
+                    {/* Bottom glow */}
+                    <div
+                      className="absolute left-1/2 transform -translate-x-1/2 pointer-events-none"
+                      style={{
+                        height: "33%",
+                        background:
+                          "linear-gradient(rgba(255, 255, 255, 0.2), rgba(255, 255, 255, 0.5))",
+                        width: "calc(100% - 3px)",
+                        borderRadius: "0 0 6px 6px",
+                        bottom: "1px",
+                        filter: "blur(0.3px)",
+                      }}
+                    />
                   </div>
                 </button>
                 {/* Minimize Button (Yellow) */}
@@ -922,7 +923,7 @@ export function WindowFrame({
                   }}
                   onMouseDown={(e) => e.stopPropagation()}
                   onTouchStart={(e) => e.stopPropagation()}
-                  className="cursor-default outline-none flex items-center justify-center relative"
+                  className="cursor-default outline-none flex items-center justify-center relative z-0"
                   style={{
                     width: "24px",
                     height: "24px",
@@ -931,10 +932,10 @@ export function WindowFrame({
                   aria-label="Minimize"
                 >
                   {/* Debug tap target overlay */}
-                  {process.env.NODE_ENV === 'development' && (
+                  {debugMode && (
                     <div
                       className="absolute inset-0 bg-yellow-500/20 border border-yellow-500/50 rounded"
-                      style={{ pointerEvents: 'none' }}
+                      style={{ pointerEvents: "none" }}
                     />
                   )}
                   <div
@@ -950,33 +951,33 @@ export function WindowFrame({
                         : "0 2px 3px rgba(0, 0, 0, 0.2), 0 1px 1px rgba(0, 0, 0, 0.3), inset 0 0 0 0.5px rgba(0, 0, 0, 0.3), inset 0 1px 2px rgba(0, 0, 0, 0.4), inset 0 2px 3px 1px #bbbbbb",
                     }}
                   >
-                  {/* Top shine */}
-                  <div
-                    className="absolute left-1/2 transform -translate-x-1/2 pointer-events-none"
-                    style={{
-                      height: "28%",
-                      background:
-                        "linear-gradient(rgba(255, 255, 255, 0.9), rgba(255, 255, 255, 0.3))",
-                      width: "calc(100% - 6px)",
-                      borderRadius: "6px 6px 0 0",
-                      top: "1px",
-                      filter: "blur(0.2px)",
-                      zIndex: 2,
-                    }}
-                  />
-                  {/* Bottom glow */}
-                  <div
-                    className="absolute left-1/2 transform -translate-x-1/2 pointer-events-none"
-                    style={{
-                      height: "33%",
-                      background:
-                        "linear-gradient(rgba(255, 255, 255, 0.2), rgba(255, 255, 255, 0.5))",
-                      width: "calc(100% - 3px)",
-                      borderRadius: "0 0 6px 6px",
-                      bottom: "1px",
-                      filter: "blur(0.3px)",
-                    }}
-                  />
+                    {/* Top shine */}
+                    <div
+                      className="absolute left-1/2 transform -translate-x-1/2 pointer-events-none"
+                      style={{
+                        height: "28%",
+                        background:
+                          "linear-gradient(rgba(255, 255, 255, 0.9), rgba(255, 255, 255, 0.3))",
+                        width: "calc(100% - 6px)",
+                        borderRadius: "6px 6px 0 0",
+                        top: "1px",
+                        filter: "blur(0.2px)",
+                        zIndex: 2,
+                      }}
+                    />
+                    {/* Bottom glow */}
+                    <div
+                      className="absolute left-1/2 transform -translate-x-1/2 pointer-events-none"
+                      style={{
+                        height: "33%",
+                        background:
+                          "linear-gradient(rgba(255, 255, 255, 0.2), rgba(255, 255, 255, 0.5))",
+                        width: "calc(100% - 3px)",
+                        borderRadius: "0 0 6px 6px",
+                        bottom: "1px",
+                        filter: "blur(0.3px)",
+                      }}
+                    />
                   </div>
                 </button>
                 {/* Maximize Button (Green) */}
@@ -987,19 +988,20 @@ export function WindowFrame({
                   }}
                   onMouseDown={(e) => e.stopPropagation()}
                   onTouchStart={(e) => e.stopPropagation()}
-                  className="cursor-default outline-none flex items-center justify-center relative"
+                  className="cursor-default outline-none flex items-center justify-center relative z-10"
                   style={{
                     width: "24px",
                     height: "24px",
                     margin: "-5.5px 0",
+                    marginLeft: "-4px",
                   }}
                   aria-label="Maximize"
                 >
                   {/* Debug tap target overlay */}
-                  {process.env.NODE_ENV === 'development' && (
+                  {debugMode && (
                     <div
                       className="absolute inset-0 bg-green-500/20 border border-green-500/50 rounded"
-                      style={{ pointerEvents: 'none' }}
+                      style={{ pointerEvents: "none" }}
                     />
                   )}
                   <div
@@ -1015,33 +1017,33 @@ export function WindowFrame({
                         : "0 2px 3px rgba(0, 0, 0, 0.2), 0 1px 1px rgba(0, 0, 0, 0.3), inset 0 0 0 0.5px rgba(0, 0, 0, 0.3), inset 0 1px 2px rgba(0, 0, 0, 0.4), inset 0 2px 3px 1px #bbbbbb",
                     }}
                   >
-                  {/* Top shine */}
-                  <div
-                    className="absolute left-1/2 transform -translate-x-1/2 pointer-events-none"
-                    style={{
-                      height: "28%",
-                      background:
-                        "linear-gradient(rgba(255, 255, 255, 0.9), rgba(255, 255, 255, 0.3))",
-                      width: "calc(100% - 6px)",
-                      borderRadius: "6px 6px 0 0",
-                      top: "1px",
-                      filter: "blur(0.2px)",
-                      zIndex: 2,
-                    }}
-                  />
-                  {/* Bottom glow */}
-                  <div
-                    className="absolute left-1/2 transform -translate-x-1/2 pointer-events-none"
-                    style={{
-                      height: "33%",
-                      background:
-                        "linear-gradient(rgba(255, 255, 255, 0.2), rgba(255, 255, 255, 0.5))",
-                      width: "calc(100% - 3px)",
-                      borderRadius: "0 0 6px 6px",
-                      bottom: "1px",
-                      filter: "blur(0.3px)",
-                    }}
-                  />
+                    {/* Top shine */}
+                    <div
+                      className="absolute left-1/2 transform -translate-x-1/2 pointer-events-none"
+                      style={{
+                        height: "28%",
+                        background:
+                          "linear-gradient(rgba(255, 255, 255, 0.9), rgba(255, 255, 255, 0.3))",
+                        width: "calc(100% - 6px)",
+                        borderRadius: "6px 6px 0 0",
+                        top: "1px",
+                        filter: "blur(0.2px)",
+                        zIndex: 2,
+                      }}
+                    />
+                    {/* Bottom glow */}
+                    <div
+                      className="absolute left-1/2 transform -translate-x-1/2 pointer-events-none"
+                      style={{
+                        height: "33%",
+                        background:
+                          "linear-gradient(rgba(255, 255, 255, 0.2), rgba(255, 255, 255, 0.5))",
+                        width: "calc(100% - 3px)",
+                        borderRadius: "0 0 6px 6px",
+                        bottom: "1px",
+                        filter: "blur(0.3px)",
+                      }}
+                    />
                   </div>
                 </button>
               </div>

--- a/src/components/layout/WindowFrame.tsx
+++ b/src/components/layout/WindowFrame.tsx
@@ -848,7 +848,7 @@ export function WindowFrame({
               }}
             >
               {/* Traffic Light Buttons */}
-              <div className="flex items-center gap-2 ml-1.5">
+              <div className="flex items-center gap-1 ml-1">
                 {/* Close Button (Red) */}
                 <button
                   onClick={(e) => {
@@ -857,19 +857,26 @@ export function WindowFrame({
                   }}
                   onMouseDown={(e) => e.stopPropagation()}
                   onTouchStart={(e) => e.stopPropagation()}
-                  className="rounded-full relative overflow-hidden cursor-default outline-none box-border"
+                  className="cursor-default outline-none p-1.5 flex items-center justify-center"
                   style={{
-                    width: "13px",
-                    height: "13px",
-                    background: isForeground
-                      ? "linear-gradient(rgb(193, 58, 45), rgb(205, 73, 52))"
-                      : "linear-gradient(rgba(160, 160, 160, 0.625), rgba(255, 255, 255, 0.625))",
-                    boxShadow: isForeground
-                      ? "rgba(0, 0, 0, 0.5) 0px 2px 4px, rgba(0, 0, 0, 0.4) 0px 1px 2px, rgba(225, 70, 64, 0.5) 0px 1px 1px, rgba(0, 0, 0, 0.3) 0px 0px 0px 0.5px inset, rgba(150, 40, 30, 0.8) 0px 1px 3px inset, rgba(225, 70, 64, 0.75) 0px 2px 3px 1px inset"
-                      : "0 2px 3px rgba(0, 0, 0, 0.2), 0 1px 1px rgba(0, 0, 0, 0.3), inset 0 0 0 0.5px rgba(0, 0, 0, 0.3), inset 0 1px 2px rgba(0, 0, 0, 0.4), inset 0 2px 3px 1px #bbbbbb",
+                    width: "22px",
+                    height: "22px",
                   }}
                   aria-label="Close"
                 >
+                  <div
+                    className="rounded-full relative overflow-hidden box-border"
+                    style={{
+                      width: "13px",
+                      height: "13px",
+                      background: isForeground
+                        ? "linear-gradient(rgb(193, 58, 45), rgb(205, 73, 52))"
+                        : "linear-gradient(rgba(160, 160, 160, 0.625), rgba(255, 255, 255, 0.625))",
+                      boxShadow: isForeground
+                        ? "rgba(0, 0, 0, 0.5) 0px 2px 4px, rgba(0, 0, 0, 0.4) 0px 1px 2px, rgba(225, 70, 64, 0.5) 0px 1px 1px, rgba(0, 0, 0, 0.3) 0px 0px 0px 0.5px inset, rgba(150, 40, 30, 0.8) 0px 1px 3px inset, rgba(225, 70, 64, 0.75) 0px 2px 3px 1px inset"
+                        : "0 2px 3px rgba(0, 0, 0, 0.2), 0 1px 1px rgba(0, 0, 0, 0.3), inset 0 0 0 0.5px rgba(0, 0, 0, 0.3), inset 0 1px 2px rgba(0, 0, 0, 0.4), inset 0 2px 3px 1px #bbbbbb",
+                    }}
+                  >
                   {/* Top shine */}
                   <div
                     className="absolute left-1/2 transform -translate-x-1/2 pointer-events-none"
@@ -897,6 +904,7 @@ export function WindowFrame({
                       filter: "blur(0.3px)",
                     }}
                   />
+                  </div>
                 </button>
                 {/* Minimize Button (Yellow) */}
                 <button
@@ -906,19 +914,26 @@ export function WindowFrame({
                   }}
                   onMouseDown={(e) => e.stopPropagation()}
                   onTouchStart={(e) => e.stopPropagation()}
-                  className="rounded-full relative overflow-hidden cursor-default outline-none box-border"
+                  className="cursor-default outline-none p-1.5 flex items-center justify-center"
                   style={{
-                    width: "13px",
-                    height: "13px",
-                    background: isForeground
-                      ? "linear-gradient(rgb(202, 130, 13), rgb(253, 253, 149))"
-                      : "linear-gradient(rgba(160, 160, 160, 0.625), rgba(255, 255, 255, 0.625))",
-                    boxShadow: isForeground
-                      ? "rgba(0, 0, 0, 0.5) 0px 2px 4px, rgba(0, 0, 0, 0.4) 0px 1px 2px, rgba(223, 161, 35, 0.5) 0px 1px 1px, rgba(0, 0, 0, 0.3) 0px 0px 0px 0.5px inset, rgb(155, 78, 21) 0px 1px 3px inset, rgb(241, 157, 20) 0px 2px 3px 1px inset"
-                      : "0 2px 3px rgba(0, 0, 0, 0.2), 0 1px 1px rgba(0, 0, 0, 0.3), inset 0 0 0 0.5px rgba(0, 0, 0, 0.3), inset 0 1px 2px rgba(0, 0, 0, 0.4), inset 0 2px 3px 1px #bbbbbb",
+                    width: "22px",
+                    height: "22px",
                   }}
                   aria-label="Minimize"
                 >
+                  <div
+                    className="rounded-full relative overflow-hidden box-border"
+                    style={{
+                      width: "13px",
+                      height: "13px",
+                      background: isForeground
+                        ? "linear-gradient(rgb(202, 130, 13), rgb(253, 253, 149))"
+                        : "linear-gradient(rgba(160, 160, 160, 0.625), rgba(255, 255, 255, 0.625))",
+                      boxShadow: isForeground
+                        ? "rgba(0, 0, 0, 0.5) 0px 2px 4px, rgba(0, 0, 0, 0.4) 0px 1px 2px, rgba(223, 161, 35, 0.5) 0px 1px 1px, rgba(0, 0, 0, 0.3) 0px 0px 0px 0.5px inset, rgb(155, 78, 21) 0px 1px 3px inset, rgb(241, 157, 20) 0px 2px 3px 1px inset"
+                        : "0 2px 3px rgba(0, 0, 0, 0.2), 0 1px 1px rgba(0, 0, 0, 0.3), inset 0 0 0 0.5px rgba(0, 0, 0, 0.3), inset 0 1px 2px rgba(0, 0, 0, 0.4), inset 0 2px 3px 1px #bbbbbb",
+                    }}
+                  >
                   {/* Top shine */}
                   <div
                     className="absolute left-1/2 transform -translate-x-1/2 pointer-events-none"
@@ -946,6 +961,7 @@ export function WindowFrame({
                       filter: "blur(0.3px)",
                     }}
                   />
+                  </div>
                 </button>
                 {/* Maximize Button (Green) */}
                 <button
@@ -955,19 +971,26 @@ export function WindowFrame({
                   }}
                   onMouseDown={(e) => e.stopPropagation()}
                   onTouchStart={(e) => e.stopPropagation()}
-                  className="rounded-full relative overflow-hidden cursor-default outline-none box-border"
+                  className="cursor-default outline-none p-1.5 flex items-center justify-center"
                   style={{
-                    width: "13px",
-                    height: "13px",
-                    background: isForeground
-                      ? "linear-gradient(rgb(111, 174, 58), rgb(138, 192, 50))"
-                      : "linear-gradient(rgba(160, 160, 160, 0.625), rgba(255, 255, 255, 0.625))",
-                    boxShadow: isForeground
-                      ? "rgba(0, 0, 0, 0.5) 0px 2px 4px, rgba(0, 0, 0, 0.4) 0px 1px 2px, rgb(59, 173, 29, 0.5) 0px 1px 1px, rgba(0, 0, 0, 0.3) 0px 0px 0px 0.5px inset, rgb(53, 91, 17) 0px 1px 3px inset, rgb(98, 187, 19) 0px 2px 3px 1px inset"
-                      : "0 2px 3px rgba(0, 0, 0, 0.2), 0 1px 1px rgba(0, 0, 0, 0.3), inset 0 0 0 0.5px rgba(0, 0, 0, 0.3), inset 0 1px 2px rgba(0, 0, 0, 0.4), inset 0 2px 3px 1px #bbbbbb",
+                    width: "22px",
+                    height: "22px",
                   }}
                   aria-label="Maximize"
                 >
+                  <div
+                    className="rounded-full relative overflow-hidden box-border"
+                    style={{
+                      width: "13px",
+                      height: "13px",
+                      background: isForeground
+                        ? "linear-gradient(rgb(111, 174, 58), rgb(138, 192, 50))"
+                        : "linear-gradient(rgba(160, 160, 160, 0.625), rgba(255, 255, 255, 0.625))",
+                      boxShadow: isForeground
+                        ? "rgba(0, 0, 0, 0.5) 0px 2px 4px, rgba(0, 0, 0, 0.4) 0px 1px 2px, rgb(59, 173, 29, 0.5) 0px 1px 1px, rgba(0, 0, 0, 0.3) 0px 0px 0px 0.5px inset, rgb(53, 91, 17) 0px 1px 3px inset, rgb(98, 187, 19) 0px 2px 3px 1px inset"
+                        : "0 2px 3px rgba(0, 0, 0, 0.2), 0 1px 1px rgba(0, 0, 0, 0.3), inset 0 0 0 0.5px rgba(0, 0, 0, 0.3), inset 0 1px 2px rgba(0, 0, 0, 0.4), inset 0 2px 3px 1px #bbbbbb",
+                    }}
+                  >
                   {/* Top shine */}
                   <div
                     className="absolute left-1/2 transform -translate-x-1/2 pointer-events-none"
@@ -995,6 +1018,7 @@ export function WindowFrame({
                       filter: "blur(0.3px)",
                     }}
                   />
+                  </div>
                 </button>
               </div>
 

--- a/src/components/layout/WindowFrame.tsx
+++ b/src/components/layout/WindowFrame.tsx
@@ -857,19 +857,27 @@ export function WindowFrame({
                   }}
                   onMouseDown={(e) => e.stopPropagation()}
                   onTouchStart={(e) => e.stopPropagation()}
-                  className="rounded-full relative overflow-hidden cursor-default outline-none box-border p-1"
+                  className="cursor-default outline-none flex items-center justify-center"
                   style={{
-                    width: "13px",
-                    height: "13px",
-                    background: isForeground
-                      ? "linear-gradient(rgb(193, 58, 45), rgb(205, 73, 52))"
-                      : "linear-gradient(rgba(160, 160, 160, 0.625), rgba(255, 255, 255, 0.625))",
-                    boxShadow: isForeground
-                      ? "rgba(0, 0, 0, 0.5) 0px 2px 4px, rgba(0, 0, 0, 0.4) 0px 1px 2px, rgba(225, 70, 64, 0.5) 0px 1px 1px, rgba(0, 0, 0, 0.3) 0px 0px 0px 0.5px inset, rgba(150, 40, 30, 0.8) 0px 1px 3px inset, rgba(225, 70, 64, 0.75) 0px 2px 3px 1px inset"
-                      : "0 2px 3px rgba(0, 0, 0, 0.2), 0 1px 1px rgba(0, 0, 0, 0.3), inset 0 0 0 0.5px rgba(0, 0, 0, 0.3), inset 0 1px 2px rgba(0, 0, 0, 0.4), inset 0 2px 3px 1px #bbbbbb",
+                    width: "24px",
+                    height: "24px",
+                    margin: "-5.5px 0",
                   }}
                   aria-label="Close"
                 >
+                  <div
+                    className="rounded-full relative overflow-hidden box-border"
+                    style={{
+                      width: "13px",
+                      height: "13px",
+                      background: isForeground
+                        ? "linear-gradient(rgb(193, 58, 45), rgb(205, 73, 52))"
+                        : "linear-gradient(rgba(160, 160, 160, 0.625), rgba(255, 255, 255, 0.625))",
+                      boxShadow: isForeground
+                        ? "rgba(0, 0, 0, 0.5) 0px 2px 4px, rgba(0, 0, 0, 0.4) 0px 1px 2px, rgba(225, 70, 64, 0.5) 0px 1px 1px, rgba(0, 0, 0, 0.3) 0px 0px 0px 0.5px inset, rgba(150, 40, 30, 0.8) 0px 1px 3px inset, rgba(225, 70, 64, 0.75) 0px 2px 3px 1px inset"
+                        : "0 2px 3px rgba(0, 0, 0, 0.2), 0 1px 1px rgba(0, 0, 0, 0.3), inset 0 0 0 0.5px rgba(0, 0, 0, 0.3), inset 0 1px 2px rgba(0, 0, 0, 0.4), inset 0 2px 3px 1px #bbbbbb",
+                    }}
+                  >
                   {/* Top shine */}
                   <div
                     className="absolute left-1/2 transform -translate-x-1/2 pointer-events-none"
@@ -897,6 +905,7 @@ export function WindowFrame({
                       filter: "blur(0.3px)",
                     }}
                   />
+                  </div>
                 </button>
                 {/* Minimize Button (Yellow) */}
                 <button
@@ -906,19 +915,27 @@ export function WindowFrame({
                   }}
                   onMouseDown={(e) => e.stopPropagation()}
                   onTouchStart={(e) => e.stopPropagation()}
-                  className="rounded-full relative overflow-hidden cursor-default outline-none box-border p-1"
+                  className="cursor-default outline-none flex items-center justify-center"
                   style={{
-                    width: "13px",
-                    height: "13px",
-                    background: isForeground
-                      ? "linear-gradient(rgb(202, 130, 13), rgb(253, 253, 149))"
-                      : "linear-gradient(rgba(160, 160, 160, 0.625), rgba(255, 255, 255, 0.625))",
-                    boxShadow: isForeground
-                      ? "rgba(0, 0, 0, 0.5) 0px 2px 4px, rgba(0, 0, 0, 0.4) 0px 1px 2px, rgba(223, 161, 35, 0.5) 0px 1px 1px, rgba(0, 0, 0, 0.3) 0px 0px 0px 0.5px inset, rgb(155, 78, 21) 0px 1px 3px inset, rgb(241, 157, 20) 0px 2px 3px 1px inset"
-                      : "0 2px 3px rgba(0, 0, 0, 0.2), 0 1px 1px rgba(0, 0, 0, 0.3), inset 0 0 0 0.5px rgba(0, 0, 0, 0.3), inset 0 1px 2px rgba(0, 0, 0, 0.4), inset 0 2px 3px 1px #bbbbbb",
+                    width: "24px",
+                    height: "24px",
+                    margin: "-5.5px 0",
                   }}
                   aria-label="Minimize"
                 >
+                  <div
+                    className="rounded-full relative overflow-hidden box-border"
+                    style={{
+                      width: "13px",
+                      height: "13px",
+                      background: isForeground
+                        ? "linear-gradient(rgb(202, 130, 13), rgb(253, 253, 149))"
+                        : "linear-gradient(rgba(160, 160, 160, 0.625), rgba(255, 255, 255, 0.625))",
+                      boxShadow: isForeground
+                        ? "rgba(0, 0, 0, 0.5) 0px 2px 4px, rgba(0, 0, 0, 0.4) 0px 1px 2px, rgba(223, 161, 35, 0.5) 0px 1px 1px, rgba(0, 0, 0, 0.3) 0px 0px 0px 0.5px inset, rgb(155, 78, 21) 0px 1px 3px inset, rgb(241, 157, 20) 0px 2px 3px 1px inset"
+                        : "0 2px 3px rgba(0, 0, 0, 0.2), 0 1px 1px rgba(0, 0, 0, 0.3), inset 0 0 0 0.5px rgba(0, 0, 0, 0.3), inset 0 1px 2px rgba(0, 0, 0, 0.4), inset 0 2px 3px 1px #bbbbbb",
+                    }}
+                  >
                   {/* Top shine */}
                   <div
                     className="absolute left-1/2 transform -translate-x-1/2 pointer-events-none"
@@ -946,6 +963,7 @@ export function WindowFrame({
                       filter: "blur(0.3px)",
                     }}
                   />
+                  </div>
                 </button>
                 {/* Maximize Button (Green) */}
                 <button
@@ -955,19 +973,27 @@ export function WindowFrame({
                   }}
                   onMouseDown={(e) => e.stopPropagation()}
                   onTouchStart={(e) => e.stopPropagation()}
-                  className="rounded-full relative overflow-hidden cursor-default outline-none box-border p-1"
+                  className="cursor-default outline-none flex items-center justify-center"
                   style={{
-                    width: "13px",
-                    height: "13px",
-                    background: isForeground
-                      ? "linear-gradient(rgb(111, 174, 58), rgb(138, 192, 50))"
-                      : "linear-gradient(rgba(160, 160, 160, 0.625), rgba(255, 255, 255, 0.625))",
-                    boxShadow: isForeground
-                      ? "rgba(0, 0, 0, 0.5) 0px 2px 4px, rgba(0, 0, 0, 0.4) 0px 1px 2px, rgb(59, 173, 29, 0.5) 0px 1px 1px, rgba(0, 0, 0, 0.3) 0px 0px 0px 0.5px inset, rgb(53, 91, 17) 0px 1px 3px inset, rgb(98, 187, 19) 0px 2px 3px 1px inset"
-                      : "0 2px 3px rgba(0, 0, 0, 0.2), 0 1px 1px rgba(0, 0, 0, 0.3), inset 0 0 0 0.5px rgba(0, 0, 0, 0.3), inset 0 1px 2px rgba(0, 0, 0, 0.4), inset 0 2px 3px 1px #bbbbbb",
+                    width: "24px",
+                    height: "24px",
+                    margin: "-5.5px 0",
                   }}
                   aria-label="Maximize"
                 >
+                  <div
+                    className="rounded-full relative overflow-hidden box-border"
+                    style={{
+                      width: "13px",
+                      height: "13px",
+                      background: isForeground
+                        ? "linear-gradient(rgb(111, 174, 58), rgb(138, 192, 50))"
+                        : "linear-gradient(rgba(160, 160, 160, 0.625), rgba(255, 255, 255, 0.625))",
+                      boxShadow: isForeground
+                        ? "rgba(0, 0, 0, 0.5) 0px 2px 4px, rgba(0, 0, 0, 0.4) 0px 1px 2px, rgb(59, 173, 29, 0.5) 0px 1px 1px, rgba(0, 0, 0, 0.3) 0px 0px 0px 0.5px inset, rgb(53, 91, 17) 0px 1px 3px inset, rgb(98, 187, 19) 0px 2px 3px 1px inset"
+                        : "0 2px 3px rgba(0, 0, 0, 0.2), 0 1px 1px rgba(0, 0, 0, 0.3), inset 0 0 0 0.5px rgba(0, 0, 0, 0.3), inset 0 1px 2px rgba(0, 0, 0, 0.4), inset 0 2px 3px 1px #bbbbbb",
+                    }}
+                  >
                   {/* Top shine */}
                   <div
                     className="absolute left-1/2 transform -translate-x-1/2 pointer-events-none"
@@ -995,6 +1021,7 @@ export function WindowFrame({
                       filter: "blur(0.3px)",
                     }}
                   />
+                  </div>
                 </button>
               </div>
 

--- a/src/components/layout/WindowFrame.tsx
+++ b/src/components/layout/WindowFrame.tsx
@@ -848,7 +848,7 @@ export function WindowFrame({
               }}
             >
               {/* Traffic Light Buttons */}
-              <div className="flex items-center gap-1 ml-1">
+              <div className="flex items-center gap-2 ml-1.5">
                 {/* Close Button (Red) */}
                 <button
                   onClick={(e) => {
@@ -857,26 +857,19 @@ export function WindowFrame({
                   }}
                   onMouseDown={(e) => e.stopPropagation()}
                   onTouchStart={(e) => e.stopPropagation()}
-                  className="cursor-default outline-none p-1.5 flex items-center justify-center"
+                  className="rounded-full relative overflow-hidden cursor-default outline-none box-border p-1"
                   style={{
-                    width: "22px",
-                    height: "22px",
+                    width: "13px",
+                    height: "13px",
+                    background: isForeground
+                      ? "linear-gradient(rgb(193, 58, 45), rgb(205, 73, 52))"
+                      : "linear-gradient(rgba(160, 160, 160, 0.625), rgba(255, 255, 255, 0.625))",
+                    boxShadow: isForeground
+                      ? "rgba(0, 0, 0, 0.5) 0px 2px 4px, rgba(0, 0, 0, 0.4) 0px 1px 2px, rgba(225, 70, 64, 0.5) 0px 1px 1px, rgba(0, 0, 0, 0.3) 0px 0px 0px 0.5px inset, rgba(150, 40, 30, 0.8) 0px 1px 3px inset, rgba(225, 70, 64, 0.75) 0px 2px 3px 1px inset"
+                      : "0 2px 3px rgba(0, 0, 0, 0.2), 0 1px 1px rgba(0, 0, 0, 0.3), inset 0 0 0 0.5px rgba(0, 0, 0, 0.3), inset 0 1px 2px rgba(0, 0, 0, 0.4), inset 0 2px 3px 1px #bbbbbb",
                   }}
                   aria-label="Close"
                 >
-                  <div
-                    className="rounded-full relative overflow-hidden box-border"
-                    style={{
-                      width: "13px",
-                      height: "13px",
-                      background: isForeground
-                        ? "linear-gradient(rgb(193, 58, 45), rgb(205, 73, 52))"
-                        : "linear-gradient(rgba(160, 160, 160, 0.625), rgba(255, 255, 255, 0.625))",
-                      boxShadow: isForeground
-                        ? "rgba(0, 0, 0, 0.5) 0px 2px 4px, rgba(0, 0, 0, 0.4) 0px 1px 2px, rgba(225, 70, 64, 0.5) 0px 1px 1px, rgba(0, 0, 0, 0.3) 0px 0px 0px 0.5px inset, rgba(150, 40, 30, 0.8) 0px 1px 3px inset, rgba(225, 70, 64, 0.75) 0px 2px 3px 1px inset"
-                        : "0 2px 3px rgba(0, 0, 0, 0.2), 0 1px 1px rgba(0, 0, 0, 0.3), inset 0 0 0 0.5px rgba(0, 0, 0, 0.3), inset 0 1px 2px rgba(0, 0, 0, 0.4), inset 0 2px 3px 1px #bbbbbb",
-                    }}
-                  >
                   {/* Top shine */}
                   <div
                     className="absolute left-1/2 transform -translate-x-1/2 pointer-events-none"
@@ -904,7 +897,6 @@ export function WindowFrame({
                       filter: "blur(0.3px)",
                     }}
                   />
-                  </div>
                 </button>
                 {/* Minimize Button (Yellow) */}
                 <button
@@ -914,26 +906,19 @@ export function WindowFrame({
                   }}
                   onMouseDown={(e) => e.stopPropagation()}
                   onTouchStart={(e) => e.stopPropagation()}
-                  className="cursor-default outline-none p-1.5 flex items-center justify-center"
+                  className="rounded-full relative overflow-hidden cursor-default outline-none box-border p-1"
                   style={{
-                    width: "22px",
-                    height: "22px",
+                    width: "13px",
+                    height: "13px",
+                    background: isForeground
+                      ? "linear-gradient(rgb(202, 130, 13), rgb(253, 253, 149))"
+                      : "linear-gradient(rgba(160, 160, 160, 0.625), rgba(255, 255, 255, 0.625))",
+                    boxShadow: isForeground
+                      ? "rgba(0, 0, 0, 0.5) 0px 2px 4px, rgba(0, 0, 0, 0.4) 0px 1px 2px, rgba(223, 161, 35, 0.5) 0px 1px 1px, rgba(0, 0, 0, 0.3) 0px 0px 0px 0.5px inset, rgb(155, 78, 21) 0px 1px 3px inset, rgb(241, 157, 20) 0px 2px 3px 1px inset"
+                      : "0 2px 3px rgba(0, 0, 0, 0.2), 0 1px 1px rgba(0, 0, 0, 0.3), inset 0 0 0 0.5px rgba(0, 0, 0, 0.3), inset 0 1px 2px rgba(0, 0, 0, 0.4), inset 0 2px 3px 1px #bbbbbb",
                   }}
                   aria-label="Minimize"
                 >
-                  <div
-                    className="rounded-full relative overflow-hidden box-border"
-                    style={{
-                      width: "13px",
-                      height: "13px",
-                      background: isForeground
-                        ? "linear-gradient(rgb(202, 130, 13), rgb(253, 253, 149))"
-                        : "linear-gradient(rgba(160, 160, 160, 0.625), rgba(255, 255, 255, 0.625))",
-                      boxShadow: isForeground
-                        ? "rgba(0, 0, 0, 0.5) 0px 2px 4px, rgba(0, 0, 0, 0.4) 0px 1px 2px, rgba(223, 161, 35, 0.5) 0px 1px 1px, rgba(0, 0, 0, 0.3) 0px 0px 0px 0.5px inset, rgb(155, 78, 21) 0px 1px 3px inset, rgb(241, 157, 20) 0px 2px 3px 1px inset"
-                        : "0 2px 3px rgba(0, 0, 0, 0.2), 0 1px 1px rgba(0, 0, 0, 0.3), inset 0 0 0 0.5px rgba(0, 0, 0, 0.3), inset 0 1px 2px rgba(0, 0, 0, 0.4), inset 0 2px 3px 1px #bbbbbb",
-                    }}
-                  >
                   {/* Top shine */}
                   <div
                     className="absolute left-1/2 transform -translate-x-1/2 pointer-events-none"
@@ -961,7 +946,6 @@ export function WindowFrame({
                       filter: "blur(0.3px)",
                     }}
                   />
-                  </div>
                 </button>
                 {/* Maximize Button (Green) */}
                 <button
@@ -971,26 +955,19 @@ export function WindowFrame({
                   }}
                   onMouseDown={(e) => e.stopPropagation()}
                   onTouchStart={(e) => e.stopPropagation()}
-                  className="cursor-default outline-none p-1.5 flex items-center justify-center"
+                  className="rounded-full relative overflow-hidden cursor-default outline-none box-border p-1"
                   style={{
-                    width: "22px",
-                    height: "22px",
+                    width: "13px",
+                    height: "13px",
+                    background: isForeground
+                      ? "linear-gradient(rgb(111, 174, 58), rgb(138, 192, 50))"
+                      : "linear-gradient(rgba(160, 160, 160, 0.625), rgba(255, 255, 255, 0.625))",
+                    boxShadow: isForeground
+                      ? "rgba(0, 0, 0, 0.5) 0px 2px 4px, rgba(0, 0, 0, 0.4) 0px 1px 2px, rgb(59, 173, 29, 0.5) 0px 1px 1px, rgba(0, 0, 0, 0.3) 0px 0px 0px 0.5px inset, rgb(53, 91, 17) 0px 1px 3px inset, rgb(98, 187, 19) 0px 2px 3px 1px inset"
+                      : "0 2px 3px rgba(0, 0, 0, 0.2), 0 1px 1px rgba(0, 0, 0, 0.3), inset 0 0 0 0.5px rgba(0, 0, 0, 0.3), inset 0 1px 2px rgba(0, 0, 0, 0.4), inset 0 2px 3px 1px #bbbbbb",
                   }}
                   aria-label="Maximize"
                 >
-                  <div
-                    className="rounded-full relative overflow-hidden box-border"
-                    style={{
-                      width: "13px",
-                      height: "13px",
-                      background: isForeground
-                        ? "linear-gradient(rgb(111, 174, 58), rgb(138, 192, 50))"
-                        : "linear-gradient(rgba(160, 160, 160, 0.625), rgba(255, 255, 255, 0.625))",
-                      boxShadow: isForeground
-                        ? "rgba(0, 0, 0, 0.5) 0px 2px 4px, rgba(0, 0, 0, 0.4) 0px 1px 2px, rgb(59, 173, 29, 0.5) 0px 1px 1px, rgba(0, 0, 0, 0.3) 0px 0px 0px 0.5px inset, rgb(53, 91, 17) 0px 1px 3px inset, rgb(98, 187, 19) 0px 2px 3px 1px inset"
-                        : "0 2px 3px rgba(0, 0, 0, 0.2), 0 1px 1px rgba(0, 0, 0, 0.3), inset 0 0 0 0.5px rgba(0, 0, 0, 0.3), inset 0 1px 2px rgba(0, 0, 0, 0.4), inset 0 2px 3px 1px #bbbbbb",
-                    }}
-                  >
                   {/* Top shine */}
                   <div
                     className="absolute left-1/2 transform -translate-x-1/2 pointer-events-none"
@@ -1018,7 +995,6 @@ export function WindowFrame({
                       filter: "blur(0.3px)",
                     }}
                   />
-                  </div>
                 </button>
               </div>
 

--- a/src/components/layout/WindowFrame.tsx
+++ b/src/components/layout/WindowFrame.tsx
@@ -857,7 +857,7 @@ export function WindowFrame({
                   }}
                   onMouseDown={(e) => e.stopPropagation()}
                   onTouchStart={(e) => e.stopPropagation()}
-                  className="cursor-default outline-none flex items-center justify-center"
+                  className="cursor-default outline-none flex items-center justify-center relative"
                   style={{
                     width: "24px",
                     height: "24px",
@@ -865,6 +865,13 @@ export function WindowFrame({
                   }}
                   aria-label="Close"
                 >
+                  {/* Debug tap target overlay */}
+                  {process.env.NODE_ENV === 'development' && (
+                    <div
+                      className="absolute inset-0 bg-red-500/20 border border-red-500/50 rounded"
+                      style={{ pointerEvents: 'none' }}
+                    />
+                  )}
                   <div
                     className="rounded-full relative overflow-hidden box-border"
                     style={{
@@ -915,7 +922,7 @@ export function WindowFrame({
                   }}
                   onMouseDown={(e) => e.stopPropagation()}
                   onTouchStart={(e) => e.stopPropagation()}
-                  className="cursor-default outline-none flex items-center justify-center"
+                  className="cursor-default outline-none flex items-center justify-center relative"
                   style={{
                     width: "24px",
                     height: "24px",
@@ -923,6 +930,13 @@ export function WindowFrame({
                   }}
                   aria-label="Minimize"
                 >
+                  {/* Debug tap target overlay */}
+                  {process.env.NODE_ENV === 'development' && (
+                    <div
+                      className="absolute inset-0 bg-yellow-500/20 border border-yellow-500/50 rounded"
+                      style={{ pointerEvents: 'none' }}
+                    />
+                  )}
                   <div
                     className="rounded-full relative overflow-hidden box-border"
                     style={{
@@ -973,7 +987,7 @@ export function WindowFrame({
                   }}
                   onMouseDown={(e) => e.stopPropagation()}
                   onTouchStart={(e) => e.stopPropagation()}
-                  className="cursor-default outline-none flex items-center justify-center"
+                  className="cursor-default outline-none flex items-center justify-center relative"
                   style={{
                     width: "24px",
                     height: "24px",
@@ -981,6 +995,13 @@ export function WindowFrame({
                   }}
                   aria-label="Maximize"
                 >
+                  {/* Debug tap target overlay */}
+                  {process.env.NODE_ENV === 'development' && (
+                    <div
+                      className="absolute inset-0 bg-green-500/20 border border-green-500/50 rounded"
+                      style={{ pointerEvents: 'none' }}
+                    />
+                  )}
                   <div
                     className="rounded-full relative overflow-hidden box-border"
                     style={{


### PR DESCRIPTION
Enlarge window frame traffic light tap targets without visual changes to improve usability.

---

[Open in Web](https://cursor.com/agents?id=bc-5553ec62-2ada-4ee9-80e3-f38a321c681d) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-5553ec62-2ada-4ee9-80e3-f38a321c681d) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)