### PR TITLE
Animate app closing from all methods

### DIFF
--- a/src/apps/base/AppManager.tsx
+++ b/src/apps/base/AppManager.tsx
@@ -9,6 +9,7 @@ import { AppId, getAppComponent, appRegistry } from "@/config/appRegistry";
 import { useAppStoreShallow } from "@/stores/helpers";
 import { extractCodeFromPath } from "@/utils/sharedUrl";
 import { toast } from "sonner";
+import { requestCloseWindow } from "@/utils/windowUtils";
 
 interface AppManagerProps {
   apps: AnyApp[];
@@ -22,7 +23,6 @@ export function AppManager({ apps }: AppManagerProps) {
     instances,
     instanceOrder,
     launchApp,
-    closeAppInstance,
     bringInstanceToForeground,
     navigateToNextInstance,
     navigateToPreviousInstance,
@@ -31,7 +31,6 @@ export function AppManager({ apps }: AppManagerProps) {
     instances: state.instances,
     instanceOrder: state.instanceOrder,
     launchApp: state.launchApp,
-    closeAppInstance: state.closeAppInstance,
     bringInstanceToForeground: state.bringInstanceToForeground,
     navigateToNextInstance: state.navigateToNextInstance,
     navigateToPreviousInstance: state.navigateToPreviousInstance,
@@ -363,7 +362,7 @@ export function AppManager({ apps }: AppManagerProps) {
             <AppComponent
               isWindowOpen={instance.isOpen}
               isForeground={instance.isForeground}
-              onClose={() => closeAppInstance(instance.instanceId)}
+              onClose={() => requestCloseWindow(instance.instanceId)}
               className="pointer-events-auto"
               helpItems={apps.find((app) => app.id === appId)?.helpItems}
               skipInitialSound={isInitialMount}

--- a/src/apps/chats/hooks/useAiChat.ts
+++ b/src/apps/chats/hooks/useAiChat.ts
@@ -15,6 +15,7 @@ import { toast } from "@/hooks/useToast";
 import { useLaunchApp, type LaunchAppOptions } from "@/hooks/useLaunchApp";
 import { AppId } from "@/config/appIds";
 import { appRegistry } from "@/config/appRegistry";
+import { requestCloseWindow } from "@/utils/windowUtils";
 import {
   useFileSystem,
   dbOperations,
@@ -701,9 +702,9 @@ export function useAiChat(onPromptSetUsername?: () => void) {
               break;
             }
 
-            // Close all open instances of this app
+            // Close all open instances of this app (with animation and sound)
             openInstances.forEach((instance) => {
-              appStore.closeAppInstance(instance.instanceId);
+              requestCloseWindow(instance.instanceId);
             });
 
             // Also close the legacy app state for backward compatibility

--- a/src/components/layout/Dock.tsx
+++ b/src/components/layout/Dock.tsx
@@ -20,6 +20,7 @@ import type { AppInstance } from "@/stores/useAppStore";
 import type { AppletViewerInitialData } from "@/apps/applet-viewer";
 import { RightClickMenu, MenuItem } from "@/components/ui/right-click-menu";
 import { ConfirmDialog } from "@/components/dialogs/ConfirmDialog";
+import { requestCloseWindow } from "@/utils/windowUtils";
 import {
   AnimatePresence,
   motion,
@@ -317,14 +318,13 @@ const MULTI_WINDOW_APPS: AppId[] = ["textedit", "finder", "applet-viewer"];
 
 function MacDock() {
   const isPhone = useIsPhone();
-  const { instances, instanceOrder, bringInstanceToForeground, restoreInstance, minimizeInstance, closeAppInstance } =
+  const { instances, instanceOrder, bringInstanceToForeground, restoreInstance, minimizeInstance } =
     useAppStoreShallow((s) => ({
       instances: s.instances,
       instanceOrder: s.instanceOrder,
       bringInstanceToForeground: s.bringInstanceToForeground,
       restoreInstance: s.restoreInstance,
       minimizeInstance: s.minimizeInstance,
-      closeAppInstance: s.closeAppInstance,
     }));
 
   const launchApp = useLaunchApp();
@@ -707,7 +707,7 @@ function MacDock() {
             type: "item",
             label: "Quit",
             onSelect: () => {
-              closeAppInstance(specificInstanceId);
+              requestCloseWindow(specificInstanceId);
             },
           });
           
@@ -802,7 +802,7 @@ function MacDock() {
         label: "Quit",
         onSelect: () => {
           appInstances.forEach((inst) => {
-            closeAppInstance(inst.instanceId);
+            requestCloseWindow(inst.instanceId);
           });
         },
         disabled: appInstances.length === 0,
@@ -810,7 +810,7 @@ function MacDock() {
       
       return items;
     },
-    [instances, finderInstances, getAppletInfo, restoreInstance, bringInstanceToForeground, minimizeInstance, closeAppInstance, launchApp]
+    [instances, finderInstances, getAppletInfo, restoreInstance, bringInstanceToForeground, minimizeInstance, launchApp]
   );
 
   // Handle app context menu

--- a/src/utils/windowUtils.ts
+++ b/src/utils/windowUtils.ts
@@ -1,0 +1,19 @@
+/**
+ * Window utilities for managing window close with animations and sounds.
+ *
+ * This module provides a centralized way to request window close operations
+ * that properly trigger the WindowFrame's close animation and sound effects.
+ */
+
+/**
+ * Request a window to close with its standard animation and sound.
+ * This dispatches an event that WindowFrame listens for, allowing it to
+ * trigger the proper close animation before actually removing the window.
+ *
+ * @param instanceId - The instance ID of the window to close
+ */
+export function requestCloseWindow(instanceId: string): void {
+  window.dispatchEvent(
+    new CustomEvent(`requestCloseWindow-${instanceId}`)
+  );
+}


### PR DESCRIPTION
Enable close animation and sound for all window closing methods.

Previously, only the close button triggered the close animation and sound. This PR unifies the window closing behavior by introducing a `requestCloseWindow` event, ensuring that all close actions (right-click menus, menubar actions, AI tool calls) now trigger the proper animation and sound effects before the window is removed.

---
<a href="https://cursor.com/background-agent?bcId=bc-88ef93b1-5dc5-4a2b-983a-61a58bc87650"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-88ef93b1-5dc5-4a2b-983a-61a58bc87650"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

