### PR TITLE
Fix ipod minimize and restore bugs

### DIFF
--- a/public/version.json
+++ b/public/version.json
@@ -1,8 +1,8 @@
 {
   "version": "10.3",
-  "buildNumber": "17ad8c0",
-  "commitSha": "17ad8c0b189ec38e2ffd7ad031cb1582ec05fcbc",
-  "buildTime": "2025-12-01T19:09:24.001Z",
+  "buildNumber": "0faf880",
+  "commitSha": "0faf88040d1451edd2a9217d14f57130547a175e",
+  "buildTime": "2025-12-01T19:12:08.323Z",
   "majorVersion": 10,
   "minorVersion": 3
 }

--- a/src/apps/ipod/components/IpodAppComponent.tsx
+++ b/src/apps/ipod/components/IpodAppComponent.tsx
@@ -2418,6 +2418,7 @@ export function IpodAppComponent({
         onNavigateNext={onNavigateNext}
         onNavigatePrevious={onNavigatePrevious}
         menuBar={isXpTheme ? menuBar : undefined}
+        keepMountedWhenMinimized
       >
         <div
           ref={containerRef}


### PR DESCRIPTION
Keep iPod playing when minimized and fix resize issues after restoring from minimize.

Previously, minimizing the iPod window caused its component tree to unmount, stopping audio/video playback. This PR changes the minimize behavior to keep the component mounted and visually hide it using `motion.div`'s `animate` prop. Additionally, after restoring from a minimized state, the iPod window sometimes failed to resize correctly; this is addressed by triggering multiple delayed resize calculations to account for animation completion.

---
<a href="https://cursor.com/background-agent?bcId=bc-128cabe5-578d-497d-b781-e05c3c30ec63"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-128cabe5-578d-497d-b781-e05c3c30ec63"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

