### PR TITLE
ipod(modern): nudge titlebar play/pause up 1px + soften split gutter

### DIFF
--- a/src/apps/ipod/components/CoverFlow.tsx
+++ b/src/apps/ipod/components/CoverFlow.tsx
@@ -1044,11 +1044,11 @@ export const CoverFlow = forwardRef<CoverFlowRef, CoverFlowProps>(function Cover
               <div className="flex shrink-0 items-center gap-1">
                 <div
                   className={cn(
-                    // `-translate-y-px` matches the main IpodScreen
+                    // `translateY(-0.5px)` matches the main IpodScreen
                     // titlebar so the play/pause glyph reads as
                     // optically centered above the 1px bottom hairline
                     // (and isn't pulled low by its own 1px drop-shadow).
-                    "flex items-center justify-center w-[14px] h-[14px] -translate-y-px",
+                    "flex items-center justify-center w-[14px] h-[14px] [transform:translateY(-0.5px)]",
                     "[filter:drop-shadow(0_1px_0_rgba(255,255,255,0.9))]",
                   )}
                 >

--- a/src/apps/ipod/components/CoverFlow.tsx
+++ b/src/apps/ipod/components/CoverFlow.tsx
@@ -1044,7 +1044,11 @@ export const CoverFlow = forwardRef<CoverFlowRef, CoverFlowProps>(function Cover
               <div className="flex shrink-0 items-center gap-1">
                 <div
                   className={cn(
-                    "flex items-center justify-center w-[14px] h-[14px]",
+                    // `-translate-y-px` matches the main IpodScreen
+                    // titlebar so the play/pause glyph reads as
+                    // optically centered above the 1px bottom hairline
+                    // (and isn't pulled low by its own 1px drop-shadow).
+                    "flex items-center justify-center w-[14px] h-[14px] -translate-y-px",
                     "[filter:drop-shadow(0_1px_0_rgba(255,255,255,0.9))]",
                   )}
                 >

--- a/src/apps/ipod/components/IpodScreen.tsx
+++ b/src/apps/ipod/components/IpodScreen.tsx
@@ -791,9 +791,15 @@ export function IpodScreen({
             // a single sharp shape on any DPI. Sized at 14px to
             // dominate the 17px titlebar (visually matches the title
             // type x-height + ascender).
+            //
+            // `-translate-y-px` nudges the glyph up 1px to compensate
+            // for the titlebar's 1px inset bottom hairline + the icon's
+            // own downward `drop-shadow(0 1px 0 …)`, which together
+            // pulled the shape's optical center half a pixel below the
+            // titlebar's visible (above-the-hairline) midline.
             <div
               className={cn(
-                "flex items-center justify-center w-[14px] h-[14px]",
+                "flex items-center justify-center w-[14px] h-[14px] -translate-y-px",
                 // Same light top highlight as the title line — title uses
                 // [text-shadow:0_1px_0_rgba(255,255,255,0.9)]; SVG paths
                 // use filter drop-shadow so the blue gradient reads with

--- a/src/apps/ipod/components/IpodScreen.tsx
+++ b/src/apps/ipod/components/IpodScreen.tsx
@@ -792,14 +792,16 @@ export function IpodScreen({
             // dominate the 17px titlebar (visually matches the title
             // type x-height + ascender).
             //
-            // `-translate-y-px` nudges the glyph up 1px to compensate
-            // for the titlebar's 1px inset bottom hairline + the icon's
-            // own downward `drop-shadow(0 1px 0 …)`, which together
-            // pulled the shape's optical center half a pixel below the
-            // titlebar's visible (above-the-hairline) midline.
+            // `translateY(-0.5px)` nudges the glyph up half a pixel
+            // to compensate for the titlebar's 1px inset bottom
+            // hairline + the icon's own downward
+            // `drop-shadow(0 1px 0 …)`, which together pulled the
+            // shape's optical center half a pixel below the titlebar's
+            // visible (above-the-hairline) midline. A full pixel
+            // overshoots and reads slightly high.
             <div
               className={cn(
-                "flex items-center justify-center w-[14px] h-[14px] -translate-y-px",
+                "flex items-center justify-center w-[14px] h-[14px] [transform:translateY(-0.5px)]",
                 // Same light top highlight as the title line — title uses
                 // [text-shadow:0_1px_0_rgba(255,255,255,0.9)]; SVG paths
                 // use filter drop-shadow so the blue gradient reads with

--- a/src/index.css
+++ b/src/index.css
@@ -1523,9 +1523,9 @@ button.piano-key.piano-key[class*="bg-[#ff33ff]"] {
 .ipod-modern-split-art {
   background: #000;
   box-shadow:
-    inset 8px 0 12px -4px rgba(0, 0, 0, 0.65),
-    inset 3px 0 5px -1px rgba(0, 0, 0, 0.55),
-    inset 1px 0 0 rgba(0, 0, 0, 0.4);
+    inset 8px 0 12px -4px rgba(0, 0, 0, 0.40),
+    inset 3px 0 5px -1px rgba(0, 0, 0, 0.30),
+    inset 1px 0 0 rgba(0, 0, 0, 0.18);
 }
 
 /* LEFT-side menu surface in split mode: must clip its contents (so menu
@@ -1554,15 +1554,18 @@ button.piano-key.piano-key[class*="bg-[#ff33ff]"] {
     1px 0 0 rgba(0, 0, 0, 0);
 }
 
-/* Deeper, longer-throw shadow stack so the menu reads as a thick card
- * floating above the album art column — matches the heavy gutter
- * shadow visible in the iPod classic 6G/7G reference photo where the
- * cover artwork's left edge is noticeably darker than its center. */
+/* Long-throw shadow stack so the menu reads as a card floating above
+ * the album art column — matches the gutter shadow visible in the
+ * iPod classic 6G/7G reference photo where the cover artwork's left
+ * edge sits a touch darker than its center. Alphas are kept on the
+ * softer side so the seam never reads as a hard inked rule (the
+ * inset gutter on `.ipod-modern-split-art` adds the rest of the
+ * depth on top). */
 .ipod-modern-menu-panel.is-split {
   box-shadow:
-    8px 0 16px -2px rgba(0, 0, 0, 0.55),
-    4px 0 8px -1px rgba(0, 0, 0, 0.45),
-    1px 0 0 rgba(0, 0, 0, 0.35);
+    8px 0 16px -2px rgba(0, 0, 0, 0.32),
+    4px 0 8px -1px rgba(0, 0, 0, 0.22),
+    1px 0 0 rgba(0, 0, 0, 0.15);
 }
 
 .ipod-modern-split-art-img {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Two small fixes to the modern iPod chrome that landed in #1199:

### 1. Titlebar play/pause optical centering

The 14×14 play/pause SVG sat geometrically centered in the 17px modern titlebar, but the row carries a 1px inset bottom hairline (`box-shadow: inset 0 -1px 0 #7995a3`) and the icon itself paints a `drop-shadow(0 1px 0 …)` highlight. Both pull the visible content area's optical center about half a pixel above geometric center, so the glyph read as sitting low.

Applied `transform: translateY(-0.5px)` to both wrapper instances (main `IpodScreen` titlebar and the `CoverFlow` status bar). A full 1px overshot and made the icon read slightly high; 0.5px lands it on the perceived midline above the hairline.

### 2. Softer split-menu gutter shadow + right border

#1199 introduced a heavy three-layer inset gradient on `.ipod-modern-split-art` plus a deeper cast shadow on `.ipod-modern-menu-panel.is-split`. Combined, the two 1px hairlines at the seam stacked to ~0.61 alpha and the soft layers were blowing past the iPod 6G/7G reference photo. Dialed both stacks back roughly 40% so the gutter still reads as layered depth, just a touch lighter:

| layer | before | after |
|---|---|---|
| split-art inset 8/12/-4 | 0.65 | **0.40** |
| split-art inset 3/5/-1 | 0.55 | **0.30** |
| split-art inset 1/0/0 (right border on art) | 0.40 | **0.18** |
| menu-panel cast 8/16/-2 | 0.55 | **0.32** |
| menu-panel cast 4/8/-1 | 0.45 | **0.22** |
| menu-panel cast 1/0/0 (right border on menu) | 0.35 | **0.15** |

### Testing
- `bun run build` (clean)
- GUI verification skipped per `AGENTS.md` (cloud-specific cosmetic change). The sub-pixel transform + shadow-alpha edits are localized and the build ran clean.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a6cbf162-2210-4982-bb80-03da9a6a3564"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a6cbf162-2210-4982-bb80-03da9a6a3564"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

