### PR TITLE
fix(chat): make markdown tables fit container before scrolling

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -810,7 +810,7 @@ button.piano-key.piano-key[class*="bg-[#ff33ff]"] {
     text-align: left;
     vertical-align: top;
     white-space: normal !important;
-    min-width: 6em;
+    min-width: 10em;
     overflow-wrap: anywhere;
   }
 

--- a/src/index.css
+++ b/src/index.css
@@ -767,8 +767,9 @@ button.piano-key.piano-key[class*="bg-[#ff33ff]"] {
      cells, and rows all clear their borders so we don't end up with the
      wrapper outline + table outline doubling up. Cells use a hairline
      bottom border for row dividers and tighter padding than Streamdown's
-     default px-4 py-2. The wrapper scrolls horizontally when the table
-     is wider than the bubble (cells enforce a `min-width`). */
+     default px-4 py-2. The table tries to fit the bubble width first;
+     the wrapper only scrolls horizontally when the column `min-width`s
+     force the table wider than the bubble. */
   .ryos-chat-streamdown [data-streamdown="table-wrapper"] {
     margin: 0.3em 0 0.05em;
     overflow-x: auto;
@@ -783,7 +784,7 @@ button.piano-key.piano-key[class*="bg-[#ff33ff]"] {
   }
 
   .ryos-chat-streamdown :where(table) {
-    width: auto;
+    width: 100%;
     max-width: none !important;
     margin: 0 !important;
     border: 0 !important;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Streamdown markdown tables in the chat bubble were always sized to their content (`width: auto; max-width: none`), which combined with the per-cell `min-width` meant a horizontal scrollbar appeared even when the table could comfortably fit the bubble. Columns were also a bit narrow at the previous `6em` floor.

This change makes the table prefer the bubble width first, only overflowing (and triggering the wrapper's horizontal scroll) when the column `min-width`s actually require more space than the container — and bumps the per-column floor so columns settle to a more readable width.

## Changes

`src/index.css`:

- `.ryos-chat-streamdown :where(table)`: `width: auto` → `width: 100%` so the table fills the bubble when it can. `max-width` stays `none !important` so the table can still grow past the bubble when the sum of column `min-width`s exceeds the bubble width — at which point the existing wrapper `overflow-x: auto` kicks in.
- `.ryos-chat-streamdown :where(th, td)`: `min-width: 6em` → `min-width: 10em` so columns get more breathing room before content wraps; the wrapper still scrolls when totals exceed the bubble.
- Updated the inline comment above the table rule to reflect the new behavior.

## Behavior

- Narrow tables (few short columns): expand to fill the bubble, no scrollbar.
- Tables whose column `min-width`s sum past the bubble width: render at intrinsic width and the wrapper scrolls horizontally as before.

## Testing

- ✅ `bun run build` — CSS compiles, full Vite build succeeds.

No JS/TSX touched, so no unit tests apply. Visual change is gated by chat content; manual UI verification skipped per AGENTS.md guidance ("Skip computer use / GUI-driven testing unless the user explicitly requests it").
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-77aefb61-bb80-4987-b69d-465354399e22"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-77aefb61-bb80-4987-b69d-465354399e22"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

