### PR TITLE
fix(karaoke): stabilize menu bar and controls during playback

### DIFF
--- a/src/apps/ipod/components/FullScreenPortal.tsx
+++ b/src/apps/ipod/components/FullScreenPortal.tsx
@@ -53,11 +53,13 @@ export function FullScreenPortal({
   fullScreenPlayerRef,
   activityState,
 }: FullScreenPortalProps) {
-  const isAnyActivityActive = activityState.isLoadingLyrics || 
-    activityState.isTranslating || 
-    activityState.isFetchingFurigana || 
-    activityState.isFetchingSoramimi || 
-    activityState.isAddingSong;
+  const isAnyActivityActive = activityState
+    ? activityState.isLoadingLyrics ||
+      activityState.isTranslating ||
+      activityState.isFetchingFurigana ||
+      activityState.isFetchingSoramimi ||
+      activityState.isAddingSong
+    : false;
 
   const { t } = useTranslation();
   const currentTheme = useThemeStore((s) => s.current);
@@ -473,10 +475,12 @@ export function FullScreenPortal({
                 "calc(max(env(safe-area-inset-right), 0.75rem) + clamp(1rem, 6dvw, 4rem))",
             }}
           >
+            {activityState && (
             <ActivityIndicatorWithLabel
               size={32}
               state={activityState}
             />
+            )}
           </motion.div>
         )}
       </AnimatePresence>

--- a/src/apps/ipod/types.ts
+++ b/src/apps/ipod/types.ts
@@ -75,8 +75,8 @@ export interface FullScreenPortalProps {
   displayModeOptions?: { value: DisplayMode; label: string }[];
   // Player ref for mobile Safari handling
   fullScreenPlayerRef: React.RefObject<ReactPlayer | null>;
-  /** Activity state for loading indicators */
-  activityState: ActivityInfo;
+  /** Activity state for loading indicators (optional — karaoke supplies from lyrics subtree) */
+  activityState?: ActivityInfo;
 }
 
 // IpodScreen props

--- a/src/apps/karaoke/components/KaraokeAppComponent.tsx
+++ b/src/apps/karaoke/components/KaraokeAppComponent.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from "react";
+import { useCallback, useMemo } from "react";
 import { AnimatePresence, motion } from "framer-motion";
 import ReactPlayer from "react-player";
 import { cn } from "@/lib/utils";
@@ -12,16 +12,22 @@ import { ShareItemDialog } from "@/components/dialogs/ShareItemDialog";
 import { LyricsSearchDialog } from "@/components/dialogs/LyricsSearchDialog";
 import { SongSearchDialog } from "@/components/dialogs/SongSearchDialog";
 import { appMetadata } from "..";
-import { LyricsDisplay } from "@/apps/ipod/components/LyricsDisplay";
 import { FullScreenPortal } from "@/apps/ipod/components/FullScreenPortal";
 import { CoverFlow } from "@/apps/ipod/components/CoverFlow";
-import { LyricsSyncMode } from "@/components/shared/LyricsSyncMode";
 import { ListenSessionInvite } from "@/components/listen/ListenSessionInvite";
 import { JoinSessionDialog } from "@/components/listen/JoinSessionDialog";
 import { ReactionOverlay } from "@/components/listen/ReactionOverlay";
 import { ListenSessionToolbar } from "@/components/listen/ListenSessionToolbar";
 import { getTranslatedAppName } from "@/utils/i18n";
-import { ActivityIndicatorWithLabel } from "@/components/ui/activity-indicator-with-label";
+import {
+  KaraokeLyricsPlaybackProvider,
+  KaraokeWindowLyricsOverlay,
+  KaraokeFullscreenLyricsOverlay,
+  KaraokeLyricsActivityIndicator,
+  KaraokeSyncModeWindowPanel,
+  KaraokeSyncModeFullscreenPanel,
+} from "./KaraokeLyricsPlayback";
+import { KaraokeIosAutoplayWatchdog } from "./KaraokeIosAutoplayWatchdog";
 import { FullscreenPlayerControls } from "@/components/shared/FullscreenPlayerControls";
 import { useAudioSettingsStore } from "@/stores/useAudioSettingsStore";
 import { useKaraokeLogic } from "../hooks/useKaraokeLogic";
@@ -31,6 +37,8 @@ import { AmbientBackground } from "@/components/shared/AmbientBackground";
 import { MeshGradientBackground } from "@/components/shared/MeshGradientBackground";
 import { WaterBackground } from "@/components/shared/WaterBackground";
 import { PLAYER_PROGRESS_INTERVAL_MS } from "@/apps/ipod/constants";
+import { useChatsStore } from "@/stores/useChatsStore";
+import { useShallow } from "zustand/react/shallow";
 
 export function KaraokeAppComponent({
   isWindowOpen,
@@ -55,7 +63,6 @@ export function KaraokeAppComponent({
     showLyrics,
     lyricsAlignment,
     lyricsFont,
-    lyricsFontClassName,
     koreanDisplay,
     japaneseFurigana,
     romanization,
@@ -68,6 +75,7 @@ export function KaraokeAppComponent({
     toggleLoopAll,
     toggleLoopCurrent,
     toggleFullScreen,
+    setIsPlaying,
     isOffline,
     manualSync,
     isHelpDialogOpen,
@@ -87,6 +95,7 @@ export function KaraokeAppComponent({
     setIsLyricsSearchDialogOpen,
     isSongSearchDialogOpen,
     setIsSongSearchDialogOpen,
+    isAddingSong,
     isListenInviteOpen,
     setIsListenInviteOpen,
     isJoinListenDialogOpen,
@@ -102,7 +111,7 @@ export function KaraokeAppComponent({
     LONG_PRESS_MOVE_THRESHOLD,
     fullScreenPlayerRef,
     playerRef,
-    displayElapsedTime,
+    lyricsPlaybackSyncRef,
     duration,
     setDuration,
     statusMessage,
@@ -112,11 +121,6 @@ export function KaraokeAppComponent({
     currentTrack,
     lyricsSourceOverride,
     coverUrl,
-    lyricsControls,
-    furiganaMap,
-    soramimiMap,
-    activityState,
-    hasActiveActivity,
     translationLanguages,
     listenSession,
     listenSessionUsername,
@@ -170,7 +174,20 @@ export function KaraokeAppComponent({
     isXpTheme,
     getCurrentKaraokeTrack,
     adjustLyricOffset,
-  } = useKaraokeLogic({ isWindowOpen, isForeground, initialData, instanceId });
+  } = useKaraokeLogic({
+    isWindowOpen,
+    isForeground,
+    initialData,
+    instanceId,
+  });
+
+  const { username, isAuthenticated } = useChatsStore(
+    useShallow((s) => ({ username: s.username, isAuthenticated: s.isAuthenticated }))
+  );
+  const auth = useMemo(
+    () => (username && isAuthenticated ? { username, isAuthenticated } : undefined),
+    [username, isAuthenticated]
+  );
 
   const displayModeOptions = [
     { value: DisplayMode.Video, label: t("apps.ipod.menu.displayVideo") },
@@ -197,6 +214,59 @@ export function KaraokeAppComponent({
     },
     [setDisplayMode, showStatus, t]
   );
+
+  const handleFullscreenLyricsSwipeUp = useCallback(() => {
+    if (isOffline) {
+      showOfflineStatus();
+    } else {
+      handleNext();
+      if (!isListenSessionRemoteOnly) {
+        setTimeout(() => {
+          const newIndex = (currentIndex + 1) % tracks.length;
+          const newTrack = tracks[newIndex];
+          if (newTrack) {
+            const artistInfo = newTrack.artist ? ` - ${newTrack.artist}` : "";
+            showStatus(`⏭ ${newTrack.title}${artistInfo}`);
+          }
+        }, 150);
+      }
+    }
+  }, [
+    currentIndex,
+    handleNext,
+    isListenSessionRemoteOnly,
+    isOffline,
+    showOfflineStatus,
+    showStatus,
+    tracks,
+  ]);
+
+  const handleFullscreenLyricsSwipeDown = useCallback(() => {
+    if (isOffline) {
+      showOfflineStatus();
+    } else {
+      handlePrevious();
+      if (!isListenSessionRemoteOnly) {
+        setTimeout(() => {
+          const newIndex = currentIndex === 0 ? tracks.length - 1 : currentIndex - 1;
+          const newTrack = tracks[newIndex];
+          if (newTrack) {
+            const artistInfo = newTrack.artist ? ` - ${newTrack.artist}` : "";
+            showStatus(`⏮ ${newTrack.title}${artistInfo}`);
+          }
+        }, 150);
+      }
+    }
+  }, [
+    currentIndex,
+    handlePrevious,
+    isListenSessionRemoteOnly,
+    isOffline,
+    showOfflineStatus,
+    showStatus,
+    tracks.length,
+    tracks,
+  ]);
 
   const menuBar = (
     <KaraokeMenuBar
@@ -347,6 +417,14 @@ export function KaraokeAppComponent({
             restartAutoHideTimer();
           }}
         >
+          <KaraokeIosAutoplayWatchdog
+            listenSession={listenSession}
+            isListenSessionDj={isListenSessionDj}
+            isPlaying={isPlaying}
+            setIsPlaying={setIsPlaying}
+            showStatus={showStatus}
+            userHasInteractedRef={userHasInteractedRef}
+          />
           {/* Reaction overlay for listen sessions */}
           {listenSession && !isSyncModeOpen && (
             <ReactionOverlay className="z-40" />
@@ -473,62 +551,56 @@ export function KaraokeAppComponent({
             )}
           </AnimatePresence>
 
-          {/* Lyrics overlay */}
-          {showLyrics && currentTrack && !isFullScreen && (
-            <>
-              <div className="absolute inset-0 z-10 bg-black/50 pointer-events-none" />
-              <div className="absolute inset-0 z-20 pointer-events-none karaoke-force-font">
-                <LyricsDisplay
-                  lines={lyricsControls.lines}
-                  originalLines={lyricsControls.originalLines}
-                  currentLine={lyricsControls.currentLine}
-                  isLoading={lyricsControls.isLoading}
-                  error={lyricsControls.error}
-                  visible={true}
-                  videoVisible={true}
-                  alignment={lyricsAlignment}
-                  koreanDisplay={koreanDisplay}
-                  japaneseFurigana={japaneseFurigana}
-                  fontClassName={lyricsFontClassName}
-                  onAdjustOffset={(delta) => {
-                    adjustLyricOffset(currentIndex, delta);
-                    const newOffset = (currentTrack?.lyricOffset ?? 0) + delta;
-                    const sign = newOffset > 0 ? "+" : newOffset < 0 ? "" : "";
-                    showStatus(`${t("apps.ipod.status.offset")} ${sign}${(newOffset / 1000).toFixed(2)}s`);
-                    lyricsControls.updateCurrentTimeManually(displayElapsedTime + newOffset / 1000);
-                  }}
-                  onSwipeUp={() => {
-                    if (isOffline) {
-                      showOfflineStatus();
-                    } else {
-                      handleNext();
-                    }
-                  }}
-                  onSwipeDown={() => {
-                    if (isOffline) {
-                      showOfflineStatus();
-                    } else {
-                      handlePrevious();
-                    }
-                  }}
-                  isTranslating={lyricsControls.isTranslating}
-                  textSizeClass="karaoke-lyrics-text"
-                  gapClass="gap-1"
-                  containerStyle={{
-                    gap: "clamp(0.3rem, 2.5cqw, 1rem)",
-                  }}
-                  interactive={true}
-                  bottomPaddingClass={showControls || anyMenuOpen || !isPlaying ? "pb-20" : "pb-12"}
-                  furiganaMap={furiganaMap}
-                  soramimiMap={soramimiMap}
-                  currentTimeMs={(displayElapsedTime + (currentTrack?.lyricOffset ?? 0) / 1000) * 1000}
-                  showInterludeEllipsis
-                  onSeekToTime={seekToTime}
-                  coverUrl={coverUrl}
-                />
-              </div>
-            </>
-          )}
+          <KaraokeLyricsPlaybackProvider
+            currentTrack={currentTrack}
+            lyricsFont={lyricsFont}
+            romanization={romanization}
+            lyricsTranslationLanguage={lyricsTranslationLanguage}
+            lyricsSourceOverride={lyricsSourceOverride}
+            isAddingSong={isAddingSong}
+            setIsLyricsSearchDialogOpen={setIsLyricsSearchDialogOpen}
+            t={t}
+            auth={auth}
+            lyricsPlaybackSyncRef={lyricsPlaybackSyncRef}
+          >
+            <KaraokeWindowLyricsOverlay
+              showLyrics={showLyrics}
+              isFullScreen={isFullScreen}
+              showControls={showControls}
+              anyMenuOpen={anyMenuOpen}
+              isPlaying={isPlaying}
+              coverUrl={coverUrl}
+              isOffline={isOffline}
+              currentIndex={currentIndex}
+              adjustLyricOffset={adjustLyricOffset}
+              showStatus={showStatus}
+              showOfflineStatus={showOfflineStatus}
+              handleNext={handleNext}
+              handlePrevious={handlePrevious}
+              seekToTime={seekToTime}
+              t={t}
+              currentTrack={currentTrack}
+              koreanDisplay={koreanDisplay}
+              japaneseFurigana={japaneseFurigana}
+              lyricsAlignment={lyricsAlignment}
+            />
+            <KaraokeLyricsActivityIndicator />
+            <KaraokeSyncModeWindowPanel
+              isSyncModeOpen={isSyncModeOpen}
+              isFullScreen={isFullScreen}
+              currentTrack={currentTrack}
+              currentIndex={currentIndex}
+              duration={duration}
+              romanization={romanization}
+              setLyricOffset={setLyricOffset}
+              adjustLyricOffset={adjustLyricOffset}
+              playerRef={playerRef}
+              closeSyncMode={closeSyncMode}
+              handleRefreshLyrics={handleRefreshLyrics}
+              showStatus={showStatus}
+              t={t}
+            />
+          </KaraokeLyricsPlaybackProvider>
 
           {/* CoverFlow overlay - full height, below notitlebar (z-50) */}
           {tracks.length > 0 && (
@@ -572,24 +644,6 @@ export function KaraokeAppComponent({
                     {statusMessage}
                   </div>
                 </div>
-              </motion.div>
-            )}
-          </AnimatePresence>
-
-          {/* Activity indicator - scales with container size */}
-          <AnimatePresence>
-            {hasActiveActivity && (
-              <motion.div
-                className="absolute top-8 right-6 z-40 pointer-events-none flex justify-end"
-                initial={{ opacity: 0, scale: 0.8 }}
-                animate={{ opacity: 1, scale: 1 }}
-                exit={{ opacity: 0, scale: 0.8 }}
-                transition={{ duration: 0.2 }}
-              >
-                <ActivityIndicatorWithLabel
-                  size={32}
-                  state={activityState}
-                />
               </motion.div>
             )}
           </AnimatePresence>
@@ -737,43 +791,22 @@ export function KaraokeAppComponent({
           onClose={() => setIsJoinListenDialogOpen(false)}
           onJoin={handleJoinListenSession}
         />
-
-        {/* Lyrics Sync Mode (non-fullscreen only - fullscreen renders in portal) */}
-        {/* z-40 so the notitlebar hover titlebar (z-50) appears above it */}
-        {!isFullScreen && isSyncModeOpen && lyricsControls.originalLines.length > 0 && (
-          <div className="absolute inset-0 z-40" style={{ borderRadius: "inherit" }}>
-            <LyricsSyncMode
-              lines={lyricsControls.originalLines}
-              currentTimeMs={displayElapsedTime * 1000}
-              durationMs={duration * 1000}
-              currentOffset={currentTrack?.lyricOffset ?? 0}
-              romanization={romanization}
-              furiganaMap={furiganaMap}
-              onSetOffset={(offsetMs) => {
-                setLyricOffset(currentIndex, offsetMs);
-                showStatus(
-                  `${t("apps.ipod.status.offset")} ${offsetMs >= 0 ? "+" : ""}${(offsetMs / 1000).toFixed(2)}s`
-                );
-              }}
-              onAdjustOffset={(deltaMs) => {
-                adjustLyricOffset(currentIndex, deltaMs);
-                const newOffset = (currentTrack?.lyricOffset ?? 0) + deltaMs;
-                showStatus(
-                  `${t("apps.ipod.status.offset")} ${newOffset >= 0 ? "+" : ""}${(newOffset / 1000).toFixed(2)}s`
-                );
-              }}
-              onSeek={(timeMs) => {
-                playerRef.current?.seekTo(timeMs / 1000);
-              }}
-              onClose={closeSyncMode}
-              onSearchLyrics={handleRefreshLyrics}
-            />
-          </div>
-        )}
       </WindowFrame>
 
       {/* Full screen portal */}
       {isFullScreen && (
+        <KaraokeLyricsPlaybackProvider
+          currentTrack={currentTrack}
+          lyricsFont={lyricsFont}
+          romanization={romanization}
+          lyricsTranslationLanguage={lyricsTranslationLanguage}
+          lyricsSourceOverride={lyricsSourceOverride}
+          isAddingSong={isAddingSong}
+          setIsLyricsSearchDialogOpen={setIsLyricsSearchDialogOpen}
+          t={t}
+          auth={auth}
+          lyricsPlaybackSyncRef={lyricsPlaybackSyncRef}
+        >
         <FullScreenPortal
           onClose={toggleFullScreen}
           togglePlay={handlePlayPause}
@@ -818,38 +851,24 @@ export function KaraokeAppComponent({
           onDisplayModeSelect={handleDisplayModeSelect}
           displayModeOptions={displayModeOptions}
           syncModeContent={
-            lyricsControls.originalLines.length > 0 ? (
-              <LyricsSyncMode
-                lines={lyricsControls.originalLines}
-                currentTimeMs={displayElapsedTime * 1000}
-                durationMs={duration * 1000}
-                currentOffset={currentTrack?.lyricOffset ?? 0}
-                romanization={romanization}
-                furiganaMap={furiganaMap}
-                onSetOffset={(offsetMs) => {
-                  setLyricOffset(currentIndex, offsetMs);
-                  showStatus(
-                    `${t("apps.ipod.status.offset")} ${offsetMs >= 0 ? "+" : ""}${(offsetMs / 1000).toFixed(2)}s`
-                  );
-                }}
-                onAdjustOffset={(deltaMs) => {
-                  adjustLyricOffset(currentIndex, deltaMs);
-                  const newOffset = (currentTrack?.lyricOffset ?? 0) + deltaMs;
-                  showStatus(
-                    `${t("apps.ipod.status.offset")} ${newOffset >= 0 ? "+" : ""}${(newOffset / 1000).toFixed(2)}s`
-                  );
-                }}
-                onSeek={(timeMs) => {
-                  const activePlayer = isFullScreen ? fullScreenPlayerRef.current : playerRef.current;
-                  activePlayer?.seekTo(timeMs / 1000);
-                }}
-                onClose={closeSyncMode}
-                onSearchLyrics={handleRefreshLyrics}
-              />
-            ) : undefined
+            <KaraokeSyncModeFullscreenPanel
+              isSyncModeOpen={isSyncModeOpen}
+              isFullScreen={isFullScreen}
+              currentTrack={currentTrack}
+              currentIndex={currentIndex}
+              duration={duration}
+              romanization={romanization}
+              setLyricOffset={setLyricOffset}
+              adjustLyricOffset={adjustLyricOffset}
+              fullScreenPlayerRef={fullScreenPlayerRef}
+              playerRef={playerRef}
+              closeSyncMode={closeSyncMode}
+              handleRefreshLyrics={handleRefreshLyrics}
+              showStatus={showStatus}
+              t={t}
+            />
           }
           fullScreenPlayerRef={fullScreenPlayerRef}
-          activityState={activityState}
         >
           {({ controlsVisible }) => (
             <div className="flex flex-col w-full h-full">
@@ -975,89 +994,31 @@ export function KaraokeAppComponent({
                   )}
                 </AnimatePresence>
 
-                {/* Lyrics overlays - positioned relative to viewport, not video container */}
-                {showLyrics && currentTrack && (
-                  <div className="fixed inset-0 bg-black/50 z-10 pointer-events-none" />
-                )}
-
-                {showLyrics && currentTrack && (
-                  <div className="absolute inset-0 z-20 pointer-events-none" data-lyrics>
-                    <LyricsDisplay
-                      lines={lyricsControls.lines}
-                      originalLines={lyricsControls.originalLines}
-                      currentLine={lyricsControls.currentLine}
-                      isLoading={lyricsControls.isLoading}
-                      error={lyricsControls.error}
-                      visible={true}
-                      videoVisible={true}
-                      alignment={lyricsAlignment}
-                      koreanDisplay={koreanDisplay}
-                      japaneseFurigana={japaneseFurigana}
-                      fontClassName={lyricsFontClassName}
-                      onAdjustOffset={(delta) => {
-                        adjustLyricOffset(currentIndex, delta);
-                        const newOffset = (currentTrack?.lyricOffset ?? 0) + delta;
-                        const sign = newOffset > 0 ? "+" : newOffset < 0 ? "" : "";
-                        showStatus(`${t("apps.ipod.status.offset")} ${sign}${(newOffset / 1000).toFixed(2)}s`);
-                        lyricsControls.updateCurrentTimeManually(displayElapsedTime + newOffset / 1000);
-                      }}
-                      onSwipeUp={() => {
-                        if (isOffline) {
-                          showOfflineStatus();
-                        } else {
-                          handleNext();
-                          if (!isListenSessionRemoteOnly) {
-                            setTimeout(() => {
-                              const newIndex = (currentIndex + 1) % tracks.length;
-                              const newTrack = tracks[newIndex];
-                              if (newTrack) {
-                                const artistInfo = newTrack.artist ? ` - ${newTrack.artist}` : "";
-                                showStatus(`⏭ ${newTrack.title}${artistInfo}`);
-                              }
-                            }, 150);
-                          }
-                        }
-                      }}
-                      onSwipeDown={() => {
-                        if (isOffline) {
-                          showOfflineStatus();
-                        } else {
-                          handlePrevious();
-                          if (!isListenSessionRemoteOnly) {
-                            setTimeout(() => {
-                              const newIndex = currentIndex === 0 ? tracks.length - 1 : currentIndex - 1;
-                              const newTrack = tracks[newIndex];
-                              if (newTrack) {
-                                const artistInfo = newTrack.artist ? ` - ${newTrack.artist}` : "";
-                                showStatus(`⏮ ${newTrack.title}${artistInfo}`);
-                              }
-                            }, 150);
-                          }
-                        }
-                      }}
-                      isTranslating={lyricsControls.isTranslating}
-                      textSizeClass="fullscreen-lyrics-text"
-                      gapClass="gap-0"
-                      containerStyle={{
-                        gap: "clamp(0.2rem, calc(min(10vw,10vh) * 0.08), 1rem)",
-                        paddingLeft: "env(safe-area-inset-left, 0px)",
-                        paddingRight: "env(safe-area-inset-right, 0px)",
-                      }}
-                      interactive={true}
-                      bottomPaddingClass={controlsVisible ? "pb-28" : "pb-16"}
-                      furiganaMap={furiganaMap}
-                      soramimiMap={soramimiMap}
-                      currentTimeMs={(displayElapsedTime + (currentTrack?.lyricOffset ?? 0) / 1000) * 1000}
-                      showInterludeEllipsis
-                      onSeekToTime={seekToTime}
-                      coverUrl={coverUrl}
-                    />
-                  </div>
-                )}
+                <KaraokeFullscreenLyricsOverlay
+                  showLyrics={showLyrics}
+                  currentTrack={currentTrack}
+                  coverUrl={coverUrl}
+                  isOffline={isOffline}
+                  currentIndex={currentIndex}
+                  adjustLyricOffset={adjustLyricOffset}
+                  showStatus={showStatus}
+                  showOfflineStatus={showOfflineStatus}
+                  handleNext={handleNext}
+                  handlePrevious={handlePrevious}
+                  seekToTime={seekToTime}
+                  t={t}
+                  controlsVisible={controlsVisible}
+                  koreanDisplay={koreanDisplay}
+                  japaneseFurigana={japaneseFurigana}
+                  lyricsAlignment={lyricsAlignment}
+                  onSwipeUp={handleFullscreenLyricsSwipeUp}
+                  onSwipeDown={handleFullscreenLyricsSwipeDown}
+                />
               </div>
             </div>
           )}
         </FullScreenPortal>
+        </KaraokeLyricsPlaybackProvider>
       )}
     </>
   );

--- a/src/apps/karaoke/components/KaraokeIosAutoplayWatchdog.tsx
+++ b/src/apps/karaoke/components/KaraokeIosAutoplayWatchdog.tsx
@@ -1,0 +1,63 @@
+import { useEffect, type MutableRefObject } from "react";
+import { useKaraokeStore } from "@/stores/useKaraokeStore";
+
+const ua = typeof navigator !== "undefined" ? navigator.userAgent : "";
+const isIOS = /iP(hone|od|ad)/.test(ua);
+const isSafari = /Safari/.test(ua) && !/Chrome/.test(ua) && !/CriOS/.test(ua);
+const isIOSSafari = isIOS && isSafari;
+
+interface KaraokeIosAutoplayWatchdogProps {
+  listenSession: unknown;
+  isListenSessionDj: boolean;
+  isPlaying: boolean;
+  setIsPlaying: (playing: boolean) => void;
+  showStatus: (message: string) => void;
+  userHasInteractedRef: MutableRefObject<boolean>;
+}
+
+/**
+ * Isolated subscription to elapsed time for iOS Safari blocked-autoplay detection.
+ * Keeps high-frequency ticks out of KaraokeAppComponent / menu / toolbar.
+ */
+export function KaraokeIosAutoplayWatchdog({
+  listenSession,
+  isListenSessionDj,
+  isPlaying,
+  setIsPlaying,
+  showStatus,
+  userHasInteractedRef,
+}: KaraokeIosAutoplayWatchdogProps) {
+  const elapsedTime = useKaraokeStore((s) => s.elapsedTime);
+
+  useEffect(() => {
+    if (
+      (listenSession && !isListenSessionDj) ||
+      !isPlaying ||
+      !isIOSSafari ||
+      userHasInteractedRef.current
+    ) {
+      return;
+    }
+
+    const startElapsed = elapsedTime;
+    const timer = setTimeout(() => {
+      if (useKaraokeStore.getState().isPlaying && useKaraokeStore.getState().elapsedTime === startElapsed) {
+        setIsPlaying(false);
+        showStatus("⏸");
+      }
+    }, 1200);
+
+    return () => clearTimeout(timer);
+  }, [
+    elapsedTime,
+    isIOSSafari,
+    isListenSessionDj,
+    isPlaying,
+    listenSession,
+    setIsPlaying,
+    showStatus,
+    userHasInteractedRef,
+  ]);
+
+  return null;
+}

--- a/src/apps/karaoke/components/KaraokeLyricsPlayback.tsx
+++ b/src/apps/karaoke/components/KaraokeLyricsPlayback.tsx
@@ -1,0 +1,610 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  type CSSProperties,
+  type MutableRefObject,
+  type ReactNode,
+} from "react";
+import type { TFunction } from "i18next";
+import { useShallow } from "zustand/react/shallow";
+import { AnimatePresence, motion } from "framer-motion";
+import { useLyrics } from "@/hooks/useLyrics";
+import { useFurigana } from "@/hooks/useFurigana";
+import { useActivityState, isAnyActivityActive } from "@/hooks/useActivityState";
+import { useLyricsErrorToast } from "@/hooks/useLyricsErrorToast";
+import { useKaraokeStore } from "@/stores/useKaraokeStore";
+import { getEffectiveTranslationLanguage, type Track } from "@/stores/useIpodStore";
+import { LyricsDisplay } from "@/apps/ipod/components/LyricsDisplay";
+import { LyricsSyncMode } from "@/components/shared/LyricsSyncMode";
+import { ActivityIndicatorWithLabel } from "@/components/ui/activity-indicator-with-label";
+import {
+  getLyricsFontClassName,
+  LyricsFont as LyricsFontEnum,
+  type JapaneseFurigana,
+  type KoreanDisplay,
+  type LyricsAlignment,
+  type LyricsFont,
+  type RomanizationSettings,
+} from "@/types/lyrics";
+import type ReactPlayer from "react-player";
+
+export interface KaraokeLyricsPlaybackContextValue {
+  lyricsControls: ReturnType<typeof useLyrics>;
+  furiganaMap: ReturnType<typeof useFurigana>["furiganaMap"];
+  soramimiMap: ReturnType<typeof useFurigana>["soramimiMap"];
+  activityState: ReturnType<typeof useActivityState>;
+  hasActiveActivity: boolean;
+  elapsedTime: number;
+  lyricsFontClassName: string;
+}
+
+const KaraokeLyricsPlaybackContext = createContext<KaraokeLyricsPlaybackContextValue | null>(
+  null
+);
+
+export function useKaraokeLyricsPlayback(): KaraokeLyricsPlaybackContextValue {
+  const ctx = useContext(KaraokeLyricsPlaybackContext);
+  if (!ctx) {
+    throw new Error("useKaraokeLyricsPlayback must be used within KaraokeLyricsPlaybackProvider");
+  }
+  return ctx;
+}
+
+interface ProviderProps {
+  children: ReactNode;
+  currentTrack: Track | null;
+  lyricsFont: LyricsFont | undefined;
+  romanization: RomanizationSettings;
+  lyricsTranslationLanguage: string | null;
+  lyricsSourceOverride: Track["lyricsSource"];
+  isAddingSong: boolean;
+  setIsLyricsSearchDialogOpen: (open: boolean) => void;
+  t: TFunction;
+  auth?: { username: string; isAuthenticated: boolean };
+  lyricsPlaybackSyncRef: MutableRefObject<
+    ((timeInLyricsSeconds: number) => void) | null
+  >;
+}
+
+export function KaraokeLyricsPlaybackProvider({
+  children,
+  currentTrack,
+  lyricsFont,
+  romanization,
+  lyricsTranslationLanguage,
+  lyricsSourceOverride,
+  isAddingSong,
+  setIsLyricsSearchDialogOpen,
+  t,
+  auth,
+  lyricsPlaybackSyncRef,
+}: ProviderProps) {
+  const elapsedTime = useKaraokeStore(useShallow((s) => s.elapsedTime));
+
+  const lyricsFontClassName = getLyricsFontClassName(lyricsFont ?? LyricsFontEnum.SerifRed);
+
+  const selectedMatchForLyrics = useMemo(() => {
+    if (!lyricsSourceOverride) return undefined;
+    return {
+      hash: lyricsSourceOverride.hash,
+      albumId: lyricsSourceOverride.albumId,
+      title: lyricsSourceOverride.title,
+      artist: lyricsSourceOverride.artist,
+      album: lyricsSourceOverride.album,
+    };
+  }, [lyricsSourceOverride]);
+
+  const effectiveTranslationLanguage = useMemo(
+    () => getEffectiveTranslationLanguage(lyricsTranslationLanguage),
+    [lyricsTranslationLanguage]
+  );
+
+  const lyricsControls = useLyrics({
+    songId: currentTrack?.id ?? "",
+    title: currentTrack?.title ?? "",
+    artist: currentTrack?.artist ?? "",
+    currentTime: elapsedTime + (currentTrack?.lyricOffset ?? 0) / 1000,
+    translateTo: effectiveTranslationLanguage,
+    selectedMatch: selectedMatchForLyrics,
+    includeFurigana: true,
+    includeSoramimi: true,
+    soramimiTargetLanguage: romanization.soramamiTargetLanguage ?? "zh-TW",
+    auth,
+  });
+
+  useLyricsErrorToast({
+    error: lyricsControls.error,
+    songId: currentTrack?.id,
+    onSearchClick: () => setIsLyricsSearchDialogOpen(true),
+    t,
+    appId: "karaoke",
+  });
+
+  const {
+    furiganaMap,
+    soramimiMap,
+    isFetchingFurigana: isFetchingFuriganaFromHook,
+    isFetchingSoramimi,
+    furiganaProgress,
+    soramimiProgress,
+  } = useFurigana({
+    songId: currentTrack?.id ?? "",
+    lines: lyricsControls.originalLines,
+    isShowingOriginal: true,
+    romanization,
+    prefetchedInfo: lyricsControls.furiganaInfo,
+    prefetchedSoramimiInfo: lyricsControls.soramimiInfo,
+    auth,
+  });
+
+  const activityState = useActivityState({
+    lyricsState: {
+      isLoading: lyricsControls.isLoading,
+      isTranslating: lyricsControls.isTranslating,
+      translationProgress: lyricsControls.translationProgress,
+    },
+    furiganaState: {
+      isFetchingFurigana: isFetchingFuriganaFromHook,
+      furiganaProgress,
+      isFetchingSoramimi,
+      soramimiProgress,
+    },
+    translationLanguage: effectiveTranslationLanguage,
+    isAddingSong,
+  });
+
+  const hasActiveActivity = isAnyActivityActive(activityState);
+
+  useEffect(() => {
+    lyricsPlaybackSyncRef.current = (timeInLyricsSeconds: number) => {
+      lyricsControls.updateCurrentTimeManually(timeInLyricsSeconds);
+    };
+    return () => {
+      lyricsPlaybackSyncRef.current = null;
+    };
+  }, [lyricsControls, lyricsPlaybackSyncRef]);
+
+  const value = useMemo(
+    (): KaraokeLyricsPlaybackContextValue => ({
+      lyricsControls,
+      furiganaMap,
+      soramimiMap,
+      activityState,
+      hasActiveActivity,
+      elapsedTime,
+      lyricsFontClassName,
+    }),
+    [
+      lyricsControls,
+      furiganaMap,
+      soramimiMap,
+      activityState,
+      hasActiveActivity,
+      elapsedTime,
+      lyricsFontClassName,
+    ]
+  );
+
+  return (
+    <KaraokeLyricsPlaybackContext.Provider value={value}>
+      {children}
+    </KaraokeLyricsPlaybackContext.Provider>
+  );
+}
+
+const windowContainerStyle: CSSProperties = {
+  gap: "clamp(0.3rem, 2.5cqw, 1rem)",
+};
+
+function buildFullscreenContainerStyle(): CSSProperties {
+  return {
+    gap: "clamp(0.2rem, calc(min(10vw,10vh) * 0.08), 1rem)",
+    paddingLeft: "env(safe-area-inset-left, 0px)",
+    paddingRight: "env(safe-area-inset-right, 0px)",
+  };
+}
+
+interface WindowLyricsProps {
+  showLyrics: boolean;
+  isFullScreen: boolean;
+  showControls: boolean;
+  anyMenuOpen: boolean;
+  isPlaying: boolean;
+  coverUrl: string | null;
+  isOffline: boolean;
+  currentIndex: number;
+  adjustLyricOffset: (index: number, delta: number) => void;
+  showStatus: (message: string) => void;
+  showOfflineStatus: () => void;
+  handleNext: () => void;
+  handlePrevious: () => void;
+  seekToTime: (timeMs: number) => void;
+  t: TFunction;
+  currentTrack: Track | null;
+  koreanDisplay: KoreanDisplay;
+  japaneseFurigana: JapaneseFurigana;
+  lyricsAlignment: LyricsAlignment;
+}
+
+export function KaraokeWindowLyricsOverlay({
+  showLyrics,
+  isFullScreen,
+  showControls,
+  anyMenuOpen,
+  isPlaying,
+  coverUrl,
+  isOffline,
+  currentIndex,
+  adjustLyricOffset,
+  showStatus,
+  showOfflineStatus,
+  handleNext,
+  handlePrevious,
+  seekToTime,
+  t,
+  currentTrack,
+  koreanDisplay,
+  japaneseFurigana,
+  lyricsAlignment,
+}: WindowLyricsProps) {
+  const {
+    lyricsControls,
+    furiganaMap,
+    soramimiMap,
+    elapsedTime,
+    lyricsFontClassName,
+  } = useKaraokeLyricsPlayback();
+
+  const onAdjustOffset = useCallback(
+    (delta: number) => {
+      adjustLyricOffset(currentIndex, delta);
+      const newOffset = (currentTrack?.lyricOffset ?? 0) + delta;
+      const sign = newOffset > 0 ? "+" : newOffset < 0 ? "" : "";
+      showStatus(`${t("apps.ipod.status.offset")} ${sign}${(newOffset / 1000).toFixed(2)}s`);
+      lyricsControls.updateCurrentTimeManually(elapsedTime + newOffset / 1000);
+    },
+    [
+      adjustLyricOffset,
+      currentIndex,
+      currentTrack?.lyricOffset,
+      elapsedTime,
+      lyricsControls,
+      showStatus,
+      t,
+    ]
+  );
+
+  const currentTimeMs =
+    (elapsedTime + (currentTrack?.lyricOffset ?? 0) / 1000) * 1000;
+
+  const bottomPadding =
+    showControls || anyMenuOpen || !isPlaying ? "pb-20" : "pb-12";
+
+  if (!showLyrics || !currentTrack || isFullScreen) return null;
+
+  return (
+    <>
+      <div className="absolute inset-0 z-10 bg-black/50 pointer-events-none" />
+      <div className="absolute inset-0 z-20 pointer-events-none karaoke-force-font">
+        <LyricsDisplay
+          lines={lyricsControls.lines}
+          originalLines={lyricsControls.originalLines}
+          currentLine={lyricsControls.currentLine}
+          isLoading={lyricsControls.isLoading}
+          error={lyricsControls.error}
+          visible={true}
+          videoVisible={true}
+          alignment={lyricsAlignment}
+          koreanDisplay={koreanDisplay}
+          japaneseFurigana={japaneseFurigana}
+          fontClassName={lyricsFontClassName}
+          onAdjustOffset={onAdjustOffset}
+          onSwipeUp={() => {
+            if (isOffline) showOfflineStatus();
+            else handleNext();
+          }}
+          onSwipeDown={() => {
+            if (isOffline) showOfflineStatus();
+            else handlePrevious();
+          }}
+          isTranslating={lyricsControls.isTranslating}
+          textSizeClass="karaoke-lyrics-text"
+          gapClass="gap-1"
+          containerStyle={windowContainerStyle}
+          interactive={true}
+          bottomPaddingClass={bottomPadding}
+          furiganaMap={furiganaMap}
+          soramimiMap={soramimiMap}
+          currentTimeMs={currentTimeMs}
+          showInterludeEllipsis
+          onSeekToTime={seekToTime}
+          coverUrl={coverUrl}
+        />
+      </div>
+    </>
+  );
+}
+
+interface FullscreenLyricsProps {
+  showLyrics: boolean;
+  currentTrack: Track | null;
+  coverUrl: string | null;
+  isOffline: boolean;
+  currentIndex: number;
+  adjustLyricOffset: (index: number, delta: number) => void;
+  showStatus: (message: string) => void;
+  showOfflineStatus: () => void;
+  handleNext: () => void;
+  handlePrevious: () => void;
+  seekToTime: (timeMs: number) => void;
+  t: TFunction;
+  controlsVisible: boolean;
+  koreanDisplay: KoreanDisplay;
+  japaneseFurigana: JapaneseFurigana;
+  lyricsAlignment: LyricsAlignment;
+  /** When set (e.g. fullscreen), replaces default next/previous swipe behavior */
+  onSwipeUp?: () => void;
+  onSwipeDown?: () => void;
+}
+
+export function KaraokeFullscreenLyricsOverlay({
+  showLyrics,
+  currentTrack,
+  coverUrl,
+  isOffline,
+  currentIndex,
+  adjustLyricOffset,
+  showStatus,
+  showOfflineStatus,
+  handleNext,
+  handlePrevious,
+  seekToTime,
+  t,
+  controlsVisible,
+  koreanDisplay,
+  japaneseFurigana,
+  lyricsAlignment,
+  onSwipeUp: onSwipeUpOverride,
+  onSwipeDown: onSwipeDownOverride,
+}: FullscreenLyricsProps) {
+  const {
+    lyricsControls,
+    furiganaMap,
+    soramimiMap,
+    elapsedTime,
+    lyricsFontClassName,
+  } = useKaraokeLyricsPlayback();
+
+  const onAdjustOffset = useCallback(
+    (delta: number) => {
+      adjustLyricOffset(currentIndex, delta);
+      const newOffset = (currentTrack?.lyricOffset ?? 0) + delta;
+      const sign = newOffset > 0 ? "+" : newOffset < 0 ? "" : "";
+      showStatus(`${t("apps.ipod.status.offset")} ${sign}${(newOffset / 1000).toFixed(2)}s`);
+      lyricsControls.updateCurrentTimeManually(elapsedTime + newOffset / 1000);
+    },
+    [
+      adjustLyricOffset,
+      currentIndex,
+      currentTrack?.lyricOffset,
+      elapsedTime,
+      lyricsControls,
+      showStatus,
+      t,
+    ]
+  );
+
+  const currentTimeMs =
+    (elapsedTime + (currentTrack?.lyricOffset ?? 0) / 1000) * 1000;
+
+  const bottomPadding = controlsVisible ? "pb-28" : "pb-16";
+
+  if (!showLyrics || !currentTrack) return null;
+
+  return (
+    <>
+      <div className="fixed inset-0 bg-black/50 z-10 pointer-events-none" />
+      <div className="absolute inset-0 z-20 pointer-events-none" data-lyrics>
+        <LyricsDisplay
+          lines={lyricsControls.lines}
+          originalLines={lyricsControls.originalLines}
+          currentLine={lyricsControls.currentLine}
+          isLoading={lyricsControls.isLoading}
+          error={lyricsControls.error}
+          visible={true}
+          videoVisible={true}
+          alignment={lyricsAlignment}
+          koreanDisplay={koreanDisplay}
+          japaneseFurigana={japaneseFurigana}
+          fontClassName={lyricsFontClassName}
+          onAdjustOffset={onAdjustOffset}
+          onSwipeUp={() => {
+            if (onSwipeUpOverride) {
+              onSwipeUpOverride();
+              return;
+            }
+            if (isOffline) showOfflineStatus();
+            else handleNext();
+          }}
+          onSwipeDown={() => {
+            if (onSwipeDownOverride) {
+              onSwipeDownOverride();
+              return;
+            }
+            if (isOffline) showOfflineStatus();
+            else handlePrevious();
+          }}
+          isTranslating={lyricsControls.isTranslating}
+          textSizeClass="fullscreen-lyrics-text"
+          gapClass="gap-0"
+          containerStyle={buildFullscreenContainerStyle()}
+          interactive={true}
+          bottomPaddingClass={bottomPadding}
+          furiganaMap={furiganaMap}
+          soramimiMap={soramimiMap}
+          currentTimeMs={currentTimeMs}
+          showInterludeEllipsis
+          onSeekToTime={seekToTime}
+          coverUrl={coverUrl}
+        />
+      </div>
+    </>
+  );
+}
+
+export function KaraokeLyricsActivityIndicator() {
+  const { activityState, hasActiveActivity } = useKaraokeLyricsPlayback();
+  return (
+    <AnimatePresence>
+      {hasActiveActivity && (
+        <motion.div
+          className="absolute top-8 right-6 z-40 pointer-events-none flex justify-end"
+          initial={{ opacity: 0, scale: 0.8 }}
+          animate={{ opacity: 1, scale: 1 }}
+          exit={{ opacity: 0, scale: 0.8 }}
+          transition={{ duration: 0.2 }}
+        >
+          <ActivityIndicatorWithLabel size={32} state={activityState} />
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}
+
+interface SyncModeWindowProps {
+  isSyncModeOpen: boolean;
+  isFullScreen: boolean;
+  currentTrack: Track | null;
+  currentIndex: number;
+  duration: number;
+  romanization: RomanizationSettings;
+  setLyricOffset: (index: number, offsetMs: number) => void;
+  adjustLyricOffset: (index: number, deltaMs: number) => void;
+  playerRef: React.RefObject<ReactPlayer | null>;
+  closeSyncMode: () => void;
+  handleRefreshLyrics: () => void;
+  showStatus: (message: string) => void;
+  t: TFunction;
+}
+
+export function KaraokeSyncModeWindowPanel({
+  isSyncModeOpen,
+  isFullScreen,
+  currentTrack,
+  currentIndex,
+  duration,
+  romanization,
+  setLyricOffset,
+  adjustLyricOffset,
+  playerRef,
+  closeSyncMode,
+  handleRefreshLyrics,
+  showStatus,
+  t,
+}: SyncModeWindowProps) {
+  const { lyricsControls, furiganaMap, elapsedTime } = useKaraokeLyricsPlayback();
+  if (!isSyncModeOpen || isFullScreen || lyricsControls.originalLines.length === 0) {
+    return null;
+  }
+  return (
+    <div className="absolute inset-0 z-40" style={{ borderRadius: "inherit" }}>
+      <LyricsSyncMode
+        lines={lyricsControls.originalLines}
+        currentTimeMs={elapsedTime * 1000}
+        durationMs={duration * 1000}
+        currentOffset={currentTrack?.lyricOffset ?? 0}
+        romanization={romanization}
+        furiganaMap={furiganaMap}
+        onSetOffset={(offsetMs) => {
+          setLyricOffset(currentIndex, offsetMs);
+          showStatus(
+            `${t("apps.ipod.status.offset")} ${offsetMs >= 0 ? "+" : ""}${(offsetMs / 1000).toFixed(2)}s`
+          );
+        }}
+        onAdjustOffset={(deltaMs) => {
+          adjustLyricOffset(currentIndex, deltaMs);
+          const newOffset = (currentTrack?.lyricOffset ?? 0) + deltaMs;
+          showStatus(
+            `${t("apps.ipod.status.offset")} ${newOffset >= 0 ? "+" : ""}${(newOffset / 1000).toFixed(2)}s`
+          );
+        }}
+        onSeek={(timeMs) => {
+          playerRef.current?.seekTo(timeMs / 1000);
+        }}
+        onClose={closeSyncMode}
+        onSearchLyrics={handleRefreshLyrics}
+      />
+    </div>
+  );
+}
+
+interface SyncModeFullscreenProps {
+  isSyncModeOpen: boolean;
+  isFullScreen: boolean;
+  currentTrack: Track | null;
+  currentIndex: number;
+  duration: number;
+  romanization: RomanizationSettings;
+  setLyricOffset: (index: number, offsetMs: number) => void;
+  adjustLyricOffset: (index: number, deltaMs: number) => void;
+  fullScreenPlayerRef: React.RefObject<ReactPlayer | null>;
+  playerRef: React.RefObject<ReactPlayer | null>;
+  closeSyncMode: () => void;
+  handleRefreshLyrics: () => void;
+  showStatus: (message: string) => void;
+  t: TFunction;
+}
+
+export function KaraokeSyncModeFullscreenPanel({
+  isSyncModeOpen,
+  isFullScreen,
+  currentTrack,
+  currentIndex,
+  duration,
+  romanization,
+  setLyricOffset,
+  adjustLyricOffset,
+  fullScreenPlayerRef,
+  playerRef,
+  closeSyncMode,
+  handleRefreshLyrics,
+  showStatus,
+  t,
+}: SyncModeFullscreenProps) {
+  const { lyricsControls, furiganaMap, elapsedTime } = useKaraokeLyricsPlayback();
+  if (!isSyncModeOpen || !isFullScreen || lyricsControls.originalLines.length === 0) {
+    return null;
+  }
+  return (
+    <LyricsSyncMode
+      lines={lyricsControls.originalLines}
+      currentTimeMs={elapsedTime * 1000}
+      durationMs={duration * 1000}
+      currentOffset={currentTrack?.lyricOffset ?? 0}
+      romanization={romanization}
+      furiganaMap={furiganaMap}
+      onSetOffset={(offsetMs) => {
+        setLyricOffset(currentIndex, offsetMs);
+        showStatus(
+          `${t("apps.ipod.status.offset")} ${offsetMs >= 0 ? "+" : ""}${(offsetMs / 1000).toFixed(2)}s`
+        );
+      }}
+      onAdjustOffset={(deltaMs) => {
+        adjustLyricOffset(currentIndex, deltaMs);
+        const newOffset = (currentTrack?.lyricOffset ?? 0) + deltaMs;
+        showStatus(
+          `${t("apps.ipod.status.offset")} ${newOffset >= 0 ? "+" : ""}${(newOffset / 1000).toFixed(2)}s`
+        );
+      }}
+      onSeek={(timeMs) => {
+        const activePlayer = isFullScreen ? fullScreenPlayerRef.current : playerRef.current;
+        activePlayer?.seekTo(timeMs / 1000);
+      }}
+      onClose={closeSyncMode}
+      onSearchLyrics={handleRefreshLyrics}
+    />
+  );
+}

--- a/src/apps/karaoke/hooks/useKaraokeLogic.ts
+++ b/src/apps/karaoke/hooks/useKaraokeLogic.ts
@@ -3,12 +3,7 @@ import ReactPlayer from "react-player";
 import { toast } from "sonner";
 import { useTranslation } from "react-i18next";
 import { useTranslatedHelpItems } from "@/hooks/useTranslatedHelpItems";
-import {
-  useIpodStore,
-  Track,
-  getEffectiveTranslationLanguage,
-  flushPendingLyricOffsetSave,
-} from "@/stores/useIpodStore";
+import { useIpodStore, Track, flushPendingLyricOffsetSave } from "@/stores/useIpodStore";
 import { useKaraokeStore } from "@/stores/useKaraokeStore";
 import { useShallow } from "zustand/react/shallow";
 import {
@@ -16,10 +11,8 @@ import {
   useAudioSettingsStoreShallow,
   useAppStoreShallow,
 } from "@/stores/helpers";
-import { useLyrics } from "@/hooks/useLyrics";
-import { useFurigana } from "@/hooks/useFurigana";
 import { useThemeStore } from "@/stores/useThemeStore";
-import { LyricsAlignment, LyricsFont, DisplayMode, getLyricsFontClassName } from "@/types/lyrics";
+import { LyricsAlignment, LyricsFont, DisplayMode } from "@/types/lyrics";
 import { useOffline } from "@/hooks/useOffline";
 import { useListenSync } from "@/hooks/useListenSync";
 import { TRANSLATION_LANGUAGES, getYouTubeVideoId, formatKugouImageUrl } from "@/apps/ipod/constants";
@@ -27,8 +20,6 @@ import { useLibraryUpdateChecker } from "@/apps/ipod/hooks/useLibraryUpdateCheck
 import { saveSongMetadataFromTrack } from "@/utils/songMetadataCache";
 import { useChatsStore } from "@/stores/useChatsStore";
 import { useListenSessionStore } from "@/stores/useListenSessionStore";
-import { useActivityState, isAnyActivityActive } from "@/hooks/useActivityState";
-import { useLyricsErrorToast } from "@/hooks/useLyricsErrorToast";
 import type { KaraokeInitialData } from "../../base/types";
 import type { CoverFlowRef } from "@/apps/ipod/components/CoverFlow";
 import type { SongSearchResult } from "@/components/dialogs/SongSearchDialog";
@@ -48,6 +39,7 @@ export function useKaraokeLogic({
   initialData,
   instanceId,
 }: UseKaraokeLogicOptions) {
+  const lyricsPlaybackSyncRef = useRef<((timeInLyricsSeconds: number) => void) | null>(null);
   const { t } = useTranslation();
   const isOffline = useOffline();
   const translatedHelpItems = useTranslatedHelpItems("karaoke", helpItems);
@@ -165,15 +157,9 @@ export function useKaraokeLogic({
     }))
   );
 
-  // Auth for protected operations (force refresh, change lyrics source)
-  const { username, isAuthenticated } = useChatsStore(
-    useShallow((s) => ({ username: s.username, isAuthenticated: s.isAuthenticated }))
+  const { username } = useChatsStore(
+    useShallow((s) => ({ username: s.username }))
   );
-  const auth = useMemo(
-    () => (username && isAuthenticated ? { username, isAuthenticated } : undefined),
-    [username, isAuthenticated]
-  );
-
   const {
     currentSession: listenSession,
     isHost: isListenSessionHost,
@@ -263,9 +249,7 @@ export function useKaraokeLogic({
   // Full screen additional state
   const fullScreenPlayerRef = useRef<ReactPlayer | null>(null);
 
-  // Playback state
-  const [elapsedTime, setElapsedTime] = useState(0);
-  const [virtualListenElapsed, setVirtualListenElapsed] = useState(0);
+  // Playback position lives in karaoke store (high-frequency updates) so the main hook does not re-render every tick
   const [duration, setDurationLocal] = useState(0);
   const setDuration = useCallback((d: number) => {
     setDurationLocal(d);
@@ -288,8 +272,6 @@ export function useKaraokeLogic({
   const ua = navigator.userAgent;
   const isIOS = /iP(hone|od|ad)/.test(ua);
   const isSafari = /Safari/.test(ua) && !/Chrome/.test(ua) && !/CriOS/.test(ua);
-  const isIOSSafari = isIOS && isSafari;
-
   // Track user interaction for autoplay guard (iOS Safari blocks autoplay until user interacts)
   const userHasInteractedRef = useRef(false);
 
@@ -412,8 +394,6 @@ export function useKaraokeLogic({
     syncListenSession,
   ]);
 
-  const displayElapsedTime = listenRemoteOnly ? virtualListenElapsed : elapsedTime;
-
   useListenSync({
     currentTrackId: currentTrack?.id ?? null,
     currentTrackMeta,
@@ -423,7 +403,7 @@ export function useKaraokeLogic({
     getActivePlayer,
     addTrackFromId: addTrackFromVideoId,
     applyListenerPlayback: !listenRemoteOnly,
-    setVirtualElapsedSeconds: listenRemoteOnly ? setVirtualListenElapsed : undefined,
+    setVirtualElapsedSeconds: listenRemoteOnly ? setStoreElapsedTime : undefined,
   });
   const lyricsSourceOverride = currentTrack?.lyricsSource;
 
@@ -437,89 +417,6 @@ export function useKaraokeLogic({
     return formatKugouImageUrl(currentTrack.cover, 800) ?? youtubeThumbnail;
   }, [currentTrack]);
 
-  // Lyrics hook
-  const selectedMatchForLyrics = useMemo(() => {
-    if (!lyricsSourceOverride) return undefined;
-    return {
-      hash: lyricsSourceOverride.hash,
-      albumId: lyricsSourceOverride.albumId,
-      title: lyricsSourceOverride.title,
-      artist: lyricsSourceOverride.artist,
-      album: lyricsSourceOverride.album,
-    };
-  }, [lyricsSourceOverride]);
-
-  // Resolve "auto" translation language to actual ryOS locale
-  const effectiveTranslationLanguage = useMemo(
-    () => getEffectiveTranslationLanguage(lyricsTranslationLanguage),
-    [lyricsTranslationLanguage]
-  );
-
-  const lyricsControls = useLyrics({
-    songId: currentTrack?.id ?? "",
-    title: currentTrack?.title ?? "",
-    artist: currentTrack?.artist ?? "",
-    currentTime: displayElapsedTime + (currentTrack?.lyricOffset ?? 0) / 1000,
-    translateTo: effectiveTranslationLanguage,
-    selectedMatch: selectedMatchForLyrics,
-    includeFurigana: true, // Fetch furigana info with lyrics to reduce API calls
-    // Always include soramimi in request to avoid hydration timing issues
-    // (default setting is false, but user's saved setting might be true after hydration)
-    // The server only returns cached soramimi data, doesn't generate anything here
-    includeSoramimi: true,
-    // Pass target language so server returns correct cached soramimi data
-    soramimiTargetLanguage: romanization.soramamiTargetLanguage ?? "zh-TW",
-    // Auth for force refresh / changing lyrics source
-    auth,
-  });
-
-  // Show toast with Search button when lyrics fetch fails
-  useLyricsErrorToast({
-    error: lyricsControls.error,
-    songId: currentTrack?.id,
-    onSearchClick: () => setIsLyricsSearchDialogOpen(true),
-    t,
-    appId: "karaoke",
-  });
-
-  // Fetch furigana for lyrics (shared between main and fullscreen displays)
-  // Use pre-fetched info from lyrics request to skip extra API call
-  const { 
-    furiganaMap, 
-    soramimiMap,
-    isFetchingFurigana: isFetchingFuriganaFromHook,
-    isFetchingSoramimi,
-    furiganaProgress,
-    soramimiProgress,
-  } = useFurigana({
-    songId: currentTrack?.id ?? "",
-    lines: lyricsControls.originalLines,
-    isShowingOriginal: true,
-    romanization,
-    prefetchedInfo: lyricsControls.furiganaInfo,
-    prefetchedSoramimiInfo: lyricsControls.soramimiInfo,
-    auth,
-  });
-
-  // Consolidated activity state for loading indicators
-  const activityState = useActivityState({
-    lyricsState: {
-      isLoading: lyricsControls.isLoading,
-      isTranslating: lyricsControls.isTranslating,
-      translationProgress: lyricsControls.translationProgress,
-    },
-    furiganaState: {
-      isFetchingFurigana: isFetchingFuriganaFromHook,
-      furiganaProgress,
-      isFetchingSoramimi,
-      soramimiProgress,
-    },
-    translationLanguage: effectiveTranslationLanguage,
-    isAddingSong,
-  });
-  
-  const hasActiveActivity = isAnyActivityActive(activityState);
-
   // Translation languages with translated labels
   const translationLanguages = useMemo(
     () =>
@@ -530,9 +427,6 @@ export function useKaraokeLogic({
       })),
     [t]
   );
-
-  // Get CSS class name for current lyrics font
-  const lyricsFontClassName = getLyricsFontClassName(lyricsFont);
 
   // Status helper functions
   const showStatus = useCallback((message: string) => {
@@ -611,7 +505,7 @@ export function useKaraokeLogic({
     if (isOffline) {
       showOfflineStatus();
     } else if (listenRemoteOnly) {
-      const positionMs = Math.round(displayElapsedTime * 1000);
+      const positionMs = Math.round(useKaraokeStore.getState().elapsedTime * 1000);
       const action = isPlaying ? "pause" : "play";
       void sendRemotePlaybackCommand({ action, positionMs }).then((r) => {
         if (!r.ok) toast.error(r.error ?? "Remote control failed");
@@ -622,7 +516,6 @@ export function useKaraokeLogic({
       showStatus(isPlaying ? "⏸" : "▶");
     }
   }, [
-    displayElapsedTime,
     isOffline,
     isPlaying,
     listenRemoteOnly,
@@ -696,7 +589,7 @@ export function useKaraokeLogic({
       const seekTarget = -newLyricOffset / 1000;
       
       if (newLyricOffset < 0 && seekTarget >= 1) {
-        setElapsedTime(seekTarget);
+        setStoreElapsedTime(seekTarget);
         
         trackSwitchTimeoutRef.current = setTimeout(() => {
           isTrackSwitchingRef.current = false;
@@ -708,14 +601,14 @@ export function useKaraokeLogic({
         }, 2000);
       } else {
         // Start from beginning for positive/zero offset or small negative offset
-        setElapsedTime(0);
+        setStoreElapsedTime(0);
         trackSwitchTimeoutRef.current = setTimeout(() => {
           isTrackSwitchingRef.current = false;
         }, 2000);
       }
     }
     prevCurrentIndexRef.current = currentIndex;
-  }, [currentIndex, tracks, isFullScreen, showStatus]);
+  }, [currentIndex, tracks, isFullScreen, showStatus, setStoreElapsedTime]);
 
   // Cleanup
   useEffect(() => {
@@ -769,7 +662,7 @@ export function useKaraokeLogic({
       
       if (isFullScreen) {
         // Entering fullscreen - sync position from main player to fullscreen player
-        const currentTime = playerRef.current?.getCurrentTime() || elapsedTime;
+        const currentTime = playerRef.current?.getCurrentTime() ?? useKaraokeStore.getState().elapsedTime;
         const wasPlaying = isPlaying;
 
         // Wait for fullscreen player to be ready before seeking
@@ -796,7 +689,7 @@ export function useKaraokeLogic({
         setTimeout(checkAndSync, 100);
       } else {
         // Exiting fullscreen - sync position from fullscreen player to main player
-        const currentTime = fullScreenPlayerRef.current?.getCurrentTime() || elapsedTime;
+        const currentTime = fullScreenPlayerRef.current?.getCurrentTime() ?? useKaraokeStore.getState().elapsedTime;
         const wasPlaying = isPlaying;
 
         setTimeout(() => {
@@ -814,7 +707,7 @@ export function useKaraokeLogic({
       }
       prevFullScreenRef.current = isFullScreen;
     }
-  }, [isFullScreen, elapsedTime, isPlaying, setIsPlaying]);
+  }, [isFullScreen, isPlaying, setIsPlaying]);
 
   // Handle closing sync mode - flush pending offset saves
   const closeSyncMode = useCallback(async () => {
@@ -841,7 +734,6 @@ export function useKaraokeLogic({
   const handleProgress = useCallback(
     (state: { playedSeconds: number }) => {
       if (listenRemoteOnly) return;
-      setElapsedTime(state.playedSeconds);
       setStoreElapsedTime(state.playedSeconds);
     },
     [listenRemoteOnly, setStoreElapsedTime]
@@ -877,37 +769,6 @@ export function useKaraokeLogic({
 
   // Handle player ready
   const handleReady = useCallback(() => {}, []);
-
-  // Watchdog for blocked autoplay on iOS Safari (local playback only).
-  // Skip for anyone in a listen session who is not the DJ — playback time comes from sync / virtual clock,
-  // so elapsed can stay flat while isPlaying is true (would wrongly force-pause and desync remote control).
-  useEffect(() => {
-    if (
-      (listenSession && !isListenSessionDj) ||
-      !isPlaying ||
-      !isIOSSafari ||
-      userHasInteractedRef.current
-    )
-      return;
-
-    const startElapsed = elapsedTime;
-    const timer = setTimeout(() => {
-      if (useKaraokeStore.getState().isPlaying && elapsedTime === startElapsed) {
-        setIsPlaying(false);
-        showStatus("⏸");
-      }
-    }, 1200);
-
-    return () => clearTimeout(timer);
-  }, [
-    elapsedTime,
-    isIOSSafari,
-    isListenSessionDj,
-    isPlaying,
-    listenSession,
-    setIsPlaying,
-    showStatus,
-  ]);
 
   // Seek time (delta)
   const seekTime = useCallback(
@@ -1543,14 +1404,14 @@ export function useKaraokeLogic({
         const newOffset = (currentTrack?.lyricOffset ?? 0) + delta;
         const sign = newOffset > 0 ? "+" : newOffset < 0 ? "" : "";
         showStatus(`${t("apps.ipod.status.offset")} ${sign}${(newOffset / 1000).toFixed(2)}s`);
-        lyricsControls.updateCurrentTimeManually(displayElapsedTime + newOffset / 1000);
+        const tSec = useKaraokeStore.getState().elapsedTime + newOffset / 1000;
+        lyricsPlaybackSyncRef.current?.(tSec);
       }
     };
 
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
   }, [
-    displayElapsedTime,
     handleNext,
     handlePlayPause,
     handlePrevious,
@@ -1566,7 +1427,7 @@ export function useKaraokeLogic({
     showOfflineStatus,
     currentIndex,
     currentTrack,
-    lyricsControls,
+    lyricsPlaybackSyncRef,
     t,
   ]);
 
@@ -1709,7 +1570,6 @@ export function useKaraokeLogic({
     showLyrics,
     lyricsAlignment,
     lyricsFont,
-    lyricsFontClassName,
     koreanDisplay,
     japaneseFurigana,
     romanization,
@@ -1765,8 +1625,7 @@ export function useKaraokeLogic({
     LONG_PRESS_MOVE_THRESHOLD,
     fullScreenPlayerRef,
     playerRef,
-    elapsedTime,
-    displayElapsedTime,
+    lyricsPlaybackSyncRef,
     duration,
     setDuration,
     statusMessage,
@@ -1776,11 +1635,6 @@ export function useKaraokeLogic({
     currentTrack,
     lyricsSourceOverride,
     coverUrl,
-    lyricsControls,
-    furiganaMap,
-    soramimiMap,
-    activityState,
-    hasActiveActivity,
     translationLanguages,
     showStatus,
     showOfflineStatus,

--- a/src/stores/useKaraokeStore.ts
+++ b/src/stores/useKaraokeStore.ts
@@ -1,5 +1,6 @@
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
+import type { SetStateAction } from "react";
 import { useIpodStore, Track } from "./useIpodStore";
 
 /** Helper to get current index from song ID */
@@ -51,7 +52,7 @@ export interface KaraokeState extends KaraokeData {
   previousTrack: () => void;
   toggleFullScreen: () => void;
   setFullScreen: (fullScreen: boolean) => void;
-  setElapsedTime: (time: number) => void;
+  setElapsedTime: (time: SetStateAction<number>) => void;
   setTotalTime: (time: number) => void;
 }
 
@@ -196,7 +197,11 @@ export const useKaraokeStore = create<KaraokeState>()(
 
       setFullScreen: (fullScreen) => set({ isFullScreen: fullScreen }),
 
-      setElapsedTime: (time) => set({ elapsedTime: time }),
+      setElapsedTime: (time) =>
+        set((state) => ({
+          elapsedTime:
+            typeof time === "function" ? (time as (prev: number) => number)(state.elapsedTime) : time,
+        })),
       setTotalTime: (time) => set({ totalTime: time }),
     }),
     {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Playback progress was updating React state every tick (~200ms), which re-rendered the whole karaoke window including the menu bar and bottom `FullscreenPlayerControls`.

This change routes high-frequency position updates through the karaoke Zustand store only, and mounts `useLyrics` / `useFurigana` / lyrics UI under a dedicated `KaraokeLyricsPlaybackProvider` subtree so the menu bar and player toolbar are no longer parents of that work. Fullscreen lyrics and sync mode panels share the same lyrics hook instance via context.

Also: `setElapsedTime` accepts functional updates for listen-session virtual clock smoothing; iOS Safari autoplay watchdog moved to a small isolated component; `FullScreenPortal` `activityState` is optional when karaoke supplies its own loading indicator.

## Testing

- `bun run build` (tsc + vite)
- `bun run test:unit`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-caffebb2-d266-4a12-b252-ef8550531d94"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-caffebb2-d266-4a12-b252-ef8550531d94"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

