### PR TITLE
Fix classic iPod titlebar showing over video and lyrics

### DIFF
--- a/src/apps/ipod/components/IpodScreen.tsx
+++ b/src/apps/ipod/components/IpodScreen.tsx
@@ -1533,7 +1533,13 @@ export function IpodScreen({
           {menuChrome}
         </div>
       ) : (
-        menuChrome
+        // Classic skin: keep menu/now-playing chrome in a z-10 stacking
+        // context so the full-bleed video + lyrics overlay (sibling z-20)
+        // paints over the titlebar during playback — same layering as the
+        // modern `ipod-modern-menu-panel` wrapper above.
+        <div className="relative z-10 h-full flex flex-col min-h-0">
+          {menuChrome}
+        </div>
       )}
 
     </div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

In the classic iPod skin, the now-playing title bar (Chicago LCD header with play indicator and battery) was rendering on top of full-bleed video and lyrics during playback.

The video/lyrics overlay and title bar were both `z-20` siblings at the screen root. Because the title bar came later in the DOM, it stacked above the overlay.

## Fix

Wrap classic menu chrome in a `relative z-10` container, matching the modern skin's `ipod-modern-menu-panel` layering. The full-bleed video/lyrics overlay remains at `z-20`, so it now paints over the title bar during playback.

## Testing

- `bun run build` — passes
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1a56bed0-b83b-48ba-a2c9-df0c26cc2949"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1a56bed0-b83b-48ba-a2c9-df0c26cc2949"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

