### PR TITLE
feat(maps): swap pin colors for home, stores, coffee, beach

### DIFF
--- a/src/apps/maps/utils/poiVisuals.ts
+++ b/src/apps/maps/utils/poiVisuals.ts
@@ -97,7 +97,7 @@ const DEFAULT_VISUAL: PoiVisual = {
 const VISUALS: Record<string, PoiVisual> = {
   // Food & drink
   restaurant: { iconKey: "ForkKnife", from: "#fb923c", to: "#dc2626" },
-  cafe: { iconKey: "Coffee", from: "#d97706", to: "#78350f" },
+  cafe: { iconKey: "Coffee", from: "#fb923c", to: "#dc2626" },
   bakery: { iconKey: "ForkKnife", from: "#fbbf24", to: "#d97706" },
   brewery: { iconKey: "BeerStein", from: "#f59e0b", to: "#92400e" },
   winery: { iconKey: "Wine", from: "#9f1239", to: "#581c87" },
@@ -105,7 +105,7 @@ const VISUALS: Record<string, PoiVisual> = {
   foodMarket: { iconKey: "ShoppingCart", from: "#84cc16", to: "#16a34a" },
 
   // Shopping
-  store: { iconKey: "Storefront", from: "#0ea5e9", to: "#06b6d4" },
+  store: { iconKey: "Storefront", from: "#facc15", to: "#ca8a04" },
   marina: { iconKey: "ShoppingBag", from: "#0ea5e9", to: "#1d4ed8" },
 
   // Money
@@ -123,7 +123,7 @@ const VISUALS: Record<string, PoiVisual> = {
   // Outdoors
   park: { iconKey: "Park", from: "#22c55e", to: "#15803d" },
   nationalPark: { iconKey: "Mountains", from: "#22c55e", to: "#065f46" },
-  beach: { iconKey: "Sun", from: "#fbbf24", to: "#06b6d4" },
+  beach: { iconKey: "Sun", from: "#0ea5e9", to: "#0284c7" },
 
   // Culture
   museum: { iconKey: "Buildings", from: "#a855f7", to: "#7c3aed" },

--- a/src/apps/maps/utils/savedPlaceVisuals.ts
+++ b/src/apps/maps/utils/savedPlaceVisuals.ts
@@ -1,7 +1,7 @@
 import type { PoiVisual } from "./poiVisuals";
 import { HOME_GLYPH_IMAGE, WORK_GLYPH_IMAGE } from "./markerGlyphs";
-/** Base hue for Home (badges and map pins). */
-export const HOME_MARKER_COLOR = "#2563eb";
+/** Base hue for Home — cyan blue (matches the previous Stores hue). */
+export const HOME_MARKER_COLOR = "#0ea5e9";
 
 /** Base hue for Work — saturated warm amber (not muddy brown or pale tan). */
 export const WORK_MARKER_COLOR = "#d97706";
@@ -10,7 +10,7 @@ export const WORK_MARKER_COLOR = "#d97706";
 export const HOME_SAVED_VISUAL: PoiVisual = {
   iconKey: "House",
   from: HOME_MARKER_COLOR,
-  to: "#1d4ed8",
+  to: "#0284c7",
 };
 
 export const WORK_SAVED_VISUAL: PoiVisual = {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Re-shuffles the Maps app marker palette so each category reads more naturally:

- **Home** — switched from blue (`#2563eb`) to cyan blue (`#0ea5e9`), the hue previously used by Stores. The saved-place gradient ramps to a darker cyan (`#0284c7`) for the bottom stop so the badge stays cohesive with the marker tint.
- **Stores** — switched from cyan blue to yellow (`#facc15` → `#ca8a04`).
- **Coffee (`cafe`)** — now uses the Restaurants gradient (`#fb923c` → `#dc2626`) so the two food categories share a visual language.
- **Beach** — now uses the cyan-blue family (`#0ea5e9` → `#0284c7`) instead of the previous yellow→cyan blend.

## Files

- `src/apps/maps/utils/savedPlaceVisuals.ts` — new `HOME_MARKER_COLOR` + saved-badge gradient.
- `src/apps/maps/utils/poiVisuals.ts` — updated `cafe`, `store`, and `beach` gradients.

## Testing

- ✅ `bun run build` — production build succeeds.
- Skipped GUI walkthrough per AGENTS.md guidance (UI verification beyond the build was not requested).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3520b128-7d12-4c2b-b004-a344d30e4ff2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3520b128-7d12-4c2b-b004-a344d30e4ff2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

