### PR TITLE
Debug shared applet tool not returning existing applet

### DIFF
--- a/src/apps/chats/hooks/useAiChat.ts
+++ b/src/apps/chats/hooks/useAiChat.ts
@@ -1655,6 +1655,7 @@ export function useAiChat(onPromptSetUsername?: () => void) {
                             limitedApplets.length === 1 ? "" : "s"
                           }.`;
                   result = summaryMessage;
+                }
               } catch (err) {
                 console.error("listSharedApplets error:", err);
                 addToolResult({


### PR DESCRIPTION
Update `listSharedApplets` tool to return the full formatted list of applets.

Previously, the tool returned a generic status like "Listed X applets", which caused the AI assistant to hallucinate and generate follow-up text instead of recognizing existing applet names. Returning the actual list allows the assistant to correctly process the tool's output.

---
<a href="https://cursor.com/background-agent?bcId=bc-72241c23-5e0b-467c-8364-35e7970d3978"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-72241c23-5e0b-467c-8364-35e7970d3978"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

