### PR TITLE
Update language switching tool with new languages

### DIFF
--- a/api/chat.ts
+++ b/api/chat.ts
@@ -38,7 +38,7 @@ interface SystemState {
   username?: string | null;
   /** User's operating system (e.g., "iOS", "Android", "macOS", "Windows", "Linux") */
   userOS?: string;
-  /** User's system locale (e.g., "en", "zh-TW", "ja", "ko", "fr", "de") */
+  /** User's system locale (e.g., "en", "zh-TW", "ja", "ko", "fr", "de", "es", "pt", "it", "ru") */
   locale?: string;
   internetExplorer: {
     url: string;
@@ -1070,10 +1070,10 @@ export default async function handler(req: Request) {
             "Change system settings in ryOS. Use this tool when the user asks to change language, theme, volume, enable/disable speech, or check for updates. Multiple settings can be changed in a single call.",
           inputSchema: z.object({
             language: z
-              .enum(["en", "zh-TW", "ja", "ko", "fr", "de"])
+              .enum(["en", "zh-TW", "ja", "ko", "fr", "de", "es", "pt", "it", "ru"])
               .optional()
               .describe(
-                "Change the system language. Supported: 'en' (English), 'zh-TW' (Traditional Chinese), 'ja' (Japanese), 'ko' (Korean), 'fr' (French), 'de' (German)."
+                "Change the system language. Supported: 'en' (English), 'zh-TW' (Traditional Chinese), 'ja' (Japanese), 'ko' (Korean), 'fr' (French), 'de' (German), 'es' (Spanish), 'pt' (Portuguese), 'it' (Italian), 'ru' (Russian)."
               ),
             theme: z
               .enum(themeIds)

--- a/api/utils/aiPrompts.ts
+++ b/api/utils/aiPrompts.ts
@@ -180,7 +180,7 @@ Use \`edit\` to make targeted changes to existing documents or applets:
 
 ## SYSTEM SETTINGS
 Use \`settings\` tool to change system preferences:
-- \`language\`: "en", "zh-TW", "ja", "ko", "fr", "de"
+- \`language\`: "en", "zh-TW", "ja", "ko", "fr", "de", "es", "pt", "it", "ru"
 - \`theme\`: "system7" (Classic Mac), "macosx" (Mac OS X), "xp" (Windows XP), "win98" (Windows 98)
 - \`masterVolume\`: 0-1 (0 = mute, 1 = full volume)
 - \`speechEnabled\`: true/false (text-to-speech for AI responses)

--- a/src/apps/chats/hooks/useAiChat.ts
+++ b/src/apps/chats/hooks/useAiChat.ts
@@ -2139,6 +2139,10 @@ export function useAiChat(onPromptSetUsername?: () => void) {
                   ko: "apps.ipod.translationLanguages.korean",
                   fr: "apps.ipod.translationLanguages.french",
                   de: "apps.ipod.translationLanguages.german",
+                  es: "apps.ipod.translationLanguages.spanish",
+                  pt: "apps.ipod.translationLanguages.portuguese",
+                  it: "apps.ipod.translationLanguages.italian",
+                  ru: "apps.ipod.translationLanguages.russian",
                 };
                 const key = langMap[langCode];
                 if (key) {
@@ -2148,7 +2152,7 @@ export function useAiChat(onPromptSetUsername?: () => void) {
                 }
                 return langCode;
               };
-              langStore.setLanguage(language as "en" | "zh-TW" | "ja" | "ko" | "fr" | "de");
+              langStore.setLanguage(language as "en" | "zh-TW" | "ja" | "ko" | "fr" | "de" | "es" | "pt" | "it" | "ru");
               changes.push(
                 i18n.t("apps.chats.toolCalls.settingsLanguageChanged", {
                   language: getLanguageDisplayName(language),


### PR DESCRIPTION
Update `settings` tool call to support all 10 available languages.

The `settings` tool call handler previously only supported 6 languages, while `i18n.ts` `SUPPORTED_LANGUAGES` included 10. This PR aligns the tool's capabilities with the full list of supported languages: English, Traditional Chinese, Japanese, Korean, French, German, Spanish, Portuguese, Italian, and Russian.

---
<a href="https://cursor.com/background-agent?bcId=bc-d401de0a-ee3b-4f4d-a2b3-c9e87debc9fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d401de0a-ee3b-4f4d-a2b3-c9e87debc9fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

