### PR TITLE
ci(image): pass GIT_COMMIT_SHA build arg so version isn't 'dev'

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -162,6 +162,11 @@ jobs:
           platforms: linux/amd64
           push: true
           tags: ${{ steps.tags.outputs.tags }}
+          # GIT_COMMIT_SHA is consumed by `scripts/generate-build-version.ts`
+          # inside the Dockerfile so the built image's `public/version.json`
+          # reports the real commit instead of falling back to 'dev'.
+          build-args: |
+            GIT_COMMIT_SHA=${{ github.sha }}
           labels: |
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
             org.opencontainers.image.revision=${{ github.sha }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,14 @@ COPY package.json bun.lock ./
 RUN bun install --frozen-lockfile
 
 COPY . .
+
+# Commit SHA passed in by CI (e.g. GitHub Actions). The prebuild script
+# (`scripts/generate-build-version.ts`) reads this to populate the build
+# number in `public/version.json`. Without it, the script falls back to
+# 'dev' because the `.git` directory is excluded by `.dockerignore`.
+ARG GIT_COMMIT_SHA=""
+ENV GIT_COMMIT_SHA=$GIT_COMMIT_SHA
+
 RUN bun run build
 
 FROM --platform=linux/amd64 oven/bun:1.3.9 AS runtime


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Docker images built by GitHub Actions report the build version as `dev` (e.g. visible in About / `/version.json`) instead of the real commit SHA.

## Root cause

`scripts/generate-build-version.ts` (the `prebuild` hook) populates `public/version.json` with a `buildNumber` derived from, in order:

1. `VERCEL_GIT_COMMIT_SHA` (Vercel)
2. `SOURCE_COMMIT` (Coolify)
3. `GIT_COMMIT_SHA` (generic CI)
4. `git rev-parse HEAD`
5. literal `'dev'` fallback

In the GHCR image build:

- `.dockerignore` excludes `.git`, so step 4 fails inside the build container.
- The workflow set `GIT_COMMIT_SHA` only on the (unrelated) `build` PR job, not on the `image` job, and it was never forwarded into the Docker build either way.

So the script always landed on `'dev'`.

## Fix

- `Dockerfile`: declare `ARG GIT_COMMIT_SHA` after `COPY . .` and re-export it as an `ENV` so `bun run build` (and therefore the prebuild script) sees it.
- `.github/workflows/build-and-deploy.yml`: pass `GIT_COMMIT_SHA=${{ github.sha }}` via `build-args` to `docker/build-push-action`.

## Verification

Reproduced the bug and confirmed the fix locally by running the prebuild script in isolation:

Before (no `GIT_COMMIT_SHA`, no `.git`):

```
[Build] Generated version: 10.4 (dev), desktop: 1.0.1 at ...
{
  "version": "10.4",
  "buildNumber": "dev",
  "commitSha": "dev",
  ...
}
```

After (`GIT_COMMIT_SHA` exported, no `.git`):

```
[Build] Generated version: 10.4 (01801aa), desktop: 1.0.1 at ...
{
  "version": "10.4",
  "buildNumber": "01801aa",
  "commitSha": "01801aad3f611d6eb887bc0f1a9ea17a705886f8",
  ...
}
```

Workflow YAML re-validated with `python3 -c "import yaml; yaml.safe_load(...)"`.

Docker is not available in the agent environment, so the end-to-end image build itself was not re-run; the change is a pure plumbing fix (`ARG` → `ENV` → existing script that's already known to consume `GIT_COMMIT_SHA`).

## Notes

- Coolify deploys (which set `SOURCE_COMMIT`) were already unaffected.
- `public/version.json` is `.gitignored` and regenerated each build, so no stale committed file to clean up.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3dcda850-c215-4bfa-a492-8843062cdf82"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3dcda850-c215-4bfa-a492-8843062cdf82"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

