### PR TITLE
Remove searchSharedApplets and use listSharedApplets

### DIFF
--- a/api/chat.ts
+++ b/api/chat.ts
@@ -984,9 +984,9 @@ export default async function handler(req: Request) {
               ),
           }),
         },
-          searchSharedApplets: {
+          listSharedApplets: {
             description:
-              "Search shared applets that are published to the Applet Store but may not be installed locally. Use this to discover reusable applets before generating new code.",
+              "List shared applets that are published to the Applet Store but may not be installed locally. Use this to discover reusable applets before generating new code.",
             inputSchema: z.object({
               query: z
                 .string()
@@ -1009,25 +1009,25 @@ export default async function handler(req: Request) {
           },
           fetchSharedApplet: {
             description:
-              "Fetch the HTML content and metadata for a shared applet by id (returned from searchSharedApplets). Use to inspect or reuse an existing shared applet.",
+              "Fetch the HTML content and metadata for a shared applet by id (returned from listSharedApplets). Use to inspect or reuse an existing shared applet.",
             inputSchema: z.object({
               id: z
                 .string()
                 .min(1)
                 .describe(
-                  "The shared applet id returned from searchSharedApplets."
+                  "The shared applet id returned from listSharedApplets."
                 ),
             }),
           },
           openSharedApplet: {
             description:
-              "Open the Applet Viewer detail view for a shared applet so the user can preview or install it. Provide the id from searchSharedApplets.",
+              "Open the Applet Viewer detail view for a shared applet so the user can preview or install it. Provide the id from listSharedApplets.",
             inputSchema: z.object({
               id: z
                 .string()
                 .min(1)
                 .describe(
-                  "The shared applet id returned from searchSharedApplets."
+                  "The shared applet id returned from listSharedApplets."
                 ),
             }),
           },

--- a/api/utils/aiPrompts.ts
+++ b/api/utils/aiPrompts.ts
@@ -49,7 +49,7 @@ When asked to make apps, code, websites, or HTML, ALWAYS use the 'generateHtml' 
 - BEFORE calling generateHtml for a new request, ALWAYS explore existing applets first:
   • Call listFiles({ directory: "/Applets" }) to enumerate what's already installed locally.
   • If any existing applet already solves or partially solves the user's request, prefer opening, reusing, or iterating on it instead of starting from scratch.
-  • When local applets are insufficient, call searchSharedApplets to review the shared Applet Store before generating something entirely new.
+  • When local applets are insufficient, call listSharedApplets to review the shared Applet Store before generating something entirely new.
   • For every promising match, call fetchSharedApplet (and openSharedApplet when helpful) to read through the existing HTML, design patterns, and interactions—borrow and adapt what works before writing brand-new structures.
 - DO NOT include complete document structure in your code - avoid doctype, html, head, and body tags. Just provide the actual content. The system will wrap it with proper HTML structure and handle imports for threejs and tailwindcss.
 - ALWAYS use Tailwindcss classes, not inline or CSS style tags. Use minimal, swiss, small text, neutral grays, in styles ryo would prefer, always use tailwind CSS classes.
@@ -161,9 +161,9 @@ FILE MANAGEMENT:
 - Items in /Applications are installed system applications that can be launched.
 
 SHARED APPLET STORE:
-- Use 'searchSharedApplets' to browse applets that are published but not necessarily installed locally. Optional 'query' filters by title, name, or creator. Always review the returned list instead of guessing what exists.
-- Use 'fetchSharedApplet' to download the full HTML and metadata for a shared applet by its id (returned from searchSharedApplets). Read and study the markup, layout, and interaction patterns; reuse or adapt the ideas before generating brand-new code.
-- Use 'openSharedApplet' to launch the Applet Viewer detail page for a shared applet so the user can preview or install it. Provide the exact id from searchSharedApplets.
+- Use 'listSharedApplets' to browse applets that are published but not necessarily installed locally. Optional 'query' filters by title, name, or creator. Always review the returned list instead of guessing what exists.
+- Use 'fetchSharedApplet' to download the full HTML and metadata for a shared applet by its id (returned from listSharedApplets). Read and study the markup, layout, and interaction patterns; reuse or adapt the ideas before generating brand-new code.
+- Use 'openSharedApplet' to launch the Applet Viewer detail page for a shared applet so the user can preview or install it. Provide the exact id from listSharedApplets.
 - When planning a new applet, prefer reusing or adapting shared applets when possible instead of generating from scratch.
 
 </tool_usage_instructions>

--- a/src/apps/chats/hooks/useAiChat.ts
+++ b/src/apps/chats/hooks/useAiChat.ts
@@ -1469,7 +1469,6 @@ export function useAiChat(onPromptSetUsername?: () => void) {
               }
               break;
             }
-            case "searchSharedApplets":
             case "listSharedApplets": {
               const {
                 listAll = true,
@@ -1665,7 +1664,7 @@ export function useAiChat(onPromptSetUsername?: () => void) {
                   errorText:
                     err instanceof Error
                       ? err.message
-                      : "Failed to search shared applets",
+                      : "Failed to list shared applets",
                 });
                 result = ""; // Clear result to prevent duplicate
               }

--- a/src/components/shared/ToolInvocationMessage.tsx
+++ b/src/components/shared/ToolInvocationMessage.tsx
@@ -59,14 +59,10 @@ export function ToolInvocationMessage({
   let displayResultMessage: string | null = null;
 
   // Handle loading states (input-streaming or input-available without output)
-  if (
-    state === "input-streaming" ||
-    (state === "input-available" && !output)
-  ) {
+  if (state === "input-streaming" || (state === "input-available" && !output)) {
     switch (toolName) {
-      case "searchSharedApplets":
       case "listSharedApplets":
-        displayCallMessage = "Searching shared applets…";
+        displayCallMessage = "Listing shared applets…";
         break;
       case "textEditSearchReplace":
         displayCallMessage = "Replacing text…";
@@ -202,10 +198,7 @@ export function ToolInvocationMessage({
           displayResultMessage = "Listed files";
         }
       }
-    } else if (
-      toolName === "searchSharedApplets" ||
-      toolName === "listSharedApplets"
-    ) {
+    } else if (toolName === "listSharedApplets") {
       if (typeof output === "string") {
         if (output.includes("No shared applets matched")) {
           displayResultMessage = "No shared applets matched";
@@ -231,9 +224,7 @@ export function ToolInvocationMessage({
         const match = output.match(/Found (\d+) songs?/);
         if (match) {
           const count = parseInt(match[1], 10);
-          displayResultMessage = `Found ${count} song${
-            count === 1 ? "" : "s"
-          }`;
+          displayResultMessage = `Found ${count} song${count === 1 ? "" : "s"}`;
         } else if (output.includes("iPod library is empty")) {
           displayResultMessage = "iPod library is empty";
         } else {
@@ -244,7 +235,9 @@ export function ToolInvocationMessage({
       // Extract file name from output message
       if (typeof output === "string") {
         const appletMatch = output.match(/Successfully opened applet: (.+)/);
-        const documentMatch = output.match(/Successfully opened document: (.+)/);
+        const documentMatch = output.match(
+          /Successfully opened document: (.+)/,
+        );
         const applicationMatch = output.match(
           /Successfully launched application: (.+)/,
         );
@@ -310,7 +303,7 @@ export function ToolInvocationMessage({
     const htmlContent = typeof input?.html === "string" ? input.html : "";
     const appletTitle = typeof input?.title === "string" ? input.title : "";
     const appletIcon = typeof input?.icon === "string" ? input.icon : "";
-    
+
     if (state === "input-streaming") {
       // Show HTML preview with streaming if HTML content is available
       if (htmlContent) {


### PR DESCRIPTION
Rename `searchSharedApplets` to `listSharedApplets` and update all references to better reflect its functionality as a listing tool.

---
<a href="https://cursor.com/background-agent?bcId=bc-11db5f34-7fa0-4002-bc34-dfee0046f394"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-11db5f34-7fa0-4002-bc34-dfee0046f394"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

