### PR TITLE
Debug image attachment api call

### DIFF
--- a/api/applet-ai.ts
+++ b/api/applet-ai.ts
@@ -151,24 +151,20 @@ const decodeBase64ToBinaryString = (value: string): string => {
   }).atob;
 
   if (typeof atobFn === "function") {
-    return Reflect.apply(atobFn, globalThis, [value]);
+    return atobFn(value);
   }
 
-  const globalBuffer = (globalThis as Record<string, unknown> & {
+  const { Buffer } = globalThis as Record<string, unknown> & {
     Buffer?: {
       from(
         data: string,
         encoding: string
       ): { toString(encoding: string): string };
     };
-  }).Buffer;
+  };
 
-  if (globalBuffer && typeof globalBuffer.from === "function") {
-    const bufferResult = Reflect.apply(globalBuffer.from, globalBuffer, [
-      value,
-      "base64",
-    ]);
-    return bufferResult.toString("binary");
+  if (Buffer && typeof Buffer.from === "function") {
+    return Buffer.from(value, "base64").toString("binary");
   }
 
   throw new Error("Base64 decoding is not supported in this environment.");


### PR DESCRIPTION
Fix "Illegal invocation" errors when decoding base64 image payloads.

This change removes `Reflect.apply` when calling `atob` and `Buffer.from` for base64 decoding, which was causing "Illegal invocation" errors in Edge environments.

---
<a href="https://cursor.com/background-agent?bcId=bc-74c947a3-ebc4-42be-9f14-a56b7b821616"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-74c947a3-ebc4-42be-9f14-a56b7b821616"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

