### PR TITLE
fix: deduplicate concurrent sync state requests

### DIFF
--- a/src/utils/cloudSync.ts
+++ b/src/utils/cloudSync.ts
@@ -1585,16 +1585,34 @@ async function uploadRedisStateDomain(
   return result.metadata;
 }
 
+type RedisSnapshotResult = {
+  data: AnySnapshotData;
+  metadata: CloudSyncDomainMetadata;
+} | null;
+
+const _redisFetchInFlight = new Map<RedisSyncDomain, Promise<RedisSnapshotResult>>();
+
 async function fetchRedisStateDomainSnapshot(
   domain: RedisSyncDomain,
   _auth: AuthContext
-): Promise<
-  | {
-      data: AnySnapshotData;
-      metadata: CloudSyncDomainMetadata;
+): Promise<RedisSnapshotResult> {
+  const inflight = _redisFetchInFlight.get(domain);
+  if (inflight) return inflight;
+
+  const promise = fetchRedisStateDomainSnapshotUncached(domain, _auth).finally(
+    () => {
+      _redisFetchInFlight.delete(domain);
     }
-  | null
-> {
+  );
+
+  _redisFetchInFlight.set(domain, promise);
+  return promise;
+}
+
+async function fetchRedisStateDomainSnapshotUncached(
+  domain: RedisSyncDomain,
+  _auth: AuthContext
+): Promise<RedisSnapshotResult> {
   const response = await abortableFetch(
     getApiUrl(`/api/sync/state?domain=${encodeURIComponent(domain)}`),
     {

--- a/src/utils/cloudSyncEvents.ts
+++ b/src/utils/cloudSyncEvents.ts
@@ -34,14 +34,25 @@ export function subscribeToCloudSyncDomainChanges(
   };
 }
 
+let _syncCheckTimer: ReturnType<typeof setTimeout> | null = null;
+
+/**
+ * Request a cloud sync check. Multiple calls within the same event-loop tick
+ * are coalesced into a single listener notification (e.g. several components
+ * mounting simultaneously each call this).
+ */
 export function requestCloudSyncCheck(): void {
-  syncCheckListeners.forEach((listener) => {
-    try {
-      listener();
-    } catch (error) {
-      console.error("[CloudSyncEvents] Sync check listener failed:", error);
-    }
-  });
+  if (_syncCheckTimer !== null) return;
+  _syncCheckTimer = setTimeout(() => {
+    _syncCheckTimer = null;
+    syncCheckListeners.forEach((listener) => {
+      try {
+        listener();
+      } catch (error) {
+        console.error("[CloudSyncEvents] Sync check listener failed:", error);
+      }
+    });
+  }, 0);
 }
 
 export function subscribeToCloudSyncCheckRequests(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Multiple duplicate `GET /api/sync/state?domain=...` requests are fired concurrently for the same domain. From the server logs, the same domain (e.g. `calendar`, `songs`, `contacts`) was being fetched 3–5 times simultaneously:

```
08:54:52 → GET /api/sync/state?domain=calendar   ×3
08:54:52 → GET /api/sync/state?domain=songs      ×3
08:54:52 → GET /api/sync/state?domain=contacts   ×3
08:55:05 → GET /api/sync/state?domain=videos     ×5
08:55:05 → GET /api/sync/state?domain=calendar   ×5
```

### Root causes

1. **No in-flight deduplication on `fetchRedisStateDomainSnapshot`**: When the batch check (`checkRemoteUpdates`), the realtime Pusher handler (`handleRealtimeDomainUpdate`), and upload pre-merge reads (`uploadRedisStateDomain`) all request the same domain concurrently, each fires a separate HTTP request.

2. **Rapid-fire `requestCloudSyncCheck()` from component mounts**: Multiple components (Calendar, Stickies, Contacts) call `requestCloudSyncCheck()` synchronously on mount, each triggering the sync check listener.

## Fix

### 1. In-flight request deduplication for `fetchRedisStateDomainSnapshot` (`cloudSync.ts`)

Added a `Map<RedisSyncDomain, Promise>` that caches in-flight requests. When multiple callers request the same domain concurrently, they share a single HTTP request. The cache is cleared when the request settles (success or error), so subsequent calls get fresh data.

### 2. Debounce `requestCloudSyncCheck()` (`cloudSyncEvents.ts`)

Replaced the synchronous dispatch with a `setTimeout(fn, 0)` coalescing pattern. All `requestCloudSyncCheck()` calls within the same event-loop tick are batched into a single listener notification.

## Testing

- `bun run build` — compiles successfully
- `bun run test:unit` — all 89 tests pass
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2b473758-140c-43e1-9137-643a6c384db0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2b473758-140c-43e1-9137-643a6c384db0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

