### PR TITLE
Fix inconsistent menubar height

### DIFF
--- a/public/version.json
+++ b/public/version.json
@@ -1,8 +1,8 @@
 {
   "version": "10.3",
-  "buildNumber": "8388bce",
-  "commitSha": "8388bce1417692b87b3af5cb9cf62a6c43419462",
-  "buildTime": "2025-12-04T06:12:44.664Z",
+  "buildNumber": "88f73d2",
+  "commitSha": "88f73d2cd5b3e1b817c08f5d693b4924270daabe",
+  "buildTime": "2025-12-04T17:09:03.830Z",
   "majorVersion": 10,
   "minorVersion": 3
 }

--- a/src/components/layout/MenuBar.tsx
+++ b/src/components/layout/MenuBar.tsx
@@ -906,12 +906,15 @@ export function MenuBar({ children, inWindowFrame = false }: MenuBarProps) {
   if (inWindowFrame && isXpTheme) {
     return (
       <Menubar
-        className="flex items-center h-7 border-none bg-transparent space-x-0 rounded-none"
+        className="flex items-center border-none bg-transparent space-x-0 rounded-none"
         style={{
           fontFamily: isXpTheme ? "var(--font-ms-sans)" : "var(--os-font-ui)",
           fontSize: "11px",
           paddingLeft: "6px",
           paddingRight: "2px",
+          height: "28px",
+          minHeight: "28px",
+          maxHeight: "28px",
         }}
       >
         {children}
@@ -1271,7 +1274,7 @@ export function MenuBar({ children, inWindowFrame = false }: MenuBarProps) {
   // Default Mac-style top menubar
   return (
     <div
-      className="fixed top-0 left-0 right-0 flex border-b-[length:var(--os-metrics-border-width)] border-os-menubar h-os-menubar items-center font-os-ui"
+      className="fixed top-0 left-0 right-0 flex border-b-[length:var(--os-metrics-border-width)] border-os-menubar items-center font-os-ui"
       style={{
         background:
           currentTheme === "macosx"
@@ -1291,10 +1294,20 @@ export function MenuBar({ children, inWindowFrame = false }: MenuBarProps) {
         paddingLeft: "calc(0.5rem + env(safe-area-inset-left, 0px))",
         paddingRight: "calc(0.5rem + env(safe-area-inset-right, 0px))",
         paddingTop: "env(safe-area-inset-top, 0px)",
+        height: "var(--os-metrics-menubar-height)",
+        minHeight: "var(--os-metrics-menubar-height)",
+        maxHeight: "var(--os-metrics-menubar-height)",
       }}
     >
       <ScrollableMenuWrapper>
-        <Menubar className="flex items-center border-none bg-transparent space-x-0 p-0 rounded-none h-auto">
+        <Menubar 
+          className="flex items-center border-none bg-transparent space-x-0 p-0 rounded-none"
+          style={{
+            height: "var(--os-metrics-menubar-height)",
+            minHeight: "var(--os-metrics-menubar-height)",
+            maxHeight: "var(--os-metrics-menubar-height)",
+          }}
+        >
           <AppleMenu apps={apps} />
           {hasActiveApp && children ? children : <DefaultMenuItems />}
         </Menubar>

--- a/src/components/ui/menubar.tsx
+++ b/src/components/ui/menubar.tsx
@@ -52,7 +52,7 @@ const Menubar = React.forwardRef<
       <MenubarPrimitive.Root
         ref={ref}
         className={cn(
-          "flex h-9 items-center space-x-1 rounded-md p-1",
+          "flex items-center space-x-1 rounded-md p-1",
           className
         )}
         onValueChange={handleValueChange}


### PR DESCRIPTION
Fixes menubar height inconsistency by removing conflicting hardcoded height and applying explicit theme-defined heights.

The base `Menubar` component had a hardcoded `h-9` (36px) class which conflicted with theme-specific CSS variables (e.g., macOS 24px, Win98 22px, XP 30px). This led to the menubar losing its height or having variable height. The fix ensures that the menubar's height is consistently set by the theme's CSS variables or explicit values for window frames.

---
<a href="https://cursor.com/background-agent?bcId=bc-b3f998a0-0d5e-4df9-aedc-09d8caacb9b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b3f998a0-0d5e-4df9-aedc-09d8caacb9b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

