### PR TITLE
Sparse default desktop app shortcuts on System 7 / Windows themes

### DIFF
--- a/src/components/layout/Desktop.tsx
+++ b/src/components/layout/Desktop.tsx
@@ -17,7 +17,7 @@ import { dbOperations } from "@/apps/finder/hooks/useFileSystem";
 import { STORES } from "@/utils/indexedDB";
 import { ConfirmDialog } from "@/components/dialogs/ConfirmDialog";
 import { useTranslation } from "react-i18next";
-import { getTranslatedAppName } from "@/utils/i18n";
+import { getTranslatedAppName, getTranslatedFolderName } from "@/utils/i18n";
 import { useEventListener } from "@/hooks/useEventListener";
 import {
   createSelectionRect,
@@ -154,6 +154,25 @@ export function Desktop({
             if (bIndex !== -1) return 1;
             return a.name.localeCompare(b.name);
           }
+          if (a.aliasType === "file" && a.aliasTarget === "/Applications") {
+            if (b.aliasType === "file" && b.aliasTarget === "/Applications") {
+              return a.name.localeCompare(b.name);
+            }
+            if (b.aliasType === "app") {
+              const bIndex = DEFAULT_SHORTCUT_ORDER.indexOf(b.aliasTarget as AppId);
+              if (bIndex === 0) return 1;
+              if (bIndex !== -1) return -1;
+            }
+            return a.name.localeCompare(b.name);
+          }
+          if (b.aliasType === "file" && b.aliasTarget === "/Applications") {
+            if (a.aliasType === "app") {
+              const aIndex = DEFAULT_SHORTCUT_ORDER.indexOf(a.aliasTarget as AppId);
+              if (aIndex === 0) return -1;
+              if (aIndex !== -1) return 1;
+            }
+            return a.name.localeCompare(b.name);
+          }
           if (a.aliasType === "app" && b.aliasType !== "app") return -1;
           if (a.aliasType !== "app" && b.aliasType === "app") return 1;
           return a.name.localeCompare(b.name);
@@ -166,6 +185,12 @@ export function Desktop({
     // For app aliases, use translated app name
     if (shortcut.aliasType === "app" && shortcut.aliasTarget) {
       return getTranslatedAppName(shortcut.aliasTarget as AppId);
+    }
+    if (shortcut.aliasType === "file" && shortcut.aliasTarget) {
+      const targetFile = getItem(shortcut.aliasTarget);
+      if (targetFile?.isDirectory) {
+        return getTranslatedFolderName(shortcut.aliasTarget);
+      }
     }
     // For file aliases, remove file extension
     return shortcut.name.replace(/\.[^/.]+$/, "");
@@ -186,6 +211,11 @@ export function Desktop({
       
       if (!targetFile) {
         console.warn(`[Desktop] Target file not found: ${targetPath}`);
+        return;
+      }
+
+      if (targetFile.isDirectory && targetPath === "/Applications") {
+        launchApp("finder", { initialPath: "/Applications", launchOrigin });
         return;
       }
 
@@ -989,7 +1019,10 @@ export function Desktop({
             >
               <FileIcon
                 name={getDisplayName(shortcut)}
-                isDirectory={false}
+                isDirectory={
+                  shortcut.aliasType === "file" &&
+                  shortcut.aliasTarget === "/Applications"
+                }
                 icon={getShortcutIcon(shortcut)}
                 onClick={(e) =>
                   handleDesktopItemClick(

--- a/src/components/layout/Desktop.tsx
+++ b/src/components/layout/Desktop.tsx
@@ -46,8 +46,9 @@ interface DesktopProps {
 const DEFAULT_SHORTCUT_ORDER: AppId[] = [
   "ipod",
   "chats",
-  "applet-viewer",
   "internet-explorer",
+  "karaoke",
+  "applet-viewer",
   "textedit",
   "photo-booth",
   "videos",
@@ -160,6 +161,10 @@ export function Desktop({
             }
             if (b.aliasType === "app") {
               const bIndex = DEFAULT_SHORTCUT_ORDER.indexOf(b.aliasTarget as AppId);
+              if (currentTheme === "system7") {
+                if (bIndex >= 0 && bIndex <= 3) return 1;
+                return -1;
+              }
               if (bIndex === 0) return 1;
               if (bIndex !== -1) return -1;
             }
@@ -168,6 +173,10 @@ export function Desktop({
           if (b.aliasType === "file" && b.aliasTarget === "/Applications") {
             if (a.aliasType === "app") {
               const aIndex = DEFAULT_SHORTCUT_ORDER.indexOf(a.aliasTarget as AppId);
+              if (currentTheme === "system7") {
+                if (aIndex >= 0 && aIndex <= 3) return -1;
+                return 1;
+              }
               if (aIndex === 0) return -1;
               if (aIndex !== -1) return 1;
             }

--- a/src/stores/useFilesStore.ts
+++ b/src/stores/useFilesStore.ts
@@ -97,7 +97,7 @@ interface FilesStoreState {
   initializeLibrary: () => Promise<void>;
   /** Ensure all root directories from filesystem.json exist in the store */
   syncRootDirectoriesFromDefaults: () => Promise<void>;
-  /** Ensure default desktop shortcuts exist for all apps */
+  /** Ensure default desktop app shortcuts exist (sparse on every OS theme; user can add more). */
   ensureDefaultDesktopShortcuts: () => Promise<void>;
 }
 
@@ -522,8 +522,16 @@ async function saveDefaultContents(
 // Function to generate an empty initial state (just for typing)
 const getEmptyFileSystemState = (): Record<string, FileSystemItem> => ({});
 
-const STORE_VERSION = 10; // Update Applets folder icon
+const STORE_VERSION = 11; // Sparse default desktop app shortcuts on all OS themes
 const STORE_NAME = "ryos:files";
+
+/** Hide bulk default app shortcuts on these themes (iPod + Applet Viewer stay visible). */
+const THEMES_WITH_SPARSE_DEFAULT_DESKTOP_SHORTCUTS: OsThemeId[] = [
+  "macosx",
+  "system7",
+  "xp",
+  "win98",
+];
 
 const initialFilesData: FilesStoreState = {
   items: getEmptyFileSystemState(),
@@ -1200,9 +1208,10 @@ export const useFilesStore = create<FilesStoreState>()(
               shortcutsToCreate.push({
                 appId,
                 appName: app.name,
-                // Apply hiddenOnThemes for non-iPod/AppletViewer
-                // This ensures they are hidden on macOS X theme but visible on others
-                hiddenOnThemes: appId !== "ipod" && appId !== "applet-viewer" ? ["macosx"] : [],
+                hiddenOnThemes:
+                  appId !== "ipod" && appId !== "applet-viewer"
+                    ? [...THEMES_WITH_SPARSE_DEFAULT_DESKTOP_SHORTCUTS]
+                    : [],
               });
             }
           }
@@ -1354,10 +1363,40 @@ export const useFilesStore = create<FilesStoreState>()(
         }
 
         if (version < 8) {
-          // Version 8 doesn't change the data structure,
-          // but we bump it to trigger the one-time sync in useFileSystem
-          // which will calculate actual file sizes and set proper timestamps
-          return persistedState;
+          // Version 8 didn't change persisted shape; sync runs on rehydrate.
+          // Do not return early — later migrations (e.g. v11) must still run.
+        }
+
+        if (version < 11) {
+          const oldState = persistedState as {
+            items: Record<string, FileSystemItem>;
+            libraryState?: LibraryState;
+          };
+          const now = Date.now();
+          const newState: Record<string, FileSystemItem> = {};
+
+          for (const path in oldState.items) {
+            const oldItem = oldState.items[path];
+            const isLegacyMacosxOnlyHidden =
+              oldItem.status === "active" &&
+              getParentPath(oldItem.path) === "/Desktop" &&
+              oldItem.aliasType === "app" &&
+              oldItem.hiddenOnThemes?.length === 1 &&
+              oldItem.hiddenOnThemes[0] === "macosx";
+
+            newState[path] = isLegacyMacosxOnlyHidden
+              ? {
+                  ...oldItem,
+                  hiddenOnThemes: [...THEMES_WITH_SPARSE_DEFAULT_DESKTOP_SHORTCUTS],
+                  modifiedAt: oldItem.modifiedAt || now,
+                }
+              : { ...oldItem };
+          }
+
+          return {
+            items: newState,
+            libraryState: oldState.libraryState || "loaded",
+          };
         }
 
         return persistedState;

--- a/src/stores/useFilesStore.ts
+++ b/src/stores/useFilesStore.ts
@@ -522,7 +522,7 @@ async function saveDefaultContents(
 // Function to generate an empty initial state (just for typing)
 const getEmptyFileSystemState = (): Record<string, FileSystemItem> => ({});
 
-const STORE_VERSION = 12; // Applications folder on non-macosx; Applet Store visible on macosx only
+const STORE_VERSION = 13; // System 7: show Chats, IE, Karaoke on desktop after iPod
 const STORE_NAME = "ryos:files";
 
 const DEFAULT_APPLICATIONS_FOLDER_ALIAS_NAME = "Applications";
@@ -531,6 +531,19 @@ const DEFAULT_APPLICATIONS_FOLDER_ALIAS_NAME = "Applications";
 const THEMES_WITH_SPARSE_DEFAULT_DESKTOP_SHORTCUTS: OsThemeId[] = [
   "macosx",
   "system7",
+  "xp",
+  "win98",
+];
+
+/** Extra desktop icons on System 7 only (after iPod); still hidden on macosx / Windows themes. */
+const SYSTEM7_PROMINENT_DESKTOP_APP_IDS: readonly string[] = [
+  "chats",
+  "internet-explorer",
+  "karaoke",
+];
+
+const THEMES_HIDE_SYSTEM7_PROMINENT_DESKTOP_APPS: OsThemeId[] = [
+  "macosx",
   "xp",
   "win98",
 ];
@@ -581,6 +594,42 @@ function migrateV12DesktopDefaultShortcuts(
         hiddenOnThemes: [
           ...THEMES_HIDE_DEFAULT_APPLICATIONS_FOLDER_DESKTOP_SHORTCUT,
         ],
+        modifiedAt: oldItem.modifiedAt || now,
+      };
+    }
+  }
+  return newState;
+}
+
+/** v13: Chats, IE, Karaoke visible on System 7 desktop (not hidden with other bulk apps). */
+function migrateV13System7ProminentDesktopApps(
+  items: Record<string, FileSystemItem>,
+  now: number
+): Record<string, FileSystemItem> {
+  const newState = { ...items };
+  const want = THEMES_HIDE_SYSTEM7_PROMINENT_DESKTOP_APPS;
+  const sparse = THEMES_WITH_SPARSE_DEFAULT_DESKTOP_SHORTCUTS;
+
+  for (const path in newState) {
+    const oldItem = newState[path];
+    if (
+      oldItem.status !== "active" ||
+      getParentPath(oldItem.path) !== "/Desktop" ||
+      oldItem.aliasType !== "app" ||
+      !SYSTEM7_PROMINENT_DESKTOP_APP_IDS.includes(oldItem.aliasTarget)
+    ) {
+      continue;
+    }
+    const h = oldItem.hiddenOnThemes;
+    const looksLikeFullSparse =
+      h?.length === sparse.length && sparse.every((t) => h.includes(t));
+    const missingProminentHides =
+      !h?.length || want.some((theme) => !h.includes(theme));
+    const wronglyHidesOnSystem7 = h?.includes("system7");
+    if (looksLikeFullSparse || missingProminentHides || wronglyHidesOnSystem7) {
+      newState[path] = {
+        ...oldItem,
+        hiddenOnThemes: [...want],
         modifiedAt: oldItem.modifiedAt || now,
       };
     }
@@ -1276,6 +1325,10 @@ export const useFilesStore = create<FilesStoreState>()(
                   hiddenOnThemes = [
                     ...THEMES_HIDE_DEFAULT_APPLET_STORE_DESKTOP_SHORTCUT,
                   ];
+                } else if (SYSTEM7_PROMINENT_DESKTOP_APP_IDS.includes(appId)) {
+                  hiddenOnThemes = [
+                    ...THEMES_HIDE_SYSTEM7_PROMINENT_DESKTOP_APPS,
+                  ];
                 } else {
                   hiddenOnThemes = [
                     ...THEMES_WITH_SPARSE_DEFAULT_DESKTOP_SHORTCUTS,
@@ -1382,6 +1435,9 @@ export const useFilesStore = create<FilesStoreState>()(
             const wantAppletHidden = THEMES_HIDE_DEFAULT_APPLET_STORE_DESKTOP_SHORTCUT;
             const wantApplicationsHidden =
               THEMES_HIDE_DEFAULT_APPLICATIONS_FOLDER_DESKTOP_SHORTCUT;
+            const wantSystem7ProminentHidden =
+              THEMES_HIDE_SYSTEM7_PROMINENT_DESKTOP_APPS;
+            const sparseThemes = THEMES_WITH_SPARSE_DEFAULT_DESKTOP_SHORTCUTS;
 
             for (const path of Object.keys(items)) {
               const item = items[path];
@@ -1423,6 +1479,31 @@ export const useFilesStore = create<FilesStoreState>()(
                   items[path] = {
                     ...item,
                     hiddenOnThemes: [...wantApplicationsHidden],
+                    modifiedAt: item.modifiedAt || now,
+                  };
+                  changed = true;
+                }
+              }
+              if (
+                item.aliasType === "app" &&
+                SYSTEM7_PROMINENT_DESKTOP_APP_IDS.includes(item.aliasTarget)
+              ) {
+                const h = item.hiddenOnThemes;
+                const looksLikeFullSparse =
+                  h?.length === sparseThemes.length &&
+                  sparseThemes.every((t) => h.includes(t));
+                const missingProminentHides =
+                  !h?.length ||
+                  wantSystem7ProminentHidden.some((theme) => !h.includes(theme));
+                const wronglyHidesOnSystem7 = h?.includes("system7");
+                if (
+                  looksLikeFullSparse ||
+                  missingProminentHides ||
+                  wronglyHidesOnSystem7
+                ) {
+                  items[path] = {
+                    ...item,
+                    hiddenOnThemes: [...wantSystem7ProminentHidden],
                     modifiedAt: item.modifiedAt || now,
                   };
                   changed = true;
@@ -1573,7 +1654,10 @@ export const useFilesStore = create<FilesStoreState>()(
           }
 
           return {
-            items: migrateV12DesktopDefaultShortcuts(newState, now),
+            items: migrateV13System7ProminentDesktopApps(
+              migrateV12DesktopDefaultShortcuts(newState, now),
+              now
+            ),
             libraryState: oldState.libraryState || "loaded",
           };
         }
@@ -1586,7 +1670,23 @@ export const useFilesStore = create<FilesStoreState>()(
           const now = Date.now();
 
           return {
-            items: migrateV12DesktopDefaultShortcuts(oldState.items, now),
+            items: migrateV13System7ProminentDesktopApps(
+              migrateV12DesktopDefaultShortcuts(oldState.items, now),
+              now
+            ),
+            libraryState: oldState.libraryState || "loaded",
+          };
+        }
+
+        if (version < 13) {
+          const oldState = persistedState as {
+            items: Record<string, FileSystemItem>;
+            libraryState?: LibraryState;
+          };
+          const now = Date.now();
+
+          return {
+            items: migrateV13System7ProminentDesktopApps(oldState.items, now),
             libraryState: oldState.libraryState || "loaded",
           };
         }

--- a/src/stores/useFilesStore.ts
+++ b/src/stores/useFilesStore.ts
@@ -522,16 +522,71 @@ async function saveDefaultContents(
 // Function to generate an empty initial state (just for typing)
 const getEmptyFileSystemState = (): Record<string, FileSystemItem> => ({});
 
-const STORE_VERSION = 11; // Sparse default desktop app shortcuts on all OS themes
+const STORE_VERSION = 12; // Applications folder on non-macosx; Applet Store visible on macosx only
 const STORE_NAME = "ryos:files";
 
-/** Hide bulk default app shortcuts on these themes (iPod + Applet Viewer stay visible). */
+const DEFAULT_APPLICATIONS_FOLDER_ALIAS_NAME = "Applications";
+
+/** Hide bulk default app shortcuts on these themes (sparse desktop). */
 const THEMES_WITH_SPARSE_DEFAULT_DESKTOP_SHORTCUTS: OsThemeId[] = [
   "macosx",
   "system7",
   "xp",
   "win98",
 ];
+
+/** Applet Store default: visible on macosx; hidden on other themes (Applications shortcut there). */
+const THEMES_HIDE_DEFAULT_APPLET_STORE_DESKTOP_SHORTCUT: OsThemeId[] = [
+  "system7",
+  "xp",
+  "win98",
+];
+
+/** Default /Applications folder shortcut: non-macosx themes only. */
+const THEMES_HIDE_DEFAULT_APPLICATIONS_FOLDER_DESKTOP_SHORTCUT: OsThemeId[] = [
+  "macosx",
+];
+
+/** v12: Applet Store vs Applications folder default desktop shortcut visibility */
+function migrateV12DesktopDefaultShortcuts(
+  items: Record<string, FileSystemItem>,
+  now: number
+): Record<string, FileSystemItem> {
+  const newState = { ...items };
+  for (const path in newState) {
+    const oldItem = newState[path];
+    const onDesktop =
+      oldItem.status === "active" && getParentPath(oldItem.path) === "/Desktop";
+
+    if (
+      onDesktop &&
+      oldItem.aliasType === "app" &&
+      oldItem.aliasTarget === "applet-viewer"
+    ) {
+      newState[path] = {
+        ...oldItem,
+        hiddenOnThemes: [...THEMES_HIDE_DEFAULT_APPLET_STORE_DESKTOP_SHORTCUT],
+        modifiedAt: oldItem.modifiedAt || now,
+      };
+      continue;
+    }
+
+    if (
+      onDesktop &&
+      oldItem.aliasType === "file" &&
+      oldItem.aliasTarget === "/Applications"
+    ) {
+      newState[path] = {
+        ...oldItem,
+        hiddenOnThemes: [
+          ...THEMES_HIDE_DEFAULT_APPLICATIONS_FOLDER_DESKTOP_SHORTCUT,
+        ],
+        modifiedAt: oldItem.modifiedAt || now,
+      };
+    }
+  }
+  return newState;
+}
 
 const initialFilesData: FilesStoreState = {
   items: getEmptyFileSystemState(),
@@ -1176,6 +1231,17 @@ export const useFilesStore = create<FilesStoreState>()(
             (item) => item.status === "trashed"
           );
 
+          const hasActiveApplicationsFolderShortcut = desktopItems.some(
+            (item) =>
+              item.aliasType === "file" && item.aliasTarget === "/Applications"
+          );
+          const hasTrashedApplicationsFolderShortcut = trashedItems.some(
+            (item) =>
+              item.aliasType === "file" &&
+              item.aliasTarget === "/Applications" &&
+              item.originalPath?.startsWith("/Desktop/")
+          );
+
           // Process all apps in registry except Finder and Control Panels
           // Use lightweight app data to avoid importing heavy component registry
           const apps = getAppBasicInfoList().filter(
@@ -1204,23 +1270,50 @@ export const useFilesStore = create<FilesStoreState>()(
             );
 
             if (!hasActiveShortcut && !hasTrashedShortcut) {
-              // Queue shortcut for batch creation
+              let hiddenOnThemes: OsThemeId[] = [];
+              if (appId !== "ipod") {
+                if (appId === "applet-viewer") {
+                  hiddenOnThemes = [
+                    ...THEMES_HIDE_DEFAULT_APPLET_STORE_DESKTOP_SHORTCUT,
+                  ];
+                } else {
+                  hiddenOnThemes = [
+                    ...THEMES_WITH_SPARSE_DEFAULT_DESKTOP_SHORTCUTS,
+                  ];
+                }
+              }
+
               shortcutsToCreate.push({
                 appId,
                 appName: app.name,
-                hiddenOnThemes:
-                  appId !== "ipod" && appId !== "applet-viewer"
-                    ? [...THEMES_WITH_SPARSE_DEFAULT_DESKTOP_SHORTCUTS]
-                    : [],
+                hiddenOnThemes,
               });
             }
           }
 
+          const needsApplicationsFolderShortcut =
+            !hasActiveApplicationsFolderShortcut &&
+            !hasTrashedApplicationsFolderShortcut;
+
           // Batch create all shortcuts in a single state update
-          if (shortcutsToCreate.length > 0) {
+          if (shortcutsToCreate.length > 0 || needsApplicationsFolderShortcut) {
             set((currentState) => {
               const newItems = { ...currentState.items };
               const now = Date.now();
+
+              const allocateUniqueDesktopPath = (displayName: string): string => {
+                const basePath = `/Desktop/${displayName}`;
+                let finalPath = basePath;
+                let counter = 1;
+                while (
+                  newItems[finalPath] &&
+                  newItems[finalPath].status === "active"
+                ) {
+                  finalPath = `/Desktop/${displayName} ${counter}`;
+                  counter++;
+                }
+                return finalPath;
+              };
 
               for (const shortcut of shortcutsToCreate) {
                 const aliasPath = `/Desktop/${shortcut.appName}`;
@@ -1245,15 +1338,99 @@ export const useFilesStore = create<FilesStoreState>()(
                   status: "active",
                   createdAt: now,
                   modifiedAt: now,
-                  hiddenOnThemes: shortcut.hiddenOnThemes.length > 0 ? shortcut.hiddenOnThemes as OsThemeId[] : undefined,
+                  hiddenOnThemes:
+                    shortcut.hiddenOnThemes.length > 0
+                      ? (shortcut.hiddenOnThemes as OsThemeId[])
+                      : undefined,
                 };
 
                 newItems[finalAliasPath] = aliasItem;
               }
 
+              if (needsApplicationsFolderShortcut) {
+                const finalPath = allocateUniqueDesktopPath(
+                  DEFAULT_APPLICATIONS_FOLDER_ALIAS_NAME
+                );
+                newItems[finalPath] = {
+                  path: finalPath,
+                  name:
+                    finalPath.split("/").pop() ||
+                    DEFAULT_APPLICATIONS_FOLDER_ALIAS_NAME,
+                  isDirectory: false,
+                  icon: "/icons/default/applications.png",
+                  type: "alias",
+                  aliasTarget: "/Applications",
+                  aliasType: "file",
+                  status: "active",
+                  createdAt: now,
+                  modifiedAt: now,
+                  hiddenOnThemes: [
+                    ...THEMES_HIDE_DEFAULT_APPLICATIONS_FOLDER_DESKTOP_SHORTCUT,
+                  ],
+                };
+              }
+
               return { items: newItems };
             });
           }
+
+          // Fix existing defaults (e.g. persisted before theme-specific metadata)
+          set((s) => {
+            const items = { ...s.items };
+            let changed = false;
+            const now = Date.now();
+            const wantAppletHidden = THEMES_HIDE_DEFAULT_APPLET_STORE_DESKTOP_SHORTCUT;
+            const wantApplicationsHidden =
+              THEMES_HIDE_DEFAULT_APPLICATIONS_FOLDER_DESKTOP_SHORTCUT;
+
+            for (const path of Object.keys(items)) {
+              const item = items[path];
+              if (
+                item.status !== "active" ||
+                getParentPath(item.path) !== "/Desktop"
+              ) {
+                continue;
+              }
+              if (
+                item.aliasType === "app" &&
+                item.aliasTarget === "applet-viewer"
+              ) {
+                const h = item.hiddenOnThemes;
+                const wronglyMacosxOnly =
+                  h?.length === 1 && h[0] === "macosx";
+                const missingNonMacosxHides =
+                  !h?.length ||
+                  wantAppletHidden.some((theme) => !h.includes(theme));
+                if (wronglyMacosxOnly || missingNonMacosxHides) {
+                  items[path] = {
+                    ...item,
+                    hiddenOnThemes: [...wantAppletHidden],
+                    modifiedAt: item.modifiedAt || now,
+                  };
+                  changed = true;
+                }
+              }
+              if (
+                item.aliasType === "file" &&
+                item.aliasTarget === "/Applications"
+              ) {
+                const h = item.hiddenOnThemes;
+                const needsApplicationsHideFix =
+                  !h?.length ||
+                  h.length !== wantApplicationsHidden.length ||
+                  wantApplicationsHidden.some((theme) => !h.includes(theme));
+                if (needsApplicationsHideFix) {
+                  items[path] = {
+                    ...item,
+                    hiddenOnThemes: [...wantApplicationsHidden],
+                    modifiedAt: item.modifiedAt || now,
+                  };
+                  changed = true;
+                }
+              }
+            }
+            return changed ? { items } : s;
+          });
         } catch (err) {
           console.error("[FilesStore] Failed to ensure default desktop shortcuts:", err);
         }
@@ -1381,6 +1558,8 @@ export const useFilesStore = create<FilesStoreState>()(
               oldItem.status === "active" &&
               getParentPath(oldItem.path) === "/Desktop" &&
               oldItem.aliasType === "app" &&
+              oldItem.aliasTarget !== "ipod" &&
+              oldItem.aliasTarget !== "applet-viewer" &&
               oldItem.hiddenOnThemes?.length === 1 &&
               oldItem.hiddenOnThemes[0] === "macosx";
 
@@ -1394,7 +1573,20 @@ export const useFilesStore = create<FilesStoreState>()(
           }
 
           return {
-            items: newState,
+            items: migrateV12DesktopDefaultShortcuts(newState, now),
+            libraryState: oldState.libraryState || "loaded",
+          };
+        }
+
+        if (version < 12) {
+          const oldState = persistedState as {
+            items: Record<string, FileSystemItem>;
+            libraryState?: LibraryState;
+          };
+          const now = Date.now();
+
+          return {
+            items: migrateV12DesktopDefaultShortcuts(oldState.items, now),
             libraryState: oldState.libraryState || "loaded",
           };
         }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- **System 7** default desktop now shows **Chats**, **Internet Explorer**, and **Karaoke** right after **iPod** (they use `hiddenOnThemes` without `system7`, so they stay hidden on macosx / XP / 98 only).
- **Desktop sort**: `DEFAULT_SHORTCUT_ORDER` includes `karaoke` after IE; **Applications** folder shortcut sorts **after** iPod + those three on **system7** only.
- **Persist v13** migrates existing desktop aliases for those three apps off the full sparse list; **`ensureDefaultDesktopShortcuts`** repair pass does the same on load.

## Testing

Please run `bun run build` locally (Bun unavailable in cloud agent).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f3f114e3-47a8-49c1-95a6-5420c7f8df47"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f3f114e3-47a8-49c1-95a6-5420c7f8df47"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

