### PR TITLE
Research backup and restore functionalities

### DIFF
--- a/public/version.json
+++ b/public/version.json
@@ -1,8 +1,8 @@
 {
   "version": "10.3",
-  "buildNumber": "0713012",
-  "commitSha": "07130126cbc3fec221152f9ab6103966045f310c",
-  "buildTime": "2025-12-05T03:36:45.056Z",
+  "buildNumber": "edf81fa",
+  "commitSha": "edf81fae4f68c9de0b2191a5d3fcd5e0227d51b6",
+  "buildTime": "2025-12-06T00:35:43.700Z",
   "majorVersion": 10,
   "minorVersion": 3
 }

--- a/src/apps/control-panels/components/ControlPanelsAppComponent.tsx
+++ b/src/apps/control-panels/components/ControlPanelsAppComponent.tsx
@@ -1055,37 +1055,37 @@ export function ControlPanelsAppComponent({
                     path: "/Documents",
                     name: "Documents",
                     type: "directory",
-                    icon: "/icons/documents.png",
+                    icon: "/icons/default/documents.png",
                   },
                   {
                     path: "/Images",
                     name: "Images",
                     type: "directory",
-                    icon: "/icons/images.png",
+                    icon: "/icons/default/images.png",
                   },
                   {
                     path: "/Applications",
                     name: "Applications",
                     type: "directory-virtual",
-                    icon: "/icons/applications.png",
+                    icon: "/icons/default/applications.png",
                   },
                   {
                     path: "/Music",
                     name: "Music",
                     type: "directory-virtual",
-                    icon: "/icons/sounds.png",
+                    icon: "/icons/default/sounds.png",
                   },
                   {
                     path: "/Videos",
                     name: "Videos",
                     type: "directory-virtual",
-                    icon: "/icons/movies.png",
+                    icon: "/icons/default/movies.png",
                   },
                   {
                     path: "/Sites",
                     name: "Sites",
                     type: "directory-virtual",
-                    icon: "/icons/sites.png",
+                    icon: "/icons/default/sites.png",
                   },
                   {
                     path: "/Applets",
@@ -1094,10 +1094,16 @@ export function ControlPanelsAppComponent({
                     icon: "/icons/default/applets.png",
                   },
                   {
+                    path: "/Desktop",
+                    name: "Desktop",
+                    type: "directory",
+                    icon: "/icons/default/desktop.png",
+                  },
+                  {
                     path: "/Trash",
                     name: "Trash",
                     type: "directory",
-                    icon: "/icons/trash-empty.png",
+                    icon: "/icons/default/trash-empty.png",
                   },
                 ];
 
@@ -1141,7 +1147,7 @@ export function ControlPanelsAppComponent({
                           path,
                           value.name,
                           type,
-                          "/icons/file-text.png",
+                          "/icons/default/file-text.png",
                           key
                         );
                         count++;
@@ -1182,7 +1188,7 @@ export function ControlPanelsAppComponent({
                           path,
                           value.name,
                           ext,
-                          "/icons/image.png",
+                          "/icons/default/image.png",
                           key
                         );
                         count++;


### PR DESCRIPTION
Adds `/Desktop` to default restore directories and corrects icon paths for consistency.

The `/Desktop` directory was missing from the restore logic, which could cause issues with desktop shortcuts after a restore. Additionally, several icon paths were inconsistent with the `filesystem.json` configuration, using generic paths instead of the `/icons/default/` prefix.

---
<a href="https://cursor.com/background-agent?bcId=bc-d5f66d05-21ab-4850-a544-0a66bb2fc3a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d5f66d05-21ab-4850-a544-0a66bb2fc3a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

