### PR TITLE
Ipod view reset lyrics

### DIFF
--- a/src/apps/ipod/components/FullScreenPortal.tsx
+++ b/src/apps/ipod/components/FullScreenPortal.tsx
@@ -40,6 +40,7 @@ export function FullScreenPortal({
   fullScreenPlayerRef,
   isLoadingLyrics,
   isProcessingLyrics,
+  isLoadingFurigana,
 }: FullScreenPortalProps) {
   const { t } = useTranslation();
   const containerRef = useRef<HTMLDivElement>(null);
@@ -489,7 +490,7 @@ export function FullScreenPortal({
 
       {/* Activity Indicator */}
       <AnimatePresence>
-        {(isLoadingLyrics || isProcessingLyrics) && (
+        {(isLoadingLyrics || isProcessingLyrics || isLoadingFurigana) && (
           <motion.div
             className="absolute z-40 pointer-events-none"
             initial={{ opacity: 0, scale: 0.8 }}

--- a/src/apps/ipod/components/IpodAppComponent.tsx
+++ b/src/apps/ipod/components/IpodAppComponent.tsx
@@ -103,6 +103,7 @@ export function IpodAppComponent({
     refreshLyrics,
     setTrackLyricsSearch,
     clearTrackLyricsSearch,
+    furiganaRefreshNonce,
   } = useIpodStoreShallow((s) => ({
     theme: s.theme,
     lcdFilterOn: s.lcdFilterOn,
@@ -129,6 +130,7 @@ export function IpodAppComponent({
     refreshLyrics: s.refreshLyrics,
     setTrackLyricsSearch: s.setTrackLyricsSearch,
     clearTrackLyricsSearch: s.clearTrackLyricsSearch,
+    furiganaRefreshNonce: s.furiganaRefreshNonce,
   }));
 
   const lyricOffset = useIpodStore(
@@ -165,6 +167,7 @@ export function IpodAppComponent({
   const [isAddingTrack, setIsAddingTrack] = useState(false);
   const [isShareDialogOpen, setIsShareDialogOpen] = useState(false);
   const [isLyricsSearchDialogOpen, setIsLyricsSearchDialogOpen] = useState(false);
+  const [isLoadingFurigana, setIsLoadingFurigana] = useState(false);
 
   // Playback state
   const [elapsedTime, setElapsedTime] = useState(0);
@@ -1211,6 +1214,9 @@ export function IpodAppComponent({
               registerActivity={registerActivity}
               isFullScreen={isFullScreen}
               lyricsControls={fullScreenLyricsControls}
+              furiganaRefreshNonce={furiganaRefreshNonce}
+              isLoadingFurigana={isLoadingFurigana}
+              onFuriganaLoadingChange={setIsLoadingFurigana}
             />
 
             <IpodWheel
@@ -1266,6 +1272,7 @@ export function IpodAppComponent({
             fullScreenPlayerRef={fullScreenPlayerRef}
             isLoadingLyrics={fullScreenLyricsControls.isLoading}
             isProcessingLyrics={fullScreenLyricsControls.isTranslating}
+            isLoadingFurigana={isLoadingFurigana}
           >
             {({ controlsVisible }) => (
               <div className="flex flex-col w-full h-full">
@@ -1360,6 +1367,8 @@ export function IpodAppComponent({
                               }}
                               interactive={isIOSSafari ? false : isPlaying}
                               bottomPaddingClass="pb-[calc(max(env(safe-area-inset-bottom),1.5rem)+clamp(5rem,16dvh,12rem))]"
+                              furiganaRefreshNonce={furiganaRefreshNonce}
+                              onFuriganaLoadingChange={setIsLoadingFurigana}
                             />
                           </div>
                         )}

--- a/src/apps/ipod/components/IpodMenuBar.tsx
+++ b/src/apps/ipod/components/IpodMenuBar.tsx
@@ -14,6 +14,7 @@ import {
   MenubarRadioItem,
 } from "@/components/ui/menubar";
 import { useIpodStoreShallow } from "@/stores/helpers";
+import { useAppStore } from "@/stores/useAppStore";
 import { toast } from "sonner";
 import { generateAppShareUrl } from "@/utils/sharedUrl";
 import { LyricsAlignment, ChineseVariant, KoreanDisplay, JapaneseFurigana } from "@/types/lyrics";
@@ -96,6 +97,7 @@ export function IpodMenuBar({
     toggleLyrics,
     setLyricsAlignment,
     refreshLyrics,
+    resetLyrics,
     setChineseVariant,
     setKoreanDisplay,
     setJapaneseFurigana,
@@ -138,6 +140,7 @@ export function IpodMenuBar({
     toggleLyrics: s.toggleLyrics,
     setLyricsAlignment: s.setLyricsAlignment,
     refreshLyrics: s.refreshLyrics,
+    resetLyrics: s.resetLyrics,
     setChineseVariant: s.setChineseVariant,
     setKoreanDisplay: s.setKoreanDisplay,
     setJapaneseFurigana: s.setJapaneseFurigana,
@@ -148,6 +151,7 @@ export function IpodMenuBar({
 
   const appTheme = useThemeStore((state) => state.current);
   const isXpTheme = appTheme === "xp" || appTheme === "win98";
+  const debugMode = useAppStore((state) => state.debugMode);
 
   const handlePlayTrack = (index: number) => {
     setCurrentIndex(index);
@@ -447,6 +451,16 @@ export function IpodMenuBar({
           >
             {t("apps.ipod.menu.refreshLyrics")}
           </MenubarItem>
+
+          {debugMode && (
+            <MenubarItem
+              onClick={resetLyrics}
+              className="text-md h-6 px-3"
+              disabled={tracks.length === 0 || currentIndex === -1}
+            >
+              {t("apps.ipod.menu.resetLyrics")}
+            </MenubarItem>
+          )}
 
           <MenubarSeparator className="h-[2px] bg-black my-1" />
 

--- a/src/apps/ipod/components/IpodScreen.tsx
+++ b/src/apps/ipod/components/IpodScreen.tsx
@@ -66,6 +66,9 @@ export function IpodScreen({
   registerActivity,
   isFullScreen,
   lyricsControls,
+  furiganaRefreshNonce,
+  isLoadingFurigana,
+  onFuriganaLoadingChange,
 }: IpodScreenProps) {
   const { t } = useTranslation();
 
@@ -301,7 +304,7 @@ export function IpodScreen({
 
             {/* Activity Indicator */}
             <AnimatePresence>
-              {(lyricsControls.isLoading || lyricsControls.isTranslating) && (
+              {(lyricsControls.isLoading || lyricsControls.isTranslating || isLoadingFurigana) && (
                 <motion.div
                   className="absolute top-4 right-4 z-40 pointer-events-none"
                   initial={{ opacity: 0, scale: 0.8 }}
@@ -331,6 +334,8 @@ export function IpodScreen({
               koreanDisplay={koreanDisplay}
               japaneseFurigana={japaneseFurigana}
               isTranslating={lyricsControls.isTranslating}
+              furiganaRefreshNonce={furiganaRefreshNonce}
+              onFuriganaLoadingChange={onFuriganaLoadingChange}
               onAdjustOffset={(deltaMs) => {
                 adjustLyricOffset(deltaMs);
                 const newOffset = lyricOffset + deltaMs;

--- a/src/apps/ipod/types.ts
+++ b/src/apps/ipod/types.ts
@@ -66,6 +66,7 @@ export interface FullScreenPortalProps {
   // Lyrics loading state
   isLoadingLyrics?: boolean;
   isProcessingLyrics?: boolean;
+  isLoadingFurigana?: boolean;
 }
 
 // IpodScreen props
@@ -107,6 +108,12 @@ export interface IpodScreenProps {
   registerActivity: () => void;
   isFullScreen: boolean;
   lyricsControls: ReturnType<typeof useLyrics>;
+  /** Nonce to force refresh furigana */
+  furiganaRefreshNonce: number;
+  /** Whether furigana is currently loading */
+  isLoadingFurigana: boolean;
+  /** Callback when furigana loading state changes */
+  onFuriganaLoadingChange: (isLoading: boolean) => void;
 }
 
 // Battery manager interface for browsers that expose navigator.getBattery

--- a/src/lib/locales/en/translation.json
+++ b/src/lib/locales/en/translation.json
@@ -1256,6 +1256,7 @@
         "lyrics": "Lyrics",
         "showLyrics": "Show Lyrics",
         "refreshLyrics": "Search Lyrics",
+        "resetLyrics": "Reset Lyrics",
         "traditionalChinese": "繁體",
         "korean": "한글",
         "furigana": "振り仮名",

--- a/src/stores/useIpodStore.ts
+++ b/src/stores/useIpodStore.ts
@@ -50,6 +50,8 @@ interface IpodData {
   currentLyrics: { lines: LyricLine[] } | null;
   /** Incrementing nonce to force-refresh lyrics fetching */
   lyricsRefreshNonce: number;
+  /** Incrementing nonce to force-refresh furigana fetching */
+  furiganaRefreshNonce: number;
   isFullScreen: boolean;
   libraryState: LibraryState;
   lastKnownVersion: number;
@@ -152,6 +154,7 @@ const initialIpodData: IpodData = {
   lyricsTranslationLanguage: null,
   currentLyrics: null,
   lyricsRefreshNonce: 0,
+  furiganaRefreshNonce: 0,
   isFullScreen: false,
   libraryState: "uninitialized",
   lastKnownVersion: 0,
@@ -558,6 +561,7 @@ export const useIpodStore = create<IpodState>()(
           if (!currentTrack) {
             return {
               lyricsRefreshNonce: state.lyricsRefreshNonce + 1,
+              furiganaRefreshNonce: state.furiganaRefreshNonce + 1,
               currentLyrics: null,
             };
           }
@@ -572,6 +576,7 @@ export const useIpodStore = create<IpodState>()(
           return {
             tracks: updatedTracks,
             lyricsRefreshNonce: state.lyricsRefreshNonce + 1,
+            furiganaRefreshNonce: state.furiganaRefreshNonce + 1,
             currentLyrics: null,
           };
         }),

--- a/src/stores/useIpodStore.ts
+++ b/src/stores/useIpodStore.ts
@@ -180,6 +180,8 @@ export interface IpodState extends IpodData {
   toggleLyrics: () => void;
   /** Force refresh lyrics for current track */
   refreshLyrics: () => void;
+  /** Reset lyrics for current track - clears cache, force refetch, and redo furigana (debug mode) */
+  resetLyrics: () => void;
   /** Adjust the lyric offset (in ms) for the track at the given index. */
   adjustLyricOffset: (trackIndex: number, deltaMs: number) => void;
   /** Set lyrics alignment mode */
@@ -549,6 +551,30 @@ export const useIpodStore = create<IpodState>()(
           lyricsRefreshNonce: state.lyricsRefreshNonce + 1,
           currentLyrics: null,
         })),
+      resetLyrics: () =>
+        set((state) => {
+          // Clear the current track's lyricsSearch to force finding new lyrics
+          const currentTrack = state.tracks[state.currentIndex];
+          if (!currentTrack) {
+            return {
+              lyricsRefreshNonce: state.lyricsRefreshNonce + 1,
+              currentLyrics: null,
+            };
+          }
+          
+          // Update tracks to clear lyricsSearch for current track
+          const updatedTracks = state.tracks.map((track, index) =>
+            index === state.currentIndex
+              ? { ...track, lyricsSearch: undefined }
+              : track
+          );
+          
+          return {
+            tracks: updatedTracks,
+            lyricsRefreshNonce: state.lyricsRefreshNonce + 1,
+            currentLyrics: null,
+          };
+        }),
       adjustLyricOffset: (trackIndex, deltaMs) =>
         set((state) => {
           if (


### PR DESCRIPTION
Add a "Reset Lyrics" menu item to the iPod view menu, visible in debug mode, to force re-fetching and re-translating lyrics, including furigana.

---
<a href="https://cursor.com/background-agent?bcId=bc-8195d420-50d1-4235-b2c2-2a7b25c09130"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8195d420-50d1-4235-b2c2-2a7b25c09130"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

