### PR TITLE
Translate remaining locale TODOs

### DIFF
--- a/src/lib/locales/de/translation.json
+++ b/src/lib/locales/de/translation.json
@@ -333,7 +333,7 @@
         "appletExportedDescription": "{{fileName}}.app erfolgreich exportiert.",
         "appletImported": "Applet importiert!",
         "appletImportedDescription": "{{fileName}} in /Applets{{iconText}} gespeichert",
-        "appletImportedIconSuffix": "[TODO]  with {{icon}} icon",
+        "appletImportedIconSuffix": " mit {{icon}}-Symbol",
         "appletNotFound": "Applet nicht gefunden",
         "appletNotFoundDescription": "Das geteilte Applet wurde möglicherweise gelöscht oder der Link ist ungültig.",
         "appletSaved": "Applet gespeichert",
@@ -714,7 +714,7 @@
         "clear": "Leeren",
         "createAccountToContinue": "Konto erstellen, um fortzufahren...",
         "dailyLimitReached": "Tägliches KI-Nachrichtenlimit erreicht.",
-        "describeThisImage": "[TODO] Describe this image",
+        "describeThisImage": "Dieses Bild beschreiben",
         "editing": "bearbeitet...",
         "leave": "Verlassen",
         "listening": "Hören",
@@ -742,20 +742,20 @@
         "usingModel": "Verwende {{model}}"
       },
       "toasts": {
-        "aiError": "[TODO] AI Error",
-        "failedToGetResponse": "[TODO] Failed to get response.",
-        "failedToSaveTranscript": "[TODO] Failed to save transcript",
-        "loginButton": "[TODO] Login",
-        "loginRequired": "[TODO] Login Required",
-        "open": "[TODO] Open",
-        "pleaseLoginToContinueChatting": "[TODO] Please login to continue chatting.",
-        "rateLimitExceeded": "[TODO] Rate Limit Exceeded",
-        "rateLimitMessageLimitLogin": "[TODO] You've reached the message limit. Please login to continue.",
-        "savedToFileName": "[TODO] Saved to {{fileName}}",
-        "sessionExpiredLoginAgain": "[TODO] Your session has expired. Please login again.",
-        "transcriptSaved": "[TODO] Transcript saved",
-        "transcriptUpdated": "[TODO] Transcript updated",
-        "unknownError": "[TODO] Unknown error"
+        "aiError": "KI-Fehler",
+        "failedToGetResponse": "Fehler beim Abrufen der Antwort.",
+        "failedToSaveTranscript": "Transkript konnte nicht gespeichert werden",
+        "loginButton": "Anmelden",
+        "loginRequired": "Anmeldung erforderlich",
+        "open": "Öffnen",
+        "pleaseLoginToContinueChatting": "Bitte melde dich an, um weiter zu chatten.",
+        "rateLimitExceeded": "Anfragelimit überschritten",
+        "rateLimitMessageLimitLogin": "Du hast das Nachrichtenlimit erreicht. Bitte melde dich an, um fortzufahren.",
+        "savedToFileName": "In {{fileName}} gespeichert",
+        "sessionExpiredLoginAgain": "Deine Sitzung ist abgelaufen. Bitte melde dich erneut an.",
+        "transcriptSaved": "Transkript gespeichert",
+        "transcriptUpdated": "Transkript aktualisiert",
+        "unknownError": "Unbekannter Fehler"
       },
       "tokenStatus": {
         "authenticated": "Angemeldet",
@@ -3057,10 +3057,10 @@
       },
       "description": "Zappe durch YouTube",
       "drawer": {
-        "close": "[TODO] Hide videos",
-        "empty": "[TODO] No videos on this channel yet.",
-        "removeVideo": "[TODO] Remove from channel",
-        "title": "[TODO] Schedule"
+        "close": "Videos ausblenden",
+        "empty": "Noch keine Videos auf diesem Kanal.",
+        "removeVideo": "Vom Kanal entfernen",
+        "title": "Planen"
       },
       "help": {
         "channels": {
@@ -3106,7 +3106,7 @@
         "play": "Wiedergabe",
         "previous": "Zurück",
         "resetChannels": "Kanäle zurücksetzen...",
-        "showVideos": "[TODO] Show Videos",
+        "showVideos": "Videos anzeigen",
         "tvHelp": "TV-Hilfe"
       },
       "name": "TV",

--- a/src/lib/locales/es/translation.json
+++ b/src/lib/locales/es/translation.json
@@ -333,7 +333,7 @@
         "appletExportedDescription": "{{fileName}}.app exportado correctamente.",
         "appletImported": "Applet importado!",
         "appletImportedDescription": "{{fileName}} guardado en /Applets{{iconText}}",
-        "appletImportedIconSuffix": "[TODO]  with {{icon}} icon",
+        "appletImportedIconSuffix": " con el icono {{icon}}",
         "appletNotFound": "Applet no encontrado",
         "appletNotFoundDescription": "El applet compartido puede haber sido eliminado o el enlace es inválido.",
         "appletSaved": "Applet guardado",
@@ -714,7 +714,7 @@
         "clear": "Borrar",
         "createAccountToContinue": "Crea una cuenta para continuar...",
         "dailyLimitReached": "Límite diario de mensajes de IA alcanzado.",
-        "describeThisImage": "[TODO] Describe this image",
+        "describeThisImage": "Describe esta imagen",
         "editing": "editando...",
         "leave": "Salir",
         "listening": "Escuchando",
@@ -742,20 +742,20 @@
         "usingModel": "Usando {{model}}"
       },
       "toasts": {
-        "aiError": "[TODO] AI Error",
-        "failedToGetResponse": "[TODO] Failed to get response.",
-        "failedToSaveTranscript": "[TODO] Failed to save transcript",
-        "loginButton": "[TODO] Login",
-        "loginRequired": "[TODO] Login Required",
-        "open": "[TODO] Open",
-        "pleaseLoginToContinueChatting": "[TODO] Please login to continue chatting.",
-        "rateLimitExceeded": "[TODO] Rate Limit Exceeded",
-        "rateLimitMessageLimitLogin": "[TODO] You've reached the message limit. Please login to continue.",
-        "savedToFileName": "[TODO] Saved to {{fileName}}",
-        "sessionExpiredLoginAgain": "[TODO] Your session has expired. Please login again.",
-        "transcriptSaved": "[TODO] Transcript saved",
-        "transcriptUpdated": "[TODO] Transcript updated",
-        "unknownError": "[TODO] Unknown error"
+        "aiError": "Error de IA",
+        "failedToGetResponse": "Error al obtener la respuesta.",
+        "failedToSaveTranscript": "Error al guardar la transcripción",
+        "loginButton": "Iniciar sesión",
+        "loginRequired": "Inicio de sesión requerido",
+        "open": "Abrir",
+        "pleaseLoginToContinueChatting": "Inicia sesión para continuar chateando.",
+        "rateLimitExceeded": "Límite de frecuencia excedido",
+        "rateLimitMessageLimitLogin": "Has alcanzado el límite de mensajes. Inicia sesión para continuar.",
+        "savedToFileName": "Guardado en {{fileName}}",
+        "sessionExpiredLoginAgain": "Tu sesión ha caducado. Inicia sesión de nuevo.",
+        "transcriptSaved": "Transcripción guardada",
+        "transcriptUpdated": "Transcripción actualizada",
+        "unknownError": "Error desconocido"
       },
       "tokenStatus": {
         "authenticated": "Sesión iniciada",
@@ -3057,10 +3057,10 @@
       },
       "description": "Haz zapping en YouTube",
       "drawer": {
-        "close": "[TODO] Hide videos",
-        "empty": "[TODO] No videos on this channel yet.",
-        "removeVideo": "[TODO] Remove from channel",
-        "title": "[TODO] Schedule"
+        "close": "Ocultar videos",
+        "empty": "Aún no hay videos en este canal.",
+        "removeVideo": "Eliminar del canal",
+        "title": "Programar"
       },
       "help": {
         "channels": {
@@ -3106,7 +3106,7 @@
         "play": "Reproducir",
         "previous": "Anterior",
         "resetChannels": "Restablecer canales...",
-        "showVideos": "[TODO] Show Videos",
+        "showVideos": "Mostrar vídeos",
         "tvHelp": "Ayuda de TV"
       },
       "name": "TV",

--- a/src/lib/locales/fr/translation.json
+++ b/src/lib/locales/fr/translation.json
@@ -333,7 +333,7 @@
         "appletExportedDescription": "{{fileName}}.app exporté avec succès.",
         "appletImported": "Applet importée !",
         "appletImportedDescription": "{{fileName}} enregistré dans /Applets{{iconText}}",
-        "appletImportedIconSuffix": "[TODO]  with {{icon}} icon",
+        "appletImportedIconSuffix": " avec l'icône {{icon}}",
         "appletNotFound": "Applet introuvable",
         "appletNotFoundDescription": "L'applet partagée a peut-être été supprimée ou le lien est invalide.",
         "appletSaved": "Applet enregistrée",
@@ -714,7 +714,7 @@
         "clear": "Effacer",
         "createAccountToContinue": "Créer un compte pour continuer...",
         "dailyLimitReached": "Limite quotidienne de messages IA atteinte.",
-        "describeThisImage": "[TODO] Describe this image",
+        "describeThisImage": "Décrire cette image",
         "editing": "Modification en cours...",
         "leave": "Quitter",
         "listening": "Écoute",
@@ -742,20 +742,20 @@
         "usingModel": "Utilisation de {{model}}"
       },
       "toasts": {
-        "aiError": "[TODO] AI Error",
-        "failedToGetResponse": "[TODO] Failed to get response.",
-        "failedToSaveTranscript": "[TODO] Failed to save transcript",
-        "loginButton": "[TODO] Login",
-        "loginRequired": "[TODO] Login Required",
-        "open": "[TODO] Open",
-        "pleaseLoginToContinueChatting": "[TODO] Please login to continue chatting.",
-        "rateLimitExceeded": "[TODO] Rate Limit Exceeded",
-        "rateLimitMessageLimitLogin": "[TODO] You've reached the message limit. Please login to continue.",
-        "savedToFileName": "[TODO] Saved to {{fileName}}",
-        "sessionExpiredLoginAgain": "[TODO] Your session has expired. Please login again.",
-        "transcriptSaved": "[TODO] Transcript saved",
-        "transcriptUpdated": "[TODO] Transcript updated",
-        "unknownError": "[TODO] Unknown error"
+        "aiError": "Erreur de l'IA",
+        "failedToGetResponse": "Échec de l'obtention de la réponse.",
+        "failedToSaveTranscript": "Échec de l'enregistrement de la transcription",
+        "loginButton": "Connexion",
+        "loginRequired": "Connexion requise",
+        "open": "Ouvrir",
+        "pleaseLoginToContinueChatting": "Veuillez vous connecter pour continuer à discuter.",
+        "rateLimitExceeded": "Limite de débit dépassée",
+        "rateLimitMessageLimitLogin": "Vous avez atteint la limite de messages. Veuillez vous connecter pour continuer.",
+        "savedToFileName": "Enregistré dans {{fileName}}",
+        "sessionExpiredLoginAgain": "Votre session a expiré. Veuillez vous reconnecter.",
+        "transcriptSaved": "Transcription enregistrée",
+        "transcriptUpdated": "Transcription mise à jour",
+        "unknownError": "Erreur inconnue"
       },
       "tokenStatus": {
         "authenticated": "Connecté",
@@ -3057,10 +3057,10 @@
       },
       "description": "Zappez sur YouTube",
       "drawer": {
-        "close": "[TODO] Hide videos",
-        "empty": "[TODO] No videos on this channel yet.",
-        "removeVideo": "[TODO] Remove from channel",
-        "title": "[TODO] Schedule"
+        "close": "Masquer les vidéos",
+        "empty": "Aucune vidéo sur cette chaîne pour le moment.",
+        "removeVideo": "Retirer de la chaîne",
+        "title": "Programmer"
       },
       "help": {
         "channels": {
@@ -3106,7 +3106,7 @@
         "play": "Lecture",
         "previous": "Précédent",
         "resetChannels": "Réinitialiser les chaînes...",
-        "showVideos": "[TODO] Show Videos",
+        "showVideos": "Afficher les vidéos",
         "tvHelp": "Aide TV"
       },
       "name": "TV",

--- a/src/lib/locales/it/translation.json
+++ b/src/lib/locales/it/translation.json
@@ -333,7 +333,7 @@
         "appletExportedDescription": "{{fileName}}.app esportato correttamente.",
         "appletImported": "Applet importata!",
         "appletImportedDescription": "{{fileName}} salvato in /Applets{{iconText}}",
-        "appletImportedIconSuffix": "[TODO]  with {{icon}} icon",
+        "appletImportedIconSuffix": " con l'icona {{icon}}",
         "appletNotFound": "Applet non trovata",
         "appletNotFoundDescription": "L'applet condivisa potrebbe essere stata eliminata o il link non è valido.",
         "appletSaved": "Applet salvata",
@@ -714,7 +714,7 @@
         "clear": "Cancella",
         "createAccountToContinue": "Crea un account per continuare...",
         "dailyLimitReached": "Limite giornaliero di messaggi IA raggiunto.",
-        "describeThisImage": "[TODO] Describe this image",
+        "describeThisImage": "Descrivi questa immagine",
         "editing": "modifica in corso...",
         "leave": "Esci",
         "listening": "In ascolto",
@@ -742,20 +742,20 @@
         "usingModel": "Utilizzo di {{model}}"
       },
       "toasts": {
-        "aiError": "[TODO] AI Error",
-        "failedToGetResponse": "[TODO] Failed to get response.",
-        "failedToSaveTranscript": "[TODO] Failed to save transcript",
-        "loginButton": "[TODO] Login",
-        "loginRequired": "[TODO] Login Required",
-        "open": "[TODO] Open",
-        "pleaseLoginToContinueChatting": "[TODO] Please login to continue chatting.",
-        "rateLimitExceeded": "[TODO] Rate Limit Exceeded",
-        "rateLimitMessageLimitLogin": "[TODO] You've reached the message limit. Please login to continue.",
-        "savedToFileName": "[TODO] Saved to {{fileName}}",
-        "sessionExpiredLoginAgain": "[TODO] Your session has expired. Please login again.",
-        "transcriptSaved": "[TODO] Transcript saved",
-        "transcriptUpdated": "[TODO] Transcript updated",
-        "unknownError": "[TODO] Unknown error"
+        "aiError": "Errore IA",
+        "failedToGetResponse": "Impossibile ottenere una risposta.",
+        "failedToSaveTranscript": "Impossibile salvare la trascrizione",
+        "loginButton": "Accedi",
+        "loginRequired": "Accesso richiesto",
+        "open": "Apri",
+        "pleaseLoginToContinueChatting": "Accedi per continuare a chattare.",
+        "rateLimitExceeded": "Limite di richieste superato",
+        "rateLimitMessageLimitLogin": "Hai raggiunto il limite di messaggi. Accedi per continuare.",
+        "savedToFileName": "Salvato in {{fileName}}",
+        "sessionExpiredLoginAgain": "La sessione è scaduta. Effettua di nuovo l'accesso.",
+        "transcriptSaved": "Trascrizione salvata",
+        "transcriptUpdated": "Trascrizione aggiornata",
+        "unknownError": "Errore sconosciuto"
       },
       "tokenStatus": {
         "authenticated": "Accesso effettuato",
@@ -3057,10 +3057,10 @@
       },
       "description": "Fai zapping su YouTube",
       "drawer": {
-        "close": "[TODO] Hide videos",
-        "empty": "[TODO] No videos on this channel yet.",
-        "removeVideo": "[TODO] Remove from channel",
-        "title": "[TODO] Schedule"
+        "close": "Nascondi video",
+        "empty": "Ancora nessun video su questo canale.",
+        "removeVideo": "Rimuovi dal canale",
+        "title": "Programma"
       },
       "help": {
         "channels": {
@@ -3106,7 +3106,7 @@
         "play": "Riproduci",
         "previous": "Precedente",
         "resetChannels": "Ripristina canali...",
-        "showVideos": "[TODO] Show Videos",
+        "showVideos": "Mostra video",
         "tvHelp": "Aiuto TV"
       },
       "name": "TV",

--- a/src/lib/locales/ja/translation.json
+++ b/src/lib/locales/ja/translation.json
@@ -333,7 +333,7 @@
         "appletExportedDescription": "{{fileName}}.app をエクスポートしました。",
         "appletImported": "アプレットをインポートしました！",
         "appletImportedDescription": "{{fileName}} を /Applets{{iconText}} に保存しました",
-        "appletImportedIconSuffix": "[TODO]  with {{icon}} icon",
+        "appletImportedIconSuffix": "（{{icon}}アイコン付き）",
         "appletNotFound": "アプレットが見つかりません",
         "appletNotFoundDescription": "共有されたアプレットが削除されたか、リンクが無効な可能性があります。",
         "appletSaved": "アプレットを保存しました",
@@ -714,7 +714,7 @@
         "clear": "クリア",
         "createAccountToContinue": "続けるにはアカウントを作成してください...",
         "dailyLimitReached": "1日のAIメッセージ制限に達しました。",
-        "describeThisImage": "[TODO] Describe this image",
+        "describeThisImage": "この画像を説明する",
         "editing": "編集中...",
         "leave": "退出",
         "listening": "聴取中",
@@ -742,20 +742,20 @@
         "usingModel": "{{model}}を使用中"
       },
       "toasts": {
-        "aiError": "[TODO] AI Error",
-        "failedToGetResponse": "[TODO] Failed to get response.",
-        "failedToSaveTranscript": "[TODO] Failed to save transcript",
-        "loginButton": "[TODO] Login",
-        "loginRequired": "[TODO] Login Required",
-        "open": "[TODO] Open",
-        "pleaseLoginToContinueChatting": "[TODO] Please login to continue chatting.",
-        "rateLimitExceeded": "[TODO] Rate Limit Exceeded",
-        "rateLimitMessageLimitLogin": "[TODO] You've reached the message limit. Please login to continue.",
-        "savedToFileName": "[TODO] Saved to {{fileName}}",
-        "sessionExpiredLoginAgain": "[TODO] Your session has expired. Please login again.",
-        "transcriptSaved": "[TODO] Transcript saved",
-        "transcriptUpdated": "[TODO] Transcript updated",
-        "unknownError": "[TODO] Unknown error"
+        "aiError": "AIエラー",
+        "failedToGetResponse": "応答の取得に失敗しました。",
+        "failedToSaveTranscript": "文字起こしの保存に失敗しました",
+        "loginButton": "ログイン",
+        "loginRequired": "ログインが必要です",
+        "open": "開く",
+        "pleaseLoginToContinueChatting": "チャットを続けるにはログインしてください。",
+        "rateLimitExceeded": "レート制限を超過しました",
+        "rateLimitMessageLimitLogin": "メッセージの上限に達しました。続行するにはログインしてください。",
+        "savedToFileName": "{{fileName}}に保存されました",
+        "sessionExpiredLoginAgain": "セッションの期限が切れました。再度ログインしてください。",
+        "transcriptSaved": "文字起こしを保存しました",
+        "transcriptUpdated": "文字起こしを更新しました",
+        "unknownError": "不明なエラー"
       },
       "tokenStatus": {
         "authenticated": "ログイン済み",
@@ -3057,10 +3057,10 @@
       },
       "description": "YouTubeをザッピング",
       "drawer": {
-        "close": "[TODO] Hide videos",
-        "empty": "[TODO] No videos on this channel yet.",
-        "removeVideo": "[TODO] Remove from channel",
-        "title": "[TODO] Schedule"
+        "close": "動画を非表示にする",
+        "empty": "このチャンネルにはまだ動画がありません。",
+        "removeVideo": "チャンネルから削除",
+        "title": "スケジュール"
       },
       "help": {
         "channels": {
@@ -3106,7 +3106,7 @@
         "play": "再生",
         "previous": "前へ",
         "resetChannels": "チャンネルをリセット...",
-        "showVideos": "[TODO] Show Videos",
+        "showVideos": "ビデオを表示",
         "tvHelp": "TVヘルプ"
       },
       "name": "TV",

--- a/src/lib/locales/ko/translation.json
+++ b/src/lib/locales/ko/translation.json
@@ -333,7 +333,7 @@
         "appletExportedDescription": "{{fileName}}.app이 성공적으로 내보내졌습니다.",
         "appletImported": "애플릿 가져오기 완료!",
         "appletImportedDescription": "{{fileName}}이(가) /Applets{{iconText}}에 저장되었습니다",
-        "appletImportedIconSuffix": "[TODO]  with {{icon}} icon",
+        "appletImportedIconSuffix": " {{icon}} 아이콘 포함",
         "appletNotFound": "애플릿을 찾을 수 없습니다",
         "appletNotFoundDescription": "공유된 애플릿이 삭제되었거나 링크가 유효하지 않을 수 있습니다.",
         "appletSaved": "애플릿 저장됨",
@@ -714,7 +714,7 @@
         "clear": "지우기",
         "createAccountToContinue": "계속하려면 계정을 만드세요...",
         "dailyLimitReached": "일일 AI 메시지 한도에 도달했습니다.",
-        "describeThisImage": "[TODO] Describe this image",
+        "describeThisImage": "이 이미지 설명하기",
         "editing": "편집 중...",
         "leave": "나가기",
         "listening": "듣는 중",
@@ -742,20 +742,20 @@
         "usingModel": "{{model}} 사용 중"
       },
       "toasts": {
-        "aiError": "[TODO] AI Error",
-        "failedToGetResponse": "[TODO] Failed to get response.",
-        "failedToSaveTranscript": "[TODO] Failed to save transcript",
-        "loginButton": "[TODO] Login",
-        "loginRequired": "[TODO] Login Required",
-        "open": "[TODO] Open",
-        "pleaseLoginToContinueChatting": "[TODO] Please login to continue chatting.",
-        "rateLimitExceeded": "[TODO] Rate Limit Exceeded",
-        "rateLimitMessageLimitLogin": "[TODO] You've reached the message limit. Please login to continue.",
-        "savedToFileName": "[TODO] Saved to {{fileName}}",
-        "sessionExpiredLoginAgain": "[TODO] Your session has expired. Please login again.",
-        "transcriptSaved": "[TODO] Transcript saved",
-        "transcriptUpdated": "[TODO] Transcript updated",
-        "unknownError": "[TODO] Unknown error"
+        "aiError": "AI 오류",
+        "failedToGetResponse": "응답을 가져오지 못했습니다.",
+        "failedToSaveTranscript": "트랜스크립트를 저장하지 못했습니다",
+        "loginButton": "로그인",
+        "loginRequired": "로그인 필요",
+        "open": "열기",
+        "pleaseLoginToContinueChatting": "대화를 계속하려면 로그인하세요.",
+        "rateLimitExceeded": "요청 제한 초과",
+        "rateLimitMessageLimitLogin": "메시지 한도에 도달했습니다. 계속하려면 로그인하세요.",
+        "savedToFileName": "{{fileName}}에 저장됨",
+        "sessionExpiredLoginAgain": "세션이 만료되었습니다. 다시 로그인해 주세요.",
+        "transcriptSaved": "트랜스크립트 저장됨",
+        "transcriptUpdated": "트랜스크립트 업데이트됨",
+        "unknownError": "알 수 없는 오류"
       },
       "tokenStatus": {
         "authenticated": "로그인됨",
@@ -3057,10 +3057,10 @@
       },
       "description": "YouTube 채널 서핑",
       "drawer": {
-        "close": "[TODO] Hide videos",
-        "empty": "[TODO] No videos on this channel yet.",
-        "removeVideo": "[TODO] Remove from channel",
-        "title": "[TODO] Schedule"
+        "close": "동영상 숨기기",
+        "empty": "이 채널에 아직 동영상이 없습니다.",
+        "removeVideo": "채널에서 제거",
+        "title": "예약"
       },
       "help": {
         "channels": {
@@ -3106,7 +3106,7 @@
         "play": "재생",
         "previous": "이전",
         "resetChannels": "채널 재설정...",
-        "showVideos": "[TODO] Show Videos",
+        "showVideos": "동영상 보기",
         "tvHelp": "TV 도움말"
       },
       "name": "TV",

--- a/src/lib/locales/pt/translation.json
+++ b/src/lib/locales/pt/translation.json
@@ -333,7 +333,7 @@
         "appletExportedDescription": "{{fileName}}.app exportado com sucesso.",
         "appletImported": "Applet importado!",
         "appletImportedDescription": "{{fileName}} salvo em /Applets{{iconText}}",
-        "appletImportedIconSuffix": "[TODO]  with {{icon}} icon",
+        "appletImportedIconSuffix": " com o ícone {{icon}}",
         "appletNotFound": "Applet não encontrado",
         "appletNotFoundDescription": "O applet compartilhado pode ter sido excluído ou o link é inválido.",
         "appletSaved": "Applet salvo",
@@ -714,7 +714,7 @@
         "clear": "Limpar",
         "createAccountToContinue": "Crie uma conta para continuar...",
         "dailyLimitReached": "Limite diário de mensagens da IA atingido.",
-        "describeThisImage": "[TODO] Describe this image",
+        "describeThisImage": "Descreva esta imagem",
         "editing": "editando...",
         "leave": "Sair",
         "listening": "Ouvindo",
@@ -742,20 +742,20 @@
         "usingModel": "Usando {{model}}"
       },
       "toasts": {
-        "aiError": "[TODO] AI Error",
-        "failedToGetResponse": "[TODO] Failed to get response.",
-        "failedToSaveTranscript": "[TODO] Failed to save transcript",
-        "loginButton": "[TODO] Login",
-        "loginRequired": "[TODO] Login Required",
-        "open": "[TODO] Open",
-        "pleaseLoginToContinueChatting": "[TODO] Please login to continue chatting.",
-        "rateLimitExceeded": "[TODO] Rate Limit Exceeded",
-        "rateLimitMessageLimitLogin": "[TODO] You've reached the message limit. Please login to continue.",
-        "savedToFileName": "[TODO] Saved to {{fileName}}",
-        "sessionExpiredLoginAgain": "[TODO] Your session has expired. Please login again.",
-        "transcriptSaved": "[TODO] Transcript saved",
-        "transcriptUpdated": "[TODO] Transcript updated",
-        "unknownError": "[TODO] Unknown error"
+        "aiError": "Erro de IA",
+        "failedToGetResponse": "Falha ao obter resposta.",
+        "failedToSaveTranscript": "Falha ao salvar a transcrição",
+        "loginButton": "Entrar",
+        "loginRequired": "Login necessário",
+        "open": "Abrir",
+        "pleaseLoginToContinueChatting": "Por favor, faça login para continuar conversando.",
+        "rateLimitExceeded": "Limite de taxa excedido",
+        "rateLimitMessageLimitLogin": "Você atingiu o limite de mensagens. Por favor, faça login para continuar.",
+        "savedToFileName": "Salvo em {{fileName}}",
+        "sessionExpiredLoginAgain": "Sua sessão expirou. Por favor, faça login novamente.",
+        "transcriptSaved": "Transcrição salva",
+        "transcriptUpdated": "Transcrição atualizada",
+        "unknownError": "Erro desconhecido"
       },
       "tokenStatus": {
         "authenticated": "Sessão iniciada",
@@ -3057,10 +3057,10 @@
       },
       "description": "Zapeie pelo YouTube",
       "drawer": {
-        "close": "[TODO] Hide videos",
-        "empty": "[TODO] No videos on this channel yet.",
-        "removeVideo": "[TODO] Remove from channel",
-        "title": "[TODO] Schedule"
+        "close": "Ocultar vídeos",
+        "empty": "Ainda não há vídeos neste canal.",
+        "removeVideo": "Remover do canal",
+        "title": "Agendar"
       },
       "help": {
         "channels": {
@@ -3106,7 +3106,7 @@
         "play": "Reproduzir",
         "previous": "Anterior",
         "resetChannels": "Redefinir canais...",
-        "showVideos": "[TODO] Show Videos",
+        "showVideos": "Mostrar Vídeos",
         "tvHelp": "Ajuda da TV"
       },
       "name": "TV",

--- a/src/lib/locales/ru/translation.json
+++ b/src/lib/locales/ru/translation.json
@@ -333,7 +333,7 @@
         "appletExportedDescription": "{{fileName}}.app успешно экспортирован.",
         "appletImported": "Апплет импортирован!",
         "appletImportedDescription": "{{fileName}} сохранен в /Applets{{iconText}}",
-        "appletImportedIconSuffix": "[TODO]  with {{icon}} icon",
+        "appletImportedIconSuffix": " с иконкой {{icon}}",
         "appletNotFound": "Апплет не найден",
         "appletNotFoundDescription": "Общий апплет, возможно, был удален, или ссылка недействительна.",
         "appletSaved": "Апплет сохранен",
@@ -714,7 +714,7 @@
         "clear": "Очистить",
         "createAccountToContinue": "Создайте аккаунт, чтобы продолжить...",
         "dailyLimitReached": "Достигнут дневной лимит сообщений ИИ.",
-        "describeThisImage": "[TODO] Describe this image",
+        "describeThisImage": "Опишите это изображение",
         "editing": "редактирование...",
         "leave": "Покинуть",
         "listening": "Слушаю",
@@ -742,20 +742,20 @@
         "usingModel": "Используется {{model}}"
       },
       "toasts": {
-        "aiError": "[TODO] AI Error",
-        "failedToGetResponse": "[TODO] Failed to get response.",
-        "failedToSaveTranscript": "[TODO] Failed to save transcript",
-        "loginButton": "[TODO] Login",
-        "loginRequired": "[TODO] Login Required",
-        "open": "[TODO] Open",
-        "pleaseLoginToContinueChatting": "[TODO] Please login to continue chatting.",
-        "rateLimitExceeded": "[TODO] Rate Limit Exceeded",
-        "rateLimitMessageLimitLogin": "[TODO] You've reached the message limit. Please login to continue.",
-        "savedToFileName": "[TODO] Saved to {{fileName}}",
-        "sessionExpiredLoginAgain": "[TODO] Your session has expired. Please login again.",
-        "transcriptSaved": "[TODO] Transcript saved",
-        "transcriptUpdated": "[TODO] Transcript updated",
-        "unknownError": "[TODO] Unknown error"
+        "aiError": "Ошибка ИИ",
+        "failedToGetResponse": "Не удалось получить ответ.",
+        "failedToSaveTranscript": "Не удалось сохранить транскрипт",
+        "loginButton": "Войти",
+        "loginRequired": "Требуется вход",
+        "open": "Открыть",
+        "pleaseLoginToContinueChatting": "Пожалуйста, войдите, чтобы продолжить общение.",
+        "rateLimitExceeded": "Превышен лимит запросов",
+        "rateLimitMessageLimitLogin": "Вы достигли лимита сообщений. Пожалуйста, войдите, чтобы продолжить.",
+        "savedToFileName": "Сохранено в {{fileName}}",
+        "sessionExpiredLoginAgain": "Срок действия сессии истек. Пожалуйста, войдите снова.",
+        "transcriptSaved": "Транскрипт сохранен",
+        "transcriptUpdated": "Транскрипт обновлен",
+        "unknownError": "Неизвестная ошибка"
       },
       "tokenStatus": {
         "authenticated": "Выполнен вход",
@@ -3057,10 +3057,10 @@
       },
       "description": "Сёрфинг по каналам YouTube",
       "drawer": {
-        "close": "[TODO] Hide videos",
-        "empty": "[TODO] No videos on this channel yet.",
-        "removeVideo": "[TODO] Remove from channel",
-        "title": "[TODO] Schedule"
+        "close": "Скрыть видео",
+        "empty": "На этом канале пока нет видео.",
+        "removeVideo": "Удалить с канала",
+        "title": "Запланировать"
       },
       "help": {
         "channels": {
@@ -3106,7 +3106,7 @@
         "play": "Воспроизвести",
         "previous": "Предыдущий",
         "resetChannels": "Сбросить каналы...",
-        "showVideos": "[TODO] Show Videos",
+        "showVideos": "Показать видео",
         "tvHelp": "Справка ТВ"
       },
       "name": "ТВ",

--- a/src/lib/locales/zh-TW/translation.json
+++ b/src/lib/locales/zh-TW/translation.json
@@ -333,7 +333,7 @@
         "appletExportedDescription": "{{fileName}}.app 已成功匯出。",
         "appletImported": "小程式已匯入！",
         "appletImportedDescription": "{{fileName}} 已儲存至 /Applets{{iconText}}",
-        "appletImportedIconSuffix": "[TODO]  with {{icon}} icon",
+        "appletImportedIconSuffix": " 帶有 {{icon}} 圖示",
         "appletNotFound": "找不到小程式",
         "appletNotFoundDescription": "該分享的小程式可能已被刪除或連結無效。",
         "appletSaved": "小程式已儲存",
@@ -714,7 +714,7 @@
         "clear": "清除",
         "createAccountToContinue": "建立帳戶以繼續...",
         "dailyLimitReached": "已達每日 AI 訊息限制。",
-        "describeThisImage": "[TODO] Describe this image",
+        "describeThisImage": "描述此圖片",
         "editing": "正在編輯...",
         "leave": "離開",
         "listening": "聆聽中",
@@ -742,20 +742,20 @@
         "usingModel": "使用 {{model}}"
       },
       "toasts": {
-        "aiError": "[TODO] AI Error",
-        "failedToGetResponse": "[TODO] Failed to get response.",
-        "failedToSaveTranscript": "[TODO] Failed to save transcript",
-        "loginButton": "[TODO] Login",
-        "loginRequired": "[TODO] Login Required",
-        "open": "[TODO] Open",
-        "pleaseLoginToContinueChatting": "[TODO] Please login to continue chatting.",
-        "rateLimitExceeded": "[TODO] Rate Limit Exceeded",
-        "rateLimitMessageLimitLogin": "[TODO] You've reached the message limit. Please login to continue.",
-        "savedToFileName": "[TODO] Saved to {{fileName}}",
-        "sessionExpiredLoginAgain": "[TODO] Your session has expired. Please login again.",
-        "transcriptSaved": "[TODO] Transcript saved",
-        "transcriptUpdated": "[TODO] Transcript updated",
-        "unknownError": "[TODO] Unknown error"
+        "aiError": "AI 錯誤",
+        "failedToGetResponse": "無法取得回應。",
+        "failedToSaveTranscript": "無法儲存逐字稿",
+        "loginButton": "登入",
+        "loginRequired": "需要登入",
+        "open": "開啟",
+        "pleaseLoginToContinueChatting": "請登入以繼續對話。",
+        "rateLimitExceeded": "已達速率限制",
+        "rateLimitMessageLimitLogin": "您已達到訊息上限。請登入以繼續。",
+        "savedToFileName": "已儲存至 {{fileName}}",
+        "sessionExpiredLoginAgain": "您的工作階段已過期。請重新登入。",
+        "transcriptSaved": "逐字稿已儲存",
+        "transcriptUpdated": "逐字稿已更新",
+        "unknownError": "未知錯誤"
       },
       "tokenStatus": {
         "authenticated": "已登入",
@@ -3057,10 +3057,10 @@
       },
       "description": "在 YouTube 上轉台",
       "drawer": {
-        "close": "[TODO] Hide videos",
-        "empty": "[TODO] No videos on this channel yet.",
-        "removeVideo": "[TODO] Remove from channel",
-        "title": "[TODO] Schedule"
+        "close": "隱藏影片",
+        "empty": "此頻道尚無影片。",
+        "removeVideo": "從頻道中移除",
+        "title": "排程"
       },
       "help": {
         "channels": {
@@ -3106,7 +3106,7 @@
         "play": "播放",
         "previous": "上一個",
         "resetChannels": "重設頻道...",
-        "showVideos": "[TODO] Show Videos",
+        "showVideos": "顯示影片",
         "tvHelp": "電視說明"
       },
       "name": "電視",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Translated the remaining `[TODO]` locale entries across de, es, fr, it, ja, ko, pt, ru, and zh-TW.
- Covered Chats status/toast strings, TV drawer/menu labels, and the Applet import icon suffix.

## Testing
- `bun run scripts/machine-translate.ts --dry-run` — confirmed 0 remaining `[TODO]` keys across all non-English locales.
- `bun --eval '<placeholder consistency check>'` — validated 21 changed keys across 9 locales and preserved interpolation placeholders.
- `bun run scripts/sync-translations.ts --dry-run` — confirmed 0 missing locale keys.
- `bun run build` — production build completed successfully.
- `bun run scripts/find-untranslated-strings.ts` — completed, but the scanner reports broad pre-existing potential hardcoded strings/false positives outside this translation-only change.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-db55d4ad-0e3a-486e-a74c-8572cb08ed19"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-db55d4ad-0e3a-486e-a74c-8572cb08ed19"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

