### PR TITLE
Prevent html previews in chat

### DIFF
--- a/src/apps/chats/components/ChatMessages.tsx
+++ b/src/apps/chats/components/ChatMessages.tsx
@@ -1127,6 +1127,7 @@ function ChatMessagesContent({
                                   stopElevatorMusic={stopElevatorMusic}
                                   playDingSound={playDingSound}
                                   className="my-1"
+                                  disableCodeView={isRoomView}
                                 />
                               )}
                             </div>
@@ -1267,6 +1268,7 @@ function ChatMessagesContent({
                         playElevatorMusic={playElevatorMusic}
                         stopElevatorMusic={stopElevatorMusic}
                         playDingSound={playDingSound}
+                        disableCodeView={isRoomView}
                       />
                     )}
                   </>

--- a/src/apps/chats/components/ChatMessages.tsx
+++ b/src/apps/chats/components/ChatMessages.tsx
@@ -895,47 +895,6 @@ function ChatMessagesContent({
             {/* Render aquarium tool(s) as their own element; component styles itself as a chat bubble */}
             {hasAquarium && <EmojiAquarium />}
 
-            {/* Link Previews - Rendered outside the message bubble */}
-            {(() => {
-              const allUrls = new Set<string>();
-              
-              if (message.role === "assistant") {
-                // Extract URLs from assistant message parts
-                message.parts?.forEach((part) => {
-                  if (part.type === "text") {
-                    const partContent = isUrgentMessage(part.text)
-                      ? part.text.slice(4).trimStart()
-                      : part.text;
-                    const decodedContent = decodeHtmlEntities(partContent);
-                    extractUrls(decodedContent).forEach((url) =>
-                      allUrls.add(url)
-                    );
-                  }
-                });
-              } else {
-                // Extract URLs from user/human message content
-                extractUrls(displayContent).forEach((url) => allUrls.add(url));
-              }
-
-              if (allUrls.size === 0) return null;
-
-              return (
-                <div
-                  className={`flex flex-col gap-2 w-full mt-2 ${
-                    message.role === "user" ? "items-end" : "items-start"
-                  }`}
-                >
-                  {Array.from(allUrls).map((url, index) => (
-                    <LinkPreview
-                      key={`${messageKey}-link-${index}`}
-                      url={url}
-                      className="max-w-[90%]"
-                    />
-                  ))}
-                </div>
-              );
-            })()}
-
             {/* Show the standard message bubble if it's not URL-only (even if aquarium exists) */}
             {!isUrlOnly(displayContent) && (
               <motion.div
@@ -1252,6 +1211,46 @@ function ChatMessagesContent({
               </motion.div>
             )}
 
+            {/* Link Previews - Rendered after the message bubble */}
+            {(() => {
+              const allUrls = new Set<string>();
+              
+              if (message.role === "assistant") {
+                // Extract URLs from assistant message parts
+                message.parts?.forEach((part) => {
+                  if (part.type === "text") {
+                    const partContent = isUrgentMessage(part.text)
+                      ? part.text.slice(4).trimStart()
+                      : part.text;
+                    const decodedContent = decodeHtmlEntities(partContent);
+                    extractUrls(decodedContent).forEach((url) =>
+                      allUrls.add(url)
+                    );
+                  }
+                });
+              } else {
+                // Extract URLs from user/human message content
+                extractUrls(displayContent).forEach((url) => allUrls.add(url));
+              }
+
+              if (allUrls.size === 0) return null;
+
+              return (
+                <div
+                  className={`flex flex-col gap-2 w-full mt-2 ${
+                    message.role === "user" ? "items-end" : "items-start"
+                  }`}
+                >
+                  {Array.from(allUrls).map((url, index) => (
+                    <LinkPreview
+                      key={`${messageKey}-link-${index}`}
+                      url={url}
+                      className="max-w-[90%]"
+                    />
+                  ))}
+                </div>
+              );
+            })()}
 
           </motion.div>
         );

--- a/src/apps/chats/components/ChatMessages.tsx
+++ b/src/apps/chats/components/ChatMessages.tsx
@@ -16,10 +16,7 @@ import { Button } from "@/components/ui/button";
 import { AnimatePresence, motion } from "framer-motion";
 import { useChatSynth } from "@/hooks/useChatSynth";
 import { useTerminalSounds } from "@/hooks/useTerminalSounds";
-import HtmlPreview, {
-  isHtmlCodeBlock,
-  extractHtmlContent,
-} from "@/components/shared/HtmlPreview";
+
 import { StickToBottom, useStickToBottomContext } from "use-stick-to-bottom";
 import { useTtsQueue } from "@/hooks/useTtsQueue";
 import { useAppStore } from "@/stores/useAppStore";
@@ -951,11 +948,8 @@ function ChatMessagesContent({
                     ? "bg-yellow-100 text-black"
                     : "bg-blue-100 text-black")
                 } ${
-                  isHtmlCodeBlock(message.content).isHtml ||
                   message.parts?.some(
-                    (part) =>
-                      part.type === "text" &&
-                      extractHtmlContent(part.text).hasHtml
+                    (part) => part.type === "tool-invocation"
                   )
                     ? "w-full"
                     : "w-fit max-w-[90%]"
@@ -1003,8 +997,7 @@ function ChatMessagesContent({
                             : part.text;
                           const displayContent =
                             decodeHtmlEntities(rawPartContent);
-                          const { hasHtml, htmlContent, textContent } =
-                            extractHtmlContent(displayContent);
+                          const textContent = displayContent;
 
                           return (
                             <div key={partKey} className="w-full">
@@ -1113,23 +1106,7 @@ function ChatMessagesContent({
                                     });
                                   })()}
                               </div>
-                              {hasHtml && htmlContent && (
-                                <HtmlPreview
-                                  htmlContent={htmlContent}
-                                  onInteractionChange={
-                                    setIsInteractingWithPreview
-                                  }
-                                  isStreaming={
-                                    isLoading &&
-                                    message === messages[messages.length - 1]
-                                  }
-                                  playElevatorMusic={playElevatorMusic}
-                                  stopElevatorMusic={stopElevatorMusic}
-                                  playDingSound={playDingSound}
-                                  className="my-1"
-                                  disableCodeView={isRoomView}
-                                />
-                              )}
+
                             </div>
                           );
                         }
@@ -1172,13 +1149,9 @@ function ChatMessagesContent({
                             : part.text;
                           const decodedContent =
                             decodeHtmlEntities(partContent);
-                          const { textContent } =
-                            extractHtmlContent(decodedContent);
-                          if (textContent) {
-                            extractUrls(textContent).forEach((url) =>
-                              allUrls.add(url)
-                            );
-                          }
+                          extractUrls(decodedContent).forEach((url) =>
+                            allUrls.add(url)
+                          );
                         }
                       });
 
@@ -1261,16 +1234,7 @@ function ChatMessagesContent({
                         });
                       })()}
                     </span>
-                    {isHtmlCodeBlock(displayContent).isHtml && (
-                      <HtmlPreview
-                        htmlContent={isHtmlCodeBlock(displayContent).content}
-                        onInteractionChange={setIsInteractingWithPreview}
-                        playElevatorMusic={playElevatorMusic}
-                        stopElevatorMusic={stopElevatorMusic}
-                        playDingSound={playDingSound}
-                        disableCodeView={isRoomView}
-                      />
-                    )}
+
                   </>
                 )}
               </motion.div>

--- a/src/components/shared/HtmlPreview.tsx
+++ b/src/components/shared/HtmlPreview.tsx
@@ -157,6 +157,7 @@ interface HtmlPreviewProps {
   isInternetExplorer?: boolean;
   baseUrlForAiContent?: string;
   mode?: "past" | "future" | "now";
+  disableCodeView?: boolean;
 }
 
 export default function HtmlPreview({
@@ -175,6 +176,7 @@ export default function HtmlPreview({
   isInternetExplorer = false,
   baseUrlForAiContent,
   mode = "now",
+  disableCodeView = false,
 }: HtmlPreviewProps) {
   const [isFullScreen, setIsFullScreen] = useState(initialFullScreen);
   const [copySuccess, setCopySuccess] = useState(false);
@@ -544,6 +546,14 @@ export default function HtmlPreview({
       isMounted = false;
     };
   }, [showCode, finalProcessedHtmlRef.current]); // Depend on showCode and the final content ref
+
+  // Reset showCode when disableCodeView becomes true
+  useEffect(() => {
+    if (disableCodeView && showCode) {
+      setShowCode(false);
+      setIsSplitView(false);
+    }
+  }, [disableCodeView, showCode]);
 
   // Play music and cancel when unmounting for streaming content
   useEffect(() => {
@@ -1025,7 +1035,7 @@ export default function HtmlPreview({
                 >
                   {/* Code view layer - always 100% width underneath */}
                   <AnimatePresence>
-                    {showCode ? (
+                    {showCode && !disableCodeView ? (
                       <motion.div
                         key="code"
                         className="absolute inset-0 bg-[#24292e] font-geneva-12 overflow-auto p-4 z-10"
@@ -1046,19 +1056,19 @@ export default function HtmlPreview({
                     initial={false}
                     animate={{
                       width:
-                        isSplitView && showCode
+                        isSplitView && showCode && !disableCodeView
                           ? isMobile
                             ? "100%"
                             : "50%"
                           : "100%",
                       height:
-                        isSplitView && showCode
+                        isSplitView && showCode && !disableCodeView
                           ? isMobile
                             ? "50%"
                             : "100%"
                           : "100%",
                       right: 0,
-                      opacity: showCode && !isSplitView ? 0 : 1,
+                      opacity: showCode && !isSplitView && !disableCodeView ? 0 : 1,
                     }}
                     transition={{
                       duration: 0.3,
@@ -1066,7 +1076,7 @@ export default function HtmlPreview({
                     }}
                     style={{
                       position: "absolute",
-                      top: showCode && isSplitView && isMobile ? "50%" : 0,
+                      top: showCode && isSplitView && isMobile && !disableCodeView ? "50%" : 0,
                       right: 0,
                       overflow: "hidden", // Clip content
                     }}
@@ -1232,7 +1242,7 @@ export default function HtmlPreview({
                           />
                         </div>
 
-                        {showCode && (
+                        {showCode && !disableCodeView && (
                           <button
                             onClick={(e) => {
                               e.stopPropagation();
@@ -1251,27 +1261,29 @@ export default function HtmlPreview({
                             </span>
                           </button>
                         )}
-                        <button
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            if (!showCode) {
-                              setShowCode(true);
-                              setIsSplitView(true);
-                              maximizeSound.play();
-                            } else {
-                              setShowCode(false);
-                              setIsSplitView(false);
-                              minimizeSound.play();
-                            }
-                          }}
-                          className="flex items-center justify-center w-8 h-8 hover:bg-white/10 rounded-full group"
-                          aria-label="Toggle code"
-                        >
-                          <Code
-                            size={20}
-                            className="text-white/70 group-hover:text-white"
-                          />
-                        </button>
+                        {!disableCodeView && (
+                          <button
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              if (!showCode) {
+                                setShowCode(true);
+                                setIsSplitView(true);
+                                maximizeSound.play();
+                              } else {
+                                setShowCode(false);
+                                setIsSplitView(false);
+                                minimizeSound.play();
+                              }
+                            }}
+                            className="flex items-center justify-center w-8 h-8 hover:bg-white/10 rounded-full group"
+                            aria-label="Toggle code"
+                          >
+                            <Code
+                              size={20}
+                              className="text-white/70 group-hover:text-white"
+                            />
+                          </button>
+                        )}
                         <button
                           onClick={handleSaveToDisk}
                           className="flex items-center justify-center w-8 h-8 hover:bg-white/10 rounded-full group"

--- a/src/components/shared/HtmlPreview.tsx
+++ b/src/components/shared/HtmlPreview.tsx
@@ -157,7 +157,6 @@ interface HtmlPreviewProps {
   isInternetExplorer?: boolean;
   baseUrlForAiContent?: string;
   mode?: "past" | "future" | "now";
-  disableCodeView?: boolean;
 }
 
 export default function HtmlPreview({
@@ -176,7 +175,6 @@ export default function HtmlPreview({
   isInternetExplorer = false,
   baseUrlForAiContent,
   mode = "now",
-  disableCodeView = false,
 }: HtmlPreviewProps) {
   const [isFullScreen, setIsFullScreen] = useState(initialFullScreen);
   const [copySuccess, setCopySuccess] = useState(false);
@@ -546,14 +544,6 @@ export default function HtmlPreview({
       isMounted = false;
     };
   }, [showCode, finalProcessedHtmlRef.current]); // Depend on showCode and the final content ref
-
-  // Reset showCode when disableCodeView becomes true
-  useEffect(() => {
-    if (disableCodeView && showCode) {
-      setShowCode(false);
-      setIsSplitView(false);
-    }
-  }, [disableCodeView, showCode]);
 
   // Play music and cancel when unmounting for streaming content
   useEffect(() => {
@@ -1035,7 +1025,7 @@ export default function HtmlPreview({
                 >
                   {/* Code view layer - always 100% width underneath */}
                   <AnimatePresence>
-                    {showCode && !disableCodeView ? (
+                    {showCode ? (
                       <motion.div
                         key="code"
                         className="absolute inset-0 bg-[#24292e] font-geneva-12 overflow-auto p-4 z-10"
@@ -1056,19 +1046,19 @@ export default function HtmlPreview({
                     initial={false}
                     animate={{
                       width:
-                        isSplitView && showCode && !disableCodeView
+                        isSplitView && showCode
                           ? isMobile
                             ? "100%"
                             : "50%"
                           : "100%",
                       height:
-                        isSplitView && showCode && !disableCodeView
+                        isSplitView && showCode
                           ? isMobile
                             ? "50%"
                             : "100%"
                           : "100%",
                       right: 0,
-                      opacity: showCode && !isSplitView && !disableCodeView ? 0 : 1,
+                      opacity: showCode && !isSplitView ? 0 : 1,
                     }}
                     transition={{
                       duration: 0.3,
@@ -1076,7 +1066,7 @@ export default function HtmlPreview({
                     }}
                     style={{
                       position: "absolute",
-                      top: showCode && isSplitView && isMobile && !disableCodeView ? "50%" : 0,
+                      top: showCode && isSplitView && isMobile ? "50%" : 0,
                       right: 0,
                       overflow: "hidden", // Clip content
                     }}
@@ -1242,7 +1232,7 @@ export default function HtmlPreview({
                           />
                         </div>
 
-                        {showCode && !disableCodeView && (
+                        {showCode && (
                           <button
                             onClick={(e) => {
                               e.stopPropagation();
@@ -1261,29 +1251,27 @@ export default function HtmlPreview({
                             </span>
                           </button>
                         )}
-                        {!disableCodeView && (
-                          <button
-                            onClick={(e) => {
-                              e.stopPropagation();
-                              if (!showCode) {
-                                setShowCode(true);
-                                setIsSplitView(true);
-                                maximizeSound.play();
-                              } else {
-                                setShowCode(false);
-                                setIsSplitView(false);
-                                minimizeSound.play();
-                              }
-                            }}
-                            className="flex items-center justify-center w-8 h-8 hover:bg-white/10 rounded-full group"
-                            aria-label="Toggle code"
-                          >
-                            <Code
-                              size={20}
-                              className="text-white/70 group-hover:text-white"
-                            />
-                          </button>
-                        )}
+                        <button
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            if (!showCode) {
+                              setShowCode(true);
+                              setIsSplitView(true);
+                              maximizeSound.play();
+                            } else {
+                              setShowCode(false);
+                              setIsSplitView(false);
+                              minimizeSound.play();
+                            }
+                          }}
+                          className="flex items-center justify-center w-8 h-8 hover:bg-white/10 rounded-full group"
+                          aria-label="Toggle code"
+                        >
+                          <Code
+                            size={20}
+                            className="text-white/70 group-hover:text-white"
+                          />
+                        </button>
                         <button
                           onClick={handleSaveToDisk}
                           className="flex items-center justify-center w-8 h-8 hover:bg-white/10 rounded-full group"


### PR DESCRIPTION
Remove automatic HTML parsing and rendering from regular chat messages.

HTML previews are now exclusively generated via explicit tool invocations, preventing unintended rendering of HTML tags in user or assistant text.

---
<a href="https://cursor.com/background-agent?bcId=bc-f171bb6d-99aa-4e65-b881-fcf137b0efd7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f171bb6d-99aa-4e65-b881-fcf137b0efd7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>