### PR TITLE
iPod modern UI: fit titlebar + 6 menu rows on screen

### DIFF
--- a/src/apps/ipod/components/BrickGame.tsx
+++ b/src/apps/ipod/components/BrickGame.tsx
@@ -140,8 +140,10 @@ export const BrickGame = forwardRef<BrickGameRef, BrickGameProps>(function Brick
   const { t } = useTranslation();
   const uiVariant = useIpodStore((s) => s.uiVariant ?? "modern");
   const isModernUi = uiVariant === "modern";
-  /** Body offset for `calc(100% - …)` — classic chrome ~26px */
-  const bodyTopOffsetPx = isModernUi ? 24 : 26;
+  /** Body offset for `calc(100% - …)` — classic chrome ~26px.
+   *  Modern bar matches `MODERN_TITLEBAR_HEIGHT` in IpodScreen (21px) so the
+   *  brick game's chrome lines up with the main menu's titlebar. */
+  const bodyTopOffsetPx = isModernUi ? 21 : 26;
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const stateRef = useRef<GameState>(initialState());
   const phaseRef = useRef<Phase>("ready");
@@ -510,7 +512,7 @@ export const BrickGame = forwardRef<BrickGameRef, BrickGameProps>(function Brick
             ? "ipod-modern-titlebar font-ipod-modern-ui text-[15px] font-semibold text-black"
             : "border-b border-[#0a3667] font-chicago text-[16px] text-[#0a3667] [text-shadow:1px_1px_0_rgba(0,0,0,0.15)]"
         )}
-        style={isModernUi ? { height: 24, minHeight: 24 } : undefined}
+        style={isModernUi ? { height: 21, minHeight: 21 } : undefined}
       >
         <div
           className={cn(

--- a/src/apps/ipod/components/IpodScreen.tsx
+++ b/src/apps/ipod/components/IpodScreen.tsx
@@ -40,8 +40,12 @@ import { useIpodStore, isAppleMusicCollectionTrack } from "@/stores/useIpodStore
 
 // Fixed row height for the iPod menu list. Each `MenuListItem` is a
 // single-line row; the classic skin's Chicago glyphs need 24px row height at
-// 16px type, while the modern (color) skin fits **24px** rows with **15px**
-// Myriad / system UI to match nano 6G/7G density without touching classic.
+// 16px type, while the modern (color) skin uses tighter **21px** rows with
+// **15px** Myriad / system UI. At 21px we can fit the titlebar plus
+// six full menu rows inside the 150px screen (21 × 7 = 147, leaving a
+// 3px tail at the bottom of the scroll container) which matches the
+// nano 6G/7G density much more closely than the previous 24px rows
+// (which only fit five rows + a sliver).
 //
 // We virtualize EVERY menu — not just huge ones — so item geometry
 // stays identical across the main menu, the artist list, and the
@@ -54,10 +58,11 @@ import { useIpodStore, isAppleMusicCollectionTrack } from "@/stores/useIpodStore
 // per-menu choice, so a single value applies cleanly to all menus and
 // the scroll-position math.
 const MENU_ITEM_HEIGHT_CLASSIC = 24;
-const MENU_ITEM_HEIGHT_MODERN = 24;
+const MENU_ITEM_HEIGHT_MODERN = 21;
 // Modern titlebar matches the row height exactly so the menu reads as
 // a single continuous list and the silver header doesn't feel chunkier
-// than the content below.
+// than the content below. Keep this linked to the row height so the
+// "titlebar + 6 rows" rhythm stays in sync if either is retuned.
 const MODERN_TITLEBAR_HEIGHT = MENU_ITEM_HEIGHT_MODERN;
 // Render this many extra items above and below the visible window so
 // scrolling doesn't reveal blank rows before React reconciles.

--- a/src/apps/ipod/components/MusicQuiz.tsx
+++ b/src/apps/ipod/components/MusicQuiz.tsx
@@ -112,8 +112,10 @@ export const MusicQuiz = forwardRef<MusicQuizRef, MusicQuizProps>(function Music
   const uiVariant = useIpodStore((s) => s.uiVariant ?? "modern");
   const isModernUi = uiVariant === "modern";
 
-  /** Body area below title bar (`calc(100% - …)`) — classic bar ~26px incl. hairline */
-  const bodyTopOffsetPx = isModernUi ? 24 : 26;
+  /** Body area below title bar (`calc(100% - …)`) — classic bar ~26px incl. hairline.
+   *  Modern bar matches `MODERN_TITLEBAR_HEIGHT` in IpodScreen (21px) so the
+   *  quiz view's chrome lines up with the main menu's titlebar. */
+  const bodyTopOffsetPx = isModernUi ? 21 : 26;
   const masterVolume = useAudioSettingsStore((s) => s.masterVolume);
   const ipodVolume = useAudioSettingsStore((s) => s.ipodVolume);
   const finalVolume = ipodVolume * masterVolume;
@@ -571,7 +573,7 @@ export const MusicQuiz = forwardRef<MusicQuizRef, MusicQuizProps>(function Music
             ? "ipod-modern-titlebar font-ipod-modern-ui text-[15px] font-semibold text-black"
             : "border-b border-[#0a3667] font-chicago text-[16px] text-[#0a3667] [text-shadow:1px_1px_0_rgba(0,0,0,0.15)]"
         )}
-        style={isModernUi ? { height: 24, minHeight: 24 } : undefined}
+        style={isModernUi ? { height: 21, minHeight: 21 } : undefined}
       >
         <div
           className={cn(

--- a/src/apps/ipod/components/screen/MenuListItem.tsx
+++ b/src/apps/ipod/components/screen/MenuListItem.tsx
@@ -37,8 +37,11 @@ export function MenuListItem({
 
   if (isModern) {
     // iPod-classic-js SelectableListItem: white row, blue gradient
-    // selection highlight, no separator. Rows are compact (**24px**) with **15px** type;
-    // leading-normal + horizontal-only ellipsis keeps ascenders/descenders intact. Classic unchanged (16px Chicago).
+    // selection highlight, no separator. Rows are compact (**21px**) with **15px** type so
+    // titlebar + six rows fit inside the 150px screen (nano 6G/7G density).
+    // leading-normal + horizontal-only ellipsis keeps ascenders/descenders intact even though
+    // the 22.5px line-box slightly exceeds the row — `overflow-y-visible` on the inner span
+    // lets glyphs breathe without clipping. Classic unchanged (16px Chicago, 24px rows).
     return (
       <div
         onClick={isLoading ? undefined : onClick}

--- a/src/index.css
+++ b/src/index.css
@@ -1415,9 +1415,10 @@ button.piano-key.piano-key[class*="bg-[#ff33ff]"] {
  *   background: linear-gradient(180deg, #feffff 0%, #b1b6b9 100%);
  *   border-bottom: 1px solid #7995a3;
  *
- * The modern titlebar is **24px** tall (`MENU_ITEM_HEIGHT_MODERN`, same rhythm as
- * classic's title strip height) — enough line-height room so row labels avoid clipping
- * ascenders/descenders next to nano-style typography.
+ * The modern titlebar is **21px** tall (`MENU_ITEM_HEIGHT_MODERN`, same rhythm as
+ * the nano-style menu rows) — together with six 21px rows it fills the 150px
+ * screen so the user can see titlebar + 6 list items at once. Classic's title
+ * strip stays at 24px to give Chicago bitmap glyphs the room they need.
  * The hairline is drawn via inset box-shadow so it doesn't
  * add height when the existing border-b utility is also present. */
 .ipod-modern-titlebar {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The modern (color) iPod skin's 150px screen could only fit its titlebar plus **5** full menu rows — the 6th row appeared as a thin sliver because both the titlebar and rows were 24px tall (5 × 24 = 120, leaving only 6px for row #6).

This PR shrinks the **modern** menu row height and modern titlebar height from `24px` → `21px` so we get the titlebar plus a clean **6** rows on screen:

```
21 (titlebar) + 6 × 21 (rows) = 147px  →  fits inside the 150px screen
```

The remaining 3px is a hidden tail at the bottom of the scroll container (white background in modern UI). When the list has more than 6 items, the user sees the titlebar + 6 fully visible rows and can wheel-scroll for the rest.

Classic (1st-gen LCD / Chicago bitmap) skin is **untouched** — its glyphs need 24px row height.

## Changes

- `src/apps/ipod/components/IpodScreen.tsx`: `MENU_ITEM_HEIGHT_MODERN` `24 → 21`; `MODERN_TITLEBAR_HEIGHT` still derived from it; expanded the comment block explaining the new math.
- `src/apps/ipod/components/screen/MenuListItem.tsx`: Updated the typography comment to mention `21px` rows and call out that the 15px font's 22.5px line-box slightly exceeds the row (handled by the existing `overflow-y-visible`).
- `src/apps/ipod/components/MusicQuiz.tsx`: Modern titlebar height + `bodyTopOffsetPx` `24 → 21` so the quiz chrome lines up with the main menu titlebar.
- `src/apps/ipod/components/BrickGame.tsx`: Same `24 → 21` swap for the modern titlebar + body offset.
- `src/index.css`: Updated the `.ipod-modern-titlebar` doc comment to reflect the new height.

## Testing

- `bun run build` succeeds.
- Manually verified in the iPod app's modern skin that the titlebar + 6 menu rows now render fully without partial cropping (see walkthrough screenshot in the PR conversation).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-02ec1967-2e9a-4f50-851b-b60f5e9020ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-02ec1967-2e9a-4f50-851b-b60f5e9020ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

