### PR TITLE
ipod: search lyrics by live track metadata for stations & playlists

### DIFF
--- a/src/apps/ipod/components/IpodAppComponent.tsx
+++ b/src/apps/ipod/components/IpodAppComponent.tsx
@@ -113,6 +113,9 @@ export function IpodAppComponent({
     setIsSyncModeOpen,
     currentTrack,
     lyricsSourceOverride,
+    lyricsTitle,
+    lyricsArtist,
+    lyricsSongId,
     fullscreenCoverUrl,
     fullScreenLyricsControls,
     furiganaMap,
@@ -861,10 +864,21 @@ export function IpodAppComponent({
           <LyricsSearchDialog
             isOpen={isLyricsSearchDialogOpen}
             onOpenChange={setIsLyricsSearchDialogOpen}
-            trackId={currentTrack.id}
-            trackTitle={currentTrack.title}
-            trackArtist={currentTrack.artist}
-            initialQuery={`${currentTrack.title} ${currentTrack.artist || ""}`.trim()}
+            // Search lyrics for the *actual song* that's playing, not
+            // the iPod track shell. For Apple Music stations and
+            // playlists `lyricsTitle` / `lyricsArtist` / `lyricsSongId`
+            // come from MusicKit's live `mediaItemDidChange` metadata,
+            // so we never use the station / playlist name as the
+            // search query. For library tracks they fall through to
+            // `currentTrack`. They are empty for a collection that
+            // hasn't received its first MusicKit media-item event
+            // yet — let the dialog render with an empty query so the
+            // user can still type one manually rather than searching
+            // for "Today's Hits".
+            trackId={lyricsSongId || currentTrack.id}
+            trackTitle={lyricsTitle}
+            trackArtist={lyricsArtist}
+            initialQuery={`${lyricsTitle} ${lyricsArtist || ""}`.trim()}
             onSelect={handleLyricsSearchSelect}
             onReset={handleLyricsSearchReset}
             hasOverride={!!lyricsSourceOverride}

--- a/src/apps/ipod/hooks/useIpodLogic.ts
+++ b/src/apps/ipod/hooks/useIpodLogic.ts
@@ -33,8 +33,11 @@ import {
   getEffectiveTranslationLanguage,
   flushPendingLyricOffsetSave,
   isAppleMusicCollectionTrack,
-  appleMusicKitIdToLyricsSongId,
 } from "@/stores/useIpodStore";
+import {
+  resolveLyricsOverrideTargetId as resolveLyricsOverrideTargetIdHelper,
+  resolveLyricsTrackMetadata,
+} from "../utils/lyricsTrackMetadata";
 import { useShallow } from "zustand/react/shallow";
 import {
   useIpodStoreShallow,
@@ -3387,24 +3390,44 @@ export function useIpodLogic({
     if (tracks.length > 0 && currentIndex >= 0) setIsLyricsSearchDialogOpen(true);
   }, [tracks, currentIndex]);
 
+  // Live MusicKit metadata for the currently-streaming song. Read here
+  // (earlier than the rest of the lyrics block below) so the
+  // override-target / search-handler callbacks can depend on it.
+  const appleMusicKitNowPlaying = useIpodStore((s) => s.appleMusicKitNowPlaying);
+
+  // Resolve the id we should persist a manual lyrics-source override
+  // against. For Apple Music stations / playlists this MUST be the
+  // live MusicKit song id, not the shell — otherwise every song
+  // streamed through the same station / playlist would inherit the
+  // user's pick. Pure logic lives in `resolveLyricsOverrideTargetId`
+  // so it's unit-testable in isolation.
+  const resolveLyricsOverrideTargetId = useCallback(
+    (): string | null =>
+      resolveLyricsOverrideTargetIdHelper(
+        tracks[currentIndex] ?? null,
+        appleMusicKitNowPlaying
+      ),
+    [tracks, currentIndex, appleMusicKitNowPlaying]
+  );
+
   const handleLyricsSearchSelect = useCallback(
     (result: { hash: string; albumId: string | number; title: string; artist: string; album?: string }) => {
-      const track = tracks[currentIndex];
-      if (track) {
-        setTrackLyricsSource(track.id, result);
+      const targetId = resolveLyricsOverrideTargetId();
+      if (targetId) {
+        setTrackLyricsSource(targetId, result);
         refreshLyrics();
       }
     },
-    [tracks, currentIndex, setTrackLyricsSource, refreshLyrics]
+    [resolveLyricsOverrideTargetId, setTrackLyricsSource, refreshLyrics]
   );
 
   const handleLyricsSearchReset = useCallback(() => {
-    const track = tracks[currentIndex];
-    if (track) {
-      clearTrackLyricsSource(track.id);
+    const targetId = resolveLyricsOverrideTargetId();
+    if (targetId) {
+      clearTrackLyricsSource(targetId);
       refreshLyrics();
     }
-  }, [tracks, currentIndex, clearTrackLyricsSource, refreshLyrics]);
+  }, [resolveLyricsOverrideTargetId, clearTrackLyricsSource, refreshLyrics]);
 
   const ipodGenerateShareUrl = useCallback(
     (songId: string): string => {
@@ -3439,7 +3462,6 @@ export function useIpodLogic({
 
   // Volume from audio settings store
   const { ipodVolume } = useAudioSettingsStoreShallow((state) => ({ ipodVolume: state.ipodVolume }));
-  const appleMusicKitNowPlaying = useIpodStore((s) => s.appleMusicKitNowPlaying);
 
   // Lyrics hook
   const selectedMatchForLyrics = useMemo(() => {
@@ -3459,29 +3481,18 @@ export function useIpodLogic({
     () => getEffectiveTranslationLanguage(lyricsTranslationLanguage),
     [lyricsTranslationLanguage, appLanguage]
   );
-  const lyricsTitle = useMemo(() => {
-    if (currentTrack && isAppleMusicCollectionTrack(currentTrack)) {
-      const live = appleMusicKitNowPlaying?.title?.trim();
-      if (live) return live;
-    }
-    return currentTrack?.title ?? "";
-  }, [currentTrack, appleMusicKitNowPlaying?.title]);
-
-  const lyricsArtist = useMemo(() => {
-    if (currentTrack && isAppleMusicCollectionTrack(currentTrack)) {
-      const live = appleMusicKitNowPlaying?.artist?.trim();
-      if (live) return live;
-    }
-    return currentTrack?.artist ?? "";
-  }, [currentTrack, appleMusicKitNowPlaying?.artist]);
-
-  const lyricsSongId = useMemo(() => {
-    if (!currentTrack) return "";
-    if (isAppleMusicCollectionTrack(currentTrack)) {
-      return appleMusicKitIdToLyricsSongId(appleMusicKitNowPlaying?.id);
-    }
-    return currentTrack.id ?? "";
-  }, [currentTrack, appleMusicKitNowPlaying?.id]);
+  // For Apple Music stations / playlists the iPod's `currentTrack` is
+  // a *shell* — its title / artist describe the station or playlist
+  // itself ("Today's Hits" / "Apple Music"), NOT the song that's
+  // currently playing through it. Resolution lives in
+  // `resolveLyricsTrackMetadata` so the rule is unit-tested in
+  // isolation (see `tests/test-ipod-lyrics-track-metadata.test.ts`).
+  const lyricsMetadata = useMemo(
+    () => resolveLyricsTrackMetadata(currentTrack, appleMusicKitNowPlaying),
+    [currentTrack, appleMusicKitNowPlaying]
+  );
+  const { title: lyricsTitle, artist: lyricsArtist, songId: lyricsSongId } =
+    lyricsMetadata;
 
   const lyricsTimingOffsetMs = useMemo(() => {
     if (
@@ -3905,6 +3916,16 @@ export function useIpodLogic({
     furiganaMap,
     soramimiMap,
     effectiveTranslationLanguage,
+    /** Title to use when fetching/searching lyrics (live MusicKit
+     *  metadata for stations / playlists, currentTrack title otherwise). */
+    lyricsTitle,
+    /** Artist to use when fetching/searching lyrics (mirrors lyricsTitle). */
+    lyricsArtist,
+    /** Song id to use when fetching/searching lyrics (live MusicKit id
+     *  for collections, currentTrack.id otherwise). May be empty for a
+     *  station / playlist that hasn't received its first
+     *  `mediaItemDidChange` event yet. */
+    lyricsSongId,
 
     // Audio
     ipodVolume,

--- a/src/apps/ipod/utils/lyricsTrackMetadata.ts
+++ b/src/apps/ipod/utils/lyricsTrackMetadata.ts
@@ -1,0 +1,99 @@
+import {
+  appleMusicKitIdToLyricsSongId,
+  isAppleMusicCollectionTrack,
+  type AppleMusicKitNowPlaying,
+  type Track,
+} from "@/stores/useIpodStore";
+
+/**
+ * Lyrics-search metadata resolved against the *actual song* the iPod
+ * is playing (rather than the iPod track shell visible in the library
+ * UI).
+ *
+ * For Apple Music **stations** and **playlists** the iPod's
+ * `currentTrack` is a shell whose `title` / `artist` describe the
+ * station or playlist itself ("Today's Hits" by "Apple Music"). The
+ * song MusicKit is currently streaming through that shell lives in
+ * `appleMusicKitNowPlaying`. Lyrics must follow the live song —
+ * searching with the station / playlist name returns obviously wrong
+ * results.
+ *
+ * For library tracks (YouTube or Apple Music songs) `currentTrack`
+ * already describes the song, so the live MusicKit metadata is
+ * irrelevant.
+ */
+export interface LyricsTrackMetadata {
+  /** Title to feed `useLyrics` and the lyrics search dialog. Empty
+   *  string for a station / playlist that hasn't received its first
+   *  MusicKit `mediaItemDidChange` yet. */
+  title: string;
+  /** Artist to feed `useLyrics` and the lyrics search dialog. Empty
+   *  string in the same shell-without-live-metadata case as `title`. */
+  artist: string;
+  /** Song id to feed `useLyrics`. For collections that's the
+   *  `am:<musickit-id>` of the live song; for library tracks it's
+   *  `currentTrack.id`. Empty string when no song id is available
+   *  (e.g. station with no live media item yet) — `useLyrics` already
+   *  bails out on empty `songId`, so this also guards the auto-fetch
+   *  from running with the wrong title / artist. */
+  songId: string;
+}
+
+/**
+ * Resolve the title / artist / song id that lyrics flows (auto-fetch
+ * via `useLyrics` AND the manual lyrics-search dialog) should use for
+ * the iPod's current track.
+ *
+ * Critically, for Apple Music stations / playlists this NEVER falls
+ * back to the shell's title / artist when the live MusicKit metadata
+ * is missing — falling back would search lyrics for the station /
+ * playlist name (e.g. "Today's Hits" by "Apple Music") and return
+ * results that have nothing to do with the song actually playing.
+ */
+export function resolveLyricsTrackMetadata(
+  currentTrack: Track | null | undefined,
+  appleMusicKitNowPlaying: AppleMusicKitNowPlaying | null | undefined
+): LyricsTrackMetadata {
+  if (!currentTrack) {
+    return { title: "", artist: "", songId: "" };
+  }
+
+  if (isAppleMusicCollectionTrack(currentTrack)) {
+    return {
+      title: appleMusicKitNowPlaying?.title?.trim() ?? "",
+      artist: appleMusicKitNowPlaying?.artist?.trim() ?? "",
+      songId: appleMusicKitIdToLyricsSongId(appleMusicKitNowPlaying?.id),
+    };
+  }
+
+  return {
+    title: currentTrack.title ?? "",
+    artist: currentTrack.artist ?? "",
+    songId: currentTrack.id ?? "",
+  };
+}
+
+/**
+ * Resolve the id we should persist a manual lyrics-source override
+ * against. For Apple Music stations / playlists the override must be
+ * keyed on the live MusicKit song id, NOT the shell — otherwise every
+ * song streamed through that station / playlist would inherit the
+ * user's pick.
+ *
+ * Returns `null` when no usable id is available (e.g. a station with
+ * no live media item yet) so callers can no-op rather than persisting
+ * against the wrong key.
+ */
+export function resolveLyricsOverrideTargetId(
+  currentTrack: Track | null | undefined,
+  appleMusicKitNowPlaying: AppleMusicKitNowPlaying | null | undefined
+): string | null {
+  if (!currentTrack) return null;
+  if (isAppleMusicCollectionTrack(currentTrack)) {
+    const liveId = appleMusicKitIdToLyricsSongId(
+      appleMusicKitNowPlaying?.id
+    );
+    return liveId || null;
+  }
+  return currentTrack.id ?? null;
+}

--- a/tests/test-ipod-lyrics-track-metadata.test.ts
+++ b/tests/test-ipod-lyrics-track-metadata.test.ts
@@ -1,0 +1,230 @@
+import { describe, expect, test } from "bun:test";
+
+// Browser globals must be installed before importing the iPod store —
+// the store re-imports `useChatsStore`, which reads `localStorage` at
+// module-load time. Mirrors the harness in
+// `tests/test-ipod-apple-music.test.ts`.
+class MemoryStorage implements Storage {
+  private readonly map = new Map<string, string>();
+  get length(): number {
+    return this.map.size;
+  }
+  clear(): void {
+    this.map.clear();
+  }
+  getItem(key: string): string | null {
+    return this.map.get(key) ?? null;
+  }
+  key(index: number): string | null {
+    return Array.from(this.map.keys())[index] ?? null;
+  }
+  removeItem(key: string): void {
+    this.map.delete(key);
+  }
+  setItem(key: string, value: string): void {
+    this.map.set(key, value);
+  }
+}
+
+const browserGlobals = globalThis as typeof globalThis & {
+  localStorage?: Storage;
+  navigator?: Navigator;
+};
+if (!browserGlobals.localStorage) {
+  browserGlobals.localStorage = new MemoryStorage();
+}
+if (!browserGlobals.navigator) {
+  browserGlobals.navigator = { onLine: true, userAgent: "test" } as Navigator;
+}
+
+const {
+  resolveLyricsTrackMetadata,
+  resolveLyricsOverrideTargetId,
+} = await import("../src/apps/ipod/utils/lyricsTrackMetadata");
+type Track = import("../src/stores/useIpodStore").Track;
+
+const youtubeTrack: Track = {
+  id: "dQw4w9WgXcQ",
+  url: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+  title: "Never Gonna Give You Up",
+  artist: "Rick Astley",
+  source: "youtube",
+};
+
+const appleMusicLibraryTrack: Track = {
+  id: "am:1616228595",
+  url: "applemusic:1616228595",
+  title: "Bohemian Rhapsody",
+  artist: "Queen",
+  source: "appleMusic",
+  appleMusicPlayParams: {
+    catalogId: "1616228595",
+  },
+};
+
+const stationShellTrack: Track = {
+  id: "am:station:ra.todays-hits",
+  url: "applemusic:station:ra.todays-hits",
+  title: "Today's Hits",
+  artist: "Apple Music",
+  source: "appleMusic",
+  appleMusicPlayParams: {
+    stationId: "ra.todays-hits",
+    kind: "radioStation",
+  },
+};
+
+const playlistShellTrack: Track = {
+  id: "am:playlist:pl.favorites-mix",
+  url: "applemusic:playlist:pl.favorites-mix",
+  title: "Favorites Mix",
+  artist: "Apple Music for Me",
+  source: "appleMusic",
+  appleMusicPlayParams: {
+    playlistId: "pl.favorites-mix",
+    kind: "playlist",
+  },
+};
+
+describe("resolveLyricsTrackMetadata", () => {
+  test("uses currentTrack for YouTube library songs (live MusicKit ignored)", () => {
+    const meta = resolveLyricsTrackMetadata(youtubeTrack, {
+      id: "irrelevant",
+      title: "Irrelevant",
+      artist: "Whoever",
+    });
+    expect(meta).toEqual({
+      title: "Never Gonna Give You Up",
+      artist: "Rick Astley",
+      songId: "dQw4w9WgXcQ",
+    });
+  });
+
+  test("uses currentTrack for Apple Music library songs", () => {
+    const meta = resolveLyricsTrackMetadata(appleMusicLibraryTrack, null);
+    expect(meta).toEqual({
+      title: "Bohemian Rhapsody",
+      artist: "Queen",
+      songId: "am:1616228595",
+    });
+  });
+
+  test("uses LIVE MusicKit metadata for radio stations (not the station name)", () => {
+    const meta = resolveLyricsTrackMetadata(stationShellTrack, {
+      id: "1616228595",
+      title: "Bohemian Rhapsody",
+      artist: "Queen",
+    });
+    expect(meta.title).toBe("Bohemian Rhapsody");
+    expect(meta.artist).toBe("Queen");
+    expect(meta.songId).toBe("am:1616228595");
+    expect(meta.title).not.toBe("Today's Hits");
+    expect(meta.artist).not.toBe("Apple Music");
+  });
+
+  test("uses LIVE MusicKit metadata for playlists (not the playlist name)", () => {
+    const meta = resolveLyricsTrackMetadata(playlistShellTrack, {
+      id: "1616228595",
+      title: "Bohemian Rhapsody",
+      artist: "Queen",
+    });
+    expect(meta.title).toBe("Bohemian Rhapsody");
+    expect(meta.artist).toBe("Queen");
+    expect(meta.songId).toBe("am:1616228595");
+    expect(meta.title).not.toBe("Favorites Mix");
+    expect(meta.artist).not.toBe("Apple Music for Me");
+  });
+
+  test("returns empty strings for a station with no live MusicKit metadata yet", () => {
+    // The bug this guards against: pre-fix `lyricsTitle` / `lyricsArtist`
+    // fell back to the shell title ("Today's Hits") whenever
+    // `appleMusicKitNowPlaying` was null, so the auto-fetch would
+    // search lyrics for the station name. Empty values short-circuit
+    // `useLyrics` instead.
+    const meta = resolveLyricsTrackMetadata(stationShellTrack, null);
+    expect(meta).toEqual({ title: "", artist: "", songId: "" });
+  });
+
+  test("returns empty strings for a playlist with no live MusicKit metadata yet", () => {
+    const meta = resolveLyricsTrackMetadata(playlistShellTrack, undefined);
+    expect(meta).toEqual({ title: "", artist: "", songId: "" });
+  });
+
+  test("trims whitespace-only live titles to empty (not station fallback)", () => {
+    const meta = resolveLyricsTrackMetadata(stationShellTrack, {
+      id: "1616228595",
+      title: "   ",
+      artist: "  ",
+    });
+    expect(meta.title).toBe("");
+    expect(meta.artist).toBe("");
+    expect(meta.title).not.toBe("Today's Hits");
+  });
+
+  test("returns the live song id even when the live title isn't trimmed yet", () => {
+    const meta = resolveLyricsTrackMetadata(stationShellTrack, {
+      id: "1616228595",
+      title: "Bohemian Rhapsody",
+    });
+    expect(meta.songId).toBe("am:1616228595");
+  });
+
+  test("returns empty for a null currentTrack", () => {
+    expect(resolveLyricsTrackMetadata(null, null)).toEqual({
+      title: "",
+      artist: "",
+      songId: "",
+    });
+  });
+});
+
+describe("resolveLyricsOverrideTargetId", () => {
+  test("returns the YouTube track id directly", () => {
+    expect(resolveLyricsOverrideTargetId(youtubeTrack, null)).toBe(
+      "dQw4w9WgXcQ"
+    );
+  });
+
+  test("returns the Apple Music library track id directly", () => {
+    expect(resolveLyricsOverrideTargetId(appleMusicLibraryTrack, null)).toBe(
+      "am:1616228595"
+    );
+  });
+
+  test("returns the live MusicKit song id for a station — NOT the station shell id", () => {
+    const id = resolveLyricsOverrideTargetId(stationShellTrack, {
+      id: "1616228595",
+      title: "Bohemian Rhapsody",
+    });
+    expect(id).toBe("am:1616228595");
+    expect(id).not.toBe("am:station:ra.todays-hits");
+  });
+
+  test("returns the live MusicKit song id for a playlist — NOT the playlist shell id", () => {
+    const id = resolveLyricsOverrideTargetId(playlistShellTrack, {
+      id: "1616228595",
+      title: "Bohemian Rhapsody",
+    });
+    expect(id).toBe("am:1616228595");
+    expect(id).not.toBe("am:playlist:pl.favorites-mix");
+  });
+
+  test("returns null when a station has no live MusicKit metadata yet (no shell fallback)", () => {
+    // The bug this guards against: pre-fix `setTrackLyricsSource` was
+    // called with the station shell id, so every song streamed
+    // through that station inherited the user's pick. Returning null
+    // makes the search-select handler no-op until MusicKit reports
+    // the actual song.
+    expect(resolveLyricsOverrideTargetId(stationShellTrack, null)).toBeNull();
+  });
+
+  test("returns null when a playlist has no live MusicKit metadata yet", () => {
+    expect(
+      resolveLyricsOverrideTargetId(playlistShellTrack, undefined)
+    ).toBeNull();
+  });
+
+  test("returns null for a null currentTrack", () => {
+    expect(resolveLyricsOverrideTargetId(null, null)).toBeNull();
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

When the iPod plays an Apple Music **station** or **playlist**, `currentTrack` is a *shell* whose `title` / `artist` describe the station or playlist itself ("Today's Hits" by "Apple Music"), **not** the song actually streaming through it.

Pre-fix, the lyrics auto-fetch and the manual lyrics search dialog both fell back to the shell's `title` / `artist` whenever MusicKit hadn't yet emitted live now-playing metadata, so:

- The auto-fetch could request lyrics for "Today's Hits" by "Apple Music" and return obviously wrong (or no) results.
- The lyrics search dialog opened with the station / playlist name pre-filled as the search query, plus the same wrong title / artist in its description and the song-id used for the search call.
- Picking a manual override saved it against the **station / playlist shell id**, so every song streamed through the same station / playlist would inherit that pick.

## Fix

- **`src/apps/ipod/utils/lyricsTrackMetadata.ts` (new)** — extract the title / artist / songId resolution into a pure helper (`resolveLyricsTrackMetadata`) and the override-target-id resolution into `resolveLyricsOverrideTargetId`. For Apple Music stations / playlists they read from `appleMusicKitNowPlaying` and **never** fall back to the shell's `title` / `artist` / `id`. Empty values short-circuit `useLyrics` (which already bails out on empty `songId`) so the auto-fetch never runs with the station / playlist name.
- **`src/apps/ipod/hooks/useIpodLogic.ts`** — switch `lyricsTitle` / `lyricsArtist` / `lyricsSongId` and the lyrics-search-select / -reset handlers to use the new helpers, and expose the resolved values for the dialog.
- **`src/apps/ipod/components/IpodAppComponent.tsx`** — wire `lyricsTitle` / `lyricsArtist` / `lyricsSongId` into `<LyricsSearchDialog />` so the manual search uses the live song's metadata (title in the description, artist in the placeholder, song-id in the API call, and a sane initial query) instead of the station / playlist name.
- **`tests/test-ipod-lyrics-track-metadata.test.ts` (new)** — 16 unit tests covering YouTube tracks, Apple Music library tracks, stations, and playlists, including the no-live-metadata-yet, whitespace-only-title, and null-currentTrack edge cases.

## Testing

- ✅ `bun test tests/test-ipod-lyrics-track-metadata.test.ts` — 16 / 16 pass.
- ✅ `bun test tests/test-ipod-apple-music.test.ts tests/test-ipod-track-order.test.ts` — 56 / 56 pass (no regressions in Apple Music slice / playback fan-out / track ordering).
- ✅ `bun run test:unit` — 215 / 215 pass.
- ✅ `bun run build` — TypeScript compiles cleanly.
- ✅ `bun run lint` — 0 errors (only pre-existing warnings unrelated to this change).

Manual GUI testing was skipped per the cloud agent's testing guidelines (UI verification of Apple Music station / playlist lyrics requires a live MusicKit session with credentials and an actual Apple Music subscription, which isn't reproducible from the cloud sandbox; the fix is fully covered by the new unit tests).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-92ae373b-3953-4701-a8c4-50830416e52c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-92ae373b-3953-4701-a8c4-50830416e52c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

