### PR TITLE
fix(aquarium): remove large empty gap under chat aquarium on macOS theme

### DIFF
--- a/src/components/shared/EmojiAquarium.tsx
+++ b/src/components/shared/EmojiAquarium.tsx
@@ -54,8 +54,19 @@ export function AquariumBubbleOverflowLayer({
 
   return (
     <div
-      className={cn("absolute left-0 top-0 pointer-events-none overflow-visible", className)}
-      style={{ width: safeWidth, height, zIndex: 60 }}
+      className={cn("pointer-events-none overflow-visible", className)}
+      style={{
+        // Inline `position` to defeat the macOS theme rule
+        // `:root[data-os-theme="macosx"] .chat-bubble > * { position: relative; }`
+        // which would otherwise force this overlay into normal flow and add
+        // an empty `height`-sized gap below the aquarium.
+        position: "absolute",
+        left: 0,
+        top: 0,
+        width: safeWidth,
+        height,
+        zIndex: 60,
+      }}
       aria-hidden="true"
     >
       {Array.from({ length: count }).map((_, i) => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Problem

After [#1160](https://github.com/ryokun6/ryos/pull/1160) (Let aquarium bubbles overflow and fade), an `EmojiAquarium` rendered in chat shows a large empty gap below the tank under the macOS theme — roughly doubling the bubble's vertical footprint.

### Root cause

The macOS chat-bubble theme defines:

```css
:root[data-os-theme="macosx"] .chat-bubble > * {
  position: relative;
  z-index: 2;
}
```

The new `AquariumBubbleOverflowLayer` is added as a direct child of the `.chat-bubble` wrapper and uses Tailwind's `absolute` class. The theme selector has higher specificity than `.absolute`, so the overlay is forced to `position: relative`. Combined with its explicit `style={{ width, height }}`, it then takes layout space — adding an empty `height`-sized block below the aquarium.

The inner aquarium scene wasn't affected because it was already `position: relative`, so the rule was a no-op for it.

### Fix

Move `position: absolute` (and `left: 0` / `top: 0`) from the Tailwind class to an inline `style`. Inline styles beat regular CSS rules, so the overlay stays absolutely positioned regardless of theme. The dashboard `AquariumBubbleOverflow` (rendered through `WidgetChrome`'s overflow slot) keeps working unchanged because its parent already supplies positioning context.

### Testing

- ✅ `bun run build`
- Manual smoke test in the browser with macOS theme — see screenshots below.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-25f668d8-25c0-47f6-86c7-b3f9f8cf6d0c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-25f668d8-25c0-47f6-86c7-b3f9f8cf6d0c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

