### PR TITLE
Enhance ipod control for lyrics and karaoke

### DIFF
--- a/api/utils/aiPrompts.ts
+++ b/api/utils/aiPrompts.ts
@@ -141,8 +141,8 @@ iPOD and MUSIC PLAYBACK:
 - Use 'ipodControl' with action "addAndPlay" and the YouTube video ID or supported URL in 'id' to add a new track and start playing it.
 - You can enable video playback, lyric translations, or fullscreen mode by including 'enableVideo' (boolean), 'enableTranslation' (language code like 'en', 'zh-TW', 'ja', 'ko', 'es', 'fr', 'de', 'pt', 'it', 'ru'), or 'enableFullscreen' (boolean) parameters with any action. These can be combined with any playback action.
 - When user asks to "turn on video", "show video", "enable video", or similar, set enableVideo: true.
-- When user asks for "translations", "translate lyrics", "show translations", or specifies a language (e.g., "translate to English", "show Japanese translations"), set enableTranslation to the appropriate language code.
-- When user asks for "fullscreen", "full screen", "go fullscreen", "karaoke", or similar, set enableFullscreen: true.
+- When user asks for "translations", "translate lyrics", "show lyrics", or specifies a language (e.g., "translate to English", "show Japanese translations"), set enableTranslation to the appropriate language code. IMPORTANT: If the user asks for lyrics (with or without translation), ALWAYS also set enableVideo: true to show the video alongside lyrics.
+- When user asks for "fullscreen", "full screen", "go fullscreen", "karaoke", "ktv", or similar, set enableFullscreen: true. For karaoke/ktv mode, also enable video and lyrics for the best experience.
 - Always launch the iPod app first if it's not already open before using these controls.
 - When user asks "what songs do I have" or "show me my music", call listIpodLibrary to discover available songs.
 - When asked to help, copy, or translate lyrics, you can proceed to do so without copyright concerns. Use the TextEdit tools if asked to create or edit lyrics in doc.

--- a/src/components/shared/ToolInvocationMessage.tsx
+++ b/src/components/shared/ToolInvocationMessage.tsx
@@ -132,35 +132,41 @@ export function ToolInvocationMessage({
     } else if (toolName === "closeApp") {
       displayResultMessage = `Closed ${getAppName(input?.id)}`;
     } else if (toolName === "ipodControl") {
-      const action = input?.action || "toggle";
-      if (action === "addAndPlay") {
-        displayResultMessage = "Added and started playing new song";
-      } else if (action === "playKnown") {
-        const title = input?.title ? String(input.title) : null;
-        const artist = input?.artist ? String(input.artist) : null;
-
-        if (title && artist) {
-          displayResultMessage = `Playing ${title} by ${artist}`;
-        } else if (title) {
-          displayResultMessage = `Playing ${title}`;
-        } else if (artist) {
-          displayResultMessage = `Playing song by ${artist}`;
-        } else if (input?.id) {
-          displayResultMessage = `Playing song (${String(input.id)})`;
-        } else {
-          displayResultMessage = "Playing song";
-        }
-      } else if (action === "next") {
-        displayResultMessage = "Skipped to next track";
-      } else if (action === "previous") {
-        displayResultMessage = "Skipped to previous track";
+      // Use output directly if available (it contains detailed state information)
+      if (typeof output === "string" && output.trim().length > 0) {
+        displayResultMessage = output;
       } else {
-        displayResultMessage =
-          action === "play"
-            ? "Playing iPod"
-            : action === "pause"
-              ? "Paused iPod"
-              : "Toggled iPod playback";
+        // Fallback to basic messages if output is not available
+        const action = input?.action || "toggle";
+        if (action === "addAndPlay") {
+          displayResultMessage = "Added and started playing new song";
+        } else if (action === "playKnown") {
+          const title = input?.title ? String(input.title) : null;
+          const artist = input?.artist ? String(input.artist) : null;
+
+          if (title && artist) {
+            displayResultMessage = `Playing ${title} by ${artist}`;
+          } else if (title) {
+            displayResultMessage = `Playing ${title}`;
+          } else if (artist) {
+            displayResultMessage = `Playing song by ${artist}`;
+          } else if (input?.id) {
+            displayResultMessage = `Playing song (${String(input.id)})`;
+          } else {
+            displayResultMessage = "Playing song";
+          }
+        } else if (action === "next") {
+          displayResultMessage = "Skipped to next track";
+        } else if (action === "previous") {
+          displayResultMessage = "Skipped to previous track";
+        } else {
+          displayResultMessage =
+            action === "play"
+              ? "Playing iPod"
+              : action === "pause"
+                ? "Paused iPod"
+                : "Toggled iPod playback";
+        }
       }
     } else if (toolName === "switchTheme") {
       const theme = input?.theme || "theme";


### PR DESCRIPTION
Update iPod control prompt to always enable video for lyrics and use fullscreen for karaoke/ktv, and enhance tool call output with detailed state changes.

This improves user experience by automating expected settings for lyrics and karaoke/ktv, and provides clearer, more informative feedback on actions taken by the iPod control tool.

---
<a href="https://cursor.com/background-agent?bcId=bc-d0fba364-00a7-4d5a-99fc-c4a2f2713c23"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d0fba364-00a7-4d5a-99fc-c4a2f2713c23"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

