### PR TITLE
Fix applet viewer icon

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -51,7 +51,7 @@ const APP_ICONS: Record<string, string> = {
   synth: "synth.png",
   pc: "pc.png",
   terminal: "terminal.png",
-  "applet-viewer": "../default/app.png",
+  "applet-viewer": "app.png",
   "control-panels": "control-panels/appearance-manager/app.png",
 };
 


### PR DESCRIPTION
Update the `applet-viewer` icon path in `middleware.ts` to use the correct `/icons/default/app.png`.

---
<a href="https://cursor.com/background-agent?bcId=bc-c70ac963-a448-4f2b-ae95-a448903cc9e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c70ac963-a448-4f2b-ae95-a448903cc9e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

