### PR TITLE
fix(maps): drop region param from mapsSearchPlaces to avoid Apple conflict

### DIFF
--- a/api/_utils/_aiPrompts.ts
+++ b/api/_utils/_aiPrompts.ts
@@ -397,6 +397,7 @@ Use \`tvControl\` to manage the TV app's channel lineup and tune in to channels.
 Use \`mapsSearchPlaces\` whenever the user asks to find a place, look up an address, browse nearby POIs, or otherwise wants real geographic data (restaurants, cafes, addresses, landmarks, businesses, neighborhoods).
 - Pass the user's intent verbatim as \`query\` (e.g. \`"best ramen near Shibuya"\`, \`"350 Sutter St San Francisco"\`).
 - The server **automatically biases the search to the user's approximate IP location** (from request \`requestGeo\`) when you don't pass \`near\`, so unqualified queries like "coffee" already return nearby hits. Only pass \`near: { latitude, longitude }\` when you have a *better* anchor than IP geolocation — e.g. the user named a different city, you're searching around an address they just mentioned, or the user shared their precise coordinates.
+- The tool only accepts a point anchor (\`near\`); there is no bounding-region parameter — keep all location intent in the \`query\` string when you don't have a coordinate.
 - Default \`limit\` is 5; bump up to 10 only when the user clearly wants a long list. Apple's daily quota is shared with MapKit JS.
 - The client renders a rich place card with the POI icon, title, and address — tapping it opens the place plotted in the ryOS Maps app. Don't paste raw lat/lng into your chat reply; let the card do the work and just refer to results by name + city.
 

--- a/api/_utils/_mapkit-server.ts
+++ b/api/_utils/_mapkit-server.ts
@@ -182,10 +182,13 @@ export async function searchPlaces(
   const url = new URL(`${MAPS_API_HOST}/v1/search`);
   url.searchParams.set("q", options.q);
 
+  // Apple's /v1/search rejects requests containing BOTH `searchLocation` and
+  // `searchRegion` ("cannot specify both searchRegion and searchLocation").
+  // Prefer `searchLocation` when callers accidentally provide both — it's the
+  // stronger ranking signal and matches `userLocation`.
   if (options.searchLocation) {
     url.searchParams.set("searchLocation", formatCoord(options.searchLocation));
-  }
-  if (options.searchRegion) {
+  } else if (options.searchRegion) {
     url.searchParams.set("searchRegion", formatRegion(options.searchRegion));
   }
   if (options.userLocation) {

--- a/api/chat/tools/index.ts
+++ b/api/chat/tools/index.ts
@@ -244,8 +244,8 @@ export const TOOL_DESCRIPTIONS = {
     "When you don't pass 'near', the server automatically biases the search to the user's approximate IP location, " +
     "so unqualified queries like 'coffee' or 'pharmacy' already return nearby hits. Only override with an explicit " +
     "'near: { latitude, longitude }' when you have a better anchor than IP geolocation (a different city the user named, " +
-    "an address they just mentioned, etc.). When you reference a result in chat, mention it by name + city — the client " +
-    "renders the rich card automatically.",
+    "an address they just mentioned, etc.). The tool only accepts a point anchor — there is no separate region/bounding-box " +
+    "parameter. When you reference a result in chat, mention it by name + city — the client renders the rich card automatically.",
 
   webFetch:
     "Fetch and read the text content of a web page. Use this when the user asks you to look something up online, " +

--- a/api/chat/tools/maps-executor.ts
+++ b/api/chat/tools/maps-executor.ts
@@ -157,7 +157,6 @@ export async function executeMapsSearchPlaces(
       ...(effectiveNear
         ? { searchLocation: effectiveNear, userLocation: effectiveNear }
         : {}),
-      ...(input.region ? { searchRegion: input.region } : {}),
       ...(input.countries && input.countries.length > 0
         ? { limitToCountries: input.countries.map((c) => c.toUpperCase()) }
         : {}),

--- a/api/chat/tools/schemas.ts
+++ b/api/chat/tools/schemas.ts
@@ -948,6 +948,11 @@ export const documentsControlSchema = z
 // Maps Search Places Schema
 // ============================================================================
 
+// Apple Maps Server API rejects requests that include both a point bias
+// (`searchLocation`) and a region bias (`searchRegion`) at the same time. To
+// avoid the surface area for that conflict, the public tool only accepts a
+// point anchor (`near`). The server still falls back to the request's
+// IP-derived coordinates when `near` is omitted.
 const mapsCoordinateSchema = z.object({
   latitude: z
     .number()
@@ -961,13 +966,6 @@ const mapsCoordinateSchema = z.object({
     .describe("Longitude in decimal degrees, between -180 and 180."),
 });
 
-const mapsRegionSchema = z.object({
-  northLatitude: z.number().min(-90).max(90),
-  eastLongitude: z.number().min(-180).max(180),
-  southLatitude: z.number().min(-90).max(90),
-  westLongitude: z.number().min(-180).max(180),
-});
-
 export const mapsSearchPlacesSchema = z.object({
   query: z
     .string()
@@ -979,12 +977,7 @@ export const mapsSearchPlacesSchema = z.object({
   near: mapsCoordinateSchema
     .optional()
     .describe(
-      "Optional approximate center used to bias the search. Pass the user's location or the visible map center when known."
-    ),
-  region: mapsRegionSchema
-    .optional()
-    .describe(
-      "Optional bounding region (NE + SW corners) used to constrain or bias results. Prefer 'near' for simple proximity ranking."
+      "Optional approximate center used to bias the search. Pass the user's location or the visible map center when known. When omitted, the server falls back to the request's IP-derived coordinates."
     ),
   countries: z
     .array(z.string().regex(/^[A-Za-z]{2}$/, { message: "Use ISO 3166-1 alpha-2 country codes" }))

--- a/api/chat/tools/types.ts
+++ b/api/chat/tools/types.ts
@@ -658,17 +658,15 @@ export interface MemoryDeleteOutput {
 export interface MapsSearchPlacesInput {
   /** Free-form search query (e.g. "best ramen near Shibuya"). */
   query: string;
-  /** Optional approximate center used to bias results. */
+  /**
+   * Optional approximate center used to bias results. Apple's Maps Server API
+   * does not allow combining a point bias with a bounding region, so the tool
+   * exposes only the point variant and falls back to the request's IP-derived
+   * coordinates when this is omitted.
+   */
   near?: {
     latitude: number;
     longitude: number;
-  };
-  /** Optional bounding region used to constrain / bias results. */
-  region?: {
-    northLatitude: number;
-    eastLongitude: number;
-    southLatitude: number;
-    westLongitude: number;
   };
   /** Optional ISO 3166-1 alpha-2 country codes to constrain results. */
   countries?: string[];

--- a/tests/test-maps-search-tool.test.ts
+++ b/tests/test-maps-search-tool.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test } from "bun:test";
+import { mapsSearchPlacesSchema } from "../api/chat/tools/schemas.js";
+
+/**
+ * Regression coverage for the Apple Maps Server API conflict that surfaced as
+ * "cannot specify both searchRegion and searchLocation". The chat tool used
+ * to expose both `near` (→ searchLocation) and `region` (→ searchRegion);
+ * we simplified it to only accept `near` so the model can't accidentally
+ * trigger that 400.
+ */
+describe("mapsSearchPlacesSchema", () => {
+  test("accepts query-only input and applies the default limit", () => {
+    const parsed = mapsSearchPlacesSchema.safeParse({ query: "coffee" });
+    expect(parsed.success).toBe(true);
+    if (parsed.success) {
+      expect(parsed.data.query).toBe("coffee");
+      expect(parsed.data.limit).toBe(5);
+      expect("region" in parsed.data).toBe(false);
+    }
+  });
+
+  test("preserves a point anchor passed as `near`", () => {
+    const parsed = mapsSearchPlacesSchema.safeParse({
+      query: "ramen",
+      near: { latitude: 35.6595, longitude: 139.7005 },
+    });
+    expect(parsed.success).toBe(true);
+    if (parsed.success) {
+      expect(parsed.data.near).toEqual({
+        latitude: 35.6595,
+        longitude: 139.7005,
+      });
+    }
+  });
+
+  test("silently strips a `region` payload from older callers", () => {
+    const parsed = mapsSearchPlacesSchema.safeParse({
+      query: "coffee",
+      region: {
+        northLatitude: 40,
+        eastLongitude: -120,
+        southLatitude: 35,
+        westLongitude: -125,
+      },
+    });
+    expect(parsed.success).toBe(true);
+    if (parsed.success) {
+      // `region` must not survive — otherwise the executor could combine it
+      // with the IP-fallback `searchLocation` and Apple would reject the call.
+      expect("region" in parsed.data).toBe(false);
+      expect(parsed.data.query).toBe("coffee");
+    }
+  });
+
+  test("rejects out-of-range coordinates so we don't waste an Apple call", () => {
+    const parsed = mapsSearchPlacesSchema.safeParse({
+      query: "coffee",
+      near: { latitude: 200, longitude: -122 },
+    });
+    expect(parsed.success).toBe(false);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The `mapsSearchPlaces` tool was failing in the client with:

> cannot specify both searchRegion and searchLocation

Apple's Maps Server API treats `searchLocation` and `searchRegion` as **mutually exclusive**. The chat tool exposed both:

- `near` → `searchLocation`
- `region` → `searchRegion`

…and the model would frequently combine them (often passing `region` *and* triggering the IP-derived `near` fallback), so `/v1/search` would 4xx and the client would render no results.

## Fix

Simplify the surface area to **only `near`**, since:

1. `near` is the stronger ranking signal,
2. It already matches the IP-derived fallback (`requestGeo`),
3. Removing `region` makes the conflict unrepresentable.

### Changes

- **`api/chat/tools/schemas.ts`** — drop `region` (and `mapsRegionSchema`) from the public Zod schema. Zod's default behavior silently strips unknown keys, so any older model output that still includes `region` validates cleanly with the field discarded.
- **`api/chat/tools/types.ts`** — remove `region` from `MapsSearchPlacesInput`.
- **`api/chat/tools/maps-executor.ts`** — stop forwarding `input.region` to `searchPlaces`.
- **`api/chat/tools/index.ts`** — clarify the tool description (point anchor only).
- **`api/_utils/_aiPrompts.ts`** — update the prompt to explicitly tell the model there is no bounding-region parameter.
- **`api/_utils/_mapkit-server.ts`** — belt-and-suspenders: at the lowest layer, prefer `searchLocation` over `searchRegion` if both are ever supplied, so we never hit Apple's conflict error again.
- **`tests/test-maps-search-tool.test.ts`** — new regression test for the schema (accepts query / `near`, strips legacy `region`, rejects bad coords).

## Testing

- ✅ `bun test tests/test-maps-search-tool.test.ts` — 4/4 pass
- ✅ `bun test tests/test-chat-tools-songs.test.ts tests/test-chat-tools-contacts.test.ts` — 10/10 pass (sibling chat-tools regressions stay green)
- ✅ `bun run build` — TypeScript + Vite build succeeds

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ceee4dd5-483e-4930-ba45-895b9a717c0c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ceee4dd5-483e-4930-ba45-895b9a717c0c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

