### PR TITLE
Fix chat room message deletion for ryo

### DIFF
--- a/api/chat-rooms/_types.ts
+++ b/api/chat-rooms/_types.ts
@@ -31,6 +31,7 @@ export interface Message {
   username: string;
   content: string;
   timestamp: number;
+  clientId?: string; // Client-generated ID for optimistic update matching
 }
 
 export interface BulkMessagesResult {
@@ -73,6 +74,7 @@ export interface SendMessageData {
   roomId: string;
   username: string;
   content: string;
+  clientId?: string; // Client-generated ID for optimistic update matching
 }
 
 export interface CreateUserData {

--- a/api/chat-rooms/messages.ts
+++ b/api/chat-rooms/messages.ts
@@ -156,7 +156,7 @@ export async function handleSendMessage(
   data: SendMessageData,
   requestId: string
 ): Promise<Response> {
-  const { roomId, username: originalUsername, content: originalContent } = data;
+  const { roomId, username: originalUsername, content: originalContent, clientId } = data;
   const username = originalUsername?.toLowerCase();
 
   // Validate identifiers early
@@ -324,13 +324,14 @@ export async function handleSendMessage(
       return createErrorResponse("Duplicate message detected", 400);
     }
 
-    // Create and save the message
+    // Create and save the message (include clientId for optimistic update matching)
     const message: Message = {
       id: generateId(),
       roomId,
       username,
       content,
       timestamp: getCurrentTimestamp(),
+      ...(clientId && { clientId }), // Include clientId if provided
     };
 
     await addMessage(roomId, message);

--- a/public/version.json
+++ b/public/version.json
@@ -1,8 +1,8 @@
 {
   "version": "10.3",
-  "buildNumber": "7c1d246",
-  "commitSha": "7c1d24650a278bbf5d50df1a371fc837b7e739b4",
-  "buildTime": "2025-12-06T16:11:20.569Z",
+  "buildNumber": "999c6fd",
+  "commitSha": "999c6fd507d373004d1d431c9ce2a12332751d9c",
+  "buildTime": "2025-12-06T16:39:35.728Z",
   "majorVersion": 10,
   "minorVersion": 3
 }

--- a/src/apps/chats/hooks/useChatRoom.ts
+++ b/src/apps/chats/hooks/useChatRoom.ts
@@ -53,8 +53,8 @@ export function useChatRoom(
     messageRenderLimit,
   } = useChatsStore();
 
-  // Derive isAdmin directly from the username
-  const isAdmin = username === "ryo";
+  // Derive isAdmin directly from the username (case-insensitive)
+  const isAdmin = username?.toLowerCase() === "ryo";
 
   // Pusher refs
   const pusherRef = useRef<ReturnType<typeof getPusherClient> | null>(null);

--- a/src/lib/locales/en/translation.json
+++ b/src/lib/locales/en/translation.json
@@ -654,7 +654,11 @@
         "typeMessage": "Type a message...",
         "typeOrPushSpace": "Type or push 'space' to talk...",
         "scrollToBottom": "Scroll to bottom",
-        "nudgeSent": "👋 *nudge sent*"
+        "nudgeSent": "👋 *nudge sent*",
+        "loginRequired": "Please log in to delete messages",
+        "unauthorized": "Authentication required",
+        "forbidden": "You don't have permission to delete this message",
+        "networkError": "Network error occurred"
       },
       "ariaLabels": {
         "sendNudge": "Send a Nudge",
@@ -681,6 +685,7 @@
         "you": "You",
         "ryo": "Ryo",
         "delete": "Delete",
+        "deleteError": "Failed to delete message",
         "greeting": "👋 hey! i'm ryo. ask me anything!"
       },
       "toolCalls": {

--- a/src/stores/useChatsStore.ts
+++ b/src/stores/useChatsStore.ts
@@ -632,8 +632,9 @@ export const useChatsStore = create<ChatsStoreState>()(
         removeMessageFromRoom: (roomId, messageId) => {
           set((state) => {
             const existingMessages = state.roomMessages[roomId] || [];
+            // Filter out messages matching by id OR clientId (handles both replaced and unreplaced optimistic messages)
             const updatedMessages = existingMessages.filter(
-              (m) => m.id !== messageId
+              (m) => m.id !== messageId && m.clientId !== messageId
             );
             // Only update if a message was actually removed
             if (updatedMessages.length < existingMessages.length) {


### PR DESCRIPTION
Fix chat room delete message functionality for "ryo" by making the `isAdmin` check case-insensitive and adding user-friendly error toasts.

The `isAdmin` check in `useChatRoom.ts` was case-sensitive, leading to inconsistencies with the backend's case-insensitive check. Additionally, the frontend lacked user feedback for failed delete operations, only logging to the console.

---
<a href="https://cursor.com/background-agent?bcId=bc-272276ab-1872-414f-aa1f-6ecc66d46684"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-272276ab-1872-414f-aa1f-6ecc66d46684"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

