### PR TITLE
Ipod video display issue

### DIFF
--- a/src/apps/ipod/components/IpodAppComponent.tsx
+++ b/src/apps/ipod/components/IpodAppComponent.tsx
@@ -453,7 +453,7 @@ export function IpodAppComponent({
                 <div className="relative w-full h-full overflow-hidden">
                   <div
                     className="absolute inset-0 w-full h-full"
-                    style={displayMode !== DisplayMode.Video ? { visibility: "hidden", pointerEvents: "none" } : undefined}
+                    style={displayMode !== DisplayMode.Video ? { zIndex: 0, pointerEvents: "none" } : undefined}
                   >
                     <div
                       className="w-full absolute"

--- a/src/apps/ipod/components/IpodScreen.tsx
+++ b/src/apps/ipod/components/IpodScreen.tsx
@@ -258,8 +258,9 @@ export function IpodScreen({
               }
             }}
           >
-            {/* YouTube player - hidden when display mode is not Video (still provides audio) */}
-            <div style={displayMode !== DisplayMode.Video ? { visibility: "hidden", pointerEvents: "none" } : undefined}>
+            {/* YouTube player - stays rendered when display mode is not Video (provides audio);
+                other display mode backgrounds layer on top via z-index */}
+            <div style={displayMode !== DisplayMode.Video ? { pointerEvents: "none" } : undefined}>
               <ReactPlayer
                 ref={playerRef}
                 url={currentTrack.url}

--- a/src/apps/karaoke/components/KaraokeAppComponent.tsx
+++ b/src/apps/karaoke/components/KaraokeAppComponent.tsx
@@ -344,7 +344,7 @@ export function KaraokeAppComponent({
           {currentTrack ? (
             <div
               className="absolute inset-0 overflow-hidden"
-              style={displayMode !== DisplayMode.Video ? { visibility: "hidden", pointerEvents: "none" } : undefined}
+              style={displayMode !== DisplayMode.Video ? { zIndex: 0, pointerEvents: "none" } : undefined}
             >
               <div className="w-full h-[calc(100%+400px)] mt-[-200px]">
                 <ReactPlayer
@@ -828,7 +828,7 @@ export function KaraokeAppComponent({
               <div className="relative w-full h-full overflow-hidden">
                 <div
                   className="absolute inset-0 w-full h-full"
-                  style={displayMode !== DisplayMode.Video ? { visibility: "hidden", pointerEvents: "none" } : undefined}
+                  style={displayMode !== DisplayMode.Video ? { zIndex: 0, pointerEvents: "none" } : undefined}
                 >
                   <div
                     className="w-full absolute"

--- a/src/stores/useIpodStore.ts
+++ b/src/stores/useIpodStore.ts
@@ -607,7 +607,7 @@ export const useIpodStore = create<IpodState>()(
         }
         set((state) => ({ showVideo: !state.showVideo }));
       },
-      setDisplayMode: (mode) => set({ displayMode: mode }),
+      setDisplayMode: (mode) => set({ displayMode: mode, showVideo: true }),
       toggleBacklight: () =>
         set((state) => ({ backlightOn: !state.backlightOn })),
       toggleLcdFilter: () =>


### PR DESCRIPTION
Set `showVideo` to `true` when `setDisplayMode` is called to ensure the iPod display overlay is visible after changing display modes.

Previously, `setDisplayMode` only updated `displayMode` and not `showVideo`. If `showVideo` was `false` (e.g., toggled off by user action), changing the display mode would not make the visual display appear, as the overlay container checks `!showVideo` to hide itself.

---
<p><a href="https://cursor.com/agents/bc-a2acbe83-5331-4543-abfc-0ced911628b2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a2acbe83-5331-4543-abfc-0ced911628b2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

