### PR TITLE
Pip player interaction fix

### DIFF
--- a/src/components/layout/WindowFrame.tsx
+++ b/src/components/layout/WindowFrame.tsx
@@ -856,7 +856,12 @@ export function WindowFrame({
       {shouldShow && (
         <motion.div
           key={`pos-${instanceId || appId}`}
-          className="absolute p-2 md:p-0"
+          className={cn(
+            "absolute p-2 md:p-0",
+            // For keepMountedWhenMinimized apps, disable pointer events on outer wrapper when minimized
+            // so clicks can pass through to windows/desktop behind it
+            (keepMountedWhenMinimized && isMinimized) && "pointer-events-none"
+          )}
           initial={false}
           animate={{
             left: windowPosition.x,


### PR DESCRIPTION
Add `pointer-events-none` to the outer `WindowFrame` wrapper to fix blocked clicks on other windows/desktop when a `keepMountedWhenMinimized` app is minimized.

When an app like iPod (with PIP) is minimized and `keepMountedWhenMinimized` is true, the `WindowFrame`'s outer positioning wrapper was still intercepting pointer events, preventing clicks from reaching elements behind it. This change ensures clicks pass through when the window is minimized.

---
<a href="https://cursor.com/background-agent?bcId=bc-cce4843b-9a01-48c8-b7c3-f7772a62301d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-cce4843b-9a01-48c8-b7c3-f7772a62301d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

