### PR TITLE
Add listRecentCursorAgents chat tool for Cursor Cloud status

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,6 +72,7 @@ The following environment variables are required for full functionality:
 - `YOUTUBE_API_KEY` - YouTube Data API (for video metadata)
 - `YOUTUBE_API_KEY_2` - YouTube Data API fallback key
 - `OPENAI_API_KEY` - OpenAI API (for audio transcription)
+- `CURSOR_API_KEY` - Cursor Cloud Agents API (owner-only chat tools: `cursorRyOsRepoAgent`, `listRecentCursorAgents` against `ryokun6/ryos`; optional `CURSOR_CLOUD_REPO_URL` / `CURSOR_API_BASE_URL` overrides)
 
 ### Localization / Scripts
 - `GOOGLE_GENERATIVE_AI_API_KEY` - Google Generative AI (for machine translation of locale files)

--- a/api/_utils/ryo-conversation.ts
+++ b/api/_utils/ryo-conversation.ts
@@ -41,6 +41,12 @@ import {
   type CursorRepoAgentTelegramNotify,
   type CursorRyOsRepoAgentInput,
 } from "../chat/tools/cursor-repo-agent.js";
+import {
+  LIST_RECENT_CURSOR_AGENTS_DESCRIPTION,
+  listRecentCursorAgentsSchema,
+  executeListRecentCursorAgents,
+  type ListRecentCursorAgentsInput,
+} from "../chat/tools/list-recent-cursor-agents.js";
 
 export interface RyoConversationSystemState {
   username?: string | null;
@@ -735,8 +741,8 @@ export async function prepareRyoConversationModelInput(
 
   const cursorSdkAddon = enableCursorRepoTool
     ? channel === "telegram"
-      ? `\n\n## CURSOR REPOSITORY AGENT\nYou have access to \`cursorRyOsRepoAgent\` for substantive edits via Cursor Cloud against the GitHub repository ryokun6/ryos. Do not use it for virtual filesystem paths (\`/Documents\`, \`/Applets\`, etc.). Use it only when the user wants changes to this product's source code on GitHub. The run is asynchronous: acknowledge it briefly to the user — they will receive a follow-up Telegram message with the result when the run completes.`
-      : `\n\n## CURSOR REPOSITORY AGENT\nYou have access to \`cursorRyOsRepoAgent\` for substantive edits via Cursor Cloud against the GitHub repository ryokun6/ryos. Do not use it for virtual filesystem paths (\`/Documents\`, \`/Applets\`, etc.). Use it only when the user wants changes to this product's source code on GitHub.`
+      ? `\n\n## CURSOR CLOUD AGENTS (ryOS REPO)\n- \`cursorRyOsRepoAgent\`: substantive edits via Cursor Cloud on GitHub ryokun6/ryos—not virtual paths (\`/Documents\`, etc.). Runs are asynchronous; on Telegram they get a completion message.\n- \`listRecentCursorAgents\`: read-only list of recent Cloud agents/latest run status for that repo (no new run). Use when the user asks what's running or for recent Cursor agent activity.`
+      : `\n\n## CURSOR CLOUD AGENTS (ryOS REPO)\n- \`cursorRyOsRepoAgent\`: substantive edits via Cursor Cloud on GitHub ryokun6/ryos—not virtual paths (\`/Documents\`, etc.).\n- \`listRecentCursorAgents\`: read-only list of recent agents and latest run statuses for that repo; use when the user asks about recent Cursor Cloud runs without starting one.`
     : "";
 
   const staticSystemPrompt = staticPrompts.join("\n") + cursorSdkAddon;
@@ -797,6 +803,24 @@ export async function prepareRyoConversationModelInput(
                 ...(cursorRepoAgentNotifyTelegram
                   ? { notifyTelegram: cursorRepoAgentNotifyTelegram }
                   : {}),
+                ...toolContextOverrides,
+              }),
+          },
+          listRecentCursorAgents: {
+            description: LIST_RECENT_CURSOR_AGENTS_DESCRIPTION,
+            inputSchema: listRecentCursorAgentsSchema,
+            execute: async (input: ListRecentCursorAgentsInput) =>
+              executeListRecentCursorAgents(input, {
+                log,
+                logError,
+                env: {
+                  YOUTUBE_API_KEY: process.env.YOUTUBE_API_KEY,
+                  YOUTUBE_API_KEY_2: process.env.YOUTUBE_API_KEY_2,
+                },
+                username: username ?? null,
+                redis,
+                timeZone: userTimeZone,
+                apiKey: cursorApiKey,
                 ...toolContextOverrides,
               }),
           },

--- a/api/_utils/telegram-status.ts
+++ b/api/_utils/telegram-status.ts
@@ -32,6 +32,8 @@ export function getTelegramToolStatusText(
       return getTelegramSongLibraryStatusText(input);
     case "cursorRyOsRepoAgent":
       return "Starting Cursor cloud agent...";
+    case "listRecentCursorAgents":
+      return "Listing recent Cursor cloud agents…";
     default:
       return "Using a tool...";
   }

--- a/api/chat/tools/list-recent-cursor-agents.ts
+++ b/api/chat/tools/list-recent-cursor-agents.ts
@@ -1,0 +1,405 @@
+/**
+ * Cursor Cloud Agents — list recent runs for chat inspection.
+ *
+ * Uses the public Cloud Agents API v1: GET https://api.cursor.com/v1/agents
+ * (basic auth with CURSOR_API_KEY). List responses include latestRunId;
+ * we call GET /v1/agents/{id}/runs/{runId} per agent for run status/timestamps.
+ *
+ * Note: Runs created only via the legacy @cursor/sdk path may not appear here
+ * until Cursor reconciles them with the v1 API; this tool still lists what the
+ * REST API returns for the authenticated key.
+ */
+
+import { z } from "zod";
+import type { MemoryToolContext } from "./executors.js";
+import {
+  CURSOR_REPO_AGENT_OWNER,
+  DEFAULT_RYOS_GITHUB_REPO_URL,
+} from "./cursor-repo-agent.js";
+
+const CURSOR_API_BASE =
+  process.env.CURSOR_API_BASE_URL?.trim() || "https://api.cursor.com";
+
+export const listRecentCursorAgentsSchema = z.object({
+  limit: z
+    .number()
+    .int()
+    .min(1)
+    .max(100)
+    .optional()
+    .describe("Max agents to return (default 10, API max 100)."),
+  status: z
+    .string()
+    .trim()
+    .min(1)
+    .max(64)
+    .optional()
+    .describe(
+      "Optional case-insensitive filter on agent status (e.g. ACTIVE) or latest run status (e.g. RUNNING, FINISHED)."
+    ),
+});
+
+export type ListRecentCursorAgentsInput = z.infer<
+  typeof listRecentCursorAgentsSchema
+>;
+
+export const LIST_RECENT_CURSOR_AGENTS_DESCRIPTION =
+  "List recent Cursor Cloud agents and their latest run status for the GitHub repo ryokun6/ryos (read-only). Use when the user asks for recent Cursor cloud runs, agent status, or what is running—without starting a new run.";
+
+/** UI-safe structured row for the model */
+export interface RecentCursorAgentRunRow {
+  id: string;
+  agentId: string;
+  createdAt?: string;
+  updatedAt?: string;
+  status: string;
+  model?: string;
+  promptPreview?: string;
+  branch?: string;
+  startingRef?: string;
+  repoUrl?: string;
+  url?: string;
+  summary?: string;
+}
+
+interface ListAgentsApiItem {
+  id?: string;
+  name?: string;
+  status?: string;
+  env?: { type?: string };
+  url?: string;
+  createdAt?: string;
+  updatedAt?: string;
+  latestRunId?: string;
+}
+
+interface GetAgentApiResponse {
+  id?: string;
+  name?: string;
+  status?: string;
+  url?: string;
+  createdAt?: string;
+  updatedAt?: string;
+  latestRunId?: string;
+  repos?: Array<{ url?: string; startingRef?: string }>;
+  branchName?: string;
+}
+
+interface GetRunApiResponse {
+  id?: string;
+  agentId?: string;
+  status?: string;
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+function normalizeRyosRepoUrl(): string {
+  return (
+    process.env.CURSOR_CLOUD_REPO_URL?.trim() || DEFAULT_RYOS_GITHUB_REPO_URL
+  );
+}
+
+/** Normalize to lowercase `owner/repo` when parsable as GitHub. Exported for repo-matching tests. */
+export function githubRepoSlug(urlRaw: string): string | undefined {
+  const u = urlRaw.trim().toLowerCase().replace(/\.git$/, "");
+  try {
+    const withScheme = /^https?:\/\//i.test(u) ? u : `https://${u}`;
+    const parsed = new URL(withScheme);
+    const parts = parsed.pathname.split("/").filter(Boolean);
+    if (parts.length >= 2 && parsed.hostname.includes("github.com")) {
+      return `${parts[0]}/${parts[1]}`;
+    }
+    return parts.length >= 2 ? `${parts[parts.length - 2]}/${parts[parts.length - 1]}` : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function repoMatchesConfigured(
+  repos: Array<{ url?: string }> | undefined,
+  configured: string
+): boolean {
+  if (!repos?.length) return false;
+  const target = githubRepoSlug(configured);
+  if (!target) return false;
+  for (const r of repos) {
+    const u = typeof r.url === "string" ? r.url : "";
+    const slug = githubRepoSlug(u);
+    if (slug && slug === target) return true;
+  }
+  return false;
+}
+
+function previewPrompt(name: string | undefined, maxLen: number): string | undefined {
+  if (!name || typeof name !== "string") return undefined;
+  const trimmed = name.trim().replace(/\s+/g, " ");
+  if (!trimmed) return undefined;
+  return trimmed.length <= maxLen ? trimmed : `${trimmed.slice(0, maxLen - 1)}…`;
+}
+
+function basicAuthHeader(apiKey: string): string {
+  const token = `${apiKey}:`;
+  return `Basic ${Buffer.from(token, "utf8").toString("base64")}`;
+}
+
+async function cursorApiJson<T>(
+  pathWithQuery: string,
+  apiKey: string,
+  logError: (...args: unknown[]) => void
+): Promise<{ ok: true; data: T } | { ok: false; status: number; message: string }> {
+  const url = `${CURSOR_API_BASE.replace(/\/$/, "")}${pathWithQuery}`;
+  try {
+    const res = await fetch(url, {
+      method: "GET",
+      headers: {
+        Authorization: basicAuthHeader(apiKey),
+        Accept: "application/json",
+      },
+    });
+    const text = await res.text();
+    if (!res.ok) {
+      let message = text.slice(0, 200).trim();
+      if (message.startsWith("{")) {
+        try {
+          const j = JSON.parse(message) as { message?: string; error?: string };
+          message =
+            typeof j.message === "string"
+              ? j.message
+              : typeof j.error === "string"
+                ? j.error
+                : message;
+        } catch {
+          /* keep raw snippet */
+        }
+      }
+      if (!message) message = `HTTP ${res.status}`;
+      return { ok: false, status: res.status, message };
+    }
+    try {
+      return { ok: true, data: JSON.parse(text) as T };
+    } catch {
+      logError("[listRecentCursorAgents] invalid JSON from Cursor API");
+      return { ok: false, status: res.status, message: "Invalid JSON response" };
+    }
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return { ok: false, status: 0, message: msg };
+  }
+}
+
+export type ListRecentCursorAgentsSuccess = {
+  ok: true;
+  source: "cursor_cloud_api_v1";
+  repoFilter: string;
+  items: RecentCursorAgentRunRow[];
+};
+
+export type ListRecentCursorAgentsFailure = {
+  ok: false;
+  error: string;
+  hint?: string;
+};
+
+export type ListRecentCursorAgentsOutput =
+  | ListRecentCursorAgentsSuccess
+  | ListRecentCursorAgentsFailure;
+
+export async function executeListRecentCursorAgents(
+  input: ListRecentCursorAgentsInput,
+  context: MemoryToolContext & { apiKey: string }
+): Promise<ListRecentCursorAgentsOutput> {
+  if (context.username !== CURSOR_REPO_AGENT_OWNER) {
+    return {
+      ok: false,
+      error: "This tool is restricted to the owner account.",
+    };
+  }
+
+  const apiKey = context.apiKey?.trim();
+  if (!apiKey) {
+    return {
+      ok: false,
+      error: "CURSOR_API_KEY is not configured on the server.",
+      hint: "Add a Cursor API key (Dashboard → Integrations) to the deployment environment.",
+    };
+  }
+
+  const limit =
+    typeof input.limit === "number"
+      ? Math.min(Math.max(input.limit, 1), 100)
+      : 10;
+  const configuredRepo = normalizeRyosRepoUrl();
+  const statusFilterRaw = input.status?.trim();
+  const statusFilter = statusFilterRaw?.toLowerCase();
+
+  context.log?.(
+    `[listRecentCursorAgents] limit=${limit}${statusFilter ? ` status=${statusFilterRaw}` : ""}`
+  );
+
+  /** Ask the API with a comfortable page size, then paginate until we have enough ryos-repo rows. */
+  const pageSize = Math.min(Math.max(limit * 4, 20), 100);
+  let listCursor: string | null | undefined;
+  let listFailedFirstPage:
+    | { status: number; message: string; isUnreachable: boolean; isUnauthorized: boolean }
+    | undefined;
+  const maxProbePages = 8;
+
+  const rows: RecentCursorAgentRunRow[] = [];
+
+  for (
+    let page = 0;
+    page < maxProbePages && rows.length < limit;
+    page++
+  ) {
+    const q = new URLSearchParams({
+      limit: String(pageSize),
+      includeArchived: "true",
+    });
+    if (listCursor) q.set("cursor", listCursor);
+    const listed = await cursorApiJson<{
+      items?: ListAgentsApiItem[];
+      nextCursor?: string | null;
+    }>(`/v1/agents?${q.toString()}`, apiKey, context.logError || (() => {}));
+
+    if (!listed.ok) {
+      if (page === 0) {
+        listFailedFirstPage = {
+          status: listed.status,
+          message: listed.message,
+          isUnreachable: listed.status === 0,
+          isUnauthorized: listed.status === 401,
+        };
+      }
+      break;
+    }
+
+    const batch = Array.isArray(listed.data.items) ? listed.data.items : [];
+    listCursor =
+      typeof listed.data.nextCursor === "string" &&
+      listed.data.nextCursor.length > 0
+        ? listed.data.nextCursor
+        : null;
+
+    for (const summary of batch) {
+      const agentId = summary.id;
+      const latestRunId = summary.latestRunId;
+      if (typeof agentId !== "string" || !agentId) continue;
+
+      const detail = await cursorApiJson<GetAgentApiResponse>(
+        `/v1/agents/${encodeURIComponent(agentId)}`,
+        apiKey,
+        context.logError || (() => {})
+      );
+
+      if (!detail.ok) {
+        context.log?.(
+          `[listRecentCursorAgents] skip agent ${agentId}: detail fetch failed`
+        );
+        continue;
+      }
+
+      if (!repoMatchesConfigured(detail.data.repos, configuredRepo)) {
+        continue;
+      }
+
+      let run: GetRunApiResponse | undefined;
+      if (typeof latestRunId === "string" && latestRunId.length > 0) {
+        const runRes = await cursorApiJson<{ id?: string; status?: string }>(
+          `/v1/agents/${encodeURIComponent(agentId)}/runs/${encodeURIComponent(latestRunId)}`,
+          apiKey,
+          context.logError || (() => {})
+        );
+        if (runRes.ok) {
+          run = runRes.data as GetRunApiResponse;
+        }
+      }
+
+      const agentStatus =
+        typeof detail.data.status === "string" ? detail.data.status : "UNKNOWN";
+      const runStatus =
+        typeof run?.status === "string" ? run.status : "UNKNOWN";
+      const name =
+        typeof detail.data.name === "string"
+          ? detail.data.name
+          : typeof summary.name === "string"
+            ? summary.name
+            : undefined;
+
+      if (statusFilter) {
+        const agentMatch = agentStatus.toLowerCase() === statusFilter;
+        const runMatch = runStatus.toLowerCase() === statusFilter;
+        if (!agentMatch && !runMatch) continue;
+      }
+
+      const repo0 = detail.data.repos?.[0];
+      const row: RecentCursorAgentRunRow = {
+        id:
+          typeof run?.id === "string"
+            ? run.id
+            : typeof latestRunId === "string"
+              ? latestRunId
+              : agentId,
+        agentId,
+        status: typeof run?.status === "string" ? run.status : agentStatus,
+        createdAt:
+          typeof run?.createdAt === "string"
+            ? run.createdAt
+            : typeof detail.data.createdAt === "string"
+              ? detail.data.createdAt
+              : undefined,
+        updatedAt:
+          typeof run?.updatedAt === "string"
+            ? run.updatedAt
+            : typeof detail.data.updatedAt === "string"
+              ? detail.data.updatedAt
+              : undefined,
+        ...(typeof repo0?.url === "string" ? { repoUrl: repo0.url } : {}),
+        ...(typeof repo0?.startingRef === "string"
+          ? { startingRef: repo0.startingRef }
+          : {}),
+        ...(typeof detail.data.branchName === "string"
+          ? { branch: detail.data.branchName }
+          : {}),
+        url:
+          typeof detail.data.url === "string"
+            ? detail.data.url
+            : typeof summary.url === "string"
+              ? summary.url
+              : undefined,
+        promptPreview: previewPrompt(name, 280),
+        summary:
+          previewPrompt(name, 400) ??
+          (agentStatus !== runStatus ? `Agent ${agentStatus}` : undefined),
+      };
+
+      rows.push(row);
+      if (rows.length >= limit) break;
+    }
+
+    if (!listCursor || batch.length === 0) break;
+  }
+
+  if (rows.length === 0 && listFailedFirstPage) {
+    const f = listFailedFirstPage;
+    return {
+      ok: false,
+      error: f.isUnreachable
+        ? "Could not reach the Cursor Cloud API."
+        : f.isUnauthorized
+          ? "Cursor API rejected credentials."
+          : `Cursor API error (${f.status}).`,
+      hint: f.isUnreachable
+        ? "Check network connectivity and retry; if outages persist, use the Cursor dashboard."
+        : f.isUnauthorized
+          ? "Verify CURSOR_API_KEY is valid and has Cloud Agents API access."
+          : f.message || undefined,
+    };
+  }
+
+  return {
+    ok: true,
+    source: "cursor_cloud_api_v1",
+    repoFilter: configuredRepo,
+    items: rows,
+  };
+}

--- a/src/apps/chats/hooks/useAiChat.ts
+++ b/src/apps/chats/hooks/useAiChat.ts
@@ -824,6 +824,11 @@ export function useAiChat(onPromptSetUsername?: () => void) {
             result = "";
             break;
           }
+          case "listRecentCursorAgents": {
+            console.log("[ToolCall] listRecentCursorAgents (server-side):", toolCall.input);
+            result = "";
+            break;
+          }
           // === Unified VFS Tools ===
           case "list": {
             const { path, query, limit } = toolCall.input as {
@@ -1846,6 +1851,7 @@ export function useAiChat(onPromptSetUsername?: () => void) {
           "memoryDelete",
           "webFetch",
           "cursorRyOsRepoAgent",
+          "listRecentCursorAgents",
         ];
         const toolParts = lastMsg.parts.filter(
           (part: { type?: string; state?: string }) =>

--- a/src/components/shared/ToolInvocationMessage.tsx
+++ b/src/components/shared/ToolInvocationMessage.tsx
@@ -185,6 +185,11 @@ export function ToolInvocationMessage({
       case "cursorRyOsRepoAgent":
         displayCallMessage = t("apps.chats.toolCalls.cursorRyOsRepoAgent.starting");
         break;
+      case "listRecentCursorAgents":
+        displayCallMessage = t(
+          "apps.chats.toolCalls.listRecentCursorAgents.querying",
+        );
+        break;
       case "web_search":
       case "google_search":
         displayCallMessage = t("apps.chats.toolCalls.searchingWeb");
@@ -618,6 +623,27 @@ export function ToolInvocationMessage({
           : t("apps.chats.toolCalls.webFetch.fetched", { siteName: out.siteName || out.message || "" });
       } else if (out?.message) {
         displayResultMessage = out.message;
+      }
+    } else if (toolName === "listRecentCursorAgents") {
+      const out = output as {
+        ok?: boolean;
+        items?: unknown[];
+        error?: string;
+        hint?: string;
+      } | undefined;
+      if (out?.ok && Array.isArray(out.items)) {
+        displayResultMessage =
+          out.items.length === 0
+            ? t("apps.chats.toolCalls.listRecentCursorAgents.none")
+            : out.items.length === 1
+              ? t("apps.chats.toolCalls.listRecentCursorAgents.one")
+              : t("apps.chats.toolCalls.listRecentCursorAgents.many", {
+                  count: out.items.length,
+                });
+      } else if (out?.error) {
+        displayResultMessage = out.hint
+          ? `${out.error} ${out.hint}`
+          : out.error;
       }
     } else if (toolName === "infiniteMacControl") {
       const action = input?.action;

--- a/src/lib/locales/en/translation.json
+++ b/src/lib/locales/en/translation.json
@@ -993,6 +993,12 @@
             "emptyAssistant": "(No message content)"
           }
         },
+        "listRecentCursorAgents": {
+          "querying": "Checking recent Cursor Cloud agents…",
+          "none": "No matching recent Cursor agents for this repo.",
+          "one": "Found 1 recent Cursor agent run",
+          "many": "Found {{count}} recent Cursor agent runs"
+        },
         "searchedWebFor": "Searched the web for {{query}}",
         "foundVideos": "Found {{count}} videos",
         "settingsNoChanges": "No changes made",

--- a/tests/test-cursor-repo-agent-tool.test.ts
+++ b/tests/test-cursor-repo-agent-tool.test.ts
@@ -4,6 +4,10 @@ import {
   executeCursorRyOsRepoAgent,
   formatCursorRunCompletionTelegramMessage,
 } from "../api/chat/tools/cursor-repo-agent.js";
+import {
+  executeListRecentCursorAgents,
+  githubRepoSlug,
+} from "../api/chat/tools/list-recent-cursor-agents.js";
 
 describe("cursorRyOsRepoAgent gate", () => {
   test("rejects callers whose username is not the repo owner", async () => {
@@ -70,5 +74,48 @@ describe("formatCursorRunCompletionTelegramMessage", () => {
     });
     expect(text.length).toBeLessThanOrEqual(3700);
     expect(text).toContain("…(truncated)");
+  });
+});
+
+describe("listRecentCursorAgents gate", () => {
+  test("rejects callers whose username is not the repo owner", async () => {
+    const result = await executeListRecentCursorAgents(
+      {},
+      {
+        username: "alice",
+        log: () => {},
+        logError: () => {},
+        env: {},
+        apiKey: "test-key",
+      }
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain("restricted");
+    }
+  });
+
+  test("reports missing api key clearly", async () => {
+    const result = await executeListRecentCursorAgents(
+      {},
+      {
+        username: "ryo",
+        log: () => {},
+        logError: () => {},
+        env: {},
+        apiKey: "   ",
+      }
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain("CURSOR_API_KEY");
+    }
+  });
+});
+
+describe("githubRepoSlug helper", () => {
+  test("parses https github urls to owner/repo", () => {
+    expect(githubRepoSlug("https://github.com/ryokun6/ryos")).toBe("ryokun6/ryos");
+    expect(githubRepoSlug("https://github.com/Acme/RePo.git")).toBe("acme/repo");
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a read-only **`listRecentCursorAgents`** developer tool alongside `cursorRyOsRepoAgent`.

**Behavior**
- Same gate as the repo agent: owner account (`ryo`) + `CURSOR_API_KEY`.
- Calls Cursor Cloud Agents API v1 (`GET /v1/agents` with paging, then `GET /v1/agents/{id}` and latest run detail) scoped to `CURSOR_CLOUD_REPO_URL` or default `https://github.com/ryokun6/ryos`.
- Inputs: optional `limit` (default **10**, max 100), optional `status` (matches agent status or latest run status, case-insensitive).
- Returns compact JSON per run (run id, agent id, timestamps, status, prompt preview from agent name, branch / startingRef / repo URL, dashboard URL). **Model field** omitted when API does not expose it.

**Graceful failures**
- Missing key: clear actionable message (no secrets in logs/response body).
- Upstream unreachable / auth failure: concise error + hint.

**Other**
- Client: `useAiChat` server-side passthrough + `isError` recovery list; Telegram status string; EN UI strings.
- Docs: AGENTS optional env note for `CURSOR_API_KEY`.
- Limitation documented in-module: `@cursor/sdk` runs may not appear in v1 list until Cursor reconciles; tool lists whatever the REST API returns.

**Tested**
`bun test tests/test-cursor-repo-agent-tool.test.ts` and `bun run build` succeeded.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2cab298a-d636-4a71-bd0f-d5f0c2b3a303"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2cab298a-d636-4a71-bd0f-d5f0c2b3a303"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

