### PR TITLE
Clean updater help text version string

### DIFF
--- a/src/apps/control-panels/components/ControlPanelsAppComponent.tsx
+++ b/src/apps/control-panels/components/ControlPanelsAppComponent.tsx
@@ -197,7 +197,7 @@ function VersionDisplay() {
   
   return (
     <p className="text-[11px] text-gray-600 font-geneva-12">
-      Current version: ryOS {displayVersion}{displayBuild}
+      ryOS {displayVersion}{displayBuild}
     </p>
   );
 }


### PR DESCRIPTION
Remove "Current version: " prefix from the control panel updater help text to simplify the display.

---
<a href="https://cursor.com/background-agent?bcId=bc-abc33022-0659-4d6f-b7a8-4c5f8a06b6df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-abc33022-0659-4d6f-b7a8-4c5f8a06b6df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

