### PR TITLE
Fix desktop shortcut icon refresh on load

### DIFF
--- a/src/components/layout/Desktop.tsx
+++ b/src/components/layout/Desktop.tsx
@@ -503,121 +503,13 @@ export function Desktop({
         )
       : sortedApps;
 
-  // Create default shortcuts based on theme
+  // Theme change handling - update desktop shortcuts visibility based on theme
   useEffect(() => {
-    // Ensure apps are loaded and Desktop folder exists
-    if (!apps || apps.length === 0) return;
-    
-    const desktopFolder = fileStore.getItem("/Desktop");
-    if (!desktopFolder || !desktopFolder.isDirectory) {
-      // Desktop folder doesn't exist yet, wait for it to be initialized
-      return;
-    }
-
-    // Get current desktop shortcuts (active) and trashed items
-    const desktopItems = fileStore.getItemsInPath("/Desktop");
-    const trashedItems = fileStore.getTrashItems();
-    
-    // Define the default order for desktop shortcuts
-    const defaultOrder: AppId[] = [
-      "ipod",
-      "chats",
-      "applet-viewer",
-      "internet-explorer",
-      "textedit",
-      "photo-booth",
-      "videos",
-      "paint",
-      "soundboard",
-      "minesweeper",
-      "synth",
-      "terminal",
-      "pc",
-    ];
-
-    // Determine which apps should have shortcuts based on theme
-    let appsToShortcut: typeof apps;
-    if (currentTheme === "macosx") {
-      // macOS X: only iPod and Applet Store (applet-viewer) as default shortcuts
-      appsToShortcut = apps.filter(
-        (app) => app.id === "ipod" || app.id === "applet-viewer"
-      );
-    } else {
-      // Other themes: all apps except Finder and Control Panels
-      appsToShortcut = apps.filter(
-        (app) => app.id !== "finder" && app.id !== "control-panels"
-      );
-    }
-
-    // Sort apps according to default order, then alphabetically for any not in the list
-    const sortedAppsToShortcut = [...appsToShortcut].sort((a, b) => {
-      const aIndex = defaultOrder.indexOf(a.id as AppId);
-      const bIndex = defaultOrder.indexOf(b.id as AppId);
-      
-      // If both are in the order list, sort by their position
-      if (aIndex !== -1 && bIndex !== -1) {
-        return aIndex - bIndex;
-      }
-      // If only one is in the list, prioritize it
-      if (aIndex !== -1) return -1;
-      if (bIndex !== -1) return 1;
-      // If neither is in the list, sort alphabetically
-      return a.name.localeCompare(b.name);
-    });
-
-    // Create shortcuts for apps that don't have them yet, in the specified order.
-    // We consider both active and previously trashed shortcuts so that if the
-    // user deletes a default icon, it is not auto-added back on theme changes.
-    sortedAppsToShortcut.forEach((app) => {
-      const appId = app.id as AppId;
-
-      const hasActiveShortcut = desktopItems.some(
-        (item) => item.aliasType === "app" && item.aliasTarget === appId
-      );
-
-      const hasTrashedShortcut = trashedItems.some(
-        (item) =>
-          item.aliasType === "app" &&
-          item.aliasTarget === appId &&
-          item.originalPath?.startsWith("/Desktop/")
-      );
-
-      if (hasActiveShortcut || hasTrashedShortcut) {
-        return;
-      }
-
-      // Use app path if available
-      const appPath = `/Applications/${app.name}`;
-      fileStore.createAlias(appPath, app.name, "app", appId);
-
-      // Mark default shortcuts as theme-conditional by hiding them on macOS X
-      // unless they are iPod or Applet Store, which should always be visible.
-      const latestDesktopItems = fileStore.getItemsInPath("/Desktop");
-      const createdShortcut = latestDesktopItems.find(
-        (item) =>
-          item.aliasType === "app" &&
-          item.aliasTarget === appId &&
-          item.status === "active"
-      );
-
-      if (!createdShortcut) {
-        return;
-      }
-
-      // Only apply theme-conditional hiding for non-macOS themes and only for
-      // apps that are NOT iPod or Applet Store.
-      if (
-        currentTheme !== "macosx" &&
-        appId !== "ipod" &&
-        appId !== "applet-viewer"
-      ) {
-        fileStore.updateItemMetadata(createdShortcut.path, {
-          hiddenOnThemes: ["macosx"],
-        });
-      }
-    });
+    // When theme changes, trigger desktop shortcuts initialization to update visibility
+    // This ensures shortcuts are shown/hidden according to theme rules
+    fileStore.initializeDesktopShortcuts();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [apps, currentTheme]);
+  }, [currentTheme]);
 
   const getContextMenuItems = (): MenuItem[] => {
     if (contextMenuShortcutPath) {


### PR DESCRIPTION
Initialize desktop shortcuts synchronously within the file store to fix icons not appearing on first load.

---
<a href="https://cursor.com/background-agent?bcId=bc-757a6942-249b-44b0-ab9f-a3b0172019d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-757a6942-249b-44b0-ab9f-a3b0172019d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

