### PR TITLE
iPod modern Cover Flow: add status bar, white background, tighter title/artist spacing

### DIFF
--- a/src/apps/ipod/components/CoverFlow.tsx
+++ b/src/apps/ipod/components/CoverFlow.tsx
@@ -297,25 +297,21 @@ function CoverImage({
   // Cover size: larger for classic iPod; modern skin uses a tighter row.
   const coverSize =
     ipodMode && !compactIpodCarousel ? 65 : ipodMode ? 58 : 60; // cqmin units
-  // Side spacing. The transform formula `direction * (baseSpacing +
-  // absPos * positionSpacing)` collapses to `direction * absPos *
-  // positionSpacing` when `baseSpacing` is 0, which gives uniform
-  // center-to-center distance between every cover (center ↔ pos 1
-  // matches pos 1 ↔ pos 2 ↔ pos 3 …). Modern Cover Flow uses that
-  // uniform spread so the neighbouring covers don't cluster
-  // immediately past the center sleeve. 30 cqmin lands pos 1 just
-  // past the 29 cqmin half-width of the center sleeve so the center
-  // cover stays fully visible even though every adjacent pair shares
-  // the same step. Classic / karaoke keep their existing
-  // tucked-against-center offsets.
+  // Side spacing — tighter on modern nano-style Cover Flow (small viewport).
   const baseSpacing =
-    ipodMode && compactIpodCarousel ? 0 : ipodMode ? 26 : 16;
+    ipodMode && compactIpodCarousel ? 17 : ipodMode ? 26 : 16;
   const positionSpacing =
-    ipodMode && compactIpodCarousel ? 30 : ipodMode ? 18 : 11;
+    ipodMode && compactIpodCarousel ? 12 : ipodMode ? 18 : 11;
 
-  // Scale values: no scaling for iPod mode, subtle for karaoke
+  // Scale values: the modern compact carousel scales the neighbouring
+  // covers up so they sit clearly past the center sleeve's edge
+  // without having to push the offset out (which clustered them at
+  // the far side). Classic stays 1.0 (matches the iPod hardware look
+  // verbatim) and karaoke uses a subtle 0.9 falloff that pairs with
+  // its wider viewport.
   const centerScale = 1.0;
-  const sideScale = ipodMode ? 1.0 : 0.9;
+  const sideScale =
+    ipodMode && compactIpodCarousel ? 1.2 : ipodMode ? 1.0 : 0.9;
   
   const isCenter = position === 0;
 

--- a/src/apps/ipod/components/CoverFlow.tsx
+++ b/src/apps/ipod/components/CoverFlow.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useRef, useState, useCallback, useImperativeHandle, forwardRef, useMemo } from "react";
-import { createPortal } from "react-dom";
 import { motion, AnimatePresence, PanInfo, useMotionValue, animate } from "framer-motion";
 import {
   getYouTubeVideoId,
@@ -258,7 +257,6 @@ function CoverImage({
   selectedIndex,
   currentIndex,
   onPlayTrackInPlace,
-  tunables,
 }: {
   track: Track;
   position: number;
@@ -271,15 +269,6 @@ function CoverImage({
   selectedIndex: number;
   currentIndex: number;
   onPlayTrackInPlace?: (index: number) => void;
-  /** Optional override knobs. When provided, these win over the
-   *  defaults below — the modern Cover Flow uses this so the debug
-   *  slider panel can tweak the geometry live. */
-  tunables?: {
-    coverSize?: number;
-    baseSpacing?: number;
-    positionSpacing?: number;
-    sideScale?: number;
-  };
 }) {
   // Use track's cover. Apple Music supplies a fully resolved URL; YouTube
   // tracks fall back to a thumbnail derived from the video ID. Karaoke mode
@@ -307,26 +296,25 @@ function CoverImage({
 
   // Cover size: larger for classic iPod; modern skin uses a tighter row.
   const coverSize =
-    tunables?.coverSize ??
-    (ipodMode && !compactIpodCarousel ? 65 : ipodMode ? 58 : 60); // cqmin units
-  // Side spacing — tighter on modern nano-style Cover Flow (small viewport).
+    ipodMode && !compactIpodCarousel ? 65 : ipodMode ? 58 : 60; // cqmin units
+  // Side spacing — modern compact carousel uses slightly larger
+  // offsets (18 / 25) than classic so its 1.2x-scaled neighbouring
+  // covers don't collide with the center sleeve. Karaoke (non-iPod)
+  // stays tight because its wider viewport keeps everything in frame.
   const baseSpacing =
-    tunables?.baseSpacing ??
-    (ipodMode && compactIpodCarousel ? 17 : ipodMode ? 26 : 16);
+    ipodMode && compactIpodCarousel ? 18 : ipodMode ? 26 : 16;
   const positionSpacing =
-    tunables?.positionSpacing ??
-    (ipodMode && compactIpodCarousel ? 12 : ipodMode ? 18 : 11);
+    ipodMode && compactIpodCarousel ? 25 : ipodMode ? 18 : 11;
 
   // Scale values: the modern compact carousel scales the neighbouring
-  // covers up so they sit clearly past the center sleeve's edge
-  // without having to push the offset out (which clustered them at
-  // the far side). Classic stays 1.0 (matches the iPod hardware look
+  // covers up so they fill more of the horizontal space without
+  // having to push the offset out (which clustered them at the far
+  // side). Classic stays 1.0 (matches the iPod hardware look
   // verbatim) and karaoke uses a subtle 0.9 falloff that pairs with
   // its wider viewport.
   const centerScale = 1.0;
   const sideScale =
-    tunables?.sideScale ??
-    (ipodMode && compactIpodCarousel ? 1.2 : ipodMode ? 1.0 : 0.9);
+    ipodMode && compactIpodCarousel ? 1.2 : ipodMode ? 1.0 : 0.9;
   
   const isCenter = position === 0;
 
@@ -608,35 +596,6 @@ export const CoverFlow = forwardRef<CoverFlowRef, CoverFlowProps>(function Cover
   const uiVariant = useIpodStore((s) => s.uiVariant);
   const isModernIpodCoverFlow = ipodMode && uiVariant === "modern";
 
-  // ----------------- TEMPORARY DEBUG TUNER ------------------------
-  //
-  // Floating slider panel for tweaking the modern Cover Flow geometry
-  // live. The four knobs feed straight into `CoverImage` (via the
-  // `tunables` prop) so changes are reflected without a rebuild. Keep
-  // this scoped to the modern compact carousel — classic / karaoke
-  // keep their original hard-coded defaults.
-  //
-  // TODO(remove): delete this block + the tunables prop + the panel
-  // JSX once the final values are locked in. The defaults below are
-  // the production values; the panel just lets us iterate quickly.
-  const DEFAULT_TUNABLES = {
-    coverSize: 58,
-    baseSpacing: 17,
-    positionSpacing: 12,
-    sideScale: 1.2,
-  };
-  const [tunables, setTunables] = useState(DEFAULT_TUNABLES);
-  const [tunerPanelOpen, setTunerPanelOpen] = useState(true);
-  const updateTunable = useCallback(
-    (key: keyof typeof DEFAULT_TUNABLES, value: number) =>
-      setTunables((prev) => ({ ...prev, [key]: value })),
-    []
-  );
-  const copyTunables = useCallback(() => {
-    const text = `coverSize: ${tunables.coverSize}, baseSpacing: ${tunables.baseSpacing}, positionSpacing: ${tunables.positionSpacing}, sideScale: ${tunables.sideScale}`;
-    navigator.clipboard?.writeText(text).catch(() => {});
-  }, [tunables]);
-
   // Track swipe state
   const swipeStartX = useRef<number | null>(null);
   const lastMoveX = useRef<number | null>(null);
@@ -816,7 +775,6 @@ export const CoverFlow = forwardRef<CoverFlowRef, CoverFlowProps>(function Cover
   );
 
   return (
-    <>
     <AnimatePresence>
       {isVisible && (
         <motion.div
@@ -963,7 +921,6 @@ export const CoverFlow = forwardRef<CoverFlowRef, CoverFlowProps>(function Cover
                     selectedIndex={selectedIndex}
                     currentIndex={currentCoverIndex}
                     onPlayTrackInPlace={playItemInPlace}
-                    tunables={isModernIpodCoverFlow ? tunables : undefined}
                   />
                 ))}
               </AnimatePresence>
@@ -1102,82 +1059,5 @@ export const CoverFlow = forwardRef<CoverFlowRef, CoverFlowProps>(function Cover
         </motion.div>
       )}
     </AnimatePresence>
-    {/* TEMPORARY: debug slider panel for tweaking the modern Cover
-        Flow geometry. Rendered through a portal to document.body so
-        the iPod app's transformed parent doesn't capture the fixed
-        positioning. Remove this whole block + the `tunables` prop
-        once the final values are locked in. */}
-    {isVisible &&
-      isModernIpodCoverFlow &&
-      typeof document !== "undefined" &&
-      createPortal(
-        <div
-          className="fixed top-4 right-4 z-[9999] w-[260px] rounded-md bg-white/95 shadow-[0_8px_28px_rgba(0,0,0,0.25)] ring-1 ring-black/10 p-3 font-sans text-[12px] text-black backdrop-blur"
-          style={{ pointerEvents: "auto" }}
-        >
-          <div className="mb-2 flex items-center justify-between">
-            <div className="font-semibold">Cover Flow tuner</div>
-            <div className="flex items-center gap-1">
-              <button
-                type="button"
-                onClick={copyTunables}
-                className="rounded border border-black/15 bg-white px-1.5 py-0.5 text-[11px] hover:bg-black/5"
-                title="Copy current values"
-              >
-                Copy
-              </button>
-              <button
-                type="button"
-                onClick={() => setTunables(DEFAULT_TUNABLES)}
-                className="rounded border border-black/15 bg-white px-1.5 py-0.5 text-[11px] hover:bg-black/5"
-                title="Reset to defaults"
-              >
-                Reset
-              </button>
-              <button
-                type="button"
-                onClick={() => setTunerPanelOpen((v) => !v)}
-                className="rounded border border-black/15 bg-white px-1.5 py-0.5 text-[11px] hover:bg-black/5"
-                title="Toggle panel"
-              >
-                {tunerPanelOpen ? "–" : "+"}
-              </button>
-            </div>
-          </div>
-          {tunerPanelOpen && (
-            <div className="space-y-2">
-              {[
-                { key: "coverSize", label: "coverSize (cqmin)", min: 30, max: 90, step: 1 },
-                { key: "baseSpacing", label: "baseSpacing (cqmin)", min: 0, max: 50, step: 1 },
-                { key: "positionSpacing", label: "positionSpacing (cqmin)", min: 0, max: 40, step: 1 },
-                { key: "sideScale", label: "sideScale", min: 0.6, max: 1.6, step: 0.05 },
-              ].map((row) => {
-                const k = row.key as keyof typeof DEFAULT_TUNABLES;
-                return (
-                  <label key={row.key} className="block">
-                    <div className="mb-0.5 flex items-center justify-between text-[11px]">
-                      <span>{row.label}</span>
-                      <span className="tabular-nums">{tunables[k]}</span>
-                    </div>
-                    <input
-                      type="range"
-                      min={row.min}
-                      max={row.max}
-                      step={row.step}
-                      value={tunables[k]}
-                      onChange={(e) =>
-                        updateTunable(k, Number(e.target.value))
-                      }
-                      className="w-full"
-                    />
-                  </label>
-                );
-              })}
-            </div>
-          )}
-        </div>,
-        document.body
-      )}
-    </>
   );
 });

--- a/src/apps/ipod/components/CoverFlow.tsx
+++ b/src/apps/ipod/components/CoverFlow.tsx
@@ -973,16 +973,17 @@ export const CoverFlow = forwardRef<CoverFlowRef, CoverFlowProps>(function Cover
             )}
             
             {/* Track info — modern skin uses black title / gray artist
-                on the white surface, with `leading-[1.06]` + a -2px
-                pull on the artist line so the two labels read as a
-                tight pair (matches the iPod nano 6G/7G Cover Flow
-                reference photo). Classic / karaoke variants keep the
-                original light-on-black look. */}
+                on the white surface. `leading-[1.15]` + no extra
+                margin tightens the pair compared to the previous
+                `leading-tight` + `mt-[1px]` while still leaving a
+                small visible gap between descenders / ascenders.
+                Classic / karaoke variants keep the original
+                light-on-black look. */}
             <div
               className={cn(
                 "text-center min-w-0 flex-1",
                 isModernIpodCoverFlow
-                  ? "[&>*]:leading-[1.06]"
+                  ? "[&>*]:leading-[1.15]"
                   : "[&>*]:leading-tight",
               )}
             >
@@ -1003,7 +1004,7 @@ export const CoverFlow = forwardRef<CoverFlowRef, CoverFlowProps>(function Cover
                   className={cn(
                     "truncate",
                     isModernIpodCoverFlow &&
-                      "text-[10px] text-[rgb(99,101,103)] -mt-[2px] tracking-tight",
+                      "text-[10px] text-[rgb(99,101,103)] tracking-tight",
                     ipodMode &&
                       !isModernIpodCoverFlow &&
                       "text-white/60 text-[8px]",

--- a/src/apps/ipod/components/CoverFlow.tsx
+++ b/src/apps/ipod/components/CoverFlow.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState, useCallback, useImperativeHandle, forwardRef, useMemo } from "react";
+import { createPortal } from "react-dom";
 import { motion, AnimatePresence, PanInfo, useMotionValue, animate } from "framer-motion";
 import {
   getYouTubeVideoId,
@@ -257,6 +258,7 @@ function CoverImage({
   selectedIndex,
   currentIndex,
   onPlayTrackInPlace,
+  tunables,
 }: {
   track: Track;
   position: number;
@@ -269,6 +271,15 @@ function CoverImage({
   selectedIndex: number;
   currentIndex: number;
   onPlayTrackInPlace?: (index: number) => void;
+  /** Optional override knobs. When provided, these win over the
+   *  defaults below — the modern Cover Flow uses this so the debug
+   *  slider panel can tweak the geometry live. */
+  tunables?: {
+    coverSize?: number;
+    baseSpacing?: number;
+    positionSpacing?: number;
+    sideScale?: number;
+  };
 }) {
   // Use track's cover. Apple Music supplies a fully resolved URL; YouTube
   // tracks fall back to a thumbnail derived from the video ID. Karaoke mode
@@ -296,12 +307,15 @@ function CoverImage({
 
   // Cover size: larger for classic iPod; modern skin uses a tighter row.
   const coverSize =
-    ipodMode && !compactIpodCarousel ? 65 : ipodMode ? 58 : 60; // cqmin units
+    tunables?.coverSize ??
+    (ipodMode && !compactIpodCarousel ? 65 : ipodMode ? 58 : 60); // cqmin units
   // Side spacing — tighter on modern nano-style Cover Flow (small viewport).
   const baseSpacing =
-    ipodMode && compactIpodCarousel ? 17 : ipodMode ? 26 : 16;
+    tunables?.baseSpacing ??
+    (ipodMode && compactIpodCarousel ? 17 : ipodMode ? 26 : 16);
   const positionSpacing =
-    ipodMode && compactIpodCarousel ? 12 : ipodMode ? 18 : 11;
+    tunables?.positionSpacing ??
+    (ipodMode && compactIpodCarousel ? 12 : ipodMode ? 18 : 11);
 
   // Scale values: the modern compact carousel scales the neighbouring
   // covers up so they sit clearly past the center sleeve's edge
@@ -311,7 +325,8 @@ function CoverImage({
   // its wider viewport.
   const centerScale = 1.0;
   const sideScale =
-    ipodMode && compactIpodCarousel ? 1.2 : ipodMode ? 1.0 : 0.9;
+    tunables?.sideScale ??
+    (ipodMode && compactIpodCarousel ? 1.2 : ipodMode ? 1.0 : 0.9);
   
   const isCenter = position === 0;
 
@@ -592,7 +607,36 @@ export const CoverFlow = forwardRef<CoverFlowRef, CoverFlowProps>(function Cover
   const isMacTheme = currentTheme === "macosx";
   const uiVariant = useIpodStore((s) => s.uiVariant);
   const isModernIpodCoverFlow = ipodMode && uiVariant === "modern";
-  
+
+  // ----------------- TEMPORARY DEBUG TUNER ------------------------
+  //
+  // Floating slider panel for tweaking the modern Cover Flow geometry
+  // live. The four knobs feed straight into `CoverImage` (via the
+  // `tunables` prop) so changes are reflected without a rebuild. Keep
+  // this scoped to the modern compact carousel — classic / karaoke
+  // keep their original hard-coded defaults.
+  //
+  // TODO(remove): delete this block + the tunables prop + the panel
+  // JSX once the final values are locked in. The defaults below are
+  // the production values; the panel just lets us iterate quickly.
+  const DEFAULT_TUNABLES = {
+    coverSize: 58,
+    baseSpacing: 17,
+    positionSpacing: 12,
+    sideScale: 1.2,
+  };
+  const [tunables, setTunables] = useState(DEFAULT_TUNABLES);
+  const [tunerPanelOpen, setTunerPanelOpen] = useState(true);
+  const updateTunable = useCallback(
+    (key: keyof typeof DEFAULT_TUNABLES, value: number) =>
+      setTunables((prev) => ({ ...prev, [key]: value })),
+    []
+  );
+  const copyTunables = useCallback(() => {
+    const text = `coverSize: ${tunables.coverSize}, baseSpacing: ${tunables.baseSpacing}, positionSpacing: ${tunables.positionSpacing}, sideScale: ${tunables.sideScale}`;
+    navigator.clipboard?.writeText(text).catch(() => {});
+  }, [tunables]);
+
   // Track swipe state
   const swipeStartX = useRef<number | null>(null);
   const lastMoveX = useRef<number | null>(null);
@@ -772,6 +816,7 @@ export const CoverFlow = forwardRef<CoverFlowRef, CoverFlowProps>(function Cover
   );
 
   return (
+    <>
     <AnimatePresence>
       {isVisible && (
         <motion.div
@@ -918,6 +963,7 @@ export const CoverFlow = forwardRef<CoverFlowRef, CoverFlowProps>(function Cover
                     selectedIndex={selectedIndex}
                     currentIndex={currentCoverIndex}
                     onPlayTrackInPlace={playItemInPlace}
+                    tunables={isModernIpodCoverFlow ? tunables : undefined}
                   />
                 ))}
               </AnimatePresence>
@@ -1056,5 +1102,82 @@ export const CoverFlow = forwardRef<CoverFlowRef, CoverFlowProps>(function Cover
         </motion.div>
       )}
     </AnimatePresence>
+    {/* TEMPORARY: debug slider panel for tweaking the modern Cover
+        Flow geometry. Rendered through a portal to document.body so
+        the iPod app's transformed parent doesn't capture the fixed
+        positioning. Remove this whole block + the `tunables` prop
+        once the final values are locked in. */}
+    {isVisible &&
+      isModernIpodCoverFlow &&
+      typeof document !== "undefined" &&
+      createPortal(
+        <div
+          className="fixed top-4 right-4 z-[9999] w-[260px] rounded-md bg-white/95 shadow-[0_8px_28px_rgba(0,0,0,0.25)] ring-1 ring-black/10 p-3 font-sans text-[12px] text-black backdrop-blur"
+          style={{ pointerEvents: "auto" }}
+        >
+          <div className="mb-2 flex items-center justify-between">
+            <div className="font-semibold">Cover Flow tuner</div>
+            <div className="flex items-center gap-1">
+              <button
+                type="button"
+                onClick={copyTunables}
+                className="rounded border border-black/15 bg-white px-1.5 py-0.5 text-[11px] hover:bg-black/5"
+                title="Copy current values"
+              >
+                Copy
+              </button>
+              <button
+                type="button"
+                onClick={() => setTunables(DEFAULT_TUNABLES)}
+                className="rounded border border-black/15 bg-white px-1.5 py-0.5 text-[11px] hover:bg-black/5"
+                title="Reset to defaults"
+              >
+                Reset
+              </button>
+              <button
+                type="button"
+                onClick={() => setTunerPanelOpen((v) => !v)}
+                className="rounded border border-black/15 bg-white px-1.5 py-0.5 text-[11px] hover:bg-black/5"
+                title="Toggle panel"
+              >
+                {tunerPanelOpen ? "–" : "+"}
+              </button>
+            </div>
+          </div>
+          {tunerPanelOpen && (
+            <div className="space-y-2">
+              {[
+                { key: "coverSize", label: "coverSize (cqmin)", min: 30, max: 90, step: 1 },
+                { key: "baseSpacing", label: "baseSpacing (cqmin)", min: 0, max: 50, step: 1 },
+                { key: "positionSpacing", label: "positionSpacing (cqmin)", min: 0, max: 40, step: 1 },
+                { key: "sideScale", label: "sideScale", min: 0.6, max: 1.6, step: 0.05 },
+              ].map((row) => {
+                const k = row.key as keyof typeof DEFAULT_TUNABLES;
+                return (
+                  <label key={row.key} className="block">
+                    <div className="mb-0.5 flex items-center justify-between text-[11px]">
+                      <span>{row.label}</span>
+                      <span className="tabular-nums">{tunables[k]}</span>
+                    </div>
+                    <input
+                      type="range"
+                      min={row.min}
+                      max={row.max}
+                      step={row.step}
+                      value={tunables[k]}
+                      onChange={(e) =>
+                        updateTunable(k, Number(e.target.value))
+                      }
+                      className="w-full"
+                    />
+                  </label>
+                );
+              })}
+            </div>
+          )}
+        </div>,
+        document.body
+      )}
+    </>
   );
 });

--- a/src/apps/ipod/components/CoverFlow.tsx
+++ b/src/apps/ipod/components/CoverFlow.tsx
@@ -297,15 +297,21 @@ function CoverImage({
   // Cover size: larger for classic iPod; modern skin uses a tighter row.
   const coverSize =
     ipodMode && !compactIpodCarousel ? 65 : ipodMode ? 58 : 60; // cqmin units
-  // Side spacing — modern Cover Flow spreads its row out closer to the
-  // iPod classic 6G/7G look so the neighbouring covers are clearly
-  // visible past the edge of the center sleeve, matching the reference
-  // photo. Karaoke (non-iPod) stays tight because its full-screen
-  // viewport keeps everything comfortably in frame.
+  // Side spacing. The transform formula `direction * (baseSpacing +
+  // absPos * positionSpacing)` collapses to `direction * absPos *
+  // positionSpacing` when `baseSpacing` is 0, which gives uniform
+  // center-to-center distance between every cover (center ↔ pos 1
+  // matches pos 1 ↔ pos 2 ↔ pos 3 …). Modern Cover Flow uses that
+  // uniform spread so the neighbouring covers don't cluster
+  // immediately past the center sleeve. 30 cqmin lands pos 1 just
+  // past the 29 cqmin half-width of the center sleeve so the center
+  // cover stays fully visible even though every adjacent pair shares
+  // the same step. Classic / karaoke keep their existing
+  // tucked-against-center offsets.
   const baseSpacing =
-    ipodMode && compactIpodCarousel ? 23 : ipodMode ? 26 : 16;
+    ipodMode && compactIpodCarousel ? 0 : ipodMode ? 26 : 16;
   const positionSpacing =
-    ipodMode && compactIpodCarousel ? 15 : ipodMode ? 18 : 11;
+    ipodMode && compactIpodCarousel ? 30 : ipodMode ? 18 : 11;
 
   // Scale values: no scaling for iPod mode, subtle for karaoke
   const centerScale = 1.0;

--- a/src/apps/ipod/components/CoverFlow.tsx
+++ b/src/apps/ipod/components/CoverFlow.tsx
@@ -297,11 +297,15 @@ function CoverImage({
   // Cover size: larger for classic iPod; modern skin uses a tighter row.
   const coverSize =
     ipodMode && !compactIpodCarousel ? 65 : ipodMode ? 58 : 60; // cqmin units
-  // Side spacing — tighter on modern nano-style Cover Flow (small viewport).
+  // Side spacing — modern Cover Flow spreads its row out closer to the
+  // iPod classic 6G/7G look so the neighbouring covers are clearly
+  // visible past the edge of the center sleeve, matching the reference
+  // photo. Karaoke (non-iPod) stays tight because its full-screen
+  // viewport keeps everything comfortably in frame.
   const baseSpacing =
-    ipodMode && compactIpodCarousel ? 17 : ipodMode ? 26 : 16;
+    ipodMode && compactIpodCarousel ? 23 : ipodMode ? 26 : 16;
   const positionSpacing =
-    ipodMode && compactIpodCarousel ? 12 : ipodMode ? 18 : 11;
+    ipodMode && compactIpodCarousel ? 15 : ipodMode ? 18 : 11;
 
   // Scale values: no scaling for iPod mode, subtle for karaoke
   const centerScale = 1.0;

--- a/src/apps/ipod/components/CoverFlow.tsx
+++ b/src/apps/ipod/components/CoverFlow.tsx
@@ -12,6 +12,16 @@ import { useThemeStore } from "@/stores/useThemeStore";
 import { useEventListener } from "@/hooks/useEventListener";
 import { useTranslation } from "react-i18next";
 import { cn } from "@/lib/utils";
+import {
+  BatteryIndicator,
+  IpodModernPlayPauseIcon,
+  ScrollingText,
+} from "./screen";
+
+// Modern-UI titlebar height. Matches `MODERN_TITLEBAR_HEIGHT` in
+// IpodScreen.tsx so the Cover Flow status bar lines up exactly with the
+// main menu's silver header strip when toggling between the two.
+const MODERN_TITLEBAR_HEIGHT = 17;
 
 // Long press delay in milliseconds
 const LONG_PRESS_DELAY = 500;
@@ -759,21 +769,76 @@ export const CoverFlow = forwardRef<CoverFlowRef, CoverFlowProps>(function Cover
     <AnimatePresence>
       {isVisible && (
         <motion.div
-          className={`absolute inset-0 z-50 bg-black overflow-hidden ${ipodMode ? "ipod-force-font" : "karaoke-force-font"}`}
+          className={cn(
+            "absolute inset-0 z-50 overflow-hidden",
+            // Modern UI: white surface to match the rest of the modern
+            // skin (Music + Now Playing, settings menus). Classic /
+            // karaoke variants keep the original deep-black backdrop.
+            isModernIpodCoverFlow ? "bg-white" : "bg-black",
+            ipodMode ? "ipod-force-font" : "karaoke-force-font",
+          )}
           style={{ containerType: "size" }}
           initial={{ opacity: 0, scale: ipodMode ? 1 : 1.05 }}
           animate={{ opacity: 1, scale: 1 }}
           exit={{ opacity: 0, scale: ipodMode ? 1 : 1.05 }}
           transition={{ duration: ipodMode ? 0.2 : 0.35, ease: "easeOut" }}
         >
-          {/* Reflective floor gradient - bottom only */}
-          <div 
+          {/* Reflective floor gradient — softer on the white modern skin so
+              it reads as a faint stage shadow under the album row instead
+              of a heavy vignette. Classic / karaoke still get the original
+              deep gradient that sells the reflective floor against black. */}
+          <div
             className="absolute inset-0"
             style={{
-              background: "linear-gradient(to bottom, transparent 40%, rgba(38,38,38,0.5) 70%, rgba(64,64,64,0.3) 100%)",
+              background: isModernIpodCoverFlow
+                ? "linear-gradient(to bottom, transparent 55%, rgba(0,0,0,0.06) 78%, rgba(0,0,0,0.12) 100%)"
+                : "linear-gradient(to bottom, transparent 40%, rgba(38,38,38,0.5) 70%, rgba(64,64,64,0.3) 100%)",
               pointerEvents: "none",
             }}
           />
+
+          {/* Modern UI status bar — same silver gradient + 12px MyriadPro
+              header used by the main menu titlebar so Cover Flow reads as
+              another screen of the same UI rather than an overlay. Shows
+              the "Cover Flow" label on the left, play/pause status icon
+              and battery on the right. Classic / karaoke variants keep
+              their full-bleed black backdrop with no status bar. */}
+          {isModernIpodCoverFlow && (
+            <div
+              className={cn(
+                "absolute top-0 left-0 right-0 z-20",
+                "ipod-modern-titlebar font-ipod-modern-ui font-semibold text-black",
+                "flex items-center pl-1.5 pr-1.5 gap-1.5",
+              )}
+              style={{
+                height: MODERN_TITLEBAR_HEIGHT,
+                minHeight: MODERN_TITLEBAR_HEIGHT,
+              }}
+            >
+              <ScrollingText
+                text={t("apps.ipod.menu.coverFlow")}
+                isPlaying
+                scrollStartDelaySec={1}
+                fadeEdges
+                align="left"
+                className={cn(
+                  "flex-1 min-w-0 leading-none text-[12px] font-semibold",
+                  "[text-shadow:0_1px_0_rgba(255,255,255,0.9)]",
+                )}
+              />
+              <div className="flex shrink-0 items-center gap-1">
+                <div
+                  className={cn(
+                    "flex items-center justify-center w-[14px] h-[14px]",
+                    "[filter:drop-shadow(0_1px_0_rgba(255,255,255,0.9))]",
+                  )}
+                >
+                  <IpodModernPlayPauseIcon playing={isPlaying} size={14} />
+                </div>
+                <BatteryIndicator backlightOn variant="modern" />
+              </div>
+            </div>
+          )}
           
           {/* Cover Flow container */}
           <motion.div
@@ -804,14 +869,20 @@ export const CoverFlow = forwardRef<CoverFlowRef, CoverFlowProps>(function Cover
             onTouchCancel={showCD ? undefined : () => endLongPress()}
             style={{ touchAction: showCD ? "auto" : "none", overflow: "visible" }}
           >
-            {/* Covers - centered with slight upward offset for track info space */}
+            {/* Covers - centered with a slight vertical offset so the
+                title/artist row at the bottom always has clearance. The
+                modern skin also reserves room at the top for the 17px
+                status bar, so we shift the carousel down by half the
+                status bar height (vs. classic which has no titlebar in
+                Cover Flow) to keep it visually centered between the
+                two pieces of chrome. */}
             <div 
               className="relative flex items-center justify-center w-full"
               style={{ 
-                height: ipodMode && isModernIpodCoverFlow ? "78%" : "75%",
+                height: ipodMode && isModernIpodCoverFlow ? "76%" : "75%",
                 marginTop:
                   ipodMode && isModernIpodCoverFlow
-                    ? "-6%"
+                    ? "0%"
                     : ipodMode
                       ? "-8%"
                       : "-2%",
@@ -893,12 +964,26 @@ export const CoverFlow = forwardRef<CoverFlowRef, CoverFlowProps>(function Cover
               </button>
             )}
             
-            {/* Track info */}
-            <div className="text-center min-w-0 flex-1 [&>*]:leading-tight">
+            {/* Track info — modern skin uses black title / gray artist
+                on the white surface, with `leading-[1.06]` + a -2px
+                pull on the artist line so the two labels read as a
+                tight pair (matches the iPod nano 6G/7G Cover Flow
+                reference photo). Classic / karaoke variants keep the
+                original light-on-black look. */}
+            <div
+              className={cn(
+                "text-center min-w-0 flex-1",
+                isModernIpodCoverFlow
+                  ? "[&>*]:leading-[1.06]"
+                  : "[&>*]:leading-tight",
+              )}
+            >
               <div
                 className={cn(
-                  "text-white truncate",
-                  isModernIpodCoverFlow && "text-[12px] font-semibold tracking-tight",
+                  "truncate",
+                  isModernIpodCoverFlow
+                    ? "text-black text-[12px] font-semibold tracking-tight"
+                    : "text-white",
                   ipodMode && !isModernIpodCoverFlow && "text-[10px]",
                 )}
                 style={ipodMode ? undefined : { fontSize: "clamp(14px, 5cqmin, 24px)" }}
@@ -910,7 +995,7 @@ export const CoverFlow = forwardRef<CoverFlowRef, CoverFlowProps>(function Cover
                   className={cn(
                     "truncate",
                     isModernIpodCoverFlow &&
-                      "text-[10px] text-white/58 mt-[1px] tracking-tight",
+                      "text-[10px] text-[rgb(99,101,103)] -mt-[2px] tracking-tight",
                     ipodMode &&
                       !isModernIpodCoverFlow &&
                       "text-white/60 text-[8px]",

--- a/src/apps/ipod/components/CoverFlow.tsx
+++ b/src/apps/ipod/components/CoverFlow.tsx
@@ -775,6 +775,14 @@ export const CoverFlow = forwardRef<CoverFlowRef, CoverFlowProps>(function Cover
             // skin (Music + Now Playing, settings menus). Classic /
             // karaoke variants keep the original deep-black backdrop.
             isModernIpodCoverFlow ? "bg-white" : "bg-black",
+            // Retain the iPod screen's black bezel + rounded corners
+            // when Cover Flow is open. The overlay is rendered as a
+            // sibling of `IpodScreen` (not a child), so without its
+            // own border it would obscure the bezel and the carousel
+            // would read as a different frame than every other view.
+            // Karaoke Cover Flow opens full-bleed inside its own
+            // window chrome and skips the bezel.
+            ipodMode && "border border-black border-2 rounded-[2px]",
             ipodMode ? "ipod-force-font" : "karaoke-force-font",
           )}
           style={{ containerType: "size" }}

--- a/src/apps/ipod/components/IpodScreen.tsx
+++ b/src/apps/ipod/components/IpodScreen.tsx
@@ -24,6 +24,7 @@ import {
   MenuListItem,
   ScrollingText,
   StatusDisplay,
+  IpodModernPlayPauseIcon,
 } from "./screen";
 import {
   PLAYER_PROGRESS_INTERVAL_MS,
@@ -86,58 +87,6 @@ function formatPlaybackTime(totalSeconds: number): string {
     "0"
   )}`;
 }
-
-/**
- * Inline SVG play/pause indicator for the modern iPod titlebar.
- *
- * Uses an embedded `<linearGradient>` so the glyph can be filled with
- * the same vertical blue gradient as the row-selection highlight
- * (`linear-gradient(180deg, rgb(60, 184, 255) 0%, rgb(52, 122, 181) 100%)`).
- * Phosphor icons render with `currentColor` and don't expose a way to
- * paint a gradient, so this small custom SVG is the cleanest way to
- * land that look without adding a new icon dep.
- *
- * Each instance gets a unique gradient ID — multiple icons may render
- * in the same DOM (e.g. mini-player + screen titlebar) and SVG defs
- * are document-scoped.
- */
-function IpodModernPlayPauseIcon({
-  playing,
-  size = 10,
-}: {
-  playing: boolean;
-  size?: number;
-}) {
-  const gradientId = useMemo(
-    () => `ipod-modern-titlebar-grad-${Math.random().toString(36).slice(2)}`,
-    []
-  );
-  return (
-    <svg
-      width={size}
-      height={size}
-      viewBox="0 0 24 24"
-      aria-label={playing ? "playing" : "paused"}
-      role="img"
-    >
-      <defs>
-        <linearGradient id={gradientId} x1="0" y1="0" x2="0" y2="1">
-          <stop offset="0%" stopColor="rgb(60, 184, 255)" />
-          <stop offset="100%" stopColor="rgb(52, 122, 181)" />
-        </linearGradient>
-      </defs>
-      {playing ? (
-        <path d="M8 5v14l11-7z" fill={`url(#${gradientId})`} />
-      ) : (
-        <g fill={`url(#${gradientId})`}>
-          <rect x="6" y="5" width="4" height="14" rx="0.5" />
-          <rect x="14" y="5" width="4" height="14" rx="0.5" />
-        </g>
-      )}
-    </svg>
-  );
-}
-
 
 /** `rotateY` + perspective for left↔right foreshortening; Karaoke-style reflection stacking.
  *

--- a/src/apps/ipod/components/screen/IpodModernPlayPauseIcon.tsx
+++ b/src/apps/ipod/components/screen/IpodModernPlayPauseIcon.tsx
@@ -1,0 +1,52 @@
+import { useMemo } from "react";
+
+/**
+ * Inline SVG play/pause indicator for the modern iPod titlebar.
+ *
+ * Uses an embedded `<linearGradient>` so the glyph can be filled with
+ * the same vertical blue gradient as the row-selection highlight
+ * (`linear-gradient(180deg, rgb(60, 184, 255) 0%, rgb(52, 122, 181) 100%)`).
+ * Phosphor icons render with `currentColor` and don't expose a way to
+ * paint a gradient, so this small custom SVG is the cleanest way to
+ * land that look without adding a new icon dep.
+ *
+ * Each instance gets a unique gradient ID — multiple icons may render
+ * in the same DOM (e.g. mini-player + screen titlebar + Cover Flow
+ * status bar) and SVG defs are document-scoped.
+ */
+export function IpodModernPlayPauseIcon({
+  playing,
+  size = 10,
+}: {
+  playing: boolean;
+  size?: number;
+}) {
+  const gradientId = useMemo(
+    () => `ipod-modern-titlebar-grad-${Math.random().toString(36).slice(2)}`,
+    []
+  );
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      aria-label={playing ? "playing" : "paused"}
+      role="img"
+    >
+      <defs>
+        <linearGradient id={gradientId} x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0%" stopColor="rgb(60, 184, 255)" />
+          <stop offset="100%" stopColor="rgb(52, 122, 181)" />
+        </linearGradient>
+      </defs>
+      {playing ? (
+        <path d="M8 5v14l11-7z" fill={`url(#${gradientId})`} />
+      ) : (
+        <g fill={`url(#${gradientId})`}>
+          <rect x="6" y="5" width="4" height="14" rx="0.5" />
+          <rect x="14" y="5" width="4" height="14" rx="0.5" />
+        </g>
+      )}
+    </svg>
+  );
+}

--- a/src/apps/ipod/components/screen/index.ts
+++ b/src/apps/ipod/components/screen/index.ts
@@ -4,3 +4,4 @@ export { Scrollbar } from "./Scrollbar";
 export { MenuListItem } from "./MenuListItem";
 export { ScrollingText } from "./ScrollingText";
 export { StatusDisplay } from "./StatusDisplay";
+export { IpodModernPlayPauseIcon } from "./IpodModernPlayPauseIcon";


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Matches the iPod nano 6G/7G Cover Flow reference photo: a silver status bar above a white surface, neighbouring covers spread wider and scaled up so they fill more of the horizontal space, and a tightly stacked title/artist row under the carousel. The black screen bezel is preserved while the overlay is open so the carousel reads as the same frame as the menu / Now Playing views.

![iPod Cover Flow modern UI with status bar, white background, spread + scaled side covers, tight title/artist row, and black screen bezel](https://cursor.com/artifacts/c/art-2529d8c5-aeb8-4353-9de5-853c7e737d15)

### Changes
- Render the same silver titlebar (Cover Flow label, play/pause status icon, modern battery indicator) at the top of the carousel when the iPod is in the modern skin — matches `MODERN_TITLEBAR_HEIGHT` (17px) and `.ipod-modern-titlebar` used by the menu / Now Playing chrome.
- Switch the modern Cover Flow surface from full-bleed black to white so it reads as part of the same modern screen as the menu and Now Playing views. Classic / karaoke variants keep their black backdrop.
- Soften the reflective floor gradient on the white surface so the album shadow remains visible without overwhelming the page.
- Tune the modern compact carousel: `coverSize: 58` (unchanged), `baseSpacing: 18`, `positionSpacing: 25`, `sideScale: 1.2`. The bigger `positionSpacing` keeps adjacent neighbours from clustering against the center sleeve and the `1.2` side scale gives them visual presence without colliding with the center cover.
- Use black title text + gray artist subtitle with `leading-[1.15]` and no extra margin so the labels read as a tight pair without descenders touching the ascenders below.
- Push the carousel down slightly to make room for the new status bar.
- Retain the black screen bezel while Cover Flow is open. `CoverFlow` renders as a sibling of `IpodScreen`, so its `absolute inset-0 z-50` overlay was hiding the screen's `border border-black border-2 rounded-[2px]`. Apply the same border + radius to the Cover Flow root in iPod mode so the bezel stays visible. Karaoke Cover Flow opens full-bleed inside its own window chrome and skips the bezel.
- Extract `IpodModernPlayPauseIcon` to `components/screen/` so both `IpodScreen` and `CoverFlow` share a single implementation.

### Files
- `src/apps/ipod/components/CoverFlow.tsx`
- `src/apps/ipod/components/IpodScreen.tsx`
- `src/apps/ipod/components/screen/IpodModernPlayPauseIcon.tsx` (new)
- `src/apps/ipod/components/screen/index.ts`

### Testing
- `bun run build` — clean
- `bun run lint` — 0 errors, only pre-existing warnings unrelated to this change
- `bun run test:unit` — 215/215 passing
- Manual: scripted Playwright capture against the dev server with five seeded albums confirmed the new status bar, white background, wider-spread and scaled-up side covers, tightened title/artist row, and now-restored black screen bezel render as expected (see screenshot above). The temporary debug slider panel used to dial in `baseSpacing=18, positionSpacing=25, sideScale=1.2` has been removed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-920229ce-b2db-401d-8908-63034669e477"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-920229ce-b2db-401d-8908-63034669e477"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

