### PR TITLE
fix(karaoke): show next lyric during center-mode interlude dots

### DIFF
--- a/src/apps/ipod/components/LyricsDisplay.tsx
+++ b/src/apps/ipod/components/LyricsDisplay.tsx
@@ -39,6 +39,7 @@ import { parseLyricTimestamps, findCurrentLineIndex } from "@/utils/lyricsSearch
 import {
   applyKaraokeInterludeEllipsis,
   buildInterludeLyricLineWithWordTimings,
+  getGapInterludeInlineLead,
   getIntroInterludeInlineLead,
   getInterludeDotsFadeOpacity,
   isInterludePlaceholderLine,
@@ -2216,6 +2217,21 @@ export function LyricsDisplay({
     [alignment, showInterludeEllipsis, actualCurrentLine, displayOriginalLines, currentTimeMs]
   );
 
+  const gapInterludeInlineLead = useMemo(
+    () =>
+      alignment === LyricsAlignment.Alternating &&
+      showInterludeEllipsis &&
+      actualCurrentLine >= 0
+        ? getGapInterludeInlineLead(
+            displayOriginalLines,
+            actualCurrentLine,
+            currentTimeMs,
+            showInterludeEllipsis
+          )
+        : null,
+    [alignment, showInterludeEllipsis, actualCurrentLine, displayOriginalLines, currentTimeMs]
+  );
+
   // Track touch start position and accumulated movement
   const touchStartRef = useRef<{ x: number; y: number; time: number } | null>(null);
   const accumulatedDeltaRef = useRef<{ x: number; y: number }>({ x: 0, y: 0 });
@@ -2415,22 +2431,28 @@ export function LyricsDisplay({
           const prevVisible = index > 0 ? visibleLines[index - 1] : undefined;
           const nextVisible =
             index < visibleLines.length - 1 ? visibleLines[index + 1] : undefined;
-          /** Gap dots sit inline on the lyric *after* the placeholder. Alternating order is either [placeholder, nextLyric] or [nextLyric, placeholder] depending on line index parity — only the former has the placeholder in prevVisible. */
+          /** Gap dots sit inline on the lyric *after* the placeholder. Alternating order is either [placeholder, nextLyric] or [nextLyric, placeholder] depending on line index parity — only the former has the placeholder in prevVisible. Long gap + alternating: [next, next+1] with inline dots on next via {@link getGapInterludeInlineLead}. */
           const interludeLeadForRow =
             introInterludeLead &&
             !isInterludePlaceholder &&
             line.startTimeMs === displayOriginalLines[0]?.startTimeMs &&
             actualCurrentLine < 0
               ? introInterludeLead
-              : prevVisible &&
-                  isInterludePlaceholderLine(prevVisible) &&
-                  prevVisible.dotsInlineWithNext
-                ? prevVisible
-                : nextVisible &&
-                    isInterludePlaceholderLine(nextVisible) &&
-                    nextVisible.dotsInlineWithNext
-                  ? nextVisible
-                  : undefined;
+              : gapInterludeInlineLead &&
+                  !isInterludePlaceholder &&
+                  actualCurrentLine >= 0 &&
+                  line.startTimeMs ===
+                    displayOriginalLines[actualCurrentLine + 1]?.startTimeMs
+                ? gapInterludeInlineLead
+                : prevVisible &&
+                    isInterludePlaceholderLine(prevVisible) &&
+                    prevVisible.dotsInlineWithNext
+                  ? prevVisible
+                  : nextVisible &&
+                      isInterludePlaceholderLine(nextVisible) &&
+                      nextVisible.dotsInlineWithNext
+                    ? nextVisible
+                    : undefined;
 
           const interludeInlineDotsLine =
             interludeLeadForRow && currentTimeMs !== undefined

--- a/src/apps/ipod/components/LyricsDisplay.tsx
+++ b/src/apps/ipod/components/LyricsDisplay.tsx
@@ -42,6 +42,7 @@ import {
   getGapInterludeInlineLead,
   getIntroInterludeInlineLead,
   getInterludeDotsFadeOpacity,
+  isAlternatingInterludeDotsActive,
   isInterludePlaceholderLine,
 } from "@/utils/karaokeInterludeDisplay";
 
@@ -2090,30 +2091,56 @@ export function LyricsDisplay({
     return "center";
   };
 
+  const interludeDotsParityRows = useMemo(
+    () =>
+      isAlternatingInterludeDotsActive(
+        displayOriginalLines,
+        alignment,
+        actualCurrentLine,
+        currentTimeMs,
+        showInterludeEllipsis
+      ),
+    [
+      displayOriginalLines,
+      alignment,
+      actualCurrentLine,
+      currentTimeMs,
+      showInterludeEllipsis,
+    ]
+  );
+
   // Helper to compute lines for Alternating alignment (current + next)
-  const computeAltVisibleLines = (
-    allLines: LyricLine[],
-    currIdx: number
-  ): LyricLine[] => {
-    if (!allLines.length) return [];
+  const computeAltVisibleLines = useCallback(
+    (allLines: LyricLine[], currIdx: number, parityInterludeRows: boolean): LyricLine[] => {
+      if (!allLines.length) return [];
 
-    // Initial state before any line is current
-    if (currIdx < 0) {
-      return allLines.slice(0, 2).filter(Boolean);
-    }
+      // Initial state before any line is current
+      if (currIdx < 0) {
+        return allLines.slice(0, 2).filter(Boolean);
+      }
 
-    const clampedIdx = Math.min(currIdx, allLines.length - 1);
-    const nextLine = allLines[clampedIdx + 1];
+      const clampedIdx = Math.min(currIdx, allLines.length - 1);
+      const nextLine = allLines[clampedIdx + 1];
 
-    // Always [current, next]: top row = active line, bottom = upcoming. Parity-based
-    // swap used to move the current line between rows and felt like positions jumping during playback.
-    return [allLines[clampedIdx], nextLine].filter(Boolean);
-  };
+      // Normal playback: stable [current, next] so the active line does not jump rows.
+      // Interlude dots (intro/gap): restore parity-based [current,next] vs [next,current] for the
+      // classic alternating look during ●●● only.
+      if (parityInterludeRows) {
+        if (clampedIdx % 2 === 0) {
+          return [allLines[clampedIdx], nextLine].filter(Boolean);
+        }
+        return [nextLine, allLines[clampedIdx]].filter(Boolean);
+      }
+
+      return [allLines[clampedIdx], nextLine].filter(Boolean);
+    },
+    []
+  );
 
   // State to hold lines displayed in Alternating mode so we can delay updates
   // Use displayOriginalLines to ensure word timings are included (not translated lines)
   const [altLines, setAltLines] = useState<LyricLine[]>(() =>
-    computeAltVisibleLines(displayOriginalLines, actualCurrentLine)
+    computeAltVisibleLines(displayOriginalLines, actualCurrentLine, false)
   );
 
   // Track previous lines array to detect song/translation changes
@@ -2130,12 +2157,30 @@ export function LyricsDisplay({
     prevLinesRef.current = displayOriginalLines;
 
     if (linesChanged || actualCurrentLine < 0) {
-      setAltLines(computeAltVisibleLines(displayOriginalLines, actualCurrentLine));
+      setAltLines(
+        computeAltVisibleLines(
+          displayOriginalLines,
+          actualCurrentLine,
+          interludeDotsParityRows
+        )
+      );
       return;
     }
 
-    setAltLines(computeAltVisibleLines(displayOriginalLines, actualCurrentLine));
-  }, [alignment, displayOriginalLines, actualCurrentLine]);
+    setAltLines(
+      computeAltVisibleLines(
+        displayOriginalLines,
+        actualCurrentLine,
+        interludeDotsParityRows
+      )
+    );
+  }, [
+    alignment,
+    displayOriginalLines,
+    actualCurrentLine,
+    interludeDotsParityRows,
+    computeAltVisibleLines,
+  ]);
 
   const nonAltVisibleLines = useMemo(() => {
     if (!displayOriginalLines.length) return [] as LyricLine[];

--- a/src/apps/ipod/components/LyricsDisplay.tsx
+++ b/src/apps/ipod/components/LyricsDisplay.tsx
@@ -2105,13 +2105,9 @@ export function LyricsDisplay({
     const clampedIdx = Math.min(currIdx, allLines.length - 1);
     const nextLine = allLines[clampedIdx + 1];
 
-    if (clampedIdx % 2 === 0) {
-      // Current is on top
-      return [allLines[clampedIdx], nextLine].filter(Boolean);
-    }
-
-    // Current is at bottom
-    return [nextLine, allLines[clampedIdx]].filter(Boolean);
+    // Always [current, next]: top row = active line, bottom = upcoming. Parity-based
+    // swap used to move the current line between rows and felt like positions jumping during playback.
+    return [allLines[clampedIdx], nextLine].filter(Boolean);
   };
 
   // State to hold lines displayed in Alternating mode so we can delay updates

--- a/src/apps/ipod/components/LyricsDisplay.tsx
+++ b/src/apps/ipod/components/LyricsDisplay.tsx
@@ -2123,7 +2123,9 @@ export function LyricsDisplay({
   // Track previous lines array to detect song/translation changes
   const prevLinesRef = useRef<LyricLine[]>(displayOriginalLines);
 
-  // Update alternating lines - instantly on song/translation change, delayed for line transitions
+  // Keep alternating pair in sync with playback immediately. A previous delayed update here
+  // left altLines stale after actualCurrentLine advanced, so interlude / visible lines
+  // still showed [previous, next] while playback had moved on — breaking next+1 preview.
   useEffect(() => {
     if (alignment !== LyricsAlignment.Alternating) return;
 
@@ -2131,36 +2133,12 @@ export function LyricsDisplay({
     const linesChanged = prevLinesRef.current !== displayOriginalLines;
     prevLinesRef.current = displayOriginalLines;
 
-    // Instantly update on song load, translation switch, or initial state
     if (linesChanged || actualCurrentLine < 0) {
       setAltLines(computeAltVisibleLines(displayOriginalLines, actualCurrentLine));
       return;
     }
 
-    // For normal line transitions within the same song, apply delay
-    // Determine the duration of the new current line
-    const clampedIdx = Math.min(Math.max(0, actualCurrentLine), displayOriginalLines.length - 1);
-    const currentStart =
-      clampedIdx >= 0 && displayOriginalLines[clampedIdx]
-        ? parseInt(displayOriginalLines[clampedIdx].startTimeMs)
-        : null;
-    const nextStart =
-      clampedIdx + 1 < displayOriginalLines.length && displayOriginalLines[clampedIdx + 1]
-        ? parseInt(displayOriginalLines[clampedIdx + 1].startTimeMs)
-        : null;
-
-    const rawDuration =
-      currentStart !== null && nextStart !== null ? nextStart - currentStart : 0;
-
-    // Use 20% of the line duration; clamp to 20-400ms range to avoid extremes
-    // (prevents 6+ second delays on long instrumental breaks)
-    const delayMs = Math.min(400, Math.max(20, Math.floor(rawDuration * 0.2)));
-
-    const timer = setTimeout(() => {
-      setAltLines(computeAltVisibleLines(displayOriginalLines, actualCurrentLine));
-    }, delayMs);
-
-    return () => clearTimeout(timer);
+    setAltLines(computeAltVisibleLines(displayOriginalLines, actualCurrentLine));
   }, [alignment, displayOriginalLines, actualCurrentLine]);
 
   const nonAltVisibleLines = useMemo(() => {

--- a/src/apps/ipod/components/LyricsDisplay.tsx
+++ b/src/apps/ipod/components/LyricsDisplay.tsx
@@ -2396,14 +2396,31 @@ export function LyricsDisplay({
           const lineActualIdx = isInterludePlaceholder
             ? line.anchorLineIndex
             : displayOriginalLines.indexOf(line);
-          const isCurrent = isInterludePlaceholder
-            ? actualCurrentLine < 0
-              ? true
-              : line.anchorLineIndex === actualCurrentLine
-            : line === displayOriginalLines[actualCurrentLine];
+          const isAlternatingGapInterlude =
+            alignment === LyricsAlignment.Alternating &&
+            showInterludeEllipsis &&
+            actualCurrentLine >= 0 &&
+            gapInterludeInlineLead !== null &&
+            currentTimeMs !== undefined;
+
+          const isCurrent = isAlternatingGapInterlude &&
+            !isInterludePlaceholder &&
+            line === displayOriginalLines[actualCurrentLine + 1]
+            ? false
+            : isInterludePlaceholder
+              ? actualCurrentLine < 0
+                ? true
+                : line.anchorLineIndex === actualCurrentLine
+              : line === displayOriginalLines[actualCurrentLine];
           let position = 0;
           if (alignment === LyricsAlignment.Alternating) {
-            position = isCurrent ? 0 : 1;
+            if (isAlternatingGapInterlude && !isInterludePlaceholder) {
+              // Visible order is [next+1, next] — index 0 top, 1 bottom matches pre-interlude
+              // [current, next] so the upcoming line does not swap vertical slots.
+              position = index;
+            } else {
+              position = isCurrent ? 0 : 1;
+            }
           } else {
             position =
               currentAnchorIdx >= 0 ? lineActualIdx - currentAnchorIdx : 0;

--- a/src/utils/karaokeInterludeDisplay.ts
+++ b/src/utils/karaokeInterludeDisplay.ts
@@ -259,8 +259,10 @@ export function applyKaraokeInterludeEllipsis({
     alignment === LyricsAlignment.Alternating ? { dotsInlineWithNext: true } : undefined
   );
 
+  // Center mode: show the upcoming line immediately (static / "cleared") alongside dots,
+  // not only after the interlude ends (FocusThree already keeps next in `visibleLines`).
   if (alignment === LyricsAlignment.Center) {
-    return [placeholder];
+    return [placeholder, nextLine];
   }
 
   return visibleLines.map((line) => (line === currentLine ? placeholder : line));

--- a/src/utils/karaokeInterludeDisplay.ts
+++ b/src/utils/karaokeInterludeDisplay.ts
@@ -266,10 +266,12 @@ export function applyKaraokeInterludeEllipsis({
   }
 
   // Alternating: drop the finished line — show the next two real lyrics with inline dots on the
-  // first (see getGapInterludeInlineLead in LyricsDisplay). No placeholder row / no anchor ghost.
+  // upcoming line (see getGapInterludeInlineLead). Order is [next+1, next] so the upcoming line
+  // stays in the same screen slot as before (bottom when current was on top); the top slot is
+  // replaced by the line after next, avoiding a vertical jump.
   if (alignment === LyricsAlignment.Alternating) {
     const afterNext = allLines[currentIndex + 2];
-    return afterNext !== undefined ? [nextLine, afterNext] : [nextLine];
+    return afterNext !== undefined ? [afterNext, nextLine] : [nextLine];
   }
 
   return visibleLines.map((line) => (line === currentLine ? placeholder : line));
@@ -281,7 +283,7 @@ export function applyKaraokeInterludeEllipsis({
  */
 /**
  * Long gap + alternating layout: same synthetic lead as the gap placeholder, but dots render
- * inline on the upcoming line — used when visible lines are [next, next+1] with no previous row.
+ * inline on the upcoming line — used when visible lines are [next+1, next] with no previous row.
  */
 export function getGapInterludeInlineLead(
   allLines: LyricLine[],

--- a/src/utils/karaokeInterludeDisplay.ts
+++ b/src/utils/karaokeInterludeDisplay.ts
@@ -265,6 +265,13 @@ export function applyKaraokeInterludeEllipsis({
     return [placeholder, nextLine];
   }
 
+  // Alternating: drop the finished line — show the next two real lyrics with inline dots on the
+  // first (see getGapInterludeInlineLead in LyricsDisplay). No placeholder row / no anchor ghost.
+  if (alignment === LyricsAlignment.Alternating) {
+    const afterNext = allLines[currentIndex + 2];
+    return afterNext !== undefined ? [nextLine, afterNext] : [nextLine];
+  }
+
   return visibleLines.map((line) => (line === currentLine ? placeholder : line));
 }
 
@@ -272,6 +279,35 @@ export function applyKaraokeInterludeEllipsis({
  * Long intro + alternating layout: timed dots are drawn inline with the first lyric; use this to
  * build synthetic timings and fade state (no placeholder row in `applyKaraokeInterludeEllipsis`).
  */
+/**
+ * Long gap + alternating layout: same synthetic lead as the gap placeholder, but dots render
+ * inline on the upcoming line — used when visible lines are [next, next+1] with no previous row.
+ */
+export function getGapInterludeInlineLead(
+  allLines: LyricLine[],
+  currentIndex: number,
+  currentTimeMs: number | undefined,
+  enabled: boolean
+): InterludePlaceholderLine | null {
+  if (!enabled || currentTimeMs === undefined) {
+    return null;
+  }
+  const currentLine = allLines[currentIndex];
+  const nextLine = allLines[currentIndex + 1];
+  if (!currentLine || !nextLine || !hasLongInterlude(currentLine, nextLine, currentTimeMs)) {
+    return null;
+  }
+  const fullStartMs = getLineEndMs(currentLine) + INTERLUDE_PLACEHOLDER_DELAY_MS;
+  const fullEndMs = getLineStartMs(nextLine);
+  const { segmentStartMs } = buildCountdownSegment(fullStartMs, fullEndMs);
+  return createInterludePlaceholder(
+    `gap-inline-${nextLine.startTimeMs}`,
+    currentIndex,
+    segmentStartMs,
+    { dotsInlineWithNext: true }
+  );
+}
+
 export function getIntroInterludeInlineLead(
   allLines: LyricLine[],
   currentTimeMs: number | undefined,

--- a/src/utils/karaokeInterludeDisplay.ts
+++ b/src/utils/karaokeInterludeDisplay.ts
@@ -144,6 +144,36 @@ export function isInterludePlaceholderLine(
 }
 
 /**
+ * True when alternating layout should use the classic parity row swap (current top vs bottom)
+ * during intro or gap interlude dots — not during normal playback.
+ */
+export function isAlternatingInterludeDotsActive(
+  allLines: LyricLine[],
+  alignment: LyricsAlignment,
+  currentIndex: number,
+  currentTimeMs: number | undefined,
+  enabled: boolean
+): boolean {
+  if (
+    alignment !== LyricsAlignment.Alternating ||
+    !enabled ||
+    currentTimeMs === undefined ||
+    !allLines.length
+  ) {
+    return false;
+  }
+  if (currentIndex < 0) {
+    return hasLongIntro(allLines, currentTimeMs);
+  }
+  const currentLine = allLines[currentIndex];
+  const nextLine = allLines[currentIndex + 1];
+  if (!currentLine || !nextLine) {
+    return false;
+  }
+  return hasLongInterlude(currentLine, nextLine, currentTimeMs);
+}
+
+/**
  * Build a real {@link LyricLine} with synthetic word timings so interlude dots use the same
  * karaoke mask/outline path as timed lyrics. The three beats fall in a short countdown window
  * ending at the next line (see INTERLUDE_COUNTDOWN_TOTAL_MS), not across the full break.

--- a/tests/test-karaoke-interlude-display.test.ts
+++ b/tests/test-karaoke-interlude-display.test.ts
@@ -192,6 +192,26 @@ describe("karaoke interlude ellipsis", () => {
     expect(getInterludeDotsFadeOpacity(12000, 12000)).toBe(1);
   });
 
+  test("center mode long gap: shows placeholder and next line so upcoming lyric is visible with dots", () => {
+    const lines = [
+      makeLine(0, "Verse line"),
+      makeLine(15000, "Next line"),
+    ];
+
+    const visible = applyKaraokeInterludeEllipsis({
+      visibleLines: [lines[0]],
+      allLines: lines,
+      alignment: LyricsAlignment.Center,
+      currentIndex: 0,
+      currentTimeMs: 5000,
+      enabled: true,
+    });
+
+    expect(visible).toHaveLength(2);
+    expect(isInterludePlaceholderLine(visible[0]!)).toBe(true);
+    expect(visible[1]).toBe(lines[1]);
+  });
+
   test("does not show ellipsis for ordinary short gaps", () => {
     const lines = [
       makeLine(0, "Line one"),

--- a/tests/test-karaoke-interlude-display.test.ts
+++ b/tests/test-karaoke-interlude-display.test.ts
@@ -4,6 +4,7 @@ import { LyricsAlignment, type LyricLine } from "../src/types/lyrics";
 import {
   applyKaraokeInterludeEllipsis,
   buildInterludeLyricLineWithWordTimings,
+  getGapInterludeInlineLead,
   getIntroInterludeInlineLead,
   getInterludeDotsFadeOpacity,
   isInterludePlaceholderLine,
@@ -101,10 +102,11 @@ describe("karaoke interlude ellipsis", () => {
     expect(getIntroInterludeInlineLead(twoLineSong, 4000, true)).not.toBeNull();
   });
 
-  test("alternating gap placeholder flags dotsInlineWithNext for inline lead on the next row", () => {
+  test("alternating long gap: shows next two lyrics (drops previous line); inline lead via getGapInterludeInlineLead", () => {
     const lines = [
       makeLine(0, "Verse line"),
       makeLine(15000, "Next line"),
+      makeLine(28000, "Third line"),
     ];
 
     const visible = applyKaraokeInterludeEllipsis({
@@ -116,10 +118,26 @@ describe("karaoke interlude ellipsis", () => {
       enabled: true,
     });
 
-    expect(visible).toHaveLength(2);
-    expect(isInterludePlaceholderLine(visible[0]!)).toBe(true);
-    expect(visible[0]!.dotsInlineWithNext).toBe(true);
-    expect(visible[1]).toBe(lines[1]);
+    expect(visible).toEqual([lines[1], lines[2]]);
+    expect(isInterludePlaceholderLine(visible[0]!)).toBe(false);
+    const lead = getGapInterludeInlineLead(lines, 0, 5000, true);
+    expect(lead).not.toBeNull();
+    expect(lead!.dotsInlineWithNext).toBe(true);
+  });
+
+  test("alternating long gap with only two lines: shows upcoming line only", () => {
+    const lines = [makeLine(0, "Verse line"), makeLine(15000, "Next line")];
+
+    const visible = applyKaraokeInterludeEllipsis({
+      visibleLines: [lines[0], lines[1]],
+      allLines: lines,
+      alignment: LyricsAlignment.Alternating,
+      currentIndex: 0,
+      currentTimeMs: 5000,
+      enabled: true,
+    });
+
+    expect(visible).toEqual([lines[1]]);
   });
 
   test("buildInterludeLyricLineWithWordTimings splits the silent gap into three timed words", () => {
@@ -127,14 +145,7 @@ describe("karaoke interlude ellipsis", () => {
       makeLine(0, "Verse line"),
       makeLine(15000, "Next line"),
     ];
-    const placeholder = applyKaraokeInterludeEllipsis({
-      visibleLines: [lines[0], lines[1]],
-      allLines: lines,
-      alignment: LyricsAlignment.Alternating,
-      currentIndex: 0,
-      currentTimeMs: 5000,
-      enabled: true,
-    })[0];
+    const placeholder = getGapInterludeInlineLead(lines, 0, 5000, true);
     if (!isInterludePlaceholderLine(placeholder!)) throw new Error("expected placeholder");
 
     const timed = buildInterludeLyricLineWithWordTimings(placeholder, lines, 0);
@@ -145,31 +156,22 @@ describe("karaoke interlude ellipsis", () => {
     expect(timed.startTimeMs).toBe("12000");
   });
 
-  test("replaces the held current line with placeholder after delay; countdownStartMs matches dot fill", () => {
+  test("gap inline lead countdownStartMs matches dot fill segment start", () => {
     const lines = [
       makeLine(0, "Verse line"),
       makeLine(15000, "Next line"),
     ];
 
-    const visible = applyKaraokeInterludeEllipsis({
-      visibleLines: [lines[0], lines[1]],
-      allLines: lines,
-      alignment: LyricsAlignment.Alternating,
-      currentIndex: 0,
-      currentTimeMs: 5000,
-      enabled: true,
-    });
-
-    expect(visible).toHaveLength(2);
-    expect(isInterludePlaceholderLine(visible[0]!)).toBe(true);
-    expect(visible[0]!.countdownStartMs).toBe(12000);
-    expect(visible[1]).toBe(lines[1]);
+    const lead = getGapInterludeInlineLead(lines, 0, 5000, true);
+    expect(lead).not.toBeNull();
+    expect(lead!.countdownStartMs).toBe(12000);
   });
 
-  test("keeps the upcoming lyric visible while ellipsis leads into a long gap", () => {
+  test("alternating long gap near next line start: still shows next two lines when a third exists", () => {
     const lines = [
       makeLine(0, "Verse line"),
       makeLine(15000, "Next line"),
+      makeLine(28000, "Third line"),
     ];
 
     const visible = applyKaraokeInterludeEllipsis({
@@ -181,9 +183,7 @@ describe("karaoke interlude ellipsis", () => {
       enabled: true,
     });
 
-    expect(visible).toHaveLength(2);
-    expect(isInterludePlaceholderLine(visible[0]!)).toBe(true);
-    expect(visible[1]).toBe(lines[1]);
+    expect(visible).toEqual([lines[1], lines[2]]);
   });
 
   test("getInterludeDotsFadeOpacity rests dim then ramps to full at countdownStartMs", () => {

--- a/tests/test-karaoke-interlude-display.test.ts
+++ b/tests/test-karaoke-interlude-display.test.ts
@@ -7,6 +7,7 @@ import {
   getGapInterludeInlineLead,
   getIntroInterludeInlineLead,
   getInterludeDotsFadeOpacity,
+  isAlternatingInterludeDotsActive,
   isInterludePlaceholderLine,
 } from "../src/utils/karaokeInterludeDisplay";
 
@@ -211,6 +212,42 @@ describe("karaoke interlude ellipsis", () => {
     expect(visible).toHaveLength(2);
     expect(isInterludePlaceholderLine(visible[0]!)).toBe(true);
     expect(visible[1]).toBe(lines[1]);
+  });
+
+  test("isAlternatingInterludeDotsActive true only during long intro/gap when enabled", () => {
+    const longGap = [
+      makeLine(0, "A"),
+      makeLine(15000, "B"),
+    ];
+    expect(
+      isAlternatingInterludeDotsActive(
+        longGap,
+        LyricsAlignment.Alternating,
+        0,
+        5000,
+        true
+      )
+    ).toBe(true);
+    expect(
+      isAlternatingInterludeDotsActive(
+        longGap,
+        LyricsAlignment.Alternating,
+        0,
+        5000,
+        false
+      )
+    ).toBe(false);
+
+    const shortGap = [makeLine(0, "A"), makeLine(7000, "B")];
+    expect(
+      isAlternatingInterludeDotsActive(
+        shortGap,
+        LyricsAlignment.Alternating,
+        0,
+        5000,
+        true
+      )
+    ).toBe(false);
   });
 
   test("does not show ellipsis for ordinary short gaps", () => {

--- a/tests/test-karaoke-interlude-display.test.ts
+++ b/tests/test-karaoke-interlude-display.test.ts
@@ -118,7 +118,8 @@ describe("karaoke interlude ellipsis", () => {
       enabled: true,
     });
 
-    expect(visible).toEqual([lines[1], lines[2]]);
+    // Top slot = line after next, bottom = upcoming (same vertical slot as pre-interlude [current, next])
+    expect(visible).toEqual([lines[2], lines[1]]);
     expect(isInterludePlaceholderLine(visible[0]!)).toBe(false);
     const lead = getGapInterludeInlineLead(lines, 0, 5000, true);
     expect(lead).not.toBeNull();
@@ -183,7 +184,7 @@ describe("karaoke interlude ellipsis", () => {
       enabled: true,
     });
 
-    expect(visible).toEqual([lines[1], lines[2]]);
+    expect(visible).toEqual([lines[2], lines[1]]);
   });
 
   test("getInterludeDotsFadeOpacity rests dim then ramps to full at countdownStartMs", () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- **Center alignment + long gap:** Placeholder + next line visible during interlude dots.
- **Alternating + long gap:** `[next+1, next]` with inline dots on upcoming line; upcoming stays bottom slot.
- **Playback sync:** `altLines` now updates **immediately** when `actualCurrentLine` changes (removed delayed `setTimeout`). Stale `altLines` had caused `applyKaraokeInterludeEllipsis` to receive the wrong `[current, next]` pair while `findCurrentLineIndex` had already advanced — interlude / preview did not follow playback through the next+1 window.

## Testing
- `bun test tests/test-karaoke-interlude-display.test.ts` (existing)
- `bun run build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9b22bcc7-df98-421b-be61-4b9bc23c5191"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9b22bcc7-df98-421b-be61-4b9bc23c5191"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

