### PR TITLE
Ryos terminal vim command

### DIFF
--- a/docs/apps-terminal.md
+++ b/docs/apps-terminal.md
@@ -27,6 +27,7 @@ To launch the Terminal app, locate its icon in the Dock or through the Applicati
 *   **Getting Help:** Type `help` to view a list of available commands and their basic usage.
 *   **Using the AI Assistant:** Initiate a query or task for the AI assistant through the `ai <your_query>` command.
 *   **Editing Files:** Open a file in the graphical TextEdit app using `edit <filename>` or launch the in-terminal Vim-style editor with `vim <filename>`.
+    *   In Vim: `:w` to save, `:wq` to save & quit, `:q` warns on unsaved changes, `:q!` force-quits without saving.
 *   **Clearing the Screen:** Use the `clear` command to wipe the terminal screen clean.
 
 ### Tips & Shortcuts

--- a/src/apps/terminal/components/VimEditor.tsx
+++ b/src/apps/terminal/components/VimEditor.tsx
@@ -7,6 +7,8 @@ interface VimEditorProps {
   vimCursorLine: number;
   vimCursorColumn: number;
   vimMode: VimState["mode"];
+  isDirty?: boolean;
+  isNewFile?: boolean;
 }
 
 export function VimEditor({
@@ -15,6 +17,8 @@ export function VimEditor({
   vimCursorLine,
   vimCursorColumn,
   vimMode,
+  isDirty = false,
+  isNewFile = false,
 }: VimEditorProps) {
   const lines = file.content.split("\n");
   const maxVisibleLines = 20; // Show up to 20 lines at a time
@@ -79,7 +83,13 @@ export function VimEditor({
             : "COMMAND"}
         </div>
         <div className="flex-1 bg-white/10 px-2 py-1 flex items-center justify-between">
-          <span className="flex-1 mx-2">[{file.name}]</span>
+          <span className="flex-1 mx-2">
+            [{file.name}]
+            <span className="ml-2 text-gray-200 text-xs">
+              {isNewFile ? "[New]" : ""}
+              {isDirty ? " [+]" : ""}
+            </span>
+          </span>
           <span>{percentage}%</span>
           <span className="ml-4 mr-2">
             {vimCursorLine + 1}:{vimCursorColumn + 1}

--- a/src/stores/useTerminalStore.ts
+++ b/src/stores/useTerminalStore.ts
@@ -25,6 +25,8 @@ interface TerminalStoreState {
   setIsInVimMode: (isInVimMode: boolean) => void;
   vimFile: { name: string; content: string } | null;
   setVimFile: (file: { name: string; content: string } | null) => void;
+  vimFilePath: string | null;
+  setVimFilePath: (path: string | null) => void;
   vimPosition: number;
   setVimPosition: (position: number | ((prev: number) => number)) => void;
   vimCursorLine: number;
@@ -35,6 +37,12 @@ interface TerminalStoreState {
   setVimMode: (mode: "normal" | "command" | "insert") => void;
   vimClipboard: string;
   setVimClipboard: (content: string) => void;
+  vimOriginalContent: string;
+  setVimOriginalContent: (content: string) => void;
+  vimIsDirty: boolean;
+  setVimIsDirty: (dirty: boolean) => void;
+  vimIsNewFile: boolean;
+  setVimIsNewFile: (isNew: boolean) => void;
 }
 
 const STORE_VERSION = 1;
@@ -76,6 +84,8 @@ export const useTerminalStore = create<TerminalStoreState>()(
       setIsInVimMode: (isInVimMode) => set({ isInVimMode }),
       vimFile: null,
       setVimFile: (file) => set({ vimFile: file }),
+      vimFilePath: null,
+      setVimFilePath: (path) => set({ vimFilePath: path }),
       vimPosition: 0,
       setVimPosition: (position) => 
         set((state) => ({
@@ -95,6 +105,12 @@ export const useTerminalStore = create<TerminalStoreState>()(
       setVimMode: (mode) => set({ vimMode: mode }),
       vimClipboard: "",
       setVimClipboard: (content) => set({ vimClipboard: content }),
+      vimOriginalContent: "",
+      setVimOriginalContent: (content) => set({ vimOriginalContent: content }),
+      vimIsDirty: false,
+      setVimIsDirty: (dirty) => set({ vimIsDirty: dirty }),
+      vimIsNewFile: false,
+      setVimIsNewFile: (isNew) => set({ vimIsNewFile: isNew }),
     }),
     {
       name: STORE_NAME,


### PR DESCRIPTION
Complete the implementation of the `vim` command in the terminal to support robust file handling, saving, and quitting.

The previous `vim` implementation was rudimentary, lacking core functionalities like proper file path resolution, content loading from persistent storage (IndexedDB), dirty state tracking, and the ability to save or quit files using standard Vim commands (`:w`, `:wq`, `:q`, `:q!`). This PR addresses these gaps, making the `vim` command a functional in-terminal editor.

---
<a href="https://cursor.com/background-agent?bcId=bc-28ac2176-71e4-414f-a2b8-e7e32f8e2219"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-28ac2176-71e4-414f-a2b8-e7e32f8e2219"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

