### PR TITLE
API handler pattern

### DIFF
--- a/_api/_utils/middleware.ts
+++ b/_api/_utils/middleware.ts
@@ -5,10 +5,18 @@
  */
 
 import type { Redis } from "@upstash/redis";
-import type { VercelRequest } from "@vercel/node";
-import { extractAuth, validateAuth } from "./auth/index.js";
+import type { VercelRequest, VercelResponse } from "@vercel/node";
+import { extractAuth, extractAuthNormalized, validateAuth } from "./auth/index.js";
 import type { AuthenticatedUser } from "./auth/index.js";
-import { getEffectiveOrigin, isAllowedOrigin } from "./_cors.js";
+import type { ValidateAuthOptions } from "./auth/index.js";
+import {
+  getEffectiveOrigin,
+  handlePreflight,
+  isAllowedOrigin,
+  setCorsHeaders,
+} from "./_cors.js";
+import type { SetCorsHeadersOptions } from "./_cors.js";
+import { createLogger } from "./_logging.js";
 import * as RateLimit from "./_rate-limit.js";
 import { createRedis } from "./redis.js";
 
@@ -155,6 +163,292 @@ export interface RequestContext {
   redis: ReturnType<typeof createRedis>;
   log: (message: string, data?: unknown) => void;
   logError: (message: string, error?: unknown) => void;
+}
+
+export interface ApiResponseHelpers {
+  readonly sent: boolean;
+  json: (
+    data: unknown,
+    status?: number,
+    headers?: Record<string, string>
+  ) => VercelResponse;
+  ok: (data: unknown, headers?: Record<string, string>) => VercelResponse;
+  error: (
+    message: string,
+    status?: number,
+    extra?: Record<string, unknown>,
+    headers?: Record<string, string>
+  ) => VercelResponse;
+  badRequest: (message?: string) => VercelResponse;
+  unauthorized: (message?: string) => VercelResponse;
+  forbidden: (message?: string) => VercelResponse;
+  methodNotAllowed: () => VercelResponse;
+}
+
+export interface AuthRequireOptions extends ValidateAuthOptions {
+  missingMessage?: string;
+  invalidMessage?: string;
+  missingStatus?: number;
+  invalidStatus?: number;
+}
+
+export interface AuthRequireAdminOptions extends AuthRequireOptions {
+  forbiddenMessage?: string;
+  forbiddenStatus?: number;
+}
+
+export interface ApiRateLimitOptions {
+  key?: string;
+  keyParts?: Array<string | number | null | undefined>;
+  windowSeconds: number;
+  limit: number;
+}
+
+export type ApiRateLimitResult = Awaited<
+  ReturnType<typeof RateLimit.checkCounterLimit>
+>;
+
+export interface ApiHandlerContext extends RequestContext {
+  req: VercelRequest;
+  res: VercelResponse;
+  method: string;
+  startedAt: number;
+  logger: ReturnType<typeof createLogger>;
+  response: ApiResponseHelpers;
+  auth: {
+    extract: () => { username: string | null; token: string | null };
+    validate: (
+      username: string | null | undefined,
+      token: string | null | undefined,
+      options?: ValidateAuthOptions
+    ) => ReturnType<typeof validateAuth>;
+    require: (options?: AuthRequireOptions) => Promise<AuthenticatedUser | null>;
+    requireAdmin: (
+      options?: AuthRequireAdminOptions
+    ) => Promise<AuthenticatedUser | null>;
+  };
+  rateLimit: {
+    check: (options: ApiRateLimitOptions) => Promise<ApiRateLimitResult>;
+  };
+}
+
+export interface ApiHandlerOptions {
+  methods: string[];
+  action?: string | null;
+  cors?: SetCorsHeadersOptions;
+  enforceOriginCheck?: boolean;
+}
+
+function createResponseHelpers(
+  res: VercelResponse,
+  logger: ReturnType<typeof createLogger>,
+  startedAt: number
+): ApiResponseHelpers {
+  let sent = false;
+
+  const json = (
+    data: unknown,
+    status = 200,
+    headers: Record<string, string> = {}
+  ): VercelResponse => {
+    if (sent || res.headersSent) return res;
+    for (const [key, value] of Object.entries(headers)) {
+      res.setHeader(key, value);
+    }
+    logger.response(status, Date.now() - startedAt);
+    sent = true;
+    return res.status(status).json(data);
+  };
+
+  return {
+    get sent() {
+      return sent || res.headersSent;
+    },
+    json,
+    ok: (data, headers = {}) => json(data, 200, headers),
+    error: (message, status = 400, extra = {}, headers = {}) =>
+      json({ error: message, ...extra }, status, headers),
+    badRequest: (message = "Bad request") => json({ error: message }, 400),
+    unauthorized: (message = "Unauthorized") => json({ error: message }, 401),
+    forbidden: (message = "Forbidden") => json({ error: message }, 403),
+    methodNotAllowed: () => json({ error: "Method not allowed" }, 405),
+  };
+}
+
+function resolveRateLimitKey(options: ApiRateLimitOptions): string {
+  if (options.key && options.key.length > 0) return options.key;
+  if (options.keyParts && options.keyParts.length > 0) {
+    return RateLimit.makeKey(
+      options.keyParts.map((part) =>
+        part === null || part === undefined ? "" : String(part)
+      )
+    );
+  }
+  throw new Error("Rate limit key is required");
+}
+
+async function checkRateLimit(
+  logger: ReturnType<typeof createLogger>,
+  options: ApiRateLimitOptions
+): Promise<ApiRateLimitResult> {
+  const key = resolveRateLimitKey(options);
+  const result = await RateLimit.checkCounterLimit({
+    key,
+    windowSeconds: options.windowSeconds,
+    limit: options.limit,
+  });
+
+  if (!result.allowed) {
+    logger.warn("Rate limit exceeded", {
+      key,
+      count: result.count,
+      limit: result.limit,
+      resetSeconds: result.resetSeconds,
+    });
+  }
+
+  return result;
+}
+
+export function createApiHandler(
+  options: ApiHandlerOptions,
+  handler: (ctx: ApiHandlerContext) => Promise<void>
+) {
+  const methods = options.methods.map((method) => method.toUpperCase());
+  const corsMethods = Array.from(new Set([...methods, "OPTIONS"]));
+  const enforceOriginCheck = options.enforceOriginCheck !== false;
+
+  return async function apiHandler(
+    req: VercelRequest,
+    res: VercelResponse
+  ): Promise<void> {
+    const startedAt = Date.now();
+    const requestId = generateRequestId();
+    const logger = createLogger(requestId);
+    const method = (req.method || methods[0] || "GET").toUpperCase();
+    const origin = getEffectiveOrigin(req);
+    const originAllowed = isAllowedOrigin(origin);
+
+    logger.request(method, req.url || "/api", options.action ?? null);
+
+    if (handlePreflight(req, res, { ...options.cors, methods: corsMethods })) {
+      logger.response(res.statusCode || 204, Date.now() - startedAt);
+      return;
+    }
+
+    setCorsHeaders(res, origin, { ...options.cors, methods: corsMethods });
+
+    if (enforceOriginCheck && !originAllowed) {
+      logger.warn("Unauthorized origin", { origin });
+      logger.response(403, Date.now() - startedAt);
+      res.status(403).json({ error: "Unauthorized" });
+      return;
+    }
+
+    if (!methods.includes(method)) {
+      logger.warn("Method not allowed", { method });
+      logger.response(405, Date.now() - startedAt);
+      res.status(405).json({ error: "Method not allowed" });
+      return;
+    }
+
+    const redis = createRedis();
+    const response = createResponseHelpers(res, logger, startedAt);
+
+    const baseContext: RequestContext = {
+      requestId,
+      origin,
+      originAllowed,
+      ip: RateLimit.getClientIp(req),
+      user: null,
+      redis,
+      log: (message, data) => logger.info(message, data),
+      logError: (message, error) => logger.error(message, error),
+    };
+
+    const ctx = {
+      ...baseContext,
+      req,
+      res,
+      method,
+      startedAt,
+      logger,
+      response,
+      auth: {
+        extract: () => extractAuthNormalized(req),
+        validate: (
+          username: string | null | undefined,
+          token: string | null | undefined,
+          validateOptions: ValidateAuthOptions = {}
+        ) => validateAuth(redis, username, token, validateOptions),
+        require: async (requireOptions: AuthRequireOptions = {}) => {
+          const {
+            allowExpired = false,
+            refreshOnGrace = false,
+            missingMessage = "Unauthorized - missing credentials",
+            invalidMessage = "Unauthorized - invalid token",
+            missingStatus = 401,
+            invalidStatus = 401,
+          } = requireOptions;
+
+          const { username, token } = extractAuthNormalized(req);
+
+          if (!username || !token) {
+            response.error(missingMessage, missingStatus);
+            return null;
+          }
+
+          const authResult = await validateAuth(redis, username, token, {
+            allowExpired,
+            refreshOnGrace,
+          });
+
+          if (!authResult.valid) {
+            response.error(invalidMessage, invalidStatus);
+            return null;
+          }
+
+          const user: AuthenticatedUser = {
+            username: username.toLowerCase(),
+            token,
+            expired: authResult.expired,
+          };
+
+          ctx.user = user;
+          return user;
+        },
+        requireAdmin: async (requireOptions: AuthRequireAdminOptions = {}) => {
+          const {
+            forbiddenMessage = "Forbidden - admin access required",
+            forbiddenStatus = 403,
+          } = requireOptions;
+
+          const user = await ctx.auth.require(requireOptions);
+          if (!user) return null;
+
+          if (user.username.toLowerCase() !== "ryo") {
+            response.error(forbiddenMessage, forbiddenStatus);
+            return null;
+          }
+
+          return user;
+        },
+      },
+      rateLimit: {
+        check: (rateLimitOptions: ApiRateLimitOptions) =>
+          checkRateLimit(logger, rateLimitOptions),
+      },
+    } satisfies ApiHandlerContext;
+
+    try {
+      await handler(ctx);
+    } catch (error) {
+      logger.error("Unhandled API error", error);
+      if (!response.sent && !res.headersSent) {
+        response.error("Internal server error", 500);
+      }
+    }
+  };
 }
 
 /**

--- a/_api/auth/login.ts
+++ b/_api/auth/login.ts
@@ -4,8 +4,6 @@
  * Authenticate user with password (Node.js runtime for bcrypt)
  */
 
-import type { VercelRequest, VercelResponse } from "@vercel/node";
-import { Redis } from "@upstash/redis";
 import {
   generateAuthToken,
   storeToken,
@@ -15,7 +13,7 @@ import {
   TOKEN_GRACE_PERIOD,
 } from "../_utils/auth/index.js";
 import { verifyPassword, getUserPasswordHash } from "../_utils/auth/_password.js";
-import { setCorsHeaders } from "../_utils/_cors.js";
+import { createApiHandler } from "../_utils/middleware.js";
 
 export const runtime = "nodejs";
 export const maxDuration = 15;
@@ -26,105 +24,80 @@ interface LoginRequest {
   oldToken?: string;
 }
 
-function getClientIp(req: VercelRequest): string {
-  const forwarded = req.headers["x-forwarded-for"];
-  if (typeof forwarded === "string") {
-    return forwarded.split(",")[0].trim();
-  }
-  if (Array.isArray(forwarded)) {
-    return forwarded[0];
-  }
-  return req.headers["x-real-ip"] as string || "unknown";
-}
-
-export default async function handler(
-  req: VercelRequest,
-  res: VercelResponse
-): Promise<void> {
-  const origin = req.headers.origin as string | undefined;
-  
-  // Handle CORS preflight
-  if (req.method === "OPTIONS") {
-    setCorsHeaders(res, origin, { methods: ["POST", "OPTIONS"] });
-    res.status(204).end();
-    return;
-  }
-
-  setCorsHeaders(res, origin, { methods: ["POST", "OPTIONS"] });
-
-  if (req.method !== "POST") {
-    res.status(405).json({ error: "Method not allowed" });
-    return;
-  }
-
-  const redis = new Redis({
-    url: process.env.REDIS_KV_REST_API_URL!,
-    token: process.env.REDIS_KV_REST_API_TOKEN!,
-  });
-
-  // Rate limiting: 10/min per IP
-  const ip = getClientIp(req);
-  const rlKey = `rl:auth:login:ip:${ip}`;
-  const current = await redis.incr(rlKey);
-  if (current === 1) {
-    await redis.expire(rlKey, 60);
-  }
-  if (current > 10) {
-    res.status(429).json({ error: "Too many login attempts. Please try again later." });
-    return;
-  }
-
-  // Parse body
-  const body = req.body as LoginRequest;
-  const { username: rawUsername, password, oldToken } = body || {};
-
-  if (!rawUsername || typeof rawUsername !== "string") {
-    res.status(400).json({ error: "Username is required" });
-    return;
-  }
-
-  if (!password || typeof password !== "string") {
-    res.status(400).json({ error: "Password is required" });
-    return;
-  }
-
-  const username = rawUsername.toLowerCase();
-  const userKey = `${CHAT_USERS_PREFIX}${username}`;
-
-  // Check if user exists
-  const userData = await redis.get(userKey);
-  if (!userData) {
-    res.status(401).json({ error: "Invalid credentials" });
-    return;
-  }
-
-  // Get and verify password
-  const passwordHash = await getUserPasswordHash(redis, username);
-  if (!passwordHash) {
-    res.status(401).json({ error: "Invalid credentials" });
-    return;
-  }
-
-  const passwordValid = await verifyPassword(password, passwordHash);
-  if (!passwordValid) {
-    res.status(401).json({ error: "Invalid credentials" });
-    return;
-  }
-
-  try {
-    // Handle old token if provided (rotation)
-    if (oldToken) {
-      await storeLastValidToken(redis, username, oldToken, Date.now(), TOKEN_GRACE_PERIOD);
-      await deleteToken(redis, oldToken);
+export default createApiHandler(
+  {
+    methods: ["POST"],
+    action: "auth/login",
+    cors: { methods: ["POST", "OPTIONS"] },
+  },
+  async (ctx): Promise<void> => {
+    // Rate limiting: 10/min per IP
+    const rlResult = await ctx.rateLimit.check({
+      keyParts: ["rl", "auth", "login", "ip", ctx.ip],
+      windowSeconds: 60,
+      limit: 10,
+    });
+    if (!rlResult.allowed) {
+      ctx.response.json(
+        { error: "Too many login attempts. Please try again later." },
+        429
+      );
+      return;
     }
 
-    // Generate new token
-    const token = generateAuthToken();
-    await storeToken(redis, username, token);
+    const body = ctx.req.body as LoginRequest;
+    const { username: rawUsername, password, oldToken } = body || {};
 
-    res.status(200).json({ token, username });
-  } catch (error) {
-    console.error("Error during login:", error);
-    res.status(500).json({ error: "Login failed" });
+    if (!rawUsername || typeof rawUsername !== "string") {
+      ctx.response.badRequest("Username is required");
+      return;
+    }
+
+    if (!password || typeof password !== "string") {
+      ctx.response.badRequest("Password is required");
+      return;
+    }
+
+    const username = rawUsername.toLowerCase();
+    const userKey = `${CHAT_USERS_PREFIX}${username}`;
+
+    const userData = await ctx.redis.get(userKey);
+    if (!userData) {
+      ctx.response.unauthorized("Invalid credentials");
+      return;
+    }
+
+    const passwordHash = await getUserPasswordHash(ctx.redis, username);
+    if (!passwordHash) {
+      ctx.response.unauthorized("Invalid credentials");
+      return;
+    }
+
+    const passwordValid = await verifyPassword(password, passwordHash);
+    if (!passwordValid) {
+      ctx.response.unauthorized("Invalid credentials");
+      return;
+    }
+
+    try {
+      if (oldToken) {
+        await storeLastValidToken(
+          ctx.redis,
+          username,
+          oldToken,
+          Date.now(),
+          TOKEN_GRACE_PERIOD
+        );
+        await deleteToken(ctx.redis, oldToken);
+      }
+
+      const token = generateAuthToken();
+      await storeToken(ctx.redis, username, token);
+
+      ctx.response.ok({ token, username });
+    } catch (error) {
+      ctx.logger.error("Error during login", error);
+      ctx.response.error("Login failed", 500);
+    }
   }
-}
+);

--- a/_api/auth/logout-all.ts
+++ b/_api/auth/logout-all.ts
@@ -4,72 +4,44 @@
  * Node.js runtime with terminal logging
  */
 
-import type { VercelRequest, VercelResponse } from "@vercel/node";
-import { Redis } from "@upstash/redis";
 import { deleteAllUserTokens, validateAuth } from "../_utils/auth/index.js";
-import { initLogger } from "../_utils/_logging.js";
-import { isAllowedOrigin, getEffectiveOrigin, setCorsHeaders } from "../_utils/_cors.js";
+import { createApiHandler } from "../_utils/middleware.js";
 
 export const runtime = "nodejs";
 export const maxDuration = 15;
 
-function createRedis(): Redis {
-  return new Redis({
-    url: process.env.REDIS_KV_REST_API_URL!,
-    token: process.env.REDIS_KV_REST_API_TOKEN!,
-  });
-}
+export default createApiHandler(
+  {
+    methods: ["POST"],
+    action: "auth/logout-all",
+    cors: { methods: ["POST", "OPTIONS"] },
+  },
+  async (ctx): Promise<void> => {
+    const { username, token } = ctx.auth.extract();
+    const authResult = await validateAuth(ctx.redis, username, token, {
+      allowExpired: true,
+    });
 
-export default async function handler(req: VercelRequest, res: VercelResponse): Promise<void> {
-  const { logger } = initLogger();
-  const startTime = Date.now();
-  const origin = getEffectiveOrigin(req);
+    if (!username || !token) {
+      ctx.response.error("Unauthorized - missing credentials", 401);
+      return;
+    }
 
-  logger.request(req.method || "POST", req.url || "/api/auth/logout-all", "logout-all");
+    if (!authResult.valid) {
+      ctx.response.error("Unauthorized - invalid token", 401);
+      return;
+    }
 
-  if (req.method === "OPTIONS") {
-    setCorsHeaders(res, origin, { methods: ["POST", "OPTIONS"] });
-    logger.response(204, Date.now() - startTime);
-    res.status(204).end();
-    return;
+    const deletedCount = await deleteAllUserTokens(
+      ctx.redis,
+      username.toLowerCase()
+    );
+
+    ctx.logger.info("Logged out from all devices", { username, deletedCount });
+    ctx.response.ok({
+      success: true,
+      message: `Logged out from ${deletedCount} devices`,
+      deletedCount,
+    });
   }
-
-  setCorsHeaders(res, origin, { methods: ["POST", "OPTIONS"] });
-
-  if (req.method !== "POST") {
-    logger.response(405, Date.now() - startTime);
-    res.status(405).json({ error: "Method not allowed" });
-    return;
-  }
-
-  if (!isAllowedOrigin(origin)) {
-    logger.response(403, Date.now() - startTime);
-    res.status(403).json({ error: "Unauthorized" });
-    return;
-  }
-
-  const redis = createRedis();
-  const authHeader = req.headers.authorization;
-  const usernameHeader = req.headers["x-username"] as string | undefined;
-  const token = authHeader?.startsWith("Bearer ") ? authHeader.slice(7) : null;
-  const username = usernameHeader || null;
-
-  if (!username || !token) {
-    logger.response(401, Date.now() - startTime);
-    res.status(401).json({ error: "Unauthorized - missing credentials" });
-    return;
-  }
-
-  const authResult = await validateAuth(redis, username, token, { allowExpired: true });
-  if (!authResult.valid) {
-    logger.response(401, Date.now() - startTime);
-    res.status(401).json({ error: "Unauthorized - invalid token" });
-    return;
-  }
-
-  const deletedCount = await deleteAllUserTokens(redis, username.toLowerCase());
-
-  logger.info("Logged out from all devices", { username, deletedCount });
-  logger.response(200, Date.now() - startTime);
-  res.status(200).json({ success: true, message: `Logged out from ${deletedCount} devices`, deletedCount });
-}
+);

--- a/_api/auth/logout.ts
+++ b/_api/auth/logout.ts
@@ -5,73 +5,37 @@
  * Node.js runtime with terminal logging
  */
 
-import type { VercelRequest, VercelResponse } from "@vercel/node";
-import { Redis } from "@upstash/redis";
 import { deleteToken, validateAuth } from "../_utils/auth/index.js";
-import { initLogger } from "../_utils/_logging.js";
-import { isAllowedOrigin, getEffectiveOrigin, setCorsHeaders } from "../_utils/_cors.js";
+import { createApiHandler } from "../_utils/middleware.js";
 
 export const runtime = "nodejs";
 export const maxDuration = 15;
 
-function createRedis(): Redis {
-  return new Redis({
-    url: process.env.REDIS_KV_REST_API_URL!,
-    token: process.env.REDIS_KV_REST_API_TOKEN!,
-  });
-}
+export default createApiHandler(
+  {
+    methods: ["POST"],
+    action: "auth/logout",
+    cors: { methods: ["POST", "OPTIONS"] },
+  },
+  async (ctx): Promise<void> => {
+    const { username, token } = ctx.auth.extract();
+    const authResult = await validateAuth(ctx.redis, username, token, {
+      allowExpired: true,
+    });
 
-export default async function handler(req: VercelRequest, res: VercelResponse): Promise<void> {
-  const { requestId: _requestId, logger } = initLogger();
-  const startTime = Date.now();
-  const origin = getEffectiveOrigin(req);
+    if (!username || !token) {
+      ctx.response.error("Unauthorized - missing credentials", 401);
+      return;
+    }
 
-  logger.request(req.method || "POST", req.url || "/api/auth/logout", "logout");
+    if (!authResult.valid) {
+      ctx.response.error("Unauthorized - invalid token", 401);
+      return;
+    }
 
-  if (req.method === "OPTIONS") {
-    setCorsHeaders(res, origin, { methods: ["POST", "OPTIONS"] });
-    logger.response(204, Date.now() - startTime);
-    res.status(204).end();
-    return;
+    await deleteToken(ctx.redis, token);
+
+    ctx.logger.info("User logged out", { username });
+    ctx.response.ok({ success: true, message: "Logged out successfully" });
   }
-
-  setCorsHeaders(res, origin, { methods: ["POST", "OPTIONS"] });
-
-  if (req.method !== "POST") {
-    logger.response(405, Date.now() - startTime);
-    res.status(405).json({ error: "Method not allowed" });
-    return;
-  }
-
-  if (!isAllowedOrigin(origin)) {
-    logger.response(403, Date.now() - startTime);
-    res.status(403).json({ error: "Unauthorized" });
-    return;
-  }
-
-  const redis = createRedis();
-
-  const authHeader = req.headers.authorization;
-  const usernameHeader = req.headers["x-username"] as string | undefined;
-  const token = authHeader?.startsWith("Bearer ") ? authHeader.slice(7) : null;
-  const username = usernameHeader || null;
-
-  if (!username || !token) {
-    logger.response(401, Date.now() - startTime);
-    res.status(401).json({ error: "Unauthorized - missing credentials" });
-    return;
-  }
-
-  const authResult = await validateAuth(redis, username, token, { allowExpired: true });
-  if (!authResult.valid) {
-    logger.response(401, Date.now() - startTime);
-    res.status(401).json({ error: "Unauthorized - invalid token" });
-    return;
-  }
-
-  await deleteToken(redis, token);
-
-  logger.info("User logged out", { username });
-  logger.response(200, Date.now() - startTime);
-  res.status(200).json({ success: true, message: "Logged out successfully" });
-}
+);

--- a/_api/auth/password/check.ts
+++ b/_api/auth/password/check.ts
@@ -4,88 +4,45 @@
  * Check if user has a password set
  */
 
-import type { VercelRequest, VercelResponse } from "@vercel/node";
-import { Redis } from "@upstash/redis";
 import { userHasPassword, validateAuth } from "../../_utils/auth/index.js";
-import { initLogger } from "../../_utils/_logging.js";
-import { isAllowedOrigin, getEffectiveOrigin, setCorsHeaders } from "../../_utils/_cors.js";
+import { createApiHandler } from "../../_utils/middleware.js";
 
 export const runtime = "nodejs";
 
-// ============================================================================
-// Local Helper Functions
-// ============================================================================
+export default createApiHandler(
+  {
+    methods: ["GET"],
+    action: "auth/password/check",
+    cors: { methods: ["GET", "OPTIONS"] },
+  },
+  async (ctx): Promise<void> => {
+    const { username, token } = ctx.auth.extract();
+    const authResult = await validateAuth(ctx.redis, username, token, {
+      allowExpired: true,
+    });
 
-function createRedis(): Redis {
-  return new Redis({
-    url: process.env.REDIS_KV_REST_API_URL as string,
-    token: process.env.REDIS_KV_REST_API_TOKEN as string,
-  });
-}
+    if (!username || !token) {
+      ctx.logger.warn("Missing credentials");
+      ctx.response.error("Unauthorized - missing credentials", 401);
+      return;
+    }
 
-function extractAuth(req: VercelRequest): { username: string | null; token: string | null } {
-  const authHeader = req.headers.authorization as string | undefined;
-  const usernameHeader = req.headers["x-username"] as string | undefined;
-  const token = authHeader?.startsWith("Bearer ") ? authHeader.slice(7) : null;
-  const username = usernameHeader?.trim().toLowerCase() || null;
-  return { username, token };
-}
+    if (!authResult.valid) {
+      ctx.logger.warn("Invalid token", { username });
+      ctx.response.error("Unauthorized - invalid token", 401);
+      return;
+    }
 
-// ============================================================================
-// Route Handler
-// ============================================================================
+    const normalizedUsername = username.toLowerCase();
+    const hasPassword = await userHasPassword(ctx.redis, normalizedUsername);
 
-export default async function handler(req: VercelRequest, res: VercelResponse) {
-  const { requestId: _requestId, logger } = initLogger();
-  const startTime = Date.now();
-  
-  const origin = getEffectiveOrigin(req);
-  setCorsHeaders(res, origin, { methods: ["GET", "OPTIONS"] });
-  
-  logger.request(req.method || "GET", req.url || "/api/auth/password/check");
-  
-  if (req.method === "OPTIONS") {
-    logger.response(204, Date.now() - startTime);
-    return res.status(204).end();
+    ctx.logger.info("Password check completed", {
+      username: normalizedUsername,
+      hasPassword,
+    });
+    ctx.response.ok({
+      hasPassword,
+      username: normalizedUsername,
+    });
   }
-
-  if (req.method !== "GET") {
-    logger.warn("Method not allowed", { method: req.method });
-    logger.response(405, Date.now() - startTime);
-    return res.status(405).json({ error: "Method not allowed" });
-  }
-
-  if (!isAllowedOrigin(origin)) {
-    logger.warn("Unauthorized origin", { origin });
-    logger.response(403, Date.now() - startTime);
-    return res.status(403).json({ error: "Unauthorized" });
-  }
-
-  const redis = createRedis();
-
-  // Extract and validate auth
-  const { username, token } = extractAuth(req);
-  if (!username || !token) {
-    logger.warn("Missing credentials");
-    logger.response(401, Date.now() - startTime);
-    return res.status(401).json({ error: "Unauthorized - missing credentials" });
-  }
-
-  const authResult = await validateAuth(redis, username, token, { allowExpired: true });
-  if (!authResult.valid) {
-    logger.warn("Invalid token", { username });
-    logger.response(401, Date.now() - startTime);
-    return res.status(401).json({ error: "Unauthorized - invalid token" });
-  }
-
-  // Check if password is set
-  const hasPassword = await userHasPassword(redis, username.toLowerCase());
-
-  logger.info("Password check completed", { username: username.toLowerCase(), hasPassword });
-  logger.response(200, Date.now() - startTime);
-  
-  return res.status(200).json({ 
-    hasPassword,
-    username: username.toLowerCase(),
-  });
-}
+);

--- a/_api/auth/password/set.ts
+++ b/_api/auth/password/set.ts
@@ -4,15 +4,13 @@
  * Set or update user's password (Node.js runtime for bcrypt)
  */
 
-import type { VercelRequest, VercelResponse } from "@vercel/node";
-import { Redis } from "@upstash/redis";
 import {
   validateAuth,
   PASSWORD_MIN_LENGTH,
   PASSWORD_MAX_LENGTH,
 } from "../../_utils/auth/index.js";
 import { hashPassword, setUserPasswordHash } from "../../_utils/auth/_password.js";
-import { setCorsHeaders } from "../../_utils/_cors.js";
+import { createApiHandler } from "../../_utils/middleware.js";
 
 export const runtime = "nodejs";
 export const maxDuration = 15;
@@ -21,86 +19,62 @@ interface SetPasswordRequest {
   password: string;
 }
 
-function extractAuth(req: VercelRequest): { username: string | null; token: string | null } {
-  const authHeader = req.headers.authorization;
-  const usernameHeader = req.headers["x-username"];
-  
-  let token: string | null = null;
-  if (authHeader && typeof authHeader === "string" && authHeader.startsWith("Bearer ")) {
-    token = authHeader.slice(7);
+export default createApiHandler(
+  {
+    methods: ["POST"],
+    action: "auth/password/set",
+    cors: { methods: ["POST", "OPTIONS"] },
+  },
+  async (ctx): Promise<void> => {
+    const { username, token } = ctx.auth.extract();
+    const authResult = await validateAuth(ctx.redis, username, token, {
+      allowExpired: true,
+    });
+
+    if (!username || !token) {
+      ctx.response.error("Unauthorized - missing credentials", 401);
+      return;
+    }
+
+    if (!authResult.valid) {
+      ctx.response.error("Unauthorized - invalid token", 401);
+      return;
+    }
+
+    const body = ctx.req.body as SetPasswordRequest;
+    const { password } = body || {};
+
+    if (!password || typeof password !== "string") {
+      ctx.response.badRequest("Password is required");
+      return;
+    }
+
+    if (password.length < PASSWORD_MIN_LENGTH) {
+      ctx.response.badRequest(
+        `Password must be at least ${PASSWORD_MIN_LENGTH} characters`
+      );
+      return;
+    }
+
+    if (password.length > PASSWORD_MAX_LENGTH) {
+      ctx.response.badRequest(
+        `Password must be ${PASSWORD_MAX_LENGTH} characters or less`
+      );
+      return;
+    }
+
+    try {
+      const passwordHash = await hashPassword(password);
+      await setUserPasswordHash(
+        ctx.redis,
+        username.toLowerCase(),
+        passwordHash
+      );
+
+      ctx.response.ok({ success: true });
+    } catch (error) {
+      ctx.logger.error("Error setting password", error);
+      ctx.response.error("Failed to set password", 500);
+    }
   }
-  
-  const username = typeof usernameHeader === "string" ? usernameHeader : null;
-  
-  return { username, token };
-}
-
-export default async function handler(
-  req: VercelRequest,
-  res: VercelResponse
-): Promise<void> {
-  const origin = req.headers.origin as string | undefined;
-  
-  // Handle CORS preflight
-  if (req.method === "OPTIONS") {
-    setCorsHeaders(res, origin, { methods: ["POST", "OPTIONS"] });
-    res.status(204).end();
-    return;
-  }
-
-  setCorsHeaders(res, origin, { methods: ["POST", "OPTIONS"] });
-
-  if (req.method !== "POST") {
-    res.status(405).json({ error: "Method not allowed" });
-    return;
-  }
-
-  const redis = new Redis({
-    url: process.env.REDIS_KV_REST_API_URL!,
-    token: process.env.REDIS_KV_REST_API_TOKEN!,
-  });
-
-  // Extract and validate auth
-  const { username, token } = extractAuth(req);
-  if (!username || !token) {
-    res.status(401).json({ error: "Unauthorized - missing credentials" });
-    return;
-  }
-
-  const authResult = await validateAuth(redis, username, token, { allowExpired: true });
-  if (!authResult.valid) {
-    res.status(401).json({ error: "Unauthorized - invalid token" });
-    return;
-  }
-
-  // Parse body
-  const body = req.body as SetPasswordRequest;
-  const { password } = body || {};
-
-  // Validate password
-  if (!password || typeof password !== "string") {
-    res.status(400).json({ error: "Password is required" });
-    return;
-  }
-
-  if (password.length < PASSWORD_MIN_LENGTH) {
-    res.status(400).json({ error: `Password must be at least ${PASSWORD_MIN_LENGTH} characters` });
-    return;
-  }
-
-  if (password.length > PASSWORD_MAX_LENGTH) {
-    res.status(400).json({ error: `Password must be ${PASSWORD_MAX_LENGTH} characters or less` });
-    return;
-  }
-
-  try {
-    // Hash and store password
-    const passwordHash = await hashPassword(password);
-    await setUserPasswordHash(redis, username.toLowerCase(), passwordHash);
-
-    res.status(200).json({ success: true });
-  } catch (error) {
-    console.error("Error setting password:", error);
-    res.status(500).json({ error: "Failed to set password" });
-  }
-}
+);

--- a/_api/auth/register.ts
+++ b/_api/auth/register.ts
@@ -4,8 +4,6 @@
  * Create a new user account with password (Node.js runtime for bcrypt)
  */
 
-import type { VercelRequest, VercelResponse } from "@vercel/node";
-import { Redis } from "@upstash/redis";
 import {
   generateAuthToken,
   storeToken,
@@ -15,7 +13,7 @@ import {
 } from "../_utils/auth/index.js";
 import { hashPassword, setUserPasswordHash, verifyPassword, getUserPasswordHash } from "../_utils/auth/_password.js";
 import { isProfaneUsername, assertValidUsername } from "../_utils/_validation.js";
-import { setCorsHeaders } from "../_utils/_cors.js";
+import { createApiHandler } from "../_utils/middleware.js";
 
 export const runtime = "nodejs";
 export const maxDuration = 15;
@@ -25,147 +23,120 @@ interface RegisterRequest {
   password: string;
 }
 
-function getClientIp(req: VercelRequest): string {
-  const forwarded = req.headers["x-forwarded-for"];
-  if (typeof forwarded === "string") {
-    return forwarded.split(",")[0].trim();
-  }
-  if (Array.isArray(forwarded)) {
-    return forwarded[0];
-  }
-  return req.headers["x-real-ip"] as string || "unknown";
-}
-
-export default async function handler(
-  req: VercelRequest,
-  res: VercelResponse
-): Promise<void> {
-  const origin = req.headers.origin as string | undefined;
-  
-  // Handle CORS preflight
-  if (req.method === "OPTIONS") {
-    setCorsHeaders(res, origin, { methods: ["POST", "OPTIONS"] });
-    res.status(204).end();
-    return;
-  }
-
-  setCorsHeaders(res, origin, { methods: ["POST", "OPTIONS"] });
-
-  if (req.method !== "POST") {
-    res.status(405).json({ error: "Method not allowed" });
-    return;
-  }
-
-  const redis = new Redis({
-    url: process.env.REDIS_KV_REST_API_URL!,
-    token: process.env.REDIS_KV_REST_API_TOKEN!,
-  });
-
-  // Rate limiting: 5/min per IP with 24h block on exceed
-  const ip = getClientIp(req);
-  const blockKey = `rl:block:register:ip:${ip}`;
-  const blocked = await redis.get(blockKey);
-  if (blocked) {
-    res.status(429).json({ error: "Too many registration attempts. Please try again later." });
-    return;
-  }
-
-  const rlKey = `rl:auth:register:ip:${ip}`;
-  const current = await redis.incr(rlKey);
-  if (current === 1) {
-    await redis.expire(rlKey, 60);
-  }
-  if (current > 5) {
-    await redis.set(blockKey, "1", { ex: 86400 });
-    res.status(429).json({ error: "Too many registration attempts. Please try again later." });
-    return;
-  }
-
-  // Parse body
-  const body = req.body as RegisterRequest;
-  const { username: rawUsername, password } = body || {};
-
-  // Validate username
-  if (!rawUsername || typeof rawUsername !== "string") {
-    res.status(400).json({ error: "Username is required" });
-    return;
-  }
-
-  try {
-    assertValidUsername(rawUsername, "register");
-  } catch (e) {
-    res.status(400).json({ error: e instanceof Error ? e.message : "Invalid username" });
-    return;
-  }
-
-  if (isProfaneUsername(rawUsername)) {
-    res.status(400).json({ error: "Username contains inappropriate language" });
-    return;
-  }
-
-  // Validate password
-  if (!password || typeof password !== "string") {
-    res.status(400).json({ error: "Password is required" });
-    return;
-  }
-
-  if (password.length < PASSWORD_MIN_LENGTH) {
-    res.status(400).json({ error: `Password must be at least ${PASSWORD_MIN_LENGTH} characters` });
-    return;
-  }
-
-  if (password.length > PASSWORD_MAX_LENGTH) {
-    res.status(400).json({ error: `Password must be ${PASSWORD_MAX_LENGTH} characters or less` });
-    return;
-  }
-
-  const username = rawUsername.toLowerCase();
-  const userKey = `${CHAT_USERS_PREFIX}${username}`;
-
-  // Check if user already exists
-  const existingUser = await redis.get(userKey);
-  if (existingUser) {
-    // User exists - try to log them in with provided password
-    try {
-      const storedHash = await getUserPasswordHash(redis, username);
-      if (storedHash) {
-        const passwordValid = await verifyPassword(password, storedHash);
-        if (passwordValid) {
-          // Password matches - log them in
-          const token = generateAuthToken();
-          await storeToken(redis, username, token);
-          res.status(200).json({ token, user: { username } });
-          return;
-        }
-      }
-    } catch (loginError) {
-      console.error("Error attempting login for existing user:", loginError);
+export default createApiHandler(
+  {
+    methods: ["POST"],
+    action: "auth/register",
+    cors: { methods: ["POST", "OPTIONS"] },
+  },
+  async (ctx): Promise<void> => {
+    const blockKey = `rl:block:register:ip:${ctx.ip}`;
+    const blocked = await ctx.redis.get(blockKey);
+    if (blocked) {
+      ctx.response.json(
+        { error: "Too many registration attempts. Please try again later." },
+        429
+      );
+      return;
     }
-    // Password doesn't match or no password set
-    res.status(409).json({ error: "Username already taken" });
-    return;
+
+    const rlResult = await ctx.rateLimit.check({
+      keyParts: ["rl", "auth", "register", "ip", ctx.ip],
+      windowSeconds: 60,
+      limit: 5,
+    });
+    if (!rlResult.allowed) {
+      await ctx.redis.set(blockKey, "1", { ex: 86400 });
+      ctx.response.json(
+        { error: "Too many registration attempts. Please try again later." },
+        429
+      );
+      return;
+    }
+
+    const body = ctx.req.body as RegisterRequest;
+    const { username: rawUsername, password } = body || {};
+
+    if (!rawUsername || typeof rawUsername !== "string") {
+      ctx.response.badRequest("Username is required");
+      return;
+    }
+
+    try {
+      assertValidUsername(rawUsername, "register");
+    } catch (error) {
+      ctx.response.badRequest(
+        error instanceof Error ? error.message : "Invalid username"
+      );
+      return;
+    }
+
+    if (isProfaneUsername(rawUsername)) {
+      ctx.response.badRequest("Username contains inappropriate language");
+      return;
+    }
+
+    if (!password || typeof password !== "string") {
+      ctx.response.badRequest("Password is required");
+      return;
+    }
+
+    if (password.length < PASSWORD_MIN_LENGTH) {
+      ctx.response.badRequest(
+        `Password must be at least ${PASSWORD_MIN_LENGTH} characters`
+      );
+      return;
+    }
+
+    if (password.length > PASSWORD_MAX_LENGTH) {
+      ctx.response.badRequest(
+        `Password must be ${PASSWORD_MAX_LENGTH} characters or less`
+      );
+      return;
+    }
+
+    const username = rawUsername.toLowerCase();
+    const userKey = `${CHAT_USERS_PREFIX}${username}`;
+
+    const existingUser = await ctx.redis.get(userKey);
+    if (existingUser) {
+      try {
+        const storedHash = await getUserPasswordHash(ctx.redis, username);
+        if (storedHash) {
+          const passwordValid = await verifyPassword(password, storedHash);
+          if (passwordValid) {
+            const token = generateAuthToken();
+            await storeToken(ctx.redis, username, token);
+            ctx.response.json({ token, user: { username } }, 200);
+            return;
+          }
+        }
+      } catch (loginError) {
+        ctx.logger.error("Error attempting login for existing user", loginError);
+      }
+
+      ctx.response.json({ error: "Username already taken" }, 409);
+      return;
+    }
+
+    try {
+      const userData = {
+        username,
+        createdAt: Date.now(),
+        lastActive: Date.now(),
+      };
+      await ctx.redis.set(userKey, JSON.stringify(userData));
+
+      const passwordHash = await hashPassword(password);
+      await setUserPasswordHash(ctx.redis, username, passwordHash);
+
+      const token = generateAuthToken();
+      await storeToken(ctx.redis, username, token);
+
+      ctx.response.json({ token, user: { username } }, 201);
+    } catch (error) {
+      ctx.logger.error("Error creating user", error);
+      ctx.response.error("Failed to create user", 500);
+    }
   }
-
-  try {
-    // Create user
-    const userData = {
-      username,
-      createdAt: Date.now(),
-      lastActive: Date.now(),
-    };
-    await redis.set(userKey, JSON.stringify(userData));
-
-    // Hash and store password
-    const passwordHash = await hashPassword(password);
-    await setUserPasswordHash(redis, username, passwordHash);
-
-    // Generate and store token
-    const token = generateAuthToken();
-    await storeToken(redis, username, token);
-
-    res.status(201).json({ token, user: { username } });
-  } catch (error) {
-    console.error("Error creating user:", error);
-    res.status(500).json({ error: "Failed to create user" });
-  }
-}
+);

--- a/_api/auth/token/verify.ts
+++ b/_api/auth/token/verify.ts
@@ -4,114 +4,68 @@
  * Verify if a token is valid
  */
 
-import type { VercelRequest, VercelResponse } from "@vercel/node";
-import { Redis } from "@upstash/redis";
 import { validateAuth } from "../../_utils/auth/index.js";
 import { isProfaneUsername } from "../../_utils/_validation.js";
-import { initLogger } from "../../_utils/_logging.js";
-import { isAllowedOrigin, getEffectiveOrigin, setCorsHeaders } from "../../_utils/_cors.js";
+import { createApiHandler } from "../../_utils/middleware.js";
 
 export const runtime = "nodejs";
 
-// ============================================================================
-// Local Helper Functions
-// ============================================================================
+export default createApiHandler(
+  {
+    methods: ["POST"],
+    action: "auth/token/verify",
+    cors: { methods: ["POST", "OPTIONS"] },
+  },
+  async (ctx): Promise<void> => {
+    const { username, token } = ctx.auth.extract();
 
-function createRedis(): Redis {
-  return new Redis({
-    url: process.env.REDIS_KV_REST_API_URL as string,
-    token: process.env.REDIS_KV_REST_API_TOKEN as string,
-  });
-}
+    if (!token) {
+      ctx.logger.warn("Missing authorization token");
+      ctx.response.error("Authorization token required", 401);
+      return;
+    }
 
-function extractAuth(req: VercelRequest): { username: string | null; token: string | null } {
-  const authHeader = req.headers.authorization as string | undefined;
-  const usernameHeader = req.headers["x-username"] as string | undefined;
-  const token = authHeader?.startsWith("Bearer ") ? authHeader.slice(7) : null;
-  const username = usernameHeader?.trim() || null;
-  return { username, token };
-}
+    if (!username) {
+      ctx.logger.warn("Missing X-Username header");
+      ctx.response.error("X-Username header required", 400);
+      return;
+    }
 
-// ============================================================================
-// Route Handler
-// ============================================================================
+    if (isProfaneUsername(username)) {
+      ctx.logger.warn("Profane username detected", { username });
+      ctx.response.error("Invalid authentication token", 401);
+      return;
+    }
 
-export default async function handler(req: VercelRequest, res: VercelResponse) {
-  const { requestId: _requestId, logger } = initLogger();
-  const startTime = Date.now();
-  
-  const origin = getEffectiveOrigin(req);
-  setCorsHeaders(res, origin, { methods: ["POST", "OPTIONS"] });
-  
-  logger.request(req.method || "POST", req.url || "/api/auth/token/verify");
-  
-  if (req.method === "OPTIONS") {
-    logger.response(204, Date.now() - startTime);
-    return res.status(204).end();
-  }
+    const result = await validateAuth(ctx.redis, username, token, {
+      allowExpired: true,
+    });
+    if (!result.valid) {
+      ctx.logger.warn("Invalid authentication token", { username });
+      ctx.response.error("Invalid authentication token", 401);
+      return;
+    }
 
-  if (req.method !== "POST") {
-    logger.warn("Method not allowed", { method: req.method });
-    logger.response(405, Date.now() - startTime);
-    return res.status(405).json({ error: "Method not allowed" });
-  }
+    if (result.expired) {
+      ctx.logger.info("Token within grace period", {
+        username: username.toLowerCase(),
+      });
+      ctx.response.ok({
+        valid: true,
+        username: username.toLowerCase(),
+        expired: true,
+        message: "Token is within grace period",
+      });
+      return;
+    }
 
-  if (!isAllowedOrigin(origin)) {
-    logger.warn("Unauthorized origin", { origin });
-    logger.response(403, Date.now() - startTime);
-    return res.status(403).json({ error: "Unauthorized" });
-  }
-
-  const redis = createRedis();
-
-  // Extract auth from headers
-  const { username, token } = extractAuth(req);
-
-  if (!token) {
-    logger.warn("Missing authorization token");
-    logger.response(401, Date.now() - startTime);
-    return res.status(401).json({ error: "Authorization token required" });
-  }
-
-  if (!username) {
-    logger.warn("Missing X-Username header");
-    logger.response(400, Date.now() - startTime);
-    return res.status(400).json({ error: "X-Username header required" });
-  }
-
-  // Check profanity
-  if (isProfaneUsername(username)) {
-    logger.warn("Profane username detected", { username });
-    logger.response(401, Date.now() - startTime);
-    return res.status(401).json({ error: "Invalid authentication token" });
-  }
-
-  // Validate token (allow expired for grace period info)
-  const result = await validateAuth(redis, username, token, { allowExpired: true });
-
-  if (!result.valid) {
-    logger.warn("Invalid authentication token", { username });
-    logger.response(401, Date.now() - startTime);
-    return res.status(401).json({ error: "Invalid authentication token" });
-  }
-
-  if (result.expired) {
-    logger.info("Token within grace period", { username: username.toLowerCase() });
-    logger.response(200, Date.now() - startTime);
-    return res.status(200).json({ 
+    ctx.logger.info("Token verified successfully", {
+      username: username.toLowerCase(),
+    });
+    ctx.response.ok({
       valid: true,
       username: username.toLowerCase(),
-      expired: true,
-      message: "Token is within grace period",
+      message: "Token is valid",
     });
   }
-
-  logger.info("Token verified successfully", { username: username.toLowerCase() });
-  logger.response(200, Date.now() - startTime);
-  
-  return res.status(200).json({ 
-    valid: true,
-    username: username.toLowerCase(),
-    message: "Token is valid",
-  });
-}
+);

--- a/_api/auth/tokens.ts
+++ b/_api/auth/tokens.ts
@@ -4,77 +4,42 @@
  * Node.js runtime with terminal logging
  */
 
-import type { VercelRequest, VercelResponse } from "@vercel/node";
-import { Redis } from "@upstash/redis";
 import { getUserTokens, validateAuth } from "../_utils/auth/index.js";
-import { initLogger } from "../_utils/_logging.js";
-import { isAllowedOrigin, getEffectiveOrigin, setCorsHeaders } from "../_utils/_cors.js";
+import { createApiHandler } from "../_utils/middleware.js";
 
 export const runtime = "nodejs";
 export const maxDuration = 15;
 
-function createRedis(): Redis {
-  return new Redis({
-    url: process.env.REDIS_KV_REST_API_URL!,
-    token: process.env.REDIS_KV_REST_API_TOKEN!,
-  });
-}
+export default createApiHandler(
+  {
+    methods: ["GET"],
+    action: "auth/tokens",
+    cors: { methods: ["GET", "OPTIONS"] },
+  },
+  async (ctx): Promise<void> => {
+    const { username, token: currentToken } = ctx.auth.extract();
+    const authResult = await validateAuth(ctx.redis, username, currentToken, {
+      allowExpired: true,
+    });
 
-export default async function handler(req: VercelRequest, res: VercelResponse): Promise<void> {
-  const { logger } = initLogger();
-  const startTime = Date.now();
-  const origin = getEffectiveOrigin(req);
+    if (!username || !currentToken) {
+      ctx.response.error("Unauthorized - missing credentials", 401);
+      return;
+    }
 
-  logger.request(req.method || "GET", req.url || "/api/auth/tokens", "tokens");
+    if (!authResult.valid) {
+      ctx.response.error("Unauthorized - invalid token", 401);
+      return;
+    }
 
-  if (req.method === "OPTIONS") {
-    setCorsHeaders(res, origin, { methods: ["GET", "OPTIONS"] });
-    logger.response(204, Date.now() - startTime);
-    res.status(204).end();
-    return;
+    const tokens = await getUserTokens(ctx.redis, username.toLowerCase());
+    const tokenList = tokens.map((tokenInfo) => ({
+      maskedToken: `...${tokenInfo.token.slice(-8)}`,
+      createdAt: tokenInfo.createdAt,
+      isCurrent: tokenInfo.token === currentToken,
+    }));
+
+    ctx.logger.info("Listed tokens", { username, count: tokenList.length });
+    ctx.response.ok({ tokens: tokenList, count: tokenList.length });
   }
-
-  setCorsHeaders(res, origin, { methods: ["GET", "OPTIONS"] });
-
-  if (req.method !== "GET") {
-    logger.response(405, Date.now() - startTime);
-    res.status(405).json({ error: "Method not allowed" });
-    return;
-  }
-
-  if (!isAllowedOrigin(origin)) {
-    logger.response(403, Date.now() - startTime);
-    res.status(403).json({ error: "Unauthorized" });
-    return;
-  }
-
-  const redis = createRedis();
-  const authHeader = req.headers.authorization;
-  const usernameHeader = req.headers["x-username"] as string | undefined;
-  const currentToken = authHeader?.startsWith("Bearer ") ? authHeader.slice(7) : null;
-  const username = usernameHeader || null;
-
-  if (!username || !currentToken) {
-    logger.response(401, Date.now() - startTime);
-    res.status(401).json({ error: "Unauthorized - missing credentials" });
-    return;
-  }
-
-  const authResult = await validateAuth(redis, username, currentToken, { allowExpired: true });
-  if (!authResult.valid) {
-    logger.response(401, Date.now() - startTime);
-    res.status(401).json({ error: "Unauthorized - invalid token" });
-    return;
-  }
-
-  const tokens = await getUserTokens(redis, username.toLowerCase());
-  const tokenList = tokens.map((t) => ({
-    maskedToken: `...${t.token.slice(-8)}`,
-    createdAt: t.createdAt,
-    isCurrent: t.token === currentToken,
-  }));
-
-  logger.info("Listed tokens", { username, count: tokenList.length });
-  logger.response(200, Date.now() - startTime);
-  res.status(200).json({ tokens: tokenList, count: tokenList.length });
-}
+);

--- a/_api/users/index.ts
+++ b/_api/users/index.ts
@@ -4,56 +4,36 @@
  * Node.js runtime with terminal logging
  */
 
-import type { VercelRequest, VercelResponse } from "@vercel/node";
 import { handleGetUsers } from "../rooms/_helpers/_users.js";
-import { isAllowedOrigin, getEffectiveOrigin, setCorsHeaders } from "../_utils/_cors.js";
-import { initLogger } from "../_utils/_logging.js";
+import { createApiHandler } from "../_utils/middleware.js";
 
 export const runtime = "nodejs";
 export const maxDuration = 15;
 
-export default async function handler(req: VercelRequest, res: VercelResponse): Promise<void> {
-  const { logger } = initLogger();
-  const startTime = Date.now();
-  const origin = getEffectiveOrigin(req);
+export default createApiHandler(
+  {
+    methods: ["GET"],
+    action: "users/search",
+    cors: { methods: ["GET", "OPTIONS"], headers: ["Content-Type"] },
+  },
+  async (ctx): Promise<void> => {
+    const searchQuery = (ctx.req.query.search as string) || "";
 
-  logger.request(req.method || "GET", req.url || "/api/users", "users");
+    try {
+      const response = await handleGetUsers("users-search", searchQuery);
+      const data = (await response.json()) as {
+        users?: unknown[];
+        [key: string]: unknown;
+      };
 
-  if (req.method === "OPTIONS") {
-    res.setHeader("Content-Type", "application/json");
-    setCorsHeaders(res, origin, { methods: ["GET", "OPTIONS"], headers: ["Content-Type"] });
-    logger.response(204, Date.now() - startTime);
-    res.status(204).end();
-    return;
+      ctx.logger.info("Users searched", {
+        query: searchQuery,
+        count: data.users?.length || 0,
+      });
+      ctx.response.json(data, response.status);
+    } catch (error) {
+      ctx.logger.error("Error searching users", error);
+      ctx.response.error("Failed to search users", 500);
+    }
   }
-
-  res.setHeader("Content-Type", "application/json");
-  setCorsHeaders(res, origin, { methods: ["GET", "OPTIONS"], headers: ["Content-Type"] });
-
-  if (!isAllowedOrigin(origin)) {
-    logger.response(403, Date.now() - startTime);
-    res.status(403).json({ error: "Unauthorized" });
-    return;
-  }
-
-  if (req.method !== "GET") {
-    logger.response(405, Date.now() - startTime);
-    res.status(405).json({ error: "Method not allowed" });
-    return;
-  }
-
-  const searchQuery = (req.query.search as string) || "";
-
-  try {
-    const response = await handleGetUsers("users-search", searchQuery);
-    const data = await response.json();
-    
-    logger.info("Users searched", { query: searchQuery, count: data.users?.length || 0 });
-    logger.response(response.status, Date.now() - startTime);
-    res.status(response.status).json(data);
-  } catch (error) {
-    logger.error("Error searching users", error);
-    logger.response(500, Date.now() - startTime);
-    res.status(500).json({ error: "Failed to search users" });
-  }
-}
+);


### PR DESCRIPTION
Standardize the API layer on one handler pattern to lower maintenance cost and simplify platform-wide hardening.

This PR introduces a unified `createApiHandler` in `_api/_utils/middleware.ts` that provides a shared request context, auth, response, and rate-limit path, and migrates auth, sync, and user-search endpoints to use it.

---
<p><a href="https://cursor.com/agents/bc-fefe6740-2512-4f40-af00-7f644f7e8371"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fefe6740-2512-4f40-af00-7f644f7e8371"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

