### PR TITLE
fix(macosx): include CJK and emoji pixel fonts in LCD font stack

### DIFF
--- a/src/styles/themes.css
+++ b/src/styles/themes.css
@@ -969,17 +969,17 @@
   font-smooth: auto !important;
 }
 :root[data-os-theme="macosx"] .videos-lcd .font-geneva-12.text-\[10px\] {
-  font-family: Geneva-12, monospace !important;
+  font-family: "Geneva-12", "ArkPixel", "SerenityOS-Emoji", monospace !important;
 }
 
 :root[data-os-theme="macosx"] .videos-lcd .font-geneva-12 .text-xl {
   font-size: 1.25rem !important;
-  font-family: Geneva-12, monospace !important;
+  font-family: "Geneva-12", "ArkPixel", "SerenityOS-Emoji", monospace !important;
 }
 
 :root[data-os-theme="macosx"] .videos-lcd .text-xl {
   font-size: 1.25rem !important;
-  font-family: Geneva-12, monospace !important;
+  font-family: "Geneva-12", "ArkPixel", "SerenityOS-Emoji", monospace !important;
 }
 
 /* Ensure AnimatedNumber components inherit correct size */
@@ -990,7 +990,7 @@
 
 :root[data-os-theme="macosx"] .videos-lcd .font-geneva-12.text-\[18px\] {
   font-size: 18px !important;
-  font-family: Geneva-12, monospace !important;
+  font-family: "Geneva-12", "ArkPixel", "SerenityOS-Emoji", monospace !important;
 }
 
 /* Videos LCD macOS X color scheme (inspired by Minesweeper LCD) */


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary

The macOS X theme override for the shared `.videos-lcd` font stack (used by both Videos and TV apps) declared `font-family: Geneva-12, monospace`. That dropped the `ArkPixel` (CJK) and `SerenityOS-Emoji` (pixel emoji) fallbacks that the rest of the System 7 font stack uses, so CJK characters and emoji in LCD text fell through to the browser's generic monospace.

This change restores those fallbacks on every macOS X `.videos-lcd` font-family rule so LCD text matches System 7 pixel typography across scripts:

`"Geneva-12", "ArkPixel", "SerenityOS-Emoji", monospace`

Affected rules in `src/styles/themes.css`:
- `.videos-lcd .font-geneva-12.text-[10px]`
- `.videos-lcd .font-geneva-12 .text-xl`
- `.videos-lcd .text-xl`
- `.videos-lcd .font-geneva-12.text-[18px]`

### Testing

- ✅ `bun run build`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-77604358-6524-4e7b-bd7d-72dada089417"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-77604358-6524-4e7b-bd7d-72dada089417"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

