### PR TITLE
Lyrics safe area padding

### DIFF
--- a/src/apps/ipod/components/IpodAppComponent.tsx
+++ b/src/apps/ipod/components/IpodAppComponent.tsx
@@ -1545,7 +1545,7 @@ export function IpodAppComponent({
                             style={{
                               transform: controlsVisible
                                 ? "translateY(-3rem)"
-                                : "translateY(clamp(1rem, 4dvh, 5rem))",
+                                : "translateY(clamp(3rem, 10dvh, 8rem))",
                               transition: "transform 200ms ease",
                             }}
                           >


### PR DESCRIPTION
Fixes iPod full screen lyrics bottom padding/safe area by updating the `translateY` value.

The previous `translateY(clamp(1rem, 4dvh, 5rem))` value for iPod full screen lyrics when controls were hidden was too small, causing lyrics to be cut off at the bottom. This PR updates it to `translateY(clamp(3rem, 10dvh, 8rem))` to match the Karaoke player, providing proper padding for the safe area.

---
<a href="https://cursor.com/background-agent?bcId=bc-4ad18519-48b6-4172-95ea-6562e3b516c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4ad18519-48b6-4172-95ea-6562e3b516c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

