### PR TITLE
fix(ipod): Match Genius playback to Radio when stations are recommended

### DIFF
--- a/src/apps/ipod/hooks/useAppleMusicLibrary.ts
+++ b/src/apps/ipod/hooks/useAppleMusicLibrary.ts
@@ -516,7 +516,15 @@ export async function fetchAppleMusicGeniusTrack(): Promise<Track | null> {
       .filter((track): track is Track => track !== null)
   );
 
-  // Prefer playlists/songs for Genius; stations are already exposed in Radio.
+  // Prefer radio stations first so Music → Genius matches the Radio UX: LIVE
+  // label, station name in the title bar, dynamic now-playing metadata from
+  // MusicKit, and skip uses station queue advances. Playlists/songs remain
+  // as fallbacks when no station is offered in recommendations.
+  const stationTrack = playableTracks.find(
+    (track) => track.appleMusicPlayParams?.stationId
+  );
+  if (stationTrack) return stationTrack;
+
   return (
     playableTracks.find((track) => track.appleMusicPlayParams?.playlistId) ??
     playableTracks.find((track) => track.appleMusicPlayParams?.catalogId) ??


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**Summary**

Apple Music » Genius was choosing playlist or single-track recommendation items ahead of recommendation **stations**. Playlists enqueue with MusicKit using `playlist` options, which bypasses all station-specific iPod UX (`stationId` is absent): no LIVE badge, no alternating station name in the title bar, no `nowPlaying` overlay from the bridge, and next/skip stayed on playlist navigation instead of `skipToNextItem` for stations.

Genius now **prefers the first playable station** from `/v1/me/recommendations` (same payloads already used under Radio). If no station appears in recommendations, behavior falls back to the previous playlist / catalog song / first-item order.

**Testing**

- Ran `npx bun install && npx bun run build`; TypeScript compile and Vite production build succeeded.
- Apple Music Genius cannot be exercised in this cloud environment (no subscribed MusicKit session); please verify briefly on-device: Music » Genius shows LIVE while a station-backed recommendation plays, title bar rotates, and skip behaves like Radio.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0cacfbaf-a067-4fe8-a9c6-157c18774b8a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0cacfbaf-a067-4fe8-a9c6-157c18774b8a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

