### PR TITLE
Delete duplicate songs from ipod library

### DIFF
--- a/public/data/ipod-videos.json
+++ b/public/data/ipod-videos.json
@@ -30,13 +30,6 @@
       "lyricOffset": -9800
     },
     {
-      "id": "9jXGDpIGwXA",
-      "url": "https://www.youtube.com/watch?v=9jXGDpIGwXA",
-      "title": "OVERLAP",
-      "artist": "Crush",
-      "lyricOffset": 1100
-    },
-    {
       "id": "qJolLqOS7Is",
       "url": "https://www.youtube.com/watch?v=qJolLqOS7Is",
       "title": "2-5-1",


### PR DESCRIPTION
Remove the "OVERLAP" song entry from the iPod library data to fulfill the user's request.

---
<a href="https://cursor.com/background-agent?bcId=bc-1a273ecc-36e2-4a96-8f76-2f3631d35867"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1a273ecc-36e2-4a96-8f76-2f3631d35867"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

