### PR TITLE
tv: refactor TvVideoDrawer to delegate fully to shared AppDrawer

### DIFF
--- a/src/apps/tv/components/TvVideoDrawer.tsx
+++ b/src/apps/tv/components/TvVideoDrawer.tsx
@@ -1,31 +1,12 @@
 import { memo, useEffect, useMemo, useRef } from "react";
-import { motion } from "framer-motion";
 import { useTranslation } from "react-i18next";
 import { cn } from "@/lib/utils";
 import { getChannelLogo, type Channel } from "@/apps/tv/data/channels";
 import { useThemeStore } from "@/stores/useThemeStore";
-import { useMediaQuery } from "@/hooks/useMediaQuery";
 import { useIsMobile } from "@/hooks/useIsMobile";
 import { useSound, Sounds } from "@/hooks/useSound";
 import { Trash } from "@phosphor-icons/react";
 import { AppDrawer, DRAWER_WIDTH, DRAWER_TRANSITION } from "@/components/shared/AppDrawer";
-
-// ── Layout constants ──────────────────────────────────────────────────────────
-
-/** Viewports below this width use a bottom sheet instead of a side drawer. */
-const COMPACT_DRAWER_MEDIA = "(max-width: 767px)";
-
-/** Horizontal inset for the compact bottom drawer (each side). */
-const COMPACT_DRAWER_INSET_PX = 12;
-
-/**
- * Negative overlap upward so the drawer covers the window body's bottom inset.
- * Matches macOS brushed-metal `mb-[8px]` on the TV window content in WindowFrame.
- */
-const COMPACT_DRAWER_OVERLAP_TOP_PX = -8;
-
-/** Compact drawer height cap — scroll inside for long playlists. */
-const COMPACT_DRAWER_MAX_HEIGHT = "min(30dvh, 216px)";
 
 // Re-export so callers that previously imported from this module still work.
 export { DRAWER_WIDTH, DRAWER_TRANSITION };
@@ -175,16 +156,14 @@ interface TvVideoDrawerProps {
 }
 
 /**
- * Classic Mac-OS-X-style drawer attached to the right edge of the TV window.
+ * Classic Mac-OS-X-style drawer attached to the TV window.
  *
- * Desktop (≥ 768 px):  delegates to the shared AppDrawer component (side
- * panel, slides right).  The TV-specific brushed-metal shell is handled by
- * AppDrawer; this component only supplies the channel strip + video list.
+ * Delegates all positioning, animation, and themed shell rendering to the
+ * shared `AppDrawer` component. This keeps the TV drawer in lockstep with
+ * other in-window drawers (Calendar, Maps), including the overflow-aware
+ * "try opposite side, then reposition / resize the host window" behaviour.
  *
- * Narrow (< 768 px):   renders a compact bottom sheet that hangs below the
- * window frame and slides down to reveal.  That layout is too TV-specific
- * (hangs outside the window, overlaps the bottom edge) for a shared component,
- * so it is implemented locally with its own motion.div.
+ * This component only supplies the channel logo strip and the video list.
  */
 export const TvVideoDrawer = memo(function TvVideoDrawer({
   isOpen,
@@ -197,7 +176,6 @@ export const TvVideoDrawer = memo(function TvVideoDrawer({
   onRemoveVideo,
 }: TvVideoDrawerProps) {
   const { t } = useTranslation();
-  const isCompactDrawer = useMediaQuery(COMPACT_DRAWER_MEDIA);
   const isMobileUi = useIsMobile();
   const showTrashAlways = isMobileUi;
   const currentTheme = useThemeStore((s) => s.current);
@@ -360,74 +338,13 @@ export const TvVideoDrawer = memo(function TvVideoDrawer({
       })
     );
 
-  // ── Content (shared between side and compact paths) ────────────────────────
-  const drawerContent = (
-    <>
+  return (
+    <AppDrawer isOpen={isOpen} data-tv-drawer>
       {channelLogoStrip}
       <ul ref={listRef} className={listUlClass} aria-label={listAriaLabel}>
         {isMacOSTheme ? renderMacVideoItems() : renderOtherVideoItems()}
       </ul>
-    </>
-  );
-
-  // ── Desktop side drawer — delegates to shared AppDrawer ───────────────────
-  // AppDrawer owns positioning, spring animation, and the themed panel shell.
-  // The TV passes its channel strip + video list as children.
-  if (!isCompactDrawer) {
-    return (
-      <AppDrawer isOpen={isOpen} data-tv-drawer data-tv-drawer-layout="side">
-        {drawerContent}
-      </AppDrawer>
-    );
-  }
-
-  // ── Compact bottom sheet (narrow viewports) ───────────────────────────────
-  // This layout hangs *below* the window frame (top: 100 %) and slides down
-  // to reveal.  That positioning is too TV-specific for the shared AppDrawer,
-  // so it is implemented with its own motion.div.
-  const compactPanelClass = cn(
-    "flex flex-1 flex-col overflow-hidden min-h-0",
-    isMacOSTheme && "tv-drawer-metal rounded-b-[0.45rem]",
-    !isMacOSTheme && isSystem7 && "bg-white border-2 border-black border-t-0 rounded-b shadow-[2px_4px_0_0_rgba(0,0,0,0.45)]",
-    !isMacOSTheme && isXpTheme && !isWin98 && "bg-[#ECE9D8] border-[3px] border-t-0 border-[#0054E3] rounded-b-[0.5rem]",
-    !isMacOSTheme && isWin98 && "bg-[#C0C0C0] border-2 border-t-0 border-l-white border-r-[#808080] border-b-[#808080]"
-  );
-
-  return (
-    <motion.div
-      className={cn("absolute select-none flex flex-col", !isOpen && "pointer-events-none")}
-      style={{
-        left: COMPACT_DRAWER_INSET_PX,
-        right: COMPACT_DRAWER_INSET_PX,
-        top: "100%",
-        bottom: "auto",
-        maxHeight: COMPACT_DRAWER_MAX_HEIGHT,
-        height: "auto",
-        zIndex: 0,
-        marginTop: COMPACT_DRAWER_OVERLAP_TOP_PX,
-        paddingBottom: "max(0px, env(safe-area-inset-bottom, 0px))",
-      }}
-      initial={false}
-      animate={{ x: 0, y: isOpen ? 0 : "-100%", opacity: isOpen ? 1 : 0 }}
-      transition={DRAWER_TRANSITION}
-      aria-hidden={!isOpen}
-      data-tv-drawer
-      data-tv-drawer-layout="bottom"
-    >
-      <div className={compactPanelClass}>
-        {isMacOSTheme ? (
-          <div className="tv-drawer-metal-inner flex flex-1 min-h-0 flex-col p-2">
-            <div className="tv-drawer-mac-list-well flex flex-1 min-h-0 flex-col overflow-hidden" style={{ borderRadius: "0 0 4px 4px" }}>
-              {drawerContent}
-            </div>
-          </div>
-        ) : (
-          <div className="flex flex-1 min-h-0 flex-col overflow-hidden p-2">
-            {drawerContent}
-          </div>
-        )}
-      </div>
-    </motion.div>
+    </AppDrawer>
   );
 });
 

--- a/src/styles/themes.css
+++ b/src/styles/themes.css
@@ -342,18 +342,6 @@
     inset 0 -1px 0 rgba(255, 255, 255, 0.08) !important;
 }
 
-/* TV app video drawer — brushed aluminum shell matching window-material-brushedmetal */
-:root[data-os-theme="macosx"] .tv-drawer-metal {
-  background: none !important;
-  position: relative;
-  border-radius: 0 0.45rem 0.45rem 0 !important;
-  border: 0.5px solid rgba(0, 0, 0, 0.5) !important;
-  box-shadow:
-    0 8px 22px rgba(0, 0, 0, 0.38),
-    inset 0 1px 0 rgba(255, 255, 255, 0.38),
-    inset 0 -1px 0 rgba(255, 255, 255, 0.1);
-}
-
 /* Generic shared side-drawer panel — same aluminum shell used by AppDrawer */
 :root[data-os-theme="macosx"] .os-drawer-metal {
   background: none !important;
@@ -389,26 +377,6 @@
     inset 0 -1px 0 rgba(255, 255, 255, 0.1);
 }
 
-/* Narrow viewports: playlist hangs below the window; round bottom corners only */
-:root[data-os-theme="macosx"] [data-tv-drawer-layout="bottom"] .tv-drawer-metal {
-  border-radius: 0 0 0.45rem 0.45rem !important;
-  box-shadow:
-    0 10px 22px rgba(0, 0, 0, 0.34),
-    inset 0 1px 0 rgba(255, 255, 255, 0.38),
-    inset 0 -1px 0 rgba(255, 255, 255, 0.1);
-}
-
-:root[data-os-theme="macosx"] .tv-drawer-metal::before {
-  content: "";
-  position: absolute;
-  inset: 0;
-  background: url("/assets/brushed-metal.jpg") center / cover no-repeat;
-  filter: contrast(0.7) brightness(1.1);
-  border-radius: inherit;
-  pointer-events: none;
-  z-index: 0;
-}
-
 :root[data-os-theme="macosx"] .os-drawer-metal::before {
   content: "";
   position: absolute;
@@ -418,21 +386,6 @@
   border-radius: inherit;
   pointer-events: none;
   z-index: 0;
-}
-
-:root[data-os-theme="macosx"] .tv-drawer-metal::after {
-  content: "";
-  position: absolute;
-  inset: 0;
-  border-radius: inherit;
-  box-shadow:
-    inset 0 2px 2px rgba(255, 255, 255, 0.65),
-    inset 0 8px 12px rgba(255, 255, 255, 0.1),
-    inset 0 -1px 0 rgba(255, 255, 255, 0.12),
-    inset 1px 0 0 rgba(255, 255, 255, 0.14),
-    inset -1px 0 0 rgba(255, 255, 255, 0.12);
-  z-index: 2;
-  pointer-events: none;
 }
 
 :root[data-os-theme="macosx"] .os-drawer-metal::after {
@@ -450,25 +403,9 @@
   pointer-events: none;
 }
 
-:root[data-os-theme="macosx"] .tv-drawer-metal > .tv-drawer-metal-inner {
-  position: relative;
-  z-index: 3;
-}
-
 :root[data-os-theme="macosx"] .os-drawer-metal > .os-drawer-metal-inner {
   position: relative;
   z-index: 3;
-}
-
-/* Recessed list inside brushed-metal drawer (Tiger-era inset field) */
-:root[data-os-theme="macosx"] .tv-drawer-mac-list-well {
-  border-radius: 4px;
-  border: 1px solid rgba(0, 0, 0, 0.38);
-  background: #fff;
-  box-shadow:
-    inset 0 1px 2px rgba(0, 0, 0, 0.22),
-    inset 0 0 1px rgba(0, 0, 0, 0.12),
-    0 1px 0 rgba(255, 255, 255, 0.5);
 }
 
 /* Recessed list inside generic os-drawer-metal panel */
@@ -493,16 +430,6 @@
 }
 :root[data-os-theme="macosx"] .os-drawer-list-well[data-placement="top"] {
   border-radius: 4px 4px 0 0;
-}
-
-/* Side drawer: square inner edge (left) toward the main window; round outward corners only */
-:root[data-os-theme="macosx"] [data-tv-drawer-layout="side"] .tv-drawer-mac-list-well {
-  border-radius: 0 4px 4px 0;
-}
-
-/* Compact bottom drawer: square top of well (flush under overlap); round bottom only */
-:root[data-os-theme="macosx"] [data-tv-drawer-layout="bottom"] .tv-drawer-mac-list-well {
-  border-radius: 0 0 4px 4px;
 }
 
 :root[data-os-theme="macosx"] .tv-drawer-mac-row-active {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

`TvVideoDrawer` had its own compact (mobile) bottom-sheet implementation with a local `motion.div`, motion constants, and a TV-specific brushed-metal CSS shell (`.tv-drawer-metal*`, `.tv-drawer-mac-list-well`, `[data-tv-drawer-layout=*]`).

Because that path bypassed `AppDrawer`, it didn't pick up the overflow-aware layout logic (try opposite side → reposition window → resize window) introduced in #1123, so on small viewports the playlist could overflow off-screen.

## What

Drop the local compact path entirely and always render through the shared `AppDrawer`, which now owns:

- side / bottom / top / left placement (driven by viewport fit)
- spring animation
- macOS Aqua brushed-metal shell + recessed list well
- automatic window reposition / resize when expansion would overflow

The TV component now only supplies the channel logo strip and the video list as `AppDrawer` children.

### Cleanup

- Removed local constants (`COMPACT_DRAWER_MEDIA`, `COMPACT_DRAWER_INSET_PX`, `COMPACT_DRAWER_OVERLAP_TOP_PX`, `COMPACT_DRAWER_MAX_HEIGHT`) and now-unused `useMediaQuery` / `motion` imports.
- Removed dead CSS: `.tv-drawer-metal`, `.tv-drawer-metal::before/::after`, `.tv-drawer-metal-inner`, `.tv-drawer-mac-list-well`, and the `[data-tv-drawer-layout="side"|"bottom"]` rules.
- Kept `.tv-drawer-mac-row-active` (still used by row styling) and the `[data-tv-drawer] button` compact-row override (still applied because `TvVideoDrawer` forwards `data-tv-drawer` through to `AppDrawer`).

Net diff: **+9 / −165 lines**.

## Behavioural impact

- **Mobile TV drawer now resizes / repositions correctly** when it would overflow (the bug being fixed). It also gains the new "fall back to top sheet" path inherited from `AppDrawer` automatically.
- **Desktop TV drawer behaves identically** to before (it was already delegating to `AppDrawer`).

## Testing

- ✅ `bun run build` — succeeds (`built in 15.76s`).
- ✅ `bun run test:unit` — 155 pass / 0 fail.
- ✅ `bun run lint` — no new warnings or errors in touched files (same pre-existing 11 warnings codebase-wide).

Manual UI verification was skipped per the AGENTS.md cloud guidance ("For most changes, `bun run build` is sufficient"). The code is a pure delegation refactor — all rendering now goes through the already-tested `AppDrawer` path.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e2628b76-b6f2-49e0-8634-4e648d75cf90"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e2628b76-b6f2-49e0-8634-4e648d75cf90"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

