### PR TITLE
Keep reset TV channels deleted in cloud sync

### DIFF
--- a/src/hooks/useAutoCloudSync.ts
+++ b/src/hooks/useAutoCloudSync.ts
@@ -251,6 +251,10 @@ function getPersistedDeletionChangeAt(domain: CloudSyncDomain): string | null {
       return getLatestCloudSyncTimestamp(
         Object.values(deletionMarkers.contactIds)
       );
+    case "tv":
+      return getLatestCloudSyncTimestamp(
+        Object.values(deletionMarkers.tvCustomChannelIds)
+      );
     case "files-metadata":
       return getLatestCloudSyncTimestamp(
         Object.values(deletionMarkers.fileMetadataPaths)
@@ -1462,6 +1466,7 @@ export function useAutoCloudSync() {
     const tvSettingsUnsubscribe = useTvStore.subscribe((state, prevState) => {
       if (
         state.customChannels !== prevState.customChannels ||
+        state.hiddenDefaultChannelIds !== prevState.hiddenDefaultChannelIds ||
         state.lcdFilterOn !== prevState.lcdFilterOn ||
         state.closedCaptionsOn !== prevState.closedCaptionsOn
       ) {

--- a/src/stores/useCloudSyncStore.ts
+++ b/src/stores/useCloudSyncStore.ts
@@ -37,6 +37,7 @@ export const CLOUD_SYNC_DELETION_BUCKETS = [
   "fileAppletKeys",
   "customWallpaperKeys",
   "songTrackIds",
+  "tvCustomChannelIds",
 ] as const;
 
 export type CloudSyncDeletionBucket =
@@ -60,6 +61,7 @@ function createEmptyDeletionMarkers(): CloudSyncDeletionMarkerState {
     fileAppletKeys: {},
     customWallpaperKeys: {},
     songTrackIds: {},
+    tvCustomChannelIds: {},
   };
 }
 
@@ -178,7 +180,7 @@ export function mergePersistedCloudSyncDomainStatus(
 }
 
 const STORE_NAME = "ryos:cloud-sync";
-const STORE_VERSION = 11;
+const STORE_VERSION = 12;
 
 export const useCloudSyncStore = create<CloudSyncStoreState>()(
   persist(

--- a/src/stores/useTvStore.ts
+++ b/src/stores/useTvStore.ts
@@ -6,6 +6,7 @@ import {
   isDefaultChannelId,
   type Channel,
 } from "@/apps/tv/data/channels";
+import { useCloudSyncStore } from "@/stores/useCloudSyncStore";
 import type { Video } from "@/stores/useVideoStore";
 
 /** Persisted custom channel; `number` is assigned at runtime from lineup order. */
@@ -121,6 +122,9 @@ export const useTvStore = create<TvStoreState>()(
           id: channel.id ?? generateChannelId(),
           createdAt: Date.now(),
         };
+        useCloudSyncStore
+          .getState()
+          .clearDeletedKeys("tvCustomChannelIds", [created.id]);
         set({ customChannels: [...existing, created] });
         return created;
       },
@@ -134,6 +138,11 @@ export const useTvStore = create<TvStoreState>()(
             isDefault && !s.hiddenDefaultChannelIds.includes(id)
               ? [...s.hiddenDefaultChannelIds, id]
               : s.hiddenDefaultChannelIds;
+          if (!isDefault && s.customChannels.some((c) => c.id === id)) {
+            useCloudSyncStore
+              .getState()
+              .markDeletedKeys("tvCustomChannelIds", [id]);
+          }
           const fallbackId =
             s.currentChannelId === id
               ? buildTvChannelLineup(customChannels, hiddenDefaultChannelIds)[0]
@@ -299,6 +308,9 @@ export const useTvStore = create<TvStoreState>()(
           added += 1;
         }
 
+        useCloudSyncStore
+          .getState()
+          .clearDeletedKeys("tvCustomChannelIds", merged.map((c) => c.id));
         set({ customChannels: merged });
         return { added, skipped };
       },
@@ -310,13 +322,20 @@ export const useTvStore = create<TvStoreState>()(
         };
         return JSON.stringify(payload, null, 2);
       },
-      resetChannels: () =>
+      resetChannels: () => {
+        const customChannelIds = get().customChannels.map((channel) => channel.id);
+        if (customChannelIds.length > 0) {
+          useCloudSyncStore
+            .getState()
+            .markDeletedKeys("tvCustomChannelIds", customChannelIds);
+        }
         set({
           customChannels: [],
           hiddenDefaultChannelIds: [],
           currentChannelId: DEFAULT_CHANNEL_ID,
           lastVideoIndexByChannel: {},
-        }),
+        });
+      },
     }),
     {
       name: "ryos:tv",

--- a/src/sync/domains.ts
+++ b/src/sync/domains.ts
@@ -153,6 +153,7 @@ interface VideosSnapshotData {
 interface TvSnapshotData {
   customChannels: CustomChannel[];
   hiddenDefaultChannelIds?: string[];
+  deletedCustomChannelIds?: DeletionMarkerMap;
   lcdFilterOn: boolean;
   closedCaptionsOn: boolean;
 }
@@ -693,9 +694,11 @@ function serializeVideosSnapshot(): VideosSnapshotData {
 
 function serializeTvSnapshot(): TvSnapshotData {
   const tvState = useTvStore.getState();
+  const deletionMarkers = useCloudSyncStore.getState().deletionMarkers;
   return {
     customChannels: tvState.customChannels,
     hiddenDefaultChannelIds: tvState.hiddenDefaultChannelIds,
+    deletedCustomChannelIds: deletionMarkers.tvCustomChannelIds,
     lcdFilterOn: tvState.lcdFilterOn,
     closedCaptionsOn: tvState.closedCaptionsOn,
   };
@@ -1110,8 +1113,23 @@ function applyVideosSnapshot(data: VideosSnapshotData): void {
 }
 
 function applyTvSnapshot(data: TvSnapshotData): void {
+  const remoteDeletedChannelIds = normalizeDeletionMarkerMap(
+    data.deletedCustomChannelIds
+  );
+  const cloudSyncState = useCloudSyncStore.getState();
+  const effectiveDeletedChannelIds = mergeDeletionMarkerMaps(
+    cloudSyncState.deletionMarkers.tvCustomChannelIds,
+    remoteDeletedChannelIds
+  );
+
+  cloudSyncState.mergeDeletedKeys("tvCustomChannelIds", remoteDeletedChannelIds);
+
   useTvStore.setState({
-    customChannels: Array.isArray(data.customChannels) ? data.customChannels : [],
+    customChannels: filterDeletedIds(
+      Array.isArray(data.customChannels) ? data.customChannels : [],
+      effectiveDeletedChannelIds,
+      (channel) => channel.id
+    ),
     hiddenDefaultChannelIds: Array.isArray(data.hiddenDefaultChannelIds)
       ? data.hiddenDefaultChannelIds
       : [],
@@ -1560,10 +1578,14 @@ function mergeTvSnapshots(
   local: TvSnapshotData,
   remote: TvSnapshotData
 ): TvSnapshotData {
+  const mergedDeleted = mergeDeletionMarkerMaps(
+    normalizeDeletionMarkerMap(local.deletedCustomChannelIds),
+    normalizeDeletionMarkerMap(remote.deletedCustomChannelIds)
+  );
   return {
     customChannels: mergeItemsById(
-      local.customChannels || [],
-      remote.customChannels || []
+      filterDeletedIds(local.customChannels || [], mergedDeleted, (channel) => channel.id),
+      filterDeletedIds(remote.customChannels || [], mergedDeleted, (channel) => channel.id)
     ),
     hiddenDefaultChannelIds: Array.from(
       new Set([
@@ -1571,6 +1593,7 @@ function mergeTvSnapshots(
         ...(remote.hiddenDefaultChannelIds || []),
       ])
     ),
+    deletedCustomChannelIds: mergedDeleted,
     lcdFilterOn: local.lcdFilterOn,
     closedCaptionsOn: local.closedCaptionsOn,
   };

--- a/tests/test-cloud-sync-tv-upload-apply.test.ts
+++ b/tests/test-cloud-sync-tv-upload-apply.test.ts
@@ -1,5 +1,6 @@
 import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
 import type { CustomChannel } from "../src/stores/useTvStore";
+import type { DeletionMarkerMap } from "../src/utils/cloudSyncDeletionMarkers";
 import type { CloudSyncDomainMetadata } from "../src/utils/cloudSyncShared";
 
 class MemoryStorage implements Storage {
@@ -180,7 +181,7 @@ beforeAll(() => {
   createBrowserTestEnvironment();
 });
 
-beforeEach(() => {
+beforeEach(async () => {
   createBrowserTestEnvironment();
   browserGlobals.localStorage.setItem(
     "ryos:tv",
@@ -194,6 +195,13 @@ beforeEach(() => {
       version: 4,
     })
   );
+  const { useCloudSyncStore } = await import("../src/stores/useCloudSyncStore");
+  useCloudSyncStore.setState((state) => ({
+    deletionMarkers: {
+      ...state.deletionMarkers,
+      tvCustomChannelIds: {},
+    },
+  }));
 });
 
 afterAll(() => {
@@ -278,6 +286,7 @@ describe("cloud sync TV upload apply", () => {
         data: {
           customChannels: CustomChannel[];
           hiddenDefaultChannelIds: string[];
+          deletedCustomChannelIds?: Record<string, string>;
           lcdFilterOn: boolean;
           closedCaptionsOn: boolean;
         };
@@ -290,6 +299,7 @@ describe("cloud sync TV upload apply", () => {
         "taiwan",
         "tokki-mix",
       ]);
+      expect(payload.data.deletedCustomChannelIds ?? {}).toEqual({});
       expect(payload.data.lcdFilterOn).toBe(true);
       expect(payload.data.closedCaptionsOn).toBe(true);
 
@@ -301,6 +311,81 @@ describe("cloud sync TV upload apply", () => {
       expect(queuedDuringApply).toEqual([]);
     } finally {
       unsubscribe();
+      globalThis.fetch = originalFetch;
+      invalidateRedisStateSnapshotForUpload(username, "tv");
+    }
+  });
+
+  test("TV upload merge respects existing custom channel deletion markers", async () => {
+    const { useTvStore } = await import("../src/stores/useTvStore");
+    const { useCloudSyncStore } = await import("../src/stores/useCloudSyncStore");
+    const { prepareCloudSyncDomainWrite, invalidateRedisStateSnapshotForUpload } =
+      await import("../src/sync/domains");
+
+    const username = `tv-reset-deleted-${Date.now()}`;
+    invalidateRedisStateSnapshotForUpload(username, "tv");
+    useTvStore.setState({
+      currentChannelId: "ryos-picks",
+      customChannels: [makeChannel("remote")],
+      hiddenDefaultChannelIds: [],
+      lcdFilterOn: true,
+      closedCaptionsOn: true,
+    });
+    useTvStore.getState().resetChannels();
+
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async (input) => {
+      const url =
+        typeof input === "string"
+          ? input
+          : input instanceof URL
+            ? input.toString()
+            : input.url;
+      if (url.endsWith("/api/sync/domains/tv")) {
+        return new Response(
+          JSON.stringify({
+            parts: {
+              tv: {
+                metadata: makeMetadata("2026-03-22T09:55:00.000Z"),
+                data: {
+                  customChannels: [makeChannel("remote")],
+                  hiddenDefaultChannelIds: [],
+                  lcdFilterOn: false,
+                  closedCaptionsOn: false,
+                },
+              },
+            },
+          }),
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }
+        );
+      }
+      throw new Error(`Unexpected fetch in test: ${url}`);
+    }) as typeof fetch;
+
+    try {
+      const prepared = await prepareCloudSyncDomainWrite("tv", {
+        username,
+        isAuthenticated: true,
+      });
+      const payload = prepared.payload as {
+        data: {
+          customChannels: CustomChannel[];
+          deletedCustomChannelIds: DeletionMarkerMap;
+        };
+      };
+
+      expect(payload.data.customChannels).toEqual([]);
+      expect(payload.data.deletedCustomChannelIds.remote).toBeString();
+
+      await prepared.onCommitted?.(makeMetadata("2026-03-22T10:00:00.000Z"));
+      expect(useTvStore.getState().customChannels).toEqual([]);
+      expect(
+        useCloudSyncStore.getState().deletionMarkers.tvCustomChannelIds.remote
+      ).toBeString();
+    } finally {
       globalThis.fetch = originalFetch;
       invalidateRedisStateSnapshotForUpload(username, "tv");
     }

--- a/tests/test-tv-store-default-channel-removal.test.ts
+++ b/tests/test-tv-store-default-channel-removal.test.ts
@@ -3,6 +3,7 @@ import {
   buildTvChannelLineup,
   DEFAULT_CHANNEL_ID,
 } from "../src/apps/tv/data/channels";
+import { useCloudSyncStore } from "../src/stores/useCloudSyncStore";
 import { useTvStore } from "../src/stores/useTvStore";
 
 describe("TV store default channel removal", () => {
@@ -16,6 +17,12 @@ describe("TV store default channel removal", () => {
       lcdFilterOn: true,
       closedCaptionsOn: true,
     });
+    useCloudSyncStore.setState((state) => ({
+      deletionMarkers: {
+        ...state.deletionMarkers,
+        tvCustomChannelIds: {},
+      },
+    }));
   });
 
   test("hides a default channel until reset", () => {
@@ -59,5 +66,38 @@ describe("TV store default channel removal", () => {
     const state = useTvStore.getState();
     expect(state.customChannels).toHaveLength(0);
     expect(state.hiddenDefaultChannelIds).toEqual([]);
+    expect(
+      useCloudSyncStore.getState().deletionMarkers.tvCustomChannelIds[custom.id]
+    ).toBeString();
+  });
+
+  test("marks reset custom channels as deleted for sync", () => {
+    const first = useTvStore.getState().addCustomChannel({
+      name: "First",
+      videos: [
+        {
+          id: "first-video",
+          url: "https://youtu.be/first-video",
+          title: "First",
+        },
+      ],
+    });
+    const second = useTvStore.getState().addCustomChannel({
+      name: "Second",
+      videos: [
+        {
+          id: "second-video",
+          url: "https://youtu.be/second-video",
+          title: "Second",
+        },
+      ],
+    });
+
+    useTvStore.getState().resetChannels();
+
+    const state = useTvStore.getState();
+    const deleted = useCloudSyncStore.getState().deletionMarkers.tvCustomChannelIds;
+    expect(state.customChannels).toEqual([]);
+    expect(Object.keys(deleted).sort()).toEqual([first.id, second.id].sort());
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add TV custom channel deletion markers so reset or deleted custom channels are not resurrected by cloud sync conflicts.
- Include TV hidden-default changes in auto-sync upload detection.
- Add focused TV store and cloud-sync tests for deletion marker behavior.

## Testing
- `PATH="$HOME/.bun/bin:$PATH" bun test "tests/test-tv-store-default-channel-removal.test.ts" "tests/test-cloud-sync-tv-upload-apply.test.ts"`
- `PATH="$HOME/.bun/bin:$PATH" bun run build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-af732da8-67d2-4207-abe4-f9764e70c2e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-af732da8-67d2-4207-abe4-f9764e70c2e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

