### PR TITLE
Fix TV hidden default channel reset sync

### DIFF
--- a/src/hooks/useAutoCloudSync.ts
+++ b/src/hooks/useAutoCloudSync.ts
@@ -1086,6 +1086,9 @@ export function useAutoCloudSync() {
           const tvState = useTvStore.getState();
           const hasLocalTvState =
             tvState.customChannels.length > 0 ||
+            tvState.hiddenDefaultChannelIds.length > 0 ||
+            Boolean(tvState.hiddenDefaultChannelIdsUpdatedAt) ||
+            Boolean(tvState.hiddenDefaultChannelIdsResetAt) ||
             tvState.lcdFilterOn !== true ||
             tvState.closedCaptionsOn !== true;
           if (hasLocalTvState) {
@@ -1467,6 +1470,10 @@ export function useAutoCloudSync() {
       if (
         state.customChannels !== prevState.customChannels ||
         state.hiddenDefaultChannelIds !== prevState.hiddenDefaultChannelIds ||
+        state.hiddenDefaultChannelIdsUpdatedAt !==
+          prevState.hiddenDefaultChannelIdsUpdatedAt ||
+        state.hiddenDefaultChannelIdsResetAt !==
+          prevState.hiddenDefaultChannelIdsResetAt ||
         state.lcdFilterOn !== prevState.lcdFilterOn ||
         state.closedCaptionsOn !== prevState.closedCaptionsOn
       ) {

--- a/src/stores/useTvStore.ts
+++ b/src/stores/useTvStore.ts
@@ -38,6 +38,8 @@ interface TvStoreState {
   isPlaying: boolean;
   customChannels: CustomChannel[];
   hiddenDefaultChannelIds: string[];
+  hiddenDefaultChannelIdsUpdatedAt: string | null;
+  hiddenDefaultChannelIdsResetAt: string | null;
   /** Whether the persistent CRT scanline / vignette overlay is on. */
   lcdFilterOn: boolean;
   /** MTV (and similar) word-timed lyric captions over the picture. */
@@ -97,6 +99,8 @@ export const useTvStore = create<TvStoreState>()(
       isPlaying: false,
       customChannels: [],
       hiddenDefaultChannelIds: [],
+      hiddenDefaultChannelIdsUpdatedAt: null,
+      hiddenDefaultChannelIdsResetAt: null,
       lcdFilterOn: true,
       closedCaptionsOn: true,
       setCurrentChannelId: (id) => set({ currentChannelId: id }),
@@ -134,10 +138,11 @@ export const useTvStore = create<TvStoreState>()(
           const customChannels = isDefault
             ? s.customChannels
             : s.customChannels.filter((c) => c.id !== id);
-          const hiddenDefaultChannelIds =
-            isDefault && !s.hiddenDefaultChannelIds.includes(id)
-              ? [...s.hiddenDefaultChannelIds, id]
-              : s.hiddenDefaultChannelIds;
+          const isNewlyHiddenDefault =
+            isDefault && !s.hiddenDefaultChannelIds.includes(id);
+          const hiddenDefaultChannelIds = isNewlyHiddenDefault
+            ? [...s.hiddenDefaultChannelIds, id]
+            : s.hiddenDefaultChannelIds;
           if (!isDefault && s.customChannels.some((c) => c.id === id)) {
             useCloudSyncStore
               .getState()
@@ -151,6 +156,9 @@ export const useTvStore = create<TvStoreState>()(
           return {
             customChannels,
             hiddenDefaultChannelIds,
+            hiddenDefaultChannelIdsUpdatedAt: isNewlyHiddenDefault
+              ? new Date().toISOString()
+              : s.hiddenDefaultChannelIdsUpdatedAt,
             currentChannelId: fallbackId,
           };
         }),
@@ -324,6 +332,7 @@ export const useTvStore = create<TvStoreState>()(
       },
       resetChannels: () => {
         const customChannelIds = get().customChannels.map((channel) => channel.id);
+        const hiddenDefaultChannelIdsResetAt = new Date().toISOString();
         if (customChannelIds.length > 0) {
           useCloudSyncStore
             .getState()
@@ -332,6 +341,8 @@ export const useTvStore = create<TvStoreState>()(
         set({
           customChannels: [],
           hiddenDefaultChannelIds: [],
+          hiddenDefaultChannelIdsUpdatedAt: hiddenDefaultChannelIdsResetAt,
+          hiddenDefaultChannelIdsResetAt,
           currentChannelId: DEFAULT_CHANNEL_ID,
           lastVideoIndexByChannel: {},
         });
@@ -339,7 +350,7 @@ export const useTvStore = create<TvStoreState>()(
     }),
     {
       name: "ryos:tv",
-      version: 4,
+      version: 5,
       migrate: (persisted, version) => {
         if (!persisted || typeof persisted !== "object") {
           return persisted as typeof persisted;
@@ -347,6 +358,8 @@ export const useTvStore = create<TvStoreState>()(
         const state = persisted as {
           customChannels?: CustomChannel[];
           hiddenDefaultChannelIds?: unknown;
+          hiddenDefaultChannelIdsUpdatedAt?: unknown;
+          hiddenDefaultChannelIdsResetAt?: unknown;
         };
         if (version < 4 && Array.isArray(state.customChannels)) {
           state.customChannels = state.customChannels.map((entry) => {
@@ -359,6 +372,12 @@ export const useTvStore = create<TvStoreState>()(
         if (!Array.isArray(state.hiddenDefaultChannelIds)) {
           state.hiddenDefaultChannelIds = [];
         }
+        if (typeof state.hiddenDefaultChannelIdsUpdatedAt !== "string") {
+          state.hiddenDefaultChannelIdsUpdatedAt = null;
+        }
+        if (typeof state.hiddenDefaultChannelIdsResetAt !== "string") {
+          state.hiddenDefaultChannelIdsResetAt = null;
+        }
         return state as typeof persisted;
       },
       // Channel lineup rotation uses an in-memory per-channel shuffle (see
@@ -367,6 +386,8 @@ export const useTvStore = create<TvStoreState>()(
         currentChannelId: s.currentChannelId,
         customChannels: s.customChannels,
         hiddenDefaultChannelIds: s.hiddenDefaultChannelIds,
+        hiddenDefaultChannelIdsUpdatedAt: s.hiddenDefaultChannelIdsUpdatedAt,
+        hiddenDefaultChannelIdsResetAt: s.hiddenDefaultChannelIdsResetAt,
         lcdFilterOn: s.lcdFilterOn,
         closedCaptionsOn: s.closedCaptionsOn,
       }),

--- a/src/sync/domains.ts
+++ b/src/sync/domains.ts
@@ -153,6 +153,8 @@ interface VideosSnapshotData {
 interface TvSnapshotData {
   customChannels: CustomChannel[];
   hiddenDefaultChannelIds?: string[];
+  hiddenDefaultChannelIdsUpdatedAt?: string | null;
+  hiddenDefaultChannelIdsResetAt?: string | null;
   deletedCustomChannelIds?: DeletionMarkerMap;
   lcdFilterOn: boolean;
   closedCaptionsOn: boolean;
@@ -189,6 +191,15 @@ type AnySnapshotData =
   | CalendarSnapshotData
   | ContactsSnapshotData
   | CustomWallpapersSnapshotData;
+
+function parseSyncTimestamp(value: string | null | undefined): number {
+  if (!value) {
+    return 0;
+  }
+
+  const parsed = new Date(value).getTime();
+  return Number.isFinite(parsed) ? parsed : 0;
+}
 
 interface SerializedStoreItemRecord {
   item: StoreItemWithKey;
@@ -698,6 +709,8 @@ function serializeTvSnapshot(): TvSnapshotData {
   return {
     customChannels: tvState.customChannels,
     hiddenDefaultChannelIds: tvState.hiddenDefaultChannelIds,
+    hiddenDefaultChannelIdsUpdatedAt: tvState.hiddenDefaultChannelIdsUpdatedAt,
+    hiddenDefaultChannelIdsResetAt: tvState.hiddenDefaultChannelIdsResetAt,
     deletedCustomChannelIds: deletionMarkers.tvCustomChannelIds,
     lcdFilterOn: tvState.lcdFilterOn,
     closedCaptionsOn: tvState.closedCaptionsOn,
@@ -1133,6 +1146,14 @@ function applyTvSnapshot(data: TvSnapshotData): void {
     hiddenDefaultChannelIds: Array.isArray(data.hiddenDefaultChannelIds)
       ? data.hiddenDefaultChannelIds
       : [],
+    hiddenDefaultChannelIdsUpdatedAt:
+      typeof data.hiddenDefaultChannelIdsUpdatedAt === "string"
+        ? data.hiddenDefaultChannelIdsUpdatedAt
+        : null,
+    hiddenDefaultChannelIdsResetAt:
+      typeof data.hiddenDefaultChannelIdsResetAt === "string"
+        ? data.hiddenDefaultChannelIdsResetAt
+        : null,
     lcdFilterOn: data.lcdFilterOn ?? true,
     closedCaptionsOn: data.closedCaptionsOn ?? true,
   });
@@ -1582,17 +1603,41 @@ function mergeTvSnapshots(
     normalizeDeletionMarkerMap(local.deletedCustomChannelIds),
     normalizeDeletionMarkerMap(remote.deletedCustomChannelIds)
   );
+  const localHiddenUpdatedAt = parseSyncTimestamp(
+    local.hiddenDefaultChannelIdsUpdatedAt
+  );
+  const remoteHiddenUpdatedAt = parseSyncTimestamp(
+    remote.hiddenDefaultChannelIdsUpdatedAt
+  );
+  const localResetAt = parseSyncTimestamp(local.hiddenDefaultChannelIdsResetAt);
+  const remoteResetAt = parseSyncTimestamp(remote.hiddenDefaultChannelIdsResetAt);
+  const hiddenDefaultChannelIds =
+    localResetAt > remoteHiddenUpdatedAt && localResetAt >= remoteResetAt
+      ? local.hiddenDefaultChannelIds || []
+      : remoteResetAt > localHiddenUpdatedAt && remoteResetAt > localResetAt
+        ? remote.hiddenDefaultChannelIds || []
+        : Array.from(
+            new Set([
+              ...(local.hiddenDefaultChannelIds || []),
+              ...(remote.hiddenDefaultChannelIds || []),
+            ])
+          );
+  const hiddenDefaultChannelIdsUpdatedAt =
+    localHiddenUpdatedAt >= remoteHiddenUpdatedAt
+      ? local.hiddenDefaultChannelIdsUpdatedAt ?? null
+      : remote.hiddenDefaultChannelIdsUpdatedAt ?? null;
+  const hiddenDefaultChannelIdsResetAt =
+    localResetAt >= remoteResetAt
+      ? local.hiddenDefaultChannelIdsResetAt ?? null
+      : remote.hiddenDefaultChannelIdsResetAt ?? null;
   return {
     customChannels: mergeItemsById(
       filterDeletedIds(local.customChannels || [], mergedDeleted, (channel) => channel.id),
       filterDeletedIds(remote.customChannels || [], mergedDeleted, (channel) => channel.id)
     ),
-    hiddenDefaultChannelIds: Array.from(
-      new Set([
-        ...(local.hiddenDefaultChannelIds || []),
-        ...(remote.hiddenDefaultChannelIds || []),
-      ])
-    ),
+    hiddenDefaultChannelIds,
+    hiddenDefaultChannelIdsUpdatedAt,
+    hiddenDefaultChannelIdsResetAt,
     deletedCustomChannelIds: mergedDeleted,
     lcdFilterOn: local.lcdFilterOn,
     closedCaptionsOn: local.closedCaptionsOn,

--- a/tests/test-cloud-sync-tv-upload-apply.test.ts
+++ b/tests/test-cloud-sync-tv-upload-apply.test.ts
@@ -189,6 +189,9 @@ beforeEach(async () => {
       state: {
         currentChannelId: "ryos-picks",
         customChannels: [],
+        hiddenDefaultChannelIds: [],
+        hiddenDefaultChannelIdsUpdatedAt: null,
+        hiddenDefaultChannelIdsResetAt: null,
         lcdFilterOn: true,
         closedCaptionsOn: true,
       },
@@ -227,6 +230,8 @@ describe("cloud sync TV upload apply", () => {
       currentChannelId: "ryos-picks",
       customChannels: [makeChannel("local")],
       hiddenDefaultChannelIds: ["taiwan"],
+      hiddenDefaultChannelIdsUpdatedAt: "2026-03-22T09:58:00.000Z",
+      hiddenDefaultChannelIdsResetAt: null,
       lcdFilterOn: true,
       closedCaptionsOn: true,
     });
@@ -248,6 +253,9 @@ describe("cloud sync TV upload apply", () => {
                 data: {
                   customChannels: [makeChannel("remote")],
                   hiddenDefaultChannelIds: ["tokki-mix"],
+                  hiddenDefaultChannelIdsUpdatedAt:
+                    "2026-03-22T09:59:00.000Z",
+                  hiddenDefaultChannelIdsResetAt: null,
                   lcdFilterOn: false,
                   closedCaptionsOn: false,
                 },
@@ -268,6 +276,10 @@ describe("cloud sync TV upload apply", () => {
       if (
         state.customChannels !== prevState.customChannels ||
         state.hiddenDefaultChannelIds !== prevState.hiddenDefaultChannelIds ||
+        state.hiddenDefaultChannelIdsUpdatedAt !==
+          prevState.hiddenDefaultChannelIdsUpdatedAt ||
+        state.hiddenDefaultChannelIdsResetAt !==
+          prevState.hiddenDefaultChannelIdsResetAt ||
         state.lcdFilterOn !== prevState.lcdFilterOn ||
         state.closedCaptionsOn !== prevState.closedCaptionsOn
       ) {
@@ -286,6 +298,8 @@ describe("cloud sync TV upload apply", () => {
         data: {
           customChannels: CustomChannel[];
           hiddenDefaultChannelIds: string[];
+          hiddenDefaultChannelIdsUpdatedAt?: string | null;
+          hiddenDefaultChannelIdsResetAt?: string | null;
           deletedCustomChannelIds?: Record<string, string>;
           lcdFilterOn: boolean;
           closedCaptionsOn: boolean;
@@ -299,6 +313,10 @@ describe("cloud sync TV upload apply", () => {
         "taiwan",
         "tokki-mix",
       ]);
+      expect(payload.data.hiddenDefaultChannelIdsUpdatedAt).toBe(
+        "2026-03-22T09:59:00.000Z"
+      );
+      expect(payload.data.hiddenDefaultChannelIdsResetAt).toBeNull();
       expect(payload.data.deletedCustomChannelIds ?? {}).toEqual({});
       expect(payload.data.lcdFilterOn).toBe(true);
       expect(payload.data.closedCaptionsOn).toBe(true);
@@ -308,9 +326,111 @@ describe("cloud sync TV upload apply", () => {
         "taiwan",
         "tokki-mix",
       ]);
+      expect(useTvStore.getState().hiddenDefaultChannelIdsUpdatedAt).toBe(
+        "2026-03-22T09:59:00.000Z"
+      );
       expect(queuedDuringApply).toEqual([]);
     } finally {
       unsubscribe();
+      globalThis.fetch = originalFetch;
+      invalidateRedisStateSnapshotForUpload(username, "tv");
+    }
+  });
+
+  test("TV upload merge keeps reset default channels visible over stale remote hidden channels", async () => {
+    const { useTvStore } = await import("../src/stores/useTvStore");
+    const { prepareCloudSyncDomainWrite, invalidateRedisStateSnapshotForUpload } =
+      await import("../src/sync/domains");
+
+    const username = `tv-reset-hidden-defaults-${Date.now()}`;
+    invalidateRedisStateSnapshotForUpload(username, "tv");
+    useTvStore.setState({
+      currentChannelId: "ryos-picks",
+      customChannels: [],
+      hiddenDefaultChannelIds: ["taiwan"],
+      hiddenDefaultChannelIdsUpdatedAt: "2026-03-22T09:58:00.000Z",
+      hiddenDefaultChannelIdsResetAt: null,
+      lcdFilterOn: true,
+      closedCaptionsOn: true,
+    });
+    const originalDate = globalThis.Date;
+    const resetAt = "2026-03-22T10:00:00.000Z";
+    const fixedNow = new originalDate(resetAt);
+    globalThis.Date = class extends originalDate {
+      constructor(...args: ConstructorParameters<typeof Date>) {
+        super(...(args.length === 0 ? [fixedNow] : args));
+      }
+
+      static now(): number {
+        return fixedNow.getTime();
+      }
+    } as typeof Date;
+    try {
+      useTvStore.getState().resetChannels();
+    } finally {
+      globalThis.Date = originalDate;
+    }
+
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async (input) => {
+      const url =
+        typeof input === "string"
+          ? input
+          : input instanceof URL
+            ? input.toString()
+            : input.url;
+      if (url.endsWith("/api/sync/domains/tv")) {
+        return new Response(
+          JSON.stringify({
+            parts: {
+              tv: {
+                metadata: makeMetadata("2026-03-22T09:59:00.000Z"),
+                data: {
+                  customChannels: [],
+                  hiddenDefaultChannelIds: ["taiwan"],
+                  hiddenDefaultChannelIdsUpdatedAt:
+                    "2026-03-22T09:58:00.000Z",
+                  hiddenDefaultChannelIdsResetAt: null,
+                  lcdFilterOn: false,
+                  closedCaptionsOn: false,
+                },
+              },
+            },
+          }),
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }
+        );
+      }
+      throw new Error(`Unexpected fetch in test: ${url}`);
+    }) as typeof fetch;
+
+    try {
+      const prepared = await prepareCloudSyncDomainWrite("tv", {
+        username,
+        isAuthenticated: true,
+      });
+      const payload = prepared.payload as {
+        data: {
+          hiddenDefaultChannelIds: string[];
+          hiddenDefaultChannelIdsUpdatedAt?: string | null;
+          hiddenDefaultChannelIdsResetAt?: string | null;
+        };
+      };
+
+      expect(payload.data.hiddenDefaultChannelIds).toEqual([]);
+      expect(payload.data.hiddenDefaultChannelIdsUpdatedAt).toBe(
+        "2026-03-22T10:00:00.000Z"
+      );
+      expect(payload.data.hiddenDefaultChannelIdsResetAt).toBe(
+        "2026-03-22T10:00:00.000Z"
+      );
+
+      await prepared.onCommitted?.(makeMetadata("2026-03-22T10:01:00.000Z"));
+      expect(useTvStore.getState().hiddenDefaultChannelIds).toEqual([]);
+    } finally {
+      globalThis.Date = originalDate;
       globalThis.fetch = originalFetch;
       invalidateRedisStateSnapshotForUpload(username, "tv");
     }
@@ -328,6 +448,8 @@ describe("cloud sync TV upload apply", () => {
       currentChannelId: "ryos-picks",
       customChannels: [makeChannel("remote")],
       hiddenDefaultChannelIds: [],
+      hiddenDefaultChannelIdsUpdatedAt: null,
+      hiddenDefaultChannelIdsResetAt: null,
       lcdFilterOn: true,
       closedCaptionsOn: true,
     });
@@ -350,6 +472,8 @@ describe("cloud sync TV upload apply", () => {
                 data: {
                   customChannels: [makeChannel("remote")],
                   hiddenDefaultChannelIds: [],
+                  hiddenDefaultChannelIdsUpdatedAt: null,
+                  hiddenDefaultChannelIdsResetAt: null,
                   lcdFilterOn: false,
                   closedCaptionsOn: false,
                 },
@@ -402,6 +526,8 @@ describe("cloud sync TV upload apply", () => {
       currentChannelId: "ryos-picks",
       customChannels: [],
       hiddenDefaultChannelIds: [],
+      hiddenDefaultChannelIdsUpdatedAt: null,
+      hiddenDefaultChannelIdsResetAt: null,
       lcdFilterOn: true,
       closedCaptionsOn: true,
     });
@@ -411,6 +537,10 @@ describe("cloud sync TV upload apply", () => {
       if (
         state.customChannels !== prevState.customChannels ||
         state.hiddenDefaultChannelIds !== prevState.hiddenDefaultChannelIds ||
+        state.hiddenDefaultChannelIdsUpdatedAt !==
+          prevState.hiddenDefaultChannelIdsUpdatedAt ||
+        state.hiddenDefaultChannelIdsResetAt !==
+          prevState.hiddenDefaultChannelIdsResetAt ||
         state.lcdFilterOn !== prevState.lcdFilterOn ||
         state.closedCaptionsOn !== prevState.closedCaptionsOn
       ) {
@@ -426,6 +556,8 @@ describe("cloud sync TV upload apply", () => {
         {
           customChannels: [makeChannel("local"), makeChannel("remote")],
           hiddenDefaultChannelIds: ["taiwan"],
+          hiddenDefaultChannelIdsUpdatedAt: "2026-03-22T09:59:00.000Z",
+          hiddenDefaultChannelIdsResetAt: null,
           lcdFilterOn: true,
           closedCaptionsOn: true,
         },
@@ -437,6 +569,9 @@ describe("cloud sync TV upload apply", () => {
         "remote",
       ]);
       expect(useTvStore.getState().hiddenDefaultChannelIds).toEqual(["taiwan"]);
+      expect(useTvStore.getState().hiddenDefaultChannelIdsUpdatedAt).toBe(
+        "2026-03-22T09:59:00.000Z"
+      );
       expect(queuedDuringApply).toEqual([]);
     } finally {
       unsubscribe();
@@ -456,6 +591,8 @@ describe("cloud sync TV upload apply", () => {
       currentChannelId: "ryos-picks",
       customChannels: [],
       hiddenDefaultChannelIds: [],
+      hiddenDefaultChannelIdsUpdatedAt: null,
+      hiddenDefaultChannelIdsResetAt: null,
       lcdFilterOn: true,
       closedCaptionsOn: true,
     });
@@ -465,6 +602,10 @@ describe("cloud sync TV upload apply", () => {
       if (
         state.customChannels !== prevState.customChannels ||
         state.hiddenDefaultChannelIds !== prevState.hiddenDefaultChannelIds ||
+        state.hiddenDefaultChannelIdsUpdatedAt !==
+          prevState.hiddenDefaultChannelIdsUpdatedAt ||
+        state.hiddenDefaultChannelIdsResetAt !==
+          prevState.hiddenDefaultChannelIdsResetAt ||
         state.lcdFilterOn !== prevState.lcdFilterOn ||
         state.closedCaptionsOn !== prevState.closedCaptionsOn
       ) {
@@ -480,6 +621,8 @@ describe("cloud sync TV upload apply", () => {
         data: {
           customChannels: [makeChannel("downloaded")],
           hiddenDefaultChannelIds: ["taiwan"],
+          hiddenDefaultChannelIdsUpdatedAt: "2026-03-22T10:04:00.000Z",
+          hiddenDefaultChannelIdsResetAt: null,
           lcdFilterOn: true,
           closedCaptionsOn: true,
         },
@@ -489,6 +632,9 @@ describe("cloud sync TV upload apply", () => {
         "downloaded",
       ]);
       expect(useTvStore.getState().hiddenDefaultChannelIds).toEqual(["taiwan"]);
+      expect(useTvStore.getState().hiddenDefaultChannelIdsUpdatedAt).toBe(
+        "2026-03-22T10:04:00.000Z"
+      );
       expect(queuedDuringApply).toEqual([]);
     } finally {
       unsubscribe();

--- a/tests/test-tv-store-default-channel-removal.test.ts
+++ b/tests/test-tv-store-default-channel-removal.test.ts
@@ -14,6 +14,8 @@ describe("TV store default channel removal", () => {
       isPlaying: false,
       customChannels: [],
       hiddenDefaultChannelIds: [],
+      hiddenDefaultChannelIdsUpdatedAt: null,
+      hiddenDefaultChannelIdsResetAt: null,
       lcdFilterOn: true,
       closedCaptionsOn: true,
     });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Track TV default-channel hide and reset timestamps in persisted state and cloud sync snapshots.
- Resolve TV sync conflicts so an explicit reset keeps deleted default channels visible when the cloud still has stale hidden-channel data.
- Add regression coverage for reset-vs-stale-cloud hidden default channels.

### Testing
- `bun test tests/test-tv-store-default-channel-removal.test.ts tests/test-cloud-sync-tv-upload-apply.test.ts`
- `bun run build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-87115a0b-8fa4-4647-beea-94be9ae91da1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-87115a0b-8fa4-4647-beea-94be9ae91da1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

