### PR TITLE
fix(chats): Cursor agent card Space key + follow-up submit UI

### DIFF
--- a/src/apps/chats/components/ChatInput.tsx
+++ b/src/apps/chats/components/ChatInput.tsx
@@ -25,6 +25,32 @@ import { preprocessImage } from "@/utils/imagePreprocessing";
 // Number of frequency bands for the full-width waveform
 const WAVEFORM_BANDS = 48;
 
+/** True when keyboard focus is in a text field other than this component's main input (e.g. tool cards). */
+function focusIsInOtherTextField(mainInputEl: HTMLInputElement | null): boolean {
+  const active = document.activeElement;
+  if (!active || !(active instanceof HTMLElement)) return false;
+  if (mainInputEl && active === mainInputEl) return false;
+  if (active.isContentEditable) return true;
+  const tag = active.tagName;
+  if (tag === "TEXTAREA") return true;
+  if (tag === "INPUT") {
+    const input = active as HTMLInputElement;
+    if (input.readOnly || input.disabled) return false;
+    const textLikeTypes = new Set([
+      "text",
+      "search",
+      "email",
+      "password",
+      "url",
+      "tel",
+      "number",
+      "",
+    ]);
+    return textLikeTypes.has(input.type);
+  }
+  return Boolean(active.closest("[contenteditable=true]"));
+}
+
 // Animated ellipsis component (copied from TerminalAppComponent)
 function AnimatedEllipsis() {
   const [dots, setDots] = useState("");
@@ -392,6 +418,7 @@ export function ChatInput({
         !e.repeat &&
         isForeground &&
         !isFocused &&
+        !focusIsInOtherTextField(inputRef.current) &&
         !isTranscribing
       ) {
         e.preventDefault();
@@ -400,7 +427,13 @@ export function ChatInput({
     };
 
     const handleKeyUp = (e: KeyboardEvent) => {
-      if (e.code === "Space" && isForeground && !isFocused && isTranscribing) {
+      if (
+        e.code === "Space" &&
+        isForeground &&
+        !isFocused &&
+        !focusIsInOtherTextField(inputRef.current) &&
+        isTranscribing
+      ) {
         e.preventDefault();
         audioButtonRef.current?.click();
       }

--- a/src/components/shared/CursorRepoAgentChatCard.tsx
+++ b/src/components/shared/CursorRepoAgentChatCard.tsx
@@ -1,4 +1,4 @@
-import { ArrowSquareOut, Check, PaperPlaneRight } from "@phosphor-icons/react";
+import { ArrowSquareOut, ArrowUp, Check } from "@phosphor-icons/react";
 import {
   KeyboardEvent,
   useCallback,
@@ -248,7 +248,7 @@ export function CursorRepoAgentChatCard({
                 e.preventDefault();
                 if (canFollowup) void submitFollowup();
               }}
-              className="flex items-end gap-1"
+              className="flex items-stretch gap-1"
             >
               <textarea
                 ref={inputRef}
@@ -284,9 +284,9 @@ export function CursorRepoAgentChatCard({
                 title={t(
                   "apps.chats.toolCalls.cursorRyOsRepoAgent.followupSend"
                 )}
-                className="inline-flex h-6 w-6 shrink-0 items-center justify-center rounded border border-blue-500 bg-blue-500 text-white transition-colors hover:bg-blue-600 disabled:cursor-not-allowed disabled:border-neutral-300 disabled:bg-neutral-200 disabled:text-neutral-500 dark:disabled:border-neutral-700 dark:disabled:bg-neutral-800 dark:disabled:text-neutral-500"
+                className="inline-flex h-[26px] w-[26px] shrink-0 items-center justify-center self-end rounded border border-blue-500 bg-blue-500 text-white transition-colors hover:bg-blue-600 disabled:cursor-not-allowed disabled:border-neutral-300 disabled:bg-neutral-200 disabled:text-neutral-500 dark:disabled:border-neutral-700 dark:disabled:bg-neutral-800 dark:disabled:text-neutral-500"
               >
-                <PaperPlaneRight className="h-3 w-3" weight="bold" />
+                <ArrowUp className="h-3.5 w-3.5" weight="bold" />
               </button>
             </form>
           </div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Problem
Pressing Space while typing in the Cursor Cloud agent follow-up field triggered the main chat **push-to-talk** shortcut instead of inserting a space.

### Root cause
`ChatInput` registers a **window-level** `keydown` listener that calls `preventDefault()` and toggles recording when Space is pressed if `isForeground && !isFocused && !isTranscribing`. `isFocused` is only toggled by the **main** chat `<Input />`. Nested fields (e.g. the Cursor agent card `<textarea>`) never set `isFocused`, so the handler still believed “no chat input focused” and intercepted Space.

### Fix
Treat **any** editable target (`textarea`, text-like `input`, `contenteditable`) as “something else has typing focus” and skip the Space shortcut unless the focused element is exactly the main chat input.

### UI polish (Cursor agent card)
- Submit control: square (`h-[26px] w-[26px]`), aligned with textarea row via `items-stretch` / `self-end`.
- Icon: **ArrowUp** (Phosphor) instead of paper plane.

### Files
- `src/apps/chats/components/ChatInput.tsx` — Space shortcut guard.
- `src/components/shared/CursorRepoAgentChatCard.tsx` — layout + icon.

### Testing
- `bun run build` (tsc + vite) — passes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-17cfe24b-424a-439c-8dac-14032fc0c964"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-17cfe24b-424a-439c-8dac-14032fc0c964"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

