### PR TITLE
fix(ipod): fade split-art with black backface on menu → now playing

### DIFF
--- a/src/apps/ipod/components/IpodScreen.tsx
+++ b/src/apps/ipod/components/IpodScreen.tsx
@@ -1404,10 +1404,12 @@ export function IpodScreen({
        *  cycles through `splitArtUrlPool`. */}
       {/* Right-half artwork: width animates 0% <-> 50% in sync with the
        *  menu chrome so entering/leaving split view feels smooth.
-       *  Kept mounted for every modern menu frame (not only when art
-       *  is visible) so collapsing to full-width still runs the exit
-       *  transition. */}
-      {isModernUi && menuMode && (
+       *  Kept mounted for EVERY modern UI frame (not gated on
+       *  `menuMode`) so collapsing to full-width AND collapsing to
+       *  now-playing both run the same exit transition — the image
+       *  fades off while the panel's solid-black backface stays put
+       *  through the 300ms window, exactly like menu → Cover Flow. */}
+      {isModernUi && (
         <div
           className={cn(
             // Outer container: width animates 50% ↔ 0% in lock-step with


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary

Match the menu → full-width-menu / menu → Cover Flow transition when navigating from a browseable menu (e.g. Music) directly to **Now Playing** in the modern-UI iPod: the right-half Ken Burns split-art column now fades its artwork off while the panel's solid-black backface stays put through the 300ms window, instead of popping away to expose the white screen background.

### Root cause

The split-art panel was conditionally rendered with `isModernUi && menuMode`. When the user selected "Now Playing" from a browseable menu, `menuMode` flipped to `false` in the same render that `showSplitMenuArt` would have flipped `false` — but because the gate included `menuMode`, the entire container unmounted instantly. The `transition-[width]` / `transition-opacity` rules that produce the smooth fade for menu → full-width and menu → Cover Flow never got a chance to run.

For menu → full-width-menu and menu → Cover Flow, `menuMode` stays `true` and only `showSplitMenuArt` flips, so the panel stays mounted and animates correctly. The fix removes the redundant `menuMode` half of the gate.

### Change

`src/apps/ipod/components/IpodScreen.tsx` — drop `&& menuMode` from the split-art container's render gate so it stays mounted for every modern-UI frame. `showSplitMenuArt` already correctly derives from `menuMode` (via `isBrowseableMenu`), so:

- **Menu (browseable, with split art) → Now Playing**: width 50% → 0%, image opacity 1 → 0 over 300ms; black backface peeks out as the artwork fades. ✅ (new)
- **Now Playing → browseable menu**: width 0% → 50%, image opacity 0 → 1 — panel is already mounted so the fade-in runs from the correct starting state. ✅ (new)
- **Menu → full-width menu**: unchanged. ✅
- **Menu ↔ Cover Flow**: unchanged. ✅
- **Classic / karaoke skins**: unaffected — split art is modern-UI only. ✅

### Testing

- ✅ `bun run build` — TypeScript + Vite build passes.
- This is a pure render-gate change inside the existing modern-UI iPod screen layout; no new state, no new transitions, no new CSS. The existing `transition-[width]` (300ms ease-in-out) on `.ipod-modern-split-art` and `transition-opacity` on the inner image layer drive the fade. `renderedSplitArtUrl` already holds the last non-null cover so the `<motion.img>` stays mounted through the fade-out.
- Skipped GUI walkthrough per the repo's "Skip computer use / GUI-driven testing unless the user explicitly requests it" guideline in `AGENTS.md`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1d869b87-7c09-48a6-998f-65dce2c691fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1d869b87-7c09-48a6-998f-65dce2c691fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

