### PR TITLE
Cover flow button text

### DIFF
--- a/src/apps/ipod/components/CoverFlow.tsx
+++ b/src/apps/ipod/components/CoverFlow.tsx
@@ -752,8 +752,8 @@ export const CoverFlow = forwardRef<CoverFlowRef, CoverFlowProps>(function Cover
                 ipodMode ? "p-1 bg-white/10" : "p-3"
               }`}
               style={{
-                width: ipodMode ? "18px" : "clamp(32px, 8cqmin, 48px)",
-                height: ipodMode ? "18px" : "clamp(32px, 8cqmin, 48px)",
+                width: ipodMode ? "18px" : "clamp(36px, 8cqmin, 48px)",
+                height: ipodMode ? "18px" : "clamp(36px, 8cqmin, 48px)",
                 ...(!ipodMode && isMacTheme ? {
                   background: "linear-gradient(to bottom, rgba(50, 50, 50, 0.7), rgba(25, 25, 25, 0.7))",
                   boxShadow: "0 2px 4px rgba(0, 0, 0, 0.3), inset 0 1px 0 rgba(255, 255, 255, 0.1)",
@@ -803,8 +803,8 @@ export const CoverFlow = forwardRef<CoverFlowRef, CoverFlowProps>(function Cover
                 !ipodMode ? (showCD ? "text-white" : "text-white/80 hover:text-white") : ""
               }`}
               style={{
-                width: ipodMode ? "18px" : "clamp(32px, 8cqmin, 48px)",
-                height: ipodMode ? "18px" : "clamp(32px, 8cqmin, 48px)",
+                width: ipodMode ? "18px" : "clamp(36px, 8cqmin, 48px)",
+                height: ipodMode ? "18px" : "clamp(36px, 8cqmin, 48px)",
                 ...(!ipodMode && isMacTheme ? {
                   background: showCD 
                     ? "linear-gradient(to bottom, rgba(70, 70, 70, 0.8), rgba(40, 40, 40, 0.8))"


### PR DESCRIPTION
Increase the minimum size of Play and CD buttons in Cover Flow to improve visibility in non-iPod configurations.

---
<a href="https://cursor.com/background-agent?bcId=bc-9a4094b6-e756-4436-865a-150e7b536697"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9a4094b6-e756-4436-865a-150e7b536697"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

