### PR TITLE
test: fix auth tests to use ryos_auth cookie token

### DIFF
--- a/tests/test-admin.test.ts
+++ b/tests/test-admin.test.ts
@@ -8,6 +8,7 @@ import {
   BASE_URL,
   fetchWithOrigin,
   fetchWithAuth,
+  getTokenFromAuthCookie,
 } from "./test-utils";
 
 // Admin user credentials for dev testing
@@ -32,9 +33,8 @@ describe("admin", () => {
     });
 
     if (res.status === 200) {
-      const data = await res.json();
-      expect(data.token).toBeTruthy();
-      adminToken = data.token;
+      adminToken = getTokenFromAuthCookie(res);
+      expect(adminToken).toBeTruthy();
       return;
     }
 
@@ -48,8 +48,7 @@ describe("admin", () => {
     });
 
     if (createRes.status === 201) {
-      const createData = await createRes.json();
-      adminToken = createData.token;
+      adminToken = getTokenFromAuthCookie(createRes);
       return;
     }
 
@@ -82,9 +81,8 @@ describe("admin", () => {
     });
 
     if (res.status === 201) {
-      const data = await res.json();
-      expect(data.token).toBeTruthy();
-      testUserToken = data.token;
+      testUserToken = getTokenFromAuthCookie(res);
+      expect(testUserToken).toBeTruthy();
       return;
     }
 
@@ -99,8 +97,7 @@ describe("admin", () => {
       });
 
       if (loginRes.status === 200) {
-        const data = await loginRes.json();
-        testUserToken = data.token;
+        testUserToken = getTokenFromAuthCookie(loginRes);
         return;
       }
     }

--- a/tests/test-auth-extra.test.ts
+++ b/tests/test-auth-extra.test.ts
@@ -13,6 +13,7 @@ import {
   fetchWithOrigin,
   fetchWithAuth,
   makeRateLimitBypassHeaders,
+  getTokenFromAuthCookie,
 } from "./test-utils";
 
 const ADMIN_USERNAME = "ryo";
@@ -34,8 +35,7 @@ async function setupTestUser(): Promise<void> {
   });
 
   if (adminLoginRes.status === 200) {
-    const data = await adminLoginRes.json();
-    testToken = data.token;
+    testToken = getTokenFromAuthCookie(adminLoginRes);
     testUsername = ADMIN_USERNAME;
     isAdminUser = true;
     return;
@@ -49,8 +49,7 @@ async function setupTestUser(): Promise<void> {
   });
 
   if (res.status === 201) {
-    const data = await res.json();
-    testToken = data.token;
+    testToken = getTokenFromAuthCookie(res);
     isAdminUser = false;
   }
 }
@@ -58,6 +57,11 @@ async function setupTestUser(): Promise<void> {
 describe("Auth Extra API Tests", () => {
   beforeAll(async () => {
     await setupTestUser();
+  });
+
+  test("Setup - obtained auth token", () => {
+    expect(testToken).toBeTruthy();
+    expect(testUsername).toBeTruthy();
   });
 
   // ============================================================================

--- a/tests/test-new-api.test.ts
+++ b/tests/test-new-api.test.ts
@@ -15,6 +15,7 @@ import {
   fetchWithAuth,
   makeRateLimitBypassHeaders,
   ensureUserAuth,
+  getTokenFromAuthCookie,
 } from "./test-utils";
 
 let testToken: string | null = null;
@@ -78,10 +79,11 @@ describe("New API", () => {
       });
       if (res.status === 429 || res.status === 409) return;
       expect(res.status).toBe(201);
+      const token = getTokenFromAuthCookie(res);
+      expect(token).toBeTruthy();
       const data = await res.json();
-      expect(data.token).toBeTruthy();
       expect(data.user?.username).toBe(testUsername.toLowerCase());
-      testToken = data.token;
+      testToken = token;
     });
 
     test("Login - success", async () => {
@@ -93,9 +95,11 @@ describe("New API", () => {
       });
       if (res.status === 429) return;
       expect(res.status).toBe(200);
+      const token = getTokenFromAuthCookie(res);
+      expect(token).toBeTruthy();
       const data = await res.json();
-      expect(data.token).toBeTruthy();
-      testToken = data.token;
+      expect(data.username).toBe(testUsername.toLowerCase());
+      testToken = token;
     });
 
     test("Login - invalid password → 401", async () => {
@@ -126,10 +130,12 @@ describe("New API", () => {
         headers: makeRateLimitBypassHeaders(),
         body: JSON.stringify({ username: testUsername, oldToken: testToken }),
       });
-      expect(res.status).toBe(201);
+      expect(res.status).toBe(200);
+      const token = getTokenFromAuthCookie(res);
+      expect(token).toBeTruthy();
       const data = await res.json();
-      expect(data.token).toBeTruthy();
-      testToken = data.token;
+      expect(data.refreshed).toBe(true);
+      testToken = token;
     });
 
     test("Password check", async () => {
@@ -160,8 +166,7 @@ describe("New API", () => {
         body: JSON.stringify({ username: ADMIN_USERNAME, password: ADMIN_PASSWORD }),
       });
       if (res.status === 200) {
-        const data = await res.json();
-        adminToken = data.token;
+        adminToken = getTokenFromAuthCookie(res);
         expect(adminToken).toBeTruthy();
       }
       // admin may not exist in test env — that's OK

--- a/tests/test-rooms-extra.test.ts
+++ b/tests/test-rooms-extra.test.ts
@@ -12,6 +12,7 @@ import {
   BASE_URL,
   fetchWithOrigin,
   fetchWithAuth,
+  getTokenFromAuthCookie,
 } from "./test-utils";
 
 // Test state
@@ -48,8 +49,7 @@ async function setupTestUser(): Promise<void> {
   });
 
   if (res.status === 201) {
-    const data = await res.json();
-    testToken = data.token;
+    testToken = getTokenFromAuthCookie(res);
   } else if (res.status === 409) {
     // User exists, try login
     const loginRes = await fetchWithOrigin(`${BASE_URL}/api/auth/login`, {
@@ -58,8 +58,7 @@ async function setupTestUser(): Promise<void> {
       body: JSON.stringify({ username: testUsername, password: "testpassword123" }),
     });
     if (loginRes.ok) {
-      const data = await loginRes.json();
-      testToken = data.token;
+      testToken = getTokenFromAuthCookie(loginRes);
     }
   }
 }
@@ -71,8 +70,7 @@ async function setupAdminUser(): Promise<void> {
     body: JSON.stringify({ username: ADMIN_USERNAME, password: ADMIN_PASSWORD }),
   });
   if (res.ok) {
-    const data = await res.json();
-    adminToken = data.token;
+    adminToken = getTokenFromAuthCookie(res);
   }
 }
 

--- a/tests/test-utils.ts
+++ b/tests/test-utils.ts
@@ -46,7 +46,14 @@ export const makeRateLimitBypassHeaders = (): Record<string, string> => ({
   "X-Forwarded-For": `10.2.${Date.now() % 255}.${Math.floor(Math.random() * 255)}`,
 });
 
-function getTokenFromAuthCookie(response: Response): string | null {
+/**
+ * Extract the auth token from a response's `ryos_auth` httpOnly cookie.
+ *
+ * The login/register/refresh endpoints no longer return `token` in the
+ * JSON body — they only set a `ryos_auth={username}:{token}` cookie.
+ * Tests that previously relied on `data.token` must read the cookie.
+ */
+export function getTokenFromAuthCookie(response: Response): string | null {
   const setCookie = response.headers.get("set-cookie");
   if (!setCookie) {
     return null;
@@ -54,6 +61,25 @@ function getTokenFromAuthCookie(response: Response): string | null {
 
   const match = setCookie.match(/(?:^|;\s*)ryos_auth=([^:;]+):([^;]+)/);
   return match?.[2] || null;
+}
+
+/**
+ * Extract both username and token from a response's `ryos_auth` cookie.
+ */
+export function getAuthFromCookie(
+  response: Response
+): { username: string; token: string } | null {
+  const setCookie = response.headers.get("set-cookie");
+  if (!setCookie) return null;
+
+  const match = setCookie.match(/(?:^|;\s*)ryos_auth=([^:;]+):([^;]+)/);
+  if (!match) return null;
+
+  try {
+    return { username: decodeURIComponent(match[1]), token: match[2] };
+  } catch {
+    return null;
+  }
 }
 
 /**


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The `/api/auth/login`, `/api/auth/register`, and `/api/auth/token/refresh` endpoints no longer return the token in the JSON body — they only set an httpOnly `ryos_auth={username}:{token}` cookie.

Tests that read `data.token` silently short-circuited when the field was undefined (via `if (!testToken) return;`), masking real failures. Those fast `[0.1ms]` green passes in the existing output were actually skipped assertions.

## Changes

- `tests/test-utils.ts`: export `getTokenFromAuthCookie` / `getAuthFromCookie` helpers so suites can extract tokens from `Set-Cookie`.
- `tests/test-auth-extra.test.ts`: read token from cookie; add a setup-level assertion so missing auth is reported as a failure rather than a skip.
- `tests/test-new-api.test.ts`: read token from cookie for register/login/refresh/admin-login; assert actual response shape (`{ username }` for login, `{ refreshed: true }` / 200 for refresh).
- `tests/test-admin.test.ts`: read admin and test-user tokens from cookie.
- `tests/test-rooms-extra.test.ts`: read admin and test-user tokens from cookie.

## Testing

- ✅ `bun test tests/test-auth-extra.test.ts tests/test-new-api.test.ts tests/test-admin.test.ts tests/test-rooms-extra.test.ts` — 78 pass, 0 fail, 148 expect() calls (previously 3 failures in `test-new-api` + silent skips elsewhere).
- ✅ `bun run test:unit` — 155 pass, 0 fail.
- `bun test tests/test-telegram-webhook.test.ts` shows 5 failures on both `main` and this branch (pre-existing, unrelated to cookie auth).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-feaabe08-4d29-47ad-9415-bad95c2009f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-feaabe08-4d29-47ad-9415-bad95c2009f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

