### PR TITLE
IRC: let authenticated users join channels on registered servers

### DIFF
--- a/api/irc/servers/[id]/channels.ts
+++ b/api/irc/servers/[id]/channels.ts
@@ -4,8 +4,8 @@
  * GET - List the channels currently advertised by an IRC server.
  *
  * The bridge runs an IRC LIST against the configured server and returns
- * the parsed result. Admin only because it requires opening (or reusing)
- * a real IRC connection.
+ * the parsed result. Any authenticated user may list channels for servers
+ * already registered by an admin (POST/DELETE on servers remain admin-only).
  */
 
 import { apiHandler } from "../../../_utils/api-handler.js";
@@ -25,12 +25,6 @@ export default apiHandler(
     if (!id) {
       logger.response(400, Date.now() - startTime);
       res.status(400).json({ error: "Server id is required" });
-      return;
-    }
-
-    if (user!.username !== "ryo") {
-      logger.response(403, Date.now() - startTime);
-      res.status(403).json({ error: "Forbidden - admin access required" });
       return;
     }
 

--- a/api/rooms/_helpers/_types.ts
+++ b/api/rooms/_helpers/_types.ts
@@ -63,6 +63,8 @@ export interface CreateRoomData {
   type?: RoomType;
   members?: string[];
   // IRC bridging metadata. Only used when `type === "irc"`.
+  /** Registry id from GET /api/irc/servers — required for non-admin IRC room creation. */
+  ircServerId?: string;
   ircHost?: string;
   ircPort?: number;
   ircTls?: boolean;

--- a/api/rooms/index.ts
+++ b/api/rooms/index.ts
@@ -19,7 +19,12 @@ import {
   DEFAULT_IRC_TLS,
   normalizeIrcChannel,
 } from "../_utils/irc/_types.js";
-import { notifyRoomBindingChange, isIrcBridgeEnabled } from "../_utils/irc/_bridge.js";
+import { getIrcServer } from "../_utils/irc/_servers.js";
+import {
+  notifyRoomBindingChange,
+  isIrcBridgeEnabled,
+  getIrcBridge,
+} from "../_utils/irc/_bridge.js";
 
 export const runtime = "nodejs";
 export const maxDuration = 30;
@@ -66,6 +71,7 @@ export default apiHandler(
       name: originalName,
       type = "public",
       members = [],
+      ircServerId: ircServerIdBody,
       ircHost: ircHostBody,
       ircPort: ircPortBody,
       ircTls: ircTlsBody,
@@ -98,11 +104,6 @@ export default apiHandler(
     }
 
     if (type === "irc") {
-      if (username !== "ryo") {
-        logger.response(403, Date.now() - startTime);
-        res.status(403).json({ error: "Forbidden - Only admin can create IRC rooms" });
-        return;
-      }
       if (isProfaneUsername(originalName || "")) {
         logger.response(400, Date.now() - startTime);
         res.status(400).json({ error: "Room name contains inappropriate language" });
@@ -124,11 +125,19 @@ export default apiHandler(
     }
 
     let roomName: string;
+    let ircResolved:
+      | {
+          host: string;
+          port: number;
+          tls: boolean;
+          channel: string;
+          ircServerLabel?: string;
+        }
+      | null = null;
+
     if (type === "public") {
       roomName = originalName.toLowerCase().replace(/ /g, "-");
     } else if (type === "irc") {
-      // Derive the display name from the channel name so sidebar shows
-      // "#pieter" etc. Fall back to provided name.
       const derivedChannel = normalizeIrcChannel(
         ircChannelBody || originalName || ""
       );
@@ -139,7 +148,96 @@ export default apiHandler(
           .json({ error: "IRC channel is required (e.g. #pieter)" });
         return;
       }
-      roomName = derivedChannel.replace(/^#/, "").toLowerCase();
+
+      const serverIdRaw =
+        typeof ircServerIdBody === "string" ? ircServerIdBody.trim() : "";
+
+      if (username === "ryo") {
+        const serverFromRegistry = serverIdRaw
+          ? await getIrcServer(serverIdRaw)
+          : null;
+        if (serverIdRaw && !serverFromRegistry) {
+          logger.response(400, Date.now() - startTime);
+          res.status(400).json({ error: "Unknown IRC server id" });
+          return;
+        }
+        if (serverFromRegistry) {
+          ircResolved = {
+            host: serverFromRegistry.host,
+            port: serverFromRegistry.port,
+            tls: serverFromRegistry.tls,
+            channel: derivedChannel,
+            ircServerLabel: serverFromRegistry.label,
+          };
+        } else {
+          ircResolved = {
+            host: (ircHostBody || DEFAULT_IRC_HOST).toString().toLowerCase(),
+            port: Number(ircPortBody) || DEFAULT_IRC_PORT,
+            tls: typeof ircTlsBody === "boolean" ? ircTlsBody : DEFAULT_IRC_TLS,
+            channel: derivedChannel,
+            ircServerLabel:
+              typeof ircServerLabelBody === "string" &&
+              ircServerLabelBody.trim()
+                ? ircServerLabelBody.trim()
+                : undefined,
+          };
+        }
+      } else {
+        if (!serverIdRaw) {
+          logger.response(403, Date.now() - startTime);
+          res.status(403).json({
+            error:
+              "Forbidden — pick a registered IRC server to create a bridged room",
+          });
+          return;
+        }
+        const serverFromRegistry = await getIrcServer(serverIdRaw);
+        if (!serverFromRegistry) {
+          logger.response(400, Date.now() - startTime);
+          res.status(400).json({ error: "Unknown IRC server id" });
+          return;
+        }
+        if (!isIrcBridgeEnabled()) {
+          logger.response(503, Date.now() - startTime);
+          res.status(503).json({
+            error: "IRC bridge is disabled in this environment",
+          });
+          return;
+        }
+        try {
+          const advertised = await getIrcBridge().listChannels(
+            serverFromRegistry.host,
+            serverFromRegistry.port,
+            serverFromRegistry.tls,
+            { maxChannels: 2000, timeoutMs: 15000 }
+          );
+          const channelOk = advertised.some(
+            (c) => c.channel.toLowerCase() === derivedChannel.toLowerCase()
+          );
+          if (!channelOk) {
+            logger.response(403, Date.now() - startTime);
+            res.status(403).json({
+              error:
+                "Channel must appear in that server’s public channel list (refresh the list and pick a channel)",
+            });
+            return;
+          }
+        } catch (err) {
+          logger.error("IRC channel validation failed", err);
+          logger.response(503, Date.now() - startTime);
+          res.status(503).json({ error: "Failed to validate IRC channel" });
+          return;
+        }
+        ircResolved = {
+          host: serverFromRegistry.host,
+          port: serverFromRegistry.port,
+          tls: serverFromRegistry.tls,
+          channel: derivedChannel,
+          ircServerLabel: serverFromRegistry.label,
+        };
+      }
+
+      roomName = ircResolved.channel.replace(/^#/, "").toLowerCase();
     } else {
       const sortedMembers = [...normalizedMembers].sort();
       roomName = sortedMembers.map((m: string) => `@${m}`).join(", ");
@@ -154,18 +252,16 @@ export default apiHandler(
         createdAt: getCurrentTimestamp(),
         userCount: type === "private" ? normalizedMembers.length : 0,
         ...(type === "private" && { members: normalizedMembers }),
-        ...(type === "irc" && {
-          ircHost: (ircHostBody || DEFAULT_IRC_HOST).toString().toLowerCase(),
-          ircPort: Number(ircPortBody) || DEFAULT_IRC_PORT,
-          ircTls: typeof ircTlsBody === "boolean" ? ircTlsBody : DEFAULT_IRC_TLS,
-          ircChannel: normalizeIrcChannel(
-            ircChannelBody || originalName || ""
-          ),
-          ircServerLabel:
-            typeof ircServerLabelBody === "string" && ircServerLabelBody.trim()
-              ? ircServerLabelBody.trim()
-              : undefined,
-        }),
+        ...(type === "irc" &&
+          ircResolved && {
+            ircHost: ircResolved.host.toLowerCase(),
+            ircPort: ircResolved.port,
+            ircTls: ircResolved.tls,
+            ircChannel: ircResolved.channel,
+            ...(ircResolved.ircServerLabel && {
+              ircServerLabel: ircResolved.ircServerLabel,
+            }),
+          }),
       };
 
       await setRoom(roomId, room);

--- a/src/api/rooms.ts
+++ b/src/api/rooms.ts
@@ -27,6 +27,8 @@ export interface CreateRoomPayload {
   type: "public" | "private" | "irc";
   name?: string;
   members?: string[];
+  /** Registered server id from GET /api/irc/servers (required for non-admin IRC rooms). */
+  ircServerId?: string;
   ircHost?: string;
   ircPort?: number;
   ircTls?: boolean;

--- a/src/apps/chats/components/ChatsDialogs.tsx
+++ b/src/apps/chats/components/ChatsDialogs.tsx
@@ -58,6 +58,7 @@ interface ChatsDialogsProps {
     type: "public" | "private" | "irc",
     members: string[],
     ircOptions?: {
+      ircServerId?: string;
       ircHost?: string;
       ircPort?: number;
       ircTls?: boolean;

--- a/src/apps/chats/components/CreateRoomDialog.tsx
+++ b/src/apps/chats/components/CreateRoomDialog.tsx
@@ -50,6 +50,7 @@ interface CreateRoomDialogProps {
     type: "public" | "private" | "irc",
     members: string[],
     ircOptions?: {
+      ircServerId?: string;
       ircHost?: string;
       ircPort?: number;
       ircTls?: boolean;
@@ -100,6 +101,8 @@ export function CreateRoomDialog({
   const [isLoadingChannels, setIsLoadingChannels] = useState(false);
   const [channelsError, setChannelsError] = useState<string | null>(null);
   const [channelFilter, setChannelFilter] = useState("");
+  /** Filter text for the channel list only (non-admins cannot type arbitrary channels). */
+  const [channelListFilter, setChannelListFilter] = useState("");
   const [selectedChannel, setSelectedChannel] = useState<string | null>(null);
   const [customChannel, setCustomChannel] = useState("");
   const [channelsTruncated, setChannelsTruncated] = useState(false);
@@ -134,6 +137,7 @@ export function CreateRoomDialog({
       setIrcChannels([]);
       setChannelsError(null);
       setChannelFilter("");
+      setChannelListFilter("");
       setSelectedChannel(null);
       setCustomChannel("");
       setChannelsTruncated(false);
@@ -271,6 +275,7 @@ export function CreateRoomDialog({
     if (!selectedServerId) return;
     setSelectedChannel(null);
     setChannelFilter("");
+    setChannelListFilter("");
     setCustomChannel("");
     void loadIrcChannels(selectedServerId);
   }, [isOpen, activeTab, selectedServerId, loadIrcChannels]);
@@ -341,7 +346,9 @@ export function CreateRoomDialog({
   );
 
   const filteredChannels = (() => {
-    const term = channelFilter.trim().toLowerCase();
+    const term = (isAdmin ? channelFilter : channelListFilter)
+      .trim()
+      .toLowerCase();
     if (!term) return ircChannels;
     return ircChannels.filter((entry) => {
       const channelMatch = entry.channel.toLowerCase().includes(term);
@@ -362,6 +369,7 @@ export function CreateRoomDialog({
     try {
       let ircOptions:
         | {
+            ircServerId?: string;
             ircHost?: string;
             ircPort?: number;
             ircTls?: boolean;
@@ -378,9 +386,17 @@ export function CreateRoomDialog({
           setIsLoading(false);
           return;
         }
-        const rawChannel = (customChannel.trim() || selectedChannel || "").trim();
+        const rawChannel = (
+          isAdmin
+            ? customChannel.trim() || selectedChannel || ""
+            : selectedChannel || ""
+        ).trim();
         if (!rawChannel) {
-          setError("Please pick or enter an IRC channel.");
+          setError(
+            isAdmin
+              ? "Please pick or enter an IRC channel."
+              : "Please pick a channel from the list."
+          );
           setIsLoading(false);
           return;
         }
@@ -388,6 +404,7 @@ export function CreateRoomDialog({
           ? rawChannel
           : `#${rawChannel}`;
         ircOptions = {
+          ircServerId: server.id,
           ircHost: server.host,
           ircPort: server.port,
           ircTls: server.tls,
@@ -440,17 +457,22 @@ export function CreateRoomDialog({
         onValueChange={(v) => setActiveTab(v as "public" | "private" | "irc")}
         className="w-full"
       >
-        {isAdmin && (
-          <ThemedTabsList className="grid grid-cols-3 w-full">
-            <ThemedTabsTrigger value="private">
-              {t("apps.chats.sidebar.private")}
-            </ThemedTabsTrigger>
+        <ThemedTabsList
+          className={cn(
+            "grid w-full",
+            isAdmin ? "grid-cols-3" : "grid-cols-2"
+          )}
+        >
+          <ThemedTabsTrigger value="private">
+            {t("apps.chats.sidebar.private")}
+          </ThemedTabsTrigger>
+          {isAdmin && (
             <ThemedTabsTrigger value="public">
               {t("apps.chats.dialogs.public")}
             </ThemedTabsTrigger>
-            <ThemedTabsTrigger value="irc">IRC</ThemedTabsTrigger>
-          </ThemedTabsList>
-        )}
+          )}
+          <ThemedTabsTrigger value="irc">IRC</ThemedTabsTrigger>
+        </ThemedTabsList>
 
         {isAdmin && (
           <ThemedTabsContent value="public">
@@ -492,8 +514,7 @@ export function CreateRoomDialog({
           </ThemedTabsContent>
         )}
 
-        {isAdmin && (
-          <ThemedTabsContent value="irc">
+        <ThemedTabsContent value="irc">
             <div className="p-4 space-y-3">
               {/* Step 1: Server picker */}
               <div className="space-y-2">
@@ -550,19 +571,23 @@ export function CreateRoomDialog({
                             </span>
                           </SelectItem>
                         ))}
-                        <SelectItem
-                          value="__add__"
-                          className={cn(themeFont, "text-blue-600")}
-                        >
-                          <span className="inline-flex items-center gap-1">
-                            <Plus className="h-3 w-3" weight="bold" />
-                            Add new server…
-                          </span>
-                        </SelectItem>
+                        {isAdmin && (
+                          <SelectItem
+                            value="__add__"
+                            className={cn(themeFont, "text-blue-600")}
+                          >
+                            <span className="inline-flex items-center gap-1">
+                              <Plus className="h-3 w-3" weight="bold" />
+                              Add new server…
+                            </span>
+                          </SelectItem>
+                        )}
                       </SelectContent>
                     </Select>
                   </div>
-                  {selectedServer && !selectedServer.isDefault && (
+                  {isAdmin &&
+                    selectedServer &&
+                    !selectedServer.isDefault && (
                     <Button
                       type="button"
                       variant="ghost"
@@ -588,7 +613,7 @@ export function CreateRoomDialog({
               </div>
 
               {/* Inline "add server" form */}
-              {showAddServerForm && (
+              {isAdmin && showAddServerForm && (
                 <div className="space-y-2 border border-gray-300 rounded p-3 bg-gray-50">
                   <Label
                     className={cn("text-gray-700 font-semibold", themeFont)}
@@ -683,8 +708,17 @@ export function CreateRoomDialog({
               )}
 
               {/* Step 2: Channel browser */}
-              {selectedServerId && !showAddServerForm && (
+              {selectedServerId && (!isAdmin || !showAddServerForm) && (
                 <div className="space-y-2">
+                  {!isAdmin && (
+                    <p
+                      className={cn("text-gray-500 text-[11px]", themeFont)}
+                      style={themeFontStyle}
+                    >
+                      IRC servers are managed by an admin. Choose a channel
+                      from the list to join.
+                    </p>
+                  )}
                   <div className="flex items-center justify-between">
                     <Label
                       htmlFor="irc-channel-filter"
@@ -712,45 +746,68 @@ export function CreateRoomDialog({
                       />
                     </Button>
                   </div>
-                  <div className="relative">
-                    <Input
-                      id="irc-channel-filter"
-                      placeholder={
-                        isLoadingChannels
-                          ? "Loading channels…"
-                          : "Filter channels or type a new one"
-                      }
-                      value={channelFilter || customChannel}
-                      onChange={(e) => {
-                        const v = e.target.value;
-                        setChannelFilter(v);
-                        // If the user types something that doesn't exactly
-                        // match an existing channel, treat it as a custom
-                        // entry too so they can join an unlisted channel.
-                        const match = ircChannels.find(
-                          (c) => c.channel.toLowerCase() === v.toLowerCase()
-                        );
-                        if (match) {
-                          setSelectedChannel(match.channel);
-                          setCustomChannel("");
-                        } else if (v.startsWith("#") || v.startsWith("&")) {
-                          setCustomChannel(v);
-                          setSelectedChannel(null);
-                        } else {
-                          setCustomChannel("");
+                  {isAdmin ? (
+                    <div className="relative">
+                      <Input
+                        id="irc-channel-filter"
+                        placeholder={
+                          isLoadingChannels
+                            ? "Loading channels…"
+                            : "Filter channels or type a new one"
                         }
-                      }}
-                      className={cn("shadow-none h-8", themeFont)}
-                      style={themeFontStyle}
-                      disabled={isLoading || isLoadingChannels}
-                    />
-                    {isLoadingChannels && (
-                      <ActivityIndicator
-                        size="sm"
-                        className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-500"
+                        value={channelFilter || customChannel}
+                        onChange={(e) => {
+                          const v = e.target.value;
+                          setChannelFilter(v);
+                          const match = ircChannels.find(
+                            (c) => c.channel.toLowerCase() === v.toLowerCase()
+                          );
+                          if (match) {
+                            setSelectedChannel(match.channel);
+                            setCustomChannel("");
+                          } else if (v.startsWith("#") || v.startsWith("&")) {
+                            setCustomChannel(v);
+                            setSelectedChannel(null);
+                          } else {
+                            setCustomChannel("");
+                          }
+                        }}
+                        className={cn("shadow-none h-8", themeFont)}
+                        style={themeFontStyle}
+                        disabled={isLoading || isLoadingChannels}
                       />
-                    )}
-                  </div>
+                      {isLoadingChannels && (
+                        <ActivityIndicator
+                          size="sm"
+                          className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-500"
+                        />
+                      )}
+                    </div>
+                  ) : (
+                    <div className="relative">
+                      <Input
+                        id="irc-channel-filter"
+                        placeholder={
+                          isLoadingChannels
+                            ? "Loading channels…"
+                            : "Filter channels"
+                        }
+                        value={channelListFilter}
+                        onChange={(e) => {
+                          setChannelListFilter(e.target.value);
+                        }}
+                        className={cn("shadow-none h-8", themeFont)}
+                        style={themeFontStyle}
+                        disabled={isLoading || isLoadingChannels}
+                      />
+                      {isLoadingChannels && (
+                        <ActivityIndicator
+                          size="sm"
+                          className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-500"
+                        />
+                      )}
+                    </div>
+                  )}
                   {channelsError && (
                     <p
                       className={cn("text-red-600", themeFont)}
@@ -762,7 +819,8 @@ export function CreateRoomDialog({
                   {!isLoadingChannels && !channelsError && (
                     <div className="border border-gray-300 rounded max-h-[180px] overflow-y-auto bg-white">
                       <div className="p-1">
-                        {filteredChannels.length === 0 && !customChannel && (
+                        {filteredChannels.length === 0 &&
+                          !(isAdmin && customChannel) && (
                           <p
                             className={cn(
                               "text-gray-500 px-2 py-2",
@@ -770,8 +828,9 @@ export function CreateRoomDialog({
                             )}
                             style={themeFontStyle}
                           >
-                            No channels available. Type a channel name above
-                            to join one anyway.
+                            {isAdmin
+                              ? "No channels available. Type a channel name above to join one anyway."
+                              : "No channels match this filter."}
                           </p>
                         )}
                         {filteredChannels.map((entry) => {
@@ -785,6 +844,7 @@ export function CreateRoomDialog({
                                 setSelectedChannel(entry.channel);
                                 setCustomChannel("");
                                 setChannelFilter("");
+                                setChannelListFilter("");
                               }}
                               className={cn(
                                 "w-full text-left flex items-center gap-2 p-2 rounded",
@@ -823,15 +883,18 @@ export function CreateRoomDialog({
                       filter to see more.
                     </p>
                   )}
-                  {(customChannel ||
-                    (selectedChannel && !customChannel)) && (
+                  {((isAdmin &&
+                    (customChannel || (selectedChannel && !customChannel))) ||
+                    (!isAdmin && selectedChannel)) && (
                     <p
                       className={cn("text-gray-500", themeFont)}
                       style={themeFontStyle}
                     >
                       Will create a room bridged to{" "}
                       <span className="font-semibold">
-                        {customChannel || selectedChannel}
+                        {isAdmin
+                          ? customChannel || selectedChannel
+                          : selectedChannel}
                       </span>{" "}
                       on{" "}
                       <span className="font-semibold">
@@ -844,7 +907,6 @@ export function CreateRoomDialog({
               )}
             </div>
           </ThemedTabsContent>
-        )}
 
         <ThemedTabsContent value="private">
           <div className="p-4">
@@ -975,8 +1037,10 @@ export function CreateRoomDialog({
             (activeTab === "private" && selectedUsers.length === 0) ||
             (activeTab === "irc" &&
               (!selectedServerId ||
-                showAddServerForm ||
-                !(customChannel.trim() || selectedChannel)))
+                (isAdmin && showAddServerForm) ||
+                (isAdmin
+                  ? !(customChannel.trim() || selectedChannel)
+                  : !selectedChannel)))
           }
           className={cn("h-7", themeFont)}
           style={themeFontStyle}

--- a/src/apps/chats/hooks/useChatRoom.ts
+++ b/src/apps/chats/hooks/useChatRoom.ts
@@ -505,6 +505,7 @@ export function useChatRoom(
       type: "public" | "private" | "irc" = "public",
       members: string[] = [],
       ircOptions: {
+        ircServerId?: string;
         ircHost?: string;
         ircPort?: number;
         ircTls?: boolean;
@@ -518,13 +519,6 @@ export function useChatRoom(
         return {
           ok: false,
           error: "Permission denied. Admin access required.",
-        };
-      }
-
-      if (type === "irc" && !isAdmin) {
-        return {
-          ok: false,
-          error: "Permission denied. Admin access required for IRC rooms.",
         };
       }
 

--- a/src/stores/useChatsStore.ts
+++ b/src/stores/useChatsStore.ts
@@ -200,6 +200,7 @@ export interface ChatsStoreState {
     type?: "public" | "private" | "irc",
     members?: string[],
     ircOptions?: {
+      ircServerId?: string;
       ircHost?: string;
       ircPort?: number;
       ircTls?: boolean;
@@ -1028,6 +1029,7 @@ export const useChatsStore = create<ChatsStoreState>()(
           type: "public" | "private" | "irc" = "public",
           members: string[] = [],
           ircOptions: {
+            ircServerId?: string;
             ircHost?: string;
             ircPort?: number;
             ircTls?: boolean;
@@ -1047,6 +1049,8 @@ export const useChatsStore = create<ChatsStoreState>()(
               payload.name = name.trim();
             } else if (type === "irc") {
               payload.name = name.trim();
+              if (ircOptions.ircServerId)
+                payload.ircServerId = ircOptions.ircServerId;
               if (ircOptions.ircHost) payload.ircHost = ircOptions.ircHost;
               if (ircOptions.ircPort) payload.ircPort = ircOptions.ircPort;
               if (typeof ircOptions.ircTls === "boolean")

--- a/tests/test-irc-bridge.test.ts
+++ b/tests/test-irc-bridge.test.ts
@@ -431,6 +431,8 @@ describe("IRC Bridge wiring", () => {
     // The create route must honour the opt-out flag so IRC_BRIDGE_DISABLED=1
     // never accidentally opens a socket.
     expect(src).toContain("isIrcBridgeEnabled");
+    expect(src).toContain("getIrcServer");
+    expect(src).toContain("ircServerId");
   });
 
   test("rooms/[id].ts wires notifyRoomBindingChange on delete", async () => {
@@ -484,8 +486,8 @@ describe("IRC Bridge wiring", () => {
     expect(src).toContain("listChannels");
     // Honour the disabled flag.
     expect(src).toContain("isIrcBridgeEnabled");
-    // Admin gate.
-    expect(src).toContain('user!.username !== "ryo"');
+    // Any authenticated user (not admin-only).
+    expect(src).not.toContain('user!.username !== "ryo"');
   });
 });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- **Channel listing** (`GET /api/irc/servers/:id/channels`): any **authenticated** user can browse channels on servers already in the registry; adding/removing servers stays **admin-only**.
- **IRC room creation** (`POST /api/rooms` with `type: "irc"`): **non-admins** must send `ircServerId` (registry id); the server runs **LIST** and only allows the channel if it appears in that snapshot (prevents arbitrary host/port from non-admins). **Admins** keep the previous flexibility (optional `ircServerId` or manual host/port/label).
- **Chats UI**: **IRC** tab is visible to everyone; **Add server** / **delete non-default server** remain admin-only; non-admins **must pick a channel from the list** (filter-only field).

## Testing

- `bun run build`
- `bun test tests/test-irc-bridge.test.ts`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6c1b29a4-b37a-4ba4-93ae-d41513b26c78"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6c1b29a4-b37a-4ba4-93ae-d41513b26c78"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

