### PR TITLE
tv: exclude YouTube Shorts from create-channel

### DIFF
--- a/api/tv/create-channel.ts
+++ b/api/tv/create-channel.ts
@@ -4,10 +4,12 @@
  * Flow:
  *   1. Take a one-line user description ("skateboarding tricks", "lofi study").
  *   2. Ask the model for a short channel name + 2-3 diverse YouTube search
- *      queries that would surface fitting videos.
+ *      queries that would surface fitting videos. The planner is instructed
+ *      to avoid Shorts-oriented query phrasings.
  *   3. Run each query against the YouTube Data API (rotating across the keys
  *      already configured for /api/youtube-search).
- *   4. De-dup by video id, return a ready-to-use Channel payload.
+ *   4. De-dup by video id, hydrate durations via videos.list, and drop
+ *      YouTube Shorts (≤ 60s) from the lineup before returning.
  */
 
 import { google } from "@ai-sdk/google";
@@ -61,6 +63,16 @@ interface YouTubeSearchResponse {
   error?: { code: number; message: string };
 }
 
+interface YouTubeVideoDetailsItem {
+  id: string;
+  contentDetails?: { duration?: string };
+}
+
+interface YouTubeVideosListResponse {
+  items?: YouTubeVideoDetailsItem[];
+  error?: { code: number; message: string };
+}
+
 interface ChannelVideo {
   id: string;
   url: string;
@@ -68,12 +80,34 @@ interface ChannelVideo {
   artist: string;
 }
 
+/**
+ * Videos with a non-empty duration ≤ this many seconds are treated as
+ * YouTube Shorts and excluded from generated channels. Conservative threshold
+ * that catches the vast majority of Shorts without dropping legitimate short
+ * music videos / clips.
+ */
+const SHORTS_MAX_DURATION_SECONDS = 60;
+
+/**
+ * Parse an ISO 8601 duration like "PT1M5S", "PT45S", "PT1H2M3S" into total
+ * seconds. Returns null if the input doesn't look like a duration.
+ */
+function parseIsoDurationSeconds(value: string | undefined): number | null {
+  if (!value) return null;
+  const match = /^P(?:\d+D)?T(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?$/.exec(value);
+  if (!match) return null;
+  const hours = match[1] ? parseInt(match[1], 10) : 0;
+  const minutes = match[2] ? parseInt(match[2], 10) : 0;
+  const seconds = match[3] ? parseInt(match[3], 10) : 0;
+  return hours * 3600 + minutes * 60 + seconds;
+}
+
 const SYSTEM_PROMPT = `You design themed YouTube "TV channels" for a retro desktop OS.
 Given a short description, return a punchy channel name, a one-line tagline, and 2-4 diverse YouTube search queries that will surface a varied lineup of videos for the channel.
 Rules:
 - Channel name: 1-3 words, evocative, NOT generic. Avoid the words "TV", "Channel", or "Network" alone unless paired distinctively (e.g. "MTV", "アニメTV").
 - Tagline: one short sentence, present-tense, no period at the end.
-- Queries: each query is its own YouTube search; vary angles (themes, decades, sub-topics) so we don't get duplicates. Use plain search terms — do NOT include site: filters or quotes.
+- Queries: each query is its own YouTube search; vary angles (themes, decades, sub-topics) so we don't get duplicates. Use plain search terms — do NOT include site: filters or quotes. Do NOT search for YouTube Shorts: never include the words "shorts", "short", "#shorts", "tiktok", or "reels" in any query, and avoid query phrasings that primarily surface vertical/sub-minute clips.
 - All output strings should be in the same language as the user's description; keep proper nouns / titles in their original language.
 Respond with ONLY the structured object. No prose.`;
 
@@ -131,6 +165,61 @@ async function searchOneQuery(
       }));
   }
   return [];
+}
+
+/**
+ * Fetch ISO 8601 durations for the given video ids via the YouTube videos.list
+ * endpoint. Rotates across keys on quota errors. Returns a Map keyed by video
+ * id; ids missing from the response (e.g. removed videos) are absent.
+ *
+ * Batches up to 50 ids per request, which is the YouTube API max for
+ * videos.list.
+ */
+async function fetchVideoDurations(
+  videoIds: string[],
+  apiKeys: string[]
+): Promise<Map<string, number>> {
+  const durations = new Map<string, number>();
+  if (videoIds.length === 0) return durations;
+
+  const BATCH_SIZE = 50;
+  for (let start = 0; start < videoIds.length; start += BATCH_SIZE) {
+    const batch = videoIds.slice(start, start + BATCH_SIZE);
+    let fetched: YouTubeVideosListResponse | null = null;
+
+    for (let i = 0; i < apiKeys.length; i++) {
+      const apiKey = apiKeys[i];
+      const url = new URL("https://www.googleapis.com/youtube/v3/videos");
+      url.searchParams.set("part", "contentDetails");
+      url.searchParams.set("id", batch.join(","));
+      url.searchParams.set("key", apiKey);
+
+      const res = await fetch(url.toString());
+      const data = (await res.json()) as YouTubeVideosListResponse;
+
+      if (!res.ok || data.error) {
+        const message = data.error?.message?.toLowerCase() ?? "";
+        const isQuota =
+          res.status === 403 &&
+          (message.includes("quota") ||
+            message.includes("exceeded") ||
+            message.includes("limit"));
+        if (isQuota && i < apiKeys.length - 1) continue;
+        throw new Error(
+          data.error?.message || `YouTube API error (${res.status})`
+        );
+      }
+      fetched = data;
+      break;
+    }
+
+    if (!fetched) continue;
+    for (const item of fetched.items ?? []) {
+      const seconds = parseIsoDurationSeconds(item.contentDetails?.duration);
+      if (seconds !== null) durations.set(item.id, seconds);
+    }
+  }
+  return durations;
 }
 
 export default apiHandler<CreateChannelRequest>(
@@ -256,9 +345,11 @@ export default apiHandler<CreateChannelRequest>(
 
     // Step 2: Fan out YouTube searches.
     const TARGET_TOTAL = 24;
+    // Over-fetch a bit so the post-filter (drop YouTube Shorts) still leaves
+    // enough videos to fill the channel.
     const perQuery = Math.max(
-      6,
-      Math.ceil(TARGET_TOTAL / plan.queries.length)
+      8,
+      Math.ceil((TARGET_TOTAL * 1.5) / plan.queries.length)
     );
 
     const settled = await Promise.allSettled(
@@ -266,7 +357,7 @@ export default apiHandler<CreateChannelRequest>(
     );
 
     const seen = new Set<string>();
-    const videos: ChannelVideo[] = [];
+    const candidates: ChannelVideo[] = [];
     for (const result of settled) {
       if (result.status !== "fulfilled") {
         logger.warn("Search query failed", {
@@ -280,14 +371,48 @@ export default apiHandler<CreateChannelRequest>(
       for (const v of result.value) {
         if (seen.has(v.id)) continue;
         seen.add(v.id);
-        videos.push(v);
-        if (videos.length >= TARGET_TOTAL) break;
+        candidates.push(v);
       }
+    }
+
+    // Step 3: Drop YouTube Shorts. We hydrate durations via videos.list and
+    // filter out anything ≤ SHORTS_MAX_DURATION_SECONDS. If we can't determine
+    // a duration (e.g. videos.list fails entirely), fall back to keeping the
+    // candidate so a transient API blip doesn't return an empty channel.
+    let durations: Map<string, number> = new Map();
+    try {
+      durations = await fetchVideoDurations(
+        candidates.map((c) => c.id),
+        apiKeys
+      );
+    } catch (err) {
+      logger.warn("Failed to fetch video durations; skipping shorts filter", {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+
+    const videos: ChannelVideo[] = [];
+    let droppedShorts = 0;
+    for (const candidate of candidates) {
+      const seconds = durations.get(candidate.id);
+      if (
+        seconds !== undefined &&
+        seconds > 0 &&
+        seconds <= SHORTS_MAX_DURATION_SECONDS
+      ) {
+        droppedShorts++;
+        continue;
+      }
+      videos.push(candidate);
       if (videos.length >= TARGET_TOTAL) break;
     }
 
     if (videos.length === 0) {
-      logger.error("No videos found for any query", { queries: plan.queries });
+      logger.error("No videos found for any query", {
+        queries: plan.queries,
+        droppedShorts,
+        candidateCount: candidates.length,
+      });
       logger.response(404, Date.now() - startTime);
       res
         .status(404)
@@ -298,6 +423,7 @@ export default apiHandler<CreateChannelRequest>(
     logger.info("Channel created", {
       name: plan.name,
       videoCount: videos.length,
+      droppedShorts,
     });
     logger.response(200, Date.now() - startTime);
     res.status(200).json({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The TV "Create Channel" feature now actively avoids YouTube Shorts in two layers:

1. **Planner side.** The system prompt instructs the channel-plan model to never include Shorts-oriented terms (`shorts`, `#shorts`, `tiktok`, `reels`, etc.) in its YouTube search queries, and to avoid phrasings that primarily surface vertical/sub-minute clips.
2. **Server side.** After fanning out the search queries, candidate video ids are hydrated via the YouTube `videos.list` (`contentDetails`) endpoint and any clip with a duration ≤ 60s is dropped before the lineup is returned.

To keep the channel full after filtering, per-query result counts are over-fetched (1.5× the 24-video target). If `videos.list` fails entirely we fall back to keeping the un-filtered candidates so a transient API blip can't return an empty channel.

## Files

- `api/tv/create-channel.ts` — system-prompt rule, new `parseIsoDurationSeconds` + `fetchVideoDurations` helpers, post-search shorts filter, updated header doc.

## Testing

- ✅ `bun run build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-35e3914d-21c0-43b2-bd91-0772d33d01fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-35e3914d-21c0-43b2-bd91-0772d33d01fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

