### PR TITLE
fix(chats): stabilize new chat dialog on IRC tab

### DIFF
--- a/src/apps/chats/components/ChatsDialogs.tsx
+++ b/src/apps/chats/components/ChatsDialogs.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from "react";
 import { HelpDialog } from "@/components/dialogs/HelpDialog";
 import { AboutDialog } from "@/components/dialogs/AboutDialog";
 import { ConfirmDialog } from "@/components/dialogs/ConfirmDialog";
@@ -145,6 +146,11 @@ export const ChatsDialogs = ({
 }: ChatsDialogsProps) => {
   const { t } = useTranslation();
 
+  const createRoomInitialUsers = useMemo(
+    () => (prefilledUser ? [prefilledUser] : []),
+    [prefilledUser]
+  );
+
   return (
     <>
       <HelpDialog
@@ -207,7 +213,7 @@ export const ChatsDialogs = ({
         onSubmit={handleAddRoom}
         isAdmin={isAdmin}
         currentUsername={username}
-        initialUsers={prefilledUser ? [prefilledUser] : []}
+        initialUsers={createRoomInitialUsers}
       />
       <ConfirmDialog
         isOpen={isDeleteRoomDialogOpen}

--- a/src/apps/chats/components/CreateRoomDialog.tsx
+++ b/src/apps/chats/components/CreateRoomDialog.tsx
@@ -14,6 +14,7 @@ import { Tabs } from "@/components/ui/tabs";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Badge } from "@/components/ui/badge";
 import { ActivityIndicator } from "@/components/ui/activity-indicator";
+import { ScrollArea } from "@/components/ui/scroll-area";
 import {
   Select,
   SelectContent,
@@ -450,11 +451,16 @@ export function CreateRoomDialog({
     : undefined;
 
   const dialogContent = (
-    <div className={isXpTheme ? "pt-2 pb-6 px-4" : "pt-3 pb-6 px-6"}>
+    <div
+      className={cn(
+        isXpTheme ? "pt-2 pb-6 px-4" : "pt-3 pb-6 px-6",
+        "min-w-0 w-full max-w-full"
+      )}
+    >
       <Tabs
         value={activeTab}
         onValueChange={(v) => setActiveTab(v as "public" | "private" | "irc")}
-        className="w-full"
+        className="w-full min-w-0"
       >
         <ThemedTabsList
           className={cn(
@@ -514,7 +520,7 @@ export function CreateRoomDialog({
         )}
 
         <ThemedTabsContent value="irc">
-            <div className="p-4 space-y-3">
+            <div className="p-4 space-y-3 min-w-0 w-full max-w-full">
               {/* Step 1: Server picker */}
               <div className="space-y-2">
                 <Label
@@ -816,62 +822,88 @@ export function CreateRoomDialog({
                     </p>
                   )}
                   {!isLoadingChannels && !channelsError && (
-                    <div className="border border-gray-300 rounded max-h-[180px] overflow-y-auto bg-white">
-                      <div className="p-1">
+                    <ScrollArea className="h-[200px] w-full min-w-0 max-w-full border border-gray-300 rounded-md bg-white">
+                      <div className="min-w-0">
                         {filteredChannels.length === 0 &&
                           !(isAdmin && customChannel) && (
-                          <p
-                            className={cn(
-                              "text-gray-500 px-2 py-2",
-                              themeFont
-                            )}
-                            style={themeFontStyle}
-                          >
-                            {isAdmin
-                              ? "No channels available. Type a channel name above to join one anyway."
-                              : "No channels match this filter."}
-                          </p>
-                        )}
-                        {filteredChannels.map((entry) => {
+                            <p
+                              className={cn(
+                                "text-gray-500 px-2 py-1.5",
+                                themeFont
+                              )}
+                              style={themeFontStyle}
+                            >
+                              {isAdmin
+                                ? "No channels available. Type a channel name above to join one anyway."
+                                : "No channels match this filter."}
+                            </p>
+                          )}
+                        {filteredChannels.map((entry, index) => {
                           const isSelected =
                             selectedChannel === entry.channel && !customChannel;
+                          const subline = [
+                            `${entry.numUsers} user${
+                              entry.numUsers === 1 ? "" : "s"
+                            }`,
+                            entry.topic,
+                          ]
+                            .filter(Boolean)
+                            .join(" • ");
                           return (
-                            <button
+                            <div
                               key={entry.channel}
-                              type="button"
+                              role="button"
+                              tabIndex={isLoading ? -1 : 0}
                               onClick={() => {
+                                if (isLoading) return;
                                 setSelectedChannel(entry.channel);
                                 setCustomChannel("");
                                 setChannelFilter("");
                                 setChannelListFilter("");
                               }}
+                              onKeyDown={(e) => {
+                                if (isLoading) return;
+                                if (e.key === "Enter" || e.key === " ") {
+                                  e.preventDefault();
+                                  setSelectedChannel(entry.channel);
+                                  setCustomChannel("");
+                                  setChannelFilter("");
+                                  setChannelListFilter("");
+                                }
+                              }}
+                              data-selected={isSelected ? "true" : undefined}
+                              aria-disabled={isLoading}
                               className={cn(
-                                "w-full text-left flex items-center gap-2 p-2 rounded",
-                                isSelected
-                                  ? "bg-blue-100 text-blue-900"
-                                  : "hover:bg-gray-100",
+                                "px-2 py-1.5 w-full min-w-0 max-w-full text-left box-border",
+                                isLoading
+                                  ? "cursor-not-allowed opacity-60"
+                                  : "cursor-pointer",
+                                !isSelected &&
+                                  (index % 2 === 1 ? "bg-gray-100" : "bg-white"),
                                 themeFont
                               )}
                               style={themeFontStyle}
-                              disabled={isLoading}
                             >
-                              <span className="font-semibold whitespace-nowrap">
+                              <div className="font-semibold truncate">
                                 {entry.channel}
-                              </span>
-                              <span className="text-[10px] text-gray-500 shrink-0">
-                                {entry.numUsers} user
-                                {entry.numUsers === 1 ? "" : "s"}
-                              </span>
-                              {entry.topic && (
-                                <span className="ml-1 text-gray-500 truncate">
-                                  {entry.topic}
-                                </span>
-                              )}
-                            </button>
+                              </div>
+                              {subline ? (
+                                <div
+                                  className={cn(
+                                    "truncate",
+                                    isSelected
+                                      ? "opacity-80"
+                                      : "text-neutral-600"
+                                  )}
+                                >
+                                  {subline}
+                                </div>
+                              ) : null}
+                            </div>
                           );
                         })}
                       </div>
-                    </div>
+                    </ScrollArea>
                   )}
                   {channelsTruncated && (
                     <p
@@ -1057,7 +1089,7 @@ export function CreateRoomDialog({
       <DialogContent
         className={cn(
           // Fixed max width so switching tabs (e.g. to IRC) does not resize the dialog.
-          "max-w-[400px]",
+          "max-w-[400px] min-w-0 w-full",
           isXpTheme && "p-0 overflow-hidden"
         )}
         style={isXpTheme ? { fontSize: "11px" } : undefined}
@@ -1067,7 +1099,7 @@ export function CreateRoomDialog({
             <DialogHeader>
               {t("apps.chats.dialogs.newChatTitle")}
             </DialogHeader>
-            <div className="window-body">{dialogContent}</div>
+            <div className="window-body min-w-0">{dialogContent}</div>
           </>
         ) : currentTheme === "macosx" ? (
           <>

--- a/src/apps/chats/components/CreateRoomDialog.tsx
+++ b/src/apps/chats/components/CreateRoomDialog.tsx
@@ -460,7 +460,7 @@ export function CreateRoomDialog({
       <Tabs
         value={activeTab}
         onValueChange={(v) => setActiveTab(v as "public" | "private" | "irc")}
-        className="w-full min-w-0"
+        className="w-full min-w-0 max-w-full overflow-x-hidden"
       >
         <ThemedTabsList
           className={cn(
@@ -822,8 +822,8 @@ export function CreateRoomDialog({
                     </p>
                   )}
                   {!isLoadingChannels && !channelsError && (
-                    <ScrollArea className="h-[200px] w-full min-w-0 max-w-full border border-gray-300 rounded-md bg-white">
-                      <div className="min-w-0">
+                    <ScrollArea className="h-[200px] w-full min-w-0 max-w-full overflow-x-hidden border border-gray-300 rounded-md bg-white">
+                      <div className="min-w-0 max-w-full overflow-x-hidden">
                         {filteredChannels.length === 0 &&
                           !(isAdmin && customChannel) && (
                             <p
@@ -874,7 +874,7 @@ export function CreateRoomDialog({
                               data-selected={isSelected ? "true" : undefined}
                               aria-disabled={isLoading}
                               className={cn(
-                                "px-2 py-1.5 w-full min-w-0 max-w-full text-left box-border",
+                                "px-2 py-1.5 w-full min-w-0 max-w-full overflow-hidden text-left box-border",
                                 isLoading
                                   ? "cursor-not-allowed opacity-60"
                                   : "cursor-pointer",
@@ -907,7 +907,10 @@ export function CreateRoomDialog({
                   )}
                   {channelsTruncated && (
                     <p
-                      className={cn("text-gray-500", themeFont)}
+                      className={cn(
+                        "text-gray-500 min-w-0 max-w-full break-words",
+                        themeFont
+                      )}
                       style={themeFontStyle}
                     >
                       Showing first {ircChannels.length} channels — refine the
@@ -918,7 +921,10 @@ export function CreateRoomDialog({
                     (customChannel || (selectedChannel && !customChannel))) ||
                     (!isAdmin && selectedChannel)) && (
                     <p
-                      className={cn("text-gray-500", themeFont)}
+                      className={cn(
+                        "text-gray-500 min-w-0 max-w-full break-words",
+                        themeFont
+                      )}
                       style={themeFontStyle}
                     >
                       Will create a room bridged to{" "}

--- a/src/apps/chats/components/CreateRoomDialog.tsx
+++ b/src/apps/chats/components/CreateRoomDialog.tsx
@@ -1057,7 +1057,7 @@ export function CreateRoomDialog({
       <DialogContent
         className={cn(
           // Fixed max width so switching tabs (e.g. to IRC) does not resize the dialog.
-          "max-w-[480px]",
+          "max-w-[400px]",
           isXpTheme && "p-0 overflow-hidden"
         )}
         style={isXpTheme ? { fontSize: "11px" } : undefined}

--- a/src/apps/chats/components/CreateRoomDialog.tsx
+++ b/src/apps/chats/components/CreateRoomDialog.tsx
@@ -109,42 +109,41 @@ export function CreateRoomDialog({
 
   const searchRequestIdRef = useRef(0);
   const channelRequestIdRef = useRef(0);
+  /** Stable key so parent re-renders with a new `initialUsers` array do not reset the dialog. */
+  const initialUsersKey = initialUsers.join("\0");
 
   // Theme detection
   const currentTheme = useThemeStore((state) => state.current);
   const isXpTheme = currentTheme === "xp" || currentTheme === "win98";
 
-  // Reset form when dialog opens
+  // Reset form when the dialog opens or when the prefilled user list actually changes.
   useEffect(() => {
-    if (isOpen) {
-      // Reset form when opening
-      setError(null);
-      setRoomName("");
-      setSelectedUsers(initialUsers); // Use initialUsers if provided
-      setSearchTerm("");
-      setUsers([]);
-      // Reset IRC tab state
-      setIrcServers([]);
-      setSelectedServerId(null);
-      setServersError(null);
-      setShowAddServerForm(false);
-      setNewServerHost("");
-      setNewServerPort(6667);
-      setNewServerTls(false);
-      setNewServerLabel("");
-      setIsAddingServer(false);
-      setAddServerError(null);
-      setIrcChannels([]);
-      setChannelsError(null);
-      setChannelFilter("");
-      setChannelListFilter("");
-      setSelectedChannel(null);
-      setCustomChannel("");
-      setChannelsTruncated(false);
-      // Reset to private tab when opening
-      setActiveTab("private");
-    }
-  }, [isOpen, initialUsers]);
+    if (!isOpen) return;
+    setError(null);
+    setRoomName("");
+    setSelectedUsers([...initialUsers]);
+    setSearchTerm("");
+    setUsers([]);
+    // Reset IRC tab state
+    setIrcServers([]);
+    setSelectedServerId(null);
+    setServersError(null);
+    setShowAddServerForm(false);
+    setNewServerHost("");
+    setNewServerPort(6667);
+    setNewServerTls(false);
+    setNewServerLabel("");
+    setIsAddingServer(false);
+    setAddServerError(null);
+    setIrcChannels([]);
+    setChannelsError(null);
+    setChannelFilter("");
+    setChannelListFilter("");
+    setSelectedChannel(null);
+    setCustomChannel("");
+    setChannelsTruncated(false);
+    setActiveTab("private");
+  }, [isOpen, initialUsersKey]);
 
   const searchUsers = useCallback(async (query: string) => {
     const requestId = ++searchRequestIdRef.current;
@@ -1057,7 +1056,8 @@ export function CreateRoomDialog({
     <Dialog open={isOpen} onOpenChange={onOpenChange}>
       <DialogContent
         className={cn(
-          activeTab === "irc" ? "max-w-[480px]" : "max-w-[400px]",
+          // Fixed max width so switching tabs (e.g. to IRC) does not resize the dialog.
+          "max-w-[480px]",
           isXpTheme && "p-0 overflow-hidden"
         )}
         style={isXpTheme ? { fontSize: "11px" } : undefined}

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -81,7 +81,7 @@ const DialogContent = React.forwardRef<
   const getDialogContentClasses = () => {
     if (isXpTheme) {
       return cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 p-0 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 origin-center",
+        "fixed left-[50%] top-[50%] z-50 grid w-full min-w-0 max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 p-0 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 origin-center",
         "window", // Use xp.css window class
         className
       );
@@ -89,7 +89,7 @@ const DialogContent = React.forwardRef<
 
     if (isMacOSTheme) {
       return cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-os-window-bg p-0 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 origin-center overflow-hidden",
+        "fixed left-[50%] top-[50%] z-50 grid w-full min-w-0 max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-os-window-bg p-0 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 origin-center overflow-hidden",
         // Ensure all descendant buttons use 13px text size in macOSX dialogs
         "border-[length:var(--os-metrics-border-width)] border-os-window shadow-os-window macosx-dialog [&_button]:text-[13px]",
         className
@@ -98,7 +98,7 @@ const DialogContent = React.forwardRef<
 
     // Default System 7 style
     return cn(
-      "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-0 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 origin-center",
+      "fixed left-[50%] top-[50%] z-50 grid w-full min-w-0 max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-0 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 origin-center",
       "bg-os-window-bg border-[length:var(--os-metrics-border-width)] border-os-window shadow-os-window",
       className
     );
@@ -116,7 +116,7 @@ const DialogContent = React.forwardRef<
         {...props}
       >
         <div
-          className="flex flex-1 min-h-0 flex-col"
+          className="flex min-h-0 min-w-0 w-full max-w-full flex-1 flex-col overflow-x-hidden"
           style={
             isMacOSTheme
               ? {

--- a/src/components/ui/scroll-area.tsx
+++ b/src/components/ui/scroll-area.tsx
@@ -12,7 +12,7 @@ const ScrollArea = React.forwardRef<
     className={cn("relative overflow-hidden", className)}
     {...props}
   >
-    <ScrollAreaPrimitive.Viewport className="h-full w-full rounded-[inherit]">
+    <ScrollAreaPrimitive.Viewport className="h-full w-full min-w-0 max-w-full rounded-[inherit]">
       {children}
     </ScrollAreaPrimitive.Viewport>
     <ScrollBar />

--- a/src/utils/tabStyles.ts
+++ b/src/utils/tabStyles.ts
@@ -31,7 +31,8 @@ export function getTabStyles(currentTheme: OsThemeId): TabStyleConfig {
   const tabTriggerBase = `relative flex-1 ${isMacOSXTheme ? "" : "h-6"} px-2 ${
     isMacOSXTheme ? "" : "-mb-[1px]"
   } rounded-t shadow-none! text-[16px]`;
-  const tabContentBase = "mt-0 h-[calc(100%-2rem)]";
+  const tabContentBase =
+    "mt-0 min-w-0 max-w-full h-[calc(100%-2rem)] overflow-x-hidden";
   // Default content style (non-themed fallback) — kept separate to avoid
   // conflicting bg/border classes when a theme provides its own.
   const tabContentDefault = "bg-white border border-black/20";


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- **Resize / reload:** `CreateRoomDialog` fixed width + stable `initialUsers` reset behavior (unchanged from prior commits).
- **IRC channel list:** Lyrics-style list with `ScrollArea`, zebra rows, `data-selected`.
- **Long text / mobile width:** Grid/flex children default to `min-width: auto`, so intrinsic min-content from long channel topics was widening the dialog. Added **`min-w-0`** on `DialogContent` (all themes), **`min-w-0 max-w-full overflow-x-hidden`** on the dialog inner flex shell, **`min-w-0 max-w-full overflow-x-hidden`** on macOS aqua **tab content** (`getTabStyles`), **`min-w-0`** on **`ScrollArea` viewport**, **`overflow-hidden`** on channel rows, and **`break-words`** on footer hint paragraphs. Tabs root gets **`overflow-x-hidden`**.

## Testing
- `bun run build` (tsc + vite) — pass.

## Notes
Root cause of horizontal stretch: CSS grid/flex min-size algorithm + long unbreakable strings; `truncate` only works when the flex item can shrink below content min-width.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8b9130fa-52ab-4fb5-a48c-58436fbb9a28"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8b9130fa-52ab-4fb5-a48c-58436fbb9a28"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

