### PR TITLE
Ipod player font options

### DIFF
--- a/src/apps/ipod/components/IpodAppComponent.tsx
+++ b/src/apps/ipod/components/IpodAppComponent.tsx
@@ -1304,6 +1304,19 @@ export function IpodAppComponent({
     );
   }, [showStatus, t]);
 
+  // Get CSS class name for current lyrics font
+  const lyricsFontClassName = useMemo(() => {
+    switch (lyricsFont) {
+      case LyricsFont.Serif:
+        return "font-lyrics-serif";
+      case LyricsFont.SansSerif:
+        return "font-lyrics-sans";
+      case LyricsFont.Rounded:
+      default:
+        return "font-lyrics-rounded";
+    }
+  }, [lyricsFont]);
+
   // Fullscreen change handler
   useEffect(() => {
     const handleFullscreenChange = () => {
@@ -1548,7 +1561,7 @@ export function IpodAppComponent({
                               chineseVariant={chineseVariant}
                               koreanDisplay={koreanDisplay}
                               japaneseFurigana={japaneseFurigana}
-                              fontClassName="font-lyrics-rounded"
+                              fontClassName={lyricsFontClassName}
                               onAdjustOffset={(delta) => {
                                 useIpodStore.getState().adjustLyricOffset(currentIndex, delta);
                                 const newOffset = (tracks[currentIndex]?.lyricOffset ?? 0) + delta;


### PR DESCRIPTION
Fix iPod app full screen player font options to dynamically apply selected fonts.

The `fontClassName` for `LyricsDisplay` was hardcoded to `"font-lyrics-rounded"`, preventing the full screen player from applying the user's selected font. This PR introduces a `lyricsFontClassName` computed value that derives the CSS class from the `lyricsFont` state, mirroring the correct implementation in the Karaoke app.

---
<a href="https://cursor.com/background-agent?bcId=bc-bab62695-a1b1-47e1-980c-61864d32dc1d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-bab62695-a1b1-47e1-980c-61864d32dc1d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

