### PR TITLE
ipod: start new track at 0s when switching songs (most visible on Apple Music)

### DIFF
--- a/src/stores/useIpodStore.ts
+++ b/src/stores/useIpodStore.ts
@@ -770,6 +770,12 @@ export const useIpodStore = create<IpodState>()(
               historyPosition: -1,
               currentLyrics: null, // Clear stale lyrics from previous song
               currentFuriganaMap: null, // Clear stale furigana from previous song
+              // Snap playback position to the start of the new track so any
+              // player wired to `elapsedTime` (e.g. AppleMusicPlayerBridge's
+              // `resumeAtSeconds`) doesn't carry the previous song's offset
+              // into the new song.
+              elapsedTime: 0,
+              totalTime: 0,
             };
           }
           return {};
@@ -943,6 +949,7 @@ export const useIpodStore = create<IpodState>()(
                 currentLyrics: isSameTrack ? state.currentLyrics : null,
                 currentFuriganaMap: isSameTrack ? state.currentFuriganaMap : null,
                 isPlaying: false,
+                ...(isSameTrack ? {} : { elapsedTime: 0, totalTime: 0 }),
               };
             }
             nextSongId = state.tracks[nextIndex]?.id ?? null;
@@ -956,6 +963,9 @@ export const useIpodStore = create<IpodState>()(
             isPlaying: true,
             playbackHistory: newPlaybackHistory,
             historyPosition: -1, // Always reset to end when moving forward
+            // Reset playback position so the new track starts at 0 instead
+            // of inheriting the previous track's elapsedTime.
+            ...(isSameTrack ? {} : { elapsedTime: 0, totalTime: 0 }),
           };
         }),
       previousTrack: () =>
@@ -997,14 +1007,17 @@ export const useIpodStore = create<IpodState>()(
             prevSongId = state.tracks[prevIndex]?.id ?? null;
           }
 
+          const isSameTrack = prevSongId === state.currentSongId;
           return {
             currentSongId: prevSongId,
-            currentLyrics: prevSongId === state.currentSongId ? state.currentLyrics : null,
-            currentFuriganaMap:
-              prevSongId === state.currentSongId ? state.currentFuriganaMap : null,
+            currentLyrics: isSameTrack ? state.currentLyrics : null,
+            currentFuriganaMap: isSameTrack ? state.currentFuriganaMap : null,
             isPlaying: true,
             playbackHistory: newPlaybackHistory,
             historyPosition: -1,
+            // Reset playback position so the new track starts at 0 instead
+            // of inheriting the previous track's elapsedTime.
+            ...(isSameTrack ? {} : { elapsedTime: 0, totalTime: 0 }),
           };
         }),
       setShowVideo: (show) => set({ showVideo: show }),
@@ -1895,10 +1908,13 @@ export const useIpodStore = create<IpodState>()(
                 ? 0
                 : (currentIndex + 1) % queueTracks.length;
             if (!state.loopAll && nextIndex === 0 && currentIndex !== -1) {
+              const lastSongId =
+                queueTracks[queueTracks.length - 1]?.id ?? null;
+              const isSameTrack = lastSongId === state.appleMusicCurrentSongId;
               return {
-                appleMusicCurrentSongId:
-                  queueTracks[queueTracks.length - 1]?.id ?? null,
+                appleMusicCurrentSongId: lastSongId,
                 isPlaying: false,
+                ...(isSameTrack ? {} : { elapsedTime: 0, totalTime: 0 }),
               };
             }
             nextSongId = queueTracks[nextIndex]?.id ?? null;
@@ -1910,6 +1926,12 @@ export const useIpodStore = create<IpodState>()(
             currentLyrics: isSameTrack ? state.currentLyrics : null,
             currentFuriganaMap: isSameTrack ? state.currentFuriganaMap : null,
             isPlaying: true,
+            // Reset playback position so the new track starts at 0 instead
+            // of inheriting the previous track's elapsedTime — otherwise the
+            // AppleMusicPlayerBridge resumes the new song from the previous
+            // song's current time (visible as a mid-song start in Apple
+            // Music mode).
+            ...(isSameTrack ? {} : { elapsedTime: 0, totalTime: 0 }),
           };
         }),
       appleMusicPreviousTrack: () =>
@@ -1947,6 +1969,9 @@ export const useIpodStore = create<IpodState>()(
             currentLyrics: isSameTrack ? state.currentLyrics : null,
             currentFuriganaMap: isSameTrack ? state.currentFuriganaMap : null,
             isPlaying: true,
+            // Reset playback position so the new track starts at 0 instead
+            // of inheriting the previous track's elapsedTime.
+            ...(isSameTrack ? {} : { elapsedTime: 0, totalTime: 0 }),
           };
         }),
       setAppleMusicStorefrontId: (storefrontId) =>

--- a/tests/test-ipod-apple-music.test.ts
+++ b/tests/test-ipod-apple-music.test.ts
@@ -255,6 +255,60 @@ describe("useIpodStore Apple Music slice", () => {
     expect(state.appleMusicCurrentSongId).toBe("am:playlist");
   });
 
+  test("appleMusicNextTrack resets elapsedTime/totalTime so the new track starts at 0", () => {
+    useIpodStore.getState().setAppleMusicTracks([
+      { id: "am:1", url: "applemusic:1", title: "One", source: "appleMusic" },
+      { id: "am:2", url: "applemusic:2", title: "Two", source: "appleMusic" },
+    ]);
+    useIpodStore.setState({ loopAll: true, isShuffled: false });
+    useIpodStore.getState().setAppleMusicCurrentSongId("am:1");
+    // Simulate the previous song being mid-playback.
+    useIpodStore.setState({ elapsedTime: 95, totalTime: 240 });
+
+    useIpodStore.getState().appleMusicNextTrack();
+
+    const state = useIpodStore.getState();
+    expect(state.appleMusicCurrentSongId).toBe("am:2");
+    expect(state.elapsedTime).toBe(0);
+    expect(state.totalTime).toBe(0);
+  });
+
+  test("appleMusicPreviousTrack resets elapsedTime/totalTime so the new track starts at 0", () => {
+    useIpodStore.getState().setAppleMusicTracks([
+      { id: "am:1", url: "applemusic:1", title: "One", source: "appleMusic" },
+      { id: "am:2", url: "applemusic:2", title: "Two", source: "appleMusic" },
+    ]);
+    useIpodStore.setState({ isShuffled: false });
+    useIpodStore.getState().setAppleMusicCurrentSongId("am:2");
+    useIpodStore.setState({ elapsedTime: 60, totalTime: 180 });
+
+    useIpodStore.getState().appleMusicPreviousTrack();
+
+    const state = useIpodStore.getState();
+    expect(state.appleMusicCurrentSongId).toBe("am:1");
+    expect(state.elapsedTime).toBe(0);
+    expect(state.totalTime).toBe(0);
+  });
+
+  test("appleMusicNextTrack at end of queue without loopAll preserves elapsedTime when staying on the last track", () => {
+    useIpodStore.getState().setAppleMusicTracks([
+      { id: "am:1", url: "applemusic:1", title: "One", source: "appleMusic" },
+      { id: "am:2", url: "applemusic:2", title: "Two", source: "appleMusic" },
+    ]);
+    useIpodStore.setState({ loopAll: false, isShuffled: false });
+    useIpodStore.getState().setAppleMusicCurrentSongId("am:2");
+    useIpodStore.setState({ elapsedTime: 30, totalTime: 200 });
+
+    useIpodStore.getState().appleMusicNextTrack();
+
+    const state = useIpodStore.getState();
+    expect(state.appleMusicCurrentSongId).toBe("am:2");
+    expect(state.isPlaying).toBe(false);
+    // Same track ⇒ don't reset position; we only stop playback.
+    expect(state.elapsedTime).toBe(30);
+    expect(state.totalTime).toBe(200);
+  });
+
   test("appleMusicNextTrack stays inside the contextual queue after a library refresh", () => {
     useIpodStore.setState({
       appleMusicTracks: [


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

When switching songs in the iPod app, the previous song's elapsed time was carried over and used as the new song's start position. The bug was most apparent on **Apple Music** mode because `AppleMusicPlayerBridge` passes `startTime: resumeAtSeconds` to `MusicKit.setQueue()`, so the next song would audibly begin partway through (e.g. switching while song A was at 1:30 caused song B to start at 1:30).

## Root cause

`appleMusicNextTrack`, `appleMusicPreviousTrack`, `setCurrentSongId`, `nextTrack`, and `previousTrack` all updated the current-song id without resetting `elapsedTime` / `totalTime`. There is a `useEffect` in `useIpodLogic.ts` that tries to reset `elapsedTime` to 0 on `currentIndex` change, but **child effects run before parent effects** in React, so `AppleMusicPlayerBridge`'s `setQueue` effect fires first with the stale `resumeAtSeconds` value, queueing the new song to start at the previous song's playback time. The store-level `setAppleMusicCurrentSongId` already did this correctly (mid-song-switch via search/menu was fine) — only the next/previous paths were broken.

## Fix

Reset `elapsedTime` and `totalTime` to `0` inside the same `set()` call that flips the song id, mirroring what `setAppleMusicCurrentSongId` already does. This makes the reset synchronous with the song change — by the time the bridge re-renders with the new `currentTrack`, `resumeAtSeconds` is already `0`.

Position is preserved (not zeroed) when the action keeps the same track:
- `loopCurrent` + next/previous (stays on current track)
- End of playlist with `loopAll` off (stays on last track and pauses)

Applied to all five affected store actions (Apple Music + YouTube) for consistency.

## Files changed

- `src/stores/useIpodStore.ts` — reset `elapsedTime`/`totalTime` in track-change actions
- `tests/test-ipod-apple-music.test.ts` — regression tests for next/previous and the same-track edge case

## Testing

- `bun test tests/test-ipod-apple-music.test.ts` — 17 pass (incl. 3 new regression tests)
- `bun run test:unit` — 179 pass
- `bun run build` — clean
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-27447868-ce2e-42c6-99c5-8d75f1dffa17"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-27447868-ce2e-42c6-99c5-8d75f1dffa17"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

