### PR TITLE
Song lyric offset issue

### DIFF
--- a/api/song/_constants.ts
+++ b/api/song/_constants.ts
@@ -56,7 +56,7 @@ export const UpdateSongSchema = z.object({
   title: z.string().max(500).optional(),
   artist: z.string().max(500).optional(),
   album: z.string().max(500).optional(),
-  lyricOffset: z.number().min(-60000).max(60000).optional(),
+  lyricOffset: z.number().min(-300000).max(300000).optional(),
   lyricsSource: LyricsSourceSchema.optional(),
   // Options to clear cached data when lyrics source changes
   clearTranslations: z.boolean().optional(),


### PR DESCRIPTION
Increase `lyricOffset` validation range to allow larger offsets.

The previous validation limited `lyricOffset` to ±60 seconds, preventing updates for songs with larger desynchronization. This change extends the range to ±5 minutes (±300000ms) to accommodate more significant lyric timing adjustments.

---
<a href="https://cursor.com/background-agent?bcId=bc-2b244647-c6e4-49c0-aff2-5c6267ed7bf7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2b244647-c6e4-49c0-aff2-5c6267ed7bf7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

