### PR TITLE
Fix html preview spacing issue

### DIFF
--- a/src/apps/applet-viewer/components/AppletViewerAppComponent.tsx
+++ b/src/apps/applet-viewer/components/AppletViewerAppComponent.tsx
@@ -550,8 +550,8 @@ export function AppletViewerAppComponent({
     // Ensure fonts.css is available and prefer Lucida Grande
     const preload = `<link rel="stylesheet" href="/fonts/fonts.css">`;
     const fontStyle = `<style data-ryos-applet-font-fix>
-      html,body{font-family:"LucidaGrande","Lucida Grande",-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,"Apple Color Emoji","Noto Color Emoji",sans-serif!important}
-      *{font-family:inherit!important}
+      html,body{margin:0;padding:0;font-family:"LucidaGrande","Lucida Grande",-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,"Apple Color Emoji","Noto Color Emoji",sans-serif!important}
+      *{font-family:inherit!important;box-sizing:border-box}
       h1,h2,h3,h4,h5,h6,p,div,span,a,li,ul,ol,button,input,select,textarea,label,code,pre,blockquote,small,strong,em,table,th,td{font-family:"LucidaGrande","Lucida Grande",-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,"Apple Color Emoji","Noto Color Emoji",sans-serif!important}
     </style>`;
 
@@ -1324,6 +1324,7 @@ export function AppletViewerAppComponent({
                   sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-popups-to-escape-sandbox allow-top-navigation allow-modals allow-pointer-lock allow-downloads allow-storage-access-by-user-activation"
                   style={{
                     display: "block",
+                    verticalAlign: "top",
                   }}
                   onLoad={() =>
                     sendAuthPayload(iframeRef.current?.contentWindow || null)

--- a/src/components/shared/HtmlPreview.tsx
+++ b/src/components/shared/HtmlPreview.tsx
@@ -434,6 +434,7 @@ export default function HtmlPreview({
     }
     html, body {
       margin: 0;
+      padding: 0;
       overflow-x: auto; /* Allow horizontal scroll if content overflows */
       width: 100%;
       height: 100%;
@@ -1336,6 +1337,7 @@ export default function HtmlPreview({
                 ? minHeight
                 : `${minHeight}px`,
               display: "block",
+              verticalAlign: "top",
               // pointerEvents: isStreaming ? "none" : "auto", // Already handled by parent div conditional
               position: "relative",
               zIndex: 1,
@@ -1480,6 +1482,8 @@ export default function HtmlPreview({
                         }
                         style={{
                           pointerEvents: isDragging ? "none" : "auto",
+                          display: "block",
+                          verticalAlign: "top",
                           ...(isInternetExplorer && {
                             position: "absolute",
                             inset: 0,


### PR DESCRIPTION
Removes an extra 1px space in HTML previews by resetting default body padding, ensuring consistent box-sizing, and adjusting iframe vertical alignment.

---
<a href="https://cursor.com/background-agent?bcId=bc-864c8246-d499-4284-ae80-d4c952375343"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-864c8246-d499-4284-ae80-d4c952375343"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

