### PR TITLE
Remove redundant type modifier in chat executors import

### DIFF
--- a/api/chat/tools/executors.ts
+++ b/api/chat/tools/executors.ts
@@ -33,7 +33,7 @@ import type {
   CalendarSnapshotData,
   StickiesSnapshotData,
   ContactsSnapshotData,
-  type StickyColor,
+  StickyColor,
   SongLibraryControlInput,
   SongLibraryControlOutput,
   SongLibraryToolRecord,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- remove the redundant `type` modifier for `StickyColor` inside the existing `import type` block in `api/chat/tools/executors.ts`

## Testing
- `bun run build`

Resolves #2206
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e5a49f40-e10e-4266-be2f-e700673caff5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e5a49f40-e10e-4266-be2f-e700673caff5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

