### PR TITLE
Window open sound playback

### DIFF
--- a/src/components/layout/WindowFrame.tsx
+++ b/src/components/layout/WindowFrame.tsx
@@ -230,9 +230,7 @@ export function WindowFrame({
   });
 
   useEffect(() => {
-    const shouldPlaySound = !skipInitialSound && !isRestoredFromStorage && hasUserInteractedYet();
-    console.log(`[WindowFrame] Window open sound check - skipInitialSound: ${skipInitialSound}, isRestoredFromStorage: ${isRestoredFromStorage}, hasUserInteracted: ${hasUserInteractedYet()}, shouldPlaySound: ${shouldPlaySound}`);
-    if (shouldPlaySound) {
+    if (!skipInitialSound && !isRestoredFromStorage && hasUserInteractedYet()) {
       playWindowOpen();
     }
     // Remove initial mount state after animation

--- a/src/components/layout/WindowFrame.tsx
+++ b/src/components/layout/WindowFrame.tsx
@@ -1,6 +1,6 @@
 import { useWindowManager } from "@/hooks/useWindowManager";
 import { ResizeType } from "@/types/types";
-import { useSound, Sounds } from "@/hooks/useSound";
+import { useSound, Sounds, hasUserInteractedYet } from "@/hooks/useSound";
 import { useVibration } from "@/hooks/useVibration";
 import { useWindowInsets } from "@/hooks/useWindowInsets";
 import { useEffect, useState, useCallback, useRef, useMemo } from "react";
@@ -121,6 +121,9 @@ export function WindowFrame({
   
   // Check if this instance is minimized
   const isMinimized = instanceId ? instances[instanceId]?.isMinimized ?? false : false;
+  const isRestoredFromStorage = instanceId
+    ? instances[instanceId]?.restoredFromStorage ?? false
+    : false;
   const { play: playWindowOpen } = useSound(Sounds.WINDOW_OPEN);
   const { play: playWindowClose } = useSound(Sounds.WINDOW_CLOSE);
   // For green button zoom (maximize/restore window size)
@@ -227,13 +230,13 @@ export function WindowFrame({
   });
 
   useEffect(() => {
-    if (!skipInitialSound) {
+    if (!skipInitialSound && !isRestoredFromStorage && hasUserInteractedYet()) {
       playWindowOpen();
     }
     // Remove initial mount state after animation
     const timer = setTimeout(() => setIsInitialMount(false), 200);
     return () => clearTimeout(timer);
-  }, []); // Play sound when component mounts
+  }, [skipInitialSound, isRestoredFromStorage, playWindowOpen]); // Play sound only on user-triggered opens
 
   // Sync window title to the app store for the dock context menu
   useEffect(() => {

--- a/src/components/layout/WindowFrame.tsx
+++ b/src/components/layout/WindowFrame.tsx
@@ -230,7 +230,9 @@ export function WindowFrame({
   });
 
   useEffect(() => {
-    if (!skipInitialSound && !isRestoredFromStorage && hasUserInteractedYet()) {
+    const shouldPlaySound = !skipInitialSound && !isRestoredFromStorage && hasUserInteractedYet();
+    console.log(`[WindowFrame] Window open sound check - skipInitialSound: ${skipInitialSound}, isRestoredFromStorage: ${isRestoredFromStorage}, hasUserInteracted: ${hasUserInteractedYet()}, shouldPlaySound: ${shouldPlaySound}`);
+    if (shouldPlaySound) {
       playWindowOpen();
     }
     // Remove initial mount state after animation

--- a/src/hooks/useSound.ts
+++ b/src/hooks/useSound.ts
@@ -9,6 +9,11 @@ const isMobileDevice =
     navigator.userAgent
   );
 
+// Track whether the user has interacted with the document (required for
+// user-initiated sound policies).
+let hasUserInteracted = false;
+export const hasUserInteractedYet = () => hasUserInteracted;
+
 // Mobile Safari handles 8-16 concurrent sources efficiently, desktop can handle more
 const MAX_CONCURRENT_SOURCES = isMobileDevice ? 16 : 32;
 // Limit cache size to prevent memory issues on mobile
@@ -299,6 +304,7 @@ export const Sounds = {
 // Lazily preload sounds after the first user interaction (click or touch)
 if (typeof document !== "undefined") {
   const handleFirstInteraction = () => {
+    hasUserInteracted = true;
     // On mobile, only preload essential sounds to conserve memory
     const soundsToPreload = isMobileDevice
       ? [


### PR DESCRIPTION
Remove window open sound playback when restoring windows from storage.

The `WINDOW_OPEN` sound was incorrectly playing when the app loaded and restored previously open windows. This change ensures the sound only plays when a user explicitly opens a new window, aligning with the principle that sounds should be user-triggered.

---
<a href="https://cursor.com/background-agent?bcId=bc-26e23fa5-6976-4a1d-935a-4756262f47c0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-26e23fa5-6976-4a1d-935a-4756262f47c0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

