### PR TITLE
fix(ipod): order synced library by catalog metadata (newest first)

### DIFF
--- a/src/apps/ipod/hooks/useLibraryUpdateChecker.ts
+++ b/src/apps/ipod/hooks/useLibraryUpdateChecker.ts
@@ -53,6 +53,8 @@ export function useLibraryUpdateChecker(isActive: boolean) {
           cover: song.cover,
           lyricOffset: song.lyricOffset,
           lyricsSource: song.lyricsSource,
+          createdAt: song.createdAt,
+          importOrder: song.importOrder,
         }));
         const serverVersion = Math.max(...cachedSongs.map((s) => s.createdAt || 1));
 
@@ -84,6 +86,8 @@ export function useLibraryUpdateChecker(isActive: boolean) {
               currentTrack.cover !== serverTrack.cover ||
               currentTrack.url !== serverTrack.url ||
               currentTrack.lyricOffset !== serverTrack.lyricOffset ||
+              currentTrack.createdAt !== serverTrack.createdAt ||
+              currentTrack.importOrder !== serverTrack.importOrder ||
               shouldUpdateLyricsSource;
             if (hasChanges) tracksUpdated++;
           }

--- a/src/stores/useIpodStore.ts
+++ b/src/stores/useIpodStore.ts
@@ -18,6 +18,7 @@ import i18n from "@/lib/i18n";
 import { useChatsStore } from "./useChatsStore";
 import { abortableFetch } from "@/utils/abortableFetch";
 import { emitCloudSyncDomainChange } from "@/utils/cloudSyncEvents";
+import { sortTracksByCatalogOrder } from "@/utils/ipodTrackOrdering";
 
 /** Special value for lyricsTranslationLanguage that means "use ryOS locale" */
 export const LYRICS_TRANSLATION_AUTO = "auto";
@@ -44,6 +45,10 @@ export interface Track {
   lyricOffset?: number;
   /** Selected lyrics source from Kugou (user override) */
   lyricsSource?: LyricsSource;
+  /** Redis/catalog creation time (ms); used for library ordering (newer first) */
+  createdAt?: number;
+  /** Stable tie-break for bulk imports (lower = earlier in list when createdAt matches) */
+  importOrder?: number;
 }
 
 type LibraryState = "uninitialized" | "loaded" | "cleared";
@@ -145,6 +150,8 @@ async function loadDefaultTracks(forceRefresh = false): Promise<{
         cover: song.cover,
         lyricOffset: song.lyricOffset,
         lyricsSource: song.lyricsSource,
+        createdAt: song.createdAt,
+        importOrder: song.importOrder,
       }));
       // Use the latest createdAt timestamp as version (or 1 if empty)
       const version = cachedSongs.length > 0 
@@ -633,7 +640,10 @@ export const useIpodStore = create<IpodState>()(
       setTheme: (theme) => set({ theme }),
       addTrack: (track) =>
         set((state) => ({
-          tracks: [track, ...state.tracks],
+          tracks: [
+            { ...track, createdAt: track.createdAt ?? Date.now() },
+            ...state.tracks,
+          ],
           currentSongId: track.id,
           currentLyrics: null,
           currentFuriganaMap: null,
@@ -658,7 +668,7 @@ export const useIpodStore = create<IpodState>()(
       resetLibrary: async () => {
         const { tracks, version } = await loadDefaultTracks();
         set({
-          tracks,
+          tracks: sortTracksByCatalogOrder(tracks),
           currentSongId: tracks[0]?.id ?? null,
           currentLyrics: null,
           currentFuriganaMap: null,
@@ -944,7 +954,7 @@ export const useIpodStore = create<IpodState>()(
         if (current.libraryState === "uninitialized") {
           const { tracks, version } = await loadDefaultTracks();
           set({
-            tracks,
+            tracks: sortTracksByCatalogOrder(tracks),
             currentSongId: tracks[0]?.id ?? null,
             currentLyrics: null,
             currentFuriganaMap: null,
@@ -1047,6 +1057,8 @@ export const useIpodStore = create<IpodState>()(
               cover: cachedMetadata.cover,
               lyricOffset: cachedMetadata.lyricOffset ?? 500,
               lyricsSource: cachedMetadata.lyricsSource,
+              createdAt: cachedMetadata.createdAt ?? Date.now(),
+              importOrder: cachedMetadata.importOrder,
             };
 
             try {
@@ -1194,6 +1206,7 @@ export const useIpodStore = create<IpodState>()(
           cover: trackInfo.cover,
           lyricOffset: 500, // Default 500ms offset for new tracks
           lyricsSource: trackInfo.lyricsSource,
+          createdAt: Date.now(),
         };
 
         try {
@@ -1236,7 +1249,9 @@ export const useIpodStore = create<IpodState>()(
                 currentTrack.album !== serverTrack.album ||
                 currentTrack.cover !== serverTrack.cover ||
                 currentTrack.url !== serverTrack.url ||
-                currentTrack.lyricOffset !== serverTrack.lyricOffset;
+                currentTrack.lyricOffset !== serverTrack.lyricOffset ||
+                currentTrack.createdAt !== serverTrack.createdAt ||
+                currentTrack.importOrder !== serverTrack.importOrder;
 
               // Check if we should update lyricsSource:
               // - Server has lyricsSource but user doesn't have one yet
@@ -1258,6 +1273,8 @@ export const useIpodStore = create<IpodState>()(
                   cover: serverTrack.cover,
                   url: serverTrack.url,
                   lyricOffset: serverTrack.lyricOffset,
+                  createdAt: serverTrack.createdAt ?? currentTrack.createdAt,
+                  importOrder: serverTrack.importOrder ?? currentTrack.importOrder,
                   // Update lyricsSource from server if it's new or different
                   ...(shouldUpdateLyricsSource && {
                     lyricsSource: serverTrack.lyricsSource,
@@ -1276,8 +1293,11 @@ export const useIpodStore = create<IpodState>()(
           );
           newTracksAdded = tracksToAdd.length;
 
-          // Combine new tracks (at top) with updated existing tracks
-          let finalTracks = [...tracksToAdd, ...updatedTracks];
+          // Merge new server tracks with existing rows, then order by catalog metadata (newest first)
+          let finalTracks = sortTracksByCatalogOrder([
+            ...tracksToAdd,
+            ...updatedTracks,
+          ]);
 
           // Fetch metadata for tracks not in the default library
           // These are user-added tracks that might have updated metadata in Redis
@@ -1313,6 +1333,8 @@ export const useIpodStore = create<IpodState>()(
                   cover?: string;
                   lyricOffset?: number;
                   lyricsSource?: LyricsSource;
+                  createdAt?: number;
+                  importOrder?: number;
                 };
                 const fetchedMap = new Map<string, FetchedSongMetadata>(
                   fetchedSongs.map((s: FetchedSongMetadata) => [s.id, s])
@@ -1336,6 +1358,10 @@ export const useIpodStore = create<IpodState>()(
                       (fetched.album && fetched.album !== track.album) ||
                       (fetched.cover && fetched.cover !== track.cover) ||
                       (fetched.lyricOffset !== undefined && fetched.lyricOffset !== track.lyricOffset) ||
+                      (fetched.createdAt !== undefined &&
+                        fetched.createdAt !== track.createdAt) ||
+                      (fetched.importOrder !== undefined &&
+                        fetched.importOrder !== track.importOrder) ||
                       shouldUpdateLyricsSource;
 
                     if (hasChanges) {
@@ -1348,6 +1374,8 @@ export const useIpodStore = create<IpodState>()(
                         album: fetched.album ?? track.album,
                         cover: fetched.cover ?? track.cover,
                         lyricOffset: fetched.lyricOffset ?? track.lyricOffset,
+                        createdAt: fetched.createdAt ?? track.createdAt,
+                        importOrder: fetched.importOrder ?? track.importOrder,
                         // Update lyricsSource from server if it's new or different
                         ...(shouldUpdateLyricsSource && {
                           lyricsSource: fetched.lyricsSource,
@@ -1362,6 +1390,8 @@ export const useIpodStore = create<IpodState>()(
               console.warn(`[iPod Store] Failed to fetch metadata for user tracks:`, error);
             }
           }
+
+          finalTracks = sortTracksByCatalogOrder(finalTracks);
 
           // Update store if there were any changes
           if (newTracksAdded > 0 || tracksUpdated > 0) {

--- a/src/sync/domains.ts
+++ b/src/sync/domains.ts
@@ -8,6 +8,7 @@ import { useAudioSettingsStore } from "@/stores/useAudioSettingsStore";
 import { useAppStore } from "@/stores/useAppStore";
 import { useFilesStore, type FileSystemItem } from "@/stores/useFilesStore";
 import { useIpodStore, type Track } from "@/stores/useIpodStore";
+import { sortTracksByCatalogOrder } from "@/utils/ipodTrackOrdering";
 import { useVideoStore, type Video } from "@/stores/useVideoStore";
 import { useDockStore } from "@/stores/useDockStore";
 import { useDashboardStore } from "@/stores/useDashboardStore";
@@ -1481,11 +1482,25 @@ function mergeSongsSnapshots(
     normalizeDeletionMarkerMap(local.deletedTrackIds),
     normalizeDeletionMarkerMap(remote.deletedTrackIds)
   );
+  const localFiltered = filterDeletedIds(
+    local.tracks,
+    mergedDeleted,
+    (t) => t.id
+  );
+  const remoteFiltered = filterDeletedIds(
+    remote.tracks,
+    mergedDeleted,
+    (t) => t.id
+  );
+  const byId = new Map<string, Track>();
+  for (const item of remoteFiltered) {
+    byId.set(item.id, item);
+  }
+  for (const item of localFiltered) {
+    byId.set(item.id, item);
+  }
   return {
-    tracks: mergeItemsById(
-      filterDeletedIds(local.tracks, mergedDeleted, (t) => t.id),
-      filterDeletedIds(remote.tracks, mergedDeleted, (t) => t.id)
-    ),
+    tracks: sortTracksByCatalogOrder(Array.from(byId.values())),
     libraryState: local.libraryState === "loaded" || remote.libraryState === "loaded"
       ? "loaded"
       : local.libraryState,

--- a/src/utils/ipodTrackOrdering.ts
+++ b/src/utils/ipodTrackOrdering.ts
@@ -1,0 +1,34 @@
+/**
+ * Shared iPod/Karaoke library ordering: matches Redis song list sort
+ * (newest createdAt first, then importOrder).
+ */
+
+export interface TrackCatalogSortKey {
+  id: string;
+  createdAt?: number;
+  importOrder?: number;
+}
+
+export function sortTracksByCatalogOrder<T extends TrackCatalogSortKey>(
+  tracks: T[]
+): T[] {
+  return [...tracks].sort((a, b) => {
+    const ac = a.createdAt;
+    const bc = b.createdAt;
+    if (ac != null && bc != null && ac !== bc) {
+      return bc - ac;
+    }
+    if (ac != null && bc == null) {
+      return -1;
+    }
+    if (ac == null && bc != null) {
+      return 1;
+    }
+    const ai = a.importOrder ?? Number.POSITIVE_INFINITY;
+    const bi = b.importOrder ?? Number.POSITIVE_INFINITY;
+    if (ai !== bi) {
+      return ai - bi;
+    }
+    return a.id.localeCompare(b.id);
+  });
+}

--- a/tests/test-ipod-catalog-order.test.ts
+++ b/tests/test-ipod-catalog-order.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from "bun:test";
+import {
+  sortTracksByCatalogOrder,
+  type TrackCatalogSortKey,
+} from "@/utils/ipodTrackOrdering";
+
+function t(
+  id: string,
+  overrides: Partial<TrackCatalogSortKey> = {}
+): TrackCatalogSortKey {
+  return { id, ...overrides };
+}
+
+describe("sortTracksByCatalogOrder", () => {
+  test("orders by createdAt descending (newest first)", () => {
+    const sorted = sortTracksByCatalogOrder([
+      t("aaa", { createdAt: 100 }),
+      t("bbb", { createdAt: 300 }),
+      t("ccc", { createdAt: 200 }),
+    ]);
+    expect(sorted.map((x) => x.id)).toEqual(["bbb", "ccc", "aaa"]);
+  });
+
+  test("places tracks without createdAt after dated tracks", () => {
+    const sorted = sortTracksByCatalogOrder([
+      t("legacy"),
+      t("new", { createdAt: 50 }),
+    ]);
+    expect(sorted.map((x) => x.id)).toEqual(["new", "legacy"]);
+  });
+
+  test("uses importOrder when createdAt ties", () => {
+    const sorted = sortTracksByCatalogOrder([
+      t("b", { createdAt: 1, importOrder: 2 }),
+      t("a", { createdAt: 1, importOrder: 1 }),
+    ]);
+    expect(sorted.map((x) => x.id)).toEqual(["a", "b"]);
+  });
+
+  test("breaks ties by id", () => {
+    const sorted = sortTracksByCatalogOrder([
+      t("z", { createdAt: 5 }),
+      t("m", { createdAt: 5 }),
+    ]);
+    expect(sorted.map((x) => x.id)).toEqual(["m", "z"]);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- iPod/Karaoke `Track` now carries optional `createdAt` / `importOrder` from Redis (same fields the song API uses for list sorting).
- `syncLibrary` merges the full list and sorts with `sortTracksByCatalogOrder` so new curator songs match server order (newest first), not “stuck at bottom” after merge quirks.
- Cloud sync `songs` domain merge no longer relies on `Map` insertion order from `mergeItemsById` (which put local-only tracks at the end); merged tracks are sorted the same way.
- Manual adds get `createdAt: Date.now()` when missing so they stay at the top among dated entries after sync.

## Testing
- `bun run build`
- `bun test tests/test-ipod-catalog-order.test.ts`
- `bun test tests/test-cloud-sync-utils.test.ts`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cb0a08a1-5b9e-4471-8fc8-3dcab5d15a80"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cb0a08a1-5b9e-4471-8fc8-3dcab5d15a80"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

