### PR TITLE
Localization file generation

### DIFF
--- a/src/apps/ipod/components/IpodMenuBar.tsx
+++ b/src/apps/ipod/components/IpodMenuBar.tsx
@@ -51,16 +51,16 @@ export function IpodMenuBar({
 
   const translationLanguages = [
     { label: t("apps.ipod.translationLanguages.original"), code: null },
-    { label: "English", code: "en" },
-    { label: "中文", code: "zh-TW" },
-    { label: "日本語", code: "ja" },
-    { label: "한국어", code: "ko" },
-    { label: "Español", code: "es" },
-    { label: "Français", code: "fr" },
-    { label: "Deutsch", code: "de" },
-    { label: "Português", code: "pt" },
-    { label: "Italiano", code: "it" },
-    { label: "Русский", code: "ru" },
+    { label: t("apps.ipod.translationLanguages.english"), code: "en" },
+    { label: t("apps.ipod.translationLanguages.chinese"), code: "zh-TW" },
+    { label: t("apps.ipod.translationLanguages.japanese"), code: "ja" },
+    { label: t("apps.ipod.translationLanguages.korean"), code: "ko" },
+    { label: t("apps.ipod.translationLanguages.spanish"), code: "es" },
+    { label: t("apps.ipod.translationLanguages.french"), code: "fr" },
+    { label: t("apps.ipod.translationLanguages.german"), code: "de" },
+    { label: t("apps.ipod.translationLanguages.portuguese"), code: "pt" },
+    { label: t("apps.ipod.translationLanguages.italian"), code: "it" },
+    { label: t("apps.ipod.translationLanguages.russian"), code: "ru" },
   ];
   const {
     tracks,

--- a/src/apps/ipod/constants.ts
+++ b/src/apps/ipod/constants.ts
@@ -11,16 +11,16 @@ export interface TranslationLanguage {
 
 export const TRANSLATION_LANGUAGES: TranslationLanguage[] = [
   { labelKey: "apps.ipod.translationLanguages.original", code: null },
-  { label: "English", code: "en" },
-  { label: "中文", code: "zh-TW" },
-  { label: "日本語", code: "ja" },
-  { label: "한국어", code: "ko" },
-  { label: "Español", code: "es" },
-  { label: "Français", code: "fr" },
-  { label: "Deutsch", code: "de" },
-  { label: "Português", code: "pt" },
-  { label: "Italiano", code: "it" },
-  { label: "Русский", code: "ru" },
+  { labelKey: "apps.ipod.translationLanguages.english", code: "en" },
+  { labelKey: "apps.ipod.translationLanguages.chinese", code: "zh-TW" },
+  { labelKey: "apps.ipod.translationLanguages.japanese", code: "ja" },
+  { labelKey: "apps.ipod.translationLanguages.korean", code: "ko" },
+  { labelKey: "apps.ipod.translationLanguages.spanish", code: "es" },
+  { labelKey: "apps.ipod.translationLanguages.french", code: "fr" },
+  { labelKey: "apps.ipod.translationLanguages.german", code: "de" },
+  { labelKey: "apps.ipod.translationLanguages.portuguese", code: "pt" },
+  { labelKey: "apps.ipod.translationLanguages.italian", code: "it" },
+  { labelKey: "apps.ipod.translationLanguages.russian", code: "ru" },
 ];
 
 // Translation badge mappings

--- a/src/apps/karaoke/components/KaraokeMenuBar.tsx
+++ b/src/apps/karaoke/components/KaraokeMenuBar.tsx
@@ -131,16 +131,16 @@ export function KaraokeMenuBar({
 
   const translationLanguages = [
     { label: t("apps.ipod.translationLanguages.original"), code: null },
-    { label: "English", code: "en" },
-    { label: "中文", code: "zh-TW" },
-    { label: "日本語", code: "ja" },
-    { label: "한국어", code: "ko" },
-    { label: "Español", code: "es" },
-    { label: "Français", code: "fr" },
-    { label: "Deutsch", code: "de" },
-    { label: "Português", code: "pt" },
-    { label: "Italiano", code: "it" },
-    { label: "Русский", code: "ru" },
+    { label: t("apps.ipod.translationLanguages.english"), code: "en" },
+    { label: t("apps.ipod.translationLanguages.chinese"), code: "zh-TW" },
+    { label: t("apps.ipod.translationLanguages.japanese"), code: "ja" },
+    { label: t("apps.ipod.translationLanguages.korean"), code: "ko" },
+    { label: t("apps.ipod.translationLanguages.spanish"), code: "es" },
+    { label: t("apps.ipod.translationLanguages.french"), code: "fr" },
+    { label: t("apps.ipod.translationLanguages.german"), code: "de" },
+    { label: t("apps.ipod.translationLanguages.portuguese"), code: "pt" },
+    { label: t("apps.ipod.translationLanguages.italian"), code: "it" },
+    { label: t("apps.ipod.translationLanguages.russian"), code: "ru" },
   ];
 
   // Group tracks by artist

--- a/src/lib/locales/de/translation.json
+++ b/src/lib/locales/de/translation.json
@@ -1012,6 +1012,7 @@
     "ipod": {
       "ariaLabels": {
         "closeFullscreen": "Vollbild schließen",
+        "cycleLyricFont": "[TODO] Cycle lyric font",
         "cycleLyricLayout": "Liedtext-Layout wechseln",
         "nextTrack": "Nächster Titel",
         "playPause": "Wiedergabe/Pause",
@@ -1114,6 +1115,9 @@
         "controls": "Steuerung",
         "exportLibrary": "Mediathek exportieren...",
         "file": "Datei",
+        "fontRounded": "[TODO] Rounded",
+        "fontSansSerif": "[TODO] Sans Serif",
+        "fontSerif": "[TODO] Serif",
         "fullScreen": "Vollbild",
         "furigana": "振り仮名",
         "importLibrary": "Mediathek importieren...",
@@ -1163,6 +1167,9 @@
       "name": "iPod",
       "status": {
         "added": "♬ Hinzugefügt",
+        "fontRounded": "[TODO] Font: Rounded",
+        "fontSansSerif": "[TODO] Font: Sans Serif",
+        "fontSerif": "[TODO] Font: Serif",
         "furiganaOff": "Furigana Aus",
         "furiganaOn": "Furigana An",
         "hangulOn": "Hangul An",

--- a/src/lib/locales/es/translation.json
+++ b/src/lib/locales/es/translation.json
@@ -1012,6 +1012,7 @@
     "ipod": {
       "ariaLabels": {
         "closeFullscreen": "Cerrar pantalla completa",
+        "cycleLyricFont": "[TODO] Cycle lyric font",
         "cycleLyricLayout": "Alternar diseño de letra",
         "nextTrack": "Siguiente pista",
         "playPause": "Reproducir/Pausar",
@@ -1114,6 +1115,9 @@
         "controls": "Controles",
         "exportLibrary": "Exportar biblioteca...",
         "file": "Archivo",
+        "fontRounded": "[TODO] Rounded",
+        "fontSansSerif": "[TODO] Sans Serif",
+        "fontSerif": "[TODO] Serif",
         "fullScreen": "Pantalla completa",
         "furigana": "振り仮名",
         "importLibrary": "Importar biblioteca...",
@@ -1163,6 +1167,9 @@
       "name": "iPod",
       "status": {
         "added": "♬ Añadido",
+        "fontRounded": "[TODO] Font: Rounded",
+        "fontSansSerif": "[TODO] Font: Sans Serif",
+        "fontSerif": "[TODO] Font: Serif",
         "furiganaOff": "Furigana Desactivado",
         "furiganaOn": "Furigana Activado",
         "hangulOn": "Hangul Activado",

--- a/src/lib/locales/fr/translation.json
+++ b/src/lib/locales/fr/translation.json
@@ -1012,6 +1012,7 @@
     "ipod": {
       "ariaLabels": {
         "closeFullscreen": "Quitter le mode plein écran",
+        "cycleLyricFont": "[TODO] Cycle lyric font",
         "cycleLyricLayout": "Alterner la disposition des paroles",
         "nextTrack": "Piste suivante",
         "playPause": "Lecture/Pause",
@@ -1114,6 +1115,9 @@
         "controls": "Commandes",
         "exportLibrary": "Exporter la bibliothèque...",
         "file": "Fichier",
+        "fontRounded": "[TODO] Rounded",
+        "fontSansSerif": "[TODO] Sans Serif",
+        "fontSerif": "[TODO] Serif",
         "fullScreen": "Plein écran",
         "furigana": "振り仮名",
         "importLibrary": "Importer la bibliothèque...",
@@ -1163,6 +1167,9 @@
       "name": "iPod",
       "status": {
         "added": "♬ Ajouté",
+        "fontRounded": "[TODO] Font: Rounded",
+        "fontSansSerif": "[TODO] Font: Sans Serif",
+        "fontSerif": "[TODO] Font: Serif",
         "furiganaOff": "Furigana désactivé",
         "furiganaOn": "Furigana activé",
         "hangulOn": "Hangul activé",

--- a/src/lib/locales/it/translation.json
+++ b/src/lib/locales/it/translation.json
@@ -1012,6 +1012,7 @@
     "ipod": {
       "ariaLabels": {
         "closeFullscreen": "Chiudi schermo intero",
+        "cycleLyricFont": "[TODO] Cycle lyric font",
         "cycleLyricLayout": "Scorri layout testi",
         "nextTrack": "Traccia successiva",
         "playPause": "Riproduci/Pausa",
@@ -1114,6 +1115,9 @@
         "controls": "Controlli",
         "exportLibrary": "Esporta libreria...",
         "file": "File",
+        "fontRounded": "[TODO] Rounded",
+        "fontSansSerif": "[TODO] Sans Serif",
+        "fontSerif": "[TODO] Serif",
         "fullScreen": "Schermo intero",
         "furigana": "振り仮名",
         "importLibrary": "Importa libreria...",
@@ -1163,6 +1167,9 @@
       "name": "iPod",
       "status": {
         "added": "♬ Aggiunta",
+        "fontRounded": "[TODO] Font: Rounded",
+        "fontSansSerif": "[TODO] Font: Sans Serif",
+        "fontSerif": "[TODO] Font: Serif",
         "furiganaOff": "Furigana disattivato",
         "furiganaOn": "Furigana attivato",
         "hangulOn": "Hangul Attivo",

--- a/src/lib/locales/ko/translation.json
+++ b/src/lib/locales/ko/translation.json
@@ -1012,6 +1012,7 @@
     "ipod": {
       "ariaLabels": {
         "closeFullscreen": "전체 화면 닫기",
+        "cycleLyricFont": "[TODO] Cycle lyric font",
         "cycleLyricLayout": "가사 레이아웃 전환",
         "nextTrack": "다음 곡",
         "playPause": "재생/일시 정지",
@@ -1114,6 +1115,9 @@
         "controls": "컨트롤",
         "exportLibrary": "보관함 내보내기...",
         "file": "파일",
+        "fontRounded": "[TODO] Rounded",
+        "fontSansSerif": "[TODO] Sans Serif",
+        "fontSerif": "[TODO] Serif",
         "fullScreen": "전체 화면",
         "furigana": "振り仮名",
         "importLibrary": "보관함 가져오기...",
@@ -1163,6 +1167,9 @@
       "name": "iPod",
       "status": {
         "added": "♬ 추가됨",
+        "fontRounded": "[TODO] Font: Rounded",
+        "fontSansSerif": "[TODO] Font: Sans Serif",
+        "fontSerif": "[TODO] Font: Serif",
         "furiganaOff": "후리가나 끄기",
         "furiganaOn": "후리가나 켜기",
         "hangulOn": "한글 켜짐",

--- a/src/lib/locales/pt/translation.json
+++ b/src/lib/locales/pt/translation.json
@@ -1012,6 +1012,7 @@
     "ipod": {
       "ariaLabels": {
         "closeFullscreen": "Sair do modo tela cheia",
+        "cycleLyricFont": "[TODO] Cycle lyric font",
         "cycleLyricLayout": "Alternar layout da letra",
         "nextTrack": "Próxima faixa",
         "playPause": "Reproduzir/Pausar",
@@ -1114,6 +1115,9 @@
         "controls": "Controles",
         "exportLibrary": "Exportar Biblioteca...",
         "file": "Arquivo",
+        "fontRounded": "[TODO] Rounded",
+        "fontSansSerif": "[TODO] Sans Serif",
+        "fontSerif": "[TODO] Serif",
         "fullScreen": "Tela Cheia",
         "furigana": "振り仮名",
         "importLibrary": "Importar Biblioteca...",
@@ -1163,6 +1167,9 @@
       "name": "iPod",
       "status": {
         "added": "♬ Adicionada",
+        "fontRounded": "[TODO] Font: Rounded",
+        "fontSansSerif": "[TODO] Font: Sans Serif",
+        "fontSerif": "[TODO] Font: Serif",
         "furiganaOff": "Furigana Desativado",
         "furiganaOn": "Furigana Ativado",
         "hangulOn": "Hangul LIGADO",

--- a/src/lib/locales/ru/translation.json
+++ b/src/lib/locales/ru/translation.json
@@ -1012,6 +1012,7 @@
     "ipod": {
       "ariaLabels": {
         "closeFullscreen": "Закрыть полноэкранный режим",
+        "cycleLyricFont": "[TODO] Cycle lyric font",
         "cycleLyricLayout": "Переключить макет текста песни",
         "nextTrack": "Следующий трек",
         "playPause": "Воспроизвести/Пауза",
@@ -1114,6 +1115,9 @@
         "controls": "Управление",
         "exportLibrary": "Экспорт медиатеки...",
         "file": "Файл",
+        "fontRounded": "[TODO] Rounded",
+        "fontSansSerif": "[TODO] Sans Serif",
+        "fontSerif": "[TODO] Serif",
         "fullScreen": "На весь экран",
         "furigana": "振り仮名",
         "importLibrary": "Импорт медиатеки...",
@@ -1163,6 +1167,9 @@
       "name": "iPod",
       "status": {
         "added": "♬ Добавлено",
+        "fontRounded": "[TODO] Font: Rounded",
+        "fontSansSerif": "[TODO] Font: Sans Serif",
+        "fontSerif": "[TODO] Font: Serif",
         "furiganaOff": "Фуригана выкл.",
         "furiganaOn": "Фуригана вкл.",
         "hangulOn": "Хангыль вкл.",

--- a/src/lib/locales/zh-TW/translation.json
+++ b/src/lib/locales/zh-TW/translation.json
@@ -1012,6 +1012,7 @@
     "ipod": {
       "ariaLabels": {
         "closeFullscreen": "關閉全螢幕",
+        "cycleLyricFont": "[TODO] Cycle lyric font",
         "cycleLyricLayout": "切換歌詞佈局",
         "nextTrack": "下一首",
         "playPause": "播放/暫停",
@@ -1114,6 +1115,9 @@
         "controls": "控制",
         "exportLibrary": "輸出資料庫...",
         "file": "檔案",
+        "fontRounded": "[TODO] Rounded",
+        "fontSansSerif": "[TODO] Sans Serif",
+        "fontSerif": "[TODO] Serif",
         "fullScreen": "全螢幕",
         "furigana": "振り仮名",
         "importLibrary": "匯入資料庫...",
@@ -1163,6 +1167,9 @@
       "name": "iPod",
       "status": {
         "added": "♬ 已新增",
+        "fontRounded": "[TODO] Font: Rounded",
+        "fontSansSerif": "[TODO] Font: Sans Serif",
+        "fontSerif": "[TODO] Font: Serif",
         "furiganaOff": "振假名：關",
         "furiganaOn": "振假名：開",
         "hangulOn": "韓文開啟",


### PR DESCRIPTION
Replace hardcoded language labels in iPod and Karaoke apps with translation keys to enable full localization.

This PR updates the language selection dropdowns in the iPod and Karaoke menu bars, as well as the `TRANSLATION_LANGUAGES` constant, to use translation keys instead of hardcoded strings. It also adds 56 new translation keys across 8 language files, marked with `[TODO]` for future machine translation.

---
<a href="https://cursor.com/background-agent?bcId=bc-713a3006-dd19-4dd5-9ea6-e54a08b223a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-713a3006-dd19-4dd5-9ea6-e54a08b223a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

