### PR TITLE
feat(telegram): Cursor repo agent tool + Telegram completion updates

### DIFF
--- a/api/_utils/_aiPrompts.ts
+++ b/api/_utils/_aiPrompts.ts
@@ -277,6 +277,11 @@ You can manage the user's calendar events, todos, and sticky notes directly from
 - These changes sync to ryOS automatically — the user will see them next time the browser polls.
 - If the user hasn't enabled cloud sync yet, these tools will let you know.
 - Always confirm what you did after making changes in one short line when possible (e.g. "added 'Dentist' on 2026-03-10 at 14:00").
+
+## Cursor repository agent (owner-only)
+When the linked ryOS user is \`ryo\` and Cursor Cloud is configured server-side, you can invoke \`cursorRyOsRepoAgent\` for real changes against ryokun6/ryos on GitHub.
+Use it only for product/source-code work—not virtual paths like \`/Documents\`.
+After starting a run, say briefly that it kicked off and that I'll DM updates here until completion (plus opened PR link when available). Tell them ryOS Chats still shows the full live stream.
 </telegram_chat_instructions>
 `;
 

--- a/api/_utils/ryo-conversation.ts
+++ b/api/_utils/ryo-conversation.ts
@@ -153,6 +153,12 @@ export interface PrepareRyoConversationOptions {
   toolProfile?: ChatToolProfile;
   toolContextOverrides?: Partial<ChatToolsContext>;
   preloadedMemoryContext?: LoadedRyoMemoryContext;
+  /** Telegram webhook: notify this DM when async Cursor repo agent runs complete */
+  telegramCursorRunNotify?: {
+    botToken: string;
+    chatId: string;
+    replyToMessageId: number;
+  };
 }
 
 export interface PreparedRyoConversation {
@@ -706,6 +712,7 @@ export async function prepareRyoConversationModelInput(
     toolProfile = CHANNEL_TOOL_PROFILES[channel],
     toolContextOverrides,
     preloadedMemoryContext,
+    telegramCursorRunNotify,
   } = options;
 
   const userTimeZone = systemState?.userLocalTime?.timeZone || timeZone;
@@ -727,8 +734,8 @@ export async function prepareRyoConversationModelInput(
     username === CURSOR_REPO_AGENT_OWNER && !!cursorApiKey;
 
   const cursorSdkAddon =
-    enableCursorRepoTool && channel === "chat"
-      ? `\n\n## CURSOR REPOSITORY AGENT\nYou have access to \`cursorRyOsRepoAgent\` for substantive edits via Cursor Cloud against the GitHub repository ryokun6/ryos. Do not use it for virtual filesystem paths (\`/Documents\`, \`/Applets\`, etc.). Use it only when the user wants changes to this product's source code on GitHub.`
+    enableCursorRepoTool && (channel === "chat" || channel === "telegram")
+      ? `\n\n## CURSOR REPOSITORY AGENT\nYou have access to \`cursorRyOsRepoAgent\` for substantive edits via Cursor Cloud against the GitHub repository ryokun6/ryos. Do not use it for virtual filesystem paths (\`/Documents\`, \`/Applets\`, etc.). Use it only when the user wants changes to this product's source code on GitHub. On Telegram, mention that progress/completion updates also arrive in this chat (not only in ryOS Chats).`
       : "";
 
   const staticSystemPrompt = staticPrompts.join("\n") + cursorSdkAddon;
@@ -767,7 +774,9 @@ export async function prepareRyoConversationModelInput(
   );
 
   const cursorRepoTools: ToolSet =
-    enableCursorRepoTool && cursorApiKey && toolProfile === "all"
+    enableCursorRepoTool &&
+    cursorApiKey &&
+    (toolProfile === "all" || toolProfile === "telegram")
       ? {
           cursorRyOsRepoAgent: {
             description: CURSOR_RYOS_REPO_AGENT_DESCRIPTION,
@@ -784,6 +793,9 @@ export async function prepareRyoConversationModelInput(
                 redis,
                 timeZone: userTimeZone,
                 apiKey: cursorApiKey,
+                ...(telegramCursorRunNotify
+                  ? { telegramCursorRunNotify }
+                  : {}),
                 ...toolContextOverrides,
               }),
           },

--- a/api/_utils/telegram-status.ts
+++ b/api/_utils/telegram-status.ts
@@ -30,6 +30,8 @@ export function getTelegramToolStatusText(
       return getTelegramContactsStatusText(input);
     case "songLibraryControl":
       return getTelegramSongLibraryStatusText(input);
+    case "cursorRyOsRepoAgent":
+      return "Starting Cursor Cloud agent on ryokun6/ryos...";
     default:
       return "Using a tool...";
   }

--- a/api/chat/tools/cursor-repo-agent.ts
+++ b/api/chat/tools/cursor-repo-agent.ts
@@ -5,6 +5,8 @@
  */
 
 import type { Redis } from "../../_utils/redis.js";
+import { getAppPublicOrigin } from "../../_utils/runtime-config.js";
+import { sendTelegramMessage } from "../../_utils/telegram.js";
 import { z } from "zod";
 import type { MemoryToolContext } from "./executors.js";
 
@@ -26,7 +28,7 @@ export const DEFAULT_RYOS_GITHUB_REPO_URL = "https://github.com/ryokun6/ryos";
 
 /** Shown to the model when this tool is enabled */
 export const CURSOR_RYOS_REPO_AGENT_DESCRIPTION =
-  "Run Cursor's coding agent in Cursor Cloud against the GitHub repo ryokun6/ryos (not the browser VFS). Use when the user asks to implement, debug, or refactor the real ryOS product codebase—not virtual paths like /Documents or /Applets (those use read/write/edit). Give clear instructions and desired outcomes. Uses CURSOR_API_KEY and Cursor SDK billing. The run is asynchronous: you get an immediate acknowledgment while work continues; the user opens the run panel in chat to watch live stream events.";
+  "Run Cursor's coding agent in Cursor Cloud against the GitHub repo ryokun6/ryos (not the browser VFS). Use when the user asks to implement, debug, or refactor the real ryOS product codebase—not virtual paths like /Documents or /Applets (those use read/write/edit). Give clear instructions and desired outcomes. Uses CURSOR_API_KEY and Cursor SDK billing. The run is asynchronous: you get an immediate acknowledgment while work continues; on web, the user can open the run panel in Chats for live stream events; on Telegram, status updates are delivered in this chat.";
 
 export const cursorRyOsRepoAgentSchema = z.object({
   prompt: z
@@ -88,6 +90,202 @@ async function safePushEvent(
   }
   await redis.lpush(eventsKey, line);
   await redis.expire(eventsKey, CURSOR_SDK_RUN_TTL_SEC);
+}
+
+/** Upstash may return objects for JSON-looking strings */
+function parseStoredJsonLine(raw: unknown): unknown {
+  if (raw === null || raw === undefined) return null;
+  if (typeof raw === "object") return raw;
+  if (typeof raw === "string") {
+    try {
+      return JSON.parse(raw) as unknown;
+    } catch {
+      return null;
+    }
+  }
+  return null;
+}
+
+export function extractPrUrlFromTerminalPayload(payload: unknown): string | null {
+  if (!payload || typeof payload !== "object") return null;
+  const rec = payload as Record<string, unknown>;
+  const git = rec.git;
+  if (!git || typeof git !== "object") return null;
+  const branches = (git as { branches?: unknown }).branches;
+  if (!Array.isArray(branches)) return null;
+  for (const b of branches) {
+    if (!b || typeof b !== "object") continue;
+    const url = (b as { prUrl?: unknown }).prUrl;
+    if (typeof url === "string" && url.startsWith("http")) return url.trim();
+  }
+  return null;
+}
+
+export function findTerminalEventInRedisLines(lines: unknown[]): {
+  status?: string;
+  summary?: string;
+  error?: string;
+  prUrl?: string | null;
+} | null {
+  for (const raw of lines) {
+    const parsed = parseStoredJsonLine(raw);
+    if (!parsed || typeof parsed !== "object") continue;
+    const o = parsed as Record<string, unknown>;
+    if (o.type === "terminal") {
+      return {
+        status: typeof o.status === "string" ? o.status : undefined,
+        summary: typeof o.summary === "string" ? o.summary : undefined,
+        error: typeof o.error === "string" ? o.error : undefined,
+        prUrl: extractPrUrlFromTerminalPayload(o),
+      };
+    }
+  }
+  return null;
+}
+
+const TELEGRAM_CURSOR_POLL_MS = 12_000;
+const TELEGRAM_CURSOR_STALE_MS = 25 * 60 * 1000;
+
+function spawnTelegramCursorRunFollowUp(input: {
+  redis: Redis;
+  eventsKey: string;
+  runId: string;
+  appOrigin: string;
+  notify: {
+    botToken: string;
+    chatId: string;
+    replyToMessageId: number;
+  };
+  log: (...args: unknown[]) => void;
+  logError: (...args: unknown[]) => void;
+}): void {
+  void (async () => {
+    const {
+      redis,
+      eventsKey,
+      runId,
+      appOrigin,
+      notify,
+      log,
+      logError,
+    } = input;
+
+    const startedAt = Date.now();
+    let lastNudgeAt = startedAt;
+
+    try {
+      while (true) {
+        const rawLinesUnknown = await redis.lrange(eventsKey, 0, 199);
+        const lines = Array.isArray(rawLinesUnknown) ? rawLinesUnknown : [];
+
+        const terminal = findTerminalEventInRedisLines(lines);
+        if (terminal) {
+          const status = terminal.status ?? "unknown";
+
+          let body =
+            status === "finished"
+              ? "Cursor Cloud agent finished."
+              : status === "error"
+                ? "Cursor Cloud agent run reported an error."
+                : `Cursor Cloud agent ended (${status}).`;
+
+          if (terminal.prUrl) {
+            body += `\n\nPR: ${terminal.prUrl}`;
+          } else if (terminal.summary?.trim()) {
+            const snippet =
+              terminal.summary.length > 1200
+                ? `${terminal.summary.slice(0, 1197)}…`
+                : terminal.summary.trim();
+            body += `\n\n${snippet}`;
+          } else if (terminal.error?.trim()) {
+            body += `\n\n${terminal.error.trim()}`;
+          }
+
+          body += `\n\nFull stream + status in ryOS Chats (repo agent panel), or poll ${appOrigin}/api/ai/cursor-run-status?runId=${encodeURIComponent(
+            runId
+          )} while signed in.`;
+
+          await sendTelegramMessage({
+            botToken: notify.botToken,
+            chatId: notify.chatId,
+            text: body,
+            replyToMessageId: notify.replyToMessageId,
+          });
+          return;
+        }
+
+        const now = Date.now();
+        const sinceStart = now - startedAt;
+        const sinceNudge = now - lastNudgeAt;
+
+        if (
+          sinceStart >= 90_000 &&
+          sinceNudge >= TELEGRAM_CURSOR_STALE_MS
+        ) {
+          const eventCount = lines.length;
+          await sendTelegramMessage({
+            botToken: notify.botToken,
+            chatId: notify.chatId,
+            text:
+              eventCount > 0
+                ? `Still running — ${eventCount} stream events so far. Open ryOS Chats for the live Cursor repo agent panel; I'll message again when it completes.`
+                : "Still waiting on the Cursor Cloud agent. Open ryOS Chats for live progress; I'll message again when it completes.",
+            replyToMessageId: notify.replyToMessageId,
+          });
+          lastNudgeAt = now;
+        }
+
+        await new Promise((r) => setTimeout(r, TELEGRAM_CURSOR_POLL_MS));
+      }
+    } catch (e) {
+      logError("[cursorRyOsRepoAgent] Telegram follow-up failed", e);
+      try {
+        await sendTelegramMessage({
+          botToken: notify.botToken,
+          chatId: notify.chatId,
+          text:
+            "Cursor Cloud agent is running — I couldn't stream progress updates here. Open ryOS Chats to watch the run, or check back later.",
+          replyToMessageId: notify.replyToMessageId,
+        });
+      } catch (sendErr) {
+        logError("[cursorRyOsRepoAgent] Telegram follow-up fallback send failed", sendErr);
+      }
+    }
+  })();
+
+  log("[cursorRyOsRepoAgent] Telegram follow-up watcher spawned", { runId });
+}
+
+async function notifyTelegramBlockingRunComplete(
+  result: CursorRyOsRepoAgentToolOutput,
+  notify: NonNullable<CursorRyOsRepoAgentContext["telegramCursorRunNotify"]>,
+  appOrigin: string
+): Promise<void> {
+  if ("async" in result && result.async) return;
+
+  const ok = result.success === true;
+  let text = ok
+    ? "Cursor Cloud agent finished (blocking run)."
+    : "Cursor Cloud agent run failed.";
+
+  if (result.summary?.trim()) {
+    const s =
+      result.summary.length > 1200
+        ? `${result.summary.slice(0, 1197)}…`
+        : result.summary.trim();
+    text += `\n\n${s}`;
+  }
+  if (!ok && result.error) {
+    text += `\n\n${result.error}`;
+  }
+  text += `\n\nDetails in ryOS Chats if you started from there: ${appOrigin}`;
+
+  await sendTelegramMessage({
+    botToken: notify.botToken,
+    chatId: notify.chatId,
+    text,
+    replyToMessageId: notify.replyToMessageId,
+  });
 }
 
 async function executeBlockingPrompt(
@@ -270,12 +468,22 @@ export async function executeCursorRyOsRepoAgent(
   if (!context.redis) {
     context.log("[cursorRyOsRepoAgent] no Redis — falling back to blocking Agent.prompt");
     try {
-      return await executeBlockingPrompt(input, context, {
+      const result = await executeBlockingPrompt(input, context, {
         repoUrl,
         startingRef,
         autoCreatePR,
         modelId,
       });
+      if (context.telegramCursorRunNotify) {
+        void notifyTelegramBlockingRunComplete(
+          result,
+          context.telegramCursorRunNotify,
+          getAppPublicOrigin()
+        ).catch((err) =>
+          context.logError("[cursorRyOsRepoAgent] Telegram blocking notify failed", err)
+        );
+      }
+      return result;
     } catch (e) {
       context.logError("[cursorRyOsRepoAgent] Agent.prompt failed", e);
       return {
@@ -358,6 +566,18 @@ export async function executeCursorRyOsRepoAgent(
       agent,
       run,
     });
+
+    if (context.telegramCursorRunNotify) {
+      spawnTelegramCursorRunFollowUp({
+        redis: context.redis,
+        eventsKey,
+        runId,
+        appOrigin: getAppPublicOrigin(),
+        notify: context.telegramCursorRunNotify,
+        log: context.log,
+        logError: context.logError,
+      });
+    }
 
     return {
       async: true,

--- a/api/chat/tools/executors.ts
+++ b/api/chat/tools/executors.ts
@@ -1209,6 +1209,12 @@ export interface MemoryToolContext extends ServerToolContext {
   username?: string | null;
   redis?: Redis;
   timeZone?: string;
+  /** When set, Cursor repo agent completion is reported to this Telegram DM (server-side follow-up). */
+  telegramCursorRunNotify?: {
+    botToken: string;
+    chatId: string;
+    replyToMessageId: number;
+  };
 }
 
 /**

--- a/api/webhooks/telegram.ts
+++ b/api/webhooks/telegram.ts
@@ -642,6 +642,11 @@ export default async function handler(
       logger.info(`[Telegram:${linkedAccount.username}]`, args),
     logError: (...args: unknown[]) =>
       logger.error(`[Telegram:${linkedAccount.username}]`, args),
+    telegramCursorRunNotify: {
+      botToken,
+      chatId: parsedUpdate.chatId,
+      replyToMessageId: parsedUpdate.messageId,
+    },
   });
 
   logger.info("Telegram prompt sections loaded", {

--- a/docs/9-changelog.md
+++ b/docs/9-changelog.md
@@ -13,6 +13,7 @@ A summary of changes and updates to ryOS, organized by month.
 - Refine wallpaper system with Leopard sets, picker layout improvements, category ordering, and a new default `nature earth horizon` wallpaper; persist display settings at version 1.
 - Refine themed desktop: System 7 shows Chats, IE, Karaoke after iPod; Applications shortcut on non-macOS X themes (Applet Store hidden there); themed Chats icons across System 7, macOSX, XP 48px, and Win98.
 - Optimize system prompts for static caching with tiered dynamic context.
+- Telegram: expose Cursor Cloud repo agent (`cursorRyOsRepoAgent`) for the owner account with queued DM updates until completion (plus PR link when available).
 
 <details>
 <summary>Minor changes (11)</summary>

--- a/tests/test-cursor-repo-agent-tool.test.ts
+++ b/tests/test-cursor-repo-agent-tool.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, test } from "bun:test";
 import {
   DEFAULT_RYOS_GITHUB_REPO_URL,
   executeCursorRyOsRepoAgent,
+  extractPrUrlFromTerminalPayload,
+  findTerminalEventInRedisLines,
 } from "../api/chat/tools/cursor-repo-agent.js";
 
 describe("cursorRyOsRepoAgent gate", () => {
@@ -24,5 +26,30 @@ describe("cursorRyOsRepoAgent gate", () => {
     expect(DEFAULT_RYOS_GITHUB_REPO_URL).toBe(
       "https://github.com/ryokun6/ryos"
     );
+  });
+
+  test("extractPrUrlFromTerminalPayload reads PR from SDK git branches", () => {
+    const url = extractPrUrlFromTerminalPayload({
+      type: "terminal",
+      status: "finished",
+      git: {
+        branches: [
+          {
+            repoUrl: "https://github.com/ryokun6/ryos",
+            prUrl: "https://github.com/ryokun6/ryos/pull/42",
+          },
+        ],
+      },
+    });
+    expect(url).toBe("https://github.com/ryokun6/ryos/pull/42");
+  });
+
+  test("findTerminalEventInRedisLines picks terminal entry", () => {
+    const t = findTerminalEventInRedisLines([
+      '{"type":"stream"}',
+      '{"type":"terminal","status":"finished","summary":"done"}',
+    ]);
+    expect(t?.status).toBe("finished");
+    expect(t?.summary).toBe("done");
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Brings `cursorRyOsRepoAgent` into the Telegram tool surface for the owner account when `CURSOR_API_KEY` is configured server-side, matching web chat behavior.

Telegram webhook passes `telegramCursorRunNotify` into conversation prep so async runs spawn a lightweight Redis poller that DM-replies with terminal summary, PR URL when present, and an authenticated poll hint URL—plus periodic nudges on long runs. Blocking/no-Redis runs send a single completion DM.

Docs (`docs/9-changelog.md`), Telegram system prompt (`TELEGRAM_CHAT_INSTRUCTIONS`), and status labels (`cursorRyOsRepoAgent`) updated accordingly.

**Testing:** `bun run build`; `bun test tests/test-cursor-repo-agent-tool.test.ts`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a0ad8d1f-4bd6-434a-9106-a0bbe5a94a6b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a0ad8d1f-4bd6-434a-9106-a0bbe5a94a6b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

