### PR TITLE
feat(lyrics): show square album art in lyrics search results

### DIFF
--- a/api/songs/_kugou.ts
+++ b/api/songs/_kugou.ts
@@ -38,6 +38,9 @@ type KugouSongInfo = {
   songname: string;
   singername: string;
   album_name?: string;
+  trans_param?: {
+    union_cover?: string;
+  };
 };
 
 type KugouSearchResponse = {
@@ -66,6 +69,12 @@ export interface KugouSearchResult {
   hash: string;
   albumId: string | number;
   score: number;
+  /**
+   * Album cover URL with `{size}` placeholder, when present in the search response
+   * (from `trans_param.union_cover`). Clients should run this through
+   * `formatKugouImageUrl` to substitute a concrete pixel size.
+   */
+  cover?: string;
 }
 
 /**
@@ -153,15 +162,23 @@ export async function searchKugou(
 
   // Convert Kugou metadata from Simplified to Traditional Chinese
   // Also normalize artist separator from Chinese comma "、" to " & "
-  const scoredResults = infoList.map((song, index) => ({
-    title: simplifiedToTraditional(song.songname),
-    artist: normalizeArtistSeparator(simplifiedToTraditional(song.singername)),
-    album: song.album_name ? simplifiedToTraditional(song.album_name) : undefined,
-    hash: song.hash,
-    albumId: song.album_id,
-    score: Math.round(scoreSongMatch(song, title, artist) * 1000) / 1000,
-    _kugouOrder: index,
-  }));
+  const scoredResults = infoList.map((song, index) => {
+    const rawCover = song.trans_param?.union_cover;
+    // Normalize to HTTPS so the {size} placeholder URL can be used directly by clients
+    const cover = rawCover
+      ? rawCover.replace(/^http:\/\//, "https://")
+      : undefined;
+    return {
+      title: simplifiedToTraditional(song.songname),
+      artist: normalizeArtistSeparator(simplifiedToTraditional(song.singername)),
+      album: song.album_name ? simplifiedToTraditional(song.album_name) : undefined,
+      hash: song.hash,
+      albumId: song.album_id,
+      score: Math.round(scoreSongMatch(song, title, artist) * 1000) / 1000,
+      cover,
+      _kugouOrder: index,
+    };
+  });
 
   scoredResults.sort((a, b) => {
     if (b.score !== a.score) return b.score - a.score;

--- a/src/apps/admin/components/SongDetailPanel.tsx
+++ b/src/apps/admin/components/SongDetailPanel.tsx
@@ -1095,6 +1095,7 @@ export const SongDetailPanel: React.FC<SongDetailPanelProps> = ({
             title: song.lyricsSource.title,
             artist: song.lyricsSource.artist,
             album: song.lyricsSource.album,
+            cover: song.cover,
           } : undefined}
         />
       )}

--- a/src/apps/ipod/components/IpodAppComponent.tsx
+++ b/src/apps/ipod/components/IpodAppComponent.tsx
@@ -770,7 +770,11 @@ export function IpodAppComponent({
             onSelect={handleLyricsSearchSelect}
             onReset={handleLyricsSearchReset}
             hasOverride={!!lyricsSourceOverride}
-            currentSelection={lyricsSourceOverride}
+            currentSelection={
+              lyricsSourceOverride
+                ? { ...lyricsSourceOverride, cover: currentTrack.cover }
+                : undefined
+            }
           />
         )}
         <SongSearchDialog

--- a/src/apps/karaoke/components/KaraokeAppComponent.tsx
+++ b/src/apps/karaoke/components/KaraokeAppComponent.tsx
@@ -796,7 +796,11 @@ export function KaraokeAppComponent({
             onSelect={handleLyricsSearchSelect}
             onReset={handleLyricsSearchReset}
             hasOverride={!!lyricsSourceOverride}
-            currentSelection={lyricsSourceOverride}
+            currentSelection={
+              lyricsSourceOverride
+                ? { ...lyricsSourceOverride, cover: currentTrack.cover }
+                : undefined
+            }
           />
         )}
         <SongSearchDialog

--- a/src/components/dialogs/LyricsSearchDialog.tsx
+++ b/src/components/dialogs/LyricsSearchDialog.tsx
@@ -44,6 +44,8 @@ interface LyricsSearchDialogProps {
     title: string;
     artist: string;
     album?: string;
+    /** Album cover URL (may contain `{size}` placeholder) */
+    cover?: string;
   };
 }
 
@@ -255,7 +257,7 @@ export function LyricsSearchDialog({
           <div className="border border-gray-300 rounded-md overflow-hidden bg-white">
             <div
               className={cn(
-                "px-2 py-1.5",
+                "flex items-center gap-2 px-2 py-1.5",
                 isXpTheme
                   ? "font-['Pixelated_MS_Sans_Serif',Arial] text-[11px]"
                   : "font-geneva-12 text-[12px]"
@@ -268,10 +270,37 @@ export function LyricsSearchDialog({
                 fontSize: isXpTheme ? "11px" : undefined,
               }}
             >
-              <div className="font-semibold">{currentSelection.title}</div>
-              <div className="opacity-80">
-                {currentSelection.artist}
-                {currentSelection.album && ` • ${currentSelection.album}`}
+              {(() => {
+                const coverUrl = formatKugouImageUrl(currentSelection.cover, 100);
+                return (
+                  <div
+                    className={cn(
+                      "flex-shrink-0 w-9 h-9 overflow-hidden bg-gray-200",
+                      isXpTheme ? "border border-gray-400" : "rounded-sm"
+                    )}
+                    aria-hidden="true"
+                  >
+                    {coverUrl ? (
+                      <img
+                        src={coverUrl}
+                        alt=""
+                        loading="lazy"
+                        className="w-full h-full object-cover"
+                        onError={(e) => {
+                          (e.currentTarget as HTMLImageElement).style.visibility = "hidden";
+                        }}
+                        draggable={false}
+                      />
+                    ) : null}
+                  </div>
+                );
+              })()}
+              <div className="min-w-0 flex-1">
+                <div className="font-semibold truncate">{currentSelection.title}</div>
+                <div className="opacity-80 truncate">
+                  {currentSelection.artist}
+                  {currentSelection.album && ` • ${currentSelection.album}`}
+                </div>
               </div>
             </div>
           </div>

--- a/src/components/dialogs/LyricsSearchDialog.tsx
+++ b/src/components/dialogs/LyricsSearchDialog.tsx
@@ -15,6 +15,7 @@ import { useTranslation } from "react-i18next";
 import { getApiUrl } from "@/utils/platform";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { abortableFetch } from "@/utils/abortableFetch";
+import { formatKugouImageUrl } from "@/apps/ipod/constants";
 
 export interface LyricsSearchResult {
   title: string;
@@ -23,6 +24,8 @@ export interface LyricsSearchResult {
   hash: string;
   albumId: string | number;
   score: number;
+  /** Album cover URL (may contain `{size}` placeholder) */
+  cover?: string;
 }
 
 interface LyricsSearchDialogProps {
@@ -314,48 +317,74 @@ export function LyricsSearchDialog({
           </p>
           <ScrollArea className="h-[200px] border border-gray-300 rounded-md overflow-hidden bg-white">
             <div>
-              {results.map((result, index) => (
-                <div
-                  key={result.hash}
-                  onClick={() => setSelectedIndex(index)}
-                  onKeyDown={(e: React.KeyboardEvent<HTMLDivElement>) => {
-                    if (e.key === "Enter" || e.key === " ") {
-                      e.preventDefault();
-                      handleSelectAndUse(index);
-                    }
-                  }}
-                  tabIndex={0}
-                  role="button"
-                  className={cn(
-                    "px-2 py-1.5 cursor-pointer",
-                    selectedIndex === index
-                      ? "" // Selection styling handled by inline style
-                      : index % 2 === 1
-                        ? "bg-gray-100"
-                        : "bg-white",
-                    isXpTheme
-                      ? "font-['Pixelated_MS_Sans_Serif',Arial] text-[11px]"
-                      : "font-geneva-12 text-[12px]"
-                  )}
-                  data-selected={selectedIndex === index ? "true" : undefined}
-                  style={{
-                    fontFamily: isXpTheme
-                      ? '"Pixelated MS Sans Serif", "ArkPixel", Arial'
-                      : undefined,
-                    fontSize: isXpTheme ? "11px" : undefined,
-                  }}
-                >
-                  <div className="font-semibold">{result.title}</div>
+              {results.map((result, index) => {
+                const coverUrl = formatKugouImageUrl(result.cover, 100);
+                return (
                   <div
+                    key={result.hash}
+                    onClick={() => setSelectedIndex(index)}
+                    onKeyDown={(e: React.KeyboardEvent<HTMLDivElement>) => {
+                      if (e.key === "Enter" || e.key === " ") {
+                        e.preventDefault();
+                        handleSelectAndUse(index);
+                      }
+                    }}
+                    tabIndex={0}
+                    role="button"
                     className={cn(
-                      selectedIndex === index ? "opacity-80" : "text-neutral-600"
+                      "flex items-center gap-2 px-2 py-1.5 cursor-pointer",
+                      selectedIndex === index
+                        ? "" // Selection styling handled by inline style
+                        : index % 2 === 1
+                          ? "bg-gray-100"
+                          : "bg-white",
+                      isXpTheme
+                        ? "font-['Pixelated_MS_Sans_Serif',Arial] text-[11px]"
+                        : "font-geneva-12 text-[12px]"
                     )}
+                    data-selected={selectedIndex === index ? "true" : undefined}
+                    style={{
+                      fontFamily: isXpTheme
+                        ? '"Pixelated MS Sans Serif", "ArkPixel", Arial'
+                        : undefined,
+                      fontSize: isXpTheme ? "11px" : undefined,
+                    }}
                   >
-                    {result.artist}
-                    {result.album && ` • ${result.album}`}
+                    <div
+                      className={cn(
+                        "flex-shrink-0 w-9 h-9 overflow-hidden bg-gray-200",
+                        isXpTheme ? "border border-gray-400" : "rounded-sm"
+                      )}
+                      aria-hidden="true"
+                    >
+                      {coverUrl ? (
+                        <img
+                          src={coverUrl}
+                          alt=""
+                          loading="lazy"
+                          className="w-full h-full object-cover"
+                          onError={(e) => {
+                            (e.currentTarget as HTMLImageElement).style.visibility = "hidden";
+                          }}
+                          draggable={false}
+                        />
+                      ) : null}
+                    </div>
+                    <div className="min-w-0 flex-1">
+                      <div className="font-semibold truncate">{result.title}</div>
+                      <div
+                        className={cn(
+                          "truncate",
+                          selectedIndex === index ? "opacity-80" : "text-neutral-600"
+                        )}
+                      >
+                        {result.artist}
+                        {result.album && ` • ${result.album}`}
+                      </div>
+                    </div>
                   </div>
-                </div>
-              ))}
+                );
+              })}
             </div>
           </ScrollArea>
         </div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a small square album art thumbnail next to each row in the **Lyrics Search** dialog so users can visually distinguish between different versions of a song (live, DJ remix, OST cut, etc.) before picking one. The same thumbnail also appears in the **Current selection** row that's shown when the dialog is reopened with an existing override.

## Implementation

- **`api/songs/_kugou.ts`** — `searchKugou()` now reads `trans_param.union_cover` from each Kugou search hit, normalizes it to HTTPS, and exposes it as a `cover` field on `KugouSearchResult`. The URL still contains the standard Kugou `{size}` placeholder so callers pick whatever resolution they need.
- **`src/components/dialogs/LyricsSearchDialog.tsx`** — `LyricsSearchResult` and `currentSelection` both gain an optional `cover` field. Each result row and the current selection render a 36×36 thumbnail (sized at 100px from Kugou) using the existing `formatKugouImageUrl` helper, with a neutral gray placeholder when no cover is available. Title/artist text uses `truncate` to prevent overflow next to the new thumbnail. XP/Win98 themes get a sharp 1px border, other themes a small rounded corner.
- **iPod / Karaoke / Admin call sites** — Pass the active track/song's `cover` URL through to the dialog's `currentSelection` prop so the existing selection has visual context too.

The `search-lyrics` API endpoint returns the new field automatically since it already returns the full `KugouSearchResult` array as JSON — no API contract changes required on the server beyond the new field.

## Walkthrough

![Lyrics Search dialog showing 4 results for 周杰倫 七里香, each with a square album cover thumbnail next to the title and artist](https://cursor.com/artifacts/c/art-869491f2-4492-4da2-b1d9-af7cf0fd9b45)

Square album art thumbnails on each search result row.

![Lyrics Search dialog showing the Current selection row with a square album art thumbnail next to the title and artist](https://cursor.com/artifacts/c/art-6f86fa1d-21c5-40ea-931d-4737c3c003e1)

Same thumbnail on the "Current selection" row when reopening the dialog with an existing override.

## Testing

- ✅ `bun run build` — TypeScript + Vite production build passes.
- ✅ `searchKugou("周杰倫 七里香", ...)` returns 19/20 results with HTTPS cover URLs containing the `{size}` placeholder.
- ✅ `POST /api/songs/{id} { action: "search-lyrics", query: "周杰倫 七里香" }` returns the new `cover` field per result.
- ✅ Manual UI verification in the iPod app's View → Search Lyrics dialog (see screenshots): thumbnails render on result rows and on the current-selection row after reopening the dialog.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c216fbc9-38ec-4b19-8d49-267b5af9275f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c216fbc9-38ec-4b19-8d49-267b5af9275f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

