### PR TITLE
Update ipod playback message display

### DIFF
--- a/src/components/shared/ToolInvocationMessage.tsx
+++ b/src/components/shared/ToolInvocationMessage.tsx
@@ -120,10 +120,27 @@ export function ToolInvocationMessage({
           : "Paused"
       } iPod`;
     } else if (toolName === "ipodPlaySong") {
-      const title = input?.title || "song";
-      displayResultMessage = `Playing "${title}"`;
+      const { title, artist, id } = input || {};
+      let songDescription = "song";
+      
+      if (title && artist) {
+        songDescription = `"${title}" by ${artist}`;
+      } else if (title) {
+        songDescription = `"${title}"`;
+      } else if (artist) {
+        songDescription = `song by ${artist}`;
+      } else if (id) {
+        songDescription = `song (ID: ${id})`;
+      }
+      
+      displayResultMessage = `Playing ${songDescription}`;
     } else if (toolName === "ipodAddAndPlaySong") {
-      displayResultMessage = `Added and playing new song`;
+      const id = input?.id;
+      if (id) {
+        displayResultMessage = `Added and playing song (ID: ${id})`;
+      } else {
+        displayResultMessage = `Added and playing new song`;
+      }
     } else if (toolName === "ipodNextTrack") {
       displayResultMessage = `Skipped to next track`;
     } else if (toolName === "ipodPreviousTrack") {


### PR DESCRIPTION
Enhance iPod playback tool call message display to handle all input parameters.

Previously, `ipodPlaySong` only displayed the song title, and `ipodAddAndPlaySong` showed a generic message. This PR updates the display logic to intelligently use `title`, `artist`, and `id` parameters for more informative and accurate messages, with appropriate fallbacks.

---
<a href="https://cursor.com/background-agent?bcId=bc-ab13ce8b-1d2b-4742-9f19-68a1346e7ec3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ab13ce8b-1d2b-4742-9f19-68a1346e7ec3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

