### PR TITLE
TV fullscreen: karaoke-style dismiss + CH± after transport

### DIFF
--- a/src/apps/ipod/components/FullScreenPortal.tsx
+++ b/src/apps/ipod/components/FullScreenPortal.tsx
@@ -16,9 +16,7 @@ import {
   MAX_VERTICAL_DRIFT,
 } from "../constants";
 import { FullscreenPlayerControls } from "@/components/shared/FullscreenPlayerControls";
-import { X } from "@phosphor-icons/react";
-import { useThemeStore } from "@/stores/useThemeStore";
-import { useSound, Sounds } from "@/hooks/useSound";
+import { FullscreenMobileDismiss } from "@/components/shared/FullscreenMobileDismiss";
 import type { FullScreenPortalProps } from "../types";
 
 const passiveActivityOptions: AddEventListenerOptions = { passive: true };
@@ -62,9 +60,6 @@ export function FullScreenPortal({
     : false;
 
   const { t } = useTranslation();
-  const currentTheme = useThemeStore((s) => s.current);
-  const isMacTheme = currentTheme === "macosx";
-  const { play: playClick } = useSound(Sounds.BUTTON_CLICK, 0.3);
   const containerRef = useRef<HTMLDivElement>(null);
   const [isLangMenuOpen, setIsLangMenuOpen] = useState(false);
   const [isPronunciationMenuOpen, setIsPronunciationMenuOpen] = useState(false);
@@ -487,51 +482,12 @@ export function FullScreenPortal({
 
       {/* Mobile close button (top right, visible only on mobile) */}
       {onClose && (
-        <div
-          data-toolbar
-          className={cn(
-            "fixed z-[10001] md:hidden transition-opacity duration-200",
-            showControls || anyMenuOpen || !getActualPlayerState()
-              ? "opacity-100 pointer-events-auto"
-              : "opacity-0 pointer-events-none"
-          )}
-          style={{
-            top: "calc(max(env(safe-area-inset-top), 0.75rem) + 0.75rem)",
-            right: "calc(max(env(safe-area-inset-right), 0.75rem) + 0.75rem)",
-          }}
-        >
-          <div
-            className={cn(
-              isMacTheme
-                ? "relative overflow-hidden rounded-full shadow-lg flex items-center gap-1 px-1 py-1"
-                : "border border-white/10 backdrop-blur-sm rounded-full shadow-lg flex items-center gap-1 px-1 py-1 bg-neutral-800/35"
-            )}
-            style={
-              isMacTheme
-                ? {
-                    background: "linear-gradient(to bottom, rgba(60, 60, 60, 0.6), rgba(30, 30, 30, 0.5))",
-                    boxShadow:
-                      "0 2px 4px rgba(0, 0, 0, 0.2), inset 0 0 0 0.5px rgba(255, 255, 255, 0.1), inset 0 1px 0 rgba(255, 255, 255, 0.15)",
-                  }
-                : {}
-            }
-          >
-            <button
-              type="button"
-              onClick={(e) => {
-                e.stopPropagation();
-                playClick();
-                registerActivity();
-                onClose();
-              }}
-              className="w-9 h-9 flex items-center justify-center rounded-full text-white/70 hover:text-white hover:bg-white/10 transition-colors focus:outline-none"
-              aria-label={t("apps.ipod.ariaLabels.closeFullscreen")}
-              title={t("common.dialog.close")}
-            >
-              <X weight="bold" size={18} />
-            </button>
-          </div>
-        </div>
+        <FullscreenMobileDismiss
+          visible={showControls || !getActualPlayerState()}
+          forceVisible={anyMenuOpen}
+          onDismiss={onClose}
+          onInteraction={registerActivity}
+        />
       )}
 
       <div className="flex-1 min-h-0">

--- a/src/apps/tv/components/TvAppComponent.tsx
+++ b/src/apps/tv/components/TvAppComponent.tsx
@@ -1492,6 +1492,8 @@ export function TvAppComponent({
           onSeek={handleSeek}
           onNext={nextVideo}
           onPrevious={prevVideo}
+          onChannelNext={nextChannel}
+          onChannelPrev={prevChannel}
           showStatus={showStatus}
           statusMessage={statusMessage}
           videoOverlay={

--- a/src/apps/tv/components/TvAppComponent.tsx
+++ b/src/apps/tv/components/TvAppComponent.tsx
@@ -742,9 +742,10 @@ export function TvAppComponent({
       channelMountedRef.current = true;
       return;
     }
+    if (isFullScreen) return;
     setChannelSwitchKey((k) => k + 1);
     void playChannelSwitch();
-  }, [currentChannelId, playChannelSwitch]);
+  }, [currentChannelId, playChannelSwitch, isFullScreen]);
 
   // Reset the buffering flag whenever the URL changes so a previous
   // channel's pending-buffer state can't leak into the new picture.
@@ -879,7 +880,10 @@ export function TvAppComponent({
   // takes effect would otherwise leak through.
   const hasUrl = Boolean(currentVideo?.url);
   const staticBedActive =
-    (isBuffering || (!hasUrl && isPlaying)) && !poweringOff && !screenOff;
+    (isBuffering || (!hasUrl && isPlaying)) &&
+    !poweringOff &&
+    !screenOff &&
+    !isFullScreen;
   useEffect(() => {
     if (staticBedActive) {
       void startStatic();
@@ -1086,6 +1090,7 @@ export function TvAppComponent({
                 onClick={handleTogglePlay}
               />
               <TvCrtEffects
+                suppressAnalogNoise={isFullScreen}
                 powerOnKey={powerOnKey}
                 poweringOff={poweringOff}
                 onPowerOffComplete={handlePowerOffComplete}

--- a/src/apps/tv/components/TvCrtEffects.tsx
+++ b/src/apps/tv/components/TvCrtEffects.tsx
@@ -541,6 +541,12 @@ function PowerOffEffect({
 }
 
 export interface TvCrtEffectsProps {
+  /**
+   * When true, skip analog static layers (NoiseCanvas) for buffering and
+   * channel-change bursts. Used in fullscreen so we do not run rAF noise
+   * while the picture is in a portal.
+   */
+  suppressAnalogNoise?: boolean;
   /** Bumped to play a power-on animation. 0 means no animation has played yet. */
   powerOnKey: number;
   /** While true, runs the power-off animation. Caller should set it true
@@ -571,6 +577,7 @@ export interface TvCrtEffectsProps {
  * style objects from being thrashed every frame.
  */
 export const TvCrtEffects = memo(function TvCrtEffects({
+  suppressAnalogNoise = false,
   powerOnKey,
   poweringOff,
   onPowerOffComplete,
@@ -602,7 +609,7 @@ export const TvCrtEffects = memo(function TvCrtEffects({
           iframe doesn't bleed through. Only the cross-fade in/out is
           partially transparent. */}
       <AnimatePresence>
-        {buffering && (
+        {buffering && !suppressAnalogNoise && (
           <motion.div
             key="tv-buffering"
             initial={{ opacity: 0 }}
@@ -621,7 +628,7 @@ export const TvCrtEffects = memo(function TvCrtEffects({
           the static. Re-keys on every channel change so a new burst
           plays even mid-fade. */}
       <AnimatePresence>
-        {activeChannelKey > 0 && (
+        {!suppressAnalogNoise && activeChannelKey > 0 && (
           <motion.div
             key={`tv-channel-${activeChannelKey}`}
             initial={{ opacity: 1 }}

--- a/src/components/shared/FullscreenMobileDismiss.tsx
+++ b/src/components/shared/FullscreenMobileDismiss.tsx
@@ -1,0 +1,77 @@
+import { cn } from "@/lib/utils";
+import { useThemeStore } from "@/stores/useThemeStore";
+import { useSound, Sounds } from "@/hooks/useSound";
+import { useTranslation } from "react-i18next";
+import { X } from "@phosphor-icons/react";
+
+export interface FullscreenMobileDismissProps {
+  visible: boolean;
+  onDismiss: () => void;
+  onInteraction?: () => void;
+  /** Extra condition to keep the control interactive (e.g. menus open) */
+  forceVisible?: boolean;
+}
+
+/**
+ * Top-right fullscreen dismiss pill used on narrow viewports (matches Karaoke / iPod FullScreenPortal).
+ */
+export function FullscreenMobileDismiss({
+  visible,
+  onDismiss,
+  onInteraction,
+  forceVisible = false,
+}: FullscreenMobileDismissProps) {
+  const { t } = useTranslation();
+  const currentTheme = useThemeStore((s) => s.current);
+  const isMacTheme = currentTheme === "macosx";
+  const { play: playClick } = useSound(Sounds.BUTTON_CLICK, 0.3);
+
+  const show = visible || forceVisible;
+
+  return (
+    <div
+      data-toolbar
+      className={cn(
+        "fixed z-[10001] md:hidden transition-opacity duration-200",
+        show ? "opacity-100 pointer-events-auto" : "opacity-0 pointer-events-none"
+      )}
+      style={{
+        top: "calc(max(env(safe-area-inset-top), 0.75rem) + 0.75rem)",
+        right: "calc(max(env(safe-area-inset-right), 0.75rem) + 0.75rem)",
+      }}
+    >
+      <div
+        className={cn(
+          isMacTheme
+            ? "relative overflow-hidden rounded-full shadow-lg flex items-center gap-1 px-1 py-1"
+            : "border border-white/10 backdrop-blur-sm rounded-full shadow-lg flex items-center gap-1 px-1 py-1 bg-neutral-800/35"
+        )}
+        style={
+          isMacTheme
+            ? {
+                background:
+                  "linear-gradient(to bottom, rgba(60, 60, 60, 0.6), rgba(30, 30, 30, 0.5))",
+                boxShadow:
+                  "0 2px 4px rgba(0, 0, 0, 0.2), inset 0 0 0 0.5px rgba(255, 255, 255, 0.1), inset 0 1px 0 rgba(255, 255, 255, 0.15)",
+              }
+            : {}
+        }
+      >
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation();
+            playClick();
+            onInteraction?.();
+            onDismiss();
+          }}
+          className="w-9 h-9 flex items-center justify-center rounded-full text-white/70 hover:text-white hover:bg-white/10 transition-colors focus:outline-none"
+          aria-label={t("apps.ipod.ariaLabels.closeFullscreen")}
+          title={t("common.dialog.close")}
+        >
+          <X weight="bold" size={18} />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/shared/FullscreenPlayerControls.tsx
+++ b/src/components/shared/FullscreenPlayerControls.tsx
@@ -233,6 +233,20 @@ export function FullscreenPlayerControls({
   const svgClasses = (baseClass?: string) =>
     cn(baseClass, isMacTheme && "text-white/70 drop-shadow-[0_1px_2px_rgba(0,0,0,0.5)]");
 
+  const channelStepButtonClasses = isMacTheme
+    ? cn(
+        variant === "compact"
+          ? "h-8 shrink-0 w-max min-w-8 px-2"
+          : "h-9 md:h-12 shrink-0 w-max min-w-9 md:min-w-12 px-2.5 md:px-4",
+        "flex items-center justify-center rounded-full transition-colors focus:outline-none relative z-10"
+      )
+    : cn(
+        variant === "compact"
+          ? "h-8 shrink-0 w-max min-w-8 px-2"
+          : "h-9 md:h-12 shrink-0 w-max min-w-9 md:min-w-12 px-2.5 md:px-4",
+        "flex items-center justify-center rounded-full text-white/70 hover:text-white hover:bg-white/10 transition-colors focus:outline-none whitespace-nowrap"
+      );
+
   return (
     <div className={cn(
       "relative ipod-force-font flex items-center",
@@ -341,13 +355,13 @@ export function FullscreenPlayerControls({
               type="button"
               onClick={handleClick(onChannelDown)}
               aria-label={channelDownTitle ?? channelDownLabel}
-              className={buttonClasses}
+              className={channelStepButtonClasses}
               title={channelDownTitle ?? channelDownLabel}
             >
               <span
                 className={cn(
                   smallIconSize,
-                  "font-semibold tabular-nums tracking-tight",
+                  "font-semibold tabular-nums tracking-tight whitespace-nowrap",
                   iconClasses
                 )}
               >
@@ -358,13 +372,13 @@ export function FullscreenPlayerControls({
               type="button"
               onClick={handleClick(onChannelUp)}
               aria-label={channelUpTitle ?? channelUpLabel}
-              className={buttonClasses}
+              className={channelStepButtonClasses}
               title={channelUpTitle ?? channelUpLabel}
             >
               <span
                 className={cn(
                   smallIconSize,
-                  "font-semibold tabular-nums tracking-tight",
+                  "font-semibold tabular-nums tracking-tight whitespace-nowrap",
                   iconClasses
                 )}
               >

--- a/src/components/shared/FullscreenPlayerControls.tsx
+++ b/src/components/shared/FullscreenPlayerControls.tsx
@@ -85,7 +85,14 @@ export interface FullscreenPlayerControlsProps {
   isLangMenuOpen: boolean;
   setIsLangMenuOpen: (open: boolean) => void;
 
-  // Optional close button (for fullscreen mode)
+  // Optional TV-style channel step (after transport, same visual language as other islands)
+  onChannelUp?: () => void;
+  onChannelDown?: () => void;
+  channelUpTitle?: string;
+  channelDownTitle?: string;
+  channelUpLabel?: string;
+  channelDownLabel?: string;
+
   onClose?: () => void;
 
   // Styling variants
@@ -126,6 +133,12 @@ export function FullscreenPlayerControls({
   translationLanguages,
   isLangMenuOpen,
   setIsLangMenuOpen,
+  onChannelUp,
+  onChannelDown,
+  channelUpTitle,
+  channelDownTitle,
+  channelUpLabel,
+  channelDownLabel,
   onClose,
   variant = "responsive",
   bgOpacity = "35",
@@ -317,6 +330,49 @@ export function FullscreenPlayerControls({
           );
         })()}
       </div>
+
+      {onChannelUp &&
+        onChannelDown &&
+        channelUpLabel &&
+        channelDownLabel && (
+          <div className={segmentClasses} style={aquaSegmentStyle}>
+            {isMacTheme && <AquaShineOverlays variant={variant} />}
+            <button
+              type="button"
+              onClick={handleClick(onChannelDown)}
+              aria-label={channelDownTitle ?? channelDownLabel}
+              className={buttonClasses}
+              title={channelDownTitle ?? channelDownLabel}
+            >
+              <span
+                className={cn(
+                  smallIconSize,
+                  "font-semibold tabular-nums tracking-tight",
+                  iconClasses
+                )}
+              >
+                {channelDownLabel}
+              </span>
+            </button>
+            <button
+              type="button"
+              onClick={handleClick(onChannelUp)}
+              aria-label={channelUpTitle ?? channelUpLabel}
+              className={buttonClasses}
+              title={channelUpTitle ?? channelUpLabel}
+            >
+              <span
+                className={cn(
+                  smallIconSize,
+                  "font-semibold tabular-nums tracking-tight",
+                  iconClasses
+                )}
+              >
+                {channelUpLabel}
+              </span>
+            </button>
+          </div>
+        )}
 
       {/* Lyrics controls island */}
       {!hideLyricsControls && (

--- a/src/components/shared/VideoFullScreenPortal.tsx
+++ b/src/components/shared/VideoFullScreenPortal.tsx
@@ -4,8 +4,10 @@ import { createPortal } from "react-dom";
 import type ReactPlayer from "react-player";
 import { cn } from "@/lib/utils";
 import { FullscreenPlayerControls } from "@/components/shared/FullscreenPlayerControls";
+import { FullscreenMobileDismiss } from "@/components/shared/FullscreenMobileDismiss";
 import { LyricsAlignment, LyricsFont } from "@/types/lyrics";
 import { YouTubePlayer } from "@/components/shared/YouTubePlayer";
+import { useTranslation } from "react-i18next";
 
 interface VideoFullScreenPortalProps {
   isOpen: boolean;
@@ -25,6 +27,9 @@ interface VideoFullScreenPortalProps {
   onSeek: (time: number) => void;
   onNext?: () => void;
   onPrevious?: () => void;
+  /** When set (e.g. TV), Arrow Up/Down step the broadcast channel instead of playlist items. */
+  onChannelNext?: () => void;
+  onChannelPrev?: () => void;
   showStatus?: (message: string) => void;
   statusMessage?: string | null;
   isShuffled?: boolean;
@@ -56,28 +61,41 @@ export function VideoFullScreenPortal({
   onSeek,
   onNext,
   onPrevious,
+  onChannelNext,
+  onChannelPrev,
   showStatus,
   statusMessage,
   isShuffled,
   onToggleShuffle,
   videoOverlay,
 }: VideoFullScreenPortalProps) {
+  const { t } = useTranslation();
   const containerRef = useRef<HTMLDivElement>(null);
   const [showControls, setShowControls] = useState(true);
   const [isLangMenuOpen, setIsLangMenuOpen] = useState(false);
   const hideControlsTimeoutRef = useRef<number | null>(null);
+
+  const getActualPlayerState = useCallback(() => {
+    const internalPlayer = playerRef.current?.getInternalPlayer?.();
+    if (internalPlayer && typeof internalPlayer.getPlayerState === "function") {
+      const playerState = internalPlayer.getPlayerState();
+      return playerState === 1;
+    }
+    return isPlaying;
+  }, [playerRef, isPlaying]);
 
   const restartAutoHideTimer = useCallback(() => {
     setShowControls(true);
     if (hideControlsTimeoutRef.current) {
       clearTimeout(hideControlsTimeoutRef.current);
     }
-    if (isPlaying) {
+    const actuallyPlaying = getActualPlayerState();
+    if (actuallyPlaying && !isLangMenuOpen) {
       hideControlsTimeoutRef.current = window.setTimeout(() => {
         setShowControls(false);
-      }, 3000);
+      }, 2000);
     }
-  }, [isPlaying]);
+  }, [getActualPlayerState, isLangMenuOpen]);
 
   useEffect(() => {
     if (!isOpen) return;
@@ -116,10 +134,11 @@ export function VideoFullScreenPortal({
       if (hideControlsTimeoutRef.current) {
         clearTimeout(hideControlsTimeoutRef.current);
       }
-      if (isPlaying) {
+      const actuallyPlaying = getActualPlayerState();
+      if (actuallyPlaying && !isLangMenuOpen) {
         hideControlsTimeoutRef.current = window.setTimeout(() => {
           setShowControls(false);
-        }, 3000);
+        }, 2000);
       }
     };
 
@@ -128,10 +147,11 @@ export function VideoFullScreenPortal({
     window.addEventListener("touchstart", handleActivity, { passive: true });
     window.addEventListener("click", handleActivity, { passive: true });
 
-    if (isPlaying) {
+    const actuallyPlayingOnMount = getActualPlayerState();
+    if (actuallyPlayingOnMount && !isLangMenuOpen) {
       hideControlsTimeoutRef.current = window.setTimeout(() => {
         setShowControls(false);
-      }, 3000);
+      }, 2000);
     }
 
     return () => {
@@ -144,7 +164,7 @@ export function VideoFullScreenPortal({
         hideControlsTimeoutRef.current = null;
       }
     };
-  }, [isOpen, isPlaying]);
+  }, [isOpen, isLangMenuOpen, getActualPlayerState]);
 
   useEffect(() => {
     if (!isOpen) return;
@@ -173,12 +193,20 @@ export function VideoFullScreenPortal({
           onSeek(newTime);
           showStatus?.("⏩ +10s");
         }
-      } else if (e.key === "ArrowUp" && onPrevious) {
+      } else if (e.key === "ArrowUp") {
         e.preventDefault();
-        onPrevious();
-      } else if (e.key === "ArrowDown" && onNext) {
+        if (onChannelPrev && onChannelNext) {
+          onChannelPrev();
+        } else if (onPrevious) {
+          onPrevious();
+        }
+      } else if (e.key === "ArrowDown") {
         e.preventDefault();
-        onNext();
+        if (onChannelPrev && onChannelNext) {
+          onChannelNext();
+        } else if (onNext) {
+          onNext();
+        }
       }
     };
 
@@ -186,12 +214,13 @@ export function VideoFullScreenPortal({
     return () => window.removeEventListener("keydown", handleKeyDown);
   }, [
     isOpen,
-    isPlaying,
     onClose,
     onTogglePlay,
     onSeek,
     onNext,
     onPrevious,
+    onChannelNext,
+    onChannelPrev,
     showStatus,
     playerRef,
     restartAutoHideTimer,
@@ -199,11 +228,18 @@ export function VideoFullScreenPortal({
 
   if (!isOpen) return null;
 
+  const controlsVisible =
+    showControls || isLangMenuOpen || !getActualPlayerState();
+
   return createPortal(
     <div
       ref={containerRef}
       className="ipod-force-font fixed inset-0 z-[9999] bg-black select-none flex flex-col"
-      onClick={() => {
+      onClick={(e) => {
+        const target = e.target as HTMLElement;
+        if (target.closest("[data-toolbar]")) {
+          return;
+        }
         onTogglePlay();
         restartAutoHideTimer();
       }}
@@ -239,6 +275,13 @@ export function VideoFullScreenPortal({
           </motion.div>
         )}
       </AnimatePresence>
+
+      <FullscreenMobileDismiss
+        visible={controlsVisible}
+        forceVisible={isLangMenuOpen}
+        onDismiss={onClose}
+        onInteraction={restartAutoHideTimer}
+      />
 
       <div className="flex-1 min-h-0 relative overflow-hidden">
         {videoOverlay ? (
@@ -286,9 +329,7 @@ export function VideoFullScreenPortal({
         data-toolbar
         className={cn(
           "fixed bottom-0 left-0 right-0 flex justify-center z-[10001] transition-opacity duration-200",
-          showControls || isLangMenuOpen || !isPlaying
-            ? "opacity-100 pointer-events-auto"
-            : "opacity-0 pointer-events-none"
+          controlsVisible ? "opacity-100 pointer-events-auto" : "opacity-0 pointer-events-none"
         )}
         style={{
           paddingBottom: "calc(env(safe-area-inset-bottom, 0px) + 1.5rem)",
@@ -299,12 +340,18 @@ export function VideoFullScreenPortal({
         }}
       >
         <FullscreenPlayerControls
-          isPlaying={isPlaying}
+          isPlaying={getActualPlayerState()}
           onPrevious={onPrevious || (() => {})}
           onPlayPause={onTogglePlay}
           onNext={onNext || (() => {})}
           isShuffled={isShuffled}
           onToggleShuffle={onToggleShuffle}
+          onChannelUp={onChannelNext}
+          onChannelDown={onChannelPrev}
+          channelUpLabel={t("apps.tv.status.channelUp")}
+          channelDownLabel={t("apps.tv.status.channelDown")}
+          channelUpTitle={t("apps.tv.menu.channelUp")}
+          channelDownTitle={t("apps.tv.menu.channelDown")}
           currentAlignment={LyricsAlignment.Center}
           onAlignmentCycle={() => {}}
           currentFont={LyricsFont.SansSerif}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- **Mobile dismiss** — TV video fullscreen uses the same top-right pill dismiss as Karaoke/iPod (`FullscreenMobileDismiss`, extracted from `FullScreenPortal`).
- **CH− / CH+** — Control island after prev/play/next in `FullscreenPlayerControls`, wired from TV via `nextChannel` / `prevChannel`.
- **Parity in `VideoFullScreenPortal`** — Root tap ignores `[data-toolbar]`, toolbar uses YouTube `getPlayerState()` for play icon / 2s auto-hide. When `onChannelNext` / `onChannelPrev` are passed, Arrow Up/Down step channels.
- **Fullscreen: no CRT static** — While TV is fullscreen, analog static (NoiseCanvas rAF), buffering static overlay, channel-switch burst, looping static audio bed, and channel-switch SFX are suppressed so the portal view stays clean and quiet.

## Files
- `src/components/shared/FullscreenMobileDismiss.tsx` (new)
- `src/apps/ipod/components/FullScreenPortal.tsx`
- `src/components/shared/FullscreenPlayerControls.tsx`
- `src/components/shared/VideoFullScreenPortal.tsx`
- `src/apps/tv/components/TvAppComponent.tsx`
- `src/apps/tv/components/TvCrtEffects.tsx`

## Testing
- `bun run build` — passed.

## Follow-ups / edge cases
- **i18n** — CH buttons use existing `apps.tv.status` strings; add shorter keys if any locale overflows the pill.
- **Double keydown** — Rare focus edge case could double-step channel; worth QA if reported.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fdceaad4-7bae-4b0a-9f5c-9a5b978552cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fdceaad4-7bae-4b0a-9f5c-9a5b978552cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

