### PR TITLE
Hide empty chat messages

### DIFF
--- a/src/apps/chats/components/ChatMessages.tsx
+++ b/src/apps/chats/components/ChatMessages.tsx
@@ -552,7 +552,21 @@ function ChatMessagesContent({
           )}
         </motion.div>
       )}
-      {messages.map((message) => {
+      {messages
+        .filter((message) => {
+          // Filter out messages with empty content
+          const rawContent = isUrgentMessage(message.content)
+            ? message.content.slice(4).trimStart()
+            : message.content;
+          const displayContent = decodeHtmlEntities(rawContent);
+          
+          // Check if message has meaningful content or parts
+          const hasContent = displayContent.trim().length > 0;
+          const hasParts = message.parts && message.parts.length > 0;
+          
+          return hasContent || hasParts;
+        })
+        .map((message) => {
         const messageKey =
           message.id || `${message.role}-${message.content.substring(0, 10)}`;
         const isInitialMessage = initialMessageIdsRef.current.has(messageKey);


### PR DESCRIPTION
Add a filter to prevent empty chat messages from rendering.

---
<a href="https://cursor.com/background-agent?bcId=bc-e97b72ab-5998-4d84-8dd1-875e3bdc2d6a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e97b72ab-5998-4d84-8dd1-875e3bdc2d6a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>