### PR TITLE
ipod(modern): menu→Cover Flow uses width transition like menu→now-playing

### DIFF
--- a/src/apps/ipod/components/CoverFlow.tsx
+++ b/src/apps/ipod/components/CoverFlow.tsx
@@ -779,7 +779,23 @@ export const CoverFlow = forwardRef<CoverFlowRef, CoverFlowProps>(function Cover
       {isVisible && (
         <motion.div
           className={cn(
-            "absolute inset-0 z-50 overflow-hidden",
+            "absolute z-50 overflow-hidden",
+            // Modern UI uses a width-based slide-in pulled from the
+            // RIGHT edge (anchored top/right/bottom; left is free so
+            // the inline `width` controls how far the panel extends
+            // leftward). This mirrors the menu ↔ now-playing chrome
+            // width animation in IpodScreen (`transition-[width]
+            // duration-300 ease-in-out`) — the now-playing panel
+            // grows from 50% to 100% as the split-art column
+            // collapses; Cover Flow likewise grows from 0% to 100%
+            // anchored at the right edge so it reads as "the same
+            // chrome animation, one screen further". Classic /
+            // karaoke variants keep the full-bleed opacity/scale
+            // overlay because they have no equivalent width
+            // transition to match.
+            isModernIpodCoverFlow
+              ? "top-0 right-0 bottom-0"
+              : "inset-0",
             // Modern UI: white surface to match the rest of the modern
             // skin (Music + Now Playing, settings menus). Classic /
             // karaoke variants keep the original deep-black backdrop.
@@ -791,14 +807,43 @@ export const CoverFlow = forwardRef<CoverFlowRef, CoverFlowProps>(function Cover
             // would read as a different frame than every other view.
             // Karaoke Cover Flow opens full-bleed inside its own
             // window chrome and skips the bezel.
-            ipodMode && "border border-black border-2 rounded-[2px]",
+            //
+            // Modern UI variant drops the LEFT border + left rounded
+            // corners during the width slide so we don't draw a stray
+            // 2px black vertical line down the middle of the iPod
+            // screen mid-animation (the underlying IpodScreen still
+            // owns the full bezel; CoverFlow's right/top/bottom edges
+            // sit flush on top of it, and the missing left edge stays
+            // hidden because right edge stays anchored at right:0).
+            ipodMode && !isModernIpodCoverFlow &&
+              "border border-black border-2 rounded-[2px]",
+            ipodMode && isModernIpodCoverFlow &&
+              "border-y-2 border-r-2 border-black rounded-tr-[2px] rounded-br-[2px]",
             ipodMode ? "ipod-force-font" : "karaoke-force-font",
           )}
           style={{ containerType: "size" }}
-          initial={{ opacity: 0, scale: ipodMode ? 1 : 1.05 }}
-          animate={{ opacity: 1, scale: 1 }}
-          exit={{ opacity: 0, scale: ipodMode ? 1 : 1.05 }}
-          transition={{ duration: ipodMode ? 0.2 : 0.35, ease: "easeOut" }}
+          initial={
+            isModernIpodCoverFlow
+              ? { width: "0%" }
+              : { opacity: 0, scale: ipodMode ? 1 : 1.05 }
+          }
+          animate={
+            isModernIpodCoverFlow
+              ? { width: "100%" }
+              : { opacity: 1, scale: 1 }
+          }
+          exit={
+            isModernIpodCoverFlow
+              ? { width: "0%" }
+              : { opacity: 0, scale: ipodMode ? 1 : 1.05 }
+          }
+          transition={
+            isModernIpodCoverFlow
+              ? // Mirror the IpodScreen menu↔now-playing chrome:
+                // `transition-[width] duration-300 ease-in-out`.
+                { duration: 0.3, ease: "easeInOut" }
+              : { duration: ipodMode ? 0.2 : 0.35, ease: "easeOut" }
+          }
         >
           {/* Reflective floor gradient — softer on the white modern skin so
               it reads as a faint stage shadow under the album row instead

--- a/src/apps/ipod/components/CoverFlow.tsx
+++ b/src/apps/ipod/components/CoverFlow.tsx
@@ -228,6 +228,14 @@ interface CoverFlowProps {
   onPlayTrackInPlace?: (index: number) => void;
   /** Group Apple Music tracks into album covers instead of per-song covers. */
   groupAppleMusicAlbums?: boolean;
+  /**
+   * Render inline inside a host panel (e.g. the modern iPod menu
+   * panel) instead of a full-screen `AnimatePresence` overlay. In
+   * this mode CoverFlow drops its own bezel / status bar / fade
+   * animation so the host's chrome can run the menu↔nowplaying width
+   * transition without us drawing a competing border or background.
+   */
+  inline?: boolean;
 }
 
 interface CoverFlowItem {
@@ -529,6 +537,7 @@ export const CoverFlow = forwardRef<CoverFlowRef, CoverFlowProps>(function Cover
   onTogglePlay,
   onPlayTrackInPlace,
   groupAppleMusicAlbums = false,
+  inline = false,
 }, ref) {
   const { t } = useTranslation();
   const unknownArtistLabel = t("apps.ipod.menu.unknownArtist");
@@ -774,28 +783,157 @@ export const CoverFlow = forwardRef<CoverFlowRef, CoverFlowProps>(function Cover
     [coverItems, onPlayTrackInPlace]
   );
 
+  // When `inline` is set, this CoverFlow renders inside another
+  // animated container (the modern iPod menu panel that owns the
+  // width transition). In that mode we skip our own border / bezel /
+  // background / status bar and rely on the host panel's chrome.
+  if (inline) {
+    return (
+      <div
+        className={cn(
+          "relative w-full h-full overflow-hidden",
+          isModernIpodCoverFlow ? "bg-white" : "bg-black",
+          ipodMode ? "ipod-force-font" : "karaoke-force-font",
+        )}
+        style={{ containerType: "size" }}
+      >
+        {/* Reflective floor — same softer modern-skin gradient. */}
+        <div
+          className="absolute inset-0"
+          style={{
+            background: isModernIpodCoverFlow
+              ? "linear-gradient(to bottom, transparent 55%, rgba(0,0,0,0.06) 78%, rgba(0,0,0,0.12) 100%)"
+              : "linear-gradient(to bottom, transparent 40%, rgba(38,38,38,0.5) 70%, rgba(64,64,64,0.3) 100%)",
+            pointerEvents: "none",
+          }}
+        />
+
+        {/* Gesture-capturing carousel stage (motion.div for framer
+            pan/wheel handlers). */}
+        <motion.div
+          ref={containerRef}
+          className={cn(
+            "absolute inset-0 flex items-center justify-center",
+            showCD ? "cursor-default" : "cursor-grab active:cursor-grabbing",
+          )}
+          onPanStart={showCD ? undefined : handlePanStart}
+          onPan={showCD ? undefined : handlePan}
+          onPanEnd={showCD ? undefined : handlePanEnd}
+          onWheel={showCD ? undefined : handleWheel}
+          onClick={() => {
+            if (isPanningRef.current || longPressFiredRef.current) {
+              longPressFiredRef.current = false;
+              return;
+            }
+            if (showCD) {
+              setShowCD(false);
+              return;
+            }
+            selectCurrent();
+          }}
+          onMouseDown={showCD ? undefined : () => startLongPress()}
+          onMouseUp={showCD ? undefined : () => endLongPress()}
+          onMouseLeave={showCD ? undefined : () => endLongPress()}
+          onTouchStart={showCD ? undefined : () => startLongPress()}
+          onTouchEnd={showCD ? undefined : () => endLongPress()}
+          onTouchCancel={showCD ? undefined : () => endLongPress()}
+          style={{ touchAction: showCD ? "auto" : "none", overflow: "visible" }}
+        >
+          <div
+            className="relative flex items-center justify-center w-full"
+            style={{
+              height: ipodMode && isModernIpodCoverFlow ? "76%" : "75%",
+              marginTop:
+                ipodMode && isModernIpodCoverFlow
+                  ? "0%"
+                  : ipodMode
+                    ? "-8%"
+                    : "-2%",
+              perspective: `${(ipodMode ? 65 : 60) * 1.5}cqmin`,
+              transformStyle: "preserve-3d",
+            }}
+          >
+            <AnimatePresence mode="popLayout">
+              {visibleCovers.map(({ item, position }) => (
+                <CoverImage
+                  key={item.key}
+                  track={item.track}
+                  position={position}
+                  ipodMode={ipodMode}
+                  compactIpodCarousel={isModernIpodCoverFlow}
+                  showCD={showCD}
+                  isPlaying={isPlaying && selectedIndex === currentCoverIndex}
+                  onTogglePlay={onTogglePlay}
+                  selectedIndex={selectedIndex}
+                  currentIndex={currentCoverIndex}
+                  onPlayTrackInPlace={playItemInPlace}
+                />
+              ))}
+            </AnimatePresence>
+          </div>
+        </motion.div>
+
+        {/* Track info — bottom row */}
+        <div
+          className={cn(
+            "absolute left-0 right-0 flex items-center justify-center gap-2 pointer-events-none",
+            isModernIpodCoverFlow ? "font-ipod-modern-ui" : "font-geneva-12",
+            ipodMode ? "px-2" : "px-6",
+          )}
+          style={{
+            bottom:
+              ipodMode && isModernIpodCoverFlow
+                ? "3px"
+                : ipodMode
+                  ? "6px"
+                  : "5cqmin",
+          }}
+        >
+          <div
+            className={cn(
+              "text-center min-w-0 flex-1",
+              isModernIpodCoverFlow
+                ? "[&>*]:leading-[1.15]"
+                : "[&>*]:leading-tight",
+            )}
+          >
+            <div
+              className={cn(
+                "truncate",
+                isModernIpodCoverFlow
+                  ? "text-black text-[12px] font-semibold tracking-tight"
+                  : "text-white",
+                ipodMode && !isModernIpodCoverFlow && "text-[10px]",
+              )}
+            >
+              {currentItem?.title || t("apps.ipod.coverFlow.noTrack")}
+            </div>
+            {currentItem?.artist && (
+              <div
+                className={cn(
+                  "truncate",
+                  isModernIpodCoverFlow &&
+                    "text-[10px] text-[rgb(99,101,103)] tracking-tight",
+                  ipodMode &&
+                    !isModernIpodCoverFlow &&
+                    "text-white/60 text-[8px]",
+                )}
+              >
+                {currentItem.artist}
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <AnimatePresence>
       {isVisible && (
         <motion.div
           className={cn(
-            "absolute z-50 overflow-hidden",
-            // Modern UI uses a width-based slide-in pulled from the
-            // RIGHT edge (anchored top/right/bottom; left is free so
-            // the inline `width` controls how far the panel extends
-            // leftward). This mirrors the menu ↔ now-playing chrome
-            // width animation in IpodScreen (`transition-[width]
-            // duration-300 ease-in-out`) — the now-playing panel
-            // grows from 50% to 100% as the split-art column
-            // collapses; Cover Flow likewise grows from 0% to 100%
-            // anchored at the right edge so it reads as "the same
-            // chrome animation, one screen further". Classic /
-            // karaoke variants keep the full-bleed opacity/scale
-            // overlay because they have no equivalent width
-            // transition to match.
-            isModernIpodCoverFlow
-              ? "top-0 right-0 bottom-0"
-              : "inset-0",
+            "absolute inset-0 z-50 overflow-hidden",
             // Modern UI: white surface to match the rest of the modern
             // skin (Music + Now Playing, settings menus). Classic /
             // karaoke variants keep the original deep-black backdrop.
@@ -807,43 +945,14 @@ export const CoverFlow = forwardRef<CoverFlowRef, CoverFlowProps>(function Cover
             // would read as a different frame than every other view.
             // Karaoke Cover Flow opens full-bleed inside its own
             // window chrome and skips the bezel.
-            //
-            // Modern UI variant drops the LEFT border + left rounded
-            // corners during the width slide so we don't draw a stray
-            // 2px black vertical line down the middle of the iPod
-            // screen mid-animation (the underlying IpodScreen still
-            // owns the full bezel; CoverFlow's right/top/bottom edges
-            // sit flush on top of it, and the missing left edge stays
-            // hidden because right edge stays anchored at right:0).
-            ipodMode && !isModernIpodCoverFlow &&
-              "border border-black border-2 rounded-[2px]",
-            ipodMode && isModernIpodCoverFlow &&
-              "border-y-2 border-r-2 border-black rounded-tr-[2px] rounded-br-[2px]",
+            ipodMode && "border border-black border-2 rounded-[2px]",
             ipodMode ? "ipod-force-font" : "karaoke-force-font",
           )}
           style={{ containerType: "size" }}
-          initial={
-            isModernIpodCoverFlow
-              ? { width: "0%" }
-              : { opacity: 0, scale: ipodMode ? 1 : 1.05 }
-          }
-          animate={
-            isModernIpodCoverFlow
-              ? { width: "100%" }
-              : { opacity: 1, scale: 1 }
-          }
-          exit={
-            isModernIpodCoverFlow
-              ? { width: "0%" }
-              : { opacity: 0, scale: ipodMode ? 1 : 1.05 }
-          }
-          transition={
-            isModernIpodCoverFlow
-              ? // Mirror the IpodScreen menu↔now-playing chrome:
-                // `transition-[width] duration-300 ease-in-out`.
-                { duration: 0.3, ease: "easeInOut" }
-              : { duration: ipodMode ? 0.2 : 0.35, ease: "easeOut" }
-          }
+          initial={{ opacity: 0, scale: ipodMode ? 1 : 1.05 }}
+          animate={{ opacity: 1, scale: 1 }}
+          exit={{ opacity: 0, scale: ipodMode ? 1 : 1.05 }}
+          transition={{ duration: ipodMode ? 0.2 : 0.35, ease: "easeOut" }}
         >
           {/* Reflective floor gradient — softer on the white modern skin so
               it reads as a faint stage shadow under the album row instead

--- a/src/apps/ipod/components/CoverFlow.tsx
+++ b/src/apps/ipod/components/CoverFlow.tsx
@@ -843,12 +843,16 @@ export const CoverFlow = forwardRef<CoverFlowRef, CoverFlowProps>(function Cover
             className="relative flex items-center justify-center w-full"
             style={{
               height: ipodMode && isModernIpodCoverFlow ? "76%" : "75%",
-              marginTop:
-                ipodMode && isModernIpodCoverFlow
-                  ? "0%"
-                  : ipodMode
-                    ? "-8%"
-                    : "-2%",
+              // Pull the carousel up so the covers sit closer to the
+              // titlebar instead of being optically centered inside the
+              // menu-panel content area. Modern iPod nano/classic 6G
+              // photos show the album row riding noticeably higher than
+              // mid-screen, with the title/artist row anchored to the
+              // bottom — the previous 0% offset left the covers
+              // floating low. -8% matches the classic iPod variant and
+              // gives a consistent "covers up, label down" feel across
+              // skins.
+              marginTop: ipodMode ? "-8%" : "-2%",
               perspective: `${(ipodMode ? 65 : 60) * 1.5}cqmin`,
               transformStyle: "preserve-3d",
             }}
@@ -1051,12 +1055,12 @@ export const CoverFlow = forwardRef<CoverFlowRef, CoverFlowProps>(function Cover
               className="relative flex items-center justify-center w-full"
               style={{ 
                 height: ipodMode && isModernIpodCoverFlow ? "76%" : "75%",
-                marginTop:
-                  ipodMode && isModernIpodCoverFlow
-                    ? "0%"
-                    : ipodMode
-                      ? "-8%"
-                      : "-2%",
+                // Pull the carousel up so the covers ride higher in
+                // the iPod screen — matches the inline modern variant
+                // and the classic skin. Karaoke (non-iPod) keeps its
+                // smaller -2% offset because its viewport is wider and
+                // the carousel is already lifted by other padding.
+                marginTop: ipodMode ? "-8%" : "-2%",
                 perspective: `${(ipodMode ? 65 : 60) * 1.5}cqmin`,
                 transformStyle: "preserve-3d",
               }}

--- a/src/apps/ipod/components/IpodAppComponent.tsx
+++ b/src/apps/ipod/components/IpodAppComponent.tsx
@@ -189,6 +189,14 @@ export function IpodAppComponent({
   const setAppleMusicKitNowPlaying = useIpodStore(
     (s) => s.setAppleMusicKitNowPlaying
   );
+  // The modern iPod skin renders Cover Flow inline inside the menu
+  // panel so the menu↔nowplaying chrome width transition (50%↔100%)
+  // carries the user into and out of Cover Flow exactly the same way
+  // as menu→now-playing. The classic 1st-gen LCD / karaoke skins keep
+  // the original full-bleed Cover Flow overlay rendered as a sibling
+  // of `IpodScreen` because their chrome has no width transition.
+  const uiVariant = useIpodStore((s) => s.uiVariant);
+  const isModernIpodUi = uiVariant === "modern";
 
   const handleClose = useCallback(() => {
     pauseBeforeWindowClose();
@@ -440,6 +448,31 @@ export function IpodAppComponent({
                   furiganaMap={furiganaMap}
                   soramimiMap={soramimiMap}
                   activityState={activityState}
+                  isCoverFlowOpen={isCoverFlowOpen}
+                  // Modern UI: render Cover Flow inline inside the menu
+                  // panel so the panel's own width transition (50%↔100%
+                  // — the same chrome animation as menu→now-playing)
+                  // carries the user into and out of Cover Flow. The
+                  // classic skin keeps the standalone overlay below
+                  // because it has no equivalent panel chrome.
+                  coverFlowSlot={
+                    isModernIpodUi ? (
+                      <CoverFlow
+                        ref={coverFlowRef}
+                        tracks={coverFlowTracks}
+                        currentIndex={coverFlowCurrentIndex}
+                        onSelectTrack={handleCoverFlowSelect}
+                        onExit={handleCoverFlowExit}
+                        onRotation={handleCoverFlowRotation}
+                        isVisible={isCoverFlowOpen}
+                        isPlaying={isPlaying}
+                        onTogglePlay={togglePlay}
+                        onPlayTrackInPlace={handleCoverFlowPlayInPlace}
+                        groupAppleMusicAlbums={isAppleMusic}
+                        inline
+                      />
+                    ) : undefined
+                  }
                   onNextTrack={() => {
                     if (isOffline) {
                       showOfflineStatus();
@@ -463,20 +496,27 @@ export function IpodAppComponent({
                 />
               )}
 
-              {/* Cover Flow overlay - positioned within screen bounds */}
-              <CoverFlow
-                ref={coverFlowRef}
-                tracks={coverFlowTracks}
-                currentIndex={coverFlowCurrentIndex}
-                onSelectTrack={handleCoverFlowSelect}
-                onExit={handleCoverFlowExit}
-                onRotation={handleCoverFlowRotation}
-                isVisible={isCoverFlowOpen}
-                isPlaying={isPlaying}
-                onTogglePlay={togglePlay}
-                onPlayTrackInPlace={handleCoverFlowPlayInPlace}
-                groupAppleMusicAlbums={isAppleMusic}
-              />
+              {/* Cover Flow overlay — only used by the classic 1st-gen
+               *  LCD / karaoke skins. The modern skin renders Cover
+               *  Flow inline above (via `coverFlowSlot`), so we skip
+               *  the standalone overlay there to avoid double-mounting
+               *  the carousel and to let the menu panel's width
+               *  transition own the entry/exit animation. */}
+              {!isModernIpodUi && (
+                <CoverFlow
+                  ref={coverFlowRef}
+                  tracks={coverFlowTracks}
+                  currentIndex={coverFlowCurrentIndex}
+                  onSelectTrack={handleCoverFlowSelect}
+                  onExit={handleCoverFlowExit}
+                  onRotation={handleCoverFlowRotation}
+                  isVisible={isCoverFlowOpen}
+                  isPlaying={isPlaying}
+                  onTogglePlay={togglePlay}
+                  onPlayTrackInPlace={handleCoverFlowPlayInPlace}
+                  groupAppleMusicAlbums={isAppleMusic}
+                />
+              )}
 
               {/* Music Quiz overlay - positioned within screen bounds */}
               <MusicQuiz

--- a/src/apps/ipod/components/IpodScreen.tsx
+++ b/src/apps/ipod/components/IpodScreen.tsx
@@ -234,6 +234,8 @@ export function IpodScreen({
   furiganaMap,
   soramimiMap,
   activityState,
+  isCoverFlowOpen = false,
+  coverFlowSlot,
 }: IpodScreenProps) {
   const { t } = useTranslation();
   
@@ -243,13 +245,17 @@ export function IpodScreen({
     activityState.isFetchingSoramimi || 
     activityState.isAddingSong;
 
-  // Current menu title
-  const currentMenuTitle = menuMode
-    ? menuHistory.length > 0
-      ? menuHistory[menuHistory.length - 1].displayTitle ??
-        menuHistory[menuHistory.length - 1].title
-      : t("apps.ipod.menuItems.ipod")
-    : t("apps.ipod.menuItems.nowPlaying");
+  // Current menu title — Cover Flow takes priority because it covers
+  // the entire menu panel, regardless of the underlying menu/now-
+  // playing state behind it.
+  const currentMenuTitle = isCoverFlowOpen
+    ? t("apps.ipod.menu.coverFlow")
+    : menuMode
+      ? menuHistory.length > 0
+        ? menuHistory[menuHistory.length - 1].displayTitle ??
+          menuHistory[menuHistory.length - 1].title
+        : t("apps.ipod.menuItems.ipod")
+      : t("apps.ipod.menuItems.nowPlaying");
 
   // Refs
   //
@@ -289,6 +295,15 @@ export function IpodScreen({
   // toggling from the menubar updates the screen instantly.
   const uiVariant = useIpodStore((s) => s.uiVariant);
   const isModernUi = uiVariant === "modern";
+  // Modern UI renders Cover Flow inline as a third state in the menu
+  // panel's AnimatePresence (alongside menu list + now-playing) so the
+  // menu↔nowplaying chrome width transition (50%↔100%) seamlessly
+  // carries the user into and out of Cover Flow. Classic / karaoke
+  // skins keep Cover Flow as a full-bleed overlay rendered outside
+  // `IpodScreen` and never receive a `coverFlowSlot`.
+  const showInlineCoverFlow = Boolean(
+    isModernUi && isCoverFlowOpen && coverFlowSlot
+  );
   const menuItemHeight = isModernUi
     ? MENU_ITEM_HEIGHT_MODERN
     : MENU_ITEM_HEIGHT_CLASSIC;
@@ -329,6 +344,10 @@ export function IpodScreen({
   }, [appleMusicKitNowPlaying, currentTrack, isAppleMusicCollectionShell]);
 
   const titlebarTitle =
+    // When Cover Flow is open inline, always show the "Cover Flow"
+    // label in the titlebar — the now-playing-shell title alternation
+    // below is for actual now-playing screens, not Cover Flow.
+    !isCoverFlowOpen &&
     !menuMode &&
     isAppleMusicCollectionShell &&
     isPlaying &&
@@ -486,8 +505,13 @@ export function IpodScreen({
     () =>
       isModernUi &&
       menuMode &&
+      // When Cover Flow is open inline, the menu panel grows to 100%
+      // and the split-art column collapses to 0% — same shape as
+      // menu→now-playing — so we suppress the split-art carousel
+      // entirely while Cover Flow is on screen.
+      !showInlineCoverFlow &&
       currentMenuItems.some((item) => item.showChevron === true),
-    [isModernUi, menuMode, currentMenuItems]
+    [isModernUi, menuMode, showInlineCoverFlow, currentMenuItems]
   );
 
   const splitArtUrlPool = useMemo(() => {
@@ -748,7 +772,29 @@ export function IpodScreen({
         }
       >
         <AnimatePresence initial={false} custom={menuDirection} mode="sync">
-          {menuMode ? (
+          {showInlineCoverFlow ? (
+            // Cover Flow inline state — rendered as the third option
+            // in the menu panel's AnimatePresence so the existing
+            // chrome width transition (the wrapping `ipod-modern-menu-
+            // panel` div animates 50%↔100% via `transition-[width]
+            // duration-300 ease-in-out` while the split-art column
+            // collapses to 0%) carries the user smoothly into and out
+            // of Cover Flow — exactly the same motion as menu→now
+            // playing. The slot itself is a `<CoverFlow inline />`
+            // node supplied by the parent.
+            <motion.div
+              key="coverflow"
+              className="absolute inset-0 flex flex-col h-full"
+              initial="enter"
+              animate="center"
+              exit="exit"
+              variants={menuVariants}
+              transition={{ duration: 0.2, ease: "easeInOut" }}
+              custom={menuDirection}
+            >
+              {coverFlowSlot}
+            </motion.div>
+          ) : menuMode ? (
             <motion.div
               key={`menu-${menuHistory.length}-${currentMenuTitle}`}
               className="absolute inset-0 flex flex-col h-full"

--- a/src/apps/ipod/hooks/useIpodLogic.ts
+++ b/src/apps/ipod/hooks/useIpodLogic.ts
@@ -1953,6 +1953,10 @@ export function useIpodLogic({
       label: coverFlowLabel,
       action: () => {
         registerActivity();
+        // Forward slide direction so the modern UI's inline Cover
+        // Flow enters from the right (x: 100% → 0) — same as
+        // navigating from menu into now-playing.
+        setMenuDirection("forward");
         setIsCoverFlowOpen(true);
       },
       showChevron: true,
@@ -2898,8 +2902,12 @@ export function useIpodLogic({
     vibrate();
     registerActivity();
 
-    // Exit Cover Flow if open
+    // Exit Cover Flow if open. Backward direction so the modern UI's
+    // inline Cover Flow exits to the right (x: 0 → 100%) and the menu
+    // (or now-playing) slides back in from the left — same shape as
+    // pressing menu from now-playing.
     if (isCoverFlowOpen) {
+      setMenuDirection("backward");
       setIsCoverFlowOpen(false);
       return;
     }
@@ -2995,7 +3003,10 @@ export function useIpodLogic({
     registerActivity();
 
     if (isCoverFlowOpen) {
-      // Exit cover flow
+      // Exit cover flow — backward direction so the modern UI's
+      // inline Cover Flow slides out to the right and now-playing
+      // slides back in from the left.
+      setMenuDirection("backward");
       setIsCoverFlowOpen(false);
     } else if (
       !menuMode &&
@@ -3003,7 +3014,10 @@ export function useIpodLogic({
       !isBrickGameOpen &&
       browsableTracks.length > 0
     ) {
-      // Enter cover flow only when in Now Playing mode and no overlay is active
+      // Enter cover flow only when in Now Playing mode and no overlay is active.
+      // Forward direction so the modern UI's inline Cover Flow slides in
+      // from the right (matching menu→now-playing).
+      setMenuDirection("forward");
       setIsCoverFlowOpen(true);
     }
   }, [playClickSound, vibrate, registerActivity, isCoverFlowOpen, menuMode, isMusicQuizOpen, isBrickGameOpen, browsableTracks.length]);
@@ -3081,6 +3095,10 @@ export function useIpodLogic({
   const handleCoverFlowExit = useCallback(() => {
     playClickSound();
     vibrate();
+    // Backward direction so the modern UI's inline Cover Flow slides
+    // out to the right (and the menu / now-playing screen behind it
+    // slides in from the left).
+    setMenuDirection("backward");
     setIsCoverFlowOpen(false);
   }, [playClickSound, vibrate]);
 

--- a/src/apps/ipod/types.ts
+++ b/src/apps/ipod/types.ts
@@ -140,6 +140,24 @@ export interface IpodScreenProps {
   soramimiMap?: Map<string, FuriganaSegment[]>;
   /** Activity state for loading indicators */
   activityState: ActivityInfo;
+  /**
+   * Whether Cover Flow is open. In the modern iPod UI we render Cover
+   * Flow inline inside the menu panel so the menu↔nowplaying chrome
+   * width transition (50%↔100%) seamlessly carries the user into and
+   * out of Cover Flow. The parent passes the actual `<CoverFlow inline />`
+   * element through `coverFlowSlot`; this `IpodScreen` only swaps it
+   * into the existing menu/now-playing AnimatePresence as a third
+   * keyed state.
+   */
+  isCoverFlowOpen?: boolean;
+  /**
+   * Pre-rendered `<CoverFlow inline />` element supplied by the parent.
+   * Rendered as the third state in the menu panel's AnimatePresence
+   * when `isCoverFlowOpen` is true. Only used by the modern UI; the
+   * classic LCD / karaoke skins render their own full-bleed Cover Flow
+   * overlay outside `IpodScreen` and leave this slot undefined.
+   */
+  coverFlowSlot?: React.ReactNode;
 }
 
 // Battery manager interface for browsers that expose navigator.getBattery


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

In the modern iPod UI:
1. **Menu → Cover Flow now grows the menu container itself** (50% → 100% width) — the same chrome animation as menu → Now Playing — instead of layering Cover Flow as a separate full-bleed overlay sliding in over everything.
2. **Cover Flow album covers ride higher** in the iPod screen so the title/artist row hugs the bottom (matching iPod nano/classic 6G photos).

Classic 1st-gen LCD and karaoke skins are unchanged.

## Implementation

### `src/apps/ipod/components/CoverFlow.tsx`

- Add an `inline` prop. When `true`, `<CoverFlow>` drops its own bezel / status bar / fade animation and just renders the carousel + title/artist row inside whatever host panel mounts it.
- Move the carousel `marginTop` from `0%` to `-8%` for both inline and standalone iPod variants so the album row sits above the vertical midline. Karaoke (non-iPod) keeps `-2%` because its viewport is wider.

### `src/apps/ipod/components/IpodScreen.tsx`

- New props `isCoverFlowOpen` + `coverFlowSlot`. When the slot is supplied (modern UI only), the menu panel's `<AnimatePresence>` gets a third keyed state (`coverflow`) alongside the menu list and now-playing.
- `isBrowseableMenu` is forced `false` while Cover Flow is open, which collapses `showSplitMenuArt` to `false` — the existing CSS `transition-[width] duration-300 ease-in-out` then animates the `ipod-modern-menu-panel` 50% → 100% and the split-art column 50% → 0% in lockstep, exactly the same shape as menu → now-playing.
- Titlebar title resolves to "Cover Flow" while the inline view is open.

### `src/apps/ipod/components/IpodAppComponent.tsx`

- Read `uiVariant` from the store. For modern UI the `<CoverFlow inline />` is passed through `coverFlowSlot`; for classic / karaoke it stays as the standalone full-bleed overlay rendered as a sibling of `IpodScreen`.

### `src/apps/ipod/hooks/useIpodLogic.ts`

- Set `menuDirection` to `forward` when entering Cover Flow and `backward` when exiting (long press, menu button, or selecting a track) so the inner content x-slide reads correctly through the chrome animation.

### `src/apps/ipod/types.ts`

- New optional `isCoverFlowOpen` + `coverFlowSlot` fields on `IpodScreenProps`.

## Walkthrough

<a href="https://cursor.com/agents/bc-7626ae4c-423e-4e1c-9f6e-a29014c3e046/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fipod_modern_menu_to_coverflow_width_transition.mp4"><img src="https://cursor.com/artifacts/c/art-1efd0412-68ab-408e-8771-67e52351856e" alt="ipod_modern_menu_to_coverflow_width_transition.mp4" /></a>
Menu → Cover Flow → Menu in modern UI: menu panel grows 50%→100%, split art collapses 50%→0%, mirroring menu → now-playing.

![Cover Flow with covers riding higher](https://cursor.com/artifacts/c/art-af24a498-923a-4b34-bc6f-3646885b09f9)
Cover Flow with the new `marginTop: -8%` — covers above the vertical midline, title/artist row anchored near the bottom.

## Testing

- ✅ `bun run build` — TypeScript compile + Vite production build pass cleanly.
- ✅ Manual verification with seeded YouTube tracks (Rick Astley, PSY, Despacito, Uptown Funk) — Music submenu shows split-art, selecting Cover Flow grows the menu panel and collapses the split-art column over ~300ms, MENU button reverses cleanly back to split-art.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7626ae4c-423e-4e1c-9f6e-a29014c3e046"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7626ae4c-423e-4e1c-9f6e-a29014c3e046"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

