### PR TITLE
feat(telegram): Cursor Cloud repo agent for linked chats

### DIFF
--- a/api/_utils/_aiPrompts.ts
+++ b/api/_utils/_aiPrompts.ts
@@ -277,6 +277,10 @@ You can manage the user's calendar events, todos, and sticky notes directly from
 - These changes sync to ryOS automatically — the user will see them next time the browser polls.
 - If the user hasn't enabled cloud sync yet, these tools will let you know.
 - Always confirm what you did after making changes in one short line when possible (e.g. "added 'Dentist' on 2026-03-10 at 14:00").
+
+## Cursor Cloud Agent (repo)
+When the user explicitly wants GitHub/repo work — bug fixes, features, refactors in the ryOS codebase, or opening a PR — call cursorRepoAgent with the public repo https://github.com/ryokun6/ryos unless they name another allowlisted HTTPS repo.
+The Cloud Agent runs asynchronously on Cursor's servers. Reply briefly after starting it; completion and streaming updates arrive as separate Telegram messages — do not claim finished work until those messages reflect it.
 </telegram_chat_instructions>
 `;
 

--- a/api/_utils/cursor-cloud-agent.ts
+++ b/api/_utils/cursor-cloud-agent.ts
@@ -1,0 +1,430 @@
+/**
+ * Cursor Cloud Agents API v1 client (https://api.cursor.com).
+ *
+ * Auth: Basic with API key as username and empty password (`-u KEY:` per Cursor docs).
+ *
+ * Environment (server-side only; never expose to the client):
+ * - CURSOR_API_KEY — from Cursor Dashboard → Integrations (required to use the tool)
+ * - CURSOR_RYOS_REPO_URLS — comma-separated GitHub HTTPS URLs allowed for this deployment
+ *   (e.g. https://github.com/ryokun6/ryos). If unset, defaults to the public ryOS repo.
+ */
+
+const DEFAULT_CURSOR_API_BASE = "https://api.cursor.com";
+
+const DEFAULT_RYOS_REPO = "https://github.com/ryokun6/ryos";
+
+/** Run statuses we treat as terminal when polling stream fallbacks. */
+const TERMINAL_RUN_STATUSES = new Set([
+  "FINISHED",
+  "FAILED",
+  "ERROR",
+  "CANCELLED",
+  "CANCELED",
+]);
+
+export type CursorAgentCreateResponse = {
+  agent?: {
+    id?: string;
+    url?: string;
+    name?: string;
+    latestRunId?: string;
+  };
+  run?: {
+    id?: string;
+    status?: string;
+    agentId?: string;
+  };
+};
+
+export type CursorRunResponse = {
+  id?: string;
+  agentId?: string;
+  status?: string;
+  createdAt?: string;
+  updatedAt?: string;
+};
+
+export function getCursorCloudApiBaseUrl(env: NodeJS.ProcessEnv): string {
+  const raw = env.CURSOR_CLOUD_API_BASE_URL?.trim().replace(/\/$/, "");
+  return raw || DEFAULT_CURSOR_API_BASE;
+}
+
+export function getCursorApiKey(env: NodeJS.ProcessEnv): string | null {
+  const key = env.CURSOR_API_KEY?.trim();
+  return key ? key : null;
+}
+
+/**
+ * GitHub HTTPS repo URLs permitted for Cursor Cloud Agent launches from ryOS Telegram.
+ */
+export function getAllowedRyosRepoUrls(env: NodeJS.ProcessEnv): string[] {
+  const explicit = env.CURSOR_RYOS_REPO_URLS?.trim();
+  const raw =
+    explicit && explicit.length > 0 ? explicit : DEFAULT_RYOS_REPO;
+  return raw
+    .split(",")
+    .map((s) =>
+      normalizeGithubRepoHttpsUrl(String(s || "").trim())
+    )
+    .filter((u): u is string => u !== null && u.length > 0);
+}
+
+export function normalizeGithubRepoHttpsUrl(
+  candidate: string
+): string | null {
+  try {
+    const u = candidate.startsWith("http")
+      ? new URL(candidate)
+      : new URL(`https://${candidate}`);
+    if (u.hostname !== "github.com") {
+      return null;
+    }
+    const pathname = u.pathname.replace(/\/+$/, "").replace(/^\/+/, "/");
+    if (!pathname.match(/^\/[^/]+\/[^/]+$/)) {
+      return null;
+    }
+    return `https://github.com${pathname}`;
+  } catch {
+    return null;
+  }
+}
+
+/** Returns true iff `requested` resolves to one of the HTTPS allowlist URLs. */
+export function isRepoAllowed(
+  repoUrl: string,
+  allowed: string[]
+): boolean {
+  const n = normalizeGithubRepoHttpsUrl(repoUrl);
+  if (!n || allowed.length === 0) return false;
+  const allowSet = new Set(allowed.map((a) => normalizeGithubRepoHttpsUrl(a)!));
+  return allowSet.has(n);
+}
+
+export function authorizationHeader(apiKey: string): string {
+  const token = Buffer.from(`${apiKey}:`, "utf8").toString("base64");
+  return `Basic ${token}`;
+}
+
+export async function cursorApiJson<T>(
+  env: NodeJS.ProcessEnv,
+  apiKey: string,
+  path: string,
+  init?: RequestInit
+): Promise<T> {
+  const base = getCursorCloudApiBaseUrl(env);
+  const url = `${base}${path.startsWith("/") ? path : `/${path}`}`;
+  const res = await fetch(url, {
+    ...init,
+    headers: {
+      Accept: "application/json",
+      "Content-Type": "application/json",
+      Authorization: authorizationHeader(apiKey),
+      ...(init?.headers as Record<string, string>),
+    },
+  });
+
+  const text = await res.text();
+  let body: unknown;
+  try {
+    body = text ? JSON.parse(text) : null;
+  } catch {
+    body = { raw: text };
+  }
+
+  if (!res.ok) {
+    const detail =
+      body && typeof body === "object" && body !== null && "message" in body
+        ? String((body as { message?: unknown }).message)
+        : text || res.statusText;
+    throw new Error(`Cursor API ${res.status}: ${detail}`);
+  }
+
+  return body as T;
+}
+
+export type CursorAgentRecord = {
+  id?: string;
+  url?: string;
+  branchName?: string;
+  repos?: unknown;
+};
+
+export async function getCursorAgent(
+  env: NodeJS.ProcessEnv,
+  apiKey: string,
+  agentId: string
+): Promise<CursorAgentRecord> {
+  return cursorApiJson<CursorAgentRecord>(
+    env,
+    apiKey,
+    `/v1/agents/${encodeURIComponent(agentId)}`,
+    { method: "GET" }
+  );
+}
+
+export async function createCursorAgentRun(
+  env: NodeJS.ProcessEnv,
+  apiKey: string,
+  args: {
+    promptText: string;
+    repoUrl: string;
+    startingRef?: string;
+    autoCreatePR?: boolean;
+    modelId?: string;
+    branchName?: string;
+    autoGenerateBranch?: boolean;
+  }
+): Promise<CursorAgentCreateResponse> {
+  const repos: Record<string, unknown>[] = [{ url: args.repoUrl }];
+  if (args.startingRef?.trim()) {
+    repos[0].startingRef = args.startingRef.trim();
+  }
+
+  const payload: Record<string, unknown> = {
+    prompt: { text: args.promptText },
+    repos,
+  };
+
+  if (typeof args.autoCreatePR === "boolean") {
+    payload.autoCreatePR = args.autoCreatePR;
+  }
+  if (typeof args.branchName === "string" && args.branchName.trim()) {
+    payload.branchName = args.branchName.trim();
+  }
+  if (typeof args.autoGenerateBranch === "boolean") {
+    payload.autoGenerateBranch = args.autoGenerateBranch;
+  }
+  if (args.modelId?.trim()) {
+    payload.model = { id: args.modelId.trim() };
+  }
+
+  return cursorApiJson<CursorAgentCreateResponse>(
+    env,
+    apiKey,
+    "/v1/agents",
+    {
+      method: "POST",
+      body: JSON.stringify(payload),
+    }
+  );
+}
+
+export async function getCursorRun(
+  env: NodeJS.ProcessEnv,
+  apiKey: string,
+  agentId: string,
+  runId: string
+): Promise<CursorRunResponse> {
+  return cursorApiJson<CursorRunResponse>(
+    env,
+    apiKey,
+    `/v1/agents/${encodeURIComponent(agentId)}/runs/${encodeURIComponent(runId)}`,
+    { method: "GET" }
+  );
+}
+
+export type ParsedSseEvent = { event: string | null; data: string };
+
+/** Minimal SSE-over-HTTPS reader (newline-delimited frames, multi-line data). */
+async function parseSseStream(
+  body: ReadableStream<Uint8Array>,
+  emit: (ev: ParsedSseEvent) => void
+): Promise<void> {
+  const reader = body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+  let pendingEvent: string | null = null;
+  let dataLines: string[] = [];
+
+  const flushFrame = (): void => {
+    if (dataLines.length === 0) return;
+    const data = dataLines.join("\n");
+    dataLines = [];
+    const evName = pendingEvent;
+    pendingEvent = null;
+    emit({ event: evName, data });
+  };
+
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+      while (buffer.includes("\n")) {
+        const nl = buffer.indexOf("\n");
+        const rawLine = buffer.slice(0, nl);
+        buffer = buffer.slice(nl + 1);
+
+        let line =
+          rawLine.endsWith("\r") ? rawLine.slice(0, -1) : rawLine;
+        line = line.replace(/\u0000/g, "");
+
+        if (!line.trim()) {
+          flushFrame();
+          pendingEvent = null;
+          continue;
+        }
+
+        if (line.startsWith("event:")) {
+          flushFrame();
+          pendingEvent = line.slice("event:".length).trim();
+          continue;
+        }
+        if (line.startsWith("data:")) {
+          dataLines.push(line.slice("data:".length).trimStart());
+          continue;
+        }
+      }
+    }
+    flushFrame();
+  } finally {
+    reader.releaseLock();
+  }
+}
+
+export type CursorAgentStreamHooks = {
+  onStatus?: (status: unknown) => void;
+  onAssistantDelta?: (text: string) => void;
+  onThinkingDelta?: (text: string) => void;
+  onResult?: (status: unknown) => void;
+  onError?: (code: unknown, message: string) => void;
+  onDone?: () => void;
+};
+
+/** Stream SSE for one run until `done`, `result`, terminal `status`, or `error`. */
+export async function streamCursorAgentRun(
+  env: NodeJS.ProcessEnv,
+  apiKey: string,
+  agentId: string,
+  runId: string,
+  hooks: CursorAgentStreamHooks
+): Promise<void> {
+  const base = getCursorCloudApiBaseUrl(env);
+  const url = `${base}/v1/agents/${encodeURIComponent(agentId)}/runs/${encodeURIComponent(runId)}/stream`;
+  const res = await fetch(url, {
+    headers: {
+      Authorization: authorizationHeader(apiKey),
+      Accept: "text/event-stream",
+    },
+  });
+
+  if (res.status === 410) {
+    hooks.onError?.("stream_expired", "SSE stream expired; using status polling.");
+    await pollUntilTerminal(env, apiKey, agentId, runId, hooks);
+    return;
+  }
+
+  if (!res.ok || !res.body) {
+    hooks.onError?.(
+      "http_error",
+      `Stream failed (${res.status})`
+    );
+    await pollUntilTerminal(env, apiKey, agentId, runId, hooks);
+    return;
+  }
+
+  await parseSseStream(res.body, ({ event, data }) => {
+    let parsed: unknown = null;
+    try {
+      parsed = data ? JSON.parse(data) : null;
+    } catch {
+      parsed = null;
+    }
+
+    const evt = (event || "").trim();
+
+    switch (evt) {
+      case "assistant": {
+        const text =
+          parsed &&
+          typeof parsed === "object" &&
+          parsed !== null &&
+          "text" in parsed &&
+          typeof (parsed as { text: unknown }).text === "string"
+            ? (parsed as { text: string }).text
+            : "";
+        if (text) hooks.onAssistantDelta?.(text);
+        break;
+      }
+      case "thinking": {
+        const text =
+          parsed &&
+          typeof parsed === "object" &&
+          parsed !== null &&
+          "text" in parsed &&
+          typeof (parsed as { text: unknown }).text === "string"
+            ? (parsed as { text: string }).text
+            : "";
+        if (text) hooks.onThinkingDelta?.(text);
+        break;
+      }
+      case "status":
+      case "":
+      case "heartbeat":
+        hooks.onStatus?.(parsed ?? data);
+        break;
+      case "result":
+        hooks.onResult?.(parsed);
+        hooks.onDone?.();
+        break;
+      case "error": {
+        const code =
+          parsed &&
+          typeof parsed === "object" &&
+          parsed !== null &&
+          "code" in parsed
+            ? (parsed as { code: unknown }).code
+            : null;
+        const msg =
+          parsed &&
+          typeof parsed === "object" &&
+          parsed !== null &&
+          "message" in parsed
+            ? String((parsed as { message: unknown }).message)
+            : data || "unknown";
+        hooks.onError?.(code, msg);
+        break;
+      }
+      case "done":
+        hooks.onDone?.();
+        break;
+      default:
+        break;
+    }
+  });
+}
+
+export async function pollUntilTerminal(
+  env: NodeJS.ProcessEnv,
+  apiKey: string,
+  agentId: string,
+  runId: string,
+  hooks: Pick<CursorAgentStreamHooks, "onStatus" | "onResult">
+): Promise<CursorRunResponse | null> {
+  const maxIterations = 120;
+  let last: CursorRunResponse | null = null;
+  for (let i = 0; i < maxIterations; i++) {
+    await new Promise((r) => setTimeout(r, Math.min(2000 + i * 100, 10_000)));
+    try {
+      last = await getCursorRun(env, apiKey, agentId, runId);
+    } catch {
+      continue;
+    }
+    const st = (last.status || "").toUpperCase();
+    hooks.onStatus?.({ runId: last.id, agentId: last.agentId, status: last.status });
+    if (st && TERMINAL_RUN_STATUSES.has(st)) {
+      hooks.onResult?.({
+        runId,
+        status: last.status,
+        polled: true,
+      });
+      return last;
+    }
+  }
+  return last;
+}
+
+export function summarizeTerminalRunStatus(run: CursorRunResponse | null): string {
+  const s = run?.status || "UNKNOWN";
+  return s.toUpperCase();
+}

--- a/api/_utils/ryo-conversation.ts
+++ b/api/_utils/ryo-conversation.ts
@@ -145,6 +145,8 @@ export interface PrepareRyoConversationOptions {
   timeZone?: string;
   toolProfile?: ChatToolProfile;
   toolContextOverrides?: Partial<ChatToolsContext>;
+  /** Passed into createChatTools for Telegram Cursor Cloud Agent routing */
+  telegramRepoAgentOverrides?: Partial<Pick<ChatToolsContext, "telegramRepoAgent">>;
   preloadedMemoryContext?: LoadedRyoMemoryContext;
 }
 
@@ -698,6 +700,7 @@ export async function prepareRyoConversationModelInput(
     timeZone,
     toolProfile = CHANNEL_TOOL_PROFILES[channel],
     toolContextOverrides,
+    telegramRepoAgentOverrides,
     preloadedMemoryContext,
   } = options;
 
@@ -740,11 +743,16 @@ export async function prepareRyoConversationModelInput(
       env: {
         YOUTUBE_API_KEY: process.env.YOUTUBE_API_KEY,
         YOUTUBE_API_KEY_2: process.env.YOUTUBE_API_KEY_2,
+        CURSOR_API_KEY: process.env.CURSOR_API_KEY,
+        CURSOR_RYOS_REPO_URLS: process.env.CURSOR_RYOS_REPO_URLS,
+        CURSOR_CLOUD_API_BASE_URL: process.env.CURSOR_CLOUD_API_BASE_URL,
+        ...toolContextOverrides?.env,
       },
       username: username ?? null,
       redis,
       timeZone: userTimeZone,
       ...toolContextOverrides,
+      ...(telegramRepoAgentOverrides ?? {}),
     },
     { profile: toolProfile }
   );

--- a/api/_utils/telegram-status.ts
+++ b/api/_utils/telegram-status.ts
@@ -30,6 +30,8 @@ export function getTelegramToolStatusText(
       return getTelegramContactsStatusText(input);
     case "songLibraryControl":
       return getTelegramSongLibraryStatusText(input);
+    case "cursorRepoAgent":
+      return getTelegramCursorRepoAgentStatusText(input);
     default:
       return "Using a tool...";
   }
@@ -121,6 +123,19 @@ function getTelegramContactsStatusText(input: unknown): string {
     default:
       return "Using contacts...";
   }
+}
+
+function getTelegramCursorRepoAgentStatusText(input: unknown): string {
+  if (!input || typeof input !== "object") {
+    return "Starting Cursor Cloud Agent…";
+  }
+  const repo =
+    "repoUrl" in input && typeof (input as { repoUrl?: unknown }).repoUrl === "string"
+      ? String((input as { repoUrl: string }).repoUrl).trim()
+      : "";
+  return repo
+    ? `Running Cursor repo agent on ${repo}…`
+    : "Running Cursor repo agent…";
 }
 
 function getTelegramSongLibraryStatusText(input: unknown): string {

--- a/api/chat/tools/executors.ts
+++ b/api/chat/tools/executors.ts
@@ -41,7 +41,25 @@ import type {
   SongLibraryLyricsSource,
   WebFetchInput,
   WebFetchOutput,
+  CursorRepoAgentInput,
+  CursorRepoAgentOutput,
 } from "./types.js";
+import {
+  createCursorAgentRun,
+  getAllowedRyosRepoUrls,
+  getCursorAgent,
+  getCursorApiKey,
+  getCursorRun,
+  isRepoAllowed,
+  normalizeGithubRepoHttpsUrl,
+  pollUntilTerminal,
+  streamCursorAgentRun,
+  summarizeTerminalRunStatus,
+  type CursorAgentCreateResponse,
+  type CursorRunResponse,
+} from "../../_utils/cursor-cloud-agent.js";
+import { sendTelegramMessage } from "../../_utils/telegram.js";
+import { waitUntil } from "@vercel/functions";
 import { stateKey, writeRedisSyncDomainFromServerTool } from "../../sync/_state.js";
 import { getAppPublicOrigin } from "../../_utils/runtime-config.js";
 import { readSongsState, writeSongsState } from "../../_utils/song-library-state.js";
@@ -1209,6 +1227,311 @@ export interface MemoryToolContext extends ServerToolContext {
   username?: string | null;
   redis?: Redis;
   timeZone?: string;
+  telegramRepoAgent?: {
+    botToken: string;
+    chatId: string;
+    replyToMessageId?: number;
+  };
+}
+
+const CURSOR_REPO_AGENT_TRUNCATE = 3800;
+
+function truncateTelegramRepoAgentText(text: string, max = CURSOR_REPO_AGENT_TRUNCATE): string {
+  const t = text.trim();
+  return t.length > max ? `${t.slice(0, max - 20)}… [truncated]` : t;
+}
+
+async function telegramCursorRepoAgentNotifyStatus(
+  context: MemoryToolContext,
+  line: string
+): Promise<void> {
+  const tg = context.telegramRepoAgent;
+  if (!tg?.botToken) return;
+  try {
+    await sendTelegramMessage({
+      botToken: tg.botToken,
+      chatId: tg.chatId,
+      text: truncateTelegramRepoAgentText(line),
+      replyToMessageId: tg.replyToMessageId,
+      disableNotification: true,
+    });
+  } catch (e) {
+    context.logError?.(
+      "[cursorRepoAgent] telegram status notify failed",
+      e instanceof Error ? e.message : String(e)
+    );
+  }
+}
+
+async function runTelegramCursorAgentFollowUp(
+  context: MemoryToolContext,
+  args: {
+    env: NodeJS.ProcessEnv;
+    apiKey: string;
+    agentId: string;
+    runId: string;
+    agentUrlHint?: string;
+    repoUrl: string;
+  }
+): Promise<void> {
+  const baseLog = (m: string) => context.log(`[cursorRepoAgent:follow-up] ${m}`);
+  await telegramCursorRepoAgentNotifyStatus(
+    context,
+    `cursor agent queued — streaming updates for run ${args.runId}…`
+  );
+
+  let assistantBuffer = "";
+  let lastAssistFlush = 0;
+  const flushAssist = async (): Promise<void> => {
+    const now = Date.now();
+    if (now - lastAssistFlush < 15_000) return;
+    const trimmed = assistantBuffer.trim();
+    if (trimmed.length < 60) return;
+    lastAssistFlush = now;
+    assistantBuffer = "";
+    await telegramCursorRepoAgentNotifyStatus(
+      context,
+      `cursor agent update:\n${truncateTelegramRepoAgentText(trimmed)}`
+    );
+  };
+
+  let lastStatusBump = "";
+  try {
+    await streamCursorAgentRun(
+      args.env,
+      args.apiKey,
+      args.agentId,
+      args.runId,
+      {
+        onStatus: async (payload) => {
+          let st = "";
+          if (
+            payload &&
+            typeof payload === "object" &&
+            "status" in payload &&
+            typeof (payload as { status?: unknown }).status === "string"
+          ) {
+            st = (payload as { status: string }).status;
+          }
+          if (
+            typeof st !== "string" ||
+            !st.trim() ||
+            st === lastStatusBump
+          ) {
+            return;
+          }
+          lastStatusBump = st;
+          baseLog(`status ${st}`);
+          await telegramCursorRepoAgentNotifyStatus(
+            context,
+            `cursor agent: ${args.repoUrl} — ${st}`
+          );
+        },
+        onAssistantDelta: async (txt) => {
+          assistantBuffer += txt;
+          await flushAssist();
+        },
+        onThinkingDelta: async (txt) => {
+          assistantBuffer += txt;
+          await flushAssist();
+        },
+        onError: (code, msg) => {
+          baseLog(`stream note: ${String(code)} ${msg}`);
+        },
+      }
+    );
+  } catch (err) {
+    context.logError("[cursorRepoAgent] SSE stream ended with error", err);
+  }
+
+  let finalRun: CursorRunResponse | null = await getCursorRun(
+    args.env,
+    args.apiKey,
+    args.agentId,
+    args.runId
+  ).catch(() => null);
+
+  if (!finalRun?.status || !isTerminalCursorRunStatus(finalRun.status)) {
+    await pollUntilTerminal(args.env, args.apiKey, args.agentId, args.runId, {
+      onStatus: () => undefined,
+      onResult: () => undefined,
+    });
+    finalRun = await getCursorRun(
+      args.env,
+      args.apiKey,
+      args.agentId,
+      args.runId
+    ).catch(() => finalRun);
+  }
+
+  let agentUrl = args.agentUrlHint?.trim() || "";
+  try {
+    const meta = await getCursorAgent(args.env, args.apiKey, args.agentId);
+    if (typeof meta.url === "string" && meta.url.trim()) {
+      agentUrl = meta.url.trim();
+    }
+    if (
+      typeof meta.branchName === "string" &&
+      meta.branchName.trim()
+    ) {
+      baseLog(`branch ${meta.branchName}`);
+    }
+  } catch {
+    /* meta optional */
+  }
+
+  const term = summarizeTerminalRunStatus(finalRun);
+  await telegramCursorRepoAgentNotifyStatus(
+    context,
+    truncateTelegramRepoAgentText(
+      [
+        `cursor agent finished: ${term}`,
+        agentUrl ? `open: ${agentUrl}` : "",
+        `repo: ${args.repoUrl}`,
+        `run: ${args.runId}`,
+      ]
+        .filter(Boolean)
+        .join("\n")
+    )
+  );
+}
+
+function isTerminalCursorRunStatus(s: string): boolean {
+  const u = (s || "").toUpperCase();
+  return ["FINISHED", "FAILED", "ERROR", "CANCELLED", "CANCELED"].includes(
+    u
+  );
+}
+
+export async function executeCursorRepoAgent(
+  input: CursorRepoAgentInput,
+  context: MemoryToolContext
+): Promise<CursorRepoAgentOutput> {
+  const tg = context.telegramRepoAgent;
+
+  context.log("[cursorRepoAgent] invoked");
+  context.log("[cursorRepoAgent]", {
+    repoUrlHint: normalizeGithubRepoHttpsUrl(input.repoUrl),
+    telegram: Boolean(tg?.botToken && tg.chatId),
+    username: context.username,
+  });
+
+  if (!tg?.botToken || !tg.chatId) {
+    context.log("[cursorRepoAgent] Missing Telegram routing context — abort");
+    return {
+      success: false,
+      message:
+        "the Cursor repo agent is only available from the linked Telegram chat.",
+      queued: false,
+    };
+  }
+
+  const apiKey = getCursorApiKey(context.env as NodeJS.ProcessEnv);
+  if (!apiKey) {
+    return {
+      success: false,
+      message:
+        "CURSOR_API_KEY is not configured on this server — ask your admin.",
+      queued: false,
+    };
+  }
+
+  const env = context.env as NodeJS.ProcessEnv;
+  const normalizedRepo = normalizeGithubRepoHttpsUrl(input.repoUrl.trim());
+  if (!normalizedRepo) {
+    return {
+      success: false,
+      message:
+        "invalid repo URL. use a github https url like https://github.com/org/repo.",
+      queued: false,
+      repoUrl: input.repoUrl,
+    };
+  }
+
+  const allowed = getAllowedRyosRepoUrls(env);
+  if (!isRepoAllowed(normalizedRepo, allowed)) {
+    context.log("[cursorRepoAgent] Repo denied by CURSOR_RYOS_REPO_URLS", {
+      requested: normalizedRepo,
+      allowed,
+    });
+    return {
+      success: false,
+      message: `repo not allowed here. permitted: ${allowed.join(", ") || "(none configured)"}`,
+      queued: false,
+      repoUrl: normalizedRepo,
+    };
+  }
+
+  const promptEnvelope = `[ryOS telegram @${context.username || "unknown"}]\n${input.instructions.trim()}`;
+
+  let createRes: CursorAgentCreateResponse;
+  try {
+    createRes = await createCursorAgentRun(env, apiKey, {
+      promptText: promptEnvelope,
+      repoUrl: normalizedRepo,
+      startingRef: input.startingRef?.trim(),
+      autoCreatePR: input.autoCreatePR,
+    });
+  } catch (e) {
+    const msg =
+      e instanceof Error ? e.message : "failed to launch Cursor Cloud Agent";
+    context.logError("[cursorRepoAgent] create failed", e);
+    return {
+      success: false,
+      message: msg,
+      queued: false,
+      repoUrl: normalizedRepo,
+    };
+  }
+
+  const agentId = createRes.agent?.id;
+  const runId = createRes.run?.id || createRes.agent?.latestRunId;
+  const agentUrl =
+    typeof createRes.agent?.url === "string" ? createRes.agent.url : "";
+  const runStatus = createRes.run?.status;
+
+  if (!agentId || !runId) {
+    context.logError(
+      "[cursorRepoAgent] unexpected API response",
+      JSON.stringify(createRes)
+    );
+    return {
+      success: false,
+      message: "Cursor API returned no agent/run id.",
+      queued: false,
+      repoUrl: normalizedRepo,
+    };
+  }
+
+  waitUntil(
+    runTelegramCursorAgentFollowUp(context, {
+      env,
+      apiKey,
+      agentId,
+      runId,
+      agentUrlHint: agentUrl,
+      repoUrl: normalizedRepo,
+    })
+  );
+
+  return {
+    success: true,
+    queued: true,
+    agentId,
+    runId,
+    ...(agentUrl ? { agentUrl } : {}),
+    repoUrl: normalizedRepo,
+    message: truncateTelegramRepoAgentText(
+      [
+        "started Cursor Cloud Agent.",
+        `(run ${runId}, status ${runStatus ?? "started"})`,
+        agentUrl ? `open ${agentUrl}` : "",
+        "streaming progress in this chat shortly.",
+      ]
+        .filter(Boolean)
+        .join(" ")
+    ),
+  };
 }
 
 /**

--- a/api/chat/tools/index.ts
+++ b/api/chat/tools/index.ts
@@ -38,6 +38,7 @@ import type {
   MemoryReadInput,
   MemoryDeleteInput,
   WebFetchInput,
+  CursorRepoAgentInput,
 } from "./types.js";
 import * as schemas from "./schemas.js";
 import type {
@@ -59,6 +60,7 @@ import {
   executeStickiesControl,
   executeContactsControl,
   executeWebFetch,
+  executeCursorRepoAgent,
   type MemoryToolContext,
 } from "./executors.js";
 
@@ -77,6 +79,7 @@ export {
   executeStickiesControl,
   executeContactsControl,
   executeWebFetch,
+  executeCursorRepoAgent,
   type MemoryToolContext,
 } from "./executors.js";
 
@@ -95,6 +98,7 @@ const _TELEGRAM_TOOL_NAMES = [
   "stickiesControl",
   "contactsControl",
   "songLibraryControl",
+  "cursorRepoAgent",
 ] as const;
 
 export type ChatToolProfile = "all" | "memory" | "telegram";
@@ -241,6 +245,13 @@ export const TOOL_DESCRIPTIONS = {
     "works best with server-rendered content (most sites). " +
     "For JS-heavy single-page apps, content may be limited. " +
     "Optionally pass a CSS selector to extract a specific section.",
+
+  cursorRepoAgent:
+    "Launch a Cursor Cloud Agent on the real ryOS GitHub repository (background coding run). " +
+    "Use when the user explicitly wants code changes, a PR, or repo work that should run in Cursor Cloud — not for browser/VFS tasks. " +
+    "Requires repoUrl (GitHub HTTPS, allowlisted by the server, default public ryOS repo). " +
+    "Optionally pass startingRef (branch/commit) and autoCreatePR. " +
+    "The run is async: you will get a short acknowledgment in-tool; progress completes in Telegram separately.",
 
   // Unified Memory Tools
   memoryWrite:
@@ -534,6 +545,13 @@ export function createChatTools(
         inputSchema: schemas.songLibraryControlSchema,
         execute: async (input: SongLibraryControlInput) => {
           return executeSongLibraryControl(input, context);
+        },
+      },
+      cursorRepoAgent: {
+        description: TOOL_DESCRIPTIONS.cursorRepoAgent,
+        inputSchema: schemas.cursorRepoAgentSchema,
+        execute: async (input: CursorRepoAgentInput) => {
+          return executeCursorRepoAgent(input, context);
         },
       },
     } as Pick<typeof allTools, (typeof _TELEGRAM_TOOL_NAMES)[number]>;

--- a/api/chat/tools/schemas.ts
+++ b/api/chat/tools/schemas.ts
@@ -1209,3 +1209,32 @@ export const memoryDeleteSchema = z.object({
     .max(MAX_KEY_LENGTH)
     .describe("The long-term memory key to delete."),
 });
+
+/**
+ * Cursor Cloud Agent — run an async coding task against an allowlisted ryOS GitHub repo.
+ */
+export const cursorRepoAgentSchema = z.object({
+  instructions: z
+    .string()
+    .min(1)
+    .max(16_000)
+    .describe("What you want the Cursor Cloud Agent to do in the ryOS repo."),
+  repoUrl: z
+    .string()
+    .min(1)
+    .max(500)
+    .describe(
+      "GitHub HTTPS URL (e.g. https://github.com/ryokun6/ryos). Must match the server allowlist."
+    ),
+  startingRef: z
+    .string()
+    .max(256)
+    .optional()
+    .describe(
+      "Branch, tag, or commit to start from (omit to use repo default)."
+    ),
+  autoCreatePR: z
+    .boolean()
+    .optional()
+    .describe("If true, ask Cursor to open a PR when the run completes."),
+});

--- a/api/chat/tools/types.ts
+++ b/api/chat/tools/types.ts
@@ -37,6 +37,12 @@ export interface ServerToolContext {
   env: {
     YOUTUBE_API_KEY?: string;
     YOUTUBE_API_KEY_2?: string;
+    /** Cursor Dashboard → Integrations API key for Cloud Agents (Telegram repo agent). */
+    CURSOR_API_KEY?: string;
+    /** Comma-separated GitHub HTTPS repo URLs allowed when launching Cursor Cloud Agents */
+    CURSOR_RYOS_REPO_URLS?: string;
+    /** Override default https://api.cursor.com if needed */
+    CURSOR_CLOUD_API_BASE_URL?: string;
   };
 }
 
@@ -641,6 +647,27 @@ export interface MemoryDeleteOutput {
 // ============================================================================
 // Web Fetch Tool Types
 // ============================================================================
+
+// ============================================================================
+// Cursor Cloud Agent — Telegram-linked repo automation
+// ============================================================================
+
+export interface CursorRepoAgentInput {
+  instructions: string;
+  repoUrl: string;
+  startingRef?: string;
+  autoCreatePR?: boolean;
+}
+
+export interface CursorRepoAgentOutput {
+  success: boolean;
+  message: string;
+  queued?: boolean;
+  agentId?: string;
+  runId?: string;
+  agentUrl?: string;
+  repoUrl?: string;
+}
 
 export interface WebFetchInput {
   url: string;

--- a/api/webhooks/telegram.ts
+++ b/api/webhooks/telegram.ts
@@ -642,6 +642,13 @@ export default async function handler(
       logger.info(`[Telegram:${linkedAccount.username}]`, args),
     logError: (...args: unknown[]) =>
       logger.error(`[Telegram:${linkedAccount.username}]`, args),
+    telegramRepoAgentOverrides: {
+      telegramRepoAgent: {
+        botToken,
+        chatId: parsedUpdate.chatId,
+        replyToMessageId: parsedUpdate.messageId,
+      },
+    },
   });
 
   logger.info("Telegram prompt sections loaded", {

--- a/tests/test-chat-tools-cursor-repo.test.ts
+++ b/tests/test-chat-tools-cursor-repo.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from "bun:test";
+import type { Redis } from "@upstash/redis";
+import { createChatTools } from "../api/chat/tools/index.js";
+
+class FakeRedis {
+  async get(): Promise<null> {
+    return null;
+  }
+}
+
+describe("cursorRepoAgent telegram tool", () => {
+  test("telegram profile exposes cursorRepoAgent execute", () => {
+    const tools = createChatTools(
+      {
+        log: () => undefined,
+        logError: () => undefined,
+        env: {},
+        username: "alice",
+        redis: new FakeRedis() as unknown as Redis,
+      },
+      { profile: "telegram" }
+    );
+    expect("cursorRepoAgent" in tools).toBe(true);
+    expect(typeof tools.cursorRepoAgent.execute).toBe("function");
+  });
+
+  test("fails safely without Telegram routing context", async () => {
+    const tools = createChatTools(
+      {
+        log: () => undefined,
+        logError: () => undefined,
+        env: { CURSOR_API_KEY: "fake" },
+        username: "alice",
+        redis: new FakeRedis() as unknown as Redis,
+      },
+      { profile: "telegram" }
+    );
+
+    const result = await tools.cursorRepoAgent.execute?.({
+      instructions: "say hi",
+      repoUrl: "https://github.com/ryokun6/ryos",
+    });
+
+    expect(result?.success).toBe(false);
+    expect((result?.message || "").toLowerCase()).toContain("telegram");
+  });
+});

--- a/tests/test-cursor-cloud-agent.test.ts
+++ b/tests/test-cursor-cloud-agent.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "bun:test";
+import {
+  getAllowedRyosRepoUrls,
+  isRepoAllowed,
+  normalizeGithubRepoHttpsUrl,
+} from "../api/_utils/cursor-cloud-agent";
+
+describe("cursor cloud agent helpers", () => {
+  test("normalizes github https repo urls", () => {
+    expect(normalizeGithubRepoHttpsUrl("https://github.com/foo/bar")).toBe(
+      "https://github.com/foo/bar"
+    );
+    expect(normalizeGithubRepoHttpsUrl("github.com/foo/bar/")).toBe(
+      "https://github.com/foo/bar"
+    );
+    expect(normalizeGithubRepoHttpsUrl("https://example.com/foo/bar")).toBeNull();
+  });
+
+  test("allowlist defaults to public ryOS repo", () => {
+    const urls = getAllowedRyosRepoUrls({});
+    expect(urls).toEqual(["https://github.com/ryokun6/ryos"]);
+  });
+
+  test("allowlist parses comma-separated CURSOR_RYOS_REPO_URLS", () => {
+    const urls = getAllowedRyosRepoUrls({
+      CURSOR_RYOS_REPO_URLS:
+        "https://github.com/a/b, https://github.com/c/d/",
+    } as NodeJS.ProcessEnv);
+    expect(urls).toEqual(["https://github.com/a/b", "https://github.com/c/d"]);
+  });
+
+  test("isRepoAllowed matches normalized github urls", () => {
+    const allowed = ["https://github.com/ryokun6/ryos"];
+    expect(isRepoAllowed("https://github.com/ryokun6/ryos", allowed)).toBe(true);
+    expect(isRepoAllowed("github.com/ryokun6/ryos", allowed)).toBe(true);
+    expect(isRepoAllowed("https://github.com/other/repo", allowed)).toBe(false);
+  });
+});

--- a/tests/test-telegram-heartbeat.test.ts
+++ b/tests/test-telegram-heartbeat.test.ts
@@ -456,6 +456,7 @@ describe("telegram heartbeat helpers", () => {
     expect("memoryWrite" in prepared.tools).toBe(true);
     expect("calendarControl" in prepared.tools).toBe(true);
     expect("stickiesControl" in prepared.tools).toBe(true);
+    expect("cursorRepoAgent" in prepared.tools).toBe(true);
     expect("web_search" in prepared.tools).toBe(true);
   });
 

--- a/tests/test-telegram-status.test.ts
+++ b/tests/test-telegram-status.test.ts
@@ -46,6 +46,11 @@ describe("telegram status helpers", () => {
         title: "Plastic Love",
       })
     ).toBe('Adding "Plastic Love" to your library...');
+    expect(
+      getTelegramToolStatusText("cursorRepoAgent", {
+        repoUrl: "https://github.com/ryokun6/ryos",
+      })
+    ).toBe("Running Cursor repo agent on https://github.com/ryokun6/ryos…");
     expect(getTelegramToolStatusText("unknownTool", {})).toBe("Using a tool...");
   });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a **telegram-only** server tool **`cursorRepoAgent`** that launches [Cursor Cloud Agents API v1](https://cursor.com/docs/background-agent/api/overview) jobs against allowlisted GitHub repos (default `https://github.com/ryokun6/ryos`). The webhook passes the linked Telegram `botToken`/chat/`reply_to` through tool context so the executor can **`waitUntil`** a background task that streams SSE (with polling fallback) and sends status / completion messages back into the same DM.

**Deploy config (secrets):**

- **`CURSOR_API_KEY`** — required; user or service API key from Cursor Dashboard → Integrations.
- **`CURSOR_RYOS_REPO_URLS`** — optional comma-separated list of GitHub HTTPS repo URLs permitted for this deployment (omit to allow only the public ryOS repo).
- **`CURSOR_CLOUD_API_BASE_URL`** — optional override of `https://api.cursor.com`.

**Tests:** bun tests updated/added (`test-cursor-cloud-agent.test.ts`, `test-chat-tools-cursor-repo.test.ts`, telegram status/heartbeat). This environment did not run the test runner (no `bun`/Node in PATH); please run locally: `bun test tests/test-cursor-cloud-agent.test.ts tests/test-chat-tools-cursor-repo.test.ts tests/test-telegram-status.test.ts tests/test-telegram-heartbeat.test.ts`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ef22d68d-d097-405b-b4ce-1bcd91e7ab31"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ef22d68d-d097-405b-b4ce-1bcd91e7ab31"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

