### PR TITLE
fix(telegram): plain-text Cursor agent completion DMs

### DIFF
--- a/api/chat/tools/cursor-repo-agent.ts
+++ b/api/chat/tools/cursor-repo-agent.ts
@@ -7,6 +7,7 @@
 import type { Redis } from "../../_utils/redis.js";
 import { z } from "zod";
 import type { MemoryToolContext } from "./executors.js";
+import { simplifyTelegramCitationDisplay } from "../../_utils/telegram-format.js";
 import { sendTelegramMessage } from "../../_utils/telegram.js";
 
 export const CURSOR_REPO_AGENT_OWNER = "ryo";
@@ -118,7 +119,10 @@ export function formatCursorRunCompletionTelegramMessage(input: {
   error?: string;
 }): string {
   const { ok, agentTitle, status, summary, error } = input;
-  const titleSuffix = agentTitle ? ` — ${agentTitle}` : "";
+  const titleForSuffix = agentTitle?.trim()
+    ? simplifyTelegramCitationDisplay(agentTitle)
+    : "";
+  const titleSuffix = titleForSuffix ? ` — ${titleForSuffix}` : "";
   const headline = ok
     ? `Cursor agent done${titleSuffix}`
     : `Cursor agent failed${titleSuffix}`;
@@ -133,11 +137,12 @@ export function formatCursorRunCompletionTelegramMessage(input: {
       ? `failed: ${status}`
       : "failed";
 
-  const body = rawBody.length > 0 ? rawBody : fallback;
+  const bodySource = rawBody.length > 0 ? rawBody : fallback;
+  const bodyPlain = simplifyTelegramCitationDisplay(bodySource);
   const truncated =
-    body.length > TELEGRAM_NOTIFY_MAX_BODY_CHARS
-      ? `${body.slice(0, TELEGRAM_NOTIFY_MAX_BODY_CHARS)}\n…(truncated)`
-      : body;
+    bodyPlain.length > TELEGRAM_NOTIFY_MAX_BODY_CHARS
+      ? `${bodyPlain.slice(0, TELEGRAM_NOTIFY_MAX_BODY_CHARS)}\n…(truncated)`
+      : bodyPlain;
 
   return `${headline}\n\n${truncated}`;
 }

--- a/docs/4-ai-system.md
+++ b/docs/4-ai-system.md
@@ -132,6 +132,7 @@ Shared conversation preparation lives in `api/_utils/ryo-conversation.ts`:
 - `prepareRyoConversationModelInput()` - Unified entry point for both web chat and Telegram channels
 - Assembles static system prompt, dynamic context (memories, daily notes, system state), and tools
 - Handles model selection, message enrichment, and OpenAI web search injection
+- Cursor Cloud agent completion notifications sent to Telegram (`formatCursorRunCompletionTelegramMessage` in `api/chat/tools/cursor-repo-agent.ts`) run the summary and title through `simplifyTelegramCitationDisplay` in `api/_utils/telegram-format.ts` so DMs stay plain text; web chat / polling still use the raw summary.
 
 ### Tool schema highlights
 

--- a/docs/9-changelog.md
+++ b/docs/9-changelog.md
@@ -6,6 +6,7 @@ A summary of changes and updates to ryOS, organized by month.
 
 ## May 2026
 
+- Cursor Cloud agent **done / failed** Telegram notifications strip markdown (headings, bullets, emphasis, code fences, links) to plain text via shared `telegram-format` helpers; web surfaces keep richer run summaries unchanged.
 - Expand **Virtual PC** beyond DOS games: integrate the **v86 x86 emulator** with an OS browser (Windows 1.0–2000/ME, FreeDOS, MS-DOS, Windows 95/98, ReactOS, Haiku, BeOS, Serenity, KolibriOS, FreeBSD/NetBSD/OpenBSD, Linux 2.6/4.x, Arch, Buildroot, MikeOS, MINIX, Fiwix, HelenOS, Oberon, Redox, SolOS, doof, DSL), persisted preset selection, COEP-enabled `/embed/pc.html` route, generated thumbnails, and full UI localization. Renames the app id from `infinite-pc` to `pc` with a legacy alias.
 - Add **Cursor agents** admin tab backed by Redis run metadata: dashboard server card, panel headers, agent counts, relaxed admin rate limits, sidebar/View menu reordering, and improved follow-up UX (Space-key fix, polished submit button).
 - Add **Aquarium** dashboard widget alongside the existing 8 widgets.

--- a/tests/test-cursor-repo-agent-tool.test.ts
+++ b/tests/test-cursor-repo-agent-tool.test.ts
@@ -93,6 +93,24 @@ describe("formatCursorRunCompletionTelegramMessage", () => {
     expect(text.length).toBeLessThanOrEqual(3700);
     expect(text).toContain("…(truncated)");
   });
+
+  test("strips markdown from summary and title for Telegram plain text", () => {
+    const text = formatCursorRunCompletionTelegramMessage({
+      ok: true,
+      agentTitle: "**Fix** bug",
+      summary:
+        "## Done\n- item\n[`code`](https://example.com)\n```\nblock\n```",
+    });
+    expect(text.startsWith("Cursor agent done — Fix bug")).toBe(true);
+    expect(text).toContain("Done");
+    expect(text).toContain("• item");
+    expect(text).toContain("code");
+    expect(text).not.toContain("example.com");
+    expect(text).toContain("block");
+    expect(text).not.toContain("**");
+    expect(text).not.toContain("## ");
+    expect(text).not.toContain("```");
+  });
 });
 
 describe("pickPrUrlFromRunGit", () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Cursor Cloud agent done/failed Telegram notifications now run the summary (or error fallback), optional agent title, and body through `simplifyTelegramCitationDisplay` so markdown is removed or converted to readable plain text. Web chat and Redis run metadata are unchanged.

Tests: `bun test tests/test-cursor-repo-agent-tool.test.ts` (new markdown-stripping case); `bun run build`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-84acc384-4bf0-4763-b780-804875c11887"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-84acc384-4bf0-4763-b780-804875c11887"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

