### PR TITLE
Update sonner toasts for ios safe area

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -61,7 +61,7 @@ export function App() {
       <AppManager apps={apps} />
       <Toaster
         position="bottom-left"
-        offset={`calc(env(safe-area-inset-bottom, 0px) + 32px)`}
+        offset="32px"
       />
     </>
   );

--- a/src/styles/themes.css
+++ b/src/styles/themes.css
@@ -1515,7 +1515,7 @@
   font-family: var(--os-font-ui) !important;
   -webkit-font-smoothing: antialiased !important;
   font-smooth: auto !important;
-  padding-bottom: env(safe-area-inset-bottom, 0px) !important;
+  padding-bottom: calc(env(safe-area-inset-bottom, 0px) + 32px) !important;
 }
 
 /* System 7: use Geneva-12 for toasts */

--- a/src/styles/themes.css
+++ b/src/styles/themes.css
@@ -1515,6 +1515,7 @@
   font-family: var(--os-font-ui) !important;
   -webkit-font-smoothing: antialiased !important;
   font-smooth: auto !important;
+  padding-bottom: env(safe-area-inset-bottom, 0px) !important;
 }
 
 /* System 7: use Geneva-12 for toasts */


### PR DESCRIPTION
Update Sonner toasts to respect the iOS safe area bottom inset.

Toasts were appearing under the iOS home indicator; this change adds CSS padding to the toaster container using `env(safe-area-inset-bottom)` and adjusts the `offset` prop in `App.tsx` as it's no longer needed for safe area positioning.

---
<a href="https://cursor.com/background-agent?bcId=bc-91420688-6164-4b45-845a-6c0e830c5b85"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-91420688-6164-4b45-845a-6c0e830c5b85"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

