### PR TITLE
Fix tablet double tap touch behavior

### DIFF
--- a/src/apps/finder/components/FileIcon.tsx
+++ b/src/apps/finder/components/FileIcon.tsx
@@ -1,6 +1,6 @@
 import { useSound, Sounds } from "@/hooks/useSound";
 import { useEffect, useState, useRef } from "react";
-import { isMobileDevice } from "@/utils/device";
+import { isTouchDevice } from "@/utils/device";
 import { useLongPress } from "@/hooks/useLongPress";
 import { useThemeStore } from "@/stores/useThemeStore";
 import { ThemedIcon } from "@/components/shared/ThemedIcon";
@@ -210,8 +210,8 @@ export function FileIcon({
   const handleClick = (e: React.MouseEvent<HTMLDivElement>) => {
     playClick();
 
-    // On mobile devices, single tap should open the app (execute onDoubleClick)
-    if (isMobileDevice() && onDoubleClick) {
+    // On touch devices, single tap should open the app (execute onDoubleClick)
+    if (isTouchDevice() && onDoubleClick) {
       onDoubleClick(e);
     } else {
       // On desktop, execute the regular onClick handler (selection)
@@ -220,8 +220,8 @@ export function FileIcon({
   };
 
   const handleDoubleClick = (e: React.MouseEvent<HTMLDivElement>) => {
-    // Only handle double-click on desktop (mobile uses single tap)
-    if (!isMobileDevice()) {
+    // Only handle double-click on desktop (touch uses single tap)
+    if (!isTouchDevice()) {
       onDoubleClick?.(e);
     }
   };

--- a/src/apps/finder/components/FileList.tsx
+++ b/src/apps/finder/components/FileList.tsx
@@ -12,7 +12,7 @@ import {
 import { ThemedIcon } from "@/components/shared/ThemedIcon";
 import { useState, useRef, useEffect } from "react";
 import { useLongPress } from "@/hooks/useLongPress";
-import { isMobileDevice } from "@/utils/device";
+import { isTouchDevice } from "@/utils/device";
 
 export interface FileItem {
   name: string;
@@ -287,8 +287,8 @@ export function FileList({
     });
 
     const handleClick = () => {
-      // On mobile devices, single tap should open the file (execute handleFileOpen)
-      if (isMobileDevice()) {
+      // On touch devices, single tap should open the file (execute handleFileOpen)
+      if (isTouchDevice()) {
         handleFileOpen(file);
       } else {
         // On desktop, execute the regular click handler (selection)
@@ -297,8 +297,8 @@ export function FileList({
     };
 
     const handleDoubleClick = () => {
-      // Only handle double-click on desktop (mobile uses single tap)
-      if (!isMobileDevice()) {
+      // Only handle double-click on desktop (touch uses single tap)
+      if (!isTouchDevice()) {
         handleFileOpen(file);
       }
     };
@@ -339,7 +339,7 @@ export function FileList({
         onDrop={(e) => handleDrop(e, file)}
         onDragEnd={handleDragEnd}
         data-file-item="true"
-        {...(isMobileDevice() ? longPressHandlers : {})}
+        {...(isTouchDevice() ? longPressHandlers : {})}
       >
         <TableCell className="flex items-center gap-2">
           {file.contentUrl && isImageFile(file) ? (
@@ -422,7 +422,7 @@ export function FileList({
           }
         }}
         data-file-item="true"
-        {...(isMobileDevice() ? longPressHandlers : {})}
+        {...(isTouchDevice() ? longPressHandlers : {})}
       >
         <FileIcon
           name={file.name}


### PR DESCRIPTION
Enable single-tap to open and long-press for context menus on tablets for file and desktop icons by using `isTouchDevice()` instead of `isMobileDevice()`.

---
<a href="https://cursor.com/background-agent?bcId=bc-a0103178-3ed5-4fad-b692-829548c1b888">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a0103178-3ed5-4fad-b692-829548c1b888">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

