### PR TITLE
Admin 1d analytics: hourly UTC charts

### DIFF
--- a/api/_utils/_analytics.ts
+++ b/api/_utils/_analytics.ts
@@ -6,7 +6,9 @@
  *
  * Redis key schema:
  *   analytics:daily:{YYYY-MM-DD}    hash  { calls, ai, errors, latsum, latcnt }
+ *   analytics:hourly:{YYYY-MM-DD}   hash  { HH_calls, HH_ai, ... } per UTC hour
  *   analytics:uv:{YYYY-MM-DD}       HyperLogLog  (unique visitor IPs)
+ *   analytics:uvh:{YYYY-MM-DD}:{HH} HyperLogLog  (unique visitors per UTC hour)
  *   analytics:ep:{YYYY-MM-DD}       hash  { endpoint: count }
  *   analytics:st:{YYYY-MM-DD}       hash  { statusCode: count }
  *   analytics:aiu:{YYYY-MM-DD}      hash  { username|"anon": count }
@@ -29,6 +31,20 @@ function todayUTC(): string {
 
 function k(suffix: string, date: string): string {
   return `analytics:${suffix}:${date}`;
+}
+
+/** Per-day hash: fields like 00_calls, 09_ai, 23_latcnt (UTC hours). */
+function hourlyHashKey(date: string): string {
+  return k("hourly", date);
+}
+
+/** HyperLogLog for unique visitors in one UTC hour. */
+function hourlyUvKey(date: string, hourPadded: string): string {
+  return `analytics:uvh:${date}:${hourPadded}`;
+}
+
+function utcHourPadded(): string {
+  return String(new Date().getUTCHours()).padStart(2, "0");
 }
 
 const AI_PATH_PREFIXES = [
@@ -82,8 +98,18 @@ export function recordAnalyticsEvent(
   if (isAI) pipe.hincrby(dailyKey, "ai", 1);
   if (isError) pipe.hincrby(dailyKey, "errors", 1);
 
+  const hourPadded = utcHourPadded();
+  const hourFieldPrefix = `${hourPadded}_`;
+  const hourlyKey = hourlyHashKey(date);
+  pipe.hincrby(hourlyKey, `${hourFieldPrefix}calls`, 1);
+  pipe.hincrby(hourlyKey, `${hourFieldPrefix}latsum`, Math.round(event.latencyMs));
+  pipe.hincrby(hourlyKey, `${hourFieldPrefix}latcnt`, 1);
+  if (isAI) pipe.hincrby(hourlyKey, `${hourFieldPrefix}ai`, 1);
+  if (isError) pipe.hincrby(hourlyKey, `${hourFieldPrefix}errors`, 1);
+
   const visitorId = event.username || `ip:${event.ip}`;
   pipe.pfadd(k("uv", date), visitorId);
+  pipe.pfadd(hourlyUvKey(date, hourPadded), visitorId);
   pipe.hincrby(k("ep", date), endpoint, 1);
   pipe.hincrby(k("st", date), String(event.status), 1);
 
@@ -96,10 +122,15 @@ export function recordAnalyticsEvent(
   if (_lastTTLDate !== date) {
     _lastTTLDate = date;
     pipe.expire(dailyKey, ANALYTICS_TTL_SECONDS);
+    pipe.expire(hourlyKey, ANALYTICS_TTL_SECONDS);
     pipe.expire(k("uv", date), ANALYTICS_TTL_SECONDS);
     pipe.expire(k("ep", date), ANALYTICS_TTL_SECONDS);
     pipe.expire(k("st", date), ANALYTICS_TTL_SECONDS);
     pipe.expire(k("aiu", date), ANALYTICS_TTL_SECONDS);
+    for (let h = 0; h < 24; h++) {
+      const hp = String(h).padStart(2, "0");
+      pipe.expire(hourlyUvKey(date, hp), ANALYTICS_TTL_SECONDS);
+    }
   }
 
   pipe.exec().catch((err) => {
@@ -146,8 +177,20 @@ export interface AIUserBreakdown {
   count: number;
 }
 
+export interface HourlyMetrics {
+  /** 0–23 (UTC), aligned with analytics buckets */
+  hour: number;
+  calls: number;
+  ai: number;
+  errors: number;
+  uniqueVisitors: number;
+  avgLatencyMs: number;
+}
+
 export interface AnalyticsDetail {
   summary: AnalyticsSummary;
+  /** Present when `days === 1`: 24 rows (UTC) for the single requested day */
+  hourly?: HourlyMetrics[];
   topEndpoints: EndpointBreakdown[];
   statusCodes: StatusBreakdown[];
   aiByUser: AIUserBreakdown[];
@@ -200,6 +243,31 @@ function mergeHashCounts(
   for (const [key, cnt] of Object.entries(raw)) {
     map.set(key, (map.get(key) || 0) + parseInt(String(cnt), 10));
   }
+}
+
+/** Builds 24 UTC hour rows from Redis hash + parallel PFCOUNT results. */
+export function buildHourlyMetrics(
+  raw: Record<string, string> | null,
+  uvByHour: number[]
+): HourlyMetrics[] {
+  const out: HourlyMetrics[] = [];
+  for (let h = 0; h < 24; h++) {
+    const p = String(h).padStart(2, "0");
+    const calls = parseInt(String(raw?.[`${p}_calls`] || "0"), 10);
+    const ai = parseInt(String(raw?.[`${p}_ai`] || "0"), 10);
+    const errors = parseInt(String(raw?.[`${p}_errors`] || "0"), 10);
+    const latsum = parseInt(String(raw?.[`${p}_latsum`] || "0"), 10);
+    const latcnt = parseInt(String(raw?.[`${p}_latcnt`] || "0"), 10);
+    out.push({
+      hour: h,
+      calls,
+      ai,
+      errors,
+      uniqueVisitors: uvByHour[h] ?? 0,
+      avgLatencyMs: latcnt > 0 ? Math.round(latsum / latcnt) : 0,
+    });
+  }
+  return out;
 }
 
 /**
@@ -395,5 +463,26 @@ export async function getAnalyticsDetail(
     });
   }
 
-  return { summary, topEndpoints, statusCodes, aiByUser, aiRateLimits };
+  let hourly: HourlyMetrics[] | undefined;
+  if (days === 1 && dates.length === 1) {
+    const day = dates[0];
+    const hpipe = redis.pipeline();
+    hpipe.hgetall(hourlyHashKey(day));
+    for (let h = 0; h < 24; h++) {
+      hpipe.pfcount(hourlyUvKey(day, String(h).padStart(2, "0")));
+    }
+    const hres = await hpipe.exec();
+    const hraw = (hres[0] as Record<string, string> | null) || null;
+    const uvByHour = hres.slice(1, 25).map((x) => Number(x) || 0);
+    hourly = buildHourlyMetrics(hraw, uvByHour);
+  }
+
+  return {
+    summary,
+    ...(hourly ? { hourly } : {}),
+    topEndpoints,
+    statusCodes,
+    aiByUser,
+    aiRateLimits,
+  };
 }

--- a/src/apps/admin/components/DashboardPanel.tsx
+++ b/src/apps/admin/components/DashboardPanel.tsx
@@ -50,8 +50,18 @@ interface AIRateLimitInfo {
   windowLabel: string;
 }
 
+interface HourlyMetrics {
+  hour: number;
+  calls: number;
+  ai: number;
+  errors: number;
+  uniqueVisitors: number;
+  avgLatencyMs: number;
+}
+
 interface AnalyticsDetail {
   summary: AnalyticsSummary;
+  hourly?: HourlyMetrics[];
   topEndpoints: EndpointBreakdown[];
   statusCodes: StatusBreakdown[];
   aiByUser: AIUserBreakdown[];
@@ -77,27 +87,68 @@ function formatDateLabel(dateStr: string): string {
   });
 }
 
+type MetricKey =
+  | "calls"
+  | "ai"
+  | "errors"
+  | "uniqueVisitors"
+  | "avgLatencyMs";
+
+interface BarChartRow {
+  key: string;
+  label: string;
+  calls: number;
+  ai: number;
+  errors: number;
+  uniqueVisitors: number;
+  avgLatencyMs: number;
+}
+
+function toBarRowsFromDays(days: DailyMetrics[]): BarChartRow[] {
+  return days.map((d) => ({
+    key: d.date,
+    label: formatDateLabel(d.date),
+    calls: d.calls,
+    ai: d.ai,
+    errors: d.errors,
+    uniqueVisitors: d.uniqueVisitors,
+    avgLatencyMs: d.avgLatencyMs,
+  }));
+}
+
+function toBarRowsFromHours(hourly: HourlyMetrics[]): BarChartRow[] {
+  return hourly.map((h) => ({
+    key: `h-${h.hour}`,
+    label: `${String(h.hour).padStart(2, "0")}:00 UTC`,
+    calls: h.calls,
+    ai: h.ai,
+    errors: h.errors,
+    uniqueVisitors: h.uniqueVisitors,
+    avgLatencyMs: h.avgLatencyMs,
+  }));
+}
+
 function MiniBarChart({
-  data,
+  rows,
   valueKey,
   color = "bg-neutral-400",
   height = 64,
 }: {
-  data: DailyMetrics[];
-  valueKey: keyof DailyMetrics;
+  rows: BarChartRow[];
+  valueKey: MetricKey;
   color?: string;
   height?: number;
 }) {
-  const values = data.map((d) => Number(d[valueKey]) || 0);
+  const values = rows.map((r) => Number(r[valueKey]) || 0);
   const max = Math.max(...values, 1);
 
   return (
-    <div className="flex items-end gap-[3px]" style={{ height }}>
+    <div className="flex items-end gap-px sm:gap-[2px]" style={{ height }}>
       {values.map((v, i) => {
         const barH = Math.max(1, (v / max) * height);
         return (
           <div
-            key={data[i].date}
+            key={rows[i].key}
             className="flex flex-col items-center flex-1 min-w-0 group relative"
             style={{ height }}
           >
@@ -107,7 +158,7 @@ function MiniBarChart({
               style={{ height: barH }}
             />
             <div className="absolute -top-5 left-1/2 -translate-x-1/2 hidden group-hover:block bg-black/80 text-white text-[9px] px-1.5 py-0.5 rounded whitespace-nowrap z-10 pointer-events-none">
-              {formatDateLabel(data[i].date)}: {formatNumber(v)}
+              {rows[i].label}: {formatNumber(v)}
             </div>
           </div>
         );
@@ -216,8 +267,18 @@ export function DashboardPanel({ onRefresh }: DashboardPanelProps) {
 
   if (!data) return null;
 
-  const { summary, topEndpoints, statusCodes, aiByUser, aiRateLimits } = data;
+  const { summary, hourly, topEndpoints, statusCodes, aiByUser, aiRateLimits } =
+    data;
   const { totals, days } = summary;
+
+  const chartRows: BarChartRow[] =
+    isToday && hourly && hourly.length > 0
+      ? toBarRowsFromHours(hourly)
+      : toBarRowsFromDays(days);
+  const chartAxisStart =
+    chartRows.length > 0 ? chartRows[0].label : "";
+  const chartAxisEnd =
+    chartRows.length > 0 ? chartRows[chartRows.length - 1].label : "";
 
   const latestDay = days.length > 0 ? days[days.length - 1] : null;
   const prevDay = days.length > 1 ? days[days.length - 2] : null;
@@ -331,68 +392,64 @@ export function DashboardPanel({ onRefresh }: DashboardPanelProps) {
           <div className="border border-gray-200 rounded p-3 bg-white">
             <div className="text-[10px] uppercase tracking-wide text-neutral-400 mb-2">
               {t("apps.admin.dashboard.charts.apiCalls")}
+              {isToday && hourly?.length ? (
+                <span className="normal-case font-normal text-neutral-300 ml-1">
+                  ({t("apps.admin.dashboard.charts.hourlyUtc")})
+                </span>
+              ) : null}
             </div>
-            <MiniBarChart data={days} valueKey="calls" color="bg-neutral-400" height={56} />
+            <MiniBarChart rows={chartRows} valueKey="calls" color="bg-neutral-400" height={56} />
             <div className="flex justify-between mt-1.5 text-[9px] text-neutral-400">
-              <span>
-                {days.length > 0 ? formatDateLabel(days[0].date) : ""}
-              </span>
-              <span>
-                {days.length > 0
-                  ? formatDateLabel(days[days.length - 1].date)
-                  : ""}
-              </span>
+              <span>{chartAxisStart}</span>
+              <span>{chartAxisEnd}</span>
             </div>
           </div>
 
           <div className="border border-gray-200 rounded p-3 bg-white">
             <div className="text-[10px] uppercase tracking-wide text-neutral-400 mb-2">
               {t("apps.admin.dashboard.charts.uniqueVisitors")}
+              {isToday && hourly?.length ? (
+                <span className="normal-case font-normal text-neutral-300 ml-1">
+                  ({t("apps.admin.dashboard.charts.hourlyUtc")})
+                </span>
+              ) : null}
             </div>
-            <MiniBarChart data={days} valueKey="uniqueVisitors" color="bg-green-400" height={56} />
+            <MiniBarChart rows={chartRows} valueKey="uniqueVisitors" color="bg-green-400" height={56} />
             <div className="flex justify-between mt-1.5 text-[9px] text-neutral-400">
-              <span>
-                {days.length > 0 ? formatDateLabel(days[0].date) : ""}
-              </span>
-              <span>
-                {days.length > 0
-                  ? formatDateLabel(days[days.length - 1].date)
-                  : ""}
-              </span>
+              <span>{chartAxisStart}</span>
+              <span>{chartAxisEnd}</span>
             </div>
           </div>
 
           <div className="border border-gray-200 rounded p-3 bg-white">
             <div className="text-[10px] uppercase tracking-wide text-neutral-400 mb-2">
               {t("apps.admin.dashboard.charts.aiRequests")}
+              {isToday && hourly?.length ? (
+                <span className="normal-case font-normal text-neutral-300 ml-1">
+                  ({t("apps.admin.dashboard.charts.hourlyUtc")})
+                </span>
+              ) : null}
             </div>
-            <MiniBarChart data={days} valueKey="ai" color="bg-yellow-400" height={56} />
+            <MiniBarChart rows={chartRows} valueKey="ai" color="bg-yellow-400" height={56} />
             <div className="flex justify-between mt-1.5 text-[9px] text-neutral-400">
-              <span>
-                {days.length > 0 ? formatDateLabel(days[0].date) : ""}
-              </span>
-              <span>
-                {days.length > 0
-                  ? formatDateLabel(days[days.length - 1].date)
-                  : ""}
-              </span>
+              <span>{chartAxisStart}</span>
+              <span>{chartAxisEnd}</span>
             </div>
           </div>
 
           <div className="border border-gray-200 rounded p-3 bg-white">
             <div className="text-[10px] uppercase tracking-wide text-neutral-400 mb-2">
               {t("apps.admin.dashboard.charts.errors")}
+              {isToday && hourly?.length ? (
+                <span className="normal-case font-normal text-neutral-300 ml-1">
+                  ({t("apps.admin.dashboard.charts.hourlyUtc")})
+                </span>
+              ) : null}
             </div>
-            <MiniBarChart data={days} valueKey="errors" color="bg-red-400" height={56} />
+            <MiniBarChart rows={chartRows} valueKey="errors" color="bg-red-400" height={56} />
             <div className="flex justify-between mt-1.5 text-[9px] text-neutral-400">
-              <span>
-                {days.length > 0 ? formatDateLabel(days[0].date) : ""}
-              </span>
-              <span>
-                {days.length > 0
-                  ? formatDateLabel(days[days.length - 1].date)
-                  : ""}
-              </span>
+              <span>{chartAxisStart}</span>
+              <span>{chartAxisEnd}</span>
             </div>
           </div>
         </div>
@@ -533,17 +590,16 @@ export function DashboardPanel({ onRefresh }: DashboardPanelProps) {
           <div className="border border-gray-200 rounded p-3 bg-white">
             <div className="text-[10px] uppercase tracking-wide text-neutral-400 mb-2">
               {t("apps.admin.dashboard.charts.avgResponseTime")}
+              {isToday && hourly?.length ? (
+                <span className="normal-case font-normal text-neutral-300 ml-1">
+                  ({t("apps.admin.dashboard.charts.hourlyUtc")})
+                </span>
+              ) : null}
             </div>
-            <MiniBarChart data={days} valueKey="avgLatencyMs" color="bg-neutral-300" height={48} />
+            <MiniBarChart rows={chartRows} valueKey="avgLatencyMs" color="bg-neutral-300" height={48} />
             <div className="flex justify-between mt-1.5 text-[9px] text-neutral-400">
-              <span>
-                {days.length > 0 ? formatDateLabel(days[0].date) : ""}
-              </span>
-              <span>
-                {days.length > 0
-                  ? formatDateLabel(days[days.length - 1].date)
-                  : ""}
-              </span>
+              <span>{chartAxisStart}</span>
+              <span>{chartAxisEnd}</span>
             </div>
           </div>
         </div>

--- a/src/lib/locales/de/translation.json
+++ b/src/lib/locales/de/translation.json
@@ -12,7 +12,8 @@
           "apiCalls": "API-Aufrufe",
           "avgResponseTime": "Durchschn. Antwortzeit (ms)",
           "errors": "Fehler",
-          "uniqueVisitors": "Eindeutige Besucher"
+          "uniqueVisitors": "Eindeutige Besucher",
+          "hourlyUtc": "stündlich UTC"
         },
         "empty": {
           "noAiUsage": "Noch keine KI-Nutzung",

--- a/src/lib/locales/en/translation.json
+++ b/src/lib/locales/en/translation.json
@@ -3109,7 +3109,8 @@
           "uniqueVisitors": "Unique Visitors",
           "aiRequests": "AI Requests",
           "errors": "Errors",
-          "avgResponseTime": "Avg Response Time (ms)"
+          "avgResponseTime": "Avg Response Time (ms)",
+          "hourlyUtc": "UTC hourly"
         },
         "sections": {
           "topEndpoints": "Top Endpoints",

--- a/src/lib/locales/es/translation.json
+++ b/src/lib/locales/es/translation.json
@@ -12,7 +12,8 @@
           "apiCalls": "Llamadas a la API",
           "avgResponseTime": "Tiempo de respuesta promedio (ms)",
           "errors": "Errores",
-          "uniqueVisitors": "Visitantes únicos"
+          "uniqueVisitors": "Visitantes únicos",
+          "hourlyUtc": "por hora UTC"
         },
         "empty": {
           "noAiUsage": "Aún no hay uso de IA",

--- a/src/lib/locales/fr/translation.json
+++ b/src/lib/locales/fr/translation.json
@@ -12,7 +12,8 @@
           "apiCalls": "Appels API",
           "avgResponseTime": "Temps de réponse moy. (ms)",
           "errors": "Erreurs",
-          "uniqueVisitors": "Visiteurs uniques"
+          "uniqueVisitors": "Visiteurs uniques",
+          "hourlyUtc": "par heure UTC"
         },
         "empty": {
           "noAiUsage": "Aucune utilisation de l'IA pour le moment",

--- a/src/lib/locales/it/translation.json
+++ b/src/lib/locales/it/translation.json
@@ -12,7 +12,8 @@
           "apiCalls": "Chiamate API",
           "avgResponseTime": "Tempo di risposta medio (ms)",
           "errors": "Errori",
-          "uniqueVisitors": "Visitatori unici"
+          "uniqueVisitors": "Visitatori unici",
+          "hourlyUtc": "orario UTC"
         },
         "empty": {
           "noAiUsage": "Ancora nessun utilizzo AI",

--- a/src/lib/locales/ja/translation.json
+++ b/src/lib/locales/ja/translation.json
@@ -12,7 +12,8 @@
           "apiCalls": "APIコール",
           "avgResponseTime": "平均レスポンス時間 (ms)",
           "errors": "エラー",
-          "uniqueVisitors": "ユニークビジター"
+          "uniqueVisitors": "ユニークビジター",
+          "hourlyUtc": "UTC 時間別"
         },
         "empty": {
           "noAiUsage": "AIの使用はまだありません",

--- a/src/lib/locales/ko/translation.json
+++ b/src/lib/locales/ko/translation.json
@@ -12,7 +12,8 @@
           "apiCalls": "API 호출",
           "avgResponseTime": "평균 응답 시간 (ms)",
           "errors": "오류",
-          "uniqueVisitors": "순 방문자 수"
+          "uniqueVisitors": "순 방문자 수",
+          "hourlyUtc": "UTC 시간대별"
         },
         "empty": {
           "noAiUsage": "아직 AI 사용 내역이 없습니다",

--- a/src/lib/locales/pt/translation.json
+++ b/src/lib/locales/pt/translation.json
@@ -12,7 +12,8 @@
           "apiCalls": "Chamadas de API",
           "avgResponseTime": "Tempo Médio de Resposta (ms)",
           "errors": "Erros",
-          "uniqueVisitors": "Visitantes Únicos"
+          "uniqueVisitors": "Visitantes Únicos",
+          "hourlyUtc": "por hora UTC"
         },
         "empty": {
           "noAiUsage": "Nenhum uso de IA ainda",

--- a/src/lib/locales/ru/translation.json
+++ b/src/lib/locales/ru/translation.json
@@ -12,7 +12,8 @@
           "apiCalls": "Вызовы API",
           "avgResponseTime": "Ср. время отклика (мс)",
           "errors": "Ошибки",
-          "uniqueVisitors": "Уникальные посетители"
+          "uniqueVisitors": "Уникальные посетители",
+          "hourlyUtc": "по часам UTC"
         },
         "empty": {
           "noAiUsage": "Использование ИИ пока отсутствует",

--- a/src/lib/locales/zh-TW/translation.json
+++ b/src/lib/locales/zh-TW/translation.json
@@ -12,7 +12,8 @@
           "apiCalls": "API 呼叫",
           "avgResponseTime": "平均回應時間 (ms)",
           "errors": "錯誤",
-          "uniqueVisitors": "不重複訪客"
+          "uniqueVisitors": "不重複訪客",
+          "hourlyUtc": "UTC 每小時"
         },
         "empty": {
           "noAiUsage": "尚無 AI 使用紀錄",

--- a/tests/test-analytics-hourly.test.ts
+++ b/tests/test-analytics-hourly.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "bun:test";
+import { buildHourlyMetrics } from "../api/_utils/_analytics.js";
+
+describe("buildHourlyMetrics", () => {
+  test("fills 24 hours with zeros when raw is null", () => {
+    const rows = buildHourlyMetrics(null, []);
+    expect(rows).toHaveLength(24);
+    expect(rows[0]).toEqual({
+      hour: 0,
+      calls: 0,
+      ai: 0,
+      errors: 0,
+      uniqueVisitors: 0,
+      avgLatencyMs: 0,
+    });
+    expect(rows[23].hour).toBe(23);
+  });
+
+  test("parses padded hour fields and UV counts", () => {
+    const raw = {
+      "09_calls": "10",
+      "09_ai": "2",
+      "09_errors": "1",
+      "09_latsum": "100",
+      "09_latcnt": "10",
+    };
+    const uv = Array.from({ length: 24 }, () => 0);
+    uv[9] = 5;
+    const rows = buildHourlyMetrics(raw, uv);
+    expect(rows[9]).toEqual({
+      hour: 9,
+      calls: 10,
+      ai: 2,
+      errors: 1,
+      uniqueVisitors: 5,
+      avgLatencyMs: 10,
+    });
+    expect(rows[8].calls).toBe(0);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- **API**: Record analytics per UTC hour (`analytics:hourly:{date}` hash + `analytics:uvh:{date}:{HH}` HLLs). `getAnalyticsDetail` with `days=1` returns `hourly` with 24 rows.
- **Admin dashboard**: When "Today" is selected and `hourly` is present, bar charts use 24 hourly buckets instead of a single daily bar.
- **i18n**: `apps.admin.dashboard.charts.hourlyUtc` in all locales.

## Testing
- `bun test tests/test-analytics-hourly.test.ts`
- `bun run build`

## Notes
- Hourly data populates from deploy forward; historical days have no backfill.
- Buckets are **UTC** (matches existing daily keys).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a9ef17ae-a433-4d35-8d9d-89700cb8e114"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a9ef17ae-a433-4d35-8d9d-89700cb8e114"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

