### PR TITLE
Remember finder view types and set defaults

### DIFF
--- a/src/apps/finder/components/FinderAppComponent.tsx
+++ b/src/apps/finder/components/FinderAppComponent.tsx
@@ -107,11 +107,10 @@ export function FinderAppComponent({
   const removeFinderInstance = useFinderStore((state) => state.removeInstance);
   const updateFinderInstance = useFinderStore((state) => state.updateInstance);
   const finderInstances = useFinderStore((state) => state.instances);
-  const pathViewPreferences = useFinderStore((state) => state.pathViewPreferences);
   const setViewTypeForPath = useFinderStore((state) => state.setViewTypeForPath);
-  const getDefaultViewTypeForPath = useFinderStore((state) => state.getDefaultViewTypeForPath);
 
   // Legacy store methods for single-window mode
+  const legacyViewType = useFinderStore((state) => state.viewType);
   const legacySortType = useFinderStore((state) => state.sortType);
   const legacySetViewType = useFinderStore((state) => state.setViewType);
   const legacySetSortType = useFinderStore((state) => state.setSortType);
@@ -176,7 +175,11 @@ export function FinderAppComponent({
   // Get current instance data (only if using instanceId)
   const currentInstance = instanceId ? finderInstances[instanceId] : null;
 
-  // Use instance data if available, otherwise use legacy store (for sort only)
+  // Use instance data if available, otherwise use legacy store
+  const viewType = instanceId
+    ? currentInstance?.viewType || "list"
+    : legacyViewType;
+
   const sortType = instanceId
     ? currentInstance?.sortType || "name"
     : legacySortType;
@@ -223,10 +226,6 @@ export function FinderAppComponent({
     createFolder,
     moveFile,
   } = useFileSystem(initialFileSystemPath, { instanceId });
-
-  // Derive view type directly from store per path (no effect)
-  const viewType: ViewType =
-    pathViewPreferences[currentPath] || getDefaultViewTypeForPath(currentPath);
 
   const setViewType = useCallback(
     (type: ViewType) => {

--- a/src/apps/finder/hooks/useFileSystem.ts
+++ b/src/apps/finder/hooks/useFileSystem.ts
@@ -313,7 +313,8 @@ export function useFileSystem(
   const setCurrentPath = useCallback(
     (path: string) => {
       if (instanceId && finderInstance) {
-        updateFinderInstance(instanceId, { currentPath: path });
+        const nextViewType = finderStore.getViewTypeForPath(path);
+        updateFinderInstance(instanceId, { currentPath: path, viewType: nextViewType });
       } else {
         setLocalCurrentPath(path);
       }

--- a/src/stores/useFinderStore.ts
+++ b/src/stores/useFinderStore.ts
@@ -26,6 +26,12 @@ interface FinderStoreState {
   viewType: ViewType;
   sortType: SortType;
 
+  // Per-path view preferences
+  pathViewPreferences: Record<string, ViewType>;
+  setViewTypeForPath: (path: string, type: ViewType) => void;
+  getViewTypeForPath: (path: string) => ViewType;
+  getDefaultViewTypeForPath: (path: string) => ViewType;
+
   // Instance actions
   createInstance: (instanceId: string, initialPath?: string) => void;
   removeInstance: (instanceId: string) => void;
@@ -42,7 +48,7 @@ interface FinderStoreState {
   reset: () => void;
 }
 
-const STORE_VERSION = 2;
+const STORE_VERSION = 3;
 const STORE_NAME = "ryos:finder";
 
 export const useFinderStore = create<FinderStoreState>()(
@@ -54,6 +60,35 @@ export const useFinderStore = create<FinderStoreState>()(
       // Legacy state (deprecated)
       viewType: "list",
       sortType: "name",
+
+      // Per-path view preferences
+      pathViewPreferences: {},
+      setViewTypeForPath: (path, type) =>
+        set((state) => ({
+          pathViewPreferences: {
+            ...state.pathViewPreferences,
+            [path]: type,
+          },
+        })),
+      getViewTypeForPath: (path) => {
+        const state = get();
+        return (
+          state.pathViewPreferences[path] ||
+          state.getDefaultViewTypeForPath(path)
+        );
+      },
+      getDefaultViewTypeForPath: (path) => {
+        // Defaults per user request
+        if (path === "/") return "large";
+        if (path.startsWith("/Images")) return "large";
+        if (path.startsWith("/Videos")) return "large";
+        if (path.startsWith("/Applications")) return "large";
+        if (path.startsWith("/Trash")) return "large";
+        if (path.startsWith("/Documents")) return "list";
+        if (path.startsWith("/Music")) return "list";
+        // Fallback
+        return "list";
+      },
 
       // Instance management
       createInstance: (instanceId, initialPath = "/") =>
@@ -71,7 +106,7 @@ export const useFinderStore = create<FinderStoreState>()(
                 currentPath: initialPath,
                 navigationHistory: [initialPath],
                 navigationIndex: 0,
-                viewType: "list",
+                viewType: state.getViewTypeForPath(initialPath),
                 sortType: "name",
                 selectedFile: null,
               },
@@ -142,6 +177,7 @@ export const useFinderStore = create<FinderStoreState>()(
       storage: createJSONStorage(() => localStorage),
       partialize: (state) => ({
         instances: state.instances,
+        pathViewPreferences: state.pathViewPreferences,
         // Don't persist legacy fields anymore
       }),
       migrate: (persistedState: unknown, version: number) => {
@@ -158,9 +194,19 @@ export const useFinderStore = create<FinderStoreState>()(
             // Keep legacy fields for backward compatibility
             viewType: oldState.viewType || "list",
             sortType: oldState.sortType || "name",
+            pathViewPreferences: {},
           };
 
           return migratedState;
+        }
+
+        // Migrate from v2 to v3 (add per-path view preferences)
+        if (version < 3) {
+          const prev = persistedState as Partial<FinderStoreState>;
+          return {
+            ...prev,
+            pathViewPreferences: prev?.pathViewPreferences || {},
+          } as Partial<FinderStoreState>;
         }
 
         return persistedState;
@@ -178,13 +224,20 @@ export const useFinderStore = create<FinderStoreState>()(
                   currentPath: instance.currentPath || "/",
                   navigationHistory: instance.navigationHistory || ["/"],
                   navigationIndex: instance.navigationIndex || 0,
-                  viewType: instance.viewType || "list",
+                  viewType:
+                    instance.viewType ||
+                    state.getViewTypeForPath?.(instance.currentPath || "/") ||
+                    "list",
                   sortType: instance.sortType || "name",
                   selectedFile: instance.selectedFile || null,
                 };
               }
             });
           }
+
+          // Ensure per-path preferences map exists
+          // @ts-expect-error: state is mutable during rehydrate
+          if (!state.pathViewPreferences) state.pathViewPreferences = {};
         }
       },
     }

--- a/src/stores/useFinderStore.ts
+++ b/src/stores/useFinderStore.ts
@@ -236,8 +236,8 @@ export const useFinderStore = create<FinderStoreState>()(
           }
 
           // Ensure per-path preferences map exists
-          // @ts-expect-error: state is mutable during rehydrate
-          if (!state.pathViewPreferences) state.pathViewPreferences = {};
+          const anyState = state as unknown as { pathViewPreferences?: Record<string, ViewType> };
+          if (!anyState.pathViewPreferences) anyState.pathViewPreferences = {};
         }
       },
     }


### PR DESCRIPTION
Implement per-path view type persistence and set default view types for Finder.

---
<a href="https://cursor.com/background-agent?bcId=bc-15ab0fa0-c866-405b-860f-1a42372a92ed">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-15ab0fa0-c866-405b-860f-1a42372a92ed">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

