### PR TITLE
Add explicit useEffect cleanup for battery and IE hooks

### DIFF
--- a/src/apps/internet-explorer/hooks/useInternetExplorerLogic.ts
+++ b/src/apps/internet-explorer/hooks/useInternetExplorerLogic.ts
@@ -1405,18 +1405,17 @@ export function useInternetExplorerLogic({
   }, [url, stripProtocol]);
 
   useEffect(() => {
-    const timeoutIds: ReturnType<typeof setTimeout>[] = [];
+    const timeoutIds = new Set<ReturnType<typeof setTimeout>>();
     const scheduleTimeout = (callback: () => void, delay: number) => {
       const timeoutId = setTimeout(callback, delay);
-      timeoutIds.push(timeoutId);
-    };
-    const clearScheduledTimeouts = () => {
-      timeoutIds.forEach((timeoutId) => clearTimeout(timeoutId));
+      timeoutIds.add(timeoutId);
+      return timeoutId;
     };
 
     // Only run initial navigation logic once when the window opens
     if (!initialNavigationRef.current && isWindowOpen) {
       initialNavigationRef.current = true;
+      let shouldRunDefaultNavigation = true;
       console.log(
         "[IE] Running initial navigation check. Received initialData:",
         initialData
@@ -1453,7 +1452,7 @@ export function useInternetExplorerLogic({
           }, 0);
           // Mark this initialData as processed
           lastProcessedInitialDataRef.current = initialData;
-          return clearScheduledTimeouts; // Skip other initial navigation
+          shouldRunDefaultNavigation = false;
         } else {
           console.warn(
             "[IE] Failed to decode share link code from initialData prop."
@@ -1467,7 +1466,11 @@ export function useInternetExplorerLogic({
       }
 
       // --- NEW: Check for direct url and year in initialData ---
-      if (initialData?.url && typeof initialData.url === "string") {
+      if (
+        shouldRunDefaultNavigation &&
+        initialData?.url &&
+        typeof initialData.url === "string"
+      ) {
         const initialUrl = initialData.url;
         const initialYear =
           typeof initialData.year === "string"
@@ -1492,17 +1495,21 @@ export function useInternetExplorerLogic({
         }, 0);
         // Mark this initialData as processed
         lastProcessedInitialDataRef.current = initialData;
-        return clearScheduledTimeouts; // Skip default navigation
+        shouldRunDefaultNavigation = false;
       }
       // --- END NEW ---
 
-      // Proceed with default navigation if not a share link or if decoding failed
-      console.log("[IE] Proceeding with default navigation.");
-      scheduleTimeout(() => {
-        handleNavigate(url, year, false);
-      }, 0);
+      // Proceed with default navigation if no initialData navigation was queued
+      if (shouldRunDefaultNavigation) {
+        console.log("[IE] Proceeding with default navigation.");
+        scheduleTimeout(() => {
+          handleNavigate(url, year, false);
+        }, 0);
+      }
     }
-    return clearScheduledTimeouts;
+    return () => {
+      timeoutIds.forEach((timeoutId) => clearTimeout(timeoutId));
+    };
   }, [
     initialData,
     isWindowOpen,

--- a/src/apps/internet-explorer/hooks/useInternetExplorerLogic.ts
+++ b/src/apps/internet-explorer/hooks/useInternetExplorerLogic.ts
@@ -1405,13 +1405,6 @@ export function useInternetExplorerLogic({
   }, [url, stripProtocol]);
 
   useEffect(() => {
-    const timeoutIds = new Set<ReturnType<typeof setTimeout>>();
-    const scheduleTimeout = (callback: () => void, delay: number) => {
-      const timeoutId = setTimeout(callback, delay);
-      timeoutIds.add(timeoutId);
-      return timeoutId;
-    };
-
     // Only run initial navigation logic once when the window opens
     if (!initialNavigationRef.current && isWindowOpen) {
       initialNavigationRef.current = true;
@@ -1438,18 +1431,12 @@ export function useInternetExplorerLogic({
             }`,
             duration: 4000,
           });
-          // Navigate using decoded data
-          scheduleTimeout(() => {
-            handleNavigate(
-              decodedData.url,
-              decodedData.year || "current",
-              false
-            );
-            // Clear initialData after navigation is initiated
-            if (instanceId) {
-              clearInstanceInitialData(instanceId);
-            }
-          }, 0);
+          // Navigate synchronously to avoid cleanup races dropping first-open navigation
+          handleNavigate(decodedData.url, decodedData.year || "current", false);
+          // Clear initialData after navigation is initiated
+          if (instanceId) {
+            clearInstanceInitialData(instanceId);
+          }
           // Mark this initialData as processed
           lastProcessedInitialDataRef.current = initialData;
           shouldRunDefaultNavigation = false;
@@ -1484,15 +1471,13 @@ export function useInternetExplorerLogic({
         setUrl(initialUrl);
         setYear(initialYear);
         // --- END FIX ---
-        scheduleTimeout(() => {
-          // --- FIX: Pass initialUrl and initialYear directly ---
-          handleNavigate(initialUrl, initialYear, false);
-          // Clear initialData after navigation is initiated
-          if (instanceId) {
-            clearInstanceInitialData(instanceId);
-          }
-          // --- END FIX ---
-        }, 0);
+        // --- FIX: Pass initialUrl and initialYear directly ---
+        handleNavigate(initialUrl, initialYear, false);
+        // Clear initialData after navigation is initiated
+        if (instanceId) {
+          clearInstanceInitialData(instanceId);
+        }
+        // --- END FIX ---
         // Mark this initialData as processed
         lastProcessedInitialDataRef.current = initialData;
         shouldRunDefaultNavigation = false;
@@ -1502,14 +1487,9 @@ export function useInternetExplorerLogic({
       // Proceed with default navigation if no initialData navigation was queued
       if (shouldRunDefaultNavigation) {
         console.log("[IE] Proceeding with default navigation.");
-        scheduleTimeout(() => {
-          handleNavigate(url, year, false);
-        }, 0);
+        handleNavigate(url, year, false);
       }
     }
-    return () => {
-      timeoutIds.forEach((timeoutId) => clearTimeout(timeoutId));
-    };
   }, [
     initialData,
     isWindowOpen,

--- a/src/apps/ipod/components/screen/BatteryIndicator.tsx
+++ b/src/apps/ipod/components/screen/BatteryIndicator.tsx
@@ -18,29 +18,33 @@ export function BatteryIndicator({
   const [animationFrame, setAnimationFrame] = useState<number>(1);
 
   useEffect(() => {
-    let removeBatteryListeners: (() => void) | undefined;
+    let batteryRef: BatteryManager | null = null;
     let isDisposed = false;
+
+    const updateLevel = () => {
+      if (batteryRef) {
+        setBatteryLevel(batteryRef.level);
+      }
+    };
+
+    const updateCharging = () => {
+      if (batteryRef) {
+        setIsCharging(batteryRef.charging);
+      }
+    };
 
     const getBattery = async () => {
       try {
         if ("getBattery" in navigator) {
-          const battery = await (
+          batteryRef = await (
             navigator as unknown as { getBattery: () => Promise<BatteryManager> }
           ).getBattery();
           if (isDisposed) return;
-          setBatteryLevel(battery.level);
-          setIsCharging(battery.charging);
+          setBatteryLevel(batteryRef.level);
+          setIsCharging(batteryRef.charging);
 
-          const updateLevel = () => setBatteryLevel(battery.level);
-          const updateCharging = () => setIsCharging(battery.charging);
-
-          battery.addEventListener("levelchange", updateLevel);
-          battery.addEventListener("chargingchange", updateCharging);
-
-          removeBatteryListeners = () => {
-            battery.removeEventListener("levelchange", updateLevel);
-            battery.removeEventListener("chargingchange", updateCharging);
-          };
+          batteryRef.addEventListener("levelchange", updateLevel);
+          batteryRef.addEventListener("chargingchange", updateCharging);
         }
       } catch {
         if (isDisposed) return;
@@ -54,7 +58,10 @@ export function BatteryIndicator({
 
     return () => {
       isDisposed = true;
-      removeBatteryListeners?.();
+      if (batteryRef) {
+        batteryRef.removeEventListener("levelchange", updateLevel);
+        batteryRef.removeEventListener("chargingchange", updateCharging);
+      }
     };
   }, []);
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- keep explicit effect cleanup changes from earlier commit
- fix IE first-open initial navigation by dispatching initial `handleNavigate(...)` synchronously instead of deferring with timeout, preventing cleanup races from dropping the first navigation

## Testing
- `bun run build`
- `bunx eslint src/apps/internet-explorer/hooks/useInternetExplorerLogic.ts`
- Manual browser validation at `http://localhost:5173`: hard reload, open Internet Explorer from dock, verify apple.com loads in main pane on first open

## Walkthrough artifacts
<a href="https://cursor.com/agents/bc-c4c56616-fa15-4501-98d9-de1fbccdc479/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fie_initial_navigation_fix_browser_test_clean_trimmed.mp4"><img src="https://cursor.com/artifacts/c/art-a87c6754-cfd4-49e3-9cb3-45c9ebe13354" alt="ie_initial_navigation_fix_browser_test_clean_trimmed.mp4" /></a>
![IE initial navigation loaded state](https://cursor.com/artifacts/c/art-4bd11d1d-f436-4fd5-b937-0b5411896b1d)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c4c56616-fa15-4501-98d9-de1fbccdc479"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c4c56616-fa15-4501-98d9-de1fbccdc479"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

