### PR TITLE
Bun build errors

### DIFF
--- a/src/apps/ipod/components/FullScreenPortal.tsx
+++ b/src/apps/ipod/components/FullScreenPortal.tsx
@@ -7,7 +7,7 @@ import { useIpodStore } from "@/stores/useIpodStore";
 import { useOffline } from "@/hooks/useOffline";
 import { useTranslation } from "react-i18next";
 import { isMobileSafari } from "@/utils/device";
-import { JapaneseFurigana, LyricsFont } from "@/types/lyrics";
+import { LyricsFont } from "@/types/lyrics";
 import {
   TRANSLATION_LANGUAGES,
   SWIPE_THRESHOLD,
@@ -37,7 +37,7 @@ export function FullScreenPortal({
   onCycleLyricsFont,
   currentKoreanDisplay,
   onToggleKoreanDisplay,
-  currentJapaneseFurigana,
+  currentJapaneseFurigana: _currentJapaneseFurigana,
   onToggleJapaneseFurigana,
   fullScreenPlayerRef,
   isLoadingLyrics,

--- a/src/apps/ipod/components/IpodAppComponent.tsx
+++ b/src/apps/ipod/components/IpodAppComponent.tsx
@@ -28,7 +28,7 @@ import { toast } from "sonner";
 import { useLyrics } from "@/hooks/useLyrics";
 import { useLibraryUpdateChecker } from "../hooks/useLibraryUpdateChecker";
 import { useThemeStore } from "@/stores/useThemeStore";
-import { LyricsAlignment, KoreanDisplay, JapaneseFurigana } from "@/types/lyrics";
+import { LyricsAlignment, KoreanDisplay, JapaneseFurigana, LyricsFont } from "@/types/lyrics";
 import { track } from "@vercel/analytics";
 import { getTranslatedAppName } from "@/utils/i18n";
 import { IPOD_ANALYTICS } from "@/utils/analytics";
@@ -82,6 +82,7 @@ export function IpodAppComponent({
     lcdFilterOn,
     showLyrics,
     lyricsAlignment,
+    lyricsFont,
     chineseVariant,
     koreanDisplay,
     japaneseFurigana,
@@ -108,6 +109,7 @@ export function IpodAppComponent({
     lcdFilterOn: s.lcdFilterOn,
     showLyrics: s.showLyrics,
     lyricsAlignment: s.lyricsAlignment,
+    lyricsFont: s.lyricsFont,
     chineseVariant: s.chineseVariant,
     koreanDisplay: s.koreanDisplay,
     japaneseFurigana: s.japaneseFurigana,
@@ -1136,6 +1138,23 @@ export function IpodAppComponent({
     showStatus(next === JapaneseFurigana.On ? t("apps.ipod.status.furiganaOn") : t("apps.ipod.status.furiganaOff"));
   }, [showStatus, t]);
 
+  const cycleLyricsFont = useCallback(() => {
+    const store = useIpodStore.getState();
+    const curr = store.lyricsFont;
+    let next: LyricsFont;
+    if (curr === LyricsFont.Rounded) next = LyricsFont.SansSerif;
+    else if (curr === LyricsFont.SansSerif) next = LyricsFont.Serif;
+    else next = LyricsFont.Rounded;
+    store.setLyricsFont(next);
+    showStatus(
+      next === LyricsFont.Rounded
+        ? t("apps.ipod.status.fontRounded")
+        : next === LyricsFont.SansSerif
+        ? t("apps.ipod.status.fontSansSerif")
+        : t("apps.ipod.status.fontSerif")
+    );
+  }, [showStatus, t]);
+
   // Fullscreen change handler
   useEffect(() => {
     const handleFullscreenChange = () => {
@@ -1293,6 +1312,8 @@ export function IpodAppComponent({
             onSelectTranslation={handleSelectTranslation}
             currentAlignment={lyricsAlignment}
             onCycleAlignment={cycleAlignment}
+            currentLyricsFont={lyricsFont}
+            onCycleLyricsFont={cycleLyricsFont}
             currentKoreanDisplay={koreanDisplay}
             onToggleKoreanDisplay={toggleKorean}
             currentJapaneseFurigana={japaneseFurigana}


### PR DESCRIPTION
Fix `bun run build` errors by resolving unused imports/variables and passing missing props to `FullScreenPortal`.

The build was failing due to `FullScreenPortal` expecting `currentLyricsFont` and `onCycleLyricsFont` props that were not being passed, and also due to unused imports (`JapaneseFurigana`) and variables (`currentJapaneseFurigana`).

---
<a href="https://cursor.com/background-agent?bcId=bc-99eb1509-699b-46ba-865c-7165a6f85f66"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-99eb1509-699b-46ba-865c-7165a6f85f66"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

