### PR TITLE
Defer shader perf detection and reduce key-based rendering glitches

### DIFF
--- a/src/apps/internet-explorer/components/InternetExplorerAppComponent.tsx
+++ b/src/apps/internet-explorer/components/InternetExplorerAppComponent.tsx
@@ -80,7 +80,7 @@ function ErrorPage({
 
       <ul className="list-disc pl-6 mb-5 space-y-2">
         {suggestions.map((suggestion, index) => (
-          <li key={index}>
+          <li key={typeof suggestion === "string" ? suggestion : index}>
             {typeof suggestion === "string" && suggestion.includes("{hostname}")
               ? suggestion.split("{hostname}").map((part, i) =>
                   i === 0 ? (

--- a/src/apps/karaoke/components/KaraokeLyricsPlayback.tsx
+++ b/src/apps/karaoke/components/KaraokeLyricsPlayback.tsx
@@ -9,7 +9,6 @@ import {
   type ReactNode,
 } from "react";
 import type { TFunction } from "i18next";
-import { useShallow } from "zustand/react/shallow";
 import { AnimatePresence, motion } from "framer-motion";
 import { useLyrics } from "@/hooks/useLyrics";
 import { useFurigana } from "@/hooks/useFurigana";
@@ -37,7 +36,6 @@ export interface KaraokeLyricsPlaybackContextValue {
   soramimiMap: ReturnType<typeof useFurigana>["soramimiMap"];
   activityState: ReturnType<typeof useActivityState>;
   hasActiveActivity: boolean;
-  elapsedTime: number;
   lyricsFontClassName: string;
 }
 
@@ -82,8 +80,6 @@ export function KaraokeLyricsPlaybackProvider({
   auth,
   lyricsPlaybackSyncRef,
 }: ProviderProps) {
-  const elapsedTime = useKaraokeStore(useShallow((s) => s.elapsedTime));
-
   const lyricsFontClassName = getLyricsFontClassName(lyricsFont ?? LyricsFontEnum.SerifRed);
 
   const selectedMatchForLyrics = useMemo(() => {
@@ -106,7 +102,11 @@ export function KaraokeLyricsPlaybackProvider({
     songId: currentTrack?.id ?? "",
     title: currentTrack?.title ?? "",
     artist: currentTrack?.artist ?? "",
-    currentTime: elapsedTime + (currentTrack?.lyricOffset ?? 0) / 1000,
+    // Karaoke playback time updates frequently. Passing it into `useLyrics` would
+    // cause this provider (and any consumers) to re-render on each tick.
+    // `LyricsDisplay` already derives the active line/highlight from `currentTimeMs`,
+    // so we keep `useLyrics` focused on fetching/translation + manual time updates.
+    currentTime: 0,
     translateTo: effectiveTranslationLanguage,
     selectedMatch: selectedMatchForLyrics,
     includeFurigana: true,
@@ -174,7 +174,6 @@ export function KaraokeLyricsPlaybackProvider({
       soramimiMap,
       activityState,
       hasActiveActivity,
-      elapsedTime,
       lyricsFontClassName,
     }),
     [
@@ -183,7 +182,6 @@ export function KaraokeLyricsPlaybackProvider({
       soramimiMap,
       activityState,
       hasActiveActivity,
-      elapsedTime,
       lyricsFontClassName,
     ]
   );
@@ -254,9 +252,9 @@ export function KaraokeWindowLyricsOverlay({
     lyricsControls,
     furiganaMap,
     soramimiMap,
-    elapsedTime,
     lyricsFontClassName,
   } = useKaraokeLyricsPlayback();
+  const elapsedTime = useKaraokeStore((s) => s.elapsedTime);
 
   const onAdjustOffset = useCallback(
     (delta: number) => {
@@ -374,9 +372,9 @@ export function KaraokeFullscreenLyricsOverlay({
     lyricsControls,
     furiganaMap,
     soramimiMap,
-    elapsedTime,
     lyricsFontClassName,
   } = useKaraokeLyricsPlayback();
+  const elapsedTime = useKaraokeStore((s) => s.elapsedTime);
 
   const onAdjustOffset = useCallback(
     (delta: number) => {
@@ -505,7 +503,8 @@ export function KaraokeSyncModeWindowPanel({
   showStatus,
   t,
 }: SyncModeWindowProps) {
-  const { lyricsControls, furiganaMap, elapsedTime } = useKaraokeLyricsPlayback();
+  const { lyricsControls, furiganaMap } = useKaraokeLyricsPlayback();
+  const elapsedTime = useKaraokeStore((s) => s.elapsedTime);
   if (!isSyncModeOpen || isFullScreen || lyricsControls.originalLines.length === 0) {
     return null;
   }
@@ -574,7 +573,8 @@ export function KaraokeSyncModeFullscreenPanel({
   showStatus,
   t,
 }: SyncModeFullscreenProps) {
-  const { lyricsControls, furiganaMap, elapsedTime } = useKaraokeLyricsPlayback();
+  const { lyricsControls, furiganaMap } = useKaraokeLyricsPlayback();
+  const elapsedTime = useKaraokeStore((s) => s.elapsedTime);
   if (!isSyncModeOpen || !isFullScreen || lyricsControls.originalLines.length === 0) {
     return null;
   }

--- a/src/apps/soundboard/components/SoundGrid.tsx
+++ b/src/apps/soundboard/components/SoundGrid.tsx
@@ -57,7 +57,7 @@ export function SoundGrid({
           <div className="grid grid-cols-3 gap-2 md:gap-4 flex-1">
             {board.slots.map((slot, index) => (
               <SoundSlot
-                key={slot.id ?? `slot-${index}`}
+                key={`${board.id}-slot-${index}`}
                 slot={slot}
                 isRecording={playbackStates[index].isRecording}
                 isPlaying={playbackStates[index].isPlaying}

--- a/src/apps/soundboard/components/SoundGrid.tsx
+++ b/src/apps/soundboard/components/SoundGrid.tsx
@@ -57,7 +57,7 @@ export function SoundGrid({
           <div className="grid grid-cols-3 gap-2 md:gap-4 flex-1">
             {board.slots.map((slot, index) => (
               <SoundSlot
-                key={index}
+                key={slot.id ?? `slot-${index}`}
                 slot={slot}
                 isRecording={playbackStates[index].isRecording}
                 isPlaying={playbackStates[index].isPlaying}

--- a/src/stores/useDisplaySettingsStore.ts
+++ b/src/stores/useDisplaySettingsStore.ts
@@ -113,17 +113,50 @@ interface DisplaySettingsState {
 }
 
 const STORE_VERSION = 1;
-const initialShaderState = checkShaderPerformance();
 
 export const useDisplaySettingsStore = create<DisplaySettingsState>()(
   persist(
-    (set, get) => ({
+    (set, get) => {
+      // Avoid creating a WebGL context during module import / first paint.
+      // For existing users, `shaderEffectEnabled` is persisted and will hydrate.
+      // For new users (no persisted display-settings yet), detect capability lazily.
+      if (typeof window !== "undefined") {
+        const storageKey = "ryos:display-settings";
+        const hasPersistedSettings =
+          typeof localStorage !== "undefined" &&
+          localStorage.getItem(storageKey) !== null;
+
+        if (!hasPersistedSettings) {
+          const schedule =
+            "requestIdleCallback" in window
+              ? (cb: () => void) =>
+                  (window as unknown as { requestIdleCallback: (c: () => void) => void }).requestIdleCallback(
+                    cb
+                  )
+              : (cb: () => void) => window.setTimeout(cb, 1500);
+
+          schedule(() => {
+            try {
+              // Only apply if still unconfigured; don't override user interaction.
+              const stillUnconfigured =
+                typeof localStorage !== "undefined" &&
+                localStorage.getItem(storageKey) === null;
+              if (!stillUnconfigured) return;
+              set({ shaderEffectEnabled: checkShaderPerformance() });
+            } catch {
+              // Ignore: capability detection is best-effort.
+            }
+          });
+        }
+      }
+
+      return {
       // Display mode
       displayMode: "color",
       setDisplayMode: (m) => set({ displayMode: m }),
 
       // Shader settings
-      shaderEffectEnabled: initialShaderState,
+      shaderEffectEnabled: false,
       selectedShaderType: ShaderType.AURORA,
       setShaderEffectEnabled: (enabled) => set({ shaderEffectEnabled: enabled }),
       setSelectedShaderType: (t) => set({ selectedShaderType: t }),
@@ -271,7 +304,8 @@ export const useDisplaySettingsStore = create<DisplaySettingsState>()(
       customWallpapersRevision: 0,
       bumpCustomWallpapersRevision: () =>
         set((s) => ({ customWallpapersRevision: s.customWallpapersRevision + 1 })),
-    }),
+      };
+    },
     {
       name: "ryos:display-settings",
       version: STORE_VERSION,

--- a/src/utils/performanceCheck.ts
+++ b/src/utils/performanceCheck.ts
@@ -8,14 +8,36 @@ import * as THREE from 'three';
  * @returns {boolean} True if the device passes the checks, false otherwise.
  */
 export function checkShaderPerformance(): boolean {
-  console.log('[PerformanceCheck] Running checks...');
+  // Avoid blocking first paint / SSR / tests: if we can't access the browser
+  // APIs we need, fall back to "off".
+  if (typeof window === "undefined" || typeof navigator === "undefined") {
+    return false;
+  }
+
+  // Cache result for this page session; WebGL context creation is expensive.
+  const cacheKey = "__ryos_shader_perf_ok__";
+  const cached = (window as unknown as Record<string, unknown>)[cacheKey];
+  if (typeof cached === "boolean") return cached;
+
+  const debug =
+    new URLSearchParams(window.location.search).has("debugPerformanceCheck") ||
+    (window as unknown as Record<string, unknown>).__RYOS_DEBUG_PERF__ === true;
+
+  if (debug) {
+    console.log('[PerformanceCheck] Running checks...');
+  }
 
   // 1. Check CPU Cores
   const coreCount = navigator.hardwareConcurrency;
   const hasEnoughCores = coreCount && coreCount >= 8;
-  console.log(`[PerformanceCheck] CPU Cores: ${coreCount} (Pass: ${hasEnoughCores})`);
+  if (debug) {
+    console.log(
+      `[PerformanceCheck] CPU Cores: ${coreCount} (Pass: ${hasEnoughCores})`
+    );
+  }
   if (!hasEnoughCores) {
-      return false; // Early exit if CPU core count is low
+    (window as unknown as Record<string, unknown>)[cacheKey] = false;
+    return false; // Early exit if CPU core count is low
   }
 
   // 2. Check WebGL Capabilities (Requires creating a temporary renderer)
@@ -31,12 +53,17 @@ export function checkShaderPerformance(): boolean {
     // Check if high precision floats are supported in fragment shaders
     highpSupported = renderer.capabilities.precision === 'highp';
 
-    console.log(`[PerformanceCheck] Max Anisotropy: ${maxAnisotropy}`);
-    console.log(`[PerformanceCheck] Max Texture Size: ${maxTextureSize}`);
-    console.log(`[PerformanceCheck] High Precision Supported: ${highpSupported}`);
+    if (debug) {
+      console.log(`[PerformanceCheck] Max Anisotropy: ${maxAnisotropy}`);
+      console.log(`[PerformanceCheck] Max Texture Size: ${maxTextureSize}`);
+      console.log(`[PerformanceCheck] High Precision Supported: ${highpSupported}`);
+    }
 
   } catch (error) {
-    console.error('[PerformanceCheck] Error creating WebGL context:', error);
+    if (debug) {
+      console.error('[PerformanceCheck] Error creating WebGL context:', error);
+    }
+    (window as unknown as Record<string, unknown>)[cacheKey] = false;
     return false; // Cannot perform WebGL checks
   } finally {
     // Ensure renderer is disposed if created
@@ -52,10 +79,15 @@ export function checkShaderPerformance(): boolean {
     maxTextureSize >= textureSizeThreshold &&
     highpSupported;
 
-  console.log(`[PerformanceCheck] GPU Checks Pass: ${passesGpuCheck}`);
+  if (debug) {
+    console.log(`[PerformanceCheck] GPU Checks Pass: ${passesGpuCheck}`);
+  }
 
   // Final decision: requires both CPU and GPU checks to pass
   const finalResult = hasEnoughCores && passesGpuCheck;
-  console.log(`[PerformanceCheck] Final Result: ${finalResult}`);
+  if (debug) {
+    console.log(`[PerformanceCheck] Final Result: ${finalResult}`);
+  }
+  (window as unknown as Record<string, unknown>)[cacheKey] = finalResult;
   return finalResult;
 } 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### What
- Avoids running GPU/WebGL capability detection during module import / first paint.
- Stabilizes a couple list keys that could cause React to reuse the wrong element when lists change.
- Reduces Karaoke lyric overlay re-renders by decoupling high-frequency `elapsedTime` from the provider context.

### Why
- `checkShaderPerformance()` creates a WebGL renderer; doing that at import time can jank first render and can be problematic in non-browser contexts.
- Index keys can manifest as subtle rendering bugs (wrong item reused) when arrays can reorder or be edited.
- React Scan showed Karaoke re-rendering large UI surfaces during playback; the provider context previously changed every tick due to `elapsedTime`.

### Notes
- Existing users keep their persisted `shaderEffectEnabled` setting.
- New users get a best-effort shader auto-enable check scheduled via `requestIdleCallback` (or timeout fallback).
- Soundboard: key now uses `board.id` + slot index (slot objects have no `id`).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b541e451-0a38-4c73-abed-69d71ad1d4c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b541e451-0a38-4c73-abed-69d71ad1d4c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

