### PR TITLE
Simplify ios tool call message

### DIFF
--- a/src/apps/chats/hooks/useAiChat.ts
+++ b/src/apps/chats/hooks/useAiChat.ts
@@ -851,7 +851,7 @@ export function useAiChat(onPromptSetUsername?: () => void) {
               // On iOS, don't auto-play - inform user to press play manually
               if (isIOS && (normalizedAction === "play" || normalizedAction === "toggle")) {
                 const stateChanges = applyIpodSettings();
-                const resultParts = ["iPod is ready. Please press the center button or play button on the iPod to start playing (iOS browser restriction)"];
+                const resultParts = ["iPod is ready. Press the center button or play button on the iPod to start playing"];
                 if (stateChanges.length > 0) {
                   resultParts.push(...stateChanges);
                 }
@@ -993,7 +993,7 @@ export function useAiChat(onPromptSetUsername?: () => void) {
               // On iOS, don't auto-play - just select the track
               if (isIOS) {
                 const stateChanges = applyIpodSettings();
-                const resultParts = [`Selected ${trackDesc}. Please press the center button or play button on the iPod to start playing (iOS browser restriction)`];
+                const resultParts = [`Selected ${trackDesc}. Press the center button or play button on the iPod to start playing`];
                 if (stateChanges.length > 0) {
                   resultParts.push(...stateChanges);
                 }
@@ -1054,7 +1054,7 @@ export function useAiChat(onPromptSetUsername?: () => void) {
                   
                   // Different message for iOS vs other platforms
                   const resultParts = isIOS
-                    ? [`Added '${addedTrack.title}' to iPod. Please press the center button or play button on the iPod to start playing (iOS browser restriction)`]
+                    ? [`Added '${addedTrack.title}' to iPod. Press the center button or play button on the iPod to start playing`]
                     : [`Added '${addedTrack.title}' to iPod and started playing`];
                   
                   if (stateChanges.length > 0) {


### PR DESCRIPTION
Simplify iOS restricted tool call messages by removing "Please" and "(iOS browser restriction)".

---
<a href="https://cursor.com/background-agent?bcId=bc-60743b30-6cef-4656-91e4-7a6fdc24168b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-60743b30-6cef-4656-91e4-7a6fdc24168b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

