### PR TITLE
Add Trash Put Back context menu

### DIFF
--- a/src/apps/finder/components/FileList.tsx
+++ b/src/apps/finder/components/FileList.tsx
@@ -866,6 +866,8 @@ export function FileList({
     containerRef.current &&
     createSelectionRect(selectionRect.start, selectionRect.end);
   const containerRect = containerRef.current?.getBoundingClientRect();
+  // Remount the table when the final row is removed to clear stale row paint.
+  const listTableKey = files.length === 0 ? "empty" : "populated";
 
   // ------------------- Render -------------------
 
@@ -879,7 +881,7 @@ export function FileList({
         onDrop={handleContainerDrop}
         onMouseDown={handleBlankMouseDown}
       >
-        <Table className="min-w-[480px]">
+        <Table key={listTableKey} className="min-w-[480px]">
           <TableHeader>
             <TableRow className="text-[10px] border-none font-normal">
               <TableHead className="font-normal bg-gray-100/50 h-[28px]">

--- a/src/apps/finder/components/FileList.tsx
+++ b/src/apps/finder/components/FileList.tsx
@@ -39,6 +39,9 @@ export interface FileItem {
   type?: string;
   aliasType?: "file" | "app"; // For desktop shortcuts/aliases
   aliasTarget?: string; // Target path or appId for aliases
+  originalPath?: string; // Original location for trashed files
+  deletedAt?: number; // Trash timestamp
+  status?: "active" | "trashed";
 }
 
 interface FileListProps {

--- a/src/apps/finder/components/FinderAppComponent.tsx
+++ b/src/apps/finder/components/FinderAppComponent.tsx
@@ -250,7 +250,9 @@ export function FinderAppComponent({
       onEmptyTrash={handleEmptyTrash}
       onRestore={handleRestore}
       isTrashEmpty={trashItemsCount === 0}
-      isInTrash={Boolean(selectedFile?.path.startsWith("/Trash"))}
+      isInTrash={Boolean(
+        selectedFile && (currentPath === "/Trash" || selectedFile.status === "trashed")
+      )}
       onNavigateBack={navigateBack}
       onNavigateForward={navigateForward}
       canNavigateBack={canNavigateBack()}

--- a/src/apps/finder/hooks/useFinderLogic.ts
+++ b/src/apps/finder/hooks/useFinderLogic.ts
@@ -1237,57 +1237,67 @@ export function useFinderLogic({
     ];
   };
 
-  const fileMenuItems = (file: FileItem): MenuItem[] => [
-    {
-      type: "item",
-      label: t("apps.finder.contextMenu.open"),
-      onSelect: () => handleFileOpen(file),
-    },
-    { type: "separator" },
-    {
-      type: "submenu",
-      label: t("apps.finder.contextMenu.shareViaAirDrop"),
-      items: getAirDropMenuItems(file),
-      disabled: !canShareViaAirDrop(file),
-    },
-    { type: "separator" },
-    {
-      type: "item",
-      label: t("apps.finder.contextMenu.addToDesktop"),
-      onSelect: () => handleAddToDesktop(file),
-      disabled:
-        file.isDirectory ||
-        file.path.startsWith("/Desktop") ||
-        file.path === "/Desktop",
-    },
-    {
-      type: "item",
-      label: t("common.dock.addToDock"),
-      onSelect: () => handleAddToDock(file),
-      disabled: !isDockable(file) || isAlreadyInDock(file),
-    },
-    { type: "separator" },
-    {
-      type: "item",
-      label: t("apps.finder.contextMenu.rename"),
-      onSelect: handleRename,
-    },
-    {
-      type: "item",
-      label: t("apps.finder.contextMenu.duplicate"),
-      onSelect: handleDuplicate,
-    },
-    {
-      type: "item",
-      label: t("apps.finder.contextMenu.moveToTrash"),
-      onSelect: () => trackedMoveToTrash(file),
-      disabled:
-        file.path.startsWith("/Trash") ||
-        file.path === "/Documents" ||
-        file.path === "/Images" ||
-        file.path === "/Applications",
-    },
-  ];
+  const fileMenuItems = (file: FileItem): MenuItem[] => {
+    const isTrashedItem = currentPath === "/Trash" || file.status === "trashed";
+
+    return [
+      {
+        type: "item",
+        label: t("apps.finder.contextMenu.open"),
+        onSelect: () => handleFileOpen(file),
+      },
+      { type: "separator" },
+      {
+        type: "submenu",
+        label: t("apps.finder.contextMenu.shareViaAirDrop"),
+        items: getAirDropMenuItems(file),
+        disabled: !canShareViaAirDrop(file),
+      },
+      { type: "separator" },
+      {
+        type: "item",
+        label: t("apps.finder.contextMenu.addToDesktop"),
+        onSelect: () => handleAddToDesktop(file),
+        disabled:
+          file.isDirectory ||
+          file.path.startsWith("/Desktop") ||
+          file.path === "/Desktop",
+      },
+      {
+        type: "item",
+        label: t("common.dock.addToDock"),
+        onSelect: () => handleAddToDock(file),
+        disabled: !isDockable(file) || isAlreadyInDock(file),
+      },
+      { type: "separator" },
+      {
+        type: "item",
+        label: t("apps.finder.contextMenu.rename"),
+        onSelect: handleRename,
+      },
+      {
+        type: "item",
+        label: t("apps.finder.contextMenu.duplicate"),
+        onSelect: handleDuplicate,
+      },
+      isTrashedItem
+        ? {
+            type: "item",
+            label: t("apps.finder.contextMenu.putBack"),
+            onSelect: () => restoreFromTrash(file),
+          }
+        : {
+            type: "item",
+            label: t("apps.finder.contextMenu.moveToTrash"),
+            onSelect: () => trackedMoveToTrash(file),
+            disabled:
+              file.path.startsWith("/Trash") ||
+              file.path === "/Documents" ||
+              file.path === "/Images" ||
+              file.path === "/Applications",
+          },
+    ];
+  };
 
   const isXpTheme = currentTheme === "xp" || currentTheme === "win98";
   const isMacOSXTheme = currentTheme === "macosx";

--- a/src/lib/locales/de/translation.json
+++ b/src/lib/locales/de/translation.json
@@ -1761,6 +1761,7 @@
         "emptyTrash": "Papierkorb leeren...",
         "kind": "Art",
         "moveToTrash": "In den Papierkorb legen",
+        "putBack": "Zurücklegen",
         "name": "Name",
         "newFolder": "Neuer Ordner…",
         "noAirDropUsersAvailable": "Keine Nutzer in der Nähe",

--- a/src/lib/locales/en/translation.json
+++ b/src/lib/locales/en/translation.json
@@ -393,6 +393,7 @@
         "rename": "Rename…",
         "duplicate": "Duplicate",
         "moveToTrash": "Move to Trash",
+        "putBack": "Put Back",
         "shareViaAirDrop": "Share via AirDrop",
         "searchingForAirDropUsers": "Searching for nearby users…",
         "noAirDropUsersAvailable": "No nearby users",

--- a/src/lib/locales/es/translation.json
+++ b/src/lib/locales/es/translation.json
@@ -1761,6 +1761,7 @@
         "emptyTrash": "Vaciar Papelera...",
         "kind": "Tipo",
         "moveToTrash": "Mover a la Papelera",
+        "putBack": "Volver a colocar",
         "name": "Nombre",
         "newFolder": "Nueva Carpeta…",
         "noAirDropUsersAvailable": "No hay usuarios cercanos",

--- a/src/lib/locales/fr/translation.json
+++ b/src/lib/locales/fr/translation.json
@@ -1761,6 +1761,7 @@
         "emptyTrash": "Vider la corbeille...",
         "kind": "Type",
         "moveToTrash": "Placer dans la corbeille",
+        "putBack": "Remettre à sa place",
         "name": "Nom",
         "newFolder": "Nouveau dossier…",
         "noAirDropUsersAvailable": "Aucun utilisateur a proximité",

--- a/src/lib/locales/it/translation.json
+++ b/src/lib/locales/it/translation.json
@@ -1761,6 +1761,7 @@
         "emptyTrash": "Svuota Cestino...",
         "kind": "Tipo",
         "moveToTrash": "Sposta nel Cestino",
+        "putBack": "Ripristina",
         "name": "Nome",
         "newFolder": "Nuova Cartella…",
         "noAirDropUsersAvailable": "Nessun utente nelle vicinanze",

--- a/src/lib/locales/ja/translation.json
+++ b/src/lib/locales/ja/translation.json
@@ -1761,6 +1761,7 @@
         "emptyTrash": "ゴミ箱を空にする...",
         "kind": "種類",
         "moveToTrash": "ゴミ箱に入れる",
+        "putBack": "元に戻す",
         "name": "名前",
         "newFolder": "新規フォルダ…",
         "noAirDropUsersAvailable": "近くのユーザーはいません",

--- a/src/lib/locales/ko/translation.json
+++ b/src/lib/locales/ko/translation.json
@@ -1761,6 +1761,7 @@
         "emptyTrash": "휴지통 비우기...",
         "kind": "종류",
         "moveToTrash": "휴지통으로 이동",
+        "putBack": "되돌리기",
         "name": "이름",
         "newFolder": "새 폴더…",
         "noAirDropUsersAvailable": "근처 사용자가 없습니다",

--- a/src/lib/locales/pt/translation.json
+++ b/src/lib/locales/pt/translation.json
@@ -1761,6 +1761,7 @@
         "emptyTrash": "Esvaziar Lixeira...",
         "kind": "Tipo",
         "moveToTrash": "Mover para a Lixeira",
+        "putBack": "Colocar de Volta",
         "name": "Nome",
         "newFolder": "Nova Pasta…",
         "noAirDropUsersAvailable": "Nenhum usuário próximo",

--- a/src/lib/locales/ru/translation.json
+++ b/src/lib/locales/ru/translation.json
@@ -1761,6 +1761,7 @@
         "emptyTrash": "Очистить Корзину...",
         "kind": "Вид",
         "moveToTrash": "Переместить в Корзину",
+        "putBack": "Вернуть на место",
         "name": "Имя",
         "newFolder": "Новая папка…",
         "noAirDropUsersAvailable": "Пользователей поблизости нет",

--- a/src/lib/locales/zh-TW/translation.json
+++ b/src/lib/locales/zh-TW/translation.json
@@ -1761,6 +1761,7 @@
         "emptyTrash": "清空垃圾桶…",
         "kind": "種類",
         "moveToTrash": "丟到垃圾桶",
+        "putBack": "放回",
         "name": "名稱",
         "newFolder": "新增檔案夾…",
         "noAirDropUsersAvailable": "附近沒有使用者",

--- a/tests/test-finder-trash-store.test.ts
+++ b/tests/test-finder-trash-store.test.ts
@@ -1,0 +1,64 @@
+#!/usr/bin/env bun
+
+import { beforeEach, describe, expect, test } from "bun:test";
+import { useFilesStore, type FileSystemItem } from "../src/stores/useFilesStore";
+
+const makeDirectory = (path: string, name: string): FileSystemItem => ({
+  path,
+  name,
+  isDirectory: true,
+  type: "directory",
+  status: "active",
+});
+
+const makeDocument = (path: string, name: string): FileSystemItem => ({
+  path,
+  name,
+  isDirectory: false,
+  type: "text",
+  uuid: `${name}-uuid`,
+  status: "active",
+});
+
+describe("finder trash store", () => {
+  beforeEach(() => {
+    useFilesStore.setState({
+      items: {
+        "/Trash": {
+          ...makeDirectory("/Trash", "Trash"),
+          icon: "/icons/trash-empty.png",
+        },
+        "/Documents": makeDirectory("/Documents", "Documents"),
+        "/Documents/Note.txt": makeDocument("/Documents/Note.txt", "Note.txt"),
+      },
+      libraryState: "loaded",
+    });
+  });
+
+  test("restores trashed items to their original path metadata", () => {
+    const store = useFilesStore.getState();
+
+    store.removeItem("/Documents/Note.txt");
+
+    expect(store.getItemsInPath("/Documents").map((item) => item.path)).toEqual([]);
+    expect(store.getItemsInPath("/Trash").map((item) => item.path)).toEqual([
+      "/Documents/Note.txt",
+    ]);
+    expect(store.getItem("/Documents/Note.txt")).toMatchObject({
+      status: "trashed",
+      originalPath: "/Documents/Note.txt",
+    });
+
+    store.restoreItem("/Documents/Note.txt");
+
+    expect(store.getItemsInPath("/Trash")).toEqual([]);
+    expect(store.getItemsInPath("/Documents").map((item) => item.path)).toEqual([
+      "/Documents/Note.txt",
+    ]);
+    expect(store.getItem("/Documents/Note.txt")).toMatchObject({
+      status: "active",
+      originalPath: undefined,
+      deletedAt: undefined,
+    });
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add a localized Finder context-menu `Put Back` action for items viewed in Trash.
- Wire the action to the existing trash restore flow so items return to their original metadata path.
- Fix Finder menubar Trash selection detection for trashed items that keep their original path.
- Remount the Finder list table when Trash transitions from populated to empty to avoid stale ghost rows.
- Add a store regression test for moving an item to Trash and restoring it.

## Walkthrough
<a href="https://cursor.com/agents/bc-07dd0724-bba0-40e5-b9d9-9b0a01b917b5/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftrash_put_back_workflow_clean.mp4"><img src="https://cursor.com/artifacts/c/art-8c95a4ab-1663-4f30-82df-e0e3e040836b" alt="trash_put_back_workflow_clean.mp4" /></a>

![Trash context menu showing Put Back](https://cursor.com/artifacts/c/art-d23d0abc-b758-4d11-812a-af661742056a)
![Trash empty after Put Back](https://cursor.com/artifacts/c/art-b21a8b7c-15b2-4ed9-a9c6-9aac9243f91d)
![Documents restored after Put Back](https://cursor.com/artifacts/c/art-e28080cc-0b1a-459f-8269-426d61da1dbd)

## Testing
- `bun test tests/test-finder-trash-store.test.ts` passed.
- `bun run build` passed.
- Manual browser retest passed: Move to Trash, Put Back context menu, clean empty Trash, restored original Documents path.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-07dd0724-bba0-40e5-b9d9-9b0a01b917b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-07dd0724-bba0-40e5-b9d9-9b0a01b917b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

