### PR TITLE
Default Korean romanization on for Karaoke lyrics

### DIFF
--- a/src/apps/ipod/components/IpodMenuBar.tsx
+++ b/src/apps/ipod/components/IpodMenuBar.tsx
@@ -462,7 +462,7 @@ export function IpodMenuBar({
                 {t("apps.ipod.menu.japaneseRomaji")}
               </MenubarCheckboxItem>
               <MenubarCheckboxItem
-                checked={romanization?.korean ?? false}
+                checked={romanization?.korean ?? true}
                 onCheckedChange={(checked) =>
                   setRomanization({ korean: checked })
                 }

--- a/src/apps/karaoke/components/KaraokeMenuBar.tsx
+++ b/src/apps/karaoke/components/KaraokeMenuBar.tsx
@@ -529,7 +529,7 @@ export function KaraokeMenuBar({
                 {t("apps.ipod.menu.japaneseRomaji")}
               </MenubarCheckboxItem>
               <MenubarCheckboxItem
-                checked={romanization?.korean ?? false}
+                checked={romanization?.korean ?? true}
                 onCheckedChange={(checked) =>
                   setRomanization({ korean: checked })
                 }

--- a/src/stores/useIpodStore.ts
+++ b/src/stores/useIpodStore.ts
@@ -209,7 +209,7 @@ const initialIpodData: IpodData = {
     enabled: true,
     japaneseFurigana: true,
     japaneseRomaji: false,
-    korean: false,
+    korean: true,
     chinese: false,
     soramimi: false,
     soramamiTargetLanguage: "zh-TW",
@@ -310,7 +310,7 @@ export interface IpodState extends IpodData {
   setTotalTime: (time: number) => void;
 }
 
-const CURRENT_IPOD_STORE_VERSION = 31; // Default lyrics font to red serif
+const CURRENT_IPOD_STORE_VERSION = 32; // Korean romanization on by default for lyrics
 
 // Helper function to get unplayed track IDs from history
 function getUnplayedTrackIds(
@@ -1557,14 +1557,13 @@ export const useIpodStore = create<IpodState>()(
           );
           
           // Migrate old romanization settings to new unified format
-          const oldKoreanDisplay = state.koreanDisplay as string | undefined;
           const oldJapaneseFurigana = state.japaneseFurigana as string | undefined;
           
           const romanization: RomanizationSettings = state.romanization ?? {
             enabled: true,
             japaneseFurigana: oldJapaneseFurigana === JapaneseFurigana.On || oldJapaneseFurigana === "on" || oldJapaneseFurigana === undefined,
             japaneseRomaji: false,
-            korean: oldKoreanDisplay === KoreanDisplay.Romanized || oldKoreanDisplay === "romanized",
+            korean: true,
             chinese: false,
             soramimi: false,
             soramamiTargetLanguage: "zh-TW",
@@ -1592,6 +1591,11 @@ export const useIpodStore = create<IpodState>()(
           // Ensure existing romanization settings have pronunciationOnly
           if (state.romanization && state.romanization.pronunciationOnly === undefined) {
             state.romanization.pronunciationOnly = false;
+          }
+
+          // Turn on Korean romanization for all users upgrading to this version (new default)
+          if (state.romanization && state.romanization.korean === false) {
+            state.romanization.korean = true;
           }
 
           const shouldUpgradeLegacyDefaultLyricsFont =


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Karaoke reads lyrics romanization from the shared iPod store (`useIpodStore`). This change turns **Korean romanization** on by default for new sessions and upgrades existing persisted stores that had it off.

## Changes

- Default `romanization.korean` to `true` in `initialIpodData`.
- Bump persisted store version to **32** and set `korean: true` when migrating from older versions if it was `false` (one-time alignment with the new default).
- Karaoke and iPod menu checkboxes use `?? true` so the UI matches when romanization is absent.

## Testing

- `bun run build` (TypeScript + Vite) succeeded on this branch.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0ff5c37c-f624-47d6-92a3-e3b8c87f9524"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0ff5c37c-f624-47d6-92a3-e3b8c87f9524"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

