### PR TITLE
Help dialog styling and cleanup

### DIFF
--- a/src/apps/control-panels/index.ts
+++ b/src/apps/control-panels/index.ts
@@ -26,11 +26,6 @@ export const helpItems = [
     description: "Export or restore all settings and files",
   },
   {
-    icon: "🌐",
-    title: "Language",
-    description: "Select your preferred language for ryOS interface",
-  },
-  {
     icon: "⚙️",
     title: "System",
     description: "Reset preferences or format the virtual file system",

--- a/src/components/dialogs/HelpDialog.tsx
+++ b/src/components/dialogs/HelpDialog.tsx
@@ -126,7 +126,7 @@ export function HelpDialog({
         </p>
         {isMacTheme ? (
           <button
-            className="aqua-button primary text-[12px] px-3 py-1"
+            className="aqua-button secondary text-[12px] px-3 py-1"
             onClick={handleViewDocs}
           >
             {t("common.dialog.viewDocs")}


### PR DESCRIPTION
Change Help Dialog's "View Docs" button to non-primary and remove duplicate untranslated "System" item from Control Panels help.

The "View Docs" button was `primary` (blue) and is now a standard button. The Control Panels help items had a mismatch between the number of items and available translation keys, causing an untranslated "System" entry; removing the "Language" item resolves this.

---
<a href="https://cursor.com/background-agent?bcId=bc-c7db00f4-dedd-4f5c-8ae3-dfad87d52624"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c7db00f4-dedd-4f5c-8ae3-dfad87d52624"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

