### PR TITLE
perf: reduce Karaoke and iPod profiling hotspots

### DIFF
--- a/src/apps/ipod/components/IpodAppComponent.tsx
+++ b/src/apps/ipod/components/IpodAppComponent.tsx
@@ -27,6 +27,8 @@ import { AmbientBackground } from "@/components/shared/AmbientBackground";
 import { MeshGradientBackground } from "@/components/shared/MeshGradientBackground";
 import { WaterBackground } from "@/components/shared/WaterBackground";
 
+const PLAYER_PROGRESS_INTERVAL_MS = 250;
+
 export function IpodAppComponent({
   isWindowOpen,
   onClose,
@@ -475,7 +477,7 @@ export function IpodAppComponent({
                             loop={loopCurrent}
                             onEnded={handleTrackEnd}
                             onProgress={handleProgress}
-                            progressInterval={100}
+                            progressInterval={PLAYER_PROGRESS_INTERVAL_MS}
                             onDuration={handleDuration}
                             onPlay={handlePlay}
                             onPause={handlePause}

--- a/src/apps/ipod/components/IpodScreen.tsx
+++ b/src/apps/ipod/components/IpodScreen.tsx
@@ -34,6 +34,9 @@ const menuVariants = {
   }),
 };
 
+const PLAYER_PROGRESS_INTERVAL_MS = 250;
+const MENU_SCROLL_RETRY_DELAYS_MS = [80, 200, 400] as const;
+
 export function IpodScreen({
   currentTrack,
   isPlaying,
@@ -97,6 +100,7 @@ export function IpodScreen({
   const menuScrollRef = useRef<HTMLDivElement>(null);
   const menuItemsRef = useRef<(HTMLDivElement | null)[]>([]);
   const needScrollRef = useRef(false);
+  const scrollRetryTimeoutsRef = useRef<number[]>([]);
 
   const masterVolume = useAudioSettingsStore((s) => s.masterVolume);
   const finalIpodVolume = ipodVolume * masterVolume;
@@ -120,9 +124,7 @@ export function IpodScreen({
   const forceScrollToSelected = useCallback(() => {
     if (!menuMode || menuHistory.length === 0) return;
 
-    const container = document.querySelector(
-      ".ipod-menu-container"
-    ) as HTMLElement;
+    const container = menuScrollRef.current;
     if (!container) return;
 
     const menuItems = Array.from(container.querySelectorAll(".ipod-menu-item"));
@@ -170,20 +172,28 @@ export function IpodScreen({
 
   // Trigger scroll on various conditions
   useEffect(() => {
-    if (menuMode && menuHistory.length > 0) {
-      needScrollRef.current = true;
-      forceScrollToSelected();
+    if (!menuMode || menuHistory.length === 0) return;
+    needScrollRef.current = true;
+    forceScrollToSelected();
+  }, [menuMode, selectedMenuItem, menuHistory.length, forceScrollToSelected]);
 
-      const attempts = [50, 100, 250, 500, 1000];
-      attempts.forEach((delay) => {
-        setTimeout(() => {
-          if (needScrollRef.current) {
-            forceScrollToSelected();
-          }
-        }, delay);
-      });
-    }
-  }, [menuMode, selectedMenuItem, menuHistory, forceScrollToSelected]);
+  // Retry scroll briefly after menu transitions/mounting settle.
+  useEffect(() => {
+    if (!menuMode || menuHistory.length === 0) return;
+    scrollRetryTimeoutsRef.current.forEach((id) => window.clearTimeout(id));
+    scrollRetryTimeoutsRef.current = MENU_SCROLL_RETRY_DELAYS_MS.map((delay) =>
+      window.setTimeout(() => {
+        if (needScrollRef.current) {
+          forceScrollToSelected();
+        }
+      }, delay)
+    );
+
+    return () => {
+      scrollRetryTimeoutsRef.current.forEach((id) => window.clearTimeout(id));
+      scrollRetryTimeoutsRef.current = [];
+    };
+  }, [menuMode, menuHistory.length, forceScrollToSelected]);
 
   // Prepare for a newly opened menu
   useEffect(() => {
@@ -276,7 +286,7 @@ export function IpodScreen({
                 loop={loopCurrent}
                 volume={finalIpodVolume}
                 playsinline={true}
-                progressInterval={100}
+                progressInterval={PLAYER_PROGRESS_INTERVAL_MS}
                 config={{
                   youtube: {
                     playerVars: {

--- a/src/apps/ipod/hooks/useIpodLogic.ts
+++ b/src/apps/ipod/hooks/useIpodLogic.ts
@@ -50,6 +50,9 @@ export interface UseIpodLogicOptions {
   instanceId: string | undefined;
 }
 
+const ACTIVITY_TIMESTAMP_SYNC_INTERVAL_MS = 120;
+const ELAPSED_TIME_STORE_SYNC_INTERVAL_MS = 500;
+
 export function useIpodLogic({
   isWindowOpen,
   isForeground,
@@ -197,6 +200,8 @@ export function useIpodLogic({
 
   // Status management
   const [lastActivityTime, setLastActivityTime] = useState(Date.now());
+  const lastActivityTimeRef = useRef(lastActivityTime);
+  const lastActivitySyncRef = useRef(0);
   const backlightTimerRef = useRef<NodeJS.Timeout | null>(null);
   const [statusMessage, setStatusMessage] = useState<string | null>(null);
   const statusTimeoutRef = useRef<NodeJS.Timeout | null>(null);
@@ -220,6 +225,7 @@ export function useIpodLogic({
   const [totalTime, setTotalTime] = useState(0);
   const playerRef = useRef<ReactPlayer | null>(null);
   const fullScreenPlayerRef = useRef<ReactPlayer | null>(null);
+  const lastElapsedStoreSyncRef = useRef(0);
   const lastTrackedSongRef = useRef<{ trackId: string; elapsedTime: number } | null>(null);
   const skipOperationRef = useRef(false);
   const coverFlowRef = useRef<CoverFlowRef | null>(null);
@@ -294,7 +300,12 @@ export function useIpodLogic({
   }, [showStatus, t]);
 
   const registerActivity = useCallback(() => {
-    setLastActivityTime(Date.now());
+    const now = Date.now();
+    if (now - lastActivitySyncRef.current >= ACTIVITY_TIMESTAMP_SYNC_INTERVAL_MS) {
+      lastActivitySyncRef.current = now;
+      setLastActivityTime(now);
+      lastActivityTimeRef.current = now;
+    }
     userHasInteractedRef.current = true;
     if (!useIpodStore.getState().backlightOn) {
       toggleBacklight();
@@ -382,6 +393,10 @@ export function useIpodLogic({
 
   // Backlight timer
   useEffect(() => {
+    lastActivityTimeRef.current = lastActivityTime;
+  }, [lastActivityTime]);
+
+  useEffect(() => {
     if (backlightTimerRef.current) {
       clearTimeout(backlightTimerRef.current);
     }
@@ -391,7 +406,7 @@ export function useIpodLogic({
         const currentShowVideo = useIpodStore.getState().showVideo;
         const currentIsPlaying = useIpodStore.getState().isPlaying;
         if (
-          Date.now() - lastActivityTime >= BACKLIGHT_TIMEOUT_MS &&
+          Date.now() - lastActivityTimeRef.current >= BACKLIGHT_TIMEOUT_MS &&
           !(currentShowVideo && currentIsPlaying)
         ) {
           toggleBacklight();
@@ -961,7 +976,11 @@ export function useIpodLogic({
 
   const handleProgress = useCallback((state: { playedSeconds: number }) => {
     setElapsedTime(state.playedSeconds);
-    useIpodStore.getState().setElapsedTime(state.playedSeconds);
+    const now = performance.now();
+    if (now - lastElapsedStoreSyncRef.current >= ELAPSED_TIME_STORE_SYNC_INTERVAL_MS) {
+      lastElapsedStoreSyncRef.current = now;
+      useIpodStore.getState().setElapsedTime(state.playedSeconds);
+    }
   }, []);
 
   const handleDuration = useCallback((duration: number) => {

--- a/src/apps/karaoke/components/KaraokeAppComponent.tsx
+++ b/src/apps/karaoke/components/KaraokeAppComponent.tsx
@@ -31,6 +31,8 @@ import { AmbientBackground } from "@/components/shared/AmbientBackground";
 import { MeshGradientBackground } from "@/components/shared/MeshGradientBackground";
 import { WaterBackground } from "@/components/shared/WaterBackground";
 
+const PLAYER_PROGRESS_INTERVAL_MS = 250;
+
 export function KaraokeAppComponent({
   isWindowOpen,
   onClose,
@@ -128,6 +130,7 @@ export function KaraokeAppComponent({
     showStatus,
     showOfflineStatus,
     restartAutoHideTimer,
+    restartAutoHideTimerFromPointerMove,
     registerActivity,
     handlePrevious,
     handlePlayPause,
@@ -253,7 +256,7 @@ export function KaraokeAppComponent({
         <div
           className="relative w-full h-full bg-black select-none overflow-hidden @container"
           onMouseMove={(e) => {
-            restartAutoHideTimer();
+            restartAutoHideTimerFromPointerMove();
             // Cancel long press if moved too far from start position
             if (longPressStartPos.current && screenLongPressTimerRef.current) {
               const dx = e.clientX - longPressStartPos.current.x;
@@ -300,6 +303,7 @@ export function KaraokeAppComponent({
             }, 500);
           }}
           onTouchMove={(e) => {
+            restartAutoHideTimerFromPointerMove();
             // Cancel long press if moved too far from start position
             if (longPressStartPos.current && screenLongPressTimerRef.current) {
               const touch = e.touches[0];
@@ -358,7 +362,7 @@ export function KaraokeAppComponent({
                   onEnded={handleTrackEnd}
                   onProgress={handleProgress}
                   onDuration={setDuration}
-                  progressInterval={100}
+                  progressInterval={PLAYER_PROGRESS_INTERVAL_MS}
                   onPlay={handlePlay}
                   onPause={handleMainPlayerPause}
                   onReady={!isFullScreen ? handleReady : undefined}
@@ -851,7 +855,7 @@ export function KaraokeAppComponent({
                           loop={loopCurrent}
                           onEnded={handleTrackEnd}
                           onProgress={handleProgress}
-                          progressInterval={100}
+                          progressInterval={PLAYER_PROGRESS_INTERVAL_MS}
                           onPlay={handlePlay}
                           onPause={handlePause}
                           onReady={isFullScreen ? handleReady : undefined}

--- a/src/apps/karaoke/hooks/useKaraokeLogic.ts
+++ b/src/apps/karaoke/hooks/useKaraokeLogic.ts
@@ -42,6 +42,9 @@ export interface UseKaraokeLogicOptions {
   instanceId: string | undefined;
 }
 
+const AUTO_HIDE_ACTIVITY_THROTTLE_MS = 120;
+const ELAPSED_TIME_STORE_SYNC_INTERVAL_MS = 500;
+
 export function useKaraokeLogic({
   isWindowOpen,
   isForeground,
@@ -247,7 +250,10 @@ export function useKaraokeLogic({
   const [statusMessage, setStatusMessage] = useState<string | null>(null);
   const statusTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const [showControls, setShowControls] = useState(true);
+  const showControlsRef = useRef(true);
   const hideControlsTimeoutRef = useRef<number | null>(null);
+  const lastAutoHideActivityRef = useRef(0);
+  const lastElapsedStoreSyncRef = useRef(0);
 
   // Track switching state to prevent race conditions
   const isTrackSwitchingRef = useRef(false);
@@ -419,17 +425,30 @@ export function useKaraokeLogic({
 
   // Auto-hide controls
   const restartAutoHideTimer = useCallback(() => {
-    setShowControls(true);
+    if (!showControlsRef.current) {
+      showControlsRef.current = true;
+      setShowControls(true);
+    }
     if (hideControlsTimeoutRef.current) {
       clearTimeout(hideControlsTimeoutRef.current);
     }
     // Don't auto-hide when sync mode is open
     if (isPlaying && !anyMenuOpen && !isSyncModeOpen) {
       hideControlsTimeoutRef.current = window.setTimeout(() => {
+        showControlsRef.current = false;
         setShowControls(false);
       }, 3000);
     }
   }, [isPlaying, anyMenuOpen, isSyncModeOpen]);
+
+  const restartAutoHideTimerFromPointerMove = useCallback(() => {
+    const now = performance.now();
+    if (now - lastAutoHideActivityRef.current < AUTO_HIDE_ACTIVITY_THROTTLE_MS) {
+      return;
+    }
+    lastAutoHideActivityRef.current = now;
+    restartAutoHideTimer();
+  }, [restartAutoHideTimer]);
 
   // Register activity (for full screen portal)
   const registerActivity = useCallback(() => {
@@ -482,9 +501,16 @@ export function useKaraokeLogic({
   }, [isOffline, showOfflineStatus, nextTrack, showStatus, startTrackSwitch]);
 
   useEffect(() => {
+    showControlsRef.current = showControls;
+  }, [showControls]);
+
+  useEffect(() => {
     // Always show controls when not playing, menu is open, or sync mode is open
     if (!isPlaying || anyMenuOpen || isSyncModeOpen) {
-      setShowControls(true);
+      if (!showControlsRef.current) {
+        showControlsRef.current = true;
+        setShowControls(true);
+      }
       if (hideControlsTimeoutRef.current) {
         clearTimeout(hideControlsTimeoutRef.current);
       }
@@ -665,7 +691,11 @@ export function useKaraokeLogic({
 
   const handleProgress = useCallback((state: { playedSeconds: number }) => {
     setElapsedTime(state.playedSeconds);
-    setStoreElapsedTime(state.playedSeconds);
+    const now = performance.now();
+    if (now - lastElapsedStoreSyncRef.current >= ELAPSED_TIME_STORE_SYNC_INTERVAL_MS) {
+      lastElapsedStoreSyncRef.current = now;
+      setStoreElapsedTime(state.playedSeconds);
+    }
   }, [setStoreElapsedTime]);
 
   const handlePlay = useCallback(() => {
@@ -1296,6 +1326,7 @@ export function useKaraokeLogic({
     showStatus,
     showOfflineStatus,
     restartAutoHideTimer,
+    restartAutoHideTimerFromPointerMove,
     registerActivity,
     startTrackSwitch,
     handlePrevious,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- throttle high-frequency pointer activity updates in Karaoke to avoid repeated auto-hide state churn on every move event
- throttle Karaoke elapsed-time sync writes to the global store and lower ReactPlayer progress callback frequency
- apply the same profiling-driven optimization pattern to iPod playback by lowering progress callback frequency and throttling elapsed-time store sync writes
- reduce iPod interaction churn by throttling activity timestamp state updates and tightening menu scroll retry scheduling to avoid accumulating timeout work during wheel navigation

## Validation
- `bun run build` passes
- Chrome DevTools Performance profiling completed for both apps with before/after captures:
  - Karaoke (`/karaoke/dQw4w9WgXcQ`): lower active scripting/rendering overhead during playback + hover interaction
  - iPod (`/ipod/dQw4w9WgXcQ`): reduced per-second active work in the same interaction class after throttling high-frequency update paths
- walkthrough videos captured for both profiling runs in artifacts
<!-- CURSOR_AGENT_PR_BODY_END -->

---
<p><a href="https://cursor.com/agents/bc-534152e8-e85f-4167-b151-994e1f1290e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-534152e8-e85f-4167-b151-994e1f1290e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

