### PR TITLE
fix(tv): play synchronously on mobile Safari tap

### DIFF
--- a/src/apps/tv/components/TvAppComponent.tsx
+++ b/src/apps/tv/components/TvAppComponent.tsx
@@ -397,6 +397,34 @@ export function TvAppComponent({
     stopStatic,
   } = useTvSoundFx();
 
+  // Mobile Safari blocks YouTube's autoplay until a user gesture. The
+  // toggle-play state path (Zustand flip → re-render → effect updates
+  // screenOff → re-render → react-player asks YT to play) is fully
+  // async, so by the time `playVideo()` is invoked the gesture token
+  // is gone and iOS rejects the play. Mirror the iPod / Karaoke pattern
+  // and call `playVideo()` *synchronously* inside the click handler so
+  // the call still rides on the user gesture. Once YouTube is playing
+  // the later state-driven `playing` prop update is a no-op.
+  const handleTogglePlay = useCallback(() => {
+    if (!isPlaying) {
+      const playYt = (player: ReactPlayer | null) => {
+        const internal = player?.getInternalPlayer?.();
+        if (internal && typeof internal.playVideo === "function") {
+          try {
+            internal.playVideo();
+          } catch {
+            // Defensive: YT iframe may not be ready yet on first open.
+            // The state-driven path will still attempt playback once
+            // the iframe finishes its initial handshake.
+          }
+        }
+      };
+      playYt(playerRef.current);
+      playYt(fullScreenPlayerRef.current);
+    }
+    togglePlay();
+  }, [isPlaying, togglePlay, playerRef, fullScreenPlayerRef]);
+
   const customChannels = useTvStore((s) => s.customChannels);
   const removeCustomChannel = useTvStore((s) => s.removeCustomChannel);
   const importChannels = useTvStore((s) => s.importChannels);
@@ -756,7 +784,7 @@ export function TvAppComponent({
       isLcdFilterOn={lcdFilterOn}
       onToggleLcdFilter={toggleLcdFilter}
       isPlaying={isPlaying}
-      onTogglePlay={togglePlay}
+      onTogglePlay={handleTogglePlay}
       onNextVideo={nextVideo}
       onPrevVideo={prevVideo}
       onNextChannel={nextChannel}
@@ -905,7 +933,7 @@ export function TvAppComponent({
               <div
                 className="absolute inset-0 z-20"
                 aria-hidden
-                onClick={togglePlay}
+                onClick={handleTogglePlay}
               />
               <TvCrtEffects
                 powerOnKey={powerOnKey}
@@ -1018,7 +1046,7 @@ export function TvAppComponent({
                     <button
                       type="button"
                       className="metal-inset-btn metal-inset-icon"
-                      onClick={togglePlay}
+                      onClick={handleTogglePlay}
                       disabled={!hasVideos}
                       style={{ minWidth: 32 }}
                     >
@@ -1058,7 +1086,7 @@ export function TvAppComponent({
                     </button>
                     <button
                       type="button"
-                      onClick={togglePlay}
+                      onClick={handleTogglePlay}
                       className={cn(
                         "flex items-center justify-center disabled:opacity-50 focus:outline-none",
                         "hover:brightness-75 active:brightness-50"
@@ -1248,7 +1276,7 @@ export function TvAppComponent({
           isPlaying={isPlaying}
           onPlay={() => setIsPlaying(true)}
           onPause={() => setIsPlaying(false)}
-          onTogglePlay={togglePlay}
+          onTogglePlay={handleTogglePlay}
           onEnded={handleVideoEnd}
           onProgress={handleProgress}
           onDuration={handleDuration}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

On Mobile Safari, tapping play in the TV app didn't actually start the video. The recent "TV: open powered off on mobile Safari" change leaves the TV in `isPlaying=false` + `screenOff=true` until the user taps, but the wake-up path is fully async:

1. `togglePlay()` flips `isPlaying` → React re-renders
2. The player's `playing` prop is `isPlaying && !screenOff` → still `false`
3. A `useEffect` watching `screenOff && isPlaying` flips `screenOff=false` → React re-renders
4. Now `playing` becomes `true` and `react-player` asks YouTube to `playVideo()`

By step 4 the user-gesture token is gone, so iOS Safari rejects the play and the TV stays paused/black.

## Fix

Mirror the iPod / Karaoke pattern: when the user taps play and we're currently paused, call `internalPlayer.playVideo()` *synchronously* inside the click handler so it still rides on the user gesture. Wired through every entry point that previously called `togglePlay` directly:

- Menu bar Play/Pause item
- Click-capture overlay over the iframe
- Player Play/Pause button (macOS-theme metal-inset and the default skinned button)
- `VideoFullScreenPortal`'s `onTogglePlay`

Once YouTube is already playing, the later state-driven `playing` prop update is a no-op, so non-Safari browsers and the macOS desktop are unaffected.

## Testing

- ✅ `bun run build`
- Cannot reproduce iOS Safari's autoplay gating in the Linux Cloud env, so this is verified by code-pattern parity with the existing iPod (`useIpodLogic.tsx` line 1696–1699) and Karaoke (`useKaraokeLogic.ts` line 805–808) workarounds, which already ship and work on iOS.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5e02d832-db71-48b2-9e69-7d29ceb546f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5e02d832-db71-48b2-9e69-7d29ceb546f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

