### PR TITLE
[Superseded by #1175] ipod: SWR-on-open for playlists + auto-update Recently Added & Favorites

### DIFF
--- a/src/apps/ipod/hooks/useAppleMusicLibrary.ts
+++ b/src/apps/ipod/hooks/useAppleMusicLibrary.ts
@@ -754,6 +754,136 @@ export async function refreshStaleAppleMusicPlaylistTracks(
   await Promise.all(workers);
 }
 
+let inFlightRecentlyAddedRefresh: Promise<Track[]> | null = null;
+let inFlightFavoritesRefresh: Promise<Track[]> | null = null;
+
+/**
+ * Refresh the "Recently Added" track collection in the background and
+ * mirror the result into the store. Mirrors `refreshAppleMusicPlaylists`
+ * for the menu-collection case so the menu can render cached content
+ * while a fresh fetch updates the store in-place when it finishes.
+ *
+ * `fetchAppleMusicRecentlyAddedTracks` already implements the cache /
+ * defensive empty-result logic (a flaky API returning 0 tracks won't
+ * wipe the cached collection), so this wrapper just adds the in-flight
+ * de-dup, the loading flag, and the store write.
+ *
+ * Playback safety: only `appleMusicRecentlyAddedTracks` is mutated. The
+ * AppleMusicPlayerBridge keys playback on `currentTrack.id` and the
+ * playback queue stores ids, so swapping this list while a track from
+ * it is playing keeps audio uninterrupted.
+ */
+export async function refreshAppleMusicRecentlyAdded(
+  options: { force?: boolean } = {}
+): Promise<Track[]> {
+  const store = useIpodStore.getState();
+
+  if (!options.force) {
+    const loadedAt = store.appleMusicRecentlyAddedLoadedAt;
+    const ageMs = loadedAt ? Date.now() - loadedAt : Infinity;
+    if (
+      store.appleMusicRecentlyAddedTracks.length > 0 &&
+      ageMs < APPLE_MUSIC_PLAYLIST_TRACKS_OPPORTUNISTIC_TTL_MS
+    ) {
+      return store.appleMusicRecentlyAddedTracks;
+    }
+  }
+
+  if (inFlightRecentlyAddedRefresh) return inFlightRecentlyAddedRefresh;
+
+  const instance = getMusicKitInstance();
+  if (!instance || !instance.isAuthorized) {
+    return store.appleMusicRecentlyAddedTracks;
+  }
+
+  // Only flip the loading flag when there's nothing to display yet — a
+  // background refresh of an existing list should not flash "Loading…".
+  const hadCached = store.appleMusicRecentlyAddedTracks.length > 0;
+  if (!hadCached) {
+    store.setAppleMusicRecentlyAddedLoading(true);
+  }
+
+  inFlightRecentlyAddedRefresh = (async () => {
+    try {
+      const tracks = await fetchAppleMusicRecentlyAddedTracks({ force: true });
+      const existing = useIpodStore.getState().appleMusicRecentlyAddedTracks;
+      if (tracks.length === 0 && existing.length > 0) {
+        // The fetcher's defensive guard already returns the cached array
+        // in this case, but keep the second check here so the store
+        // never gets flipped to an empty array on a flaky refresh.
+        return existing;
+      }
+      useIpodStore
+        .getState()
+        .setAppleMusicRecentlyAddedTracks(tracks, Date.now());
+      return tracks;
+    } finally {
+      inFlightRecentlyAddedRefresh = null;
+      if (!hadCached) {
+        useIpodStore.getState().setAppleMusicRecentlyAddedLoading(false);
+      }
+    }
+  })();
+
+  return inFlightRecentlyAddedRefresh;
+}
+
+/**
+ * Refresh the "Favorite Songs" track collection in the background and
+ * mirror the result into the store. See `refreshAppleMusicRecentlyAdded`
+ * for the rationale and playback-safety notes — the only difference is
+ * which IndexedDB collection key + store slot is updated.
+ */
+export async function refreshAppleMusicFavorites(
+  options: { force?: boolean } = {}
+): Promise<Track[]> {
+  const store = useIpodStore.getState();
+
+  if (!options.force) {
+    const loadedAt = store.appleMusicFavoriteTracksLoadedAt;
+    const ageMs = loadedAt ? Date.now() - loadedAt : Infinity;
+    if (
+      store.appleMusicFavoriteTracks.length > 0 &&
+      ageMs < APPLE_MUSIC_PLAYLIST_TRACKS_OPPORTUNISTIC_TTL_MS
+    ) {
+      return store.appleMusicFavoriteTracks;
+    }
+  }
+
+  if (inFlightFavoritesRefresh) return inFlightFavoritesRefresh;
+
+  const instance = getMusicKitInstance();
+  if (!instance || !instance.isAuthorized) {
+    return store.appleMusicFavoriteTracks;
+  }
+
+  const hadCached = store.appleMusicFavoriteTracks.length > 0;
+  if (!hadCached) {
+    store.setAppleMusicFavoritesLoading(true);
+  }
+
+  inFlightFavoritesRefresh = (async () => {
+    try {
+      const tracks = await fetchAppleMusicFavoriteSongTracks({ force: true });
+      const existing = useIpodStore.getState().appleMusicFavoriteTracks;
+      if (tracks.length === 0 && existing.length > 0) {
+        return existing;
+      }
+      useIpodStore
+        .getState()
+        .setAppleMusicFavoriteTracks(tracks, Date.now());
+      return tracks;
+    } finally {
+      inFlightFavoritesRefresh = null;
+      if (!hadCached) {
+        useIpodStore.getState().setAppleMusicFavoritesLoading(false);
+      }
+    }
+  })();
+
+  return inFlightFavoritesRefresh;
+}
+
 /**
  * Fetch the user's full Apple Music library and write the result into the
  * store. Resolves with the number of tracks loaded; rejects when MusicKit
@@ -1137,6 +1267,48 @@ export function useAppleMusicLibrary({
             });
           }
         }
+
+        // Recently Added & Favorites (each persisted under its own
+        // IndexedDB key by `saveAppleMusicTrackCollection`). Hydrating
+        // here means the menu shows cached entries instantly on iPod
+        // open instead of flashing "Loading…" while the lazy menu-open
+        // fetcher runs.
+        if (
+          useIpodStore.getState().appleMusicRecentlyAddedTracks.length === 0
+        ) {
+          const cached = await loadAppleMusicTrackCollection(
+            "recently-added"
+          );
+          if (cancelled) return;
+          if (
+            cached &&
+            cached.tracks.length > 0 &&
+            useIpodStore.getState().appleMusicRecentlyAddedTracks.length === 0
+          ) {
+            useIpodStore
+              .getState()
+              .setAppleMusicRecentlyAddedTracks(
+                cached.tracks,
+                cached.loadedAt
+              );
+          }
+        }
+
+        if (useIpodStore.getState().appleMusicFavoriteTracks.length === 0) {
+          const cached = await loadAppleMusicTrackCollection(
+            "favorite-songs"
+          );
+          if (cancelled) return;
+          if (
+            cached &&
+            cached.tracks.length > 0 &&
+            useIpodStore.getState().appleMusicFavoriteTracks.length === 0
+          ) {
+            useIpodStore
+              .getState()
+              .setAppleMusicFavoriteTracks(cached.tracks, cached.loadedAt);
+          }
+        }
       } finally {
         inFlight = false;
       }
@@ -1294,6 +1466,15 @@ export function useAppleMusicLibrary({
         await refreshAppleMusicPlaylists();
         if (cancelled) return;
         await refreshStaleAppleMusicPlaylistTracks();
+        if (cancelled) return;
+        // Recently Added and Favorites have their own freshness windows
+        // (handled inside each helper). Run them in parallel since they
+        // hit separate Apple Music endpoints and don't share the same
+        // in-flight guard.
+        await Promise.allSettled([
+          refreshAppleMusicRecentlyAdded(),
+          refreshAppleMusicFavorites(),
+        ]);
       } catch (err) {
         // Each helper handles its own per-call errors; a top-level
         // failure here would be unexpected (e.g. MusicKit instance went

--- a/src/apps/ipod/hooks/useIpodLogic.ts
+++ b/src/apps/ipod/hooks/useIpodLogic.ts
@@ -16,12 +16,11 @@ import { useLibraryUpdateChecker } from "./useLibraryUpdateChecker";
 import {
   useAppleMusicLibrary,
   fetchAppleMusicPlaylistTracks,
-  fetchAppleMusicFavoriteSongTracks,
-  fetchAppleMusicRecentlyAddedTracks,
+  refreshAppleMusicRecentlyAdded,
+  refreshAppleMusicFavorites,
   searchAppleMusicTracks,
   addAppleMusicTrackToFavorites,
   cacheAppleMusicFavoriteSongTrack,
-  APPLE_MUSIC_LIBRARY_STALE_AFTER_MS,
   type AppleMusicSearchScope,
 } from "./useAppleMusicLibrary";
 import { useMusicKit } from "@/hooks/useMusicKit";
@@ -353,14 +352,23 @@ export function useIpodLogic({
   const [isSongSearchDialogOpen, setIsSongSearchDialogOpen] = useState(false);
   const [isSyncModeOpen, setIsSyncModeOpen] = useState(false);
   const [isAddingSong, setIsAddingSong] = useState(false);
-  const [appleMusicRecentlyAddedTracks, setAppleMusicRecentlyAddedTracks] =
-    useState<Track[]>([]);
-  const [isAppleMusicRecentlyAddedLoading, setIsAppleMusicRecentlyAddedLoading] =
-    useState(false);
-  const [appleMusicFavoriteTracks, setAppleMusicFavoriteTracks] =
-    useState<Track[]>([]);
-  const [isAppleMusicFavoritesLoading, setIsAppleMusicFavoritesLoading] =
-    useState(false);
+  // Recently Added + Favorites moved into the global iPod store (mirrored
+  // from IndexedDB on iPod open) so the opportunistic refresh path in
+  // `useAppleMusicLibrary` can update the same source the menu reads
+  // from. Selectors keep these in sync with the store without forcing a
+  // re-render of the entire hook on unrelated state changes.
+  const appleMusicRecentlyAddedTracks = useIpodStore(
+    (s) => s.appleMusicRecentlyAddedTracks
+  );
+  const isAppleMusicRecentlyAddedLoading = useIpodStore(
+    (s) => s.appleMusicRecentlyAddedLoading
+  );
+  const appleMusicFavoriteTracks = useIpodStore(
+    (s) => s.appleMusicFavoriteTracks
+  );
+  const isAppleMusicFavoritesLoading = useIpodStore(
+    (s) => s.appleMusicFavoritesLoading
+  );
   
   // Cover Flow state
   const [isCoverFlowOpen, setIsCoverFlowOpen] = useState(false);
@@ -749,23 +757,22 @@ export function useIpodLogic({
   );
 
   const requestPlaylistTracksIfNeeded = useCallback((playlistId: string) => {
-    const state = useIpodStore.getState();
-    const loadedAt = state.appleMusicPlaylistTracksLoadedAt[playlistId];
-    const ageMs = loadedAt ? Date.now() - loadedAt : Infinity;
-    const hasTracks =
-      (state.appleMusicPlaylistTracks[playlistId]?.length ?? 0) > 0;
-    const isStale = ageMs >= APPLE_MUSIC_LIBRARY_STALE_AFTER_MS;
-
-    if (!hasTracks || isStale) {
-      void fetchAppleMusicPlaylistTracks(playlistId, {
-        force: isStale && hasTracks,
-      }).catch((err) => {
+    // Always trigger a background refresh on playlist open. The fetcher
+    // dedupes in-flight calls via `appleMusicPlaylistTracksLoading`, and
+    // the menu builder gates "Loading…" behind
+    // `playlistTracks.length === 0`, so cached tracks render
+    // immediately while the refresh updates them in place. This gives
+    // users a true SWR experience: opening a playlist shows cached
+    // contents instantly AND silently picks up any new songs added
+    // since the last view.
+    void fetchAppleMusicPlaylistTracks(playlistId, { force: true }).catch(
+      (err) => {
         console.warn(
           `[apple music] failed to load playlist tracks for ${playlistId}`,
           err
         );
-      });
-    }
+      }
+    );
   }, []);
 
   // -------------------------------------------------------------------
@@ -803,6 +810,12 @@ export function useIpodLogic({
       appleMusicPlaylistTracks: {},
       appleMusicPlaylistTracksLoadedAt: {},
       appleMusicPlaylistTracksLoading: {},
+      appleMusicRecentlyAddedTracks: [],
+      appleMusicRecentlyAddedLoadedAt: null,
+      appleMusicRecentlyAddedLoading: false,
+      appleMusicFavoriteTracks: [],
+      appleMusicFavoriteTracksLoadedAt: null,
+      appleMusicFavoritesLoading: false,
       appleMusicPlaybackQueue: null,
     });
     // Drop the IndexedDB-cached library so a different user signing
@@ -873,69 +886,77 @@ export function useIpodLogic({
     [mergeAppleMusicTracks, setIsPlaying, showStatus, t]
   );
 
+  // Open the "Recently Added" menu.
+  //
+  // Reads cached tracks straight from the store (already populated via
+  // the IndexedDB hydration in `useAppleMusicLibrary`) and kicks off a
+  // background refresh that updates the store in-place when it
+  // resolves. The menu builder gates "Loading…" on cache emptiness, so
+  // the only time the user sees the placeholder is the very first
+  // load — every subsequent open shows cached entries instantly while
+  // the refresh runs invisibly.
   const loadAppleMusicRecentlyAdded = useCallback(async () => {
     if (!appleMusicAuthorized) {
       void handleAppleMusicSignIn();
       return;
     }
-    if (isAppleMusicRecentlyAddedLoading) return;
-    setIsAppleMusicRecentlyAddedLoading(true);
     try {
-      const recentTracks = await fetchAppleMusicRecentlyAddedTracks();
-      setAppleMusicRecentlyAddedTracks(recentTracks);
-      mergeAppleMusicTracks(recentTracks);
+      const tracks = await refreshAppleMusicRecentlyAdded({ force: true });
+      mergeAppleMusicTracks(tracks);
     } catch (err) {
-      toast.error(
-        t(
-          "apps.ipod.dialogs.appleMusicRecentlyAddedFailed",
-          "Failed to load recently added songs"
-        ),
-        {
-          description: err instanceof Error ? err.message : String(err),
-        }
-      );
-    } finally {
-      setIsAppleMusicRecentlyAddedLoading(false);
+      // Only surface the toast when there's no cached content to fall
+      // back on — otherwise the user already has a working menu and a
+      // background failure shouldn't pop a UI error.
+      const hasCached =
+        useIpodStore.getState().appleMusicRecentlyAddedTracks.length > 0;
+      if (!hasCached) {
+        toast.error(
+          t(
+            "apps.ipod.dialogs.appleMusicRecentlyAddedFailed",
+            "Failed to load recently added songs"
+          ),
+          {
+            description: err instanceof Error ? err.message : String(err),
+          }
+        );
+      } else {
+        console.warn(
+          "[apple music] recently added refresh failed (using cached collection)",
+          err
+        );
+      }
     }
-  }, [
-    appleMusicAuthorized,
-    handleAppleMusicSignIn,
-    isAppleMusicRecentlyAddedLoading,
-    mergeAppleMusicTracks,
-    t,
-  ]);
+  }, [appleMusicAuthorized, handleAppleMusicSignIn, mergeAppleMusicTracks, t]);
 
   const loadAppleMusicFavorites = useCallback(async () => {
     if (!appleMusicAuthorized) {
       void handleAppleMusicSignIn();
       return;
     }
-    if (isAppleMusicFavoritesLoading) return;
-    setIsAppleMusicFavoritesLoading(true);
     try {
-      const favoriteTracks = await fetchAppleMusicFavoriteSongTracks();
-      setAppleMusicFavoriteTracks(favoriteTracks);
-      mergeAppleMusicTracks(favoriteTracks);
+      const tracks = await refreshAppleMusicFavorites({ force: true });
+      mergeAppleMusicTracks(tracks);
     } catch (err) {
-      toast.error(
-        t(
-          "apps.ipod.dialogs.appleMusicFavoritesFailed",
-          "Failed to load favorite songs"
-        ),
-        {
-          description: err instanceof Error ? err.message : String(err),
-        }
-      );
-    } finally {
-      setIsAppleMusicFavoritesLoading(false);
+      const hasCached =
+        useIpodStore.getState().appleMusicFavoriteTracks.length > 0;
+      if (!hasCached) {
+        toast.error(
+          t(
+            "apps.ipod.dialogs.appleMusicFavoritesFailed",
+            "Failed to load favorite songs"
+          ),
+          {
+            description: err instanceof Error ? err.message : String(err),
+          }
+        );
+      } else {
+        console.warn(
+          "[apple music] favorites refresh failed (using cached collection)",
+          err
+        );
+      }
     }
-  }, [
-    appleMusicAuthorized,
-    handleAppleMusicSignIn,
-    isAppleMusicFavoritesLoading,
-    mergeAppleMusicTracks,
-    t,
-  ]);
+  }, [appleMusicAuthorized, handleAppleMusicSignIn, mergeAppleMusicTracks, t]);
 
   const handleAppleMusicAddToFavorites = useCallback(async () => {
     registerActivity();
@@ -946,10 +967,11 @@ export function useIpodLogic({
     if (!track) return;
     try {
       await addAppleMusicTrackToFavorites(track);
-      setAppleMusicFavoriteTracks((existingTracks) => [
-        track,
-        ...existingTracks.filter((candidate) => candidate.id !== track.id),
-      ]);
+      // Optimistically update the store + IndexedDB. We don't bump the
+      // freshness timestamp here so the next opportunistic refresh
+      // still revalidates against the server (which catches the eventual
+      // catalog ↔ library mapping for this favorite).
+      useIpodStore.getState().prependAppleMusicFavoriteTrack(track);
       void cacheAppleMusicFavoriteSongTrack(track);
       showStatus(
         t("apps.ipod.status.appleMusicAddedToFavorites", "Added to Favorites")

--- a/src/stores/useIpodStore.ts
+++ b/src/stores/useIpodStore.ts
@@ -157,6 +157,22 @@ interface IpodData {
   appleMusicPlaylistTracksLoadedAt: Record<string, number>;
   /** Per-playlist in-flight fetch flags. */
   appleMusicPlaylistTracksLoading: Record<string, boolean>;
+  /**
+   * Tracks shown in the "Recently Added" menu, mirrored from IndexedDB
+   * so the menu can render cached content immediately on iPod open and
+   * the opportunistic refresh path in `useAppleMusicLibrary` can update
+   * the same source other consumers read from.
+   */
+  appleMusicRecentlyAddedTracks: Track[];
+  /** Last sync timestamp for `appleMusicRecentlyAddedTracks`. */
+  appleMusicRecentlyAddedLoadedAt: number | null;
+  /** True while a Recently Added refresh is in flight (drives the
+   *  one-time "Loading…" placeholder when the cache is empty). */
+  appleMusicRecentlyAddedLoading: boolean;
+  /** Tracks shown in the "Favorite Songs" menu (same shape as above). */
+  appleMusicFavoriteTracks: Track[];
+  appleMusicFavoriteTracksLoadedAt: number | null;
+  appleMusicFavoritesLoading: boolean;
   /** Currently selected song id within the Apple Music library. */
   appleMusicCurrentSongId: string | null;
   /**
@@ -338,6 +354,12 @@ const initialIpodData: IpodData = {
   appleMusicPlaylistTracks: {},
   appleMusicPlaylistTracksLoadedAt: {},
   appleMusicPlaylistTracksLoading: {},
+  appleMusicRecentlyAddedTracks: [],
+  appleMusicRecentlyAddedLoadedAt: null,
+  appleMusicRecentlyAddedLoading: false,
+  appleMusicFavoriteTracks: [],
+  appleMusicFavoriteTracksLoadedAt: null,
+  appleMusicFavoritesLoading: false,
   appleMusicCurrentSongId: null,
   appleMusicPlaybackQueue: null,
   appleMusicLibraryLoadedAt: null,
@@ -472,6 +494,29 @@ export interface IpodState extends IpodData {
     playlistId: string,
     loading: boolean
   ) => void;
+  /**
+   * Replace the cached "Recently Added" track list. When `loadedAt` is
+   * omitted, the freshness timestamp is set to `Date.now()`. Pass an
+   * explicit value when hydrating from IndexedDB.
+   */
+  setAppleMusicRecentlyAddedTracks: (
+    tracks: Track[],
+    loadedAt?: number | null
+  ) => void;
+  setAppleMusicRecentlyAddedLoading: (loading: boolean) => void;
+  /** Same as the Recently Added setters, but for "Favorite Songs". */
+  setAppleMusicFavoriteTracks: (
+    tracks: Track[],
+    loadedAt?: number | null
+  ) => void;
+  setAppleMusicFavoritesLoading: (loading: boolean) => void;
+  /**
+   * Optimistically prepend a track to the favorites list (used right
+   * after `addAppleMusicTrackToFavorites` succeeds). Doesn't bump
+   * `loadedAt` so the next opportunistic refresh still revalidates
+   * against the server (catches the eventual catalog ↔ library mapping).
+   */
+  prependAppleMusicFavoriteTrack: (track: Track) => void;
   /** Mark a library load as in-flight (or finished). */
   setAppleMusicLibraryLoading: (loading: boolean) => void;
   /** Persist any error from the latest library fetch. */
@@ -1858,6 +1903,31 @@ export const useIpodStore = create<IpodState>()(
             [playlistId]: loading,
           },
         })),
+      setAppleMusicRecentlyAddedTracks: (tracks, loadedAt) =>
+        set({
+          appleMusicRecentlyAddedTracks: tracks,
+          appleMusicRecentlyAddedLoadedAt:
+            loadedAt === undefined ? Date.now() : loadedAt,
+          appleMusicRecentlyAddedLoading: false,
+        }),
+      setAppleMusicRecentlyAddedLoading: (loading) =>
+        set({ appleMusicRecentlyAddedLoading: loading }),
+      setAppleMusicFavoriteTracks: (tracks, loadedAt) =>
+        set({
+          appleMusicFavoriteTracks: tracks,
+          appleMusicFavoriteTracksLoadedAt:
+            loadedAt === undefined ? Date.now() : loadedAt,
+          appleMusicFavoritesLoading: false,
+        }),
+      setAppleMusicFavoritesLoading: (loading) =>
+        set({ appleMusicFavoritesLoading: loading }),
+      prependAppleMusicFavoriteTrack: (track) =>
+        set((state) => ({
+          appleMusicFavoriteTracks: [
+            track,
+            ...state.appleMusicFavoriteTracks.filter((t) => t.id !== track.id),
+          ],
+        })),
       setAppleMusicLibraryLoading: (loading) =>
         set({ appleMusicLibraryLoading: loading }),
       setAppleMusicLibraryError: (error) =>
@@ -2196,6 +2266,12 @@ if (import.meta.hot) {
       appleMusicPlaylistTracks: s.appleMusicPlaylistTracks,
       appleMusicPlaylistTracksLoadedAt: s.appleMusicPlaylistTracksLoadedAt,
       appleMusicPlaylistTracksLoading: {},
+      appleMusicRecentlyAddedTracks: s.appleMusicRecentlyAddedTracks,
+      appleMusicRecentlyAddedLoadedAt: s.appleMusicRecentlyAddedLoadedAt,
+      appleMusicRecentlyAddedLoading: false,
+      appleMusicFavoriteTracks: s.appleMusicFavoriteTracks,
+      appleMusicFavoriteTracksLoadedAt: s.appleMusicFavoriteTracksLoadedAt,
+      appleMusicFavoritesLoading: false,
       appleMusicCurrentSongId: s.appleMusicCurrentSongId,
       appleMusicPlaybackQueue: s.appleMusicPlaybackQueue,
       appleMusicLibraryLoadedAt: s.appleMusicLibraryLoadedAt,

--- a/tests/test-ipod-apple-music.test.ts
+++ b/tests/test-ipod-apple-music.test.ts
@@ -40,7 +40,10 @@ const {
   libraryResourceToTrack,
   refreshAppleMusicPlaylists,
   refreshStaleAppleMusicPlaylistTracks,
+  refreshAppleMusicRecentlyAdded,
+  refreshAppleMusicFavorites,
   APPLE_MUSIC_PLAYLISTS_OPPORTUNISTIC_TTL_MS,
+  APPLE_MUSIC_PLAYLIST_TRACKS_OPPORTUNISTIC_TTL_MS,
 } = await import("../src/apps/ipod/hooks/useAppleMusicLibrary");
 const { useIpodStore } = await import("../src/stores/useIpodStore");
 const {
@@ -413,5 +416,157 @@ describe("Apple Music opportunistic playlist refresh", () => {
     // Should not throw; should not flip any loading flags either.
     await refreshStaleAppleMusicPlaylistTracks();
     expect(useIpodStore.getState().appleMusicPlaylistTracksLoading).toEqual({});
+  });
+});
+
+describe("Apple Music Recently Added & Favorites store + refresh", () => {
+  beforeEach(() => {
+    useIpodStore.setState({
+      appleMusicRecentlyAddedTracks: [],
+      appleMusicRecentlyAddedLoadedAt: null,
+      appleMusicRecentlyAddedLoading: false,
+      appleMusicFavoriteTracks: [],
+      appleMusicFavoriteTracksLoadedAt: null,
+      appleMusicFavoritesLoading: false,
+    });
+  });
+
+  test("setAppleMusicRecentlyAddedTracks stamps loadedAt + clears the loading flag", () => {
+    useIpodStore.setState({ appleMusicRecentlyAddedLoading: true });
+    const before = Date.now();
+    useIpodStore
+      .getState()
+      .setAppleMusicRecentlyAddedTracks([
+        {
+          id: "am:1",
+          url: "applemusic:1",
+          title: "One",
+          source: "appleMusic",
+        },
+      ]);
+    const after = Date.now();
+    const state = useIpodStore.getState();
+    expect(state.appleMusicRecentlyAddedTracks).toHaveLength(1);
+    expect(state.appleMusicRecentlyAddedLoading).toBe(false);
+    expect(state.appleMusicRecentlyAddedLoadedAt!).toBeGreaterThanOrEqual(before);
+    expect(state.appleMusicRecentlyAddedLoadedAt!).toBeLessThanOrEqual(after);
+  });
+
+  test("setAppleMusicFavoriteTracks honours an explicit loadedAt (used by hydration)", () => {
+    useIpodStore.getState().setAppleMusicFavoriteTracks(
+      [
+        {
+          id: "am:1",
+          url: "applemusic:1",
+          title: "Liked",
+          source: "appleMusic",
+        },
+      ],
+      99999
+    );
+    expect(useIpodStore.getState().appleMusicFavoriteTracksLoadedAt).toBe(
+      99999
+    );
+  });
+
+  test("prependAppleMusicFavoriteTrack adds the track to the front and de-dupes by id", () => {
+    useIpodStore.setState({
+      appleMusicFavoriteTracks: [
+        {
+          id: "am:1",
+          url: "applemusic:1",
+          title: "One",
+          source: "appleMusic",
+        },
+        {
+          id: "am:2",
+          url: "applemusic:2",
+          title: "Two",
+          source: "appleMusic",
+        },
+      ],
+      appleMusicFavoriteTracksLoadedAt: 12345,
+    });
+
+    useIpodStore.getState().prependAppleMusicFavoriteTrack({
+      id: "am:2",
+      url: "applemusic:2",
+      title: "Two (renamed)",
+      source: "appleMusic",
+    });
+
+    const state = useIpodStore.getState();
+    expect(state.appleMusicFavoriteTracks.map((t) => t.id)).toEqual([
+      "am:2",
+      "am:1",
+    ]);
+    expect(state.appleMusicFavoriteTracks[0].title).toBe("Two (renamed)");
+    // Don't bump loadedAt so the next opportunistic refresh still
+    // revalidates against the server.
+    expect(state.appleMusicFavoriteTracksLoadedAt).toBe(12345);
+  });
+
+  test("refreshAppleMusicRecentlyAdded short-circuits when the cache is fresh enough", async () => {
+    const cached = [
+      {
+        id: "am:1",
+        url: "applemusic:1",
+        title: "Cached",
+        source: "appleMusic" as const,
+      },
+    ];
+    useIpodStore.setState({
+      appleMusicRecentlyAddedTracks: cached,
+      appleMusicRecentlyAddedLoadedAt: Date.now() - 1000,
+    });
+
+    const result = await refreshAppleMusicRecentlyAdded();
+
+    expect(result).toBe(cached);
+    expect(useIpodStore.getState().appleMusicRecentlyAddedLoading).toBe(false);
+  });
+
+  test("refreshAppleMusicRecentlyAdded silently returns cached when MusicKit isn't available + doesn't toggle loading on a stale-but-cached refresh", async () => {
+    const cached = [
+      {
+        id: "am:1",
+        url: "applemusic:1",
+        title: "Stale",
+        source: "appleMusic" as const,
+      },
+    ];
+    useIpodStore.setState({
+      appleMusicRecentlyAddedTracks: cached,
+      appleMusicRecentlyAddedLoadedAt:
+        Date.now() - APPLE_MUSIC_PLAYLIST_TRACKS_OPPORTUNISTIC_TTL_MS - 1,
+    });
+
+    const result = await refreshAppleMusicRecentlyAdded();
+
+    expect(result).toBe(cached);
+    // Loading flag stays false because there's already cached content
+    // for the menu — background refresh must never flash "Loading…".
+    expect(useIpodStore.getState().appleMusicRecentlyAddedLoading).toBe(false);
+  });
+
+  test("refreshAppleMusicFavorites short-circuits when the cache is fresh enough", async () => {
+    const cached = [
+      {
+        id: "am:liked",
+        url: "applemusic:liked",
+        title: "Liked",
+        source: "appleMusic" as const,
+      },
+    ];
+    useIpodStore.setState({
+      appleMusicFavoriteTracks: cached,
+      appleMusicFavoriteTracksLoadedAt:
+        Date.now() - APPLE_MUSIC_PLAYLISTS_OPPORTUNISTIC_TTL_MS,
+    });
+
+    const result = await refreshAppleMusicFavorites();
+
+    expect(result).toBe(cached);
+    expect(useIpodStore.getState().appleMusicFavoritesLoading).toBe(false);
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**Superseded by #1175** — these changes have been folded into the parent PR per follow-up request.

The branch backing this PR (`cursor/ipod-apple-music-swr-on-open-fa17`) has been deleted. Please close this PR from the GitHub UI.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-27447868-ce2e-42c6-99c5-8d75f1dffa17"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-27447868-ce2e-42c6-99c5-8d75f1dffa17"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

