### PR TITLE
fix(ipod): prevent menu item wrapping in Library menu

### DIFF
--- a/src/apps/ipod/components/IpodMenuBar.tsx
+++ b/src/apps/ipod/components/IpodMenuBar.tsx
@@ -301,13 +301,13 @@ export function IpodMenuBar({
         <>
           <MenubarItem
             onClick={onClearLibrary}
-            className="text-md h-6 px-3"
+            className="text-md h-6 px-3 whitespace-nowrap"
           >
             {t("apps.ipod.menu.clearLibrary")}
           </MenubarItem>
           <MenubarItem
             onClick={onSyncLibrary}
-            className="text-md h-6 px-3"
+            className="text-md h-6 px-3 whitespace-nowrap"
           >
             {t("apps.ipod.menu.syncLibrary")}
           </MenubarItem>
@@ -319,14 +319,14 @@ export function IpodMenuBar({
             <>
               <MenubarItem
                 onClick={onAppleMusicRefresh}
-                className="text-md h-6 px-3"
+                className="text-md h-6 px-3 whitespace-nowrap"
                 disabled={!onAppleMusicRefresh}
               >
                 {t("apps.ipod.menu.refreshAppleMusic")}
               </MenubarItem>
               <MenubarItem
                 onClick={onAppleMusicSignOut}
-                className="text-md h-6 px-3"
+                className="text-md h-6 px-3 whitespace-nowrap"
                 disabled={!onAppleMusicSignOut}
               >
                 {t("apps.ipod.menu.appleMusicSignOut")}
@@ -335,7 +335,7 @@ export function IpodMenuBar({
           ) : (
             <MenubarItem
               onClick={onAppleMusicSignIn}
-              className="text-md h-6 px-3"
+              className="text-md h-6 px-3 whitespace-nowrap"
               disabled={!onAppleMusicSignIn}
             >
               {t("apps.ipod.menu.appleMusicSignIn")}
@@ -349,7 +349,7 @@ export function IpodMenuBar({
   const librarySwitchMenubarItem = (
     <MenubarItem
       onClick={handleSwitchLibraryMenu}
-      className="text-md h-6 px-3"
+      className="text-md h-6 px-3 whitespace-nowrap"
       disabled={
         !onSwitchLibrary || (!isAppleMusic && !musicKitConfigured)
       }
@@ -835,11 +835,11 @@ export function IpodMenuBar({
         <MenubarContent
           align="start"
           sideOffset={1}
-          className="px-0 max-w-[180px] sm:max-w-[220px]"
+          className="px-0 max-w-[260px] sm:max-w-[280px]"
         >
           <MenubarItem
             onClick={onAddSong}
-            className="text-md h-6 px-3"
+            className="text-md h-6 px-3 whitespace-nowrap"
           >
             {t("apps.ipod.menu.addToLibrary")}
           </MenubarItem>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Long static items in the iPod app's **Library** menu (e.g. `Sign Out of Apple Music…`, `Switch to YouTube Library`) were wrapping to two lines on narrower screens, breaking the menu's row height and looking broken.

### Root cause

`MenubarContent` in the Library menu was constrained to `max-w-[180px] sm:max-w-[220px]`, and the static `MenubarItem`s did not set `whitespace-nowrap`. Once a localized string exceeded the menu's max width, the text wrapped within the `h-6` row.

The same items are also rendered inside the **File** menu, but the File menu has no max-width constraint so they always rendered on one line there.

### Fix

- Bump the Library menu's `MenubarContent` max width to `max-w-[260px] sm:max-w-[280px]` so the longest static items fit on a single line.
- Add `whitespace-nowrap` to the static `MenubarItem`s used in the Library menu (`Add to Library`, `Clear Library`, `Sync Library`, `Refresh Library`, `Sign In/Out of Apple Music…`, `Switch to YouTube Library` / `Switch to Apple Music`) so they never wrap, even when reused elsewhere.

The artist sub-trigger and song items inside `MenubarSubContent` already use the `<span class="truncate min-w-0">` pattern to ellipsize long names, so they remain capped at their existing widths and were left untouched.

## Before

![iPod Library menu showing ](https://cursor.com/artifacts/c/art-a5023a3f-0f53-42ba-8d7a-cdbc9198a6e5)

## Testing

- ✅ `bun run build` — TypeScript compile + Vite build succeeded.
- Per `AGENTS.md` ("For most changes, `bun run build` is sufficient to verify the code compiles correctly"), no manual GUI testing was performed; the change is a small CSS-only fix in a single file.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9212a419-a034-42dd-9483-ec4f30d2e9a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9212a419-a034-42dd-9483-ec4f30d2e9a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

