### PR TITLE
Auto-hide dock on inactivity

### DIFF
--- a/public/version.json
+++ b/public/version.json
@@ -1,8 +1,8 @@
 {
   "version": "10.3",
-  "buildNumber": "d0c258f",
-  "commitSha": "d0c258f91affe4c178f34f41037b3cc5e4f64fbd",
-  "buildTime": "2025-12-07T02:02:42.433Z",
+  "buildNumber": "0cf3518",
+  "commitSha": "0cf3518ba69f142997c843a172b7549d3a1630a9",
+  "buildTime": "2025-12-07T02:08:53.393Z",
   "majorVersion": 10,
   "minorVersion": 3
 }


### PR DESCRIPTION
Implement auto-hide functionality for the dock on phone devices after a period of inactivity.

---
<a href="https://cursor.com/background-agent?bcId=bc-3ee16322-99fc-42ca-81a5-f6c68862f3e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3ee16322-99fc-42ca-81a5-f6c68862f3e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

