### PR TITLE
Optimize hidden video visual effects

### DIFF
--- a/src/apps/ipod/components/IpodAppComponent.tsx
+++ b/src/apps/ipod/components/IpodAppComponent.tsx
@@ -195,6 +195,8 @@ export function IpodAppComponent({
     />
   );
   const shouldAnimateFullScreenVisuals = isPlaying && (isForeground ?? true);
+  const shouldRenderFullScreenAnimatedVisuals =
+    shouldAnimateFullScreenVisuals && displayMode !== DisplayMode.Video;
 
   if (!isWindowOpen) return null;
 
@@ -538,37 +540,45 @@ export function IpodAppComponent({
                   </div>
 
                   {/* Landscape video background (fullscreen) */}
-                  {displayMode === DisplayMode.Landscapes && tracks[currentIndex] && (
+                  {displayMode === DisplayMode.Landscapes &&
+                    shouldRenderFullScreenAnimatedVisuals &&
+                    tracks[currentIndex] && (
                     <LandscapeVideoBackground
-                      isActive={shouldAnimateFullScreenVisuals}
+                      isActive={shouldRenderFullScreenAnimatedVisuals}
                       className="fixed inset-0 z-[5]"
                     />
                   )}
 
                   {/* Warp shader background (fullscreen) */}
-                  {displayMode === DisplayMode.Shader && tracks[currentIndex] && (
+                  {displayMode === DisplayMode.Shader &&
+                    shouldRenderFullScreenAnimatedVisuals &&
+                    tracks[currentIndex] && (
                     <AmbientBackground
                       coverUrl={fullscreenCoverUrl}
                       variant="warp"
-                      isActive={shouldAnimateFullScreenVisuals}
+                      isActive={shouldRenderFullScreenAnimatedVisuals}
                       className="fixed inset-0 z-[5]"
                     />
                   )}
 
                   {/* Mesh gradient background (fullscreen) */}
-                  {displayMode === DisplayMode.Mesh && tracks[currentIndex] && (
+                  {displayMode === DisplayMode.Mesh &&
+                    shouldRenderFullScreenAnimatedVisuals &&
+                    tracks[currentIndex] && (
                     <MeshGradientBackground
                       coverUrl={fullscreenCoverUrl}
-                      isActive={shouldAnimateFullScreenVisuals}
+                      isActive={shouldRenderFullScreenAnimatedVisuals}
                       className="fixed inset-0 z-[5]"
                     />
                   )}
 
                   {/* Water shader background (fullscreen) */}
-                  {displayMode === DisplayMode.Water && tracks[currentIndex] && (
+                  {displayMode === DisplayMode.Water &&
+                    shouldRenderFullScreenAnimatedVisuals &&
+                    tracks[currentIndex] && (
                     <WaterBackground
                       coverUrl={fullscreenCoverUrl}
-                      isActive={shouldAnimateFullScreenVisuals}
+                      isActive={shouldRenderFullScreenAnimatedVisuals}
                       className="fixed inset-0 z-[5]"
                     />
                   )}

--- a/src/apps/ipod/components/IpodScreen.tsx
+++ b/src/apps/ipod/components/IpodScreen.tsx
@@ -304,7 +304,7 @@ export function IpodScreen({
             </div>
 
             {/* Landscape video background */}
-            {displayMode === DisplayMode.Landscapes && (
+            {displayMode === DisplayMode.Landscapes && shouldAnimateVisuals && (
               <LandscapeVideoBackground
                 isActive={shouldAnimateVisuals}
                 className="absolute inset-0 z-[5]"
@@ -312,7 +312,7 @@ export function IpodScreen({
             )}
 
             {/* Warp shader background */}
-            {displayMode === DisplayMode.Shader && (
+            {displayMode === DisplayMode.Shader && shouldAnimateVisuals && (
               <AmbientBackground
                 coverUrl={coverUrl}
                 variant="warp"
@@ -322,7 +322,7 @@ export function IpodScreen({
             )}
 
             {/* Mesh gradient background */}
-            {displayMode === DisplayMode.Mesh && (
+            {displayMode === DisplayMode.Mesh && shouldAnimateVisuals && (
               <MeshGradientBackground
                 coverUrl={coverUrl}
                 isActive={shouldAnimateVisuals}
@@ -331,7 +331,7 @@ export function IpodScreen({
             )}
 
             {/* Water shader background */}
-            {displayMode === DisplayMode.Water && (
+            {displayMode === DisplayMode.Water && shouldAnimateVisuals && (
               <WaterBackground
                 coverUrl={coverUrl}
                 isActive={shouldAnimateVisuals}

--- a/src/apps/karaoke/components/KaraokeAppComponent.tsx
+++ b/src/apps/karaoke/components/KaraokeAppComponent.tsx
@@ -191,6 +191,8 @@ export function KaraokeAppComponent({
   );
 
   const showEmptyLibrary = tracks.length === 0 && !currentTrack;
+  const visualBackgroundActive =
+    shouldAnimateVisuals && effectiveDisplayMode !== DisplayMode.Video;
 
   const displayModeOptions = [
     { value: DisplayMode.Video, label: t("apps.ipod.menu.displayVideo") },
@@ -500,37 +502,45 @@ export function KaraokeAppComponent({
           )}
 
           {/* Landscape video background */}
-          {effectiveDisplayMode === DisplayMode.Landscapes && currentTrack && (
+          {effectiveDisplayMode === DisplayMode.Landscapes &&
+            visualBackgroundActive &&
+            currentTrack && (
             <LandscapeVideoBackground
-              isActive={shouldAnimateVisuals}
+              isActive={visualBackgroundActive}
               className="absolute inset-0 z-[5]"
             />
           )}
 
           {/* Warp shader background */}
-          {effectiveDisplayMode === DisplayMode.Shader && currentTrack && (
+          {effectiveDisplayMode === DisplayMode.Shader &&
+            visualBackgroundActive &&
+            currentTrack && (
             <AmbientBackground
               coverUrl={coverUrl}
               variant="warp"
-              isActive={shouldAnimateVisuals}
+              isActive={visualBackgroundActive}
               className="absolute inset-0 z-[5]"
             />
           )}
 
           {/* Mesh gradient background */}
-          {effectiveDisplayMode === DisplayMode.Mesh && currentTrack && (
+          {effectiveDisplayMode === DisplayMode.Mesh &&
+            visualBackgroundActive &&
+            currentTrack && (
             <MeshGradientBackground
               coverUrl={coverUrl}
-              isActive={shouldAnimateVisuals}
+              isActive={visualBackgroundActive}
               className="absolute inset-0 z-[5]"
             />
           )}
 
           {/* Water shader background */}
-          {effectiveDisplayMode === DisplayMode.Water && currentTrack && (
+          {effectiveDisplayMode === DisplayMode.Water &&
+            visualBackgroundActive &&
+            currentTrack && (
             <WaterBackground
               coverUrl={coverUrl}
-              isActive={shouldAnimateVisuals}
+              isActive={visualBackgroundActive}
               className="absolute inset-0 z-[5]"
             />
           )}
@@ -945,37 +955,45 @@ export function KaraokeAppComponent({
                 </div>
 
                 {/* Landscape video background (fullscreen) */}
-                {effectiveDisplayMode === DisplayMode.Landscapes && currentTrack && (
+                {effectiveDisplayMode === DisplayMode.Landscapes &&
+                  visualBackgroundActive &&
+                  currentTrack && (
                   <LandscapeVideoBackground
-                    isActive={shouldAnimateVisuals}
+                    isActive={visualBackgroundActive}
                     className="fixed inset-0 z-[5]"
                   />
                 )}
 
                 {/* Warp shader background (fullscreen) */}
-                {effectiveDisplayMode === DisplayMode.Shader && currentTrack && (
+                {effectiveDisplayMode === DisplayMode.Shader &&
+                  visualBackgroundActive &&
+                  currentTrack && (
                   <AmbientBackground
                     coverUrl={coverUrl}
                     variant="warp"
-                    isActive={shouldAnimateVisuals}
+                    isActive={visualBackgroundActive}
                     className="fixed inset-0 z-[5]"
                   />
                 )}
 
                 {/* Mesh gradient background (fullscreen) */}
-                {effectiveDisplayMode === DisplayMode.Mesh && currentTrack && (
+                {effectiveDisplayMode === DisplayMode.Mesh &&
+                  visualBackgroundActive &&
+                  currentTrack && (
                   <MeshGradientBackground
                     coverUrl={coverUrl}
-                    isActive={shouldAnimateVisuals}
+                    isActive={visualBackgroundActive}
                     className="fixed inset-0 z-[5]"
                   />
                 )}
 
                 {/* Water shader background (fullscreen) */}
-                {effectiveDisplayMode === DisplayMode.Water && currentTrack && (
+                {effectiveDisplayMode === DisplayMode.Water &&
+                  visualBackgroundActive &&
+                  currentTrack && (
                   <WaterBackground
                     coverUrl={coverUrl}
-                    isActive={shouldAnimateVisuals}
+                    isActive={visualBackgroundActive}
                     className="fixed inset-0 z-[5]"
                   />
                 )}

--- a/src/apps/karaoke/components/KaraokeAppComponent.tsx
+++ b/src/apps/karaoke/components/KaraokeAppComponent.tsx
@@ -191,8 +191,6 @@ export function KaraokeAppComponent({
   );
 
   const showEmptyLibrary = tracks.length === 0 && !currentTrack;
-  const visualBackgroundActive =
-    shouldAnimateVisuals && effectiveDisplayMode !== DisplayMode.Video;
 
   const displayModeOptions = [
     { value: DisplayMode.Video, label: t("apps.ipod.menu.displayVideo") },
@@ -323,6 +321,8 @@ export function KaraokeAppComponent({
   const effectiveDisplayMode = isListenSessionRemoteOnly
     ? DisplayMode.Cover
     : displayMode;
+  const visualBackgroundActive =
+    shouldAnimateVisuals && effectiveDisplayMode !== DisplayMode.Video;
 
   if (!isWindowOpen) return null;
 

--- a/src/apps/videos/components/VideosAppComponent.tsx
+++ b/src/apps/videos/components/VideosAppComponent.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef, useEffect, type RefObject } from "react";
-import { motion, AnimatePresence } from "framer-motion";
+import { motion, AnimatePresence, useIsPresent } from "framer-motion";
 import ReactPlayer from "react-player";
 import { YouTubePlayer } from "@/components/shared/YouTubePlayer";
 import { cn } from "@/lib/utils";
@@ -157,50 +157,72 @@ function AnimatedTitle({
   );
 }
 
-function WhiteNoiseEffect() {
+function WhiteNoiseEffect({ active }: { active: boolean }) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const animationFrameRef = useRef<number | null>(null);
-  const [brightness, setBrightness] = useState(0);
+  const brightnessAnimationFrameRef = useRef<number | null>(null);
+  const brightnessRef = useRef(0);
 
   useEffect(() => {
+    if (!active) {
+      if (animationFrameRef.current !== null) {
+        cancelAnimationFrame(animationFrameRef.current);
+        animationFrameRef.current = null;
+      }
+      return;
+    }
+
     const canvas = canvasRef.current;
     if (!canvas) return;
 
-    const ctx = canvas.getContext("2d");
+    const ctx = canvas.getContext("2d", { alpha: false });
     if (!ctx) return;
 
-    const drawNoise = () => {
-      const imageData = ctx.createImageData(canvas.width, canvas.height);
-      const data = imageData.data;
+    let imageData: ImageData | null = null;
+    let pixels32: Uint32Array | null = null;
 
-      for (let i = 0; i < data.length; i += 4) {
-        const value = Math.random() * 255 * brightness;
-        data[i] = value; // R
-        data[i + 1] = value; // G
-        data[i + 2] = value; // B
-        data[i + 3] = 255; // A
+    const resizeCanvas = () => {
+      // Render at 1/1.5x CSS resolution; the browser upscales each
+      // canvas pixel ~1.5x on screen, giving slightly chunky analog
+      // grain without the per-frame fill cost of full-res.
+      const width = Math.max(1, Math.floor(canvas.offsetWidth / 1.5));
+      const height = Math.max(1, Math.floor(canvas.offsetHeight / 1.5));
+      const sizeChanged = canvas.width !== width || canvas.height !== height;
+      if (sizeChanged) {
+        canvas.width = width;
+        canvas.height = height;
+      }
+      if (sizeChanged || !imageData || !pixels32) {
+        imageData = ctx.createImageData(width, height);
+        pixels32 = new Uint32Array(imageData.data.buffer);
+      }
+    };
+
+    const drawNoise = () => {
+      if (!imageData || !pixels32) {
+        animationFrameRef.current = requestAnimationFrame(drawNoise);
+        return;
       }
 
-      // Add scan lines
+      const brightness = brightnessRef.current;
+      const len = pixels32.length;
+      for (let i = 0; i < len; i++) {
+        const value = (Math.random() * 255 * brightness) | 0;
+        pixels32[i] = 0xff000000 | (value << 16) | (value << 8) | value;
+      }
+
+      // Add scan lines using the packed pixel view to keep the frame loop cheap.
       for (let y = 0; y < canvas.height; y += 2) {
-        for (let x = 0; x < canvas.width; x++) {
-          const i = (y * canvas.width + x) * 4;
-          data[i] *= 0.8; // R
-          data[i + 1] *= 0.8; // G
-          data[i + 2] *= 0.8; // B
+        const rowStart = y * canvas.width;
+        const rowEnd = rowStart + canvas.width;
+        for (let i = rowStart; i < rowEnd; i++) {
+          const value = ((pixels32[i] & 0xff) * 205) >> 8;
+          pixels32[i] = 0xff000000 | (value << 16) | (value << 8) | value;
         }
       }
 
       ctx.putImageData(imageData, 0, 0);
       animationFrameRef.current = requestAnimationFrame(drawNoise);
-    };
-
-    const resizeCanvas = () => {
-      // Render at 1/1.5× CSS resolution; the browser upscales each
-      // canvas pixel ~1.5× on screen, giving slightly chunky analog
-      // grain without the per-frame fill cost of full-res.
-      canvas.width = Math.max(1, Math.floor(canvas.offsetWidth / 1.5));
-      canvas.height = Math.max(1, Math.floor(canvas.offsetHeight / 1.5));
     };
 
     resizeCanvas();
@@ -214,31 +236,50 @@ function WhiteNoiseEffect() {
         cancelAnimationFrame(animationFrameRef.current);
         animationFrameRef.current = null;
       }
+      imageData = null;
+      pixels32 = null;
     };
-  }, [brightness]);
+  }, [active]);
 
   // Animate brightness
   useEffect(() => {
+    if (!active) {
+      if (brightnessAnimationFrameRef.current !== null) {
+        cancelAnimationFrame(brightnessAnimationFrameRef.current);
+        brightnessAnimationFrameRef.current = null;
+      }
+      brightnessRef.current = 0;
+      return;
+    }
+
     const duration = 1000; // 1 second animation
-    const startTime = Date.now();
+    const startTime = performance.now();
     const startBrightness = 0;
     const targetBrightness = 1;
+    brightnessRef.current = startBrightness;
 
-    const animate = () => {
-      const elapsed = Date.now() - startTime;
+    const animate = (now: number) => {
+      const elapsed = now - startTime;
       const progress = Math.min(elapsed / duration, 1);
       const easeOut = 1 - Math.pow(1 - progress, 3); // Cubic ease out
-      setBrightness(
-        startBrightness + (targetBrightness - startBrightness) * easeOut
-      );
+      brightnessRef.current = startBrightness + (targetBrightness - startBrightness) * easeOut;
 
       if (progress < 1) {
-        requestAnimationFrame(animate);
+        brightnessAnimationFrameRef.current = requestAnimationFrame(animate);
+      } else {
+        brightnessAnimationFrameRef.current = null;
       }
     };
 
-    animate();
-  }, []);
+    brightnessAnimationFrameRef.current = requestAnimationFrame(animate);
+
+    return () => {
+      if (brightnessAnimationFrameRef.current !== null) {
+        cancelAnimationFrame(brightnessAnimationFrameRef.current);
+        brightnessAnimationFrameRef.current = null;
+      }
+    };
+  }, [active]);
 
   return (
     <canvas
@@ -255,6 +296,12 @@ function WhiteNoiseEffect() {
       }}
     />
   );
+}
+
+function WhiteNoiseOverlay() {
+  const isPresent = useIsPresent();
+
+  return <WhiteNoiseEffect active={isPresent} />;
 }
 
 function StatusDisplay({ message }: { message: string }) {
@@ -367,6 +414,8 @@ export function VideosAppComponent({
     instanceId,
   });
 
+  const shouldShowWhiteNoise = videos.length > 0 && !isPlaying && !isFullScreen;
+
   const menuBar = (
     <VideosMenuBar
       onClose={onClose}
@@ -462,7 +511,7 @@ export function VideosAppComponent({
                   )}
                   {/* White noise effect (z-10) */}
                   <AnimatePresence>
-                    {!isPlaying && (
+                    {shouldShowWhiteNoise && (
                       <motion.div
                         initial={{ opacity: 0, scale: 1.15 }}
                         animate={{ opacity: 1, scale: 1 }}
@@ -482,7 +531,7 @@ export function VideosAppComponent({
                           height: "calc(100% + 1px)",
                         }}
                       >
-                        <WhiteNoiseEffect />
+                        <WhiteNoiseOverlay />
                       </motion.div>
                     )}
                   </AnimatePresence>

--- a/src/components/shared/AmbientBackground.tsx
+++ b/src/components/shared/AmbientBackground.tsx
@@ -222,6 +222,7 @@ export function AmbientBackground({
   // ---------- react to cover URL changes ----------
 
   useEffect(() => {
+    if (!isActive) return;
     if (!coverUrl || coverUrl === currentUrlRef.current) return;
     currentUrlRef.current = coverUrl;
 
@@ -244,7 +245,7 @@ export function AmbientBackground({
         showingBRef.current = !showingBRef.current;
       })
       .catch(() => {});
-  }, [coverUrl, loadTexture]);
+  }, [coverUrl, isActive, loadTexture]);
 
   // ---------- Three.js setup & animation ----------
 

--- a/src/components/shared/MeshGradientBackground.tsx
+++ b/src/components/shared/MeshGradientBackground.tsx
@@ -20,7 +20,7 @@ export function MeshGradientBackground({
   isActive = true,
   className = "",
 }: MeshGradientBackgroundProps) {
-  const colors = useCoverPalette(coverUrl ?? null);
+  const colors = useCoverPalette(isActive ? coverUrl ?? null : null);
 
   if (!isActive) return null;
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Stop the Videos white-noise canvas from rendering while video is playing or fullscreen hides the inline player.
- Reuse the Videos noise frame buffer and brightness ref to avoid per-frame allocations and React re-renders.
- Gate iPod/Karaoke animated visual backgrounds before mounting and avoid inactive cover-palette/texture work.

### Testing
- `bun run build`
- Playwright smoke: Videos paused state has one visible noise canvas; after clicking play, the noise canvas unmounts.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-677b40aa-e919-48d8-b8f5-5f633a7548bb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-677b40aa-e919-48d8-b8f5-5f633a7548bb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

