### PR TITLE
Implement windows minimize and hide

### DIFF
--- a/src/apps/base/AppManager.tsx
+++ b/src/apps/base/AppManager.tsx
@@ -187,12 +187,6 @@ export function AppManager({ apps }: AppManagerProps) {
             window.history.replaceState({}, "", "/"); // Clean URL
           }, 100); // Small delay might help robustness
         } else {
-          // Optional: Handle invalid app paths if necessary, or just ignore
-          // console.log(`Path ${path} does not correspond to a known app.`);
-          // Maybe redirect to root or show a 404 within the app context
-          // For now, just clean the URL if it wasn't a valid app path or IE code
-          // Update condition: Only clean if it's not an IE path (we handle cleaning IE path above)
-          // Update condition: Also check for ipod and videos paths
           if (
             !path.startsWith("/internet-explorer/") &&
             !path.startsWith("/ipod/") &&
@@ -278,7 +272,7 @@ export function AppManager({ apps }: AppManagerProps) {
       })()}
       {/* App Instances */}
       {Object.values(instances).map((instance) => {
-        if (!instance.isOpen) return null;
+        if (!instance.isOpen || instance.isMinimized) return null;
 
         const appId = instance.appId as AppId;
         const zIndex = getZIndexForInstance(instance.instanceId);

--- a/src/components/layout/MenuBar.tsx
+++ b/src/components/layout/MenuBar.tsx
@@ -664,6 +664,7 @@ export function MenuBar({ children, inWindowFrame = false }: MenuBarProps) {
                 return (
                   <button
                     key={instanceId}
+                    data-taskbar-instance-id={instanceId}
                     className="px-2 gap-1 border-t border-y rounded-sm flex items-center justify-start"
                     onClick={() => {
                       if (isMinimized) {

--- a/src/components/layout/WindowFrame.tsx
+++ b/src/components/layout/WindowFrame.tsx
@@ -105,6 +105,7 @@ export function WindowFrame({
   const lastToggleTimeRef = useRef<number>(0);
   // Keep track of window size before maximizing to restore it later
   const previousSizeRef = useRef({ width: 0, height: 0 });
+  const windowRef = useRef<HTMLDivElement | null>(null);
 
   // Get current theme
   const currentTheme = useThemeStore((state) => state.current);
@@ -183,6 +184,67 @@ export function WindowFrame({
       setIsOpen(false);
     }
   };
+
+  // Animate shrink to taskbar when minimizing (XP/98 only)
+  const animateMinimizeToTaskbar = useCallback(
+    (instanceIdParam?: string) => {
+      if (!isXpTheme || !windowRef.current) return false;
+      const id = instanceIdParam || instanceId;
+      if (!id) return false;
+      const taskButton = document.querySelector(
+        `[data-taskbar-instance-id="${id}"]`
+      ) as HTMLElement | null;
+      if (!taskButton) return false;
+      const winEl = windowRef.current;
+      const winRect = winEl.getBoundingClientRect();
+      const btnRect = taskButton.getBoundingClientRect();
+
+      // Create a clone for animation
+      const clone = winEl.cloneNode(true) as HTMLElement;
+      clone.style.position = "fixed";
+      clone.style.left = `${winRect.left}px`;
+      clone.style.top = `${winRect.top}px`;
+      clone.style.width = `${winRect.width}px`;
+      clone.style.height = `${winRect.height}px`;
+      clone.style.margin = "0";
+      clone.style.zIndex = "100000";
+      clone.style.pointerEvents = "none";
+      clone.style.transition = "all 160ms ease-in";
+      document.body.appendChild(clone);
+
+      // Force reflow then animate to taskbar button
+      void clone.getBoundingClientRect();
+      clone.style.left = `${btnRect.left}px`;
+      clone.style.top = `${btnRect.top}px`;
+      clone.style.width = `${Math.max(90, Math.min(140, btnRect.width))}px`;
+      clone.style.height = `24px`;
+      clone.style.opacity = "0.85";
+      clone.style.transform = "scale(0.98)";
+
+      // Clean up after transition
+      const cleanup = () => {
+        clone.removeEventListener("transitionend", cleanup);
+        clone.remove();
+      };
+      clone.addEventListener("transitionend", cleanup);
+      return true;
+    },
+    [isXpTheme, instanceId]
+  );
+
+  const handleMinimize = useCallback(() => {
+    if (!instanceId) return;
+    // Run animation for XP/98, then minimize
+    const didAnimate = animateMinimizeToTaskbar(instanceId);
+    // Slight delay to let animation run before hiding the window
+    if (didAnimate) {
+      setTimeout(() => {
+        useAppStore.getState().minimizeInstance(instanceId);
+      }, 140);
+    } else {
+      useAppStore.getState().minimizeInstance(instanceId);
+    }
+  }, [instanceId, animateMinimizeToTaskbar]);
 
   // Function to actually perform the close operation
   // This should be called by the parent component after confirmation
@@ -552,6 +614,7 @@ export function WindowFrame({
 
   return (
     <div
+      ref={windowRef}
       className={cn(
         "absolute p-2 md:p-0 w-full md:h-full md:mt-0 select-none",
         "transition-all duration-200 ease-in-out",
@@ -817,9 +880,7 @@ export function WindowFrame({
                   aria-label="Minimize"
                   onClick={(e) => {
                     e.stopPropagation();
-                    if (instanceId) {
-                      useAppStore.getState().minimizeInstance(instanceId);
-                    }
+                    handleMinimize();
                   }}
                   onMouseDown={(e) => e.stopPropagation()}
                   onTouchStart={(e) => e.stopPropagation()}
@@ -971,9 +1032,7 @@ export function WindowFrame({
                 <button
                   onClick={(e) => {
                     e.stopPropagation();
-                    if (instanceId) {
-                      useAppStore.getState().minimizeInstance(instanceId);
-                    }
+                    handleMinimize();
                   }}
                   onMouseDown={(e) => e.stopPropagation()}
                   onTouchStart={(e) => e.stopPropagation()}

--- a/src/components/layout/WindowFrame.tsx
+++ b/src/components/layout/WindowFrame.tsx
@@ -14,6 +14,7 @@ import { useAppStoreShallow } from "@/stores/helpers";
 import { useThemeStore } from "@/stores/useThemeStore";
 import { getTheme } from "@/themes";
 import { ThemedIcon } from "@/components/shared/ThemedIcon";
+import { useAppStore } from "@/stores/useAppStore";
 
 interface WindowFrameProps {
   children: React.ReactNode;
@@ -816,7 +817,9 @@ export function WindowFrame({
                   aria-label="Minimize"
                   onClick={(e) => {
                     e.stopPropagation();
-                    // Minimize functionality could be added here
+                    if (instanceId) {
+                      useAppStore.getState().minimizeInstance(instanceId);
+                    }
                   }}
                   onMouseDown={(e) => e.stopPropagation()}
                   onTouchStart={(e) => e.stopPropagation()}
@@ -968,7 +971,9 @@ export function WindowFrame({
                 <button
                   onClick={(e) => {
                     e.stopPropagation();
-                    // Minimize functionality could be added here
+                    if (instanceId) {
+                      useAppStore.getState().minimizeInstance(instanceId);
+                    }
                   }}
                   onMouseDown={(e) => e.stopPropagation()}
                   onTouchStart={(e) => e.stopPropagation()}

--- a/src/components/layout/WindowFrame.tsx
+++ b/src/components/layout/WindowFrame.tsx
@@ -15,7 +15,7 @@ import { useThemeStore } from "@/stores/useThemeStore";
 import { getTheme } from "@/themes";
 import { ThemedIcon } from "@/components/shared/ThemedIcon";
 import { useAppStore } from "@/stores/useAppStore";
-import { motion } from "framer-motion";
+// import { motion } from "framer-motion"; // REVERTED
 
 interface WindowFrameProps {
   children: React.ReactNode;
@@ -107,8 +107,7 @@ export function WindowFrame({
   // Keep track of window size before maximizing to restore it later
   const previousSizeRef = useRef({ width: 0, height: 0 });
   const windowRef = useRef<HTMLDivElement | null>(null);
-  const [isMinimizing, setIsMinimizing] = useState(false);
-  const [minimizeOrigin, setMinimizeOrigin] = useState<string | null>(null);
+  // REVERTED: framer-motion state removed
 
   // Get current theme
   const currentTheme = useThemeStore((state) => state.current);
@@ -188,41 +187,62 @@ export function WindowFrame({
     }
   };
 
-  // Compute transform-origin so scale zooms into the taskbar button horizontally
-  const computeMinimizeOrigin = useCallback((): string | null => {
-    if (!windowRef.current) return null;
-    const id = instanceId;
-    const winRect = windowRef.current.getBoundingClientRect();
-    let targetX = winRect.left + winRect.width / 2;
-    if (id) {
-      const btn = document.querySelector(
+  // Animate shrink to taskbar when minimizing (XP/98 only) - clone approach
+  const animateMinimizeToTaskbar = useCallback(
+    (instanceIdParam?: string) => {
+      if (!isXpTheme || !windowRef.current) return false;
+      const id = instanceIdParam || instanceId;
+      if (!id) return false;
+      const taskButton = document.querySelector(
         `[data-taskbar-instance-id="${id}"]`
       ) as HTMLElement | null;
-      if (btn) {
-        const br = btn.getBoundingClientRect();
-        targetX = br.left + br.width / 2;
-      }
-    }
-    const percentX = Math.max(
-      0,
-      Math.min(100, ((targetX - winRect.left) / winRect.width) * 100)
-    );
-    return `${percentX}% 100%`;
-  }, [instanceId]);
+      if (!taskButton) return false;
+      const winEl = windowRef.current;
+      const winRect = winEl.getBoundingClientRect();
+      const btnRect = taskButton.getBoundingClientRect();
+
+      const clone = winEl.cloneNode(true) as HTMLElement;
+      clone.style.position = "fixed";
+      clone.style.left = `${winRect.left}px`;
+      clone.style.top = `${winRect.top}px`;
+      clone.style.width = `${winRect.width}px`;
+      clone.style.height = `${winRect.height}px`;
+      clone.style.margin = "0";
+      clone.style.zIndex = "100000";
+      clone.style.pointerEvents = "none";
+      clone.style.transition = "all 160ms ease-in";
+      document.body.appendChild(clone);
+
+      // reflow
+      void clone.getBoundingClientRect();
+      clone.style.left = `${btnRect.left}px`;
+      clone.style.top = `${btnRect.top}px`;
+      clone.style.width = `${Math.max(90, Math.min(140, btnRect.width))}px`;
+      clone.style.height = `24px`;
+      clone.style.opacity = "0.85";
+      clone.style.transform = "scale(0.98)";
+
+      const cleanup = () => {
+        clone.removeEventListener("transitionend", cleanup);
+        clone.remove();
+      };
+      clone.addEventListener("transitionend", cleanup);
+      return true;
+    },
+    [isXpTheme, instanceId]
+  );
 
   const handleMinimize = useCallback(() => {
     if (!instanceId) return;
-    if (isXpTheme) {
-      const origin = computeMinimizeOrigin();
-      if (origin) setMinimizeOrigin(origin);
-      setIsMinimizing(true);
+    const didAnimate = animateMinimizeToTaskbar(instanceId);
+    if (didAnimate) {
       setTimeout(() => {
         useAppStore.getState().minimizeInstance(instanceId);
-      }, 180);
+      }, 140);
     } else {
       useAppStore.getState().minimizeInstance(instanceId);
     }
-  }, [instanceId, isXpTheme, computeMinimizeOrigin]);
+  }, [instanceId, animateMinimizeToTaskbar]);
 
   // Function to actually perform the close operation
   // This should be called by the parent component after confirmation
@@ -591,7 +611,7 @@ export function WindowFrame({
   };
 
   return (
-    <motion.div
+    <div
       ref={windowRef}
       className={cn(
         "absolute p-2 md:p-0 w-full md:h-full md:mt-0 select-none",
@@ -601,9 +621,6 @@ export function WindowFrame({
         // Disable all pointer events when window is closing
         !isOpen && "pointer-events-none"
       )}
-      initial={false}
-      animate={isMinimizing ? { scale: 0.06, opacity: 0 } : { scale: 1, opacity: 1 }}
-      transition={{ duration: 0.18, ease: [0.2, 0, 0.2, 1] }}
       onClick={() => {
         if (!isForeground) {
           if (instanceId) {
@@ -625,9 +642,9 @@ export function WindowFrame({
         maxWidth: mergedConstraints.maxWidth || undefined,
         maxHeight: mergedConstraints.maxHeight || undefined,
         transition: isDragging || resizeType ? "none" : undefined,
-        transform: !isMinimizing && !isInitialMount && !isOpen ? "scale(0.95)" : undefined,
-        opacity: !isMinimizing && !isInitialMount && !isOpen ? 0 : undefined,
-        transformOrigin: minimizeOrigin || "center",
+        transform: !isInitialMount && !isOpen ? "scale(0.95)" : undefined,
+        opacity: !isInitialMount && !isOpen ? 0 : undefined,
+        transformOrigin: "center",
       }}
     >
       <div className="relative w-full h-full">
@@ -1260,6 +1277,6 @@ export function WindowFrame({
           </div>
         </div>
       </div>
-    </motion.div>
+    </div>
   );
 }

--- a/src/stores/useThemeStore.ts
+++ b/src/stores/useThemeStore.ts
@@ -1,6 +1,7 @@
 import { create } from "zustand";
 import { OsThemeId } from "@/themes/types";
 import { invalidateIconCache } from "@/utils/icons";
+import { useAppStore } from "./useAppStore";
 
 interface ThemeState {
   current: OsThemeId;
@@ -57,6 +58,12 @@ export const useThemeStore = create<ThemeState>((set) => ({
     ensureLegacyCss(theme);
     // Force-refresh icon URLs so newly themed assets fetch fresh, bypassing any stale cache.
     invalidateIconCache(`theme-${theme}`);
+    // If switching away from XP/Win98, unminimize all windows to make them visible
+    if (theme === "macosx" || theme === "system7") {
+      try {
+        useAppStore.getState().unminimizeAllInstances();
+      } catch {}
+    }
   },
   hydrate: () => {
     const saved = localStorage.getItem("os_theme") as OsThemeId | null;


### PR DESCRIPTION
Implement window minimize to taskbar for Windows 98/XP themes and unhide all windows when switching to macOS/System 7.

---
<a href="https://cursor.com/background-agent?bcId=bc-09db24e0-914f-47ac-921b-f81965c02e31">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-09db24e0-914f-47ac-921b-f81965c02e31">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

