### PR TITLE
Optimize repeated includes/find lookups with Set/Map

### DIFF
--- a/api/_utils/_ssrf.ts
+++ b/api/_utils/_ssrf.ts
@@ -20,6 +20,8 @@ const BLOCKED_HOST_SUFFIXES = [
   ".localhost",
   ".home.arpa",
 ];
+const ALLOWED_PROTOCOLS = new Set(["http:", "https:"]);
+const REDIRECT_TO_GET_STATUSES = new Set([301, 302, 303]);
 
 export class SsrfBlockedError extends Error {
   readonly code = "SSRF_BLOCKED";
@@ -59,7 +61,7 @@ export const validatePublicUrl = async (rawUrl: string): Promise<URL> => {
     throw new SsrfBlockedError("Invalid URL format");
   }
 
-  if (!["http:", "https:"].includes(parsed.protocol)) {
+  if (!ALLOWED_PROTOCOLS.has(parsed.protocol)) {
     throw new SsrfBlockedError("Only HTTP and HTTPS URLs are allowed");
   }
 
@@ -130,7 +132,7 @@ export const safeFetchWithRedirects = async (
         throw new SsrfBlockedError("Too many redirects");
       }
 
-      if ([301, 302, 303].includes(response.status)) {
+      if (REDIRECT_TO_GET_STATUSES.has(response.status)) {
         currentInit = {
           ...currentInit,
           method: "GET",

--- a/api/ai/extract-memories.ts
+++ b/api/ai/extract-memories.ts
@@ -295,6 +295,10 @@ export async function extractMemoriesFromConversation({
   const currentCount = currentIndex?.memories.length || 0;
   const remainingSlots = MAX_MEMORIES_PER_USER - currentCount;
   const existingKeys = currentIndex?.memories.map((memory) => memory.key) || [];
+  const existingKeySet = new Set(existingKeys);
+  const existingMemoryByKey = new Map(
+    (currentIndex?.memories || []).map((memory) => [memory.key, memory] as const)
+  );
   const existingMemoriesText =
     currentIndex && currentIndex.memories.length > 0
       ? currentIndex.memories.map((memory) => `- ${memory.key}: ${memory.summary}`).join("\n")
@@ -366,8 +370,8 @@ export async function extractMemoriesFromConversation({
       const keysToDelete: string[] = [];
       const relatedKeys = (mem.relatedKeys || [])
         .map((relatedKey) => relatedKey.toLowerCase().replace(/[^a-z0-9_]/g, "_"))
-        .filter((relatedKey) => relatedKey !== key && existingKeys.includes(relatedKey));
-      const targetKeyExists = existingKeys.includes(key);
+        .filter((relatedKey) => relatedKey !== key && existingKeySet.has(relatedKey));
+      const targetKeyExists = existingKeySet.has(key);
 
       if (relatedKeys.length > 0 || targetKeyExists) {
         const keysToFetch = targetKeyExists ? [key, ...relatedKeys] : relatedKeys;
@@ -382,7 +386,7 @@ export async function extractMemoriesFromConversation({
         const existingContents = await Promise.all(
           uniqueKeysToFetch.map(async (existingKey) => {
             const detail = await getMemoryDetail(redis, username, existingKey);
-            const entry = currentIndex?.memories.find((memory) => memory.key === existingKey);
+            const entry = existingMemoryByKey.get(existingKey);
             return {
               key: existingKey,
               summary: entry?.summary || "",

--- a/api/ai/process-daily-notes.ts
+++ b/api/ai/process-daily-notes.ts
@@ -249,6 +249,7 @@ async function _processDailyNotesForUserInner(
   let totalCreated = 0;
   let totalUpdated = 0;
   const processedDates: string[] = [];
+  const processedDateSet = new Set<string>();
   const skippedDates: string[] = [];
 
   // 2. Process each day as a separate batch
@@ -261,13 +262,13 @@ async function _processDailyNotesForUserInner(
         elapsedMs: elapsed,
         processedSoFar: totalProcessed,
         remainingDates: unprocessedNotes
-          .filter(n => !processedDates.includes(n.date))
+          .filter(n => !processedDateSet.has(n.date))
           .map(n => n.date),
       });
       // Track remaining dates as skipped (they'll be picked up next run)
       skippedDates.push(
         ...unprocessedNotes
-          .filter(n => !processedDates.includes(n.date))
+          .filter(n => !processedDateSet.has(n.date))
           .map(n => n.date)
       );
       break;
@@ -286,6 +287,7 @@ async function _processDailyNotesForUserInner(
       await markDailyNoteProcessed(redis, username, note.date);
       totalProcessed++;
       processedDates.push(note.date);
+      processedDateSet.add(note.date);
 
       log("[processDailyNotes] Day batch complete", {
         username,
@@ -386,6 +388,10 @@ async function _processSingleDayBatch(
   const currentCount = currentIndex?.memories.length || 0;
   const remainingSlots = MAX_MEMORIES_PER_USER - currentCount;
   const existingKeys = currentIndex?.memories.map(m => m.key) || [];
+  const existingKeySet = new Set(existingKeys);
+  const existingMemoryByKey = new Map(
+    (currentIndex?.memories || []).map((memory) => [memory.key, memory] as const)
+  );
   const existingMemoriesText = currentIndex && currentIndex.memories.length > 0
     ? currentIndex.memories.map(m => `- ${m.key}: ${m.summary}`).join("\n")
     : "";
@@ -428,9 +434,9 @@ async function _processSingleDayBatch(
 
     const relatedKeys = (mem.relatedKeys || [])
       .map(k => k.toLowerCase().replace(/[^a-z0-9_]/g, "_"))
-      .filter(k => k !== key && existingKeys.includes(k));
+      .filter(k => k !== key && existingKeySet.has(k));
 
-    const targetKeyExists = existingKeys.includes(key);
+    const targetKeyExists = existingKeySet.has(key);
 
     if (!targetKeyExists && relatedKeys.length === 0 && remainingSlots <= 0) {
       continue;
@@ -445,7 +451,7 @@ async function _processSingleDayBatch(
       const existingContents = await Promise.all(
         uniqueKeysToFetch.map(async (k) => {
           const detail = await getMemoryDetail(redis, username, k);
-          const entry = currentIndex?.memories.find(m => m.key === k);
+          const entry = existingMemoryByKey.get(k);
           return { key: k, summary: entry?.summary || "", content: detail?.content || "" };
         })
       );

--- a/api/songs/[id].ts
+++ b/api/songs/[id].ts
@@ -196,16 +196,17 @@ export default apiHandler<Record<string, unknown>>(
 
       const includeParam = (req.query.include as string) || "metadata";
       const includes = includeParam.split(",").map((s) => s.trim());
+      const includeSet = new Set(includes);
 
       logger.info("GET song", { songId, includes });
 
       // Fetch song with requested includes
       const song = await getSong(redis, songId, {
-        includeMetadata: includes.includes("metadata"),
-        includeLyrics: includes.includes("lyrics"),
-        includeTranslations: includes.includes("translations"),
-        includeFurigana: includes.includes("furigana"),
-        includeSoramimi: includes.includes("soramimi"),
+        includeMetadata: includeSet.has("metadata"),
+        includeLyrics: includeSet.has("lyrics"),
+        includeTranslations: includeSet.has("translations"),
+        includeFurigana: includeSet.has("furigana"),
+        includeSoramimi: includeSet.has("soramimi"),
       });
 
       if (!song) {

--- a/api/tv/create-channel.ts
+++ b/api/tv/create-channel.ts
@@ -120,10 +120,7 @@ async function searchOneQuery(
     if (!res.ok || data.error) {
       const message = data.error?.message?.toLowerCase() ?? "";
       const isQuota =
-        res.status === 403 &&
-        (message.includes("quota") ||
-          message.includes("exceeded") ||
-          message.includes("limit"));
+        res.status === 403 && /(quota|exceeded|limit)/.test(message);
       if (isQuota && i < apiKeys.length - 1) continue;
       throw new Error(
         data.error?.message || `YouTube API error (${res.status})`

--- a/scripts/extract-strings.ts
+++ b/scripts/extract-strings.ts
@@ -100,6 +100,7 @@ const IGNORE_DIRS = [
   ".vercel",
   "dev-dist",
 ];
+const IGNORE_DIR_SET = new Set(IGNORE_DIRS);
 
 const IGNORE_FILES = [
   ".test.tsx",
@@ -337,7 +338,8 @@ async function analyzeFile(filePath: string): Promise<FileAnalysis> {
 async function findTsxFiles(
   dir: string,
   excludeDirs: string[] = [],
-  pattern?: string
+  pattern?: string,
+  excludeDirSet: ReadonlySet<string> = new Set(excludeDirs)
 ): Promise<string[]> {
   const files: string[] = [];
   
@@ -350,13 +352,13 @@ async function findTsxFiles(
       // Skip ignored directories
       if (
         entry.isDirectory() &&
-        (IGNORE_DIRS.includes(entry.name) || excludeDirs.includes(entry.name))
+        (IGNORE_DIR_SET.has(entry.name) || excludeDirSet.has(entry.name))
       ) {
         continue;
       }
       
       if (entry.isDirectory()) {
-        files.push(...(await findTsxFiles(fullPath, excludeDirs, pattern)));
+        files.push(...(await findTsxFiles(fullPath, excludeDirs, pattern, excludeDirSet)));
       } else if (entry.name.endsWith(".tsx") && !entry.name.endsWith(".d.tsx")) {
         // Check if file should be ignored
         const shouldIgnoreFile = IGNORE_FILES.some(ignore => entry.name.includes(ignore));
@@ -382,6 +384,7 @@ async function findTsxFiles(
 async function main() {
   // Parse arguments
   const args = process.argv.slice(2);
+  const argSet = new Set(args);
   const dirArg = args.find((arg) => arg.startsWith("--dir="))?.split("=")[1];
   const patternArg = args.find((arg) => arg.startsWith("--pattern="))?.split("=")[1];
   const excludeArg = args.find((arg) => arg.startsWith("--exclude="))?.split("=")[1];
@@ -472,7 +475,7 @@ async function main() {
   console.log(`Needs translation: ${untranslated.length}`);
   console.log(`Total strings found: ${totalStrings}`);
   
-  if (args.includes("--help") || args.includes("-h")) {
+  if (argSet.has("--help") || argSet.has("-h")) {
     console.log(`
 Usage: bun run scripts/extract-strings.ts [options]
 

--- a/scripts/generate-app-docs.ts
+++ b/scripts/generate-app-docs.ts
@@ -46,6 +46,7 @@ const APP_CONFIGS: Record<string, { sectionNum: string; docName: string }> = {
 };
 
 const APP_IDS = Object.keys(APP_CONFIGS) as (keyof typeof APP_CONFIGS)[];
+const APP_ID_SET = new Set<string>(APP_IDS);
 
 interface AppMetadata {
   name: string;
@@ -609,13 +610,16 @@ async function generateAppDocumentation(appId: string, dryRun: boolean = false, 
  */
 async function main() {
   const args = process.argv.slice(2);
-  const dryRun = args.includes("--dry-run");
-  const force = args.includes("--force");
-  const appArg = args.find((arg) => arg.startsWith("--app="))?.split("=")[1] || 
-                 (args.includes("--app") && args[args.indexOf("--app") + 1]) || 
-                 undefined;
+  const argSet = new Set(args);
+  const dryRun = argSet.has("--dry-run");
+  const force = argSet.has("--force");
+  const appArgFromEquals = args.find((arg) => arg.startsWith("--app="))?.split("=")[1];
+  const appFlagIndex = args.indexOf("--app");
+  const appArgFromFlag =
+    appFlagIndex >= 0 ? args[appFlagIndex + 1] : undefined;
+  const appArg = appArgFromEquals || appArgFromFlag || undefined;
 
-  if (args.includes("--help") || args.includes("-h")) {
+  if (argSet.has("--help") || argSet.has("-h")) {
     console.log(`
 Usage: bun run scripts/generate-app-docs.ts [options]
 
@@ -672,8 +676,8 @@ Environment:
   let successCount = 0;
   let failCount = 0;
 
-  for (const appId of appsToProcess) {
-    if (!(APP_IDS as readonly string[]).includes(appId)) {
+  for (const [index, appId] of appsToProcess.entries()) {
+    if (!APP_ID_SET.has(appId)) {
       console.error(`❌ Invalid app ID: ${appId}`);
       failCount++;
       continue;
@@ -684,7 +688,7 @@ Environment:
       successCount++;
       
       // Small delay to avoid rate limiting
-      if (!dryRun && appsToProcess.indexOf(appId) < appsToProcess.length - 1) {
+      if (!dryRun && index < appsToProcess.length - 1) {
         await new Promise((resolve) => setTimeout(resolve, 1000));
       }
     } catch (error) {

--- a/src/apps/chats/hooks/useAiChat.ts
+++ b/src/apps/chats/hooks/useAiChat.ts
@@ -1821,7 +1821,7 @@ export function useAiChat(onPromptSetUsername?: () => void) {
       // Only target server-side tools (client-side tools already called
       // addToolResult from their handlers, so they don't need recovery).
       if (isError) {
-        const SERVER_SIDE_TOOLS = [
+        const SERVER_SIDE_TOOL_SET = new Set([
           "generateHtml",
           "searchSongs",
           "memoryWrite",
@@ -1831,16 +1831,14 @@ export function useAiChat(onPromptSetUsername?: () => void) {
           "cursorCloudAgent",
           "listCursorCloudAgentRuns",
           "mapsSearchPlaces",
-        ];
+        ]);
         const toolParts = lastMsg.parts.filter(
           (part: { type?: string; state?: string }) =>
             typeof part.type === "string" &&
             part.type.startsWith("tool-") &&
             (part.state === "output-available" ||
               part.state === "output-error") &&
-            SERVER_SIDE_TOOLS.includes(
-              (part.type as string).replace(/^tool-/, ""),
-            ),
+            SERVER_SIDE_TOOL_SET.has((part.type as string).replace(/^tool-/, "")),
         );
         if (toolParts.length > 0) {
           console.log(

--- a/src/apps/finder/hooks/useFileSystem.ts
+++ b/src/apps/finder/hooks/useFileSystem.ts
@@ -92,6 +92,12 @@ const trackFinderFileOperation = (
 const arePathArraysEqual = (first: readonly string[], second: readonly string[]) =>
   first.length === second.length &&
   first.every((path, index) => path === second[index]);
+const DEFAULT_FILE_PATHS = new Set([
+  "/Documents/README.md",
+  "/Documents/Quick Tips.md",
+  "/Images/steve-jobs.png",
+  "/Images/susan-kare.png",
+]);
 
 const getCloudSyncDomainForContentStore = (
   storeName: string
@@ -2113,12 +2119,7 @@ export function useFileSystem(
             if (!item.createdAt || !item.modifiedAt) {
               const now = Date.now();
               // For default files, use a date in the past
-              const isDefaultFile = [
-                "/Documents/README.md",
-                "/Documents/Quick Tips.md",
-                "/Images/steve-jobs.png",
-                "/Images/susan-kare.png",
-              ].includes(item.path);
+              const isDefaultFile = DEFAULT_FILE_PATHS.has(item.path);
 
               const baseTime = isDefaultFile
                 ? now - 30 * 24 * 60 * 60 * 1000 // 30 days ago for default files

--- a/src/apps/terminal/hooks/useVimLogic.ts
+++ b/src/apps/terminal/hooks/useVimLogic.ts
@@ -1,4 +1,4 @@
-import { useRef } from "react";
+import { useMemo, useRef } from "react";
 import type {
   ChangeEvent,
   Dispatch,
@@ -88,6 +88,15 @@ export const useVimLogic = ({
     key: "",
     time: 0,
   });
+  const filesByName = useMemo(() => {
+    const map = new Map<string, TerminalFileItem>();
+    for (const file of files) {
+      if (!map.has(file.name)) {
+        map.set(file.name, file);
+      }
+    }
+    return map;
+  }, [files]);
 
   const pushUndoBeforeMutation = () => {
     if (vimFile)
@@ -154,7 +163,7 @@ export const useVimLogic = ({
   const saveVimFile = async (vimFileToSave: { name: string; content: string }) => {
     try {
       // Find the file in the current files list to get its path
-      const fileObj = files.find((file) => file.name === vimFileToSave.name);
+      const fileObj = filesByName.get(vimFileToSave.name);
 
       if (!fileObj) {
         console.error(`Could not find file ${vimFileToSave.name} for saving`);

--- a/src/hooks/useAutoCloudSync.ts
+++ b/src/hooks/useAutoCloudSync.ts
@@ -489,8 +489,9 @@ export function useAutoCloudSync() {
       firstQueuedAtRef.current[logicalDomain] = 0;
       pendingUploadAfterCurrentRef.current[logicalDomain] = false;
       uploadInFlightRef.current[logicalDomain] = true;
+      const enabledPartDomainSet = new Set(enabledPartDomains);
       const dirtyPartDomains = getPersistedLogicalDirtyParts(logicalDomain).filter(
-        (partDomain) => enabledPartDomains.includes(partDomain)
+        (partDomain) => enabledPartDomainSet.has(partDomain)
       );
       const targetPartDomains =
         dirtyPartDomains.length > 0 ? dirtyPartDomains : enabledPartDomains;
@@ -1058,8 +1059,9 @@ export function useAutoCloudSync() {
       // Narrow suppression: applied domains get a short post-apply window,
       // all others are released immediately.
       const postApplyUntil = Date.now() + REMOTE_APPLY_SUPPRESSION_MS;
+      const appliedDomainSet = new Set(appliedDomains);
       for (const d of CLOUD_SYNC_DOMAINS) {
-        remoteApplySuppressUntilRef.current[d] = appliedDomains.includes(d)
+        remoteApplySuppressUntilRef.current[d] = appliedDomainSet.has(d)
           ? postApplyUntil
           : 0;
       }
@@ -1262,8 +1264,9 @@ export function useAutoCloudSync() {
 
       const physicalOrder =
         getLogicalCloudSyncDomainPhysicalParts(logicalDomain);
+      const partsNeedingUploadSet = new Set(partsNeedingUpload);
       const representative =
-        physicalOrder.find((d) => partsNeedingUpload.includes(d)) ??
+        physicalOrder.find((d) => partsNeedingUploadSet.has(d)) ??
         partsNeedingUpload[0];
 
       setTimeout(

--- a/src/hooks/useCoverPalette.ts
+++ b/src/hooks/useCoverPalette.ts
@@ -103,6 +103,7 @@ function extractPaletteFromImage(img: HTMLImageElement): string[] {
 
   // Greedily pick N distinct colors
   const result: string[] = [];
+  const selectedHexes = new Set<string>();
   for (const c of sorted) {
     if (result.length >= COLOR_COUNT) break;
     const tooClose = result.some((hex) => {
@@ -114,7 +115,9 @@ function extractPaletteFromImage(img: HTMLImageElement): string[] {
       return colorDistSq(c.r, c.g, c.b, r2, g2, b2) < MIN_DISTINCT_SQ;
     });
     if (!tooClose) {
-      result.push(rgbToHex(c.r, c.g, c.b));
+      const hex = rgbToHex(c.r, c.g, c.b);
+      result.push(hex);
+      selectedHexes.add(hex);
     }
   }
 
@@ -122,7 +125,10 @@ function extractPaletteFromImage(img: HTMLImageElement): string[] {
   for (const c of sorted) {
     if (result.length >= COLOR_COUNT) break;
     const hex = rgbToHex(c.r, c.g, c.b);
-    if (!result.includes(hex)) result.push(hex);
+    if (!selectedHexes.has(hex)) {
+      result.push(hex);
+      selectedHexes.add(hex);
+    }
   }
 
   return result.length >= COLOR_COUNT ? result : DEFAULT_PALETTE;

--- a/src/hooks/useTerminalSounds.ts
+++ b/src/hooks/useTerminalSounds.ts
@@ -573,6 +573,7 @@ export function useTerminalSounds() {
   // Generate a melodic sequence from the note pool - highly simplified for coherence
   const generateMelodySequence = useCallback(() => {
     const { notePool, timeMode } = elevatorMusicRef.current;
+    const noteToIndex = new Map(notePool.map((note, index) => [note, index] as const));
     
     // Future mode uses simple predictable patterns
     if (timeMode === "future") {
@@ -637,7 +638,7 @@ export function useTerminalSounds() {
       
       for (let i = 1; i < length; i++) {
         if (Math.random() < 0.6) {
-          const lastIndex = notePool.indexOf(melody[i - 1]);
+          const lastIndex = noteToIndex.get(melody[i - 1]) ?? -1;
           const stepUp = Math.random() < 0.5;
 
           if (stepUp && lastIndex < notePool.length - 1) {

--- a/src/stores/useFilesStore.ts
+++ b/src/stores/useFilesStore.ts
@@ -541,6 +541,9 @@ const SYSTEM7_PROMINENT_DESKTOP_APP_IDS: readonly string[] = [
   "internet-explorer",
   "karaoke",
 ];
+const SYSTEM7_PROMINENT_DESKTOP_APP_ID_SET = new Set<string>(
+  SYSTEM7_PROMINENT_DESKTOP_APP_IDS
+);
 
 const THEMES_HIDE_SYSTEM7_PROMINENT_DESKTOP_APPS: OsThemeId[] = [
   "macosx",
@@ -617,16 +620,17 @@ function migrateV13System7ProminentDesktopApps(
       getParentPath(oldItem.path) !== "/Desktop" ||
       oldItem.aliasType !== "app" ||
       !oldItem.aliasTarget ||
-      !SYSTEM7_PROMINENT_DESKTOP_APP_IDS.includes(oldItem.aliasTarget)
+      !SYSTEM7_PROMINENT_DESKTOP_APP_ID_SET.has(oldItem.aliasTarget)
     ) {
       continue;
     }
     const h = oldItem.hiddenOnThemes;
+    const hiddenThemeSet = new Set(h || []);
     const looksLikeFullSparse =
-      h?.length === sparse.length && sparse.every((t) => h.includes(t));
+      h?.length === sparse.length && sparse.every((t) => hiddenThemeSet.has(t));
     const missingProminentHides =
-      !h?.length || want.some((theme) => !h.includes(theme));
-    const wronglyHidesOnSystem7 = h?.includes("system7");
+      !h?.length || want.some((theme) => !hiddenThemeSet.has(theme));
+    const wronglyHidesOnSystem7 = hiddenThemeSet.has("system7");
     if (looksLikeFullSparse || missingProminentHides || wronglyHidesOnSystem7) {
       newState[path] = {
         ...oldItem,
@@ -1326,7 +1330,7 @@ export const useFilesStore = create<FilesStoreState>()(
                   hiddenOnThemes = [
                     ...THEMES_HIDE_DEFAULT_APPLET_STORE_DESKTOP_SHORTCUT,
                   ];
-                } else if (SYSTEM7_PROMINENT_DESKTOP_APP_IDS.includes(appId)) {
+                } else if (SYSTEM7_PROMINENT_DESKTOP_APP_ID_SET.has(appId)) {
                   hiddenOnThemes = [
                     ...THEMES_HIDE_SYSTEM7_PROMINENT_DESKTOP_APPS,
                   ];
@@ -1453,11 +1457,12 @@ export const useFilesStore = create<FilesStoreState>()(
                 item.aliasTarget === "applet-viewer"
               ) {
                 const h = item.hiddenOnThemes;
+                const hiddenThemeSet = new Set(h || []);
                 const wronglyMacosxOnly =
                   h?.length === 1 && h[0] === "macosx";
                 const missingNonMacosxHides =
                   !h?.length ||
-                  wantAppletHidden.some((theme) => !h.includes(theme));
+                  wantAppletHidden.some((theme) => !hiddenThemeSet.has(theme));
                 if (wronglyMacosxOnly || missingNonMacosxHides) {
                   items[path] = {
                     ...item,
@@ -1472,10 +1477,11 @@ export const useFilesStore = create<FilesStoreState>()(
                 item.aliasTarget === "/Applications"
               ) {
                 const h = item.hiddenOnThemes;
+                const hiddenThemeSet = new Set(h || []);
                 const needsApplicationsHideFix =
                   !h?.length ||
                   h.length !== wantApplicationsHidden.length ||
-                  wantApplicationsHidden.some((theme) => !h.includes(theme));
+                  wantApplicationsHidden.some((theme) => !hiddenThemeSet.has(theme));
                 if (needsApplicationsHideFix) {
                   items[path] = {
                     ...item,
@@ -1488,16 +1494,19 @@ export const useFilesStore = create<FilesStoreState>()(
               if (
                 item.aliasType === "app" &&
                 item.aliasTarget &&
-                SYSTEM7_PROMINENT_DESKTOP_APP_IDS.includes(item.aliasTarget)
+                SYSTEM7_PROMINENT_DESKTOP_APP_ID_SET.has(item.aliasTarget)
               ) {
                 const h = item.hiddenOnThemes;
+                const hiddenThemeSet = new Set(h || []);
                 const looksLikeFullSparse =
                   h?.length === sparseThemes.length &&
-                  sparseThemes.every((t) => h.includes(t));
+                  sparseThemes.every((t) => hiddenThemeSet.has(t));
                 const missingProminentHides =
                   !h?.length ||
-                  wantSystem7ProminentHidden.some((theme) => !h.includes(theme));
-                const wronglyHidesOnSystem7 = h?.includes("system7");
+                  wantSystem7ProminentHidden.some(
+                    (theme) => !hiddenThemeSet.has(theme)
+                  );
+                const wronglyHidesOnSystem7 = hiddenThemeSet.has("system7");
                 if (
                   looksLikeFullSparse ||
                   missingProminentHides ||

--- a/src/utils/syncLogicalDomains.ts
+++ b/src/utils/syncLogicalDomains.ts
@@ -17,6 +17,9 @@ export const LOGICAL_CLOUD_SYNC_DOMAINS = [
   "contacts",
   "maps",
 ] as const;
+const LOGICAL_CLOUD_SYNC_DOMAIN_SET = new Set<string>(
+  LOGICAL_CLOUD_SYNC_DOMAINS as readonly string[]
+);
 
 export type LogicalCloudSyncDomain = (typeof LOGICAL_CLOUD_SYNC_DOMAINS)[number];
 
@@ -40,6 +43,15 @@ export const LOGICAL_TO_PHYSICAL_CLOUD_SYNC_DOMAINS: Record<
   contacts: ["contacts"],
   maps: ["maps"],
 };
+const LOGICAL_TO_PHYSICAL_CLOUD_SYNC_DOMAIN_SETS: Record<
+  LogicalCloudSyncDomain,
+  Set<CloudSyncDomain>
+> = Object.fromEntries(
+  LOGICAL_CLOUD_SYNC_DOMAINS.map((domain) => [
+    domain,
+    new Set(LOGICAL_TO_PHYSICAL_CLOUD_SYNC_DOMAINS[domain]),
+  ])
+) as Record<LogicalCloudSyncDomain, Set<CloudSyncDomain>>;
 
 export interface LogicalCloudSyncDomainMetadata {
   updatedAt: string;
@@ -56,10 +68,7 @@ export type LogicalCloudSyncMetadataMap = Record<
 export function isLogicalCloudSyncDomain(
   value: unknown
 ): value is LogicalCloudSyncDomain {
-  return (
-    typeof value === "string" &&
-    (LOGICAL_CLOUD_SYNC_DOMAINS as readonly string[]).includes(value)
-  );
+  return typeof value === "string" && LOGICAL_CLOUD_SYNC_DOMAIN_SET.has(value);
 }
 
 export function createEmptyLogicalCloudSyncMetadataMap(): LogicalCloudSyncMetadataMap {
@@ -95,7 +104,7 @@ export function getLogicalCloudSyncDomainForPhysical(
   domain: CloudSyncDomain
 ): LogicalCloudSyncDomain {
   for (const logicalDomain of LOGICAL_CLOUD_SYNC_DOMAINS) {
-    if (LOGICAL_TO_PHYSICAL_CLOUD_SYNC_DOMAINS[logicalDomain].includes(domain)) {
+    if (LOGICAL_TO_PHYSICAL_CLOUD_SYNC_DOMAIN_SETS[logicalDomain].has(domain)) {
       return logicalDomain;
     }
   }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Replace repeated `Array.includes`/`find` membership and keyed lookups with `Set.has` / `Map.get` in targeted API, hooks, stores, and scripts.
- Convert repeated fixed-list status/protocol checks to Set-based lookups in SSRF utilities.
- Simplify repeated YouTube quota substring checks in channel creation using one regex test.

## Validation
- `bun run build` ✅
- `bun run test:unit` ✅

## Notes
- No behavior changes intended; this is a lookup performance and readability refactor only.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9c52aeff-bb41-4b37-ab80-83144ac2b51c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9c52aeff-bb41-4b37-ab80-83144ac2b51c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

