### PR TITLE
feat(dashboard): format currency converter input as currency

### DIFF
--- a/src/components/layout/dashboard/CurrencyWidget.tsx
+++ b/src/components/layout/dashboard/CurrencyWidget.tsx
@@ -1,9 +1,17 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, type ChangeEvent } from "react";
 import { useThemeStore } from "@/stores/useThemeStore";
 import { useDashboardStore, type CurrencyWidgetConfig } from "@/stores/useDashboardStore";
 import { useTranslation } from "react-i18next";
 import { ArrowsDownUp, ArrowsLeftRight } from "@phosphor-icons/react";
-import { fetchCurrencyRateForWidget, parseAmountInput } from "@/lib/currency/frankfurter";
+import {
+  countDigitsBeforePos,
+  fetchCurrencyRateForWidget,
+  formatCurrencyAmountDisplay,
+  getCurrencyMaxFractionDigits,
+  normalizeAmountInput,
+  parseAmountInput,
+  positionAfterNthDigit,
+} from "@/lib/currency/frankfurter";
 
 const MAIN_CURRENCIES = [
   "USD",
@@ -59,7 +67,12 @@ export function CurrencyWidget({ widgetId }: CurrencyWidgetProps) {
 
   const [fromCurrency, setFromCurrency] = useState(config?.fromCurrency ?? "USD");
   const [toCurrency, setToCurrency] = useState(config?.toCurrency ?? "EUR");
-  const [amountStr, setAmountStr] = useState(config?.lastAmount ?? "100");
+  const [amountStr, setAmountStr] = useState(() =>
+    normalizeAmountInput(
+      config?.lastAmount ?? "100",
+      getCurrencyMaxFractionDigits(config?.fromCurrency ?? "USD")
+    )
+  );
   const [rateData, setRateData] = useState<RateCacheEntry | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -70,7 +83,13 @@ export function CurrencyWidget({ widgetId }: CurrencyWidgetProps) {
   useEffect(() => {
     if (config?.fromCurrency && config.fromCurrency !== fromCurrency) setFromCurrency(config.fromCurrency);
     if (config?.toCurrency && config.toCurrency !== toCurrency) setToCurrency(config.toCurrency);
-    if (config?.lastAmount != null && config.lastAmount !== amountStr) setAmountStr(config.lastAmount);
+    if (config?.lastAmount != null) {
+      const normalized = normalizeAmountInput(
+        config.lastAmount,
+        getCurrencyMaxFractionDigits(config.fromCurrency ?? fromCurrency)
+      );
+      if (normalized !== amountStr) setAmountStr(normalized);
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [config?.fromCurrency, config?.toCurrency, config?.lastAmount]);
 
@@ -175,7 +194,12 @@ export function CurrencyWidget({ widgetId }: CurrencyWidgetProps) {
 
   const handleFromChange = (code: string) => {
     setFromCurrency(code);
-    persistFields({ fromCurrency: code, toCurrency, lastAmount: amountStr });
+    const renormalized = normalizeAmountInput(
+      amountStr,
+      getCurrencyMaxFractionDigits(code)
+    );
+    if (renormalized !== amountStr) setAmountStr(renormalized);
+    persistFields({ fromCurrency: code, toCurrency, lastAmount: renormalized });
   };
 
   const handleToChange = (code: string) => {
@@ -183,9 +207,42 @@ export function CurrencyWidget({ widgetId }: CurrencyWidgetProps) {
     persistFields({ fromCurrency, toCurrency: code, lastAmount: amountStr });
   };
 
-  const handleAmountChange = (v: string) => {
-    setAmountStr(v);
-    persistFields({ fromCurrency, toCurrency, lastAmount: v });
+  const maxFractionDigits = getCurrencyMaxFractionDigits(fromCurrency);
+  const formattedAmount = useMemo(
+    () => formatCurrencyAmountDisplay(amountStr, fromCurrency, i18n.language),
+    [amountStr, fromCurrency, i18n.language]
+  );
+
+  const handleAmountInput = (
+    e: ChangeEvent<HTMLInputElement>
+  ) => {
+    const inputEl = e.target;
+    const rawValue = inputEl.value;
+    const selStart = inputEl.selectionStart ?? rawValue.length;
+
+    // How many digits precede the caret in what the user typed?
+    const digitsBeforeCaret = countDigitsBeforePos(rawValue, selStart);
+
+    const normalized = normalizeAmountInput(rawValue, maxFractionDigits);
+    const nextDisplay = formatCurrencyAmountDisplay(
+      normalized,
+      fromCurrency,
+      i18n.language
+    );
+
+    setAmountStr(normalized);
+    persistFields({ fromCurrency, toCurrency, lastAmount: normalized });
+
+    // Restore caret to sit after the same digit count in the formatted output.
+    requestAnimationFrame(() => {
+      if (!inputEl || document.activeElement !== inputEl) return;
+      const target = positionAfterNthDigit(nextDisplay, digitsBeforeCaret);
+      try {
+        inputEl.setSelectionRange(target, target);
+      } catch {
+        // Some browsers throw on certain input types; safe to ignore.
+      }
+    });
   };
 
   const handleSwap = () => {
@@ -238,8 +295,8 @@ export function CurrencyWidget({ widgetId }: CurrencyWidgetProps) {
         <input
           type="text"
           inputMode="decimal"
-          value={amountStr}
-          onChange={(e) => handleAmountChange(e.target.value)}
+          value={formattedAmount}
+          onChange={handleAmountInput}
           onPointerDown={(e) => e.stopPropagation()}
           placeholder={t("apps.dashboard.currency.amountPlaceholder", "Amount")}
           style={{
@@ -371,8 +428,8 @@ export function CurrencyWidget({ widgetId }: CurrencyWidgetProps) {
         <input
           type="text"
           inputMode="decimal"
-          value={amountStr}
-          onChange={(e) => handleAmountChange(e.target.value)}
+          value={formattedAmount}
+          onChange={handleAmountInput}
           onPointerDown={(e) => e.stopPropagation()}
           placeholder={t("apps.dashboard.currency.amountPlaceholder", "Amount")}
           style={{

--- a/src/components/layout/dashboard/CurrencyWidget.tsx
+++ b/src/components/layout/dashboard/CurrencyWidget.tsx
@@ -70,7 +70,8 @@ export function CurrencyWidget({ widgetId }: CurrencyWidgetProps) {
   const [amountStr, setAmountStr] = useState(() =>
     normalizeAmountInput(
       config?.lastAmount ?? "100",
-      getCurrencyMaxFractionDigits(config?.fromCurrency ?? "USD")
+      getCurrencyMaxFractionDigits(config?.fromCurrency ?? "USD"),
+      i18n.language
     )
   );
   const [rateData, setRateData] = useState<RateCacheEntry | null>(null);
@@ -86,7 +87,8 @@ export function CurrencyWidget({ widgetId }: CurrencyWidgetProps) {
     if (config?.lastAmount != null) {
       const normalized = normalizeAmountInput(
         config.lastAmount,
-        getCurrencyMaxFractionDigits(config.fromCurrency ?? fromCurrency)
+        getCurrencyMaxFractionDigits(config.fromCurrency ?? fromCurrency),
+        i18n.language
       );
       if (normalized !== amountStr) setAmountStr(normalized);
     }
@@ -196,7 +198,8 @@ export function CurrencyWidget({ widgetId }: CurrencyWidgetProps) {
     setFromCurrency(code);
     const renormalized = normalizeAmountInput(
       amountStr,
-      getCurrencyMaxFractionDigits(code)
+      getCurrencyMaxFractionDigits(code),
+      i18n.language
     );
     if (renormalized !== amountStr) setAmountStr(renormalized);
     persistFields({ fromCurrency: code, toCurrency, lastAmount: renormalized });
@@ -223,7 +226,11 @@ export function CurrencyWidget({ widgetId }: CurrencyWidgetProps) {
     // How many digits precede the caret in what the user typed?
     const digitsBeforeCaret = countDigitsBeforePos(rawValue, selStart);
 
-    const normalized = normalizeAmountInput(rawValue, maxFractionDigits);
+    const normalized = normalizeAmountInput(
+      rawValue,
+      maxFractionDigits,
+      i18n.language
+    );
     const nextDisplay = formatCurrencyAmountDisplay(
       normalized,
       fromCurrency,

--- a/src/lib/currency/frankfurter.ts
+++ b/src/lib/currency/frankfurter.ts
@@ -44,36 +44,38 @@ export function getCurrencyMaxFractionDigits(currency: string): number {
 /**
  * Normalize a user-typed amount string into a canonical numeric form
  * (digits and at most one ".") suitable for storage and parsing.
- * Accepts "," as decimal separator while typing and strips all other chars
- * (currency symbols, group separators, whitespace, letters).
+ *
+ * Locale-aware: only the locale's decimal separator is treated as a decimal
+ * point. The locale's group separator (and all other non-digit characters
+ * — currency symbols, whitespace, letters) is stripped. To enter decimals
+ * the user must explicitly type the decimal separator.
  */
-export function normalizeAmountInput(raw: string, maxFractionDigits = 2): string {
+export function normalizeAmountInput(
+  raw: string,
+  maxFractionDigits = 2,
+  locale = "en-US"
+): string {
   if (!raw) return "";
 
-  let s = raw;
+  const { decimal: decimalSep } = getNumberSeparators(locale);
 
-  // If both "." and "," are present, treat the rightmost separator as decimal
-  // and the others as group separators.
-  const lastDot = s.lastIndexOf(".");
-  const lastComma = s.lastIndexOf(",");
-  if (lastDot !== -1 && lastComma !== -1) {
-    if (lastDot > lastComma) {
-      s = s.replace(/,/g, "");
-    } else {
-      s = s.replace(/\./g, "").replace(",", ".");
+  // Convert the locale decimal separator to canonical "." and strip everything
+  // else that isn't a digit. This intentionally drops group separators (which
+  // are typed implicitly by formatting) and any stray currency symbols.
+  let s = "";
+  let seenDot = false;
+  for (let i = 0; i < raw.length; i++) {
+    const ch = raw[i];
+    if (ch >= "0" && ch <= "9") {
+      s += ch;
+    } else if (ch === decimalSep && !seenDot) {
+      s += ".";
+      seenDot = true;
+    } else if (decimalSep !== "." && ch === "." && !seenDot) {
+      // Locale's decimal isn't "." — treat literal "." as group separator and skip.
+      continue;
     }
-  } else if (lastComma !== -1) {
-    // Only commas — treat the last one as decimal separator
-    const before = s.slice(0, lastComma).replace(/,/g, "");
-    const after = s.slice(lastComma + 1);
-    s = `${before}.${after}`;
-  }
-
-  // Keep only digits and a single dot
-  s = s.replace(/[^\d.]/g, "");
-  const firstDot = s.indexOf(".");
-  if (firstDot !== -1) {
-    s = s.slice(0, firstDot + 1) + s.slice(firstDot + 1).replace(/\./g, "");
+    // anything else (group separator, currency symbol, letters, spaces) is dropped
   }
 
   if (maxFractionDigits <= 0) {

--- a/src/lib/currency/frankfurter.ts
+++ b/src/lib/currency/frankfurter.ts
@@ -25,6 +25,159 @@ export function parseAmountInput(raw: string): number {
   return Number.isFinite(n) ? n : 0;
 }
 
+export function getCurrencyMaxFractionDigits(currency: string): number {
+  const upper = currency.trim().toUpperCase();
+  // Currencies that conventionally have no minor unit
+  if (
+    upper === "JPY" ||
+    upper === "KRW" ||
+    upper === "VND" ||
+    upper === "CLP" ||
+    upper === "ISK" ||
+    upper === "HUF"
+  ) {
+    return 0;
+  }
+  return 2;
+}
+
+/**
+ * Normalize a user-typed amount string into a canonical numeric form
+ * (digits and at most one ".") suitable for storage and parsing.
+ * Accepts "," as decimal separator while typing and strips all other chars
+ * (currency symbols, group separators, whitespace, letters).
+ */
+export function normalizeAmountInput(raw: string, maxFractionDigits = 2): string {
+  if (!raw) return "";
+
+  let s = raw;
+
+  // If both "." and "," are present, treat the rightmost separator as decimal
+  // and the others as group separators.
+  const lastDot = s.lastIndexOf(".");
+  const lastComma = s.lastIndexOf(",");
+  if (lastDot !== -1 && lastComma !== -1) {
+    if (lastDot > lastComma) {
+      s = s.replace(/,/g, "");
+    } else {
+      s = s.replace(/\./g, "").replace(",", ".");
+    }
+  } else if (lastComma !== -1) {
+    // Only commas — treat the last one as decimal separator
+    const before = s.slice(0, lastComma).replace(/,/g, "");
+    const after = s.slice(lastComma + 1);
+    s = `${before}.${after}`;
+  }
+
+  // Keep only digits and a single dot
+  s = s.replace(/[^\d.]/g, "");
+  const firstDot = s.indexOf(".");
+  if (firstDot !== -1) {
+    s = s.slice(0, firstDot + 1) + s.slice(firstDot + 1).replace(/\./g, "");
+  }
+
+  if (maxFractionDigits <= 0) {
+    s = s.replace(/\./g, "");
+  } else if (s.includes(".")) {
+    const [intPart, decPart = ""] = s.split(".");
+    s = intPart + "." + decPart.slice(0, maxFractionDigits);
+  }
+
+  // Strip leading zeros from the integer part (keep "0" and "0.xxx")
+  if (s.includes(".")) {
+    const [intPart, decPart] = s.split(".");
+    const trimmedInt = intPart.replace(/^0+/, "");
+    s = (trimmedInt === "" ? "0" : trimmedInt) + "." + decPart;
+  } else if (s.length > 1) {
+    const trimmed = s.replace(/^0+/, "");
+    s = trimmed === "" ? "0" : trimmed;
+  }
+
+  return s;
+}
+
+/** Locale-specific decimal/group separators for plain number formatting. */
+function getNumberSeparators(locale: string): { decimal: string; group: string } {
+  try {
+    const parts = new Intl.NumberFormat(locale, {
+      minimumFractionDigits: 1,
+      useGrouping: true,
+    }).formatToParts(1234.5);
+    return {
+      decimal: parts.find((p) => p.type === "decimal")?.value ?? ".",
+      group: parts.find((p) => p.type === "group")?.value ?? ",",
+    };
+  } catch {
+    return { decimal: ".", group: "," };
+  }
+}
+
+/**
+ * Format a canonical numeric string (e.g. "1234.5") as a localized currency
+ * display string (e.g. "$1,234.5"). Preserves a trailing "." and trailing
+ * fractional zeros so the user can keep typing.
+ */
+export function formatCurrencyAmountDisplay(
+  normalized: string,
+  currency: string,
+  locale: string
+): string {
+  const maxFrac = getCurrencyMaxFractionDigits(currency);
+  const sep = getNumberSeparators(locale);
+
+  if (normalized === "" || normalized === "." || normalized === "0.") {
+    // Show empty when nothing typed; show "0" + decimal sep when partially typed
+    if (normalized === "") return "";
+    if (normalized === ".") return `0${sep.decimal}`;
+    return `0${sep.decimal}`;
+  }
+
+  const hasDecimal = normalized.includes(".");
+  const [intPartRaw, decPartRaw = ""] = normalized.split(".");
+  const intPart = intPartRaw === "" ? "0" : intPartRaw;
+  const intNum = Number.parseInt(intPart, 10);
+  if (!Number.isFinite(intNum)) return "";
+
+  // Format the integer part with the currency symbol/placement and grouping.
+  const intFormatted = new Intl.NumberFormat(locale, {
+    style: "currency",
+    currency,
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0,
+  }).format(intNum);
+
+  if (!hasDecimal || maxFrac === 0) {
+    return intFormatted;
+  }
+
+  // Append the decimal separator + raw decimal digits (preserving trailing zeros)
+  const dec = decPartRaw.slice(0, maxFrac);
+  return `${intFormatted}${sep.decimal}${dec}`;
+}
+
+/** Count digit characters in a string up to (but not including) `pos`. */
+export function countDigitsBeforePos(s: string, pos: number): number {
+  let count = 0;
+  const limit = Math.min(pos, s.length);
+  for (let i = 0; i < limit; i++) {
+    if (s.charCodeAt(i) >= 48 && s.charCodeAt(i) <= 57) count++;
+  }
+  return count;
+}
+
+/** Find the string index that comes right after the Nth digit. */
+export function positionAfterNthDigit(s: string, n: number): number {
+  if (n <= 0) return 0;
+  let count = 0;
+  for (let i = 0; i < s.length; i++) {
+    if (s.charCodeAt(i) >= 48 && s.charCodeAt(i) <= 57) {
+      count++;
+      if (count === n) return i + 1;
+    }
+  }
+  return s.length;
+}
+
 /** Direct Frankfurter (ECB). Uses `redirect: "follow"` because api.frankfurter.app may 301. */
 export async function fetchFrankfurterPairRateDirect(
   from: string,

--- a/tests/test-currency-frankfurter.test.ts
+++ b/tests/test-currency-frankfurter.test.ts
@@ -48,38 +48,50 @@ describe("normalizeAmountInput", () => {
     expect(normalizeAmountInput("100")).toBe("100");
   });
 
-  test("strips currency symbols, group separators, and spaces", () => {
-    expect(normalizeAmountInput("$1,234.56")).toBe("1234.56");
-    expect(normalizeAmountInput("€ 1.234,56")).toBe("1234.56");
-    expect(normalizeAmountInput("¥1,000", 0)).toBe("1000");
+  test("strips currency symbols, group separators, and spaces (en-US)", () => {
+    expect(normalizeAmountInput("$1,234.56", 2, "en-US")).toBe("1234.56");
+    expect(normalizeAmountInput("¥1,000", 0, "en-US")).toBe("1000");
   });
 
-  test("treats single comma as decimal separator", () => {
-    expect(normalizeAmountInput("3,14")).toBe("3.14");
+  test("strips locale group separators and uses locale decimal separator (de-DE)", () => {
+    expect(normalizeAmountInput("1.234,56", 2, "de-DE")).toBe("1234.56");
+    expect(normalizeAmountInput("3,14", 2, "de-DE")).toBe("3.14");
+    // Literal "." in a comma-decimal locale is treated as a group separator
+    expect(normalizeAmountInput("1.000", 2, "de-DE")).toBe("1000");
   });
 
-  test("collapses multiple decimal points", () => {
-    expect(normalizeAmountInput("1.2.3")).toBe("1.23");
+  test("does NOT treat group separator as decimal when typing past it", () => {
+    // Regression: typing "0" after "$7,000" used to produce "7.00".
+    expect(normalizeAmountInput("$7,0000", 2, "en-US")).toBe("70000");
+    expect(normalizeAmountInput("$70,000", 2, "en-US")).toBe("70000");
+    expect(normalizeAmountInput("$700", 2, "en-US")).toBe("700");
+    expect(normalizeAmountInput("700", 2, "en-US")).toBe("700");
+    // de-DE equivalent
+    expect(normalizeAmountInput("7.0000", 2, "de-DE")).toBe("70000");
+  });
+
+  test("only the first decimal separator counts; later ones are dropped", () => {
+    expect(normalizeAmountInput("1.2.3", 2, "en-US")).toBe("1.23");
   });
 
   test("trims fractional digits to maxFractionDigits", () => {
-    expect(normalizeAmountInput("1.23456", 2)).toBe("1.23");
-    expect(normalizeAmountInput("1.99", 0)).toBe("199");
+    expect(normalizeAmountInput("1.23456", 2, "en-US")).toBe("1.23");
+    expect(normalizeAmountInput("1.99", 0, "en-US")).toBe("199");
   });
 
   test("preserves trailing dot to allow further typing", () => {
-    expect(normalizeAmountInput("100.")).toBe("100.");
+    expect(normalizeAmountInput("100.", 2, "en-US")).toBe("100.");
   });
 
   test("normalizes leading zeros", () => {
-    expect(normalizeAmountInput("0010")).toBe("10");
-    expect(normalizeAmountInput("0.5")).toBe("0.5");
-    expect(normalizeAmountInput("0")).toBe("0");
+    expect(normalizeAmountInput("0010", 2, "en-US")).toBe("10");
+    expect(normalizeAmountInput("0.5", 2, "en-US")).toBe("0.5");
+    expect(normalizeAmountInput("0", 2, "en-US")).toBe("0");
   });
 
   test("returns empty for empty input", () => {
-    expect(normalizeAmountInput("")).toBe("");
-    expect(normalizeAmountInput("abc")).toBe("");
+    expect(normalizeAmountInput("", 2, "en-US")).toBe("");
+    expect(normalizeAmountInput("abc", 2, "en-US")).toBe("");
   });
 });
 

--- a/tests/test-currency-frankfurter.test.ts
+++ b/tests/test-currency-frankfurter.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, test } from "bun:test";
-import { parseAmountInput } from "@/lib/currency/frankfurter";
+import {
+  countDigitsBeforePos,
+  formatCurrencyAmountDisplay,
+  getCurrencyMaxFractionDigits,
+  normalizeAmountInput,
+  parseAmountInput,
+  positionAfterNthDigit,
+} from "@/lib/currency/frankfurter";
 
 describe("parseAmountInput", () => {
   test("parses plain decimal", () => {
@@ -19,5 +26,98 @@ describe("parseAmountInput", () => {
   test("returns 0 for empty or invalid", () => {
     expect(parseAmountInput("")).toBe(0);
     expect(parseAmountInput("abc")).toBe(0);
+  });
+});
+
+describe("getCurrencyMaxFractionDigits", () => {
+  test("returns 0 for zero-decimal currencies", () => {
+    expect(getCurrencyMaxFractionDigits("JPY")).toBe(0);
+    expect(getCurrencyMaxFractionDigits("krw")).toBe(0);
+    expect(getCurrencyMaxFractionDigits("HUF")).toBe(0);
+  });
+
+  test("returns 2 for typical currencies", () => {
+    expect(getCurrencyMaxFractionDigits("USD")).toBe(2);
+    expect(getCurrencyMaxFractionDigits("EUR")).toBe(2);
+    expect(getCurrencyMaxFractionDigits("GBP")).toBe(2);
+  });
+});
+
+describe("normalizeAmountInput", () => {
+  test("keeps plain digits", () => {
+    expect(normalizeAmountInput("100")).toBe("100");
+  });
+
+  test("strips currency symbols, group separators, and spaces", () => {
+    expect(normalizeAmountInput("$1,234.56")).toBe("1234.56");
+    expect(normalizeAmountInput("€ 1.234,56")).toBe("1234.56");
+    expect(normalizeAmountInput("¥1,000", 0)).toBe("1000");
+  });
+
+  test("treats single comma as decimal separator", () => {
+    expect(normalizeAmountInput("3,14")).toBe("3.14");
+  });
+
+  test("collapses multiple decimal points", () => {
+    expect(normalizeAmountInput("1.2.3")).toBe("1.23");
+  });
+
+  test("trims fractional digits to maxFractionDigits", () => {
+    expect(normalizeAmountInput("1.23456", 2)).toBe("1.23");
+    expect(normalizeAmountInput("1.99", 0)).toBe("199");
+  });
+
+  test("preserves trailing dot to allow further typing", () => {
+    expect(normalizeAmountInput("100.")).toBe("100.");
+  });
+
+  test("normalizes leading zeros", () => {
+    expect(normalizeAmountInput("0010")).toBe("10");
+    expect(normalizeAmountInput("0.5")).toBe("0.5");
+    expect(normalizeAmountInput("0")).toBe("0");
+  });
+
+  test("returns empty for empty input", () => {
+    expect(normalizeAmountInput("")).toBe("");
+    expect(normalizeAmountInput("abc")).toBe("");
+  });
+});
+
+describe("formatCurrencyAmountDisplay", () => {
+  test("formats USD in en-US with grouping", () => {
+    expect(formatCurrencyAmountDisplay("1234", "USD", "en-US")).toBe("$1,234");
+    expect(formatCurrencyAmountDisplay("1234.5", "USD", "en-US")).toBe("$1,234.5");
+    expect(formatCurrencyAmountDisplay("1234.56", "USD", "en-US")).toBe("$1,234.56");
+  });
+
+  test("preserves trailing decimal separator while typing", () => {
+    expect(formatCurrencyAmountDisplay("1234.", "USD", "en-US")).toBe("$1,234.");
+  });
+
+  test("ignores decimals for zero-decimal currencies", () => {
+    expect(formatCurrencyAmountDisplay("1000", "JPY", "en-US")).toMatch(/1,000/);
+    expect(formatCurrencyAmountDisplay("1000.5", "JPY", "en-US")).toMatch(/1,000/);
+  });
+
+  test("returns empty string for empty input", () => {
+    expect(formatCurrencyAmountDisplay("", "USD", "en-US")).toBe("");
+  });
+});
+
+describe("caret position helpers", () => {
+  test("countDigitsBeforePos counts only digits", () => {
+    expect(countDigitsBeforePos("$1,234.56", 0)).toBe(0);
+    expect(countDigitsBeforePos("$1,234.56", 1)).toBe(0);
+    expect(countDigitsBeforePos("$1,234.56", 2)).toBe(1);
+    expect(countDigitsBeforePos("$1,234.56", 6)).toBe(4);
+    expect(countDigitsBeforePos("$1,234.56", 9)).toBe(6);
+  });
+
+  test("positionAfterNthDigit lands after the right digit", () => {
+    expect(positionAfterNthDigit("$1,234.56", 0)).toBe(0);
+    expect(positionAfterNthDigit("$1,234.56", 1)).toBe(2);
+    expect(positionAfterNthDigit("$1,234.56", 4)).toBe(6);
+    expect(positionAfterNthDigit("$1,234.56", 6)).toBe(9);
+    expect(positionAfterNthDigit("$1,234.56", 99)).toBe(9);
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Display the amount in the Dashboard currency converter widget as a localized currency string (e.g. `$1,234.56`) while still accepting raw numeric typing. The input formats as you type — adding the currency symbol, locale-correct grouping, and clamping fractional digits to the source currency's convention (e.g. JPY allows none).

Internally we keep a canonical numeric string (`"1234.56"`) so downstream parsing, conversion, and persistence are unchanged. Caret position is restored by digit-index after each keystroke so editing inside the formatted value feels natural.

**Decimals are user-driven**: only the locale's actual decimal separator (e.g. `.` in en-US, `,` in de-DE) introduces a decimal. The locale's group separator and other non-digit characters are stripped — so typing `7`, `0`, `0`, `0`, `0` always yields `$70,000`, never `$7.00`.

## Changes

- `src/lib/currency/frankfurter.ts`: add `normalizeAmountInput`, `formatCurrencyAmountDisplay`, `getCurrencyMaxFractionDigits`, and caret helpers (`countDigitsBeforePos`, `positionAfterNthDigit`). Locale-aware — `normalizeAmountInput` takes the locale and only treats the locale's decimal separator as decimal.
- `src/components/layout/dashboard/CurrencyWidget.tsx`:
  - render the input value via `formatCurrencyAmountDisplay` (both XP and graphite themes).
  - normalize input on change, re-format, and restore caret position by digit index.
  - re-normalize fractional digits when switching source currency (e.g. `USD → JPY` drops decimals).
  - normalize legacy persisted `lastAmount` on mount / config sync, threading `i18n.language` through everywhere.
- `tests/test-currency-frankfurter.test.ts`: 17 new unit tests, including regression cases for `$7,0000`, `$70,000`, `700`, and de-DE locale behaviour.

## Testing

- ✅ `bun test tests/test-currency-frankfurter.test.ts` — 21 pass / 0 fail
- ✅ `bun run build` — clean build, no TS errors

Manual GUI verification was skipped per the project's `## Cursor Cloud specific instructions`. The fix is exercised end-to-end by the new unit tests for normalization, formatting, caret-position math, and the specific regression (`$7,0000` → `70000`).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8a125c28-c66d-44ef-91c5-5e1e73f74dbd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8a125c28-c66d-44ef-91c5-5e1e73f74dbd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

