### PR TITLE
Match dashboard widget widths to weather; tighten currency widget

### DIFF
--- a/src/apps/dashboard/hooks/useDashboardLogic.ts
+++ b/src/apps/dashboard/hooks/useDashboardLogic.ts
@@ -40,12 +40,12 @@ export function useDashboardLogic() {
         calendar: { width: 240, height: 350 },
         weather: { width: 340, height: 180 },
         stocks: { width: 240, height: 340 },
-        aquarium: { width: 300, height: 200 },
+        aquarium: { width: 340, height: 200 },
         ipod: { width: 320, height: 125 },
-        dictionary: { width: 240, height: 220 },
+        dictionary: { width: 340, height: 220 },
         stickynote: { width: 200, height: 200 },
-        translation: { width: 300, height: 170 },
-        currency: { width: 280, height: 186 },
+        translation: { width: 340, height: 170 },
+        currency: { width: 340, height: 170 },
       };
       const size = sizeMap[type];
 

--- a/src/components/layout/dashboard/CurrencyWidget.tsx
+++ b/src/components/layout/dashboard/CurrencyWidget.tsx
@@ -267,7 +267,7 @@ export function CurrencyWidget({ widgetId }: CurrencyWidgetProps) {
             ))}
           </select>
           <button type="button" onClick={handleSwap} onPointerDown={(e) => e.stopPropagation()} style={swapBtnXp} title={t("apps.dashboard.currency.swap", "Swap currencies")}>
-            <ArrowsLeftRight size={12} weight="bold" />
+            <ArrowsLeftRight size={12} weight="bold" style={{ transform: "rotate(90deg)" }} />
           </button>
           <select
             value={toCurrency}
@@ -426,7 +426,7 @@ export function CurrencyWidget({ widgetId }: CurrencyWidgetProps) {
             title={t("apps.dashboard.currency.swap", "Swap currencies")}
             style={graphiteBtnStyle}
           >
-            <ArrowsDownUp size={14} weight="bold" />
+            <ArrowsDownUp size={14} weight="bold" style={{ transform: "rotate(90deg)" }} />
           </button>
           <div style={{ position: "relative", flex: 1, minWidth: 0 }}>
             <select

--- a/src/stores/useDashboardStore.ts
+++ b/src/stores/useDashboardStore.ts
@@ -104,6 +104,24 @@ const DEFAULT_WIDGETS: DashboardWidget[] = [
   },
 ];
 
+// Default sizes per widget type. Used to normalize sizes during persisted
+// state migrations so existing widgets adopt updated layout dimensions
+// without requiring a manual reset.
+const DEFAULT_WIDGET_SIZES: Record<WidgetType, { width: number; height: number }> = {
+  clock: { width: 170, height: 170 },
+  calendar: { width: 240, height: 350 },
+  weather: { width: 340, height: 180 },
+  stocks: { width: 240, height: 340 },
+  aquarium: { width: 340, height: 200 },
+  ipod: { width: 320, height: 125 },
+  dictionary: { width: 340, height: 220 },
+  stickynote: { width: 200, height: 200 },
+  translation: { width: 340, height: 170 },
+  currency: { width: 340, height: 170 },
+};
+
+const DASHBOARD_STORE_VERSION = 1;
+
 export const useDashboardStore = create<DashboardStoreState>()(
   persist(
     (set, _get) => ({
@@ -165,6 +183,26 @@ export const useDashboardStore = create<DashboardStoreState>()(
     }),
     {
       name: "dashboard-storage",
+      version: DASHBOARD_STORE_VERSION,
+      migrate: (persistedState, version) => {
+        const state = (persistedState ?? {}) as Partial<DashboardStoreState>;
+        if (version < 1) {
+          // v1: Normalize widths/heights for currency/translation/aquarium/dictionary
+          // to match the weather widget width (340) and trim currency height.
+          const TYPES_TO_RESIZE: WidgetType[] = [
+            "currency",
+            "translation",
+            "aquarium",
+            "dictionary",
+          ];
+          state.widgets = (state.widgets ?? []).map((w) => {
+            if (!TYPES_TO_RESIZE.includes(w.type)) return w;
+            const target = DEFAULT_WIDGET_SIZES[w.type];
+            return { ...w, size: { ...target } };
+          });
+        }
+        return state as DashboardStoreState;
+      },
     }
   )
 );


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Aligns the default size and look of the Currency, Translation, Aquarium, and Dictionary dashboard widgets with the Weather widget, plus a small icon polish on the currency swap button.

### Changes

- **Width parity**: `currency`, `translation`, `aquarium`, and `dictionary` widgets now default to `width: 340`, matching the Weather widget.
- **Currency height trimmed**: Default currency widget height drops from `186` to `170`, removing the extra empty space at the bottom.
- **Currency swap icon rotated 90°**: Both the XP/Win98 (`ArrowsLeftRight`) and Aqua (`ArrowsDownUp`) variants of the swap button icon now have a 90° rotation for a more balanced look against the horizontal currency layout.
- **Persisted state migration**: Bumped the dashboard store to `version: 1` and added a migration that normalizes the size of existing persisted widgets of these four types to the new defaults, so users who already added these widgets get the new sizing without manually resetting their dashboard.

### Files

- `src/apps/dashboard/hooks/useDashboardLogic.ts` — updated `sizeMap` defaults for new widgets.
- `src/stores/useDashboardStore.ts` — added `DEFAULT_WIDGET_SIZES`, `version: 1`, and `migrate` for persisted widgets.
- `src/components/layout/dashboard/CurrencyWidget.tsx` — added `transform: rotate(90deg)` on both swap-button icons.

## Testing

- ✅ `bun run build` — succeeds with no new errors or warnings.
- Visual changes are layout/sizing only and the build verifies the type-safe wiring of the widget size map and the migration.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f8bff390-0709-4902-9e2b-aa3642ece093"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f8bff390-0709-4902-9e2b-aa3642ece093"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

