### PR TITLE
refactor(theme): centralize Windows checks with isWindowsTheme()

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,6 +21,7 @@ import { DesktopErrorBoundary } from "@/components/errors/ErrorBoundaries";
 import { useAutoCloudSync } from "@/hooks/useAutoCloudSync";
 import { AirDropListener } from "@/components/AirDropListener";
 import { useFilesStore } from "@/stores/useFilesStore";
+import { isWindowsTheme } from "@/themes";
 
 // Convert registry to array
 const apps: AnyApp[] = Object.values(appRegistry);
@@ -44,9 +45,9 @@ export function App() {
 
   // Determine toast position and offset based on theme and device
   const toastConfig = useMemo(() => {
-    const isWindowsTheme = currentTheme === "xp" || currentTheme === "win98";
+    const windowsTheme = isWindowsTheme(currentTheme);
     const dockHeight = currentTheme === "macosx" ? 56 : 0;
-    const taskbarHeight = isWindowsTheme ? 30 : 0;
+    const taskbarHeight = windowsTheme ? 30 : 0;
     
     // Mobile: always show at bottom-center with dock/taskbar and safe area clearance
     if (isMobile) {
@@ -57,7 +58,7 @@ export function App() {
       };
     }
 
-    if (isWindowsTheme) {
+    if (windowsTheme) {
       // Windows themes: bottom-right with taskbar clearance (30px + padding)
       return {
         position: "bottom-right" as const,

--- a/src/apps/admin/components/AdminMenuBar.tsx
+++ b/src/apps/admin/components/AdminMenuBar.tsx
@@ -9,6 +9,7 @@ import {
 } from "@/components/ui/menubar";
 import { useThemeStore } from "@/stores/useThemeStore";
 import { useTranslation } from "react-i18next";
+import { isWindowsTheme } from "@/themes";
 
 type AdminSection = "dashboard" | "users" | "rooms" | "songs" | "server";
 
@@ -35,7 +36,7 @@ export function AdminMenuBar({
 }: AdminMenuBarProps) {
   const { t } = useTranslation();
   const currentTheme = useThemeStore((state) => state.current);
-  const isXpTheme = currentTheme === "xp" || currentTheme === "win98";
+  const isXpTheme = isWindowsTheme(currentTheme);
   const isMacOsxTheme = currentTheme === "macosx";
 
   return (

--- a/src/apps/admin/hooks/useAdminLogic.ts
+++ b/src/apps/admin/hooks/useAdminLogic.ts
@@ -32,6 +32,7 @@ import {
   type AdminSection,
 } from "../utils/navigationState";
 import { helpItems } from "..";
+import { isWindowsTheme } from "@/themes";
 
 /**
  * Format Kugou image URL with size and HTTPS
@@ -173,7 +174,7 @@ export function useAdminLogic({ isWindowOpen }: UseAdminLogicProps) {
   const { username, isAuthenticated } = useAuth();
   const isOffline = useOffline();
   const currentTheme = useThemeStore((state) => state.current);
-  const isXpTheme = currentTheme === "xp" || currentTheme === "win98";
+  const isXpTheme = isWindowsTheme(currentTheme);
 
   const [isHelpDialogOpen, setIsHelpDialogOpen] = useState(false);
   const [isAboutDialogOpen, setIsAboutDialogOpen] = useState(false);

--- a/src/apps/applet-viewer/components/AppStore.tsx
+++ b/src/apps/applet-viewer/components/AppStore.tsx
@@ -10,6 +10,7 @@ import { AppStoreFeed, type AppStoreFeedRef } from "./AppStoreFeed";
 import { useTranslation } from "react-i18next";
 import { getApiUrl } from "@/utils/platform";
 import { abortableFetch } from "@/utils/abortableFetch";
+import { isWindowsTheme } from "@/themes";
 
 interface AppStoreProps {
   theme?: string;
@@ -34,7 +35,7 @@ export function AppStore({ theme, sharedAppletId, focusWindow }: AppStoreProps) 
   const isMacTheme = theme === "macosx";
   const isSystem7Theme = theme === "system7";
   const currentTheme = useThemeStore((state) => state.current);
-  const isXpTheme = currentTheme === "xp" || currentTheme === "win98";
+  const isXpTheme = isWindowsTheme(currentTheme);
   
   const actions = useAppletActions();
   const lastUpdateToastKeyRef = useRef<string | null>(null);

--- a/src/apps/applet-viewer/components/AppStoreFeed.tsx
+++ b/src/apps/applet-viewer/components/AppStoreFeed.tsx
@@ -12,6 +12,7 @@ import { useTranslation } from "react-i18next";
 import { getApiUrl } from "@/utils/platform";
 import { useChatsStoreShallow } from "@/stores/helpers";
 import { abortableFetch } from "@/utils/abortableFetch";
+import { isWindowsTheme } from "@/themes";
 
 interface AppStoreFeedProps {
   theme?: string;
@@ -54,7 +55,7 @@ export const AppStoreFeed = forwardRef<AppStoreFeedRef, AppStoreFeedProps>(
   const PREVIEW_Y_SPACING = -28;
   const isMacTheme = theme === "macosx" || currentTheme === "macosx";
   const isSystem7Theme = theme === "system7" || currentTheme === "system7";
-  const isXpTheme = currentTheme === "xp" || currentTheme === "win98";
+  const isXpTheme = isWindowsTheme(currentTheme);
 
   const actions = useAppletActions();
 

--- a/src/apps/applet-viewer/components/AppletViewerMenuBar.tsx
+++ b/src/apps/applet-viewer/components/AppletViewerMenuBar.tsx
@@ -20,6 +20,7 @@ import { useChatsStore } from "@/stores/useChatsStore";
 import { ShareItemDialog } from "@/components/dialogs/ShareItemDialog";
 import { appRegistry } from "@/config/appRegistry";
 import { useTranslation } from "react-i18next";
+import { isWindowsTheme } from "@/themes";
 
 interface AppletViewerMenuBarProps {
   onClose: () => void;
@@ -61,7 +62,7 @@ export function AppletViewerMenuBar({
   const appId = "applet-viewer";
   const appName = appRegistry[appId as keyof typeof appRegistry]?.name || appId;
   const currentTheme = useThemeStore((s) => s.current);
-  const isXpTheme = currentTheme === "xp" || currentTheme === "win98";
+  const isXpTheme = isWindowsTheme(currentTheme);
   const isMacOsxTheme = currentTheme === "macosx";
   const launchApp = useLaunchApp();
   const fileInputRef = React.useRef<HTMLInputElement>(null);

--- a/src/apps/applet-viewer/hooks/useAppletViewerLogic.ts
+++ b/src/apps/applet-viewer/hooks/useAppletViewerLogic.ts
@@ -28,6 +28,7 @@ import { track } from "@vercel/analytics";
 import { APPLET_ANALYTICS } from "@/utils/analytics";
 import { extractMetadataFromHtml } from "@/utils/appletMetadata";
 import { exportAppletAsHtml } from "@/utils/appletImportExport";
+import { isWindowsTheme } from "@/themes";
 import {
   emitFileSaved,
   onAppletUpdated,
@@ -54,7 +55,7 @@ export function useAppletViewerLogic({
   const iframeRef = useRef<HTMLIFrameElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const currentTheme = useThemeStore((state) => state.current);
-  const isXpTheme = currentTheme === "xp" || currentTheme === "win98";
+  const isXpTheme = isWindowsTheme(currentTheme);
   const isMacTheme = currentTheme === "macosx";
   const username = useChatsStore((state) => state.username);
   const isAuthenticated = useChatsStore((state) => state.isAuthenticated);

--- a/src/apps/base/AppManager.tsx
+++ b/src/apps/base/AppManager.tsx
@@ -27,6 +27,7 @@ import {
   toggleSpotlightSearch,
 } from "@/utils/appEventBus";
 import { useGlobalUndoRedo } from "@/hooks/useGlobalUndoRedo";
+import { isWindowsTheme } from "@/themes";
 
 interface AppManagerProps {
   apps: AnyApp[];
@@ -66,7 +67,7 @@ export function AppManager({ apps }: AppManagerProps) {
 
   // Get current theme to determine if we should show the desktop menubar
   const currentTheme = useThemeStore((state) => state.current);
-  const isXpTheme = currentTheme === "xp" || currentTheme === "win98";
+  const isXpTheme = isWindowsTheme(currentTheme);
 
   const [crashedInstanceIds, setCrashedInstanceIds] = useState<Set<string>>(
     () => new Set()

--- a/src/apps/base/types.ts
+++ b/src/apps/base/types.ts
@@ -153,8 +153,9 @@ export type AnyInitialData =
 // For XP/98 themes, pass the menu bar as a prop to WindowFrame
 // For other themes, render the menu bar normally outside WindowFrame
 // Example:
+// import { isWindowsTheme } from "@/themes";
 // const currentTheme = useThemeStore((state) => state.current);
-// const isXpTheme = currentTheme === "xp" || currentTheme === "win98";
+// const isXpTheme = isWindowsTheme(currentTheme);
 // const menuBar = <AppMenuBar ... />;
 // return (
 //   <>

--- a/src/apps/calendar/components/EventDialog.tsx
+++ b/src/apps/calendar/components/EventDialog.tsx
@@ -17,6 +17,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { useThemeStore } from "@/stores/useThemeStore";
 import { cn } from "@/lib/utils";
 import type { CalendarEvent, EventColor, CalendarGroup } from "@/stores/useCalendarStore";
+import { isWindowsTheme } from "@/themes";
 
 interface EventDialogProps {
   isOpen: boolean;
@@ -57,7 +58,7 @@ export function EventDialog({
 }: EventDialogProps) {
   const { t } = useTranslation();
   const currentTheme = useThemeStore((state) => state.current);
-  const isXpTheme = currentTheme === "xp" || currentTheme === "win98";
+  const isXpTheme = isWindowsTheme(currentTheme);
   const isMacTheme = currentTheme === "macosx";
 
   const [title, setTitle] = useState("");

--- a/src/apps/candybar/components/CandyBarMenuBar.tsx
+++ b/src/apps/candybar/components/CandyBarMenuBar.tsx
@@ -8,6 +8,7 @@ import {
 } from "@/components/ui/menubar";
 import { useThemeStore } from "@/stores/useThemeStore";
 import { useTranslation } from "react-i18next";
+import { isWindowsTheme } from "@/themes";
 
 interface CandyBarMenuBarProps {
   onClose: () => void;
@@ -30,7 +31,7 @@ export function CandyBarMenuBar({
 }: CandyBarMenuBarProps) {
   const { t } = useTranslation();
   const currentTheme = useThemeStore((state) => state.current);
-  const isXpTheme = currentTheme === "xp" || currentTheme === "win98";
+  const isXpTheme = isWindowsTheme(currentTheme);
   const isMacOsxTheme = currentTheme === "macosx";
 
   return (

--- a/src/apps/candybar/hooks/useCandyBarLogic.ts
+++ b/src/apps/candybar/hooks/useCandyBarLogic.ts
@@ -4,6 +4,7 @@ import { toast } from "sonner";
 import { useTranslatedHelpItems } from "@/hooks/useTranslatedHelpItems";
 import { useThemeStore } from "@/stores/useThemeStore";
 import { helpItems } from "..";
+import { isWindowsTheme } from "@/themes";
 
 export interface IconPackIcon {
   name: string;
@@ -49,7 +50,7 @@ export function useCandyBarLogic({
   const { t } = useTranslation();
   const translatedHelpItems = useTranslatedHelpItems("candybar", helpItems);
   const currentTheme = useThemeStore((state) => state.current);
-  const isXpTheme = currentTheme === "xp" || currentTheme === "win98";
+  const isXpTheme = isWindowsTheme(currentTheme);
   const isMacOSXTheme = currentTheme === "macosx";
 
   const [isHelpDialogOpen, setIsHelpDialogOpen] = useState(false);

--- a/src/apps/chats/components/ChatsAppComponent.tsx
+++ b/src/apps/chats/components/ChatsAppComponent.tsx
@@ -36,6 +36,7 @@ import { useChatsFrameLayout } from "../hooks/useChatsFrameLayout";
 import { useProactiveGreeting } from "../hooks/useProactiveGreeting";
 import { useTelegramLink } from "@/hooks/useTelegramLink";
 import { useGlobalPresence } from "@/hooks/useGlobalPresence";
+import { isWindowsTheme } from "@/themes";
 
 export function ChatsAppComponent({
   isWindowOpen,
@@ -418,7 +419,7 @@ export function ChatsAppComponent({
   }, [setIsNewRoomDialogOpen]);
 
   const currentTheme = useThemeStore((state) => state.current);
-  const isXpTheme = currentTheme === "xp" || currentTheme === "win98";
+  const isXpTheme = isWindowsTheme(currentTheme);
   const isWindowsLegacyTheme = isXpTheme;
   const isMacTheme = currentTheme === "macosx";
   const isOffline = useOffline();

--- a/src/apps/chats/components/CreateRoomDialog.tsx
+++ b/src/apps/chats/components/CreateRoomDialog.tsx
@@ -20,6 +20,7 @@ import { useThemeStore } from "@/stores/useThemeStore";
 import { cn } from "@/lib/utils";
 import { useTranslation } from "react-i18next";
 import { abortableFetch } from "@/utils/abortableFetch";
+import { isWindowsTheme } from "@/themes";
 import {
   ThemedTabsList,
   ThemedTabsTrigger,
@@ -60,7 +61,7 @@ export function CreateRoomDialog({
 
   // Theme detection
   const currentTheme = useThemeStore((state) => state.current);
-  const isXpTheme = currentTheme === "xp" || currentTheme === "win98";
+  const isXpTheme = isWindowsTheme(currentTheme);
 
   // Reset form when dialog opens
   useEffect(() => {

--- a/src/apps/contacts/components/UserPicturePicker.tsx
+++ b/src/apps/contacts/components/UserPicturePicker.tsx
@@ -13,6 +13,7 @@ import { cn } from "@/lib/utils";
 import { ALL_USER_PICTURES } from "@/utils/userPictures";
 import { resizeImageToBase64 } from "@/utils/imageResize";
 import { useTranslation } from "react-i18next";
+import { isWindowsTheme } from "@/themes";
 
 interface UserPicturePickerProps {
   isOpen: boolean;
@@ -29,7 +30,7 @@ export function UserPicturePicker({
 }: UserPicturePickerProps) {
   const { t } = useTranslation();
   const currentTheme = useThemeStore((state) => state.current);
-  const isXpTheme = currentTheme === "xp" || currentTheme === "win98";
+  const isXpTheme = isWindowsTheme(currentTheme);
   const isMacTheme = currentTheme === "macosx";
 
   const fontClassName = isXpTheme

--- a/src/apps/control-panels/components/ControlPanelsMenuBar.tsx
+++ b/src/apps/control-panels/components/ControlPanelsMenuBar.tsx
@@ -12,6 +12,7 @@ import { useThemeStore } from "@/stores/useThemeStore";
 import { ShareItemDialog } from "@/components/dialogs/ShareItemDialog";
 import { appRegistry } from "@/config/appRegistry";
 import { useTranslation } from "react-i18next";
+import { isWindowsTheme } from "@/themes";
 
 interface ControlPanelsMenuBarProps {
   onClose: () => void;
@@ -29,7 +30,7 @@ export function ControlPanelsMenuBar({
   const appId = "control-panels";
   const appName = appRegistry[appId as keyof typeof appRegistry]?.name || appId;
   const currentTheme = useThemeStore((state) => state.current);
-  const isXpTheme = currentTheme === "xp" || currentTheme === "win98";
+  const isXpTheme = isWindowsTheme(currentTheme);
   const isMacOsxTheme = currentTheme === "macosx";
 
   return (

--- a/src/apps/control-panels/hooks/useControlPanelsLogic.ts
+++ b/src/apps/control-panels/hooks/useControlPanelsLogic.ts
@@ -47,6 +47,7 @@ import {
   isLogicalCloudSyncDomainEnabled,
   type LogicalCloudSyncDomain,
 } from "@/utils/syncLogicalDomains";
+import { isWindowsTheme } from "@/themes";
 import {
   readStoreItems,
   restoreStoreItems,
@@ -1492,7 +1493,7 @@ export function useControlPanelsLogic({
     performFormat();
   };
 
-  const isXpTheme = currentTheme === "xp" || currentTheme === "win98";
+  const isXpTheme = isWindowsTheme(currentTheme);
   const isMacOSXTheme = currentTheme === "macosx";
   const isSystem7Theme = currentTheme === "system7";
   const isClassicMacTheme = isMacOSXTheme || isSystem7Theme;

--- a/src/apps/dashboard/components/DashboardMenuBar.tsx
+++ b/src/apps/dashboard/components/DashboardMenuBar.tsx
@@ -11,6 +11,7 @@ import {
 } from "@/components/ui/menubar";
 import { useThemeStore } from "@/stores/useThemeStore";
 import { useTranslation } from "react-i18next";
+import { isWindowsTheme } from "@/themes";
 
 interface DashboardMenuBarProps {
   onClose: () => void;
@@ -43,7 +44,7 @@ export function DashboardMenuBar({
 }: DashboardMenuBarProps) {
   const { t } = useTranslation();
   const currentTheme = useThemeStore((state) => state.current);
-  const isXpTheme = currentTheme === "xp" || currentTheme === "win98";
+  const isXpTheme = isWindowsTheme(currentTheme);
   const isMacOsxTheme = currentTheme === "macosx";
 
   return (

--- a/src/apps/finder/components/FileList.tsx
+++ b/src/apps/finder/components/FileList.tsx
@@ -17,6 +17,7 @@ import { getFinderDisplayName } from "@/utils/finderDisplay";
 import { useThemeStore } from "@/stores/useThemeStore";
 import type { LaunchOriginRect } from "@/stores/useAppStore";
 import { useTranslation } from "react-i18next";
+import { isWindowsTheme } from "@/themes";
 import {
   createSelectionRect,
   getIntersectingSelectionIds,
@@ -383,7 +384,7 @@ export function FileList({
   } | null>(null);
   const currentTheme = useThemeStore((state) => state.current);
   const isMacOSXTheme = currentTheme === "macosx";
-  const isXpTheme = currentTheme === "xp" || currentTheme === "win98";
+  const isXpTheme = isWindowsTheme(currentTheme);
 
   // Add refs for rename timing
   const clickTimeoutRef = useRef<NodeJS.Timeout | null>(null);

--- a/src/apps/finder/hooks/useFileSystem.ts
+++ b/src/apps/finder/hooks/useFileSystem.ts
@@ -30,6 +30,7 @@ import {
   type CloudSyncDeletionBucket,
 } from "@/stores/useCloudSyncStore";
 import { useThemeStore } from "@/stores/useThemeStore";
+import { isWindowsTheme } from "@/themes";
 
 // Interface for content stored in IndexedDB
 export interface DocumentContent {
@@ -872,7 +873,7 @@ export function useFileSystem(
                   name: "Macintosh HD",
                   isDirectory: true,
                   icon:
-                    currentTheme === "xp" || currentTheme === "win98"
+                    isWindowsTheme(currentTheme)
                       ? "/icons/default/pc.png"
                       : "/icons/default/disk.png",
                   type: "directory",

--- a/src/apps/finder/hooks/useFinderLogic.ts
+++ b/src/apps/finder/hooks/useFinderLogic.ts
@@ -34,6 +34,7 @@ import {
 } from "@/utils/appEventBus";
 import { useAirDropStore } from "@/stores/useAirDropStore";
 import { useChatsStore } from "@/stores/useChatsStore";
+import { isWindowsTheme } from "@/themes";
 
 type FinderUndoAction =
   | { type: "moveToTrash"; fileName: string; originalPath: string }
@@ -1289,7 +1290,7 @@ export function useFinderLogic({
     },
   ];
 
-  const isXpTheme = currentTheme === "xp" || currentTheme === "win98";
+  const isXpTheme = isWindowsTheme(currentTheme);
   const isMacOSXTheme = currentTheme === "macosx";
 
   // Sidebar state

--- a/src/apps/infinite-mac/components/InfiniteMacMenuBar.tsx
+++ b/src/apps/infinite-mac/components/InfiniteMacMenuBar.tsx
@@ -13,6 +13,7 @@ import {
 import { useThemeStore } from "@/stores/useThemeStore";
 import { useTranslation } from "react-i18next";
 import type { ScaleOption } from "../hooks/useInfiniteMacLogic";
+import { isWindowsTheme } from "@/themes";
 
 interface InfiniteMacMenuBarProps {
   onClose: () => void;
@@ -43,7 +44,7 @@ export function InfiniteMacMenuBar({
 }: InfiniteMacMenuBarProps) {
   const { t } = useTranslation();
   const currentTheme = useThemeStore((state) => state.current);
-  const isXpTheme = currentTheme === "xp" || currentTheme === "win98";
+  const isXpTheme = isWindowsTheme(currentTheme);
   const isMacOsxTheme = currentTheme === "macosx";
 
   return (

--- a/src/apps/infinite-mac/hooks/useInfiniteMacLogic.ts
+++ b/src/apps/infinite-mac/hooks/useInfiniteMacLogic.ts
@@ -11,6 +11,7 @@ import {
 } from "@/stores/useInfiniteMacStore";
 import { helpItems } from "../metadata";
 import { useShallow } from "zustand/react/shallow";
+import { isWindowsTheme } from "@/themes";
 
 // Re-export types and presets for consumers
 export type { ScaleOption, MacPreset, ScreenData } from "@/stores/useInfiniteMacStore";
@@ -106,7 +107,7 @@ export function useInfiniteMacLogic({
 
   const { t } = useTranslation();
   const currentTheme = useThemeStore((state) => state.current);
-  const isXpTheme = currentTheme === "xp" || currentTheme === "win98";
+  const isXpTheme = isWindowsTheme(currentTheme);
   const translatedHelpItems = useTranslatedHelpItems("infinite-mac", helpItems);
   const embedUrl = selectedPreset ? buildWrapperUrl(selectedPreset, currentScale) : null;
 

--- a/src/apps/internet-explorer/components/InternetExplorerMenuBar.tsx
+++ b/src/apps/internet-explorer/components/InternetExplorerMenuBar.tsx
@@ -24,6 +24,7 @@ import { ThemedIcon } from "@/components/shared/ThemedIcon";
 import { ShareItemDialog } from "@/components/dialogs/ShareItemDialog";
 import { appRegistry } from "@/config/appRegistry";
 import { useTranslation } from "react-i18next";
+import { isWindowsTheme } from "@/themes";
 
 interface InternetExplorerMenuBarProps extends Omit<AppProps, "onClose" | "instanceId"> {
   instanceId?: string;
@@ -199,7 +200,7 @@ export function InternetExplorerMenuBar({
   ].reverse();
 
   const currentTheme = useThemeStore((s) => s.current);
-  const isXpTheme = currentTheme === "xp" || currentTheme === "win98";
+  const isXpTheme = isWindowsTheme(currentTheme);
   const isMacOsxTheme = currentTheme === "macosx";
 
   return (

--- a/src/apps/internet-explorer/hooks/useInternetExplorerLogic.ts
+++ b/src/apps/internet-explorer/hooks/useInternetExplorerLogic.ts
@@ -35,6 +35,7 @@ import { useInternetExplorerStoreShallow } from "@/stores/helpers";
 import { abortableFetch } from "@/utils/abortableFetch";
 import { onAppUpdate } from "@/utils/appEventBus";
 import { decodeHtmlEntities } from "@/utils/decodeHtmlEntities";
+import { isWindowsTheme } from "@/themes";
 
 // Helper function to get language display name
 const getLanguageDisplayName = (lang: LanguageOption): string => {
@@ -1899,7 +1900,7 @@ export function useInternetExplorerLogic({
     setIsShareDialogOpen(true);
   }, []);
 
-  const isXpTheme = currentTheme === "xp" || currentTheme === "win98";
+  const isXpTheme = isWindowsTheme(currentTheme);
   const isOffline = useOffline();
 
   return {

--- a/src/apps/ipod/components/IpodMenuBar.tsx
+++ b/src/apps/ipod/components/IpodMenuBar.tsx
@@ -23,6 +23,7 @@ import { useThemeStore } from "@/stores/useThemeStore";
 import { ShareItemDialog } from "@/components/dialogs/ShareItemDialog";
 import { appRegistry } from "@/config/appRegistry";
 import { useTranslation } from "react-i18next";
+import { isWindowsTheme } from "@/themes";
 
 interface IpodMenuBarProps {
   onClose: () => void;
@@ -151,7 +152,7 @@ export function IpodMenuBar({
   }));
 
   const appTheme = useThemeStore((state) => state.current);
-  const isXpTheme = appTheme === "xp" || appTheme === "win98";
+  const isXpTheme = isWindowsTheme(appTheme);
   const isMacOsxTheme = appTheme === "macosx";
   const debugMode = useDisplaySettingsStore((state) => state.debugMode);
   const username = useChatsStore((state) => state.username);

--- a/src/apps/ipod/components/PipPlayer.tsx
+++ b/src/apps/ipod/components/PipPlayer.tsx
@@ -9,6 +9,7 @@ import { useIsPhone } from "@/hooks/useIsPhone";
 import { getYouTubeVideoId, formatKugouImageUrl } from "../constants";
 import type { PipPlayerProps } from "../types";
 import { SkipBack, SkipForward, Play, Pause, MusicNote } from "@phosphor-icons/react";
+import { isWindowsTheme } from "@/themes";
 
 export function PipPlayer({
   currentTrack,
@@ -25,8 +26,7 @@ export function PipPlayer({
 
   // Calculate bottom offset based on theme (similar to Sonner positioning)
   const bottomOffset = useMemo(() => {
-    const isWindowsTheme = currentTheme === "xp" || currentTheme === "win98";
-    if (isWindowsTheme) {
+    if (isWindowsTheme(currentTheme)) {
       // Windows themes: taskbar height (30px) + padding
       return "calc(env(safe-area-inset-bottom, 0px) + 42px)";
     } else if (currentTheme === "macosx") {

--- a/src/apps/ipod/hooks/useIpodLogic.ts
+++ b/src/apps/ipod/hooks/useIpodLogic.ts
@@ -42,6 +42,7 @@ import type { IpodInitialData } from "../../base/types";
 import type { CoverFlowRef } from "../components/CoverFlow";
 import type { SongSearchResult } from "@/components/dialogs/SongSearchDialog";
 import { helpItems } from "..";
+import { isWindowsTheme } from "@/themes";
 
 export interface UseIpodLogicOptions {
   isWindowOpen: boolean;
@@ -1721,7 +1722,7 @@ export function useIpodLogic({
   );
 
   const currentTheme = useThemeStore((state) => state.current);
-  const isXpTheme = currentTheme === "xp" || currentTheme === "win98";
+  const isXpTheme = isWindowsTheme(currentTheme);
 
   return {
     // Translation

--- a/src/apps/karaoke/components/KaraokeMenuBar.tsx
+++ b/src/apps/karaoke/components/KaraokeMenuBar.tsx
@@ -23,6 +23,7 @@ import { useChatsStore } from "@/stores/useChatsStore";
 import { toast } from "sonner";
 import { LyricsAlignment, LyricsFont, DisplayMode } from "@/types/lyrics";
 import { Track } from "@/stores/useIpodStore";
+import { isWindowsTheme } from "@/themes";
 
 interface KaraokeMenuBarProps {
   onClose: () => void;
@@ -105,7 +106,7 @@ export function KaraokeMenuBar({
   const appName = t("apps.karaoke.name");
 
   const currentTheme = useThemeStore((state) => state.current);
-  const isXpTheme = currentTheme === "xp" || currentTheme === "win98";
+  const isXpTheme = isWindowsTheme(currentTheme);
   const isMacOsxTheme = currentTheme === "macosx";
   const debugMode = useDisplaySettingsStore((state) => state.debugMode);
   const username = useChatsStore((state) => state.username);

--- a/src/apps/karaoke/hooks/useKaraokeLogic.ts
+++ b/src/apps/karaoke/hooks/useKaraokeLogic.ts
@@ -34,6 +34,7 @@ import type { CoverFlowRef } from "@/apps/ipod/components/CoverFlow";
 import type { SongSearchResult } from "@/components/dialogs/SongSearchDialog";
 import { helpItems } from "..";
 import { onAppUpdate } from "@/utils/appEventBus";
+import { isWindowsTheme } from "@/themes";
 
 export interface UseKaraokeLogicOptions {
   isWindowOpen: boolean;
@@ -1201,7 +1202,7 @@ export function useKaraokeLogic({
   }, [processVideoId, bringInstanceToForeground, joinListenSession, username, instanceId]);
 
   const currentTheme = useThemeStore((state) => state.current);
-  const isXpTheme = currentTheme === "xp" || currentTheme === "win98";
+  const isXpTheme = isWindowsTheme(currentTheme);
 
   const getCurrentKaraokeTrack = useCallback(() => {
     return useKaraokeStore.getState().getCurrentTrack();

--- a/src/apps/paint/components/PaintMenuBar.tsx
+++ b/src/apps/paint/components/PaintMenuBar.tsx
@@ -16,6 +16,7 @@ import { useThemeStore } from "@/stores/useThemeStore";
 import { ShareItemDialog } from "@/components/dialogs/ShareItemDialog";
 import { appRegistry } from "@/config/appRegistry";
 import { useTranslation } from "react-i18next";
+import { isWindowsTheme } from "@/themes";
 
 interface PaintMenuBarProps {
   isWindowOpen: boolean;
@@ -647,7 +648,7 @@ export function PaintMenuBar({
 
   const appId = "paint";
   const appName = appRegistry[appId as keyof typeof appRegistry]?.name || appId;
-  const isXpTheme = currentTheme === "xp" || currentTheme === "win98";
+  const isXpTheme = isWindowsTheme(currentTheme);
   const isMacOsxTheme = currentTheme === "macosx";
 
   if (!isWindowOpen) return null;

--- a/src/apps/paint/hooks/usePaintLogic.ts
+++ b/src/apps/paint/hooks/usePaintLogic.ts
@@ -13,6 +13,7 @@ import { useTranslation } from "react-i18next";
 import { helpItems } from "..";
 import type { PaintInitialData } from "../../base/types";
 import { emitFileSaved } from "@/utils/appEventBus";
+import { isWindowsTheme } from "@/themes";
 
 interface PaintCanvasHandle {
   undo: () => void;
@@ -423,7 +424,7 @@ export function usePaintLogic({ initialData, instanceId }: UsePaintLogicProps) {
   }, []);
 
   const currentTheme = useThemeStore((state) => state.current);
-  const isXpTheme = currentTheme === "xp" || currentTheme === "win98";
+  const isXpTheme = isWindowsTheme(currentTheme);
 
   const windowTitle = currentFilePath
     ? currentFilePath.split("/").pop() || t("apps.paint.untitled")

--- a/src/apps/pc/components/PcMenuBar.tsx
+++ b/src/apps/pc/components/PcMenuBar.tsx
@@ -16,6 +16,7 @@ import { useThemeStore } from "@/stores/useThemeStore";
 import { ShareItemDialog } from "@/components/dialogs/ShareItemDialog";
 import { appRegistry } from "@/config/appRegistry";
 import { useTranslation } from "react-i18next";
+import { isWindowsTheme } from "@/themes";
 
 interface PcMenuBarProps {
   onClose: () => void;
@@ -59,7 +60,7 @@ export function PcMenuBar({
   const appId = "pc";
   const appName = appRegistry[appId as keyof typeof appRegistry]?.name || appId;
   const currentTheme = useThemeStore((state) => state.current);
-  const isXpTheme = currentTheme === "xp" || currentTheme === "win98";
+  const isXpTheme = isWindowsTheme(currentTheme);
   const isMacOsxTheme = currentTheme === "macosx";
   const availableGames = loadGames();
   const renderAspects = ["AsIs", "1/1", "5/4", "4/3", "16/10", "16/9", "Fit"];

--- a/src/apps/pc/hooks/usePcLogic.ts
+++ b/src/apps/pc/hooks/usePcLogic.ts
@@ -5,6 +5,7 @@ import { useTranslatedHelpItems } from "@/hooks/useTranslatedHelpItems";
 import { Game, loadGames } from "@/stores/usePcStore";
 import { useJsDos, DosProps, DosEvent } from "./useJsDos";
 import { useThemeStore } from "@/stores/useThemeStore";
+import { isWindowsTheme } from "@/themes";
 
 interface UsePcLogicProps {
   isWindowOpen: boolean;
@@ -30,7 +31,7 @@ export function usePcLogic({ isWindowOpen, instanceId }: UsePcLogicProps) {
 
   const { t } = useTranslation();
   const currentTheme = useThemeStore((state) => state.current);
-  const isXpTheme = currentTheme === "xp" || currentTheme === "win98";
+  const isXpTheme = isWindowsTheme(currentTheme);
   const translatedHelpItems = useTranslatedHelpItems("pc", helpItems);
 
   const handleLoadGame = useCallback(

--- a/src/apps/photo-booth/components/PhotoBoothMenuBar.tsx
+++ b/src/apps/photo-booth/components/PhotoBoothMenuBar.tsx
@@ -13,6 +13,7 @@ import { useThemeStore } from "@/stores/useThemeStore";
 import { ShareItemDialog } from "@/components/dialogs/ShareItemDialog";
 import { appRegistry } from "@/config/appRegistry";
 import { useTranslation } from "react-i18next";
+import { isWindowsTheme } from "@/themes";
 
 interface Effect {
   name: string;
@@ -52,7 +53,7 @@ export function PhotoBoothMenuBar({
   const appId = "photo-booth";
   const appName = appRegistry[appId as keyof typeof appRegistry]?.name || appId;
   const currentTheme = useThemeStore((s) => s.current);
-  const isXpTheme = currentTheme === "xp" || currentTheme === "win98";
+  const isXpTheme = isWindowsTheme(currentTheme);
   const isMacOsxTheme = currentTheme === "macosx";
 
   return (

--- a/src/apps/photo-booth/hooks/usePhotoBoothLogic.ts
+++ b/src/apps/photo-booth/hooks/usePhotoBoothLogic.ts
@@ -12,6 +12,7 @@ import { useLatestRef } from "@/hooks/useLatestRef";
 import { useTimeout } from "@/hooks/useTimeout";
 import { helpItems } from "..";
 import { useShallow } from "zustand/react/shallow";
+import { isWindowsTheme } from "@/themes";
 
 interface Effect {
   name: string;
@@ -191,7 +192,7 @@ export function usePhotoBoothLogic({
   const recentPhotoPreviewsRef = useRef<Map<string, string>>(new Map());
 
   const currentTheme = useThemeStore((state) => state.current);
-  const isXpTheme = currentTheme === "xp" || currentTheme === "win98";
+  const isXpTheme = isWindowsTheme(currentTheme);
   const isMacTheme = currentTheme === "macosx";
 
   const windowTitle = getTranslatedAppName("photo-booth");

--- a/src/apps/soundboard/components/BoardList.tsx
+++ b/src/apps/soundboard/components/BoardList.tsx
@@ -9,6 +9,7 @@ import {
 import { SelectableListItem } from "@/components/ui/selectable-list-item";
 import { Plus } from "@phosphor-icons/react";
 import { Soundboard } from "@/types/types";
+import { isWindowsTheme } from "@/themes";
 
 import { useThemeStore } from "@/stores/useThemeStore";
 import { useTranslation } from "react-i18next";
@@ -36,7 +37,7 @@ export function BoardList({
 }: BoardListProps) {
   // Theme detection for border styling
   const currentTheme = useThemeStore((state) => state.current);
-  const isXpTheme = currentTheme === "xp" || currentTheme === "win98";
+  const isXpTheme = isWindowsTheme(currentTheme);
   const isWindowsLegacyTheme = isXpTheme;
   const { t } = useTranslation();
 

--- a/src/apps/stickies/components/StickiesMenuBar.tsx
+++ b/src/apps/stickies/components/StickiesMenuBar.tsx
@@ -13,6 +13,7 @@ import { useThemeStore } from "@/stores/useThemeStore";
 import { requestCloudSyncDomainCheck } from "@/utils/cloudSyncEvents";
 import { useTranslation } from "react-i18next";
 import { StickyColor } from "@/stores/useStickiesStore";
+import { isWindowsTheme } from "@/themes";
 
 interface StickiesMenuBarProps {
   onClose: () => void;
@@ -46,7 +47,7 @@ export function StickiesMenuBar({
 }: StickiesMenuBarProps) {
   const { t } = useTranslation();
   const currentTheme = useThemeStore((state) => state.current);
-  const isXpTheme = currentTheme === "xp" || currentTheme === "win98";
+  const isXpTheme = isWindowsTheme(currentTheme);
   const isMacOsxTheme = currentTheme === "macosx";
 
   return (

--- a/src/apps/synth/components/SynthMenuBar.tsx
+++ b/src/apps/synth/components/SynthMenuBar.tsx
@@ -14,6 +14,7 @@ import { ShareItemDialog } from "@/components/dialogs/ShareItemDialog";
 import { appRegistry } from "@/config/appRegistry";
 import type { NoteLabelType } from "@/stores/useSynthStore";
 import { useTranslation } from "react-i18next";
+import { isWindowsTheme } from "@/themes";
 
 interface SynthMenuBarProps {
   onAddPreset: () => void;
@@ -45,7 +46,7 @@ export function SynthMenuBar({
   const appId = "synth";
   const appName = appRegistry[appId as keyof typeof appRegistry]?.name || appId;
   const currentTheme = useThemeStore((state) => state.current);
-  const isXpTheme = currentTheme === "xp" || currentTheme === "win98";
+  const isXpTheme = isWindowsTheme(currentTheme);
   const isMacOsxTheme = currentTheme === "macosx";
 
   return (

--- a/src/apps/synth/hooks/useSynthLogic.ts
+++ b/src/apps/synth/hooks/useSynthLogic.ts
@@ -12,6 +12,7 @@ import { useTranslation } from "react-i18next";
 import { useTranslatedHelpItems } from "@/hooks/useTranslatedHelpItems";
 import { helpItems } from "..";
 import { useShallow } from "zustand/react/shallow";
+import { isWindowsTheme } from "@/themes";
 
 // Define oscillator type
 type OscillatorType = "sine" | "square" | "triangle" | "sawtooth";
@@ -127,7 +128,7 @@ export const useSynthLogic = ({
   const { t } = useTranslation();
   const translatedHelpItems = useTranslatedHelpItems("synth", helpItems);
   const currentTheme = useThemeStore((state) => state.current);
-  const isXpTheme = currentTheme === "xp" || currentTheme === "win98";
+  const isXpTheme = isWindowsTheme(currentTheme);
   const isSystem7Theme = currentTheme === "system7";
   const isClassicTheme = currentTheme === "macosx" || isXpTheme;
   const isMacOSTheme = currentTheme === "macosx";

--- a/src/apps/terminal/components/TerminalMenuBar.tsx
+++ b/src/apps/terminal/components/TerminalMenuBar.tsx
@@ -13,6 +13,7 @@ import { useThemeStore } from "@/stores/useThemeStore";
 import { ShareItemDialog } from "@/components/dialogs/ShareItemDialog";
 import { appRegistry } from "@/config/appRegistry";
 import { useTranslation } from "react-i18next";
+import { isWindowsTheme } from "@/themes";
 
 export interface TerminalMenuBarProps {
   onClose: () => void;
@@ -42,7 +43,7 @@ export function TerminalMenuBar({
   const appId = "terminal";
   const appName = appRegistry[appId as keyof typeof appRegistry]?.name || appId;
   const currentTheme = useThemeStore((state) => state.current);
-  const isXpTheme = currentTheme === "xp" || currentTheme === "win98";
+  const isXpTheme = isWindowsTheme(currentTheme);
   const isMacOsxTheme = currentTheme === "macosx";
 
   return (

--- a/src/apps/terminal/hooks/useTerminalLogic.ts
+++ b/src/apps/terminal/hooks/useTerminalLogic.ts
@@ -31,6 +31,7 @@ import { TERMINAL_ANALYTICS } from "@/utils/analytics";
 import i18n from "@/lib/i18n";
 import { CommandHistory, CommandContext, ToolInvocationData } from "../types";
 import { abortableFetch } from "@/utils/abortableFetch";
+import { isWindowsTheme } from "@/themes";
 
 // Maximum number of rendered command entries to keep in memory
 const MAX_RENDERED_HISTORY = 200;
@@ -379,7 +380,7 @@ export const useTerminalLogic = ({
 
   const username = useChatsStore((state) => state.username);
   const currentTheme = useThemeStore((state) => state.current);
-  const isXpTheme = currentTheme === "xp" || currentTheme === "win98";
+  const isXpTheme = isWindowsTheme(currentTheme);
 
   // Load command history from store
   useEffect(() => {

--- a/src/apps/textedit/components/EditorToolbar.tsx
+++ b/src/apps/textedit/components/EditorToolbar.tsx
@@ -19,10 +19,11 @@ import { CaretDown, SpeakerHigh, TextB as BoldIcon, TextItalic as ItalicIcon, Te
 import { ActivityIndicator } from "@/components/ui/activity-indicator";
 import { useSound, Sounds } from "@/hooks/useSound";
 import { useTranslation } from "react-i18next";
+import { isWindowsTheme, type OsThemeId } from "@/themes";
 
 interface EditorToolbarProps {
   editor: Editor | null;
-  currentTheme: string;
+  currentTheme: OsThemeId;
   speechEnabled: boolean;
   isTranscribing: boolean;
   isTtsLoading: boolean;
@@ -45,7 +46,7 @@ export function EditorToolbar({
 }: EditorToolbarProps) {
   const { t } = useTranslation();
   const { play: playButtonClick } = useSound(Sounds.BUTTON_CLICK);
-  const isXpTheme = currentTheme === "xp" || currentTheme === "win98";
+  const isXpTheme = isWindowsTheme(currentTheme);
   const isLegacyToolbarTheme = isXpTheme || currentTheme === "system7";
   const isMacOSTheme = currentTheme === "macosx";
 
@@ -307,9 +308,7 @@ export function EditorToolbar({
           ? "border-b border-[#919b9c]"
           : isMacOSTheme
           ? "bg-transparent"
-          : currentTheme === "system7"
-          ? "bg-gray-100 border-b border-black"
-          : "bg-gray-100 border-b border-gray-300"
+          : "bg-gray-100 border-b border-black"
       }`}
       style={{
         borderBottom:

--- a/src/apps/textedit/components/TextEditAppComponent.tsx
+++ b/src/apps/textedit/components/TextEditAppComponent.tsx
@@ -23,6 +23,7 @@ import { markdownToHtml } from "@/utils/markdown";
 import { useTranslation } from "react-i18next";
 import { onDocumentUpdated } from "@/utils/appEventBus";
 import { useRegisterUndoRedo } from "@/hooks/useUndoRedo";
+import { isWindowsTheme } from "@/themes";
 
 // Inner component that has access to editor context
 function TextEditContent({
@@ -47,7 +48,7 @@ function TextEditContent({
   const launchAppInstance = useAppStore((state) => state.launchApp);
   const currentTheme = useThemeStore((state) => state.current);
   const speechEnabled = useAudioSettingsStore((state) => state.speechEnabled);
-  const isXpTheme = currentTheme === "xp" || currentTheme === "win98";
+  const isXpTheme = isWindowsTheme(currentTheme);
   // Local UI-only state for Save dialog filename
   const [saveFileName, setSaveFileName] = useState("");
   const [closeSaveFileName, setCloseSaveFileName] = useState("");

--- a/src/apps/textedit/components/TextEditMenuBar.tsx
+++ b/src/apps/textedit/components/TextEditMenuBar.tsx
@@ -18,6 +18,7 @@ import { ShareItemDialog } from "@/components/dialogs/ShareItemDialog";
 import { appRegistry } from "@/config/appRegistry";
 import { useTranslation } from "react-i18next";
 import { useInstanceUndoRedo } from "@/hooks/useUndoRedo";
+import { isWindowsTheme } from "@/themes";
 
 interface TextEditMenuBarProps {
   editor: Editor | null;
@@ -53,7 +54,7 @@ export function TextEditMenuBar({
   const appId = "textedit";
   const appName = appRegistry[appId as keyof typeof appRegistry]?.name || appId;
   const currentTheme = useThemeStore((state) => state.current);
-  const isXpTheme = currentTheme === "xp" || currentTheme === "win98";
+  const isXpTheme = isWindowsTheme(currentTheme);
   const isMacOsxTheme = currentTheme === "macosx";
   const { canUndo, canRedo, undo, redo } = useInstanceUndoRedo(instanceId || "");
 

--- a/src/apps/videos/components/VideosMenuBar.tsx
+++ b/src/apps/videos/components/VideosMenuBar.tsx
@@ -17,6 +17,7 @@ import { useThemeStore } from "@/stores/useThemeStore";
 import { ShareItemDialog } from "@/components/dialogs/ShareItemDialog";
 import { appRegistry } from "@/config/appRegistry";
 import { useTranslation } from "react-i18next";
+import { isWindowsTheme } from "@/themes";
 
 interface Video {
   id: string;
@@ -79,7 +80,7 @@ export function VideosMenuBar({
   const appId = "videos";
   const appName = appRegistry[appId as keyof typeof appRegistry]?.name || appId;
   const currentTheme = useThemeStore((state) => state.current);
-  const isXpTheme = currentTheme === "xp" || currentTheme === "win98";
+  const isXpTheme = isWindowsTheme(currentTheme);
   const isMacOsxTheme = currentTheme === "macosx";
 
   // Group videos by artist

--- a/src/apps/videos/hooks/useVideosLogic.ts
+++ b/src/apps/videos/hooks/useVideosLogic.ts
@@ -14,6 +14,7 @@ import { helpItems } from "..";
 import type { VideosInitialData } from "../../base/types";
 import { abortableFetch } from "@/utils/abortableFetch";
 import { onAppUpdate } from "@/utils/appEventBus";
+import { isWindowsTheme } from "@/themes";
 
 interface Video {
   id: string;
@@ -66,7 +67,7 @@ export function useVideosLogic({
 
   // Theme and audio settings
   const currentTheme = useThemeStore((state) => state.current);
-  const isXpTheme = currentTheme === "xp" || currentTheme === "win98";
+  const isXpTheme = isWindowsTheme(currentTheme);
   const isMacOSTheme = currentTheme === "macosx";
   const masterVolume = useAudioSettingsStore((state) => state.masterVolume);
 

--- a/src/apps/winamp/components/WinampMenuBar.tsx
+++ b/src/apps/winamp/components/WinampMenuBar.tsx
@@ -12,6 +12,7 @@ import {
 import { useThemeStore } from "@/stores/useThemeStore";
 import { useTranslation } from "react-i18next";
 import { WEBAMP_SKINS } from "../skins";
+import { isWindowsTheme } from "@/themes";
 
 interface WinampMenuBarProps {
   onClose: () => void;
@@ -48,7 +49,7 @@ export function WinampMenuBar({
 }: WinampMenuBarProps) {
   const { t } = useTranslation();
   const currentTheme = useThemeStore((state) => state.current);
-  const isXpTheme = currentTheme === "xp" || currentTheme === "win98";
+  const isXpTheme = isWindowsTheme(currentTheme);
   const isMacOsxTheme = currentTheme === "macosx";
 
   return (

--- a/src/apps/winamp/hooks/useWinampLogic.ts
+++ b/src/apps/winamp/hooks/useWinampLogic.ts
@@ -3,12 +3,13 @@ import { useTranslation } from "react-i18next";
 import { useTranslatedHelpItems } from "@/hooks/useTranslatedHelpItems";
 import { useThemeStore } from "@/stores/useThemeStore";
 import { helpItems } from "..";
+import { isWindowsTheme } from "@/themes";
 
 export function useWinampLogic() {
   const { t } = useTranslation();
   const translatedHelpItems = useTranslatedHelpItems("winamp", helpItems);
   const currentTheme = useThemeStore((state) => state.current);
-  const isXpTheme = currentTheme === "xp" || currentTheme === "win98";
+  const isXpTheme = isWindowsTheme(currentTheme);
 
   const [isHelpDialogOpen, setIsHelpDialogOpen] = useState(false);
   const [isAboutDialogOpen, setIsAboutDialogOpen] = useState(false);

--- a/src/components/dialogs/AboutDialog.tsx
+++ b/src/components/dialogs/AboutDialog.tsx
@@ -11,6 +11,7 @@ import { ThemedIcon } from "@/components/shared/ThemedIcon";
 import { useTranslation } from "react-i18next";
 import { getTranslatedAppName, AppId } from "@/utils/i18n";
 import { useAppStore } from "@/stores/useAppStore";
+import { isWindowsTheme } from "@/themes";
 
 const APP_DOC_NAMES: Partial<Record<AppId, string>> = {
   pc: "virtual-pc",
@@ -41,7 +42,7 @@ export function AboutDialog({
 }: AboutDialogProps) {
   const { t } = useTranslation();
   const currentTheme = useThemeStore((state) => state.current);
-  const isXpTheme = currentTheme === "xp" || currentTheme === "win98";
+  const isXpTheme = isWindowsTheme(currentTheme);
   const launchApp = useAppStore((state) => state.launchApp);
   
   // Use translated app name if appId is provided, otherwise fall back to metadata.name

--- a/src/components/dialogs/AboutFinderDialog.tsx
+++ b/src/components/dialogs/AboutFinderDialog.tsx
@@ -16,6 +16,7 @@ import { ThemedIcon } from "@/components/shared/ThemedIcon";
 import { getTranslatedAppName } from "@/utils/i18n";
 import type { AppId } from "@/config/appRegistry";
 import { abortableFetch } from "@/utils/abortableFetch";
+import { isWindowsTheme } from "@/themes";
 
 interface AboutFinderDialogProps {
   isOpen: boolean;
@@ -39,7 +40,7 @@ export function AboutFinderDialog({
   const version = useAppStore((state) => state.ryOSVersion);
   const buildNumber = useAppStore((state) => state.ryOSBuildNumber);
   const buildTime = useAppStore((state) => state.ryOSBuildTime);
-  const isXpTheme = currentTheme === "xp" || currentTheme === "win98";
+  const isXpTheme = isWindowsTheme(currentTheme);
   const [versionDisplayMode, setVersionDisplayMode] = useState(0); // 0: version, 1: commit, 2: date
   const [desktopVersion, setDesktopVersion] = useState<string | null>(null);
   const isMac = useMemo(() => 

--- a/src/components/dialogs/BootScreen.tsx
+++ b/src/components/dialogs/BootScreen.tsx
@@ -5,6 +5,7 @@ import { VisuallyHidden } from "@radix-ui/react-visually-hidden";
 import { useSound, Sounds } from "@/hooks/useSound";
 import { useTranslation } from "react-i18next";
 import { useThemeStore } from "@/stores/useThemeStore";
+import { isWindowsTheme } from "@/themes";
 
 interface BootScreenProps {
   isOpen: boolean;
@@ -27,7 +28,7 @@ export function BootScreen({
   const currentTheme = useThemeStore((state) => state.current);
   const localizedTitle = title ?? t("common.system.systemRestoring");
   
-  const isWindowsTheme = currentTheme === "xp" || currentTheme === "win98";
+  const windowsTheme = isWindowsTheme(currentTheme);
   const isMacOSX = currentTheme === "macosx";
 
   const handleDone = () => {
@@ -99,7 +100,7 @@ export function BootScreen({
   };
 
   // Windows themes use full boot screen images
-  if (isWindowsTheme) {
+  if (windowsTheme) {
     return (
       <Dialog open={isOpen} onOpenChange={() => {}} modal>
         <DialogPrimitive.Portal>

--- a/src/components/dialogs/ConfirmDialog.tsx
+++ b/src/components/dialogs/ConfirmDialog.tsx
@@ -13,6 +13,7 @@ import { useThemeStore } from "@/stores/useThemeStore";
 import { cn } from "@/lib/utils";
 import { ThemedIcon } from "@/components/shared/ThemedIcon";
 import { useTranslation } from "react-i18next";
+import { isWindowsTheme } from "@/themes";
 
 interface ConfirmDialogProps {
   isOpen: boolean;
@@ -33,7 +34,7 @@ export function ConfirmDialog({
   const confirmButtonRef = useRef<HTMLButtonElement>(null);
   const { play: playAlertSound } = useSound(Sounds.ALERT_SOSUMI);
   const currentTheme = useThemeStore((state) => state.current);
-  const isXpTheme = currentTheme === "xp" || currentTheme === "win98";
+  const isXpTheme = isWindowsTheme(currentTheme);
   const isMacTheme = currentTheme === "macosx";
 
   // Play sound when dialog opens

--- a/src/components/dialogs/EmojiDialog.tsx
+++ b/src/components/dialogs/EmojiDialog.tsx
@@ -8,6 +8,7 @@ import {
 import { useThemeStore } from "@/stores/useThemeStore";
 import { cn } from "@/lib/utils";
 import { useTranslation } from "react-i18next";
+import { isWindowsTheme } from "@/themes";
 
 interface EmojiDialogProps {
   isOpen: boolean;
@@ -234,7 +235,7 @@ export function EmojiDialog({
 }: EmojiDialogProps) {
   const { t } = useTranslation();
   const currentTheme = useThemeStore((state) => state.current);
-  const isXpTheme = currentTheme === "xp" || currentTheme === "win98";
+  const isXpTheme = isWindowsTheme(currentTheme);
 
   const dialogContent = (
     <div className={isXpTheme ? "p-2 px-4 pt-0" : "p-4 py-6"}>

--- a/src/components/dialogs/FutureSettingsDialog.tsx
+++ b/src/components/dialogs/FutureSettingsDialog.tsx
@@ -22,6 +22,7 @@ import {
   DEFAULT_TIMELINE,
 } from "@/stores/useInternetExplorerStore";
 import { useInternetExplorerStoreShallow } from "@/stores/helpers";
+import { isWindowsTheme } from "@/themes";
 
 interface FutureSettingsDialogProps {
   isOpen: boolean;
@@ -34,7 +35,7 @@ const FutureSettingsDialog = ({
 }: FutureSettingsDialogProps) => {
   const { t } = useTranslation();
   const currentTheme = useThemeStore((state) => state.current);
-  const isXpTheme = currentTheme === "xp" || currentTheme === "win98";
+  const isXpTheme = isWindowsTheme(currentTheme);
   const isMacTheme = currentTheme === "macosx";
   const [selectedYear, setSelectedYear] = useState<string>("2030");
   const saveButtonRef = useRef<HTMLButtonElement>(null);

--- a/src/components/dialogs/HelpDialog.tsx
+++ b/src/components/dialogs/HelpDialog.tsx
@@ -12,6 +12,7 @@ import { useTranslation } from "react-i18next";
 import { getTranslatedAppName, type AppId } from "@/utils/i18n";
 import { useAppStore } from "@/stores/useAppStore";
 import { getDocsBaseUrl } from "@/utils/runtimeConfig";
+import { isWindowsTheme } from "@/themes";
 
 // Map appId to doc URL path (most are same, but some have different names)
 const APP_DOC_NAMES: Partial<Record<AppId, string>> = {
@@ -27,7 +28,7 @@ interface HelpCardProps {
 
 function HelpCard({ icon, title, description }: HelpCardProps) {
   const currentTheme = useThemeStore((state) => state.current);
-  const isXpTheme = currentTheme === "xp" || currentTheme === "win98";
+  const isXpTheme = isWindowsTheme(currentTheme);
   const isMacTheme = currentTheme === "macosx";
 
   return (
@@ -85,7 +86,7 @@ export function HelpDialog({
 }: HelpDialogProps) {
   const { t } = useTranslation();
   const currentTheme = useThemeStore((state) => state.current);
-  const isXpTheme = currentTheme === "xp" || currentTheme === "win98";
+  const isXpTheme = isWindowsTheme(currentTheme);
   const isMacTheme = currentTheme === "macosx";
   const launchApp = useAppStore((state) => state.launchApp);
 

--- a/src/components/dialogs/InputDialog.tsx
+++ b/src/components/dialogs/InputDialog.tsx
@@ -12,6 +12,7 @@ import { Button } from "@/components/ui/button";
 import { useThemeStore } from "@/stores/useThemeStore";
 import { cn } from "@/lib/utils";
 import { useTranslation } from "react-i18next";
+import { isWindowsTheme } from "@/themes";
 
 interface InputDialogProps {
   isOpen: boolean;
@@ -50,7 +51,7 @@ export function InputDialog({
 }: InputDialogProps) {
   const { t } = useTranslation();
   const currentTheme = useThemeStore((state) => state.current);
-  const isXpTheme = currentTheme === "xp" || currentTheme === "win98";
+  const isXpTheme = isWindowsTheme(currentTheme);
   const isMacTheme = currentTheme === "macosx";
   const defaultSubmitLabel = submitLabel || t("common.dialog.save");
 

--- a/src/components/dialogs/LoginDialog.tsx
+++ b/src/components/dialogs/LoginDialog.tsx
@@ -14,6 +14,7 @@ import { Tabs } from "@/components/ui/tabs";
 import { useThemeStore } from "@/stores/useThemeStore";
 import { cn } from "@/lib/utils";
 import { useTranslation } from "react-i18next";
+import { isWindowsTheme } from "@/themes";
 import {
   ThemedTabsList,
   ThemedTabsTrigger,
@@ -69,7 +70,7 @@ export function LoginDialog({
 }: LoginDialogProps) {
   const [activeTab, setActiveTab] = useState<"login" | "signup">(initialTab);
   const currentTheme = useThemeStore((state) => state.current);
-  const isXpTheme = currentTheme === "xp" || currentTheme === "win98";
+  const isXpTheme = isWindowsTheme(currentTheme);
   const { t } = useTranslation();
   const dialogTitle = t("common.auth.dialogTitle");
 

--- a/src/components/dialogs/LyricsSearchDialog.tsx
+++ b/src/components/dialogs/LyricsSearchDialog.tsx
@@ -15,6 +15,7 @@ import { useTranslation } from "react-i18next";
 import { getApiUrl } from "@/utils/platform";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { abortableFetch } from "@/utils/abortableFetch";
+import { isWindowsTheme } from "@/themes";
 
 export interface LyricsSearchResult {
   title: string;
@@ -58,7 +59,7 @@ export function LyricsSearchDialog({
 }: LyricsSearchDialogProps) {
   const { t } = useTranslation();
   const currentTheme = useThemeStore((state) => state.current);
-  const isXpTheme = currentTheme === "xp" || currentTheme === "win98";
+  const isXpTheme = isWindowsTheme(currentTheme);
   const isMacTheme = currentTheme === "macosx";
 
   const [query, setQuery] = useState(initialQuery || "");

--- a/src/components/dialogs/ShareItemDialog.tsx
+++ b/src/components/dialogs/ShareItemDialog.tsx
@@ -14,6 +14,7 @@ import { useThemeStore } from "@/stores/useThemeStore";
 import { cn } from "@/lib/utils";
 import { QRCodeSVG } from "qrcode.react";
 import { useTranslation } from "react-i18next";
+import { isWindowsTheme } from "@/themes";
 
 interface ShareItemDialogProps {
   isOpen: boolean;
@@ -45,7 +46,7 @@ export function ShareItemDialog({
   const [shareUrl, setShareUrl] = useState("");
   const inputRef = useRef<HTMLInputElement>(null);
   const currentTheme = useThemeStore((state) => state.current);
-  const isXpTheme = currentTheme === "xp" || currentTheme === "win98";
+  const isXpTheme = isWindowsTheme(currentTheme);
   const isMacOsxTheme = currentTheme === "macosx";
 
   // Translate itemType (e.g., "Page" -> translated "Page", "Song" -> translated "Song")

--- a/src/components/dialogs/SongSearchDialog.tsx
+++ b/src/components/dialogs/SongSearchDialog.tsx
@@ -15,6 +15,7 @@ import { useTranslation } from "react-i18next";
 import { getApiUrl } from "@/utils/platform";
 import { abortableFetch } from "@/utils/abortableFetch";
 import { decodeHtmlEntities } from "@/utils/decodeHtmlEntities";
+import { isWindowsTheme } from "@/themes";
 
 // Check if input looks like a YouTube URL
 function isYouTubeUrl(input: string): boolean {
@@ -52,7 +53,7 @@ export function SongSearchDialog({
 }: SongSearchDialogProps) {
   const { t } = useTranslation();
   const currentTheme = useThemeStore((state) => state.current);
-  const isXpTheme = currentTheme === "xp" || currentTheme === "win98";
+  const isXpTheme = isWindowsTheme(currentTheme);
   const isMacTheme = currentTheme === "macosx";
 
   const [query, setQuery] = useState(initialQuery);

--- a/src/components/dialogs/TelegramLinkDialog.tsx
+++ b/src/components/dialogs/TelegramLinkDialog.tsx
@@ -17,6 +17,7 @@ import type {
 } from "@/api/telegram";
 import { getTelegramLinkedAccountLabel } from "@/hooks/useTelegramLink";
 import { ArrowRight, PaperPlaneRight } from "@phosphor-icons/react";
+import { isWindowsTheme } from "@/themes";
 
 interface TelegramLinkDialogProps {
   isOpen: boolean;
@@ -47,7 +48,7 @@ export function TelegramLinkDialog({
 }: TelegramLinkDialogProps) {
   const { t } = useTranslation();
   const currentTheme = useThemeStore((state) => state.current);
-  const isXpTheme = currentTheme === "xp" || currentTheme === "win98";
+  const isXpTheme = isWindowsTheme(currentTheme);
   const isMacOsxTheme = currentTheme === "macosx";
 
   const linkedAccountLabel = linkedAccount

--- a/src/components/errors/ErrorBoundaries.tsx
+++ b/src/components/errors/ErrorBoundaries.tsx
@@ -12,6 +12,7 @@ import { ThemedIcon } from "@/components/shared/ThemedIcon";
 import { cn } from "@/lib/utils";
 import type { AppId } from "@/config/appRegistry";
 import { useThemeStore } from "@/stores/useThemeStore";
+import { isWindowsTheme } from "@/themes";
 import {
   reportRuntimeCrash,
   RYOS_ERROR_BOUNDARY_TEST_EVENT,
@@ -154,7 +155,7 @@ function CrashDialog({
   const headingId = React.useId();
   const descriptionId = React.useId();
 
-  const isXpTheme = currentTheme === "xp" || currentTheme === "win98";
+  const isXpTheme = isWindowsTheme(currentTheme);
   const isMacTheme = currentTheme === "macosx";
 
   const bodyTextClasses = cn(

--- a/src/components/layout/Desktop.tsx
+++ b/src/components/layout/Desktop.tsx
@@ -18,6 +18,7 @@ import { ConfirmDialog } from "@/components/dialogs/ConfirmDialog";
 import { useTranslation } from "react-i18next";
 import { getTranslatedAppName } from "@/utils/i18n";
 import { useEventListener } from "@/hooks/useEventListener";
+import { isWindowsTheme } from "@/themes";
 import {
   createSelectionRect,
   getIntersectingSelectionIds,
@@ -102,7 +103,7 @@ export function Desktop({
 
   // Get current theme for layout adjustments
   const currentTheme = useThemeStore((state) => state.current);
-  const isXpTheme = currentTheme === "xp" || currentTheme === "win98";
+  const isXpTheme = isWindowsTheme(currentTheme);
   
   // Check if running in Tauri
   const isTauriApp = typeof window !== "undefined" && "__TAURI__" in window;

--- a/src/components/layout/MenuBar.tsx
+++ b/src/components/layout/MenuBar.tsx
@@ -49,6 +49,7 @@ import { useSpotlightStore } from "@/stores/useSpotlightStore";
 import { toggleExposeView, toggleSpotlightSearch, requestAppLaunch } from "@/utils/appEventBus";
 import { useUndoRedoStore } from "@/stores/useUndoRedoStore";
 import { useCloudSyncStore } from "@/stores/useCloudSyncStore";
+import { isWindowsTheme } from "@/themes";
 
 // Helper function to get app name (using translations)
 const getAppName = (appId: string): string => {
@@ -290,7 +291,7 @@ function Clock({ enableExposeToggle = false, enableCalendarOpen = false }: Clock
   const [time, setTime] = useState(new Date());
   const [viewportWidth, setViewportWidth] = useState(window.innerWidth);
   const currentTheme = useThemeStore((state) => state.current);
-  const isXpTheme = currentTheme === "xp" || currentTheme === "win98";
+  const isXpTheme = isWindowsTheme(currentTheme);
   const { t, i18n: i18nInstance } = useTranslation();
   
   // Get current locale from i18n (reactive to language changes)
@@ -859,7 +860,7 @@ function VolumeControl() {
   const launchApp = useLaunchApp();
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
   const currentTheme = useThemeStore((state) => state.current);
-  const isXpTheme = currentTheme === "xp" || currentTheme === "win98";
+  const isXpTheme = isWindowsTheme(currentTheme);
 
   const getVolumeIcon = () => {
     if (masterVolume === 0) {
@@ -953,7 +954,7 @@ export function MenuBar({ children, inWindowFrame = false }: MenuBarProps) {
 
   // Get current theme
   const currentTheme = useThemeStore((state) => state.current);
-  const isXpTheme = currentTheme === "xp" || currentTheme === "win98";
+  const isXpTheme = isWindowsTheme(currentTheme);
   
   // Check if on phone (must be called before any early returns)
   const isPhone = useIsPhone();
@@ -1560,7 +1561,7 @@ export function MenuBar({ children, inWindowFrame = false }: MenuBarProps) {
 function SpotlightMenuBarButton() {
   const { t } = useTranslation();
   const currentTheme = useThemeStore((state) => state.current);
-  const isXpTheme = currentTheme === "xp" || currentTheme === "win98";
+  const isXpTheme = isWindowsTheme(currentTheme);
   const isSpotlightOpen = useSpotlightStore((state) => state.isOpen);
 
   // Only show on Mac themes — Windows themes use Start Menu "Run..."
@@ -1605,7 +1606,7 @@ function OfflineIndicator() {
   const { t } = useTranslation();
   const isOffline = useOffline();
   const currentTheme = useThemeStore((state) => state.current);
-  const isXpTheme = currentTheme === "xp" || currentTheme === "win98";
+  const isXpTheme = isWindowsTheme(currentTheme);
 
   if (!isOffline) return null;
 
@@ -1637,7 +1638,7 @@ function OfflineIndicator() {
 function ExposeButton() {
   const { t } = useTranslation();
   const currentTheme = useThemeStore((state) => state.current);
-  const isXpTheme = currentTheme === "xp" || currentTheme === "win98";
+  const isXpTheme = isWindowsTheme(currentTheme);
   
   // Don't show on Windows themes (they have their own taskbar)
   if (isXpTheme) return null;
@@ -1665,7 +1666,7 @@ function ExposeButton() {
 function CloudSyncIndicator() {
   const { t } = useTranslation();
   const currentTheme = useThemeStore((state) => state.current);
-  const isXpTheme = currentTheme === "xp" || currentTheme === "win98";
+  const isXpTheme = isWindowsTheme(currentTheme);
   const isPhone = useIsPhone();
   const [isTooltipVisible, setIsTooltipVisible] = useState(false);
   const tooltipTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);

--- a/src/components/layout/SpotlightSearch.tsx
+++ b/src/components/layout/SpotlightSearch.tsx
@@ -13,6 +13,7 @@ import { useTranslation } from "react-i18next";
 import { useIsMobile } from "@/hooks/useIsMobile";
 import { isTauri, isTauriWindows } from "@/utils/platform";
 import { onExposeToggle, onSpotlightToggle } from "@/utils/appEventBus";
+import { isWindowsTheme } from "@/themes";
 
 // Section header labels by result type
 const SECTION_TYPE_ORDER: SpotlightResult["type"][] = [
@@ -55,7 +56,7 @@ export function SpotlightSearch() {
   const listRef = useRef<HTMLDivElement>(null);
   const proxyInputRef = useRef<HTMLInputElement>(null);
   const currentTheme = useThemeStore((state) => state.current);
-  const isXpTheme = currentTheme === "xp" || currentTheme === "win98";
+  const isXpTheme = isWindowsTheme(currentTheme);
   const isSystem7 = currentTheme === "system7";
   const isMac = currentTheme === "macosx" || isSystem7;
   const isMobile = useIsMobile();

--- a/src/components/layout/StartMenu.tsx
+++ b/src/components/layout/StartMenu.tsx
@@ -14,6 +14,7 @@ import { AppId } from "@/config/appIds";
 import { ThemedIcon } from "@/components/shared/ThemedIcon";
 import { getTranslatedAppName } from "@/utils/i18n";
 import { toggleSpotlightSearch } from "@/utils/appEventBus";
+import { isWindowsTheme } from "@/themes";
 
 interface StartMenuProps {
   apps: AnyApp[];
@@ -118,7 +119,7 @@ export function StartMenu({ apps }: StartMenuProps) {
             width: "280px",
             maxHeight: "80vh",
             background:
-              currentTheme === "xp" || currentTheme === "win98"
+              isWindowsTheme(currentTheme)
                 ? "#ece9d8"
                 : "#c0c0c0",
             border:
@@ -132,7 +133,7 @@ export function StartMenu({ apps }: StartMenuProps) {
         >
           <div className="flex h-full">
             {/* Left Panel with rotated text */}
-            {(currentTheme === "xp" || currentTheme === "win98") && (
+            {(isWindowsTheme(currentTheme)) && (
               <div
                 className="relative w-[32px] overflow-hidden"
                 style={{
@@ -169,7 +170,7 @@ export function StartMenu({ apps }: StartMenuProps) {
               className="flex-1 flex flex-col"
               style={{
                 background:
-                  currentTheme === "xp" || currentTheme === "win98"
+                  isWindowsTheme(currentTheme)
                     ? "#ffffff"
                     : "#c0c0c0",
                 maxHeight: "80vh", // Responsive height to enable scrolling

--- a/src/components/layout/dashboard/CalendarWidget.tsx
+++ b/src/components/layout/dashboard/CalendarWidget.tsx
@@ -4,6 +4,7 @@ import { useThemeStore } from "@/stores/useThemeStore";
 import { requestAppLaunch } from "@/utils/appEventBus";
 import { useTranslation } from "react-i18next";
 import { useDashboardStore, type CalendarWidgetConfig } from "@/stores/useDashboardStore";
+import { isWindowsTheme } from "@/themes";
 
 function getLocalizedDayHeaders(locale: string): string[] {
   const fmt = new Intl.DateTimeFormat(locale, { weekday: "narrow" });
@@ -35,7 +36,7 @@ export function CalendarWidget({ widgetId }: CalendarWidgetProps) {
   const { i18n } = useTranslation();
   const locale = i18n.language || "en";
   const currentTheme = useThemeStore((state) => state.current);
-  const isXpTheme = currentTheme === "xp" || currentTheme === "win98";
+  const isXpTheme = isWindowsTheme(currentTheme);
 
   const widget = useDashboardStore((s) => widgetId ? s.widgets.find((w) => w.id === widgetId) : undefined);
   const calConfig = widget?.config as CalendarWidgetConfig | undefined;
@@ -274,7 +275,7 @@ const ALL_COLORS: { id: EventColor; hex: string }[] = [
 export function CalendarBackPanel({ widgetId }: { widgetId: string }) {
   const { t } = useTranslation();
   const currentTheme = useThemeStore((state) => state.current);
-  const isXpTheme = currentTheme === "xp" || currentTheme === "win98";
+  const isXpTheme = isWindowsTheme(currentTheme);
   const widget = useDashboardStore((s) => s.widgets.find((w) => w.id === widgetId));
   const updateWidgetConfig = useDashboardStore((s) => s.updateWidgetConfig);
   const calConfig = widget?.config as CalendarWidgetConfig | undefined;

--- a/src/components/layout/dashboard/ClockWidget.tsx
+++ b/src/components/layout/dashboard/ClockWidget.tsx
@@ -4,6 +4,7 @@ import { useDashboardStore, type ClockWidgetConfig } from "@/stores/useDashboard
 import { MapPin, MagnifyingGlass, NavigationArrow } from "@phosphor-icons/react";
 import { useTranslation } from "react-i18next";
 import type { TFunction } from "i18next";
+import { isWindowsTheme } from "@/themes";
 
 interface CityResult {
   name: string;
@@ -73,7 +74,7 @@ export function ClockWidget({ widgetId, isFlipped }: ClockWidgetProps) {
   const { t } = useTranslation();
   const [time, setTime] = useState(new Date());
   const currentTheme = useThemeStore((state) => state.current);
-  const isXpTheme = currentTheme === "xp" || currentTheme === "win98";
+  const isXpTheme = isWindowsTheme(currentTheme);
   const widget = useDashboardStore((s) => widgetId ? s.widgets.find((w) => w.id === widgetId) : undefined);
   const config = widget?.config as ClockWidgetConfig | undefined;
   const gradId = useMemo(() => widgetId?.replace(/[^a-zA-Z0-9]/g, "") ?? "default", [widgetId]);
@@ -231,7 +232,7 @@ export function ClockBackPanel({ widgetId, onDone }: { widgetId: string; onDone?
   const { t } = useTranslation();
   const popularCities = useMemo(() => getPopularCities(t), [t]);
   const currentTheme = useThemeStore((state) => state.current);
-  const isXpTheme = currentTheme === "xp" || currentTheme === "win98";
+  const isXpTheme = isWindowsTheme(currentTheme);
   const updateWidgetConfig = useDashboardStore((s) => s.updateWidgetConfig);
 
   const [searchQuery, setSearchQuery] = useState("");

--- a/src/components/layout/dashboard/DictionaryWidget.tsx
+++ b/src/components/layout/dashboard/DictionaryWidget.tsx
@@ -3,6 +3,7 @@ import { useThemeStore } from "@/stores/useThemeStore";
 import { useDashboardStore, type DictionaryWidgetConfig } from "@/stores/useDashboardStore";
 import { MagnifyingGlass } from "@phosphor-icons/react";
 import { useTranslation } from "react-i18next";
+import { isWindowsTheme } from "@/themes";
 
 interface DictionaryMeaning {
   partOfSpeech: string;
@@ -25,7 +26,7 @@ interface DictionaryWidgetProps {
 export function DictionaryWidget({ widgetId }: DictionaryWidgetProps) {
   const { t } = useTranslation();
   const currentTheme = useThemeStore((state) => state.current);
-  const isXpTheme = currentTheme === "xp" || currentTheme === "win98";
+  const isXpTheme = isWindowsTheme(currentTheme);
 
   const widget = useDashboardStore((s) =>
     s.widgets.find((w) => w.id === widgetId)
@@ -425,7 +426,7 @@ export function DictionaryBackPanel({
 }) {
   const { t } = useTranslation();
   const currentTheme = useThemeStore((state) => state.current);
-  const isXpTheme = currentTheme === "xp" || currentTheme === "win98";
+  const isXpTheme = isWindowsTheme(currentTheme);
   const textColor = isXpTheme ? "#000" : "rgba(255,255,255,0.8)";
   const mutedColor = isXpTheme ? "#888" : "rgba(255,255,255,0.4)";
 

--- a/src/components/layout/dashboard/IpodWidget.tsx
+++ b/src/components/layout/dashboard/IpodWidget.tsx
@@ -15,6 +15,7 @@ import {
   RepeatOnce,
 } from "@phosphor-icons/react";
 import { useTranslation } from "react-i18next";
+import { isWindowsTheme } from "@/themes";
 
 interface IpodWidgetProps {
   widgetId?: string;
@@ -178,7 +179,7 @@ function ClickWheel({
 export function IpodWidget({ widgetId }: IpodWidgetProps) {
   const { t } = useTranslation();
   const currentTheme = useThemeStore((state) => state.current);
-  const isXpTheme = currentTheme === "xp" || currentTheme === "win98";
+  const isXpTheme = isWindowsTheme(currentTheme);
 
   const widget = useDashboardStore((s) => widgetId ? s.widgets.find((w) => w.id === widgetId) : undefined);
   const controlMode = (widget?.config as IpodWidgetConfig | undefined)?.controlMode ?? "ipod";
@@ -521,7 +522,7 @@ export function IpodBackPanel({
 }) {
   const { t } = useTranslation();
   const currentTheme = useThemeStore((state) => state.current);
-  const isXpTheme = currentTheme === "xp" || currentTheme === "win98";
+  const isXpTheme = isWindowsTheme(currentTheme);
   const textColor = isXpTheme ? "#000" : "rgba(255,255,255,0.8)";
   const updateWidgetConfig = useDashboardStore((s) => s.updateWidgetConfig);
   const widget = useDashboardStore((s) => s.widgets.find((w) => w.id === widgetId));

--- a/src/components/layout/dashboard/StickyNoteWidget.tsx
+++ b/src/components/layout/dashboard/StickyNoteWidget.tsx
@@ -2,6 +2,7 @@ import { useState, useCallback, useRef, useEffect } from "react";
 import { useThemeStore } from "@/stores/useThemeStore";
 import { useDashboardStore } from "@/stores/useDashboardStore";
 import { useTranslation } from "react-i18next";
+import { isWindowsTheme } from "@/themes";
 
 interface StickyNoteWidgetConfig {
   text?: string;
@@ -40,7 +41,7 @@ function textColorForBg(hex: string): string {
 export function StickyNoteWidget({ widgetId }: StickyNoteWidgetProps) {
   const { t } = useTranslation();
   const currentTheme = useThemeStore((state) => state.current);
-  const isXpTheme = currentTheme === "xp" || currentTheme === "win98";
+  const isXpTheme = isWindowsTheme(currentTheme);
 
   const widget = useDashboardStore((s) =>
     widgetId ? s.widgets.find((w) => w.id === widgetId) : undefined
@@ -198,7 +199,7 @@ export function StickyNoteBackPanel({
 }) {
   const { t } = useTranslation();
   const currentTheme = useThemeStore((state) => state.current);
-  const isXpTheme = currentTheme === "xp" || currentTheme === "win98";
+  const isXpTheme = isWindowsTheme(currentTheme);
 
   const widget = useDashboardStore((s) =>
     s.widgets.find((w) => w.id === widgetId)

--- a/src/components/layout/dashboard/StocksWidget.tsx
+++ b/src/components/layout/dashboard/StocksWidget.tsx
@@ -3,6 +3,7 @@ import { useThemeStore } from "@/stores/useThemeStore";
 import { useDashboardStore, type StocksWidgetConfig } from "@/stores/useDashboardStore";
 import { useTranslation } from "react-i18next";
 import { MagnifyingGlass, Plus, X, ArrowClockwise } from "@phosphor-icons/react";
+import { isWindowsTheme } from "@/themes";
 
 interface StockQuote {
   symbol: string;
@@ -241,7 +242,7 @@ interface StocksWidgetProps {
 export function StocksWidget({ widgetId }: StocksWidgetProps) {
   const { t } = useTranslation();
   const currentTheme = useThemeStore((state) => state.current);
-  const isXpTheme = currentTheme === "xp" || currentTheme === "win98";
+  const isXpTheme = isWindowsTheme(currentTheme);
 
   const widget = useDashboardStore((s) => s.widgets.find((w) => w.id === widgetId));
   const config = widget?.config as StocksWidgetConfig | undefined;
@@ -559,7 +560,7 @@ export function StocksBackPanel({
 }) {
   const { t } = useTranslation();
   const currentTheme = useThemeStore((state) => state.current);
-  const isXpTheme = currentTheme === "xp" || currentTheme === "win98";
+  const isXpTheme = isWindowsTheme(currentTheme);
   const updateWidgetConfig = useDashboardStore((s) => s.updateWidgetConfig);
 
   const widget = useDashboardStore((s) => s.widgets.find((w) => w.id === widgetId));

--- a/src/components/layout/dashboard/TranslationWidget.tsx
+++ b/src/components/layout/dashboard/TranslationWidget.tsx
@@ -3,6 +3,7 @@ import { useThemeStore } from "@/stores/useThemeStore";
 import { useDashboardStore, type TranslationWidgetConfig } from "@/stores/useDashboardStore";
 import { useTranslation } from "react-i18next";
 import { ArrowsLeftRight, ArrowsDownUp } from "@phosphor-icons/react";
+import { isWindowsTheme } from "@/themes";
 
 const LANGUAGE_CODES = ["en", "fr", "es", "de", "it", "pt", "ja", "ko", "zh-TW", "ru"] as const;
 
@@ -28,7 +29,7 @@ export function TranslationWidget({ widgetId }: TranslationWidgetProps) {
   const { t, i18n } = useTranslation();
   const LANGUAGES = useLocalizedLanguages(i18n.language);
   const currentTheme = useThemeStore((state) => state.current);
-  const isXpTheme = currentTheme === "xp" || currentTheme === "win98";
+  const isXpTheme = isWindowsTheme(currentTheme);
 
   const widget = useDashboardStore((s) =>
     widgetId ? s.widgets.find((w) => w.id === widgetId) : undefined
@@ -524,7 +525,7 @@ export function TranslationBackPanel({
   const { t, i18n } = useTranslation();
   const LANGUAGES = useLocalizedLanguages(i18n.language);
   const currentTheme = useThemeStore((state) => state.current);
-  const isXpTheme = currentTheme === "xp" || currentTheme === "win98";
+  const isXpTheme = isWindowsTheme(currentTheme);
   const updateWidgetConfig = useDashboardStore((s) => s.updateWidgetConfig);
   const widget = useDashboardStore((s) => s.widgets.find((w) => w.id === widgetId));
   const config = widget?.config as TranslationWidgetConfig | undefined;

--- a/src/components/layout/dashboard/WeatherWidget.tsx
+++ b/src/components/layout/dashboard/WeatherWidget.tsx
@@ -4,6 +4,7 @@ import type { TFunction } from "i18next";
 import { useThemeStore } from "@/stores/useThemeStore";
 import { useDashboardStore, type WeatherWidgetConfig } from "@/stores/useDashboardStore";
 import { MapPin, MagnifyingGlass, NavigationArrow } from "@phosphor-icons/react";
+import { isWindowsTheme } from "@/themes";
 
 interface DailyForecast {
   dayLabel: string;
@@ -130,7 +131,7 @@ export function WeatherWidget({ widgetId }: WeatherWidgetProps) {
   const { t, i18n } = useTranslation();
   const locale = i18n.language || "en";
   const currentTheme = useThemeStore((state) => state.current);
-  const isXpTheme = currentTheme === "xp" || currentTheme === "win98";
+  const isXpTheme = isWindowsTheme(currentTheme);
 
   const widget = useDashboardStore((s) => s.widgets.find((w) => w.id === widgetId));
   const cityConfig = widget?.config as WeatherWidgetConfig | undefined;
@@ -434,7 +435,7 @@ export function WeatherBackPanel({ widgetId, onDone }: { widgetId: string; onDon
   const { t } = useTranslation();
   const popularCities = useMemo(() => getPopularCities(t), [t]);
   const currentTheme = useThemeStore((state) => state.current);
-  const isXpTheme = currentTheme === "xp" || currentTheme === "win98";
+  const isXpTheme = isWindowsTheme(currentTheme);
   const updateWidgetConfig = useDashboardStore((s) => s.updateWidgetConfig);
 
   const [searchQuery, setSearchQuery] = useState("");

--- a/src/components/layout/dashboard/WidgetChrome.tsx
+++ b/src/components/layout/dashboard/WidgetChrome.tsx
@@ -3,6 +3,7 @@ import { X, Info } from "@phosphor-icons/react";
 import { useThemeStore } from "@/stores/useThemeStore";
 import { motion, AnimatePresence } from "framer-motion";
 import { useTranslation } from "react-i18next";
+import { isWindowsTheme } from "@/themes";
 
 interface WidgetChromeProps {
   children: ReactNode | ((isFlipped: boolean) => ReactNode);
@@ -37,7 +38,7 @@ export function WidgetChrome({
 }: WidgetChromeProps) {
   const { t } = useTranslation();
   const currentTheme = useThemeStore((state) => state.current);
-  const isXpTheme = currentTheme === "xp" || currentTheme === "win98";
+  const isXpTheme = isWindowsTheme(currentTheme);
   const [isHovered, setIsHovered] = useState(false);
   const [isTouchActive, setIsTouchActive] = useState(false);
   const [isDragging, setIsDragging] = useState(false);

--- a/src/components/listen/JoinSessionDialog.tsx
+++ b/src/components/listen/JoinSessionDialog.tsx
@@ -17,6 +17,7 @@ import {
   type ListenSessionSummary,
 } from "@/stores/useListenSessionStore";
 import { cn } from "@/lib/utils";
+import { isWindowsTheme } from "@/themes";
 
 interface JoinSessionDialogProps {
   isOpen: boolean;
@@ -63,7 +64,7 @@ export function JoinSessionDialog({
   const currentTheme = useThemeStore((state) => state.current);
   const fetchSessions = useListenSessionStore((state) => state.fetchSessions);
 
-  const isXpTheme = currentTheme === "xp" || currentTheme === "win98";
+  const isXpTheme = isWindowsTheme(currentTheme);
   const isMacTheme = currentTheme === "macosx";
 
   const loadSessions = useCallback(async () => {

--- a/src/components/listen/ListenSessionBadge.tsx
+++ b/src/components/listen/ListenSessionBadge.tsx
@@ -2,6 +2,7 @@ import { useTranslation } from "react-i18next";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { useThemeStore } from "@/stores/useThemeStore";
+import { isWindowsTheme } from "@/themes";
 
 interface ListenSessionBadgeProps {
   listenerCount: number;
@@ -24,7 +25,7 @@ export function ListenSessionBadge({
 }: ListenSessionBadgeProps) {
   const { t } = useTranslation();
   const currentTheme = useThemeStore((state) => state.current);
-  const isXpTheme = currentTheme === "xp" || currentTheme === "win98";
+  const isXpTheme = isWindowsTheme(currentTheme);
 
   const buttonClassName = cn(
     "h-6 px-2 text-[11px]",

--- a/src/components/listen/ListenSessionInvite.tsx
+++ b/src/components/listen/ListenSessionInvite.tsx
@@ -15,6 +15,7 @@ import { toast } from "sonner";
 import { useThemeStore } from "@/stores/useThemeStore";
 import { cn } from "@/lib/utils";
 import { getAppPublicOrigin } from "@/utils/runtimeConfig";
+import { isWindowsTheme } from "@/themes";
 
 interface ListenSessionInviteProps {
   isOpen: boolean;
@@ -33,7 +34,7 @@ export function ListenSessionInvite({
   const [shareUrl, setShareUrl] = useState("");
   const inputRef = useRef<HTMLInputElement>(null);
   const currentTheme = useThemeStore((state) => state.current);
-  const isXpTheme = currentTheme === "xp" || currentTheme === "win98";
+  const isXpTheme = isWindowsTheme(currentTheme);
   const isMacOsxTheme = currentTheme === "macosx";
 
   const baseUrl = useMemo(() => {

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -4,6 +4,7 @@ import { Check, CaretRight, Circle } from "@phosphor-icons/react";
 import { useSound, Sounds } from "@/hooks/useSound";
 import { useThemeStore } from "@/stores/useThemeStore";
 import { useMediaQuery } from "@/hooks/useMediaQuery";
+import { isWindowsTheme } from "@/themes";
 
 import { cn } from "@/lib/utils";
 
@@ -83,13 +84,13 @@ const DropdownMenuSubTrigger = React.forwardRef<
       )}
       style={{
         fontFamily:
-          currentTheme === "xp" || currentTheme === "win98"
+          isWindowsTheme(currentTheme)
             ? '"Pixelated MS Sans Serif", "ArkPixel", Arial'
             : currentTheme === "macosx"
             ? '"LucidaGrande", "Lucida Grande", "AquaKana", "Hiragino Sans", "Hiragino Sans GB", "Heiti SC", "Lucida Sans Unicode", sans-serif'
             : undefined,
         fontSize:
-          currentTheme === "xp" || currentTheme === "win98"
+          isWindowsTheme(currentTheme)
             ? "11px"
             : currentTheme === "macosx"
             ? "12px !important"
@@ -200,7 +201,7 @@ const DropdownMenuItem = React.forwardRef<
 >(({ className, inset, ...props }, ref) => {
   const currentTheme = useThemeStore((state) => state.current);
   const isMacOSTheme = currentTheme === "macosx";
-  const isXpTheme = currentTheme === "xp" || currentTheme === "win98";
+  const isXpTheme = isWindowsTheme(currentTheme);
 
   return (
     <DropdownMenuPrimitive.Item
@@ -242,7 +243,7 @@ const DropdownMenuCheckboxItem = React.forwardRef<
 >(({ className, children, checked, ...props }, ref) => {
   const currentTheme = useThemeStore((state) => state.current);
   const isMacOSTheme = currentTheme === "macosx";
-  const isXpTheme = currentTheme === "xp" || currentTheme === "win98";
+  const isXpTheme = isWindowsTheme(currentTheme);
   const isSystem7 = currentTheme === "system7";
 
   return (
@@ -314,13 +315,13 @@ const DropdownMenuRadioItem = React.forwardRef<
       )}
       style={{
         fontFamily:
-          currentTheme === "xp" || currentTheme === "win98"
+          isWindowsTheme(currentTheme)
             ? '"Pixelated MS Sans Serif", "ArkPixel", Arial'
             : currentTheme === "macosx"
             ? '"LucidaGrande", "Lucida Grande", "AquaKana", "Hiragino Sans", "Hiragino Sans GB", "Heiti SC", "Lucida Sans Unicode", sans-serif'
             : undefined,
         fontSize:
-          currentTheme === "xp" || currentTheme === "win98"
+          isWindowsTheme(currentTheme)
             ? "11px"
             : undefined,
       }}
@@ -355,13 +356,13 @@ const DropdownMenuLabel = React.forwardRef<
       )}
       style={{
         fontFamily:
-          currentTheme === "xp" || currentTheme === "win98"
+          isWindowsTheme(currentTheme)
             ? '"Pixelated MS Sans Serif", "ArkPixel", Arial'
             : currentTheme === "macosx"
             ? '"LucidaGrande", "Lucida Grande", "AquaKana", "Hiragino Sans", "Hiragino Sans GB", "Heiti SC", "Lucida Sans Unicode", sans-serif'
             : undefined,
         fontSize:
-          currentTheme === "xp" || currentTheme === "win98"
+          isWindowsTheme(currentTheme)
             ? "11px"
             : undefined,
       }}

--- a/src/components/ui/menubar.tsx
+++ b/src/components/ui/menubar.tsx
@@ -4,6 +4,7 @@ import { Check, CaretRight, Circle } from "@phosphor-icons/react"
 import { useSound, Sounds } from "@/hooks/useSound"
 import { useThemeStore } from "@/stores/useThemeStore"
 import { useMediaQuery } from "@/hooks/useMediaQuery"
+import { isWindowsTheme } from "@/themes";
 
 import { cn } from "@/lib/utils"
 
@@ -68,7 +69,7 @@ const MenubarTrigger = React.forwardRef<
   React.ComponentPropsWithoutRef<typeof MenubarPrimitive.Trigger>
 >(({ className, style, ...props }, ref) => {
   const currentTheme = useThemeStore((state) => state.current)
-  const isWindowsTheme = currentTheme === "xp" || currentTheme === "win98"
+  const windowsTheme = isWindowsTheme(currentTheme)
   const isSystem7 = currentTheme === "system7"
   const isMacOSX = currentTheme === "macosx"
 
@@ -84,7 +85,7 @@ const MenubarTrigger = React.forwardRef<
     // Base styles - h-full + self-stretch ensures trigger fills parent height (works with both CSS var and Tauri's 32px)
     "flex cursor-default select-none items-center h-full self-stretch px-2 text-md font-medium outline-none",
     // Windows themes: plain text style, no background changes, add menubar-trigger class for CSS override
-    isWindowsTheme && "rounded-none menubar-trigger",
+    windowsTheme && "rounded-none menubar-trigger",
     // System 7: black background, white text when open
     // Explicitly clear state when closed to prevent lingering styles (overrides focus states)
     isSystem7 && "rounded-none data-[state=open]:bg-black data-[state=open]:text-white data-[state=closed]:!bg-transparent data-[state=closed]:!text-inherit",
@@ -92,7 +93,7 @@ const MenubarTrigger = React.forwardRef<
     // Explicitly clear state when closed to prevent lingering styles (use !important to override focus states)
     isMacOSX && "rounded-none data-[state=open]:bg-[rgba(39,101,202,0.88)] data-[state=open]:text-white data-[state=closed]:!bg-transparent data-[state=closed]:!text-inherit",
     // Default/other themes
-    !isWindowsTheme && !isSystem7 && !isMacOSX && "rounded-sm data-[state=open]:bg-accent data-[state=open]:text-accent-foreground",
+    !windowsTheme && !isSystem7 && !isMacOSX && "rounded-sm data-[state=open]:bg-accent data-[state=open]:text-accent-foreground",
     className
   )
 
@@ -115,7 +116,7 @@ const MenubarSubTrigger = React.forwardRef<
 >(({ className, inset, children, ...props }, ref) => {
   const currentTheme = useThemeStore((state) => state.current)
   const isMacOSTheme = currentTheme === "macosx"
-  const isXpTheme = currentTheme === "xp" || currentTheme === "win98"
+  const isXpTheme = isWindowsTheme(currentTheme)
   const isSystem7 = currentTheme === "system7"
 
   return (
@@ -256,7 +257,7 @@ const MenubarItem = React.forwardRef<
 >(({ className, inset, ...props }, ref) => {
   const currentTheme = useThemeStore((state) => state.current)
   const isMacOSTheme = currentTheme === "macosx"
-  const isXpTheme = currentTheme === "xp" || currentTheme === "win98"
+  const isXpTheme = isWindowsTheme(currentTheme)
   const isSystem7 = currentTheme === "system7"
 
   return (
@@ -307,7 +308,7 @@ const MenubarCheckboxItem = React.forwardRef<
 >(({ className, children, checked, ...props }, ref) => {
   const currentTheme = useThemeStore((state) => state.current)
   const isMacOSTheme = currentTheme === "macosx"
-  const isXpTheme = currentTheme === "xp" || currentTheme === "win98"
+  const isXpTheme = isWindowsTheme(currentTheme)
   const isSystem7 = currentTheme === "system7"
 
   return (
@@ -369,7 +370,7 @@ const MenubarRadioItem = React.forwardRef<
 >(({ className, children, ...props }, ref) => {
   const currentTheme = useThemeStore((state) => state.current)
   const isMacOSTheme = currentTheme === "macosx"
-  const isXpTheme = currentTheme === "xp" || currentTheme === "win98"
+  const isXpTheme = isWindowsTheme(currentTheme)
   const isSystem7 = currentTheme === "system7"
 
   return (
@@ -442,13 +443,13 @@ const MenubarLabel = React.forwardRef<
       )}
       style={{
         fontFamily:
-          currentTheme === "xp" || currentTheme === "win98"
+          isWindowsTheme(currentTheme)
             ? '"Pixelated MS Sans Serif", "ArkPixel", Arial'
             : currentTheme === "macosx"
             ? '"LucidaGrande", "Lucida Grande", "AquaKana", "Hiragino Sans", "Hiragino Sans GB", "Heiti SC", "Lucida Sans Unicode", sans-serif'
             : undefined,
         fontSize:
-          currentTheme === "xp" || currentTheme === "win98"
+          isWindowsTheme(currentTheme)
             ? "11px"
             : undefined,
       }}

--- a/src/hooks/useThemeFlags.ts
+++ b/src/hooks/useThemeFlags.ts
@@ -2,6 +2,10 @@ import { useMemo } from "react";
 import { useThemeStore } from "@/stores/useThemeStore";
 import { getThemeMetadata } from "@/themes";
 
+/**
+ * Theme-derived flags for React components. Prefer this or `isWindowsTheme()` from `@/themes`
+ * instead of `currentTheme === "xp" || currentTheme === "win98"`.
+ */
 export function useThemeFlags() {
   const currentTheme = useThemeStore((state) => state.current);
   const metadata = useMemo(() => getThemeMetadata(currentTheme), [currentTheme]);
@@ -10,6 +14,7 @@ export function useThemeFlags() {
   const isMacTheme = metadata.isMac;
   const isMacOSTheme = currentTheme === "macosx";
   const isSystem7Theme = currentTheme === "system7";
+  /** True for XP and Windows 98 (same as `isWindowsTheme`). */
   const isXpTheme = isWindowsTheme;
   const isClassicTheme = isXpTheme || isSystem7Theme;
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Replaces inline `currentTheme === "xp" || currentTheme === "win98"` with `isWindowsTheme()` from `@/themes` (backed by theme metadata) across ~80 call sites: apps, `MenuBar`, dialogs, Radix menu primitives, widgets, etc.
- Resolves import/name shadowing in `App.tsx`, `menubar.tsx`, `BootScreen`, `PipPlayer` via `windowsTheme` locals or direct `isWindowsTheme(currentTheme)` calls.
- `EditorToolbar`: `currentTheme` prop typed as `OsThemeId`; removed unreachable ternary branch after narrowing.
- `useThemeFlags`: short JSDoc pointing to `isWindowsTheme` / avoiding raw string OR checks.
- `apps/base/types.ts` comment example updated to show `isWindowsTheme` import.

## Testing
- `bun run build`
- `bun run test:unit`

## Notes
- XP-only vs 98-only styling still uses `currentTheme === "xp"` / `"win98"` where themes diverge; only the combined “Windows” discriminator was unified.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a61a3ff1-6f98-42b0-a7c8-32fc15f14818"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a61a3ff1-6f98-42b0-a7c8-32fc15f14818"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

