### PR TITLE
Default lyrics font to sans-serif (iPod + Karaoke)

### DIFF
--- a/src/apps/karaoke/components/KaraokeLyricsPlayback.tsx
+++ b/src/apps/karaoke/components/KaraokeLyricsPlayback.tsx
@@ -91,7 +91,7 @@ export function KaraokeLyricsPlaybackProvider({
   const appLanguage = i18n.resolvedLanguage ?? i18n.language;
   const elapsedTime = useKaraokeStore(useShallow((s) => s.elapsedTime));
 
-  const lyricsFontClassName = getLyricsFontClassName(lyricsFont ?? LyricsFontEnum.SerifRed);
+  const lyricsFontClassName = getLyricsFontClassName(lyricsFont ?? LyricsFontEnum.SansSerif);
 
   const selectedMatchForLyrics = useMemo(() => {
     if (!lyricsSourceOverride) return undefined;

--- a/src/apps/karaoke/components/KaraokeMenuBar.tsx
+++ b/src/apps/karaoke/components/KaraokeMenuBar.tsx
@@ -129,7 +129,7 @@ export function KaraokeMenuBar({
     exportLibrary,
   } = useIpodStoreShallow((s) => ({
     lyricsAlignment: s.lyricsAlignment ?? LyricsAlignment.FocusThree,
-    lyricsFont: s.lyricsFont ?? LyricsFont.SerifRed,
+    lyricsFont: s.lyricsFont ?? LyricsFont.SansSerif,
     romanization: s.romanization,
     lyricsTranslationLanguage: s.lyricsTranslationLanguage,
     displayMode: s.displayMode ?? DisplayMode.Video,

--- a/src/stores/useIpodStore.ts
+++ b/src/stores/useIpodStore.ts
@@ -367,7 +367,7 @@ const initialIpodData: IpodData = {
   lcdFilterOn: true,
   showLyrics: true,
   lyricsAlignment: LyricsAlignment.Alternating,
-  lyricsFont: LyricsFont.SerifRed,
+  lyricsFont: LyricsFont.SansSerif,
   koreanDisplay: KoreanDisplay.Original,
   japaneseFurigana: JapaneseFurigana.On,
   romanization: {
@@ -2251,8 +2251,8 @@ export const useIpodStore = create<IpodState>()(
             showLyrics: state.showLyrics ?? true,
             lyricsAlignment: state.lyricsAlignment ?? LyricsAlignment.Alternating,
             lyricsFont: shouldUpgradeLegacyDefaultLyricsFont
-              ? LyricsFont.SerifRed
-              : state.lyricsFont ?? LyricsFont.SerifRed,
+              ? LyricsFont.SansSerif
+              : state.lyricsFont ?? LyricsFont.SansSerif,
             displayMode: state.displayMode ?? DisplayMode.Video,
             koreanDisplay: state.koreanDisplay ?? KoreanDisplay.Original,
             japaneseFurigana: state.japaneseFurigana ?? JapaneseFurigana.On,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**Summary**

- **`useIpodStore`**: Default `lyricsFont` is now `LyricsFont.SansSerif`, so both iPod and Karaoke pick up the same shared preference. The historic persist migration path (`version < 31`, legacy `Serif` / missing font) now upgrades to **SansSerif** instead of Serif (red), and any missing `lyricsFont` during that migration falls back to **SansSerif** instead of Serif (red).
- **Karaoke**: `KaraokeLyricsPlayback` and `KaraokeMenuBar` use **SansSerif** when the store value is absent (defensive fallback).

Menu/radio options and font cycling are unchanged; users can still choose Serif (red), rounded, glow, gradient, etc.

**Testing**

- `bun run build` — pass.
- `bun run test:unit` — 219 tests pass.

**Note:** Profiles that already have `lyricsFont: serif-red` in localStorage keep that value until the user changes it or clears storage (no store version bump to avoid the heavy migrate side effects in this module).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-248c4db0-1e55-482d-9a08-6ceeeb8cf1dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-248c4db0-1e55-482d-9a08-6ceeeb8cf1dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

