### PR TITLE
Make menu bar mobile friendly with scroll and fade

### DIFF
--- a/public/version.json
+++ b/public/version.json
@@ -1,8 +1,8 @@
 {
   "version": "10.3",
-  "buildNumber": "39fe87c",
-  "commitSha": "39fe87c6b557a8ffd5dc25caabc16bb20afff376",
-  "buildTime": "2025-12-02T19:15:11.834Z",
+  "buildNumber": "48daf57",
+  "commitSha": "48daf57e44b40129b3b576b52e963db917482920",
+  "buildTime": "2025-12-02T21:07:46.650Z",
   "majorVersion": 10,
   "minorVersion": 3
 }

--- a/src/components/layout/MenuBar.tsx
+++ b/src/components/layout/MenuBar.tsx
@@ -647,13 +647,6 @@ export function MenuBar({ children, inWindowFrame = false }: MenuBarProps) {
     return { icon, label, isEmoji };
   };
 
-  // Scroll handling for mobile menu bar (must be before early returns)
-  const scrollContainerRef = useRef<HTMLDivElement>(null);
-  const [showLeftMask, setShowLeftMask] = useState(false);
-  const [showRightMask, setShowRightMask] = useState(false);
-  const [isScrolling, setIsScrolling] = useState(false);
-  const scrollTimeoutRef = useRef<number | null>(null);
-  const touchStartRef = useRef<{ x: number; y: number; scrollLeft: number } | null>(null);
 
   // Taskbar overflow handling (used for XP taskbar rendering)
   const runningAreaRef = useRef<HTMLDivElement>(null);
@@ -711,95 +704,6 @@ export function MenuBar({ children, inWindowFrame = false }: MenuBarProps) {
       window.removeEventListener("resize", compute);
     };
   }, [isXpTheme, inWindowFrame, allTaskbarIds]);
-
-  // Scroll handling useEffect for mobile menu bar (must be before early returns)
-  useEffect(() => {
-    // Only set up scroll handling for Mac-style menubar (not XP/98 taskbar)
-    if (isXpTheme && !inWindowFrame) return;
-    
-    const container = scrollContainerRef.current;
-    if (!container) return;
-
-    const updateMasks = () => {
-      const { scrollLeft, scrollWidth, clientWidth } = container;
-      // Show left mask if scrolled to the right (not at the start)
-      setShowLeftMask(scrollLeft > 0);
-      // Show right mask if there's more content to scroll (not at the end)
-      setShowRightMask(scrollLeft < scrollWidth - clientWidth - 1);
-    };
-
-    // Track scrolling state to prevent clicks during scroll
-    const handleScroll = () => {
-      setIsScrolling(true);
-      updateMasks();
-      
-      // Clear existing timeout
-      if (scrollTimeoutRef.current) {
-        clearTimeout(scrollTimeoutRef.current);
-      }
-      
-      // Reset scrolling state after scroll ends
-      scrollTimeoutRef.current = setTimeout(() => {
-        setIsScrolling(false);
-      }, 150);
-    };
-
-    // Handle touch events to detect scrolling vs tapping
-    const handleTouchStart = (e: TouchEvent) => {
-      if (!e.touches || e.touches.length === 0) return;
-      const touch = e.touches[0];
-      touchStartRef.current = {
-        x: touch.clientX,
-        y: touch.clientY,
-        scrollLeft: container.scrollLeft,
-      };
-    };
-
-    const handleTouchMove = (e: TouchEvent) => {
-      if (!touchStartRef.current || !e.touches || e.touches.length === 0) return;
-      
-      const touch = e.touches[0];
-      const deltaX = Math.abs(touch.clientX - touchStartRef.current.x);
-      const deltaY = Math.abs(touch.clientY - touchStartRef.current.y);
-      const scrollDelta = Math.abs(container.scrollLeft - touchStartRef.current.scrollLeft);
-      
-      // If moved more than 5px horizontally or scrolled, consider it scrolling
-      if (deltaX > 5 || deltaY > 5 || scrollDelta > 1) {
-        setIsScrolling(true);
-      }
-    };
-
-    const handleTouchEnd = () => {
-      // Reset scrolling state after a short delay
-      if (scrollTimeoutRef.current) {
-        clearTimeout(scrollTimeoutRef.current);
-      }
-      scrollTimeoutRef.current = setTimeout(() => {
-        setIsScrolling(false);
-        touchStartRef.current = null;
-      }, 100);
-    };
-
-    updateMasks();
-    container.addEventListener("scroll", handleScroll);
-    container.addEventListener("touchstart", handleTouchStart, { passive: true });
-    container.addEventListener("touchmove", handleTouchMove, { passive: true });
-    container.addEventListener("touchend", handleTouchEnd, { passive: true });
-    
-    const resizeObserver = new ResizeObserver(updateMasks);
-    resizeObserver.observe(container);
-
-    return () => {
-      container.removeEventListener("scroll", handleScroll);
-      container.removeEventListener("touchstart", handleTouchStart);
-      container.removeEventListener("touchmove", handleTouchMove);
-      container.removeEventListener("touchend", handleTouchEnd);
-      if (scrollTimeoutRef.current) {
-        clearTimeout(scrollTimeoutRef.current);
-      }
-      resizeObserver.disconnect();
-    };
-  }, [isXpTheme, inWindowFrame, hasActiveApp, children]);
 
   // If inside window frame for XP/98, use plain style
   if (inWindowFrame && isXpTheme) {
@@ -1164,98 +1068,6 @@ export function MenuBar({ children, inWindowFrame = false }: MenuBarProps) {
   }
 
   // Default Mac-style top menubar
-  const scrollContainerRef = useRef<HTMLDivElement>(null);
-  const [showLeftMask, setShowLeftMask] = useState(false);
-  const [showRightMask, setShowRightMask] = useState(false);
-  const [isScrolling, setIsScrolling] = useState(false);
-  const scrollTimeoutRef = useRef<number | null>(null);
-  const touchStartRef = useRef<{ x: number; y: number; scrollLeft: number } | null>(null);
-
-  useEffect(() => {
-    const container = scrollContainerRef.current;
-    if (!container) return;
-
-    const updateMasks = () => {
-      const { scrollLeft, scrollWidth, clientWidth } = container;
-      // Show left mask if scrolled to the right (not at the start)
-      setShowLeftMask(scrollLeft > 0);
-      // Show right mask if there's more content to scroll (not at the end)
-      setShowRightMask(scrollLeft < scrollWidth - clientWidth - 1);
-    };
-
-    // Track scrolling state to prevent clicks during scroll
-    const handleScroll = () => {
-      setIsScrolling(true);
-      updateMasks();
-      
-      // Clear existing timeout
-      if (scrollTimeoutRef.current) {
-        clearTimeout(scrollTimeoutRef.current);
-      }
-      
-      // Reset scrolling state after scroll ends
-      scrollTimeoutRef.current = setTimeout(() => {
-        setIsScrolling(false);
-      }, 150);
-    };
-
-    // Handle touch events to detect scrolling vs tapping
-    const handleTouchStart = (e: TouchEvent) => {
-      if (!e.touches || e.touches.length === 0) return;
-      const touch = e.touches[0];
-      touchStartRef.current = {
-        x: touch.clientX,
-        y: touch.clientY,
-        scrollLeft: container.scrollLeft,
-      };
-    };
-
-    const handleTouchMove = (e: TouchEvent) => {
-      if (!touchStartRef.current || !e.touches || e.touches.length === 0) return;
-      
-      const touch = e.touches[0];
-      const deltaX = Math.abs(touch.clientX - touchStartRef.current.x);
-      const deltaY = Math.abs(touch.clientY - touchStartRef.current.y);
-      const scrollDelta = Math.abs(container.scrollLeft - touchStartRef.current.scrollLeft);
-      
-      // If moved more than 5px horizontally or scrolled, consider it scrolling
-      if (deltaX > 5 || deltaY > 5 || scrollDelta > 1) {
-        setIsScrolling(true);
-      }
-    };
-
-    const handleTouchEnd = () => {
-      // Reset scrolling state after a short delay
-      if (scrollTimeoutRef.current) {
-        clearTimeout(scrollTimeoutRef.current);
-      }
-      scrollTimeoutRef.current = setTimeout(() => {
-        setIsScrolling(false);
-        touchStartRef.current = null;
-      }, 100);
-    };
-
-    updateMasks();
-    container.addEventListener("scroll", handleScroll);
-    container.addEventListener("touchstart", handleTouchStart, { passive: true });
-    container.addEventListener("touchmove", handleTouchMove, { passive: true });
-    container.addEventListener("touchend", handleTouchEnd, { passive: true });
-    
-    const resizeObserver = new ResizeObserver(updateMasks);
-    resizeObserver.observe(container);
-
-    return () => {
-      container.removeEventListener("scroll", handleScroll);
-      container.removeEventListener("touchstart", handleTouchStart);
-      container.removeEventListener("touchmove", handleTouchMove);
-      container.removeEventListener("touchend", handleTouchEnd);
-      if (scrollTimeoutRef.current) {
-        clearTimeout(scrollTimeoutRef.current);
-      }
-      resizeObserver.disconnect();
-    };
-  }, [hasActiveApp, children]);
-
   return (
     <div
       className="fixed top-0 left-0 right-0 flex border-b-[length:var(--os-metrics-border-width)] border-os-menubar px-2 h-os-menubar items-center font-os-ui"
@@ -1278,56 +1090,36 @@ export function MenuBar({ children, inWindowFrame = false }: MenuBarProps) {
       }}
     >
       <AppleMenu apps={apps} />
-      {/* Scrollable menu items container with fade masks */}
+      {/* Scrollable menu items container with CSS scroll-driven fade masks */}
       <div className="flex-1 relative min-w-0 overflow-hidden">
         <div
-          ref={scrollContainerRef}
-          className="overflow-x-auto scrollbar-hide flex items-center gap-0"
+          className="overflow-x-auto scrollbar-hide flex items-center gap-0 menubar-scroll-container"
           style={{
             scrollbarWidth: "none",
             msOverflowStyle: "none",
             WebkitOverflowScrolling: "touch",
+            maskImage: "linear-gradient(to right, transparent 0, black 2rem, black calc(100% - 2rem), transparent 100%)",
+            WebkitMaskImage: "linear-gradient(to right, transparent 0, black 2rem, black calc(100% - 2rem), transparent 100%)",
+            maskPosition: "0 0",
           }}
         >
           <style>{`
             .scrollbar-hide::-webkit-scrollbar {
               display: none;
             }
+            .menubar-scroll-container {
+              animation: menubar-mask-in;
+              animation-timeline: scroll(self inline);
+              animation-range: 0 2rem;
+            }
+            @keyframes menubar-mask-in {
+              0% {
+                mask-position: -2rem 0;
+              }
+            }
           `}</style>
-          <div
-            style={{
-              pointerEvents: isScrolling ? "none" : "auto",
-            }}
-          >
-            {hasActiveApp ? children : <DefaultMenuItems />}
-          </div>
+          {hasActiveApp ? children : <DefaultMenuItems />}
         </div>
-        {/* Left fade mask - shows when scrolled to the right */}
-        {showLeftMask && (
-          <div
-            className="absolute left-0 top-0 bottom-0 w-8 pointer-events-none z-10"
-            style={{
-              maskImage: "linear-gradient(to right, black, transparent)",
-              WebkitMaskImage: "linear-gradient(to right, black, transparent)",
-              backgroundColor: currentTheme === "macosx"
-                ? "rgba(248, 248, 248, 0.85)"
-                : "var(--os-color-menubar-bg)",
-            }}
-          />
-        )}
-        {/* Right fade mask - shows when there's more content to scroll */}
-        {showRightMask && (
-          <div
-            className="absolute right-0 top-0 bottom-0 w-8 pointer-events-none z-10"
-            style={{
-              maskImage: "linear-gradient(to left, black, transparent)",
-              WebkitMaskImage: "linear-gradient(to left, black, transparent)",
-              backgroundColor: currentTheme === "macosx"
-                ? "rgba(248, 248, 248, 0.85)"
-                : "var(--os-color-menubar-bg)",
-            }}
-          />
-        )}
       </div>
       <div className="ml-auto flex items-center flex-shrink-0">
         <OfflineIndicator />

--- a/src/components/layout/MenuBar.tsx
+++ b/src/components/layout/MenuBar.tsx
@@ -1089,8 +1089,34 @@ export function MenuBar({ children, inWindowFrame = false }: MenuBarProps) {
       }}
     >
       <AppleMenu apps={apps} />
-      {hasActiveApp ? children : <DefaultMenuItems />}
-      <div className="ml-auto flex items-center">
+      {/* Scrollable menu items container with fade mask */}
+      <div className="flex-1 relative min-w-0 overflow-hidden">
+        <div
+          className="overflow-x-auto scrollbar-hide flex items-center gap-0"
+          style={{
+            scrollbarWidth: "none",
+            msOverflowStyle: "none",
+            WebkitOverflowScrolling: "touch",
+          }}
+        >
+          <style>{`
+            .scrollbar-hide::-webkit-scrollbar {
+              display: none;
+            }
+          `}</style>
+          {hasActiveApp ? children : <DefaultMenuItems />}
+        </div>
+        {/* Fade mask on the right side */}
+        <div
+          className="absolute right-0 top-0 bottom-0 w-8 pointer-events-none z-10"
+          style={{
+            background: currentTheme === "macosx"
+              ? "linear-gradient(to right, transparent, rgba(248, 248, 248, 0.85))"
+              : `linear-gradient(to right, transparent, var(--os-color-menubar-bg))`,
+          }}
+        />
+      </div>
+      <div className="ml-auto flex items-center flex-shrink-0">
         <OfflineIndicator />
         <div className="hidden sm:flex">
           <VolumeControl />

--- a/src/components/layout/MenuBar.tsx
+++ b/src/components/layout/MenuBar.tsx
@@ -648,6 +648,12 @@ export function MenuBar({ children, inWindowFrame = false }: MenuBarProps) {
   };
 
 
+  // Scroll container ref for Mac-style menubar (must be before early returns)
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
+  const [showLeftMask, setShowLeftMask] = useState(false);
+  const [showRightMask, setShowRightMask] = useState(false);
+  const isScrollingRef = useRef(false);
+
   // Taskbar overflow handling (used for XP taskbar rendering)
   const runningAreaRef = useRef<HTMLDivElement>(null);
   const [visibleTaskbarIds, setVisibleTaskbarIds] = useState<string[]>([]);
@@ -704,6 +710,91 @@ export function MenuBar({ children, inWindowFrame = false }: MenuBarProps) {
       window.removeEventListener("resize", compute);
     };
   }, [isXpTheme, inWindowFrame, allTaskbarIds]);
+
+  // Scroll detection for Mac-style menubar (must be before early returns)
+  useEffect(() => {
+    // Only set up for Mac-style menubar (not XP/98 taskbar)
+    if (isXpTheme && !inWindowFrame) return;
+    
+    const container = scrollContainerRef.current;
+    if (!container) return;
+
+    const updateMasks = () => {
+      const { scrollLeft, scrollWidth, clientWidth } = container;
+      setShowLeftMask(scrollLeft > 1);
+      setShowRightMask(scrollLeft < scrollWidth - clientWidth - 1);
+    };
+
+    const handleScroll = () => {
+      isScrollingRef.current = true;
+      updateMasks();
+      // Reset scrolling state after scroll ends
+      setTimeout(() => {
+        isScrollingRef.current = false;
+      }, 150);
+    };
+
+    // Prevent clicks during touch scrolling
+    let touchStartX = 0;
+    let touchStartY = 0;
+    let isTouchScrolling = false;
+
+    const handleTouchStart = (e: TouchEvent) => {
+      if (e.touches.length > 0) {
+        touchStartX = e.touches[0].clientX;
+        touchStartY = e.touches[0].clientY;
+        isTouchScrolling = false;
+      }
+    };
+
+    const handleTouchMove = (e: TouchEvent) => {
+      if (e.touches.length > 0) {
+        const deltaX = Math.abs(e.touches[0].clientX - touchStartX);
+        const deltaY = Math.abs(e.touches[0].clientY - touchStartY);
+        if (deltaX > 5 || deltaY > 5) {
+          isTouchScrolling = true;
+          isScrollingRef.current = true;
+        }
+      }
+    };
+
+    const handleTouchEnd = () => {
+      if (isTouchScrolling) {
+        setTimeout(() => {
+          isScrollingRef.current = false;
+          isTouchScrolling = false;
+        }, 100);
+      }
+    };
+
+    const handleClick = (e: MouseEvent) => {
+      if (isScrollingRef.current) {
+        e.preventDefault();
+        e.stopPropagation();
+        e.stopImmediatePropagation();
+        return false;
+      }
+    };
+
+    updateMasks();
+    container.addEventListener("scroll", handleScroll);
+    container.addEventListener("touchstart", handleTouchStart, { passive: true });
+    container.addEventListener("touchmove", handleTouchMove, { passive: true });
+    container.addEventListener("touchend", handleTouchEnd, { passive: true });
+    container.addEventListener("click", handleClick, true);
+    
+    const resizeObserver = new ResizeObserver(updateMasks);
+    resizeObserver.observe(container);
+
+    return () => {
+      container.removeEventListener("scroll", handleScroll);
+      container.removeEventListener("touchstart", handleTouchStart);
+      container.removeEventListener("touchmove", handleTouchMove);
+      container.removeEventListener("touchend", handleTouchEnd);
+      container.removeEventListener("click", handleClick, true);
+      resizeObserver.disconnect();
+    };
+  }, [isXpTheme, inWindowFrame, hasActiveApp, children]);
 
   // If inside window frame for XP/98, use plain style
   if (inWindowFrame && isXpTheme) {
@@ -1093,33 +1184,57 @@ export function MenuBar({ children, inWindowFrame = false }: MenuBarProps) {
       {/* Scrollable menu items container with CSS scroll-driven fade masks */}
       <div className="flex-1 relative min-w-0 overflow-hidden">
         <div
+          ref={scrollContainerRef}
           className="overflow-x-auto scrollbar-hide flex items-center gap-0 menubar-scroll-container"
           style={{
             scrollbarWidth: "none",
             msOverflowStyle: "none",
             WebkitOverflowScrolling: "touch",
-            maskImage: "linear-gradient(to right, transparent 0, black 2rem, black calc(100% - 2rem), transparent 100%)",
-            WebkitMaskImage: "linear-gradient(to right, transparent 0, black 2rem, black calc(100% - 2rem), transparent 100%)",
-            maskPosition: "0 0",
           }}
         >
           <style>{`
             .scrollbar-hide::-webkit-scrollbar {
               display: none;
             }
-            .menubar-scroll-container {
-              animation: menubar-mask-in;
-              animation-timeline: scroll(self inline);
-              animation-range: 0 2rem;
-            }
-            @keyframes menubar-mask-in {
-              0% {
-                mask-position: -2rem 0;
-              }
+            .menubar-scroll-content {
+              touch-action: pan-x;
             }
           `}</style>
-          {hasActiveApp ? children : <DefaultMenuItems />}
+          <div 
+            className="menubar-scroll-content"
+            style={{
+              pointerEvents: isScrollingRef.current ? "none" : "auto",
+            }}
+          >
+            {hasActiveApp ? children : <DefaultMenuItems />}
+          </div>
         </div>
+        {/* Left fade mask - only shows when scrolled to the right */}
+        {showLeftMask && (
+          <div
+            className="absolute left-0 top-0 bottom-0 w-8 pointer-events-none z-10"
+            style={{
+              maskImage: "linear-gradient(to right, black, transparent)",
+              WebkitMaskImage: "linear-gradient(to right, black, transparent)",
+              backgroundColor: currentTheme === "macosx"
+                ? "rgba(248, 248, 248, 0.85)"
+                : "var(--os-color-menubar-bg)",
+            }}
+          />
+        )}
+        {/* Right fade mask - only shows when not at the end */}
+        {showRightMask && (
+          <div
+            className="absolute right-0 top-0 bottom-0 w-8 pointer-events-none z-10"
+            style={{
+              maskImage: "linear-gradient(to left, black, transparent)",
+              WebkitMaskImage: "linear-gradient(to left, black, transparent)",
+              backgroundColor: currentTheme === "macosx"
+                ? "rgba(248, 248, 248, 0.85)"
+                : "var(--os-color-menubar-bg)",
+            }}
+          />
+        )}
       </div>
       <div className="ml-auto flex items-center flex-shrink-0">
         <OfflineIndicator />

--- a/src/components/layout/MenuBar.tsx
+++ b/src/components/layout/MenuBar.tsx
@@ -1176,7 +1176,7 @@ export function MenuBar({ children, inWindowFrame = false }: MenuBarProps) {
       <div className="flex-1 relative min-w-0 overflow-hidden">
         <div
           ref={scrollContainerRef}
-          className="overflow-x-auto scrollbar-hide flex items-center gap-0 menubar-scroll-container"
+          className="overflow-x-auto scrollbar-hide flex items-center gap-0 menubar-scroll-container flex-nowrap"
           style={{
             scrollbarWidth: "none",
             msOverflowStyle: "none",
@@ -1205,7 +1205,7 @@ export function MenuBar({ children, inWindowFrame = false }: MenuBarProps) {
             }
           `}</style>
           <div 
-            className="menubar-scroll-content"
+            className="menubar-scroll-content flex items-center flex-nowrap"
             style={{
               pointerEvents: isScrolling ? "none" : "auto",
             }}


### PR DESCRIPTION
Make the menu bar mobile-friendly by adding horizontal scrolling for menu items and a fade mask on the right.

---
<a href="https://cursor.com/background-agent?bcId=bc-e2b56376-bf8a-49a4-897e-ce8384d81af8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e2b56376-bf8a-49a4-897e-ce8384d81af8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

