### PR TITLE
iPod: fade box-shadow + cover art on split→full, black backface

### DIFF
--- a/src/apps/ipod/components/IpodScreen.tsx
+++ b/src/apps/ipod/components/IpodScreen.tsx
@@ -76,6 +76,13 @@ const MODERN_TITLEBAR_HEIGHT = 17;
 // "Music + Now Playing" split shown in the reference photo. The
 // titlebar + menu list are clamped to the left half in split mode.
 const MODERN_SPLIT_HALF = "50%";
+// Shared timing for every property that animates during the modern UI
+// split↔full transition: menu panel width + box-shadow, split-art
+// column width, and the cover-art image's opacity. Keeping all four
+// on the same 300ms `ease-in-out` curve is what makes the move read
+// as one continuous motion instead of overlapping easings.
+const SPLIT_LAYOUT_TRANSITION_TIMING =
+  "duration-300 ease-in-out motion-reduce:transition-none";
 // Render this many extra items above and below the visible window so
 // scrolling doesn't reveal blank rows before React reconciles.
 const OVERSCAN_ITEMS = 6;
@@ -1391,7 +1398,7 @@ export function IpodScreen({
             // screen leak through a half-faded panel).
             "ipod-modern-split-art absolute top-0 right-0 bottom-0 z-[5] overflow-hidden",
             splitLayoutTransitionReady &&
-              "transition-[width] duration-300 ease-in-out motion-reduce:transition-none"
+              `transition-[width] ${SPLIT_LAYOUT_TRANSITION_TIMING}`
           )}
           style={{
             width: showSplitMenuArt ? MODERN_SPLIT_HALF : "0%",
@@ -1407,7 +1414,7 @@ export function IpodScreen({
             className={cn(
               "absolute inset-0",
               splitLayoutTransitionReady &&
-                "transition-opacity duration-300 ease-in-out motion-reduce:transition-none"
+                `transition-opacity ${SPLIT_LAYOUT_TRANSITION_TIMING}`
             )}
             style={{ opacity: showSplitMenuArt ? 1 : 0 }}
           >
@@ -1443,14 +1450,14 @@ export function IpodScreen({
             "relative flex min-h-0 flex-col overflow-hidden z-10 h-full ipod-modern-menu-panel",
             showSplitMenuArt && "is-split",
             splitLayoutTransitionReady &&
-              "transition-[width,box-shadow] duration-300 ease-in-out motion-reduce:transition-none"
+              `transition-[width,box-shadow] ${SPLIT_LAYOUT_TRANSITION_TIMING}`
           )}
+          // `showSplitMenuArt` already implies `menuMode` (see its
+          // definition above), so the `menuMode ?` ternary collapses:
+          // both !menuMode and (menuMode && !showSplitMenuArt) want
+          // 100%, only showSplitMenuArt wants the split half.
           style={{
-            width: menuMode
-              ? showSplitMenuArt
-                ? MODERN_SPLIT_HALF
-                : "100%"
-              : "100%",
+            width: showSplitMenuArt ? MODERN_SPLIT_HALF : "100%",
           }}
         >
           {menuChrome}

--- a/src/apps/ipod/components/IpodScreen.tsx
+++ b/src/apps/ipod/components/IpodScreen.tsx
@@ -1382,40 +1382,68 @@ export function IpodScreen({
       {isModernUi && menuMode && (
         <div
           className={cn(
+            // Outer container: width animates 50% ↔ 0% in lock-step with
+            // the menu panel's 50% ↔ 100% width animation. We do NOT
+            // fade the container's own opacity — the panel's solid-black
+            // background must remain visible as the cover image fades
+            // off so it reads as a true "black backface" peeking out
+            // from under the covers (instead of letting the white
+            // screen leak through a half-faded panel).
             "ipod-modern-split-art absolute top-0 right-0 bottom-0 z-[5] overflow-hidden",
             splitLayoutTransitionReady &&
-              "transition-[width,opacity] duration-300 ease-in-out motion-reduce:transition-none"
+              "transition-[width] duration-300 ease-in-out motion-reduce:transition-none"
           )}
           style={{
             width: showSplitMenuArt ? MODERN_SPLIT_HALF : "0%",
-            opacity: showSplitMenuArt ? 1 : 0,
           }}
           aria-hidden
         >
-          {splitArtUrl ? (
-            <AnimatePresence initial={false} mode="sync">
-              <motion.img
-                key={splitArtUrl}
-                src={splitArtUrl}
-                alt=""
-                draggable={false}
-                className="ipod-modern-split-art-img absolute inset-0 size-full object-cover select-none"
-                initial={{ opacity: 0 }}
-                animate={{ opacity: 1 }}
-                exit={{ opacity: 0 }}
-                transition={{ duration: 0.35, ease: "easeInOut" }}
-              />
-            </AnimatePresence>
-          ) : null}
+          {/* Cover art layer: fades on its OWN opacity track, leaving
+           *  the parent panel at full opacity. When `showSplitMenuArt`
+           *  flips off, the image fades to 0 over the same 300ms
+           *  window as the width transition — revealing the solid
+           *  black backface beneath before the column clips away. */}
+          <div
+            className={cn(
+              "absolute inset-0",
+              splitLayoutTransitionReady &&
+                "transition-opacity duration-300 ease-in-out motion-reduce:transition-none"
+            )}
+            style={{ opacity: showSplitMenuArt ? 1 : 0 }}
+          >
+            {splitArtUrl ? (
+              <AnimatePresence initial={false} mode="sync">
+                <motion.img
+                  key={splitArtUrl}
+                  src={splitArtUrl}
+                  alt=""
+                  draggable={false}
+                  className="ipod-modern-split-art-img absolute inset-0 size-full object-cover select-none"
+                  initial={{ opacity: 0 }}
+                  animate={{ opacity: 1 }}
+                  exit={{ opacity: 0 }}
+                  transition={{ duration: 0.35, ease: "easeInOut" }}
+                />
+              </AnimatePresence>
+            ) : null}
+          </div>
         </div>
       )}
       {isModernUi ? (
         <div
           className={cn(
-            "relative flex min-h-0 flex-col overflow-hidden z-10 h-full",
-            showSplitMenuArt && "ipod-modern-menu-panel",
+            // `ipod-modern-menu-panel` is kept mounted on every modern
+            // UI frame (not gated on `showSplitMenuArt`) so its
+            // box-shadow can transition smoothly. The `.is-split`
+            // modifier fades the shadow alphas in/out as the menu
+            // animates 50%↔100%, in lock-step with the width transition
+            // below. The split-art column to the right meanwhile fades
+            // its cover image off, revealing the panel's solid-black
+            // backface (see `.ipod-modern-split-art`).
+            "relative flex min-h-0 flex-col overflow-hidden z-10 h-full ipod-modern-menu-panel",
+            showSplitMenuArt && "is-split",
             splitLayoutTransitionReady &&
-              "transition-[width] duration-300 ease-in-out motion-reduce:transition-none"
+              "transition-[width,box-shadow] duration-300 ease-in-out motion-reduce:transition-none"
           )}
           style={{
             width: menuMode

--- a/src/apps/ipod/components/IpodScreen.tsx
+++ b/src/apps/ipod/components/IpodScreen.tsx
@@ -592,6 +592,27 @@ export function IpodScreen({
   // the screen falls back to the standard full-width chrome.
   const showSplitMenuArt = isModernUi && menuMode && Boolean(splitArtUrl);
 
+  // The cover image is rendered against the LAST non-null
+  // `splitArtUrl` (not the live value) so it stays mounted through
+  // the fade-out when `splitArtUrl` flips null in the same render
+  // that `showSplitMenuArt` does — e.g. navigating from a browseable
+  // menu (Music root) into a flat song list / settings menu, which
+  // empties `splitArtUrlPool` immediately. Without this, the
+  // `{splitArtUrl ? <motion.img/> : null}` branch would unmount
+  // before the wrapper had a chance to animate its opacity / width
+  // to zero, and the cover would pop instead of fading. We only
+  // update on a real (non-null) value so the previous artwork
+  // remains rendered behind the fading cover-art layer for the full
+  // 300ms transition window.
+  const [renderedSplitArtUrl, setRenderedSplitArtUrl] = useState<
+    string | null
+  >(splitArtUrl);
+  useEffect(() => {
+    if (splitArtUrl) {
+      setRenderedSplitArtUrl(splitArtUrl);
+    }
+  }, [splitArtUrl]);
+
   // Defer width/opacity transitions until after the first paint so
   // mounting in split or full layout does not animate from a default.
   const [splitLayoutTransitionReady, setSplitLayoutTransitionReady] =
@@ -1409,7 +1430,14 @@ export function IpodScreen({
            *  the parent panel at full opacity. When `showSplitMenuArt`
            *  flips off, the image fades to 0 over the same 300ms
            *  window as the width transition — revealing the solid
-           *  black backface beneath before the column clips away. */}
+           *  black backface beneath before the column clips away.
+           *
+           *  We render against `renderedSplitArtUrl` (the last non-null
+           *  cover) instead of the live `splitArtUrl` so the image
+           *  stays mounted while the layer fades out — otherwise the
+           *  image would unmount in the same render that
+           *  `showSplitMenuArt` flips false and the cover would pop
+           *  instead of fading. */}
           <div
             className={cn(
               "absolute inset-0",
@@ -1418,11 +1446,11 @@ export function IpodScreen({
             )}
             style={{ opacity: showSplitMenuArt ? 1 : 0 }}
           >
-            {splitArtUrl ? (
+            {renderedSplitArtUrl ? (
               <AnimatePresence initial={false} mode="sync">
                 <motion.img
-                  key={splitArtUrl}
-                  src={splitArtUrl}
+                  key={renderedSplitArtUrl}
+                  src={renderedSplitArtUrl}
                   alt=""
                   draggable={false}
                   className="ipod-modern-split-art-img absolute inset-0 size-full object-cover select-none"

--- a/src/index.css
+++ b/src/index.css
@@ -1505,9 +1505,14 @@ button.piano-key.piano-key[class*="bg-[#ff33ff]"] {
  * the menu's drop shadow lands on top of the artwork. We keep only
  * a 1px hairline at the very left edge here — the depth illusion
  * comes from `.ipod-modern-menu-panel`'s drop shadow, not from a
- * second inset shadow stacked on top of it. */
+ * second inset shadow stacked on top of it.
+ *
+ * Background is pure black so it reads as a "backface" behind the
+ * cover artwork — as the cover art image fades out during the
+ * split→full transition the visible backing is solid black instead
+ * of leaking the white screen color through. */
 .ipod-modern-split-art {
-  background: #1a1a1a;
+  background: #000;
   box-shadow: inset 1px 0 0 rgba(0, 0, 0, 0.18);
 }
 
@@ -1521,9 +1526,22 @@ button.piano-key.piano-key[class*="bg-[#ff33ff]"] {
  * split mode, so the shadow runs unbroken down the entire right
  * edge of the menu surface. No inset line on the right — that read
  * as a hard border next to the art; depth comes from the outer
- * drop-shadow layers only. */
+ * drop-shadow layers only.
+ *
+ * The class is kept mounted on the menu wrapper for every modern UI
+ * frame so the box-shadow can transition smoothly as the menu width
+ * animates split↔full. Default state has both shadow layers at zero
+ * alpha; the `.is-split` modifier fades them in. Combined with a
+ * `transition: box-shadow ...` on the wrapper this gives a smooth
+ * fade of the depth shadow in lock-step with the width animation. */
 .ipod-modern-menu-panel {
   overflow: hidden;
+  box-shadow:
+    4px 0 8px -2px rgba(0, 0, 0, 0),
+    2px 0 3px -1px rgba(0, 0, 0, 0);
+}
+
+.ipod-modern-menu-panel.is-split {
   box-shadow:
     4px 0 8px -2px rgba(0, 0, 0, 0.28),
     2px 0 3px -1px rgba(0, 0, 0, 0.18);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

When the iPod modern UI menu transitions from the **split** layout (50% menu + 50% Ken Burns cover art) to **full-width** (100% menu), three details now animate together so the transition reads as one continuous motion instead of a series of pops:

- **Box shadow fades.** The menu panel's drop shadow (which lands on the cover-art column to its right in split mode) now fades to zero alpha as the menu widens, rather than snapping off the moment `showSplitMenuArt` flips.
- **Cover art fades.** The cover image is now isolated on its own opacity track so it fades to 0 as the column shrinks — the surrounding column doesn't fade with it.
- **Black backface under the covers.** With the column itself no longer fading, its `background` (changed from `#1a1a1a` → `#000`) stays at full opacity behind the cover image, so what shows through during the fade is solid black instead of the screen's white surface bleeding through a half-faded panel.

## Implementation notes

### `src/index.css`
- `.ipod-modern-split-art`: `background: #1a1a1a` → `#000` so the panel reads as a true black backface behind the artwork.
- `.ipod-modern-menu-panel`: split into a base state (both shadow layers at `rgba(0,0,0,0)`) and a `.is-split` modifier that raises them to the active alphas (`0.28` / `0.18`). Keeping the class mounted at all times lets the wrapper's CSS transition animate `box-shadow` smoothly.

### `src/apps/ipod/components/IpodScreen.tsx`
- Menu panel wrapper: `ipod-modern-menu-panel` is now always applied in modern UI; `is-split` toggles based on `showSplitMenuArt`. The Tailwind `transition-[width]` becomes `transition-[width,box-shadow]` so both properties animate together over the existing `duration-300 ease-in-out` curve.
- Split-art column: the outer container drops its panel-level opacity transition and only animates `width`. The cover image is wrapped in an inner `transition-opacity` layer whose opacity tracks `showSplitMenuArt`, so the image fades independently while the parent's solid-black background stays at full opacity throughout the transition.
- The `<motion.img>` is rendered against a `renderedSplitArtUrl` state that latches the last non-null `splitArtUrl`. Without this, navigating from a browseable menu into a flat list (e.g. All Songs, Settings) emptied `splitArtUrlPool` in the same render and the `splitArtUrl ? … : null` gate unmounted the image before the cover-art layer's opacity transition could play — the cover popped instead of fading. The latch keeps the previous artwork mounted while the layer fades to 0.

### Follow-up refactor commit
- Hoisted the duplicated transition tail (`duration-300 ease-in-out motion-reduce:transition-none`) into a module-level `SPLIT_LAYOUT_TRANSITION_TIMING` constant; the three animating surfaces now reference one string.
- Simplified the menu panel `width` ternary — `showSplitMenuArt` already implies `menuMode`, so the outer `menuMode ?` arm was redundant (both falsy branches returned `100%`).

## Testing

- ✅ `bun run build` — clean build on every commit, no TypeScript or Vite errors.
- Per repo guidance (`AGENTS.md` → "Manual Testing Guidelines"), GUI-driven testing is skipped unless explicitly requested. The user instructed not to test before pushing.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6f46f314-c033-4ab2-85c2-16b92d9f4e9a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6f46f314-c033-4ab2-85c2-16b92d9f4e9a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

