### PR TITLE
Chat: align lists with paragraph text, tighten list spacing, drop URLs from speech

### DIFF
--- a/src/apps/chats/components/ChatMessages.tsx
+++ b/src/apps/chats/components/ChatMessages.tsx
@@ -35,6 +35,7 @@ import { abortableFetch } from "@/utils/abortableFetch";
 import { decodeHtmlEntities } from "@/utils/decodeHtmlEntities";
 import { formatToolName } from "@/lib/toolInvocationDisplay";
 import { segmentChatMarkdownText } from "@/lib/chatMarkdown";
+import { cleanTextForSpeech } from "../utils/textForSpeech";
 
 // Helper to extract image URLs from message parts
 const extractImageParts = (message: {
@@ -644,9 +645,9 @@ const ChatMessageItem = memo(function ChatMessageItem(props: ChatMessageItemProp
                       const chunks: string[] = [];
                       const lines = text.split(/\r?\n/);
                       for (const line of lines) {
-                        const trimmedLine = line.trim();
-                        if (trimmedLine && trimmedLine.length > 0) {
-                          chunks.push(trimmedLine);
+                        const cleanedLine = cleanTextForSpeech(line);
+                        if (cleanedLine && cleanedLine.length > 0) {
+                          chunks.push(cleanedLine);
                         }
                       }
                       if (chunks.length > 0) {

--- a/src/apps/chats/hooks/useAiChat.ts
+++ b/src/apps/chats/hooks/useAiChat.ts
@@ -49,6 +49,7 @@ import {
   persistChatApplet,
   persistChatDocument,
 } from "../utils/chatFilePersistence";
+import { cleanTextForSpeech } from "../utils/textForSpeech";
 import {
   handleLaunchApp,
   handleCloseApp,
@@ -649,20 +650,6 @@ export function useAiChat(onPromptSetUsername?: () => void) {
 
   // Queue-based TTS – speaks chunks as they arrive
   const { speak, stop: stopTts, isSpeaking } = useTtsQueue();
-
-  // Strip any number of leading exclamation marks (urgent markers) plus following spaces,
-  // then remove any leading standalone punctuation that may remain.
-  const cleanTextForSpeech = (text: string) => {
-    // First, remove HTML code blocks (```html...``` or similar)
-    const withoutCodeBlocks = text
-      .replace(/```[\s\S]*?```/g, "") // Remove all code blocks
-      .replace(/<[^>]*>/g, "") // Remove any HTML tags
-      .replace(/^!+\s*/, "") // remove !!!!!! prefix
-      .replace(/^[\s.!?。，！？；：]+/, "") // remove leftover punctuation/space at start
-      .trim();
-
-    return withoutCodeBlocks;
-  };
 
   // Rate limit state
   const [rateLimitError, setRateLimitError] = useState<{

--- a/src/apps/chats/utils/textForSpeech.ts
+++ b/src/apps/chats/utils/textForSpeech.ts
@@ -1,0 +1,42 @@
+// Helpers that prepare assistant chat text for the TTS queue.
+//
+// Notes:
+// - Markdown links of the form `[text](url)` collapse to just `text` so the
+//   visible label is still spoken.
+// - Bare http(s)/www/email/markdown-image URLs are dropped entirely – speaking
+//   them out loud is noisy and uninformative.
+// - Code blocks and HTML are stripped so they aren't read aloud.
+
+const MARKDOWN_IMAGE_RE = /!\[[^\]]*\]\([^)]*\)/g;
+const MARKDOWN_LINK_RE = /\[([^\]]+)\]\(([^)\s]+)(?:\s+"[^"]*")?\)/g;
+const ANGLE_AUTOLINK_RE = /<((?:https?:\/\/|www\.|mailto:)[^>\s]+)>/gi;
+const BARE_URL_RE = /\bhttps?:\/\/[^\s<>()]+/gi;
+const BARE_WWW_RE = /\bwww\.[^\s<>()]+/gi;
+const BARE_EMAIL_RE = /\b[\w.+-]+@[\w-]+\.[\w.-]+\b/gi;
+
+export function stripUrlsForSpeech(text: string): string {
+  return text
+    .replace(MARKDOWN_IMAGE_RE, "")
+    .replace(MARKDOWN_LINK_RE, "$1")
+    .replace(ANGLE_AUTOLINK_RE, "")
+    .replace(BARE_URL_RE, "")
+    .replace(BARE_WWW_RE, "")
+    .replace(BARE_EMAIL_RE, "")
+    .replace(/[ \t]{2,}/g, " ");
+}
+
+export function cleanTextForSpeech(text: string): string {
+  return text
+    .replace(/```[\s\S]*?```/g, "")
+    .replace(/<[^>]*>/g, "")
+    .replace(/^!+\s*/, "")
+    .replace(/^[\s.!?。，！？；：]+/, "")
+    .replace(MARKDOWN_IMAGE_RE, "")
+    .replace(MARKDOWN_LINK_RE, "$1")
+    .replace(ANGLE_AUTOLINK_RE, "")
+    .replace(BARE_URL_RE, "")
+    .replace(BARE_WWW_RE, "")
+    .replace(BARE_EMAIL_RE, "")
+    .replace(/[ \t]{2,}/g, " ")
+    .trim();
+}

--- a/src/index.css
+++ b/src/index.css
@@ -637,7 +637,7 @@ button.piano-key.piano-key[class*="bg-[#ff33ff]"] {
   }
 
   .ryos-chat-streamdown :where(li + li) {
-    margin-top: 0.25em;
+    margin-top: 0.1em;
   }
 
   .ryos-chat-streamdown :where(pre) {

--- a/src/index.css
+++ b/src/index.css
@@ -625,7 +625,7 @@ button.piano-key.piano-key[class*="bg-[#ff33ff]"] {
 
   .ryos-chat-streamdown :where(ul, ol) {
     margin-bottom: 0;
-    padding-left: 1.1em;
+    padding-left: 1.6em;
   }
 
   .ryos-chat-streamdown :where(ul) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Three small chat-message tweaks:

1. **List indent** — `.ryos-chat-streamdown :where(ul, ol)` `padding-left` `1.1em` → `1.6em` so list markers and item text align with surrounding paragraph text in chat bubbles.
2. **Tighter list-item gaps** — `.ryos-chat-streamdown :where(li + li)` `margin-top` `0.25em` → `0.1em`.
3. **Drop URLs from chat speech (TTS)** — Chat assistant speech no longer reads URLs out loud:
   - Markdown links `[text](url)` collapse to just `text`.
   - Bare `https?://…`, `www.…`, `<…>` autolinks, markdown image links, and email addresses are removed entirely.
   - Code blocks and HTML tags are still stripped (existing behavior).

To avoid duplicating logic, the speech-cleanup helper moved out of `useAiChat.ts` into a small shared util (`src/apps/chats/utils/textForSpeech.ts`) and is now also used by the per-message "play" button in `ChatMessages.tsx` so manually triggered playback also skips URLs.

## Files
- `src/index.css` — list `padding-left` and `li + li` `margin-top` adjustments.
- `src/apps/chats/utils/textForSpeech.ts` — new shared `cleanTextForSpeech` / `stripUrlsForSpeech` helpers.
- `src/apps/chats/hooks/useAiChat.ts` — use shared helper; removes inline copy.
- `src/apps/chats/components/ChatMessages.tsx` — per-line speech chunks now go through `cleanTextForSpeech`.

## Testing
- `bun run build` passes.
- Spot-checked `cleanTextForSpeech` against 8 representative inputs (markdown links, bare http(s), `www.` links, `<…>` autolinks, markdown images, email, code blocks, leading `!!!` urgent prefix). All pass.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e9b087de-e599-4059-a2ac-1468e0c102a4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e9b087de-e599-4059-a2ac-1468e0c102a4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

