### PR TITLE
Add TWD to currency widget; use Frankfurter v2 API for rates

### DIFF
--- a/api/currency-rate.ts
+++ b/api/currency-rate.ts
@@ -4,13 +4,14 @@ import { crossRateFromUsdRates } from "./_utils/currency-cross-rate.js";
 export const runtime = "nodejs";
 export const maxDuration = 10;
 
-const FRANKFURTER = "https://api.frankfurter.app/latest";
+const FRANKFURTER_V2 = "https://api.frankfurter.dev/v2";
 
-interface FrankfurterLatestResponse {
-  amount: number;
-  base: string;
+/** `GET /v2/rate/{base}/{quote}` — see https://frankfurter.dev/ */
+interface FrankfurterV2RateResponse {
   date: string;
-  rates: Record<string, number>;
+  base: string;
+  quote: string;
+  rate: number;
 }
 
 interface OpenErApiResponse {
@@ -40,19 +41,18 @@ async function fetchFrankfurterPair(
   to: string,
   signal: AbortSignal
 ): Promise<{ rate: number; rateDate: string }> {
-  const url = `${FRANKFURTER}?from=${encodeURIComponent(from)}&to=${encodeURIComponent(to)}`;
+  const url = `${FRANKFURTER_V2}/rate/${encodeURIComponent(from)}/${encodeURIComponent(to)}`;
   const res = await fetch(url, {
     redirect: "follow",
     signal,
     headers: { Accept: "application/json" },
   });
   if (!res.ok) throw new Error(`Frankfurter HTTP ${res.status}`);
-  const data = (await res.json()) as FrankfurterLatestResponse;
-  const rate = data.rates[to];
-  if (typeof rate !== "number" || !Number.isFinite(rate)) {
+  const data = (await res.json()) as FrankfurterV2RateResponse;
+  if (typeof data.rate !== "number" || !Number.isFinite(data.rate)) {
     throw new Error("Frankfurter: missing rate");
   }
-  return { rate, rateDate: data.date };
+  return { rate: data.rate, rateDate: data.date };
 }
 
 async function fetchOpenErApiPair(

--- a/src/components/layout/dashboard/CurrencyWidget.tsx
+++ b/src/components/layout/dashboard/CurrencyWidget.tsx
@@ -35,6 +35,7 @@ const MAIN_CURRENCIES = [
   "KRW",
   "SGD",
   "HKD",
+  "TWD",
   "TRY",
   "ZAR",
   "ILS",

--- a/src/lib/currency/frankfurter.ts
+++ b/src/lib/currency/frankfurter.ts
@@ -1,12 +1,13 @@
 /** Prefer `/api/currency-rate` (server proxy + fallbacks); see `api/currency-rate.ts`. */
 
-const FRANKFURTER_LATEST = "https://api.frankfurter.app/latest";
+const FRANKFURTER_V2 = "https://api.frankfurter.dev/v2";
 
-export interface FrankfurterLatestResponse {
-  amount: number;
-  base: string;
+/** v2 single-pair rate: `GET /v2/rate/{base}/{quote}` */
+export interface FrankfurterV2RateResponse {
   date: string;
-  rates: Record<string, number>;
+  base: string;
+  quote: string;
+  rate: number;
 }
 
 interface CurrencyRateApiOk {
@@ -180,7 +181,7 @@ export function positionAfterNthDigit(s: string, n: number): number {
   return s.length;
 }
 
-/** Direct Frankfurter (ECB). Uses `redirect: "follow"` because api.frankfurter.app may 301. */
+/** Direct Frankfurter v2 (see https://frankfurter.dev/). */
 export async function fetchFrankfurterPairRateDirect(
   from: string,
   to: string,
@@ -192,7 +193,7 @@ export async function fetchFrankfurterPairRateDirect(
     return { rate: 1, rateDate: new Date().toISOString().slice(0, 10) };
   }
 
-  const url = `${FRANKFURTER_LATEST}?from=${encodeURIComponent(trimmedFrom)}&to=${encodeURIComponent(trimmedTo)}`;
+  const url = `${FRANKFURTER_V2}/rate/${encodeURIComponent(trimmedFrom)}/${encodeURIComponent(trimmedTo)}`;
   const res = await fetch(url, {
     signal,
     redirect: "follow",
@@ -201,12 +202,11 @@ export async function fetchFrankfurterPairRateDirect(
   if (!res.ok) {
     throw new Error(`Frankfurter HTTP ${res.status}`);
   }
-  const data = (await res.json()) as FrankfurterLatestResponse;
-  const rate = data.rates[trimmedTo];
-  if (typeof rate !== "number" || !Number.isFinite(rate)) {
+  const data = (await res.json()) as FrankfurterV2RateResponse;
+  if (typeof data.rate !== "number" || !Number.isFinite(data.rate)) {
     throw new Error("Frankfurter: missing rate");
   }
-  return { rate, rateDate: data.date };
+  return { rate: data.rate, rateDate: data.date };
 }
 
 export async function fetchCurrencyRateForWidget(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Adds **TWD** (New Taiwan dollar) to the dashboard currency widget pickers.
- Switches the primary exchange-rate source from the legacy unversioned Frankfurter URL to **[Frankfurter v2](https://frankfurter.dev/)** (`GET https://api.frankfurter.dev/v2/rate/{base}/{quote}`), which includes TWD in the supported currency set. The server route `api/currency-rate.ts` and the client direct fallback in `src/lib/currency/frankfurter.ts` both use this endpoint.
- No NTD alias: the UI uses ISO **TWD** only.

## Testing

- `bun test tests/test-currency-frankfurter.test.ts tests/test-currency-cross-rate.test.ts`
- `bun run build` (after `bun install`)
- Smoke: `fetchFrankfurterPairRateDirect('USD','TWD')` returns a finite rate and date.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-17e32d2f-f9be-4b07-953d-ee6741727f7c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-17e32d2f-f9be-4b07-953d-ee6741727f7c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

