### PR TITLE
Fix taskbar menu not showing on xp/98

### DIFF
--- a/src/apps/base/AppManager.tsx
+++ b/src/apps/base/AppManager.tsx
@@ -38,6 +38,8 @@ export function AppManager({ apps }: AppManagerProps) {
   }));
 
   const [isInitialMount, setIsInitialMount] = useState(true);
+  const currentTheme = useThemeStore((state) => state.current);
+  const isXpTheme = currentTheme === "xp" || currentTheme === "win98";
 
   // Create legacy-compatible appStates from instances for AppContext
   // NOTE: There can be multiple open instances for the same appId. We need to
@@ -269,8 +271,6 @@ export function AppManager({ apps }: AppManagerProps) {
       }}
     >
       {(() => {
-        const currentTheme = useThemeStore.getState().current;
-        const isXpTheme = currentTheme === "xp" || currentTheme === "win98";
         const hasForeground = Boolean(getForegroundInstance());
         // XP/Win98: always render global MenuBar (taskbar)
         // Mac/System7: render placeholder MenuBar only when no app is foreground


### PR DESCRIPTION
Fixes taskbar menu bar not showing immediately when switching to XP/98 themes.

The `isXpTheme` check was not reactive to theme changes, causing the taskbar to only appear after a re-render triggered by other actions like moving a window. Making the theme subscription reactive ensures the taskbar mounts instantly.

---
<a href="https://cursor.com/background-agent?bcId=bc-5f50557c-c549-49b4-a30a-ec41fcdb3be4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5f50557c-c549-49b4-a30a-ec41fcdb3be4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

