### PR TITLE
Persist lyric translation setting across tracks

### DIFF
--- a/src/apps/ipod/components/IpodAppComponent.tsx
+++ b/src/apps/ipod/components/IpodAppComponent.tsx
@@ -885,7 +885,7 @@ export function IpodAppComponent({
     lyricsAlignment,
     chineseVariant,
     koreanDisplay,
-    lyricsTranslationRequest,
+    lyricsTranslationLanguage,
     isFullScreen,
     toggleFullScreen,
     setCurrentIndex,
@@ -907,7 +907,7 @@ export function IpodAppComponent({
     lyricsAlignment: s.lyricsAlignment,
     chineseVariant: s.chineseVariant,
     koreanDisplay: s.koreanDisplay,
-    lyricsTranslationRequest: s.lyricsTranslationRequest,
+    lyricsTranslationLanguage: s.lyricsTranslationLanguage,
     isFullScreen: s.isFullScreen,
     toggleFullScreen: s.toggleFullScreen,
     setCurrentIndex: s.setCurrentIndex,
@@ -2157,10 +2157,7 @@ export function IpodAppComponent({
     artist: tracks[currentIndex]?.artist ?? "",
     album: tracks[currentIndex]?.album ?? "",
     currentTime: elapsedTime + (tracks[currentIndex]?.lyricOffset ?? 0) / 1000,
-    translateTo:
-      lyricsTranslationRequest?.songId === tracks[currentIndex]?.id
-        ? lyricsTranslationRequest?.language
-        : null,
+    translateTo: lyricsTranslationLanguage,
   });
 
   // Add a ref to track the previous fullscreen state
@@ -2233,19 +2230,14 @@ export function IpodAppComponent({
     [showStatus]
   );
 
-  const currentTranslationCode =
-    lyricsTranslationRequest?.songId === tracks[currentIndex]?.id
-      ? lyricsTranslationRequest?.language ?? null
-      : null;
+  const currentTranslationCode = lyricsTranslationLanguage;
 
   const handleSelectTranslation = useCallback(
     (code: string | null) => {
-      const songId = tracks[currentIndex]?.id;
-      const setReq = useIpodStore.getState().setLyricsTranslationRequest;
-      if (code && songId) setReq(code, songId);
-      else setReq(null, null);
+      const setLang = useIpodStore.getState().setLyricsTranslationLanguage;
+      setLang(code);
     },
-    [tracks, currentIndex]
+    []
   );
 
   const cycleAlignment = useCallback(() => {

--- a/src/apps/ipod/components/IpodMenuBar.tsx
+++ b/src/apps/ipod/components/IpodMenuBar.tsx
@@ -66,7 +66,7 @@ export function IpodMenuBar({
     lyricsAlignment,
     chineseVariant,
     koreanDisplay,
-    lyricsTranslationRequest,
+    lyricsTranslationLanguage,
     // Actions
     setCurrentIndex,
     setIsPlaying,
@@ -86,7 +86,7 @@ export function IpodMenuBar({
     refreshLyrics,
     setChineseVariant,
     setKoreanDisplay,
-    setLyricsTranslationRequest,
+    setLyricsTranslationLanguage,
     importLibrary,
     exportLibrary,
   } = useIpodStoreShallow((s) => ({
@@ -106,7 +106,7 @@ export function IpodMenuBar({
     lyricsAlignment: s.lyricsAlignment ?? LyricsAlignment.FocusThree,
     chineseVariant: s.chineseVariant ?? ChineseVariant.Traditional,
     koreanDisplay: s.koreanDisplay ?? KoreanDisplay.Original,
-    lyricsTranslationRequest: s.lyricsTranslationRequest,
+    lyricsTranslationLanguage: s.lyricsTranslationLanguage,
     // Actions
     setCurrentIndex: s.setCurrentIndex,
     setIsPlaying: s.setIsPlaying,
@@ -126,7 +126,7 @@ export function IpodMenuBar({
     refreshLyrics: s.refreshLyrics,
     setChineseVariant: s.setChineseVariant,
     setKoreanDisplay: s.setKoreanDisplay,
-    setLyricsTranslationRequest: s.setLyricsTranslationRequest,
+    setLyricsTranslationLanguage: s.setLyricsTranslationLanguage,
     importLibrary: s.importLibrary,
     exportLibrary: s.exportLibrary,
   }));
@@ -445,25 +445,20 @@ export function IpodMenuBar({
             </DropdownMenuSubTrigger>
             <DropdownMenuSubContent className="px-0 max-h-[400px] overflow-y-auto">
               {translationLanguages.map((lang) => {
-                const currentTrackId = tracks[currentIndex]?.id;
-                // Show checkmark if this language will be applied to the current track
-                const willBeApplied = lyricsTranslationRequest?.language === lang.code;
-                const isOriginal = !lang.code && !lyricsTranslationRequest;
+                // Show checkmark if this language is the current persistent preference
+                const isSelected = lyricsTranslationLanguage === lang.code;
+                const isOriginal = !lang.code && !lyricsTranslationLanguage;
                 
                 return (
                   <DropdownMenuItem
                     key={lang.code || "off"}
                     onClick={() => {
-                      if (currentTrackId && lang.code) {
-                        setLyricsTranslationRequest(lang.code, currentTrackId);
-                      } else if (!lang.code) {
-                        setLyricsTranslationRequest(null, null);
-                      }
+                      setLyricsTranslationLanguage(lang.code);
                     }}
                     className="text-md h-6 px-3 active:bg-gray-900 active:text-white"
                   >
-                    <span className={cn((!willBeApplied && !isOriginal) && "pl-4")}>
-                      {(willBeApplied || isOriginal) ? "✓ " : ""}{lang.label}
+                    <span className={cn((!isSelected && !isOriginal) && "pl-4")}>
+                      {(isSelected || isOriginal) ? "✓ " : ""}{lang.label}
                     </span>
                   </DropdownMenuItem>
                 );


### PR DESCRIPTION
Make lyric translation state persist across tracks to avoid requiring users to re-select the translation language for every new song.

---
<a href="https://cursor.com/background-agent?bcId=bc-9ed9bbb0-9398-43f9-98a1-e459e35d0565">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9ed9bbb0-9398-43f9-98a1-e459e35d0565">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

