### PR TITLE
Slow Streamdown fade-in animation

### DIFF
--- a/src/apps/chats/components/ChatMessages.tsx
+++ b/src/apps/chats/components/ChatMessages.tsx
@@ -209,7 +209,7 @@ const CHAT_STREAMDOWN_PLUGINS = {
 };
 const CHAT_STREAMDOWN_ANIMATED = {
   animation: "fadeIn",
-  duration: 150,
+  duration: 400,
   easing: "ease-out",
   sep: "word",
 } as const;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Slows the per-word fade-in animation used by `Streamdown` in chat messages.

### Change
- `CHAT_STREAMDOWN_ANIMATED.duration`: `150ms` → `400ms` in `src/apps/chats/components/ChatMessages.tsx`.

The `easing` (`ease-out`) and `sep` (`word`) settings are unchanged, so each streamed word still fades in independently — just more gently.

### Testing
- `bun run build` — passes.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9c5971b8-cdae-4d51-8f73-683d0b8d3961"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9c5971b8-cdae-4d51-8f73-683d0b8d3961"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

