### PR TITLE
feat(chats): bridge ryOS Chats to IRC (default irc.pieter.com)

### DIFF
--- a/api/_utils/irc/_bridge.ts
+++ b/api/_utils/irc/_bridge.ts
@@ -487,6 +487,24 @@ export function getIrcBridge(): IrcBridge {
   return g[GLOBAL_KEY]!;
 }
 
+/**
+ * Return the existing bridge if one has been created, else `null`. Used by
+ * the send-message path so we don't accidentally open new IRC connections in
+ * environments where the bridge has been explicitly disabled.
+ */
+export function getIrcBridgeIfInitialized(): IrcBridge | null {
+  const g = globalThis as GlobalWithBridge;
+  return g[GLOBAL_KEY] ?? null;
+}
+
+/**
+ * Whether the IRC bridge should be active in the current environment.
+ * Setting `IRC_BRIDGE_DISABLED=1` opts out entirely.
+ */
+export function isIrcBridgeEnabled(): boolean {
+  return process.env.IRC_BRIDGE_DISABLED !== "1";
+}
+
 export function setIrcBridgeForTesting(bridge: IrcBridge | null): void {
   const g = globalThis as GlobalWithBridge;
   if (bridge) {

--- a/api/_utils/irc/_bridge.ts
+++ b/api/_utils/irc/_bridge.ts
@@ -1,0 +1,542 @@
+/**
+ * IRC Bridge
+ *
+ * Maintains persistent IRC connections on the API server and bridges IRC
+ * channels to ryOS chat rooms. Each configured IRC server gets one shared
+ * `IrcClient` instance which joins the set of channels currently bound
+ * to rooms via the `ircServer` / `ircChannel` fields on the Room object.
+ *
+ * Inbound (IRC → ryOS):
+ *   on 'message' → write a ChatMessage to Redis + broadcast via realtime
+ *
+ * Outbound (ryOS → IRC):
+ *   sendMessageToIrc(room, username, content) → client.say(channel, text)
+ *
+ * Serverless / Vercel note: this bridge is designed to run inside the
+ * long-lived Bun standalone API server. On Vercel serverless, the outbound
+ * path falls back to a short-lived "fire-and-forget" connection which sends
+ * a single PRIVMSG and disconnects.
+ */
+
+import EventEmitter from "node:events";
+import { createRequire } from "node:module";
+import {
+  DEFAULT_IRC_HOST,
+  DEFAULT_IRC_PORT,
+  DEFAULT_IRC_TLS,
+  buildIrcServerKey,
+  normalizeIrcChannel,
+} from "./_types.js";
+import type { Room, Message } from "../../rooms/_helpers/_types.js";
+import {
+  addMessage,
+  generateId,
+  getAllRoomIds,
+  getCurrentTimestamp,
+  getRoom,
+  parseRoomData,
+  setRoom,
+} from "../../rooms/_helpers/_redis.js";
+import { createRedis } from "../redis.js";
+import { broadcastNewMessage } from "../../rooms/_helpers/_pusher.js";
+import { CHAT_ROOM_PREFIX } from "../../rooms/_helpers/_constants.js";
+import { escapeHTML, filterProfanityPreservingUrls } from "../_validation.js";
+
+// Use createRequire so we can load the CommonJS-only `irc-framework` module
+// from an ESM context without forcing it on consumers that never touch IRC.
+const requireIrcFramework = createRequire(import.meta.url);
+
+type IrcClientCtor = new (options: Record<string, unknown>) => IrcClientLike;
+
+interface IrcMessageEvent {
+  type?: string;
+  target?: string;
+  nick?: string;
+  ident?: string;
+  hostname?: string;
+  message?: string;
+}
+
+export interface IrcClientLike extends EventEmitter {
+  connect(options?: Record<string, unknown>): void;
+  join(channel: string, key?: string): void;
+  part(channel: string, message?: string): void;
+  say(target: string, message: string): void;
+  changeNick(nick: string): void;
+  quit(message?: string): void;
+  connected?: boolean;
+}
+
+interface IrcBridgeDependencies {
+  /**
+   * Factory for creating an IRC client. Defaults to lazily importing
+   * `irc-framework` on first use. Injectable for tests.
+   */
+  createClient?: (options: Record<string, unknown>) => IrcClientLike;
+  /**
+   * Persist an incoming IRC message to Redis + broadcast. Injectable for tests.
+   */
+  persistIncomingMessage?: (
+    roomId: string,
+    message: Message,
+    room: Room | null
+  ) => Promise<void>;
+  /**
+   * Nick prefix used to identify the bot / nick base. Defaults to "ryos".
+   */
+  nickPrefix?: string;
+}
+
+interface ServerState {
+  key: string;
+  host: string;
+  port: number;
+  tls: boolean;
+  client: IrcClientLike | null;
+  ready: boolean;
+  channels: Map<string, Set<string>>; // channel → set of roomIds
+  pendingJoins: Set<string>;
+  nick: string | null;
+}
+
+const GLOBAL_KEY = "__ryosIrcBridge";
+
+type GlobalWithBridge = typeof globalThis & {
+  [GLOBAL_KEY]?: IrcBridge;
+};
+
+export class IrcBridge extends EventEmitter {
+  private readonly servers = new Map<string, ServerState>();
+  private initialized = false;
+  private readonly deps: Required<IrcBridgeDependencies>;
+
+  constructor(deps: IrcBridgeDependencies = {}) {
+    super();
+    this.deps = {
+      createClient:
+        deps.createClient ??
+        ((options) => {
+          // Lazy-load irc-framework via createRequire so tests that inject
+          // a custom client never touch the real module.
+          const mod = requireIrcFramework("irc-framework") as {
+            Client: IrcClientCtor;
+          };
+          return new mod.Client(options);
+        }),
+      persistIncomingMessage:
+        deps.persistIncomingMessage ?? defaultPersistIncomingMessage,
+      nickPrefix: deps.nickPrefix ?? "ryos",
+    };
+  }
+
+  /**
+   * Initialize the bridge by loading all Room records flagged as IRC rooms
+   * from Redis and connecting / joining them.
+   */
+  async initialize(): Promise<void> {
+    if (this.initialized) return;
+    this.initialized = true;
+
+    try {
+      const roomIds = await getAllRoomIds();
+      if (roomIds.length === 0) return;
+
+      const redis = createRedis();
+      const keys = roomIds.map((id) => `${CHAT_ROOM_PREFIX}${id}`);
+      const raws = await redis.mget<(Room | string | null)[]>(
+        ...(keys as [string, ...string[]])
+      );
+
+      for (let i = 0; i < raws.length; i++) {
+        const raw = raws[i];
+        if (!raw) continue;
+        const room = parseRoomData(raw);
+        if (!room) continue;
+        if (room.type !== "irc") continue;
+        if (!room.ircChannel) continue;
+
+        try {
+          await this.bindRoom(room);
+        } catch (err) {
+          console.error(
+            `[IrcBridge] Failed to bind room ${room.id} during init:`,
+            err
+          );
+        }
+      }
+    } catch (err) {
+      console.error("[IrcBridge] Initialization failed:", err);
+    }
+  }
+
+  /**
+   * Bind a ryOS room to an IRC channel. Creates/ensures the server connection
+   * exists and joins the channel if not already joined.
+   */
+  async bindRoom(room: Room): Promise<void> {
+    if (room.type !== "irc") return;
+    const host = (room.ircHost || DEFAULT_IRC_HOST).toLowerCase();
+    const port = Number(room.ircPort) || DEFAULT_IRC_PORT;
+    const tls = Boolean(room.ircTls ?? DEFAULT_IRC_TLS);
+    const channel = normalizeIrcChannel(room.ircChannel || "");
+    if (!channel) return;
+
+    const key = buildIrcServerKey(host, port, tls);
+    let server = this.servers.get(key);
+    if (!server) {
+      server = this.createServerState(key, host, port, tls);
+      this.servers.set(key, server);
+      this.connectServer(server);
+    }
+
+    const existing = server.channels.get(channel) || new Set<string>();
+    existing.add(room.id);
+    server.channels.set(channel, existing);
+
+    if (server.ready) {
+      if (!server.pendingJoins.has(channel)) {
+        server.pendingJoins.add(channel);
+        server.client?.join(channel);
+      }
+    }
+  }
+
+  /**
+   * Unbind a ryOS room from an IRC channel. Parts the channel if no other
+   * rooms are bound to it.
+   */
+  async unbindRoom(room: Pick<Room, "id" | "type" | "ircHost" | "ircPort" | "ircTls" | "ircChannel">): Promise<void> {
+    if (room.type !== "irc") return;
+    const host = (room.ircHost || DEFAULT_IRC_HOST).toLowerCase();
+    const port = Number(room.ircPort) || DEFAULT_IRC_PORT;
+    const tls = Boolean(room.ircTls ?? DEFAULT_IRC_TLS);
+    const channel = normalizeIrcChannel(room.ircChannel || "");
+    if (!channel) return;
+
+    const key = buildIrcServerKey(host, port, tls);
+    const server = this.servers.get(key);
+    if (!server) return;
+
+    const set = server.channels.get(channel);
+    if (set) {
+      set.delete(room.id);
+      if (set.size === 0) {
+        server.channels.delete(channel);
+        server.pendingJoins.delete(channel);
+        try {
+          server.client?.part(channel);
+        } catch (err) {
+          console.warn(`[IrcBridge] Failed to part ${channel}:`, err);
+        }
+      }
+    }
+
+    if (server.channels.size === 0 && server.client) {
+      try {
+        server.client.quit("ryOS bridge idle");
+      } catch {
+        // ignore
+      }
+      this.servers.delete(key);
+    }
+  }
+
+  /**
+   * Send a message from a ryOS user into the IRC channel bound to `room`.
+   */
+  async sendMessage(room: Room, username: string, content: string): Promise<void> {
+    if (room.type !== "irc" || !room.ircChannel) return;
+    const host = (room.ircHost || DEFAULT_IRC_HOST).toLowerCase();
+    const port = Number(room.ircPort) || DEFAULT_IRC_PORT;
+    const tls = Boolean(room.ircTls ?? DEFAULT_IRC_TLS);
+    const channel = normalizeIrcChannel(room.ircChannel);
+    const key = buildIrcServerKey(host, port, tls);
+    const server = this.servers.get(key);
+
+    const text = sanitizeOutgoing(`<${username}> ${content}`);
+
+    if (server?.client && server.ready) {
+      try {
+        server.client.say(channel, text);
+      } catch (err) {
+        console.error("[IrcBridge] Failed to send message to IRC:", err);
+      }
+      return;
+    }
+
+    // No persistent connection - ensure a binding is created so the next
+    // connect attempt joins this channel. Message itself will be delivered
+    // when the persistent connection becomes ready.
+    await this.bindRoom(room);
+  }
+
+  /**
+   * Stop all IRC connections. Used during shutdown / tests.
+   */
+  async shutdown(): Promise<void> {
+    for (const server of this.servers.values()) {
+      try {
+        server.client?.quit("ryOS bridge shutdown");
+      } catch {
+        // ignore
+      }
+    }
+    this.servers.clear();
+    this.initialized = false;
+  }
+
+  /**
+   * Return the current set of bound (server, channel) pairs. Useful for tests
+   * and admin introspection.
+   */
+  getBindings(): Array<{
+    host: string;
+    port: number;
+    tls: boolean;
+    channel: string;
+    roomIds: string[];
+  }> {
+    const results: Array<{
+      host: string;
+      port: number;
+      tls: boolean;
+      channel: string;
+      roomIds: string[];
+    }> = [];
+    for (const server of this.servers.values()) {
+      for (const [channel, ids] of server.channels.entries()) {
+        results.push({
+          host: server.host,
+          port: server.port,
+          tls: server.tls,
+          channel,
+          roomIds: Array.from(ids),
+        });
+      }
+    }
+    return results;
+  }
+
+  // Internals -------------------------------------------------------------
+
+  private createServerState(
+    key: string,
+    host: string,
+    port: number,
+    tls: boolean
+  ): ServerState {
+    return {
+      key,
+      host,
+      port,
+      tls,
+      client: null,
+      ready: false,
+      channels: new Map(),
+      pendingJoins: new Set(),
+      nick: null,
+    };
+  }
+
+  private connectServer(server: ServerState): void {
+    const nick = this.buildNick();
+    server.nick = nick;
+
+    const options: Record<string, unknown> = {
+      host: server.host,
+      port: server.port,
+      tls: server.tls,
+      nick,
+      username: nick,
+      gecos: "ryOS IRC bridge",
+      version: "ryos-irc-bridge",
+      auto_reconnect: true,
+      auto_reconnect_max_retries: 10,
+    };
+
+    let client: IrcClientLike;
+    try {
+      client = this.deps.createClient(options);
+    } catch (err) {
+      console.error(
+        `[IrcBridge] Failed to create IRC client for ${server.key}:`,
+        err
+      );
+      return;
+    }
+
+    server.client = client;
+
+    client.on("registered", () => {
+      server.ready = true;
+      for (const channel of server.channels.keys()) {
+        server.pendingJoins.add(channel);
+        try {
+          client.join(channel);
+        } catch (err) {
+          console.error(
+            `[IrcBridge] join(${channel}) failed on ${server.key}:`,
+            err
+          );
+        }
+      }
+    });
+
+    client.on("join", (event: IrcMessageEvent) => {
+      if (event?.nick && server.nick && event.nick === server.nick) {
+        const channel = normalizeIrcChannel(event.target || event.message || "");
+        if (channel) server.pendingJoins.delete(channel);
+      }
+    });
+
+    client.on("close", () => {
+      server.ready = false;
+    });
+
+    client.on("socket error", (err: unknown) => {
+      console.warn(`[IrcBridge] Socket error on ${server.key}:`, err);
+    });
+
+    client.on("message", (event: IrcMessageEvent) => {
+      void this.handleIncomingMessage(server, event).catch((err) => {
+        console.error("[IrcBridge] handleIncomingMessage failed:", err);
+      });
+    });
+
+    try {
+      client.connect();
+    } catch (err) {
+      console.error(`[IrcBridge] connect() failed for ${server.key}:`, err);
+    }
+  }
+
+  private async handleIncomingMessage(
+    server: ServerState,
+    event: IrcMessageEvent
+  ): Promise<void> {
+    if (!event) return;
+    const type = event.type || "privmsg";
+    if (type !== "privmsg" && type !== "action") return;
+
+    const rawChannel = event.target || "";
+    if (!rawChannel.startsWith("#") && !rawChannel.startsWith("&") && !rawChannel.startsWith("+")) {
+      // Ignore private messages to the bot
+      return;
+    }
+    const channel = normalizeIrcChannel(rawChannel);
+    const bound = server.channels.get(channel);
+    if (!bound || bound.size === 0) return;
+
+    const nick = (event.nick || "").trim();
+    if (!nick) return;
+    // Don't echo our own messages (we already persisted them via sendMessage)
+    if (server.nick && nick === server.nick) return;
+
+    const raw = (event.message || "").toString();
+    if (!raw) return;
+
+    const content = escapeHTML(filterProfanityPreservingUrls(raw));
+    const nickSafe = escapeHTML(nick);
+
+    for (const roomId of bound) {
+      const room = await getRoom(roomId).catch(() => null);
+      const message: Message = {
+        id: generateId(),
+        roomId,
+        username: `irc:${nickSafe}`,
+        content: type === "action" ? `* ${content}` : content,
+        timestamp: getCurrentTimestamp(),
+      };
+
+      try {
+        await this.deps.persistIncomingMessage(roomId, message, room);
+      } catch (err) {
+        console.error(
+          `[IrcBridge] Failed to persist IRC message for room ${roomId}:`,
+          err
+        );
+      }
+    }
+  }
+
+  private buildNick(): string {
+    const rand = Math.floor(Math.random() * 9999).toString(36);
+    return `${this.deps.nickPrefix}-${rand}`;
+  }
+}
+
+async function defaultPersistIncomingMessage(
+  roomId: string,
+  message: Message,
+  room: Room | null
+): Promise<void> {
+  await addMessage(roomId, message);
+  await broadcastNewMessage(roomId, message, room);
+}
+
+function sanitizeOutgoing(text: string): string {
+  // IRC line-endings: strip \r\n to keep to one message
+  return text.replace(/[\r\n]+/g, " ").slice(0, 400);
+}
+
+export function getIrcBridge(): IrcBridge {
+  const g = globalThis as GlobalWithBridge;
+  if (!g[GLOBAL_KEY]) {
+    g[GLOBAL_KEY] = new IrcBridge();
+  }
+  return g[GLOBAL_KEY]!;
+}
+
+export function setIrcBridgeForTesting(bridge: IrcBridge | null): void {
+  const g = globalThis as GlobalWithBridge;
+  if (bridge) {
+    g[GLOBAL_KEY] = bridge;
+  } else {
+    delete g[GLOBAL_KEY];
+  }
+}
+
+/**
+ * Persist an IRC room mutation (bind/unbind) that was triggered by a room
+ * creation or deletion API call. Safe to call from any environment; will
+ * become a no-op when the bridge hasn't been initialised.
+ */
+export async function notifyRoomBindingChange(
+  action: "bind" | "unbind",
+  room: Room
+): Promise<void> {
+  if (room.type !== "irc") return;
+  const g = globalThis as GlobalWithBridge;
+  const bridge = g[GLOBAL_KEY];
+  if (!bridge) return;
+  if (action === "bind") {
+    await bridge.bindRoom(room);
+  } else {
+    await bridge.unbindRoom(room);
+  }
+}
+
+/**
+ * Persist room to Redis if the server-details fields need defaults filled in.
+ */
+export async function ensureIrcRoomDefaults(room: Room): Promise<Room> {
+  if (room.type !== "irc") return room;
+  const updated: Room = {
+    ...room,
+    ircHost: room.ircHost || DEFAULT_IRC_HOST,
+    ircPort: Number(room.ircPort) || DEFAULT_IRC_PORT,
+    ircTls: typeof room.ircTls === "boolean" ? room.ircTls : DEFAULT_IRC_TLS,
+    ircChannel: normalizeIrcChannel(
+      room.ircChannel || (room.name?.startsWith("#") ? room.name : `#${room.name || ""}`)
+    ),
+  };
+  const changed =
+    updated.ircHost !== room.ircHost ||
+    updated.ircPort !== room.ircPort ||
+    updated.ircTls !== room.ircTls ||
+    updated.ircChannel !== room.ircChannel;
+  if (changed) {
+    await setRoom(updated.id, updated);
+  }
+  return updated;
+}

--- a/api/_utils/irc/_bridge.ts
+++ b/api/_utils/irc/_bridge.ts
@@ -19,6 +19,7 @@
  */
 
 import EventEmitter from "node:events";
+import { randomInt } from "node:crypto";
 import { createRequire } from "node:module";
 import {
   DEFAULT_IRC_HOST,
@@ -641,7 +642,7 @@ export class IrcBridge extends EventEmitter {
   }
 
   private buildNick(): string {
-    const rand = Math.floor(Math.random() * 9999).toString(36);
+    const rand = randomInt(0, 1_000_000).toString(36);
     return `${this.deps.nickPrefix}-${rand}`;
   }
 }

--- a/api/_utils/irc/_bridge.ts
+++ b/api/_utils/irc/_bridge.ts
@@ -64,7 +64,14 @@ export interface IrcClientLike extends EventEmitter {
   say(target: string, message: string): void;
   changeNick(nick: string): void;
   quit(message?: string): void;
+  list?: (...args: unknown[]) => void;
   connected?: boolean;
+}
+
+export interface IrcChannelListEntry {
+  channel: string;
+  numUsers: number;
+  topic: string;
 }
 
 interface IrcBridgeDependencies {
@@ -283,6 +290,180 @@ export class IrcBridge extends EventEmitter {
     }
     this.servers.clear();
     this.initialized = false;
+  }
+
+  /**
+   * Run an IRC LIST against the given server and return the result.
+   *
+   * If a persistent connection already exists for the server (because at
+   * least one room is bound to it), the LIST is issued on that client.
+   * Otherwise a short-lived client is created, the LIST is collected, and
+   * the client is disconnected.
+   *
+   * Resolves with up to `options.maxChannels` channels (default 500). The
+   * promise is rejected only if the underlying client fails to connect.
+   */
+  async listChannels(
+    host: string,
+    port: number,
+    tls: boolean,
+    options: { timeoutMs?: number; maxChannels?: number } = {}
+  ): Promise<IrcChannelListEntry[]> {
+    const timeoutMs = Math.max(1000, options.timeoutMs ?? 15000);
+    const maxChannels = Math.max(1, options.maxChannels ?? 500);
+    const normalizedHost = host.toLowerCase();
+    const key = buildIrcServerKey(normalizedHost, port, tls);
+    const existing = this.servers.get(key);
+
+    if (existing?.client && existing.ready) {
+      return await this.collectChannelList(existing.client, timeoutMs, maxChannels);
+    }
+
+    return await this.runOneShotChannelList(
+      normalizedHost,
+      port,
+      tls,
+      timeoutMs,
+      maxChannels
+    );
+  }
+
+  private collectChannelList(
+    client: IrcClientLike,
+    timeoutMs: number,
+    maxChannels: number
+  ): Promise<IrcChannelListEntry[]> {
+    return new Promise<IrcChannelListEntry[]>((resolve) => {
+      const collected: IrcChannelListEntry[] = [];
+      let settled = false;
+
+      const finish = (): void => {
+        if (settled) return;
+        settled = true;
+        try {
+          client.off("channel list", onBatch);
+        } catch {
+          // ignore
+        }
+        try {
+          client.off("channel list end", onEnd);
+        } catch {
+          // ignore
+        }
+        clearTimeout(timer);
+        resolve(collected.slice(0, maxChannels));
+      };
+
+      const onBatch = (
+        batch: Array<{ channel?: string; num_users?: number; topic?: string }>
+      ): void => {
+        if (!Array.isArray(batch)) return;
+        for (const entry of batch) {
+          if (!entry || typeof entry.channel !== "string") continue;
+          collected.push({
+            channel: entry.channel,
+            numUsers: Number(entry.num_users) || 0,
+            topic: typeof entry.topic === "string" ? entry.topic : "",
+          });
+          if (collected.length >= maxChannels) {
+            finish();
+            return;
+          }
+        }
+      };
+
+      const onEnd = (): void => {
+        finish();
+      };
+
+      const timer = setTimeout(finish, timeoutMs);
+
+      try {
+        client.on("channel list", onBatch);
+        client.on("channel list end", onEnd);
+      } catch {
+        finish();
+        return;
+      }
+
+      try {
+        if (typeof client.list === "function") {
+          client.list();
+        } else {
+          finish();
+        }
+      } catch (err) {
+        console.warn("[IrcBridge] LIST command failed:", err);
+        finish();
+      }
+    });
+  }
+
+  private async runOneShotChannelList(
+    host: string,
+    port: number,
+    tls: boolean,
+    timeoutMs: number,
+    maxChannels: number
+  ): Promise<IrcChannelListEntry[]> {
+    const nick = this.buildNick();
+
+    let client: IrcClientLike;
+    try {
+      client = this.deps.createClient({
+        host,
+        port,
+        tls,
+        nick,
+        username: nick,
+        gecos: "ryOS IRC bridge (lister)",
+        version: "ryos-irc-bridge",
+        auto_reconnect: false,
+        auto_reconnect_max_retries: 0,
+      });
+    } catch (err) {
+      console.error(
+        `[IrcBridge] Failed to create one-shot IRC client for ${host}:${port}:`,
+        err
+      );
+      return [];
+    }
+
+    return await new Promise<IrcChannelListEntry[]>((resolve) => {
+      let settled = false;
+
+      const finish = (results: IrcChannelListEntry[]): void => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(connectTimer);
+        try {
+          client.quit("ryOS list complete");
+        } catch {
+          // ignore
+        }
+        resolve(results);
+      };
+
+      const connectTimer = setTimeout(() => finish([]), timeoutMs);
+
+      client.on("registered", () => {
+        void this.collectChannelList(client, timeoutMs, maxChannels).then(
+          (results) => finish(results)
+        );
+      });
+      client.on("close", () => finish([]));
+      client.on("socket error", () => finish([]));
+
+      try {
+        client.connect();
+      } catch (err) {
+        console.warn(
+          `[IrcBridge] one-shot connect failed for ${host}:${port}:`,
+          err
+        );
+        finish([]);
+      }
+    });
   }
 
   /**

--- a/api/_utils/irc/_servers.ts
+++ b/api/_utils/irc/_servers.ts
@@ -1,0 +1,175 @@
+/**
+ * IRC server registry
+ *
+ * Stores user-configured IRC servers in Redis so the Chats app can
+ * present a server picker in the IRC tab. The default `irc.pieter.com`
+ * is auto-seeded on first read so users always have at least one option
+ * to select.
+ *
+ * Storage layout:
+ *   chat:irc:server:<id>      → JSON-encoded `IrcServer`
+ *   chat:irc:servers          → SET of server ids
+ */
+
+import { createRedis } from "../redis.js";
+import {
+  DEFAULT_IRC_HOST,
+  DEFAULT_IRC_PORT,
+  DEFAULT_IRC_TLS,
+} from "./_types.js";
+
+export const IRC_SERVER_PREFIX = "chat:irc:server:";
+export const IRC_SERVERS_SET = "chat:irc:servers";
+
+export interface IrcServer {
+  id: string;
+  label: string;
+  host: string;
+  port: number;
+  tls: boolean;
+  isDefault?: boolean;
+  createdAt: number;
+}
+
+const DEFAULT_SERVER_ID = "default-pieter";
+
+const DEFAULT_SERVER: IrcServer = {
+  id: DEFAULT_SERVER_ID,
+  label: "irc.pieter.com",
+  host: DEFAULT_IRC_HOST,
+  port: DEFAULT_IRC_PORT,
+  tls: DEFAULT_IRC_TLS,
+  isDefault: true,
+  createdAt: 0,
+};
+
+function getRedis() {
+  return createRedis();
+}
+
+export function generateIrcServerId(): string {
+  const bytes = new Uint8Array(8);
+  crypto.getRandomValues(bytes);
+  return Array.from(bytes)
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+function parseServerData(raw: unknown): IrcServer | null {
+  if (!raw) return null;
+  if (typeof raw === "object") return raw as IrcServer;
+  if (typeof raw === "string") {
+    try {
+      return JSON.parse(raw) as IrcServer;
+    } catch {
+      return null;
+    }
+  }
+  return null;
+}
+
+/**
+ * Persist a server record + add it to the registry set.
+ */
+export async function setIrcServer(server: IrcServer): Promise<void> {
+  const redis = getRedis();
+  await redis.set(`${IRC_SERVER_PREFIX}${server.id}`, JSON.stringify(server));
+  await redis.sadd(IRC_SERVERS_SET, server.id);
+}
+
+export async function getIrcServer(id: string): Promise<IrcServer | null> {
+  const redis = getRedis();
+  const raw = await redis.get(`${IRC_SERVER_PREFIX}${id}`);
+  return parseServerData(raw);
+}
+
+export async function deleteIrcServer(id: string): Promise<void> {
+  const redis = getRedis();
+  await redis.del(`${IRC_SERVER_PREFIX}${id}`);
+  await redis.srem(IRC_SERVERS_SET, id);
+}
+
+/**
+ * List all stored IRC servers, auto-seeding the default `irc.pieter.com`
+ * record on first call so the UI always has at least one entry to select.
+ */
+export async function listIrcServers(): Promise<IrcServer[]> {
+  const redis = getRedis();
+  let ids = (await redis.smembers<string[]>(IRC_SERVERS_SET)) || [];
+
+  if (!ids.includes(DEFAULT_SERVER_ID)) {
+    const seed: IrcServer = { ...DEFAULT_SERVER, createdAt: Date.now() };
+    await setIrcServer(seed);
+    ids = await redis.smembers<string[]>(IRC_SERVERS_SET);
+  }
+
+  if (ids.length === 0) return [];
+
+  const keys = ids.map((id) => `${IRC_SERVER_PREFIX}${id}`);
+  const raws = await redis.mget<(IrcServer | string | null)[]>(
+    ...(keys as [string, ...string[]])
+  );
+
+  const servers: IrcServer[] = [];
+  for (let i = 0; i < raws.length; i++) {
+    const parsed = parseServerData(raws[i]);
+    if (parsed) servers.push(parsed);
+  }
+
+  // Stable sort: default first, then label asc.
+  servers.sort((a, b) => {
+    if (a.isDefault && !b.isDefault) return -1;
+    if (!a.isDefault && b.isDefault) return 1;
+    return a.label.localeCompare(b.label);
+  });
+
+  return servers;
+}
+
+/**
+ * Validate user-supplied server fields. Returns a normalized server (no id /
+ * createdAt yet) on success, or an error message.
+ */
+export function normalizeIrcServerInput(input: {
+  label?: unknown;
+  host?: unknown;
+  port?: unknown;
+  tls?: unknown;
+}): { ok: true; value: Omit<IrcServer, "id" | "createdAt"> } | { ok: false; error: string } {
+  const label = typeof input.label === "string" ? input.label.trim() : "";
+  const host = typeof input.host === "string" ? input.host.trim().toLowerCase() : "";
+  const portRaw = input.port;
+  const port =
+    typeof portRaw === "number"
+      ? portRaw
+      : typeof portRaw === "string"
+        ? parseInt(portRaw, 10)
+        : NaN;
+  const tls = Boolean(input.tls);
+
+  if (!host) {
+    return { ok: false, error: "Server host is required" };
+  }
+  if (host.length > 253) {
+    return { ok: false, error: "Server host is too long" };
+  }
+  // Conservative hostname/IP validation: alnum + dots + dashes only.
+  if (!/^[a-z0-9][a-z0-9.-]*[a-z0-9]$/i.test(host) && !/^\[?[0-9a-f:.]+\]?$/i.test(host)) {
+    return { ok: false, error: "Invalid server host" };
+  }
+  if (!Number.isFinite(port) || port < 1 || port > 65535) {
+    return { ok: false, error: "Server port must be between 1 and 65535" };
+  }
+
+  return {
+    ok: true,
+    value: {
+      label: label || host,
+      host,
+      port,
+      tls,
+    },
+  };
+}
+
+export const __DEFAULT_IRC_SERVER_ID = DEFAULT_SERVER_ID;

--- a/api/_utils/irc/_types.ts
+++ b/api/_utils/irc/_types.ts
@@ -1,0 +1,41 @@
+/**
+ * IRC bridge types
+ */
+
+export const DEFAULT_IRC_HOST = "irc.pieter.com";
+export const DEFAULT_IRC_PORT = 6667;
+export const DEFAULT_IRC_TLS = false;
+export const DEFAULT_IRC_CHANNEL = "#pieter";
+
+export interface IrcServerConfig {
+  host: string;
+  port: number;
+  tls: boolean;
+}
+
+export interface IrcRoomBinding {
+  roomId: string;
+  channel: string; // e.g. "#pieter"
+  host: string;
+  port: number;
+  tls: boolean;
+}
+
+export interface IrcIncomingMessage {
+  roomId: string;
+  nick: string;
+  content: string;
+  timestamp: number;
+}
+
+export function normalizeIrcChannel(channel: string): string {
+  const trimmed = channel.trim();
+  if (!trimmed) return "";
+  // Ensure it starts with # (support &, +, ! too but default to #)
+  if (/^[#&+!]/.test(trimmed)) return trimmed;
+  return `#${trimmed.replace(/^#+/, "")}`;
+}
+
+export function buildIrcServerKey(host: string, port: number, tls: boolean): string {
+  return `${tls ? "ircs" : "irc"}://${host.toLowerCase()}:${port}`;
+}

--- a/api/irc/servers/[id].ts
+++ b/api/irc/servers/[id].ts
@@ -1,0 +1,59 @@
+/**
+ * /api/irc/servers/[id]
+ *
+ * DELETE - Remove an IRC server from the registry (admin only)
+ */
+
+import { apiHandler } from "../../_utils/api-handler.js";
+import {
+  __DEFAULT_IRC_SERVER_ID,
+  deleteIrcServer,
+  getIrcServer,
+} from "../../_utils/irc/_servers.js";
+
+export const runtime = "nodejs";
+export const maxDuration = 10;
+
+export default apiHandler(
+  { methods: ["DELETE"], auth: "required" },
+  async ({ req, res, logger, startTime, user }) => {
+    const id = (req.query.id as string | undefined)?.trim();
+    if (!id) {
+      logger.response(400, Date.now() - startTime);
+      res.status(400).json({ error: "Server id is required" });
+      return;
+    }
+
+    if (user!.username !== "ryo") {
+      logger.response(403, Date.now() - startTime);
+      res.status(403).json({ error: "Forbidden - admin access required" });
+      return;
+    }
+
+    if (id === __DEFAULT_IRC_SERVER_ID) {
+      logger.response(400, Date.now() - startTime);
+      res
+        .status(400)
+        .json({ error: "Cannot delete the default irc.pieter.com server" });
+      return;
+    }
+
+    const existing = await getIrcServer(id);
+    if (!existing) {
+      logger.response(404, Date.now() - startTime);
+      res.status(404).json({ error: "Server not found" });
+      return;
+    }
+
+    try {
+      await deleteIrcServer(id);
+      logger.info("IRC server deleted", { id, host: existing.host });
+      logger.response(200, Date.now() - startTime);
+      res.status(200).json({ success: true });
+    } catch (error) {
+      logger.error("Error deleting IRC server", error);
+      logger.response(500, Date.now() - startTime);
+      res.status(500).json({ error: "Failed to delete IRC server" });
+    }
+  }
+);

--- a/api/irc/servers/[id]/channels.ts
+++ b/api/irc/servers/[id]/channels.ts
@@ -1,0 +1,88 @@
+/**
+ * /api/irc/servers/[id]/channels
+ *
+ * GET - List the channels currently advertised by an IRC server.
+ *
+ * The bridge runs an IRC LIST against the configured server and returns
+ * the parsed result. Admin only because it requires opening (or reusing)
+ * a real IRC connection.
+ */
+
+import { apiHandler } from "../../../_utils/api-handler.js";
+import { getIrcServer } from "../../../_utils/irc/_servers.js";
+import {
+  getIrcBridge,
+  isIrcBridgeEnabled,
+} from "../../../_utils/irc/_bridge.js";
+
+export const runtime = "nodejs";
+export const maxDuration = 30;
+
+export default apiHandler(
+  { methods: ["GET"], auth: "required" },
+  async ({ req, res, logger, startTime, user }) => {
+    const id = (req.query.id as string | undefined)?.trim();
+    if (!id) {
+      logger.response(400, Date.now() - startTime);
+      res.status(400).json({ error: "Server id is required" });
+      return;
+    }
+
+    if (user!.username !== "ryo") {
+      logger.response(403, Date.now() - startTime);
+      res.status(403).json({ error: "Forbidden - admin access required" });
+      return;
+    }
+
+    if (!isIrcBridgeEnabled()) {
+      logger.response(503, Date.now() - startTime);
+      res.status(503).json({
+        error: "IRC bridge is disabled in this environment",
+      });
+      return;
+    }
+
+    const server = await getIrcServer(id);
+    if (!server) {
+      logger.response(404, Date.now() - startTime);
+      res.status(404).json({ error: "Server not found" });
+      return;
+    }
+
+    const limitParam = req.query.limit as string | undefined;
+    const requestedLimit = limitParam ? parseInt(limitParam, 10) : NaN;
+    const maxChannels = Number.isFinite(requestedLimit)
+      ? Math.min(2000, Math.max(1, requestedLimit))
+      : 500;
+    const timeoutParam = req.query.timeoutMs as string | undefined;
+    const requestedTimeout = timeoutParam ? parseInt(timeoutParam, 10) : NaN;
+    const timeoutMs = Number.isFinite(requestedTimeout)
+      ? Math.min(30000, Math.max(1000, requestedTimeout))
+      : 15000;
+
+    try {
+      const channels = await getIrcBridge().listChannels(
+        server.host,
+        server.port,
+        server.tls,
+        { maxChannels, timeoutMs }
+      );
+
+      logger.info("IRC channel list retrieved", {
+        host: server.host,
+        port: server.port,
+        count: channels.length,
+      });
+      logger.response(200, Date.now() - startTime);
+      res.status(200).json({
+        server,
+        channels,
+        truncated: channels.length >= maxChannels,
+      });
+    } catch (error) {
+      logger.error("Error listing IRC channels", error);
+      logger.response(500, Date.now() - startTime);
+      res.status(500).json({ error: "Failed to list IRC channels" });
+    }
+  }
+);

--- a/api/irc/servers/[id]/channels.ts
+++ b/api/irc/servers/[id]/channels.ts
@@ -4,8 +4,8 @@
  * GET - List the channels currently advertised by an IRC server.
  *
  * The bridge runs an IRC LIST against the configured server and returns
- * the parsed result. Admin only because it requires opening (or reusing)
- * a real IRC connection.
+ * the parsed result. Any authenticated user may list channels for servers
+ * already registered by an admin (POST/DELETE on servers remain admin-only).
  */
 
 import { apiHandler } from "../../../_utils/api-handler.js";
@@ -25,12 +25,6 @@ export default apiHandler(
     if (!id) {
       logger.response(400, Date.now() - startTime);
       res.status(400).json({ error: "Server id is required" });
-      return;
-    }
-
-    if (user!.username !== "ryo") {
-      logger.response(403, Date.now() - startTime);
-      res.status(403).json({ error: "Forbidden - admin access required" });
       return;
     }
 

--- a/api/irc/servers/index.ts
+++ b/api/irc/servers/index.ts
@@ -1,0 +1,87 @@
+/**
+ * /api/irc/servers
+ *
+ * GET  - List all configured IRC servers (anyone can read)
+ * POST - Add a new IRC server (admin only)
+ */
+
+import { apiHandler } from "../../_utils/api-handler.js";
+import {
+  generateIrcServerId,
+  listIrcServers,
+  normalizeIrcServerInput,
+  setIrcServer,
+  type IrcServer,
+} from "../../_utils/irc/_servers.js";
+
+export const runtime = "nodejs";
+export const maxDuration = 15;
+
+export default apiHandler(
+  { methods: ["GET", "POST"], auth: "optional" },
+  async ({ req, res, logger, startTime, user }) => {
+    const method = (req.method || "GET").toUpperCase();
+
+    if (method === "GET") {
+      try {
+        const servers = await listIrcServers();
+        logger.info("Listed IRC servers", { count: servers.length });
+        logger.response(200, Date.now() - startTime);
+        res.status(200).json({ servers });
+      } catch (error) {
+        logger.error("Error listing IRC servers", error);
+        logger.response(500, Date.now() - startTime);
+        res.status(500).json({ error: "Failed to list IRC servers" });
+      }
+      return;
+    }
+
+    if (!user) {
+      logger.response(401, Date.now() - startTime);
+      res.status(401).json({ error: "Unauthorized - missing credentials" });
+      return;
+    }
+
+    if (user.username !== "ryo") {
+      logger.response(403, Date.now() - startTime);
+      res.status(403).json({ error: "Forbidden - admin access required" });
+      return;
+    }
+
+    const body = req.body || {};
+    const normalized = normalizeIrcServerInput({
+      label: body.label,
+      host: body.host,
+      port: body.port,
+      tls: body.tls,
+    });
+
+    if (!normalized.ok) {
+      logger.response(400, Date.now() - startTime);
+      res.status(400).json({ error: normalized.error });
+      return;
+    }
+
+    const server: IrcServer = {
+      id: generateIrcServerId(),
+      ...normalized.value,
+      createdAt: Date.now(),
+    };
+
+    try {
+      await setIrcServer(server);
+      logger.info("IRC server added", {
+        id: server.id,
+        host: server.host,
+        port: server.port,
+        tls: server.tls,
+      });
+      logger.response(201, Date.now() - startTime);
+      res.status(201).json({ server });
+    } catch (error) {
+      logger.error("Error adding IRC server", error);
+      logger.response(500, Date.now() - startTime);
+      res.status(500).json({ error: "Failed to add IRC server" });
+    }
+  }
+);

--- a/api/rooms/[id].ts
+++ b/api/rooms/[id].ts
@@ -13,6 +13,7 @@ import { CHAT_ROOM_PREFIX, CHAT_ROOM_USERS_PREFIX, CHAT_ROOMS_SET } from "./_hel
 import { refreshRoomUserCount, deleteRoomPresence } from "./_helpers/_presence.js";
 import { broadcastRoomDeleted, broadcastRoomUpdated } from "./_helpers/_pusher.js";
 import type { Room } from "./_helpers/_types.js";
+import { notifyRoomBindingChange } from "../_utils/irc/_bridge.js";
 
 export const runtime = "nodejs";
 export const maxDuration = 30;
@@ -95,6 +96,14 @@ export default apiHandler(
           logger.response(403, Date.now() - startTime);
           res.status(403).json({ error: "Unauthorized - admin required" });
           return;
+        }
+      }
+
+      if (roomData.type === "irc") {
+        try {
+          await notifyRoomBindingChange("unbind", roomData);
+        } catch (err) {
+          logger.warn("IRC bridge unbind failed", err);
         }
       }
 

--- a/api/rooms/[id].ts
+++ b/api/rooms/[id].ts
@@ -13,7 +13,7 @@ import { CHAT_ROOM_PREFIX, CHAT_ROOM_USERS_PREFIX, CHAT_ROOMS_SET } from "./_hel
 import { refreshRoomUserCount, deleteRoomPresence } from "./_helpers/_presence.js";
 import { broadcastRoomDeleted, broadcastRoomUpdated } from "./_helpers/_pusher.js";
 import type { Room } from "./_helpers/_types.js";
-import { notifyRoomBindingChange } from "../_utils/irc/_bridge.js";
+import { notifyRoomBindingChange, isIrcBridgeEnabled } from "../_utils/irc/_bridge.js";
 
 export const runtime = "nodejs";
 export const maxDuration = 30;
@@ -99,7 +99,7 @@ export default apiHandler(
         }
       }
 
-      if (roomData.type === "irc") {
+      if (roomData.type === "irc" && isIrcBridgeEnabled()) {
         try {
           await notifyRoomBindingChange("unbind", roomData);
         } catch (err) {

--- a/api/rooms/[id]/messages.ts
+++ b/api/rooms/[id]/messages.ts
@@ -28,7 +28,7 @@ import { refreshRoomPresence } from "../_helpers/_presence.js";
 import type { Message } from "../_helpers/_types.js";
 import { getRoomReadAccessError, getRoomWriteAccessError } from "../_helpers/_access.js";
 import { broadcastNewMessage } from "../_helpers/_pusher.js";
-import { getIrcBridge } from "../../_utils/irc/_bridge.js";
+import { getIrcBridge, isIrcBridgeEnabled } from "../../_utils/irc/_bridge.js";
 
 export const runtime = "nodejs";
 
@@ -236,9 +236,9 @@ export default apiHandler(
       await broadcastNewMessage(roomId, message, roomData);
       logger.info("Pusher room-message broadcast sent", { roomId, messageId: message.id });
 
-      // If this is an IRC room, forward the message to the IRC bridge. Send the
-      // unescaped content so the IRC side doesn't see HTML entities.
-      if (roomData.type === "irc") {
+      // If this is an IRC room, forward the message to the IRC bridge. Send
+      // the unescaped content so the IRC side doesn't see HTML entities.
+      if (roomData.type === "irc" && isIrcBridgeEnabled()) {
         try {
           await getIrcBridge().sendMessage(
             roomData,

--- a/api/rooms/[id]/messages.ts
+++ b/api/rooms/[id]/messages.ts
@@ -28,6 +28,7 @@ import { refreshRoomPresence } from "../_helpers/_presence.js";
 import type { Message } from "../_helpers/_types.js";
 import { getRoomReadAccessError, getRoomWriteAccessError } from "../_helpers/_access.js";
 import { broadcastNewMessage } from "../_helpers/_pusher.js";
+import { getIrcBridge } from "../../_utils/irc/_bridge.js";
 
 export const runtime = "nodejs";
 
@@ -234,6 +235,20 @@ export default apiHandler(
 
       await broadcastNewMessage(roomId, message, roomData);
       logger.info("Pusher room-message broadcast sent", { roomId, messageId: message.id });
+
+      // If this is an IRC room, forward the message to the IRC bridge. Send the
+      // unescaped content so the IRC side doesn't see HTML entities.
+      if (roomData.type === "irc") {
+        try {
+          await getIrcBridge().sendMessage(
+            roomData,
+            username,
+            filterProfanityPreservingUrls(originalContent)
+          );
+        } catch (err) {
+          logger.error("Failed to forward message to IRC bridge", err);
+        }
+      }
 
       logger.info("Message sent", { username, roomId, messageId: message.id });
       logger.response(201, Date.now() - startTime);

--- a/api/rooms/_helpers/_pusher.ts
+++ b/api/rooms/_helpers/_pusher.ts
@@ -47,11 +47,13 @@ export function filterRoomsForUser(
   username: string | null
 ): Room[] {
   if (!username) {
-    return rooms.filter((room) => !room.type || room.type === "public");
+    return rooms.filter(
+      (room) => !room.type || room.type === "public" || room.type === "irc"
+    );
   }
   const lower = username.toLowerCase();
   return rooms.filter((room) => {
-    if (!room.type || room.type === "public") return true;
+    if (!room.type || room.type === "public" || room.type === "irc") return true;
     if (room.type === "private" && room.members) {
       return room.members.includes(lower);
     }
@@ -77,7 +79,7 @@ export async function broadcastRoomUpdated(roomId: string): Promise<void> {
     const count = await refreshRoomUserCount(roomId);
     const room: Room = { ...roomObj, userCount: count };
 
-    if (!room.type || room.type === "public") {
+    if (!room.type || room.type === "public" || room.type === "irc") {
       await triggerRealtimeEvent("chats-public", "room-updated", { room });
     } else if (Array.isArray(room.members)) {
       await fanOutToPrivateMembers(roomId, "room-updated", { room });
@@ -93,7 +95,7 @@ export async function broadcastRoomUpdated(roomId: string): Promise<void> {
  */
 export async function broadcastRoomCreated(room: Room): Promise<void> {
   try {
-    if (!room.type || room.type === "public") {
+    if (!room.type || room.type === "public" || room.type === "irc") {
       await triggerRealtimeEvent("chats-public", "room-created", { room });
     } else if (Array.isArray(room.members) && room.members.length > 0) {
       // Use batch trigger for multiple members
@@ -119,7 +121,7 @@ export async function broadcastRoomDeleted(
   members: string[] = []
 ): Promise<void> {
   try {
-    if (!type || type === "public") {
+    if (!type || type === "public" || type === "irc") {
       await triggerRealtimeEvent("chats-public", "room-deleted", { roomId });
     } else if (Array.isArray(members) && members.length > 0) {
       // Use batch trigger for multiple members

--- a/api/rooms/_helpers/_types.ts
+++ b/api/rooms/_helpers/_types.ts
@@ -63,6 +63,8 @@ export interface CreateRoomData {
   type?: RoomType;
   members?: string[];
   // IRC bridging metadata. Only used when `type === "irc"`.
+  /** Registry id from GET /api/irc/servers — required for non-admin IRC room creation. */
+  ircServerId?: string;
   ircHost?: string;
   ircPort?: number;
   ircTls?: boolean;

--- a/api/rooms/_helpers/_types.ts
+++ b/api/rooms/_helpers/_types.ts
@@ -6,7 +6,7 @@
 // Room Types
 // ============================================================================
 
-export type RoomType = "public" | "private";
+export type RoomType = "public" | "private" | "irc";
 
 export interface Room {
   id: string;
@@ -15,6 +15,12 @@ export interface Room {
   createdAt: number;
   userCount: number;
   members?: string[]; // Only for private rooms
+  // IRC bridging metadata. Present only when `type === "irc"`.
+  ircHost?: string;
+  ircPort?: number;
+  ircTls?: boolean;
+  ircChannel?: string; // e.g. "#pieter"
+  ircServerLabel?: string; // Friendly label shown in UI
 }
 
 export interface RoomWithUsers extends Room {
@@ -56,6 +62,12 @@ export interface CreateRoomData {
   name?: string;
   type?: RoomType;
   members?: string[];
+  // IRC bridging metadata. Only used when `type === "irc"`.
+  ircHost?: string;
+  ircPort?: number;
+  ircTls?: boolean;
+  ircChannel?: string;
+  ircServerLabel?: string;
 }
 
 export interface JoinLeaveRoomData {

--- a/api/rooms/index.ts
+++ b/api/rooms/index.ts
@@ -19,7 +19,7 @@ import {
   DEFAULT_IRC_TLS,
   normalizeIrcChannel,
 } from "../_utils/irc/_types.js";
-import { notifyRoomBindingChange } from "../_utils/irc/_bridge.js";
+import { notifyRoomBindingChange, isIrcBridgeEnabled } from "../_utils/irc/_bridge.js";
 
 export const runtime = "nodejs";
 export const maxDuration = 30;
@@ -175,7 +175,7 @@ export default apiHandler(
         await Promise.all(normalizedMembers.map((member: string) => setRoomPresence(roomId, member)));
       }
 
-      if (type === "irc") {
+      if (type === "irc" && isIrcBridgeEnabled()) {
         try {
           await notifyRoomBindingChange("bind", room);
         } catch (err) {

--- a/api/rooms/index.ts
+++ b/api/rooms/index.ts
@@ -13,6 +13,13 @@ import { setRoomPresence } from "./_helpers/_presence.js";
 import { broadcastRoomCreated } from "./_helpers/_pusher.js";
 import { filterVisibleRooms } from "./_helpers/_access.js";
 import type { Room } from "./_helpers/_types.js";
+import {
+  DEFAULT_IRC_HOST,
+  DEFAULT_IRC_PORT,
+  DEFAULT_IRC_TLS,
+  normalizeIrcChannel,
+} from "../_utils/irc/_types.js";
+import { notifyRoomBindingChange } from "../_utils/irc/_bridge.js";
 
 export const runtime = "nodejs";
 export const maxDuration = 30;
@@ -55,9 +62,18 @@ export default apiHandler(
 
     const username = user.username;
     const body = req.body || {};
-    const { name: originalName, type = "public", members = [] } = body;
+    const {
+      name: originalName,
+      type = "public",
+      members = [],
+      ircHost: ircHostBody,
+      ircPort: ircPortBody,
+      ircTls: ircTlsBody,
+      ircChannel: ircChannelBody,
+      ircServerLabel: ircServerLabelBody,
+    } = body;
 
-    if (!["public", "private"].includes(type)) {
+    if (!["public", "private", "irc"].includes(type)) {
       logger.response(400, Date.now() - startTime);
       res.status(400).json({ error: "Invalid room type" });
       return;
@@ -81,6 +97,19 @@ export default apiHandler(
       }
     }
 
+    if (type === "irc") {
+      if (username !== "ryo") {
+        logger.response(403, Date.now() - startTime);
+        res.status(403).json({ error: "Forbidden - Only admin can create IRC rooms" });
+        return;
+      }
+      if (isProfaneUsername(originalName || "")) {
+        logger.response(400, Date.now() - startTime);
+        res.status(400).json({ error: "Room name contains inappropriate language" });
+        return;
+      }
+    }
+
     let normalizedMembers = [...(members || [])];
     if (type === "private") {
       if (!members || members.length === 0) {
@@ -97,6 +126,20 @@ export default apiHandler(
     let roomName: string;
     if (type === "public") {
       roomName = originalName.toLowerCase().replace(/ /g, "-");
+    } else if (type === "irc") {
+      // Derive the display name from the channel name so sidebar shows
+      // "#pieter" etc. Fall back to provided name.
+      const derivedChannel = normalizeIrcChannel(
+        ircChannelBody || originalName || ""
+      );
+      if (!derivedChannel) {
+        logger.response(400, Date.now() - startTime);
+        res
+          .status(400)
+          .json({ error: "IRC channel is required (e.g. #pieter)" });
+        return;
+      }
+      roomName = derivedChannel.replace(/^#/, "").toLowerCase();
     } else {
       const sortedMembers = [...normalizedMembers].sort();
       roomName = sortedMembers.map((m: string) => `@${m}`).join(", ");
@@ -111,6 +154,18 @@ export default apiHandler(
         createdAt: getCurrentTimestamp(),
         userCount: type === "private" ? normalizedMembers.length : 0,
         ...(type === "private" && { members: normalizedMembers }),
+        ...(type === "irc" && {
+          ircHost: (ircHostBody || DEFAULT_IRC_HOST).toString().toLowerCase(),
+          ircPort: Number(ircPortBody) || DEFAULT_IRC_PORT,
+          ircTls: typeof ircTlsBody === "boolean" ? ircTlsBody : DEFAULT_IRC_TLS,
+          ircChannel: normalizeIrcChannel(
+            ircChannelBody || originalName || ""
+          ),
+          ircServerLabel:
+            typeof ircServerLabelBody === "string" && ircServerLabelBody.trim()
+              ? ircServerLabelBody.trim()
+              : undefined,
+        }),
       };
 
       await setRoom(roomId, room);
@@ -118,6 +173,14 @@ export default apiHandler(
 
       if (type === "private") {
         await Promise.all(normalizedMembers.map((member: string) => setRoomPresence(roomId, member)));
+      }
+
+      if (type === "irc") {
+        try {
+          await notifyRoomBindingChange("bind", room);
+        } catch (err) {
+          logger.warn("IRC bridge bind failed", err);
+        }
       }
 
       await broadcastRoomCreated(room);

--- a/api/rooms/index.ts
+++ b/api/rooms/index.ts
@@ -19,7 +19,12 @@ import {
   DEFAULT_IRC_TLS,
   normalizeIrcChannel,
 } from "../_utils/irc/_types.js";
-import { notifyRoomBindingChange, isIrcBridgeEnabled } from "../_utils/irc/_bridge.js";
+import { getIrcServer } from "../_utils/irc/_servers.js";
+import {
+  notifyRoomBindingChange,
+  isIrcBridgeEnabled,
+  getIrcBridge,
+} from "../_utils/irc/_bridge.js";
 
 export const runtime = "nodejs";
 export const maxDuration = 30;
@@ -66,6 +71,7 @@ export default apiHandler(
       name: originalName,
       type = "public",
       members = [],
+      ircServerId: ircServerIdBody,
       ircHost: ircHostBody,
       ircPort: ircPortBody,
       ircTls: ircTlsBody,
@@ -98,11 +104,6 @@ export default apiHandler(
     }
 
     if (type === "irc") {
-      if (username !== "ryo") {
-        logger.response(403, Date.now() - startTime);
-        res.status(403).json({ error: "Forbidden - Only admin can create IRC rooms" });
-        return;
-      }
       if (isProfaneUsername(originalName || "")) {
         logger.response(400, Date.now() - startTime);
         res.status(400).json({ error: "Room name contains inappropriate language" });
@@ -124,11 +125,19 @@ export default apiHandler(
     }
 
     let roomName: string;
+    let ircResolved:
+      | {
+          host: string;
+          port: number;
+          tls: boolean;
+          channel: string;
+          ircServerLabel?: string;
+        }
+      | null = null;
+
     if (type === "public") {
       roomName = originalName.toLowerCase().replace(/ /g, "-");
     } else if (type === "irc") {
-      // Derive the display name from the channel name so sidebar shows
-      // "#pieter" etc. Fall back to provided name.
       const derivedChannel = normalizeIrcChannel(
         ircChannelBody || originalName || ""
       );
@@ -139,7 +148,96 @@ export default apiHandler(
           .json({ error: "IRC channel is required (e.g. #pieter)" });
         return;
       }
-      roomName = derivedChannel.replace(/^#/, "").toLowerCase();
+
+      const serverIdRaw =
+        typeof ircServerIdBody === "string" ? ircServerIdBody.trim() : "";
+
+      if (username === "ryo") {
+        const serverFromRegistry = serverIdRaw
+          ? await getIrcServer(serverIdRaw)
+          : null;
+        if (serverIdRaw && !serverFromRegistry) {
+          logger.response(400, Date.now() - startTime);
+          res.status(400).json({ error: "Unknown IRC server id" });
+          return;
+        }
+        if (serverFromRegistry) {
+          ircResolved = {
+            host: serverFromRegistry.host,
+            port: serverFromRegistry.port,
+            tls: serverFromRegistry.tls,
+            channel: derivedChannel,
+            ircServerLabel: serverFromRegistry.label,
+          };
+        } else {
+          ircResolved = {
+            host: (ircHostBody || DEFAULT_IRC_HOST).toString().toLowerCase(),
+            port: Number(ircPortBody) || DEFAULT_IRC_PORT,
+            tls: typeof ircTlsBody === "boolean" ? ircTlsBody : DEFAULT_IRC_TLS,
+            channel: derivedChannel,
+            ircServerLabel:
+              typeof ircServerLabelBody === "string" &&
+              ircServerLabelBody.trim()
+                ? ircServerLabelBody.trim()
+                : undefined,
+          };
+        }
+      } else {
+        if (!serverIdRaw) {
+          logger.response(403, Date.now() - startTime);
+          res.status(403).json({
+            error:
+              "Forbidden — pick a registered IRC server to create a bridged room",
+          });
+          return;
+        }
+        const serverFromRegistry = await getIrcServer(serverIdRaw);
+        if (!serverFromRegistry) {
+          logger.response(400, Date.now() - startTime);
+          res.status(400).json({ error: "Unknown IRC server id" });
+          return;
+        }
+        if (!isIrcBridgeEnabled()) {
+          logger.response(503, Date.now() - startTime);
+          res.status(503).json({
+            error: "IRC bridge is disabled in this environment",
+          });
+          return;
+        }
+        try {
+          const advertised = await getIrcBridge().listChannels(
+            serverFromRegistry.host,
+            serverFromRegistry.port,
+            serverFromRegistry.tls,
+            { maxChannels: 2000, timeoutMs: 15000 }
+          );
+          const channelOk = advertised.some(
+            (c) => c.channel.toLowerCase() === derivedChannel.toLowerCase()
+          );
+          if (!channelOk) {
+            logger.response(403, Date.now() - startTime);
+            res.status(403).json({
+              error:
+                "Channel must appear in that server’s public channel list (refresh the list and pick a channel)",
+            });
+            return;
+          }
+        } catch (err) {
+          logger.error("IRC channel validation failed", err);
+          logger.response(503, Date.now() - startTime);
+          res.status(503).json({ error: "Failed to validate IRC channel" });
+          return;
+        }
+        ircResolved = {
+          host: serverFromRegistry.host,
+          port: serverFromRegistry.port,
+          tls: serverFromRegistry.tls,
+          channel: derivedChannel,
+          ircServerLabel: serverFromRegistry.label,
+        };
+      }
+
+      roomName = ircResolved.channel.replace(/^#/, "").toLowerCase();
     } else {
       const sortedMembers = [...normalizedMembers].sort();
       roomName = sortedMembers.map((m: string) => `@${m}`).join(", ");
@@ -154,18 +252,16 @@ export default apiHandler(
         createdAt: getCurrentTimestamp(),
         userCount: type === "private" ? normalizedMembers.length : 0,
         ...(type === "private" && { members: normalizedMembers }),
-        ...(type === "irc" && {
-          ircHost: (ircHostBody || DEFAULT_IRC_HOST).toString().toLowerCase(),
-          ircPort: Number(ircPortBody) || DEFAULT_IRC_PORT,
-          ircTls: typeof ircTlsBody === "boolean" ? ircTlsBody : DEFAULT_IRC_TLS,
-          ircChannel: normalizeIrcChannel(
-            ircChannelBody || originalName || ""
-          ),
-          ircServerLabel:
-            typeof ircServerLabelBody === "string" && ircServerLabelBody.trim()
-              ? ircServerLabelBody.trim()
-              : undefined,
-        }),
+        ...(type === "irc" &&
+          ircResolved && {
+            ircHost: ircResolved.host.toLowerCase(),
+            ircPort: ircResolved.port,
+            ircTls: ircResolved.tls,
+            ircChannel: ircResolved.channel,
+            ...(ircResolved.ircServerLabel && {
+              ircServerLabel: ircResolved.ircServerLabel,
+            }),
+          }),
       };
 
       await setRoom(roomId, room);

--- a/bun.lock
+++ b/bun.lock
@@ -61,6 +61,7 @@
         "i18next-browser-languagedetector": "^8.2.0",
         "ioredis": "^5.10.0",
         "ios-vibrator-pro-max": "^1.3.2",
+        "irc-framework": "^4.14.0",
         "leo-profanity": "^1.8.0",
         "next-themes": "^0.4.6",
         "openai": "^4.104.0",
@@ -1288,7 +1289,7 @@
 
     "balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
-    "base64-js": ["base64-js@0.0.8", "", {}, "sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw=="],
+    "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
 
     "baseline-browser-mapping": ["baseline-browser-mapping@2.9.11", "", { "bin": { "baseline-browser-mapping": "dist/cli.js" } }, "sha512-Sg0xJUNDU1sJNGdfGWhVHX0kkZ+HWcvmVymJbj6NSgZZmW/8S9Y2HQ5euytnIgakgxN6papOAWiwDo1ctFDcoQ=="],
 
@@ -1306,7 +1307,7 @@
 
     "browserslist": ["browserslist@4.24.4", "", { "dependencies": { "caniuse-lite": "^1.0.30001688", "electron-to-chromium": "^1.5.73", "node-releases": "^2.0.19", "update-browserslist-db": "^1.1.1" }, "bin": { "browserslist": "cli.js" } }, "sha512-KDi1Ny1gSePi1vm0q4oxSF8b4DR44GF4BbmS2YdhPLOEqd8pDviZOGH/GsmRwoWJ2+5Lr085X7naowMwKHDG1A=="],
 
-    "buffer": ["buffer@5.7.1", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.1.13" } }, "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ=="],
+    "buffer": ["buffer@6.0.3", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.2.1" } }, "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA=="],
 
     "buffer-crc32": ["buffer-crc32@0.2.13", "", {}, "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ=="],
 
@@ -1388,7 +1389,7 @@
 
     "cookie-es": ["cookie-es@2.0.0", "", {}, "sha512-RAj4E421UYRgqokKUmotqAwuplYw15qtdXfY+hGzgCJ/MBjCVZcSoHK/kH9kocfjRjcDME7IiDWR/1WX1TM2Pg=="],
 
-    "core-js": ["core-js@2.6.12", "", {}, "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ=="],
+    "core-js": ["core-js@3.49.0", "", {}, "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg=="],
 
     "core-js-compat": ["core-js-compat@3.41.0", "", { "dependencies": { "browserslist": "^4.24.4" } }, "sha512-RFsU9LySVue9RTwdDVX/T0e2Y6jRYWXERKElIjpuEOEnxaXffI0X7RUwVzfYLfzuLXSNJDYoRYUAmRUcyln20A=="],
 
@@ -1580,6 +1581,8 @@
 
     "event-target-shim": ["event-target-shim@5.0.1", "", {}, "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="],
 
+    "eventemitter3": ["eventemitter3@5.0.4", "", {}, "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw=="],
+
     "events-intercept": ["events-intercept@2.0.0", "", {}, "sha512-blk1va0zol9QOrdZt0rFXo5KMkNPVSp92Eju/Qz8THwKWKRKeE0T8Br/1aW6+Edkyq9xHYgYxn2QtOnUKPUp+Q=="],
 
     "eventsource-parser": ["eventsource-parser@3.0.6", "", {}, "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg=="],
@@ -1595,6 +1598,8 @@
     "fast-json-stable-stringify": ["fast-json-stable-stringify@2.1.0", "", {}, "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="],
 
     "fast-levenshtein": ["fast-levenshtein@2.0.6", "", {}, "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="],
+
+    "fast-text-encoding": ["fast-text-encoding@1.0.6", "", {}, "sha512-VhXlQgj9ioXCqGstD37E/HBeqEGV/qOD/kmbVG8h5xKBYvM1L3lR1Zn4555cQ8GkYbJa8aJSipLPndE1k6zK2w=="],
 
     "fast-uri": ["fast-uri@3.0.6", "", {}, "sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw=="],
 
@@ -1700,6 +1705,8 @@
 
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
 
+    "grapheme-splitter": ["grapheme-splitter@1.0.4", "", {}, "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ=="],
+
     "hangul-romanization": ["hangul-romanization@1.0.1", "", {}, "sha512-Nh67VGRK0Zet2JRDWII4/RW004XSZyWVySSurM9PEAR1p+7/5Kr8OrrcSYQcQhyGCcBEKyQm98xd+rRnyO0uXg=="],
 
     "has-bigints": ["has-bigints@1.1.0", "", {}, "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg=="],
@@ -1744,7 +1751,7 @@
 
     "i18next-browser-languagedetector": ["i18next-browser-languagedetector@8.2.0", "", { "dependencies": { "@babel/runtime": "^7.23.2" } }, "sha512-P+3zEKLnOF0qmiesW383vsLdtQVyKtCNA9cjSoKCppTKPQVfKd2W8hbVo5ZhNJKDqeM7BOcvNoKJOjpHh4Js9g=="],
 
-    "iconv-lite": ["iconv-lite@0.4.24", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3" } }, "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA=="],
+    "iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
 
     "idb": ["idb@7.1.1", "", {}, "sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ=="],
 
@@ -1774,9 +1781,15 @@
 
     "ios-vibrator-pro-max": ["ios-vibrator-pro-max@1.3.2", "", {}, "sha512-HG5bUMXlju4pjDOQ4jg8d/9eAVh8myDzDOFuTfrHz6CmswNzLePPpIDjxX0lppO2F/2XMjQoWrIaSL6xj1Dyfg=="],
 
+    "ip-address": ["ip-address@10.1.0", "", {}, "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q=="],
+
+    "irc-framework": ["irc-framework@4.14.0", "", { "dependencies": { "buffer": "^6.0.3", "core-js": "^3.38.1", "eventemitter3": "^5.0.1", "grapheme-splitter": "^1.0.4", "iconv-lite": "^0.6.3", "isomorphic-textencoder": "^1.0.1", "lodash": "^4.17.21", "middleware-handler": "^0.2.0", "regenerator-runtime": "^0.14.1", "socks": "^2.8.3", "stream-browserify": "^3.0.0", "util": "^0.12.5" } }, "sha512-lNujDAxy9kcu89WbU5H7IDWly64aD1B9nN9AV5M6btfx88qyQuyH16j1tjS40nmkQH6ld6vvaihKRn9cjk1JrA=="],
+
     "is-alphabetical": ["is-alphabetical@2.0.1", "", {}, "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ=="],
 
     "is-alphanumerical": ["is-alphanumerical@2.0.1", "", { "dependencies": { "is-alphabetical": "^2.0.0", "is-decimal": "^2.0.0" } }, "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw=="],
+
+    "is-arguments": ["is-arguments@1.2.0", "", { "dependencies": { "call-bound": "^1.0.2", "has-tostringtag": "^1.0.2" } }, "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA=="],
 
     "is-array-buffer": ["is-array-buffer@3.0.5", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.3", "get-intrinsic": "^1.2.6" } }, "sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A=="],
 
@@ -1859,6 +1872,8 @@
     "isarray": ["isarray@1.0.0", "", {}, "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="],
 
     "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
+
+    "isomorphic-textencoder": ["isomorphic-textencoder@1.0.1", "", { "dependencies": { "fast-text-encoding": "^1.0.0" } }, "sha512-676hESgHullDdHDsj469hr+7t3i/neBKU9J7q1T4RHaWwLAsaQnywC0D1dIUId0YZ+JtVrShzuBk1soo0+GVcQ=="],
 
     "jackspeak": ["jackspeak@4.1.1", "", { "dependencies": { "@isaacs/cliui": "^8.0.2" } }, "sha512-zptv57P3GpL+O0I7VdMJNBZCu+BPHVQUk55Ft8/QCJjTVxrnJHuVuX/0Bl2A6/+2oyR/ZMEuFKwmzqqZ/U5nPQ=="],
 
@@ -2071,6 +2086,8 @@
     "micromark-util-types": ["micromark-util-types@2.0.2", "", {}, "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA=="],
 
     "micromatch": ["micromatch@4.0.8", "", { "dependencies": { "braces": "^3.0.3", "picomatch": "^2.3.1" } }, "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA=="],
+
+    "middleware-handler": ["middleware-handler@0.2.0", "", {}, "sha512-Qz4B0yWndSokapr3Kl7fpMRysS0DaBlOuATrExFuZbr+oXZ3rsAPufdLe8mUJXiG5A4aJGW6GfKS4PDfQwu7Mg=="],
 
     "milkdrop-eel-parser": ["milkdrop-eel-parser@0.0.4", "", {}, "sha512-4PsOdTMDB7GM3UFzqXQQXf8MBeoolOhsBLMlhug+IIMZ+yNkvqLbdqDbrueGZc8P8tLRJP8pbAxna1yjFr06HQ=="],
 
@@ -2312,7 +2329,7 @@
 
     "react-style-singleton": ["react-style-singleton@2.2.3", "", { "dependencies": { "get-nonce": "^1.0.0", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ=="],
 
-    "readable-stream": ["readable-stream@2.3.8", "", { "dependencies": { "core-util-is": "~1.0.0", "inherits": "~2.0.3", "isarray": "~1.0.0", "process-nextick-args": "~2.0.0", "safe-buffer": "~5.1.1", "string_decoder": "~1.1.1", "util-deprecate": "~1.0.1" } }, "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA=="],
+    "readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
 
     "readdirp": ["readdirp@4.1.2", "", {}, "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg=="],
 
@@ -2432,7 +2449,11 @@
 
     "sisteransi": ["sisteransi@1.0.5", "", {}, "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="],
 
+    "smart-buffer": ["smart-buffer@4.2.0", "", {}, "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg=="],
+
     "smob": ["smob@1.5.0", "", {}, "sha512-g6T+p7QO8npa+/hNx9ohv1E5pVCmWrVCUzUXJyLdMmftX6ER0oiWY/w9knEonLpnOp6b6FenKnMfR8gqwWdwig=="],
+
+    "socks": ["socks@2.8.7", "", { "dependencies": { "ip-address": "^10.0.1", "smart-buffer": "^4.2.0" } }, "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A=="],
 
     "sonner": ["sonner@2.0.7", "", { "peerDependencies": { "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc", "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc" } }, "sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w=="],
 
@@ -2457,6 +2478,8 @@
     "statuses": ["statuses@1.5.0", "", {}, "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA=="],
 
     "stop-iteration-iterator": ["stop-iteration-iterator@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "internal-slot": "^1.1.0" } }, "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ=="],
+
+    "stream-browserify": ["stream-browserify@3.0.0", "", { "dependencies": { "inherits": "~2.0.4", "readable-stream": "^3.5.0" } }, "sha512-H73RAHsVBapbim0tU2JwwOiXUj+fikfiaoYAKHF3VJfA0pe2BCzkhAHBlLG6REzE+2WNZcxOXjK7lkso+9euLA=="],
 
     "stream-to-array": ["stream-to-array@2.3.0", "", { "dependencies": { "any-promise": "^1.1.0" } }, "sha512-UsZtOYEn4tWU2RGLOXr/o/xjRBftZRlG3dEWoaHr8j4GuypJ3isitGbVyjQKAuMu+xbiop8q224TjiZWc4XTZA=="],
 
@@ -2672,7 +2695,7 @@
 
     "utf8-buffer": ["utf8-buffer@1.0.0", "", {}, "sha512-ueuhzvWnp5JU5CiGSY4WdKbiN/PO2AZ/lpeLiz2l38qwdLy/cW40XobgyuIWucNyum0B33bVB0owjFCeGBSLqg=="],
 
-    "util": ["util@0.10.4", "", { "dependencies": { "inherits": "2.0.3" } }, "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A=="],
+    "util": ["util@0.12.5", "", { "dependencies": { "inherits": "^2.0.3", "is-arguments": "^1.0.4", "is-generator-function": "^1.0.7", "is-typed-array": "^1.1.3", "which-typed-array": "^1.1.2" } }, "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA=="],
 
     "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
 
@@ -3048,17 +3071,19 @@
 
     "arraybuffer.prototype.slice/es-abstract": ["es-abstract@1.23.9", "", { "dependencies": { "array-buffer-byte-length": "^1.0.2", "arraybuffer.prototype.slice": "^1.0.4", "available-typed-arrays": "^1.0.7", "call-bind": "^1.0.8", "call-bound": "^1.0.3", "data-view-buffer": "^1.0.2", "data-view-byte-length": "^1.0.2", "data-view-byte-offset": "^1.0.1", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.0.0", "es-set-tostringtag": "^2.1.0", "es-to-primitive": "^1.3.0", "function.prototype.name": "^1.1.8", "get-intrinsic": "^1.2.7", "get-proto": "^1.0.0", "get-symbol-description": "^1.1.0", "globalthis": "^1.0.4", "gopd": "^1.2.0", "has-property-descriptors": "^1.0.2", "has-proto": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "internal-slot": "^1.1.0", "is-array-buffer": "^3.0.5", "is-callable": "^1.2.7", "is-data-view": "^1.0.2", "is-regex": "^1.2.1", "is-shared-array-buffer": "^1.0.4", "is-string": "^1.1.1", "is-typed-array": "^1.1.15", "is-weakref": "^1.1.0", "math-intrinsics": "^1.1.0", "object-inspect": "^1.13.3", "object-keys": "^1.1.1", "object.assign": "^4.1.7", "own-keys": "^1.0.1", "regexp.prototype.flags": "^1.5.3", "safe-array-concat": "^1.1.3", "safe-push-apply": "^1.0.0", "safe-regex-test": "^1.1.0", "set-proto": "^1.0.0", "string.prototype.trim": "^1.2.10", "string.prototype.trimend": "^1.0.9", "string.prototype.trimstart": "^1.0.8", "typed-array-buffer": "^1.0.3", "typed-array-byte-length": "^1.0.3", "typed-array-byte-offset": "^1.0.4", "typed-array-length": "^1.0.7", "unbox-primitive": "^1.1.0", "which-typed-array": "^1.1.18" } }, "sha512-py07lI0wjxAC/DcfK1S6G7iANonniZwTISvdPzk9hzeH0IZIshbuuFxLIU96OyF89Yb9hiqWn8M/bY83KY5vzA=="],
 
+    "assert/util": ["util@0.10.4", "", { "dependencies": { "inherits": "2.0.3" } }, "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A=="],
+
     "audio-format/is-buffer": ["is-buffer@1.1.6", "", {}, "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="],
 
     "automation-events/@babel/runtime": ["@babel/runtime@7.26.10", "", { "dependencies": { "regenerator-runtime": "^0.14.0" } }, "sha512-2WJMeRQPHKSPemqk/awGrAiuFfzBmOIPXKizAsVhWH9YJqLZ0H+HS4c8loHGgW6utJ3E/ejXQUsiGaQy2NZ9Fw=="],
 
     "babel-plugin-polyfill-corejs2/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
+    "babel-runtime/core-js": ["core-js@2.6.12", "", {}, "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ=="],
+
     "babel-runtime/regenerator-runtime": ["regenerator-runtime@0.11.1", "", {}, "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="],
 
     "browserslist/caniuse-lite": ["caniuse-lite@1.0.30001705", "", {}, "sha512-S0uyMMiYvA7CxNgomYBwwwPUnWzFD83f3B1ce5jHUfHTH//QL6hHsreI8RVC5606R4ssqravelYO5TU6t8sEyg=="],
-
-    "buffer/base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
 
     "edge-runtime/async-listen": ["async-listen@3.0.1", "", {}, "sha512-cWMaNwUJnf37C/S5TfCkk/15MwbPRwVYALA2jtjkbHjCmAPiDXyNJy2q3p1KAZzDLHAWyarUWSujUoHR4pEgrA=="],
 
@@ -3090,6 +3115,10 @@
 
     "jszip/pako": ["pako@1.0.11", "", {}, "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="],
 
+    "jszip/readable-stream": ["readable-stream@2.3.8", "", { "dependencies": { "core-util-is": "~1.0.0", "inherits": "~2.0.3", "isarray": "~1.0.0", "process-nextick-args": "~2.0.0", "safe-buffer": "~5.1.1", "string_decoder": "~1.1.1", "util-deprecate": "~1.0.1" } }, "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA=="],
+
+    "linebreak/base64-js": ["base64-js@0.0.8", "", {}, "sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw=="],
+
     "lru-cache/yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
 
     "mdast-util-find-and-replace/escape-string-regexp": ["escape-string-regexp@5.0.0", "", {}, "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="],
@@ -3102,11 +3131,11 @@
 
     "music-metadata/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
+    "music-metadata-browser/buffer": ["buffer@5.7.1", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.1.13" } }, "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ=="],
+
     "music-metadata-browser/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
     "music-metadata-browser/music-metadata": ["music-metadata@3.8.0", "", { "dependencies": { "debug": "^4.1.0", "file-type": "^11.0.0", "media-typer": "0.3.0", "strtok3": "^2.3.0", "token-types": "^1.0.1" } }, "sha512-aIADbp3uCS+ANr4nnFEHzTzMy81OT7PR7WBMW73SJ28Y7P94nnEugmTOj1ICP2JmxBBDlo+MeYVgiPnxVN69tg=="],
-
-    "music-metadata-browser/readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
 
     "object.fromentries/es-abstract": ["es-abstract@1.23.9", "", { "dependencies": { "array-buffer-byte-length": "^1.0.2", "arraybuffer.prototype.slice": "^1.0.4", "available-typed-arrays": "^1.0.7", "call-bind": "^1.0.8", "call-bound": "^1.0.3", "data-view-buffer": "^1.0.2", "data-view-byte-length": "^1.0.2", "data-view-byte-offset": "^1.0.1", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.0.0", "es-set-tostringtag": "^2.1.0", "es-to-primitive": "^1.3.0", "function.prototype.name": "^1.1.8", "get-intrinsic": "^1.2.7", "get-proto": "^1.0.0", "get-symbol-description": "^1.1.0", "globalthis": "^1.0.4", "gopd": "^1.2.0", "has-property-descriptors": "^1.0.2", "has-proto": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "internal-slot": "^1.1.0", "is-array-buffer": "^3.0.5", "is-callable": "^1.2.7", "is-data-view": "^1.0.2", "is-regex": "^1.2.1", "is-shared-array-buffer": "^1.0.4", "is-string": "^1.1.1", "is-typed-array": "^1.1.15", "is-weakref": "^1.1.0", "math-intrinsics": "^1.1.0", "object-inspect": "^1.13.3", "object-keys": "^1.1.1", "object.assign": "^4.1.7", "own-keys": "^1.0.1", "regexp.prototype.flags": "^1.5.3", "safe-array-concat": "^1.1.3", "safe-push-apply": "^1.0.0", "safe-regex-test": "^1.1.0", "set-proto": "^1.0.0", "string.prototype.trim": "^1.2.10", "string.prototype.trimend": "^1.0.9", "string.prototype.trimstart": "^1.0.8", "typed-array-buffer": "^1.0.3", "typed-array-byte-length": "^1.0.3", "typed-array-byte-offset": "^1.0.4", "typed-array-length": "^1.0.7", "unbox-primitive": "^1.1.0", "which-typed-array": "^1.1.18" } }, "sha512-py07lI0wjxAC/DcfK1S6G7iANonniZwTISvdPzk9hzeH0IZIshbuuFxLIU96OyF89Yb9hiqWn8M/bY83KY5vzA=="],
 
@@ -3131,6 +3160,8 @@
     "randombytes/safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
 
     "raw-body/http-errors": ["http-errors@1.7.3", "", { "dependencies": { "depd": "~1.1.2", "inherits": "2.0.4", "setprototypeof": "1.1.1", "statuses": ">= 1.5.0 < 2", "toidentifier": "1.0.0" } }, "sha512-ZTTX0MWrsQ2ZAhA1cejAwDLycFsd7I7nVtnkT3Ol0aqodaKW+0CTZDQ1uBv5whptCnc8e8HeRRJxRs0kmm/Qfw=="],
+
+    "raw-body/iconv-lite": ["iconv-lite@0.4.24", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3" } }, "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA=="],
 
     "react-redux/@types/use-sync-external-store": ["@types/use-sync-external-store@0.0.3", "", {}, "sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA=="],
 
@@ -3197,8 +3228,6 @@
     "unicode-trie/pako": ["pako@0.2.9", "", {}, "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA=="],
 
     "unified/is-plain-obj": ["is-plain-obj@4.1.0", "", {}, "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg=="],
-
-    "util/inherits": ["inherits@2.0.3", "", {}, "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw=="],
 
     "vercel/@vercel/blob": ["@vercel/blob@1.0.2", "", { "dependencies": { "async-retry": "^1.3.3", "is-buffer": "^2.0.5", "is-node-process": "^1.2.0", "throttleit": "^2.1.0", "undici": "^5.28.4" } }, "sha512-Im/KeFH4oPx7UsM+QiteimnE07bIUD7JK6CBafI9Z0jRFogaialTBMiZj8EKk/30ctUYsrpIIyP9iIY1YxWnUQ=="],
 
@@ -3549,6 +3578,8 @@
     "@vercel/nft/glob/minimatch": ["minimatch@10.1.1", "", { "dependencies": { "@isaacs/brace-expansion": "^5.0.0" } }, "sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ=="],
 
     "@vercel/static-config/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
+
+    "assert/util/inherits": ["inherits@2.0.3", "", {}, "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw=="],
 
     "filelist/minimatch/brace-expansion": ["brace-expansion@2.0.1", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA=="],
 

--- a/package.json
+++ b/package.json
@@ -121,6 +121,7 @@
     "i18next-browser-languagedetector": "^8.2.0",
     "ioredis": "^5.10.0",
     "ios-vibrator-pro-max": "^1.3.2",
+    "irc-framework": "^4.14.0",
     "leo-profanity": "^1.8.0",
     "next-themes": "^0.4.6",
     "openai": "^4.104.0",

--- a/scripts/api-standalone-server.ts
+++ b/scripts/api-standalone-server.ts
@@ -28,7 +28,7 @@ import {
   unregisterRealtimeSocket,
   unsubscribeRealtimeSocket,
 } from "../api/_utils/realtime.js";
-import { getIrcBridge } from "../api/_utils/irc/_bridge.js";
+import { getIrcBridge, isIrcBridgeEnabled } from "../api/_utils/irc/_bridge.js";
 import {
   discoverApiRouteManifest,
   type ApiRouteManifestEntry,
@@ -717,7 +717,7 @@ async function bootstrap(): Promise<void> {
   // Initialize the IRC bridge: connects to any IRC servers referenced by
   // existing `type: "irc"` rooms and keeps the connections open so inbound
   // IRC messages are persisted + broadcast to subscribed clients.
-  if (process.env.IRC_BRIDGE_DISABLED !== "1") {
+  if (isIrcBridgeEnabled()) {
     try {
       await getIrcBridge().initialize();
     } catch (err) {

--- a/scripts/api-standalone-server.ts
+++ b/scripts/api-standalone-server.ts
@@ -28,6 +28,7 @@ import {
   unregisterRealtimeSocket,
   unsubscribeRealtimeSocket,
 } from "../api/_utils/realtime.js";
+import { getIrcBridge } from "../api/_utils/irc/_bridge.js";
 import {
   discoverApiRouteManifest,
   type ApiRouteManifestEntry,
@@ -711,6 +712,17 @@ async function bootstrap(): Promise<void> {
 
   if (shouldEnableLocalRealtime()) {
     await ensureRealtimePubSubBridge();
+  }
+
+  // Initialize the IRC bridge: connects to any IRC servers referenced by
+  // existing `type: "irc"` rooms and keeps the connections open so inbound
+  // IRC messages are persisted + broadcast to subscribed clients.
+  if (process.env.IRC_BRIDGE_DISABLED !== "1") {
+    try {
+      await getIrcBridge().initialize();
+    } catch (err) {
+      console.warn("[api-standalone] IRC bridge init failed:", err);
+    }
   }
 
   Bun.serve<LocalRealtimeSocketData>({

--- a/src/api/irc.ts
+++ b/src/api/irc.ts
@@ -1,0 +1,71 @@
+import { apiRequest } from "@/api/core";
+
+export interface IrcServerSummary {
+  id: string;
+  label: string;
+  host: string;
+  port: number;
+  tls: boolean;
+  isDefault?: boolean;
+  createdAt: number;
+}
+
+export interface IrcChannelEntry {
+  channel: string;
+  numUsers: number;
+  topic: string;
+}
+
+export interface CreateIrcServerPayload {
+  label?: string;
+  host: string;
+  port: number;
+  tls: boolean;
+}
+
+export async function listIrcServers(): Promise<{ servers: IrcServerSummary[] }> {
+  return apiRequest<{ servers: IrcServerSummary[] }>({
+    path: "/api/irc/servers",
+    method: "GET",
+  });
+}
+
+export async function createIrcServer(
+  payload: CreateIrcServerPayload
+): Promise<{ server: IrcServerSummary }> {
+  return apiRequest<{ server: IrcServerSummary }, CreateIrcServerPayload>({
+    path: "/api/irc/servers",
+    method: "POST",
+    body: payload,
+  });
+}
+
+export async function deleteIrcServer(id: string): Promise<{ success: boolean }> {
+  return apiRequest<{ success: boolean }>({
+    path: `/api/irc/servers/${encodeURIComponent(id)}`,
+    method: "DELETE",
+  });
+}
+
+export async function listIrcChannels(
+  serverId: string,
+  options: { limit?: number; timeoutMs?: number } = {}
+): Promise<{
+  server: IrcServerSummary;
+  channels: IrcChannelEntry[];
+  truncated: boolean;
+}> {
+  return apiRequest<{
+    server: IrcServerSummary;
+    channels: IrcChannelEntry[];
+    truncated: boolean;
+  }>({
+    path: `/api/irc/servers/${encodeURIComponent(serverId)}/channels`,
+    method: "GET",
+    query: {
+      limit: options.limit ?? undefined,
+      timeoutMs: options.timeoutMs ?? undefined,
+    },
+    timeout: 35000,
+  });
+}

--- a/src/api/rooms.ts
+++ b/src/api/rooms.ts
@@ -27,6 +27,8 @@ export interface CreateRoomPayload {
   type: "public" | "private" | "irc";
   name?: string;
   members?: string[];
+  /** Registered server id from GET /api/irc/servers (required for non-admin IRC rooms). */
+  ircServerId?: string;
   ircHost?: string;
   ircPort?: number;
   ircTls?: boolean;

--- a/src/api/rooms.ts
+++ b/src/api/rooms.ts
@@ -3,10 +3,15 @@ import { apiRequest } from "@/api/core";
 export interface RoomSummary {
   id: string;
   name: string;
-  type?: "public" | "private";
+  type?: "public" | "private" | "irc";
   createdAt: number;
   members?: string[];
   userCount: number;
+  ircHost?: string;
+  ircPort?: number;
+  ircTls?: boolean;
+  ircChannel?: string;
+  ircServerLabel?: string;
 }
 
 export interface RoomMessage {
@@ -19,9 +24,14 @@ export interface RoomMessage {
 }
 
 export interface CreateRoomPayload {
-  type: "public" | "private";
+  type: "public" | "private" | "irc";
   name?: string;
   members?: string[];
+  ircHost?: string;
+  ircPort?: number;
+  ircTls?: boolean;
+  ircChannel?: string;
+  ircServerLabel?: string;
 }
 
 export async function listRooms(): Promise<{ rooms: RoomSummary[] }> {

--- a/src/apps/admin/components/AdminSidebar.tsx
+++ b/src/apps/admin/components/AdminSidebar.tsx
@@ -12,7 +12,7 @@ type AdminSection = "dashboard" | "users" | "rooms" | "songs" | "server";
 interface Room {
   id: string;
   name: string;
-  type: "public" | "private";
+  type: "public" | "private" | "irc";
   userCount: number;
 }
 

--- a/src/apps/admin/hooks/useAdminLogic.ts
+++ b/src/apps/admin/hooks/useAdminLogic.ts
@@ -56,10 +56,15 @@ interface User {
 interface Room {
   id: string;
   name: string;
-  type: "public" | "private";
+  type: "public" | "private" | "irc";
   createdAt: number;
   userCount: number;
   members?: string[];
+  ircHost?: string;
+  ircPort?: number;
+  ircTls?: boolean;
+  ircChannel?: string;
+  ircServerLabel?: string;
 }
 
 interface Message {

--- a/src/apps/chats/components/ChatRoomSidebar.tsx
+++ b/src/apps/chats/components/ChatRoomSidebar.tsx
@@ -101,6 +101,14 @@ export const ChatRoomSidebar: React.FC<ChatRoomSidebarProps> = ({
               ? getPrivateRoomDisplayName(room, username ?? null)
               : `#${room.name}`}
           </span>
+          {room.type === "irc" && (
+            <span
+              className="ml-1 text-[9px] font-bold uppercase tracking-wider text-purple-700/70"
+              title={`IRC ${room.ircHost || "irc.pieter.com"}`}
+            >
+              irc
+            </span>
+          )}
           {(hasUnread || room.type !== "private") && (
             <span
               className={cn(

--- a/src/apps/chats/components/ChatsDialogs.tsx
+++ b/src/apps/chats/components/ChatsDialogs.tsx
@@ -58,6 +58,7 @@ interface ChatsDialogsProps {
     type: "public" | "private" | "irc",
     members: string[],
     ircOptions?: {
+      ircServerId?: string;
       ircHost?: string;
       ircPort?: number;
       ircTls?: boolean;

--- a/src/apps/chats/components/ChatsDialogs.tsx
+++ b/src/apps/chats/components/ChatsDialogs.tsx
@@ -55,8 +55,15 @@ interface ChatsDialogsProps {
   prefilledUser: string;
   handleAddRoom: (
     roomName: string,
-    type: "public" | "private",
-    members: string[]
+    type: "public" | "private" | "irc",
+    members: string[],
+    ircOptions?: {
+      ircHost?: string;
+      ircPort?: number;
+      ircTls?: boolean;
+      ircChannel?: string;
+      ircServerLabel?: string;
+    }
   ) => Promise<{ ok: boolean; error?: string }>;
   isAdmin: boolean;
   username: string | null;

--- a/src/apps/chats/components/CreateRoomDialog.tsx
+++ b/src/apps/chats/components/CreateRoomDialog.tsx
@@ -50,6 +50,7 @@ interface CreateRoomDialogProps {
     type: "public" | "private" | "irc",
     members: string[],
     ircOptions?: {
+      ircServerId?: string;
       ircHost?: string;
       ircPort?: number;
       ircTls?: boolean;
@@ -100,6 +101,8 @@ export function CreateRoomDialog({
   const [isLoadingChannels, setIsLoadingChannels] = useState(false);
   const [channelsError, setChannelsError] = useState<string | null>(null);
   const [channelFilter, setChannelFilter] = useState("");
+  /** Filter text for the channel list only (non-admins cannot type arbitrary channels). */
+  const [channelListFilter, setChannelListFilter] = useState("");
   const [selectedChannel, setSelectedChannel] = useState<string | null>(null);
   const [customChannel, setCustomChannel] = useState("");
   const [channelsTruncated, setChannelsTruncated] = useState(false);
@@ -134,6 +137,7 @@ export function CreateRoomDialog({
       setIrcChannels([]);
       setChannelsError(null);
       setChannelFilter("");
+      setChannelListFilter("");
       setSelectedChannel(null);
       setCustomChannel("");
       setChannelsTruncated(false);
@@ -271,6 +275,7 @@ export function CreateRoomDialog({
     if (!selectedServerId) return;
     setSelectedChannel(null);
     setChannelFilter("");
+    setChannelListFilter("");
     setCustomChannel("");
     void loadIrcChannels(selectedServerId);
   }, [isOpen, activeTab, selectedServerId, loadIrcChannels]);
@@ -341,7 +346,9 @@ export function CreateRoomDialog({
   );
 
   const filteredChannels = (() => {
-    const term = channelFilter.trim().toLowerCase();
+    const term = (isAdmin ? channelFilter : channelListFilter)
+      .trim()
+      .toLowerCase();
     if (!term) return ircChannels;
     return ircChannels.filter((entry) => {
       const channelMatch = entry.channel.toLowerCase().includes(term);
@@ -362,6 +369,7 @@ export function CreateRoomDialog({
     try {
       let ircOptions:
         | {
+            ircServerId?: string;
             ircHost?: string;
             ircPort?: number;
             ircTls?: boolean;
@@ -378,9 +386,17 @@ export function CreateRoomDialog({
           setIsLoading(false);
           return;
         }
-        const rawChannel = (customChannel.trim() || selectedChannel || "").trim();
+        const rawChannel = (
+          isAdmin
+            ? customChannel.trim() || selectedChannel || ""
+            : selectedChannel || ""
+        ).trim();
         if (!rawChannel) {
-          setError("Please pick or enter an IRC channel.");
+          setError(
+            isAdmin
+              ? "Please pick or enter an IRC channel."
+              : "Please pick a channel from the list."
+          );
           setIsLoading(false);
           return;
         }
@@ -388,6 +404,7 @@ export function CreateRoomDialog({
           ? rawChannel
           : `#${rawChannel}`;
         ircOptions = {
+          ircServerId: server.id,
           ircHost: server.host,
           ircPort: server.port,
           ircTls: server.tls,
@@ -440,17 +457,22 @@ export function CreateRoomDialog({
         onValueChange={(v) => setActiveTab(v as "public" | "private" | "irc")}
         className="w-full"
       >
-        {isAdmin && (
-          <ThemedTabsList className="grid grid-cols-3 w-full">
-            <ThemedTabsTrigger value="private">
-              {t("apps.chats.sidebar.private")}
-            </ThemedTabsTrigger>
+        <ThemedTabsList
+          className={cn(
+            "grid w-full",
+            isAdmin ? "grid-cols-3" : "grid-cols-2"
+          )}
+        >
+          <ThemedTabsTrigger value="private">
+            {t("apps.chats.sidebar.private")}
+          </ThemedTabsTrigger>
+          {isAdmin && (
             <ThemedTabsTrigger value="public">
               {t("apps.chats.dialogs.public")}
             </ThemedTabsTrigger>
-            <ThemedTabsTrigger value="irc">IRC</ThemedTabsTrigger>
-          </ThemedTabsList>
-        )}
+          )}
+          <ThemedTabsTrigger value="irc">IRC</ThemedTabsTrigger>
+        </ThemedTabsList>
 
         {isAdmin && (
           <ThemedTabsContent value="public">
@@ -492,8 +514,7 @@ export function CreateRoomDialog({
           </ThemedTabsContent>
         )}
 
-        {isAdmin && (
-          <ThemedTabsContent value="irc">
+        <ThemedTabsContent value="irc">
             <div className="p-4 space-y-3">
               {/* Step 1: Server picker */}
               <div className="space-y-2">
@@ -550,19 +571,23 @@ export function CreateRoomDialog({
                             </span>
                           </SelectItem>
                         ))}
-                        <SelectItem
-                          value="__add__"
-                          className={cn(themeFont, "text-blue-600")}
-                        >
-                          <span className="inline-flex items-center gap-1">
-                            <Plus className="h-3 w-3" weight="bold" />
-                            Add new server…
-                          </span>
-                        </SelectItem>
+                        {isAdmin && (
+                          <SelectItem
+                            value="__add__"
+                            className={cn(themeFont, "text-blue-600")}
+                          >
+                            <span className="inline-flex items-center gap-1">
+                              <Plus className="h-3 w-3" weight="bold" />
+                              Add new server…
+                            </span>
+                          </SelectItem>
+                        )}
                       </SelectContent>
                     </Select>
                   </div>
-                  {selectedServer && !selectedServer.isDefault && (
+                  {isAdmin &&
+                    selectedServer &&
+                    !selectedServer.isDefault && (
                     <Button
                       type="button"
                       variant="ghost"
@@ -588,7 +613,7 @@ export function CreateRoomDialog({
               </div>
 
               {/* Inline "add server" form */}
-              {showAddServerForm && (
+              {isAdmin && showAddServerForm && (
                 <div className="space-y-2 border border-gray-300 rounded p-3 bg-gray-50">
                   <Label
                     className={cn("text-gray-700 font-semibold", themeFont)}
@@ -683,8 +708,17 @@ export function CreateRoomDialog({
               )}
 
               {/* Step 2: Channel browser */}
-              {selectedServerId && !showAddServerForm && (
+              {selectedServerId && (!isAdmin || !showAddServerForm) && (
                 <div className="space-y-2">
+                  {!isAdmin && (
+                    <p
+                      className={cn("text-gray-500 text-[11px]", themeFont)}
+                      style={themeFontStyle}
+                    >
+                      IRC servers are managed by an admin. Choose a channel
+                      from the list to join.
+                    </p>
+                  )}
                   <div className="flex items-center justify-between">
                     <Label
                       htmlFor="irc-channel-filter"
@@ -712,45 +746,68 @@ export function CreateRoomDialog({
                       />
                     </Button>
                   </div>
-                  <div className="relative">
-                    <Input
-                      id="irc-channel-filter"
-                      placeholder={
-                        isLoadingChannels
-                          ? "Loading channels…"
-                          : "Filter channels or type a new one"
-                      }
-                      value={channelFilter || customChannel}
-                      onChange={(e) => {
-                        const v = e.target.value;
-                        setChannelFilter(v);
-                        // If the user types something that doesn't exactly
-                        // match an existing channel, treat it as a custom
-                        // entry too so they can join an unlisted channel.
-                        const match = ircChannels.find(
-                          (c) => c.channel.toLowerCase() === v.toLowerCase()
-                        );
-                        if (match) {
-                          setSelectedChannel(match.channel);
-                          setCustomChannel("");
-                        } else if (v.startsWith("#") || v.startsWith("&")) {
-                          setCustomChannel(v);
-                          setSelectedChannel(null);
-                        } else {
-                          setCustomChannel("");
+                  {isAdmin ? (
+                    <div className="relative">
+                      <Input
+                        id="irc-channel-filter"
+                        placeholder={
+                          isLoadingChannels
+                            ? "Loading channels…"
+                            : "Filter channels or type a new one"
                         }
-                      }}
-                      className={cn("shadow-none h-8", themeFont)}
-                      style={themeFontStyle}
-                      disabled={isLoading || isLoadingChannels}
-                    />
-                    {isLoadingChannels && (
-                      <ActivityIndicator
-                        size="sm"
-                        className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-500"
+                        value={channelFilter || customChannel}
+                        onChange={(e) => {
+                          const v = e.target.value;
+                          setChannelFilter(v);
+                          const match = ircChannels.find(
+                            (c) => c.channel.toLowerCase() === v.toLowerCase()
+                          );
+                          if (match) {
+                            setSelectedChannel(match.channel);
+                            setCustomChannel("");
+                          } else if (v.startsWith("#") || v.startsWith("&")) {
+                            setCustomChannel(v);
+                            setSelectedChannel(null);
+                          } else {
+                            setCustomChannel("");
+                          }
+                        }}
+                        className={cn("shadow-none h-8", themeFont)}
+                        style={themeFontStyle}
+                        disabled={isLoading || isLoadingChannels}
                       />
-                    )}
-                  </div>
+                      {isLoadingChannels && (
+                        <ActivityIndicator
+                          size="sm"
+                          className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-500"
+                        />
+                      )}
+                    </div>
+                  ) : (
+                    <div className="relative">
+                      <Input
+                        id="irc-channel-filter"
+                        placeholder={
+                          isLoadingChannels
+                            ? "Loading channels…"
+                            : "Filter channels"
+                        }
+                        value={channelListFilter}
+                        onChange={(e) => {
+                          setChannelListFilter(e.target.value);
+                        }}
+                        className={cn("shadow-none h-8", themeFont)}
+                        style={themeFontStyle}
+                        disabled={isLoading || isLoadingChannels}
+                      />
+                      {isLoadingChannels && (
+                        <ActivityIndicator
+                          size="sm"
+                          className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-500"
+                        />
+                      )}
+                    </div>
+                  )}
                   {channelsError && (
                     <p
                       className={cn("text-red-600", themeFont)}
@@ -762,7 +819,8 @@ export function CreateRoomDialog({
                   {!isLoadingChannels && !channelsError && (
                     <div className="border border-gray-300 rounded max-h-[180px] overflow-y-auto bg-white">
                       <div className="p-1">
-                        {filteredChannels.length === 0 && !customChannel && (
+                        {filteredChannels.length === 0 &&
+                          !(isAdmin && customChannel) && (
                           <p
                             className={cn(
                               "text-gray-500 px-2 py-2",
@@ -770,8 +828,9 @@ export function CreateRoomDialog({
                             )}
                             style={themeFontStyle}
                           >
-                            No channels available. Type a channel name above
-                            to join one anyway.
+                            {isAdmin
+                              ? "No channels available. Type a channel name above to join one anyway."
+                              : "No channels match this filter."}
                           </p>
                         )}
                         {filteredChannels.map((entry) => {
@@ -785,6 +844,7 @@ export function CreateRoomDialog({
                                 setSelectedChannel(entry.channel);
                                 setCustomChannel("");
                                 setChannelFilter("");
+                                setChannelListFilter("");
                               }}
                               className={cn(
                                 "w-full text-left flex items-center gap-2 p-2 rounded",
@@ -823,15 +883,18 @@ export function CreateRoomDialog({
                       filter to see more.
                     </p>
                   )}
-                  {(customChannel ||
-                    (selectedChannel && !customChannel)) && (
+                  {((isAdmin &&
+                    (customChannel || (selectedChannel && !customChannel))) ||
+                    (!isAdmin && selectedChannel)) && (
                     <p
                       className={cn("text-gray-500", themeFont)}
                       style={themeFontStyle}
                     >
                       Will create a room bridged to{" "}
                       <span className="font-semibold">
-                        {customChannel || selectedChannel}
+                        {isAdmin
+                          ? customChannel || selectedChannel
+                          : selectedChannel}
                       </span>{" "}
                       on{" "}
                       <span className="font-semibold">
@@ -844,7 +907,6 @@ export function CreateRoomDialog({
               )}
             </div>
           </ThemedTabsContent>
-        )}
 
         <ThemedTabsContent value="private">
           <div className="p-4">
@@ -975,8 +1037,10 @@ export function CreateRoomDialog({
             (activeTab === "private" && selectedUsers.length === 0) ||
             (activeTab === "irc" &&
               (!selectedServerId ||
-                showAddServerForm ||
-                !(customChannel.trim() || selectedChannel)))
+                (isAdmin && showAddServerForm) ||
+                (isAdmin
+                  ? !(customChannel.trim() || selectedChannel)
+                  : !selectedChannel)))
           }
           className={cn("h-7", themeFont)}
           style={themeFontStyle}

--- a/src/apps/chats/components/CreateRoomDialog.tsx
+++ b/src/apps/chats/components/CreateRoomDialog.tsx
@@ -31,8 +31,15 @@ interface CreateRoomDialogProps {
   onOpenChange: (open: boolean) => void;
   onSubmit: (
     name: string,
-    type: "public" | "private",
-    members: string[]
+    type: "public" | "private" | "irc",
+    members: string[],
+    ircOptions?: {
+      ircHost?: string;
+      ircPort?: number;
+      ircTls?: boolean;
+      ircChannel?: string;
+      ircServerLabel?: string;
+    }
   ) => Promise<{ ok: boolean; error?: string }>;
   isAdmin: boolean;
   currentUsername: string | null;
@@ -54,8 +61,14 @@ export function CreateRoomDialog({
   const [selectedUsers, setSelectedUsers] = useState<string[]>([]);
   const [users, setUsers] = useState<User[]>([]);
   const [searchTerm, setSearchTerm] = useState("");
-  const [activeTab, setActiveTab] = useState<"public" | "private">("private");
+  const [activeTab, setActiveTab] = useState<"public" | "private" | "irc">(
+    "private"
+  );
   const [isSearching, setIsSearching] = useState(false);
+  const [ircChannel, setIrcChannel] = useState("#pieter");
+  const [ircHost, setIrcHost] = useState("irc.pieter.com");
+  const [ircPort, setIrcPort] = useState(6667);
+  const [ircTls, setIrcTls] = useState(false);
   const searchRequestIdRef = useRef(0);
 
   // Theme detection
@@ -71,6 +84,10 @@ export function CreateRoomDialog({
       setSelectedUsers(initialUsers); // Use initialUsers if provided
       setSearchTerm("");
       setUsers([]);
+      setIrcChannel("#pieter");
+      setIrcHost("irc.pieter.com");
+      setIrcPort(6667);
+      setIrcTls(false);
       // Reset to private tab when opening
       setActiveTab("private");
     }
@@ -132,7 +149,28 @@ export function CreateRoomDialog({
     setError(null);
 
     try {
-      const result = await onSubmit(roomName, activeTab, selectedUsers);
+      const ircOptions =
+        activeTab === "irc"
+          ? {
+              ircHost: ircHost.trim() || "irc.pieter.com",
+              ircPort: Number(ircPort) || 6667,
+              ircTls: Boolean(ircTls),
+              ircChannel: ircChannel.trim() || "#pieter",
+              ircServerLabel: (ircHost.trim() || "irc.pieter.com"),
+            }
+          : undefined;
+
+      const ircRoomName =
+        activeTab === "irc"
+          ? (ircChannel.trim() || "#pieter").replace(/^#/, "").toLowerCase()
+          : roomName;
+
+      const result = await onSubmit(
+        ircRoomName,
+        activeTab,
+        selectedUsers,
+        ircOptions
+      );
 
       if (result.ok) {
         onOpenChange(false);
@@ -167,17 +205,18 @@ export function CreateRoomDialog({
     <div className={isXpTheme ? "pt-2 pb-6 px-4" : "pt-3 pb-6 px-6"}>
       <Tabs
         value={activeTab}
-        onValueChange={(v) => setActiveTab(v as "public" | "private")}
+        onValueChange={(v) => setActiveTab(v as "public" | "private" | "irc")}
         className="w-full"
       >
         {isAdmin && (
-          <ThemedTabsList className="grid grid-cols-2 w-full">
+          <ThemedTabsList className="grid grid-cols-3 w-full">
             <ThemedTabsTrigger value="private">
               {t("apps.chats.sidebar.private")}
             </ThemedTabsTrigger>
             <ThemedTabsTrigger value="public">
               {t("apps.chats.dialogs.public")}
             </ThemedTabsTrigger>
+            <ThemedTabsTrigger value="irc">IRC</ThemedTabsTrigger>
           </ThemedTabsList>
         )}
 
@@ -217,6 +256,104 @@ export function CreateRoomDialog({
                   />
                 </div>
               </div>
+            </div>
+          </ThemedTabsContent>
+        )}
+
+        {isAdmin && (
+          <ThemedTabsContent value="irc">
+            <div className="p-4 space-y-3">
+              <div className="space-y-2">
+                <Label
+                  htmlFor="irc-channel"
+                  className={cn("text-gray-700", themeFont)}
+                  style={themeFontStyle}
+                >
+                  Channel
+                </Label>
+                <div className="relative">
+                  <Input
+                    id="irc-channel"
+                    value={ircChannel}
+                    onChange={(e) => {
+                      let v = e.target.value;
+                      if (!v.startsWith("#")) v = `#${v.replace(/^#+/, "")}`;
+                      setIrcChannel(v);
+                    }}
+                    placeholder="#pieter"
+                    className={cn("shadow-none h-8", themeFont)}
+                    style={themeFontStyle}
+                    disabled={isLoading}
+                  />
+                </div>
+              </div>
+              <div className="space-y-2">
+                <Label
+                  htmlFor="irc-host"
+                  className={cn("text-gray-700", themeFont)}
+                  style={themeFontStyle}
+                >
+                  Server
+                </Label>
+                <Input
+                  id="irc-host"
+                  value={ircHost}
+                  onChange={(e) => setIrcHost(e.target.value)}
+                  placeholder="irc.pieter.com"
+                  className={cn("shadow-none h-8", themeFont)}
+                  style={themeFontStyle}
+                  disabled={isLoading}
+                />
+              </div>
+              <div className="flex gap-3">
+                <div className="flex-1 space-y-2">
+                  <Label
+                    htmlFor="irc-port"
+                    className={cn("text-gray-700", themeFont)}
+                    style={themeFontStyle}
+                  >
+                    Port
+                  </Label>
+                  <Input
+                    id="irc-port"
+                    type="number"
+                    value={String(ircPort)}
+                    onChange={(e) => setIrcPort(Number(e.target.value) || 6667)}
+                    className={cn("shadow-none h-8", themeFont)}
+                    style={themeFontStyle}
+                    disabled={isLoading}
+                  />
+                </div>
+                <div className="flex-1 flex items-end pb-1">
+                  <Label
+                    htmlFor="irc-tls"
+                    className={cn("flex items-center gap-2", themeFont)}
+                    style={themeFontStyle}
+                  >
+                    <Checkbox
+                      id="irc-tls"
+                      checked={ircTls}
+                      onCheckedChange={(v) => setIrcTls(Boolean(v))}
+                      className="h-4 w-4"
+                      disabled={isLoading}
+                    />
+                    <span>TLS</span>
+                  </Label>
+                </div>
+              </div>
+              <p
+                className={cn("text-gray-500 pt-1", themeFont)}
+                style={themeFontStyle}
+              >
+                Messages in this room are bridged to{" "}
+                <span className="font-semibold">
+                  {ircHost || "irc.pieter.com"}
+                </span>{" "}
+                <span className="font-semibold">
+                  {ircChannel || "#pieter"}
+                </span>
+                .
+              </p>
             </div>
           </ThemedTabsContent>
         )}
@@ -347,7 +484,8 @@ export function CreateRoomDialog({
           disabled={
             isLoading ||
             (activeTab === "public" && !roomName.trim()) ||
-            (activeTab === "private" && selectedUsers.length === 0)
+            (activeTab === "private" && selectedUsers.length === 0) ||
+            (activeTab === "irc" && (!ircChannel.trim() || !ircHost.trim()))
           }
           className={cn("h-7", themeFont)}
           style={themeFontStyle}

--- a/src/apps/chats/components/CreateRoomDialog.tsx
+++ b/src/apps/chats/components/CreateRoomDialog.tsx
@@ -14,7 +14,14 @@ import { Tabs } from "@/components/ui/tabs";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Badge } from "@/components/ui/badge";
 import { ActivityIndicator } from "@/components/ui/activity-indicator";
-import { X } from "@phosphor-icons/react";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { X, Trash, Plus, ArrowClockwise } from "@phosphor-icons/react";
 import { type User } from "@/types/chat";
 import { useThemeStore } from "@/stores/useThemeStore";
 import { cn } from "@/lib/utils";
@@ -25,6 +32,15 @@ import {
   ThemedTabsTrigger,
   ThemedTabsContent,
 } from "@/components/shared/ThemedTabs";
+import {
+  createIrcServer as createIrcServerApi,
+  deleteIrcServer as deleteIrcServerApi,
+  listIrcChannels as listIrcChannelsApi,
+  listIrcServers as listIrcServersApi,
+  type IrcChannelEntry,
+  type IrcServerSummary,
+} from "@/api/irc";
+import { ApiRequestError } from "@/api/core";
 
 interface CreateRoomDialogProps {
   isOpen: boolean;
@@ -65,11 +81,31 @@ export function CreateRoomDialog({
     "private"
   );
   const [isSearching, setIsSearching] = useState(false);
-  const [ircChannel, setIrcChannel] = useState("#pieter");
-  const [ircHost, setIrcHost] = useState("irc.pieter.com");
-  const [ircPort, setIrcPort] = useState(6667);
-  const [ircTls, setIrcTls] = useState(false);
+
+  // IRC server picker state
+  const [ircServers, setIrcServers] = useState<IrcServerSummary[]>([]);
+  const [selectedServerId, setSelectedServerId] = useState<string | null>(null);
+  const [isLoadingServers, setIsLoadingServers] = useState(false);
+  const [serversError, setServersError] = useState<string | null>(null);
+  const [showAddServerForm, setShowAddServerForm] = useState(false);
+  const [newServerHost, setNewServerHost] = useState("");
+  const [newServerPort, setNewServerPort] = useState(6667);
+  const [newServerTls, setNewServerTls] = useState(false);
+  const [newServerLabel, setNewServerLabel] = useState("");
+  const [isAddingServer, setIsAddingServer] = useState(false);
+  const [addServerError, setAddServerError] = useState<string | null>(null);
+
+  // IRC channel browser state
+  const [ircChannels, setIrcChannels] = useState<IrcChannelEntry[]>([]);
+  const [isLoadingChannels, setIsLoadingChannels] = useState(false);
+  const [channelsError, setChannelsError] = useState<string | null>(null);
+  const [channelFilter, setChannelFilter] = useState("");
+  const [selectedChannel, setSelectedChannel] = useState<string | null>(null);
+  const [customChannel, setCustomChannel] = useState("");
+  const [channelsTruncated, setChannelsTruncated] = useState(false);
+
   const searchRequestIdRef = useRef(0);
+  const channelRequestIdRef = useRef(0);
 
   // Theme detection
   const currentTheme = useThemeStore((state) => state.current);
@@ -84,10 +120,23 @@ export function CreateRoomDialog({
       setSelectedUsers(initialUsers); // Use initialUsers if provided
       setSearchTerm("");
       setUsers([]);
-      setIrcChannel("#pieter");
-      setIrcHost("irc.pieter.com");
-      setIrcPort(6667);
-      setIrcTls(false);
+      // Reset IRC tab state
+      setIrcServers([]);
+      setSelectedServerId(null);
+      setServersError(null);
+      setShowAddServerForm(false);
+      setNewServerHost("");
+      setNewServerPort(6667);
+      setNewServerTls(false);
+      setNewServerLabel("");
+      setIsAddingServer(false);
+      setAddServerError(null);
+      setIrcChannels([]);
+      setChannelsError(null);
+      setChannelFilter("");
+      setSelectedChannel(null);
+      setCustomChannel("");
+      setChannelsTruncated(false);
       // Reset to private tab when opening
       setActiveTab("private");
     }
@@ -144,29 +193,212 @@ export function CreateRoomDialog({
     return () => clearTimeout(timeoutId);
   }, [searchTerm, searchUsers]);
 
+  // Fetch the list of IRC servers when the IRC tab becomes visible. Auto-
+  // selects the default (irc.pieter.com) server on first load.
+  const loadIrcServers = useCallback(async () => {
+    setIsLoadingServers(true);
+    setServersError(null);
+    try {
+      const data = await listIrcServersApi();
+      const servers = data.servers || [];
+      setIrcServers(servers);
+      setSelectedServerId((current) => {
+        if (current && servers.some((s) => s.id === current)) return current;
+        const def = servers.find((s) => s.isDefault) || servers[0];
+        return def?.id ?? null;
+      });
+    } catch (err) {
+      console.error("Failed to load IRC servers:", err);
+      setServersError(
+        err instanceof ApiRequestError
+          ? err.message
+          : "Failed to load IRC servers"
+      );
+    } finally {
+      setIsLoadingServers(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    if (activeTab !== "irc") return;
+    if (ircServers.length > 0 || isLoadingServers) return;
+    void loadIrcServers();
+  }, [isOpen, activeTab, ircServers.length, isLoadingServers, loadIrcServers]);
+
+  // Fetch the channel list whenever the selected server changes.
+  const loadIrcChannels = useCallback(
+    async (serverId: string) => {
+      const requestId = ++channelRequestIdRef.current;
+      setIsLoadingChannels(true);
+      setChannelsError(null);
+      setIrcChannels([]);
+      setChannelsTruncated(false);
+      try {
+        const data = await listIrcChannelsApi(serverId, { limit: 500 });
+        if (requestId !== channelRequestIdRef.current) return;
+        const channels = data.channels || [];
+        setIrcChannels(channels);
+        setChannelsTruncated(Boolean(data.truncated));
+        // Pre-select the first / default channel where applicable.
+        setSelectedChannel((current) => {
+          if (current && channels.some((c) => c.channel === current)) {
+            return current;
+          }
+          if (channels.length > 0) return channels[0].channel;
+          return null;
+        });
+      } catch (err) {
+        if (requestId !== channelRequestIdRef.current) return;
+        console.error("Failed to load IRC channels:", err);
+        setChannelsError(
+          err instanceof ApiRequestError
+            ? err.message
+            : "Failed to load IRC channels"
+        );
+      } finally {
+        if (requestId === channelRequestIdRef.current) {
+          setIsLoadingChannels(false);
+        }
+      }
+    },
+    []
+  );
+
+  useEffect(() => {
+    if (!isOpen) return;
+    if (activeTab !== "irc") return;
+    if (!selectedServerId) return;
+    setSelectedChannel(null);
+    setChannelFilter("");
+    setCustomChannel("");
+    void loadIrcChannels(selectedServerId);
+  }, [isOpen, activeTab, selectedServerId, loadIrcChannels]);
+
+  const handleAddIrcServer = useCallback(async () => {
+    setAddServerError(null);
+    const trimmedHost = newServerHost.trim();
+    if (!trimmedHost) {
+      setAddServerError("Server host is required");
+      return;
+    }
+    setIsAddingServer(true);
+    try {
+      const data = await createIrcServerApi({
+        host: trimmedHost,
+        port: Number(newServerPort) || 6667,
+        tls: Boolean(newServerTls),
+        label: newServerLabel.trim() || undefined,
+      });
+      setIrcServers((prev) => {
+        const next = prev.filter((s) => s.id !== data.server.id);
+        next.push(data.server);
+        next.sort((a, b) => {
+          if (a.isDefault && !b.isDefault) return -1;
+          if (!a.isDefault && b.isDefault) return 1;
+          return a.label.localeCompare(b.label);
+        });
+        return next;
+      });
+      setSelectedServerId(data.server.id);
+      setShowAddServerForm(false);
+      setNewServerHost("");
+      setNewServerPort(6667);
+      setNewServerTls(false);
+      setNewServerLabel("");
+    } catch (err) {
+      console.error("Failed to add IRC server:", err);
+      setAddServerError(
+        err instanceof ApiRequestError
+          ? err.message
+          : "Failed to add IRC server"
+      );
+    } finally {
+      setIsAddingServer(false);
+    }
+  }, [newServerHost, newServerPort, newServerTls, newServerLabel]);
+
+  const handleDeleteIrcServer = useCallback(
+    async (server: IrcServerSummary) => {
+      if (server.isDefault) return;
+      try {
+        await deleteIrcServerApi(server.id);
+        setIrcServers((prev) => prev.filter((s) => s.id !== server.id));
+        setSelectedServerId((current) => {
+          if (current !== server.id) return current;
+          return ircServers.find((s) => s.id !== server.id)?.id ?? null;
+        });
+      } catch (err) {
+        console.error("Failed to delete IRC server:", err);
+        setServersError(
+          err instanceof ApiRequestError
+            ? err.message
+            : "Failed to delete IRC server"
+        );
+      }
+    },
+    [ircServers]
+  );
+
+  const filteredChannels = (() => {
+    const term = channelFilter.trim().toLowerCase();
+    if (!term) return ircChannels;
+    return ircChannels.filter((entry) => {
+      const channelMatch = entry.channel.toLowerCase().includes(term);
+      const topicMatch =
+        typeof entry.topic === "string" &&
+        entry.topic.toLowerCase().includes(term);
+      return channelMatch || topicMatch;
+    });
+  })();
+
+  const selectedServer =
+    ircServers.find((s) => s.id === selectedServerId) ?? null;
+
   const handleSubmit = async () => {
     setIsLoading(true);
     setError(null);
 
     try {
-      const ircOptions =
-        activeTab === "irc"
-          ? {
-              ircHost: ircHost.trim() || "irc.pieter.com",
-              ircPort: Number(ircPort) || 6667,
-              ircTls: Boolean(ircTls),
-              ircChannel: ircChannel.trim() || "#pieter",
-              ircServerLabel: (ircHost.trim() || "irc.pieter.com"),
-            }
-          : undefined;
+      let ircOptions:
+        | {
+            ircHost?: string;
+            ircPort?: number;
+            ircTls?: boolean;
+            ircChannel?: string;
+            ircServerLabel?: string;
+          }
+        | undefined;
+      let resolvedRoomName = roomName;
 
-      const ircRoomName =
-        activeTab === "irc"
-          ? (ircChannel.trim() || "#pieter").replace(/^#/, "").toLowerCase()
-          : roomName;
+      if (activeTab === "irc") {
+        const server = selectedServer;
+        if (!server) {
+          setError("Please pick an IRC server first.");
+          setIsLoading(false);
+          return;
+        }
+        const rawChannel = (customChannel.trim() || selectedChannel || "").trim();
+        if (!rawChannel) {
+          setError("Please pick or enter an IRC channel.");
+          setIsLoading(false);
+          return;
+        }
+        const normalizedChannel = rawChannel.startsWith("#")
+          ? rawChannel
+          : `#${rawChannel}`;
+        ircOptions = {
+          ircHost: server.host,
+          ircPort: server.port,
+          ircTls: server.tls,
+          ircChannel: normalizedChannel,
+          ircServerLabel: server.label,
+        };
+        resolvedRoomName = normalizedChannel.replace(/^#/, "").toLowerCase();
+      }
 
       const result = await onSubmit(
-        ircRoomName,
+        resolvedRoomName,
         activeTab,
         selectedUsers,
         ircOptions
@@ -263,97 +495,353 @@ export function CreateRoomDialog({
         {isAdmin && (
           <ThemedTabsContent value="irc">
             <div className="p-4 space-y-3">
+              {/* Step 1: Server picker */}
               <div className="space-y-2">
                 <Label
-                  htmlFor="irc-channel"
-                  className={cn("text-gray-700", themeFont)}
-                  style={themeFontStyle}
-                >
-                  Channel
-                </Label>
-                <div className="relative">
-                  <Input
-                    id="irc-channel"
-                    value={ircChannel}
-                    onChange={(e) => {
-                      let v = e.target.value;
-                      if (!v.startsWith("#")) v = `#${v.replace(/^#+/, "")}`;
-                      setIrcChannel(v);
-                    }}
-                    placeholder="#pieter"
-                    className={cn("shadow-none h-8", themeFont)}
-                    style={themeFontStyle}
-                    disabled={isLoading}
-                  />
-                </div>
-              </div>
-              <div className="space-y-2">
-                <Label
-                  htmlFor="irc-host"
+                  htmlFor="irc-server"
                   className={cn("text-gray-700", themeFont)}
                   style={themeFontStyle}
                 >
                   Server
                 </Label>
-                <Input
-                  id="irc-host"
-                  value={ircHost}
-                  onChange={(e) => setIrcHost(e.target.value)}
-                  placeholder="irc.pieter.com"
-                  className={cn("shadow-none h-8", themeFont)}
-                  style={themeFontStyle}
-                  disabled={isLoading}
-                />
-              </div>
-              <div className="flex gap-3">
-                <div className="flex-1 space-y-2">
-                  <Label
-                    htmlFor="irc-port"
-                    className={cn("text-gray-700", themeFont)}
+                <div className="flex items-center gap-1">
+                  <div className="flex-1 min-w-0">
+                    <Select
+                      value={selectedServerId ?? undefined}
+                      onValueChange={(v) => {
+                        if (v === "__add__") {
+                          setShowAddServerForm(true);
+                          return;
+                        }
+                        setSelectedServerId(v);
+                      }}
+                      disabled={isLoading || isLoadingServers}
+                    >
+                      <SelectTrigger
+                        id="irc-server"
+                        className={cn("h-8", themeFont)}
+                        style={themeFontStyle}
+                      >
+                        <SelectValue
+                          placeholder={
+                            isLoadingServers ? "Loading…" : "Pick a server"
+                          }
+                        />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {ircServers.map((server) => (
+                          <SelectItem
+                            key={server.id}
+                            value={server.id}
+                            className={themeFont}
+                          >
+                            <span className="flex items-center gap-1.5">
+                              <span>{server.label}</span>
+                              {server.isDefault && (
+                                <span className="text-[9px] uppercase tracking-wider text-purple-600/70">
+                                  default
+                                </span>
+                              )}
+                              {server.tls && (
+                                <span className="text-[9px] uppercase tracking-wider text-emerald-600/70">
+                                  tls
+                                </span>
+                              )}
+                            </span>
+                          </SelectItem>
+                        ))}
+                        <SelectItem
+                          value="__add__"
+                          className={cn(themeFont, "text-blue-600")}
+                        >
+                          <span className="inline-flex items-center gap-1">
+                            <Plus className="h-3 w-3" weight="bold" />
+                            Add new server…
+                          </span>
+                        </SelectItem>
+                      </SelectContent>
+                    </Select>
+                  </div>
+                  {selectedServer && !selectedServer.isDefault && (
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => handleDeleteIrcServer(selectedServer)}
+                      disabled={isLoading}
+                      className="h-8 w-8 p-0"
+                      title="Remove server"
+                      aria-label="Remove server"
+                    >
+                      <Trash className="h-3 w-3" weight="bold" />
+                    </Button>
+                  )}
+                </div>
+                {serversError && (
+                  <p
+                    className={cn("text-red-600", themeFont)}
                     style={themeFontStyle}
                   >
-                    Port
+                    {serversError}
+                  </p>
+                )}
+              </div>
+
+              {/* Inline "add server" form */}
+              {showAddServerForm && (
+                <div className="space-y-2 border border-gray-300 rounded p-3 bg-gray-50">
+                  <Label
+                    className={cn("text-gray-700 font-semibold", themeFont)}
+                    style={themeFontStyle}
+                  >
+                    Add a server
                   </Label>
                   <Input
-                    id="irc-port"
-                    type="number"
-                    value={String(ircPort)}
-                    onChange={(e) => setIrcPort(Number(e.target.value) || 6667)}
+                    placeholder="irc.example.com"
+                    value={newServerHost}
+                    onChange={(e) => setNewServerHost(e.target.value)}
                     className={cn("shadow-none h-8", themeFont)}
                     style={themeFontStyle}
-                    disabled={isLoading}
+                    disabled={isAddingServer}
                   />
-                </div>
-                <div className="flex-1 flex items-end pb-1">
-                  <Label
-                    htmlFor="irc-tls"
-                    className={cn("flex items-center gap-2", themeFont)}
+                  <Input
+                    placeholder="Optional label"
+                    value={newServerLabel}
+                    onChange={(e) => setNewServerLabel(e.target.value)}
+                    className={cn("shadow-none h-8", themeFont)}
                     style={themeFontStyle}
-                  >
-                    <Checkbox
-                      id="irc-tls"
-                      checked={ircTls}
-                      onCheckedChange={(v) => setIrcTls(Boolean(v))}
-                      className="h-4 w-4"
-                      disabled={isLoading}
-                    />
-                    <span>TLS</span>
-                  </Label>
+                    disabled={isAddingServer}
+                  />
+                  <div className="flex gap-3">
+                    <div className="flex-1">
+                      <Input
+                        type="number"
+                        placeholder="6667"
+                        value={String(newServerPort)}
+                        onChange={(e) =>
+                          setNewServerPort(Number(e.target.value) || 6667)
+                        }
+                        className={cn("shadow-none h-8", themeFont)}
+                        style={themeFontStyle}
+                        disabled={isAddingServer}
+                      />
+                    </div>
+                    <Label
+                      htmlFor="new-irc-tls"
+                      className={cn(
+                        "flex items-center gap-2 self-center",
+                        themeFont
+                      )}
+                      style={themeFontStyle}
+                    >
+                      <Checkbox
+                        id="new-irc-tls"
+                        checked={newServerTls}
+                        onCheckedChange={(v) => setNewServerTls(Boolean(v))}
+                        className="h-4 w-4"
+                        disabled={isAddingServer}
+                      />
+                      <span>TLS</span>
+                    </Label>
+                  </div>
+                  {addServerError && (
+                    <p
+                      className={cn("text-red-600", themeFont)}
+                      style={themeFontStyle}
+                    >
+                      {addServerError}
+                    </p>
+                  )}
+                  <div className="flex gap-2 justify-end">
+                    <Button
+                      type="button"
+                      variant="retro"
+                      size="sm"
+                      onClick={() => {
+                        setShowAddServerForm(false);
+                        setAddServerError(null);
+                      }}
+                      disabled={isAddingServer}
+                      className={cn("h-7", themeFont)}
+                      style={themeFontStyle}
+                    >
+                      Cancel
+                    </Button>
+                    <Button
+                      type="button"
+                      variant="retro"
+                      size="sm"
+                      onClick={handleAddIrcServer}
+                      disabled={isAddingServer || !newServerHost.trim()}
+                      className={cn("h-7", themeFont)}
+                      style={themeFontStyle}
+                    >
+                      {isAddingServer ? "Adding…" : "Add server"}
+                    </Button>
+                  </div>
                 </div>
-              </div>
-              <p
-                className={cn("text-gray-500 pt-1", themeFont)}
-                style={themeFontStyle}
-              >
-                Messages in this room are bridged to{" "}
-                <span className="font-semibold">
-                  {ircHost || "irc.pieter.com"}
-                </span>{" "}
-                <span className="font-semibold">
-                  {ircChannel || "#pieter"}
-                </span>
-                .
-              </p>
+              )}
+
+              {/* Step 2: Channel browser */}
+              {selectedServerId && !showAddServerForm && (
+                <div className="space-y-2">
+                  <div className="flex items-center justify-between">
+                    <Label
+                      htmlFor="irc-channel-filter"
+                      className={cn("text-gray-700", themeFont)}
+                      style={themeFontStyle}
+                    >
+                      Channel
+                    </Label>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => loadIrcChannels(selectedServerId)}
+                      disabled={isLoadingChannels || isLoading}
+                      className="h-7 px-2"
+                      title="Refresh channel list"
+                      aria-label="Refresh channel list"
+                    >
+                      <ArrowClockwise
+                        className={cn(
+                          "h-3 w-3",
+                          isLoadingChannels && "animate-spin"
+                        )}
+                        weight="bold"
+                      />
+                    </Button>
+                  </div>
+                  <div className="relative">
+                    <Input
+                      id="irc-channel-filter"
+                      placeholder={
+                        isLoadingChannels
+                          ? "Loading channels…"
+                          : "Filter channels or type a new one"
+                      }
+                      value={channelFilter || customChannel}
+                      onChange={(e) => {
+                        const v = e.target.value;
+                        setChannelFilter(v);
+                        // If the user types something that doesn't exactly
+                        // match an existing channel, treat it as a custom
+                        // entry too so they can join an unlisted channel.
+                        const match = ircChannels.find(
+                          (c) => c.channel.toLowerCase() === v.toLowerCase()
+                        );
+                        if (match) {
+                          setSelectedChannel(match.channel);
+                          setCustomChannel("");
+                        } else if (v.startsWith("#") || v.startsWith("&")) {
+                          setCustomChannel(v);
+                          setSelectedChannel(null);
+                        } else {
+                          setCustomChannel("");
+                        }
+                      }}
+                      className={cn("shadow-none h-8", themeFont)}
+                      style={themeFontStyle}
+                      disabled={isLoading || isLoadingChannels}
+                    />
+                    {isLoadingChannels && (
+                      <ActivityIndicator
+                        size="sm"
+                        className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-500"
+                      />
+                    )}
+                  </div>
+                  {channelsError && (
+                    <p
+                      className={cn("text-red-600", themeFont)}
+                      style={themeFontStyle}
+                    >
+                      {channelsError}
+                    </p>
+                  )}
+                  {!isLoadingChannels && !channelsError && (
+                    <div className="border border-gray-300 rounded max-h-[180px] overflow-y-auto bg-white">
+                      <div className="p-1">
+                        {filteredChannels.length === 0 && !customChannel && (
+                          <p
+                            className={cn(
+                              "text-gray-500 px-2 py-2",
+                              themeFont
+                            )}
+                            style={themeFontStyle}
+                          >
+                            No channels available. Type a channel name above
+                            to join one anyway.
+                          </p>
+                        )}
+                        {filteredChannels.map((entry) => {
+                          const isSelected =
+                            selectedChannel === entry.channel && !customChannel;
+                          return (
+                            <button
+                              key={entry.channel}
+                              type="button"
+                              onClick={() => {
+                                setSelectedChannel(entry.channel);
+                                setCustomChannel("");
+                                setChannelFilter("");
+                              }}
+                              className={cn(
+                                "w-full text-left flex items-center gap-2 p-2 rounded",
+                                isSelected
+                                  ? "bg-blue-100 text-blue-900"
+                                  : "hover:bg-gray-100",
+                                themeFont
+                              )}
+                              style={themeFontStyle}
+                              disabled={isLoading}
+                            >
+                              <span className="font-semibold whitespace-nowrap">
+                                {entry.channel}
+                              </span>
+                              <span className="text-[10px] text-gray-500 shrink-0">
+                                {entry.numUsers} user
+                                {entry.numUsers === 1 ? "" : "s"}
+                              </span>
+                              {entry.topic && (
+                                <span className="ml-1 text-gray-500 truncate">
+                                  {entry.topic}
+                                </span>
+                              )}
+                            </button>
+                          );
+                        })}
+                      </div>
+                    </div>
+                  )}
+                  {channelsTruncated && (
+                    <p
+                      className={cn("text-gray-500", themeFont)}
+                      style={themeFontStyle}
+                    >
+                      Showing first {ircChannels.length} channels — refine the
+                      filter to see more.
+                    </p>
+                  )}
+                  {(customChannel ||
+                    (selectedChannel && !customChannel)) && (
+                    <p
+                      className={cn("text-gray-500", themeFont)}
+                      style={themeFontStyle}
+                    >
+                      Will create a room bridged to{" "}
+                      <span className="font-semibold">
+                        {customChannel || selectedChannel}
+                      </span>{" "}
+                      on{" "}
+                      <span className="font-semibold">
+                        {selectedServer?.label ?? "irc.pieter.com"}
+                      </span>
+                      .
+                    </p>
+                  )}
+                </div>
+              )}
             </div>
           </ThemedTabsContent>
         )}
@@ -485,7 +973,10 @@ export function CreateRoomDialog({
             isLoading ||
             (activeTab === "public" && !roomName.trim()) ||
             (activeTab === "private" && selectedUsers.length === 0) ||
-            (activeTab === "irc" && (!ircChannel.trim() || !ircHost.trim()))
+            (activeTab === "irc" &&
+              (!selectedServerId ||
+                showAddServerForm ||
+                !(customChannel.trim() || selectedChannel)))
           }
           className={cn("h-7", themeFont)}
           style={themeFontStyle}
@@ -502,7 +993,7 @@ export function CreateRoomDialog({
     <Dialog open={isOpen} onOpenChange={onOpenChange}>
       <DialogContent
         className={cn(
-          "max-w-[400px]",
+          activeTab === "irc" ? "max-w-[480px]" : "max-w-[400px]",
           isXpTheme && "p-0 overflow-hidden"
         )}
         style={isXpTheme ? { fontSize: "11px" } : undefined}

--- a/src/apps/chats/hooks/useChatRoom.ts
+++ b/src/apps/chats/hooks/useChatRoom.ts
@@ -505,6 +505,7 @@ export function useChatRoom(
       type: "public" | "private" | "irc" = "public",
       members: string[] = [],
       ircOptions: {
+        ircServerId?: string;
         ircHost?: string;
         ircPort?: number;
         ircTls?: boolean;
@@ -518,13 +519,6 @@ export function useChatRoom(
         return {
           ok: false,
           error: "Permission denied. Admin access required.",
-        };
-      }
-
-      if (type === "irc" && !isAdmin) {
-        return {
-          ok: false,
-          error: "Permission denied. Admin access required for IRC rooms.",
         };
       }
 

--- a/src/apps/chats/hooks/useChatRoom.ts
+++ b/src/apps/chats/hooks/useChatRoom.ts
@@ -502,8 +502,15 @@ export function useChatRoom(
   const handleAddRoom = useCallback(
     async (
       roomName: string,
-      type: "public" | "private" = "public",
-      members: string[] = []
+      type: "public" | "private" | "irc" = "public",
+      members: string[] = [],
+      ircOptions: {
+        ircHost?: string;
+        ircPort?: number;
+        ircTls?: boolean;
+        ircChannel?: string;
+        ircServerLabel?: string;
+      } = {}
     ) => {
       if (!username) return { ok: false, error: "Set a username first." };
 
@@ -514,7 +521,14 @@ export function useChatRoom(
         };
       }
 
-      const result = await createRoom(roomName, type, members);
+      if (type === "irc" && !isAdmin) {
+        return {
+          ok: false,
+          error: "Permission denied. Admin access required for IRC rooms.",
+        };
+      }
+
+      const result = await createRoom(roomName, type, members, ircOptions);
       if (result.ok && result.roomId) {
         handleRoomSelect(result.roomId); // Switch to the new room
       }

--- a/src/stores/useChatsStore.ts
+++ b/src/stores/useChatsStore.ts
@@ -197,8 +197,15 @@ export interface ChatsStoreState {
   ) => Promise<{ ok: boolean; error?: string }>;
   createRoom: (
     name: string,
-    type?: "public" | "private",
-    members?: string[]
+    type?: "public" | "private" | "irc",
+    members?: string[],
+    ircOptions?: {
+      ircHost?: string;
+      ircPort?: number;
+      ircTls?: boolean;
+      ircChannel?: string;
+      ircServerLabel?: string;
+    }
   ) => Promise<{ ok: boolean; error?: string; roomId?: string }>;
   deleteRoom: (roomId: string) => Promise<{ ok: boolean; error?: string }>;
   sendMessage: (
@@ -304,12 +311,14 @@ export const useChatsStore = create<ChatsStoreState>()(
           saveUsernameToRecovery(username);
           set({ username });
 
-          // Re-filter rooms: drop private rooms the new identity cannot see
+          // Re-filter rooms: drop private rooms the new identity cannot see.
+          // IRC rooms remain visible to everyone.
           const lowerUser = username?.toLowerCase() ?? null;
           const currentRooms = get().rooms;
           if (currentRooms.length > 0) {
             const filtered = currentRooms.filter((room) => {
-              if (!room.type || room.type === "public") return true;
+              if (!room.type || room.type === "public" || room.type === "irc")
+                return true;
               if (!lowerUser) return false;
               return Array.isArray(room.members) && room.members.includes(lowerUser);
             });
@@ -421,9 +430,11 @@ export const useChatsStore = create<ChatsStoreState>()(
 
           const currentUsername = get().username?.toLowerCase() ?? null;
 
-          // Filter out private rooms where current user is not a member
+          // Filter out private rooms where current user is not a member.
+          // IRC rooms are visible to everyone.
           const filtered = newRooms.filter((room) => {
-            if (!room.type || room.type === "public") return true;
+            if (!room.type || room.type === "public" || room.type === "irc")
+              return true;
             if (!currentUsername) return false;
             return Array.isArray(room.members) && room.members.includes(currentUsername);
           });
@@ -1014,8 +1025,15 @@ export const useChatsStore = create<ChatsStoreState>()(
         },
         createRoom: async (
           name: string,
-          type: "public" | "private" = "public",
-          members: string[] = []
+          type: "public" | "private" | "irc" = "public",
+          members: string[] = [],
+          ircOptions: {
+            ircHost?: string;
+            ircPort?: number;
+            ircTls?: boolean;
+            ircChannel?: string;
+            ircServerLabel?: string;
+          } = {}
         ) => {
           const username = get().username;
 
@@ -1027,6 +1045,16 @@ export const useChatsStore = create<ChatsStoreState>()(
             const payload: CreateRoomPayload = { type };
             if (type === "public") {
               payload.name = name.trim();
+            } else if (type === "irc") {
+              payload.name = name.trim();
+              if (ircOptions.ircHost) payload.ircHost = ircOptions.ircHost;
+              if (ircOptions.ircPort) payload.ircPort = ircOptions.ircPort;
+              if (typeof ircOptions.ircTls === "boolean")
+                payload.ircTls = ircOptions.ircTls;
+              if (ircOptions.ircChannel)
+                payload.ircChannel = ircOptions.ircChannel;
+              if (ircOptions.ircServerLabel)
+                payload.ircServerLabel = ircOptions.ircServerLabel;
             } else {
               payload.members = members;
             }
@@ -1368,11 +1396,12 @@ export const useChatsStore = create<ChatsStoreState>()(
 
           // Filter out private rooms the current user is not a member of.
           // Persisted state may contain stale private rooms from a
-          // previous session or a different user.
+          // previous session or a different user. IRC rooms are public-like.
           if (Array.isArray(finalState.rooms)) {
             const lowerUser = finalState.username?.toLowerCase() ?? null;
             finalState.rooms = finalState.rooms.filter((room) => {
-              if (!room.type || room.type === "public") return true;
+              if (!room.type || room.type === "public" || room.type === "irc")
+                return true;
               if (!lowerUser) return false;
               return Array.isArray(room.members) && room.members.includes(lowerUser);
             });

--- a/src/stores/useChatsStore.ts
+++ b/src/stores/useChatsStore.ts
@@ -200,6 +200,7 @@ export interface ChatsStoreState {
     type?: "public" | "private" | "irc",
     members?: string[],
     ircOptions?: {
+      ircServerId?: string;
       ircHost?: string;
       ircPort?: number;
       ircTls?: boolean;
@@ -1028,6 +1029,7 @@ export const useChatsStore = create<ChatsStoreState>()(
           type: "public" | "private" | "irc" = "public",
           members: string[] = [],
           ircOptions: {
+            ircServerId?: string;
             ircHost?: string;
             ircPort?: number;
             ircTls?: boolean;
@@ -1047,6 +1049,8 @@ export const useChatsStore = create<ChatsStoreState>()(
               payload.name = name.trim();
             } else if (type === "irc") {
               payload.name = name.trim();
+              if (ircOptions.ircServerId)
+                payload.ircServerId = ircOptions.ircServerId;
               if (ircOptions.ircHost) payload.ircHost = ircOptions.ircHost;
               if (ircOptions.ircPort) payload.ircPort = ircOptions.ircPort;
               if (typeof ircOptions.ircTls === "boolean")

--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -20,11 +20,17 @@ export type ChatMessage = {
 export type ChatRoom = {
   id: string;
   name: string;
-  type?: "public" | "private"; // optional for backward compatibility
+  type?: "public" | "private" | "irc"; // optional for backward compatibility
   createdAt: number;
   userCount: number;
   users?: string[];
   members?: string[]; // for private rooms - list of usernames who can access
+  // IRC bridging metadata. Present only when `type === "irc"`.
+  ircHost?: string;
+  ircPort?: number;
+  ircTls?: boolean;
+  ircChannel?: string; // e.g. "#pieter"
+  ircServerLabel?: string; // Friendly label shown in UI
 };
 
 export type User = {

--- a/tests/test-irc-bridge.test.ts
+++ b/tests/test-irc-bridge.test.ts
@@ -1,0 +1,322 @@
+#!/usr/bin/env bun
+/**
+ * Unit tests for the IRC bridge.
+ *
+ * The bridge is tested against a fake IRC client (injected via the
+ * `createClient` dependency) so the tests run fully offline without
+ * touching `irc-framework` or any real network.
+ *
+ * We exercise:
+ *   - bindRoom() opening a connection and joining the channel on `registered`
+ *   - sendMessage() forwarding to `client.say(channel, text)`
+ *   - incoming `message` events being persisted via the supplied callback
+ *   - unbindRoom() parting the channel once the last room releases it
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import EventEmitter from "node:events";
+import {
+  IrcBridge,
+  setIrcBridgeForTesting,
+  type IrcClientLike,
+} from "../api/_utils/irc/_bridge";
+import {
+  normalizeIrcChannel,
+  DEFAULT_IRC_HOST,
+  DEFAULT_IRC_PORT,
+} from "../api/_utils/irc/_types";
+import type { Message, Room } from "../api/rooms/_helpers/_types";
+
+interface FakeCall {
+  type: "connect" | "join" | "say" | "part" | "quit";
+  args: unknown[];
+}
+
+class FakeIrcClient extends EventEmitter implements IrcClientLike {
+  calls: FakeCall[] = [];
+  connected = false;
+
+  connect(_options?: Record<string, unknown>): void {
+    this.calls.push({ type: "connect", args: [_options] });
+    // Simulate async registration shortly after connect
+    queueMicrotask(() => {
+      this.connected = true;
+      this.emit("registered", {});
+    });
+  }
+
+  join(channel: string, key?: string): void {
+    this.calls.push({ type: "join", args: [channel, key] });
+    // Simulate the server echoing our JOIN event back so the bridge can
+    // clear its pending-join set. `target` carries the channel for JOIN
+    // events in irc-framework.
+    queueMicrotask(() => {
+      this.emit("join", { nick: this.nick, target: channel });
+    });
+  }
+
+  part(channel: string, message?: string): void {
+    this.calls.push({ type: "part", args: [channel, message] });
+  }
+
+  say(target: string, message: string): void {
+    this.calls.push({ type: "say", args: [target, message] });
+  }
+
+  changeNick(nick: string): void {
+    this.nick = nick;
+  }
+
+  quit(message?: string): void {
+    this.calls.push({ type: "quit", args: [message] });
+  }
+
+  nick: string = "";
+}
+
+function makeIrcRoom(overrides: Partial<Room> = {}): Room {
+  return {
+    id: "testroom1",
+    name: "pieter",
+    type: "irc",
+    createdAt: Date.now(),
+    userCount: 0,
+    ircHost: DEFAULT_IRC_HOST,
+    ircPort: DEFAULT_IRC_PORT,
+    ircTls: false,
+    ircChannel: "#pieter",
+    ...overrides,
+  };
+}
+
+describe("IRC Bridge", () => {
+  let persisted: Array<{ roomId: string; message: Message; room: Room | null }> = [];
+  let fakeClients: FakeIrcClient[] = [];
+  let bridge: IrcBridge;
+
+  beforeEach(() => {
+    persisted = [];
+    fakeClients = [];
+    bridge = new IrcBridge({
+      createClient: (options) => {
+        const client = new FakeIrcClient();
+        client.nick = String(options.nick ?? "test-bot");
+        fakeClients.push(client);
+        return client;
+      },
+      persistIncomingMessage: async (roomId, message, room) => {
+        persisted.push({ roomId, message, room });
+      },
+    });
+    setIrcBridgeForTesting(bridge);
+  });
+
+  afterEach(async () => {
+    await bridge.shutdown();
+    setIrcBridgeForTesting(null);
+  });
+
+  test("normalizeIrcChannel prefixes channels with '#'", () => {
+    expect(normalizeIrcChannel("pieter")).toBe("#pieter");
+    expect(normalizeIrcChannel("#pieter")).toBe("#pieter");
+    expect(normalizeIrcChannel("&chan")).toBe("&chan");
+    expect(normalizeIrcChannel("")).toBe("");
+  });
+
+  test("bindRoom connects and joins channel on registered", async () => {
+    const room = makeIrcRoom();
+    await bridge.bindRoom(room);
+
+    // Wait a microtask tick for the fake `registered` event to fire.
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(fakeClients.length).toBe(1);
+    const client = fakeClients[0];
+    expect(client.calls.some((c) => c.type === "connect")).toBe(true);
+    expect(client.calls.some((c) => c.type === "join" && c.args[0] === "#pieter")).toBe(true);
+
+    const bindings = bridge.getBindings();
+    expect(bindings.length).toBe(1);
+    expect(bindings[0].channel).toBe("#pieter");
+    expect(bindings[0].roomIds).toContain("testroom1");
+  });
+
+  test("sendMessage forwards to client.say with prefixed username", async () => {
+    const room = makeIrcRoom();
+    await bridge.bindRoom(room);
+
+    // Let the fake client register so server.ready becomes true.
+    await new Promise((r) => setTimeout(r, 5));
+
+    await bridge.sendMessage(room, "alice", "hello world");
+
+    const client = fakeClients[0];
+    const sayCalls = client.calls.filter((c) => c.type === "say");
+    expect(sayCalls.length).toBe(1);
+    expect(sayCalls[0].args[0]).toBe("#pieter");
+    expect(sayCalls[0].args[1]).toBe("<alice> hello world");
+  });
+
+  test("incoming IRC messages are persisted via the callback", async () => {
+    const room = makeIrcRoom();
+    await bridge.bindRoom(room);
+    await new Promise((r) => setTimeout(r, 5));
+
+    const client = fakeClients[0];
+    client.emit("message", {
+      type: "privmsg",
+      target: "#pieter",
+      nick: "bob",
+      message: "hi there",
+    });
+
+    // Allow the async handler (which also calls getRoom) to settle.
+    await new Promise((r) => setTimeout(r, 200));
+
+    expect(persisted.length).toBe(1);
+    const persistedItem = persisted[0];
+    expect(persistedItem.roomId).toBe("testroom1");
+    expect(persistedItem.message.username).toBe("irc:bob");
+    expect(persistedItem.message.content).toBe("hi there");
+  });
+
+  test("incoming IRC 'action' events are prefixed with '*'", async () => {
+    const room = makeIrcRoom();
+    await bridge.bindRoom(room);
+    await new Promise((r) => setTimeout(r, 5));
+
+    const client = fakeClients[0];
+    client.emit("message", {
+      type: "action",
+      target: "#pieter",
+      nick: "carol",
+      message: "waves",
+    });
+
+    await new Promise((r) => setTimeout(r, 200));
+
+    expect(persisted.length).toBe(1);
+    expect(persisted[0].message.content).toBe("* waves");
+  });
+
+  test("incoming messages from unbound channels are ignored", async () => {
+    const room = makeIrcRoom();
+    await bridge.bindRoom(room);
+    await new Promise((r) => setTimeout(r, 5));
+
+    const client = fakeClients[0];
+    client.emit("message", {
+      type: "privmsg",
+      target: "#unbound",
+      nick: "bob",
+      message: "hi",
+    });
+
+    await new Promise((r) => setTimeout(r, 5));
+    expect(persisted.length).toBe(0);
+  });
+
+  test("bot's own messages (by nick match) are not persisted back", async () => {
+    const room = makeIrcRoom();
+    await bridge.bindRoom(room);
+    await new Promise((r) => setTimeout(r, 5));
+
+    const client = fakeClients[0];
+    client.emit("message", {
+      type: "privmsg",
+      target: "#pieter",
+      nick: client.nick,
+      message: "<alice> hello",
+    });
+
+    await new Promise((r) => setTimeout(r, 5));
+    expect(persisted.length).toBe(0);
+  });
+
+  test("unbindRoom parts channel and drops the binding", async () => {
+    const room = makeIrcRoom();
+    await bridge.bindRoom(room);
+    await new Promise((r) => setTimeout(r, 5));
+
+    await bridge.unbindRoom(room);
+
+    expect(bridge.getBindings().length).toBe(0);
+    const client = fakeClients[0];
+    expect(client.calls.some((c) => c.type === "part" && c.args[0] === "#pieter")).toBe(true);
+  });
+
+  test("multiple rooms bound to the same channel share one connection", async () => {
+    const roomA = makeIrcRoom({ id: "rA" });
+    const roomB = makeIrcRoom({ id: "rB" });
+
+    await bridge.bindRoom(roomA);
+    await bridge.bindRoom(roomB);
+    await new Promise((r) => setTimeout(r, 5));
+
+    // Still only a single IRC connection.
+    expect(fakeClients.length).toBe(1);
+    const bindings = bridge.getBindings();
+    expect(bindings.length).toBe(1);
+    expect(bindings[0].roomIds.sort()).toEqual(["rA", "rB"]);
+  });
+
+  test("different servers get separate connections", async () => {
+    await bridge.bindRoom(makeIrcRoom({ id: "rA", ircHost: "irc.example.com" }));
+    await bridge.bindRoom(makeIrcRoom({ id: "rB", ircHost: "irc.pieter.com" }));
+    await new Promise((r) => setTimeout(r, 5));
+
+    expect(fakeClients.length).toBe(2);
+    const bindings = bridge.getBindings().map((b) => b.host).sort();
+    expect(bindings).toEqual(["irc.example.com", "irc.pieter.com"]);
+  });
+
+  test("sendMessage on unconnected server falls back to bindRoom", async () => {
+    // Simulate a race: sendMessage called before any bind.
+    const room = makeIrcRoom({ id: "rLazy" });
+    await bridge.sendMessage(room, "alice", "hi");
+    await new Promise((r) => setTimeout(r, 5));
+
+    // A client should now exist because sendMessage triggered bindRoom.
+    expect(fakeClients.length).toBe(1);
+    const bindings = bridge.getBindings();
+    expect(bindings.length).toBe(1);
+    expect(bindings[0].roomIds).toContain("rLazy");
+  });
+});
+
+describe("IRC Bridge wiring", () => {
+  test("rooms/index.ts wires notifyRoomBindingChange on create", async () => {
+    const fs = await import("node:fs/promises");
+    const src = await fs.readFile("api/rooms/index.ts", "utf-8");
+    expect(src).toContain("notifyRoomBindingChange");
+    expect(/notifyRoomBindingChange\s*\(\s*"bind"/.test(src)).toBe(true);
+    // The create route must honour the opt-out flag so IRC_BRIDGE_DISABLED=1
+    // never accidentally opens a socket.
+    expect(src).toContain("isIrcBridgeEnabled");
+  });
+
+  test("rooms/[id].ts wires notifyRoomBindingChange on delete", async () => {
+    const fs = await import("node:fs/promises");
+    const src = await fs.readFile("api/rooms/[id].ts", "utf-8");
+    expect(src).toContain("notifyRoomBindingChange");
+    expect(/notifyRoomBindingChange\s*\(\s*"unbind"/.test(src)).toBe(true);
+    expect(src).toContain("isIrcBridgeEnabled");
+  });
+
+  test("rooms/[id]/messages.ts forwards outbound to IRC bridge", async () => {
+    const fs = await import("node:fs/promises");
+    const src = await fs.readFile("api/rooms/[id]/messages.ts", "utf-8");
+    expect(src).toContain("getIrcBridge");
+    expect(/roomData\.type === "irc"/.test(src)).toBe(true);
+    expect(src).toContain("isIrcBridgeEnabled");
+  });
+
+  test("standalone server initialises the IRC bridge on startup", async () => {
+    const fs = await import("node:fs/promises");
+    const src = await fs.readFile("scripts/api-standalone-server.ts", "utf-8");
+    expect(src).toContain("getIrcBridge");
+    expect(/getIrcBridge\(\)\.initialize\(\)/.test(src)).toBe(true);
+    expect(src).toContain("isIrcBridgeEnabled");
+  });
+});

--- a/tests/test-irc-bridge.test.ts
+++ b/tests/test-irc-bridge.test.ts
@@ -28,13 +28,20 @@ import {
 import type { Message, Room } from "../api/rooms/_helpers/_types";
 
 interface FakeCall {
-  type: "connect" | "join" | "say" | "part" | "quit";
+  type: "connect" | "join" | "say" | "part" | "quit" | "list";
   args: unknown[];
 }
 
 class FakeIrcClient extends EventEmitter implements IrcClientLike {
   calls: FakeCall[] = [];
   connected = false;
+
+  /**
+   * Channels the next `list()` call should respond with. If empty, the
+   * client emits `channel list end` immediately. Tests can override this
+   * to feed the bridge a synthetic LIST result.
+   */
+  listResponse: Array<{ channel: string; num_users: number; topic: string }> = [];
 
   connect(_options?: Record<string, unknown>): void {
     this.calls.push({ type: "connect", args: [_options] });
@@ -69,6 +76,16 @@ class FakeIrcClient extends EventEmitter implements IrcClientLike {
 
   quit(message?: string): void {
     this.calls.push({ type: "quit", args: [message] });
+  }
+
+  list(...args: unknown[]): void {
+    this.calls.push({ type: "list", args });
+    queueMicrotask(() => {
+      if (this.listResponse.length > 0) {
+        this.emit("channel list", this.listResponse);
+      }
+      this.emit("channel list end", undefined);
+    });
   }
 
   nick: string = "";
@@ -283,6 +300,126 @@ describe("IRC Bridge", () => {
     expect(bindings.length).toBe(1);
     expect(bindings[0].roomIds).toContain("rLazy");
   });
+
+  test("listChannels reuses an existing connection when available", async () => {
+    const room = makeIrcRoom();
+    await bridge.bindRoom(room);
+    await new Promise((r) => setTimeout(r, 10));
+
+    // Bridge should now have a single ready client; queue a synthetic LIST
+    // response on it before invoking listChannels.
+    expect(fakeClients.length).toBe(1);
+    const client = fakeClients[0];
+    client.listResponse = [
+      { channel: "#pieter", num_users: 12, topic: "the home channel" },
+      { channel: "#dev", num_users: 4, topic: "" },
+    ];
+
+    const channels = await bridge.listChannels(
+      DEFAULT_IRC_HOST,
+      DEFAULT_IRC_PORT,
+      false
+    );
+
+    // No new client should have been spawned.
+    expect(fakeClients.length).toBe(1);
+    expect(client.calls.some((c) => c.type === "list")).toBe(true);
+    expect(channels.length).toBe(2);
+    expect(channels[0]).toEqual({
+      channel: "#pieter",
+      numUsers: 12,
+      topic: "the home channel",
+    });
+    expect(channels[1]).toEqual({
+      channel: "#dev",
+      numUsers: 4,
+      topic: "",
+    });
+  });
+
+  test("listChannels spins up a one-shot client when no connection exists", async () => {
+    // Inject a list response BEFORE the bridge spawns the client.
+    bridge = new IrcBridge({
+      createClient: (options) => {
+        const client = new FakeIrcClient();
+        client.nick = String(options.nick ?? "test-bot");
+        client.listResponse = [
+          { channel: "#alpha", num_users: 7, topic: "alpha topic" },
+        ];
+        fakeClients.push(client);
+        return client;
+      },
+    });
+
+    const channels = await bridge.listChannels(
+      "irc.example.com",
+      6697,
+      true
+    );
+
+    // A one-shot client was created just for this LIST.
+    expect(fakeClients.length).toBe(1);
+    const client = fakeClients[0];
+    expect(client.calls.some((c) => c.type === "connect")).toBe(true);
+    expect(client.calls.some((c) => c.type === "list")).toBe(true);
+    // After settling the bridge should ask the one-shot client to quit.
+    expect(client.calls.some((c) => c.type === "quit")).toBe(true);
+
+    expect(channels.length).toBe(1);
+    expect(channels[0]).toEqual({
+      channel: "#alpha",
+      numUsers: 7,
+      topic: "alpha topic",
+    });
+  });
+
+  test("listChannels enforces maxChannels truncation", async () => {
+    bridge = new IrcBridge({
+      createClient: (options) => {
+        const client = new FakeIrcClient();
+        client.nick = String(options.nick ?? "test-bot");
+        client.listResponse = Array.from({ length: 50 }, (_, i) => ({
+          channel: `#chan${i}`,
+          num_users: i,
+          topic: "",
+        }));
+        fakeClients.push(client);
+        return client;
+      },
+    });
+
+    const channels = await bridge.listChannels("irc.example.com", 6667, false, {
+      maxChannels: 5,
+    });
+
+    expect(channels.length).toBe(5);
+  });
+
+  test("listChannels resolves with an empty array when LIST times out", async () => {
+    bridge = new IrcBridge({
+      createClient: (options) => {
+        // A bare EventEmitter that never emits anything (no register/list end)
+        const client: IrcClientLike = Object.assign(new EventEmitter(), {
+          connect: () => undefined,
+          join: () => undefined,
+          part: () => undefined,
+          say: () => undefined,
+          changeNick: () => undefined,
+          quit: () => undefined,
+          list: () => undefined,
+        });
+        // Touch options to silence unused-arg lint
+        void options;
+        fakeClients.push(client as unknown as FakeIrcClient);
+        return client;
+      },
+    });
+
+    const channels = await bridge.listChannels("irc.silent.example", 6667, false, {
+      timeoutMs: 50,
+    });
+    expect(channels).toEqual([]);
+  });
 });
 
 describe("IRC Bridge wiring", () => {
@@ -318,5 +455,100 @@ describe("IRC Bridge wiring", () => {
     expect(src).toContain("getIrcBridge");
     expect(/getIrcBridge\(\)\.initialize\(\)/.test(src)).toBe(true);
     expect(src).toContain("isIrcBridgeEnabled");
+  });
+
+  test("irc/servers/index.ts handles GET + POST", async () => {
+    const fs = await import("node:fs/promises");
+    const src = await fs.readFile("api/irc/servers/index.ts", "utf-8");
+    expect(src).toContain("listIrcServers");
+    expect(src).toContain("setIrcServer");
+    expect(src).toContain("normalizeIrcServerInput");
+    expect(src).toContain("generateIrcServerId");
+    // Admin gate
+    expect(src).toContain('user.username !== "ryo"');
+  });
+
+  test("irc/servers/[id].ts deletes a non-default server", async () => {
+    const fs = await import("node:fs/promises");
+    const src = await fs.readFile("api/irc/servers/[id].ts", "utf-8");
+    expect(src).toContain("deleteIrcServer");
+    // Default server is protected.
+    expect(src).toContain("__DEFAULT_IRC_SERVER_ID");
+    expect(src).toContain('user!.username !== "ryo"');
+  });
+
+  test("irc/servers/[id]/channels.ts wires bridge.listChannels", async () => {
+    const fs = await import("node:fs/promises");
+    const src = await fs.readFile("api/irc/servers/[id]/channels.ts", "utf-8");
+    expect(src).toContain("getIrcBridge");
+    expect(src).toContain("listChannels");
+    // Honour the disabled flag.
+    expect(src).toContain("isIrcBridgeEnabled");
+    // Admin gate.
+    expect(src).toContain('user!.username !== "ryo"');
+  });
+});
+
+describe("IRC server registry", () => {
+  test("normalizeIrcServerInput rejects empty hosts", async () => {
+    const { normalizeIrcServerInput } = await import(
+      "../api/_utils/irc/_servers"
+    );
+    const result = normalizeIrcServerInput({ host: "", port: 6667 });
+    expect(result.ok).toBe(false);
+    if (result.ok === false) {
+      expect(result.error.toLowerCase()).toContain("host");
+    }
+  });
+
+  test("normalizeIrcServerInput rejects out-of-range ports", async () => {
+    const { normalizeIrcServerInput } = await import(
+      "../api/_utils/irc/_servers"
+    );
+    const result = normalizeIrcServerInput({
+      host: "irc.example.com",
+      port: 99999,
+    });
+    expect(result.ok).toBe(false);
+  });
+
+  test("normalizeIrcServerInput accepts valid hostnames + IPs", async () => {
+    const { normalizeIrcServerInput } = await import(
+      "../api/_utils/irc/_servers"
+    );
+    const hostname = normalizeIrcServerInput({
+      host: "irc.example.com",
+      port: 6667,
+      tls: false,
+    });
+    expect(hostname.ok).toBe(true);
+    if (hostname.ok) {
+      expect(hostname.value.host).toBe("irc.example.com");
+    }
+
+    const ip = normalizeIrcServerInput({
+      host: "192.168.1.1",
+      port: 6697,
+      tls: true,
+    });
+    expect(ip.ok).toBe(true);
+    if (ip.ok) {
+      expect(ip.value.host).toBe("192.168.1.1");
+      expect(ip.value.tls).toBe(true);
+    }
+  });
+
+  test("normalizeIrcServerInput defaults the label to the host", async () => {
+    const { normalizeIrcServerInput } = await import(
+      "../api/_utils/irc/_servers"
+    );
+    const result = normalizeIrcServerInput({
+      host: "irc.example.com",
+      port: 6667,
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.label).toBe("irc.example.com");
+    }
   });
 });

--- a/tests/test-irc-bridge.test.ts
+++ b/tests/test-irc-bridge.test.ts
@@ -431,6 +431,8 @@ describe("IRC Bridge wiring", () => {
     // The create route must honour the opt-out flag so IRC_BRIDGE_DISABLED=1
     // never accidentally opens a socket.
     expect(src).toContain("isIrcBridgeEnabled");
+    expect(src).toContain("getIrcServer");
+    expect(src).toContain("ircServerId");
   });
 
   test("rooms/[id].ts wires notifyRoomBindingChange on delete", async () => {
@@ -484,8 +486,8 @@ describe("IRC Bridge wiring", () => {
     expect(src).toContain("listChannels");
     // Honour the disabled flag.
     expect(src).toContain("isIrcBridgeEnabled");
-    // Admin gate.
-    expect(src).toContain('user!.username !== "ryo"');
+    // Any authenticated user (not admin-only).
+    expect(src).not.toContain('user!.username !== "ryo"');
   });
 });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

IRC bridge + Chats integration (default `irc.pieter.com`), server registry, channel browser, and non-admin participation on registered servers.

**CI fix:** Replaced `Math.random()` in `IrcBridge.buildNick()` with `crypto.randomInt` to satisfy CodeQL `js/insecure-randomness`.

## Testing

- `bun run build`
- `bun test tests/test-irc-bridge.test.ts`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6c1b29a4-b37a-4ba4-93ae-d41513b26c78"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6c1b29a4-b37a-4ba4-93ae-d41513b26c78"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

