### PR TITLE
tv: filter YouTube Shorts on the client, drop server videos.list call

### DIFF
--- a/api/tv/create-channel.ts
+++ b/api/tv/create-channel.ts
@@ -8,8 +8,17 @@
  *      to avoid Shorts-oriented query phrasings.
  *   3. Run each query against the YouTube Data API (rotating across the keys
  *      already configured for /api/youtube-search).
- *   4. De-dup by video id, hydrate durations via videos.list, and drop
- *      YouTube Shorts (≤ 60s) from the lineup before returning.
+ *   4. De-dup by video id and return the lineup.
+ *
+ * Shorts handling: we deliberately do NOT call videos.list to fetch
+ * durations and filter out Shorts server-side. Each channel build only
+ * spends the search.list quota (100 units / query × 2-4 queries) plus the
+ * AI planner — adding videos.list (1 unit) is cheap on quota but costs a
+ * serial round-trip and another HTTP failure mode. The TV player already
+ * receives `onDuration` from ReactPlayer, so the client (`useTvLogic`)
+ * auto-skips Shorts as they come up. Combined with the planner's "no
+ * Shorts" prompt rules, this keeps the build fast and tolerates Shorts
+ * that slip through without an extra API call.
  */
 
 import { google } from "@ai-sdk/google";
@@ -63,43 +72,11 @@ interface YouTubeSearchResponse {
   error?: { code: number; message: string };
 }
 
-interface YouTubeVideoDetailsItem {
-  id: string;
-  contentDetails?: { duration?: string };
-}
-
-interface YouTubeVideosListResponse {
-  items?: YouTubeVideoDetailsItem[];
-  error?: { code: number; message: string };
-}
-
 interface ChannelVideo {
   id: string;
   url: string;
   title: string;
   artist: string;
-}
-
-/**
- * Videos with a non-empty duration ≤ this many seconds are treated as
- * YouTube Shorts and excluded from generated channels. Conservative threshold
- * that catches the vast majority of Shorts without dropping legitimate short
- * music videos / clips.
- */
-const SHORTS_MAX_DURATION_SECONDS = 60;
-
-/**
- * Parse an ISO 8601 duration like "PT1M5S", "PT45S", "PT1H2M3S" into total
- * seconds. Returns null if the input doesn't look like a duration.
- */
-function parseIsoDurationSeconds(value: string | undefined): number | null {
-  if (!value) return null;
-  const match = /^P(?:\d+D)?T(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?$/.exec(value);
-  if (!match) return null;
-  const hours = match[1] ? parseInt(match[1], 10) : 0;
-  const minutes = match[2] ? parseInt(match[2], 10) : 0;
-  const seconds = match[3] ? parseInt(match[3], 10) : 0;
-  return hours * 3600 + minutes * 60 + seconds;
 }
 
 const SYSTEM_PROMPT = `You design themed YouTube "TV channels" for a retro desktop OS.
@@ -165,61 +142,6 @@ async function searchOneQuery(
       }));
   }
   return [];
-}
-
-/**
- * Fetch ISO 8601 durations for the given video ids via the YouTube videos.list
- * endpoint. Rotates across keys on quota errors. Returns a Map keyed by video
- * id; ids missing from the response (e.g. removed videos) are absent.
- *
- * Batches up to 50 ids per request, which is the YouTube API max for
- * videos.list.
- */
-async function fetchVideoDurations(
-  videoIds: string[],
-  apiKeys: string[]
-): Promise<Map<string, number>> {
-  const durations = new Map<string, number>();
-  if (videoIds.length === 0) return durations;
-
-  const BATCH_SIZE = 50;
-  for (let start = 0; start < videoIds.length; start += BATCH_SIZE) {
-    const batch = videoIds.slice(start, start + BATCH_SIZE);
-    let fetched: YouTubeVideosListResponse | null = null;
-
-    for (let i = 0; i < apiKeys.length; i++) {
-      const apiKey = apiKeys[i];
-      const url = new URL("https://www.googleapis.com/youtube/v3/videos");
-      url.searchParams.set("part", "contentDetails");
-      url.searchParams.set("id", batch.join(","));
-      url.searchParams.set("key", apiKey);
-
-      const res = await fetch(url.toString());
-      const data = (await res.json()) as YouTubeVideosListResponse;
-
-      if (!res.ok || data.error) {
-        const message = data.error?.message?.toLowerCase() ?? "";
-        const isQuota =
-          res.status === 403 &&
-          (message.includes("quota") ||
-            message.includes("exceeded") ||
-            message.includes("limit"));
-        if (isQuota && i < apiKeys.length - 1) continue;
-        throw new Error(
-          data.error?.message || `YouTube API error (${res.status})`
-        );
-      }
-      fetched = data;
-      break;
-    }
-
-    if (!fetched) continue;
-    for (const item of fetched.items ?? []) {
-      const seconds = parseIsoDurationSeconds(item.contentDetails?.duration);
-      if (seconds !== null) durations.set(item.id, seconds);
-    }
-  }
-  return durations;
 }
 
 export default apiHandler<CreateChannelRequest>(
@@ -349,10 +271,12 @@ export default apiHandler<CreateChannelRequest>(
       queries: plan.queries,
     });
 
-    // Step 2: Fan out YouTube searches.
+    // Step 2: Fan out YouTube searches. We over-fetch a bit per query so
+    // that even if the client auto-skips a few Shorts at playback time,
+    // the channel still has plenty of watchable videos. `maxResults`
+    // doesn't affect search.list quota cost (still 100 units per call),
+    // so over-fetching is free here.
     const TARGET_TOTAL = 24;
-    // Over-fetch a bit so the post-filter (drop YouTube Shorts) still leaves
-    // enough videos to fill the channel.
     const perQuery = Math.max(
       8,
       Math.ceil((TARGET_TOTAL * 1.5) / plan.queries.length)
@@ -363,7 +287,7 @@ export default apiHandler<CreateChannelRequest>(
     );
 
     const seen = new Set<string>();
-    const candidates: ChannelVideo[] = [];
+    const videos: ChannelVideo[] = [];
     for (const result of settled) {
       if (result.status !== "fulfilled") {
         logger.warn("Search query failed", {
@@ -377,47 +301,22 @@ export default apiHandler<CreateChannelRequest>(
       for (const v of result.value) {
         if (seen.has(v.id)) continue;
         seen.add(v.id);
-        candidates.push(v);
+        videos.push(v);
+        if (videos.length >= TARGET_TOTAL) break;
       }
-    }
-
-    // Step 3: Drop YouTube Shorts. We hydrate durations via videos.list and
-    // filter out anything ≤ SHORTS_MAX_DURATION_SECONDS. If we can't determine
-    // a duration (e.g. videos.list fails entirely), fall back to keeping the
-    // candidate so a transient API blip doesn't return an empty channel.
-    let durations: Map<string, number> = new Map();
-    try {
-      durations = await fetchVideoDurations(
-        candidates.map((c) => c.id),
-        apiKeys
-      );
-    } catch (err) {
-      logger.warn("Failed to fetch video durations; skipping shorts filter", {
-        error: err instanceof Error ? err.message : String(err),
-      });
-    }
-
-    const videos: ChannelVideo[] = [];
-    let droppedShorts = 0;
-    for (const candidate of candidates) {
-      const seconds = durations.get(candidate.id);
-      if (
-        seconds !== undefined &&
-        seconds > 0 &&
-        seconds <= SHORTS_MAX_DURATION_SECONDS
-      ) {
-        droppedShorts++;
-        continue;
-      }
-      videos.push(candidate);
       if (videos.length >= TARGET_TOTAL) break;
     }
+
+    // Shorts are filtered on the client at playback time via the
+    // `onDuration` callback (see `useTvLogic.handleDuration`). The
+    // planner is also prompted to avoid Shorts-oriented queries
+    // (`SYSTEM_PROMPT` above), so the lineup we ship here is already
+    // mostly Shorts-free; the client just covers the long tail without
+    // an extra videos.list round-trip.
 
     if (videos.length === 0) {
       logger.error("No videos found for any query", {
         queries: plan.queries,
-        droppedShorts,
-        candidateCount: candidates.length,
       });
       logger.response(404, Date.now() - startTime);
       res
@@ -429,7 +328,6 @@ export default apiHandler<CreateChannelRequest>(
     logger.info("Channel created", {
       name: plan.name,
       videoCount: videos.length,
-      droppedShorts,
     });
     logger.response(200, Date.now() - startTime);
     res.status(200).json({

--- a/src/apps/tv/hooks/useTvLogic.ts
+++ b/src/apps/tv/hooks/useTvLogic.ts
@@ -10,6 +10,7 @@ import { useAudioSettingsStore } from "@/stores/useAudioSettingsStore";
 import { helpItems } from "..";
 import { buildTvChannelLineup, type Channel } from "@/apps/tv/data/channels";
 import {
+  isShortDuration,
   isYouTubeUrl,
   nextIndex,
   prevIndex,
@@ -93,6 +94,14 @@ export function useTvLogic({ isWindowOpen, isForeground }: UseTvLogicOptions) {
   // skip + channel switch; flipped to false when a video advances because
   // it ended naturally, so the *following* video plays from 0.
   const tuneInRandomlyOnNextDurationRef = useRef(true);
+  // Per-channel set of video ids we've already classified as Shorts and
+  // auto-skipped. Used as a circuit breaker: if we've skipped every video
+  // on the current channel, stop skipping and let the last one play, so a
+  // channel that happens to contain only Shorts (e.g. a user-imported
+  // lineup or a planner that returned all sub-60s videos) doesn't loop
+  // forever. Keyed by channel id so different channels don't pollute
+  // each other's skip state.
+  const skippedShortsByChannelRef = useRef<Map<string, Set<string>>>(new Map());
 
   const ipodTracks = useIpodStore((s) => s.tracks);
   const videosLibrary = useVideoStore((s) => s.videos);
@@ -276,6 +285,40 @@ export function useTvLogic({ isWindowOpen, isForeground }: UseTvLogicOptions) {
       setDuration(d);
       const id = currentVideo?.id;
       if (!id || lastRandomSeekedIdRef.current === id) return;
+
+      // Auto-skip YouTube Shorts on the client. The server no longer hits
+      // videos.list to filter them out (it's a wasted YouTube quota per
+      // channel build), so we rely on the player reporting duration and
+      // skip forward when it looks like a Short. Mark the id as
+      // already-handled BEFORE advancing so a duplicate `onDuration` for
+      // the same id (ReactPlayer can fire it again on metadata refresh)
+      // can't trigger a second skip and accidentally advance two videos.
+      if (isShortDuration(d)) {
+        const list = currentChannel?.videos ?? [];
+        const channelId = currentChannel?.id ?? currentChannelId;
+        let skipped = skippedShortsByChannelRef.current.get(channelId);
+        if (!skipped) {
+          skipped = new Set();
+          skippedShortsByChannelRef.current.set(channelId, skipped);
+        }
+        // Circuit breaker: if every video on this channel has already
+        // been auto-skipped as a Short at least once, give up skipping
+        // and let this one play. Without this, an all-Shorts channel
+        // would advance forever and never render any video.
+        const everythingSkipped =
+          list.length > 0 && skipped.size >= list.length;
+        if (!everythingSkipped && list.length > 1) {
+          skipped.add(id);
+          lastRandomSeekedIdRef.current = id;
+          // Preserve the "tune in randomly" flag — we're advancing past
+          // a video we never intended to play, not consuming a manual
+          // skip — so the next video still tunes in mid-program.
+          setVideoIndex(currentChannelId, nextIndex(videoIndex, list.length));
+          setIsPlaying(true);
+          return;
+        }
+      }
+
       lastRandomSeekedIdRef.current = id;
       // Reset the flag for the *next* duration event regardless of which
       // branch we take, so a future natural rollover won't be inherited.
@@ -292,7 +335,14 @@ export function useTvLogic({ isWindowOpen, isForeground }: UseTvLogicOptions) {
         fullScreenPlayerRef.current?.seekTo(start, "seconds");
       }
     },
-    [currentVideo?.id]
+    [
+      currentVideo?.id,
+      currentChannel,
+      currentChannelId,
+      videoIndex,
+      setVideoIndex,
+      setIsPlaying,
+    ]
   );
 
   const handleSeek = useCallback((time: number) => {

--- a/src/apps/tv/utils.ts
+++ b/src/apps/tv/utils.ts
@@ -103,3 +103,26 @@ export function randomTuneInOffset(
   if (!Number.isFinite(d) || d <= minDuration) return null;
   return rng() * d * 0.75;
 }
+
+/**
+ * Threshold (in seconds) at or below which a YouTube video is treated as a
+ * Short and skipped from TV channel playback. Conservative — catches the
+ * vast majority of Shorts without dropping legitimate short music videos.
+ */
+export const SHORTS_MAX_DURATION_SECONDS = 60;
+
+/**
+ * Returns true iff `d` looks like a YouTube Shorts duration: a finite,
+ * positive value at or below `SHORTS_MAX_DURATION_SECONDS`. Live streams
+ * report `Infinity`, and an unknown duration shows up as `0` / `NaN` —
+ * both are treated as "not a short" so we don't drop a video while the
+ * player is still booting up.
+ */
+export function isShortDuration(
+  d: number,
+  threshold = SHORTS_MAX_DURATION_SECONDS
+): boolean {
+  if (!Number.isFinite(d)) return false;
+  if (d <= 0) return false;
+  return d <= threshold;
+}

--- a/tests/test-tv-utils.test.ts
+++ b/tests/test-tv-utils.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, test } from "bun:test";
 import {
+  isShortDuration,
   isYouTubeUrl,
   nextIndex,
   parseYouTubeId,
   prevIndex,
   randomTuneInOffset,
+  SHORTS_MAX_DURATION_SECONDS,
   shuffleArray,
 } from "../src/apps/tv/utils";
 
@@ -170,5 +172,36 @@ describe("randomTuneInOffset", () => {
   test("custom threshold lets callers tune in to shorter clips", () => {
     const out = randomTuneInOffset(20, () => 0.5, 10);
     expect(out).toBeCloseTo(7.5);
+  });
+});
+
+describe("isShortDuration", () => {
+  test("flags durations at or below the default 60s threshold as Shorts", () => {
+    expect(isShortDuration(15)).toBe(true);
+    expect(isShortDuration(45)).toBe(true);
+    expect(isShortDuration(SHORTS_MAX_DURATION_SECONDS)).toBe(true);
+  });
+
+  test("does not flag durations above the threshold", () => {
+    expect(isShortDuration(SHORTS_MAX_DURATION_SECONDS + 0.5)).toBe(false);
+    expect(isShortDuration(120)).toBe(false);
+    expect(isShortDuration(3600)).toBe(false);
+  });
+
+  test("treats unknown / not-yet-loaded durations as not-Shorts", () => {
+    // Don't drop a video while the player is still bootstrapping — duration
+    // shows up as 0 (not loaded) or NaN (driver glitch) before the video
+    // actually starts playing.
+    expect(isShortDuration(0)).toBe(false);
+    expect(isShortDuration(NaN)).toBe(false);
+  });
+
+  test("treats live streams (Infinity) as not-Shorts", () => {
+    expect(isShortDuration(Infinity)).toBe(false);
+  });
+
+  test("custom threshold lets callers tune the cutoff", () => {
+    expect(isShortDuration(90, 120)).toBe(true);
+    expect(isShortDuration(150, 120)).toBe(false);
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Move the YouTube Shorts filter for AI-generated TV channels off of `videos.list` (server) and onto the player's `onDuration` callback (client).

## Why

`api/tv/create-channel.ts` was making an extra `videos.list` round-trip after the `search.list` fan-out just to drop sub-60s videos. The TV player already receives an `onDuration` event from ReactPlayer for every video it plays, so the same Shorts cutoff can be applied at playback time without an extra YouTube API hit per channel build. Saves one HTTP round-trip + one YouTube quota unit per build, and removes a server-side failure mode.

## Changes

- **`src/apps/tv/utils.ts`** — new `isShortDuration(d, threshold = 60)` helper. Flags finite, positive durations ≤ threshold as Shorts; live streams (`Infinity`), unknown / not-yet-loaded durations (`0`, `NaN`), and longer videos are not flagged so the player can't accidentally advance off a video while metadata is still loading. Exports `SHORTS_MAX_DURATION_SECONDS` for callers.
- **`src/apps/tv/hooks/useTvLogic.ts`** — `handleDuration` now auto-advances when `isShortDuration(d)` is true. Two safety properties:
  - **Per-channel circuit breaker.** A `Map<channelId, Set<videoId>>` ref tracks which videos we've already auto-skipped. Once we've skipped every video on the current channel at least once, we stop skipping and let the next one play, so a channel that happens to contain only Shorts (e.g. an imported lineup) doesn't loop forever.
  - **Re-entrancy guard.** We mark the id as already-handled (`lastRandomSeekedIdRef`) before advancing, so a duplicate `onDuration` fire for the same id can't double-advance.
  - The "tune in randomly" flag is preserved across an auto-skip (we're advancing past a video the user never intended to watch, so the *next* video should still tune in mid-program).
- **`api/tv/create-channel.ts`** — drops `fetchVideoDurations`, `parseIsoDurationSeconds`, the `YouTubeVideoDetailsItem`/`YouTubeVideosListResponse` types, the `SHORTS_MAX_DURATION_SECONDS` constant, and the post-search filter loop. Header comment updated to document the move. The dedup + `TARGET_TOTAL` cap is now applied inline during the search-result merge instead of a separate pass.
- **`tests/test-tv-utils.test.ts`** — 5 new cases covering threshold edges (≤ 60s, > 60s), unknown durations (`0`, `NaN`), live streams (`Infinity`), and a custom threshold.

## Tradeoffs

- The Shorts filter is now best-effort and depends on the player loading enough metadata to fire `onDuration`. In practice ReactPlayer fires `onDuration` immediately on metadata-loaded, so the user briefly sees a Short flash before we advance. This is the same behavior as the existing `handleError` auto-advance for geo-blocked / removed videos. The system prompt still discourages Shorts-y queries, so the lineups should already be mostly Shorts-free.
- All-Shorts channels degrade gracefully (one Short plays after the circuit breaker kicks in) instead of returning a 404 from the server.

## Testing

- ✅ `bun test tests/test-tv-utils.test.ts` — 27 / 27 pass (including the 5 new `isShortDuration` cases).
- ✅ `bun run test:unit` — 130 / 130 pass.
- ✅ `bun run build` — clean TypeScript + Vite + PWA build.
- ⚠️ `bun run lint` — 9 pre-existing findings in unrelated files (per `AGENTS.md` these are not blockers); no new findings from this change.

No manual / GUI testing was performed because the change is non-visual (client-side auto-advance reuses the existing `onDuration` plumbing) and the helper is fully covered by unit tests. End-to-end verification of an all-Shorts channel would require a live YouTube API key + manual prompt, which isn't available in this environment.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e01275e5-504e-49f3-a5cc-faaae0d275a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e01275e5-504e-49f3-a5cc-faaae0d275a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

