### PR TITLE
fix(i18n): localize user-facing toasts, dialogs, and chrome strings

### DIFF
--- a/src/apps/applet-viewer/hooks/useAppletViewerLogic.ts
+++ b/src/apps/applet-viewer/hooks/useAppletViewerLogic.ts
@@ -122,20 +122,32 @@ export function useAppletViewerLogic({
     const result = await checkForUpdates();
     if (result.count > 0) {
       const appletNames = result.updates
-        .map((applet) => applet.title || applet.name || "Untitled Applet")
+        .map(
+          (applet) =>
+            applet.title ||
+            applet.name ||
+            t("apps.applet-viewer.dialogs.untitledApplet")
+        )
         .join(", ");
       toast.info(
-        `${result.count} new applet update${result.count > 1 ? "s" : ""}`,
+        t(
+          result.count === 1
+            ? "apps.applet-viewer.dialogs.newAppletUpdates"
+            : "apps.applet-viewer.dialogs.newAppletUpdatesPlural",
+          { count: result.count }
+        ),
         {
           description: appletNames,
           action: {
-            label: "Update",
+            label: t("apps.applet-viewer.status.update"),
             onClick: async () => {
               const updateCount = result.updates.length;
               const loadingMessage =
                 updateCount === 1
-                  ? "Updating 1 applet..."
-                  : `Updating ${updateCount} applets...`;
+                  ? t("apps.applet-viewer.dialogs.updatingAppletSingle")
+                  : t("apps.applet-viewer.dialogs.updatingAppletsPlural", {
+                      count: updateCount,
+                    });
               const loadingToastId = toast.loading(loadingMessage, {
                 duration: Infinity,
               });
@@ -149,8 +161,10 @@ export function useAppletViewerLogic({
 
                 toast.success(
                   updateCount === 1
-                    ? "Applet updated"
-                    : `${updateCount} applets updated`,
+                    ? t("apps.applet-viewer.dialogs.appletUpdated")
+                    : t("apps.applet-viewer.dialogs.appletsUpdated", {
+                        count: updateCount,
+                      }),
                   {
                     id: loadingToastId,
                     duration: 3000,
@@ -158,11 +172,11 @@ export function useAppletViewerLogic({
                 );
               } catch (error) {
                 console.error("Error updating applets:", error);
-                toast.error("Failed to update applets", {
+                toast.error(t("apps.applet-viewer.dialogs.failedToUpdateApplets"), {
                   description:
                     error instanceof Error
                       ? error.message
-                      : "Please try again later.",
+                      : t("apps.applet-viewer.dialogs.pleaseTryAgainLater"),
                   id: loadingToastId,
                 });
               }
@@ -172,9 +186,9 @@ export function useAppletViewerLogic({
         }
       );
     } else {
-      toast.success("All applets are up to date");
+      toast.success(t("apps.applet-viewer.dialogs.allAppletsUpToDate"));
     }
-  }, [checkForUpdates, actions]);
+  }, [checkForUpdates, actions, t]);
 
   const handleUpdateAll = useCallback(async () => {
     if (updatesAvailable.length === 0) return;
@@ -182,8 +196,10 @@ export function useAppletViewerLogic({
     const updateCount = updatesAvailable.length;
     const loadingMessage =
       updateCount === 1
-        ? "Updating 1 applet..."
-        : `Updating ${updateCount} applets...`;
+        ? t("apps.applet-viewer.dialogs.updatingAppletSingle")
+        : t("apps.applet-viewer.dialogs.updatingAppletsPlural", {
+            count: updateCount,
+          });
     const loadingToastId = toast.loading(loadingMessage, {
       duration: Infinity,
     });
@@ -197,8 +213,8 @@ export function useAppletViewerLogic({
 
       toast.success(
         updateCount === 1
-          ? "Applet updated"
-          : `${updateCount} applets updated`,
+          ? t("apps.applet-viewer.dialogs.appletUpdated")
+          : t("apps.applet-viewer.dialogs.appletsUpdated", { count: updateCount }),
         {
           id: loadingToastId,
           duration: 3000,
@@ -206,13 +222,15 @@ export function useAppletViewerLogic({
       );
     } catch (error) {
       console.error("Error updating applets:", error);
-      toast.error("Failed to update applets", {
+      toast.error(t("apps.applet-viewer.dialogs.failedToUpdateApplets"), {
         description:
-          error instanceof Error ? error.message : "Please try again later.",
+          error instanceof Error
+            ? error.message
+            : t("apps.applet-viewer.dialogs.pleaseTryAgainLater"),
         id: loadingToastId,
       });
     }
-  }, [updatesAvailable, actions, checkForUpdates]);
+  }, [updatesAvailable, actions, checkForUpdates, t]);
 
   const sendAuthPayload = useCallback(
     (target: Window | null | undefined) => {
@@ -990,15 +1008,18 @@ export function useAppletViewerLogic({
           },
         });
 
-        toast.success("Applet imported!", {
-          description: `${importFileName} saved to /Applets${
-            icon ? ` with ${icon} icon` : ""
-          }`,
+        toast.success(t("apps.applet-viewer.dialogs.appletImported"), {
+          description: t("apps.applet-viewer.dialogs.appletImportedDescription", {
+            fileName: importFileName,
+            iconText: icon
+              ? t("apps.finder.messages.appletImportedIconText", { icon })
+              : "",
+          }),
         });
       } catch (error) {
         console.error("Import failed:", error);
-        toast.error("Import failed", {
-          description: "Could not import the file.",
+        toast.error(t("apps.applet-viewer.dialogs.importFailed"), {
+          description: t("apps.applet-viewer.dialogs.couldNotImportFile"),
         });
       }
     }
@@ -1084,16 +1105,18 @@ export function useAppletViewerLogic({
       document.body.removeChild(a);
       URL.revokeObjectURL(url);
 
-      toast.success("Applet exported!", {
-        description: `${filename}.app exported successfully.`,
+      toast.success(t("apps.applet-viewer.dialogs.appletExported"), {
+        description: t("apps.applet-viewer.dialogs.appletExportedDescription", {
+          fileName: filename,
+        }),
       });
     } catch (compressionError) {
       console.error("Compression failed:", compressionError);
-      toast.error("Export failed", {
+      toast.error(t("apps.applet-viewer.dialogs.exportFailed"), {
         description:
           compressionError instanceof Error
             ? compressionError.message
-            : "Could not compress the applet file.",
+            : t("apps.applet-viewer.dialogs.couldNotCompressAppletFile"),
       });
     }
   };
@@ -1105,15 +1128,15 @@ export function useAppletViewerLogic({
 
   const handleShareApplet = async () => {
     if (!hasAppletContent) {
-      toast.error("No applet to share", {
-        description: "Please open an applet first.",
+      toast.error(t("apps.applet-viewer.dialogs.noAppletToShare"), {
+        description: t("apps.applet-viewer.dialogs.pleaseOpenAppletFirst"),
       });
       return;
     }
 
     if (!username || !isAuthenticated) {
-      toast.error("Login required", {
-        description: "You must be logged in to share applets.",
+      toast.error(t("apps.applet-viewer.dialogs.loginRequired"), {
+        description: t("apps.applet-viewer.dialogs.mustBeLoggedInToShare"),
       });
       return;
     }
@@ -1132,8 +1155,8 @@ export function useAppletViewerLogic({
       if (existingShareId && !isAuthor) {
         setShareId(existingShareId);
         setIsShareDialogOpen(true);
-        toast.success("Applet already shared", {
-          description: "Showing existing share link.",
+        toast.success(t("apps.applet-viewer.dialogs.appletAlreadyShared"), {
+          description: t("apps.applet-viewer.dialogs.showingExistingShareLink"),
         });
         return;
       }
@@ -1189,17 +1212,24 @@ export function useAppletViewerLogic({
         }
       }
 
-      toast.success(data.updated ? "Applet updated!" : "Applet shared!", {
-        description: data.updated
-          ? "Share link updated successfully."
-          : "Share link generated successfully.",
-        duration: 3000,
-      });
+      toast.success(
+        data.updated
+          ? t("apps.applet-viewer.dialogs.appletUpdatedShare")
+          : t("apps.applet-viewer.dialogs.appletShared"),
+        {
+          description: data.updated
+            ? t("apps.applet-viewer.dialogs.shareLinkUpdatedSuccessfully")
+            : t("apps.applet-viewer.dialogs.shareLinkGeneratedSuccessfully"),
+          duration: 3000,
+        }
+      );
     } catch (error) {
       console.error("Error sharing applet:", error);
-      toast.error("Failed to share applet", {
+      toast.error(t("apps.applet-viewer.dialogs.failedToShareApplet"), {
         description:
-          error instanceof Error ? error.message : "Please try again later.",
+          error instanceof Error
+            ? error.message
+            : t("apps.applet-viewer.dialogs.pleaseTryAgainLater"),
       });
     }
   };
@@ -1257,11 +1287,12 @@ export function useAppletViewerLogic({
             }
           }
 
-          const displayName = data.title || data.name || "Shared Applet";
-          toast.success("Shared applet loaded", {
+          const displayName =
+            data.title || data.name || t("apps.applet-viewer.dialogs.sharedApplet");
+          toast.success(t("apps.applet-viewer.dialogs.sharedAppletLoaded"), {
             description: displayName,
             action: {
-              label: "Save",
+              label: t("apps.applet-viewer.dialogs.save"),
               onClick: async () => {
                 try {
                   let defaultName = data.name || data.title || "shared-applet";
@@ -1309,16 +1340,18 @@ export function useAppletViewerLogic({
                     icon: data.icon || undefined,
                   });
 
-                  toast.success("Applet saved", {
-                    description: `Saved to /Applets/${finalName}`,
+                  toast.success(t("apps.applet-viewer.dialogs.appletSaved"), {
+                    description: t("apps.applet-viewer.dialogs.appletSavedDescription", {
+                      fileName: finalName,
+                    }),
                   });
                 } catch (error) {
                   console.error("Error saving shared applet:", error);
-                  toast.error("Failed to save applet", {
+                  toast.error(t("apps.applet-viewer.dialogs.failedToSaveApplet"), {
                     description:
                       error instanceof Error
                         ? error.message
-                        : "Please try again.",
+                        : t("apps.applet-viewer.dialogs.pleaseTryAgainLater"),
                   });
                 }
               },
@@ -1332,14 +1365,13 @@ export function useAppletViewerLogic({
           if (!isActive || controller.signal.aborted) return;
           console.error("Error fetching shared applet:", error);
           if (error instanceof Error && error.message.includes("404")) {
-            toast.error("Applet not found", {
-              description:
-                "The shared applet may have been deleted or the link is invalid.",
+            toast.error(t("apps.applet-viewer.dialogs.appletNotFound"), {
+              description: t("apps.applet-viewer.dialogs.appletNotFoundDescription"),
             });
             return;
           }
-          toast.error("Failed to load shared applet", {
-            description: "Please check your connection and try again.",
+          toast.error(t("apps.applet-viewer.dialogs.failedToLoadSharedApplet"), {
+            description: t("apps.applet-viewer.dialogs.pleaseCheckConnection"),
           });
         }
       };
@@ -1362,6 +1394,7 @@ export function useAppletViewerLogic({
     instanceId,
     saveFile,
     updateFileItemMetadata,
+    t,
   ]);
 
   useEffect(() => {

--- a/src/apps/applet-viewer/utils/appletActions.ts
+++ b/src/apps/applet-viewer/utils/appletActions.ts
@@ -1,5 +1,6 @@
 import { useCallback, useRef } from "react";
 import { toast } from "sonner";
+import { useTranslation } from "react-i18next";
 import { useFileSystem } from "@/apps/finder/hooks/useFileSystem";
 import { useLaunchApp } from "@/hooks/useLaunchApp";
 import { useFilesStore } from "@/stores/useFilesStore";
@@ -41,6 +42,7 @@ export const extractEmojiIcon = (
 };
 
 export const useAppletActions = () => {
+  const { t } = useTranslation();
   const { saveFile, files, handleFileOpen } = useFileSystem("/Applets");
   const launchApp = useLaunchApp();
   const getFileItem = useFilesStore((state) => state.getItem);
@@ -134,7 +136,7 @@ export const useAppletActions = () => {
           await handleFileOpen(installedApplet);
         } catch (error) {
           console.error("Error launching applet from disk:", error);
-          toast.error("Failed to launch applet");
+          toast.error(t("apps.applet-viewer.dialogs.failedToLaunchApplet"));
         }
       }
     } else {
@@ -226,21 +228,28 @@ export const useAppletActions = () => {
         });
       }
       
-      toast.success(isUpdate ? "Applet updated" : "Applet installed", {
-        description: `Saved to /Applets/${finalName}`,
-        duration: 3000,
-        action: {
-          label: "Open",
-          onClick: () => {
-            launchApp("applet-viewer", {
-              initialData: {
-                path: finalPath,
-                content: data.content,
-              },
-            });
+      toast.success(
+        isUpdate
+          ? t("apps.applet-viewer.dialogs.appletUpdated")
+          : t("apps.applet-viewer.dialogs.appletInstalledToast"),
+        {
+          description: t("apps.applet-viewer.dialogs.savedToAppletsPath", {
+            fileName: finalName,
+          }),
+          duration: 3000,
+          action: {
+            label: t("common.htmlPreview.toastOpenAction"),
+            onClick: () => {
+              launchApp("applet-viewer", {
+                initialData: {
+                  path: finalPath,
+                  content: data.content,
+                },
+              });
+            },
           },
-        },
-      });
+        }
+      );
       
       // Automatically open the applet in a new window instance (only for new installs, not updates)
       if (!isUpdate) {
@@ -258,8 +267,11 @@ export const useAppletActions = () => {
       }
     } catch (error) {
       console.error("Error installing applet:", error);
-      toast.error("Failed to install applet", {
-        description: error instanceof Error ? error.message : "Please try again later.",
+      toast.error(t("apps.applet-viewer.dialogs.failedToInstallApplet"), {
+        description:
+          error instanceof Error
+            ? error.message
+            : t("apps.applet-viewer.dialogs.pleaseTryAgainLater"),
       });
     }
   };

--- a/src/apps/chats/components/CreateRoomDialog.tsx
+++ b/src/apps/chats/components/CreateRoomDialog.tsx
@@ -216,12 +216,12 @@ export function CreateRoomDialog({
       setServersError(
         err instanceof ApiRequestError
           ? err.message
-          : "Failed to load IRC servers"
+          : t("apps.chats.dialogs.createRoomIrc.failedToLoadServers")
       );
     } finally {
       setIsLoadingServers(false);
     }
-  }, []);
+  }, [t]);
 
   useEffect(() => {
     if (!isOpen) return;
@@ -258,7 +258,7 @@ export function CreateRoomDialog({
         setChannelsError(
           err instanceof ApiRequestError
             ? err.message
-            : "Failed to load IRC channels"
+            : t("apps.chats.dialogs.createRoomIrc.failedToLoadChannels")
         );
       } finally {
         if (requestId === channelRequestIdRef.current) {
@@ -266,7 +266,7 @@ export function CreateRoomDialog({
         }
       }
     },
-    []
+    [t]
   );
 
   useEffect(() => {
@@ -284,7 +284,7 @@ export function CreateRoomDialog({
     setAddServerError(null);
     const trimmedHost = newServerHost.trim();
     if (!trimmedHost) {
-      setAddServerError("Server host is required");
+      setAddServerError(t("apps.chats.dialogs.createRoomIrc.serverHostRequired"));
       return;
     }
     setIsAddingServer(true);
@@ -316,12 +316,12 @@ export function CreateRoomDialog({
       setAddServerError(
         err instanceof ApiRequestError
           ? err.message
-          : "Failed to add IRC server"
+          : t("apps.chats.dialogs.createRoomIrc.failedToAddServer")
       );
     } finally {
       setIsAddingServer(false);
     }
-  }, [newServerHost, newServerPort, newServerTls, newServerLabel]);
+  }, [newServerHost, newServerPort, newServerTls, newServerLabel, t]);
 
   const handleDeleteIrcServer = useCallback(
     async (server: IrcServerSummary) => {
@@ -338,11 +338,11 @@ export function CreateRoomDialog({
         setServersError(
           err instanceof ApiRequestError
             ? err.message
-            : "Failed to delete IRC server"
+            : t("apps.chats.dialogs.createRoomIrc.failedToDeleteServer")
         );
       }
     },
-    [ircServers]
+    [ircServers, t]
   );
 
   const filteredChannels = (() => {
@@ -382,7 +382,7 @@ export function CreateRoomDialog({
       if (activeTab === "irc") {
         const server = selectedServer;
         if (!server) {
-          setError("Please pick an IRC server first.");
+          setError(t("apps.chats.dialogs.createRoomIrc.pickServerFirst"));
           setIsLoading(false);
           return;
         }
@@ -394,8 +394,8 @@ export function CreateRoomDialog({
         if (!rawChannel) {
           setError(
             isAdmin
-              ? "Please pick or enter an IRC channel."
-              : "Please pick a channel from the list."
+              ? t("apps.chats.dialogs.createRoomIrc.pickChannel")
+              : t("apps.chats.dialogs.createRoomIrc.pickChannelFromList")
           );
           setIsLoading(false);
           return;
@@ -528,7 +528,7 @@ export function CreateRoomDialog({
                   className={cn("text-gray-700", themeFont)}
                   style={themeFontStyle}
                 >
-                  Server
+                  {t("apps.chats.dialogs.createRoomIrc.server")}
                 </Label>
                 <div className="flex items-center gap-1">
                   <div className="flex-1 min-w-0">
@@ -550,7 +550,11 @@ export function CreateRoomDialog({
                       >
                         <SelectValue
                           placeholder={
-                            isLoadingServers ? "Loading…" : "Pick a server"
+                            isLoadingServers
+                              ? t(
+                                  "apps.chats.dialogs.createRoomIrc.pickServerLoading"
+                                )
+                              : t("apps.chats.dialogs.createRoomIrc.pickServer")
                           }
                         />
                       </SelectTrigger>
@@ -565,12 +569,14 @@ export function CreateRoomDialog({
                               <span>{server.label}</span>
                               {server.isDefault && (
                                 <span className="text-[9px] uppercase tracking-wider text-purple-600/70">
-                                  default
+                                  {t(
+                                    "apps.chats.dialogs.createRoomIrc.badgeDefault"
+                                  )}
                                 </span>
                               )}
                               {server.tls && (
                                 <span className="text-[9px] uppercase tracking-wider text-emerald-600/70">
-                                  tls
+                                  {t("apps.chats.dialogs.createRoomIrc.badgeTls")}
                                 </span>
                               )}
                             </span>
@@ -583,7 +589,9 @@ export function CreateRoomDialog({
                           >
                             <span className="inline-flex items-center gap-1">
                               <Plus className="h-3 w-3" weight="bold" />
-                              Add new server…
+                              {t(
+                                "apps.chats.dialogs.createRoomIrc.addNewServer"
+                              )}
                             </span>
                           </SelectItem>
                         )}
@@ -600,8 +608,12 @@ export function CreateRoomDialog({
                       onClick={() => handleDeleteIrcServer(selectedServer)}
                       disabled={isLoading}
                       className="h-8 w-8 p-0"
-                      title="Remove server"
-                      aria-label="Remove server"
+                      title={t(
+                        "apps.chats.dialogs.createRoomIrc.removeServerTitle"
+                      )}
+                      aria-label={t(
+                        "apps.chats.dialogs.createRoomIrc.removeServerAria"
+                      )}
                     >
                       <Trash className="h-3 w-3" weight="bold" />
                     </Button>
@@ -624,10 +636,12 @@ export function CreateRoomDialog({
                     className={cn("text-gray-700 font-semibold", themeFont)}
                     style={themeFontStyle}
                   >
-                    Add a server
+                    {t("apps.chats.dialogs.createRoomIrc.addAServer")}
                   </Label>
                   <Input
-                    placeholder="irc.example.com"
+                    placeholder={t(
+                      "apps.chats.dialogs.createRoomIrc.hostPlaceholder"
+                    )}
                     value={newServerHost}
                     onChange={(e) => setNewServerHost(e.target.value)}
                     className={cn("shadow-none h-8", themeFont)}
@@ -635,7 +649,9 @@ export function CreateRoomDialog({
                     disabled={isAddingServer}
                   />
                   <Input
-                    placeholder="Optional label"
+                    placeholder={t(
+                      "apps.chats.dialogs.createRoomIrc.optionalLabelPlaceholder"
+                    )}
                     value={newServerLabel}
                     onChange={(e) => setNewServerLabel(e.target.value)}
                     className={cn("shadow-none h-8", themeFont)}
@@ -646,7 +662,9 @@ export function CreateRoomDialog({
                     <div className="flex-1">
                       <Input
                         type="number"
-                        placeholder="6667"
+                        placeholder={t(
+                          "apps.chats.dialogs.createRoomIrc.portPlaceholder"
+                        )}
                         value={String(newServerPort)}
                         onChange={(e) =>
                           setNewServerPort(Number(e.target.value) || 6667)
@@ -671,7 +689,7 @@ export function CreateRoomDialog({
                         className="h-4 w-4"
                         disabled={isAddingServer}
                       />
-                      <span>TLS</span>
+                      <span>{t("apps.chats.dialogs.createRoomIrc.tls")}</span>
                     </Label>
                   </div>
                   {addServerError && (
@@ -695,7 +713,7 @@ export function CreateRoomDialog({
                       className={cn("h-7", themeFont)}
                       style={themeFontStyle}
                     >
-                      Cancel
+                      {t("apps.chats.dialogs.cancel")}
                     </Button>
                     <Button
                       type="button"
@@ -706,7 +724,9 @@ export function CreateRoomDialog({
                       className={cn("h-7", themeFont)}
                       style={themeFontStyle}
                     >
-                      {isAddingServer ? "Adding…" : "Add server"}
+                      {isAddingServer
+                        ? t("apps.chats.dialogs.createRoomIrc.addingServer")
+                        : t("apps.chats.dialogs.createRoomIrc.addServer")}
                     </Button>
                   </div>
                 </div>
@@ -720,8 +740,9 @@ export function CreateRoomDialog({
                       className={cn("text-gray-500 text-[11px]", themeFont)}
                       style={themeFontStyle}
                     >
-                      IRC servers are managed by an admin. Choose a channel
-                      from the list to join.
+                      {t(
+                        "apps.chats.dialogs.createRoomIrc.ircServersAdminHint"
+                      )}
                     </p>
                   )}
                   <div className="flex items-center justify-between">
@@ -730,7 +751,7 @@ export function CreateRoomDialog({
                       className={cn("text-gray-700", themeFont)}
                       style={themeFontStyle}
                     >
-                      Channel
+                      {t("apps.chats.dialogs.createRoomIrc.channel")}
                     </Label>
                     <Button
                       type="button"
@@ -739,8 +760,12 @@ export function CreateRoomDialog({
                       onClick={() => loadIrcChannels(selectedServerId)}
                       disabled={isLoadingChannels || isLoading}
                       className="h-7 px-2"
-                      title="Refresh channel list"
-                      aria-label="Refresh channel list"
+                      title={t(
+                        "apps.chats.dialogs.createRoomIrc.refreshChannelsTitle"
+                      )}
+                      aria-label={t(
+                        "apps.chats.dialogs.createRoomIrc.refreshChannelsAria"
+                      )}
                     >
                       <ArrowClockwise
                         className={cn(
@@ -757,8 +782,12 @@ export function CreateRoomDialog({
                         id="irc-channel-filter"
                         placeholder={
                           isLoadingChannels
-                            ? "Loading channels…"
-                            : "Filter channels or type a new one"
+                            ? t(
+                                "apps.chats.dialogs.createRoomIrc.loadingChannels"
+                              )
+                            : t(
+                                "apps.chats.dialogs.createRoomIrc.filterChannelsTyping"
+                              )
                         }
                         value={channelFilter || customChannel}
                         onChange={(e) => {
@@ -794,8 +823,10 @@ export function CreateRoomDialog({
                         id="irc-channel-filter"
                         placeholder={
                           isLoadingChannels
-                            ? "Loading channels…"
-                            : "Filter channels"
+                            ? t(
+                                "apps.chats.dialogs.createRoomIrc.loadingChannels"
+                              )
+                            : t("apps.chats.dialogs.createRoomIrc.filterChannels")
                         }
                         value={channelListFilter}
                         onChange={(e) => {
@@ -834,8 +865,12 @@ export function CreateRoomDialog({
                               style={themeFontStyle}
                             >
                               {isAdmin
-                                ? "No channels available. Type a channel name above to join one anyway."
-                                : "No channels match this filter."}
+                                ? t(
+                                    "apps.chats.dialogs.createRoomIrc.noChannelsHint"
+                                  )
+                                : t(
+                                    "apps.chats.dialogs.createRoomIrc.noChannelsMatch"
+                                  )}
                             </p>
                           )}
                         {filteredChannels.map((entry, index) => {

--- a/src/apps/chats/hooks/useAiChat.ts
+++ b/src/apps/chats/hooks/useAiChat.ts
@@ -1954,12 +1954,13 @@ export function useAiChat(onPromptSetUsername?: () => void) {
         useChatsStore.getState().setAuthenticated(false);
 
         // Show user-friendly error message with action button
-        toast.error("Login Required", {
-          description: message || "Please login to continue chatting.",
+        toast.error(t("apps.chats.status.loginRequired"), {
+          description:
+            message || t("apps.chats.status.pleaseLoginToSendMessages"),
           duration: 5000,
           action: onPromptSetUsername
             ? {
-                label: "Login",
+                label: t("apps.chats.status.loginButton"),
                 onClick: onPromptSetUsername,
               }
             : undefined,
@@ -1999,7 +2000,7 @@ export function useAiChat(onPromptSetUsername?: () => void) {
               errorData.error === "unauthorized" ||
               errorData.error === "username mismatch"
             ) {
-              handleAuthError("Your session has expired. Please login again.");
+              handleAuthError(t("apps.chats.toasts.sessionExpiredDescription"));
               return; // Exit early to prevent showing generic error toast
             }
           } catch (parseError) {
@@ -2014,13 +2015,12 @@ export function useAiChat(onPromptSetUsername?: () => void) {
         ) {
           // Generic rate limit message if we couldn't parse the details
           setNeedsUsername(true);
-          toast.error("Rate Limit Exceeded", {
-            description:
-              "You've reached the message limit. Please login to continue.",
+          toast.error(t("apps.chats.toasts.rateLimitExceeded"), {
+            description: t("apps.chats.toasts.rateLimitDescription"),
             duration: 5000,
             action: onPromptSetUsername
               ? {
-                  label: "Login",
+                  label: t("apps.chats.status.loginButton"),
                   onClick: onPromptSetUsername,
                 }
               : undefined,
@@ -2045,8 +2045,9 @@ export function useAiChat(onPromptSetUsername?: () => void) {
       }
 
       // For non-rate-limit errors, show the generic error toast
-      toast.error("AI Error", {
-        description: err.message || "Failed to get response.",
+      toast.error(t("apps.chats.toasts.aiError"), {
+        description:
+          err.message || t("apps.chats.toasts.failedToGetAiResponse"),
       });
     },
   });
@@ -2181,8 +2182,8 @@ export function useAiChat(onPromptSetUsername?: () => void) {
 
       // Check if user needs to set username before submitting
       if (needsUsername && !username) {
-        toast.error("Login Required", {
-          description: "Please login to continue chatting.",
+        toast.error(t("apps.chats.status.loginRequired"), {
+          description: t("apps.chats.status.pleaseLoginToSendMessages"),
           duration: 3000,
         });
         return;
@@ -2190,8 +2191,8 @@ export function useAiChat(onPromptSetUsername?: () => void) {
 
       // Check if user is authenticated (cookies handle auth automatically)
       if (username && !isAuthenticated) {
-        toast.error("Login Required", {
-          description: "Please login to continue chatting.",
+        toast.error(t("apps.chats.status.loginRequired"), {
+          description: t("apps.chats.status.pleaseLoginToSendMessages"),
           duration: 3000,
         });
         return;
@@ -2227,7 +2228,7 @@ export function useAiChat(onPromptSetUsername?: () => void) {
         // Send message with image attachment using files array
         sendMessage(
           {
-            text: messageContent.trim() || "Describe this image",
+            text: messageContent.trim() || t("apps.chats.messages.describeThisImage"),
             files: [
               {
                 type: "file" as const,
@@ -2275,6 +2276,7 @@ export function useAiChat(onPromptSetUsername?: () => void) {
       isAuthenticated,
       aiModel,
       setInput,
+      t,
     ],
   );
 
@@ -2284,8 +2286,8 @@ export function useAiChat(onPromptSetUsername?: () => void) {
 
       // Check if user needs to set username before submitting
       if (needsUsername && !username) {
-        toast.error("Login Required", {
-          description: "Please login to continue chatting.",
+        toast.error(t("apps.chats.status.loginRequired"), {
+          description: t("apps.chats.status.pleaseLoginToSendMessages"),
           duration: 3000,
         });
         return;
@@ -2293,8 +2295,8 @@ export function useAiChat(onPromptSetUsername?: () => void) {
 
       // Check if user is authenticated (cookies handle auth automatically)
       if (username && !isAuthenticated) {
-        toast.error("Login Required", {
-          description: "Please login to continue chatting.",
+        toast.error(t("apps.chats.status.loginRequired"), {
+          description: t("apps.chats.status.pleaseLoginToSendMessages"),
           duration: 3000,
         });
         return;
@@ -2486,12 +2488,18 @@ export function useAiChat(onPromptSetUsername?: () => void) {
         });
 
         setIsSaveDialogOpen(false);
-        toast.success(isUpdate ? "Transcript updated" : "Transcript saved", {
-          description: `Saved to ${finalFileName}`,
-          duration: 5000,
-          action: {
-            label: "Open",
-            onClick: () => {
+        toast.success(
+          isUpdate
+            ? t("apps.chats.toasts.transcriptUpdated")
+            : t("apps.chats.toasts.transcriptSaved"),
+          {
+            description: t("apps.chats.toasts.transcriptSavedDescription", {
+              fileName: finalFileName,
+            }),
+            duration: 5000,
+            action: {
+              label: t("common.htmlPreview.toastOpenAction"),
+              onClick: () => {
               // Check if this file is already open in a TextEdit instance
               const textEditStore = useTextEditStore.getState();
               const existingInstanceId = textEditStore.getInstanceIdByPath(filePath);
@@ -2526,12 +2534,15 @@ export function useAiChat(onPromptSetUsername?: () => void) {
         });
       } catch (error) {
         console.error("Error saving transcript:", error);
-        toast.error("Failed to save transcript", {
-          description: error instanceof Error ? error.message : "Unknown error",
+        toast.error(t("apps.chats.toasts.failedToSaveTranscript"), {
+          description:
+            error instanceof Error
+              ? error.message
+              : t("apps.chats.toasts.unknownError"),
         });
       }
     },
-    [username, saveFile, launchApp],
+    [username, saveFile, launchApp, t],
   );
 
   // Stop both chat streaming and TTS queue

--- a/src/apps/control-panels/hooks/useControlPanelsLogic.ts
+++ b/src/apps/control-panels/hooks/useControlPanelsLogic.ts
@@ -417,7 +417,7 @@ export function useControlPanelsLogic({
     setPasswordError(null);
 
     if (!password || password.length < 8) {
-      setPasswordError("Password must be at least 8 characters");
+      setPasswordError(t("apps.control-panels.dialogs.passwordMinLength"));
       setIsSettingPassword(false);
       return;
     }
@@ -425,13 +425,13 @@ export function useControlPanelsLogic({
     const result = await setPassword(password);
 
     if (result.ok) {
-      toast.success("Password Set", {
-        description: "You can now use your password to recover your account",
+      toast.success(t("apps.chats.dialogs.passwordSetSuccess"), {
+        description: t("apps.chats.dialogs.passwordSetSuccessDescription"),
       });
       setIsPasswordDialogOpen(false);
       setPasswordInput("");
     } else {
-      setPasswordError(result.error || "Failed to set password");
+      setPasswordError(result.error || t("apps.chats.dialogs.passwordSetFailed"));
     }
 
     setIsSettingPassword(false);
@@ -443,8 +443,8 @@ export function useControlPanelsLogic({
     try {
       // Ensure we have auth info from the auth hook
       if (!isAuthenticated || !username) {
-        toast.error("Authentication Error", {
-          description: "Not authenticated",
+        toast.error(t("common.auth.logoutAllDevices.authenticationError"), {
+          description: t("common.auth.logoutAllDevices.notAuthenticated"),
         });
         return;
       }
@@ -462,8 +462,10 @@ export function useControlPanelsLogic({
       const data = await response.json();
 
       if (response.ok) {
-        toast.success("Logged Out", {
-          description: data.message || "Logged out from all devices",
+        toast.success(t("common.auth.logoutAllDevices.loggedOut"), {
+          description:
+            data.message ||
+            t("common.auth.logoutAllDevices.loggedOutFromAllDevices"),
         });
 
         // Immediately clear auth via store logout (bypass confirmation)
@@ -471,14 +473,16 @@ export function useControlPanelsLogic({
 
         // No full page reload needed – UI will update via store reset
       } else {
-        toast.error("Logout Failed", {
-          description: data.error || "Failed to logout from all devices",
+        toast.error(t("common.auth.logoutAllDevices.logoutFailed"), {
+          description:
+            data.error ||
+            t("common.auth.logoutAllDevices.logoutFromAllDevicesFailed"),
         });
       }
     } catch (error) {
       console.error("Error logging out all devices:", error);
-      toast.error("Network Error", {
-        description: "Failed to connect to server",
+      toast.error(t("common.auth.logoutAllDevices.networkError"), {
+        description: t("common.auth.logoutAllDevices.failedToConnect"),
       });
     } finally {
       setIsLoggingOutAllDevices(false);

--- a/src/apps/internet-explorer/components/InternetExplorerAppComponent.tsx
+++ b/src/apps/internet-explorer/components/InternetExplorerAppComponent.tsx
@@ -283,17 +283,18 @@ export function InternetExplorerAppComponent({
     // Map ErrorResponse to ErrorPageProps
     const title =
       errorDetails.type === "network"
-        ? "Cannot find server or DNS Error"
-        : "Error";
-    const primaryMessage = errorDetails.message || "An error occurred";
+        ? t("apps.internet-explorer.cannotFindServerOrDnsError")
+        : t("apps.internet-explorer.error");
+    const primaryMessage =
+      errorDetails.message || t("apps.internet-explorer.anErrorOccurred");
     const secondaryMessage = errorDetails.details;
     const suggestions = [
-      "Check the web address you typed and try again.",
-      "Go back to the previous page.",
-      "Try refreshing the page.",
+      t("apps.internet-explorer.checkWebAddressAndTryAgain"),
+      t("apps.internet-explorer.goBackToPreviousPage"),
+      t("apps.internet-explorer.tryRefreshingThePage"),
     ];
     const footerText = errorDetails.hostname
-      ? `Host: ${errorDetails.hostname}`
+      ? t("apps.internet-explorer.host", { hostname: errorDetails.hostname })
       : "";
 
     return (
@@ -414,13 +415,13 @@ export function InternetExplorerAppComponent({
                         size="icon"
                         onClick={handleSharePage}
                         className="h-8 w-8 focus-visible:ring-0 focus-visible:ring-offset-0"
-                        aria-label="Share this page"
+                        aria-label={t("apps.internet-explorer.shareThisPage")}
                       >
                         <Export size={14} weight="bold" />
                       </Button>
                     </TooltipTrigger>
                     <TooltipContent side="bottom">
-                      <p>Share this page</p>
+                      <p>{t("apps.internet-explorer.shareThisPage")}</p>
                     </TooltipContent>
                   </Tooltip>
                 </div>
@@ -439,7 +440,7 @@ export function InternetExplorerAppComponent({
                     onKeyDown={(e) => {
                       if (isOffline && e.key === "Enter") {
                         checkOfflineAndShowError(
-                          "Internet Explorer requires an internet connection to navigate"
+                          t("apps.internet-explorer.requiresInternetConnection")
                         );
                         return;
                       }
@@ -555,7 +556,7 @@ export function InternetExplorerAppComponent({
                           }
                         : undefined
                     }
-                    placeholder="Enter URL"
+                    placeholder={t("apps.internet-explorer.enterUrl")}
                     spellCheck="false"
                     autoComplete="off"
                     autoCapitalize="off"
@@ -747,7 +748,7 @@ export function InternetExplorerAppComponent({
                           : "!text-[16px]"
                       }
                     >
-                      <SelectValue placeholder="Year" />
+                      <SelectValue placeholder={t("apps.internet-explorer.year")} />
                     </SelectTrigger>
                     <SelectContent className="px-0">
                       {futureYears.map((y) => (

--- a/src/apps/internet-explorer/hooks/useInternetExplorerLogic.ts
+++ b/src/apps/internet-explorer/hooks/useInternetExplorerLogic.ts
@@ -1424,12 +1424,17 @@ export function useInternetExplorerLogic({
           console.log(
             `[IE] Decoded share link from initialData prop: ${decodedData.url} (${decodedData.year})`
           );
-          toast.info(`Opening shared page`, {
-            description: `${decodedData.url}${
-              decodedData.year && decodedData.year !== "current"
-                ? ` from ${decodedData.year}`
-                : ""
-            }`,
+          toast.info(t("apps.internet-explorer.openingSharedPage"), {
+            description: t("apps.internet-explorer.sharedPageToastDescription", {
+              url: decodedData.url,
+              yearPart:
+                decodedData.year && decodedData.year !== "current"
+                  ? t("apps.internet-explorer.sharedPageToastYearPart", {
+                      from: t("apps.internet-explorer.from"),
+                      year: decodedData.year,
+                    })
+                  : "",
+            }),
             duration: 4000,
           });
           // Navigate using decoded data
@@ -1451,8 +1456,8 @@ export function useInternetExplorerLogic({
           console.warn(
             "[IE] Failed to decode share link code from initialData prop."
           );
-          toast.error("Invalid Share Link", {
-            description: "The share link provided is invalid or corrupted.",
+          toast.error(t("apps.internet-explorer.invalidShareLink"), {
+            description: t("apps.internet-explorer.shareLinkInvalidOrCorrupted"),
             duration: 5000,
           });
           // Fall through to check for direct url/year or default navigation
@@ -1532,12 +1537,17 @@ export function useInternetExplorerLogic({
           console.log(
             `[IE] Navigating to shared link: ${decodedData.url} (${decodedData.year})`
           );
-          toast.info(`Opening shared page`, {
-            description: `${decodedData.url}${
-              decodedData.year && decodedData.year !== "current"
-                ? ` from ${decodedData.year}`
-                : ""
-            }`,
+          toast.info(t("apps.internet-explorer.openingSharedPage"), {
+            description: t("apps.internet-explorer.sharedPageToastDescription", {
+              url: decodedData.url,
+              yearPart:
+                decodedData.year && decodedData.year !== "current"
+                  ? t("apps.internet-explorer.sharedPageToastYearPart", {
+                      from: t("apps.internet-explorer.from"),
+                      year: decodedData.year,
+                    })
+                  : "",
+            }),
             duration: 4000,
           });
           setTimeout(() => {
@@ -1625,12 +1635,17 @@ export function useInternetExplorerLogic({
             );
 
             // Show toast and navigate
-            toast.info(`Opening shared page`, {
-              description: `${decodedData.url}${
-                decodedData.year && decodedData.year !== "current"
-                  ? ` from ${decodedData.year}`
-                  : ""
-              }`,
+            toast.info(t("apps.internet-explorer.openingSharedPage"), {
+              description: t("apps.internet-explorer.sharedPageToastDescription", {
+                url: decodedData.url,
+                yearPart:
+                  decodedData.year && decodedData.year !== "current"
+                    ? t("apps.internet-explorer.sharedPageToastYearPart", {
+                        from: t("apps.internet-explorer.from"),
+                        year: decodedData.year,
+                      })
+                    : "",
+              }),
               duration: 4000,
             });
             // Use timeout to allow potential state updates (like foreground) to settle
@@ -1647,8 +1662,8 @@ export function useInternetExplorerLogic({
             console.warn(
               "[IE] Failed to decode share link code from updateApp event."
             );
-            toast.error("Invalid Share Link", {
-              description: "The share link provided is invalid or corrupted.",
+            toast.error(t("apps.internet-explorer.invalidShareLink"), {
+              description: t("apps.internet-explorer.shareLinkInvalidOrCorrupted"),
               duration: 5000,
             });
           }
@@ -1674,7 +1689,7 @@ export function useInternetExplorerLogic({
 
     return onAppUpdate(handleUpdateApp);
     // Add isForeground to dependencies to refresh navigation when focus changes
-  }, [handleNavigate, isForeground, instanceId]);
+  }, [handleNavigate, isForeground, instanceId, t]);
   // --- End updateApp listener ---
 
   useEffect(() => {

--- a/src/apps/ipod/hooks/useIpodLogic.ts
+++ b/src/apps/ipod/hooks/useIpodLogic.ts
@@ -926,8 +926,8 @@ export function useIpodLogic({
         joinListenSession(sessionIdToProcess, username || undefined)
           .then((result) => {
             if (!result.ok) {
-              toast.error("Failed to join session", {
-                description: result.error || "Please try again.",
+              toast.error(t("common.listenAlong.failedToJoinSession"), {
+                description: result.error || t("common.errors.pleaseTryAgain"),
               });
             }
             if (instanceId) clearIpodInitialData(instanceId);
@@ -945,6 +945,7 @@ export function useIpodLogic({
     username,
     clearIpodInitialData,
     instanceId,
+    t,
   ]);
 
   // Update app event handling
@@ -967,8 +968,8 @@ export function useIpodLogic({
         }
         processVideoId(videoId).catch((error) => {
           console.error(`Error processing videoId ${videoId}:`, error);
-          toast.error("Failed to load shared track", {
-            description: `Video ID: ${videoId}`,
+          toast.error(t("common.listenAlong.failedToLoadSharedTrack"), {
+            description: t("common.listenAlong.videoIdLabel", { videoId }),
           });
         });
         lastProcessedInitialDataRef.current = updateInitialData;
@@ -987,8 +988,8 @@ export function useIpodLogic({
         joinListenSession(sessionId, username || undefined)
           .then((result) => {
             if (!result.ok) {
-              toast.error("Failed to join session", {
-                description: result.error || "Please try again.",
+              toast.error(t("common.listenAlong.failedToJoinSession"), {
+                description: result.error || t("common.errors.pleaseTryAgain"),
               });
             }
           })
@@ -998,7 +999,7 @@ export function useIpodLogic({
         lastProcessedListenSessionRef.current = sessionId;
       }
     });
-  }, [bringInstanceToForeground, instanceId, joinListenSession, processVideoId, username]);
+  }, [bringInstanceToForeground, instanceId, joinListenSession, processVideoId, username, t]);
 
   // Handle closing sync mode - flush pending offset saves
   const closeSyncMode = useCallback(async () => {

--- a/src/apps/karaoke/hooks/useKaraokeLogic.ts
+++ b/src/apps/karaoke/hooks/useKaraokeLogic.ts
@@ -481,7 +481,7 @@ export function useKaraokeLogic({
       showOfflineStatus();
     } else if (listenRemoteOnly) {
       void sendRemotePlaybackCommand({ action: "previous" }).then((r) => {
-        if (!r.ok) toast.error(r.error ?? "Could not skip");
+        if (!r.ok) toast.error(r.error ?? t("common.listenAlong.couldNotSkip"));
       });
       showStatus("⏮");
     } else {
@@ -497,6 +497,7 @@ export function useKaraokeLogic({
     showOfflineStatus,
     showStatus,
     startTrackSwitch,
+    t,
   ]);
 
   const handlePlayPause = useCallback(() => {
@@ -508,7 +509,7 @@ export function useKaraokeLogic({
       const positionMs = Math.round(useKaraokeStore.getState().elapsedTime * 1000);
       const action = isPlaying ? "pause" : "play";
       void sendRemotePlaybackCommand({ action, positionMs }).then((r) => {
-        if (!r.ok) toast.error(r.error ?? "Remote control failed");
+        if (!r.ok) toast.error(r.error ?? t("common.listenAlong.remoteControlFailed"));
       });
       showStatus(isPlaying ? "⏸" : "▶");
     } else {
@@ -523,6 +524,7 @@ export function useKaraokeLogic({
     showOfflineStatus,
     togglePlay,
     showStatus,
+    t,
   ]);
 
   const handleNext = useCallback(() => {
@@ -530,7 +532,7 @@ export function useKaraokeLogic({
       showOfflineStatus();
     } else if (listenRemoteOnly) {
       void sendRemotePlaybackCommand({ action: "next" }).then((r) => {
-        if (!r.ok) toast.error(r.error ?? "Could not skip");
+        if (!r.ok) toast.error(r.error ?? t("common.listenAlong.couldNotSkip"));
       });
       showStatus("⏭");
     } else {
@@ -546,6 +548,7 @@ export function useKaraokeLogic({
     showOfflineStatus,
     showStatus,
     startTrackSwitch,
+    t,
   ]);
 
   useEffect(() => {
@@ -814,7 +817,7 @@ export function useKaraokeLogic({
 
       return true;
     },
-    [getActivePlayer, isPlaying, setIsPlaying]
+    [getActivePlayer, isPlaying, setIsPlaying, listenRemoteOnly, sendRemotePlaybackCommand, showStatus, t]
   );
 
   // Seek to absolute time (in ms) and start playing
@@ -827,7 +830,7 @@ export function useKaraokeLogic({
 
       if (listenRemoteOnly) {
         void sendRemotePlaybackCommand({ action: "seek", positionMs: playerTimeMs }).then((r) => {
-          if (!r.ok) toast.error(r.error ?? "Could not seek");
+          if (!r.ok) toast.error(r.error ?? t("common.listenAlong.couldNotSeek"));
         });
         showStatus(
           `▶ ${Math.floor(newTime / 60)}:${String(Math.floor(newTime % 60)).padStart(2, "0")}`
@@ -847,6 +850,7 @@ export function useKaraokeLogic({
       seekActivePlayerToMs,
       showStatus,
       currentTrack?.lyricOffset,
+      t,
     ]
   );
 
@@ -958,72 +962,74 @@ export function useKaraokeLogic({
 
   const handleStartListenSession = useCallback(async () => {
     if (!username) {
-      toast.error("Login required", {
-        description: "Set a username in Chats to start a session.",
+      toast.error(t("common.listenAlong.loginRequired"), {
+        description: t("common.listenAlong.loginRequiredDescription"),
       });
       return;
     }
     const result = await createListenSession(username);
     if (!result.ok) {
-      toast.error("Failed to start session", {
-        description: result.error || "Please try again.",
+      toast.error(t("common.listenAlong.failedToStartSession"), {
+        description: result.error || t("common.errors.pleaseTryAgain"),
       });
       return;
     }
     setIsListenInviteOpen(true);
-  }, [createListenSession, username]);
+  }, [createListenSession, username, t]);
 
   const handleJoinListenSession = useCallback(
     async (sessionId: string) => {
       // Allow anonymous users to join (username will be undefined)
       const result = await joinListenSession(sessionId, username || undefined);
       if (!result.ok) {
-        toast.error("Failed to join session", {
-          description: result.error || "Please try again.",
+        toast.error(t("common.listenAlong.failedToJoinSession"), {
+          description: result.error || t("common.errors.pleaseTryAgain"),
         });
         return;
       }
     },
-    [joinListenSession, username]
+    [joinListenSession, username, t]
   );
 
   const handleLeaveListenSession = useCallback(async () => {
     const result = await leaveListenSession();
     if (!result.ok) {
-      toast.error("Failed to leave session", {
-        description: result.error || "Please try again.",
+      toast.error(t("common.listenAlong.failedToLeaveSession"), {
+        description: result.error || t("common.errors.pleaseTryAgain"),
       });
       return;
     }
     setIsListenInviteOpen(false);
-  }, [leaveListenSession]);
+  }, [leaveListenSession, t]);
 
   const handleAssignPlaybackDevice = useCallback(
     async (nextDj: string, nextDjClientInstanceId: string) => {
       const result = await assignListenDj(nextDj, nextDjClientInstanceId);
       if (!result.ok) {
-        toast.error("Could not set playback device", {
-          description: result.error || "Please try again.",
+        toast.error(t("common.listenAlong.couldNotSetPlaybackDevice"), {
+          description: result.error || t("common.errors.pleaseTryAgain"),
         });
       } else {
-        toast.success("Playback device updated", {
-          description: `@${nextDj} plays audio for the group.`,
+        toast.success(t("common.listenAlong.playbackDeviceUpdated"), {
+          description: t("common.listenAlong.playbackDeviceUpdatedDescription", {
+            username: nextDj,
+          }),
         });
       }
     },
-    [assignListenDj]
+    [assignListenDj, t]
   );
 
   const handleTransferSessionHost = useCallback(
     async (nextHost: string, nextHostClientInstanceId: string) => {
       const result = await transferListenHost(nextHost, nextHostClientInstanceId);
       if (!result.ok) {
-        toast.error("Could not transfer host", {
-          description: result.error || "Please try again.",
+        toast.error(t("common.listenAlong.couldNotTransferHost"), {
+          description: result.error || t("common.errors.pleaseTryAgain"),
         });
       }
     },
-    [transferListenHost]
+    [transferListenHost, t]
   );
 
   const handlePassDj = useCallback(
@@ -1043,12 +1049,14 @@ export function useKaraokeLogic({
         djClientInstanceId: nextDjClientInstanceId,
       });
       if (!result.ok) {
-        toast.error("Failed to pass DJ", {
-          description: result.error || "Please try again.",
+        toast.error(t("common.listenAlong.failedToPassDj"), {
+          description: result.error || t("common.errors.pleaseTryAgain"),
         });
       } else {
-        toast.success("DJ passed", {
-          description: `@${nextDj} is now the DJ.`,
+        toast.success(t("common.listenAlong.djPassed"), {
+          description: t("common.listenAlong.djPassedDescription", {
+            username: nextDj,
+          }),
         });
       }
     },
@@ -1060,6 +1068,7 @@ export function useKaraokeLogic({
       isListenSessionHost,
       isPlaying,
       syncListenSession,
+      t,
     ]
   );
 
@@ -1133,7 +1142,7 @@ export function useKaraokeLogic({
         }
         void pushListenState().then((r) => {
           if (!r.ok) {
-            toast.error("Could not sync after remote control", {
+            toast.error(t("common.listenAlong.couldNotSyncAfterRemoteControl"), {
               description: r.error ?? undefined,
             });
           }
@@ -1153,18 +1162,19 @@ export function useKaraokeLogic({
     setIsPlaying,
     startTrackSwitch,
     takeRemoteCommands,
+    t,
   ]);
 
   const handleSendReaction = useCallback(
     async (emoji: string) => {
       const result = await sendListenReaction(emoji);
       if (!result.ok) {
-        toast.error("Failed to send reaction", {
-          description: result.error || "Please try again.",
+        toast.error(t("common.listenAlong.failedToSendReaction"), {
+          description: result.error || t("common.errors.pleaseTryAgain"),
         });
       }
     },
-    [sendListenReaction]
+    [sendListenReaction, t]
   );
 
   // Generate share URL for song
@@ -1215,7 +1225,7 @@ export function useKaraokeLogic({
               cover: result.thumbnail,
             },
           });
-          if (!r.ok) toast.error(r.error ?? "Could not queue track");
+          if (!r.ok) toast.error(r.error ?? t("common.listenAlong.couldNotQueueTrack"));
           showStatus(t("apps.ipod.status.added"));
           return;
         }
@@ -1234,16 +1244,16 @@ export function useKaraokeLogic({
       if (listenRemoteOnly) {
         const id = getYouTubeVideoId(url);
         if (!id) {
-          toast.error("Only YouTube links can be queued remotely");
+          toast.error(t("common.listenAlong.youtubeOnlyRemoteQueue"));
           return;
         }
         const r = await sendRemotePlaybackCommand({ action: "playTrack", trackId: id });
-        if (!r.ok) toast.error(r.error ?? "Could not queue track");
+        if (!r.ok) toast.error(r.error ?? t("common.listenAlong.couldNotQueueTrack"));
         return;
       }
       await handleAddTrack(url);
     },
-    [handleAddTrack, listenRemoteOnly, sendRemotePlaybackCommand]
+    [handleAddTrack, listenRemoteOnly, sendRemotePlaybackCommand, t]
   );
 
   // Play track handler for Library menu
@@ -1260,7 +1270,7 @@ export function useKaraokeLogic({
             ? { title: tr.title, artist: tr.artist, cover: tr.cover }
             : undefined,
         }).then((r) => {
-          if (!r.ok) toast.error(r.error ?? "Could not queue track");
+          if (!r.ok) toast.error(r.error ?? t("common.listenAlong.couldNotQueueTrack"));
         });
         return;
       }
@@ -1301,7 +1311,7 @@ export function useKaraokeLogic({
             ? { title: tr.title, artist: tr.artist, cover: tr.cover }
             : undefined,
         }).then((r) => {
-          if (!r.ok) toast.error(r.error ?? "Could not queue track");
+          if (!r.ok) toast.error(r.error ?? t("common.listenAlong.couldNotQueueTrack"));
         });
         setIsCoverFlowOpen(false);
         return;
@@ -1336,7 +1346,7 @@ export function useKaraokeLogic({
             ? { title: tr.title, artist: tr.artist, cover: tr.cover }
             : undefined,
         }).then((r) => {
-          if (!r.ok) toast.error(r.error ?? "Could not queue track");
+          if (!r.ok) toast.error(r.error ?? t("common.listenAlong.couldNotQueueTrack"));
         });
         return;
       }
@@ -1482,8 +1492,8 @@ export function useKaraokeLogic({
         joinListenSession(sessionIdToProcess, username || undefined)
           .then((result) => {
             if (!result.ok) {
-              toast.error("Failed to join session", {
-                description: result.error || "Please try again.",
+              toast.error(t("common.listenAlong.failedToJoinSession"), {
+                description: result.error || t("common.errors.pleaseTryAgain"),
               });
             }
             if (instanceId) clearInstanceInitialData(instanceId);
@@ -1494,7 +1504,7 @@ export function useKaraokeLogic({
       }, 100);
       lastProcessedListenSessionRef.current = initialData.listenSessionId;
     }
-  }, [isWindowOpen, initialData, joinListenSession, username, clearInstanceInitialData, instanceId]);
+  }, [isWindowOpen, initialData, joinListenSession, username, clearInstanceInitialData, instanceId, t]);
 
   // Handle updateApp event for when app is already open and receives new video
   useEffect(() => {
@@ -1516,7 +1526,9 @@ export function useKaraokeLogic({
         }
         processVideoId(videoId).catch((error) => {
           console.error(`[Karaoke] Error processing videoId ${videoId}:`, error);
-          toast.error("Failed to load shared track", { description: `Video ID: ${videoId}` });
+          toast.error(t("common.listenAlong.failedToLoadSharedTrack"), {
+            description: t("common.listenAlong.videoIdLabel", { videoId }),
+          });
         });
         lastProcessedInitialDataRef.current = updateInitialData;
       }
@@ -1534,8 +1546,8 @@ export function useKaraokeLogic({
         joinListenSession(sessionId, username || undefined)
           .then((result) => {
             if (!result.ok) {
-              toast.error("Failed to join session", {
-                description: result.error || "Please try again.",
+              toast.error(t("common.listenAlong.failedToJoinSession"), {
+                description: result.error || t("common.errors.pleaseTryAgain"),
               });
             }
           })
@@ -1547,7 +1559,7 @@ export function useKaraokeLogic({
     };
 
     return onAppUpdate(handleUpdateApp);
-  }, [processVideoId, bringInstanceToForeground, joinListenSession, username, instanceId]);
+  }, [processVideoId, bringInstanceToForeground, joinListenSession, username, instanceId, t]);
 
   const currentTheme = useThemeStore((state) => state.current);
   const isXpTheme = currentTheme === "xp" || currentTheme === "win98";

--- a/src/apps/paint/hooks/usePaintLogic.ts
+++ b/src/apps/paint/hooks/usePaintLogic.ts
@@ -270,10 +270,10 @@ export function usePaintLogic({ initialData, instanceId }: UsePaintLogicProps) {
       setLastFilePath(filePath);
       setHasUnsavedChanges(false);
       setIsSaveDialogOpen(false);
-      toast.success("Image saved successfully");
+      toast.success(t("apps.paint.dialogs.imageSavedSuccessfully"));
     } catch (err) {
       console.error("Error saving file:", err);
-      toast.error("Failed to save image");
+      toast.error(t("apps.paint.dialogs.failedToSaveImage"));
     }
   };
 

--- a/src/apps/soundboard/components/BoardList.tsx
+++ b/src/apps/soundboard/components/BoardList.tsx
@@ -86,7 +86,9 @@ export function BoardList({
           >
             <Select value={selectedDeviceId} onValueChange={onDeviceSelect}>
               <SelectTrigger className="w-full h-7 text-xs">
-                <SelectValue placeholder="Select microphone" />
+                <SelectValue
+                  placeholder={t("apps.soundboard.selectMicrophone")}
+                />
               </SelectTrigger>
               <SelectContent>
                 {audioDevices.map((device) => (
@@ -96,7 +98,9 @@ export function BoardList({
                     className="text-xs"
                   >
                     {device.label ||
-                      `Microphone ${device.deviceId.slice(0, 4)}...`}
+                      t("apps.soundboard.defaultMicrophoneLabel", {
+                        id: device.deviceId.slice(0, 4),
+                      })}
                   </SelectItem>
                 ))}
               </SelectContent>

--- a/src/components/shared/LinkPreview.tsx
+++ b/src/components/shared/LinkPreview.tsx
@@ -119,11 +119,11 @@ export function LinkPreview({ url, className = "" }: LinkPreviewProps) {
       if (videoId) {
         launchApp("ipod", { initialData: { videoId } });
       } else {
-        toast.error("Could not extract video ID from this YouTube URL");
+        toast.error(t("components.linkPreview.couldNotExtractYouTubeVideoId"));
         console.warn("Could not extract video ID from YouTube URL:", url);
       }
     } catch (error) {
-      toast.error("Failed to open video in iPod app");
+      toast.error(t("components.linkPreview.failedToOpenInIpod"));
       console.error("Error launching iPod app:", error);
     }
   };
@@ -136,11 +136,11 @@ export function LinkPreview({ url, className = "" }: LinkPreviewProps) {
       if (videoId) {
         launchApp("karaoke", { initialData: { videoId } });
       } else {
-        toast.error("Could not extract video ID from this URL");
+        toast.error(t("components.linkPreview.couldNotExtractVideoId"));
         console.warn("Could not extract video ID from URL:", url);
       }
     } catch (error) {
-      toast.error("Failed to open video in Karaoke app");
+      toast.error(t("components.linkPreview.failedToOpenInKaraoke"));
       console.error("Error launching Karaoke app:", error);
     }
   };
@@ -345,11 +345,11 @@ export function LinkPreview({ url, className = "" }: LinkPreviewProps) {
             );
             launchApp("ipod", { initialData: { videoId } });
           } else {
-            toast.error("Could not extract video ID from this iPod URL");
+            toast.error(t("components.linkPreview.couldNotExtractVideoIdFromIpodUrl"));
             console.warn("Could not extract video ID from iPod URL:", url);
           }
         } catch (error) {
-          toast.error("Failed to open video in iPod app");
+          toast.error(t("components.linkPreview.failedToOpenInIpod"));
           console.error("Error launching iPod app:", error);
         }
       } else if (url.includes("/karaoke/")) {
@@ -362,11 +362,11 @@ export function LinkPreview({ url, className = "" }: LinkPreviewProps) {
             );
             launchApp("karaoke", { initialData: { videoId } });
           } else {
-            toast.error("Could not extract video ID from this Karaoke URL");
+            toast.error(t("components.linkPreview.couldNotExtractVideoIdFromKaraokeUrl"));
             console.warn("Could not extract video ID from Karaoke URL:", url);
           }
         } catch (error) {
-          toast.error("Failed to open video in Karaoke app");
+          toast.error(t("components.linkPreview.failedToOpenInKaraoke"));
           console.error("Error launching Karaoke app:", error);
         }
       } else {

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,11 +1,13 @@
 import { useState, useCallback } from "react";
 import { toast } from "sonner";
+import { useTranslation } from "react-i18next";
 import { track } from "@vercel/analytics";
 import { APP_ANALYTICS } from "@/utils/analytics";
 import { useChatsStoreShallow } from "@/stores/helpers";
 import { loginWithPassword, verifyAuthToken } from "@/api/auth";
 
 export function useAuth() {
+  const { t } = useTranslation();
   const {
     username,
     isAuthenticated,
@@ -57,7 +59,7 @@ export function useAuth() {
 
     const trimmedUsername = newUsername.trim();
     if (!trimmedUsername) {
-      setUsernameError("Username cannot be empty.");
+      setUsernameError(t("common.auth.validation.usernameCannotBeEmpty"));
       setIsSettingUsername(false);
       return;
     }
@@ -67,13 +69,13 @@ export function useAuth() {
     }
 
     if (!newPassword.trim()) {
-      setUsernameError("Password is required.");
+      setUsernameError(t("common.auth.validation.passwordRequired"));
       setIsSettingUsername(false);
       return;
     }
 
     if (newPassword.length < 8) {
-      setUsernameError("Password must be at least 8 characters.");
+      setUsernameError(t("common.auth.validation.passwordMinLength"));
       setIsSettingUsername(false);
       return;
     }
@@ -84,15 +86,15 @@ export function useAuth() {
       setIsUsernameDialogOpen(false);
       setNewUsername("");
       setNewPassword("");
-      toast.success("Logged In", {
-        description: `Welcome, ${trimmedUsername}!`,
+      toast.success(t("common.auth.toast.loggedIn"), {
+        description: t("common.auth.toast.welcomeUser", { username: trimmedUsername }),
       });
     } else {
-      setUsernameError(result.error || "Failed to set username");
+      setUsernameError(result.error || t("common.auth.toast.failedToSetUsername"));
     }
 
     setIsSettingUsername(false);
-  }, [newUsername, newPassword, createUser, username, logout]);
+  }, [newUsername, newPassword, createUser, username, logout, t]);
 
   const promptVerifyToken = useCallback(() => {
     setVerifyTokenInput("");
@@ -105,7 +107,7 @@ export function useAuth() {
   const handleVerifyTokenSubmit = useCallback(
     async (input: string, isPassword: boolean = false) => {
       if (!input.trim()) {
-        setVerifyError(isPassword ? "Password required" : "Token required");
+        setVerifyError(isPassword ? t("common.auth.validation.passwordFieldRequired") : t("common.auth.validation.tokenRequired"));
         return;
       }
 
@@ -130,8 +132,8 @@ export function useAuth() {
             track(APP_ANALYTICS.USER_LOGIN_PASSWORD, {
               username: result.username,
             });
-            toast.success("Success", {
-              description: "Logged in successfully with password",
+            toast.success(t("common.auth.toast.success"), {
+              description: t("common.auth.toast.loggedInWithPassword"),
             });
             setVerifyDialogOpen(false);
             setVerifyPasswordInput("");
@@ -153,8 +155,8 @@ export function useAuth() {
             track(APP_ANALYTICS.USER_LOGIN_TOKEN, {
               username: result.username,
             });
-            toast.success("Success", {
-              description: "Token verified and set successfully",
+            toast.success(t("common.auth.toast.success"), {
+              description: t("common.auth.toast.tokenVerified"),
             });
             setVerifyDialogOpen(false);
             setVerifyTokenInput("");
@@ -164,13 +166,13 @@ export function useAuth() {
       } catch (err) {
         console.error("[useAuth] Error verifying:", err);
         const message =
-          err instanceof Error ? err.message : "Network error while verifying";
+          err instanceof Error ? err.message : t("common.auth.toast.networkErrorVerifying");
         setVerifyError(message);
       } finally {
         setIsVerifyingToken(false);
       }
     },
-    [setAuthenticated, setUsername, username, verifyUsernameInput, isAuthenticated, logout]
+    [setAuthenticated, setUsername, username, verifyUsernameInput, isAuthenticated, logout, t]
   );
 
   const checkHasPassword = useCallback(async () => {
@@ -198,10 +200,10 @@ export function useAuth() {
 
     await logout();
 
-    toast.success("Logged Out", {
-      description: "You have been successfully logged out.",
+    toast.success(t("common.auth.toast.loggedOut"), {
+      description: t("common.auth.toast.loggedOutDescription"),
     });
-  }, [logout]);
+  }, [logout, t]);
 
   const promptLogout = useCallback(async () => {
     setIsLogoutConfirmDialogOpen(true);

--- a/src/hooks/useListenSync.ts
+++ b/src/hooks/useListenSync.ts
@@ -6,6 +6,7 @@ import {
   type ListenTrackMeta,
 } from "@/stores/useListenSessionStore";
 import { toast } from "sonner";
+import i18n from "@/lib/i18n";
 
 interface ListenSyncOptions {
   currentTrackId: string | null;
@@ -315,16 +316,20 @@ export function useListenSync({
 
       if (timeSinceLastSync > DJ_DISCONNECT_PROMOTE_MS) {
         if (!djDisconnectWarningShownRef.current) {
-          toast.warning("Playback device may be offline", {
-            description: "Waiting for the device that plays audio to reconnect.",
+          toast.warning(i18n.t("common.listenSession.playbackDeviceOffline"), {
+            description: i18n.t(
+              "common.listenSession.playbackDeviceOfflineDescription"
+            ),
             duration: 10000,
           });
           djDisconnectWarningShownRef.current = true;
         }
       } else if (timeSinceLastSync > DJ_DISCONNECT_WARNING_MS) {
         if (!djDisconnectWarningShownRef.current) {
-          toast.info("Connection unstable", {
-            description: "Haven't received updates from the playback device in a while.",
+          toast.info(i18n.t("common.listenSession.connectionUnstable"), {
+            description: i18n.t(
+              "common.listenSession.connectionUnstableDescription"
+            ),
             duration: 5000,
           });
           djDisconnectWarningShownRef.current = true;

--- a/src/lib/locales/en/translation.json
+++ b/src/lib/locales/en/translation.json
@@ -118,7 +118,8 @@
     "errors": {
       "failedToAccessCamera": "Failed to access camera",
       "failedToFetchFurigana": "Failed to fetch furigana",
-      "failedToFetchSoramimi": "Failed to fetch soramimi"
+      "failedToFetchSoramimi": "Failed to fetch soramimi",
+      "pleaseTryAgain": "Please try again."
     },
     "system": {
       "systemRestoring": "System Restoring...",
@@ -229,6 +230,52 @@
       "alreadyLatestVersion": "Already running the latest version",
       "couldNotCheckUpdates": "Could not check for updates"
     },
+    "network": {
+      "featureRequiresInternet": "This feature requires an internet connection"
+    },
+    "airdrop": {
+      "sentFileTo": "Sent \"{{fileName}}\" to @{{recipient}}",
+      "failedToSendFile": "Failed to send file",
+      "sendFailed": "Send failed",
+      "acceptedFile": "@{{recipient}} accepted \"{{fileName}}\"",
+      "declinedFile": "@{{recipient}} declined \"{{fileName}}\""
+    },
+    "listenSession": {
+      "sessionEnded": "Session ended",
+      "sessionEndedDescription": "The host ended the listening session.",
+      "djDisconnected": "DJ disconnected",
+      "djDisconnectedDescription": "@{{username}} appears to have disconnected.",
+      "playbackDeviceOffline": "Playback device may be offline",
+      "playbackDeviceOfflineDescription": "Waiting for the device that plays audio to reconnect.",
+      "connectionUnstable": "Connection unstable",
+      "connectionUnstableDescription": "Haven't received updates from the playback device in a while.",
+      "failedToJoinSession": "Failed to join session",
+      "failedToLoadSharedTrack": "Failed to load shared track",
+      "videoIdLabel": "Video ID: {{videoId}}"
+    },
+    "listenAlong": {
+      "loginRequired": "Login required",
+      "loginRequiredDescription": "Set a username in Chats to start a session.",
+      "failedToStartSession": "Failed to start session",
+      "failedToJoinSession": "Failed to join session",
+      "failedToLeaveSession": "Failed to leave session",
+      "couldNotSetPlaybackDevice": "Could not set playback device",
+      "playbackDeviceUpdated": "Playback device updated",
+      "playbackDeviceUpdatedDescription": "@{{username}} plays audio for the group.",
+      "couldNotTransferHost": "Could not transfer host",
+      "failedToPassDj": "Failed to pass DJ",
+      "djPassed": "DJ passed",
+      "djPassedDescription": "@{{username}} is now the DJ.",
+      "couldNotSyncAfterRemoteControl": "Could not sync after remote control",
+      "failedToSendReaction": "Failed to send reaction",
+      "youtubeOnlyRemoteQueue": "Only YouTube links can be queued remotely",
+      "couldNotSkip": "Could not skip",
+      "remoteControlFailed": "Remote control failed",
+      "couldNotSeek": "Could not seek",
+      "couldNotQueueTrack": "Could not queue track",
+      "failedToLoadSharedTrack": "Failed to load shared track",
+      "videoIdLabel": "Video ID: {{videoId}}"
+    },
     "auth": {
       "dialogTitle": "ryOS Login",
       "username": "Username",
@@ -242,7 +289,35 @@
       "setPasswordRequired": "Set Password Required",
       "setPasswordRequiredDescription": "You need to set a password before logging out to ensure you can recover your account. Would you like to set a password now?",
       "logOut": "Log Out",
-      "logOutDescription": "Are you sure you want to log out? You will be signed out of your account."
+      "logOutDescription": "Are you sure you want to log out? You will be signed out of your account.",
+      "validation": {
+        "usernameCannotBeEmpty": "Username cannot be empty.",
+        "passwordRequired": "Password is required.",
+        "passwordMinLength": "Password must be at least 8 characters.",
+        "passwordFieldRequired": "Password required",
+        "tokenRequired": "Token required"
+      },
+      "toast": {
+        "loggedIn": "Logged In",
+        "welcomeUser": "Welcome, {{username}}!",
+        "failedToSetUsername": "Failed to set username",
+        "success": "Success",
+        "loggedInWithPassword": "Logged in successfully with password",
+        "tokenVerified": "Token verified and set successfully",
+        "networkErrorVerifying": "Network error while verifying",
+        "loggedOut": "Logged Out",
+        "loggedOutDescription": "You have been successfully logged out."
+      },
+      "logoutAllDevices": {
+        "authenticationError": "Authentication Error",
+        "notAuthenticated": "Not authenticated",
+        "loggedOut": "Logged Out",
+        "loggedOutFromAllDevices": "Logged out from all devices",
+        "logoutFailed": "Logout Failed",
+        "logoutFromAllDevicesFailed": "Failed to logout from all devices",
+        "networkError": "Network Error",
+        "failedToConnect": "Failed to connect to server"
+      }
     },
     "htmlPreview": {
       "toastSaved": "Applet saved successfully",
@@ -473,6 +548,8 @@
       "name": "Soundboard",
       "description": "Play sound effects",
       "soundboards": "Soundboards",
+      "selectMicrophone": "Select microphone",
+      "defaultMicrophoneLabel": "Microphone {{id}}",
       "newSoundboardDefault": "New Soundboard",
       "importedSoundboard": "Imported Soundboard",
       "menu": {
@@ -567,6 +644,8 @@
       "cannotAccessWebsite": "Cannot access {{url}}. The website might be blocking access or requires authentication.",
       "pageCouldNotBeLoadedInIframe": "The page could not be loaded in the iframe. This could be due to security restrictions or network issues.",
       "openingSharedPage": "Opening shared page",
+      "sharedPageToastDescription": "{{url}}{{yearPart}}",
+      "sharedPageToastYearPart": " {{from}} {{year}}",
       "from": "from",
       "invalidShareLink": "Invalid Share Link",
       "shareLinkInvalidOrCorrupted": "The share link provided is invalid or corrupted.",
@@ -781,7 +860,53 @@
         "creating": "Creating...",
         "cancel": "Cancel",
         "create": "Create",
-        "failedToCreateRoom": "Failed to create room"
+        "failedToCreateRoom": "Failed to create room",
+        "createRoomIrc": {
+          "failedToLoadServers": "Failed to load IRC servers",
+          "failedToLoadChannels": "Failed to load IRC channels",
+          "serverHostRequired": "Server host is required",
+          "failedToAddServer": "Failed to add IRC server",
+          "failedToDeleteServer": "Failed to delete IRC server",
+          "pickServerFirst": "Please pick an IRC server first.",
+          "pickChannel": "Please pick or enter an IRC channel.",
+          "pickChannelFromList": "Please pick a channel from the list.",
+          "pickServerLoading": "Loading…",
+          "pickServer": "Pick a server",
+          "removeServerTitle": "Remove server",
+          "removeServerAria": "Remove server",
+          "hostPlaceholder": "irc.example.com",
+          "optionalLabelPlaceholder": "Optional label",
+          "portPlaceholder": "6667",
+          "addingServer": "Adding…",
+          "addServer": "Add server",
+          "refreshChannelsTitle": "Refresh channel list",
+          "refreshChannelsAria": "Refresh channel list",
+          "filterChannelsTyping": "Filter channels or type a new one",
+          "filterChannels": "Filter channels",
+          "noChannelsHint": "No channels available. Type a channel name above to join one anyway.",
+          "noChannelsMatch": "No channels match this filter.",
+          "server": "Server",
+          "channel": "Channel",
+          "addNewServer": "Add new server…",
+          "badgeDefault": "default",
+          "badgeTls": "tls",
+          "addAServer": "Add a server",
+          "tls": "TLS",
+          "ircServersAdminHint": "IRC servers are managed by an admin. Choose a channel from the list to join.",
+          "loadingChannels": "Loading channels…"
+        }
+      },
+      "toasts": {
+        "transcriptSaved": "Transcript saved",
+        "transcriptUpdated": "Transcript updated",
+        "transcriptSavedDescription": "Saved to {{fileName}}",
+        "failedToSaveTranscript": "Failed to save transcript",
+        "unknownError": "Unknown error",
+        "aiError": "AI Error",
+        "rateLimitExceeded": "Rate Limit Exceeded",
+        "rateLimitDescription": "You've reached the message limit. Please login to continue.",
+        "sessionExpiredDescription": "Your session has expired. Please login again.",
+        "failedToGetAiResponse": "Failed to get response."
       },
       "status": {
         "loginToRyOS": "Login to ryOS",
@@ -845,7 +970,8 @@
         "you": "You",
         "ryo": "Ryo",
         "delete": "Delete",
-        "greeting": "👋 hey! i'm ryo. ask me anything!"
+        "greeting": "👋 hey! i'm ryo. ask me anything!",
+        "describeThisImage": "Describe this image"
       },
       "toolCalls": {
         "loadingMusicLibrary": "Loading music library…",
@@ -2341,6 +2467,8 @@
         "couldNotImportFile": "Could not import the file.",
         "appletExported": "Applet exported!",
         "appletExportedDescription": "{{fileName}}.app exported successfully.",
+        "htmlExported": "HTML exported!",
+        "htmlExportedDescription": "{{fileName}}.html exported successfully.",
         "exportFailed": "Export failed",
         "couldNotCompressAppletFile": "Could not compress the applet file.",
         "noAppletToShare": "No applet to share",
@@ -2354,6 +2482,10 @@
         "shareLinkUpdatedSuccessfully": "Share link updated successfully.",
         "shareLinkGeneratedSuccessfully": "Share link generated successfully.",
         "failedToShareApplet": "Failed to share applet",
+        "failedToLaunchApplet": "Failed to launch applet",
+        "appletInstalledToast": "Applet installed",
+        "savedToAppletsPath": "Saved to /Applets/{{fileName}}",
+        "failedToInstallApplet": "Failed to install applet",
         "appletNotFound": "Applet not found",
         "appletNotFoundDescription": "The shared applet may have been deleted or the link is invalid.",
         "failedToFetchSharedApplet": "Failed to fetch shared applet",
@@ -2412,6 +2544,10 @@
         "controlPanelsHelpForMacosX": "System Preferences Help",
         "aboutControlPanels": "About Control Panels",
         "aboutControlPanelsForMacosX": "About System Preferences"
+      },
+      "dialogs": {
+        "passwordMinLength": "Password must be at least 8 characters",
+        "failedToSetPassword": "Failed to set password"
       },
       "masterVolume": "Master Volume",
       "master": "Master",
@@ -3546,7 +3682,13 @@
       "openIpod": "Open iPod",
       "openKaraoke": "Open Karaoke",
       "openYouTube": "Open YouTube",
-      "addToIpod": "Add to iPod"
+      "addToIpod": "Add to iPod",
+      "couldNotExtractYouTubeVideoId": "Could not extract video ID from this YouTube URL",
+      "failedToOpenInIpod": "Failed to open video in iPod app",
+      "couldNotExtractVideoId": "Could not extract video ID from this URL",
+      "failedToOpenInKaraoke": "Failed to open video in Karaoke app",
+      "couldNotExtractVideoIdFromIpodUrl": "Could not extract video ID from this iPod URL",
+      "couldNotExtractVideoIdFromKaraokeUrl": "Could not extract video ID from this Karaoke URL"
     }
   },
   "settings": {

--- a/src/stores/useAirDropStore.ts
+++ b/src/stores/useAirDropStore.ts
@@ -7,6 +7,7 @@ import {
 } from "@/lib/pusherClient";
 import type { PusherChannel } from "@/lib/pusherClient";
 import { toast } from "sonner";
+import i18n from "@/lib/i18n";
 
 const AIRDROP_PRESENCE_TTL_MS = 60_000;
 const AIRDROP_LOBBY_CHANNEL = "airdrop-lobby";
@@ -187,14 +188,16 @@ export const useAirDropStore = create<AirDropState>((set, get) => ({
         body: JSON.stringify({ recipient, fileName, fileType, content }),
       });
       if (res.ok) {
-        toast.success(`Sent "${fileName}" to @${recipient}`);
+        toast.success(
+          i18n.t("common.airdrop.sentFileTo", { fileName, recipient })
+        );
         return true;
       }
-      const err = await res.json().catch(() => ({ error: "Send failed" }));
-      toast.error(err.error || "Failed to send file");
+      const err = await res.json().catch(() => ({ error: i18n.t("common.airdrop.sendFailed") }));
+      toast.error(err.error || i18n.t("common.airdrop.failedToSendFile"));
       return false;
     } catch {
-      toast.error("Failed to send file");
+      toast.error(i18n.t("common.airdrop.failedToSendFile"));
       return false;
     } finally {
       set({ isSending: false });
@@ -250,7 +253,9 @@ export const useAirDropStore = create<AirDropState>((set, get) => ({
         fileName: string;
         recipient: string;
       };
-      toast.success(`@${recipient} accepted "${fileName}"`);
+      toast.success(
+        i18n.t("common.airdrop.acceptedFile", { fileName, recipient })
+      );
     });
 
     channel.bind("airdrop-declined", (data: unknown) => {
@@ -258,7 +263,9 @@ export const useAirDropStore = create<AirDropState>((set, get) => ({
         fileName: string;
         recipient: string;
       };
-      toast.error(`@${recipient} declined "${fileName}"`);
+      toast.error(
+        i18n.t("common.airdrop.declinedFile", { fileName, recipient })
+      );
     });
 
     set({ pusherChannel: channel, subscribedUsername: username });

--- a/src/stores/useListenSessionStore.ts
+++ b/src/stores/useListenSessionStore.ts
@@ -3,6 +3,7 @@ import type { PusherChannel } from "@/lib/pusherClient";
 import { getPusherClient } from "@/lib/pusherClient";
 import { toast } from "@/hooks/useToast";
 import { useChatsStore } from "@/stores/useChatsStore";
+import i18n from "@/lib/i18n";
 import {
   assignListenSessionDj,
   createListenSession,
@@ -550,8 +551,8 @@ export const useListenSessionStore = create<ListenSessionState>((set, get) => {
     });
 
     channelRef.bind("session-ended", () => {
-      toast("Session ended", {
-        description: "The host ended the listening session.",
+      toast(i18n.t("common.listenSession.sessionEnded"), {
+        description: i18n.t("common.listenSession.sessionEndedDescription"),
       });
       unsubscribeFromSession();
       set({
@@ -566,8 +567,10 @@ export const useListenSessionStore = create<ListenSessionState>((set, get) => {
       ({ djUsername }: { djUsername: string }) => {
         const state = get();
         if (!state.currentSession || state.isDj) return;
-        toast.warning("DJ disconnected", {
-          description: `@${djUsername} appears to have disconnected.`,
+        toast.warning(i18n.t("common.listenSession.djDisconnected"), {
+          description: i18n.t("common.listenSession.djDisconnectedDescription", {
+            username: djUsername,
+          }),
           duration: 8000,
         });
       }

--- a/src/utils/appletImportExport.ts
+++ b/src/utils/appletImportExport.ts
@@ -7,6 +7,7 @@ import { extractMetadataFromHtml, injectMetadataIntoHtml, type AppletMetadata } 
 import { extractEmojiIcon } from "@/apps/applet-viewer/utils/appletActions";
 import { useFilesStore } from "@/stores/useFilesStore";
 import { toast } from "sonner";
+import i18n from "@/lib/i18n";
 
 export interface ImportedAppletData {
   content: string;
@@ -177,8 +178,8 @@ export async function exportAppletAsApp(
     ? appletPath
         .split("/")
         .pop()
-        ?.replace(/\.(html|app)$/i, "") || "Untitled"
-    : "Untitled");
+        ?.replace(/\.(html|app)$/i, "") || i18n.t("apps.applet-viewer.dialogs.untitled")
+    : i18n.t("apps.applet-viewer.dialogs.untitled"));
 
   // Get file metadata from the filesystem
   const fileStore = useFilesStore.getState();
@@ -255,15 +256,17 @@ export async function exportAppletAsApp(
     document.body.removeChild(a);
     URL.revokeObjectURL(url);
 
-    toast.success("Applet exported!", {
-      description: `${finalFilename}.app exported successfully.`,
+    toast.success(i18n.t("apps.applet-viewer.dialogs.appletExported"), {
+      description: i18n.t("apps.applet-viewer.dialogs.appletExportedDescription", {
+        fileName: finalFilename,
+      }),
     });
   } catch (compressionError) {
     console.error("Compression failed:", compressionError);
-    toast.error("Export failed", {
+    toast.error(i18n.t("apps.applet-viewer.dialogs.exportFailed"), {
       description: compressionError instanceof Error
         ? compressionError.message
-        : "Could not compress the applet file.",
+        : i18n.t("apps.applet-viewer.dialogs.couldNotCompressAppletFile"),
     });
     throw compressionError;
   }
@@ -282,8 +285,8 @@ export function exportAppletAsHtml(
     ? appletPath
         .split("/")
         .pop()
-        ?.replace(/\.(html|app)$/i, "") || "Untitled"
-    : "Untitled");
+        ?.replace(/\.(html|app)$/i, "") || i18n.t("apps.applet-viewer.dialogs.untitled")
+    : i18n.t("apps.applet-viewer.dialogs.untitled"));
 
   // Get file metadata from the filesystem
   const fileStore = useFilesStore.getState();
@@ -314,8 +317,10 @@ export function exportAppletAsHtml(
   document.body.removeChild(a);
   URL.revokeObjectURL(url);
 
-  toast.success("HTML exported!", {
-    description: `${baseFilename}.html exported successfully.`,
+  toast.success(i18n.t("apps.applet-viewer.dialogs.htmlExported"), {
+    description: i18n.t("apps.applet-viewer.dialogs.htmlExportedDescription", {
+      fileName: baseFilename,
+    }),
   });
 }
 

--- a/src/utils/offline.ts
+++ b/src/utils/offline.ts
@@ -1,4 +1,5 @@
 import { toast } from "sonner";
+import i18n from "@/lib/i18n";
 
 /**
  * Check if the browser is currently offline
@@ -15,7 +16,7 @@ export function isOffline(): boolean {
  * Uses a unique ID to prevent duplicate toasts
  */
 export function showOfflineError(message?: string): void {
-  toast.error(message || "This feature requires an internet connection", {
+  toast.error(message || i18n.t("common.network.featureRequiresInternet"), {
     id: "offline-error",
     duration: 3000,
   });

--- a/src/utils/prefetch.ts
+++ b/src/utils/prefetch.ts
@@ -317,7 +317,7 @@ async function checkAndUpdate(isManual: boolean = false): Promise<void> {
   if (result.action === 'none') {
     if (isManual) {
       const stored = getStoredVersion();
-      toast.success('Already running the latest version', {
+      toast.success(i18n.t("common.toast.alreadyLatestVersion"), {
         description: stored.version ? `ryOS ${stored.version} (${stored.buildNumber})` : undefined,
       });
     }
@@ -369,7 +369,7 @@ export async function forceRefreshCache(): Promise<void> {
   const serverVersion = await fetchServerVersion();
   
   if (!serverVersion) {
-    toast.error('Could not check for updates');
+    toast.error(i18n.t("common.toast.couldNotCheckUpdates"));
     return;
   }
   
@@ -378,7 +378,7 @@ export async function forceRefreshCache(): Promise<void> {
   
   // If already on latest version, just show success message without reboot
   if (!isNewVersion) {
-    toast.success('Already running the latest version', {
+    toast.success(i18n.t("common.toast.alreadyLatestVersion"), {
       description: stored.version ? `ryOS ${stored.version} (${stored.buildNumber})` : undefined,
     });
     return;
@@ -417,7 +417,7 @@ async function runPrefetchWithToast(
   // Fetch manifest first
   const manifest = await fetchIconManifest();
   if (!manifest) {
-    toast.error('Failed to load asset manifest');
+    toast.error(i18n.t("common.toast.failedToLoadAssetManifest"));
     console.log('[Prefetch] Could not fetch manifest');
     return;
   }
@@ -431,7 +431,7 @@ async function runPrefetchWithToast(
   const totalItems = iconUrls.length + soundUrls.length + jsUrls.length + assetUrls.length;
   
   if (totalItems === 0) {
-    toast.info('No assets to cache');
+    toast.info(i18n.t("common.toast.noAssetsToCache"));
     console.log('[Prefetch] No assets to prefetch');
     return;
   }
@@ -538,7 +538,7 @@ async function runPrefetchWithToast(
     
   } catch (error) {
     console.error('[Prefetch] Error during prefetch:', error);
-    toast.error('Failed to cache assets', { id: toastId });
+    toast.error(i18n.t("common.toast.failedToCacheAssets"), { id: toastId });
   }
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
This pass replaces obvious hardcoded UI copy with `t()` / `i18n.t()` and adds matching keys under `src/lib/locales/en/translation.json`. Non-English locales continue to fall back to English via i18next until `bun run i18n:sync` (or machine translate) is run.

**Areas covered**
- Chats: IRC create-room dialog, AI chat toasts (login, rate limit, errors, transcript save), image caption default
- Internet Explorer: error page strings, URL/year placeholders, share tooltip/aria, offline message, share-link toasts in hook
- Applet viewer / store: update checks, import/export/share/save flows, install/launch actions
- Listen-along / KTV: Karaoke + iPod session toasts; shared `common.listenAlong.*` for remote control errors
- Auth & system: `useAuth` validation + toasts, Control Panels logout-all-devices toasts, password dialog copy, prefetch toasts, offline default message, AirDrop toasts, listen session store toasts, `useListenSync` warnings

**Testing**
- `bun run build` could not be run in this environment (Bun/Node not on PATH). Please run locally to verify.

**Remaining gaps (examples)**
- Many apps still have English-only strings in components not touched here (e.g. some IE favorite dialogs, Contacts `index.tsx` help metadata, TV/admin surfaces, `defaultValue` fallbacks in a few places)
- New keys exist in **English only**; run `bun run i18n:sync` / translate pipeline to populate `ja`, `de`, etc.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-05c49925-136c-4346-91e5-a882ad3530cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-05c49925-136c-4346-91e5-a882ad3530cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

