### PR TITLE
feat(ipod): bigger Cover Flow covers + tighter top padding for modern UI

### DIFF
--- a/src/apps/ipod/components/CoverFlow.tsx
+++ b/src/apps/ipod/components/CoverFlow.tsx
@@ -284,14 +284,18 @@ function CoverImage({
     }
   }, [selectedIndex, currentIndex, onPlayTrackInPlace, onTogglePlay]);
 
-  // Cover size: larger for classic iPod; modern skin uses a tighter row.
+  // Cover size: classic iPod stays at 65; modern (nano-style) skin uses
+  // a wider/taller cover that fills more of the small viewport — closer
+  // to the actual nano 6G/7G Cover Flow proportions.
   const coverSize =
-    ipodMode && !compactIpodCarousel ? 65 : ipodMode ? 58 : 60; // cqmin units
-  // Side spacing — tighter on modern nano-style Cover Flow (small viewport).
+    ipodMode && !compactIpodCarousel ? 65 : ipodMode ? 70 : 60; // cqmin units
+  // Side spacing — bumped slightly on modern to keep the carousel
+  // breathing room after the larger covers (otherwise the side cards
+  // overlap the center cover too aggressively).
   const baseSpacing =
-    ipodMode && compactIpodCarousel ? 17 : ipodMode ? 26 : 16;
+    ipodMode && compactIpodCarousel ? 19 : ipodMode ? 26 : 16;
   const positionSpacing =
-    ipodMode && compactIpodCarousel ? 12 : ipodMode ? 18 : 11;
+    ipodMode && compactIpodCarousel ? 13 : ipodMode ? 18 : 11;
 
   // Scale values: no scaling for iPod mode, subtle for karaoke
   const centerScale = 1.0;
@@ -808,10 +812,11 @@ export const CoverFlow = forwardRef<CoverFlowRef, CoverFlowProps>(function Cover
             <div 
               className="relative flex items-center justify-center w-full"
               style={{ 
-                height: ipodMode && isModernIpodCoverFlow ? "78%" : "75%",
+                height:
+                  ipodMode && isModernIpodCoverFlow ? "90%" : "75%",
                 marginTop:
                   ipodMode && isModernIpodCoverFlow
-                    ? "-6%"
+                    ? "-14%"
                     : ipodMode
                       ? "-8%"
                       : "-2%",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Tightens the modern (nano-style) iPod Cover Flow geometry so the center cover fills more of the small 250×150 screen and sits closer to the title bar — closer to the actual nano 6G/7G hardware feel.

## Changes (modern skin only — classic geometry untouched)

| Parameter | Before | After | Effect |
|-----------|--------|-------|--------|
| `coverSize` | 58 cqmin | **70 cqmin** | Wider + taller center cover |
| `baseSpacing` | 17 cqmin | **19 cqmin** | Side cards stay clear of the larger center |
| `positionSpacing` | 12 cqmin | **13 cqmin** | Same — keeps the carousel breathing |
| Cover container `height` | 78% | **90%** | More vertical room for the larger covers |
| Cover container `marginTop` | -6% | **-14%** | Carousel sits up under the title bar — less padding to the top |

## Files

- `src/apps/ipod/components/CoverFlow.tsx` — only the modern (`compactIpodCarousel` / `isModernIpodCoverFlow`) branches in `CoverImage` and the inner cover container were touched. The classic-skin geometry (`!compactIpodCarousel`, non-modern `ipodMode`, and karaoke) is unchanged.

## Testing

- ✅ `bun run build` — TypeScript + Vite production build clean.

This is a pure CSS/sizing change scoped to the modern skin's Cover Flow rendering — no event handling, no store changes — so the existing iPod test suites continue to apply unchanged. Manual visual verification skipped per AGENTS.md ("Skip computer use / GUI-driven testing unless the user explicitly requests it"); easy to iterate further if the new proportions need a tweak.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-521703f4-2914-457e-a510-12e882c36d71"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-521703f4-2914-457e-a510-12e882c36d71"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

