### PR TITLE
Add open file button to transcript save toast

### DIFF
--- a/src/apps/chats/hooks/useAiChat.ts
+++ b/src/apps/chats/hooks/useAiChat.ts
@@ -2741,8 +2741,16 @@ export function useAiChat(onPromptSetUsername?: () => void) {
   const handleSaveSubmit = useCallback(
     async (fileName: string) => {
       const transcript = aiMessages // Use messages from store
-        .map((msg: UIMessage) => {
-          const time = ""; // v5 UIMessage doesn't have createdAt
+        .map((msg) => {
+          const aiMsg = msg as AIChatMessage;
+          const createdAt = aiMsg.metadata?.createdAt;
+          const time = createdAt
+            ? createdAt.toLocaleTimeString([], {
+                hour: "numeric",
+                minute: "2-digit",
+                hour12: true,
+              })
+            : "";
           const sender = msg.role === "user" ? username || "You" : "Ryo";
           const content = getAssistantVisibleText(msg);
           return `**${sender}** (${time}):\n${content}`;

--- a/src/apps/chats/hooks/useAiChat.ts
+++ b/src/apps/chats/hooks/useAiChat.ts
@@ -2762,6 +2762,11 @@ export function useAiChat(onPromptSetUsername?: () => void) {
         : `${fileName}.md`;
       const filePath = `/Documents/${finalFileName}`;
 
+      // Check if file already exists
+      const fileStore = useFilesStore.getState();
+      const existingFile = fileStore.getItem(filePath);
+      const isOverwriting = !!existingFile;
+
       try {
         await saveFile({
           path: filePath,
@@ -2772,18 +2777,23 @@ export function useAiChat(onPromptSetUsername?: () => void) {
         });
 
         setIsSaveDialogOpen(false);
-        toast.success("Transcript saved", {
-          description: `Saved to ${finalFileName}`,
-          duration: 3000,
-          action: {
-            label: "Open",
-            onClick: () => {
-              launchApp("textedit", {
-                initialData: { path: filePath, content: transcript },
-              });
+        toast.success(
+          isOverwriting ? "Transcript updated" : "Transcript saved",
+          {
+            description: isOverwriting
+              ? `Updated ${finalFileName}`
+              : `Saved to ${finalFileName}`,
+            duration: 3000,
+            action: {
+              label: "Open",
+              onClick: () => {
+                launchApp("textedit", {
+                  initialData: { path: filePath, content: transcript },
+                });
+              },
             },
-          },
-        });
+          }
+        );
       } catch (error) {
         console.error("Error saving transcript:", error);
         toast.error("Failed to save transcript", {

--- a/src/apps/chats/hooks/useAiChat.ts
+++ b/src/apps/chats/hooks/useAiChat.ts
@@ -2740,6 +2740,14 @@ export function useAiChat(onPromptSetUsername?: () => void) {
 
   const handleSaveSubmit = useCallback(
     async (fileName: string) => {
+      // Validate filename
+      if (!fileName || fileName.trim() === "") {
+        toast.error("Invalid filename", {
+          description: "Please enter a filename",
+        });
+        return;
+      }
+
       const transcript = aiMessages // Use messages from store
         .map((msg) => {
           const aiMsg = msg as AIChatMessage;

--- a/src/apps/chats/hooks/useAiChat.ts
+++ b/src/apps/chats/hooks/useAiChat.ts
@@ -2767,6 +2767,14 @@ export function useAiChat(onPromptSetUsername?: () => void) {
         toast.success("Transcript saved", {
           description: `Saved to ${finalFileName}`,
           duration: 3000,
+          action: {
+            label: "Open",
+            onClick: () => {
+              launchApp("textedit", {
+                initialData: { path: filePath, content: transcript },
+              });
+            },
+          },
         });
       } catch (error) {
         console.error("Error saving transcript:", error);
@@ -2775,7 +2783,7 @@ export function useAiChat(onPromptSetUsername?: () => void) {
         });
       }
     },
-    [aiMessages, username, saveFile],
+    [aiMessages, username, saveFile, launchApp],
   );
 
   // Stop both chat streaming and TTS queue

--- a/src/apps/finder/hooks/useFileSystem.ts
+++ b/src/apps/finder/hooks/useFileSystem.ts
@@ -1280,20 +1280,24 @@ export function useFileSystem(
               `[useFileSystem:saveFile] Error saving content to IndexedDB for ${path}:`,
               err
             );
-            setError(`Failed to save file content for ${name}`);
+            const errorMessage = `Failed to save file content for ${name}`;
+            setError(errorMessage);
+            throw new Error(errorMessage);
           }
         } else {
-          console.warn(
-            `[useFileSystem:saveFile] No valid content store for path: ${path}`
-          );
+          const errorMessage = `No valid content store for path: ${path}`;
+          console.warn(`[useFileSystem:saveFile] ${errorMessage}`);
+          setError(errorMessage);
+          throw new Error(errorMessage);
         }
       } catch (metaError) {
         console.error(
           `[useFileSystem:saveFile] Error updating metadata store for ${path}:`,
           metaError
         );
-        setError(`Failed to save file metadata for ${name}`);
-        return;
+        const errorMessage = `Failed to save file metadata for ${name}`;
+        setError(errorMessage);
+        throw metaError instanceof Error ? metaError : new Error(errorMessage);
       }
     },
     [fileStore]


### PR DESCRIPTION
Add an "Open" button to the transcript save toast in Chats to allow users to quickly open the saved file.

---
<a href="https://cursor.com/background-agent?bcId=bc-38eca29d-722b-4b4b-b1e0-f4ff5b39006f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-38eca29d-722b-4b4b-b1e0-f4ff5b39006f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

