### PR TITLE
ci: build and deploy via Coolify webhook

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -1,0 +1,172 @@
+name: Build and Deploy
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      force_deploy:
+        description: "Force a Coolify deploy even if no source changes"
+        required: false
+        default: "false"
+        type: choice
+        options:
+          - "false"
+          - "true"
+
+concurrency:
+  group: build-and-deploy-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build (Bun ${{ matrix.bun-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        bun-version: ["1.3.9"]
+    env:
+      NODE_OPTIONS: "--max-old-space-size=4096"
+      GIT_COMMIT_SHA: ${{ github.sha }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: ${{ matrix.bun-version }}
+
+      - name: Cache Bun install
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.bun/install/cache
+            node_modules
+          key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Type check and build
+        run: bun run build
+
+      - name: Run unit tests
+        run: bun run test:unit
+
+      - name: Upload build artifact
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist-${{ github.sha }}
+          path: dist
+          retention-days: 7
+          if-no-files-found: error
+
+  deploy:
+    name: Deploy to Coolify
+    needs: build
+    if: |
+      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+      github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    environment:
+      name: production
+      url: ${{ vars.COOLIFY_APP_URL }}
+    timeout-minutes: 15
+    steps:
+      - name: Verify Coolify secrets are configured
+        env:
+          COOLIFY_WEBHOOK_URL: ${{ secrets.COOLIFY_WEBHOOK_URL }}
+          COOLIFY_TOKEN: ${{ secrets.COOLIFY_TOKEN }}
+        run: |
+          if [ -z "${COOLIFY_WEBHOOK_URL}" ]; then
+            echo "::error::Missing required secret COOLIFY_WEBHOOK_URL."
+            echo "Set it under Settings -> Secrets and variables -> Actions."
+            echo "Example: https://coolify.example.com/api/v1/deploy?uuid=<resource-uuid>&force=false"
+            exit 1
+          fi
+          if [ -z "${COOLIFY_TOKEN}" ]; then
+            echo "::error::Missing required secret COOLIFY_TOKEN (Coolify API token)."
+            exit 1
+          fi
+          echo "Coolify secrets are configured."
+
+      - name: Trigger Coolify deploy webhook
+        env:
+          COOLIFY_WEBHOOK_URL: ${{ secrets.COOLIFY_WEBHOOK_URL }}
+          COOLIFY_TOKEN: ${{ secrets.COOLIFY_TOKEN }}
+          FORCE_DEPLOY: ${{ github.event.inputs.force_deploy || 'false' }}
+          COMMIT_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+
+          url="${COOLIFY_WEBHOOK_URL}"
+          if [ "${FORCE_DEPLOY}" = "true" ]; then
+            if printf '%s' "${url}" | grep -q '?'; then
+              url="${url}&force=true"
+            else
+              url="${url}?force=true"
+            fi
+            echo "Force deploy requested."
+          fi
+
+          # Mask URL in logs to avoid leaking the resource UUID.
+          echo "::add-mask::${url}"
+
+          echo "Triggering Coolify deploy for commit ${COMMIT_SHA}..."
+
+          # Retry up to 3 times on transient network/5xx errors.
+          attempt=1
+          max_attempts=3
+          while : ; do
+            http_code=$(curl --silent --show-error --output /tmp/coolify_response.json \
+              --write-out "%{http_code}" \
+              --request GET \
+              --max-time 60 \
+              --header "Authorization: Bearer ${COOLIFY_TOKEN}" \
+              --header "Accept: application/json" \
+              "${url}") || http_code="000"
+
+            echo "Coolify responded with HTTP ${http_code} (attempt ${attempt}/${max_attempts})"
+            if [ -s /tmp/coolify_response.json ]; then
+              echo "Response body:"
+              cat /tmp/coolify_response.json
+              echo
+            fi
+
+            if [ "${http_code}" -ge 200 ] && [ "${http_code}" -lt 300 ]; then
+              echo "Coolify deploy successfully triggered."
+              break
+            fi
+
+            if [ "${attempt}" -ge "${max_attempts}" ]; then
+              echo "::error::Coolify webhook failed after ${max_attempts} attempts (last HTTP ${http_code})."
+              exit 1
+            fi
+
+            sleep_seconds=$((attempt * 5))
+            echo "Retrying in ${sleep_seconds}s..."
+            sleep "${sleep_seconds}"
+            attempt=$((attempt + 1))
+          done
+
+      - name: Summary
+        if: success()
+        run: |
+          {
+            echo "## Coolify deploy triggered"
+            echo
+            echo "- Commit: \`${{ github.sha }}\`"
+            echo "- Ref: \`${{ github.ref }}\`"
+            echo "- Actor: @${{ github.actor }}"
+            echo
+            echo "Coolify will pull the latest commit and rebuild the Dockerfile image."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/1.3-self-hosting-vps.md
+++ b/docs/1.3-self-hosting-vps.md
@@ -176,6 +176,24 @@ No extra env vars needed — Coolify injects `SOURCE_COMMIT` when that option is
 
 Coolify deployments are auto-detected (via `COOLIFY_*` environment variables) and displayed in the Admin app's Server page.
 
+### Gating Coolify deploys behind GitHub Actions
+
+The repository ships with a `.github/workflows/build-and-deploy.yml` workflow that runs on every push and pull request:
+
+1. Installs dependencies with Bun and runs `bun run build` + `bun run test:unit`.
+2. On a green build of `main`, calls a Coolify deploy webhook so Coolify only redeploys when CI is green.
+
+To wire it up:
+
+1. In Coolify, open your application → **Webhooks** → copy the **Deploy webhook URL** (it looks like `https://coolify.example.com/api/v1/deploy?uuid=<resource-uuid>`) and the **API token**.
+2. In GitHub, open **Settings → Secrets and variables → Actions → New repository secret** and add:
+   - `COOLIFY_WEBHOOK_URL` — the deploy webhook URL
+   - `COOLIFY_TOKEN` — the Coolify API token (sent as `Authorization: Bearer ...`)
+3. Optional: under **Variables**, set `COOLIFY_APP_URL` to your public app URL so it shows up on the GitHub deployment timeline.
+4. Optional: in Coolify, disable the built-in Git auto-deploy so the webhook from GitHub Actions is the single source of truth.
+
+The workflow also exposes a manual `workflow_dispatch` trigger with a `force_deploy` input that appends `force=true` to the webhook URL (useful when only environment variables changed).
+
 ---
 
 ## 7) VPS + systemd example


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `.github/workflows/build-and-deploy.yml` so every push and PR runs the Bun build + unit tests on GitHub Actions, and a green build on `main` triggers a Coolify deploy via the resource's deploy webhook. This gates Coolify deploys on green CI instead of relying on Coolify's raw Git auto-deploy.

## What the workflow does

- **`build` job** (runs on every push to `main` and every PR)
  - Sets up Bun `1.3.9` (matrix-ready) with cached `~/.bun/install/cache` + `node_modules` keyed on `bun.lock`.
  - `bun install --frozen-lockfile` → `bun run build` → `bun run test:unit` (155 unit tests, no server required per `AGENTS.md`).
  - Threads `GIT_COMMIT_SHA: ${{ github.sha }}` into the build so `version.json` shows the real commit (instead of falling back to `dev`, per `docs/1.3-self-hosting-vps.md` §6).
  - Uploads `dist/` as an artifact on `main` pushes for debugging (7-day retention).

- **`deploy` job** (runs only on `main` pushes or `workflow_dispatch`)
  - `needs: build`, gated behind a `production` GitHub Environment so reviewers / protection rules can be applied.
  - Validates that `COOLIFY_WEBHOOK_URL` and `COOLIFY_TOKEN` secrets are set and fails loudly with setup instructions if not.
  - `curl`s the webhook with `Authorization: Bearer ${COOLIFY_TOKEN}`, retries up to 3 times on transient/5xx errors with backoff, and prints the response body.
  - Masks the webhook URL via `::add-mask::` so the resource UUID does not leak in public logs.
  - `workflow_dispatch` exposes a `force_deploy` input that appends `force=true` to the URL (handles both `?` and no-query-string webhook formats), useful when only Coolify env vars change.
  - Concurrency group `build-and-deploy-${{ github.ref }}` cancels superseded runs to avoid stacking deploys.

## Required setup (one-time)

In **GitHub → Settings → Secrets and variables → Actions** add the following repository secrets:

| Secret | Value |
| --- | --- |
| `COOLIFY_WEBHOOK_URL` | The Coolify resource's **Deploy webhook URL** (e.g. `https://coolify.example.com/api/v1/deploy?uuid=<resource-uuid>`) |
| `COOLIFY_TOKEN` | A Coolify API token (sent as `Authorization: Bearer ...`) |

Optional: a `COOLIFY_APP_URL` repository **variable** so the deployment shows up with a clickable link on the GitHub deployments timeline.

Optional but recommended: in Coolify, disable the built-in Git auto-deploy on the resource so the GitHub Actions webhook is the single source of truth.

## Docs

`docs/1.3-self-hosting-vps.md` (the existing self-hosting + Coolify guide) gets a new "Gating Coolify deploys behind GitHub Actions" subsection explaining the secrets and the `force_deploy` flag.

## Testing

- ✅ `bun run build` (with `GIT_COMMIT_SHA=test123abc`) → produces `dist/` and `version.json` shows `"commitSha": "test123abc"`, confirming the workflow's commit-SHA threading.
- ✅ `bun run test:unit` → 155/155 pass, 0 fail (`Ran 155 tests across 22 files. [1.68s]`).
- ✅ `actionlint -no-color .github/workflows/build-and-deploy.yml` → 0 issues.
- ✅ Local bash smoke-tested the deploy step: URL with existing query string correctly appends `&force=true`, URL without query string correctly appends `?force=true`, retry-on-500 logic retries 3x then fails with a clear `::error::`, and a 200 response short-circuits with `Coolify deploy successfully triggered.`
- The actual webhook call against a real Coolify instance can only be verified once `COOLIFY_WEBHOOK_URL` / `COOLIFY_TOKEN` secrets are set and the workflow runs on `main` (or via `workflow_dispatch`).

## Notes

- No app code changes — purely CI + docs.
- The repository already ships a `Dockerfile` that's been reviewed for Coolify (`docs/1.3-self-hosting-vps.md` §6), so Coolify continues to do the actual image build/run after the webhook fires; GitHub Actions only acts as the build/test gate and the trigger.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9768fd3a-e450-40d7-8818-7c18c40e6f0d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9768fd3a-e450-40d7-8818-7c18c40e6f0d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

