### PR TITLE
Modern iPod now playing: square album art and reflection corners

### DIFF
--- a/src/apps/ipod/components/IpodScreen.tsx
+++ b/src/apps/ipod/components/IpodScreen.tsx
@@ -110,12 +110,14 @@ function formatPlaybackTime(totalSeconds: number): string {
  * stack stays inside the now-playing row. */
 const MODERN_NOW_PLAYING_ART_PX = 60;
 const MODERN_NOW_PLAYING_REFLECT_RATIO = 0.3;
+/** Shared clip radius for modern now-playing sleeve + reflection (modern skin only). */
+const MODERN_NOW_PLAYING_COVER_BORDER_RADIUS_PX = 0;
 // Neutral mid-gray placeholder shown while the cover image is in
 // flight. Cross-fades to the loaded image via `FadeInImage` so the
 // art panel never flashes from a near-black square to a cover.
 const MODERN_NOW_PLAYING_SLEEVE: CSSProperties = {
   background: "#a8a8a8",
-  borderRadius: "3px",
+  borderRadius: `${MODERN_NOW_PLAYING_COVER_BORDER_RADIUS_PX}px`,
 };
 const MODERN_NOW_PLAYING_REFLECT_IMG: CSSProperties = {
   transform: "scaleY(-1)",
@@ -124,7 +126,7 @@ const MODERN_NOW_PLAYING_REFLECT_IMG: CSSProperties = {
     "linear-gradient(to top, rgba(0, 0, 0, 1) 0%, transparent 50%)",
   WebkitMaskImage:
     "linear-gradient(to top, rgba(0, 0, 0, 1) 0%, transparent 50%)",
-  borderRadius: "3px",
+  borderRadius: `${MODERN_NOW_PLAYING_COVER_BORDER_RADIUS_PX}px`,
 };
 const MODERN_NOW_PLAYING_3D_PERSPECTIVE_PX = 180;
 /** Left→right perspective (rotate around vertical axis). Negate angle to mirror. */


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Modern iPod’s now-playing sleeve and its flipped reflection both used rounded corners (`3px` before). This change adds a shared `MODERN_NOW_PLAYING_COVER_BORDER_RADIUS_PX` set to **0px**, applied only in `ModernNowPlayingArtwork` (modern/color skin).

**Verification:** `bun run build`

**Risk:** Classic iPod layout does not render this component; split/Ken Burns and other surfaces are untouched.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a77a8780-7c77-48a1-8fe8-aeb11977d71b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a77a8780-7c77-48a1-8fe8-aeb11977d71b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

