### PR TITLE
ci: build & push Docker image to GHCR before deploy

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -95,18 +95,74 @@ jobs:
       - name: Type check and build
         run: bun run build
 
-      - name: Upload build artifact
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: actions/upload-artifact@v4
+  image:
+    name: Build & push Docker image to GHCR
+    needs: [build]
+    if: |
+      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+      github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    env:
+      IMAGE_NAME: ghcr.io/ryokun6/ryos
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
         with:
-          name: dist-${{ github.sha }}
-          path: dist
-          retention-days: 7
-          if-no-files-found: error
+          fetch-depth: 1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute image tags
+        id: tags
+        run: |
+          {
+            echo "tags<<EOF"
+            echo "${IMAGE_NAME}:latest"
+            echo "${IMAGE_NAME}:sha-${GITHUB_SHA}"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Build and push image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.tags.outputs.tags }}
+          labels: |
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.created=${{ github.event.repository.updated_at }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          provenance: false
+
+      - name: Image summary
+        run: |
+          {
+            echo "## Pushed Docker image"
+            echo
+            echo "- \`${IMAGE_NAME}:latest\`"
+            echo "- \`${IMAGE_NAME}:sha-${GITHUB_SHA}\`"
+            echo
+            echo "Coolify can now pull \`${IMAGE_NAME}:latest\` for the next deploy."
+          } >> "$GITHUB_STEP_SUMMARY"
 
   deploy:
     name: Deploy to Coolify (production)
-    needs: [build]
+    needs: [image]
     if: |
       (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
       github.event_name == 'workflow_dispatch'
@@ -202,5 +258,5 @@ jobs:
             echo "- Ref: \`${{ github.ref }}\`"
             echo "- Actor: @${{ github.actor }}"
             echo
-            echo "Coolify will pull the latest commit and rebuild the Dockerfile image."
+            echo "Coolify will pull \`ghcr.io/ryokun6/ryos:latest\` (sha-${{ github.sha }}) and roll out the new image."
           } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Add a new `image` job to the build-and-deploy workflow that builds the existing `Dockerfile` and pushes it to GHCR so Coolify can pull a pre-built image instead of rebuilding from source on every deploy.

Pushed tags:

- `ghcr.io/ryokun6/ryos:latest`
- `ghcr.io/ryokun6/ryos:sha-<commit>` (for traceability / rollbacks)

The pipeline order becomes:

```
test → build → image → deploy
```

`deploy` now `needs: [image]`, so the Coolify webhook only fires after the new image has been published.

## Implementation notes

- Uses `docker/setup-buildx-action@v3`, `docker/login-action@v3`, and `docker/build-push-action@v6`.
- Authenticates to `ghcr.io` with the workflow's `GITHUB_TOKEN` (`permissions: contents: read, packages: write` on the job).
- Builds for `linux/amd64` to match the existing `Dockerfile`'s `--platform=linux/amd64`.
- Caching uses `type=gha` cache-from/cache-to for fast incremental layer reuse.
- OCI image labels (`source`, `revision`, `created`) are populated for provenance.
- The `image` job (and `deploy`) only run on push to `main` or `workflow_dispatch` — PRs still get fast `test` + `build` validation but don't publish images.
- Removed the now-redundant `dist-<sha>` build artifact upload — the Docker image is the deployable artifact.
- Updated the deploy step's summary message to mention the GHCR image instead of "rebuild the Dockerfile image".

## Required Coolify follow-up (one-time)

Reconfigure the Coolify resource to pull from the GHCR image instead of building from source:

- Source type: **Public/Private Docker Image** (add a registry credential in Coolify if you keep the package private)
- Image: `ghcr.io/ryokun6/ryos:latest`
- Keep the existing `COOLIFY_WEBHOOK_URL` / `COOLIFY_TOKEN` secrets — only the *what Coolify does on receiving the webhook* changes, not the trigger.

The first run will create the `ryos` package under `ghcr.io/ryokun6/`. Visibility (public/private) can be set in the GitHub Packages UI afterwards.

## Verification

- ✅ `js-yaml` parses the workflow.
- ✅ `actionlint 1.7.7` passes with no errors.
- Job graph after change:
  - `test` (no deps)
  - `build` (`needs: [test]`)
  - `image` (`needs: [build]`, gated to `push:main` / `workflow_dispatch`, `permissions: contents:read, packages:write`)
  - `deploy` (`needs: [image]`, gated to `push:main` / `workflow_dispatch`)

End-to-end push/pull will be exercised the first time this lands on `main`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cf472a2e-c822-4076-91c1-bf2868df9a70"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cf472a2e-c822-4076-91c1-bf2868df9a70"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

