### PR TITLE
Fix macosx menu bar focus style

### DIFF
--- a/public/version.json
+++ b/public/version.json
@@ -1,8 +1,8 @@
 {
   "version": "10.3",
-  "buildNumber": "fa66da6",
-  "commitSha": "fa66da6903de22aecdbb0661770b1fcc77c4af54",
-  "buildTime": "2025-12-04T05:17:26.226Z",
+  "buildNumber": "56553e4",
+  "commitSha": "56553e48e2bdb4e993a5de7a311b729442e925b4",
+  "buildTime": "2025-12-04T05:41:05.704Z",
   "majorVersion": 10,
   "minorVersion": 3
 }

--- a/src/components/ui/menubar.tsx
+++ b/src/components/ui/menubar.tsx
@@ -80,8 +80,8 @@ const MenubarTrigger = React.forwardRef<
     // System 7: black background, white text when open, full height
     isSystem7 && "rounded-none data-[state=open]:bg-black data-[state=open]:text-white data-[state=open]:py-[3px] data-[state=open]:my-[-2px]",
     // macOS X: blue background (#1a66d3), white text when open, no rounded corners, slightly taller
-    // Also ensure no focus background when menu is closed
-    isMacOSX && "rounded-none data-[state=open]:bg-[#1a66d3] data-[state=open]:text-white data-[state=open]:py-[5px] data-[state=open]:my-[-1px] focus:bg-transparent focus-visible:bg-transparent",
+    // Also ensure no focus/highlighted background when menu is closed
+    isMacOSX && "rounded-none data-[state=open]:bg-[#1a66d3] data-[state=open]:text-white data-[state=open]:py-[5px] data-[state=open]:my-[-1px] focus:bg-transparent focus-visible:bg-transparent data-[highlighted]:bg-transparent data-[state=closed]:bg-transparent",
     // Default/other themes
     !isWindowsTheme && !isSystem7 && !isMacOSX && "rounded-sm data-[state=open]:bg-accent data-[state=open]:text-accent-foreground",
     className

--- a/src/components/ui/menubar.tsx
+++ b/src/components/ui/menubar.tsx
@@ -74,13 +74,14 @@ const MenubarTrigger = React.forwardRef<
   // Theme-specific classes
   const themeClasses = cn(
     // Base styles
-    "flex cursor-default select-none items-center px-2 py-1 text-md font-medium outline-none",
+    "flex cursor-default select-none items-center px-2 py-1 text-md font-medium outline-none focus:outline-none focus-visible:outline-none",
     // Windows themes: plain text style, no background changes, add menubar-trigger class for CSS override
     isWindowsTheme && "rounded-none menubar-trigger",
     // System 7: black background, white text when open, full height
     isSystem7 && "rounded-none data-[state=open]:bg-black data-[state=open]:text-white data-[state=open]:py-[3px] data-[state=open]:my-[-2px]",
     // macOS X: blue background (#1a66d3), white text when open, no rounded corners, slightly taller
-    isMacOSX && "rounded-none data-[state=open]:bg-[#1a66d3] data-[state=open]:text-white data-[state=open]:py-[5px] data-[state=open]:my-[-1px]",
+    // Also ensure no focus background when menu is closed
+    isMacOSX && "rounded-none data-[state=open]:bg-[#1a66d3] data-[state=open]:text-white data-[state=open]:py-[5px] data-[state=open]:my-[-1px] focus:bg-transparent focus-visible:bg-transparent",
     // Default/other themes
     !isWindowsTheme && !isSystem7 && !isMacOSX && "rounded-sm data-[state=open]:bg-accent data-[state=open]:text-accent-foreground",
     className

--- a/src/styles/themes.css
+++ b/src/styles/themes.css
@@ -479,16 +479,20 @@
   z-index: 2;
 }
 
-/* Remove focus background on macOS menubar triggers when menu is closed */
+/* Remove focus/highlighted background on macOS menubar triggers when menu is closed */
 :root[data-os-theme="macosx"] [data-radix-menubar-trigger]:focus,
-:root[data-os-theme="macosx"] [data-radix-menubar-trigger]:focus-visible {
+:root[data-os-theme="macosx"] [data-radix-menubar-trigger]:focus-visible,
+:root[data-os-theme="macosx"] [data-radix-menubar-trigger][data-highlighted],
+:root[data-os-theme="macosx"] [data-radix-menubar-trigger][data-state="closed"] {
   background-color: transparent !important;
   outline: none !important;
 }
 
 /* Keep the blue background only when the menu is open */
+:root[data-os-theme="macosx"] [data-radix-menubar-trigger][data-state="open"],
 :root[data-os-theme="macosx"] [data-radix-menubar-trigger][data-state="open"]:focus,
-:root[data-os-theme="macosx"] [data-radix-menubar-trigger][data-state="open"]:focus-visible {
+:root[data-os-theme="macosx"] [data-radix-menubar-trigger][data-state="open"]:focus-visible,
+:root[data-os-theme="macosx"] [data-radix-menubar-trigger][data-state="open"][data-highlighted] {
   background-color: #1a66d3 !important;
 }
 
@@ -1076,7 +1080,8 @@
 }
 
 /* macOS dropdown menu item hover/focus styles */
-:root[data-os-theme="macosx"] [role="menuitem"]:focus,
+/* Note: Exclude menubar triggers from this rule - they have their own styling */
+:root[data-os-theme="macosx"] [role="menuitem"]:focus:not([data-radix-menubar-trigger]),
 :root[data-os-theme="macosx"] [role="menuitemcheckbox"]:focus,
 :root[data-os-theme="macosx"] [role="menuitemradio"]:focus,
 :root[data-os-theme="macosx"] [role="option"]:focus,

--- a/src/styles/themes.css
+++ b/src/styles/themes.css
@@ -479,6 +479,19 @@
   z-index: 2;
 }
 
+/* Remove focus background on macOS menubar triggers when menu is closed */
+:root[data-os-theme="macosx"] [data-radix-menubar-trigger]:focus,
+:root[data-os-theme="macosx"] [data-radix-menubar-trigger]:focus-visible {
+  background-color: transparent !important;
+  outline: none !important;
+}
+
+/* Keep the blue background only when the menu is open */
+:root[data-os-theme="macosx"] [data-radix-menubar-trigger][data-state="open"]:focus,
+:root[data-os-theme="macosx"] [data-radix-menubar-trigger][data-state="open"]:focus-visible {
+  background-color: #1a66d3 !important;
+}
+
 :root[data-os-theme="macosx"] .title-bar {
   font-size: 13px !important;
   font-weight: 500 !important;


### PR DESCRIPTION
Remove the persistent blue focus background on the macOS X menubar trigger after the menu closes.

The `MenubarTrigger` element in the macOS X theme retained its blue `data-state="open"` background color even after the menu closed, due to the element still holding focus. This fix explicitly clears the background on focus when the menu is not open, while preserving the blue highlight when it is.

---
<a href="https://cursor.com/background-agent?bcId=bc-303b3fec-473b-4082-94e9-93f4e7c89041"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-303b3fec-473b-4082-94e9-93f4e7c89041"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

