### PR TITLE
Fix dock right click menu bugs

### DIFF
--- a/public/version.json
+++ b/public/version.json
@@ -1,8 +1,8 @@
 {
   "version": "10.3",
-  "buildNumber": "063c0f1",
-  "commitSha": "063c0f1508c29cc432f623114c45d23b106d7971",
-  "buildTime": "2025-12-01T05:58:50.703Z",
+  "buildNumber": "acda61f",
+  "commitSha": "acda61f8be3b27c7d2866ad668f480c6a48c1eab",
+  "buildTime": "2025-12-01T12:23:49.991Z",
   "majorVersion": 10,
   "minorVersion": 3
 }


### PR DESCRIPTION
Fixes dock right-click menu issues where 'Quit' didn't work for minimized windows and 'Hide' didn't play a sound.

The 'Quit' action failed for minimized windows because the `WindowFrame` component, which listens for close events, doesn't render when minimized. This PR now directly calls `closeAppInstance` for minimized windows. The 'Hide' action now plays the `WINDOW_ZOOM_MINIMIZE` sound, aligning its behavior with minimizing via a window's title bar.

---
<a href="https://cursor.com/background-agent?bcId=bc-a73e4eff-a315-4377-adbd-4e51c692e02b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a73e4eff-a315-4377-adbd-4e51c692e02b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

