### PR TITLE
fix(maps): open directions in same tab

### DIFF
--- a/src/apps/maps/components/MapsAppComponent.tsx
+++ b/src/apps/maps/components/MapsAppComponent.tsx
@@ -780,7 +780,7 @@ export function MapsAppComponent({
       place.latitude,
       place.longitude
     );
-    window.open(url, "_blank", "noopener,noreferrer");
+    window.location.assign(url);
   }, []);
 
   const handleToggleFavorite = useCallback(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
The Maps place card "Directions" action used `window.open` with `_blank`, which opened Apple Maps in a new browser tab. It now navigates the current tab with `window.location.assign` so there is no new tab / implicit `target="_blank"` behavior.

## Testing
- `bun run build` (tsc + vite) passed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f09c5116-5532-40f5-8c90-8bfd36797849"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f09c5116-5532-40f5-8c90-8bfd36797849"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

