### PR TITLE
Debug ipod add song api after sdk upgrade

### DIFF
--- a/api/parse-title.ts
+++ b/api/parse-title.ts
@@ -116,14 +116,22 @@ export default async function handler(req: Request) {
       });
     }
 
-    // Use generateObject from the AI SDK
+    // Use generateObject from the AI SDK v5
     const { object: parsedData } = await generateObject({
       model: openai("gpt-4.1-mini"),
       schema: ParsedTitleSchema, // Provide the Zod schema
-      system: `You are an expert music metadata parser. Given a raw YouTube video title and optionally the channel name, extract the song title and artist. If possible, also extract the album name. Use the channel name as additional context for identifying the artist, especially when the artist name is not clear from the title alone. Respond ONLY with a valid JSON object matching the provided schema. If you cannot determine a field, omit it or set it to null. Prefer Chinese, then English, then Korean, then Japanese, then other languages name. Only include preferred language names and omit names for other languages. Example input: title="NewJeans (뉴진스) 'How Sweet' Official MV", author_name="HYBE LABELS". Example output: {"title": "How Sweet", "artist": "NewJeans"}. Example input: title="Lofi Hip Hop Radio - Beats to Relax/Study to", author_name="ChillHop Music". Example output: {"title": "Lofi Hip Hop Radio - Beats to Relax/Study to", "artist": null}.`,
-      prompt: `Title: ${rawTitle}${
-        author_name ? `\nChannel: ${author_name}` : ""
-      }`,
+      messages: [
+        {
+          role: "system",
+          content: `You are an expert music metadata parser. Given a raw YouTube video title and optionally the channel name, extract the song title and artist. If possible, also extract the album name. Use the channel name as additional context for identifying the artist, especially when the artist name is not clear from the title alone. Respond ONLY with a valid JSON object matching the provided schema. If you cannot determine a field, omit it or set it to null. Prefer Chinese, then English, then Korean, then Japanese, then other languages name. Only include preferred language names and omit names for other languages. Example input: title="NewJeans (뉴진스) 'How Sweet' Official MV", author_name="HYBE LABELS". Example output: {"title": "How Sweet", "artist": "NewJeans"}. Example input: title="Lofi Hip Hop Radio - Beats to Relax/Study to", author_name="ChillHop Music". Example output: {"title": "Lofi Hip Hop Radio - Beats to Relax/Study to", "artist": null}.`,
+        },
+        {
+          role: "user",
+          content: `Title: ${rawTitle}${
+            author_name ? `\nChannel: ${author_name}` : ""
+          }`,
+        },
+      ],
       temperature: 0.2,
     });
 

--- a/api/translate-lyrics.ts
+++ b/api/translate-lyrics.ts
@@ -186,8 +186,16 @@ Do not include timestamps or any other formatting in your output strings; just t
     const { object: aiResponse } = await generateObject({
       model: google("gemini-2.5-flash"),
       schema: AiTranslatedTextsSchema, // Use the new simplified schema for AI output
-      prompt: JSON.stringify(lines.map((line) => ({ words: line.words }))), // Send only words to AI for translation context
-      system: systemPrompt,
+      messages: [
+        {
+          role: "system",
+          content: systemPrompt,
+        },
+        {
+          role: "user",
+          content: JSON.stringify(lines.map((line) => ({ words: line.words }))), // Send only words to AI for translation context
+        },
+      ],
       temperature: 0.3,
     });
 


### PR DESCRIPTION
Update `generateObject` calls in `parse-title.ts` and `translate-lyrics.ts` to use the AI SDK v5 `messages` array format.

AI SDK v5 changed the signature for `generateObject`, requiring `system` and `prompt` content to be passed within a `messages` array, which fixes the iPod add song parse API and translate lyrics API.

---
<a href="https://cursor.com/background-agent?bcId=bc-64599997-2201-4a27-b4f3-e7319ab8b3b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-64599997-2201-4a27-b4f3-e7319ab8b3b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

