### PR TITLE
Karaoke toolbar icon change

### DIFF
--- a/public/version.json
+++ b/public/version.json
@@ -1,8 +1,8 @@
 {
   "version": "10.3",
-  "buildNumber": "56ba767",
-  "commitSha": "56ba7677d1e08809c3ef6596e98bc993997b3b1d",
-  "buildTime": "2025-12-27T00:24:40.686Z",
+  "buildNumber": "4fe9f3b",
+  "commitSha": "4fe9f3b0c55d057bdc23c64948e7231d21ee53c9",
+  "buildTime": "2025-12-27T02:43:54.966Z",
   "majorVersion": 10,
   "minorVersion": 3,
   "desktopVersion": "1.0.1"

--- a/src/components/shared/FullscreenPlayerControls.tsx
+++ b/src/components/shared/FullscreenPlayerControls.tsx
@@ -1,16 +1,9 @@
-import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { cn } from "@/lib/utils";
 import type { LyricsAlignment, RomanizationSettings } from "@/types/lyrics";
 import { LyricsFont } from "@/types/lyrics";
 import { getTranslationBadge } from "@/apps/ipod/constants";
 import { Globe, Maximize2, X, Clock } from "lucide-react";
-import { useIpodStore } from "@/stores/useIpodStore";
-import {
-  lyricsHaveJapanese,
-  lyricsHaveKorean,
-  lyricsHaveChinese,
-} from "@/utils/languageDetection";
 import {
   DropdownMenu,
   DropdownMenuCheckboxItem,
@@ -107,18 +100,6 @@ export function FullscreenPlayerControls({
 
   const translationBadge = getTranslationBadge(currentTranslationCode);
 
-  // Get current lyrics from store to detect language
-  const currentLyrics = useIpodStore((s) => s.currentLyrics);
-
-  // Detect lyrics language for pronunciation button glyph
-  const lyricsLanguage = useMemo(() => {
-    if (!currentLyrics?.lines) return null;
-    if (lyricsHaveJapanese(currentLyrics.lines)) return "ja";
-    if (lyricsHaveKorean(currentLyrics.lines)) return "ko";
-    if (lyricsHaveChinese(currentLyrics.lines)) return "zh";
-    return null;
-  }, [currentLyrics]);
-
   // Get pronunciation button glyph based on active romanization setting
   const getPronunciationGlyph = () => {
     if (!romanization?.enabled) return "漢";
@@ -130,9 +111,6 @@ export function FullscreenPlayerControls({
     if (romanization.chinese) return "拼";
     return "漢";
   };
-
-  // No ruby needed - the glyph itself indicates the active mode
-  const isRomanizationActiveForLyrics = () => false;
 
   // Get font label based on current locale
   const getFontLabel = () => {
@@ -417,16 +395,7 @@ export function FullscreenPlayerControls({
                 )}
                 title={t("apps.ipod.menu.pronunciation")}
               >
-                {isRomanizationActiveForLyrics() ? (
-                  <ruby className={cn(smallIconSize, "ruby-align-center")} style={{ rubyPosition: "over" }}>
-                    {getPronunciationGlyph()}
-                    <rt style={{ fontSize: variant === "compact" ? "8px" : "9px", opacity: 0.7, paddingBottom: "1px", letterSpacing: "-0.5px", lineHeight: 1, maxHeight: "10px" }}>
-                      {getPronunciationRuby()}
-                    </rt>
-                  </ruby>
-                ) : (
-                  <span className={smallIconSize}>{getPronunciationGlyph()}</span>
-                )}
+                <span className={smallIconSize}>{getPronunciationGlyph()}</span>
               </button>
             </DropdownMenuTrigger>
             <DropdownMenuContent


### PR DESCRIPTION
Update karaoke toolbar pronunciation icon to "漢 han かん" for Japanese and Chinese lyrics.

---
<a href="https://cursor.com/background-agent?bcId=bc-9aab76ee-2188-4b40-9a12-e2eb4a537ebf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9aab76ee-2188-4b40-9a12-e2eb4a537ebf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

