### PR TITLE
Fix video player right and bottom gap

### DIFF
--- a/src/apps/internet-explorer/components/InternetExplorerAppComponent.tsx
+++ b/src/apps/internet-explorer/components/InternetExplorerAppComponent.tsx
@@ -2562,7 +2562,11 @@ export function InternetExplorerAppComponent({
                 <iframe
                   ref={iframeRef}
                   src={finalUrl || ""}
-className="w-full h-full border-0 block"
+                  className="border-0 block"
+                  style={{
+                    width: "calc(100% + 1px)",
+                    height: "calc(100% + 1px)",
+                  }}
                   sandbox="allow-scripts allow-forms allow-same-origin allow-popups allow-pointer-lock"
                   onLoad={handleIframeLoad}
                   onError={handleIframeError}

--- a/src/apps/internet-explorer/components/InternetExplorerAppComponent.tsx
+++ b/src/apps/internet-explorer/components/InternetExplorerAppComponent.tsx
@@ -2562,7 +2562,7 @@ export function InternetExplorerAppComponent({
                 <iframe
                   ref={iframeRef}
                   src={finalUrl || ""}
-                  className="w-full h-full border-0"
+                  className="w-full h-full border-0 block"
                   sandbox="allow-scripts allow-forms allow-same-origin allow-popups allow-pointer-lock"
                   onLoad={handleIframeLoad}
                   onError={handleIframeError}

--- a/src/apps/videos/components/VideosAppComponent.tsx
+++ b/src/apps/videos/components/VideosAppComponent.tsx
@@ -1040,14 +1040,14 @@ export function VideosAppComponent({
         menuBar={isXpTheme ? menuBar : undefined}
       >
         <div className="flex flex-col w-full h-full bg-[#1a1a1a] text-white">
-          <div className="flex-1 relative">
+          <div className="flex-1 relative min-h-0">
             {videos.length > 0 ? (
               <div
-                className="w-full h-full overflow-hidden relative"
+                className="absolute inset-0 overflow-hidden"
                 onMouseEnter={() => setIsVideoHovered(true)}
                 onMouseLeave={() => setIsVideoHovered(false)}
               >
-                <div className="w-full h-[calc(100%+120px)] mt-[-60px] relative">
+                <div className="absolute inset-0 h-[calc(100%+120px)] mt-[-60px]">
                   <ReactPlayer
                     ref={playerRef}
                     url={getCurrentVideo()?.url || ""}

--- a/src/components/shared/HtmlPreview.tsx
+++ b/src/components/shared/HtmlPreview.tsx
@@ -1327,13 +1327,14 @@ export default function HtmlPreview({
             // srcDoc is now set by useEffect after streaming finishes
             // srcDoc={processedHtmlContent()}
             title={t("common.htmlPreview.codePreviewTitle")}
-            className={`w-full border-0 block ${
-              !isInternetExplorer && (appletTitle || appletIcon) ? "flex-1" : "h-full"
+            className={`border-0 block ${
+              !isInternetExplorer && (appletTitle || appletIcon) ? "flex-1" : ""
             }`}
             sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-popups-to-escape-sandbox allow-top-navigation allow-modals allow-pointer-lock allow-downloads allow-storage-access-by-user-activation"
             style={{
+              width: isInternetExplorer ? "calc(100% + 1px)" : "100%",
               height: isInternetExplorer
-                ? "100%"
+                ? "calc(100% + 1px)"
                 : !isInternetExplorer && (appletTitle || appletIcon)
                 ? "100%"
                 : typeof minHeight === "string"

--- a/src/components/shared/HtmlPreview.tsx
+++ b/src/components/shared/HtmlPreview.tsx
@@ -1327,7 +1327,7 @@ export default function HtmlPreview({
             // srcDoc is now set by useEffect after streaming finishes
             // srcDoc={processedHtmlContent()}
             title={t("common.htmlPreview.codePreviewTitle")}
-            className={`w-full border-0 ${
+            className={`w-full border-0 block ${
               !isInternetExplorer && (appletTitle || appletIcon) ? "flex-1" : "h-full"
             }`}
             sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-popups-to-escape-sandbox allow-top-navigation allow-modals allow-pointer-lock allow-downloads allow-storage-access-by-user-activation"

--- a/src/index.css
+++ b/src/index.css
@@ -661,6 +661,15 @@ button.piano-key.piano-key[class*="bg-[#ff33ff]"] {
   filter: brightness(1.05) contrast(1.02) saturate(1.1);
 }
 
+/* Fix 1px gap on right and bottom for video players and iframes */
+.react-player,
+.react-player > div,
+.react-player iframe,
+.react-player video {
+  display: block !important;
+  line-height: 0;
+}
+
 /* Hide default scrollbars for custom implementation */
 .ipod-menu-container {
   scrollbar-width: none; /* Firefox */

--- a/src/index.css
+++ b/src/index.css
@@ -670,6 +670,12 @@ button.piano-key.piano-key[class*="bg-[#ff33ff]"] {
   line-height: 0;
 }
 
+/* Extend react-player to cover 1px gap on right and bottom */
+.react-player {
+  width: calc(100% + 1px) !important;
+  height: calc(100% + 1px) !important;
+}
+
 /* Hide default scrollbars for custom implementation */
 .ipod-menu-container {
   scrollbar-width: none; /* Firefox */


### PR DESCRIPTION
Fix 1px gap on the right and bottom of video players and Internet Explorer HTML views.

The 1px gap was caused by iframes and video elements defaulting to `display: inline`, which creates a gap due to text baseline alignment. Setting `display: block` and `line-height: 0` removes this behavior.

---
<a href="https://cursor.com/background-agent?bcId=bc-8c374425-1eca-41bc-81fb-a1d69671ad1b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8c374425-1eca-41bc-81fb-a1d69671ad1b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

