### PR TITLE
Refresh lyrics and translate if set

### DIFF
--- a/src/hooks/useLyrics.ts
+++ b/src/hooks/useLyrics.ts
@@ -173,12 +173,16 @@ export function useLyrics({
       console.warn("Lyrics translation timed out");
     }, 120000);
 
+    // Check if this translation is triggered by a refresh (refreshNonce changed)
+    const isRefreshTriggered = lastRefreshNonceRef.current !== refreshNonce;
+    
     fetch("/api/translate-lyrics", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
         lines: originalLines,
         targetLanguage: translateTo,
+        bypassCache: isRefreshTriggered,
       }),
       signal: controller.signal,
     })
@@ -208,6 +212,8 @@ export function useLyrics({
           // If translation returns empty we still keep original in the store.
           setTranslatedLines([]);
         }
+        // Update the refresh nonce reference so subsequent translations use cache
+        lastRefreshNonceRef.current = refreshNonce;
       })
       .catch((err: unknown) => {
         if (cancelled) return;

--- a/src/hooks/useLyrics.ts
+++ b/src/hooks/useLyrics.ts
@@ -234,7 +234,7 @@ export function useLyrics({
       controller.abort();
       clearTimeout(translationTimeoutId);
     };
-  }, [originalLines, translateTo, isFetchingOriginal, title, artist]);
+  }, [originalLines, translateTo, isFetchingOriginal, title, artist, refreshNonce]);
 
   const displayLines = translatedLines || originalLines;
 

--- a/src/stores/useIpodStore.ts
+++ b/src/stores/useIpodStore.ts
@@ -447,10 +447,18 @@ export const useIpodStore = create<IpodState>()(
       setShowVideo: (show) => set({ showVideo: show }),
       toggleLyrics: () => set((state) => ({ showLyrics: !state.showLyrics })),
       refreshLyrics: () =>
-        set((state) => ({
-          lyricsRefreshNonce: state.lyricsRefreshNonce + 1,
-          currentLyrics: null,
-        })),
+        set((state) => {
+          // If translation is enabled, also trigger a retranslation by updating the translation request
+          const newTranslationRequest = state.lyricsTranslationLanguage && state.tracks[state.currentIndex]?.id
+            ? { language: state.lyricsTranslationLanguage, songId: state.tracks[state.currentIndex].id }
+            : null;
+
+          return {
+            lyricsRefreshNonce: state.lyricsRefreshNonce + 1,
+            currentLyrics: null,
+            lyricsTranslationRequest: newTranslationRequest,
+          };
+        }),
       adjustLyricOffset: (trackIndex, deltaMs) =>
         set((state) => {
           if (


### PR DESCRIPTION
Make the "refresh lyrics" menu item retranslate lyrics if a translation language is set.

The existing "refresh lyrics" only triggered a re-fetch of original lyrics. This PR ensures that if a translation language is active, refreshing lyrics also triggers a retranslation by updating the translation request and making the translation effect dependent on the lyrics refresh nonce.

---
<a href="https://cursor.com/background-agent?bcId=bc-4a8ac80c-512f-4599-aa30-6f8a70f06194">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4a8ac80c-512f-4599-aa30-6f8a70f06194">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

