### PR TITLE
Toolbar padding issue ios

### DIFF
--- a/src/apps/ipod/components/FullScreenPortal.tsx
+++ b/src/apps/ipod/components/FullScreenPortal.tsx
@@ -514,7 +514,7 @@ export function FullScreenPortal({
       <div 
         className="flex-shrink-0"
         style={{
-          height: "calc(max(env(safe-area-inset-bottom), 0.75rem) + 48px)",
+          height: "calc(env(safe-area-inset-bottom, 0px) + 48px)",
         }}
       />
 
@@ -522,7 +522,7 @@ export function FullScreenPortal({
       <div
         data-toolbar
         className={cn(
-          "fixed bottom-0 left-0 right-0 flex justify-center z-[10001] transition-opacity duration-200 pb-6",
+          "fixed bottom-0 left-0 right-0 flex justify-center z-[10001] transition-opacity duration-200",
           showControls || anyMenuOpen || !getActualPlayerState()
             ? "opacity-100 pointer-events-auto"
             : "opacity-0 pointer-events-none"

--- a/src/apps/ipod/components/FullScreenPortal.tsx
+++ b/src/apps/ipod/components/FullScreenPortal.tsx
@@ -529,7 +529,7 @@ export function FullScreenPortal({
         )}
         style={{
           paddingBottom:
-            "calc(env(safe-area-inset-bottom, 0px) + 0.75rem)",
+            "calc(env(safe-area-inset-bottom, 0px) + 1.5rem)",
         }}
         onClick={(e) => {
           e.stopPropagation();

--- a/src/apps/ipod/components/FullScreenPortal.tsx
+++ b/src/apps/ipod/components/FullScreenPortal.tsx
@@ -529,7 +529,7 @@ export function FullScreenPortal({
         )}
         style={{
           paddingBottom:
-            "calc(max(env(safe-area-inset-bottom), 0.75rem) + 1.5rem)",
+            "calc(env(safe-area-inset-bottom, 0px) + 0.75rem)",
         }}
         onClick={(e) => {
           e.stopPropagation();

--- a/src/apps/karaoke/components/KaraokeAppComponent.tsx
+++ b/src/apps/karaoke/components/KaraokeAppComponent.tsx
@@ -987,7 +987,7 @@ export function KaraokeAppComponent({
                 : "opacity-0 pointer-events-none"
             )}
             style={{
-              paddingBottom: "calc(max(env(safe-area-inset-bottom), 0.75rem) + 1.5rem)",
+              paddingBottom: "calc(env(safe-area-inset-bottom, 0px) + 0.75rem)",
             }}
             onClick={(e) => {
               e.stopPropagation();

--- a/src/apps/karaoke/components/KaraokeAppComponent.tsx
+++ b/src/apps/karaoke/components/KaraokeAppComponent.tsx
@@ -987,7 +987,7 @@ export function KaraokeAppComponent({
                 : "opacity-0 pointer-events-none"
             )}
             style={{
-              paddingBottom: "0.75rem",
+              paddingBottom: "1.5rem",
             }}
             onClick={(e) => {
               e.stopPropagation();

--- a/src/apps/karaoke/components/KaraokeAppComponent.tsx
+++ b/src/apps/karaoke/components/KaraokeAppComponent.tsx
@@ -987,7 +987,7 @@ export function KaraokeAppComponent({
                 : "opacity-0 pointer-events-none"
             )}
             style={{
-              paddingBottom: "calc(env(safe-area-inset-bottom, 0px) + 0.75rem)",
+              paddingBottom: "0.75rem",
             }}
             onClick={(e) => {
               e.stopPropagation();

--- a/src/apps/karaoke/components/KaraokeAppComponent.tsx
+++ b/src/apps/karaoke/components/KaraokeAppComponent.tsx
@@ -923,7 +923,7 @@ export function KaraokeAppComponent({
                           gap: "clamp(0.3rem, 2.5cqw, 1rem)",
                         }}
                         interactive={true}
-                        bottomPaddingClass={showControls || anyMenuOpen || !isPlaying ? "pb-28" : "pb-12"}
+                        bottomPaddingClass={showControls || anyMenuOpen || !isPlaying ? "pb-20" : "pb-12"}
                         furiganaMap={furiganaMap}
                         currentTimeMs={(elapsedTime + (currentTrack?.lyricOffset ?? 0) / 1000) * 1000}
                         onSeekToTime={seekToTime}


### PR DESCRIPTION
Reduce excessive padding under the toolbar in the karaoke app, especially on iOS.

The previous padding formula `calc(max(env(safe-area-inset-bottom), 0.75rem) + 1.5rem)` resulted in too much padding on iOS (e.g., ~58px) due to stacking safe area and fixed values. The new formula `calc(env(safe-area-inset-bottom, 0px) + 0.75rem)` provides more appropriate padding (e.g., ~46px on iOS).

---
<a href="https://cursor.com/background-agent?bcId=bc-0137fef9-d75f-449c-9b7c-4913b81d142a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0137fef9-d75f-449c-9b7c-4913b81d142a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

