### PR TITLE
Check and exclude user ryo from tts rate limits

### DIFF
--- a/src/hooks/useTtsQueue.ts
+++ b/src/hooks/useTtsQueue.ts
@@ -2,6 +2,7 @@ import { useRef, useEffect, useCallback, useState } from "react";
 import { getAudioContext, resumeAudioContext } from "@/lib/audioContext";
 import { useAppStore } from "@/stores/useAppStore";
 import { useIpodStore } from "@/stores/useIpodStore";
+import { useChatsStore } from "@/stores/useChatsStore";
 import { checkOfflineAndShowError } from "@/utils/offline";
 
 /**
@@ -126,9 +127,19 @@ export function useTtsQueue(endpoint: string = "/api/speech") {
           }
           // If ttsModel is null, don't add voice settings - let server decide
 
+          // Get auth credentials for rate limit bypass
+          const { authToken, username } = useChatsStore.getState();
+          const headers: Record<string, string> = {
+            "Content-Type": "application/json",
+          };
+          if (authToken && username) {
+            headers["Authorization"] = `Bearer ${authToken}`;
+            headers["X-Username"] = username;
+          }
+
           const res = await fetch(endpoint, {
             method: "POST",
-            headers: { "Content-Type": "application/json" },
+            headers,
             body: JSON.stringify(requestBody),
             signal: controller.signal,
           });


### PR DESCRIPTION
Fix TTS rate limit bypass for "ryo" by sending authentication headers from the client.

The `useTtsQueue.ts` hook was not including `Authorization` and `X-Username` headers in TTS requests, preventing the server-side rate limit bypass for authenticated users like "ryo" from being triggered. This change ensures the client sends the necessary authentication details.

---
<a href="https://cursor.com/background-agent?bcId=bc-56fdfabe-90a3-4e80-be63-ae0be4f83055"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-56fdfabe-90a3-4e80-be63-ae0be4f83055"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

