### PR TITLE
Karaoke vortex shader mode

### DIFF
--- a/src/apps/ipod/components/IpodAppComponent.tsx
+++ b/src/apps/ipod/components/IpodAppComponent.tsx
@@ -530,6 +530,16 @@ export function IpodAppComponent({
                     />
                   )}
 
+                  {/* Vortex shader background (fullscreen) */}
+                  {displayMode === DisplayMode.Vortex && tracks[currentIndex] && (
+                    <AmbientBackground
+                      coverUrl={fullscreenCoverUrl}
+                      variant="vortex"
+                      isActive={!!tracks[currentIndex]}
+                      className="fixed inset-0 z-[5]"
+                    />
+                  )}
+
                   {/* Cover overlay: shows when paused (any mode) or always in Cover mode */}
                   <AnimatePresence>
                     {tracks[currentIndex] && fullscreenCoverUrl && (displayMode === DisplayMode.Cover || !isPlaying) && (

--- a/src/apps/ipod/components/IpodMenuBar.tsx
+++ b/src/apps/ipod/components/IpodMenuBar.tsx
@@ -562,6 +562,15 @@ export function IpodMenuBar({
               >
                 {t("apps.ipod.menu.displayLiquid")}
               </MenubarCheckboxItem>
+              <MenubarCheckboxItem
+                checked={displayMode === DisplayMode.Vortex}
+                onCheckedChange={(checked) => {
+                  if (checked) setDisplayMode(DisplayMode.Vortex);
+                }}
+                className="text-md h-6 pr-3"
+              >
+                {t("apps.ipod.menu.displayVortex")}
+              </MenubarCheckboxItem>
             </MenubarSubContent>
           </MenubarSub>
 

--- a/src/apps/ipod/components/IpodScreen.tsx
+++ b/src/apps/ipod/components/IpodScreen.tsx
@@ -324,6 +324,16 @@ export function IpodScreen({
               />
             )}
 
+            {/* Vortex shader background */}
+            {displayMode === DisplayMode.Vortex && (
+              <AmbientBackground
+                coverUrl={coverUrl}
+                variant="vortex"
+                isActive={showVideo}
+                className="absolute inset-0 z-[5]"
+              />
+            )}
+
             {/* Dark overlay when lyrics are shown */}
             {showVideo && shouldShowLyrics && (
               <div className="absolute inset-0 bg-black/30 z-25" />

--- a/src/apps/karaoke/components/KaraokeAppComponent.tsx
+++ b/src/apps/karaoke/components/KaraokeAppComponent.tsx
@@ -389,6 +389,16 @@ export function KaraokeAppComponent({
             />
           )}
 
+          {/* Vortex shader background */}
+          {displayMode === DisplayMode.Vortex && currentTrack && (
+            <AmbientBackground
+              coverUrl={coverUrl}
+              variant="vortex"
+              isActive={!!currentTrack}
+              className="absolute inset-0 z-[5]"
+            />
+          )}
+
           {/* Cover overlay: shows when paused (any mode) or always in Cover mode */}
           <AnimatePresence>
             {currentTrack && coverUrl && (displayMode === DisplayMode.Cover || !isPlaying) && (
@@ -857,6 +867,16 @@ export function KaraokeAppComponent({
                   <AmbientBackground
                     coverUrl={coverUrl}
                     variant="liquid"
+                    isActive={!!currentTrack}
+                    className="fixed inset-0 z-[5]"
+                  />
+                )}
+
+                {/* Vortex shader background (fullscreen) */}
+                {displayMode === DisplayMode.Vortex && currentTrack && (
+                  <AmbientBackground
+                    coverUrl={coverUrl}
+                    variant="vortex"
                     isActive={!!currentTrack}
                     className="fixed inset-0 z-[5]"
                   />

--- a/src/apps/karaoke/components/KaraokeMenuBar.tsx
+++ b/src/apps/karaoke/components/KaraokeMenuBar.tsx
@@ -629,6 +629,15 @@ export function KaraokeMenuBar({
               >
                 {t("apps.ipod.menu.displayLiquid")}
               </MenubarCheckboxItem>
+              <MenubarCheckboxItem
+                checked={displayMode === DisplayMode.Vortex}
+                onCheckedChange={(checked) => {
+                  if (checked) setDisplayMode(DisplayMode.Vortex);
+                }}
+                className="text-md h-6 pr-3"
+              >
+                {t("apps.ipod.menu.displayVortex")}
+              </MenubarCheckboxItem>
             </MenubarSubContent>
           </MenubarSub>
 

--- a/src/components/shared/AmbientBackground.tsx
+++ b/src/components/shared/AmbientBackground.tsx
@@ -4,12 +4,12 @@ import * as THREE from "three";
 /** Duration of crossfade between cover textures (seconds) */
 const CROSSFADE_SECONDS = 1.5;
 
-export type AmbientVariant = "liquid" | "warp";
+export type AmbientVariant = "liquid" | "warp" | "vortex";
 
 interface AmbientBackgroundProps {
   /** URL of the cover art to use as color source */
   coverUrl: string | null;
-  /** Shader variant: "liquid" (Apple Music style) or "warp" (Kali fractal) */
+  /** Shader variant: "liquid" (Apple Music style), "warp" (Kali fractal), or "vortex" (volumetric vortex) */
   variant?: AmbientVariant;
   /** Whether the background should be active/animating */
   isActive?: boolean;
@@ -167,10 +167,97 @@ const warpFragmentShader = `
   }
 `;
 
+// =====================================================================
+// VORTEX – Volumetric raymarched vortex tinted by cover art colors
+// Based on Shadertoy technique: accumulate along ray with noise field
+// =====================================================================
+const vortexFragmentShader = `
+  uniform vec2 resolution;
+  uniform float time;
+  uniform sampler2D coverTextureA;
+  uniform sampler2D coverTextureB;
+  uniform float blendFactor;
+  varying vec2 vUv;
+
+  // 2D rotation matrix
+  vec2 rot(vec2 v, float t) {
+    float s = sin(t), c = cos(t);
+    return mat2(c, -s, s, c) * v;
+  }
+
+  // ACES tonemap (attempt Fitted – Krzysztof Narkowicz)
+  vec3 aces(vec3 c) {
+    mat3 m1 = mat3(
+      0.59719, 0.07600, 0.02840,
+      0.35458, 0.90834, 0.13383,
+      0.04823, 0.01566, 0.83777
+    );
+    mat3 m2 = mat3(
+       1.60475, -0.10208, -0.00327,
+      -0.53108,  1.10813, -0.07276,
+      -0.07367, -0.00605,  1.07602
+    );
+    vec3 v = m1 * c;
+    vec3 a = v * (v + 0.0245786) - 0.000090537;
+    vec3 b = v * (0.983729 * v + 0.4329510) + 0.238081;
+    return m2 * (a / b);
+  }
+
+  // Xor dot noise (compact hash-free 3D noise)
+  float xnoise(vec3 p) {
+    const float PHI = 1.618033988;
+    const mat3 GOLD = mat3(
+      -0.571464913, +0.814921382, +0.096597072,
+      -0.278044873, -0.303026659, +0.911518454,
+      +0.772087367, +0.494042493, +0.399753815
+    );
+    return dot(cos(GOLD * p), sin(PHI * p * GOLD));
+  }
+
+  void main() {
+    float t = time;
+    vec2 uv = gl_FragCoord.xy;
+    vec3 d = normalize(vec3(2.0 * uv - resolution.xy, resolution.y));
+    vec3 p = vec3(0.0, 0.0, t);
+    vec3 l = vec3(0.0);
+
+    for (float i = 0.0; i < 10.0; i += 1.0) {
+      vec3 b = p;
+      b.xy = rot(sin(b.xy), t * 1.5 + b.z * 3.0);
+      float s = 0.001 + abs(xnoise(b * 12.0) / 12.0 - xnoise(b)) * 0.4;
+      s = max(s, 2.0 - length(p.xy));
+      s += abs(p.y * 0.75 + sin(p.z + t * 0.1 + p.x * 1.5)) * 0.2;
+      p += d * s;
+      l += (1.0 + sin(i + length(p.xy * 0.1) + vec3(3.0, 1.5, 1.0))) / s;
+    }
+
+    vec3 col = aces(l * l / 600.0);
+
+    // Sample cover art at a UV derived from ray endpoint for color tinting
+    vec2 texUV = fract(p.xy * 0.02 + 0.5);
+    vec3 coverCol = mix(
+      texture2D(coverTextureA, texUV).rgb,
+      texture2D(coverTextureB, texUV).rgb,
+      blendFactor
+    );
+
+    // Blend volumetric color with cover tint
+    float luma = dot(col, vec3(0.299, 0.587, 0.114));
+    col = mix(col, coverCol * luma * 2.0, 0.45);
+
+    // Boost saturation slightly
+    float gray = dot(col, vec3(0.299, 0.587, 0.114));
+    col = mix(vec3(gray), col, 1.3);
+
+    gl_FragColor = vec4(clamp(col, 0.0, 1.0), 1.0);
+  }
+`;
+
 /**
- * Cover-art visualizer with two shader variants:
+ * Cover-art visualizer with three shader variants:
  * - **liquid**: Apple Music-style smooth noise warping, bloom, swirl
  * - **warp**: Kali-fold fractal producing deep nebula-like color fields
+ * - **vortex**: Volumetric raymarched vortex tinted by cover art colors
  *
  * Dual-texture crossfade handles track transitions smoothly.
  */
@@ -274,7 +361,12 @@ export function AmbientBackground({
     );
     defaultTex.needsUpdate = true;
 
-    const chosenFragment = variant === "warp" ? warpFragmentShader : liquidFragmentShader;
+    const chosenFragment =
+      variant === "warp"
+        ? warpFragmentShader
+        : variant === "vortex"
+          ? vortexFragmentShader
+          : liquidFragmentShader;
 
     const shaderMaterial = new THREE.ShaderMaterial({
       uniforms: {

--- a/src/lib/locales/de/translation.json
+++ b/src/lib/locales/de/translation.json
@@ -1353,6 +1353,7 @@
         "displayCover": "Cover",
         "displayLandscapes": "Landschaften",
         "displayLiquid": "Flüssigkeit",
+        "displayVortex": "Wirbel",
         "displayShader": "Warp",
         "displayVideo": "Video",
         "enableRomanization": "Romanisierung aktivieren",

--- a/src/lib/locales/en/translation.json
+++ b/src/lib/locales/en/translation.json
@@ -1469,6 +1469,7 @@
         "displayLandscapes": "Landscapes",
         "displayShader": "Warp",
         "displayLiquid": "Liquid",
+        "displayVortex": "Vortex",
         "coverFlow": "Cover Flow",
         "classic": "Classic",
         "black": "Black",

--- a/src/lib/locales/es/translation.json
+++ b/src/lib/locales/es/translation.json
@@ -1353,6 +1353,7 @@
         "displayCover": "Portada",
         "displayLandscapes": "Paisajes",
         "displayLiquid": "Líquido",
+        "displayVortex": "Vórtice",
         "displayShader": "Warp",
         "displayVideo": "Vídeo",
         "enableRomanization": "Activar Romanización",

--- a/src/lib/locales/fr/translation.json
+++ b/src/lib/locales/fr/translation.json
@@ -1353,6 +1353,7 @@
         "displayCover": "Pochette",
         "displayLandscapes": "Paysages",
         "displayLiquid": "Liquide",
+        "displayVortex": "Vortex",
         "displayShader": "Warp",
         "displayVideo": "Vidéo",
         "enableRomanization": "Activer la romanisation",

--- a/src/lib/locales/it/translation.json
+++ b/src/lib/locales/it/translation.json
@@ -1353,6 +1353,7 @@
         "displayCover": "Copertina",
         "displayLandscapes": "Paesaggi",
         "displayLiquid": "Liquido",
+        "displayVortex": "Vortice",
         "displayShader": "Warp",
         "displayVideo": "Video",
         "enableRomanization": "Attiva romanizzazione",

--- a/src/lib/locales/ja/translation.json
+++ b/src/lib/locales/ja/translation.json
@@ -1353,6 +1353,7 @@
         "displayCover": "カバー",
         "displayLandscapes": "風景",
         "displayLiquid": "液体",
+        "displayVortex": "ボルテックス",
         "displayShader": "ワープ",
         "displayVideo": "ビデオ",
         "enableRomanization": "読み仮名を有効化",

--- a/src/lib/locales/ko/translation.json
+++ b/src/lib/locales/ko/translation.json
@@ -1353,6 +1353,7 @@
         "displayCover": "커버",
         "displayLandscapes": "풍경",
         "displayLiquid": "액체",
+        "displayVortex": "소용돌이",
         "displayShader": "워프",
         "displayVideo": "비디오",
         "enableRomanization": "발음 표기 활성화",

--- a/src/lib/locales/pt/translation.json
+++ b/src/lib/locales/pt/translation.json
@@ -1353,6 +1353,7 @@
         "displayCover": "Capa",
         "displayLandscapes": "Paisagens",
         "displayLiquid": "Líquido",
+        "displayVortex": "Vórtice",
         "displayShader": "Warp",
         "displayVideo": "Vídeo",
         "enableRomanization": "Ativar Romanização",

--- a/src/lib/locales/ru/translation.json
+++ b/src/lib/locales/ru/translation.json
@@ -1353,6 +1353,7 @@
         "displayCover": "Обложка",
         "displayLandscapes": "Пейзажи",
         "displayLiquid": "Жидкость",
+        "displayVortex": "Вихрь",
         "displayShader": "Варп",
         "displayVideo": "Видео",
         "enableRomanization": "Включить романизацию",

--- a/src/lib/locales/zh-TW/translation.json
+++ b/src/lib/locales/zh-TW/translation.json
@@ -1353,6 +1353,7 @@
         "displayCover": "封面",
         "displayLandscapes": "風景",
         "displayLiquid": "液體",
+        "displayVortex": "漩渦",
         "displayShader": "扭曲",
         "displayVideo": "影片",
         "enableRomanization": "啟用羅馬拼音",

--- a/src/types/lyrics.ts
+++ b/src/types/lyrics.ts
@@ -69,6 +69,8 @@ export enum DisplayMode {
   Shader = "shader",
   /** Show Apple Music-style liquid distortion of cover art */
   Liquid = "liquid",
+  /** Show volumetric vortex shader sampling cover art colors */
+  Vortex = "vortex",
 }
 
 export enum KoreanDisplay {


### PR DESCRIPTION
Adds a new 'Vortex' shader display mode to the karaoke and iPod apps, providing a dynamic, cover-art-integrated volumetric visualizer.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-f5155857-1915-4eed-a6e5-5d3b860b58c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f5155857-1915-4eed-a6e5-5d3b860b58c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

