### PR TITLE
Add mobile exposé zoom

### DIFF
--- a/public/version.json
+++ b/public/version.json
@@ -1,8 +1,8 @@
 {
   "version": "10.3",
-  "buildNumber": "277dc6a",
-  "commitSha": "277dc6a63077b13241058997b8faf6b1c5b579e0",
-  "buildTime": "2025-12-09T12:28:31.685Z",
+  "buildNumber": "464535d",
+  "commitSha": "464535d1854d80e1d677aa669606bd9b6e142104",
+  "buildTime": "2025-12-11T06:32:22.090Z",
   "majorVersion": 10,
   "minorVersion": 3,
   "desktopVersion": "1.0.1"

--- a/src/components/layout/Desktop.tsx
+++ b/src/components/layout/Desktop.tsx
@@ -8,6 +8,7 @@ import { useWallpaper } from "@/hooks/useWallpaper";
 import { RightClickMenu, MenuItem } from "@/components/ui/right-click-menu";
 import { SortType } from "@/apps/finder/components/FinderMenuBar";
 import { useLongPress } from "@/hooks/useLongPress";
+import { usePinchGesture } from "@/hooks/usePinchGesture";
 import { useThemeStore } from "@/stores/useThemeStore";
 import { useFilesStore, FileSystemItem } from "@/stores/useFilesStore";
 import { useLaunchApp } from "@/hooks/useLaunchApp";
@@ -312,6 +313,15 @@ export function Desktop({
     const touch = e.touches[0];
     setContextMenuPos({ x: touch.clientX, y: touch.clientY });
     setContextMenuAppId(null);
+  });
+
+  // ------------------ Mobile pinch gesture support ------------------
+  // Trigger Exposé (Mission Control) when user does a two-finger pinch-in gesture.
+  const pinchGestureHandlers = usePinchGesture({
+    threshold: 80,
+    onPinchIn: () => {
+      window.dispatchEvent(new CustomEvent("toggleExposeView"));
+    },
   });
 
   // Add visibility change and focus handlers to resume video playback
@@ -649,7 +659,22 @@ export function Desktop({
       onDragLeave={handleDragLeave}
       onDrop={handleDrop}
       style={finalStyles}
-      {...longPressHandlers}
+      onTouchStart={(e) => {
+        longPressHandlers.onTouchStart(e);
+        pinchGestureHandlers.onTouchStart(e);
+      }}
+      onTouchEnd={(e) => {
+        longPressHandlers.onTouchEnd();
+        pinchGestureHandlers.onTouchEnd(e);
+      }}
+      onTouchMove={(e) => {
+        longPressHandlers.onTouchMove();
+        pinchGestureHandlers.onTouchMove(e);
+      }}
+      onTouchCancel={(e) => {
+        longPressHandlers.onTouchCancel();
+        pinchGestureHandlers.onTouchCancel(e);
+      }}
     >
       <video
         ref={videoRef}

--- a/src/components/layout/ExposeView.tsx
+++ b/src/components/layout/ExposeView.tsx
@@ -8,6 +8,7 @@ import { useFilesStore } from "@/stores/useFilesStore";
 import { useThemeStore } from "@/stores/useThemeStore";
 import { useSound, Sounds } from "@/hooks/useSound";
 import { useIsMobile } from "@/hooks/useIsMobile";
+import { usePinchGesture } from "@/hooks/usePinchGesture";
 import type { AppInstance } from "@/stores/useAppStore";
 import type { AppletViewerInitialData } from "@/apps/applet-viewer";
 import {
@@ -174,13 +175,19 @@ export function ExposeView({ isOpen, onClose }: ExposeViewProps) {
     );
   }, [openInstances.length, isMobile]);
 
+  // Pinch-out gesture to close expose view (spreading fingers)
+  const pinchGestureHandlers = usePinchGesture({
+    threshold: 80,
+    onPinchOut: onClose,
+  });
+
   if (!isOpen) return null;
 
   return (
     <AnimatePresence>
       {isOpen && (
         <>
-          {/* Backdrop - clicking closes expose view */}
+          {/* Backdrop - clicking or pinch-out gesture closes expose view */}
           <motion.div
             className="fixed inset-0 z-[9998] bg-black/50"
             initial={{ opacity: 0 }}
@@ -188,6 +195,7 @@ export function ExposeView({ isOpen, onClose }: ExposeViewProps) {
             exit={{ opacity: 0 }}
             transition={{ duration: 0.3 }}
             onClick={onClose}
+            {...pinchGestureHandlers}
           />
 
           {/* Global style to disable iframe interactions in expose mode */}

--- a/src/hooks/usePinchGesture.ts
+++ b/src/hooks/usePinchGesture.ts
@@ -1,0 +1,88 @@
+import { useCallback, useRef } from "react";
+
+interface PinchGestureOptions {
+  /** Minimum distance change (in pixels) to trigger the gesture */
+  threshold?: number;
+  /** Called when pinch-in (zoom out) gesture is detected */
+  onPinchIn?: () => void;
+  /** Called when pinch-out (zoom in) gesture is detected */
+  onPinchOut?: () => void;
+}
+
+/**
+ * Hook to detect two-finger pinch gestures on touch devices.
+ *
+ * - onPinchIn: triggered when fingers move together (zoom out gesture)
+ * - onPinchOut: triggered when fingers spread apart (zoom in gesture)
+ *
+ * Example:
+ * const pinchHandlers = usePinchGesture({
+ *   onPinchIn: () => console.log("pinch in"),
+ *   onPinchOut: () => console.log("pinch out"),
+ * });
+ * <div {...pinchHandlers} />
+ */
+export function usePinchGesture({
+  threshold = 100,
+  onPinchIn,
+  onPinchOut,
+}: PinchGestureOptions = {}) {
+  const initialDistanceRef = useRef<number | null>(null);
+  const hasTriggeredRef = useRef(false);
+
+  const getDistance = (touches: React.TouchList) => {
+    if (touches.length < 2) return null;
+    const dx = touches[0].clientX - touches[1].clientX;
+    const dy = touches[0].clientY - touches[1].clientY;
+    return Math.sqrt(dx * dx + dy * dy);
+  };
+
+  const handleTouchStart = useCallback((e: React.TouchEvent) => {
+    if (e.touches.length === 2) {
+      initialDistanceRef.current = getDistance(e.touches);
+      hasTriggeredRef.current = false;
+    }
+  }, []);
+
+  const handleTouchMove = useCallback(
+    (e: React.TouchEvent) => {
+      if (
+        e.touches.length !== 2 ||
+        initialDistanceRef.current === null ||
+        hasTriggeredRef.current
+      ) {
+        return;
+      }
+
+      const currentDistance = getDistance(e.touches);
+      if (currentDistance === null) return;
+
+      const delta = currentDistance - initialDistanceRef.current;
+
+      // Pinch in (fingers coming together) - negative delta
+      if (delta < -threshold && onPinchIn) {
+        hasTriggeredRef.current = true;
+        onPinchIn();
+      }
+      // Pinch out (fingers spreading apart) - positive delta
+      else if (delta > threshold && onPinchOut) {
+        hasTriggeredRef.current = true;
+        onPinchOut();
+      }
+    },
+    [threshold, onPinchIn, onPinchOut]
+  );
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const handleTouchEnd = useCallback((_e?: React.TouchEvent) => {
+    initialDistanceRef.current = null;
+    hasTriggeredRef.current = false;
+  }, []);
+
+  return {
+    onTouchStart: handleTouchStart,
+    onTouchMove: handleTouchMove,
+    onTouchEnd: handleTouchEnd,
+    onTouchCancel: handleTouchEnd,
+  } as const;
+}


### PR DESCRIPTION
Add two-finger pinch gestures to Exposé for intuitive opening from the desktop and closing from within Exposé on mobile devices.

---
<a href="https://cursor.com/background-agent?bcId=bc-1ed2d691-c691-4cd1-a74e-578f5c30e6de"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1ed2d691-c691-4cd1-a74e-578f5c30e6de"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

