### PR TITLE
ci: split unit tests into own CI job + add Coolify per-PR preview deploys

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -217,32 +217,28 @@ jobs:
       url: ${{ vars.COOLIFY_PREVIEW_APP_URL }}
     timeout-minutes: 15
     steps:
-      - name: Verify Coolify preview secrets are configured
+      - name: Verify Coolify secrets are configured
         env:
-          COOLIFY_PREVIEW_WEBHOOK_URL: ${{ secrets.COOLIFY_PREVIEW_WEBHOOK_URL }}
-          COOLIFY_PREVIEW_TOKEN: ${{ secrets.COOLIFY_PREVIEW_TOKEN }}
+          COOLIFY_WEBHOOK_URL: ${{ secrets.COOLIFY_WEBHOOK_URL }}
           COOLIFY_TOKEN: ${{ secrets.COOLIFY_TOKEN }}
         run: |
-          if [ -z "${COOLIFY_PREVIEW_WEBHOOK_URL}" ]; then
-            echo "::error::Missing required secret COOLIFY_PREVIEW_WEBHOOK_URL."
+          if [ -z "${COOLIFY_WEBHOOK_URL}" ]; then
+            echo "::error::Missing required secret COOLIFY_WEBHOOK_URL."
             echo "Set it under Settings -> Secrets and variables -> Actions."
-            echo "This must point to the deploy webhook of the application that has Coolify"
-            echo "Preview Deployments enabled (typically your production app's webhook URL,"
-            echo "without any 'tag' or 'pr' query parameters — those are appended per-PR)."
+            echo "Per-PR previews reuse the production app's deploy webhook and append '&pr=<NUMBER>',"
+            echo "so the URL must not contain 'tag', 'pr', or 'pull_request_id' query parameters."
             echo "Example: https://coolify.example.com/api/v1/deploy?uuid=<app-uuid>"
             exit 1
           fi
-          if [ -z "${COOLIFY_PREVIEW_TOKEN}" ] && [ -z "${COOLIFY_TOKEN}" ]; then
-            echo "::error::Missing Coolify API token."
-            echo "Set COOLIFY_PREVIEW_TOKEN (preferred) or COOLIFY_TOKEN under Settings -> Secrets and variables -> Actions."
+          if [ -z "${COOLIFY_TOKEN}" ]; then
+            echo "::error::Missing required secret COOLIFY_TOKEN (Coolify API token)."
             exit 1
           fi
-          echo "Coolify preview secrets are configured."
+          echo "Coolify secrets are configured."
 
       - name: Trigger Coolify preview deploy webhook
         env:
-          COOLIFY_PREVIEW_WEBHOOK_URL: ${{ secrets.COOLIFY_PREVIEW_WEBHOOK_URL }}
-          COOLIFY_PREVIEW_TOKEN: ${{ secrets.COOLIFY_PREVIEW_TOKEN }}
+          COOLIFY_WEBHOOK_URL: ${{ secrets.COOLIFY_WEBHOOK_URL }}
           COOLIFY_TOKEN: ${{ secrets.COOLIFY_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
@@ -250,9 +246,8 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Prefer the preview-specific token; fall back to the shared Coolify token.
-          token="${COOLIFY_PREVIEW_TOKEN:-${COOLIFY_TOKEN}}"
-          base_url="${COOLIFY_PREVIEW_WEBHOOK_URL}"
+          token="${COOLIFY_TOKEN}"
+          base_url="${COOLIFY_WEBHOOK_URL}"
 
           # Validate PR number is a positive integer before interpolating into the URL.
           if ! printf '%s' "${PR_NUMBER}" | grep -Eq '^[1-9][0-9]*$'; then
@@ -262,14 +257,14 @@ jobs:
 
           # Coolify rejects combining 'pr' with 'tag'. Refuse misconfigured URLs early.
           if printf '%s' "${base_url}" | grep -Eq '(\?|&)tag='; then
-            echo "::error::COOLIFY_PREVIEW_WEBHOOK_URL contains a 'tag' query parameter."
+            echo "::error::COOLIFY_WEBHOOK_URL contains a 'tag' query parameter."
             echo "Coolify cannot combine 'tag' with 'pr'. Remove 'tag=...' from the secret."
             exit 1
           fi
 
-          # If the secret already pins a different PR, refuse rather than send a confusing request.
+          # If the secret already pins a PR, refuse rather than send a confusing request.
           if printf '%s' "${base_url}" | grep -Eq '(\?|&)(pr|pull_request_id)='; then
-            echo "::error::COOLIFY_PREVIEW_WEBHOOK_URL already contains a 'pr' or 'pull_request_id' query parameter."
+            echo "::error::COOLIFY_WEBHOOK_URL already contains a 'pr' or 'pull_request_id' query parameter."
             echo "The workflow appends '&pr=<PR_NUMBER>' itself. Remove it from the secret."
             exit 1
           fi

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -226,8 +226,10 @@ jobs:
           if [ -z "${COOLIFY_PREVIEW_WEBHOOK_URL}" ]; then
             echo "::error::Missing required secret COOLIFY_PREVIEW_WEBHOOK_URL."
             echo "Set it under Settings -> Secrets and variables -> Actions."
-            echo "This must point to the preview Coolify resource webhook (different from the production one)."
-            echo "Example: https://coolify.example.com/api/v1/deploy?uuid=<preview-resource-uuid>&force=false"
+            echo "This must point to the deploy webhook of the application that has Coolify"
+            echo "Preview Deployments enabled (typically your production app's webhook URL,"
+            echo "without any 'tag' or 'pr' query parameters — those are appended per-PR)."
+            echo "Example: https://coolify.example.com/api/v1/deploy?uuid=<app-uuid>"
             exit 1
           fi
           if [ -z "${COOLIFY_PREVIEW_TOKEN}" ] && [ -z "${COOLIFY_TOKEN}" ]; then
@@ -250,9 +252,38 @@ jobs:
 
           # Prefer the preview-specific token; fall back to the shared Coolify token.
           token="${COOLIFY_PREVIEW_TOKEN:-${COOLIFY_TOKEN}}"
-          url="${COOLIFY_PREVIEW_WEBHOOK_URL}"
+          base_url="${COOLIFY_PREVIEW_WEBHOOK_URL}"
 
-          # Mask URL in logs to avoid leaking the resource UUID.
+          # Validate PR number is a positive integer before interpolating into the URL.
+          if ! printf '%s' "${PR_NUMBER}" | grep -Eq '^[1-9][0-9]*$'; then
+            echo "::error::Invalid PR_NUMBER '${PR_NUMBER}'."
+            exit 1
+          fi
+
+          # Coolify rejects combining 'pr' with 'tag'. Refuse misconfigured URLs early.
+          if printf '%s' "${base_url}" | grep -Eq '(\?|&)tag='; then
+            echo "::error::COOLIFY_PREVIEW_WEBHOOK_URL contains a 'tag' query parameter."
+            echo "Coolify cannot combine 'tag' with 'pr'. Remove 'tag=...' from the secret."
+            exit 1
+          fi
+
+          # If the secret already pins a different PR, refuse rather than send a confusing request.
+          if printf '%s' "${base_url}" | grep -Eq '(\?|&)(pr|pull_request_id)='; then
+            echo "::error::COOLIFY_PREVIEW_WEBHOOK_URL already contains a 'pr' or 'pull_request_id' query parameter."
+            echo "The workflow appends '&pr=<PR_NUMBER>' itself. Remove it from the secret."
+            exit 1
+          fi
+
+          # Append '&pr=<PR_NUMBER>' (or '?pr=' if the URL has no query string yet)
+          # to trigger Coolify's native Preview Deployment for this PR.
+          if printf '%s' "${base_url}" | grep -q '?'; then
+            url="${base_url}&pr=${PR_NUMBER}"
+          else
+            url="${base_url}?pr=${PR_NUMBER}"
+          fi
+
+          # Mask both URLs in logs to avoid leaking the resource UUID.
+          echo "::add-mask::${base_url}"
           echo "::add-mask::${url}"
 
           echo "Triggering Coolify preview deploy for PR #${PR_NUMBER} (${PR_HEAD_REF} @ ${PR_HEAD_SHA})..."
@@ -308,5 +339,6 @@ jobs:
             echo "- Commit: \`${PR_HEAD_SHA}\`"
             echo "- Actor: @${ACTOR}"
             echo
-            echo "Coolify will pull the latest PR commit and rebuild the preview Dockerfile image."
+            echo "Coolify will build a per-PR preview deployment using the URL template"
+            echo "configured on the application (e.g. \`{{pr_id}}.<wildcard-domain>\`)."
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -214,7 +214,9 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: preview
-      url: ${{ vars.COOLIFY_PREVIEW_APP_URL }}
+      # Mirrors the Coolify Preview URL Template ({{pr_id}}-preview.os.ryo.lu)
+      # so the GitHub PR check links straight to the per-PR preview.
+      url: https://${{ github.event.pull_request.number }}-preview.os.ryo.lu
     timeout-minutes: 15
     steps:
       - name: Verify Coolify secrets are configured
@@ -326,14 +328,16 @@ jobs:
           PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           ACTOR: ${{ github.actor }}
         run: |
+          preview_url="https://${PR_NUMBER}-preview.os.ryo.lu"
           {
             echo "## Coolify preview deploy triggered"
             echo
+            echo "- Preview: [${preview_url}](${preview_url})"
             echo "- PR: #${PR_NUMBER}"
             echo "- Branch: \`${PR_HEAD_REF}\`"
             echo "- Commit: \`${PR_HEAD_SHA}\`"
             echo "- Actor: @${ACTOR}"
             echo
-            echo "Coolify will build a per-PR preview deployment using the URL template"
-            echo "configured on the application (e.g. \`{{pr_id}}.<wildcard-domain>\`)."
+            echo "Coolify is building a per-PR preview using the configured URL template"
+            echo "(\`{{pr_id}}-preview.os.ryo.lu\`)."
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -21,6 +21,42 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  test:
+    name: Unit tests (Bun ${{ matrix.bun-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        bun-version: ["1.3.9"]
+    env:
+      NODE_OPTIONS: "--max-old-space-size=4096"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: ${{ matrix.bun-version }}
+
+      - name: Cache Bun install
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.bun/install/cache
+            node_modules
+          key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Run unit tests
+        run: bun run test:unit
+
   build:
     name: Build (Bun ${{ matrix.bun-version }})
     runs-on: ubuntu-latest
@@ -58,9 +94,6 @@ jobs:
       - name: Type check and build
         run: bun run build
 
-      - name: Run unit tests
-        run: bun run test:unit
-
       - name: Upload build artifact
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: actions/upload-artifact@v4
@@ -71,8 +104,8 @@ jobs:
           if-no-files-found: error
 
   deploy:
-    name: Deploy to Coolify
-    needs: build
+    name: Deploy to Coolify (production)
+    needs: [test, build]
     if: |
       (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
       github.event_name == 'workflow_dispatch'
@@ -169,4 +202,111 @@ jobs:
             echo "- Actor: @${{ github.actor }}"
             echo
             echo "Coolify will pull the latest commit and rebuild the Dockerfile image."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  deploy-preview:
+    name: Deploy preview to Coolify
+    needs: [test, build]
+    # Only run on PRs from the same repository (forks cannot access secrets).
+    if: |
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    environment:
+      name: preview
+      url: ${{ vars.COOLIFY_PREVIEW_APP_URL }}
+    timeout-minutes: 15
+    steps:
+      - name: Verify Coolify preview secrets are configured
+        env:
+          COOLIFY_PREVIEW_WEBHOOK_URL: ${{ secrets.COOLIFY_PREVIEW_WEBHOOK_URL }}
+          COOLIFY_PREVIEW_TOKEN: ${{ secrets.COOLIFY_PREVIEW_TOKEN }}
+          COOLIFY_TOKEN: ${{ secrets.COOLIFY_TOKEN }}
+        run: |
+          if [ -z "${COOLIFY_PREVIEW_WEBHOOK_URL}" ]; then
+            echo "::error::Missing required secret COOLIFY_PREVIEW_WEBHOOK_URL."
+            echo "Set it under Settings -> Secrets and variables -> Actions."
+            echo "This must point to the preview Coolify resource webhook (different from the production one)."
+            echo "Example: https://coolify.example.com/api/v1/deploy?uuid=<preview-resource-uuid>&force=false"
+            exit 1
+          fi
+          if [ -z "${COOLIFY_PREVIEW_TOKEN}" ] && [ -z "${COOLIFY_TOKEN}" ]; then
+            echo "::error::Missing Coolify API token."
+            echo "Set COOLIFY_PREVIEW_TOKEN (preferred) or COOLIFY_TOKEN under Settings -> Secrets and variables -> Actions."
+            exit 1
+          fi
+          echo "Coolify preview secrets are configured."
+
+      - name: Trigger Coolify preview deploy webhook
+        env:
+          COOLIFY_PREVIEW_WEBHOOK_URL: ${{ secrets.COOLIFY_PREVIEW_WEBHOOK_URL }}
+          COOLIFY_PREVIEW_TOKEN: ${{ secrets.COOLIFY_PREVIEW_TOKEN }}
+          COOLIFY_TOKEN: ${{ secrets.COOLIFY_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        run: |
+          set -euo pipefail
+
+          # Prefer the preview-specific token; fall back to the shared Coolify token.
+          token="${COOLIFY_PREVIEW_TOKEN:-${COOLIFY_TOKEN}}"
+          url="${COOLIFY_PREVIEW_WEBHOOK_URL}"
+
+          # Mask URL in logs to avoid leaking the resource UUID.
+          echo "::add-mask::${url}"
+
+          echo "Triggering Coolify preview deploy for PR #${PR_NUMBER} (${PR_HEAD_REF} @ ${PR_HEAD_SHA})..."
+
+          # Retry up to 3 times on transient network/5xx errors.
+          attempt=1
+          max_attempts=3
+          while : ; do
+            http_code=$(curl --silent --show-error --output /tmp/coolify_preview_response.json \
+              --write-out "%{http_code}" \
+              --request GET \
+              --max-time 60 \
+              --header "Authorization: Bearer ${token}" \
+              --header "Accept: application/json" \
+              "${url}") || http_code="000"
+
+            echo "Coolify responded with HTTP ${http_code} (attempt ${attempt}/${max_attempts})"
+            if [ -s /tmp/coolify_preview_response.json ]; then
+              echo "Response body:"
+              cat /tmp/coolify_preview_response.json
+              echo
+            fi
+
+            if [ "${http_code}" -ge 200 ] && [ "${http_code}" -lt 300 ]; then
+              echo "Coolify preview deploy successfully triggered."
+              break
+            fi
+
+            if [ "${attempt}" -ge "${max_attempts}" ]; then
+              echo "::error::Coolify preview webhook failed after ${max_attempts} attempts (last HTTP ${http_code})."
+              exit 1
+            fi
+
+            sleep_seconds=$((attempt * 5))
+            echo "Retrying in ${sleep_seconds}s..."
+            sleep "${sleep_seconds}"
+            attempt=$((attempt + 1))
+          done
+
+      - name: Summary
+        if: success()
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          ACTOR: ${{ github.actor }}
+        run: |
+          {
+            echo "## Coolify preview deploy triggered"
+            echo
+            echo "- PR: #${PR_NUMBER}"
+            echo "- Branch: \`${PR_HEAD_REF}\`"
+            echo "- Commit: \`${PR_HEAD_SHA}\`"
+            echo "- Actor: @${ACTOR}"
+            echo
+            echo "Coolify will pull the latest PR commit and rebuild the preview Dockerfile image."
           } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Two changes to `.github/workflows/build-and-deploy.yml`:

1. **Move unit tests to their own CI job.** `bun run test:unit` previously ran as a step inside the `build` job. It now runs in a dedicated `test` job that executes in parallel with `build`, giving faster red/green feedback and clearer CI status. Both deploy jobs now `needs: [test, build]`, so a test failure blocks deploys.

2. **Add Coolify per-PR preview deployments (Option A — native Coolify Preview Deployments).** A new `deploy-preview` job triggers on `pull_request` events. It reuses the existing `COOLIFY_WEBHOOK_URL` / `COOLIFY_TOKEN` secrets and appends `&pr=<PR_NUMBER>` at runtime, which tells Coolify to build/deploy a per-PR preview using the application's configured **Preview URL Template** (`{{pr_id}}-preview.os.ryo.lu`).
   - The GitHub Actions Environment URL is set to `https://<PR_NUMBER>-preview.os.ryo.lu` so the **`preview` check on each PR links straight to the deployment**, and the same link is at the top of the deploy step summary.
   - PR number is validated as a positive integer before interpolation.
   - Misconfigured URLs fail fast: rejects `tag=` (Coolify can't combine `tag` with `pr`) and rejects hard-coded `pr=` / `pull_request_id=` (the workflow appends `pr=` itself).
   - Skipped on PRs from forks (secrets aren't available there).
   - Reuses the same retry/backoff and URL-masking logic as the production deploy.

Production deploy behavior is unchanged: still only on `push` to `main` or `workflow_dispatch`.

## Required setup (Coolify side — Option A)

In Coolify, on the **production application**:

1. **DNS**: add a wildcard `A` record `*-preview.os.ryo.lu` → your Coolify server IP (or `*.os.ryo.lu` if you also want the bare wildcard).
2. **General → Wildcard Domain**: set so it matches the template (e.g. `https://os.ryo.lu` with the wildcard handling subdomains).
3. **Preview Deployments** tab → enable, then set:
   - **Preview URL Template**: `{{pr_id}}-preview.os.ryo.lu`
   - **Scoped Deployments**: `Preview Deployments` (members/collaborators only).
   - **Scoped Secrets**: copy/override env vars that should differ from prod.
4. *(Optional but recommended)* Connect the Coolify GitHub App so PRs get auto status comments + checks. Required permissions: Pull Requests R/W, Checks R/W, Contents R.

The existing `COOLIFY_WEBHOOK_URL` (the production app's `…/api/v1/deploy?uuid=<app-uuid>`) **must not contain** any `tag=` / `pr=` / `pull_request_id=` query parameters — the workflow appends `pr=` per PR.

## Required setup (GitHub side)

No new secrets — reuses the existing production ones (`COOLIFY_WEBHOOK_URL`, `COOLIFY_TOKEN`).

## Testing

- ✅ `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/build-and-deploy.yml'))"` — valid YAML
- ✅ `actionlint .github/workflows/build-and-deploy.yml` — clean (untrusted PR ref/sha passed through env vars)
- ✅ `bun install --frozen-lockfile` — same command the new `test` job runs
- ✅ `bun run test:unit` — 155 tests pass, 0 fail across 22 files
- ✅ `bash /tmp/test_preview_url.sh` — 10/10 unit tests for the URL construction + validation logic

[preview_url_logic_tests.log](https://cursor.com/artifacts/c/art-a49a33be-7df8-4bc4-af2e-d0ddd7a08293)

The Coolify deploy itself can only be exercised against a real webhook — once Preview Deployments are enabled on the production application in Coolify with the `{{pr_id}}-preview.os.ryo.lu` template, this PR's next push will trigger a real per-PR deploy at https://1146-preview.os.ryo.lu.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-796aa72e-4f3c-445c-a6ab-0d624b9558c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-796aa72e-4f3c-445c-a6ab-0d624b9558c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

