### PR TITLE
Add left padding to xp 98 menubar

### DIFF
--- a/src/components/layout/MenuBar.tsx
+++ b/src/components/layout/MenuBar.tsx
@@ -898,7 +898,7 @@ export function MenuBar({ children, inWindowFrame = false }: MenuBarProps) {
   if (inWindowFrame && isXpTheme) {
     return (
       <Menubar
-        className="flex items-center h-7 pl-2 pr-1 border-none bg-transparent space-x-0 p-0 rounded-none"
+        className="flex items-center h-7 pl-3 pr-1 border-none bg-transparent space-x-0 p-0 rounded-none"
         style={{
           fontFamily: isXpTheme ? "var(--font-ms-sans)" : "var(--os-font-ui)",
           fontSize: "11px",


### PR DESCRIPTION
Increase left padding for XP/98 nested menubar to prevent menu items from being too close to the window edge.

---
<a href="https://cursor.com/background-agent?bcId=bc-5c6a0247-eb37-4f54-8ed3-55d385219234"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5c6a0247-eb37-4f54-8ed3-55d385219234"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

