### PR TITLE
Default desktop wallpaper to nature earth_horizon

### DIFF
--- a/src/apps/control-panels/hooks/useControlPanelsLogic.ts
+++ b/src/apps/control-panels/hooks/useControlPanelsLogic.ts
@@ -11,6 +11,7 @@ import {
   useAudioSettingsStoreShallow,
   useDisplaySettingsStoreShallow,
 } from "@/stores/helpers";
+import { DEFAULT_WALLPAPER_PATH } from "@/stores/useDisplaySettingsStore";
 import { setNextBootMessage, clearNextBootMessage } from "@/utils/bootMessage";
 import { clearPrefetchFlag, forceRefreshCache } from "@/utils/prefetch";
 import { AI_MODEL_METADATA } from "@/types/aiModels";
@@ -1479,7 +1480,7 @@ export function useControlPanelsLogic({
 
   const performFormat = async () => {
     // Reset wallpaper to default before formatting
-    setCurrentWallpaper("/wallpapers/photos/aqua/water.jpg");
+    setCurrentWallpaper(DEFAULT_WALLPAPER_PATH);
     await formatFileSystem();
     clearPrefetchFlag(); // Force re-prefetch on next boot
     setNextBootMessage(t("common.system.formattingFileSystem"));

--- a/src/stores/useDisplaySettingsStore.ts
+++ b/src/stores/useDisplaySettingsStore.ts
@@ -11,6 +11,10 @@ import {
 import { convertImageFileToWallpaperJpeg } from "@/utils/customWallpaperProcessing";
 import { useCloudSyncStore } from "@/stores/useCloudSyncStore";
 
+/** Default desktop wallpaper (nature photo). */
+export const DEFAULT_WALLPAPER_PATH =
+  "/wallpapers/photos/nature/earth_horizon.jpg";
+
 /**
  * Display settings store - manages wallpaper, shaders, and screen saver settings.
  * Extracted from useAppStore to reduce complexity and improve separation of concerns.
@@ -112,7 +116,8 @@ interface DisplaySettingsState {
   bumpCustomWallpapersRevision: () => void;
 }
 
-const STORE_VERSION = 1;
+const LEGACY_DEFAULT_WALLPAPER_PATH = "/wallpapers/photos/aqua/water.jpg";
+const STORE_VERSION = 2; // default wallpaper → nature earth_horizon
 const initialShaderState = checkShaderPerformance();
 
 export const useDisplaySettingsStore = create<DisplaySettingsState>()(
@@ -129,8 +134,8 @@ export const useDisplaySettingsStore = create<DisplaySettingsState>()(
       setSelectedShaderType: (t) => set({ selectedShaderType: t }),
 
       // Wallpaper
-      currentWallpaper: "/wallpapers/photos/aqua/water.jpg",
-      wallpaperSource: "/wallpapers/photos/aqua/water.jpg",
+      currentWallpaper: DEFAULT_WALLPAPER_PATH,
+      wallpaperSource: DEFAULT_WALLPAPER_PATH,
       setCurrentWallpaper: (p) => set({ currentWallpaper: p, wallpaperSource: p }),
 
       setWallpaper: async (path) => {
@@ -207,8 +212,8 @@ export const useDisplaySettingsStore = create<DisplaySettingsState>()(
           }
           if (get().currentWallpaper === reference) {
             set({
-              currentWallpaper: "/wallpapers/photos/aqua/water.jpg",
-              wallpaperSource: "/wallpapers/photos/aqua/water.jpg",
+              currentWallpaper: DEFAULT_WALLPAPER_PATH,
+              wallpaperSource: DEFAULT_WALLPAPER_PATH,
             });
           }
           get().bumpCustomWallpapersRevision();
@@ -275,6 +280,24 @@ export const useDisplaySettingsStore = create<DisplaySettingsState>()(
     {
       name: "ryos:display-settings",
       version: STORE_VERSION,
+      migrate: (persistedState, version) => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const s = persistedState as any;
+        if (version >= 2) return s;
+        const cw = s.currentWallpaper as string | undefined;
+        const ws = s.wallpaperSource as string | undefined;
+        if (
+          cw === LEGACY_DEFAULT_WALLPAPER_PATH &&
+          ws === LEGACY_DEFAULT_WALLPAPER_PATH
+        ) {
+          return {
+            ...s,
+            currentWallpaper: DEFAULT_WALLPAPER_PATH,
+            wallpaperSource: DEFAULT_WALLPAPER_PATH,
+          };
+        }
+        return s;
+      },
       partialize: (state) => ({
         displayMode: state.displayMode,
         shaderEffectEnabled: state.shaderEffectEnabled,

--- a/src/stores/useDisplaySettingsStore.ts
+++ b/src/stores/useDisplaySettingsStore.ts
@@ -116,8 +116,7 @@ interface DisplaySettingsState {
   bumpCustomWallpapersRevision: () => void;
 }
 
-const LEGACY_DEFAULT_WALLPAPER_PATH = "/wallpapers/photos/aqua/water.jpg";
-const STORE_VERSION = 2; // default wallpaper → nature earth_horizon
+const STORE_VERSION = 2;
 const initialShaderState = checkShaderPerformance();
 
 export const useDisplaySettingsStore = create<DisplaySettingsState>()(
@@ -280,24 +279,6 @@ export const useDisplaySettingsStore = create<DisplaySettingsState>()(
     {
       name: "ryos:display-settings",
       version: STORE_VERSION,
-      migrate: (persistedState, version) => {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const s = persistedState as any;
-        if (version >= 2) return s;
-        const cw = s.currentWallpaper as string | undefined;
-        const ws = s.wallpaperSource as string | undefined;
-        if (
-          cw === LEGACY_DEFAULT_WALLPAPER_PATH &&
-          ws === LEGACY_DEFAULT_WALLPAPER_PATH
-        ) {
-          return {
-            ...s,
-            currentWallpaper: DEFAULT_WALLPAPER_PATH,
-            wallpaperSource: DEFAULT_WALLPAPER_PATH,
-          };
-        }
-        return s;
-      },
       partialize: (state) => ({
         displayMode: state.displayMode,
         shaderEffectEnabled: state.shaderEffectEnabled,

--- a/src/stores/useDisplaySettingsStore.ts
+++ b/src/stores/useDisplaySettingsStore.ts
@@ -116,7 +116,7 @@ interface DisplaySettingsState {
   bumpCustomWallpapersRevision: () => void;
 }
 
-const STORE_VERSION = 2;
+const STORE_VERSION = 1;
 const initialShaderState = checkShaderPerformance();
 
 export const useDisplaySettingsStore = create<DisplaySettingsState>()(

--- a/src/sync/domains.ts
+++ b/src/sync/domains.ts
@@ -3,7 +3,10 @@ import { ensureIndexedDBInitialized, STORES } from "@/utils/indexedDB";
 import { getApiUrl } from "@/utils/platform";
 import { useThemeStore } from "@/stores/useThemeStore";
 import { useLanguageStore } from "@/stores/useLanguageStore";
-import { useDisplaySettingsStore } from "@/stores/useDisplaySettingsStore";
+import {
+  DEFAULT_WALLPAPER_PATH,
+  useDisplaySettingsStore,
+} from "@/stores/useDisplaySettingsStore";
 import { useAudioSettingsStore } from "@/stores/useAudioSettingsStore";
 import { useAppStore } from "@/stores/useAppStore";
 import { useFilesStore, type FileSystemItem } from "@/stores/useFilesStore";
@@ -1191,8 +1194,8 @@ async function finalizeCustomWallpaperSync(remoteKeys: Iterable<string>): Promis
       await displayStore.setWallpaper(current);
     } else {
       useDisplaySettingsStore.setState({
-        currentWallpaper: "/wallpapers/photos/aqua/water.jpg",
-        wallpaperSource: "/wallpapers/photos/aqua/water.jpg",
+        currentWallpaper: DEFAULT_WALLPAPER_PATH,
+        wallpaperSource: DEFAULT_WALLPAPER_PATH,
       });
     }
   }

--- a/tests/test-wallpaper-cloud-sync-debug.test.ts
+++ b/tests/test-wallpaper-cloud-sync-debug.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { subscribeToCloudSyncCheckRequests } from "../src/utils/cloudSyncEvents";
+import { subscribeToCloudSyncDomainCheckRequests } from "../src/utils/cloudSyncEvents";
 import { planIndividualBlobDownload } from "../src/utils/cloudSyncIndividualBlobMerge";
 import { shouldApplyRemoteUpdate } from "../src/utils/cloudSyncShared";
 
@@ -95,18 +95,18 @@ describe("wallpaper cloud sync debug reproduction", () => {
     } as unknown as new (type: string, init?: unknown) => unknown;
     browserGlobals.localStorage = new MemoryStorage();
 
-    const { useDisplaySettingsStore } = await import(
+    const { useDisplaySettingsStore, DEFAULT_WALLPAPER_PATH } = await import(
       "../src/stores/useDisplaySettingsStore"
     );
-    let syncChecks = 0;
-    const unsubscribe = subscribeToCloudSyncCheckRequests(() => {
-      syncChecks += 1;
+    let syncDomainChecks: string[] = [];
+    const unsubscribe = subscribeToCloudSyncDomainCheckRequests((domain) => {
+      syncDomainChecks.push(domain);
     });
 
     try {
       useDisplaySettingsStore.setState({
-        currentWallpaper: "/wallpapers/photos/aqua/water.jpg",
-        wallpaperSource: "/wallpapers/photos/aqua/water.jpg",
+        currentWallpaper: DEFAULT_WALLPAPER_PATH,
+        wallpaperSource: DEFAULT_WALLPAPER_PATH,
         getWallpaperData: async () => null,
       });
 
@@ -118,9 +118,9 @@ describe("wallpaper cloud sync debug reproduction", () => {
         "indexeddb://wallpaper-1"
       );
       expect(useDisplaySettingsStore.getState().wallpaperSource).toBe(
-        "/wallpapers/photos/aqua/water.jpg"
+        DEFAULT_WALLPAPER_PATH
       );
-      expect(syncChecks).toBe(1);
+      expect(syncDomainChecks).toEqual(["custom-wallpapers"]);
     } finally {
       unsubscribe();
       browserGlobals.window = originalWindow;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets the system default desktop wallpaper to **Nature → Earth horizon** (`/wallpapers/photos/nature/earth_horizon.jpg`).

## Details

- `DEFAULT_WALLPAPER_PATH` in `useDisplaySettingsStore.ts` for initial state, deleting the active custom wallpaper, and persist **version 1** (no migrations).
- Control Panels format reset and custom-wallpaper cloud sync fallback use the same constant.
- `tests/test-wallpaper-cloud-sync-debug.test.ts`: uses `DEFAULT_WALLPAPER_PATH` and `subscribeToCloudSyncDomainCheckRequests`.

## Testing

- `bun run build`
- `bun test tests/test-wallpaper-cloud-sync-debug.test.ts`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0ff5c37c-f624-47d6-92a3-e3b8c87f9524"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0ff5c37c-f624-47d6-92a3-e3b8c87f9524"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

