### PR TITLE
Font fallback configuration

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -406,7 +406,7 @@ button.piano-key.piano-key[class*="bg-[#ff33ff]"] {
 
   /* Sans-serif lyrics font utility (default OS typeface) */
   .font-lyrics-sans {
-    font-family: "Geneva-12", "Hiragino Sans", "Hiragino Kaku Gothic ProN",
+    font-family: "Geneva-12", "ArkPixel", "Hiragino Sans", "Hiragino Kaku Gothic ProN",
       "PingFang SC", "Microsoft YaHei", "Apple SD Gothic Neo", "Malgun Gothic",
       "Nanum Gothic", system-ui, -apple-system, sans-serif;
     font-weight: 700;


### PR DESCRIPTION
Add ArkPixel as a fallback font to non-macOS theme lyrics for improved CJK character rendering.

---
<a href="https://cursor.com/background-agent?bcId=bc-67451a8c-850d-46a7-87ca-5891fdd32bba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-67451a8c-850d-46a7-87ca-5891fdd32bba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

