### PR TITLE
IE: diagnose ryo.lu proxy blocks (Cloudflare) + store docs

### DIFF
--- a/api/iframe-check.ts
+++ b/api/iframe-check.ts
@@ -684,14 +684,28 @@ export default apiHandler(
         res.setHeader("Content-Type", "application/json");
         res.setHeader("Access-Control-Allow-Origin", "*");
         logger.response(upstreamRes.status, Date.now() - startTime);
+
+        const cfMitigated = upstreamRes.headers.get("cf-mitigated");
+        const serverHdr = upstreamRes.headers.get("server")?.toLowerCase() ?? "";
+        const isCloudflareChallenge =
+          upstreamRes.status === 403 &&
+          (cfMitigated !== null || serverHdr.includes("cloudflare"));
+
+        const defaultMessage = `The page cannot be found. HTTP ${upstreamRes.status} - ${
+          upstreamRes.statusText || "File not found"
+        }`;
+
         return res.status(upstreamRes.status).json({
           error: true,
           status: upstreamRes.status,
           statusText: upstreamRes.statusText || "File not found",
-          type: "http_error",
-          message: `The page cannot be found. HTTP ${upstreamRes.status} - ${
-            upstreamRes.statusText || "File not found"
-          }`,
+          type: isCloudflareChallenge ? "cloudflare_challenge" : "http_error",
+          message: isCloudflareChallenge
+            ? "This site blocked the ryOS preview proxy (often Cloudflare bot / challenge mode)."
+            : defaultMessage,
+          details: isCloudflareChallenge
+            ? "The Internet Explorer app fetches pages on the server to strip frame-blocking headers. Automated requests cannot complete browser challenges. Fix: allowlist ryOS deployment IPs or trusted headers on the target zone, or open the URL in an external browser."
+            : undefined,
         });
       }
 

--- a/src/stores/useInternetExplorerStore.ts
+++ b/src/stores/useInternetExplorerStore.ts
@@ -12,7 +12,11 @@ export interface Favorite {
   isDirectory?: boolean; // New: Flag to indicate if it's a folder
 }
 
-// Define a constant for domains that bypass the proxy when in "now" mode
+// Domains that load directly in the iframe (must allow embedding from os.ryo.lu).
+// Do not add bare `ryo.lu`: it sends X-Frame-Options: SAMEORIGIN, so only pages on
+// exactly https://ryo.lu could embed it — not https://os.ryo.lu. Those sites must use
+// /api/iframe-check (server-side fetch). If that fetch gets HTTP 403 from Cloudflare
+// (cf-mitigated: challenge), the site owner must relax bot rules or allowlist ryOS.
 export const DIRECT_PASSTHROUGH_DOMAINS = [
   "baby-cursor.ryo.lu",
   "os.ryo.lu",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- **`api/iframe-check`**: When upstream returns HTTP 403 and Cloudflare signals (`cf-mitigated` or `server: cloudflare`), respond with `type: cloudflare_challenge` and clearer `message` / `details` so DevTools and the IE error UI explain server-side fetch limits.
- **`useInternetExplorerStore`**: Document why bare `ryo.lu` is not in `DIRECT_PASSTHROUGH_DOMAINS` (X-Frame-Options) and that proxy fetch can still fail on CF.

## Root cause (manual investigation)
- `https://ryo.lu` is loaded in “current” mode via `/api/iframe-check` (not direct iframe) because it cannot be embedded cross-origin from `os.ryo.lu` when the site sends `X-Frame-Options: SAMEORIGIN`.
- Server-side `curl -sSIL https://ryo.lu` from CI-like environments returns **403** with **`cf-mitigated: challenge`**, so the proxy cannot retrieve HTML for embedding.

## Testing
- `bun run build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b2a77d60-405a-41ff-8259-95b2ee0cbf26"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b2a77d60-405a-41ff-8259-95b2ee0cbf26"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

