### PR TITLE
Window restore animation

### DIFF
--- a/src/components/layout/WindowFrame.tsx
+++ b/src/components/layout/WindowFrame.tsx
@@ -758,6 +758,11 @@ export function WindowFrame({
 
   // Determine animation variants
   const getInitialAnimation = () => {
+    // Skip animation for windows being restored on page load
+    // (skipInitialSound is true when restoring windows from persistence)
+    if (skipInitialSound) {
+      return false;
+    }
     if (shouldAnimateRestore) {
       // Restoring from minimized - animate from dock icon position
       return { 

--- a/src/components/layout/WindowFrame.tsx
+++ b/src/components/layout/WindowFrame.tsx
@@ -758,11 +758,6 @@ export function WindowFrame({
 
   // Determine animation variants
   const getInitialAnimation = () => {
-    // Skip animation for windows being restored on page load
-    // (skipInitialSound is true when restoring windows from persistence)
-    if (skipInitialSound) {
-      return false;
-    }
     if (shouldAnimateRestore) {
       // Restoring from minimized - animate from dock icon position
       return { 
@@ -773,6 +768,16 @@ export function WindowFrame({
       };
     }
     if (isInitialMount) {
+      // Windows restored on page load should animate from dock icon, not launch origin
+      // (skipInitialSound is true when restoring windows from persistence)
+      if (skipInitialSound) {
+        return { 
+          scale: 0.1, 
+          opacity: 0,
+          x: dockIconOffset.x,
+          y: dockIconOffset.y,
+        };
+      }
       // Initial window open - animate from launch origin if available
       if (launchOriginOffset) {
         return { 


### PR DESCRIPTION
Skip initial window animation when restoring windows on load.

---
<a href="https://cursor.com/background-agent?bcId=bc-3c92fe1d-b9c4-4e09-bf6a-6deb3a67bbd8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3c92fe1d-b9c4-4e09-bf6a-6deb3a67bbd8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

