### PR TITLE
Irc chat integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ A modern web-based desktop environment inspired by classic macOS and Windows, bu
 - **Synth** — Virtual synthesizer with multiple waveforms, effects, and MIDI support
 - **Photo Booth** — Camera app with real-time filters and photo gallery
 - **Internet Explorer** — Time Machine that explores web history via Wayback Machine; AI generates sites for years before 1996 or in the future
-- **Chats** — AI chat with Ryo, public/private chat rooms, voice messages, and tool calling
+- **Chats** — AI chat with Ryo, IRC channels, voice messages, and tool calling
 - **Control Panels** — System preferences: appearance, sounds, backup/restore, and file system management
 - **Minesweeper** — Classic puzzle game
 - **Virtual PC** — DOS emulator for classic games (Doom, SimCity, etc.)

--- a/api/irc/_client.ts
+++ b/api/irc/_client.ts
@@ -249,6 +249,7 @@ export class IrcConnection extends EventEmitter {
     if (parsed.command === "001") {
       this.connected = true;
       this.registered = true;
+      this.nick = this.requestedNick;
       this.emitSystem("IRC registration successful");
       this.emitState();
       return;

--- a/api/irc/_client.ts
+++ b/api/irc/_client.ts
@@ -1,0 +1,395 @@
+import { createConnection, type Socket } from "node:net";
+import { EventEmitter } from "node:events";
+import { randomUUID } from "node:crypto";
+import type {
+  IrcChannel,
+  IrcConnectionState,
+  IrcMessage,
+  IrcMessageType,
+} from "../../src/types/irc.js";
+
+type IrcEvent =
+  | { type: "message"; payload: IrcMessage }
+  | { type: "system"; payload: { text: string } }
+  | { type: "state"; payload: { state: IrcConnectionState } };
+
+interface ParsedIrcLine {
+  prefix?: string;
+  command: string;
+  params: string[];
+  trailing?: string;
+  raw: string;
+}
+
+const IRC_HOST = "irc.pieter.com";
+const IRC_PORT = 6667;
+
+const MAX_NICK_ATTEMPTS = 5;
+const SYSTEM_NICK = "irc";
+
+const normalizeChannelName = (name: string) =>
+  name.startsWith("#") ? name : `#${name}`;
+
+const parsePrefixNick = (prefix?: string) => {
+  if (!prefix) return null;
+  const exclamationIndex = prefix.indexOf("!");
+  if (exclamationIndex === -1) return prefix;
+  return prefix.slice(0, exclamationIndex);
+};
+
+const parseIrcLine = (line: string): ParsedIrcLine => {
+  let rest = line.trim();
+  let prefix: string | undefined;
+
+  if (rest.startsWith(":")) {
+    const spaceIndex = rest.indexOf(" ");
+    prefix = rest.slice(1, spaceIndex);
+    rest = rest.slice(spaceIndex + 1);
+  }
+
+  const parts = rest.split(" ");
+  const command = parts.shift() || "";
+  const params: string[] = [];
+  let trailing = "";
+  let foundTrailing = false;
+
+  for (const part of parts) {
+    if (foundTrailing) {
+      trailing += ` ${part}`;
+    } else if (part.startsWith(":")) {
+      foundTrailing = true;
+      trailing = part.slice(1);
+    } else {
+      params.push(part);
+    }
+  }
+
+  if (foundTrailing) {
+    trailing = trailing.trimEnd();
+  } else {
+    trailing = undefined;
+  }
+
+  return {
+    prefix,
+    command,
+    params,
+    trailing,
+    raw: line,
+  };
+};
+
+export class IrcConnection extends EventEmitter {
+  private socket: Socket | null = null;
+  private buffer = "";
+  private nick: string;
+  private requestedNick: string;
+  private connected = false;
+  private registered = false;
+  private nickAttempts = 0;
+  private channels = new Set<string>();
+  private channelTopics = new Map<string, string>();
+  private usersByChannel = new Map<string, Set<string>>();
+
+  constructor(initialNick: string) {
+    super();
+    this.nick = initialNick;
+    this.requestedNick = initialNick;
+  }
+
+  connect() {
+    if (this.socket) return;
+    this.socket = createConnection({ host: IRC_HOST, port: IRC_PORT });
+    this.socket.setEncoding("utf8");
+
+    this.socket.on("connect", () => {
+      this.emitSystem(`Connected to ${IRC_HOST}:${IRC_PORT}`);
+      this.sendRaw(`NICK ${this.requestedNick}`);
+      this.sendRaw(`USER ${this.requestedNick} 0 * :ryOS Chat`);
+    });
+
+    this.socket.on("data", (data) => {
+      this.buffer += data;
+      let lineEndIndex = this.buffer.indexOf("\r\n");
+      while (lineEndIndex !== -1) {
+        const line = this.buffer.slice(0, lineEndIndex);
+        this.buffer = this.buffer.slice(lineEndIndex + 2);
+        this.handleLine(line);
+        lineEndIndex = this.buffer.indexOf("\r\n");
+      }
+    });
+
+    this.socket.on("error", (error) => {
+      this.emitSystem(`Connection error: ${error.message}`);
+      this.connected = false;
+      this.emitState();
+    });
+
+    this.socket.on("close", () => {
+      this.emitSystem("Connection closed");
+      this.connected = false;
+      this.registered = false;
+      this.emitState();
+    });
+  }
+
+  disconnect() {
+    if (!this.socket) return;
+    this.sendRaw("QUIT :ryOS disconnect");
+    this.socket.end();
+    this.socket.destroy();
+    this.socket = null;
+  }
+
+  joinChannel(channel: string) {
+    const normalized = normalizeChannelName(channel);
+    this.channels.add(normalized);
+    if (!this.usersByChannel.has(normalized)) {
+      this.usersByChannel.set(normalized, new Set());
+    }
+    this.sendRaw(`JOIN ${normalized}`);
+    this.emitState();
+  }
+
+  partChannel(channel: string) {
+    const normalized = normalizeChannelName(channel);
+    this.channels.delete(normalized);
+    this.usersByChannel.delete(normalized);
+    this.channelTopics.delete(normalized);
+    this.sendRaw(`PART ${normalized}`);
+    this.emitState();
+  }
+
+  sendMessage(channel: string, content: string) {
+    const normalized = normalizeChannelName(channel);
+    this.sendRaw(`PRIVMSG ${normalized} :${content}`);
+  }
+
+  getNick() {
+    return this.nick;
+  }
+
+  getState(): IrcConnectionState {
+    return {
+      connected: this.connected,
+      nick: this.nick,
+      channels: Array.from(this.channels),
+      serverInfo: this.connected
+        ? {
+            name: IRC_HOST,
+          }
+        : undefined,
+    };
+  }
+
+  getChannels(): IrcChannel[] {
+    return Array.from(this.channels).map((channel) => {
+      const users = Array.from(this.usersByChannel.get(channel) || []);
+      return {
+        name: channel,
+        topic: this.channelTopics.get(channel),
+        users,
+        userCount: users.length,
+      };
+    });
+  }
+
+  onEvent(listener: (event: IrcEvent) => void) {
+    this.on("event", listener);
+  }
+
+  removeEventListener(listener: (event: IrcEvent) => void) {
+    this.off("event", listener);
+  }
+
+  private emitEvent(event: IrcEvent) {
+    this.emit("event", event);
+  }
+
+  private emitSystem(text: string) {
+    this.emitEvent({ type: "system", payload: { text } });
+  }
+
+  private emitState() {
+    this.emitEvent({ type: "state", payload: { state: this.getState() } });
+  }
+
+  private emitMessage(
+    channel: string,
+    nick: string,
+    content: string,
+    type: IrcMessageType
+  ) {
+    const message: IrcMessage = {
+      id: randomUUID(),
+      channel,
+      nick,
+      content,
+      timestamp: Date.now(),
+      type,
+    };
+    this.emitEvent({ type: "message", payload: message });
+  }
+
+  private sendRaw(line: string) {
+    if (!this.socket) return;
+    this.socket.write(`${line}\r\n`);
+  }
+
+  private handleLine(line: string) {
+    if (!line) return;
+    const parsed = parseIrcLine(line);
+
+    if (parsed.command === "PING") {
+      const payload = parsed.trailing || parsed.params[0] || "";
+      this.sendRaw(`PONG :${payload}`);
+      return;
+    }
+
+    if (parsed.command === "001") {
+      this.connected = true;
+      this.registered = true;
+      this.emitSystem("IRC registration successful");
+      this.emitState();
+      return;
+    }
+
+    if (parsed.command === "433") {
+      this.handleNickInUse();
+      return;
+    }
+
+    if (parsed.command === "PRIVMSG") {
+      const channel = parsed.params[0];
+      const nick = parsePrefixNick(parsed.prefix) || SYSTEM_NICK;
+      if (!channel || !parsed.trailing) return;
+      this.emitMessage(channel, nick, parsed.trailing, "message");
+      return;
+    }
+
+    if (parsed.command === "NOTICE") {
+      const channel = parsed.params[0] || SYSTEM_NICK;
+      const nick = parsePrefixNick(parsed.prefix) || SYSTEM_NICK;
+      if (!parsed.trailing) return;
+      this.emitMessage(channel, nick, parsed.trailing, "notice");
+      return;
+    }
+
+    if (parsed.command === "JOIN") {
+      const channel = normalizeChannelName(parsed.trailing || parsed.params[0]);
+      const nick = parsePrefixNick(parsed.prefix) || SYSTEM_NICK;
+      if (!channel) return;
+      this.addUserToChannel(channel, nick);
+      if (nick === this.nick) {
+        this.channels.add(channel);
+      }
+      this.emitMessage(channel, nick, `joined ${channel}`, "join");
+      this.emitState();
+      return;
+    }
+
+    if (parsed.command === "PART" || parsed.command === "QUIT") {
+      const channel = normalizeChannelName(parsed.params[0] || "");
+      const nick = parsePrefixNick(parsed.prefix) || SYSTEM_NICK;
+      if (channel) {
+        this.removeUserFromChannel(channel, nick);
+        if (nick === this.nick) {
+          this.channels.delete(channel);
+        }
+        this.emitMessage(
+          channel,
+          nick,
+          `left ${channel}`,
+          parsed.command === "QUIT" ? "part" : "part"
+        );
+      }
+      this.emitState();
+      return;
+    }
+
+    if (parsed.command === "TOPIC") {
+      const channel = normalizeChannelName(parsed.params[0] || "");
+      const topic = parsed.trailing || "";
+      const nick = parsePrefixNick(parsed.prefix) || SYSTEM_NICK;
+      if (channel) {
+        this.channelTopics.set(channel, topic);
+        this.emitMessage(channel, nick, `topic: ${topic}`, "topic");
+        this.emitState();
+      }
+      return;
+    }
+
+    if (parsed.command === "NICK") {
+      const newNick = parsed.trailing || parsed.params[0];
+      const oldNick = parsePrefixNick(parsed.prefix);
+      if (!newNick || !oldNick) return;
+      if (oldNick === this.nick) {
+        this.nick = newNick;
+        this.emitSystem(`Nick changed to ${newNick}`);
+      }
+      this.updateNickInChannels(oldNick, newNick);
+      this.emitMessage(
+        this.channels.values().next().value || SYSTEM_NICK,
+        oldNick,
+        `is now known as ${newNick}`,
+        "nick"
+      );
+      this.emitState();
+      return;
+    }
+
+    if (parsed.command === "353") {
+      const channel = normalizeChannelName(parsed.params[2] || "");
+      const names = parsed.trailing?.split(" ") || [];
+      if (channel) {
+        const channelUsers = this.usersByChannel.get(channel) || new Set();
+        names.forEach((name) => {
+          const cleanName = name.replace(/^[@+~&%]/, "");
+          if (cleanName) channelUsers.add(cleanName);
+        });
+        this.usersByChannel.set(channel, channelUsers);
+        this.emitState();
+      }
+      return;
+    }
+
+    if (parsed.command === "366") {
+      this.emitState();
+      return;
+    }
+  }
+
+  private handleNickInUse() {
+    if (this.nickAttempts >= MAX_NICK_ATTEMPTS) {
+      this.emitSystem("Nickname in use; unable to find available nick");
+      return;
+    }
+    this.nickAttempts += 1;
+    const suffix = Math.floor(Math.random() * 1000);
+    this.requestedNick = `${this.requestedNick}_${suffix}`;
+    this.sendRaw(`NICK ${this.requestedNick}`);
+    this.emitSystem(`Nickname in use, trying ${this.requestedNick}`);
+  }
+
+  private addUserToChannel(channel: string, nick: string) {
+    const channelUsers = this.usersByChannel.get(channel) || new Set<string>();
+    channelUsers.add(nick);
+    this.usersByChannel.set(channel, channelUsers);
+  }
+
+  private removeUserFromChannel(channel: string, nick: string) {
+    const channelUsers = this.usersByChannel.get(channel);
+    if (!channelUsers) return;
+    channelUsers.delete(nick);
+    this.usersByChannel.set(channel, channelUsers);
+  }
+
+  private updateNickInChannels(oldNick: string, newNick: string) {
+    this.usersByChannel.forEach((users) => {
+      if (users.has(oldNick)) {
+        users.delete(oldNick);
+        users.add(newNick);
+      }
+    });
+  }
+}

--- a/api/irc/_client.ts
+++ b/api/irc/_client.ts
@@ -27,8 +27,10 @@ const IRC_PORT = 6667;
 const MAX_NICK_ATTEMPTS = 5;
 const SYSTEM_NICK = "irc";
 
-const normalizeChannelName = (name: string) =>
-  name.startsWith("#") ? name : `#${name}`;
+const normalizeChannelName = (name: string) => {
+  if (!name) return "";
+  return name.startsWith("#") ? name : `#${name}`;
+};
 
 const parsePrefixNick = (prefix?: string) => {
   if (!prefix) return null;
@@ -277,7 +279,9 @@ export class IrcConnection extends EventEmitter {
     }
 
     if (parsed.command === "JOIN") {
-      const channel = normalizeChannelName(parsed.trailing || parsed.params[0]);
+      const channel = normalizeChannelName(
+        parsed.trailing || parsed.params[0] || ""
+      );
       const nick = parsePrefixNick(parsed.prefix) || SYSTEM_NICK;
       if (!channel) return;
       this.addUserToChannel(channel, nick);

--- a/api/irc/_sessions.ts
+++ b/api/irc/_sessions.ts
@@ -1,0 +1,148 @@
+import { randomUUID } from "node:crypto";
+import { IrcConnection } from "./_client.js";
+import type {
+  IrcChannel,
+  IrcConnectResponse,
+  IrcStreamEvent,
+} from "../../src/types/irc.js";
+
+const DEFAULT_CHANNELS = ["#ryos"];
+const SESSION_TTL_MS = 30 * 60 * 1000;
+
+interface IrcSession {
+  id: string;
+  nick: string;
+  connection: IrcConnection;
+  createdAt: number;
+  lastActive: number;
+  listeners: Set<(event: IrcStreamEvent) => void>;
+}
+
+const globalWithSessions = globalThis as typeof globalThis & {
+  __ircSessions?: Map<string, IrcSession>;
+};
+
+const getSessionStore = () => {
+  if (!globalWithSessions.__ircSessions) {
+    globalWithSessions.__ircSessions = new Map<string, IrcSession>();
+  }
+  return globalWithSessions.__ircSessions;
+};
+
+const touchSession = (session: IrcSession) => {
+  session.lastActive = Date.now();
+};
+
+export const cleanupSessions = () => {
+  const store = getSessionStore();
+  const now = Date.now();
+  for (const [id, session] of store.entries()) {
+    const isExpired = now - session.lastActive > SESSION_TTL_MS;
+    if (isExpired && session.listeners.size === 0) {
+      session.connection.disconnect();
+      store.delete(id);
+    }
+  }
+};
+
+export const createSession = (
+  nick: string,
+  channels?: string[]
+): IrcConnectResponse => {
+  cleanupSessions();
+  const store = getSessionStore();
+  const sessionId = randomUUID();
+  const connection = new IrcConnection(nick);
+
+  const session: IrcSession = {
+    id: sessionId,
+    nick,
+    connection,
+    createdAt: Date.now(),
+    lastActive: Date.now(),
+    listeners: new Set(),
+  };
+
+  connection.onEvent((event) => {
+    touchSession(session);
+    session.listeners.forEach((listener) => listener(event));
+  });
+
+  store.set(sessionId, session);
+
+  const joinChannels = channels && channels.length > 0 ? channels : DEFAULT_CHANNELS;
+  connection.connect();
+  joinChannels.forEach((channel) => connection.joinChannel(channel));
+
+  return {
+    sessionId,
+    nick,
+    channels: joinChannels,
+  };
+};
+
+export const getSession = (sessionId: string): IrcSession | null => {
+  cleanupSessions();
+  const store = getSessionStore();
+  return store.get(sessionId) || null;
+};
+
+export const registerSessionListener = (
+  sessionId: string,
+  listener: (event: IrcStreamEvent) => void
+): (() => void) => {
+  const session = getSession(sessionId);
+  if (!session) {
+    throw new Error("Session not found");
+  }
+  session.listeners.add(listener);
+  touchSession(session);
+  listener({
+    type: "state",
+    payload: { state: session.connection.getState() },
+  });
+  return () => {
+    session.listeners.delete(listener);
+  };
+};
+
+export const sendSessionMessage = (
+  sessionId: string,
+  channel: string,
+  content: string
+) => {
+  const session = getSession(sessionId);
+  if (!session) {
+    return { ok: false, error: "Session not found" };
+  }
+  session.connection.sendMessage(channel, content);
+  touchSession(session);
+  return { ok: true };
+};
+
+export const joinSessionChannel = (sessionId: string, channel: string) => {
+  const session = getSession(sessionId);
+  if (!session) {
+    return { ok: false, error: "Session not found" };
+  }
+  session.connection.joinChannel(channel);
+  touchSession(session);
+  return { ok: true };
+};
+
+export const partSessionChannel = (sessionId: string, channel: string) => {
+  const session = getSession(sessionId);
+  if (!session) {
+    return { ok: false, error: "Session not found" };
+  }
+  session.connection.partChannel(channel);
+  touchSession(session);
+  return { ok: true };
+};
+
+export const listSessionChannels = (sessionId: string): IrcChannel[] => {
+  const session = getSession(sessionId);
+  if (!session) return [];
+  touchSession(session);
+  return session.connection.getChannels();
+};

--- a/api/irc/channels.ts
+++ b/api/irc/channels.ts
@@ -1,0 +1,30 @@
+import type { VercelRequest, VercelResponse } from "@vercel/node";
+import { listSessionChannels } from "./_sessions.js";
+
+export const runtime = "nodejs";
+export const maxDuration = 15;
+
+export default function handler(req: VercelRequest, res: VercelResponse) {
+  res.setHeader("Access-Control-Allow-Origin", "*");
+  res.setHeader("Access-Control-Allow-Methods", "GET, OPTIONS");
+  res.setHeader("Access-Control-Allow-Headers", "Content-Type");
+
+  if (req.method === "OPTIONS") {
+    return res.status(200).end();
+  }
+
+  if (req.method !== "GET") {
+    return res.status(405).json({ error: "Method not allowed" });
+  }
+
+  const sessionId = Array.isArray(req.query.sessionId)
+    ? req.query.sessionId[0]
+    : req.query.sessionId;
+
+  if (!sessionId) {
+    return res.status(400).json({ error: "sessionId is required" });
+  }
+
+  const channels = listSessionChannels(sessionId);
+  return res.status(200).json({ channels });
+}

--- a/api/irc/connect.ts
+++ b/api/irc/connect.ts
@@ -1,0 +1,49 @@
+import type { VercelRequest, VercelResponse } from "@vercel/node";
+import { createSession } from "./_sessions.js";
+
+export const runtime = "nodejs";
+export const maxDuration = 15;
+
+const sanitizeNick = (nick: string) =>
+  nick
+    .trim()
+    .replace(/\s+/g, "_")
+    .replace(/[^a-zA-Z0-9_\-\[\]\\`^{}|]/g, "")
+    .slice(0, 24) || "ryos_guest";
+
+const parseBody = (req: VercelRequest) => {
+  if (!req.body) return {};
+  if (typeof req.body === "string") {
+    try {
+      return JSON.parse(req.body);
+    } catch {
+      return {};
+    }
+  }
+  return req.body;
+};
+
+export default function handler(req: VercelRequest, res: VercelResponse) {
+  res.setHeader("Access-Control-Allow-Origin", "*");
+  res.setHeader("Access-Control-Allow-Methods", "POST, OPTIONS");
+  res.setHeader("Access-Control-Allow-Headers", "Content-Type");
+
+  if (req.method === "OPTIONS") {
+    return res.status(200).end();
+  }
+
+  if (req.method !== "POST") {
+    return res.status(405).json({ error: "Method not allowed" });
+  }
+
+  const body = parseBody(req);
+  const nickInput = typeof body.nick === "string" ? body.nick : "";
+  const channelsInput = Array.isArray(body.channels)
+    ? body.channels.filter((channel: unknown) => typeof channel === "string")
+    : undefined;
+
+  const nick = sanitizeNick(nickInput);
+  const response = createSession(nick, channelsInput);
+
+  return res.status(200).json(response);
+}

--- a/api/irc/join.ts
+++ b/api/irc/join.ts
@@ -1,0 +1,46 @@
+import type { VercelRequest, VercelResponse } from "@vercel/node";
+import { joinSessionChannel } from "./_sessions.js";
+
+export const runtime = "nodejs";
+export const maxDuration = 15;
+
+const parseBody = (req: VercelRequest) => {
+  if (!req.body) return {};
+  if (typeof req.body === "string") {
+    try {
+      return JSON.parse(req.body);
+    } catch {
+      return {};
+    }
+  }
+  return req.body;
+};
+
+export default function handler(req: VercelRequest, res: VercelResponse) {
+  res.setHeader("Access-Control-Allow-Origin", "*");
+  res.setHeader("Access-Control-Allow-Methods", "POST, OPTIONS");
+  res.setHeader("Access-Control-Allow-Headers", "Content-Type");
+
+  if (req.method === "OPTIONS") {
+    return res.status(200).end();
+  }
+
+  if (req.method !== "POST") {
+    return res.status(405).json({ error: "Method not allowed" });
+  }
+
+  const body = parseBody(req);
+  const sessionId = typeof body.sessionId === "string" ? body.sessionId : "";
+  const channel = typeof body.channel === "string" ? body.channel : "";
+
+  if (!sessionId || !channel) {
+    return res.status(400).json({ error: "sessionId and channel required" });
+  }
+
+  const result = joinSessionChannel(sessionId, channel);
+  if (!result.ok) {
+    return res.status(404).json({ error: result.error || "Session not found" });
+  }
+
+  return res.status(200).json({ ok: true });
+}

--- a/api/irc/part.ts
+++ b/api/irc/part.ts
@@ -1,0 +1,46 @@
+import type { VercelRequest, VercelResponse } from "@vercel/node";
+import { partSessionChannel } from "./_sessions.js";
+
+export const runtime = "nodejs";
+export const maxDuration = 15;
+
+const parseBody = (req: VercelRequest) => {
+  if (!req.body) return {};
+  if (typeof req.body === "string") {
+    try {
+      return JSON.parse(req.body);
+    } catch {
+      return {};
+    }
+  }
+  return req.body;
+};
+
+export default function handler(req: VercelRequest, res: VercelResponse) {
+  res.setHeader("Access-Control-Allow-Origin", "*");
+  res.setHeader("Access-Control-Allow-Methods", "POST, OPTIONS");
+  res.setHeader("Access-Control-Allow-Headers", "Content-Type");
+
+  if (req.method === "OPTIONS") {
+    return res.status(200).end();
+  }
+
+  if (req.method !== "POST") {
+    return res.status(405).json({ error: "Method not allowed" });
+  }
+
+  const body = parseBody(req);
+  const sessionId = typeof body.sessionId === "string" ? body.sessionId : "";
+  const channel = typeof body.channel === "string" ? body.channel : "";
+
+  if (!sessionId || !channel) {
+    return res.status(400).json({ error: "sessionId and channel required" });
+  }
+
+  const result = partSessionChannel(sessionId, channel);
+  if (!result.ok) {
+    return res.status(404).json({ error: result.error || "Session not found" });
+  }
+
+  return res.status(200).json({ ok: true });
+}

--- a/api/irc/send.ts
+++ b/api/irc/send.ts
@@ -1,0 +1,47 @@
+import type { VercelRequest, VercelResponse } from "@vercel/node";
+import { sendSessionMessage } from "./_sessions.js";
+
+export const runtime = "nodejs";
+export const maxDuration = 15;
+
+const parseBody = (req: VercelRequest) => {
+  if (!req.body) return {};
+  if (typeof req.body === "string") {
+    try {
+      return JSON.parse(req.body);
+    } catch {
+      return {};
+    }
+  }
+  return req.body;
+};
+
+export default function handler(req: VercelRequest, res: VercelResponse) {
+  res.setHeader("Access-Control-Allow-Origin", "*");
+  res.setHeader("Access-Control-Allow-Methods", "POST, OPTIONS");
+  res.setHeader("Access-Control-Allow-Headers", "Content-Type");
+
+  if (req.method === "OPTIONS") {
+    return res.status(200).end();
+  }
+
+  if (req.method !== "POST") {
+    return res.status(405).json({ error: "Method not allowed" });
+  }
+
+  const body = parseBody(req);
+  const sessionId = typeof body.sessionId === "string" ? body.sessionId : "";
+  const channel = typeof body.channel === "string" ? body.channel : "";
+  const content = typeof body.content === "string" ? body.content.trim() : "";
+
+  if (!sessionId || !channel || !content) {
+    return res.status(400).json({ error: "sessionId, channel, content required" });
+  }
+
+  const result = sendSessionMessage(sessionId, channel, content);
+  if (!result.ok) {
+    return res.status(404).json({ error: result.error || "Session not found" });
+  }
+
+  return res.status(200).json({ ok: true });
+}

--- a/api/irc/stream.ts
+++ b/api/irc/stream.ts
@@ -1,0 +1,60 @@
+import type { VercelRequest, VercelResponse } from "@vercel/node";
+import { getSession, registerSessionListener } from "./_sessions.js";
+import type { IrcStreamEvent } from "../../src/types/irc.js";
+
+export const runtime = "nodejs";
+export const maxDuration = 60;
+
+export default function handler(req: VercelRequest, res: VercelResponse) {
+  res.setHeader("Access-Control-Allow-Origin", "*");
+  res.setHeader("Access-Control-Allow-Methods", "GET, OPTIONS");
+  res.setHeader("Access-Control-Allow-Headers", "Content-Type");
+
+  if (req.method === "OPTIONS") {
+    return res.status(200).end();
+  }
+
+  if (req.method !== "GET") {
+    return res.status(405).json({ error: "Method not allowed" });
+  }
+
+  const sessionId = Array.isArray(req.query.sessionId)
+    ? req.query.sessionId[0]
+    : req.query.sessionId;
+
+  if (!sessionId) {
+    return res.status(400).json({ error: "sessionId is required" });
+  }
+
+  const session = getSession(sessionId);
+  if (!session) {
+    return res.status(404).json({ error: "Session not found" });
+  }
+
+  res.writeHead(200, {
+    "Content-Type": "text/event-stream",
+    "Cache-Control": "no-cache",
+    Connection: "keep-alive",
+  });
+  res.flushHeaders?.();
+
+  const sendEvent = (event: IrcStreamEvent) => {
+    res.write(`data: ${JSON.stringify(event)}\n\n`);
+  };
+
+  sendEvent({
+    type: "system",
+    payload: { text: "connected" },
+  });
+
+  const unsubscribe = registerSessionListener(sessionId, sendEvent);
+  const keepAlive = setInterval(() => {
+    res.write(": ping\n\n");
+  }, 15000);
+
+  req.on("close", () => {
+    clearInterval(keepAlive);
+    unsubscribe();
+    res.end();
+  });
+}

--- a/docs/1-overview.md
+++ b/docs/1-overview.md
@@ -55,7 +55,7 @@ graph TB
 - **[17 Built-in Apps](/docs/apps):** Finder, TextEdit, Paint, iPod, Terminal, Chats, and more
 - **[AI Assistant (Ryo)](/docs/ai-system):** Chat, tool calling, app control, code generation
 - **[Virtual File System](/docs/file-system):** IndexedDB-backed with lazy loading
-- **[Real-time Chat](/docs/chat-rooms-api):** Pusher-powered rooms with AI integration
+- **[IRC Chat](/docs/irc-api):** Public IRC channels bridged into ryOS
 - **[Audio System](/docs/audio-system):** Synthesizer, soundboard, TTS, and UI sounds
 - **[Component Library](/docs/component-library):** shadcn/ui + custom components with i18n
 
@@ -70,7 +70,7 @@ graph TB
 | Text Editor | TipTap |
 | Storage | IndexedDB, LocalStorage, Redis (Upstash) |
 | AI | OpenAI, Anthropic, Google via Vercel AI SDK |
-| Real-time | Pusher |
+| Real-time | IRC gateway (primary), Pusher (legacy chat rooms) |
 | Build | Vite, Bun |
 | Desktop | Tauri (macOS, Windows, Linux) |
 | Deployment | Vercel |

--- a/docs/1.1-architecture.md
+++ b/docs/1.1-architecture.md
@@ -32,12 +32,14 @@ graph TB
         Chat[Chat API]
         Media[Media APIs]
         Rooms[Chat Rooms API]
+        IRC[IRC Gateway]
         Utility[Utility APIs]
     end
     
     subgraph External["External Services"]
         AI[AI Providers<br/>OpenAI, Anthropic, Google]
         Pusher[Pusher<br/>Real-time]
+        IRCServer[IRC Server<br/>irc.pieter.com]
         Redis[(Upstash Redis)]
         YouTube[YouTube API]
     end
@@ -49,6 +51,7 @@ graph TB
     Presentation --> API
     API --> External
     State --> API
+    IRC --> IRCServer
 ```
 
 ## Deployment Targets

--- a/docs/1.2-api-architecture.md
+++ b/docs/1.2-api-architecture.md
@@ -16,6 +16,7 @@ graph TB
         SongAPI[song]
         SpeechAPI[speech]
         RoomsAPI[chat-rooms]
+        IRCAPI[irc]
         IEAPI[ie-generate]
         AppletAPI[applet-ai]
     end
@@ -33,6 +34,7 @@ graph TB
     
     subgraph Realtime["Real-time"]
         Pusher[Pusher]
+        IRCGateway[IRC Gateway]
     end
     
     UI --> Hooks
@@ -41,6 +43,7 @@ graph TB
     Edge --> Storage
     Edge --> Realtime
     RoomsAPI --> Pusher
+    IRCAPI --> IRCGateway
 ```
 
 ## API Directory Structure
@@ -67,6 +70,12 @@ api/
 │   ├── _lyrics.ts            # Lyrics parsing
 │   └── _furigana.ts          # Japanese furigana
 └── [endpoint].ts             # Individual endpoints
+├── irc/                      # IRC gateway endpoints
+│   ├── connect.ts            # Connect to IRC server
+│   ├── stream.ts             # SSE stream
+│   ├── send.ts               # Send message
+│   ├── join.ts               # Join channel
+│   └── part.ts               # Leave channel
 ```
 
 ## API Endpoint Inventory
@@ -101,6 +110,7 @@ api/
 | Endpoint | Methods | Purpose |
 |----------|---------|---------|
 | `/api/chat-rooms` | GET, POST, DELETE | Real-time chat rooms |
+| `/api/irc/*` | GET, POST | IRC gateway endpoints |
 | `/api/share-applet` | GET, POST, PATCH, DELETE | Applet sharing/store |
 
 ### Utility APIs

--- a/docs/1.2-api-architecture.md
+++ b/docs/1.2-api-architecture.md
@@ -69,13 +69,13 @@ api/
 │   ├── [id].ts               # Single song CRUD
 │   ├── _lyrics.ts            # Lyrics parsing
 │   └── _furigana.ts          # Japanese furigana
-└── [endpoint].ts             # Individual endpoints
 ├── irc/                      # IRC gateway endpoints
 │   ├── connect.ts            # Connect to IRC server
 │   ├── stream.ts             # SSE stream
 │   ├── send.ts               # Send message
 │   ├── join.ts               # Join channel
 │   └── part.ts               # Leave channel
+└── [endpoint].ts             # Individual endpoints
 ```
 
 ## API Endpoint Inventory

--- a/docs/2-apps.md
+++ b/docs/2-apps.md
@@ -16,7 +16,7 @@ ryOS includes 17 built-in applications, each designed to replicate classic deskt
 | [Soundboard](/docs/soundboard) | Record and play sound effects | Audio |
 | [Synth](/docs/synth) | Virtual synthesizer with 3D waveform visualization | Audio |
 | [Terminal](/docs/terminal) | Command line interface with AI integration | Development |
-| [Chats](/docs/chats) | Chat with Ryo AI assistant and join chat rooms | Communication |
+| [Chats](/docs/chats) | Chat with Ryo AI assistant and join IRC channels | Communication |
 | [Internet Explorer](/docs/internet-explorer) | Web browser with AI-powered content generation | Web |
 | [Applet Store](/docs/applet-store) | Browse and run user-created HTML applets | Utilities |
 | [Control Panels](/docs/control-panels) | System settings for themes, wallpapers, and audio | System |

--- a/docs/2.1-chats.md
+++ b/docs/2.1-chats.md
@@ -1,10 +1,10 @@
 # Chats
 
-Chats is the central communication hub for ryOS, enabling users to interact with the intelligent Ryo AI assistant, engage in public chat rooms, and even control their desktop environment using natural language commands. It streamlines various ryOS functionalities into a single, intuitive interface.
+Chats is the central communication hub for ryOS, enabling users to interact with the intelligent Ryo AI assistant, join IRC channels, and even control their desktop environment using natural language commands. It streamlines various ryOS functionalities into a single, intuitive interface.
 
 ## Overview
 
-The Chats app serves as a versatile communication platform within ryOS. Its primary function is to provide direct access to the Ryo AI assistant, a powerful tool capable of understanding natural language requests to assist with coding, provide help with ryOS features, and even manage files and applications. Beyond its AI capabilities, Chats also fosters community interaction by allowing users to join public chat rooms, connecting with other ryOS users.
+The Chats app serves as a versatile communication platform within ryOS. Its primary function is to provide direct access to the Ryo AI assistant, a powerful tool capable of understanding natural language requests to assist with coding, provide help with ryOS features, and even manage files and applications. Beyond its AI capabilities, Chats also fosters community interaction by allowing users to join IRC channels hosted on irc.pieter.com, connecting with other ryOS users.
 
 Whether you need to quickly generate a code snippet, find a specific file, launch an app, or simply chat with fellow users, Chats offers a unified and efficient way to manage your digital interactions. Its blend of AI-driven productivity and social connectivity makes it an indispensable part of the ryOS experience, designed to enhance user workflow and collaboration.
 
@@ -15,9 +15,9 @@ Whether you need to quickly generate a code snippet, find a specific file, launc
     *   **File & Applet Management:** Request Ryo to create new HTML applets, edit existing documents, read file contents, or search the Applets Store for new tools.
     *   **System Control:** Command Ryo to launch or close applications, switch between ryOS themes, or manage playback in the [iPod](/docs/ipod) app.
     *   **Contextual Assistance:** Send a 👋 nudge to receive context-aware tips from Ryo. When music is playing, Ryo automatically enters "DJ Mode," offering relevant music-related interactions.
-*   **Interactive Chat Rooms:**
-    *   **Public Engagement:** Join various public chat rooms to connect and communicate with other ryOS users.
-    *   **AI Integration in Rooms:** Mention `@ryo` within any chat room to solicit responses or assistance from the AI assistant in a public context.
+*   **IRC Channels:**
+    *   **Public Engagement:** Join IRC channels to connect and communicate with other ryOS users.
+    *   **Server Connection:** Channels are hosted on `irc.pieter.com:6667` and appear in the sidebar as `#channel` names.
 *   **Voice Messaging:**
     *   **Push-to-Talk:** Utilize the Push-to-Talk feature by holding the `Space` key or tapping the microphone button to record and send voice messages effortlessly.
 
@@ -30,12 +30,12 @@ To launch the Chats app, simply click its icon in the ryOS dock or navigate to i
 *   **To chat with Ryo:** Type your message directly into the input field at the bottom of the window and press Enter.
 *   **To create or edit files:** Simply ask Ryo, e.g., "Ryo, create a new HTML applet called 'MyWidget'" or "Ryo, edit my 'Notes.txt' file."
 *   **To control ryOS apps:** Issue commands like "Ryo, launch Calculator" or "Ryo, switch to Dark theme."
-*   **To join a chat room:** Look for the chat room sidebar (if visible) or use a menu option to browse and join available rooms.
+*   **To join an IRC channel:** Use the sidebar or the Chats menu to join channels (for example, `#ryos`).
 *   **To send a voice message:** Hold down the `Space` key while speaking, then release to send. Alternatively, click the microphone icon to record.
 
 ### Tips & Shortcuts
 *   **Push-to-Talk:** Hold the `Space` key for quick voice messages.
-*   **AI in Chat Rooms:** Type `@ryo` followed by your message in a chat room to get an AI response.
+*   **IRC Channels:** Join `#ryos` to meet other users and keep the sidebar visible to switch channels quickly.
 *   **Contextual Help:** Send a `👋 nudge` message to Ryo for helpful tips based on your current ryOS activity.
 *   **DJ Mode:** If the Music app is playing, Ryo will automatically offer music-related interactions.
 
@@ -60,7 +60,7 @@ The app consists of 7 component file(s):
 **Custom Hooks:**
 *   `src/apps/chats/hooks/useTokenRefresh.ts`
 *   `src/apps/chats/hooks/useRyoChat.ts`
-*   `src/apps/chats/hooks/useChatRoom.ts`
+*   `src/apps/chats/hooks/useIrcChat.ts`
 *   `src/apps/chats/hooks/useAiChat.ts`
 
 ### State Management

--- a/docs/2.1-chats.md
+++ b/docs/2.1-chats.md
@@ -24,7 +24,7 @@ Whether you need to quickly generate a code snippet, find a specific file, launc
 ## User Guide
 
 ### Getting Started
-To launch the Chats app, simply click its icon in the ryOS dock or navigate to it via the [Applet Store](/docs/applet-store). Upon opening, you'll be presented with the chat interface, ready for you to interact with Ryo or join a chat room.
+To launch the Chats app, simply click its icon in the ryOS dock or navigate to it via the [Applet Store](/docs/applet-store). Upon opening, you'll be presented with the chat interface, ready for you to interact with Ryo or join an IRC channel.
 
 ### Key Actions
 *   **To chat with Ryo:** Type your message directly into the input field at the bottom of the window and press Enter.

--- a/docs/8-api-reference.md
+++ b/docs/8-api-reference.md
@@ -26,6 +26,7 @@ graph LR
 | [Song API](/docs/song-api) | Music library CRUD, lyrics, furigana, translations |
 | [Media API](/docs/media-api) | Text-to-speech, transcription, YouTube search |
 | [Chat Rooms API](/docs/chat-rooms-api) | Real-time chat rooms with Pusher/Redis |
+| IRC Gateway API | IRC channels via `/api/irc/*` endpoints |
 | [AI Generation APIs](/docs/ai-generation-apis) | Applet generation, IE time-travel, parse-title |
 | [Utility APIs](/docs/utility-apis) | Link preview, iframe check, share applet, admin |
 
@@ -55,6 +56,12 @@ graph LR
 | Endpoint | Purpose |
 |----------|---------|
 | `/api/chat-rooms` | Real-time chat room management |
+| `/api/irc/connect` | Connect to IRC server |
+| `/api/irc/stream` | Stream IRC events (SSE) |
+| `/api/irc/send` | Send IRC channel message |
+| `/api/irc/join` | Join IRC channel |
+| `/api/irc/part` | Leave IRC channel |
+| `/api/irc/channels` | List joined IRC channels |
 
 ### Utility Endpoints
 
@@ -86,6 +93,7 @@ graph TD
     Media --> yt["/youtube-search"]
     
     Comm --> rooms["/chat-rooms"]
+    Comm --> irc["/irc/*"]
     
     Util --> preview["/link-preview"]
     Util --> iframe["/iframe-check"]

--- a/docs/8-api-reference.md
+++ b/docs/8-api-reference.md
@@ -26,7 +26,7 @@ graph LR
 | [Song API](/docs/song-api) | Music library CRUD, lyrics, furigana, translations |
 | [Media API](/docs/media-api) | Text-to-speech, transcription, YouTube search |
 | [Chat Rooms API](/docs/chat-rooms-api) | Real-time chat rooms with Pusher/Redis |
-| IRC Gateway API | IRC channels via `/api/irc/*` endpoints |
+| [IRC Gateway API](/docs/irc-api) | IRC channels via `/api/irc/*` endpoints |
 | [AI Generation APIs](/docs/ai-generation-apis) | Applet generation, IE time-travel, parse-title |
 | [Utility APIs](/docs/utility-apis) | Link preview, iframe check, share applet, admin |
 

--- a/docs/8.7-irc-api.md
+++ b/docs/8.7-irc-api.md
@@ -1,0 +1,145 @@
+# IRC Gateway API
+
+The IRC Gateway API bridges the Chats app to the public IRC server at `irc.pieter.com:6667`. It exposes simple HTTP and Server-Sent Events (SSE) endpoints that the frontend uses to connect, send messages, and receive real-time events.
+
+## Overview
+
+- **IRC server:** `irc.pieter.com:6667`
+- **Default channel:** `#ryos`
+- **Transport:** HTTP + SSE
+- **Authentication:** none (nickname-based)
+
+## Endpoints
+
+### POST `/api/irc/connect`
+
+Create a new IRC session and connect to the server.
+
+**Request**
+```json
+{
+  "nick": "ryos_user",
+  "channels": ["#ryos", "#general"]
+}
+```
+
+**Response**
+```json
+{
+  "sessionId": "uuid",
+  "nick": "ryos_user",
+  "channels": ["#ryos", "#general"]
+}
+```
+
+---
+
+### GET `/api/irc/stream?sessionId=...`
+
+Open an SSE stream to receive IRC events.
+
+**Event Payloads**
+```json
+{ "type": "state", "payload": { "state": { "connected": true, "nick": "ryos_user", "channels": ["#ryos"] } } }
+```
+
+```json
+{ "type": "system", "payload": { "text": "IRC registration successful" } }
+```
+
+```json
+{
+  "type": "message",
+  "payload": {
+    "id": "uuid",
+    "channel": "#ryos",
+    "nick": "someone",
+    "content": "hello world",
+    "timestamp": 1730000000000,
+    "type": "message"
+  }
+}
+```
+
+---
+
+### POST `/api/irc/send`
+
+Send a message to an IRC channel.
+
+**Request**
+```json
+{
+  "sessionId": "uuid",
+  "channel": "#ryos",
+  "content": "hello!"
+}
+```
+
+**Response**
+```json
+{ "ok": true }
+```
+
+---
+
+### POST `/api/irc/join`
+
+Join a channel.
+
+**Request**
+```json
+{
+  "sessionId": "uuid",
+  "channel": "#general"
+}
+```
+
+**Response**
+```json
+{ "ok": true }
+```
+
+---
+
+### POST `/api/irc/part`
+
+Leave a channel.
+
+**Request**
+```json
+{
+  "sessionId": "uuid",
+  "channel": "#general"
+}
+```
+
+**Response**
+```json
+{ "ok": true }
+```
+
+---
+
+### GET `/api/irc/channels?sessionId=...`
+
+List channels the session is currently in.
+
+**Response**
+```json
+{
+  "channels": [
+    {
+      "name": "#ryos",
+      "topic": "ryOS",
+      "users": ["alice", "bob"],
+      "userCount": 2
+    }
+  ]
+}
+```
+
+## Notes
+
+- Channel names can be provided with or without `#`; the server normalizes them.
+- SSE streams include a keepalive ping every 15 seconds.

--- a/docs/9-changelog.md
+++ b/docs/9-changelog.md
@@ -6,6 +6,7 @@ A summary of changes and updates to ryOS, organized by month.
 
 ## January 2026
 
+- Replaced public chat rooms with IRC channels (irc.pieter.com) and added IRC gateway APIs.
 - Restructured documentation with hierarchical DeepWiki-style navigation and clean URLs.
 - Enhanced documentation generation with skip and force options.
 - Improved documentation navigation and routing.

--- a/src/apps/chats/components/ChatInput.tsx
+++ b/src/apps/chats/components/ChatInput.tsx
@@ -62,6 +62,8 @@ interface ChatInputProps {
   isInChatRoom?: boolean;
   /** Whether TTS speech is currently playing */
   isSpeechPlaying?: boolean;
+  /** Whether to show the @mention button in chat rooms */
+  showMentionButton?: boolean;
   rateLimitError?: {
     isAuthenticated: boolean;
     count: number;
@@ -91,6 +93,7 @@ export function ChatInput({
   showNudgeButton = true,
   isInChatRoom = false,
   isSpeechPlaying = false,
+  showMentionButton = true,
   rateLimitError,
   needsUsername = false,
   isOffline = false,
@@ -694,7 +697,7 @@ export function ChatInput({
                       </Tooltip>
                     </TooltipProvider>
                   )}
-                  {isInChatRoom && (
+                  {isInChatRoom && showMentionButton && (
                     <TooltipProvider>
                       <Tooltip>
                         <TooltipTrigger asChild>

--- a/src/apps/chats/components/ChatInput.tsx
+++ b/src/apps/chats/components/ChatInput.tsx
@@ -146,7 +146,9 @@ export function ChatInput({
 
   // Check if user is typing @ryo
   const isTypingRyoMention =
-    isInChatRoom && (input.startsWith("@ryo ") || input === "@ryo");
+    showMentionButton &&
+    isInChatRoom &&
+    (input.startsWith("@ryo ") || input === "@ryo");
 
   useEffect(() => {
     // Check if device has touch capability

--- a/src/apps/chats/components/ChatRoomSidebar.tsx
+++ b/src/apps/chats/components/ChatRoomSidebar.tsx
@@ -24,6 +24,7 @@ interface ChatRoomSidebarProps {
   onDeleteRoom?: (room: ChatRoom) => void;
   isVisible: boolean;
   isAdmin: boolean;
+  connectionStatus?: "connected" | "connecting" | "disconnected";
   /** Allow leaving public channels for IRC */
   allowPublicLeave?: boolean;
   /** When rendered inside mobile/overlay mode, occupies full width and hides right border */
@@ -39,6 +40,7 @@ export const ChatRoomSidebar: React.FC<ChatRoomSidebarProps> = ({
   onDeleteRoom,
   isVisible,
   isAdmin,
+  connectionStatus,
   allowPublicLeave = false,
   isOverlay = false,
   username,
@@ -148,6 +150,18 @@ export const ChatRoomSidebar: React.FC<ChatRoomSidebarProps> = ({
     );
   };
 
+  const statusStyles = (() => {
+    switch (connectionStatus) {
+      case "connected":
+        return "bg-emerald-500";
+      case "disconnected":
+        return "bg-red-500";
+      case "connecting":
+      default:
+        return "bg-amber-500";
+    }
+  })();
+
   return (
     <div
       className={cn(
@@ -176,8 +190,17 @@ export const ChatRoomSidebar: React.FC<ChatRoomSidebarProps> = ({
         )}
       >
         <div className="flex justify-between items-center mb-2 flex-shrink-0 px-3">
-          <div className="flex items-baseline gap-1.5">
+          <div className="flex items-center gap-2">
             <h2 className="text-[14px] pl-1">{t("apps.chats.sidebar.chats")}</h2>
+            {connectionStatus && (
+              <div
+                className="flex items-center gap-1 text-[10px] text-black/50"
+                title={`IRC ${connectionStatus}`}
+              >
+                <span className={`h-2 w-2 rounded-full ${statusStyles}`} />
+                <span className="uppercase tracking-wide">IRC</span>
+              </div>
+            )}
           </div>
           <TooltipProvider>
             <Tooltip>

--- a/src/apps/chats/components/ChatRoomSidebar.tsx
+++ b/src/apps/chats/components/ChatRoomSidebar.tsx
@@ -24,6 +24,8 @@ interface ChatRoomSidebarProps {
   onDeleteRoom?: (room: ChatRoom) => void;
   isVisible: boolean;
   isAdmin: boolean;
+  /** Allow leaving public channels for IRC */
+  allowPublicLeave?: boolean;
   /** When rendered inside mobile/overlay mode, occupies full width and hides right border */
   isOverlay?: boolean;
   username?: string | null;
@@ -37,6 +39,7 @@ export const ChatRoomSidebar: React.FC<ChatRoomSidebarProps> = ({
   onDeleteRoom,
   isVisible,
   isAdmin,
+  allowPublicLeave = false,
   isOverlay = false,
   username,
 }) => {
@@ -65,6 +68,9 @@ export const ChatRoomSidebar: React.FC<ChatRoomSidebarProps> = ({
     const unreadCount = unreadCounts[room.id] || 0;
     const hasUnread = unreadCount > 0;
     const isSelected = currentRoom?.id === room.id;
+
+    const canLeave =
+      room.type !== "private" ? isAdmin || allowPublicLeave : true;
 
     return (
       <div
@@ -114,7 +120,7 @@ export const ChatRoomSidebar: React.FC<ChatRoomSidebarProps> = ({
             </span>
           )}
         </div>
-        {((isAdmin && room.type !== "private") || room.type === "private") &&
+        {canLeave &&
           onDeleteRoom && (
             <button
               className={cn(

--- a/src/apps/chats/components/ChatsAppComponent.tsx
+++ b/src/apps/chats/components/ChatsAppComponent.tsx
@@ -129,6 +129,7 @@ export function ChatsAppComponent({
     isSidebarVisible,
     isAdmin,
     ircNick,
+    connectionStatus,
     handleRoomSelect,
     sendRoomMessage,
     toggleSidebarVisibility,
@@ -566,6 +567,7 @@ export function ChatsAppComponent({
                     isVisible={true} // Always visible when overlay is shown
                     isAdmin={isAdmin}
                   allowPublicLeave={true}
+                  connectionStatus={connectionStatus}
                     username={username}
                     isOverlay={true}
                   />
@@ -590,6 +592,7 @@ export function ChatsAppComponent({
                 isVisible={sidebarVisibleBool}
                 isAdmin={isAdmin}
                 allowPublicLeave={true}
+                connectionStatus={connectionStatus}
                 username={username}
               />
             </div>

--- a/src/apps/chats/components/CreateRoomDialog.tsx
+++ b/src/apps/chats/components/CreateRoomDialog.tsx
@@ -31,6 +31,7 @@ interface CreateRoomDialogProps {
   isAdmin: boolean;
   currentUsername: string | null;
   initialUsers?: string[]; // Optional prop to prefill users
+  mode?: "rooms" | "irc";
 }
 
 export function CreateRoomDialog({
@@ -40,6 +41,7 @@ export function CreateRoomDialog({
   isAdmin,
   currentUsername,
   initialUsers = [],
+  mode = "rooms",
 }: CreateRoomDialogProps) {
   const { t } = useTranslation();
   const [isLoading, setIsLoading] = useState(false);
@@ -50,6 +52,7 @@ export function CreateRoomDialog({
   const [searchTerm, setSearchTerm] = useState("");
   const [activeTab, setActiveTab] = useState<"public" | "private">("private");
   const [isSearching, setIsSearching] = useState(false);
+  const isIrcMode = mode === "irc";
 
   // Theme detection
   const currentTheme = useThemeStore((state) => state.current);
@@ -65,12 +68,13 @@ export function CreateRoomDialog({
       setSearchTerm("");
       setUsers([]);
       // Reset to private tab when opening
-      setActiveTab("private");
+      setActiveTab(isIrcMode ? "public" : "private");
     }
-  }, [isOpen, initialUsers]);
+  }, [isOpen, initialUsers, isIrcMode]);
 
   // Search for users when search term changes (with debouncing)
   useEffect(() => {
+    if (isIrcMode) return;
     if (searchTerm.length < 2) {
       setUsers([]);
       return;
@@ -81,7 +85,7 @@ export function CreateRoomDialog({
     }, 300); // 300ms debounce
 
     return () => clearTimeout(timeoutId);
-  }, [searchTerm]);
+  }, [searchTerm, isIrcMode]);
 
   const searchUsers = async (query: string) => {
     setIsSearching(true);
@@ -110,7 +114,9 @@ export function CreateRoomDialog({
     setError(null);
 
     try {
-      const result = await onSubmit(roomName, activeTab, selectedUsers);
+      const submitType = isIrcMode ? "public" : activeTab;
+      const submitMembers = isIrcMode ? [] : selectedUsers;
+      const result = await onSubmit(roomName, submitType, submitMembers);
 
       if (result.ok) {
         onOpenChange(false);
@@ -136,7 +142,8 @@ export function CreateRoomDialog({
         value={activeTab}
         onValueChange={(v) => setActiveTab(v as "public" | "private")}
       >
-        {isAdmin &&
+        {!isIrcMode &&
+          isAdmin &&
           (isXpTheme ? (
             <TabsList asChild>
               <menu
@@ -164,7 +171,7 @@ export function CreateRoomDialog({
             </TabsList>
           ))}
 
-        {isAdmin && (
+        {(isIrcMode || isAdmin) && (
           <TabsContent
             value="public"
             className={cn(
@@ -235,40 +242,20 @@ export function CreateRoomDialog({
           </TabsContent>
         )}
 
-        <TabsContent
-          value="private"
-          className={cn(
-            "mt-0",
-            isXpTheme ? "bg-white border border-[#919b9c] p-4" : ""
-          )}
-        >
-          <div className="space-y-3">
-            <div className="space-y-2">
-              <Label
-                htmlFor="search-users"
-                className={cn(
-                  "text-gray-700",
-                  isXpTheme
-                    ? "font-['Pixelated_MS_Sans_Serif',Arial] text-[11px]"
-                    : "font-geneva-12 text-[12px]"
-                )}
-                style={{
-                  fontFamily: isXpTheme
-                    ? '"Pixelated MS Sans Serif", "ArkPixel", Arial'
-                    : undefined,
-                  fontSize: isXpTheme ? "11px" : undefined,
-                }}
-              >
-                {t("apps.chats.dialogs.addUsersToPrivateChat")}
-              </Label>
-              <div className="relative">
-                <Input
-                  id="search-users"
-                  placeholder={t("apps.chats.dialogs.searchUsernamePlaceholder")}
-                  value={searchTerm}
-                  onChange={(e) => setSearchTerm(e.target.value)}
+        {!isIrcMode && (
+          <TabsContent
+            value="private"
+            className={cn(
+              "mt-0",
+              isXpTheme ? "bg-white border border-[#919b9c] p-4" : ""
+            )}
+          >
+            <div className="space-y-3">
+              <div className="space-y-2">
+                <Label
+                  htmlFor="search-users"
                   className={cn(
-                    "shadow-none h-8 pr-8",
+                    "text-gray-700",
                     isXpTheme
                       ? "font-['Pixelated_MS_Sans_Serif',Arial] text-[11px]"
                       : "font-geneva-12 text-[12px]"
@@ -279,84 +266,106 @@ export function CreateRoomDialog({
                       : undefined,
                     fontSize: isXpTheme ? "11px" : undefined,
                   }}
-                  disabled={isLoading}
-                />
-                {isSearching && searchTerm.length >= 2 && (
-                  <ActivityIndicator size="sm" className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-500" />
+                >
+                  {t("apps.chats.dialogs.addUsersToPrivateChat")}
+                </Label>
+                <div className="relative">
+                  <Input
+                    id="search-users"
+                    placeholder={t("apps.chats.dialogs.searchUsernamePlaceholder")}
+                    value={searchTerm}
+                    onChange={(e) => setSearchTerm(e.target.value)}
+                    className={cn(
+                      "shadow-none h-8 pr-8",
+                      isXpTheme
+                        ? "font-['Pixelated_MS_Sans_Serif',Arial] text-[11px]"
+                        : "font-geneva-12 text-[12px]"
+                    )}
+                    style={{
+                      fontFamily: isXpTheme
+                        ? '"Pixelated MS Sans Serif", "ArkPixel", Arial'
+                        : undefined,
+                      fontSize: isXpTheme ? "11px" : undefined,
+                    }}
+                    disabled={isLoading}
+                  />
+                  {isSearching && searchTerm.length >= 2 && (
+                    <ActivityIndicator size="sm" className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-500" />
+                  )}
+                </div>
+
+                {/* Selected users tokens */}
+                {selectedUsers.length > 0 && (
+                  <div className="flex flex-wrap gap-1.5 pt-1">
+                    {selectedUsers.map((username) => (
+                      <Badge
+                        key={username}
+                        variant="secondary"
+                        className={cn(
+                          "py-0.5 pl-2 pr-1 bg-gray-100 hover:bg-gray-200 border-gray-300",
+                          isXpTheme
+                            ? "font-['Pixelated_MS_Sans_Serif',Arial] text-[10px]"
+                            : "font-geneva-12 text-[11px]"
+                        )}
+                        style={{
+                          fontFamily: isXpTheme
+                            ? '"Pixelated MS Sans Serif", "ArkPixel", Arial'
+                            : undefined,
+                          fontSize: isXpTheme ? "10px" : undefined,
+                        }}
+                      >
+                        @{username}
+                        <button
+                          type="button"
+                          onClick={() => toggleUserSelection(username)}
+                          className="ml-1 hover:bg-gray-300 rounded-sm p-0.5"
+                          disabled={isLoading}
+                        >
+                          <X className="h-3 w-3" weight="bold" />
+                        </button>
+                      </Badge>
+                    ))}
+                  </div>
                 )}
               </div>
 
-              {/* Selected users tokens */}
-              {selectedUsers.length > 0 && (
-                <div className="flex flex-wrap gap-1.5 pt-1">
-                  {selectedUsers.map((username) => (
-                    <Badge
-                      key={username}
-                      variant="secondary"
-                      className={cn(
-                        "py-0.5 pl-2 pr-1 bg-gray-100 hover:bg-gray-200 border-gray-300",
-                        isXpTheme
-                          ? "font-['Pixelated_MS_Sans_Serif',Arial] text-[10px]"
-                          : "font-geneva-12 text-[11px]"
-                      )}
-                      style={{
-                        fontFamily: isXpTheme
-                          ? '"Pixelated MS Sans Serif", "ArkPixel", Arial'
-                          : undefined,
-                        fontSize: isXpTheme ? "10px" : undefined,
-                      }}
-                    >
-                      @{username}
-                      <button
-                        type="button"
-                        onClick={() => toggleUserSelection(username)}
-                        className="ml-1 hover:bg-gray-300 rounded-sm p-0.5"
-                        disabled={isLoading}
+              {/* Show results */}
+              {!isSearching && searchTerm.length >= 2 && users.length > 0 && (
+                <div className="border border-gray-300 rounded max-h-[180px] overflow-y-auto bg-white">
+                  <div className="p-1">
+                    {users.map((user) => (
+                      <label
+                        key={user.username}
+                        className={cn(
+                          "flex items-center p-2 hover:bg-gray-100 cursor-pointer rounded",
+                          isXpTheme
+                            ? "font-['Pixelated_MS_Sans_Serif',Arial] text-[11px]"
+                            : "font-geneva-12 text-[12px]"
+                        )}
+                        style={{
+                          fontFamily: isXpTheme
+                            ? '"Pixelated MS Sans Serif", "ArkPixel", Arial'
+                            : undefined,
+                          fontSize: isXpTheme ? "11px" : undefined,
+                        }}
                       >
-                        <X className="h-3 w-3" weight="bold" />
-                      </button>
-                    </Badge>
-                  ))}
+                        <Checkbox
+                          checked={selectedUsers.includes(user.username)}
+                          onCheckedChange={() =>
+                            toggleUserSelection(user.username)
+                          }
+                          className="h-4 w-4"
+                          disabled={isLoading}
+                        />
+                        <span className="ml-2">@{user.username}</span>
+                      </label>
+                    ))}
+                  </div>
                 </div>
               )}
             </div>
-
-            {/* Show results */}
-            {!isSearching && searchTerm.length >= 2 && users.length > 0 && (
-              <div className="border border-gray-300 rounded max-h-[180px] overflow-y-auto bg-white">
-                <div className="p-1">
-                  {users.map((user) => (
-                    <label
-                      key={user.username}
-                      className={cn(
-                        "flex items-center p-2 hover:bg-gray-100 cursor-pointer rounded",
-                        isXpTheme
-                          ? "font-['Pixelated_MS_Sans_Serif',Arial] text-[11px]"
-                          : "font-geneva-12 text-[12px]"
-                      )}
-                      style={{
-                        fontFamily: isXpTheme
-                          ? '"Pixelated MS Sans Serif", "ArkPixel", Arial'
-                          : undefined,
-                        fontSize: isXpTheme ? "11px" : undefined,
-                      }}
-                    >
-                      <Checkbox
-                        checked={selectedUsers.includes(user.username)}
-                        onCheckedChange={() =>
-                          toggleUserSelection(user.username)
-                        }
-                        className="h-4 w-4"
-                        disabled={isLoading}
-                      />
-                      <span className="ml-2">@{user.username}</span>
-                    </label>
-                  ))}
-                </div>
-              </div>
-            )}
-          </div>
-        </TabsContent>
+          </TabsContent>
+        )}
       </Tabs>
 
       {error && (
@@ -403,8 +412,11 @@ export function CreateRoomDialog({
           onClick={handleSubmit}
           disabled={
             isLoading ||
-            (activeTab === "public" && !roomName.trim()) ||
-            (activeTab === "private" && selectedUsers.length === 0)
+            (isIrcMode
+              ? !roomName.trim()
+              : activeTab === "public"
+              ? !roomName.trim()
+              : selectedUsers.length === 0)
           }
           className={cn(
             "h-7",

--- a/src/apps/chats/components/CreateRoomDialog.tsx
+++ b/src/apps/chats/components/CreateRoomDialog.tsx
@@ -53,6 +53,11 @@ export function CreateRoomDialog({
   const [activeTab, setActiveTab] = useState<"public" | "private">("private");
   const [isSearching, setIsSearching] = useState(false);
   const isIrcMode = mode === "irc";
+  const dialogDescription = isIrcMode
+    ? t("apps.chats.dialogs.newChatDescription")
+    : isAdmin
+    ? t("apps.chats.dialogs.newChatDescription")
+    : t("apps.chats.dialogs.newChatDescriptionPrivate");
 
   // Theme detection
   const currentTheme = useThemeStore((state) => state.current);
@@ -467,9 +472,7 @@ export function CreateRoomDialog({
                 {t("apps.chats.dialogs.newChatTitle")}
               </DialogTitle>
               <DialogDescription className="sr-only">
-                {isAdmin
-                  ? t("apps.chats.dialogs.newChatDescription")
-                  : t("apps.chats.dialogs.newChatDescriptionPrivate")}
+                {dialogDescription}
               </DialogDescription>
             </DialogHeader>
             {dialogContent}

--- a/src/apps/chats/hooks/useIrcChat.ts
+++ b/src/apps/chats/hooks/useIrcChat.ts
@@ -292,9 +292,11 @@ export function useIrcChat(isWindowOpen: boolean) {
     : [];
 
   const isConnected = connectionState?.connected ?? false;
+  const ircNick = connectionState?.nick ?? lastNickRef.current ?? username ?? null;
 
   return {
     username,
+    ircNick,
     authToken: null,
     rooms,
     currentRoomId,

--- a/src/apps/chats/hooks/useIrcChat.ts
+++ b/src/apps/chats/hooks/useIrcChat.ts
@@ -1,0 +1,323 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type { ChatMessage, ChatRoom } from "@/types/chat";
+import type {
+  IrcChannel,
+  IrcConnectionState,
+  IrcMessage,
+  IrcStreamEvent,
+} from "@/types/irc";
+import { useChatsStore } from "@/stores/useChatsStore";
+import { toast } from "@/hooks/useToast";
+
+const DEFAULT_CHANNEL = "#ryos";
+
+const formatIrcMessageContent = (message: IrcMessage) => {
+  switch (message.type) {
+    case "join":
+    case "part":
+    case "nick":
+    case "topic":
+      return message.content;
+    case "notice":
+      return `[notice] ${message.content}`;
+    default:
+      return message.content;
+  }
+};
+
+const mapIrcMessageToChatMessage = (message: IrcMessage): ChatMessage => ({
+  id: message.id,
+  roomId: message.channel,
+  username: message.nick,
+  content: formatIrcMessageContent(message),
+  timestamp: message.timestamp,
+});
+
+const mapChannelToRoom = (channel: IrcChannel): ChatRoom => ({
+  id: channel.name,
+  name: channel.name.replace(/^#/, ""),
+  type: "public",
+  createdAt: Date.now(),
+  userCount: channel.userCount ?? channel.users.length,
+  users: channel.users,
+});
+
+const buildNick = (username?: string | null) => {
+  if (username && username.trim().length > 0) return username;
+  const suffix = Math.floor(Math.random() * 10000);
+  return `ryos_guest_${suffix}`;
+};
+
+export function useIrcChat(isWindowOpen: boolean) {
+  const username = useChatsStore((state) => state.username);
+  const messageRenderLimit = useChatsStore((state) => state.messageRenderLimit);
+  const isSidebarVisible = useChatsStore((state) => state.isSidebarVisible);
+  const toggleSidebarVisibility = useChatsStore(
+    (state) => state.toggleSidebarVisibility
+  );
+  const incrementUnread = useChatsStore((state) => state.incrementUnread);
+  const clearUnread = useChatsStore((state) => state.clearUnread);
+
+  const [sessionId, setSessionId] = useState<string | null>(null);
+  const [connectionState, setConnectionState] =
+    useState<IrcConnectionState | null>(null);
+  const [channels, setChannels] = useState<IrcChannel[]>([]);
+  const [currentRoomId, setCurrentRoomId] = useState<string | null>(null);
+  const [messagesByRoom, setMessagesByRoom] = useState<
+    Record<string, ChatMessage[]>
+  >({});
+  const [isNewRoomDialogOpen, setIsNewRoomDialogOpen] = useState(false);
+  const [isDeleteRoomDialogOpen, setIsDeleteRoomDialogOpen] = useState(false);
+  const [roomToDelete, setRoomToDelete] = useState<ChatRoom | null>(null);
+
+  const eventSourceRef = useRef<EventSource | null>(null);
+  const lastNickRef = useRef<string | null>(null);
+
+  const rooms = useMemo(() => channels.map(mapChannelToRoom), [channels]);
+
+  const refreshChannels = useCallback(async () => {
+    if (!sessionId) return;
+    try {
+      const response = await fetch(`/api/irc/channels?sessionId=${sessionId}`);
+      if (!response.ok) {
+        return;
+      }
+      const data = await response.json();
+      if (Array.isArray(data.channels)) {
+        setChannels(data.channels);
+      }
+    } catch (error) {
+      console.error("[IRC] Failed to fetch channels:", error);
+    }
+  }, [sessionId]);
+
+  const connect = useCallback(async () => {
+    const nick = buildNick(username);
+    lastNickRef.current = nick;
+
+    try {
+      const response = await fetch("/api/irc/connect", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ nick, channels: [DEFAULT_CHANNEL] }),
+      });
+      if (!response.ok) {
+        throw new Error("Failed to connect to IRC");
+      }
+      const data = await response.json();
+      setSessionId(data.sessionId);
+      if (data.channels?.length > 0) {
+        setCurrentRoomId(data.channels[0]);
+      }
+    } catch (error) {
+      toast.error("IRC Connection Failed", {
+        description: "Unable to connect to the IRC server.",
+      });
+      console.error("[IRC] Connection error:", error);
+    }
+  }, [username]);
+
+  useEffect(() => {
+    if (!isWindowOpen) return;
+    if (!sessionId) {
+      connect();
+      return;
+    }
+    return undefined;
+  }, [isWindowOpen, sessionId, connect]);
+
+  useEffect(() => {
+    if (!isWindowOpen || !sessionId) return;
+
+    if (eventSourceRef.current) {
+      eventSourceRef.current.close();
+    }
+
+    const eventSource = new EventSource(`/api/irc/stream?sessionId=${sessionId}`);
+    eventSourceRef.current = eventSource;
+
+    eventSource.onmessage = (event) => {
+      const payload = JSON.parse(event.data) as IrcStreamEvent;
+      if (payload.type === "state") {
+        setConnectionState(payload.payload.state);
+        refreshChannels();
+        return;
+      }
+      if (payload.type === "system") {
+        const text = payload.payload.text;
+        if (text) {
+          toast(text);
+        }
+        return;
+      }
+      if (payload.type === "message") {
+        const message = payload.payload as IrcMessage;
+        const chatMessage = mapIrcMessageToChatMessage(message);
+        setMessagesByRoom((prev) => {
+          const existing = prev[chatMessage.roomId] || [];
+          return {
+            ...prev,
+            [chatMessage.roomId]: [...existing, chatMessage],
+          };
+        });
+        if (currentRoomId && chatMessage.roomId !== currentRoomId) {
+          incrementUnread(chatMessage.roomId);
+        }
+      }
+    };
+
+    eventSource.onerror = () => {
+      setConnectionState((prev) =>
+        prev ? { ...prev, connected: false } : prev
+      );
+    };
+
+    return () => {
+      eventSource.close();
+    };
+  }, [
+    isWindowOpen,
+    sessionId,
+    currentRoomId,
+    incrementUnread,
+    refreshChannels,
+  ]);
+
+  useEffect(() => {
+    if (username && lastNickRef.current && username !== lastNickRef.current) {
+      setSessionId(null);
+      setChannels([]);
+      setMessagesByRoom({});
+      setCurrentRoomId(null);
+    }
+  }, [username]);
+
+  const handleRoomSelect = useCallback(
+    async (roomId: string | null) => {
+      setCurrentRoomId(roomId);
+      if (roomId) {
+        clearUnread(roomId);
+      }
+      return { hadUnreads: false };
+    },
+    [clearUnread]
+  );
+
+  const sendRoomMessage = useCallback(
+    async (content: string) => {
+      if (!sessionId || !currentRoomId || !content.trim()) return;
+      const response = await fetch("/api/irc/send", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          sessionId,
+          channel: currentRoomId,
+          content: content.trim(),
+        }),
+      });
+      if (!response.ok) {
+        toast.error("Failed to send message", {
+          description: "The IRC server did not accept the message.",
+        });
+      }
+    },
+    [sessionId, currentRoomId]
+  );
+
+  const handleAddRoom = useCallback(
+    async (roomName: string) => {
+      if (!sessionId) {
+        return { ok: false, error: "Not connected to IRC yet." };
+      }
+      const trimmed = roomName.trim();
+      if (!trimmed) {
+        return { ok: false, error: "Channel name is required." };
+      }
+      const response = await fetch("/api/irc/join", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          sessionId,
+          channel: trimmed,
+        }),
+      });
+      if (!response.ok) {
+        return { ok: false, error: "Failed to join channel." };
+      }
+      await refreshChannels();
+      const normalized = trimmed.startsWith("#") ? trimmed : `#${trimmed}`;
+      setCurrentRoomId(normalized);
+      return { ok: true };
+    },
+    [sessionId, refreshChannels]
+  );
+
+  const promptAddRoom = useCallback(() => {
+    setIsNewRoomDialogOpen(true);
+  }, []);
+
+  const promptDeleteRoom = useCallback((room: ChatRoom) => {
+    setRoomToDelete(room);
+    setIsDeleteRoomDialogOpen(true);
+  }, []);
+
+  const confirmDeleteRoom = useCallback(async () => {
+    if (!roomToDelete || !sessionId) return;
+    const response = await fetch("/api/irc/part", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        sessionId,
+        channel: roomToDelete.id,
+      }),
+    });
+    if (response.ok) {
+      if (currentRoomId === roomToDelete.id) {
+        setCurrentRoomId(null);
+      }
+      setIsDeleteRoomDialogOpen(false);
+      setRoomToDelete(null);
+      refreshChannels();
+    } else {
+      toast.error("Failed to leave channel");
+    }
+  }, [roomToDelete, sessionId, currentRoomId, refreshChannels]);
+
+  const currentRoomMessages = currentRoomId
+    ? messagesByRoom[currentRoomId] || []
+    : [];
+
+  const currentRoomMessagesLimited = currentRoomId
+    ? currentRoomMessages.slice(-messageRenderLimit)
+    : [];
+
+  const isConnected = connectionState?.connected ?? false;
+
+  return {
+    username,
+    authToken: null,
+    rooms,
+    currentRoomId,
+    currentRoomMessages,
+    currentRoomMessagesLimited,
+    isSidebarVisible,
+    isAdmin: false,
+    isConnected,
+    handleRoomSelect,
+    sendRoomMessage,
+    toggleSidebarVisibility,
+    handleAddRoom: (
+      roomName: string,
+      _type?: "public" | "private",
+      _members?: string[]
+    ) => handleAddRoom(roomName),
+    promptAddRoom,
+    promptDeleteRoom,
+    isNewRoomDialogOpen,
+    setIsNewRoomDialogOpen,
+    isDeleteRoomDialogOpen,
+    setIsDeleteRoomDialogOpen,
+    roomToDelete,
+    confirmDeleteRoom,
+  };
+}

--- a/src/apps/chats/hooks/useIrcChat.ts
+++ b/src/apps/chats/hooks/useIrcChat.ts
@@ -194,11 +194,13 @@ export function useIrcChat(isWindowOpen: boolean) {
 
   const handleRoomSelect = useCallback(
     async (roomId: string | null) => {
+      const { unreadCounts } = useChatsStore.getState();
+      const hadUnreads = roomId ? (unreadCounts[roomId] || 0) > 0 : false;
       setCurrentRoomId(roomId);
       if (roomId) {
         clearUnread(roomId);
       }
-      return { hadUnreads: false };
+      return { hadUnreads };
     },
     [clearUnread]
   );

--- a/src/apps/chats/hooks/useIrcChat.ts
+++ b/src/apps/chats/hooks/useIrcChat.ts
@@ -101,6 +101,7 @@ export function useIrcChat(isWindowOpen: boolean) {
     lastNickRef.current = nick;
 
     try {
+      setConnectionError(false);
       const channelsToJoin =
         channels.length > 0 ? channels.map((channel) => channel.name) : [DEFAULT_CHANNEL];
       const response = await fetch("/api/irc/connect", {

--- a/src/apps/chats/hooks/useIrcChat.ts
+++ b/src/apps/chats/hooks/useIrcChat.ts
@@ -76,6 +76,7 @@ export function useIrcChat(isWindowOpen: boolean) {
   const lastNickRef = useRef<string | null>(null);
   const reconnectAttemptRef = useRef(0);
   const reconnectTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const allowReconnectRef = useRef(true);
 
   const rooms = useMemo(() => channels.map(mapChannelToRoom), [channels]);
 
@@ -144,6 +145,8 @@ export function useIrcChat(isWindowOpen: boolean) {
   useEffect(() => {
     if (!isWindowOpen || !sessionId) return;
 
+    allowReconnectRef.current = true;
+
     if (eventSourceRef.current) {
       eventSourceRef.current.close();
     }
@@ -194,6 +197,9 @@ export function useIrcChat(isWindowOpen: boolean) {
     };
 
     eventSource.onerror = () => {
+      if (!allowReconnectRef.current) {
+        return;
+      }
       setConnectionState((prev) =>
         prev ? { ...prev, connected: false } : prev
       );
@@ -218,6 +224,7 @@ export function useIrcChat(isWindowOpen: boolean) {
     };
 
     return () => {
+      allowReconnectRef.current = false;
       eventSource.close();
       if (reconnectTimeoutRef.current) {
         clearTimeout(reconnectTimeoutRef.current);

--- a/src/apps/chats/hooks/useIrcChat.ts
+++ b/src/apps/chats/hooks/useIrcChat.ts
@@ -62,6 +62,7 @@ export function useIrcChat(isWindowOpen: boolean) {
   const [connectionState, setConnectionState] =
     useState<IrcConnectionState | null>(null);
   const [connectionError, setConnectionError] = useState(false);
+  const pendingReconnectToastRef = useRef(false);
   const [channels, setChannels] = useState<IrcChannel[]>([]);
   const [currentRoomId, setCurrentRoomId] = useState<string | null>(null);
   const [messagesByRoom, setMessagesByRoom] = useState<
@@ -117,6 +118,10 @@ export function useIrcChat(isWindowOpen: boolean) {
           : data.channels?.[0] || null;
       setCurrentRoomId(nextRoom);
       setConnectionError(false);
+      if (pendingReconnectToastRef.current) {
+        toast.success("IRC reconnected");
+        pendingReconnectToastRef.current = false;
+      }
       reconnectAttemptRef.current = 0;
     } catch (error) {
       toast.error("IRC Connection Failed", {
@@ -193,6 +198,10 @@ export function useIrcChat(isWindowOpen: boolean) {
         prev ? { ...prev, connected: false } : prev
       );
       setConnectionError(true);
+      if (!pendingReconnectToastRef.current) {
+        toast("Reconnecting to IRC…");
+        pendingReconnectToastRef.current = true;
+      }
       eventSource.close();
       if (!reconnectTimeoutRef.current) {
         reconnectAttemptRef.current += 1;

--- a/src/apps/chats/hooks/useIrcChat.ts
+++ b/src/apps/chats/hooks/useIrcChat.ts
@@ -139,12 +139,14 @@ export function useIrcChat(isWindowOpen: boolean) {
     eventSource.onmessage = (event) => {
       const payload = JSON.parse(event.data) as IrcStreamEvent;
       if (payload.type === "state") {
-        setConnectionState(payload.payload.state);
+        const statePayload = payload.payload as { state: IrcConnectionState };
+        setConnectionState(statePayload.state);
         refreshChannels();
         return;
       }
       if (payload.type === "system") {
-        const text = payload.payload.text;
+        const systemPayload = payload.payload as { text: string };
+        const text = systemPayload.text;
         if (text) {
           toast(text);
         }

--- a/src/apps/chats/hooks/useIrcChat.ts
+++ b/src/apps/chats/hooks/useIrcChat.ts
@@ -77,6 +77,7 @@ export function useIrcChat(isWindowOpen: boolean) {
   const reconnectAttemptRef = useRef(0);
   const reconnectTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const allowReconnectRef = useRef(true);
+  const currentRoomIdRef = useRef<string | null>(null);
 
   const rooms = useMemo(() => channels.map(mapChannelToRoom), [channels]);
 
@@ -198,7 +199,8 @@ export function useIrcChat(isWindowOpen: boolean) {
             [chatMessage.roomId]: [...existing, chatMessage],
           };
         });
-        if (currentRoomId && chatMessage.roomId !== currentRoomId) {
+        const activeRoom = currentRoomIdRef.current;
+        if (!activeRoom || chatMessage.roomId !== activeRoom) {
           incrementUnread(chatMessage.roomId);
         }
       }
@@ -242,10 +244,13 @@ export function useIrcChat(isWindowOpen: boolean) {
   }, [
     isWindowOpen,
     sessionId,
-    currentRoomId,
     incrementUnread,
     refreshChannels,
   ]);
+
+  useEffect(() => {
+    currentRoomIdRef.current = currentRoomId;
+  }, [currentRoomId]);
 
   useEffect(() => {
     if (username && lastNickRef.current && username !== lastNickRef.current) {

--- a/src/apps/chats/hooks/useIrcChat.ts
+++ b/src/apps/chats/hooks/useIrcChat.ts
@@ -99,6 +99,7 @@ export function useIrcChat(isWindowOpen: boolean) {
   const handleSessionMissing = useCallback(() => {
     toast("IRC session expired. Reconnecting...");
     setConnectionError(true);
+    setConnectionState(null);
     setSessionId(null);
   }, []);
 

--- a/src/apps/chats/index.tsx
+++ b/src/apps/chats/index.tsx
@@ -22,9 +22,9 @@ export const helpItems = [
   },
   {
     icon: "#️⃣",
-    title: "Join Chat Rooms",
+    title: "Join IRC Channels",
     description:
-      "Connect with others in public chat rooms. Mention @ryo for AI responses.",
+      "Connect with others in IRC channels hosted on irc.pieter.com.",
   },
   {
     icon: "🎤",

--- a/src/lib/locales/en/translation.json
+++ b/src/lib/locales/en/translation.json
@@ -204,7 +204,7 @@
       "loggingIn": "Logging in...",
       "creatingAccount": "Creating...",
       "loginDescription": "Log in to your account",
-      "signupDescription": "Create an account to access chat rooms and save your settings",
+      "signupDescription": "Create an account to access chat channels and save your settings",
       "setPasswordRequired": "Set Password Required",
       "setPasswordRequiredDescription": "You need to set a password before logging out to ensure you can recover your account. Would you like to set a password now?",
       "logOut": "Log Out",

--- a/src/lib/locales/en/translation.json
+++ b/src/lib/locales/en/translation.json
@@ -646,7 +646,7 @@
         "increaseFontSize": "Increase Font Size",
         "decreaseFontSize": "Decrease Font Size",
         "resetFontSize": "Reset Font Size",
-        "showRooms": "Show Rooms",
+        "showRooms": "Show Channels",
         "chatsHelp": "Chats Help",
         "aboutChats": "About Chats"
       },

--- a/src/lib/locales/en/translation.json
+++ b/src/lib/locales/en/translation.json
@@ -638,7 +638,7 @@
         "createAccount": "Create Account...",
         "login": "Login...",
         "chats": "Chats",
-        "newChat": "New Chat...",
+        "newChat": "Join Channel...",
         "sound": "Sound",
         "chatSpeech": "Chat Speech",
         "typingSynth": "Typing Synth",
@@ -664,8 +664,8 @@
           "description": "Ask Ryo to launch or close apps, switch themes, or control iPod playback."
         },
         "joinChatRooms": {
-          "title": "Join Chat Rooms",
-          "description": "Connect with others in public chat rooms. Mention @ryo for AI responses."
+          "title": "Join IRC Channels",
+          "description": "Connect with others in IRC channels hosted on irc.pieter.com."
         },
         "pushToTalk": {
           "title": "Push to Talk",
@@ -692,8 +692,8 @@
         "passwordSetSuccessDescription": "You can now use your password to recover your account",
         "passwordMinLengthError": "Password must be at least 8 characters",
         "passwordSetFailed": "Failed to set password",
-        "newChatTitle": "New Chat",
-        "newChatDescription": "Create a public chat room or start a private conversation",
+        "newChatTitle": "Join Channel",
+        "newChatDescription": "Join an IRC channel to chat with others.",
         "newChatDescriptionPrivate": "Start a private conversation",
         "public": "Public",
         "roomName": "Channel Name",
@@ -702,8 +702,8 @@
         "searchUsernamePlaceholder": "Search username...",
         "creating": "Creating...",
         "cancel": "Cancel",
-        "create": "Create",
-        "failedToCreateRoom": "Failed to create room"
+        "create": "Join",
+        "failedToCreateRoom": "Failed to join channel"
       },
       "status": {
         "loginToRyOS": "Login to ryOS",

--- a/src/lib/locales/en/translation.json
+++ b/src/lib/locales/en/translation.json
@@ -682,9 +682,9 @@
         "saveTranscriptTitle": "Save Transcript",
         "saveTranscriptDescription": "Enter a name for your chat transcript file",
         "leaveConversationTitle": "Leave Conversation",
-        "deleteChatRoomTitle": "Delete Chat Room",
+        "deleteChatRoomTitle": "Leave Channel",
         "leaveConversationDescription": "Are you sure you want to leave \"{{name}}\"? You will no longer see messages in this conversation.",
-        "deleteChatRoomDescription": "Are you sure you want to delete the room \"{{name}}\"? This action cannot be undone.",
+        "deleteChatRoomDescription": "Are you sure you want to leave the channel \"{{name}}\"?",
         "setPasswordTitle": "Set Password",
         "setPasswordDescription": "Set a password to enable account recovery. You can use this password to get a new token if you lose access.",
         "setPasswordButton": "Set Password",
@@ -747,7 +747,7 @@
         "messageUser": "Message {{username}}",
         "newChat": "New Chat",
         "leaveConversation": "Leave conversation",
-        "deleteRoom": "Delete room"
+        "deleteRoom": "Leave channel"
       },
       "sidebar": {
         "chats": "Chats",

--- a/src/lib/locales/en/translation.json
+++ b/src/lib/locales/en/translation.json
@@ -696,8 +696,8 @@
         "newChatDescription": "Create a public chat room or start a private conversation",
         "newChatDescriptionPrivate": "Start a private conversation",
         "public": "Public",
-        "roomName": "Room Name",
-        "roomNamePlaceholder": "general",
+        "roomName": "Channel Name",
+        "roomNamePlaceholder": "ryos",
         "addUsersToPrivateChat": "Add Users to Private Chat",
         "searchUsernamePlaceholder": "Search username...",
         "creating": "Creating...",
@@ -751,7 +751,7 @@
       },
       "sidebar": {
         "chats": "Chats",
-        "rooms": "Rooms",
+        "rooms": "Channels",
         "private": "Private",
         "new": "new",
         "online": "online"

--- a/src/lib/locales/en/translation.json
+++ b/src/lib/locales/en/translation.json
@@ -745,7 +745,7 @@
         "speakMessage": "Speak message",
         "stopSpeech": "Stop speech",
         "messageUser": "Message {{username}}",
-        "newChat": "New Chat",
+        "newChat": "Join channel",
         "leaveConversation": "Leave conversation",
         "deleteRoom": "Leave channel"
       },

--- a/src/types/irc.ts
+++ b/src/types/irc.ts
@@ -1,0 +1,76 @@
+export type IrcMessageType =
+  | "message"
+  | "join"
+  | "part"
+  | "notice"
+  | "action"
+  | "topic"
+  | "nick"
+  | "system";
+
+export interface IrcMessage {
+  id: string;
+  channel: string;
+  nick: string;
+  content: string;
+  timestamp: number;
+  type: IrcMessageType;
+}
+
+export interface IrcChannel {
+  name: string;
+  topic?: string;
+  users: string[];
+  userCount: number;
+}
+
+export interface IrcUser {
+  nick: string;
+  modes?: string[];
+}
+
+export interface IrcConnectionState {
+  connected: boolean;
+  nick: string | null;
+  channels: string[];
+  serverInfo?: {
+    name: string;
+    version?: string;
+  };
+}
+
+export interface IrcConnectRequest {
+  nick: string;
+  channels?: string[];
+}
+
+export interface IrcConnectResponse {
+  sessionId: string;
+  nick: string;
+  channels: string[];
+}
+
+export interface IrcSendRequest {
+  sessionId: string;
+  channel: string;
+  content: string;
+}
+
+export interface IrcJoinRequest {
+  sessionId: string;
+  channel: string;
+}
+
+export interface IrcPartRequest {
+  sessionId: string;
+  channel: string;
+}
+
+export interface IrcChannelsResponse {
+  channels: IrcChannel[];
+}
+
+export interface IrcStreamEvent {
+  type: "message" | "system" | "state";
+  payload: IrcMessage | { state: IrcConnectionState } | { text: string };
+}


### PR DESCRIPTION
Replace the public chat with IRC integration, connecting to `irc.pieter.com:6667`.

This PR introduces a backend IRC gateway with session management and API endpoints for IRC operations (connect, stream, send, join, part, channels). The frontend chat components (`ChatsAppComponent`, `ChatRoomSidebar`, `ChatInput`, `CreateRoomDialog`) have been updated to utilize the new `useIrcChat` hook and interact with the IRC gateway, effectively replacing the previous public chat implementation. `@ryo` mentions are now disabled in IRC rooms.

---
<a href="https://cursor.com/background-agent?bcId=bc-1f4f76de-2b47-48f4-ae48-b3cf0fcb01b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1f4f76de-2b47-48f4-ae48-b3cf0fcb01b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

