### PR TITLE
Song api lyrics type

### DIFF
--- a/api/song/index.ts
+++ b/api/song/index.ts
@@ -238,7 +238,7 @@ export default async function handler(req: Request) {
           const existing = await getSong(redis, songData.id, { includeMetadata: true });
 
           // Convert legacy lyricsSearch to lyricsSource
-          let lyricsSource: LyricsSource | undefined = songData.lyricsSource;
+          let lyricsSource: LyricsSource | undefined = songData.lyricsSource as LyricsSource | undefined;
           if (!lyricsSource && songData.lyricsSearch?.selection) {
             lyricsSource = songData.lyricsSearch.selection as LyricsSource;
           }


### PR DESCRIPTION
Add type assertion to `songData.lyricsSource` to resolve a TypeScript error where `albumId` was incorrectly inferred as optional.

---
<a href="https://cursor.com/background-agent?bcId=bc-7a55941c-3fdd-4b4e-b266-8e56d16fac6e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7a55941c-3fdd-4b4e-b266-8e56d16fac6e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

