### PR TITLE
Pinyin without tones

### DIFF
--- a/src/utils/romanization.tsx
+++ b/src/utils/romanization.tsx
@@ -124,8 +124,8 @@ export function renderChineseWithPinyin(text: string, keyPrefix: string = "cn"):
   // pinyin-pro gives wrong readings for traditional chars (e.g., 車 → jū instead of chē)
   const simplifiedText = traditionalToSimplified(text);
   
-  // Get pinyin with tone marks for each character (from simplified text)
-  const pinyinResult = pinyin(simplifiedText, { type: 'array', toneType: 'symbol' });
+  // Get pinyin without tone marks for each character (from simplified text)
+  const pinyinResult = pinyin(simplifiedText, { type: 'array', toneType: 'none' });
   const chars = [...text]; // Original characters for display
   
   if (chars.length === 0) {


### PR DESCRIPTION
Update Chinese pinyin configuration to not show tones.

---
<a href="https://cursor.com/background-agent?bcId=bc-fe5a4073-04f7-4b55-8d2b-ec835d7339dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-fe5a4073-04f7-4b55-8d2b-ec835d7339dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

