### PR TITLE
Telegram maps search: include Apple Maps URLs in replies

### DIFF
--- a/api/_utils/_aiPrompts.ts
+++ b/api/_utils/_aiPrompts.ts
@@ -279,7 +279,7 @@ You can manage the user's calendar events, todos, and sticky notes directly from
 - Always confirm what you did after making changes in one short line when possible (e.g. "added 'Dentist' on 2026-03-10 at 14:00").
 
 ## Maps
-Use mapsSearchPlaces when the user asks to find a place, look up an address, or browse nearby POIs. Pass the user's intent verbatim as 'query' and, when known, the user's coordinates as 'near' so results are biased correctly. Reply with the top result's name + city in one short line and let the place card link in the chat surface do the rest.
+Use mapsSearchPlaces when the user asks to find a place, look up an address, or browse nearby POIs. Pass the user's intent verbatim as 'query' and, when known, the user's coordinates as 'near' so results are biased correctly. Each result includes an Apple Maps URL (appleMapsUrl). Telegram has no place cards — after the tool returns, list every place you mention on its own line as: name — city/area — full https://maps.apple.com/... URL from the tool output (plain URL text, no markdown links).
 </telegram_chat_instructions>
 `;
 

--- a/api/chat/tools/index.ts
+++ b/api/chat/tools/index.ts
@@ -247,6 +247,12 @@ export const TOOL_DESCRIPTIONS = {
     "an address they just mentioned, etc.). The tool only accepts a point anchor — there is no separate region/bounding-box " +
     "parameter. When you reference a result in chat, mention it by name + city — the client renders the rich card automatically.",
 
+  mapsSearchPlacesTelegram:
+    "Search Apple Maps for points of interest, businesses, and addresses (Telegram DM). Same inputs as the main maps tool. " +
+    "Each result includes 'appleMapsUrl' (https://maps.apple.com/...). There is no rich place card in Telegram — you MUST paste " +
+    "the exact appleMapsUrl for every place you mention in your reply (plain URL text, one per line is fine). " +
+    "Do not invent URLs; only use appleMapsUrl values from this tool's JSON output.",
+
   webFetch:
     "Fetch and read the text content of a web page. Use this when the user asks you to look something up online, " +
     "read an article, check a website, get information from a URL, or when you need live/current data from the web. " +
@@ -561,7 +567,10 @@ export function createChatTools(
           return executeSongLibraryControl(input, context);
         },
       },
-      mapsSearchPlaces: allTools.mapsSearchPlaces,
+      mapsSearchPlaces: {
+        ...allTools.mapsSearchPlaces,
+        description: TOOL_DESCRIPTIONS.mapsSearchPlacesTelegram,
+      },
     } as Pick<typeof allTools, (typeof _TELEGRAM_TOOL_NAMES)[number]>;
   }
 

--- a/tests/test-telegram-maps-search-tool.test.ts
+++ b/tests/test-telegram-maps-search-tool.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, mock, test } from "bun:test";
+import { createChatTools, TOOL_DESCRIPTIONS } from "../api/chat/tools/index.js";
+import { TELEGRAM_CHAT_INSTRUCTIONS } from "../api/_utils/_aiPrompts.js";
+
+describe("telegram mapsSearchPlaces tool profile", () => {
+  const context = {
+    log: mock(() => {}),
+    logError: mock(() => {}),
+    env: {},
+    username: "ryo",
+    timeZone: "America/Los_Angeles",
+  };
+
+  test("telegram profile uses Telegram-specific description for mapsSearchPlaces", () => {
+    const tools = createChatTools(context, { profile: "telegram" });
+    expect(tools.mapsSearchPlaces.description).toBe(
+      TOOL_DESCRIPTIONS.mapsSearchPlacesTelegram
+    );
+    expect(tools.mapsSearchPlaces.description).toContain("appleMapsUrl");
+    expect(tools.mapsSearchPlaces.description).toContain("Telegram");
+  });
+
+  test("chat (all) profile keeps ryOS place-card wording for mapsSearchPlaces", () => {
+    const tools = createChatTools(context, { profile: "all" });
+    expect(tools.mapsSearchPlaces.description).toBe(TOOL_DESCRIPTIONS.mapsSearchPlaces);
+    expect(tools.mapsSearchPlaces.description).toContain("rich card");
+    expect(tools.mapsSearchPlaces.description).not.toContain("Telegram DM");
+    expect(tools.mapsSearchPlaces.description).not.toContain(
+      "There is no rich place card in Telegram"
+    );
+  });
+});
+
+describe("telegram chat instructions for maps", () => {
+  test("instructs listing appleMapsUrl for each mentioned place", () => {
+    expect(TELEGRAM_CHAT_INSTRUCTIONS).toContain("appleMapsUrl");
+    expect(TELEGRAM_CHAT_INSTRUCTIONS).toContain("https://maps.apple.com/");
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Telegram DMs do not render ryOS place cards, so the model was instructed to rely on cards that never appear. This change aligns prompts with Telegram: after `mapsSearchPlaces`, the assistant should list each mentioned place with the exact `appleMapsUrl` from the tool JSON (plain `https://maps.apple.com/...` text).

## Changes

- **`TELEGRAM_CHAT_INSTRUCTIONS`**: Maps section now requires one line per place (name — area — full Apple Maps URL from tool output).
- **`createChatTools` (telegram profile)**: `mapsSearchPlaces` uses a dedicated description (`mapsSearchPlacesTelegram`) that tells the model to paste every `appleMapsUrl` and not invent URLs. The web/chat profile keeps the existing “rich card” wording.

## Testing

- `bun test tests/test-telegram-maps-search-tool.test.ts`
- `bun run build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1f9f24f5-9708-497a-9309-4fc77d46f63a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1f9f24f5-9708-497a-9309-4fc77d46f63a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

