### PR TITLE
Add song JoyRide to iPod library

### DIFF
--- a/public/data/ipod-videos.json
+++ b/public/data/ipod-videos.json
@@ -1,6 +1,13 @@
 {
   "videos": [
     {
+      "id": "8QZeXvOjgGE",
+      "url": "https://www.youtube.com/watch?v=8QZeXvOjgGE",
+      "title": "JoyRide",
+      "artist": "CORTIS",
+      "lyricOffset": 1400
+    },
+    {
       "id": "WXS-o57VJ5w",
       "url": "https://www.youtube.com/watch?v=WXS-o57VJ5w",
       "title": "GO!",


### PR DESCRIPTION
Add "JoyRide" by CORTIS to the top of the iPod library in `ipod-videos.json`.

---
<a href="https://cursor.com/background-agent?bcId=bc-6104f16d-6cb3-4bd4-99aa-2233203f4bd8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6104f16d-6cb3-4bd4-99aa-2233203f4bd8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

