### PR TITLE
iPod: radio-style UX for Genius/playlist shells + live lyrics

### DIFF
--- a/src/apps/ipod/components/IpodAppComponent.tsx
+++ b/src/apps/ipod/components/IpodAppComponent.tsx
@@ -23,6 +23,7 @@ import { LyricsSearchDialog } from "@/components/dialogs/LyricsSearchDialog";
 import { SongSearchDialog } from "@/components/dialogs/SongSearchDialog";
 import { getTranslatedAppName } from "@/utils/i18n";
 import { useAudioSettingsStore } from "@/stores/useAudioSettingsStore";
+import { useIpodStore } from "@/stores/useIpodStore";
 import { useIpodLogic } from "../hooks/useIpodLogic";
 import { DisplayMode } from "@/types/lyrics";
 import { useCallback, useMemo } from "react";
@@ -182,6 +183,10 @@ export function IpodAppComponent({
     handleSwitchToAppleMusic,
     pauseBeforeWindowClose,
   } = useIpodLogic({ isWindowOpen, isForeground, initialData, instanceId });
+
+  const setAppleMusicKitNowPlaying = useIpodStore(
+    (s) => s.setAppleMusicKitNowPlaying
+  );
 
   const handleClose = useCallback(() => {
     pauseBeforeWindowClose();
@@ -621,6 +626,7 @@ export function IpodAppComponent({
                               onPause={handlePause}
                               onEnded={handleTrackEnd}
                               onReady={handleReady}
+                              onNowPlayingItemChange={setAppleMusicKitNowPlaying}
                             />
                           ) : (
                             <ReactPlayer

--- a/src/apps/ipod/components/IpodScreen.tsx
+++ b/src/apps/ipod/components/IpodScreen.tsx
@@ -14,7 +14,6 @@ import { useAudioSettingsStore } from "@/stores/useAudioSettingsStore";
 import { LyricsDisplay } from "./LyricsDisplay";
 import {
   AppleMusicPlayerBridge,
-  type AppleMusicNowPlayingMetadata,
 } from "./AppleMusicPlayerBridge";
 import { ActivityIndicatorWithLabel } from "@/components/ui/activity-indicator-with-label";
 import { useTranslation } from "react-i18next";
@@ -36,6 +35,7 @@ import { AmbientBackground } from "@/components/shared/AmbientBackground";
 import { MeshGradientBackground } from "@/components/shared/MeshGradientBackground";
 import { WaterBackground } from "@/components/shared/WaterBackground";
 import type { IpodScreenProps } from "../types";
+import { useIpodStore, isAppleMusicCollectionTrack } from "@/stores/useIpodStore";
 
 // Fixed row height for the iPod menu list. Each `MenuListItem` is a
 // single-line `font-chicago text-[16px]` row; 24px gives a touch more
@@ -158,12 +158,17 @@ export function IpodScreen({
   const masterVolume = useAudioSettingsStore((s) => s.masterVolume);
   const finalIpodVolume = ipodVolume * masterVolume;
   const isAppleMusicTrack = currentTrack?.source === "appleMusic";
-  const isAppleMusicStationTrack = Boolean(
-    currentTrack?.appleMusicPlayParams?.stationId
+  const isAppleMusicCollectionShell =
+    isAppleMusicCollectionTrack(currentTrack);
+  const collectionShellKey =
+    currentTrack?.appleMusicPlayParams?.stationId ??
+    currentTrack?.appleMusicPlayParams?.playlistId ??
+    null;
+  const appleMusicKitNowPlaying = useIpodStore((s) => s.appleMusicKitNowPlaying);
+  const setAppleMusicKitNowPlaying = useIpodStore(
+    (s) => s.setAppleMusicKitNowPlaying
   );
-  const [appleMusicNowPlayingItem, setAppleMusicNowPlayingItem] =
-    useState<AppleMusicNowPlayingMetadata | null>(null);
-  const [showStationTitleInTitlebar, setShowStationTitleInTitlebar] =
+  const [showShellTitleInTitlebar, setShowShellTitleInTitlebar] =
     useState(false);
   const effectiveDisplayMode =
     isAppleMusicTrack && displayMode === DisplayMode.Video
@@ -171,41 +176,39 @@ export function IpodScreen({
       : displayMode;
   const shouldAnimateVisuals = showVideo && isPlaying;
 
-  const stationId = currentTrack?.appleMusicPlayParams?.stationId ?? null;
   useEffect(() => {
-    setAppleMusicNowPlayingItem(null);
-    setShowStationTitleInTitlebar(false);
-  }, [stationId]);
+    setShowShellTitleInTitlebar(false);
+  }, [collectionShellKey]);
 
   useEffect(() => {
-    if (!stationId || menuMode || !isPlaying) {
-      setShowStationTitleInTitlebar(false);
+    if (!collectionShellKey || menuMode || !isPlaying) {
+      setShowShellTitleInTitlebar(false);
       return;
     }
     const intervalId = window.setInterval(() => {
-      setShowStationTitleInTitlebar((showStation) => !showStation);
+      setShowShellTitleInTitlebar((show) => !show);
     }, 5000);
     return () => window.clearInterval(intervalId);
-  }, [isPlaying, menuMode, stationId]);
+  }, [isPlaying, menuMode, collectionShellKey]);
 
   const nowPlayingDisplayTrack = useMemo(() => {
-    if (!currentTrack || !isAppleMusicStationTrack || !appleMusicNowPlayingItem) {
+    if (!currentTrack || !isAppleMusicCollectionShell || !appleMusicKitNowPlaying) {
       return currentTrack;
     }
     return {
       ...currentTrack,
-      title: appleMusicNowPlayingItem.title,
-      artist: appleMusicNowPlayingItem.artist ?? currentTrack.artist,
-      album: appleMusicNowPlayingItem.album,
-      cover: appleMusicNowPlayingItem.cover ?? currentTrack.cover,
+      title: appleMusicKitNowPlaying.title,
+      artist: appleMusicKitNowPlaying.artist ?? currentTrack.artist,
+      album: appleMusicKitNowPlaying.album,
+      cover: appleMusicKitNowPlaying.cover ?? currentTrack.cover,
     };
-  }, [appleMusicNowPlayingItem, currentTrack, isAppleMusicStationTrack]);
+  }, [appleMusicKitNowPlaying, currentTrack, isAppleMusicCollectionShell]);
 
   const titlebarTitle =
     !menuMode &&
-    isAppleMusicStationTrack &&
+    isAppleMusicCollectionShell &&
     isPlaying &&
-    showStationTitleInTitlebar &&
+    showShellTitleInTitlebar &&
     currentTrack?.title
       ? currentTrack.title
       : currentMenuTitle;
@@ -418,7 +421,7 @@ export function IpodScreen({
                 onPause={!isFullScreen ? handlePause : undefined}
                 onEnded={!isFullScreen ? handleTrackEnd : undefined}
                 onReady={!isFullScreen ? handleReady : undefined}
-                onNowPlayingItemChange={setAppleMusicNowPlayingItem}
+                onNowPlayingItemChange={setAppleMusicKitNowPlaying}
               />
             ) : (
               <div
@@ -749,9 +752,11 @@ export function IpodScreen({
                       )}
                     >
                       <span>
-                        {isAppleMusicStationTrack
+                        {currentTrack?.appleMusicPlayParams?.stationId
                           ? "LIVE"
-                          : `${currentIndex + 1} of ${tracksLength}`}
+                          : isAppleMusicCollectionShell
+                            ? "MIX"
+                            : `${currentIndex + 1} of ${tracksLength}`}
                       </span>
                       {isShuffled && (
                         <Shuffle

--- a/src/apps/ipod/hooks/useIpodLogic.ts
+++ b/src/apps/ipod/hooks/useIpodLogic.ts
@@ -32,6 +32,8 @@ import {
   Track,
   getEffectiveTranslationLanguage,
   flushPendingLyricOffsetSave,
+  isAppleMusicCollectionTrack,
+  appleMusicKitIdToLyricsSongId,
 } from "@/stores/useIpodStore";
 import { useShallow } from "zustand/react/shallow";
 import {
@@ -74,13 +76,6 @@ const IS_IOS = /iP(hone|od|ad)/.test(UA);
 const IS_SAFARI =
   /Safari/.test(UA) && !/Chrome/.test(UA) && !/CriOS/.test(UA);
 const IS_IOS_SAFARI = IS_IOS && IS_SAFARI;
-
-function isAppleMusicCollectionTrack(track: Track | null | undefined): boolean {
-  return Boolean(
-    track?.appleMusicPlayParams?.stationId ||
-      track?.appleMusicPlayParams?.playlistId
-  );
-}
 
 export interface UseIpodLogicOptions {
   isWindowOpen: boolean;
@@ -2506,7 +2501,7 @@ export function useIpodLogic({
     }, 2000);
   }, []);
 
-  const getCurrentAppleMusicStationTrack = useCallback(() => {
+  const getCurrentAppleMusicCollectionShellTrack = useCallback(() => {
     const state = useIpodStore.getState();
     if (state.librarySource !== "appleMusic" || !state.appleMusicCurrentSongId) {
       return null;
@@ -2519,58 +2514,80 @@ export function useIpodLogic({
         (candidate) => candidate.id === state.appleMusicCurrentSongId
       ) ??
       null;
-    return track?.appleMusicPlayParams?.stationId ? track : null;
+    return track && isAppleMusicCollectionTrack(track) ? track : null;
   }, [appleMusicRadioTracks]);
 
-  const skipAppleMusicStationTrack = useCallback(async () => {
-    if (!getCurrentAppleMusicStationTrack()) return false;
-    const activePlayer = isFullScreen
-      ? fullScreenPlayerRef.current
-      : playerRef.current;
-    const instance = activePlayer?.getInternalPlayer?.();
-    if (!instance || typeof instance.skipToNextItem !== "function") {
-      return false;
-    }
+  const skipAppleMusicCollectionShell = useCallback(
+    async (direction: "next" | "previous") => {
+      const shellTrack = getCurrentAppleMusicCollectionShellTrack();
+      if (!shellTrack) return false;
+      const activePlayer = isFullScreen
+        ? fullScreenPlayerRef.current
+        : playerRef.current;
+      const instance = activePlayer?.getInternalPlayer?.();
+      if (!instance) return false;
 
-    try {
-      skipOperationRef.current = true;
-      startTrackSwitch();
-      useIpodStore.getState().setElapsedTime(0);
-      useIpodStore.getState().setTotalTime(0);
-      await instance.skipToNextItem();
-      setIsPlaying(true);
-      showStatus("⏭");
-      return true;
-    } catch (err) {
-      console.warn("[apple music] failed to skip radio station item", err);
-      return false;
-    }
-  }, [
-    getCurrentAppleMusicStationTrack,
-    isFullScreen,
-    setIsPlaying,
-    showStatus,
-    startTrackSwitch,
-  ]);
+      const isStation = Boolean(shellTrack.appleMusicPlayParams?.stationId);
+      const skipNext =
+        direction === "next" ||
+        isStation ||
+        typeof instance.skipToPreviousItem !== "function";
+      if (skipNext && typeof instance.skipToNextItem !== "function") {
+        return false;
+      }
+      if (!skipNext && typeof instance.skipToPreviousItem !== "function") {
+        return false;
+      }
+
+      try {
+        skipOperationRef.current = true;
+        startTrackSwitch();
+        useIpodStore.getState().setElapsedTime(0);
+        useIpodStore.getState().setTotalTime(0);
+        if (skipNext) {
+          await instance.skipToNextItem();
+        } else {
+          await instance.skipToPreviousItem();
+        }
+        setIsPlaying(true);
+        showStatus(direction === "previous" ? "⏮" : "⏭");
+        return true;
+      } catch (err) {
+        console.warn("[apple music] failed to skip collection queue item", err);
+        return false;
+      }
+    },
+    [
+      getCurrentAppleMusicCollectionShellTrack,
+      isFullScreen,
+      setIsPlaying,
+      showStatus,
+      startTrackSwitch,
+    ]
+  );
 
   const nextTrack = useCallback(() => {
-    if (getCurrentAppleMusicStationTrack()) {
-      void skipAppleMusicStationTrack();
+    if (getCurrentAppleMusicCollectionShellTrack()) {
+      void skipAppleMusicCollectionShell("next");
       return;
     }
     rawNextTrack();
-  }, [getCurrentAppleMusicStationTrack, rawNextTrack, skipAppleMusicStationTrack]);
+  }, [
+    getCurrentAppleMusicCollectionShellTrack,
+    rawNextTrack,
+    skipAppleMusicCollectionShell,
+  ]);
 
   const previousTrack = useCallback(() => {
-    if (getCurrentAppleMusicStationTrack()) {
-      void skipAppleMusicStationTrack();
+    if (getCurrentAppleMusicCollectionShellTrack()) {
+      void skipAppleMusicCollectionShell("previous");
       return;
     }
     rawPreviousTrack();
   }, [
-    getCurrentAppleMusicStationTrack,
+    getCurrentAppleMusicCollectionShellTrack,
     rawPreviousTrack,
-    skipAppleMusicStationTrack,
+    skipAppleMusicCollectionShell,
   ]);
 
   // Track handling
@@ -3039,8 +3056,8 @@ export function useIpodLogic({
           }
           if (isOffline) {
             showOfflineStatus();
-          } else if (getCurrentAppleMusicStationTrack()) {
-            void skipAppleMusicStationTrack();
+          } else if (getCurrentAppleMusicCollectionShellTrack()) {
+            void skipAppleMusicCollectionShell("next");
           } else {
             skipOperationRef.current = true;
             startTrackSwitch();
@@ -3077,8 +3094,8 @@ export function useIpodLogic({
           }
           if (isOffline) {
             showOfflineStatus();
-          } else if (getCurrentAppleMusicStationTrack()) {
-            void skipAppleMusicStationTrack();
+          } else if (getCurrentAppleMusicCollectionShellTrack()) {
+            void skipAppleMusicCollectionShell("previous");
           } else {
             skipOperationRef.current = true;
             startTrackSwitch();
@@ -3128,7 +3145,7 @@ export function useIpodLogic({
           break;
       }
     },
-    [playClickSound, vibrate, registerActivity, getCurrentAppleMusicStationTrack, skipAppleMusicStationTrack, nextTrack, showStatus, togglePlay, previousTrack, menuMode, menuHistory, selectedMenuItem, tracks, currentIndex, isPlaying, toggleVideo, handleMenuButton, isOffline, showOfflineStatus, startTrackSwitch, isCoverFlowOpen, isMusicQuizOpen, isBrickGameOpen]
+    [playClickSound, vibrate, registerActivity, getCurrentAppleMusicCollectionShellTrack, skipAppleMusicCollectionShell, nextTrack, showStatus, togglePlay, previousTrack, menuMode, menuHistory, selectedMenuItem, tracks, currentIndex, isPlaying, toggleVideo, handleMenuButton, isOffline, showOfflineStatus, startTrackSwitch, isCoverFlowOpen, isMusicQuizOpen, isBrickGameOpen]
   );
 
   // Wheel rotation handler
@@ -3371,6 +3388,7 @@ export function useIpodLogic({
 
   // Volume from audio settings store
   const { ipodVolume } = useAudioSettingsStoreShallow((state) => ({ ipodVolume: state.ipodVolume }));
+  const appleMusicKitNowPlaying = useIpodStore((s) => s.appleMusicKitNowPlaying);
 
   // Lyrics hook
   const selectedMatchForLyrics = useMemo(() => {
@@ -3390,16 +3408,45 @@ export function useIpodLogic({
     () => getEffectiveTranslationLanguage(lyricsTranslationLanguage),
     [lyricsTranslationLanguage, appLanguage]
   );
-  const lyricsSongId =
-    isAppleMusicCollectionTrack(currentTrack)
-      ? ""
-      : currentTrack?.id ?? "";
+  const lyricsTitle = useMemo(() => {
+    if (currentTrack && isAppleMusicCollectionTrack(currentTrack)) {
+      const live = appleMusicKitNowPlaying?.title?.trim();
+      if (live) return live;
+    }
+    return currentTrack?.title ?? "";
+  }, [currentTrack, appleMusicKitNowPlaying?.title]);
+
+  const lyricsArtist = useMemo(() => {
+    if (currentTrack && isAppleMusicCollectionTrack(currentTrack)) {
+      const live = appleMusicKitNowPlaying?.artist?.trim();
+      if (live) return live;
+    }
+    return currentTrack?.artist ?? "";
+  }, [currentTrack, appleMusicKitNowPlaying?.artist]);
+
+  const lyricsSongId = useMemo(() => {
+    if (!currentTrack) return "";
+    if (isAppleMusicCollectionTrack(currentTrack)) {
+      return appleMusicKitIdToLyricsSongId(appleMusicKitNowPlaying?.id);
+    }
+    return currentTrack.id ?? "";
+  }, [currentTrack, appleMusicKitNowPlaying?.id]);
+
+  const lyricsTimingOffsetMs = useMemo(() => {
+    if (
+      isAppleMusicCollectionTrack(currentTrack) &&
+      appleMusicKitNowPlaying?.id
+    ) {
+      return 0;
+    }
+    return currentTrack?.lyricOffset ?? 0;
+  }, [currentTrack, appleMusicKitNowPlaying?.id]);
 
   const fullScreenLyricsControls = useLyrics({
     songId: lyricsSongId,
-    title: currentTrack?.title ?? "",
-    artist: currentTrack?.artist ?? "",
-    currentTime: elapsedTime + (currentTrack?.lyricOffset ?? 0) / 1000,
+    title: lyricsTitle,
+    artist: lyricsArtist,
+    currentTime: elapsedTime + lyricsTimingOffsetMs / 1000,
     translateTo: effectiveTranslationLanguage,
     selectedMatch: selectedMatchForLyrics,
     includeFurigana: true, // Fetch furigana info with lyrics to reduce API calls

--- a/src/stores/useIpodStore.ts
+++ b/src/stores/useIpodStore.ts
@@ -92,6 +92,28 @@ export interface Track {
   appleMusicPlayParams?: AppleMusicPlayParams;
 }
 
+/**
+ * Live now-playing row from MusicKit (`mediaItemDidChange`) while a station or
+ * catalog playlist queue is active. Drives LCD metadata, title bar rotation,
+ * and lyrics for air items (the store `currentTrack` stays the shell row).
+ */
+export interface AppleMusicKitNowPlaying {
+  id?: string;
+  title: string;
+  artist?: string;
+  album?: string;
+  cover?: string;
+}
+
+/** Map a MusicKit media item id to the `am:…` form expected by `/api/songs`. */
+export function appleMusicKitIdToLyricsSongId(
+  kitId: string | undefined
+): string {
+  if (!kitId) return "";
+  if (kitId.startsWith("am:")) return kitId;
+  return `am:${kitId}`;
+}
+
 type LibraryState = "uninitialized" | "loaded" | "cleared";
 
 interface IpodData {
@@ -194,6 +216,8 @@ interface IpodData {
   appleMusicLibraryError: string | null;
   /** Cached storefront ID reported by MusicKit (e.g. "us"). */
   appleMusicStorefrontId: string | null;
+  /** Live MusicKit now-playing metadata during station / playlist queue playback. */
+  appleMusicKitNowPlaying: AppleMusicKitNowPlaying | null;
 
   // ---------- Menu navigation persistence ----------
 
@@ -370,6 +394,7 @@ const initialIpodData: IpodData = {
   appleMusicLibraryLoading: false,
   appleMusicLibraryError: null,
   appleMusicStorefrontId: null,
+  appleMusicKitNowPlaying: null,
 
   ipodMenuBreadcrumb: null,
   ipodMenuMode: null,
@@ -396,10 +421,12 @@ function resolveAppleMusicQueueTracks(state: IpodData): Track[] {
     .filter((track): track is Track => track !== null);
 }
 
-function isAppleMusicCollectionTrack(track: Track): boolean {
+export function isAppleMusicCollectionTrack(
+  track: Track | null | undefined
+): boolean {
   return Boolean(
-    track.appleMusicPlayParams?.stationId ||
-      track.appleMusicPlayParams?.playlistId
+    track?.appleMusicPlayParams?.stationId ||
+      track?.appleMusicPlayParams?.playlistId
   );
 }
 
@@ -547,6 +574,10 @@ export interface IpodState extends IpodData {
   appleMusicPreviousTrack: () => void;
   /** Cache the user's storefront for catalog API calls. */
   setAppleMusicStorefrontId: (storefrontId: string | null) => void;
+  /** Live MusicKit now-playing snapshot (station / playlist queue air item). */
+  setAppleMusicKitNowPlaying: (
+    snapshot: AppleMusicKitNowPlaying | null
+  ) => void;
 
   /** Persist the user's current menu navigation breadcrumb. */
   setIpodMenuBreadcrumb: (
@@ -1841,6 +1872,7 @@ export const useIpodStore = create<IpodState>()(
           totalTime: 0,
           currentLyrics: null,
           currentFuriganaMap: null,
+          appleMusicKitNowPlaying: null,
         });
       },
       setAppleMusicTracks: (tracks) => {
@@ -1970,6 +2002,7 @@ export const useIpodStore = create<IpodState>()(
           // Reset transient progress + lyrics whenever the active track changes.
           return {
             appleMusicCurrentSongId: songId,
+            appleMusicKitNowPlaying: null,
             currentLyrics: null,
             currentFuriganaMap: null,
             elapsedTime: 0,
@@ -2084,6 +2117,8 @@ export const useIpodStore = create<IpodState>()(
         }),
       setAppleMusicStorefrontId: (storefrontId) =>
         set({ appleMusicStorefrontId: storefrontId }),
+      setAppleMusicKitNowPlaying: (snapshot) =>
+        set({ appleMusicKitNowPlaying: snapshot }),
       setIpodMenuBreadcrumb: (breadcrumb) =>
         set({ ipodMenuBreadcrumb: breadcrumb }),
       setIpodMenuMode: (menuMode) => set({ ipodMenuMode: menuMode }),

--- a/tests/test-ipod-apple-music.test.ts
+++ b/tests/test-ipod-apple-music.test.ts
@@ -46,7 +46,7 @@ const {
   APPLE_MUSIC_PLAYLISTS_OPPORTUNISTIC_TTL_MS,
   APPLE_MUSIC_PLAYLIST_TRACKS_OPPORTUNISTIC_TTL_MS,
 } = await import("../src/apps/ipod/hooks/useAppleMusicLibrary");
-const { useIpodStore } = await import("../src/stores/useIpodStore");
+const { useIpodStore, appleMusicKitIdToLyricsSongId } = await import("../src/stores/useIpodStore");
 const {
   isValidAppleMusicSongId,
   isValidYouTubeVideoId,
@@ -78,6 +78,12 @@ describe("Apple Music song ID validation", () => {
     expect(isValidSongId("not-a-real-id")).toBe(false);
     expect(isValidSongId("am:")).toBe(false);
     expect(isValidSongId("am:foo bar")).toBe(false);
+  });
+
+  test("normalizes MusicKit ids for lyrics API paths", () => {
+    expect(appleMusicKitIdToLyricsSongId(undefined)).toBe("");
+    expect(appleMusicKitIdToLyricsSongId("1616228595")).toBe("am:1616228595");
+    expect(appleMusicKitIdToLyricsSongId("am:1616228595")).toBe("am:1616228595");
   });
 });
 
@@ -287,6 +293,7 @@ describe("useIpodStore Apple Music slice", () => {
       isPlaying: true,
       elapsedTime: 42,
       totalTime: 200,
+      appleMusicKitNowPlaying: { title: "On Air", id: "1616228595" },
     });
     useIpodStore.getState().setLibrarySource("appleMusic");
     const state = useIpodStore.getState();
@@ -294,6 +301,17 @@ describe("useIpodStore Apple Music slice", () => {
     expect(state.isPlaying).toBe(false);
     expect(state.elapsedTime).toBe(0);
     expect(state.totalTime).toBe(0);
+    expect(state.appleMusicKitNowPlaying).toBeNull();
+  });
+
+  test("setAppleMusicCurrentSongId clears live MusicKit metadata snapshot", () => {
+    useIpodStore.setState({
+      librarySource: "appleMusic",
+      appleMusicCurrentSongId: "am:station:x",
+      appleMusicKitNowPlaying: { title: "Song", id: "999" },
+    });
+    useIpodStore.getState().setAppleMusicCurrentSongId("am:1");
+    expect(useIpodStore.getState().appleMusicKitNowPlaying).toBeNull();
   });
 
   test("setAppleMusicTracks selects the first track when current is no longer in the list", () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
This aligns **Apple Music station playback** and **catalog playlist shells** (Genius / `setQueue({ playlist })`) so the iPod behaves like radio for the parts you called out.

**What changed**
- **Title bar:** While Now Playing, a station or recommendation-playlist shell still alternates every ~5s between “Now Playing” and the **shell row title** (station name / Genius mix name), with marquee scrolling unchanged.
- **LCD:** Uses **live `mediaItemDidChange` metadata** (title, artist, album, artwork) for both `stationId` and `playlistId` shells—not just radio.
- **Skip:** Shell tracks still use MusicKit. **Radio:** previous and next both advance the station (unchanged). **Playlist shells:** **next → `skipToNextItem`**, **previous → `skipToPreviousItem`** (in-menu wheel and shared `nextTrack` / `previousTrack` paths).
- **Lyrics:** Lyrics hook uses the **live MusicKit song id** (normalized to `am:…` for `/api/songs`) plus live title/artist when a shell is playing. Fullscreen `AppleMusicPlayerBridge` now reports `onNowPlayingItemChange` like the windowed player.
- **Store:** `appleMusicKitNowPlaying` + setter; cleared on library switch, current-song change, and covered by tests.

**Badge:** Station rows still show **LIVE**; playlist shells show **MIX** (so Genius isn’t labeled LIVE).

**Testing**
- `bun run build` (tsc + vite) — pass.
- `bun test tests/test-ipod-apple-music.test.ts` — pass (including new cases for lyrics id normalization and store resets).

Live Apple Music / MusicKit behavior wasn’t exercised here (no session); unit + compile coverage only.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-80cd1545-7be5-4c8b-b8ab-83cf545a8b1b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-80cd1545-7be5-4c8b-b8ab-83cf545a8b1b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

