### PR TITLE
Keep lead dots inline with the next lyric row

### DIFF
--- a/src/apps/ipod/components/LyricsDisplay.tsx
+++ b/src/apps/ipod/components/LyricsDisplay.tsx
@@ -34,6 +34,7 @@ import {
   buildInterludeLyricLineWithWordTimings,
   getInterludeDotsFadeOpacity,
   isInterludePlaceholderLine,
+  mergeLeadingInterludeWithNextLine,
 } from "@/utils/karaokeInterludeDisplay";
 
 interface LyricsDisplayProps {
@@ -1173,6 +1174,11 @@ type LyricsLineRowContentProps = {
   line: LyricLine;
   isCurrent: boolean;
   isInterludePlaceholder?: boolean;
+  leadingInterlude?: {
+    line: LyricLine;
+    countdownStartMs: number;
+    timeMs: number | undefined;
+  };
   hasWordTimings: boolean;
   /** Only passed for rows that need per-tick playback time (word highlight + gradient hue). */
   timeMsForRow: number | undefined;
@@ -1207,6 +1213,7 @@ function LyricsLineRowContent({
   line,
   isCurrent,
   isInterludePlaceholder = false,
+  leadingInterlude,
   hasWordTimings,
   timeMsForRow,
   translatedText,
@@ -1258,6 +1265,14 @@ function LyricsLineRowContent({
     return getInterludeDotsFadeOpacity(t, interludeMeta.countdownStartMs);
   }, [interludeMeta, timeMsForRow]);
 
+  const leadingInterludeDotsOpacity = useMemo(() => {
+    if (!leadingInterlude || leadingInterlude.timeMs === undefined) return 1;
+    return getInterludeDotsFadeOpacity(
+      leadingInterlude.timeMs,
+      leadingInterlude.countdownStartMs
+    );
+  }, [leadingInterlude]);
+
   return (
     <>
       {(() => {
@@ -1270,6 +1285,260 @@ function LyricsLineRowContent({
           (romanization.enabled && romanization.japaneseFurigana
             ? furiganaMap.get(line.startTimeMs)
             : undefined);
+        const leadingInterludeContent = leadingInterlude ? (
+          <span
+            className="karaoke-interlude-leading-prefix"
+            style={{ whiteSpace: "nowrap" }}
+          >
+            <span
+              className="karaoke-interlude-circle-dots"
+              style={{
+                opacity: leadingInterludeDotsOpacity,
+                transition: "opacity 0.12s linear",
+              }}
+            >
+              {leadingInterlude.timeMs !== undefined ? (
+                <WordTimingHighlight
+                  wordTimings={leadingInterlude.line.wordTimings!}
+                  lineStartTimeMs={parseInt(leadingInterlude.line.startTimeMs, 10)}
+                  currentTimeMs={leadingInterlude.timeMs}
+                  processText={processText}
+                  onSeekToTime={undefined}
+                  isOldSchoolKaraoke={isOldSchoolKaraoke}
+                  highlightColor={highlightColor}
+                  glowFilter={glowFilter}
+                  baseColor={baseColor}
+                  isGradient={isGradientStyle}
+                  rainbowHue={
+                    isGradientStyle
+                      ? ((leadingInterlude.timeMs / 6000) * 360) % 360
+                      : undefined
+                  }
+                />
+              ) : (
+                <StaticWordRendering
+                  wordTimings={leadingInterlude.line.wordTimings!}
+                  processText={processText}
+                  lineStartTimeMs={parseInt(leadingInterlude.line.startTimeMs, 10)}
+                  onSeekToTime={undefined}
+                  isOldSchoolKaraoke={isOldSchoolKaraoke}
+                  baseColor={baseColor}
+                />
+              )}
+            </span>{" "}
+          </span>
+        ) : null;
+        const mainLineContent = shouldUseAnimatedWordTiming ? (
+          isInterludePlaceholder ? (
+            <>
+              {interludeMeta?.anchorLine &&
+                (() => {
+                  const anchorLine = interludeMeta.anchorLine;
+                  const anchorSoramimi =
+                    romanization.enabled && romanization.soramimi
+                      ? soramimiMap.get(anchorLine.startTimeMs)
+                      : undefined;
+                  const anchorAnnotations =
+                    anchorSoramimi ??
+                    (romanization.enabled && romanization.japaneseFurigana
+                      ? furiganaMap.get(anchorLine.startTimeMs)
+                      : undefined);
+                  return (
+                    <div className="karaoke-interlude-anchor-ghost mb-1 opacity-[0.5]">
+                      {anchorLine.wordTimings?.length ? (
+                        <StaticWordRendering
+                          wordTimings={anchorLine.wordTimings}
+                          processText={processText}
+                          furiganaSegments={anchorAnnotations}
+                          koreanRomanized={!anchorSoramimi && showKoreanRomanization}
+                          japaneseRomaji={
+                            !anchorSoramimi &&
+                            romanization.enabled &&
+                            romanization.japaneseRomaji
+                          }
+                          chinesePinyin={
+                            !anchorSoramimi && romanization.enabled && romanization.chinese
+                          }
+                          pronunciationOnly={
+                            romanization.enabled && romanization.pronunciationOnly
+                          }
+                          soramimiTargetLanguage={
+                            anchorSoramimi ? romanization.soramamiTargetLanguage : undefined
+                          }
+                          lineStartTimeMs={parseInt(anchorLine.startTimeMs, 10)}
+                          onSeekToTime={undefined}
+                          isOldSchoolKaraoke={isOldSchoolKaraoke}
+                          baseColor={baseColor}
+                        />
+                      ) : (
+                        renderWithFurigana(anchorLine, processText(anchorLine.words))
+                      )}
+                    </div>
+                  );
+                })()}
+              <div
+                className="karaoke-interlude-circle-dots"
+                style={{
+                  opacity: interludeDotsOpacity,
+                  transition: "opacity 0.12s linear",
+                }}
+              >
+                <WordTimingHighlight
+                  wordTimings={line.wordTimings!}
+                  lineStartTimeMs={parseInt(line.startTimeMs, 10)}
+                  currentTimeMs={timeMsForRow!}
+                  processText={processText}
+                  furiganaSegments={annotationSegments}
+                  koreanRomanized={!soramimiSegments && showKoreanRomanization}
+                  japaneseRomaji={
+                    !soramimiSegments && romanization.enabled && romanization.japaneseRomaji
+                  }
+                  chinesePinyin={!soramimiSegments && romanization.enabled && romanization.chinese}
+                  pronunciationOnly={romanization.enabled && romanization.pronunciationOnly}
+                  soramimiTargetLanguage={
+                    soramimiSegments ? romanization.soramamiTargetLanguage : undefined
+                  }
+                  onSeekToTime={undefined}
+                  isOldSchoolKaraoke={isOldSchoolKaraoke}
+                  highlightColor={highlightColor}
+                  glowFilter={glowFilter}
+                  baseColor={baseColor}
+                  isGradient={isGradientStyle}
+                  rainbowHue={
+                    isGradientStyle && timeMsForRow !== undefined
+                      ? ((timeMsForRow / 6000) * 360) % 360
+                      : undefined
+                  }
+                />
+              </div>
+            </>
+          ) : (
+            <WordTimingHighlight
+              wordTimings={line.wordTimings!}
+              lineStartTimeMs={parseInt(line.startTimeMs, 10)}
+              currentTimeMs={timeMsForRow!}
+              processText={processText}
+              furiganaSegments={annotationSegments}
+              koreanRomanized={!soramimiSegments && showKoreanRomanization}
+              japaneseRomaji={
+                !soramimiSegments && romanization.enabled && romanization.japaneseRomaji
+              }
+              chinesePinyin={!soramimiSegments && romanization.enabled && romanization.chinese}
+              pronunciationOnly={romanization.enabled && romanization.pronunciationOnly}
+              soramimiTargetLanguage={
+                soramimiSegments ? romanization.soramamiTargetLanguage : undefined
+              }
+              onSeekToTime={onSeekToTime}
+              isOldSchoolKaraoke={isOldSchoolKaraoke}
+              highlightColor={highlightColor}
+              glowFilter={glowFilter}
+              baseColor={baseColor}
+              isGradient={isGradientStyle}
+              rainbowHue={
+                isGradientStyle && timeMsForRow !== undefined
+                  ? ((timeMsForRow / 6000) * 360) % 360
+                  : undefined
+              }
+            />
+          )
+        ) : hasWordTimings ? (
+          isInterludePlaceholder ? (
+            <>
+              {interludeMeta?.anchorLine &&
+                (() => {
+                  const anchorLine = interludeMeta.anchorLine;
+                  const anchorSoramimi =
+                    romanization.enabled && romanization.soramimi
+                      ? soramimiMap.get(anchorLine.startTimeMs)
+                      : undefined;
+                  const anchorAnnotations =
+                    anchorSoramimi ??
+                    (romanization.enabled && romanization.japaneseFurigana
+                      ? furiganaMap.get(anchorLine.startTimeMs)
+                      : undefined);
+                  return (
+                    <div className="karaoke-interlude-anchor-ghost mb-1 opacity-[0.5]">
+                      {anchorLine.wordTimings?.length ? (
+                        <StaticWordRendering
+                          wordTimings={anchorLine.wordTimings}
+                          processText={processText}
+                          furiganaSegments={anchorAnnotations}
+                          koreanRomanized={!anchorSoramimi && showKoreanRomanization}
+                          japaneseRomaji={
+                            !anchorSoramimi &&
+                            romanization.enabled &&
+                            romanization.japaneseRomaji
+                          }
+                          chinesePinyin={
+                            !anchorSoramimi && romanization.enabled && romanization.chinese
+                          }
+                          pronunciationOnly={
+                            romanization.enabled && romanization.pronunciationOnly
+                          }
+                          soramimiTargetLanguage={
+                            anchorSoramimi ? romanization.soramamiTargetLanguage : undefined
+                          }
+                          lineStartTimeMs={parseInt(anchorLine.startTimeMs, 10)}
+                          onSeekToTime={undefined}
+                          isOldSchoolKaraoke={isOldSchoolKaraoke}
+                          baseColor={baseColor}
+                        />
+                      ) : (
+                        renderWithFurigana(anchorLine, processText(anchorLine.words))
+                      )}
+                    </div>
+                  );
+                })()}
+              <div
+                className="karaoke-interlude-circle-dots"
+                style={{
+                  opacity: interludeDotsOpacity,
+                  transition: "opacity 0.12s linear",
+                }}
+              >
+                <StaticWordRendering
+                  wordTimings={line.wordTimings!}
+                  processText={processText}
+                  furiganaSegments={annotationSegments}
+                  koreanRomanized={!soramimiSegments && showKoreanRomanization}
+                  japaneseRomaji={
+                    !soramimiSegments && romanization.enabled && romanization.japaneseRomaji
+                  }
+                  chinesePinyin={!soramimiSegments && romanization.enabled && romanization.chinese}
+                  pronunciationOnly={romanization.enabled && romanization.pronunciationOnly}
+                  soramimiTargetLanguage={
+                    soramimiSegments ? romanization.soramamiTargetLanguage : undefined
+                  }
+                  lineStartTimeMs={parseInt(line.startTimeMs, 10)}
+                  onSeekToTime={undefined}
+                  isOldSchoolKaraoke={isOldSchoolKaraoke}
+                  baseColor={baseColor}
+                />
+              </div>
+            </>
+          ) : (
+            <StaticWordRendering
+              wordTimings={line.wordTimings!}
+              processText={processText}
+              furiganaSegments={annotationSegments}
+              koreanRomanized={!soramimiSegments && showKoreanRomanization}
+              japaneseRomaji={
+                !soramimiSegments && romanization.enabled && romanization.japaneseRomaji
+              }
+              chinesePinyin={!soramimiSegments && romanization.enabled && romanization.chinese}
+              pronunciationOnly={romanization.enabled && romanization.pronunciationOnly}
+              soramimiTargetLanguage={
+                soramimiSegments ? romanization.soramamiTargetLanguage : undefined
+              }
+              lineStartTimeMs={parseInt(line.startTimeMs, 10)}
+              onSeekToTime={onSeekToTime}
+              isOldSchoolKaraoke={isOldSchoolKaraoke}
+              baseColor={baseColor}
+            />
+          )
+        ) : (
+          renderWithFurigana(line, processedOriginal)
+        );
         return (
           <div
             className={`${textSizeClass} ${fontClassName} ${lineHeightClass} ${
@@ -1311,217 +1580,8 @@ function LyricsLineRowContent({
                 : undefined
             }
           >
-            {shouldUseAnimatedWordTiming ? (
-              isInterludePlaceholder ? (
-                <>
-                  {interludeMeta?.anchorLine &&
-                    (() => {
-                      const anchorLine = interludeMeta.anchorLine;
-                      const anchorSoramimi =
-                        romanization.enabled && romanization.soramimi
-                          ? soramimiMap.get(anchorLine.startTimeMs)
-                          : undefined;
-                      const anchorAnnotations =
-                        anchorSoramimi ??
-                        (romanization.enabled && romanization.japaneseFurigana
-                          ? furiganaMap.get(anchorLine.startTimeMs)
-                          : undefined);
-                      return (
-                        <div className="karaoke-interlude-anchor-ghost mb-1 opacity-[0.5]">
-                          {anchorLine.wordTimings?.length ? (
-                            <StaticWordRendering
-                              wordTimings={anchorLine.wordTimings}
-                              processText={processText}
-                              furiganaSegments={anchorAnnotations}
-                              koreanRomanized={!anchorSoramimi && showKoreanRomanization}
-                              japaneseRomaji={
-                                !anchorSoramimi &&
-                                romanization.enabled &&
-                                romanization.japaneseRomaji
-                              }
-                              chinesePinyin={
-                                !anchorSoramimi && romanization.enabled && romanization.chinese
-                              }
-                              pronunciationOnly={
-                                romanization.enabled && romanization.pronunciationOnly
-                              }
-                              soramimiTargetLanguage={
-                                anchorSoramimi ? romanization.soramamiTargetLanguage : undefined
-                              }
-                              lineStartTimeMs={parseInt(anchorLine.startTimeMs, 10)}
-                              onSeekToTime={undefined}
-                              isOldSchoolKaraoke={isOldSchoolKaraoke}
-                              baseColor={baseColor}
-                            />
-                          ) : (
-                            renderWithFurigana(anchorLine, processText(anchorLine.words))
-                          )}
-                        </div>
-                      );
-                    })()}
-                  <div
-                    className="karaoke-interlude-circle-dots"
-                    style={{
-                      opacity: interludeDotsOpacity,
-                      transition: "opacity 0.12s linear",
-                    }}
-                  >
-                    <WordTimingHighlight
-                      wordTimings={line.wordTimings!}
-                      lineStartTimeMs={parseInt(line.startTimeMs, 10)}
-                      currentTimeMs={timeMsForRow!}
-                      processText={processText}
-                      furiganaSegments={annotationSegments}
-                      koreanRomanized={!soramimiSegments && showKoreanRomanization}
-                      japaneseRomaji={
-                        !soramimiSegments && romanization.enabled && romanization.japaneseRomaji
-                      }
-                      chinesePinyin={!soramimiSegments && romanization.enabled && romanization.chinese}
-                      pronunciationOnly={romanization.enabled && romanization.pronunciationOnly}
-                      soramimiTargetLanguage={
-                        soramimiSegments ? romanization.soramamiTargetLanguage : undefined
-                      }
-                      onSeekToTime={undefined}
-                      isOldSchoolKaraoke={isOldSchoolKaraoke}
-                      highlightColor={highlightColor}
-                      glowFilter={glowFilter}
-                      baseColor={baseColor}
-                      isGradient={isGradientStyle}
-                      rainbowHue={
-                        isGradientStyle && timeMsForRow !== undefined
-                          ? ((timeMsForRow / 6000) * 360) % 360
-                          : undefined
-                      }
-                    />
-                  </div>
-                </>
-              ) : (
-                <WordTimingHighlight
-                  wordTimings={line.wordTimings!}
-                  lineStartTimeMs={parseInt(line.startTimeMs, 10)}
-                  currentTimeMs={timeMsForRow!}
-                  processText={processText}
-                  furiganaSegments={annotationSegments}
-                  koreanRomanized={!soramimiSegments && showKoreanRomanization}
-                  japaneseRomaji={
-                    !soramimiSegments && romanization.enabled && romanization.japaneseRomaji
-                  }
-                  chinesePinyin={!soramimiSegments && romanization.enabled && romanization.chinese}
-                  pronunciationOnly={romanization.enabled && romanization.pronunciationOnly}
-                  soramimiTargetLanguage={
-                    soramimiSegments ? romanization.soramamiTargetLanguage : undefined
-                  }
-                  onSeekToTime={onSeekToTime}
-                  isOldSchoolKaraoke={isOldSchoolKaraoke}
-                  highlightColor={highlightColor}
-                  glowFilter={glowFilter}
-                  baseColor={baseColor}
-                  isGradient={isGradientStyle}
-                  rainbowHue={
-                    isGradientStyle && timeMsForRow !== undefined
-                      ? ((timeMsForRow / 6000) * 360) % 360
-                      : undefined
-                  }
-                />
-              )
-            ) : hasWordTimings ? (
-              isInterludePlaceholder ? (
-                <>
-                  {interludeMeta?.anchorLine &&
-                    (() => {
-                      const anchorLine = interludeMeta.anchorLine;
-                      const anchorSoramimi =
-                        romanization.enabled && romanization.soramimi
-                          ? soramimiMap.get(anchorLine.startTimeMs)
-                          : undefined;
-                      const anchorAnnotations =
-                        anchorSoramimi ??
-                        (romanization.enabled && romanization.japaneseFurigana
-                          ? furiganaMap.get(anchorLine.startTimeMs)
-                          : undefined);
-                      return (
-                        <div className="karaoke-interlude-anchor-ghost mb-1 opacity-[0.5]">
-                          {anchorLine.wordTimings?.length ? (
-                            <StaticWordRendering
-                              wordTimings={anchorLine.wordTimings}
-                              processText={processText}
-                              furiganaSegments={anchorAnnotations}
-                              koreanRomanized={!anchorSoramimi && showKoreanRomanization}
-                              japaneseRomaji={
-                                !anchorSoramimi &&
-                                romanization.enabled &&
-                                romanization.japaneseRomaji
-                              }
-                              chinesePinyin={
-                                !anchorSoramimi && romanization.enabled && romanization.chinese
-                              }
-                              pronunciationOnly={
-                                romanization.enabled && romanization.pronunciationOnly
-                              }
-                              soramimiTargetLanguage={
-                                anchorSoramimi ? romanization.soramamiTargetLanguage : undefined
-                              }
-                              lineStartTimeMs={parseInt(anchorLine.startTimeMs, 10)}
-                              onSeekToTime={undefined}
-                              isOldSchoolKaraoke={isOldSchoolKaraoke}
-                              baseColor={baseColor}
-                            />
-                          ) : (
-                            renderWithFurigana(anchorLine, processText(anchorLine.words))
-                          )}
-                        </div>
-                      );
-                    })()}
-                  <div
-                    className="karaoke-interlude-circle-dots"
-                    style={{
-                      opacity: interludeDotsOpacity,
-                      transition: "opacity 0.12s linear",
-                    }}
-                  >
-                    <StaticWordRendering
-                      wordTimings={line.wordTimings!}
-                      processText={processText}
-                      furiganaSegments={annotationSegments}
-                      koreanRomanized={!soramimiSegments && showKoreanRomanization}
-                      japaneseRomaji={
-                        !soramimiSegments && romanization.enabled && romanization.japaneseRomaji
-                      }
-                      chinesePinyin={!soramimiSegments && romanization.enabled && romanization.chinese}
-                      pronunciationOnly={romanization.enabled && romanization.pronunciationOnly}
-                      soramimiTargetLanguage={
-                        soramimiSegments ? romanization.soramamiTargetLanguage : undefined
-                      }
-                      lineStartTimeMs={parseInt(line.startTimeMs, 10)}
-                      onSeekToTime={undefined}
-                      isOldSchoolKaraoke={isOldSchoolKaraoke}
-                      baseColor={baseColor}
-                    />
-                  </div>
-                </>
-              ) : (
-                <StaticWordRendering
-                  wordTimings={line.wordTimings!}
-                  processText={processText}
-                  furiganaSegments={annotationSegments}
-                  koreanRomanized={!soramimiSegments && showKoreanRomanization}
-                  japaneseRomaji={
-                    !soramimiSegments && romanization.enabled && romanization.japaneseRomaji
-                  }
-                  chinesePinyin={!soramimiSegments && romanization.enabled && romanization.chinese}
-                  pronunciationOnly={romanization.enabled && romanization.pronunciationOnly}
-                  soramimiTargetLanguage={
-                    soramimiSegments ? romanization.soramamiTargetLanguage : undefined
-                  }
-                  lineStartTimeMs={parseInt(line.startTimeMs, 10)}
-                  onSeekToTime={onSeekToTime}
-                  isOldSchoolKaraoke={isOldSchoolKaraoke}
-                  baseColor={baseColor}
-                />
-              )
-            ) : (
-              renderWithFurigana(line, processedOriginal)
-            )}
+            {leadingInterludeContent}
+            {mainLineContent}
           </div>
         );
       })()}
@@ -2023,6 +2083,11 @@ export function LyricsDisplay({
     ]
   );
 
+  const renderableVisibleLines = useMemo(
+    () => mergeLeadingInterludeWithNextLine(visibleLines),
+    [visibleLines]
+  );
+
   // Track touch start position and accumulated movement
   const touchStartRef = useRef<{ x: number; y: number; time: number } | null>(null);
   const accumulatedDeltaRef = useRef<{ x: number; y: number }>({ x: 0, y: 0 });
@@ -2175,7 +2240,8 @@ export function LyricsDisplay({
       onTouchCancel={handleTouchCancel}
     >
       <AnimatePresence mode="popLayout">
-        {visibleLines.map((line, index) => {
+        {renderableVisibleLines.map(
+          ({ line, leadingInterlude, originalIndex, totalVisibleLines }) => {
           const isInterludePlaceholder = isInterludePlaceholderLine(line);
           const lineForContent: LyricLine = isInterludePlaceholder
             ? buildInterludeLyricLineWithWordTimings(
@@ -2202,10 +2268,17 @@ export function LyricsDisplay({
           const hasWordTimings = !!(
             lineForContent.wordTimings && lineForContent.wordTimings.length > 0
           );
+          const leadingInterludeLine = leadingInterlude
+            ? buildInterludeLyricLineWithWordTimings(
+                leadingInterlude,
+                displayOriginalLines,
+                actualCurrentLine
+              )
+            : undefined;
           const lineTextAlign = getTextAlign(
             alignment,
-            index,
-            visibleLines.length
+            originalIndex,
+            totalVisibleLines
           );
           const translatedText = !isInterludePlaceholder && hasTranslation
             ? translationMap.get(line.startTimeMs) ||
@@ -2250,14 +2323,14 @@ export function LyricsDisplay({
                 pointerEvents: interactive ? "auto" : "none",
                 paddingLeft:
                   alignment === LyricsAlignment.Alternating &&
-                  index === 0 &&
-                  visibleLines.length > 1
+                  originalIndex === 0 &&
+                  totalVisibleLines > 1
                     ? "5%"
                     : undefined,
                 paddingRight:
                   alignment === LyricsAlignment.Alternating &&
-                  index === 1 &&
-                  visibleLines.length > 1
+                  originalIndex === 1 &&
+                  totalVisibleLines > 1
                     ? "5%"
                     : undefined,
                 backfaceVisibility: "hidden",
@@ -2268,6 +2341,15 @@ export function LyricsDisplay({
                 line={lineForContent}
                 isCurrent={isCurrent}
                 isInterludePlaceholder={isInterludePlaceholder}
+                leadingInterlude={
+                  leadingInterlude && leadingInterludeLine
+                    ? {
+                        line: leadingInterludeLine,
+                        countdownStartMs: leadingInterlude.countdownStartMs,
+                        timeMs: currentTimeMs,
+                      }
+                    : undefined
+                }
                 hasWordTimings={hasWordTimings}
                 timeMsForRow={timeMsForRow}
                 translatedText={translatedText}

--- a/src/apps/ipod/components/LyricsDisplay.tsx
+++ b/src/apps/ipod/components/LyricsDisplay.tsx
@@ -45,7 +45,7 @@ type DebugLogPayload = {
 };
 
 const appendDebugLog = (payload: DebugLogPayload) => {
-  if (typeof Bun === "undefined") return;
+  if (!("Bun" in globalThis)) return;
   void Function("return import('node:fs')")()
     .then(({ appendFileSync }: typeof import("node:fs")) => {
       appendFileSync(

--- a/src/apps/ipod/components/LyricsDisplay.tsx
+++ b/src/apps/ipod/components/LyricsDisplay.tsx
@@ -37,25 +37,6 @@ import {
   mergeLeadingInterludeWithNextLine,
 } from "@/utils/karaokeInterludeDisplay";
 
-type DebugLogPayload = {
-  hypothesisId: string;
-  location: string;
-  message: string;
-  data: Record<string, unknown>;
-};
-
-const appendDebugLog = (payload: DebugLogPayload) => {
-  if (!("Bun" in globalThis)) return;
-  void Function("return import('node:fs')")()
-    .then(({ appendFileSync }: typeof import("node:fs")) => {
-      appendFileSync(
-        "/opt/cursor/logs/debug.log",
-        `${JSON.stringify({ ...payload, timestamp: Date.now() })}\n`
-      );
-    })
-    .catch(() => {});
-};
-
 interface LyricsDisplayProps {
   lines: LyricLine[];
   /** Original untranslated lyrics (used for furigana) */
@@ -1968,21 +1949,7 @@ export function LyricsDisplay({
     }
 
     if (align === LyricsAlignment.Alternating) {
-      const alternatingTextAlign =
-        totalVisibleLines === 1 ? "center" : lineIndex === 0 ? "left" : "right";
-      // #region agent log
-      appendDebugLog({
-        hypothesisId: "A",
-        location: "src/apps/ipod/components/LyricsDisplay.tsx:1951",
-        message: "Computed alternating text alignment",
-        data: {
-          lineIndex,
-          totalVisibleLines,
-          alternatingTextAlign,
-        },
-      });
-      // #endregion
-      return alternatingTextAlign;
+      return totalVisibleLines === 1 ? "center" : lineIndex === 0 ? "left" : "right";
     }
 
     if (totalVisibleLines === 1) {
@@ -2015,37 +1982,11 @@ export function LyricsDisplay({
 
     if (clampedIdx % 2 === 0) {
       // Current is on top
-      const result = [allLines[clampedIdx], nextLine].filter(Boolean);
-      // #region agent log
-      appendDebugLog({
-        hypothesisId: "C",
-        location: "src/apps/ipod/components/LyricsDisplay.tsx:1984",
-        message: "Computed alternating visible lines for even current index",
-        data: {
-          currIdx,
-          clampedIdx,
-          resultStarts: result.map((line) => line.startTimeMs),
-        },
-      });
-      // #endregion
-      return result;
+      return [allLines[clampedIdx], nextLine].filter(Boolean);
     }
 
     // Current is at bottom
-    const result = [nextLine, allLines[clampedIdx]].filter(Boolean);
-    // #region agent log
-    appendDebugLog({
-      hypothesisId: "C",
-      location: "src/apps/ipod/components/LyricsDisplay.tsx:1989",
-      message: "Computed alternating visible lines for odd current index",
-      data: {
-        currIdx,
-        clampedIdx,
-        resultStarts: result.map((line) => line.startTimeMs),
-      },
-    });
-    // #endregion
-    return result;
+    return [nextLine, allLines[clampedIdx]].filter(Boolean);
   };
 
   // State to hold lines displayed in Alternating mode so we can delay updates
@@ -2067,20 +2008,7 @@ export function LyricsDisplay({
 
     // Instantly update on song load, translation switch, or initial state
     if (linesChanged || actualCurrentLine < 0) {
-      const nextAltLines = computeAltVisibleLines(displayOriginalLines, actualCurrentLine);
-      // #region agent log
-      appendDebugLog({
-        hypothesisId: "C",
-        location: "src/apps/ipod/components/LyricsDisplay.tsx:2010",
-        message: "Applied immediate alternating line update",
-        data: {
-          linesChanged,
-          actualCurrentLine,
-          nextAltLineStarts: nextAltLines.map((line) => line.startTimeMs),
-        },
-      });
-      // #endregion
-      setAltLines(nextAltLines);
+      setAltLines(computeAltVisibleLines(displayOriginalLines, actualCurrentLine));
       return;
     }
 
@@ -2104,20 +2032,7 @@ export function LyricsDisplay({
     const delayMs = Math.min(400, Math.max(20, Math.floor(rawDuration * 0.2)));
 
     const timer = setTimeout(() => {
-      const nextAltLines = computeAltVisibleLines(displayOriginalLines, actualCurrentLine);
-      // #region agent log
-      appendDebugLog({
-        hypothesisId: "C",
-        location: "src/apps/ipod/components/LyricsDisplay.tsx:2035",
-        message: "Applied delayed alternating line update",
-        data: {
-          actualCurrentLine,
-          delayMs,
-          nextAltLineStarts: nextAltLines.map((line) => line.startTimeMs),
-        },
-      });
-      // #endregion
-      setAltLines(nextAltLines);
+      setAltLines(computeAltVisibleLines(displayOriginalLines, actualCurrentLine));
     }, delayMs);
 
     return () => clearTimeout(timer);
@@ -2390,31 +2305,6 @@ export function LyricsDisplay({
             filter: ANIMATION_CONFIG.fade,
             duration: 0.15,
           };
-
-          if (
-            alignment === LyricsAlignment.Alternating &&
-            (leadingInterlude || totalVisibleLines === 1 || isInterludePlaceholder)
-          ) {
-            // #region agent log
-            appendDebugLog({
-              hypothesisId: "B",
-              location: "src/apps/ipod/components/LyricsDisplay.tsx:2310",
-              message: "Rendering alternating lyric row",
-              data: {
-                lineStart: line.startTimeMs,
-                isCurrent,
-                isInterludePlaceholder,
-                hasLeadingInterlude: !!leadingInterlude,
-                originalIndex,
-                totalVisibleLines,
-                lineTextAlign,
-                position,
-                lineActualIdx,
-                currentAnchorIdx,
-              },
-            });
-            // #endregion
-          }
 
           return (
             <motion.div

--- a/src/apps/ipod/components/LyricsDisplay.tsx
+++ b/src/apps/ipod/components/LyricsDisplay.tsx
@@ -37,6 +37,25 @@ import {
   mergeLeadingInterludeWithNextLine,
 } from "@/utils/karaokeInterludeDisplay";
 
+type DebugLogPayload = {
+  hypothesisId: string;
+  location: string;
+  message: string;
+  data: Record<string, unknown>;
+};
+
+const appendDebugLog = (payload: DebugLogPayload) => {
+  if (typeof Bun === "undefined") return;
+  void Function("return import('node:fs')")()
+    .then(({ appendFileSync }: typeof import("node:fs")) => {
+      appendFileSync(
+        "/opt/cursor/logs/debug.log",
+        `${JSON.stringify({ ...payload, timestamp: Date.now() })}\n`
+      );
+    })
+    .catch(() => {});
+};
+
 interface LyricsDisplayProps {
   lines: LyricLine[];
   /** Original untranslated lyrics (used for furigana) */
@@ -1949,8 +1968,21 @@ export function LyricsDisplay({
     }
 
     if (align === LyricsAlignment.Alternating) {
-      if (totalVisibleLines === 1) return "center";
-      return lineIndex === 0 ? "left" : "right";
+      const alternatingTextAlign =
+        totalVisibleLines === 1 ? "center" : lineIndex === 0 ? "left" : "right";
+      // #region agent log
+      appendDebugLog({
+        hypothesisId: "A",
+        location: "src/apps/ipod/components/LyricsDisplay.tsx:1951",
+        message: "Computed alternating text alignment",
+        data: {
+          lineIndex,
+          totalVisibleLines,
+          alternatingTextAlign,
+        },
+      });
+      // #endregion
+      return alternatingTextAlign;
     }
 
     if (totalVisibleLines === 1) {
@@ -1983,11 +2015,37 @@ export function LyricsDisplay({
 
     if (clampedIdx % 2 === 0) {
       // Current is on top
-      return [allLines[clampedIdx], nextLine].filter(Boolean);
+      const result = [allLines[clampedIdx], nextLine].filter(Boolean);
+      // #region agent log
+      appendDebugLog({
+        hypothesisId: "C",
+        location: "src/apps/ipod/components/LyricsDisplay.tsx:1984",
+        message: "Computed alternating visible lines for even current index",
+        data: {
+          currIdx,
+          clampedIdx,
+          resultStarts: result.map((line) => line.startTimeMs),
+        },
+      });
+      // #endregion
+      return result;
     }
 
     // Current is at bottom
-    return [nextLine, allLines[clampedIdx]].filter(Boolean);
+    const result = [nextLine, allLines[clampedIdx]].filter(Boolean);
+    // #region agent log
+    appendDebugLog({
+      hypothesisId: "C",
+      location: "src/apps/ipod/components/LyricsDisplay.tsx:1989",
+      message: "Computed alternating visible lines for odd current index",
+      data: {
+        currIdx,
+        clampedIdx,
+        resultStarts: result.map((line) => line.startTimeMs),
+      },
+    });
+    // #endregion
+    return result;
   };
 
   // State to hold lines displayed in Alternating mode so we can delay updates
@@ -2009,7 +2067,20 @@ export function LyricsDisplay({
 
     // Instantly update on song load, translation switch, or initial state
     if (linesChanged || actualCurrentLine < 0) {
-      setAltLines(computeAltVisibleLines(displayOriginalLines, actualCurrentLine));
+      const nextAltLines = computeAltVisibleLines(displayOriginalLines, actualCurrentLine);
+      // #region agent log
+      appendDebugLog({
+        hypothesisId: "C",
+        location: "src/apps/ipod/components/LyricsDisplay.tsx:2010",
+        message: "Applied immediate alternating line update",
+        data: {
+          linesChanged,
+          actualCurrentLine,
+          nextAltLineStarts: nextAltLines.map((line) => line.startTimeMs),
+        },
+      });
+      // #endregion
+      setAltLines(nextAltLines);
       return;
     }
 
@@ -2033,7 +2104,20 @@ export function LyricsDisplay({
     const delayMs = Math.min(400, Math.max(20, Math.floor(rawDuration * 0.2)));
 
     const timer = setTimeout(() => {
-      setAltLines(computeAltVisibleLines(displayOriginalLines, actualCurrentLine));
+      const nextAltLines = computeAltVisibleLines(displayOriginalLines, actualCurrentLine);
+      // #region agent log
+      appendDebugLog({
+        hypothesisId: "C",
+        location: "src/apps/ipod/components/LyricsDisplay.tsx:2035",
+        message: "Applied delayed alternating line update",
+        data: {
+          actualCurrentLine,
+          delayMs,
+          nextAltLineStarts: nextAltLines.map((line) => line.startTimeMs),
+        },
+      });
+      // #endregion
+      setAltLines(nextAltLines);
     }, delayMs);
 
     return () => clearTimeout(timer);
@@ -2306,6 +2390,31 @@ export function LyricsDisplay({
             filter: ANIMATION_CONFIG.fade,
             duration: 0.15,
           };
+
+          if (
+            alignment === LyricsAlignment.Alternating &&
+            (leadingInterlude || totalVisibleLines === 1 || isInterludePlaceholder)
+          ) {
+            // #region agent log
+            appendDebugLog({
+              hypothesisId: "B",
+              location: "src/apps/ipod/components/LyricsDisplay.tsx:2310",
+              message: "Rendering alternating lyric row",
+              data: {
+                lineStart: line.startTimeMs,
+                isCurrent,
+                isInterludePlaceholder,
+                hasLeadingInterlude: !!leadingInterlude,
+                originalIndex,
+                totalVisibleLines,
+                lineTextAlign,
+                position,
+                lineActualIdx,
+                currentAnchorIdx,
+              },
+            });
+            // #endregion
+          }
 
           return (
             <motion.div

--- a/src/utils/karaokeInterludeDisplay.ts
+++ b/src/utils/karaokeInterludeDisplay.ts
@@ -8,7 +8,7 @@ type DebugLogPayload = {
 };
 
 const appendDebugLog = (payload: DebugLogPayload) => {
-  if (typeof Bun === "undefined") return;
+  if (!("Bun" in globalThis)) return;
   void Function("return import('node:fs')")()
     .then(({ appendFileSync }: typeof import("node:fs")) => {
       appendFileSync(

--- a/src/utils/karaokeInterludeDisplay.ts
+++ b/src/utils/karaokeInterludeDisplay.ts
@@ -1,24 +1,5 @@
 import { LyricsAlignment, type LyricLine, type LyricWord } from "@/types/lyrics";
 
-type DebugLogPayload = {
-  hypothesisId: string;
-  location: string;
-  message: string;
-  data: Record<string, unknown>;
-};
-
-const appendDebugLog = (payload: DebugLogPayload) => {
-  if (!("Bun" in globalThis)) return;
-  void Function("return import('node:fs')")()
-    .then(({ appendFileSync }: typeof import("node:fs")) => {
-      appendFileSync(
-        "/opt/cursor/logs/debug.log",
-        `${JSON.stringify({ ...payload, timestamp: Date.now() })}\n`
-      );
-    })
-    .catch(() => {});
-};
-
 export interface InterludePlaceholderLine {
   startTimeMs: string;
   words: string;
@@ -167,7 +148,6 @@ export function mergeLeadingInterludeWithNextLine(
   visibleLines: VisibleLyricLine[]
 ): RenderableVisibleLyricLine[] {
   const mergedRows = visibleLines.flatMap((line, index) => {
-    const totalVisibleLines = visibleLines.length;
     const nextLine = visibleLines[index + 1];
     const previousLine = visibleLines[index - 1];
 
@@ -186,28 +166,12 @@ export function mergeLeadingInterludeWithNextLine(
         ? previousLine
         : undefined;
 
-    if (leadingInterlude) {
-      // #region agent log
-      appendDebugLog({
-        hypothesisId: "A",
-        location: "src/utils/karaokeInterludeDisplay.ts:183",
-        message: "Merged leading interlude onto lyric row",
-        data: {
-          mergedLineStart: line.startTimeMs,
-          leadingInterludeStart: leadingInterlude.startTimeMs,
-          originalIndex: index,
-          totalVisibleLines,
-        },
-      });
-      // #endregion
-    }
-
     return [
       {
         line,
         leadingInterlude,
         originalIndex: index,
-        totalVisibleLines,
+        totalVisibleLines: visibleLines.length,
       },
     ];
   });
@@ -326,23 +290,6 @@ export function applyKaraokeInterludeEllipsis({
     currentIndex,
     segmentStartMs
   );
-
-  // #region agent log
-  appendDebugLog({
-    hypothesisId: "A",
-    location: "src/utils/karaokeInterludeDisplay.ts:281",
-    message: "Created gap interlude placeholder",
-    data: {
-      alignment,
-      currentIndex,
-      currentLineStart: currentLine.startTimeMs,
-      nextLineStart: nextLine.startTimeMs,
-      visibleLines: visibleLines.map((line) => line.startTimeMs),
-      placeholderStart: placeholder.startTimeMs,
-      countdownStartMs: placeholder.countdownStartMs,
-    },
-  });
-  // #endregion
 
   if (alignment === LyricsAlignment.Center) {
     return [placeholder];

--- a/src/utils/karaokeInterludeDisplay.ts
+++ b/src/utils/karaokeInterludeDisplay.ts
@@ -166,9 +166,8 @@ export function isInterludePlaceholderLine(
 export function mergeLeadingInterludeWithNextLine(
   visibleLines: VisibleLyricLine[]
 ): RenderableVisibleLyricLine[] {
-  const totalVisibleLines = visibleLines.length;
-
-  return visibleLines.flatMap((line, index) => {
+  const mergedRows = visibleLines.flatMap((line, index) => {
+    const totalVisibleLines = visibleLines.length;
     const nextLine = visibleLines[index + 1];
     const previousLine = visibleLines[index - 1];
 
@@ -212,6 +211,13 @@ export function mergeLeadingInterludeWithNextLine(
       },
     ];
   });
+
+  const renderableTotalLines = mergedRows.length;
+  return mergedRows.map((row, renderIndex) => ({
+    ...row,
+    originalIndex: renderIndex,
+    totalVisibleLines: renderableTotalLines,
+  }));
 }
 
 /**

--- a/src/utils/karaokeInterludeDisplay.ts
+++ b/src/utils/karaokeInterludeDisplay.ts
@@ -11,6 +11,13 @@ export interface InterludePlaceholderLine {
 
 export type VisibleLyricLine = LyricLine | InterludePlaceholderLine;
 
+export interface RenderableVisibleLyricLine {
+  line: VisibleLyricLine;
+  leadingInterlude?: InterludePlaceholderLine;
+  originalIndex: number;
+  totalVisibleLines: number;
+}
+
 const MIN_LINE_HOLD_MS = 2500;
 const LONG_INTERLUDE_THRESHOLD_MS = 8000;
 const INTERLUDE_PLACEHOLDER_DELAY_MS = 2000;
@@ -131,6 +138,43 @@ export function isInterludePlaceholderLine(
   line: VisibleLyricLine
 ): line is InterludePlaceholderLine {
   return "isInterludePlaceholder" in line && line.isInterludePlaceholder === true;
+}
+
+/**
+ * Collapse a standalone interlude placeholder onto the following lyric row so the dots
+ * can render with the next lyric instead of taking a dedicated layout slot.
+ */
+export function mergeLeadingInterludeWithNextLine(
+  visibleLines: VisibleLyricLine[]
+): RenderableVisibleLyricLine[] {
+  const totalVisibleLines = visibleLines.length;
+
+  return visibleLines.flatMap((line, index) => {
+    const nextLine = visibleLines[index + 1];
+    const previousLine = visibleLines[index - 1];
+
+    if (
+      isInterludePlaceholderLine(line) &&
+      nextLine &&
+      !isInterludePlaceholderLine(nextLine)
+    ) {
+      return [];
+    }
+
+    return [
+      {
+        line,
+        leadingInterlude:
+          previousLine &&
+          isInterludePlaceholderLine(previousLine) &&
+          !isInterludePlaceholderLine(line)
+            ? previousLine
+            : undefined,
+        originalIndex: index,
+        totalVisibleLines,
+      },
+    ];
+  });
 }
 
 /**

--- a/src/utils/karaokeInterludeDisplay.ts
+++ b/src/utils/karaokeInterludeDisplay.ts
@@ -1,5 +1,24 @@
 import { LyricsAlignment, type LyricLine, type LyricWord } from "@/types/lyrics";
 
+type DebugLogPayload = {
+  hypothesisId: string;
+  location: string;
+  message: string;
+  data: Record<string, unknown>;
+};
+
+const appendDebugLog = (payload: DebugLogPayload) => {
+  if (typeof Bun === "undefined") return;
+  void Function("return import('node:fs')")()
+    .then(({ appendFileSync }: typeof import("node:fs")) => {
+      appendFileSync(
+        "/opt/cursor/logs/debug.log",
+        `${JSON.stringify({ ...payload, timestamp: Date.now() })}\n`
+      );
+    })
+    .catch(() => {});
+};
+
 export interface InterludePlaceholderLine {
   startTimeMs: string;
   words: string;
@@ -161,15 +180,33 @@ export function mergeLeadingInterludeWithNextLine(
       return [];
     }
 
+    const leadingInterlude =
+      previousLine &&
+      isInterludePlaceholderLine(previousLine) &&
+      !isInterludePlaceholderLine(line)
+        ? previousLine
+        : undefined;
+
+    if (leadingInterlude) {
+      // #region agent log
+      appendDebugLog({
+        hypothesisId: "A",
+        location: "src/utils/karaokeInterludeDisplay.ts:183",
+        message: "Merged leading interlude onto lyric row",
+        data: {
+          mergedLineStart: line.startTimeMs,
+          leadingInterludeStart: leadingInterlude.startTimeMs,
+          originalIndex: index,
+          totalVisibleLines,
+        },
+      });
+      // #endregion
+    }
+
     return [
       {
         line,
-        leadingInterlude:
-          previousLine &&
-          isInterludePlaceholderLine(previousLine) &&
-          !isInterludePlaceholderLine(line)
-            ? previousLine
-            : undefined,
+        leadingInterlude,
         originalIndex: index,
         totalVisibleLines,
       },
@@ -283,6 +320,23 @@ export function applyKaraokeInterludeEllipsis({
     currentIndex,
     segmentStartMs
   );
+
+  // #region agent log
+  appendDebugLog({
+    hypothesisId: "A",
+    location: "src/utils/karaokeInterludeDisplay.ts:281",
+    message: "Created gap interlude placeholder",
+    data: {
+      alignment,
+      currentIndex,
+      currentLineStart: currentLine.startTimeMs,
+      nextLineStart: nextLine.startTimeMs,
+      visibleLines: visibleLines.map((line) => line.startTimeMs),
+      placeholderStart: placeholder.startTimeMs,
+      countdownStartMs: placeholder.countdownStartMs,
+    },
+  });
+  // #endregion
 
   if (alignment === LyricsAlignment.Center) {
     return [placeholder];

--- a/tests/test-karaoke-interlude-display.test.ts
+++ b/tests/test-karaoke-interlude-display.test.ts
@@ -152,8 +152,8 @@ describe("karaoke interlude ellipsis", () => {
     expect(renderable).toHaveLength(1);
     expect(renderable[0]?.line).toBe(lines[1]);
     expect(renderable[0]?.leadingInterlude?.countdownStartMs).toBe(12000);
-    expect(renderable[0]?.originalIndex).toBe(1);
-    expect(renderable[0]?.totalVisibleLines).toBe(2);
+    expect(renderable[0]?.originalIndex).toBe(0);
+    expect(renderable[0]?.totalVisibleLines).toBe(1);
   });
 
   test("getInterludeDotsFadeOpacity rests dim then ramps to full at countdownStartMs", () => {

--- a/tests/test-karaoke-interlude-display.test.ts
+++ b/tests/test-karaoke-interlude-display.test.ts
@@ -6,6 +6,7 @@ import {
   buildInterludeLyricLineWithWordTimings,
   getInterludeDotsFadeOpacity,
   isInterludePlaceholderLine,
+  mergeLeadingInterludeWithNextLine,
 } from "../src/utils/karaokeInterludeDisplay";
 
 function makeLine(startTimeMs: number, words: string): LyricLine {
@@ -129,6 +130,30 @@ describe("karaoke interlude ellipsis", () => {
     expect(visible).toHaveLength(2);
     expect(isInterludePlaceholderLine(visible[0]!)).toBe(true);
     expect(visible[1]).toBe(lines[1]);
+  });
+
+  test("merges alternating placeholder dots onto the upcoming lyric row", () => {
+    const lines = [
+      makeLine(0, "Verse line"),
+      makeLine(15000, "Next line"),
+    ];
+
+    const visible = applyKaraokeInterludeEllipsis({
+      visibleLines: [lines[0], lines[1]],
+      allLines: lines,
+      alignment: LyricsAlignment.Alternating,
+      currentIndex: 0,
+      currentTimeMs: 5000,
+      enabled: true,
+    });
+
+    const renderable = mergeLeadingInterludeWithNextLine(visible);
+
+    expect(renderable).toHaveLength(1);
+    expect(renderable[0]?.line).toBe(lines[1]);
+    expect(renderable[0]?.leadingInterlude?.countdownStartMs).toBe(12000);
+    expect(renderable[0]?.originalIndex).toBe(1);
+    expect(renderable[0]?.totalVisibleLines).toBe(2);
   });
 
   test("getInterludeDotsFadeOpacity rests dim then ramps to full at countdownStartMs", () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- keep interlude lead dots attached to the following lyric row instead of rendering them as a separate animated row
- reindex merged alternating rows after the placeholder is collapsed so the lyric keeps the same rendered slot before and after the dots disappear
- add focused regression coverage for the merged alternating-row metadata

## Testing
- `bun test tests/test-karaoke-interlude-display.test.ts`
- `bun run build`
- manual browser verification in Karaoke alternating layout with built-in track `h4Q8r60ojSo`

## Walkthrough
[karaoke_alternating_lead_dots_stable.mp4](https://cursor.com/agents/bc-4cd0ba1e-a2d7-4259-b183-04d9253174fd/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fkaraoke_alternating_lead_dots_stable.mp4)
[Lead dots anchored in alternating interlude](https://cursor.com/agents/bc-4cd0ba1e-a2d7-4259-b183-04d9253174fd/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flead_dots_alternating_interlude.webp)
[Next lyric remains in the same slot after transition](https://cursor.com/agents/bc-4cd0ba1e-a2d7-4259-b183-04d9253174fd/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flead_dots_transition_stable.webp)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4cd0ba1e-a2d7-4259-b183-04d9253174fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4cd0ba1e-a2d7-4259-b183-04d9253174fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

