### PR TITLE
feat(calendar): restore to-do sidebar; use tray for event/to-do details

### DIFF
--- a/src/apps/calendar/components/CalendarAppComponent.tsx
+++ b/src/apps/calendar/components/CalendarAppComponent.tsx
@@ -21,6 +21,7 @@ import { CaretLeft, CaretRight, Plus, ListChecks, Trash, SidebarSimple, Calendar
 import { SearchInput } from "@/components/ui/search-input";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
+import { useCalendarStore } from "@/stores/useCalendarStore";
 import type { CalendarEvent, CalendarGroup, TodoItem } from "@/stores/useCalendarStore";
 import { useChatsStore } from "@/stores/useChatsStore";
 import { useCloudSyncStore } from "@/stores/useCloudSyncStore";
@@ -29,6 +30,7 @@ import { useTranslation } from "react-i18next";
 import { AquaCheckbox } from "@/components/ui/aqua-checkbox";
 import { AppDrawer } from "@/components/shared/AppDrawer";
 import { useSound, Sounds } from "@/hooks/useSound";
+import { TrayDetails } from "./TrayDetails";
 
 // ============================================================================
 // CONSTANTS
@@ -138,6 +140,8 @@ function TodoSidebar({
   isSystem7Theme,
   fullWidth,
   noHeader,
+  selectedTodoId,
+  onSelectTodo,
 }: {
   todos: TodoItem[];
   calendars: CalendarGroup[];
@@ -152,6 +156,8 @@ function TodoSidebar({
   isSystem7Theme: boolean;
   fullWidth?: boolean;
   noHeader?: boolean;
+  selectedTodoId?: string | null;
+  onSelectTodo?: (id: string) => void;
 }) {
   const { t } = useTranslation();
   const useGeneva = isMacOSTheme || isSystem7Theme;
@@ -246,8 +252,15 @@ function TodoSidebar({
         {todos.map((todo) => {
           const cal = calendars.find((c) => c.id === todo.calendarId);
           const isEditing = editingTodoId === todo.id;
+          const isSelected = selectedTodoId === todo.id;
           return (
-            <div key={todo.id} className="group relative flex items-start gap-1.5 px-0.5 py-1 min-h-[30px]">
+            <div
+              key={todo.id}
+              className={cn(
+                "group relative flex items-start gap-1.5 px-0.5 py-1 min-h-[30px] rounded-sm",
+                isSelected && (isMacOSTheme ? "bg-black/[0.06]" : "bg-black/[0.05]")
+              )}
+            >
               <button type="button" onClick={() => onToggle(todo.id)} className="shrink-0 mt-[3px]">
                 <AquaCheckbox checked={todo.completed} color={EVENT_COLOR_MAP[cal?.color || "blue"]} />
               </button>
@@ -273,7 +286,16 @@ function TodoSidebar({
               ) : (
                 <button
                   type="button"
-                  onClick={() => startEditingTodo(todo)}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    if (isSelected) {
+                      startEditingTodo(todo);
+                    } else if (onSelectTodo) {
+                      onSelectTodo(todo.id);
+                    } else {
+                      startEditingTodo(todo);
+                    }
+                  }}
                   className={cn(
                     todoTitleFieldClass,
                     "text-left border-transparent bg-transparent",
@@ -1166,10 +1188,12 @@ export function CalendarAppComponent({
     calendars, toggleCalendarVisibility,
     todos, addTodo, toggleTodo, updateTodo, deleteTodo, showTodoSidebar, setShowTodoSidebar,
     navigateMonth, navigateWeek, goToToday, setView, setSelectedDate,
-    handleDateClick, handleDateDoubleClick, handleNewEvent, handleNewEventAtTime, handleEditEvent, handleSaveEvent, handleEditSelectedEvent, handleDeleteSelectedEvent, handleDeleteEditingEvent,
+    handleDateClick, handleDateDoubleClick, handleNewEvent, handleNewEventAtTime, handleEditEvent, handleSaveEvent, handleEditSelectedEvent, handleDeleteSelectedEvent, handleDeleteEditingEvent, handleUpdateEvent,
     fileInputRef, handleImport, handleFileSelected, handleExport,
     undoCalendar, redoCalendar, canUndo, canRedo,
   } = logic;
+
+  const events = useCalendarStore((s) => s.events);
 
   useRegisterUndoRedo(instanceId!, {
     undo: undoCalendar,
@@ -1177,6 +1201,50 @@ export function CalendarAppComponent({
     canUndo,
     canRedo,
   });
+
+  // Selected todo (mirrors selectedEventId — drives the details tray).
+  const [selectedTodoId, setSelectedTodoId] = useState<string | null>(null);
+
+  // Resolve currently-selected event/todo for the tray.
+  const selectedEvent = useMemo(
+    () => (selectedEventId ? events.find((e) => e.id === selectedEventId) || null : null),
+    [selectedEventId, events]
+  );
+  const selectedTodo = useMemo(
+    () => (selectedTodoId ? todos.find((t) => t.id === selectedTodoId) || null : null),
+    [selectedTodoId, todos]
+  );
+
+  // Open the details tray whenever something is selected; close otherwise.
+  const showTrayDrawer = !!(selectedEvent || selectedTodo);
+
+  // Selecting an event clears any selected todo and vice versa so only one
+  // detail panel shows at a time.
+  const handleSelectEvent = useCallback((id: string) => {
+    setSelectedTodoId(null);
+    setSelectedEventId(id);
+  }, [setSelectedEventId]);
+
+  const handleSelectTodo = useCallback((id: string) => {
+    setSelectedEventId(null);
+    setSelectedTodoId(id);
+  }, [setSelectedEventId]);
+
+  const handleCloseTray = useCallback(() => {
+    setSelectedEventId(null);
+    setSelectedTodoId(null);
+  }, [setSelectedEventId]);
+
+  const handleDeleteEventFromTray = useCallback((id: string) => {
+    if (id === selectedEventId) {
+      handleDeleteSelectedEvent();
+    }
+  }, [selectedEventId, handleDeleteSelectedEvent]);
+
+  const handleDeleteTodoFromTray = useCallback((id: string) => {
+    deleteTodo(id);
+    if (id === selectedTodoId) setSelectedTodoId(null);
+  }, [deleteTodo, selectedTodoId]);
 
   // Drawer open/close sounds — same SFX as the TV drawer for consistency.
   const { play: playDrawerOpen } = useSound(Sounds.WINDOW_ZOOM_MAXIMIZE);
@@ -1187,9 +1255,9 @@ export function CalendarAppComponent({
       drawerSoundMountedRef.current = true;
       return;
     }
-    if (showTodoSidebar) void playDrawerOpen();
+    if (showTrayDrawer) void playDrawerOpen();
     else void playDrawerClose();
-  }, [showTodoSidebar, playDrawerOpen, playDrawerClose]);
+  }, [showTrayDrawer, playDrawerOpen, playDrawerClose]);
 
   const containerRef = useRef<HTMLDivElement>(null);
   const [containerWidth, setContainerWidth] = useState(700);
@@ -1207,6 +1275,8 @@ export function CalendarAppComponent({
 
   const isNarrow = containerWidth < 600;
   const showSidebar = containerWidth >= 540 && showCalendarSidebar;
+  const showTodo = showTodoSidebar && !isNarrow;
+  const showTodoFullWidth = showTodoSidebar && isNarrow;
   const effectiveView = view;
   const safeSearchQuery = searchQuery ?? "";
   const normalizedSearchQuery = useMemo(() => safeSearchQuery.trim().toLocaleLowerCase(), [safeSearchQuery]);
@@ -1231,7 +1301,15 @@ export function CalendarAppComponent({
     }
   }, [effectiveView, navigateWeek, navigateMonth, selectedDate, setSelectedDate]);
 
-  const headerLabel = effectiveView === "week" ? weekLabel : effectiveView === "day" ? selectedDateLabel : monthYearLabel;
+  const headerLabel = showTodoFullWidth
+    ? t("apps.calendar.sidebar.toDoItems")
+    : effectiveView === "week" ? weekLabel : effectiveView === "day" ? selectedDateLabel : monthYearLabel;
+
+  const trayTitle = selectedEvent
+    ? t("apps.calendar.tray.eventDetails")
+    : selectedTodo
+      ? t("apps.calendar.tray.todoDetails")
+      : "";
 
   const menuBar = (
     <CalendarMenuBar
@@ -1272,20 +1350,23 @@ export function CalendarAppComponent({
         windowConstraints={{ minWidth: 300, minHeight: 380 }}
         drawer={
           <AppDrawer
-            isOpen={showTodoSidebar}
-            title={t("apps.calendar.sidebar.toDoItems")}
+            isOpen={showTrayDrawer}
+            onClose={handleCloseTray}
+            title={trayTitle}
           >
-            <TodoSidebar
-              todos={todos}
+            <TrayDetails
+              selectedEvent={selectedEvent}
+              selectedTodo={selectedTodo}
               calendars={calendars}
-              onToggle={toggleTodo}
-              onAdd={addTodo}
-              onUpdate={updateTodo}
-              onDelete={deleteTodo}
               isMacOSTheme={isMacOSTheme}
               isSystem7Theme={isSystem7Theme}
-              fullWidth
-              noHeader
+              isXpTheme={isXpTheme}
+              onUpdateEvent={handleUpdateEvent}
+              onDeleteEvent={handleDeleteEventFromTray}
+              onEditEvent={handleEditEvent}
+              onUpdateTodo={updateTodo}
+              onToggleTodo={toggleTodo}
+              onDeleteTodo={handleDeleteTodoFromTray}
             />
           </AppDrawer>
         }
@@ -1369,35 +1450,84 @@ export function CalendarAppComponent({
               )
             )}
 
-            {/* Main calendar view */}
-            <div
-              className={cn("flex-1 flex overflow-hidden calendar-grid bg-white")}
-              style={isMacOSTheme ? {
-                border: "1px solid rgba(0, 0, 0, 0.55)",
-                boxShadow: "inset 0 1px 2px rgba(0, 0, 0, 0.25), 0 1px 0 rgba(255, 255, 255, 0.4)",
-              } : undefined}
-            >
-              {effectiveView === "week" && (
-                <WeekTimeGrid weekDates={weekDates} selectedEventId={selectedEventId}
-                  onDateClick={handleDateClick} onTimeSlotClick={handleNewEventAtTime}
-                  onEventClick={(ev) => setSelectedEventId(ev.id)} onEventDoubleClick={handleEditEvent}
-                  isXpTheme={isXpTheme} isMacOSTheme={isMacOSTheme} isSystem7Theme={isSystem7Theme} searchQuery={normalizedSearchQuery} hourLabels={hourLabels}
-                  hourHeight={weekTimeGridHourHeight} setHourHeight={setWeekTimeGridHourHeight} />
-              )}
-              {effectiveView === "day" && (
-                <DayTimeGrid date={selectedDate} events={selectedDateEvents} selectedEventId={selectedEventId}
-                  onTimeSlotClick={handleNewEventAtTime}
-                  onEventClick={(ev) => setSelectedEventId(ev.id)} onEventDoubleClick={handleEditEvent}
-                  isXpTheme={isXpTheme} isMacOSTheme={isMacOSTheme} isSystem7Theme={isSystem7Theme} searchQuery={normalizedSearchQuery} hourLabels={hourLabels}
-                  hourHeight={dayTimeGridHourHeight} setHourHeight={setDayTimeGridHourHeight} />
-              )}
-              {effectiveView === "month" && (
-                <MonthGrid calendarGrid={calendarGrid} selectedEventId={selectedEventId}
-                  onDateClick={handleDateClick} onDateDoubleClick={handleDateDoubleClick}
-                  onEventClick={(ev) => setSelectedEventId(ev.id)} onEventDoubleClick={handleEditEvent}
-                  isXpTheme={isXpTheme} searchQuery={normalizedSearchQuery} narrowDayNames={narrowDayNames} />
-              )}
-            </div>
+            {/* Main view area — hidden when todo is full-width on narrow screens */}
+            {!showTodoFullWidth && (
+              <div
+                className={cn("flex-1 flex overflow-hidden calendar-grid bg-white")}
+                style={isMacOSTheme ? {
+                  border: "1px solid rgba(0, 0, 0, 0.55)",
+                  boxShadow: "inset 0 1px 2px rgba(0, 0, 0, 0.25), 0 1px 0 rgba(255, 255, 255, 0.4)",
+                } : undefined}
+              >
+                {effectiveView === "week" && (
+                  <WeekTimeGrid weekDates={weekDates} selectedEventId={selectedEventId}
+                    onDateClick={handleDateClick} onTimeSlotClick={handleNewEventAtTime}
+                    onEventClick={(ev) => handleSelectEvent(ev.id)} onEventDoubleClick={handleEditEvent}
+                    isXpTheme={isXpTheme} isMacOSTheme={isMacOSTheme} isSystem7Theme={isSystem7Theme} searchQuery={normalizedSearchQuery} hourLabels={hourLabels}
+                    hourHeight={weekTimeGridHourHeight} setHourHeight={setWeekTimeGridHourHeight} />
+                )}
+                {effectiveView === "day" && (
+                  <DayTimeGrid date={selectedDate} events={selectedDateEvents} selectedEventId={selectedEventId}
+                    onTimeSlotClick={handleNewEventAtTime}
+                    onEventClick={(ev) => handleSelectEvent(ev.id)} onEventDoubleClick={handleEditEvent}
+                    isXpTheme={isXpTheme} isMacOSTheme={isMacOSTheme} isSystem7Theme={isSystem7Theme} searchQuery={normalizedSearchQuery} hourLabels={hourLabels}
+                    hourHeight={dayTimeGridHourHeight} setHourHeight={setDayTimeGridHourHeight} />
+                )}
+                {effectiveView === "month" && (
+                  <MonthGrid calendarGrid={calendarGrid} selectedEventId={selectedEventId}
+                    onDateClick={handleDateClick} onDateDoubleClick={handleDateDoubleClick}
+                    onEventClick={(ev) => handleSelectEvent(ev.id)} onEventDoubleClick={handleEditEvent}
+                    isXpTheme={isXpTheme} searchQuery={normalizedSearchQuery} narrowDayNames={narrowDayNames} />
+                )}
+              </div>
+            )}
+
+            {/* Todo: full-width on narrow screens, sidebar on wide */}
+            {showTodoFullWidth && (
+              <div
+                className="flex-1 overflow-y-auto bg-white"
+                style={isMacOSTheme ? {
+                  border: "1px solid rgba(0, 0, 0, 0.55)",
+                  boxShadow: "inset 0 1px 2px rgba(0, 0, 0, 0.25), 0 1px 0 rgba(255, 255, 255, 0.4)",
+                } : undefined}
+              >
+                <TodoSidebar
+                  todos={todos}
+                  calendars={calendars}
+                  onToggle={toggleTodo}
+                  onAdd={addTodo}
+                  onUpdate={updateTodo}
+                  onDelete={deleteTodo}
+                  isMacOSTheme={isMacOSTheme}
+                  isSystem7Theme={isSystem7Theme}
+                  fullWidth
+                  selectedTodoId={selectedTodoId}
+                  onSelectTodo={handleSelectTodo}
+                />
+              </div>
+            )}
+            {showTodo && (
+              <div
+                className="shrink-0 overflow-y-auto bg-white"
+                style={isMacOSTheme ? {
+                  border: "1px solid rgba(0, 0, 0, 0.55)",
+                  boxShadow: "inset 0 1px 2px rgba(0, 0, 0, 0.25), 0 1px 0 rgba(255, 255, 255, 0.4)",
+                } : { borderLeft: "1px solid rgba(0,0,0,0.08)" }}
+              >
+                <TodoSidebar
+                  todos={todos}
+                  calendars={calendars}
+                  onToggle={toggleTodo}
+                  onAdd={addTodo}
+                  onUpdate={updateTodo}
+                  onDelete={deleteTodo}
+                  isMacOSTheme={isMacOSTheme}
+                  isSystem7Theme={isSystem7Theme}
+                  selectedTodoId={selectedTodoId}
+                  onSelectTodo={handleSelectTodo}
+                />
+              </div>
+            )}
           </div>
 
           {/* Bottom toolbar */}

--- a/src/apps/calendar/components/TrayDetails.tsx
+++ b/src/apps/calendar/components/TrayDetails.tsx
@@ -1,0 +1,466 @@
+import { useEffect, useState, useRef } from "react";
+import { useTranslation } from "react-i18next";
+import { cn } from "@/lib/utils";
+import { Trash, PencilSimple } from "@phosphor-icons/react";
+import { Button } from "@/components/ui/button";
+import { AquaCheckbox } from "@/components/ui/aqua-checkbox";
+import type {
+  CalendarEvent,
+  CalendarGroup,
+  TodoItem,
+} from "@/stores/useCalendarStore";
+
+const EVENT_COLOR_MAP: Record<string, string> = {
+  blue: "#4A90D9",
+  red: "#D94A4A",
+  green: "#5AB55A",
+  orange: "#E89B3E",
+  purple: "#9B59B6",
+};
+
+interface TrayDetailsProps {
+  selectedEvent: CalendarEvent | null;
+  selectedTodo: TodoItem | null;
+  calendars: CalendarGroup[];
+  isMacOSTheme: boolean;
+  isSystem7Theme: boolean;
+  isXpTheme: boolean;
+  onUpdateEvent: (id: string, updates: Partial<CalendarEvent>) => void;
+  onDeleteEvent: (id: string) => void;
+  onEditEvent: (event: CalendarEvent) => void;
+  onUpdateTodo: (
+    id: string,
+    updates: Partial<Pick<TodoItem, "title" | "calendarId" | "dueDate" | "completed">>
+  ) => void;
+  onToggleTodo: (id: string) => void;
+  onDeleteTodo: (id: string) => void;
+}
+
+/**
+ * Format YYYY-MM-DD into a localized "long" date label.
+ */
+function formatDateLabel(dateStr: string, locale: string): string {
+  if (!dateStr) return "";
+  const [y, m, d] = dateStr.split("-").map(Number);
+  if (!y || !m || !d) return dateStr;
+  const date = new Date(y, m - 1, d);
+  return date.toLocaleDateString(locale, {
+    weekday: "long",
+    month: "long",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+export function TrayDetails({
+  selectedEvent,
+  selectedTodo,
+  calendars,
+  isMacOSTheme,
+  isSystem7Theme,
+  isXpTheme,
+  onUpdateEvent,
+  onDeleteEvent,
+  onEditEvent,
+  onUpdateTodo,
+  onToggleTodo,
+  onDeleteTodo,
+}: TrayDetailsProps) {
+  const { t, i18n } = useTranslation();
+  const useGeneva = isMacOSTheme || isSystem7Theme;
+
+  if (selectedEvent) {
+    return (
+      <EventDetails
+        event={selectedEvent}
+        calendars={calendars}
+        useGeneva={useGeneva}
+        isMacOSTheme={isMacOSTheme}
+        isXpTheme={isXpTheme}
+        locale={i18n.language}
+        t={t}
+        onUpdate={onUpdateEvent}
+        onDelete={onDeleteEvent}
+        onEditFull={onEditEvent}
+      />
+    );
+  }
+
+  if (selectedTodo) {
+    return (
+      <TodoDetails
+        todo={selectedTodo}
+        calendars={calendars}
+        useGeneva={useGeneva}
+        isMacOSTheme={isMacOSTheme}
+        isXpTheme={isXpTheme}
+        locale={i18n.language}
+        t={t}
+        onToggle={onToggleTodo}
+        onUpdate={onUpdateTodo}
+        onDelete={onDeleteTodo}
+      />
+    );
+  }
+
+  return (
+    <div
+      className={cn(
+        "flex-1 flex items-center justify-center text-center px-3 opacity-40 text-[11px]",
+        useGeneva && "font-geneva-12"
+      )}
+    >
+      {t("apps.calendar.tray.empty")}
+    </div>
+  );
+}
+
+// ============================================================================
+// EVENT DETAILS
+// ============================================================================
+
+function EventDetails({
+  event,
+  calendars,
+  useGeneva,
+  isMacOSTheme,
+  isXpTheme,
+  locale,
+  t,
+  onUpdate,
+  onDelete,
+  onEditFull,
+}: {
+  event: CalendarEvent;
+  calendars: CalendarGroup[];
+  useGeneva: boolean;
+  isMacOSTheme: boolean;
+  isXpTheme: boolean;
+  locale: string;
+  t: (key: string) => string;
+  onUpdate: (id: string, updates: Partial<CalendarEvent>) => void;
+  onDelete: (id: string) => void;
+  onEditFull: (event: CalendarEvent) => void;
+}) {
+  const [title, setTitle] = useState(event.title);
+  const [notes, setNotes] = useState(event.notes || "");
+  const lastEventIdRef = useRef(event.id);
+
+  useEffect(() => {
+    if (lastEventIdRef.current !== event.id) {
+      lastEventIdRef.current = event.id;
+      setTitle(event.title);
+      setNotes(event.notes || "");
+    }
+  }, [event.id, event.title, event.notes]);
+
+  const calendar = calendars.find((c) => c.id === event.calendarId) || calendars[0];
+  const color = EVENT_COLOR_MAP[event.color] || EVENT_COLOR_MAP.blue;
+
+  const commitTitle = () => {
+    const next = title.trim();
+    if (next && next !== event.title) {
+      onUpdate(event.id, { title: next });
+    } else if (!next) {
+      setTitle(event.title);
+    }
+  };
+
+  const commitNotes = () => {
+    if ((notes || "") !== (event.notes || "")) {
+      onUpdate(event.id, { notes: notes.trim() || undefined });
+    }
+  };
+
+  const inputBase = cn(
+    "w-full rounded border bg-white/90 outline-none px-1.5 py-0.5 text-[12px]",
+    useGeneva ? "border-black/20 font-geneva-12" : "border-black/15"
+  );
+
+  const labelClass = cn(
+    "block text-[9px] uppercase tracking-wide opacity-60 mb-0.5",
+    useGeneva && "font-geneva-12"
+  );
+
+  return (
+    <div className={cn("flex-1 flex flex-col min-h-0 overflow-y-auto px-1 pt-1.5 pb-1.5 gap-2.5")}>
+      {/* Color stripe + calendar name */}
+      <div className="flex items-center gap-1.5 px-0.5">
+        <span
+          className="inline-block w-2.5 h-2.5 rounded-sm shrink-0 border border-black/20"
+          style={{ backgroundColor: color }}
+        />
+        <span className={cn("text-[10px] opacity-70 truncate", useGeneva && "font-geneva-12")}>
+          {calendar?.name || t("apps.calendar.event.calendar")}
+        </span>
+      </div>
+
+      {/* Title */}
+      <div className="px-0.5">
+        <label className={labelClass}>{t("apps.calendar.event.title")}</label>
+        <input
+          type="text"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          onBlur={commitTitle}
+          onKeyDown={(e) => {
+            e.stopPropagation();
+            if (e.key === "Enter") (e.target as HTMLInputElement).blur();
+            if (e.key === "Escape") {
+              setTitle(event.title);
+              (e.target as HTMLInputElement).blur();
+            }
+          }}
+          className={inputBase}
+        />
+      </div>
+
+      {/* Date */}
+      <div className="px-0.5">
+        <label className={labelClass}>{t("apps.calendar.event.date")}</label>
+        <div
+          className={cn(
+            "text-[12px] px-1.5 py-0.5",
+            useGeneva && "font-geneva-12"
+          )}
+        >
+          {formatDateLabel(event.date, locale)}
+        </div>
+      </div>
+
+      {/* Time */}
+      {event.startTime ? (
+        <div className="px-0.5">
+          <label className={labelClass}>{t("apps.calendar.event.startTime")}</label>
+          <div className={cn("text-[12px] px-1.5 py-0.5", useGeneva && "font-geneva-12")}>
+            {event.startTime}
+            {event.endTime ? ` – ${event.endTime}` : ""}
+          </div>
+        </div>
+      ) : (
+        <div className="px-0.5">
+          <span className={cn("text-[10px] opacity-60", useGeneva && "font-geneva-12")}>
+            {t("apps.calendar.event.allDay")}
+          </span>
+        </div>
+      )}
+
+      {/* Notes */}
+      <div className="px-0.5 flex-1 min-h-0 flex flex-col">
+        <label className={labelClass}>{t("apps.calendar.event.notes")}</label>
+        <textarea
+          value={notes}
+          onChange={(e) => setNotes(e.target.value)}
+          onBlur={commitNotes}
+          onKeyDown={(e) => e.stopPropagation()}
+          placeholder={t("apps.calendar.event.notes")}
+          rows={3}
+          className={cn(
+            inputBase,
+            "flex-1 min-h-[60px] resize-none"
+          )}
+        />
+      </div>
+
+      {/* Actions */}
+      <div className="px-0.5 pt-0.5 flex items-center gap-1">
+        <Button
+          variant={isMacOSTheme ? "default" : "retro"}
+          onClick={() => onEditFull(event)}
+          className={cn(
+            "h-7 flex-1 text-[11px] gap-1.5",
+            useGeneva && "font-geneva-12",
+            isXpTheme && "text-black"
+          )}
+        >
+          <PencilSimple size={11} weight="bold" />
+          {t("apps.calendar.event.editEvent")}
+        </Button>
+        <Button
+          variant="retro"
+          onClick={() => onDelete(event.id)}
+          className={cn(
+            "h-7 text-[11px] text-red-600 hover:text-red-700 px-2 gap-1",
+            useGeneva && "font-geneva-12"
+          )}
+          title={t("apps.calendar.event.delete")}
+          aria-label={t("apps.calendar.event.delete")}
+        >
+          <Trash size={11} weight="bold" />
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+// ============================================================================
+// TODO DETAILS
+// ============================================================================
+
+function TodoDetails({
+  todo,
+  calendars,
+  useGeneva,
+  isMacOSTheme,
+  isXpTheme,
+  locale,
+  t,
+  onToggle,
+  onUpdate,
+  onDelete,
+}: {
+  todo: TodoItem;
+  calendars: CalendarGroup[];
+  useGeneva: boolean;
+  isMacOSTheme: boolean;
+  isXpTheme: boolean;
+  locale: string;
+  t: (key: string) => string;
+  onToggle: (id: string) => void;
+  onUpdate: (
+    id: string,
+    updates: Partial<Pick<TodoItem, "title" | "calendarId" | "dueDate" | "completed">>
+  ) => void;
+  onDelete: (id: string) => void;
+}) {
+  const [title, setTitle] = useState(todo.title);
+  const lastTodoIdRef = useRef(todo.id);
+
+  useEffect(() => {
+    if (lastTodoIdRef.current !== todo.id) {
+      lastTodoIdRef.current = todo.id;
+      setTitle(todo.title);
+    }
+  }, [todo.id, todo.title]);
+
+  const calendar = calendars.find((c) => c.id === todo.calendarId) || calendars[0];
+  const color = EVENT_COLOR_MAP[calendar?.color || "blue"];
+
+  const commitTitle = () => {
+    const next = title.trim();
+    if (next && next !== todo.title) {
+      onUpdate(todo.id, { title: next });
+    } else if (!next) {
+      setTitle(todo.title);
+    }
+  };
+
+  const inputBase = cn(
+    "w-full rounded border bg-white/90 outline-none px-1.5 py-0.5 text-[12px]",
+    useGeneva ? "border-black/20 font-geneva-12" : "border-black/15"
+  );
+
+  const labelClass = cn(
+    "block text-[9px] uppercase tracking-wide opacity-60 mb-0.5",
+    useGeneva && "font-geneva-12"
+  );
+
+  // Calendar select
+  const calendarOptions = calendars.map((c) => (
+    <option key={c.id} value={c.id}>
+      {c.name}
+    </option>
+  ));
+
+  return (
+    <div className={cn("flex-1 flex flex-col min-h-0 overflow-y-auto px-1 pt-1.5 pb-1.5 gap-2.5")}>
+      {/* Color stripe + calendar name */}
+      <div className="flex items-center gap-1.5 px-0.5">
+        <button type="button" onClick={() => onToggle(todo.id)} className="shrink-0">
+          <AquaCheckbox checked={todo.completed} color={color} />
+        </button>
+        <span className={cn("text-[10px] opacity-70 truncate", useGeneva && "font-geneva-12")}>
+          {calendar?.name || t("apps.calendar.event.calendar")}
+        </span>
+      </div>
+
+      {/* Title */}
+      <div className="px-0.5">
+        <label className={labelClass}>{t("apps.calendar.event.title")}</label>
+        <input
+          type="text"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          onBlur={commitTitle}
+          onKeyDown={(e) => {
+            e.stopPropagation();
+            if (e.key === "Enter") (e.target as HTMLInputElement).blur();
+            if (e.key === "Escape") {
+              setTitle(todo.title);
+              (e.target as HTMLInputElement).blur();
+            }
+          }}
+          className={cn(
+            inputBase,
+            todo.completed && "line-through opacity-60"
+          )}
+        />
+      </div>
+
+      {/* Due date */}
+      <div className="px-0.5">
+        <label className={labelClass}>{t("apps.calendar.event.date")}</label>
+        <input
+          type="date"
+          value={todo.dueDate || ""}
+          onChange={(e) =>
+            onUpdate(todo.id, { dueDate: e.target.value || null })
+          }
+          onKeyDown={(e) => e.stopPropagation()}
+          className={inputBase}
+        />
+        {todo.dueDate && (
+          <div className={cn("text-[10px] opacity-60 mt-0.5 px-0.5", useGeneva && "font-geneva-12")}>
+            {formatDateLabel(todo.dueDate, locale)}
+          </div>
+        )}
+      </div>
+
+      {/* Calendar */}
+      {calendars.length > 1 && (
+        <div className="px-0.5">
+          <label className={labelClass}>{t("apps.calendar.event.calendar")}</label>
+          <select
+            value={todo.calendarId}
+            onChange={(e) => onUpdate(todo.id, { calendarId: e.target.value })}
+            onKeyDown={(e) => e.stopPropagation()}
+            className={inputBase}
+          >
+            {calendarOptions}
+          </select>
+        </div>
+      )}
+
+      <div className="flex-1" />
+
+      {/* Actions */}
+      <div className="px-0.5 pt-0.5 flex items-center gap-1">
+        <Button
+          variant={isMacOSTheme ? "default" : "retro"}
+          onClick={() => onToggle(todo.id)}
+          className={cn(
+            "h-7 flex-1 text-[11px]",
+            useGeneva && "font-geneva-12",
+            isXpTheme && "text-black"
+          )}
+        >
+          {todo.completed
+            ? t("apps.calendar.tray.markIncomplete")
+            : t("apps.calendar.tray.markComplete")}
+        </Button>
+        <Button
+          variant="retro"
+          onClick={() => onDelete(todo.id)}
+          className={cn(
+            "h-7 text-[11px] text-red-600 hover:text-red-700 px-2 gap-1",
+            useGeneva && "font-geneva-12"
+          )}
+          title={t("apps.calendar.event.delete")}
+          aria-label={t("apps.calendar.event.delete")}
+        >
+          <Trash size={11} weight="bold" />
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/apps/calendar/hooks/useCalendarLogic.ts
+++ b/src/apps/calendar/hooks/useCalendarLogic.ts
@@ -479,6 +479,22 @@ export function useCalendarLogic() {
     }
   }, [selectedEventId, events]);
 
+  /**
+   * Inline event update (used by the details tray). Records an undo entry
+   * so changes made in the tray remain undoable from the Edit menu.
+   */
+  const handleUpdateEvent = useCallback(
+    (id: string, updates: Partial<CalendarEvent>) => {
+      const existing = events.find((e) => e.id === id);
+      if (!existing) return;
+      const before = { ...existing };
+      updateEvent(id, updates);
+      const after = { ...existing, ...updates, updatedAt: Date.now() };
+      pushUndo({ type: "updateEvent", eventId: id, before, after });
+    },
+    [events, updateEvent, pushUndo]
+  );
+
   const handleDeleteSelectedEvent = useCallback(() => {
     if (selectedEventId) {
       const ev = events.find((e) => e.id === selectedEventId);
@@ -638,6 +654,7 @@ export function useCalendarLogic() {
     handleEditSelectedEvent,
     handleDeleteSelectedEvent,
     handleDeleteEditingEvent,
+    handleUpdateEvent,
 
     // Import / Export
     fileInputRef,

--- a/src/components/shared/AppDrawer.tsx
+++ b/src/components/shared/AppDrawer.tsx
@@ -44,6 +44,15 @@ const DRAWER_OPEN_UNDERLAP_PX = 6;
 const DRAWER_SIDE_PROTRUSION_PX =
   DRAWER_WIDTH - DRAWER_OPEN_UNDERLAP_PX + DRAWER_EDGE_INSET_PX;
 
+/**
+ * When open, the drawer must paint above the main `.window` body (drawer slot
+ * is rendered before it in DOM order). Otherwise the tray is only visible in
+ * the narrow strip past the window’s right edge — often clipped off-screen when
+ * the window is flush with the viewport. Stay below `WindowFrame`’s resize
+ * layer (`z-[60]` on macOS) so resize handles still receive events.
+ */
+const DRAWER_OPEN_Z_INDEX = 55;
+
 // Compact bottom-sheet geometry (mobile) — matches TvVideoDrawer exactly
 const COMPACT_DRAWER_MEDIA = "(max-width: 767px)";
 const COMPACT_DRAWER_INSET_PX = 12;
@@ -325,7 +334,7 @@ export function AppDrawer({
           top: "auto",
           maxHeight: COMPACT_DRAWER_MAX_HEIGHT,
           height: "auto",
-          zIndex: 0,
+          zIndex: isOpen ? DRAWER_OPEN_Z_INDEX : 0,
           marginBottom: COMPACT_DRAWER_OVERLAP_TOP_PX,
           paddingTop: "max(0px, env(safe-area-inset-top, 0px))",
         }
@@ -336,7 +345,7 @@ export function AppDrawer({
           bottom: "auto",
           maxHeight: COMPACT_DRAWER_MAX_HEIGHT,
           height: "auto",
-          zIndex: 0,
+          zIndex: isOpen ? DRAWER_OPEN_Z_INDEX : 0,
           marginTop: COMPACT_DRAWER_OVERLAP_TOP_PX,
           paddingBottom: "max(0px, env(safe-area-inset-bottom, 0px))",
         };
@@ -366,14 +375,14 @@ export function AppDrawer({
         top: DRAWER_VERTICAL_INSET_PX,
         bottom: DRAWER_VERTICAL_INSET_PX,
         width: DRAWER_WIDTH,
-        zIndex: 0,
+        zIndex: isOpen ? DRAWER_OPEN_Z_INDEX : 0,
         left: DRAWER_EDGE_INSET_PX,
       }
     : {
         top: DRAWER_VERTICAL_INSET_PX,
         bottom: DRAWER_VERTICAL_INSET_PX,
         width: DRAWER_WIDTH,
-        zIndex: 0,
+        zIndex: isOpen ? DRAWER_OPEN_Z_INDEX : 0,
         right: DRAWER_EDGE_INSET_PX,
       };
 

--- a/src/lib/locales/en/translation.json
+++ b/src/lib/locales/en/translation.json
@@ -3159,6 +3159,13 @@
         "noTodoItems": "No to-do items",
         "newTodoPlaceholder": "New To Do..."
       },
+      "tray": {
+        "eventDetails": "Event Details",
+        "todoDetails": "To Do Details",
+        "empty": "Select an event or to-do",
+        "markComplete": "Mark Complete",
+        "markIncomplete": "Mark Incomplete"
+      },
       "import": {
         "success": "{{count}} event imported",
         "successPlural": "{{count}} events imported"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Reverts the calendar back to the right-side **TodoSidebar** layout (pre-`cbacb7df2`) and repurposes the `AppDrawer` ("tray") to display **details for the currently selected event or to-do item**.

## What changed

- **TodoSidebar restored** to the right side of the calendar (and full-width fallback on narrow widths). The `ListChecks` toolbar button still toggles the panel.
- **Tray (`AppDrawer`)** now opens whenever an event or to-do is selected and shows an editable detail panel:
  - **Event details**: title (inline edit), date, time, calendar/color chip, notes (inline edit), Edit/Delete actions.
  - **To-do details**: completion checkbox, title (inline edit), due date picker, calendar select, Mark Complete/Delete actions.
- **Single-click** an event or to-do row to select + open the tray. Closing the tray (× button) clears the selection.
- TodoSidebar rows now visually highlight when selected. A single click selects; clicking an already-selected row enters inline rename (preserves prior behavior).
- New `useCalendarLogic.handleUpdateEvent` helper wraps the store `updateEvent` with undo/redo so tray edits are fully undoable.
- Added `apps.calendar.tray.*` locale strings (English only — other locales fall back to English until machine translation runs).

## Files

- `src/apps/calendar/components/CalendarAppComponent.tsx` — restore right-side TodoSidebar layout, wire selection state into tray.
- `src/apps/calendar/components/TrayDetails.tsx` — new component rendering event/to-do detail panels inside the drawer.
- `src/apps/calendar/hooks/useCalendarLogic.ts` — add `handleUpdateEvent` (undoable inline event update for the tray).
- `src/lib/locales/en/translation.json` — add `tray.*` strings.

## Testing

- `bun run build` passes (TypeScript + Vite).
- Visual verification follows in-thread.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e0d48d81-0289-49ff-93e4-853ae9c5bbf6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e0d48d81-0289-49ff-93e4-853ae9c5bbf6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

