### PR TITLE
fix(ipod): split-art fades to pure-black backface (not darkened image) on menu → now playing

### DIFF
--- a/src/apps/ipod/components/IpodScreen.tsx
+++ b/src/apps/ipod/components/IpodScreen.tsx
@@ -76,13 +76,28 @@ const MODERN_TITLEBAR_HEIGHT = 17;
 // "Music + Now Playing" split shown in the reference photo. The
 // titlebar + menu list are clamped to the left half in split mode.
 const MODERN_SPLIT_HALF = "50%";
-// Shared timing for every property that animates during the modern UI
-// split↔full transition: menu panel width + box-shadow, split-art
-// column width, and the cover-art image's opacity. Keeping all four
-// on the same 300ms `ease-in-out` curve is what makes the move read
-// as one continuous motion instead of overlapping easings.
+// Shared timing for the chrome-width animation (menu panel width +
+// box-shadow, split-art column width). Kept on a 300ms `ease-in-out`
+// curve so the menu panel growing 50%↔100% and the split-art column
+// shrinking 50%↔0% read as one continuous motion.
 const SPLIT_LAYOUT_TRANSITION_TIMING =
   "duration-300 ease-in-out motion-reduce:transition-none";
+// The cover-art image fades on a SHORTER, directional curve so the
+// "black backface" effect actually reads as one. On EXIT the image
+// fades to 0 in the first half of the 300ms window, leaving the
+// panel's solid-black backface visible (with no faint image
+// overlay) for the remaining 150ms while the column shrinks. On
+// ENTRY the image fades back in only after the column has grown to
+// its final width, so a wider image crop doesn't keep snapping as
+// `object-cover` re-fits during the grow. Without the asymmetric
+// delay, the cover would otherwise track the panel collapse 1:1
+// (matching widths) and the fade would never visibly resolve to
+// pure black before the column clipped away — defeating the
+// backface illusion described above for `.ipod-modern-split-art`.
+const SPLIT_ART_IMAGE_FADE_OUT =
+  "duration-150 delay-0 ease-in-out motion-reduce:transition-none";
+const SPLIT_ART_IMAGE_FADE_IN =
+  "duration-150 delay-150 ease-in-out motion-reduce:transition-none";
 // Render this many extra items above and below the visible window so
 // scrolling doesn't reveal blank rows before React reconciles.
 const OVERSCAN_ITEMS = 6;
@@ -1429,10 +1444,24 @@ export function IpodScreen({
           aria-hidden
         >
           {/* Cover art layer: fades on its OWN opacity track, leaving
-           *  the parent panel at full opacity. When `showSplitMenuArt`
-           *  flips off, the image fades to 0 over the same 300ms
-           *  window as the width transition — revealing the solid
-           *  black backface beneath before the column clips away.
+           *  the parent panel at full opacity. The fade is timed
+           *  ASYMMETRICALLY against the 300ms width animation so the
+           *  black backface actually shows:
+           *    - Exiting (split→full): image fades 1→0 over the first
+           *      150ms with no delay. The remaining 150ms of the
+           *      width shrink runs against a now-empty (pure black)
+           *      backface, so the user sees "image fades into black,
+           *      black collapses to the right" — matching the
+           *      `.ipod-modern-split-art` comment. Without the
+           *      shorter fade, the image's opacity tracked the panel
+           *      width 1:1 and never resolved to pure black before
+           *      the column clipped away.
+           *    - Entering (full→split): image fades 0→1 over 150ms
+           *      after a 150ms delay. The panel column grows to its
+           *      final 50% width FIRST (so `object-cover` doesn't
+           *      keep re-cropping while it's wider every frame),
+           *      then the cover fades in against the now-stable
+           *      backface.
            *
            *  We render against `renderedSplitArtUrl` (the last non-null
            *  cover) instead of the live `splitArtUrl` so the image
@@ -1444,7 +1473,11 @@ export function IpodScreen({
             className={cn(
               "absolute inset-0",
               splitLayoutTransitionReady &&
-                `transition-opacity ${SPLIT_LAYOUT_TRANSITION_TIMING}`
+                "transition-opacity",
+              splitLayoutTransitionReady &&
+                (showSplitMenuArt
+                  ? SPLIT_ART_IMAGE_FADE_IN
+                  : SPLIT_ART_IMAGE_FADE_OUT)
             )}
             style={{ opacity: showSplitMenuArt ? 1 : 0 }}
           >


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary

Follow-up to #1197. PR #1197 kept the modern-UI split-art column mounted on every frame so its width could transition during menu → Now Playing (matching menu → Cover Flow), but the user reported the artwork still doesn't visibly resolve into a black backface — it still reads as a darkening image collapsing to the right, not as "image fades, black panel stays put".

### Demo

<a href="https://cursor.com/agents/bc-ac0d3260-1a99-4548-9fe9-468e4c228058/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fipod_split_demo.mp4"><img src="https://cursor.com/artifacts/c/art-46fd6fe7-ca28-429d-9bbe-2fb7173a802e" alt="ipod_split_demo.mp4" /></a>

Side-by-side, slowed 3× — left is the previous behavior (PR #1197), right is this PR. Same menu → Now Playing transition in both. The right clip clearly resolves to a pure-black column before the panel collapses; the left clip never does, the artwork just shrinks while staying dimly visible.

![iPod menu → Now Playing transition: BEFORE shows faded artwork on the right, AFTER shows pure-black backface](https://cursor.com/artifacts/c/art-3a3a7aeb-48ab-44a2-b126-a61c2ab3f448)

Mid-transition still: BEFORE keeps a recognizable cover image on the right (warm tones, "Christmas Star" text); AFTER shows a clean black column collapsing rightward.

### Root cause

The column-width shrink and the cover-image opacity were both on the same `duration-300 ease-in-out` curve. The visible split-art column at any moment is bounded by the menu panel's width growth (50% ↔ 100%), so:

| t (post-click) | menu width | visible split-art width | image opacity |
|---|---|---|---|
| 75ms  | ~62.5% | ~37.5% | ~0.83 |
| 150ms | ~75%   | ~25%   | ~0.50 |
| 225ms | ~87.5% | ~12.5% | ~0.22 |
| 300ms | 100%   | 0%     | 0     |

The image's alpha effectively **tracks the panel collapse 1:1**. At every frame the visible right-edge column shows a darkened image (`opacity * image + (1-opacity) * black`), never a pure-black backface. By the time the image is at 0 opacity, the column is also 0px wide — so the "black backface" the comment promises is never actually visible.

### Change

Decouple the cover image's fade timing from the panel-width shrink. Two new directional timing constants drive the inner opacity layer:

- **Exit** (`SPLIT_ART_IMAGE_FADE_OUT`, e.g. menu → now-playing, menu → Cover Flow, menu → leaf list): `transition-opacity duration-150 delay-0`. Image fades 1 → 0 in the **first 150ms** of the 300ms window. The remaining 150ms of the panel-width shrink runs against an empty (pure black) backface — so the user actually sees "cover fades, black panel collapses to the right".
- **Entry** (`SPLIT_ART_IMAGE_FADE_IN`, e.g. full-menu → split-menu): `transition-opacity duration-150 delay-150`. The column grows to its final width FIRST, then the cover fades in over the last 150ms against the now-stable backface. Without the delay, `object-cover` would keep re-cropping the image every frame as the column widened.

The outer column's `transition-[width]` and the menu panel's `transition-[width,box-shadow]` continue to use the shared `SPLIT_LAYOUT_TRANSITION_TIMING` (300ms ease-in-out) — no change to the chrome-width animation; menu → Cover Flow chrome timing is preserved bit-for-bit.

`src/apps/ipod/components/IpodScreen.tsx` — only file changed.

### Testing

- ✅ `bun run build` — TypeScript + Vite build passes (15.08s).
- Captured the menu → Now Playing transition with Playwright video recording against a live full-stack dev server (105 tracks loaded from Redis cache), once on `main` (PR #1197 head) and once on this branch. Per-frame `getComputedStyle` sampling confirms:
  - `splitArtCS.transition` still `width 0.3s cubic-bezier(0.4, 0, 0.2, 1)` (unchanged).
  - `inner.transition` now `opacity 0.15s` (was `0.3s` on `main`).
  - `splitArtCS.backgroundColor` stays `rgb(0, 0, 0)` for the full window.
- 30fps frame-by-frame extraction shows the AFTER clip has at least one frame with a clean pure-black panel on the right; BEFORE never does (the image is always at least faintly visible during the entire collapse).
- Pure CSS-class change inside the existing modern-UI iPod screen layout. No new state, no new DOM nodes, no new motion components. Classic / karaoke skins are unaffected — split art is modern-UI only.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ac0d3260-1a99-4548-9fe9-468e4c228058"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ac0d3260-1a99-4548-9fe9-468e4c228058"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

