### PR TITLE
Use Streamdown for Chats message rendering

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -27,6 +27,7 @@
         "@radix-ui/react-tabs": "^1.1.13",
         "@radix-ui/react-tooltip": "^1.2.8",
         "@radix-ui/react-visually-hidden": "^1.2.4",
+        "@streamdown/code": "^1.1.1",
         "@tailwindcss/vite": "^4.1.18",
         "@tiptap/core": "^2.27",
         "@tiptap/extension-task-item": "^2.27",
@@ -852,6 +853,20 @@
 
     "@sentry/utils": ["@sentry/utils@5.8.0", "", { "dependencies": { "@sentry/types": "5.7.1", "tslib": "^1.9.3" } }, "sha512-KDxUvBSYi0/dHMdunbxAxD3389pcQioLtcO6CI6zt/nJXeVFolix66cRraeQvqupdLhvOk/el649W4fCPayTHw=="],
 
+    "@shikijs/core": ["@shikijs/core@3.23.0", "", { "dependencies": { "@shikijs/types": "3.23.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4", "hast-util-to-html": "^9.0.5" } }, "sha512-NSWQz0riNb67xthdm5br6lAkvpDJRTgB36fxlo37ZzM2yq0PQFFzbd8psqC2XMPgCzo1fW6cVi18+ArJ44wqgA=="],
+
+    "@shikijs/engine-javascript": ["@shikijs/engine-javascript@3.23.0", "", { "dependencies": { "@shikijs/types": "3.23.0", "@shikijs/vscode-textmate": "^10.0.2", "oniguruma-to-es": "^4.3.4" } }, "sha512-aHt9eiGFobmWR5uqJUViySI1bHMqrAgamWE1TYSUoftkAeCCAiGawPMwM+VCadylQtF4V3VNOZ5LmfItH5f3yA=="],
+
+    "@shikijs/engine-oniguruma": ["@shikijs/engine-oniguruma@3.23.0", "", { "dependencies": { "@shikijs/types": "3.23.0", "@shikijs/vscode-textmate": "^10.0.2" } }, "sha512-1nWINwKXxKKLqPibT5f4pAFLej9oZzQTsby8942OTlsJzOBZ0MWKiwzMsd+jhzu8YPCHAswGnnN1YtQfirL35g=="],
+
+    "@shikijs/langs": ["@shikijs/langs@3.23.0", "", { "dependencies": { "@shikijs/types": "3.23.0" } }, "sha512-2Ep4W3Re5aB1/62RSYQInK9mM3HsLeB91cHqznAJMuylqjzNVAVCMnNWRHFtcNHXsoNRayP9z1qj4Sq3nMqYXg=="],
+
+    "@shikijs/themes": ["@shikijs/themes@3.23.0", "", { "dependencies": { "@shikijs/types": "3.23.0" } }, "sha512-5qySYa1ZgAT18HR/ypENL9cUSGOeI2x+4IvYJu4JgVJdizn6kG4ia5Q1jDEOi7gTbN4RbuYtmHh0W3eccOrjMA=="],
+
+    "@shikijs/types": ["@shikijs/types@3.23.0", "", { "dependencies": { "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ=="],
+
+    "@shikijs/vscode-textmate": ["@shikijs/vscode-textmate@10.0.2", "", {}, "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg=="],
+
     "@shuding/opentype.js": ["@shuding/opentype.js@1.4.0-beta.0", "", { "dependencies": { "fflate": "^0.7.3", "string.prototype.codepointat": "^0.2.1" }, "bin": { "ot": "bin/ot" } }, "sha512-3NgmNyH3l/Hv6EvsWJbsvpcpUba6R8IREQ83nH83cyakCw7uM1arZKNfHwv1Wz6jgqrF/j4x5ELvR6PnK9nTcA=="],
 
     "@sinclair/typebox": ["@sinclair/typebox@0.25.24", "", {}, "sha512-XJfwUVUKDHF5ugKwIcxEgc9k8b7HbznCp6eUfWgu710hMPNIO4aw4/zB5RogDQz8nd6gyCDpU9O/m6qYEWY6yQ=="],
@@ -963,6 +978,8 @@
     "@statsig/client-core": ["@statsig/client-core@3.31.0", "", {}, "sha512-SuxQD6TmVszPG7FoMKwTk/uyBuVFk7XnxI3T/E0uyb7PL7GNjONtfsoh+NqBBVUJVse0CUeSFfgJPoZy1ZOslQ=="],
 
     "@statsig/js-client": ["@statsig/js-client@3.31.0", "", { "dependencies": { "@statsig/client-core": "3.31.0" } }, "sha512-LFa5E0LjT6sTfZv3sNGoyRLSZ1078+agdgOA+Vm1ecjG+KbSOfBLTW7hMwimrJ29slRwbYDzbtKaPJo/R37N2g=="],
+
+    "@streamdown/code": ["@streamdown/code@1.1.1", "", { "dependencies": { "shiki": "^3.19.0" }, "peerDependencies": { "react": "^18.0.0 || ^19.0.0" } }, "sha512-i7HTNuDgZWb+VdrNVOam9gQhIc5MSSDXKWXgbUrn/4vSRaSMM+Rtl10MQj4wLWPNpF7p80waJsAqFP8HZfb0Jg=="],
 
     "@surma/rollup-plugin-off-main-thread": ["@surma/rollup-plugin-off-main-thread@2.2.3", "", { "dependencies": { "ejs": "^3.1.6", "json5": "^2.2.0", "magic-string": "^0.25.0", "string.prototype.matchall": "^4.0.6" } }, "sha512-lR8q/9W7hZpMWweNiAKU7NQerBnzQQLvi8qnTDU/fxItPhtZVMbPV3lbCwjhIlNBe9Bbr5V+KHshvWmVSG9cxQ=="],
 
@@ -1996,6 +2013,8 @@
 
     "hast-util-sanitize": ["hast-util-sanitize@5.0.2", "", { "dependencies": { "@types/hast": "^3.0.0", "@ungap/structured-clone": "^1.0.0", "unist-util-position": "^5.0.0" } }, "sha512-3yTWghByc50aGS7JlGhk61SPenfE/p1oaFeNwkOOyrscaOkMGrcW9+Cy/QAIOBpZxP1yqDIzFMR0+Np0i0+usg=="],
 
+    "hast-util-to-html": ["hast-util-to-html@9.0.5", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "ccount": "^2.0.0", "comma-separated-tokens": "^2.0.0", "hast-util-whitespace": "^3.0.0", "html-void-elements": "^3.0.0", "mdast-util-to-hast": "^13.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0", "stringify-entities": "^4.0.0", "zwitch": "^2.0.4" } }, "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw=="],
+
     "hast-util-to-jsx-runtime": ["hast-util-to-jsx-runtime@2.3.6", "", { "dependencies": { "@types/estree": "^1.0.0", "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "comma-separated-tokens": "^2.0.0", "devlop": "^1.0.0", "estree-util-is-identifier-name": "^3.0.0", "hast-util-whitespace": "^3.0.0", "mdast-util-mdx-expression": "^2.0.0", "mdast-util-mdx-jsx": "^3.0.0", "mdast-util-mdxjs-esm": "^2.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0", "style-to-js": "^1.0.0", "unist-util-position": "^5.0.0", "vfile-message": "^4.0.0" } }, "sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg=="],
 
     "hast-util-to-parse5": ["hast-util-to-parse5@8.0.1", "", { "dependencies": { "@types/hast": "^3.0.0", "comma-separated-tokens": "^2.0.0", "devlop": "^1.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0", "web-namespaces": "^2.0.0", "zwitch": "^2.0.0" } }, "sha512-MlWT6Pjt4CG9lFCjiz4BH7l9wmrMkfkJYCxFwKQic8+RTZgWPuWxwAfjJElsXkex7DJjfSJsQIt931ilUgmwdA=="],
@@ -2502,6 +2521,10 @@
 
     "onetime": ["onetime@5.1.2", "", { "dependencies": { "mimic-fn": "^2.1.0" } }, "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg=="],
 
+    "oniguruma-parser": ["oniguruma-parser@0.12.2", "", {}, "sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw=="],
+
+    "oniguruma-to-es": ["oniguruma-to-es@4.3.6", "", { "dependencies": { "oniguruma-parser": "^0.12.2", "regex": "^6.1.0", "regex-recursion": "^6.0.2" } }, "sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA=="],
+
     "openai": ["openai@4.104.0", "", { "dependencies": { "@types/node": "^18.11.18", "@types/node-fetch": "^2.6.4", "abort-controller": "^3.0.0", "agentkeepalive": "^4.2.1", "form-data-encoder": "1.7.2", "formdata-node": "^4.3.2", "node-fetch": "^2.6.7" }, "peerDependencies": { "ws": "^8.18.0", "zod": "^3.23.8" }, "optionalPeers": ["ws", "zod"], "bin": { "openai": "bin/cli" } }, "sha512-p99EFNsA/yX6UhVO93f5kJsDRLAg+CTA2RBqdHK4RtK8u5IJw32Hyb2dTGKbnnFmnuoBv5r7Z2CURI9sGZpSuA=="],
 
     "opencc-js": ["opencc-js@1.0.5", "", {}, "sha512-LD+1SoNnZdlRwtYTjnQdFrSVCAaYpuDqL5CkmOaHOkKoKh7mFxUicLTRVNLU5C+Jmi1vXQ3QL4jWdgSaa4sKjg=="],
@@ -2728,6 +2751,12 @@
 
     "regenerator-transform": ["regenerator-transform@0.15.2", "", { "dependencies": { "@babel/runtime": "^7.8.4" } }, "sha512-hfMp2BoF0qOk3uc5V20ALGDS2ddjQaLrdl7xrGXvAIow7qeWRM2VA2HuCHkUKk9slq3VwEwLNK3DFBqDfPGYtg=="],
 
+    "regex": ["regex@6.1.0", "", { "dependencies": { "regex-utilities": "^2.3.0" } }, "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg=="],
+
+    "regex-recursion": ["regex-recursion@6.0.2", "", { "dependencies": { "regex-utilities": "^2.3.0" } }, "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg=="],
+
+    "regex-utilities": ["regex-utilities@2.3.0", "", {}, "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng=="],
+
     "regexp.prototype.flags": ["regexp.prototype.flags@1.5.4", "", { "dependencies": { "call-bind": "^1.0.8", "define-properties": "^1.2.1", "es-errors": "^1.3.0", "get-proto": "^1.0.1", "gopd": "^1.2.0", "set-function-name": "^2.0.2" } }, "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA=="],
 
     "regexpu-core": ["regexpu-core@6.2.0", "", { "dependencies": { "regenerate": "^1.4.2", "regenerate-unicode-properties": "^10.2.0", "regjsgen": "^0.8.0", "regjsparser": "^0.12.0", "unicode-match-property-ecmascript": "^2.0.0", "unicode-match-property-value-ecmascript": "^2.1.0" } }, "sha512-H66BPQMrv+V16t8xtmq+UC0CBpiTBA60V8ibS1QVReIp8T1z8hwFxqcGzm9K6lgsN7sB5edVH8a+ze6Fqm4weA=="],
@@ -2831,6 +2860,8 @@
     "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
 
     "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
+
+    "shiki": ["shiki@3.23.0", "", { "dependencies": { "@shikijs/core": "3.23.0", "@shikijs/engine-javascript": "3.23.0", "@shikijs/engine-oniguruma": "3.23.0", "@shikijs/langs": "3.23.0", "@shikijs/themes": "3.23.0", "@shikijs/types": "3.23.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-55Dj73uq9ZXL5zyeRPzHQsK7Nbyt6Y10k5s7OjuFZGMhpp4r/rsLBH0o/0fstIzX1Lep9VxefWljK/SKCzygIA=="],
 
     "side-channel": ["side-channel@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.3", "side-channel-list": "^1.0.0", "side-channel-map": "^1.0.1", "side-channel-weakmap": "^1.0.2" } }, "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -80,6 +80,7 @@
         "react-scan": "^0.5.3",
         "remark-gfm": "^4.0.1",
         "sonner": "^2.0.7",
+        "streamdown": "^2.5.0",
         "tailwind-merge": "^2.6.0",
         "tailwindcss-animate": "^1.0.7",
         "three": "^0.176.0",
@@ -144,6 +145,8 @@
     "@ai-sdk/react": ["@ai-sdk/react@3.0.51", "", { "dependencies": { "@ai-sdk/provider-utils": "4.0.9", "ai": "6.0.49", "swr": "^2.2.5", "throttleit": "2.1.0" }, "peerDependencies": { "react": "^18 || ~19.0.1 || ~19.1.2 || ^19.2.1" } }, "sha512-7nmCwEJM52NQZB4/ED8qJ4wbDg7EEWh94qJ7K9GSJxD6sWF3GOKrRZ5ivm4qNmKhY+JfCxCAxfghGY5mTKOsxw=="],
 
     "@ampproject/remapping": ["@ampproject/remapping@2.3.0", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.5", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw=="],
+
+    "@antfu/install-pkg": ["@antfu/install-pkg@1.1.0", "", { "dependencies": { "package-manager-detector": "^1.3.0", "tinyexec": "^1.0.1" } }, "sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ=="],
 
     "@apideck/better-ajv-errors": ["@apideck/better-ajv-errors@0.3.6", "", { "dependencies": { "json-schema": "^0.4.0", "jsonpointer": "^5.0.0", "leven": "^3.1.0" }, "peerDependencies": { "ajv": ">=8" } }, "sha512-P+ZygBLZtkp0qqOAJJVX4oX/sFo5JR3eBWwwuqHHhK0GIgQOKWrAfiAaWX0aArHkRWHMuggFEgAZNxVPwPZYaA=="],
 
@@ -411,9 +414,21 @@
 
     "@borewit/text-codec": ["@borewit/text-codec@0.2.1", "", {}, "sha512-k7vvKPbf7J2fZ5klGRD9AeKfUvojuZIQ3BT5u7Jfv+puwXkUBUT5PVyMDfJZpy30CBDXGMgw7fguK/lpOMBvgw=="],
 
+    "@braintree/sanitize-url": ["@braintree/sanitize-url@7.1.2", "", {}, "sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA=="],
+
     "@bufbuild/protobuf": ["@bufbuild/protobuf@1.10.0", "", {}, "sha512-QDdVFLoN93Zjg36NoQPZfsVH9tZew7wKDKyV5qRdj8ntT4wQCOradQjRaTdwMhWUYsgKsvCINKKm87FdEk96Ag=="],
 
     "@bytecodealliance/preview2-shim": ["@bytecodealliance/preview2-shim@0.17.6", "", {}, "sha512-n3cM88gTen5980UOBAD6xDcNNL3ocTK8keab21bpx1ONdA+ARj7uD1qoFxOWCyKlkpSi195FH+GeAut7Oc6zZw=="],
+
+    "@chevrotain/cst-dts-gen": ["@chevrotain/cst-dts-gen@12.0.0", "", { "dependencies": { "@chevrotain/gast": "12.0.0", "@chevrotain/types": "12.0.0" } }, "sha512-fSL4KXjTl7cDgf0B5Rip9Q05BOrYvkJV/RrBTE/bKDN096E4hN/ySpcBK5B24T76dlQ2i32Zc3PAE27jFnFrKg=="],
+
+    "@chevrotain/gast": ["@chevrotain/gast@12.0.0", "", { "dependencies": { "@chevrotain/types": "12.0.0" } }, "sha512-1ne/m3XsIT8aEdrvT33so0GUC+wkctpUPK6zU9IlOyJLUbR0rg4G7ZiApiJbggpgPir9ERy3FRjT6T7lpgetnQ=="],
+
+    "@chevrotain/regexp-to-ast": ["@chevrotain/regexp-to-ast@12.0.0", "", {}, "sha512-p+EW9MaJwgaHguhoqwOtx/FwuGr+DnNn857sXWOi/mClXIkPGl3rn7hGNWvo31HA3vyeQxjqe+H36yZJwYU8cA=="],
+
+    "@chevrotain/types": ["@chevrotain/types@12.0.0", "", {}, "sha512-S+04vjFQKeuYw0/eW3U52LkAHQsB1ASxsPGsLPUyQgrZ2iNNibQrsidruDzjEX2JYfespXMG0eZmXlhA6z7nWA=="],
+
+    "@chevrotain/utils": ["@chevrotain/utils@12.0.0", "", {}, "sha512-lB59uJoaGIfOOL9knQqQRfhl9g7x8/wqFkp13zTdkRu1huG9kg6IJs1O8hqj9rs6h7orGxHJUKb+mX3rPbWGhA=="],
 
     "@connectrpc/connect": ["@connectrpc/connect@1.7.0", "", { "peerDependencies": { "@bufbuild/protobuf": "^1.10.0" } }, "sha512-iNKdJRi69YP3mq6AePRT8F/HrxWCewrhxnLMNm0vpqXAR8biwzRtO6Hjx80C6UvtKJ5sFmffQT7I4Baecz389w=="],
 
@@ -543,6 +558,10 @@
 
     "@humanwhocodes/retry": ["@humanwhocodes/retry@0.4.2", "", {}, "sha512-xeO57FpIu4p1Ri3Jq/EXq4ClRm86dVF2z/+kvFnyqVYRavTZmaFaUBbWCOuuTh0o/g7DSsk6kc2vrS4Vl5oPOQ=="],
 
+    "@iconify/types": ["@iconify/types@2.0.0", "", {}, "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg=="],
+
+    "@iconify/utils": ["@iconify/utils@3.1.3", "", { "dependencies": { "@antfu/install-pkg": "^1.1.0", "@iconify/types": "^2.0.0", "import-meta-resolve": "^4.2.0" } }, "sha512-LPKOXPn/zV+zis1oOfGWogaXVpqUybF3ZS6SCZIsz8vg0ivVp9+fVqyYB7xq0aiST/VhUQYGO1qo6uoYSiEJqw=="],
+
     "@ioredis/commands": ["@ioredis/commands@1.5.1", "", {}, "sha512-JH8ZL/ywcJyR9MmJ5BNqZllXNZQqQbnVZOqpPQqE1vHiFgAw4NHbvE0FOduNU8IX9babitBT46571OnPTT0Zcw=="],
 
     "@isaacs/balanced-match": ["@isaacs/balanced-match@4.0.1", "", {}, "sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ=="],
@@ -568,6 +587,8 @@
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.25", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ=="],
 
     "@mapbox/node-pre-gyp": ["@mapbox/node-pre-gyp@2.0.0", "", { "dependencies": { "consola": "^3.2.3", "detect-libc": "^2.0.0", "https-proxy-agent": "^7.0.5", "node-fetch": "^2.6.7", "nopt": "^8.0.0", "semver": "^7.5.3", "tar": "^7.4.0" }, "bin": { "node-pre-gyp": "bin/node-pre-gyp" } }, "sha512-llMXd39jtP0HpQLVI37Bf1m2ADlEb35GYSh1SDSLsBhR+5iCxiNGlT31yqbNtVHygHAtMy6dWFERpU2JgufhPg=="],
+
+    "@mermaid-js/parser": ["@mermaid-js/parser@1.1.0", "", { "dependencies": { "langium": "^4.0.0" } }, "sha512-gxK9ZX2+Fex5zu8LhRQoMeMPEHbc73UKZ0FQ54YrQtUxE1VVhMwzeNtKRPAu5aXks4FasbMe4xB4bWrmq6Jlxw=="],
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.4", "", { "dependencies": { "@tybys/wasm-util": "^0.10.1" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow=="],
 
@@ -1113,6 +1134,68 @@
 
     "@types/bcryptjs": ["@types/bcryptjs@3.0.0", "", { "dependencies": { "bcryptjs": "*" } }, "sha512-WRZOuCuaz8UcZZE4R5HXTco2goQSI2XxjGY3hbM/xDvwmqFWd4ivooImsMx65OKM6CtNKbnZ5YL+YwAwK7c1dg=="],
 
+    "@types/d3": ["@types/d3@7.4.3", "", { "dependencies": { "@types/d3-array": "*", "@types/d3-axis": "*", "@types/d3-brush": "*", "@types/d3-chord": "*", "@types/d3-color": "*", "@types/d3-contour": "*", "@types/d3-delaunay": "*", "@types/d3-dispatch": "*", "@types/d3-drag": "*", "@types/d3-dsv": "*", "@types/d3-ease": "*", "@types/d3-fetch": "*", "@types/d3-force": "*", "@types/d3-format": "*", "@types/d3-geo": "*", "@types/d3-hierarchy": "*", "@types/d3-interpolate": "*", "@types/d3-path": "*", "@types/d3-polygon": "*", "@types/d3-quadtree": "*", "@types/d3-random": "*", "@types/d3-scale": "*", "@types/d3-scale-chromatic": "*", "@types/d3-selection": "*", "@types/d3-shape": "*", "@types/d3-time": "*", "@types/d3-time-format": "*", "@types/d3-timer": "*", "@types/d3-transition": "*", "@types/d3-zoom": "*" } }, "sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww=="],
+
+    "@types/d3-array": ["@types/d3-array@3.2.2", "", {}, "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw=="],
+
+    "@types/d3-axis": ["@types/d3-axis@3.0.6", "", { "dependencies": { "@types/d3-selection": "*" } }, "sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw=="],
+
+    "@types/d3-brush": ["@types/d3-brush@3.0.6", "", { "dependencies": { "@types/d3-selection": "*" } }, "sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A=="],
+
+    "@types/d3-chord": ["@types/d3-chord@3.0.6", "", {}, "sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg=="],
+
+    "@types/d3-color": ["@types/d3-color@3.1.3", "", {}, "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A=="],
+
+    "@types/d3-contour": ["@types/d3-contour@3.0.6", "", { "dependencies": { "@types/d3-array": "*", "@types/geojson": "*" } }, "sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg=="],
+
+    "@types/d3-delaunay": ["@types/d3-delaunay@6.0.4", "", {}, "sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw=="],
+
+    "@types/d3-dispatch": ["@types/d3-dispatch@3.0.7", "", {}, "sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA=="],
+
+    "@types/d3-drag": ["@types/d3-drag@3.0.7", "", { "dependencies": { "@types/d3-selection": "*" } }, "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ=="],
+
+    "@types/d3-dsv": ["@types/d3-dsv@3.0.7", "", {}, "sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g=="],
+
+    "@types/d3-ease": ["@types/d3-ease@3.0.2", "", {}, "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA=="],
+
+    "@types/d3-fetch": ["@types/d3-fetch@3.0.7", "", { "dependencies": { "@types/d3-dsv": "*" } }, "sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA=="],
+
+    "@types/d3-force": ["@types/d3-force@3.0.10", "", {}, "sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw=="],
+
+    "@types/d3-format": ["@types/d3-format@3.0.4", "", {}, "sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g=="],
+
+    "@types/d3-geo": ["@types/d3-geo@3.1.0", "", { "dependencies": { "@types/geojson": "*" } }, "sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ=="],
+
+    "@types/d3-hierarchy": ["@types/d3-hierarchy@3.1.7", "", {}, "sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg=="],
+
+    "@types/d3-interpolate": ["@types/d3-interpolate@3.0.4", "", { "dependencies": { "@types/d3-color": "*" } }, "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA=="],
+
+    "@types/d3-path": ["@types/d3-path@3.1.1", "", {}, "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg=="],
+
+    "@types/d3-polygon": ["@types/d3-polygon@3.0.2", "", {}, "sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA=="],
+
+    "@types/d3-quadtree": ["@types/d3-quadtree@3.0.6", "", {}, "sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg=="],
+
+    "@types/d3-random": ["@types/d3-random@3.0.3", "", {}, "sha512-Imagg1vJ3y76Y2ea0871wpabqp613+8/r0mCLEBfdtqC7xMSfj9idOnmBYyMoULfHePJyxMAw3nWhJxzc+LFwQ=="],
+
+    "@types/d3-scale": ["@types/d3-scale@4.0.9", "", { "dependencies": { "@types/d3-time": "*" } }, "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw=="],
+
+    "@types/d3-scale-chromatic": ["@types/d3-scale-chromatic@3.1.0", "", {}, "sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ=="],
+
+    "@types/d3-selection": ["@types/d3-selection@3.0.11", "", {}, "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w=="],
+
+    "@types/d3-shape": ["@types/d3-shape@3.1.8", "", { "dependencies": { "@types/d3-path": "*" } }, "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w=="],
+
+    "@types/d3-time": ["@types/d3-time@3.0.4", "", {}, "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g=="],
+
+    "@types/d3-time-format": ["@types/d3-time-format@4.0.3", "", {}, "sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg=="],
+
+    "@types/d3-timer": ["@types/d3-timer@3.0.2", "", {}, "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw=="],
+
+    "@types/d3-transition": ["@types/d3-transition@3.0.9", "", { "dependencies": { "@types/d3-selection": "*" } }, "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg=="],
+
+    "@types/d3-zoom": ["@types/d3-zoom@3.0.8", "", { "dependencies": { "@types/d3-interpolate": "*", "@types/d3-selection": "*" } }, "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw=="],
+
     "@types/debug": ["@types/debug@4.1.12", "", { "dependencies": { "@types/ms": "*" } }, "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ=="],
 
     "@types/dompurify": ["@types/dompurify@3.2.0", "", { "dependencies": { "dompurify": "*" } }, "sha512-Fgg31wv9QbLDA0SpTOXO3MaxySc4DKGLi8sna4/Utjo4r3ZRPdCt4UQee8BWr+Q5z21yifghREPJGYaEOEIACg=="],
@@ -1124,6 +1207,8 @@
     "@types/estree-jsx": ["@types/estree-jsx@1.0.5", "", { "dependencies": { "@types/estree": "*" } }, "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg=="],
 
     "@types/formidable": ["@types/formidable@3.4.6", "", { "dependencies": { "@types/node": "*" } }, "sha512-LI4Hk+KNsM5q7br4oMVoaWeb+gUqJpz1N8+Y2Q6Cz9cVH33ybahRKUWaRmMboVlkwSbOUGgwc/pEkS7yMSzoWg=="],
+
+    "@types/geojson": ["@types/geojson@7946.0.16", "", {}, "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg=="],
 
     "@types/hast": ["@types/hast@3.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ=="],
 
@@ -1190,6 +1275,8 @@
     "@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.50.1", "", { "dependencies": { "@typescript-eslint/types": "8.50.1", "eslint-visitor-keys": "^4.2.1" } }, "sha512-IrDKrw7pCRUR94zeuCSUWQ+w8JEf5ZX5jl/e6AHGSLi1/zIr0lgutfn/7JpfCey+urpgQEdrZVYzCaVVKiTwhQ=="],
 
     "@ungap/structured-clone": ["@ungap/structured-clone@1.3.0", "", {}, "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g=="],
+
+    "@upsetjs/venn.js": ["@upsetjs/venn.js@2.0.0", "", { "optionalDependencies": { "d3-selection": "^3.0.0", "d3-transition": "^3.0.1" } }, "sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw=="],
 
     "@upstash/redis": ["@upstash/redis@1.36.0", "", { "dependencies": { "uncrypto": "^0.1.3" } }, "sha512-9zN2UV9QJGPnXfWU3yZBLVQaqqENDh7g+Y4J2vJuSxBCi9FQ0aUOtaXlzuFhnsiZvCqM+eS27ic+tgmkWUsfOg=="],
 
@@ -1441,6 +1528,10 @@
 
     "character-reference-invalid": ["character-reference-invalid@2.0.1", "", {}, "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw=="],
 
+    "chevrotain": ["chevrotain@12.0.0", "", { "dependencies": { "@chevrotain/cst-dts-gen": "12.0.0", "@chevrotain/gast": "12.0.0", "@chevrotain/regexp-to-ast": "12.0.0", "@chevrotain/types": "12.0.0", "@chevrotain/utils": "12.0.0" } }, "sha512-csJvb+6kEiQaqo1woTdSAuOWdN0WTLIydkKrBnS+V5gZz0oqBrp4kQ35519QgK6TpBThiG3V1vNSHlIkv4AglQ=="],
+
+    "chevrotain-allstar": ["chevrotain-allstar@0.4.3", "", { "dependencies": { "lodash-es": "^4.18.1" }, "peerDependencies": { "chevrotain": "^12.0.0" } }, "sha512-2X4mkroolSMKqW+H22pyPMUVDqYZzPhephTmg/NODKb1IGYPHfxfhcW0EjS7wcPJNbze2i4vBWT7zT5FKF2lrQ=="],
+
     "chokidar": ["chokidar@4.0.0", "", { "dependencies": { "readdirp": "^4.0.1" } }, "sha512-mxIojEAQcuEvT/lyXq+jf/3cO/KoA6z4CeNDGGevTybECPOMFCnQy3OPahluUkbqgPNGw5Bi78UC7Po6Lhy+NA=="],
 
     "chownr": ["chownr@2.0.0", "", {}, "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ=="],
@@ -1495,6 +1586,8 @@
 
     "core-util-is": ["core-util-is@1.0.3", "", {}, "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="],
 
+    "cose-base": ["cose-base@1.0.3", "", { "dependencies": { "layout-base": "^1.0.0" } }, "sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg=="],
+
     "crelt": ["crelt@1.0.6", "", {}, "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g=="],
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
@@ -1515,6 +1608,78 @@
 
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
 
+    "cytoscape": ["cytoscape@3.33.3", "", {}, "sha512-Gej7U+OKR+LZ8kvX7rb2HhCYJ0IhvEFsnkud4SB1PR+BUY/TsSO0dmOW59WEVLu51b1Rm+gQRKoz4bLYxGSZ2g=="],
+
+    "cytoscape-cose-bilkent": ["cytoscape-cose-bilkent@4.1.0", "", { "dependencies": { "cose-base": "^1.0.0" }, "peerDependencies": { "cytoscape": "^3.2.0" } }, "sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ=="],
+
+    "cytoscape-fcose": ["cytoscape-fcose@2.2.0", "", { "dependencies": { "cose-base": "^2.2.0" }, "peerDependencies": { "cytoscape": "^3.2.0" } }, "sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ=="],
+
+    "d3": ["d3@7.9.0", "", { "dependencies": { "d3-array": "3", "d3-axis": "3", "d3-brush": "3", "d3-chord": "3", "d3-color": "3", "d3-contour": "4", "d3-delaunay": "6", "d3-dispatch": "3", "d3-drag": "3", "d3-dsv": "3", "d3-ease": "3", "d3-fetch": "3", "d3-force": "3", "d3-format": "3", "d3-geo": "3", "d3-hierarchy": "3", "d3-interpolate": "3", "d3-path": "3", "d3-polygon": "3", "d3-quadtree": "3", "d3-random": "3", "d3-scale": "4", "d3-scale-chromatic": "3", "d3-selection": "3", "d3-shape": "3", "d3-time": "3", "d3-time-format": "4", "d3-timer": "3", "d3-transition": "3", "d3-zoom": "3" } }, "sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA=="],
+
+    "d3-array": ["d3-array@3.2.4", "", { "dependencies": { "internmap": "1 - 2" } }, "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg=="],
+
+    "d3-axis": ["d3-axis@3.0.0", "", {}, "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw=="],
+
+    "d3-brush": ["d3-brush@3.0.0", "", { "dependencies": { "d3-dispatch": "1 - 3", "d3-drag": "2 - 3", "d3-interpolate": "1 - 3", "d3-selection": "3", "d3-transition": "3" } }, "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ=="],
+
+    "d3-chord": ["d3-chord@3.0.1", "", { "dependencies": { "d3-path": "1 - 3" } }, "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g=="],
+
+    "d3-color": ["d3-color@3.1.0", "", {}, "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA=="],
+
+    "d3-contour": ["d3-contour@4.0.2", "", { "dependencies": { "d3-array": "^3.2.0" } }, "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA=="],
+
+    "d3-delaunay": ["d3-delaunay@6.0.4", "", { "dependencies": { "delaunator": "5" } }, "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A=="],
+
+    "d3-dispatch": ["d3-dispatch@3.0.1", "", {}, "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg=="],
+
+    "d3-drag": ["d3-drag@3.0.0", "", { "dependencies": { "d3-dispatch": "1 - 3", "d3-selection": "3" } }, "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg=="],
+
+    "d3-dsv": ["d3-dsv@3.0.1", "", { "dependencies": { "commander": "7", "iconv-lite": "0.6", "rw": "1" }, "bin": { "csv2json": "bin/dsv2json.js", "csv2tsv": "bin/dsv2dsv.js", "dsv2dsv": "bin/dsv2dsv.js", "dsv2json": "bin/dsv2json.js", "json2csv": "bin/json2dsv.js", "json2dsv": "bin/json2dsv.js", "json2tsv": "bin/json2dsv.js", "tsv2csv": "bin/dsv2dsv.js", "tsv2json": "bin/dsv2json.js" } }, "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q=="],
+
+    "d3-ease": ["d3-ease@3.0.1", "", {}, "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w=="],
+
+    "d3-fetch": ["d3-fetch@3.0.1", "", { "dependencies": { "d3-dsv": "1 - 3" } }, "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw=="],
+
+    "d3-force": ["d3-force@3.0.0", "", { "dependencies": { "d3-dispatch": "1 - 3", "d3-quadtree": "1 - 3", "d3-timer": "1 - 3" } }, "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg=="],
+
+    "d3-format": ["d3-format@3.1.2", "", {}, "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg=="],
+
+    "d3-geo": ["d3-geo@3.1.1", "", { "dependencies": { "d3-array": "2.5.0 - 3" } }, "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q=="],
+
+    "d3-hierarchy": ["d3-hierarchy@3.1.2", "", {}, "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA=="],
+
+    "d3-interpolate": ["d3-interpolate@3.0.1", "", { "dependencies": { "d3-color": "1 - 3" } }, "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g=="],
+
+    "d3-path": ["d3-path@3.1.0", "", {}, "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ=="],
+
+    "d3-polygon": ["d3-polygon@3.0.1", "", {}, "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg=="],
+
+    "d3-quadtree": ["d3-quadtree@3.0.1", "", {}, "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw=="],
+
+    "d3-random": ["d3-random@3.0.1", "", {}, "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ=="],
+
+    "d3-sankey": ["d3-sankey@0.12.3", "", { "dependencies": { "d3-array": "1 - 2", "d3-shape": "^1.2.0" } }, "sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ=="],
+
+    "d3-scale": ["d3-scale@4.0.2", "", { "dependencies": { "d3-array": "2.10.0 - 3", "d3-format": "1 - 3", "d3-interpolate": "1.2.0 - 3", "d3-time": "2.1.1 - 3", "d3-time-format": "2 - 4" } }, "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ=="],
+
+    "d3-scale-chromatic": ["d3-scale-chromatic@3.1.0", "", { "dependencies": { "d3-color": "1 - 3", "d3-interpolate": "1 - 3" } }, "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ=="],
+
+    "d3-selection": ["d3-selection@3.0.0", "", {}, "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ=="],
+
+    "d3-shape": ["d3-shape@3.2.0", "", { "dependencies": { "d3-path": "^3.1.0" } }, "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA=="],
+
+    "d3-time": ["d3-time@3.1.0", "", { "dependencies": { "d3-array": "2 - 3" } }, "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q=="],
+
+    "d3-time-format": ["d3-time-format@4.1.0", "", { "dependencies": { "d3-time": "1 - 3" } }, "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg=="],
+
+    "d3-timer": ["d3-timer@3.0.1", "", {}, "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA=="],
+
+    "d3-transition": ["d3-transition@3.0.1", "", { "dependencies": { "d3-color": "1 - 3", "d3-dispatch": "1 - 3", "d3-ease": "1 - 3", "d3-interpolate": "1 - 3", "d3-timer": "1 - 3" }, "peerDependencies": { "d3-selection": "2 - 3" } }, "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w=="],
+
+    "d3-zoom": ["d3-zoom@3.0.0", "", { "dependencies": { "d3-dispatch": "1 - 3", "d3-drag": "2 - 3", "d3-interpolate": "1 - 3", "d3-selection": "2 - 3", "d3-transition": "2 - 3" } }, "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw=="],
+
+    "dagre-d3-es": ["dagre-d3-es@7.0.14", "", { "dependencies": { "d3": "^7.9.0", "lodash-es": "^4.17.21" } }, "sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg=="],
+
     "damerau-levenshtein": ["damerau-levenshtein@1.0.8", "", {}, "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA=="],
 
     "data-uri-to-buffer": ["data-uri-to-buffer@4.0.1", "", {}, "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A=="],
@@ -1524,6 +1689,8 @@
     "data-view-byte-length": ["data-view-byte-length@1.0.2", "", { "dependencies": { "call-bound": "^1.0.3", "es-errors": "^1.3.0", "is-data-view": "^1.0.2" } }, "sha512-tuhGbE6CfTM9+5ANGf+oQb72Ky/0+s3xKUpHvShfiz2RxMFgFPjsXuRLBVMtvMs15awe45SRb83D6wH4ew6wlQ=="],
 
     "data-view-byte-offset": ["data-view-byte-offset@1.0.1", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "is-data-view": "^1.0.1" } }, "sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ=="],
+
+    "dayjs": ["dayjs@1.11.20", "", {}, "sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ=="],
 
     "debug": ["debug@4.4.0", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA=="],
 
@@ -1542,6 +1709,8 @@
     "define-properties": ["define-properties@1.2.1", "", { "dependencies": { "define-data-property": "^1.0.1", "has-property-descriptors": "^1.0.0", "object-keys": "^1.1.1" } }, "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg=="],
 
     "degenerator": ["degenerator@5.0.1", "", { "dependencies": { "ast-types": "^0.13.4", "escodegen": "^2.1.0", "esprima": "^4.0.1" } }, "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ=="],
+
+    "delaunator": ["delaunator@5.1.0", "", { "dependencies": { "robust-predicates": "^3.0.2" } }, "sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ=="],
 
     "delayed-stream": ["delayed-stream@1.0.0", "", {}, "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="],
 
@@ -1797,6 +1966,8 @@
 
     "grapheme-splitter": ["grapheme-splitter@1.0.4", "", {}, "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ=="],
 
+    "hachure-fill": ["hachure-fill@0.5.2", "", {}, "sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg=="],
+
     "hangul-romanization": ["hangul-romanization@1.0.1", "", {}, "sha512-Nh67VGRK0Zet2JRDWII4/RW004XSZyWVySSurM9PEAR1p+7/5Kr8OrrcSYQcQhyGCcBEKyQm98xd+rRnyO0uXg=="],
 
     "has-bigints": ["has-bigints@1.1.0", "", {}, "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg=="],
@@ -1817,9 +1988,21 @@
 
     "hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
 
+    "hast-util-from-parse5": ["hast-util-from-parse5@8.0.3", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "devlop": "^1.0.0", "hastscript": "^9.0.0", "property-information": "^7.0.0", "vfile": "^6.0.0", "vfile-location": "^5.0.0", "web-namespaces": "^2.0.0" } }, "sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg=="],
+
+    "hast-util-parse-selector": ["hast-util-parse-selector@4.0.0", "", { "dependencies": { "@types/hast": "^3.0.0" } }, "sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A=="],
+
+    "hast-util-raw": ["hast-util-raw@9.1.0", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "@ungap/structured-clone": "^1.0.0", "hast-util-from-parse5": "^8.0.0", "hast-util-to-parse5": "^8.0.0", "html-void-elements": "^3.0.0", "mdast-util-to-hast": "^13.0.0", "parse5": "^7.0.0", "unist-util-position": "^5.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0", "web-namespaces": "^2.0.0", "zwitch": "^2.0.0" } }, "sha512-Y8/SBAHkZGoNkpzqqfCldijcuUKh7/su31kEBp67cFY09Wy0mTRgtsLYsiIxMJxlu0f6AA5SUTbDR8K0rxnbUw=="],
+
+    "hast-util-sanitize": ["hast-util-sanitize@5.0.2", "", { "dependencies": { "@types/hast": "^3.0.0", "@ungap/structured-clone": "^1.0.0", "unist-util-position": "^5.0.0" } }, "sha512-3yTWghByc50aGS7JlGhk61SPenfE/p1oaFeNwkOOyrscaOkMGrcW9+Cy/QAIOBpZxP1yqDIzFMR0+Np0i0+usg=="],
+
     "hast-util-to-jsx-runtime": ["hast-util-to-jsx-runtime@2.3.6", "", { "dependencies": { "@types/estree": "^1.0.0", "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "comma-separated-tokens": "^2.0.0", "devlop": "^1.0.0", "estree-util-is-identifier-name": "^3.0.0", "hast-util-whitespace": "^3.0.0", "mdast-util-mdx-expression": "^2.0.0", "mdast-util-mdx-jsx": "^3.0.0", "mdast-util-mdxjs-esm": "^2.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0", "style-to-js": "^1.0.0", "unist-util-position": "^5.0.0", "vfile-message": "^4.0.0" } }, "sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg=="],
 
+    "hast-util-to-parse5": ["hast-util-to-parse5@8.0.1", "", { "dependencies": { "@types/hast": "^3.0.0", "comma-separated-tokens": "^2.0.0", "devlop": "^1.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0", "web-namespaces": "^2.0.0", "zwitch": "^2.0.0" } }, "sha512-MlWT6Pjt4CG9lFCjiz4BH7l9wmrMkfkJYCxFwKQic8+RTZgWPuWxwAfjJElsXkex7DJjfSJsQIt931ilUgmwdA=="],
+
     "hast-util-whitespace": ["hast-util-whitespace@3.0.0", "", { "dependencies": { "@types/hast": "^3.0.0" } }, "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw=="],
+
+    "hastscript": ["hastscript@9.0.1", "", { "dependencies": { "@types/hast": "^3.0.0", "comma-separated-tokens": "^2.0.0", "hast-util-parse-selector": "^4.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0" } }, "sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w=="],
 
     "hex-rgb": ["hex-rgb@4.3.0", "", {}, "sha512-Ox1pJVrDCyGHMG9CFg1tmrRUMRPRsAWYc/PinY0XzJU4K7y7vjNoLKIQ7BR5UJMCxNN8EM1MNDmHWA/B3aZUuw=="],
 
@@ -1828,6 +2011,8 @@
     "html-parse-stringify": ["html-parse-stringify@3.0.1", "", { "dependencies": { "void-elements": "3.1.0" } }, "sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg=="],
 
     "html-url-attributes": ["html-url-attributes@3.0.1", "", {}, "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ=="],
+
+    "html-void-elements": ["html-void-elements@3.0.0", "", {}, "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg=="],
 
     "http-cache-semantics": ["http-cache-semantics@4.2.0", "", {}, "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ=="],
 
@@ -1863,6 +2048,8 @@
 
     "import-fresh": ["import-fresh@3.3.1", "", { "dependencies": { "parent-module": "^1.0.0", "resolve-from": "^4.0.0" } }, "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ=="],
 
+    "import-meta-resolve": ["import-meta-resolve@4.2.0", "", {}, "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg=="],
+
     "imurmurhash": ["imurmurhash@0.1.4", "", {}, "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA=="],
 
     "indent-string": ["indent-string@4.0.0", "", {}, "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="],
@@ -1878,6 +2065,8 @@
     "inline-style-parser": ["inline-style-parser@0.2.7", "", {}, "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA=="],
 
     "internal-slot": ["internal-slot@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "hasown": "^2.0.2", "side-channel": "^1.1.0" } }, "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw=="],
+
+    "internmap": ["internmap@2.0.3", "", {}, "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg=="],
 
     "invariant": ["invariant@2.2.4", "", { "dependencies": { "loose-envify": "^1.0.0" } }, "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA=="],
 
@@ -2017,13 +2206,21 @@
 
     "jszip": ["jszip@3.10.1", "", { "dependencies": { "lie": "~3.3.0", "pako": "~1.0.2", "readable-stream": "~2.3.6", "setimmediate": "^1.0.5" } }, "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g=="],
 
+    "katex": ["katex@0.16.45", "", { "dependencies": { "commander": "^8.3.0" }, "bin": { "katex": "cli.js" } }, "sha512-pQpZbdBu7wCTmQUh7ufPmLr0pFoObnGUoL/yhtwJDgmmQpbkg/0HSVti25Fu4rmd1oCR6NGWe9vqTWuWv3GcNA=="],
+
     "keyv": ["keyv@4.5.4", "", { "dependencies": { "json-buffer": "3.0.1" } }, "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw=="],
 
+    "khroma": ["khroma@2.1.0", "", {}, "sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw=="],
+
     "kleur": ["kleur@3.0.3", "", {}, "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w=="],
+
+    "langium": ["langium@4.2.3", "", { "dependencies": { "@chevrotain/regexp-to-ast": "~12.0.0", "chevrotain": "~12.0.0", "chevrotain-allstar": "~0.4.3", "vscode-languageserver": "~9.0.1", "vscode-languageserver-textdocument": "~1.0.11", "vscode-uri": "~3.1.0" } }, "sha512-sOPIi4hISFnY7twwV97ca1TsxpBtXq0URu/LL1AvxwccPG/RIBBlKS7a/f/EL6w8lTNaS0EFs/F+IdSOaqYpng=="],
 
     "language-subtag-registry": ["language-subtag-registry@0.3.23", "", {}, "sha512-0K65Lea881pHotoGEa5gDlMxt3pctLi2RplBb7Ezh4rRdLEOtgi7n4EwK9lamnUCkKBqaeKRVebTq6BAxSkpXQ=="],
 
     "language-tags": ["language-tags@1.0.9", "", { "dependencies": { "language-subtag-registry": "^0.3.20" } }, "sha512-MbjN408fEndfiQXbFQ1vnd+1NoLDsnQW41410oQBXiyXDMYH5z505juWa4KUE1LqxRC7DgOgZDbKLxHIwm27hA=="],
+
+    "layout-base": ["layout-base@1.0.2", "", {}, "sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg=="],
 
     "leo-profanity": ["leo-profanity@1.8.0", "", { "optionalDependencies": { "french-badwords-list": "^1.0.7", "russian-bad-words": "^0.5.0" } }, "sha512-TATupbZhT3oFCtsiEXzgXcLvW6cDPhDtN+0yQAibjwBdSw3WJFLKM0DZ18eEW8KeFTT10x8gCP+DDZz0cI4Bfg=="],
 
@@ -2067,6 +2264,8 @@
 
     "lodash": ["lodash@4.17.21", "", {}, "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="],
 
+    "lodash-es": ["lodash-es@4.18.1", "", {}, "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A=="],
+
     "lodash.debounce": ["lodash.debounce@4.0.8", "", {}, "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow=="],
 
     "lodash.defaults": ["lodash.defaults@4.2.0", "", {}, "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ=="],
@@ -2092,6 +2291,8 @@
     "markdown-it": ["markdown-it@14.1.0", "", { "dependencies": { "argparse": "^2.0.1", "entities": "^4.4.0", "linkify-it": "^5.0.0", "mdurl": "^2.0.0", "punycode.js": "^2.3.1", "uc.micro": "^2.1.0" }, "bin": { "markdown-it": "bin/markdown-it.mjs" } }, "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg=="],
 
     "markdown-table": ["markdown-table@3.0.4", "", {}, "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw=="],
+
+    "marked": ["marked@17.0.6", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-gB0gkNafnonOw0obSTEGZTT86IuhILt2Wfx0mWH/1Au83kybTayroZ/V6nS25mN7u8ASy+5fMhgB3XPNrOZdmA=="],
 
     "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
 
@@ -2134,6 +2335,8 @@
     "merge-stream": ["merge-stream@2.0.0", "", {}, "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="],
 
     "merge2": ["merge2@1.4.1", "", {}, "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="],
+
+    "mermaid": ["mermaid@11.14.0", "", { "dependencies": { "@braintree/sanitize-url": "^7.1.1", "@iconify/utils": "^3.0.2", "@mermaid-js/parser": "^1.1.0", "@types/d3": "^7.4.3", "@upsetjs/venn.js": "^2.0.0", "cytoscape": "^3.33.1", "cytoscape-cose-bilkent": "^4.1.0", "cytoscape-fcose": "^2.2.0", "d3": "^7.9.0", "d3-sankey": "^0.12.3", "dagre-d3-es": "7.0.14", "dayjs": "^1.11.19", "dompurify": "^3.3.1", "katex": "^0.16.25", "khroma": "^2.1.0", "lodash-es": "^4.17.23", "marked": "^16.3.0", "roughjs": "^4.6.6", "stylis": "^4.3.6", "ts-dedent": "^2.2.0", "uuid": "^11.1.0" } }, "sha512-GSGloRsBs+JINmmhl0JDwjpuezCsHB4WGI4NASHxL3fHo3o/BRXTxhDLKnln8/Q0lRFRyDdEjmk1/d5Sn1Xz8g=="],
 
     "meshoptimizer": ["meshoptimizer@0.18.1", "", {}, "sha512-ZhoIoL7TNV4s5B6+rx5mC//fw8/POGyNxS/DZyCJeiZ12ScLfVwRE/GfsxwiTkMYYD5DmK2/JXnEVXqL4rF+Sw=="],
 
@@ -2327,6 +2530,8 @@
 
     "package-json-from-dist": ["package-json-from-dist@1.0.1", "", {}, "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw=="],
 
+    "package-manager-detector": ["package-manager-detector@1.6.0", "", {}, "sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA=="],
+
     "pako": ["pako@2.1.0", "", {}, "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug=="],
 
     "parent-module": ["parent-module@1.0.1", "", { "dependencies": { "callsites": "^3.0.0" } }, "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g=="],
@@ -2337,7 +2542,11 @@
 
     "parse-ms": ["parse-ms@2.1.0", "", {}, "sha512-kHt7kzLoS9VBZfUsiKjv43mr91ea+U05EyKkEtqp7vNbHxmaVuEqN7XxeEVnGrMtYOAxGrDElSi96K7EgO1zCA=="],
 
+    "parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
+
     "path-browserify": ["path-browserify@1.0.1", "", {}, "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="],
+
+    "path-data-parser": ["path-data-parser@0.1.0", "", {}, "sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w=="],
 
     "path-exists": ["path-exists@4.0.0", "", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
 
@@ -2370,6 +2579,10 @@
     "playwright": ["playwright@1.58.0", "", { "dependencies": { "playwright-core": "1.58.0" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-2SVA0sbPktiIY/MCOPX8e86ehA/e+tDNq+e5Y8qjKYti2Z/JG7xnronT/TXTIkKbYGWlCbuucZ6dziEgkoEjQQ=="],
 
     "playwright-core": ["playwright-core@1.58.0", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-aaoB1RWrdNi3//rOeKuMiS65UCcgOVljU46At6eFcOFPFHWtd2weHRRow6z/n+Lec0Lvu0k9ZPKJSjPugikirw=="],
+
+    "points-on-curve": ["points-on-curve@0.2.0", "", {}, "sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A=="],
+
+    "points-on-path": ["points-on-path@0.2.1", "", { "dependencies": { "path-data-parser": "0.1.0", "points-on-curve": "0.2.0" } }, "sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g=="],
 
     "possible-typed-array-names": ["possible-typed-array-names@1.1.0", "", {}, "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg=="],
 
@@ -2523,6 +2736,12 @@
 
     "regjsparser": ["regjsparser@0.12.0", "", { "dependencies": { "jsesc": "~3.0.2" }, "bin": { "regjsparser": "bin/parser" } }, "sha512-cnE+y8bz4NhMjISKbgeVJtqNbtf5QpjZP+Bslo+UqkIt9QPnX9q095eiRRASJG1/tz6dlNr6Z5NsBiWYokp6EQ=="],
 
+    "rehype-harden": ["rehype-harden@1.1.8", "", { "dependencies": { "unist-util-visit": "^5.0.0" } }, "sha512-Qn7vR1xrf6fZCrkm9TDWi/AB4ylrHy+jqsNm1EHOAmbARYA6gsnVJBq/sdBh6kmT4NEZxH5vgIjrscefJAOXcw=="],
+
+    "rehype-raw": ["rehype-raw@7.0.0", "", { "dependencies": { "@types/hast": "^3.0.0", "hast-util-raw": "^9.0.0", "vfile": "^6.0.0" } }, "sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww=="],
+
+    "rehype-sanitize": ["rehype-sanitize@6.0.0", "", { "dependencies": { "@types/hast": "^3.0.0", "hast-util-sanitize": "^5.0.0" } }, "sha512-CsnhKNsyI8Tub6L4sm5ZFsme4puGfc6pYylvXo1AeqaGbjOYyzNv3qZPwvs0oMJ39eryyeOdmxwUIo94IpEhqg=="],
+
     "remark-gfm": ["remark-gfm@4.0.1", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-gfm": "^3.0.0", "micromark-extension-gfm": "^3.0.0", "remark-parse": "^11.0.0", "remark-stringify": "^11.0.0", "unified": "^11.0.0" } }, "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg=="],
 
     "remark-parse": ["remark-parse@11.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-from-markdown": "^2.0.0", "micromark-util-types": "^2.0.0", "unified": "^11.0.0" } }, "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA=="],
@@ -2530,6 +2749,8 @@
     "remark-rehype": ["remark-rehype@11.1.2", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "mdast-util-to-hast": "^13.0.0", "unified": "^11.0.0", "vfile": "^6.0.0" } }, "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw=="],
 
     "remark-stringify": ["remark-stringify@11.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-to-markdown": "^2.0.0", "unified": "^11.0.0" } }, "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw=="],
+
+    "remend": ["remend@1.3.0", "", {}, "sha512-iIhggPkhW3hFImKtB10w0dz4EZbs28mV/dmbcYVonWEJ6UGHHpP+bFZnTh6GNWJONg5m+U56JrL+8IxZRdgWjw=="],
 
     "remove": ["remove@0.1.5", "", { "dependencies": { "seq": ">= 0.3.5" } }, "sha512-AJMA9oWvJzdTjwIGwSQZsjGQiRx73YTmiOWmfCp1fpLa/D4n7jKcpoA+CZiVLJqKcEKUuh1Suq80c5wF+L/qVQ=="],
 
@@ -2555,15 +2776,21 @@
 
     "rimraf": ["rimraf@3.0.2", "", { "dependencies": { "glob": "^7.1.3" }, "bin": { "rimraf": "bin.js" } }, "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA=="],
 
+    "robust-predicates": ["robust-predicates@3.0.3", "", {}, "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA=="],
+
     "rolldown": ["rolldown@1.0.0-rc.1", "", { "dependencies": { "@oxc-project/types": "=0.110.0", "@rolldown/pluginutils": "1.0.0-rc.1" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.0.0-rc.1", "@rolldown/binding-darwin-arm64": "1.0.0-rc.1", "@rolldown/binding-darwin-x64": "1.0.0-rc.1", "@rolldown/binding-freebsd-x64": "1.0.0-rc.1", "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.1", "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.1", "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.1", "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.1", "@rolldown/binding-linux-x64-musl": "1.0.0-rc.1", "@rolldown/binding-openharmony-arm64": "1.0.0-rc.1", "@rolldown/binding-wasm32-wasi": "1.0.0-rc.1", "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.1", "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.1" }, "bin": { "rolldown": "bin/cli.mjs" } }, "sha512-M3AeZjYE6UclblEf531Hch0WfVC/NOL43Cc+WdF3J50kk5/fvouHhDumSGTh0oRjbZ8C4faaVr5r6Nx1xMqDGg=="],
 
     "rollup": ["rollup@4.60.2", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.60.2", "@rollup/rollup-android-arm64": "4.60.2", "@rollup/rollup-darwin-arm64": "4.60.2", "@rollup/rollup-darwin-x64": "4.60.2", "@rollup/rollup-freebsd-arm64": "4.60.2", "@rollup/rollup-freebsd-x64": "4.60.2", "@rollup/rollup-linux-arm-gnueabihf": "4.60.2", "@rollup/rollup-linux-arm-musleabihf": "4.60.2", "@rollup/rollup-linux-arm64-gnu": "4.60.2", "@rollup/rollup-linux-arm64-musl": "4.60.2", "@rollup/rollup-linux-loong64-gnu": "4.60.2", "@rollup/rollup-linux-loong64-musl": "4.60.2", "@rollup/rollup-linux-ppc64-gnu": "4.60.2", "@rollup/rollup-linux-ppc64-musl": "4.60.2", "@rollup/rollup-linux-riscv64-gnu": "4.60.2", "@rollup/rollup-linux-riscv64-musl": "4.60.2", "@rollup/rollup-linux-s390x-gnu": "4.60.2", "@rollup/rollup-linux-x64-gnu": "4.60.2", "@rollup/rollup-linux-x64-musl": "4.60.2", "@rollup/rollup-openbsd-x64": "4.60.2", "@rollup/rollup-openharmony-arm64": "4.60.2", "@rollup/rollup-win32-arm64-msvc": "4.60.2", "@rollup/rollup-win32-ia32-msvc": "4.60.2", "@rollup/rollup-win32-x64-gnu": "4.60.2", "@rollup/rollup-win32-x64-msvc": "4.60.2", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ=="],
 
     "rope-sequence": ["rope-sequence@1.3.4", "", {}, "sha512-UT5EDe2cu2E/6O4igUr5PSFs23nvvukicWHx6GnOPlHAiiYbzNuCRQCuiUdHJQcqKalLKlrYJnjY0ySGsXNQXQ=="],
 
+    "roughjs": ["roughjs@4.6.6", "", { "dependencies": { "hachure-fill": "^0.5.2", "path-data-parser": "^0.1.0", "points-on-curve": "^0.2.0", "points-on-path": "^0.2.1" } }, "sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ=="],
+
     "run-parallel": ["run-parallel@1.2.0", "", { "dependencies": { "queue-microtask": "^1.2.2" } }, "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA=="],
 
     "russian-bad-words": ["russian-bad-words@0.5.0", "", {}, "sha512-euNvEYki6iYYpkNbeudW+lEMMYGEmN7EBwVF8ezlbv0bZoQpVYB7W10cCeUIGV7Ed50sJynLQ0c559q5iI0ejQ=="],
+
+    "rw": ["rw@1.3.3", "", {}, "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ=="],
 
     "safe-array-concat": ["safe-array-concat@1.1.3", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.2", "get-intrinsic": "^1.2.6", "has-symbols": "^1.1.0", "isarray": "^2.0.5" } }, "sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q=="],
 
@@ -2667,6 +2894,8 @@
 
     "stream-to-promise": ["stream-to-promise@2.2.0", "", { "dependencies": { "any-promise": "~1.3.0", "end-of-stream": "~1.1.0", "stream-to-array": "~2.3.0" } }, "sha512-HAGUASw8NT0k8JvIVutB2Y/9iBk7gpgEyAudXwNJmZERdMITGdajOa4VJfD/kNiA3TppQpTP4J+CtcHwdzKBAw=="],
 
+    "streamdown": ["streamdown@2.5.0", "", { "dependencies": { "clsx": "^2.1.1", "hast-util-to-jsx-runtime": "^2.3.6", "html-url-attributes": "^3.0.1", "marked": "^17.0.1", "mermaid": "^11.12.2", "rehype-harden": "^1.1.8", "rehype-raw": "^7.0.0", "rehype-sanitize": "^6.0.0", "remark-gfm": "^4.0.1", "remark-parse": "^11.0.0", "remark-rehype": "^11.1.2", "remend": "1.3.0", "tailwind-merge": "^3.4.0", "unified": "^11.0.5", "unist-util-visit": "^5.0.0", "unist-util-visit-parents": "^6.0.0" }, "peerDependencies": { "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" } }, "sha512-/tTnURfIOxZK/pqJAxsfCvETG/XCJHoWnk3jq9xLcuz6CSpnjjuxSRBTTL4PKGhxiZQf0lqPxGhImdpwcZ2XwA=="],
+
     "streamx": ["streamx@2.25.0", "", { "dependencies": { "events-universal": "^1.0.0", "fast-fifo": "^1.3.2", "text-decoder": "^1.1.0" } }, "sha512-0nQuG6jf1w+wddNEEXCF4nTg3LtufWINB5eFEN+5TNZW7KWJp6x87+JFL43vaAUPyCfH1wID+mNVyW6OHtFamg=="],
 
     "string-to-arraybuffer": ["string-to-arraybuffer@1.0.2", "", { "dependencies": { "atob-lite": "^2.0.0", "is-base64": "^0.1.0" } }, "sha512-DaGZidzi93dwjQen5I2osxR9ERS/R7B1PFyufNMnzhj+fmlDQAc1DSDIJVJhgI8Oq221efIMbABUBdPHDRt43Q=="],
@@ -2712,6 +2941,8 @@
     "style-to-js": ["style-to-js@1.1.21", "", { "dependencies": { "style-to-object": "1.0.14" } }, "sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ=="],
 
     "style-to-object": ["style-to-object@1.0.14", "", { "dependencies": { "inline-style-parser": "0.2.7" } }, "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw=="],
+
+    "stylis": ["stylis@4.4.0", "", {}, "sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA=="],
 
     "supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
@@ -2788,6 +3019,8 @@
     "trough": ["trough@2.2.0", "", {}, "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw=="],
 
     "ts-api-utils": ["ts-api-utils@2.1.0", "", { "peerDependencies": { "typescript": ">=4.8.4" } }, "sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ=="],
+
+    "ts-dedent": ["ts-dedent@2.2.0", "", {}, "sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ=="],
 
     "ts-morph": ["ts-morph@12.0.0", "", { "dependencies": { "@ts-morph/common": "~0.11.0", "code-block-writer": "^10.1.1" } }, "sha512-VHC8XgU2fFW7yO1f/b3mxKDje1vmyzFXHWzOYmKEkCEwcLjDtbdLgBQviqj4ZwP4MJkQtRo6Ha2I29lq/B+VxA=="],
 
@@ -2899,6 +3132,8 @@
 
     "vfile": ["vfile@6.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "vfile-message": "^4.0.0" } }, "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q=="],
 
+    "vfile-location": ["vfile-location@5.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "vfile": "^6.0.0" } }, "sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg=="],
+
     "vfile-message": ["vfile-message@4.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw=="],
 
     "vite": ["vite@6.4.2", "", { "dependencies": { "esbuild": "^0.25.0", "fdir": "^6.4.4", "picomatch": "^4.0.2", "postcss": "^8.5.3", "rollup": "^4.34.9", "tinyglobby": "^0.2.13" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "jiti": ">=1.21.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ=="],
@@ -2907,11 +3142,25 @@
 
     "void-elements": ["void-elements@3.1.0", "", {}, "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w=="],
 
+    "vscode-jsonrpc": ["vscode-jsonrpc@8.2.0", "", {}, "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA=="],
+
+    "vscode-languageserver": ["vscode-languageserver@9.0.1", "", { "dependencies": { "vscode-languageserver-protocol": "3.17.5" }, "bin": { "installServerIntoExtension": "bin/installServerIntoExtension" } }, "sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g=="],
+
+    "vscode-languageserver-protocol": ["vscode-languageserver-protocol@3.17.5", "", { "dependencies": { "vscode-jsonrpc": "8.2.0", "vscode-languageserver-types": "3.17.5" } }, "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg=="],
+
+    "vscode-languageserver-textdocument": ["vscode-languageserver-textdocument@1.0.12", "", {}, "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA=="],
+
+    "vscode-languageserver-types": ["vscode-languageserver-types@3.17.5", "", {}, "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg=="],
+
+    "vscode-uri": ["vscode-uri@3.1.0", "", {}, "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ=="],
+
     "w3c-keyname": ["w3c-keyname@2.2.8", "", {}, "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ=="],
 
     "wanakana": ["wanakana@5.3.1", "", {}, "sha512-OSDqupzTlzl2LGyqTdhcXcl6ezMiFhcUwLBP8YKaBIbMYW1wAwDvupw2T9G9oVaKT9RmaSpyTXjxddFPUcFFIw=="],
 
     "wavesurfer.js": ["wavesurfer.js@7.12.1", "", {}, "sha512-NswPjVHxk0Q1F/VMRemCPUzSojjuHHisQrBqQiRXg7MVbe3f5vQ6r0rTTXA/a/neC/4hnOEC4YpXca4LpH0SUg=="],
+
+    "web-namespaces": ["web-namespaces@2.0.1", "", {}, "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ=="],
 
     "web-streams-polyfill": ["web-streams-polyfill@3.3.3", "", {}, "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw=="],
 
@@ -3008,6 +3257,8 @@
     "zustand": ["zustand@5.0.9", "", { "peerDependencies": { "@types/react": ">=18.0.0", "immer": ">=9.0.6", "react": ">=18.0.0", "use-sync-external-store": ">=1.2.0" }, "optionalPeers": ["@types/react", "immer", "react", "use-sync-external-store"] }, "sha512-ALBtUj0AfjJt3uNRQoL1tL2tMvj6Gp/6e39dnfT6uzpelGru8v1tPOGBzayOWbPJvujM8JojDk3E1LxeFisBNg=="],
 
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
+
+    "@antfu/install-pkg/tinyexec": ["tinyexec@1.1.2", "", {}, "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA=="],
 
     "@apideck/better-ajv-errors/ajv": ["ajv@8.17.1", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g=="],
 
@@ -3409,6 +3660,14 @@
 
     "cacache/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
 
+    "cytoscape-fcose/cose-base": ["cose-base@2.2.0", "", { "dependencies": { "layout-base": "^2.0.0" } }, "sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g=="],
+
+    "d3-dsv/commander": ["commander@7.2.0", "", {}, "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw=="],
+
+    "d3-sankey/d3-array": ["d3-array@2.12.1", "", { "dependencies": { "internmap": "^1.0.0" } }, "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ=="],
+
+    "d3-sankey/d3-shape": ["d3-shape@1.3.7", "", { "dependencies": { "d3-path": "1" } }, "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw=="],
+
     "edge-runtime/async-listen": ["async-listen@3.0.1", "", {}, "sha512-cWMaNwUJnf37C/S5TfCkk/15MwbPRwVYALA2jtjkbHjCmAPiDXyNJy2q3p1KAZzDLHAWyarUWSujUoHR4pEgrA=="],
 
     "edge-runtime/picocolors": ["picocolors@1.0.0", "", {}, "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="],
@@ -3453,6 +3712,8 @@
 
     "jszip/readable-stream": ["readable-stream@2.3.8", "", { "dependencies": { "core-util-is": "~1.0.0", "inherits": "~2.0.3", "isarray": "~1.0.0", "process-nextick-args": "~2.0.0", "safe-buffer": "~5.1.1", "string_decoder": "~1.1.1", "util-deprecate": "~1.0.1" } }, "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA=="],
 
+    "katex/commander": ["commander@8.3.0", "", {}, "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="],
+
     "linebreak/base64-js": ["base64-js@0.0.8", "", {}, "sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw=="],
 
     "make-fetch-happen/http-proxy-agent": ["http-proxy-agent@4.0.1", "", { "dependencies": { "@tootallnate/once": "1", "agent-base": "6", "debug": "4" } }, "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg=="],
@@ -3466,6 +3727,8 @@
     "make-fetch-happen/socks-proxy-agent": ["socks-proxy-agent@6.2.1", "", { "dependencies": { "agent-base": "^6.0.2", "debug": "^4.3.3", "socks": "^2.6.2" } }, "sha512-a6KW9G+6B3nWZ1yB8G7pJwL3ggLy1uTzKAgCb7ttblwqdz9fMGJUuTy3uFzEP48FAs9FLILlmzDlE2JJhVQaXQ=="],
 
     "mdast-util-find-and-replace/escape-string-regexp": ["escape-string-regexp@5.0.0", "", {}, "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="],
+
+    "mermaid/marked": ["marked@16.4.2", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA=="],
 
     "micro/content-type": ["content-type@1.0.4", "", {}, "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="],
 
@@ -3504,6 +3767,8 @@
     "pac-proxy-agent/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
     "parse-entities/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
+
+    "parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
 
     "path-scurry/lru-cache": ["lru-cache@11.2.2", "", {}, "sha512-F9ODfyqML2coTIsQpSkRHnLSZMtkU8Q+mSfcaIyKwy58u+8k5nvAYeiNhsyMARvzNcXJ9QfWVrcPsC9e9rAxtg=="],
 
@@ -3560,6 +3825,8 @@
     "ssri/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
 
     "standardized-audio-context/@babel/runtime": ["@babel/runtime@7.26.10", "", { "dependencies": { "regenerator-runtime": "^0.14.0" } }, "sha512-2WJMeRQPHKSPemqk/awGrAiuFfzBmOIPXKizAsVhWH9YJqLZ0H+HS4c8loHGgW6utJ3E/ejXQUsiGaQy2NZ9Fw=="],
+
+    "streamdown/tailwind-merge": ["tailwind-merge@3.5.0", "", {}, "sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A=="],
 
     "string-to-arraybuffer/is-base64": ["is-base64@0.1.0", "", {}, "sha512-WRRyllsGXJM7ZN7gPTCCQ/6wNPTRDwiWdPK66l5sJzcU/oOzcIcRRf0Rux8bkpox/1yjt0F6VJRsQOIG2qz5sg=="],
 
@@ -3990,6 +4257,12 @@
     "@yarnpkg/parsers/js-yaml/argparse": ["argparse@1.0.10", "", { "dependencies": { "sprintf-js": "~1.0.2" } }, "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg=="],
 
     "assert/util/inherits": ["inherits@2.0.3", "", {}, "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw=="],
+
+    "cytoscape-fcose/cose-base/layout-base": ["layout-base@2.0.1", "", {}, "sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg=="],
+
+    "d3-sankey/d3-array/internmap": ["internmap@1.0.1", "", {}, "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw=="],
+
+    "d3-sankey/d3-shape/d3-path": ["d3-path@1.0.9", "", {}, "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg=="],
 
     "filelist/minimatch/brace-expansion": ["brace-expansion@2.0.1", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA=="],
 

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "@radix-ui/react-tabs": "^1.1.13",
     "@radix-ui/react-tooltip": "^1.2.8",
     "@radix-ui/react-visually-hidden": "^1.2.4",
+    "@streamdown/code": "^1.1.1",
     "@tailwindcss/vite": "^4.1.18",
     "@tiptap/core": "^2.27",
     "@tiptap/extension-task-item": "^2.27",

--- a/package.json
+++ b/package.json
@@ -141,6 +141,7 @@
     "react-scan": "^0.5.3",
     "remark-gfm": "^4.0.1",
     "sonner": "^2.0.7",
+    "streamdown": "^2.5.0",
     "tailwind-merge": "^2.6.0",
     "tailwindcss-animate": "^1.0.7",
     "three": "^0.176.0",

--- a/src/apps/chats/components/ChatMessages.tsx
+++ b/src/apps/chats/components/ChatMessages.tsx
@@ -1,6 +1,6 @@
 import { UIMessage as VercelMessage } from "@ai-sdk/react";
 import { WarningCircle, ChatCircle, Copy, Check, CaretDown, Trash, SpeakerHigh, Pause, PaperPlaneRight } from "@phosphor-icons/react";
-import { useEffect, useRef, useState, memo, useCallback } from "react";
+import { useEffect, useRef, useState, memo, useCallback, type CSSProperties } from "react";
 import { Streamdown, type Components as StreamdownComponents } from "streamdown";
 import { Button } from "@/components/ui/button";
 import { ActivityIndicator } from "@/components/ui/activity-indicator";
@@ -195,6 +195,25 @@ const chatStreamdownComponents: StreamdownComponents = {
 };
 
 const STREAMDOWN_DISALLOWED_ELEMENTS = ["img"] as const;
+const CHAT_STREAMDOWN_SHIKI_THEME: ["github-light", "github-dark"] = [
+  "github-light",
+  "github-dark",
+];
+
+type ChatMessageStyle = CSSProperties & {
+  "--ryos-chat-font-size": string;
+};
+
+const getChatMessageStyle = (
+  fontSize: number,
+  isEmojiMessage = false
+): ChatMessageStyle => {
+  const size = isEmojiMessage ? "24px" : `${fontSize}px`;
+  return {
+    fontSize: size,
+    "--ryos-chat-font-size": size,
+  };
+};
 
 // Define an extended message type that includes username
 // Extend VercelMessage and add username and the 'human' role
@@ -758,7 +777,7 @@ const ChatMessageItem = memo(function ChatMessageItem(props: ChatMessageItemProp
                   ? "bg-yellow-100 text-black"
                   : "bg-blue-100 text-black")
           } w-fit max-w-[90%] min-h-[12px] rounded leading-snug font-geneva-12 break-words select-text`}
-          style={{ fontSize: `${fontSize}px` }}
+          style={getChatMessageStyle(fontSize)}
         >
           {showTypingDots ? (
             <TypingDots />
@@ -808,9 +827,7 @@ const ChatMessageItem = memo(function ChatMessageItem(props: ChatMessageItemProp
                         <div
                           key={partKey}
                           className="w-full"
-                          style={{
-                            fontSize: isEmojiMessage ? "24px" : `${fontSize}px`,
-                          }}
+                          style={getChatMessageStyle(fontSize, isEmojiMessage)}
                         >
                           {streamdownContent && (
                             <Streamdown
@@ -819,6 +836,9 @@ const ChatMessageItem = memo(function ChatMessageItem(props: ChatMessageItemProp
                               }`}
                               components={chatStreamdownComponents}
                               disallowedElements={STREAMDOWN_DISALLOWED_ELEMENTS}
+                              controls={false}
+                              lineNumbers={false}
+                              shikiTheme={CHAT_STREAMDOWN_SHIKI_THEME}
                               skipHtml
                               unwrapDisallowed
                               mode={isStreamingMessage ? "streaming" : "static"}
@@ -863,9 +883,7 @@ const ChatMessageItem = memo(function ChatMessageItem(props: ChatMessageItemProp
             displayContent && (
               <div
                 className="select-text"
-                style={{
-                  fontSize: isEmojiOnly(displayContent) ? "24px" : `${fontSize}px`,
-                }}
+                style={getChatMessageStyle(fontSize, isEmojiOnly(displayContent))}
               >
                 <Streamdown
                   className={`ryos-chat-streamdown ${
@@ -873,6 +891,9 @@ const ChatMessageItem = memo(function ChatMessageItem(props: ChatMessageItemProp
                   }`}
                   components={chatStreamdownComponents}
                   disallowedElements={STREAMDOWN_DISALLOWED_ELEMENTS}
+                  controls={false}
+                  lineNumbers={false}
+                  shikiTheme={CHAT_STREAMDOWN_SHIKI_THEME}
                   skipHtml
                   unwrapDisallowed
                   mode="static"
@@ -1197,7 +1218,7 @@ function ChatMessagesContent({
           >
             <div
               className="p-1.5 px-2 chat-bubble bg-neutral-200 text-neutral-400 w-fit max-w-[90%] min-h-[12px] rounded leading-snug font-geneva-12 break-words"
-              style={{ fontSize: `${fontSize}px` }}
+              style={getChatMessageStyle(fontSize)}
             >
               <div className="flex items-center gap-1.5">
                 <TypingDots />

--- a/src/apps/chats/components/ChatMessages.tsx
+++ b/src/apps/chats/components/ChatMessages.tsx
@@ -1,5 +1,6 @@
 import { UIMessage as VercelMessage } from "@ai-sdk/react";
 import { WarningCircle, ChatCircle, Copy, Check, CaretDown, Trash, SpeakerHigh, Pause, PaperPlaneRight } from "@phosphor-icons/react";
+import { createCodePlugin } from "@streamdown/code";
 import { useEffect, useRef, useState, memo, useCallback, type CSSProperties } from "react";
 import { Streamdown, type Components as StreamdownComponents } from "streamdown";
 import { Button } from "@/components/ui/button";
@@ -199,6 +200,12 @@ const CHAT_STREAMDOWN_SHIKI_THEME: ["github-light", "github-dark"] = [
   "github-light",
   "github-dark",
 ];
+const chatCodePlugin = createCodePlugin({
+  themes: CHAT_STREAMDOWN_SHIKI_THEME,
+});
+const CHAT_STREAMDOWN_PLUGINS = {
+  code: chatCodePlugin,
+};
 
 type ChatMessageStyle = CSSProperties & {
   "--ryos-chat-font-size": string;
@@ -839,6 +846,7 @@ const ChatMessageItem = memo(function ChatMessageItem(props: ChatMessageItemProp
                               controls={false}
                               lineNumbers={false}
                               shikiTheme={CHAT_STREAMDOWN_SHIKI_THEME}
+                              plugins={CHAT_STREAMDOWN_PLUGINS}
                               skipHtml
                               unwrapDisallowed
                               mode={isStreamingMessage ? "streaming" : "static"}
@@ -894,6 +902,7 @@ const ChatMessageItem = memo(function ChatMessageItem(props: ChatMessageItemProp
                   controls={false}
                   lineNumbers={false}
                   shikiTheme={CHAT_STREAMDOWN_SHIKI_THEME}
+                  plugins={CHAT_STREAMDOWN_PLUGINS}
                   skipHtml
                   unwrapDisallowed
                   mode="static"

--- a/src/apps/chats/components/ChatMessages.tsx
+++ b/src/apps/chats/components/ChatMessages.tsx
@@ -1193,12 +1193,35 @@ function ChatMessagesContent({
     }
   }, [roomId, onMessageDeleted]);
 
-  const streamingAssistantMessage = isLoading
-    ? [...messages].reverse().find((msg) => msg.role === "assistant")
-    : undefined;
+  // Only treat the very last message as a streaming target, and only if it
+  // is an assistant message. Searching backwards for the last assistant can
+  // briefly flag a previously-completed assistant message as streaming
+  // during the moment after the user's new message is appended but before
+  // the AI SDK pushes the next empty assistant message — that flicker would
+  // make Streamdown's animate plugin re-run and rapidly fade-in the whole
+  // prior reply word-by-word.
+  const lastMessage = messages.length > 0 ? messages[messages.length - 1] : undefined;
+  const streamingAssistantMessage =
+    isLoading && lastMessage && lastMessage.role === "assistant"
+      ? lastMessage
+      : undefined;
   const streamingAssistantMessageKey = streamingAssistantMessage
     ? getMessageKey(streamingAssistantMessage)
     : null;
+
+  // Belt-and-suspenders: once a message key has been seen as streaming and
+  // then leaves that state, lock its `isAnimating` to false forever so any
+  // future flicker (e.g. message list reorder, key reuse) cannot re-trigger
+  // the animation.
+  const animatedKeysRef = useRef<Set<string>>(new Set());
+  const previousStreamingKeyRef = useRef<string | null>(null);
+  useEffect(() => {
+    const previousKey = previousStreamingKeyRef.current;
+    if (previousKey && previousKey !== streamingAssistantMessageKey) {
+      animatedKeysRef.current.add(previousKey);
+    }
+    previousStreamingKeyRef.current = streamingAssistantMessageKey;
+  }, [streamingAssistantMessageKey]);
 
   // Return the message list rendering logic
   return (
@@ -1226,7 +1249,9 @@ function ChatMessagesContent({
       {messages.map((message) => {
         const messageKey = getMessageKey(message);
         const isInitialMessage = initialMessageIdsRef.current.has(messageKey);
-        const isStreamingMessage = messageKey === streamingAssistantMessageKey;
+        const isStreamingMessage =
+          messageKey === streamingAssistantMessageKey &&
+          !animatedKeysRef.current.has(messageKey);
         return (
           <ChatMessageItem
             key={messageKey}

--- a/src/apps/chats/components/ChatMessages.tsx
+++ b/src/apps/chats/components/ChatMessages.tsx
@@ -206,6 +206,12 @@ const chatCodePlugin = createCodePlugin({
 const CHAT_STREAMDOWN_PLUGINS = {
   code: chatCodePlugin,
 };
+const CHAT_STREAMDOWN_ANIMATED = {
+  animation: "fadeIn",
+  duration: 150,
+  easing: "ease-out",
+  sep: "word",
+} as const;
 
 type ChatMessageStyle = CSSProperties & {
   "--ryos-chat-font-size": string;
@@ -362,6 +368,7 @@ interface ChatMessageItemProps {
   setSpeechLoadingId: (id: string | null) => void;
   speak: (text: string, onDone?: () => void) => void;
   stop: () => void;
+  playNote: () => void;
   playElevatorMusic: () => void;
   stopElevatorMusic: () => void;
   playDingSound: () => void;
@@ -394,6 +401,7 @@ const ChatMessageItem = memo(function ChatMessageItem(props: ChatMessageItemProp
     setSpeechLoadingId,
     speak,
     stop,
+    playNote,
     playElevatorMusic,
     stopElevatorMusic,
     playDingSound,
@@ -401,6 +409,38 @@ const ChatMessageItem = memo(function ChatMessageItem(props: ChatMessageItemProp
 
   const [isHovered, setIsHovered] = useState(false);
   const [isInteractingWithPreview, setIsInteractingWithPreview] = useState(false);
+
+  // Stable ref to playNote so the bubbling animationstart handler stays stable
+  // across renders and Streamdown's animated word spans don't trigger
+  // unnecessary re-binds.
+  const playNoteRef = useRef(playNote);
+  useEffect(() => {
+    playNoteRef.current = playNote;
+  }, [playNote]);
+
+  // Counter so we play a note on every other animated word during streaming,
+  // matching the original chat synth cadence and avoiding audio overload on
+  // bursty token arrivals.
+  const animationCountRef = useRef(0);
+  const handleStreamdownAnimationStart = useCallback(
+    (event: React.AnimationEvent<HTMLDivElement>) => {
+      const target = event.target as HTMLElement | null;
+      if (!target || !target.dataset || target.dataset.sdAnimate === undefined) {
+        return;
+      }
+      animationCountRef.current += 1;
+      if (animationCountRef.current % 2 !== 0) {
+        return;
+      }
+      try {
+        playNoteRef.current();
+      } catch {
+        // useChatSynth handles audio context errors internally; swallow any
+        // synchronous throws so streaming doesn't break.
+      }
+    },
+    []
+  );
 
   let messageText = getMessageText(message);
   const isStaticGreeting = message.role === "assistant" && message.id === "1";
@@ -835,6 +875,11 @@ const ChatMessageItem = memo(function ChatMessageItem(props: ChatMessageItemProp
                           key={partKey}
                           className="w-full"
                           style={getChatMessageStyle(fontSize, isEmojiMessage)}
+                          onAnimationStart={
+                            isStreamingMessage
+                              ? handleStreamdownAnimationStart
+                              : undefined
+                          }
                         >
                           {streamdownContent && (
                             <Streamdown
@@ -850,6 +895,7 @@ const ChatMessageItem = memo(function ChatMessageItem(props: ChatMessageItemProp
                               skipHtml
                               unwrapDisallowed
                               mode={isStreamingMessage ? "streaming" : "static"}
+                              animated={CHAT_STREAMDOWN_ANIMATED}
                               isAnimating={isStreamingMessage}
                               parseIncompleteMarkdown={isStreamingMessage}
                             >
@@ -1208,6 +1254,7 @@ function ChatMessagesContent({
             setSpeechLoadingId={setSpeechLoadingId}
             speak={speak}
             stop={stop}
+            playNote={playNote}
             playElevatorMusic={playElevatorMusic}
             stopElevatorMusic={stopElevatorMusic}
             playDingSound={playDingSound}

--- a/src/apps/chats/components/ChatMessages.tsx
+++ b/src/apps/chats/components/ChatMessages.tsx
@@ -1,6 +1,7 @@
 import { UIMessage as VercelMessage } from "@ai-sdk/react";
 import { WarningCircle, ChatCircle, Copy, Check, CaretDown, Trash, SpeakerHigh, Pause, PaperPlaneRight } from "@phosphor-icons/react";
 import { useEffect, useRef, useState, memo, useCallback } from "react";
+import { Streamdown, type Components as StreamdownComponents } from "streamdown";
 import { Button } from "@/components/ui/button";
 import { ActivityIndicator } from "@/components/ui/activity-indicator";
 import { AnimatePresence, motion } from "framer-motion";
@@ -32,7 +33,7 @@ import i18n from "@/lib/i18n";
 import { abortableFetch } from "@/utils/abortableFetch";
 import { decodeHtmlEntities } from "@/utils/decodeHtmlEntities";
 import { formatToolName } from "@/lib/toolInvocationDisplay";
-import { segmentChatMarkdownText, type ChatMarkdownToken } from "@/lib/chatMarkdown";
+import { segmentChatMarkdownText } from "@/lib/chatMarkdown";
 
 // Helper to extract image URLs from message parts
 const extractImageParts = (message: {
@@ -89,29 +90,9 @@ const isUrlOnly = (text: string): boolean => {
 
 const isUrgentMessage = (content: string) => content.startsWith("!!!!");
 
-const getFaviconUrl = (url: string): string => {
-  try {
-    const domain = new URL(url).hostname;
-    return `https://www.google.com/s2/favicons?domain=${domain}&sz=16`;
-  } catch {
-    return `https://www.google.com/s2/favicons?domain=example.com&sz=16`;
-  }
-};
-
-const getCitationLabel = (url: string): string => {
-  try {
-    return new URL(url).hostname.replace(/^www\./, "");
-  } catch {
-    return url;
-  }
-};
-
 // Stable module-level animation objects — prevents Framer Motion from seeing
 // prop changes on every render, which would otherwise re-trigger animations.
 const CHAT_BUBBLE_VARIANTS = { initial: { opacity: 0 }, animate: { opacity: 1 } };
-const MOTION_SPAN_ANIMATE = { opacity: 1, y: 0 } as const;
-const MOTION_SPAN_INITIAL_NEW = { opacity: 0, y: 12 } as const;
-const MOTION_SPAN_INITIAL_LOADED = { opacity: 1, y: 0 } as const;
 const MOTION_BTN_INITIAL = { opacity: 0, scale: 0.8 } as const;
 
 // Helper function to extract user-friendly error message
@@ -184,6 +165,36 @@ const getMessageText = (message: {
     .map((p) => (p as { type: string; text?: string }).text || "")
     .join("");
 };
+
+const getMessageKey = (message: {
+  id?: string;
+  role: string;
+  parts?: Array<{ type: string; text?: string }>;
+}): string => {
+  const messageText = getMessageText(message);
+  return message.id === "1" || message.id === "proactive-1"
+    ? "greeting"
+    : message.id || `${message.role}-${messageText.substring(0, 10)}`;
+};
+
+const chatStreamdownComponents: StreamdownComponents = {
+  a: ({ children, href, onClick }) => (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="ryos-chat-streamdown-link"
+      onClick={(event) => {
+        onClick?.(event);
+        event.stopPropagation();
+      }}
+    >
+      {children}
+    </a>
+  ),
+};
+
+const STREAMDOWN_DISALLOWED_ELEMENTS = ["img"] as const;
 
 // Define an extended message type that includes username
 // Extend VercelMessage and add username and the 'human' role
@@ -304,6 +315,7 @@ interface ChatMessageItemProps {
   message: ChatMessage;
   messageKey: string;
   isInitialMessage: boolean;
+  isStreamingMessage: boolean;
   isLoading: boolean;
   isLoadingGreeting: boolean;
   isRoomView: boolean;
@@ -312,10 +324,6 @@ interface ChatMessageItemProps {
   copiedMessageId: string | null;
   playingMessageId: string | null;
   speechLoadingId: string | null;
-  highlightSegment: { messageId: string; start: number; end: number } | null;
-  localHighlightSegment: { messageId: string; start: number; end: number } | null;
-  isSpeaking: boolean;
-  localTtsSpeaking: boolean;
   speechEnabled: boolean;
   isAdmin: boolean;
   roomId?: string;
@@ -324,13 +332,10 @@ interface ChatMessageItemProps {
   onSendMessage?: (username: string) => void;
   onCopyMessage: (message: ChatMessage) => void;
   onDeleteMessage: (message: ChatMessage) => void;
-  setLocalHighlightSegment: (seg: { messageId: string; start: number; end: number } | null) => void;
   setPlayingMessageId: (id: string | null) => void;
   setSpeechLoadingId: (id: string | null) => void;
-  localHighlightQueueRef: React.MutableRefObject<{ messageId: string; start: number; end: number }[]>;
   speak: (text: string, onDone?: () => void) => void;
   stop: () => void;
-  playNote: () => void;
   playElevatorMusic: () => void;
   stopElevatorMusic: () => void;
   playDingSound: () => void;
@@ -342,6 +347,7 @@ const ChatMessageItem = memo(function ChatMessageItem(props: ChatMessageItemProp
     message,
     messageKey,
     isInitialMessage,
+    isStreamingMessage,
     isLoading,
     isLoadingGreeting,
     isRoomView,
@@ -350,10 +356,6 @@ const ChatMessageItem = memo(function ChatMessageItem(props: ChatMessageItemProp
     copiedMessageId,
     playingMessageId,
     speechLoadingId,
-    highlightSegment,
-    localHighlightSegment,
-    isSpeaking,
-    localTtsSpeaking,
     speechEnabled,
     isAdmin,
     roomId: _roomId,
@@ -362,13 +364,10 @@ const ChatMessageItem = memo(function ChatMessageItem(props: ChatMessageItemProp
     onSendMessage,
     onCopyMessage,
     onDeleteMessage,
-    setLocalHighlightSegment,
     setPlayingMessageId,
     setSpeechLoadingId,
-    localHighlightQueueRef,
     speak,
     stop,
-    playNote,
     playElevatorMusic,
     stopElevatorMusic,
     playDingSound,
@@ -376,11 +375,6 @@ const ChatMessageItem = memo(function ChatMessageItem(props: ChatMessageItemProp
 
   const [isHovered, setIsHovered] = useState(false);
   const [isInteractingWithPreview, setIsInteractingWithPreview] = useState(false);
-
-  // Keep a ref to the latest playNote so onComplete callbacks stay stable
-  // across renders and don't cause Framer Motion to re-run animations.
-  const playNoteRef = useRef(playNote);
-  useEffect(() => { playNoteRef.current = playNote; }, [playNote]);
 
   let messageText = getMessageText(message);
   const isStaticGreeting = message.role === "assistant" && message.id === "1";
@@ -418,13 +412,6 @@ const ChatMessageItem = memo(function ChatMessageItem(props: ChatMessageItemProp
     hasAquarium = true;
   }
 
-  const combinedHighlightSeg = highlightSegment || localHighlightSegment;
-  const combinedIsSpeaking = isSpeaking || localTtsSpeaking;
-  const highlightActive =
-    combinedIsSpeaking &&
-    combinedHighlightSeg &&
-    combinedHighlightSeg.messageId === message.id;
-
   const isTouchDevice = () =>
     "ontouchstart" in window || navigator.maxTouchPoints > 0;
 
@@ -434,55 +421,6 @@ const ChatMessageItem = memo(function ChatMessageItem(props: ChatMessageItemProp
       if (token.type === "link" && token.url) urls.add(token.url);
     });
     return Array.from(urls);
-  };
-
-  const renderInlineToken = (segment: ChatMarkdownToken) => {
-    const tokenNode =
-      (segment.type === "link" || segment.type === "citation") && segment.url ? (
-        <a
-          href={segment.url}
-          target="_blank"
-          rel="noopener noreferrer"
-          className={
-            segment.type === "citation"
-              ? "inline-flex h-4 w-4 translate-y-[1px] items-center justify-center align-baseline no-underline"
-              : "text-blue-600 hover:underline"
-          }
-          style={{
-            color:
-              segment.type === "citation"
-                ? undefined
-                : isUrgent
-                ? "inherit"
-                : undefined,
-          }}
-          onClick={(e) => e.stopPropagation()}
-          title={
-            segment.type === "citation"
-              ? getCitationLabel(segment.url)
-              : undefined
-          }
-          aria-label={
-            segment.type === "citation"
-              ? `Source: ${getCitationLabel(segment.url)}`
-              : undefined
-          }
-        >
-          {segment.type === "citation" ? (
-            <img
-              src={getFaviconUrl(segment.url)}
-              alt=""
-              aria-hidden="true"
-              className="h-3.5 w-3.5 rounded-[2px]"
-            />
-          ) : (
-            segment.content
-          )}
-        </a>
-      ) : (
-        segment.content
-      );
-    return tokenNode;
   };
 
   return (
@@ -634,8 +572,6 @@ const ChatMessageItem = memo(function ChatMessageItem(props: ChatMessageItemProp
                     setPlayingMessageId(null);
                   } else {
                     stop();
-                    setLocalHighlightSegment(null);
-                    localHighlightQueueRef.current = [];
                     setSpeechLoadingId(null);
                     const text = displayContent.trim();
                     if (text) {
@@ -648,33 +584,13 @@ const ChatMessageItem = memo(function ChatMessageItem(props: ChatMessageItemProp
                         }
                       }
                       if (chunks.length > 0) {
-                        let charCursor = 0;
-                        const segments = chunks.map((chunk) => {
-                          const visibleLen = segmentChatMarkdownText(chunk).reduce(
-                            (acc, token) => acc + token.content.length,
-                            0
-                          );
-                          const seg = {
-                            messageId: message.id || messageKey,
-                            start: charCursor,
-                            end: charCursor + visibleLen,
-                          };
-                          charCursor += visibleLen;
-                          return seg;
-                        });
-                        localHighlightQueueRef.current = segments;
-                        setLocalHighlightSegment(segments[0]);
+                        let pendingChunks = chunks.length;
                         setSpeechLoadingId(messageKey);
                         setPlayingMessageId(messageKey);
                         chunks.forEach((chunk) => {
                           speak(chunk, () => {
-                            localHighlightQueueRef.current.shift();
-                            if (localHighlightQueueRef.current.length > 0) {
-                              setLocalHighlightSegment(
-                                localHighlightQueueRef.current[0]
-                              );
-                            } else {
-                              setLocalHighlightSegment(null);
+                            pendingChunks -= 1;
+                            if (pendingChunks === 0) {
                               setPlayingMessageId(null);
                               setSpeechLoadingId(null);
                             }
@@ -872,15 +788,12 @@ const ChatMessageItem = memo(function ChatMessageItem(props: ChatMessageItemProp
                         ).length;
                         if (openTags !== closeTags) {
                           return (
-                            <motion.span
+                            <span
                               key={partKey}
-                              initial={{ opacity: 1 }}
-                              animate={{ opacity: 1 }}
-                              transition={{ duration: 0 }}
                               className="select-text italic"
                             >
                               {t("apps.chats.status.editing")}
-                            </motion.span>
+                            </span>
                           );
                         }
                       }
@@ -889,69 +802,32 @@ const ChatMessageItem = memo(function ChatMessageItem(props: ChatMessageItemProp
                         : partText;
                       const partDisplayContent = decodeHtmlEntities(rawPartContent);
                       const textContent = partDisplayContent;
+                      const streamdownContent = textContent.trim();
+                      const isEmojiMessage = isEmojiOnly(textContent);
                       return (
-                        <div key={partKey} className="w-full">
-                          <div className="whitespace-pre-wrap">
-                            {textContent &&
-                              (() => {
-                                const tokens = segmentChatMarkdownText(textContent.trim());
-                                let charPos = 0;
-                                return tokens.map((segment, idx) => {
-                                  const start = charPos;
-                                  const end = charPos + segment.content.length;
-                                  charPos = end;
-                                  return (
-                                    <motion.span
-                                      key={`${partKey}-segment-${idx}`}
-                                      initial={
-                                        isInitialMessage
-                                          ? MOTION_SPAN_INITIAL_LOADED
-                                          : MOTION_SPAN_INITIAL_NEW
-                                      }
-                                      animate={MOTION_SPAN_ANIMATE}
-                                      className={`select-text ${
-                                        isEmojiOnly(textContent)
-                                          ? "text-[24px]"
-                                          : ""
-                                      } ${
-                                        segment.type === "bold"
-                                          ? "font-bold"
-                                          : segment.type === "italic"
-                                          ? "italic"
-                                          : ""
-                                      }`}
-                                      style={{
-                                        userSelect: "text",
-                                        fontSize: isEmojiOnly(textContent)
-                                          ? undefined
-                                          : `${fontSize}px`,
-                                      }}
-                                      transition={{
-                                        duration: 0.08,
-                                        delay: idx * 0.02,
-                                        ease: "easeOut",
-                                        // Only play a note for tokens that are
-                                        // actively streaming in, not for history
-                                        // messages that animate as a no-op on mount.
-                                        ...((!isInitialMessage && idx % 2 === 0) && {
-                                          onComplete: () => { playNoteRef.current(); },
-                                        }),
-                                      }}
-                                    >
-                                      {highlightActive &&
-                                      start < (combinedHighlightSeg?.end ?? 0) &&
-                                      end > (combinedHighlightSeg?.start ?? 0) ? (
-                                        <span className="animate-highlight">
-                                          {renderInlineToken(segment)}
-                                        </span>
-                                      ) : (
-                                        renderInlineToken(segment)
-                                      )}
-                                    </motion.span>
-                                  );
-                                });
-                              })()}
-                          </div>
+                        <div
+                          key={partKey}
+                          className="w-full"
+                          style={{
+                            fontSize: isEmojiMessage ? "24px" : `${fontSize}px`,
+                          }}
+                        >
+                          {streamdownContent && (
+                            <Streamdown
+                              className={`ryos-chat-streamdown ${
+                                isUrgent ? "ryos-chat-streamdown-urgent" : ""
+                              }`}
+                              components={chatStreamdownComponents}
+                              disallowedElements={STREAMDOWN_DISALLOWED_ELEMENTS}
+                              skipHtml
+                              unwrapDisallowed
+                              mode={isStreamingMessage ? "streaming" : "static"}
+                              isAnimating={isStreamingMessage}
+                              parseIncompleteMarkdown={isStreamingMessage}
+                            >
+                              {streamdownContent}
+                            </Streamdown>
+                          )}
                         </div>
                       );
                     }
@@ -984,56 +860,27 @@ const ChatMessageItem = memo(function ChatMessageItem(props: ChatMessageItemProp
               )}
             </motion.div>
           ) : (
-            <>
-              {displayContent && (
-                <span
-                  className={`select-text whitespace-pre-wrap ${
-                    isEmojiOnly(displayContent) ? "text-[24px]" : ""
+            displayContent && (
+              <div
+                className="select-text"
+                style={{
+                  fontSize: isEmojiOnly(displayContent) ? "24px" : `${fontSize}px`,
+                }}
+              >
+                <Streamdown
+                  className={`ryos-chat-streamdown ${
+                    isUrgent ? "ryos-chat-streamdown-urgent" : ""
                   }`}
-                  style={{
-                    userSelect: "text",
-                    fontSize: isEmojiOnly(displayContent)
-                      ? undefined
-                      : `${fontSize}px`,
-                  }}
+                  components={chatStreamdownComponents}
+                  disallowedElements={STREAMDOWN_DISALLOWED_ELEMENTS}
+                  skipHtml
+                  unwrapDisallowed
+                  mode="static"
                 >
-                  {(() => {
-                    const tokens = segmentChatMarkdownText(displayContent);
-                    let charPos2 = 0;
-                    return tokens.map((segment, idx) => {
-                      const start2 = charPos2;
-                      const end2 = charPos2 + segment.content.length;
-                      charPos2 = end2;
-                      const isHighlight =
-                        highlightActive &&
-                        start2 < (combinedHighlightSeg?.end ?? 0) &&
-                        end2 > (combinedHighlightSeg?.start ?? 0);
-                      const contentNode = renderInlineToken(segment);
-                      return (
-                        <span
-                          key={`${messageKey}-segment-${idx}`}
-                          className={`${
-                            segment.type === "bold"
-                              ? "font-bold"
-                              : segment.type === "italic"
-                              ? "italic"
-                              : ""
-                          }`}
-                        >
-                          {isHighlight ? (
-                            <span className="bg-yellow-200 animate-highlight">
-                              {contentNode}
-                            </span>
-                          ) : (
-                            contentNode
-                          )}
-                        </span>
-                      );
-                    });
-                  })()}
-                </span>
-              )}
-            </>
+                  {displayContent}
+                </Streamdown>
+              </div>
+            )
           )}
         </motion.div>
       )}
@@ -1095,8 +942,6 @@ interface ChatMessagesContentProps {
   onMessageDeleted?: (messageId: string) => void;
   fontSize: number;
   scrollToBottomTrigger: number;
-  highlightSegment?: { messageId: string; start: number; end: number } | null;
-  isSpeaking?: boolean;
   onSendMessage?: (username: string) => void;
   isLoadingGreeting?: boolean;
   typingUsers?: string[];
@@ -1115,8 +960,6 @@ function ChatMessagesContent({
   onMessageDeleted,
   fontSize,
   scrollToBottomTrigger,
-  highlightSegment,
-  isSpeaking,
   onSendMessage,
   isLoadingGreeting,
   typingUsers,
@@ -1131,16 +974,6 @@ function ChatMessagesContent({
   const currentTheme = useThemeStore((s) => s.current);
   const [playingMessageId, setPlayingMessageId] = useState<string | null>(null);
   const [speechLoadingId, setSpeechLoadingId] = useState<string | null>(null);
-
-  // Local highlight state for manual speech triggered from this component
-  const [localHighlightSegment, setLocalHighlightSegment] = useState<{
-    messageId: string;
-    start: number;
-    end: number;
-  } | null>(null);
-  const localHighlightQueueRef = useRef<
-    { messageId: string; start: number; end: number }[]
-  >([]);
 
   const previousMessagesRef = useRef<ChatMessage[]>([]);
   const initialMessageIdsRef = useRef<Set<string>>(new Set());
@@ -1186,11 +1019,7 @@ function ChatMessagesContent({
     if (!hasInitializedRef.current && messages.length > 0) {
       hasInitializedRef.current = true;
       previousMessagesRef.current = messages;
-      initialMessageIdsRef.current = new Set(
-        messages.map(
-          (m) => m.id || `${m.role}-${getMessageText(m).substring(0, 10)}`
-        )
-      );
+      initialMessageIdsRef.current = new Set(messages.map(getMessageKey));
     } else if (messages.length === 0) {
       hasInitializedRef.current = false;
     }
@@ -1288,6 +1117,13 @@ function ChatMessagesContent({
     }
   }, [roomId, onMessageDeleted]);
 
+  const streamingAssistantMessage = isLoading
+    ? [...messages].reverse().find((msg) => msg.role === "assistant")
+    : undefined;
+  const streamingAssistantMessageKey = streamingAssistantMessage
+    ? getMessageKey(streamingAssistantMessage)
+    : null;
+
   // Return the message list rendering logic
   return (
     <AnimatePresence initial={false} mode="sync">
@@ -1312,17 +1148,16 @@ function ChatMessagesContent({
         </motion.div>
       )}
       {messages.map((message) => {
-        const messageText = getMessageText(message);
-        const messageKey = (message.id === "1" || message.id === "proactive-1")
-          ? "greeting"
-          : message.id || `${message.role}-${messageText.substring(0, 10)}`;
+        const messageKey = getMessageKey(message);
         const isInitialMessage = initialMessageIdsRef.current.has(messageKey);
+        const isStreamingMessage = messageKey === streamingAssistantMessageKey;
         return (
           <ChatMessageItem
             key={messageKey}
             message={message}
             messageKey={messageKey}
             isInitialMessage={isInitialMessage}
+            isStreamingMessage={isStreamingMessage}
             isLoading={isLoading}
             isLoadingGreeting={!!isLoadingGreeting}
             isRoomView={isRoomView}
@@ -1331,10 +1166,6 @@ function ChatMessagesContent({
             copiedMessageId={copiedMessageId}
             playingMessageId={playingMessageId}
             speechLoadingId={speechLoadingId}
-            highlightSegment={highlightSegment ?? null}
-            localHighlightSegment={localHighlightSegment}
-            isSpeaking={!!isSpeaking}
-            localTtsSpeaking={localTtsSpeaking}
             speechEnabled={speechEnabled}
             isAdmin={isAdmin}
             roomId={roomId}
@@ -1343,13 +1174,10 @@ function ChatMessagesContent({
             onSendMessage={onSendMessage}
             onCopyMessage={copyMessage}
             onDeleteMessage={deleteMessage}
-            setLocalHighlightSegment={setLocalHighlightSegment}
             setPlayingMessageId={setPlayingMessageId}
             setSpeechLoadingId={setSpeechLoadingId}
-            localHighlightQueueRef={localHighlightQueueRef}
             speak={speak}
             stop={stop}
-            playNote={playNote}
             playElevatorMusic={playElevatorMusic}
             stopElevatorMusic={stopElevatorMusic}
             playDingSound={playDingSound}
@@ -1458,8 +1286,6 @@ export function ChatMessages({
   onMessageDeleted,
   fontSize,
   scrollToBottomTrigger,
-  highlightSegment,
-  isSpeaking,
   onSendMessage,
   isLoadingGreeting,
   typingUsers,
@@ -1488,8 +1314,6 @@ export function ChatMessages({
           onMessageDeleted={onMessageDeleted}
           fontSize={fontSize}
           scrollToBottomTrigger={scrollToBottomTrigger}
-          highlightSegment={highlightSegment}
-          isSpeaking={isSpeaking}
           onSendMessage={onSendMessage}
           isLoadingGreeting={isLoadingGreeting}
           typingUsers={typingUsers}

--- a/src/index.css
+++ b/src/index.css
@@ -764,20 +764,24 @@ button.piano-key.piano-key[class*="bg-[#ff33ff]"] {
      cells, and rows all clear their borders so we don't end up with the
      wrapper outline + table outline doubling up. Cells use a hairline
      bottom border for row dividers and tighter padding than Streamdown's
-     default px-4 py-2. */
+     default px-4 py-2. The wrapper scrolls horizontally when the table
+     is wider than the bubble (cells enforce a `min-width`). */
   .ryos-chat-streamdown [data-streamdown="table-wrapper"] {
     margin: 0.3em 0 0.05em;
-    overflow: hidden;
+    overflow-x: auto;
+    overflow-y: hidden;
+    max-width: 100%;
     border: 0 !important;
     border-radius: 3px;
     background: #ffffff !important;
     padding: 0 !important;
     box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.18);
+    -webkit-overflow-scrolling: touch;
   }
 
   .ryos-chat-streamdown :where(table) {
     width: auto;
-    max-width: 100%;
+    max-width: none !important;
     margin: 0 !important;
     border: 0 !important;
     border-collapse: collapse;
@@ -802,6 +806,8 @@ button.piano-key.piano-key[class*="bg-[#ff33ff]"] {
     text-align: left;
     vertical-align: top;
     white-space: normal !important;
+    min-width: 6em;
+    overflow-wrap: anywhere;
   }
 
   .ryos-chat-streamdown :where(tr:last-child td) {

--- a/src/index.css
+++ b/src/index.css
@@ -1,6 +1,7 @@
 @import url("/fonts/fonts.css");
 @import "./styles/themes.css";
 @import "tailwindcss";
+@import "streamdown/styles.css";
 @source "../node_modules/@streamdown/code/dist/*.js";
 @config "../tailwind.config.js";
 

--- a/src/index.css
+++ b/src/index.css
@@ -736,9 +736,22 @@ button.piano-key.piano-key[class*="bg-[#ff33ff]"] {
     background: transparent !important;
   }
 
-  /* Final pre inside the code panel is the only thing that should pad. */
+  /* Final pre inside the code panel is the only thing that should pad.
+     Wrap long lines instead of forcing a horizontal scroll so the panel
+     stays compact in chat bubbles, while still respecting authored line
+     breaks via `pre-wrap`. */
   .ryos-chat-streamdown [data-streamdown="code-block"] :where(pre) {
     padding: 0.3em 0.55em !important;
+    white-space: pre-wrap !important;
+    word-break: break-word;
+    overflow-wrap: anywhere;
+    overflow-x: hidden;
+  }
+
+  .ryos-chat-streamdown [data-streamdown="code-block"] :where(pre, code, span) {
+    white-space: inherit !important;
+    word-break: inherit;
+    overflow-wrap: inherit;
   }
 
   .ryos-chat-streamdown :where(blockquote) {

--- a/src/index.css
+++ b/src/index.css
@@ -737,13 +737,20 @@ button.piano-key.piano-key[class*="bg-[#ff33ff]"] {
   }
 
   /* Final pre inside the code panel is the only thing that should pad.
-     Keep `white-space: pre` so authored line breaks render as separate
-     lines; if a line is wider than the bubble, the panel scrolls
-     horizontally instead of collapsing lines together. */
+     Keep `white-space: pre` so authored whitespace is preserved; if a
+     line is wider than the bubble, the panel scrolls horizontally. */
   .ryos-chat-streamdown [data-streamdown="code-block"] :where(pre) {
     padding: 0.3em 0.55em !important;
     white-space: pre !important;
     overflow-x: auto;
+  }
+
+  /* Streamdown's Shiki output wraps each code line in a sibling `<span>`
+     with no newline separator between them, so without intervention every
+     line collapses onto the same row. Force the direct line-wrapper spans
+     to render block so authored line breaks become visible line breaks. */
+  .ryos-chat-streamdown [data-streamdown="code-block"] :where(pre) > span {
+    display: block;
   }
 
   .ryos-chat-streamdown :where(blockquote) {

--- a/src/index.css
+++ b/src/index.css
@@ -646,14 +646,14 @@ button.piano-key.piano-key[class*="bg-[#ff33ff]"] {
     border-radius: 0;
     background: transparent;
     margin: 0;
-    padding: 0.38em 0.5em;
+    padding: 0.2em 0.45em;
     font-size: inherit !important;
-    line-height: 1.4;
+    line-height: 1.3;
   }
 
   .ryos-chat-streamdown :where(code) {
     border-radius: 2px;
-    background: rgb(255 255 255 / 0.55);
+    background: rgb(0 0 0 / 0.06);
     padding: 0 0.18em;
     font-family: var(--font-monaco);
     font-size: 0.92em !important;
@@ -663,20 +663,20 @@ button.piano-key.piano-key[class*="bg-[#ff33ff]"] {
     background: transparent;
     padding: 0;
     font-size: inherit !important;
+    line-height: inherit;
   }
 
   .ryos-chat-streamdown [data-streamdown="code-block"] {
     content-visibility: visible !important;
     contain-intrinsic-size: auto !important;
     gap: 0 !important;
-    margin: 0.35em 0 0 !important;
+    margin: 0.25em 0 0 !important;
     overflow: hidden !important;
     border: 0 !important;
-    border-radius: 3px !important;
+    border-radius: 2px !important;
     background: #24292e !important;
     padding: 0 !important;
     font-size: var(--ryos-chat-font-size, inherit) !important;
-    box-shadow: 0 0 0 1px rgb(0 0 0 / 0.3);
   }
 
   .ryos-chat-streamdown [data-streamdown="code-block"] > :first-child {

--- a/src/index.css
+++ b/src/index.css
@@ -644,9 +644,9 @@ button.piano-key.piano-key[class*="bg-[#ff33ff]"] {
     overflow-x: auto;
     border: 0;
     border-radius: 0;
-    background: transparent;
-    margin: 0;
-    padding: 0.2em 0.45em;
+    background: transparent !important;
+    margin: 0 !important;
+    padding: 0.3em 0.55em !important;
     font-size: inherit !important;
     line-height: 1.3;
   }
@@ -710,21 +710,66 @@ button.piano-key.piano-key[class*="bg-[#ff33ff]"] {
     background-color: var(--sdm-tbg, transparent) !important;
   }
 
+  /* Streamdown's compiled JS applies Tailwind `border` and `border-border`
+     classes to many internal elements (inner pre, table wrapper, cells).
+     Our global `* { @apply border-border }` resolves border-color to solid
+     black, which produced the harsh black lines inside the code panel and
+     around tables. Soften the inherited border-color inside the chat
+     markdown surface so any stray `border` class becomes a quiet hairline. */
+  .ryos-chat-streamdown,
+  .ryos-chat-streamdown * {
+    border-color: rgba(0, 0, 0, 0.14);
+  }
+
+  /* The outer `[data-streamdown="code-block"]` already provides the panel
+     outline via box-shadow; clear every nested border so the inner pre /
+     header / actions don't draw extra lines on top of the white panel. */
+  .ryos-chat-streamdown [data-streamdown="code-block"],
+  .ryos-chat-streamdown [data-streamdown="code-block"] * {
+    border: 0 !important;
+  }
+
   .ryos-chat-streamdown :where(blockquote) {
-    border-left: 2px solid rgb(0 0 0 / 0.25);
+    border-left: 2px solid rgba(0, 0, 0, 0.18);
     margin-bottom: 0;
     padding-left: 0.6em;
   }
 
+  /* Tables: keep them flush like the applet preview with a single thin
+     outer outline, light header band, and hairline row dividers — no
+     thick cell-by-cell black grid. */
   .ryos-chat-streamdown :where(table) {
+    border: 0 !important;
     border-collapse: collapse;
+    border-spacing: 0;
+    width: auto;
     max-width: 100%;
-    overflow-x: auto;
+    overflow: hidden;
+    margin: 0.3em 0 0.05em;
+    border-radius: 3px;
+    background: #ffffff;
+    box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.18);
+  }
+
+  .ryos-chat-streamdown :where(thead) {
+    background: rgba(0, 0, 0, 0.04);
   }
 
   .ryos-chat-streamdown :where(th, td) {
-    border: 1px solid rgb(0 0 0 / 0.25);
-    padding: 0.25em 0.4em;
+    border: 0 !important;
+    border-bottom: 1px solid rgba(0, 0, 0, 0.1) !important;
+    padding: 0.25em 0.55em;
+    text-align: left;
+    vertical-align: top;
+  }
+
+  .ryos-chat-streamdown :where(tr:last-child td) {
+    border-bottom: 0 !important;
+  }
+
+  .ryos-chat-streamdown :where(th) {
+    font-weight: 600;
+    color: rgba(0, 0, 0, 0.7);
   }
 
   .ryos-chat-streamdown-link {

--- a/src/index.css
+++ b/src/index.css
@@ -1,6 +1,7 @@
 @import url("/fonts/fonts.css");
 @import "./styles/themes.css";
 @import "tailwindcss";
+@source "../node_modules/@streamdown/code/dist/*.js";
 @config "../tailwind.config.js";
 
 /* Additional fonts not in fonts.css */

--- a/src/index.css
+++ b/src/index.css
@@ -737,21 +737,13 @@ button.piano-key.piano-key[class*="bg-[#ff33ff]"] {
   }
 
   /* Final pre inside the code panel is the only thing that should pad.
-     Wrap long lines instead of forcing a horizontal scroll so the panel
-     stays compact in chat bubbles, while still respecting authored line
-     breaks via `pre-wrap`. */
+     Keep `white-space: pre` so authored line breaks render as separate
+     lines; if a line is wider than the bubble, the panel scrolls
+     horizontally instead of collapsing lines together. */
   .ryos-chat-streamdown [data-streamdown="code-block"] :where(pre) {
     padding: 0.3em 0.55em !important;
-    white-space: pre-wrap !important;
-    word-break: break-word;
-    overflow-wrap: anywhere;
-    overflow-x: hidden;
-  }
-
-  .ryos-chat-streamdown [data-streamdown="code-block"] :where(pre, code, span) {
-    white-space: inherit !important;
-    word-break: inherit;
-    overflow-wrap: inherit;
+    white-space: pre !important;
+    overflow-x: auto;
   }
 
   .ryos-chat-streamdown :where(blockquote) {

--- a/src/index.css
+++ b/src/index.css
@@ -604,8 +604,13 @@ button.piano-key.piano-key[class*="bg-[#ff33ff]"] {
 
   .ryos-chat-streamdown {
     max-width: 100%;
+    font-size: var(--ryos-chat-font-size, inherit) !important;
     line-height: 1.25;
     overflow-wrap: anywhere;
+  }
+
+  .ryos-chat-streamdown :where(p, li, blockquote, table, th, td, a, strong, em, span) {
+    font-size: inherit !important;
   }
 
   .ryos-chat-streamdown :where(p) {
@@ -636,10 +641,13 @@ button.piano-key.piano-key[class*="bg-[#ff33ff]"] {
   .ryos-chat-streamdown :where(pre) {
     max-width: 100%;
     overflow-x: auto;
-    border: 1px solid rgb(0 0 0 / 0.2);
-    border-radius: 3px;
-    background: rgb(255 255 255 / 0.55);
-    padding: 0.5em;
+    border: 0;
+    border-radius: 0;
+    background: transparent;
+    margin: 0;
+    padding: 0.55em 0.7em;
+    font-size: inherit !important;
+    line-height: 1.45;
   }
 
   .ryos-chat-streamdown :where(code) {
@@ -647,12 +655,60 @@ button.piano-key.piano-key[class*="bg-[#ff33ff]"] {
     background: rgb(255 255 255 / 0.55);
     padding: 0.05em 0.25em;
     font-family: var(--font-monaco);
-    font-size: 0.9em;
+    font-size: 0.92em !important;
   }
 
   .ryos-chat-streamdown :where(pre code) {
     background: transparent;
     padding: 0;
+    font-size: inherit !important;
+  }
+
+  .ryos-chat-streamdown [data-streamdown="code-block"] {
+    content-visibility: visible !important;
+    contain-intrinsic-size: auto !important;
+    gap: 0 !important;
+    margin: 0.55em 0 0 !important;
+    overflow: hidden !important;
+    border: 1px solid rgb(31 41 55 / 0.24) !important;
+    border-radius: 4px !important;
+    background: #f6f8fa !important;
+    padding: 0 !important;
+    font-size: var(--ryos-chat-font-size, inherit) !important;
+    box-shadow: inset 0 1px 0 rgb(255 255 255 / 0.8);
+  }
+
+  .ryos-chat-streamdown [data-streamdown="code-block"] > :first-child {
+    min-height: 0 !important;
+    border-bottom: 1px solid rgb(31 41 55 / 0.12);
+    background: #eaeef2;
+    padding: 0.18em 0.65em !important;
+    color: rgb(31 41 55 / 0.68);
+    font-family: var(--font-geneva-12);
+    font-size: 0.78em !important;
+    line-height: 1.2;
+    text-transform: lowercase;
+  }
+
+  .ryos-chat-streamdown [data-streamdown="code-block-actions"] {
+    display: none !important;
+  }
+
+  .ryos-chat-streamdown [data-streamdown="code-block"] :where(pre, code, span) {
+    font-family: var(--font-monaco) !important;
+  }
+
+  .ryos-chat-streamdown [data-streamdown="code-block"] :where(pre, code) {
+    color: #24292f;
+  }
+
+  .ryos-chat-streamdown [data-streamdown="code-block"] span[style*="--sdm-c"],
+  .ryos-chat-streamdown [data-streamdown="code-block"] span[style*="--shiki-light"] {
+    color: var(--shiki-light, var(--sdm-c, #24292f)) !important;
+  }
+
+  .ryos-chat-streamdown [data-streamdown="code-block"] span[style*="--sdm-tbg"] {
+    background-color: var(--shiki-light-bg, var(--sdm-tbg, transparent)) !important;
   }
 
   .ryos-chat-streamdown :where(blockquote) {

--- a/src/index.css
+++ b/src/index.css
@@ -710,23 +710,35 @@ button.piano-key.piano-key[class*="bg-[#ff33ff]"] {
     background-color: var(--sdm-tbg, transparent) !important;
   }
 
-  /* Streamdown's compiled JS applies Tailwind `border` and `border-border`
-     classes to many internal elements (inner pre, table wrapper, cells).
-     Our global `* { @apply border-border }` resolves border-color to solid
-     black, which produced the harsh black lines inside the code panel and
-     around tables. Soften the inherited border-color inside the chat
-     markdown surface so any stray `border` class becomes a quiet hairline. */
+  /* Streamdown's compiled JS applies Tailwind `border` / `border-border`
+     classes to many nested elements (inner code body div, table wrapper,
+     cells). Our global `* { @apply border-border }` resolves border-color
+     to solid black, which produced harsh black lines inside the code panel
+     and around tables. Soften inherited border-color across the chat
+     markdown surface so any stray `border` class is a quiet hairline. */
   .ryos-chat-streamdown,
   .ryos-chat-streamdown * {
     border-color: rgba(0, 0, 0, 0.14);
   }
 
   /* The outer `[data-streamdown="code-block"]` already provides the panel
-     outline via box-shadow; clear every nested border so the inner pre /
-     header / actions don't draw extra lines on top of the white panel. */
+     outline via box-shadow; nuke every nested border, padding, and
+     background so the inner `code-block-body` div doesn't repaint a
+     second border or 16px (`p-4`) inset on top of the white panel. */
   .ryos-chat-streamdown [data-streamdown="code-block"],
   .ryos-chat-streamdown [data-streamdown="code-block"] * {
     border: 0 !important;
+  }
+
+  .ryos-chat-streamdown [data-streamdown="code-block"] :where(div),
+  .ryos-chat-streamdown [data-streamdown="code-block-body"] {
+    padding: 0 !important;
+    background: transparent !important;
+  }
+
+  /* Final pre inside the code panel is the only thing that should pad. */
+  .ryos-chat-streamdown [data-streamdown="code-block"] :where(pre) {
+    padding: 0.3em 0.55em !important;
   }
 
   .ryos-chat-streamdown :where(blockquote) {
@@ -735,32 +747,48 @@ button.piano-key.piano-key[class*="bg-[#ff33ff]"] {
     padding-left: 0.6em;
   }
 
-  /* Tables: keep them flush like the applet preview with a single thin
-     outer outline, light header band, and hairline row dividers — no
-     thick cell-by-cell black grid. */
-  .ryos-chat-streamdown :where(table) {
-    border: 0 !important;
-    border-collapse: collapse;
-    border-spacing: 0;
-    width: auto;
-    max-width: 100%;
-    overflow: hidden;
+  /* Tables: only the wrapper draws the panel outline. The table itself,
+     cells, and rows all clear their borders so we don't end up with the
+     wrapper outline + table outline doubling up. Cells use a hairline
+     bottom border for row dividers and tighter padding than Streamdown's
+     default px-4 py-2. */
+  .ryos-chat-streamdown [data-streamdown="table-wrapper"] {
     margin: 0.3em 0 0.05em;
+    overflow: hidden;
+    border: 0 !important;
     border-radius: 3px;
-    background: #ffffff;
+    background: #ffffff !important;
+    padding: 0 !important;
     box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.18);
   }
 
-  .ryos-chat-streamdown :where(thead) {
-    background: rgba(0, 0, 0, 0.04);
+  .ryos-chat-streamdown :where(table) {
+    width: auto;
+    max-width: 100%;
+    margin: 0 !important;
+    border: 0 !important;
+    border-collapse: collapse;
+    border-spacing: 0;
+    background: transparent;
+    box-shadow: none !important;
+  }
+
+  .ryos-chat-streamdown :where(thead),
+  .ryos-chat-streamdown [data-streamdown="table-header"] {
+    background: rgba(0, 0, 0, 0.04) !important;
+  }
+
+  .ryos-chat-streamdown :where(tr) {
+    border: 0 !important;
   }
 
   .ryos-chat-streamdown :where(th, td) {
     border: 0 !important;
     border-bottom: 1px solid rgba(0, 0, 0, 0.1) !important;
-    padding: 0.25em 0.55em;
+    padding: 0.22em 0.55em !important;
     text-align: left;
     vertical-align: top;
+    white-space: normal !important;
   }
 
   .ryos-chat-streamdown :where(tr:last-child td) {
@@ -769,7 +797,7 @@ button.piano-key.piano-key[class*="bg-[#ff33ff]"] {
 
   .ryos-chat-streamdown :where(th) {
     font-weight: 600;
-    color: rgba(0, 0, 0, 0.7);
+    color: rgba(0, 0, 0, 0.72);
   }
 
   .ryos-chat-streamdown-link {

--- a/src/index.css
+++ b/src/index.css
@@ -619,12 +619,12 @@ button.piano-key.piano-key[class*="bg-[#ff33ff]"] {
   }
 
   .ryos-chat-streamdown :where(p + p, ul, ol, pre, blockquote, table) {
-    margin-top: 0.5em;
+    margin-top: 0.35em;
   }
 
   .ryos-chat-streamdown :where(ul, ol) {
     margin-bottom: 0;
-    padding-left: 1.25em;
+    padding-left: 1.1em;
   }
 
   .ryos-chat-streamdown :where(ul) {
@@ -646,15 +646,15 @@ button.piano-key.piano-key[class*="bg-[#ff33ff]"] {
     border-radius: 0;
     background: transparent;
     margin: 0;
-    padding: 0.55em 0.7em;
+    padding: 0.38em 0.5em;
     font-size: inherit !important;
-    line-height: 1.45;
+    line-height: 1.4;
   }
 
   .ryos-chat-streamdown :where(code) {
     border-radius: 2px;
     background: rgb(255 255 255 / 0.55);
-    padding: 0.05em 0.25em;
+    padding: 0 0.18em;
     font-family: var(--font-monaco);
     font-size: 0.92em !important;
   }
@@ -669,26 +669,18 @@ button.piano-key.piano-key[class*="bg-[#ff33ff]"] {
     content-visibility: visible !important;
     contain-intrinsic-size: auto !important;
     gap: 0 !important;
-    margin: 0.55em 0 0 !important;
+    margin: 0.35em 0 0 !important;
     overflow: hidden !important;
-    border: 1px solid rgb(31 41 55 / 0.24) !important;
-    border-radius: 4px !important;
-    background: #f6f8fa !important;
+    border: 0 !important;
+    border-radius: 3px !important;
+    background: #24292e !important;
     padding: 0 !important;
     font-size: var(--ryos-chat-font-size, inherit) !important;
-    box-shadow: inset 0 1px 0 rgb(255 255 255 / 0.8);
+    box-shadow: 0 0 0 1px rgb(0 0 0 / 0.3);
   }
 
   .ryos-chat-streamdown [data-streamdown="code-block"] > :first-child {
-    min-height: 0 !important;
-    border-bottom: 1px solid rgb(31 41 55 / 0.12);
-    background: #eaeef2;
-    padding: 0.18em 0.65em !important;
-    color: rgb(31 41 55 / 0.68);
-    font-family: var(--font-geneva-12);
-    font-size: 0.78em !important;
-    line-height: 1.2;
-    text-transform: lowercase;
+    display: none !important;
   }
 
   .ryos-chat-streamdown [data-streamdown="code-block-actions"] {
@@ -700,16 +692,16 @@ button.piano-key.piano-key[class*="bg-[#ff33ff]"] {
   }
 
   .ryos-chat-streamdown [data-streamdown="code-block"] :where(pre, code) {
-    color: #24292f;
+    color: rgb(209 213 219);
   }
 
   .ryos-chat-streamdown [data-streamdown="code-block"] span[style*="--sdm-c"],
   .ryos-chat-streamdown [data-streamdown="code-block"] span[style*="--shiki-light"] {
-    color: var(--shiki-light, var(--sdm-c, #24292f)) !important;
+    color: var(--shiki-dark, var(--shiki-light, var(--sdm-c, rgb(209 213 219)))) !important;
   }
 
   .ryos-chat-streamdown [data-streamdown="code-block"] span[style*="--sdm-tbg"] {
-    background-color: var(--shiki-light-bg, var(--sdm-tbg, transparent)) !important;
+    background-color: var(--shiki-dark-bg, var(--shiki-light-bg, var(--sdm-tbg, transparent))) !important;
   }
 
   .ryos-chat-streamdown :where(blockquote) {

--- a/src/index.css
+++ b/src/index.css
@@ -666,17 +666,20 @@ button.piano-key.piano-key[class*="bg-[#ff33ff]"] {
     line-height: inherit;
   }
 
+  /* Code block panel — matches the applet preview box: white, subtle 1px
+     outline, gently rounded, centered inside the chat bubble. */
   .ryos-chat-streamdown [data-streamdown="code-block"] {
     content-visibility: visible !important;
     contain-intrinsic-size: auto !important;
     gap: 0 !important;
-    margin: 0.25em 0 0 !important;
+    margin: 0.3em 0 0.05em !important;
     overflow: hidden !important;
     border: 0 !important;
-    border-radius: 2px !important;
-    background: #24292e !important;
+    border-radius: 3px !important;
+    background: #ffffff !important;
     padding: 0 !important;
     font-size: var(--ryos-chat-font-size, inherit) !important;
+    box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.18);
   }
 
   .ryos-chat-streamdown [data-streamdown="code-block"] > :first-child {
@@ -692,34 +695,19 @@ button.piano-key.piano-key[class*="bg-[#ff33ff]"] {
   }
 
   .ryos-chat-streamdown [data-streamdown="code-block"] :where(pre, code) {
-    color: rgb(209 213 219);
+    color: #24292f;
   }
 
-  .ryos-chat-streamdown [data-streamdown="code-block"] span[style*="--sdm-c"],
-  .ryos-chat-streamdown [data-streamdown="code-block"] span[style*="--shiki-light"] {
-    color: var(--shiki-dark, var(--shiki-light, var(--sdm-c, rgb(209 213 219)))) !important;
+  /* Streamdown's Shiki dual-theme spans expose --sdm-c for the light token
+     color and --shiki-dark for dark mode. Force the light token color to
+     paint correctly on our white panel without depending on Tailwind
+     scanning Streamdown's compiled output for arbitrary-value classes. */
+  .ryos-chat-streamdown [data-streamdown="code-block"] span[style*="--sdm-c"] {
+    color: var(--sdm-c, #24292f) !important;
   }
 
   .ryos-chat-streamdown [data-streamdown="code-block"] span[style*="--sdm-tbg"] {
-    background-color: var(--shiki-dark-bg, var(--shiki-light-bg, var(--sdm-tbg, transparent))) !important;
-  }
-
-  /* In macOS aqua, the chat bubble has heavy inset strokes, 12px padding,
-     16px rounded corners, and overflow:hidden. Let the code block extend to
-     the bubble edges so the aqua bevel/shine clips it cleanly instead of
-     framing it with a visible border ring. */
-  :root[data-os-theme="macosx"] .ryos-chat-streamdown [data-streamdown="code-block"] {
-    margin-left: -12px !important;
-    margin-right: -12px !important;
-    border-radius: 0 !important;
-  }
-
-  :root[data-os-theme="macosx"] .ryos-chat-streamdown [data-streamdown="code-block"]:last-child {
-    margin-bottom: -6px !important;
-  }
-
-  :root[data-os-theme="macosx"] .ryos-chat-streamdown [data-streamdown="code-block"] :where(pre) {
-    padding: 0.35em 12px;
+    background-color: var(--sdm-tbg, transparent) !important;
   }
 
   .ryos-chat-streamdown :where(blockquote) {

--- a/src/index.css
+++ b/src/index.css
@@ -745,12 +745,15 @@ button.piano-key.piano-key[class*="bg-[#ff33ff]"] {
     overflow-x: auto;
   }
 
-  /* Streamdown's Shiki output wraps each code line in a sibling `<span>`
-     with no newline separator between them, so without intervention every
-     line collapses onto the same row. Force the direct line-wrapper spans
-     to render block so authored line breaks become visible line breaks. */
+  /* Streamdown's Shiki output is `<pre><code><span>line1</span><span>line2</span>…`
+     with no newline separator between the line wrappers, so without
+     intervention every line collapses onto a single row. Force those
+     line-wrapper spans (direct children of `<code>` inside the panel) to
+     render block-level so authored line breaks become visible. */
+  .ryos-chat-streamdown [data-streamdown="code-block"] :where(pre) > code > span,
   .ryos-chat-streamdown [data-streamdown="code-block"] :where(pre) > span {
     display: block;
+    white-space: inherit;
   }
 
   .ryos-chat-streamdown :where(blockquote) {

--- a/src/index.css
+++ b/src/index.css
@@ -704,6 +704,24 @@ button.piano-key.piano-key[class*="bg-[#ff33ff]"] {
     background-color: var(--shiki-dark-bg, var(--shiki-light-bg, var(--sdm-tbg, transparent))) !important;
   }
 
+  /* In macOS aqua, the chat bubble has heavy inset strokes, 12px padding,
+     16px rounded corners, and overflow:hidden. Let the code block extend to
+     the bubble edges so the aqua bevel/shine clips it cleanly instead of
+     framing it with a visible border ring. */
+  :root[data-os-theme="macosx"] .ryos-chat-streamdown [data-streamdown="code-block"] {
+    margin-left: -12px !important;
+    margin-right: -12px !important;
+    border-radius: 0 !important;
+  }
+
+  :root[data-os-theme="macosx"] .ryos-chat-streamdown [data-streamdown="code-block"]:last-child {
+    margin-bottom: -6px !important;
+  }
+
+  :root[data-os-theme="macosx"] .ryos-chat-streamdown [data-streamdown="code-block"] :where(pre) {
+    padding: 0.35em 12px;
+  }
+
   .ryos-chat-streamdown :where(blockquote) {
     border-left: 2px solid rgb(0 0 0 / 0.25);
     margin-bottom: 0;

--- a/src/index.css
+++ b/src/index.css
@@ -596,8 +596,89 @@ button.piano-key.piano-key[class*="bg-[#ff33ff]"] {
     font-smooth: always;
   }
 
-  .animate-highlight {
-    animation: highlight-bg-opacity 1.5s ease-in-out infinite;
+  .ryos-chat-streamdown,
+  .ryos-chat-streamdown * {
+    user-select: text;
+    -webkit-user-select: text;
+  }
+
+  .ryos-chat-streamdown {
+    max-width: 100%;
+    line-height: 1.25;
+    overflow-wrap: anywhere;
+  }
+
+  .ryos-chat-streamdown :where(p) {
+    margin: 0;
+  }
+
+  .ryos-chat-streamdown :where(p + p, ul, ol, pre, blockquote, table) {
+    margin-top: 0.5em;
+  }
+
+  .ryos-chat-streamdown :where(ul, ol) {
+    margin-bottom: 0;
+    padding-left: 1.25em;
+  }
+
+  .ryos-chat-streamdown :where(ul) {
+    list-style: disc;
+  }
+
+  .ryos-chat-streamdown :where(ol) {
+    list-style: decimal;
+  }
+
+  .ryos-chat-streamdown :where(li + li) {
+    margin-top: 0.25em;
+  }
+
+  .ryos-chat-streamdown :where(pre) {
+    max-width: 100%;
+    overflow-x: auto;
+    border: 1px solid rgb(0 0 0 / 0.2);
+    border-radius: 3px;
+    background: rgb(255 255 255 / 0.55);
+    padding: 0.5em;
+  }
+
+  .ryos-chat-streamdown :where(code) {
+    border-radius: 2px;
+    background: rgb(255 255 255 / 0.55);
+    padding: 0.05em 0.25em;
+    font-family: var(--font-monaco);
+    font-size: 0.9em;
+  }
+
+  .ryos-chat-streamdown :where(pre code) {
+    background: transparent;
+    padding: 0;
+  }
+
+  .ryos-chat-streamdown :where(blockquote) {
+    border-left: 2px solid rgb(0 0 0 / 0.25);
+    margin-bottom: 0;
+    padding-left: 0.6em;
+  }
+
+  .ryos-chat-streamdown :where(table) {
+    border-collapse: collapse;
+    max-width: 100%;
+    overflow-x: auto;
+  }
+
+  .ryos-chat-streamdown :where(th, td) {
+    border: 1px solid rgb(0 0 0 / 0.25);
+    padding: 0.25em 0.4em;
+  }
+
+  .ryos-chat-streamdown-link {
+    color: rgb(37 99 235);
+    text-decoration: underline;
+  }
+
+  .ryos-chat-streamdown-urgent .ryos-chat-streamdown-link {
+    color: inherit;
   }
 
   /* Draggable area styles - prevents browser gestures on touch devices */
@@ -791,16 +872,6 @@ button.piano-key.piano-key[class*="bg-[#ff33ff]"] {
   -webkit-text-stroke-width: calc(0.12em * var(--interlude-dot-stroke-scale, 1.212121)) !important;
   -webkit-text-stroke-color: #fff !important;
   paint-order: stroke fill !important;
-}
-
-@keyframes highlight-bg-opacity {
-  0%,
-  100% {
-    background-color: rgb(254 249 195 / 1); /* bg-yellow-200 */
-  }
-  50% {
-    background-color: rgb(254 249 195 / 0.5); /* bg-yellow-200/50 */
-  }
 }
 
 /* CRT Scanline Effect */


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add Streamdown as the markdown renderer for Chats message bodies; remove the custom token-segmenting Framer Motion implementation.
- Enable `@streamdown/code` with GitHub Shiki themes for chat code-block syntax highlighting.
- Style fenced code blocks like the applet preview box: single thin gray outline, white background, gently rounded, centered inside the chat bubble.
- Override Streamdown's compiled-in Tailwind classes (`border border-border`, `p-4`, `divide-y`, `px-4 py-2`) so the inner code body div doesn't paint a secondary border or 16px chunky inset, and the table wrapper + table don't stack into a double border.
- Compact, single-outline tables with a soft header band, hairline row dividers, `min-width` per cell, and horizontal scroll on the wrapper when wider than the bubble.
- Force Shiki's per-line `<span>` wrappers (under `<code>`) to `display: block` so authored newlines render as separate lines instead of collapsing to one row, while keeping `white-space: pre` and horizontal scroll for over-wide lines.
- Re-enable the chat synth + per-word fade-in via Streamdown's official animation API (`animated={{animation: "fadeIn", duration: 150, easing: "ease-out", sep: "word"}}` + `isAnimating={isStreamingMessage}`), with `streamdown/styles.css` imported for the keyframes. The chat synth `playNote` is fired off the bubbling React `onAnimationStart` event for `[data-sd-animate]` spans (every other word).
- Compute `isStreamingMessage` from the actual last message rather than "most recent assistant" so a previously-completed assistant reply doesn't briefly flag as streaming when the user sends a new message — that flicker was causing Streamdown's animate plugin to re-run and rapidly fade-in the entire prior reply word-by-word. Also lock any message key that has previously completed streaming so future flicker can't re-trigger animation.

### Testing
- `bun run build` passed.
- Manually verified in Chrome on macOS Aqua theme: real assistant reply streams with per-word fade-in, code block keeps authored line breaks with horizontal scroll for long lines, tables render with one thin border + compact cells + horizontal scroll when wide, and previously completed assistant replies stay stable (no flicker / no re-animation) when a new message is sent.

![Previous reply stays stable when sending a new message](https://cursor.com/artifacts/c/art-62042012-1e43-4013-bdec-289522caf149)

![Streaming chat reply with per-word fade animation](https://cursor.com/artifacts/c/art-b559139a-ad28-4770-8674-2487943d73c2)

![Multi-line code block with authored line breaks rendered](https://cursor.com/artifacts/c/art-2a05ce13-57de-49d1-b8ce-3c85ed03f1ea)

![Chat bubble showing single-bordered code block and single-bordered table with compact padding](https://cursor.com/artifacts/c/art-6f6a1a9c-e9f9-4d49-8851-395b0875228c)

<a href="https://cursor.com/agents/bc-1d58d680-b2c8-498c-a77a-f84b5e553993/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fstreamdown_chats_htmlpreview_codeblock_demo.mp4"><img src="https://cursor.com/artifacts/c/art-d1e8b754-76b9-4e8a-acbd-c75330a672b4" alt="streamdown_chats_htmlpreview_codeblock_demo.mp4" /></a>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1d58d680-b2c8-498c-a77a-f84b5e553993"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1d58d680-b2c8-498c-a77a-f84b5e553993"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

