### PR TITLE
Add listRecentCursorAgents read-only Cursor Cloud tool

### DIFF
--- a/api/_utils/ryo-conversation.ts
+++ b/api/_utils/ryo-conversation.ts
@@ -41,6 +41,12 @@ import {
   type CursorRepoAgentTelegramNotify,
   type CursorRyOsRepoAgentInput,
 } from "../chat/tools/cursor-repo-agent.js";
+import {
+  LIST_RECENT_CURSOR_AGENTS_DESCRIPTION,
+  listRecentCursorAgentsSchema,
+  executeListRecentCursorAgents,
+  type ListRecentCursorAgentsInput,
+} from "../chat/tools/cursor-list-agents.js";
 
 export interface RyoConversationSystemState {
   username?: string | null;
@@ -735,8 +741,8 @@ export async function prepareRyoConversationModelInput(
 
   const cursorSdkAddon = enableCursorRepoTool
     ? channel === "telegram"
-      ? `\n\n## CURSOR REPOSITORY AGENT\nYou have access to \`cursorRyOsRepoAgent\` for substantive edits via Cursor Cloud against the GitHub repository ryokun6/ryos. Do not use it for virtual filesystem paths (\`/Documents\`, \`/Applets\`, etc.). Use it only when the user wants changes to this product's source code on GitHub. The run is asynchronous: acknowledge it briefly to the user — they will receive a follow-up Telegram message with the result when the run completes.`
-      : `\n\n## CURSOR REPOSITORY AGENT\nYou have access to \`cursorRyOsRepoAgent\` for substantive edits via Cursor Cloud against the GitHub repository ryokun6/ryos. Do not use it for virtual filesystem paths (\`/Documents\`, \`/Applets\`, etc.). Use it only when the user wants changes to this product's source code on GitHub.`
+      ? `\n\n## CURSOR REPOSITORY AGENT\nYou have access to \`cursorRyOsRepoAgent\` for substantive edits via Cursor Cloud against the GitHub repository ryokun6/ryos. Do not use it for virtual filesystem paths (\`/Documents\`, \`/Applets\`, etc.). Use it only when the user wants changes to this product's source code on GitHub. The run is asynchronous: acknowledge it briefly to the user — they will receive a follow-up Telegram message with the result when the run completes.\n\nYou also have \`listRecentCursorAgents\`: read-only, lists recent Cursor Cloud agents and latest run status for the same repo (no new runs). Use when the user asks about recent background agents or run status.`
+      : `\n\n## CURSOR REPOSITORY AGENT\nYou have access to \`cursorRyOsRepoAgent\` for substantive edits via Cursor Cloud against the GitHub repository ryokun6/ryos. Do not use it for virtual filesystem paths (\`/Documents\`, \`/Applets\`, etc.). Use it only when the user wants changes to this product's source code on GitHub.\n\nYou also have \`listRecentCursorAgents\`: read-only list of recent cloud agents and run statuses for ryokun6/ryos (does not start a run).`
     : "";
 
   const staticSystemPrompt = staticPrompts.join("\n") + cursorSdkAddon;
@@ -797,6 +803,24 @@ export async function prepareRyoConversationModelInput(
                 ...(cursorRepoAgentNotifyTelegram
                   ? { notifyTelegram: cursorRepoAgentNotifyTelegram }
                   : {}),
+                ...toolContextOverrides,
+              }),
+          },
+          listRecentCursorAgents: {
+            description: LIST_RECENT_CURSOR_AGENTS_DESCRIPTION,
+            inputSchema: listRecentCursorAgentsSchema,
+            execute: async (input: ListRecentCursorAgentsInput) =>
+              executeListRecentCursorAgents(input, {
+                log,
+                logError,
+                env: {
+                  YOUTUBE_API_KEY: process.env.YOUTUBE_API_KEY,
+                  YOUTUBE_API_KEY_2: process.env.YOUTUBE_API_KEY_2,
+                },
+                username: username ?? null,
+                redis,
+                timeZone: userTimeZone,
+                apiKey: cursorApiKey,
                 ...toolContextOverrides,
               }),
           },

--- a/api/_utils/telegram-status.ts
+++ b/api/_utils/telegram-status.ts
@@ -32,6 +32,8 @@ export function getTelegramToolStatusText(
       return getTelegramSongLibraryStatusText(input);
     case "cursorRyOsRepoAgent":
       return "Starting Cursor cloud agent...";
+    case "listRecentCursorAgents":
+      return "Listing recent Cursor agents...";
     default:
       return "Using a tool...";
   }

--- a/api/chat/tools/cursor-list-agents.ts
+++ b/api/chat/tools/cursor-list-agents.ts
@@ -1,0 +1,355 @@
+/**
+ * Read-only inspection of recent Cursor Cloud agents / runs via @cursor/sdk
+ * (Agent.list → Agent.get / Agent.listRuns → Agent.getRun), matching Cursor's
+ * Cloud Agents API model: durable agents with per-prompt runs.
+ *
+ * API limitation (see Cloud Agents docs): there is no global "list all runs"
+ * endpoint — runs are listed per agent. This tool therefore walks recent agents
+ * (newest first) and attaches each agent's latest run (+ fresh status from getRun).
+ * SDK-started agents may be hidden from default UI lists but still appear in
+ * Agent.list when includeArchived / filters allow.
+ */
+
+import { z } from "zod";
+import type { MemoryToolContext } from "./executors.js";
+import {
+  CURSOR_REPO_AGENT_OWNER,
+  DEFAULT_RYOS_GITHUB_REPO_URL,
+} from "./cursor-repo-agent.js";
+
+export const listRecentCursorAgentsSchema = z.object({
+  limit: z
+    .number()
+    .int()
+    .min(1)
+    .max(100)
+    .optional()
+    .describe("Maximum number of runs to return (default 10)."),
+  status: z
+    .string()
+    .trim()
+    .min(1)
+    .optional()
+    .describe(
+      "Optional run status filter (e.g. RUNNING, FINISHED). Case-insensitive."
+    ),
+});
+
+export type ListRecentCursorAgentsInput = z.infer<
+  typeof listRecentCursorAgentsSchema
+>;
+
+export const LIST_RECENT_CURSOR_AGENTS_DESCRIPTION =
+  "List recent Cursor Cloud agents and their latest run status for the configured GitHub repo (default ryokun6/ryos). Read-only: does not start agents. Uses CURSOR_API_KEY. Use when the user asks about recent Cursor background agents, cloud runs, or PR bot activity.";
+
+/** Normalized for comparing Cursor repo URLs to env/default. */
+function repoKeyFromUrl(url: string): string {
+  try {
+    const u = url.trim().toLowerCase().replace(/\.git$/, "");
+    const noProto = u.replace(/^https?:\/\//, "");
+    if (noProto.startsWith("github.com/")) {
+      return noProto.slice("github.com/".length).replace(/\/+$/, "");
+    }
+    return noProto.replace(/\/+$/, "");
+  } catch {
+    return url.trim().toLowerCase();
+  }
+}
+
+function agentRelatesToRepo(
+  repos: string[] | undefined,
+  targetKey: string
+): { matches: boolean; indeterminate: boolean } {
+  if (!repos || repos.length === 0) {
+    return { matches: true, indeterminate: true };
+  }
+  for (const r of repos) {
+    if (repoKeyFromUrl(r) === targetKey) {
+      return { matches: true, indeterminate: false };
+    }
+  }
+  return { matches: false, indeterminate: false };
+}
+
+function truncatePreview(s: string, max: number): string {
+  const t = s.trim().replace(/\s+/g, " ");
+  if (t.length <= max) return t;
+  return `${t.slice(0, Math.max(0, max - 1))}…`;
+}
+
+function firstLine(s: string): string {
+  const line = s.split(/\r?\n/).find((l) => l.trim().length > 0);
+  return (line ?? s).trim();
+}
+
+/** Map SDK / API run.status to cloud-style labels (REST uses SCREAMING_SNAKE). */
+function normalizeRunStatusForOutput(
+  status: string | undefined
+): string | undefined {
+  if (!status) return undefined;
+  const u = status.toUpperCase();
+  if (u === "RUNNING") return "RUNNING";
+  if (u === "FINISHED") return "FINISHED";
+  if (u === "ERROR") return "ERROR";
+  if (u === "CANCELLED" || u === "CANCELED") return "CANCELLED";
+  if (u === "CREATING") return "CREATING";
+  if (u === "EXPIRED") return "EXPIRED";
+  return u;
+}
+
+export interface ListRecentCursorAgentsRow {
+  id: string;
+  agentId?: string;
+  createdAt?: string;
+  updatedAt?: string;
+  status?: string;
+  model?: string;
+  promptPreview?: string;
+  branch?: string;
+  commit?: string;
+  prUrl?: string;
+  url?: string;
+  summary?: string;
+}
+
+export type ListRecentCursorAgentsToolOutput =
+  | {
+      ok: true;
+      runs: ListRecentCursorAgentsRow[];
+      repoFilter: string;
+      /** Present when some agents had no repo metadata in the API — rows may include non-repo agents. */
+      repoFilterIndeterminate?: boolean;
+      truncated?: boolean;
+    }
+  | { ok: false; error: string };
+
+export interface ListRecentCursorAgentsContext extends MemoryToolContext {
+  apiKey: string;
+}
+
+const MAX_AGENT_LIST_PAGES = 8;
+const AGENTS_PAGE_SIZE = 20;
+const MAX_RUNS_PER_AGENT = 5;
+
+export async function executeListRecentCursorAgents(
+  input: ListRecentCursorAgentsInput,
+  context: ListRecentCursorAgentsContext
+): Promise<ListRecentCursorAgentsToolOutput> {
+  if (context.username !== CURSOR_REPO_AGENT_OWNER) {
+    return {
+      ok: false,
+      error: "This tool is restricted to the owner account.",
+    };
+  }
+
+  const key = context.apiKey?.trim();
+  if (!key) {
+    return {
+      ok: false,
+      error:
+        "Cursor API key is not configured. Set CURSOR_API_KEY in the server environment (Cursor Dashboard → Integrations).",
+    };
+  }
+
+  const limit = Math.min(100, Math.max(1, input.limit ?? 10));
+  const statusFilterRaw = input.status?.trim();
+  const statusFilter = statusFilterRaw
+    ? statusFilterRaw.toUpperCase()
+    : undefined;
+
+  const repoUrl =
+    process.env.CURSOR_CLOUD_REPO_URL?.trim() || DEFAULT_RYOS_GITHUB_REPO_URL;
+  const repoKey = repoKeyFromUrl(repoUrl);
+
+  try {
+    const { Agent } = await import("@cursor/sdk");
+
+    type SdkAgentInfo = Awaited<
+      ReturnType<typeof Agent.list>
+    >["items"][number];
+
+    type AgentGetExtras = {
+      latestRunId?: string;
+      branchName?: string;
+      url?: string;
+    };
+
+    const runs: ListRecentCursorAgentsRow[] = [];
+    let listCursor: string | undefined;
+    let listPages = 0;
+    let indeterminateRepo = false;
+    let truncated = false;
+
+    outer: while (runs.length < limit && listPages < MAX_AGENT_LIST_PAGES) {
+      listPages += 1;
+      const page = await Agent.list({
+        runtime: "cloud",
+        apiKey: key,
+        limit: AGENTS_PAGE_SIZE,
+        ...(listCursor ? { cursor: listCursor } : {}),
+      });
+
+      for (const item of page.items) {
+        if (runs.length >= limit) {
+          truncated = page.nextCursor !== undefined;
+          break outer;
+        }
+
+        const aid = item.agentId;
+        if (!aid.startsWith("bc-")) continue;
+
+        let info: SdkAgentInfo = item;
+        try {
+          info = await Agent.get(aid, { apiKey: key });
+        } catch {
+          info = item;
+        }
+
+        const repos = info.runtime === "cloud" ? info.repos : undefined;
+        const { matches, indeterminate } = agentRelatesToRepo(repos, repoKey);
+        if (indeterminate) indeterminateRepo = true;
+        if (!matches) continue;
+
+        const extras = info as SdkAgentInfo & AgentGetExtras;
+        let runId =
+          typeof extras.latestRunId === "string" ? extras.latestRunId : undefined;
+
+        if (!runId) {
+          try {
+            const runPage = await Agent.listRuns(aid, {
+              runtime: "cloud",
+              apiKey: key,
+              limit: MAX_RUNS_PER_AGENT,
+            });
+            runId = runPage.items[0]?.id;
+          } catch {
+            runId = undefined;
+          }
+        }
+
+        if (!runId) {
+          if (statusFilter) continue;
+          const name = typeof info.name === "string" ? info.name : "";
+          const st = normalizeRunStatusForOutput(info.status);
+          runs.push({
+            id: `agent:${aid}`,
+            agentId: aid,
+            ...(info.createdAt != null
+              ? { createdAt: new Date(info.createdAt).toISOString() }
+              : {}),
+            ...(info.lastModified != null
+              ? { updatedAt: new Date(info.lastModified).toISOString() }
+              : {}),
+            ...(st ? { status: st } : {}),
+            ...(name
+              ? { promptPreview: truncatePreview(firstLine(name), 280) }
+              : {}),
+            ...(typeof info.summary === "string" && info.summary.trim()
+              ? {
+                  summary: truncatePreview(firstLine(info.summary), 500),
+                }
+              : {}),
+            url: `https://cursor.com/agents?id=${encodeURIComponent(aid)}`,
+          });
+          continue;
+        }
+
+        let run: Awaited<ReturnType<typeof Agent.getRun>>;
+        try {
+          run = await Agent.getRun(runId, {
+            runtime: "cloud",
+            agentId: aid,
+            apiKey: key,
+          });
+        } catch {
+          continue;
+        }
+
+        const normStatus = normalizeRunStatusForOutput(run.status);
+        if (statusFilter && normStatus !== statusFilter) continue;
+
+        const name = typeof info.name === "string" ? info.name : "";
+        const summary =
+          typeof info.summary === "string" && info.summary.trim()
+            ? truncatePreview(firstLine(info.summary), 500)
+            : run.result
+              ? truncatePreview(run.result, 500)
+              : undefined;
+
+        const modelId = run.model?.id;
+        const gitBranch = run.git?.branches?.[0];
+        let branch = gitBranch?.branch;
+        const prUrl = gitBranch?.prUrl;
+        if (!branch && typeof extras.branchName === "string") {
+          branch = extras.branchName;
+        }
+
+        const row: ListRecentCursorAgentsRow = {
+          id: run.id,
+          agentId: run.agentId,
+          ...(run.createdAt != null
+            ? { createdAt: new Date(run.createdAt).toISOString() }
+            : {}),
+          ...(normStatus ? { status: normStatus } : {}),
+          ...(modelId ? { model: modelId } : {}),
+          ...(name
+            ? { promptPreview: truncatePreview(firstLine(name), 280) }
+            : {}),
+          ...(branch ? { branch } : {}),
+          ...(prUrl ? { prUrl } : {}),
+          url: `https://cursor.com/agents?id=${encodeURIComponent(aid)}`,
+          ...(summary ? { summary } : {}),
+        };
+        runs.push(row);
+      }
+
+      listCursor = page.nextCursor;
+      if (!listCursor) break;
+    }
+
+    if (listPages >= MAX_AGENT_LIST_PAGES && listCursor !== undefined) {
+      truncated = true;
+    }
+
+    return {
+      ok: true,
+      runs,
+      repoFilter: repoKey,
+      ...(indeterminateRepo ? { repoFilterIndeterminate: true } : {}),
+      ...(truncated ? { truncated: true } : {}),
+    };
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    const lower = msg.toLowerCase();
+    if (
+      lower.includes("401") ||
+      lower.includes("unauthorized") ||
+      lower.includes("authentication") ||
+      lower.includes("api key")
+    ) {
+      return {
+        ok: false,
+        error:
+          "Cursor API rejected the request (check CURSOR_API_KEY is valid and not expired).",
+      };
+    }
+    if (
+      lower.includes("network") ||
+      lower.includes("econnreset") ||
+      lower.includes("fetch failed") ||
+      lower.includes("503") ||
+      lower.includes("502") ||
+      lower.includes("504")
+    ) {
+      return {
+        ok: false,
+        error:
+          "Cursor Cloud is temporarily unreachable. Retry in a moment.",
+      };
+    }
+    return {
+      ok: false,
+      error: `Cursor API error: ${msg}`,
+    };
+  }
+}

--- a/src/apps/chats/hooks/useAiChat.ts
+++ b/src/apps/chats/hooks/useAiChat.ts
@@ -824,6 +824,11 @@ export function useAiChat(onPromptSetUsername?: () => void) {
             result = "";
             break;
           }
+          case "listRecentCursorAgents": {
+            console.log("[ToolCall] listRecentCursorAgents (server-side):", toolCall.input);
+            result = "";
+            break;
+          }
           // === Unified VFS Tools ===
           case "list": {
             const { path, query, limit } = toolCall.input as {
@@ -1846,6 +1851,7 @@ export function useAiChat(onPromptSetUsername?: () => void) {
           "memoryDelete",
           "webFetch",
           "cursorRyOsRepoAgent",
+          "listRecentCursorAgents",
         ];
         const toolParts = lastMsg.parts.filter(
           (part: { type?: string; state?: string }) =>

--- a/src/components/shared/ToolInvocationMessage.tsx
+++ b/src/components/shared/ToolInvocationMessage.tsx
@@ -185,6 +185,9 @@ export function ToolInvocationMessage({
       case "cursorRyOsRepoAgent":
         displayCallMessage = t("apps.chats.toolCalls.cursorRyOsRepoAgent.starting");
         break;
+      case "listRecentCursorAgents":
+        displayCallMessage = t("apps.chats.toolCalls.listRecentCursorAgents.loading");
+        break;
       case "web_search":
       case "google_search":
         displayCallMessage = t("apps.chats.toolCalls.searchingWeb");
@@ -714,6 +717,29 @@ export function ToolInvocationMessage({
         headerTitle={headerTitle}
         introMessage={out.message}
       />
+    );
+  }
+
+  if (
+    state === "output-available" &&
+    toolName === "listRecentCursorAgents" &&
+    output &&
+    typeof output === "object" &&
+    output !== null
+  ) {
+    let text: string;
+    try {
+      text = JSON.stringify(output, null, 2);
+    } catch {
+      text = String(output);
+    }
+    return (
+      <div
+        key={partKey}
+        className="mb-1 max-h-64 overflow-auto rounded border border-neutral-200 bg-neutral-50 px-2 py-1 text-[11px] font-mono text-neutral-800 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-200"
+      >
+        <pre className="whitespace-pre-wrap break-words">{text}</pre>
+      </div>
     );
   }
 

--- a/src/lib/locales/en/translation.json
+++ b/src/lib/locales/en/translation.json
@@ -972,6 +972,9 @@
           "fetched": "Read {{siteName}}",
           "fetchedPage": "Read \"{{title}}\""
         },
+        "listRecentCursorAgents": {
+          "loading": "Fetching recent Cursor agents…"
+        },
         "cursorRyOsRepoAgent": {
           "starting": "Starting Cursor Cloud agent…",
           "panelTitle": "Cursor repo agent",

--- a/tests/test-cursor-list-agents-tool.test.ts
+++ b/tests/test-cursor-list-agents-tool.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "bun:test";
+import { executeListRecentCursorAgents } from "../api/chat/tools/cursor-list-agents.js";
+
+describe("listRecentCursorAgents gate", () => {
+  test("rejects callers whose username is not the repo owner", async () => {
+    const result = await executeListRecentCursorAgents(
+      {},
+      {
+        username: "alice",
+        log: () => {},
+        logError: () => {},
+        env: {},
+        apiKey: "test-key",
+      }
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain("restricted");
+    }
+  });
+
+  test("returns actionable error when api key is missing", async () => {
+    const result = await executeListRecentCursorAgents(
+      {},
+      {
+        username: "ryo",
+        log: () => {},
+        logError: () => {},
+        env: {},
+        apiKey: "",
+      }
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain("CURSOR_API_KEY");
+    }
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a chat tool `listRecentCursorAgents` that lists recent Cursor Cloud agents scoped (by repo URL from `Agent.get`) to `ryokun6/ryos` or `CURSOR_CLOUD_REPO_URL`, using the same owner gate and `CURSOR_API_KEY` as `cursorRyOsRepoAgent`.

Implementation follows the current Cursor TypeScript SDK: `Agent.list` / `Agent.get` / `Agent.listRuns` / `Agent.getRun` with `runtime: "cloud"` (aligned with the Cloud Agents API’s agent + run model). Code comments note that there is no global run list endpoint—only per-agent run lists.

**Testing:** `bun test` on the new gate tests + existing cursor repo agent tests; `bun run build` succeeded.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-676055f4-664c-4bd0-9c15-0b6654c092bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-676055f4-664c-4bd0-9c15-0b6654c092bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

