### PR TITLE
Update macosx video playback buttons font

### DIFF
--- a/src/apps/videos/components/VideosAppComponent.tsx
+++ b/src/apps/videos/components/VideosAppComponent.tsx
@@ -1217,27 +1217,24 @@ export function VideosAppComponent({
                       variant="aqua_select"
                       disabled={videos.length === 0}
                       className="aqua-compact font-chicago"
-                      style={{ paddingTop: "7px", paddingBottom: "1px" }}
                     >
-                      ⏮
+                      <span className="translate-y-[2px] inline-block">⏮</span>
                     </Button>
                     <Button
                       onClick={togglePlay}
                       variant="aqua_select"
                       disabled={videos.length === 0}
                       className="aqua-compact-wide font-chicago"
-                      style={{ paddingTop: "7px", paddingBottom: "1px" }}
                     >
-                      {isPlaying ? "⏸" : "▶"}
+                      <span className="translate-y-[2px] inline-block">{isPlaying ? "⏸" : "▶"}</span>
                     </Button>
                     <Button
                       onClick={nextVideo}
                       variant="aqua_select"
                       disabled={videos.length === 0}
                       className="aqua-compact font-chicago"
-                      style={{ paddingTop: "7px", paddingBottom: "1px" }}
                     >
-                      ⏭
+                      <span className="translate-y-[2px] inline-block">⏭</span>
                     </Button>
                   </div>
                 ) : (

--- a/src/apps/videos/components/VideosAppComponent.tsx
+++ b/src/apps/videos/components/VideosAppComponent.tsx
@@ -1216,7 +1216,7 @@ export function VideosAppComponent({
                       onClick={previousVideo}
                       variant="aqua_select"
                       disabled={videos.length === 0}
-                      className="aqua-compact"
+                      className="aqua-compact font-chicago"
                     >
                       ⏮
                     </Button>
@@ -1224,7 +1224,7 @@ export function VideosAppComponent({
                       onClick={togglePlay}
                       variant="aqua_select"
                       disabled={videos.length === 0}
-                      className="aqua-compact-wide"
+                      className="aqua-compact-wide font-chicago"
                     >
                       {isPlaying ? "⏸" : "▶"}
                     </Button>
@@ -1232,7 +1232,7 @@ export function VideosAppComponent({
                       onClick={nextVideo}
                       variant="aqua_select"
                       disabled={videos.length === 0}
-                      className="aqua-compact"
+                      className="aqua-compact font-chicago"
                     >
                       ⏭
                     </Button>

--- a/src/apps/videos/components/VideosAppComponent.tsx
+++ b/src/apps/videos/components/VideosAppComponent.tsx
@@ -1217,6 +1217,7 @@ export function VideosAppComponent({
                       variant="aqua_select"
                       disabled={videos.length === 0}
                       className="aqua-compact font-chicago"
+                      style={{ paddingTop: "7px", paddingBottom: "1px" }}
                     >
                       ⏮
                     </Button>
@@ -1225,6 +1226,7 @@ export function VideosAppComponent({
                       variant="aqua_select"
                       disabled={videos.length === 0}
                       className="aqua-compact-wide font-chicago"
+                      style={{ paddingTop: "7px", paddingBottom: "1px" }}
                     >
                       {isPlaying ? "⏸" : "▶"}
                     </Button>
@@ -1233,6 +1235,7 @@ export function VideosAppComponent({
                       variant="aqua_select"
                       disabled={videos.length === 0}
                       className="aqua-compact font-chicago"
+                      style={{ paddingTop: "7px", paddingBottom: "1px" }}
                     >
                       ⏭
                     </Button>


### PR DESCRIPTION
Apply Chicago Hare font to playback buttons in the macOS theme video app component.

---
<a href="https://cursor.com/background-agent?bcId=bc-0db65a1a-ec57-4b31-b24b-65bf3af4f87c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0db65a1a-ec57-4b31-b24b-65bf3af4f87c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

