### PR TITLE
Subtle chat tool errors; fix maps search unhandled flash

### DIFF
--- a/api/chat/tools/cursor-repo-agent.ts
+++ b/api/chat/tools/cursor-repo-agent.ts
@@ -815,8 +815,7 @@ export async function executeCursorCloudAgent(
       agentId,
       agentDashboardUrl: cursorCloudAgentDashboardUrl(agentId),
       ...(agentTitle ? { agentTitle } : {}),
-      message:
-        "Started. Share the Cursor agent link with the user (agentDashboardUrl) — not the run id — for where to follow progress.",
+      message: "Started — live progress streams in the chat card below.",
       pollHint:
         "Poll GET /api/ai/cursor-run-status?runId=… for events until a terminal entry appears.",
     };
@@ -1042,8 +1041,7 @@ export async function sendCursorAgentFollowup(input: {
     agentId,
     agentDashboardUrl: cursorCloudAgentDashboardUrl(agentId),
     previousRunId,
-    message:
-      "Follow-up started. Tell the user to use the same Cursor agent link (agentDashboardUrl) to follow this turn.",
+    message: "Follow-up sent — live progress streams in the chat card below.",
   };
 }
 

--- a/src/apps/chats/hooks/useAiChat.ts
+++ b/src/apps/chats/hooks/useAiChat.ts
@@ -826,6 +826,12 @@ export function useAiChat(onPromptSetUsername?: () => void) {
             result = "";
             break;
           }
+          case "mapsSearchPlaces": {
+            console.log("[ToolCall] mapsSearchPlaces (server-side):", toolCall.input);
+            // Result comes from server — do not call addToolResult
+            result = "";
+            break;
+          }
           // === Unified VFS Tools ===
           case "list": {
             const { path, query, limit } = toolCall.input as {
@@ -1837,6 +1843,7 @@ export function useAiChat(onPromptSetUsername?: () => void) {
           "webFetch",
           "cursorCloudAgent",
           "listCursorCloudAgentRuns",
+          "mapsSearchPlaces",
         ];
         const toolParts = lastMsg.parts.filter(
           (part: { type?: string; state?: string }) =>

--- a/src/apps/terminal/components/TerminalToolInvocation.tsx
+++ b/src/apps/terminal/components/TerminalToolInvocation.tsx
@@ -311,7 +311,9 @@ export function TerminalToolInvocation({
 
   // Handle error states
   if (state === "output-error") {
-    displayResultMessage = t("apps.chats.toolCalls.toolExecutionFailed");
+    displayResultMessage = t("apps.chats.toolCalls.toolAttempted", {
+      toolName: formatToolName(toolName),
+    });
   }
 
   // Fallback for loading states if no specific message was set
@@ -336,8 +338,12 @@ export function TerminalToolInvocation({
         </>
       ) : state === "output-error" ? (
         <>
-          <span className="text-red-400">⚠️</span>
-          <span className="italic text-red-400">{displayResultMessage}</span>
+          <Check
+            className="h-3 w-3 shrink-0 text-neutral-500 flex-shrink-0"
+            weight="bold"
+            aria-hidden
+          />
+          <span className="italic text-neutral-500">{displayResultMessage}</span>
         </>
       ) : displayCallMessage ? (
         <>

--- a/src/components/shared/ToolInvocationMessage.tsx
+++ b/src/components/shared/ToolInvocationMessage.tsx
@@ -91,7 +91,7 @@ export function ToolInvocationMessage({
 }: ToolInvocationMessageProps) {
   const { t } = useTranslation();
   const toolName = getToolName(part);
-  const { state, input, output, errorText } = part;
+  const { state, input, output } = part;
 
   // Friendly display strings
   let displayCallMessage: string | null = null;
@@ -324,8 +324,10 @@ export function ToolInvocationMessage({
         truncated?: boolean;
         error?: string;
       };
-      if (o.success === false && typeof o.error === "string") {
-        displayResultMessage = o.error;
+      if (o.success === false) {
+        displayResultMessage = t("apps.chats.toolCalls.toolAttempted", {
+          toolName: formatToolName(toolName),
+        });
       } else if (o.success === true && Array.isArray(o.runs)) {
         const more = o.truncated
           ? ` ${t("apps.chats.toolCalls.listCursorCloudAgentRuns.truncatedHint")}`
@@ -720,11 +722,6 @@ export function ToolInvocationMessage({
     }
   }
 
-  // Handle error states
-  if (state === "output-error" && errorText) {
-    displayResultMessage = t("apps.chats.toolCalls.error", { errorText });
-  }
-
   // Async Cursor Cloud agent — server streams events to Redis; UI polls /api/ai/cursor-run-status
   if (
     state === "output-available" &&
@@ -803,6 +800,29 @@ export function ToolInvocationMessage({
           {results.length > 0 && (
             <MapsSearchPlacesCard query={query} results={results} />
           )}
+        </div>
+      );
+    }
+    if (out && out.success === false) {
+      return (
+        <div key={partKey} className="mb-0 px-1 py-0.5 text-[12px]">
+          <ToolInvocationStatusRow
+            icon={
+              <Check
+                className="h-3 w-3 shrink-0 text-neutral-400"
+                weight="bold"
+                aria-hidden
+              />
+            }
+            className="text-neutral-500"
+            align="start"
+          >
+            <span>
+              {t("apps.chats.toolCalls.toolAttempted", {
+                toolName: formatToolName(toolName),
+              })}
+            </span>
+          </ToolInvocationStatusRow>
         </div>
       );
     }
@@ -915,8 +935,9 @@ export function ToolInvocationMessage({
   }
 
   // Default rendering for other tools
-  const fallbackErrorText =
-    errorText || t("apps.chats.toolCalls.toolExecutionFailed");
+  const toolAttemptedLabel = t("apps.chats.toolCalls.toolAttempted", {
+    toolName: formatToolName(toolName),
+  });
 
   return (
     <div key={partKey} className="mb-0 px-1 py-0.5 italic text-[12px]">
@@ -959,13 +980,15 @@ export function ToolInvocationMessage({
       {state === "output-error" && (
         <ToolInvocationStatusRow
           icon={
-            <span className="text-[10px] leading-none" aria-hidden="true">
-              ⚠️
-            </span>
+            <Check
+              className="h-3 w-3 shrink-0 text-neutral-400"
+              weight="bold"
+              aria-hidden
+            />
           }
-          className="text-red-600"
+          className="text-neutral-500"
         >
-          <span className="text-xs">{fallbackErrorText}</span>
+          <span>{toolAttemptedLabel}</span>
         </ToolInvocationStatusRow>
       )}
     </div>

--- a/src/lib/locales/de/translation.json
+++ b/src/lib/locales/de/translation.json
@@ -1111,6 +1111,7 @@
         "textNotFound": "Text nicht gefunden",
         "toggledIpodPlayback": "iPod-Wiedergabe umgeschaltet",
         "toolExecutionFailed": "Tool-Ausführung fehlgeschlagen",
+        "toolAttempted": "{{toolName}} versucht",
         "tv": {
           "addedVideo": "{{title}} zu {{channel}} hinzugefügt",
           "addingVideo": "Video wird zum Kanal hinzugefügt…",

--- a/src/lib/locales/en/translation.json
+++ b/src/lib/locales/en/translation.json
@@ -978,6 +978,7 @@
         "generating": "Generating…",
         "preparingHtmlPreview": "Preparing HTML preview...",
         "toolExecutionFailed": "Tool execution failed",
+        "toolAttempted": "{{toolName}} attempted",
         "error": "Error: {{errorText}}",
         "changingSettings": "Changing settings…",
         "settingsUpdated": "Settings updated",

--- a/src/lib/locales/es/translation.json
+++ b/src/lib/locales/es/translation.json
@@ -1111,6 +1111,7 @@
         "textNotFound": "Texto no encontrado",
         "toggledIpodPlayback": "Alternó la reproducción del iPod",
         "toolExecutionFailed": "Fallo en la ejecución de la herramienta",
+        "toolAttempted": "{{toolName}} intentado",
         "tv": {
           "addedVideo": "Se ha añadido {{title}} a {{channel}}",
           "addingVideo": "Añadiendo vídeo al canal…",

--- a/src/lib/locales/fr/translation.json
+++ b/src/lib/locales/fr/translation.json
@@ -1111,6 +1111,7 @@
         "textNotFound": "Texte introuvable",
         "toggledIpodPlayback": "Lecture iPod basculée",
         "toolExecutionFailed": "Échec de l'exécution de l'outil",
+        "toolAttempted": "{{toolName}} tenté",
         "tv": {
           "addedVideo": "Ajouté {{title}} à {{channel}}",
           "addingVideo": "Ajout de la vidéo à la chaîne…",

--- a/src/lib/locales/it/translation.json
+++ b/src/lib/locales/it/translation.json
@@ -1111,6 +1111,7 @@
         "textNotFound": "Testo non trovato",
         "toggledIpodPlayback": "Stato riproduzione iPod modificato",
         "toolExecutionFailed": "Esecuzione strumento fallita",
+        "toolAttempted": "{{toolName}} tentato",
         "tv": {
           "addedVideo": "Aggiunto {{title}} a {{channel}}",
           "addingVideo": "Aggiunta video al canale…",

--- a/src/lib/locales/ja/translation.json
+++ b/src/lib/locales/ja/translation.json
@@ -1111,6 +1111,7 @@
         "textNotFound": "テキストが見つかりませんでした",
         "toggledIpodPlayback": "iPod の再生を切り替えました",
         "toolExecutionFailed": "ツールの実行に失敗しました",
+        "toolAttempted": "{{toolName}} を試行しました",
         "tv": {
           "addedVideo": "{{title}}を{{channel}}に追加しました",
           "addingVideo": "チャンネルに動画を追加中…",

--- a/src/lib/locales/ko/translation.json
+++ b/src/lib/locales/ko/translation.json
@@ -1111,6 +1111,7 @@
         "textNotFound": "텍스트를 찾을 수 없음",
         "toggledIpodPlayback": "iPod 재생 전환됨",
         "toolExecutionFailed": "도구 실행 실패",
+        "toolAttempted": "{{toolName}} 시도됨",
         "tv": {
           "addedVideo": "{{channel}}에 {{title}}을(를) 추가했습니다",
           "addingVideo": "채널에 동영상 추가 중…",

--- a/src/lib/locales/pt/translation.json
+++ b/src/lib/locales/pt/translation.json
@@ -1111,6 +1111,7 @@
         "textNotFound": "Texto não encontrado",
         "toggledIpodPlayback": "Alternou a reprodução do iPod",
         "toolExecutionFailed": "Falha na execução da ferramenta",
+        "toolAttempted": "{{toolName}} tentado",
         "tv": {
           "addedVideo": "Adicionado {{title}} a {{channel}}",
           "addingVideo": "Adicionando vídeo ao canal…",

--- a/src/lib/locales/ru/translation.json
+++ b/src/lib/locales/ru/translation.json
@@ -1111,6 +1111,7 @@
         "textNotFound": "Текст не найден",
         "toggledIpodPlayback": "Переключено воспроизведение iPod",
         "toolExecutionFailed": "Ошибка выполнения инструмента",
+        "toolAttempted": "{{toolName}} — попытка выполнена",
         "tv": {
           "addedVideo": "Добавлено «{{title}}» в «{{channel}}»",
           "addingVideo": "Добавление видео в канал…",

--- a/src/lib/locales/zh-TW/translation.json
+++ b/src/lib/locales/zh-TW/translation.json
@@ -1111,6 +1111,7 @@
         "textNotFound": "找不到文字",
         "toggledIpodPlayback": "切換 iPod 播放",
         "toolExecutionFailed": "工具執行失敗",
+        "toolAttempted": "已嘗試 {{toolName}}",
         "tv": {
           "addedVideo": "已將 {{title}} 新增至 {{channel}}",
           "addingVideo": "正在將影片新增至頻道…",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Treat `mapsSearchPlaces` as a server-side tool in `onToolCall` so the client no longer briefly reports it as unhandled while the stream delivers the real result.
- Tool failures in chat show a **gray checkmark** and localized **"{toolName} attempted"** instead of red text, warning emoji, or raw error strings; maps failures with `success: false` match; terminal tool errors aligned.
- **Cursor runs:** shortened the async `cursorCloudAgent` tool `message` (and follow-up `message`) so it no longer tells the model to paste/share the agent dashboard URL — the intro line now points at the in-chat card stream only.

## Testing

Not run in this cloud image: `bun` / `node` were unavailable in the agent shell; run `bun run build` locally to verify.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a716f98a-e771-475f-a4a6-57f741420ff3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a716f98a-e771-475f-a4a6-57f741420ff3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

