### PR TITLE
ci: decouple deploy from test/build, only depend on image

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -59,7 +59,6 @@ jobs:
 
   build:
     name: Build (Bun ${{ matrix.bun-version }})
-    needs: [test]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: true
@@ -97,7 +96,6 @@ jobs:
 
   image:
     name: Build & push Docker image to GHCR
-    needs: [build]
     if: |
       (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
       github.event_name == 'workflow_dispatch'


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Decouple the production image+deploy from the `test` and `build` CI checks.

### Before

```
test → build → image → deploy   (strict serial chain)
```

A red unit test or a slow `bun run build` would block production deploys.

### After

```
test           ┐
build          ┤  (CI checks — run on every PR and every push to main)
image  → deploy   (production path — runs only on push to main / workflow_dispatch)
```

- `test` and `build` still run on every PR and every push to `main`. They remain visible CI checks (and you can mark them as required in branch protection if you want them to gate merges).
- `image` no longer `needs: [build]` — it kicks off in parallel with `test`/`build` on push to `main` and just builds + pushes the Docker image.
- `deploy` still `needs: [image]`, so Coolify only fires after `ghcr.io/ryokun6/ryos:latest` is updated.

## Diff

```diff
   build:
     name: Build (Bun ${{ matrix.bun-version }})
-    needs: [test]
     runs-on: ubuntu-latest

   image:
     name: Build & push Docker image to GHCR
-    needs: [build]
     if: |
       (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
       github.event_name == 'workflow_dispatch'
```

## Trade-off (worth flagging)

A deploy can now ship even if `test` or `build` is red on `main`. If you'd rather have unit tests gate the production image, the change is one line — re-add `needs: [test]` to the `image` job. Per the request, this PR explicitly does **not** gate on them.

To enforce gating without gating the image job, the cleanest path is GitHub branch protection: mark the two CI checks as required for merging into `main`, which catches failures *before* they reach `main` rather than *after*.

## Verification

- ✅ `js-yaml` parses the workflow.
- ✅ `actionlint 1.7.7` passes with no errors.
- Job graph after change:
  - `test` — no `needs:`, no `if:` (runs on PR + push)
  - `build` — no `needs:`, no `if:` (runs on PR + push)
  - `image` — no `needs:`, gated to push-to-main / workflow_dispatch (`permissions: contents:read, packages:write`)
  - `deploy` — `needs: [image]`, gated to push-to-main / workflow_dispatch
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cf472a2e-c822-4076-91c1-bf2868df9a70"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cf472a2e-c822-4076-91c1-bf2868df9a70"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

