### PR TITLE
Investigate mobile top resize drag lock

### DIFF
--- a/src/hooks/useWindowManager.ts
+++ b/src/hooks/useWindowManager.ts
@@ -239,7 +239,7 @@ export const useWindowManager = ({
         }
       }
 
-      if (resizeType && (resizeType.match(/^[ns]$/) || !isMobile)) {
+      if (resizeType) {
         e.preventDefault();
         const clientX =
           "touches" in e ? e.touches[0].clientX : (e as MouseEvent).clientX;
@@ -290,7 +290,7 @@ export const useWindowManager = ({
             Math.max(resizeStart.height + deltaY, minHeight),
             maxPossibleHeight
           );
-        } else if (resizeType.includes("n") && !isMobile) {
+        } else if (resizeType.includes("n")) {
           const maxPossibleHeight =
             resizeStart.height + (resizeStart.top - menuBarHeight);
           const potentialHeight = Math.min(


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Enable top resize dragging for mobile devices.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
Previously, explicit `!isMobile` checks in the resize logic prevented top (north) resizing on mobile, causing the drag action to appear locked. This change removes those restrictions.

---
<a href="https://cursor.com/background-agent?bcId=bc-3298aaa6-7a81-458f-bca1-44559551b4b7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3298aaa6-7a81-458f-bca1-44559551b4b7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>