### PR TITLE
Defer admin user activity loading

### DIFF
--- a/api/admin.ts
+++ b/api/admin.ts
@@ -6,7 +6,12 @@
  */
 
 import { Redis } from "@upstash/redis";
-import { CHAT_USERS_PREFIX } from "./rooms/_helpers/_constants.js";
+import {
+  CHAT_MESSAGES_PREFIX,
+  CHAT_ROOM_PREFIX,
+  CHAT_ROOMS_SET,
+  CHAT_USERS_PREFIX,
+} from "./rooms/_helpers/_constants.js";
 import { deleteAllUserTokens, PASSWORD_HASH_PREFIX } from "./_utils/auth/index.js";
 import * as RateLimit from "./_utils/_rate-limit.js";
 import { getClientIp } from "./_utils/_rate-limit.js";
@@ -36,6 +41,33 @@ interface UserProfile {
   bannedAt?: number;
   messageCount?: number;
   rooms?: { id: string; name: string }[];
+}
+
+interface UserActivityMessage {
+  id: string;
+  roomId: string;
+  roomName: string;
+  content: string;
+  timestamp: number;
+}
+
+interface UserRoomActivity {
+  messageCount: number;
+  rooms: { id: string; name: string }[];
+  messages: UserActivityMessage[];
+}
+
+const ROOM_ACTIVITY_SCAN_BATCH_SIZE = 25;
+
+function chunkArray<T>(items: T[], chunkSize: number): T[][] {
+  if (chunkSize <= 0) return [items];
+
+  const chunks: T[][] = [];
+  for (let index = 0; index < items.length; index += chunkSize) {
+    chunks.push(items.slice(index, index + chunkSize));
+  }
+
+  return chunks;
 }
 
 async function deleteUser(redis: Redis, targetUsername: string): Promise<{ success: boolean; error?: string }> {
@@ -91,42 +123,6 @@ async function getUserProfile(redis: Redis, targetUsername: string): Promise<Use
     if (!userData) return null;
 
     const parsed = typeof userData === "string" ? JSON.parse(userData) : userData;
-    let messageCount = 0;
-    const userRooms: { id: string; name: string }[] = [];
-    
-    const roomIds = await redis.smembers("chat:rooms");
-    const roomNameMap: Record<string, string> = {};
-    
-    for (const roomId of roomIds || []) {
-      try {
-        const roomData = await redis.get<{ name: string } | string>(`chat:room:${roomId}`);
-        if (roomData) {
-          const p = typeof roomData === "string" ? JSON.parse(roomData) : roomData;
-          roomNameMap[roomId] = p.name || roomId;
-        } else {
-          roomNameMap[roomId] = roomId;
-        }
-      } catch {
-        roomNameMap[roomId] = roomId;
-      }
-    }
-    
-    for (const roomId of roomIds || []) {
-      const messages = await redis.lrange(`chat:messages:${roomId}`, 0, -1);
-      let roomMessageCount = 0;
-      
-      for (const msg of messages || []) {
-        const msgData = typeof msg === "string" ? JSON.parse(msg) : msg;
-        if (msgData?.username?.toLowerCase() === normalizedUsername) {
-          roomMessageCount++;
-          messageCount++;
-        }
-      }
-      
-      if (roomMessageCount > 0) {
-        userRooms.push({ id: roomId, name: roomNameMap[roomId] || roomId });
-      }
-    }
 
     return {
       username: parsed.username,
@@ -134,8 +130,6 @@ async function getUserProfile(redis: Redis, targetUsername: string): Promise<Use
       banned: parsed.banned || false,
       banReason: parsed.banReason,
       bannedAt: parsed.bannedAt,
-      messageCount,
-      rooms: userRooms,
     };
   } catch (error) {
     console.error(`Error fetching user profile for ${normalizedUsername}:`, error);
@@ -143,44 +137,153 @@ async function getUserProfile(redis: Redis, targetUsername: string): Promise<Use
   }
 }
 
-async function getUserMessages(redis: Redis, targetUsername: string, limit = 50): Promise<{ id: string; roomId: string; roomName: string; content: string; timestamp: number }[]> {
+async function getRoomNameMap(
+  redis: Redis,
+  roomIds: string[]
+): Promise<Record<string, string>> {
+  if (roomIds.length === 0) {
+    return {};
+  }
+
+  const roomKeys = roomIds.map((roomId) => `${CHAT_ROOM_PREFIX}${roomId}`);
+  const roomPayloads = await redis.mget<
+    ({ name?: string } | string | null)[]
+  >(...roomKeys);
+
+  const roomNameMap: Record<string, string> = {};
+  roomIds.forEach((roomId, index) => {
+    const rawRoom = roomPayloads?.[index];
+    if (!rawRoom) {
+      roomNameMap[roomId] = roomId;
+      return;
+    }
+
+    try {
+      const parsedRoom =
+        typeof rawRoom === "string" ? JSON.parse(rawRoom) : rawRoom;
+      roomNameMap[roomId] = parsedRoom?.name || roomId;
+    } catch {
+      roomNameMap[roomId] = roomId;
+    }
+  });
+
+  return roomNameMap;
+}
+
+async function getUserRoomActivity(
+  redis: Redis,
+  targetUsername: string,
+  limit = 50
+): Promise<UserRoomActivity> {
   const normalizedUsername = targetUsername.toLowerCase();
-  const messages: { id: string; roomId: string; roomName: string; content: string; timestamp: number }[] = [];
+  const recentMessages: Array<Omit<UserActivityMessage, "roomName">> = [];
+  const roomActivity = new Map<string, { latestTimestamp: number }>();
+  let messageCount = 0;
 
   try {
-    const roomIds = await redis.smembers("chat:rooms");
-    const roomNameMap: Record<string, string> = {};
-    
-    for (const roomId of roomIds || []) {
-      try {
-        const roomData = await redis.get<{ name: string } | string>(`chat:room:${roomId}`);
-        if (roomData) {
-          const p = typeof roomData === "string" ? JSON.parse(roomData) : roomData;
-          roomNameMap[roomId] = p.name || roomId;
-        } else {
-          roomNameMap[roomId] = roomId;
+    const roomIds = await redis.smembers(CHAT_ROOMS_SET);
+
+    for (const roomIdBatch of chunkArray(
+      roomIds || [],
+      ROOM_ACTIVITY_SCAN_BATCH_SIZE
+    )) {
+      const batchActivity = await Promise.all(
+        roomIdBatch.map(async (roomId) => {
+          try {
+            const roomMessages = await redis.lrange<
+              (Record<string, unknown> | string)[]
+            >(`${CHAT_MESSAGES_PREFIX}${roomId}`, 0, -1);
+            const matchingMessages: Array<Omit<UserActivityMessage, "roomName">> =
+              [];
+            let latestTimestamp = 0;
+
+            for (const rawMessage of roomMessages || []) {
+              const message =
+                typeof rawMessage === "string"
+                  ? JSON.parse(rawMessage)
+                  : rawMessage;
+              const messageUsername =
+                typeof message?.username === "string"
+                  ? message.username.toLowerCase()
+                  : "";
+
+              if (messageUsername !== normalizedUsername) {
+                continue;
+              }
+
+              const timestamp =
+                typeof message.timestamp === "number" ? message.timestamp : 0;
+              latestTimestamp = Math.max(latestTimestamp, timestamp);
+              matchingMessages.push({
+                id:
+                  typeof message.id === "string"
+                    ? message.id
+                    : `${roomId}:${timestamp}`,
+                roomId,
+                content:
+                  typeof message.content === "string" ? message.content : "",
+                timestamp,
+              });
+            }
+
+            return { roomId, matchingMessages, latestTimestamp };
+          } catch (error) {
+            console.error(`Error scanning room activity for ${roomId}:`, error);
+            return { roomId, matchingMessages: [], latestTimestamp: 0 };
+          }
+        })
+      );
+
+      for (const { roomId, matchingMessages, latestTimestamp } of batchActivity) {
+        if (matchingMessages.length === 0) {
+          continue;
         }
-      } catch {
-        roomNameMap[roomId] = roomId;
-      }
-    }
-    
-    for (const roomId of roomIds || []) {
-      const roomMessages = await redis.lrange(`chat:messages:${roomId}`, 0, -1);
-      for (const msg of roomMessages || []) {
-        const msgData = typeof msg === "string" ? JSON.parse(msg) : msg;
-        if (msgData?.username?.toLowerCase() === normalizedUsername) {
-          messages.push({ id: msgData.id, roomId, roomName: roomNameMap[roomId] || roomId, content: msgData.content, timestamp: msgData.timestamp });
-        }
+
+        messageCount += matchingMessages.length;
+        roomActivity.set(roomId, { latestTimestamp });
+        recentMessages.push(...matchingMessages);
       }
     }
 
-    messages.sort((a, b) => b.timestamp - a.timestamp);
-    return messages.slice(0, limit);
+    const matchedRoomIds = Array.from(roomActivity.keys());
+    const roomNameMap = await getRoomNameMap(redis, matchedRoomIds);
+    const safeLimit = Math.max(1, Math.min(limit, 100));
+
+    const rooms = matchedRoomIds
+      .map((roomId) => ({
+        id: roomId,
+        name: roomNameMap[roomId] || roomId,
+        latestTimestamp: roomActivity.get(roomId)?.latestTimestamp || 0,
+      }))
+      .sort((a, b) => b.latestTimestamp - a.latestTimestamp)
+      .map(({ id, name }) => ({ id, name }));
+
+    const messages = recentMessages
+      .sort((a, b) => b.timestamp - a.timestamp)
+      .slice(0, safeLimit)
+      .map((message) => ({
+        ...message,
+        roomName: roomNameMap[message.roomId] || message.roomId,
+      }));
+
+    return {
+      messageCount,
+      rooms,
+      messages,
+    };
   } catch (error) {
-    console.error(`Error fetching messages for ${normalizedUsername}:`, error);
-    return [];
+    console.error(`Error fetching room activity for ${normalizedUsername}:`, error);
+    return { messageCount: 0, rooms: [], messages: [] };
   }
+}
+
+async function getUserMessages(
+  redis: Redis,
+  targetUsername: string,
+  limit = 50
+): Promise<UserActivityMessage[]> {
+  const activity = await getUserRoomActivity(redis, targetUsername, limit);
+  return activity.messages;
 }
 
 async function banUser(redis: Redis, targetUsername: string, reason?: string): Promise<{ success: boolean; error?: string }> {
@@ -389,6 +492,25 @@ export default apiHandler<AdminRequest>(
           logger.info("Messages retrieved", { targetUsername, count: messages.length });
           logger.response(200, Date.now() - startTime);
           res.status(200).json({ messages });
+          return;
+        }
+        case "getUserRoomActivity": {
+          const targetUsername = req.query.username as string | undefined;
+          const limit = parseInt((req.query.limit as string) || "50");
+          if (!targetUsername) {
+            logger.response(400, Date.now() - startTime);
+            res.status(400).json({ error: "Username is required" });
+            return;
+          }
+          const activity = await getUserRoomActivity(redis, targetUsername, limit);
+          logger.info("Room activity retrieved", {
+            targetUsername,
+            roomCount: activity.rooms.length,
+            messageCount: activity.messageCount,
+            recentMessagesCount: activity.messages.length,
+          });
+          logger.response(200, Date.now() - startTime);
+          res.status(200).json(activity);
           return;
         }
         case "getUserMemories": {

--- a/src/api/admin.ts
+++ b/src/api/admin.ts
@@ -54,6 +54,14 @@ export async function getAdminUserMessages<TResponse>(
   return adminGet<TResponse>(auth, "getUserMessages", { username, limit });
 }
 
+export async function getAdminUserRoomActivity<TResponse>(
+  auth: ApiAuthContext,
+  username: string,
+  limit?: number
+): Promise<TResponse> {
+  return adminGet<TResponse>(auth, "getUserRoomActivity", { username, limit });
+}
+
 export async function getAdminUserMemories<TResponse>(
   auth: ApiAuthContext,
   username: string

--- a/src/apps/admin/components/UserProfilePanel.tsx
+++ b/src/apps/admin/components/UserProfilePanel.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useCallback } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { ScrollArea } from "@/components/ui/scroll-area";
+import { ActivityIndicator } from "@/components/ui/activity-indicator";
 import {
   Table,
   TableBody,
@@ -23,8 +24,8 @@ import {
   forceAdminDailyNotes,
   getAdminUserHeartbeats,
   getAdminUserMemories,
-  getAdminUserMessages,
   getAdminUserProfile,
+  getAdminUserRoomActivity,
   unbanAdminUser,
 } from "@/api/admin";
 import { ApiRequestError } from "@/api/core";
@@ -45,6 +46,12 @@ interface UserMessage {
   roomName?: string;
   content: string;
   timestamp: number;
+}
+
+interface UserRoomActivity {
+  messageCount: number;
+  rooms: { id: string; name: string }[];
+  messages: UserMessage[];
 }
 
 interface UserMemory {
@@ -95,7 +102,7 @@ export const UserProfilePanel: React.FC<UserProfilePanelProps> = ({
   const { t } = useTranslation();
   const { username: currentUser, authToken } = useAuth();
   const [profile, setProfile] = useState<UserProfile | null>(null);
-  const [messages, setMessages] = useState<UserMessage[]>([]);
+  const [roomActivity, setRoomActivity] = useState<UserRoomActivity | null>(null);
   const [memories, setMemories] = useState<UserMemory[]>([]);
   const [dailyNotes, setDailyNotes] = useState<DailyNote[]>([]);
   const [heartbeats, setHeartbeats] = useState<HeartbeatRecord[]>([]);
@@ -109,10 +116,12 @@ export const UserProfilePanel: React.FC<UserProfilePanelProps> = ({
   const [isBanDialogOpen, setIsBanDialogOpen] = useState(false);
   const [isRoomsOpen, setIsRoomsOpen] = useState(false);
   const [isMessagesOpen, setIsMessagesOpen] = useState(false);
+  const [hasLoadedRoomActivity, setHasLoadedRoomActivity] = useState(false);
   const [isClearMemoryDialogOpen, setIsClearMemoryDialogOpen] = useState(false);
   const [isForceProcessDialogOpen, setIsForceProcessDialogOpen] = useState(false);
   const [isClearingMemory, setIsClearingMemory] = useState(false);
   const [isProcessingNotes, setIsProcessingNotes] = useState(false);
+  const [isRoomActivityLoading, setIsRoomActivityLoading] = useState(false);
 
   const fetchProfile = useCallback(async () => {
     if (!currentUser || !authToken) return;
@@ -131,10 +140,13 @@ export const UserProfilePanel: React.FC<UserProfilePanelProps> = ({
     }
   }, [username, authToken, currentUser, t]);
 
-  const fetchMessages = useCallback(async () => {
+  const fetchRoomActivity = useCallback(async () => {
     if (!currentUser || !authToken) return;
+    if (hasLoadedRoomActivity || isRoomActivityLoading) return;
+
+    setIsRoomActivityLoading(true);
     try {
-      const data = await getAdminUserMessages<{ messages?: UserMessage[] }>(
+      const data = await getAdminUserRoomActivity<UserRoomActivity>(
         {
           username: currentUser,
           token: authToken,
@@ -142,11 +154,31 @@ export const UserProfilePanel: React.FC<UserProfilePanelProps> = ({
         username,
         50
       );
-      setMessages(data.messages || []);
+      setRoomActivity({
+        messageCount: data.messageCount || 0,
+        rooms: data.rooms || [],
+        messages: data.messages || [],
+      });
+      setHasLoadedRoomActivity(true);
     } catch (error) {
-      console.error("Failed to fetch messages:", error);
+      console.error("Failed to fetch room activity:", error);
+      toast.error(
+        t(
+          "apps.admin.errors.failedToFetchRoomActivity",
+          "Failed to load user room activity"
+        )
+      );
+    } finally {
+      setIsRoomActivityLoading(false);
     }
-  }, [username, authToken, currentUser]);
+  }, [
+    username,
+    authToken,
+    currentUser,
+    hasLoadedRoomActivity,
+    isRoomActivityLoading,
+    t,
+  ]);
 
   const fetchMemories = useCallback(async () => {
     if (!currentUser || !authToken) return;
@@ -225,14 +257,17 @@ export const UserProfilePanel: React.FC<UserProfilePanelProps> = ({
 
   useEffect(() => {
     setIsLoading(true);
-    Promise.all([fetchProfile(), fetchMessages(), fetchMemories(), fetchHeartbeats()]).finally(() => {
+    Promise.all([fetchProfile(), fetchMemories(), fetchHeartbeats()]).finally(() => {
       setIsLoading(false);
     });
-  }, [fetchProfile, fetchMessages, fetchMemories, fetchHeartbeats]);
+  }, [fetchProfile, fetchMemories, fetchHeartbeats]);
 
   useEffect(() => {
     setIsRoomsOpen(false);
     setIsMessagesOpen(false);
+    setRoomActivity(null);
+    setHasLoadedRoomActivity(false);
+    setIsRoomActivityLoading(false);
   }, [username]);
 
   const handleBan = async () => {
@@ -375,6 +410,36 @@ export const UserProfilePanel: React.FC<UserProfilePanelProps> = ({
     return new Date(timestamp).toLocaleString();
   };
 
+  const openRooms = useCallback(() => {
+    setIsRoomsOpen(true);
+    void fetchRoomActivity();
+  }, [fetchRoomActivity]);
+
+  const openMessages = useCallback(() => {
+    setIsMessagesOpen(true);
+    void fetchRoomActivity();
+  }, [fetchRoomActivity]);
+
+  const toggleRooms = useCallback(() => {
+    setIsRoomsOpen((prev) => {
+      const next = !prev;
+      if (next) {
+        void fetchRoomActivity();
+      }
+      return next;
+    });
+  }, [fetchRoomActivity]);
+
+  const toggleMessages = useCallback(() => {
+    setIsMessagesOpen((prev) => {
+      const next = !prev;
+      if (next) {
+        void fetchRoomActivity();
+      }
+      return next;
+    });
+  }, [fetchRoomActivity]);
+
   if (!isLoading && !profile) {
     return (
       <div className="flex flex-col items-center justify-center h-full gap-2">
@@ -389,8 +454,17 @@ export const UserProfilePanel: React.FC<UserProfilePanelProps> = ({
   }
 
   const isTargetAdmin = username.toLowerCase() === "ryo";
-  const roomsCount = profile?.rooms?.length ?? 0;
-  const messagesCount = messages.length;
+  const rooms = roomActivity?.rooms ?? [];
+  const messages = roomActivity?.messages ?? [];
+  const roomsCount = hasLoadedRoomActivity ? rooms.length : null;
+  const messagesCount = hasLoadedRoomActivity
+    ? roomActivity?.messageCount ?? messages.length
+    : null;
+  const isMessagesTruncated =
+    hasLoadedRoomActivity &&
+    messagesCount !== null &&
+    messages.length > 0 &&
+    messages.length < messagesCount;
 
   // Skeleton placeholder component
   const Skeleton = ({ className }: { className?: string }) => (
@@ -433,6 +507,42 @@ export const UserProfilePanel: React.FC<UserProfilePanelProps> = ({
         {icon}
         <span>{children}</span>
       </Component>
+    );
+  };
+  const LazySectionState = ({
+    onLoad,
+    emptyLabel,
+  }: {
+    onLoad: () => void;
+    emptyLabel: string;
+  }) => {
+    if (isRoomActivityLoading) {
+      return (
+        <div className="flex items-center gap-2 py-2 text-[11px] text-neutral-500">
+          <ActivityIndicator size={12} />
+          <span>{t("common.loading.default")}</span>
+        </div>
+      );
+    }
+
+    if (!hasLoadedRoomActivity) {
+      return (
+        <button
+          type="button"
+          onClick={onLoad}
+          className="aqua-button secondary h-6 px-2 text-[10px]"
+        >
+          <span>
+            {t("apps.admin.profile.loadOnDemand", "Load on demand")}
+          </span>
+        </button>
+      );
+    }
+
+    return (
+      <div className="text-[11px] text-neutral-400 text-center py-4">
+        {emptyLabel}
+      </div>
     );
   };
 
@@ -490,26 +600,52 @@ export const UserProfilePanel: React.FC<UserProfilePanelProps> = ({
         <div className="p-3 space-y-4">
           {/* Stats */}
           <div className="grid grid-cols-2 gap-2">
-            <div className="py-1.5">
+            <button
+              type="button"
+              onClick={openMessages}
+              disabled={isLoading}
+              className="py-1.5 text-left disabled:cursor-default"
+            >
               <SectionHeader className="mb-1">
                 {t("apps.admin.profile.messages")}
               </SectionHeader>
               {isLoading ? (
                 <Skeleton className="h-5 w-8" />
+              ) : isRoomActivityLoading && !hasLoadedRoomActivity ? (
+                <span className="text-[11px] text-neutral-500">
+                  {t("common.loading.default")}
+                </span>
+              ) : messagesCount !== null ? (
+                <span className="text-[14px] font-medium">{messagesCount}</span>
               ) : (
-                <span className="text-[14px] font-medium">{profile?.messageCount || 0}</span>
+                <span className="text-[11px] text-neutral-500">
+                  {t("apps.admin.profile.loadOnDemand", "Load on demand")}
+                </span>
               )}
-            </div>
-            <div className="py-1.5">
+            </button>
+            <button
+              type="button"
+              onClick={openRooms}
+              disabled={isLoading}
+              className="py-1.5 text-left disabled:cursor-default"
+            >
               <SectionHeader className="mb-1">
                 {t("apps.admin.profile.rooms")}
               </SectionHeader>
               {isLoading ? (
                 <Skeleton className="h-5 w-8" />
+              ) : isRoomActivityLoading && !hasLoadedRoomActivity ? (
+                <span className="text-[11px] text-neutral-500">
+                  {t("common.loading.default")}
+                </span>
+              ) : roomsCount !== null ? (
+                <span className="text-[14px] font-medium">{roomsCount}</span>
               ) : (
-                <span className="text-[14px] font-medium">{profile?.rooms?.length || 0}</span>
+                <span className="text-[11px] text-neutral-500">
+                  {t("apps.admin.profile.loadOnDemand", "Load on demand")}
+                </span>
               )}
-            </div>
+            </button>
           </div>
 
           {/* Ban Info */}
@@ -897,17 +1033,26 @@ export const UserProfilePanel: React.FC<UserProfilePanelProps> = ({
           ) : (
             <div className="space-y-2">
               <SectionHeader
-                onClick={() => setIsRoomsOpen((prev) => !prev)}
+                onClick={toggleRooms}
                 isOpen={isRoomsOpen}
                 showCaret={true}
               >
-                {t("apps.admin.profile.activeRooms")} ({roomsCount})
+                {t("apps.admin.profile.activeRooms")}
+                {roomsCount !== null ? ` (${roomsCount})` : ""}
               </SectionHeader>
               {isRoomsOpen && (
                 <>
-                  {roomsCount > 0 && (
+                  {!hasLoadedRoomActivity || roomsCount === 0 ? (
+                    <LazySectionState
+                      onLoad={openRooms}
+                      emptyLabel={t(
+                        "apps.admin.profile.noActiveRooms",
+                        "No room activity found"
+                      )}
+                    />
+                  ) : (
                     <div className="flex flex-wrap gap-1">
-                      {profile?.rooms?.map((room) => (
+                      {rooms.map((room) => (
                         <span
                           key={room.id}
                           className="px-2 py-1 text-[10px] bg-gray-100 rounded"
@@ -934,53 +1079,66 @@ export const UserProfilePanel: React.FC<UserProfilePanelProps> = ({
           ) : (
             <div className="space-y-2">
               <SectionHeader
-                onClick={() => setIsMessagesOpen((prev) => !prev)}
+                onClick={toggleMessages}
                 isOpen={isMessagesOpen}
                 showCaret={true}
               >
-                {t("apps.admin.profile.recentMessages")} ({messagesCount})
+                {t("apps.admin.profile.recentMessages")}
+                {messagesCount !== null ? ` (${messagesCount})` : ""}
               </SectionHeader>
               {isMessagesOpen && (
                 <>
-                  {messagesCount === 0 ? (
-                    <div className="text-[11px] text-neutral-400 text-center py-4">
-                      {t("apps.admin.profile.noMessages")}
-                    </div>
+                  {!hasLoadedRoomActivity || messages.length === 0 ? (
+                    <LazySectionState
+                      onLoad={openMessages}
+                      emptyLabel={t("apps.admin.profile.noMessages")}
+                    />
                   ) : (
-                    <Table className="table-fixed">
-                      <TableHeader>
-                        <TableRow className="text-[10px] border-none font-normal">
-                          <TableHead className="font-normal bg-gray-100/50 h-[24px] w-[25%]">
-                            {t("apps.admin.profile.room")}
-                          </TableHead>
-                          <TableHead className="font-normal bg-gray-100/50 h-[24px]">
-                            {t("apps.admin.tableHeaders.message")}
-                          </TableHead>
-                          <TableHead className="font-normal bg-gray-100/50 h-[24px] whitespace-nowrap w-[20%]">
-                            {t("apps.admin.tableHeaders.time")}
-                          </TableHead>
-                        </TableRow>
-                      </TableHeader>
-                      <TableBody className="text-[11px]">
-                        {messages.map((message) => (
-                          <TableRow
-                            key={message.id}
-                            className="border-none hover:bg-gray-100/50 transition-colors cursor-default odd:bg-gray-200/30"
-                          >
-                            <TableCell>
-                              <span className="text-neutral-500">#</span>
-                              <span className="break-all">{message.roomName || message.roomId}</span>
-                            </TableCell>
-                            <TableCell className="min-w-0">
-                              <span className="line-clamp-2 break-words">{message.content}</span>
-                            </TableCell>
-                            <TableCell className="whitespace-nowrap text-neutral-500">
-                              {formatRelativeTime(message.timestamp)}
-                            </TableCell>
+                    <div className="space-y-2">
+                      {isMessagesTruncated && (
+                        <div className="text-[10px] text-neutral-400">
+                          {t("apps.admin.profile.showingLatestMessages", {
+                            shown: messages.length,
+                            total: messagesCount || messages.length,
+                            defaultValue: `Showing latest ${messages.length} of ${messagesCount || messages.length} messages`,
+                          })}
+                        </div>
+                      )}
+                      <Table className="table-fixed">
+                        <TableHeader>
+                          <TableRow className="text-[10px] border-none font-normal">
+                            <TableHead className="font-normal bg-gray-100/50 h-[24px] w-[25%]">
+                              {t("apps.admin.profile.room")}
+                            </TableHead>
+                            <TableHead className="font-normal bg-gray-100/50 h-[24px]">
+                              {t("apps.admin.tableHeaders.message")}
+                            </TableHead>
+                            <TableHead className="font-normal bg-gray-100/50 h-[24px] whitespace-nowrap w-[20%]">
+                              {t("apps.admin.tableHeaders.time")}
+                            </TableHead>
                           </TableRow>
-                        ))}
-                      </TableBody>
-                    </Table>
+                        </TableHeader>
+                        <TableBody className="text-[11px]">
+                          {messages.map((message) => (
+                            <TableRow
+                              key={message.id}
+                              className="border-none hover:bg-gray-100/50 transition-colors cursor-default odd:bg-gray-200/30"
+                            >
+                              <TableCell>
+                                <span className="text-neutral-500">#</span>
+                                <span className="break-all">{message.roomName || message.roomId}</span>
+                              </TableCell>
+                              <TableCell className="min-w-0">
+                                <span className="line-clamp-2 break-words">{message.content}</span>
+                              </TableCell>
+                              <TableCell className="whitespace-nowrap text-neutral-500">
+                                {formatRelativeTime(message.timestamp)}
+                              </TableCell>
+                            </TableRow>
+                          ))}
+                        </TableBody>
+                      </Table>
+                    </div>
                   )}
                 </>
               )}

--- a/tests/test-admin.test.ts
+++ b/tests/test-admin.test.ts
@@ -18,6 +18,7 @@ let adminToken: string | null = null;
 // Test user for deletion tests
 let testUserToken: string | null = null;
 let testUsername: string | null = null;
+let activityRoomId: string | null = null;
 
 describe("admin", () => {
   beforeAll(async () => {
@@ -203,6 +204,86 @@ describe("admin", () => {
       );
       expect(adminUser).toBeTruthy();
       expect(typeof adminUser.lastActive).toBe("number");
+    });
+
+    test("GET getUserProfile - returns lightweight profile payload", async () => {
+      if (!adminToken || !testUsername) {
+        console.log("  ⚠️  Skipped (no admin token or test user available)");
+        return;
+      }
+
+      const res = await fetchWithAuth(
+        `${BASE_URL}/api/admin?action=getUserProfile&username=${encodeURIComponent(testUsername)}`,
+        ADMIN_USERNAME,
+        adminToken,
+        { method: "GET" }
+      );
+
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.username).toBe(testUsername);
+      expect(typeof data.lastActive).toBe("number");
+      expect("rooms" in data).toBe(false);
+      expect("messageCount" in data).toBe(false);
+    });
+
+    test("GET getUserRoomActivity - loads rooms and recent messages on demand", async () => {
+      if (!adminToken || !testUserToken || !testUsername) {
+        console.log("  ⚠️  Skipped (missing auth setup)");
+        return;
+      }
+
+      const createRoomRes = await fetchWithAuth(
+        `${BASE_URL}/api/rooms`,
+        ADMIN_USERNAME,
+        adminToken,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            type: "private",
+            members: [testUsername],
+          }),
+        }
+      );
+      expect(createRoomRes.status).toBe(201);
+      const createRoomData = await createRoomRes.json();
+      activityRoomId = createRoomData.room?.id ?? null;
+      expect(activityRoomId).toBeTruthy();
+
+      const messageContent = `Admin activity test message ${Date.now()}`;
+      const sendMessageRes = await fetchWithAuth(
+        `${BASE_URL}/api/rooms/${activityRoomId}/messages`,
+        testUsername,
+        testUserToken,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ content: messageContent }),
+        }
+      );
+      expect(sendMessageRes.status).toBe(201);
+
+      const activityRes = await fetchWithAuth(
+        `${BASE_URL}/api/admin?action=getUserRoomActivity&username=${encodeURIComponent(testUsername)}&limit=10`,
+        ADMIN_USERNAME,
+        adminToken,
+        { method: "GET" }
+      );
+      expect(activityRes.status).toBe(200);
+      const activityData = await activityRes.json();
+
+      expect(typeof activityData.messageCount).toBe("number");
+      expect(activityData.messageCount).toBeGreaterThanOrEqual(1);
+      expect(Array.isArray(activityData.rooms)).toBe(true);
+      expect(Array.isArray(activityData.messages)).toBe(true);
+      expect(activityData.rooms.some((room: { id: string }) => room.id === activityRoomId)).toBe(true);
+      expect(
+        activityData.messages.some(
+          (message: { roomId: string; content: string }) =>
+            message.roomId === activityRoomId && message.content.includes("Admin activity test message")
+        )
+      ).toBe(true);
     });
 
     test("POST deleteUser - missing target username", async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- stop loading admin user rooms and recent messages during initial profile open
- move room/message activity into a dedicated lazy-loaded admin endpoint
- add admin API coverage for the lightweight profile payload and on-demand activity fetch

## Testing
- bun run build
- API_URL=http://localhost:3001 bun run test:admin
- manual UI verification attempted, but local Vite `/api` proxy returned 403 for authenticated admin requests while direct standalone API requests succeeded
<!-- CURSOR_AGENT_PR_BODY_END -->

---
<p><a href="https://cursor.com/agents/bc-9f3fb65d-ec8b-4530-8d66-8710a9af8436"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9f3fb65d-ec8b-4530-8d66-8710a9af8436"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

