### PR TITLE
Admin app localization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Core dumps
+core
+
 # Logs
 logs
 *.log

--- a/src/lib/locales/de/translation.json
+++ b/src/lib/locales/de/translation.json
@@ -8,16 +8,21 @@
       },
       "description": "Systemadministrationspanel",
       "dialogs": {
+        "banDescription": "Möchten Sie {{username}} wirklich sperren? Die Person wird abgemeldet und kann nicht mehr auf den Dienst zugreifen.",
+        "banTitle": "Benutzer sperren?",
         "deleteDescription": "Möchten Sie {{type}} „{{name}}“ wirklich löschen? Diese Aktion kann nicht rückgängig gemacht werden.",
         "deleteTitle": "{{type}} löschen?"
       },
       "errors": {
+        "failedToBanUser": "Benutzer konnte nicht gesperrt werden",
         "failedToDeleteMessage": "Nachricht konnte nicht gelöscht werden",
         "failedToDeleteRoom": "Raum konnte nicht gelöscht werden",
         "failedToDeleteUser": "Benutzer konnte nicht gelöscht werden",
         "failedToFetchMessages": "Nachrichten konnten nicht abgerufen werden",
+        "failedToFetchProfile": "Benutzerprofil konnte nicht abgerufen werden",
         "failedToFetchRooms": "Räume konnten nicht abgerufen werden",
-        "failedToFetchUsers": "Benutzer konnten nicht abgerufen werden"
+        "failedToFetchUsers": "Benutzer konnten nicht abgerufen werden",
+        "failedToUnbanUser": "Benutzer konnte nicht entsperrt werden"
       },
       "help": {
         "adminAccess": {
@@ -47,9 +52,34 @@
         "dataRefreshed": "Daten aktualisiert",
         "messageDeleted": "Nachricht gelöscht",
         "roomDeleted": "Raum gelöscht",
-        "userDeleted": "Benutzer {{username}} gelöscht"
+        "userBanned": "Benutzer {{username}} gesperrt",
+        "userDeleted": "Benutzer {{username}} gelöscht",
+        "userUnbanned": "Benutzer {{username}} entsperrt"
       },
       "name": "Admin",
+      "profile": {
+        "actions": "Aktionen",
+        "activeRooms": "Aktiv in Räumen",
+        "back": "Zurück",
+        "ban": "Benutzer sperren",
+        "banDetails": "Sperrdetails",
+        "banReasonPlaceholder": "Sperrgrund (optional)",
+        "banned": "Gesperrt",
+        "bannedOn": "Gesperrt am",
+        "confirmBan": "Sperren",
+        "delete": "Benutzer löschen",
+        "lastActive": "Zuletzt aktiv",
+        "loading": "Profil wird geladen...",
+        "messages": "Nachrichten",
+        "noMessages": "Keine Nachrichten gefunden",
+        "noReason": "Kein Grund angegeben",
+        "notFound": "Benutzer nicht gefunden",
+        "reason": "Grund",
+        "recentMessages": "Neueste Nachrichten",
+        "room": "Raum",
+        "rooms": "Räume",
+        "unban": "Benutzer entbannen"
+      },
       "room": {
         "messagesCount": "{{count}} Nachrichten",
         "noMessages": "Keine Nachrichten"
@@ -78,6 +108,7 @@
         "lastActive": "Zuletzt aktiv",
         "message": "Nachricht",
         "role": "Rolle",
+        "status": "Status",
         "time": "Zeit",
         "user": "Benutzer",
         "username": "Benutzername"
@@ -90,7 +121,9 @@
       },
       "title": "Admin",
       "user": {
+        "active": "Aktiv",
         "admin": "admin",
+        "banned": "Gesperrt",
         "user": "Benutzer"
       }
     },
@@ -329,11 +362,11 @@
       },
       "name": "Chats",
       "sidebar": {
-        "rooms": "Räume",
         "chats": "Chats",
         "new": "neu",
         "online": "aktiv",
-        "private": "Privat"
+        "private": "Privat",
+        "rooms": "Räume"
       },
       "status": {
         "chatRequiresInternet": "Chat erfordert eine Internetverbindung",

--- a/src/lib/locales/es/translation.json
+++ b/src/lib/locales/es/translation.json
@@ -8,16 +8,21 @@
       },
       "description": "Panel de administración del sistema",
       "dialogs": {
+        "banDescription": "¿Estás seguro de que quieres banear a {{username}}? Se cerrará su sesión y no podrá acceder al servicio.",
+        "banTitle": "¿Banear usuario?",
         "deleteDescription": "¿Estás seguro de que quieres eliminar {{type}} \"{{name}}\"? Esta acción no se puede deshacer.",
         "deleteTitle": "¿Eliminar {{type}}?"
       },
       "errors": {
+        "failedToBanUser": "Error al banear usuario",
         "failedToDeleteMessage": "Error al eliminar mensaje",
         "failedToDeleteRoom": "Error al eliminar sala",
         "failedToDeleteUser": "Error al eliminar usuario",
         "failedToFetchMessages": "Error al obtener mensajes",
+        "failedToFetchProfile": "Error al cargar el perfil del usuario",
         "failedToFetchRooms": "Error al obtener salas",
-        "failedToFetchUsers": "Error al obtener usuarios"
+        "failedToFetchUsers": "Error al obtener usuarios",
+        "failedToUnbanUser": "Error al desbanear usuario"
       },
       "help": {
         "adminAccess": {
@@ -47,9 +52,34 @@
         "dataRefreshed": "Datos actualizados",
         "messageDeleted": "Mensaje eliminado",
         "roomDeleted": "Sala eliminada",
-        "userDeleted": "Usuario {{username}} eliminado"
+        "userBanned": "Usuario {{username}} baneado",
+        "userDeleted": "Usuario {{username}} eliminado",
+        "userUnbanned": "Usuario {{username}} desbaneado"
       },
       "name": "Admin",
+      "profile": {
+        "actions": "Acciones",
+        "activeRooms": "Activo en salas",
+        "back": "Volver",
+        "ban": "Banear usuario",
+        "banDetails": "Detalles del baneo",
+        "banReasonPlaceholder": "Motivo del baneo (opcional)",
+        "banned": "Baneado",
+        "bannedOn": "Baneado el",
+        "confirmBan": "Banear",
+        "delete": "Eliminar usuario",
+        "lastActive": "Última actividad",
+        "loading": "Cargando perfil...",
+        "messages": "Mensajes",
+        "noMessages": "No se encontraron mensajes",
+        "noReason": "No se proporcionó ninguna razón",
+        "notFound": "Usuario no encontrado",
+        "reason": "Razón",
+        "recentMessages": "Mensajes recientes",
+        "room": "Sala",
+        "rooms": "Salas",
+        "unban": "Desbloquear usuario"
+      },
       "room": {
         "messagesCount": "{{count}} mensajes",
         "noMessages": "No hay mensajes"
@@ -78,6 +108,7 @@
         "lastActive": "Última actividad",
         "message": "Mensaje",
         "role": "Rol",
+        "status": "Estado",
         "time": "Hora",
         "user": "Usuario",
         "username": "Nombre de usuario"
@@ -90,7 +121,9 @@
       },
       "title": "Administrador",
       "user": {
+        "active": "Activo",
         "admin": "administrador",
+        "banned": "Bloqueado",
         "user": "usuario"
       }
     },
@@ -329,11 +362,11 @@
       },
       "name": "Chats",
       "sidebar": {
-        "rooms": "Salas",
         "chats": "Chats",
         "new": "nuevo",
         "online": "en línea",
-        "private": "Privado"
+        "private": "Privado",
+        "rooms": "Salas"
       },
       "status": {
         "chatRequiresInternet": "El chat requiere una conexión a internet",

--- a/src/lib/locales/fr/translation.json
+++ b/src/lib/locales/fr/translation.json
@@ -8,16 +8,21 @@
       },
       "description": "Panneau d'administration système",
       "dialogs": {
+        "banDescription": "Êtes-vous sûr de vouloir bannir {{username}} ? Il/Elle sera déconnecté(e) et ne pourra plus accéder au service.",
+        "banTitle": "Bannir l'utilisateur ?",
         "deleteDescription": "Êtes-vous sûr de vouloir supprimer {{type}} « {{name}} » ? Cette action est irréversible.",
         "deleteTitle": "Supprimer {{type}} ?"
       },
       "errors": {
+        "failedToBanUser": "Échec du bannissement de l'utilisateur",
         "failedToDeleteMessage": "Échec de la suppression du message",
         "failedToDeleteRoom": "Échec de la suppression du salon",
         "failedToDeleteUser": "Échec de la suppression de l'utilisateur",
         "failedToFetchMessages": "Échec de la récupération des messages",
+        "failedToFetchProfile": "Échec de la récupération du profil utilisateur",
         "failedToFetchRooms": "Échec de la récupération des salons",
-        "failedToFetchUsers": "Échec de la récupération des utilisateurs"
+        "failedToFetchUsers": "Échec de la récupération des utilisateurs",
+        "failedToUnbanUser": "Échec du débannissement de l'utilisateur"
       },
       "help": {
         "adminAccess": {
@@ -47,9 +52,34 @@
         "dataRefreshed": "Données actualisées",
         "messageDeleted": "Message supprimé",
         "roomDeleted": "Salon supprimé",
-        "userDeleted": "Utilisateur {{username}} supprimé"
+        "userBanned": "Utilisateur {{username}} banni",
+        "userDeleted": "Utilisateur {{username}} supprimé",
+        "userUnbanned": "Utilisateur {{username}} débanni"
       },
       "name": "Admin",
+      "profile": {
+        "actions": "Actions",
+        "activeRooms": "Actif dans les salons",
+        "back": "Retour",
+        "ban": "Bannir l'utilisateur",
+        "banDetails": "Détails du bannissement",
+        "banReasonPlaceholder": "Motif du bannissement (facultatif)",
+        "banned": "Banni",
+        "bannedOn": "Banni le",
+        "confirmBan": "Bannir",
+        "delete": "Supprimer l'utilisateur",
+        "lastActive": "Dernière activité",
+        "loading": "Chargement du profil...",
+        "messages": "Messages",
+        "noMessages": "Aucun message trouvé",
+        "noReason": "Aucune raison fournie",
+        "notFound": "Utilisateur introuvable",
+        "reason": "Raison",
+        "recentMessages": "Messages récents",
+        "room": "Salon",
+        "rooms": "Salons",
+        "unban": "Débannir l'utilisateur"
+      },
       "room": {
         "messagesCount": "{{count}} messages",
         "noMessages": "Aucun message"
@@ -78,6 +108,7 @@
         "lastActive": "Dernière activité",
         "message": "Message",
         "role": "Rôle",
+        "status": "Statut",
         "time": "Heure",
         "user": "Utilisateur",
         "username": "Nom d'utilisateur"
@@ -90,7 +121,9 @@
       },
       "title": "Admin",
       "user": {
+        "active": "Actif",
         "admin": "admin",
+        "banned": "Banni",
         "user": "utilisateur"
       }
     },
@@ -329,11 +362,11 @@
       },
       "name": "Chats",
       "sidebar": {
-        "rooms": "Salons",
         "chats": "Discussions",
         "new": "nouveau",
         "online": "en ligne",
-        "private": "Privé"
+        "private": "Privé",
+        "rooms": "Salons"
       },
       "status": {
         "chatRequiresInternet": "Le chat nécessite une connexion internet",

--- a/src/lib/locales/it/translation.json
+++ b/src/lib/locales/it/translation.json
@@ -8,16 +8,21 @@
       },
       "description": "Pannello di amministrazione del sistema",
       "dialogs": {
+        "banDescription": "Sei sicuro di voler bannare {{username}}? Verrà disconnesso e non potrà più accedere al servizio.",
+        "banTitle": "Bannare utente?",
         "deleteDescription": "Sei sicuro di voler eliminare {{type}} \"{{name}}\"? Questa azione non può essere annullata.",
         "deleteTitle": "Eliminare {{type}}?"
       },
       "errors": {
+        "failedToBanUser": "Impossibile bannare l'utente",
         "failedToDeleteMessage": "Impossibile eliminare il messaggio",
         "failedToDeleteRoom": "Impossibile eliminare la stanza",
         "failedToDeleteUser": "Impossibile eliminare l'utente",
         "failedToFetchMessages": "Impossibile recuperare i messaggi",
+        "failedToFetchProfile": "Impossibile caricare il profilo utente",
         "failedToFetchRooms": "Impossibile recuperare le stanze",
-        "failedToFetchUsers": "Impossibile recuperare gli utenti"
+        "failedToFetchUsers": "Impossibile recuperare gli utenti",
+        "failedToUnbanUser": "Impossibile sbannare l'utente"
       },
       "help": {
         "adminAccess": {
@@ -47,9 +52,34 @@
         "dataRefreshed": "Dati aggiornati",
         "messageDeleted": "Messaggio eliminato",
         "roomDeleted": "Stanza eliminata",
-        "userDeleted": "Utente {{username}} eliminato"
+        "userBanned": "Utente {{username}} bannato",
+        "userDeleted": "Utente {{username}} eliminato",
+        "userUnbanned": "Utente {{username}} sbannato"
       },
       "name": "Admin",
+      "profile": {
+        "actions": "Azioni",
+        "activeRooms": "Attivo nelle stanze",
+        "back": "Indietro",
+        "ban": "Banna utente",
+        "banDetails": "Dettagli ban",
+        "banReasonPlaceholder": "Motivo del ban (facoltativo)",
+        "banned": "Bannato",
+        "bannedOn": "Bannato il",
+        "confirmBan": "Banna",
+        "delete": "Elimina utente",
+        "lastActive": "Ultima attività",
+        "loading": "Caricamento profilo...",
+        "messages": "Messaggi",
+        "noMessages": "Nessun messaggio trovato",
+        "noReason": "Nessun motivo fornito",
+        "notFound": "Utente non trovato",
+        "reason": "Motivo",
+        "recentMessages": "Messaggi recenti",
+        "room": "Stanza",
+        "rooms": "Stanze",
+        "unban": "Sblocca utente"
+      },
       "room": {
         "messagesCount": "{{count}} messaggi",
         "noMessages": "Nessun messaggio"
@@ -78,6 +108,7 @@
         "lastActive": "Ultima Attività",
         "message": "Messaggio",
         "role": "Ruolo",
+        "status": "Stato",
         "time": "Ora",
         "user": "Utente",
         "username": "Nome utente"
@@ -90,7 +121,9 @@
       },
       "title": "Amministratore",
       "user": {
+        "active": "Attivo",
         "admin": "amministratore",
+        "banned": "Bannato",
         "user": "utente"
       }
     },
@@ -329,11 +362,11 @@
       },
       "name": "Chat",
       "sidebar": {
-        "rooms": "Stanze",
         "chats": "Chat",
         "new": "nuovo",
         "online": "online",
-        "private": "Privato"
+        "private": "Privato",
+        "rooms": "Stanze"
       },
       "status": {
         "chatRequiresInternet": "La chat richiede una connessione a internet",

--- a/src/lib/locales/ja/translation.json
+++ b/src/lib/locales/ja/translation.json
@@ -8,16 +8,21 @@
       },
       "description": "システム管理画面",
       "dialogs": {
+        "banDescription": "{{username}} をBANしますか？ユーザーはログアウトされ、サービスにアクセスできなくなります。",
+        "banTitle": "ユーザーをBANしますか？",
         "deleteDescription": "{{type}}「{{name}}」を削除しますか？この操作は元に戻せません。",
         "deleteTitle": "{{type}}を削除しますか？"
       },
       "errors": {
+        "failedToBanUser": "ユーザーのBANに失敗しました",
         "failedToDeleteMessage": "メッセージの削除に失敗しました。",
         "failedToDeleteRoom": "ルームの削除に失敗しました。",
         "failedToDeleteUser": "ユーザーの削除に失敗しました。",
         "failedToFetchMessages": "メッセージの取得に失敗しました。",
+        "failedToFetchProfile": "ユーザープロフィールの取得に失敗しました",
         "failedToFetchRooms": "ルームの取得に失敗しました。",
-        "failedToFetchUsers": "ユーザーの取得に失敗しました。"
+        "failedToFetchUsers": "ユーザーの取得に失敗しました。",
+        "failedToUnbanUser": "ユーザーのBAN解除に失敗しました"
       },
       "help": {
         "adminAccess": {
@@ -47,9 +52,34 @@
         "dataRefreshed": "データが更新されました",
         "messageDeleted": "メッセージが削除されました",
         "roomDeleted": "ルームが削除されました",
-        "userDeleted": "ユーザー {{username}} が削除されました"
+        "userBanned": "{{username}} をBANしました",
+        "userDeleted": "ユーザー {{username}} が削除されました",
+        "userUnbanned": "{{username}} のBANを解除しました"
       },
       "name": "Admin",
+      "profile": {
+        "actions": "アクション",
+        "activeRooms": "ルームでアクティブ",
+        "back": "戻る",
+        "ban": "ユーザーをBAN",
+        "banDetails": "BANの詳細",
+        "banReasonPlaceholder": "BAN理由（任意）",
+        "banned": "BAN済み",
+        "bannedOn": "BAN日",
+        "confirmBan": "BAN",
+        "delete": "ユーザーを削除",
+        "lastActive": "最終アクティブ",
+        "loading": "プロフィールを読み込み中...",
+        "messages": "メッセージ",
+        "noMessages": "メッセージが見つかりませんでした",
+        "noReason": "理由が提供されていません",
+        "notFound": "ユーザーが見つかりませんでした",
+        "reason": "理由",
+        "recentMessages": "最近のメッセージ",
+        "room": "ルーム",
+        "rooms": "ルーム",
+        "unban": "ユーザーのBAN解除"
+      },
       "room": {
         "messagesCount": "メッセージ{{count}}件",
         "noMessages": "メッセージはありません"
@@ -78,6 +108,7 @@
         "lastActive": "最終アクティブ",
         "message": "メッセージ",
         "role": "役割",
+        "status": "ステータス",
         "time": "時間",
         "user": "ユーザー",
         "username": "ユーザー名"
@@ -90,7 +121,9 @@
       },
       "title": "管理者",
       "user": {
+        "active": "アクティブ",
         "admin": "管理者",
+        "banned": "BAN済み",
         "user": "ユーザー"
       }
     },
@@ -329,11 +362,11 @@
       },
       "name": "チャット",
       "sidebar": {
-        "rooms": "ルーム",
         "chats": "チャット",
         "new": "新規",
         "online": "オンライン",
-        "private": "プライベート"
+        "private": "プライベート",
+        "rooms": "ルーム"
       },
       "status": {
         "chatRequiresInternet": "チャットにはインターネット接続が必要です",

--- a/src/lib/locales/ko/translation.json
+++ b/src/lib/locales/ko/translation.json
@@ -8,16 +8,21 @@
       },
       "description": "시스템 관리 패널",
       "dialogs": {
+        "banDescription": "{{username}}을(를) 차단하시겠습니까? 해당 사용자는 로그아웃되며 서비스에 접속할 수 없게 됩니다.",
+        "banTitle": "사용자 차단?",
         "deleteDescription": "{{type}} \"{{name}}\"을(를) 정말 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다.",
         "deleteTitle": "{{type}}(을)를 삭제하시겠습니까?"
       },
       "errors": {
+        "failedToBanUser": "사용자 차단 실패",
         "failedToDeleteMessage": "메시지 삭제 실패",
         "failedToDeleteRoom": "채팅방 삭제 실패",
         "failedToDeleteUser": "사용자 삭제 실패",
         "failedToFetchMessages": "메시지 불러오기 실패",
+        "failedToFetchProfile": "사용자 프로필 불러오기 실패",
         "failedToFetchRooms": "채팅방 불러오기 실패",
-        "failedToFetchUsers": "사용자 불러오기 실패"
+        "failedToFetchUsers": "사용자 불러오기 실패",
+        "failedToUnbanUser": "사용자 차단 해제 실패"
       },
       "help": {
         "adminAccess": {
@@ -47,9 +52,34 @@
         "dataRefreshed": "데이터 새로고침 완료",
         "messageDeleted": "메시지 삭제됨",
         "roomDeleted": "방 삭제됨",
-        "userDeleted": "사용자 {{username}} 삭제됨"
+        "userBanned": "사용자 {{username}} 차단됨",
+        "userDeleted": "사용자 {{username}} 삭제됨",
+        "userUnbanned": "사용자 {{username}} 차단 해제됨"
       },
       "name": "관리자",
+      "profile": {
+        "actions": "작업",
+        "activeRooms": "채팅방 활동 중",
+        "back": "뒤로",
+        "ban": "사용자 차단",
+        "banDetails": "차단 정보",
+        "banReasonPlaceholder": "차단 사유 (선택 사항)",
+        "banned": "차단됨",
+        "bannedOn": "차단일",
+        "confirmBan": "차단",
+        "delete": "사용자 삭제",
+        "lastActive": "마지막 활동",
+        "loading": "프로필 불러오는 중...",
+        "messages": "메시지",
+        "noMessages": "메시지를 찾을 수 없습니다.",
+        "noReason": "이유 없음",
+        "notFound": "사용자를 찾을 수 없습니다.",
+        "reason": "이유",
+        "recentMessages": "최근 메시지",
+        "room": "방",
+        "rooms": "방",
+        "unban": "사용자 차단 해제"
+      },
       "room": {
         "messagesCount": "{{count}}개 메시지",
         "noMessages": "메시지 없음"
@@ -78,6 +108,7 @@
         "lastActive": "마지막 활동",
         "message": "메시지",
         "role": "역할",
+        "status": "상태",
         "time": "시간",
         "user": "사용자",
         "username": "사용자 이름"
@@ -90,7 +121,9 @@
       },
       "title": "관리자",
       "user": {
+        "active": "활성",
         "admin": "관리자",
+        "banned": "차단됨",
         "user": "사용자"
       }
     },
@@ -329,11 +362,11 @@
       },
       "name": "채팅",
       "sidebar": {
-        "rooms": "방",
         "chats": "채팅",
         "new": "신규",
         "online": "온라인",
-        "private": "비공개"
+        "private": "비공개",
+        "rooms": "방"
       },
       "status": {
         "chatRequiresInternet": "채팅을 이용하려면 인터넷 연결이 필요합니다",

--- a/src/lib/locales/pt/translation.json
+++ b/src/lib/locales/pt/translation.json
@@ -8,16 +8,21 @@
       },
       "description": "Painel de administração do sistema",
       "dialogs": {
+        "banDescription": "Tem certeza de que deseja banir {{username}}? Essa pessoa será desconectada e não poderá acessar o serviço.",
+        "banTitle": "Banir Usuário?",
         "deleteDescription": "Tem certeza de que deseja excluir {{type}} \"{{name}}\"? Esta ação não pode ser desfeita.",
         "deleteTitle": "Excluir {{type}}?"
       },
       "errors": {
+        "failedToBanUser": "Falha ao banir usuário",
         "failedToDeleteMessage": "Falha ao excluir mensagem",
         "failedToDeleteRoom": "Falha ao excluir sala",
         "failedToDeleteUser": "Falha ao excluir usuário",
         "failedToFetchMessages": "Falha ao buscar mensagens",
+        "failedToFetchProfile": "Falha ao buscar perfil do usuário",
         "failedToFetchRooms": "Falha ao buscar salas",
-        "failedToFetchUsers": "Falha ao buscar usuários"
+        "failedToFetchUsers": "Falha ao buscar usuários",
+        "failedToUnbanUser": "Falha ao desbanir usuário"
       },
       "help": {
         "adminAccess": {
@@ -47,9 +52,34 @@
         "dataRefreshed": "Dados atualizados",
         "messageDeleted": "Mensagem eliminada",
         "roomDeleted": "Sala eliminada",
-        "userDeleted": "Utilizador {{username}} eliminado"
+        "userBanned": "Usuário {{username}} banido",
+        "userDeleted": "Utilizador {{username}} eliminado",
+        "userUnbanned": "Usuário {{username}} desbanido"
       },
       "name": "Admin",
+      "profile": {
+        "actions": "Ações",
+        "activeRooms": "Ativo em Salas",
+        "back": "Voltar",
+        "ban": "Banir Usuário",
+        "banDetails": "Detalhes do Banimento",
+        "banReasonPlaceholder": "Motivo do banimento (opcional)",
+        "banned": "Banido",
+        "bannedOn": "Banido em",
+        "confirmBan": "Banir",
+        "delete": "Excluir Usuário",
+        "lastActive": "Última atividade",
+        "loading": "Carregando perfil...",
+        "messages": "Mensagens",
+        "noMessages": "Nenhuma mensagem encontrada",
+        "noReason": "Nenhum motivo fornecido",
+        "notFound": "Usuário não encontrado",
+        "reason": "Motivo",
+        "recentMessages": "Mensagens Recentes",
+        "room": "Sala",
+        "rooms": "Salas",
+        "unban": "Desbanir Usuário"
+      },
       "room": {
         "messagesCount": "{{count}} mensagens",
         "noMessages": "Nenhuma mensagem"
@@ -78,6 +108,7 @@
         "lastActive": "Última Atividade",
         "message": "Mensagem",
         "role": "Função",
+        "status": "Status",
         "time": "Hora",
         "user": "Usuário",
         "username": "Nome de Usuário"
@@ -90,7 +121,9 @@
       },
       "title": "Admin",
       "user": {
+        "active": "Ativo",
         "admin": "admin",
+        "banned": "Banido",
         "user": "usuário"
       }
     },
@@ -329,11 +362,11 @@
       },
       "name": "Bate-papos",
       "sidebar": {
-        "rooms": "Salas",
         "chats": "Chats",
         "new": "novo",
         "online": "online",
-        "private": "Privado"
+        "private": "Privado",
+        "rooms": "Salas"
       },
       "status": {
         "chatRequiresInternet": "O chat requer uma conexão com a internet",

--- a/src/lib/locales/ru/translation.json
+++ b/src/lib/locales/ru/translation.json
@@ -8,16 +8,21 @@
       },
       "description": "Панель администрирования системы",
       "dialogs": {
+        "banDescription": "Вы уверены, что хотите заблокировать {{username}}? Они будут выведены из системы и не смогут получить доступ к сервису.",
+        "banTitle": "Заблокировать пользователя?",
         "deleteDescription": "Вы уверены, что хотите удалить {{type}} «{{name}}»? Это действие невозможно отменить.",
         "deleteTitle": "Удалить {{type}}?"
       },
       "errors": {
+        "failedToBanUser": "Не удалось заблокировать пользователя",
         "failedToDeleteMessage": "Не удалось удалить сообщение",
         "failedToDeleteRoom": "Не удалось удалить комнату",
         "failedToDeleteUser": "Не удалось удалить пользователя",
         "failedToFetchMessages": "Не удалось получить сообщения",
+        "failedToFetchProfile": "Не удалось загрузить профиль пользователя",
         "failedToFetchRooms": "Не удалось получить комнаты",
-        "failedToFetchUsers": "Не удалось получить пользователей"
+        "failedToFetchUsers": "Не удалось получить пользователей",
+        "failedToUnbanUser": "Не удалось разблокировать пользователя"
       },
       "help": {
         "adminAccess": {
@@ -47,9 +52,34 @@
         "dataRefreshed": "Данные обновлены",
         "messageDeleted": "Сообщение удалено",
         "roomDeleted": "Комната удалена",
-        "userDeleted": "Пользователь {{username}} удален"
+        "userBanned": "Пользователь {{username}} заблокирован",
+        "userDeleted": "Пользователь {{username}} удален",
+        "userUnbanned": "Пользователь {{username}} разблокирован"
       },
       "name": "Администрирование",
+      "profile": {
+        "actions": "Действия",
+        "activeRooms": "Активен в комнатах",
+        "back": "Назад",
+        "ban": "Заблокировать пользователя",
+        "banDetails": "Детали блокировки",
+        "banReasonPlaceholder": "Причина блокировки (необязательно)",
+        "banned": "Заблокирован",
+        "bannedOn": "Дата блокировки",
+        "confirmBan": "Заблокировать",
+        "delete": "Удалить пользователя",
+        "lastActive": "Последняя активность",
+        "loading": "Загрузка профиля...",
+        "messages": "Сообщения",
+        "noMessages": "Нет сообщений",
+        "noReason": "Причина не указана",
+        "notFound": "Пользователь не найден",
+        "reason": "Причина",
+        "recentMessages": "Недавние сообщения",
+        "room": "Комната",
+        "rooms": "Комнаты",
+        "unban": "Разблокировать пользователя"
+      },
       "room": {
         "messagesCount": "{{count}} сообщений",
         "noMessages": "Нет сообщений"
@@ -78,6 +108,7 @@
         "lastActive": "Последняя активность",
         "message": "Сообщение",
         "role": "Роль",
+        "status": "Статус",
         "time": "Время",
         "user": "Пользователь",
         "username": "Имя пользователя"
@@ -90,7 +121,9 @@
       },
       "title": "Админ",
       "user": {
+        "active": "Активен",
         "admin": "админ",
+        "banned": "Заблокирован",
         "user": "пользователь"
       }
     },
@@ -329,11 +362,11 @@
       },
       "name": "Чаты",
       "sidebar": {
-        "rooms": "Комнаты",
         "chats": "Чаты",
         "new": "новый",
         "online": "онлайн",
-        "private": "Приватный"
+        "private": "Приватный",
+        "rooms": "Комнаты"
       },
       "status": {
         "chatRequiresInternet": "Для чата требуется подключение к интернету",

--- a/src/lib/locales/zh-TW/translation.json
+++ b/src/lib/locales/zh-TW/translation.json
@@ -8,16 +8,21 @@
       },
       "description": "系統管理面板",
       "dialogs": {
+        "banDescription": "您確定要封鎖 {{username}} 嗎？他們將會被登出且無法存取服務。",
+        "banTitle": "封鎖使用者？",
         "deleteDescription": "您確定要刪除{{type}}「{{name}}」嗎？此動作無法復原。",
         "deleteTitle": "刪除{{type}}？"
       },
       "errors": {
+        "failedToBanUser": "封鎖使用者失敗",
         "failedToDeleteMessage": "無法刪除訊息",
         "failedToDeleteRoom": "無法刪除聊天室",
         "failedToDeleteUser": "無法刪除使用者",
         "failedToFetchMessages": "無法擷取訊息",
+        "failedToFetchProfile": "擷取使用者個人資料失敗",
         "failedToFetchRooms": "無法擷取聊天室",
-        "failedToFetchUsers": "無法擷取使用者"
+        "failedToFetchUsers": "無法擷取使用者",
+        "failedToUnbanUser": "解除封鎖使用者失敗"
       },
       "help": {
         "adminAccess": {
@@ -47,9 +52,34 @@
         "dataRefreshed": "資料已重新整理",
         "messageDeleted": "訊息已刪除",
         "roomDeleted": "聊天室已刪除",
-        "userDeleted": "使用者 {{username}} 已刪除"
+        "userBanned": "使用者 {{username}} 已被封鎖",
+        "userDeleted": "使用者 {{username}} 已刪除",
+        "userUnbanned": "使用者 {{username}} 已被解除封鎖"
       },
       "name": "管理員",
+      "profile": {
+        "actions": "動作",
+        "activeRooms": "在聊天室中活躍",
+        "back": "返回",
+        "ban": "封鎖使用者",
+        "banDetails": "封鎖詳情",
+        "banReasonPlaceholder": "封鎖原因（選填）",
+        "banned": "已封鎖",
+        "bannedOn": "封鎖於",
+        "confirmBan": "封鎖",
+        "delete": "刪除使用者",
+        "lastActive": "上次活躍",
+        "loading": "正在載入個人資料...",
+        "messages": "訊息",
+        "noMessages": "未找到訊息",
+        "noReason": "未提供原因",
+        "notFound": "未找到使用者",
+        "reason": "原因",
+        "recentMessages": "最近訊息",
+        "room": "聊天室",
+        "rooms": "聊天室",
+        "unban": "解除封鎖使用者"
+      },
       "room": {
         "messagesCount": "{{count}} 則訊息",
         "noMessages": "沒有訊息"
@@ -78,6 +108,7 @@
         "lastActive": "上次活動",
         "message": "訊息",
         "role": "角色",
+        "status": "狀態",
         "time": "時間",
         "user": "使用者",
         "username": "使用者名稱"
@@ -90,7 +121,9 @@
       },
       "title": "管理員",
       "user": {
+        "active": "啟用中",
         "admin": "管理員",
+        "banned": "已封鎖",
         "user": "使用者"
       }
     },
@@ -329,11 +362,11 @@
       },
       "name": "聊天",
       "sidebar": {
-        "rooms": "房間",
         "chats": "聊天",
         "new": "新",
         "online": "線上",
-        "private": "私人"
+        "private": "私人",
+        "rooms": "房間"
       },
       "status": {
         "chatRequiresInternet": "聊天需要網路連線。",


### PR DESCRIPTION
Sync and machine translate missing localization keys for the admin app.

This PR adds 31 missing localization keys to 9 non-English languages and machine translates all admin app strings to ensure full localization. It also adds `core` to `.gitignore` to prevent accidental commits of core dump files.

---
<a href="https://cursor.com/background-agent?bcId=bc-566ea225-0529-43c8-84b2-d1d2962a84a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-566ea225-0529-43c8-84b2-d1d2962a84a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

