### PR TITLE
Fix Telegram contacts deletion: add contactsControl to prompt and preserve myContactId

### DIFF
--- a/api/_utils/_aiPrompts.ts
+++ b/api/_utils/_aiPrompts.ts
@@ -268,11 +268,12 @@ You're chatting with a linked ryOS user in a private Telegram DM.
 - Only include a plain URL when the user explicitly asks for the source or direct link.
 - Never use markdown link syntax, parenthetical citation blocks, or a separate sources/references list.
 
-## Calendar & Stickies
-You can manage the user's calendar events, todos, and sticky notes directly from Telegram.
+## Calendar, Stickies, Contacts & Documents
+You can manage the user's calendar events, todos, sticky notes, contacts, and documents directly from Telegram.
 - Use calendarControl to list/create/update/delete events and todos. Dates are YYYY-MM-DD, times are HH:MM.
 - When listing todos with 'listTodos', do NOT pass a 'date' parameter unless the user specifically asks for todos due on a certain date — most todos have no due date and would be filtered out.
 - Use stickiesControl to list/create/update/delete sticky notes.
+- Use contactsControl to list/get/create/update/delete contacts. Always call 'list' first to get IDs before get/update/delete.
 - Use documentsControl to list, read, write, and edit synced markdown files under /Documents. List results include document names and exact /Documents/*.md paths.
 - These changes sync to ryOS automatically — the user will see them next time the browser polls.
 - If the user hasn't enabled cloud sync yet, these tools will let you know.

--- a/api/_utils/contacts.ts
+++ b/api/_utils/contacts.ts
@@ -21,8 +21,10 @@ export async function readContactsState(
   }
 
   const parsed = typeof raw === "string" ? JSON.parse(raw) : raw;
+  const data = parsed?.data as ContactsSnapshotData | undefined;
   return {
-    contacts: normalizeContacts(parsed?.data?.contacts),
+    contacts: normalizeContacts(data?.contacts),
+    myContactId: typeof data?.myContactId === "string" ? data.myContactId : null,
   };
 }
 

--- a/api/chat/tools/executors.ts
+++ b/api/chat/tools/executors.ts
@@ -1325,6 +1325,7 @@ export async function executeContactsControl(
       const contact = createContactFromDraft(toContactsDraft(input));
       await writeContactsState(context.redis, context.username, {
         contacts: sortContacts([...state.contacts, contact]),
+        myContactId: state.myContactId,
       });
       context.log(
         `[contactsControl] Created contact "${contact.displayName}" (${getContactSummary(contact)})`
@@ -1354,6 +1355,7 @@ export async function executeContactsControl(
 
       await writeContactsState(context.redis, context.username, {
         contacts: sortContacts(nextContacts),
+        myContactId: state.myContactId,
       });
 
       return {
@@ -1372,8 +1374,10 @@ export async function executeContactsControl(
         };
       }
 
+      const deletedId = contact.id;
       await writeContactsState(context.redis, context.username, {
         contacts: state.contacts.filter((item) => item.id !== input.id),
+        myContactId: state.myContactId === deletedId ? null : state.myContactId,
       });
 
       return {

--- a/api/chat/tools/types.ts
+++ b/api/chat/tools/types.ts
@@ -550,4 +550,5 @@ export interface StickiesSnapshotData {
 
 export interface ContactsSnapshotData {
   contacts: Contact[];
+  myContactId?: string | null;
 }

--- a/tests/test-server-app-state-tools.test.ts
+++ b/tests/test-server-app-state-tools.test.ts
@@ -83,6 +83,7 @@ const contactsData = {
         updatedAt: 1000,
       },
     ],
+    myContactId: "contact-1",
   },
   updatedAt: "2026-03-06T00:00:00.000Z",
   version: 1,
@@ -584,5 +585,32 @@ describe("Server-side Contacts Executor", () => {
     );
     expect(result.success).toBe(true);
     expect(result.message).toContain("Deleted");
+  });
+
+  test("create preserves myContactId in persisted state", async () => {
+    await executeContactsControl(
+      { action: "create", displayName: "New Person", emails: ["new@example.com"] },
+      context
+    );
+    const stored = JSON.parse(redis._store["sync:state:testuser:contacts"]);
+    expect(stored.data.myContactId).toBe("contact-1");
+  });
+
+  test("update preserves myContactId in persisted state", async () => {
+    await executeContactsControl(
+      { action: "update", id: "contact-1", notes: "Changed" },
+      context
+    );
+    const stored = JSON.parse(redis._store["sync:state:testuser:contacts"]);
+    expect(stored.data.myContactId).toBe("contact-1");
+  });
+
+  test("delete clears myContactId when the pinned contact is deleted", async () => {
+    await executeContactsControl(
+      { action: "delete", id: "contact-1" },
+      context
+    );
+    const stored = JSON.parse(redis._store["sync:state:testuser:contacts"]);
+    expect(stored.data.myContactId).toBe(null);
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Deleting contacts through Telegram wasn't working due to two issues:

1. **Missing prompt instructions**: The `TELEGRAM_CHAT_INSTRUCTIONS` prompt mentioned calendar, stickies, and documents tools but completely omitted `contactsControl`. The AI didn't know it could manage contacts from Telegram, so it would not attempt to use the tool when asked.

2. **`myContactId` data loss**: The server-side `ContactsSnapshotData` type was missing the `myContactId` field. Any server-side contacts operation (create, update, delete via Telegram) would silently drop this field, resetting the user's "my contact" pin on the next cloud sync.

## Changes

- **`api/_utils/_aiPrompts.ts`**: Added `contactsControl` to the Telegram chat instructions section (renamed from "Calendar & Stickies" to "Calendar, Stickies, Contacts & Documents")
- **`api/chat/tools/types.ts`**: Added `myContactId` to `ContactsSnapshotData`
- **`api/_utils/contacts.ts`**: Updated `readContactsState` to read and return `myContactId` from Redis
- **`api/chat/tools/executors.ts`**: Updated all `writeContactsState` calls in `executeContactsControl` to pass through `myContactId`, and clear it when the pinned contact is deleted
- **`tests/test-server-app-state-tools.test.ts`**: Added 3 tests verifying `myContactId` preservation through create, update, and delete operations
<!-- CURSOR_AGENT_PR_BODY_END -->

---
<p><a href="https://cursor.com/agents/bc-9b1a6d56-f028-46c8-ba97-0ab7c9e49ef3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9b1a6d56-f028-46c8-ba97-0ab7c9e49ef3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

