### PR TITLE
Switch applet-ai model to gemini 2.5 flash

### DIFF
--- a/api/applet-ai.ts
+++ b/api/applet-ai.ts
@@ -1,5 +1,5 @@
 import { generateText } from "ai";
-import { openai } from "@ai-sdk/openai";
+import { google } from "@ai-sdk/google";
 import { z } from "zod";
 import {
   getEffectiveOrigin,
@@ -148,7 +148,7 @@ export default async function handler(req: Request): Promise<Response> {
 
   try {
     const { text } = await generateText({
-      model: openai("gpt-5-mini"),
+      model: google("gemini-2.5-flash"),
       messages: finalMessages,
       temperature: temperature ?? 0.6,
       maxOutputTokens: 2048,


### PR DESCRIPTION
Swap the Applet AI model back to Gemini 2.5 Flash as requested.

---
<a href="https://cursor.com/background-agent?bcId=bc-29be75ef-c891-43d2-87cb-0bb743fa238d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-29be75ef-c891-43d2-87cb-0bb743fa238d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

