### PR TITLE
fix(i18n): localize Chats, Applet Viewer, and Finder list accessibility

### DIFF
--- a/src/apps/applet-viewer/hooks/useAppletViewerLogic.ts
+++ b/src/apps/applet-viewer/hooks/useAppletViewerLogic.ts
@@ -122,20 +122,31 @@ export function useAppletViewerLogic({
     const result = await checkForUpdates();
     if (result.count > 0) {
       const appletNames = result.updates
-        .map((applet) => applet.title || applet.name || "Untitled Applet")
+        .map((applet) =>
+          applet.title ||
+          applet.name ||
+          t("apps.applet-viewer.dialogs.untitledApplet")
+        )
         .join(", ");
       toast.info(
-        `${result.count} new applet update${result.count > 1 ? "s" : ""}`,
+        t(
+          result.count !== 1
+            ? "apps.applet-viewer.dialogs.newAppletUpdatesPlural"
+            : "apps.applet-viewer.dialogs.newAppletUpdates",
+          { count: result.count }
+        ),
         {
           description: appletNames,
           action: {
-            label: "Update",
+            label: t("apps.applet-viewer.status.update"),
             onClick: async () => {
               const updateCount = result.updates.length;
               const loadingMessage =
                 updateCount === 1
-                  ? "Updating 1 applet..."
-                  : `Updating ${updateCount} applets...`;
+                  ? t("apps.applet-viewer.dialogs.updatingAppletSingle")
+                  : t("apps.applet-viewer.dialogs.updatingAppletsPlural", {
+                      count: updateCount,
+                    });
               const loadingToastId = toast.loading(loadingMessage, {
                 duration: Infinity,
               });
@@ -149,8 +160,10 @@ export function useAppletViewerLogic({
 
                 toast.success(
                   updateCount === 1
-                    ? "Applet updated"
-                    : `${updateCount} applets updated`,
+                    ? t("apps.applet-viewer.dialogs.appletUpdated")
+                    : t("apps.applet-viewer.dialogs.appletsUpdated", {
+                        count: updateCount,
+                      }),
                   {
                     id: loadingToastId,
                     duration: 3000,
@@ -158,11 +171,11 @@ export function useAppletViewerLogic({
                 );
               } catch (error) {
                 console.error("Error updating applets:", error);
-                toast.error("Failed to update applets", {
+                toast.error(t("apps.applet-viewer.dialogs.failedToUpdateApplets"), {
                   description:
                     error instanceof Error
                       ? error.message
-                      : "Please try again later.",
+                      : t("apps.applet-viewer.dialogs.pleaseTryAgainLater"),
                   id: loadingToastId,
                 });
               }
@@ -172,9 +185,9 @@ export function useAppletViewerLogic({
         }
       );
     } else {
-      toast.success("All applets are up to date");
+      toast.success(t("apps.applet-viewer.dialogs.allAppletsUpToDate"));
     }
-  }, [checkForUpdates, actions]);
+  }, [checkForUpdates, actions, t]);
 
   const handleUpdateAll = useCallback(async () => {
     if (updatesAvailable.length === 0) return;
@@ -182,8 +195,10 @@ export function useAppletViewerLogic({
     const updateCount = updatesAvailable.length;
     const loadingMessage =
       updateCount === 1
-        ? "Updating 1 applet..."
-        : `Updating ${updateCount} applets...`;
+        ? t("apps.applet-viewer.dialogs.updatingAppletSingle")
+        : t("apps.applet-viewer.dialogs.updatingAppletsPlural", {
+            count: updateCount,
+          });
     const loadingToastId = toast.loading(loadingMessage, {
       duration: Infinity,
     });
@@ -197,8 +212,8 @@ export function useAppletViewerLogic({
 
       toast.success(
         updateCount === 1
-          ? "Applet updated"
-          : `${updateCount} applets updated`,
+          ? t("apps.applet-viewer.dialogs.appletUpdated")
+          : t("apps.applet-viewer.dialogs.appletsUpdated", { count: updateCount }),
         {
           id: loadingToastId,
           duration: 3000,
@@ -206,13 +221,15 @@ export function useAppletViewerLogic({
       );
     } catch (error) {
       console.error("Error updating applets:", error);
-      toast.error("Failed to update applets", {
+      toast.error(t("apps.applet-viewer.dialogs.failedToUpdateApplets"), {
         description:
-          error instanceof Error ? error.message : "Please try again later.",
+          error instanceof Error
+            ? error.message
+            : t("apps.applet-viewer.dialogs.pleaseTryAgainLater"),
         id: loadingToastId,
       });
     }
-  }, [updatesAvailable, actions, checkForUpdates]);
+  }, [updatesAvailable, actions, checkForUpdates, t]);
 
   const sendAuthPayload = useCallback(
     (target: Window | null | undefined) => {
@@ -990,15 +1007,20 @@ export function useAppletViewerLogic({
           },
         });
 
-        toast.success("Applet imported!", {
-          description: `${importFileName} saved to /Applets${
-            icon ? ` with ${icon} icon` : ""
-          }`,
+        toast.success(t("apps.applet-viewer.dialogs.appletImported"), {
+          description: t("apps.applet-viewer.dialogs.appletImportedDescription", {
+            fileName: importFileName,
+            iconText: icon
+              ? t("apps.applet-viewer.dialogs.appletImportedIconSuffix", {
+                  icon,
+                })
+              : "",
+          }),
         });
       } catch (error) {
         console.error("Import failed:", error);
-        toast.error("Import failed", {
-          description: "Could not import the file.",
+        toast.error(t("apps.applet-viewer.dialogs.importFailed"), {
+          description: t("apps.applet-viewer.dialogs.couldNotImportFile"),
         });
       }
     }
@@ -1084,16 +1106,18 @@ export function useAppletViewerLogic({
       document.body.removeChild(a);
       URL.revokeObjectURL(url);
 
-      toast.success("Applet exported!", {
-        description: `${filename}.app exported successfully.`,
+      toast.success(t("apps.applet-viewer.dialogs.appletExported"), {
+        description: t("apps.applet-viewer.dialogs.appletExportedDescription", {
+          fileName: filename,
+        }),
       });
     } catch (compressionError) {
       console.error("Compression failed:", compressionError);
-      toast.error("Export failed", {
+      toast.error(t("apps.applet-viewer.dialogs.exportFailed"), {
         description:
           compressionError instanceof Error
             ? compressionError.message
-            : "Could not compress the applet file.",
+            : t("apps.applet-viewer.dialogs.couldNotCompressAppletFile"),
       });
     }
   };
@@ -1105,15 +1129,15 @@ export function useAppletViewerLogic({
 
   const handleShareApplet = async () => {
     if (!hasAppletContent) {
-      toast.error("No applet to share", {
-        description: "Please open an applet first.",
+      toast.error(t("apps.applet-viewer.dialogs.noAppletToShare"), {
+        description: t("apps.applet-viewer.dialogs.pleaseOpenAppletFirst"),
       });
       return;
     }
 
     if (!username || !isAuthenticated) {
-      toast.error("Login required", {
-        description: "You must be logged in to share applets.",
+      toast.error(t("apps.applet-viewer.dialogs.loginRequired"), {
+        description: t("apps.applet-viewer.dialogs.mustBeLoggedInToShare"),
       });
       return;
     }
@@ -1132,8 +1156,8 @@ export function useAppletViewerLogic({
       if (existingShareId && !isAuthor) {
         setShareId(existingShareId);
         setIsShareDialogOpen(true);
-        toast.success("Applet already shared", {
-          description: "Showing existing share link.",
+        toast.success(t("apps.applet-viewer.dialogs.appletAlreadyShared"), {
+          description: t("apps.applet-viewer.dialogs.showingExistingShareLink"),
         });
         return;
       }
@@ -1189,17 +1213,24 @@ export function useAppletViewerLogic({
         }
       }
 
-      toast.success(data.updated ? "Applet updated!" : "Applet shared!", {
-        description: data.updated
-          ? "Share link updated successfully."
-          : "Share link generated successfully.",
-        duration: 3000,
-      });
+      toast.success(
+        data.updated
+          ? t("apps.applet-viewer.dialogs.appletUpdatedShare")
+          : t("apps.applet-viewer.dialogs.appletShared"),
+        {
+          description: data.updated
+            ? t("apps.applet-viewer.dialogs.shareLinkUpdatedSuccessfully")
+            : t("apps.applet-viewer.dialogs.shareLinkGeneratedSuccessfully"),
+          duration: 3000,
+        }
+      );
     } catch (error) {
       console.error("Error sharing applet:", error);
-      toast.error("Failed to share applet", {
+      toast.error(t("apps.applet-viewer.dialogs.failedToShareApplet"), {
         description:
-          error instanceof Error ? error.message : "Please try again later.",
+          error instanceof Error
+            ? error.message
+            : t("apps.applet-viewer.dialogs.pleaseTryAgainLater"),
       });
     }
   };
@@ -1257,11 +1288,11 @@ export function useAppletViewerLogic({
             }
           }
 
-          const displayName = data.title || data.name || "Shared Applet";
-          toast.success("Shared applet loaded", {
+          const displayName = data.title || data.name || t("apps.applet-viewer.dialogs.sharedApplet");
+          toast.success(t("apps.applet-viewer.dialogs.sharedAppletLoaded"), {
             description: displayName,
             action: {
-              label: "Save",
+              label: t("apps.applet-viewer.status.save"),
               onClick: async () => {
                 try {
                   let defaultName = data.name || data.title || "shared-applet";
@@ -1309,16 +1340,18 @@ export function useAppletViewerLogic({
                     icon: data.icon || undefined,
                   });
 
-                  toast.success("Applet saved", {
-                    description: `Saved to /Applets/${finalName}`,
+                  toast.success(t("apps.applet-viewer.dialogs.appletSaved"), {
+                    description: t("apps.applet-viewer.dialogs.appletSavedDescription", {
+                      fileName: finalName,
+                    }),
                   });
                 } catch (error) {
                   console.error("Error saving shared applet:", error);
-                  toast.error("Failed to save applet", {
+                  toast.error(t("apps.applet-viewer.dialogs.failedToSaveApplet"), {
                     description:
                       error instanceof Error
                         ? error.message
-                        : "Please try again.",
+                        : t("apps.applet-viewer.dialogs.pleaseTryAgainLater"),
                   });
                 }
               },
@@ -1332,14 +1365,13 @@ export function useAppletViewerLogic({
           if (!isActive || controller.signal.aborted) return;
           console.error("Error fetching shared applet:", error);
           if (error instanceof Error && error.message.includes("404")) {
-            toast.error("Applet not found", {
-              description:
-                "The shared applet may have been deleted or the link is invalid.",
+            toast.error(t("apps.applet-viewer.dialogs.appletNotFound"), {
+              description: t("apps.applet-viewer.dialogs.appletNotFoundDescription"),
             });
             return;
           }
-          toast.error("Failed to load shared applet", {
-            description: "Please check your connection and try again.",
+          toast.error(t("apps.applet-viewer.dialogs.failedToLoadSharedApplet"), {
+            description: t("apps.applet-viewer.dialogs.pleaseCheckConnection"),
           });
         }
       };
@@ -1362,6 +1394,7 @@ export function useAppletViewerLogic({
     instanceId,
     saveFile,
     updateFileItemMetadata,
+    t,
   ]);
 
   useEffect(() => {

--- a/src/apps/chats/hooks/useAiChat.ts
+++ b/src/apps/chats/hooks/useAiChat.ts
@@ -1962,12 +1962,13 @@ export function useAiChat(onPromptSetUsername?: () => void) {
         useChatsStore.getState().setAuthenticated(false);
 
         // Show user-friendly error message with action button
-        toast.error("Login Required", {
-          description: message || "Please login to continue chatting.",
+        toast.error(i18n.t("apps.chats.toasts.loginRequired"), {
+          description:
+            message || i18n.t("apps.chats.toasts.pleaseLoginToContinueChatting"),
           duration: 5000,
           action: onPromptSetUsername
             ? {
-                label: "Login",
+                label: i18n.t("apps.chats.toasts.loginButton"),
                 onClick: onPromptSetUsername,
               }
             : undefined,
@@ -2007,7 +2008,7 @@ export function useAiChat(onPromptSetUsername?: () => void) {
               errorData.error === "unauthorized" ||
               errorData.error === "username mismatch"
             ) {
-              handleAuthError("Your session has expired. Please login again.");
+              handleAuthError(i18n.t("apps.chats.toasts.sessionExpiredLoginAgain"));
               return; // Exit early to prevent showing generic error toast
             }
           } catch (parseError) {
@@ -2022,13 +2023,12 @@ export function useAiChat(onPromptSetUsername?: () => void) {
         ) {
           // Generic rate limit message if we couldn't parse the details
           setNeedsUsername(true);
-          toast.error("Rate Limit Exceeded", {
-            description:
-              "You've reached the message limit. Please login to continue.",
+          toast.error(i18n.t("apps.chats.toasts.rateLimitExceeded"), {
+            description: i18n.t("apps.chats.toasts.rateLimitMessageLimitLogin"),
             duration: 5000,
             action: onPromptSetUsername
               ? {
-                  label: "Login",
+                  label: i18n.t("apps.chats.toasts.loginButton"),
                   onClick: onPromptSetUsername,
                 }
               : undefined,
@@ -2053,8 +2053,9 @@ export function useAiChat(onPromptSetUsername?: () => void) {
       }
 
       // For non-rate-limit errors, show the generic error toast
-      toast.error("AI Error", {
-        description: err.message || "Failed to get response.",
+      toast.error(i18n.t("apps.chats.toasts.aiError"), {
+        description:
+          err.message || i18n.t("apps.chats.toasts.failedToGetResponse"),
       });
     },
   });
@@ -2189,8 +2190,8 @@ export function useAiChat(onPromptSetUsername?: () => void) {
 
       // Check if user needs to set username before submitting
       if (needsUsername && !username) {
-        toast.error("Login Required", {
-          description: "Please login to continue chatting.",
+        toast.error(i18n.t("apps.chats.toasts.loginRequired"), {
+          description: i18n.t("apps.chats.toasts.pleaseLoginToContinueChatting"),
           duration: 3000,
         });
         return;
@@ -2198,8 +2199,8 @@ export function useAiChat(onPromptSetUsername?: () => void) {
 
       // Check if user is authenticated (cookies handle auth automatically)
       if (username && !isAuthenticated) {
-        toast.error("Login Required", {
-          description: "Please login to continue chatting.",
+        toast.error(i18n.t("apps.chats.toasts.loginRequired"), {
+          description: i18n.t("apps.chats.toasts.pleaseLoginToContinueChatting"),
           duration: 3000,
         });
         return;
@@ -2235,7 +2236,7 @@ export function useAiChat(onPromptSetUsername?: () => void) {
         // Send message with image attachment using files array
         sendMessage(
           {
-            text: messageContent.trim() || "Describe this image",
+            text: messageContent.trim() || t("apps.chats.status.describeThisImage"),
             files: [
               {
                 type: "file" as const,
@@ -2283,6 +2284,7 @@ export function useAiChat(onPromptSetUsername?: () => void) {
       isAuthenticated,
       aiModel,
       setInput,
+      t,
     ],
   );
 
@@ -2292,8 +2294,8 @@ export function useAiChat(onPromptSetUsername?: () => void) {
 
       // Check if user needs to set username before submitting
       if (needsUsername && !username) {
-        toast.error("Login Required", {
-          description: "Please login to continue chatting.",
+        toast.error(i18n.t("apps.chats.toasts.loginRequired"), {
+          description: i18n.t("apps.chats.toasts.pleaseLoginToContinueChatting"),
           duration: 3000,
         });
         return;
@@ -2301,8 +2303,8 @@ export function useAiChat(onPromptSetUsername?: () => void) {
 
       // Check if user is authenticated (cookies handle auth automatically)
       if (username && !isAuthenticated) {
-        toast.error("Login Required", {
-          description: "Please login to continue chatting.",
+        toast.error(i18n.t("apps.chats.toasts.loginRequired"), {
+          description: i18n.t("apps.chats.toasts.pleaseLoginToContinueChatting"),
           duration: 3000,
         });
         return;
@@ -2494,12 +2496,18 @@ export function useAiChat(onPromptSetUsername?: () => void) {
         });
 
         setIsSaveDialogOpen(false);
-        toast.success(isUpdate ? "Transcript updated" : "Transcript saved", {
-          description: `Saved to ${finalFileName}`,
-          duration: 5000,
-          action: {
-            label: "Open",
-            onClick: () => {
+        toast.success(
+          isUpdate
+            ? i18n.t("apps.chats.toasts.transcriptUpdated")
+            : i18n.t("apps.chats.toasts.transcriptSaved"),
+          {
+            description: i18n.t("apps.chats.toasts.savedToFileName", {
+              fileName: finalFileName,
+            }),
+            duration: 5000,
+            action: {
+              label: i18n.t("apps.chats.toasts.open"),
+              onClick: () => {
               // Check if this file is already open in a TextEdit instance
               const textEditStore = useTextEditStore.getState();
               const existingInstanceId = textEditStore.getInstanceIdByPath(filePath);
@@ -2534,8 +2542,11 @@ export function useAiChat(onPromptSetUsername?: () => void) {
         });
       } catch (error) {
         console.error("Error saving transcript:", error);
-        toast.error("Failed to save transcript", {
-          description: error instanceof Error ? error.message : "Unknown error",
+        toast.error(i18n.t("apps.chats.toasts.failedToSaveTranscript"), {
+          description:
+            error instanceof Error
+              ? error.message
+              : i18n.t("apps.chats.toasts.unknownError"),
         });
       }
     },

--- a/src/apps/finder/components/FileList.tsx
+++ b/src/apps/finder/components/FileList.tsx
@@ -84,6 +84,7 @@ interface ListRowItemProps {
   getIconPath: (file: FileItem) => string;
   getDisplayName: (file: FileItem) => string;
   getFileType: (file: FileItem) => string;
+  getListIconAlt: (file: FileItem) => string;
   shouldShowThumbnail: (file: FileItem) => boolean;
   isImageFile: (file: FileItem) => boolean;
 }
@@ -103,6 +104,7 @@ const ListRowItem = memo(function ListRowItem({
   getIconPath,
   getDisplayName,
   getFileType,
+  getListIconAlt,
   shouldShowThumbnail,
   isImageFile,
 }: ListRowItemProps) {
@@ -220,7 +222,7 @@ const ListRowItem = memo(function ListRowItem({
         ) : (
           <ThemedIcon
             name={getIconPath(file)}
-            alt={file.isDirectory ? "Directory" : "File"}
+            alt={getListIconAlt(file)}
             className="w-4 h-4"
             style={{ imageRendering: "pixelated" }}
             data-legacy-aware="true"
@@ -852,6 +854,10 @@ export function FileList({
   // Also hide extensions for desktop shortcuts
   // For folders, use translated names
   const getDisplayName = (file: FileItem): string => getFinderDisplayName(file);
+  const getListIconAlt = (file: FileItem): string =>
+    file.isDirectory
+      ? t("apps.finder.fileTypes.directory")
+      : t("apps.finder.fileTypes.file");
   const renderedSelectionRect =
     selectionRect &&
     containerRef.current &&
@@ -905,6 +911,7 @@ export function FileList({
                 getIconPath={getIconPath}
                 getDisplayName={getDisplayName}
                 getFileType={getFileType}
+                getListIconAlt={getListIconAlt}
                 shouldShowThumbnail={shouldShowThumbnail}
                 isImageFile={isImageFile}
               />

--- a/src/lib/locales/de/translation.json
+++ b/src/lib/locales/de/translation.json
@@ -333,6 +333,7 @@
         "appletExportedDescription": "{{fileName}}.app erfolgreich exportiert.",
         "appletImported": "Applet importiert!",
         "appletImportedDescription": "{{fileName}} in /Applets{{iconText}} gespeichert",
+        "appletImportedIconSuffix": "[TODO]  with {{icon}} icon",
         "appletNotFound": "Applet nicht gefunden",
         "appletNotFoundDescription": "Das geteilte Applet wurde möglicherweise gelöscht oder der Link ist ungültig.",
         "appletSaved": "Applet gespeichert",
@@ -713,6 +714,7 @@
         "clear": "Leeren",
         "createAccountToContinue": "Konto erstellen, um fortzufahren...",
         "dailyLimitReached": "Tägliches KI-Nachrichtenlimit erreicht.",
+        "describeThisImage": "[TODO] Describe this image",
         "editing": "bearbeitet...",
         "leave": "Verlassen",
         "listening": "Hören",
@@ -738,6 +740,22 @@
         "typeMessage": "Nachricht eingeben...",
         "typeOrPushSpace": "Tippen oder 'Leertaste' drücken, um zu sprechen...",
         "usingModel": "Verwende {{model}}"
+      },
+      "toasts": {
+        "aiError": "[TODO] AI Error",
+        "failedToGetResponse": "[TODO] Failed to get response.",
+        "failedToSaveTranscript": "[TODO] Failed to save transcript",
+        "loginButton": "[TODO] Login",
+        "loginRequired": "[TODO] Login Required",
+        "open": "[TODO] Open",
+        "pleaseLoginToContinueChatting": "[TODO] Please login to continue chatting.",
+        "rateLimitExceeded": "[TODO] Rate Limit Exceeded",
+        "rateLimitMessageLimitLogin": "[TODO] You've reached the message limit. Please login to continue.",
+        "savedToFileName": "[TODO] Saved to {{fileName}}",
+        "sessionExpiredLoginAgain": "[TODO] Your session has expired. Please login again.",
+        "transcriptSaved": "[TODO] Transcript saved",
+        "transcriptUpdated": "[TODO] Transcript updated",
+        "unknownError": "[TODO] Unknown error"
       },
       "tokenStatus": {
         "authenticated": "Angemeldet",
@@ -3033,18 +3051,17 @@
         "title": "Neuer Kanal",
         "toastSuccess": "Eingestellt auf {{name}}"
       },
-      "youtubePaste": {
-        "added": "„{{title}}“ zu diesem Kanal hinzugefügt",
-        "alreadyInChannel": "Dieses Video ist bereits auf diesem Kanal",
-        "alreadyInLibrary": "Dieses Video ist bereits in Ihrer Mediathek",
-        "needsEditableChannel": "Stellen Sie auf Ryo TV, MTV oder einen eigenen Kanal ein, um Videos per Link hinzuzufügen",
-        "fetchFailed": "Dieses YouTube-Video konnte nicht geladen werden"
-      },
       "delete": {
         "description": "Soll der Kanal „{{name}}“ von deinem Fernseher entfernt werden?",
         "title": "Kanal löschen"
       },
       "description": "Zappe durch YouTube",
+      "drawer": {
+        "close": "[TODO] Hide videos",
+        "empty": "[TODO] No videos on this channel yet.",
+        "removeVideo": "[TODO] Remove from channel",
+        "title": "[TODO] Schedule"
+      },
       "help": {
         "channels": {
           "description": "Zappe durch kuratierte YouTube-Kanäle wie bei einem Fernseher",
@@ -3089,6 +3106,7 @@
         "play": "Wiedergabe",
         "previous": "Zurück",
         "resetChannels": "Kanäle zurücksetzen...",
+        "showVideos": "[TODO] Show Videos",
         "tvHelp": "TV-Hilfe"
       },
       "name": "TV",
@@ -3119,6 +3137,13 @@
         "importSuccess_one": "{{count}} Kanal importiert ({{skipped}} übersprungen)",
         "importSuccess_other": "{{count}} Kanäle importiert ({{skipped}} übersprungen)",
         "resetSuccess": "Kanäle auf Standardwerte zurückgesetzt"
+      },
+      "youtubePaste": {
+        "added": "„{{title}}“ zu diesem Kanal hinzugefügt",
+        "alreadyInChannel": "Dieses Video ist bereits auf diesem Kanal",
+        "alreadyInLibrary": "Dieses Video ist bereits in Ihrer Mediathek",
+        "fetchFailed": "Dieses YouTube-Video konnte nicht geladen werden",
+        "needsEditableChannel": "Stellen Sie auf Ryo TV, MTV oder einen eigenen Kanal ein, um Videos per Link hinzuzufügen"
       }
     },
     "videos": {

--- a/src/lib/locales/en/translation.json
+++ b/src/lib/locales/en/translation.json
@@ -810,6 +810,7 @@
         "transcribing": "Transcribing...",
         "createAccountToContinue": "Create account to continue...",
         "typeMessage": "Type a message...",
+        "describeThisImage": "Describe this image",
         "typeOrPushSpace": "Type or push 'space' to talk...",
         "scrollToBottom": "Scroll to bottom",
         "nudgeSent": "👋 *nudge sent*"
@@ -846,6 +847,22 @@
         "ryo": "Ryo",
         "delete": "Delete",
         "greeting": "👋 hey! i'm ryo. ask me anything!"
+      },
+      "toasts": {
+        "loginRequired": "Login Required",
+        "pleaseLoginToContinueChatting": "Please login to continue chatting.",
+        "loginButton": "Login",
+        "rateLimitExceeded": "Rate Limit Exceeded",
+        "rateLimitMessageLimitLogin": "You've reached the message limit. Please login to continue.",
+        "sessionExpiredLoginAgain": "Your session has expired. Please login again.",
+        "aiError": "AI Error",
+        "failedToGetResponse": "Failed to get response.",
+        "transcriptUpdated": "Transcript updated",
+        "transcriptSaved": "Transcript saved",
+        "savedToFileName": "Saved to {{fileName}}",
+        "open": "Open",
+        "failedToSaveTranscript": "Failed to save transcript",
+        "unknownError": "Unknown error"
       },
       "toolCalls": {
         "loadingMusicLibrary": "Loading music library…",
@@ -2378,6 +2395,7 @@
         "pleaseTryAgainLater": "Please try again later.",
         "appletImported": "Applet imported!",
         "appletImportedDescription": "{{fileName}} saved to /Applets{{iconText}}",
+        "appletImportedIconSuffix": " with {{icon}} icon",
         "importFailed": "Import failed",
         "couldNotImportFile": "Could not import the file.",
         "appletExported": "Applet exported!",

--- a/src/lib/locales/es/translation.json
+++ b/src/lib/locales/es/translation.json
@@ -333,6 +333,7 @@
         "appletExportedDescription": "{{fileName}}.app exportado correctamente.",
         "appletImported": "Applet importado!",
         "appletImportedDescription": "{{fileName}} guardado en /Applets{{iconText}}",
+        "appletImportedIconSuffix": "[TODO]  with {{icon}} icon",
         "appletNotFound": "Applet no encontrado",
         "appletNotFoundDescription": "El applet compartido puede haber sido eliminado o el enlace es inválido.",
         "appletSaved": "Applet guardado",
@@ -713,6 +714,7 @@
         "clear": "Borrar",
         "createAccountToContinue": "Crea una cuenta para continuar...",
         "dailyLimitReached": "Límite diario de mensajes de IA alcanzado.",
+        "describeThisImage": "[TODO] Describe this image",
         "editing": "editando...",
         "leave": "Salir",
         "listening": "Escuchando",
@@ -738,6 +740,22 @@
         "typeMessage": "Escribe un mensaje...",
         "typeOrPushSpace": "Escribe o pulsa 'espacio' para hablar...",
         "usingModel": "Usando {{model}}"
+      },
+      "toasts": {
+        "aiError": "[TODO] AI Error",
+        "failedToGetResponse": "[TODO] Failed to get response.",
+        "failedToSaveTranscript": "[TODO] Failed to save transcript",
+        "loginButton": "[TODO] Login",
+        "loginRequired": "[TODO] Login Required",
+        "open": "[TODO] Open",
+        "pleaseLoginToContinueChatting": "[TODO] Please login to continue chatting.",
+        "rateLimitExceeded": "[TODO] Rate Limit Exceeded",
+        "rateLimitMessageLimitLogin": "[TODO] You've reached the message limit. Please login to continue.",
+        "savedToFileName": "[TODO] Saved to {{fileName}}",
+        "sessionExpiredLoginAgain": "[TODO] Your session has expired. Please login again.",
+        "transcriptSaved": "[TODO] Transcript saved",
+        "transcriptUpdated": "[TODO] Transcript updated",
+        "unknownError": "[TODO] Unknown error"
       },
       "tokenStatus": {
         "authenticated": "Sesión iniciada",
@@ -3033,18 +3051,17 @@
         "title": "Nuevo canal",
         "toastSuccess": "Sintonizado en {{name}}"
       },
-      "youtubePaste": {
-        "added": "Se añadió «{{title}}» a este canal",
-        "alreadyInChannel": "Ese vídeo ya está en este canal",
-        "alreadyInLibrary": "Ese vídeo ya está en tu biblioteca",
-        "needsEditableChannel": "Sintoniza Ryo TV, MTV o un canal personalizado para añadir vídeos desde un enlace",
-        "fetchFailed": "No se pudo cargar ese vídeo de YouTube"
-      },
       "delete": {
         "description": "¿Eliminar el canal \"{{name}}\" de tu TV?",
         "title": "Eliminar canal"
       },
       "description": "Haz zapping en YouTube",
+      "drawer": {
+        "close": "[TODO] Hide videos",
+        "empty": "[TODO] No videos on this channel yet.",
+        "removeVideo": "[TODO] Remove from channel",
+        "title": "[TODO] Schedule"
+      },
       "help": {
         "channels": {
           "description": "Navega por canales de YouTube seleccionados como en una TV",
@@ -3089,6 +3106,7 @@
         "play": "Reproducir",
         "previous": "Anterior",
         "resetChannels": "Restablecer canales...",
+        "showVideos": "[TODO] Show Videos",
         "tvHelp": "Ayuda de TV"
       },
       "name": "TV",
@@ -3119,6 +3137,13 @@
         "importSuccess_one": "Se importó {{count}} canal ({{skipped}} omitido)",
         "importSuccess_other": "Se importaron {{count}} canales ({{skipped}} omitidos)",
         "resetSuccess": "Canales restablecidos a los predeterminados"
+      },
+      "youtubePaste": {
+        "added": "Se añadió «{{title}}» a este canal",
+        "alreadyInChannel": "Ese vídeo ya está en este canal",
+        "alreadyInLibrary": "Ese vídeo ya está en tu biblioteca",
+        "fetchFailed": "No se pudo cargar ese vídeo de YouTube",
+        "needsEditableChannel": "Sintoniza Ryo TV, MTV o un canal personalizado para añadir vídeos desde un enlace"
       }
     },
     "videos": {

--- a/src/lib/locales/fr/translation.json
+++ b/src/lib/locales/fr/translation.json
@@ -333,6 +333,7 @@
         "appletExportedDescription": "{{fileName}}.app exporté avec succès.",
         "appletImported": "Applet importée !",
         "appletImportedDescription": "{{fileName}} enregistré dans /Applets{{iconText}}",
+        "appletImportedIconSuffix": "[TODO]  with {{icon}} icon",
         "appletNotFound": "Applet introuvable",
         "appletNotFoundDescription": "L'applet partagée a peut-être été supprimée ou le lien est invalide.",
         "appletSaved": "Applet enregistrée",
@@ -713,6 +714,7 @@
         "clear": "Effacer",
         "createAccountToContinue": "Créer un compte pour continuer...",
         "dailyLimitReached": "Limite quotidienne de messages IA atteinte.",
+        "describeThisImage": "[TODO] Describe this image",
         "editing": "Modification en cours...",
         "leave": "Quitter",
         "listening": "Écoute",
@@ -738,6 +740,22 @@
         "typeMessage": "Écrire un message...",
         "typeOrPushSpace": "Écrire ou appuyer sur 'espace' pour parler...",
         "usingModel": "Utilisation de {{model}}"
+      },
+      "toasts": {
+        "aiError": "[TODO] AI Error",
+        "failedToGetResponse": "[TODO] Failed to get response.",
+        "failedToSaveTranscript": "[TODO] Failed to save transcript",
+        "loginButton": "[TODO] Login",
+        "loginRequired": "[TODO] Login Required",
+        "open": "[TODO] Open",
+        "pleaseLoginToContinueChatting": "[TODO] Please login to continue chatting.",
+        "rateLimitExceeded": "[TODO] Rate Limit Exceeded",
+        "rateLimitMessageLimitLogin": "[TODO] You've reached the message limit. Please login to continue.",
+        "savedToFileName": "[TODO] Saved to {{fileName}}",
+        "sessionExpiredLoginAgain": "[TODO] Your session has expired. Please login again.",
+        "transcriptSaved": "[TODO] Transcript saved",
+        "transcriptUpdated": "[TODO] Transcript updated",
+        "unknownError": "[TODO] Unknown error"
       },
       "tokenStatus": {
         "authenticated": "Connecté",
@@ -3033,18 +3051,17 @@
         "title": "Nouvelle chaîne",
         "toastSuccess": "À l'écoute de {{name}}"
       },
-      "youtubePaste": {
-        "added": "« {{title}} » ajouté à cette chaîne",
-        "alreadyInChannel": "Cette vidéo est déjà sur cette chaîne",
-        "alreadyInLibrary": "Cette vidéo est déjà dans votre bibliothèque",
-        "needsEditableChannel": "Accordez-vous sur Ryo TV, MTV ou une chaîne personnalisée pour ajouter une vidéo depuis un lien",
-        "fetchFailed": "Impossible de charger cette vidéo YouTube"
-      },
       "delete": {
         "description": "Supprimer la chaîne « {{name}} » de votre téléviseur ?",
         "title": "Supprimer la chaîne"
       },
       "description": "Zappez sur YouTube",
+      "drawer": {
+        "close": "[TODO] Hide videos",
+        "empty": "[TODO] No videos on this channel yet.",
+        "removeVideo": "[TODO] Remove from channel",
+        "title": "[TODO] Schedule"
+      },
       "help": {
         "channels": {
           "description": "Parcourez des chaînes YouTube sélectionnées comme sur un téléviseur",
@@ -3089,6 +3106,7 @@
         "play": "Lecture",
         "previous": "Précédent",
         "resetChannels": "Réinitialiser les chaînes...",
+        "showVideos": "[TODO] Show Videos",
         "tvHelp": "Aide TV"
       },
       "name": "TV",
@@ -3119,6 +3137,13 @@
         "importSuccess_one": "{{count}} chaîne importée ({{skipped}} ignorée)",
         "importSuccess_other": "{{count}} chaînes importées ({{skipped}} ignorées)",
         "resetSuccess": "Chaînes réinitialisées par défaut"
+      },
+      "youtubePaste": {
+        "added": "« {{title}} » ajouté à cette chaîne",
+        "alreadyInChannel": "Cette vidéo est déjà sur cette chaîne",
+        "alreadyInLibrary": "Cette vidéo est déjà dans votre bibliothèque",
+        "fetchFailed": "Impossible de charger cette vidéo YouTube",
+        "needsEditableChannel": "Accordez-vous sur Ryo TV, MTV ou une chaîne personnalisée pour ajouter une vidéo depuis un lien"
       }
     },
     "videos": {

--- a/src/lib/locales/it/translation.json
+++ b/src/lib/locales/it/translation.json
@@ -333,6 +333,7 @@
         "appletExportedDescription": "{{fileName}}.app esportato correttamente.",
         "appletImported": "Applet importata!",
         "appletImportedDescription": "{{fileName}} salvato in /Applets{{iconText}}",
+        "appletImportedIconSuffix": "[TODO]  with {{icon}} icon",
         "appletNotFound": "Applet non trovata",
         "appletNotFoundDescription": "L'applet condivisa potrebbe essere stata eliminata o il link non è valido.",
         "appletSaved": "Applet salvata",
@@ -713,6 +714,7 @@
         "clear": "Cancella",
         "createAccountToContinue": "Crea un account per continuare...",
         "dailyLimitReached": "Limite giornaliero di messaggi IA raggiunto.",
+        "describeThisImage": "[TODO] Describe this image",
         "editing": "modifica in corso...",
         "leave": "Esci",
         "listening": "In ascolto",
@@ -738,6 +740,22 @@
         "typeMessage": "Digita un messaggio...",
         "typeOrPushSpace": "Digita o premi 'spazio' per parlare...",
         "usingModel": "Utilizzo di {{model}}"
+      },
+      "toasts": {
+        "aiError": "[TODO] AI Error",
+        "failedToGetResponse": "[TODO] Failed to get response.",
+        "failedToSaveTranscript": "[TODO] Failed to save transcript",
+        "loginButton": "[TODO] Login",
+        "loginRequired": "[TODO] Login Required",
+        "open": "[TODO] Open",
+        "pleaseLoginToContinueChatting": "[TODO] Please login to continue chatting.",
+        "rateLimitExceeded": "[TODO] Rate Limit Exceeded",
+        "rateLimitMessageLimitLogin": "[TODO] You've reached the message limit. Please login to continue.",
+        "savedToFileName": "[TODO] Saved to {{fileName}}",
+        "sessionExpiredLoginAgain": "[TODO] Your session has expired. Please login again.",
+        "transcriptSaved": "[TODO] Transcript saved",
+        "transcriptUpdated": "[TODO] Transcript updated",
+        "unknownError": "[TODO] Unknown error"
       },
       "tokenStatus": {
         "authenticated": "Accesso effettuato",
@@ -3033,18 +3051,17 @@
         "title": "Nuovo canale",
         "toastSuccess": "Sintonizzato su {{name}}"
       },
-      "youtubePaste": {
-        "added": "Aggiunto «{{title}}» a questo canale",
-        "alreadyInChannel": "Questo video è già su questo canale",
-        "alreadyInLibrary": "Questo video è già nella tua libreria",
-        "needsEditableChannel": "Sintonizza Ryo TV, MTV o un canale personalizzato per aggiungere video da un link",
-        "fetchFailed": "Impossibile caricare quel video di YouTube"
-      },
       "delete": {
         "description": "Rimuovere il canale \"{{name}}\" dalla tua TV?",
         "title": "Elimina canale"
       },
       "description": "Fai zapping su YouTube",
+      "drawer": {
+        "close": "[TODO] Hide videos",
+        "empty": "[TODO] No videos on this channel yet.",
+        "removeVideo": "[TODO] Remove from channel",
+        "title": "[TODO] Schedule"
+      },
       "help": {
         "channels": {
           "description": "Sfoglia canali YouTube selezionati come in TV",
@@ -3089,6 +3106,7 @@
         "play": "Riproduci",
         "previous": "Precedente",
         "resetChannels": "Ripristina canali...",
+        "showVideos": "[TODO] Show Videos",
         "tvHelp": "Aiuto TV"
       },
       "name": "TV",
@@ -3119,6 +3137,13 @@
         "importSuccess_one": "Importato {{count}} canale ({{skipped}} ignorati)",
         "importSuccess_other": "Importati {{count}} canali ({{skipped}} ignorati)",
         "resetSuccess": "Canali ripristinati ai valori predefiniti"
+      },
+      "youtubePaste": {
+        "added": "Aggiunto «{{title}}» a questo canale",
+        "alreadyInChannel": "Questo video è già su questo canale",
+        "alreadyInLibrary": "Questo video è già nella tua libreria",
+        "fetchFailed": "Impossibile caricare quel video di YouTube",
+        "needsEditableChannel": "Sintonizza Ryo TV, MTV o un canale personalizzato per aggiungere video da un link"
       }
     },
     "videos": {

--- a/src/lib/locales/ja/translation.json
+++ b/src/lib/locales/ja/translation.json
@@ -333,6 +333,7 @@
         "appletExportedDescription": "{{fileName}}.app をエクスポートしました。",
         "appletImported": "アプレットをインポートしました！",
         "appletImportedDescription": "{{fileName}} を /Applets{{iconText}} に保存しました",
+        "appletImportedIconSuffix": "[TODO]  with {{icon}} icon",
         "appletNotFound": "アプレットが見つかりません",
         "appletNotFoundDescription": "共有されたアプレットが削除されたか、リンクが無効な可能性があります。",
         "appletSaved": "アプレットを保存しました",
@@ -713,6 +714,7 @@
         "clear": "クリア",
         "createAccountToContinue": "続けるにはアカウントを作成してください...",
         "dailyLimitReached": "1日のAIメッセージ制限に達しました。",
+        "describeThisImage": "[TODO] Describe this image",
         "editing": "編集中...",
         "leave": "退出",
         "listening": "聴取中",
@@ -738,6 +740,22 @@
         "typeMessage": "メッセージを入力...",
         "typeOrPushSpace": "入力または「スペース」を押して話す...",
         "usingModel": "{{model}}を使用中"
+      },
+      "toasts": {
+        "aiError": "[TODO] AI Error",
+        "failedToGetResponse": "[TODO] Failed to get response.",
+        "failedToSaveTranscript": "[TODO] Failed to save transcript",
+        "loginButton": "[TODO] Login",
+        "loginRequired": "[TODO] Login Required",
+        "open": "[TODO] Open",
+        "pleaseLoginToContinueChatting": "[TODO] Please login to continue chatting.",
+        "rateLimitExceeded": "[TODO] Rate Limit Exceeded",
+        "rateLimitMessageLimitLogin": "[TODO] You've reached the message limit. Please login to continue.",
+        "savedToFileName": "[TODO] Saved to {{fileName}}",
+        "sessionExpiredLoginAgain": "[TODO] Your session has expired. Please login again.",
+        "transcriptSaved": "[TODO] Transcript saved",
+        "transcriptUpdated": "[TODO] Transcript updated",
+        "unknownError": "[TODO] Unknown error"
       },
       "tokenStatus": {
         "authenticated": "ログイン済み",
@@ -3033,18 +3051,17 @@
         "title": "新規チャンネル",
         "toastSuccess": "{{name}} を視聴中"
       },
-      "youtubePaste": {
-        "added": "「{{title}}」をこのチャンネルに追加しました",
-        "alreadyInChannel": "その動画はすでにこのチャンネルにあります",
-        "alreadyInLibrary": "その動画はすでにライブラリにあります",
-        "needsEditableChannel": "リンクから追加するには、Ryo TV、MTV、またはカスタムチャンネルに合わせてください",
-        "fetchFailed": "そのYouTube動画を読み込めませんでした"
-      },
       "delete": {
         "description": "テレビからチャンネル「{{name}}」を削除しますか？",
         "title": "チャンネルを削除"
       },
       "description": "YouTubeをザッピング",
+      "drawer": {
+        "close": "[TODO] Hide videos",
+        "empty": "[TODO] No videos on this channel yet.",
+        "removeVideo": "[TODO] Remove from channel",
+        "title": "[TODO] Schedule"
+      },
       "help": {
         "channels": {
           "description": "テレビのように、厳選されたYouTubeチャンネルをザッピングできます。",
@@ -3089,6 +3106,7 @@
         "play": "再生",
         "previous": "前へ",
         "resetChannels": "チャンネルをリセット...",
+        "showVideos": "[TODO] Show Videos",
         "tvHelp": "TVヘルプ"
       },
       "name": "TV",
@@ -3119,6 +3137,13 @@
         "importSuccess_one": "{{count}}個のチャンネルをインポートしました（{{skipped}}個をスキップ）",
         "importSuccess_other": "{{count}}個のチャンネルをインポートしました（{{skipped}}個をスキップ）",
         "resetSuccess": "チャンネルをデフォルトにリセットしました"
+      },
+      "youtubePaste": {
+        "added": "「{{title}}」をこのチャンネルに追加しました",
+        "alreadyInChannel": "その動画はすでにこのチャンネルにあります",
+        "alreadyInLibrary": "その動画はすでにライブラリにあります",
+        "fetchFailed": "そのYouTube動画を読み込めませんでした",
+        "needsEditableChannel": "リンクから追加するには、Ryo TV、MTV、またはカスタムチャンネルに合わせてください"
       }
     },
     "videos": {

--- a/src/lib/locales/ko/translation.json
+++ b/src/lib/locales/ko/translation.json
@@ -333,6 +333,7 @@
         "appletExportedDescription": "{{fileName}}.app이 성공적으로 내보내졌습니다.",
         "appletImported": "애플릿 가져오기 완료!",
         "appletImportedDescription": "{{fileName}}이(가) /Applets{{iconText}}에 저장되었습니다",
+        "appletImportedIconSuffix": "[TODO]  with {{icon}} icon",
         "appletNotFound": "애플릿을 찾을 수 없습니다",
         "appletNotFoundDescription": "공유된 애플릿이 삭제되었거나 링크가 유효하지 않을 수 있습니다.",
         "appletSaved": "애플릿 저장됨",
@@ -713,6 +714,7 @@
         "clear": "지우기",
         "createAccountToContinue": "계속하려면 계정을 만드세요...",
         "dailyLimitReached": "일일 AI 메시지 한도에 도달했습니다.",
+        "describeThisImage": "[TODO] Describe this image",
         "editing": "편집 중...",
         "leave": "나가기",
         "listening": "듣는 중",
@@ -738,6 +740,22 @@
         "typeMessage": "메시지를 입력하세요...",
         "typeOrPushSpace": "입력하거나 '스페이스'를 눌러 말하세요...",
         "usingModel": "{{model}} 사용 중"
+      },
+      "toasts": {
+        "aiError": "[TODO] AI Error",
+        "failedToGetResponse": "[TODO] Failed to get response.",
+        "failedToSaveTranscript": "[TODO] Failed to save transcript",
+        "loginButton": "[TODO] Login",
+        "loginRequired": "[TODO] Login Required",
+        "open": "[TODO] Open",
+        "pleaseLoginToContinueChatting": "[TODO] Please login to continue chatting.",
+        "rateLimitExceeded": "[TODO] Rate Limit Exceeded",
+        "rateLimitMessageLimitLogin": "[TODO] You've reached the message limit. Please login to continue.",
+        "savedToFileName": "[TODO] Saved to {{fileName}}",
+        "sessionExpiredLoginAgain": "[TODO] Your session has expired. Please login again.",
+        "transcriptSaved": "[TODO] Transcript saved",
+        "transcriptUpdated": "[TODO] Transcript updated",
+        "unknownError": "[TODO] Unknown error"
       },
       "tokenStatus": {
         "authenticated": "로그인됨",
@@ -3033,18 +3051,17 @@
         "title": "새 채널",
         "toastSuccess": "{{name}} 청취 중"
       },
-      "youtubePaste": {
-        "added": "이 채널에 \"{{title}}\"을(를) 추가했습니다",
-        "alreadyInChannel": "해당 영상은 이미 이 채널에 있습니다",
-        "alreadyInLibrary": "해당 영상은 이미 라이브러리에 있습니다",
-        "needsEditableChannel": "링크로 영상을 추가하려면 Ryo TV, MTV 또는 사용자 지정 채널로 맞추세요",
-        "fetchFailed": "해당 YouTube 영상을 불러올 수 없습니다"
-      },
       "delete": {
         "description": "TV에서 \"{{name}}\" 채널을 삭제하시겠습니까?",
         "title": "채널 삭제"
       },
       "description": "YouTube 채널 서핑",
+      "drawer": {
+        "close": "[TODO] Hide videos",
+        "empty": "[TODO] No videos on this channel yet.",
+        "removeVideo": "[TODO] Remove from channel",
+        "title": "[TODO] Schedule"
+      },
       "help": {
         "channels": {
           "description": "TV처럼 큐레이션된 YouTube 채널을 넘겨보세요",
@@ -3089,6 +3106,7 @@
         "play": "재생",
         "previous": "이전",
         "resetChannels": "채널 재설정...",
+        "showVideos": "[TODO] Show Videos",
         "tvHelp": "TV 도움말"
       },
       "name": "TV",
@@ -3119,6 +3137,13 @@
         "importSuccess_one": "{{count}}개의 채널을 가져왔습니다 ({{skipped}}개 건너뜀)",
         "importSuccess_other": "{{count}}개의 채널을 가져왔습니다 ({{skipped}}개 건너뜀)",
         "resetSuccess": "채널이 기본값으로 재설정되었습니다"
+      },
+      "youtubePaste": {
+        "added": "이 채널에 \"{{title}}\"을(를) 추가했습니다",
+        "alreadyInChannel": "해당 영상은 이미 이 채널에 있습니다",
+        "alreadyInLibrary": "해당 영상은 이미 라이브러리에 있습니다",
+        "fetchFailed": "해당 YouTube 영상을 불러올 수 없습니다",
+        "needsEditableChannel": "링크로 영상을 추가하려면 Ryo TV, MTV 또는 사용자 지정 채널로 맞추세요"
       }
     },
     "videos": {

--- a/src/lib/locales/pt/translation.json
+++ b/src/lib/locales/pt/translation.json
@@ -333,6 +333,7 @@
         "appletExportedDescription": "{{fileName}}.app exportado com sucesso.",
         "appletImported": "Applet importado!",
         "appletImportedDescription": "{{fileName}} salvo em /Applets{{iconText}}",
+        "appletImportedIconSuffix": "[TODO]  with {{icon}} icon",
         "appletNotFound": "Applet não encontrado",
         "appletNotFoundDescription": "O applet compartilhado pode ter sido excluído ou o link é inválido.",
         "appletSaved": "Applet salvo",
@@ -713,6 +714,7 @@
         "clear": "Limpar",
         "createAccountToContinue": "Crie uma conta para continuar...",
         "dailyLimitReached": "Limite diário de mensagens da IA atingido.",
+        "describeThisImage": "[TODO] Describe this image",
         "editing": "editando...",
         "leave": "Sair",
         "listening": "Ouvindo",
@@ -738,6 +740,22 @@
         "typeMessage": "Digite uma mensagem...",
         "typeOrPushSpace": "Digite ou pressione 'espaço' para falar...",
         "usingModel": "Usando {{model}}"
+      },
+      "toasts": {
+        "aiError": "[TODO] AI Error",
+        "failedToGetResponse": "[TODO] Failed to get response.",
+        "failedToSaveTranscript": "[TODO] Failed to save transcript",
+        "loginButton": "[TODO] Login",
+        "loginRequired": "[TODO] Login Required",
+        "open": "[TODO] Open",
+        "pleaseLoginToContinueChatting": "[TODO] Please login to continue chatting.",
+        "rateLimitExceeded": "[TODO] Rate Limit Exceeded",
+        "rateLimitMessageLimitLogin": "[TODO] You've reached the message limit. Please login to continue.",
+        "savedToFileName": "[TODO] Saved to {{fileName}}",
+        "sessionExpiredLoginAgain": "[TODO] Your session has expired. Please login again.",
+        "transcriptSaved": "[TODO] Transcript saved",
+        "transcriptUpdated": "[TODO] Transcript updated",
+        "unknownError": "[TODO] Unknown error"
       },
       "tokenStatus": {
         "authenticated": "Sessão iniciada",
@@ -3033,18 +3051,17 @@
         "title": "Novo Canal",
         "toastSuccess": "Sintonizado em {{name}}"
       },
-      "youtubePaste": {
-        "added": "«{{title}}» adicionado a este canal",
-        "alreadyInChannel": "Esse vídeo já está neste canal",
-        "alreadyInLibrary": "Esse vídeo já está na sua biblioteca",
-        "needsEditableChannel": "Sintonize Ryo TV, MTV ou um canal personalizado para adicionar vídeos por link",
-        "fetchFailed": "Não foi possível carregar esse vídeo do YouTube"
-      },
       "delete": {
         "description": "Remover o canal \"{{name}}\" da sua TV?",
         "title": "Excluir Canal"
       },
       "description": "Zapeie pelo YouTube",
+      "drawer": {
+        "close": "[TODO] Hide videos",
+        "empty": "[TODO] No videos on this channel yet.",
+        "removeVideo": "[TODO] Remove from channel",
+        "title": "[TODO] Schedule"
+      },
       "help": {
         "channels": {
           "description": "Navegue por canais selecionados do YouTube como em uma TV",
@@ -3089,6 +3106,7 @@
         "play": "Reproduzir",
         "previous": "Anterior",
         "resetChannels": "Redefinir canais...",
+        "showVideos": "[TODO] Show Videos",
         "tvHelp": "Ajuda da TV"
       },
       "name": "TV",
@@ -3119,6 +3137,13 @@
         "importSuccess_one": "Importado {{count}} canal ({{skipped}} ignorado)",
         "importSuccess_other": "Importados {{count}} canais ({{skipped}} ignorados)",
         "resetSuccess": "Canais redefinidos para os padrões"
+      },
+      "youtubePaste": {
+        "added": "«{{title}}» adicionado a este canal",
+        "alreadyInChannel": "Esse vídeo já está neste canal",
+        "alreadyInLibrary": "Esse vídeo já está na sua biblioteca",
+        "fetchFailed": "Não foi possível carregar esse vídeo do YouTube",
+        "needsEditableChannel": "Sintonize Ryo TV, MTV ou um canal personalizado para adicionar vídeos por link"
       }
     },
     "videos": {

--- a/src/lib/locales/ru/translation.json
+++ b/src/lib/locales/ru/translation.json
@@ -333,6 +333,7 @@
         "appletExportedDescription": "{{fileName}}.app успешно экспортирован.",
         "appletImported": "Апплет импортирован!",
         "appletImportedDescription": "{{fileName}} сохранен в /Applets{{iconText}}",
+        "appletImportedIconSuffix": "[TODO]  with {{icon}} icon",
         "appletNotFound": "Апплет не найден",
         "appletNotFoundDescription": "Общий апплет, возможно, был удален, или ссылка недействительна.",
         "appletSaved": "Апплет сохранен",
@@ -713,6 +714,7 @@
         "clear": "Очистить",
         "createAccountToContinue": "Создайте аккаунт, чтобы продолжить...",
         "dailyLimitReached": "Достигнут дневной лимит сообщений ИИ.",
+        "describeThisImage": "[TODO] Describe this image",
         "editing": "редактирование...",
         "leave": "Покинуть",
         "listening": "Слушаю",
@@ -738,6 +740,22 @@
         "typeMessage": "Введите сообщение...",
         "typeOrPushSpace": "Наберите текст или нажмите 'пробел', чтобы говорить...",
         "usingModel": "Используется {{model}}"
+      },
+      "toasts": {
+        "aiError": "[TODO] AI Error",
+        "failedToGetResponse": "[TODO] Failed to get response.",
+        "failedToSaveTranscript": "[TODO] Failed to save transcript",
+        "loginButton": "[TODO] Login",
+        "loginRequired": "[TODO] Login Required",
+        "open": "[TODO] Open",
+        "pleaseLoginToContinueChatting": "[TODO] Please login to continue chatting.",
+        "rateLimitExceeded": "[TODO] Rate Limit Exceeded",
+        "rateLimitMessageLimitLogin": "[TODO] You've reached the message limit. Please login to continue.",
+        "savedToFileName": "[TODO] Saved to {{fileName}}",
+        "sessionExpiredLoginAgain": "[TODO] Your session has expired. Please login again.",
+        "transcriptSaved": "[TODO] Transcript saved",
+        "transcriptUpdated": "[TODO] Transcript updated",
+        "unknownError": "[TODO] Unknown error"
       },
       "tokenStatus": {
         "authenticated": "Выполнен вход",
@@ -3033,18 +3051,17 @@
         "title": "Новый канал",
         "toastSuccess": "Настроено на {{name}}"
       },
-      "youtubePaste": {
-        "added": "Добавлено «{{title}}» на этот канал",
-        "alreadyInChannel": "Это видео уже есть на этом канале",
-        "alreadyInLibrary": "Это видео уже есть в вашей библиотеке",
-        "needsEditableChannel": "Переключитесь на Ryo TV, MTV или свой канал, чтобы добавить видео по ссылке",
-        "fetchFailed": "Не удалось загрузить это видео с YouTube"
-      },
       "delete": {
         "description": "Удалить канал «{{name}}» с вашего телевизора?",
         "title": "Удалить канал"
       },
       "description": "Сёрфинг по каналам YouTube",
+      "drawer": {
+        "close": "[TODO] Hide videos",
+        "empty": "[TODO] No videos on this channel yet.",
+        "removeVideo": "[TODO] Remove from channel",
+        "title": "[TODO] Schedule"
+      },
       "help": {
         "channels": {
           "description": "Листайте тематические каналы YouTube, как на телевизоре",
@@ -3089,6 +3106,7 @@
         "play": "Воспроизвести",
         "previous": "Предыдущий",
         "resetChannels": "Сбросить каналы...",
+        "showVideos": "[TODO] Show Videos",
         "tvHelp": "Справка ТВ"
       },
       "name": "ТВ",
@@ -3119,6 +3137,13 @@
         "importSuccess_one": "Импортирован {{count}} канал ({{skipped}} пропущено)",
         "importSuccess_other": "Импортировано {{count}} каналов ({{skipped}} пропущено)",
         "resetSuccess": "Каналы сброшены к значениям по умолчанию"
+      },
+      "youtubePaste": {
+        "added": "Добавлено «{{title}}» на этот канал",
+        "alreadyInChannel": "Это видео уже есть на этом канале",
+        "alreadyInLibrary": "Это видео уже есть в вашей библиотеке",
+        "fetchFailed": "Не удалось загрузить это видео с YouTube",
+        "needsEditableChannel": "Переключитесь на Ryo TV, MTV или свой канал, чтобы добавить видео по ссылке"
       }
     },
     "videos": {

--- a/src/lib/locales/zh-TW/translation.json
+++ b/src/lib/locales/zh-TW/translation.json
@@ -333,6 +333,7 @@
         "appletExportedDescription": "{{fileName}}.app 已成功匯出。",
         "appletImported": "小程式已匯入！",
         "appletImportedDescription": "{{fileName}} 已儲存至 /Applets{{iconText}}",
+        "appletImportedIconSuffix": "[TODO]  with {{icon}} icon",
         "appletNotFound": "找不到小程式",
         "appletNotFoundDescription": "該分享的小程式可能已被刪除或連結無效。",
         "appletSaved": "小程式已儲存",
@@ -713,6 +714,7 @@
         "clear": "清除",
         "createAccountToContinue": "建立帳戶以繼續...",
         "dailyLimitReached": "已達每日 AI 訊息限制。",
+        "describeThisImage": "[TODO] Describe this image",
         "editing": "正在編輯...",
         "leave": "離開",
         "listening": "聆聽中",
@@ -738,6 +740,22 @@
         "typeMessage": "輸入訊息...",
         "typeOrPushSpace": "輸入或按空白鍵說話...",
         "usingModel": "使用 {{model}}"
+      },
+      "toasts": {
+        "aiError": "[TODO] AI Error",
+        "failedToGetResponse": "[TODO] Failed to get response.",
+        "failedToSaveTranscript": "[TODO] Failed to save transcript",
+        "loginButton": "[TODO] Login",
+        "loginRequired": "[TODO] Login Required",
+        "open": "[TODO] Open",
+        "pleaseLoginToContinueChatting": "[TODO] Please login to continue chatting.",
+        "rateLimitExceeded": "[TODO] Rate Limit Exceeded",
+        "rateLimitMessageLimitLogin": "[TODO] You've reached the message limit. Please login to continue.",
+        "savedToFileName": "[TODO] Saved to {{fileName}}",
+        "sessionExpiredLoginAgain": "[TODO] Your session has expired. Please login again.",
+        "transcriptSaved": "[TODO] Transcript saved",
+        "transcriptUpdated": "[TODO] Transcript updated",
+        "unknownError": "[TODO] Unknown error"
       },
       "tokenStatus": {
         "authenticated": "已登入",
@@ -3033,18 +3051,17 @@
         "title": "新頻道",
         "toastSuccess": "正在收聽 {{name}}"
       },
-      "youtubePaste": {
-        "added": "已將「{{title}}」加入此頻道",
-        "alreadyInChannel": "該影片已在此頻道中",
-        "alreadyInLibrary": "該影片已在您的媒體庫中",
-        "needsEditableChannel": "請切換到 Ryo TV、MTV 或自訂頻道，才能透過連結新增影片",
-        "fetchFailed": "無法載入該 YouTube 影片"
-      },
       "delete": {
         "description": "要從您的電視移除「{{name}}」頻道嗎？",
         "title": "刪除頻道"
       },
       "description": "在 YouTube 上轉台",
+      "drawer": {
+        "close": "[TODO] Hide videos",
+        "empty": "[TODO] No videos on this channel yet.",
+        "removeVideo": "[TODO] Remove from channel",
+        "title": "[TODO] Schedule"
+      },
       "help": {
         "channels": {
           "description": "像看電視一樣切換精選的 YouTube 頻道",
@@ -3089,6 +3106,7 @@
         "play": "播放",
         "previous": "上一個",
         "resetChannels": "重設頻道...",
+        "showVideos": "[TODO] Show Videos",
         "tvHelp": "電視說明"
       },
       "name": "電視",
@@ -3119,6 +3137,13 @@
         "importSuccess_one": "已匯入 {{count}} 個頻道 (已跳過 {{skipped}} 個)",
         "importSuccess_other": "已匯入 {{count}} 個頻道 (已跳過 {{skipped}} 個)",
         "resetSuccess": "頻道已重設為預設值"
+      },
+      "youtubePaste": {
+        "added": "已將「{{title}}」加入此頻道",
+        "alreadyInChannel": "該影片已在此頻道中",
+        "alreadyInLibrary": "該影片已在您的媒體庫中",
+        "fetchFailed": "無法載入該 YouTube 影片",
+        "needsEditableChannel": "請切換到 Ryo TV、MTV 或自訂頻道，才能透過連結新增影片"
       }
     },
     "videos": {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**Summary**

- **Chats:** Replaced hardcoded Sonner toasts in `useAiChat` (login required, rate limit, session expiry, AI errors, transcript save/open) with `i18n.t` / `apps.chats.toasts.*`. Localized the empty-caption fallback for image sends via `apps.chats.status.describeThisImage`.
- **Applet Viewer:** Routed import/export, sharing, shared-applet load/save, batch update, and “all up to date” toasts through existing `apps.applet-viewer.dialogs.*` / `status.*` keys; added `appletImportedIconSuffix` for the optional emoji fragment in import descriptions.
- **Finder:** List view `ThemedIcon` `alt` text now uses `apps.finder.fileTypes.directory` / `file`.

Ran `bun run build` successfully.

**Localization audit note (remaining gaps / categories)**

- **Per-app `metadata.ts` onboarding/help titles and descriptions** — still English-only at source (Finder, Calendar, Chats, TV, Admin, etc.); convention today is `useTranslatedHelpItems` for Help menu only, not launcher copy.
- **Tool / API oriented strings** — literal tokens like `"file"`, `"DELETE"` in handlers often denote protocol or MIME, not UI; only user-visible surfaces should be wrapped.
- **Language picker labels** (e.g. iPod/Karaoke `label: "English"`) — native language names; may stay as-is by design.
- **Admin and internal panels** — many English strings and toasts in admin/control-panels logic not covered here.
- **Dynamic / server messages** — error bodies from APIs often stay English until backend localization exists.

Non-English locale files received new keys via `bun run i18n:sync:mark-todo` (`[TODO]` placeholders until machine translation or manual review).


<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-351e7d8e-7ea5-4abe-b21d-869f9148645a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-351e7d8e-7ea5-4abe-b21d-869f9148645a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

