### PR TITLE
Fix career page horizontal scroll bug

### DIFF
--- a/src/apps/base/AppManager.tsx
+++ b/src/apps/base/AppManager.tsx
@@ -348,7 +348,7 @@ export function AppManager({ apps }: AppManagerProps) {
           <div
             key={instance.instanceId}
             style={{ zIndex }}
-            className="absolute inset-x-0 md:inset-x-auto w-full md:w-auto"
+            className="absolute inset-x-0 md:inset-x-auto w-full md:w-auto max-w-full"
             onMouseDown={() => {
               if (!instance.isForeground) {
                 bringInstanceToForeground(instance.instanceId);

--- a/src/index.css
+++ b/src/index.css
@@ -143,10 +143,18 @@
     -webkit-user-select: none;
   }
 
+  /* Prevent any element from causing horizontal overflow */
+  #root {
+    width: 100%;
+    max-width: 100vw;
+    overflow-x: hidden;
+  }
+
   .no-touch-callout {
     -webkit-touch-callout: none;
   }
   html {
+    overflow-x: hidden;
     overscroll-behavior: none;
     overscroll-behavior-x: none;
     overscroll-behavior-y: none;
@@ -164,8 +172,10 @@
     -webkit-font-smoothing: none;
     font-smooth: never;
     overflow: hidden;
+    overflow-x: hidden;
     position: fixed;
     inset: 0;
+    width: 100%;
     /* Additional mobile gesture prevention */
     overscroll-behavior: none;
     overscroll-behavior-x: none;


### PR DESCRIPTION
Fixes an extra horizontal scroll bug on the careers page and throughout the ryOS app by adding multi-level `overflow-x` constraints and proper width handling for app containers.

---
[Slack Thread](https://anysphere.slack.com/archives/C09B9GPQCC9/p1762486239503199?thread_ts=1762486239.503199&cid=C09B9GPQCC9)

<a href="https://cursor.com/background-agent?bcId=bc-c1f980a9-3c9b-4d7a-a8cc-5d164be3755b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c1f980a9-3c9b-4d7a-a8cc-5d164be3755b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

