### PR TITLE
Soramimi output english intact

### DIFF
--- a/api/song/_soramimi.ts
+++ b/api/song/_soramimi.ts
@@ -47,17 +47,40 @@ CRITICAL: KEEP ENGLISH WORDS INTACT
 - Format for English: just the word itself, no braces: "hello" → hello
 - Format for non-English: {original|chinese}
 
+IMPORTANT: Use MEANINGFUL Chinese words when possible!
+- Prefer real Chinese words/phrases over random phonetic characters
+- Choose characters that sound similar AND have related or interesting meanings
+- Use common, recognizable vocabulary
+
 COVERAGE RULES BY LANGUAGE:
-- Japanese kana: EACH kana = 1 Chinese char: {な|那}{に|你}{げ|給}
-- Japanese kanji: BY SYLLABLE COUNT of the reading, NOT by kanji count:
-  - 何(なに/nani) = 2 syllables → {何|那你}
-  - 人(ひと/hito) = 2 syllables → {人|嘻頭}
-  - 愛(あい/ai) = 2 syllables → {愛|啊一}
-  - 心(こころ/kokoro) = 3 syllables → {心|可可囉}
-  - 意(い/i) = 1 syllable → {意|一}
+- Japanese kana: EACH kana = 1 Chinese char (prefer meaningful chars):
+  {な|娜}{に|妮}{げ|給} or {な|那}{に|你}{げ|鬼}
+- Japanese kanji: BY SYLLABLE COUNT of the reading, use meaningful words:
+  - 愛(あい/ai) "love" = 2 syllables → {愛|哀} (哀 āi = sorrow, poetic!)
+  - 夢(ゆめ/yume) "dream" = 2 syllables → {夢|玉美} (玉美 = jade beauty)
+  - 雪(ゆき/yuki) "snow" = 2 syllables → {雪|遇奇} (遇奇 = encounter wonder)
+  - 君(きみ/kimi) "you" = 2 syllables → {君|奇蜜} (奇蜜 = sweet miracle)
+  - 心(こころ/kokoro) "heart" = 3 syllables → {心|叩叩肉} (knocking flesh/heart)
+  - 花(はな/hana) "flower" = 2 syllables → {花|哈娜} (哈娜 = a lovely name)
+  - 空(そら/sora) "sky" = 2 syllables → {空|搜啦}
+  - 歌(うた/uta) "song" = 2 syllables → {歌|嗚她} (cry for her)
 - Japanese っ (small tsu) or — (long dash): Use ～ for the pause: {っ|～} or {—|～}
 - English: KEEP AS-IS, no Chinese reading: "love" → love, "hello" → hello
-- Korean: BY SYLLABLE: {안|安}{녕|寧}
+- Korean: BY SYLLABLE, prefer meaningful matches:
+  - 안녕(annyeong) "peace/hello" → {안|安}{녕|寧} (安寧 = peace, SAME meaning!)
+  - 사랑(sarang) "love" → {사|撒}{랑|浪} (撒浪 = scatter waves)
+  - 감사(gamsa) "thanks" → {감|甘}{사|謝} (甘謝 = sweet thanks)
+  - 행복(haengbok) "happiness" → {행|幸}{복|福} (幸福 = happiness, SAME meaning!)
+  - 영원히(yeongwonhi) "forever" → {영|永}{원|遠}{히|嘻} (永遠 = forever!)
+  - 시간(sigan) "time" → {시|時}{간|間} (時間 = time, SAME meaning!)
+  - 세상(sesang) "world" → {세|世}{상|上} (世上 = world, SAME meaning!)
+  - 기억(gieok) "memory" → {기|奇}{억|憶} (奇憶 = wonder + remember)
+  - 마음(maeum) "heart" → {마|媽}{음|音} (媽音 = mother's sound)
+  - 노래(norae) "song" → {노|諾}{래|來} (諾來 = promise comes)
+  - 하늘(haneul) "sky" → {하|哈}{늘|呢}
+  - 눈물(nunmul) "tears" → {눈|嫩}{물|木}
+  - 미안(mian) "sorry" → {미|迷}{안|安}
+  - 좋아해(joahae) "I like you" → {좋|就}{아|啊}{해|嗨}
 
 Format: {original|chinese} for non-English, plain text for English
 
@@ -66,23 +89,36 @@ LINE RULES:
 - Keep exact same line numbers
 - For mixed lines: {日本語|讀音} English words {日本語|讀音}
 
-Japanese kana reference:
-あ啊 い一 う嗚 え欸 お喔 | か卡 き奇 く酷 け給 こ可
-さ撒 し西 す素 せ些 そ搜 | た他 ち吃 つ此 て貼 と頭
-な那 に你 ぬ奴 ね內 の諾 | は哈 ひ嘻 ふ夫 へ嘿 ほ火
+Japanese kana reference (basic phonetic mapping):
+あ阿 い衣 う屋 え欸 お喔 | か咖 き奇 く酷 け給 こ可
+さ撒 し詩 す蘇 せ些 そ搜 | た她 ち吃 つ此 て貼 と頭
+な娜 に妮 ぬ奴 ね內 の諾 | は哈 ひ嘻 ふ夫 へ嘿 ほ火
 ま媽 み咪 む木 め沒 も摸 | ら啦 り里 る嚕 れ咧 ろ囉
 わ哇 を喔 ん嗯 っ～ —～
 
+Korean syllable reference (common mappings):
+아阿 어喔 오喔 우屋 으嗯 이衣 | 가咖 거哥 고高 구姑 기奇
+나娜 너呢 노諾 누奴 니妮 | 다她 더德 도都 두肚 디低
+마媽 머摸 모摸 무木 미咪 | 바爸 버波 보寶 부夫 비比
+사撒 서些 소搜 수蘇 시詩 | 자渣 저這 조就 주朱 지知
+하哈 허賀 호火 후乎 히嘻 | 라啦 러樂 로囉 루嚕 리里
+
 Example:
 Input:
-1: 何があっても
+1: 夢を見ていた
 2: I love you
 3: 君をloveしてる
+4: 안녕하세요
+5: 사랑해 영원히
+6: 행복한 시간
 
 Output:
-1: {何|那你}{が|嘎}{あ|啊}{っ|～}{て|貼}{も|摸}
+1: {夢|玉美}{を|喔}{見|咪}{て|貼}{い|衣}{た|她}
 2: I love you
-3: {君|奇咪}{を|喔}love{し|西}{て|貼}{る|嚕}`;
+3: {君|奇蜜}{を|喔}love{し|詩}{て|貼}{る|嚕}
+4: {안|安}{녕|寧}{하|哈}{세|些}{요|喲}
+5: {사|撒}{랑|浪}{해|嗨} {영|永}{원|遠}{히|嘻}
+6: {행|幸}{복|福}{한|漢} {시|時}{간|間}`;
 
 // AI generation timeout (60 seconds)
 const AI_TIMEOUT_MS = 60000;


### PR DESCRIPTION
Modify soramimi generation to leave English lines and words intact.

---
<a href="https://cursor.com/background-agent?bcId=bc-ee7c4bb6-dfef-4f98-acbe-c5f74b5f7912"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ee7c4bb6-dfef-4f98-acbe-c5f74b5f7912"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

