### PR TITLE
Reduce ai model reasoning effort

### DIFF
--- a/api/chat.ts
+++ b/api/chat.ts
@@ -1084,7 +1084,7 @@ export default async function handler(req: Request) {
       },
       providerOptions: {
         openai: {
-          reasoningEffort: "minimal", // Turn off reasoning for GPT-5 and other reasoning models
+          reasoningEffort: "none", // Turn off reasoning for GPT-5 and other reasoning models
         },
       },
     });

--- a/api/ie-generate.ts
+++ b/api/ie-generate.ts
@@ -336,7 +336,7 @@ export default async function handler(req: Request) {
       experimental_transform: smoothStream(),
       providerOptions: {
         openai: {
-          reasoningEffort: "minimal", // Turn off reasoning for GPT-5 and other reasoning models
+          reasoningEffort: "none", // Turn off reasoning for GPT-5 and other reasoning models
         },
       },
       onFinish: async ({ text }) => {


### PR DESCRIPTION
Change AI models reasoning effort from minimal to none to disable reasoning for GPT-5 and other reasoning models.

---
<a href="https://cursor.com/background-agent?bcId=bc-941e7509-3525-40de-bbcc-c028dff84dd9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-941e7509-3525-40de-bbcc-c028dff84dd9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

