### PR TITLE
fix: reactive "auto" lyrics translation when ryOS language changes

### DIFF
--- a/src/apps/ipod/hooks/useIpodLogic.ts
+++ b/src/apps/ipod/hooks/useIpodLogic.ts
@@ -57,7 +57,7 @@ export function useIpodLogic({
   initialData,
   instanceId,
 }: UseIpodLogicOptions) {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const { play: playClickSound } = useSound(Sounds.BUTTON_CLICK);
   const { play: playScrollSound } = useSound(Sounds.IPOD_CLICK_WHEEL);
   const vibrate = useVibration(100, 50);
@@ -1509,10 +1509,11 @@ export function useIpodLogic({
     };
   }, [lyricsSourceOverride]);
 
-  // Resolve "auto" translation language to actual ryOS locale
+  // Resolve "auto" translation language to actual ryOS locale (must track i18n so UI updates when system language changes)
+  const appLanguage = i18n.resolvedLanguage ?? i18n.language;
   const effectiveTranslationLanguage = useMemo(
     () => getEffectiveTranslationLanguage(lyricsTranslationLanguage),
-    [lyricsTranslationLanguage]
+    [lyricsTranslationLanguage, appLanguage]
   );
 
   const fullScreenLyricsControls = useLyrics({

--- a/src/apps/karaoke/components/KaraokeLyricsPlayback.tsx
+++ b/src/apps/karaoke/components/KaraokeLyricsPlayback.tsx
@@ -9,6 +9,7 @@ import {
   type ReactNode,
 } from "react";
 import type { TFunction } from "i18next";
+import { useTranslation } from "react-i18next";
 import { useShallow } from "zustand/react/shallow";
 import { AnimatePresence, motion } from "framer-motion";
 import { useLyrics } from "@/hooks/useLyrics";
@@ -85,6 +86,8 @@ export function KaraokeLyricsPlaybackProvider({
   auth,
   lyricsPlaybackSyncRef,
 }: ProviderProps) {
+  const { i18n } = useTranslation();
+  const appLanguage = i18n.resolvedLanguage ?? i18n.language;
   const elapsedTime = useKaraokeStore(useShallow((s) => s.elapsedTime));
 
   const lyricsFontClassName = getLyricsFontClassName(lyricsFont ?? LyricsFontEnum.SerifRed);
@@ -102,7 +105,7 @@ export function KaraokeLyricsPlaybackProvider({
 
   const effectiveTranslationLanguage = useMemo(
     () => getEffectiveTranslationLanguage(lyricsTranslationLanguage),
-    [lyricsTranslationLanguage]
+    [lyricsTranslationLanguage, appLanguage]
   );
 
   const lyricsControls = useLyrics({

--- a/tests/test-cloud-sync-launch-and-store.test.ts
+++ b/tests/test-cloud-sync-launch-and-store.test.ts
@@ -1,4 +1,4 @@
-import { beforeAll, beforeEach, describe, expect, test } from "bun:test";
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
 import { shouldRequestCloudSyncOnAppLaunch } from "../src/utils/cloudSyncLaunch";
 import {
   beginApplyingRemoteDomain,
@@ -41,6 +41,7 @@ type IpodStoreModule = typeof import("../src/stores/useIpodStore");
 
 const browserGlobals = globalThis as typeof globalThis & {
   localStorage?: Storage;
+  window?: typeof globalThis;
 };
 
 let storeModulePromise: Promise<StoreModule> | null = null;
@@ -324,5 +325,67 @@ describe("cloud sync store download audit timestamps", () => {
     expect(useCloudSyncStore.getState().domainStatus.settings.lastFetchedAt).toBe(
       metadata.updatedAt
     );
+  });
+});
+
+describe("getEffectiveTranslationLanguage", () => {
+  let ensureLanguageResources: (language: string) => Promise<void>;
+  let i18nDefault: typeof import("../src/lib/i18n").default;
+
+  beforeAll(async () => {
+    browserGlobals.window = globalThis as typeof globalThis;
+    if (!globalThis.navigator?.language) {
+      Object.defineProperty(globalThis, "navigator", {
+        value: { languages: ["en-US"], language: "en-US" },
+        configurable: true,
+      });
+    }
+    const i18nMod = await import("../src/lib/i18n");
+    ensureLanguageResources = i18nMod.ensureLanguageResources;
+    i18nDefault = i18nMod.default;
+    const storage = browserGlobals.localStorage ?? new MemoryStorage();
+    browserGlobals.localStorage = storage;
+    Object.defineProperty(browserGlobals.window, "localStorage", {
+      value: storage,
+      configurable: true,
+    });
+    await i18nMod.initializeI18n();
+  });
+
+  beforeEach(() => {
+    if (browserGlobals.window && browserGlobals.localStorage) {
+      Object.defineProperty(browserGlobals.window, "localStorage", {
+        value: browserGlobals.localStorage,
+        configurable: true,
+      });
+    }
+  });
+
+  afterAll(async () => {
+    await ensureLanguageResources("en");
+    await i18nDefault.changeLanguage("en");
+  });
+
+  test('"auto" resolves to the current i18n language after changeLanguage', async () => {
+    const { getEffectiveTranslationLanguage, LYRICS_TRANSLATION_AUTO } =
+      await getIpodStoreModule();
+    const before = i18nDefault.resolvedLanguage || i18nDefault.language;
+    expect(getEffectiveTranslationLanguage(LYRICS_TRANSLATION_AUTO)).toBe(before);
+
+    await ensureLanguageResources("ja");
+    await i18nDefault.changeLanguage("ja");
+    expect(getEffectiveTranslationLanguage(LYRICS_TRANSLATION_AUTO)).toBe("ja");
+  });
+
+  test("null stays off (original lyrics)", async () => {
+    const { getEffectiveTranslationLanguage } = await getIpodStoreModule();
+    expect(getEffectiveTranslationLanguage(null)).toBeNull();
+  });
+
+  test("explicit codes are unaffected by app locale", async () => {
+    const { getEffectiveTranslationLanguage } = await getIpodStoreModule();
+    await ensureLanguageResources("ja");
+    await i18nDefault.changeLanguage("ja");
+    expect(getEffectiveTranslationLanguage("de")).toBe("de");
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Fixes Karaoke and iPod so **Lyrics translation → Auto** follows the **current ryOS locale** immediately after switching system language, without toggling the setting or restarting the app.

## Root cause
`getEffectiveTranslationLanguage()` already maps `"auto"` to `i18n.language` at **read time**, but both call sites wrapped it in `useMemo` with **only** `lyricsTranslationLanguage` as a dependency. When the user changed the app language, the stored preference stayed `"auto"` (unchanged), so React never recomputed the memoized value and `useLyrics` kept the **old** `translateTo` until something else forced a refresh.

## Fix
- **iPod** (`useIpodLogic`): add `useTranslation()` and include `i18n.resolvedLanguage ?? i18n.language` in the `useMemo` dependency list for the effective translation language.
- **Karaoke** (`KaraokeLyricsPlaybackProvider`): same pattern so the shared lyrics hook receives an updated `translateTo` on language change.

Explicit language codes and `null` (original/off) are unchanged.

## Tests
- Extended `tests/test-cloud-sync-launch-and-store.test.ts` with a small `getEffectiveTranslationLanguage` describe block (reuses the file’s existing `localStorage` harness and initializes i18n with a browser-like `window` stub for Bun).

**Verification:** `bun test tests/test-cloud-sync-launch-and-store.test.ts` and `bun run build` both pass.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c619a392-b653-41de-9074-4f4c392759fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c619a392-b653-41de-9074-4f4c392759fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

