### PR TITLE
Mobile lyric tap bug

### DIFF
--- a/src/components/layout/WindowFrame.tsx
+++ b/src/components/layout/WindowFrame.tsx
@@ -189,10 +189,14 @@ export function WindowFrame({
   // titlebar for real mouse pointers (trackpad/mouse), not touch pointers.
   const handleNoTitlebarPointerHover = useCallback(
     (e: React.PointerEvent) => {
+      // On mobile, disable hover-driven titlebar reveal entirely.
+      // Mobile browsers can synthesize mouse/pointer move events during/after taps,
+      // which would otherwise keep retriggering the auto-hide timer.
+      if (isMobile) return;
       if (e.pointerType !== "mouse") return;
       showTitlebarWithAutoHide();
     },
-    [showTitlebarWithAutoHide]
+    [showTitlebarWithAutoHide, isMobile]
   );
 
   // Cleanup titlebar hide timeout
@@ -1135,12 +1139,12 @@ export function WindowFrame({
             ...(!isXpTheme ? getSwipeStyle() : undefined),
           }}
           onPointerEnter={
-            isNoTitlebar && !disableTitlebarAutoHide
+            isNoTitlebar && !disableTitlebarAutoHide && !isMobile
               ? handleNoTitlebarPointerHover
               : undefined
           }
           onPointerMove={
-            isNoTitlebar && !disableTitlebarAutoHide
+            isNoTitlebar && !disableTitlebarAutoHide && !isMobile
               ? handleNoTitlebarPointerHover
               : undefined
           }


### PR DESCRIPTION
Ignore touch-emulated mouse events to prevent the titlebar from repeatedly showing on mobile.

On mobile, tapping a lyric line in the karaoke app could generate touch-emulated mouse events, which would repeatedly trigger the `onMouseMove` handler in `WindowFrame.tsx` and cause the titlebar to reappear even without actual user interaction. This change adds a check to ignore mouse events that originated from touch.

---
<a href="https://cursor.com/background-agent?bcId=bc-5343e069-37c7-4f19-91fc-26531082ad54"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5343e069-37c7-4f19-91fc-26531082ad54"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

