### PR TITLE
Lyrics loading error handling

### DIFF
--- a/src/apps/ipod/components/IpodAppComponent.tsx
+++ b/src/apps/ipod/components/IpodAppComponent.tsx
@@ -1195,6 +1195,27 @@ export function IpodAppComponent({
     selectedMatch: selectedMatchForLyrics,
   });
 
+  // Show toast with Search action when lyrics loading fails with HTTP error
+  const prevLyricsErrorRef = useRef<string | undefined>(undefined);
+  useEffect(() => {
+    const error = fullScreenLyricsControls.error;
+    // Only show toast when error changes (not on initial mount or repeated errors)
+    if (error && error !== prevLyricsErrorRef.current) {
+      // Check if error is HTTP-related (status codes like 404, 500, etc.)
+      const isHttpError = /status\s+\d{3}/i.test(error);
+      if (isHttpError && currentTrack) {
+        toast.error(t("apps.ipod.dialogs.lyricsLoadError"), {
+          description: error,
+          action: {
+            label: t("apps.ipod.dialogs.lyricsLoadErrorAction"),
+            onClick: () => setIsLyricsSearchDialogOpen(true),
+          },
+        });
+      }
+    }
+    prevLyricsErrorRef.current = error;
+  }, [fullScreenLyricsControls.error, currentTrack, t]);
+
   // Fullscreen sync
   const prevFullScreenRef = useRef(isFullScreen);
 

--- a/src/apps/karaoke/components/KaraokeAppComponent.tsx
+++ b/src/apps/karaoke/components/KaraokeAppComponent.tsx
@@ -32,6 +32,7 @@ import {
   getTranslationBadge,
 } from "@/apps/ipod/constants";
 import { useLibraryUpdateChecker } from "@/apps/ipod/hooks/useLibraryUpdateChecker";
+import { toast } from "sonner";
 
 export function KaraokeAppComponent({
   isWindowOpen,
@@ -202,6 +203,27 @@ export function KaraokeAppComponent({
     searchQueryOverride: lyricsSearchOverride?.query,
     selectedMatch: selectedMatchForLyrics,
   });
+
+  // Show toast with Search action when lyrics loading fails with HTTP error
+  const prevLyricsErrorRef = useRef<string | undefined>(undefined);
+  useEffect(() => {
+    const error = lyricsControls.error;
+    // Only show toast when error changes (not on initial mount or repeated errors)
+    if (error && error !== prevLyricsErrorRef.current) {
+      // Check if error is HTTP-related (status codes like 404, 500, etc.)
+      const isHttpError = /status\s+\d{3}/i.test(error);
+      if (isHttpError && currentTrack) {
+        toast.error(t("apps.ipod.dialogs.lyricsLoadError"), {
+          description: error,
+          action: {
+            label: t("apps.ipod.dialogs.lyricsLoadErrorAction"),
+            onClick: () => setIsLyricsSearchDialogOpen(true),
+          },
+        });
+      }
+    }
+    prevLyricsErrorRef.current = error;
+  }, [lyricsControls.error, currentTrack, t]);
 
   // Translation languages with translated labels
   const translationLanguages = useMemo(

--- a/src/lib/locales/de/translation.json
+++ b/src/lib/locales/de/translation.json
@@ -1074,6 +1074,8 @@
         "lyricsSearchEmptyQuery": "Bitte geben Sie einen Suchbegriff ein",
         "lyricsSearchError": "Fehler beim Suchen nach Liedtext",
         "lyricsSearchInvalidResponse": "Ungültige Antwort vom Server",
+        "lyricsLoadError": "Liedtext konnte nicht geladen werden",
+        "lyricsLoadErrorAction": "Suchen",
         "lyricsSearchNoResults": "Keine Ergebnisse gefunden",
         "lyricsSearchPlaceholder": "Suchbegriff eingeben (z.B. Songtitel, Künstler)",
         "lyricsSearchReset": "Auf Auto zurücksetzen",

--- a/src/lib/locales/en/translation.json
+++ b/src/lib/locales/en/translation.json
@@ -1381,6 +1381,8 @@
         "lyricsSearchNoResults": "No results found",
         "lyricsSearchError": "Error searching for lyrics",
         "lyricsSearchInvalidResponse": "Invalid response from server",
+        "lyricsLoadError": "Failed to load lyrics",
+        "lyricsLoadErrorAction": "Search",
         "songSearchTitle": "Search Songs",
         "songSearchDescription": "Search song, artist, or paste YouTube URL",
         "songSearchPlaceholder": "Search or paste URL...",

--- a/src/lib/locales/es/translation.json
+++ b/src/lib/locales/es/translation.json
@@ -1074,6 +1074,8 @@
         "lyricsSearchEmptyQuery": "Por favor ingrese una consulta de búsqueda",
         "lyricsSearchError": "Error al buscar letras",
         "lyricsSearchInvalidResponse": "Respuesta inválida del servidor",
+        "lyricsLoadError": "Error al cargar letras",
+        "lyricsLoadErrorAction": "Buscar",
         "lyricsSearchNoResults": "No se encontraron resultados",
         "lyricsSearchPlaceholder": "Ingrese consulta de búsqueda (ej., título de canción, artista)",
         "lyricsSearchReset": "Restablecer a automático",

--- a/src/lib/locales/fr/translation.json
+++ b/src/lib/locales/fr/translation.json
@@ -1074,6 +1074,8 @@
         "lyricsSearchEmptyQuery": "Veuillez entrer une requête de recherche",
         "lyricsSearchError": "Erreur lors de la recherche de paroles",
         "lyricsSearchInvalidResponse": "Réponse invalide du serveur",
+        "lyricsLoadError": "Échec du chargement des paroles",
+        "lyricsLoadErrorAction": "Rechercher",
         "lyricsSearchNoResults": "Aucun résultat trouvé",
         "lyricsSearchPlaceholder": "Entrez une requête de recherche (ex. titre de chanson, artiste)",
         "lyricsSearchReset": "Réinitialiser à auto",

--- a/src/lib/locales/it/translation.json
+++ b/src/lib/locales/it/translation.json
@@ -1074,6 +1074,8 @@
         "lyricsSearchEmptyQuery": "Inserisci una query di ricerca",
         "lyricsSearchError": "Errore nella ricerca del testo",
         "lyricsSearchInvalidResponse": "Risposta non valida dal server",
+        "lyricsLoadError": "Impossibile caricare i testi",
+        "lyricsLoadErrorAction": "Cerca",
         "lyricsSearchNoResults": "Nessun risultato trovato",
         "lyricsSearchPlaceholder": "Inserisci query di ricerca (es. titolo canzone, artista)",
         "lyricsSearchReset": "Reimposta su auto",

--- a/src/lib/locales/ja/translation.json
+++ b/src/lib/locales/ja/translation.json
@@ -1074,6 +1074,8 @@
         "lyricsSearchEmptyQuery": "検索クエリを入力してください",
         "lyricsSearchError": "歌詞の検索中にエラーが発生しました",
         "lyricsSearchInvalidResponse": "サーバーからの無効な応答",
+        "lyricsLoadError": "歌詞の読み込みに失敗しました",
+        "lyricsLoadErrorAction": "検索",
         "lyricsSearchNoResults": "結果が見つかりません",
         "lyricsSearchPlaceholder": "検索クエリを入力（例：曲名、アーティスト）",
         "lyricsSearchReset": "自動にリセット",

--- a/src/lib/locales/ko/translation.json
+++ b/src/lib/locales/ko/translation.json
@@ -1074,6 +1074,8 @@
         "lyricsSearchEmptyQuery": "검색어를 입력하세요",
         "lyricsSearchError": "가사 검색 중 오류 발생",
         "lyricsSearchInvalidResponse": "서버에서 잘못된 응답",
+        "lyricsLoadError": "가사 로드 실패",
+        "lyricsLoadErrorAction": "검색",
         "lyricsSearchNoResults": "결과를 찾을 수 없습니다",
         "lyricsSearchPlaceholder": "검색어 입력 (예: 노래 제목, 아티스트)",
         "lyricsSearchReset": "자동으로 재설정",

--- a/src/lib/locales/pt/translation.json
+++ b/src/lib/locales/pt/translation.json
@@ -1074,6 +1074,8 @@
         "lyricsSearchEmptyQuery": "Por favor, digite uma consulta de pesquisa",
         "lyricsSearchError": "Erro ao pesquisar letras",
         "lyricsSearchInvalidResponse": "Resposta inválida do servidor",
+        "lyricsLoadError": "Falha ao carregar letras",
+        "lyricsLoadErrorAction": "Pesquisar",
         "lyricsSearchNoResults": "Nenhum resultado encontrado",
         "lyricsSearchPlaceholder": "Digite a consulta de pesquisa (ex: título da música, artista)",
         "lyricsSearchReset": "Redefinir para automático",

--- a/src/lib/locales/ru/translation.json
+++ b/src/lib/locales/ru/translation.json
@@ -1074,6 +1074,8 @@
         "lyricsSearchEmptyQuery": "Пожалуйста, введите поисковый запрос",
         "lyricsSearchError": "Ошибка при поиске текста",
         "lyricsSearchInvalidResponse": "Неверный ответ от сервера",
+        "lyricsLoadError": "Не удалось загрузить текст",
+        "lyricsLoadErrorAction": "Поиск",
         "lyricsSearchNoResults": "Результаты не найдены",
         "lyricsSearchPlaceholder": "Введите поисковый запрос (например, название песни, исполнитель)",
         "lyricsSearchReset": "Сбросить на автоматический",

--- a/src/lib/locales/zh-TW/translation.json
+++ b/src/lib/locales/zh-TW/translation.json
@@ -1074,6 +1074,8 @@
         "lyricsSearchEmptyQuery": "請輸入搜尋關鍵字",
         "lyricsSearchError": "搜尋歌詞時發生錯誤",
         "lyricsSearchInvalidResponse": "伺服器回應無效",
+        "lyricsLoadError": "無法載入歌詞",
+        "lyricsLoadErrorAction": "搜尋",
         "lyricsSearchNoResults": "找不到結果",
         "lyricsSearchPlaceholder": "輸入搜尋關鍵字（例如：歌曲名稱、歌手）",
         "lyricsSearchReset": "重設為自動",


### PR DESCRIPTION
Show a toast with a 'Search' action for HTTP errors during lyrics loading to enable manual search.

---
<a href="https://cursor.com/background-agent?bcId=bc-b802997d-314d-414f-8cab-0e348ecb21e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b802997d-314d-414f-8cab-0e348ecb21e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

