### PR TITLE
iPod modern UI: split menu Ken Burns art + slim left-aligned titlebar

### DIFF
--- a/src/apps/ipod/components/IpodScreen.tsx
+++ b/src/apps/ipod/components/IpodScreen.tsx
@@ -915,13 +915,15 @@ export function IpodScreen({
           )}
         >
           {isModernUi && (
-            // Compact play/pause status glyph painted with the same
-            // top-to-bottom blue gradient as the row-selection
-            // highlight, matching the iOS 6 / iPod nano 6G "tinted"
-            // status-bar look. Inline SVG with an embedded gradient
-            // so it stays a single sharp shape on any DPI.
-            <div className="flex items-center justify-center w-3 h-3">
-              <IpodModernPlayPauseIcon playing={isPlaying} size={10} />
+            // Play/pause status glyph painted with the same top-to-
+            // bottom blue gradient as the row-selection highlight,
+            // matching the iOS 6 / iPod nano 6G "tinted" status-bar
+            // look. Inline SVG with an embedded gradient so it stays
+            // a single sharp shape on any DPI. Sized at 14px to
+            // dominate the 17px titlebar (visually matches the title
+            // type x-height + ascender).
+            <div className="flex items-center justify-center w-[14px] h-[14px]">
+              <IpodModernPlayPauseIcon playing={isPlaying} size={14} />
             </div>
           )}
           <BatteryIndicator backlightOn={backlightOn} variant={uiVariant} />

--- a/src/apps/ipod/components/IpodScreen.tsx
+++ b/src/apps/ipod/components/IpodScreen.tsx
@@ -67,12 +67,14 @@ const MENU_ITEM_HEIGHT_MODERN = 21;
 // a 7px tail for the optional Ken Burns split-art column to breathe
 // against the bottom edge.
 const MODERN_TITLEBAR_HEIGHT = 17;
-// Width of the Ken Burns split-art strip rendered alongside the menu in
-// modern UI when a track is playing — sized as a fixed pixel column so
-// the menu list keeps a predictable text width across screen widths
-// (the screen is ~218px wide). Matches the right-hand artwork peek on
-// the real iPod nano/classic 6G+ menu.
-const MODERN_SPLIT_ART_WIDTH = 90;
+// The Ken Burns album-art strip rendered alongside the menu in the
+// modern UI takes exactly **half** of the screen width and the FULL
+// screen height — the art panel covers the right half from the very
+// top of the screen down (including the area where the titlebar
+// would otherwise extend), exactly like the iPod classic 6G/7G
+// "Music + Now Playing" split shown in the reference photo. The
+// titlebar + menu list are clamped to the left half in split mode.
+const MODERN_SPLIT_HALF = "50%";
 // Render this many extra items above and below the visible window so
 // scrolling doesn't reveal blank rows before React reconciles.
 const OVERSCAN_ITEMS = 6;
@@ -456,6 +458,13 @@ export function IpodScreen({
 
   const shouldShowLyrics = showLyrics;
 
+  // True when the modern UI should render its iPod 6G/7G classic
+  // "Music + Now Playing" split: titlebar + menu list clamped to the
+  // left half, full-height Ken Burns album art on the right half.
+  // Only meaningful in menu mode with an actual cover URL — otherwise
+  // the screen falls back to the standard full-width chrome.
+  const showSplitMenuArt = isModernUi && menuMode && Boolean(coverUrl);
+
   return (
     <div
       className={cn(
@@ -750,18 +759,43 @@ export function IpodScreen({
         </div>
       )}
 
+      {/* Full-height Ken Burns album art panel covering the right half
+       *  of the screen when the modern UI is in split menu mode.
+       *  Rendered as an absolutely-positioned overlay so it can extend
+       *  from the very top of the screen (over where the titlebar would
+       *  otherwise sit) all the way to the bottom — matching the iPod
+       *  classic 6G/7G "Music + Now Playing" reference photo where the
+       *  album art has no titlebar above it. The titlebar + menu below
+       *  are clamped to the left half so they don't bleed underneath. */}
+      {showSplitMenuArt && coverUrl && (
+        <div
+          className="ipod-modern-split-art absolute top-0 right-0 bottom-0 z-[15] overflow-hidden"
+          style={{ width: MODERN_SPLIT_HALF }}
+          aria-hidden
+        >
+          <img
+            src={coverUrl}
+            alt=""
+            draggable={false}
+            className="ipod-modern-split-art-img absolute inset-0 size-full object-cover select-none"
+          />
+        </div>
+      )}
+
       {/* Title bar
        *
        * Modern (nano 6G/7G + iPod classic 6G silver header):
        *   - Slim 17px strip, 12px MyriadPro semibold black text.
        *   - Title left-aligned (no centering).
        *   - Status icons (play/pause + battery) clustered on the right.
+       *   - Clamped to the LEFT HALF of the screen in split menu mode
+       *     so the album art column extends to the very top edge.
        *
        * Classic (1st-gen LCD): unchanged — Chicago glyphs centered with
        *   play indicator on the left and battery on the right. */}
       <div
         className={cn(
-          "shrink-0 py-0 flex items-center sticky top-0 z-10",
+          "shrink-0 py-0 flex items-center sticky top-0 z-20",
           isModernUi
             ? "ipod-modern-titlebar text-black font-ipod-modern-ui font-semibold pl-2 pr-1.5 gap-1.5"
             : "h-6 min-h-6 px-2 border-b border-[#0a3667] font-chicago text-[16px] text-[#0a3667] [text-shadow:1px_1px_0_rgba(0,0,0,0.15)]"
@@ -771,6 +805,7 @@ export function IpodScreen({
             ? {
                 height: MODERN_TITLEBAR_HEIGHT,
                 minHeight: MODERN_TITLEBAR_HEIGHT,
+                width: showSplitMenuArt ? MODERN_SPLIT_HALF : undefined,
               }
             : undefined
         }
@@ -832,7 +867,10 @@ export function IpodScreen({
 
       {/* Content area - z-30 only when video is not showing so it can
           receive events. Content height subtracts the titlebar height
-          so the menu/now-playing area is the same in both skins. */}
+          so the menu/now-playing area is the same in both skins.
+          Width clamps to the LEFT HALF of the screen when the split
+          menu Ken Burns art column is showing so the menu list doesn't
+          bleed under the album art. */}
       <div
         className={cn(
           "relative",
@@ -842,13 +880,14 @@ export function IpodScreen({
           height: isModernUi
             ? `calc(100% - ${MODERN_TITLEBAR_HEIGHT}px)`
             : "calc(100% - 24px)",
+          width: showSplitMenuArt ? MODERN_SPLIT_HALF : undefined,
         }}
       >
         <AnimatePresence initial={false} custom={menuDirection} mode="sync">
           {menuMode ? (
             <motion.div
               key={`menu-${menuHistory.length}-${currentMenuTitle}`}
-              className="absolute inset-0 flex h-full"
+              className="absolute inset-0 flex flex-col h-full"
               initial="enter"
               animate="center"
               exit="exit"
@@ -856,10 +895,7 @@ export function IpodScreen({
               transition={{ duration: 0.2, ease: "easeInOut" }}
               custom={menuDirection}
             >
-              {/* Left column: scrolling menu list. Shrinks when the
-                  Ken Burns split-art column is visible (modern UI +
-                  active track) so both fit cleanly side-by-side. */}
-              <div className="flex-1 min-w-0 relative">
+              <div className="flex-1 relative">
                 <div
                   ref={setMenuScrollRef}
                   className="absolute inset-0 overflow-auto ipod-menu-container"
@@ -913,27 +949,6 @@ export function IpodScreen({
                   variant={uiVariant}
                 />
               </div>
-              {/* Right column: Ken Burns album art "split menu" peek
-                  shown when the modern UI has a current track with
-                  artwork — the same right-hand artwork strip the
-                  iPod nano 6G/7G + classic 6G/7G show beside menus.
-                  Hidden when no artwork is available so the menu
-                  reverts to full-width and we never render an
-                  empty black bar. */}
-              {isModernUi && coverUrl && (
-                <div
-                  className="ipod-modern-split-art relative shrink-0 overflow-hidden"
-                  style={{ width: MODERN_SPLIT_ART_WIDTH }}
-                  aria-hidden
-                >
-                  <img
-                    src={coverUrl}
-                    alt=""
-                    draggable={false}
-                    className="ipod-modern-split-art-img absolute inset-0 size-full object-cover select-none"
-                  />
-                </div>
-              )}
             </motion.div>
           ) : (
             <motion.div

--- a/src/apps/ipod/components/IpodScreen.tsx
+++ b/src/apps/ipod/components/IpodScreen.tsx
@@ -847,7 +847,13 @@ export function IpodScreen({
        *   play indicator on the left and battery on the right. */}
       <div
         className={cn(
-          "shrink-0 py-0 flex items-center sticky top-0 z-20",
+          // z-10 (NOT z-20) so the video / lyrics overlay (z-20) cleanly
+          // covers the titlebar when active — the user wants the screen
+          // to read as full-bleed video / lyrics with no chrome on top.
+          // In all other states (menu, now-playing without video, split
+          // menu) the titlebar still renders normally because nothing
+          // higher-z is drawn over it.
+          "shrink-0 py-0 flex items-center sticky top-0 z-10",
           isModernUi
             ? "ipod-modern-titlebar text-black font-ipod-modern-ui font-semibold pl-1.5 pr-1.5 gap-1.5"
             : "h-6 min-h-6 px-2 border-b border-[#0a3667] font-chicago text-[16px] text-[#0a3667] [text-shadow:1px_1px_0_rgba(0,0,0,0.15)]",

--- a/src/apps/ipod/components/IpodScreen.tsx
+++ b/src/apps/ipod/components/IpodScreen.tsx
@@ -886,6 +886,13 @@ export function IpodScreen({
           isPlaying
           scrollStartDelaySec={1}
           fadeEdges={isModernUi}
+          // ScrollingText defaults align to "center", which forces
+          // `justify-center` and overrides any `text-left` class. The
+          // modern titlebar wants the title hard-aligned to the left
+          // (matching the iPod nano 6G/7G "iPod" / "Now Playing"
+          // header in the reference photo); the classic skin keeps
+          // its centered Chicago glyphs.
+          align={isModernUi ? "left" : "center"}
           className={cn(
             "flex-1 min-w-0 leading-none",
             isModernUi
@@ -895,10 +902,10 @@ export function IpodScreen({
                   // 11px Helvetica Neue used by iOS 6 status bars but
                   // still well under the 15px MyriadPro list rows so the
                   // header reads as secondary chrome.
-                  "text-left text-[12px] font-semibold",
+                  "text-[12px] font-semibold",
                   "[text-shadow:0_1px_0_rgba(255,255,255,0.9)]"
                 )
-              : "px-1 text-center"
+              : "px-1"
           )}
         />
         <div

--- a/src/apps/ipod/components/IpodScreen.tsx
+++ b/src/apps/ipod/components/IpodScreen.tsx
@@ -1090,12 +1090,10 @@ export function IpodScreen({
                         <div
                           className={cn(
                             "flex min-h-0 min-w-0 flex-1 flex-col justify-start gap-0 overflow-visible text-left",
-                            // Nudge the title / artist / album column
-                            // down so the first line sits roughly at the
-                            // cover's optical center-top instead of
-                            // hugging the cover's top edge — matches
+                            // Small downward nudge so the first line
+                            // doesn't hug the cover's top edge — matches
                             // the iPod nano 6G/7G "Now Playing" baseline.
-                            "pt-2",
+                            "pt-1",
                             "[&>*]:py-0",
                             "[&>*:not(:first-child)]:-mt-[3px]",
                             "font-ipod-modern-ui"

--- a/src/apps/ipod/components/IpodScreen.tsx
+++ b/src/apps/ipod/components/IpodScreen.tsx
@@ -1090,6 +1090,12 @@ export function IpodScreen({
                         <div
                           className={cn(
                             "flex min-h-0 min-w-0 flex-1 flex-col justify-start gap-0 overflow-visible text-left",
+                            // Nudge the title / artist / album column
+                            // down so the first line sits roughly at the
+                            // cover's optical center-top instead of
+                            // hugging the cover's top edge — matches
+                            // the iPod nano 6G/7G "Now Playing" baseline.
+                            "pt-2",
                             "[&>*]:py-0",
                             "[&>*:not(:first-child)]:-mt-[3px]",
                             "font-ipod-modern-ui"

--- a/src/apps/ipod/components/IpodScreen.tsx
+++ b/src/apps/ipod/components/IpodScreen.tsx
@@ -59,11 +59,20 @@ import { useIpodStore, isAppleMusicCollectionTrack } from "@/stores/useIpodStore
 // the scroll-position math.
 const MENU_ITEM_HEIGHT_CLASSIC = 24;
 const MENU_ITEM_HEIGHT_MODERN = 21;
-// Modern titlebar matches the row height exactly so the menu reads as
-// a single continuous list and the silver header doesn't feel chunkier
-// than the content below. Keep this linked to the row height so the
-// "titlebar + 6 rows" rhythm stays in sync if either is retuned.
-const MODERN_TITLEBAR_HEIGHT = MENU_ITEM_HEIGHT_MODERN;
+// Modern titlebar is intentionally tighter than the row height. The
+// nano 6G/7G + iPod classic 6G silver header is a slim 17px strip with
+// 12px MyriadPro semibold text — slimmer than each list row so the
+// header reads as a separator, not as another row. Six 21px rows still
+// fit cleanly inside the remaining 133px of screen (21 × 6 = 126), with
+// a 7px tail for the optional Ken Burns split-art column to breathe
+// against the bottom edge.
+const MODERN_TITLEBAR_HEIGHT = 17;
+// Width of the Ken Burns split-art strip rendered alongside the menu in
+// modern UI when a track is playing — sized as a fixed pixel column so
+// the menu list keeps a predictable text width across screen widths
+// (the screen is ~218px wide). Matches the right-hand artwork peek on
+// the real iPod nano/classic 6G+ menu.
+const MODERN_SPLIT_ART_WIDTH = 90;
 // Render this many extra items above and below the visible window so
 // scrolling doesn't reveal blank rows before React reconciles.
 const OVERSCAN_ITEMS = 6;
@@ -741,17 +750,21 @@ export function IpodScreen({
         </div>
       )}
 
-      {/* Title bar */}
+      {/* Title bar
+       *
+       * Modern (nano 6G/7G + iPod classic 6G silver header):
+       *   - Slim 17px strip, 12px MyriadPro semibold black text.
+       *   - Title left-aligned (no centering).
+       *   - Status icons (play/pause + battery) clustered on the right.
+       *
+       * Classic (1st-gen LCD): unchanged — Chicago glyphs centered with
+       *   play indicator on the left and battery on the right. */}
       <div
         className={cn(
-          // Header height differs by skin:
-          //   - Classic: 24px (h-6) — Chicago bitmap glyphs need the room.
-          //   - Modern: matches the row height (24px) so the silver
-          //     header reads as part of the same list rhythm.
-          "shrink-0 py-0 px-2 flex items-center sticky top-0 z-10",
+          "shrink-0 py-0 flex items-center sticky top-0 z-10",
           isModernUi
-            ? "ipod-modern-titlebar text-black font-ipod-modern-ui text-[15px] font-semibold"
-            : "h-6 min-h-6 border-b border-[#0a3667] font-chicago text-[16px] text-[#0a3667] [text-shadow:1px_1px_0_rgba(0,0,0,0.15)]"
+            ? "ipod-modern-titlebar text-black font-ipod-modern-ui font-semibold pl-2 pr-1.5 gap-1.5"
+            : "h-6 min-h-6 px-2 border-b border-[#0a3667] font-chicago text-[16px] text-[#0a3667] [text-shadow:1px_1px_0_rgba(0,0,0,0.15)]"
         )}
         style={
           isModernUi
@@ -762,54 +775,57 @@ export function IpodScreen({
             : undefined
         }
       >
-        <div
-          className={cn(
-            "flex items-center justify-start",
-            isModernUi
-              ? "w-6 font-ipod-modern-ui font-semibold text-[15px] text-black/80"
-              : `w-6 font-chicago ${isPlaying ? "text-xs" : "text-[18px]"}`
-          )}
-        >
+        {!isModernUi && (
           <div
             className={cn(
-              "flex items-center justify-center",
-              isModernUi ? "w-4 h-4" : "w-4 h-4 mt-0.5"
+              "flex items-center justify-start",
+              `w-6 font-chicago ${isPlaying ? "text-xs" : "text-[18px]"}`
             )}
           >
-            {isModernUi ? (
-              isPlaying ? (
-                <Play
-                  size={12}
-                  weight="fill"
-                  aria-label="playing"
-                />
-              ) : (
-                <Pause
-                  size={12}
-                  weight="fill"
-                  aria-label="paused"
-                />
-              )
-            ) : (
-              isPlaying ? "▶" : "⏸︎"
-            )}
+            <div className="flex items-center justify-center w-4 h-4 mt-0.5">
+              {isPlaying ? "▶" : "⏸︎"}
+            </div>
           </div>
-        </div>
+        )}
         <ScrollingText
           text={titlebarTitle}
           isPlaying
           scrollStartDelaySec={1}
           fadeEdges={isModernUi}
           className={cn(
-            "flex-1 min-w-0 px-1 text-center leading-none",
-            isModernUi &&
-              cn(
-                "font-ipod-modern-ui text-[15px] font-semibold",
-                "[text-shadow:0_1px_0_rgba(255,255,255,0.9)]"
-              )
+            "flex-1 min-w-0 leading-none",
+            isModernUi
+              ? cn(
+                  // Slimmer 12px header type matches the iPod 6G/7G photo
+                  // we were referenced to — one full pixel above the
+                  // 11px Helvetica Neue used by iOS 6 status bars but
+                  // still well under the 15px MyriadPro list rows so the
+                  // header reads as secondary chrome.
+                  "text-left text-[12px] font-semibold",
+                  "[text-shadow:0_1px_0_rgba(255,255,255,0.9)]"
+                )
+              : "px-1 text-center"
           )}
         />
-        <div className="flex w-6 items-center justify-end">
+        <div
+          className={cn(
+            "flex items-center justify-end",
+            isModernUi ? "shrink-0 gap-1" : "w-6"
+          )}
+        >
+          {isModernUi && (
+            // Compact play/pause status glyph mirroring the green-arrow
+            // affordance from the classic-iPod silver header. Render in
+            // the iPod's signature green tint (#3ea73e ≈ Apple green) so
+            // it pops against the brushed-silver gradient like the photo.
+            <div className="flex items-center justify-center w-3 h-3 text-[#3ea73e]">
+              {isPlaying ? (
+                <Play size={10} weight="fill" aria-label="playing" />
+              ) : (
+                <Pause size={10} weight="fill" aria-label="paused" />
+              )}
+            </div>
+          )}
           <BatteryIndicator backlightOn={backlightOn} variant={uiVariant} />
         </div>
       </div>
@@ -832,7 +848,7 @@ export function IpodScreen({
           {menuMode ? (
             <motion.div
               key={`menu-${menuHistory.length}-${currentMenuTitle}`}
-              className="absolute inset-0 flex flex-col h-full"
+              className="absolute inset-0 flex h-full"
               initial="enter"
               animate="center"
               exit="exit"
@@ -840,7 +856,10 @@ export function IpodScreen({
               transition={{ duration: 0.2, ease: "easeInOut" }}
               custom={menuDirection}
             >
-              <div className="flex-1 relative">
+              {/* Left column: scrolling menu list. Shrinks when the
+                  Ken Burns split-art column is visible (modern UI +
+                  active track) so both fit cleanly side-by-side. */}
+              <div className="flex-1 min-w-0 relative">
                 <div
                   ref={setMenuScrollRef}
                   className="absolute inset-0 overflow-auto ipod-menu-container"
@@ -894,6 +913,27 @@ export function IpodScreen({
                   variant={uiVariant}
                 />
               </div>
+              {/* Right column: Ken Burns album art "split menu" peek
+                  shown when the modern UI has a current track with
+                  artwork — the same right-hand artwork strip the
+                  iPod nano 6G/7G + classic 6G/7G show beside menus.
+                  Hidden when no artwork is available so the menu
+                  reverts to full-width and we never render an
+                  empty black bar. */}
+              {isModernUi && coverUrl && (
+                <div
+                  className="ipod-modern-split-art relative shrink-0 overflow-hidden"
+                  style={{ width: MODERN_SPLIT_ART_WIDTH }}
+                  aria-hidden
+                >
+                  <img
+                    src={coverUrl}
+                    alt=""
+                    draggable={false}
+                    className="ipod-modern-split-art-img absolute inset-0 size-full object-cover select-none"
+                  />
+                </div>
+              )}
             </motion.div>
           ) : (
             <motion.div

--- a/src/apps/ipod/components/IpodScreen.tsx
+++ b/src/apps/ipod/components/IpodScreen.tsx
@@ -139,8 +139,15 @@ function IpodModernPlayPauseIcon({
 }
 
 
-/** `rotateY` + perspective for left↔right foreshortening; Karaoke-style reflection stacking. */
-const MODERN_NOW_PLAYING_ART_PX = 54;
+/** `rotateY` + perspective for left↔right foreshortening; Karaoke-style reflection stacking.
+ *
+ * Cover sized at 72px (up from 54px) so it dominates the now-playing
+ * row like the iPod nano 6G/7G reference photo, where the artwork
+ * occupies roughly the left third of the screen. Reflection ratio
+ * dropped from 0.5 → 0.3 so the taller cover doesn't push its
+ * mirrored copy down into the progress bar. */
+const MODERN_NOW_PLAYING_ART_PX = 72;
+const MODERN_NOW_PLAYING_REFLECT_RATIO = 0.3;
 const MODERN_NOW_PLAYING_SLEEVE: CSSProperties = {
   background: "#1a1a1a",
   borderRadius: "3px",
@@ -167,7 +174,7 @@ const MODERN_NOW_PLAYING_ART_3D: CSSProperties = {
 
 /** Sleeve + reflection in one `preserve-3d` group tipped with rotateY + perspective. */
 function ModernNowPlayingArtwork({ coverUrl }: { coverUrl: string | null }) {
-  const reflectH = MODERN_NOW_PLAYING_ART_PX * 0.5;
+  const reflectH = MODERN_NOW_PLAYING_ART_PX * MODERN_NOW_PLAYING_REFLECT_RATIO;
 
   return (
     <div

--- a/src/apps/ipod/components/IpodScreen.tsx
+++ b/src/apps/ipod/components/IpodScreen.tsx
@@ -9,7 +9,7 @@ import {
 } from "react";
 import ReactPlayer from "react-player";
 import { motion, AnimatePresence } from "framer-motion";
-import { Pause, Play, Shuffle } from "@phosphor-icons/react";
+import { Shuffle } from "@phosphor-icons/react";
 import { cn } from "@/lib/utils";
 import { useAudioSettingsStore } from "@/stores/useAudioSettingsStore";
 import { LyricsDisplay } from "./LyricsDisplay";
@@ -85,6 +85,57 @@ function formatPlaybackTime(totalSeconds: number): string {
     2,
     "0"
   )}`;
+}
+
+/**
+ * Inline SVG play/pause indicator for the modern iPod titlebar.
+ *
+ * Uses an embedded `<linearGradient>` so the glyph can be filled with
+ * the same vertical blue gradient as the row-selection highlight
+ * (`linear-gradient(180deg, rgb(60, 184, 255) 0%, rgb(52, 122, 181) 100%)`).
+ * Phosphor icons render with `currentColor` and don't expose a way to
+ * paint a gradient, so this small custom SVG is the cleanest way to
+ * land that look without adding a new icon dep.
+ *
+ * Each instance gets a unique gradient ID — multiple icons may render
+ * in the same DOM (e.g. mini-player + screen titlebar) and SVG defs
+ * are document-scoped.
+ */
+function IpodModernPlayPauseIcon({
+  playing,
+  size = 10,
+}: {
+  playing: boolean;
+  size?: number;
+}) {
+  const gradientId = useMemo(
+    () => `ipod-modern-titlebar-grad-${Math.random().toString(36).slice(2)}`,
+    []
+  );
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      aria-label={playing ? "playing" : "paused"}
+      role="img"
+    >
+      <defs>
+        <linearGradient id={gradientId} x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0%" stopColor="rgb(60, 184, 255)" />
+          <stop offset="100%" stopColor="rgb(52, 122, 181)" />
+        </linearGradient>
+      </defs>
+      {playing ? (
+        <path d="M8 5v14l11-7z" fill={`url(#${gradientId})`} />
+      ) : (
+        <g fill={`url(#${gradientId})`}>
+          <rect x="6" y="5" width="4" height="14" rx="0.5" />
+          <rect x="14" y="5" width="4" height="14" rx="0.5" />
+        </g>
+      )}
+    </svg>
+  );
 }
 
 
@@ -786,7 +837,8 @@ export function IpodScreen({
        *
        * Modern (nano 6G/7G + iPod classic 6G silver header):
        *   - Slim 17px strip, 12px MyriadPro semibold black text.
-       *   - Title left-aligned (no centering).
+       *   - Title left-aligned with 6px padding to match the menu
+       *     row text indent (`MenuListItem` uses `pl-1.5 pr-2`).
        *   - Status icons (play/pause + battery) clustered on the right.
        *   - Clamped to the LEFT HALF of the screen in split menu mode
        *     so the album art column extends to the very top edge.
@@ -797,8 +849,9 @@ export function IpodScreen({
         className={cn(
           "shrink-0 py-0 flex items-center sticky top-0 z-20",
           isModernUi
-            ? "ipod-modern-titlebar text-black font-ipod-modern-ui font-semibold pl-2 pr-1.5 gap-1.5"
-            : "h-6 min-h-6 px-2 border-b border-[#0a3667] font-chicago text-[16px] text-[#0a3667] [text-shadow:1px_1px_0_rgba(0,0,0,0.15)]"
+            ? "ipod-modern-titlebar text-black font-ipod-modern-ui font-semibold pl-1.5 pr-1.5 gap-1.5"
+            : "h-6 min-h-6 px-2 border-b border-[#0a3667] font-chicago text-[16px] text-[#0a3667] [text-shadow:1px_1px_0_rgba(0,0,0,0.15)]",
+          showSplitMenuArt && "ipod-modern-menu-panel"
         )}
         style={
           isModernUi
@@ -849,16 +902,13 @@ export function IpodScreen({
           )}
         >
           {isModernUi && (
-            // Compact play/pause status glyph mirroring the green-arrow
-            // affordance from the classic-iPod silver header. Render in
-            // the iPod's signature green tint (#3ea73e ≈ Apple green) so
-            // it pops against the brushed-silver gradient like the photo.
-            <div className="flex items-center justify-center w-3 h-3 text-[#3ea73e]">
-              {isPlaying ? (
-                <Play size={10} weight="fill" aria-label="playing" />
-              ) : (
-                <Pause size={10} weight="fill" aria-label="paused" />
-              )}
+            // Compact play/pause status glyph painted with the same
+            // top-to-bottom blue gradient as the row-selection
+            // highlight, matching the iOS 6 / iPod nano 6G "tinted"
+            // status-bar look. Inline SVG with an embedded gradient
+            // so it stays a single sharp shape on any DPI.
+            <div className="flex items-center justify-center w-3 h-3">
+              <IpodModernPlayPauseIcon playing={isPlaying} size={10} />
             </div>
           )}
           <BatteryIndicator backlightOn={backlightOn} variant={uiVariant} />
@@ -874,7 +924,8 @@ export function IpodScreen({
       <div
         className={cn(
           "relative",
-          !showVideo && "z-30"
+          !showVideo && "z-30",
+          showSplitMenuArt && "ipod-modern-menu-panel bg-white"
         )}
         style={{
           height: isModernUi

--- a/src/apps/ipod/components/IpodScreen.tsx
+++ b/src/apps/ipod/components/IpodScreen.tsx
@@ -141,12 +141,12 @@ function IpodModernPlayPauseIcon({
 
 /** `rotateY` + perspective for left↔right foreshortening; Karaoke-style reflection stacking.
  *
- * Cover sized at 72px (up from 54px) so it dominates the now-playing
- * row like the iPod nano 6G/7G reference photo, where the artwork
- * occupies roughly the left third of the screen. Reflection ratio
- * dropped from 0.5 → 0.3 so the taller cover doesn't push its
- * mirrored copy down into the progress bar. */
-const MODERN_NOW_PLAYING_ART_PX = 72;
+ * Cover sized at 60px — comfortably bigger than the original 54px
+ * without crowding the title / artist / album text column to its
+ * right or pushing the reflection down into the progress bar.
+ * Reflection ratio kept at 0.3 (subtler than the prior 0.5) so the
+ * stack stays inside the now-playing row. */
+const MODERN_NOW_PLAYING_ART_PX = 60;
 const MODERN_NOW_PLAYING_REFLECT_RATIO = 0.3;
 const MODERN_NOW_PLAYING_SLEEVE: CSSProperties = {
   background: "#1a1a1a",

--- a/src/apps/ipod/components/screen/BatteryIndicator.tsx
+++ b/src/apps/ipod/components/screen/BatteryIndicator.tsx
@@ -64,13 +64,16 @@ export function BatteryIndicator({
   const filledBars = isCharging ? animationFrame : Math.ceil(level * 4);
 
   if (isModern) {
-    // Glossy grey shell (rounded), green fill clipped inside shell; nib overlaps the
-    // right curve (-ml-[2px]) so there's no slit, protrudes farther right vs prior 2×6 cap.
+    // Compact iPod nano 6G/7G battery: smaller pill (14×7) sized for the
+    // slim 17px titlebar, with a "half-glossy" highlight that brightens
+    // the top half only and fades to transparent at the midline. The
+    // green fill carries the same half-gloss so charge level reads as
+    // a single glossy lozenge rather than a flat bar.
     const fillPercent = Math.max(0, Math.min(1, level)) * 100;
     const isLow = !isCharging && level <= 0.2;
     return (
       <div className="flex items-center">
-        <div className="relative h-[10px] w-[19px] shrink-0 overflow-hidden rounded-[2px] ipod-modern-battery-container">
+        <div className="relative h-[7px] w-[14px] shrink-0 overflow-hidden rounded-[1.5px] ipod-modern-battery-container">
           <div
             className={cn(
               "absolute inset-y-0 left-0 ipod-modern-battery-fill transition-[width] duration-300",
@@ -79,7 +82,7 @@ export function BatteryIndicator({
             style={{ width: `${fillPercent}%` }}
           />
         </div>
-        <div className="-ml-[2px] h-[5px] w-[4px] shrink-0 ipod-modern-battery-cap" />
+        <div className="-ml-[1px] h-[3px] w-[2px] shrink-0 ipod-modern-battery-cap" />
       </div>
     );
   }

--- a/src/apps/ipod/components/screen/BatteryIndicator.tsx
+++ b/src/apps/ipod/components/screen/BatteryIndicator.tsx
@@ -73,7 +73,7 @@ export function BatteryIndicator({
     const isLow = !isCharging && level <= 0.2;
     return (
       <div className="flex items-center">
-        <div className="relative h-[7px] w-[14px] shrink-0 overflow-hidden rounded-[1.5px] ipod-modern-battery-container">
+        <div className="relative h-[9px] w-[14px] shrink-0 overflow-hidden rounded-[2px] ipod-modern-battery-container">
           <div
             className={cn(
               "absolute inset-y-0 left-0 ipod-modern-battery-fill transition-[width] duration-300",
@@ -82,7 +82,7 @@ export function BatteryIndicator({
             style={{ width: `${fillPercent}%` }}
           />
         </div>
-        <div className="-ml-[1px] h-[3px] w-[2px] shrink-0 ipod-modern-battery-cap" />
+        <div className="-ml-[1px] h-[5px] w-[2px] shrink-0 ipod-modern-battery-cap" />
       </div>
     );
   }

--- a/src/apps/ipod/components/screen/MenuListItem.tsx
+++ b/src/apps/ipod/components/screen/MenuListItem.tsx
@@ -1,4 +1,5 @@
 import { cn } from "@/lib/utils";
+import { ScrollingText } from "./ScrollingText";
 
 interface MenuListItemProps {
   text: string;
@@ -39,9 +40,14 @@ export function MenuListItem({
     // iPod-classic-js SelectableListItem: white row, blue gradient
     // selection highlight, no separator. Rows are compact (**21px**) with **15px** type so
     // titlebar + six rows fit inside the 150px screen (nano 6G/7G density).
-    // leading-normal + horizontal-only ellipsis keeps ascenders/descenders intact even though
-    // the 22.5px line-box slightly exceeds the row — `overflow-y-visible` on the inner span
-    // lets glyphs breathe without clipping. Classic unchanged (16px Chicago, 24px rows).
+    //
+    // Long labels truncate via `ScrollingText` with `fadeEdges`:
+    //   - When the label fits, ScrollingText renders static text.
+    //   - When it overflows, a fade-to-transparent mask appears on the
+    //     right edge (truncation hint) instead of an ellipsis.
+    //   - When the row is also `isSelected`, the marquee animates and
+    //     both edges fade — matches the iPod nano 6G/7G's behavior of
+    //     scrolling the highlighted row's text horizontally.
     return (
       <div
         onClick={isLoading ? undefined : onClick}
@@ -58,15 +64,14 @@ export function MenuListItem({
         )}
       >
         <span className="flex min-h-0 min-w-0 flex-1 items-center mr-2">
-          <span
-            className={cn(
-              /* ellipsis needs overflow control; truncate uses overflow:hidden and clips glyphs vertically */
-              "max-w-full min-w-0 block overflow-x-clip overflow-y-visible text-ellipsis whitespace-nowrap",
-              "text-[15px] font-semibold leading-normal"
-            )}
-          >
-            {text}
-          </span>
+          <ScrollingText
+            text={text}
+            align="left"
+            fadeEdges
+            isPlaying={isSelected && !isLoading}
+            scrollStartDelaySec={0.5}
+            className="max-w-full min-w-0 block text-[15px] font-semibold leading-normal"
+          />
         </span>
         {value ? (
           <span

--- a/src/index.css
+++ b/src/index.css
@@ -1495,18 +1495,37 @@ button.piano-key.piano-key[class*="bg-[#ff33ff]"] {
   border-radius: 0 3px 3px 0;
 }
 
-/* iPod 6G/7G "split menu" view: a square-ish strip on the right side of
- * a menu screen that shows the now-playing album art with a slow
- * Ken Burns zoom + pan. Matches the artwork peek visible on real
- * iPod nano 6G/7G + classic 6G/7G menus. The container clips the
- * over-scaled image; the inner image animates `transform`.
+/* iPod 6G/7G "split menu" view: the right HALF of the screen shows
+ * the now-playing album art with a slow Ken Burns zoom + pan, while
+ * the menu list + titlebar are clamped to the left half. Matches the
+ * "Music + Now Playing" layout on the iPod classic 6G/7G reference
+ * photo. The container clips the over-scaled image; the inner image
+ * animates `transform`.
  *
- * The art column is divided from the menu by a thin grey hairline
- * (same hue family as the titlebar bottom border) so the menu list
- * still reads as a distinct surface. */
+ * The art panel sits *behind* the menu surface with a soft inset
+ * shadow on its left edge, making it look like the menu (foreground
+ * white panel) is casting a shadow onto the art (background image).
+ * That depth read matches the reference photo where the menu has a
+ * crisp right edge with the art visibly receding behind it. */
 .ipod-modern-split-art {
   background: #1a1a1a;
-  box-shadow: inset 1px 0 0 #cfd2d4;
+  box-shadow:
+    inset 8px 0 10px -4px rgba(0, 0, 0, 0.55),
+    inset 1px 0 0 rgba(0, 0, 0, 0.35);
+}
+
+/* LEFT-side menu surface in split mode: must clip its contents (so menu
+ * row chrome and the silver titlebar gradient never bleed past the
+ * panel edge) and cast a soft drop shadow onto the album art panel
+ * to its right. The inset shadow on `.ipod-modern-split-art` does
+ * most of the depth work — this rule just adds a crisp 1px right
+ * edge + a short outer falloff so the menu reads as a foreground
+ * surface in front of the artwork. */
+.ipod-modern-menu-panel {
+  overflow: hidden;
+  box-shadow:
+    2px 0 4px -1px rgba(0, 0, 0, 0.25),
+    inset -1px 0 0 rgba(0, 0, 0, 0.18);
 }
 
 .ipod-modern-split-art-img {

--- a/src/index.css
+++ b/src/index.css
@@ -1449,24 +1449,23 @@ button.piano-key.piano-key[class*="bg-[#ff33ff]"] {
   color: #ffffff;
 }
 
-/* iPod nano 6G/7G battery, "half-glossy" treatment:
- *   - Container: dark grey shell with a 1px hairline and a glossy white
- *     highlight covering ONLY the top half (fades to transparent at
- *     the midline) — same lacquer look as the iOS 6 status bar
- *     battery icon.
- *   - Fill: green (or red at ≤20%) carrying the same top-half gloss so
- *     the charge level reads as a single glossy lozenge.
- *   - Cap: tiny matched-grey nib protruding past the right curve.
+/* iPod-classic-js BatteryIndicator (sampled directly):
+ *   ChargeLevelContainer: 1px solid #626262, background #54585b w/ a
+ *     gloss `linear-gradient(180deg, transparent 25%, 65%, rgba(255,255,255,.5))`
+ *   ChargeLevel: green #A5E07F (or red #D17F6B at <=20%) overlaid with a
+ *     specular highlight + dark base.
+ *   BatteryCap: light grey #c4c4c4 with a #626262 outline.
  *
- * Sized at 14×7 with a 2×3 cap for the slim 17px modern titlebar. */
+ * Sized at 14×7 with a 2×3 cap for the slim 17px modern titlebar — the
+ * gradient stops are unchanged from the iPod-classic-js reference. */
 .ipod-modern-battery-container {
   border: 1px solid #626262;
   background-color: #54585b;
   background-image: linear-gradient(
     180deg,
-    rgba(255, 255, 255, 0.55) 0%,
-    rgba(255, 255, 255, 0.18) 45%,
-    transparent 50%
+    transparent 25%,
+    transparent 65%,
+    rgba(255, 255, 255, 0.5) 100%
   );
 }
 
@@ -1474,9 +1473,13 @@ button.piano-key.piano-key[class*="bg-[#ff33ff]"] {
   background-color: #a5e07f;
   background-image: linear-gradient(
     180deg,
-    rgba(255, 255, 255, 0.6) 0%,
-    rgba(255, 255, 255, 0.15) 45%,
-    transparent 50%
+    transparent 10%,
+    rgba(255, 255, 255, 0.5) 20%,
+    transparent 35%,
+    transparent 40%,
+    rgba(0, 0, 0, 0.2) 55%,
+    rgba(0, 0, 0, 0.3) 65%,
+    rgba(0, 0, 0, 0.4) 80%
   );
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -1495,6 +1495,45 @@ button.piano-key.piano-key[class*="bg-[#ff33ff]"] {
   border-radius: 0 3px 3px 0;
 }
 
+/* iPod 6G/7G "split menu" view: a square-ish strip on the right side of
+ * a menu screen that shows the now-playing album art with a slow
+ * Ken Burns zoom + pan. Matches the artwork peek visible on real
+ * iPod nano 6G/7G + classic 6G/7G menus. The container clips the
+ * over-scaled image; the inner image animates `transform`.
+ *
+ * The art column is divided from the menu by a thin grey hairline
+ * (same hue family as the titlebar bottom border) so the menu list
+ * still reads as a distinct surface. */
+.ipod-modern-split-art {
+  background: #1a1a1a;
+  box-shadow: inset 1px 0 0 #cfd2d4;
+}
+
+.ipod-modern-split-art-img {
+  transform-origin: center center;
+  animation: ipod-modern-ken-burns 16s ease-in-out infinite alternate;
+  will-change: transform;
+}
+
+@keyframes ipod-modern-ken-burns {
+  0% {
+    transform: scale(1.08) translate(-3%, -2%);
+  }
+  50% {
+    transform: scale(1.18) translate(2%, 1%);
+  }
+  100% {
+    transform: scale(1.1) translate(3%, 3%);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ipod-modern-split-art-img {
+    animation: none;
+    transform: scale(1.08);
+  }
+}
+
 /* macOS theme override: the `.ipod-force-font *` rule in themes.css sets
  * `font-family: inherit !important`, which would clobber Helvetica Neue.
  * Restore it for the modern skin classes — same approach used for

--- a/src/index.css
+++ b/src/index.css
@@ -1449,24 +1449,24 @@ button.piano-key.piano-key[class*="bg-[#ff33ff]"] {
   color: #ffffff;
 }
 
-/* iPod-classic-js BatteryIndicator (sampled directly):
- *   ChargeLevelContainer: 1px solid #626262, background #54585b w/ a
- *     gloss `linear-gradient(180deg, transparent 25%, 65%, rgba(255,255,255,.5))`
- *   ChargeLevel: green #A5E07F (or red #D17F6B at <=20%) overlaid with a
- *     specular highlight + dark base.
- *   BatteryCap: light grey #c4c4c4 with a #626262 outline.
+/* iPod nano 6G/7G battery, "half-glossy" treatment:
+ *   - Container: dark grey shell with a 1px hairline and a glossy white
+ *     highlight covering ONLY the top half (fades to transparent at
+ *     the midline) — same lacquer look as the iOS 6 status bar
+ *     battery icon.
+ *   - Fill: green (or red at ≤20%) carrying the same top-half gloss so
+ *     the charge level reads as a single glossy lozenge.
+ *   - Cap: tiny matched-grey nib protruding past the right curve.
  *
- * The bar count is irrelevant in this skin — the CSS draws a continuous
- * fill % rather than 4 segments. The component handles the percentage
- * sampling. */
+ * Sized at 14×7 with a 2×3 cap for the slim 17px modern titlebar. */
 .ipod-modern-battery-container {
   border: 1px solid #626262;
   background-color: #54585b;
   background-image: linear-gradient(
     180deg,
-    transparent 25%,
-    transparent 65%,
-    rgba(255, 255, 255, 0.5) 100%
+    rgba(255, 255, 255, 0.55) 0%,
+    rgba(255, 255, 255, 0.18) 45%,
+    transparent 50%
   );
 }
 
@@ -1474,13 +1474,9 @@ button.piano-key.piano-key[class*="bg-[#ff33ff]"] {
   background-color: #a5e07f;
   background-image: linear-gradient(
     180deg,
-    transparent 10%,
-    rgba(255, 255, 255, 0.5) 20%,
-    transparent 35%,
-    transparent 40%,
-    rgba(0, 0, 0, 0.2) 55%,
-    rgba(0, 0, 0, 0.3) 65%,
-    rgba(0, 0, 0, 0.4) 80%
+    rgba(255, 255, 255, 0.6) 0%,
+    rgba(255, 255, 255, 0.15) 45%,
+    transparent 50%
   );
 }
 
@@ -1492,7 +1488,7 @@ button.piano-key.piano-key[class*="bg-[#ff33ff]"] {
   background-color: #c4c4c4;
   border: 1px solid #626262;
   border-left-width: 0;
-  border-radius: 0 3px 3px 0;
+  border-radius: 0 2px 2px 0;
 }
 
 /* iPod 6G/7G "split menu" view: the right HALF of the screen shows


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates the modern iPod skin to match the iPod nano 6G/7G + iPod classic 6G/7G "Music + Now Playing" reference photo.

### Title bar (status bar)
- Slimmed from 21px → 17px tall.
- 12px MyriadPro semibold text (down from 15px).
- Title is now **left-aligned** with the same 6px left padding as the menu rows below (`pl-1.5`), so the title text aligns vertically with the menu item labels.
- Play/pause status icon moved to the right cluster, painted with the **iOS 6 blue gradient** (the same `linear-gradient(rgb(60, 184, 255) → rgb(52, 122, 181))` used by the row-selection highlight). Inline SVG with an embedded `<linearGradient>` def keeps it crisp at any DPI.
- Battery sits to the right of the play/pause indicator.
- In split menu mode, the titlebar is **clamped to the left half** of the screen so the album art panel can extend to the very top edge.

### Split menu view (50/50)
- When in menu mode and the modern UI has a track with artwork loaded, the right **half** of the screen becomes a full-height Ken Burns album-art panel.
- Album art animates with a slow zoom + pan loop (16s, alternating, respects `prefers-reduced-motion`).
- The left-side menu panel (titlebar + menu list) **clips its contents** (`overflow: hidden`) and casts a soft drop shadow onto the album art, with a matching inset shadow on the art's left edge — making the menu read as a foreground surface above the artwork.
- Falls back to full-width chrome when no track / no cover URL is available, so empty installs never see a black panel.
- Now Playing view stays full-width; only the menu mode renders the split.

Classic skin (Chicago + monochrome blue) is unchanged.

## Files
- `src/apps/ipod/components/IpodScreen.tsx` — slim titlebar layout, blue-gradient play/pause SVG, split menu panel rendering, full-height art overlay.
- `src/index.css` — `.ipod-modern-split-art`, `.ipod-modern-menu-panel`, `@keyframes ipod-modern-ken-burns`.

## Testing
- `bun run build` ✅ — passes (per user request, manual UI verification skipped).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d7aec2d6-3c31-4645-ac53-3a11f61f1517"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d7aec2d6-3c31-4645-ac53-3a11f61f1517"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

