### PR TITLE
Increase vertical padding/gap between file icons in Finder icon view and desktop

### DIFF
--- a/src/apps/finder/components/FileIcon.tsx
+++ b/src/apps/finder/components/FileIcon.tsx
@@ -283,7 +283,7 @@ export function FileIcon({
   return (
     <div
       className={`flex flex-col items-center justify-start cursor-default ${
-        isMacOSXTheme ? "gap-0 pb-1" : "gap-0"
+        isMacOSXTheme ? "gap-0 pb-2" : "gap-0 pb-1"
       } ${sizes.container} ${className}`}
       onDoubleClick={handleDoubleClick}
       onClick={handleClick}

--- a/src/apps/finder/components/FileList.tsx
+++ b/src/apps/finder/components/FileList.tsx
@@ -759,7 +759,7 @@ export function FileList({
         viewType === "large"
           ? "grid-cols-[repeat(auto-fit,minmax(96px,1fr))]"
           : "grid-cols-[repeat(auto-fit,minmax(80px,1fr))]"
-      } gap-x-2 gap-y-1 p-2 min-h-[150px] ${
+      } gap-x-2 gap-y-3 p-2 min-h-[150px] ${
         files.length <= 1 ? "justify-items-start" : "justify-items-center"
       }`}
       onDragOver={handleContainerDragOver}

--- a/src/components/layout/Desktop.tsx
+++ b/src/components/layout/Desktop.tsx
@@ -732,8 +732,8 @@ export function Desktop({
         <div
           className={
             isXpTheme
-              ? "flex flex-col flex-wrap justify-start content-start h-full gap-y-0 gap-x-px"
-              : "flex flex-col flex-wrap-reverse justify-start content-start h-full gap-y-0 gap-x-px"
+              ? "flex flex-col flex-wrap justify-start content-start h-full gap-y-2 gap-x-px"
+              : "flex flex-col flex-wrap-reverse justify-start content-start h-full gap-y-2 gap-x-px"
           }
         >
           <FileIcon


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Increases the vertical spacing between file icons in both the Finder icon view grid and the desktop icon layout for a less cramped appearance.

## Changes

- **Finder icon view** (`FileList.tsx`): `gap-y-1` (4px) → `gap-y-3` (12px) between grid rows
- **Desktop icons** (`Desktop.tsx`): `gap-y-0` → `gap-y-2` (8px) between flex items (both XP and macOS layouts)
- **FileIcon** (`FileIcon.tsx`): Increased bottom padding — macOS theme `pb-1` → `pb-2`, other themes gain `pb-1`

## Testing

- Verified build passes (`bun run build`)
- Manually tested in browser — desktop icons and Finder icon view both show increased vertical spacing
<!-- CURSOR_AGENT_PR_BODY_END -->

---
<p><a href="https://cursor.com/agents/bc-eef4449b-1582-4345-9702-a6064b479ed2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eef4449b-1582-4345-9702-a6064b479ed2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

