### PR TITLE
i18n: desktop toasts, link preview strings, and synced locales

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -124,12 +124,12 @@ export function App() {
         // Mark as seen immediately so dismissing the toast won't show it again
         setLastSeenDesktopVersion(result.version);
         // New version available - show update toast (both web and Tauri)
-        toast(`ryOS ${result.version} for Mac is available`, {
+        toast(t("common.desktop.updateToast", { version: result.version }), {
           id: 'desktop-update',
           icon: <DownloadSimple className="h-4 w-4" weight="bold" />,
           duration: Infinity,
           action: {
-            label: "Download",
+            label: t("common.desktop.downloadAction"),
             onClick: () => {
               window.open(
                 `https://github.com/ryokun6/ryos/releases/download/v${result.version}/ryOS_${result.version}_aarch64.dmg`,
@@ -142,12 +142,12 @@ export function App() {
         // Mark as seen immediately so dismissing the toast won't show it again
         setLastSeenDesktopVersion(result.version);
         // First time user on web - show initial download toast (not in Tauri)
-        toast("ryOS is available as a Mac app", {
+        toast(t("common.desktop.firstRunToast"), {
           id: 'desktop-update',
           icon: <DownloadSimple className="h-4 w-4" weight="bold" />,
           duration: Infinity,
           action: {
-            label: "Download",
+            label: t("common.desktop.downloadAction"),
             onClick: () => {
               window.open(
                 `https://github.com/ryokun6/ryos/releases/download/v${result.version}/ryOS_${result.version}_aarch64.dmg`,
@@ -172,7 +172,7 @@ export function App() {
     }, 2000);
 
     return () => clearTimeout(timer);
-  }, [setLastSeenDesktopVersion]);
+  }, [setLastSeenDesktopVersion, t]);
 
   if (showBootScreen) {
     return (

--- a/src/components/layout/StartMenu.tsx
+++ b/src/components/layout/StartMenu.tsx
@@ -190,7 +190,7 @@ export function StartMenu({ apps }: StartMenuProps) {
                 >
                   <ThemedIcon
                     name="info.png"
-                    alt="About"
+                    alt={t("common.dialog.about")}
                     className="w-6 h-6 [image-rendering:pixelated]"
                   />
                   {t("common.startMenu.aboutThisComputer")}

--- a/src/components/listen/ListenSessionInvite.tsx
+++ b/src/components/listen/ListenSessionInvite.tsx
@@ -165,7 +165,11 @@ export function ListenSessionInvite({
           >
             <div className="title-bar-text">{t("apps.karaoke.liveListen.inviteToListen")}</div>
             <div className="title-bar-controls">
-              <button aria-label="Close" data-action="close" onClick={onClose} />
+              <button
+                aria-label={t("common.menu.close")}
+                data-action="close"
+                onClick={onClose}
+              />
             </div>
           </div>
           <div className="window-body">{dialogContent}</div>

--- a/src/components/shared/AppDrawer.tsx
+++ b/src/components/shared/AppDrawer.tsx
@@ -19,6 +19,7 @@
 import { type ReactNode } from "react";
 import { motion, type Transition } from "framer-motion";
 import { X } from "@phosphor-icons/react";
+import { useTranslation } from "react-i18next";
 import { cn } from "@/lib/utils";
 import { useThemeStore } from "@/stores/useThemeStore";
 import { useMediaQuery } from "@/hooks/useMediaQuery";
@@ -80,6 +81,7 @@ export function AppDrawer({
   className,
   ...dataAttrs
 }: AppDrawerProps) {
+  const { t } = useTranslation();
   const currentTheme = useThemeStore((s) => s.current);
   const isMacOSTheme = currentTheme === "macosx";
   const isSystem7 = currentTheme === "system7";
@@ -170,7 +172,12 @@ export function AppDrawer({
               <div className={headerClass} style={headerStyle}>
                 {title && <span className={titleClass}>{title}</span>}
                 {onClose && (
-                  <button type="button" onClick={onClose} className={closeBtnClass} aria-label="Close">
+                  <button
+                    type="button"
+                    onClick={onClose}
+                    className={closeBtnClass}
+                    aria-label={t("common.menu.close")}
+                  >
                     <X size={11} weight="bold" />
                   </button>
                 )}
@@ -189,7 +196,12 @@ export function AppDrawer({
           <div className={headerClass}>
             {title && <span className={titleClass}>{title}</span>}
             {onClose && (
-              <button type="button" onClick={onClose} className={closeBtnClass} aria-label="Close">
+              <button
+                type="button"
+                onClick={onClose}
+                className={closeBtnClass}
+                aria-label={t("common.menu.close")}
+              >
                 <X size={11} weight="bold" />
               </button>
             )}

--- a/src/components/shared/LinkPreview.tsx
+++ b/src/components/shared/LinkPreview.tsx
@@ -119,11 +119,11 @@ export function LinkPreview({ url, className = "" }: LinkPreviewProps) {
       if (videoId) {
         launchApp("ipod", { initialData: { videoId } });
       } else {
-        toast.error("Could not extract video ID from this YouTube URL");
+        toast.error(t("components.linkPreview.couldNotExtractYouTubeVideoId"));
         console.warn("Could not extract video ID from YouTube URL:", url);
       }
     } catch (error) {
-      toast.error("Failed to open video in iPod app");
+      toast.error(t("components.linkPreview.failedToOpenIpodVideo"));
       console.error("Error launching iPod app:", error);
     }
   };
@@ -136,11 +136,11 @@ export function LinkPreview({ url, className = "" }: LinkPreviewProps) {
       if (videoId) {
         launchApp("karaoke", { initialData: { videoId } });
       } else {
-        toast.error("Could not extract video ID from this URL");
+        toast.error(t("components.linkPreview.couldNotExtractVideoId"));
         console.warn("Could not extract video ID from URL:", url);
       }
     } catch (error) {
-      toast.error("Failed to open video in Karaoke app");
+      toast.error(t("components.linkPreview.failedToOpenKaraokeVideo"));
       console.error("Error launching Karaoke app:", error);
     }
   };
@@ -202,7 +202,7 @@ export function LinkPreview({ url, className = "" }: LinkPreviewProps) {
                   image:
                     youtubeData.image ||
                     `https://img.youtube.com/vi/${videoId}/maxresdefault.jpg`,
-                  siteName: "YouTube",
+                  siteName: t("components.linkPreview.youtubeSiteName"),
                   url: url,
                 });
                 return;
@@ -223,10 +223,10 @@ export function LinkPreview({ url, className = "" }: LinkPreviewProps) {
             // Fallback to basic YouTube-style metadata
             if (!isActive || abortController.signal.aborted) return;
             setMetadata({
-              title: `YouTube Video ${videoId}`,
-              description: "Watch on YouTube",
+              title: t("components.linkPreview.fallbackVideoTitle", { videoId }),
+              description: t("components.linkPreview.watchOnYouTube"),
               image: `https://img.youtube.com/vi/${videoId}/maxresdefault.jpg`,
-              siteName: "YouTube",
+              siteName: t("components.linkPreview.youtubeSiteName"),
               url: url,
             });
             return;
@@ -263,7 +263,7 @@ export function LinkPreview({ url, className = "" }: LinkPreviewProps) {
         }
         if (!isActive || abortController.signal.aborted) return;
         console.error("Error fetching link metadata:", err);
-        setError("Failed to load preview");
+        setError(t("components.linkPreview.failedToLoadPreview"));
         // Set basic metadata with just the URL
         setMetadata({
           title: url,
@@ -282,7 +282,7 @@ export function LinkPreview({ url, className = "" }: LinkPreviewProps) {
       isActive = false;
       abortController.abort();
     };
-  }, [url]);
+  }, [url, t]);
 
   if (loading) {
     return (
@@ -345,11 +345,11 @@ export function LinkPreview({ url, className = "" }: LinkPreviewProps) {
             );
             launchApp("ipod", { initialData: { videoId } });
           } else {
-            toast.error("Could not extract video ID from this iPod URL");
+            toast.error(t("components.linkPreview.couldNotExtractIpodVideoId"));
             console.warn("Could not extract video ID from iPod URL:", url);
           }
         } catch (error) {
-          toast.error("Failed to open video in iPod app");
+          toast.error(t("components.linkPreview.failedToOpenIpodVideo"));
           console.error("Error launching iPod app:", error);
         }
       } else if (url.includes("/karaoke/")) {
@@ -362,11 +362,11 @@ export function LinkPreview({ url, className = "" }: LinkPreviewProps) {
             );
             launchApp("karaoke", { initialData: { videoId } });
           } else {
-            toast.error("Could not extract video ID from this Karaoke URL");
+            toast.error(t("components.linkPreview.couldNotExtractKaraokeVideoId"));
             console.warn("Could not extract video ID from Karaoke URL:", url);
           }
         } catch (error) {
-          toast.error("Failed to open video in Karaoke app");
+          toast.error(t("components.linkPreview.failedToOpenKaraokeVideo"));
           console.error("Error launching Karaoke app:", error);
         }
       } else {
@@ -436,7 +436,7 @@ export function LinkPreview({ url, className = "" }: LinkPreviewProps) {
           >
             <img
               src={metadata.image}
-              alt={metadata.title || "Link preview"}
+              alt={metadata.title || t("components.linkPreview.linkPreviewAlt")}
               className="w-full h-full object-cover"
               onError={(e) => {
                 // Hide image if it fails to load
@@ -449,7 +449,7 @@ export function LinkPreview({ url, className = "" }: LinkPreviewProps) {
               <div className="flex items-center gap-2">
                 <img
                   src={getFaviconUrl(url)}
-                  alt="Site favicon"
+                  alt={t("components.linkPreview.siteFaviconAlt")}
                   className="h-4 w-4 flex-shrink-0"
                   onError={(e) => {
                     // Fallback to a simple circle if favicon fails to load
@@ -576,11 +576,11 @@ export function LinkPreview({ url, className = "" }: LinkPreviewProps) {
                       ? "aqua-button secondary w-full"
                       : "flex items-center justify-center gap-1.5 px-3 py-2 text-[12px] bg-gray-100 hover:bg-gray-200 rounded-md transition-colors w-full"
                   )}
-                  title="Open Externally"
+                  title={t("components.linkPreview.openExternally")}
                   data-link-preview
                 >
                   {theme !== "macosx" && <ArrowSquareOut className="h-3 w-3" weight="bold" />}
-                  <span>Open Externally</span>
+                  <span>{t("components.linkPreview.openExternally")}</span>
                 </button>
               </div>
             )}
@@ -599,7 +599,7 @@ export function LinkPreview({ url, className = "" }: LinkPreviewProps) {
               >
                 <img
                   src={metadata.image}
-                  alt={metadata.title || "Link preview"}
+                  alt={metadata.title || t("components.linkPreview.linkPreviewAlt")}
                   className="w-full h-full object-cover"
                   onError={(e) => {
                     // Hide image if it fails to load
@@ -659,7 +659,7 @@ export function LinkPreview({ url, className = "" }: LinkPreviewProps) {
                 <div className="flex items-center gap-2">
                   <img
                     src={getFaviconUrl(url)}
-                    alt="Site favicon"
+                    alt={t("components.linkPreview.siteFaviconAlt")}
                     className="h-4 w-4 flex-shrink-0"
                     onError={(e) => {
                       // Fallback to a simple circle if favicon fails to load
@@ -797,11 +797,11 @@ export function LinkPreview({ url, className = "" }: LinkPreviewProps) {
                         ? "aqua-button secondary w-full"
                         : "flex items-center justify-center gap-1.5 px-3 py-2 text-[12px] bg-gray-100 hover:bg-gray-200 rounded-md transition-colors w-full"
                     )}
-                    title="Open Externally"
+                    title={t("components.linkPreview.openExternally")}
                     data-link-preview
                   >
                     {theme !== "macosx" && <ArrowSquareOut className="h-3 w-3" weight="bold" />}
-                    <span>Open Externally</span>
+                    <span>{t("components.linkPreview.openExternally")}</span>
                   </button>
                 </div>
               )}

--- a/src/lib/locales/de/translation.json
+++ b/src/lib/locales/de/translation.json
@@ -3781,8 +3781,11 @@
       "yellow": "gelb"
     },
     "desktop": {
+      "downloadAction": "Download",
+      "firstRunToast": "ryOS is available as a Mac app",
       "myComputer": "Arbeitsplatz",
-      "setWallpaper": "Hintergrundbild festlegen…"
+      "setWallpaper": "Hintergrundbild festlegen…",
+      "updateToast": "ryOS {{version}} for Mac is available"
     },
     "dialog": {
       "about": "Über",
@@ -4005,9 +4008,22 @@
   "components": {
     "linkPreview": {
       "addToIpod": "Zu iPod hinzufügen",
+      "couldNotExtractIpodVideoId": "Could not extract video ID from this iPod URL",
+      "couldNotExtractKaraokeVideoId": "Could not extract video ID from this Karaoke URL",
+      "couldNotExtractVideoId": "Could not extract video ID from this URL",
+      "couldNotExtractYouTubeVideoId": "Could not extract video ID from this YouTube URL",
+      "failedToLoadPreview": "Failed to load preview",
+      "failedToOpenIpodVideo": "Failed to open video in iPod app",
+      "failedToOpenKaraokeVideo": "Failed to open video in Karaoke app",
+      "fallbackVideoTitle": "YouTube video {{videoId}}",
+      "linkPreviewAlt": "Link preview",
+      "openExternally": "Open Externally",
       "openIpod": "iPod öffnen",
       "openKaraoke": "Karaoke öffnen",
-      "openYouTube": "YouTube öffnen"
+      "openYouTube": "YouTube öffnen",
+      "siteFaviconAlt": "Site favicon",
+      "watchOnYouTube": "Watch on YouTube",
+      "youtubeSiteName": "YouTube"
     }
   },
   "settings": {

--- a/src/lib/locales/en/translation.json
+++ b/src/lib/locales/en/translation.json
@@ -136,7 +136,10 @@
     },
     "desktop": {
       "setWallpaper": "Set Wallpaper…",
-      "myComputer": "My Computer"
+      "myComputer": "My Computer",
+      "updateToast": "ryOS {{version}} for Mac is available",
+      "firstRunToast": "ryOS is available as a Mac app",
+      "downloadAction": "Download"
     },
     "dock": {
       "open": "Open",
@@ -4021,7 +4024,20 @@
       "openIpod": "Open iPod",
       "openKaraoke": "Open Karaoke",
       "openYouTube": "Open YouTube",
-      "addToIpod": "Add to iPod"
+      "addToIpod": "Add to iPod",
+      "openExternally": "Open Externally",
+      "youtubeSiteName": "YouTube",
+      "fallbackVideoTitle": "YouTube video {{videoId}}",
+      "watchOnYouTube": "Watch on YouTube",
+      "failedToLoadPreview": "Failed to load preview",
+      "couldNotExtractYouTubeVideoId": "Could not extract video ID from this YouTube URL",
+      "couldNotExtractVideoId": "Could not extract video ID from this URL",
+      "couldNotExtractIpodVideoId": "Could not extract video ID from this iPod URL",
+      "couldNotExtractKaraokeVideoId": "Could not extract video ID from this Karaoke URL",
+      "failedToOpenIpodVideo": "Failed to open video in iPod app",
+      "failedToOpenKaraokeVideo": "Failed to open video in Karaoke app",
+      "linkPreviewAlt": "Link preview",
+      "siteFaviconAlt": "Site favicon"
     }
   },
   "settings": {

--- a/src/lib/locales/es/translation.json
+++ b/src/lib/locales/es/translation.json
@@ -3781,8 +3781,11 @@
       "yellow": "amarillo"
     },
     "desktop": {
+      "downloadAction": "Download",
+      "firstRunToast": "ryOS is available as a Mac app",
       "myComputer": "Mi PC",
-      "setWallpaper": "Establecer fondo de pantalla…"
+      "setWallpaper": "Establecer fondo de pantalla…",
+      "updateToast": "ryOS {{version}} for Mac is available"
     },
     "dialog": {
       "about": "Acerca de",
@@ -3990,9 +3993,22 @@
   "components": {
     "linkPreview": {
       "addToIpod": "Añadir a iPod",
+      "couldNotExtractIpodVideoId": "Could not extract video ID from this iPod URL",
+      "couldNotExtractKaraokeVideoId": "Could not extract video ID from this Karaoke URL",
+      "couldNotExtractVideoId": "Could not extract video ID from this URL",
+      "couldNotExtractYouTubeVideoId": "Could not extract video ID from this YouTube URL",
+      "failedToLoadPreview": "Failed to load preview",
+      "failedToOpenIpodVideo": "Failed to open video in iPod app",
+      "failedToOpenKaraokeVideo": "Failed to open video in Karaoke app",
+      "fallbackVideoTitle": "YouTube video {{videoId}}",
+      "linkPreviewAlt": "Link preview",
+      "openExternally": "Open Externally",
       "openIpod": "Abrir iPod",
       "openKaraoke": "Abrir Karaoke",
-      "openYouTube": "Abrir YouTube"
+      "openYouTube": "Abrir YouTube",
+      "siteFaviconAlt": "Site favicon",
+      "watchOnYouTube": "Watch on YouTube",
+      "youtubeSiteName": "YouTube"
     }
   },
   "settings": {

--- a/src/lib/locales/fr/translation.json
+++ b/src/lib/locales/fr/translation.json
@@ -3781,8 +3781,11 @@
       "yellow": "jaune"
     },
     "desktop": {
+      "downloadAction": "Download",
+      "firstRunToast": "ryOS is available as a Mac app",
       "myComputer": "Mon ordinateur",
-      "setWallpaper": "Définir le fond d'écran…"
+      "setWallpaper": "Définir le fond d'écran…",
+      "updateToast": "ryOS {{version}} for Mac is available"
     },
     "dialog": {
       "about": "À propos",
@@ -4005,9 +4008,22 @@
   "components": {
     "linkPreview": {
       "addToIpod": "Ajouter à l'iPod",
+      "couldNotExtractIpodVideoId": "Could not extract video ID from this iPod URL",
+      "couldNotExtractKaraokeVideoId": "Could not extract video ID from this Karaoke URL",
+      "couldNotExtractVideoId": "Could not extract video ID from this URL",
+      "couldNotExtractYouTubeVideoId": "Could not extract video ID from this YouTube URL",
+      "failedToLoadPreview": "Failed to load preview",
+      "failedToOpenIpodVideo": "Failed to open video in iPod app",
+      "failedToOpenKaraokeVideo": "Failed to open video in Karaoke app",
+      "fallbackVideoTitle": "YouTube video {{videoId}}",
+      "linkPreviewAlt": "Link preview",
+      "openExternally": "Open Externally",
       "openIpod": "Ouvrir l'iPod",
       "openKaraoke": "Ouvrir le Karaoké",
-      "openYouTube": "Ouvrir YouTube"
+      "openYouTube": "Ouvrir YouTube",
+      "siteFaviconAlt": "Site favicon",
+      "watchOnYouTube": "Watch on YouTube",
+      "youtubeSiteName": "YouTube"
     }
   },
   "settings": {

--- a/src/lib/locales/it/translation.json
+++ b/src/lib/locales/it/translation.json
@@ -3781,8 +3781,11 @@
       "yellow": "giallo"
     },
     "desktop": {
+      "downloadAction": "Download",
+      "firstRunToast": "ryOS is available as a Mac app",
       "myComputer": "Computer",
-      "setWallpaper": "Imposta sfondo…"
+      "setWallpaper": "Imposta sfondo…",
+      "updateToast": "ryOS {{version}} for Mac is available"
     },
     "dialog": {
       "about": "Informazioni",
@@ -3990,9 +3993,22 @@
   "components": {
     "linkPreview": {
       "addToIpod": "Aggiungi a iPod",
+      "couldNotExtractIpodVideoId": "Could not extract video ID from this iPod URL",
+      "couldNotExtractKaraokeVideoId": "Could not extract video ID from this Karaoke URL",
+      "couldNotExtractVideoId": "Could not extract video ID from this URL",
+      "couldNotExtractYouTubeVideoId": "Could not extract video ID from this YouTube URL",
+      "failedToLoadPreview": "Failed to load preview",
+      "failedToOpenIpodVideo": "Failed to open video in iPod app",
+      "failedToOpenKaraokeVideo": "Failed to open video in Karaoke app",
+      "fallbackVideoTitle": "YouTube video {{videoId}}",
+      "linkPreviewAlt": "Link preview",
+      "openExternally": "Open Externally",
       "openIpod": "Apri iPod",
       "openKaraoke": "Apri Karaoke",
-      "openYouTube": "Apri YouTube"
+      "openYouTube": "Apri YouTube",
+      "siteFaviconAlt": "Site favicon",
+      "watchOnYouTube": "Watch on YouTube",
+      "youtubeSiteName": "YouTube"
     }
   },
   "settings": {

--- a/src/lib/locales/ja/translation.json
+++ b/src/lib/locales/ja/translation.json
@@ -3781,8 +3781,11 @@
       "yellow": "黄色"
     },
     "desktop": {
+      "downloadAction": "Download",
+      "firstRunToast": "ryOS is available as a Mac app",
       "myComputer": "マイコンピュータ",
-      "setWallpaper": "壁紙を設定…"
+      "setWallpaper": "壁紙を設定…",
+      "updateToast": "ryOS {{version}} for Mac is available"
     },
     "dialog": {
       "about": "について",
@@ -4005,9 +4008,22 @@
   "components": {
     "linkPreview": {
       "addToIpod": "iPodに追加",
+      "couldNotExtractIpodVideoId": "Could not extract video ID from this iPod URL",
+      "couldNotExtractKaraokeVideoId": "Could not extract video ID from this Karaoke URL",
+      "couldNotExtractVideoId": "Could not extract video ID from this URL",
+      "couldNotExtractYouTubeVideoId": "Could not extract video ID from this YouTube URL",
+      "failedToLoadPreview": "Failed to load preview",
+      "failedToOpenIpodVideo": "Failed to open video in iPod app",
+      "failedToOpenKaraokeVideo": "Failed to open video in Karaoke app",
+      "fallbackVideoTitle": "YouTube video {{videoId}}",
+      "linkPreviewAlt": "Link preview",
+      "openExternally": "Open Externally",
       "openIpod": "iPodを開く",
       "openKaraoke": "カラオケを開く",
-      "openYouTube": "YouTubeを開く"
+      "openYouTube": "YouTubeを開く",
+      "siteFaviconAlt": "Site favicon",
+      "watchOnYouTube": "Watch on YouTube",
+      "youtubeSiteName": "YouTube"
     }
   },
   "settings": {

--- a/src/lib/locales/ko/translation.json
+++ b/src/lib/locales/ko/translation.json
@@ -3781,8 +3781,11 @@
       "yellow": "노란색"
     },
     "desktop": {
+      "downloadAction": "Download",
+      "firstRunToast": "ryOS is available as a Mac app",
       "myComputer": "내 컴퓨터",
-      "setWallpaper": "배경화면 설정…"
+      "setWallpaper": "배경화면 설정…",
+      "updateToast": "ryOS {{version}} for Mac is available"
     },
     "dialog": {
       "about": "정보",
@@ -4005,9 +4008,22 @@
   "components": {
     "linkPreview": {
       "addToIpod": "iPod에 추가",
+      "couldNotExtractIpodVideoId": "Could not extract video ID from this iPod URL",
+      "couldNotExtractKaraokeVideoId": "Could not extract video ID from this Karaoke URL",
+      "couldNotExtractVideoId": "Could not extract video ID from this URL",
+      "couldNotExtractYouTubeVideoId": "Could not extract video ID from this YouTube URL",
+      "failedToLoadPreview": "Failed to load preview",
+      "failedToOpenIpodVideo": "Failed to open video in iPod app",
+      "failedToOpenKaraokeVideo": "Failed to open video in Karaoke app",
+      "fallbackVideoTitle": "YouTube video {{videoId}}",
+      "linkPreviewAlt": "Link preview",
+      "openExternally": "Open Externally",
       "openIpod": "iPod 열기",
       "openKaraoke": "노래방 열기",
-      "openYouTube": "유튜브 열기"
+      "openYouTube": "유튜브 열기",
+      "siteFaviconAlt": "Site favicon",
+      "watchOnYouTube": "Watch on YouTube",
+      "youtubeSiteName": "YouTube"
     }
   },
   "settings": {

--- a/src/lib/locales/pt/translation.json
+++ b/src/lib/locales/pt/translation.json
@@ -3781,8 +3781,11 @@
       "yellow": "amarelo"
     },
     "desktop": {
+      "downloadAction": "Download",
+      "firstRunToast": "ryOS is available as a Mac app",
       "myComputer": "Meu Computador",
-      "setWallpaper": "Definir Papel de Parede…"
+      "setWallpaper": "Definir Papel de Parede…",
+      "updateToast": "ryOS {{version}} for Mac is available"
     },
     "dialog": {
       "about": "Sobre",
@@ -3990,9 +3993,22 @@
   "components": {
     "linkPreview": {
       "addToIpod": "Adicionar ao iPod",
+      "couldNotExtractIpodVideoId": "Could not extract video ID from this iPod URL",
+      "couldNotExtractKaraokeVideoId": "Could not extract video ID from this Karaoke URL",
+      "couldNotExtractVideoId": "Could not extract video ID from this URL",
+      "couldNotExtractYouTubeVideoId": "Could not extract video ID from this YouTube URL",
+      "failedToLoadPreview": "Failed to load preview",
+      "failedToOpenIpodVideo": "Failed to open video in iPod app",
+      "failedToOpenKaraokeVideo": "Failed to open video in Karaoke app",
+      "fallbackVideoTitle": "YouTube video {{videoId}}",
+      "linkPreviewAlt": "Link preview",
+      "openExternally": "Open Externally",
       "openIpod": "Abrir iPod",
       "openKaraoke": "Abrir Karaoke",
-      "openYouTube": "Abrir YouTube"
+      "openYouTube": "Abrir YouTube",
+      "siteFaviconAlt": "Site favicon",
+      "watchOnYouTube": "Watch on YouTube",
+      "youtubeSiteName": "YouTube"
     }
   },
   "settings": {

--- a/src/lib/locales/ru/translation.json
+++ b/src/lib/locales/ru/translation.json
@@ -3781,8 +3781,11 @@
       "yellow": "жёлтый"
     },
     "desktop": {
+      "downloadAction": "Download",
+      "firstRunToast": "ryOS is available as a Mac app",
       "myComputer": "Мой компьютер",
-      "setWallpaper": "Установить обои…"
+      "setWallpaper": "Установить обои…",
+      "updateToast": "ryOS {{version}} for Mac is available"
     },
     "dialog": {
       "about": "О программе",
@@ -3990,9 +3993,22 @@
   "components": {
     "linkPreview": {
       "addToIpod": "Добавить в iPod",
+      "couldNotExtractIpodVideoId": "Could not extract video ID from this iPod URL",
+      "couldNotExtractKaraokeVideoId": "Could not extract video ID from this Karaoke URL",
+      "couldNotExtractVideoId": "Could not extract video ID from this URL",
+      "couldNotExtractYouTubeVideoId": "Could not extract video ID from this YouTube URL",
+      "failedToLoadPreview": "Failed to load preview",
+      "failedToOpenIpodVideo": "Failed to open video in iPod app",
+      "failedToOpenKaraokeVideo": "Failed to open video in Karaoke app",
+      "fallbackVideoTitle": "YouTube video {{videoId}}",
+      "linkPreviewAlt": "Link preview",
+      "openExternally": "Open Externally",
       "openIpod": "Открыть iPod",
       "openKaraoke": "Открыть Караоке",
-      "openYouTube": "Открыть YouTube"
+      "openYouTube": "Открыть YouTube",
+      "siteFaviconAlt": "Site favicon",
+      "watchOnYouTube": "Watch on YouTube",
+      "youtubeSiteName": "YouTube"
     }
   },
   "settings": {

--- a/src/lib/locales/zh-TW/translation.json
+++ b/src/lib/locales/zh-TW/translation.json
@@ -3781,8 +3781,11 @@
       "yellow": "黃色"
     },
     "desktop": {
+      "downloadAction": "Download",
+      "firstRunToast": "ryOS is available as a Mac app",
       "myComputer": "我的電腦",
-      "setWallpaper": "設定背景圖片…"
+      "setWallpaper": "設定背景圖片…",
+      "updateToast": "ryOS {{version}} for Mac is available"
     },
     "dialog": {
       "about": "關於",
@@ -4005,9 +4008,22 @@
   "components": {
     "linkPreview": {
       "addToIpod": "加入iPod",
+      "couldNotExtractIpodVideoId": "Could not extract video ID from this iPod URL",
+      "couldNotExtractKaraokeVideoId": "Could not extract video ID from this Karaoke URL",
+      "couldNotExtractVideoId": "Could not extract video ID from this URL",
+      "couldNotExtractYouTubeVideoId": "Could not extract video ID from this YouTube URL",
+      "failedToLoadPreview": "Failed to load preview",
+      "failedToOpenIpodVideo": "Failed to open video in iPod app",
+      "failedToOpenKaraokeVideo": "Failed to open video in Karaoke app",
+      "fallbackVideoTitle": "YouTube video {{videoId}}",
+      "linkPreviewAlt": "Link preview",
+      "openExternally": "Open Externally",
       "openIpod": "開啟iPod",
       "openKaraoke": "開啟卡拉OK",
-      "openYouTube": "開啟YouTube"
+      "openYouTube": "開啟YouTube",
+      "siteFaviconAlt": "Site favicon",
+      "watchOnYouTube": "Watch on YouTube",
+      "youtubeSiteName": "YouTube"
     }
   },
   "settings": {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
This PR tightens localization for a few high-visibility user-facing surfaces and runs the repo’s translation sync so every locale picks up the new keys (English placeholders where other languages had no prior string).

**What changed**
- **Mac desktop toasts** in `App.tsx`: version-available / first-run messages and the Download action now use `common.desktop.*` keys so they follow the active language.
- **`LinkPreview`**: error toasts, YouTube fallback title/description/site name, “Open Externally” control, preview/favicon `alt` text, and metadata-fetch error state use `components.linkPreview.*`.
- **Accessibility**: close buttons in `AppDrawer`, XP chrome in `ListenSessionInvite`, and the Start menu About icon `alt` use existing `common.menu.close` / `common.dialog.about`.

**Workflow**
- Ran `bun run scripts/sync-translations.ts` (not `i18n:translate`: machine translation needs `GOOGLE_GENERATIVE_AI_API_KEY`).

**Verification**
- `bun run build` (tsc + vite) succeeds.

**Remaining gaps**
- `bun run i18n:find-untranslated` still flags many files (app `metadata.ts` help copy, stores with English descriptions, terminal strings, etc.). Those are mostly unchanged in this pass; follow-up work can route them through `t()` / `useTranslatedHelpItems` where appropriate.
- Non-English locale files currently contain English text for the new keys until human or machine translation is applied.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ec59cbc8-5087-4714-8791-0569441df9f0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ec59cbc8-5087-4714-8791-0569441df9f0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

