### PR TITLE
Add pointer lock to ie iframe permissions

### DIFF
--- a/api/iframe-check.ts
+++ b/api/iframe-check.ts
@@ -796,7 +796,7 @@ export default async function handler(req: Request) {
       headers.delete("content-security-policy");
       headers.set(
         "content-security-policy",
-        "frame-ancestors *; sandbox allow-scripts allow-forms allow-same-origin allow-popups"
+        "frame-ancestors *; sandbox allow-scripts allow-forms allow-same-origin allow-popups allow-pointer-lock"
       );
       headers.set("access-control-allow-origin", "*");
 

--- a/src/apps/internet-explorer/components/InternetExplorerAppComponent.tsx
+++ b/src/apps/internet-explorer/components/InternetExplorerAppComponent.tsx
@@ -2522,6 +2522,7 @@ export function InternetExplorerAppComponent({
                   ref={iframeRef}
                   src={finalUrl || ""}
                   className="w-full h-full border-0"
+                  sandbox="allow-scripts allow-same-origin allow-pointer-lock"
                   onLoad={handleIframeLoad}
                   onError={handleIframeError}
                 />

--- a/src/apps/internet-explorer/components/TimeMachineView.tsx
+++ b/src/apps/internet-explorer/components/TimeMachineView.tsx
@@ -835,7 +835,7 @@ const TimeMachineView: React.FC<TimeMachineViewProps> = ({
                                             <iframe
                                               src={previewContent}
                                               className="w-full h-full border-none bg-white"
-                                              sandbox="allow-scripts allow-same-origin"
+                                              sandbox="allow-scripts allow-same-origin allow-pointer-lock"
                                               title={`Preview for ${previewYear}`}
                                               onLoad={() => {
                                                 console.log(


### PR DESCRIPTION
Add `allow-pointer-lock` to iframe sandbox attributes and the iframe proxy CSP to enable pointer lock functionality.

---
<a href="https://cursor.com/background-agent?bcId=bc-a8375eb5-f5d4-4a4a-8773-5ba9962bdd27">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a8375eb5-f5d4-4a4a-8773-5ba9962bdd27">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

