### PR TITLE
Fix ie iframe unauthorized requests from ryolu

### DIFF
--- a/api/iframe-check.ts
+++ b/api/iframe-check.ts
@@ -163,7 +163,7 @@ export default async function handler(req: Request) {
   const month = searchParams.get("month");
   const requestId = generateRequestId(); // Generate request ID
   const origin = req.headers.get("origin");
-  const ALLOWED_ORIGINS = new Set(["https://os.ryo.lu", "http://localhost:3000"]);
+  const ALLOWED_ORIGINS = new Set(["https://os.ryo.lu", "https://ryo.lu", "http://localhost:3000"]);
   if (!origin || !ALLOWED_ORIGINS.has(origin)) {
     return new Response("Unauthorized", { status: 403 });
   }


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Add `https://ryo.lu` to allowed origins for the iframe check to resolve unauthorized requests.

---
<a href="https://cursor.com/background-agent?bcId=bc-4742ec2d-5090-462e-8297-d17cd4e734cb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4742ec2d-5090-462e-8297-d17cd4e734cb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>