### PR TITLE
feat: add Live Listen support to iPod (Remote Control)

### DIFF
--- a/src/apps/base/appRouteRegistry.ts
+++ b/src/apps/base/appRouteRegistry.ts
@@ -125,9 +125,14 @@ export function resolveInitialRoute(pathname: string): RouteAction | null {
 
   const listenMatch = pathname.match(/^\/listen\/(.+)$/);
   if (listenMatch) {
+    const searchParams = typeof window !== "undefined"
+      ? new URLSearchParams(window.location.search)
+      : new URLSearchParams();
+    const appParam = searchParams.get("app");
+    const targetApp = appParam === "ipod" ? "ipod" as const : "karaoke" as const;
     return createLaunchAction(
       {
-        appId: "karaoke",
+        appId: targetApp,
         initialData: {
           listenSessionId: listenMatch[1],
         },

--- a/src/apps/base/types.ts
+++ b/src/apps/base/types.ts
@@ -92,6 +92,7 @@ export interface InternetExplorerInitialData {
 
 export interface IpodInitialData {
   videoId?: string;
+  listenSessionId?: string;
 }
 
 export interface KaraokeInitialData {

--- a/src/apps/ipod/components/IpodAppComponent.tsx
+++ b/src/apps/ipod/components/IpodAppComponent.tsx
@@ -28,6 +28,11 @@ import { AmbientBackground } from "@/components/shared/AmbientBackground";
 import { MeshGradientBackground } from "@/components/shared/MeshGradientBackground";
 import { WaterBackground } from "@/components/shared/WaterBackground";
 import { PLAYER_PROGRESS_INTERVAL_MS } from "../constants";
+import { ListenSessionInvite } from "@/components/listen/ListenSessionInvite";
+import { JoinSessionDialog } from "@/components/listen/JoinSessionDialog";
+import { ListenSessionBadge } from "@/components/listen/ListenSessionBadge";
+import { ListenSessionToolbar } from "@/components/listen/ListenSessionToolbar";
+import { ReactionOverlay } from "@/components/listen/ReactionOverlay";
 
 export function IpodAppComponent({
   isWindowOpen,
@@ -95,6 +100,20 @@ export function IpodAppComponent({
     setIsSongSearchDialogOpen,
     isSyncModeOpen,
     setIsSyncModeOpen,
+    isListenInviteOpen,
+    setIsListenInviteOpen,
+    isJoinListenDialogOpen,
+    setIsJoinListenDialogOpen,
+    listenSession,
+    listenListenerCount,
+    isListenSessionHost,
+    isListenSessionDj,
+    isListenSessionAnonymous,
+    handleStartListenSession,
+    handleJoinListenSession,
+    handleLeaveListenSession,
+    handlePassDj,
+    handleSendReaction,
     currentTrack,
     lyricsSourceOverride,
     fullscreenCoverUrl,
@@ -192,6 +211,12 @@ export function IpodAppComponent({
       onRefreshLyrics={handleRefreshLyrics}
       onAdjustTiming={() => setIsSyncModeOpen(true)}
       onToggleCoverFlow={() => setIsCoverFlowOpen(!isCoverFlowOpen)}
+      onStartListenSession={handleStartListenSession}
+      onJoinListenSession={() => setIsJoinListenDialogOpen(true)}
+      onShareListenSession={() => setIsListenInviteOpen(true)}
+      onLeaveListenSession={handleLeaveListenSession}
+      isInListenSession={!!listenSession}
+      isListenSessionHost={isListenSessionHost}
     />
   );
   const shouldAnimateFullScreenVisuals = isPlaying && (isForeground ?? true);
@@ -402,6 +427,20 @@ export function IpodAppComponent({
               onCenterLongPress={handleCenterLongPress}
             />
           </div>
+
+          {/* Live Listen session badge */}
+          {listenSession && (
+            <div className="absolute bottom-2 left-1/2 -translate-x-1/2 z-10">
+              <ListenSessionBadge
+                listenerCount={listenListenerCount}
+                isHost={isListenSessionHost}
+                isDj={isListenSessionDj}
+                onOpenPanel={() => setIsListenInviteOpen(true)}
+                onShare={() => setIsListenInviteOpen(true)}
+                onLeave={handleLeaveListenSession}
+              />
+            </div>
+          )}
         </div>
 
         {/* Full screen portal */}
@@ -672,6 +711,28 @@ export function IpodAppComponent({
                       />
                     </div>
                   )}
+
+                  {/* Live Listen toolbar in fullscreen */}
+                  {listenSession && (
+                    <div className="fixed top-4 left-1/2 -translate-x-1/2 z-30">
+                      <ListenSessionToolbar
+                        session={listenSession}
+                        isDj={isListenSessionDj}
+                        isAnonymous={isListenSessionAnonymous}
+                        listenerCount={listenListenerCount}
+                        onShare={() => setIsListenInviteOpen(true)}
+                        onLeave={handleLeaveListenSession}
+                        onPassDj={handlePassDj}
+                        onSendReaction={handleSendReaction}
+                        onInteraction={registerActivity}
+                      />
+                    </div>
+                  )}
+
+                  {/* Live Listen reaction overlay */}
+                  {listenSession && (
+                    <ReactionOverlay className="fixed inset-0 z-25 pointer-events-none" />
+                  )}
                 </div>
               </div>
             )}
@@ -729,6 +790,19 @@ export function IpodAppComponent({
           onOpenChange={setIsSongSearchDialogOpen}
           onSelect={handleSongSearchSelect}
           onAddUrl={handleAddUrl}
+        />
+        {listenSession && (
+          <ListenSessionInvite
+            isOpen={isListenInviteOpen}
+            onClose={() => setIsListenInviteOpen(false)}
+            sessionId={listenSession.id}
+            appType="ipod"
+          />
+        )}
+        <JoinSessionDialog
+          isOpen={isJoinListenDialogOpen}
+          onClose={() => setIsJoinListenDialogOpen(false)}
+          onJoin={handleJoinListenSession}
         />
 
         {/* Lyrics Sync Mode (non-fullscreen only - fullscreen renders in portal) */}

--- a/src/apps/ipod/components/IpodMenuBar.tsx
+++ b/src/apps/ipod/components/IpodMenuBar.tsx
@@ -35,6 +35,12 @@ interface IpodMenuBarProps {
   onRefreshLyrics?: () => void;
   onAdjustTiming?: () => void;
   onToggleCoverFlow?: () => void;
+  onStartListenSession?: () => void;
+  onJoinListenSession?: () => void;
+  onShareListenSession?: () => void;
+  onLeaveListenSession?: () => void;
+  isInListenSession?: boolean;
+  isListenSessionHost?: boolean;
 }
 
 export function IpodMenuBar({
@@ -48,6 +54,12 @@ export function IpodMenuBar({
   onRefreshLyrics,
   onAdjustTiming,
   onToggleCoverFlow,
+  onStartListenSession,
+  onJoinListenSession,
+  onShareListenSession,
+  onLeaveListenSession,
+  isInListenSession,
+  isListenSessionHost,
 }: IpodMenuBarProps) {
   const { t } = useTranslation();
   const [isShareDialogOpen, setIsShareDialogOpen] = useState(false);
@@ -253,6 +265,26 @@ export function IpodMenuBar({
           >
             {t("apps.ipod.menu.shareSong")}
           </MenubarItem>
+          <MenubarSeparator className="h-[2px] bg-black my-1" />
+          {!isInListenSession ? (
+            <>
+              <MenubarItem onClick={onStartListenSession} className="text-md h-6 px-3">
+                {t("apps.karaoke.liveListen.start")}
+              </MenubarItem>
+              <MenubarItem onClick={onJoinListenSession} className="text-md h-6 px-3">
+                {t("apps.karaoke.liveListen.join")}
+              </MenubarItem>
+            </>
+          ) : (
+            <>
+              <MenubarItem onClick={onShareListenSession} className="text-md h-6 px-3">
+                {t("apps.karaoke.liveListen.invite")}
+              </MenubarItem>
+              <MenubarItem onClick={onLeaveListenSession} className="text-md h-6 px-3">
+                {isListenSessionHost ? t("apps.karaoke.liveListen.end") : t("apps.karaoke.liveListen.leave")}
+              </MenubarItem>
+            </>
+          )}
           <MenubarSeparator className="h-[2px] bg-black my-1" />
           <MenubarItem
             onClick={handleExportLibrary}

--- a/src/apps/ipod/hooks/useIpodLogic.ts
+++ b/src/apps/ipod/hooks/useIpodLogic.ts
@@ -12,6 +12,8 @@ import { useFurigana } from "@/hooks/useFurigana";
 import { useActivityState } from "@/hooks/useActivityState";
 import { useLyricsErrorToast } from "@/hooks/useLyricsErrorToast";
 import { useCustomEventListener, useEventListener } from "@/hooks/useEventListener";
+import { useListenSync } from "@/hooks/useListenSync";
+import { useListenSessionStore } from "@/stores/useListenSessionStore";
 import { useLibraryUpdateChecker } from "./useLibraryUpdateChecker";
 import {
   useIpodStore,
@@ -169,6 +171,33 @@ export function useIpodLogic({
     [username, isAuthenticated]
   );
 
+  // Live Listen session state
+  const {
+    currentSession: listenSession,
+    isHost: isListenSessionHost,
+    isDj: isListenSessionDj,
+    isAnonymous: isListenSessionAnonymous,
+    listenerCount: listenListenerCount,
+    createSession: createListenSession,
+    joinSession: joinListenSession,
+    leaveSession: leaveListenSession,
+    syncSession: syncListenSession,
+    sendReaction: sendListenReaction,
+  } = useListenSessionStore(
+    useShallow((state) => ({
+      currentSession: state.currentSession,
+      isHost: state.isHost,
+      isDj: state.isDj,
+      isAnonymous: state.isAnonymous,
+      listenerCount: state.listenerCount,
+      createSession: state.createSession,
+      joinSession: state.joinSession,
+      leaveSession: state.leaveSession,
+      syncSession: state.syncSession,
+      sendReaction: state.sendReaction,
+    }))
+  );
+
 
   const lyricOffset = useIpodStore(
     (s) => {
@@ -213,6 +242,8 @@ export function useIpodLogic({
   const [isSongSearchDialogOpen, setIsSongSearchDialogOpen] = useState(false);
   const [isSyncModeOpen, setIsSyncModeOpen] = useState(false);
   const [isAddingSong, setIsAddingSong] = useState(false);
+  const [isListenInviteOpen, setIsListenInviteOpen] = useState(false);
+  const [isJoinListenDialogOpen, setIsJoinListenDialogOpen] = useState(false);
   
   // Cover Flow state
   const [isCoverFlowOpen, setIsCoverFlowOpen] = useState(false);
@@ -275,6 +306,39 @@ export function useIpodLogic({
   const isIOS = /iP(hone|od|ad)/.test(ua);
   const isSafari = /Safari/.test(ua) && !/Chrome/.test(ua) && !/CriOS/.test(ua);
   const isIOSSafari = isIOS && isSafari;
+
+  // Current track metadata for Live Listen sync
+  const currentTrackForSync: Track | null = tracks[currentIndex] || null;
+  const currentTrackMeta = useMemo(
+    () =>
+      currentTrackForSync
+        ? {
+            title: currentTrackForSync.title,
+            artist: currentTrackForSync.artist,
+            cover: currentTrackForSync.cover,
+          }
+        : null,
+    [currentTrackForSync]
+  );
+
+  const getActivePlayer = useCallback(
+    () => (isFullScreen ? fullScreenPlayerRef.current : playerRef.current),
+    [isFullScreen]
+  );
+
+  // Live Listen sync hook
+  useListenSync({
+    currentTrackId: currentTrackForSync?.id ?? null,
+    currentTrackMeta,
+    isPlaying,
+    setIsPlaying,
+    setCurrentTrackId: setCurrentSongId,
+    getActivePlayer,
+    addTrackFromId: useIpodStore.getState().addTrackFromVideoId,
+  });
+
+  // Ref to track processed listen session data
+  const lastProcessedListenSessionRef = useRef<string | null>(null);
 
   // Status helper functions
   const showStatus = useCallback((message: string) => {
@@ -910,11 +974,39 @@ export function useIpodLogic({
   }, [isWindowOpen, initialData, processVideoId, clearIpodInitialData, instanceId]);
 
 
+  // Handle listenSessionId from initial data
+  useEffect(() => {
+    if (
+      isWindowOpen &&
+      initialData?.listenSessionId &&
+      typeof initialData.listenSessionId === "string"
+    ) {
+      if (lastProcessedListenSessionRef.current === initialData.listenSessionId) return;
+
+      const sessionIdToProcess = initialData.listenSessionId;
+      setTimeout(() => {
+        joinListenSession(sessionIdToProcess, username || undefined)
+          .then((result) => {
+            if (!result.ok) {
+              toast.error("Failed to join session", {
+                description: result.error || "Please try again.",
+              });
+            }
+            if (instanceId) clearIpodInitialData(instanceId);
+          })
+          .catch((error) => {
+            console.error(`[iPod] Error joining listen session ${sessionIdToProcess}:`, error);
+          });
+      }, 100);
+      lastProcessedListenSessionRef.current = initialData.listenSessionId;
+    }
+  }, [isWindowOpen, initialData, joinListenSession, username, clearIpodInitialData, instanceId]);
+
   // Update app event handling
   useEffect(() => {
     return onAppUpdate((event) => {
       const updateInitialData = event.detail.initialData as
-        | { videoId?: string }
+        | { videoId?: string; listenSessionId?: string }
         | undefined;
 
       if (
@@ -936,8 +1028,32 @@ export function useIpodLogic({
         });
         lastProcessedInitialDataRef.current = updateInitialData;
       }
+
+      if (
+        event.detail.appId === "ipod" &&
+        updateInitialData?.listenSessionId &&
+        (!event.detail.instanceId || event.detail.instanceId === instanceId)
+      ) {
+        const sessionId = updateInitialData.listenSessionId;
+        if (lastProcessedListenSessionRef.current === sessionId) return;
+        if (instanceId) {
+          bringInstanceToForeground(instanceId);
+        }
+        joinListenSession(sessionId, username || undefined)
+          .then((result) => {
+            if (!result.ok) {
+              toast.error("Failed to join session", {
+                description: result.error || "Please try again.",
+              });
+            }
+          })
+          .catch((error) => {
+            console.error(`[iPod] Error joining listen session ${sessionId}:`, error);
+          });
+        lastProcessedListenSessionRef.current = sessionId;
+      }
     });
-  }, [bringInstanceToForeground, instanceId, processVideoId]);
+  }, [bringInstanceToForeground, instanceId, processVideoId, joinListenSession, username]);
 
   // Handle closing sync mode - flush pending offset saves
   const closeSyncMode = useCallback(async () => {
@@ -1388,6 +1504,84 @@ export function useIpodLogic({
     [handleAddTrack]
   );
 
+  // Live Listen session handlers
+  const handleStartListenSession = useCallback(async () => {
+    if (!username) {
+      toast.error("Login required", {
+        description: "Set a username in Chats to start a session.",
+      });
+      return;
+    }
+    const result = await createListenSession(username);
+    if (!result.ok) {
+      toast.error("Failed to start session", {
+        description: result.error || "Please try again.",
+      });
+      return;
+    }
+    setIsListenInviteOpen(true);
+  }, [createListenSession, username]);
+
+  const handleJoinListenSession = useCallback(
+    async (sessionId: string) => {
+      const result = await joinListenSession(sessionId, username || undefined);
+      if (!result.ok) {
+        toast.error("Failed to join session", {
+          description: result.error || "Please try again.",
+        });
+        return;
+      }
+    },
+    [joinListenSession, username]
+  );
+
+  const handleLeaveListenSession = useCallback(async () => {
+    const result = await leaveListenSession();
+    if (!result.ok) {
+      toast.error("Failed to leave session", {
+        description: result.error || "Please try again.",
+      });
+      return;
+    }
+    setIsListenInviteOpen(false);
+  }, [leaveListenSession]);
+
+  const handlePassDj = useCallback(
+    async (nextDj: string) => {
+      const activePlayer = getActivePlayer();
+      const positionMs = Math.max(0, (activePlayer?.getCurrentTime() ?? 0) * 1000);
+      const result = await syncListenSession({
+        currentTrackId: currentTrackForSync?.id ?? null,
+        currentTrackMeta,
+        isPlaying,
+        positionMs,
+        djUsername: nextDj,
+      });
+      if (!result.ok) {
+        toast.error("Failed to pass DJ", {
+          description: result.error || "Please try again.",
+        });
+      } else {
+        toast.success("DJ passed", {
+          description: `@${nextDj} is now the DJ.`,
+        });
+      }
+    },
+    [currentTrackForSync, currentTrackMeta, getActivePlayer, isPlaying, syncListenSession]
+  );
+
+  const handleSendReaction = useCallback(
+    async (emoji: string) => {
+      const result = await sendListenReaction(emoji);
+      if (!result.ok) {
+        toast.error("Failed to send reaction", {
+          description: result.error || "Please try again.",
+        });
+      }
+    },
+    [sendListenReaction]
+  );
+
   const currentTrack = tracks[currentIndex];
   const lyricsSourceOverride = currentTrack?.lyricsSource;
 
@@ -1793,6 +1987,22 @@ export function useIpodLogic({
     setIsSongSearchDialogOpen,
     isSyncModeOpen,
     setIsSyncModeOpen,
+    isListenInviteOpen,
+    setIsListenInviteOpen,
+    isJoinListenDialogOpen,
+    setIsJoinListenDialogOpen,
+
+    // Live Listen
+    listenSession,
+    listenListenerCount,
+    isListenSessionHost,
+    isListenSessionDj,
+    isListenSessionAnonymous,
+    handleStartListenSession,
+    handleJoinListenSession,
+    handleLeaveListenSession,
+    handlePassDj,
+    handleSendReaction,
 
     // Current track
     currentTrack,

--- a/src/types/appInitialData.ts
+++ b/src/types/appInitialData.ts
@@ -26,9 +26,10 @@ export interface InternetExplorerInitialData {
   shareCode?: string;
 }
 
-/** iPod initial data - for playing specific videos */
+/** iPod initial data - for playing specific videos or joining listen sessions */
 export interface IpodInitialData {
   videoId?: string;
+  listenSessionId?: string;
 }
 
 /** Videos initial data - for playing specific videos */


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds Live Listen (listen-together) support to the iPod app, enabling real-time playback sync across different clients/instances. Previously this feature was only available in the Karaoke app.

## Changes

### Types
- Added `listenSessionId` to `IpodInitialData` in both `src/apps/base/types.ts` and `src/types/appInitialData.ts`

### Route Registry
- Updated `/listen/:sessionId` route to respect `?app=ipod` query param, allowing listen session links to open in iPod instead of always defaulting to Karaoke

### iPod Logic (`useIpodLogic.ts`)
- Integrated `useListenSync` hook for real-time playback synchronization (track, play/pause, position drift correction)
- Added `useListenSessionStore` subscription for session state (DJ status, listener count, etc.)
- Added session management handlers: create, join, leave, pass DJ, send reactions
- Added `listenSessionId` handling in initial data and app update events

### iPod Menu Bar (`IpodMenuBar.tsx`)
- Added Live Listen menu items to File menu: Start/Join (when not in session), Invite/End (when in session)

### iPod App Component (`IpodAppComponent.tsx`)
- Added `ListenSessionBadge` for non-fullscreen session indicator
- Added `ListenSessionToolbar` with DJ controls, reactions, and share button in fullscreen
- Added `ReactionOverlay` for animated emoji reactions in fullscreen
- Added `ListenSessionInvite` dialog with QR code and share link
- Added `JoinSessionDialog` for browsing/joining active sessions

## How It Works

1. **Start a session**: File > Start Live Listen (requires login via Chats)
2. **Invite others**: Share the generated link (includes `?app=ipod` to open in iPod)
3. **DJ controls**: The DJ's playback state syncs to all listeners via Pusher
4. **Listeners**: Automatically sync track, play/pause, and position with soft/hard drift correction
5. **Pass DJ**: Transfer DJ control to another listener
6. **Reactions**: Send emoji reactions visible to all participants

## Testing

- Build passes (`bun run build`)
- All unit tests pass (`bun run test:unit` - 89/89)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9a594f64-248e-4271-ad4f-52353760af01"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9a594f64-248e-4271-ad4f-52353760af01"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

