### PR TITLE
Maps: default view to Muted Standard

### DIFF
--- a/src/apps/maps/hooks/useMapsLogic.ts
+++ b/src/apps/maps/hooks/useMapsLogic.ts
@@ -34,7 +34,7 @@ export function useMapsLogic() {
 
   const [isHelpDialogOpen, setIsHelpDialogOpen] = useState(false);
   const [isAboutDialogOpen, setIsAboutDialogOpen] = useState(false);
-  const [mapType, setMapType] = useState<MapsMapType>("standard");
+  const [mapType, setMapType] = useState<MapsMapType>("mutedStandard");
 
   const mapKitLanguage = ryOSLocaleToMapKitLanguage(i18n.language);
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Maps app now opens with **Muted Standard** as the initial map type (`useMapsLogic` default state). Help dialog strings in `src/apps/maps/index.tsx` and locale files are unchanged.

## Testing

- `bun run build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1f9f24f5-9708-497a-9309-4fc77d46f63a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1f9f24f5-9708-497a-9309-4fc77d46f63a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

