### PR TITLE
Applet generation issue

### DIFF
--- a/api/_utils/aiPrompts.ts
+++ b/api/_utils/aiPrompts.ts
@@ -160,7 +160,7 @@ export const IE_HTML_GENERATION_INSTRUCTIONS = `
 - Output ONLY raw HTML – no markdown code blocks, no chat, no comments before or after
 - Begin with title comment: <!-- TITLE: Your Generated Page Title -->
 - Body content only – no doctype, html, head, or body tags (system wraps it in an iframe)
-- Single self-contained file: styles in <style> tag, scripts in <script> tag
+- Put HTML content FIRST, then <style> tags and <script> tags at the VERY END
 - Never import external files or scripts (except CDN libraries like Three.js if needed)
 
 ## Styling

--- a/api/_utils/aiPrompts.ts
+++ b/api/_utils/aiPrompts.ts
@@ -159,8 +159,8 @@ export const IE_HTML_GENERATION_INSTRUCTIONS = `
 ## Output Format
 - Output ONLY raw HTML – no markdown code blocks, no chat, no comments before or after
 - Begin with title comment: <!-- TITLE: Your Generated Page Title -->
-- Generate a COMPLETE standalone HTML page with full doctype, html, head, and body tags
-- Single self-contained file: all styles in <style> tag, all scripts in <script> tag
+- Body content only – no doctype, html, head, or body tags (system wraps it)
+- Single self-contained file: styles in <style> tag, scripts in <script> tag
 - Never import external files or scripts (except CDN libraries like Three.js if needed)
 
 ## Styling
@@ -171,8 +171,8 @@ export const IE_HTML_GENERATION_INSTRUCTIONS = `
 - Consider what technology and design tools would have been available in that era
 
 ## Layout
-- Design for the browser viewport – this is a full webpage, not a small applet window
-- Create immersive, era-appropriate layouts
+- Design for the browser viewport – this is a full webpage in an iframe, not a small applet window
+- Create immersive, era-appropriate layouts that fill the viewport
 - Include appropriate navigation, headers, and content sections for the era
 - Make it feel like an authentic website from that time period
 

--- a/api/_utils/aiPrompts.ts
+++ b/api/_utils/aiPrompts.ts
@@ -159,20 +159,28 @@ export const IE_HTML_GENERATION_INSTRUCTIONS = `
 ## Output Format
 - Output ONLY raw HTML – no markdown code blocks, no chat, no comments before or after
 - Begin with title comment: <!-- TITLE: Your Generated Page Title -->
-- Body content only – no doctype, html, head, or body tags (system wraps it)
+- Body content only – no doctype, html, head, or body tags (system wraps it in an iframe)
 - Single self-contained file: styles in <style> tag, scripts in <script> tag
 - Never import external files or scripts (except CDN libraries like Three.js if needed)
 
 ## Styling
-- Use inline <style> tags for all CSS
+- Tailwind CSS is available – use Tailwind classes for styling
+- Use <style> tag for complex animations or era-specific styles not available in Tailwind
+- DO NOT define global html, body, or :root styles – the wrapper handles these
+- DO NOT use @font-face – system fonts are pre-loaded
+- DO NOT use position: fixed or position: sticky – they get converted to relative
+- DO NOT use Tailwind fixed/sticky classes or top-*/bottom-*/left-*/right-* positioning classes
 - Match the visual design language of the target year and era
 - For past years: simulate period-appropriate design (typewriter, newspaper, early web aesthetics)
 - For future years: use clean, minimal design with simple colors, backdrop-blur, subtle animations
-- Consider what technology and design tools would have been available in that era
+
+## Available Fonts
+body: font-geneva | headings: font-neuebit font-bold | serif: font-mondwest | mono: font-monaco | blackletter: font-jacquard
 
 ## Layout
-- Design for the browser viewport – this is a full webpage in an iframe, not a small applet window
-- Create immersive, era-appropriate layouts that fill the viewport
+- Content renders in an iframe – design for the full viewport
+- Create immersive, era-appropriate layouts that fill the available space
+- Use relative/absolute positioning within containers, not fixed positioning
 - Include appropriate navigation, headers, and content sections for the era
 - Make it feel like an authentic website from that time period
 

--- a/api/_utils/aiPrompts.ts
+++ b/api/_utils/aiPrompts.ts
@@ -146,17 +146,58 @@ POST to "/api/applet-ai" with "Content-Type: application/json":
 - Use concise variable names: i, j for indices, e for event, el for element
 - Each output should run immediately with no external dependencies
 
-## Internet Explorer Time-Travel Output
-When generating HTML for Internet Explorer time-travel:
-1. Begin with title comment: <!-- TITLE: Your Generated Page Title -->
-2. No chat/comments before or after the HTML output
-
 ## Three.js Example
 <script type="module">
 import * as THREE from 'https://cdnjs.cloudflare.com/ajax/libs/three.js/0.174.0/three.module.min.js';
 // ... rest of code
 </script>
 </code_generation_instructions>
+`;
+
+export const IE_HTML_GENERATION_INSTRUCTIONS = `
+<ie_html_generation_instructions>
+## Output Format
+- Output ONLY raw HTML – no markdown code blocks, no chat, no comments before or after
+- Begin with title comment: <!-- TITLE: Your Generated Page Title -->
+- Generate a COMPLETE standalone HTML page with full doctype, html, head, and body tags
+- Single self-contained file: all styles in <style> tag, all scripts in <script> tag
+- Never import external files or scripts (except CDN libraries like Three.js if needed)
+
+## Styling
+- Use inline <style> tags for all CSS
+- Match the visual design language of the target year and era
+- For past years: simulate period-appropriate design (typewriter, newspaper, early web aesthetics)
+- For future years: use clean, minimal design with simple colors, backdrop-blur, subtle animations
+- Consider what technology and design tools would have been available in that era
+
+## Layout
+- Design for the browser viewport – this is a full webpage, not a small applet window
+- Create immersive, era-appropriate layouts
+- Include appropriate navigation, headers, and content sections for the era
+- Make it feel like an authentic website from that time period
+
+## Content
+- Reimagine the website content for the target year
+- Consider historical events, cultural context, and technological capabilities
+- For past years: what would this company/site have been doing then?
+- For future years: speculate on plausible evolution of the brand/product
+
+## Images
+- Use provided image URLs when available
+- Use emojis or simple SVG graphics as visual elements
+- DO NOT use imgur, placeholders, or base64 data URIs
+
+## Code Style
+- Keep code simple and self-contained
+- Each output should render immediately with no external dependencies
+- Use concise variable names: i, j for indices, e for event, el for element
+
+## Three.js Example (if needed for 3D elements)
+<script type="module">
+import * as THREE from 'https://cdnjs.cloudflare.com/ajax/libs/three.js/0.174.0/three.module.min.js';
+// ... rest of code
+</script>
+</ie_html_generation_instructions>
 `;
 
 export const CHAT_INSTRUCTIONS = `

--- a/api/ie-generate.ts
+++ b/api/ie-generate.ts
@@ -21,7 +21,7 @@ import { normalizeUrlForCacheKey } from "./_utils/url.js";
 import {
   CORE_PRIORITY_INSTRUCTIONS,
   RYO_PERSONA_INSTRUCTIONS,
-  CODE_GENERATION_INSTRUCTIONS,
+  IE_HTML_GENERATION_INSTRUCTIONS,
   } from "./_utils/aiPrompts.js";
 import { SUPPORTED_AI_MODELS } from "../src/types/aiModels.js";
 
@@ -85,7 +85,7 @@ export const config = { runtime: "edge" };
 // Static portion of the system prompt shared across requests. This string is
 // passed via the `system` option to enable prompt caching by the model
 // provider.
-const STATIC_SYSTEM_PROMPT = `${CORE_PRIORITY_INSTRUCTIONS}\n\nThe user is in ryOS Internet Explorer asking to time travel with website context and a specific year. You are Ryo, a visionary designer specialized in turning present websites into past and futuristic coherent versions in story and design.\n\nGenerate content for the URL path and year provided, original site content, and use provided HTML as template if available.\n\n${CODE_GENERATION_INSTRUCTIONS}`;
+const STATIC_SYSTEM_PROMPT = `${CORE_PRIORITY_INSTRUCTIONS}\n\nThe user is in ryOS Internet Explorer asking to time travel with website context and a specific year. You are Ryo, a visionary designer specialized in turning present websites into past and futuristic coherent versions in story and design.\n\nGenerate content for the URL path and year provided, original site content, and use provided HTML as template if available.\n\n${IE_HTML_GENERATION_INSTRUCTIONS}`;
 
 // Function to generate the dynamic portion of the system prompt. This portion
 // depends on the requested year and URL and will be sent as a regular system


### PR DESCRIPTION
Separate AI instructions for IE HTML generation to prevent applet code output.

The `ie-generate` endpoint was incorrectly using `CODE_GENERATION_INSTRUCTIONS`, which are tailored for generating applet-like content within the Chat app. This led to incomplete HTML output (e.g., missing doctype, html, head, body tags) when full, standalone HTML pages were expected for Internet Explorer time-travel. A new, dedicated instruction set ensures proper full HTML generation.

---
<a href="https://cursor.com/background-agent?bcId=bc-9cfc2f1c-ecc7-4af5-bb78-a6ff4d680d93"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9cfc2f1c-ecc7-4af5-bb78-a6ff4d680d93"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

