### PR TITLE
Offline sw flash bug

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -18,7 +18,28 @@ primeReactResources();
 // CHUNK LOAD ERROR HANDLING - Reload when old assets 404 after deployment
 // ============================================================================
 window.addEventListener("vite:preloadError", (event) => {
-  console.warn("[ryOS] Chunk load failed, reloading for fresh assets...", event);
+  console.warn("[ryOS] Chunk load failed:", event);
+  
+  // Don't reload if offline - it won't help and will cause a flash loop
+  if (!navigator.onLine) {
+    console.warn("[ryOS] Skipping reload - device is offline");
+    return;
+  }
+  
+  // Use the same loop protection as index.html's stale bundle detection
+  const reloadKey = "ryos-stale-reload";
+  const lastReload = sessionStorage.getItem(reloadKey);
+  const now = Date.now();
+  
+  // If we reloaded in the last 10 seconds, don't reload again
+  if (lastReload && now - parseInt(lastReload, 10) < 10000) {
+    console.warn("[ryOS] Recently reloaded for stale bundle, skipping to prevent loop");
+    return;
+  }
+  
+  // Mark that we're reloading
+  sessionStorage.setItem(reloadKey, String(now));
+  console.log("[ryOS] Reloading for fresh assets...");
   window.location.reload();
 });
 


### PR DESCRIPTION
Add offline and loop protection to `vite:preloadError` handler to prevent infinite reloads when offline.

The app would constantly flash black and reload if loaded offline via a prefetched service worker and a lazy-loaded chunk was not in the cache. The `vite:preloadError` handler would trigger an immediate `window.location.reload()`, leading to an infinite loop as the missing chunk would cause the error again. This fix prevents reloads when offline and introduces a cooldown to break the loop.

---
<a href="https://cursor.com/background-agent?bcId=bc-7db9a24b-5215-4213-b323-3f6a79e2ab80"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7db9a24b-5215-4213-b323-3f6a79e2ab80"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

