### PR TITLE
Fix nested component definition lint warnings in admin panels

### DIFF
--- a/src/apps/admin/components/SongDetailPanel.tsx
+++ b/src/apps/admin/components/SongDetailPanel.tsx
@@ -69,6 +69,10 @@ interface SongDetailPanelProps {
   onSongDeleted: () => void;
 }
 
+const Skeleton = ({ className }: { className?: string }) => (
+  <div className={cn("bg-neutral-200 animate-pulse rounded", className)} />
+);
+
 export const SongDetailPanel: React.FC<SongDetailPanelProps> = ({
   youtubeId,
   onBack,
@@ -481,11 +485,6 @@ export const SongDetailPanel: React.FC<SongDetailPanelProps> = ({
     const sign = ms >= 0 ? "+" : "";
     return `${sign}${ms}ms (${(ms / 1000).toFixed(2)}s)`;
   };
-
-  // Skeleton placeholder component
-  const Skeleton = ({ className }: { className?: string }) => (
-    <div className={cn("bg-neutral-200 animate-pulse rounded", className)} />
-  );
 
   if (!isLoading && !song) {
     return (

--- a/src/apps/admin/components/UserProfilePanel.tsx
+++ b/src/apps/admin/components/UserProfilePanel.tsx
@@ -95,6 +95,53 @@ interface UserProfilePanelProps {
   onUserDeleted: () => void;
 }
 
+const SECTION_HEADER_CLASS = "!text-[11px] uppercase tracking-wide text-black/50";
+
+const Skeleton = ({ className }: { className?: string }) => (
+  <div className={cn("bg-neutral-200 animate-pulse rounded", className)} />
+);
+
+interface SectionHeaderProps {
+  children: React.ReactNode;
+  icon?: React.ReactNode;
+  onClick?: () => void;
+  isOpen?: boolean;
+  showCaret?: boolean;
+  className?: string;
+}
+
+const SectionHeader = ({
+  children,
+  icon,
+  onClick,
+  isOpen,
+  showCaret,
+  className,
+}: SectionHeaderProps) => {
+  const Component = onClick ? "button" : "div";
+  return (
+    <Component
+      type={onClick ? "button" : undefined}
+      onClick={onClick}
+      aria-expanded={onClick ? isOpen : undefined}
+      className={cn(
+        SECTION_HEADER_CLASS,
+        onClick && "flex items-center gap-1.5 text-left",
+        className
+      )}
+    >
+      {showCaret && (
+        <CaretRight
+          className={cn("h-3 w-3 transition-transform", isOpen && "rotate-90")}
+          weight="bold"
+        />
+      )}
+      {icon}
+      <span>{children}</span>
+    </Component>
+  );
+};
+
 export const UserProfilePanel: React.FC<UserProfilePanelProps> = ({
   username,
   onBack,
@@ -439,50 +486,6 @@ export const UserProfilePanel: React.FC<UserProfilePanelProps> = ({
   const messagesCount = hasLoadedMessages
     ? messages.length
     : Math.min(profile?.messageCount ?? 0, RECENT_MESSAGES_LIMIT);
-
-  // Skeleton placeholder component
-  const Skeleton = ({ className }: { className?: string }) => (
-    <div className={cn("bg-neutral-200 animate-pulse rounded", className)} />
-  );
-  const sectionHeaderClass = "!text-[11px] uppercase tracking-wide text-black/50";
-  const SectionHeader = ({
-    children,
-    icon,
-    onClick,
-    isOpen,
-    showCaret,
-    className,
-  }: {
-    children: React.ReactNode;
-    icon?: React.ReactNode;
-    onClick?: () => void;
-    isOpen?: boolean;
-    showCaret?: boolean;
-    className?: string;
-  }) => {
-    const Component = onClick ? "button" : "div";
-    return (
-      <Component
-        type={onClick ? "button" : undefined}
-        onClick={onClick}
-        aria-expanded={onClick ? isOpen : undefined}
-        className={cn(
-          sectionHeaderClass,
-          onClick && "flex items-center gap-1.5 text-left",
-          className
-        )}
-      >
-        {showCaret && (
-          <CaretRight
-            className={cn("h-3 w-3 transition-transform", isOpen && "rotate-90")}
-            weight="bold"
-          />
-        )}
-        {icon}
-        <span>{children}</span>
-      </Component>
-    );
-  };
 
   return (
     <div className="flex flex-col h-full font-geneva-12">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Move `Skeleton` and `SectionHeader` helper components in `UserProfilePanel` to module scope.
- Move `Skeleton` helper component in `SongDetailPanel` to module scope.
- Merge latest `main` into this branch and resolve the single conflict in `UserProfilePanel` by keeping module-scope helper components.

## Testing
- `git diff --check --cached`
- `rg "const Skeleton|const SectionHeader|export const (UserProfilePanel|SongDetailPanel)" src/apps/admin/components/*.tsx`
- `npx eslint src/apps/admin/components/UserProfilePanel.tsx src/apps/admin/components/SongDetailPanel.tsx` *(fails in this cloud VM due to missing local eslint config dependencies / Bun toolchain)*
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5460a0f8-9d15-42c3-84b6-7b6320bd370a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5460a0f8-9d15-42c3-84b6-7b6320bd370a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

