### PR TITLE
Update aqua kana and pixel fonts

### DIFF
--- a/public/version.json
+++ b/public/version.json
@@ -1,8 +1,8 @@
 {
   "version": "10.3",
-  "buildNumber": "c5a693e",
-  "commitSha": "c5a693e14e285e72783b1b9430656f11addb3902",
-  "buildTime": "2025-12-04T17:44:44.039Z",
+  "buildNumber": "57290d7",
+  "commitSha": "57290d76e6c16b061a703324872c4a030ed151ab",
+  "buildTime": "2025-12-04T17:45:37.089Z",
   "majorVersion": 10,
   "minorVersion": 3
 }

--- a/src/styles/themes.css
+++ b/src/styles/themes.css
@@ -592,9 +592,14 @@
 }
 
 /* Preserve LCD display styling in Videos app - keep original pixel fonts */
+/* But use Aqua Kana for player control buttons */
 :root[data-os-theme="macosx"] .videos-player-controls button.font-geneva-12 {
-  font-family: Geneva-12, monospace !important;
+  font-family: "LucidaGrande", "Lucida Grande", "AquaKana", "Hiragino Sans",
+    "Hiragino Sans GB", "Heiti SC", ui-sans-serif, system-ui, -apple-system,
+    BlinkMacSystemFont, sans-serif !important;
   font-size: 9px !important;
+  -webkit-font-smoothing: antialiased !important;
+  font-smooth: auto !important;
 }
 :root[data-os-theme="macosx"] .videos-lcd .font-geneva-12.text-\[10px\] {
   font-family: Geneva-12, monospace !important;


### PR DESCRIPTION
Update macOSX theme to use Aqua Kana font for synth and video player.

The synth and video player apps previously used old pixel fonts (Geneva-12) when the macOSX theme was active, which was inconsistent with the desired macOSX aesthetic. This PR updates the font stacks to use "Lucida Grande" with "AquaKana" as a fallback for Japanese characters, along with proper antialiasing, for a more native look and feel. The iPod app retains its pixel font for retro consistency.

---
<a href="https://cursor.com/background-agent?bcId=bc-12c65f5b-daf2-4cef-8078-76b0ef9d9fb0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-12c65f5b-daf2-4cef-8078-76b0ef9d9fb0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

