### PR TITLE
Stabilize karaoke and lyrics playback rerenders

### DIFF
--- a/src/apps/ipod/components/LyricsDisplay.tsx
+++ b/src/apps/ipod/components/LyricsDisplay.tsx
@@ -9,6 +9,7 @@ import {
 import { motion, AnimatePresence } from "framer-motion";
 import { useTranslation } from "react-i18next";
 import {
+  memo,
   useMemo,
   useRef,
   useState,
@@ -1301,7 +1302,11 @@ function LyricsLineRowContent({
     interludeInlineCountdownStartMs !== undefined
   );
   const [dotsExitDone, setDotsExitDone] = useState(true);
-  if (dotsActive && dotsExitDone) setDotsExitDone(false);
+  useEffect(() => {
+    if (dotsActive) {
+      setDotsExitDone(false);
+    }
+  }, [dotsActive]);
 
   return (
     <>
@@ -1722,6 +1727,100 @@ function LyricsLineRowContent({
     </>
   );
 }
+
+function areWordTimingsEquivalent(
+  prev?: LyricWord[],
+  next?: LyricWord[]
+): boolean {
+  if (prev === next) return true;
+  if (!prev || !next) return prev === next;
+  if (prev.length !== next.length) return false;
+
+  for (let index = 0; index < prev.length; index += 1) {
+    const prevWord = prev[index];
+    const nextWord = next[index];
+    if (
+      prevWord.text !== nextWord.text ||
+      prevWord.startTimeMs !== nextWord.startTimeMs ||
+      prevWord.durationMs !== nextWord.durationMs
+    ) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+function areLyricLinesEquivalent(
+  prev: LyricLine | null | undefined,
+  next: LyricLine | null | undefined
+): boolean {
+  if (prev === next) return true;
+  if (!prev || !next) return prev === next;
+
+  return (
+    prev.startTimeMs === next.startTimeMs &&
+    prev.words === next.words &&
+    areWordTimingsEquivalent(prev.wordTimings, next.wordTimings)
+  );
+}
+
+function areInterludeMetaEquivalent(
+  prev: LyricsLineRowContentProps["interludeMeta"],
+  next: LyricsLineRowContentProps["interludeMeta"]
+): boolean {
+  if (prev === next) return true;
+  if (!prev || !next) return prev === next;
+
+  return (
+    prev.countdownStartMs === next.countdownStartMs &&
+    areLyricLinesEquivalent(prev.anchorLine, next.anchorLine)
+  );
+}
+
+const MemoizedLyricsLineRowContent = memo(
+  LyricsLineRowContent,
+  (prev, next) => {
+    return (
+      areLyricLinesEquivalent(prev.line, next.line) &&
+      prev.isCurrent === next.isCurrent &&
+      prev.isInterludePlaceholder === next.isInterludePlaceholder &&
+      prev.hasWordTimings === next.hasWordTimings &&
+      prev.timeMsForRow === next.timeMsForRow &&
+      prev.translatedText === next.translatedText &&
+      prev.textSizeClass === next.textSizeClass &&
+      prev.lineHeightClass === next.lineHeightClass &&
+      prev.fontClassName === next.fontClassName &&
+      prev.interactive === next.interactive &&
+      prev.onSeekToTime === next.onSeekToTime &&
+      prev.romanization === next.romanization &&
+      prev.furiganaMap === next.furiganaMap &&
+      prev.soramimiMap === next.soramimiMap &&
+      prev.renderWithFurigana === next.renderWithFurigana &&
+      prev.processText === next.processText &&
+      prev.showKoreanRomanization === next.showKoreanRomanization &&
+      prev.isOldSchoolKaraoke === next.isOldSchoolKaraoke &&
+      prev.isGradientStyle === next.isGradientStyle &&
+      prev.isColoredGlow === next.isColoredGlow &&
+      prev.highlightColor === next.highlightColor &&
+      prev.baseColor === next.baseColor &&
+      prev.glowFilter === next.glowFilter &&
+      prev.glowShadowHighlight === next.glowShadowHighlight &&
+      areInterludeMetaEquivalent(prev.interludeMeta, next.interludeMeta) &&
+      prev.interludePlaceholderDotsInlineOnlyGhost ===
+        next.interludePlaceholderDotsInlineOnlyGhost &&
+      areLyricLinesEquivalent(
+        prev.interludeInlineDotsLine,
+        next.interludeInlineDotsLine
+      ) &&
+      prev.timeMsForInterludeDots === next.timeMsForInterludeDots &&
+      prev.interludeInlineCountdownStartMs ===
+        next.interludeInlineCountdownStartMs &&
+      prev.lineTextAlign === next.lineTextAlign
+    );
+  }
+);
+MemoizedLyricsLineRowContent.displayName = "LyricsLineRowContent";
 
 export function LyricsDisplay({
   lines,
@@ -2496,7 +2595,7 @@ export function LyricsDisplay({
                 transform: "translateZ(0)",
               }}
             >
-              <LyricsLineRowContent
+              <MemoizedLyricsLineRowContent
                 line={lineForContent}
                 isCurrent={isCurrent}
                 isInterludePlaceholder={isInterludePlaceholder}

--- a/src/apps/karaoke/components/KaraokeAppComponent.tsx
+++ b/src/apps/karaoke/components/KaraokeAppComponent.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from "react";
+import { useCallback, useMemo } from "react";
 import { AnimatePresence, motion } from "framer-motion";
 import ReactPlayer from "react-player";
 import { cn } from "@/lib/utils";
@@ -172,14 +172,17 @@ export function KaraokeAppComponent({
     adjustLyricOffset,
   } = useKaraokeLogic({ isWindowOpen, isForeground, initialData, instanceId });
 
-  const displayModeOptions = [
-    { value: DisplayMode.Video, label: t("apps.ipod.menu.displayVideo") },
-    { value: DisplayMode.Mesh, label: t("apps.ipod.menu.displayGradient") },
-    { value: DisplayMode.Water, label: t("apps.ipod.menu.displayWater") },
-    { value: DisplayMode.Shader, label: t("apps.ipod.menu.displayShader") },
-    { value: DisplayMode.Landscapes, label: t("apps.ipod.menu.displayLandscapes") },
-    { value: DisplayMode.Cover, label: t("apps.ipod.menu.displayCover") },
-  ];
+  const displayModeOptions = useMemo(
+    () => [
+      { value: DisplayMode.Video, label: t("apps.ipod.menu.displayVideo") },
+      { value: DisplayMode.Mesh, label: t("apps.ipod.menu.displayGradient") },
+      { value: DisplayMode.Water, label: t("apps.ipod.menu.displayWater") },
+      { value: DisplayMode.Shader, label: t("apps.ipod.menu.displayShader") },
+      { value: DisplayMode.Landscapes, label: t("apps.ipod.menu.displayLandscapes") },
+      { value: DisplayMode.Cover, label: t("apps.ipod.menu.displayCover") },
+    ],
+    [t]
+  );
 
   const handleDisplayModeSelect = useCallback(
     (value: DisplayMode) => {
@@ -198,42 +201,109 @@ export function KaraokeAppComponent({
     [setDisplayMode, showStatus, t]
   );
 
-  const menuBar = (
-    <KaraokeMenuBar
-      onClose={onClose}
-      onShowHelp={() => setIsHelpDialogOpen(true)}
-      onShowAbout={() => setIsAboutDialogOpen(true)}
-      onAddSong={handleAddSong}
-      onShareSong={handleShareSong}
-      onClearLibrary={() => setIsConfirmClearOpen(true)}
-      onSyncLibrary={manualSync}
-      onPlayTrack={handlePlayTrack}
-      onTogglePlay={handlePlayPause}
-      onPreviousTrack={handlePrevious}
-      onNextTrack={handleNext}
-      isPlaying={isPlaying}
-      isShuffled={isShuffled}
-      onToggleShuffle={toggleShuffle}
-      loopAll={loopAll}
-      onToggleLoopAll={toggleLoopAll}
-      loopCurrent={loopCurrent}
-      onToggleLoopCurrent={toggleLoopCurrent}
-      showLyrics={showLyrics}
-      onToggleLyrics={toggleLyrics}
-      onToggleFullScreen={toggleFullScreen}
-      onRefreshLyrics={handleRefreshLyrics}
-      onAdjustTiming={() => setIsSyncModeOpen(true)}
-      tracks={tracks}
-      currentIndex={currentIndex}
-      onToggleCoverFlow={handleToggleCoverFlow}
-      onStartListenSession={handleStartListenSession}
-      onJoinListenSession={() => setIsJoinListenDialogOpen(true)}
-      onShareListenSession={() => setIsListenInviteOpen(true)}
-      onLeaveListenSession={handleLeaveListenSession}
-      isInListenSession={!!listenSession}
-      isListenSessionHost={isListenSessionHost}
-    />
+  const openHelpDialog = useCallback(() => {
+    setIsHelpDialogOpen(true);
+  }, [setIsHelpDialogOpen]);
+
+  const openAboutDialog = useCallback(() => {
+    setIsAboutDialogOpen(true);
+  }, [setIsAboutDialogOpen]);
+
+  const openClearLibraryConfirm = useCallback(() => {
+    setIsConfirmClearOpen(true);
+  }, [setIsConfirmClearOpen]);
+
+  const openSyncMode = useCallback(() => {
+    setIsSyncModeOpen(true);
+  }, [setIsSyncModeOpen]);
+
+  const toggleSyncMode = useCallback(() => {
+    setIsSyncModeOpen((prev) => !prev);
+  }, [setIsSyncModeOpen]);
+
+  const openJoinListenDialog = useCallback(() => {
+    setIsJoinListenDialogOpen(true);
+  }, [setIsJoinListenDialogOpen]);
+
+  const openListenInviteDialog = useCallback(() => {
+    setIsListenInviteOpen(true);
+  }, [setIsListenInviteOpen]);
+
+  const menuBar = useMemo(
+    () => (
+      <KaraokeMenuBar
+        onClose={onClose}
+        onShowHelp={openHelpDialog}
+        onShowAbout={openAboutDialog}
+        onAddSong={handleAddSong}
+        onShareSong={handleShareSong}
+        onClearLibrary={openClearLibraryConfirm}
+        onSyncLibrary={manualSync}
+        onPlayTrack={handlePlayTrack}
+        onTogglePlay={handlePlayPause}
+        onPreviousTrack={handlePrevious}
+        onNextTrack={handleNext}
+        isPlaying={isPlaying}
+        isShuffled={isShuffled}
+        onToggleShuffle={toggleShuffle}
+        loopAll={loopAll}
+        onToggleLoopAll={toggleLoopAll}
+        loopCurrent={loopCurrent}
+        onToggleLoopCurrent={toggleLoopCurrent}
+        showLyrics={showLyrics}
+        onToggleLyrics={toggleLyrics}
+        onToggleFullScreen={toggleFullScreen}
+        onRefreshLyrics={handleRefreshLyrics}
+        onAdjustTiming={openSyncMode}
+        tracks={tracks}
+        currentIndex={currentIndex}
+        onToggleCoverFlow={handleToggleCoverFlow}
+        onStartListenSession={handleStartListenSession}
+        onJoinListenSession={openJoinListenDialog}
+        onShareListenSession={openListenInviteDialog}
+        onLeaveListenSession={handleLeaveListenSession}
+        isInListenSession={!!listenSession}
+        isListenSessionHost={isListenSessionHost}
+      />
+    ),
+    [
+      onClose,
+      openHelpDialog,
+      openAboutDialog,
+      handleAddSong,
+      handleShareSong,
+      openClearLibraryConfirm,
+      manualSync,
+      handlePlayTrack,
+      handlePlayPause,
+      handlePrevious,
+      handleNext,
+      isPlaying,
+      isShuffled,
+      toggleShuffle,
+      loopAll,
+      toggleLoopAll,
+      loopCurrent,
+      toggleLoopCurrent,
+      showLyrics,
+      toggleLyrics,
+      toggleFullScreen,
+      handleRefreshLyrics,
+      openSyncMode,
+      tracks,
+      currentIndex,
+      handleToggleCoverFlow,
+      handleStartListenSession,
+      openJoinListenDialog,
+      openListenInviteDialog,
+      handleLeaveListenSession,
+      listenSession,
+      isListenSessionHost,
+    ]
   );
+
+  const lyricsCurrentTimeMs =
+    (displayElapsedTime + (currentTrack?.lyricOffset ?? 0) / 1000) * 1000;
   const shouldAnimateVisuals =
     isPlaying && (isForeground ?? true) && !isListenSessionRemoteOnly;
 
@@ -521,7 +591,7 @@ export function KaraokeAppComponent({
                   bottomPaddingClass={showControls || anyMenuOpen || !isPlaying ? "pb-20" : "pb-12"}
                   furiganaMap={furiganaMap}
                   soramimiMap={soramimiMap}
-                  currentTimeMs={(displayElapsedTime + (currentTrack?.lyricOffset ?? 0) / 1000) * 1000}
+                  currentTimeMs={lyricsCurrentTimeMs}
                   showInterludeEllipsis
                   onSeekToTime={seekToTime}
                   coverUrl={coverUrl}
@@ -651,7 +721,7 @@ export function KaraokeAppComponent({
               displayMode={displayMode}
               onDisplayModeSelect={handleDisplayModeSelect}
               displayModeOptions={displayModeOptions}
-              onSyncMode={() => setIsSyncModeOpen((prev) => !prev)}
+              onSyncMode={toggleSyncMode}
               currentAlignment={lyricsAlignment}
               onAlignmentCycle={cycleAlignment}
               currentFont={lyricsFont}
@@ -812,7 +882,7 @@ export function KaraokeAppComponent({
           onCycleLyricsFont={cycleLyricsFont}
           romanization={romanization}
           onRomanizationChange={setRomanization}
-          onSyncMode={() => setIsSyncModeOpen((prev) => !prev)}
+          onSyncMode={toggleSyncMode}
           isSyncModeOpen={isSyncModeOpen}
           displayMode={displayMode}
           onDisplayModeSelect={handleDisplayModeSelect}
@@ -1047,7 +1117,7 @@ export function KaraokeAppComponent({
                       bottomPaddingClass={controlsVisible ? "pb-28" : "pb-16"}
                       furiganaMap={furiganaMap}
                       soramimiMap={soramimiMap}
-                      currentTimeMs={(displayElapsedTime + (currentTrack?.lyricOffset ?? 0) / 1000) * 1000}
+                      currentTimeMs={lyricsCurrentTimeMs}
                       showInterludeEllipsis
                       onSeekToTime={seekToTime}
                       coverUrl={coverUrl}

--- a/src/apps/karaoke/components/KaraokeMenuBar.tsx
+++ b/src/apps/karaoke/components/KaraokeMenuBar.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { memo, useCallback, useMemo, useState } from "react";
 import { MenuBar } from "@/components/layout/MenuBar";
 import {
   MenubarMenu,
@@ -65,7 +65,7 @@ interface KaraokeMenuBarProps {
   currentIndex: number;
 }
 
-export function KaraokeMenuBar({
+function KaraokeMenuBarComponent({
   onClose,
   onShowHelp,
   onShowAbout,
@@ -144,40 +144,52 @@ export function KaraokeMenuBar({
     exportLibrary: s.exportLibrary,
   }));
 
-  const translationLanguages = [
-    { label: t("apps.ipod.translationLanguages.original"), code: null },
-    { label: t("apps.ipod.translationLanguages.auto"), code: "auto" },
-    { separator: true },
-    { label: "English", code: "en" },
-    { label: "中文", code: "zh-TW" },
-    { label: "日本語", code: "ja" },
-    { label: "한국어", code: "ko" },
-    { label: "Español", code: "es" },
-    { label: "Français", code: "fr" },
-    { label: "Deutsch", code: "de" },
-    { label: "Português", code: "pt" },
-    { label: "Italiano", code: "it" },
-    { label: "Русский", code: "ru" },
-  ];
-
-  // Group tracks by artist
-  const tracksByArtist = tracks.reduce<
-    Record<string, { track: Track; index: number }[]>
-  >((acc, track, index) => {
-    const artist = track.artist || t("apps.ipod.menu.unknownArtist");
-    if (!acc[artist]) {
-      acc[artist] = [];
-    }
-    acc[artist].push({ track, index });
-    return acc;
-  }, {});
-
-  // Get sorted list of artists
-  const artists = Object.keys(tracksByArtist).sort((a, b) =>
-    a.localeCompare(b, undefined, { sensitivity: "base" })
+  const translationLanguages = useMemo(
+    () => [
+      { label: t("apps.ipod.translationLanguages.original"), code: null },
+      { label: t("apps.ipod.translationLanguages.auto"), code: "auto" },
+      { separator: true },
+      { label: "English", code: "en" },
+      { label: "中文", code: "zh-TW" },
+      { label: "日本語", code: "ja" },
+      { label: "한국어", code: "ko" },
+      { label: "Español", code: "es" },
+      { label: "Français", code: "fr" },
+      { label: "Deutsch", code: "de" },
+      { label: "Português", code: "pt" },
+      { label: "Italiano", code: "it" },
+      { label: "Русский", code: "ru" },
+    ],
+    [t]
   );
 
-  const handleExportLibrary = () => {
+  // Group tracks by artist
+  const tracksByArtist = useMemo(
+    () =>
+      tracks.reduce<Record<string, { track: Track; index: number }[]>>(
+        (acc, track, index) => {
+          const artist = track.artist || t("apps.ipod.menu.unknownArtist");
+          if (!acc[artist]) {
+            acc[artist] = [];
+          }
+          acc[artist].push({ track, index });
+          return acc;
+        },
+        {}
+      ),
+    [tracks, t]
+  );
+
+  // Get sorted list of artists
+  const artists = useMemo(
+    () =>
+      Object.keys(tracksByArtist).sort((a, b) =>
+        a.localeCompare(b, undefined, { sensitivity: "base" })
+      ),
+    [tracksByArtist]
+  );
+
+  const handleExportLibrary = useCallback(() => {
     try {
       const json = exportLibrary();
       const blob = new Blob([json], { type: "application/json" });
@@ -194,9 +206,9 @@ export function KaraokeMenuBar({
       console.error("Failed to export library:", error);
       toast.error(t("apps.ipod.dialogs.failedToExportLibrary"));
     }
-  };
+  }, [exportLibrary, t]);
 
-  const handleImportLibrary = () => {
+  const handleImportLibrary = useCallback(() => {
     const input = document.createElement("input");
     input.type = "file";
     input.accept = ".json";
@@ -218,7 +230,7 @@ export function KaraokeMenuBar({
       reader.readAsText(file);
     };
     input.click();
-  };
+  }, [importLibrary, t]);
 
   return (
     <MenuBar inWindowFrame={isXpTheme}>
@@ -819,3 +831,6 @@ export function KaraokeMenuBar({
     </MenuBar>
   );
 }
+
+export const KaraokeMenuBar = memo(KaraokeMenuBarComponent);
+KaraokeMenuBar.displayName = "KaraokeMenuBar";

--- a/src/apps/karaoke/hooks/useKaraokeLogic.ts
+++ b/src/apps/karaoke/hooks/useKaraokeLogic.ts
@@ -413,6 +413,11 @@ export function useKaraokeLogic({
   ]);
 
   const displayElapsedTime = listenRemoteOnly ? virtualListenElapsed : elapsedTime;
+  const displayElapsedTimeRef = useRef(displayElapsedTime);
+
+  useEffect(() => {
+    displayElapsedTimeRef.current = displayElapsedTime;
+  }, [displayElapsedTime]);
 
   useListenSync({
     currentTrackId: currentTrack?.id ?? null,
@@ -611,7 +616,7 @@ export function useKaraokeLogic({
     if (isOffline) {
       showOfflineStatus();
     } else if (listenRemoteOnly) {
-      const positionMs = Math.round(displayElapsedTime * 1000);
+      const positionMs = Math.round(displayElapsedTimeRef.current * 1000);
       const action = isPlaying ? "pause" : "play";
       void sendRemotePlaybackCommand({ action, positionMs }).then((r) => {
         if (!r.ok) toast.error(r.error ?? "Remote control failed");
@@ -622,7 +627,6 @@ export function useKaraokeLogic({
       showStatus(isPlaying ? "⏸" : "▶");
     }
   }, [
-    displayElapsedTime,
     isOffline,
     isPlaying,
     listenRemoteOnly,
@@ -1543,14 +1547,13 @@ export function useKaraokeLogic({
         const newOffset = (currentTrack?.lyricOffset ?? 0) + delta;
         const sign = newOffset > 0 ? "+" : newOffset < 0 ? "" : "";
         showStatus(`${t("apps.ipod.status.offset")} ${sign}${(newOffset / 1000).toFixed(2)}s`);
-        lyricsControls.updateCurrentTimeManually(displayElapsedTime + newOffset / 1000);
+        lyricsControls.updateCurrentTimeManually(displayElapsedTimeRef.current + newOffset / 1000);
       }
     };
 
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
   }, [
-    displayElapsedTime,
     handleNext,
     handlePlayPause,
     handlePrevious,

--- a/src/components/shared/FullscreenPlayerControls.tsx
+++ b/src/components/shared/FullscreenPlayerControls.tsx
@@ -1,3 +1,4 @@
+import { memo } from "react";
 import { useTranslation } from "react-i18next";
 import { cn } from "@/lib/utils";
 import { useSound, Sounds } from "@/hooks/useSound";
@@ -102,7 +103,7 @@ export interface FullscreenPlayerControlsProps {
   hideLyricsControls?: boolean;
 }
 
-export function FullscreenPlayerControls({
+function FullscreenPlayerControlsComponent({
   isPlaying,
   onPrevious,
   onPlayPause,
@@ -637,3 +638,6 @@ export function FullscreenPlayerControls({
     </div>
   );
 }
+
+export const FullscreenPlayerControls = memo(FullscreenPlayerControlsComponent);
+FullscreenPlayerControls.displayName = "FullscreenPlayerControls";


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- stabilized karaoke playback callback identities so elapsed-time ticks no longer churn menu/control props
- memoized karaoke menu/control trees and expensive menu-bar derived data to reduce avoidable rerenders
- memoized lyrics row rendering so inactive rows stay stable while active timed rows continue smooth highlighting
- moved interlude exit flag transition out of render phase to an effect for deterministic render behavior

## Testing
- `bun test tests/test-karaoke-interlude-display.test.ts tests/test-furigana-word-spacing.test.ts`
- `bun run build`
- manual karaoke playback check in browser (playback running, lyrics progressing, pause/resume interaction)

## Walkthrough artifacts
<a href="https://cursor.com/agents/bc-a1a8dfa7-b111-4298-9c46-cd1ccfb5a428/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fkaraoke-playback-ui-stability.mp4"><img src="https://cursor.com/artifacts/c/art-9b46fc3e-277e-4827-b5b6-ed0745e76679" alt="karaoke-playback-ui-stability.mp4" /></a>
![karaoke final playback state](https://cursor.com/artifacts/c/art-7cd8848a-656c-4c5d-996a-68634bc05298)
![karaoke lyrics progression](https://cursor.com/artifacts/c/art-45f18b4e-39b8-4b7d-be3c-28b382d42d30)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a1a8dfa7-b111-4298-9c46-cd1ccfb5a428"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a1a8dfa7-b111-4298-9c46-cd1ccfb5a428"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

