### PR TITLE
Fix aqua-select-btn radius when not in group

### DIFF
--- a/src/styles/themes.css
+++ b/src/styles/themes.css
@@ -685,6 +685,16 @@
   height: 0 !important;
 }
 
+/* Default border radius for standalone aqua-select buttons */
+:root[data-os-theme="macosx"] .aqua-select-btn {
+  border-radius: 6px !important;
+}
+
+/* Ensure the gloss effect matches the border radius for standalone buttons */
+:root[data-os-theme="macosx"] .aqua-select-btn:before {
+  border-radius: 5px 5px 2px 2px !important;
+}
+
 /* Button group styling for aqua-select buttons: only first/last rounded */
 :root[data-os-theme="macosx"] .aqua-select-group .aqua-select-btn {
   border-radius: 0 !important;


### PR DESCRIPTION
Sets the border radius of standalone `aqua-select-btn` elements to 6px to match macOS design guidelines.

Previously, standalone `aqua-select-btn` elements (like the "Add" button in the Videos app) inherited a smaller default border radius, as the specific 6px radius was only applied to buttons within an `aqua-select-group`. This change ensures consistency for standalone buttons.

---
<a href="https://cursor.com/background-agent?bcId=bc-86155eaa-0005-46f1-885a-e98260e023a9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-86155eaa-0005-46f1-885a-e98260e023a9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

