### PR TITLE
Ipod karaoke negative offset

### DIFF
--- a/src/apps/ipod/hooks/useIpodLogic.ts
+++ b/src/apps/ipod/hooks/useIpodLogic.ts
@@ -224,6 +224,7 @@ export function useIpodLogic({
   // Track switching state to prevent race conditions
   const isTrackSwitchingRef = useRef(false);
   const trackSwitchTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const autoSeekTimeoutRef = useRef<NodeJS.Timeout | null>(null);
 
   // Menu state
   const initialMenuMode = useMemo(() => {
@@ -423,34 +424,81 @@ export function useIpodLogic({
       if (trackSwitchTimeoutRef.current) {
         clearTimeout(trackSwitchTimeoutRef.current);
       }
+      if (autoSeekTimeoutRef.current) {
+        clearTimeout(autoSeekTimeoutRef.current);
+        autoSeekTimeoutRef.current = null;
+      }
       
       // Check if new track has a negative offset - if so, auto-skip to where lyrics start at 0
       const newTrack = tracks[currentIndex];
       const newLyricOffset = newTrack?.lyricOffset ?? 0;
+      const endTrackSwitch = (delayMs: number) => {
+        if (trackSwitchTimeoutRef.current) {
+          clearTimeout(trackSwitchTimeoutRef.current);
+        }
+        if (delayMs <= 0) {
+          isTrackSwitchingRef.current = false;
+          return;
+        }
+        trackSwitchTimeoutRef.current = setTimeout(() => {
+          isTrackSwitchingRef.current = false;
+        }, delayMs);
+      };
       
       if (newLyricOffset < 0) {
         // For negative offset, seek to the position where lyrics time = 0
         // Formula: lyricsTime = playerTime + (lyricOffset / 1000)
         // When lyricsTime = 0: playerTime = -lyricOffset / 1000
-        const seekTarget = -newLyricOffset / 1000;
-        setElapsedTime(seekTarget);
-        
-        trackSwitchTimeoutRef.current = setTimeout(() => {
-          isTrackSwitchingRef.current = false;
-          // Seek to the position where lyrics start at 0
+        const seekTarget = Math.max(0, -newLyricOffset / 1000);
+        const targetTrackId = newTrack?.id;
+        const startTime = Date.now();
+        const AUTO_SEEK_MAX_WAIT_MS = 8000;
+        const AUTO_SEEK_POLL_MS = 100;
+        setElapsedTime(0);
+
+        const attemptSeek = () => {
+          const currentTrackId = useIpodStore.getState().currentSongId;
+          if (targetTrackId && currentTrackId !== targetTrackId) return;
+
           const activePlayer = isFullScreen ? fullScreenPlayerRef.current : playerRef.current;
-          if (activePlayer) {
-            activePlayer.seekTo(seekTarget);
-            // Show status message for auto-skip
-            showStatus(`▶ ${Math.floor(seekTarget / 60)}:${String(Math.floor(seekTarget % 60)).padStart(2, "0")}`);
+          if (!activePlayer) {
+            if (Date.now() - startTime < AUTO_SEEK_MAX_WAIT_MS) {
+              autoSeekTimeoutRef.current = setTimeout(attemptSeek, AUTO_SEEK_POLL_MS);
+            } else {
+              endTrackSwitch(0);
+            }
+            return;
           }
-        }, 2000);
+
+          const internalPlayer = activePlayer.getInternalPlayer?.();
+          const playerState =
+            internalPlayer && typeof internalPlayer.getPlayerState === "function"
+              ? internalPlayer.getPlayerState()
+              : null;
+          const isReady = playerState === null || (playerState !== -1 && playerState !== 3 && playerState !== 5);
+          if (!isReady) {
+            if (Date.now() - startTime < AUTO_SEEK_MAX_WAIT_MS) {
+              autoSeekTimeoutRef.current = setTimeout(attemptSeek, AUTO_SEEK_POLL_MS);
+            } else {
+              endTrackSwitch(0);
+            }
+            return;
+          }
+
+          activePlayer.seekTo(seekTarget);
+          setElapsedTime(seekTarget);
+          // Show status message for auto-skip
+          showStatus(
+            `▶ ${Math.floor(seekTarget / 60)}:${String(Math.floor(seekTarget % 60)).padStart(2, "0")}`
+          );
+          endTrackSwitch(500);
+        };
+
+        attemptSeek();
       } else {
         // Normal case: start from beginning
         setElapsedTime(0);
-        trackSwitchTimeoutRef.current = setTimeout(() => {
-          isTrackSwitchingRef.current = false;
-        }, 2000);
+        endTrackSwitch(2000);
       }
     }
     prevCurrentIndexRef.current = currentIndex;
@@ -464,6 +512,9 @@ export function useIpodLogic({
       }
       if (trackSwitchTimeoutRef.current) {
         clearTimeout(trackSwitchTimeoutRef.current);
+      }
+      if (autoSeekTimeoutRef.current) {
+        clearTimeout(autoSeekTimeoutRef.current);
       }
     };
   }, []);


### PR DESCRIPTION
Implement readiness-aware auto-seek for negative lyric offsets in iPod and Karaoke to fix incorrect start times.

The previous implementation would attempt to seek immediately after a track switch, which could fail if the player wasn't fully initialized or ready, leading to the track starting from the beginning instead of the intended offset. The new logic polls the player's state to ensure it's ready before performing the seek, ensuring accurate playback for negative offsets.

---
<a href="https://cursor.com/background-agent?bcId=bc-5831a538-3697-4049-b485-f050edd385c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5831a538-3697-4049-b485-f050edd385c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

