### PR TITLE
🖥️ Add screen savers to the control pannel

### DIFF
--- a/src/apps/base/AppManager.tsx
+++ b/src/apps/base/AppManager.tsx
@@ -9,6 +9,7 @@ import { AppId, getAppComponent, appRegistry } from "@/config/appRegistry";
 import { useAppStoreShallow } from "@/stores/helpers";
 import { extractCodeFromPath } from "@/utils/sharedUrl";
 import { toast } from "sonner";
+import { ScreenSaverOverlay } from "@/components/screensavers/ScreenSaverOverlay";
 
 interface AppManagerProps {
   apps: AnyApp[];
@@ -387,6 +388,7 @@ export function AppManager({ apps }: AppManagerProps) {
         }}
         appStates={{ windowOrder: instanceOrder, apps: legacyAppStates }}
       />
+      <ScreenSaverOverlay />
     </AppContext.Provider>
   );
 }

--- a/src/apps/control-panels/components/ControlPanelsAppComponent.tsx
+++ b/src/apps/control-panels/components/ControlPanelsAppComponent.tsx
@@ -20,6 +20,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { WallpaperPicker } from "./WallpaperPicker";
+import { ScreenSaverPicker } from "./ScreenSaverPicker";
 import { AppProps, ControlPanelsInitialData } from "@/apps/base/types";
 import { clearAllAppStates } from "@/stores/useAppStore";
 import { ensureIndexedDBInitialized } from "@/utils/indexedDB";
@@ -646,7 +647,9 @@ export function ControlPanelsAppComponent({
       }
 
       // Combine chunks into a single blob
-      const compressedBlob = new Blob(chunks, { type: "application/gzip" });
+      const compressedBlob = new Blob(chunks as BlobPart[], {
+        type: "application/gzip",
+      });
 
       // Create download link
       const url = URL.createObjectURL(compressedBlob);
@@ -1496,6 +1499,7 @@ export function ControlPanelsAppComponent({
                   className="h-7! flex justify-start! p-0 -mt-1 -mb-[2px] bg-transparent shadow-none /* Windows XP/98 tab strip */"
                 >
                   <TabsTrigger value="appearance">Appearance</TabsTrigger>
+                  <TabsTrigger value="screensaver">Screen Saver</TabsTrigger>
                   <TabsTrigger value="sound">Sound</TabsTrigger>
                   <TabsTrigger value="system">System</TabsTrigger>
                 </menu>
@@ -1507,6 +1511,12 @@ export function ControlPanelsAppComponent({
                   className={tabStyles.tabTriggerClasses}
                 >
                   Appearance
+                </TabsTrigger>
+                <TabsTrigger
+                  value="screensaver"
+                  className={tabStyles.tabTriggerClasses}
+                >
+                  Screen Saver
                 </TabsTrigger>
                 <TabsTrigger
                   value="sound"
@@ -1561,6 +1571,15 @@ export function ControlPanelsAppComponent({
                 />
 
                 <WallpaperPicker />
+              </div>
+            </TabsContent>
+
+            <TabsContent
+              value="screensaver"
+              className={tabStyles.tabContentClasses}
+            >
+              <div className="space-y-4 h-full overflow-y-auto p-4 pt-6">
+                <ScreenSaverPicker />
               </div>
             </TabsContent>
 

--- a/src/apps/control-panels/components/ScreenSaverPicker.tsx
+++ b/src/apps/control-panels/components/ScreenSaverPicker.tsx
@@ -1,0 +1,117 @@
+import { useState } from "react";
+import { useAppStore } from "@/stores/useAppStore";
+import { getAllScreenSavers } from "@/utils/screenSavers";
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { ScreenSaverOverlay } from "@/components/screensavers/ScreenSaverOverlay";
+import { Button } from "@/components/ui/button";
+import { Slider } from "@/components/ui/slider";
+
+export function ScreenSaverPicker() {
+  const {
+    screenSaverId,
+    setScreenSaverId,
+    screenSaverEnabled,
+    setScreenSaverEnabled,
+    screenSaverTimeout,
+    setScreenSaverTimeout,
+  } = useAppStore();
+
+  const [isPreviewOpen, setIsPreviewOpen] = useState(false);
+  const screenSavers = getAllScreenSavers();
+
+  const selectedSaver = screenSavers.find((s) => s.id === screenSaverId);
+
+  return (
+    <div className="space-y-6 h-full p-1">
+      {/* Main Toggle */}
+      <div className="flex items-center justify-between">
+        <div className="flex flex-col gap-1">
+          <Label>Enable Screen Saver</Label>
+          <Label className="text-[11px] text-gray-600 font-geneva-12">
+            Automatically start screen saver when idle
+          </Label>
+        </div>
+        <Switch
+          checked={screenSaverEnabled}
+          onCheckedChange={setScreenSaverEnabled}
+          className="data-[state=checked]:bg-[#000000]"
+        />
+      </div>
+
+      {screenSaverEnabled && (
+        <>
+          <div className="space-y-4 border rounded-md p-4 bg-white/50">
+            {/* Saver Selection */}
+            <div className="flex flex-col gap-2">
+              <Label>Screen Saver</Label>
+              <div className="flex gap-2">
+                <Select
+                  value={screenSaverId}
+                  onValueChange={setScreenSaverId}
+                >
+                  <SelectTrigger className="w-full">
+                    <SelectValue placeholder="Select Screen Saver">
+                      {selectedSaver?.name || "Select"}
+                    </SelectValue>
+                  </SelectTrigger>
+                  <SelectContent>
+                    {screenSavers.map((saver) => (
+                      <SelectItem key={saver.id} value={saver.id}>
+                        {saver.name}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                <Button 
+                  variant="retro" 
+                  onClick={() => setIsPreviewOpen(true)}
+                  disabled={!selectedSaver}
+                >
+                  Preview
+                </Button>
+              </div>
+              {selectedSaver?.description && (
+                <p className="text-[11px] text-gray-500 font-geneva-12 mt-1">
+                  {selectedSaver.description}
+                </p>
+              )}
+            </div>
+
+            {/* Timeout Slider */}
+            <div className="flex flex-col gap-3 pt-2">
+              <div className="flex justify-between">
+                <Label>Start after</Label>
+                <span className="text-xs font-mono">{screenSaverTimeout} min</span>
+              </div>
+              <Slider
+                value={[screenSaverTimeout]}
+                onValueChange={(vals) => setScreenSaverTimeout(vals[0])}
+                min={1}
+                max={60}
+                step={1}
+                className="w-full"
+              />
+            </div>
+          </div>
+        </>
+      )}
+
+      {/* Preview Overlay */}
+      {isPreviewOpen && (
+        <ScreenSaverOverlay 
+          previewMode={true} 
+          onExitPreview={() => setIsPreviewOpen(false)} 
+        />
+      )}
+    </div>
+  );
+}
+

--- a/src/apps/control-panels/components/ScreenSaverPicker.tsx
+++ b/src/apps/control-panels/components/ScreenSaverPicker.tsx
@@ -88,14 +88,14 @@ export function ScreenSaverPicker() {
             {/* Timeout Slider */}
             <div className="flex flex-col gap-3 pt-2">
               <div className="flex justify-between">
-                <Label>Start after</Label>
+                <Label>Start after (1-5 min)</Label>
                 <span className="text-xs font-mono">{screenSaverTimeout} min</span>
               </div>
               <Slider
                 value={[screenSaverTimeout]}
                 onValueChange={(vals) => setScreenSaverTimeout(vals[0])}
                 min={1}
-                max={60}
+                max={5}
                 step={1}
                 className="w-full"
               />

--- a/src/components/screensavers/MystifyScreenSaver.tsx
+++ b/src/components/screensavers/MystifyScreenSaver.tsx
@@ -1,0 +1,147 @@
+import { useEffect, useRef } from "react";
+
+interface Point {
+  x: number;
+  y: number;
+  vx: number;
+  vy: number;
+}
+
+interface Polygon {
+  points: Point[];
+  color: string; // current color
+  hue: number; // for color cycling
+}
+
+const MAX_HISTORY = 8; // Reduced trails
+const HISTORY_GAP = 5; // Frames to skip between snapshots
+const NUM_POLYGONS = 2;
+const NUM_POINTS = 4;
+const SPEED = 4.5;
+
+export function MystifyScreenSaver() {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+
+    let width = window.innerWidth;
+    let height = window.innerHeight;
+    let animationFrameId: number;
+
+    // State for polygons
+    const polygons: Polygon[] = [];
+    // History buffers: [polygonIndex][historyIndex] -> Array of points
+    const history: Point[][][] = [];
+
+    // Initialize Polygons
+    for (let i = 0; i < NUM_POLYGONS; i++) {
+      const points: Point[] = [];
+      for (let j = 0; j < NUM_POINTS; j++) {
+        points.push({
+          x: Math.random() * width,
+          y: Math.random() * height,
+          vx: (Math.random() - 0.5) * SPEED * 2,
+          vy: (Math.random() - 0.5) * SPEED * 2,
+        });
+      }
+      // Start with distinct hues
+      const hue = (i * 360) / NUM_POLYGONS;
+      polygons.push({
+        points,
+        color: `hsl(${hue}, 100%, 50%)`,
+        hue,
+      });
+      history.push([]);
+    }
+
+    const resize = () => {
+      width = window.innerWidth;
+      height = window.innerHeight;
+      canvas.width = width;
+      canvas.height = height;
+    };
+
+    const update = () => {
+      // Clear with slight fade for extra trail smoothness, or hard clear
+      // Classic Mystify is usually hard clear but draws multiple history frames
+      ctx.fillStyle = "#000000";
+      ctx.fillRect(0, 0, width, height);
+
+      polygons.forEach((poly, polyIndex) => {
+        // Update color
+        poly.hue = (poly.hue + 0.5) % 360;
+        poly.color = `hsl(${poly.hue}, 100%, 50%)`;
+
+        // Update points
+        poly.points.forEach((p) => {
+          p.x += p.vx;
+          p.y += p.vy;
+
+          // Bounce off walls
+          if (p.x < 0) {
+            p.x = 0;
+            p.vx *= -1;
+          }
+          if (p.x > width) {
+            p.x = width;
+            p.vx *= -1;
+          }
+          if (p.y < 0) {
+            p.y = 0;
+            p.vy *= -1;
+          }
+          if (p.y > height) {
+            p.y = height;
+            p.vy *= -1;
+          }
+        });
+
+        // Save current state to history periodically
+        // Deep copy points
+        if (animationFrameId % HISTORY_GAP === 0) {
+          const currentPoints = poly.points.map((p) => ({ ...p }));
+          history[polyIndex].unshift(currentPoints);
+          if (history[polyIndex].length > MAX_HISTORY) {
+            history[polyIndex].pop();
+          }
+        }
+
+        // Draw history
+        history[polyIndex].forEach((pointsSnapshot) => {
+          // Use constant full brightness/opacity
+          ctx.strokeStyle = `hsl(${poly.hue}, 100%, 50%)`;
+          ctx.lineWidth = 1;
+          ctx.beginPath();
+          ctx.moveTo(pointsSnapshot[0].x, pointsSnapshot[0].y);
+          for (let k = 1; k < pointsSnapshot.length; k++) {
+            ctx.lineTo(pointsSnapshot[k].x, pointsSnapshot[k].y);
+          }
+          // Close the loop
+          ctx.lineTo(pointsSnapshot[0].x, pointsSnapshot[0].y);
+          ctx.stroke();
+        });
+      });
+
+      animationFrameId = requestAnimationFrame(update);
+    };
+
+    window.addEventListener("resize", resize);
+    resize();
+    update();
+
+    return () => {
+      window.removeEventListener("resize", resize);
+      cancelAnimationFrame(animationFrameId);
+    };
+  }, []);
+
+  return <canvas ref={canvasRef} className="w-full h-full block bg-black" />;
+}
+
+export default MystifyScreenSaver;
+

--- a/src/components/screensavers/PipesScreenSaver.tsx
+++ b/src/components/screensavers/PipesScreenSaver.tsx
@@ -1,0 +1,379 @@
+'use client';
+
+import { useEffect, useRef } from "react";
+import * as THREE from "three";
+
+const GRID_SIZE = 20;
+const HALF_GRID = GRID_SIZE / 2;
+const PIPE_RADIUS = 0.4;
+const MAX_PIPES = 3;
+const SPEED = 0.1;
+const SEGMENT_LIMIT = 1000;
+const MIN_STRAIGHT_STEPS = 4;
+const RANDOM_TURN_CHANCE = 0.5;
+
+type Vec3 = [number, number, number];
+type Direction = Vec3;
+
+const DIRECTIONS: Direction[] = [
+  [1, 0, 0],
+  [-1, 0, 0],
+  [0, 1, 0],
+  [0, -1, 0],
+  [0, 0, 1],
+  [0, 0, -1],
+];
+
+const ALL_COLORS = [
+  "#FF0000",
+  "#00FF00",
+  "#0000FF",
+  "#FFFF00",
+  "#00FFFF",
+  "#FF00FF",
+  "#FFFFFF",
+  "#FF8000",
+  "#8000FF",
+];
+
+interface ActivePipe {
+  id: number;
+  position: Vec3;
+  direction: Direction;
+  color: string;
+  lastUpdate: number;
+  stepsSinceTurn: number;
+}
+
+const createPalette = () => {
+  const shuffled = [...ALL_COLORS];
+  for (let i = shuffled.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
+  }
+  // Ensure we have enough colors for MAX_PIPES by repeating if necessary,
+  // but always take at least MAX_PIPES distinct colors if available.
+  // Since ALL_COLORS has 9 entries and MAX_PIPES is 3, we can just slice.
+  return shuffled.slice(0, MAX_PIPES);
+};
+
+const addVec = (a: Vec3, b: Direction): Vec3 => [
+  a[0] + b[0],
+  a[1] + b[1],
+  a[2] + b[2],
+];
+
+const posKey = (pos: Vec3) => `${pos[0]},${pos[1]},${pos[2]}`;
+
+const orthogonalDirections = (dir: Direction) =>
+  DIRECTIONS.filter(
+    (candidate) =>
+      candidate[0] * dir[0] + candidate[1] * dir[1] + candidate[2] * dir[2] === 0
+  );
+
+const randomDirection = () =>
+  DIRECTIONS[Math.floor(Math.random() * DIRECTIONS.length)];
+
+const randomFrom = <T,>(list: T[]) =>
+  list[Math.floor(Math.random() * list.length)];
+
+const randomPosition = (): Vec3 => [
+  Math.floor(Math.random() * GRID_SIZE) - HALF_GRID,
+  Math.floor(Math.random() * GRID_SIZE) - HALF_GRID,
+  Math.floor(Math.random() * GRID_SIZE) - HALF_GRID,
+];
+
+const isValidPosition = (pos: Vec3, occupied: Set<string>) =>
+  Math.abs(pos[0]) <= HALF_GRID &&
+  Math.abs(pos[1]) <= HALF_GRID &&
+  Math.abs(pos[2]) <= HALF_GRID &&
+  !occupied.has(posKey(pos));
+
+const getValidTurnDirections = (
+  position: Vec3,
+  currentDir: Direction,
+  occupied: Set<string>
+) =>
+  orthogonalDirections(currentDir).filter((dir) =>
+    isValidPosition(addVec(position, dir), occupied)
+  );
+
+const disposeObject = (object: THREE.Object3D) => {
+  object.traverse((child) => {
+    if ((child as THREE.Mesh).isMesh) {
+      const mesh = child as THREE.Mesh;
+      mesh.geometry.dispose();
+      if (Array.isArray(mesh.material)) {
+        mesh.material.forEach((mat) => mat.dispose());
+      } else if (mesh.material) {
+        mesh.material.dispose();
+      }
+    }
+  });
+};
+
+export function PipesScreenSaver() {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+
+    const renderer = new THREE.WebGLRenderer({ canvas, antialias: true });
+    renderer.setPixelRatio(window.devicePixelRatio);
+    renderer.setSize(window.innerWidth, window.innerHeight);
+
+    const scene = new THREE.Scene();
+    scene.background = new THREE.Color(0x050507);
+
+    const camera = new THREE.PerspectiveCamera(
+      50,
+      window.innerWidth / window.innerHeight,
+      0.1,
+      1000
+    );
+    camera.position.set(0, 0, 40);
+    camera.lookAt(0, 0, 0);
+
+    const clock = new THREE.Clock();
+    const ambientLight = new THREE.AmbientLight(0xfefefe, 0.7);
+    const lightA = new THREE.PointLight(0xfff3e0, 2);
+    lightA.position.set(18, 12, 14);
+    const lightB = new THREE.PointLight(0xdfe9ff, 1.5);
+    lightB.position.set(-16, 10, -12);
+    scene.add(ambientLight, lightA, lightB);
+
+    const softboxLights: THREE.PointLight[] = [];
+    const spawnSoftbox = (
+      center: Vec3,
+      size: { width: number; height: number },
+      color: number,
+      intensity: number
+    ) => {
+      const cols = 3;
+      const rows = 2;
+      for (let ix = 0; ix < cols; ix++) {
+        for (let iy = 0; iy < rows; iy++) {
+          const offsetX = ((ix / (cols - 1)) - 0.5) * size.width;
+          const offsetY = ((iy / (rows - 1)) - 0.5) * size.height;
+          const light = new THREE.PointLight(color, intensity);
+          light.position.set(center[0] + offsetX, center[1] + offsetY, center[2]);
+          light.castShadow = false;
+          scene.add(light);
+          softboxLights.push(light);
+        }
+      }
+    };
+    spawnSoftbox([0, 18, 16], { width: 18, height: 10 }, 0xffffff, 30);
+    spawnSoftbox([-10, -6, 22], { width: 14, height: 8 }, 0xfbf4ff, 10);
+
+    // No panels added
+
+    const grid = new Set<string>();
+    const activePipes: ActivePipe[] = [];
+    let segments: THREE.Object3D[] = [];
+    let animationFrameId: number;
+
+    const createPipeMaterial = (hex: string) => {
+      const base = new THREE.Color(hex);
+      return new THREE.MeshPhysicalMaterial({
+        color: base,
+        roughness: 0.2,
+        metalness: 0.1,
+        clearcoat: 1.0,
+        clearcoatRoughness: 0.15,
+        sheen: 0.5,
+        sheenColor: new THREE.Color(0xffffff),
+        sheenRoughness: 0.5,
+        transmission: 0,
+      });
+    };
+
+    const clearSegments = () => {
+      segments.forEach((obj) => {
+        scene.remove(obj);
+        disposeObject(obj);
+      });
+      segments = [];
+    };
+
+    const createJoint = (position: Vec3, color: string) => {
+      const geometry = new THREE.SphereGeometry(PIPE_RADIUS * 1.3, 24, 24);
+      const material = createPipeMaterial(color);
+      const mesh = new THREE.Mesh(geometry, material);
+      mesh.position.set(position[0], position[1], position[2]);
+      scene.add(mesh);
+      segments.push(mesh);
+    };
+
+    const createStraight = (position: Vec3, direction: Direction, color: string) => {
+      const geometry = new THREE.CylinderGeometry(
+        PIPE_RADIUS,
+        PIPE_RADIUS,
+        1,
+        24
+      );
+      const material = createPipeMaterial(color);
+      const mesh = new THREE.Mesh(geometry, material);
+      mesh.position.set(position[0], position[1], position[2]);
+      if (direction[0] !== 0) {
+        mesh.rotation.z = Math.PI / 2;
+      } else if (direction[2] !== 0) {
+        mesh.rotation.x = Math.PI / 2;
+      }
+      scene.add(mesh);
+      segments.push(mesh);
+    };
+
+    const randomizeCamera = () => {
+      const distance = 26;
+      const theta = Math.random() * Math.PI * 2;
+      const phi = Math.acos(Math.random() * 2 - 1);
+      const x = distance * Math.sin(phi) * Math.cos(theta);
+      const y = distance * Math.sin(phi) * Math.sin(theta);
+      const z = distance * Math.cos(phi);
+      camera.position.set(x, y, z);
+      camera.up
+        .set(Math.random() - 0.5, Math.random() - 0.5, Math.random() - 0.5)
+        .normalize();
+      camera.lookAt(0, 0, 0);
+      camera.updateProjectionMatrix();
+    };
+
+    const randomFreePosition = (): Vec3 => {
+      for (let attempt = 0; attempt < 100; attempt++) {
+        const candidate = randomPosition();
+        if (!grid.has(posKey(candidate))) {
+          return candidate;
+        }
+      }
+      grid.clear();
+      return randomPosition();
+    };
+
+    const respawnPipe = (pipe: ActivePipe, now: number) => {
+      pipe.position = randomFreePosition();
+      pipe.direction = randomDirection();
+      pipe.lastUpdate = now;
+      pipe.stepsSinceTurn = 0;
+      grid.add(posKey(pipe.position));
+      createJoint(pipe.position, pipe.color);
+    };
+
+    const initialize = () => {
+      const now = clock.getElapsedTime();
+      grid.clear();
+      clearSegments();
+      activePipes.length = 0;
+      randomizeCamera();
+      const palette = createPalette();
+      for (let i = 0; i < MAX_PIPES; i++) {
+        const pipe: ActivePipe = {
+          id: i,
+          position: randomFreePosition(),
+          direction: randomDirection(),
+          color: palette[i % palette.length],
+          lastUpdate: now,
+          stepsSinceTurn: 0,
+        };
+        activePipes.push(pipe);
+        grid.add(posKey(pipe.position));
+        createJoint(pipe.position, pipe.color);
+      }
+    };
+
+    const updatePipes = (time: number) => {
+      let resetTriggered = false;
+      activePipes.forEach((pipe) => {
+        if (resetTriggered || time - pipe.lastUpdate <= SPEED) {
+          return;
+        }
+
+        pipe.lastUpdate = time;
+        const nextPos = addVec(pipe.position, pipe.direction);
+        const turnOptions = getValidTurnDirections(
+          pipe.position,
+          pipe.direction,
+          grid
+        );
+        let targetDir = pipe.direction;
+        let targetPos = nextPos;
+        let turned = false;
+
+        if (!isValidPosition(targetPos, grid)) {
+          if (turnOptions.length > 0) {
+            targetDir = randomFrom(turnOptions);
+            targetPos = addVec(pipe.position, targetDir);
+            turned = true;
+          } else {
+            respawnPipe(pipe, time);
+            return;
+          }
+        } else if (
+          turnOptions.length > 0 &&
+          pipe.stepsSinceTurn >= MIN_STRAIGHT_STEPS &&
+          Math.random() < RANDOM_TURN_CHANCE
+        ) {
+          targetDir = randomFrom(turnOptions);
+          targetPos = addVec(pipe.position, targetDir);
+          turned = true;
+        }
+
+        if (turned) {
+          createJoint(pipe.position, pipe.color);
+        }
+
+        const midPoint: Vec3 = [
+          pipe.position[0] + targetDir[0] * 0.5,
+          pipe.position[1] + targetDir[1] * 0.5,
+          pipe.position[2] + targetDir[2] * 0.5,
+        ];
+        createStraight(midPoint, targetDir, pipe.color);
+
+        pipe.position = targetPos;
+        pipe.direction = targetDir;
+        grid.add(posKey(pipe.position));
+        pipe.stepsSinceTurn = turned ? 0 : pipe.stepsSinceTurn + 1;
+
+        if (segments.length > SEGMENT_LIMIT) {
+          resetTriggered = true;
+          initialize();
+        }
+      });
+    };
+
+    const renderLoop = () => {
+      animationFrameId = requestAnimationFrame(renderLoop);
+      const time = clock.getElapsedTime();
+      updatePipes(time);
+      renderer.render(scene, camera);
+    };
+
+    initialize();
+    renderLoop();
+
+    const handleResize = () => {
+      const width = window.innerWidth;
+      const height = window.innerHeight || 1;
+      renderer.setSize(width, height);
+      camera.aspect = width / height;
+      camera.updateProjectionMatrix();
+    };
+
+    window.addEventListener("resize", handleResize);
+
+    return () => {
+      cancelAnimationFrame(animationFrameId);
+      window.removeEventListener("resize", handleResize);
+      clearSegments();
+      softboxLights.forEach((light) => {
+        scene.remove(light);
+      });
+      renderer.dispose();
+    };
+  }, []);
+
+  return <canvas ref={canvasRef} className="w-full h-full block bg-black" />;
+}
+
+export default PipesScreenSaver;

--- a/src/components/screensavers/ScreenSaverOverlay.tsx
+++ b/src/components/screensavers/ScreenSaverOverlay.tsx
@@ -1,0 +1,128 @@
+import React, { useEffect, useRef, useState, useCallback } from "react";
+import { useAppStore } from "@/stores/useAppStore";
+import { getScreenSaver } from "@/utils/screenSavers";
+import { useSound, Sounds } from "@/hooks/useSound";
+
+interface ScreenSaverOverlayProps {
+  previewMode?: boolean; // If true, forces display and ignores idle timers (for settings preview)
+  onExitPreview?: () => void;
+}
+
+export function ScreenSaverOverlay({ previewMode = false, onExitPreview }: ScreenSaverOverlayProps) {
+  const { screenSaverId, screenSaverEnabled, screenSaverTimeout } = useAppStore();
+  const [isActive, setIsActive] = useState(false);
+  const idleTimerRef = useRef<NodeJS.Timeout | null>(null);
+  const wakeLockRef = useRef<WakeLockSentinel | null>(null);
+  const { play: playClick } = useSound(Sounds.BUTTON_CLICK, 0.1); // Subtle sound on wake
+
+  // Handle Screen Wake Lock
+  useEffect(() => {
+    const manageWakeLock = async () => {
+      try {
+        if (isActive) {
+          if ("wakeLock" in navigator && !wakeLockRef.current) {
+            wakeLockRef.current = await navigator.wakeLock.request("screen");
+          }
+        } else {
+          if (wakeLockRef.current) {
+            await wakeLockRef.current.release();
+            wakeLockRef.current = null;
+          }
+        }
+      } catch (err) {
+        console.error("Wake Lock error:", err);
+      }
+    };
+
+    manageWakeLock();
+
+    return () => {
+      if (wakeLockRef.current) {
+        wakeLockRef.current.release().catch(() => {});
+        wakeLockRef.current = null;
+      }
+    };
+  }, [isActive]);
+
+  const activateScreenSaver = useCallback(() => {
+    if (screenSaverEnabled || previewMode) {
+      setIsActive(true);
+    }
+  }, [screenSaverEnabled, previewMode]);
+
+  const resetIdleTimer = useCallback(() => {
+    if (previewMode) return; // Don't manage timer in preview mode
+
+    if (isActive) {
+      // If active, any activity wakes the screen
+      setIsActive(false);
+      // Optional: play wake sound
+      // playClick();
+    }
+
+    if (idleTimerRef.current) {
+      clearTimeout(idleTimerRef.current);
+    }
+
+    if (screenSaverEnabled && screenSaverTimeout > 0) {
+      // Convert minutes to milliseconds
+      idleTimerRef.current = setTimeout(activateScreenSaver, screenSaverTimeout * 60 * 1000);
+    }
+  }, [isActive, screenSaverEnabled, screenSaverTimeout, activateScreenSaver, previewMode]);
+
+  // Set up activity listeners
+  useEffect(() => {
+    if (previewMode) {
+      setIsActive(true);
+      return;
+    }
+
+    const events = ["mousemove", "mousedown", "keydown", "touchstart", "wheel"];
+    
+    const handleActivity = () => {
+      resetIdleTimer();
+    };
+
+    // Initial timer start
+    resetIdleTimer();
+
+    events.forEach((event) => {
+      window.addEventListener(event, handleActivity);
+    });
+
+    return () => {
+      events.forEach((event) => {
+        window.removeEventListener(event, handleActivity);
+      });
+      if (idleTimerRef.current) {
+        clearTimeout(idleTimerRef.current);
+      }
+    };
+  }, [resetIdleTimer, previewMode]);
+
+  // Handle preview exit
+  const handleOverlayClick = () => {
+    if (previewMode && onExitPreview) {
+      onExitPreview();
+    } else if (isActive) {
+      setIsActive(false);
+    }
+  };
+
+  if (!isActive) return null;
+
+  const ScreenSaverComponent = getScreenSaver(screenSaverId)?.component;
+
+  if (!ScreenSaverComponent) return null;
+
+  return (
+    <div 
+      className="fixed inset-0 z-[2147483647] bg-black cursor-none"
+      onClick={handleOverlayClick}
+      onMouseMove={() => !previewMode && setIsActive(false)}
+    >
+      <ScreenSaverComponent />
+    </div>
+  );
+}
+

--- a/src/components/screensavers/StarfieldScreenSaver.tsx
+++ b/src/components/screensavers/StarfieldScreenSaver.tsx
@@ -14,75 +14,63 @@ export function StarfieldScreenSaver() {
     let width = window.innerWidth;
     let height = window.innerHeight;
 
-    const stars: { x: number; y: number; z: number; pz: number }[] = [];
-    const speed = 15; // Slightly faster for better effect
-    const numStars = 1000;
+    const stars: { x: number; y: number; z: number }[] = [];
+    const speed = 18;
+    const density = 0.0012;
+    let starCount = 0;
 
     const resize = () => {
       width = window.innerWidth;
       height = window.innerHeight;
       canvas.width = width;
       canvas.height = height;
+      initStars();
     };
 
     const initStars = () => {
       stars.length = 0;
-      for (let i = 0; i < numStars; i++) {
+      starCount = Math.max(
+        750,
+        Math.floor(width * height * density)
+      );
+      for (let i = 0; i < starCount; i++) {
         stars.push({
           x: (Math.random() - 0.5) * width * 2,
           y: (Math.random() - 0.5) * height * 2,
           z: Math.random() * width,
-          pz: Math.random() * width, // previous z
         });
       }
     };
 
     const update = () => {
-      // Create trail effect
-      ctx.fillStyle = "rgba(0, 0, 0, 0.4)";
+      ctx.fillStyle = "rgba(0, 0, 0, 1)";
       ctx.fillRect(0, 0, width, height);
 
       const cx = width / 2;
       const cy = height / 2;
 
-      for (let i = 0; i < numStars; i++) {
+      for (let i = 0; i < starCount; i++) {
         const star = stars[i];
-        
-        // Move star closer
         star.z -= speed;
 
-        // Reset star if it passes screen
         if (star.z <= 0) {
           star.x = (Math.random() - 0.5) * width * 2;
           star.y = (Math.random() - 0.5) * height * 2;
           star.z = width;
-          star.pz = width;
         }
 
-        // Project 3D coordinates to 2D
         const x = (star.x / star.z) * width + cx;
         const y = (star.y / star.z) * height + cy;
 
-        // Project previous coordinates for trails
-        const px = (star.x / star.pz) * width + cx;
-        const py = (star.y / star.pz) * height + cy;
-
-        star.pz = star.z;
-
-        // Draw if within bounds
         if (x >= 0 && x <= width && y >= 0 && y <= height) {
-          const distance = 1 - star.z / width;
-          const size = distance * 3;
-          const brightness = Math.floor(distance * 255);
-          
-          ctx.lineWidth = Math.max(0.5, size);
-          ctx.strokeStyle = `rgb(${brightness}, ${brightness}, ${brightness})`;
-          ctx.lineCap = "round";
-          
-          ctx.beginPath();
-          ctx.moveTo(px, py);
-          ctx.lineTo(x, y);
-          ctx.stroke();
+          const depthScale = 1 - star.z / width;
+          const size = Math.max(1, depthScale * 4);
+          const brightness = Math.min(255, Math.floor(180 + depthScale * 75));
+
+          ctx.fillStyle = `rgb(${brightness}, ${brightness}, ${brightness})`;
+          const drawX = Math.round(x);
+          const drawY = Math.round(y);
+          ctx.fillRect(drawX, drawY, size, size);
         }
       }
 
@@ -91,7 +79,6 @@ export function StarfieldScreenSaver() {
 
     window.addEventListener("resize", resize);
     resize();
-    initStars();
     update();
 
     return () => {

--- a/src/components/screensavers/StarfieldScreenSaver.tsx
+++ b/src/components/screensavers/StarfieldScreenSaver.tsx
@@ -1,0 +1,106 @@
+import { useEffect, useRef } from "react";
+
+export function StarfieldScreenSaver() {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+
+    let animationFrameId: number;
+    let width = window.innerWidth;
+    let height = window.innerHeight;
+
+    const stars: { x: number; y: number; z: number; pz: number }[] = [];
+    const speed = 15; // Slightly faster for better effect
+    const numStars = 1000;
+
+    const resize = () => {
+      width = window.innerWidth;
+      height = window.innerHeight;
+      canvas.width = width;
+      canvas.height = height;
+    };
+
+    const initStars = () => {
+      stars.length = 0;
+      for (let i = 0; i < numStars; i++) {
+        stars.push({
+          x: (Math.random() - 0.5) * width * 2,
+          y: (Math.random() - 0.5) * height * 2,
+          z: Math.random() * width,
+          pz: Math.random() * width, // previous z
+        });
+      }
+    };
+
+    const update = () => {
+      // Create trail effect
+      ctx.fillStyle = "rgba(0, 0, 0, 0.4)";
+      ctx.fillRect(0, 0, width, height);
+
+      const cx = width / 2;
+      const cy = height / 2;
+
+      for (let i = 0; i < numStars; i++) {
+        const star = stars[i];
+        
+        // Move star closer
+        star.z -= speed;
+
+        // Reset star if it passes screen
+        if (star.z <= 0) {
+          star.x = (Math.random() - 0.5) * width * 2;
+          star.y = (Math.random() - 0.5) * height * 2;
+          star.z = width;
+          star.pz = width;
+        }
+
+        // Project 3D coordinates to 2D
+        const x = (star.x / star.z) * width + cx;
+        const y = (star.y / star.z) * height + cy;
+
+        // Project previous coordinates for trails
+        const px = (star.x / star.pz) * width + cx;
+        const py = (star.y / star.pz) * height + cy;
+
+        star.pz = star.z;
+
+        // Draw if within bounds
+        if (x >= 0 && x <= width && y >= 0 && y <= height) {
+          const distance = 1 - star.z / width;
+          const size = distance * 3;
+          const brightness = Math.floor(distance * 255);
+          
+          ctx.lineWidth = Math.max(0.5, size);
+          ctx.strokeStyle = `rgb(${brightness}, ${brightness}, ${brightness})`;
+          ctx.lineCap = "round";
+          
+          ctx.beginPath();
+          ctx.moveTo(px, py);
+          ctx.lineTo(x, y);
+          ctx.stroke();
+        }
+      }
+
+      animationFrameId = requestAnimationFrame(update);
+    };
+
+    window.addEventListener("resize", resize);
+    resize();
+    initStars();
+    update();
+
+    return () => {
+      window.removeEventListener("resize", resize);
+      cancelAnimationFrame(animationFrameId);
+    };
+  }, []);
+
+  return <canvas ref={canvasRef} className="w-full h-full block bg-black" />;
+}
+
+

--- a/src/stores/useAppStore.ts
+++ b/src/stores/useAppStore.ts
@@ -136,7 +136,13 @@ interface AppStoreState extends AppManagerState {
   _debugCheckInstanceIntegrity: () => void;
 }
 
-const CURRENT_APP_STORE_VERSION = 3; // bump for instanceOrder unification
+const CURRENT_APP_STORE_VERSION = 4; // bump for screensaver timeout clamp
+const clampScreenSaverTimeout = (value: number | undefined | null) => {
+  if (typeof value !== "number" || Number.isNaN(value)) {
+    return 1;
+  }
+  return Math.min(Math.max(value, 1), 5);
+};
 const initialShaderState = checkShaderPerformance();
 
 // ---------------- Store ---------------------------------------------------------
@@ -463,7 +469,8 @@ export const useAppStore = create<AppStoreState>()(
       screenSaverEnabled: true,
       setScreenSaverEnabled: (enabled) => set({ screenSaverEnabled: enabled }),
       screenSaverTimeout: 1, // 1 minute default
-      setScreenSaverTimeout: (timeout) => set({ screenSaverTimeout: timeout }),
+      setScreenSaverTimeout: (timeout) =>
+        set({ screenSaverTimeout: clampScreenSaverTimeout(timeout) }),
 
       // Instance store
       instances: {},
@@ -789,6 +796,11 @@ export const useAppStore = create<AppStoreState>()(
           ).filter((id: string) => prev.instances?.[id]);
           delete prev.instanceStackOrder;
           delete prev.instanceWindowOrder;
+        }
+        if (version < 4) {
+          prev.screenSaverTimeout = clampScreenSaverTimeout(
+            prev.screenSaverTimeout
+          );
         }
         prev.version = CURRENT_APP_STORE_VERSION;
         return prev;

--- a/src/stores/useAppStore.ts
+++ b/src/stores/useAppStore.ts
@@ -31,6 +31,14 @@ const getInitialState = (): AppManagerState => {
 };
 
 interface AppStoreState extends AppManagerState {
+  // Screen Saver state
+  screenSaverId: string;
+  setScreenSaverId: (id: string) => void;
+  screenSaverEnabled: boolean;
+  setScreenSaverEnabled: (enabled: boolean) => void;
+  screenSaverTimeout: number;
+  setScreenSaverTimeout: (minutes: number) => void;
+
   // Instance (window) management
   instances: Record<string, AppInstance>;
   instanceOrder: string[]; // END = TOP (foreground)
@@ -449,6 +457,14 @@ export const useAppStore = create<AppStoreState>()(
       ipodVolume: 1,
       setIpodVolume: (v) => set({ ipodVolume: v }),
 
+      // Screen Saver
+      screenSaverId: "starfield",
+      setScreenSaverId: (id) => set({ screenSaverId: id }),
+      screenSaverEnabled: true,
+      setScreenSaverEnabled: (enabled) => set({ screenSaverEnabled: enabled }),
+      screenSaverTimeout: 1, // 1 minute default
+      setScreenSaverTimeout: (timeout) => set({ screenSaverTimeout: timeout }),
+
       // Instance store
       instances: {},
       instanceOrder: [],
@@ -720,6 +736,9 @@ export const useAppStore = create<AppStoreState>()(
         ttsVoice: state.ttsVoice,
         ipodVolume: state.ipodVolume,
         masterVolume: state.masterVolume,
+        screenSaverId: state.screenSaverId,
+        screenSaverEnabled: state.screenSaverEnabled,
+        screenSaverTimeout: state.screenSaverTimeout,
         instances: Object.fromEntries(
           Object.entries(state.instances)
             .filter(([, inst]) => inst.isOpen)

--- a/src/utils/screenSavers.ts
+++ b/src/utils/screenSavers.ts
@@ -20,6 +20,7 @@ export const getAllScreenSavers = () => Object.values(SCREEN_SAVERS);
 // Import built-in screen savers
 import { StarfieldScreenSaver } from "../components/screensavers/StarfieldScreenSaver";
 import { PipesScreenSaver } from "../components/screensavers/PipesScreenSaver";
+import { MystifyScreenSaver } from "../components/screensavers/MystifyScreenSaver";
 
 // Register built-in screen savers
 registerScreenSaver({
@@ -34,5 +35,12 @@ registerScreenSaver({
   name: "Pipes",
   component: PipesScreenSaver,
   description: "Procedural 3D pipes weaving through space",
+});
+
+registerScreenSaver({
+  id: "mystify",
+  name: "Mystify Your Mind",
+  component: MystifyScreenSaver,
+  description: "Geometric shapes drifting and morphing",
 });
 

--- a/src/utils/screenSavers.ts
+++ b/src/utils/screenSavers.ts
@@ -19,6 +19,7 @@ export const getAllScreenSavers = () => Object.values(SCREEN_SAVERS);
 
 // Import built-in screen savers
 import { StarfieldScreenSaver } from "../components/screensavers/StarfieldScreenSaver";
+import { PipesScreenSaver } from "../components/screensavers/PipesScreenSaver";
 
 // Register built-in screen savers
 registerScreenSaver({
@@ -26,5 +27,12 @@ registerScreenSaver({
   name: "Starfield",
   component: StarfieldScreenSaver,
   description: "Classic 3D flying stars simulation",
+});
+
+registerScreenSaver({
+  id: "pipes",
+  name: "Pipes",
+  component: PipesScreenSaver,
+  description: "Procedural 3D pipes weaving through space",
 });
 

--- a/src/utils/screenSavers.ts
+++ b/src/utils/screenSavers.ts
@@ -1,0 +1,30 @@
+import React from "react";
+
+export interface ScreenSaver {
+  id: string;
+  name: string;
+  component: React.ComponentType<{ preview?: boolean }>;
+  description?: string;
+}
+
+export const SCREEN_SAVERS: Record<string, ScreenSaver> = {};
+
+export const registerScreenSaver = (saver: ScreenSaver) => {
+  SCREEN_SAVERS[saver.id] = saver;
+};
+
+export const getScreenSaver = (id: string) => SCREEN_SAVERS[id];
+
+export const getAllScreenSavers = () => Object.values(SCREEN_SAVERS);
+
+// Import built-in screen savers
+import { StarfieldScreenSaver } from "../components/screensavers/StarfieldScreenSaver";
+
+// Register built-in screen savers
+registerScreenSaver({
+  id: "starfield",
+  name: "Starfield",
+  component: StarfieldScreenSaver,
+  description: "Classic 3D flying stars simulation",
+});
+


### PR DESCRIPTION
A cheeky little addition to the control pannel - with three classic screen savers to get started: Starfield, Pipes, and Mystify. 

**Functionality**
- Enable or disable screen saver functionality via the control pannel. 
- Select / preview a screen saver
- Control wait time before screen saver activates (1-5min)
- Implemented browser Wake Lock support to prevent the host OS from dimming the screen or activating the system screen saver while the ryOS screensaver is active

**Under the hood**
- Pipes uses Three.js (standard WebGL library) to render the 3D geometry, lighting, and materials.
- Starfield uses the native HTML5 Canvas 2D API (canvas.getContext('2d')) to draw simple 2D rectangles for the stars. It does not use Three.js.
- Mystify also uses the Canvas 2D API for its lines and trails.

**Considerations**
- `screensavers` is a new top level directory under `components`. Is this the best place for it? (Cursor thought so, even under cross-examination 😅 )
- Possibility to add logic that binds certain screen savers to their respective OS, IE - You're not going to see Pipes on a Mac, and you wouldn't see Flurry on windows98
- Future screen savers could have their own controls that appear when they're selected
- Prop for small preview window in control pannel, not implemented yet

**Making more screen savers**
Here's a sample prompt to get you started 
```
"Create a new React component in src/components/screensavers/[Name]ScreenSaver.tsx that renders a [description of visual effect] using [Canvas 2D / Three.js]. It should handle its own resize and cleanup logic. Once built, register it in src/utils/screenSavers.ts with a unique ID so it appears in the Control Panels picker."
``` 
Just be sure to replace [Name] with whatever you want, and replace [Canvas 2D / Three.js] with your choice depending on what you're looking to make. 

**If you want to do it the old fashioned way:**

Create the Component:
- Build a React component (e.g., src/components/screensavers/MyCoolSaver.tsx).
- It should render full-screen (usually a `<canvas>` or absolute `<div>`)
- It receives no mandatory props, but can accept { preview?: boolean } if you want special behavior for a tiny preview window. (not implemented yet)

Register It:
- Open src/utils/screenSavers.ts.
- Import your component.
- Call registerScreenSaver({...}) with a unique id, display name, the component, and a short description.

Done:
- It will automatically appear in the Control Panels dropdown.
- The system handles the idle timer, wake lock, and overlay mounting for you, and mounting/ and cleanup when to show/hide it, and wake locks for you, and wake locks.

**Screenshots**
<img width="917" height="506" alt="Screenshot 2025-11-26 at 9 06 08 PM" src="https://github.com/user-attachments/assets/6889b8e4-b58f-4748-98d2-7fb92b73e3b2" />

<img width="1884" height="1187" alt="Screenshot 2025-11-26 at 8 39 05 PM" src="https://github.com/user-attachments/assets/4b7ea289-ab73-4802-abf9-0fc23e2da547" />

<img width="1904" height="1207" alt="Screenshot 2025-11-26 at 9 05 13 PM" src="https://github.com/user-attachments/assets/d5745fb6-3965-4180-80bf-3bcc1ea43093" />

<img width="1904" height="1207" alt="Screenshot 2025-11-26 at 9 37 11 PM" src="https://github.com/user-attachments/assets/b6b464cc-0cf7-4ac3-863e-13d6a3958c2d" />

**Tested**
- Set system OS screensaver to activate after 2 minutes
- Set ryOS screensaver to activate after 1 minute (Default setting)
- ryOS screensaver activated, system OS screensaver prevented from activating 
- Turned ryOS screensaver OFF, waited two minutes, system OS screensaver turned on.

🤙 