### PR TITLE
Fix persistent menubar highlight after menu close

### DIFF
--- a/src/components/ui/menubar.tsx
+++ b/src/components/ui/menubar.tsx
@@ -80,7 +80,8 @@ const MenubarTrigger = React.forwardRef<
     // System 7: black background, white text when open, full height
     isSystem7 && "rounded-none data-[state=open]:bg-black data-[state=open]:text-white data-[state=open]:py-[3px] data-[state=open]:my-[-2px]",
     // macOS X: blue background (#1a66d3), white text when open, no rounded corners, slightly taller
-    isMacOSX && "rounded-none data-[state=open]:bg-[#1a66d3] data-[state=open]:text-white data-[state=open]:py-[5px] data-[state=open]:my-[-1px]",
+    // Only show background when menu is actually open, not on focus
+    isMacOSX && "rounded-none bg-transparent data-[state=open]:bg-[#1a66d3] data-[state=open]:text-white data-[state=open]:py-[5px] data-[state=open]:my-[-1px]",
     // Default/other themes
     !isWindowsTheme && !isSystem7 && !isMacOSX && "rounded-sm data-[state=open]:bg-accent data-[state=open]:text-accent-foreground",
     className

--- a/src/styles/themes.css
+++ b/src/styles/themes.css
@@ -479,6 +479,11 @@
   z-index: 2;
 }
 
+/* macOS menubar triggers: only show blue background when menu is open, not on focus */
+:root[data-os-theme="macosx"] .menubar button:not([data-state="open"]) {
+  background-color: transparent !important;
+}
+
 :root[data-os-theme="macosx"] .title-bar {
   font-size: 13px !important;
   font-weight: 500 !important;


### PR DESCRIPTION
Fixes persistent blue background highlight on macOS X menubar triggers when the menu is closed but the trigger remains focused.

Previously, the trigger could retain focus after a menu item was selected, causing the blue highlight to persist even when the menu was no longer open. This PR ensures the background is transparent when the menu is closed, regardless of the trigger's focus state.

---
<a href="https://cursor.com/background-agent?bcId=bc-fbd64313-068a-4029-bc61-a6725a96dfda"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-fbd64313-068a-4029-bc61-a6725a96dfda"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

