### PR TITLE
ci(coolify): fail deploy when HTTP 200 hides a "PR not found" body

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -175,13 +175,43 @@ jobs:
               echo
             fi
 
-            if [ "${http_code}" -ge 200 ] && [ "${http_code}" -lt 300 ]; then
+            # Coolify can return HTTP 200 with a body that actually describes a
+            # failure (e.g. resource not deployable). A successful response
+            # contains a deployment_uuid for each entry in "deployments". If
+            # the body is JSON of the expected shape, require every entry to
+            # have a deployment_uuid; otherwise treat the call as failed.
+            body_ok=true
+            body_messages=""
+            if [ "${http_code}" -ge 200 ] && [ "${http_code}" -lt 300 ] \
+               && [ -s /tmp/coolify_response.json ] \
+               && command -v jq >/dev/null 2>&1 \
+               && jq -e '.deployments | type == "array"' \
+                    /tmp/coolify_response.json >/dev/null 2>&1; then
+              total=$(jq '.deployments | length' /tmp/coolify_response.json)
+              ok=$(jq '[.deployments[] | select((.deployment_uuid // "") != "")] | length' \
+                   /tmp/coolify_response.json)
+              if [ "${total}" -eq 0 ] || [ "${ok}" -lt "${total}" ]; then
+                body_ok=false
+                body_messages=$(jq -r '[.deployments[].message // ""] | map(select(. != "")) | join(" | ")' \
+                                /tmp/coolify_response.json)
+              fi
+            fi
+
+            if [ "${http_code}" -ge 200 ] && [ "${http_code}" -lt 300 ] && [ "${body_ok}" = "true" ]; then
               echo "Coolify deploy successfully triggered."
               break
             fi
 
+            if [ "${body_ok}" = "false" ]; then
+              echo "::warning::Coolify accepted the request (HTTP ${http_code}) but did not queue a deployment: ${body_messages}"
+            fi
+
             if [ "${attempt}" -ge "${max_attempts}" ]; then
-              echo "::error::Coolify webhook failed after ${max_attempts} attempts (last HTTP ${http_code})."
+              if [ "${body_ok}" = "false" ]; then
+                echo "::error::Coolify deploy failed: ${body_messages}"
+              else
+                echo "::error::Coolify webhook failed after ${max_attempts} attempts (last HTTP ${http_code})."
+              fi
               exit 1
             fi
 
@@ -285,9 +315,11 @@ jobs:
 
           echo "Triggering Coolify preview deploy for PR #${PR_NUMBER} (${PR_HEAD_REF} @ ${PR_HEAD_SHA})..."
 
-          # Retry up to 3 times on transient network/5xx errors.
+          # Retry up to 4 times. The first request may race the GitHub App's
+          # 'pull_request' webhook delivery to Coolify, which is what creates
+          # the per-PR ApplicationPreview record that '?pr=' looks up.
           attempt=1
-          max_attempts=3
+          max_attempts=4
           while : ; do
             http_code=$(curl --silent --show-error --output /tmp/coolify_preview_response.json \
               --write-out "%{http_code}" \
@@ -304,17 +336,71 @@ jobs:
               echo
             fi
 
-            if [ "${http_code}" -ge 200 ] && [ "${http_code}" -lt 300 ]; then
+            # Coolify's preview deploy endpoint returns HTTP 200 even when it
+            # cannot queue a deployment (for example, when no preview record
+            # exists for this PR yet, the body is:
+            #   {"deployments":[{"message":"Pull request <N> not found for this resource.",...}]}
+            # ). A truly successful response includes a deployment_uuid on
+            # every entry. If the body is parseable JSON of the expected
+            # shape, require deployment_uuid on every deployments[] entry;
+            # otherwise treat the call as failed.
+            body_ok=true
+            body_messages=""
+            if [ "${http_code}" -ge 200 ] && [ "${http_code}" -lt 300 ] \
+               && [ -s /tmp/coolify_preview_response.json ] \
+               && command -v jq >/dev/null 2>&1 \
+               && jq -e '.deployments | type == "array"' \
+                    /tmp/coolify_preview_response.json >/dev/null 2>&1; then
+              total=$(jq '.deployments | length' /tmp/coolify_preview_response.json)
+              ok=$(jq '[.deployments[] | select((.deployment_uuid // "") != "")] | length' \
+                   /tmp/coolify_preview_response.json)
+              if [ "${total}" -eq 0 ] || [ "${ok}" -lt "${total}" ]; then
+                body_ok=false
+                body_messages=$(jq -r '[.deployments[].message // ""] | map(select(. != "")) | join(" | ")' \
+                                /tmp/coolify_preview_response.json)
+              fi
+            fi
+
+            if [ "${http_code}" -ge 200 ] && [ "${http_code}" -lt 300 ] && [ "${body_ok}" = "true" ]; then
               echo "Coolify preview deploy successfully triggered."
               break
             fi
 
+            if [ "${body_ok}" = "false" ]; then
+              echo "::warning::Coolify accepted the request (HTTP ${http_code}) but did not queue a preview deployment: ${body_messages}"
+            fi
+
             if [ "${attempt}" -ge "${max_attempts}" ]; then
-              echo "::error::Coolify preview webhook failed after ${max_attempts} attempts (last HTTP ${http_code})."
+              if [ "${body_ok}" = "false" ]; then
+                echo "::error::Coolify preview deploy failed: ${body_messages}"
+                if printf '%s' "${body_messages}" | grep -qi 'not found'; then
+                  echo
+                  echo "Coolify has no preview record for PR #${PR_NUMBER} on this resource."
+                  echo
+                  echo "Likely causes:"
+                  echo "  * The Coolify GitHub App is not installed on this repository, or"
+                  echo "    'Preview Deployments' is not enabled on the source"
+                  echo "    (Sources -> <your GitHub App>; permissions must include"
+                  echo "    Pull Requests: Read & write, with the 'Pull requests' event subscribed)."
+                  echo "  * The 'pull_request' webhook delivery to Coolify failed or was"
+                  echo "    delivered before preview deploys were enabled on the application."
+                  echo "  * 'Allow Public PR Deployments' is off and the PR author is not a"
+                  echo "    repository member, collaborator, or contributor."
+                  echo
+                  echo "Fixes:"
+                  echo "  * Open the application in Coolify -> 'Preview Deployments' tab and"
+                  echo "    click 'Load Pull Requests', then re-run this workflow."
+                  echo "  * Verify the GitHub App permissions and 'Pull requests' subscription,"
+                  echo "    then redeliver the webhook from GitHub -> Settings -> Webhooks."
+                  echo "  * See https://coolify.io/docs/applications/ci-cd/github/preview-deploy"
+                fi
+              else
+                echo "::error::Coolify preview webhook failed after ${max_attempts} attempts (last HTTP ${http_code})."
+              fi
               exit 1
             fi
 
-            sleep_seconds=$((attempt * 5))
+            sleep_seconds=$((attempt * 10))
             echo "Retrying in ${sleep_seconds}s..."
             sleep "${sleep_seconds}"
             attempt=$((attempt + 1))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

The `Deploy preview to Coolify` job is reporting **success** even when Coolify silently refuses the request:

```
Coolify responded with HTTP 200 (attempt 1/3)
Response body:
{"deployments":[{"message":"Pull request 1147 not found for this resource.","resource_uuid":"…"}]}
Coolify preview deploy successfully triggered.
```

Coolify's `/deploy?uuid=…&pr=N` endpoint always returns HTTP 200 — even when it cannot queue a deployment. A successful response carries a `deployment_uuid` for each `deployments[]` entry; the failure case above does not. The previous workflow only inspected the HTTP status, so the green checkmark was misleading and no preview was ever built.

The "Pull request not found for this resource" body specifically means Coolify has no `ApplicationPreview` record for that PR yet — it is created by the Coolify GitHub App's `pull_request` webhook. If the App's webhook delivery loses the race against this job (or the App isn't installed / Preview Deployments aren't enabled), `?pr=N` has nothing to look up.

## What

- Parse the JSON response with `jq` in both the production `deploy` job and the `deploy-preview` job and require every `deployments[]` entry to have a non-empty `deployment_uuid`. Anything else is now a failure even if the HTTP status is 2xx.
- Surface Coolify's own `message` field in the GitHub Actions warning/error, so the log makes the actual cause obvious instead of "successfully triggered".
- For the preview job, bump retries from 3 → 4 with linear `attempt * 10s` backoff. This gives the Coolify GitHub App ~60s of webhook-delivery slack to create the preview record before the workflow gives up.
- When the final failure message contains "not found", append an actionable hint pointing at:
  - Sources → GitHub App → Preview Deployments + `Pull requests: Read & write` permission + `Pull requests` event
  - The Coolify UI's "Load Pull Requests" button on the application's Preview Deployments tab
  - The [Coolify preview-deploy docs](https://coolify.io/docs/applications/ci-cd/github/preview-deploy)
- Defensive: only run the body check when the body is present, `jq` is available, and the response is JSON with a `deployments` array; otherwise fall back to the previous status-code-only behavior. Non-JSON 2xx responses are still considered successful (matches old behavior).

## Testing

I extracted the new validation block into `bash` and drove it through seven scenarios covering the actual failing body, a real success body, partial successes, empty arrays, non-JSON bodies, and HTTP 5xx:

- ✅ `bash /tmp/test_coolify_logic.sh` — all 7 scenarios pass:
  - `Pull request 1147 not found for this resource.` (HTTP 200) → `body_ok=false`, message preserved
  - `Deployment request queued.` with `deployment_uuid` (HTTP 200) → `body_ok=true`
  - mixed `deployments[]` (one missing `deployment_uuid`) → `body_ok=false`
  - empty `deployments[]` → `body_ok=false`
  - non-JSON body → falls back to status-only success
  - JSON without `deployments` key → falls back to status-only success
  - HTTP 502 → validation skipped, retry/fail path triggers as before
- ✅ `bash -n` against every `run:` block in `.github/workflows/build-and-deploy.yml`
- ✅ YAML parse via `bun --eval` (`yaml.parse`) — workflow loads, jobs unchanged: `test, build, deploy, deploy-preview`

End-to-end CI verification will happen when this PR triggers the same `deploy-preview` job that hit the bug; the next run should either succeed (if the Coolify App eventually syncs PR #1147) or fail loudly with the actionable error instead of falsely reporting success.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8da36442-626f-425a-99c0-277c659ac2af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8da36442-626f-425a-99c0-277c659ac2af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

