### PR TITLE
Show only close button for macosx dialogs

### DIFF
--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -220,88 +220,6 @@ const DialogHeader = ({
               />
             </button>
           </DialogPrimitive.Close>
-          {/* Minimize Button (Yellow) */}
-          <button
-            className="rounded-full relative overflow-hidden cursor-default outline-none box-border"
-            style={{
-              width: "13px",
-              height: "13px",
-              background:
-                "linear-gradient(rgb(202, 130, 13), rgb(253, 253, 149))",
-              boxShadow:
-                "rgba(0, 0, 0, 0.5) 0px 2px 4px, rgba(0, 0, 0, 0.4) 0px 1px 2px, rgba(223, 161, 35, 0.5) 0px 1px 1px, rgba(0, 0, 0, 0.3) 0px 0px 0px 0.5px inset, rgb(155, 78, 21) 0px 1px 3px inset, rgb(241, 157, 20) 0px 2px 3px 1px inset",
-            }}
-            aria-label="Minimize"
-          >
-            {/* Top shine */}
-            <div
-              className="absolute left-1/2 transform -translate-x-1/2 pointer-events-none"
-              style={{
-                height: "33%",
-                background:
-                  "linear-gradient(rgba(255, 255, 255, 0.9), rgba(255, 255, 255, 0.3))",
-                width: "calc(100% - 6px)",
-                borderRadius: "6px 6px 0 0",
-                top: "1px",
-                filter: "blur(0.2px)",
-                zIndex: 2,
-              }}
-            />
-            {/* Bottom glow */}
-            <div
-              className="absolute left-1/2 transform -translate-x-1/2 pointer-events-none"
-              style={{
-                height: "33%",
-                background:
-                  "linear-gradient(rgba(255, 255, 255, 0.2), rgba(255, 255, 255, 0.5))",
-                width: "calc(100% - 3px)",
-                borderRadius: "0 0 6px 6px",
-                bottom: "1px",
-                filter: "blur(0.3px)",
-              }}
-            />
-          </button>
-          {/* Maximize Button (Green) */}
-          <button
-            className="rounded-full relative overflow-hidden cursor-default outline-none box-border"
-            style={{
-              width: "13px",
-              height: "13px",
-              background:
-                "linear-gradient(rgb(111, 174, 58), rgb(138, 192, 50))",
-              boxShadow:
-                "rgba(0, 0, 0, 0.5) 0px 2px 4px, rgba(0, 0, 0, 0.4) 0px 1px 2px, rgb(59, 173, 29, 0.5) 0px 1px 1px, rgba(0, 0, 0, 0.3) 0px 0px 0px 0.5px inset, rgb(53, 91, 17) 0px 1px 3px inset, rgb(98, 187, 19) 0px 2px 3px 1px inset",
-            }}
-            aria-label="Maximize"
-          >
-            {/* Top shine */}
-            <div
-              className="absolute left-1/2 transform -translate-x-1/2 pointer-events-none"
-              style={{
-                height: "33%",
-                background:
-                  "linear-gradient(rgba(255, 255, 255, 0.9), rgba(255, 255, 255, 0.3))",
-                width: "calc(100% - 6px)",
-                borderRadius: "6px 6px 0 0",
-                top: "1px",
-                filter: "blur(0.2px)",
-                zIndex: 2,
-              }}
-            />
-            {/* Bottom glow */}
-            <div
-              className="absolute left-1/2 transform -translate-x-1/2 pointer-events-none"
-              style={{
-                height: "33%",
-                background:
-                  "linear-gradient(rgba(255, 255, 255, 0.2), rgba(255, 255, 255, 0.5))",
-                width: "calc(100% - 3px)",
-                borderRadius: "0 0 6px 6px",
-                bottom: "1px",
-                filter: "blur(0.3px)",
-              }}
-            />
-          </button>
         </div>
 
         {/* Title */}
@@ -316,7 +234,7 @@ const DialogHeader = ({
         </span>
 
         {/* Spacer to balance the traffic lights */}
-        <div className="mr-2 w-12 h-4" />
+        <div className="mr-2 w-4 h-4" />
       </div>
     );
   }

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -222,15 +222,14 @@ const DialogHeader = ({
           </DialogPrimitive.Close>
           {/* Minimize Button (Yellow) - Inactive */}
           <button
-            className="rounded-full relative overflow-hidden cursor-default outline-none box-border opacity-60"
+            className="rounded-full relative overflow-hidden cursor-default outline-none box-border"
             style={{
               width: "13px",
               height: "13px",
               background:
-                "linear-gradient(rgb(202, 130, 13), rgb(253, 253, 149))",
+                "linear-gradient(rgba(160, 160, 160, 0.625), rgba(255, 255, 255, 0.625))",
               boxShadow:
-                "rgba(0, 0, 0, 0.5) 0px 2px 4px, rgba(0, 0, 0, 0.4) 0px 1px 2px, rgba(223, 161, 35, 0.5) 0px 1px 1px, rgba(0, 0, 0, 0.3) 0px 0px 0px 0.5px inset, rgb(155, 78, 21) 0px 1px 3px inset, rgb(241, 157, 20) 0px 2px 3px 1px inset",
-              filter: "grayscale(0.8)",
+                "0 2px 3px rgba(0, 0, 0, 0.2), 0 1px 1px rgba(0, 0, 0, 0.3), inset 0 0 0 0.5px rgba(0, 0, 0, 0.3), inset 0 1px 2px rgba(0, 0, 0, 0.4), inset 0 2px 3px 1px #bbbbbb",
               pointerEvents: "none",
             }}
             aria-label="Minimize (disabled)"
@@ -266,15 +265,14 @@ const DialogHeader = ({
           </button>
           {/* Maximize Button (Green) - Inactive */}
           <button
-            className="rounded-full relative overflow-hidden cursor-default outline-none box-border opacity-60"
+            className="rounded-full relative overflow-hidden cursor-default outline-none box-border"
             style={{
               width: "13px",
               height: "13px",
               background:
-                "linear-gradient(rgb(111, 174, 58), rgb(138, 192, 50))",
+                "linear-gradient(rgba(160, 160, 160, 0.625), rgba(255, 255, 255, 0.625))",
               boxShadow:
-                "rgba(0, 0, 0, 0.5) 0px 2px 4px, rgba(0, 0, 0, 0.4) 0px 1px 2px, rgb(59, 173, 29, 0.5) 0px 1px 1px, rgba(0, 0, 0, 0.3) 0px 0px 0px 0.5px inset, rgb(53, 91, 17) 0px 1px 3px inset, rgb(98, 187, 19) 0px 2px 3px 1px inset",
-              filter: "grayscale(0.8)",
+                "0 2px 3px rgba(0, 0, 0, 0.2), 0 1px 1px rgba(0, 0, 0, 0.3), inset 0 0 0 0.5px rgba(0, 0, 0, 0.3), inset 0 1px 2px rgba(0, 0, 0, 0.4), inset 0 2px 3px 1px #bbbbbb",
               pointerEvents: "none",
             }}
             aria-label="Maximize (disabled)"

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -220,6 +220,94 @@ const DialogHeader = ({
               />
             </button>
           </DialogPrimitive.Close>
+          {/* Minimize Button (Yellow) - Inactive */}
+          <button
+            className="rounded-full relative overflow-hidden cursor-default outline-none box-border opacity-60"
+            style={{
+              width: "13px",
+              height: "13px",
+              background:
+                "linear-gradient(rgb(202, 130, 13), rgb(253, 253, 149))",
+              boxShadow:
+                "rgba(0, 0, 0, 0.5) 0px 2px 4px, rgba(0, 0, 0, 0.4) 0px 1px 2px, rgba(223, 161, 35, 0.5) 0px 1px 1px, rgba(0, 0, 0, 0.3) 0px 0px 0px 0.5px inset, rgb(155, 78, 21) 0px 1px 3px inset, rgb(241, 157, 20) 0px 2px 3px 1px inset",
+              filter: "grayscale(0.8)",
+              pointerEvents: "none",
+            }}
+            aria-label="Minimize (disabled)"
+            disabled
+          >
+            {/* Top shine */}
+            <div
+              className="absolute left-1/2 transform -translate-x-1/2 pointer-events-none"
+              style={{
+                height: "33%",
+                background:
+                  "linear-gradient(rgba(255, 255, 255, 0.9), rgba(255, 255, 255, 0.3))",
+                width: "calc(100% - 6px)",
+                borderRadius: "6px 6px 0 0",
+                top: "1px",
+                filter: "blur(0.2px)",
+                zIndex: 2,
+              }}
+            />
+            {/* Bottom glow */}
+            <div
+              className="absolute left-1/2 transform -translate-x-1/2 pointer-events-none"
+              style={{
+                height: "33%",
+                background:
+                  "linear-gradient(rgba(255, 255, 255, 0.2), rgba(255, 255, 255, 0.5))",
+                width: "calc(100% - 3px)",
+                borderRadius: "0 0 6px 6px",
+                bottom: "1px",
+                filter: "blur(0.3px)",
+              }}
+            />
+          </button>
+          {/* Maximize Button (Green) - Inactive */}
+          <button
+            className="rounded-full relative overflow-hidden cursor-default outline-none box-border opacity-60"
+            style={{
+              width: "13px",
+              height: "13px",
+              background:
+                "linear-gradient(rgb(111, 174, 58), rgb(138, 192, 50))",
+              boxShadow:
+                "rgba(0, 0, 0, 0.5) 0px 2px 4px, rgba(0, 0, 0, 0.4) 0px 1px 2px, rgb(59, 173, 29, 0.5) 0px 1px 1px, rgba(0, 0, 0, 0.3) 0px 0px 0px 0.5px inset, rgb(53, 91, 17) 0px 1px 3px inset, rgb(98, 187, 19) 0px 2px 3px 1px inset",
+              filter: "grayscale(0.8)",
+              pointerEvents: "none",
+            }}
+            aria-label="Maximize (disabled)"
+            disabled
+          >
+            {/* Top shine */}
+            <div
+              className="absolute left-1/2 transform -translate-x-1/2 pointer-events-none"
+              style={{
+                height: "33%",
+                background:
+                  "linear-gradient(rgba(255, 255, 255, 0.9), rgba(255, 255, 255, 0.3))",
+                width: "calc(100% - 6px)",
+                borderRadius: "6px 6px 0 0",
+                top: "1px",
+                filter: "blur(0.2px)",
+                zIndex: 2,
+              }}
+            />
+            {/* Bottom glow */}
+            <div
+              className="absolute left-1/2 transform -translate-x-1/2 pointer-events-none"
+              style={{
+                height: "33%",
+                background:
+                  "linear-gradient(rgba(255, 255, 255, 0.2), rgba(255, 255, 255, 0.5))",
+                width: "calc(100% - 3px)",
+                borderRadius: "0 0 6px 6px",
+                bottom: "1px",
+                filter: "blur(0.3px)",
+              }}
+            />
+          </button>
         </div>
 
         {/* Title */}
@@ -234,7 +322,7 @@ const DialogHeader = ({
         </span>
 
         {/* Spacer to balance the traffic lights */}
-        <div className="mr-2 w-4 h-4" />
+        <div className="mr-2 w-12 h-4" />
       </div>
     );
   }


### PR DESCRIPTION
Only show the close button for macOS dialog traffic lights and adjust spacer width because the minimize and maximize buttons are non-functional.

---
<a href="https://cursor.com/background-agent?bcId=bc-c6ff22dc-9e38-4cec-9401-171ba675e37c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c6ff22dc-9e38-4cec-9401-171ba675e37c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>