### PR TITLE
Redirect 404 errors to root

### DIFF
--- a/public/404.html
+++ b/public/404.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Redirecting…</title>
+    <meta http-equiv="refresh" content="0; url=/" />
+    <meta name="robots" content="noindex" />
+    <link rel="canonical" href="/" />
+    <script>
+      (function () {
+        var target = '/';
+        try {
+          if (window && window.location && window.location.origin) {
+            target = window.location.origin + '/';
+          }
+        } catch (e) {}
+        window.location.replace(target);
+      })();
+    </script>
+    <style>
+      html, body { height: 100%; margin: 0; }
+      body { display: flex; align-items: center; justify-content: center; font-family: system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif; }
+      a { color: inherit; }
+    </style>
+  </head>
+  <body>
+    <p>Redirecting to <a href="/">/</a>…</p>
+  </body>
+  </html>
+

--- a/vercel.json
+++ b/vercel.json
@@ -176,5 +176,8 @@
     { "source": "/pc", "destination": "/" },
     { "source": "/terminal", "destination": "/" },
     { "source": "/control-panels", "destination": "/" }
+  ],
+  "redirects": [
+    { "source": "/404", "destination": "/", "permanent": false }
   ]
 }


### PR DESCRIPTION
Add 404 handling to redirect unknown Vercel routes to the root path.

---
<a href="https://cursor.com/background-agent?bcId=bc-3560031e-d536-4bad-91be-81c12d01ae70">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3560031e-d536-4bad-91be-81c12d01ae70">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

