### PR TITLE
Add Welsh language option to Internet Explorer

### DIFF
--- a/src/apps/internet-explorer/components/InternetExplorerMenuBar.tsx
+++ b/src/apps/internet-explorer/components/InternetExplorerMenuBar.tsx
@@ -386,6 +386,15 @@ export function InternetExplorerMenuBar({
                 </span>
               </DropdownMenuItem>
 
+              <DropdownMenuItem
+                onClick={() => onLanguageChange?.("welsh")}
+                className="text-md h-6 px-3 active:bg-gray-900 active:text-white"
+              >
+                <span className={cn(language !== "welsh" && "pl-4")}>
+                  {language === "welsh" ? "✓ Welsh" : "Welsh"}
+                </span>
+              </DropdownMenuItem>
+
               {/* Ancient Languages */}
               <DropdownMenuSeparator className="h-[2px] bg-black my-1" />
               <DropdownMenuItem

--- a/src/apps/internet-explorer/hooks/useAiGeneration.ts
+++ b/src/apps/internet-explorer/hooks/useAiGeneration.ts
@@ -94,6 +94,7 @@ export function useAiGeneration({
       spanish: "Spanish",
       portuguese: "Portuguese",
       german: "German",
+      welsh: "Welsh",
       sanskrit: "Sanskrit",
       latin: "Latin",
       alien: "Alien Language",

--- a/src/stores/useInternetExplorerStore.ts
+++ b/src/stores/useInternetExplorerStore.ts
@@ -41,6 +41,7 @@ export type LanguageOption =
   | "spanish"
   | "portuguese"
   | "german"
+  | "welsh"
   | "sanskrit"
   | "latin"
   | "alien"


### PR DESCRIPTION
This PR adds a Welsh language option to the Internet Explorer app.\n\nChanges:\n- Add 'welsh' to LanguageOption in src/stores/useInternetExplorerStore.ts\n- Insert Welsh in the Language menu (below German) in src/apps/internet-explorer/components/InternetExplorerMenuBar.tsx\n- Map Welsh display name in src/apps/internet-explorer/hooks/useAiGeneration.ts\n\nNotes:\n- Language setting affects AI-generated pages (future or <= 1995), not live/proxied pages.\n- No API changes required; prompt language context is handled client-side.