### PR TITLE
Update default chat model to gpt-4.1

### DIFF
--- a/src/types/aiModels.ts
+++ b/src/types/aiModels.ts
@@ -58,4 +58,4 @@ export const AI_MODEL_METADATA: AIModelInfo[] = Object.entries(AI_MODELS).map(
 );
 
 // Default model
-export const DEFAULT_AI_MODEL: SupportedModel = "claude-4";
+export const DEFAULT_AI_MODEL: SupportedModel = "gpt-4.1";


### PR DESCRIPTION
Change the default chat model to `gpt-4.1`.

---
<a href="https://cursor.com/background-agent?bcId=bc-ea25fb9f-2418-4ea1-88c0-4dd841070473">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ea25fb9f-2418-4ea1-88c0-4dd841070473">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

