### PR TITLE
Fix persistent menubar highlight after menu close

### DIFF
--- a/public/version.json
+++ b/public/version.json
@@ -1,8 +1,8 @@
 {
   "version": "10.3",
-  "buildNumber": "fa66da6",
-  "commitSha": "fa66da6903de22aecdbb0661770b1fcc77c4af54",
-  "buildTime": "2025-12-04T05:17:26.226Z",
+  "buildNumber": "5bb447e",
+  "commitSha": "5bb447e3b9e093f33891158ab5478c20609cd328",
+  "buildTime": "2025-12-04T05:51:29.975Z",
   "majorVersion": 10,
   "minorVersion": 3
 }

--- a/src/styles/themes.css
+++ b/src/styles/themes.css
@@ -1073,6 +1073,12 @@
   outline: none !important;
 }
 
+/* Prevent menubar trigger highlight when menu is closed - only show highlight when open */
+:root[data-os-theme="macosx"] .menubar [role="menuitem"]:focus:not([data-state="open"]) {
+  background-color: transparent !important;
+  color: inherit !important;
+}
+
 /* Override the 11px font size for dropdown menu items */
 :root[data-os-theme="macosx"] [role="menuitem"],
 :root[data-os-theme="macosx"] [role="menuitemcheckbox"],


### PR DESCRIPTION
Prevent macOS menubar triggers from retaining a blue highlight when the menu is closed.

The existing CSS applied a blue background to `[role="menuitem"]:focus`. Since `MenubarTrigger` has this role, focus returning to it after a menu item selection caused the highlight to persist even after the menu closed. This PR adds a rule to clear the background when the menu is not open.

---
<a href="https://cursor.com/background-agent?bcId=bc-7e85b9b3-8158-4270-b83f-eddb0bba94d4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7e85b9b3-8158-4270-b83f-eddb0bba94d4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

