### PR TITLE
Animate chat text with pretext reveal

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -11,6 +11,7 @@
         "@ai-sdk/react": "^3.0.51",
         "@aws-sdk/client-s3": "^3.1004.0",
         "@aws-sdk/s3-request-presigner": "^3.1004.0",
+        "@chenglou/pretext": "^0.0.3",
         "@paper-design/shaders-react": "^0.0.71",
         "@phosphor-icons/react": "^2.1.10",
         "@radix-ui/react-checkbox": "^1.3.3",
@@ -406,6 +407,8 @@
     "@babel/types": ["@babel/types@7.27.6", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.27.1" } }, "sha512-ETyHEk2VHHvl9b9jZP5IHPavHYk57EhanlRRuae9XCpb/j5bDCbPPMOBfCWhnl/7EDJz0jEMCi/RhccCE8r1+Q=="],
 
     "@borewit/text-codec": ["@borewit/text-codec@0.2.1", "", {}, "sha512-k7vvKPbf7J2fZ5klGRD9AeKfUvojuZIQ3BT5u7Jfv+puwXkUBUT5PVyMDfJZpy30CBDXGMgw7fguK/lpOMBvgw=="],
+
+    "@chenglou/pretext": ["@chenglou/pretext@0.0.3", "", {}, "sha512-RQmqMqUAPRCyv4R3LlRi/ao6KbNWYclqLA+V1HS7sWgyUUbjn3JmmlfXZSY/BjM4rbmIaMSyIVisYocYGYftiQ=="],
 
     "@cspotcode/source-map-support": ["@cspotcode/source-map-support@0.8.1", "", { "dependencies": { "@jridgewell/trace-mapping": "0.3.9" } }, "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw=="],
 

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "@ai-sdk/react": "^3.0.51",
     "@aws-sdk/client-s3": "^3.1004.0",
     "@aws-sdk/s3-request-presigner": "^3.1004.0",
+    "@chenglou/pretext": "^0.0.3",
     "@paper-design/shaders-react": "^0.0.71",
     "@phosphor-icons/react": "^2.1.10",
     "@radix-ui/react-checkbox": "^1.3.3",

--- a/src/apps/chats/components/ChatMessages.tsx
+++ b/src/apps/chats/components/ChatMessages.tsx
@@ -1,6 +1,14 @@
 import { UIMessage as VercelMessage } from "@ai-sdk/react";
 import { WarningCircle, ChatCircle, Copy, Check, CaretDown, Trash, SpeakerHigh, Pause, PaperPlaneRight } from "@phosphor-icons/react";
-import { useEffect, useRef, useState, memo } from "react";
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  memo,
+} from "react";
 import { Button } from "@/components/ui/button";
 import { ActivityIndicator } from "@/components/ui/activity-indicator";
 import { AnimatePresence, motion } from "framer-motion";
@@ -32,7 +40,15 @@ import i18n from "@/lib/i18n";
 import { abortableFetch } from "@/utils/abortableFetch";
 import { decodeHtmlEntities } from "@/utils/decodeHtmlEntities";
 import { formatToolName } from "@/lib/toolInvocationDisplay";
-import { segmentChatMarkdownText, type ChatMarkdownToken } from "@/lib/chatMarkdown";
+import {
+  coalesceChatMarkdownTokens,
+  segmentChatMarkdownText,
+  type ChatMarkdownToken,
+} from "@/lib/chatMarkdown";
+import {
+  estimateChatTextLineCount,
+  shouldAnimateAssistantTokens,
+} from "@/apps/chats/utils/chatTextLayout";
 
 // Helper to extract image URLs from message parts
 const extractImageParts = (message: {
@@ -292,6 +308,154 @@ function ScrollToBottomButton() {
   );
 }
 
+interface AssistantTextPartProps {
+  partKey: string;
+  textContent: string;
+  isInitialMessage: boolean;
+  fontSize: number;
+  activeHighlightSegment: { start: number; end: number } | null;
+  renderInlineToken: (segment: ChatMarkdownToken) => React.ReactNode;
+  playNote: () => void;
+}
+
+const AssistantTextPart = memo(function AssistantTextPart({
+  partKey,
+  textContent,
+  isInitialMessage,
+  fontSize,
+  activeHighlightSegment,
+  renderInlineToken,
+  playNote,
+}: AssistantTextPartProps) {
+  const contentRef = useRef<HTMLDivElement | null>(null);
+  const [contentWidth, setContentWidth] = useState(0);
+
+  const trimmedText = textContent.trim();
+  const emojiOnly = useMemo(() => isEmojiOnly(trimmedText), [trimmedText]);
+  const tokens = useMemo(() => segmentChatMarkdownText(trimmedText), [trimmedText]);
+  const groupedTokens = useMemo(() => coalesceChatMarkdownTokens(tokens), [tokens]);
+  const visibleText = useMemo(
+    () => tokens.map((token) => token.content).join(""),
+    [tokens]
+  );
+  const lineCount = useMemo(
+    () => estimateChatTextLineCount(visibleText, fontSize, contentWidth),
+    [visibleText, fontSize, contentWidth]
+  );
+  const animateTokens = useMemo(
+    () =>
+      shouldAnimateAssistantTokens({
+        tokenCount: tokens.length,
+        textLength: visibleText.length,
+        lineCount,
+      }),
+    [tokens.length, visibleText.length, lineCount]
+  );
+  const renderedTokens = animateTokens ? tokens : groupedTokens;
+
+  useLayoutEffect(() => {
+    const node = contentRef.current;
+    if (!node || typeof ResizeObserver === "undefined") {
+      return;
+    }
+
+    const updateWidth = (width: number) => {
+      setContentWidth((previousWidth) =>
+        Math.abs(previousWidth - width) < 0.5 ? previousWidth : width
+      );
+    };
+
+    updateWidth(node.getBoundingClientRect().width);
+
+    const observer = new ResizeObserver((entries) => {
+      const entry = entries[0];
+      if (!entry) {
+        return;
+      }
+
+      updateWidth(entry.contentRect.width);
+    });
+
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, [fontSize]);
+
+  if (!trimmedText) {
+    return null;
+  }
+
+  let charPos = 0;
+
+  return (
+    <div className="w-full">
+      <div ref={contentRef} className="whitespace-pre-wrap">
+        {renderedTokens.map((segment, idx) => {
+          const start = charPos;
+          const end = charPos + segment.content.length;
+          charPos = end;
+          const isHighlight =
+            !!activeHighlightSegment &&
+            start < activeHighlightSegment.end &&
+            end > activeHighlightSegment.start;
+          const contentNode = isHighlight ? (
+            <span className="animate-highlight">{renderInlineToken(segment)}</span>
+          ) : (
+            renderInlineToken(segment)
+          );
+
+          const className = `select-text ${
+            emojiOnly ? "text-[24px]" : ""
+          } ${
+            segment.type === "bold"
+              ? "font-bold"
+              : segment.type === "italic"
+              ? "italic"
+              : ""
+          }`;
+          const style = {
+            userSelect: "text" as const,
+            fontSize: emojiOnly ? undefined : `${fontSize}px`,
+          };
+
+          if (!animateTokens) {
+            return (
+              <span
+                key={`${partKey}-segment-${idx}`}
+                className={className}
+                style={style}
+              >
+                {contentNode}
+              </span>
+            );
+          }
+
+          return (
+            <motion.span
+              key={`${partKey}-segment-${idx}`}
+              initial={
+                isInitialMessage ? { opacity: 1, y: 0 } : { opacity: 0, y: 12 }
+              }
+              animate={{ opacity: 1, y: 0 }}
+              className={className}
+              style={style}
+              transition={{
+                duration: 0.08,
+                delay: idx * 0.02,
+                ease: "easeOut",
+                onComplete: () => {
+                  if (idx % 2 === 0) playNote();
+                },
+              }}
+            >
+              {contentNode}
+            </motion.span>
+          );
+        })}
+      </div>
+    </div>
+  );
+});
+
 // Memoized chat message item - extracted for list rendering performance
 interface ChatMessageItemProps {
   message: ChatMessage;
@@ -418,6 +582,12 @@ const ChatMessageItem = memo(function ChatMessageItem(props: ChatMessageItemProp
     combinedIsSpeaking &&
     combinedHighlightSeg &&
     combinedHighlightSeg.messageId === message.id;
+  const activeHighlightSegment = highlightActive
+    ? {
+        start: combinedHighlightSeg.start,
+        end: combinedHighlightSeg.end,
+      }
+    : null;
 
   const isTouchDevice = () =>
     "ontouchstart" in window || navigator.maxTouchPoints > 0;
@@ -430,7 +600,15 @@ const ChatMessageItem = memo(function ChatMessageItem(props: ChatMessageItemProp
     return Array.from(urls);
   };
 
-  const renderInlineToken = (segment: ChatMarkdownToken) => {
+  const displayTokens = useMemo(
+    () =>
+      displayContent
+        ? coalesceChatMarkdownTokens(segmentChatMarkdownText(displayContent))
+        : [],
+    [displayContent]
+  );
+
+  const renderInlineToken = useCallback((segment: ChatMarkdownToken) => {
     const tokenNode =
       (segment.type === "link" || segment.type === "citation") && segment.url ? (
         <a
@@ -477,7 +655,7 @@ const ChatMessageItem = memo(function ChatMessageItem(props: ChatMessageItemProp
         segment.content
       );
     return tokenNode;
-  };
+  }, [isUrgent]);
 
   return (
     <motion.div
@@ -884,66 +1062,16 @@ const ChatMessageItem = memo(function ChatMessageItem(props: ChatMessageItemProp
                       const partDisplayContent = decodeHtmlEntities(rawPartContent);
                       const textContent = partDisplayContent;
                       return (
-                        <div key={partKey} className="w-full">
-                          <div className="whitespace-pre-wrap">
-                            {textContent &&
-                              (() => {
-                                const tokens = segmentChatMarkdownText(textContent.trim());
-                                let charPos = 0;
-                                return tokens.map((segment, idx) => {
-                                  const start = charPos;
-                                  const end = charPos + segment.content.length;
-                                  charPos = end;
-                                  return (
-                                    <motion.span
-                                      key={`${partKey}-segment-${idx}`}
-                                      initial={
-                                        isInitialMessage
-                                          ? { opacity: 1, y: 0 }
-                                          : { opacity: 0, y: 12 }
-                                      }
-                                      animate={{ opacity: 1, y: 0 }}
-                                      className={`select-text ${
-                                        isEmojiOnly(textContent)
-                                          ? "text-[24px]"
-                                          : ""
-                                      } ${
-                                        segment.type === "bold"
-                                          ? "font-bold"
-                                          : segment.type === "italic"
-                                          ? "italic"
-                                          : ""
-                                      }`}
-                                      style={{
-                                        userSelect: "text",
-                                        fontSize: isEmojiOnly(textContent)
-                                          ? undefined
-                                          : `${fontSize}px`,
-                                      }}
-                                      transition={{
-                                        duration: 0.08,
-                                        delay: idx * 0.02,
-                                        ease: "easeOut",
-                                        onComplete: () => {
-                                          if (idx % 2 === 0) playNote();
-                                        },
-                                      }}
-                                    >
-                                      {highlightActive &&
-                                      start < (combinedHighlightSeg?.end ?? 0) &&
-                                      end > (combinedHighlightSeg?.start ?? 0) ? (
-                                        <span className="animate-highlight">
-                                          {renderInlineToken(segment)}
-                                        </span>
-                                      ) : (
-                                        renderInlineToken(segment)
-                                      )}
-                                    </motion.span>
-                                  );
-                                });
-                              })()}
-                          </div>
-                        </div>
+                        <AssistantTextPart
+                          key={partKey}
+                          partKey={partKey}
+                          textContent={textContent}
+                          isInitialMessage={isInitialMessage}
+                          fontSize={fontSize}
+                          activeHighlightSegment={activeHighlightSegment}
+                          renderInlineToken={renderInlineToken}
+                          playNote={playNote}
+                        />
                       );
                     }
                     default: {
@@ -989,16 +1117,15 @@ const ChatMessageItem = memo(function ChatMessageItem(props: ChatMessageItemProp
                   }}
                 >
                   {(() => {
-                    const tokens = segmentChatMarkdownText(displayContent);
                     let charPos2 = 0;
-                    return tokens.map((segment, idx) => {
+                    return displayTokens.map((segment, idx) => {
                       const start2 = charPos2;
                       const end2 = charPos2 + segment.content.length;
                       charPos2 = end2;
                       const isHighlight =
-                        highlightActive &&
-                        start2 < (combinedHighlightSeg?.end ?? 0) &&
-                        end2 > (combinedHighlightSeg?.start ?? 0);
+                        !!activeHighlightSegment &&
+                        start2 < activeHighlightSegment.end &&
+                        end2 > activeHighlightSegment.start;
                       const contentNode = renderInlineToken(segment);
                       return (
                         <span

--- a/src/apps/chats/components/ChatMessages.tsx
+++ b/src/apps/chats/components/ChatMessages.tsx
@@ -46,8 +46,9 @@ import {
   type ChatMarkdownToken,
 } from "@/lib/chatMarkdown";
 import {
-  estimateChatTextLineCount,
-  shouldAnimateAssistantTokens,
+  getChatTextLayoutInfo,
+  getChatTextRevealDurationMs,
+  shouldUseDetailedAssistantTokens,
 } from "@/apps/chats/utils/chatTextLayout";
 
 // Helper to extract image URLs from message parts
@@ -318,6 +319,29 @@ interface AssistantTextPartProps {
   playNote: () => void;
 }
 
+interface AssistantRenderedToken {
+  segment: ChatMarkdownToken;
+  start: number;
+  end: number;
+}
+
+function countRevealedLines(lineEnds: number[], revealedChars: number): number {
+  if (revealedChars <= 0 || lineEnds.length === 0) {
+    return 0;
+  }
+
+  let revealedLines = 0;
+  for (const lineEnd of lineEnds) {
+    if (revealedChars >= lineEnd) {
+      revealedLines += 1;
+      continue;
+    }
+    break;
+  }
+
+  return revealedLines;
+}
+
 const AssistantTextPart = memo(function AssistantTextPart({
   partKey,
   textContent,
@@ -329,29 +353,43 @@ const AssistantTextPart = memo(function AssistantTextPart({
 }: AssistantTextPartProps) {
   const contentRef = useRef<HTMLDivElement | null>(null);
   const [contentWidth, setContentWidth] = useState(0);
+  const [revealedChars, setRevealedChars] = useState(
+    isInitialMessage ? Number.MAX_SAFE_INTEGER : 0
+  );
+  const previousVisibleLengthRef = useRef(0);
+  const revealTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const trimmedText = textContent.trim();
   const emojiOnly = useMemo(() => isEmojiOnly(trimmedText), [trimmedText]);
   const tokens = useMemo(() => segmentChatMarkdownText(trimmedText), [trimmedText]);
-  const groupedTokens = useMemo(() => coalesceChatMarkdownTokens(tokens), [tokens]);
   const visibleText = useMemo(
     () => tokens.map((token) => token.content).join(""),
     [tokens]
   );
-  const lineCount = useMemo(
-    () => estimateChatTextLineCount(visibleText, fontSize, contentWidth),
+  const layoutInfo = useMemo(
+    () => getChatTextLayoutInfo(visibleText, fontSize, contentWidth),
     [visibleText, fontSize, contentWidth]
   );
-  const animateTokens = useMemo(
+  const lineCount = layoutInfo?.lineCount ?? null;
+  const useDetailedTokens = useMemo(
     () =>
-      shouldAnimateAssistantTokens({
+      shouldUseDetailedAssistantTokens({
         tokenCount: tokens.length,
         textLength: visibleText.length,
         lineCount,
       }),
     [tokens.length, visibleText.length, lineCount]
   );
-  const renderedTokens = animateTokens ? tokens : groupedTokens;
+  const renderedTokens = useMemo<AssistantRenderedToken[]>(() => {
+    const baseTokens = useDetailedTokens ? tokens : coalesceChatMarkdownTokens(tokens);
+    let charPos = 0;
+    return baseTokens.map((segment) => {
+      const start = charPos;
+      const end = charPos + segment.content.length;
+      charPos = end;
+      return { segment, start, end };
+    });
+  }, [tokens, useDetailedTokens]);
 
   useLayoutEffect(() => {
     const node = contentRef.current;
@@ -380,23 +418,75 @@ const AssistantTextPart = memo(function AssistantTextPart({
     return () => observer.disconnect();
   }, [fontSize]);
 
+  useEffect(() => {
+    if (revealTimerRef.current) {
+      clearTimeout(revealTimerRef.current);
+      revealTimerRef.current = null;
+    }
+
+    if (isInitialMessage) {
+      previousVisibleLengthRef.current = visibleText.length;
+      setRevealedChars(Number.MAX_SAFE_INTEGER);
+      return;
+    }
+
+    const previousLength = previousVisibleLengthRef.current;
+    const nextLength = visibleText.length;
+    const normalizedPrevious = Math.min(previousLength, nextLength);
+    previousVisibleLengthRef.current = nextLength;
+
+    if (nextLength <= 0) {
+      setRevealedChars(0);
+      return;
+    }
+
+    if (nextLength <= normalizedPrevious) {
+      setRevealedChars(nextLength);
+      return;
+    }
+
+    const revealedLineCountBefore = countRevealedLines(
+      layoutInfo?.lineEnds ?? [],
+      normalizedPrevious
+    );
+    const revealedLineCountAfter = countRevealedLines(
+      layoutInfo?.lineEnds ?? [],
+      nextLength
+    );
+
+    setRevealedChars(normalizedPrevious);
+    revealTimerRef.current = setTimeout(() => {
+      setRevealedChars(nextLength);
+      if (nextLength > normalizedPrevious) {
+        playNote();
+      }
+      revealTimerRef.current = null;
+    }, getChatTextRevealDurationMs(
+      nextLength - normalizedPrevious,
+      Math.max(1, revealedLineCountAfter - revealedLineCountBefore)
+    ));
+
+    return () => {
+      if (revealTimerRef.current) {
+        clearTimeout(revealTimerRef.current);
+        revealTimerRef.current = null;
+      }
+    };
+  }, [isInitialMessage, layoutInfo?.lineEnds, playNote, visibleText]);
+
   if (!trimmedText) {
     return null;
   }
 
-  let charPos = 0;
-
   return (
     <div className="w-full">
       <div ref={contentRef} className="whitespace-pre-wrap">
-        {renderedTokens.map((segment, idx) => {
-          const start = charPos;
-          const end = charPos + segment.content.length;
-          charPos = end;
+        {renderedTokens.map(({ segment, start, end }, idx) => {
           const isHighlight =
             !!activeHighlightSegment &&
             start < activeHighlightSegment.end &&
             end > activeHighlightSegment.start;
+          const hidden = end > revealedChars;
           const contentNode = isHighlight ? (
             <span className="animate-highlight">{renderInlineToken(segment)}</span>
           ) : (
@@ -416,39 +506,17 @@ const AssistantTextPart = memo(function AssistantTextPart({
             userSelect: "text" as const,
             fontSize: emojiOnly ? undefined : `${fontSize}px`,
           };
-
-          if (!animateTokens) {
-            return (
-              <span
-                key={`${partKey}-segment-${idx}`}
-                className={className}
-                style={style}
-              >
-                {contentNode}
-              </span>
-            );
-          }
-
           return (
-            <motion.span
+            <span
               key={`${partKey}-segment-${idx}`}
-              initial={
-                isInitialMessage ? { opacity: 1, y: 0 } : { opacity: 0, y: 12 }
-              }
-              animate={{ opacity: 1, y: 0 }}
               className={className}
-              style={style}
-              transition={{
-                duration: 0.08,
-                delay: idx * 0.02,
-                ease: "easeOut",
-                onComplete: () => {
-                  if (idx % 2 === 0) playNote();
-                },
+              style={{
+                ...style,
+                visibility: hidden ? "hidden" : "visible",
               }}
             >
               {contentNode}
-            </motion.span>
+            </span>
           );
         })}
       </div>
@@ -1019,7 +1087,7 @@ const ChatMessageItem = memo(function ChatMessageItem(props: ChatMessageItemProp
           {showTypingDots ? (
             <TypingDots />
           ) : message.role === "assistant" ? (
-            <motion.div className="select-text flex flex-col gap-1">
+            <div className="select-text flex flex-col gap-1">
               {message.parts?.map(
                 (
                   part: ToolInvocationPart | { type: string; text?: string },
@@ -1044,15 +1112,12 @@ const ChatMessageItem = memo(function ChatMessageItem(props: ChatMessageItemProp
                         ).length;
                         if (openTags !== closeTags) {
                           return (
-                            <motion.span
+                            <span
                               key={partKey}
-                              initial={{ opacity: 1 }}
-                              animate={{ opacity: 1 }}
-                              transition={{ duration: 0 }}
                               className="select-text italic"
                             >
                               {t("apps.chats.status.editing")}
-                            </motion.span>
+                            </span>
                           );
                         }
                       }
@@ -1101,7 +1166,7 @@ const ChatMessageItem = memo(function ChatMessageItem(props: ChatMessageItemProp
                   }
                 }
               )}
-            </motion.div>
+            </div>
           ) : (
             <>
               {displayContent && (

--- a/src/apps/chats/utils/chatTextLayout.ts
+++ b/src/apps/chats/utils/chatTextLayout.ts
@@ -1,0 +1,79 @@
+import { layout, prepare, type PreparedText } from "@chenglou/pretext";
+
+const PREPARED_TEXT_CACHE_LIMIT = 200;
+const preparedTextCache = new Map<string, PreparedText>();
+const CHAT_TEXT_LINE_HEIGHT_RATIO = 1.375;
+
+export interface AssistantTokenAnimationInput {
+  tokenCount: number;
+  textLength: number;
+  lineCount?: number | null;
+}
+
+function setPreparedTextCache(key: string, prepared: PreparedText): PreparedText {
+  preparedTextCache.set(key, prepared);
+  if (preparedTextCache.size > PREPARED_TEXT_CACHE_LIMIT) {
+    const oldestKey = preparedTextCache.keys().next().value;
+    if (oldestKey !== undefined) {
+      preparedTextCache.delete(oldestKey);
+    }
+  }
+  return prepared;
+}
+
+export function getChatTextFont(fontSize: number): string {
+  return `${fontSize}px "Geneva-12"`;
+}
+
+export function getChatTextLineHeight(fontSize: number): number {
+  return Math.max(fontSize + 2, Math.round(fontSize * CHAT_TEXT_LINE_HEIGHT_RATIO));
+}
+
+export function estimateChatTextLineCount(
+  text: string,
+  fontSize: number,
+  maxWidth: number
+): number | null {
+  if (!text || maxWidth <= 0) {
+    return null;
+  }
+
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  const font = getChatTextFont(fontSize);
+  const cacheKey = `${font}\u0000${text}`;
+  const prepared =
+    preparedTextCache.get(cacheKey) ??
+    setPreparedTextCache(
+      cacheKey,
+      prepare(text, font, {
+        whiteSpace: "pre-wrap",
+      })
+    );
+
+  return layout(prepared, maxWidth, getChatTextLineHeight(fontSize)).lineCount;
+}
+
+export function shouldAnimateAssistantTokens({
+  tokenCount,
+  textLength,
+  lineCount,
+}: AssistantTokenAnimationInput): boolean {
+  if (tokenCount === 0 || textLength === 0) {
+    return false;
+  }
+
+  // Per-token motion looks best on short replies, but long streaming replies
+  // create too many motion nodes and animation timelines.
+  if (textLength > 320 || tokenCount > 90) {
+    return false;
+  }
+
+  if (lineCount !== null && lineCount !== undefined && lineCount > 7) {
+    return false;
+  }
+
+  return true;
+}

--- a/src/apps/chats/utils/chatTextLayout.ts
+++ b/src/apps/chats/utils/chatTextLayout.ts
@@ -1,16 +1,29 @@
-import { layout, prepare, type PreparedText } from "@chenglou/pretext";
+import {
+  layoutWithLines,
+  prepareWithSegments,
+  type PreparedTextWithSegments,
+} from "@chenglou/pretext";
 
 const PREPARED_TEXT_CACHE_LIMIT = 200;
-const preparedTextCache = new Map<string, PreparedText>();
+const preparedTextCache = new Map<string, PreparedTextWithSegments>();
 const CHAT_TEXT_LINE_HEIGHT_RATIO = 1.375;
 
-export interface AssistantTokenAnimationInput {
+export interface AssistantTextAnimationInput {
   tokenCount: number;
   textLength: number;
   lineCount?: number | null;
 }
 
-function setPreparedTextCache(key: string, prepared: PreparedText): PreparedText {
+export interface ChatTextLayoutInfo {
+  lineCount: number;
+  lineEnds: number[];
+  totalChars: number;
+}
+
+function setPreparedTextCache(
+  key: string,
+  prepared: PreparedTextWithSegments
+): PreparedTextWithSegments {
   preparedTextCache.set(key, prepared);
   if (preparedTextCache.size > PREPARED_TEXT_CACHE_LIMIT) {
     const oldestKey = preparedTextCache.keys().next().value;
@@ -29,16 +42,36 @@ export function getChatTextLineHeight(fontSize: number): number {
   return Math.max(fontSize + 2, Math.round(fontSize * CHAT_TEXT_LINE_HEIGHT_RATIO));
 }
 
-export function estimateChatTextLineCount(
+export function buildChatTextLineEnds(
+  lineTexts: string[],
+  totalChars: number
+): number[] {
+  let charPos = 0;
+  const lineEnds: number[] = [];
+
+  for (const lineText of lineTexts) {
+    charPos += lineText.length;
+    lineEnds.push(Math.min(totalChars, charPos));
+  }
+
+  if (lineEnds.length === 0 && totalChars > 0) {
+    return [totalChars];
+  }
+
+  const lastLineEnd = lineEnds.at(-1) ?? 0;
+  if (lastLineEnd < totalChars) {
+    lineEnds.push(totalChars);
+  }
+
+  return lineEnds;
+}
+
+export function getChatTextLayoutInfo(
   text: string,
   fontSize: number,
   maxWidth: number
-): number | null {
-  if (!text || maxWidth <= 0) {
-    return null;
-  }
-
-  if (typeof window === "undefined") {
+): ChatTextLayoutInfo | null {
+  if (!text || maxWidth <= 0 || typeof window === "undefined") {
     return null;
   }
 
@@ -48,19 +81,43 @@ export function estimateChatTextLineCount(
     preparedTextCache.get(cacheKey) ??
     setPreparedTextCache(
       cacheKey,
-      prepare(text, font, {
+      prepareWithSegments(text, font, {
         whiteSpace: "pre-wrap",
       })
     );
 
-  return layout(prepared, maxWidth, getChatTextLineHeight(fontSize)).lineCount;
+  const { lineCount, lines } = layoutWithLines(
+    prepared,
+    maxWidth,
+    getChatTextLineHeight(fontSize)
+  );
+
+  return {
+    lineCount,
+    lineEnds: buildChatTextLineEnds(
+      lines.map((line) => line.text),
+      text.length
+    ),
+    totalChars: text.length,
+  };
 }
 
-export function shouldAnimateAssistantTokens({
+export function getChatTextRevealDurationMs(
+  charDelta: number,
+  crossedLineCount: number
+): number {
+  if (charDelta <= 0) {
+    return 0;
+  }
+
+  return Math.max(120, Math.min(700, charDelta * 8 + crossedLineCount * 70));
+}
+
+export function shouldUseDetailedAssistantTokens({
   tokenCount,
   textLength,
   lineCount,
-}: AssistantTokenAnimationInput): boolean {
+}: AssistantTextAnimationInput): boolean {
   if (tokenCount === 0 || textLength === 0) {
     return false;
   }

--- a/src/lib/chatMarkdown.ts
+++ b/src/lib/chatMarkdown.ts
@@ -4,6 +4,10 @@ export type ChatMarkdownToken = {
   url?: string;
 };
 
+const TOKEN_CACHE_LIMIT = 500;
+const inlineTokenCache = new Map<string, ChatMarkdownToken[]>();
+const segmentedTokenCache = new Map<string, ChatMarkdownToken[]>();
+
 const PARENTHESIZED_MARKDOWN_LINK_RE =
   /^\(\[([^\]]+?)\]\((https?:\/\/[^\s]+?)\)\)/u;
 const MARKDOWN_LINK_RE = /^\[([^\]]+?)\]\((https?:\/\/[^\s]+?)\)/u;
@@ -53,7 +57,22 @@ function splitTrailingUrlPunctuation(rawUrl: string): {
   return { url, trailing };
 }
 
-export function parseChatMarkdownInline(text: string): ChatMarkdownToken[] {
+function setCachedTokens(
+  cache: Map<string, ChatMarkdownToken[]>,
+  key: string,
+  value: ChatMarkdownToken[]
+): ChatMarkdownToken[] {
+  cache.set(key, value);
+  if (cache.size > TOKEN_CACHE_LIMIT) {
+    const oldestKey = cache.keys().next().value;
+    if (oldestKey !== undefined) {
+      cache.delete(oldestKey);
+    }
+  }
+  return value;
+}
+
+function parseChatMarkdownInlineUncached(text: string): ChatMarkdownToken[] {
   const tokens: ChatMarkdownToken[] = [];
   let remaining = text;
 
@@ -129,7 +148,16 @@ export function parseChatMarkdownInline(text: string): ChatMarkdownToken[] {
   return tokens;
 }
 
-export function segmentChatMarkdownText(text: string): ChatMarkdownToken[] {
+export function parseChatMarkdownInline(text: string): ChatMarkdownToken[] {
+  const cached = inlineTokenCache.get(text);
+  if (cached) {
+    return cached;
+  }
+
+  return setCachedTokens(inlineTokenCache, text, parseChatMarkdownInlineUncached(text));
+}
+
+function segmentChatMarkdownTextUncached(text: string): ChatMarkdownToken[] {
   return text.split(/(\n)/).flatMap((segment) => {
     if (segment === "\n") {
       return [{ type: "text", content: "\n" }];
@@ -137,4 +165,37 @@ export function segmentChatMarkdownText(text: string): ChatMarkdownToken[] {
 
     return parseChatMarkdownInline(segment);
   });
+}
+
+export function segmentChatMarkdownText(text: string): ChatMarkdownToken[] {
+  const cached = segmentedTokenCache.get(text);
+  if (cached) {
+    return cached;
+  }
+
+  return setCachedTokens(segmentedTokenCache, text, segmentChatMarkdownTextUncached(text));
+}
+
+export function coalesceChatMarkdownTokens(
+  tokens: ChatMarkdownToken[]
+): ChatMarkdownToken[] {
+  const merged: ChatMarkdownToken[] = [];
+
+  for (const token of tokens) {
+    const previous = merged.at(-1);
+    const canMerge =
+      previous &&
+      previous.type === token.type &&
+      previous.type !== "link" &&
+      previous.type !== "citation";
+
+    if (canMerge) {
+      previous.content += token.content;
+      continue;
+    }
+
+    merged.push({ ...token });
+  }
+
+  return merged;
 }

--- a/tests/test-chat-markdown.test.ts
+++ b/tests/test-chat-markdown.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import {
+  coalesceChatMarkdownTokens,
   parseChatMarkdownInline,
   segmentChatMarkdownText,
 } from "../src/lib/chatMarkdown";
@@ -72,6 +73,22 @@ describe("chat markdown parsing", () => {
         content: "source",
         url: "https://example.com",
       },
+    ]);
+  });
+
+  test("coalesces adjacent plain text tokens without merging links", () => {
+    const tokens = segmentChatMarkdownText(
+      "see [the article](https://example.com/story) please"
+    );
+
+    expect(coalesceChatMarkdownTokens(tokens)).toEqual([
+      { type: "text", content: "see " },
+      {
+        type: "link",
+        content: "the article",
+        url: "https://example.com/story",
+      },
+      { type: "text", content: " please" },
     ]);
   });
 });

--- a/tests/test-chat-text-layout.test.ts
+++ b/tests/test-chat-text-layout.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, test } from "bun:test";
 import {
+  buildChatTextLineEnds,
   getChatTextFont,
   getChatTextLineHeight,
-  shouldAnimateAssistantTokens,
+  shouldUseDetailedAssistantTokens,
 } from "../src/apps/chats/utils/chatTextLayout";
 
 describe("chat text layout heuristics", () => {
@@ -17,7 +18,7 @@ describe("chat text layout heuristics", () => {
 
   test("keeps per-token animation for short replies", () => {
     expect(
-      shouldAnimateAssistantTokens({
+      shouldUseDetailedAssistantTokens({
         tokenCount: 24,
         textLength: 120,
         lineCount: 4,
@@ -27,7 +28,7 @@ describe("chat text layout heuristics", () => {
 
   test("disables per-token animation for long replies", () => {
     expect(
-      shouldAnimateAssistantTokens({
+      shouldUseDetailedAssistantTokens({
         tokenCount: 120,
         textLength: 480,
         lineCount: 10,
@@ -37,11 +38,16 @@ describe("chat text layout heuristics", () => {
 
   test("disables per-token animation when line count is high", () => {
     expect(
-      shouldAnimateAssistantTokens({
+      shouldUseDetailedAssistantTokens({
         tokenCount: 40,
         textLength: 180,
         lineCount: 8,
       })
     ).toBe(false);
+  });
+
+  test("builds reveal line ends from pretext line text", () => {
+    expect(buildChatTextLineEnds(["hello", " world"], 11)).toEqual([5, 11]);
+    expect(buildChatTextLineEnds([], 4)).toEqual([4]);
   });
 });

--- a/tests/test-chat-text-layout.test.ts
+++ b/tests/test-chat-text-layout.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from "bun:test";
+import {
+  getChatTextFont,
+  getChatTextLineHeight,
+  shouldAnimateAssistantTokens,
+} from "../src/apps/chats/utils/chatTextLayout";
+
+describe("chat text layout heuristics", () => {
+  test("returns the Geneva chat font shorthand", () => {
+    expect(getChatTextFont(12)).toBe('12px "Geneva-12"');
+  });
+
+  test("returns a stable chat line height", () => {
+    expect(getChatTextLineHeight(12)).toBe(17);
+    expect(getChatTextLineHeight(16)).toBe(22);
+  });
+
+  test("keeps per-token animation for short replies", () => {
+    expect(
+      shouldAnimateAssistantTokens({
+        tokenCount: 24,
+        textLength: 120,
+        lineCount: 4,
+      })
+    ).toBe(true);
+  });
+
+  test("disables per-token animation for long replies", () => {
+    expect(
+      shouldAnimateAssistantTokens({
+        tokenCount: 120,
+        textLength: 480,
+        lineCount: 10,
+      })
+    ).toBe(false);
+  });
+
+  test("disables per-token animation when line count is high", () => {
+    expect(
+      shouldAnimateAssistantTokens({
+        tokenCount: 40,
+        textLength: 180,
+        lineCount: 8,
+      })
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add `@chenglou/pretext`-driven line layout and reveal timing for assistant chat text so the text animation no longer depends on per-token `framer-motion` spans
- keep the markdown tokenization cache/coalescing so assistant text can still render rich inline formatting efficiently while revealing via pretext-derived character/line progress
- retain the rest of the chat UI structure and fallback rendering, while replacing the assistant text hot path with a plain React reveal based on precomputed layout information

## Testing
- `bun test tests/test-chat-markdown.test.ts tests/test-chat-text-layout.test.ts`
- `bun run build`
- browser validation of the Chats UI on a fresh client confirmed the app loads and the Chats app opens; manual generation of new assistant replies was blocked by the local anonymous rate limit on the existing API server, so runtime validation focused on build/test correctness and UI load behavior
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7a55320c-c273-4a92-9c78-143ee9ceb6df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7a55320c-c273-4a92-9c78-143ee9ceb6df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

