### PR TITLE
Fix dock overlap in internet explorer time machine

### DIFF
--- a/src/apps/internet-explorer/components/TimeMachineView.tsx
+++ b/src/apps/internet-explorer/components/TimeMachineView.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useCallback, useRef } from "react";
+import { createPortal } from "react-dom";
 import { motion, AnimatePresence } from "framer-motion";
 import { X, Blend, Share } from "lucide-react";
 import HtmlPreview from "@/components/shared/HtmlPreview";
@@ -652,7 +653,7 @@ const TimeMachineView: React.FC<TimeMachineViewProps> = ({
   return (
     <>
       <AnimatePresence>
-        {isOpen && (
+        {isOpen && createPortal(
           <motion.div
             className={`fixed inset-0 z-[10000] ${
               shaderEffectEnabled
@@ -1138,8 +1139,8 @@ const TimeMachineView: React.FC<TimeMachineViewProps> = ({
                 </DropdownMenu>
               </div>
             </div>
-          </motion.div>
-        )}
+          </motion.div>, document.body)
+        }
       </AnimatePresence>
 
       <ShareItemDialog


### PR DESCRIPTION
Render the Internet Explorer Time Machine full-view overlay using a React portal to fix it overlapping the dock.

The previous `z-index` on the overlay was insufficient because the Time Machine window created a new stacking context, preventing the overlay from layering above the dock. Using `createPortal` renders the overlay directly to `document.body`, escaping this context and ensuring it always appears on top.

---
<a href="https://cursor.com/background-agent?bcId=bc-bf3a7120-dc9a-48f1-821c-162565fc350c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-bf3a7120-dc9a-48f1-821c-162565fc350c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

