### PR TITLE
Add delay to ryo chat responses

### DIFF
--- a/public/version.json
+++ b/public/version.json
@@ -1,8 +1,8 @@
 {
   "version": "10.3",
-  "buildNumber": "751329c",
-  "commitSha": "751329cfca525ab68b3ca650f26e22466a75be08",
-  "buildTime": "2025-12-06T17:57:32.371Z",
+  "buildNumber": "d4d1a88",
+  "commitSha": "d4d1a88659656b3ee96d9423f68fa2377ccb8c37",
+  "buildTime": "2025-12-06T18:16:30.428Z",
   "majorVersion": 10,
   "minorVersion": 3
 }

--- a/public/version.json
+++ b/public/version.json
@@ -1,8 +1,8 @@
 {
   "version": "10.3",
-  "buildNumber": "3f25e89",
-  "commitSha": "3f25e8994574294a6d44253d0d261c2114edc553",
-  "buildTime": "2025-12-06T17:46:44.682Z",
+  "buildNumber": "751329c",
+  "commitSha": "751329cfca525ab68b3ca650f26e22466a75be08",
+  "buildTime": "2025-12-06T17:57:32.371Z",
   "majorVersion": 10,
   "minorVersion": 3
 }

--- a/src/apps/chats/hooks/useRyoChat.ts
+++ b/src/apps/chats/hooks/useRyoChat.ts
@@ -138,6 +138,10 @@ export function useRyoChat({
 
   const handleRyoMention = useCallback(
     async (messageContent: string) => {
+      // Add a delay to ensure the user's message is fully received by the server
+      // and visible to other users before Ryo responds
+      await new Promise((resolve) => setTimeout(resolve, 2000));
+
       // Get recent chat room messages as context (last 20 messages)
       const recentMessages = roomMessages
         .slice(-20)


### PR DESCRIPTION
Add a 2-second delay to Ryo's response generation to ensure the user's message is fully sent before Ryo replies.

---
<a href="https://cursor.com/background-agent?bcId=bc-128a6b75-7b54-427d-87d1-e0708185fa93"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-128a6b75-7b54-427d-87d1-e0708185fa93"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

