### PR TITLE
Fix mobile macosx theme window occlusion

### DIFF
--- a/src/components/layout/WindowFrame.tsx
+++ b/src/components/layout/WindowFrame.tsx
@@ -584,7 +584,7 @@ export function WindowFrame({
                 ? isXpTheme
                   ? "top-0 h-4" // Start from top but be shorter for XP/98 themes
                   : currentTheme === "macosx"
-                  ? "top-6 h-8" // Start below title bar for macOS to avoid traffic lights
+                  ? "top-[-8px] h-8" // Extend above window for macOS to avoid traffic lights
                   : "top-0 h-8"
                 : "top-1 h-2"
             )}

--- a/src/components/layout/WindowFrame.tsx
+++ b/src/components/layout/WindowFrame.tsx
@@ -605,7 +605,9 @@ export function WindowFrame({
               resizeType?.includes("s")
                 ? "bottom-[-100px] h-[200px]"
                 : isMobile
-                ? "bottom-0 h-6"
+                ? currentTheme === "macosx"
+                  ? "bottom-[-4px] h-4" // Extend below window for macOS
+                  : "bottom-0 h-6"
                 : "bottom-1 h-2"
             )}
             onMouseDown={(e) =>

--- a/src/components/layout/WindowFrame.tsx
+++ b/src/components/layout/WindowFrame.tsx
@@ -573,13 +573,18 @@ export function WindowFrame({
           {/* Top resize handle */}
           <div
             className={cn(
-              "absolute left-1 right-0 cursor-n-resize pointer-events-auto transition-[top,height] select-none resize-handle",
+              "absolute cursor-n-resize pointer-events-auto transition-[top,height] select-none resize-handle",
+              isMobile && currentTheme === "macosx" 
+                ? "left-0 right-0" // Extend full width for better touch on macOS mobile
+                : "left-1 right-0",
               debugMode && "bg-red-500/50",
               resizeType?.includes("n")
                 ? "top-[-100px] h-[200px]"
                 : isMobile
                 ? isXpTheme
                   ? "top-0 h-4" // Start from top but be shorter for XP/98 themes
+                  : currentTheme === "macosx"
+                  ? "top-6 h-8" // Start below title bar for macOS to avoid traffic lights
                   : "top-0 h-8"
                 : "top-1 h-2"
             )}

--- a/src/components/layout/WindowFrame.tsx
+++ b/src/components/layout/WindowFrame.tsx
@@ -584,7 +584,7 @@ export function WindowFrame({
                 ? isXpTheme
                   ? "top-0 h-4" // Start from top but be shorter for XP/98 themes
                   : currentTheme === "macosx"
-                  ? "top-[-8px] h-8" // Extend above window for macOS to avoid traffic lights
+                  ? "top-[-4px] h-4" // Extend above window for macOS to avoid traffic lights
                   : "top-0 h-8"
                 : "top-1 h-2"
             )}


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Adjust macOS mobile window resizer positioning and height to prevent traffic light occlusion and improve touch interaction.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
Previously, the top resizer on macOS mobile was too tall (`h-8`) and started at `top-0`, occluding the traffic lights. This PR repositions the top resizer to extend 4px *above* the window (`top-[-4px]`) and reduces its height to `h-4` (16px). The bottom resizer is similarly adjusted to extend 4px *below* the window with `h-4` for consistent and improved mobile touch areas.

---
<a href="https://cursor.com/background-agent?bcId=bc-df98150f-e182-466e-9688-f94aa461a2d9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-df98150f-e182-466e-9688-f94aa461a2d9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>