### PR TITLE
Fix text edit insert tool call instance id

### DIFF
--- a/api/chat.ts
+++ b/api/chat.ts
@@ -792,7 +792,7 @@ export default async function handler(req: Request) {
         },
         textEditSearchReplace: {
           description:
-            "Search and replace text in a specific TextEdit document. You MUST always provide 'search', 'replace', and 'instanceId'. Set 'isRegex: true' ONLY if the user explicitly mentions using a regular expression. Use the instanceId from the system state (e.g., '15') to target a specific window.",
+            "Search and replace text in a specific TextEdit document. You MUST always provide 'search', 'replace', and 'instanceId'. Set 'isRegex: true' ONLY if the user explicitly mentions using a regular expression. Use the instanceId from the system state (e.g., '15') to target a specific window. If you just created a new file with textEditNewFile, use the instanceId from that tool call result.",
           inputSchema: z.object({
             search: z
               .string()
@@ -813,13 +813,13 @@ export default async function handler(req: Request) {
             instanceId: z
               .string()
               .describe(
-                "REQUIRED: The specific TextEdit instance ID to modify (e.g., '15'). Get this from the system state TextEdit Windows list."
+                "REQUIRED: The specific TextEdit instance ID to modify (e.g., '15'). Get this from the system state TextEdit Windows list or from a previous textEditNewFile result."
               ),
           }),
         },
         textEditInsertText: {
           description:
-            "Insert plain text into a specific TextEdit document. You MUST always provide 'text' and 'instanceId'. Appends to the end by default; use position 'start' to prepend. Use the instanceId from the system state (e.g., '15') to target a specific window.",
+            "Insert plain text into a specific TextEdit document. You MUST always provide 'text' and 'instanceId'. Appends to the end by default; use position 'start' to prepend. Use the instanceId from the system state (e.g., '15') to target a specific window. If you just created a new file with textEditNewFile, use the instanceId from that tool call result.",
           inputSchema: z.object({
             text: z.string().describe("REQUIRED: The text to insert"),
             position: z
@@ -831,13 +831,13 @@ export default async function handler(req: Request) {
             instanceId: z
               .string()
               .describe(
-                "REQUIRED: The specific TextEdit instance ID to modify (e.g., '15'). Get this from the system state TextEdit Windows list."
+                "REQUIRED: The specific TextEdit instance ID to modify (e.g., '15'). Get this from the system state TextEdit Windows list or from a previous textEditNewFile result."
               ),
           }),
         },
         textEditNewFile: {
           description:
-            "Create a new blank document in a new TextEdit instance. Use when the user explicitly requests a new or untitled file.",
+            "Create a new blank document in a new TextEdit instance. Use when the user explicitly requests a new or untitled file. The result will include the new instanceId that you MUST use for any subsequent textEditInsertText or textEditSearchReplace calls on this document.",
           inputSchema: z.object({
             title: z
               .string()

--- a/api/utils/aiPrompts.ts
+++ b/api/utils/aiPrompts.ts
@@ -91,6 +91,7 @@ TEXT EDITING:
    • Use 'textEditInsertText' to add plain text. **REQUIRED**: 'text' and 'instanceId'. Optional: 'position' ("start" or "end", default is "end").
    • Use 'textEditNewFile' to create a blank file. TextEdit will launch automatically if not open. Use this when the user requests a new doc and the current file content is irrelevant.
 - IMPORTANT: Always include the 'instanceId' parameter by checking the system state for the specific TextEdit instance ID (e.g., '15', '78', etc.).
+- CRITICAL: When you call 'textEditNewFile', the result will include the new instanceId (e.g., "with instanceId: 123"). You MUST use this exact instanceId for any subsequent textEditInsertText or textEditSearchReplace calls on that new document.
 - You can call multiple textEditSearchReplace or textEditInsertText tools to edit the document. If the user requests several distinct edits, issue them in separate tool calls in the exact order the user gave.
 
 iPOD and MUSIC PLAYBACK:

--- a/src/apps/chats/hooks/useAiChat.ts
+++ b/src/apps/chats/hooks/useAiChat.ts
@@ -550,6 +550,7 @@ export function useAiChat(onPromptSetUsername?: () => void) {
                   Object.keys(textEditState.instances).join(", ") || "none"
                 }.`
               );
+              console.log("[ToolCall] Current TextEdit instances:", textEditState.instances);
               break;
             }
 
@@ -678,6 +679,7 @@ export function useAiChat(onPromptSetUsername?: () => void) {
                   Object.keys(textEditState.instances).join(", ") || "none"
                 }.`
               );
+              console.log("[ToolCall] Current TextEdit instances:", textEditState.instances);
               break;
             }
 
@@ -781,19 +783,19 @@ export function useAiChat(onPromptSetUsername?: () => void) {
               true
             );
 
-            // Wait a bit for the app to initialize
-            await new Promise((resolve) => setTimeout(resolve, 200));
+            // Wait a bit for the app to initialize and TextEdit store to be updated
+            await new Promise((resolve) => setTimeout(resolve, 300));
 
             // Bring the new instance to foreground so user can see it
             appStore.bringInstanceToForeground(instanceId);
 
             const resultMessage = `Created new document${
               title ? ` "${title}"` : ""
-            } (instanceId: ${instanceId})`;
+            } with instanceId: ${instanceId}`;
             console.log(
               `[ToolCall] Created a new, untitled document in TextEdit${
                 title ? ` (${title})` : ""
-              }.`
+              } with instanceId: ${instanceId}.`
             );
 
             // Add tool result back to messages


### PR DESCRIPTION
Ensure `textEditInsertText` uses the correct `instanceId` from `textEditNewFile` results to prevent text from being inserted into the wrong document.

The AI was sometimes using a stale `instanceId` for subsequent text editing operations after creating a new file, leading to incorrect behavior. This PR clarifies AI instructions, improves result message parsing, and adds debugging to ensure the correct `instanceId` is always used.

---
<a href="https://cursor.com/background-agent?bcId=bc-4fc2b834-5551-4aa9-bc0f-bf11306169a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4fc2b834-5551-4aa9-bc0f-bf11306169a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

