### PR TITLE
Handle window focus for applet previews

### DIFF
--- a/src/apps/applet-viewer/components/AppStore.tsx
+++ b/src/apps/applet-viewer/components/AppStore.tsx
@@ -164,6 +164,14 @@ export function AppStore({ theme, sharedAppletId }: AppStoreProps) {
     }
   };
 
+  const handlePreviewClick = async (applet: Applet) => {
+    const installed = actions.isAppletInstalled(applet.id);
+    if (installed) {
+      // If installed, bring window to foreground
+      await handleAppletClick(applet);
+    }
+  };
+
   const handleInstall = async (applet: Applet) => {
     await actions.handleInstall(applet, async () => {
       await fetchApplets();
@@ -488,7 +496,15 @@ export function AppStore({ theme, sharedAppletId }: AppStoreProps) {
               Get
             </Button>
           </div>
-          <div className="flex-1 overflow-hidden bg-white">
+          <div 
+            className="flex-1 overflow-hidden bg-white"
+            onClick={() => {
+              // Only handle click for installed applets to bring window to foreground
+              if (selectedApplet) {
+                handlePreviewClick(selectedApplet);
+              }
+            }}
+          >
             {selectedAppletContent ? (
               <iframe
                 srcDoc={ensureMacFonts(selectedAppletContent)}

--- a/src/apps/applet-viewer/components/AppStoreFeed.tsx
+++ b/src/apps/applet-viewer/components/AppStoreFeed.tsx
@@ -303,6 +303,14 @@ export const AppStoreFeed = forwardRef<AppStoreFeedRef, AppStoreFeedProps>(
     }
   };
 
+  const handlePreviewClick = async (applet: Applet) => {
+    const installed = actions.isAppletInstalled(applet.id);
+    if (installed) {
+      // If installed, bring window to foreground
+      await handleAppletClick(applet);
+    }
+  };
+
   if (isLoading) {
     return (
       <div className="h-full w-full flex items-center justify-center">
@@ -345,6 +353,12 @@ export const AppStoreFeed = forwardRef<AppStoreFeedRef, AppStoreFeedProps>(
         <div 
           className="absolute inset-0" 
           style={{ paddingTop: "45px" }}
+          onClick={() => {
+            // Only handle click for installed applets to bring window to foreground
+            if (index === currentIndex) {
+              handlePreviewClick(applet);
+            }
+          }}
           onWheel={(e) => {
             // Only handle wheel for the current applet
             if (index !== currentIndex) return;


### PR DESCRIPTION
Add click handlers to applet detail previews to bring installed applet windows to the foreground upon tap.

Previously, only clicking the "Open" button would focus an installed applet's window. This change allows users to tap anywhere on an installed applet's preview to bring its window to the foreground, providing a more intuitive interaction similar to desktop icons.

---
<a href="https://cursor.com/background-agent?bcId=bc-8de8c8b8-98f7-4e05-af45-43288d866e9f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8de8c8b8-98f7-4e05-af45-43288d866e9f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

