### PR TITLE
tv: slightly taller mobile video drawer default height

### DIFF
--- a/src/apps/tv/components/TvVideoDrawer.tsx
+++ b/src/apps/tv/components/TvVideoDrawer.tsx
@@ -33,7 +33,7 @@ const COMPACT_DRAWER_INSET_PX = 12;
 const COMPACT_DRAWER_OVERLAP_TOP_PX = -8;
 
 /** Compact drawer height cap — scroll inside for long playlists. */
-const COMPACT_DRAWER_MAX_HEIGHT = "min(28dvh, 200px)";
+const COMPACT_DRAWER_MAX_HEIGHT = "min(30dvh, 216px)";
 
 // Slow enough to read as a real "panel sliding out" but fast enough to
 // not feel laggy. Matches the cadence of the channel-switch animation


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**What changed**

Mobile compact TV playlist drawer (`max-width: 767px` bottom sheet) max height cap increased slightly so the open drawer shows a bit more list content without covering most of the picture.

**Sizing**

- **Before:** `min(28dvh, 200px)`
- **After:** `min(30dvh, 216px)` (~+2dvh viewport-relative cap, +16px fixed cap for taller phones where the pixel limit wins)

**Files**

- `src/apps/tv/components/TvVideoDrawer.tsx` — `COMPACT_DRAWER_MAX_HEIGHT` only

Desktop side drawer is unchanged (same breakpoint and layout path as before).

**Testing**

- `bun run build` (tsc + vite) — pass

**Evidence**

No UI recording: change is a single CSS max-height constant on the existing compact layout; validation via full project build.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8fe2a07b-c394-46d6-9916-a2bb310c0aa5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8fe2a07b-c394-46d6-9916-a2bb310c0aa5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

