### PR TITLE
Add safe area for landscape lyrics display

### DIFF
--- a/src/apps/ipod/components/IpodAppComponent.tsx
+++ b/src/apps/ipod/components/IpodAppComponent.tsx
@@ -2514,7 +2514,7 @@ export function IpodAppComponent({
                         {/* Lyrics Overlay */}
                         {showLyrics && (
                           <div
-                            className="absolute bottom-0 inset-0 pointer-events-none z-20"
+                            className="absolute bottom-0 inset-0 pointer-events-none z-20 pl-safe pr-safe"
                             style={{
                               transform: controlsVisible
                                 ? "translateY(-3rem)"

--- a/src/apps/ipod/components/LyricsDisplay.tsx
+++ b/src/apps/ipod/components/LyricsDisplay.tsx
@@ -44,8 +44,6 @@ interface LyricsDisplayProps {
   fontClassName?: string;
   /** Optional inline styles for the outer container (e.g., dynamic gap) */
   containerStyle?: CSSProperties;
-  /** Whether to apply safe area padding for fullscreen mode */
-  useSafeAreaPadding?: boolean;
 }
 
 const ANIMATION_CONFIG = {
@@ -175,7 +173,6 @@ export function LyricsDisplay({
   gapClass = "gap-2",
   fontClassName = "font-geneva-12",
   containerStyle,
-  useSafeAreaPadding = true,
 }: LyricsDisplayProps) {
   const chineseConverter = useMemo(
     () => Converter({ from: "cn", to: "tw" }),
@@ -373,7 +370,7 @@ export function LyricsDisplay({
     <motion.div
       layout={alignment === LyricsAlignment.Alternating}
       transition={ANIMATION_CONFIG.spring}
-      className={`absolute inset-x-0 mx-auto top-0 left-0 right-0 bottom-0 w-full h-full overflow-hidden flex flex-col items-center justify-end ${gapClass} z-40 select-none px-0 ${bottomPaddingClass} pl-safe pr-safe`}
+      className={`absolute inset-x-0 mx-auto top-0 left-0 right-0 bottom-0 w-full h-full overflow-hidden flex flex-col items-center justify-end ${gapClass} z-40 select-none px-0 ${bottomPaddingClass}`}
       style={{
         ...(containerStyle || {}),
         pointerEvents: interactive ? "auto" : "none",

--- a/src/apps/ipod/components/LyricsDisplay.tsx
+++ b/src/apps/ipod/components/LyricsDisplay.tsx
@@ -370,7 +370,7 @@ export function LyricsDisplay({
     <motion.div
       layout={alignment === LyricsAlignment.Alternating}
       transition={ANIMATION_CONFIG.spring}
-      className={`absolute inset-x-0 mx-auto top-0 left-0 right-0 bottom-0 w-full h-full overflow-hidden flex flex-col items-center justify-end ${gapClass} z-40 select-none px-0 ${bottomPaddingClass}`}
+      className={`absolute inset-x-0 mx-auto top-0 left-0 right-0 bottom-0 w-full h-full overflow-hidden flex flex-col items-center justify-end ${gapClass} z-40 select-none px-0 ${bottomPaddingClass} pl-safe pr-safe`}
       style={{
         ...(containerStyle || {}),
         pointerEvents: interactive ? "auto" : "none",

--- a/src/apps/ipod/components/LyricsDisplay.tsx
+++ b/src/apps/ipod/components/LyricsDisplay.tsx
@@ -44,6 +44,8 @@ interface LyricsDisplayProps {
   fontClassName?: string;
   /** Optional inline styles for the outer container (e.g., dynamic gap) */
   containerStyle?: CSSProperties;
+  /** Whether to apply safe area padding for fullscreen mode */
+  useSafeAreaPadding?: boolean;
 }
 
 const ANIMATION_CONFIG = {
@@ -173,6 +175,7 @@ export function LyricsDisplay({
   gapClass = "gap-2",
   fontClassName = "font-geneva-12",
   containerStyle,
+  useSafeAreaPadding = true,
 }: LyricsDisplayProps) {
   const chineseConverter = useMemo(
     () => Converter({ from: "cn", to: "tw" }),

--- a/src/index.css
+++ b/src/index.css
@@ -444,6 +444,15 @@ button.piano-key.piano-key[class*="bg-[#ff33ff]"] {
     font-smooth: always;
   }
 
+  /* Safe area padding utilities */
+  .pl-safe {
+    padding-left: env(safe-area-inset-left);
+  }
+
+  .pr-safe {
+    padding-right: env(safe-area-inset-right);
+  }
+
   .font-monaco,
   .font-monaco-9 {
     font-family: "Monaco", "ArkPixel", "SerenityOS-Emoji", monospace;


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Add viewport safe area insets to the full-screen iPod player's lyric display to prevent content cutoff on iPhones in landscape mode.

---
<a href="https://cursor.com/background-agent?bcId=bc-cda6afcb-e15d-423b-95e1-871bcf270072">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-cda6afcb-e15d-423b-95e1-871bcf270072">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>