### PR TITLE
Optimize AI prompts for provider caching

### DIFF
--- a/api/_utils/_aiModels.ts
+++ b/api/_utils/_aiModels.ts
@@ -1,7 +1,8 @@
 import { openai } from "@ai-sdk/openai";
 import { anthropic } from "@ai-sdk/anthropic";
 import { google } from "@ai-sdk/google";
-import type { LanguageModel } from "ai";
+import type { LanguageModel, ProviderOptions } from "ai";
+import { mergeProviderOptions } from "./prompt-caching.js";
 
 // ============================================================================
 // AI Model Types and Constants (duplicated from src/types/aiModels.ts)
@@ -54,7 +55,7 @@ export const getModelInstance = (model: SupportedModel): LanguageModel => {
 
 export function getOpenAIProviderOptions(
   model: SupportedModel
-): { openai: { reasoningEffort?: OpenAIReasoningEffort } } | undefined {
+): ProviderOptions | undefined {
   if (AI_MODELS[model].provider !== "OpenAI") {
     return undefined;
   }
@@ -75,4 +76,13 @@ export function getOpenAIProviderOptions(
   return {
     openai: openaiOptions,
   };
+}
+
+export function getPromptOptimizedProviderOptions(
+  model: SupportedModel,
+  ...options: Array<ProviderOptions | undefined>
+): ProviderOptions | undefined {
+  const openAIOptions = getOpenAIProviderOptions(model);
+
+  return mergeProviderOptions(openAIOptions, ...options);
 }

--- a/api/_utils/prompt-caching.ts
+++ b/api/_utils/prompt-caching.ts
@@ -1,0 +1,108 @@
+import type {
+  LanguageModel,
+  ModelMessage,
+  ProviderOptions,
+  SystemModelMessage,
+} from "ai";
+
+export const ANTHROPIC_PROMPT_CACHE_PROVIDER_OPTIONS = {
+  anthropic: {
+    cacheControl: { type: "ephemeral" },
+  },
+} as const satisfies ProviderOptions;
+
+export function mergeProviderOptions(
+  ...options: Array<ProviderOptions | undefined>
+): ProviderOptions | undefined {
+  const merged: ProviderOptions = {};
+
+  for (const option of options) {
+    if (!option) continue;
+
+    for (const [provider, providerOptions] of Object.entries(option)) {
+      merged[provider] = {
+        ...((merged[provider] as Record<string, unknown> | undefined) ?? {}),
+        ...providerOptions,
+      };
+    }
+  }
+
+  return Object.keys(merged).length > 0 ? merged : undefined;
+}
+
+const textChars = (content: ModelMessage["content"]): number => {
+  if (typeof content === "string") {
+    return content.length;
+  }
+
+  return content.reduce((total, part) => {
+    if ("text" in part && typeof part.text === "string") {
+      return total + part.text.length;
+    }
+
+    return total;
+  }, 0);
+};
+
+export function withPromptCacheForLongContent<
+  T extends { content: ModelMessage["content"]; providerOptions?: ProviderOptions },
+>(value: T, minChars = 3000): T & { providerOptions?: ProviderOptions } {
+  return textChars(value.content) >= minChars ? withPromptCache(value) : value;
+}
+
+export function withPromptCache<T extends { providerOptions?: ProviderOptions }>(
+  value: T
+): T & { providerOptions: ProviderOptions } {
+  return {
+    ...value,
+    providerOptions: mergeProviderOptions(
+      value.providerOptions,
+      ANTHROPIC_PROMPT_CACHE_PROVIDER_OPTIONS
+    ),
+  } as T & { providerOptions: ProviderOptions };
+}
+
+export function createCachedSystemMessage(
+  content: string
+): SystemModelMessage {
+  return withPromptCache({
+    role: "system",
+    content,
+  });
+}
+
+export function isAnthropicModel(model: LanguageModel): boolean {
+  if (typeof model === "string") {
+    return /anthropic|claude/i.test(model);
+  }
+
+  const modelDetails = model as { provider?: string; modelId?: string };
+  return [modelDetails.provider, modelDetails.modelId].some(
+    (value) => typeof value === "string" && /anthropic|claude/i.test(value)
+  );
+}
+
+export function addPromptCacheToLastMessage(
+  messages: ModelMessage[],
+  model: LanguageModel
+): ModelMessage[] {
+  if (messages.length === 0 || !isAnthropicModel(model)) {
+    return messages;
+  }
+
+  return messages.map((message, index) =>
+    index === messages.length - 1 ? withPromptCache(message) : message
+  );
+}
+
+export function preparePromptCachingStep({
+  messages,
+  model,
+}: {
+  messages: ModelMessage[];
+  model: LanguageModel;
+}): { messages: ModelMessage[] } {
+  return {
+    messages: addPromptCacheToLastMessage(messages, model),
+  };
+}

--- a/api/_utils/ryo-conversation.ts
+++ b/api/_utils/ryo-conversation.ts
@@ -33,6 +33,7 @@ import {
   type ChatToolProfile,
   type ChatToolsContext,
 } from "../chat/tools/index.js";
+import { createCachedSystemMessage } from "./prompt-caching.js";
 
 export interface RyoConversationSystemState {
   username?: string | null;
@@ -159,12 +160,6 @@ export interface PreparedRyoConversation {
   dailyNotesText: string | null;
   userTimeZone?: string;
 }
-
-const CACHE_CONTROL_OPTIONS = {
-  providerOptions: {
-    anthropic: { cacheControl: { type: "ephemeral" } },
-  },
-} as const;
 
 const CHANNEL_PROMPT_SECTIONS = {
   chat: [
@@ -712,11 +707,7 @@ export async function prepareRyoConversationModelInput(
   });
 
   const enrichedMessages = [
-    {
-      role: "system" as const,
-      content: staticSystemPrompt,
-      ...CACHE_CONTROL_OPTIONS,
-    },
+    createCachedSystemMessage(staticSystemPrompt),
     ...(dynamicSystemPrompt
       ? [{ role: "system" as const, content: dynamicSystemPrompt }]
       : []),

--- a/api/ai/extract-memories.ts
+++ b/api/ai/extract-memories.ts
@@ -26,6 +26,10 @@ import {
   markDailyNoteProcessed,
   MAX_MEMORIES_PER_USER,
 } from "../_utils/_memory.js";
+import {
+  createCachedSystemMessage,
+  withPromptCacheForLongContent,
+} from "../_utils/prompt-caching.js";
 
 export const runtime = "nodejs";
 export const maxDuration = 60;
@@ -320,9 +324,15 @@ export async function extractMemoriesFromConversation({
   const { object: result } = await generateObject({
     model: google("gemini-3-flash-preview"),
     schema: extractionSchema,
-    prompt:
-      `${EXTRACTION_PROMPT}${existingStateSection}\n\n--- CONVERSATION ---\n${conversationText}\n--- END CONVERSATION ---\n\n` +
-      `Extract up to 8 daily notes and up to ${maxLongTerm} long-term memories. Return empty arrays if nothing qualifies.`,
+    messages: [
+      createCachedSystemMessage(EXTRACTION_PROMPT),
+      withPromptCacheForLongContent({
+        role: "user",
+        content:
+          `${existingStateSection}\n\n--- CONVERSATION ---\n${conversationText}\n--- END CONVERSATION ---\n\n` +
+          `Extract up to 8 daily notes and up to ${maxLongTerm} long-term memories. Return empty arrays if nothing qualifies.`,
+      }),
+    ],
     temperature: 0.3,
   });
 
@@ -400,9 +410,15 @@ export async function extractMemoriesFromConversation({
         const { object: consolidated } = await generateObject({
           model: google("gemini-3-flash-preview"),
           schema: consolidationSchema,
-          prompt:
-            `${CONSOLIDATION_PROMPT}\n\nNEW:\nSummary: ${mem.summary}\nContent: ${mem.content}\n\nEXISTING:\n${existingContentText}\n\n` +
-            "Merge into one clean, deduplicated entry.",
+          messages: [
+            createCachedSystemMessage(CONSOLIDATION_PROMPT),
+            withPromptCacheForLongContent({
+              role: "user",
+              content:
+                `NEW:\nSummary: ${mem.summary}\nContent: ${mem.content}\n\nEXISTING:\n${existingContentText}\n\n` +
+                "Merge into one clean, deduplicated entry.",
+            }),
+          ],
           temperature: 0.3,
         });
 

--- a/api/ai/process-daily-notes.ts
+++ b/api/ai/process-daily-notes.ts
@@ -34,6 +34,10 @@ import {
   MAX_MEMORIES_PER_USER,
   CANONICAL_MEMORY_KEYS,
 } from "../_utils/_memory.js";
+import {
+  createCachedSystemMessage,
+  withPromptCacheForLongContent,
+} from "../_utils/prompt-caching.js";
 
 export const runtime = "nodejs";
 export const maxDuration = 60;
@@ -403,7 +407,13 @@ async function _processSingleDayBatch(
   const { object: result } = await generateObject({
     model: google("gemini-3-flash-preview"),
     schema: dailyNotesExtractionSchema,
-    prompt: `${DAILY_NOTES_EXTRACTION_PROMPT}${existingStateSection}\n\n--- DAILY NOTES ---\n${dailyNotesText}\n--- END DAILY NOTES ---\n\nExtract up to ${Math.max(maxExtract, 3)} long-term memories. For existing keys, you may suggest updates via relatedKeys. Return empty array if nothing qualifies.`,
+    messages: [
+      createCachedSystemMessage(DAILY_NOTES_EXTRACTION_PROMPT),
+      withPromptCacheForLongContent({
+        role: "user",
+        content: `${existingStateSection}\n\n--- DAILY NOTES ---\n${dailyNotesText}\n--- END DAILY NOTES ---\n\nExtract up to ${Math.max(maxExtract, 3)} long-term memories. For existing keys, you may suggest updates via relatedKeys. Return empty array if nothing qualifies.`,
+      }),
+    ],
     temperature: 0.3,
   });
 
@@ -457,7 +467,13 @@ async function _processSingleDayBatch(
       const { object: consolidated } = await generateObject({
         model: google("gemini-3-flash-preview"),
         schema: consolidationSchema,
-        prompt: `${CONSOLIDATION_PROMPT}\n\nNEW:\nSummary: ${mem.summary}\nContent: ${mem.content}\n\nEXISTING:\n${existingContentText}\n\nMerge into one clean, deduplicated entry.`,
+        messages: [
+          createCachedSystemMessage(CONSOLIDATION_PROMPT),
+          withPromptCacheForLongContent({
+            role: "user",
+            content: `NEW:\nSummary: ${mem.summary}\nContent: ${mem.content}\n\nEXISTING:\n${existingContentText}\n\nMerge into one clean, deduplicated entry.`,
+          }),
+        ],
         temperature: 0.3,
       });
 

--- a/api/ai/ryo-reply.ts
+++ b/api/ai/ryo-reply.ts
@@ -12,6 +12,7 @@ import { roomExists, addMessage, generateId, getCurrentTimestamp } from "../room
 import { broadcastNewMessage } from "../rooms/_helpers/_pusher.js";
 import type { Message } from "../rooms/_helpers/_types.js";
 import { apiHandler } from "../_utils/api-handler.js";
+import { createCachedSystemMessage } from "../_utils/prompt-caching.js";
 
 export const runtime = "nodejs";
 
@@ -111,7 +112,7 @@ export default apiHandler<RyoReplyRequest>(
     }
 
     const messages = [
-      { role: "system" as const, content: STATIC_SYSTEM_PROMPT },
+      createCachedSystemMessage(STATIC_SYSTEM_PROMPT),
       systemState?.chatRoomContext
         ? {
             role: "system" as const,

--- a/api/applet-ai.ts
+++ b/api/applet-ai.ts
@@ -14,6 +14,7 @@ import * as RateLimit from "./_utils/_rate-limit.js";
 import { getClientIp } from "./_utils/_rate-limit.js";
 import { apiHandler } from "./_utils/api-handler.js";
 import { isAllowedAppHost } from "./_utils/runtime-config.js";
+import { createCachedSystemMessage } from "./_utils/prompt-caching.js";
 
 export const runtime = "nodejs";
 export const maxDuration = 60;
@@ -236,7 +237,7 @@ const buildModelMessages = (
   context?: string
 ): ModelMessage[] => {
   const messages: ModelMessage[] = [
-    { role: "system", content: APPLET_SYSTEM_PROMPT.trim() },
+    createCachedSystemMessage(APPLET_SYSTEM_PROMPT.trim()),
   ];
 
   if (context) {

--- a/api/chat.ts
+++ b/api/chat.ts
@@ -9,7 +9,7 @@ import { google } from "@ai-sdk/google";
 import {
   DEFAULT_MODEL,
   SUPPORTED_AI_MODELS,
-  getOpenAIProviderOptions,
+  getPromptOptimizedProviderOptions,
   type SupportedModel,
 } from "./_utils/_aiModels.js";
 import {
@@ -21,6 +21,10 @@ import {
   type RyoConversationSystemState,
   type SimpleConversationMessage,
 } from "./_utils/ryo-conversation.js";
+import {
+  createCachedSystemMessage,
+  preparePromptCachingStep,
+} from "./_utils/prompt-caching.js";
 import { checkAndIncrementAIMessageCount } from "./_utils/_rate-limit.js";
 import { apiHandler } from "./_utils/api-handler.js";
 import { getHeader } from "./_utils/request-helpers.js";
@@ -245,7 +249,9 @@ export default apiHandler<{
           model: google("gemini-3-flash-preview"),
           temperature: 1,
           maxOutputTokens: 2000,
-          system: `You are Ryo, a friendly AI assistant. You're greeting a returning user at the start of a new chat.
+          messages: [
+            createCachedSystemMessage(
+              `You are Ryo, a friendly AI assistant. You're greeting a returning user at the start of a new chat.
 
 Your style:
 - Lowercase, casual, warm
@@ -256,10 +262,6 @@ Your style:
 - Be specific — reference something from their memories or recent activity
 - Mix it up: sometimes ask a question, sometimes share an observation, sometimes reference a shared interest
 
-It's ${dayOfWeek} ${sfTime}. The user's name is "${username}".
-
-${greetingMemoryContext}
-
 Generate ONE short proactive greeting. Pick one interesting angle from the context — a recent topic, a memory, something timely — and use it naturally. Don't try to cover everything.
 
 Examples of good greetings:
@@ -269,7 +271,16 @@ Examples of good greetings:
 - "hey ryo. happy friday — any plans?"
 
 Do NOT start with generic greetings like "hey! i'm ryo" or "welcome back". Jump straight into something specific and interesting. Output ONLY the greeting text, nothing else.`,
-          prompt: "Generate a proactive greeting.",
+            ),
+            {
+              role: "system",
+              content: `It's ${dayOfWeek} ${sfTime}. The user's name is "${username}".\n\n${greetingMemoryContext}`,
+            },
+            {
+              role: "user",
+              content: "Generate a proactive greeting.",
+            },
+          ],
         });
 
         const greeting = text.trim();
@@ -330,13 +341,14 @@ Do NOT start with generic greetings like "hey! i'm ryo" or "welcome back". Jump 
       experimental_transform: smoothStream({
         chunking: /[\u4E00-\u9FFF]|\S+\s+/,
       }),
+      prepareStep: preparePromptCachingStep,
       headers: {
         // Enable fine-grained tool streaming for Anthropic models
         ...(model.startsWith("claude")
           ? { "anthropic-beta": "fine-grained-tool-streaming-2025-05-14" }
           : {}),
       },
-      providerOptions: getOpenAIProviderOptions(model as SupportedModel),
+      providerOptions: getPromptOptimizedProviderOptions(model as SupportedModel),
     });
 
     // Set CORS headers

--- a/api/cron/telegram-heartbeat.ts
+++ b/api/cron/telegram-heartbeat.ts
@@ -38,10 +38,11 @@ import {
   prepareRyoConversationModelInput,
   type SimpleConversationMessage,
 } from "../_utils/ryo-conversation.js";
+import { preparePromptCachingStep } from "../_utils/prompt-caching.js";
 import {
   TELEGRAM_DEFAULT_MODEL,
   SUPPORTED_AI_MODELS,
-  getOpenAIProviderOptions,
+  getPromptOptimizedProviderOptions,
   type SupportedModel,
 } from "../_utils/_aiModels.js";
 import { getHeader } from "../_utils/request-helpers.js";
@@ -413,7 +414,8 @@ export default async function handler(
     temperature: 0.7,
     maxOutputTokens: 4000,
     stopWhen: stepCountIs(6),
-    providerOptions: getOpenAIProviderOptions(telegramModel),
+    prepareStep: preparePromptCachingStep,
+    providerOptions: getPromptOptimizedProviderOptions(telegramModel),
     onStepFinish: async (stepResult) => {
       if (stepResult.toolResults.length > 0) {
         logger.info("Telegram heartbeat completed tool step", {

--- a/api/ie-generate.ts
+++ b/api/ie-generate.ts
@@ -11,7 +11,7 @@ import {
   SupportedModel,
   DEFAULT_MODEL,
   getModelInstance,
-  getOpenAIProviderOptions,
+  getPromptOptimizedProviderOptions,
 } from "./_utils/_aiModels.js";
 import { normalizeUrlForCacheKey } from "./_utils/_url.js";
 import {
@@ -21,6 +21,7 @@ import {
   } from "./_utils/_aiPrompts.js";
 import { SUPPORTED_AI_MODELS } from "./_utils/_aiModels.js";
 import { apiHandler } from "./_utils/api-handler.js";
+import { createCachedSystemMessage } from "./_utils/prompt-caching.js";
 
 export const runtime = "nodejs";
 export const maxDuration = 80;
@@ -275,10 +276,7 @@ export default apiHandler<IEGenerateRequestBody>(
     const systemPrompt = getDynamicSystemPrompt(effectiveYear, rawUrl ?? null);
 
     // Build system messages similar to chat.ts approach
-    const staticSystemMessage = {
-      role: "system" as const,
-      content: STATIC_SYSTEM_PROMPT,
-    };
+    const staticSystemMessage = createCachedSystemMessage(STATIC_SYSTEM_PROMPT);
 
     const dynamicSystemMessage = {
       role: "system" as const,
@@ -308,7 +306,7 @@ export default apiHandler<IEGenerateRequestBody>(
       temperature: 0.7,
       maxOutputTokens: 4000,
       experimental_transform: smoothStream(),
-      providerOptions: getOpenAIProviderOptions(model),
+      providerOptions: getPromptOptimizedProviderOptions(model),
       onFinish: async ({ text }) => {
         if (!cacheKey) {
           logger.info("No cacheKey available, skipping cache save");

--- a/api/parse-title.ts
+++ b/api/parse-title.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 import * as RateLimit from "./_utils/_rate-limit.js";
 import { getClientIp } from "./_utils/_rate-limit.js";
 import { apiHandler } from "./_utils/api-handler.js";
+import { createCachedSystemMessage } from "./_utils/prompt-caching.js";
 
 export const runtime = "nodejs";
 export const maxDuration = 30;
@@ -86,10 +87,9 @@ export default apiHandler<ParseTitleRequest>(
           name: "parsed_title",
         }),
         messages: [
-          {
-            role: "system",
-            content: `You are an expert music metadata parser. Given a raw YouTube video title and optionally the channel name, extract the song title and artist. If possible, also extract the album name. Use the channel name as additional context for identifying the artist, especially when the artist name is not clear from the title alone. Respond ONLY with a valid JSON object matching the provided schema. If you cannot determine a field, omit it or set it to null. Always prefer the original language names over translated/romanized versions. For example, prefer "晴天" over "Sunny Day", "周杰倫" over "Jay Chou", "뉴진스" over "NewJeans". When both original and translated names are present, use the original language version. If the song originates from a non-English speaking region, use the native script (Chinese characters, Korean hangul, Japanese kanji/hiragana/katakana, etc.). Example input: title="Jay Chou - Sunny Day (周杰倫 - 晴天)", author_name="Jay Chou". Example output: {"title": "晴天", "artist": "周杰倫"}. Example input: title="NewJeans (뉴진스) 'How Sweet' Official MV", author_name="HYBE LABELS". Example output: {"title": "How Sweet", "artist": "뉴진스"}. Example input: title="Lofi Hip Hop Radio - Beats to Relax/Study to", author_name="ChillHop Music". Example output: {"title": "Lofi Hip Hop Radio - Beats to Relax/Study to", "artist": null}.`,
-          },
+          createCachedSystemMessage(
+            `You are an expert music metadata parser. Given a raw YouTube video title and optionally the channel name, extract the song title and artist. If possible, also extract the album name. Use the channel name as additional context for identifying the artist, especially when the artist name is not clear from the title alone. Respond ONLY with a valid JSON object matching the provided schema. If you cannot determine a field, omit it or set it to null. Always prefer the original language names over translated/romanized versions. For example, prefer "晴天" over "Sunny Day", "周杰倫" over "Jay Chou", "뉴진스" over "NewJeans". When both original and translated names are present, use the original language version. If the song originates from a non-English speaking region, use the native script (Chinese characters, Korean hangul, Japanese kanji/hiragana/katakana, etc.). Example input: title="Jay Chou - Sunny Day (周杰倫 - 晴天)", author_name="Jay Chou". Example output: {"title": "晴天", "artist": "周杰倫"}. Example input: title="NewJeans (뉴진스) 'How Sweet' Official MV", author_name="HYBE LABELS". Example output: {"title": "How Sweet", "artist": "뉴진스"}. Example input: title="Lofi Hip Hop Radio - Beats to Relax/Study to", author_name="ChillHop Music". Example output: {"title": "Lofi Hip Hop Radio - Beats to Relax/Study to", "artist": null}.`
+          ),
           {
             role: "user",
             content: `Title: ${rawTitle}${author_name ? `\nChannel: ${author_name}` : ""}`,

--- a/api/rooms/_helpers/_messages.ts
+++ b/api/rooms/_helpers/_messages.ts
@@ -44,6 +44,7 @@ import {
   MAX_MESSAGE_LENGTH,
 } from "../../_utils/_validation.js";
 import { validateAuth } from "../../_utils/auth/index.js";
+import { createCachedSystemMessage } from "../../_utils/prompt-caching.js";
 import { createErrorResponse } from "./_helpers.js";
 import { ensureUserExists } from "./_users.js";
 import type { Message, SendMessageData, GenerateRyoReplyData } from "./_types.js";
@@ -452,7 +453,7 @@ when user asks for an aquarium, fish tank, fishes, or sam's aquarium, include th
 </chat_instructions>`;
 
   const messages = [
-    { role: "system" as const, content: STATIC_SYSTEM_PROMPT },
+    createCachedSystemMessage(STATIC_SYSTEM_PROMPT),
     systemState
       ? {
           role: "system" as const,

--- a/api/songs/_utils.ts
+++ b/api/songs/_utils.ts
@@ -8,6 +8,7 @@ import { Converter } from "opencc-js";
 import { google } from "@ai-sdk/google";
 import { generateText, Output } from "ai";
 import { KRC_DECRYPTION_KEY, YOUTUBE_VIDEO_ID_REGEX } from "./_constants.js";
+import { createCachedSystemMessage } from "../_utils/prompt-caching.js";
 
 /** Traditional → Simplified for cross-strait lyric metadata matching (KuGou is Simplified) */
 const traditionalToSimplified = Converter({ from: "tw", to: "cn" });
@@ -362,9 +363,8 @@ export async function parseYouTubeTitleWithAI(
         name: "parsed_song_metadata",
       }),
       messages: [
-        {
-          role: "system",
-          content: `You are an expert music metadata parser. Given a raw YouTube video title and optionally the channel name, extract the song title and artist.
+        createCachedSystemMessage(
+          `You are an expert music metadata parser. Given a raw YouTube video title and optionally the channel name, extract the song title and artist.
 
 Rules:
 - Return ONLY the clean song title and artist name as simple strings
@@ -378,8 +378,8 @@ Examples:
 - "Jay Chou - Sunny Day (周杰倫 - 晴天)" → title: "晴天", artist: "周杰倫"
 - "NewJeans (뉴진스) 'How Sweet' Official MV" → title: "How Sweet", artist: "뉴진스"
 - "Kenshi Yonezu - KICK BACK" with channel "Kenshi Yonezu" → title: "KICK BACK", artist: "米津玄師"
-- "Lofi Hip Hop Radio" with channel "ChillHop Music" → title: "Lofi Hip Hop Radio", artist: null`,
-        },
+- "Lofi Hip Hop Radio" with channel "ChillHop Music" → title: "Lofi Hip Hop Radio", artist: null`
+        ),
         {
           role: "user",
           content: `Title: ${cleanTitle}${cleanChannel ? `\nChannel: ${cleanChannel}` : ""}`,

--- a/api/webhooks/telegram.ts
+++ b/api/webhooks/telegram.ts
@@ -34,10 +34,11 @@ import {
   prepareRyoConversationModelInput,
   type SimpleConversationMessage,
 } from "../_utils/ryo-conversation.js";
+import { preparePromptCachingStep } from "../_utils/prompt-caching.js";
 import {
   TELEGRAM_DEFAULT_MODEL,
   SUPPORTED_AI_MODELS,
-  getOpenAIProviderOptions,
+  getPromptOptimizedProviderOptions,
   type SupportedModel,
 } from "../_utils/_aiModels.js";
 import {
@@ -685,7 +686,8 @@ export default async function handler(
       temperature: 0.7,
       maxOutputTokens: 4000,
       stopWhen: stepCountIs(6),
-      providerOptions: getOpenAIProviderOptions(telegramModel),
+      prepareStep: preparePromptCachingStep,
+      providerOptions: getPromptOptimizedProviderOptions(telegramModel),
       onChunk: async ({ chunk }) => {
         if (chunk.type !== "tool-input-start" && chunk.type !== "tool-call") {
           return;

--- a/tests/test-ai-model-provider-options.test.ts
+++ b/tests/test-ai-model-provider-options.test.ts
@@ -1,5 +1,14 @@
 import { describe, expect, test } from "bun:test";
-import { getOpenAIProviderOptions } from "../api/_utils/_aiModels.js";
+import type { LanguageModel } from "ai";
+import {
+  getOpenAIProviderOptions,
+  getPromptOptimizedProviderOptions,
+} from "../api/_utils/_aiModels.js";
+import {
+  addPromptCacheToLastMessage,
+  createCachedSystemMessage,
+  withPromptCacheForLongContent,
+} from "../api/_utils/prompt-caching.js";
 
 describe("OpenAI provider options", () => {
   test("preserves explicit reasoning effort for gpt-5.4", () => {
@@ -12,5 +21,76 @@ describe("OpenAI provider options", () => {
 
   test("ignores OpenAI provider options for non-OpenAI models", () => {
     expect(getOpenAIProviderOptions("sonnet-4.6")).toBeUndefined();
+  });
+
+  test("merges prompt optimized provider options with OpenAI defaults", () => {
+    expect(
+      getPromptOptimizedProviderOptions("gpt-5.4", {
+        gateway: { caching: "auto" },
+      })
+    ).toEqual({
+      openai: {
+        reasoningEffort: "none",
+      },
+      gateway: {
+        caching: "auto",
+      },
+    });
+  });
+});
+
+describe("prompt caching helpers", () => {
+  test("adds Anthropic cache control to cached system messages", () => {
+    expect(createCachedSystemMessage("stable instructions")).toEqual({
+      role: "system",
+      content: "stable instructions",
+      providerOptions: {
+        anthropic: {
+          cacheControl: { type: "ephemeral" },
+        },
+      },
+    });
+  });
+
+  test("only caches long dynamic content above the threshold", () => {
+    const shortMessage = { role: "user" as const, content: "short" };
+    const longMessage = { role: "user" as const, content: "a".repeat(3000) };
+
+    expect(withPromptCacheForLongContent(shortMessage).providerOptions).toBeUndefined();
+    expect(withPromptCacheForLongContent(longMessage).providerOptions).toEqual({
+      anthropic: {
+        cacheControl: { type: "ephemeral" },
+      },
+    });
+  });
+
+  test("adds per-step cache control only for Anthropic models", () => {
+    const messages = [
+      { role: "system" as const, content: "stable instructions" },
+      { role: "user" as const, content: "hello" },
+    ];
+    const anthropicModel = {
+      provider: "anthropic",
+      modelId: "claude-sonnet-4-6",
+    };
+    const googleModel = {
+      provider: "google",
+      modelId: "gemini-3-flash-preview",
+    };
+
+    expect(
+      addPromptCacheToLastMessage(messages, googleModel as unknown as LanguageModel)
+    ).toEqual(messages);
+    expect(
+      addPromptCacheToLastMessage(messages, anthropicModel as unknown as LanguageModel)[1]
+    ).toEqual({
+      role: "user",
+      content: "hello",
+      providerOptions: {
+        anthropic: {
+          cacheControl: { type: "ephemeral" },
+        },
+      },
+    });
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add shared prompt-cache helpers for Anthropic cache-control metadata, long-content cache marks, per-step cache marks, and provider-option merging.
- Mark reusable system prompts in chat, Telegram, memory extraction/processing, applet AI, IE generation, room replies, parse-title, and song title AI parsing.
- Add per-step Anthropic cache control for Ryo chat and Telegram tool loops while preserving OpenAI reasoning provider options.
- Expand provider-options unit coverage for prompt caching helpers.

### Testing
- `bun test tests/test-ai-model-provider-options.test.ts tests/test-telegram-status.test.ts`
- `bun run test:unit`
- `bun run build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a29b3175-456e-4e8c-8158-320e9aefb4fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a29b3175-456e-4e8c-8158-320e9aefb4fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

