### PR TITLE
Add aquarium dashboard widget

### DIFF
--- a/src/apps/dashboard/components/DashboardAppComponent.tsx
+++ b/src/apps/dashboard/components/DashboardAppComponent.tsx
@@ -15,6 +15,7 @@ import { IpodWidget, IpodBackPanel } from "@/components/layout/dashboard/IpodWid
 import { TranslationWidget, TranslationBackPanel } from "@/components/layout/dashboard/TranslationWidget";
 import { StickyNoteWidget, StickyNoteBackPanel } from "@/components/layout/dashboard/StickyNoteWidget";
 import { DictionaryWidget, DictionaryBackPanel } from "@/components/layout/dashboard/DictionaryWidget";
+import { AquariumWidget } from "@/components/layout/dashboard/AquariumWidget";
 import { DashboardMenuBar } from "./DashboardMenuBar";
 import { useAppStore } from "@/stores/useAppStore";
 import { useTranslation } from "react-i18next";
@@ -39,6 +40,8 @@ function WidgetContent({ type, widgetId, isFlipped }: { type: string; widgetId: 
       return <StickyNoteWidget widgetId={widgetId} />;
     case "dictionary":
       return <DictionaryWidget widgetId={widgetId} />;
+    case "aquarium":
+      return <AquariumWidget widgetId={widgetId} />;
     default:
       return null;
   }
@@ -81,6 +84,7 @@ const WIDGET_ICONS: Record<WidgetType, string> = {
   translation: "🌐",
   stickynote: "📝",
   dictionary: "📖",
+  aquarium: "🐠",
 };
 
 function WidgetStrip({
@@ -118,6 +122,7 @@ function WidgetStrip({
     { type: "translation", label: t("apps.dashboard.widgets.translation", "Translation") },
     { type: "stickynote", label: t("apps.dashboard.widgets.stickyNote", "Sticky Note") },
     { type: "dictionary", label: t("apps.dashboard.widgets.dictionary", "Dictionary") },
+    { type: "aquarium", label: t("apps.dashboard.widgets.aquarium", "Aquarium") },
   ];
 
   return (
@@ -294,6 +299,7 @@ export function DashboardAppComponent({
       onAddTranslation={() => handleAddWidget("translation")}
       onAddStickyNote={() => handleAddWidget("stickynote")}
       onAddDictionary={() => handleAddWidget("dictionary")}
+      onAddAquarium={() => handleAddWidget("aquarium")}
       onResetWidgets={resetToDefaults}
     />
   );

--- a/src/apps/dashboard/components/DashboardMenuBar.tsx
+++ b/src/apps/dashboard/components/DashboardMenuBar.tsx
@@ -24,6 +24,7 @@ interface DashboardMenuBarProps {
   onAddTranslation: () => void;
   onAddStickyNote: () => void;
   onAddDictionary: () => void;
+  onAddAquarium: () => void;
   onResetWidgets: () => void;
 }
 
@@ -39,6 +40,7 @@ export function DashboardMenuBar({
   onAddTranslation,
   onAddStickyNote,
   onAddDictionary,
+  onAddAquarium,
   onResetWidgets,
 }: DashboardMenuBarProps) {
   const { t } = useTranslation();
@@ -82,6 +84,9 @@ export function DashboardMenuBar({
               </MenubarItem>
               <MenubarItem onClick={onAddDictionary} className="text-md h-6 px-3">
                 📖 {t("apps.dashboard.widgets.dictionary", "Dictionary")}
+              </MenubarItem>
+              <MenubarItem onClick={onAddAquarium} className="text-md h-6 px-3">
+                🐠 {t("apps.dashboard.widgets.aquarium", "Aquarium")}
               </MenubarItem>
             </MenubarSubContent>
           </MenubarSub>

--- a/src/apps/dashboard/hooks/useDashboardLogic.ts
+++ b/src/apps/dashboard/hooks/useDashboardLogic.ts
@@ -40,6 +40,7 @@ export function useDashboardLogic() {
         calendar: { width: 240, height: 350 },
         weather: { width: 340, height: 180 },
         stocks: { width: 240, height: 340 },
+        aquarium: { width: 300, height: 200 },
         ipod: { width: 320, height: 125 },
         dictionary: { width: 240, height: 220 },
         stickynote: { width: 200, height: 200 },

--- a/src/components/layout/dashboard/AquariumWidget.tsx
+++ b/src/components/layout/dashboard/AquariumWidget.tsx
@@ -1,0 +1,22 @@
+import EmojiAquarium from "@/components/shared/EmojiAquarium";
+
+interface AquariumWidgetProps {
+  widgetId: string;
+}
+
+export function AquariumWidget({ widgetId }: AquariumWidgetProps) {
+  return (
+    <div
+      className="flex h-full min-h-[inherit] items-stretch rounded-[inherit]"
+      style={{
+        background: "linear-gradient(180deg, #7dd3fc 0%, #38bdf8 45%, #0ea5e9 100%)",
+      }}
+    >
+      <EmojiAquarium
+        seed={widgetId}
+        variant="widget"
+        className="h-full min-h-[inherit] rounded-[inherit] shadow-[inset_0_1px_8px_rgba(255,255,255,0.35),inset_0_-10px_18px_rgba(3,105,161,0.2)]"
+      />
+    </div>
+  );
+}

--- a/src/components/shared/EmojiAquarium.tsx
+++ b/src/components/shared/EmojiAquarium.tsx
@@ -10,6 +10,7 @@ interface EmojiAquariumProps {
   density?: AquariumDensity;
   seed?: string;
   className?: string;
+  variant?: "chat" | "widget";
 }
 
 function useSeededRandom(seed?: string) {
@@ -29,7 +30,7 @@ function useSeededRandom(seed?: string) {
   };
 }
 
-export function EmojiAquarium({ seed, className }: EmojiAquariumProps) {
+export function EmojiAquarium({ seed, className, variant = "chat" }: EmojiAquariumProps) {
   // Create a stable seed once so re-renders (e.g., hover) don't change layout.
   const seedRef = useRef<string | undefined>(seed);
   if (seedRef.current === undefined) {
@@ -44,13 +45,18 @@ export function EmojiAquarium({ seed, className }: EmojiAquariumProps) {
 
   const rand = useSeededRandom(seedRef.current);
 
-  // Responsive: fill the container width and compute height via aspect ratio.
+  // Responsive: chat uses an aspect ratio, dashboard widgets fill their frame.
   const containerRef = useRef<HTMLDivElement>(null);
-  const [containerWidth, setContainerWidth] = useState<number>(420);
+  const [containerSize, setContainerSize] = useState({ width: 420, height: 0 });
   useLayoutEffect(() => {
     const el = containerRef.current;
     if (!el) return;
-    const update = () => setContainerWidth(el.clientWidth || 420);
+    const update = () => {
+      setContainerSize({
+        width: el.clientWidth || 420,
+        height: el.clientHeight || 0,
+      });
+    };
     update();
     const ro = new ResizeObserver(() => update());
     ro.observe(el);
@@ -58,8 +64,12 @@ export function EmojiAquarium({ seed, className }: EmojiAquariumProps) {
   }, []);
 
   const aspect = 236 / 420; // ~16:9
-  const width = containerWidth;
-  const height = Math.max(120, Math.round(containerWidth * aspect));
+  const width = containerSize.width;
+  const aspectHeight = Math.round(containerSize.width * aspect);
+  const height =
+    variant === "widget"
+      ? Math.max(120, containerSize.height || aspectHeight)
+      : Math.max(120, aspectHeight);
   // Scale sand height with container for a larger, responsive base
   const sandHeight = Math.max(24, Math.round(height * 0.35));
 
@@ -103,13 +113,15 @@ export function EmojiAquarium({ seed, className }: EmojiAquariumProps) {
     <MotionConfig reducedMotion="never">
       <div
         className={cn(
-          "chat-bubble bg-blue-300 text-black !p-0 mb-2 w-full max-w-[420px] rounded",
+          variant === "chat"
+            ? "chat-bubble bg-blue-300 text-black !p-0 mb-2 w-full max-w-[420px] rounded"
+            : "h-full min-h-[inherit] bg-blue-300 text-black w-full overflow-hidden rounded-[inherit]",
           className
         )}
+        ref={containerRef}
       >
         <div
-          ref={containerRef}
-          className={cn("relative z-0 overflow-hidden rounded")}
+          className={cn("relative z-0 overflow-hidden rounded-[inherit]")}
           style={{ width: "100%", height }}
         >
           {/* small fish */}

--- a/src/lib/locales/de/translation.json
+++ b/src/lib/locales/de/translation.json
@@ -1601,6 +1601,7 @@
       },
       "widgets": {
         "addWidget": "Widget hinzufügen...",
+        "aquarium": "Aquarium",
         "calendar": "Kalender",
         "clock": "Uhr",
         "dictionary": "Wörterbuch",

--- a/src/lib/locales/en/translation.json
+++ b/src/lib/locales/en/translation.json
@@ -3086,6 +3086,7 @@
         "calendar": "Calendar",
         "weather": "Weather",
         "stocks": "Stocks",
+        "aquarium": "Aquarium",
         "stickyNote": "Sticky Note",
         "ipod": "iPod",
         "dictionary": "Dictionary",

--- a/src/lib/locales/es/translation.json
+++ b/src/lib/locales/es/translation.json
@@ -1601,6 +1601,7 @@
       },
       "widgets": {
         "addWidget": "Añadir widget...",
+        "aquarium": "Acuario",
         "calendar": "Calendario",
         "clock": "Reloj",
         "dictionary": "Diccionario",

--- a/src/lib/locales/fr/translation.json
+++ b/src/lib/locales/fr/translation.json
@@ -1601,6 +1601,7 @@
       },
       "widgets": {
         "addWidget": "Ajouter un widget...",
+        "aquarium": "Aquarium",
         "calendar": "Calendrier",
         "clock": "Horloge",
         "dictionary": "Dictionnaire",

--- a/src/lib/locales/it/translation.json
+++ b/src/lib/locales/it/translation.json
@@ -1601,6 +1601,7 @@
       },
       "widgets": {
         "addWidget": "Aggiungi widget...",
+        "aquarium": "Acquario",
         "calendar": "Calendario",
         "clock": "Orologio",
         "dictionary": "Dizionario",

--- a/src/lib/locales/ja/translation.json
+++ b/src/lib/locales/ja/translation.json
@@ -1601,6 +1601,7 @@
       },
       "widgets": {
         "addWidget": "ウィジェットを追加...",
+        "aquarium": "水族館",
         "calendar": "カレンダー",
         "clock": "時計",
         "dictionary": "辞書",

--- a/src/lib/locales/ko/translation.json
+++ b/src/lib/locales/ko/translation.json
@@ -1601,6 +1601,7 @@
       },
       "widgets": {
         "addWidget": "위젯 추가...",
+        "aquarium": "수족관",
         "calendar": "캘린더",
         "clock": "시계",
         "dictionary": "사전",

--- a/src/lib/locales/pt/translation.json
+++ b/src/lib/locales/pt/translation.json
@@ -1601,6 +1601,7 @@
       },
       "widgets": {
         "addWidget": "Adicionar Widget...",
+        "aquarium": "Aquário",
         "calendar": "Calendário",
         "clock": "Relógio",
         "dictionary": "Dicionário",

--- a/src/lib/locales/ru/translation.json
+++ b/src/lib/locales/ru/translation.json
@@ -1601,6 +1601,7 @@
       },
       "widgets": {
         "addWidget": "Добавить виджет...",
+        "aquarium": "Аквариум",
         "calendar": "Календарь",
         "clock": "Часы",
         "dictionary": "Словарь",

--- a/src/lib/locales/zh-TW/translation.json
+++ b/src/lib/locales/zh-TW/translation.json
@@ -1601,6 +1601,7 @@
       },
       "widgets": {
         "addWidget": "加入小工具...",
+        "aquarium": "水族箱",
         "calendar": "日曆",
         "clock": "時鐘",
         "dictionary": "字典",

--- a/src/stores/useDashboardStore.ts
+++ b/src/stores/useDashboardStore.ts
@@ -2,7 +2,7 @@ import { create } from "zustand";
 import { persist } from "zustand/middleware";
 import type { EventColor } from "./useCalendarStore";
 
-export type WidgetType = "clock" | "weather" | "calendar" | "stocks" | "ipod" | "dictionary" | "stickynote" | "translation";
+export type WidgetType = "clock" | "weather" | "calendar" | "stocks" | "ipod" | "dictionary" | "stickynote" | "translation" | "aquarium";
 
 export interface WeatherWidgetConfig {
   cityName?: string;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add an Aquarium widget to Dashboard rendering the existing emoji aquarium animation.
- Wire the widget into the dashboard picker, menu bar, widget type registry, sizing, and localized labels.
- Add a dashboard-friendly variant to `EmojiAquarium` so chat rendering remains unchanged.

## Walkthrough
<a href="https://cursor.com/agents/bc-f4dd9efb-336c-4a9e-b5dc-5fcfd5462eb9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Faquarium_dashboard_widget_flow.webm"><img src="https://cursor.com/artifacts/c/art-ec6e18a2-db4d-4556-939f-021cecb4719c" alt="aquarium_dashboard_widget_flow.webm" /></a>

![Aquarium dashboard widget](https://cursor.com/artifacts/c/art-549bec66-9a53-4594-b0cf-3bacd60ef606)

## Testing
- `bun run build` passed.
- Browser smoke test passed: opened Dashboard, opened widget picker, selected Aquarium, verified the Aquarium widget rendered and persisted in `dashboard-storage`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f4dd9efb-336c-4a9e-b5dc-5fcfd5462eb9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f4dd9efb-336c-4a9e-b5dc-5fcfd5462eb9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

