### PR TITLE
Apply aqua_select for macosx synth theme

### DIFF
--- a/src/apps/synth/components/SynthAppComponent.tsx
+++ b/src/apps/synth/components/SynthAppComponent.tsx
@@ -985,7 +985,10 @@ export function SynthAppComponent({
                             currentPreset.id === preset.id ? "on" : "off"
                           }
                           onClick={() => loadPreset(preset)}
-                          className="h-[22px] px-2 whitespace-nowrap uppercase select-none"
+                          className={cn(
+                            "h-[22px] px-2 whitespace-nowrap uppercase select-none",
+                            isXpTheme && "text-black"
+                          )}
                         >
                           {preset.name}
                         </Button>
@@ -1009,6 +1012,7 @@ export function SynthAppComponent({
                     }
                     className={cn(
                       isSystem7Theme ? "h-[22px] px-2" : isMacOSTheme ? "aqua-compact" : "h-[22px] px-2",
+                      isXpTheme && "text-black",
                       "select-none"
                     )}
                   >
@@ -1025,6 +1029,7 @@ export function SynthAppComponent({
                     }
                     className={cn(
                       isSystem7Theme ? "h-[22px] px-2" : isMacOSTheme ? "aqua-compact" : "h-[22px] px-2",
+                      isXpTheme && "text-black",
                       "select-none"
                     )}
                   >
@@ -1039,6 +1044,7 @@ export function SynthAppComponent({
                         : isMacOSTheme
                         ? "aqua-compact font-geneva-12 !text-[11px]"
                         : "h-[22px] px-2",
+                      isXpTheme && "text-black",
                       "select-none"
                     )}
                   >
@@ -1073,7 +1079,10 @@ export function SynthAppComponent({
                           <Button
                             variant={isMacOSTheme ? "aqua_select" : isSystem7Theme ? "player" : "default"}
                             onClick={addPreset}
-                            className="h-[22px] px-2 text-[9px] select-none"
+                            className={cn(
+                              "h-[22px] px-2 text-[9px] select-none",
+                              isXpTheme && "text-black"
+                            )}
                           >
                             ADD PRESET
                           </Button>

--- a/src/apps/synth/components/SynthAppComponent.tsx
+++ b/src/apps/synth/components/SynthAppComponent.tsx
@@ -881,6 +881,7 @@ export function SynthAppComponent({
   const isXpTheme = currentTheme === "xp" || currentTheme === "win98";
   const isSystem7Theme = currentTheme === "system7";
   const isClassicTheme = currentTheme === "macosx" || isXpTheme;
+  const isMacOSTheme = currentTheme === "macosx";
 
   const menuBar = (
     <SynthMenuBar
@@ -979,7 +980,7 @@ export function SynthAppComponent({
                       presets.map((preset) => (
                         <Button
                           key={preset.id}
-                          variant={isSystem7Theme ? "player" : "aqua_select"}
+                          variant={isMacOSTheme ? "aqua_select" : isSystem7Theme ? "player" : "default"}
                           data-state={
                             currentPreset.id === preset.id ? "on" : "off"
                           }
@@ -998,7 +999,7 @@ export function SynthAppComponent({
                 </div>
                 <div className="flex gap-0 aqua-select-group">
                   <Button
-                    variant={isSystem7Theme ? "player" : "aqua_select"}
+                    variant={isMacOSTheme ? "aqua_select" : isSystem7Theme ? "player" : "default"}
                     onClick={() =>
                       setOctaveOffset((prev) => {
                         const next = Math.max(-2, prev - 1);
@@ -1014,7 +1015,7 @@ export function SynthAppComponent({
                     &lt;
                   </Button>
                   <Button
-                    variant={isSystem7Theme ? "player" : "aqua_select"}
+                    variant={isMacOSTheme ? "aqua_select" : isSystem7Theme ? "player" : "default"}
                     onClick={() =>
                       setOctaveOffset((prev) => {
                         const next = Math.min(2, prev + 1);
@@ -1030,7 +1031,7 @@ export function SynthAppComponent({
                     &gt;
                   </Button>
                   <Button
-                    variant={isSystem7Theme ? "player" : "aqua_select"}
+                    variant={isMacOSTheme ? "aqua_select" : isSystem7Theme ? "player" : "default"}
                     onClick={() => setIsControlsVisible(!isControlsVisible)}
                     className={cn(
                       isSystem7Theme
@@ -1068,7 +1069,7 @@ export function SynthAppComponent({
                             Oscillator
                           </h3>
                           <Button
-                            variant={isSystem7Theme ? "player" : "aqua_select"}
+                            variant={isMacOSTheme ? "aqua_select" : isSystem7Theme ? "player" : "default"}
                             onClick={addPreset}
                             className="h-[22px] px-2 text-[9px] select-none"
                           >

--- a/src/apps/synth/components/SynthAppComponent.tsx
+++ b/src/apps/synth/components/SynthAppComponent.tsx
@@ -975,7 +975,7 @@ export function SynthAppComponent({
                   </div>
 
                   {/* Desktop preset buttons */}
-                  <div className="hidden md:flex gap-0 aqua-select-group">
+                  <div className={cn("hidden md:flex gap-0", isMacOSTheme && "aqua-select-group")}>
                     {presets.length > 0 ? (
                       presets.map((preset) => (
                         <Button
@@ -997,7 +997,7 @@ export function SynthAppComponent({
                     )}
                   </div>
                 </div>
-                <div className="flex gap-0 aqua-select-group">
+                <div className={cn("flex gap-0", isMacOSTheme && "aqua-select-group")}>
                   <Button
                     variant={isMacOSTheme ? "aqua_select" : isSystem7Theme ? "player" : "default"}
                     onClick={() =>
@@ -1008,7 +1008,7 @@ export function SynthAppComponent({
                       })
                     }
                     className={cn(
-                      isSystem7Theme ? "h-[22px] px-2" : "aqua-compact",
+                      isSystem7Theme ? "h-[22px] px-2" : isMacOSTheme ? "aqua-compact" : "h-[22px] px-2",
                       "select-none"
                     )}
                   >
@@ -1024,7 +1024,7 @@ export function SynthAppComponent({
                       })
                     }
                     className={cn(
-                      isSystem7Theme ? "h-[22px] px-2" : "aqua-compact",
+                      isSystem7Theme ? "h-[22px] px-2" : isMacOSTheme ? "aqua-compact" : "h-[22px] px-2",
                       "select-none"
                     )}
                   >
@@ -1036,7 +1036,9 @@ export function SynthAppComponent({
                     className={cn(
                       isSystem7Theme
                         ? "h-[22px] px-2"
-                        : "aqua-compact font-geneva-12 !text-[11px]",
+                        : isMacOSTheme
+                        ? "aqua-compact font-geneva-12 !text-[11px]"
+                        : "h-[22px] px-2",
                       "select-none"
                     )}
                   >

--- a/src/apps/synth/components/SynthAppComponent.tsx
+++ b/src/apps/synth/components/SynthAppComponent.tsx
@@ -943,7 +943,7 @@ export function SynthAppComponent({
                     >
                       <SelectTrigger
                         className={cn(
-                          "w-full font-geneva-12 text-[12px] p-2",
+                          "w-full h-[22px] font-geneva-12 text-[12px] p-2",
                           isClassicTheme && "text-black bg-transparent",
                           !isClassicTheme &&
                             "bg-black border-[#3a3a3a] text-white"


### PR DESCRIPTION
Apply `aqua_select` button variant only for macOS theme in synth app.

---
<a href="https://cursor.com/background-agent?bcId=bc-b6fcd29f-9928-4857-9ba3-d3c74292ca34">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b6fcd29f-9928-4857-9ba3-d3c74292ca34">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

