### PR TITLE
Advance alternating lyrics during interludes

### DIFF
--- a/src/apps/ipod/components/LyricsDisplay.tsx
+++ b/src/apps/ipod/components/LyricsDisplay.tsx
@@ -13,7 +13,6 @@ import {
   useRef,
   useState,
   useEffect,
-  useLayoutEffect,
   useCallback,
 } from "react";
 import type { CSSProperties, ReactNode } from "react";
@@ -40,12 +39,12 @@ import { parseLyricTimestamps, findCurrentLineIndex } from "@/utils/lyricsSearch
 import {
   applyKaraokeInterludeEllipsis,
   buildInterludeLyricLineWithWordTimings,
-  didAdvancePastLongInterlude,
   getIntroInterludeInlineLead,
   getInterludeDotsFadeOpacity,
   isInterludeInlineLyricLine,
   isInterludePlaceholderLine,
 } from "@/utils/karaokeInterludeDisplay";
+import { useAlternatingVisibleLines } from "@/apps/ipod/components/useAlternatingVisibleLines";
 
 interface LyricsDisplayProps {
   lines: LyricLine[];
@@ -946,16 +945,17 @@ function WordTimingHighlight({
     [renderItems]
   );
 
-  // Sync time ref when prop changes
-  useEffect(() => {
+  const previousPropTime = timeRef.current.propTime;
+  if (previousPropTime !== currentTimeMs) {
     timeRef.current.propTime = currentTimeMs;
     timeRef.current.propTimestamp = performance.now();
-  }, [currentTimeMs]);
+  }
 
   // Animation loop - updates DOM directly without React re-renders
   // Uses CSS custom properties for GPU-accelerated mask animation
   useEffect(() => {
     let animationFrameId: number;
+    lastProgressRef.current = Array.from({ length: renderItems.length }, () => Number.NaN);
     
     const updateMasks = () => {
       // Interpolate time for smooth animation between prop updates
@@ -1008,14 +1008,9 @@ function WordTimingHighlight({
     return () => cancelAnimationFrame(animationFrameId);
   }, [lineStartTimeMs, timingWindows]);
 
-  // Initialize refs array length
-  useEffect(() => {
+  if (overlayRefs.current.length !== renderItems.length) {
     overlayRefs.current = overlayRefs.current.slice(0, renderItems.length);
-  }, [renderItems.length]);
-
-  useEffect(() => {
-    lastProgressRef.current = Array.from({ length: renderItems.length }, () => Number.NaN);
-  }, [lineStartTimeMs, timingWindows, renderItems.length]);
+  }
 
   const handleWordClick = (wordStartTimeMs: number) => {
     if (onSeekToTime) {
@@ -2092,91 +2087,11 @@ export function LyricsDisplay({
     return "center";
   };
 
-  // Helper to compute lines for Alternating alignment (current + next)
-  const computeAltVisibleLines = (
-    allLines: LyricLine[],
-    currIdx: number
-  ): LyricLine[] => {
-    if (!allLines.length) return [];
-
-    // Initial state before any line is current
-    if (currIdx < 0) {
-      return allLines.slice(0, 2).filter(Boolean);
-    }
-
-    const clampedIdx = Math.min(currIdx, allLines.length - 1);
-    const nextLine = allLines[clampedIdx + 1];
-
-    if (clampedIdx % 2 === 0) {
-      // Current is on top
-      return [allLines[clampedIdx], nextLine].filter(Boolean);
-    }
-
-    // Current is at bottom
-    return [nextLine, allLines[clampedIdx]].filter(Boolean);
-  };
-
-  // State to hold lines displayed in Alternating mode so we can delay updates
-  // Use displayOriginalLines to ensure word timings are included (not translated lines)
-  const [altLines, setAltLines] = useState<LyricLine[]>(() =>
-    computeAltVisibleLines(displayOriginalLines, actualCurrentLine)
-  );
-
-  // Track previous lines array to detect song/translation changes
-  const prevLinesRef = useRef<LyricLine[]>(displayOriginalLines);
-  const prevActualCurrentLineRef = useRef(actualCurrentLine);
-
-  // Update alternating lines - instantly on song/translation change, delayed for line transitions
-  useLayoutEffect(() => {
-    if (alignment !== LyricsAlignment.Alternating) {
-      prevActualCurrentLineRef.current = actualCurrentLine;
-      return;
-    }
-
-    // Check if lines array changed (new song or translation switch)
-    const linesChanged = prevLinesRef.current !== displayOriginalLines;
-    const previousActualCurrentLine = prevActualCurrentLineRef.current;
-    prevLinesRef.current = displayOriginalLines;
-    prevActualCurrentLineRef.current = actualCurrentLine;
-    const exitedLongInterlude =
-      !linesChanged &&
-      didAdvancePastLongInterlude(
-        displayOriginalLines,
-        previousActualCurrentLine,
-        actualCurrentLine
-      );
-
-    // Instantly update on song load, translation switch, or initial state
-    if (linesChanged || actualCurrentLine < 0 || exitedLongInterlude) {
-      setAltLines(computeAltVisibleLines(displayOriginalLines, actualCurrentLine));
-      return;
-    }
-
-    // For normal line transitions within the same song, apply delay
-    // Determine the duration of the new current line
-    const clampedIdx = Math.min(Math.max(0, actualCurrentLine), displayOriginalLines.length - 1);
-    const currentStart =
-      clampedIdx >= 0 && displayOriginalLines[clampedIdx]
-        ? parseInt(displayOriginalLines[clampedIdx].startTimeMs)
-        : null;
-    const nextStart =
-      clampedIdx + 1 < displayOriginalLines.length && displayOriginalLines[clampedIdx + 1]
-        ? parseInt(displayOriginalLines[clampedIdx + 1].startTimeMs)
-        : null;
-
-    const rawDuration =
-      currentStart !== null && nextStart !== null ? nextStart - currentStart : 0;
-
-    // Use 20% of the line duration; clamp to 20-400ms range to avoid extremes
-    // (prevents 6+ second delays on long instrumental breaks)
-    const delayMs = Math.min(400, Math.max(20, Math.floor(rawDuration * 0.2)));
-
-    const timer = setTimeout(() => {
-      setAltLines(computeAltVisibleLines(displayOriginalLines, actualCurrentLine));
-    }, delayMs);
-
-    return () => clearTimeout(timer);
-  }, [alignment, displayOriginalLines, actualCurrentLine]);
+  const altLines = useAlternatingVisibleLines({
+    alignment,
+    allLines: displayOriginalLines,
+    actualCurrentLine,
+  });
 
   const nonAltVisibleLines = useMemo(() => {
     if (!displayOriginalLines.length) return [] as LyricLine[];

--- a/src/apps/ipod/components/LyricsDisplay.tsx
+++ b/src/apps/ipod/components/LyricsDisplay.tsx
@@ -41,6 +41,7 @@ import {
   buildInterludeLyricLineWithWordTimings,
   getIntroInterludeInlineLead,
   getInterludeDotsFadeOpacity,
+  isInterludeInlineLyricLine,
   isInterludePlaceholderLine,
 } from "@/utils/karaokeInterludeDisplay";
 
@@ -2370,6 +2371,10 @@ export function LyricsDisplay({
       <AnimatePresence mode="popLayout">
         {visibleLines.map((line, index) => {
           const isInterludePlaceholder = isInterludePlaceholderLine(line);
+          const interludeInlineLead =
+            !isInterludePlaceholder && isInterludeInlineLyricLine(line)
+              ? line.interludeInlineLead
+              : undefined;
           const lineForContent: LyricLine = isInterludePlaceholder
             ? buildInterludeLyricLineWithWordTimings(
                 line,
@@ -2379,12 +2384,16 @@ export function LyricsDisplay({
             : line;
           const lineActualIdx = isInterludePlaceholder
             ? line.anchorLineIndex
-            : displayOriginalLines.indexOf(line);
+            : isInterludeInlineLyricLine(line)
+              ? line.sourceLineIndex
+              : displayOriginalLines.findIndex(
+                  (originalLine) => originalLine.startTimeMs === line.startTimeMs
+                );
           const isCurrent = isInterludePlaceholder
             ? actualCurrentLine < 0
               ? true
               : line.anchorLineIndex === actualCurrentLine
-            : line === displayOriginalLines[actualCurrentLine];
+            : lineActualIdx === actualCurrentLine;
           let position = 0;
           if (alignment === LyricsAlignment.Alternating) {
             position = isCurrent ? 0 : 1;
@@ -2415,13 +2424,15 @@ export function LyricsDisplay({
           const prevVisible = index > 0 ? visibleLines[index - 1] : undefined;
           const nextVisible =
             index < visibleLines.length - 1 ? visibleLines[index + 1] : undefined;
-          /** Gap dots sit inline on the lyric *after* the placeholder. Alternating order is either [placeholder, nextLyric] or [nextLyric, placeholder] depending on line index parity — only the former has the placeholder in prevVisible. */
+          /** Gap dots either ride on a decorated upcoming lyric row or fall back to a visible placeholder. */
           const interludeLeadForRow =
             introInterludeLead &&
             !isInterludePlaceholder &&
             line.startTimeMs === displayOriginalLines[0]?.startTimeMs &&
             actualCurrentLine < 0
               ? introInterludeLead
+              : interludeInlineLead
+                ? interludeInlineLead
               : prevVisible &&
                   isInterludePlaceholderLine(prevVisible) &&
                   prevVisible.dotsInlineWithNext

--- a/src/apps/ipod/components/LyricsDisplay.tsx
+++ b/src/apps/ipod/components/LyricsDisplay.tsx
@@ -39,6 +39,7 @@ import { parseLyricTimestamps, findCurrentLineIndex } from "@/utils/lyricsSearch
 import {
   applyKaraokeInterludeEllipsis,
   buildInterludeLyricLineWithWordTimings,
+  hasLongInterludeAtTime,
   getIntroInterludeInlineLead,
   getInterludeDotsFadeOpacity,
   isInterludeInlineLyricLine,
@@ -2122,6 +2123,7 @@ export function LyricsDisplay({
 
   // Track previous lines array to detect song/translation changes
   const prevLinesRef = useRef<LyricLine[]>(displayOriginalLines);
+  const prevWasLongInterludeRef = useRef(false);
 
   // Update alternating lines - instantly on song/translation change, delayed for line transitions
   useEffect(() => {
@@ -2130,9 +2132,15 @@ export function LyricsDisplay({
     // Check if lines array changed (new song or translation switch)
     const linesChanged = prevLinesRef.current !== displayOriginalLines;
     prevLinesRef.current = displayOriginalLines;
+    const isInLongInterlude =
+      currentTimeMs !== undefined &&
+      actualCurrentLine >= 0 &&
+      hasLongInterludeAtTime(displayOriginalLines, actualCurrentLine, currentTimeMs);
+    const exitedLongInterlude = prevWasLongInterludeRef.current && !isInLongInterlude;
+    prevWasLongInterludeRef.current = isInLongInterlude;
 
     // Instantly update on song load, translation switch, or initial state
-    if (linesChanged || actualCurrentLine < 0) {
+    if (linesChanged || actualCurrentLine < 0 || exitedLongInterlude) {
       setAltLines(computeAltVisibleLines(displayOriginalLines, actualCurrentLine));
       return;
     }
@@ -2161,7 +2169,7 @@ export function LyricsDisplay({
     }, delayMs);
 
     return () => clearTimeout(timer);
-  }, [alignment, displayOriginalLines, actualCurrentLine]);
+  }, [alignment, displayOriginalLines, actualCurrentLine, currentTimeMs]);
 
   const nonAltVisibleLines = useMemo(() => {
     if (!displayOriginalLines.length) return [] as LyricLine[];

--- a/src/apps/ipod/components/LyricsDisplay.tsx
+++ b/src/apps/ipod/components/LyricsDisplay.tsx
@@ -13,6 +13,7 @@ import {
   useRef,
   useState,
   useEffect,
+  useLayoutEffect,
   useCallback,
 } from "react";
 import type { CSSProperties, ReactNode } from "react";
@@ -2126,7 +2127,7 @@ export function LyricsDisplay({
   const prevActualCurrentLineRef = useRef(actualCurrentLine);
 
   // Update alternating lines - instantly on song/translation change, delayed for line transitions
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (alignment !== LyricsAlignment.Alternating) {
       prevActualCurrentLineRef.current = actualCurrentLine;
       return;

--- a/src/apps/ipod/components/LyricsDisplay.tsx
+++ b/src/apps/ipod/components/LyricsDisplay.tsx
@@ -39,7 +39,7 @@ import { parseLyricTimestamps, findCurrentLineIndex } from "@/utils/lyricsSearch
 import {
   applyKaraokeInterludeEllipsis,
   buildInterludeLyricLineWithWordTimings,
-  hasLongInterludeAtTime,
+  didAdvancePastLongInterlude,
   getIntroInterludeInlineLead,
   getInterludeDotsFadeOpacity,
   isInterludeInlineLyricLine,
@@ -2123,21 +2123,27 @@ export function LyricsDisplay({
 
   // Track previous lines array to detect song/translation changes
   const prevLinesRef = useRef<LyricLine[]>(displayOriginalLines);
-  const prevWasLongInterludeRef = useRef(false);
+  const prevActualCurrentLineRef = useRef(actualCurrentLine);
 
   // Update alternating lines - instantly on song/translation change, delayed for line transitions
   useEffect(() => {
-    if (alignment !== LyricsAlignment.Alternating) return;
+    if (alignment !== LyricsAlignment.Alternating) {
+      prevActualCurrentLineRef.current = actualCurrentLine;
+      return;
+    }
 
     // Check if lines array changed (new song or translation switch)
     const linesChanged = prevLinesRef.current !== displayOriginalLines;
+    const previousActualCurrentLine = prevActualCurrentLineRef.current;
     prevLinesRef.current = displayOriginalLines;
-    const isInLongInterlude =
-      currentTimeMs !== undefined &&
-      actualCurrentLine >= 0 &&
-      hasLongInterludeAtTime(displayOriginalLines, actualCurrentLine, currentTimeMs);
-    const exitedLongInterlude = prevWasLongInterludeRef.current && !isInLongInterlude;
-    prevWasLongInterludeRef.current = isInLongInterlude;
+    prevActualCurrentLineRef.current = actualCurrentLine;
+    const exitedLongInterlude =
+      !linesChanged &&
+      didAdvancePastLongInterlude(
+        displayOriginalLines,
+        previousActualCurrentLine,
+        actualCurrentLine
+      );
 
     // Instantly update on song load, translation switch, or initial state
     if (linesChanged || actualCurrentLine < 0 || exitedLongInterlude) {
@@ -2169,7 +2175,7 @@ export function LyricsDisplay({
     }, delayMs);
 
     return () => clearTimeout(timer);
-  }, [alignment, displayOriginalLines, actualCurrentLine, currentTimeMs]);
+  }, [alignment, displayOriginalLines, actualCurrentLine]);
 
   const nonAltVisibleLines = useMemo(() => {
     if (!displayOriginalLines.length) return [] as LyricLine[];

--- a/src/apps/ipod/components/useAlternatingVisibleLines.ts
+++ b/src/apps/ipod/components/useAlternatingVisibleLines.ts
@@ -1,0 +1,94 @@
+import { useLayoutEffect, useRef, useState } from "react";
+
+import { LyricsAlignment, type LyricLine } from "@/types/lyrics";
+import { didAdvancePastLongInterlude } from "@/utils/karaokeInterludeDisplay";
+
+export function computeAlternatingVisibleLines(
+  allLines: LyricLine[],
+  currentLineIndex: number
+): LyricLine[] {
+  if (!allLines.length) return [];
+
+  if (currentLineIndex < 0) {
+    return allLines.slice(0, 2).filter(Boolean);
+  }
+
+  const clampedIndex = Math.min(currentLineIndex, allLines.length - 1);
+  const nextLine = allLines[clampedIndex + 1];
+
+  return clampedIndex % 2 === 0
+    ? [allLines[clampedIndex], nextLine].filter(Boolean)
+    : [nextLine, allLines[clampedIndex]].filter(Boolean);
+}
+
+function getAlternatingLineTransitionDelayMs(
+  allLines: LyricLine[],
+  currentLineIndex: number
+): number {
+  const clampedIndex = Math.min(Math.max(0, currentLineIndex), allLines.length - 1);
+  const currentStart =
+    clampedIndex >= 0 && allLines[clampedIndex]
+      ? parseInt(allLines[clampedIndex].startTimeMs, 10)
+      : null;
+  const nextStart =
+    clampedIndex + 1 < allLines.length && allLines[clampedIndex + 1]
+      ? parseInt(allLines[clampedIndex + 1].startTimeMs, 10)
+      : null;
+
+  const rawDuration = currentStart !== null && nextStart !== null ? nextStart - currentStart : 0;
+
+  // Use 20% of the line duration; clamp to 20-400ms range to avoid extremes
+  // (prevents 6+ second delays on long instrumental breaks)
+  return Math.min(400, Math.max(20, Math.floor(rawDuration * 0.2)));
+}
+
+export function useAlternatingVisibleLines({
+  allLines,
+  alignment,
+  actualCurrentLine,
+}: {
+  allLines: LyricLine[];
+  alignment: LyricsAlignment;
+  actualCurrentLine: number;
+}): LyricLine[] {
+  const [visibleLines, setVisibleLines] = useState<LyricLine[]>(() =>
+    computeAlternatingVisibleLines(allLines, actualCurrentLine)
+  );
+  const previousLinesRef = useRef(allLines);
+  const previousCurrentLineRef = useRef(actualCurrentLine);
+  const previousAlignmentRef = useRef(alignment);
+
+  useLayoutEffect(() => {
+    const alignmentChanged = previousAlignmentRef.current !== alignment;
+    previousAlignmentRef.current = alignment;
+
+    if (alignment !== LyricsAlignment.Alternating) {
+      previousLinesRef.current = allLines;
+      previousCurrentLineRef.current = actualCurrentLine;
+      return;
+    }
+
+    const linesChanged = previousLinesRef.current !== allLines;
+    const previousCurrentLineIndex = previousCurrentLineRef.current;
+    previousLinesRef.current = allLines;
+    previousCurrentLineRef.current = actualCurrentLine;
+
+    const nextVisibleLines = computeAlternatingVisibleLines(allLines, actualCurrentLine);
+    const exitedLongInterlude =
+      !linesChanged &&
+      didAdvancePastLongInterlude(allLines, previousCurrentLineIndex, actualCurrentLine);
+
+    if (alignmentChanged || linesChanged || actualCurrentLine < 0 || exitedLongInterlude) {
+      setVisibleLines(nextVisibleLines);
+      return;
+    }
+
+    const timer = setTimeout(() => {
+      setVisibleLines(nextVisibleLines);
+    }, getAlternatingLineTransitionDelayMs(allLines, actualCurrentLine));
+
+    return () => clearTimeout(timer);
+  }, [alignment, allLines, actualCurrentLine]);
+
+  return visibleLines;
+}

--- a/src/utils/karaokeInterludeDisplay.ts
+++ b/src/utils/karaokeInterludeDisplay.ts
@@ -131,18 +131,42 @@ function hasLongInterlude(
   nextLine: LyricLine,
   currentTimeMs: number
 ): boolean {
-  const currentLineEndMs = getLineEndMs(currentLine);
-  const nextLineStartMs = getLineStartMs(nextLine);
-  const silentGapMs = nextLineStartMs - currentLineEndMs;
-
-  if (silentGapMs < LONG_INTERLUDE_THRESHOLD_MS) {
+  if (!hasLongInterludeGap(currentLine, nextLine)) {
     return false;
   }
 
+  const currentLineEndMs = getLineEndMs(currentLine);
+  const nextLineStartMs = getLineStartMs(nextLine);
   return (
     currentTimeMs >= currentLineEndMs + INTERLUDE_PLACEHOLDER_DELAY_MS &&
     currentTimeMs < nextLineStartMs
   );
+}
+
+function hasLongInterludeGap(currentLine: LyricLine, nextLine: LyricLine): boolean {
+  const currentLineEndMs = getLineEndMs(currentLine);
+  const nextLineStartMs = getLineStartMs(nextLine);
+  const silentGapMs = nextLineStartMs - currentLineEndMs;
+
+  return silentGapMs >= LONG_INTERLUDE_THRESHOLD_MS;
+}
+
+export function hasLongInterludeAtTime(
+  allLines: LyricLine[],
+  currentIndex: number,
+  currentTimeMs: number
+): boolean {
+  if (currentIndex < 0) {
+    return false;
+  }
+
+  const currentLine = allLines[currentIndex];
+  const nextLine = allLines[currentIndex + 1];
+  if (!currentLine || !nextLine) {
+    return false;
+  }
+
+  return hasLongInterlude(currentLine, nextLine, currentTimeMs);
 }
 
 export function isInterludePlaceholderLine(

--- a/src/utils/karaokeInterludeDisplay.ts
+++ b/src/utils/karaokeInterludeDisplay.ts
@@ -14,7 +14,15 @@ export interface InterludePlaceholderLine {
   dotsInlineWithNext?: boolean;
 }
 
-export type VisibleLyricLine = LyricLine | InterludePlaceholderLine;
+export interface InterludeInlineLyricLine extends LyricLine {
+  interludeInlineLead: InterludePlaceholderLine;
+  sourceLineIndex: number;
+}
+
+export type VisibleLyricLine =
+  | LyricLine
+  | InterludePlaceholderLine
+  | InterludeInlineLyricLine;
 
 const MIN_LINE_HOLD_MS = 2500;
 const LONG_INTERLUDE_THRESHOLD_MS = 8000;
@@ -143,6 +151,24 @@ export function isInterludePlaceholderLine(
   return "isInterludePlaceholder" in line && line.isInterludePlaceholder === true;
 }
 
+export function isInterludeInlineLyricLine(
+  line: VisibleLyricLine
+): line is InterludeInlineLyricLine {
+  return "interludeInlineLead" in line;
+}
+
+function decorateLyricLineWithInterludeLead(
+  line: LyricLine,
+  sourceLineIndex: number,
+  interludeInlineLead: InterludePlaceholderLine
+): InterludeInlineLyricLine {
+  return {
+    ...line,
+    interludeInlineLead,
+    sourceLineIndex,
+  };
+}
+
 /**
  * Build a real {@link LyricLine} with synthetic word timings so interlude dots use the same
  * karaoke mask/outline path as timed lyrics. The three beats fall in a short countdown window
@@ -261,6 +287,19 @@ export function applyKaraokeInterludeEllipsis({
 
   if (alignment === LyricsAlignment.Center) {
     return [placeholder];
+  }
+
+  if (alignment === LyricsAlignment.Alternating) {
+    const decoratedNext = decorateLyricLineWithInterludeLead(
+      nextLine,
+      currentIndex + 1,
+      placeholder
+    );
+    const followingLine = allLines[currentIndex + 2];
+
+    return currentIndex % 2 === 0
+      ? [followingLine, decoratedNext].filter(Boolean)
+      : [decoratedNext, followingLine].filter(Boolean);
   }
 
   return visibleLines.map((line) => (line === currentLine ? placeholder : line));

--- a/src/utils/karaokeInterludeDisplay.ts
+++ b/src/utils/karaokeInterludeDisplay.ts
@@ -151,22 +151,26 @@ function hasLongInterludeGap(currentLine: LyricLine, nextLine: LyricLine): boole
   return silentGapMs >= LONG_INTERLUDE_THRESHOLD_MS;
 }
 
-export function hasLongInterludeAtTime(
+export function didAdvancePastLongInterlude(
   allLines: LyricLine[],
-  currentIndex: number,
-  currentTimeMs: number
+  previousCurrentIndex: number,
+  currentIndex: number
 ): boolean {
-  if (currentIndex < 0) {
+  if (
+    previousCurrentIndex < 0 ||
+    currentIndex < 0 ||
+    currentIndex !== previousCurrentIndex + 1
+  ) {
     return false;
   }
 
+  const previousLine = allLines[previousCurrentIndex];
   const currentLine = allLines[currentIndex];
-  const nextLine = allLines[currentIndex + 1];
-  if (!currentLine || !nextLine) {
+  if (!previousLine || !currentLine) {
     return false;
   }
 
-  return hasLongInterlude(currentLine, nextLine, currentTimeMs);
+  return hasLongInterludeGap(previousLine, currentLine);
 }
 
 export function isInterludePlaceholderLine(

--- a/tests/test-karaoke-interlude-display.test.ts
+++ b/tests/test-karaoke-interlude-display.test.ts
@@ -6,6 +6,7 @@ import {
   buildInterludeLyricLineWithWordTimings,
   getIntroInterludeInlineLead,
   getInterludeDotsFadeOpacity,
+  isInterludeInlineLyricLine,
   isInterludePlaceholderLine,
 } from "../src/utils/karaokeInterludeDisplay";
 
@@ -101,10 +102,11 @@ describe("karaoke interlude ellipsis", () => {
     expect(getIntroInterludeInlineLead(twoLineSong, 4000, true)).not.toBeNull();
   });
 
-  test("alternating gap placeholder flags dotsInlineWithNext for inline lead on the next row", () => {
+  test("alternating gap advances to the next lyric pair and carries inline dots on the upcoming row", () => {
     const lines = [
       makeLine(0, "Verse line"),
       makeLine(15000, "Next line"),
+      makeLine(22000, "Line after next"),
     ];
 
     const visible = applyKaraokeInterludeEllipsis({
@@ -117,27 +119,40 @@ describe("karaoke interlude ellipsis", () => {
     });
 
     expect(visible).toHaveLength(2);
-    expect(isInterludePlaceholderLine(visible[0]!)).toBe(true);
-    expect(visible[0]!.dotsInlineWithNext).toBe(true);
-    expect(visible[1]).toBe(lines[1]);
+    expect(visible[0]).toBe(lines[2]);
+    expect(isInterludeInlineLyricLine(visible[1]!)).toBe(true);
+    if (!isInterludeInlineLyricLine(visible[1]!)) {
+      throw new Error("expected upcoming lyric with inline interlude lead");
+    }
+    expect(visible[1].startTimeMs).toBe(lines[1]!.startTimeMs);
+    expect(visible[1].words).toBe(lines[1]!.words);
+    expect(visible[1].interludeInlineLead.dotsInlineWithNext).toBe(true);
   });
 
   test("buildInterludeLyricLineWithWordTimings splits the silent gap into three timed words", () => {
     const lines = [
       makeLine(0, "Verse line"),
       makeLine(15000, "Next line"),
+      makeLine(22000, "Line after next"),
     ];
-    const placeholder = applyKaraokeInterludeEllipsis({
+    const visible = applyKaraokeInterludeEllipsis({
       visibleLines: [lines[0], lines[1]],
       allLines: lines,
       alignment: LyricsAlignment.Alternating,
       currentIndex: 0,
       currentTimeMs: 5000,
       enabled: true,
-    })[0];
-    if (!isInterludePlaceholderLine(placeholder!)) throw new Error("expected placeholder");
+    });
+    const upcomingWithLead = visible[1];
+    if (!isInterludeInlineLyricLine(upcomingWithLead!)) {
+      throw new Error("expected upcoming lyric with inline interlude lead");
+    }
 
-    const timed = buildInterludeLyricLineWithWordTimings(placeholder, lines, 0);
+    const timed = buildInterludeLyricLineWithWordTimings(
+      upcomingWithLead.interludeInlineLead,
+      lines,
+      0
+    );
     expect(timed.wordTimings).toHaveLength(3);
     // Countdown is last 3s before next line: next at 15000 → line starts at 12000, 3000ms total
     const total = timed.wordTimings!.reduce((s, w) => s + w.durationMs, 0);
@@ -145,31 +160,38 @@ describe("karaoke interlude ellipsis", () => {
     expect(timed.startTimeMs).toBe("12000");
   });
 
-  test("replaces the held current line with placeholder after delay; countdownStartMs matches dot fill", () => {
+  test("alternating odd rows keep the upcoming lyric first and bring in the following lyric during gaps", () => {
     const lines = [
-      makeLine(0, "Verse line"),
-      makeLine(15000, "Next line"),
+      makeLine(0, "Line one"),
+      makeLine(4000, "Line two"),
+      makeLine(20000, "Line three"),
+      makeLine(28000, "Line four"),
     ];
 
     const visible = applyKaraokeInterludeEllipsis({
-      visibleLines: [lines[0], lines[1]],
+      visibleLines: [lines[2], lines[1]],
       allLines: lines,
       alignment: LyricsAlignment.Alternating,
-      currentIndex: 0,
-      currentTimeMs: 5000,
+      currentIndex: 1,
+      currentTimeMs: 9000,
       enabled: true,
     });
 
     expect(visible).toHaveLength(2);
-    expect(isInterludePlaceholderLine(visible[0]!)).toBe(true);
-    expect(visible[0]!.countdownStartMs).toBe(12000);
-    expect(visible[1]).toBe(lines[1]);
+    expect(isInterludeInlineLyricLine(visible[0]!)).toBe(true);
+    if (!isInterludeInlineLyricLine(visible[0]!)) {
+      throw new Error("expected upcoming lyric with inline interlude lead");
+    }
+    expect(visible[0].startTimeMs).toBe(lines[2]!.startTimeMs);
+    expect(visible[0].interludeInlineLead.countdownStartMs).toBe(17000);
+    expect(visible[1]).toBe(lines[3]);
   });
 
   test("keeps the upcoming lyric visible while ellipsis leads into a long gap", () => {
     const lines = [
       makeLine(0, "Verse line"),
       makeLine(15000, "Next line"),
+      makeLine(22000, "Line after next"),
     ];
 
     const visible = applyKaraokeInterludeEllipsis({
@@ -182,8 +204,12 @@ describe("karaoke interlude ellipsis", () => {
     });
 
     expect(visible).toHaveLength(2);
-    expect(isInterludePlaceholderLine(visible[0]!)).toBe(true);
-    expect(visible[1]).toBe(lines[1]);
+    expect(visible[0]).toBe(lines[2]);
+    expect(isInterludeInlineLyricLine(visible[1]!)).toBe(true);
+    if (!isInterludeInlineLyricLine(visible[1]!)) {
+      throw new Error("expected upcoming lyric with inline interlude lead");
+    }
+    expect(visible[1].startTimeMs).toBe(lines[1]!.startTimeMs);
   });
 
   test("getInterludeDotsFadeOpacity rests dim then ramps to full at countdownStartMs", () => {

--- a/tests/test-karaoke-interlude-display.test.ts
+++ b/tests/test-karaoke-interlude-display.test.ts
@@ -6,6 +6,7 @@ import {
   buildInterludeLyricLineWithWordTimings,
   getIntroInterludeInlineLead,
   getInterludeDotsFadeOpacity,
+  hasLongInterludeAtTime,
   isInterludeInlineLyricLine,
   isInterludePlaceholderLine,
 } from "../src/utils/karaokeInterludeDisplay";
@@ -216,6 +217,16 @@ describe("karaoke interlude ellipsis", () => {
     expect(getInterludeDotsFadeOpacity(11400, 12000)).toBe(0.4);
     expect(getInterludeDotsFadeOpacity(11775, 12000)).toBeCloseTo(0.7, 5);
     expect(getInterludeDotsFadeOpacity(12000, 12000)).toBe(1);
+  });
+
+  test("hasLongInterludeAtTime turns off exactly when the upcoming line starts", () => {
+    const lines = [
+      makeLine(0, "Verse line"),
+      makeLine(15000, "Next line"),
+    ];
+
+    expect(hasLongInterludeAtTime(lines, 0, 14999)).toBe(true);
+    expect(hasLongInterludeAtTime(lines, 0, 15000)).toBe(false);
   });
 
   test("does not show ellipsis for ordinary short gaps", () => {

--- a/tests/test-karaoke-interlude-display.test.ts
+++ b/tests/test-karaoke-interlude-display.test.ts
@@ -4,9 +4,9 @@ import { LyricsAlignment, type LyricLine } from "../src/types/lyrics";
 import {
   applyKaraokeInterludeEllipsis,
   buildInterludeLyricLineWithWordTimings,
+  didAdvancePastLongInterlude,
   getIntroInterludeInlineLead,
   getInterludeDotsFadeOpacity,
-  hasLongInterludeAtTime,
   isInterludeInlineLyricLine,
   isInterludePlaceholderLine,
 } from "../src/utils/karaokeInterludeDisplay";
@@ -219,14 +219,16 @@ describe("karaoke interlude ellipsis", () => {
     expect(getInterludeDotsFadeOpacity(12000, 12000)).toBe(1);
   });
 
-  test("hasLongInterludeAtTime turns off exactly when the upcoming line starts", () => {
+  test("didAdvancePastLongInterlude only trips on adjacent line advances across a long gap", () => {
     const lines = [
       makeLine(0, "Verse line"),
       makeLine(15000, "Next line"),
+      makeLine(22000, "Line after next"),
     ];
 
-    expect(hasLongInterludeAtTime(lines, 0, 14999)).toBe(true);
-    expect(hasLongInterludeAtTime(lines, 0, 15000)).toBe(false);
+    expect(didAdvancePastLongInterlude(lines, 0, 1)).toBe(true);
+    expect(didAdvancePastLongInterlude(lines, 1, 2)).toBe(false);
+    expect(didAdvancePastLongInterlude(lines, 0, 2)).toBe(false);
   });
 
   test("does not show ellipsis for ordinary short gaps", () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- shift alternating interlude windows forward so the display shows the upcoming lyric pair instead of holding the outgoing line
- attach inline interlude countdown metadata to the upcoming lyric row in the renderer
- refresh alternating rows immediately when playback exits a long interlude so `next+1` does not flicker out and back
- avoid timer starvation in alternating lyrics by detecting long-interlude exits from adjacent line-index changes instead of rerunning the delayed row effect on every playback tick
- sync the alternating row correction before paint so the final stale frame does not flash during the `next+1` handoff
- update focused karaoke interlude tests for even and odd alternating layouts plus the long-gap handoff helper

## Testing
- `bun test tests/test-karaoke-interlude-display.test.ts`
- `bun run build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b998ae9c-3c3f-4313-9ebf-0ba1a4bed00b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b998ae9c-3c3f-4313-9ebf-0ba1a4bed00b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

