### PR TITLE
fix(build): guard optional aliasTarget in System 7 desktop migration

### DIFF
--- a/src/stores/useFilesStore.ts
+++ b/src/stores/useFilesStore.ts
@@ -616,6 +616,7 @@ function migrateV13System7ProminentDesktopApps(
       oldItem.status !== "active" ||
       getParentPath(oldItem.path) !== "/Desktop" ||
       oldItem.aliasType !== "app" ||
+      !oldItem.aliasTarget ||
       !SYSTEM7_PROMINENT_DESKTOP_APP_IDS.includes(oldItem.aliasTarget)
     ) {
       continue;
@@ -1486,6 +1487,7 @@ export const useFilesStore = create<FilesStoreState>()(
               }
               if (
                 item.aliasType === "app" &&
+                item.aliasTarget &&
                 SYSTEM7_PROMINENT_DESKTOP_APP_IDS.includes(item.aliasTarget)
               ) {
                 const h = item.hiddenOnThemes;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

`bun run build` was failing with two TypeScript errors:

```
src/stores/useFilesStore.ts(619,51): error TS2345: Argument of type 'string | undefined' is not assignable to parameter of type 'string'.
src/stores/useFilesStore.ts(1489,60): error TS2345: Argument of type 'string | undefined' is not assignable to parameter of type 'string'.
```

`FileSystemItem.aliasTarget` is typed as `string | undefined`, but two recent migration paths pass it directly into `SYSTEM7_PROMINENT_DESKTOP_APP_IDS.includes(...)`, which expects `string`.

## Fix

Added explicit `!!aliasTarget` / `item.aliasTarget &&` guards before the `includes` calls in:

- `migrateV13System7ProminentDesktopApps` (the v13 desktop migration)
- The inline "backfill for System 7 prominent desktop apps" block in the Zustand persisted migrator

Behavior is unchanged for items that have an `aliasTarget`, and items without a target are now correctly skipped instead of being treated as non-matches via `undefined`.

## Testing

- `bun run build` — passes end-to-end (tsc -b + vite build + PWA/service worker generation).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cfc2afda-4cde-4150-b387-c7fcd9523b02"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cfc2afda-4cde-4150-b387-c7fcd9523b02"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

