### PR TITLE
fix(ipod): Apple Music next-song / displayed-song mismatch

### DIFF
--- a/src/apps/ipod/components/AppleMusicPlayerBridge.tsx
+++ b/src/apps/ipod/components/AppleMusicPlayerBridge.tsx
@@ -10,6 +10,7 @@ import type { Track } from "@/stores/useIpodStore";
 import { onMusicKitReady } from "@/hooks/useMusicKit";
 import { PLAYER_PROGRESS_INTERVAL_MS } from "../constants";
 import {
+  getMusicKitEventItemId,
   isWithinEndedFanoutDedupWindow,
   shouldFireEndedForPlaybackState,
 } from "./appleMusicPlayerBridgeUtils";
@@ -206,13 +207,21 @@ export const AppleMusicPlayerBridge = forwardRef<
   const currentTrackRef = useRef(currentTrack);
   currentTrackRef.current = currentTrack;
 
-  // Wall-clock timestamp of the last `onEnded` fan-out. Used to dedup the
-  // back-to-back `ended` (5) + `completed` (10) MusicKit events that both
-  // fire when a single-song queue's only item finishes. Without this the
-  // parent's `nextTrack` runs twice and the second pick races MusicKit's
-  // first `setQueue`, so the audio the user hears can mismatch the song
-  // the iPod displays (the display reflects the *second* pick, the audio
-  // can settle on either). See `isWithinEndedFanoutDedupWindow`.
+  // Dedup state for `onEnded` fan-out. MusicKit JS fires both `ended`
+  // (5) and `completed` (10) when a single-song queue's only item
+  // finishes. Without dedup the parent's `nextTrack` runs twice — the
+  // second pick races MusicKit's first `setQueue`, so the audio the user
+  // hears can mismatch the song the iPod displays. With shuffle on the
+  // mismatch is the most visible because each call picks a different
+  // random song.
+  //
+  // Two layers (either match suppresses):
+  //  - `lastEndedFiredForItemIdRef`: the just-ended item id. State 5 and
+  //    state 10 reference the SAME item, so identical ids dedup
+  //    regardless of timing.
+  //  - `lastEndedFiredAtRef`: wall-clock timestamp + window. Backstop for
+  //    builds that strip `event.item` from the second event.
+  const lastEndedFiredForItemIdRef = useRef<string | null>(null);
   const lastEndedFiredAtRef = useRef(0);
 
   // Wire up MusicKit event listeners once the instance is available.
@@ -247,12 +256,25 @@ export const AppleMusicPlayerBridge = forwardRef<
       ) {
         // MusicKit fires both `ended` (5) and `completed` (10) when a
         // single-song queue's only item finishes — dedup so the parent's
-        // next-track handler runs once per song-ending event.
+        // next-track handler runs once per song-ending event. Most
+        // visible with shuffle on, where two fan-outs would pick two
+        // different random songs and race two `setQueue` calls in
+        // MusicKit, leaving the audio on a different song than the
+        // display.
         const now = Date.now();
-        if (
-          isWithinEndedFanoutDedupWindow(now, lastEndedFiredAtRef.current)
-        ) {
+        const eventItemId = getMusicKitEventItemId(event?.item);
+        const itemIdMatches =
+          eventItemId !== null &&
+          lastEndedFiredForItemIdRef.current === eventItemId;
+        const withinTimeWindow = isWithinEndedFanoutDedupWindow(
+          now,
+          lastEndedFiredAtRef.current
+        );
+        if (itemIdMatches || withinTimeWindow) {
           return;
+        }
+        if (eventItemId !== null) {
+          lastEndedFiredForItemIdRef.current = eventItemId;
         }
         lastEndedFiredAtRef.current = now;
         onEndedRef.current?.();

--- a/src/apps/ipod/components/AppleMusicPlayerBridge.tsx
+++ b/src/apps/ipod/components/AppleMusicPlayerBridge.tsx
@@ -9,6 +9,7 @@ import {
 import type { Track } from "@/stores/useIpodStore";
 import { onMusicKitReady } from "@/hooks/useMusicKit";
 import { PLAYER_PROGRESS_INTERVAL_MS } from "../constants";
+import { shouldFireEndedForPlaybackState } from "./appleMusicPlayerBridgeUtils";
 
 /**
  * Apple Music playback bridge.
@@ -197,6 +198,11 @@ export const AppleMusicPlayerBridge = forwardRef<
   onEndedRef.current = onEnded;
   onNowPlayingItemChangeRef.current = onNowPlayingItemChange;
 
+  // Track latest currentTrack so the once-only event listeners can read it
+  // without resubscribing on every render.
+  const currentTrackRef = useRef(currentTrack);
+  currentTrackRef.current = currentTrack;
+
   // Wire up MusicKit event listeners once the instance is available.
   // We deliberately skip `playbackTimeDidChange` for progress updates:
   // runtime logs (debug session b224e4) confirmed that MusicKit JS v3's
@@ -215,23 +221,24 @@ export const AppleMusicPlayerBridge = forwardRef<
 
     const handleState = (event: MusicKit.PlaybackStateDidChangeEvent) => {
       const state = event?.state ?? activeInstance?.playbackState;
-      switch (state) {
-        case 2: // playing
-          onPlayRef.current?.();
-          break;
-        case 3: // paused
-        case 4: // stopped
-          onPauseRef.current?.();
-          break;
-        case 5: // ended
-        case 10: // completed
-          onEndedRef.current?.();
-          break;
-        default:
-          // loading/seeking/waiting/stalled — no-op for the iPod UI;
-          // the activity indicator is driven separately.
-          break;
+      if (state === 2) {
+        onPlayRef.current?.();
+        return;
       }
+      if (state === 3 || state === 4) {
+        onPauseRef.current?.();
+        return;
+      }
+      if (
+        (state === 5 || state === 10) &&
+        shouldFireEndedForPlaybackState(state, currentTrackRef.current)
+      ) {
+        onEndedRef.current?.();
+        return;
+      }
+      // loading/seeking/waiting/stalled and the suppressed mid-queue
+      // `ended` for shells — no-op for the iPod UI; the activity
+      // indicator is driven separately.
     };
 
     const handleMediaItem = (event: MusicKit.MediaItemDidChangeEvent) => {

--- a/src/apps/ipod/components/AppleMusicPlayerBridge.tsx
+++ b/src/apps/ipod/components/AppleMusicPlayerBridge.tsx
@@ -9,7 +9,10 @@ import {
 import type { Track } from "@/stores/useIpodStore";
 import { onMusicKitReady } from "@/hooks/useMusicKit";
 import { PLAYER_PROGRESS_INTERVAL_MS } from "../constants";
-import { shouldFireEndedForPlaybackState } from "./appleMusicPlayerBridgeUtils";
+import {
+  isWithinEndedFanoutDedupWindow,
+  shouldFireEndedForPlaybackState,
+} from "./appleMusicPlayerBridgeUtils";
 
 /**
  * Apple Music playback bridge.
@@ -203,6 +206,15 @@ export const AppleMusicPlayerBridge = forwardRef<
   const currentTrackRef = useRef(currentTrack);
   currentTrackRef.current = currentTrack;
 
+  // Wall-clock timestamp of the last `onEnded` fan-out. Used to dedup the
+  // back-to-back `ended` (5) + `completed` (10) MusicKit events that both
+  // fire when a single-song queue's only item finishes. Without this the
+  // parent's `nextTrack` runs twice and the second pick races MusicKit's
+  // first `setQueue`, so the audio the user hears can mismatch the song
+  // the iPod displays (the display reflects the *second* pick, the audio
+  // can settle on either). See `isWithinEndedFanoutDedupWindow`.
+  const lastEndedFiredAtRef = useRef(0);
+
   // Wire up MusicKit event listeners once the instance is available.
   // We deliberately skip `playbackTimeDidChange` for progress updates:
   // runtime logs (debug session b224e4) confirmed that MusicKit JS v3's
@@ -233,6 +245,16 @@ export const AppleMusicPlayerBridge = forwardRef<
         (state === 5 || state === 10) &&
         shouldFireEndedForPlaybackState(state, currentTrackRef.current)
       ) {
+        // MusicKit fires both `ended` (5) and `completed` (10) when a
+        // single-song queue's only item finishes — dedup so the parent's
+        // next-track handler runs once per song-ending event.
+        const now = Date.now();
+        if (
+          isWithinEndedFanoutDedupWindow(now, lastEndedFiredAtRef.current)
+        ) {
+          return;
+        }
+        lastEndedFiredAtRef.current = now;
         onEndedRef.current?.();
         return;
       }
@@ -431,7 +453,29 @@ export const AppleMusicPlayerBridge = forwardRef<
     }
 
     const localQueueKey = queueKey;
-    queueLoadingRef.current = (async () => {
+    // Serialize back-to-back queue swaps. If another track change is
+    // already in flight (rapid `nextTrack` clicks, an `onEnded` advance
+    // racing a user press, etc.), wait for it to settle before issuing
+    // our own `setQueue`. Two concurrent `setQueue` calls inside
+    // MusicKit can resolve out of order — without serialization the
+    // older queue can briefly start playing after the newer one
+    // landed, so the audio mismatches the song the iPod displays
+    // (display reflects the *latest* React state, audio reflects
+    // whichever `setQueue` resolved last). Capture the *previous* ref
+    // so the new chain awaits the old one rather than itself.
+    const previousQueueLoading = queueLoadingRef.current;
+    let thisLoad: Promise<void> | null = null;
+    thisLoad = (async () => {
+      if (previousQueueLoading) {
+        // Best-effort wait — failures of the previous queue load
+        // shouldn't block a fresh user action.
+        try {
+          await previousQueueLoading;
+        } catch {
+          /* ignore — the previous load already logged its own error */
+        }
+        if (cancelled) return;
+      }
       try {
         const resumeSeconds = getSafeStartSeconds(
           currentTrack,
@@ -469,9 +513,17 @@ export const AppleMusicPlayerBridge = forwardRef<
       } catch (err) {
         console.error("[apple music] setQueue failed", err);
       } finally {
-        queueLoadingRef.current = null;
+        // Only clear the shared ref when *we* are still the most recent
+        // load. A newer track change already replaced `queueLoadingRef`
+        // with its own promise; nulling here would let play/pause sync
+        // think there's no pending queue load and race the newer
+        // `setQueue` mid-flight.
+        if (queueLoadingRef.current === thisLoad) {
+          queueLoadingRef.current = null;
+        }
       }
     })();
+    queueLoadingRef.current = thisLoad;
     return () => {
       cancelled = true;
     };

--- a/src/apps/ipod/components/appleMusicPlayerBridgeUtils.ts
+++ b/src/apps/ipod/components/appleMusicPlayerBridgeUtils.ts
@@ -39,16 +39,18 @@ export function shouldFireEndedForPlaybackState(
  *
  * If the bridge forwards both events to the parent's `onEnded`, our
  * `handleTrackEnd` → `nextTrack` runs *twice*. In shuffle mode each call
- * picks a different random song; in sequential mode each call advances
- * one step. The two back-to-back `setQueue(...)` calls then race inside
- * MusicKit so the song the user actually hears can mismatch the song the
- * iPod displays (the display reflects the *latest* store update, but the
- * audio can settle on whichever `setQueue` resolves last). Suppress the
- * second fan-out within a window long enough to span the state 5 → state
- * 10 transition for the same item, but short enough never to swallow a
- * subsequent track's own end-of-playback signal.
+ * picks a *different* random song (so the bug is most obvious with shuffle
+ * on); in sequential mode each call advances one step (skipping a song).
+ * The two back-to-back `setQueue(...)` calls then race inside MusicKit so
+ * the song the user actually hears can mismatch the song the iPod displays
+ * (the display reflects the *latest* store update, but the audio can
+ * settle on whichever `setQueue` resolved last). Suppress the second
+ * fan-out within a window long enough to span the state 5 → state 10
+ * transition for the same item, but short enough never to swallow a
+ * subsequent track's own end-of-playback signal (real songs are minimum
+ * tens of seconds long).
  */
-export const ENDED_FANOUT_DEDUP_WINDOW_MS = 1500;
+export const ENDED_FANOUT_DEDUP_WINDOW_MS = 3000;
 
 /**
  * Returns true when an `onEnded` fan-out at `now` should be suppressed
@@ -65,4 +67,35 @@ export function isWithinEndedFanoutDedupWindow(
 ): boolean {
   if (lastFiredAt <= 0) return false;
   return now - lastFiredAt < windowMs;
+}
+
+/**
+ * Pull a stable identifier out of a MusicKit `playbackStateDidChange` /
+ * `mediaItemDidChange` event payload. Used as the *primary* dedup key for
+ * `onEnded` fan-out: when state=5 and state=10 reference the same item
+ * (the just-ended song), the second event's id matches the first and we
+ * suppress regardless of timing.
+ *
+ * Falls back through the multiple shapes MusicKit JS uses across versions
+ * (`item.id`, `item.attributes.playParams.id`,
+ * `item.attributes.playParams.catalogId`).
+ */
+export function getMusicKitEventItemId(
+  item:
+    | {
+        id?: string;
+        attributes?: {
+          playParams?: { id?: string; catalogId?: string };
+        };
+      }
+    | null
+    | undefined
+): string | null {
+  if (!item) return null;
+  return (
+    item.id ||
+    item.attributes?.playParams?.id ||
+    item.attributes?.playParams?.catalogId ||
+    null
+  );
 }

--- a/src/apps/ipod/components/appleMusicPlayerBridgeUtils.ts
+++ b/src/apps/ipod/components/appleMusicPlayerBridgeUtils.ts
@@ -28,3 +28,41 @@ export function shouldFireEndedForPlaybackState(
   if (state === 5) return !isAppleMusicCollectionTrack(currentTrack);
   return false;
 }
+
+/**
+ * Dedup window for `onEnded` fan-out.
+ *
+ * MusicKit JS fires *both* `ended` (state=5) and `completed` (state=10) when
+ * a single-song queue (`setQueue({ song: id })`) finishes its only item:
+ *   - state=5 fires when the song itself ends.
+ *   - state=10 fires immediately afterwards because the queue is now empty.
+ *
+ * If the bridge forwards both events to the parent's `onEnded`, our
+ * `handleTrackEnd` → `nextTrack` runs *twice*. In shuffle mode each call
+ * picks a different random song; in sequential mode each call advances
+ * one step. The two back-to-back `setQueue(...)` calls then race inside
+ * MusicKit so the song the user actually hears can mismatch the song the
+ * iPod displays (the display reflects the *latest* store update, but the
+ * audio can settle on whichever `setQueue` resolves last). Suppress the
+ * second fan-out within a window long enough to span the state 5 → state
+ * 10 transition for the same item, but short enough never to swallow a
+ * subsequent track's own end-of-playback signal.
+ */
+export const ENDED_FANOUT_DEDUP_WINDOW_MS = 1500;
+
+/**
+ * Returns true when an `onEnded` fan-out at `now` should be suppressed
+ * because we already fanned out for the same song-ending event at
+ * `lastFiredAt`. `lastFiredAt <= 0` means we haven't fanned out yet.
+ *
+ * Exported so the regression test pinning the dedup behavior can run
+ * without spinning up React + MusicKit.
+ */
+export function isWithinEndedFanoutDedupWindow(
+  now: number,
+  lastFiredAt: number,
+  windowMs: number = ENDED_FANOUT_DEDUP_WINDOW_MS
+): boolean {
+  if (lastFiredAt <= 0) return false;
+  return now - lastFiredAt < windowMs;
+}

--- a/src/apps/ipod/components/appleMusicPlayerBridgeUtils.ts
+++ b/src/apps/ipod/components/appleMusicPlayerBridgeUtils.ts
@@ -1,0 +1,30 @@
+// Pure helpers for the AppleMusicPlayerBridge.
+//
+// Lives in its own module so the bridge component file only exports the
+// component itself — keeping React Fast Refresh working for hot reloads
+// during development (`react-refresh/only-export-components`).
+
+import { isAppleMusicCollectionTrack, type Track } from "@/stores/useIpodStore";
+
+/**
+ * Decide whether a `playbackStateDidChange` event should fan out to the
+ * parent's `onEnded` callback (which triggers our own next-track handler).
+ *
+ * MusicKit JS fires `ended` (state=5) once for *every* track that finishes.
+ * Inside a multi-item queue (catalog station / playlist set up via
+ * `setQueue({ station | playlist })`), MusicKit auto-advances to the next
+ * item internally — invoking `onEnded` then would call our parent's
+ * `nextTrack` → `skipToNextItem()`, skipping past the item MusicKit just
+ * moved to and visibly mismatching the displayed Now Playing entry from
+ * what's actually playing. Suppress for shells; the terminal `completed`
+ * (state=10) signal still hands control back when the whole queue is
+ * exhausted.
+ */
+export function shouldFireEndedForPlaybackState(
+  state: number | undefined,
+  currentTrack: Track | null
+): boolean {
+  if (state === 10) return true;
+  if (state === 5) return !isAppleMusicCollectionTrack(currentTrack);
+  return false;
+}

--- a/tests/test-ipod-apple-music.test.ts
+++ b/tests/test-ipod-apple-music.test.ts
@@ -51,6 +51,7 @@ const {
   shouldFireEndedForPlaybackState,
   isWithinEndedFanoutDedupWindow,
   ENDED_FANOUT_DEDUP_WINDOW_MS,
+  getMusicKitEventItemId,
 } = await import(
   "../src/apps/ipod/components/appleMusicPlayerBridgeUtils"
 );
@@ -886,12 +887,13 @@ describe("AppleMusicPlayerBridge ended fan-out dedup window", () => {
   test("second fire inside the window is suppressed (state 5 → state 10 collapse)", () => {
     // state 5 fires at t=1000, state 10 follows at t=1100 — same song.
     expect(isWithinEndedFanoutDedupWindow(1_100, 1_000)).toBe(true);
-    // Even with hundreds of ms between events, dedup still bites.
-    expect(isWithinEndedFanoutDedupWindow(1_999, 1_000)).toBe(true);
+    // Even with seconds between events the dedup still bites — covers
+    // builds where state 10 lags behind state 5 noticeably.
+    expect(isWithinEndedFanoutDedupWindow(1_000 + 2_999, 1_000)).toBe(true);
   });
 
   test("subsequent song's own ended event (well outside window) fans out", () => {
-    // Songs are at minimum a few seconds long, so the next track's end
+    // Real songs are minimum tens of seconds, so the next track's end
     // is always well past the dedup window.
     expect(
       isWithinEndedFanoutDedupWindow(
@@ -905,7 +907,7 @@ describe("AppleMusicPlayerBridge ended fan-out dedup window", () => {
         1_000
       )
     ).toBe(false);
-    expect(isWithinEndedFanoutDedupWindow(60_000, 1_000)).toBe(false);
+    expect(isWithinEndedFanoutDedupWindow(120_000, 1_000)).toBe(false);
   });
 
   test("dedup window is comfortably wider than typical state 5 → state 10 latency, narrower than song length", () => {
@@ -918,5 +920,48 @@ describe("AppleMusicPlayerBridge ended fan-out dedup window", () => {
   test("custom window override works (used by tests + future hardening)", () => {
     expect(isWithinEndedFanoutDedupWindow(100, 50, 100)).toBe(true);
     expect(isWithinEndedFanoutDedupWindow(150, 50, 100)).toBe(false);
+  });
+});
+
+describe("AppleMusicPlayerBridge MusicKit event item id extraction", () => {
+  // Primary dedup key for `onEnded` fan-out: state=5 and state=10 reference
+  // the SAME just-ended item, so identical ids let us suppress the second
+  // fan-out regardless of timing — important when state 10 lags more than
+  // the timestamp window. Falls back through the multiple shapes MusicKit
+  // JS uses across versions so the dedup keeps working when one shape is
+  // empty.
+  test("returns null for nullish items (avoids spurious dedup)", () => {
+    expect(getMusicKitEventItemId(null)).toBeNull();
+    expect(getMusicKitEventItemId(undefined)).toBeNull();
+    expect(getMusicKitEventItemId({})).toBeNull();
+    // Empty string ids are falsy → fallback chain → null.
+    expect(getMusicKitEventItemId({ id: "" })).toBeNull();
+  });
+
+  test("prefers the top-level item.id when present", () => {
+    expect(
+      getMusicKitEventItemId({
+        id: "1616228595",
+        attributes: {
+          playParams: { id: "other", catalogId: "another" },
+        },
+      })
+    ).toBe("1616228595");
+  });
+
+  test("falls back to attributes.playParams.id when item.id is absent", () => {
+    expect(
+      getMusicKitEventItemId({
+        attributes: { playParams: { id: "i.uUZAkT3" } },
+      })
+    ).toBe("i.uUZAkT3");
+  });
+
+  test("falls back to attributes.playParams.catalogId for library songs", () => {
+    expect(
+      getMusicKitEventItemId({
+        attributes: { playParams: { catalogId: "1616228595" } },
+      })
+    ).toBe("1616228595");
   });
 });

--- a/tests/test-ipod-apple-music.test.ts
+++ b/tests/test-ipod-apple-music.test.ts
@@ -47,7 +47,11 @@ const {
   APPLE_MUSIC_PLAYLIST_TRACKS_OPPORTUNISTIC_TTL_MS,
 } = await import("../src/apps/ipod/hooks/useAppleMusicLibrary");
 const { useIpodStore, appleMusicKitIdToLyricsSongId } = await import("../src/stores/useIpodStore");
-const { shouldFireEndedForPlaybackState } = await import(
+const {
+  shouldFireEndedForPlaybackState,
+  isWithinEndedFanoutDedupWindow,
+  ENDED_FANOUT_DEDUP_WINDOW_MS,
+} = await import(
   "../src/apps/ipod/components/appleMusicPlayerBridgeUtils"
 );
 type Track = import("../src/stores/useIpodStore").Track;
@@ -863,5 +867,56 @@ describe("AppleMusicPlayerBridge playback-state fan-out", () => {
     // Defensive: if the current track is unknown, prefer the legacy
     // behavior of advancing on `ended` over getting stuck silent.
     expect(shouldFireEndedForPlaybackState(5, null)).toBe(true);
+  });
+});
+
+describe("AppleMusicPlayerBridge ended fan-out dedup window", () => {
+  // Regression: even for non-shell single-song queues
+  // (`setQueue({ song: id })`), MusicKit JS fires both `ended` (5) and
+  // `completed` (10) when the song finishes. Forwarding both to the
+  // parent runs `nextTrack` twice — the second pick races MusicKit's
+  // first `setQueue`, so the audio the user actually hears can mismatch
+  // the song the iPod displays. The dedup window collapses the pair so
+  // `onEnded` fans out at most once per song-ending event.
+  test("first fire after never having fired is allowed", () => {
+    expect(isWithinEndedFanoutDedupWindow(1_000, 0)).toBe(false);
+    expect(isWithinEndedFanoutDedupWindow(1_000, -1)).toBe(false);
+  });
+
+  test("second fire inside the window is suppressed (state 5 → state 10 collapse)", () => {
+    // state 5 fires at t=1000, state 10 follows at t=1100 — same song.
+    expect(isWithinEndedFanoutDedupWindow(1_100, 1_000)).toBe(true);
+    // Even with hundreds of ms between events, dedup still bites.
+    expect(isWithinEndedFanoutDedupWindow(1_999, 1_000)).toBe(true);
+  });
+
+  test("subsequent song's own ended event (well outside window) fans out", () => {
+    // Songs are at minimum a few seconds long, so the next track's end
+    // is always well past the dedup window.
+    expect(
+      isWithinEndedFanoutDedupWindow(
+        1_000 + ENDED_FANOUT_DEDUP_WINDOW_MS,
+        1_000
+      )
+    ).toBe(false);
+    expect(
+      isWithinEndedFanoutDedupWindow(
+        1_000 + ENDED_FANOUT_DEDUP_WINDOW_MS + 1,
+        1_000
+      )
+    ).toBe(false);
+    expect(isWithinEndedFanoutDedupWindow(60_000, 1_000)).toBe(false);
+  });
+
+  test("dedup window is comfortably wider than typical state 5 → state 10 latency, narrower than song length", () => {
+    // Sanity: window is in the realm of "a beat between events" (>= 1s)
+    // but never long enough to swallow a real song's end (< 30s).
+    expect(ENDED_FANOUT_DEDUP_WINDOW_MS).toBeGreaterThanOrEqual(1_000);
+    expect(ENDED_FANOUT_DEDUP_WINDOW_MS).toBeLessThan(30_000);
+  });
+
+  test("custom window override works (used by tests + future hardening)", () => {
+    expect(isWithinEndedFanoutDedupWindow(100, 50, 100)).toBe(true);
+    expect(isWithinEndedFanoutDedupWindow(150, 50, 100)).toBe(false);
   });
 });

--- a/tests/test-ipod-apple-music.test.ts
+++ b/tests/test-ipod-apple-music.test.ts
@@ -47,6 +47,10 @@ const {
   APPLE_MUSIC_PLAYLIST_TRACKS_OPPORTUNISTIC_TTL_MS,
 } = await import("../src/apps/ipod/hooks/useAppleMusicLibrary");
 const { useIpodStore, appleMusicKitIdToLyricsSongId } = await import("../src/stores/useIpodStore");
+const { shouldFireEndedForPlaybackState } = await import(
+  "../src/apps/ipod/components/appleMusicPlayerBridgeUtils"
+);
+type Track = import("../src/stores/useIpodStore").Track;
 const {
   isValidAppleMusicSongId,
   isValidYouTubeVideoId,
@@ -793,5 +797,71 @@ describe("Apple Music Recently Added & Favorites store + refresh", () => {
 
     expect(result).toBe(cached);
     expect(useIpodStore.getState().appleMusicFavoritesLoading).toBe(false);
+  });
+});
+
+describe("AppleMusicPlayerBridge playback-state fan-out", () => {
+  // Regression: when MusicKit JS plays a multi-item queue (catalog
+  // station / playlist), `playbackState=5 (ended)` fires once for
+  // every track that finishes — including intermediate items that
+  // MusicKit then auto-advances past. Forwarding that to our parent
+  // calls `nextTrack` → `skipToNextItem`, which skips the song
+  // MusicKit just moved to. The displayed Now Playing entry then
+  // mismatches the song actually playing in the queue. The bridge
+  // must suppress the parent fan-out for shells and rely on the
+  // terminal `completed` (10) signal instead.
+  const baseTrack: Track = {
+    id: "am:1616228595",
+    url: "applemusic:1616228595",
+    title: "Bohemian Rhapsody",
+    source: "appleMusic",
+    appleMusicPlayParams: { catalogId: "1616228595" },
+  };
+  const stationShell: Track = {
+    id: "am:station:ra.u-personal",
+    url: "applemusic:station:ra.u-personal",
+    title: "My Station",
+    source: "appleMusic",
+    appleMusicPlayParams: { stationId: "ra.u-personal", kind: "radioStation" },
+  };
+  const playlistShell: Track = {
+    id: "am:playlist:pl.pm-mix",
+    url: "applemusic:playlist:pl.pm-mix",
+    title: "Favorites Mix",
+    source: "appleMusic",
+    appleMusicPlayParams: { playlistId: "pl.pm-mix", kind: "playlist" },
+  };
+
+  test("non-shell single-song queue: ended (5) fans out so we pick the next song", () => {
+    expect(shouldFireEndedForPlaybackState(5, baseTrack)).toBe(true);
+  });
+
+  test("station shell: ended (5) is suppressed so MusicKit's auto-advance wins", () => {
+    expect(shouldFireEndedForPlaybackState(5, stationShell)).toBe(false);
+  });
+
+  test("playlist shell: ended (5) is suppressed so MusicKit's auto-advance wins", () => {
+    expect(shouldFireEndedForPlaybackState(5, playlistShell)).toBe(false);
+  });
+
+  test("completed (10) always fans out — terminal signal for both shells and single-song queues", () => {
+    expect(shouldFireEndedForPlaybackState(10, baseTrack)).toBe(true);
+    expect(shouldFireEndedForPlaybackState(10, stationShell)).toBe(true);
+    expect(shouldFireEndedForPlaybackState(10, playlistShell)).toBe(true);
+    expect(shouldFireEndedForPlaybackState(10, null)).toBe(true);
+  });
+
+  test("non-terminal states never fan out as ended", () => {
+    for (const state of [0, 1, 2, 3, 4, 6, 8, 9, undefined]) {
+      expect(shouldFireEndedForPlaybackState(state, baseTrack)).toBe(false);
+      expect(shouldFireEndedForPlaybackState(state, stationShell)).toBe(false);
+      expect(shouldFireEndedForPlaybackState(state, playlistShell)).toBe(false);
+    }
+  });
+
+  test("null currentTrack with ended (5) fans out (no shell context to suppress)", () => {
+    // Defensive: if the current track is unknown, prefer the legacy
+    // behavior of advancing on `ended` over getting stuck silent.
+    expect(shouldFireEndedForPlaybackState(5, null)).toBe(true);
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the Apple Music bug where the next song that plays in the queue does not match the next song the iPod displays. The bug surfaces three different ways; this PR addresses all of them.

---

## Root cause #1 — collection shells (stations / catalog playlists)

When the iPod is playing a catalog **station** or **playlist** (a "collection shell" track), MusicKit JS owns a multi-item queue and auto-advances internally. Crucially, MusicKit also fires `playbackState=5` (`ended`) once for **every** track that finishes — including intermediate items that it has just moved past.

`AppleMusicPlayerBridge` was forwarding that to the parent's `onEnded`, which calls:

```
handleTrackEnd → nextTrack → skipAppleMusicCollectionShell → instance.skipToNextItem()
```

With MusicKit already auto-advanced, the extra `skipToNextItem()` jumped one song *ahead* of the item MusicKit just queued.

## Root cause #2 — single-song queues (regular library / playlist songs), most visible with shuffle on

Even for non-shell tracks, MusicKit fires **both** `ended` (5) and `completed` (10) when a `setQueue({ song: id })` queue's only item finishes:

- state=5 fires when the song itself ends.
- state=10 fires immediately afterwards because the queue is now empty.

Forwarding both to the parent ran `nextTrack` **twice**:

- In **shuffle** mode each call picks a *different* random song — the bug is the most obvious here because the audio audibly lands on a song the iPod never displayed.
- In sequential mode each call advances one step, silently skipping a song.

The two back-to-back `setQueue(...)` calls then race inside MusicKit, so the audio could settle on either pick while the display always reflects the latest store update.

## Root cause #3 — concurrent `setQueue` calls

Even after collapsing duplicate `onEnded` events, rapid manual `Next` clicks (or an `onEnded` racing a user press) could still leave two `setQueue` promises in flight inside MusicKit. The older one could resolve last and briefly start playing after the newer one landed, again mismatching the displayed track.

The pre-existing `queueLoadingRef.current = null` in the `finally` block also cleared the shared ref even when a newer load had already replaced it, letting the play/pause sync think there was no pending queue load and race the newer `setQueue` mid-flight.

---

## Fix

`AppleMusicPlayerBridge` now consults three pure helpers from a sibling module so the bridge stays Fast Refresh-friendly and the logic is unit-testable without React + MusicKit:

1. **`shouldFireEndedForPlaybackState(state, currentTrack)`** — decision matrix for shells vs. non-shells.

   | `playbackState` | Current track is shell? | Fan out `onEnded`? |
   |----------------|------------------------|--------------------|
   | `5` (ended)    | yes (station/playlist) | **no** — let MusicKit auto-advance |
   | `5` (ended)    | no (single-song queue) | yes — we pick the next song |
   | `10` (completed) | any                  | yes — terminal "queue exhausted" signal |
   | anything else  | any                    | no |

2. **Two-layer dedup for the `onEnded` fan-out** — either match suppresses:
   - **`getMusicKitEventItemId(event.item)`** identifies the just-ended item via `item.id` → `attributes.playParams.id` → `attributes.playParams.catalogId`. State 5 and state 10 reference the SAME item, so identical ids dedup regardless of timing.
   - **`isWithinEndedFanoutDedupWindow(now, lastFiredAt)`** with a 3000 ms window. Backstop for MusicKit builds that strip `event.item` from the second event.

3. **Serialized `setQueue` swaps** — the queue-change effect chains `thisLoad` onto any previously-pending load (`queueLoadingRef.current`) before issuing its own `setQueue`. Rapid track changes no longer race two `setQueue` promises inside MusicKit. The `finally` only clears the shared ref when *we're* still the most recent load.

## Files

- `src/apps/ipod/components/AppleMusicPlayerBridge.tsx` — consult `shouldFireEndedForPlaybackState`, dedup `onEnded` fan-out by event item id + timestamp window, serialize the `setQueue` chain, and stop nulling `queueLoadingRef` when a newer load has replaced it. Track latest `currentTrack` via a ref so the once-only event listeners read it without resubscribing.
- `src/apps/ipod/components/appleMusicPlayerBridgeUtils.ts` — pure helpers: `shouldFireEndedForPlaybackState`, `isWithinEndedFanoutDedupWindow`, `ENDED_FANOUT_DEDUP_WINDOW_MS`, `getMusicKitEventItemId`.
- `tests/test-ipod-apple-music.test.ts` — fifteen regression tests pinning the shell-vs-single-song decision matrix, the dedup window's allow-first / suppress-second / next-song-allowed / window-bounds behavior, and `getMusicKitEventItemId`'s fallback chain across MusicKit JS id shapes.

## Testing

- ✅ `bun test tests/test-ipod-apple-music.test.ts` — **53 pass / 0 fail** (38 pre-existing + 15 new across the three helper suites).
- ✅ `bun run test:unit` — **215 pass / 0 fail**.
- ✅ `bun run build` — TypeScript + Vite production build clean.
- ✅ `bun run lint` — 13 warnings (unchanged from `main`; the new helpers stay in their own module so the bridge keeps Fast Refresh).

The fix is queue-state + event-routing logic that runs only inside the MusicKit playback listener and the queue-loading async chain, with no UI surface area to demo. The new `bun:test` cases pin all three regressions directly.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-521703f4-2914-457e-a510-12e882c36d71"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-521703f4-2914-457e-a510-12e882c36d71"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

