### PR TITLE
Dashboard: add mobile (narrow) layout alongside the floating desktop layout

### DIFF
--- a/src/apps/dashboard/components/DashboardAppComponent.tsx
+++ b/src/apps/dashboard/components/DashboardAppComponent.tsx
@@ -21,6 +21,7 @@ import { useAppStore } from "@/stores/useAppStore";
 import { useTranslation } from "react-i18next";
 import { Plus } from "@phosphor-icons/react";
 import { useDashboardStore, type WidgetType } from "@/stores/useDashboardStore";
+import { useMediaQuery } from "@/hooks/useMediaQuery";
 
 function WidgetContent({ type, widgetId, isFlipped }: { type: string; widgetId: string; isFlipped?: boolean }) {
   switch (type) {
@@ -234,6 +235,7 @@ export function DashboardAppComponent({
   const [isPickerOpen, setIsPickerOpen] = useState(false);
   const [isClosing, setIsClosing] = useState(false);
   const [stripHeight, setStripHeight] = useState(0);
+  const isMobile = useMediaQuery("(max-width: 767px)");
 
   const {
     translatedHelpItems,
@@ -308,6 +310,7 @@ export function DashboardAppComponent({
 
   useEffect(() => {
     if (!showOverlay) return;
+    if (isMobile) return;
     const reposition = () => {
       const vw = window.innerWidth;
       const vh = window.innerHeight;
@@ -328,7 +331,7 @@ export function DashboardAppComponent({
     reposition();
     window.addEventListener("resize", reposition);
     return () => window.removeEventListener("resize", reposition);
-  }, [showOverlay]);
+  }, [showOverlay, isMobile]);
 
   return (
     <>
@@ -375,51 +378,113 @@ export function DashboardAppComponent({
                 }}
               />
               {/* Widgets - pointer-events-none so scrim receives backdrop clicks */}
-              <motion.div
-                data-dashboard-widget
-                className="absolute inset-0"
-                style={{ pointerEvents: "none" }}
-                animate={{ y: isPickerOpen ? -stripHeight : 0 }}
-                transition={{ type: "spring", stiffness: 300, damping: 30 }}
-              >
-                <AnimatePresence>
-                  {widgets.map((widget) => (
-                    <motion.div
-                    key={widget.id}
-                    initial={{ opacity: 0, scale: 0.8 }}
-                    animate={{ opacity: 1, scale: 1 }}
-                    exit={{ opacity: 0, scale: 0.8 }}
-                    transition={{
-                      duration: 0.3,
-                      ease: [0.4, 0, 0.2, 1],
-                    }}
-                    style={{
-                      position: "relative",
-                      pointerEvents: "auto",
-                      zIndex: widget.zIndex ?? 1,
-                      transformOrigin: `${widget.position.x + widget.size.width / 2}px ${widget.position.y + widget.size.height / 2}px`,
-                    }}
+              {isMobile ? (
+                <div
+                  className="absolute inset-0 overflow-y-auto overflow-x-hidden"
+                  style={{
+                    pointerEvents: "auto",
+                    paddingTop: "calc(env(safe-area-inset-top, 0px) + 20px)",
+                    paddingBottom: isPickerOpen
+                      ? `calc(${stripHeight + 80}px + env(safe-area-inset-bottom, 0px))`
+                      : "calc(80px + env(safe-area-inset-bottom, 0px))",
+                    paddingLeft: 16,
+                    paddingRight: 16,
+                    WebkitOverflowScrolling: "touch",
+                  }}
+                >
+                  <div
+                    className="flex flex-col items-center"
+                    style={{ gap: 16, width: "100%" }}
                   >
-                    <WidgetChrome
-                      width={widget.size.width}
-                      height={widget.size.height}
-                      x={widget.position.x}
-                      y={widget.position.y}
-                      zIndex={widget.zIndex ?? 1}
-                      borderRadius={widget.type === "ipod" ? "9999px" : undefined}
-                      hideDoneButton={widget.type === "ipod"}
-                      onRemove={() => removeWidget(widget.id)}
-                      onMove={(pos) => moveWidget(widget.id, pos)}
-                      onBringToFront={() => bringToFront(widget.id)}
-                      overflowContent={<WidgetOverflow type={widget.type} widgetId={widget.id} />}
-                      backContent={(onFlipBack) => <WidgetBackContent type={widget.type} widgetId={widget.id} onDone={onFlipBack} />}
-                    >
-                      {(isFlipped) => <WidgetContent type={widget.type} widgetId={widget.id} isFlipped={isFlipped} />}
-                    </WidgetChrome>
-                  </motion.div>
-                  ))}
-                </AnimatePresence>
-              </motion.div>
+                    <AnimatePresence initial={false}>
+                      {widgets.map((widget) => {
+                        const maxAvailable = Math.max(0, window.innerWidth - 32);
+                        const renderWidth = Math.min(widget.size.width, maxAvailable);
+                        return (
+                          <motion.div
+                            key={widget.id}
+                            data-dashboard-widget
+                            layout
+                            initial={{ opacity: 0, scale: 0.85 }}
+                            animate={{ opacity: 1, scale: 1 }}
+                            exit={{ opacity: 0, scale: 0.85, height: 0, marginTop: 0 }}
+                            transition={{
+                              duration: 0.3,
+                              ease: [0.4, 0, 0.2, 1],
+                            }}
+                            style={{
+                              position: "relative",
+                              pointerEvents: "auto",
+                            }}
+                          >
+                            <WidgetChrome
+                              layout="stacked"
+                              width={renderWidth}
+                              height={widget.size.height}
+                              x={0}
+                              y={0}
+                              zIndex={widget.zIndex ?? 1}
+                              borderRadius={widget.type === "ipod" ? "9999px" : undefined}
+                              hideDoneButton={widget.type === "ipod"}
+                              onRemove={() => removeWidget(widget.id)}
+                              overflowContent={<WidgetOverflow type={widget.type} widgetId={widget.id} />}
+                              backContent={(onFlipBack) => <WidgetBackContent type={widget.type} widgetId={widget.id} onDone={onFlipBack} />}
+                            >
+                              {(isFlipped) => <WidgetContent type={widget.type} widgetId={widget.id} isFlipped={isFlipped} />}
+                            </WidgetChrome>
+                          </motion.div>
+                        );
+                      })}
+                    </AnimatePresence>
+                  </div>
+                </div>
+              ) : (
+                <motion.div
+                  data-dashboard-widget
+                  className="absolute inset-0"
+                  style={{ pointerEvents: "none" }}
+                  animate={{ y: isPickerOpen ? -stripHeight : 0 }}
+                  transition={{ type: "spring", stiffness: 300, damping: 30 }}
+                >
+                  <AnimatePresence>
+                    {widgets.map((widget) => (
+                      <motion.div
+                        key={widget.id}
+                        initial={{ opacity: 0, scale: 0.8 }}
+                        animate={{ opacity: 1, scale: 1 }}
+                        exit={{ opacity: 0, scale: 0.8 }}
+                        transition={{
+                          duration: 0.3,
+                          ease: [0.4, 0, 0.2, 1],
+                        }}
+                        style={{
+                          position: "relative",
+                          pointerEvents: "auto",
+                          zIndex: widget.zIndex ?? 1,
+                          transformOrigin: `${widget.position.x + widget.size.width / 2}px ${widget.position.y + widget.size.height / 2}px`,
+                        }}
+                      >
+                        <WidgetChrome
+                          width={widget.size.width}
+                          height={widget.size.height}
+                          x={widget.position.x}
+                          y={widget.position.y}
+                          zIndex={widget.zIndex ?? 1}
+                          borderRadius={widget.type === "ipod" ? "9999px" : undefined}
+                          hideDoneButton={widget.type === "ipod"}
+                          onRemove={() => removeWidget(widget.id)}
+                          onMove={(pos) => moveWidget(widget.id, pos)}
+                          onBringToFront={() => bringToFront(widget.id)}
+                          overflowContent={<WidgetOverflow type={widget.type} widgetId={widget.id} />}
+                          backContent={(onFlipBack) => <WidgetBackContent type={widget.type} widgetId={widget.id} onDone={onFlipBack} />}
+                        >
+                          {(isFlipped) => <WidgetContent type={widget.type} widgetId={widget.id} isFlipped={isFlipped} />}
+                        </WidgetChrome>
+                      </motion.div>
+                    ))}
+                  </AnimatePresence>
+                </motion.div>
+              )}
 
               {/* Widget strip */}
               <AnimatePresence>

--- a/src/apps/dashboard/components/DashboardAppComponent.tsx
+++ b/src/apps/dashboard/components/DashboardAppComponent.tsx
@@ -236,6 +236,8 @@ export function DashboardAppComponent({
   const [isClosing, setIsClosing] = useState(false);
   const [stripHeight, setStripHeight] = useState(0);
   const isMobile = useMediaQuery("(max-width: 767px)");
+  const mobileScrollRef = useRef<HTMLDivElement>(null);
+  const prevWidgetCountRef = useRef(0);
 
   const {
     translatedHelpItems,
@@ -309,6 +311,28 @@ export function DashboardAppComponent({
   const showOverlay = isWindowOpen && !isClosing;
 
   useEffect(() => {
+    if (!isMobile) {
+      prevWidgetCountRef.current = widgets.length;
+      return;
+    }
+    const prev = prevWidgetCountRef.current;
+    prevWidgetCountRef.current = widgets.length;
+    if (widgets.length <= prev) return;
+    const container = mobileScrollRef.current;
+    if (!container) return;
+    // Defer to next frame so the new widget has been laid out.
+    const raf = requestAnimationFrame(() => {
+      const target = container.scrollHeight - container.clientHeight;
+      try {
+        container.scrollTo({ top: target, behavior: "smooth" });
+      } catch {
+        container.scrollTop = target;
+      }
+    });
+    return () => cancelAnimationFrame(raf);
+  }, [widgets.length, isMobile]);
+
+  useEffect(() => {
     if (!showOverlay) return;
     if (isMobile) return;
     const reposition = () => {
@@ -380,6 +404,7 @@ export function DashboardAppComponent({
               {/* Widgets - pointer-events-none so scrim receives backdrop clicks */}
               {isMobile ? (
                 <div
+                  ref={mobileScrollRef}
                   className="absolute inset-0 overflow-y-auto overflow-x-hidden"
                   style={{
                     pointerEvents: "auto",

--- a/src/components/layout/dashboard/WidgetChrome.tsx
+++ b/src/components/layout/dashboard/WidgetChrome.tsx
@@ -15,6 +15,12 @@ interface WidgetChromeProps {
   zIndex?: number;
   borderRadius?: string;
   hideDoneButton?: boolean;
+  /**
+   * "absolute" (default) — uses x/y for positioning and supports drag.
+   * "stacked" — relative positioning for use in a vertical/grid layout (mobile);
+   * disables drag, ignores x/y, and lets the parent control placement.
+   */
+  layout?: "absolute" | "stacked";
   onRemove?: () => void;
   onMove?: (position: { x: number; y: number }) => void;
   onBringToFront?: () => void;
@@ -31,10 +37,12 @@ export function WidgetChrome({
   zIndex = 1,
   borderRadius: borderRadiusProp,
   hideDoneButton,
+  layout = "absolute",
   onRemove,
   onMove,
   onBringToFront,
 }: WidgetChromeProps) {
+  const isStacked = layout === "stacked";
   const { t } = useTranslation();
   const currentTheme = useThemeStore((state) => state.current);
   const isXpTheme = currentTheme === "xp" || currentTheme === "win98";
@@ -48,7 +56,7 @@ export function WidgetChrome({
   const didDragRef = useRef(false);
   const containerRef = useRef<HTMLDivElement>(null);
 
-  const showControls = isHovered || isTouchActive;
+  const showControls = isHovered || isTouchActive || isStacked;
 
   useEffect(() => {
     if (!isTouchActive) return;
@@ -67,6 +75,7 @@ export function WidgetChrome({
       if ((e.target as HTMLElement).closest("[data-flip-btn]")) return;
       if ((e.target as HTMLElement).closest("button, input, select, textarea, a")) return;
       if (isFlipped) return;
+      if (isStacked) return;
       if (e.button !== 0) return;
       e.preventDefault();
       e.stopPropagation();
@@ -78,7 +87,7 @@ export function WidgetChrome({
       dragStartRef.current = { px: e.clientX, py: e.clientY, startX: x, startY: y };
       setIsDragging(true);
     },
-    [x, y, onBringToFront, isFlipped]
+    [x, y, onBringToFront, isFlipped, isStacked]
   );
 
   const handlePointerMove = useCallback(
@@ -166,19 +175,28 @@ export function WidgetChrome({
   return (
     <div
       ref={containerRef}
-      className="absolute select-none touch-none"
-      style={{
-        left: x,
-        top: y,
-        width,
-        height: "auto",
-        cursor: isDragging ? "grabbing" : isFlipped ? "default" : "grab",
-        zIndex: isDragging ? 9999 : zIndex,
-      }}
-      onPointerDown={handlePointerDown}
-      onPointerMove={handlePointerMove}
-      onPointerUp={handlePointerUp}
-      onPointerCancel={handlePointerCancel}
+      className={`${isStacked ? "relative select-none" : "absolute select-none touch-none"}`}
+      style={
+        isStacked
+          ? {
+              width,
+              height: "auto",
+              cursor: isFlipped ? "default" : "default",
+              zIndex,
+            }
+          : {
+              left: x,
+              top: y,
+              width,
+              height: "auto",
+              cursor: isDragging ? "grabbing" : isFlipped ? "default" : "grab",
+              zIndex: isDragging ? 9999 : zIndex,
+            }
+      }
+      onPointerDown={isStacked ? undefined : handlePointerDown}
+      onPointerMove={isStacked ? undefined : handlePointerMove}
+      onPointerUp={isStacked ? undefined : handlePointerUp}
+      onPointerCancel={isStacked ? undefined : handlePointerCancel}
       onMouseEnter={() => setIsHovered(true)}
       onMouseLeave={() => setIsHovered(false)}
       onDoubleClick={handleDoubleClick}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a dedicated mobile layout for the Dashboard app that activates on narrow viewports (`max-width: 767px`).

- **Desktop (≥768px)**: unchanged — widgets are absolutely positioned, draggable, and overlap freely.
- **Mobile (<768px)**: widgets render in a centered, vertically stacked, scrollable column. Drag is disabled and widgets cap their width to the viewport so nothing clips off-screen.

## Changes

- `src/apps/dashboard/components/DashboardAppComponent.tsx`
  - Use `useMediaQuery("(max-width: 767px)")` to choose between layouts.
  - Render a scrollable column on mobile with safe-area padding and dynamic bottom padding when the widget picker strip is open.
  - Keep the existing absolute/draggable layout for desktop.
  - Skip the resize-driven reposition effect on mobile (not needed when widgets stack).
- `src/components/layout/dashboard/WidgetChrome.tsx`
  - New `layout?: "absolute" | "stacked"` prop (default `"absolute"`).
  - In `"stacked"` mode: positions relatively, ignores `x`/`y`, disables drag handlers, and shows close/info controls without requiring hover (better for touch).

## Walkthrough

Mobile (~420px wide) — widgets stack vertically and fit the viewport. The clock at the top is partially obscured by a Chrome system dialog in the screenshot, but it is rendered above the calendar:

![Dashboard mobile stacked layout](https://cursor.com/artifacts/c/art-40fbebb5-3048-4d57-a007-ceeeabd4d92d)

Desktop — widgets float freely and remain draggable as before:

![Dashboard desktop floating layout](https://cursor.com/artifacts/c/art-82a99d3c-0456-42f9-954c-8692863f9bff)

## Testing

- `bun run build` — passes.
- `bun run lint` — no new warnings.
- Manual: opened Dashboard at desktop (~1280px) and mobile (~420px) viewports; confirmed floating vs. stacked rendering and that the widget picker `+` button still toggles the picker strip in both modes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b6982339-35f0-4631-9f7f-f7a325b002b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b6982339-35f0-4631-9f7f-f7a325b002b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

