### PR TITLE
Lyric line breaking inconsistency

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -937,9 +937,11 @@ ruby.lyrics-furigana {
 
 /* Word-level highlight container for karaoke-style lyrics animation */
 /* Uses inline-grid to stack dimmed/highlighted layers */
+/* white-space: pre ensures trailing spaces in word texts are preserved for consistent line breaking */
 .lyrics-word-highlight {
   display: inline-grid;
   vertical-align: baseline;
+  white-space: pre;
 }
 
 /* Layer positioning - both layers share the same grid cell (1/1) */


### PR DESCRIPTION
Ensure consistent lyric line breaking by using the same DOM structure for active and inactive lines with word timings.

The original issue caused "jank" because lyric lines would re-wrap when transitioning from inactive to active due to a change in their underlying DOM structure. Active lines used `display: inline-grid` for each word, while inactive lines were plain text. This PR introduces a `StaticWordRendering` component that renders inactive lines with word timings using the same `inline-grid` word wrappers, thus maintaining a consistent DOM structure and preventing line re-wrapping. Additionally, `white-space: pre` is added to the word highlight container to prevent whitespace collapsing, which is essential for accurate line breaking.

---
<a href="https://cursor.com/background-agent?bcId=bc-278d60d5-ecaf-464c-8324-f5c9d641362d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-278d60d5-ecaf-464c-8324-f5c9d641362d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

