### PR TITLE
Fix missing effect cleanups for timers and listeners

### DIFF
--- a/src/apps/chats/components/ChatInput.tsx
+++ b/src/apps/chats/components/ChatInput.tsx
@@ -225,11 +225,12 @@ export const ChatInput = memo(function ChatInput({
     // This ensures we wait for BOTH loading AND speech to complete
     if (wasBusy && isNowDone) {
       // Auto-start recording after a small delay
-      setTimeout(() => {
+      const timeoutId = setTimeout(() => {
         if (!isRecording && !isTranscribing) {
           audioButtonRef.current?.click();
         }
       }, 300);
+      return () => clearTimeout(timeoutId);
     }
   }, [isLoading, isSpeechPlaying, isInKeepTalkingMode, keepTalkingEnabled, isRecording, isTranscribing]);
 

--- a/src/apps/chats/hooks/useAiChat.ts
+++ b/src/apps/chats/hooks/useAiChat.ts
@@ -2113,6 +2113,7 @@ export function useAiChat(onPromptSetUsername?: () => void) {
     if (progress >= content.length) return;
 
     let scanPos = progress;
+    const highlightTimeoutIds: ReturnType<typeof setTimeout>[] = [];
     const processChunk = (endPos: number) => {
       const rawChunk = content.slice(scanPos, endPos);
       const cleaned = cleanTextForSpeech(rawChunk);
@@ -2121,11 +2122,12 @@ export function useAiChat(onPromptSetUsername?: () => void) {
         highlightQueueRef.current.push(seg);
         if (!highlightSegment) {
           // Delay highlighting slightly so text sync aligns closer to actual speech start
-          setTimeout(() => {
+          const highlightTimeoutId = setTimeout(() => {
             if (highlightQueueRef.current[0] === seg) {
               setHighlightSegment(seg);
             }
           }, 80);
+          highlightTimeoutIds.push(highlightTimeoutId);
         }
 
         speak(cleaned, () => {
@@ -2155,6 +2157,9 @@ export function useAiChat(onPromptSetUsername?: () => void) {
       // Record updated progress so subsequent effect runs start after the newline
       speechProgressRef.current[lastMsg.id] = scanPos;
     }
+    return () => {
+      highlightTimeoutIds.forEach((timeoutId) => clearTimeout(timeoutId));
+    };
   }, [currentSdkMessages, isLoading, speechEnabled, speak, highlightSegment]);
 
   // Clear rate limit error when username is set

--- a/src/apps/internet-explorer/hooks/useInternetExplorerLogic.ts
+++ b/src/apps/internet-explorer/hooks/useInternetExplorerLogic.ts
@@ -1405,6 +1405,15 @@ export function useInternetExplorerLogic({
   }, [url, stripProtocol]);
 
   useEffect(() => {
+    const timeoutIds: ReturnType<typeof setTimeout>[] = [];
+    const scheduleTimeout = (callback: () => void, delay: number) => {
+      const timeoutId = setTimeout(callback, delay);
+      timeoutIds.push(timeoutId);
+    };
+    const clearScheduledTimeouts = () => {
+      timeoutIds.forEach((timeoutId) => clearTimeout(timeoutId));
+    };
+
     // Only run initial navigation logic once when the window opens
     if (!initialNavigationRef.current && isWindowOpen) {
       initialNavigationRef.current = true;
@@ -1431,7 +1440,7 @@ export function useInternetExplorerLogic({
             duration: 4000,
           });
           // Navigate using decoded data
-          setTimeout(() => {
+          scheduleTimeout(() => {
             handleNavigate(
               decodedData.url,
               decodedData.year || "current",
@@ -1444,7 +1453,7 @@ export function useInternetExplorerLogic({
           }, 0);
           // Mark this initialData as processed
           lastProcessedInitialDataRef.current = initialData;
-          return; // Skip other initial navigation
+          return clearScheduledTimeouts; // Skip other initial navigation
         } else {
           console.warn(
             "[IE] Failed to decode share link code from initialData prop."
@@ -1472,7 +1481,7 @@ export function useInternetExplorerLogic({
         setUrl(initialUrl);
         setYear(initialYear);
         // --- END FIX ---
-        setTimeout(() => {
+        scheduleTimeout(() => {
           // --- FIX: Pass initialUrl and initialYear directly ---
           handleNavigate(initialUrl, initialYear, false);
           // Clear initialData after navigation is initiated
@@ -1483,16 +1492,17 @@ export function useInternetExplorerLogic({
         }, 0);
         // Mark this initialData as processed
         lastProcessedInitialDataRef.current = initialData;
-        return; // Skip default navigation
+        return clearScheduledTimeouts; // Skip default navigation
       }
       // --- END NEW ---
 
       // Proceed with default navigation if not a share link or if decoding failed
       console.log("[IE] Proceeding with default navigation.");
-      setTimeout(() => {
+      scheduleTimeout(() => {
         handleNavigate(url, year, false);
       }, 0);
     }
+    return clearScheduledTimeouts;
   }, [
     initialData,
     isWindowOpen,
@@ -1507,6 +1517,8 @@ export function useInternetExplorerLogic({
 
   // --- Watch for initialData changes when app is already open ---
   useEffect(() => {
+    let timeoutId: ReturnType<typeof setTimeout> | null = null;
+
     // Only react to initialData changes if the window is already open and we have initialData
     if (!isWindowOpen || !initialData) return;
 
@@ -1538,7 +1550,7 @@ export function useInternetExplorerLogic({
             }`,
             duration: 4000,
           });
-          setTimeout(() => {
+          timeoutId = setTimeout(() => {
             handleNavigate(
               decodedData.url,
               decodedData.year || "current",
@@ -1566,7 +1578,7 @@ export function useInternetExplorerLogic({
           `[IE] Navigating to direct url/year: ${navUrl} (${navYear})`
         );
 
-        setTimeout(() => {
+        timeoutId = setTimeout(() => {
           handleNavigate(navUrl, navYear, false);
           // Clear initialData after navigation
           if (instanceId) {
@@ -1577,6 +1589,11 @@ export function useInternetExplorerLogic({
         lastProcessedInitialDataRef.current = initialData;
       }
     }
+    return () => {
+      if (timeoutId !== null) {
+        clearTimeout(timeoutId);
+      }
+    };
   }, [
     isWindowOpen,
     initialData,
@@ -1587,6 +1604,16 @@ export function useInternetExplorerLogic({
 
   // --- Add listener for updateApp event (handles share links when app is already open) ---
   useEffect(() => {
+    const timeoutIds = new Set<ReturnType<typeof setTimeout>>();
+    const scheduleTimeout = (callback: () => void, delay: number) => {
+      const timeoutId = setTimeout(() => {
+        timeoutIds.delete(timeoutId);
+        callback();
+      }, delay);
+      timeoutIds.add(timeoutId);
+      return timeoutId;
+    };
+
     // Define a type for the initialData expected in the event detail
     interface AppUpdateInitialData {
       shareCode?: string;
@@ -1632,7 +1659,7 @@ export function useInternetExplorerLogic({
               duration: 4000,
             });
             // Use timeout to allow potential state updates (like foreground) to settle
-            setTimeout(() => {
+            scheduleTimeout(() => {
               handleNavigate(
                 decodedData.url,
                 decodedData.year || "current",
@@ -1660,7 +1687,7 @@ export function useInternetExplorerLogic({
           );
 
           // Use timeout to allow potential state updates (like foreground) to settle
-          setTimeout(() => {
+          scheduleTimeout(() => {
             handleNavigate(directUrl, directYear, false);
           }, 50); // Small delay
           // Mark this initialData as processed
@@ -1670,7 +1697,12 @@ export function useInternetExplorerLogic({
       }
     };
 
-    return onAppUpdate(handleUpdateApp);
+    const unsubscribe = onAppUpdate(handleUpdateApp);
+    return () => {
+      unsubscribe();
+      timeoutIds.forEach((timeoutId) => clearTimeout(timeoutId));
+      timeoutIds.clear();
+    };
     // Add isForeground to dependencies to refresh navigation when focus changes
   }, [handleNavigate, isForeground, instanceId]);
   // --- End updateApp listener ---

--- a/src/apps/ipod/components/screen/BatteryIndicator.tsx
+++ b/src/apps/ipod/components/screen/BatteryIndicator.tsx
@@ -18,12 +18,16 @@ export function BatteryIndicator({
   const [animationFrame, setAnimationFrame] = useState<number>(1);
 
   useEffect(() => {
+    let removeBatteryListeners: (() => void) | undefined;
+    let isDisposed = false;
+
     const getBattery = async () => {
       try {
         if ("getBattery" in navigator) {
           const battery = await (
             navigator as unknown as { getBattery: () => Promise<BatteryManager> }
           ).getBattery();
+          if (isDisposed) return;
           setBatteryLevel(battery.level);
           setIsCharging(battery.charging);
 
@@ -33,19 +37,25 @@ export function BatteryIndicator({
           battery.addEventListener("levelchange", updateLevel);
           battery.addEventListener("chargingchange", updateCharging);
 
-          return () => {
+          removeBatteryListeners = () => {
             battery.removeEventListener("levelchange", updateLevel);
             battery.removeEventListener("chargingchange", updateCharging);
           };
         }
       } catch {
+        if (isDisposed) return;
         // Fallback to a default level
         setBatteryLevel(1.0);
         setIsCharging(false);
       }
     };
 
-    getBattery();
+    void getBattery();
+
+    return () => {
+      isDisposed = true;
+      removeBatteryListeners?.();
+    };
   }, []);
 
   // Animation effect for charging

--- a/src/apps/ipod/hooks/useIpodLogic.ts
+++ b/src/apps/ipod/hooks/useIpodLogic.ts
@@ -1304,6 +1304,8 @@ export function useIpodLogic({
   // Using null as initial value ensures first render triggers the auto-skip check
   const prevCurrentIndexRef = useRef<number | null>(null);
   useEffect(() => {
+    let timeoutId: ReturnType<typeof setTimeout> | null = null;
+
     // Check if track changed or this is initial render (prevCurrentIndexRef.current is null)
     if (prevCurrentIndexRef.current !== currentIndex) {
       isTrackSwitchingRef.current = true;
@@ -1325,7 +1327,7 @@ export function useIpodLogic({
       if (newLyricOffset < 0 && seekTarget >= 1) {
         useIpodStore.getState().setElapsedTime(seekTarget);
         
-        trackSwitchTimeoutRef.current = setTimeout(() => {
+        timeoutId = setTimeout(() => {
           isTrackSwitchingRef.current = false;
           const activePlayer = isFullScreen ? fullScreenPlayerRef.current : playerRef.current;
           if (activePlayer) {
@@ -1333,15 +1335,25 @@ export function useIpodLogic({
             showStatus(`▶ ${Math.floor(seekTarget / 60)}:${String(Math.floor(seekTarget % 60)).padStart(2, "0")}`);
           }
         }, 2000);
+        trackSwitchTimeoutRef.current = timeoutId;
       } else {
         // Start from beginning for positive/zero offset or small negative offset
         useIpodStore.getState().setElapsedTime(0);
-        trackSwitchTimeoutRef.current = setTimeout(() => {
+        timeoutId = setTimeout(() => {
           isTrackSwitchingRef.current = false;
         }, 2000);
+        trackSwitchTimeoutRef.current = timeoutId;
       }
     }
     prevCurrentIndexRef.current = currentIndex;
+    return () => {
+      if (timeoutId !== null) {
+        clearTimeout(timeoutId);
+        if (trackSwitchTimeoutRef.current === timeoutId) {
+          trackSwitchTimeoutRef.current = null;
+        }
+      }
+    };
   }, [currentIndex, tracks, isFullScreen, showStatus]);
 
   // Cleanup status timeout
@@ -2706,11 +2718,13 @@ export function useIpodLogic({
 
   // Initial data handling
   useEffect(() => {
+    let timeoutId: ReturnType<typeof setTimeout> | null = null;
+
     if (isWindowOpen && initialData?.videoId && typeof initialData.videoId === "string") {
       if (lastProcessedInitialDataRef.current === initialData) return;
 
       const videoIdToProcess = initialData.videoId;
-      setTimeout(() => {
+      timeoutId = setTimeout(() => {
         processVideoId(videoIdToProcess)
           .then(() => {
             if (instanceId) clearIpodInitialData(instanceId);
@@ -2721,9 +2735,16 @@ export function useIpodLogic({
       }, 100);
       lastProcessedInitialDataRef.current = initialData;
     }
+    return () => {
+      if (timeoutId !== null) {
+        clearTimeout(timeoutId);
+      }
+    };
   }, [isWindowOpen, initialData, processVideoId, clearIpodInitialData, instanceId]);
 
   useEffect(() => {
+    let timeoutId: ReturnType<typeof setTimeout> | null = null;
+
     if (
       isWindowOpen &&
       initialData?.listenSessionId &&
@@ -2732,7 +2753,7 @@ export function useIpodLogic({
       if (lastProcessedListenSessionRef.current === initialData.listenSessionId) return;
 
       const sessionIdToProcess = initialData.listenSessionId;
-      setTimeout(() => {
+      timeoutId = setTimeout(() => {
         joinListenSession(sessionIdToProcess, username || undefined)
           .then((result) => {
             if (!result.ok) {
@@ -2748,6 +2769,11 @@ export function useIpodLogic({
       }, 100);
       lastProcessedListenSessionRef.current = initialData.listenSessionId;
     }
+    return () => {
+      if (timeoutId !== null) {
+        clearTimeout(timeoutId);
+      }
+    };
   }, [
     isWindowOpen,
     initialData,
@@ -3617,6 +3643,16 @@ export function useIpodLogic({
   const prevFullScreenRef = useRef(isFullScreen);
 
   useEffect(() => {
+    const timeoutIds = new Set<ReturnType<typeof setTimeout>>();
+    const scheduleTimeout = (callback: () => void, delay: number) => {
+      const timeoutId = setTimeout(() => {
+        timeoutIds.delete(timeoutId);
+        callback();
+      }, delay);
+      timeoutIds.add(timeoutId);
+      return timeoutId;
+    };
+
     if (isFullScreen !== prevFullScreenRef.current) {
       // Apple Music plays through a single shared MusicKit instance, so
       // toggling fullscreen never needs the YouTube-style seek-and-resume
@@ -3651,21 +3687,21 @@ export function useIpodLogic({
                 }
               }
               // End track switch after sync complete
-              trackSwitchTimeoutRef.current = setTimeout(() => {
+              trackSwitchTimeoutRef.current = scheduleTimeout(() => {
                 isTrackSwitchingRef.current = false;
               }, 500);
               return;
             }
           }
           // Player not ready, retry
-          setTimeout(checkAndSync, 100);
+          scheduleTimeout(checkAndSync, 100);
         };
-        setTimeout(checkAndSync, 100);
+        scheduleTimeout(checkAndSync, 100);
       } else {
         const currentTime = fullScreenPlayerRef.current?.getCurrentTime() || elapsedTime;
         const wasPlaying = isPlaying;
 
-        setTimeout(() => {
+        scheduleTimeout(() => {
           if (playerRef.current) {
             playerRef.current.seekTo(currentTime);
             if (wasPlaying && !useIpodStore.getState().isPlaying) {
@@ -3673,13 +3709,17 @@ export function useIpodLogic({
             }
           }
           // End track switch after sync complete
-          trackSwitchTimeoutRef.current = setTimeout(() => {
+          trackSwitchTimeoutRef.current = scheduleTimeout(() => {
             isTrackSwitchingRef.current = false;
           }, 500);
         }, 200);
       }
       prevFullScreenRef.current = isFullScreen;
     }
+    return () => {
+      timeoutIds.forEach((timeoutId) => clearTimeout(timeoutId));
+      timeoutIds.clear();
+    };
   }, [isAppleMusic, isFullScreen, elapsedTime, isPlaying, setIsPlaying, isIOSSafari]);
 
   // Seek time for fullscreen (delta)

--- a/src/apps/karaoke/hooks/useKaraokeLogic.ts
+++ b/src/apps/karaoke/hooks/useKaraokeLogic.ts
@@ -578,6 +578,8 @@ export function useKaraokeLogic({
   // Using null as initial value ensures first render triggers the auto-skip check
   const prevCurrentIndexRef = useRef<number | null>(null);
   useEffect(() => {
+    let timeoutId: ReturnType<typeof setTimeout> | null = null;
+
     // Check if track changed or this is initial render (prevCurrentIndexRef.current is null)
     if (prevCurrentIndexRef.current !== currentIndex) {
       isTrackSwitchingRef.current = true;
@@ -599,7 +601,7 @@ export function useKaraokeLogic({
       if (newLyricOffset < 0 && seekTarget >= 1) {
         setStoreElapsedTime(seekTarget);
         
-        trackSwitchTimeoutRef.current = setTimeout(() => {
+        timeoutId = setTimeout(() => {
           isTrackSwitchingRef.current = false;
           const activePlayer = isFullScreen ? fullScreenPlayerRef.current : playerRef.current;
           if (activePlayer) {
@@ -607,15 +609,25 @@ export function useKaraokeLogic({
             showStatus(`▶ ${Math.floor(seekTarget / 60)}:${String(Math.floor(seekTarget % 60)).padStart(2, "0")}`);
           }
         }, 2000);
+        trackSwitchTimeoutRef.current = timeoutId;
       } else {
         // Start from beginning for positive/zero offset or small negative offset
         setStoreElapsedTime(0);
-        trackSwitchTimeoutRef.current = setTimeout(() => {
+        timeoutId = setTimeout(() => {
           isTrackSwitchingRef.current = false;
         }, 2000);
+        trackSwitchTimeoutRef.current = timeoutId;
       }
     }
     prevCurrentIndexRef.current = currentIndex;
+    return () => {
+      if (timeoutId !== null) {
+        clearTimeout(timeoutId);
+        if (trackSwitchTimeoutRef.current === timeoutId) {
+          trackSwitchTimeoutRef.current = null;
+        }
+      }
+    };
   }, [currentIndex, tracks, isFullScreen, showStatus, setStoreElapsedTime]);
 
   // Cleanup
@@ -661,6 +673,16 @@ export function useKaraokeLogic({
   const prevFullScreenRef = useRef(isFullScreen);
 
   useEffect(() => {
+    const timeoutIds = new Set<ReturnType<typeof setTimeout>>();
+    const scheduleTimeout = (callback: () => void, delay: number) => {
+      const timeoutId = setTimeout(() => {
+        timeoutIds.delete(timeoutId);
+        callback();
+      }, delay);
+      timeoutIds.add(timeoutId);
+      return timeoutId;
+    };
+
     if (isFullScreen !== prevFullScreenRef.current) {
       // Mark as track switching to prevent spurious play/pause events during sync
       isTrackSwitchingRef.current = true;
@@ -686,23 +708,23 @@ export function useKaraokeLogic({
                 internalPlayer.playVideo();
               }
               // End track switch after sync complete
-              trackSwitchTimeoutRef.current = setTimeout(() => {
+              trackSwitchTimeoutRef.current = scheduleTimeout(() => {
                 isTrackSwitchingRef.current = false;
               }, 500);
               return;
             }
           }
           // Player not ready, retry
-          setTimeout(checkAndSync, 100);
+          scheduleTimeout(checkAndSync, 100);
         };
-        setTimeout(checkAndSync, 100);
+        scheduleTimeout(checkAndSync, 100);
       } else {
         trackAnalytics(MEDIA_ANALYTICS.FULLSCREEN, { appId: "karaoke", isOpen: false });
         // Exiting fullscreen - sync position from fullscreen player to main player
         const currentTime = fullScreenPlayerRef.current?.getCurrentTime() ?? useKaraokeStore.getState().elapsedTime;
         const wasPlaying = isPlaying;
 
-        setTimeout(() => {
+        scheduleTimeout(() => {
           if (playerRef.current) {
             playerRef.current.seekTo(currentTime);
             if (wasPlaying) {
@@ -710,13 +732,17 @@ export function useKaraokeLogic({
             }
           }
           // End track switch after sync complete
-          trackSwitchTimeoutRef.current = setTimeout(() => {
+          trackSwitchTimeoutRef.current = scheduleTimeout(() => {
             isTrackSwitchingRef.current = false;
           }, 500);
         }, 200);
       }
       prevFullScreenRef.current = isFullScreen;
     }
+    return () => {
+      timeoutIds.forEach((timeoutId) => clearTimeout(timeoutId));
+      timeoutIds.clear();
+    };
   }, [isFullScreen, isPlaying, setIsPlaying]);
 
   // Handle closing sync mode - flush pending offset saves
@@ -1453,11 +1479,13 @@ export function useKaraokeLogic({
 
   // Handle initial data (shared track) - process video ID to add/play
   useEffect(() => {
+    let timeoutId: ReturnType<typeof setTimeout> | null = null;
+
     if (isWindowOpen && initialData?.videoId && typeof initialData.videoId === "string") {
       if (lastProcessedInitialDataRef.current === initialData) return;
 
       const videoIdToProcess = initialData.videoId;
-      setTimeout(() => {
+      timeoutId = setTimeout(() => {
         processVideoId(videoIdToProcess)
           .then(() => {
             if (instanceId) clearInstanceInitialData(instanceId);
@@ -1477,6 +1505,11 @@ export function useKaraokeLogic({
       // Reset to first track if current song no longer exists in library
       setCurrentSongId(tracks[0]?.id ?? null);
     }
+    return () => {
+      if (timeoutId !== null) {
+        clearTimeout(timeoutId);
+      }
+    };
   }, [
     isWindowOpen,
     initialData,
@@ -1490,6 +1523,8 @@ export function useKaraokeLogic({
   ]);
 
   useEffect(() => {
+    let timeoutId: ReturnType<typeof setTimeout> | null = null;
+
     if (
       isWindowOpen &&
       initialData?.listenSessionId &&
@@ -1498,7 +1533,7 @@ export function useKaraokeLogic({
       if (lastProcessedListenSessionRef.current === initialData.listenSessionId) return;
 
       const sessionIdToProcess = initialData.listenSessionId;
-      setTimeout(() => {
+      timeoutId = setTimeout(() => {
         joinListenSession(sessionIdToProcess, username || undefined)
           .then((result) => {
             if (!result.ok) {
@@ -1514,6 +1549,11 @@ export function useKaraokeLogic({
       }, 100);
       lastProcessedListenSessionRef.current = initialData.listenSessionId;
     }
+    return () => {
+      if (timeoutId !== null) {
+        clearTimeout(timeoutId);
+      }
+    };
   }, [isWindowOpen, initialData, joinListenSession, username, clearInstanceInitialData, instanceId]);
 
   // Handle updateApp event for when app is already open and receives new video

--- a/src/apps/maps/components/MapsAppComponent.tsx
+++ b/src/apps/maps/components/MapsAppComponent.tsx
@@ -303,7 +303,14 @@ export function MapsAppComponent({
   // composite key so we can diff updates in-place without rebuilding the
   // entire annotation set on every store change.
   const savedAnnotationsRef = useRef<
-    Map<string, { annotation: MapKitMarkerAnnotation; place: SavedPlace }>
+    Map<
+      string,
+      {
+        annotation: MapKitMarkerAnnotation;
+        place: SavedPlace;
+        onSelect: () => void;
+      }
+    >
   >(new Map());
   const mapMarkersClusteredRef = useRef(false);
   const regionChangeEndListenerRef = useRef<(() => void) | null>(null);
@@ -431,6 +438,13 @@ export function MapsAppComponent({
     // a re-render so effects that read `mapInstanceRef.current` actually
     // see the new value instead of skipping it on a stale closure.
     setMapReadyTick((tick) => tick + 1);
+    return () => {
+      try {
+        map.removeEventListener?.("region-change-end", onRegionChangeEnd);
+      } catch {
+        // ignore
+      }
+    };
     // We intentionally do NOT depend on mapType here — the next effect
     // syncs it whenever the user picks a different option.
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -894,6 +908,11 @@ export function MapsAppComponent({
     // Drop all previously-attached saved annotations before re-adding.
     for (const value of savedAnnotationsRef.current.values()) {
       try {
+        value.annotation.removeEventListener?.("select", value.onSelect);
+      } catch {
+        // ignore — mapkit may have already detached
+      }
+      try {
         map.removeAnnotation(value.annotation);
       } catch {
         // ignore — mapkit may have already detached
@@ -901,7 +920,11 @@ export function MapsAppComponent({
     }
     const next = new Map<
       string,
-      { annotation: MapKitMarkerAnnotation; place: SavedPlace }
+      {
+        annotation: MapKitMarkerAnnotation;
+        place: SavedPlace;
+        onSelect: () => void;
+      }
     >();
 
     for (const entry of savedPlaceEntries) {
@@ -938,10 +961,10 @@ export function MapsAppComponent({
         withMapPlaceClustering(markerOptions, clusteringId)
       );
 
-      const wrapper = { annotation, place: entry.place };
       const handleSelect = () => {
-        focusSavedPlaceRef.current(wrapper.place);
+        focusSavedPlaceRef.current(entry.place);
       };
+      const wrapper = { annotation, place: entry.place, onSelect: handleSelect };
       annotation.addEventListener?.("select", handleSelect);
 
       try {
@@ -954,6 +977,15 @@ export function MapsAppComponent({
 
     savedAnnotationsRef.current = next;
     syncMapMarkerClustering();
+    return () => {
+      for (const value of next.values()) {
+        try {
+          value.annotation.removeEventListener?.("select", value.onSelect);
+        } catch {
+          // ignore
+        }
+      }
+    };
   }, [
     status,
     savedPlaceEntries,

--- a/src/apps/pc/hooks/useJsDos.ts
+++ b/src/apps/pc/hooks/useJsDos.ts
@@ -46,6 +46,8 @@ export function useJsDos() {
   const [isScriptLoaded, setIsScriptLoaded] = useState(isScriptLoadedRef);
 
   useEffect(() => {
+    let loadCheckTimeoutId: ReturnType<typeof setTimeout> | null = null;
+
     // Only load script if it hasn't been loaded yet
     if (!scriptRef && !window.Dos) {
       console.log("Loading js-dos script...");
@@ -55,10 +57,11 @@ export function useJsDos() {
       script.onload = () => {
         console.log("js-dos script loaded successfully");
         // Wait a bit to ensure the script is fully initialized
-        setTimeout(() => {
+        loadCheckTimeoutId = setTimeout(() => {
           console.log("Checking if Dos function is available:", !!window.Dos);
           isScriptLoadedRef = true;
           setIsScriptLoaded(true);
+          loadCheckTimeoutId = null;
         }, 1000);
       };
       script.onerror = (error) => {
@@ -72,6 +75,9 @@ export function useJsDos() {
     return () => {
       // Don't remove the script or clear the global Dos function
       // We want to keep it loaded for the entire app lifecycle
+      if (loadCheckTimeoutId !== null) {
+        clearTimeout(loadCheckTimeoutId);
+      }
     };
   }, []);
 

--- a/src/apps/photo-booth/hooks/usePhotoBoothLogic.ts
+++ b/src/apps/photo-booth/hooks/usePhotoBoothLogic.ts
@@ -594,6 +594,11 @@ export function usePhotoBoothLogic({
   // Force visibility refresh for Chrome
   useEffect(() => {
     if (!isChrome || !videoRef.current || !stream) return;
+    const timeoutIds: ReturnType<typeof setTimeout>[] = [];
+    const scheduleTimeout = (callback: () => void, delay: number) => {
+      const timeoutId = setTimeout(callback, delay);
+      timeoutIds.push(timeoutId);
+    };
 
     console.log("Applying Chrome-specific visibility fixes");
 
@@ -605,14 +610,14 @@ export function usePhotoBoothLogic({
       videoRef.current.style.visibility = "hidden";
       videoRef.current.style.display = "none";
 
-      setTimeout(() => {
+      scheduleTimeout(() => {
         if (videoRef.current) {
           videoRef.current.style.visibility = "visible";
           videoRef.current.style.display = "block";
 
           // Some Chrome versions need this nudge
           videoRef.current.style.opacity = "0.99";
-          setTimeout(() => {
+          scheduleTimeout(() => {
             if (videoRef.current) videoRef.current.style.opacity = "1";
           }, 50);
         }
@@ -620,8 +625,11 @@ export function usePhotoBoothLogic({
     };
 
     // Apply fix after a delay to let rendering settle
-    setTimeout(forceVisibility, 300);
-    setTimeout(forceVisibility, 1000);
+    scheduleTimeout(forceVisibility, 300);
+    scheduleTimeout(forceVisibility, 1000);
+    return () => {
+      timeoutIds.forEach((timeoutId) => clearTimeout(timeoutId));
+    };
   }, [stream, isChrome]);
 
   // Add event listener for the video element to handle Safari initialization

--- a/src/apps/videos/hooks/useVideosLogic.ts
+++ b/src/apps/videos/hooks/useVideosLogic.ts
@@ -921,6 +921,16 @@ export function useVideosLogic({
 
   // Sync playback position when entering fullscreen
   useEffect(() => {
+    const timeoutIds = new Set<ReturnType<typeof setTimeout>>();
+    const scheduleTimeout = (callback: () => void, delay: number) => {
+      const timeoutId = setTimeout(() => {
+        timeoutIds.delete(timeoutId);
+        callback();
+      }, delay);
+      timeoutIds.add(timeoutId);
+      return timeoutId;
+    };
+
     if (isFullScreen && !prevFullScreenRef.current) {
       // Just entered fullscreen - sync position from main player to fullscreen player
       const currentTime = playerRef.current?.getCurrentTime() || playedSeconds;
@@ -945,18 +955,22 @@ export function useVideosLogic({
             if (trackSwitchTimeoutRef.current) {
               clearTimeout(trackSwitchTimeoutRef.current);
             }
-            trackSwitchTimeoutRef.current = setTimeout(() => {
+            trackSwitchTimeoutRef.current = scheduleTimeout(() => {
               isTrackSwitchingRef.current = false;
             }, 500);
             return;
           }
         }
         // Player not ready yet, retry
-        setTimeout(checkAndSync, 100);
+        scheduleTimeout(checkAndSync, 100);
       };
-      setTimeout(checkAndSync, 100);
+      scheduleTimeout(checkAndSync, 100);
     }
     prevFullScreenRef.current = isFullScreen;
+    return () => {
+      timeoutIds.forEach((timeoutId) => clearTimeout(timeoutId));
+      timeoutIds.clear();
+    };
   }, [isFullScreen, playedSeconds, isPlaying]);
 
   // Listen for App Menu fullscreen toggle

--- a/src/components/layout/Dock.tsx
+++ b/src/components/layout/Dock.tsx
@@ -1915,55 +1915,49 @@ function MacDock() {
   // Disable magnification on mobile/touch (coarse pointer or no hover)
   const [magnifyEnabled, setMagnifyEnabled] = useState(true);
   useEffect(() => {
+    if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
+      setMagnifyEnabled(true);
+      return;
+    }
+
+    const mqlPointerCoarse = window.matchMedia("(pointer: coarse)");
+    const mqlHoverNone = window.matchMedia("(hover: none)");
     const compute = () => {
-      if (
-        typeof window === "undefined" ||
-        typeof window.matchMedia !== "function"
-      ) {
-        setMagnifyEnabled(true);
-        return;
-      }
-      const coarse = window.matchMedia("(pointer: coarse)").matches;
-      const noHover = window.matchMedia("(hover: none)").matches;
+      const coarse = mqlPointerCoarse.matches;
+      const noHover = mqlHoverNone.matches;
       setMagnifyEnabled(!(coarse || noHover));
     };
     compute();
 
-    const mqlPointerCoarse = window.matchMedia("(pointer: coarse)");
-    const mqlHoverNone = window.matchMedia("(hover: none)");
-
     const onChange = () => compute();
 
-    const removeListeners: Array<() => void> = [];
+    const legacyPointerListener = () => onChange();
+    const legacyHoverListener = () => onChange();
 
-    const addListener = (mql: MediaQueryList) => {
-      if (typeof mql.addEventListener === "function") {
-        const listener = onChange as EventListener;
-        mql.addEventListener("change", listener);
-        removeListeners.push(() => mql.removeEventListener("change", listener));
-      } else if (
-        typeof (
-          mql as {
-            addListener?: (
-              this: MediaQueryList,
-              listener: (ev: MediaQueryListEvent) => void
-            ) => void;
-          }
-        ).addListener === "function"
-      ) {
-        const legacyListener = () => onChange();
-        (mql as MediaQueryList).addListener!(legacyListener);
-        removeListeners.push(() =>
-          (mql as MediaQueryList).removeListener!(legacyListener)
-        );
-      }
-    };
+    if (typeof mqlPointerCoarse.addEventListener === "function") {
+      mqlPointerCoarse.addEventListener("change", onChange as EventListener);
+    } else if (typeof mqlPointerCoarse.addListener === "function") {
+      mqlPointerCoarse.addListener(legacyPointerListener);
+    }
 
-    addListener(mqlPointerCoarse);
-    addListener(mqlHoverNone);
+    if (typeof mqlHoverNone.addEventListener === "function") {
+      mqlHoverNone.addEventListener("change", onChange as EventListener);
+    } else if (typeof mqlHoverNone.addListener === "function") {
+      mqlHoverNone.addListener(legacyHoverListener);
+    }
 
     return () => {
-      removeListeners.forEach((fn) => fn());
+      if (typeof mqlPointerCoarse.removeEventListener === "function") {
+        mqlPointerCoarse.removeEventListener("change", onChange as EventListener);
+      } else if (typeof mqlPointerCoarse.removeListener === "function") {
+        mqlPointerCoarse.removeListener(legacyPointerListener);
+      }
+
+      if (typeof mqlHoverNone.removeEventListener === "function") {
+        mqlHoverNone.removeEventListener("change", onChange as EventListener);
+      } else if (typeof mqlHoverNone.removeListener === "function") {
+        mqlHoverNone.removeListener(legacyHoverListener);
+      }
     };
   }, []);
 

--- a/src/components/listen/ReactionOverlay.tsx
+++ b/src/components/listen/ReactionOverlay.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { AnimatePresence, motion } from "framer-motion";
 import { cn } from "@/lib/utils";
 import {
@@ -55,6 +55,14 @@ export function ReactionOverlay({ className }: ReactionOverlayProps) {
   // Track all processed reaction IDs to prevent re-showing after animation completes
   const processedIdsRef = useRef<Set<string>>(new Set());
 
+  const scheduleReactionRemoval = useCallback((reactionId: string) => {
+    const timeout = setTimeout(() => {
+      setVisible((prev) => prev.filter((item) => item.id !== reactionId));
+      delete timeoutsRef.current[reactionId];
+    }, REACTION_LIFETIME_MS);
+    timeoutsRef.current[reactionId] = timeout;
+  }, []);
+
   useEffect(() => {
     // Filter to only truly new reactions (not yet processed)
     const newReactions = reactions.filter(
@@ -82,13 +90,9 @@ export function ReactionOverlay({ className }: ReactionOverlayProps) {
     ]);
 
     newReactions.forEach((reaction) => {
-      const timeout = setTimeout(() => {
-        setVisible((prev) => prev.filter((item) => item.id !== reaction.id));
-        delete timeoutsRef.current[reaction.id];
-      }, REACTION_LIFETIME_MS);
-      timeoutsRef.current[reaction.id] = timeout;
+      scheduleReactionRemoval(reaction.id);
     });
-  }, [reactions]);
+  }, [reactions, scheduleReactionRemoval]);
 
   useEffect(() => {
     return () => {

--- a/src/hooks/useTimeout.ts
+++ b/src/hooks/useTimeout.ts
@@ -58,11 +58,17 @@ export function useTimeout(
       return;
     }
 
-    timeoutRef.current = setTimeout(() => {
+    const timeoutId = setTimeout(() => {
       savedCallback.current();
     }, delay);
+    timeoutRef.current = timeoutId;
 
-    return clear;
+    return () => {
+      clearTimeout(timeoutId);
+      if (timeoutRef.current === timeoutId) {
+        timeoutRef.current = null;
+      }
+    };
   }, [delay, clear]);
 
   return { clear, reset };

--- a/src/hooks/useTimeout.ts
+++ b/src/hooks/useTimeout.ts
@@ -51,7 +51,6 @@ export function useTimeout(
     }
   }, [delay, clear]);
 
-  // Set up the timeout
   useEffect(() => {
     // Don't schedule if delay is null
     if (delay === null) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add explicit cleanup functions for timer/listener effects across Internet Explorer, Chats, Maps, iPod, Karaoke, Videos, Dock, Photo Booth, JS-DOS, and shared hooks/components
- ensure async battery/listener setup in iPod `BatteryIndicator` returns a real teardown from the effect
- keep existing behavior while ensuring subscriptions/timers are disposed on dependency change/unmount

## Testing
- `npm run lint -- src/apps/chats/components/ChatInput.tsx src/apps/chats/hooks/useAiChat.ts src/apps/internet-explorer/hooks/useInternetExplorerLogic.ts src/apps/ipod/components/screen/BatteryIndicator.tsx src/apps/ipod/hooks/useIpodLogic.ts src/apps/karaoke/hooks/useKaraokeLogic.ts src/apps/maps/components/MapsAppComponent.tsx src/apps/pc/hooks/useJsDos.ts src/apps/photo-booth/hooks/usePhotoBoothLogic.ts src/apps/videos/hooks/useVideosLogic.ts src/components/layout/Dock.tsx src/components/listen/ReactionOverlay.tsx src/hooks/useTimeout.ts` (passes; repository still has unrelated pre-existing warnings)
- `npx tsc -b && npx vite build` (passes)

## Notes
- `bun` was unavailable in this cloud runtime, so validation used equivalent `npm`/`npx` commands.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4c267c8f-8c36-44d9-98d6-97d570dc4d33"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4c267c8f-8c36-44d9-98d6-97d570dc4d33"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

