### PR TITLE
iPod modern UI: reset menu marquee on deselect

### DIFF
--- a/src/apps/ipod/components/screen/MenuListItem.tsx
+++ b/src/apps/ipod/components/screen/MenuListItem.tsx
@@ -54,6 +54,9 @@ export function MenuListItem({
     //   - When the row is also `isSelected`, the marquee animates and
     //     both edges fade — matches the iPod nano 6G/7G's behavior of
     //     scrolling the highlighted row's text horizontally.
+    //   - `resetOnPause` is enabled so deselecting a row snaps the
+    //     marquee back to translate(0) instead of leaving the text
+    //     frozen at whatever offset it had scrolled to.
     return (
       <div
         onClick={isLoading ? undefined : onClick}
@@ -76,6 +79,7 @@ export function MenuListItem({
             fadeEdges
             allowMarquee={allowScrollingMarquee}
             isPlaying={isSelected && !isLoading}
+            resetOnPause
             scrollStartDelaySec={0.5}
             className="max-w-full min-w-0 block text-[15px] font-semibold leading-normal"
           />

--- a/src/apps/ipod/components/screen/ScrollingText.tsx
+++ b/src/apps/ipod/components/screen/ScrollingText.tsx
@@ -18,6 +18,18 @@ interface ScrollingTextProps {
   allowMarquee?: boolean;
   /** Seconds to wait before the marquee starts (each scroll cycle still runs full duration). */
   scrollStartDelaySec?: number;
+  /**
+   * When `true`, toggling `isPlaying` to `false` snaps the text back to its
+   * starting position (the marquee track is unmounted instead of pausing
+   * mid-scroll). The right-edge truncation fade still renders so overflowing
+   * labels remain hinted. Use for selection-driven marquees (e.g. iPod menu
+   * rows) where deselection should reset the row.
+   *
+   * Defaults to `false` — legacy "freeze in place" behavior that matches the
+   * real iPod Now Playing screen, which keeps the marquee paused at the
+   * current offset when the user pauses playback.
+   */
+  resetOnPause?: boolean;
   style?: CSSProperties;
 }
 
@@ -29,6 +41,7 @@ export function ScrollingText({
   fadeEdges = false,
   allowMarquee = true,
   scrollStartDelaySec = 0,
+  resetOnPause = false,
   style,
 }: ScrollingTextProps) {
   const containerRef = useRef<HTMLDivElement>(null);
@@ -61,11 +74,17 @@ export function ScrollingText({
     return () => resizeObserver.disconnect();
   }, [text, allowMarquee]);
 
-  const showMarquee = shouldScroll && allowMarquee;
+  // When `resetOnPause` is enabled and we're paused, drop the marquee track
+  // entirely so the duplicated text snaps back to translate(0). The static
+  // branch still gets the right-edge truncation fade below.
+  const isResetPaused = resetOnPause && !isPlaying;
+  const showMarquee = shouldScroll && allowMarquee && !isResetPaused;
+  const showStaticOverflowFade =
+    shouldScroll && allowMarquee && isResetPaused && fadeEdges;
 
   useEffect(() => {
     setEdgeFadeActive(false);
-  }, [text, shouldScroll, allowMarquee, scrollStartDelaySec, fadeEdges]);
+  }, [text, showMarquee, scrollStartDelaySec, fadeEdges]);
 
   const handleMarqueeAnimationStart = useCallback((e: AnimationEvent<HTMLDivElement>) => {
     if (!e.animationName.includes("scrolling-text-marquee")) return;
@@ -73,13 +92,19 @@ export function ScrollingText({
   }, []);
 
   const fadeInset = "0.75em";
-  const maskImage =
-    showMarquee && fadeEdges
-      ? edgeFadeActive
-        ? // Full fade: hides seam at both edges while looping
-          `linear-gradient(to right, transparent 0, black ${fadeInset}, black calc(100% - ${fadeInset}), transparent 100%)`
-        : // Pre-start / idle: keep text crisp on the left, hint overflow on the right
-          `linear-gradient(to right, black 0, black calc(100% - ${fadeInset}), transparent 100%)`
+  // Right-only fade: keep text crisp on the left, hint overflow on the right.
+  // Used for the idle/pre-start frame of the marquee AND for the
+  // `resetOnPause` static fallback (so deselected overflowing rows still
+  // render a truncation hint instead of a hard cut).
+  const rightOnlyFadeGradient = `linear-gradient(to right, black 0, black calc(100% - ${fadeInset}), transparent 100%)`;
+  // Full fade: hides the seam at both edges while the marquee loops.
+  const bothEdgesFadeGradient = `linear-gradient(to right, transparent 0, black ${fadeInset}, black calc(100% - ${fadeInset}), transparent 100%)`;
+  const maskImage = showMarquee && fadeEdges
+    ? edgeFadeActive
+      ? bothEdgesFadeGradient
+      : rightOnlyFadeGradient
+    : showStaticOverflowFade
+      ? rightOnlyFadeGradient
       : undefined;
   const mergedStyle: CSSProperties = {
     ...style,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

In the iPod **modern** UI, long menu labels marquee-scroll only while the row is selected. When the user scrolled to a different row, the previously selected row's text was just *paused* in place (CSS `animation-play-state: paused`), so any row that had been highlighted ended up frozen at whatever offset the marquee happened to be at — partially scrolled, with the seam to the duplicate text visible.

This change snaps the text back to its starting position when the row is no longer selected. Newly-touched rows look identical to rows that were never selected.

## Implementation

- Add a `resetOnPause` prop (default `false`) to `ScrollingText` (`src/apps/ipod/components/screen/ScrollingText.tsx`).
  - When `true` and `isPlaying` is `false`, the marquee track is unmounted and the component falls back to the existing static-text branch — which renders at `translate(0)`.
  - The right-edge truncation fade (`fadeEdges`) still applies to the static branch when content overflows, so the "label too long" hint is preserved.
  - The `edgeFadeActive` reset effect now keys on `showMarquee` so re-selecting a row starts in the idle "right-only fade" frame before the both-edges fade kicks in on animation start (matching the existing pre-start behavior).
- Wire `resetOnPause` in `MenuListItem` (`src/apps/ipod/components/screen/MenuListItem.tsx`), only for the `modern` variant where the selection-driven marquee actually runs.

The default (`false`) keeps the legacy "freeze in place" semantics for the Now-Playing title/artist/album marquees in `IpodScreen.tsx`, which intentionally mirror the real iPod nano 6G/7G behavior of freezing the scroll when audio is paused.

## Testing

- ✅ `bun run build` — TypeScript compile + Vite build succeeds.
- Manual verification was skipped per `AGENTS.md` (modern iPod marquee is a small visual behavior tweak; `bun run build` is sufficient).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3c8df13b-19d9-4f04-b78b-33f2ef1805e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3c8df13b-19d9-4f04-b78b-33f2ef1805e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

