### PR TITLE
Enable horizontal scrolling for mobile dock

### DIFF
--- a/src/components/layout/Dock.tsx
+++ b/src/components/layout/Dock.tsx
@@ -6,7 +6,7 @@ import { AppId, getAppIconPath, appRegistry } from "@/config/appRegistry";
 import { useLaunchApp } from "@/hooks/useLaunchApp";
 import { useFinderStore } from "@/stores/useFinderStore";
 import { useFilesStore } from "@/stores/useFilesStore";
-import { useIsMobile } from "@/hooks/useIsMobile";
+import { useIsPhone } from "@/hooks/useIsPhone";
 import {
   AnimatePresence,
   motion,
@@ -18,7 +18,7 @@ import {
 } from "framer-motion";
 
 function MacDock() {
-  const isMobile = useIsMobile();
+  const isPhone = useIsPhone();
   const { instances, instanceOrder, bringInstanceToForeground } =
     useAppStoreShallow((s) => ({
       instances: s.instances,
@@ -397,10 +397,10 @@ function MacDock() {
             maxWidth: "min(92vw, 980px)",
             transformOrigin: "center bottom",
             borderRadius: "0px",
-            overflowX: isMobile ? "auto" : "visible",
+            overflowX: isPhone ? "auto" : "visible",
             overflowY: "hidden",
-            WebkitOverflowScrolling: isMobile ? "touch" : undefined,
-            overscrollBehaviorX: isMobile ? "contain" : undefined,
+            WebkitOverflowScrolling: isPhone ? "touch" : undefined,
+            overscrollBehaviorX: isPhone ? "contain" : undefined,
           }}
           transition={{
             layout: {


### PR DESCRIPTION
Enable horizontal scrolling for the Dock only on phone devices when icons exceed available space.

---
<a href="https://cursor.com/background-agent?bcId=bc-1284d71a-f43e-41cb-8d8a-03e3dc6d2abd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1284d71a-f43e-41cb-8d8a-03e3dc6d2abd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

