### PR TITLE
Add karaoke lyrics text stroke

### DIFF
--- a/src/apps/ipod/components/IpodAppComponent.tsx
+++ b/src/apps/ipod/components/IpodAppComponent.tsx
@@ -2533,8 +2533,8 @@ export function IpodAppComponent({
                               alignment={lyricsAlignment}
                               chineseVariant={chineseVariant}
                               koreanDisplay={koreanDisplay}
-                              fontClassName={"font-lyrics-rounded"}
-                              onAdjustOffset={(delta) => {
+                                                             fontClassName={"font-lyrics-rounded lyrics-stroke"}
+                               onAdjustOffset={(delta) => {
                                 // Update store with the adjusted offset
                                 useIpodStore
                                   .getState()
@@ -2588,7 +2588,7 @@ export function IpodAppComponent({
                               <div
                                 className={cn(
                                   "shimmer opacity-60 text-[min(10vw,10vh)]",
-                                  "font-lyrics-rounded"
+                                                                     "font-lyrics-rounded lyrics-stroke"
                                 )}
                               >
                                 Translating lyrics…

--- a/src/apps/ipod/components/LyricsDisplay.tsx
+++ b/src/apps/ipod/components/LyricsDisplay.tsx
@@ -419,8 +419,8 @@ export function LyricsDisplay({
               exit="exit"
               variants={variants}
               transition={dynamicTransition}
-              className={`px-2 md:px-6 ${textSizeClass} ${fontClassName} ${lineHeightClass} whitespace-pre-wrap break-words max-w-full text-white`}
-              style={{
+                                            className={`px-2 md:px-6 ${textSizeClass} ${fontClassName} ${lineHeightClass} whitespace-pre-wrap break-words max-w-full text-white`}
+               style={{
                 textAlign: lineTextAlign as CanvasTextAlign,
                 width: "100%",
                 paddingLeft:

--- a/src/index.css
+++ b/src/index.css
@@ -444,6 +444,12 @@ button.piano-key.piano-key[class*="bg-[#ff33ff]"] {
     font-smooth: always;
   }
 
+  /* Karaoke lyric outline for high contrast over video */
+  .lyrics-stroke {
+    -webkit-text-stroke: 0.06em rgba(0, 0, 0, 0.7);
+    paint-order: stroke;
+  }
+
   .font-monaco,
   .font-monaco-9 {
     font-family: "Monaco", "ArkPixel", "SerenityOS-Emoji", monospace;


### PR DESCRIPTION
Add a 70% black WebKit text stroke to full-screen karaoke lyrics for improved contrast.

---
<a href="https://cursor.com/background-agent?bcId=bc-45cdfef3-e326-4134-8ee6-2c4cd8846de7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-45cdfef3-e326-4134-8ee6-2c4cd8846de7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

