### PR TITLE
ci: skip test+build jobs on main pushes, keep them for PR checks

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -23,6 +23,9 @@ concurrency:
 jobs:
   test:
     name: Unit tests (Bun ${{ matrix.bun-version }})
+    # Only run on pull requests. Pushes to main go straight to image build +
+    # Coolify deploy; PR CI is responsible for running tests before merge.
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: true
@@ -59,6 +62,9 @@ jobs:
 
   build:
     name: Build (Bun ${{ matrix.bun-version }})
+    # Only run on pull requests. Pushes to main skip this job since the
+    # Dockerfile already runs the production build inside the image step.
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: true


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Gate the `test` and `build` jobs in `.github/workflows/build-and-deploy.yml` on `github.event_name == 'pull_request'` so they only run as CI checks for PRs. Pushes to `main` (and manual `workflow_dispatch`) now go straight to image build + Coolify deploy.

## Why

Previously both jobs ran on every event, including pushes to `main`. On main:

- They blocked nothing — `image` doesn't `needs: [test, build]` — so they were effectively duplicate work running in parallel with the deploy.
- The Dockerfile already runs `bun run build` inside the image build, so the standalone `build` job was redundant on deploys.
- Result: every push to `main` paid for two extra jobs (test + a second build) before the deploy could finish.

## Behavior matrix

| Event | `test` | `build` | `image` | `deploy` |
|---|---|---|---|---|
| PR to `main` | ✅ runs | ✅ runs | skipped | skipped |
| Push to `main` | skipped | skipped | ✅ runs | ✅ runs |
| `workflow_dispatch` | skipped | skipped | ✅ runs | ✅ runs |

## Testing

- ✅ Parsed the workflow with `js-yaml` and confirmed all four jobs load with the expected `if:` conditions.
- ⚠️ No runtime test — GitHub Actions behavior is only observable once merged. The change is config-only and the `image`/`deploy` jobs were already gated identically, so the deploy path is unchanged.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f9418945-8dea-4bbc-a491-7c0e67b680ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f9418945-8dea-4bbc-a491-7c0e67b680ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

