### PR TITLE
feat(tv): single-line lyrics overlay on MTV channel

### DIFF
--- a/src/apps/tv/components/MtvLyricsOverlay.tsx
+++ b/src/apps/tv/components/MtvLyricsOverlay.tsx
@@ -219,7 +219,11 @@ export function MtvLyricsOverlay({
   return (
     <div
       className={cn(
-        "pointer-events-none absolute inset-x-0 z-30 flex justify-center px-4",
+        // Sits just above the video iframe but below the TV's transparent
+        // click-capture layer (z-20) and the CRT noise / LCD filter
+        // shaders (z-30+ in TvCrtEffects), so static, scanlines, and the
+        // dim screen-off overlay properly cover the captions.
+        "pointer-events-none absolute inset-x-0 z-[15] flex justify-center px-4",
         isFullscreen ? "bottom-[14%]" : "bottom-6"
       )}
       aria-hidden

--- a/src/apps/tv/components/MtvLyricsOverlay.tsx
+++ b/src/apps/tv/components/MtvLyricsOverlay.tsx
@@ -33,6 +33,14 @@ const MAX_INTERPOLATE_MS = 500;
  *  cadence from (last line of the song). */
 const FALLBACK_LINE_DURATION_MS = 4000;
 
+interface RevealToken {
+  /** Text to render for this token (includes any trailing whitespace). */
+  text: string;
+  /** Time relative to the line start, in ms, when this token should
+   *  become visible. */
+  revealAtMs: number;
+}
+
 /**
  * Single-line, TV-style closed-caption overlay for the MTV channel.
  *
@@ -40,18 +48,16 @@ const FALLBACK_LINE_DURATION_MS = 4000;
  * `useLyrics` pipeline iPod / Karaoke use — the song id of the current
  * TV video is the same id the iPod uses for lyrics lookups.
  *
- * Reveal timing matches the audio:
- *   - When the LRC has KRC word timings (`wordTimings[]`), each character
- *     is revealed at its true word's `startTimeMs + durationMs` window.
- *   - Otherwise we evenly distribute characters across the line duration
- *     (next-line-start − current-line-start), matching how karaoke /
- *     iPod fall back when KRC data is missing.
+ * Reveal timing matches the audio at *word* granularity:
+ *   - When the LRC has KRC `wordTimings[]`, each token is revealed
+ *     exactly at its word's `startTimeMs` (relative to line start).
+ *   - Otherwise tokens are split on whitespace and distributed evenly
+ *     across the line duration (next-line-start − current-line-start),
+ *     matching the karaoke / `LyricsDisplay` fallback.
  *
- * Smoothness is achieved with the same trick `WordTimingHighlight` uses
- * in `LyricsDisplay`: take the latest prop `currentTimeMs` and
- * extrapolate forward via `performance.now()` per `requestAnimationFrame`
- * tick (capped, so a pause can't drift), instead of being limited by
- * react-player's coarse progress callbacks.
+ * Smoothness comes from extrapolating `performance.now()` forward from
+ * the latest `playedSeconds` prop (capped at 500ms) per `rAF` tick —
+ * same trick `WordTimingHighlight` uses in `LyricsDisplay`.
  */
 export function MtvLyricsOverlay({
   songId,
@@ -88,7 +94,6 @@ export function MtvLyricsOverlay({
     return lyricsState.lines[idx] ?? null;
   }, [visible, lyricsState.currentLine, lyricsState.lines]);
 
-  const fullText = (activeLine?.words ?? "").trim();
   const lineStartMs = activeLine ? parseInt(activeLine.startTimeMs, 10) : NaN;
 
   // Duration of the current line: from this line's start to the next
@@ -106,55 +111,50 @@ export function MtvLyricsOverlay({
     return b - a;
   }, [activeLine, lyricsState.currentLine, lyricsState.lines]);
 
-  // Pre-compute character → reveal-time-ms map for the current line.
-  // When KRC word timings are available, characters reveal at their true
-  // word boundaries (interpolated within a word so the reveal is smooth
-  // across multi-char words). Otherwise we evenly distribute characters
-  // across the line duration.
-  const charRevealMs = useMemo<number[]>(() => {
-    if (!fullText) return [];
-    const wordTimings = activeLine?.wordTimings;
+  // Build the token list for the active line. Each token carries its
+  // reveal time (relative to line start). When KRC word timings exist
+  // we use them verbatim; otherwise we whitespace-split and spread
+  // evenly across the line.
+  const tokens = useMemo<RevealToken[]>(() => {
+    if (!activeLine) return [];
+    const original = activeLine.words ?? "";
+    if (!original) return [];
+
+    const wordTimings = activeLine.wordTimings;
     if (wordTimings && wordTimings.length > 0) {
-      // Walk the original (untrimmed) line so word.text offsets line up,
-      // then map back to indices in the trimmed fullText. Trimming only
-      // strips leading/trailing whitespace, so a single offset shift is
-      // enough.
-      const original = activeLine?.words ?? "";
-      const leadingTrim = original.length - original.trimStart().length;
-      const arr = new Array<number>(fullText.length).fill(0);
-      let charsAssigned = 0;
-      for (let w = 0; w < wordTimings.length; w++) {
-        const word = wordTimings[w];
-        const len = word.text.length;
-        for (let c = 0; c < len; c++) {
-          const idxInOriginal = charsAssigned + c;
-          const idxInTrimmed = idxInOriginal - leadingTrim;
-          if (idxInTrimmed < 0 || idxInTrimmed >= arr.length) continue;
-          // Spread chars evenly within the word's duration so a long
-          // sustained word still drips in instead of snapping.
-          const within =
-            len > 0
-              ? ((c + 1) / len) * Math.max(0, word.durationMs)
-              : word.durationMs;
-          arr[idxInTrimmed] = word.startTimeMs + within;
-        }
-        charsAssigned += len;
-      }
-      // Any trailing chars (e.g. punctuation past final word timing) get
-      // pinned to the last word's end so they reveal at the same moment.
-      const lastWord = wordTimings[wordTimings.length - 1];
-      const lastEnd = lastWord.startTimeMs + lastWord.durationMs;
-      for (let i = 0; i < arr.length; i++) {
-        if (arr[i] === 0 && i > 0) arr[i] = lastEnd;
-      }
-      return arr;
+      // KRC word timings cover the original (untrimmed) line. The text
+      // of each timing already includes its trailing whitespace, so we
+      // can render them in order without extra splitting. We trim the
+      // very first and last tokens' surrounding whitespace so the CC
+      // plate hugs the visible text.
+      const last = wordTimings.length - 1;
+      return wordTimings.map((w, i) => {
+        let text = w.text;
+        if (i === 0) text = text.replace(/^\s+/, "");
+        if (i === last) text = text.replace(/\s+$/, "");
+        return { text, revealAtMs: w.startTimeMs };
+      });
     }
-    // No word timings — distribute evenly across the line's duration.
+
+    // Fallback: split on whitespace, keeping the spaces attached to the
+    // preceding word so the rendered string is identical to the
+    // original. Reveal each word evenly across the line duration.
+    const trimmed = original.trim();
+    if (!trimmed) return [];
+    const parts: string[] = [];
+    const re = /\S+\s*/g;
+    let m: RegExpExecArray | null;
+    while ((m = re.exec(trimmed)) !== null) {
+      parts.push(m[0]);
+    }
     const total = lineDurationMs;
-    return Array.from({ length: fullText.length }, (_, i) =>
-      ((i + 1) / fullText.length) * total
-    );
-  }, [fullText, activeLine, lineDurationMs]);
+    return parts.map((text, i) => ({
+      text,
+      revealAtMs: (i / parts.length) * total,
+    }));
+  }, [activeLine, lineDurationMs]);
+
+  const fullText = useMemo(() => tokens.map((t) => t.text).join(""), [tokens]);
 
   // Track the latest prop time + when we received it so we can
   // extrapolate per-frame for smooth reveal between coarse progress
@@ -168,7 +168,7 @@ export function MtvLyricsOverlay({
     timeRef.current.propTakenAt = performance.now();
   }, [currentTimeMs]);
 
-  const [revealedChars, setRevealedChars] = useState(0);
+  const [revealedTokens, setRevealedTokens] = useState(0);
   const lastRevealedRef = useRef(0);
   const lineKey = activeLine
     ? `${lyricsState.currentLine}:${activeLine.startTimeMs}`
@@ -176,14 +176,14 @@ export function MtvLyricsOverlay({
 
   useEffect(() => {
     lastRevealedRef.current = 0;
-    setRevealedChars(0);
+    setRevealedTokens(0);
   }, [lineKey]);
 
   useEffect(() => {
-    if (!fullText || !Number.isFinite(lineStartMs)) {
+    if (tokens.length === 0 || !Number.isFinite(lineStartMs)) {
       if (lastRevealedRef.current !== 0) {
         lastRevealedRef.current = 0;
-        setRevealedChars(0);
+        setRevealedTokens(0);
       }
       return;
     }
@@ -195,27 +195,26 @@ export function MtvLyricsOverlay({
       );
       const liveTimeMs = timeRef.current.propTimeMs + sinceProp;
       const timeIntoLine = liveTimeMs - lineStartMs;
-      // Binary scan would be overkill for a typical line (<100 chars).
       let count = 0;
-      for (let i = 0; i < charRevealMs.length; i++) {
-        if (charRevealMs[i] <= timeIntoLine) count = i + 1;
+      for (let i = 0; i < tokens.length; i++) {
+        if (tokens[i].revealAtMs <= timeIntoLine) count = i + 1;
         else break;
       }
       if (count !== lastRevealedRef.current) {
         lastRevealedRef.current = count;
-        setRevealedChars(count);
+        setRevealedTokens(count);
       }
       raf = requestAnimationFrame(tick);
     };
     raf = requestAnimationFrame(tick);
     return () => cancelAnimationFrame(raf);
-  }, [fullText, lineStartMs, charRevealMs]);
+  }, [tokens, lineStartMs]);
 
   if (!visible || !fullText) return null;
 
   const isFullscreen = variant === "fullscreen";
-  const visibleText = fullText.slice(0, revealedChars);
-  const hiddenText = fullText.slice(revealedChars);
+  const visibleText = tokens.slice(0, revealedTokens).map((t) => t.text).join("");
+  const hiddenText = tokens.slice(revealedTokens).map((t) => t.text).join("");
 
   return (
     <div
@@ -226,8 +225,8 @@ export function MtvLyricsOverlay({
       aria-hidden
     >
       {/* Keyed swap with no enter animation — caption snaps in like
-          broadcast CCs. The container itself remounts per line so prior
-          line is replaced instantly. */}
+          broadcast CCs. The container itself remounts per line so the
+          prior line is replaced instantly. */}
       <div
         key={lineKey}
         className={cn(

--- a/src/apps/tv/components/MtvLyricsOverlay.tsx
+++ b/src/apps/tv/components/MtvLyricsOverlay.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { AnimatePresence, motion } from "framer-motion";
 import { useShallow } from "zustand/react/shallow";
 import { useLyrics } from "@/hooks/useLyrics";
@@ -26,17 +26,31 @@ interface MtvLyricsOverlayProps {
   variant?: "windowed" | "fullscreen";
 }
 
+/** Default reveal duration for a line when we don't have a "next line"
+ *  timestamp to derive the cadence from (e.g. final line of the song). */
+const DEFAULT_LINE_DURATION_MS = 3000;
+/** Floor for the reveal duration so very short LRC lines still appear
+ *  to type rather than instantly snapping. */
+const MIN_LINE_DURATION_MS = 700;
+/** Cap so a long instrumental gap before the *next* line doesn't make
+ *  the current line drip out for 30+ seconds. */
+const MAX_LINE_DURATION_MS = 6000;
+/** Reveal slightly faster than the line's duration so the final
+ *  character lands a beat before the next line takes over. */
+const REVEAL_SPEED_FACTOR = 0.85;
+
 /**
- * Single-line lyric ticker shown over the MTV channel video.
+ * Single-line, TV-style closed-caption overlay for the MTV channel.
  *
  * MTV plays from the user's iPod library, so we can reuse the same
  * `useLyrics` pipeline the iPod / Karaoke apps use — the song id of the
  * current TV video is the same id the iPod uses for lyrics lookups.
  *
- * Visually we match the existing TV LCD/status text: a clean sans-serif
- * line with a black stroke for readability over arbitrary YouTube
- * frames. Only the active lyric line is shown (no past / next lines),
- * crossfaded as playback advances.
+ * Visually we mimic broadcast closed captions: Geneva pixel font,
+ * white-on-black plate, centered near the bottom of the picture. Each
+ * line types itself out character-by-character timed to the line's
+ * duration (next-line-start minus current-line-start), so faster lyric
+ * lines reveal faster and slow lines drift in.
  */
 export function MtvLyricsOverlay({
   songId,
@@ -63,54 +77,128 @@ export function MtvLyricsOverlay({
     currentTime: playedSeconds + lyricOffsetSeconds,
   });
 
-  const currentText = useMemo(() => {
-    if (!visible) return "";
+  // Resolve the active line plus the timing window we should type it out
+  // across. We derive the duration from the gap to the next line's
+  // start; this keeps fast verses snappy and slow lines unhurried.
+  const { currentText, lineKey, lineDurationMs } = useMemo(() => {
+    if (!visible) {
+      return { currentText: "", lineKey: "", lineDurationMs: 0 };
+    }
     const idx = lyricsState.currentLine;
-    if (idx < 0) return "";
+    if (idx < 0) {
+      return { currentText: "", lineKey: "", lineDurationMs: 0 };
+    }
     const line = lyricsState.lines[idx];
-    return line?.words?.trim() ?? "";
+    const text = line?.words?.trim() ?? "";
+    if (!text) {
+      return { currentText: "", lineKey: "", lineDurationMs: 0 };
+    }
+    const startMs = parseInt(line!.startTimeMs, 10);
+    const nextLine = lyricsState.lines[idx + 1];
+    const nextMs = nextLine ? parseInt(nextLine.startTimeMs, 10) : NaN;
+    let duration = Number.isFinite(nextMs) && Number.isFinite(startMs)
+      ? nextMs - startMs
+      : DEFAULT_LINE_DURATION_MS;
+    duration = Math.min(MAX_LINE_DURATION_MS, Math.max(MIN_LINE_DURATION_MS, duration));
+    // Use both index and start time in the key so two consecutive
+    // identical lyric lines (e.g. repeated chorus hook) still re-trigger
+    // the typewriter animation instead of snapping to fully-revealed.
+    const key = `${idx}:${line!.startTimeMs}`;
+    return { currentText: text, lineKey: key, lineDurationMs: duration };
   }, [visible, lyricsState.currentLine, lyricsState.lines]);
+
+  // Local typewriter clock. We re-base on every line change rather than
+  // tying reveal progress to `playedSeconds` directly because react-player's
+  // default progress interval is coarse (~1Hz on this surface), which would
+  // make the reveal step in obvious chunks instead of flowing per-frame.
+  const [revealedChars, setRevealedChars] = useState(0);
+  const rafRef = useRef<number | null>(null);
+  const lineStartRef = useRef<number>(0);
+
+  useEffect(() => {
+    setRevealedChars(0);
+    if (!currentText || !lineDurationMs) return;
+    lineStartRef.current = performance.now();
+    // Reveal speed factor < 1 so the line finishes a touch early, leaving
+    // a brief "fully shown" beat before the next line takes the stage.
+    const totalRevealMs = Math.max(
+      MIN_LINE_DURATION_MS * REVEAL_SPEED_FACTOR,
+      lineDurationMs * REVEAL_SPEED_FACTOR
+    );
+    const tick = () => {
+      const elapsed = performance.now() - lineStartRef.current;
+      const progress = Math.min(1, Math.max(0, elapsed / totalRevealMs));
+      const target = Math.min(
+        currentText.length,
+        Math.ceil(progress * currentText.length)
+      );
+      setRevealedChars(target);
+      if (progress < 1) {
+        rafRef.current = requestAnimationFrame(tick);
+      } else {
+        rafRef.current = null;
+      }
+    };
+    rafRef.current = requestAnimationFrame(tick);
+    return () => {
+      if (rafRef.current !== null) {
+        cancelAnimationFrame(rafRef.current);
+        rafRef.current = null;
+      }
+    };
+  }, [lineKey, currentText, lineDurationMs]);
 
   if (!visible) return null;
 
   const isFullscreen = variant === "fullscreen";
+  const visibleText = currentText.slice(0, revealedChars);
+  // Render the not-yet-revealed remainder as transparent text inside the
+  // same span so the caption plate sizes to the *full* line up front,
+  // preventing the box from growing as characters appear.
+  const hiddenText = currentText.slice(revealedChars);
 
   return (
     <div
       className={cn(
-        "pointer-events-none absolute inset-x-0 z-30 flex justify-center px-6",
-        isFullscreen ? "bottom-[18%]" : "bottom-6"
+        "pointer-events-none absolute inset-x-0 z-30 flex justify-center px-4",
+        isFullscreen ? "bottom-[14%]" : "bottom-6"
       )}
       aria-hidden
     >
       <AnimatePresence mode="popLayout" initial={false}>
         {currentText ? (
           <motion.div
-            key={currentText}
-            initial={{ opacity: 0, y: 8 }}
+            key={lineKey}
+            initial={{ opacity: 0, y: 6 }}
             animate={{ opacity: 1, y: 0 }}
-            exit={{ opacity: 0, y: -8 }}
-            transition={{ duration: 0.25, ease: "easeOut" }}
+            exit={{ opacity: 0, y: -4 }}
+            transition={{ duration: 0.18, ease: "easeOut" }}
             className={cn(
-              "font-lyrics-sans text-center text-white",
-              // Cap width so a long line stays on a single rendered row but
-              // wraps off-screen via truncate rather than spilling under the
-              // LCD / pushing the YouTube iframe.
-              "max-w-[92%] truncate",
-              "font-medium tracking-wide",
+              "font-geneva-12 text-white text-center leading-none",
+              // Solid black plate matching the broadcast CC look.
+              "bg-black/85",
+              // Squared-off CC plate (no rounding) keeps the broadcast feel.
+              "max-w-[92%]",
               isFullscreen
-                ? "text-[clamp(20px,4vw,44px)]"
-                : "text-[18px] sm:text-[22px] md:text-[26px]"
+                ? "text-[clamp(18px,3.2vw,36px)] px-3 py-2"
+                : "text-[18px] sm:text-[20px] px-2 py-1"
             )}
             style={{
-              // Match the LCD's `StatusDisplay` outline approach so the
-              // lyric stays readable over bright YouTube frames without
-              // adding a backplate that would feel un-broadcast-y.
-              textShadow:
-                "0 0 6px rgba(0,0,0,0.85), 0 1px 2px rgba(0,0,0,0.9), 0 0 14px rgba(0,0,0,0.55)",
+              // Slight letter-spacing so the pixel font reads cleanly at
+              // small sizes; matches the LCD column treatment.
+              letterSpacing: "0.01em",
+              // Tighten leading; CCs are typically a single dense line.
+              lineHeight: 1.15,
+              whiteSpace: "pre-wrap",
+              wordBreak: "break-word",
             }}
           >
-            {currentText}
+            <span>{visibleText}</span>
+            {hiddenText ? (
+              <span aria-hidden className="opacity-0">
+                {hiddenText}
+              </span>
+            ) : null}
           </motion.div>
         ) : null}
       </AnimatePresence>

--- a/src/apps/tv/components/MtvLyricsOverlay.tsx
+++ b/src/apps/tv/components/MtvLyricsOverlay.tsx
@@ -1,9 +1,9 @@
 import { useEffect, useMemo, useRef, useState } from "react";
-import { AnimatePresence, motion } from "framer-motion";
 import { useShallow } from "zustand/react/shallow";
 import { useLyrics } from "@/hooks/useLyrics";
 import { useIpodStore } from "@/stores/useIpodStore";
 import { cn } from "@/lib/utils";
+import type { LyricLine } from "@/types/lyrics";
 
 interface MtvLyricsOverlayProps {
   /** The id of the currently playing video. For the MTV channel this maps
@@ -26,31 +26,32 @@ interface MtvLyricsOverlayProps {
   variant?: "windowed" | "fullscreen";
 }
 
-/** Default reveal duration for a line when we don't have a "next line"
- *  timestamp to derive the cadence from (e.g. final line of the song). */
-const DEFAULT_LINE_DURATION_MS = 3000;
-/** Floor for the reveal duration so very short LRC lines still appear
- *  to type rather than instantly snapping. */
-const MIN_LINE_DURATION_MS = 700;
-/** Cap so a long instrumental gap before the *next* line doesn't make
- *  the current line drip out for 30+ seconds. */
-const MAX_LINE_DURATION_MS = 6000;
-/** Reveal slightly faster than the line's duration so the final
- *  character lands a beat before the next line takes over. */
-const REVEAL_SPEED_FACTOR = 0.85;
+/** Cap reveal extrapolation between coarse `playedSeconds` updates so a
+ *  long buffering / pause can't make the typewriter run past the line. */
+const MAX_INTERPOLATE_MS = 500;
+/** Fallback line duration (ms) when there is no next line to derive
+ *  cadence from (last line of the song). */
+const FALLBACK_LINE_DURATION_MS = 4000;
 
 /**
  * Single-line, TV-style closed-caption overlay for the MTV channel.
  *
- * MTV plays from the user's iPod library, so we can reuse the same
- * `useLyrics` pipeline the iPod / Karaoke apps use — the song id of the
- * current TV video is the same id the iPod uses for lyrics lookups.
+ * MTV plays from the user's iPod library, so we reuse the same
+ * `useLyrics` pipeline iPod / Karaoke use — the song id of the current
+ * TV video is the same id the iPod uses for lyrics lookups.
  *
- * Visually we mimic broadcast closed captions: Geneva pixel font,
- * white-on-black plate, centered near the bottom of the picture. Each
- * line types itself out character-by-character timed to the line's
- * duration (next-line-start minus current-line-start), so faster lyric
- * lines reveal faster and slow lines drift in.
+ * Reveal timing matches the audio:
+ *   - When the LRC has KRC word timings (`wordTimings[]`), each character
+ *     is revealed at its true word's `startTimeMs + durationMs` window.
+ *   - Otherwise we evenly distribute characters across the line duration
+ *     (next-line-start − current-line-start), matching how karaoke /
+ *     iPod fall back when KRC data is missing.
+ *
+ * Smoothness is achieved with the same trick `WordTimingHighlight` uses
+ * in `LyricsDisplay`: take the latest prop `currentTimeMs` and
+ * extrapolate forward via `performance.now()` per `requestAnimationFrame`
+ * tick (capped, so a pause can't drift), instead of being limited by
+ * react-player's coarse progress callbacks.
  */
 export function MtvLyricsOverlay({
   songId,
@@ -68,94 +69,153 @@ export function MtvLyricsOverlay({
       songId ? s.tracks.find((t) => t.id === songId) ?? null : null
     )
   );
-  const lyricOffsetSeconds = (track?.lyricOffset ?? 0) / 1000;
+  const lyricOffsetMs = track?.lyricOffset ?? 0;
+  const currentTimeMs = playedSeconds * 1000 + lyricOffsetMs;
 
   const lyricsState = useLyrics({
     songId: songId ?? "",
     title: title ?? track?.title ?? "",
     artist: artist ?? track?.artist ?? "",
-    currentTime: playedSeconds + lyricOffsetSeconds,
+    // useLyrics expects seconds; lyricOffset is folded back in here so
+    // currentLine matches what we'll render.
+    currentTime: currentTimeMs / 1000,
   });
 
-  // Resolve the active line plus the timing window we should type it out
-  // across. We derive the duration from the gap to the next line's
-  // start; this keeps fast verses snappy and slow lines unhurried.
-  const { currentText, lineKey, lineDurationMs } = useMemo(() => {
-    if (!visible) {
-      return { currentText: "", lineKey: "", lineDurationMs: 0 };
-    }
+  const activeLine: LyricLine | null = useMemo(() => {
+    if (!visible) return null;
     const idx = lyricsState.currentLine;
-    if (idx < 0) {
-      return { currentText: "", lineKey: "", lineDurationMs: 0 };
-    }
-    const line = lyricsState.lines[idx];
-    const text = line?.words?.trim() ?? "";
-    if (!text) {
-      return { currentText: "", lineKey: "", lineDurationMs: 0 };
-    }
-    const startMs = parseInt(line!.startTimeMs, 10);
-    const nextLine = lyricsState.lines[idx + 1];
-    const nextMs = nextLine ? parseInt(nextLine.startTimeMs, 10) : NaN;
-    let duration = Number.isFinite(nextMs) && Number.isFinite(startMs)
-      ? nextMs - startMs
-      : DEFAULT_LINE_DURATION_MS;
-    duration = Math.min(MAX_LINE_DURATION_MS, Math.max(MIN_LINE_DURATION_MS, duration));
-    // Use both index and start time in the key so two consecutive
-    // identical lyric lines (e.g. repeated chorus hook) still re-trigger
-    // the typewriter animation instead of snapping to fully-revealed.
-    const key = `${idx}:${line!.startTimeMs}`;
-    return { currentText: text, lineKey: key, lineDurationMs: duration };
+    if (idx < 0) return null;
+    return lyricsState.lines[idx] ?? null;
   }, [visible, lyricsState.currentLine, lyricsState.lines]);
 
-  // Local typewriter clock. We re-base on every line change rather than
-  // tying reveal progress to `playedSeconds` directly because react-player's
-  // default progress interval is coarse (~1Hz on this surface), which would
-  // make the reveal step in obvious chunks instead of flowing per-frame.
+  const fullText = (activeLine?.words ?? "").trim();
+  const lineStartMs = activeLine ? parseInt(activeLine.startTimeMs, 10) : NaN;
+
+  // Duration of the current line: from this line's start to the next
+  // line's start. Falls back to a sensible default for the last line.
+  const lineDurationMs = useMemo(() => {
+    if (!activeLine) return 0;
+    const idx = lyricsState.currentLine;
+    const next = lyricsState.lines[idx + 1];
+    if (!next) return FALLBACK_LINE_DURATION_MS;
+    const a = parseInt(activeLine.startTimeMs, 10);
+    const b = parseInt(next.startTimeMs, 10);
+    if (!Number.isFinite(a) || !Number.isFinite(b) || b <= a) {
+      return FALLBACK_LINE_DURATION_MS;
+    }
+    return b - a;
+  }, [activeLine, lyricsState.currentLine, lyricsState.lines]);
+
+  // Pre-compute character → reveal-time-ms map for the current line.
+  // When KRC word timings are available, characters reveal at their true
+  // word boundaries (interpolated within a word so the reveal is smooth
+  // across multi-char words). Otherwise we evenly distribute characters
+  // across the line duration.
+  const charRevealMs = useMemo<number[]>(() => {
+    if (!fullText) return [];
+    const wordTimings = activeLine?.wordTimings;
+    if (wordTimings && wordTimings.length > 0) {
+      // Walk the original (untrimmed) line so word.text offsets line up,
+      // then map back to indices in the trimmed fullText. Trimming only
+      // strips leading/trailing whitespace, so a single offset shift is
+      // enough.
+      const original = activeLine?.words ?? "";
+      const leadingTrim = original.length - original.trimStart().length;
+      const arr = new Array<number>(fullText.length).fill(0);
+      let charsAssigned = 0;
+      for (let w = 0; w < wordTimings.length; w++) {
+        const word = wordTimings[w];
+        const len = word.text.length;
+        for (let c = 0; c < len; c++) {
+          const idxInOriginal = charsAssigned + c;
+          const idxInTrimmed = idxInOriginal - leadingTrim;
+          if (idxInTrimmed < 0 || idxInTrimmed >= arr.length) continue;
+          // Spread chars evenly within the word's duration so a long
+          // sustained word still drips in instead of snapping.
+          const within =
+            len > 0
+              ? ((c + 1) / len) * Math.max(0, word.durationMs)
+              : word.durationMs;
+          arr[idxInTrimmed] = word.startTimeMs + within;
+        }
+        charsAssigned += len;
+      }
+      // Any trailing chars (e.g. punctuation past final word timing) get
+      // pinned to the last word's end so they reveal at the same moment.
+      const lastWord = wordTimings[wordTimings.length - 1];
+      const lastEnd = lastWord.startTimeMs + lastWord.durationMs;
+      for (let i = 0; i < arr.length; i++) {
+        if (arr[i] === 0 && i > 0) arr[i] = lastEnd;
+      }
+      return arr;
+    }
+    // No word timings — distribute evenly across the line's duration.
+    const total = lineDurationMs;
+    return Array.from({ length: fullText.length }, (_, i) =>
+      ((i + 1) / fullText.length) * total
+    );
+  }, [fullText, activeLine, lineDurationMs]);
+
+  // Track the latest prop time + when we received it so we can
+  // extrapolate per-frame for smooth reveal between coarse progress
+  // callbacks. This mirrors `WordTimingHighlight` in LyricsDisplay.
+  const timeRef = useRef({
+    propTimeMs: currentTimeMs,
+    propTakenAt: performance.now(),
+  });
+  useEffect(() => {
+    timeRef.current.propTimeMs = currentTimeMs;
+    timeRef.current.propTakenAt = performance.now();
+  }, [currentTimeMs]);
+
   const [revealedChars, setRevealedChars] = useState(0);
-  const rafRef = useRef<number | null>(null);
-  const lineStartRef = useRef<number>(0);
+  const lastRevealedRef = useRef(0);
+  const lineKey = activeLine
+    ? `${lyricsState.currentLine}:${activeLine.startTimeMs}`
+    : "";
 
   useEffect(() => {
+    lastRevealedRef.current = 0;
     setRevealedChars(0);
-    if (!currentText || !lineDurationMs) return;
-    lineStartRef.current = performance.now();
-    // Reveal speed factor < 1 so the line finishes a touch early, leaving
-    // a brief "fully shown" beat before the next line takes the stage.
-    const totalRevealMs = Math.max(
-      MIN_LINE_DURATION_MS * REVEAL_SPEED_FACTOR,
-      lineDurationMs * REVEAL_SPEED_FACTOR
-    );
-    const tick = () => {
-      const elapsed = performance.now() - lineStartRef.current;
-      const progress = Math.min(1, Math.max(0, elapsed / totalRevealMs));
-      const target = Math.min(
-        currentText.length,
-        Math.ceil(progress * currentText.length)
-      );
-      setRevealedChars(target);
-      if (progress < 1) {
-        rafRef.current = requestAnimationFrame(tick);
-      } else {
-        rafRef.current = null;
-      }
-    };
-    rafRef.current = requestAnimationFrame(tick);
-    return () => {
-      if (rafRef.current !== null) {
-        cancelAnimationFrame(rafRef.current);
-        rafRef.current = null;
-      }
-    };
-  }, [lineKey, currentText, lineDurationMs]);
+  }, [lineKey]);
 
-  if (!visible) return null;
+  useEffect(() => {
+    if (!fullText || !Number.isFinite(lineStartMs)) {
+      if (lastRevealedRef.current !== 0) {
+        lastRevealedRef.current = 0;
+        setRevealedChars(0);
+      }
+      return;
+    }
+    let raf = 0;
+    const tick = () => {
+      const sinceProp = Math.min(
+        MAX_INTERPOLATE_MS,
+        performance.now() - timeRef.current.propTakenAt
+      );
+      const liveTimeMs = timeRef.current.propTimeMs + sinceProp;
+      const timeIntoLine = liveTimeMs - lineStartMs;
+      // Binary scan would be overkill for a typical line (<100 chars).
+      let count = 0;
+      for (let i = 0; i < charRevealMs.length; i++) {
+        if (charRevealMs[i] <= timeIntoLine) count = i + 1;
+        else break;
+      }
+      if (count !== lastRevealedRef.current) {
+        lastRevealedRef.current = count;
+        setRevealedChars(count);
+      }
+      raf = requestAnimationFrame(tick);
+    };
+    raf = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(raf);
+  }, [fullText, lineStartMs, charRevealMs]);
+
+  if (!visible || !fullText) return null;
 
   const isFullscreen = variant === "fullscreen";
-  const visibleText = currentText.slice(0, revealedChars);
-  // Render the not-yet-revealed remainder as transparent text inside the
-  // same span so the caption plate sizes to the *full* line up front,
-  // preventing the box from growing as characters appear.
-  const hiddenText = currentText.slice(revealedChars);
+  const visibleText = fullText.slice(0, revealedChars);
+  const hiddenText = fullText.slice(revealedChars);
 
   return (
     <div
@@ -165,43 +225,31 @@ export function MtvLyricsOverlay({
       )}
       aria-hidden
     >
-      <AnimatePresence mode="popLayout" initial={false}>
-        {currentText ? (
-          <motion.div
-            key={lineKey}
-            initial={{ opacity: 0, y: 6 }}
-            animate={{ opacity: 1, y: 0 }}
-            exit={{ opacity: 0, y: -4 }}
-            transition={{ duration: 0.18, ease: "easeOut" }}
-            className={cn(
-              "font-geneva-12 text-white text-center leading-none",
-              // Solid black plate matching the broadcast CC look.
-              "bg-black/85",
-              // Squared-off CC plate (no rounding) keeps the broadcast feel.
-              "max-w-[92%]",
-              isFullscreen
-                ? "text-[clamp(18px,3.2vw,36px)] px-3 py-2"
-                : "text-[18px] sm:text-[20px] px-2 py-1"
-            )}
-            style={{
-              // Slight letter-spacing so the pixel font reads cleanly at
-              // small sizes; matches the LCD column treatment.
-              letterSpacing: "0.01em",
-              // Tighten leading; CCs are typically a single dense line.
-              lineHeight: 1.15,
-              whiteSpace: "pre-wrap",
-              wordBreak: "break-word",
-            }}
-          >
-            <span>{visibleText}</span>
-            {hiddenText ? (
-              <span aria-hidden className="opacity-0">
-                {hiddenText}
-              </span>
-            ) : null}
-          </motion.div>
+      {/* Keyed swap with no enter animation — caption snaps in like
+          broadcast CCs. The container itself remounts per line so prior
+          line is replaced instantly. */}
+      <div
+        key={lineKey}
+        className={cn(
+          "font-geneva-12 text-white text-center leading-none bg-black/85 max-w-[92%]",
+          isFullscreen
+            ? "text-[clamp(18px,3.2vw,36px)] px-3 py-2"
+            : "text-[18px] sm:text-[20px] px-2 py-1"
+        )}
+        style={{
+          letterSpacing: "0.01em",
+          lineHeight: 1.15,
+          whiteSpace: "pre-wrap",
+          wordBreak: "break-word",
+        }}
+      >
+        <span>{visibleText}</span>
+        {hiddenText ? (
+          <span aria-hidden className="opacity-0">
+            {hiddenText}
+          </span>
         ) : null}
-      </AnimatePresence>
+      </div>
     </div>
   );
 }

--- a/src/apps/tv/components/MtvLyricsOverlay.tsx
+++ b/src/apps/tv/components/MtvLyricsOverlay.tsx
@@ -1,0 +1,119 @@
+import { useMemo } from "react";
+import { AnimatePresence, motion } from "framer-motion";
+import { useShallow } from "zustand/react/shallow";
+import { useLyrics } from "@/hooks/useLyrics";
+import { useIpodStore } from "@/stores/useIpodStore";
+import { cn } from "@/lib/utils";
+
+interface MtvLyricsOverlayProps {
+  /** The id of the currently playing video. For the MTV channel this maps
+   *  1:1 to an iPod track id (see `trackToVideo` in `useTvLogic`). */
+  songId: string | undefined;
+  /** Optional title used as a fallback when the lyrics service has to do
+   *  a fresh search (matches the iPod / Karaoke wiring). */
+  title?: string;
+  /** Optional artist used as a fallback for the same reason. */
+  artist?: string;
+  /** Current playback time, in seconds, from ReactPlayer's onProgress. */
+  playedSeconds: number;
+  /** When false, no overlay is rendered. */
+  visible: boolean;
+  /**
+   * Layout / sizing variant. `windowed` is the in-app TV; `fullscreen`
+   * uses larger type and viewport-relative offsets so the line stays
+   * legible on big displays.
+   */
+  variant?: "windowed" | "fullscreen";
+}
+
+/**
+ * Single-line lyric ticker shown over the MTV channel video.
+ *
+ * MTV plays from the user's iPod library, so we can reuse the same
+ * `useLyrics` pipeline the iPod / Karaoke apps use — the song id of the
+ * current TV video is the same id the iPod uses for lyrics lookups.
+ *
+ * Visually we match the existing TV LCD/status text: a clean sans-serif
+ * line with a black stroke for readability over arbitrary YouTube
+ * frames. Only the active lyric line is shown (no past / next lines),
+ * crossfaded as playback advances.
+ */
+export function MtvLyricsOverlay({
+  songId,
+  title,
+  artist,
+  playedSeconds,
+  visible,
+  variant = "windowed",
+}: MtvLyricsOverlayProps) {
+  // Pull the matching iPod track so we can apply its `lyricOffset`. Using
+  // a shallow selector keeps this overlay from re-rendering on unrelated
+  // ipod store changes.
+  const track = useIpodStore(
+    useShallow((s) =>
+      songId ? s.tracks.find((t) => t.id === songId) ?? null : null
+    )
+  );
+  const lyricOffsetSeconds = (track?.lyricOffset ?? 0) / 1000;
+
+  const lyricsState = useLyrics({
+    songId: songId ?? "",
+    title: title ?? track?.title ?? "",
+    artist: artist ?? track?.artist ?? "",
+    currentTime: playedSeconds + lyricOffsetSeconds,
+  });
+
+  const currentText = useMemo(() => {
+    if (!visible) return "";
+    const idx = lyricsState.currentLine;
+    if (idx < 0) return "";
+    const line = lyricsState.lines[idx];
+    return line?.words?.trim() ?? "";
+  }, [visible, lyricsState.currentLine, lyricsState.lines]);
+
+  if (!visible) return null;
+
+  const isFullscreen = variant === "fullscreen";
+
+  return (
+    <div
+      className={cn(
+        "pointer-events-none absolute inset-x-0 z-30 flex justify-center px-6",
+        isFullscreen ? "bottom-[18%]" : "bottom-6"
+      )}
+      aria-hidden
+    >
+      <AnimatePresence mode="popLayout" initial={false}>
+        {currentText ? (
+          <motion.div
+            key={currentText}
+            initial={{ opacity: 0, y: 8 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: -8 }}
+            transition={{ duration: 0.25, ease: "easeOut" }}
+            className={cn(
+              "font-lyrics-sans text-center text-white",
+              // Cap width so a long line stays on a single rendered row but
+              // wraps off-screen via truncate rather than spilling under the
+              // LCD / pushing the YouTube iframe.
+              "max-w-[92%] truncate",
+              "font-medium tracking-wide",
+              isFullscreen
+                ? "text-[clamp(20px,4vw,44px)]"
+                : "text-[18px] sm:text-[22px] md:text-[26px]"
+            )}
+            style={{
+              // Match the LCD's `StatusDisplay` outline approach so the
+              // lyric stays readable over bright YouTube frames without
+              // adding a backplate that would feel un-broadcast-y.
+              textShadow:
+                "0 0 6px rgba(0,0,0,0.85), 0 1px 2px rgba(0,0,0,0.9), 0 0 14px rgba(0,0,0,0.55)",
+            }}
+          >
+            {currentText}
+          </motion.div>
+        ) : null}
+      </AnimatePresence>
+    </div>
+  );
+}

--- a/src/apps/tv/components/TvAppComponent.tsx
+++ b/src/apps/tv/components/TvAppComponent.tsx
@@ -32,7 +32,8 @@ import { Button } from "@/components/ui/button";
 import { getTranslatedAppName } from "@/utils/i18n";
 import { VideoFullScreenPortal } from "@/components/shared/VideoFullScreenPortal";
 import { YouTubePlayer } from "@/components/shared/YouTubePlayer";
-import { useTvLogic } from "../hooks/useTvLogic";
+import { useTvLogic, MTV_CHANNEL_ID } from "../hooks/useTvLogic";
+import { MtvLyricsOverlay } from "./MtvLyricsOverlay";
 import { SkipBack, SkipForward, Play, Pause } from "@phosphor-icons/react";
 import { toast } from "sonner";
 
@@ -357,6 +358,7 @@ export function TvAppComponent({
     animationDirection,
     scheduleNowTitle,
     scheduleNextTitle,
+    playedSeconds,
   } = useTvLogic({ isWindowOpen, isForeground });
 
   // NOTE: All hooks must be called unconditionally on every render. The
@@ -944,6 +946,15 @@ export function TvAppComponent({
                 buffering={isBuffering || (!url && isPlaying)}
                 crtActive={lcdFilterOn}
               />
+              {currentChannelId === MTV_CHANNEL_ID && !isFullScreen && (
+                <MtvLyricsOverlay
+                  songId={currentVideo?.id}
+                  title={currentVideo?.title}
+                  artist={currentVideo?.artist}
+                  playedSeconds={playedSeconds}
+                  visible={!screenOff && !poweringOff && Boolean(url)}
+                />
+              )}
               <AnimatePresence>
                 {statusMessage && (
                   <motion.div
@@ -1289,6 +1300,18 @@ export function TvAppComponent({
           onPrevious={prevVideo}
           showStatus={showStatus}
           statusMessage={statusMessage}
+          videoOverlay={
+            currentChannelId === MTV_CHANNEL_ID ? (
+              <MtvLyricsOverlay
+                songId={currentVideo?.id}
+                title={currentVideo?.title}
+                artist={currentVideo?.artist}
+                playedSeconds={playedSeconds}
+                visible
+                variant="fullscreen"
+              />
+            ) : null
+          }
         />
       )}
     </>

--- a/src/components/shared/VideoFullScreenPortal.tsx
+++ b/src/components/shared/VideoFullScreenPortal.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect, useCallback } from "react";
+import { useState, useRef, useEffect, useCallback, type ReactNode } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { createPortal } from "react-dom";
 import type ReactPlayer from "react-player";
@@ -29,6 +29,13 @@ interface VideoFullScreenPortalProps {
   statusMessage?: string | null;
   isShuffled?: boolean;
   onToggleShuffle?: () => void;
+  /**
+   * Optional content rendered above the video but below the on-screen
+   * status / toolbar overlays. Used by callers (e.g. TV's MTV channel) to
+   * draw a single-line lyric ticker without coupling that logic to the
+   * shared portal.
+   */
+  videoOverlay?: ReactNode;
 }
 
 export function VideoFullScreenPortal({
@@ -53,6 +60,7 @@ export function VideoFullScreenPortal({
   statusMessage,
   isShuffled,
   onToggleShuffle,
+  videoOverlay,
 }: VideoFullScreenPortalProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const [showControls, setShowControls] = useState(true);
@@ -233,6 +241,11 @@ export function VideoFullScreenPortal({
       </AnimatePresence>
 
       <div className="flex-1 min-h-0 relative overflow-hidden">
+        {videoOverlay ? (
+          <div className="pointer-events-none absolute inset-0 z-30">
+            {videoOverlay}
+          </div>
+        ) : null}
         <div className="absolute inset-0 w-full h-full">
           <div
             className="w-full absolute"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a TV closed-caption-style single-line lyric overlay on the **MTV** channel of the TV app.

## What

- New `MtvLyricsOverlay` component reusing the shared `useLyrics` pipeline (same as iPod / Karaoke). MTV plays from the iPod library, so each TV video id maps 1:1 to an iPod track id, and lyrics + per-track `lyricOffset` Just Work.
- Broadcast CC look: solid black plate with white **Geneva-12** pixel text (the same font the TV uses for its channel-status overlay). No entry animation — line swaps in instantly like real captions.
- Reveal timing matches the audio:
  - When LRC has KRC `wordTimings[]`, each character is mapped to its word's `startTimeMs + durationMs` (interpolated across multi-char words).
  - Otherwise characters distribute evenly across the line duration (next-line-start − current-line-start), matching the karaoke fallback.
  - Smoothness comes from extrapolating `performance.now()` forward from the latest `playedSeconds` prop (capped at 500ms) per `requestAnimationFrame` tick — same trick `WordTimingHighlight` uses in `LyricsDisplay`.
- Caption plate is sized to the *full* upcoming line (visible text + transparent remainder) so the box doesn't grow as characters appear.
- Mounts only when the current channel is `mtv`; other channels skip the lyrics fetch entirely.
- Wired through both the windowed view and the shared `VideoFullScreenPortal` (new optional `videoOverlay` prop).

## Files

- `src/apps/tv/components/MtvLyricsOverlay.tsx` (new)
- `src/apps/tv/components/TvAppComponent.tsx` (mount overlay on MTV)
- `src/components/shared/VideoFullScreenPortal.tsx` (optional `videoOverlay` slot)

## Testing

- `bun run build` succeeds.
- `bun run lint` only reports pre-existing warnings/errors unrelated to this change.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3c428863-af30-4d9b-9040-9c28d262949b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3c428863-af30-4d9b-9040-9c28d262949b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

