### PR TITLE
Make Maps app default window square (like Karaoke)

### DIFF
--- a/src/config/appRegistry.tsx
+++ b/src/config/appRegistry.tsx
@@ -555,8 +555,8 @@ export const appRegistry = {
     helpItems: mapsHelpItems,
     metadata: mapsMetadata,
     windowConfig: {
-      defaultSize: { width: 720, height: 520 },
-      minSize: { width: 360, height: 320 },
+      defaultSize: { width: 560, height: 560 },
+      minSize: { width: 400, height: 300 },
     } as WindowConstraints,
   },
 } as const;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Mirrors the Karaoke app's window config for the Maps app so the default window opens as a square.

## Changes

- `src/config/appRegistry.tsx` — for the `maps` entry:
  - `defaultSize`: `720 × 520` → `560 × 560` (matches Karaoke's square default)
  - `minSize`: `360 × 320` → `400 × 300` (matches Karaoke's min size)

## Testing

- `bun run build` passes.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-db6954f0-c5e7-4885-82f3-bdfb1702e11d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-db6954f0-c5e7-4885-82f3-bdfb1702e11d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

