### PR TITLE
Fix finder icon alignment for two items

### DIFF
--- a/src/apps/finder/components/FileList.tsx
+++ b/src/apps/finder/components/FileList.tsx
@@ -480,7 +480,7 @@ export function FileList({
 
   return (
           <div
-        className={`grid ${viewType === "large" ? "grid-cols-[repeat(auto-fit,minmax(96px,1fr))]" : "grid-cols-[repeat(auto-fit,minmax(80px,1fr))]"} gap-2 p-2 min-h-[150px] ${files.length <= 2 ? "justify-items-start" : "justify-items-center"}`}
+        className={`grid ${files.length === 2 ? "grid-cols-[repeat(2,max-content)]" : viewType === "large" ? "grid-cols-[repeat(auto-fit,minmax(96px,1fr))]" : "grid-cols-[repeat(auto-fit,minmax(80px,1fr))]"} gap-2 p-2 min-h-[150px] ${files.length === 2 ? "justify-center justify-items-center" : files.length <= 1 ? "justify-items-start" : "justify-items-center"}`}
         onDragOver={handleContainerDragOver}
         onDragLeave={handleContainerDragLeave}
         onDrop={handleContainerDrop}


### PR DESCRIPTION
Align two file icons in Finder to be centered, matching the layout for 4, 6, or 8 items.

Previously, two items were left-aligned, causing an odd visual gap. This change applies specific grid column and justification styles when exactly two items are present, ensuring they are centered while preserving the left-alignment for a single item.

---
<a href="https://cursor.com/background-agent?bcId=bc-8eacad1d-0b11-43eb-9ca1-3ef66f9945ba">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8eacad1d-0b11-43eb-9ca1-3ef66f9945ba">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

