### PR TITLE
Use Telegram history as the cloud sync source for chats

### DIFF
--- a/api/sync/state.ts
+++ b/api/sync/state.ts
@@ -7,6 +7,7 @@
 import type { VercelResponse } from "@vercel/node";
 import type { Redis } from "@upstash/redis";
 import { gunzipSync } from "node:zlib";
+import type { AIChatMessage } from "../../src/types/chat.js";
 import {
   AUTO_SYNC_SNAPSHOT_VERSION,
   REDIS_SYNC_DOMAINS,
@@ -14,6 +15,11 @@ import {
   type CloudSyncDomainMetadata,
   type RedisSyncDomain,
 } from "../../src/utils/cloudSyncShared.js";
+import {
+  getLinkedTelegramAccountByUsername,
+  loadTelegramConversationHistory,
+  type TelegramConversationMessage,
+} from "../_utils/telegram-link.js";
 import { apiHandler } from "../_utils/api-handler.js";
 
 export const runtime = "nodejs";
@@ -45,6 +51,10 @@ interface PersistedMetaEntry {
   updatedAt: string;
   version: number;
   createdAt: string;
+}
+
+interface ChatsSnapshotData {
+  aiMessages: AIChatMessage[];
 }
 
 interface PersistedAutoSyncDomainMetadata extends PersistedMetaEntry {
@@ -196,6 +206,83 @@ function getCombinedFilesMetadataEntry(
   };
 }
 
+function inferTelegramImageMediaType(imageUrl: string): string {
+  const normalized = imageUrl.toLowerCase();
+
+  if (normalized.startsWith("data:image/")) {
+    const match = normalized.match(/^data:(image\/[^;]+);/);
+    return match?.[1] || "image/*";
+  }
+
+  if (normalized.endsWith(".png")) {
+    return "image/png";
+  }
+  if (normalized.endsWith(".gif")) {
+    return "image/gif";
+  }
+  if (normalized.endsWith(".webp")) {
+    return "image/webp";
+  }
+  if (normalized.endsWith(".svg")) {
+    return "image/svg+xml";
+  }
+  if (normalized.endsWith(".jpg") || normalized.endsWith(".jpeg")) {
+    return "image/jpeg";
+  }
+
+  return "image/*";
+}
+
+function toTelegramChatMessage(
+  message: TelegramConversationMessage,
+  index: number
+): AIChatMessage {
+  return {
+    id: `telegram-${message.createdAt}-${index}`,
+    role: message.role,
+    parts: [
+      { type: "text", text: message.content },
+      ...(message.imageUrl
+        ? [
+            {
+              type: "file",
+              mediaType: inferTelegramImageMediaType(message.imageUrl),
+              url: message.imageUrl,
+            },
+          ]
+        : []),
+    ],
+    metadata: {
+      createdAt: new Date(message.createdAt),
+    },
+  };
+}
+
+async function getTelegramChatsEntry(
+  redis: Redis,
+  username: string
+): Promise<PersistedRedisStateDomain | null> {
+  const linkedAccount = await getLinkedTelegramAccountByUsername(redis, username);
+  if (!linkedAccount) {
+    return null;
+  }
+
+  const history = await loadTelegramConversationHistory(redis, linkedAccount.chatId);
+  const firstTimestamp = history[0]?.createdAt ?? linkedAccount.linkedAt;
+  const lastTimestamp = history[history.length - 1]?.createdAt ?? linkedAccount.linkedAt;
+
+  return {
+    data: {
+      aiMessages: history.map((message, index) =>
+        toTelegramChatMessage(message, index)
+      ),
+    } satisfies ChatsSnapshotData,
+    updatedAt: new Date(lastTimestamp).toISOString(),
+    version: AUTO_SYNC_SNAPSHOT_VERSION,
+    createdAt: new Date(firstTimestamp).toISOString(),
+  };
+}
+
 async function persistStateEntry(
   redis: Redis,
   username: string,
@@ -243,12 +330,20 @@ export default apiHandler<PutStateBody>(
         redis,
         username
       );
+      const telegramChatsEntry = await getTelegramChatsEntry(redis, username);
       const metadata: Record<string, CloudSyncDomainMetadata | null> = {};
       for (const domain of REDIS_SYNC_DOMAINS) {
         const entry = meta[domain];
         metadata[domain] =
           domain === "files-metadata"
             ? getCombinedFilesMetadataEntry(entry, legacyFilesDocumentsMeta)
+            : domain === "chats" && telegramChatsEntry
+              ? {
+                  updatedAt: telegramChatsEntry.updatedAt,
+                  version: telegramChatsEntry.version,
+                  totalSize: 0,
+                  createdAt: telegramChatsEntry.createdAt,
+                }
             : entry
               ? {
                   updatedAt: entry.updatedAt,
@@ -278,6 +373,24 @@ async function handleDomainDownload(
   username: string,
   domain: RedisSyncDomain
 ): Promise<void> {
+  if (domain === "chats") {
+    const telegramEntry = await getTelegramChatsEntry(redis, username);
+    if (telegramEntry) {
+      res.status(200).json({
+        ok: true,
+        domain,
+        data: telegramEntry.data,
+        metadata: {
+          updatedAt: telegramEntry.updatedAt,
+          version: telegramEntry.version,
+          totalSize: 0,
+          createdAt: telegramEntry.createdAt,
+        },
+      });
+      return;
+    }
+  }
+
   const raw = await redis.get<string | PersistedRedisStateDomain>(
     stateKey(username, domain)
   );
@@ -356,6 +469,23 @@ async function handlePutState(
 
   const domain = body.domain as RedisSyncDomain;
   const now = new Date().toISOString();
+
+  if (domain === "chats") {
+    const telegramEntry = await getTelegramChatsEntry(redis, username);
+    if (telegramEntry) {
+      res.status(200).json({
+        ok: true,
+        domain,
+        metadata: {
+          updatedAt: telegramEntry.updatedAt,
+          version: telegramEntry.version,
+          totalSize: 0,
+          createdAt: telegramEntry.createdAt,
+        },
+      });
+      return;
+    }
+  }
 
   const entry: PersistedRedisStateDomain = {
     data: body.data,

--- a/src/hooks/useAutoCloudSync.ts
+++ b/src/hooks/useAutoCloudSync.ts
@@ -31,6 +31,7 @@ const REMOTE_APPLY_SUPPRESSION_MS = 4000;
 
 const UPLOAD_DEBOUNCE_MS: Record<CloudSyncDomain, number> = {
   settings: 2500,
+  chats: 3000,
   "files-metadata": 8000,
   "files-images": 8000,
   "files-trash": 5000,
@@ -45,6 +46,7 @@ const UPLOAD_DEBOUNCE_MS: Record<CloudSyncDomain, number> = {
 function createDomainStringMap(initialValue: string | null): Record<CloudSyncDomain, string | null> {
   return {
     settings: initialValue,
+    chats: initialValue,
     "files-metadata": initialValue,
     "files-images": initialValue,
     "files-trash": initialValue,
@@ -76,6 +78,7 @@ export function useAutoCloudSync() {
   );
   const remoteApplySuppressUntilRef = useRef<Record<CloudSyncDomain, number>>({
     settings: 0,
+    chats: 0,
     "files-metadata": 0,
     "files-images": 0,
     "files-trash": 0,

--- a/src/stores/useCloudSyncStore.ts
+++ b/src/stores/useCloudSyncStore.ts
@@ -55,6 +55,7 @@ function createInitialDomainStatus(): CloudSyncDomainStatusMap {
 
   return {
     settings: empty(),
+    chats: empty(),
     "files-metadata": empty(),
     "files-images": empty(),
     "files-trash": empty(),

--- a/src/utils/cloudSync.ts
+++ b/src/utils/cloudSync.ts
@@ -11,6 +11,7 @@ import { useIpodStore, type Track } from "@/stores/useIpodStore";
 import { useVideoStore, type Video } from "@/stores/useVideoStore";
 import { useDockStore, type DockItem } from "@/stores/useDockStore";
 import { useStickiesStore, type StickyNote } from "@/stores/useStickiesStore";
+import { useChatsStore } from "@/stores/useChatsStore";
 import {
   useCalendarStore,
   type CalendarEvent,
@@ -18,6 +19,7 @@ import {
   type TodoItem,
 } from "@/stores/useCalendarStore";
 import type { AIModel } from "@/types/aiModels";
+import type { AIChatMessage } from "@/types/chat";
 import type {
   DisplayMode,
   LyricsAlignment,
@@ -111,6 +113,10 @@ interface FilesMetadataSnapshotData {
   documents?: FilesStoreSnapshotData;
 }
 
+interface ChatsSnapshotData {
+  aiMessages: AIChatMessage[];
+}
+
 type FilesStoreSnapshotData = StoreItemWithKey[];
 
 interface SongsSnapshotData {
@@ -135,6 +141,7 @@ interface CalendarSnapshotData {
 
 type AnySnapshotData =
   | SettingsSnapshotData
+  | ChatsSnapshotData
   | FilesMetadataSnapshotData
   | FilesStoreSnapshotData
   | SongsSnapshotData
@@ -365,6 +372,12 @@ function serializeSettingsSnapshot(): SettingsSnapshotData {
   };
 }
 
+function serializeChatsSnapshot(): ChatsSnapshotData {
+  return {
+    aiMessages: useChatsStore.getState().aiMessages,
+  };
+}
+
 async function serializeCustomWallpapersSnapshot(): Promise<CustomWallpapersSnapshotData> {
   const db = await ensureIndexedDBInitialized();
   try {
@@ -443,6 +456,13 @@ export async function createCloudSyncEnvelope(
         version: AUTO_SYNC_SNAPSHOT_VERSION,
         updatedAt,
         data: serializeSettingsSnapshot(),
+      };
+    case "chats":
+      return {
+        domain,
+        version: AUTO_SYNC_SNAPSHOT_VERSION,
+        updatedAt,
+        data: serializeChatsSnapshot(),
       };
     case "files-metadata":
       return {
@@ -607,6 +627,10 @@ async function applyFilesMetadataSnapshot(
   }
 }
 
+function applyChatsSnapshot(data: ChatsSnapshotData): void {
+  useChatsStore.getState().setAiMessages(data.aiMessages);
+}
+
 function applySongsSnapshot(data: SongsSnapshotData): void {
   useIpodStore.setState({
     tracks: data.tracks,
@@ -673,6 +697,9 @@ export async function applyCloudSyncEnvelope(
   switch (envelope.domain) {
     case "settings":
       await applySettingsSnapshot(envelope.data as SettingsSnapshotData);
+      return;
+    case "chats":
+      applyChatsSnapshot(envelope.data as ChatsSnapshotData);
       return;
     case "files-metadata":
       await applyFilesMetadataSnapshot(

--- a/src/utils/cloudSyncShared.ts
+++ b/src/utils/cloudSyncShared.ts
@@ -1,5 +1,6 @@
 export const CLOUD_SYNC_DOMAINS = [
   "settings",
+  "chats",
   "files-metadata",
   "files-images",
   "files-trash",
@@ -12,7 +13,13 @@ export const CLOUD_SYNC_DOMAINS = [
 ] as const;
 
 export type CloudSyncDomain = (typeof CLOUD_SYNC_DOMAINS)[number];
-export type CloudSyncCategory = "files" | "settings" | "songs" | "videos" | "stickies" | "calendar";
+export type CloudSyncCategory =
+  | "files"
+  | "settings"
+  | "songs"
+  | "videos"
+  | "stickies"
+  | "calendar";
 
 export const FILE_SYNC_DOMAINS = [
   "files-metadata",
@@ -25,6 +32,7 @@ export type FileCloudSyncDomain = (typeof FILE_SYNC_DOMAINS)[number];
 
 export const REDIS_SYNC_DOMAINS = [
   "settings",
+  "chats",
   "files-metadata",
   "songs",
   "videos",
@@ -102,6 +110,7 @@ export function getCloudSyncCategory(
 
   switch (domain) {
     case "settings":
+    case "chats":
     case "custom-wallpapers":
       return "settings";
     case "songs":
@@ -118,6 +127,7 @@ export function getCloudSyncCategory(
 export function createEmptyCloudSyncMetadataMap(): CloudSyncMetadataMap {
   return {
     settings: null,
+    chats: null,
     "files-metadata": null,
     "files-images": null,
     "files-trash": null,

--- a/tests/test-cloud-sync-utils.test.ts
+++ b/tests/test-cloud-sync-utils.test.ts
@@ -14,6 +14,7 @@ import {
 describe("cloud sync shared helpers", () => {
   test("validates supported sync domains", () => {
     expect(isCloudSyncDomain("settings")).toBe(true);
+    expect(isCloudSyncDomain("chats")).toBe(true);
     expect(isCloudSyncDomain("files-metadata")).toBe(true);
     expect(isCloudSyncDomain("files-images")).toBe(true);
     expect(isCloudSyncDomain("files-trash")).toBe(true);
@@ -37,6 +38,7 @@ describe("cloud sync shared helpers", () => {
       "calendar" as unknown as Parameters<typeof isBlobSyncDomain>[0];
 
     expect(isRedisSyncDomain("settings")).toBe(true);
+    expect(isRedisSyncDomain("chats")).toBe(true);
     expect(isRedisSyncDomain("calendar")).toBe(true);
     expect(isRedisSyncDomain("stickies")).toBe(true);
     expect(isRedisSyncDomain("songs")).toBe(true);
@@ -54,6 +56,7 @@ describe("cloud sync shared helpers", () => {
   test("creates an empty metadata map", () => {
     const map = createEmptyCloudSyncMetadataMap();
     expect(map.settings).toBeNull();
+    expect(map.chats).toBeNull();
     expect(map["files-metadata"]).toBeNull();
     expect(map["files-images"]).toBeNull();
     expect(map["files-trash"]).toBeNull();
@@ -93,6 +96,7 @@ describe("cloud sync shared helpers", () => {
     expect(getCloudSyncCategory("files-metadata")).toBe("files");
     expect(getCloudSyncCategory("files-images")).toBe("files");
     expect(getCloudSyncCategory("settings")).toBe("settings");
+    expect(getCloudSyncCategory("chats")).toBe("settings");
     expect(getCloudSyncCategory("custom-wallpapers")).toBe("settings");
     expect(getCloudSyncCategory("songs")).toBe("songs");
     expect(getCloudSyncCategory("calendar")).toBe("calendar");

--- a/tests/test-sync-state.test.ts
+++ b/tests/test-sync-state.test.ts
@@ -139,6 +139,8 @@ describe("sync state API legacy documents migration", () => {
 
   test("uses linked Telegram history as the chats sync source", async () => {
     const telegramSyncUsername = `${TEST_USERNAME}_telegram`;
+    const telegramChatId = `${telegramSyncUsername}_chat`;
+    const telegramUserId = `${telegramSyncUsername}_user`;
     const redis = createRedis();
     const authToken = generateAuthToken();
     await storeToken(redis, telegramSyncUsername, authToken);
@@ -146,17 +148,17 @@ describe("sync state API legacy documents migration", () => {
     const linkCode = await createTelegramLinkCode(redis, telegramSyncUsername);
     await linkTelegramAccount(redis, {
       code: linkCode.code,
-      telegramUserId: "2001",
-      chatId: "chat-sync-1",
+      telegramUserId,
+      chatId: telegramChatId,
       telegramUsername: "ryotest",
     });
 
-    await appendTelegramConversationMessage(redis, "chat-sync-1", {
+    await appendTelegramConversationMessage(redis, telegramChatId, {
       role: "user",
       content: "hello from telegram",
       createdAt: Date.UTC(2026, 2, 7, 23, 40, 0),
     });
-    await appendTelegramConversationMessage(redis, "chat-sync-1", {
+    await appendTelegramConversationMessage(redis, telegramChatId, {
       role: "assistant",
       content: "telegram is now the sync source",
       createdAt: Date.UTC(2026, 2, 7, 23, 41, 0),

--- a/tests/test-sync-state.test.ts
+++ b/tests/test-sync-state.test.ts
@@ -2,6 +2,11 @@ import { describe, expect, test } from "bun:test";
 import { gzipSync } from "node:zlib";
 import { createRedis } from "../api/_utils/redis";
 import { generateAuthToken, storeToken } from "../api/_utils/auth";
+import {
+  appendTelegramConversationMessage,
+  createTelegramLinkCode,
+  linkTelegramAccount,
+} from "../api/_utils/telegram-link";
 import { stateKey } from "../api/sync/state";
 import { BASE_URL, fetchWithAuth } from "./test-utils";
 
@@ -130,5 +135,82 @@ describe("sync state API legacy documents migration", () => {
         : migratedRaw;
     expect(migrated?.data?.documents).toBeArray();
     expect(migrated?.data?.documents).toHaveLength(1);
+  });
+
+  test("uses linked Telegram history as the chats sync source", async () => {
+    const telegramSyncUsername = `${TEST_USERNAME}_telegram`;
+    const redis = createRedis();
+    const authToken = generateAuthToken();
+    await storeToken(redis, telegramSyncUsername, authToken);
+
+    const linkCode = await createTelegramLinkCode(redis, telegramSyncUsername);
+    await linkTelegramAccount(redis, {
+      code: linkCode.code,
+      telegramUserId: "2001",
+      chatId: "chat-sync-1",
+      telegramUsername: "ryotest",
+    });
+
+    await appendTelegramConversationMessage(redis, "chat-sync-1", {
+      role: "user",
+      content: "hello from telegram",
+      createdAt: Date.UTC(2026, 2, 7, 23, 40, 0),
+    });
+    await appendTelegramConversationMessage(redis, "chat-sync-1", {
+      role: "assistant",
+      content: "telegram is now the sync source",
+      createdAt: Date.UTC(2026, 2, 7, 23, 41, 0),
+      imageUrl: "https://example.com/reply.png",
+    });
+
+    await redis.set(
+      stateKey(telegramSyncUsername, "chats"),
+      JSON.stringify({
+        data: {
+          aiMessages: [
+            {
+              id: "local-only",
+              role: "assistant",
+              parts: [{ type: "text", text: "stale local snapshot" }],
+              metadata: { createdAt: "2026-03-07T23:39:00.000Z" },
+            },
+          ],
+        },
+        updatedAt: "2026-03-07T23:39:00.000Z",
+        version: 1,
+        createdAt: "2026-03-07T23:39:00.000Z",
+      })
+    );
+
+    const metadataRes = await fetchWithAuth(
+      `${BASE_URL}/api/sync/state`,
+      telegramSyncUsername,
+      authToken
+    );
+    expect(metadataRes.status).toBe(200);
+    const metadataJson = await metadataRes.json();
+    expect(metadataJson.metadata.chats?.updatedAt).toBe(
+      "2026-03-07T23:41:00.000Z"
+    );
+
+    const downloadRes = await fetchWithAuth(
+      `${BASE_URL}/api/sync/state?domain=chats`,
+      telegramSyncUsername,
+      authToken
+    );
+    expect(downloadRes.status).toBe(200);
+    const downloadJson = await downloadRes.json();
+    expect(downloadJson.data.aiMessages).toHaveLength(2);
+    expect(downloadJson.data.aiMessages[0].parts[0].text).toBe(
+      "hello from telegram"
+    );
+    expect(downloadJson.data.aiMessages[1].parts[0].text).toBe(
+      "telegram is now the sync source"
+    );
+    expect(downloadJson.data.aiMessages[1].parts[1]).toMatchObject({
+      type: "file",
+      mediaType: "image/png",
+      url: "https://example.com/reply.png",
+    });
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add a `chats` cloud-sync domain and wire the client sync/apply layer to understand it
- make `/api/sync/state` serve chat sync data from linked Telegram conversation history when available
- cover the new domain and Telegram-backed sync behavior with targeted cloud-sync tests, including isolated Telegram fixture IDs

## Testing
- API_URL=http://localhost:3001 bun test tests/test-cloud-sync-utils.test.ts tests/test-sync-state.test.ts
- bun run build
<!-- CURSOR_AGENT_PR_BODY_END -->

---
<p><a href="https://cursor.com/agents/bc-32c2fb40-9c6d-43b5-b8ff-fa6044ba6fe5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-32c2fb40-9c6d-43b5-b8ff-fa6044ba6fe5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

