### PR TITLE
Hide admin app menu

### DIFF
--- a/src/components/layout/AppleMenu.tsx
+++ b/src/components/layout/AppleMenu.tsx
@@ -27,6 +27,9 @@ export function AppleMenu({ apps }: AppleMenuProps) {
   const currentTheme = useThemeStore((state) => state.current);
   const isMacOsxTheme = currentTheme === "macosx";
 
+  // Filter out admin-only apps from the Apple menu
+  const visibleApps = apps.filter((app) => app.id !== "admin");
+
   const handleAppClick = (appId: string) => {
     // Simply launch the app - the instance system will handle focus if already open
     launchApp(appId as AppId);
@@ -59,7 +62,7 @@ export function AppleMenu({ apps }: AppleMenuProps) {
             {t("common.appleMenu.aboutThisComputer")}
           </MenubarItem>
           <MenubarSeparator className="h-[2px] bg-black my-1" />
-          {apps.map((app) => (
+          {visibleApps.map((app) => (
             <MenubarItem
               key={app.id}
               onClick={() => handleAppClick(app.id)}


### PR DESCRIPTION
Hide the admin app from the Apple menu.

---
<a href="https://cursor.com/background-agent?bcId=bc-00ffc8c4-8cb9-4325-b057-64db163df36a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-00ffc8c4-8cb9-4325-b057-64db163df36a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

