### PR TITLE
Refactor fetch tool call rendering logic

### DIFF
--- a/src/components/shared/ToolInvocationMessage.tsx
+++ b/src/components/shared/ToolInvocationMessage.tsx
@@ -422,7 +422,7 @@ export function ToolInvocationMessage({
             <span>{displayResultMessage}</span>
           ) : (
             <div className="flex flex-col">
-              {typeof output === "string" && output.length > 0 && toolName !== "fetchSharedApplet" ? (
+              {typeof output === "string" && output.length > 0 ? (
                 <span className="text-gray-500">{output}</span>
               ) : (
                 <span>{formatToolName(toolName)}</span>


### PR DESCRIPTION
Remove the conditional rendering check for `fetchSharedApplet` to align its output display logic with other tools like `readFile`.

The `fetchSharedApplet` tool already correctly sets its `displayResultMessage` property, making the explicit `toolName !== "fetchSharedApplet"` exclusion redundant and inconsistent with how other tools (e.g., `readFile`) handle output in the "output-available" state. This change simplifies the rendering logic and ensures consistent behavior.

---
<a href="https://cursor.com/background-agent?bcId=bc-732021c6-a36b-43f9-8bae-23e3a6cbffa0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-732021c6-a36b-43f9-8bae-23e3a6cbffa0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

