### PR TITLE
Limit ie cache burst loads

### DIFF
--- a/api/iframe-check.ts
+++ b/api/iframe-check.ts
@@ -273,7 +273,7 @@ export default async function handler(req: Request) {
       const res = await RateLimit.checkCounterLimit({
         key,
         windowSeconds: BURST_WINDOW,
-        limit: 120, // Relaxed limits for cached lookups/listing
+        limit: 300, // Increased limit for cached lookups/listing (no AI generation cost)
       });
       if (!res.allowed) {
         return new Response(


### PR DESCRIPTION
Increase the rate limit for "ie load from cache" operations to 300 requests per minute because these are inexpensive cache lookups with no AI generation cost.

---
<a href="https://cursor.com/background-agent?bcId=bc-63f4b886-8e1b-46cc-a184-533de88c01ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-63f4b886-8e1b-46cc-a184-533de88c01ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

