### PR TITLE
Debug applet auth bridge

### DIFF
--- a/src/utils/appletAuthBridge.ts
+++ b/src/utils/appletAuthBridge.ts
@@ -53,102 +53,101 @@ export const APPLET_AUTH_BRIDGE_SCRIPT = `
       requestOnce();
     }, REQUEST_INTERVAL_MS);
 
-      setTimeout(function () {
-        if (!authResolved) {
-          clearInterval(requestTimer);
-          resolveAuth(null);
-        }
-      }, TIMEOUT_MS);
-
-      window.addEventListener("message", function (event) {
-        var data = event && event.data;
-        if (!data || data.type !== CHANNEL || data.action !== "response") {
-          return;
-        }
+    setTimeout(function () {
+      if (!authResolved) {
         clearInterval(requestTimer);
-        if (authResolved) {
-          currentAuthPayload = data.payload || null;
-          try {
-            window.__RYOS_APPLET_AUTH = currentAuthPayload || {};
-          } catch (err) {
-            console.warn("[ryOS] Failed to refresh applet auth payload:", err);
-          }
-          return;
-        }
-        resolveAuth(data.payload || null);
-      });
+        resolveAuth(null);
+      }
+    }, TIMEOUT_MS);
 
-      if (window.__RYOS_APPLET_FETCH_PATCHED) {
+    window.addEventListener("message", function (event) {
+      var data = event && event.data;
+      if (!data || data.type !== CHANNEL || data.action !== "response") {
         return;
       }
+      clearInterval(requestTimer);
+      if (authResolved) {
+        currentAuthPayload = data.payload || null;
+        try {
+          window.__RYOS_APPLET_AUTH = currentAuthPayload || {};
+        } catch (err) {
+          console.warn("[ryOS] Failed to refresh applet auth payload:", err);
+        }
+        return;
+      }
+      resolveAuth(data.payload || null);
+    });
 
-      var originalFetch = window.fetch.bind(window);
-      window.__RYOS_APPLET_FETCH_PATCHED = true;
-      window.__RYOS_ORIGINAL_FETCH = originalFetch;
+    if (window.__RYOS_APPLET_FETCH_PATCHED) {
+      return;
+    }
 
-      window.fetch = function (input, init) {
-        return authReady.then(function () {
-          var payload = currentAuthPayload;
-          if (!payload || (!payload.username && !payload.authToken)) {
-            return originalFetch(input, init);
+    var originalFetch = window.fetch.bind(window);
+    window.__RYOS_APPLET_FETCH_PATCHED = true;
+    window.__RYOS_ORIGINAL_FETCH = originalFetch;
+
+    window.fetch = function (input, init) {
+      return authReady.then(function () {
+        var payload = currentAuthPayload;
+        // Only add auth headers if BOTH username AND authToken are available
+        // This prevents sending username without token (which causes 401 errors)
+        if (!payload || !payload.username || !payload.authToken) {
+          return originalFetch(input, init);
+        }
+
+        var extraHeaders = {
+          "X-Username": payload.username,
+          "Authorization": "Bearer " + payload.authToken
+        };
+
+        var shouldAugment = function (url) {
+          try {
+            var resolved = new URL(url, document.baseURI || window.location.origin);
+            return resolved.pathname === "/api/applet-ai";
+          } catch (err) {
+            return false;
           }
+        };
 
-          var extraHeaders = {};
-          if (payload.username) {
-            extraHeaders["X-Username"] = payload.username;
-          }
-          if (payload.authToken) {
-            extraHeaders["Authorization"] = "Bearer " + payload.authToken;
-          }
-
-          var shouldAugment = function (url) {
-            try {
-              var resolved = new URL(url, document.baseURI || window.location.origin);
-              return resolved.pathname === "/api/applet-ai";
-            } catch (err) {
-              return false;
-            }
-          };
-
-          var mergeHeaders = function (primary, secondary) {
-            var headers = new Headers(primary || undefined);
-            if (secondary) {
-              new Headers(secondary).forEach(function (value, key) {
-                headers.set(key, value);
-              });
-            }
-            Object.keys(extraHeaders).forEach(function (key) {
-              var value = extraHeaders[key];
-              if (value) {
-                headers.set(key, value);
-              }
+        var mergeHeaders = function (primary, secondary) {
+          var headers = new Headers(primary || undefined);
+          if (secondary) {
+            new Headers(secondary).forEach(function (value, key) {
+              headers.set(key, value);
             });
-            return headers;
-          };
-
-          var url;
-          if (typeof input === "string" || input instanceof URL) {
-            url = input.toString();
-          } else if (input instanceof Request) {
-            url = input.url;
           }
+          Object.keys(extraHeaders).forEach(function (key) {
+            var value = extraHeaders[key];
+            if (value) {
+              headers.set(key, value);
+            }
+          });
+          return headers;
+        };
 
-          if (!url || !shouldAugment(url)) {
-            return originalFetch(input, init);
-          }
+        var url;
+        if (typeof input === "string" || input instanceof URL) {
+          url = input.toString();
+        } else if (input instanceof Request) {
+          url = input.url;
+        }
 
-          if (input instanceof Request) {
-            var headers = mergeHeaders(input.headers, init && init.headers);
-            var augmentedRequest = new Request(input, { headers: headers });
-            return originalFetch(augmentedRequest);
-          }
+        if (!url || !shouldAugment(url)) {
+          return originalFetch(input, init);
+        }
 
-          var headersForInit = mergeHeaders(init && init.headers);
-          var augmentedInit = init ? Object.assign({}, init) : {};
-          augmentedInit.headers = headersForInit;
-          return originalFetch(input, augmentedInit);
-        });
-      };
+        if (input instanceof Request) {
+          var headers = mergeHeaders(input.headers, init && init.headers);
+          var augmentedRequest = new Request(input, { headers: headers });
+          return originalFetch(augmentedRequest);
+        }
+
+        var headersForInit = mergeHeaders(init && init.headers);
+        var augmentedInit = init ? Object.assign({}, init) : {};
+        augmentedInit.headers = headersForInit;
+        return originalFetch(input, augmentedInit);
+      });
+    };
   })();
 </script>
 `;


### PR DESCRIPTION
Fix applet auth bridge to prevent 401 errors when username is present but authToken is missing.

The previous logic would add an `X-Username` header without an `Authorization` header if `payload.username` was truthy but `payload.authToken` was null. This caused API endpoints to return a 401 error. The updated logic now requires both `username` and `authToken` to be present before adding any auth headers, ensuring requests are either fully authenticated or correctly treated as anonymous.

---
<a href="https://cursor.com/background-agent?bcId=bc-7e7a3f88-1aa1-484f-a06a-0ca9621771f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7e7a3f88-1aa1-484f-a06a-0ca9621771f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

