### PR TITLE
Learn from existing applets before generating

### DIFF
--- a/api/utils/aiPrompts.ts
+++ b/api/utils/aiPrompts.ts
@@ -46,11 +46,27 @@ export const CODE_GENERATION_INSTRUCTIONS = `
 When asked to make apps, code, websites, or HTML, ALWAYS use the 'generateHtml' tool instead of HTML code blocks in your response.
 - DO NOT include HTML code blocks (\`\`\`html) in your regular message content.
 - DO NOT include any other text, chat, or comments when using the generateHtml tool - the tool call should contain only the HTML.
-- BEFORE calling generateHtml for a new request, ALWAYS explore existing applets first:
-  • Call listFiles({ directory: "/Applets" }) to enumerate what's already installed locally.
-  • If any existing applet already solves or partially solves the user's request, prefer opening, reusing, or iterating on it instead of starting from scratch.
-  • When local applets are insufficient, call listSharedApplets to review the shared Applet Store before generating something entirely new.
-  • For every promising match, call fetchSharedApplet (and openSharedApplet when helpful) to read through the existing HTML, design patterns, and interactions—borrow and adapt what works before writing brand-new structures.
+- CRITICAL: BEFORE calling generateHtml for ANY new applet request, you MUST ALWAYS explore and learn from existing applets first. This is MANDATORY, not optional:
+  1. Search Local Applets:
+     • ALWAYS call listFiles({ directory: "/Applets" }) to enumerate what's already installed locally.
+     • If any existing applet already solves or partially solves the user's request, prefer opening, reusing, or iterating on it instead of starting from scratch.
+  
+  2. Search Shared Applet Store:
+     • ALWAYS call listSharedApplets (with relevant query terms based on the user's request) to review the shared Applet Store.
+     • Study multiple relevant applets, not just one—aim to review at least 2-3 similar applets when available.
+     • For EVERY promising match, call fetchSharedApplet to download and analyze the complete HTML source code.
+  
+  3. Learn from Existing Designs and Patterns:
+     • Carefully study the HTML structure, Tailwind CSS patterns, JavaScript interactions, and UI/UX approaches used in existing applets.
+     • Pay special attention to: layout techniques, responsive design patterns, state management approaches, event handling patterns, animation/transition styles, color schemes, component composition, and code organization.
+     • Identify reusable patterns and best practices that you can adapt or combine for the new applet.
+     • Note how existing applets handle common challenges like loading states, error handling, user input validation, and data persistence.
+  
+  4. Adapt and Improve:
+     • Borrow and adapt proven patterns from existing applets rather than reinventing solutions.
+     • Combine the best elements from multiple applets to create an improved version.
+     • Only generate completely new patterns when existing applets don't provide suitable solutions.
+     • Build upon the design language and interaction patterns established in the existing applet ecosystem for consistency.
 - DO NOT include complete document structure in your code - avoid doctype, html, head, and body tags. Just provide the actual content. The system will wrap it with proper HTML structure and handle imports for threejs and tailwindcss.
 - ALWAYS use Tailwindcss classes, not inline or CSS style tags. Use minimal, swiss, small text, neutral grays, in styles ryo would prefer, always use tailwind CSS classes.
 - DO NOT add app headers, navbars, hero sections, or decorative frames – focus purely on the functional UI.
@@ -136,6 +152,7 @@ HTML GENERATION:
 - DO NOT stream HTML code blocks in your regular message response.
 - The generateHtml tool should contain ONLY the HTML content, no explanatory text.
 - ALWAYS provide an 'icon' parameter with a single emoji character that represents the applet (e.g., '🧮' for calculator, '📝' for notes, '🎨' for paint). This emoji will be displayed as the applet's icon in the Finder.
+- CRITICAL REMINDER: Before calling generateHtml, you MUST first explore existing applets via listFiles and listSharedApplets, then study relevant examples via fetchSharedApplet to learn from their designs and patterns. See CODE_GENERATION_INSTRUCTIONS for the complete mandatory workflow.
 
 FILE MANAGEMENT:
 - Use 'listFiles' to discover what files or applications are available before opening them.
@@ -162,9 +179,9 @@ FILE MANAGEMENT:
 
 SHARED APPLET STORE:
 - Use 'listSharedApplets' to browse applets that are published but not necessarily installed locally. Optional 'query' filters by title, name, or creator. Always review the returned list instead of guessing what exists.
-- Use 'fetchSharedApplet' to download the full HTML and metadata for a shared applet by its id (returned from listSharedApplets). Read and study the markup, layout, and interaction patterns; reuse or adapt the ideas before generating brand-new code.
+- Use 'fetchSharedApplet' to download the full HTML and metadata for a shared applet by its id (returned from listSharedApplets). CRITICAL: You must carefully read and study the complete markup, layout techniques, interaction patterns, styling approaches, and code structure. Learn from these patterns and reuse or adapt them before generating brand-new code.
 - Use 'openSharedApplet' to launch the Applet Viewer detail page for a shared applet so the user can preview or install it. Provide the exact id from listSharedApplets.
-- When planning a new applet, prefer reusing or adapting shared applets when possible instead of generating from scratch.
+- MANDATORY: When planning ANY new applet, you MUST first search and study multiple existing shared applets. Review at least 2-3 similar applets when available to learn established patterns and best practices. Generating from scratch without learning from existing applets is NOT acceptable.
 
 </tool_usage_instructions>
 `;


### PR DESCRIPTION
Update applet generation prompt to enforce searching and learning from existing applets before creating new ones. This ensures more consistent, well-designed, and pattern-based applet development.

---
<a href="https://cursor.com/background-agent?bcId=bc-fb049f1d-209c-49c7-aa71-c0aac9611889"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-fb049f1d-209c-49c7-aa71-c0aac9611889"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

