### PR TITLE
Update preload calculator applet id

### DIFF
--- a/public/data/applets.json
+++ b/public/data/applets.json
@@ -25,7 +25,7 @@
       "type": "html",
       "icon": "🧮",
       "status": "active",
-      "shareId": "aefde2d4ded237e1cef2a6de170fa167"
+      "shareId": "7bd837678200f4d81a7b79fcb9093b6a"
     }
   ]
 }


### PR DESCRIPTION
Update the Calculator applet's share ID to load the latest version of the applet content.

---
<a href="https://cursor.com/background-agent?bcId=bc-00791992-678e-4c23-a8af-5916e92a1722"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-00791992-678e-4c23-a8af-5916e92a1722"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

