### PR TITLE
fix(tv): keep MTV CC spacer in sync with per-word padding

### DIFF
--- a/src/apps/tv/components/MtvLyricsOverlay.tsx
+++ b/src/apps/tv/components/MtvLyricsOverlay.tsx
@@ -240,6 +240,15 @@ export function MtvLyricsOverlay({
     boxDecorationBreak: "clone" as const,
   };
 
+  // Inline horizontal padding on each visible word adds a few px of width
+  // per token. The invisible spacer below — which sets the row height the
+  // animated line slides through — must use the *same* per-token markup
+  // and padding, otherwise the visible row can be a few px wider than the
+  // spacer, wrap to a second visual line, and get clipped by the parent's
+  // overflow-hidden (used for the slide transitions). That manifested as
+  // the last word silently disappearing on lines that just barely fit.
+  const wordPlateClassName = "bg-black/85 text-white px-0.5 rounded-none";
+
   // z-[15]: below click-capture (z-20), CRT static (z-30+).
   return (
     <div
@@ -258,7 +267,15 @@ export function MtvLyricsOverlay({
           transforms. */}
       <div className="relative w-full max-w-[92%]">
         <div aria-hidden className={cn(lineTypography, "invisible")} style={lineTone}>
-          {fullText}
+          {tokens.map((t, i) => (
+            <span
+              key={`s-${lineKey}-${i}`}
+              className={wordPlateClassName}
+              style={wordPlateStyle}
+            >
+              {t.text}
+            </span>
+          ))}
         </div>
         <div className="pointer-events-none absolute inset-0 overflow-hidden">
           <AnimatePresence mode="sync" initial={false}>
@@ -280,7 +297,7 @@ export function MtvLyricsOverlay({
               {revealed.map((t, i) => (
                 <span
                   key={`v-${lineKey}-${i}`}
-                  className="bg-black/85 text-white px-0.5 rounded-none"
+                  className={wordPlateClassName}
                   style={wordPlateStyle}
                 >
                   {t.text}
@@ -290,7 +307,8 @@ export function MtvLyricsOverlay({
                 <span
                   key={`h-${lineKey}-${i}`}
                   aria-hidden
-                  className="inline opacity-0"
+                  className={cn(wordPlateClassName, "opacity-0")}
+                  style={wordPlateStyle}
                 >
                   {t.text}
                 </span>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

On the MTV channel, lyric lines that just barely fit on a single row would silently lose their last word.

## Root cause

`MtvLyricsOverlay` renders two stacked layers inside an `overflow-hidden` parent (the parent clips during slide-in/out line transitions):

1. An **invisible spacer** that locks the row height for the animation, rendered as plain text from `fullText`.
2. The **visible animated line**, rendered as one `<span>` per word, each with `bg-black/85 text-white px-0.5 rounded-none` for the per-token dark plate.

The `px-0.5` (4px horizontal padding) on each visible span accumulates: with N words, the visible row is roughly `4 * 2 * N` pixels wider than the plain-text spacer. On lines whose plain text fits a single line by only a few pixels, the padded version overflows to a second visual line, which is then clipped by the parent's `overflow-hidden` — the last word disappears.

## Fix

Render the invisible spacer with the **same per-token spans and same `px-0.5` plate classes** as the visible content, so both layers wrap identically. Also apply the plate classes to the unrevealed (transparent) tokens so the visible row's width stays consistent across reveal frames.

The per-token plate styling (the original reason for `px-0.5`) is preserved.

## Files

- `src/apps/tv/components/MtvLyricsOverlay.tsx` — extract `wordPlateClassName`, mirror it on the spacer and the unrevealed tokens.

## Testing

- ✅ `bun run build` — clean build, no TypeScript errors.
- ⚠️ `bun run lint` — only pre-existing warnings/errors in unrelated files; no new issues in `MtvLyricsOverlay.tsx`.

Skipped GUI testing per `AGENTS.md` ("Skip computer use / GUI-driven testing unless the user explicitly requests it") since this is a layout-correctness fix and the visible plate appearance is unchanged.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2b71815e-71db-4751-ba05-b298b3cbf638"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2b71815e-71db-4751-ba05-b298b3cbf638"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

