### PR TITLE
Find missing german translations for chats

### DIFF
--- a/src/lib/locales/de/translation.json
+++ b/src/lib/locales/de/translation.json
@@ -209,22 +209,22 @@
         }
       },
       "menu": {
-        "aboutChats": "About Chats",
-        "chatSpeech": "Chat Speech",
+        "aboutChats": "Über Chats",
+        "chatSpeech": "Chat-Sprachausgabe",
         "chats": "Chats",
-        "chatsHelp": "Chats Help",
-        "clearChat": "Clear Chat",
-        "createAccount": "Create Account...",
-        "decreaseFontSize": "Decrease Font Size",
-        "increaseFontSize": "Increase Font Size",
-        "logOut": "Log Out",
-        "login": "Login...",
-        "newChat": "New Chat...",
-        "resetFontSize": "Reset Font Size",
-        "saveTranscript": "Save Transcript...",
-        "showRooms": "Show Rooms",
-        "sound": "Sound",
-        "typingSynth": "Typing Synth"
+        "chatsHelp": "Chats-Hilfe",
+        "clearChat": "Chat leeren",
+        "createAccount": "Konto erstellen...",
+        "decreaseFontSize": "Schriftgröße verkleinern",
+        "increaseFontSize": "Schriftgröße vergrößern",
+        "logOut": "Abmelden",
+        "login": "Anmelden...",
+        "newChat": "Neuer Chat...",
+        "resetFontSize": "Schriftgröße zurücksetzen",
+        "saveTranscript": "Transkript speichern...",
+        "showRooms": "Räume anzeigen",
+        "sound": "Ton",
+        "typingSynth": "Tipp-Synthesizer"
       },
       "messages": {
         "delete": "Löschen",
@@ -237,7 +237,7 @@
         "channels": "Kanäle",
         "chats": "Chats",
         "new": "neu",
-        "online": "online",
+        "online": "aktiv",
         "private": "Privat"
       },
       "status": {


### PR DESCRIPTION
Adds missing German translations for the Chats app menu and "online" status, as the existing translation sync script doesn't detect untranslated values.

The `sync-translations.ts` script only identifies keys that are missing from a locale file, not instances where a key exists but its value is still the English source string. A custom script was used to find these untranslated values.

---
<a href="https://cursor.com/background-agent?bcId=bc-d3e24bcc-74f5-41d9-b146-4aa4282864be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d3e24bcc-74f5-41d9-b146-4aa4282864be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

