### PR TITLE
ci(image): allow GHCR_PAT secret as fallback for GHCR push

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -116,12 +116,29 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      # Prefer a long-lived PAT (secrets.GHCR_PAT) when configured, falling
+      # back to the auto-injected GITHUB_TOKEN otherwise. The PAT path is
+      # the escape hatch for the first push to a new user-namespace package
+      # (and for repos where org settings restrict the GITHUB_TOKEN's
+      # `packages: write` upgrade). Once the package exists and the repo's
+      # workflow permissions allow it, GITHUB_TOKEN is sufficient.
+      - name: Report which GHCR credential will be used
+        env:
+          HAS_PAT: ${{ secrets.GHCR_PAT != '' }}
+        run: |
+          if [ "${HAS_PAT}" = "true" ]; then
+            echo "Using GHCR_PAT (PAT owner: ${{ github.repository_owner }})"
+          else
+            echo "Using GITHUB_TOKEN (actor: ${{ github.actor }})"
+            echo "::notice::No GHCR_PAT secret set; falling back to GITHUB_TOKEN. If this push 403s, see PR description for fix options."
+          fi
+
       - name: Log in to GHCR
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          username: ${{ secrets.GHCR_PAT != '' && github.repository_owner || github.actor }}
+          password: ${{ secrets.GHCR_PAT || secrets.GITHUB_TOKEN }}
 
       - name: Compute image tags
         id: tags


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Add an escape‑hatch credential to the `image` job: if a repo secret named **`GHCR_PAT`** is set, use it (with `github.repository_owner` as the username) for the `ghcr.io` push. Otherwise, fall back to the default `GITHUB_TOKEN` flow exactly as before.

```diff
   - name: Log in to GHCR
     uses: docker/login-action@v3
     with:
       registry: ghcr.io
-      username: ${{ github.actor }}
-      password: ${{ secrets.GITHUB_TOKEN }}
+      username: ${{ secrets.GHCR_PAT != '' && github.repository_owner || github.actor }}
+      password: ${{ secrets.GHCR_PAT || secrets.GITHUB_TOKEN }}
```

A small report step prints which credential was selected and emits a `::notice::` annotation when falling back to `GITHUB_TOKEN`, so the next 403 has a clear breadcrumb back to this PR.

## Why

The first GHCR push from this workflow failed with:

```
failed to push ghcr.io/ryokun6/ryos:latest: unexpected status from HEAD request to
  https://ghcr.io/v2/ryokun6/ryos/blobs/sha256:7316047...: 403 Forbidden
```

The package didn't exist yet (verified via `GET /users/ryokun6/packages/container/ryos` → `404 Package not found`), and although the job declares `permissions: packages: write`, **job‑level permission upgrades are bounded by the repo's default workflow permissions**. The auto‑injected `GITHUB_TOKEN` can log in (the `[auth] ryokun6/ryos:pull,push` step succeeded) but isn't allowed to *create* a brand‑new user‑namespace package until the repo default is flipped to "Read and write permissions" — or the package is bootstrapped out‑of‑band with a PAT.

This PR makes the second path work without touching repo‑wide permissions.

## How to use

### Step 1 — Create the PAT

Either form works; fine‑grained is preferred.

**Fine‑grained (recommended):** https://github.com/settings/personal-access-tokens
- Resource owner: `ryokun6`
- Repository access: only `ryokun6/ryos`
- Account permissions → **Packages** → **Read and write**

**Classic:** https://github.com/settings/tokens
- Scope: **`write:packages`** (which implies `read:packages`)

### Step 2 — Add it as a repo secret

`https://github.com/ryokun6/ryos/settings/secrets/actions` → **New repository secret**
- Name: `GHCR_PAT`
- Value: the token

### Step 3 — Re‑run the workflow

The next run will print:

```
Using GHCR_PAT (PAT owner: ryokun6)
```

…and the push to `ghcr.io/ryokun6/ryos:latest` will succeed.

### Step 4 (optional) — go back to GITHUB_TOKEN later

Once the package exists, you can:

1. Visit `https://github.com/users/ryokun6/packages/container/ryos/settings`
2. Under **"Manage Actions access"** → **Add repository** → `ryokun6/ryos` → **Write**
3. Delete the `GHCR_PAT` secret.

The job will silently fall back to `GITHUB_TOKEN` (short‑lived, auto‑rotates, scoped to the run — preferred for security).

## Verification

- ✅ `actionlint 1.7.7` passes with no errors.
- The login step uses inline ternaries on `secrets.GHCR_PAT != ''`, so behavior is fully gated by whether the secret exists.
- No change to which events trigger the job, no change to permissions block, no change to the deploy gating — only the credentials used for the GHCR login.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cf472a2e-c822-4076-91c1-bf2868df9a70"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cf472a2e-c822-4076-91c1-bf2868df9a70"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

