### PR TITLE
fix(ipod): modern titlebar hairline vs. blue menu selection

### DIFF
--- a/src/apps/ipod/components/IpodScreen.tsx
+++ b/src/apps/ipod/components/IpodScreen.tsx
@@ -719,13 +719,11 @@ export function IpodScreen({
        *   play indicator on the left and battery on the right. */}
       <div
         className={cn(
-          // z-10 (NOT z-20) so the video / lyrics overlay (z-20) cleanly
-          // covers the titlebar when active — the user wants the screen
-          // to read as full-bleed video / lyrics with no chrome on top.
-          // In all other states (menu, now-playing without video, split
-          // menu) the titlebar still renders normally because nothing
-          // higher-z is drawn over it.
-          "shrink-0 py-0 flex items-center sticky top-0 z-10",
+          // Above menu / now-playing content (z-10) so the blue selection
+          // highlight cannot paint over the titlebar hairline. The parent
+          // panel stays z-10, so full-bleed video (sibling z-20) still
+          // stacks over this chrome when playing.
+          "shrink-0 py-0 flex items-center sticky top-0 z-20",
           isModernUi
             ? "ipod-modern-titlebar text-black font-ipod-modern-ui font-semibold pl-1.5 pr-1.5 gap-1.5"
             : "h-6 min-h-6 px-2 border-b border-[#0a3667] font-chicago text-[16px] text-[#0a3667] [text-shadow:1px_1px_0_rgba(0,0,0,0.15)]",
@@ -818,16 +816,18 @@ export function IpodScreen({
         </div>
       </div>
 
-      {/* Content area - z-30 only when video is not showing so it can
-          receive events. Content height subtracts the titlebar height
-          so the menu/now-playing area is the same in both skins.
+      {/* Content area - z-10 (below the titlebar z-20) when video is not
+          showing so list/now-playing paint under the silver header.
+          The screen wrapper stays above the z-0 video layer in menu mode
+          via the parent panel. Content height subtracts the titlebar
+          height so the menu/now-playing area is the same in both skins.
           Width clamps to the LEFT HALF of the screen when the split
           menu Ken Burns art column is showing so the menu list doesn't
           bleed under the album art. */}
       <div
         className={cn(
           "relative",
-          !showVideo && "z-30",
+          !showVideo && "z-10",
           isModernUi && showSplitMenuArt && "bg-white",
           isModernUi && "flex-1 min-h-0"
         )}

--- a/src/index.css
+++ b/src/index.css
@@ -1369,7 +1369,7 @@ button.piano-key.piano-key[class*="bg-[#ff33ff]"] {
  * gradients and hairlines match the established reference 1:1:
  *
  *   - Header: linear-gradient(180deg, #feffff 0%, #b1b6b9 100%)
- *             border-bottom: 1px solid #7995a3
+ *             bottom hairline: neutral gray (reference used #7995a3; ours is desaturated)
  *             15px black title (adjusted from reference for readability)
  *   - Selected row: linear-gradient(#3cb8ff 0%, #347ab5 100%)
  *                   white text, no shadow
@@ -1413,7 +1413,7 @@ button.piano-key.piano-key[class*="bg-[#ff33ff]"] {
 
 /* iPod-classic-js Header (sampled from app/components/Header/index.tsx):
  *   background: linear-gradient(180deg, #feffff 0%, #b1b6b9 100%);
- *   border-bottom: 1px solid #7995a3;
+ *   reference border-bottom was #7995a3 (slightly blue); we use a neutral gray.
  *
  * The modern titlebar is **21px** tall (`MENU_ITEM_HEIGHT_MODERN`, same rhythm as
  * the nano-style menu rows) — together with six 21px rows it fills the 150px
@@ -1423,7 +1423,7 @@ button.piano-key.piano-key[class*="bg-[#ff33ff]"] {
  * add height when the existing border-b utility is also present. */
 .ipod-modern-titlebar {
   background-image: linear-gradient(180deg, #feffff 0%, #b1b6b9 100%);
-  box-shadow: inset 0 -1px 0 #7995a3;
+  box-shadow: inset 0 -1px 0 #939393;
 }
 
 /* iPod-classic-js list rows are simple white cells with no separator —


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**Problem:** On the modern iPod skin, the silver status header’s bottom edge could read as a bright blue “border” on nested menus while the root **iPod** screen looked correct; the hairline color `#7995a3` also read slightly blue on its own.

**Cause:** The menu/now-playing content area used a higher stacking order (`z-30`) than the titlebar (`z-10`), so the first row’s blue selection highlight could composite over the header hairline. The reference hairline hex is also cyan-shifted.

**Change:** (1) Titlebar is now `z-20` and the content area `z-10` when video is not showing, so the header paints above the list. (2) `.ipod-modern-titlebar` inset hairline uses neutral gray `#939393` instead of `#7995a3`. The parent panel remains `z-10`, so full-bleed playback (video overlay at `z-20`) still stacks above this chrome.

**Testing:** `bun run build` succeeds on this branch.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-aea4feac-b996-4998-ac26-da2cc9239640"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-aea4feac-b996-4998-ac26-da2cc9239640"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

