### PR TITLE
Lyric padding on toolbar

### DIFF
--- a/src/apps/karaoke/components/KaraokeAppComponent.tsx
+++ b/src/apps/karaoke/components/KaraokeAppComponent.tsx
@@ -923,7 +923,7 @@ export function KaraokeAppComponent({
                           gap: "clamp(0.3rem, 2.5cqw, 1rem)",
                         }}
                         interactive={true}
-                        bottomPaddingClass={showControls || anyMenuOpen || !isPlaying ? "pb-22" : "pb-12"}
+                        bottomPaddingClass={showControls || anyMenuOpen || !isPlaying ? "pb-28" : "pb-12"}
                         furiganaMap={furiganaMap}
                         currentTimeMs={(elapsedTime + (currentTrack?.lyricOffset ?? 0) / 1000) * 1000}
                         onSeekToTime={seekToTime}


### PR DESCRIPTION
Increase bottom padding under lyrics in the karaoke app to prevent overlap with the toolbar on Safari iOS.

The previous `pb-22` (88px) was insufficient to clear the toolbar, which can be ~98px tall on iOS Safari when accounting for the `safe-area-inset-bottom`. This change updates the padding to `pb-28` (112px) when controls are shown, providing adequate clearance.

---
<a href="https://cursor.com/background-agent?bcId=bc-11016d49-0a35-4c15-8f3e-438379529ea9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-11016d49-0a35-4c15-8f3e-438379529ea9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

