### PR TITLE
Process English lines in Chinese soramimi

### DIFF
--- a/api/songs/[id].ts
+++ b/api/songs/[id].ts
@@ -86,6 +86,8 @@ import {
   parseSoramimiRubyMarkup,
   fillMissingReadings,
   cleanSoramimiReading,
+  selectSoramimiLinesToProcess,
+  shouldProcessEnglishForSoramimi,
 } from "./_soramimi.js";
 
 import { streamText } from "ai";
@@ -1333,17 +1335,10 @@ export default apiHandler<Record<string, unknown>>(
           wordTimings: line.wordTimings,
         }));
 
-        // Build the text prompt for soramimi
-        const nonEnglishLines: { line: LyricLine; originalIndex: number }[] = [];
-        for (let i = 0; i < lines.length; i++) {
-          const line = lines[i];
-          const text = line.words.trim();
-          if (!text) continue;
-          const isEnglish = /^[a-zA-Z0-9\s.,!?'"()\-:;]+$/.test(text);
-          if (!isEnglish) {
-            nonEnglishLines.push({ line, originalIndex: i });
-          }
-        }
+        // Chinese soramimi should also reinterpret ASCII English lines instead of
+        // passing them through unchanged. English-output soramimi keeps passthrough.
+        const shouldProcessEnglishLines = shouldProcessEnglishForSoramimi(targetLanguage);
+        const linesToProcess = selectSoramimiLinesToProcess(lines, targetLanguage);
         
         // Build prompt text - if furigana is available, use annotated text format
         let textsToProcess: string;
@@ -1354,7 +1349,7 @@ export default apiHandler<Record<string, unknown>>(
         
         if (hasFuriganaData) {
           const annotatedLines = convertLinesToAnnotatedText(lines, clientFurigana);
-          textsToProcess = nonEnglishLines.map((info, idx) => {
+          textsToProcess = linesToProcess.map((info, idx) => {
             return `${idx + 1}: ${annotatedLines[info.originalIndex]}`;
           }).join("\n");
           systemPrompt = isEnglishOutput 
@@ -1362,7 +1357,7 @@ export default apiHandler<Record<string, unknown>>(
             : SORAMIMI_JAPANESE_WITH_FURIGANA_PROMPT;
           logger.info(`Using ${isEnglishOutput ? 'English' : 'Chinese'} prompt with furigana annotations`);
         } else {
-          textsToProcess = nonEnglishLines.map((info, idx) => {
+          textsToProcess = linesToProcess.map((info, idx) => {
             const wordTimings = info.line.wordTimings;
             if (wordTimings && wordTimings.length > 0) {
               const wordsMarked = wordTimings.map(w => w.text).join('|');
@@ -1398,21 +1393,20 @@ export default apiHandler<Record<string, unknown>>(
           // Send start event immediately
           sendEvent("start", { totalLines, message: "AI processing started" });
 
-          // Emit soramimi for English lines immediately (they stay as-is)
+          // For English-output soramimi, ASCII English lines passthrough unchanged.
           for (let i = 0; i < lines.length; i++) {
             const text = lines[i].words.trim();
             if (!text) {
               allSoramimi[i] = [{ text: "" }];
               continue;
             }
-            const isEnglish = /^[a-zA-Z0-9\s.,!?'"()\-:;]+$/.test(text);
-            if (isEnglish) {
+            if (!shouldProcessEnglishLines && !linesToProcess.some((info) => info.originalIndex === i)) {
               allSoramimi[i] = [{ text }];
               completedLines++;
-              sendEvent("line", { 
-                lineIndex: i, 
-                soramimi: [{ text }], 
-                progress: Math.round((completedLines / totalLines) * 100) 
+              sendEvent("line", {
+                lineIndex: i,
+                soramimi: [{ text }],
+                progress: Math.round((completedLines / totalLines) * 100)
               });
             }
           }
@@ -1424,11 +1418,11 @@ export default apiHandler<Record<string, unknown>>(
             
             const match = trimmedLine.match(/^(\d+)[:.\s]\s*(.*)$/);
             if (match) {
-              const nonEnglishLineIndex = parseInt(match[1], 10) - 1;
+              const processedLineIndex = parseInt(match[1], 10) - 1;
               const content = match[2].trim();
               
-              if (nonEnglishLineIndex >= 0 && nonEnglishLineIndex < nonEnglishLines.length && content) {
-                const info = nonEnglishLines[nonEnglishLineIndex];
+              if (processedLineIndex >= 0 && processedLineIndex < linesToProcess.length && content) {
+                const info = linesToProcess[processedLineIndex];
                 const originalIndex = info.originalIndex;
                 
                 const rawSegments = parseSoramimiRubyMarkup(content);

--- a/api/songs/_soramimi.ts
+++ b/api/songs/_soramimi.ts
@@ -63,6 +63,47 @@ export function isKoreanLyrics(lines: { words: string }[]): boolean {
   return lines.some(line => containsHangul(line.words));
 }
 
+/**
+ * ASCII-only lyric lines are treated as English for soramimi routing.
+ * Chinese soramimi should still process them, but English soramimi can passthrough.
+ */
+export function isEnglishLyricLine(text: string): boolean {
+  return /^[a-zA-Z0-9\s.,!?'"()\-:;]+$/.test(text.trim());
+}
+
+/**
+ * English passthrough is only valid when generating English soramimi.
+ * Chinese soramimi should feed English lines to the model as well.
+ */
+export function shouldProcessEnglishForSoramimi(targetLanguage: "zh-TW" | "en"): boolean {
+  return targetLanguage === "zh-TW";
+}
+
+/**
+ * Decide which lyric lines should be sent to the soramimi model.
+ * Chinese soramimi processes every non-empty line, including English ones.
+ * English soramimi preserves English lines and only sends non-English lines.
+ */
+export function selectSoramimiLinesToProcess<T extends { words: string }>(
+  lines: T[],
+  targetLanguage: "zh-TW" | "en"
+): Array<{ line: T; originalIndex: number }> {
+  const shouldProcessEnglishLines = shouldProcessEnglishForSoramimi(targetLanguage);
+  const selected: Array<{ line: T; originalIndex: number }> = [];
+
+  for (let i = 0; i < lines.length; i++) {
+    const text = lines[i]?.words?.trim() ?? "";
+    if (!text) continue;
+
+    const isEnglish = isEnglishLyricLine(text);
+    if (!isEnglish || shouldProcessEnglishLines) {
+      selected.push({ line: lines[i], originalIndex: i });
+    }
+  }
+
+  return selected;
+}
+
 // =============================================================================
 // Fallback Kana to Chinese Map (last resort when AI misses characters)
 // This is only used as a fallback - the AI is encouraged to create creative,
@@ -170,9 +211,9 @@ export function fillMissingReadings(segments: FuriganaSegment[]): FuriganaSegmen
 export const SORAMIMI_SYSTEM_PROMPT = `Create 空耳 (soramimi) - Chinese "misheard lyrics" (繁體字) that SOUND like Japanese/Korean lyrics while carrying poetic meaning.
 
 CRITICAL RULES:
-1. You MUST wrap EVERY non-English word in <original:chinese> format
+1. You MUST wrap EVERY lyric segment in <original:chinese> format, including English
 2. Chinese readings must be ONLY Chinese characters - no Hangul or kana!
-3. English words stay unwrapped (no angle brackets)
+3. Even English words must get Chinese-sounding renderings; never leave them plain
 
 === OUTPUT FORMAT (MANDATORY) ===
 
@@ -183,7 +224,7 @@ EXAMPLE INPUT:
 2: 사랑해요
 
 EXAMPLE OUTPUT:
-1: Oh no <시간이:時光裡> <갈수록:割愁錄> <널:念>
+1: <Oh:歐><no:諾> <시간이:時光裡> <갈수록:割愁錄> <널:念>
 2: <사랑해요:思浪海喲>
 
 === PHILOSOPHY: SOUND + MEANING TOGETHER ===
@@ -248,11 +289,11 @@ Never sacrifice phonetics completely:
 
 === RULES ===
 
-1. EVERY non-English word MUST be wrapped: <word:chinese>
-2. English words stay plain (unwrapped)
+1. EVERY lyric segment MUST be wrapped: <word:chinese>
+2. English segments also need Chinese-character readings
 3. If input has | between words, wrap each segment separately
 4. Output one numbered line per input line
-5. NEVER output plain Korean/Japanese without <:> wrapper!
+5. NEVER output plain lyric text without <:> wrapper!
 6. Prefer compound words over single characters when phonetically possible`;
 
 /**
@@ -268,9 +309,9 @@ You are given text with:
 - Segments separated by | (pipe)
 
 CRITICAL RULES:
-1. You MUST wrap EVERY Japanese AND Korean segment in <original:chinese> format
+1. You MUST wrap EVERY lyric segment in <original:chinese> format, including English
 2. Chinese readings must be ONLY Chinese characters - no kana or hangul!
-3. Use furigana for Japanese pronunciation, read Korean as-is
+3. Use furigana for Japanese pronunciation, read Korean as-is, and approximate English phonetically into Chinese characters
 4. Do NOT include parentheses in output
 
 === OUTPUT FORMAT (MANDATORY) ===
@@ -356,11 +397,11 @@ Never sacrifice phonetics completely:
 
 === RULES ===
 
-1. EVERY Japanese AND Korean segment MUST be wrapped: <segment:chinese>
+1. EVERY lyric segment MUST be wrapped: <segment:chinese>
 2. Remove furigana parentheses from output
-3. English words stay unwrapped
+3. English segments also need Chinese-character readings
 4. Output one numbered line per input line
-5. NEVER output plain Japanese or Korean without <:> wrapper!
+5. NEVER output plain lyric text without <:> wrapper!
 6. Prefer compound words that relate to the song's meaning`;
 
 // =============================================================================

--- a/tests/test-soramimi-routing.test.ts
+++ b/tests/test-soramimi-routing.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  SORAMIMI_JAPANESE_WITH_FURIGANA_PROMPT,
+  SORAMIMI_SYSTEM_PROMPT,
+  selectSoramimiLinesToProcess,
+  isEnglishLyricLine,
+  shouldProcessEnglishForSoramimi,
+} from "../api/songs/_soramimi.ts";
+
+describe("soramimi English line routing", () => {
+  test("detects ASCII English lyric lines", () => {
+    expect(isEnglishLyricLine("I love you")).toBe(true);
+    expect(isEnglishLyricLine("Oh no!")).toBe(true);
+    expect(isEnglishLyricLine("사랑해요")).toBe(false);
+    expect(isEnglishLyricLine("こんにちは")).toBe(false);
+  });
+
+  test("processes English lines for Chinese soramimi", () => {
+    expect(shouldProcessEnglishForSoramimi("zh-TW")).toBe(true);
+
+    const lines = selectSoramimiLinesToProcess(
+      [
+        { words: "I love you", startTimeMs: "1000" },
+        { words: "사랑해요", startTimeMs: "2000" },
+      ],
+      "zh-TW"
+    );
+
+    expect(lines.map((line) => line.line.words)).toEqual(["I love you", "사랑해요"]);
+    expect(lines.map((line) => line.originalIndex)).toEqual([0, 1]);
+  });
+
+  test("keeps English passthrough for English soramimi", () => {
+    expect(shouldProcessEnglishForSoramimi("en")).toBe(false);
+
+    const lines = selectSoramimiLinesToProcess(
+      [
+        { words: "I love you", startTimeMs: "1000" },
+        { words: "사랑해요", startTimeMs: "2000" },
+      ],
+      "en"
+    );
+
+    expect(lines.map((line) => line.line.words)).toEqual(["사랑해요"]);
+    expect(lines.map((line) => line.originalIndex)).toEqual([1]);
+  });
+});
+
+describe("Chinese soramimi prompts", () => {
+  test("require English segments to be transformed", () => {
+    expect(SORAMIMI_SYSTEM_PROMPT).toContain("including English");
+    expect(SORAMIMI_SYSTEM_PROMPT).toContain("never leave them plain");
+    expect(SORAMIMI_JAPANESE_WITH_FURIGANA_PROMPT).toContain("including English");
+    expect(SORAMIMI_JAPANESE_WITH_FURIGANA_PROMPT).toContain("English segments also need Chinese-character readings");
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- route ASCII English lyric lines through the Chinese soramimi generator instead of passing them through unchanged
- update Chinese soramimi prompts so English segments must also receive Chinese-character readings
- add a focused regression test covering line routing and prompt expectations

## Testing
- bun test tests/test-soramimi-routing.test.ts tests/test-lyrics-parsing.test.ts tests/test-furigana-line-detection.test.ts
- bun run build
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e82f5794-d535-49fc-8fc5-ccb7a4763087"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e82f5794-d535-49fc-8fc5-ccb7a4763087"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

