### PR TITLE
Implement windows minimize and hide

### DIFF
--- a/src/apps/base/types.ts
+++ b/src/apps/base/types.ts
@@ -68,6 +68,7 @@ export interface AppState<TInitialData = unknown> {
   size?: { width: number; height: number };
   isForeground?: boolean;
   initialData?: TInitialData;
+  isMinimized?: boolean;
 }
 
 export interface AppManagerState {

--- a/src/components/layout/MenuBar.tsx
+++ b/src/components/layout/MenuBar.tsx
@@ -516,18 +516,21 @@ function VolumeControl() {
 
 export function MenuBar({ children, inWindowFrame = false }: MenuBarProps) {
   const { apps } = useAppContext();
+  const { play: playWindowExpand } = useSound(Sounds.WINDOW_EXPAND);
   const {
     getForegroundInstance,
     instances,
 
     bringInstanceToForeground,
     foregroundInstanceId, // Add this to get the foreground instance ID
+    restoreInstance,
   } = useAppStoreShallow((s) => ({
     getForegroundInstance: s.getForegroundInstance,
     instances: s.instances,
 
     bringInstanceToForeground: s.bringInstanceToForeground,
     foregroundInstanceId: s.foregroundInstanceId, // Add this
+    restoreInstance: s.restoreInstance,
   }));
 
   const foregroundInstance = getForegroundInstance();
@@ -662,14 +665,25 @@ export function MenuBar({ children, inWindowFrame = false }: MenuBarProps) {
                   <button
                     key={instanceId}
                     className="px-2 gap-1 border-t border-y rounded-sm flex items-center justify-start"
-                    onClick={() => bringInstanceToForeground(instanceId)}
+                    onClick={() => {
+                      if (instance.isMinimized) {
+                        playWindowExpand();
+                        restoreInstance(instanceId);
+                      } else {
+                        bringInstanceToForeground(instanceId);
+                      }
+                    }}
                     style={{
                       height: "85%",
                       flex: "0 1 160px",
                       minWidth: "110px",
                       marginTop: "2px",
                       marginRight: "2px",
-                      background: isForeground
+                      background: instance.isMinimized
+                        ? currentTheme === "xp"
+                          ? "#0e48c7"
+                          : "#a0a0a0"
+                        : isForeground
                         ? currentTheme === "xp"
                           ? "#3980f4"
                           : "#c0c0c0"
@@ -811,7 +825,14 @@ export function MenuBar({ children, inWindowFrame = false }: MenuBarProps) {
                     return (
                       <DropdownMenuItem
                         key={instanceId}
-                        onClick={() => bringInstanceToForeground(instanceId)}
+                        onClick={() => {
+                      if (instance.isMinimized) {
+                        playWindowExpand();
+                        restoreInstance(instanceId);
+                      } else {
+                        bringInstanceToForeground(instanceId);
+                      }
+                    }}
                         className="text-md h-6 px-3 active:bg-gray-900 active:text-white flex items-center gap-2"
                       >
                         <ThemedIcon

--- a/src/components/layout/WindowFrame.tsx
+++ b/src/components/layout/WindowFrame.tsx
@@ -975,6 +975,7 @@ export function WindowFrame({
                   onClick={(e) => {
                     e.stopPropagation();
                     if (instanceId) {
+                      playWindowCollapse();
                       minimizeInstance(instanceId);
                     }
                   }}

--- a/src/components/layout/WindowFrame.tsx
+++ b/src/components/layout/WindowFrame.tsx
@@ -79,11 +79,15 @@ export function WindowFrame({
     debugMode,
     updateWindowState,
     updateInstanceWindowState,
+    minimizeInstance,
+    isMinimized,
   } = useAppStoreShallow((state) => ({
     bringInstanceToForeground: state.bringInstanceToForeground,
     debugMode: state.debugMode,
     updateWindowState: state.updateWindowState,
     updateInstanceWindowState: state.updateInstanceWindowState,
+    minimizeInstance: state.minimizeInstance,
+    isMinimized: instanceId ? state.instances[instanceId]?.isMinimized : false,
   }));
   const { play: playWindowOpen } = useSound(Sounds.WINDOW_OPEN);
   const { play: playWindowClose } = useSound(Sounds.WINDOW_CLOSE);
@@ -557,7 +561,9 @@ export function WindowFrame({
         isInitialMount && "animate-in fade-in-0 zoom-in-95 duration-200",
         isShaking && "animate-shake",
         // Disable all pointer events when window is closing
-        !isOpen && "pointer-events-none"
+        !isOpen && "pointer-events-none",
+        // Hide window when minimized (only for Windows themes)
+        isMinimized && isXpTheme && "hidden"
       )}
       onClick={() => {
         if (!isForeground) {
@@ -968,7 +974,9 @@ export function WindowFrame({
                 <button
                   onClick={(e) => {
                     e.stopPropagation();
-                    // Minimize functionality could be added here
+                    if (instanceId) {
+                      minimizeInstance(instanceId);
+                    }
                   }}
                   onMouseDown={(e) => e.stopPropagation()}
                   onTouchStart={(e) => e.stopPropagation()}

--- a/src/stores/useAppStore.ts
+++ b/src/stores/useAppStore.ts
@@ -62,6 +62,9 @@ interface AppStoreState extends AppManagerState {
     title?: string,
     multiWindow?: boolean
   ) => string;
+  minimizeInstance: (instanceId: string) => void;
+  restoreInstance: (instanceId: string) => void;
+  restoreAllInstances: () => void;
 
   // Legacy app‑level window APIs (kept as wrappers)
   bringToForeground: (appId: AppId | "") => void;
@@ -641,6 +644,43 @@ export const useAppStore = create<AppStoreState>()(
           }
         }
         return state.createAppInstance(appId, initialData, title);
+      },
+
+      minimizeInstance: (instanceId) => {
+        set((state) => ({
+          instances: {
+            ...state.instances,
+            [instanceId]: {
+              ...state.instances[instanceId],
+              isMinimized: true,
+            },
+          },
+        }));
+      },
+
+      restoreInstance: (instanceId) => {
+        set((state) => ({
+          instances: {
+            ...state.instances,
+            [instanceId]: {
+              ...state.instances[instanceId],
+              isMinimized: false,
+            },
+          },
+        }));
+        // Bring the restored window to foreground
+        get().bringInstanceToForeground(instanceId);
+      },
+
+      restoreAllInstances: () => {
+        set((state) => ({
+          instances: Object.fromEntries(
+            Object.entries(state.instances).map(([id, inst]) => [
+              id,
+              { ...inst, isMinimized: false },
+            ])
+          ),
+        }));
       },
 
       _debugCheckInstanceIntegrity: () => {


### PR DESCRIPTION
Implements core window minimize functionality for Windows 98/XP themes.

This PR introduces the `isMinimized` state to app instances and adds methods to minimize, restore, and restore all windows. It also updates the `WindowFrame` component to hide windows when minimized under Windows themes. This lays the groundwork for taskbar integration and automatic unhiding on theme changes, which will be addressed in subsequent PRs.

---
<a href="https://cursor.com/background-agent?bcId=bc-6e3042e4-a381-4e24-987d-c82db54434da">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6e3042e4-a381-4e24-987d-c82db54434da">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

