### PR TITLE
fix: resolve eslint errors blocking lint build

### DIFF
--- a/api/irc/servers/[id]/channels.ts
+++ b/api/irc/servers/[id]/channels.ts
@@ -20,7 +20,7 @@ export const maxDuration = 30;
 
 export default apiHandler(
   { methods: ["GET"], auth: "required" },
-  async ({ req, res, logger, startTime, user }) => {
+  async ({ req, res, logger, startTime }) => {
     const id = (req.query.id as string | undefined)?.trim();
     if (!id) {
       logger.response(400, Date.now() - startTime);

--- a/tests/test-wallpaper-cloud-sync-debug.test.ts
+++ b/tests/test-wallpaper-cloud-sync-debug.test.ts
@@ -98,7 +98,7 @@ describe("wallpaper cloud sync debug reproduction", () => {
     const { useDisplaySettingsStore, DEFAULT_WALLPAPER_PATH } = await import(
       "../src/stores/useDisplaySettingsStore"
     );
-    let syncDomainChecks: string[] = [];
+    const syncDomainChecks: string[] = [];
     const unsubscribe = subscribeToCloudSyncDomainCheckRequests((domain) => {
       syncDomainChecks.push(domain);
     });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`bun run lint` was failing with two errors. The `bun run build` step (`tsc -b && vite build`) itself was already green, but the lint command exited non-zero, which can block CI / build pipelines that gate on lint.

### Errors fixed

1. `api/irc/servers/[id]/channels.ts:23:41` — `'user' is defined but never used` (`@typescript-eslint/no-unused-vars`).
   - Dropped `user` from the destructured handler arguments. The handler does not reference the authenticated user, only the route id from `req.query`.
2. `tests/test-wallpaper-cloud-sync-debug.test.ts:101:9` — `'syncDomainChecks' is never reassigned. Use 'const' instead` (`prefer-const`).
   - Changed `let` to `const`; the array is only mutated via `.push`, never reassigned.

After the fix, `bun run lint` exits 0 with only pre-existing warnings (no errors), and `bun run build` continues to succeed.

## Verification

- `bun run lint` — passes (warnings only, no errors)
- `bun run build` — passes (TypeScript + Vite build)
- `bun test tests/test-wallpaper-cloud-sync-debug.test.ts` — passes

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2c12950b-ca9a-4faa-b1ba-984fc82f2d46"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2c12950b-ca9a-4faa-b1ba-984fc82f2d46"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

