### PR TITLE
Update sonner toasts for ios safe area

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -61,7 +61,7 @@ export function App() {
       <AppManager apps={apps} />
       <Toaster
         position="bottom-left"
-        offset={`calc(env(safe-area-inset-bottom, 0px) + 32px)`}
+        offset="32px"
       />
     </>
   );

--- a/src/styles/themes.css
+++ b/src/styles/themes.css
@@ -1515,6 +1515,8 @@
   font-family: var(--os-font-ui) !important;
   -webkit-font-smoothing: antialiased !important;
   font-smooth: auto !important;
+  /* iOS safe area support - add bottom padding for safe area */
+  padding-bottom: env(safe-area-inset-bottom, 0px) !important;
 }
 
 /* System 7: use Geneva-12 for toasts */


### PR DESCRIPTION
Update Sonner toasts to correctly respect iOS safe area insets at the bottom.

The previous `offset` calculation was simplified, and `padding-bottom` with `env(safe-area-inset-bottom)` was added to the `.toaster` class. This ensures toasts are always visible above the iOS home indicator and other safe area elements, while maintaining a 32px offset on other platforms.

---
<a href="https://cursor.com/background-agent?bcId=bc-bdbf8339-bbeb-4629-b1d7-af5ed5cad761"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-bdbf8339-bbeb-4629-b1d7-af5ed5cad761"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

