### PR TITLE
New Cloud Agent

### DIFF
--- a/api/audio-transcribe.ts
+++ b/api/audio-transcribe.ts
@@ -1,5 +1,5 @@
 import OpenAI from "openai";
-import * as RateLimit from "./utils/rate-limit";
+import * as RateLimit from "./utils/rate-limit.js";
 import { getEffectiveOrigin, isAllowedOrigin, preflightIfNeeded } from "./utils/cors.js";
 
 interface OpenAIError {

--- a/api/chat.ts
+++ b/api/chat.ts
@@ -9,7 +9,7 @@ import {
   SupportedModel,
   DEFAULT_MODEL,
   getModelInstance,
-} from "./utils/aiModels";
+} from "./utils/aiModels.js";
 import {
   CORE_PRIORITY_INSTRUCTIONS,
   RYO_PERSONA_INSTRUCTIONS,
@@ -18,15 +18,15 @@ import {
   CHAT_INSTRUCTIONS,
   TOOL_USAGE_INSTRUCTIONS,
   DELIVERABLE_REQUIREMENTS,
-} from "./utils/aiPrompts";
+} from "./utils/aiPrompts.js";
 import { z } from "zod";
-import { SUPPORTED_AI_MODELS } from "../src/types/aiModels";
-import { appIds } from "../src/config/appIds";
-import type { OsThemeId } from "../src/themes/types";
+import { SUPPORTED_AI_MODELS } from "../src/types/aiModels.js";
+import { appIds } from "../src/config/appIds.js";
+import type { OsThemeId } from "../src/themes/types.js";
 import {
   checkAndIncrementAIMessageCount,
   AI_LIMIT_PER_5_HOURS,
-} from "./utils/rate-limit";
+  } from "./utils/rate-limit.js";
 import { Redis } from "@upstash/redis";
 
 // Central list of supported theme IDs for tool validation

--- a/api/iframe-check.ts
+++ b/api/iframe-check.ts
@@ -1,14 +1,14 @@
 // No Next.js types needed – omit unused import to keep file framework‑agnostic.
 
 import { Redis } from "@upstash/redis"; // Use direct import
-import * as RateLimit from "./utils/rate-limit";
+import * as RateLimit from "./utils/rate-limit.js";
 import { getEffectiveOrigin, isAllowedOrigin } from "./utils/cors.js";
 
 export const config = {
   runtime: "edge",
 };
 
-import { normalizeUrlForCacheKey } from "./utils/url"; // Import the function
+import { normalizeUrlForCacheKey } from "./utils/url.js"; // Import the function
 
 // --- Logging Utilities ---------------------------------------------------
 

--- a/api/link-preview.ts
+++ b/api/link-preview.ts
@@ -2,7 +2,7 @@ export const config = {
   runtime: "edge",
 };
 
-import * as RateLimit from "./utils/rate-limit";
+import * as RateLimit from "./utils/rate-limit.js";
 import { getEffectiveOrigin, isAllowedOrigin, preflightIfNeeded } from "./utils/cors.js";
 interface LinkMetadata {
   title?: string;

--- a/api/parse-title.ts
+++ b/api/parse-title.ts
@@ -1,7 +1,7 @@
 import { openai } from "@ai-sdk/openai";
 import { generateObject } from "ai";
 import { z } from "zod";
-import * as RateLimit from "./utils/rate-limit";
+import * as RateLimit from "./utils/rate-limit.js";
 import {
   getEffectiveOrigin,
   isAllowedOrigin,

--- a/api/speech.ts
+++ b/api/speech.ts
@@ -1,7 +1,7 @@
 import { experimental_generateSpeech as generateSpeech } from "ai";
 import { openai } from "@ai-sdk/openai";
 import { getEffectiveOrigin, isAllowedOrigin, preflightIfNeeded } from "./utils/cors.js";
-import * as RateLimit from "./utils/rate-limit";
+import * as RateLimit from "./utils/rate-limit.js";
 import { Redis } from "@upstash/redis";
 
 // --- Default Configuration -----------------------------------------------
@@ -351,7 +351,7 @@ export default async function handler(req: Request) {
       });
 
       audioData = audio.uint8Array.buffer;
-      mimeType = audio.mimeType ?? "audio/mpeg";
+      mimeType = audio.mediaType ?? "audio/mpeg";
       logInfo(requestId, "OpenAI speech generated", {
         bytes: audioData.byteLength,
         voice: openaiVoice,

--- a/api/utils/aiModels.ts
+++ b/api/utils/aiModels.ts
@@ -5,7 +5,7 @@ import { LanguageModelV2 } from "@ai-sdk/provider";
 import {
   SupportedModel as ImportedSupportedModel,
   DEFAULT_AI_MODEL,
-} from "../../src/types/aiModels";
+} from "../../src/types/aiModels.js";
 
 // Re-export the type
 export type SupportedModel = ImportedSupportedModel;


### PR DESCRIPTION
Fixes Vercel build errors by adding explicit `.js` extensions to relative imports and correcting a property name in OpenAI speech generation.

The build was failing with `TS2835` errors due to missing `.js` extensions in relative import paths, required when `moduleResolution` is `node16` or `nodenext`. Additionally, `api/speech.ts` had a `TS2339` error because it was using `mimeType` instead of `mediaType` for the `GeneratedAudioFile` type from the AI SDK.

---
<a href="https://cursor.com/background-agent?bcId=bc-97da5349-5339-4e39-93a2-6023ab8028b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-97da5349-5339-4e39-93a2-6023ab8028b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

