### PR TITLE
Animate app closing from all methods

### DIFF
--- a/src/apps/applet-viewer/components/AppletViewerAppComponent.tsx
+++ b/src/apps/applet-viewer/components/AppletViewerAppComponent.tsx
@@ -36,6 +36,7 @@ import { exportAppletAsHtml } from "@/utils/appletImportExport";
 
 export function AppletViewerAppComponent({
   onClose,
+  onCloseComplete,
   isWindowOpen,
   isForeground = true,
   skipInitialSound,
@@ -1458,6 +1459,7 @@ export function AppletViewerAppComponent({
       <WindowFrame
         title={windowTitle}
         onClose={onClose}
+        onCloseComplete={onCloseComplete}
         isForeground={isForeground}
         appId="applet-viewer"
         skipInitialSound={skipInitialSound}

--- a/src/apps/base/AppManager.tsx
+++ b/src/apps/base/AppManager.tsx
@@ -364,13 +364,8 @@ export function AppManager({ apps }: AppManagerProps) {
               isWindowOpen={instance.isOpen}
               isForeground={instance.isForeground}
               onClose={() => {
-                // Dispatch close event to trigger animated close in WindowFrame
-                const event = new CustomEvent(`closeWindow-${instance.instanceId}`);
-                window.dispatchEvent(event);
-              }}
-              onCloseComplete={() => {
-                // This is called after the close animation completes
-                // Dispatch the actual close to the store
+                // This will be wrapped by WindowFrame to trigger animated close
+                // The actual closeAppInstance happens after animation completes
                 closeAppInstance(instance.instanceId);
               }}
               className="pointer-events-auto"

--- a/src/apps/base/AppManager.tsx
+++ b/src/apps/base/AppManager.tsx
@@ -363,7 +363,16 @@ export function AppManager({ apps }: AppManagerProps) {
             <AppComponent
               isWindowOpen={instance.isOpen}
               isForeground={instance.isForeground}
-              onClose={() => closeAppInstance(instance.instanceId)}
+              onClose={() => {
+                // Dispatch close event to trigger animated close in WindowFrame
+                const event = new CustomEvent(`closeWindow-${instance.instanceId}`);
+                window.dispatchEvent(event);
+              }}
+              onCloseComplete={() => {
+                // This is called after the close animation completes
+                // Dispatch the actual close to the store
+                closeAppInstance(instance.instanceId);
+              }}
               className="pointer-events-auto"
               helpItems={apps.find((app) => app.id === appId)?.helpItems}
               skipInitialSound={isInitialMount}

--- a/src/apps/base/types.ts
+++ b/src/apps/base/types.ts
@@ -3,7 +3,6 @@ import type { AppletViewerInitialData } from "@/apps/applet-viewer";
 export interface AppProps<TInitialData = unknown> {
   isWindowOpen: boolean;
   onClose: () => void;
-  onCloseComplete?: () => void; // Called after close animation completes
   isForeground?: boolean;
   className?: string;
   skipInitialSound?: boolean;

--- a/src/apps/base/types.ts
+++ b/src/apps/base/types.ts
@@ -3,6 +3,7 @@ import type { AppletViewerInitialData } from "@/apps/applet-viewer";
 export interface AppProps<TInitialData = unknown> {
   isWindowOpen: boolean;
   onClose: () => void;
+  onCloseComplete?: () => void; // Called after close animation completes
   isForeground?: boolean;
   className?: string;
   skipInitialSound?: boolean;

--- a/src/apps/chats/components/ChatsAppComponent.tsx
+++ b/src/apps/chats/components/ChatsAppComponent.tsx
@@ -43,6 +43,7 @@ interface DisplayMessage extends Omit<AIChatMessage, "role"> {
 export function ChatsAppComponent({
   isWindowOpen,
   onClose,
+  onCloseComplete,
   isForeground,
   skipInitialSound,
   instanceId,
@@ -523,6 +524,7 @@ export function ChatsAppComponent({
             : "@ryo"
         }
         onClose={onClose}
+        onCloseComplete={onCloseComplete}
         isForeground={isForeground}
         appId="chats"
         skipInitialSound={skipInitialSound}

--- a/src/apps/chats/hooks/useAiChat.ts
+++ b/src/apps/chats/hooks/useAiChat.ts
@@ -701,9 +701,11 @@ export function useAiChat(onPromptSetUsername?: () => void) {
               break;
             }
 
-            // Close all open instances of this app
+            // Close all open instances of this app by dispatching close events
+            // This triggers the animated close in WindowFrame
             openInstances.forEach((instance) => {
-              appStore.closeAppInstance(instance.instanceId);
+              const event = new CustomEvent(`closeWindow-${instance.instanceId}`);
+              window.dispatchEvent(event);
             });
 
             // Also close the legacy app state for backward compatibility

--- a/src/apps/chats/hooks/useAiChat.ts
+++ b/src/apps/chats/hooks/useAiChat.ts
@@ -701,11 +701,10 @@ export function useAiChat(onPromptSetUsername?: () => void) {
               break;
             }
 
-            // Close all open instances of this app by dispatching close events
-            // This triggers the animated close in WindowFrame
+            // Close all open instances - trigger animated close via store
+            // The store will call onClose which WindowFrame wraps to trigger animation
             openInstances.forEach((instance) => {
-              const event = new CustomEvent(`closeWindow-${instance.instanceId}`);
-              window.dispatchEvent(event);
+              appStore.closeAppInstance(instance.instanceId);
             });
 
             // Also close the legacy app state for backward compatibility

--- a/src/apps/control-panels/components/ControlPanelsAppComponent.tsx
+++ b/src/apps/control-panels/components/ControlPanelsAppComponent.tsx
@@ -201,6 +201,7 @@ function VersionDisplay() {
 export function ControlPanelsAppComponent({
   isWindowOpen,
   onClose,
+  onCloseComplete,
   isForeground,
   skipInitialSound,
   initialData,
@@ -1486,6 +1487,7 @@ export function ControlPanelsAppComponent({
       <WindowFrame
         title="Control Panels"
         onClose={onClose}
+        onCloseComplete={onCloseComplete}
         isForeground={isForeground}
         appId="control-panels"
         skipInitialSound={skipInitialSound}

--- a/src/apps/finder/components/FinderAppComponent.tsx
+++ b/src/apps/finder/components/FinderAppComponent.tsx
@@ -84,6 +84,7 @@ const getFileType = (file: FileItem): string => {
 
 export function FinderAppComponent({
   onClose,
+  onCloseComplete,
   isWindowOpen,
   isForeground = true,
   skipInitialSound,
@@ -1036,6 +1037,7 @@ export function FinderAppComponent({
               })()
         }
         onClose={onClose}
+        onCloseComplete={onCloseComplete}
         isForeground={isForeground}
         appId="finder"
         skipInitialSound={skipInitialSound}

--- a/src/apps/finder/components/FinderMenuBar.tsx
+++ b/src/apps/finder/components/FinderMenuBar.tsx
@@ -15,6 +15,7 @@ import { useThemeStore } from "@/stores/useThemeStore";
 import { ThemedIcon } from "@/components/shared/ThemedIcon";
 import { ShareItemDialog } from "@/components/dialogs/ShareItemDialog";
 import { appRegistry } from "@/config/appRegistry";
+import { useWindowFrameClose } from "@/components/layout/WindowFrame";
 
 export type ViewType = "small" | "large" | "list";
 export type SortType = "name" | "date" | "size" | "kind";
@@ -74,6 +75,8 @@ export function FinderMenuBar({
   rootFolders,
   onNewWindow,
 }: FinderMenuBarProps) {
+  // Use wrapped close from WindowFrame if available (for animated close), otherwise fall back to prop
+  const wrappedOnClose = useWindowFrameClose() || onClose;
   const [isShareDialogOpen, setIsShareDialogOpen] = useState(false);
   const appId = "finder";
   const appName = appRegistry[appId as keyof typeof appRegistry]?.name || appId;
@@ -167,7 +170,7 @@ export function FinderMenuBar({
           </DropdownMenuItem>
           <DropdownMenuSeparator className="h-[2px] bg-black my-1" />
           <DropdownMenuItem
-            onClick={onClose}
+            onClick={wrappedOnClose}
             className="text-md h-6 px-3 active:bg-gray-900 active:text-white"
           >
             Close

--- a/src/apps/internet-explorer/components/InternetExplorerAppComponent.tsx
+++ b/src/apps/internet-explorer/components/InternetExplorerAppComponent.tsx
@@ -307,6 +307,7 @@ const normalizeUrlForHistory = (url: string): string => {
 export function InternetExplorerAppComponent({
   isWindowOpen,
   onClose,
+  onCloseComplete,
   isForeground,
   skipInitialSound,
   helpItems,
@@ -1992,6 +1993,7 @@ export function InternetExplorerAppComponent({
         <WindowFrame
           title={displayTitle}
           onClose={onClose}
+          onCloseComplete={onCloseComplete}
           isForeground={isForeground}
           appId="internet-explorer"
           skipInitialSound={skipInitialSound}

--- a/src/apps/ipod/components/IpodAppComponent.tsx
+++ b/src/apps/ipod/components/IpodAppComponent.tsx
@@ -864,6 +864,7 @@ function FullScreenPortal({
 export function IpodAppComponent({
   isWindowOpen,
   onClose,
+  onCloseComplete,
   isForeground,
   skipInitialSound,
   initialData,
@@ -2393,6 +2394,7 @@ export function IpodAppComponent({
       <WindowFrame
         title="iPod"
         onClose={onClose}
+        onCloseComplete={onCloseComplete}
         isForeground={isForeground}
         appId="ipod"
         transparentBackground

--- a/src/apps/minesweeper/components/MinesweeperAppComponent.tsx
+++ b/src/apps/minesweeper/components/MinesweeperAppComponent.tsx
@@ -174,6 +174,7 @@ function Cell({
 export function MinesweeperAppComponent({
   isWindowOpen,
   onClose,
+  onCloseComplete,
   isForeground,
   skipInitialSound,
   instanceId,
@@ -461,6 +462,7 @@ export function MinesweeperAppComponent({
       <WindowFrame
         title="Minesweeper"
         onClose={onClose}
+        onCloseComplete={onCloseComplete}
         isForeground={isForeground}
         appId="minesweeper"
         skipInitialSound={skipInitialSound}

--- a/src/apps/paint/components/PaintAppComponent.tsx
+++ b/src/apps/paint/components/PaintAppComponent.tsx
@@ -23,6 +23,7 @@ import { useThemeStore } from "@/stores/useThemeStore";
 export const PaintAppComponent: React.FC<AppProps<PaintInitialData>> = ({
   isWindowOpen,
   onClose,
+  onCloseComplete,
   isForeground = false,
   skipInitialSound,
   initialData,
@@ -453,6 +454,7 @@ export const PaintAppComponent: React.FC<AppProps<PaintInitialData>> = ({
             : `Untitled${hasUnsavedChanges ? " •" : ""}`
         }
         onClose={onClose}
+        onCloseComplete={onCloseComplete}
         isForeground={isForeground}
         appId="paint"
         skipInitialSound={skipInitialSound}

--- a/src/apps/pc/components/PcAppComponent.tsx
+++ b/src/apps/pc/components/PcAppComponent.tsx
@@ -14,6 +14,7 @@ import { useThemeStore } from "@/stores/useThemeStore";
 export function PcAppComponent({
   isWindowOpen,
   onClose,
+  onCloseComplete,
   isForeground,
   skipInitialSound,
   instanceId,
@@ -261,6 +262,7 @@ export function PcAppComponent({
       <WindowFrame
         title="Virtual PC"
         onClose={onClose}
+        onCloseComplete={onCloseComplete}
         isForeground={isForeground}
         appId="pc"
         skipInitialSound={skipInitialSound}

--- a/src/apps/photo-booth/components/PhotoBoothComponent.tsx
+++ b/src/apps/photo-booth/components/PhotoBoothComponent.tsx
@@ -106,6 +106,7 @@ function useSwipeDetection(onSwipeLeft: () => void, onSwipeRight: () => void) {
 export function PhotoBoothComponent({
   isWindowOpen,
   onClose,
+  onCloseComplete,
   isForeground,
   skipInitialSound,
   instanceId,
@@ -840,6 +841,7 @@ export function PhotoBoothComponent({
       <WindowFrame
         title="Photo Booth"
         onClose={onClose}
+        onCloseComplete={onCloseComplete}
         isForeground={isForeground}
         appId="photo-booth"
         skipInitialSound={skipInitialSound}

--- a/src/apps/soundboard/components/SoundboardAppComponent.tsx
+++ b/src/apps/soundboard/components/SoundboardAppComponent.tsx
@@ -29,6 +29,7 @@ interface ImportedBoard {
 
 export function SoundboardAppComponent({
   onClose,
+  onCloseComplete,
   isWindowOpen,
   isForeground,
   helpItems = [],
@@ -380,6 +381,7 @@ export function SoundboardAppComponent({
       <WindowFrame
         title="Soundboard"
         onClose={onClose}
+        onCloseComplete={onCloseComplete}
         isForeground={isForeground}
         appId="soundboard"
         skipInitialSound={skipInitialSound}

--- a/src/apps/synth/components/SynthAppComponent.tsx
+++ b/src/apps/synth/components/SynthAppComponent.tsx
@@ -143,6 +143,7 @@ const PianoKey: React.FC<{
 export function SynthAppComponent({
   isWindowOpen,
   onClose,
+  onCloseComplete,
   isForeground,
   skipInitialSound,
   instanceId,
@@ -856,6 +857,7 @@ export function SynthAppComponent({
       <WindowFrame
         title="Synth"
         onClose={onClose}
+        onCloseComplete={onCloseComplete}
         isForeground={isForeground}
         appId="synth"
         skipInitialSound={skipInitialSound}

--- a/src/apps/terminal/components/TerminalAppComponent.tsx
+++ b/src/apps/terminal/components/TerminalAppComponent.tsx
@@ -535,6 +535,7 @@ const formatToolInvocation = (invocation: ToolInvocation): string | null => {
 
 export function TerminalAppComponent({
   onClose,
+  onCloseComplete,
   isWindowOpen,
   isForeground = true,
   skipInitialSound,
@@ -2968,6 +2969,7 @@ export function TerminalAppComponent({
         appId="terminal"
         title="Terminal"
         onClose={onClose}
+        onCloseComplete={onCloseComplete}
         isForeground={isForeground}
         transparentBackground={true}
         skipInitialSound={skipInitialSound}

--- a/src/apps/videos/components/VideosAppComponent.tsx
+++ b/src/apps/videos/components/VideosAppComponent.tsx
@@ -273,6 +273,7 @@ function StatusDisplay({ message }: { message: string }) {
 export function VideosAppComponent({
   isWindowOpen,
   onClose,
+  onCloseComplete,
   isForeground,
   skipInitialSound,
   initialData,
@@ -1020,6 +1021,7 @@ export function VideosAppComponent({
       <WindowFrame
         title="Videos"
         onClose={onClose}
+        onCloseComplete={onCloseComplete}
         isForeground={isForeground}
         appId="videos"
         skipInitialSound={skipInitialSound}

--- a/src/components/layout/Dock.tsx
+++ b/src/components/layout/Dock.tsx
@@ -707,7 +707,9 @@ function MacDock() {
             type: "item",
             label: "Quit",
             onSelect: () => {
-              closeAppInstance(specificInstanceId);
+              // Dispatch close event to trigger animated close in WindowFrame
+              const event = new CustomEvent(`closeWindow-${specificInstanceId}`);
+              window.dispatchEvent(event);
             },
           });
           
@@ -801,8 +803,10 @@ function MacDock() {
         type: "item",
         label: "Quit",
         onSelect: () => {
+          // Dispatch close events to trigger animated close in WindowFrame
           appInstances.forEach((inst) => {
-            closeAppInstance(inst.instanceId);
+            const event = new CustomEvent(`closeWindow-${inst.instanceId}`);
+            window.dispatchEvent(event);
           });
         },
         disabled: appInstances.length === 0,

--- a/src/components/layout/Dock.tsx
+++ b/src/components/layout/Dock.tsx
@@ -707,9 +707,8 @@ function MacDock() {
             type: "item",
             label: "Quit",
             onSelect: () => {
-              // Dispatch close event to trigger animated close in WindowFrame
-              const event = new CustomEvent(`closeWindow-${specificInstanceId}`);
-              window.dispatchEvent(event);
+              // Close instance - WindowFrame will wrap onClose to trigger animation
+              closeAppInstance(specificInstanceId);
             },
           });
           
@@ -803,10 +802,9 @@ function MacDock() {
         type: "item",
         label: "Quit",
         onSelect: () => {
-          // Dispatch close events to trigger animated close in WindowFrame
+          // Close instances - WindowFrame will wrap onClose to trigger animation
           appInstances.forEach((inst) => {
-            const event = new CustomEvent(`closeWindow-${inst.instanceId}`);
-            window.dispatchEvent(event);
+            closeAppInstance(inst.instanceId);
           });
         },
         disabled: appInstances.length === 0,


### PR DESCRIPTION
Unify app closing behavior to ensure all close methods trigger the animated exit with sound and vibration.

---
<a href="https://cursor.com/background-agent?bcId=bc-20562ba2-21ac-41ba-a017-5500b7bd60ba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-20562ba2-21ac-41ba-a017-5500b7bd60ba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

