### PR TITLE
Maps: merge Home/Work into Favorites section in places drawer

### DIFF
--- a/src/apps/maps/components/MapsPlacesDrawer.tsx
+++ b/src/apps/maps/components/MapsPlacesDrawer.tsx
@@ -47,11 +47,22 @@ interface PlaceRowProps {
   onClick: () => void;
   /** Override the auto-derived POI visual (e.g. for Home / Work rows). */
   visualOverride?: PoiVisual;
+  /** Override the displayed title (e.g. "Home" / "Work"). */
+  titleOverride?: string;
 }
 
-function PlaceRow({ place, onClick, visualOverride }: PlaceRowProps) {
+function PlaceRow({
+  place,
+  onClick,
+  visualOverride,
+  titleOverride,
+}: PlaceRowProps) {
   const visual = visualOverride ?? getPoiVisual(place.category);
   const Icon = visual.Icon;
+  const title = titleOverride ?? place.name;
+  const subtitle = titleOverride
+    ? place.subtitle || place.name
+    : place.subtitle;
   return (
     <button
       type="button"
@@ -69,10 +80,10 @@ function PlaceRow({ place, onClick, visualOverride }: PlaceRowProps) {
         <Icon size={14} weight="fill" />
       </div>
       <div className="min-w-0 flex-1">
-        <div className="truncate font-medium text-black">{place.name}</div>
-        {place.subtitle && (
+        <div className="truncate font-medium text-black">{title}</div>
+        {subtitle && (
           <div className="truncate text-[11px] text-black/55">
-            {place.subtitle}
+            {subtitle}
           </div>
         )}
       </div>
@@ -126,37 +137,33 @@ export function MapsPlacesDrawer({
           />
         )}
 
-        {home && (
-          <Section
-            title={t("apps.maps.places.home", { defaultValue: "Home" })}
-          >
-            <PlaceRow
-              place={home}
-              onClick={() => handleSelect(home)}
-              visualOverride={HOME_VISUAL}
-            />
-          </Section>
-        )}
-
-        {work && (
-          <Section
-            title={t("apps.maps.places.work", { defaultValue: "Work" })}
-          >
-            <PlaceRow
-              place={work}
-              onClick={() => handleSelect(work)}
-              visualOverride={WORK_VISUAL}
-            />
-          </Section>
-        )}
-
-        {favorites.length > 0 && (
+        {(home || work || favorites.length > 0) && (
           <Section
             title={t("apps.maps.places.favorites", {
               defaultValue: "Favorites",
             })}
           >
             <div className="space-y-0.5">
+              {home && (
+                <PlaceRow
+                  place={home}
+                  onClick={() => handleSelect(home)}
+                  visualOverride={HOME_VISUAL}
+                  titleOverride={t("apps.maps.places.home", {
+                    defaultValue: "Home",
+                  })}
+                />
+              )}
+              {work && (
+                <PlaceRow
+                  place={work}
+                  onClick={() => handleSelect(work)}
+                  visualOverride={WORK_VISUAL}
+                  titleOverride={t("apps.maps.places.work", {
+                    defaultValue: "Work",
+                  })}
+                />
+              )}
               {favorites.map((place) => (
                 <PlaceRow
                   key={place.id}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
In the Maps places drawer, Home and Work used to render as their own sections at the top. They now appear as the first two rows under the existing **Favorites** section.

Each row uses the localized "Home" / "Work" label as the primary title and keeps the actual saved place name/address on the secondary line, so users still see which address is configured.

### Changes
- `src/apps/maps/components/MapsPlacesDrawer.tsx`
  - Combined the previous `Home`, `Work`, and `Favorites` sections into a single `Favorites` section.
  - `PlaceRow` now accepts an optional `titleOverride`; when provided it pushes the original `name` (or existing subtitle) down to the secondary line.
  - Reuses existing `apps.maps.places.home` / `apps.maps.places.work` i18n keys (already present in all locales — no new strings added).

### Testing
- `bun run build` — succeeds.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-be6eddf2-555f-4e0c-9ebe-a1608fa9e61f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-be6eddf2-555f-4e0c-9ebe-a1608fa9e61f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

