### PR TITLE
Maps: Directions button on place card (Apple Maps)

### DIFF
--- a/src/apps/maps/components/MapsAppComponent.tsx
+++ b/src/apps/maps/components/MapsAppComponent.tsx
@@ -1371,6 +1371,8 @@ export function MapsAppComponent({
                 !!workPlace &&
                 workPlace.id === selectedPlace.id
               }
+              savedHomePlace={homePlace}
+              savedWorkPlace={workPlace}
               onSetHome={(p) => setHomePlace(p)}
               onSetWork={(p) => setWorkPlace(p)}
               onToggleFavorite={handleToggleFavorite}

--- a/src/apps/maps/components/MapsAppComponent.tsx
+++ b/src/apps/maps/components/MapsAppComponent.tsx
@@ -17,6 +17,7 @@ import { MapsPlaceCard } from "./MapsPlaceCard";
 import { useMapsStore } from "@/stores/useMapsStore";
 import type { SavedPlace } from "../utils/types";
 import { getPoiMarkerAnnotationOptions } from "../utils/poiMarkerStyle";
+import { buildAppleMapsDrivingDirectionsUrl } from "../utils/appleMapsLinks";
 import {
   homeMarkerAnnotationStyle,
   workMarkerAnnotationStyle,
@@ -774,6 +775,14 @@ export function MapsAppComponent({
     clearDroppedAnnotation();
   }, [setSelectedPlace, clearDroppedAnnotation]);
 
+  const handleOpenPlaceDirections = useCallback((place: SavedPlace) => {
+    const url = buildAppleMapsDrivingDirectionsUrl(
+      place.latitude,
+      place.longitude
+    );
+    window.open(url, "_blank", "noopener,noreferrer");
+  }, []);
+
   const handleToggleFavorite = useCallback(
     (place: SavedPlace) => {
       if (isPlaceFavorite(place.id)) {
@@ -1365,6 +1374,7 @@ export function MapsAppComponent({
               onSetHome={(p) => setHomePlace(p)}
               onSetWork={(p) => setWorkPlace(p)}
               onToggleFavorite={handleToggleFavorite}
+              onDirections={handleOpenPlaceDirections}
               onClose={handleClosePlaceCard}
             />
 

--- a/src/apps/maps/components/MapsPlaceCard.tsx
+++ b/src/apps/maps/components/MapsPlaceCard.tsx
@@ -1,6 +1,12 @@
 import { useTranslation } from "react-i18next";
 import { motion, AnimatePresence, type Transition } from "framer-motion";
-import { Briefcase, House, Star, X } from "@phosphor-icons/react";
+import {
+  Briefcase,
+  House,
+  NavigationArrow,
+  Star,
+  X,
+} from "@phosphor-icons/react";
 import { cn } from "@/lib/utils";
 import {
   AQUA_ICON_BUTTON_PADDING_CLASS,
@@ -27,6 +33,7 @@ export interface MapsPlaceCardProps {
   onSetHome: (place: SavedPlace) => void;
   onSetWork: (place: SavedPlace) => void;
   onToggleFavorite: (place: SavedPlace) => void;
+  onDirections: (place: SavedPlace) => void;
   onClose: () => void;
 }
 
@@ -78,6 +85,7 @@ export function MapsPlaceCard({
   onSetHome,
   onSetWork,
   onToggleFavorite,
+  onDirections,
   onClose,
 }: MapsPlaceCardProps) {
   const { t } = useTranslation();
@@ -133,6 +141,7 @@ export function MapsPlaceCard({
               onSetHome={onSetHome}
               onSetWork={onSetWork}
               onToggleFavorite={onToggleFavorite}
+              onDirections={onDirections}
               t={t}
             />
           </div>
@@ -232,6 +241,7 @@ interface PlaceCardActionsProps {
   onSetHome: (place: SavedPlace) => void;
   onSetWork: (place: SavedPlace) => void;
   onToggleFavorite: (place: SavedPlace) => void;
+  onDirections: (place: SavedPlace) => void;
   t: ReturnType<typeof useTranslation>["t"];
 }
 
@@ -243,6 +253,7 @@ function PlaceCardActions({
   onSetHome,
   onSetWork,
   onToggleFavorite,
+  onDirections,
   t,
 }: PlaceCardActionsProps) {
   const { isMacOSTheme } = useThemeFlags();
@@ -250,6 +261,27 @@ function PlaceCardActions({
 
   return (
     <div className="flex flex-wrap items-center gap-1.5">
+      <Button
+        type="button"
+        variant={variant}
+        size="sm"
+        onClick={() => onDirections(place)}
+        title={t("apps.maps.placeCard.openDirections", {
+          defaultValue: "Get directions in Apple Maps",
+        })}
+        className={AQUA_ICON_BUTTON_PADDING_CLASS}
+      >
+        <NavigationArrow
+          size={AQUA_ICON_BUTTON_PHOSPHOR_SIZE}
+          weight="bold"
+        />
+        <span>
+          {t("apps.maps.placeCard.directions", {
+            defaultValue: "Directions",
+          })}
+        </span>
+      </Button>
+
       <Button
         type="button"
         variant={variant}

--- a/src/apps/maps/components/MapsPlaceCard.tsx
+++ b/src/apps/maps/components/MapsPlaceCard.tsx
@@ -30,6 +30,10 @@ export interface MapsPlaceCardProps {
   isFavorite: boolean;
   isHome: boolean;
   isWork: boolean;
+  /** When set elsewhere, the Home action is hidden unless this card is Home. */
+  savedHomePlace: SavedPlace | null;
+  /** When set elsewhere, the Work action is hidden unless this card is Work. */
+  savedWorkPlace: SavedPlace | null;
   onSetHome: (place: SavedPlace) => void;
   onSetWork: (place: SavedPlace) => void;
   onToggleFavorite: (place: SavedPlace) => void;
@@ -82,6 +86,8 @@ export function MapsPlaceCard({
   isFavorite,
   isHome,
   isWork,
+  savedHomePlace,
+  savedWorkPlace,
   onSetHome,
   onSetWork,
   onToggleFavorite,
@@ -138,6 +144,8 @@ export function MapsPlaceCard({
               isFavorite={isFavorite}
               isHome={isHome}
               isWork={isWork}
+              savedHomePlace={savedHomePlace}
+              savedWorkPlace={savedWorkPlace}
               onSetHome={onSetHome}
               onSetWork={onSetWork}
               onToggleFavorite={onToggleFavorite}
@@ -238,6 +246,8 @@ interface PlaceCardActionsProps {
   isFavorite: boolean;
   isHome: boolean;
   isWork: boolean;
+  savedHomePlace: SavedPlace | null;
+  savedWorkPlace: SavedPlace | null;
   onSetHome: (place: SavedPlace) => void;
   onSetWork: (place: SavedPlace) => void;
   onToggleFavorite: (place: SavedPlace) => void;
@@ -250,6 +260,8 @@ function PlaceCardActions({
   isFavorite,
   isHome,
   isWork,
+  savedHomePlace,
+  savedWorkPlace,
   onSetHome,
   onSetWork,
   onToggleFavorite,
@@ -258,6 +270,8 @@ function PlaceCardActions({
 }: PlaceCardActionsProps) {
   const { isMacOSTheme } = useThemeFlags();
   const variant = isMacOSTheme ? "aqua" : "retro";
+  const showHomeButton = !savedHomePlace || isHome;
+  const showWorkButton = !savedWorkPlace || isWork;
 
   return (
     <div className="flex flex-wrap items-center gap-1.5">
@@ -314,53 +328,57 @@ function PlaceCardActions({
         </span>
       </Button>
 
-      <Button
-        type="button"
-        variant={variant}
-        size="sm"
-        onClick={() => onSetHome(place)}
-        aria-pressed={isHome}
-        title={t("apps.maps.placeCard.setHome", {
-          defaultValue: "Set as Home",
-        })}
-        className={AQUA_ICON_BUTTON_PADDING_CLASS}
-      >
-        <House
-          size={AQUA_ICON_BUTTON_PHOSPHOR_SIZE}
-          weight={isHome ? "fill" : "regular"}
-        />
-        <span>
-          {isHome
-            ? t("apps.maps.placeCard.home", { defaultValue: "Home" })
-            : t("apps.maps.placeCard.setHome", {
-                defaultValue: "Set as Home",
-              })}
-        </span>
-      </Button>
+      {showHomeButton && (
+        <Button
+          type="button"
+          variant={variant}
+          size="sm"
+          onClick={() => onSetHome(place)}
+          aria-pressed={isHome}
+          title={t("apps.maps.placeCard.setHome", {
+            defaultValue: "Set as Home",
+          })}
+          className={AQUA_ICON_BUTTON_PADDING_CLASS}
+        >
+          <House
+            size={AQUA_ICON_BUTTON_PHOSPHOR_SIZE}
+            weight={isHome ? "fill" : "regular"}
+          />
+          <span>
+            {isHome
+              ? t("apps.maps.placeCard.home", { defaultValue: "Home" })
+              : t("apps.maps.placeCard.setHome", {
+                  defaultValue: "Set as Home",
+                })}
+          </span>
+        </Button>
+      )}
 
-      <Button
-        type="button"
-        variant={variant}
-        size="sm"
-        onClick={() => onSetWork(place)}
-        aria-pressed={isWork}
-        title={t("apps.maps.placeCard.setWork", {
-          defaultValue: "Set as Work",
-        })}
-        className={AQUA_ICON_BUTTON_PADDING_CLASS}
-      >
-        <Briefcase
-          size={AQUA_ICON_BUTTON_PHOSPHOR_SIZE}
-          weight={isWork ? "fill" : "regular"}
-        />
-        <span>
-          {isWork
-            ? t("apps.maps.placeCard.work", { defaultValue: "Work" })
-            : t("apps.maps.placeCard.setWork", {
-                defaultValue: "Set as Work",
-              })}
-        </span>
-      </Button>
+      {showWorkButton && (
+        <Button
+          type="button"
+          variant={variant}
+          size="sm"
+          onClick={() => onSetWork(place)}
+          aria-pressed={isWork}
+          title={t("apps.maps.placeCard.setWork", {
+            defaultValue: "Set as Work",
+          })}
+          className={AQUA_ICON_BUTTON_PADDING_CLASS}
+        >
+          <Briefcase
+            size={AQUA_ICON_BUTTON_PHOSPHOR_SIZE}
+            weight={isWork ? "fill" : "regular"}
+          />
+          <span>
+            {isWork
+              ? t("apps.maps.placeCard.work", { defaultValue: "Work" })
+              : t("apps.maps.placeCard.setWork", {
+                  defaultValue: "Set as Work",
+                })}
+          </span>
+        </Button>
+      )}
     </div>
   );
 }

--- a/src/apps/maps/utils/appleMapsLinks.ts
+++ b/src/apps/maps/utils/appleMapsLinks.ts
@@ -1,0 +1,17 @@
+/**
+ * Opens Apple Maps driving directions in the default Maps client (or browser).
+ * Omitting `saddr` uses the device’s current location as the start.
+ *
+ * @see https://developer.apple.com/documentation/mapkit/unified-map-urls
+ */
+export function buildAppleMapsDrivingDirectionsUrl(
+  latitude: number,
+  longitude: number
+): string {
+  const daddr = `${latitude},${longitude}`;
+  const params = new URLSearchParams({
+    daddr,
+    dirflg: "d",
+  });
+  return `https://maps.apple.com/?${params.toString()}`;
+}

--- a/src/lib/locales/de/translation.json
+++ b/src/lib/locales/de/translation.json
@@ -1110,8 +1110,8 @@
         "switchingTheme": "Thema wird gewechselt…",
         "textNotFound": "Text nicht gefunden",
         "toggledIpodPlayback": "iPod-Wiedergabe umgeschaltet",
-        "toolExecutionFailed": "Tool-Ausführung fehlgeschlagen",
         "toolAttempted": "{{toolName}} versucht",
+        "toolExecutionFailed": "Tool-Ausführung fehlgeschlagen",
         "tv": {
           "addedVideo": "{{title}} zu {{channel}} hinzugefügt",
           "addingVideo": "Video wird zum Kanal hinzugefügt…",
@@ -2548,9 +2548,11 @@
       "placeCard": {
         "addFavorite": "Zu Favoriten hinzufügen",
         "close": "Ortskarte schließen",
+        "directions": "Directions",
         "favorite": "Favorit",
         "favorited": "Favorisiert",
         "home": "Privat",
+        "openDirections": "Get directions in Apple Maps",
         "regionLabel": "Ausgewählter Ort",
         "removeFavorite": "Aus Favoriten entfernen",
         "setHome": "Als Privat festlegen",

--- a/src/lib/locales/en/translation.json
+++ b/src/lib/locales/en/translation.json
@@ -3923,6 +3923,8 @@
       "placeCard": {
         "regionLabel": "Selected place",
         "close": "Close place card",
+        "directions": "Directions",
+        "openDirections": "Get directions in Apple Maps",
         "setHome": "Set as Home",
         "home": "Home",
         "setWork": "Set as Work",

--- a/src/lib/locales/es/translation.json
+++ b/src/lib/locales/es/translation.json
@@ -1110,8 +1110,8 @@
         "switchingTheme": "Cambiando tema…",
         "textNotFound": "Texto no encontrado",
         "toggledIpodPlayback": "Alternó la reproducción del iPod",
-        "toolExecutionFailed": "Fallo en la ejecución de la herramienta",
         "toolAttempted": "{{toolName}} intentado",
+        "toolExecutionFailed": "Fallo en la ejecución de la herramienta",
         "tv": {
           "addedVideo": "Se ha añadido {{title}} a {{channel}}",
           "addingVideo": "Añadiendo vídeo al canal…",
@@ -2548,9 +2548,11 @@
       "placeCard": {
         "addFavorite": "Añadir a Favoritos",
         "close": "Cerrar tarjeta de lugar",
+        "directions": "Directions",
         "favorite": "Favorito",
         "favorited": "En favoritos",
         "home": "Casa",
+        "openDirections": "Get directions in Apple Maps",
         "regionLabel": "Lugar seleccionado",
         "removeFavorite": "Eliminar de Favoritos",
         "setHome": "Establecer como Casa",

--- a/src/lib/locales/fr/translation.json
+++ b/src/lib/locales/fr/translation.json
@@ -1110,8 +1110,8 @@
         "switchingTheme": "Changement de thème…",
         "textNotFound": "Texte introuvable",
         "toggledIpodPlayback": "Lecture iPod basculée",
-        "toolExecutionFailed": "Échec de l'exécution de l'outil",
         "toolAttempted": "{{toolName}} tenté",
+        "toolExecutionFailed": "Échec de l'exécution de l'outil",
         "tv": {
           "addedVideo": "Ajouté {{title}} à {{channel}}",
           "addingVideo": "Ajout de la vidéo à la chaîne…",
@@ -2548,9 +2548,11 @@
       "placeCard": {
         "addFavorite": "Ajouter aux favoris",
         "close": "Fermer la fiche du lieu",
+        "directions": "Directions",
         "favorite": "Favori",
         "favorited": "Ajouté aux favoris",
         "home": "Domicile",
+        "openDirections": "Get directions in Apple Maps",
         "regionLabel": "Lieu sélectionné",
         "removeFavorite": "Supprimer des favoris",
         "setHome": "Définir comme domicile",

--- a/src/lib/locales/it/translation.json
+++ b/src/lib/locales/it/translation.json
@@ -1110,8 +1110,8 @@
         "switchingTheme": "Cambio tema…",
         "textNotFound": "Testo non trovato",
         "toggledIpodPlayback": "Stato riproduzione iPod modificato",
-        "toolExecutionFailed": "Esecuzione strumento fallita",
         "toolAttempted": "{{toolName}} tentato",
+        "toolExecutionFailed": "Esecuzione strumento fallita",
         "tv": {
           "addedVideo": "Aggiunto {{title}} a {{channel}}",
           "addingVideo": "Aggiunta video al canale…",
@@ -2548,9 +2548,11 @@
       "placeCard": {
         "addFavorite": "Aggiungi ai preferiti",
         "close": "Chiudi scheda del luogo",
+        "directions": "Directions",
         "favorite": "Preferito",
         "favorited": "Aggiunto ai preferiti",
         "home": "Casa",
+        "openDirections": "Get directions in Apple Maps",
         "regionLabel": "Luogo selezionato",
         "removeFavorite": "Rimuovi dai preferiti",
         "setHome": "Imposta come Casa",

--- a/src/lib/locales/ja/translation.json
+++ b/src/lib/locales/ja/translation.json
@@ -1110,8 +1110,8 @@
         "switchingTheme": "テーマを切り替え中…",
         "textNotFound": "テキストが見つかりませんでした",
         "toggledIpodPlayback": "iPod の再生を切り替えました",
-        "toolExecutionFailed": "ツールの実行に失敗しました",
         "toolAttempted": "{{toolName}} を試行しました",
+        "toolExecutionFailed": "ツールの実行に失敗しました",
         "tv": {
           "addedVideo": "{{title}}を{{channel}}に追加しました",
           "addingVideo": "チャンネルに動画を追加中…",
@@ -2548,9 +2548,11 @@
       "placeCard": {
         "addFavorite": "よく使う項目に追加",
         "close": "場所のカードを閉じる",
+        "directions": "Directions",
         "favorite": "よく使う項目",
         "favorited": "よく使う項目に追加済み",
         "home": "自宅",
+        "openDirections": "Get directions in Apple Maps",
         "regionLabel": "選択中の場所",
         "removeFavorite": "よく使う項目から削除",
         "setHome": "自宅に設定",

--- a/src/lib/locales/ko/translation.json
+++ b/src/lib/locales/ko/translation.json
@@ -1110,8 +1110,8 @@
         "switchingTheme": "테마 전환 중…",
         "textNotFound": "텍스트를 찾을 수 없음",
         "toggledIpodPlayback": "iPod 재생 전환됨",
-        "toolExecutionFailed": "도구 실행 실패",
         "toolAttempted": "{{toolName}} 시도됨",
+        "toolExecutionFailed": "도구 실행 실패",
         "tv": {
           "addedVideo": "{{channel}}에 {{title}}을(를) 추가했습니다",
           "addingVideo": "채널에 동영상 추가 중…",
@@ -2548,9 +2548,11 @@
       "placeCard": {
         "addFavorite": "즐겨찾기에 추가",
         "close": "장소 카드 닫기",
+        "directions": "Directions",
         "favorite": "즐겨찾기",
         "favorited": "즐겨찾기에 추가됨",
         "home": "집",
+        "openDirections": "Get directions in Apple Maps",
         "regionLabel": "선택된 장소",
         "removeFavorite": "즐겨찾기에서 제거",
         "setHome": "집으로 설정",

--- a/src/lib/locales/pt/translation.json
+++ b/src/lib/locales/pt/translation.json
@@ -1110,8 +1110,8 @@
         "switchingTheme": "Trocando tema…",
         "textNotFound": "Texto não encontrado",
         "toggledIpodPlayback": "Alternou a reprodução do iPod",
-        "toolExecutionFailed": "Falha na execução da ferramenta",
         "toolAttempted": "{{toolName}} tentado",
+        "toolExecutionFailed": "Falha na execução da ferramenta",
         "tv": {
           "addedVideo": "Adicionado {{title}} a {{channel}}",
           "addingVideo": "Adicionando vídeo ao canal…",
@@ -2548,9 +2548,11 @@
       "placeCard": {
         "addFavorite": "Adicionar aos Favoritos",
         "close": "Fechar cartão do local",
+        "directions": "Directions",
         "favorite": "Favorito",
         "favorited": "Favoritado",
         "home": "Casa",
+        "openDirections": "Get directions in Apple Maps",
         "regionLabel": "Local selecionado",
         "removeFavorite": "Remover dos Favoritos",
         "setHome": "Definir como Casa",

--- a/src/lib/locales/ru/translation.json
+++ b/src/lib/locales/ru/translation.json
@@ -1110,8 +1110,8 @@
         "switchingTheme": "Переключение темы…",
         "textNotFound": "Текст не найден",
         "toggledIpodPlayback": "Переключено воспроизведение iPod",
-        "toolExecutionFailed": "Ошибка выполнения инструмента",
         "toolAttempted": "{{toolName}} — попытка выполнена",
+        "toolExecutionFailed": "Ошибка выполнения инструмента",
         "tv": {
           "addedVideo": "Добавлено «{{title}}» в «{{channel}}»",
           "addingVideo": "Добавление видео в канал…",
@@ -2548,9 +2548,11 @@
       "placeCard": {
         "addFavorite": "Добавить в избранное",
         "close": "Закрыть карточку места",
+        "directions": "Directions",
         "favorite": "Избранное",
         "favorited": "В избранном",
         "home": "Дом",
+        "openDirections": "Get directions in Apple Maps",
         "regionLabel": "Выбранное место",
         "removeFavorite": "Удалить из избранного",
         "setHome": "Сделать домом",

--- a/src/lib/locales/zh-TW/translation.json
+++ b/src/lib/locales/zh-TW/translation.json
@@ -1110,8 +1110,8 @@
         "switchingTheme": "切換主題…",
         "textNotFound": "找不到文字",
         "toggledIpodPlayback": "切換 iPod 播放",
-        "toolExecutionFailed": "工具執行失敗",
         "toolAttempted": "已嘗試 {{toolName}}",
+        "toolExecutionFailed": "工具執行失敗",
         "tv": {
           "addedVideo": "已將 {{title}} 新增至 {{channel}}",
           "addingVideo": "正在將影片新增至頻道…",
@@ -2548,9 +2548,11 @@
       "placeCard": {
         "addFavorite": "加入最愛",
         "close": "關閉地點卡",
+        "directions": "Directions",
         "favorite": "最愛",
         "favorited": "已加入最愛",
         "home": "住家",
+        "openDirections": "Get directions in Apple Maps",
         "regionLabel": "已選取的地點",
         "removeFavorite": "從最愛移除",
         "setHome": "設為住家",

--- a/tests/test-apple-maps-links.test.ts
+++ b/tests/test-apple-maps-links.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, test } from "bun:test";
+import { buildAppleMapsDrivingDirectionsUrl } from "../src/apps/maps/utils/appleMapsLinks";
+
+describe("buildAppleMapsDrivingDirectionsUrl", () => {
+  test("builds driving directions URL with daddr and dirflg", () => {
+    const url = buildAppleMapsDrivingDirectionsUrl(37.3349, -122.009);
+    expect(url).toBe(
+      "https://maps.apple.com/?daddr=37.3349%2C-122.009&dirflg=d"
+    );
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a **Directions** action to the Maps place card (Apple Maps driving directions).

**Follow-up:** Home / Work buttons only appear when that slot is empty **or** when viewing that saved pin (`savedHomePlace` / `savedWorkPlace`), so “Set as …” is hidden once assigned elsewhere until you open that location.

## Changes

- `MapsPlaceCard`: Directions button + conditional Home/Work visibility.
- `MapsAppComponent`: passes store `home`/`work`; directions handler.
- `buildAppleMapsDrivingDirectionsUrl` helper + unit test.
- i18n for directions.

## Testing

- `bun test tests/test-apple-maps-links.test.ts`
- `bun run build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c4674166-8e7c-4870-ab4d-5fc158430767"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c4674166-8e7c-4870-ab4d-5fc158430767"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

