### PR TITLE
Localize Apple Music search UI and catalog metadata

### DIFF
--- a/src/apps/ipod/hooks/useAppleMusicLibrary.ts
+++ b/src/apps/ipod/hooks/useAppleMusicLibrary.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef } from "react";
 import { toast } from "sonner";
 import { useTranslation } from "react-i18next";
+import i18n from "@/lib/i18n";
 import {
   useIpodStore,
   type AppleMusicPlaylist,
@@ -223,7 +224,7 @@ export function libraryResourceToTrack(
     url: attrs.url?.startsWith("https://music.apple.com/")
       ? attrs.url
       : `applemusic:${stableId}`,
-    title: attrs.name || "Untitled",
+    title: attrs.name || i18n.t("apps.ipod.appleMusic.untitledSong"),
     artist: attrs.artistName || "",
     album: attrs.albumName || albumResource?.attributes?.name,
     albumArtist: attrs.albumArtistName || albumResource?.attributes?.artistName,
@@ -286,7 +287,7 @@ function libraryPlaylistResourceToPlaylist(
 
 export function appleMusicPlayableResourceToTrack(
   res: AppleMusicCatalogPlayableResource,
-  fallbackArtist = "Apple Music"
+  fallbackArtist?: string
 ): Track | null {
   const attrs = res.attributes;
   if (!attrs) return null;
@@ -294,14 +295,17 @@ export function appleMusicPlayableResourceToTrack(
   const playableId = playParams?.id || playParams?.catalogId || res.id;
   if (!playableId) return null;
 
+  const curatorFallback =
+    fallbackArtist ?? i18n.t("apps.ipod.appleMusic.fallbackCurator");
+
   if (res.type === "stations") {
     return {
       id: `am:station:${playableId}`,
       url: attrs.url?.startsWith("https://music.apple.com/")
         ? attrs.url
         : `applemusic:station:${playableId}`,
-      title: attrs.name || "Apple Music Radio",
-      artist: attrs.curatorName || fallbackArtist,
+      title: attrs.name || i18n.t("apps.ipod.appleMusic.fallbackRadioTitle"),
+      artist: attrs.curatorName || curatorFallback,
       cover: resolveArtworkUrl(attrs.artwork, 600),
       source: "appleMusic",
       appleMusicPlayParams: {
@@ -318,8 +322,8 @@ export function appleMusicPlayableResourceToTrack(
       url: attrs.url?.startsWith("https://music.apple.com/")
         ? attrs.url
         : `applemusic:playlist:${playableId}`,
-      title: attrs.name || "Apple Music Mix",
-      artist: attrs.curatorName || fallbackArtist,
+      title: attrs.name || i18n.t("apps.ipod.appleMusic.fallbackPlaylistTitle"),
+      artist: attrs.curatorName || curatorFallback,
       cover: resolveArtworkUrl(attrs.artwork, 600),
       source: "appleMusic",
       appleMusicPlayParams: {
@@ -473,7 +477,7 @@ export async function fetchAppleMusicRadioStations(
         .map((resource) =>
           appleMusicPlayableResourceToTrack(
             resource,
-            recommendation.attributes?.title?.stringForDisplay || "Apple Music"
+            recommendation.attributes?.title?.stringForDisplay
           )
         )
         .filter((track): track is Track => track !== null)
@@ -510,7 +514,7 @@ export async function fetchAppleMusicGeniusTrack(): Promise<Track | null> {
       .map((resource) =>
         appleMusicPlayableResourceToTrack(
           resource,
-          recommendation.attributes?.title?.stringForDisplay || "Apple Music"
+          recommendation.attributes?.title?.stringForDisplay
         )
       )
       .filter((track): track is Track => track !== null)

--- a/src/components/dialogs/SongSearchDialog.tsx
+++ b/src/components/dialogs/SongSearchDialog.tsx
@@ -144,18 +144,12 @@ export function SongSearchDialog({
       if (isAppleMusicMode) {
         if (!appleMusicAuthorized) {
           throw new Error(
-            t(
-              "apps.ipod.dialogs.appleMusicSearchSignInRequired",
-              "Sign in to Apple Music to search"
-            )
+            t("apps.ipod.dialogs.appleMusicSearchSignInRequired")
           );
         }
         if (!onAppleMusicSearch) {
           throw new Error(
-            t(
-              "apps.ipod.dialogs.appleMusicSearchUnavailable",
-              "Apple Music search is unavailable"
-            )
+            t("apps.ipod.dialogs.appleMusicSearchUnavailable")
           );
         }
         const appleResults = await onAppleMusicSearch(
@@ -298,10 +292,10 @@ export function SongSearchDialog({
         >
           <ThemedTabsList className="w-full mb-2">
             <ThemedTabsTrigger value="catalog" className="flex-1">
-              {t("apps.ipod.dialogs.appleMusicSearchAppleMusic", "Apple Music")}
+              {t("apps.ipod.dialogs.appleMusicSearchAppleMusic")}
             </ThemedTabsTrigger>
             <ThemedTabsTrigger value="library" className="flex-1">
-              {t("apps.ipod.dialogs.appleMusicSearchLibrary", "Library")}
+              {t("apps.ipod.dialogs.appleMusicSearchLibrary")}
             </ThemedTabsTrigger>
           </ThemedTabsList>
         </Tabs>
@@ -318,10 +312,7 @@ export function SongSearchDialog({
           }}
           placeholder={
             isAppleMusicMode
-              ? t(
-                  "apps.ipod.dialogs.appleMusicSearchPlaceholder",
-                  "Search Apple Music..."
-                )
+              ? t("apps.ipod.dialogs.appleMusicSearchPlaceholder")
               : t("apps.ipod.dialogs.songSearchPlaceholder")
           }
           className={cn("shadow-none", fontClass)}
@@ -403,7 +394,12 @@ export function SongSearchDialog({
                 color: selected ? undefined : "#4b5563",
               }}
             >
-              {[result.artist, result.album].filter(Boolean).join(" · ")}
+              {[
+                result.artist?.trim() || t("apps.ipod.menu.unknownArtist"),
+                result.album,
+              ]
+                .filter(Boolean)
+                .join(" · ")}
             </div>
           </div>
         </div>
@@ -486,10 +482,7 @@ export function SongSearchDialog({
         <div style={{ marginBottom: "12px" }}>
           <p className={cn("text-gray-500 mb-2", fontClass)} style={fontStyle}>
             {isAppleMusicMode
-              ? t(
-                  "apps.ipod.dialogs.appleMusicSearchSelectResult",
-                  "Select a song to add:"
-                )
+              ? t("apps.ipod.dialogs.appleMusicSearchSelectResult")
               : t("apps.ipod.dialogs.songSearchSelectResult")}
           </p>
           <div
@@ -557,7 +550,9 @@ export function SongSearchDialog({
                 {t("apps.ipod.dialogs.addSongTitle")}
               </DialogTitle>
               <DialogDescription className="sr-only">
-                {t("apps.ipod.dialogs.songSearchDescription")}
+                {isAppleMusicMode
+                  ? t("apps.ipod.dialogs.appleMusicSearchDescription")
+                  : t("apps.ipod.dialogs.songSearchDescription")}
               </DialogDescription>
             </DialogHeader>
             {dialogContent}

--- a/src/lib/locales/de/translation.json
+++ b/src/lib/locales/de/translation.json
@@ -2140,6 +2140,12 @@
       "year": "Jahr"
     },
     "ipod": {
+      "appleMusic": {
+        "fallbackCurator": "[TODO] Apple Music",
+        "fallbackPlaylistTitle": "[TODO] Apple Music Mix",
+        "fallbackRadioTitle": "[TODO] Apple Music Radio",
+        "untitledSong": "[TODO] Untitled"
+      },
       "ariaLabels": {
         "closeFullscreen": "Vollbild schließen",
         "cycleLyricFont": "Liedtext-Schriftart wechseln",
@@ -2193,6 +2199,7 @@
         "appleMusicRadioFailed": "Apple Music-Radio konnte nicht geladen werden",
         "appleMusicRecentlyAddedFailed": "Fehler beim Laden der zuletzt hinzugefügten Titel",
         "appleMusicSearchAppleMusic": "Apple Music",
+        "appleMusicSearchDescription": "[TODO] Search Apple Music and your library, then pick a song to add",
         "appleMusicSearchLibrary": "Mediathek",
         "appleMusicSearchPlaceholder": "Apple Music durchsuchen...",
         "appleMusicSearchSelectResult": "Wähle einen Titel zum Hinzufügen aus:",
@@ -2263,13 +2270,13 @@
           "description": "Wähle Cover-, Landschafts-, Warp-, Mesh- oder Wasser-Visualisierungen; Apple Music startet mit Cover und blendet den Videomodus aus",
           "title": "Vollbild-Visualisierungen"
         },
-        "shareSongs": {
-          "description": "YouTube-Songs teilen ryOS-Links, während Apple Music-Songs ihren Apple Music-Link kopieren",
-          "title": "Songs teilen"
-        },
         "lyricsPronunciation": {
           "description": "Sieh dir live-synchronisierte Songtexte mit Übersetzungen, Furigana, Romaji und Pinyin an",
           "title": "Synchrone Songtexte"
+        },
+        "shareSongs": {
+          "description": "YouTube-Songs teilen ryOS-Links, während Apple Music-Songs ihren Apple Music-Link kopieren",
+          "title": "Songs teilen"
         },
         "wheelNavigation": {
           "description": "Drehe das Rad (oder dein Scrollrad), um durch Menüs und Titel zu blättern",

--- a/src/lib/locales/en/translation.json
+++ b/src/lib/locales/en/translation.json
@@ -1751,6 +1751,12 @@
     "ipod": {
       "name": "iPod",
       "description": "Music player",
+      "appleMusic": {
+        "untitledSong": "Untitled",
+        "fallbackCurator": "Apple Music",
+        "fallbackRadioTitle": "Apple Music Radio",
+        "fallbackPlaylistTitle": "Apple Music Mix"
+      },
       "menu": {
         "addSong": "Add Song...",
         "searchSongs": "Search Songs...",
@@ -1925,6 +1931,7 @@
         "appleMusicLibraryFailed": "Failed to load Apple Music library",
         "appleMusicSearchSignInRequired": "Sign in to Apple Music to search",
         "appleMusicSearchUnavailable": "Apple Music search is unavailable",
+        "appleMusicSearchDescription": "Search Apple Music and your library, then pick a song to add",
         "appleMusicSearchAppleMusic": "Apple Music",
         "appleMusicSearchLibrary": "Library",
         "appleMusicSearchPlaceholder": "Search Apple Music...",

--- a/src/lib/locales/es/translation.json
+++ b/src/lib/locales/es/translation.json
@@ -2140,6 +2140,12 @@
       "year": "Año"
     },
     "ipod": {
+      "appleMusic": {
+        "fallbackCurator": "[TODO] Apple Music",
+        "fallbackPlaylistTitle": "[TODO] Apple Music Mix",
+        "fallbackRadioTitle": "[TODO] Apple Music Radio",
+        "untitledSong": "[TODO] Untitled"
+      },
       "ariaLabels": {
         "closeFullscreen": "Cerrar pantalla completa",
         "cycleLyricFont": "Alternar fuente de la letra",
@@ -2193,6 +2199,7 @@
         "appleMusicRadioFailed": "Error al cargar la radio de Apple Music",
         "appleMusicRecentlyAddedFailed": "Error al cargar las canciones añadidas recientemente",
         "appleMusicSearchAppleMusic": "Apple Music",
+        "appleMusicSearchDescription": "[TODO] Search Apple Music and your library, then pick a song to add",
         "appleMusicSearchLibrary": "Biblioteca",
         "appleMusicSearchPlaceholder": "Buscar en Apple Music...",
         "appleMusicSearchSelectResult": "Selecciona una canción para añadir:",
@@ -2263,13 +2270,13 @@
           "description": "Elige visuales de carátula, paisajes, distorsión, malla o agua; Apple Music usa carátula por defecto y oculta el modo vídeo",
           "title": "Visualizaciones a pantalla completa"
         },
-        "shareSongs": {
-          "description": "Las canciones de YouTube comparten enlaces de ryOS, mientras que las de Apple Music copian su enlace de Apple Music",
-          "title": "Compartir canciones"
-        },
         "lyricsPronunciation": {
           "description": "Mira letras sincronizadas en vivo con traducciones, furigana, romaji y pinyin",
           "title": "Letras sincronizadas"
+        },
+        "shareSongs": {
+          "description": "Las canciones de YouTube comparten enlaces de ryOS, mientras que las de Apple Music copian su enlace de Apple Music",
+          "title": "Compartir canciones"
         },
         "wheelNavigation": {
           "description": "Gira la rueda (o tu rueda de desplazamiento) para navegar por los menús y las pistas",

--- a/src/lib/locales/fr/translation.json
+++ b/src/lib/locales/fr/translation.json
@@ -2140,6 +2140,12 @@
       "year": "Année"
     },
     "ipod": {
+      "appleMusic": {
+        "fallbackCurator": "[TODO] Apple Music",
+        "fallbackPlaylistTitle": "[TODO] Apple Music Mix",
+        "fallbackRadioTitle": "[TODO] Apple Music Radio",
+        "untitledSong": "[TODO] Untitled"
+      },
       "ariaLabels": {
         "closeFullscreen": "Quitter le mode plein écran",
         "cycleLyricFont": "Changer la police des paroles",
@@ -2193,6 +2199,7 @@
         "appleMusicRadioFailed": "Échec du chargement de la radio Apple Music",
         "appleMusicRecentlyAddedFailed": "Échec du chargement des morceaux ajoutés récemment",
         "appleMusicSearchAppleMusic": "Apple Music",
+        "appleMusicSearchDescription": "[TODO] Search Apple Music and your library, then pick a song to add",
         "appleMusicSearchLibrary": "Bibliothèque",
         "appleMusicSearchPlaceholder": "Rechercher dans Apple Music…",
         "appleMusicSearchSelectResult": "Sélectionnez un morceau à ajouter :",
@@ -2263,13 +2270,13 @@
           "description": "Choisissez les visuels pochette, paysage, warp, mesh ou eau; Apple Music utilise la pochette par défaut et masque le mode vidéo",
           "title": "Visuels plein écran"
         },
-        "shareSongs": {
-          "description": "Les morceaux YouTube se partagent avec des liens ryOS, tandis que les morceaux Apple Music copient leur lien Apple Music",
-          "title": "Partager des morceaux"
-        },
         "lyricsPronunciation": {
           "description": "Affichez les paroles synchronisées en direct avec traductions, furigana, romaji et pinyin.",
           "title": "Paroles synchronisées"
+        },
+        "shareSongs": {
+          "description": "Les morceaux YouTube se partagent avec des liens ryOS, tandis que les morceaux Apple Music copient leur lien Apple Music",
+          "title": "Partager des morceaux"
         },
         "wheelNavigation": {
           "description": "Faites tourner la molette (ou votre molette de défilement) pour parcourir les menus et les morceaux.",

--- a/src/lib/locales/it/translation.json
+++ b/src/lib/locales/it/translation.json
@@ -2140,6 +2140,12 @@
       "year": "Anno"
     },
     "ipod": {
+      "appleMusic": {
+        "fallbackCurator": "[TODO] Apple Music",
+        "fallbackPlaylistTitle": "[TODO] Apple Music Mix",
+        "fallbackRadioTitle": "[TODO] Apple Music Radio",
+        "untitledSong": "[TODO] Untitled"
+      },
       "ariaLabels": {
         "closeFullscreen": "Chiudi schermo intero",
         "cycleLyricFont": "Scorri carattere testi",
@@ -2193,6 +2199,7 @@
         "appleMusicRadioFailed": "Impossibile caricare la radio di Apple Music",
         "appleMusicRecentlyAddedFailed": "Impossibile caricare i brani aggiunti di recente",
         "appleMusicSearchAppleMusic": "Apple Music",
+        "appleMusicSearchDescription": "[TODO] Search Apple Music and your library, then pick a song to add",
         "appleMusicSearchLibrary": "Libreria",
         "appleMusicSearchPlaceholder": "Cerca su Apple Music...",
         "appleMusicSearchSelectResult": "Seleziona un brano da aggiungere:",
@@ -2263,13 +2270,13 @@
           "description": "Scegli visual cover, paesaggi, warp, mesh o acqua; Apple Music usa la cover per impostazione predefinita e nasconde la modalità video",
           "title": "Visualizzazioni a schermo intero"
         },
-        "shareSongs": {
-          "description": "I brani YouTube condividono link ryOS, mentre i brani Apple Music copiano il loro link Apple Music",
-          "title": "Condividi brani"
-        },
         "lyricsPronunciation": {
           "description": "Visualizza i testi sincronizzati in tempo reale con traduzioni, furigana, romaji e pinyin",
           "title": "Testi sincronizzati"
+        },
+        "shareSongs": {
+          "description": "I brani YouTube condividono link ryOS, mentre i brani Apple Music copiano il loro link Apple Music",
+          "title": "Condividi brani"
         },
         "wheelNavigation": {
           "description": "Ruota la ghiera (o la rotella di scorrimento) per sfogliare menu e brani",

--- a/src/lib/locales/ja/translation.json
+++ b/src/lib/locales/ja/translation.json
@@ -2140,6 +2140,12 @@
       "year": "年"
     },
     "ipod": {
+      "appleMusic": {
+        "fallbackCurator": "[TODO] Apple Music",
+        "fallbackPlaylistTitle": "[TODO] Apple Music Mix",
+        "fallbackRadioTitle": "[TODO] Apple Music Radio",
+        "untitledSong": "[TODO] Untitled"
+      },
       "ariaLabels": {
         "closeFullscreen": "フルスクリーンを閉じる",
         "cycleLyricFont": "歌詞フォントを切り替える",
@@ -2193,6 +2199,7 @@
         "appleMusicRadioFailed": "Apple Music ラジオの読み込みに失敗しました",
         "appleMusicRecentlyAddedFailed": "最近追加した曲の読み込みに失敗しました",
         "appleMusicSearchAppleMusic": "Apple Music",
+        "appleMusicSearchDescription": "[TODO] Search Apple Music and your library, then pick a song to add",
         "appleMusicSearchLibrary": "ライブラリ",
         "appleMusicSearchPlaceholder": "Apple Musicを検索...",
         "appleMusicSearchSelectResult": "追加する曲を選択してください:",
@@ -2263,13 +2270,13 @@
           "description": "カバー、ランドスケープ、ワープ、メッシュ、ウォーターのビジュアルを選べます。Apple Music はカバーを既定にし、ビデオモードを非表示にします",
           "title": "フルスクリーン・ビジュアル"
         },
-        "shareSongs": {
-          "description": "YouTube の曲は ryOS リンクで共有し、Apple Music の曲は Apple Music リンクをコピーします",
-          "title": "曲を共有"
-        },
         "lyricsPronunciation": {
           "description": "翻訳、ふりがな、ローマ字、ピンインに対応したリアルタイム同期歌詞を表示します。",
           "title": "同期歌詞"
+        },
+        "shareSongs": {
+          "description": "YouTube の曲は ryOS リンクで共有し、Apple Music の曲は Apple Music リンクをコピーします",
+          "title": "曲を共有"
         },
         "wheelNavigation": {
           "description": "ホイール（またはマウスのスクロールホイール）を回して、メニューやトラックをブラウズします。",

--- a/src/lib/locales/ko/translation.json
+++ b/src/lib/locales/ko/translation.json
@@ -2140,6 +2140,12 @@
       "year": "년"
     },
     "ipod": {
+      "appleMusic": {
+        "fallbackCurator": "[TODO] Apple Music",
+        "fallbackPlaylistTitle": "[TODO] Apple Music Mix",
+        "fallbackRadioTitle": "[TODO] Apple Music Radio",
+        "untitledSong": "[TODO] Untitled"
+      },
       "ariaLabels": {
         "closeFullscreen": "전체 화면 닫기",
         "cycleLyricFont": "가사 글꼴 순환",
@@ -2193,6 +2199,7 @@
         "appleMusicRadioFailed": "Apple Music 라디오를 불러오지 못했습니다",
         "appleMusicRecentlyAddedFailed": "최근 추가된 노래를 불러오지 못했습니다",
         "appleMusicSearchAppleMusic": "Apple Music",
+        "appleMusicSearchDescription": "[TODO] Search Apple Music and your library, then pick a song to add",
         "appleMusicSearchLibrary": "보관함",
         "appleMusicSearchPlaceholder": "Apple Music 검색...",
         "appleMusicSearchSelectResult": "추가할 노래 선택:",
@@ -2263,13 +2270,13 @@
           "description": "커버, 풍경, 워프, 메시 또는 워터 비주얼을 선택하세요. Apple Music은 기본적으로 커버를 사용하고 비디오 모드를 숨깁니다",
           "title": "전체 화면 비주얼"
         },
-        "shareSongs": {
-          "description": "YouTube 곡은 ryOS 링크로 공유되고, Apple Music 곡은 Apple Music 링크가 복사됩니다",
-          "title": "노래 공유"
-        },
         "lyricsPronunciation": {
           "description": "번역, 후리가나, 로마자, 병음이 포함된 실시간 동기화 가사를 확인하세요.",
           "title": "동기화된 가사"
+        },
+        "shareSongs": {
+          "description": "YouTube 곡은 ryOS 링크로 공유되고, Apple Music 곡은 Apple Music 링크가 복사됩니다",
+          "title": "노래 공유"
         },
         "wheelNavigation": {
           "description": "휠(또는 마우스 스크롤 휠)을 돌려 메뉴와 트랙을 탐색하세요.",

--- a/src/lib/locales/pt/translation.json
+++ b/src/lib/locales/pt/translation.json
@@ -2140,6 +2140,12 @@
       "year": "Ano"
     },
     "ipod": {
+      "appleMusic": {
+        "fallbackCurator": "[TODO] Apple Music",
+        "fallbackPlaylistTitle": "[TODO] Apple Music Mix",
+        "fallbackRadioTitle": "[TODO] Apple Music Radio",
+        "untitledSong": "[TODO] Untitled"
+      },
       "ariaLabels": {
         "closeFullscreen": "Sair do modo tela cheia",
         "cycleLyricFont": "Alternar fonte da letra",
@@ -2193,6 +2199,7 @@
         "appleMusicRadioFailed": "Falha ao carregar a rádio do Apple Music",
         "appleMusicRecentlyAddedFailed": "Falha ao carregar músicas adicionadas recentemente",
         "appleMusicSearchAppleMusic": "Apple Music",
+        "appleMusicSearchDescription": "[TODO] Search Apple Music and your library, then pick a song to add",
         "appleMusicSearchLibrary": "Biblioteca",
         "appleMusicSearchPlaceholder": "Buscar no Apple Music...",
         "appleMusicSearchSelectResult": "Selecione uma música para adicionar:",
@@ -2263,13 +2270,13 @@
           "description": "Escolha visuais de capa, paisagem, distorção, malha ou água; o Apple Music usa capa por padrão e oculta o modo de vídeo",
           "title": "Visuais em Tela Cheia"
         },
-        "shareSongs": {
-          "description": "Músicas do YouTube compartilham links do ryOS, enquanto músicas do Apple Music copiam o link do Apple Music",
-          "title": "Compartilhar músicas"
-        },
         "lyricsPronunciation": {
           "description": "Veja letras sincronizadas ao vivo com traduções, furigana, romaji e pinyin",
           "title": "Letras Sincronizadas"
+        },
+        "shareSongs": {
+          "description": "Músicas do YouTube compartilham links do ryOS, enquanto músicas do Apple Music copiam o link do Apple Music",
+          "title": "Compartilhar músicas"
         },
         "wheelNavigation": {
           "description": "Gire a roda (ou a roda de rolagem) para navegar por menus e faixas",

--- a/src/lib/locales/ru/translation.json
+++ b/src/lib/locales/ru/translation.json
@@ -2140,6 +2140,12 @@
       "year": "Год"
     },
     "ipod": {
+      "appleMusic": {
+        "fallbackCurator": "[TODO] Apple Music",
+        "fallbackPlaylistTitle": "[TODO] Apple Music Mix",
+        "fallbackRadioTitle": "[TODO] Apple Music Radio",
+        "untitledSong": "[TODO] Untitled"
+      },
       "ariaLabels": {
         "closeFullscreen": "Закрыть полноэкранный режим",
         "cycleLyricFont": "Переключить шрифт текста песни",
@@ -2193,6 +2199,7 @@
         "appleMusicRadioFailed": "Не удалось загрузить радио Apple Music",
         "appleMusicRecentlyAddedFailed": "Не удалось загрузить недавно добавленные песни",
         "appleMusicSearchAppleMusic": "Apple Music",
+        "appleMusicSearchDescription": "[TODO] Search Apple Music and your library, then pick a song to add",
         "appleMusicSearchLibrary": "Медиатека",
         "appleMusicSearchPlaceholder": "Поиск в Apple Music...",
         "appleMusicSearchSelectResult": "Выберите песню для добавления:",
@@ -2263,13 +2270,13 @@
           "description": "Выбирайте обложку, пейзажи, деформацию, сетку или водные визуализации; Apple Music по умолчанию использует обложку и скрывает режим видео",
           "title": "Полноэкранные эффекты"
         },
-        "shareSongs": {
-          "description": "Песни YouTube отправляются ссылками ryOS, а для песен Apple Music копируется ссылка Apple Music",
-          "title": "Поделиться песнями"
-        },
         "lyricsPronunciation": {
           "description": "Просматривайте синхронизированный текст с переводом, фуриганой, ромадзи и пиньинем",
           "title": "Синхронизированный текст"
+        },
+        "shareSongs": {
+          "description": "Песни YouTube отправляются ссылками ryOS, а для песен Apple Music копируется ссылка Apple Music",
+          "title": "Поделиться песнями"
         },
         "wheelNavigation": {
           "description": "Вращайте колесо (или колесико мыши), чтобы просматривать меню и треки",

--- a/src/lib/locales/zh-TW/translation.json
+++ b/src/lib/locales/zh-TW/translation.json
@@ -2140,6 +2140,12 @@
       "year": "年"
     },
     "ipod": {
+      "appleMusic": {
+        "fallbackCurator": "[TODO] Apple Music",
+        "fallbackPlaylistTitle": "[TODO] Apple Music Mix",
+        "fallbackRadioTitle": "[TODO] Apple Music Radio",
+        "untitledSong": "[TODO] Untitled"
+      },
       "ariaLabels": {
         "closeFullscreen": "關閉全螢幕",
         "cycleLyricFont": "循環歌詞字體",
@@ -2193,6 +2199,7 @@
         "appleMusicRadioFailed": "無法載入 Apple Music 廣播",
         "appleMusicRecentlyAddedFailed": "無法載入最近加入的歌曲",
         "appleMusicSearchAppleMusic": "Apple Music",
+        "appleMusicSearchDescription": "[TODO] Search Apple Music and your library, then pick a song to add",
         "appleMusicSearchLibrary": "資料庫",
         "appleMusicSearchPlaceholder": "搜尋 Apple Music...",
         "appleMusicSearchSelectResult": "選擇要加入的歌曲：",
@@ -2263,13 +2270,13 @@
           "description": "選擇封面、風景、扭曲、網格或水波視覺效果；Apple Music 預設使用封面並隱藏影片模式",
           "title": "全螢幕視覺效果"
         },
-        "shareSongs": {
-          "description": "YouTube 歌曲會分享 ryOS 連結，Apple Music 歌曲則會複製 Apple Music 連結",
-          "title": "分享歌曲"
-        },
         "lyricsPronunciation": {
           "description": "查看包含翻譯、振假名、羅馬拼音與漢語拼音的即時同步歌詞",
           "title": "同步歌詞"
+        },
+        "shareSongs": {
+          "description": "YouTube 歌曲會分享 ryOS 連結，Apple Music 歌曲則會複製 Apple Music 連結",
+          "title": "分享歌曲"
         },
         "wheelNavigation": {
           "description": "旋轉選盤（或滾輪）以瀏覽選單與曲目",

--- a/tests/test-ipod-apple-music.test.ts
+++ b/tests/test-ipod-apple-music.test.ts
@@ -33,8 +33,22 @@ if (!browserGlobals.localStorage) {
   browserGlobals.localStorage = new MemoryStorage();
 }
 if (!browserGlobals.navigator) {
-  browserGlobals.navigator = { onLine: true, userAgent: "test" } as Navigator;
+  browserGlobals.navigator = {
+    onLine: true,
+    userAgent: "test",
+    language: "en-US",
+    languages: ["en-US"],
+  } as Navigator;
+} else {
+  const nav = browserGlobals.navigator as Navigator & {
+    languages?: string[];
+  };
+  if (!nav.language) nav.language = "en-US";
+  if (!nav.languages?.length) nav.languages = ["en-US"];
 }
+
+const { initializeI18n } = await import("../src/lib/i18n");
+await initializeI18n();
 
 const {
   appleMusicPlayableResourceToTrack,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds `apps.ipod.appleMusic.*` strings for API fallbacks (untitled track, default curator, radio/playlist titles) and `appleMusicSearchDescription` for the add-song dialog when searching Apple Music. `SongSearchDialog` now uses locale-only `t()` keys, the correct screen-reader description per mode, and `unknownArtist` for empty artist lines. `useAppleMusicLibrary` resolves those catalog labels via `i18n.t` so search results and radio/genius content follow ryOS language.

**Testing:** `bun test tests/test-ipod-apple-music.test.ts` and `bun run build` (i18n initialized in that suite; navigator mock includes `language` / `languages`). Non-English locale files include `[TODO]` placeholders for the new keys from `sync-translations`; run machine translate when ready.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dbe9361e-e95c-4d7e-b6c2-70915d91daaa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dbe9361e-e95c-4d7e-b6c2-70915d91daaa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

