### PR TITLE
Admin sidebar collapsible behavior

### DIFF
--- a/public/version.json
+++ b/public/version.json
@@ -1,8 +1,8 @@
 {
   "version": "10.3",
-  "buildNumber": "4127ec9",
-  "commitSha": "4127ec951a4705fa533387dc24c174e309a81edd",
-  "buildTime": "2025-12-13T08:14:50.256Z",
+  "buildNumber": "7a96aa6",
+  "commitSha": "7a96aa66a78b12e9aabe9d4f9127fc43afa20aa2",
+  "buildTime": "2025-12-15T14:08:08.988Z",
   "majorVersion": 10,
   "minorVersion": 3,
   "desktopVersion": "1.0.1"

--- a/src/apps/admin/components/AdminMenuBar.tsx
+++ b/src/apps/admin/components/AdminMenuBar.tsx
@@ -1,5 +1,6 @@
 import { MenuBar } from "@/components/layout/MenuBar";
 import {
+  MenubarCheckboxItem,
   MenubarContent,
   MenubarItem,
   MenubarMenu,
@@ -14,6 +15,8 @@ interface AdminMenuBarProps {
   onShowHelp: () => void;
   onShowAbout: () => void;
   onRefresh: () => void;
+  onToggleSidebar: () => void;
+  isSidebarVisible: boolean;
 }
 
 export function AdminMenuBar({
@@ -21,6 +24,8 @@ export function AdminMenuBar({
   onShowHelp,
   onShowAbout,
   onRefresh,
+  onToggleSidebar,
+  isSidebarVisible,
 }: AdminMenuBarProps) {
   const { t } = useTranslation();
   const currentTheme = useThemeStore((state) => state.current);
@@ -41,6 +46,24 @@ export function AdminMenuBar({
           <MenubarItem onClick={onClose} className="text-md h-6 px-3">
             {t("common.menu.close")}
           </MenubarItem>
+        </MenubarContent>
+      </MenubarMenu>
+
+      {/* View Menu */}
+      <MenubarMenu>
+        <MenubarTrigger className="text-md px-2 py-1 border-none focus-visible:ring-0">
+          {t("common.menu.view")}
+        </MenubarTrigger>
+        <MenubarContent align="start" sideOffset={1} className="px-0">
+          <MenubarCheckboxItem
+            checked={isSidebarVisible}
+            onCheckedChange={(checked) => {
+              if (checked !== isSidebarVisible) onToggleSidebar();
+            }}
+            className="text-md h-6 px-3"
+          >
+            {t("apps.admin.menu.showSidebar")}
+          </MenubarCheckboxItem>
         </MenubarContent>
       </MenubarMenu>
 

--- a/src/apps/admin/components/AdminSidebar.tsx
+++ b/src/apps/admin/components/AdminSidebar.tsx
@@ -27,6 +27,7 @@ interface AdminSidebarProps {
     totalRooms: number;
     totalMessages: number;
   };
+  isVisible: boolean;
 }
 
 export const AdminSidebar: React.FC<AdminSidebarProps> = ({
@@ -38,6 +39,7 @@ export const AdminSidebar: React.FC<AdminSidebarProps> = ({
   isRoomsExpanded,
   onToggleRoomsExpanded,
   stats,
+  isVisible,
 }) => {
   const { t } = useTranslation();
   const { play: playButtonClick } = useSound(Sounds.BUTTON_CLICK);
@@ -46,6 +48,10 @@ export const AdminSidebar: React.FC<AdminSidebarProps> = ({
   const isWindowsLegacyTheme = isXpTheme;
 
   const publicRooms = rooms.filter((r) => r.type !== "private");
+
+  if (!isVisible) {
+    return null;
+  }
 
   return (
     <div

--- a/src/lib/locales/de/translation.json
+++ b/src/lib/locales/de/translation.json
@@ -46,7 +46,8 @@
       "menu": {
         "aboutAdmin": "Über Admin",
         "adminHelp": "Admin-Hilfe",
-        "refreshData": "Daten aktualisieren"
+        "refreshData": "Daten aktualisieren",
+        "showSidebar": "Seitenleiste anzeigen"
       },
       "messages": {
         "dataRefreshed": "Daten aktualisiert",

--- a/src/lib/locales/en/translation.json
+++ b/src/lib/locales/en/translation.json
@@ -1905,6 +1905,7 @@
       "title": "Admin",
       "menu": {
         "refreshData": "Refresh Data",
+        "showSidebar": "Show Sidebar",
         "adminHelp": "Admin Help",
         "aboutAdmin": "About Admin"
       },

--- a/src/lib/locales/es/translation.json
+++ b/src/lib/locales/es/translation.json
@@ -46,7 +46,8 @@
       "menu": {
         "aboutAdmin": "Acerca de Admin",
         "adminHelp": "Ayuda de Admin",
-        "refreshData": "Actualizar datos"
+        "refreshData": "Actualizar datos",
+        "showSidebar": "Mostrar barra lateral"
       },
       "messages": {
         "dataRefreshed": "Datos actualizados",

--- a/src/lib/locales/fr/translation.json
+++ b/src/lib/locales/fr/translation.json
@@ -46,7 +46,8 @@
       "menu": {
         "aboutAdmin": "À propos d'Admin",
         "adminHelp": "Aide Admin",
-        "refreshData": "Actualiser les données"
+        "refreshData": "Actualiser les données",
+        "showSidebar": "Afficher la barre latérale"
       },
       "messages": {
         "dataRefreshed": "Données actualisées",

--- a/src/lib/locales/it/translation.json
+++ b/src/lib/locales/it/translation.json
@@ -46,7 +46,8 @@
       "menu": {
         "aboutAdmin": "Informazioni su Admin",
         "adminHelp": "Guida Admin",
-        "refreshData": "Aggiorna dati"
+        "refreshData": "Aggiorna dati",
+        "showSidebar": "Mostra barra laterale"
       },
       "messages": {
         "dataRefreshed": "Dati aggiornati",

--- a/src/lib/locales/ja/translation.json
+++ b/src/lib/locales/ja/translation.json
@@ -46,7 +46,8 @@
       "menu": {
         "aboutAdmin": "Adminについて",
         "adminHelp": "Adminヘルプ",
-        "refreshData": "データ更新"
+        "refreshData": "データ更新",
+        "showSidebar": "サイドバーを表示"
       },
       "messages": {
         "dataRefreshed": "データが更新されました",

--- a/src/lib/locales/ko/translation.json
+++ b/src/lib/locales/ko/translation.json
@@ -46,7 +46,8 @@
       "menu": {
         "aboutAdmin": "관리자 정보",
         "adminHelp": "관리자 도움말",
-        "refreshData": "데이터 새로 고침"
+        "refreshData": "데이터 새로 고침",
+        "showSidebar": "사이드바 표시"
       },
       "messages": {
         "dataRefreshed": "데이터 새로고침 완료",

--- a/src/lib/locales/pt/translation.json
+++ b/src/lib/locales/pt/translation.json
@@ -46,7 +46,8 @@
       "menu": {
         "aboutAdmin": "Sobre o Admin",
         "adminHelp": "Ajuda do Admin",
-        "refreshData": "Atualizar Dados"
+        "refreshData": "Atualizar Dados",
+        "showSidebar": "Mostrar Barra Lateral"
       },
       "messages": {
         "dataRefreshed": "Dados atualizados",

--- a/src/lib/locales/ru/translation.json
+++ b/src/lib/locales/ru/translation.json
@@ -46,7 +46,8 @@
       "menu": {
         "aboutAdmin": "Об администрировании",
         "adminHelp": "Справка по администрированию",
-        "refreshData": "Обновить данные"
+        "refreshData": "Обновить данные",
+        "showSidebar": "Показать боковую панель"
       },
       "messages": {
         "dataRefreshed": "Данные обновлены",

--- a/src/lib/locales/zh-TW/translation.json
+++ b/src/lib/locales/zh-TW/translation.json
@@ -46,7 +46,8 @@
       "menu": {
         "aboutAdmin": "關於管理員",
         "adminHelp": "管理員說明",
-        "refreshData": "重新整理資料"
+        "refreshData": "重新整理資料",
+        "showSidebar": "顯示側邊欄"
       },
       "messages": {
         "dataRefreshed": "資料已重新整理",


### PR DESCRIPTION
Make the Admin app sidebar collapsible, collapse by default on mobile, and add a "Show Sidebar" option to the View menu.

---
<a href="https://cursor.com/background-agent?bcId=bc-09bd9275-5577-47a7-bfd9-a1ef286ebdcb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-09bd9275-5577-47a7-bfd9-a1ef286ebdcb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

