### PR TITLE
Change ipod hdr lyric color to white

### DIFF
--- a/public/version.json
+++ b/public/version.json
@@ -1,8 +1,8 @@
 {
   "version": "10.3",
-  "buildNumber": "aa0349f",
-  "commitSha": "aa0349fc48d31ed5cb626210e4ebdc85e874a96b",
-  "buildTime": "2025-12-04T03:14:59.490Z",
+  "buildNumber": "cb04653",
+  "commitSha": "cb04653665367c64dfb5379c5de65eea18031c11",
+  "buildTime": "2025-12-04T03:17:42.051Z",
   "majorVersion": 10,
   "minorVersion": 3
 }

--- a/public/version.json
+++ b/public/version.json
@@ -1,8 +1,8 @@
 {
   "version": "10.3",
-  "buildNumber": "68cb181",
-  "commitSha": "68cb1812d56e50033e1723d8504210f626e991a0",
-  "buildTime": "2025-12-04T02:36:01.866Z",
+  "buildNumber": "aa0349f",
+  "commitSha": "aa0349fc48d31ed5cb626210e4ebdc85e874a96b",
+  "buildTime": "2025-12-04T03:14:59.490Z",
   "majorVersion": 10,
   "minorVersion": 3
 }

--- a/src/apps/ipod/components/LyricsDisplay.tsx
+++ b/src/apps/ipod/components/LyricsDisplay.tsx
@@ -447,6 +447,7 @@ export function LyricsDisplay({
               style={{
                 textAlign: lineTextAlign as CanvasTextAlign,
                 width: "100%",
+                color: isCurrent ? "#ffffff" : undefined,
                 paddingLeft:
                   alignment === LyricsAlignment.Alternating &&
                   index === 0 &&

--- a/src/apps/ipod/components/LyricsDisplay.tsx
+++ b/src/apps/ipod/components/LyricsDisplay.tsx
@@ -447,7 +447,7 @@ export function LyricsDisplay({
               style={{
                 textAlign: lineTextAlign as CanvasTextAlign,
                 width: "100%",
-                color: isCurrent ? "#ffffff" : undefined,
+                color: isCurrent ? "color(display-p3 1 1 1)" : undefined,
                 paddingLeft:
                   alignment === LyricsAlignment.Alternating &&
                   index === 0 &&


### PR DESCRIPTION
Add explicit white color styling to the highlighted lyric in iPod HDR mode.

---
<a href="https://cursor.com/background-agent?bcId=bc-1fcaf586-07c1-4612-90f0-5c8181a38682"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1fcaf586-07c1-4612-90f0-5c8181a38682"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

