### PR TITLE
Placeholder menu bar loading

### DIFF
--- a/src/apps/base/AppManager.tsx
+++ b/src/apps/base/AppManager.tsx
@@ -68,8 +68,11 @@ export function AppManager({ apps }: AppManagerProps) {
   // For Mac/System7 themes, hide the desktop menubar when there's a foreground app
   // For XP/98, the menubar is actually a taskbar and should always show
   // Always show menubar in expose mode
-  const hasForegroundApp = !!foregroundInstanceId;
-  const showDesktopMenuBar = isXpTheme || !hasForegroundApp || exposeMode;
+  // If the foreground instance is still loading (lazy), show the desktop menubar
+  // as a placeholder since the loading app can't render its own menu bar yet
+  const foregroundInstance = foregroundInstanceId ? instances[foregroundInstanceId] : null;
+  const foregroundIsLoaded = !!foregroundInstance && !foregroundInstance.isLoading;
+  const showDesktopMenuBar = isXpTheme || !foregroundIsLoaded || exposeMode;
 
   const [isInitialMount, setIsInitialMount] = useState(true);
   const [isExposeViewOpen, setIsExposeViewOpen] = useState(false);

--- a/src/components/layout/MenuBar.tsx
+++ b/src/components/layout/MenuBar.tsx
@@ -927,7 +927,9 @@ export function MenuBar({ children, inWindowFrame = false }: MenuBarProps) {
   const debugMode = useDisplaySettingsStoreShallow((s) => s.debugMode);
 
   const foregroundInstance = getForegroundInstance();
-  const hasActiveApp = !!foregroundInstance;
+  // Treat a still-loading foreground instance as "no active app" so the
+  // Finder/default menu bar shows as a placeholder during lazy load
+  const hasActiveApp = !!foregroundInstance && !foregroundInstance.isLoading;
 
   // Get current theme
   const currentTheme = useThemeStore((state) => state.current);


### PR DESCRIPTION
Treat a loading app instance as "no active app" to ensure the desktop menu bar (Finder/default) shows as a placeholder during app loading.

Previously, if `foregroundInstanceId` pointed to a lazy-loading instance, the desktop menu bar was hidden (assuming an app was foregrounded) but the loading app couldn't render its own menu bar yet, resulting in no menu bar being displayed. This change ensures a consistent placeholder.

---
<p><a href="https://cursor.com/agents/bc-280679b6-fcea-4558-ab41-eae3aded9002"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-280679b6-fcea-4558-ab41-eae3aded9002"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

