### PR TITLE
Sync Apple Music user tokens via Redis

### DIFF
--- a/api/_utils/musickit-user-token.ts
+++ b/api/_utils/musickit-user-token.ts
@@ -1,0 +1,83 @@
+import type { Redis } from "./redis.js";
+
+export interface StoredMusicKitUserToken {
+  token: string;
+  updatedAt: string;
+}
+
+export const MUSICKIT_USER_TOKEN_MAX_LENGTH = 8192;
+
+export function musicKitUserTokenKey(username: string): string {
+  return `musickit:user-token:${username.toLowerCase()}`;
+}
+
+export function normalizeMusicKitUserToken(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const token = value.trim();
+  if (!token || token.length > MUSICKIT_USER_TOKEN_MAX_LENGTH) return null;
+  return token;
+}
+
+export function parseStoredMusicKitUserToken(
+  raw: string | StoredMusicKitUserToken | null
+): StoredMusicKitUserToken | null {
+  if (!raw) return null;
+
+  if (typeof raw === "string") {
+    try {
+      const parsed = JSON.parse(raw) as Partial<StoredMusicKitUserToken>;
+      const token = normalizeMusicKitUserToken(parsed.token);
+      if (!token) return null;
+      return {
+        token,
+        updatedAt:
+          typeof parsed.updatedAt === "string" ? parsed.updatedAt : "",
+      };
+    } catch {
+      const token = normalizeMusicKitUserToken(raw);
+      return token ? { token, updatedAt: "" } : null;
+    }
+  }
+
+  const token = normalizeMusicKitUserToken(raw.token);
+  if (!token) return null;
+  return {
+    token,
+    updatedAt: typeof raw.updatedAt === "string" ? raw.updatedAt : "",
+  };
+}
+
+export async function readMusicKitUserToken(
+  redis: Redis,
+  username: string
+): Promise<StoredMusicKitUserToken | null> {
+  const raw = await redis.get<string | StoredMusicKitUserToken>(
+    musicKitUserTokenKey(username)
+  );
+  return parseStoredMusicKitUserToken(raw);
+}
+
+export async function saveMusicKitUserToken(
+  redis: Redis,
+  username: string,
+  token: string
+): Promise<StoredMusicKitUserToken> {
+  const normalized = normalizeMusicKitUserToken(token);
+  if (!normalized) {
+    throw new Error("Invalid Apple Music user token");
+  }
+
+  const stored: StoredMusicKitUserToken = {
+    token: normalized,
+    updatedAt: new Date().toISOString(),
+  };
+  await redis.set(musicKitUserTokenKey(username), JSON.stringify(stored));
+  return stored;
+}
+
+export async function deleteMusicKitUserToken(
+  redis: Redis,
+  username: string
+): Promise<void> {
+  await redis.del(musicKitUserTokenKey(username));
+}

--- a/api/musickit-user-token.ts
+++ b/api/musickit-user-token.ts
@@ -1,0 +1,62 @@
+import { apiHandler } from "./_utils/api-handler.js";
+import {
+  deleteMusicKitUserToken,
+  normalizeMusicKitUserToken,
+  readMusicKitUserToken,
+  saveMusicKitUserToken,
+} from "./_utils/musickit-user-token.js";
+
+export const runtime = "nodejs";
+export const maxDuration = 10;
+
+interface MusicKitUserTokenBody {
+  token?: unknown;
+}
+
+export default apiHandler<MusicKitUserTokenBody>(
+  {
+    methods: ["GET", "PUT", "DELETE"],
+    auth: "required",
+    parseJsonBody: true,
+  },
+  async ({ req, res, redis, user, body }): Promise<void> => {
+    res.setHeader("Cache-Control", "no-store");
+
+    const username = user?.username || "";
+    const method = (req.method || "GET").toUpperCase();
+
+    if (method === "GET") {
+      const stored = await readMusicKitUserToken(redis, username);
+      if (!stored) {
+        res.status(200).json({ hasToken: false });
+        return;
+      }
+
+      res.status(200).json({
+        hasToken: true,
+        token: stored.token,
+        updatedAt: stored.updatedAt || null,
+      });
+      return;
+    }
+
+    if (method === "DELETE") {
+      await deleteMusicKitUserToken(redis, username);
+      res.status(200).json({ ok: true, hasToken: false });
+      return;
+    }
+
+    const token = normalizeMusicKitUserToken(body?.token);
+    if (!token) {
+      res.status(400).json({ error: "Invalid Apple Music user token" });
+      return;
+    }
+
+    const stored = await saveMusicKitUserToken(redis, username, token);
+    res.status(200).json({
+      ok: true,
+      hasToken: true,
+      updatedAt: stored.updatedAt,
+    });
+  }
+);

--- a/src/hooks/useMusicKit.ts
+++ b/src/hooks/useMusicKit.ts
@@ -406,7 +406,9 @@ export function useMusicKit(
         typeof event === "object" && event !== null && "token" in event
           ? (event as { token?: unknown }).token
           : undefined;
-      const token = normalizeMusicUserToken(tokenFromEvent ?? instance.musicUserToken);
+      const token = normalizeMusicUserToken(
+        tokenFromEvent ?? instance.musicUserToken
+      );
       if (token) {
         void saveSyncedMusicUserToken(token).catch((err) => {
           console.warn("[musickit] failed to save synced user token", err);

--- a/src/hooks/useMusicKit.ts
+++ b/src/hooks/useMusicKit.ts
@@ -397,14 +397,16 @@ export function useMusicKit(
   // shape across versions.
   useEffect(() => {
     if (!instance) return;
-    const refresh = (event?: { token?: string }) => {
+    const refresh = (event?: unknown) => {
       const authorized = Boolean(instance.isAuthorized);
       setIsAuthorized(authorized);
       if (!authorized) return;
 
-      const token = normalizeMusicUserToken(
-        event?.token ?? instance.musicUserToken
-      );
+      const tokenFromEvent =
+        typeof event === "object" && event !== null && "token" in event
+          ? (event as { token?: unknown }).token
+          : undefined;
+      const token = normalizeMusicUserToken(tokenFromEvent ?? instance.musicUserToken);
       if (token) {
         void saveSyncedMusicUserToken(token).catch((err) => {
           console.warn("[musickit] failed to save synced user token", err);

--- a/src/hooks/useMusicKit.ts
+++ b/src/hooks/useMusicKit.ts
@@ -18,6 +18,7 @@ import { useCallback, useEffect, useState } from "react";
 const MUSICKIT_SCRIPT_SRC = "https://js-cdn.music.apple.com/musickit/v3/musickit.js";
 const MUSICKIT_SCRIPT_ID = "ryos-musickit-js-v3";
 const MUSICKIT_TOKEN_ENDPOINT = "/api/musickit-token";
+const MUSICKIT_USER_TOKEN_ENDPOINT = "/api/musickit-user-token";
 const TOKEN_REFRESH_BUFFER_MS = 60 * 60 * 1000; // refresh if <1h left
 
 export type MusicKitStatus =
@@ -34,6 +35,8 @@ interface CachedDeveloperToken {
 
 let cachedDeveloperToken: CachedDeveloperToken | null = null;
 let inFlightTokenFetch: Promise<string> | null = null;
+let inFlightUserTokenFetch: Promise<string | null> | null = null;
+let lastPersistedUserToken: string | null = null;
 
 let scriptPromise: Promise<void> | null = null;
 let configurePromise: Promise<MusicKit.MusicKitInstance> | null = null;
@@ -114,6 +117,86 @@ async function resolveDeveloperToken(): Promise<string> {
     }
     throw err;
   }
+}
+
+function normalizeMusicUserToken(token: unknown): string | null {
+  if (typeof token !== "string") return null;
+  const trimmed = token.trim();
+  return trimmed ? trimmed : null;
+}
+
+async function fetchSyncedMusicUserToken(): Promise<string | null> {
+  if (typeof window === "undefined") return null;
+  if (inFlightUserTokenFetch) return inFlightUserTokenFetch;
+
+  inFlightUserTokenFetch = (async () => {
+    const res = await fetch(MUSICKIT_USER_TOKEN_ENDPOINT, {
+      method: "GET",
+      credentials: "same-origin",
+      headers: { Accept: "application/json" },
+    });
+
+    if (res.status === 401 || res.status === 403) return null;
+    if (!res.ok) {
+      throw new Error(`MusicKit user token endpoint returned ${res.status}`);
+    }
+
+    const data = (await res.json()) as {
+      hasToken?: boolean;
+      token?: unknown;
+    };
+    if (!data.hasToken) return null;
+    const token = normalizeMusicUserToken(data.token);
+    if (token) lastPersistedUserToken = token;
+    return token;
+  })();
+
+  try {
+    return await inFlightUserTokenFetch;
+  } catch (err) {
+    console.warn("[musickit] failed to load synced user token", err);
+    return null;
+  } finally {
+    inFlightUserTokenFetch = null;
+  }
+}
+
+async function saveSyncedMusicUserToken(token: string): Promise<void> {
+  const normalized = normalizeMusicUserToken(token);
+  if (!normalized || normalized === lastPersistedUserToken) return;
+
+  const res = await fetch(MUSICKIT_USER_TOKEN_ENDPOINT, {
+    method: "PUT",
+    credentials: "same-origin",
+    headers: {
+      Accept: "application/json",
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ token: normalized }),
+  });
+
+  if (res.status === 401 || res.status === 403) return;
+  if (!res.ok) {
+    throw new Error(`MusicKit user token save returned ${res.status}`);
+  }
+  lastPersistedUserToken = normalized;
+}
+
+async function deleteSyncedMusicUserToken(): Promise<void> {
+  const res = await fetch(MUSICKIT_USER_TOKEN_ENDPOINT, {
+    method: "DELETE",
+    credentials: "same-origin",
+    headers: { Accept: "application/json" },
+  });
+
+  if (res.status === 401 || res.status === 403) {
+    lastPersistedUserToken = null;
+    return;
+  }
+  if (!res.ok) {
+    throw new Error(`MusicKit user token delete returned ${res.status}`);
+  }
+  lastPersistedUserToken = null;
 }
 
 function loadScript(): Promise<void> {
@@ -197,7 +280,8 @@ function loadScript(): Promise<void> {
 
 async function configureMusicKit(
   developerToken: string,
-  app: MusicKit.AppMetadata
+  app: MusicKit.AppMetadata,
+  musicUserToken?: string | null
 ): Promise<MusicKit.MusicKitInstance> {
   if (configuredInstance) return configuredInstance;
   if (configurePromise) return configurePromise;
@@ -212,6 +296,7 @@ async function configureMusicKit(
       window.MusicKit!.configure({
         developerToken,
         app,
+        ...(musicUserToken ? { musicUserToken } : {}),
       })
     );
     const instance = result ?? window.MusicKit!.getInstance?.();
@@ -312,7 +397,20 @@ export function useMusicKit(
   // shape across versions.
   useEffect(() => {
     if (!instance) return;
-    const refresh = () => setIsAuthorized(Boolean(instance.isAuthorized));
+    const refresh = (event?: { token?: string }) => {
+      const authorized = Boolean(instance.isAuthorized);
+      setIsAuthorized(authorized);
+      if (!authorized) return;
+
+      const token = normalizeMusicUserToken(
+        event?.token ?? instance.musicUserToken
+      );
+      if (token) {
+        void saveSyncedMusicUserToken(token).catch((err) => {
+          console.warn("[musickit] failed to save synced user token", err);
+        });
+      }
+    };
     instance.addEventListener("authorizationStatusDidChange", refresh);
     instance.addEventListener("userTokenDidChange", refresh);
     refresh();
@@ -342,11 +440,14 @@ export function useMusicKit(
         if (cancelled) return;
         setHasToken(true);
 
+        const musicUserToken = await fetchSyncedMusicUserToken();
+        if (cancelled) return;
+
         await loadScript();
         if (cancelled) return;
 
         try {
-          const inst = await configureMusicKit(token, app);
+          const inst = await configureMusicKit(token, app, musicUserToken);
           if (cancelled) return;
           setInstance(inst);
           setIsAuthorized(Boolean(inst.isAuthorized));
@@ -383,6 +484,11 @@ export function useMusicKit(
     try {
       const token = await inst.authorize();
       setIsAuthorized(Boolean(inst.isAuthorized));
+      if (token) {
+        void saveSyncedMusicUserToken(token).catch((err) => {
+          console.warn("[musickit] failed to save synced user token", err);
+        });
+      }
       return token ?? null;
     } catch (err) {
       console.error("[musickit] authorize failed", err);
@@ -397,6 +503,9 @@ export function useMusicKit(
     try {
       await inst.unauthorize();
       setIsAuthorized(false);
+      void deleteSyncedMusicUserToken().catch((err) => {
+        console.warn("[musickit] failed to delete synced user token", err);
+      });
     } catch (err) {
       console.error("[musickit] unauthorize failed", err);
     }

--- a/tests/test-musickit-token.test.ts
+++ b/tests/test-musickit-token.test.ts
@@ -6,6 +6,15 @@ import {
   parseMusicKitPrivateKey,
   listMusicKitMissingEnv,
 } from "../api/_utils/_musickit-jwt";
+import {
+  deleteMusicKitUserToken,
+  musicKitUserTokenKey,
+  normalizeMusicKitUserToken,
+  parseStoredMusicKitUserToken,
+  readMusicKitUserToken,
+  saveMusicKitUserToken,
+} from "../api/_utils/musickit-user-token";
+import type { Redis } from "../api/_utils/redis";
 
 /**
  * Round-trip check: generate an ES256 key, sign a MusicKit JWT, and verify
@@ -27,6 +36,26 @@ function generateP8(): { pem: string; pkcs8: string } {
 }
 
 const ORIGINAL_ENV = { ...process.env };
+
+function createMockRedis(): Redis {
+  const store = new Map<string, unknown>();
+  return {
+    async get<T = unknown>(key: string): Promise<T | null> {
+      return (store.get(key) as T | undefined) ?? null;
+    },
+    async set(key: string, value: unknown): Promise<unknown> {
+      store.set(key, value);
+      return "OK";
+    },
+    async del(...keys: string[]): Promise<number> {
+      let removed = 0;
+      for (const key of keys) {
+        if (store.delete(key)) removed += 1;
+      }
+      return removed;
+    },
+  } as Redis;
+}
 
 describe("MusicKit JWT signer", () => {
   beforeEach(() => {
@@ -113,5 +142,44 @@ describe("MusicKit JWT signer", () => {
     expect(payload.origin).toBeUndefined();
     expect(payload.iss).toBe("TEAM_NO_ORIGIN");
     expect(payload.exp).toBeGreaterThan(Math.floor(Date.now() / 1000));
+  });
+});
+
+describe("MusicKit user token Redis storage", () => {
+  test("uses a normalized per-user Redis key", () => {
+    expect(musicKitUserTokenKey("Ryo")).toBe("musickit:user-token:ryo");
+  });
+
+  test("normalizes valid token strings and rejects invalid values", () => {
+    expect(normalizeMusicKitUserToken("  music-user-token  ")).toBe(
+      "music-user-token"
+    );
+    expect(normalizeMusicKitUserToken("")).toBeNull();
+    expect(normalizeMusicKitUserToken(null)).toBeNull();
+  });
+
+  test("saves, reads, and deletes a token in Redis", async () => {
+    const redis = createMockRedis();
+
+    const saved = await saveMusicKitUserToken(redis, "Ryo", " user-token ");
+    expect(saved.token).toBe("user-token");
+    expect(saved.updatedAt).toBeTruthy();
+
+    const loaded = await readMusicKitUserToken(redis, "ryo");
+    expect(loaded).toEqual(saved);
+
+    await deleteMusicKitUserToken(redis, "RYO");
+    expect(await readMusicKitUserToken(redis, "ryo")).toBeNull();
+  });
+
+  test("parses legacy raw-string values defensively", () => {
+    expect(parseStoredMusicKitUserToken("raw-token")).toEqual({
+      token: "raw-token",
+      updatedAt: "",
+    });
+    expect(parseStoredMusicKitUserToken("{not json")).toEqual({
+      token: "{not json",
+      updatedAt: "",
+    });
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add an authenticated MusicKit user-token API backed by Redis.
- Hydrate MusicKit configuration from the synced token and persist/delete token changes from the client.
- Cover MusicKit user-token storage helpers with Bun tests.

### Testing
- `bun test tests/test-musickit-token.test.ts`
- `bun run build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-05b955ef-3534-4b60-adca-99f1c7c73b64"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-05b955ef-3534-4b60-adca-99f1c7c73b64"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

