### PR TITLE
ipod: opportunistic Apple Music refresh + SWR-on-open + auto-update Recently Added & Favorites

### DIFF
--- a/src/apps/ipod/hooks/useAppleMusicLibrary.ts
+++ b/src/apps/ipod/hooks/useAppleMusicLibrary.ts
@@ -754,6 +754,136 @@ export async function refreshStaleAppleMusicPlaylistTracks(
   await Promise.all(workers);
 }
 
+let inFlightRecentlyAddedRefresh: Promise<Track[]> | null = null;
+let inFlightFavoritesRefresh: Promise<Track[]> | null = null;
+
+/**
+ * Refresh the "Recently Added" track collection in the background and
+ * mirror the result into the store. Mirrors `refreshAppleMusicPlaylists`
+ * for the menu-collection case so the menu can render cached content
+ * while a fresh fetch updates the store in-place when it finishes.
+ *
+ * `fetchAppleMusicRecentlyAddedTracks` already implements the cache /
+ * defensive empty-result logic (a flaky API returning 0 tracks won't
+ * wipe the cached collection), so this wrapper just adds the in-flight
+ * de-dup, the loading flag, and the store write.
+ *
+ * Playback safety: only `appleMusicRecentlyAddedTracks` is mutated. The
+ * AppleMusicPlayerBridge keys playback on `currentTrack.id` and the
+ * playback queue stores ids, so swapping this list while a track from
+ * it is playing keeps audio uninterrupted.
+ */
+export async function refreshAppleMusicRecentlyAdded(
+  options: { force?: boolean } = {}
+): Promise<Track[]> {
+  const store = useIpodStore.getState();
+
+  if (!options.force) {
+    const loadedAt = store.appleMusicRecentlyAddedLoadedAt;
+    const ageMs = loadedAt ? Date.now() - loadedAt : Infinity;
+    if (
+      store.appleMusicRecentlyAddedTracks.length > 0 &&
+      ageMs < APPLE_MUSIC_PLAYLIST_TRACKS_OPPORTUNISTIC_TTL_MS
+    ) {
+      return store.appleMusicRecentlyAddedTracks;
+    }
+  }
+
+  if (inFlightRecentlyAddedRefresh) return inFlightRecentlyAddedRefresh;
+
+  const instance = getMusicKitInstance();
+  if (!instance || !instance.isAuthorized) {
+    return store.appleMusicRecentlyAddedTracks;
+  }
+
+  // Only flip the loading flag when there's nothing to display yet — a
+  // background refresh of an existing list should not flash "Loading…".
+  const hadCached = store.appleMusicRecentlyAddedTracks.length > 0;
+  if (!hadCached) {
+    store.setAppleMusicRecentlyAddedLoading(true);
+  }
+
+  inFlightRecentlyAddedRefresh = (async () => {
+    try {
+      const tracks = await fetchAppleMusicRecentlyAddedTracks({ force: true });
+      const existing = useIpodStore.getState().appleMusicRecentlyAddedTracks;
+      if (tracks.length === 0 && existing.length > 0) {
+        // The fetcher's defensive guard already returns the cached array
+        // in this case, but keep the second check here so the store
+        // never gets flipped to an empty array on a flaky refresh.
+        return existing;
+      }
+      useIpodStore
+        .getState()
+        .setAppleMusicRecentlyAddedTracks(tracks, Date.now());
+      return tracks;
+    } finally {
+      inFlightRecentlyAddedRefresh = null;
+      if (!hadCached) {
+        useIpodStore.getState().setAppleMusicRecentlyAddedLoading(false);
+      }
+    }
+  })();
+
+  return inFlightRecentlyAddedRefresh;
+}
+
+/**
+ * Refresh the "Favorite Songs" track collection in the background and
+ * mirror the result into the store. See `refreshAppleMusicRecentlyAdded`
+ * for the rationale and playback-safety notes — the only difference is
+ * which IndexedDB collection key + store slot is updated.
+ */
+export async function refreshAppleMusicFavorites(
+  options: { force?: boolean } = {}
+): Promise<Track[]> {
+  const store = useIpodStore.getState();
+
+  if (!options.force) {
+    const loadedAt = store.appleMusicFavoriteTracksLoadedAt;
+    const ageMs = loadedAt ? Date.now() - loadedAt : Infinity;
+    if (
+      store.appleMusicFavoriteTracks.length > 0 &&
+      ageMs < APPLE_MUSIC_PLAYLIST_TRACKS_OPPORTUNISTIC_TTL_MS
+    ) {
+      return store.appleMusicFavoriteTracks;
+    }
+  }
+
+  if (inFlightFavoritesRefresh) return inFlightFavoritesRefresh;
+
+  const instance = getMusicKitInstance();
+  if (!instance || !instance.isAuthorized) {
+    return store.appleMusicFavoriteTracks;
+  }
+
+  const hadCached = store.appleMusicFavoriteTracks.length > 0;
+  if (!hadCached) {
+    store.setAppleMusicFavoritesLoading(true);
+  }
+
+  inFlightFavoritesRefresh = (async () => {
+    try {
+      const tracks = await fetchAppleMusicFavoriteSongTracks({ force: true });
+      const existing = useIpodStore.getState().appleMusicFavoriteTracks;
+      if (tracks.length === 0 && existing.length > 0) {
+        return existing;
+      }
+      useIpodStore
+        .getState()
+        .setAppleMusicFavoriteTracks(tracks, Date.now());
+      return tracks;
+    } finally {
+      inFlightFavoritesRefresh = null;
+      if (!hadCached) {
+        useIpodStore.getState().setAppleMusicFavoritesLoading(false);
+      }
+    }
+  })();
+
+  return inFlightFavoritesRefresh;
+}
+
 /**
  * Fetch the user's full Apple Music library and write the result into the
  * store. Resolves with the number of tracks loaded; rejects when MusicKit
@@ -1137,6 +1267,48 @@ export function useAppleMusicLibrary({
             });
           }
         }
+
+        // Recently Added & Favorites (each persisted under its own
+        // IndexedDB key by `saveAppleMusicTrackCollection`). Hydrating
+        // here means the menu shows cached entries instantly on iPod
+        // open instead of flashing "Loading…" while the lazy menu-open
+        // fetcher runs.
+        if (
+          useIpodStore.getState().appleMusicRecentlyAddedTracks.length === 0
+        ) {
+          const cached = await loadAppleMusicTrackCollection(
+            "recently-added"
+          );
+          if (cancelled) return;
+          if (
+            cached &&
+            cached.tracks.length > 0 &&
+            useIpodStore.getState().appleMusicRecentlyAddedTracks.length === 0
+          ) {
+            useIpodStore
+              .getState()
+              .setAppleMusicRecentlyAddedTracks(
+                cached.tracks,
+                cached.loadedAt
+              );
+          }
+        }
+
+        if (useIpodStore.getState().appleMusicFavoriteTracks.length === 0) {
+          const cached = await loadAppleMusicTrackCollection(
+            "favorite-songs"
+          );
+          if (cancelled) return;
+          if (
+            cached &&
+            cached.tracks.length > 0 &&
+            useIpodStore.getState().appleMusicFavoriteTracks.length === 0
+          ) {
+            useIpodStore
+              .getState()
+              .setAppleMusicFavoriteTracks(cached.tracks, cached.loadedAt);
+          }
+        }
       } finally {
         inFlight = false;
       }
@@ -1294,6 +1466,15 @@ export function useAppleMusicLibrary({
         await refreshAppleMusicPlaylists();
         if (cancelled) return;
         await refreshStaleAppleMusicPlaylistTracks();
+        if (cancelled) return;
+        // Recently Added and Favorites have their own freshness windows
+        // (handled inside each helper). Run them in parallel since they
+        // hit separate Apple Music endpoints and don't share the same
+        // in-flight guard.
+        await Promise.allSettled([
+          refreshAppleMusicRecentlyAdded(),
+          refreshAppleMusicFavorites(),
+        ]);
       } catch (err) {
         // Each helper handles its own per-call errors; a top-level
         // failure here would be unexpected (e.g. MusicKit instance went

--- a/src/apps/ipod/hooks/useAppleMusicLibrary.ts
+++ b/src/apps/ipod/hooks/useAppleMusicLibrary.ts
@@ -607,6 +607,154 @@ async function fetchAppleMusicPlaylistsList(): Promise<AppleMusicPlaylist[]> {
 }
 
 /**
+ * Opportunistic background refresh for the playlist list and per-playlist
+ * tracks. Tighter than the 24h library SWR window because both are cheap
+ * (one paginated call for the list, one per cached playlist) and the user
+ * notices "I added a playlist on my phone but it's not on the iPod" much
+ * faster than they notice missing songs.
+ */
+export const APPLE_MUSIC_PLAYLISTS_OPPORTUNISTIC_TTL_MS = 15 * 60 * 1000; // 15 min
+export const APPLE_MUSIC_PLAYLIST_TRACKS_OPPORTUNISTIC_TTL_MS =
+  60 * 60 * 1000; // 1h
+
+let inFlightPlaylistsRefresh: Promise<AppleMusicPlaylist[]> | null = null;
+
+/**
+ * Refresh the Apple Music playlist list in the background and write the
+ * result to the store + IndexedDB. Safe to call from anywhere — the
+ * promise is shared across concurrent callers, and the function returns
+ * the cached list immediately when the user is unauthorized or MusicKit
+ * isn't ready (no error is thrown so opportunistic callers don't need to
+ * try/catch).
+ *
+ * Playback is unaffected: only `appleMusicPlaylists` /
+ * `appleMusicPlaylistsLoadedAt` are mutated, neither of which feeds the
+ * MusicKit player. The defensive empty-result check mirrors the library
+ * fetcher so a flaky network response can't wipe the cached list.
+ */
+export async function refreshAppleMusicPlaylists(
+  options: { force?: boolean } = {}
+): Promise<AppleMusicPlaylist[]> {
+  const store = useIpodStore.getState();
+
+  if (!options.force) {
+    const loadedAt = store.appleMusicPlaylistsLoadedAt;
+    const ageMs = loadedAt ? Date.now() - loadedAt : Infinity;
+    if (
+      store.appleMusicPlaylists.length > 0 &&
+      ageMs < APPLE_MUSIC_PLAYLISTS_OPPORTUNISTIC_TTL_MS
+    ) {
+      return store.appleMusicPlaylists;
+    }
+  }
+
+  if (inFlightPlaylistsRefresh) return inFlightPlaylistsRefresh;
+
+  const instance = getMusicKitInstance();
+  if (!instance || !instance.isAuthorized) {
+    return store.appleMusicPlaylists;
+  }
+
+  inFlightPlaylistsRefresh = (async () => {
+    try {
+      const playlists = await fetchAppleMusicPlaylistsList();
+      const existing = useIpodStore.getState().appleMusicPlaylists;
+      // Defensive: never overwrite a non-empty cached list with an empty
+      // refresh result. Apple Music occasionally returns 0 playlists when
+      // a token is mid-rotation; preserving the cached list keeps the
+      // menu populated.
+      if (playlists.length === 0 && existing.length > 0) {
+        console.warn(
+          "[apple music] playlist refresh returned 0; keeping cached list"
+        );
+        return existing;
+      }
+      const loadedAt = Date.now();
+      useIpodStore.getState().setAppleMusicPlaylists(playlists, loadedAt);
+      void saveAppleMusicPlaylists({ playlists, loadedAt });
+      return playlists;
+    } finally {
+      inFlightPlaylistsRefresh = null;
+    }
+  })();
+
+  return inFlightPlaylistsRefresh;
+}
+
+const inFlightPlaylistTracksRefresh = new Set<string>();
+
+/**
+ * Refresh stale tracks for every playlist that currently has a cached
+ * copy in memory or IndexedDB. Iterates with bounded concurrency so a
+ * user with 50 cached playlists doesn't fire 50 simultaneous Apple Music
+ * requests on iPod open.
+ *
+ * Playback safety: each refresh uses
+ * `setAppleMusicPlaylistTracks(playlistId, ...)`, which only mutates the
+ * per-playlist track map. The active playback queue (`appleMusicPlaybackQueue`)
+ * stores track ids, not direct references into the playlist tracks map, so
+ * updating a playlist's contents while a track from it is playing does not
+ * affect the running queue.
+ *
+ * Unlike `refreshAppleMusicPlaylists`, this function is fire-and-forget
+ * by design — failures per playlist are logged but never thrown.
+ */
+export async function refreshStaleAppleMusicPlaylistTracks(
+  options: { force?: boolean; concurrency?: number } = {}
+): Promise<void> {
+  const instance = getMusicKitInstance();
+  if (!instance || !instance.isAuthorized) return;
+
+  const state = useIpodStore.getState();
+  const loadedAtMap = state.appleMusicPlaylistTracksLoadedAt;
+  const playlistIds = Object.keys(loadedAtMap);
+  if (playlistIds.length === 0) return;
+
+  const stalePlaylistIds = options.force
+    ? playlistIds
+    : playlistIds.filter((id) => {
+        const loadedAt = loadedAtMap[id];
+        if (!loadedAt) return true;
+        return (
+          Date.now() - loadedAt >=
+          APPLE_MUSIC_PLAYLIST_TRACKS_OPPORTUNISTIC_TTL_MS
+        );
+      });
+  if (stalePlaylistIds.length === 0) return;
+
+  const queue = stalePlaylistIds.filter(
+    (id) => !inFlightPlaylistTracksRefresh.has(id)
+  );
+  if (queue.length === 0) return;
+
+  const concurrency = Math.max(1, options.concurrency ?? 2);
+  const workers: Promise<void>[] = [];
+  for (let i = 0; i < concurrency; i++) {
+    workers.push(
+      (async () => {
+        while (queue.length > 0) {
+          const id = queue.shift();
+          if (!id) break;
+          inFlightPlaylistTracksRefresh.add(id);
+          try {
+            await fetchAppleMusicPlaylistTracks(id, { force: true });
+          } catch (err) {
+            console.warn(
+              `[apple music] background refresh of playlist ${id} failed`,
+              err
+            );
+          } finally {
+            inFlightPlaylistTracksRefresh.delete(id);
+          }
+        }
+      })()
+    );
+  }
+
+  await Promise.all(workers);
+}
+
+/**
  * Fetch the user's full Apple Music library and write the result into the
  * store. Resolves with the number of tracks loaded; rejects when MusicKit
  * is unavailable / the user is not authorized.
@@ -685,17 +833,11 @@ export async function fetchAppleMusicLibrary(
     }
 
     try {
-      const playlists = await fetchAppleMusicPlaylistsList();
-      const existingPlaylists = useIpodStore.getState().appleMusicPlaylists;
-      if (playlists.length === 0 && existingPlaylists.length > 0) {
-        console.warn(
-          "[apple music] playlist refresh returned 0; keeping cached list"
-        );
-      } else {
-        const loadedAt = Date.now();
-        store.setAppleMusicPlaylists(playlists);
-        void saveAppleMusicPlaylists({ playlists, loadedAt });
-      }
+      // Run via the standalone helper so the same in-flight de-dup,
+      // defensive empty-result guard, and cache write applies whether the
+      // refresh came from a full library fetch or the opportunistic
+      // background path.
+      await refreshAppleMusicPlaylists({ force: true });
     } catch (err) {
       console.warn("[apple music] playlist sync failed (songs kept)", err);
     }
@@ -960,6 +1102,10 @@ export function useAppleMusicLibrary({
           ) {
             useIpodStore.setState({
               appleMusicPlaylists: cachedPlaylists.playlists,
+              // Mirror the cached freshness timestamp so the opportunistic
+              // background refresh below treats this entry as a real
+              // (possibly stale) cache instead of "never synced".
+              appleMusicPlaylistsLoadedAt: cachedPlaylists.loadedAt,
             });
           }
         }
@@ -1102,6 +1248,96 @@ export function useAppleMusicLibrary({
   useEffect(() => {
     if (!isAuthorized) hasLoadedRef.current = false;
   }, [isAuthorized]);
+
+  // Opportunistic background refresh of the playlists list and per-playlist
+  // tracks.
+  //
+  // The full library fetcher above only re-fetches when the library is
+  // older than 24h, and per-playlist tracks were only refreshed when the
+  // user explicitly opened that playlist. So a user who plays the iPod
+  // every day for a month and never reopens a playlist would see month-old
+  // playlist contents.
+  //
+  // This effect closes that gap by:
+  //   1. Running once a few seconds after the hook becomes enabled+authed
+  //      (hydration has had time to seed the in-memory store first).
+  //   2. Re-running whenever the document becomes visible (fast path for
+  //      "user came back to the tab").
+  //   3. Polling on a 15-min timer while the iPod is open as a backstop
+  //      for long-lived sessions.
+  //
+  // All paths are silent (no toast). The refresh helpers themselves
+  // short-circuit when the cache is fresh enough, so this is essentially
+  // free when nothing has actually expired. Track refresh uses bounded
+  // concurrency so a user with many cached playlists doesn't hammer the
+  // Apple Music API on every visibility change.
+  //
+  // Playback is unaffected: only the playlists list and per-playlist
+  // tracks map are mutated, neither of which is read by the
+  // AppleMusicPlayerBridge. The active queue stores ids, so swapping a
+  // playlist's tracks while one of them is playing keeps playback going.
+  useEffect(() => {
+    if (!enabled || !isAuthorized) return;
+
+    let cancelled = false;
+    let lastRunAt = 0;
+    const MIN_INTERVAL_MS = 60 * 1000; // throttle visibility-driven calls
+    const POLL_INTERVAL_MS = 15 * 60 * 1000;
+
+    const runOpportunisticRefresh = async () => {
+      if (cancelled) return;
+      if (typeof document !== "undefined" && document.hidden) return;
+      const now = Date.now();
+      if (now - lastRunAt < MIN_INTERVAL_MS) return;
+      lastRunAt = now;
+      try {
+        await refreshAppleMusicPlaylists();
+        if (cancelled) return;
+        await refreshStaleAppleMusicPlaylistTracks();
+      } catch (err) {
+        // Each helper handles its own per-call errors; a top-level
+        // failure here would be unexpected (e.g. MusicKit instance went
+        // away mid-refresh). Log + swallow so opportunistic background
+        // work never bubbles into the UI.
+        console.warn(
+          "[apple music] opportunistic playlist refresh failed",
+          err
+        );
+      }
+    };
+
+    // Give hydration + the cold-load decision a head start before kicking
+    // off the first opportunistic pass — there's no point fetching
+    // playlists in the background while the foreground library load is
+    // still mid-flight.
+    const initialTimeout = setTimeout(() => {
+      void runOpportunisticRefresh();
+    }, 3000);
+
+    const interval = setInterval(() => {
+      void runOpportunisticRefresh();
+    }, POLL_INTERVAL_MS);
+
+    const onVisibilityChange = () => {
+      if (typeof document === "undefined" || document.hidden) return;
+      void runOpportunisticRefresh();
+    };
+    if (typeof document !== "undefined") {
+      document.addEventListener("visibilitychange", onVisibilityChange);
+    }
+
+    return () => {
+      cancelled = true;
+      clearTimeout(initialTimeout);
+      clearInterval(interval);
+      if (typeof document !== "undefined") {
+        document.removeEventListener(
+          "visibilitychange",
+          onVisibilityChange
+        );
+      }
+    };
+  }, [enabled, isAuthorized]);
 
   return { refresh };
 }

--- a/src/apps/ipod/hooks/useIpodLogic.ts
+++ b/src/apps/ipod/hooks/useIpodLogic.ts
@@ -799,6 +799,7 @@ export function useIpodLogic({
     useIpodStore.getState().setAppleMusicTracks([]);
     useIpodStore.setState({
       appleMusicPlaylists: [],
+      appleMusicPlaylistsLoadedAt: null,
       appleMusicPlaylistTracks: {},
       appleMusicPlaylistTracksLoadedAt: {},
       appleMusicPlaylistTracksLoading: {},

--- a/src/apps/ipod/hooks/useIpodLogic.ts
+++ b/src/apps/ipod/hooks/useIpodLogic.ts
@@ -16,12 +16,11 @@ import { useLibraryUpdateChecker } from "./useLibraryUpdateChecker";
 import {
   useAppleMusicLibrary,
   fetchAppleMusicPlaylistTracks,
-  fetchAppleMusicFavoriteSongTracks,
-  fetchAppleMusicRecentlyAddedTracks,
+  refreshAppleMusicRecentlyAdded,
+  refreshAppleMusicFavorites,
   searchAppleMusicTracks,
   addAppleMusicTrackToFavorites,
   cacheAppleMusicFavoriteSongTrack,
-  APPLE_MUSIC_LIBRARY_STALE_AFTER_MS,
   type AppleMusicSearchScope,
 } from "./useAppleMusicLibrary";
 import { useMusicKit } from "@/hooks/useMusicKit";
@@ -353,14 +352,23 @@ export function useIpodLogic({
   const [isSongSearchDialogOpen, setIsSongSearchDialogOpen] = useState(false);
   const [isSyncModeOpen, setIsSyncModeOpen] = useState(false);
   const [isAddingSong, setIsAddingSong] = useState(false);
-  const [appleMusicRecentlyAddedTracks, setAppleMusicRecentlyAddedTracks] =
-    useState<Track[]>([]);
-  const [isAppleMusicRecentlyAddedLoading, setIsAppleMusicRecentlyAddedLoading] =
-    useState(false);
-  const [appleMusicFavoriteTracks, setAppleMusicFavoriteTracks] =
-    useState<Track[]>([]);
-  const [isAppleMusicFavoritesLoading, setIsAppleMusicFavoritesLoading] =
-    useState(false);
+  // Recently Added + Favorites moved into the global iPod store (mirrored
+  // from IndexedDB on iPod open) so the opportunistic refresh path in
+  // `useAppleMusicLibrary` can update the same source the menu reads
+  // from. Selectors keep these in sync with the store without forcing a
+  // re-render of the entire hook on unrelated state changes.
+  const appleMusicRecentlyAddedTracks = useIpodStore(
+    (s) => s.appleMusicRecentlyAddedTracks
+  );
+  const isAppleMusicRecentlyAddedLoading = useIpodStore(
+    (s) => s.appleMusicRecentlyAddedLoading
+  );
+  const appleMusicFavoriteTracks = useIpodStore(
+    (s) => s.appleMusicFavoriteTracks
+  );
+  const isAppleMusicFavoritesLoading = useIpodStore(
+    (s) => s.appleMusicFavoritesLoading
+  );
   
   // Cover Flow state
   const [isCoverFlowOpen, setIsCoverFlowOpen] = useState(false);
@@ -749,23 +757,22 @@ export function useIpodLogic({
   );
 
   const requestPlaylistTracksIfNeeded = useCallback((playlistId: string) => {
-    const state = useIpodStore.getState();
-    const loadedAt = state.appleMusicPlaylistTracksLoadedAt[playlistId];
-    const ageMs = loadedAt ? Date.now() - loadedAt : Infinity;
-    const hasTracks =
-      (state.appleMusicPlaylistTracks[playlistId]?.length ?? 0) > 0;
-    const isStale = ageMs >= APPLE_MUSIC_LIBRARY_STALE_AFTER_MS;
-
-    if (!hasTracks || isStale) {
-      void fetchAppleMusicPlaylistTracks(playlistId, {
-        force: isStale && hasTracks,
-      }).catch((err) => {
+    // Always trigger a background refresh on playlist open. The fetcher
+    // dedupes in-flight calls via `appleMusicPlaylistTracksLoading`, and
+    // the menu builder gates "Loading…" behind
+    // `playlistTracks.length === 0`, so cached tracks render
+    // immediately while the refresh updates them in place. This gives
+    // users a true SWR experience: opening a playlist shows cached
+    // contents instantly AND silently picks up any new songs added
+    // since the last view.
+    void fetchAppleMusicPlaylistTracks(playlistId, { force: true }).catch(
+      (err) => {
         console.warn(
           `[apple music] failed to load playlist tracks for ${playlistId}`,
           err
         );
-      });
-    }
+      }
+    );
   }, []);
 
   // -------------------------------------------------------------------
@@ -803,6 +810,12 @@ export function useIpodLogic({
       appleMusicPlaylistTracks: {},
       appleMusicPlaylistTracksLoadedAt: {},
       appleMusicPlaylistTracksLoading: {},
+      appleMusicRecentlyAddedTracks: [],
+      appleMusicRecentlyAddedLoadedAt: null,
+      appleMusicRecentlyAddedLoading: false,
+      appleMusicFavoriteTracks: [],
+      appleMusicFavoriteTracksLoadedAt: null,
+      appleMusicFavoritesLoading: false,
       appleMusicPlaybackQueue: null,
     });
     // Drop the IndexedDB-cached library so a different user signing
@@ -873,69 +886,77 @@ export function useIpodLogic({
     [mergeAppleMusicTracks, setIsPlaying, showStatus, t]
   );
 
+  // Open the "Recently Added" menu.
+  //
+  // Reads cached tracks straight from the store (already populated via
+  // the IndexedDB hydration in `useAppleMusicLibrary`) and kicks off a
+  // background refresh that updates the store in-place when it
+  // resolves. The menu builder gates "Loading…" on cache emptiness, so
+  // the only time the user sees the placeholder is the very first
+  // load — every subsequent open shows cached entries instantly while
+  // the refresh runs invisibly.
   const loadAppleMusicRecentlyAdded = useCallback(async () => {
     if (!appleMusicAuthorized) {
       void handleAppleMusicSignIn();
       return;
     }
-    if (isAppleMusicRecentlyAddedLoading) return;
-    setIsAppleMusicRecentlyAddedLoading(true);
     try {
-      const recentTracks = await fetchAppleMusicRecentlyAddedTracks();
-      setAppleMusicRecentlyAddedTracks(recentTracks);
-      mergeAppleMusicTracks(recentTracks);
+      const tracks = await refreshAppleMusicRecentlyAdded({ force: true });
+      mergeAppleMusicTracks(tracks);
     } catch (err) {
-      toast.error(
-        t(
-          "apps.ipod.dialogs.appleMusicRecentlyAddedFailed",
-          "Failed to load recently added songs"
-        ),
-        {
-          description: err instanceof Error ? err.message : String(err),
-        }
-      );
-    } finally {
-      setIsAppleMusicRecentlyAddedLoading(false);
+      // Only surface the toast when there's no cached content to fall
+      // back on — otherwise the user already has a working menu and a
+      // background failure shouldn't pop a UI error.
+      const hasCached =
+        useIpodStore.getState().appleMusicRecentlyAddedTracks.length > 0;
+      if (!hasCached) {
+        toast.error(
+          t(
+            "apps.ipod.dialogs.appleMusicRecentlyAddedFailed",
+            "Failed to load recently added songs"
+          ),
+          {
+            description: err instanceof Error ? err.message : String(err),
+          }
+        );
+      } else {
+        console.warn(
+          "[apple music] recently added refresh failed (using cached collection)",
+          err
+        );
+      }
     }
-  }, [
-    appleMusicAuthorized,
-    handleAppleMusicSignIn,
-    isAppleMusicRecentlyAddedLoading,
-    mergeAppleMusicTracks,
-    t,
-  ]);
+  }, [appleMusicAuthorized, handleAppleMusicSignIn, mergeAppleMusicTracks, t]);
 
   const loadAppleMusicFavorites = useCallback(async () => {
     if (!appleMusicAuthorized) {
       void handleAppleMusicSignIn();
       return;
     }
-    if (isAppleMusicFavoritesLoading) return;
-    setIsAppleMusicFavoritesLoading(true);
     try {
-      const favoriteTracks = await fetchAppleMusicFavoriteSongTracks();
-      setAppleMusicFavoriteTracks(favoriteTracks);
-      mergeAppleMusicTracks(favoriteTracks);
+      const tracks = await refreshAppleMusicFavorites({ force: true });
+      mergeAppleMusicTracks(tracks);
     } catch (err) {
-      toast.error(
-        t(
-          "apps.ipod.dialogs.appleMusicFavoritesFailed",
-          "Failed to load favorite songs"
-        ),
-        {
-          description: err instanceof Error ? err.message : String(err),
-        }
-      );
-    } finally {
-      setIsAppleMusicFavoritesLoading(false);
+      const hasCached =
+        useIpodStore.getState().appleMusicFavoriteTracks.length > 0;
+      if (!hasCached) {
+        toast.error(
+          t(
+            "apps.ipod.dialogs.appleMusicFavoritesFailed",
+            "Failed to load favorite songs"
+          ),
+          {
+            description: err instanceof Error ? err.message : String(err),
+          }
+        );
+      } else {
+        console.warn(
+          "[apple music] favorites refresh failed (using cached collection)",
+          err
+        );
+      }
     }
-  }, [
-    appleMusicAuthorized,
-    handleAppleMusicSignIn,
-    isAppleMusicFavoritesLoading,
-    mergeAppleMusicTracks,
-    t,
-  ]);
+  }, [appleMusicAuthorized, handleAppleMusicSignIn, mergeAppleMusicTracks, t]);
 
   const handleAppleMusicAddToFavorites = useCallback(async () => {
     registerActivity();
@@ -946,10 +967,11 @@ export function useIpodLogic({
     if (!track) return;
     try {
       await addAppleMusicTrackToFavorites(track);
-      setAppleMusicFavoriteTracks((existingTracks) => [
-        track,
-        ...existingTracks.filter((candidate) => candidate.id !== track.id),
-      ]);
+      // Optimistically update the store + IndexedDB. We don't bump the
+      // freshness timestamp here so the next opportunistic refresh
+      // still revalidates against the server (which catches the eventual
+      // catalog ↔ library mapping for this favorite).
+      useIpodStore.getState().prependAppleMusicFavoriteTrack(track);
       void cacheAppleMusicFavoriteSongTrack(track);
       showStatus(
         t("apps.ipod.status.appleMusicAddedToFavorites", "Added to Favorites")

--- a/src/stores/useIpodStore.ts
+++ b/src/stores/useIpodStore.ts
@@ -157,6 +157,22 @@ interface IpodData {
   appleMusicPlaylistTracksLoadedAt: Record<string, number>;
   /** Per-playlist in-flight fetch flags. */
   appleMusicPlaylistTracksLoading: Record<string, boolean>;
+  /**
+   * Tracks shown in the "Recently Added" menu, mirrored from IndexedDB
+   * so the menu can render cached content immediately on iPod open and
+   * the opportunistic refresh path in `useAppleMusicLibrary` can update
+   * the same source other consumers read from.
+   */
+  appleMusicRecentlyAddedTracks: Track[];
+  /** Last sync timestamp for `appleMusicRecentlyAddedTracks`. */
+  appleMusicRecentlyAddedLoadedAt: number | null;
+  /** True while a Recently Added refresh is in flight (drives the
+   *  one-time "Loading…" placeholder when the cache is empty). */
+  appleMusicRecentlyAddedLoading: boolean;
+  /** Tracks shown in the "Favorite Songs" menu (same shape as above). */
+  appleMusicFavoriteTracks: Track[];
+  appleMusicFavoriteTracksLoadedAt: number | null;
+  appleMusicFavoritesLoading: boolean;
   /** Currently selected song id within the Apple Music library. */
   appleMusicCurrentSongId: string | null;
   /**
@@ -338,6 +354,12 @@ const initialIpodData: IpodData = {
   appleMusicPlaylistTracks: {},
   appleMusicPlaylistTracksLoadedAt: {},
   appleMusicPlaylistTracksLoading: {},
+  appleMusicRecentlyAddedTracks: [],
+  appleMusicRecentlyAddedLoadedAt: null,
+  appleMusicRecentlyAddedLoading: false,
+  appleMusicFavoriteTracks: [],
+  appleMusicFavoriteTracksLoadedAt: null,
+  appleMusicFavoritesLoading: false,
   appleMusicCurrentSongId: null,
   appleMusicPlaybackQueue: null,
   appleMusicLibraryLoadedAt: null,
@@ -472,6 +494,29 @@ export interface IpodState extends IpodData {
     playlistId: string,
     loading: boolean
   ) => void;
+  /**
+   * Replace the cached "Recently Added" track list. When `loadedAt` is
+   * omitted, the freshness timestamp is set to `Date.now()`. Pass an
+   * explicit value when hydrating from IndexedDB.
+   */
+  setAppleMusicRecentlyAddedTracks: (
+    tracks: Track[],
+    loadedAt?: number | null
+  ) => void;
+  setAppleMusicRecentlyAddedLoading: (loading: boolean) => void;
+  /** Same as the Recently Added setters, but for "Favorite Songs". */
+  setAppleMusicFavoriteTracks: (
+    tracks: Track[],
+    loadedAt?: number | null
+  ) => void;
+  setAppleMusicFavoritesLoading: (loading: boolean) => void;
+  /**
+   * Optimistically prepend a track to the favorites list (used right
+   * after `addAppleMusicTrackToFavorites` succeeds). Doesn't bump
+   * `loadedAt` so the next opportunistic refresh still revalidates
+   * against the server (catches the eventual catalog ↔ library mapping).
+   */
+  prependAppleMusicFavoriteTrack: (track: Track) => void;
   /** Mark a library load as in-flight (or finished). */
   setAppleMusicLibraryLoading: (loading: boolean) => void;
   /** Persist any error from the latest library fetch. */
@@ -1858,6 +1903,31 @@ export const useIpodStore = create<IpodState>()(
             [playlistId]: loading,
           },
         })),
+      setAppleMusicRecentlyAddedTracks: (tracks, loadedAt) =>
+        set({
+          appleMusicRecentlyAddedTracks: tracks,
+          appleMusicRecentlyAddedLoadedAt:
+            loadedAt === undefined ? Date.now() : loadedAt,
+          appleMusicRecentlyAddedLoading: false,
+        }),
+      setAppleMusicRecentlyAddedLoading: (loading) =>
+        set({ appleMusicRecentlyAddedLoading: loading }),
+      setAppleMusicFavoriteTracks: (tracks, loadedAt) =>
+        set({
+          appleMusicFavoriteTracks: tracks,
+          appleMusicFavoriteTracksLoadedAt:
+            loadedAt === undefined ? Date.now() : loadedAt,
+          appleMusicFavoritesLoading: false,
+        }),
+      setAppleMusicFavoritesLoading: (loading) =>
+        set({ appleMusicFavoritesLoading: loading }),
+      prependAppleMusicFavoriteTrack: (track) =>
+        set((state) => ({
+          appleMusicFavoriteTracks: [
+            track,
+            ...state.appleMusicFavoriteTracks.filter((t) => t.id !== track.id),
+          ],
+        })),
       setAppleMusicLibraryLoading: (loading) =>
         set({ appleMusicLibraryLoading: loading }),
       setAppleMusicLibraryError: (error) =>
@@ -2196,6 +2266,12 @@ if (import.meta.hot) {
       appleMusicPlaylistTracks: s.appleMusicPlaylistTracks,
       appleMusicPlaylistTracksLoadedAt: s.appleMusicPlaylistTracksLoadedAt,
       appleMusicPlaylistTracksLoading: {},
+      appleMusicRecentlyAddedTracks: s.appleMusicRecentlyAddedTracks,
+      appleMusicRecentlyAddedLoadedAt: s.appleMusicRecentlyAddedLoadedAt,
+      appleMusicRecentlyAddedLoading: false,
+      appleMusicFavoriteTracks: s.appleMusicFavoriteTracks,
+      appleMusicFavoriteTracksLoadedAt: s.appleMusicFavoriteTracksLoadedAt,
+      appleMusicFavoritesLoading: false,
       appleMusicCurrentSongId: s.appleMusicCurrentSongId,
       appleMusicPlaybackQueue: s.appleMusicPlaybackQueue,
       appleMusicLibraryLoadedAt: s.appleMusicLibraryLoadedAt,

--- a/src/stores/useIpodStore.ts
+++ b/src/stores/useIpodStore.ts
@@ -144,6 +144,13 @@ interface IpodData {
   appleMusicTracks: Track[];
   /** Playlists from the user's Apple Music library (IndexedDB-backed). */
   appleMusicPlaylists: AppleMusicPlaylist[];
+  /**
+   * Timestamp (epoch ms) when the playlist list itself was last synced.
+   * Drives the opportunistic background refresh in
+   * `useAppleMusicLibrary` independently of the heavier full-library
+   * fetch (which has its own `appleMusicLibraryLoadedAt`).
+   */
+  appleMusicPlaylistsLoadedAt: number | null;
   /** Tracks per playlist id; lazy-loaded on drill-down. */
   appleMusicPlaylistTracks: Record<string, Track[]>;
   /** Per-playlist cache timestamp for stale-while-revalidate. */
@@ -327,6 +334,7 @@ const initialIpodData: IpodData = {
   librarySource: "youtube",
   appleMusicTracks: [],
   appleMusicPlaylists: [],
+  appleMusicPlaylistsLoadedAt: null,
   appleMusicPlaylistTracks: {},
   appleMusicPlaylistTracksLoadedAt: {},
   appleMusicPlaylistTracksLoading: {},
@@ -448,8 +456,15 @@ export interface IpodState extends IpodData {
   setLibrarySource: (source: LibrarySource) => void;
   /** Replace the cached Apple Music library with the supplied tracks. */
   setAppleMusicTracks: (tracks: Track[]) => void;
-  /** Replace the cached Apple Music playlist list. */
-  setAppleMusicPlaylists: (playlists: AppleMusicPlaylist[]) => void;
+  /**
+   * Replace the cached Apple Music playlist list. When `loadedAt` is
+   * omitted, the freshness timestamp is set to `Date.now()`. Pass an
+   * explicit value (typically from IndexedDB) when hydrating from cache.
+   */
+  setAppleMusicPlaylists: (
+    playlists: AppleMusicPlaylist[],
+    loadedAt?: number | null
+  ) => void;
   /** Cache tracks for one playlist and mark it fresh. */
   setAppleMusicPlaylistTracks: (playlistId: string, tracks: Track[]) => void;
   /** Mark a per-playlist track fetch as in-flight (or finished). */
@@ -1812,8 +1827,15 @@ export const useIpodStore = create<IpodState>()(
           storefrontId: storefrontIdAtSave,
         });
       },
-      setAppleMusicPlaylists: (playlists) =>
-        set({ appleMusicPlaylists: playlists }),
+      setAppleMusicPlaylists: (playlists, loadedAt) =>
+        set({
+          appleMusicPlaylists: playlists,
+          // `null` is reserved for "never synced". When the caller doesn't
+          // pass a timestamp, treat this as a fresh sync (default behavior
+          // for opportunistic / foreground refresh paths).
+          appleMusicPlaylistsLoadedAt:
+            loadedAt === undefined ? Date.now() : loadedAt,
+        }),
       setAppleMusicPlaylistTracks: (playlistId, tracks) =>
         set((state) => ({
           appleMusicPlaylistTracks: {
@@ -2170,6 +2192,7 @@ if (import.meta.hot) {
       librarySource: s.librarySource,
       appleMusicTracks: s.appleMusicTracks,
       appleMusicPlaylists: s.appleMusicPlaylists,
+      appleMusicPlaylistsLoadedAt: s.appleMusicPlaylistsLoadedAt,
       appleMusicPlaylistTracks: s.appleMusicPlaylistTracks,
       appleMusicPlaylistTracksLoadedAt: s.appleMusicPlaylistTracksLoadedAt,
       appleMusicPlaylistTracksLoading: {},

--- a/tests/test-ipod-apple-music.test.ts
+++ b/tests/test-ipod-apple-music.test.ts
@@ -36,9 +36,12 @@ if (!browserGlobals.navigator) {
   browserGlobals.navigator = { onLine: true, userAgent: "test" } as Navigator;
 }
 
-const { libraryResourceToTrack } = await import(
-  "../src/apps/ipod/hooks/useAppleMusicLibrary"
-);
+const {
+  libraryResourceToTrack,
+  refreshAppleMusicPlaylists,
+  refreshStaleAppleMusicPlaylistTracks,
+  APPLE_MUSIC_PLAYLISTS_OPPORTUNISTIC_TTL_MS,
+} = await import("../src/apps/ipod/hooks/useAppleMusicLibrary");
 const { useIpodStore } = await import("../src/stores/useIpodStore");
 const {
   isValidAppleMusicSongId,
@@ -294,5 +297,121 @@ describe("useIpodStore Apple Music slice", () => {
     useIpodStore.getState().appleMusicNextTrack();
 
     expect(useIpodStore.getState().appleMusicCurrentSongId).toBe("am:q2");
+  });
+});
+
+describe("Apple Music opportunistic playlist refresh", () => {
+  beforeEach(() => {
+    useIpodStore.setState({
+      appleMusicPlaylists: [],
+      appleMusicPlaylistsLoadedAt: null,
+      appleMusicPlaylistTracks: {},
+      appleMusicPlaylistTracksLoadedAt: {},
+      appleMusicPlaylistTracksLoading: {},
+    });
+  });
+
+  test("setAppleMusicPlaylists stamps loadedAt with the current time by default", () => {
+    const before = Date.now();
+    useIpodStore.getState().setAppleMusicPlaylists([
+      {
+        id: "p:1",
+        name: "Workout",
+        artworkUrl: undefined,
+        trackCount: 12,
+        canEdit: true,
+      },
+    ]);
+    const after = Date.now();
+    const state = useIpodStore.getState();
+    expect(state.appleMusicPlaylists).toHaveLength(1);
+    expect(state.appleMusicPlaylistsLoadedAt).not.toBeNull();
+    expect(state.appleMusicPlaylistsLoadedAt!).toBeGreaterThanOrEqual(before);
+    expect(state.appleMusicPlaylistsLoadedAt!).toBeLessThanOrEqual(after);
+  });
+
+  test("setAppleMusicPlaylists honours an explicit loadedAt (used by hydration from IndexedDB)", () => {
+    useIpodStore.getState().setAppleMusicPlaylists(
+      [
+        {
+          id: "p:1",
+          name: "Old",
+          artworkUrl: undefined,
+          trackCount: 0,
+          canEdit: false,
+        },
+      ],
+      12345
+    );
+    expect(useIpodStore.getState().appleMusicPlaylistsLoadedAt).toBe(12345);
+  });
+
+  test("refreshAppleMusicPlaylists short-circuits when the cache is fresh enough", async () => {
+    const cached = [
+      {
+        id: "p:1",
+        name: "Recent",
+        artworkUrl: undefined,
+        trackCount: 5,
+        canEdit: false,
+      },
+    ];
+    useIpodStore.setState({
+      appleMusicPlaylists: cached,
+      // Pretend the cache was written 1 second ago — well within the
+      // opportunistic TTL.
+      appleMusicPlaylistsLoadedAt: Date.now() - 1000,
+    });
+
+    const result = await refreshAppleMusicPlaylists();
+
+    // Returns the cached array as-is (no network call attempted).
+    expect(result).toBe(cached);
+    // Timestamp untouched.
+    expect(
+      Date.now() - (useIpodStore.getState().appleMusicPlaylistsLoadedAt ?? 0)
+    ).toBeGreaterThanOrEqual(1000);
+  });
+
+  test("refreshAppleMusicPlaylists returns cached list silently when MusicKit isn't available", async () => {
+    const cached = [
+      {
+        id: "p:1",
+        name: "Stale",
+        artworkUrl: undefined,
+        trackCount: 5,
+        canEdit: false,
+      },
+    ];
+    useIpodStore.setState({
+      appleMusicPlaylists: cached,
+      // Mark the cache as stale so the freshness check doesn't short-
+      // circuit and we exercise the "no MusicKit instance" branch.
+      appleMusicPlaylistsLoadedAt:
+        Date.now() - APPLE_MUSIC_PLAYLISTS_OPPORTUNISTIC_TTL_MS - 1,
+    });
+
+    const result = await refreshAppleMusicPlaylists();
+
+    expect(result).toBe(cached);
+  });
+
+  test("refreshStaleAppleMusicPlaylistTracks no-ops when no playlist tracks have been cached yet", async () => {
+    // No cached playlist tracks → nothing to revalidate, no network call.
+    await refreshStaleAppleMusicPlaylistTracks();
+    const state = useIpodStore.getState();
+    expect(state.appleMusicPlaylistTracksLoadedAt).toEqual({});
+    expect(state.appleMusicPlaylistTracksLoading).toEqual({});
+  });
+
+  test("refreshStaleAppleMusicPlaylistTracks no-ops silently when MusicKit isn't available even with stale entries", async () => {
+    useIpodStore.setState({
+      appleMusicPlaylistTracks: { "p:1": [] },
+      appleMusicPlaylistTracksLoadedAt: { "p:1": 1 },
+    });
+
+    // Should not throw; should not flip any loading flags either.
+    await refreshStaleAppleMusicPlaylistTracks();
+    expect(useIpodStore.getState().appleMusicPlaylistTracksLoading).toEqual({});
   });
 });

--- a/tests/test-ipod-apple-music.test.ts
+++ b/tests/test-ipod-apple-music.test.ts
@@ -40,7 +40,10 @@ const {
   libraryResourceToTrack,
   refreshAppleMusicPlaylists,
   refreshStaleAppleMusicPlaylistTracks,
+  refreshAppleMusicRecentlyAdded,
+  refreshAppleMusicFavorites,
   APPLE_MUSIC_PLAYLISTS_OPPORTUNISTIC_TTL_MS,
+  APPLE_MUSIC_PLAYLIST_TRACKS_OPPORTUNISTIC_TTL_MS,
 } = await import("../src/apps/ipod/hooks/useAppleMusicLibrary");
 const { useIpodStore } = await import("../src/stores/useIpodStore");
 const {
@@ -413,5 +416,157 @@ describe("Apple Music opportunistic playlist refresh", () => {
     // Should not throw; should not flip any loading flags either.
     await refreshStaleAppleMusicPlaylistTracks();
     expect(useIpodStore.getState().appleMusicPlaylistTracksLoading).toEqual({});
+  });
+});
+
+describe("Apple Music Recently Added & Favorites store + refresh", () => {
+  beforeEach(() => {
+    useIpodStore.setState({
+      appleMusicRecentlyAddedTracks: [],
+      appleMusicRecentlyAddedLoadedAt: null,
+      appleMusicRecentlyAddedLoading: false,
+      appleMusicFavoriteTracks: [],
+      appleMusicFavoriteTracksLoadedAt: null,
+      appleMusicFavoritesLoading: false,
+    });
+  });
+
+  test("setAppleMusicRecentlyAddedTracks stamps loadedAt + clears the loading flag", () => {
+    useIpodStore.setState({ appleMusicRecentlyAddedLoading: true });
+    const before = Date.now();
+    useIpodStore
+      .getState()
+      .setAppleMusicRecentlyAddedTracks([
+        {
+          id: "am:1",
+          url: "applemusic:1",
+          title: "One",
+          source: "appleMusic",
+        },
+      ]);
+    const after = Date.now();
+    const state = useIpodStore.getState();
+    expect(state.appleMusicRecentlyAddedTracks).toHaveLength(1);
+    expect(state.appleMusicRecentlyAddedLoading).toBe(false);
+    expect(state.appleMusicRecentlyAddedLoadedAt!).toBeGreaterThanOrEqual(before);
+    expect(state.appleMusicRecentlyAddedLoadedAt!).toBeLessThanOrEqual(after);
+  });
+
+  test("setAppleMusicFavoriteTracks honours an explicit loadedAt (used by hydration)", () => {
+    useIpodStore.getState().setAppleMusicFavoriteTracks(
+      [
+        {
+          id: "am:1",
+          url: "applemusic:1",
+          title: "Liked",
+          source: "appleMusic",
+        },
+      ],
+      99999
+    );
+    expect(useIpodStore.getState().appleMusicFavoriteTracksLoadedAt).toBe(
+      99999
+    );
+  });
+
+  test("prependAppleMusicFavoriteTrack adds the track to the front and de-dupes by id", () => {
+    useIpodStore.setState({
+      appleMusicFavoriteTracks: [
+        {
+          id: "am:1",
+          url: "applemusic:1",
+          title: "One",
+          source: "appleMusic",
+        },
+        {
+          id: "am:2",
+          url: "applemusic:2",
+          title: "Two",
+          source: "appleMusic",
+        },
+      ],
+      appleMusicFavoriteTracksLoadedAt: 12345,
+    });
+
+    useIpodStore.getState().prependAppleMusicFavoriteTrack({
+      id: "am:2",
+      url: "applemusic:2",
+      title: "Two (renamed)",
+      source: "appleMusic",
+    });
+
+    const state = useIpodStore.getState();
+    expect(state.appleMusicFavoriteTracks.map((t) => t.id)).toEqual([
+      "am:2",
+      "am:1",
+    ]);
+    expect(state.appleMusicFavoriteTracks[0].title).toBe("Two (renamed)");
+    // Don't bump loadedAt so the next opportunistic refresh still
+    // revalidates against the server.
+    expect(state.appleMusicFavoriteTracksLoadedAt).toBe(12345);
+  });
+
+  test("refreshAppleMusicRecentlyAdded short-circuits when the cache is fresh enough", async () => {
+    const cached = [
+      {
+        id: "am:1",
+        url: "applemusic:1",
+        title: "Cached",
+        source: "appleMusic" as const,
+      },
+    ];
+    useIpodStore.setState({
+      appleMusicRecentlyAddedTracks: cached,
+      appleMusicRecentlyAddedLoadedAt: Date.now() - 1000,
+    });
+
+    const result = await refreshAppleMusicRecentlyAdded();
+
+    expect(result).toBe(cached);
+    expect(useIpodStore.getState().appleMusicRecentlyAddedLoading).toBe(false);
+  });
+
+  test("refreshAppleMusicRecentlyAdded silently returns cached when MusicKit isn't available + doesn't toggle loading on a stale-but-cached refresh", async () => {
+    const cached = [
+      {
+        id: "am:1",
+        url: "applemusic:1",
+        title: "Stale",
+        source: "appleMusic" as const,
+      },
+    ];
+    useIpodStore.setState({
+      appleMusicRecentlyAddedTracks: cached,
+      appleMusicRecentlyAddedLoadedAt:
+        Date.now() - APPLE_MUSIC_PLAYLIST_TRACKS_OPPORTUNISTIC_TTL_MS - 1,
+    });
+
+    const result = await refreshAppleMusicRecentlyAdded();
+
+    expect(result).toBe(cached);
+    // Loading flag stays false because there's already cached content
+    // for the menu — background refresh must never flash "Loading…".
+    expect(useIpodStore.getState().appleMusicRecentlyAddedLoading).toBe(false);
+  });
+
+  test("refreshAppleMusicFavorites short-circuits when the cache is fresh enough", async () => {
+    const cached = [
+      {
+        id: "am:liked",
+        url: "applemusic:liked",
+        title: "Liked",
+        source: "appleMusic" as const,
+      },
+    ];
+    useIpodStore.setState({
+      appleMusicFavoriteTracks: cached,
+      appleMusicFavoriteTracksLoadedAt:
+        Date.now() - APPLE_MUSIC_PLAYLISTS_OPPORTUNISTIC_TTL_MS,
+    });
+
+    const result = await refreshAppleMusicFavorites();
+
+    expect(result).toBe(cached);
+    expect(useIpodStore.getState().appleMusicFavoritesLoading).toBe(false);
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## How Apple Music data was updated before this PR

| Data | Where it's cached | When it was refreshed |
| --- | --- | --- |
| Library tracks | IndexedDB (`appleMusicLibraryCache`) | Library SWR: cold load (with toast) or stale-after-24h silent refresh on iPod open |
| **Playlists list** | IndexedDB | Only as a side effect of the library SWR fetch (no independent freshness window) |
| **Per-playlist tracks** | IndexedDB | Only when the user reopens that playlist *and* its cache is ≥ 24h old |
| **Recently Added** | IndexedDB | Only when the user opens the menu, then 24h SWR; menu briefly flashed "Loading…" on every iPod open because the in-memory state lived in local React state and was reset on mount |
| **Favorite Songs** | IndexedDB | Same as Recently Added |

So a user who plays the iPod every day for a month and never reopens a playlist would see month-old playlist contents, a new playlist created on their phone could take 24h to appear, and the Recently Added / Favorites menus flashed a placeholder on every open.

## Change

Combines two related changes that together turn the entire Apple Music side of the iPod into a true stale-while-revalidate experience without ever interrupting playback.

### Part 1 — Opportunistic background refresh of playlists list + per-playlist tracks
Commit `35bf9d419` ([browse](https://github.com/ryokun6/ryos/blob/35bf9d419/))

- New `appleMusicPlaylistsLoadedAt` field on the store + IndexedDB hydration so the playlists list has its own freshness timestamp independent of the song library.
- New exported `refreshAppleMusicPlaylists()` helper:
  - In-flight de-dup (concurrent callers share the same promise).
  - Defensive empty-result guard mirrors the library fetcher (a flaky API response can't wipe the cached list).
  - `fetchAppleMusicLibrary` now delegates to it for consistency.
- New exported `refreshStaleAppleMusicPlaylistTracks()` helper that walks every cached playlist and re-fetches stale entries with bounded concurrency (default 2), tracking in-flight ids.
- New opportunistic refresh effect in `useAppleMusicLibrary`:
  - Initial run 3s after enable + auth (lets the foreground load settle).
  - Re-runs on `visibilitychange` (throttled to 1/min).
  - 15-min poll as a backstop for long-lived sessions.
  - All paths silent (no toast).

Opportunistic TTLs (independent of the existing 24h library SWR window):
- `APPLE_MUSIC_PLAYLISTS_OPPORTUNISTIC_TTL_MS = 15 min` — one cheap paginated call.
- `APPLE_MUSIC_PLAYLIST_TRACKS_OPPORTUNISTIC_TTL_MS = 1 hour` — one call per cached playlist.

### Part 2 — SWR-on-open + auto-update Recently Added / Favorites
Commit `932743db8` ([browse](https://github.com/ryokun6/ryos/blob/932743db8/))

**Always background-refresh on playlist open**: `requestPlaylistTracksIfNeeded` previously only fired when the playlist's tracks cache was missing or ≥ 24h stale. Now it always triggers a fetch on open, with cached tracks rendering immediately while the refresh updates them in place. Dedup is handled by `appleMusicPlaylistTracksLoading[id]`, and the menu's "Loading…" placeholder remains gated on `tracks.length === 0` so cached entries never flicker.

**Auto-update Recently Added + Favorite Songs** (these were stuck in local React state):
- Hoists both collections into the iPod store with their own freshness timestamps and loading flags.
- Hydrates them from IndexedDB on hook mount alongside the existing collections.
- New `refreshAppleMusicRecentlyAdded()` / `refreshAppleMusicFavorites()` helpers with in-flight de-dup, defensive empty-result guard, and silent loading-flag handling (only flips when there's no cached content).
- Wires both into the opportunistic-refresh effect so they auto-update on enable+auth, on visibility change, and on the 15-min poll.
- Menu open handlers now read from the store + fire foreground refresh; the error toast only shows when there's no cached content (a background failure with cached content stays silent).
- `handleAppleMusicAddToFavorites` switches to the new `prependAppleMusicFavoriteTrack` action so the optimistic update flows through the store.

## Playback safety

`AppleMusicPlayerBridge` keys playback on `currentTrack.id`, and `appleMusicPlaybackQueue` stores ids (not direct references). None of the new store slots — `appleMusicPlaylists`, `appleMusicPlaylistsLoadedAt`, `appleMusicRecentlyAddedTracks`, `appleMusicFavoriteTracks`, the per-playlist track map — feed the bridge, so swapping any of them while a track is playing keeps audio uninterrupted. The existing `playlistTracks.length === 0` check on the menu suppresses any "Loading…" flicker for cached playlists.

## Files changed

- `src/stores/useIpodStore.ts` — add `appleMusicPlaylistsLoadedAt` + 6 new fields for Recently Added / Favorites + 6 new actions; update `setAppleMusicPlaylists` to track its loadedAt.
- `src/apps/ipod/hooks/useAppleMusicLibrary.ts` — 4 new exported refresh helpers; hydrate playlists / Recently Added / Favorites on hook mount; opportunistic refresh effect (initial + visibility + 15-min poll).
- `src/apps/ipod/hooks/useIpodLogic.ts` — clear new fields on Apple Music sign-out; replace local Recently Added / Favorites state with store selectors; rewire load handlers; always-refresh playlists on open; favorite-add uses store action.
- `tests/test-ipod-apple-music.test.ts` — 12 new regression tests (26 total) covering freshness stamps, fresh-cache short-circuits, optimistic favorite prepend with id de-dup, and silent-no-op behavior when MusicKit isn't available.

## Testing

- ✅ `bun test tests/test-ipod-apple-music.test.ts` — 26 pass (12 new)
- ✅ `bun run test:unit` — 188 pass
- ✅ `bun run build` — clean
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-27447868-ce2e-42c6-99c5-8d75f1dffa17"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-27447868-ce2e-42c6-99c5-8d75f1dffa17"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

