### PR TITLE
Harden cloud sync remote apply reconciliation

### DIFF
--- a/src/apps/control-panels/hooks/useControlPanelsLogic.ts
+++ b/src/apps/control-panels/hooks/useControlPanelsLogic.ts
@@ -869,6 +869,8 @@ export function useControlPanelsLogic({
           const metadata = await downloadAndApplyCloudSyncDomain(domain, {
             username,
             isAuthenticated,
+          }, {
+            applyMode: "replace",
           });
           syncStore.markDownloadSuccess(domain, metadata.updatedAt);
           syncStore.updateRemoteMetadataForDomain(domain, metadata);

--- a/src/hooks/useAutoCloudSync.ts
+++ b/src/hooks/useAutoCloudSync.ts
@@ -30,6 +30,10 @@ import {
   uploadCloudSyncDomain,
 } from "@/utils/cloudSync";
 import {
+  describeActiveCloudSyncMutationSources,
+  shouldSkipAutoCloudSyncUpload,
+} from "@/utils/cloudSyncMutationSource";
+import {
   CLOUD_SYNC_DOMAINS,
   CLOUD_SYNC_REMOTE_APPLY_DOMAINS,
   getLatestCloudSyncTimestamp,
@@ -234,6 +238,13 @@ export function useAutoCloudSync() {
     (domain: CloudSyncDomain) => {
       if (!isSyncActive || !isDomainEnabled(domain)) {
         console.log(`[CloudSync] queueUpload(${domain}) skipped: syncActive=${isSyncActive}, enabled=${isDomainEnabled(domain)}`);
+        return;
+      }
+
+      if (shouldSkipAutoCloudSyncUpload()) {
+        console.log(
+          `[CloudSync] queueUpload(${domain}) ignored: non-user mutation (${describeActiveCloudSyncMutationSources()})`
+        );
         return;
       }
 

--- a/src/stores/useFilesStore.ts
+++ b/src/stores/useFilesStore.ts
@@ -5,6 +5,7 @@ import { ensureIndexedDBInitialized, STORES } from "@/utils/indexedDB";
 import type { OsThemeId } from "@/themes/types";
 import { getAppBasicInfoList } from "@/config/appRegistryData";
 import { abortableFetch } from "@/utils/abortableFetch";
+import { runWithCloudSyncMutationSource } from "@/utils/cloudSyncMutationSource";
 import { useCloudSyncStore } from "@/stores/useCloudSyncStore";
 
 // Define the structure for a file system item (metadata)
@@ -1374,26 +1375,35 @@ export const useFilesStore = create<FilesStoreState>()(
           if (state.libraryState === "uninitialized") {
             // For new users: initializeLibrary handles everything including
             // creating directories and desktop shortcuts in proper order
-            Promise.resolve(state.initializeLibrary()).catch((err) =>
+            void runWithCloudSyncMutationSource(
+              "system-bootstrap",
+              () => state.initializeLibrary(),
+              "files-store:initializeLibrary"
+            ).catch((err) =>
               console.error("Files initialization failed on rehydrate", err)
             );
           } else {
             // For existing users: sync root directories and ensure desktop shortcuts
             // This handles cases where new apps are added in updates
             // Also register default files for lazy loading (uses cached JSON)
-            Promise.all([
-              loadDefaultFiles().then((data) => {
-                registerFilesForLazyLoad(data.files, state.items);
-              }),
-              loadDefaultApplets().then((data) => {
-                registerFilesForLazyLoad(data.applets, state.items);
-              }),
-              state.syncRootDirectoriesFromDefaults().then(() => {
-                if (state.ensureDefaultDesktopShortcuts) {
-                  return state.ensureDefaultDesktopShortcuts();
-                }
-              }),
-            ]).catch(
+            void runWithCloudSyncMutationSource(
+              "system-bootstrap",
+              () =>
+                Promise.all([
+                  loadDefaultFiles().then((data) => {
+                    registerFilesForLazyLoad(data.files, state.items);
+                  }),
+                  loadDefaultApplets().then((data) => {
+                    registerFilesForLazyLoad(data.applets, state.items);
+                  }),
+                  state.syncRootDirectoriesFromDefaults().then(() => {
+                    if (state.ensureDefaultDesktopShortcuts) {
+                      return state.ensureDefaultDesktopShortcuts();
+                    }
+                  }),
+                ]),
+              "files-store:rehydrate"
+            ).catch(
               (err) =>
                 console.error(
                   "Files root directory sync failed on rehydrate",

--- a/src/stores/useIpodStore.ts
+++ b/src/stores/useIpodStore.ts
@@ -6,6 +6,7 @@ import type { FuriganaSegment } from "@/utils/romanization";
 import { getApiUrl } from "@/utils/platform";
 import { getAppPublicOrigin } from "@/utils/runtimeConfig";
 import { getCachedSongMetadata, listAllCachedSongMetadata } from "@/utils/songMetadataCache";
+import { runWithCloudSyncMutationSource } from "@/utils/cloudSyncMutationSource";
 import i18n from "@/lib/i18n";
 import { useChatsStore } from "./useChatsStore";
 import { abortableFetch } from "@/utils/abortableFetch";
@@ -1533,7 +1534,11 @@ export const useIpodStore = create<IpodState>()(
             console.error("Error rehydrating iPod store:", error);
           } else if (state && state.libraryState === "uninitialized") {
             // Only auto-initialize if library state is uninitialized
-            Promise.resolve(state.initializeLibrary()).catch((err) =>
+            void runWithCloudSyncMutationSource(
+              "system-bootstrap",
+              () => state.initializeLibrary(),
+              "ipod-store:initializeLibrary"
+            ).catch((err) =>
               console.error("Initialization failed on rehydrate", err)
             );
           }

--- a/src/utils/cloudSync.ts
+++ b/src/utils/cloudSync.ts
@@ -60,6 +60,7 @@ import {
   normalizeDeletionMarkerMap,
   type DeletionMarkerMap,
 } from "@/utils/cloudSyncDeletionMarkers";
+import { runWithCloudSyncMutationSource } from "@/utils/cloudSyncMutationSource";
 type AuthContext = {
   username: string;
   isAuthenticated: boolean;
@@ -1532,11 +1533,17 @@ export async function downloadAndApplyCloudSyncDomain(
   domain: CloudSyncDomain,
   _auth: AuthContext
 ): Promise<CloudSyncDomainMetadata> {
-  if (isRedisSyncDomain(domain)) {
-    return downloadRedisStateDomain(domain, _auth);
-  }
-  if (isBlobSyncDomain(domain)) {
-    return downloadBlobDomain(domain, _auth);
-  }
-  throw new Error(`Unknown sync domain: ${domain}`);
+  return runWithCloudSyncMutationSource(
+    "remote-sync",
+    async () => {
+      if (isRedisSyncDomain(domain)) {
+        return downloadRedisStateDomain(domain, _auth);
+      }
+      if (isBlobSyncDomain(domain)) {
+        return downloadBlobDomain(domain, _auth);
+      }
+      throw new Error(`Unknown sync domain: ${domain}`);
+    },
+    domain
+  );
 }

--- a/src/utils/cloudSync.ts
+++ b/src/utils/cloudSync.ts
@@ -60,11 +60,21 @@ import {
   normalizeDeletionMarkerMap,
   type DeletionMarkerMap,
 } from "@/utils/cloudSyncDeletionMarkers";
+import {
+  planIndividualBlobDomainApply,
+  resolveIndividualBlobApplyMode,
+  type IndividualBlobApplyMode,
+  type IndividualBlobDownloadApplyMode,
+} from "@/utils/cloudSyncIndividualBlobApply";
 import { runWithCloudSyncMutationSource } from "@/utils/cloudSyncMutationSource";
 type AuthContext = {
   username: string;
   isAuthenticated: boolean;
 };
+
+export interface DownloadCloudSyncDomainOptions {
+  applyMode?: IndividualBlobDownloadApplyMode;
+}
 
 let _syncSessionId: string | null = null;
 
@@ -998,30 +1008,38 @@ async function applyIndividualBlobDomain(
   domain: IndividualBlobSyncDomain,
   remoteKeys: string[],
   changedItems: Record<string, StoreItemWithKey>,
-  deletedKeys: DeletionMarkerMap = {}
+  deletedKeys: DeletionMarkerMap = {},
+  mode: IndividualBlobApplyMode = "incremental"
 ): Promise<void> {
   const storeName = getIndividualBlobStoreName(domain);
   const db = await ensureIndexedDBInitialized();
-  const effectiveRemoteKeys = remoteKeys.filter((key) => !deletedKeys[key]);
+  let finalKeys: string[] = [];
 
   try {
     const existingItems = await readStoreItems(db, storeName);
-    const existingKeys = new Set(existingItems.map((item) => item.key));
-    const remoteKeySet = new Set(effectiveRemoteKeys);
-    const keysToDelete = Array.from(existingKeys).filter((key) => !remoteKeySet.has(key));
+    const plan = planIndividualBlobDomainApply({
+      mode,
+      existingKeys: existingItems.map((item) => item.key),
+      remoteKeys,
+      changedItemKeys: Object.keys(changedItems),
+      deletedKeys,
+    });
 
-    await deleteStoreItemsByKey(db, storeName, keysToDelete);
+    await deleteStoreItemsByKey(db, storeName, plan.keysToDelete);
     await upsertStoreItems(
       db,
       storeName,
-      Object.values(changedItems).filter((item) => !deletedKeys[item.key])
+      plan.keysToUpsert
+        .map((key) => changedItems[key])
+        .filter((item): item is StoreItemWithKey => Boolean(item))
     );
+    finalKeys = plan.finalKeys;
   } finally {
     db.close();
   }
 
   if (domain === "custom-wallpapers") {
-    await finalizeCustomWallpaperSync(effectiveRemoteKeys);
+    await finalizeCustomWallpaperSync(finalKeys);
   }
 }
 
@@ -1467,7 +1485,8 @@ async function downloadRedisStateDomain(
 
 async function downloadBlobDomain(
   domain: BlobSyncDomain,
-  _auth: AuthContext
+  _auth: AuthContext,
+  options: DownloadCloudSyncDomainOptions = {}
 ): Promise<CloudSyncDomainMetadata> {
   const data = await fetchBlobDomainInfo(domain, _auth);
   if (!data?.metadata) {
@@ -1483,6 +1502,14 @@ async function downloadBlobDomain(
       remoteDeletedItems
     );
     const localRecords = await serializeIndividualBlobDomainRecords(domain);
+    const domainStatus = useCloudSyncStore.getState().domainStatus[domain];
+    const applyMode = resolveIndividualBlobApplyMode({
+      requestedMode: options.applyMode,
+      localItemCount: localRecords.length,
+      hasSyncHistory: Boolean(
+        domainStatus.lastAppliedRemoteAt || domainStatus.lastUploadedAt
+      ),
+    });
     const localRecordMap = new Map(
       localRecords.map((record) => [record.item.key, record])
     );
@@ -1500,7 +1527,11 @@ async function downloadBlobDomain(
       }
 
       const localRecord = localRecordMap.get(itemKey);
-      if (localRecord && localRecord.signature === itemMetadata.signature) {
+      if (
+        applyMode !== "replace" &&
+        localRecord &&
+        localRecord.signature === itemMetadata.signature
+      ) {
         continue;
       }
 
@@ -1514,7 +1545,8 @@ async function downloadBlobDomain(
       domain,
       Object.keys(remoteItems),
       changedItems,
-      effectiveDeletedItems
+      effectiveDeletedItems,
+      applyMode
     );
     return data.metadata;
   }
@@ -1531,7 +1563,8 @@ async function downloadBlobDomain(
 
 export async function downloadAndApplyCloudSyncDomain(
   domain: CloudSyncDomain,
-  _auth: AuthContext
+  _auth: AuthContext,
+  options: DownloadCloudSyncDomainOptions = {}
 ): Promise<CloudSyncDomainMetadata> {
   return runWithCloudSyncMutationSource(
     "remote-sync",
@@ -1540,7 +1573,7 @@ export async function downloadAndApplyCloudSyncDomain(
         return downloadRedisStateDomain(domain, _auth);
       }
       if (isBlobSyncDomain(domain)) {
-        return downloadBlobDomain(domain, _auth);
+        return downloadBlobDomain(domain, _auth, options);
       }
       throw new Error(`Unknown sync domain: ${domain}`);
     },

--- a/src/utils/cloudSyncIndividualBlobApply.ts
+++ b/src/utils/cloudSyncIndividualBlobApply.ts
@@ -1,0 +1,87 @@
+import type { DeletionMarkerMap } from "@/utils/cloudSyncDeletionMarkers";
+
+export type IndividualBlobApplyMode = "incremental" | "replace";
+export type IndividualBlobDownloadApplyMode =
+  | "auto"
+  | IndividualBlobApplyMode;
+
+interface ResolveIndividualBlobApplyModeParams {
+  requestedMode?: IndividualBlobDownloadApplyMode;
+  localItemCount: number;
+  hasSyncHistory: boolean;
+}
+
+interface PlanIndividualBlobDomainApplyParams {
+  mode: IndividualBlobApplyMode;
+  existingKeys: Iterable<string>;
+  remoteKeys: Iterable<string>;
+  changedItemKeys: Iterable<string>;
+  deletedKeys?: DeletionMarkerMap;
+}
+
+export interface IndividualBlobApplyPlan {
+  keysToDelete: string[];
+  keysToUpsert: string[];
+  finalKeys: string[];
+}
+
+export function resolveIndividualBlobApplyMode({
+  requestedMode = "auto",
+  localItemCount,
+  hasSyncHistory,
+}: ResolveIndividualBlobApplyModeParams): IndividualBlobApplyMode {
+  if (requestedMode === "incremental" || requestedMode === "replace") {
+    return requestedMode;
+  }
+
+  if (!hasSyncHistory && localItemCount === 0) {
+    return "replace";
+  }
+
+  return "incremental";
+}
+
+export function planIndividualBlobDomainApply({
+  mode,
+  existingKeys,
+  remoteKeys,
+  changedItemKeys,
+  deletedKeys = {},
+}: PlanIndividualBlobDomainApplyParams): IndividualBlobApplyPlan {
+  const existingKeySet = new Set(existingKeys);
+  const filteredRemoteKeySet = new Set(
+    Array.from(remoteKeys).filter((key) => !deletedKeys[key])
+  );
+  const changedKeySet = new Set(
+    Array.from(changedItemKeys).filter((key) => !deletedKeys[key])
+  );
+
+  if (mode === "replace") {
+    return {
+      keysToDelete: Array.from(existingKeySet).filter(
+        (key) => !filteredRemoteKeySet.has(key)
+      ),
+      keysToUpsert: Array.from(changedKeySet),
+      finalKeys: Array.from(filteredRemoteKeySet),
+    };
+  }
+
+  const deletedKeySet = new Set(
+    Object.keys(deletedKeys).filter((key) => existingKeySet.has(key))
+  );
+  const finalKeySet = new Set(existingKeySet);
+
+  for (const key of deletedKeySet) {
+    finalKeySet.delete(key);
+  }
+
+  for (const key of changedKeySet) {
+    finalKeySet.add(key);
+  }
+
+  return {
+    keysToDelete: Array.from(deletedKeySet),
+    keysToUpsert: Array.from(changedKeySet),
+    finalKeys: Array.from(finalKeySet),
+  };
+}

--- a/src/utils/cloudSyncMutationSource.ts
+++ b/src/utils/cloudSyncMutationSource.ts
@@ -1,0 +1,72 @@
+export const CLOUD_SYNC_MUTATION_SOURCES = [
+  "remote-sync",
+  "system-bootstrap",
+] as const;
+
+export type CloudSyncMutationSource =
+  (typeof CLOUD_SYNC_MUTATION_SOURCES)[number];
+
+interface CloudSyncMutationFrame {
+  source: CloudSyncMutationSource;
+  reason?: string;
+}
+
+const activeMutationFrames: CloudSyncMutationFrame[] = [];
+
+function removeMutationFrame(frame: CloudSyncMutationFrame): void {
+  const index = activeMutationFrames.lastIndexOf(frame);
+  if (index >= 0) {
+    activeMutationFrames.splice(index, 1);
+  }
+}
+
+export function getActiveCloudSyncMutationFrames(): readonly CloudSyncMutationFrame[] {
+  return activeMutationFrames;
+}
+
+export function getActiveCloudSyncMutationSources(): readonly CloudSyncMutationSource[] {
+  return Array.from(new Set(activeMutationFrames.map((frame) => frame.source)));
+}
+
+export function describeActiveCloudSyncMutationSources(): string {
+  if (activeMutationFrames.length === 0) {
+    return "none";
+  }
+
+  return activeMutationFrames
+    .map((frame) => (frame.reason ? `${frame.source}:${frame.reason}` : frame.source))
+    .join(", ");
+}
+
+export function hasActiveCloudSyncMutationSource(
+  source?: CloudSyncMutationSource
+): boolean {
+  if (!source) {
+    return activeMutationFrames.length > 0;
+  }
+
+  return activeMutationFrames.some((frame) => frame.source === source);
+}
+
+export function shouldSkipAutoCloudSyncUpload(): boolean {
+  return hasActiveCloudSyncMutationSource();
+}
+
+export async function runWithCloudSyncMutationSource<T>(
+  source: CloudSyncMutationSource,
+  callback: () => Promise<T> | T,
+  reason?: string
+): Promise<T> {
+  const frame: CloudSyncMutationFrame = { source, reason };
+  activeMutationFrames.push(frame);
+
+  try {
+    return await callback();
+  } finally {
+    removeMutationFrame(frame);
+  }
+}
+
+export function __resetCloudSyncMutationSourcesForTests(): void {
+  activeMutationFrames.length = 0;
+}

--- a/tests/test-cloud-sync-individual-blob-apply.test.ts
+++ b/tests/test-cloud-sync-individual-blob-apply.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test } from "bun:test";
+import {
+  planIndividualBlobDomainApply,
+  resolveIndividualBlobApplyMode,
+} from "../src/utils/cloudSyncIndividualBlobApply";
+
+describe("cloud sync individual blob apply planning", () => {
+  test("uses replace mode for first download into an empty store", () => {
+    expect(
+      resolveIndividualBlobApplyMode({
+        requestedMode: "auto",
+        localItemCount: 0,
+        hasSyncHistory: false,
+      })
+    ).toBe("replace");
+  });
+
+  test("uses incremental mode once local state or sync history exists", () => {
+    expect(
+      resolveIndividualBlobApplyMode({
+        requestedMode: "auto",
+        localItemCount: 2,
+        hasSyncHistory: false,
+      })
+    ).toBe("incremental");
+
+    expect(
+      resolveIndividualBlobApplyMode({
+        requestedMode: "auto",
+        localItemCount: 0,
+        hasSyncHistory: true,
+      })
+    ).toBe("incremental");
+  });
+
+  test("incremental apply keeps unrelated local items and deletes only explicit tombstones", () => {
+    expect(
+      planIndividualBlobDomainApply({
+        mode: "incremental",
+        existingKeys: ["wall-1", "wall-2", "local-only"],
+        remoteKeys: ["wall-1", "wall-3"],
+        changedItemKeys: ["wall-3"],
+        deletedKeys: {
+          "wall-2": "2026-03-13T22:55:00.000Z",
+        },
+      })
+    ).toEqual({
+      keysToDelete: ["wall-2"],
+      keysToUpsert: ["wall-3"],
+      finalKeys: ["wall-1", "local-only", "wall-3"],
+    });
+  });
+
+  test("replace apply reconciles local state to the remote set", () => {
+    expect(
+      planIndividualBlobDomainApply({
+        mode: "replace",
+        existingKeys: ["wall-1", "wall-2", "local-only"],
+        remoteKeys: ["wall-1", "wall-3"],
+        changedItemKeys: ["wall-1", "wall-3"],
+        deletedKeys: {},
+      })
+    ).toEqual({
+      keysToDelete: ["wall-2", "local-only"],
+      keysToUpsert: ["wall-1", "wall-3"],
+      finalKeys: ["wall-1", "wall-3"],
+    });
+  });
+});

--- a/tests/test-cloud-sync-mutation-source.test.ts
+++ b/tests/test-cloud-sync-mutation-source.test.ts
@@ -1,0 +1,75 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  __resetCloudSyncMutationSourcesForTests,
+  describeActiveCloudSyncMutationSources,
+  getActiveCloudSyncMutationSources,
+  hasActiveCloudSyncMutationSource,
+  runWithCloudSyncMutationSource,
+  shouldSkipAutoCloudSyncUpload,
+} from "../src/utils/cloudSyncMutationSource";
+
+describe("cloud sync mutation source tracking", () => {
+  afterEach(() => {
+    __resetCloudSyncMutationSourcesForTests();
+  });
+
+  test("treats remote-sync mutations as non-user uploads", async () => {
+    expect(shouldSkipAutoCloudSyncUpload()).toBe(false);
+
+    await runWithCloudSyncMutationSource(
+      "remote-sync",
+      async () => {
+        expect(shouldSkipAutoCloudSyncUpload()).toBe(true);
+        expect(hasActiveCloudSyncMutationSource("remote-sync")).toBe(true);
+        expect(getActiveCloudSyncMutationSources()).toEqual(["remote-sync"]);
+        expect(describeActiveCloudSyncMutationSources()).toBe(
+          "remote-sync:files-metadata"
+        );
+      },
+      "files-metadata"
+    );
+
+    expect(shouldSkipAutoCloudSyncUpload()).toBe(false);
+    expect(getActiveCloudSyncMutationSources()).toEqual([]);
+  });
+
+  test("keeps uploads blocked until nested bootstrap scopes complete", async () => {
+    await runWithCloudSyncMutationSource(
+      "remote-sync",
+      async () => {
+        await runWithCloudSyncMutationSource(
+          "system-bootstrap",
+          async () => {
+            expect(shouldSkipAutoCloudSyncUpload()).toBe(true);
+            expect(getActiveCloudSyncMutationSources()).toEqual([
+              "remote-sync",
+              "system-bootstrap",
+            ]);
+          },
+          "files-store:initializeLibrary"
+        );
+
+        expect(shouldSkipAutoCloudSyncUpload()).toBe(true);
+        expect(getActiveCloudSyncMutationSources()).toEqual(["remote-sync"]);
+      },
+      "settings"
+    );
+
+    expect(shouldSkipAutoCloudSyncUpload()).toBe(false);
+  });
+
+  test("cleans up mutation state after failures", async () => {
+    await expect(
+      runWithCloudSyncMutationSource(
+        "system-bootstrap",
+        async () => {
+          throw new Error("boom");
+        },
+        "ipod-store:initializeLibrary"
+      )
+    ).rejects.toThrow("boom");
+
+    expect(shouldSkipAutoCloudSyncUpload()).toBe(false);
+    expect(describeActiveCloudSyncMutationSources()).toBe("none");
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- track non-user cloud-sync mutation sources so remote applies and bootstrap hydration do not queue uploads back to the cloud
- switch individual blob domains to incremental per-item apply during normal sync, while keeping full replacement for force download and first sync into an empty local store
- add focused regression tests for mutation-source gating and individual blob apply planning

## Testing
- bun test tests/test-cloud-sync-mutation-source.test.ts tests/test-cloud-sync-individual-blob-apply.test.ts tests/test-cloud-sync-utils.test.ts
- bun run build
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-62dc05c8-c053-4512-817b-bbadd697bb1d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-62dc05c8-c053-4512-817b-bbadd697bb1d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

