### PR TITLE
Update ai endpoint for streaming image generation

### DIFF
--- a/api/utils/aiPrompts.ts
+++ b/api/utils/aiPrompts.ts
@@ -50,7 +50,9 @@ When asked to make apps, code, websites, or HTML, ALWAYS use the 'generateHtml' 
 - ALWAYS use Tailwindcss classes, not inline or CSS style tags. Use minimal, swiss, small text, neutral grays, in styles ryo would prefer, always use tailwind CSS classes.
 - DO NOT add app headers, navbars, hero sections, or decorative frames – focus purely on the functional UI.
 - Applets run inside small, independent app windows in ryOS (not the browser tab). Design for mobile/small width first but keep layouts fully responsive and fluid up to 100% widths.
-- When the applet needs AI-powered output, send POST requests to "/api/applet-ai" with the header "Content-Type: application/json" and a body such as {"prompt":"..."} or {"messages":[{"role":"user","content":"..."}],"context":"..."}. The API responds with {"reply":"..."} using Gemini 2.5 Flash.
+- When the applet needs AI-powered output, send POST requests to "/api/applet-ai" with the header "Content-Type: application/json".
+  - For text replies, use a body such as {"prompt":"..."} or {"messages":[{"role":"user","content":"..."}],"context":"..."}; the API responds with {"reply":"..."} using Gemini 2.5 Flash.
+  - For image generation, send {"mode":"image","prompt":"..."} (context is optional). The API streams back the generated image bytes with the appropriate Content-Type header—pipe the response into a Blob or Object URL instead of saving to disk.
 - Always show a visible loading state while waiting for /api/applet-ai and handle non-OK or network errors gracefully with a friendly inline message and retry button.
 - Default to simple, minimal layouts that feel mobile-first and touch-friendly with tight, readable spacing.
 - DO NOT include headers, background panels, extra containers, borders, or padding around the main app content. The applet code should only include the app's inner contents – the system will provide the window frame and outer container.

--- a/src/apps/applet-viewer/index.ts
+++ b/src/apps/applet-viewer/index.ts
@@ -17,7 +17,7 @@ export const helpItems = [
     icon: "🤖",
     title: "Built-in AI",
     description:
-      "Inside your applet, call fetch('/api/applet-ai') with JSON { prompt: \"...\" } to get Gemini 2.5 Flash replies.",
+      "Inside your applet, call fetch('/api/applet-ai') with JSON { prompt: \"...\" } for Gemini text or { mode: \"image\", prompt: \"...\" } to stream Gemini image previews.",
   },
   {
     icon: "📂",


### PR DESCRIPTION
Add image generation capability to the `/api/applet-ai` endpoint to allow applets to stream AI-generated images.

---
<a href="https://cursor.com/background-agent?bcId=bc-0ec246bf-bb29-45ff-8399-6dcc36dcf512"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0ec246bf-bb29-45ff-8399-6dcc36dcf512"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

