### PR TITLE
feat: Water-themed default wallpapers

### DIFF
--- a/src/stores/useDisplaySettingsStore.ts
+++ b/src/stores/useDisplaySettingsStore.ts
@@ -11,9 +11,9 @@ import {
 import { convertImageFileToWallpaperJpeg } from "@/utils/customWallpaperProcessing";
 import { useCloudSyncStore } from "@/stores/useCloudSyncStore";
 
-/** Default desktop wallpaper (nature photo). */
+/** Default desktop wallpaper (calm water — bundled under public/wallpapers). */
 export const DEFAULT_WALLPAPER_PATH =
-  "/wallpapers/photos/nature/earth_horizon.jpg";
+  "/wallpapers/photos/nature/tranquil_surface.jpg";
 
 /**
  * Display settings store - manages wallpaper, shaders, and screen saver settings.

--- a/src/themes/macosx.ts
+++ b/src/themes/macosx.ts
@@ -65,6 +65,6 @@ export const macosx: OsTheme = {
     windowShadow: "0 8px 25px rgba(0,0,0,0.5)",
   },
   wallpaperDefaults: {
-    photo: "/wallpapers/photos/aqua/abstract-7.jpg",
+    photo: "/wallpapers/photos/aqua/water.jpg",
   },
 };

--- a/src/themes/system7.ts
+++ b/src/themes/system7.ts
@@ -53,6 +53,6 @@ export const system7: OsTheme = {
     windowShadow: "2px 2px 0px 0px rgba(0,0,0,0.5)",
   },
   wallpaperDefaults: {
-    tile: "/wallpapers/tiles/Property 1=1.svg",
+    tile: "/wallpapers/tiles/waves_bondi.png",
   },
 };

--- a/src/themes/win98.ts
+++ b/src/themes/win98.ts
@@ -53,6 +53,6 @@ export const win98: OsTheme = {
     windowShadow: "none",
   },
   wallpaperDefaults: {
-    tile: "/wallpapers/tiles/bondi.png",
+    tile: "/wallpapers/tiles/ripple_bondi.png",
   },
 };

--- a/src/themes/xp.ts
+++ b/src/themes/xp.ts
@@ -52,6 +52,6 @@ export const xp: OsTheme = {
     windowShadow: "0 4px 8px rgba(0,0,0,0.25)",
   },
   wallpaperDefaults: {
-    photo: "/wallpapers/photos/landscapes/bliss.jpg",
+    photo: "/wallpapers/photos/landscapes/mono_lake.jpg",
   },
 };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->

Default desktop wallpaper paths now use bundled water-themed images from `public/wallpapers` (already listed in `manifest.json`). Global default in `useDisplaySettingsStore` is `tranquil_surface.jpg`. Per-theme defaults: XP Mono Lake landscape, Win98 ripple Bondi tile, System 7 waves Bondi tile, Aqua `water.jpg`. XP no longer references missing `bliss.jpg`.

Verification: edits only reference existing assets. `bun run build` was not runnable in this environment (`node`/ `bun` absent); please run `bun run build` locally.



<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-35747c35-7721-43db-9742-7d4033b061d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-35747c35-7721-43db-9742-7d4033b061d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

