### PR TITLE
feat(karaoke): open Cover Flow from title card album art

### DIFF
--- a/src/apps/karaoke/components/KaraokeAppComponent.tsx
+++ b/src/apps/karaoke/components/KaraokeAppComponent.tsx
@@ -166,6 +166,7 @@ export function KaraokeAppComponent({
     handleSendReaction,
     handlePlayTrack,
     handleToggleCoverFlow,
+    handleOpenCoverFlow,
     handleCoverFlowSelectTrack,
     handleCoverFlowPlayInPlace,
     handleCoverFlowRotation,
@@ -240,6 +241,12 @@ export function KaraokeAppComponent({
     showStatus,
     tracks,
   ]);
+
+  const handleTitleCardCoverClick = useCallback(() => {
+    userHasInteractedRef.current = true;
+    registerActivity();
+    handleOpenCoverFlow();
+  }, [handleOpenCoverFlow, registerActivity]);
 
   const handleFullscreenLyricsSwipeDown = useCallback(() => {
     if (isOffline) {
@@ -583,6 +590,7 @@ export function KaraokeAppComponent({
               koreanDisplay={koreanDisplay}
               japaneseFurigana={japaneseFurigana}
               lyricsAlignment={lyricsAlignment}
+              onTitleCardCoverClick={handleTitleCardCoverClick}
             />
             <KaraokeLyricsActivityIndicator />
             <KaraokeSyncModeWindowPanel
@@ -1013,6 +1021,7 @@ export function KaraokeAppComponent({
                   lyricsAlignment={lyricsAlignment}
                   onSwipeUp={handleFullscreenLyricsSwipeUp}
                   onSwipeDown={handleFullscreenLyricsSwipeDown}
+                  onTitleCardCoverClick={handleTitleCardCoverClick}
                 />
               </div>
             </div>

--- a/src/apps/karaoke/components/KaraokeLyricsPlayback.tsx
+++ b/src/apps/karaoke/components/KaraokeLyricsPlayback.tsx
@@ -336,6 +336,8 @@ function KaraokeTitleCard({
   variant,
   coverUrl,
   bottomPaddingClass = "pb-12",
+  onCoverClick,
+  coverArtAriaLabel,
 }: {
   title: string;
   artist?: string;
@@ -344,6 +346,9 @@ function KaraokeTitleCard({
   variant: "window" | "fullscreen";
   coverUrl?: string | null;
   bottomPaddingClass?: string;
+  /** When set, album art opens Cover Flow (parent handles empty library). */
+  onCoverClick?: () => void;
+  coverArtAriaLabel?: string;
 }) {
   const styleCategory = getTitleCardStyleCategory(fontClassName);
   const palette = useCoverPalette(styleCategory === "glow-gold" ? (coverUrl ?? null) : null);
@@ -454,14 +459,34 @@ function KaraokeTitleCard({
       >
         {coverUrl && (
           <div className="relative shrink-0" style={coverImageStyle}>
-            <div className="absolute inset-0 overflow-hidden" style={coverSleeveStyle}>
-              <img
-                src={coverUrl}
-                alt=""
-                className="w-full h-full object-cover"
-                draggable={false}
-              />
-            </div>
+            {onCoverClick ? (
+              <button
+                type="button"
+                className="absolute inset-0 z-[1] overflow-hidden cursor-pointer p-0 border-0 bg-transparent appearance-none text-left rounded-[1%] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white/80 pointer-events-auto"
+                style={coverSleeveStyle}
+                aria-label={coverArtAriaLabel}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onCoverClick();
+                }}
+              >
+                <img
+                  src={coverUrl}
+                  alt=""
+                  className="w-full h-full object-cover pointer-events-none"
+                  draggable={false}
+                />
+              </button>
+            ) : (
+              <div className="absolute inset-0 overflow-hidden" style={coverSleeveStyle}>
+                <img
+                  src={coverUrl}
+                  alt=""
+                  className="w-full h-full object-cover"
+                  draggable={false}
+                />
+              </div>
+            )}
             <div
               className="absolute top-full left-0 w-full pointer-events-none"
               style={{ height: "50%" }}
@@ -525,6 +550,7 @@ interface WindowLyricsProps {
   koreanDisplay: KoreanDisplay;
   japaneseFurigana: JapaneseFurigana;
   lyricsAlignment: LyricsAlignment;
+  onTitleCardCoverClick?: () => void;
 }
 
 export function KaraokeWindowLyricsOverlay({
@@ -547,6 +573,7 @@ export function KaraokeWindowLyricsOverlay({
   koreanDisplay,
   japaneseFurigana,
   lyricsAlignment,
+  onTitleCardCoverClick,
 }: WindowLyricsProps) {
   const {
     lyricsControls,
@@ -602,6 +629,8 @@ export function KaraokeWindowLyricsOverlay({
               variant="window"
               coverUrl={coverUrl}
               bottomPaddingClass={bottomPadding}
+              onCoverClick={onTitleCardCoverClick}
+              coverArtAriaLabel={t("apps.ipod.menu.coverFlow")}
             />
           )}
         </AnimatePresence>
@@ -666,6 +695,7 @@ interface FullscreenLyricsProps {
   /** When set (e.g. fullscreen), replaces default next/previous swipe behavior */
   onSwipeUp?: () => void;
   onSwipeDown?: () => void;
+  onTitleCardCoverClick?: () => void;
 }
 
 export function KaraokeFullscreenLyricsOverlay({
@@ -687,6 +717,7 @@ export function KaraokeFullscreenLyricsOverlay({
   lyricsAlignment,
   onSwipeUp: onSwipeUpOverride,
   onSwipeDown: onSwipeDownOverride,
+  onTitleCardCoverClick,
 }: FullscreenLyricsProps) {
   const {
     lyricsControls,
@@ -741,6 +772,8 @@ export function KaraokeFullscreenLyricsOverlay({
               variant="fullscreen"
               coverUrl={coverUrl}
               bottomPaddingClass={bottomPadding}
+              onCoverClick={onTitleCardCoverClick}
+              coverArtAriaLabel={t("apps.ipod.menu.coverFlow")}
             />
           )}
         </AnimatePresence>

--- a/src/apps/karaoke/hooks/useKaraokeLogic.ts
+++ b/src/apps/karaoke/hooks/useKaraokeLogic.ts
@@ -1287,6 +1287,13 @@ export function useKaraokeLogic({
     }
   }, [isCoverFlowOpen, tracks.length]);
 
+  /** Open Cover Flow without toggling closed (e.g. title card album art). */
+  const handleOpenCoverFlow = useCallback(() => {
+    if (tracks.length > 0) {
+      setIsCoverFlowOpen(true);
+    }
+  }, [tracks.length]);
+
   // CoverFlow track selection handler
   const handleCoverFlowSelectTrack = useCallback(
     (index: number) => {
@@ -1682,6 +1689,7 @@ export function useKaraokeLogic({
     handleAddUrl,
     handlePlayTrack,
     handleToggleCoverFlow,
+    handleOpenCoverFlow,
     handleCoverFlowSelectTrack,
     handleCoverFlowPlayInPlace,
     handleCoverFlowRotation,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- **Title card**: When lyrics are on and the intro title card shows album art, the art is a focusable button (`aria-label` uses the existing iPod Cover Flow menu string). Click/tap opens Cover Flow and does not steal clicks from the rest of the screen (only the sleeve area uses `pointer-events-auto`).
- **Hook**: Added `handleOpenCoverFlow` so opening from the title card always shows Cover Flow when the library has tracks, without toggling it closed if it was already open (unlike `handleToggleCoverFlow`).
- **App**: Wired `onTitleCardCoverClick` for window and fullscreen lyrics overlays; marks user interaction and `registerActivity()` for autoplay / UI timers.

## Testing

- `PATH="/root/.bun/bin:$PATH" bun run build` — TypeScript + Vite production build succeeded.

No browser walkthrough: AGENTS.md says to skip GUI testing unless requested; change is a small click handler plus build verification.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-266e8060-4cd8-47f8-a2f8-7d79b1dd7523"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-266e8060-4cd8-47f8-a2f8-7d79b1dd7523"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

