### PR TITLE
ipod: Add Music Quiz game (Extras menu)

### DIFF
--- a/src/apps/ipod/components/IpodAppComponent.tsx
+++ b/src/apps/ipod/components/IpodAppComponent.tsx
@@ -14,6 +14,7 @@ import { PipPlayer } from "./PipPlayer";
 import { FullScreenPortal } from "./FullScreenPortal";
 import { LyricsDisplay } from "./LyricsDisplay";
 import { CoverFlow } from "./CoverFlow";
+import { MusicQuiz } from "./MusicQuiz";
 import { LyricsSyncMode } from "@/components/shared/LyricsSyncMode";
 import { ShareItemDialog } from "@/components/dialogs/ShareItemDialog";
 import { LyricsSearchDialog } from "@/components/dialogs/LyricsSearchDialog";
@@ -79,6 +80,12 @@ export function IpodAppComponent({
     menuDirection,
     menuHistory,
     isCoverFlowOpen,
+    isMusicQuizOpen,
+    setIsMusicQuizOpen,
+    musicQuizRef,
+    playClickSound,
+    playScrollSound,
+    vibrate,
     activityState,
     skipOperationRef,
     isHelpDialogOpen,
@@ -395,6 +402,16 @@ export function IpodAppComponent({
                 isPlaying={isPlaying}
                 onTogglePlay={togglePlay}
                 onPlayTrackInPlace={handleCoverFlowPlayInPlace}
+              />
+
+              {/* Music Quiz overlay - positioned within screen bounds */}
+              <MusicQuiz
+                ref={musicQuizRef}
+                isVisible={isMusicQuizOpen}
+                onExit={() => setIsMusicQuizOpen(false)}
+                playClick={playClickSound}
+                playScroll={playScrollSound}
+                vibrate={vibrate}
               />
             </div>
 

--- a/src/apps/ipod/components/IpodAppComponent.tsx
+++ b/src/apps/ipod/components/IpodAppComponent.tsx
@@ -327,68 +327,70 @@ export function IpodAppComponent({
                 screenLongPressStartPos.current = null;
               }}
             >
-              <IpodScreen
-                currentTrack={tracks[currentIndex] || null}
-                isPlaying={isPlaying && !isFullScreen}
-                elapsedTime={elapsedTime}
-                totalTime={totalTime}
-                menuMode={menuMode}
-                menuHistory={menuHistory}
-                selectedMenuItem={selectedMenuItem}
-                onSelectMenuItem={setSelectedMenuItem}
-                currentIndex={currentIndex}
-                tracksLength={tracks.length}
-                backlightOn={backlightOn}
-                menuDirection={menuDirection}
-                onMenuItemAction={handleMenuItemAction}
-                showVideo={showVideo}
-                displayMode={displayMode}
-                playerRef={playerRef}
-                handleTrackEnd={handleTrackEnd}
-                handleProgress={handleProgress}
-                handleDuration={handleDuration}
-                handlePlay={handlePlay}
-                handlePause={handlePause}
-                handleReady={handleReady}
-                loopCurrent={loopCurrent}
-                statusMessage={statusMessage}
-                onToggleVideo={toggleVideo}
-                lcdFilterOn={lcdFilterOn}
-                ipodVolume={ipodVolume}
-                showStatusCallback={showStatus}
-                showLyrics={showLyrics}
-                lyricsAlignment={lyricsAlignment}
-                koreanDisplay={koreanDisplay}
-                japaneseFurigana={japaneseFurigana}
-                lyricOffset={lyricOffset ?? 0}
-                adjustLyricOffset={(delta) => adjustLyricOffset(currentIndex, delta)}
-                registerActivity={registerActivity}
-                isFullScreen={isFullScreen}
-                lyricsControls={fullScreenLyricsControls}
-                furiganaMap={furiganaMap}
-                soramimiMap={soramimiMap}
-                activityState={activityState}
-                onNextTrack={() => {
-                  if (isOffline) {
-                    showOfflineStatus();
-                  } else {
-                    skipOperationRef.current = true;
-                    startTrackSwitch();
-                    nextTrack();
-                    showStatus("⏭");
-                  }
-                }}
-                onPreviousTrack={() => {
-                  if (isOffline) {
-                    showOfflineStatus();
-                  } else {
-                    skipOperationRef.current = true;
-                    startTrackSwitch();
-                    previousTrack();
-                    showStatus("⏮");
-                  }
-                }}
-              />
+              {!isMusicQuizOpen && (
+                <IpodScreen
+                  currentTrack={tracks[currentIndex] || null}
+                  isPlaying={isPlaying && !isFullScreen}
+                  elapsedTime={elapsedTime}
+                  totalTime={totalTime}
+                  menuMode={menuMode}
+                  menuHistory={menuHistory}
+                  selectedMenuItem={selectedMenuItem}
+                  onSelectMenuItem={setSelectedMenuItem}
+                  currentIndex={currentIndex}
+                  tracksLength={tracks.length}
+                  backlightOn={backlightOn}
+                  menuDirection={menuDirection}
+                  onMenuItemAction={handleMenuItemAction}
+                  showVideo={showVideo}
+                  displayMode={displayMode}
+                  playerRef={playerRef}
+                  handleTrackEnd={handleTrackEnd}
+                  handleProgress={handleProgress}
+                  handleDuration={handleDuration}
+                  handlePlay={handlePlay}
+                  handlePause={handlePause}
+                  handleReady={handleReady}
+                  loopCurrent={loopCurrent}
+                  statusMessage={statusMessage}
+                  onToggleVideo={toggleVideo}
+                  lcdFilterOn={lcdFilterOn}
+                  ipodVolume={ipodVolume}
+                  showStatusCallback={showStatus}
+                  showLyrics={showLyrics}
+                  lyricsAlignment={lyricsAlignment}
+                  koreanDisplay={koreanDisplay}
+                  japaneseFurigana={japaneseFurigana}
+                  lyricOffset={lyricOffset ?? 0}
+                  adjustLyricOffset={(delta) => adjustLyricOffset(currentIndex, delta)}
+                  registerActivity={registerActivity}
+                  isFullScreen={isFullScreen}
+                  lyricsControls={fullScreenLyricsControls}
+                  furiganaMap={furiganaMap}
+                  soramimiMap={soramimiMap}
+                  activityState={activityState}
+                  onNextTrack={() => {
+                    if (isOffline) {
+                      showOfflineStatus();
+                    } else {
+                      skipOperationRef.current = true;
+                      startTrackSwitch();
+                      nextTrack();
+                      showStatus("⏭");
+                    }
+                  }}
+                  onPreviousTrack={() => {
+                    if (isOffline) {
+                      showOfflineStatus();
+                    } else {
+                      skipOperationRef.current = true;
+                      startTrackSwitch();
+                      previousTrack();
+                      showStatus("⏮");
+                    }
+                  }}
+                />
+              )}
 
               {/* Cover Flow overlay - positioned within screen bounds */}
               <CoverFlow
@@ -409,6 +411,8 @@ export function IpodAppComponent({
                 ref={musicQuizRef}
                 isVisible={isMusicQuizOpen}
                 onExit={() => setIsMusicQuizOpen(false)}
+                lcdFilterOn={lcdFilterOn}
+                backlightOn={backlightOn}
                 playClick={playClickSound}
                 playScroll={playScrollSound}
                 vibrate={vibrate}

--- a/src/apps/ipod/components/MusicQuiz.tsx
+++ b/src/apps/ipod/components/MusicQuiz.tsx
@@ -1,0 +1,508 @@
+import { useEffect, useRef, useState, useMemo, useCallback, useImperativeHandle, forwardRef } from "react";
+import { motion, AnimatePresence } from "framer-motion";
+import ReactPlayer from "react-player";
+import { useTranslation } from "react-i18next";
+import { cn } from "@/lib/utils";
+import { useAudioSettingsStore } from "@/stores/useAudioSettingsStore";
+import { useIpodStore, type Track } from "@/stores/useIpodStore";
+import { MenuListItem } from "./screen";
+
+const SNIPPET_DURATION_MS = 10000;
+const FEEDBACK_DURATION_MS = 1800;
+const TOTAL_ROUNDS = 5;
+const NUM_OPTIONS = 4;
+// Avoid the very beginning and end so snippets feel like "the song", not intros/outros.
+// We still cap by half the actual duration once it loads.
+const SNIPPET_MIN_START_SEC = 20;
+const SNIPPET_MAX_FALLBACK_SEC = 180;
+
+export interface MusicQuizRound {
+  correctIndex: number;
+  options: Track[];
+  startSec: number;
+  selectedIndex: number | null;
+  isCorrect: boolean | null;
+}
+
+type Phase = "idle" | "loading" | "playing" | "feedback" | "finished";
+
+export interface MusicQuizRef {
+  /** Move selection up/down. Returns true if handled. */
+  navigate: (direction: "next" | "previous") => boolean;
+  /** Confirm current selection (or advance to next round / restart from finished). */
+  selectCurrent: () => void;
+  /** Replay the current snippet from its start. */
+  replaySnippet: () => void;
+}
+
+export interface MusicQuizProps {
+  isVisible: boolean;
+  onExit: () => void;
+  /** Pause the main library player when entering, called once when visible turns true */
+  onEnter?: () => void;
+  /** Sound effects */
+  playClick?: () => void;
+  playScroll?: () => void;
+  vibrate?: () => void;
+}
+
+function shuffle<T>(arr: T[]): T[] {
+  const a = arr.slice();
+  for (let i = a.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [a[i], a[j]] = [a[j], a[i]];
+  }
+  return a;
+}
+
+function pickRound(tracks: Track[]): { options: Track[]; correctIndex: number; correct: Track } | null {
+  if (tracks.length < 1) return null;
+  const optionCount = Math.min(NUM_OPTIONS, tracks.length);
+  const shuffled = shuffle(tracks);
+  const options = shuffled.slice(0, optionCount);
+  const correctIndex = Math.floor(Math.random() * options.length);
+  return { options, correctIndex, correct: options[correctIndex] };
+}
+
+export const MusicQuiz = forwardRef<MusicQuizRef, MusicQuizProps>(function MusicQuiz(
+  { isVisible, onExit: _onExit, onEnter, playClick, playScroll, vibrate },
+  ref
+) {
+  const { t } = useTranslation();
+  const tracks = useIpodStore((s) => s.tracks);
+  const masterVolume = useAudioSettingsStore((s) => s.masterVolume);
+  const ipodVolume = useAudioSettingsStore((s) => s.ipodVolume);
+  const finalVolume = ipodVolume * masterVolume;
+
+  const [phase, setPhase] = useState<Phase>("idle");
+  const [round, setRound] = useState<MusicQuizRound | null>(null);
+  const [roundNumber, setRoundNumber] = useState(0);
+  const [score, setScore] = useState(0);
+  const [selectedIndex, setSelectedIndex] = useState(0);
+
+  const playerRef = useRef<ReactPlayer | null>(null);
+  const snippetTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const feedbackTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const startSecRef = useRef(0);
+  const enteredRef = useRef(false);
+
+  const hasEnoughTracks = tracks.length >= 2;
+
+  const clearTimers = useCallback(() => {
+    if (snippetTimerRef.current) {
+      clearTimeout(snippetTimerRef.current);
+      snippetTimerRef.current = null;
+    }
+    if (feedbackTimerRef.current) {
+      clearTimeout(feedbackTimerRef.current);
+      feedbackTimerRef.current = null;
+    }
+  }, []);
+
+  const computeStartSec = useCallback((duration: number) => {
+    // Use track duration if available; otherwise pick within a fallback window.
+    const safeDuration = Number.isFinite(duration) && duration > 0 ? duration : SNIPPET_MAX_FALLBACK_SEC;
+    // Avoid intros/outros: pick from [min, max] where:
+    //   min = clamp 20s but no more than 25% of song
+    //   max = 75% of song
+    const min = Math.min(SNIPPET_MIN_START_SEC, Math.max(0, safeDuration * 0.1));
+    const max = Math.max(min + 1, safeDuration * 0.75 - SNIPPET_DURATION_MS / 1000);
+    if (max <= min) return Math.max(0, safeDuration / 4);
+    return min + Math.random() * (max - min);
+  }, []);
+
+  const startNextRound = useCallback(() => {
+    clearTimers();
+    if (!hasEnoughTracks) {
+      setPhase("idle");
+      return;
+    }
+    const next = pickRound(tracks);
+    if (!next) {
+      setPhase("idle");
+      return;
+    }
+    // Pick a provisional start; we'll re-pick once duration is known via onDuration.
+    const provisionalStart = SNIPPET_MIN_START_SEC + Math.random() * 30;
+    startSecRef.current = provisionalStart;
+    setRound({
+      options: next.options,
+      correctIndex: next.correctIndex,
+      startSec: provisionalStart,
+      selectedIndex: null,
+      isCorrect: null,
+    });
+    setRoundNumber((n) => n + 1);
+    setSelectedIndex(0);
+    setPhase("loading");
+  }, [clearTimers, hasEnoughTracks, tracks]);
+
+  // When becoming visible, start the game.
+  useEffect(() => {
+    if (isVisible) {
+      if (!enteredRef.current) {
+        enteredRef.current = true;
+        onEnter?.();
+        setScore(0);
+        setRoundNumber(0);
+        startNextRound();
+      }
+    } else {
+      // Reset on hide
+      enteredRef.current = false;
+      clearTimers();
+      setPhase("idle");
+      setRound(null);
+      setRoundNumber(0);
+      setScore(0);
+      setSelectedIndex(0);
+    }
+  }, [isVisible, onEnter, startNextRound, clearTimers]);
+
+  // Cleanup on unmount
+  useEffect(() => () => clearTimers(), [clearTimers]);
+
+  const handleAnswer = useCallback(
+    (idx: number) => {
+      if (!round || phase !== "playing") return;
+      playClick?.();
+      vibrate?.();
+      clearTimers();
+      const isCorrect = idx === round.correctIndex;
+      setRound({ ...round, selectedIndex: idx, isCorrect });
+      setSelectedIndex(round.correctIndex);
+      setPhase("feedback");
+      if (isCorrect) setScore((s) => s + 1);
+
+      feedbackTimerRef.current = setTimeout(() => {
+        if (roundNumber >= TOTAL_ROUNDS) {
+          setPhase("finished");
+        } else {
+          startNextRound();
+        }
+      }, FEEDBACK_DURATION_MS);
+    },
+    [round, phase, playClick, vibrate, clearTimers, roundNumber, startNextRound]
+  );
+
+  // Snippet playback control
+  const startSnippet = useCallback(() => {
+    if (!playerRef.current) return;
+    clearTimers();
+    playerRef.current.seekTo(startSecRef.current, "seconds");
+    snippetTimerRef.current = setTimeout(() => {
+      // Time's up — auto-mark wrong (no answer)
+      if (!round) return;
+      clearTimers();
+      const updated = { ...round, selectedIndex: null, isCorrect: false };
+      setRound(updated);
+      setSelectedIndex(round.correctIndex);
+      setPhase("feedback");
+      feedbackTimerRef.current = setTimeout(() => {
+        if (roundNumber >= TOTAL_ROUNDS) {
+          setPhase("finished");
+        } else {
+          startNextRound();
+        }
+      }, FEEDBACK_DURATION_MS);
+    }, SNIPPET_DURATION_MS);
+  }, [clearTimers, round, roundNumber, startNextRound]);
+
+  const handleDuration = useCallback(
+    (duration: number) => {
+      // Re-pick a start within the song's true bounds.
+      if (!round || phase !== "loading") return;
+      const start = computeStartSec(duration);
+      startSecRef.current = start;
+      setRound((r) => (r ? { ...r, startSec: start } : r));
+    },
+    [round, phase, computeStartSec]
+  );
+
+  const handleReady = useCallback(() => {
+    if (phase !== "loading") return;
+    setPhase("playing");
+    // Defer to next tick to ensure player is fully ready before seeking
+    setTimeout(() => {
+      if (playerRef.current) {
+        playerRef.current.seekTo(startSecRef.current, "seconds");
+      }
+      startSnippet();
+    }, 50);
+  }, [phase, startSnippet]);
+
+  // Imperative API exposed via ref
+  useImperativeHandle(ref, () => ({
+    navigate: (direction) => {
+      if (phase === "playing" && round) {
+        playScroll?.();
+        setSelectedIndex((prev) => {
+          const len = round.options.length;
+          if (direction === "next") return Math.min(len - 1, prev + 1);
+          return Math.max(0, prev - 1);
+        });
+        return true;
+      }
+      if (phase === "finished") {
+        // No-op navigation in finished view
+        return true;
+      }
+      return false;
+    },
+    selectCurrent: () => {
+      if (phase === "playing" && round) {
+        handleAnswer(selectedIndex);
+        return;
+      }
+      if (phase === "feedback") {
+        // Skip remaining feedback timer
+        clearTimers();
+        if (roundNumber >= TOTAL_ROUNDS) {
+          setPhase("finished");
+        } else {
+          startNextRound();
+        }
+        return;
+      }
+      if (phase === "finished") {
+        // Restart
+        playClick?.();
+        vibrate?.();
+        setScore(0);
+        setRoundNumber(0);
+        setSelectedIndex(0);
+        startNextRound();
+        return;
+      }
+    },
+    replaySnippet: () => {
+      if (phase === "playing" && playerRef.current) {
+        playClick?.();
+        vibrate?.();
+        playerRef.current.seekTo(startSecRef.current, "seconds");
+        // Restart snippet timer
+        clearTimers();
+        snippetTimerRef.current = setTimeout(() => {
+          if (!round) return;
+          clearTimers();
+          setRound((r) => (r ? { ...r, selectedIndex: null, isCorrect: false } : r));
+          setSelectedIndex((round?.correctIndex) ?? 0);
+          setPhase("feedback");
+          feedbackTimerRef.current = setTimeout(() => {
+            if (roundNumber >= TOTAL_ROUNDS) {
+              setPhase("finished");
+            } else {
+              startNextRound();
+            }
+          }, FEEDBACK_DURATION_MS);
+        }, SNIPPET_DURATION_MS);
+      }
+    },
+  }), [phase, round, selectedIndex, handleAnswer, playClick, playScroll, vibrate, clearTimers, roundNumber, startNextRound]);
+
+  const headerTitle = useMemo(() => {
+    if (phase === "finished") return t("apps.ipod.musicQuiz.results", "Results");
+    return t("apps.ipod.musicQuiz.title", "Music Quiz");
+  }, [phase, t]);
+
+  if (!isVisible) return null;
+
+  // Hidden ReactPlayer for the snippet (audio only)
+  const correctTrackUrl = round?.options[round.correctIndex]?.url;
+
+  return (
+    <div className="absolute inset-0 z-30 flex flex-col bg-[#c5e0f5] bg-gradient-to-b from-[#d1e8fa] to-[#e0f0fc] overflow-hidden font-chicago">
+      {/* Header */}
+      <div className="border-b border-[#0a3667] py-0 px-2 text-[16px] flex items-center text-[#0a3667] [text-shadow:1px_1px_0_rgba(0,0,0,0.15)]">
+        <div className="w-12 text-left text-[12px]">
+          {phase !== "finished" && hasEnoughTracks && (
+            <span>
+              {Math.min(roundNumber, TOTAL_ROUNDS)}/{TOTAL_ROUNDS}
+            </span>
+          )}
+        </div>
+        <div className="flex-1 truncate text-center">{headerTitle}</div>
+        <div className="w-12 text-right text-[12px]">
+          {phase !== "finished" && hasEnoughTracks && (
+            <span>
+              {t("apps.ipod.musicQuiz.scoreShort", "Score")}: {score}
+            </span>
+          )}
+        </div>
+      </div>
+
+      {/* Body */}
+      <div className="flex-1 relative overflow-hidden">
+        {!hasEnoughTracks ? (
+          <div className="absolute inset-0 flex flex-col items-center justify-center px-3 text-center text-[#0a3667] [text-shadow:1px_1px_0_rgba(0,0,0,0.15)]">
+            <p className="text-[14px]">
+              {t(
+                "apps.ipod.musicQuiz.notEnoughTracks",
+                "Add more songs to play the quiz"
+              )}
+            </p>
+          </div>
+        ) : phase === "finished" ? (
+          <div className="absolute inset-0 flex flex-col items-center justify-center px-3 text-center text-[#0a3667] [text-shadow:1px_1px_0_rgba(0,0,0,0.15)]">
+            <div className="text-[14px] mb-1">
+              {t("apps.ipod.musicQuiz.finalScore", "Final Score")}
+            </div>
+            <div className="text-[28px] leading-none mb-2">
+              {score}/{TOTAL_ROUNDS}
+            </div>
+            <div className="text-[12px] mb-3">
+              {t(scoreMessageKey(score, TOTAL_ROUNDS), {
+                defaultValue:
+                  score === TOTAL_ROUNDS
+                    ? "Perfect score! 🏆"
+                    : score / TOTAL_ROUNDS >= 0.6
+                    ? "Great job!"
+                    : score / TOTAL_ROUNDS >= 0.3
+                    ? "Not bad!"
+                    : "Keep listening!",
+              })}
+            </div>
+            <div className="text-[11px] opacity-80">
+              {t("apps.ipod.musicQuiz.pressCenterToReplay", "Press center to play again · Menu to exit")}
+            </div>
+          </div>
+        ) : phase === "loading" ? (
+          <div className="absolute inset-0 flex flex-col items-center justify-center px-3 text-center text-[#0a3667] [text-shadow:1px_1px_0_rgba(0,0,0,0.15)]">
+            <div className="text-[14px] animate-pulse">
+              {t("apps.ipod.musicQuiz.loading", "Loading snippet…")}
+            </div>
+          </div>
+        ) : (
+          <div className="absolute inset-0 flex flex-col">
+            {/* Prompt + snippet progress */}
+            <div className="px-2 pt-1 pb-1 text-center text-[#0a3667] [text-shadow:1px_1px_0_rgba(0,0,0,0.15)]">
+              <div className="text-[12px]">
+                {phase === "feedback"
+                  ? round?.isCorrect
+                    ? t("apps.ipod.musicQuiz.correct", "Correct!")
+                    : round?.selectedIndex == null
+                    ? t("apps.ipod.musicQuiz.timesUp", "Time's up!")
+                    : t("apps.ipod.musicQuiz.wrong", "Not quite!")
+                  : t("apps.ipod.musicQuiz.guessTheSong", "Guess the song")}
+              </div>
+              <SnippetProgressBar
+                key={`${roundNumber}-${phase}`}
+                durationMs={SNIPPET_DURATION_MS}
+                running={phase === "playing"}
+              />
+            </div>
+
+            {/* Options */}
+            <div className="flex-1 overflow-auto">
+              {round?.options.map((option, idx) => {
+                const isSelected = idx === selectedIndex;
+                const isCorrectOption = phase === "feedback" && idx === round.correctIndex;
+                const isWrongPicked =
+                  phase === "feedback" &&
+                  round.selectedIndex === idx &&
+                  idx !== round.correctIndex;
+                return (
+                  <div
+                    key={`${roundNumber}-${idx}-${option.id}`}
+                    className={cn(
+                      "ipod-menu-item",
+                      isSelected ? "selected" : "",
+                      isCorrectOption && "bg-[#1c8a3a]/30",
+                      isWrongPicked && "bg-[#a83232]/30"
+                    )}
+                  >
+                    <MenuListItem
+                      text={formatOption(option)}
+                      isSelected={isSelected}
+                      backlightOn={true}
+                      onClick={() => {
+                        if (phase === "playing") {
+                          setSelectedIndex(idx);
+                          handleAnswer(idx);
+                        }
+                      }}
+                      showChevron={false}
+                      value={
+                        isCorrectOption
+                          ? "✓"
+                          : isWrongPicked
+                          ? "✗"
+                          : undefined
+                      }
+                    />
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* Hidden audio-only player for snippet */}
+      <div
+        className="absolute opacity-0 pointer-events-none"
+        style={{ width: 1, height: 1, left: -9999, top: -9999 }}
+        aria-hidden
+      >
+        {correctTrackUrl && phase !== "finished" && phase !== "idle" && (
+          <ReactPlayer
+            ref={playerRef}
+            url={correctTrackUrl}
+            playing={phase === "playing"}
+            controls={false}
+            volume={finalVolume}
+            width="1px"
+            height="1px"
+            playsinline
+            onReady={handleReady}
+            onDuration={handleDuration}
+            config={{
+              youtube: {
+                playerVars: {
+                  modestbranding: 1,
+                  rel: 0,
+                  showinfo: 0,
+                  iv_load_policy: 3,
+                  fs: 0,
+                  disablekb: 1,
+                  playsinline: 1,
+                  enablejsapi: 1,
+                  origin: window.location.origin,
+                },
+              },
+            }}
+          />
+        )}
+      </div>
+    </div>
+  );
+});
+
+function formatOption(track: Track): string {
+  const artist = track.artist ? ` — ${track.artist}` : "";
+  return `${track.title}${artist}`;
+}
+
+function scoreMessageKey(score: number, total: number): string {
+  const ratio = total === 0 ? 0 : score / total;
+  if (ratio === 1) return "apps.ipod.musicQuiz.perfect";
+  if (ratio >= 0.6) return "apps.ipod.musicQuiz.greatJob";
+  if (ratio >= 0.3) return "apps.ipod.musicQuiz.notBad";
+  return "apps.ipod.musicQuiz.keepPracticing";
+}
+
+function SnippetProgressBar({ durationMs, running }: { durationMs: number; running: boolean }) {
+  return (
+    <div className="mt-1 w-full h-[6px] rounded-full border border-[#0a3667] overflow-hidden">
+      <AnimatePresence mode="wait">
+        <motion.div
+          key={running ? "run" : "stop"}
+          className="h-full bg-[#0a3667]"
+          initial={{ width: "0%" }}
+          animate={{ width: running ? "100%" : "0%" }}
+          transition={{ duration: running ? durationMs / 1000 : 0, ease: "linear" }}
+        />
+      </AnimatePresence>
+    </div>
+  );
+}

--- a/src/apps/ipod/components/MusicQuiz.tsx
+++ b/src/apps/ipod/components/MusicQuiz.tsx
@@ -38,6 +38,8 @@ export interface MusicQuizRef {
 export interface MusicQuizProps {
   isVisible: boolean;
   onExit: () => void;
+  lcdFilterOn?: boolean;
+  backlightOn?: boolean;
   /** Pause the main library player when entering, called once when visible turns true */
   onEnter?: () => void;
   /** Sound effects */
@@ -65,7 +67,16 @@ function pickRound(tracks: Track[]): { options: Track[]; correctIndex: number; c
 }
 
 export const MusicQuiz = forwardRef<MusicQuizRef, MusicQuizProps>(function MusicQuiz(
-  { isVisible, onExit: _onExit, onEnter, playClick, playScroll, vibrate },
+  {
+    isVisible,
+    onExit: _onExit,
+    lcdFilterOn = false,
+    backlightOn = true,
+    onEnter,
+    playClick,
+    playScroll,
+    vibrate,
+  },
   ref
 ) {
   const { t } = useTranslation();
@@ -311,10 +322,29 @@ export const MusicQuiz = forwardRef<MusicQuizRef, MusicQuizProps>(function Music
   const correctTrackUrl = round?.options[round.correctIndex]?.url;
 
   return (
-    <div className="absolute inset-0 z-30 flex flex-col bg-[#c5e0f5] bg-gradient-to-b from-[#d1e8fa] to-[#e0f0fc] overflow-hidden font-chicago">
-      {/* Header */}
-      <div className="border-b border-[#0a3667] py-0 px-2 text-[16px] flex items-center text-[#0a3667] [text-shadow:1px_1px_0_rgba(0,0,0,0.15)]">
-        <div className="w-12 text-left text-[12px]">
+    <div
+      className={cn(
+        "relative z-50 flex h-full min-h-[150px] w-full flex-col overflow-hidden select-none font-chicago",
+        "border border-black border-2 rounded-[2px]",
+        lcdFilterOn ? "lcd-screen" : "",
+        backlightOn
+          ? "bg-[#c5e0f5] bg-gradient-to-b from-[#d1e8fa] to-[#e0f0fc]"
+          : "bg-[#8a9da9] contrast-65 saturate-50",
+        lcdFilterOn &&
+          backlightOn &&
+          "shadow-[0_0_10px_2px_rgba(197,224,245,0.05)]"
+      )}
+    >
+      {lcdFilterOn && (
+        <div className="absolute inset-0 pointer-events-none z-[25] lcd-scan-lines" />
+      )}
+      {lcdFilterOn && (
+        <div className="absolute inset-0 pointer-events-none z-[25] lcd-reflection" />
+      )}
+
+      {/* Title bar — match IpodScreen */}
+      <div className="border-b border-[#0a3667] py-0 px-2 font-chicago text-[16px] flex items-center sticky top-0 z-10 text-[#0a3667] [text-shadow:1px_1px_0_rgba(0,0,0,0.15)]">
+        <div className="w-6 flex items-center justify-start text-xs tabular-nums">
           {phase !== "finished" && hasEnoughTracks && (
             <span>
               {Math.min(roundNumber, TOTAL_ROUNDS)}/{TOTAL_ROUNDS}
@@ -322,17 +352,13 @@ export const MusicQuiz = forwardRef<MusicQuizRef, MusicQuizProps>(function Music
           )}
         </div>
         <div className="flex-1 truncate text-center">{headerTitle}</div>
-        <div className="w-12 text-right text-[12px]">
-          {phase !== "finished" && hasEnoughTracks && (
-            <span>
-              {t("apps.ipod.musicQuiz.scoreShort", "Score")}: {score}
-            </span>
-          )}
+        <div className="w-6 flex items-center justify-end text-xs tabular-nums">
+          {phase !== "finished" && hasEnoughTracks && <span>{score}</span>}
         </div>
       </div>
 
       {/* Body */}
-      <div className="flex-1 relative overflow-hidden">
+      <div className="relative h-[calc(100%-26px)] overflow-hidden z-30">
         {!hasEnoughTracks ? (
           <div className="absolute inset-0 flex flex-col items-center justify-center px-3 text-center text-[#0a3667] [text-shadow:1px_1px_0_rgba(0,0,0,0.15)]">
             <p className="text-[14px]">
@@ -343,27 +369,27 @@ export const MusicQuiz = forwardRef<MusicQuizRef, MusicQuizProps>(function Music
             </p>
           </div>
         ) : phase === "finished" ? (
-          <div className="absolute inset-0 flex flex-col items-center justify-center px-3 text-center text-[#0a3667] [text-shadow:1px_1px_0_rgba(0,0,0,0.15)]">
-            <div className="text-[14px] mb-1">
-              {t("apps.ipod.musicQuiz.finalScore", "Final Score")}
-            </div>
-            <div className="text-[28px] leading-none mb-2">
+          <div className="absolute inset-0 flex flex-col items-center justify-center gap-1.5 px-3 text-center text-[#0a3667] [text-shadow:1px_1px_0_rgba(0,0,0,0.15)]">
+            <span className="font-chicago text-[16px] tabular-nums leading-4">
               {score}/{TOTAL_ROUNDS}
-            </div>
-            <div className="text-[12px] mb-3">
+            </span>
+            <span className="font-chicago text-[14px] leading-4">
               {t(scoreMessageKey(score, TOTAL_ROUNDS), {
                 defaultValue:
                   score === TOTAL_ROUNDS
-                    ? "Perfect score! 🏆"
+                    ? "Perfect score!"
                     : score / TOTAL_ROUNDS >= 0.6
-                    ? "Great job!"
-                    : score / TOTAL_ROUNDS >= 0.3
-                    ? "Not bad!"
-                    : "Keep listening!",
+                      ? "Great job!"
+                      : score / TOTAL_ROUNDS >= 0.3
+                        ? "Not bad!"
+                        : "Keep listening!",
               })}
-            </div>
-            <div className="text-[11px] opacity-80">
-              {t("apps.ipod.musicQuiz.pressCenterToReplay", "Press center to play again · Menu to exit")}
+            </span>
+            <div className="flex flex-col font-chicago text-[14px] leading-4 opacity-85">
+              <span>
+                {t("apps.ipod.musicQuiz.pressCenterToReplay", "Press center to play again")}
+              </span>
+              <span>{t("apps.ipod.musicQuiz.menuToExit", "Menu to exit")}</span>
             </div>
           </div>
         ) : phase === "loading" ? (
@@ -374,22 +400,25 @@ export const MusicQuiz = forwardRef<MusicQuizRef, MusicQuizProps>(function Music
           </div>
         ) : (
           <div className="absolute inset-0 flex flex-col">
-            {/* Prompt + snippet progress */}
-            <div className="px-2 pt-1 pb-1 text-center text-[#0a3667] [text-shadow:1px_1px_0_rgba(0,0,0,0.15)]">
-              <div className="text-[12px]">
-                {phase === "feedback"
-                  ? round?.isCorrect
-                    ? t("apps.ipod.musicQuiz.correct", "Correct!")
-                    : round?.selectedIndex == null
-                    ? t("apps.ipod.musicQuiz.timesUp", "Time's up!")
-                    : t("apps.ipod.musicQuiz.wrong", "Not quite!")
-                  : t("apps.ipod.musicQuiz.guessTheSong", "Guess the song")}
+            {/* Snippet progress or feedback — fixed slot height */}
+            <div className="px-2 py-px text-[#0a3667] [text-shadow:1px_1px_0_rgba(0,0,0,0.15)]">
+              <div className="flex h-5 w-full items-center justify-center">
+                {phase === "feedback" ? (
+                  <div className="w-full truncate text-center font-chicago text-[16px] leading-4">
+                    {round?.isCorrect
+                      ? t("apps.ipod.musicQuiz.correct", "Correct!")
+                      : round?.selectedIndex == null
+                        ? t("apps.ipod.musicQuiz.timesUp", "Time's up!")
+                        : t("apps.ipod.musicQuiz.wrong", "Not quite!")}
+                  </div>
+                ) : (
+                  <SnippetProgressBar
+                    key={`${roundNumber}-playing`}
+                    durationMs={SNIPPET_DURATION_MS}
+                    running={phase === "playing"}
+                  />
+                )}
               </div>
-              <SnippetProgressBar
-                key={`${roundNumber}-${phase}`}
-                durationMs={SNIPPET_DURATION_MS}
-                running={phase === "playing"}
-              />
             </div>
 
             {/* Options */}
@@ -414,7 +443,7 @@ export const MusicQuiz = forwardRef<MusicQuizRef, MusicQuizProps>(function Music
                     <MenuListItem
                       text={formatOption(option)}
                       isSelected={isSelected}
-                      backlightOn={true}
+                      backlightOn={backlightOn}
                       onClick={() => {
                         if (phase === "playing") {
                           setSelectedIndex(idx);
@@ -493,7 +522,7 @@ function scoreMessageKey(score: number, total: number): string {
 
 function SnippetProgressBar({ durationMs, running }: { durationMs: number; running: boolean }) {
   return (
-    <div className="mt-1 w-full h-[6px] rounded-full border border-[#0a3667] overflow-hidden">
+    <div className="h-[6px] w-full shrink-0 rounded-full border border-[#0a3667] overflow-hidden">
       <AnimatePresence mode="wait">
         <motion.div
           key={running ? "run" : "stop"}

--- a/src/apps/ipod/hooks/useIpodLogic.ts
+++ b/src/apps/ipod/hooks/useIpodLogic.ts
@@ -41,6 +41,7 @@ import {
 import type { WheelArea, RotationDirection } from "../types";
 import type { IpodInitialData } from "../../base/types";
 import type { CoverFlowRef } from "../components/CoverFlow";
+import type { MusicQuizRef } from "../components/MusicQuiz";
 import type { SongSearchResult } from "@/components/dialogs/SongSearchDialog";
 import { helpItems } from "..";
 
@@ -221,6 +222,10 @@ export function useIpodLogic({
   // Cover Flow state
   const [isCoverFlowOpen, setIsCoverFlowOpen] = useState(false);
 
+  // Music Quiz state
+  const [isMusicQuizOpen, setIsMusicQuizOpen] = useState(false);
+  const wasPlayingBeforeQuizRef = useRef(false);
+
   // Playback state
   const [elapsedTime, setElapsedTime] = useState(0);
   const [totalTime, setTotalTime] = useState(0);
@@ -229,6 +234,7 @@ export function useIpodLogic({
   const lastTrackedSongRef = useRef<{ trackId: string; elapsedTime: number } | null>(null);
   const skipOperationRef = useRef(false);
   const coverFlowRef = useRef<CoverFlowRef | null>(null);
+  const musicQuizRef = useRef<MusicQuizRef | null>(null);
   
   // Screen long press for CoverFlow toggle
   const screenLongPressTimerRef = useRef<NodeJS.Timeout | null>(null);
@@ -653,7 +659,41 @@ export function useIpodLogic({
         action: () => {
           registerActivity();
           if (useIpodStore.getState().showVideo) toggleVideo();
-          setIsSongSearchDialogOpen(true);
+          setMenuDirection("forward");
+          const extrasLabel = t("apps.ipod.menuItems.extras");
+          const extrasItems = [
+            {
+              label: t("apps.ipod.menuItems.musicQuiz", "Music Quiz"),
+              action: () => {
+                registerActivity();
+                if (isOffline) {
+                  showOfflineStatus();
+                  return;
+                }
+                // Save what was playing so we can restore the paused state on exit
+                wasPlayingBeforeQuizRef.current = useIpodStore.getState().isPlaying;
+                if (wasPlayingBeforeQuizRef.current) {
+                  setIsPlaying(false);
+                }
+                if (useIpodStore.getState().showVideo) toggleVideo();
+                setIsMusicQuizOpen(true);
+              },
+              showChevron: true,
+            },
+            {
+              label: t("apps.ipod.menu.searchSongs", "Search Songs..."),
+              action: () => {
+                registerActivity();
+                setIsSongSearchDialogOpen(true);
+              },
+              showChevron: false,
+            },
+          ];
+          setMenuHistory((prev) => [
+            ...prev,
+            { title: extrasLabel, items: extrasItems, selectedIndex: 0 },
+          ]);
+          setSelectedMenuItem(0);
         },
         showChevron: true,
       },
@@ -697,7 +737,7 @@ export function useIpodLogic({
         showChevron: true,
       },
     ];
-  }, [registerActivity, toggleVideo, musicMenuItems, settingsMenuItems, memoizedToggleShuffle, memoizedToggleBacklight, t]);
+  }, [registerActivity, toggleVideo, musicMenuItems, settingsMenuItems, memoizedToggleShuffle, memoizedToggleBacklight, t, isOffline, showOfflineStatus, setIsPlaying]);
 
   // Initialize menu history
   useEffect(() => {
@@ -716,6 +756,9 @@ export function useIpodLogic({
       return musicMenuItems;
     } else if (menu.title === t("apps.ipod.menuItems.settings")) {
       return settingsMenuItems;
+    } else if (menu.title === t("apps.ipod.menuItems.extras")) {
+      // Extras submenu has stable items; keep existing references to avoid stale closures.
+      return menu.items;
     } else if (menu.title === t("apps.ipod.menuItems.allSongs")) {
       // Rebuild "All Songs" submenu from current tracks
       return tracks.map((track, trackIndex) => ({
@@ -1096,6 +1139,12 @@ export function useIpodLogic({
       return;
     }
 
+    // Exit Music Quiz if open
+    if (isMusicQuizOpen) {
+      setIsMusicQuizOpen(false);
+      return;
+    }
+
     if (showVideo) toggleVideo();
 
     if (menuMode) {
@@ -1167,7 +1216,7 @@ export function useIpodLogic({
       }
       setMenuMode(true);
     }
-  }, [playClickSound, vibrate, registerActivity, isCoverFlowOpen, showVideo, toggleVideo, menuMode, menuHistory, mainMenuItems, musicMenuItems, tracks, currentIndex, cameFromNowPlayingMenuItem, isOffline, showOfflineStatus, setCurrentSongId, setIsPlaying, t]);
+  }, [playClickSound, vibrate, registerActivity, isCoverFlowOpen, isMusicQuizOpen, showVideo, toggleVideo, menuMode, menuHistory, mainMenuItems, musicMenuItems, tracks, currentIndex, cameFromNowPlayingMenuItem, isOffline, showOfflineStatus, setCurrentSongId, setIsPlaying, t]);
 
   // Cover Flow handlers
   const handleCenterLongPress = useCallback(() => {
@@ -1242,6 +1291,10 @@ export function useIpodLogic({
           handleMenuButton();
           break;
         case "right":
+          if (isMusicQuizOpen && musicQuizRef.current) {
+            musicQuizRef.current.navigate("next");
+            return;
+          }
           if (isOffline) {
             showOfflineStatus();
           } else {
@@ -1252,6 +1305,11 @@ export function useIpodLogic({
           }
           break;
         case "bottom":
+          if (isMusicQuizOpen && musicQuizRef.current) {
+            // Replay current snippet
+            musicQuizRef.current.replaySnippet();
+            return;
+          }
           if (isOffline) {
             showOfflineStatus();
           } else {
@@ -1260,6 +1318,10 @@ export function useIpodLogic({
           }
           break;
         case "left":
+          if (isMusicQuizOpen && musicQuizRef.current) {
+            musicQuizRef.current.navigate("previous");
+            return;
+          }
           if (isOffline) {
             showOfflineStatus();
           } else {
@@ -1270,6 +1332,11 @@ export function useIpodLogic({
           }
           break;
         case "center":
+          // Handle Music Quiz selection
+          if (isMusicQuizOpen && musicQuizRef.current) {
+            musicQuizRef.current.selectCurrent();
+            return;
+          }
           // Handle Cover Flow selection
           if (isCoverFlowOpen && coverFlowRef.current) {
             coverFlowRef.current.selectCurrent();
@@ -1301,7 +1368,7 @@ export function useIpodLogic({
           break;
       }
     },
-    [playClickSound, vibrate, registerActivity, nextTrack, showStatus, togglePlay, previousTrack, menuMode, menuHistory, selectedMenuItem, tracks, currentIndex, isPlaying, toggleVideo, handleMenuButton, isOffline, showOfflineStatus, startTrackSwitch, isCoverFlowOpen]
+    [playClickSound, vibrate, registerActivity, nextTrack, showStatus, togglePlay, previousTrack, menuMode, menuHistory, selectedMenuItem, tracks, currentIndex, isPlaying, toggleVideo, handleMenuButton, isOffline, showOfflineStatus, startTrackSwitch, isCoverFlowOpen, isMusicQuizOpen]
   );
 
   // Wheel rotation handler
@@ -1309,6 +1376,14 @@ export function useIpodLogic({
     (direction: RotationDirection) => {
       playScrollSound();
       registerActivity();
+
+      // Handle Music Quiz navigation
+      if (isMusicQuizOpen && musicQuizRef.current) {
+        const handled = musicQuizRef.current.navigate(
+          direction === "clockwise" ? "next" : "previous"
+        );
+        if (handled) return;
+      }
 
       // Handle Cover Flow navigation
       if (isCoverFlowOpen && coverFlowRef.current) {
@@ -1351,7 +1426,7 @@ export function useIpodLogic({
         );
       }
     },
-    [playScrollSound, registerActivity, menuMode, menuHistory, isFullScreen, showStatus, isCoverFlowOpen]
+    [playScrollSound, registerActivity, menuMode, menuHistory, isFullScreen, showStatus, isCoverFlowOpen, isMusicQuizOpen]
   );
 
   // Scaling
@@ -1825,6 +1900,11 @@ export function useIpodLogic({
     coverFlowRef,
     containerRef,
 
+    // Sound effects (exposed for quiz / extras)
+    playClickSound,
+    playScrollSound,
+    vibrate,
+
     // State
     statusMessage,
     elapsedTime,
@@ -1836,6 +1916,9 @@ export function useIpodLogic({
     menuHistory,
     cameFromNowPlayingMenuItem,
     isCoverFlowOpen,
+    isMusicQuizOpen,
+    setIsMusicQuizOpen,
+    musicQuizRef,
     isAddingSong,
     activityState,
     skipOperationRef,

--- a/src/lib/locales/en/translation.json
+++ b/src/lib/locales/en/translation.json
@@ -1935,11 +1935,12 @@
         "timesUp": "Time's up!",
         "scoreShort": "Score",
         "finalScore": "Final Score",
-        "perfect": "Perfect score! 🏆",
+        "perfect": "Perfect score!",
         "greatJob": "Great job!",
         "notBad": "Not bad!",
         "keepPracticing": "Keep listening!",
-        "pressCenterToReplay": "Press center to play again · Menu to exit",
+        "pressCenterToReplay": "Press center to play again",
+        "menuToExit": "Menu to exit",
         "notEnoughTracks": "Add more songs to play the quiz"
       },
       "translationLanguages": {

--- a/src/lib/locales/en/translation.json
+++ b/src/lib/locales/en/translation.json
@@ -1911,6 +1911,7 @@
         "music": "Music",
         "settings": "Settings",
         "extras": "Extras",
+        "musicQuiz": "Music Quiz",
         "shuffleSongs": "Shuffle Songs",
         "nowPlaying": "Now Playing",
         "ipod": "iPod",
@@ -1923,6 +1924,23 @@
         "one": "One",
         "all": "All",
         "allSongs": "All Songs"
+      },
+      "musicQuiz": {
+        "title": "Music Quiz",
+        "results": "Results",
+        "guessTheSong": "Guess the song",
+        "loading": "Loading snippet…",
+        "correct": "Correct!",
+        "wrong": "Not quite!",
+        "timesUp": "Time's up!",
+        "scoreShort": "Score",
+        "finalScore": "Final Score",
+        "perfect": "Perfect score! 🏆",
+        "greatJob": "Great job!",
+        "notBad": "Not bad!",
+        "keepPracticing": "Keep listening!",
+        "pressCenterToReplay": "Press center to play again · Menu to exit",
+        "notEnoughTracks": "Add more songs to play the quiz"
       },
       "translationLanguages": {
         "auto": "Auto",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a "Music Quiz" game to the iPod app, reachable from the iPod menu under **Extras → Music Quiz**. The quiz plays a ~10 second snippet from a random start point of a randomly chosen library track and lets the user pick from 4 options (1 correct + up to 3 wrong choices), all rendered in the iPod menu style.

## Behavior

- Entered from `iPod ▸ Extras ▸ Music Quiz` (Extras is now a real submenu with both `Music Quiz` and `Search Songs...`).
- Pauses the main library player on entry; the quiz uses its own hidden ReactPlayer for the snippet (audio-only).
- Each round picks 4 random tracks from the library and one of them as the correct answer. The snippet starts from a random offset in the song (avoiding intros/outros), with bounds clamped to the actual track duration once it loads.
- 5 rounds total; the snippet auto-stops after 10s (auto-marked wrong if no answer).
- Feedback (✓ / ✗) shows for 1.8s before the next round.
- Final screen shows the score and lets the user replay.

## Wheel mapping inside the quiz

- Spin wheel / Left / Right: navigate options (or no-op on the results screen).
- Center: confirm selection / advance through feedback / replay from the results screen.
- Play/Pause (bottom): replay the snippet from the same start position.
- Menu (top): exit back to the iPod menu.
- Tapping an option directly also selects it.

## Edge cases handled

- Offline state at entry shows the iPod offline status and skips quiz entry.
- Library with fewer than 2 tracks shows an "Add more songs to play" message.
- Snippet start is recomputed once the player reports its real duration to avoid seeking past the end of short clips.

## Files

- `src/apps/ipod/components/MusicQuiz.tsx` — new component (state machine, options UI, hidden snippet player).
- `src/apps/ipod/hooks/useIpodLogic.ts` — Extras becomes a submenu; quiz state, ref, and wheel routing wired in.
- `src/apps/ipod/components/IpodAppComponent.tsx` — renders the quiz overlay inside the iPod screen bounds.
- `src/lib/locales/en/translation.json` — new `apps.ipod.musicQuiz.*` strings.

## Testing

- ✅ `bun run build` — clean build.
- Manual GUI testing in browser (screenshots/video below).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-27332d80-5b25-463b-8d41-8b213ed169dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-27332d80-5b25-463b-8d41-8b213ed169dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

