### PR TITLE
Update applet-ai to gpt-5-mini

### DIFF
--- a/api/applet-ai.ts
+++ b/api/applet-ai.ts
@@ -148,7 +148,7 @@ export default async function handler(req: Request): Promise<Response> {
 
   try {
     const { text } = await generateText({
-      model: openai("gpt-5"),
+      model: openai("gpt-5-mini"),
       messages: finalMessages,
       temperature: temperature ?? 0.6,
       maxOutputTokens: 2048,


### PR DESCRIPTION
Update `applet-ai` to use the `gpt-5-mini` model.

---
<a href="https://cursor.com/background-agent?bcId=bc-356aad95-1905-4184-92ad-e5f0c2bda886"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-356aad95-1905-4184-92ad-e5f0c2bda886"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

