### PR TITLE
tv: power back on when paused user hits Next/Prev/CH

### DIFF
--- a/src/apps/tv/components/TvAppComponent.tsx
+++ b/src/apps/tv/components/TvAppComponent.tsx
@@ -746,18 +746,10 @@ export function TvAppComponent({
     />
   );
 
-  // Power-off shader runs *before* the window-frame close animation.
-  // We intercept the close, play the CRT collapse, then dispatch the
-  // standard close-confirmation event WindowFrame listens for.
-  const handleInterceptedClose = () => {
-    if (poweringOff) return;
-    setPoweringOff(true);
-    stopStatic();
-    void playPowerOff();
-  };
-
-  const handlePowerOffComplete = () => {
-    // Tell WindowFrame to actually run its close animation + cleanup.
+  // Tell WindowFrame to actually run its close animation + cleanup.
+  // Used both by the natural power-off completion path and the
+  // already-paused short-circuit below.
+  const dispatchWindowClose = () => {
     if (!instanceId) {
       // Non-instance fallback: just call the prop. (Shouldn't happen
       // in practice — TV is always instance-mounted — but keep it
@@ -770,6 +762,31 @@ export function TvAppComponent({
         detail: { onComplete: onClose },
       })
     );
+  };
+
+  // Power-off shader runs *before* the window-frame close animation.
+  // We intercept the close, play the CRT collapse, then dispatch the
+  // standard close-confirmation event WindowFrame listens for.
+  //
+  // Short-circuit: if the screen is already off (user paused the TV
+  // and is now closing), skip the 750ms squeeze + sound — it's
+  // already black, replaying the animation just delays the close
+  // without any visible benefit. Also stops the static bed in case
+  // it was somehow still running.
+  const handleInterceptedClose = () => {
+    if (poweringOff) return;
+    if (screenOff) {
+      stopStatic();
+      dispatchWindowClose();
+      return;
+    }
+    setPoweringOff(true);
+    stopStatic();
+    void playPowerOff();
+  };
+
+  const handlePowerOffComplete = () => {
+    dispatchWindowClose();
   };
 
   if (!isWindowOpen) return null;

--- a/src/apps/tv/components/TvAppComponent.tsx
+++ b/src/apps/tv/components/TvAppComponent.tsx
@@ -605,11 +605,16 @@ export function TvAppComponent({
   // Suppression rules:
   //   - Buffering transitions are ignored (YouTube briefly toggles
   //     play state during buffer events).
-  //   - Channel-switch / video-id transitions are also ignored: when
+  //   - Channel-switch / video-id transitions are mostly ignored: when
   //     the video changes, isBuffering is reset and the new video's
   //     onBuffer/onPlay/onPause events arrive in an unpredictable
-  //     order. Without this, a switch from paused → new channel
-  //     could double-fire (channel-switch burst + spurious power-on).
+  //     order. Without this, a play → channel-switch flow could
+  //     double-fire (channel-switch burst + spurious power-on shader).
+  //     The exception is "screen-off → next/prev/CH+ while paused":
+  //     screenOff stays true unless we explicitly turn it back on, so
+  //     a user-initiated playback action (which sets isPlaying true)
+  //     while screenOff is true must trigger the power-on even though
+  //     the video id also changed.
   //   - Powering off / closing: don't react to anything; we're
   //     tearing down.
   const prevPlayingRef = useRef(isPlaying);
@@ -622,6 +627,20 @@ export function TvAppComponent({
       prevVideoIdRef.current = currentVideoId;
       return;
     }
+
+    // Resume-from-paused via Next/Prev/CH+/CH-: setIsPlaying(true) plus
+    // a video/channel change land in the same render. Power back on
+    // first, then let the channel-switch / buffer logic handle the
+    // rest of the visual choreography.
+    if (screenOff && isPlaying) {
+      setScreenOff(false);
+      setPowerOnKey((k) => k + 1);
+      void playPowerOn();
+      prevPlayingRef.current = isPlaying;
+      prevVideoIdRef.current = currentVideoId;
+      return;
+    }
+
     if (isBuffering) {
       prevPlayingRef.current = isPlaying;
       prevVideoIdRef.current = currentVideoId;
@@ -655,6 +674,7 @@ export function TvAppComponent({
     isWindowOpen,
     isBuffering,
     poweringOff,
+    screenOff,
     currentVideo?.id,
     playPowerOff,
     playPowerOn,

--- a/src/apps/tv/components/TvCrtEffects.tsx
+++ b/src/apps/tv/components/TvCrtEffects.tsx
@@ -334,9 +334,10 @@ function PowerOffEffect({
   const totalSec = POWER_OFF_DURATION_MS / 1000;
   // Phase milestones (as fractions of totalSec):
   //   0.00 .. 0.30  bars close in from top/bottom (cubic ease-in)
-  //   0.30 .. 0.42  beam fades up at the slit, holds bright
-  //   0.40 .. 0.62  black fill takes over; beam fades out
-  //   0.40 .. 0.92  center dot brightens, holds, then collapses + fades
+  //   0.22 .. 0.44  beam fades up at the slit, holds full width briefly
+  //   0.40 .. 0.55  black fill takes over the rest of the screen
+  //   0.44 .. 0.70  beam collapses horizontally toward center
+  //   0.55 .. 0.94  center dot fades in, holds, then collapses + fades
 
   return (
     <AnimatePresence>
@@ -391,47 +392,54 @@ function PowerOffEffect({
             className="absolute inset-0 bg-black"
           />
 
-          {/* Bright horizontal beam at the slit. The dot below handles
-              the collapse-to-a-point — this beam just fades out cleanly
-              after the bars close, instead of also scaling to a sliver
-              (which would leave a thin 4%-wide line on screen for a few
-              frames during the handoff). The glow is built into the
-              gradient + a tight box-shadow that's small enough not to
-              detach when the beam fades. */}
+          {/* Bright horizontal beam at the slit — the picture's
+              electron beam compressed onto a single line. The whole
+              beam (bright core + bloom halo + vertical falloff) is
+              baked into a radial gradient on a tall (50px) element,
+              so when we scaleX it down the halo shrinks with the
+              core. No box-shadow → no disconnected glow at the end.
+              Animates: fade in as the bars close → hold full width
+              for one breath → collapse horizontally toward the
+              center, where the dot takes over. */}
           <motion.div
-            initial={{ opacity: 0 }}
-            animate={{ opacity: [0, 0, 1, 1, 0] }}
+            initial={{ opacity: 0, scaleX: 1 }}
+            animate={{
+              opacity: [0, 0, 1, 1, 1, 0],
+              scaleX: [1, 1, 1, 1, 0.06, 0],
+            }}
             transition={{
               duration: totalSec,
-              times: [0, 0.22, 0.34, 0.5, 0.66],
-              ease: "easeOut",
+              times: [0, 0.22, 0.34, 0.44, 0.62, 0.7],
+              ease: [0.55, 0, 0.35, 1],
             }}
             className="absolute left-0 right-0 top-1/2 -translate-y-1/2"
             style={{
-              height: "3px",
-              background:
-                "linear-gradient(to right, transparent 0%, rgba(255,255,255,1) 50%, transparent 100%)",
-              boxShadow:
-                "0 0 12px 3px rgba(255,255,255,0.85), 0 0 28px 8px rgba(255,255,255,0.35)",
+              height: "50px",
               transformOrigin: "center",
+              // Wide bright horizontal core with vertical glow falloff.
+              // ellipse-50% wide × 9% tall → visible bright band with
+              // soft halo above/below. All transparent at the edges so
+              // there are no harsh seams when the element scales.
+              background:
+                "radial-gradient(ellipse 50% 9% at center, rgba(255,255,255,1) 0%, rgba(240,250,255,0.92) 16%, rgba(200,225,255,0.45) 40%, rgba(140,170,220,0.15) 65%, rgba(80,100,180,0.04) 80%, transparent 100%)",
             }}
           />
 
           {/* Center collapse dot. The halo is part of a single radial
               gradient on an 80px element so when we scale the element
               down, the bright core *and* the halo shrink together — no
-              disconnected glow at the end. Scale ends at 0 so the dot
-              actually disappears (the previous version ended at 0.25,
-              leaving a faint ghost). */}
+              disconnected glow at the end. Fades in just as the beam
+              starts collapsing, so the visual energy hands off cleanly
+              from the horizontal beam to the center point. */}
           <motion.div
-            initial={{ opacity: 0, scale: 1.4 }}
+            initial={{ opacity: 0, scale: 1.2 }}
             animate={{
               opacity: [0, 0, 1, 1, 0],
-              scale: [1.4, 1.4, 1, 0.55, 0],
+              scale: [1.2, 1.2, 1, 0.55, 0],
             }}
             transition={{
               duration: totalSec,
-              times: [0, 0.4, 0.55, 0.72, 0.94],
+              times: [0, 0.5, 0.65, 0.78, 0.94],
               ease: [0.4, 0, 0.6, 1],
             }}
             className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 rounded-full"

--- a/src/apps/tv/components/TvCrtEffects.tsx
+++ b/src/apps/tv/components/TvCrtEffects.tsx
@@ -334,9 +334,9 @@ function PowerOffEffect({
   const totalSec = POWER_OFF_DURATION_MS / 1000;
   // Phase milestones (as fractions of totalSec):
   //   0.00 .. 0.30  bars close in from top/bottom (cubic ease-in)
-  //   0.20 .. 0.32  beam fades up at the slit
-  //   0.32 .. 0.55  black fill takes over; beam collapses to a dot
-  //   0.55 .. 1.00  dot fades with bloom halo
+  //   0.30 .. 0.42  beam fades up at the slit, holds bright
+  //   0.40 .. 0.62  black fill takes over; beam fades out
+  //   0.40 .. 0.92  center dot brightens, holds, then collapses + fades
 
   return (
     <AnimatePresence>
@@ -391,20 +391,20 @@ function PowerOffEffect({
             className="absolute inset-0 bg-black"
           />
 
-          {/* Bright horizontal beam at the slit. scaleX 1 while the
-              slit is still open, then 1 → 0 as the slit collapses
-              toward the center, mimicking the electron beam compressed
-              into a single line and then a point. */}
+          {/* Bright horizontal beam at the slit. The dot below handles
+              the collapse-to-a-point — this beam just fades out cleanly
+              after the bars close, instead of also scaling to a sliver
+              (which would leave a thin 4%-wide line on screen for a few
+              frames during the handoff). The glow is built into the
+              gradient + a tight box-shadow that's small enough not to
+              detach when the beam fades. */}
           <motion.div
-            initial={{ opacity: 0, scaleX: 1 }}
-            animate={{
-              opacity: [0, 0, 1, 1, 0],
-              scaleX: [1, 1, 1, 0.04, 0],
-            }}
+            initial={{ opacity: 0 }}
+            animate={{ opacity: [0, 0, 1, 1, 0] }}
             transition={{
               duration: totalSec,
-              times: [0, 0.2, 0.32, 0.6, 0.72],
-              ease: [0.6, 0, 0.4, 1],
+              times: [0, 0.22, 0.34, 0.5, 0.66],
+              ease: "easeOut",
             }}
             className="absolute left-0 right-0 top-1/2 -translate-y-1/2"
             style={{
@@ -412,33 +412,38 @@ function PowerOffEffect({
               background:
                 "linear-gradient(to right, transparent 0%, rgba(255,255,255,1) 50%, transparent 100%)",
               boxShadow:
-                "0 0 18px 5px rgba(255,255,255,0.95), 0 0 40px 12px rgba(255,255,255,0.5)",
+                "0 0 12px 3px rgba(255,255,255,0.85), 0 0 28px 8px rgba(255,255,255,0.35)",
               transformOrigin: "center",
             }}
           />
 
-          {/* Center afterglow dot. Appears just as the beam collapses,
-              shrinks slightly, and fades — the way phosphor cools after
-              the beam shuts off. */}
+          {/* Center collapse dot. The halo is part of a single radial
+              gradient on an 80px element so when we scale the element
+              down, the bright core *and* the halo shrink together — no
+              disconnected glow at the end. Scale ends at 0 so the dot
+              actually disappears (the previous version ended at 0.25,
+              leaving a faint ghost). */}
           <motion.div
-            initial={{ opacity: 0, scale: 1 }}
+            initial={{ opacity: 0, scale: 1.4 }}
             animate={{
               opacity: [0, 0, 1, 1, 0],
-              scale: [1, 1, 1, 0.55, 0.25],
+              scale: [1.4, 1.4, 1, 0.55, 0],
             }}
             transition={{
               duration: totalSec,
-              times: [0, 0.55, 0.62, 0.72, 1],
-              ease: "easeOut",
+              times: [0, 0.4, 0.55, 0.72, 0.94],
+              ease: [0.4, 0, 0.6, 1],
             }}
             className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 rounded-full"
             style={{
-              width: 16,
-              height: 16,
+              width: 80,
+              height: 80,
+              // Tight bright core (0–6%), warm glow falloff (6–35%),
+              // long blue-tinted bloom (35–80%) that fades to fully
+              // transparent. Background = "halo built into the
+              // element", which means scale() shrinks it cleanly.
               background:
-                "radial-gradient(circle, rgba(255,255,255,1) 0%, rgba(220,235,255,0.6) 40%, rgba(180,210,255,0.2) 70%, transparent 100%)",
-              boxShadow:
-                "0 0 36px 14px rgba(255,255,255,0.8), 0 0 78px 28px rgba(180,210,255,0.4)",
+                "radial-gradient(circle, rgba(255,255,255,1) 0%, rgba(240,250,255,0.9) 6%, rgba(220,235,255,0.45) 18%, rgba(180,210,255,0.18) 38%, rgba(80,100,180,0.05) 60%, transparent 82%)",
             }}
           />
         </motion.div>


### PR DESCRIPTION
## Summary

When the TV was paused (black screen-off overlay parked) and the user hit Next, Prev, CH+, or CH-, the TV stayed black instead of turning back on.

## Root cause

The handlers chain \`setIsPlaying(true)\` + \`setVideoIndex(...)\` (or \`setCurrentChannelId(...)\`) into the same React commit. By the time the \`prevPlayingRef\` watcher in \`TvAppComponent\` runs, both \`isPlaying\` flipped false→true *and* \`currentVideo.id\` changed.

That path was suppressed precisely to avoid double-firing during normal channel switches (channel-switch burst + spurious power-on shader)  — but the suppression also swallowed the legitimate screen-off → playing transition.

## Fix

Added an early-return branch for \`screenOff && isPlaying\` *before* the buffering / video-id-changed checks: power back on (clear \`screenOff\`, bump \`powerOnKey\`, play the power-on synth), then sync the refs and bail. The existing channel-switch / buffer logic handles the rest of the visual choreography on top of the unfold.

## Test plan

- [ ] Pause TV → click Next → TV powers back on, channel-switch burst plays
- [ ] Pause TV → click Prev → TV powers back on, channel-switch burst plays
- [ ] Pause TV → click CH+ / CH- → TV powers back on, channel-switch burst plays
- [ ] Normal Next while playing → only channel-switch burst, no power-on shader
- [ ] Normal pause → power-off animation, parked black screen
- [ ] Normal play after pause → power-on animation
- [ ] Close paused TV → close animation + window closes

Made with [Cursor](https://cursor.com)