### PR TITLE
Fix text edit insert tool call instance id

### DIFF
--- a/api/utils/aiPrompts.ts
+++ b/api/utils/aiPrompts.ts
@@ -90,7 +90,9 @@ TEXT EDITING:
    • Use 'textEditSearchReplace' to find and replace content. **REQUIRED**: 'search', 'replace', and 'instanceId' (from system state). Set 'isRegex: true' **only** if the user explicitly mentions using a regular expression.
    • Use 'textEditInsertText' to add plain text. **REQUIRED**: 'text' and 'instanceId'. Optional: 'position' ("start" or "end", default is "end").
    • Use 'textEditNewFile' to create a blank file. TextEdit will launch automatically if not open. Use this when the user requests a new doc and the current file content is irrelevant.
-- IMPORTANT: Always include the 'instanceId' parameter by checking the system state for the specific TextEdit instance ID (e.g., '15', '78', etc.).
+- IMPORTANT: Always include the 'instanceId' parameter:
+   • If you just called 'textEditNewFile', use the instanceId from that tool call's result (e.g., "Created new document (instanceId: 15)" → use instanceId: "15")
+   • Otherwise, get the instanceId from the system state for the specific TextEdit instance ID (e.g., '15', '78', etc.)
 - You can call multiple textEditSearchReplace or textEditInsertText tools to edit the document. If the user requests several distinct edits, issue them in separate tool calls in the exact order the user gave.
 
 iPOD and MUSIC PLAYBACK:


### PR DESCRIPTION
Update AI prompt to ensure `textEditInsertText` uses the correct `instanceId` from `textEditNewFile` tool results when a new file is opened.

Previously, the AI was instructed to get the `instanceId` from the system state. However, when `textEditNewFile` creates a new document, its `instanceId` is only available in the tool's result message, not yet in the system state. This could cause subsequent text editing tools to target an incorrect or non-existent TextEdit instance. The updated prompt explicitly guides the AI to parse the `instanceId` from the `textEditNewFile` tool result for immediate follow-up actions.

---
<a href="https://cursor.com/background-agent?bcId=bc-d99122dd-6e86-4eb2-abca-98d5c22094ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d99122dd-6e86-4eb2-abca-98d5c22094ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

