### PR TITLE
fix(theme): restore Lucida Grande on chat meta in macOS X theme

### DIFF
--- a/src/styles/themes.css
+++ b/src/styles/themes.css
@@ -1081,12 +1081,18 @@
   line-height: 1 !important;
 }
 
-/* Chat meta (username/timestamp) override BEFORE generic Control Panels override anchor */
+/* Chat meta (username/timestamp) override BEFORE generic Control Panels override anchor.
+ * font-family override replaces the removed `:root[data-os-theme="macosx"] *` wildcard
+ * so the meta row uses Lucida Grande instead of the inline `font-['Geneva-9']` class
+ * (which would otherwise render the username + timestamp as pixelated bitmap text). */
 :root[data-os-theme="macosx"] .chat-messages-meta {
+  font-family: var(--os-font-ui) !important;
   font-size: 11px !important;
   line-height: 1.1 !important;
   padding-bottom: 0.5rem !important;
   padding-top: 0.5rem !important;
+  -webkit-font-smoothing: antialiased !important;
+  font-smooth: auto !important;
 }
 
 /* Control Panels sub text override - higher specificity */


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Regression introduced by the theme refactor (#1206). The chat message meta row (username + timestamp) is rendering as tiny pixelated Geneva-9 bitmap text on the macOS X (Aqua) theme instead of the smooth Lucida Grande it had before.

## Root cause

#1206 deleted this catch-all from `src/styles/themes.css`:

```css
:root[data-os-theme="macosx"] * {
  font-family: inherit;
}
```

That sledgehammer was previously flattening every explicit `font-family` declaration under the macOS X root to inherit the body's `--os-font-ui` (Lucida Grande). One thing it was silently neutralizing was the inline `font-['Geneva-9']` class on the chat meta row in `src/apps/chats/components/ChatMessages.tsx`:

```tsx
<div className={`${
  isMacOSTheme ? "text-[10px]" : "text-[16px]"
} chat-messages-meta text-gray-500 mb-0.5 font-['Geneva-9'] mb-[-2px] ...`}
```

Without the wildcard, `font-['Geneva-9']` now actually takes effect on macOS X, and the username + timestamp render as small pixelated bitmap text. The existing `:root[data-os-theme="macosx"] .chat-messages-meta` rule only adjusts `font-size` / `line-height` — it does not override `font-family`.

## Fix

Add an explicit `font-family: var(--os-font-ui)` (plus matching antialiasing) to the existing macOS X `.chat-messages-meta` override. Scoped to the chat meta row — does not reintroduce the global `*` wildcard the refactor intentionally removed, and does not touch component code.

```css
:root[data-os-theme="macosx"] .chat-messages-meta {
  font-family: var(--os-font-ui) !important;
  font-size: 11px !important;
  line-height: 1.1 !important;
  padding-bottom: 0.5rem !important;
  padding-top: 0.5rem !important;
  -webkit-font-smoothing: antialiased !important;
  font-smooth: auto !important;
}
```

## Walkthrough

Before — pixelated Geneva-9 bitmap text on the meta row:

![Chat meta row before fix (pixelated Geneva-9)](https://cursor.com/artifacts/c/art-7ef5a5cf-d481-4fdb-afcf-0ba6bc533b23)

After — smooth anti-aliased Lucida Grande matching the rest of the Aqua chrome:

![Chat meta row after fix (smooth Lucida Grande)](https://cursor.com/artifacts/c/art-f6bf55e7-d0d4-463b-964b-f552a5c5ddbd)

## Testing

- `bun run build` — clean
- Manual: ran `bun run dev:vite`, opened Chats on the macOS X theme, sent a message, and verified the "Ryo HH:MM" / "You HH:MM" meta rows now render in smooth Lucida Grande. Confirmed regression by stashing the change (text reverts to pixelated Geneva-9), then re-applying the fix.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-32d32ac5-1073-4639-aca6-8eb0ffb47c0b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-32d32ac5-1073-4639-aca6-8eb0ffb47c0b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

