### PR TITLE
ipod(modern): radial play/pause, square battery, deeper split shadow

### DIFF
--- a/src/apps/ipod/components/screen/BatteryIndicator.tsx
+++ b/src/apps/ipod/components/screen/BatteryIndicator.tsx
@@ -69,11 +69,16 @@ export function BatteryIndicator({
     // the top half only and fades to transparent at the midline. The
     // green fill carries the same half-gloss so charge level reads as
     // a single glossy lozenge rather than a flat bar.
+    //
+    // Sharp 90° corners (no border-radius) on both the body and the cap
+    // — the iPod classic 6G/7G silver header in the reference photo
+    // uses a flat rectangular battery, not the rounded pill the iOS 6
+    // status-bar battery has.
     const fillPercent = Math.max(0, Math.min(1, level)) * 100;
     const isLow = !isCharging && level <= 0.2;
     return (
       <div className="flex items-center">
-        <div className="relative h-[9px] w-[14px] shrink-0 overflow-hidden rounded-[2px] ipod-modern-battery-container">
+        <div className="relative h-[9px] w-[14px] shrink-0 overflow-hidden ipod-modern-battery-container">
           <div
             className={cn(
               "absolute inset-y-0 left-0 ipod-modern-battery-fill transition-[width] duration-300",

--- a/src/apps/ipod/components/screen/IpodModernPlayPauseIcon.tsx
+++ b/src/apps/ipod/components/screen/IpodModernPlayPauseIcon.tsx
@@ -3,9 +3,14 @@ import { useMemo } from "react";
 /**
  * Inline SVG play/pause indicator for the modern iPod titlebar.
  *
- * Uses an embedded `<linearGradient>` so the glyph can be filled with
- * the same vertical blue gradient as the row-selection highlight
- * (`linear-gradient(180deg, rgb(60, 184, 255) 0%, rgb(52, 122, 181) 100%)`).
+ * Uses an embedded `<radialGradient>` so the glyph reads as a small
+ * glossy 3D button — the same look the iPod nano 6G/7G + iPod classic
+ * 6G silver header uses for status icons in the reference photo. The
+ * highlight is biased toward the upper-left of the icon (cx=35%,
+ * cy=25%) and falls off to the deeper blue at the bottom-right edge,
+ * which gives the play/pause shape a convex, lit-from-above feel
+ * instead of the flat top-to-bottom linear fade we had before.
+ *
  * Phosphor icons render with `currentColor` and don't expose a way to
  * paint a gradient, so this small custom SVG is the cleanest way to
  * land that look without adding a new icon dep.
@@ -34,10 +39,18 @@ export function IpodModernPlayPauseIcon({
       role="img"
     >
       <defs>
-        <linearGradient id={gradientId} x1="0" y1="0" x2="0" y2="1">
-          <stop offset="0%" stopColor="rgb(60, 184, 255)" />
-          <stop offset="100%" stopColor="rgb(52, 122, 181)" />
-        </linearGradient>
+        <radialGradient
+          id={gradientId}
+          cx="35%"
+          cy="25%"
+          r="85%"
+          fx="35%"
+          fy="20%"
+        >
+          <stop offset="0%" stopColor="rgb(170, 224, 255)" />
+          <stop offset="45%" stopColor="rgb(60, 162, 230)" />
+          <stop offset="100%" stopColor="rgb(36, 92, 148)" />
+        </radialGradient>
       </defs>
       {playing ? (
         <path d="M8 5v14l11-7z" fill={`url(#${gradientId})`} />

--- a/src/index.css
+++ b/src/index.css
@@ -1491,7 +1491,9 @@ button.piano-key.piano-key[class*="bg-[#ff33ff]"] {
   background-color: #c4c4c4;
   border: 1px solid #626262;
   border-left-width: 0;
-  border-radius: 0 2px 2px 0;
+  /* No rounded corners — the iPod classic 6G/7G silver header battery
+   * is a flat rectangle (cap included), not the iOS 6 rounded pill. */
+  border-radius: 0;
 }
 
 /* iPod 6G/7G "split menu" view: the right HALF of the screen shows
@@ -1502,10 +1504,17 @@ button.piano-key.piano-key[class*="bg-[#ff33ff]"] {
  * animates `transform`.
  *
  * The art panel sits *behind* the menu (z-5 < menu's z-10/z-30) so
- * the menu's drop shadow lands on top of the artwork. We keep only
- * a 1px hairline at the very left edge here — the depth illusion
- * comes from `.ipod-modern-menu-panel`'s drop shadow, not from a
- * second inset shadow stacked on top of it.
+ * the menu's drop shadow lands on top of the artwork. The depth
+ * illusion comes from two stacked sources: an inset gradient on the
+ * art column itself that darkens the leftmost slice of the cover (so
+ * the shadow reads as falling ON the artwork rather than a flat
+ * gutter), plus the soft drop shadow cast by `.ipod-modern-menu-panel`.
+ *
+ * The inner box-shadow uses an inset spread so it darkens roughly
+ * the leftmost ~12px of the cover with a smooth falloff — without
+ * this, the cast shadow alone leaves the cover edge looking too
+ * bright next to the menu, and the split read more like two flat
+ * panels than a layered stack.
  *
  * Background is pure black so it reads as a "backface" behind the
  * cover artwork — as the cover art image fades out during the
@@ -1513,7 +1522,10 @@ button.piano-key.piano-key[class*="bg-[#ff33ff]"] {
  * of leaking the white screen color through. */
 .ipod-modern-split-art {
   background: #000;
-  box-shadow: inset 1px 0 0 rgba(0, 0, 0, 0.18);
+  box-shadow:
+    inset 8px 0 12px -4px rgba(0, 0, 0, 0.65),
+    inset 3px 0 5px -1px rgba(0, 0, 0, 0.55),
+    inset 1px 0 0 rgba(0, 0, 0, 0.4);
 }
 
 /* LEFT-side menu surface in split mode: must clip its contents (so menu
@@ -1537,14 +1549,20 @@ button.piano-key.piano-key[class*="bg-[#ff33ff]"] {
 .ipod-modern-menu-panel {
   overflow: hidden;
   box-shadow:
-    4px 0 8px -2px rgba(0, 0, 0, 0),
-    2px 0 3px -1px rgba(0, 0, 0, 0);
+    8px 0 16px -2px rgba(0, 0, 0, 0),
+    4px 0 8px -1px rgba(0, 0, 0, 0),
+    1px 0 0 rgba(0, 0, 0, 0);
 }
 
+/* Deeper, longer-throw shadow stack so the menu reads as a thick card
+ * floating above the album art column — matches the heavy gutter
+ * shadow visible in the iPod classic 6G/7G reference photo where the
+ * cover artwork's left edge is noticeably darker than its center. */
 .ipod-modern-menu-panel.is-split {
   box-shadow:
-    4px 0 8px -2px rgba(0, 0, 0, 0.28),
-    2px 0 3px -1px rgba(0, 0, 0, 0.18);
+    8px 0 16px -2px rgba(0, 0, 0, 0.55),
+    4px 0 8px -1px rgba(0, 0, 0, 0.45),
+    1px 0 0 rgba(0, 0, 0, 0.35);
 }
 
 .ipod-modern-split-art-img {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Three small chrome tweaks to make the modern iPod skin match the iPod classic 6G/7G silver-header reference photo more faithfully.

### Changes

- **Radial gradient play/pause icon** — `IpodModernPlayPauseIcon` swaps its top→bottom `linearGradient` for a `radialGradient` biased toward the upper-left (`cx=35%, cy=25%, r=85%`). The status glyph now reads as a small glossy 3D button instead of a flat fade. Affects the screen titlebar (`IpodScreen`) and the Cover Flow titlebar (`CoverFlow`).
- **Sharp-cornered battery** — `BatteryIndicator` (modern variant) drops `rounded-[2px]` from the body and changes the cap's `border-radius` from `0 2px 2px 0` to `0`. The battery is now a flat rectangle with a square cap, matching the silver-header chrome (not the iOS 6 status-bar pill it was inheriting).
- **Deeper split-menu cover shadow** — `.ipod-modern-menu-panel.is-split` casts a heavier, longer-throw drop shadow (`8px/16px @ 0.55` + `4px/8px @ 0.45` + `1px hairline @ 0.35`), and `.ipod-modern-split-art` adds a matching inset gradient that darkens the leftmost ~12px of the cover artwork. Together they sell the "menu floats above cover" depth visible in the reference photo.

### Files touched

- `src/apps/ipod/components/screen/IpodModernPlayPauseIcon.tsx`
- `src/apps/ipod/components/screen/BatteryIndicator.tsx`
- `src/index.css`

## Walkthrough

Modern UI in split-menu mode (Music root, blue-highlighted selection, cover art on the right half), captured with a Playwright headless run against the dev server.

![iPod modern split menu — after](https://cursor.com/artifacts/c/art-9c17becd-0cd2-4c74-87e5-2e024befd3a1)

### Titlebar — radial gradient play/pause + square battery

Before (linear gradient + rounded battery):

![iPod modern titlebar — before](https://cursor.com/artifacts/c/art-7d668921-bb36-4880-8d74-52362ae86418)

After (radial gradient + square battery):

![iPod modern titlebar — after](https://cursor.com/artifacts/c/art-89bcfeab-97cb-42f2-86d5-b03edc86bf5e)

### Split-menu shadow seam

Before (light gutter, cover starts almost immediately at the seam):

![iPod split shadow seam — before](https://cursor.com/artifacts/c/art-f9b4f56f-a13c-4088-a286-5ea027e9ac39)

After (heavier shadow, ~12–15px gradient darkens the cover's left edge):

![iPod split shadow seam — after](https://cursor.com/artifacts/c/art-a4dfe84e-b5d8-4d6d-a742-9260053e3e5e)

## Testing

- ✅ `bun run build` — clean compile, no new TypeScript or Vite errors.
- ✅ Visual diff captured with Playwright against `bun run dev:vite`. Localstorage was pre-seeded with four test tracks, modern UI variant, and an open iPod app instance to deterministically render the split-menu state. Same script ran against `main` for the "before" set.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d26d92bd-a719-427a-831b-0daf3e7c85a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d26d92bd-a719-427a-831b-0daf3e7c85a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

