### PR TITLE
docs: update AGENTS.md with Cursor Cloud environment notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-## Cloud-specific instructions
+## Cursor Cloud specific instructions
 
 # ryOS Cloud Environment Guide
 
@@ -173,3 +173,12 @@ Tests use `describe`/`test`/`expect` from `bun:test`. Shared HTTP helpers are in
 - **Build process**: The build generates service worker files (`sw.js`, `workbox-*.js`) which are copied to `.vercel/output/static/`.
 - **Vercel CLI**: Installed globally, but optional for local testing now that standalone Bun API is available.
 - **Port conflicts**: If port 3000 is occupied, set `API_PORT=<port>` for `bun run dev:api` and adjust proxy target accordingly.
+
+### Cloud Environment Notes
+
+- All required secrets (Redis, Pusher, AI keys, S3, etc.) are injected as environment variables. No `.env.local` file is needed.
+- `REDIS_PROVIDER=upstash` is pre-set; the API uses Upstash REST (`REDIS_KV_REST_API_URL`/`REDIS_KV_REST_API_TOKEN`).
+- `REALTIME_PROVIDER=pusher` is pre-set with all Pusher credentials.
+- Redis is also installed locally (`redis-server`) and can be started if needed for local-mode testing, but the injected Upstash credentials are the default.
+- The `test:new-api` auth tests (Register, Login, Admin login) may fail in this environment since they rely on specific admin password setup — this is expected and not a code issue.
+- Bun and Node are installed via the update script. Ensure `PATH` includes `$HOME/.bun/bin` and nvm is sourced before running commands.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -180,5 +180,5 @@ Tests use `describe`/`test`/`expect` from `bun:test`. Shared HTTP helpers are in
 - `REDIS_PROVIDER=upstash` is pre-set; the API uses Upstash REST (`REDIS_KV_REST_API_URL`/`REDIS_KV_REST_API_TOKEN`).
 - `REALTIME_PROVIDER=pusher` is pre-set with all Pusher credentials.
 - Redis is also installed locally (`redis-server`) and can be started if needed for local-mode testing, but the injected Upstash credentials are the default.
-- The `test:new-api` auth tests (Register, Login, Admin login) may fail in this environment since they rely on specific admin password setup — this is expected and not a code issue.
+- The `test:new-api` auth tests (Register, Login, Admin login) fail with `expect(data.token).toBeTruthy()` because the auth endpoints return the token only in the `Set-Cookie` header (`ryos_auth=<user>:<token>`), not in the JSON body. The credentials `ryo`/`testtest` work correctly (HTTP 200). This is a pre-existing test/API mismatch.
 - Bun and Node are installed via the update script. Ensure `PATH` includes `$HOME/.bun/bin` and nvm is sourced before running commands.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates `AGENTS.md` with cloud-specific environment notes discovered during development environment setup.

### Changes
- Renamed section header from "Cloud-specific instructions" to "Cursor Cloud specific instructions" (matching the standard heading)
- Added "Cloud Environment Notes" subsection documenting:
  - All required secrets are pre-injected (no `.env.local` needed)
  - Default Redis and Pusher configurations
  - Known auth test expectations in this environment
  - PATH setup requirements for Bun and Node

### Environment Verification

The full development environment was set up and verified:

| Check | Status |
|-------|--------|
| `bun install` | ✅ 1542 packages |
| `bun run lint` | ✅ 0 errors, 11 pre-existing warnings |
| `bun run test:unit` | ✅ 155 tests pass |
| `bun run build` | ✅ Built in 13.80s |
| `bun run dev` | ✅ API (port 3000) + Vite (port 5173) |
| API health check | ✅ 73 routes loaded |
| Frontend loads | ✅ Desktop environment renders |
| App interaction | ✅ Finder, TextEdit functional |

![ryOS desktop loaded](https://cursor.com/artifacts/c/art-6857eb4f-e9fc-40b8-9c38-841f30c07c91)
![TextEdit hello world demo](https://cursor.com/artifacts/c/art-8576827b-20de-4e88-8a6e-696ea2e734cd)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1b00ac2c-27a9-4a5d-ba3d-980fab02007e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1b00ac2c-27a9-4a5d-ba3d-980fab02007e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

