### PR TITLE
React best-practices pass on iPod, Lyrics, Karaoke

### DIFF
--- a/src/apps/ipod/components/IpodAppComponent.tsx
+++ b/src/apps/ipod/components/IpodAppComponent.tsx
@@ -25,7 +25,7 @@ import { getTranslatedAppName } from "@/utils/i18n";
 import { useAudioSettingsStore } from "@/stores/useAudioSettingsStore";
 import { useIpodLogic } from "../hooks/useIpodLogic";
 import { DisplayMode } from "@/types/lyrics";
-import { useCallback } from "react";
+import { useCallback, useMemo } from "react";
 import { LandscapeVideoBackground } from "@/components/shared/LandscapeVideoBackground";
 import { AmbientBackground } from "@/components/shared/AmbientBackground";
 import { MeshGradientBackground } from "@/components/shared/MeshGradientBackground";
@@ -181,14 +181,20 @@ export function IpodAppComponent({
     window.dispatchEvent(new Event(`closeWindow-${instanceId || "ipod"}`));
   }, [instanceId, pauseBeforeWindowClose]);
 
-  const displayModeOptions = [
-    { value: DisplayMode.Video, label: t("apps.ipod.menu.displayVideo") },
-    { value: DisplayMode.Mesh, label: t("apps.ipod.menu.displayGradient") },
-    { value: DisplayMode.Water, label: t("apps.ipod.menu.displayWater") },
-    { value: DisplayMode.Shader, label: t("apps.ipod.menu.displayShader") },
-    { value: DisplayMode.Landscapes, label: t("apps.ipod.menu.displayLandscapes") },
-    { value: DisplayMode.Cover, label: t("apps.ipod.menu.displayCover") },
-  ];
+  // Memoized so the FullScreenPortal / FullscreenPlayerControls don't see a
+  // freshly-allocated array on every parent render (this component re-renders
+  // on every playback tick because elapsedTime is a hook return value).
+  const displayModeOptions = useMemo(
+    () => [
+      { value: DisplayMode.Video, label: t("apps.ipod.menu.displayVideo") },
+      { value: DisplayMode.Mesh, label: t("apps.ipod.menu.displayGradient") },
+      { value: DisplayMode.Water, label: t("apps.ipod.menu.displayWater") },
+      { value: DisplayMode.Shader, label: t("apps.ipod.menu.displayShader") },
+      { value: DisplayMode.Landscapes, label: t("apps.ipod.menu.displayLandscapes") },
+      { value: DisplayMode.Cover, label: t("apps.ipod.menu.displayCover") },
+    ],
+    [t]
+  );
 
   const handleDisplayModeSelect = useCallback(
     (value: DisplayMode) => {

--- a/src/apps/ipod/components/LyricsDisplay.tsx
+++ b/src/apps/ipod/components/LyricsDisplay.tsx
@@ -282,6 +282,13 @@ const GRADIENT_COLORS = "#00FFFF"; // Cyan starting color (hue-rotate will cycle
 const GRADIENT_GLOW_SHADOW = "0 0 6px rgba(0,255,255,0.5), 0 0 12px rgba(0,255,255,0.3), 0 0 4px rgba(0,0,0,0.3)";
 const GRADIENT_GLOW_FILTER = "drop-shadow(0 0 6px rgba(0,255,255,0.5)) drop-shadow(0 0 12px rgba(0,255,255,0.3))";
 
+// Shared empty maps used as the default for furigana/soramimi props. Allocating
+// `new Map()` in the destructured defaults would create a fresh identity on
+// every render and bust downstream `useCallback`/`useMemo` deps that include
+// these maps (e.g. `renderWithFurigana`).
+const EMPTY_FURIGANA_MAP: ReadonlyMap<string, FuriganaSegment[]> = new Map();
+const EMPTY_SORAMIMI_MAP: ReadonlyMap<string, FuriganaSegment[]> = new Map();
+
 // Style category detection
 type StyleCategory = 'outline-blue' | 'outline-red' | 'glow-white' | 'glow-gold' | 'glow-gradient';
 
@@ -1744,8 +1751,8 @@ export function LyricsDisplay({
   gapClass = "gap-2",
   fontClassName = "font-geneva-12",
   containerStyle,
-  furiganaMap = new Map(),
-  soramimiMap = new Map(),
+  furiganaMap = EMPTY_FURIGANA_MAP as Map<string, FuriganaSegment[]>,
+  soramimiMap = EMPTY_SORAMIMI_MAP as Map<string, FuriganaSegment[]>,
   currentTimeMs,
   onSeekToTime,
   coverUrl,
@@ -1999,9 +2006,16 @@ export function LyricsDisplay({
   // For word-level timing, we still need to track Korean romanization state
   const showKoreanRomanization = romanization.enabled && romanization.korean;
 
-  // Detect style category and whether to use outline styling
-  const styleCategory = getStyleCategory(fontClassName);
-  const isOldSchoolKaraoke = styleCategory === 'outline-blue' || styleCategory === 'outline-red';
+  // Detect style category and whether to use outline styling. `styleCategory`
+  // only depends on `fontClassName`; bundling all derived style values into a
+  // single useMemo keeps every per-line render from re-running these tiny
+  // switches and avoids freshly-allocated string props that bust child memo.
+  const styleCategory = useMemo(
+    () => getStyleCategory(fontClassName),
+    [fontClassName]
+  );
+  const isOldSchoolKaraoke =
+    styleCategory === "outline-blue" || styleCategory === "outline-red";
 
   // Extract primary color from album art for the glow-gold style
   const palette = useCoverPalette(styleCategory === 'glow-gold' ? (coverUrl ?? null) : null);
@@ -2010,52 +2024,75 @@ export function LyricsDisplay({
     const boosted = boostGlowColor(raw);
     return makeGlowFromColor(boosted);
   }, [palette]);
-  
-  // Get the highlight color based on style category (returns gradient string for gradient style)
-  const getHighlightColor = (): string => {
+
+  const styleProps = useMemo(() => {
+    const isOutline =
+      styleCategory === "outline-blue" || styleCategory === "outline-red";
+    const isColoredGlow =
+      styleCategory === "glow-gold" || styleCategory === "glow-gradient";
+    const isGradient = styleCategory === "glow-gradient";
+
+    let highlight: string;
     switch (styleCategory) {
-      case 'outline-blue': return OLD_SCHOOL_HIGHLIGHT_COLOR;
-      case 'outline-red': return SERIF_RED_HIGHLIGHT_COLOR;
-      case 'glow-gold': return primaryGlow.color;
-      case 'glow-gradient': return GRADIENT_COLORS;
-      default: return "rgba(255, 255, 255, 1)";
+      case "outline-blue":
+        highlight = OLD_SCHOOL_HIGHLIGHT_COLOR;
+        break;
+      case "outline-red":
+        highlight = SERIF_RED_HIGHLIGHT_COLOR;
+        break;
+      case "glow-gold":
+        highlight = primaryGlow.color;
+        break;
+      case "glow-gradient":
+        highlight = GRADIENT_COLORS;
+        break;
+      default:
+        highlight = "rgba(255, 255, 255, 1)";
     }
-  };
-  
-  // Get the glow shadow based on style category
-  const getGlowShadow = (isHighlight: boolean): string => {
-    if (isOldSchoolKaraoke) return "none";
-    switch (styleCategory) {
-      case 'glow-gold': return isHighlight ? primaryGlow.shadow : BASE_SHADOW;
-      case 'glow-gradient': return isHighlight ? GRADIENT_GLOW_SHADOW : BASE_SHADOW;
-      default: return isHighlight ? GLOW_SHADOW : BASE_SHADOW;
+
+    let shadowHighlight: string;
+    if (isOutline) {
+      shadowHighlight = "none";
+    } else if (styleCategory === "glow-gold") {
+      shadowHighlight = primaryGlow.shadow;
+    } else if (styleCategory === "glow-gradient") {
+      shadowHighlight = GRADIENT_GLOW_SHADOW;
+    } else {
+      shadowHighlight = GLOW_SHADOW;
     }
-  };
-  
-  // Get the glow filter based on style category
-  const getGlowFilter = (): string => {
-    if (isOldSchoolKaraoke) return "none";
-    switch (styleCategory) {
-      case 'glow-gold': return primaryGlow.filter;
-      case 'glow-gradient': return GRADIENT_GLOW_FILTER;
-      default: return GLOW_FILTER;
+
+    let filter: string;
+    if (isOutline) {
+      filter = "none";
+    } else if (styleCategory === "glow-gold") {
+      filter = primaryGlow.filter;
+    } else if (styleCategory === "glow-gradient") {
+      filter = GRADIENT_GLOW_FILTER;
+    } else {
+      filter = GLOW_FILTER;
     }
-  };
-  
-  // Get base color for colored glow styles (inactive state). Gradient matches glow-white (semi-transparent white + opacity-55 on word layers).
-  const getBaseColor = (): string | undefined => {
-    switch (styleCategory) {
-      case 'glow-gold': return primaryGlow.baseColor;
-      default: return undefined;
-    }
-  };
-  
-  const highlightColor = getHighlightColor();
-  const isColoredGlow = styleCategory === 'glow-gold' || styleCategory === 'glow-gradient';
-  const isGradientStyle = styleCategory === 'glow-gradient';
-  const glowShadowHighlight = getGlowShadow(true);
-  const glowFilterStr = getGlowFilter();
-  const baseColorResolved = getBaseColor();
+
+    const base =
+      styleCategory === "glow-gold" ? primaryGlow.baseColor : undefined;
+
+    return {
+      highlightColor: highlight,
+      isColoredGlow,
+      isGradientStyle: isGradient,
+      glowShadowHighlight: shadowHighlight,
+      glowFilterStr: filter,
+      baseColorResolved: base,
+    };
+  }, [styleCategory, primaryGlow]);
+
+  const {
+    highlightColor,
+    isColoredGlow,
+    isGradientStyle,
+    glowShadowHighlight,
+    glowFilterStr,
+    baseColorResolved,
+  } = styleProps;
 
   const getTextAlign = (
     align: LyricsAlignment,

--- a/src/apps/ipod/hooks/useIpodLogic.ts
+++ b/src/apps/ipod/hooks/useIpodLogic.ts
@@ -53,6 +53,16 @@ import type { BrickGameRef } from "../components/BrickGame";
 import type { SongSearchResult } from "@/components/dialogs/SongSearchDialog";
 import { helpItems } from "..";
 
+// User-agent sniffing is constant for the document lifetime, so compute once
+// at module load instead of re-running these regexes on every render of the
+// hook. The fallback for non-browser contexts (e.g. SSR, tests) keeps the
+// module import safe.
+const UA = typeof navigator !== "undefined" ? navigator.userAgent : "";
+const IS_IOS = /iP(hone|od|ad)/.test(UA);
+const IS_SAFARI =
+  /Safari/.test(UA) && !/Chrome/.test(UA) && !/CriOS/.test(UA);
+const IS_IOS_SAFARI = IS_IOS && IS_SAFARI;
+
 export interface UseIpodLogicOptions {
   isWindowOpen: boolean;
   isForeground: boolean | undefined;
@@ -318,8 +328,10 @@ export function useIpodLogic({
 
   const joinListenSession = useListenSessionStore((s) => s.joinSession);
 
-  // Status management
-  const [lastActivityTime, setLastActivityTime] = useState(Date.now());
+  // Status management. Use a lazy initializer for `Date.now()` so the
+  // timestamp is captured exactly once on mount instead of on every render
+  // (the result is immediately discarded after the first commit anyway).
+  const [lastActivityTime, setLastActivityTime] = useState(() => Date.now());
   const backlightTimerRef = useRef<NodeJS.Timeout | null>(null);
   const [statusMessage, setStatusMessage] = useState<string | null>(null);
   const statusTimeoutRef = useRef<NodeJS.Timeout | null>(null);
@@ -525,11 +537,10 @@ export function useIpodLogic({
     isWindowOpen && (isForeground ?? false)
   );
 
-  // iOS Safari detection
-  const ua = navigator.userAgent;
-  const isIOS = /iP(hone|od|ad)/.test(ua);
-  const isSafari = /Safari/.test(ua) && !/Chrome/.test(ua) && !/CriOS/.test(ua);
-  const isIOSSafari = isIOS && isSafari;
+  // iOS Safari detection (cached at module scope; see top of file).
+  const isIOS = IS_IOS;
+  const isSafari = IS_SAFARI;
+  const isIOSSafari = IS_IOS_SAFARI;
 
   // Status helper functions
   const showStatus = useCallback((message: string) => {

--- a/src/apps/karaoke/components/KaraokeAppComponent.tsx
+++ b/src/apps/karaoke/components/KaraokeAppComponent.tsx
@@ -192,14 +192,20 @@ export function KaraokeAppComponent({
 
   const showEmptyLibrary = tracks.length === 0 && !currentTrack;
 
-  const displayModeOptions = [
-    { value: DisplayMode.Video, label: t("apps.ipod.menu.displayVideo") },
-    { value: DisplayMode.Mesh, label: t("apps.ipod.menu.displayGradient") },
-    { value: DisplayMode.Water, label: t("apps.ipod.menu.displayWater") },
-    { value: DisplayMode.Shader, label: t("apps.ipod.menu.displayShader") },
-    { value: DisplayMode.Landscapes, label: t("apps.ipod.menu.displayLandscapes") },
-    { value: DisplayMode.Cover, label: t("apps.ipod.menu.displayCover") },
-  ];
+  // Memoized so the FullScreenPortal / FullscreenPlayerControls don't see a
+  // freshly-allocated array on every parent render (this component re-renders
+  // on every playback tick because elapsedTime is a hook return value).
+  const displayModeOptions = useMemo(
+    () => [
+      { value: DisplayMode.Video, label: t("apps.ipod.menu.displayVideo") },
+      { value: DisplayMode.Mesh, label: t("apps.ipod.menu.displayGradient") },
+      { value: DisplayMode.Water, label: t("apps.ipod.menu.displayWater") },
+      { value: DisplayMode.Shader, label: t("apps.ipod.menu.displayShader") },
+      { value: DisplayMode.Landscapes, label: t("apps.ipod.menu.displayLandscapes") },
+      { value: DisplayMode.Cover, label: t("apps.ipod.menu.displayCover") },
+    ],
+    [t]
+  );
 
   const handleDisplayModeSelect = useCallback(
     (value: DisplayMode) => {

--- a/src/apps/karaoke/components/KaraokeLyricsPlayback.tsx
+++ b/src/apps/karaoke/components/KaraokeLyricsPlayback.tsx
@@ -1,5 +1,6 @@
 import {
   createContext,
+  memo,
   useCallback,
   useContext,
   useEffect,
@@ -323,15 +324,80 @@ function makeTitleCardGlow(hex: string) {
   };
 }
 
-function buildFullscreenContainerStyle(): CSSProperties {
-  return {
-    gap: "clamp(0.2rem, calc(min(10vw,10vh) * 0.08), 1rem)",
-    paddingLeft: "env(safe-area-inset-left, 0px)",
-    paddingRight: "env(safe-area-inset-right, 0px)",
-  };
-}
+// Hoisted to module scope so the rendered LyricsDisplay doesn't receive a
+// freshly-allocated `containerStyle` prop on every parent render. The values
+// are pure CSS strings (no per-render data), so a single shared instance is
+// safe.
+const FULLSCREEN_CONTAINER_STYLE: CSSProperties = {
+  gap: "clamp(0.2rem, calc(min(10vw,10vh) * 0.08), 1rem)",
+  paddingLeft: "env(safe-area-inset-left, 0px)",
+  paddingRight: "env(safe-area-inset-right, 0px)",
+};
 
-function KaraokeTitleCard({
+// All inline style objects below are split between "fullscreen" and "window"
+// variants and are constant strings. Hoisting to module scope keeps the
+// title card's React.memo equality fast and avoids dozens of object allocs
+// per playback tick when the title card is on screen.
+const TITLE_CARD_SECONDARY_TEXT_STYLE: CSSProperties = {
+  lineHeight: 1.1,
+  opacity: 0.55,
+};
+const TITLE_CARD_COVER_SLEEVE_STYLE: CSSProperties = {
+  background: "#1a1a1a",
+  borderRadius: "1%",
+  boxShadow: "0 12px 40px rgba(0,0,0,0.5)",
+};
+const TITLE_CARD_COVER_REFLECTION_STYLE: CSSProperties = {
+  transform: "scaleY(-1)",
+  opacity: 0.3,
+  maskImage:
+    "linear-gradient(to top, rgba(0,0,0,1) 0%, transparent 50%)",
+  WebkitMaskImage:
+    "linear-gradient(to top, rgba(0,0,0,1) 0%, transparent 50%)",
+  borderRadius: "1%",
+};
+const TITLE_CARD_COVER_REFLECTION_WRAPPER_STYLE: CSSProperties = {
+  height: "50%",
+};
+const TITLE_CARD_COVER_IMAGE_STYLE_FULLSCREEN: CSSProperties = {
+  width: "clamp(120px, min(24vw, 24vh), 320px)",
+  height: "clamp(120px, min(24vw, 24vh), 320px)",
+};
+const TITLE_CARD_COVER_IMAGE_STYLE_WINDOW: CSSProperties = {
+  width: "clamp(96px, 18cqw, 220px)",
+  height: "clamp(96px, 18cqw, 220px)",
+};
+const TITLE_CARD_CONTENT_STYLE_FULLSCREEN: CSSProperties = {
+  gap: "clamp(22px, min(5vw, 5vh), 64px)",
+};
+const TITLE_CARD_CONTENT_STYLE_WINDOW: CSSProperties = {
+  gap: "clamp(22px, 5cqw, 64px)",
+};
+const TITLE_CARD_OUTER_STYLE_FULLSCREEN: CSSProperties = {
+  paddingLeft: "clamp(24px, min(6vw, 6vh), 80px)",
+};
+const TITLE_CARD_OUTER_STYLE_WINDOW: CSSProperties = {
+  paddingLeft: "clamp(24px, 6cqw, 80px)",
+};
+const TITLE_CARD_REGULAR_OUTLINE_STYLE: TitleCardLineStyle = {
+  color: "#fff",
+  lineHeight: 1,
+  WebkitTextStroke: "0.12em rgba(0,0,0,0.7)",
+  paintOrder: "stroke fill",
+  textShadow: "none",
+};
+const TITLE_CARD_REGULAR_GRADIENT_STYLE: TitleCardLineStyle = {
+  color: "rgba(255, 255, 255, 0.78)",
+  lineHeight: 1,
+  textShadow: TITLE_CARD_BASE_SHADOW,
+};
+
+// Wrapped in React.memo because the parent overlays re-render on every
+// playback tick (~10/s). The title card's props (title / artist / album /
+// coverUrl / fontClassName / variant / isPlaying / bottomPaddingClass /
+// onOpenCoverFlow / coverFlowLabel) are all stable for the lifetime of a
+// track, so memo lets the entire title-card subtree skip those re-renders.
+const KaraokeTitleCard = memo(function KaraokeTitleCard({
   title,
   artist,
   album,
@@ -368,48 +434,21 @@ function KaraokeTitleCard({
     variant === "fullscreen"
       ? "karaoke-title-card-secondary-fullscreen"
       : "karaoke-title-card-secondary-window";
-  const secondaryTextStyle: CSSProperties = {
-    lineHeight: 1.1,
-    opacity: 0.55,
-  };
-  const coverImageStyle: CSSProperties = {
-    width:
-      variant === "fullscreen"
-        ? "clamp(120px, min(24vw, 24vh), 320px)"
-        : "clamp(96px, 18cqw, 220px)",
-    height:
-      variant === "fullscreen"
-        ? "clamp(120px, min(24vw, 24vh), 320px)"
-        : "clamp(96px, 18cqw, 220px)",
-  };
-  const coverSleeveStyle: CSSProperties = {
-    background: "#1a1a1a",
-    borderRadius: "1%",
-    boxShadow: "0 12px 40px rgba(0,0,0,0.5)",
-  };
-  const titleCardContentStyle: CSSProperties = {
-    gap:
-      variant === "fullscreen"
-        ? "clamp(22px, min(5vw, 5vh), 64px)"
-        : "clamp(22px, 5cqw, 64px)",
-  };
-  const titleCardOuterStyle: CSSProperties = {
-    paddingLeft:
-      variant === "fullscreen"
-        ? "clamp(24px, min(6vw, 6vh), 80px)"
-        : "clamp(24px, 6cqw, 80px)",
-  };
+  const isFullscreen = variant === "fullscreen";
+  const coverImageStyle = isFullscreen
+    ? TITLE_CARD_COVER_IMAGE_STYLE_FULLSCREEN
+    : TITLE_CARD_COVER_IMAGE_STYLE_WINDOW;
+  const titleCardContentStyle = isFullscreen
+    ? TITLE_CARD_CONTENT_STYLE_FULLSCREEN
+    : TITLE_CARD_CONTENT_STYLE_WINDOW;
+  const titleCardOuterStyle = isFullscreen
+    ? TITLE_CARD_OUTER_STYLE_FULLSCREEN
+    : TITLE_CARD_OUTER_STYLE_WINDOW;
   const regularTextStyle = useMemo((): TitleCardLineStyle => {
     switch (styleCategory) {
       case "outline-blue":
       case "outline-red":
-        return {
-          color: "#fff",
-          lineHeight: 1,
-          WebkitTextStroke: "0.12em rgba(0,0,0,0.7)",
-          paintOrder: "stroke fill",
-          textShadow: "none",
-        };
+        return TITLE_CARD_REGULAR_OUTLINE_STYLE;
       case "glow-gold":
         return {
           color: primaryGlow.baseColor,
@@ -419,11 +458,7 @@ function KaraokeTitleCard({
         };
       case "glow-gradient":
       default:
-        return {
-          color: "rgba(255, 255, 255, 0.78)",
-          lineHeight: 1,
-          textShadow: TITLE_CARD_BASE_SHADOW,
-        };
+        return TITLE_CARD_REGULAR_GRADIENT_STYLE;
     }
   }, [primaryGlow, styleCategory]);
   const metadataLines = useMemo(() => {
@@ -473,7 +508,10 @@ function KaraokeTitleCard({
                 onTouchEnd={(e) => e.stopPropagation()}
               />
             )}
-            <div className="absolute inset-0 overflow-hidden" style={coverSleeveStyle}>
+            <div
+              className="absolute inset-0 overflow-hidden"
+              style={TITLE_CARD_COVER_SLEEVE_STYLE}
+            >
               <img
                 src={coverUrl}
                 alt=""
@@ -483,19 +521,13 @@ function KaraokeTitleCard({
             </div>
             <div
               className="absolute top-full left-0 w-full pointer-events-none"
-              style={{ height: "50%" }}
+              style={TITLE_CARD_COVER_REFLECTION_WRAPPER_STYLE}
             >
               <img
                 src={coverUrl}
                 alt=""
                 className="w-full h-auto"
-                style={{
-                  transform: "scaleY(-1)",
-                  opacity: 0.3,
-                  maskImage: "linear-gradient(to top, rgba(0,0,0,1) 0%, transparent 50%)",
-                  WebkitMaskImage: "linear-gradient(to top, rgba(0,0,0,1) 0%, transparent 50%)",
-                  borderRadius: "1%",
-                }}
+                style={TITLE_CARD_COVER_REFLECTION_STYLE}
                 draggable={false}
               />
             </div>
@@ -515,7 +547,7 @@ function KaraokeTitleCard({
             <div
               key={metadataLine}
               className={`text-white ${secondaryTextSizeClass} ${fontClassName} whitespace-pre-wrap break-words`}
-              style={secondaryTextStyle}
+              style={TITLE_CARD_SECONDARY_TEXT_STYLE}
             >
               {metadataLine}
             </div>
@@ -524,7 +556,7 @@ function KaraokeTitleCard({
       </motion.div>
     </motion.div>
   );
-}
+});
 
 interface WindowLyricsProps {
   showLyrics: boolean;
@@ -806,7 +838,7 @@ export function KaraokeFullscreenLyricsOverlay({
             isTranslating={lyricsControls.isTranslating}
             textSizeClass="fullscreen-lyrics-text"
             gapClass="gap-0"
-            containerStyle={buildFullscreenContainerStyle()}
+            containerStyle={FULLSCREEN_CONTAINER_STYLE}
             interactive={true}
             bottomPaddingClass={bottomPadding}
             furiganaMap={furiganaMap}

--- a/src/apps/karaoke/hooks/useKaraokeLogic.ts
+++ b/src/apps/karaoke/hooks/useKaraokeLogic.ts
@@ -27,6 +27,14 @@ import { helpItems } from "..";
 import { onAppUpdate } from "@/utils/appEventBus";
 import { MEDIA_ANALYTICS, track as trackAnalytics } from "@/utils/analytics";
 
+// User-agent sniffing is constant for the document lifetime, so compute once
+// at module load instead of re-running these regexes on every render of the
+// hook. Falling back to "" keeps the module import safe in non-browser envs.
+const UA = typeof navigator !== "undefined" ? navigator.userAgent : "";
+const IS_IOS = /iP(hone|od|ad)/.test(UA);
+const IS_SAFARI =
+  /Safari/.test(UA) && !/Chrome/.test(UA) && !/CriOS/.test(UA);
+
 export interface UseKaraokeLogicOptions {
   isWindowOpen: boolean;
   isForeground: boolean | undefined;
@@ -269,10 +277,9 @@ export function useKaraokeLogic({
   // Volume from audio settings store
   const { ipodVolume } = useAudioSettingsStoreShallow((state) => ({ ipodVolume: state.ipodVolume }));
 
-  // iOS/Safari detection for autoplay restrictions
-  const ua = navigator.userAgent;
-  const isIOS = /iP(hone|od|ad)/.test(ua);
-  const isSafari = /Safari/.test(ua) && !/Chrome/.test(ua) && !/CriOS/.test(ua);
+  // iOS/Safari detection for autoplay restrictions (cached at module scope).
+  const isIOS = IS_IOS;
+  const isSafari = IS_SAFARI;
   // Track user interaction for autoplay guard (iOS Safari blocks autoplay until user interacts)
   const userHasInteractedRef = useRef(false);
 

--- a/src/components/shared/LyricsSyncMode.tsx
+++ b/src/components/shared/LyricsSyncMode.tsx
@@ -17,7 +17,13 @@ import {
 } from "@/utils/romanization";
 import { parseLyricTimestamps, findCurrentLineIndex } from "@/utils/lyricsSearch";
 
-// Memoized lyric line component to prevent unnecessary re-renders
+// Memoized lyric line component to prevent unnecessary re-renders.
+//
+// `onClick` / `setRef` accept the row index so the parent can pass stable
+// references (one per LyricsSyncMode instance) instead of allocating a new
+// closure per row per render. Inline closures here would defeat React.memo
+// because `Object.is` comparison on prop functions would always fail, and
+// every progress tick (~10/s for the seek bar) would re-render every row.
 const LyricLineItem = memo(function LyricLineItem({
   line,
   index,
@@ -34,15 +40,24 @@ const LyricLineItem = memo(function LyricLineItem({
   isPast: boolean;
   romanizedText: string | null;
   displayText: string;
-  onClick: () => void;
-  setRef: (el: HTMLButtonElement | null) => void;
+  onClick: (index: number) => void;
+  setRef: (index: number, el: HTMLButtonElement | null) => void;
 }) {
+  const handleClick = useCallback(() => {
+    onClick(index);
+  }, [onClick, index]);
+  const handleRef = useCallback(
+    (el: HTMLButtonElement | null) => {
+      setRef(index, el);
+    },
+    [setRef, index]
+  );
   return (
     <button
       type="button"
       key={`${line.startTimeMs}-${index}`}
-      ref={setRef}
-      onClick={onClick}
+      ref={handleRef}
+      onClick={handleClick}
       className={cn(
         "w-full text-left py-2 px-3 rounded-xl",
         "hover:bg-white/10 active:bg-white/20",
@@ -217,16 +232,35 @@ export function LyricsSyncMode({
     return findCurrentLineIndex(parsedTimestamps, adjustedTime);
   }, [parsedTimestamps, lines.length, currentTimeMs, currentOffset]);
 
-  // Handle line tap - calculate new offset so this line plays at current time
+  // Mirror `currentTimeMs` in a ref so the row click handler can stay
+  // referentially stable. Without this, `handleLineTap` would change every
+  // ~100ms (every seek-bar tick), invalidating the per-row memoization.
+  const currentTimeMsRef = useRef(currentTimeMs);
+  useEffect(() => {
+    currentTimeMsRef.current = currentTimeMs;
+  }, [currentTimeMs]);
+
+  // Stable line click handler keyed by index — the row component closes over
+  // the index, so this can stay identity-stable across renders.
   const handleLineTap = useCallback(
-    (line: LyricLine) => {
+    (index: number) => {
+      const line = lines[index];
+      if (!line) return;
       const lineStartMs = parseInt(line.startTimeMs, 10);
       // new_offset = line_start_time - current_playback_time
-      // This means: "The line I tapped should be playing right now"
-      const newOffset = lineStartMs - currentTimeMs;
+      // "The line I tapped should be playing right now."
+      const newOffset = lineStartMs - currentTimeMsRef.current;
       onSetOffset(newOffset);
     },
-    [currentTimeMs, onSetOffset]
+    [lines, onSetOffset]
+  );
+
+  // Stable ref-setter keyed by index for the same reason.
+  const setLineRef = useCallback(
+    (index: number, el: HTMLButtonElement | null) => {
+      lineRefs.current[index] = el;
+    },
+    []
   );
 
   // Track last scrolled line to avoid redundant scrolls
@@ -421,10 +455,8 @@ export function LyricsSyncMode({
                 isPast={index < currentLineIndex}
                 romanizedText={romanizedTexts.get(index) ?? null}
                 displayText={line.words}
-                onClick={() => handleLineTap(line)}
-                setRef={(el) => {
-                  lineRefs.current[index] = el;
-                }}
+                onClick={handleLineTap}
+                setRef={setLineRef}
               />
             ))}
           </div>

--- a/src/hooks/useLyrics.ts
+++ b/src/hooks/useLyrics.ts
@@ -110,11 +110,20 @@ export function useLyrics({
   const [furiganaInfo, setFuriganaInfo] = useState<FuriganaStreamInfo | undefined>();
   const [soramimiInfo, setSoramimiInfo] = useState<SoramimiStreamInfo | undefined>();
 
-  // Refs for tracking state across renders
+  // Refs for tracking state across renders.
+  //
+  // `currentSongIdRef` is read inside async callbacks fired by the fetch
+  // pipeline below to bail out when the user has navigated to a different
+  // song while a request was in flight. Mutating a ref during render is
+  // unsafe under concurrent React (a render can be discarded and re-run);
+  // instead we sync the ref in a layout effect so the value is committed
+  // before any other effects observe it.
   const cachedKeyRef = useRef<string | null>(null);
   const lastTimeRef = useRef<number>(currentTime);
   const currentSongIdRef = useRef(songId);
-  currentSongIdRef.current = songId;
+  useEffect(() => {
+    currentSongIdRef.current = songId;
+  }, [songId]);
 
   // Cache bust and refetch triggers
   const { isForceRequest: isCacheBustRequest, markHandled: markCacheBustHandled } = useCacheBustTrigger();

--- a/src/lib/audioContext.ts
+++ b/src/lib/audioContext.ts
@@ -5,11 +5,20 @@
 // "interrupted" states, or being closed when the page is backgrounded for a
 // while).
 
-// Safari pre-2017 requires webkitAudioContext prefix
+// Safari pre-2017 requires webkitAudioContext prefix.
+//
+// Guarded with `typeof window` so this module is safe to import in
+// non-browser environments (Bun's default test runner, Node-only API
+// handlers, SSR). Tests like `tests/test-ipod-apple-music.test.ts`
+// pull this module in transitively via the iPod store; without the
+// guard, just loading the module would throw `ReferenceError: window
+// is not defined` and abort the suite.
 const AudioContextClass =
-  window.AudioContext ||
-  (window as unknown as { webkitAudioContext?: typeof AudioContext })
-    .webkitAudioContext;
+  typeof window !== "undefined"
+    ? window.AudioContext ||
+      (window as unknown as { webkitAudioContext?: typeof AudioContext })
+        .webkitAudioContext
+    : undefined;
 
 let audioContext: AudioContext | null = null;
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Targeted React best-practices pass over the iPod / Lyrics / Karaoke surface plus a CI fix for a pre-existing unit-test crash. No behavior changes — just removing render-time waste, fixing two memo breaks, tightening a concurrency-unsafe ref mutation, and unblocking the unit-test runner.

The lyric overlay sub-tree is the hottest re-render path in the app: every progress tick (~10/s during playback) triggers `LyricsDisplay`, `LyricsSyncMode`, and `KaraokeTitleCard` to re-render. Every fix below targets a prop / dep that was busting memoization or a per-render allocation along that path.

## Fixes

### 1. `LyricsSyncMode` — restore `React.memo` on lyric rows
`LyricLineItem` was wrapped in `React.memo`, but the parent passed inline arrow closures for `onClick` and `setRef` on every render. The seek bar updates `LyricsSyncMode` ~10x/s, so every memoized row was re-rendering on every tick — the memo was dead.

Now passing stable, index-keyed callbacks. `currentTimeMs` is mirrored into a ref so `handleLineTap` can stay referentially stable while still reading the latest value at click time.

### 2. `LyricsDisplay` — stable `EMPTY_MAP` defaults + memoized style derivations
- `furiganaMap = new Map()` / `soramimiMap = new Map()` defaults allocated a fresh `Map` on every render whenever a caller didn't pass these props, busting the deps on `renderWithFurigana`. Hoisted to module-level `EMPTY_FURIGANA_MAP` / `EMPTY_SORAMIMI_MAP` constants.
- `getHighlightColor` / `getGlowShadow` / `getGlowFilter` / `getBaseColor` were re-running on every render and produced fresh string identities for `primaryGlow`-derived values. Bundled the whole derivation into a single `useMemo` keyed on `[styleCategory, primaryGlow]`. Downstream row props (`highlightColor`, `glowFilter`, `baseColorResolved`, …) now keep stable identity as long as the cover palette and font class don't change.

### 3. `useIpodLogic` / `useKaraokeLogic` — hoist `navigator.userAgent` checks
`navigator.userAgent` never changes for the document's lifetime, so running three regexes on every render of these multi-thousand-line hooks (each re-renders on every playback tick) was wasted work. Cached at module scope with an SSR-safe fallback.

Also flipped `useState(Date.now())` → `useState(() => Date.now())` in `useIpodLogic` so the timestamp is captured once on mount instead of on every render.

### 4. `useLyrics` — sync `currentSongIdRef` in an effect, not during render
Mutating a ref during render is unsafe under concurrent React: a render can be discarded and re-run, leaving the ref out of sync with the committed tree. The ref is only consumed inside fetch `.then` callbacks that fire well after commit, so a `useEffect` sync is sufficient.

### 5. `IpodAppComponent` / `KaraokeAppComponent` — memoize `displayModeOptions`
Both components re-render on every playback tick (because `elapsedTime` is part of their hook's return). Each render allocated a fresh `displayModeOptions` array that flows into `FullScreenPortal` → `FullscreenPlayerControls`. `useMemo` on `[t]` keeps the prop identity stable across ticks.

### 6. `KaraokeTitleCard` — wrap in `React.memo` + hoist style objects
The Karaoke title card's parent overlays re-render ~10/s because `elapsedTime` ticks through context. The title card subtree itself has nothing per-tick driving it — `title` / `artist` / `album` / `coverUrl` / `fontClassName` / `variant` / `isPlaying` / `bottomPaddingClass` / `onOpenCoverFlow` / `coverFlowLabel` are all stable for the lifetime of a track.

- Wrapped in `React.memo` so the entire subtree (including the `useCoverPalette` call and `ScrollingText`) skips those re-renders.
- Hoisted the static cover-sleeve / cover-reflection / secondary-text / outline / gradient style objects to module scope so the memoized component's prop equality stays cheap. Variant-dependent style objects pick a hoisted constant by branch instead of allocating fresh objects each render.
- Replaced the `buildFullscreenContainerStyle()` factory with a hoisted `FULLSCREEN_CONTAINER_STYLE` constant for the same reason.

### 7. `audioContext` — guard `window` reference for non-browser test envs
`tests/test-ipod-apple-music.test.ts` was crashing with `ReferenceError: window is not defined` (a pre-existing failure on `main`, not introduced by this PR). The test sets up `localStorage` and `navigator` polyfills but not `window`, and importing `useIpodStore` transitively pulls in `src/lib/audioContext.ts`, which read `window.AudioContext` unconditionally at module load.

Gating the lookup on `typeof window !== "undefined"` keeps browser behavior identical (the `typeof` check is `true` and the rest of the expression is unchanged) while letting the module load cleanly in Bun's default Node-like test env. `getAudioContext()` already handles a missing `AudioContextClass` internally, so non-browser callers that actually try to use it fail at point-of-use instead of crashing every importer at module load.

## Testing

- ✅ `npx tsc -b` — clean
- ✅ `bun run test:unit` — **174 pass / 0 fail** (was 162 pass / 1 fail / 1 error on `main`, blocking CI)
- ✅ `bun test tests/test-lyrics-parsing.test.ts tests/test-karaoke-title-card.test.ts tests/test-karaoke-interlude-display.test.ts tests/test-furigana-word-spacing.test.ts` — 36 / 36 pass
- ✅ `bun run build` — succeeds (15s)
- ✅ `bun run lint` — only pre-existing warnings; no new ones on the modified files

These are pure plumbing/perf changes. No store shape, API, or rendered output changes; existing tests cover the surfaces.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f64bfa5f-3f29-4e43-b30b-47ec2c17d963"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f64bfa5f-3f29-4e43-b30b-47ec2c17d963"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

