### PR TITLE
Update sonner toasts for ios safe area

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -61,7 +61,10 @@ export function App() {
       <AppManager apps={apps} />
       <Toaster
         position="bottom-left"
-        offset={`calc(env(safe-area-inset-bottom, 0px) + 32px)`}
+        offset={{
+          left: 32,
+          bottom: "calc(env(safe-area-inset-bottom, 0px) + 32px)",
+        }}
       />
     </>
   );


### PR DESCRIPTION
Update Sonner toasts to correctly apply iOS safe area offset at the bottom while maintaining the left margin.

---
<a href="https://cursor.com/background-agent?bcId=bc-9b8e6b6c-ac66-4c17-b139-9e696e091b71"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9b8e6b6c-ac66-4c17-b139-9e696e091b71"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

