### PR TITLE
Increase applet ai max output tokens

### DIFF
--- a/api/applet-ai.ts
+++ b/api/applet-ai.ts
@@ -151,7 +151,7 @@ export default async function handler(req: Request): Promise<Response> {
       model: google("gemini-2.5-flash"),
       messages: finalMessages,
       temperature: temperature ?? 0.6,
-      maxOutputTokens: 2048,
+      maxOutputTokens: 4000,
     });
 
     return jsonResponse({ reply: text.trim() }, 200, effectiveOrigin);


### PR DESCRIPTION
Raise the `maxOutputTokens` for applet AI to allow for longer replies.

---
<a href="https://cursor.com/background-agent?bcId=bc-986462a8-e4ad-4168-9df0-f838d1d33cc3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-986462a8-e4ad-4168-9df0-f838d1d33cc3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

