### PR TITLE
Adjust link preview top margin for chat messages

### DIFF
--- a/src/apps/chats/components/ChatMessages.tsx
+++ b/src/apps/chats/components/ChatMessages.tsx
@@ -1237,7 +1237,7 @@ function ChatMessagesContent({
 
               return (
                 <div
-                  className={`flex flex-col gap-2 w-full mt-2 ${
+                  className={`flex flex-col gap-2 w-full ${!isUrlOnly(displayContent) ? 'mt-2' : ''} ${
                     message.role === "user" ? "items-end" : "items-start"
                   }`}
                 >


### PR DESCRIPTION
Conditionally apply top margin to link previews to ensure spacing only appears when following a chat message bubble.

---
<a href="https://cursor.com/background-agent?bcId=bc-282793ee-766c-469d-8ad3-0837b0652963">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-282793ee-766c-469d-8ad3-0837b0652963">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>