### PR TITLE
Offset sonner toasts above task bar

### DIFF
--- a/public/version.json
+++ b/public/version.json
@@ -1,8 +1,8 @@
 {
   "version": "10.3",
-  "buildNumber": "5582dab",
-  "commitSha": "5582dab32844560c5c60a5ff0d6b4a0423db9ca0",
-  "buildTime": "2025-12-03T23:07:00.353Z",
+  "buildNumber": "68cb181",
+  "commitSha": "68cb1812d56e50033e1723d8504210f626e991a0",
+  "buildTime": "2025-12-04T02:36:01.866Z",
   "majorVersion": 10,
   "minorVersion": 3
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -31,17 +31,19 @@ export function App() {
 
   // Determine toast position and offset based on theme and device
   const toastConfig = useMemo(() => {
+    const isWindowsTheme = currentTheme === "xp" || currentTheme === "win98";
     const dockHeight = currentTheme === "macosx" ? 56 : 0;
+    const taskbarHeight = isWindowsTheme ? 30 : 0;
     
-    // Mobile: always show at bottom-center with dock and safe area clearance
+    // Mobile: always show at bottom-center with dock/taskbar and safe area clearance
     if (isMobile) {
+      const bottomOffset = dockHeight + taskbarHeight + 16;
       return {
         position: "bottom-center" as const,
-        offset: `calc(env(safe-area-inset-bottom, 0px) + ${dockHeight + 16}px)`,
+        offset: `calc(env(safe-area-inset-bottom, 0px) + ${bottomOffset}px)`,
       };
     }
 
-    const isWindowsTheme = currentTheme === "xp" || currentTheme === "win98";
     if (isWindowsTheme) {
       // Windows themes: bottom-right with taskbar clearance (30px + padding)
       return {

--- a/src/index.css
+++ b/src/index.css
@@ -737,7 +737,7 @@ button.piano-key.piano-key[class*="bg-[#ff33ff]"] {
   right: 12px !important;
 }
 
-/* Mobile bottom-positioned toasts: account for dock height and safe area */
+/* Mobile bottom-positioned toasts: account for dock/taskbar height and safe area */
 @media (max-width: 768px) {
   [data-sonner-toaster][data-y-position="bottom"] {
     bottom: calc(env(safe-area-inset-bottom, 0px) + 16px) !important;
@@ -746,6 +746,16 @@ button.piano-key.piano-key[class*="bg-[#ff33ff]"] {
   /* macOS X theme: add dock height (56px) */
   :root[data-os-theme="macosx"] [data-sonner-toaster][data-y-position="bottom"] {
     bottom: calc(env(safe-area-inset-bottom, 0px) + 72px) !important;
+  }
+  
+  /* Windows XP theme: add taskbar height (30px) */
+  :root[data-os-theme="xp"] [data-sonner-toaster][data-y-position="bottom"] {
+    bottom: calc(env(safe-area-inset-bottom, 0px) + 46px) !important;
+  }
+  
+  /* Windows 98 theme: add taskbar height (30px) */
+  :root[data-os-theme="win98"] [data-sonner-toaster][data-y-position="bottom"] {
+    bottom: calc(env(safe-area-inset-bottom, 0px) + 46px) !important;
   }
 }
 


### PR DESCRIPTION
Offset Sonner toasts above the taskbar on mobile for Windows XP/98 themes to prevent them from being obscured.

---
<a href="https://cursor.com/background-agent?bcId=bc-57ddabbb-4888-40da-8412-f7b7e0c4b9c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-57ddabbb-4888-40da-8412-f7b7e0c4b9c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

