### PR TITLE
Remove webkit text stroke from lyrics

### DIFF
--- a/src/apps/ipod/components/IpodAppComponent.tsx
+++ b/src/apps/ipod/components/IpodAppComponent.tsx
@@ -551,7 +551,7 @@ function FullScreenPortal({
                 </div>
                 <div
                   className="font-chicago text-black text-[min(5vw,5vh)] absolute inset-0"
-                  style={{ WebkitTextStroke: "5px black", textShadow: "none" }}
+                  style={{ textShadow: "none" }}
                 >
                   {statusMessage}
                 </div>

--- a/src/apps/ipod/components/IpodScreen.tsx
+++ b/src/apps/ipod/components/IpodScreen.tsx
@@ -313,7 +313,6 @@ function StatusDisplay({ message }: { message: string }) {
         <div
           className="font-chicago text-black text-xl absolute inset-0"
           style={{
-            WebkitTextStroke: "3px black",
             textShadow: "none",
           }}
         >

--- a/src/apps/videos/components/VideosAppComponent.tsx
+++ b/src/apps/videos/components/VideosAppComponent.tsx
@@ -260,7 +260,6 @@ function StatusDisplay({ message }: { message: string }) {
       <div
         className="font-geneva-12 text-black text-xl absolute inset-0"
         style={{
-          WebkitTextStroke: "3px black",
           textShadow: "none",
         }}
       >


### PR DESCRIPTION
Remove `-webkit-text-stroke` from status display components to comply with styling requirements.

While the primary lyrics text did not use `-webkit-text-stroke`, the overlaid status messages that appear during the full-screen lyrics experience (e.g., offset adjustments) did. These styles have been removed from those components, preserving `text-shadow` as requested.

---
<a href="https://cursor.com/background-agent?bcId=bc-c38d8bbb-c350-4fea-a8dc-a612685f3928">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c38d8bbb-c350-4fea-a8dc-a612685f3928">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

