### PR TITLE
Let aquarium bubbles overflow and fade

### DIFF
--- a/src/apps/dashboard/components/DashboardAppComponent.tsx
+++ b/src/apps/dashboard/components/DashboardAppComponent.tsx
@@ -16,7 +16,7 @@ import { TranslationWidget, TranslationBackPanel } from "@/components/layout/das
 import { CurrencyWidget, CurrencyBackPanel } from "@/components/layout/dashboard/CurrencyWidget";
 import { StickyNoteWidget, StickyNoteBackPanel } from "@/components/layout/dashboard/StickyNoteWidget";
 import { DictionaryWidget, DictionaryBackPanel } from "@/components/layout/dashboard/DictionaryWidget";
-import { AquariumWidget } from "@/components/layout/dashboard/AquariumWidget";
+import { AquariumWidget, AquariumBubbleOverflow } from "@/components/layout/dashboard/AquariumWidget";
 import { DashboardMenuBar } from "./DashboardMenuBar";
 import { useAppStore } from "@/stores/useAppStore";
 import { useTranslation } from "react-i18next";
@@ -79,6 +79,7 @@ function WidgetBackContent({ type, widgetId, onDone }: { type: string; widgetId:
 
 function WidgetOverflow({ type, widgetId }: { type: string; widgetId: string }) {
   if (type === "weather") return <WeatherEmojiOverflow widgetId={widgetId} />;
+  if (type === "aquarium") return <AquariumBubbleOverflow widgetId={widgetId} />;
   return null;
 }
 

--- a/src/apps/dashboard/components/DashboardAppComponent.tsx
+++ b/src/apps/dashboard/components/DashboardAppComponent.tsx
@@ -16,7 +16,7 @@ import { TranslationWidget, TranslationBackPanel } from "@/components/layout/das
 import { CurrencyWidget, CurrencyBackPanel } from "@/components/layout/dashboard/CurrencyWidget";
 import { StickyNoteWidget, StickyNoteBackPanel } from "@/components/layout/dashboard/StickyNoteWidget";
 import { DictionaryWidget, DictionaryBackPanel } from "@/components/layout/dashboard/DictionaryWidget";
-import { AquariumWidget, AquariumBubbleOverflow } from "@/components/layout/dashboard/AquariumWidget";
+import { AquariumWidget } from "@/components/layout/dashboard/AquariumWidget";
 import { DashboardMenuBar } from "./DashboardMenuBar";
 import { useAppStore } from "@/stores/useAppStore";
 import { useTranslation } from "react-i18next";
@@ -79,7 +79,6 @@ function WidgetBackContent({ type, widgetId, onDone }: { type: string; widgetId:
 
 function WidgetOverflow({ type, widgetId }: { type: string; widgetId: string }) {
   if (type === "weather") return <WeatherEmojiOverflow widgetId={widgetId} />;
-  if (type === "aquarium") return <AquariumBubbleOverflow widgetId={widgetId} />;
   return null;
 }
 
@@ -461,6 +460,7 @@ export function DashboardAppComponent({
                               zIndex={widget.zIndex ?? 1}
                               borderRadius={widget.type === "ipod" ? "9999px" : undefined}
                               hideDoneButton={widget.type === "ipod"}
+                              allowOverflow={widget.type === "aquarium"}
                               onRemove={() => removeWidget(widget.id)}
                               overflowContent={<WidgetOverflow type={widget.type} widgetId={widget.id} />}
                               backContent={(onFlipBack) => <WidgetBackContent type={widget.type} widgetId={widget.id} onDone={onFlipBack} />}
@@ -507,6 +507,7 @@ export function DashboardAppComponent({
                           zIndex={widget.zIndex ?? 1}
                           borderRadius={widget.type === "ipod" ? "9999px" : undefined}
                           hideDoneButton={widget.type === "ipod"}
+                          allowOverflow={widget.type === "aquarium"}
                           onRemove={() => removeWidget(widget.id)}
                           onMove={(pos) => moveWidget(widget.id, pos)}
                           onBringToFront={() => bringToFront(widget.id)}

--- a/src/apps/dashboard/components/DashboardAppComponent.tsx
+++ b/src/apps/dashboard/components/DashboardAppComponent.tsx
@@ -16,7 +16,7 @@ import { TranslationWidget, TranslationBackPanel } from "@/components/layout/das
 import { CurrencyWidget, CurrencyBackPanel } from "@/components/layout/dashboard/CurrencyWidget";
 import { StickyNoteWidget, StickyNoteBackPanel } from "@/components/layout/dashboard/StickyNoteWidget";
 import { DictionaryWidget, DictionaryBackPanel } from "@/components/layout/dashboard/DictionaryWidget";
-import { AquariumWidget } from "@/components/layout/dashboard/AquariumWidget";
+import { AquariumWidget, AquariumBubbleOverflow } from "@/components/layout/dashboard/AquariumWidget";
 import { DashboardMenuBar } from "./DashboardMenuBar";
 import { useAppStore } from "@/stores/useAppStore";
 import { useTranslation } from "react-i18next";
@@ -79,6 +79,7 @@ function WidgetBackContent({ type, widgetId, onDone }: { type: string; widgetId:
 
 function WidgetOverflow({ type, widgetId }: { type: string; widgetId: string }) {
   if (type === "weather") return <WeatherEmojiOverflow widgetId={widgetId} />;
+  if (type === "aquarium") return <AquariumBubbleOverflow widgetId={widgetId} />;
   return null;
 }
 
@@ -460,7 +461,6 @@ export function DashboardAppComponent({
                               zIndex={widget.zIndex ?? 1}
                               borderRadius={widget.type === "ipod" ? "9999px" : undefined}
                               hideDoneButton={widget.type === "ipod"}
-                              allowOverflow={widget.type === "aquarium"}
                               onRemove={() => removeWidget(widget.id)}
                               overflowContent={<WidgetOverflow type={widget.type} widgetId={widget.id} />}
                               backContent={(onFlipBack) => <WidgetBackContent type={widget.type} widgetId={widget.id} onDone={onFlipBack} />}
@@ -507,7 +507,6 @@ export function DashboardAppComponent({
                           zIndex={widget.zIndex ?? 1}
                           borderRadius={widget.type === "ipod" ? "9999px" : undefined}
                           hideDoneButton={widget.type === "ipod"}
-                          allowOverflow={widget.type === "aquarium"}
                           onRemove={() => removeWidget(widget.id)}
                           onMove={(pos) => moveWidget(widget.id, pos)}
                           onBringToFront={() => bringToFront(widget.id)}

--- a/src/components/layout/dashboard/AquariumWidget.tsx
+++ b/src/components/layout/dashboard/AquariumWidget.tsx
@@ -1,4 +1,5 @@
-import EmojiAquarium from "@/components/shared/EmojiAquarium";
+import EmojiAquarium, { AquariumBubbleOverflowLayer } from "@/components/shared/EmojiAquarium";
+import { useDashboardStore } from "@/stores/useDashboardStore";
 
 interface AquariumWidgetProps {
   widgetId: string;
@@ -18,5 +19,20 @@ export function AquariumWidget({ widgetId }: AquariumWidgetProps) {
         className="h-full min-h-[inherit] rounded-[inherit] shadow-[inset_0_1px_8px_rgba(255,255,255,0.35),inset_0_-10px_18px_rgba(3,105,161,0.2)]"
       />
     </div>
+  );
+}
+
+export function AquariumBubbleOverflow({ widgetId }: AquariumWidgetProps) {
+  const widget = useDashboardStore((s) => s.widgets.find((w) => w.id === widgetId));
+  if (!widget) return null;
+
+  return (
+    <AquariumBubbleOverflowLayer
+      seed={`${widgetId}:dashboard-bubble-overflow`}
+      width={widget.size.width}
+      height={widget.size.height}
+      count={4}
+      className="z-10"
+    />
   );
 }

--- a/src/components/layout/dashboard/AquariumWidget.tsx
+++ b/src/components/layout/dashboard/AquariumWidget.tsx
@@ -31,7 +31,7 @@ export function AquariumBubbleOverflow({ widgetId }: AquariumWidgetProps) {
       seed={`${widgetId}:dashboard-bubble-overflow`}
       width={widget.size.width}
       height={widget.size.height}
-      count={8}
+      count={10}
       className="z-50"
     />
   );

--- a/src/components/layout/dashboard/AquariumWidget.tsx
+++ b/src/components/layout/dashboard/AquariumWidget.tsx
@@ -1,4 +1,5 @@
-import EmojiAquarium from "@/components/shared/EmojiAquarium";
+import EmojiAquarium, { AquariumBubbleOverflowLayer } from "@/components/shared/EmojiAquarium";
+import { useDashboardStore } from "@/stores/useDashboardStore";
 
 interface AquariumWidgetProps {
   widgetId: string;
@@ -18,5 +19,20 @@ export function AquariumWidget({ widgetId }: AquariumWidgetProps) {
         className="h-full min-h-[inherit] rounded-[inherit] shadow-[inset_0_1px_8px_rgba(255,255,255,0.35),inset_0_-10px_18px_rgba(3,105,161,0.2)]"
       />
     </div>
+  );
+}
+
+export function AquariumBubbleOverflow({ widgetId }: AquariumWidgetProps) {
+  const widget = useDashboardStore((s) => s.widgets.find((w) => w.id === widgetId));
+  if (!widget) return null;
+
+  return (
+    <AquariumBubbleOverflowLayer
+      seed={`${widgetId}:dashboard-bubble-overflow`}
+      width={widget.size.width}
+      height={widget.size.height}
+      count={8}
+      className="z-50"
+    />
   );
 }

--- a/src/components/layout/dashboard/AquariumWidget.tsx
+++ b/src/components/layout/dashboard/AquariumWidget.tsx
@@ -31,7 +31,7 @@ export function AquariumBubbleOverflow({ widgetId }: AquariumWidgetProps) {
       seed={`${widgetId}:dashboard-bubble-overflow`}
       width={widget.size.width}
       height={widget.size.height}
-      count={4}
+      count={6}
       className="z-10"
     />
   );

--- a/src/components/layout/dashboard/AquariumWidget.tsx
+++ b/src/components/layout/dashboard/AquariumWidget.tsx
@@ -1,5 +1,4 @@
-import EmojiAquarium, { AquariumBubbleOverflowLayer } from "@/components/shared/EmojiAquarium";
-import { useDashboardStore } from "@/stores/useDashboardStore";
+import EmojiAquarium from "@/components/shared/EmojiAquarium";
 
 interface AquariumWidgetProps {
   widgetId: string;
@@ -19,20 +18,5 @@ export function AquariumWidget({ widgetId }: AquariumWidgetProps) {
         className="h-full min-h-[inherit] rounded-[inherit] shadow-[inset_0_1px_8px_rgba(255,255,255,0.35),inset_0_-10px_18px_rgba(3,105,161,0.2)]"
       />
     </div>
-  );
-}
-
-export function AquariumBubbleOverflow({ widgetId }: AquariumWidgetProps) {
-  const widget = useDashboardStore((s) => s.widgets.find((w) => w.id === widgetId));
-  if (!widget) return null;
-
-  return (
-    <AquariumBubbleOverflowLayer
-      seed={`${widgetId}:dashboard-bubble-overflow`}
-      width={widget.size.width}
-      height={widget.size.height}
-      count={6}
-      className="z-10"
-    />
   );
 }

--- a/src/components/layout/dashboard/WidgetChrome.tsx
+++ b/src/components/layout/dashboard/WidgetChrome.tsx
@@ -15,6 +15,7 @@ interface WidgetChromeProps {
   zIndex?: number;
   borderRadius?: string;
   hideDoneButton?: boolean;
+  allowOverflow?: boolean;
   /**
    * "absolute" (default) — uses x/y for positioning and supports drag.
    * "stacked" — relative positioning for use in a vertical/grid layout (mobile);
@@ -37,6 +38,7 @@ export function WidgetChrome({
   zIndex = 1,
   borderRadius: borderRadiusProp,
   hideDoneButton,
+  allowOverflow = false,
   layout = "absolute",
   onRemove,
   onMove,
@@ -276,7 +278,7 @@ export function WidgetChrome({
         >
           {/* Front face */}
           <div
-            className="relative overflow-hidden"
+            className={`relative ${allowOverflow ? "overflow-visible" : "overflow-hidden"}`}
             style={{
               ...cardStyle,
               backfaceVisibility: "hidden",

--- a/src/components/layout/dashboard/WidgetChrome.tsx
+++ b/src/components/layout/dashboard/WidgetChrome.tsx
@@ -15,7 +15,6 @@ interface WidgetChromeProps {
   zIndex?: number;
   borderRadius?: string;
   hideDoneButton?: boolean;
-  allowOverflow?: boolean;
   /**
    * "absolute" (default) — uses x/y for positioning and supports drag.
    * "stacked" — relative positioning for use in a vertical/grid layout (mobile);
@@ -38,7 +37,6 @@ export function WidgetChrome({
   zIndex = 1,
   borderRadius: borderRadiusProp,
   hideDoneButton,
-  allowOverflow = false,
   layout = "absolute",
   onRemove,
   onMove,
@@ -278,7 +276,7 @@ export function WidgetChrome({
         >
           {/* Front face */}
           <div
-            className={`relative ${allowOverflow ? "overflow-visible" : "overflow-hidden"}`}
+            className="relative overflow-hidden"
             style={{
               ...cardStyle,
               backfaceVisibility: "hidden",

--- a/src/components/shared/EmojiAquarium.tsx
+++ b/src/components/shared/EmojiAquarium.tsx
@@ -14,7 +14,17 @@ interface EmojiAquariumProps {
   variant?: "chat" | "widget";
 }
 
-function useSeededRandom(seed?: string) {
+interface AquariumBubbleOverflowLayerProps {
+  seed?: string;
+  width: number;
+  height: number;
+  count?: number;
+  className?: string;
+}
+
+const BUBBLE_EMOJI = "🫧"; // falls back to monochrome when unsupported
+
+function createSeededRandom(seed?: string) {
   // Mulberry32 PRNG
   let a = 0;
   if (seed && seed.length > 0) {
@@ -31,6 +41,65 @@ function useSeededRandom(seed?: string) {
   };
 }
 
+export function AquariumBubbleOverflowLayer({
+  seed,
+  width,
+  height,
+  count = 3,
+  className,
+}: AquariumBubbleOverflowLayerProps) {
+  const rand = createSeededRandom(seed);
+  const escapeHeight = Math.max(28, Math.round(height * 0.24));
+  const safeWidth = Math.max(1, width);
+
+  return (
+    <div
+      className={cn("absolute left-0 top-0 pointer-events-none overflow-visible", className)}
+      style={{ width: safeWidth, height }}
+      aria-hidden="true"
+    >
+      {Array.from({ length: count }).map((_, i) => {
+        const edgePad = 8;
+        const x = edgePad + rand() * Math.max(0, safeWidth - edgePad * 2);
+        const start = rand() * (height * 0.5);
+        const drift = (rand() - 0.5) * 34;
+        const dur = 11 + rand() * 10;
+        const delay = rand() * 7;
+        const size = 18 + rand() * 10;
+        const exitsTank = rand() > 0.35;
+        const endY = exitsTank ? -(18 + rand() * escapeHeight) : -16;
+
+        return (
+          <motion.span
+            key={`bubble-overflow-${i}`}
+            initial={{ x, y: height - start, opacity: 0, scale: 0.45 }}
+            animate={{
+              x: [x, x + drift * 0.4, x + drift],
+              y: [height - start, Math.min(10, endY + escapeHeight * 0.45), endY],
+              opacity: [0, 0.45, 0.75, 0],
+              scale: [0.45, 0.85, 1.15, 0.7],
+            }}
+            transition={{
+              duration: dur,
+              ease: "easeOut",
+              repeat: Infinity,
+              delay,
+            }}
+            style={{
+              position: "absolute",
+              willChange: "transform, opacity",
+              filter: "drop-shadow(0 2px 4px rgba(255,255,255,0.22))",
+            }}
+            className="select-none"
+          >
+            <Emoji emoji={BUBBLE_EMOJI} size={size} />
+          </motion.span>
+        );
+      })}
+    </div>
+  );
+}
+
 export function EmojiAquarium({ seed, className, variant = "chat" }: EmojiAquariumProps) {
   // Create a stable seed once so re-renders (e.g., hover) don't change layout.
   const seedRef = useRef<string | undefined>(seed);
@@ -44,7 +113,7 @@ export function EmojiAquarium({ seed, className, variant = "chat" }: EmojiAquari
     }
   }, [seed]);
 
-  const rand = useSeededRandom(seedRef.current);
+  const rand = createSeededRandom(seedRef.current);
 
   // Responsive: chat uses an aspect ratio, dashboard widgets fill their frame.
   const containerRef = useRef<HTMLDivElement>(null);
@@ -85,8 +154,6 @@ export function EmojiAquarium({ seed, className, variant = "chat" }: EmojiAquari
   const largeFishes = ["🦈", "🐬"];
   const decor = ["🪸", "⚓️", "🪨", "🌿", "🗿", "🐚", "🦑", "🦀"];
 
-  const bubbles = "🫧"; // falls back to monochrome when unsupported
-
   const floorXs = useMemo(() => {
     const xs: number[] = [];
     if (floorCount <= 0) return xs;
@@ -115,8 +182,8 @@ export function EmojiAquarium({ seed, className, variant = "chat" }: EmojiAquari
       <div
         className={cn(
           variant === "chat"
-            ? "chat-bubble bg-blue-300 text-black !p-0 mb-2 w-full max-w-[420px] rounded"
-            : "h-full min-h-[inherit] bg-blue-300 text-black w-full overflow-hidden rounded-[inherit]",
+            ? "chat-bubble relative overflow-visible bg-blue-300 text-black !p-0 mb-2 w-full max-w-[420px] rounded"
+            : "relative h-full min-h-[inherit] bg-blue-300 text-black w-full overflow-visible rounded-[inherit]",
           className
         )}
         ref={containerRef}
@@ -300,7 +367,7 @@ export function EmojiAquarium({ seed, className, variant = "chat" }: EmojiAquari
                 }}
                 className="select-none z-25"
               >
-                <Emoji emoji={bubbles} size={24} />
+                <Emoji emoji={BUBBLE_EMOJI} size={24} />
               </motion.span>
             );
           })}
@@ -334,7 +401,7 @@ export function EmojiAquarium({ seed, className, variant = "chat" }: EmojiAquari
                 }}
                 className="select-none z-40"
               >
-                <Emoji emoji={bubbles} size={28} />
+                <Emoji emoji={BUBBLE_EMOJI} size={28} />
               </motion.span>
             );
           })}
@@ -383,6 +450,15 @@ export function EmojiAquarium({ seed, className, variant = "chat" }: EmojiAquari
             <Emoji emoji={"🛟"} size={24} />
           </motion.span>
         </div>
+        {variant === "chat" && (
+          <AquariumBubbleOverflowLayer
+            seed={`${seedRef.current}:chat-bubble-overflow`}
+            width={width}
+            height={height}
+            count={3}
+            className="z-50"
+          />
+        )}
       </div>
     </MotionConfig>
   );

--- a/src/components/shared/EmojiAquarium.tsx
+++ b/src/components/shared/EmojiAquarium.tsx
@@ -450,15 +450,13 @@ export function EmojiAquarium({ seed, className, variant = "chat" }: EmojiAquari
             <Emoji emoji={"🛟"} size={24} />
           </motion.span>
         </div>
-        {variant === "chat" && (
-          <AquariumBubbleOverflowLayer
-            seed={`${seedRef.current}:chat-bubble-overflow`}
-            width={width}
-            height={height}
-            count={4}
-            className="z-50"
-          />
-        )}
+        <AquariumBubbleOverflowLayer
+          seed={`${seedRef.current}:${variant}-bubble-overflow`}
+          width={width}
+          height={height}
+          count={variant === "widget" ? 6 : 4}
+          className="z-50"
+        />
       </div>
     </MotionConfig>
   );

--- a/src/components/shared/EmojiAquarium.tsx
+++ b/src/components/shared/EmojiAquarium.tsx
@@ -49,7 +49,7 @@ export function AquariumBubbleOverflowLayer({
   className,
 }: AquariumBubbleOverflowLayerProps) {
   const rand = createSeededRandom(seed);
-  const escapeHeight = Math.max(16, Math.round(height * 0.1));
+  const escapeHeight = Math.max(28, Math.round(height * 0.14));
   const safeWidth = Math.max(1, width);
 
   return (
@@ -68,11 +68,11 @@ export function AquariumBubbleOverflowLayer({
         const drift = (rand() - 0.5) * 34;
         const dur = 8 + rand() * 7;
         const delay = i * 0.8 + rand() * 1.5;
-        const size = (startsNearSurface ? 24 : 18) + rand() * 10;
+        const size = (startsNearSurface ? 32 : 20) + rand() * 10;
         const exitsTank = i < Math.ceil(count / 2) || rand() > 0.35;
-        const endY = exitsTank ? -(6 + rand() * escapeHeight) : -6;
-        const edgeY = exitsTank ? Math.min(-6, endY * 0.55) : 6;
-        const fadeY = exitsTank ? endY - 10 : endY;
+        const endY = exitsTank ? -(12 + rand() * escapeHeight) : -6;
+        const edgeY = exitsTank ? Math.min(-10, endY * 0.5) : 6;
+        const fadeY = exitsTank ? endY - 14 : endY;
 
         return (
           <motion.span
@@ -81,8 +81,8 @@ export function AquariumBubbleOverflowLayer({
             animate={{
               x: [x, x + drift * 0.35, x + drift * 0.7, x + drift],
               y: [startY, edgeY, endY, fadeY],
-              opacity: [0, 0.9, 0.85, 0],
-              scale: [0.45, 1.05, 1, 0.72],
+              opacity: [0, 1, 0.95, 0],
+              scale: [0.45, 1.12, 1.05, 0.72],
             }}
             transition={{
               duration: dur,
@@ -93,7 +93,7 @@ export function AquariumBubbleOverflowLayer({
             style={{
               position: "absolute",
               willChange: "transform, opacity",
-              filter: "drop-shadow(0 2px 6px rgba(255,255,255,0.35))",
+              filter: "drop-shadow(0 2px 8px rgba(255,255,255,0.55))",
             }}
             className="select-none"
           >
@@ -460,7 +460,7 @@ export function EmojiAquarium({ seed, className, variant = "chat" }: EmojiAquari
             seed={`${seedRef.current}:chat-bubble-overflow`}
             width={width}
             height={height}
-            count={5}
+            count={6}
             className="z-50"
           />
         )}

--- a/src/components/shared/EmojiAquarium.tsx
+++ b/src/components/shared/EmojiAquarium.tsx
@@ -55,7 +55,7 @@ export function AquariumBubbleOverflowLayer({
   return (
     <div
       className={cn("absolute left-0 top-0 pointer-events-none overflow-visible", className)}
-      style={{ width: safeWidth, height }}
+      style={{ width: safeWidth, height, zIndex: 60 }}
       aria-hidden="true"
     >
       {Array.from({ length: count }).map((_, i) => {
@@ -63,10 +63,10 @@ export function AquariumBubbleOverflowLayer({
         const x = edgePad + rand() * Math.max(0, safeWidth - edgePad * 2);
         const start = rand() * (height * 0.5);
         const drift = (rand() - 0.5) * 34;
-        const dur = 11 + rand() * 10;
-        const delay = rand() * 7;
+        const dur = 8 + rand() * 7;
+        const delay = i * 0.8 + rand() * 1.5;
         const size = 18 + rand() * 10;
-        const exitsTank = rand() > 0.35;
+        const exitsTank = i < Math.ceil(count / 2) || rand() > 0.35;
         const endY = exitsTank ? -(18 + rand() * escapeHeight) : -16;
 
         return (
@@ -455,7 +455,7 @@ export function EmojiAquarium({ seed, className, variant = "chat" }: EmojiAquari
             seed={`${seedRef.current}:chat-bubble-overflow`}
             width={width}
             height={height}
-            count={3}
+            count={4}
             className="z-50"
           />
         )}

--- a/src/components/shared/EmojiAquarium.tsx
+++ b/src/components/shared/EmojiAquarium.tsx
@@ -61,23 +61,27 @@ export function AquariumBubbleOverflowLayer({
       {Array.from({ length: count }).map((_, i) => {
         const edgePad = 8;
         const x = edgePad + rand() * Math.max(0, safeWidth - edgePad * 2);
-        const start = rand() * (height * 0.5);
+        const startsNearSurface = i < Math.ceil(count / 3);
+        const startY = startsNearSurface
+          ? 10 + rand() * Math.max(12, height * 0.16)
+          : height - rand() * (height * 0.5);
         const drift = (rand() - 0.5) * 34;
         const dur = 8 + rand() * 7;
         const delay = i * 0.8 + rand() * 1.5;
-        const size = 18 + rand() * 10;
+        const size = (startsNearSurface ? 24 : 18) + rand() * 10;
         const exitsTank = i < Math.ceil(count / 2) || rand() > 0.35;
         const endY = exitsTank ? -(18 + rand() * escapeHeight) : -16;
+        const edgeY = exitsTank ? Math.min(-10, endY * 0.45) : 6;
 
         return (
           <motion.span
             key={`bubble-overflow-${i}`}
-            initial={{ x, y: height - start, opacity: 0, scale: 0.45 }}
+            initial={{ x, y: startY, opacity: 0, scale: 0.45 }}
             animate={{
               x: [x, x + drift * 0.4, x + drift],
-              y: [height - start, Math.min(10, endY + escapeHeight * 0.45), endY],
-              opacity: [0, 0.45, 0.75, 0],
-              scale: [0.45, 0.85, 1.15, 0.7],
+              y: [startY, edgeY, endY],
+              opacity: [0, 0.8, 0],
+              scale: [0.45, 1.05, 0.72],
             }}
             transition={{
               duration: dur,

--- a/src/components/shared/EmojiAquarium.tsx
+++ b/src/components/shared/EmojiAquarium.tsx
@@ -455,13 +455,15 @@ export function EmojiAquarium({ seed, className, variant = "chat" }: EmojiAquari
             <Emoji emoji={"🛟"} size={24} />
           </motion.span>
         </div>
-        <AquariumBubbleOverflowLayer
-          seed={`${seedRef.current}:${variant}-bubble-overflow`}
-          width={width}
-          height={height}
-          count={variant === "widget" ? 8 : 5}
-          className="z-50"
-        />
+        {variant === "chat" && (
+          <AquariumBubbleOverflowLayer
+            seed={`${seedRef.current}:chat-bubble-overflow`}
+            width={width}
+            height={height}
+            count={5}
+            className="z-50"
+          />
+        )}
       </div>
     </MotionConfig>
   );

--- a/src/components/shared/EmojiAquarium.tsx
+++ b/src/components/shared/EmojiAquarium.tsx
@@ -49,7 +49,7 @@ export function AquariumBubbleOverflowLayer({
   className,
 }: AquariumBubbleOverflowLayerProps) {
   const rand = createSeededRandom(seed);
-  const escapeHeight = Math.max(28, Math.round(height * 0.24));
+  const escapeHeight = Math.max(16, Math.round(height * 0.1));
   const safeWidth = Math.max(1, width);
 
   return (
@@ -70,8 +70,8 @@ export function AquariumBubbleOverflowLayer({
         const delay = i * 0.8 + rand() * 1.5;
         const size = (startsNearSurface ? 24 : 18) + rand() * 10;
         const exitsTank = i < Math.ceil(count / 2) || rand() > 0.35;
-        const endY = exitsTank ? -(18 + rand() * escapeHeight) : -16;
-        const edgeY = exitsTank ? Math.min(-10, endY * 0.45) : 6;
+        const endY = exitsTank ? -(6 + rand() * escapeHeight) : -6;
+        const edgeY = exitsTank ? Math.min(-6, endY * 0.55) : 6;
 
         return (
           <motion.span

--- a/src/components/shared/EmojiAquarium.tsx
+++ b/src/components/shared/EmojiAquarium.tsx
@@ -61,7 +61,7 @@ export function AquariumBubbleOverflowLayer({
       {Array.from({ length: count }).map((_, i) => {
         const edgePad = 8;
         const x = edgePad + rand() * Math.max(0, safeWidth - edgePad * 2);
-        const startsNearSurface = i < Math.ceil(count / 3);
+        const startsNearSurface = i < Math.ceil(count / 2);
         const startY = startsNearSurface
           ? 10 + rand() * Math.max(12, height * 0.16)
           : height - rand() * (height * 0.5);
@@ -72,16 +72,17 @@ export function AquariumBubbleOverflowLayer({
         const exitsTank = i < Math.ceil(count / 2) || rand() > 0.35;
         const endY = exitsTank ? -(6 + rand() * escapeHeight) : -6;
         const edgeY = exitsTank ? Math.min(-6, endY * 0.55) : 6;
+        const fadeY = exitsTank ? endY - 10 : endY;
 
         return (
           <motion.span
             key={`bubble-overflow-${i}`}
             initial={{ x, y: startY, opacity: 0, scale: 0.45 }}
             animate={{
-              x: [x, x + drift * 0.4, x + drift],
-              y: [startY, edgeY, endY],
-              opacity: [0, 0.8, 0],
-              scale: [0.45, 1.05, 0.72],
+              x: [x, x + drift * 0.35, x + drift * 0.7, x + drift],
+              y: [startY, edgeY, endY, fadeY],
+              opacity: [0, 0.9, 0.85, 0],
+              scale: [0.45, 1.05, 1, 0.72],
             }}
             transition={{
               duration: dur,
@@ -92,7 +93,7 @@ export function AquariumBubbleOverflowLayer({
             style={{
               position: "absolute",
               willChange: "transform, opacity",
-              filter: "drop-shadow(0 2px 4px rgba(255,255,255,0.22))",
+              filter: "drop-shadow(0 2px 6px rgba(255,255,255,0.35))",
             }}
             className="select-none"
           >
@@ -458,7 +459,7 @@ export function EmojiAquarium({ seed, className, variant = "chat" }: EmojiAquari
           seed={`${seedRef.current}:${variant}-bubble-overflow`}
           width={width}
           height={height}
-          count={variant === "widget" ? 6 : 4}
+          count={variant === "widget" ? 8 : 5}
           className="z-50"
         />
       </div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Adds a reusable aquarium bubble overflow layer that rises and fades above the tank edge.
- Renders Dashboard aquarium escape bubbles through the existing widget overflow slot so they are not clipped by widget chrome.
- Applies the same top-edge overflow behavior to chat aquariums.

### Walkthrough
<a href="https://cursor.com/agents/bc-f9f9fa0f-ee64-4ba3-aa2f-a4db438529e4/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Faquarium_bubbles_overflow_visible.mp4"><img src="https://cursor.com/artifacts/c/art-13959850-972b-4ecd-bb42-f724e4107081" alt="aquarium_bubbles_overflow_visible.mp4" /></a>

### Testing
- Passing: `bun run build`
- Passing: browser walkthrough recording confirms larger bubbles escape above the top boundary and fade over the background
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f9f9fa0f-ee64-4ba3-aa2f-a4db438529e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f9f9fa0f-ee64-4ba3-aa2f-a4db438529e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

