### PR TITLE
iPod: use Phosphor filled Play/Pause in modern UI titlebar

### DIFF
--- a/src/apps/ipod/components/IpodScreen.tsx
+++ b/src/apps/ipod/components/IpodScreen.tsx
@@ -9,7 +9,7 @@ import {
 } from "react";
 import ReactPlayer from "react-player";
 import { motion, AnimatePresence } from "framer-motion";
-import { Shuffle } from "@phosphor-icons/react";
+import { Pause, Play, Shuffle } from "@phosphor-icons/react";
 import { cn } from "@/lib/utils";
 import { useAudioSettingsStore } from "@/stores/useAudioSettingsStore";
 import { LyricsDisplay } from "./LyricsDisplay";
@@ -776,7 +776,23 @@ export function IpodScreen({
               isModernUi ? "w-4 h-4" : "w-4 h-4 mt-0.5"
             )}
           >
-            {isPlaying ? "▶" : "⏸︎"}
+            {isModernUi ? (
+              isPlaying ? (
+                <Play
+                  size={12}
+                  weight="fill"
+                  aria-label="playing"
+                />
+              ) : (
+                <Pause
+                  size={12}
+                  weight="fill"
+                  aria-label="paused"
+                />
+              )
+            ) : (
+              isPlaying ? "▶" : "⏸︎"
+            )}
           </div>
         </div>
         <ScrollingText


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Replaces the unicode glyph fallback (`▶` / `⏸︎`) in the iPod modern-UI screen titlebar status indicator with Phosphor's filled `Play` and `Pause` icons. Classic UI keeps its Chicago bitmap glyphs untouched so the iPod-classic-js aesthetic stays pixel-faithful.

- Render `<Play weight="fill" />` when `isPlaying` is true and `<Pause weight="fill" />` when paused.
- Sized at 12px to fit inside the existing 16×16 icon container without changing the titlebar height (`MODERN_TITLEBAR_HEIGHT = 21px`).
- Uses `currentColor` so the icons pick up the same `text-black/80` tone as the silver-gradient titlebar typography.
- No new dependencies; `@phosphor-icons/react` is already used elsewhere in `IpodScreen.tsx` (e.g. the `Shuffle` indicator).

## Files

- `src/apps/ipod/components/IpodScreen.tsx`

## Walkthrough

![Modern UI titlebar — filled Pause icon (paused)](https://cursor.com/artifacts/c/art-b5bc7ae7-7909-4b3e-a45e-2122643307da)

Paused state: filled Phosphor `Pause` icon on the left of the silver-gradient titlebar.

![Modern UI titlebar — filled Play icon (playing)](https://cursor.com/artifacts/c/art-a62c3e6e-ade7-4c00-b09a-7bc98dd02719)

Playing state: filled Phosphor `Play` triangle in the same slot.

DOM verification (rendered SVG inside `.ipod-modern-titlebar`):

- Paused → `<svg width="12" height="12" fill="currentColor" viewBox="0 0 256 256" aria-label="paused"><path d="M216,48V208a16,16,0,0,1-16,16H160…">`
- Playing → `<svg width="12" height="12" fill="currentColor" viewBox="0 0 256 256" aria-label="playing"><path d="M240,128a15.74,15.74,0,0,1-7.6,13.51L88.32,229.65…">`

(`viewBox="0 0 256 256"` confirms Phosphor; the `fill` paths are Pause-fill and Play-fill respectively.)

## Testing

- ✅ `bun run build`
- ✅ `bunx eslint src/apps/ipod/components/IpodScreen.tsx`
- ✅ Manual: launched the iPod in a headless Chrome instance against `bun run dev:vite`, asserted DOM and captured screenshots of both paused and playing states.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6ca46fdb-ec48-4f45-b9f8-d708ed9208d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6ca46fdb-ec48-4f45-b9f8-d708ed9208d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

