### PR TITLE
Remove duplicate system entry in help

### DIFF
--- a/src/apps/control-panels/index.ts
+++ b/src/apps/control-panels/index.ts
@@ -30,11 +30,6 @@ export const helpItems = [
     title: "Language",
     description: "Select your preferred language for ryOS interface",
   },
-  {
-    icon: "⚙️",
-    title: "System",
-    description: "Reset preferences or format the virtual file system",
-  },
 ];
 
 export const appMetadata = {

--- a/src/hooks/useTranslatedHelpItems.ts
+++ b/src/hooks/useTranslatedHelpItems.ts
@@ -27,7 +27,7 @@ export function useTranslatedHelpItems(
     pc: ["pcEmulator", "keyboardControls", "mouseCapture", "fullscreenMode", "saveStates", "aspectRatio"],
     terminal: ["basicCommands", "navigation", "commandHistory", "aiAssistant", "fileEditing", "terminalSounds"],
     "applet-viewer": ["appletStore", "createWithRyosChat", "viewApplets", "shareApplets", "openFromFinder", "keepUpdated"],
-    "control-panels": ["appearance", "sounds", "aiModel", "shaderEffects", "backupRestore", "system"],
+    "control-panels": ["appearance", "sounds", "aiModel", "shaderEffects", "backupRestore", "language"],
   };
 
   return useMemo(() => {


### PR DESCRIPTION
Remove duplicate "System" item from Control Panels help and update translation key for "Language" item.

---
<a href="https://cursor.com/background-agent?bcId=bc-108111d7-f3fb-4a91-9ed1-fdbe0ccf688d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-108111d7-f3fb-4a91-9ed1-fdbe0ccf688d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

