### PR TITLE
Open Karaoke Cover Flow from title art

### DIFF
--- a/src/apps/karaoke/components/KaraokeAppComponent.tsx
+++ b/src/apps/karaoke/components/KaraokeAppComponent.tsx
@@ -215,6 +215,13 @@ export function KaraokeAppComponent({
     [setDisplayMode, showStatus, t]
   );
 
+  const handleOpenCoverFlowFromTitleCard = useCallback(() => {
+    if (tracks.length === 0) return;
+    userHasInteractedRef.current = true;
+    restartAutoHideTimer();
+    setIsCoverFlowOpen(true);
+  }, [restartAutoHideTimer, setIsCoverFlowOpen, tracks.length, userHasInteractedRef]);
+
   const handleFullscreenLyricsSwipeUp = useCallback(() => {
     if (isOffline) {
       showOfflineStatus();
@@ -578,6 +585,7 @@ export function KaraokeAppComponent({
               handleNext={handleNext}
               handlePrevious={handlePrevious}
               seekToTime={seekToTime}
+              onOpenCoverFlow={handleOpenCoverFlowFromTitleCard}
               t={t}
               currentTrack={currentTrack}
               koreanDisplay={koreanDisplay}

--- a/src/apps/karaoke/components/KaraokeLyricsPlayback.tsx
+++ b/src/apps/karaoke/components/KaraokeLyricsPlayback.tsx
@@ -335,6 +335,8 @@ function KaraokeTitleCard({
   fontClassName,
   variant,
   coverUrl,
+  onOpenCoverFlow,
+  coverFlowLabel,
   bottomPaddingClass = "pb-12",
 }: {
   title: string;
@@ -343,6 +345,8 @@ function KaraokeTitleCard({
   fontClassName: string;
   variant: "window" | "fullscreen";
   coverUrl?: string | null;
+  onOpenCoverFlow?: () => void;
+  coverFlowLabel?: string;
   bottomPaddingClass?: string;
 }) {
   const styleCategory = getTitleCardStyleCategory(fontClassName);
@@ -454,6 +458,22 @@ function KaraokeTitleCard({
       >
         {coverUrl && (
           <div className="relative shrink-0" style={coverImageStyle}>
+            {onOpenCoverFlow && (
+              <button
+                type="button"
+                aria-label={coverFlowLabel}
+                title={coverFlowLabel}
+                className="absolute inset-0 z-10 p-0 border-0 bg-transparent cursor-pointer pointer-events-auto"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onOpenCoverFlow();
+                }}
+                onMouseDown={(e) => e.stopPropagation()}
+                onMouseUp={(e) => e.stopPropagation()}
+                onTouchStart={(e) => e.stopPropagation()}
+                onTouchEnd={(e) => e.stopPropagation()}
+              />
+            )}
             <div className="absolute inset-0 overflow-hidden" style={coverSleeveStyle}>
               <img
                 src={coverUrl}
@@ -520,6 +540,7 @@ interface WindowLyricsProps {
   handleNext: () => void;
   handlePrevious: () => void;
   seekToTime: (timeMs: number) => void;
+  onOpenCoverFlow?: () => void;
   t: TFunction;
   currentTrack: Track | null;
   koreanDisplay: KoreanDisplay;
@@ -542,6 +563,7 @@ export function KaraokeWindowLyricsOverlay({
   handleNext,
   handlePrevious,
   seekToTime,
+  onOpenCoverFlow,
   t,
   currentTrack,
   koreanDisplay,
@@ -601,6 +623,8 @@ export function KaraokeWindowLyricsOverlay({
               fontClassName={lyricsFontClassName}
               variant="window"
               coverUrl={coverUrl}
+              onOpenCoverFlow={onOpenCoverFlow}
+              coverFlowLabel={t("apps.ipod.menu.coverFlow")}
               bottomPaddingClass={bottomPadding}
             />
           )}

--- a/tests/test-karaoke-title-card.test.ts
+++ b/tests/test-karaoke-title-card.test.ts
@@ -1,9 +1,14 @@
 import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
 import type { LyricLine } from "@/types/lyrics";
 import {
   getFirstLyricStartMs,
   shouldShowKaraokeTitleCard,
 } from "@/apps/karaoke/utils/titleCard";
+
+const readSource = (relativePath: string): string =>
+  readFileSync(resolve(process.cwd(), relativePath), "utf-8");
 
 const line = (startTimeMs: string, words: string): LyricLine => ({
   startTimeMs,
@@ -95,5 +100,16 @@ describe("karaoke title card timing", () => {
         lyricOffsetMs: 2000,
       })
     ).toBe(false);
+  });
+
+  test("wires title card album art click to open cover flow", () => {
+    const lyricsSource = readSource("src/apps/karaoke/components/KaraokeLyricsPlayback.tsx");
+    const appSource = readSource("src/apps/karaoke/components/KaraokeAppComponent.tsx");
+
+    expect(lyricsSource.includes("onOpenCoverFlow?: () => void")).toBe(true);
+    expect(lyricsSource.includes("aria-label={coverFlowLabel}")).toBe(true);
+    expect(lyricsSource.includes("pointer-events-auto")).toBe(true);
+    expect(lyricsSource.includes("onOpenCoverFlow()")).toBe(true);
+    expect(appSource.includes("onOpenCoverFlow={handleOpenCoverFlowFromTitleCard}")).toBe(true);
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Adds a clickable title-card album-art hit target in Karaoke that opens the existing Cover Flow overlay.
- Keeps the rest of the title card passive so lyrics/player background clicks remain unchanged.
- Adds a guardrail test for the title-card Cover Flow wiring.

### Walkthrough
<a href="https://cursor.com/agents/bc-599cbe10-b761-4fda-af71-376336add81a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fkaraoke_title_art_opens_cover_flow_v2.webm"><img src="https://cursor.com/artifacts/c/art-3885e0a9-0a99-40ab-9ba5-ee1820ebb925" alt="karaoke_title_art_opens_cover_flow_v2.webm" /></a>
![Karaoke title card before Cover Flow](https://cursor.com/artifacts/c/art-0d3f3735-01a3-44e3-86c0-623ac82ca22f)
![Karaoke Cover Flow after album art click](https://cursor.com/artifacts/c/art-63338afc-1a21-431c-ac5d-c96f06559a58)

### Testing
- `PATH="/root/.bun/bin:$PATH" bun test tests/test-karaoke-title-card.test.ts`
- `PATH="/root/.bun/bin:$PATH" bun run build`
- Browser walkthrough against local `bun run dev` with seeded Karaoke tracks and title-card artwork.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-599cbe10-b761-4fda-af71-376336add81a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-599cbe10-b761-4fda-af71-376336add81a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

