### PR TITLE
Add and set gpt-5.1 as default model

### DIFF
--- a/api/utils/aiModels.ts
+++ b/api/utils/aiModels.ts
@@ -31,6 +31,8 @@ export const getModelInstance = (model: SupportedModel): LanguageModelV2 => {
       return anthropic("claude-3-5-sonnet-20241022");
     case "gpt-5":
       return openai("gpt-5");
+    case "gpt-5.1":
+      return openai("gpt-5.1");
     case "gpt-5-mini":
       return openai("gpt-5-mini");
     case "gpt-4o":
@@ -41,6 +43,6 @@ export const getModelInstance = (model: SupportedModel): LanguageModelV2 => {
       return openai("gpt-4.1-mini");
     default:
       // Fallback – should never happen due to exhaustive switch
-      return openai("gpt-5");
+      return openai("gpt-5.1");
   }
 };

--- a/src/types/aiModels.ts
+++ b/src/types/aiModels.ts
@@ -30,6 +30,10 @@ export const AI_MODELS = {
     name: "gpt-5",
     provider: "OpenAI",
   },
+  "gpt-5.1": {
+    name: "gpt-5.1",
+    provider: "OpenAI",
+  },
   "gpt-5-mini": {
     name: "gpt-5-mini",
     provider: "OpenAI",
@@ -70,4 +74,4 @@ export const AI_MODEL_METADATA: AIModelInfo[] = Object.entries(AI_MODELS).map(
 );
 
 // Default model
-export const DEFAULT_AI_MODEL: SupportedModel = "claude-4.5";
+export const DEFAULT_AI_MODEL: SupportedModel = "gpt-5.1";


### PR DESCRIPTION
Add `gpt-5.1` to the list of AI models and set it as the new default model.

---
<a href="https://cursor.com/background-agent?bcId=bc-2c9a174e-1b41-4579-947b-ce46632c1ef2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2c9a174e-1b41-4579-947b-ce46632c1ef2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

