### PR TITLE
ipod: render playback status glyphs as Phosphor icons in modern UI

### DIFF
--- a/src/apps/ipod/components/screen/StatusDisplay.tsx
+++ b/src/apps/ipod/components/screen/StatusDisplay.tsx
@@ -1,6 +1,56 @@
+import {
+  FastForward,
+  Pause,
+  Play,
+  Prohibit,
+  Rewind,
+  SkipBack,
+  SkipForward,
+  XCircle,
+  type Icon,
+} from "@phosphor-icons/react";
+
 interface StatusDisplayProps {
   message: string;
   variant?: "classic" | "modern";
+}
+
+// Maps the leading playback glyph used in `showStatus(...)` calls to a
+// Phosphor icon so the modern (color) skin renders proper vector icons
+// instead of the raw emoji/symbol characters that Chicago renders for
+// the classic skin. The trailing `\uFE0E` (text-presentation variation
+// selector) is stripped before the lookup so both `"⏸"` and `"⏸\uFE0E"`
+// resolve to the same icon.
+const PLAYBACK_GLYPHS: Record<string, Icon> = {
+  "\u25B6": Play,        // ▶
+  "\u23F8": Pause,       // ⏸
+  "\u23ED": SkipForward, // ⏭
+  "\u23EE": SkipBack,    // ⏮
+  "\u23E9": FastForward, // ⏩
+  "\u23EA": Rewind,      // ⏪
+  "\u274C": XCircle,     // ❌
+  "\u{1F6AB}": Prohibit, // 🚫
+};
+
+interface ParsedStatus {
+  Icon: Icon | null;
+  rest: string;
+}
+
+function parseStatusMessage(message: string): ParsedStatus {
+  if (!message) return { Icon: null, rest: message };
+
+  // Match a leading glyph (handles surrogate pairs for emoji like 🚫)
+  // followed by an optional U+FE0E variation selector.
+  const match = message.match(/^([\uD800-\uDBFF][\uDC00-\uDFFF]|.)\uFE0E?/);
+  if (!match) return { Icon: null, rest: message };
+
+  const leading = match[1];
+  const Icon = PLAYBACK_GLYPHS[leading] ?? null;
+  if (!Icon) return { Icon: null, rest: message };
+
+  const rest = message.slice(match[0].length).replace(/^\s+/, "");
+  return { Icon, rest };
 }
 
 export function StatusDisplay({
@@ -13,15 +63,7 @@ export function StatusDisplay({
     <div className="absolute top-4 left-4 pointer-events-none">
       <div className="relative">
         {isModern ? (
-          <div
-            className="font-ipod-modern-ui text-white text-[15px] font-semibold leading-none"
-            style={{
-              textShadow:
-                "0 1px 1px rgba(0,0,0,0.45), 0 0 6px rgba(0,0,0,0.35)",
-            }}
-          >
-            {message}
-          </div>
+          <ModernStatus message={message} />
         ) : (
           <>
             <div className="font-chicago text-white text-xl relative z-10">
@@ -39,6 +81,34 @@ export function StatusDisplay({
           </>
         )}
       </div>
+    </div>
+  );
+}
+
+function ModernStatus({ message }: { message: string }) {
+  const { Icon, rest } = parseStatusMessage(message);
+  const hasText = rest.length > 0;
+
+  return (
+    <div
+      className="font-ipod-modern-ui text-white text-[15px] font-semibold leading-none flex items-center gap-1.5"
+      style={{
+        textShadow:
+          "0 1px 1px rgba(0,0,0,0.45), 0 0 6px rgba(0,0,0,0.35)",
+      }}
+    >
+      {Icon ? (
+        <Icon
+          size={15}
+          weight="fill"
+          aria-hidden
+          style={{
+            filter:
+              "drop-shadow(0 1px 1px rgba(0,0,0,0.45)) drop-shadow(0 0 6px rgba(0,0,0,0.35))",
+          }}
+        />
+      ) : null}
+      {hasText || !Icon ? <span>{Icon ? rest : message}</span> : null}
     </div>
   );
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary

Replace the playback status text/emoji glyphs (`▶`, `⏸`, `⏭`, `⏮`, `⏩`, `⏪`, `🚫`, `❌`) with matching Phosphor icons in the iPod **modern** (color) skin's `StatusDisplay`. The classic skin keeps the original Chicago bitmap glyphs unchanged.

### Why

The modern skin uses `font-ipod-modern-ui` (Myriad / system UI), which renders these Unicode media-control characters inconsistently — they show as colored emoji on some hosts, blank tofu boxes on others, and don't visually match the rest of the modern UI (which already uses Phosphor `Play` / `Pause` / `Shuffle` icons in the title bar and now-playing screen).

### How

`StatusDisplay` now parses the leading character of the message in the modern variant:

| Glyph | Phosphor icon |
|---|---|
| `▶` | `Play` |
| `⏸` / `⏸\uFE0E` | `Pause` |
| `⏭` | `SkipForward` |
| `⏮` | `SkipBack` |
| `⏩\uFE0E` | `FastForward` |
| `⏪\uFE0E` | `Rewind` |
| `🚫` | `Prohibit` |
| `❌` | `XCircle` |

Trailing text after the glyph (timestamps like `▶ 1:23`, track titles like `⏭ Song - Artist`, error suffixes like `❌ Failed to add ...`) is preserved and rendered inline next to the icon. Plain text status messages (`Shuffle: On`, `Repeat: All`, `Apple Music ✓`, ...) fall back to the original text rendering.

The parser handles:
- The U+FE0E text-presentation variation selector that several `showStatus` calls append (`⏸︎`, `⏩︎`, `⏪︎`).
- Surrogate-pair emoji like `🚫`.

No call sites were changed — the swap is entirely local to `StatusDisplay.tsx`.

### Files

- `src/apps/ipod/components/screen/StatusDisplay.tsx` — add `parseStatusMessage` + `ModernStatus` and use Phosphor icons in the modern variant.

### Testing

- ✅ `bun run build` — clean build, no type or lint errors.
- ✅ Unit-verified the glyph parser against every known `showStatus` payload (`▶`, `⏸`, `⏸\uFE0E`, `⏭`, `⏮`, `⏩\uFE0E`, `⏪\uFE0E`, `🚫`, `❌ Failed to add`, `▶ 1:23`, `⏭ Song Title - Artist`, plain text `Shuffle: On`, empty string) — all map to the right icon and trailing text.

Per the repo's `AGENTS.md` ("Skip computer use / GUI-driven testing unless the user explicitly requests it"), no browser screenshot was captured.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-332058af-5134-4931-b8eb-a8ccfafa8f9f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-332058af-5134-4931-b8eb-a8ccfafa8f9f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

