### PR TITLE
Ipod pip zindex adjustment

### DIFF
--- a/src/apps/ipod/components/IpodAppComponent.tsx
+++ b/src/apps/ipod/components/IpodAppComponent.tsx
@@ -104,8 +104,9 @@ function PipPlayer({
       exit={{ opacity: 0, y: 20, scale: 0.9, x: shouldCenter ? "-50%" : 0 }}
       transition={{ duration: 0.2, ease: "easeOut" }}
       className={cn(
-        "fixed flex items-center gap-3 bg-black/40 backdrop-blur-xl rounded-xl shadow-2xl p-2 pr-3 cursor-pointer select-none",
-        shouldCenter ? "left-1/2 z-[9998]" : "right-3 z-[9998]"
+        // Keep PiP below normal application windows (AppManager windows start at z-index 2+)
+        "fixed z-[1] flex items-center gap-3 bg-black/40 backdrop-blur-xl rounded-xl shadow-2xl p-2 pr-3 cursor-pointer select-none",
+        shouldCenter ? "left-1/2" : "right-3"
       )}
       style={{ 
         ...(isPhone


### PR DESCRIPTION
Fix iPod PiP player z-index so it sits below application windows.

The iPod PiP player was previously hard-coded with `z-[9998]`, causing it to always float above all application windows. This change sets its z-index to `z-[1]`, ensuring it renders underneath normal application windows (which start at z-index 2+ via `AppManager`).

---
<a href="https://cursor.com/background-agent?bcId=bc-09528674-59fc-41b2-8f16-0a6f7c2342dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-09528674-59fc-41b2-8f16-0a6f7c2342dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

