### PR TITLE
refactor: collapse redundant width/height utilities to size

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -125,7 +125,7 @@ export function App() {
         // New version available - show update toast (both web and Tauri)
         toast(`ryOS ${result.version} for Mac is available`, {
           id: 'desktop-update',
-          icon: <DownloadSimple className="h-4 w-4" weight="bold" />,
+          icon: <DownloadSimple className="size-4" weight="bold" />,
           duration: Infinity,
           action: {
             label: "Download",
@@ -143,7 +143,7 @@ export function App() {
         // First time user on web - show initial download toast (not in Tauri)
         toast("ryOS is available as a Mac app", {
           id: 'desktop-update',
-          icon: <DownloadSimple className="h-4 w-4" weight="bold" />,
+          icon: <DownloadSimple className="size-4" weight="bold" />,
           duration: Infinity,
           action: {
             label: "Download",

--- a/src/apps/admin/components/AdminAppComponent.tsx
+++ b/src/apps/admin/components/AdminAppComponent.tsx
@@ -247,7 +247,7 @@ export function AdminAppComponent({
           menuBar={isXpTheme ? menuBar : undefined}
         >
           <div className="flex flex-col items-center justify-center h-full gap-3 p-8 text-center bg-white">
-            <Warning className="h-10 w-10 text-neutral-400" weight="bold" />
+            <Warning className="size-10 text-neutral-400" weight="bold" />
             <h2 className="text-sm font-bold">
               {t("apps.admin.accessDenied.title")}
             </h2>
@@ -282,7 +282,7 @@ export function AdminAppComponent({
           menuBar={isXpTheme ? menuBar : undefined}
         >
           <div className="flex flex-col items-center justify-center h-full gap-3 p-8 text-center bg-white">
-            <WifiSlash className="h-10 w-10 text-neutral-400" weight="bold" />
+            <WifiSlash className="size-10 text-neutral-400" weight="bold" />
             <h2 className="text-sm font-bold">
               {t("apps.admin.offline.title", "Offline")}
             </h2>
@@ -318,7 +318,7 @@ export function AdminAppComponent({
         onNavigatePrevious={onNavigatePrevious}
         menuBar={isXpTheme ? menuBar : undefined}
       >
-        <div ref={containerRef} className="flex h-full w-full admin-force-font">
+        <div ref={containerRef} className="flex size-full admin-force-font">
           {/* Sidebar */}
           <AdminSidebar
             activeSection={activeSection}
@@ -357,7 +357,7 @@ export function AdminAppComponent({
                 {activeSection === "users" && !selectedRoomId && (
                   <div className="relative flex-1">
                     <MagnifyingGlass
-                      className="absolute left-2 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-neutral-400"
+                      className="absolute left-2 top-1/2 -translate-y-1/2 size-3.5 text-neutral-400"
                       weight="bold"
                     />
                     <Input
@@ -373,7 +373,7 @@ export function AdminAppComponent({
                   <>
                     <div className="relative flex-1">
                       <MagnifyingGlass
-                        className="absolute left-2 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-neutral-400"
+                        className="absolute left-2 top-1/2 -translate-y-1/2 size-3.5 text-neutral-400"
                         weight="bold"
                       />
                       <Input
@@ -391,7 +391,7 @@ export function AdminAppComponent({
                       size="sm"
                       onClick={() => setSongsFilterByRyoOnly((v) => !v)}
                       className={cn(
-                        "h-7 w-7 p-0",
+                        "size-7 p-0",
                         songsFilterByRyoOnly && "bg-neutral-200"
                       )}
                       title={t(
@@ -417,7 +417,7 @@ export function AdminAppComponent({
                       size="sm"
                       onClick={() => fileInputRef.current?.click()}
                       disabled={isImporting || isExporting || isDeletingAll}
-                      className="h-7 w-7 p-0"
+                      className="size-7 p-0"
                       title={
                         isImporting
                           ? t("apps.admin.songs.importing", {
@@ -448,7 +448,7 @@ export function AdminAppComponent({
                         isDeletingAll ||
                         songs.length === 0
                       }
-                      className="h-7 w-7 p-0"
+                      className="size-7 p-0"
                       title={t("apps.admin.songs.export", "Export Library")}
                     >
                       {isExporting ? (
@@ -463,7 +463,7 @@ export function AdminAppComponent({
                       size="sm"
                       onClick={handleDeleteAllSongs}
                       disabled={isDeletingAll || isImporting || songs.length === 0}
-                      className="h-7 w-7 p-0"
+                      className="size-7 p-0"
                       title={t("apps.admin.songs.deleteAll", "Delete All Songs")}
                     >
                       {isDeletingAll ? (
@@ -495,7 +495,7 @@ export function AdminAppComponent({
                     onClick={() =>
                       promptDelete("room", selectedRoomId, selectedRoom?.name || "")
                     }
-                    className="h-7 w-7 p-0"
+                    className="size-7 p-0"
                   >
                     <Trash size={14} weight="bold" />
                   </Button>
@@ -505,7 +505,7 @@ export function AdminAppComponent({
                   variant="ghost"
                   size="sm"
                   onClick={handleRefresh}
-                  className="h-7 w-7 p-0"
+                  className="size-7 p-0"
                 >
                   {isLoading ? (
                     <ActivityIndicator size={14} />
@@ -615,7 +615,7 @@ export function AdminAppComponent({
                     {users.length === 0 && !isLoading ? (
                       <div className="flex flex-col items-center justify-center py-12 text-neutral-400">
                         <MagnifyingGlass
-                          className="h-8 w-8 mb-2 opacity-50"
+                          className="size-8 mb-2 opacity-50"
                           weight="bold"
                         />
                         <span className="text-[11px]">
@@ -654,7 +654,7 @@ export function AdminAppComponent({
                                 <TableCell className="flex items-center gap-2">
                                   <div
                                     className={cn(
-                                      "w-4 h-4 rounded-full flex items-center justify-center text-[9px] font-medium",
+                                      "size-4 rounded-full flex items-center justify-center text-[9px] font-medium",
                                       user.banned
                                         ? "bg-red-200 text-red-700"
                                         : "bg-neutral-200 text-neutral-600"
@@ -668,7 +668,7 @@ export function AdminAppComponent({
                                   {user.banned ? (
                                     <span className="inline-flex items-center gap-1 px-1.5 py-0.5 text-[9px] bg-red-100 text-red-700 rounded">
                                       <Prohibit
-                                        className="h-2.5 w-2.5"
+                                        className="size-2.5"
                                         weight="bold"
                                       />
                                       {t("apps.admin.user.banned")}
@@ -699,7 +699,7 @@ export function AdminAppComponent({
                                           user.username
                                         );
                                       }}
-                                      className="h-5 w-5 p-0 md:opacity-0 md:group-hover:opacity-100 text-neutral-500 hover:text-neutral-700 hover:bg-neutral-100"
+                                      className="size-5 p-0 md:opacity-0 md:group-hover:opacity-100 text-neutral-500 hover:text-neutral-700 hover:bg-neutral-100"
                                     >
                                       <Trash size={14} weight="bold" />
                                     </Button>
@@ -741,7 +741,7 @@ export function AdminAppComponent({
                     {songs.length === 0 && !isLoading ? (
                       <div className="flex flex-col items-center justify-center py-12 text-neutral-400">
                         <MusicNote
-                          className="h-8 w-8 mb-2 opacity-50"
+                          className="size-8 mb-2 opacity-50"
                           weight="bold"
                         />
                         <span className="text-[11px]">
@@ -751,7 +751,7 @@ export function AdminAppComponent({
                     ) : filteredSongs.length === 0 ? (
                       <div className="flex flex-col items-center justify-center py-12 text-neutral-400">
                         <Funnel
-                          className="h-8 w-8 mb-2 opacity-50"
+                          className="size-8 mb-2 opacity-50"
                           weight="bold"
                         />
                         <span className="text-[11px]">
@@ -775,14 +775,14 @@ export function AdminAppComponent({
                                 }
                               >
                                 {/* Cover Image */}
-                                <div className="w-10 h-10 flex-shrink-0 rounded overflow-hidden bg-gray-200">
+                                <div className="size-10 flex-shrink-0 rounded overflow-hidden bg-gray-200">
                                   <img
                                     src={
                                       formatKugouImageUrl(song.cover, 100) ||
                                       `https://i.ytimg.com/vi/${song.youtubeId}/default.jpg`
                                     }
                                     alt={song.title}
-                                    className="w-full h-full object-cover"
+                                    className="size-full object-cover"
                                     loading="lazy"
                                   />
                                 </div>
@@ -819,7 +819,7 @@ export function AdminAppComponent({
                                       song.title
                                     );
                                   }}
-                                  className="h-6 w-6 p-0 flex-shrink-0 md:opacity-0 md:group-hover:opacity-100 text-neutral-500 hover:text-neutral-700 hover:bg-neutral-100"
+                                  className="size-6 p-0 flex-shrink-0 md:opacity-0 md:group-hover:opacity-100 text-neutral-500 hover:text-neutral-700 hover:bg-neutral-100"
                                 >
                                   <Trash size={14} weight="bold" />
                                 </Button>
@@ -882,7 +882,7 @@ export function AdminAppComponent({
                             className="border-none hover:bg-gray-100/50 transition-colors cursor-default odd:bg-gray-200/50 group"
                           >
                             <TableCell className="flex items-center gap-2 whitespace-nowrap">
-                              <div className="w-4 h-4 rounded-full bg-neutral-200 flex items-center justify-center text-[9px] font-medium text-neutral-600">
+                              <div className="size-4 rounded-full bg-neutral-200 flex items-center justify-center text-[9px] font-medium text-neutral-600">
                                 {message.username[0].toUpperCase()}
                               </div>
                               {message.username}
@@ -904,7 +904,7 @@ export function AdminAppComponent({
                                     deleteMessage(selectedRoomId, message.id);
                                   }
                                 }}
-                                className="h-5 w-5 p-0 md:opacity-0 md:group-hover:opacity-100 text-neutral-500 hover:text-neutral-700 hover:bg-neutral-100"
+                                className="size-5 p-0 md:opacity-0 md:group-hover:opacity-100 text-neutral-500 hover:text-neutral-700 hover:bg-neutral-100"
                               >
                                 <Trash size={14} weight="bold" />
                               </Button>

--- a/src/apps/admin/components/CursorAgentsPanel.tsx
+++ b/src/apps/admin/components/CursorAgentsPanel.tsx
@@ -127,7 +127,7 @@ function CursorAgentsToolbar({
           size="sm"
           onClick={onRefresh}
           disabled={refreshDisabled || isSubmitting}
-          className="h-7 w-7 shrink-0 p-0"
+          className="size-7 shrink-0 p-0"
           aria-label={t("apps.admin.cursorAgents.refresh", "Refresh")}
           title={t("apps.admin.cursorAgents.refresh", "Refresh")}
         >
@@ -285,7 +285,7 @@ export function CursorAgentsPanel({
             onClick={handleRefreshClick}
             className="h-8 text-[11px]"
           >
-            <ArrowsClockwise className="h-3.5 w-3.5 mr-1" weight="bold" />
+            <ArrowsClockwise className="size-3.5 mr-1" weight="bold" />
             {t("apps.admin.cursorAgents.retry", "Retry")}
           </Button>
         </div>
@@ -298,7 +298,7 @@ export function CursorAgentsPanel({
       <div className={panelShellClass}>
         {toolbar}
         <div className="flex flex-col items-center justify-center py-16 text-neutral-400 px-6 text-center gap-2">
-          <Robot className="h-9 w-9 opacity-50" weight="bold" />
+          <Robot className="size-9 opacity-50" weight="bold" />
           <p className="text-[12px] font-medium text-neutral-500">
             {t("apps.admin.cursorAgents.emptyTitle", "No Cursor agent runs in Redis")}
           </p>
@@ -377,7 +377,7 @@ export function CursorAgentsPanel({
                 <TableCell className="w-0 align-top py-2 pl-2 pr-1">
                   <span
                     className={cn(
-                      "mt-[5px] inline-block h-2 w-2 shrink-0 rounded-full",
+                      "mt-[5px] inline-block size-2 shrink-0 rounded-full",
                       statusDotClass(run.status)
                     )}
                     title={run.status}

--- a/src/apps/admin/components/DashboardPanel.tsx
+++ b/src/apps/admin/components/DashboardPanel.tsx
@@ -342,7 +342,7 @@ export function DashboardPanel({ onRefresh }: DashboardPanelProps) {
   if (error && !data) {
     return (
       <div className="flex flex-col items-center justify-center py-16 gap-3">
-        <Warning className="h-8 w-8 text-neutral-400" weight="bold" />
+        <Warning className="size-8 text-neutral-400" weight="bold" />
         <span className="text-[12px] text-neutral-600">{error}</span>
         <Button variant="outline" size="sm" onClick={fetchData}>
           {t("apps.admin.dashboard.retry")}
@@ -420,7 +420,7 @@ export function DashboardPanel({ onRefresh }: DashboardPanelProps) {
                 setServerReloadKey((k) => k + 1);
                 onRefresh?.();
               }}
-              className="h-7 w-7 shrink-0 p-0"
+              className="size-7 shrink-0 p-0"
             >
               {isLoading ? (
                 <ActivityIndicator size={14} />

--- a/src/apps/admin/components/SongDetailPanel.tsx
+++ b/src/apps/admin/components/SongDetailPanel.tsx
@@ -490,12 +490,12 @@ export const SongDetailPanel: React.FC<SongDetailPanelProps> = ({
   if (!isLoading && !song) {
     return (
       <div className="flex flex-col items-center justify-center h-full gap-2">
-        <Warning className="h-8 w-8 text-neutral-400" weight="bold" />
+        <Warning className="size-8 text-neutral-400" weight="bold" />
         <span className="text-[11px] text-neutral-500">
           {t("apps.admin.song.notFound", "Song not found")}
         </span>
         <Button variant="ghost" size="sm" onClick={onBack} className="text-[11px]">
-          <ArrowLeft className="h-3 w-3 mr-1" weight="bold" />
+          <ArrowLeft className="size-3 mr-1" weight="bold" />
           {t("apps.admin.profile.back", "Back")}
         </Button>
       </div>
@@ -510,14 +510,14 @@ export const SongDetailPanel: React.FC<SongDetailPanelProps> = ({
           variant="ghost"
           size="sm"
           onClick={onBack}
-          className="h-6 w-6 p-0"
+          className="size-6 p-0"
         >
-          <ArrowLeft className="h-3.5 w-3.5" weight="bold" />
+          <ArrowLeft className="size-3.5" weight="bold" />
         </Button>
         <div className="flex items-center gap-2 flex-1 min-w-0">
           <div
             className={cn(
-              "w-10 h-10 rounded flex items-center justify-center text-sm font-medium text-neutral-600 flex-shrink-0 overflow-hidden",
+              "size-10 rounded flex items-center justify-center text-sm font-medium text-neutral-600 flex-shrink-0 overflow-hidden",
               isLoading ? "bg-neutral-200 animate-pulse" : "bg-neutral-200"
             )}
           >
@@ -525,7 +525,7 @@ export const SongDetailPanel: React.FC<SongDetailPanelProps> = ({
               <img
                 src={formatKugouImageUrl(song?.cover, 150) || `https://img.youtube.com/vi/${youtubeId}/mqdefault.jpg`}
                 alt=""
-                className="w-full h-full object-cover"
+                className="size-full object-cover"
                 onError={(e) => {
                   // Fall back to YouTube thumbnail if Kugou cover fails
                   // Use proper URL parsing to check hostname (not substring match which could be bypassed)
@@ -566,22 +566,22 @@ export const SongDetailPanel: React.FC<SongDetailPanelProps> = ({
           size="sm"
           onClick={() => setIsDeleteDialogOpen(true)}
           disabled={isLoading}
-          className="h-6 w-6 p-0 flex-shrink-0"
+          className="size-6 p-0 flex-shrink-0"
           title={t("apps.admin.song.delete", "Delete Song")}
         >
-          <Trash className="h-3.5 w-3.5" weight="bold" />
+          <Trash className="size-3.5" weight="bold" />
         </Button>
         <Button
           variant="ghost"
           size="sm"
           onClick={fetchSong}
           disabled={isLoading}
-          className="h-6 w-6 p-0 flex-shrink-0"
+          className="size-6 p-0 flex-shrink-0"
         >
           {isLoading ? (
             <ActivityIndicator size={14} />
           ) : (
-            <ArrowsClockwise className="h-3.5 w-3.5" weight="bold" />
+            <ArrowsClockwise className="size-3.5" weight="bold" />
           )}
         </Button>
       </div>
@@ -660,7 +660,7 @@ export const SongDetailPanel: React.FC<SongDetailPanelProps> = ({
             <div className="space-y-2">
               {/* Title */}
               <div className="flex items-start gap-2 py-1.5">
-                <MusicNote className="h-3.5 w-3.5 text-neutral-400 flex-shrink-0 mt-0.5" weight="bold" />
+                <MusicNote className="size-3.5 text-neutral-400 flex-shrink-0 mt-0.5" weight="bold" />
                 <div className="flex-1 min-w-0">
                   <div className="text-[10px] text-neutral-500">{t("apps.admin.tableHeaders.title", "Title")}</div>
                   {isLoading ? (
@@ -706,7 +706,7 @@ export const SongDetailPanel: React.FC<SongDetailPanelProps> = ({
 
               {/* Artist */}
               <div className="flex items-start gap-2 py-1.5">
-                <User className="h-3.5 w-3.5 text-neutral-400 flex-shrink-0 mt-0.5" weight="bold" />
+                <User className="size-3.5 text-neutral-400 flex-shrink-0 mt-0.5" weight="bold" />
                 <div className="flex-1 min-w-0">
                   <div className="text-[10px] text-neutral-500">{t("apps.admin.tableHeaders.artist", "Artist")}</div>
                   {isLoading ? (
@@ -752,7 +752,7 @@ export const SongDetailPanel: React.FC<SongDetailPanelProps> = ({
 
               {/* Album */}
               <div className="flex items-start gap-2 py-1.5">
-                <VinylRecord className="h-3.5 w-3.5 text-neutral-400 flex-shrink-0 mt-0.5" weight="bold" />
+                <VinylRecord className="size-3.5 text-neutral-400 flex-shrink-0 mt-0.5" weight="bold" />
                 <div className="flex-1 min-w-0">
                   <div className="text-[10px] text-neutral-500">{t("apps.admin.song.album", "Album")}</div>
                   {isLoading ? (
@@ -798,7 +798,7 @@ export const SongDetailPanel: React.FC<SongDetailPanelProps> = ({
 
               {/* Lyric Offset */}
               <div className="flex items-start gap-2 py-1.5">
-                <Clock className="h-3.5 w-3.5 text-neutral-400 flex-shrink-0 mt-0.5" weight="bold" />
+                <Clock className="size-3.5 text-neutral-400 flex-shrink-0 mt-0.5" weight="bold" />
                 <div className="flex-1 min-w-0">
                   <div className="text-[10px] text-neutral-500">{t("apps.admin.song.lyricsOffset", "Lyrics Offset")}</div>
                   {isLoading ? (
@@ -846,7 +846,7 @@ export const SongDetailPanel: React.FC<SongDetailPanelProps> = ({
 
               {/* YouTube ID */}
               <div className="flex items-start gap-2 py-1.5">
-                <Hash className="h-3.5 w-3.5 text-neutral-400 flex-shrink-0 mt-0.5" weight="bold" />
+                <Hash className="size-3.5 text-neutral-400 flex-shrink-0 mt-0.5" weight="bold" />
                 <div className="flex-1 min-w-0">
                   <div className="text-[10px] text-neutral-500">{t("apps.admin.song.youtubeId", "YouTube ID")}</div>
                   {isLoading ? (
@@ -871,7 +871,7 @@ export const SongDetailPanel: React.FC<SongDetailPanelProps> = ({
                           rel="noopener noreferrer"
                           className="text-blue-500 hover:text-blue-600"
                         >
-                          <ArrowSquareOut className="h-3 w-3" weight="bold" />
+                          <ArrowSquareOut className="size-3" weight="bold" />
                         </a>
                       </div>
                     </>
@@ -889,7 +889,7 @@ export const SongDetailPanel: React.FC<SongDetailPanelProps> = ({
             <div className="space-y-2">
               {/* Lyrics Source */}
               <div className="flex items-start gap-2 py-1.5">
-                <FileText className="h-3.5 w-3.5 text-neutral-400 flex-shrink-0 mt-0.5" weight="bold" />
+                <FileText className="size-3.5 text-neutral-400 flex-shrink-0 mt-0.5" weight="bold" />
                 <div className="flex-1 min-w-0">
                   <div className="text-[10px] text-neutral-500">{t("apps.admin.song.lyricsSource", "Lyrics")}</div>
                   {isLoading ? (
@@ -898,7 +898,7 @@ export const SongDetailPanel: React.FC<SongDetailPanelProps> = ({
                     <div className="flex items-center gap-1 mt-0.5">
                       {song?.lyrics?.lrc ? (
                         <>
-                          <Check className="h-3 w-3 text-green-500" weight="bold" />
+                          <Check className="size-3 text-green-500" weight="bold" />
                           <span className="text-[11px] text-green-600">
                             {song.lyrics.parsedLines?.length || 0} {t("apps.admin.song.lines", "lines")}
                             {song.lyrics.krc && (
@@ -910,7 +910,7 @@ export const SongDetailPanel: React.FC<SongDetailPanelProps> = ({
                         </>
                       ) : (
                         <>
-                          <X className="h-3 w-3 text-neutral-400" weight="bold" />
+                          <X className="size-3 text-neutral-400" weight="bold" />
                           <span className="text-[11px] text-neutral-400">
                             {t("apps.admin.song.notAvailable", "Not available")}
                           </span>
@@ -928,7 +928,7 @@ export const SongDetailPanel: React.FC<SongDetailPanelProps> = ({
 
               {/* Furigana */}
               <div className="flex items-start gap-2 py-1.5">
-                <TextT className="h-3.5 w-3.5 text-neutral-400 flex-shrink-0 mt-0.5" weight="bold" />
+                <TextT className="size-3.5 text-neutral-400 flex-shrink-0 mt-0.5" weight="bold" />
                 <div className="flex-1 min-w-0">
                   <div className="text-[10px] text-neutral-500">{t("apps.admin.song.furigana", "Furigana")}</div>
                   {isLoading ? (
@@ -937,14 +937,14 @@ export const SongDetailPanel: React.FC<SongDetailPanelProps> = ({
                     <div className="flex items-center gap-1 mt-0.5">
                       {song?.furigana && song.furigana.length > 0 ? (
                         <>
-                          <Check className="h-3 w-3 text-green-500" weight="bold" />
+                          <Check className="size-3 text-green-500" weight="bold" />
                           <span className="text-[11px] text-green-600">
                             {song.furigana.length} {t("apps.admin.song.lines", "lines")}
                           </span>
                         </>
                       ) : (
                         <>
-                          <X className="h-3 w-3 text-neutral-400" weight="bold" />
+                          <X className="size-3 text-neutral-400" weight="bold" />
                           <span className="text-[11px] text-neutral-400">
                             {t("apps.admin.song.notGenerated", "Not generated")}
                           </span>
@@ -957,7 +957,7 @@ export const SongDetailPanel: React.FC<SongDetailPanelProps> = ({
 
               {/* Translations */}
               <div className="flex items-start gap-2 py-1.5">
-                <Translate className="h-3.5 w-3.5 text-neutral-400 flex-shrink-0 mt-0.5" weight="bold" />
+                <Translate className="size-3.5 text-neutral-400 flex-shrink-0 mt-0.5" weight="bold" />
                 <div className="flex-1 min-w-0">
                   <div className="text-[10px] text-neutral-500">{t("apps.admin.song.translations", "Translations")}</div>
                   {isLoading ? (
@@ -966,7 +966,7 @@ export const SongDetailPanel: React.FC<SongDetailPanelProps> = ({
                     <div className="flex items-center gap-1 mt-0.5">
                       {song?.translations && Object.keys(song.translations).length > 0 ? (
                         <>
-                          <Check className="h-3 w-3 text-green-500" weight="bold" />
+                          <Check className="size-3 text-green-500" weight="bold" />
                           <span className="text-[11px] text-green-600">
                             {Object.keys(song.translations).map(lang => 
                               t(`apps.admin.languages.${lang}`, lang)
@@ -975,7 +975,7 @@ export const SongDetailPanel: React.FC<SongDetailPanelProps> = ({
                         </>
                       ) : (
                         <>
-                          <X className="h-3 w-3 text-neutral-400" weight="bold" />
+                          <X className="size-3 text-neutral-400" weight="bold" />
                           <span className="text-[11px] text-neutral-400">
                             {t("apps.admin.song.notGenerated", "Not generated")}
                           </span>
@@ -988,7 +988,7 @@ export const SongDetailPanel: React.FC<SongDetailPanelProps> = ({
 
               {/* Soramimi */}
               <div className="flex items-start gap-2 py-1.5">
-                <Ear className="h-3.5 w-3.5 text-neutral-400 flex-shrink-0 mt-0.5" weight="bold" />
+                <Ear className="size-3.5 text-neutral-400 flex-shrink-0 mt-0.5" weight="bold" />
                 <div className="flex-1 min-w-0">
                   <div className="text-[10px] text-neutral-500">{t("apps.admin.song.soramimi", "Soramimi (空耳)")}</div>
                   {isLoading ? (
@@ -1010,7 +1010,7 @@ export const SongDetailPanel: React.FC<SongDetailPanelProps> = ({
                           }
                           return (
                             <>
-                              <Check className="h-3 w-3 text-green-500" weight="bold" />
+                              <Check className="size-3 text-green-500" weight="bold" />
                               <span className="text-[11px] text-green-600">
                                 {languages.map(l => t(`apps.admin.languages.${l}`, l)).join(", ")}
                               </span>
@@ -1019,7 +1019,7 @@ export const SongDetailPanel: React.FC<SongDetailPanelProps> = ({
                         }
                         return (
                           <>
-                            <X className="h-3 w-3 text-neutral-400" weight="bold" />
+                            <X className="size-3 text-neutral-400" weight="bold" />
                             <span className="text-[11px] text-neutral-400">
                               {t("apps.admin.song.notGenerated", "Not generated")}
                             </span>

--- a/src/apps/admin/components/UserProfilePanel.tsx
+++ b/src/apps/admin/components/UserProfilePanel.tsx
@@ -424,10 +424,10 @@ export const UserProfilePanel: React.FC<UserProfilePanelProps> = ({
   if (!isLoading && !profile) {
     return (
       <div className="flex flex-col items-center justify-center h-full gap-2">
-        <Warning className="h-8 w-8 text-neutral-400" weight="bold" />
+        <Warning className="size-8 text-neutral-400" weight="bold" />
         <span className="text-[11px] text-neutral-500">{t("apps.admin.profile.notFound")}</span>
         <Button variant="ghost" size="sm" onClick={onBack} className="text-[11px]">
-          <ArrowLeft className="h-3 w-3 mr-1" weight="bold" />
+          <ArrowLeft className="size-3 mr-1" weight="bold" />
           {t("apps.admin.profile.back")}
         </Button>
       </div>
@@ -474,7 +474,7 @@ export const UserProfilePanel: React.FC<UserProfilePanelProps> = ({
       >
         {showCaret && (
           <CaretRight
-            className={cn("h-3 w-3 transition-transform", isOpen && "rotate-90")}
+            className={cn("size-3 transition-transform", isOpen && "rotate-90")}
             weight="bold"
           />
         )}
@@ -492,13 +492,13 @@ export const UserProfilePanel: React.FC<UserProfilePanelProps> = ({
           variant="ghost"
           size="sm"
           onClick={onBack}
-          className="h-6 w-6 p-0"
+          className="size-6 p-0"
         >
-          <ArrowLeft className="h-3.5 w-3.5" weight="bold" />
+          <ArrowLeft className="size-3.5" weight="bold" />
         </Button>
         <div className="flex items-center gap-2">
           <div className={cn(
-            "w-8 h-8 rounded-full flex items-center justify-center text-sm font-medium text-neutral-600",
+            "size-8 rounded-full flex items-center justify-center text-sm font-medium text-neutral-600",
             isLoading ? "bg-neutral-200 animate-pulse" : "bg-neutral-200"
           )}>
             {!isLoading && username[0].toUpperCase()}
@@ -565,7 +565,7 @@ export const UserProfilePanel: React.FC<UserProfilePanelProps> = ({
             <div className="p-2 bg-red-50 rounded border border-red-200">
               <SectionHeader
                 className="flex items-start gap-1.5 text-red-600 mb-1"
-                icon={<Prohibit className="h-3 w-3 mt-px" weight="bold" />}
+                icon={<Prohibit className="size-3 mt-px" weight="bold" />}
               >
                 {t("apps.admin.profile.banDetails")}
               </SectionHeader>
@@ -737,7 +737,7 @@ export const UserProfilePanel: React.FC<UserProfilePanelProps> = ({
                                       <span className="text-purple-700 font-medium break-all">{memory.key}</span>
                                       <CaretRight
                                         className={cn(
-                                          "h-3 w-3 inline-block ml-1 text-neutral-400 transition-transform",
+                                          "size-3 inline-block ml-1 text-neutral-400 transition-transform",
                                           isExpanded && "rotate-90"
                                         )}
                                         weight="bold"
@@ -810,7 +810,7 @@ export const UserProfilePanel: React.FC<UserProfilePanelProps> = ({
                                   >
                                     <CaretRight
                                       className={cn(
-                                        "h-3 w-3 text-neutral-400 transition-transform flex-shrink-0",
+                                        "size-3 text-neutral-400 transition-transform flex-shrink-0",
                                         isExpanded && "rotate-90"
                                       )}
                                       weight="bold"
@@ -919,7 +919,7 @@ export const UserProfilePanel: React.FC<UserProfilePanelProps> = ({
                                         </span>
                                         <CaretRight
                                           className={cn(
-                                            "h-3 w-3 inline-block ml-1 text-neutral-400 transition-transform",
+                                            "size-3 inline-block ml-1 text-neutral-400 transition-transform",
                                             isExpanded && "rotate-90"
                                           )}
                                           weight="bold"

--- a/src/apps/applet-viewer/components/AppStore.tsx
+++ b/src/apps/applet-viewer/components/AppStore.tsx
@@ -474,7 +474,7 @@ export function AppStore({ theme, sharedAppletId, focusWindow }: AppStoreProps) 
     return (
       <>
         <style>{appletIconStyles}</style>
-        <div className="h-full w-full flex items-center justify-center">
+        <div className="size-full flex items-center justify-center">
           <div className="text-center">
             <p className="text-sm text-neutral-600 font-geneva-12 shimmer-gray">{t("apps.applet-viewer.dialogs.loading")}</p>
           </div>
@@ -574,7 +574,7 @@ export function AppStore({ theme, sharedAppletId, focusWindow }: AppStoreProps) 
                   title={applet.featured ? t("apps.applet-viewer.labels.removeFromFeatured") : t("apps.applet-viewer.labels.addToFeatured")}
                 >
                   <Star
-                    className={`h-4 w-4 ${applet.featured ? "text-yellow-400" : "text-gray-400"}`}
+                    className={`size-4 ${applet.featured ? "text-yellow-400" : "text-gray-400"}`}
                     weight={applet.featured ? "fill" : "bold"}
                   />
                 </button>
@@ -586,7 +586,7 @@ export function AppStore({ theme, sharedAppletId, focusWindow }: AppStoreProps) 
                   className="p-1 hover:bg-gray-200 rounded transition-all text-gray-400 inline-flex md:hidden md:group-hover:inline-flex"
                   title={t("apps.applet-viewer.labels.deleteApplet")}
                 >
-                  <Trash className="h-4 w-4" weight="bold" />
+                  <Trash className="size-4" weight="bold" />
                 </button>
               </div>
             )}
@@ -627,7 +627,7 @@ export function AppStore({ theme, sharedAppletId, focusWindow }: AppStoreProps) 
     return (
       <>
         <style>{appletIconStyles}</style>
-        <div className="h-full w-full flex items-center justify-center">
+        <div className="size-full flex items-center justify-center">
           <div className="text-center px-6 font-geneva-12">
             <p className="text-[11px] text-neutral-600 font-geneva-12">
               {t("apps.applet-viewer.dialogs.noAppletsAvailable")}
@@ -646,7 +646,7 @@ export function AppStore({ theme, sharedAppletId, focusWindow }: AppStoreProps) 
     return (
       <>
         <style>{appletIconStyles}</style>
-        <div className="h-full w-full flex flex-col">
+        <div className="size-full flex flex-col">
           {/* Detail view toolbar */}
           <div
             className={`flex items-center gap-3 px-3 py-2 ${
@@ -674,9 +674,9 @@ export function AppStore({ theme, sharedAppletId, focusWindow }: AppStoreProps) 
                 setSelectedApplet(null);
                 setIsSharedApplet(false);
               }}
-              className="h-7 w-7 flex-shrink-0"
+              className="size-7 flex-shrink-0"
             >
-              <ArrowLeft className="h-4 w-4" />
+              <ArrowLeft className="size-4" />
             </Button>
             <div 
               className="!text-2xl flex-shrink-0 applet-icon flex items-center justify-center"
@@ -713,7 +713,7 @@ export function AppStore({ theme, sharedAppletId, focusWindow }: AppStoreProps) 
               <iframe
                 srcDoc={ensureMacFonts(selectedAppletContent)}
                 title={displayName}
-                className="w-full h-full border-0"
+                className="size-full border-0"
                 sandbox={getAppletSandboxAttribute(
                   isTrustedAppletAuthor(selectedApplet?.createdBy)
                 )}
@@ -737,7 +737,7 @@ export function AppStore({ theme, sharedAppletId, focusWindow }: AppStoreProps) 
   return (
     <>
       <style>{appletIconStyles}</style>
-      <div className="h-full w-full flex flex-col">
+      <div className="size-full flex flex-col">
         {!showListView ? (
             <div className="flex-1 overflow-hidden relative">
               <AppStoreFeed
@@ -755,12 +755,12 @@ export function AppStore({ theme, sharedAppletId, focusWindow }: AppStoreProps) 
                 variant={isMacTheme ? "aqua" : "default"}
                 size="sm"
                 onClick={() => feedRef.current?.goToPrevious()}
-                className={`h-7 w-7 p-0 flex items-center justify-center ${
+                className={`size-7 p-0 flex items-center justify-center ${
                   isMacTheme ? "rounded-full" : "rounded-none"
                 }`}
                 style={{ height: "28px", width: "28px" }}
               >
-                <CaretLeft className="h-4 w-4" weight="bold" />
+                <CaretLeft className="size-4" weight="bold" />
               </Button>
               <Button
                 variant={isMacTheme ? "aqua" : "default"}
@@ -774,12 +774,12 @@ export function AppStore({ theme, sharedAppletId, focusWindow }: AppStoreProps) 
                 variant={isMacTheme ? "aqua" : "default"}
                 size="sm"
                 onClick={() => feedRef.current?.goToNext()}
-                className={`h-7 w-7 p-0 flex items-center justify-center ${
+                className={`size-7 p-0 flex items-center justify-center ${
                   isMacTheme ? "rounded-full" : "rounded-none"
                 }`}
                 style={{ height: "28px", width: "28px" }}
               >
-                <CaretRight className="h-4 w-4" weight="bold" />
+                <CaretRight className="size-4" weight="bold" />
               </Button>
             </div>
           </div>
@@ -831,7 +831,7 @@ export function AppStore({ theme, sharedAppletId, focusWindow }: AppStoreProps) 
                 onClick={() => setShowListView(false)}
                 className="flex items-center gap-1 px-1"
               >
-                <Sparkle className="h-4 w-4" weight="fill" />
+                <Sparkle className="size-4" weight="fill" />
                 <span className="text-xs font-geneva-12">{t("apps.applet-viewer.labels.discover")}</span>
               </Button>
             </div>

--- a/src/apps/calendar/components/CalendarAppComponent.tsx
+++ b/src/apps/calendar/components/CalendarAppComponent.tsx
@@ -654,7 +654,7 @@ function WeekTimeGrid({
                   return (
                     <div className="absolute left-0 right-0 pointer-events-none" style={{ top: topPos, zIndex: 5 }}>
                       <div className="flex items-center">
-                        <div className="w-2 h-2 rounded-full -ml-1" style={{ backgroundColor: isXpTheme ? TODAY_RED_XP : TODAY_RED }} />
+                        <div className="size-2 rounded-full -ml-1" style={{ backgroundColor: isXpTheme ? TODAY_RED_XP : TODAY_RED }} />
                         <div className="flex-1 h-px" style={{ backgroundColor: isXpTheme ? TODAY_RED_XP : TODAY_RED }} />
                       </div>
                     </div>
@@ -822,7 +822,7 @@ function DayTimeGrid({
               return (
                 <div className="absolute left-0 right-0 pointer-events-none" style={{ top: topPos, zIndex: 5 }}>
                   <div className="flex items-center">
-                    <div className="w-2 h-2 rounded-full -ml-1 shrink-0" style={{ backgroundColor: isXpTheme ? TODAY_RED_XP : TODAY_RED }} />
+                    <div className="size-2 rounded-full -ml-1 shrink-0" style={{ backgroundColor: isXpTheme ? TODAY_RED_XP : TODAY_RED }} />
                     <div className="flex-1 h-px min-w-0" style={{ backgroundColor: isXpTheme ? TODAY_RED_XP : TODAY_RED }} />
                   </div>
                 </div>
@@ -1002,7 +1002,7 @@ function BottomToolbar({
           <div className="shrink-0">
             <div className="metal-inset-btn-group">
               <button type="button" className="metal-inset-btn metal-inset-icon" onClick={onPrev}>
-                <span className="inline-block w-0 h-0 border-t-[4px] border-t-transparent border-b-[4px] border-b-transparent border-r-[5px] border-r-current" />
+                <span className="inline-block size-0 border-t-[4px] border-t-transparent border-b-[4px] border-b-transparent border-r-[5px] border-r-current" />
               </button>
               {views.map((v) => (
                 <button key={v.id} type="button" className="metal-inset-btn font-geneva-12 !text-[11px] w-[48px] justify-center px-0"
@@ -1011,7 +1011,7 @@ function BottomToolbar({
                 </button>
               ))}
               <button type="button" className="metal-inset-btn metal-inset-icon" onClick={onNext}>
-                <span className="inline-block w-0 h-0 border-t-[4px] border-t-transparent border-b-[4px] border-b-transparent border-l-[5px] border-l-current" />
+                <span className="inline-block size-0 border-t-[4px] border-t-transparent border-b-[4px] border-b-transparent border-l-[5px] border-l-current" />
               </button>
             </div>
           </div>
@@ -1048,7 +1048,7 @@ function BottomToolbar({
                   variant={isSystem7Theme ? "player" : "ghost"}
                   onClick={onToggleCalendarSidebar}
                   data-state={showCalendarSidebar ? "on" : "off"}
-                  className={cn("h-6 w-6", isXpTheme && "text-black")}
+                  className={cn("size-6", isXpTheme && "text-black")}
                   title={t("apps.calendar.sidebar.calendars")}
                 >
                   <SidebarSimple size={14} />
@@ -1057,7 +1057,7 @@ function BottomToolbar({
                   variant={isSystem7Theme ? "player" : "ghost"}
                   onClick={onToggleMiniCalendar}
                   data-state={showMiniCalendar ? "on" : "off"}
-                  className={cn("h-6 w-6", isXpTheme && "text-black")}
+                  className={cn("size-6", isXpTheme && "text-black")}
                 >
                   <CalendarBlank size={14} />
                 </Button>
@@ -1094,12 +1094,12 @@ function BottomToolbar({
           )}
           <div className="flex items-center gap-0 shrink-0">
             <Button variant={isSystem7Theme ? "player" : "ghost"} onClick={onNewEvent}
-              className={cn("h-6 w-6", isXpTheme && "text-black")} title={t("apps.calendar.menu.newEvent")}>
+              className={cn("size-6", isXpTheme && "text-black")} title={t("apps.calendar.menu.newEvent")}>
               <Plus size={12} weight="bold" />
             </Button>
             <Button variant={isSystem7Theme ? "player" : "ghost"}
               onClick={onToggleTodoSidebar} data-state={showTodoSidebar ? "on" : "off"}
-              className={cn("h-6 w-6", isXpTheme && "text-black")} title={t("apps.calendar.sidebar.toDoItems")}>
+              className={cn("size-6", isXpTheme && "text-black")} title={t("apps.calendar.sidebar.toDoItems")}>
               <ListChecks size={12} weight="bold" />
             </Button>
           </div>
@@ -1365,7 +1365,7 @@ export function CalendarAppComponent({
       >
         <div
           ref={containerRef}
-          className={cn("flex flex-col h-full w-full font-os-ui overflow-hidden", isMacOSTheme ? "bg-transparent" : "bg-white")}
+          className={cn("flex flex-col size-full font-os-ui overflow-hidden", isMacOSTheme ? "bg-transparent" : "bg-white")}
         >
           {/* Main content area */}
           <div className={cn("flex-1 flex overflow-hidden", isMacOSTheme && "gap-[5px]")}>

--- a/src/apps/calendar/components/TrayDetails.tsx
+++ b/src/apps/calendar/components/TrayDetails.tsx
@@ -398,7 +398,7 @@ function EventTrayEditor({
         <TrayFieldRow label={t("apps.calendar.event.calendar")} useGeneva={useGeneva}>
           <div className="flex items-center gap-1.5 min-w-0">
             <span
-              className="inline-block w-2.5 h-2.5 shrink-0 rounded-sm border border-black/20"
+              className="inline-block size-2.5 shrink-0 rounded-sm border border-black/20"
               style={{
                 backgroundColor:
                   EVENT_COLOR_MAP[
@@ -619,7 +619,7 @@ function TodoDetails({
         <TrayFieldRow label={t("apps.calendar.event.calendar")} useGeneva={useGeneva}>
           <div className="flex items-center gap-1.5 min-w-0">
             <span
-              className="inline-block w-2.5 h-2.5 shrink-0 rounded-sm border border-black/20"
+              className="inline-block size-2.5 shrink-0 rounded-sm border border-black/20"
               style={{ backgroundColor: color }}
             />
             <select

--- a/src/apps/candybar/components/CandyBarAppComponent.tsx
+++ b/src/apps/candybar/components/CandyBarAppComponent.tsx
@@ -264,7 +264,7 @@ export function CandyBarAppComponent({
       >
         <div
           className={cn(
-            "flex flex-col h-full w-full relative",
+            "flex flex-col size-full relative",
             isMacOSXTheme ? "bg-transparent" : ""
           )}
         >
@@ -330,7 +330,7 @@ export function CandyBarAppComponent({
                   size="icon"
                   onClick={navigateBack}
                   disabled={!canNavigateBack}
-                  className="h-8 w-8"
+                  className="size-8"
                 >
                   <ArrowLeft size={14} weight="bold" />
                 </Button>
@@ -339,7 +339,7 @@ export function CandyBarAppComponent({
                   size="icon"
                   onClick={navigateForward}
                   disabled={!canNavigateForward}
-                  className="h-8 w-8"
+                  className="size-8"
                 >
                   <ArrowRight size={14} weight="bold" />
                 </Button>

--- a/src/apps/chats/components/ChatInput.tsx
+++ b/src/apps/chats/components/ChatInput.tsx
@@ -499,7 +499,7 @@ export const ChatInput = memo(function ChatInput({
                 <button
                   type="button"
                   onClick={handleImageClear}
-                  className={`absolute -top-1.5 -right-1.5 w-5 h-5 flex items-center justify-center z-20 ${
+                  className={`absolute -top-1.5 -right-1.5 size-5 flex items-center justify-center z-20 ${
                     isMacTheme 
                       ? "rounded-full overflow-hidden" 
                       : "rounded-sm bg-black/40 backdrop-blur-sm hover:bg-black/60"
@@ -529,7 +529,7 @@ export const ChatInput = memo(function ChatInput({
                       }}
                     />
                   )}
-                  <X className={`h-2.5 w-2.5 relative z-[3] ${isMacTheme ? "text-neutral-500" : "text-white"}`} weight="bold" />
+                  <X className={`size-2.5 relative z-[3] ${isMacTheme ? "text-neutral-500" : "text-white"}`} weight="bold" />
                 </button>
               </div>
             </motion.div>
@@ -687,7 +687,7 @@ export const ChatInput = memo(function ChatInput({
                       animate={{ opacity: 1 }}
                       exit={{ opacity: 0 }}
                       transition={{ duration: 0.15 }}
-                      className="absolute top-0 left-0 w-full h-full pointer-events-none flex items-center pl-3"
+                      className="absolute top-0 left-0 size-full pointer-events-none flex items-center pl-3"
                     >
                       <span className="text-gray-500 opacity-70 shimmer-gray text-[13px] font-geneva-12">
                         {t("apps.chats.status.thinking")}
@@ -705,7 +705,7 @@ export const ChatInput = memo(function ChatInput({
                             <button
                               type="button"
                               onClick={handleNudgeClick}
-                              className={`w-[22px] h-[22px] flex items-center justify-center ${
+                              className={`size-[22px] flex items-center justify-center ${
                                 isMacTheme
                                   ? "text-neutral-400 hover:text-neutral-800 transition-colors"
                                   : ""
@@ -713,7 +713,7 @@ export const ChatInput = memo(function ChatInput({
                               disabled={isLoading}
                               aria-label={t("apps.chats.ariaLabels.sendNudge")}
                             >
-                              <Hand className="h-4 w-4 -rotate-40" weight="bold" />
+                              <Hand className="size-4 -rotate-40" weight="bold" />
                             </button>
                           </div>
                         </TooltipTrigger>
@@ -731,7 +731,7 @@ export const ChatInput = memo(function ChatInput({
                             <button
                               type="button"
                               onClick={handleMentionClick}
-                              className={`w-[22px] h-[22px] flex items-center justify-center ${
+                              className={`size-[22px] flex items-center justify-center ${
                                 isMacTheme
                                   ? "text-neutral-400 hover:text-neutral-800 transition-colors"
                                   : ""
@@ -739,7 +739,7 @@ export const ChatInput = memo(function ChatInput({
                               disabled={isLoading}
                               aria-label={t("apps.chats.ariaLabels.mentionRyo")}
                             >
-                              <At className="h-4 w-4" weight="bold" />
+                              <At className="size-4" weight="bold" />
                             </button>
                           </div>
                         </TooltipTrigger>
@@ -756,7 +756,7 @@ export const ChatInput = memo(function ChatInput({
                           <button
                             type="button"
                             onClick={() => imageInputRef.current?.click()}
-                            className={`w-[22px] h-[22px] flex items-center justify-center ${
+                            className={`size-[22px] flex items-center justify-center ${
                               isMacTheme
                                 ? "text-neutral-400 hover:text-neutral-800 transition-colors"
                                 : ""
@@ -764,7 +764,7 @@ export const ChatInput = memo(function ChatInput({
                             disabled={isLoading || isProcessingImage}
                             aria-label={t("apps.chats.ariaLabels.attachImage") || "Attach image"}
                           >
-                            <ImageSquare className="h-4 w-4" weight="bold" />
+                            <ImageSquare className="size-4" weight="bold" />
                           </button>
                         </TooltipTrigger>
                         <TooltipContent>
@@ -779,7 +779,7 @@ export const ChatInput = memo(function ChatInput({
                         <button
                           type="button"
                           onClick={() => audioButtonRef.current?.click()}
-                          className={`w-[22px] h-[22px] flex items-center justify-center ${
+                          className={`size-[22px] flex items-center justify-center ${
                             isMacTheme
                               ? "text-neutral-400 hover:text-neutral-800 transition-colors"
                               : ""
@@ -787,7 +787,7 @@ export const ChatInput = memo(function ChatInput({
                           disabled={isTranscribing}
                           aria-label={t("apps.chats.ariaLabels.pushToTalk")}
                         >
-                          <Microphone className="h-4 w-4" weight="bold" />
+                          <Microphone className="size-4" weight="bold" />
                         </button>
                       </TooltipTrigger>
                       <TooltipContent>
@@ -819,7 +819,7 @@ export const ChatInput = memo(function ChatInput({
                       onManualStop?.();
                     }
                   }}
-                  className={`text-xs w-9 h-9 p-0 flex items-center justify-center ${
+                  className={`text-xs size-9 p-0 flex items-center justify-center ${
                     isMacTheme ? "rounded-full" : "rounded-none"
                   } ${
                     isMacTheme
@@ -873,7 +873,7 @@ export const ChatInput = memo(function ChatInput({
                     </>
                   )}
                   <Square
-                    className={`h-4 w-4 ${
+                    className={`size-4 ${
                       isMacTheme
                         ? "text-black/70 relative z-10"
                         : isXpTheme
@@ -894,7 +894,7 @@ export const ChatInput = memo(function ChatInput({
               >
                 <Button
                   type="submit"
-                  className={`text-xs w-9 h-9 p-0 flex items-center justify-center ${
+                  className={`text-xs size-9 p-0 flex items-center justify-center ${
                     isMacTheme ? "rounded-full" : "rounded-none"
                   } ${
                     isMacTheme
@@ -949,7 +949,7 @@ export const ChatInput = memo(function ChatInput({
                     </>
                   )}
                   <ArrowUp
-                    className={`h-4 w-4 ${
+                    className={`size-4 ${
                       isMacTheme
                         ? "text-black/70 relative z-10"
                         : isXpTheme

--- a/src/apps/chats/components/ChatMessages.tsx
+++ b/src/apps/chats/components/ChatMessages.tsx
@@ -331,7 +331,7 @@ function ScrollToBottomButton() {
             </>
           )}
           <CaretDown
-            className={`h-2.5 w-2.5 ${
+            className={`size-2.5 ${
               isMacTheme ? "text-black/70 relative z-10" : "text-neutral-800"
             }`}
             weight="bold"
@@ -538,11 +538,11 @@ const ChatMessageItem = memo(function ChatMessageItem(props: ChatMessageItemProp
                         opacity: isHovered ? 1 : 0,
                         scale: 1,
                       }}
-                      className="h-3 w-3 text-gray-400 hover:text-red-600 transition-colors"
+                      className="size-3 text-gray-400 hover:text-red-600 transition-colors"
                       onClick={() => onDeleteMessage(message)}
                       aria-label={t("apps.chats.ariaLabels.deleteMessage")}
                     >
-                      <Trash className="h-3 w-3" weight="bold" />
+                      <Trash className="size-3" weight="bold" />
                     </motion.button>
                   </TooltipTrigger>
                   <TooltipContent>
@@ -557,14 +557,14 @@ const ChatMessageItem = memo(function ChatMessageItem(props: ChatMessageItemProp
                 opacity: isHovered ? 1 : 0,
                 scale: 1,
               }}
-              className="h-3 w-3 text-gray-400 hover:text-neutral-600 transition-colors"
+              className="size-3 text-gray-400 hover:text-neutral-600 transition-colors"
               onClick={() => onCopyMessage(message)}
               aria-label={t("apps.chats.ariaLabels.copyMessage")}
             >
               {copiedMessageId === messageKey ? (
-                <Check className="h-3 w-3" weight="bold" />
+                <Check className="size-3" weight="bold" />
               ) : (
-                <Copy className="h-3 w-3" weight="bold" />
+                <Copy className="size-3" weight="bold" />
               )}
             </motion.button>
           </>
@@ -614,14 +614,14 @@ const ChatMessageItem = memo(function ChatMessageItem(props: ChatMessageItemProp
                 opacity: isHovered ? 1 : 0,
                 scale: 1,
               }}
-              className="h-3 w-3 text-gray-400 hover:text-neutral-600 transition-colors"
+              className="size-3 text-gray-400 hover:text-neutral-600 transition-colors"
               onClick={() => onCopyMessage(message)}
               aria-label={t("apps.chats.ariaLabels.copyMessage")}
             >
               {copiedMessageId === messageKey ? (
-                <Check className="h-3 w-3" weight="bold" />
+                <Check className="size-3" weight="bold" />
               ) : (
-                <Copy className="h-3 w-3" weight="bold" />
+                <Copy className="size-3" weight="bold" />
               )}
             </motion.button>
             {speechEnabled && (
@@ -631,7 +631,7 @@ const ChatMessageItem = memo(function ChatMessageItem(props: ChatMessageItemProp
                   opacity: isHovered ? 1 : 0,
                   scale: 1,
                 }}
-                className="h-3 w-3 text-gray-400 hover:text-neutral-600 transition-colors"
+                className="size-3 text-gray-400 hover:text-neutral-600 transition-colors"
                 onClick={() => {
                   if (playingMessageId === messageKey) {
                     stop();
@@ -682,10 +682,10 @@ const ChatMessageItem = memo(function ChatMessageItem(props: ChatMessageItemProp
                   speechLoadingId === messageKey ? (
                     <ActivityIndicator size="xs" />
                   ) : (
-                    <Pause className="h-3 w-3" weight="bold" />
+                    <Pause className="size-3" weight="bold" />
                   )
                 ) : (
-                  <SpeakerHigh className="h-3 w-3" weight="bold" />
+                  <SpeakerHigh className="size-3" weight="bold" />
                 )}
               </motion.button>
             )}
@@ -704,13 +704,13 @@ const ChatMessageItem = memo(function ChatMessageItem(props: ChatMessageItemProp
                       opacity: isHovered ? 1 : 0,
                       scale: 1,
                     }}
-                    className="h-3 w-3 text-gray-400 hover:text-blue-600 transition-colors"
+                    className="size-3 text-gray-400 hover:text-blue-600 transition-colors"
                     onClick={() => onSendMessage(message.username!)}
                     aria-label={t("apps.chats.ariaLabels.messageUser", {
                       username: message.username,
                     })}
                   >
-                    <PaperPlaneRight className="h-3 w-3" weight="bold" />
+                    <PaperPlaneRight className="size-3" weight="bold" />
                   </motion.button>
                 </TooltipTrigger>
                 <TooltipContent>
@@ -733,11 +733,11 @@ const ChatMessageItem = memo(function ChatMessageItem(props: ChatMessageItemProp
                     opacity: isHovered ? 1 : 0,
                     scale: 1,
                   }}
-                  className="h-3 w-3 text-gray-400 hover:text-red-600 transition-colors"
+                  className="size-3 text-gray-400 hover:text-red-600 transition-colors"
                   onClick={() => onDeleteMessage(message)}
                   aria-label={t("apps.chats.ariaLabels.deleteMessage")}
                 >
-                  <Trash className="h-3 w-3" weight="bold" />
+                  <Trash className="size-3" weight="bold" />
                 </motion.button>
               </TooltipTrigger>
               <TooltipContent>
@@ -1232,7 +1232,7 @@ function ChatMessagesContent({
           animate={{ opacity: 1, y: 0 }}
           className="flex items-center gap-2 text-gray-500 font-['Geneva-9'] text-[16px] antialiased h-[12px]"
         >
-          <ChatCircle className="h-3 w-3" weight="bold" />
+          <ChatCircle className="size-3" weight="bold" />
           <span>{t("apps.chats.status.startNewConversation")}</span>
           {onClear && (
             <Button
@@ -1339,7 +1339,7 @@ function ChatMessagesContent({
                 animate={{ opacity: 1, y: 0 }}
                 className="flex items-center gap-2 text-gray-500 font-['Geneva-9'] text-[16px] antialiased h-[12px]"
               >
-                <ChatCircle className="h-3 w-3" weight="bold" />
+                <ChatCircle className="size-3" weight="bold" />
                 <span>{errorMessage}</span>
               </motion.div>
             );
@@ -1353,7 +1353,7 @@ function ChatMessagesContent({
               exit={{ opacity: 0 }}
               className="flex items-start gap-2 text-red-600 font-['Geneva-9'] text-[16px] antialiased pl-1 py-1"
             >
-              <WarningCircle className="h-3 w-3 mt-0.5 flex-shrink-0" weight="bold" />
+              <WarningCircle className="size-3 mt-0.5 flex-shrink-0" weight="bold" />
               <div className="flex-1 flex flex-row items-start justify-between gap-1">
                 <span className="leading-none">{errorMessage}</span>
                 {onRetry && (
@@ -1395,7 +1395,7 @@ export function ChatMessages({
   return (
     // Use StickToBottom component as the main container
     <StickToBottom
-      className="flex-1 relative flex flex-col overflow-hidden w-full h-full"
+      className="flex-1 relative flex flex-col overflow-hidden size-full"
       // Optional props for smooth scrolling behavior
       resize="smooth"
       initial="instant"

--- a/src/apps/chats/components/ChatRoomSidebar.tsx
+++ b/src/apps/chats/components/ChatRoomSidebar.tsx
@@ -90,7 +90,7 @@ export const ChatRoomSidebar = React.memo(function ChatRoomSidebar({
         <div className="flex items-center">
           {isPrivateOnline && (
             <span
-              className="inline-block w-1.5 h-1.5 rounded-full bg-green-500 mr-1.5 flex-shrink-0"
+              className="inline-block size-1.5 rounded-full bg-green-500 mr-1.5 flex-shrink-0"
               title="Online"
             />
           )}
@@ -150,7 +150,7 @@ export const ChatRoomSidebar = React.memo(function ChatRoomSidebar({
                 room.type === "private" ? t("apps.chats.ariaLabels.leaveConversation") : t("apps.chats.ariaLabels.deleteRoom")
               }
             >
-              <Trash className="w-3 h-3 text-black/30" weight="bold" />
+              <Trash className="size-3 text-black/30" weight="bold" />
             </button>
           )}
       </div>
@@ -196,9 +196,9 @@ export const ChatRoomSidebar = React.memo(function ChatRoomSidebar({
                     variant="ghost"
                     size="sm"
                     onClick={onAddRoom}
-                    className="flex items-center text-xs hover:bg-black/5 w-[24px] h-[24px]"
+                    className="flex items-center text-xs hover:bg-black/5 size-[24px]"
                   >
-                    <Plus className="w-3 h-3" weight="bold" />
+                    <Plus className="size-3" weight="bold" />
                   </Button>
                 </TooltipTrigger>
                 <TooltipContent>
@@ -270,7 +270,7 @@ export const ChatRoomSidebar = React.memo(function ChatRoomSidebar({
                               <span className="ml-2 opacity-0 group-hover:opacity-100 transition-opacity">
                                 <CaretRight
                                   className={cn(
-                                    "w-2.5 h-2.5 text-black/50 transition-transform",
+                                    "size-2.5 text-black/50 transition-transform",
                                     isChannelsOpen ? "rotate-90" : "rotate-0"
                                   )}
                                 />
@@ -297,7 +297,7 @@ export const ChatRoomSidebar = React.memo(function ChatRoomSidebar({
                             <span className="ml-2 opacity-0 group-hover:opacity-100 transition-opacity">
                               <CaretRight
                                 className={cn(
-                                  "w-2.5 h-2.5 text-black/50 transition-transform",
+                                  "size-2.5 text-black/50 transition-transform",
                                   isPrivateOpen ? "rotate-90" : "rotate-0"
                                 )}
                               />

--- a/src/apps/chats/components/ChatsAppComponent.tsx
+++ b/src/apps/chats/components/ChatsAppComponent.tsx
@@ -611,7 +611,7 @@ export function ChatsAppComponent({
       >
         <div
           ref={containerRef}
-          className={`relative h-full w-full ${
+          className={`relative size-full ${
             isWindowsLegacyTheme ? "border-t border-[#919b9c]" : ""
           }`}
         >
@@ -748,7 +748,7 @@ export function ChatsAppComponent({
                           : `#${currentRoom.name}`
                         : "@ryo"}
                     </h2>
-                    <CaretDown className="h-2.5 w-2.5 transform transition-transform duration-200 text-neutral-400" weight="bold" />
+                    <CaretDown className="size-2.5 transform transition-transform duration-200 text-neutral-400" weight="bold" />
                   </Button>
 
                   {currentRoom &&

--- a/src/apps/chats/components/CreateRoomDialog.tsx
+++ b/src/apps/chats/components/CreateRoomDialog.tsx
@@ -581,7 +581,7 @@ export function CreateRoomDialog({
                             className={cn(themeFont, "text-blue-600")}
                           >
                             <span className="inline-flex items-center gap-1">
-                              <Plus className="h-3 w-3" weight="bold" />
+                              <Plus className="size-3" weight="bold" />
                               Add new server…
                             </span>
                           </SelectItem>
@@ -598,11 +598,11 @@ export function CreateRoomDialog({
                       size="sm"
                       onClick={() => handleDeleteIrcServer(selectedServer)}
                       disabled={isLoading}
-                      className="h-8 w-8 p-0"
+                      className="size-8 p-0"
                       title="Remove server"
                       aria-label="Remove server"
                     >
-                      <Trash className="h-3 w-3" weight="bold" />
+                      <Trash className="size-3" weight="bold" />
                     </Button>
                   )}
                 </div>
@@ -667,7 +667,7 @@ export function CreateRoomDialog({
                         id="new-irc-tls"
                         checked={newServerTls}
                         onCheckedChange={(v) => setNewServerTls(Boolean(v))}
-                        className="h-4 w-4"
+                        className="size-4"
                         disabled={isAddingServer}
                       />
                       <span>TLS</span>
@@ -743,7 +743,7 @@ export function CreateRoomDialog({
                     >
                       <ArrowClockwise
                         className={cn(
-                          "h-3 w-3",
+                          "size-3",
                           isLoadingChannels && "animate-spin"
                         )}
                         weight="bold"
@@ -1005,7 +1005,7 @@ export function CreateRoomDialog({
                           className="ml-1 hover:bg-gray-300 rounded-sm p-0.5"
                           disabled={isLoading}
                         >
-                          <X className="h-3 w-3" weight="bold" />
+                          <X className="size-3" weight="bold" />
                         </button>
                       </Badge>
                     ))}
@@ -1031,7 +1031,7 @@ export function CreateRoomDialog({
                           onCheckedChange={() =>
                             toggleUserSelection(user.username)
                           }
-                          className="h-4 w-4"
+                          className="size-4"
                           disabled={isLoading}
                         />
                         <span className="ml-2">@{user.username}</span>

--- a/src/apps/chats/components/TokenStatus.tsx
+++ b/src/apps/chats/components/TokenStatus.tsx
@@ -17,7 +17,7 @@ export function TokenStatus() {
   if (debugMode && username && isAuthenticated) {
     return (
       <div className="flex items-center gap-1 px-2 py-0.5">
-        <CheckCircle className="h-3 w-3 text-green-500" weight="bold" />
+        <CheckCircle className="size-3 text-green-500" weight="bold" />
         <span className="font-geneva-12 text-[11px] text-green-600">
           {t("apps.chats.tokenStatus.authenticated", { defaultValue: "Logged in" })}
         </span>

--- a/src/apps/contacts/components/ContactsAppComponent.tsx
+++ b/src/apps/contacts/components/ContactsAppComponent.tsx
@@ -61,11 +61,11 @@ function ContactListItem({
         <img
           src={contact.picture}
           alt=""
-          className="shrink-0 w-5 h-5 rounded-full bg-white/70 shadow-[inset_0_0_0_1px_rgba(0,0,0,0.15)] object-contain"
+          className="shrink-0 size-5 rounded-full bg-white/70 shadow-[inset_0_0_0_1px_rgba(0,0,0,0.15)] object-contain"
         />
       ) : (
         <div
-          className="shrink-0 w-5 h-5 rounded-full shadow-[inset_0_0_0_1px_rgba(0,0,0,0.15)] bg-[linear-gradient(to_bottom,#e0e0e0,#c8c8c8)] flex items-center justify-center text-[8px] font-semibold text-white"
+          className="shrink-0 size-5 rounded-full shadow-[inset_0_0_0_1px_rgba(0,0,0,0.15)] bg-[linear-gradient(to_bottom,#e0e0e0,#c8c8c8)] flex items-center justify-center text-[8px] font-semibold text-white"
           style={{ textShadow: smallAvatarInitialsTextShadow }}
         >
           {getContactInitials(contact)}
@@ -281,7 +281,7 @@ export function ContactsAppComponent({
         <div
           ref={containerRef}
           className={cn(
-            "h-full w-full flex flex-col font-os-ui overflow-hidden",
+            "size-full flex flex-col font-os-ui overflow-hidden",
             isMacOsxTheme ? "bg-transparent" : isSystem7Theme ? "bg-white" : "bg-[#efede4]"
           )}
         >
@@ -383,7 +383,7 @@ export function ContactsAppComponent({
                       variant={isSystem7Theme ? "player" : "ghost"}
                       onClick={() => setShowGroupSidebar((current) => !current)}
                       data-state={showGroupSidebar && !isCardOnlyView ? "on" : "off"}
-                      className={cn("h-6 w-6 px-0", isXpTheme && "text-black")}
+                      className={cn("size-6 px-0", isXpTheme && "text-black")}
                       title={t("apps.contacts.views.toggleGroups", { defaultValue: "Toggle Groups" })}
                     >
                       <SidebarSimple size={14} />
@@ -394,7 +394,7 @@ export function ContactsAppComponent({
                     variant={isSystem7Theme ? "player" : "ghost"}
                     onClick={() => setIsCardOnlyView((current) => !current)}
                     data-state={isCardOnlyView ? "on" : "off"}
-                    className={cn("h-6 w-6 px-0", isXpTheme && "text-black")}
+                    className={cn("size-6 px-0", isXpTheme && "text-black")}
                     title={t("apps.contacts.views.cardOnly", { defaultValue: "Card Only" })}
                   >
                     <IdentificationCard size={14} />
@@ -403,7 +403,7 @@ export function ContactsAppComponent({
                     type="button"
                     variant={isSystem7Theme ? "player" : "ghost"}
                     onClick={handleCreateContactAndEdit}
-                    className={cn("h-6 w-6 px-0", isXpTheme && "text-black")}
+                    className={cn("size-6 px-0", isXpTheme && "text-black")}
                     title={t("apps.contacts.menu.newContact")}
                   >
                     <Plus size={12} weight="bold" />
@@ -412,7 +412,7 @@ export function ContactsAppComponent({
                     type="button"
                     variant={isSystem7Theme ? "player" : "ghost"}
                     onClick={handleImport}
-                    className={cn("h-6 w-6 px-0", isXpTheme && "text-black")}
+                    className={cn("size-6 px-0", isXpTheme && "text-black")}
                     title={t("apps.contacts.menu.importVCard")}
                   >
                     <DownloadSimple size={12} weight="bold" />
@@ -546,7 +546,7 @@ export function ContactsAppComponent({
                     <button
                       type="button"
                       onClick={() => setIsPicturePickerOpen(true)}
-                      className="w-12 h-12 shrink-0 rounded-full shadow-[inset_0_0_0_1px_rgba(0,0,0,0.15)] flex items-center justify-center text-base font-semibold text-white overflow-hidden cursor-pointer hover:opacity-90 transition-opacity"
+                      className="size-12 shrink-0 rounded-full shadow-[inset_0_0_0_1px_rgba(0,0,0,0.15)] flex items-center justify-center text-base font-semibold text-white overflow-hidden cursor-pointer hover:opacity-90 transition-opacity"
                       style={
                         selectedContact.picture
                           ? { background: "rgba(255, 255, 255, 0.72)" }
@@ -561,7 +561,7 @@ export function ContactsAppComponent({
                         <img
                           src={selectedContact.picture}
                           alt={selectedContact.displayName}
-                          className="w-full h-full object-contain"
+                          className="size-full object-contain"
                         />
                       ) : (
                         getContactInitials(selectedContact)

--- a/src/apps/control-panels/components/ControlPanelsAppComponent.tsx
+++ b/src/apps/control-panels/components/ControlPanelsAppComponent.tsx
@@ -178,7 +178,7 @@ function SyncSectionTitle({
         <ThemedIcon
           name="/icons/default/cloud-sync.png"
           alt=""
-          className="w-8 h-8 object-contain"
+          className="size-8 object-contain"
         />
       </div>
       <div className="min-w-0 space-y-1">
@@ -212,7 +212,7 @@ function SyncDomainRow({
         <ThemedIcon
           name={getAppIconPath(appId)}
           alt=""
-          className="h-8 w-8 shrink-0 object-contain"
+          className="size-8 shrink-0 object-contain"
         />
         <div className="space-y-0.5 min-w-0">
           <Label className="leading-none">{label}</Label>
@@ -230,7 +230,7 @@ function SyncDomainRow({
 
 const userAvatarInitialsTextShadow =
   "0 2px 3px rgba(0, 0, 0, 0.45), 0 0 3px rgba(0, 0, 0, 0.15)";
-const controlPanelItemIconShell = "w-8 h-8 shrink-0";
+const controlPanelItemIconShell = "size-8 shrink-0";
 
 export function ControlPanelsAppComponent({
   isWindowOpen,
@@ -460,7 +460,7 @@ export function ControlPanelsAppComponent({
         menuBar={isXpTheme ? menuBar : undefined}
       >
         <div
-          className={`flex flex-col h-full w-full ${
+          className={`flex flex-col size-full ${
             isWindowsLegacyTheme ? "pt-0 pb-2 px-2" : ""
           } ${
             isClassicMacTheme
@@ -470,7 +470,7 @@ export function ControlPanelsAppComponent({
               : ""
           }`}
         >
-          <Tabs defaultValue={defaultTab} className="w-full h-full">
+          <Tabs defaultValue={defaultTab} className="size-full">
             <ThemedTabsList>
               <ThemedTabsTrigger value="appearance">
                 {t("apps.control-panels.appearance")}
@@ -1010,7 +1010,7 @@ export function ControlPanelsAppComponent({
                                 <img
                                   src={myContact.picture}
                                   alt={accountAvatarLabel}
-                                  className="w-full h-full object-contain"
+                                  className="size-full object-contain"
                                 />
                               ) : (
                                 accountAvatarInitials
@@ -1018,7 +1018,7 @@ export function ControlPanelsAppComponent({
                             </div>
                             <span
                               className={cn(
-                                "absolute -bottom-px -right-px block h-[10px] w-[10px] rounded-full border-[1.5px] border-white",
+                                "absolute -bottom-px -right-px block size-[10px] rounded-full border-[1.5px] border-white",
                                 realtimeStatus === "connected"
                                   ? "bg-green-500"
                                   : realtimeStatus === "connecting"
@@ -1117,7 +1117,7 @@ export function ControlPanelsAppComponent({
                             <img
                               src="/apple-touch-icon.png"
                               alt={t("apps.control-panels.ryOSAccount")}
-                              className="w-8 h-8 object-contain"
+                              className="size-8 object-contain"
                             />
                           </div>
                           <div className="flex flex-col gap-0.5 min-w-0">

--- a/src/apps/control-panels/components/WallpaperPicker.tsx
+++ b/src/apps/control-panels/components/WallpaperPicker.tsx
@@ -99,7 +99,7 @@ function WallpaperItem({
         )}
         <video
           ref={videoRef}
-          className="absolute inset-0 w-full h-full object-cover"
+          className="absolute inset-0 size-full object-cover"
           src={displayUrl}
           loop
           muted
@@ -497,7 +497,7 @@ export function WallpaperPicker({ onSelect }: WallpaperPickerProps) {
                   }
                 }}
               >
-                <Plus className="h-5 w-5 text-gray-500" weight="bold" />
+                <Plus className="size-5 text-gray-500" weight="bold" />
               </button>
               {customWallpaperRefs.length > 0 ? (
                 customWallpaperRefs.map((path) => (
@@ -517,7 +517,7 @@ export function WallpaperPicker({ onSelect }: WallpaperPickerProps) {
                       className="absolute top-1 right-1 p-0.5 rounded bg-black/50 text-white opacity-0 group-hover:opacity-100 transition-opacity cursor-pointer hover:bg-red-600/80"
                       onClick={(e) => handleDeleteWallpaper(e, path)}
                     >
-                      <Trash className="h-3.5 w-3.5" weight="bold" />
+                      <Trash className="size-3.5" weight="bold" />
                     </button>
                   </div>
                 ))

--- a/src/apps/finder/components/AirDropView.tsx
+++ b/src/apps/finder/components/AirDropView.tsx
@@ -32,7 +32,7 @@ interface UserAvatarProps {
 function UserAvatar({ username, picture, initials, label, size = "sm", onDrop, className, style }: UserAvatarProps) {
   const [isDragOver, setIsDragOver] = useState(false);
   const isLarge = size === "lg";
-  const avatarSize = isLarge ? "w-16 h-16" : "w-12 h-12";
+  const avatarSize = isLarge ? "size-16" : "size-12";
 
   const handleDragOver = useCallback(
     (e: DragEvent<HTMLDivElement>) => {
@@ -113,7 +113,7 @@ function UserAvatar({ username, picture, initials, label, size = "sm", onDrop, c
           <img
             src={picture}
             alt={label}
-            className="w-full h-full object-contain"
+            className="size-full object-contain"
           />
         ) : (
           initials
@@ -221,7 +221,7 @@ export function AirDropView({
         <ThemedIcon
           name="/icons/default/cloud-sync.png"
           alt="AirDrop"
-          className="w-20 h-20"
+          className="size-20"
         />
         <div>
           <p className="text-[13px] font-semibold mb-1">
@@ -250,7 +250,7 @@ export function AirDropView({
   return (
     <div
       ref={containerRef}
-      className="relative h-full w-full select-none overflow-hidden"
+      className="relative size-full select-none overflow-hidden"
     >
       {/* Concentric circles — centered horizontally, bottom-aligned to container */}
       {ringRadii.map((r, i) => (

--- a/src/apps/finder/components/FileList.tsx
+++ b/src/apps/finder/components/FileList.tsx
@@ -215,7 +215,7 @@ const ListRowItem = memo(function ListRowItem({
           <img
             src={file.contentUrl}
             alt={file.name}
-            className="w-4 h-4 object-cover rounded-sm"
+            className="size-4 object-cover rounded-sm"
             style={{ imageRendering: isImageFile(file) ? "pixelated" : "auto" }}
             onError={(e) => {
               console.error(`Error loading thumbnail for ${file.name}`);
@@ -226,7 +226,7 @@ const ListRowItem = memo(function ListRowItem({
           <ThemedIcon
             name={getIconPath(file)}
             alt={getListIconAlt(file)}
-            className="w-4 h-4"
+            className="size-4"
             style={{ imageRendering: "pixelated" }}
             data-legacy-aware="true"
           />

--- a/src/apps/finder/components/FinderAppComponent.tsx
+++ b/src/apps/finder/components/FinderAppComponent.tsx
@@ -65,7 +65,7 @@ function SidebarItem({
       )}
       data-selected={isActive ? "true" : undefined}
     >
-      <ThemedIcon name={icon} alt="" className="w-8 h-8 shrink-0 [image-rendering:auto]" />
+      <ThemedIcon name={icon} alt="" className="size-8 shrink-0 [image-rendering:auto]" />
       <span className="truncate">{name}</span>
     </button>
   );
@@ -303,7 +303,7 @@ export function FinderAppComponent({
         <div
           ref={containerRef}
           className={cn(
-            "flex flex-col h-full w-full relative",
+            "flex flex-col size-full relative",
             isDraggingOver && currentPath === "/Documents"
               ? "after:absolute after:inset-0 after:bg-black/20"
               : "",
@@ -410,7 +410,7 @@ export function FinderAppComponent({
                       }
                     }}
                     disabled={!isAirDropView && !canNavigateBack()}
-                    className="h-8 w-8"
+                    className="size-8"
                   >
                     <ArrowLeft size={14} weight="bold" />
                   </Button>
@@ -419,7 +419,7 @@ export function FinderAppComponent({
                     size="icon"
                     onClick={navigateForward}
                     disabled={!canNavigateForward()}
-                    className="h-8 w-8"
+                    className="size-8"
                   >
                     <ArrowRight size={14} weight="bold" />
                   </Button>
@@ -428,7 +428,7 @@ export function FinderAppComponent({
                     size="icon"
                     onClick={navigateUp}
                     disabled={currentPath === "/"}
-                    className="h-8 w-8"
+                    className="size-8"
                     onDragOver={handleParentButtonDragOver}
                     onDragLeave={handleParentButtonDragLeave}
                     onDrop={handleParentButtonDrop}

--- a/src/apps/finder/components/FinderMenuBar.tsx
+++ b/src/apps/finder/components/FinderMenuBar.tsx
@@ -333,7 +333,7 @@ export function FinderMenuBar({
             <ThemedIcon
               name="/icons/default/cloud-sync.png"
               alt=""
-              className="w-4 h-4 [image-rendering:pixelated]"
+              className="size-4 [image-rendering:pixelated]"
             />
             {t("apps.finder.airdrop.title")}
           </MenubarItem>
@@ -349,7 +349,7 @@ export function FinderMenuBar({
               <ThemedIcon
                 name={folder.icon || "/icons/directory.png"}
                 alt=""
-                className="w-4 h-4 [image-rendering:pixelated]"
+                className="size-4 [image-rendering:pixelated]"
               />
               {folder.name}
             </MenubarItem>
@@ -367,7 +367,7 @@ export function FinderMenuBar({
                   : "/icons/trash-full.png"
               }
               alt=""
-              className="w-4 h-4 [image-rendering:pixelated]"
+              className="size-4 [image-rendering:pixelated]"
             />
             {t("common.menu.trash")}
           </MenubarItem>

--- a/src/apps/internet-explorer/components/InternetExplorerAppComponent.tsx
+++ b/src/apps/internet-explorer/components/InternetExplorerAppComponent.tsx
@@ -369,7 +369,7 @@ export function InternetExplorerAppComponent({
           onNavigatePrevious={onNavigatePrevious}
           menuBar={isXpTheme ? menuBar : undefined}
         >
-          <div className="flex flex-col h-full w-full relative">
+          <div className="flex flex-col size-full relative">
             <div
               className={`flex flex-col gap-1 p-1 ${
                 isXpTheme
@@ -394,7 +394,7 @@ export function InternetExplorerAppComponent({
                     size="icon"
                     onClick={handleGoBack}
                     disabled={isOffline || historyIndex >= history.length - 1}
-                    className="h-8 w-8"
+                    className="size-8"
                   >
                     <ArrowLeft size={14} weight="bold" />
                   </Button>
@@ -403,7 +403,7 @@ export function InternetExplorerAppComponent({
                     size="icon"
                     onClick={handleGoForward}
                     disabled={isOffline || historyIndex <= 0}
-                    className="h-8 w-8"
+                    className="size-8"
                   >
                     <ArrowRight size={14} weight="bold" />
                   </Button>
@@ -413,7 +413,7 @@ export function InternetExplorerAppComponent({
                         variant="ghost"
                         size="icon"
                         onClick={handleSharePage}
-                        className="h-8 w-8 focus-visible:ring-0 focus-visible:ring-offset-0"
+                        className="size-8 focus-visible:ring-0 focus-visible:ring-offset-0"
                         aria-label="Share this page"
                       >
                         <Export size={14} weight="bold" />
@@ -648,14 +648,14 @@ export function InternetExplorerAppComponent({
                           >
                             {suggestion.type === "search" ? (
                               <MagnifyingGlass
-                                className="w-4 h-4 text-neutral-400"
+                                className="size-4 text-neutral-400"
                                 weight="bold"
                               />
                             ) : suggestion.favicon && !isOffline ? (
                               <img
                                 src={suggestion.favicon}
                                 alt=""
-                                className="w-4 h-4"
+                                className="size-4"
                                 onError={(e) => {
                                   e.currentTarget.src =
                                     "/icons/default/ie-site.png";
@@ -665,7 +665,7 @@ export function InternetExplorerAppComponent({
                               <ThemedIcon
                                 name="ie-site.png"
                                 alt=""
-                                className="w-4 h-4 [image-rendering:pixelated]"
+                                className="size-4 [image-rendering:pixelated]"
                               />
                             )}
                             <div className="flex-1 truncate">
@@ -702,7 +702,7 @@ export function InternetExplorerAppComponent({
                         disabled={
                           isFetchingCachedYears || cachedYears.length <= 1
                         }
-                        className={`h-7 w-7 absolute right-1 top-1/2 -translate-y-1/2 focus-visible:ring-0 focus-visible:ring-offset-0 ${
+                        className={`size-7 absolute right-1 top-1/2 -translate-y-1/2 focus-visible:ring-0 focus-visible:ring-offset-0 ${
                           cachedYears.length > 1
                             ? ""
                             : "opacity-50 cursor-not-allowed"
@@ -714,7 +714,7 @@ export function InternetExplorerAppComponent({
                         }}
                       >
                         <ClockCounterClockwise
-                          className={`h-4 w-4 ${
+                          className={`size-4 ${
                             cachedYears.length > 1
                               ? "text-orange-500"
                               : "text-neutral-400"
@@ -800,7 +800,7 @@ export function InternetExplorerAppComponent({
                                 <ThemedIcon
                                   name="directory.png"
                                   alt="Folder"
-                                  className="w-4 h-4 mr-1 [image-rendering:pixelated]"
+                                  className="size-4 mr-1 [image-rendering:pixelated]"
                                 />
                                 <span className="truncate">
                                   {favorite.title}
@@ -828,7 +828,7 @@ export function InternetExplorerAppComponent({
                                     <img
                                       src={child.favicon}
                                       alt=""
-                                      className="w-4 h-4"
+                                      className="size-4"
                                       onError={(e) => {
                                         e.currentTarget.src =
                                           "/icons/default/ie-site.png";
@@ -838,7 +838,7 @@ export function InternetExplorerAppComponent({
                                     <ThemedIcon
                                       name="ie-site.png"
                                       alt=""
-                                      className="w-4 h-4 [image-rendering:pixelated]"
+                                      className="size-4 [image-rendering:pixelated]"
                                     />
                                   )}
                                   {child.title}
@@ -879,7 +879,7 @@ export function InternetExplorerAppComponent({
                               <img
                                 src={favorite.favicon}
                                 alt="Site"
-                                className="w-4 h-4 mr-1"
+                                className="size-4 mr-1"
                                 onError={(e) => {
                                   e.currentTarget.src =
                                     "/icons/default/ie-site.png";
@@ -889,7 +889,7 @@ export function InternetExplorerAppComponent({
                               <ThemedIcon
                                 name="ie-site.png"
                                 alt="Site"
-                                className="w-4 h-4 mr-1 [image-rendering:pixelated]"
+                                className="size-4 mr-1 [image-rendering:pixelated]"
                               />
                             )}
                             <span className="truncate">{favorite.title}</span>
@@ -913,7 +913,7 @@ export function InternetExplorerAppComponent({
               ) : isFutureYear ||
                 (mode === "past" &&
                   (isAiLoading || aiGeneratedHtml !== null)) ? (
-                <div className="w-full h-full overflow-hidden absolute inset-0 font-geneva-12">
+                <div className="size-full overflow-hidden absolute inset-0 font-geneva-12">
                   <HtmlPreview
                     htmlContent={
                       isAiLoading ? generatedHtml || "" : aiGeneratedHtml || ""

--- a/src/apps/internet-explorer/components/InternetExplorerMenuBar.tsx
+++ b/src/apps/internet-explorer/components/InternetExplorerMenuBar.tsx
@@ -72,7 +72,7 @@ const renderFavoriteItem = (
           <ThemedIcon
             name="directory.png"
             alt="Folder"
-            className="w-4 h-4 [image-rendering:pixelated]"
+            className="size-4 [image-rendering:pixelated]"
           />
           {favorite.title}
         </MenubarSubTrigger>
@@ -95,7 +95,7 @@ const renderFavoriteItem = (
           <img
             src={favorite.favicon}
             alt=""
-            className="w-4 h-4"
+            className="size-4"
             onError={(e) => {
               e.currentTarget.src = "/icons/default/ie-site.png";
             }}
@@ -104,7 +104,7 @@ const renderFavoriteItem = (
           <ThemedIcon
             name="ie-site.png"
             alt=""
-            className="w-4 h-4 [image-rendering:pixelated]"
+            className="size-4 [image-rendering:pixelated]"
           />
         )}
         {favorite.title}
@@ -714,7 +714,7 @@ export function InternetExplorerMenuBar({
                     <img
                       src={entry.favicon}
                       alt=""
-                      className="w-4 h-4"
+                      className="size-4"
                       onError={(e) => {
                         e.currentTarget.src = "/icons/default/ie-site.png";
                       }}
@@ -723,7 +723,7 @@ export function InternetExplorerMenuBar({
                     <ThemedIcon
                       name="ie-site.png"
                       alt=""
-                      className="w-4 h-4 [image-rendering:pixelated]"
+                      className="size-4 [image-rendering:pixelated]"
                     />
                   )}
                   <span className="truncate">

--- a/src/apps/internet-explorer/components/TimeMachineView.tsx
+++ b/src/apps/internet-explorer/components/TimeMachineView.tsx
@@ -783,10 +783,10 @@ const TimeMachineView: React.FC<TimeMachineViewProps> = ({
                         }}
                       >
                         {/* Placeholder Content / HtmlPreview container */}
-                        <div className="w-full h-full">
+                        <div className="size-full">
                           {/* Only render content for the active pane */}
                           {distance === 0 && (
-                            <div className="w-full h-full flex items-center justify-center">
+                            <div className="size-full flex items-center justify-center">
                               <AnimatePresence mode="wait">
                                 <motion.div
                                   key={previewStatus} // Animate based on status change
@@ -794,11 +794,11 @@ const TimeMachineView: React.FC<TimeMachineViewProps> = ({
                                   animate={{ opacity: 1 }}
                                   exit={{ opacity: 0 }}
                                   transition={{ duration: 0.2 }}
-                                  className="w-full h-full"
+                                  className="size-full"
                                 >
                                   {previewStatus === "loading" && (
                                     <motion.div
-                                      className="w-full h-full flex items-center justify-center bg-transparent"
+                                      className="size-full flex items-center justify-center bg-transparent"
                                       variants={pulsingAnimationVariants}
                                       animate="loading"
                                     >
@@ -808,7 +808,7 @@ const TimeMachineView: React.FC<TimeMachineViewProps> = ({
                                     </motion.div>
                                   )}
                                   {previewStatus === "error" && (
-                                    <div className="w-full h-full flex items-center justify-center p-4">
+                                    <div className="size-full flex items-center justify-center p-4">
                                       <p className="text-red-400 text-center">
                                         {previewError ||
                                           t("apps.internet-explorer.errorLoadingPreview")}
@@ -824,7 +824,7 @@ const TimeMachineView: React.FC<TimeMachineViewProps> = ({
                                           duration: 0.5,
                                           delay: 0.1,
                                         }}
-                                        className="w-full h-full overflow-hidden"
+                                        className="size-full overflow-hidden"
                                       >
                                         {previewSourceType === "url" && (
                                           <motion.div // Animate iframe opacity based on load state
@@ -835,7 +835,7 @@ const TimeMachineView: React.FC<TimeMachineViewProps> = ({
                                                 ? "loaded"
                                                 : "loading"
                                             } // Use pulsing when loading, solid when loaded
-                                            className="w-full h-full relative"
+                                            className="size-full relative"
                                           >
                                             <AnimatePresence>
                                               {!isIframeLoaded && (
@@ -852,7 +852,7 @@ const TimeMachineView: React.FC<TimeMachineViewProps> = ({
                                             </AnimatePresence>
                                             <iframe
                                               src={previewContent}
-                                              className="w-full h-full border-none bg-white"
+                                              className="size-full border-none bg-white"
                                               sandbox="allow-scripts allow-forms allow-same-origin allow-popups allow-pointer-lock"
                                               title={`Preview for ${previewYear}`}
                                               onLoad={() => {
@@ -879,7 +879,7 @@ const TimeMachineView: React.FC<TimeMachineViewProps> = ({
                                             initial={{ opacity: 0 }} // Start transparent
                                             animate={{ opacity: 1 }} // Always fade in fully for HTML content
                                             transition={{ duration: 0.5 }} // Match iframe fade duration
-                                            className="w-full h-full"
+                                            className="size-full"
                                           >
                                             <HtmlPreview
                                               htmlContent={previewContent}
@@ -899,7 +899,7 @@ const TimeMachineView: React.FC<TimeMachineViewProps> = ({
                                   {(previewStatus === "idle" ||
                                     (previewStatus === "success" &&
                                       !previewContent)) && (
-                                    <div className="w-full h-full flex items-center justify-center">
+                                    <div className="size-full flex items-center justify-center">
                                       {" "}
                                       {/* Placeholder/Idle */}{" "}
                                     </div>
@@ -910,7 +910,7 @@ const TimeMachineView: React.FC<TimeMachineViewProps> = ({
                           )}
                           {/* Add a subtle background or placeholder for non-active cards */}
                           {distance !== 0 && (
-                            <div className="w-full h-full bg-neutral-900/30"></div> // Simple background
+                            <div className="size-full bg-neutral-900/30"></div> // Simple background
                           )}
                         </div>
                       </motion.div>
@@ -1076,7 +1076,7 @@ const TimeMachineView: React.FC<TimeMachineViewProps> = ({
                 <Button
                   variant="ghost"
                   size="icon"
-                  className="h-7 w-7 rounded-full hover:bg-white/10 opacity-60 hover:opacity-100 transition-opacity"
+                  className="size-7 rounded-full hover:bg-white/10 opacity-60 hover:opacity-100 transition-opacity"
                   onClick={handleSharePage}
                   aria-label={t("apps.internet-explorer.shareThisPageAndTime")}
                 >
@@ -1145,7 +1145,7 @@ const TimeMachineView: React.FC<TimeMachineViewProps> = ({
                     <Button
                       variant="ghost"
                       size="icon"
-                      className="h-7 w-7 rounded-full hover:bg-white/10 opacity-60 hover:opacity-100 transition-opacity"
+                      className="size-7 rounded-full hover:bg-white/10 opacity-60 hover:opacity-100 transition-opacity"
                     >
                       <Sparkle size={16} className="text-neutral-300" weight="bold" />
                     </Button>

--- a/src/apps/ipod/components/IpodScreen.tsx
+++ b/src/apps/ipod/components/IpodScreen.tsx
@@ -744,7 +744,7 @@ export function IpodScreen({
               `w-6 font-chicago ${isPlaying ? "text-xs" : "text-[18px]"}`
             )}
           >
-            <div className="flex items-center justify-center w-4 h-4 mt-0.5">
+            <div className="flex items-center justify-center size-4 mt-0.5">
               {isPlaying ? "▶" : "⏸︎"}
             </div>
           </div>
@@ -801,7 +801,7 @@ export function IpodScreen({
             // overshoots and reads slightly high.
             <div
               className={cn(
-                "flex items-center justify-center w-[14px] h-[14px] [transform:translateY(-0.5px)]",
+                "flex items-center justify-center size-[14px] [transform:translateY(-0.5px)]",
                 // Same light top highlight as the title line — title uses
                 // [text-shadow:0_1px_0_rgba(255,255,255,0.9)]; SVG paths
                 // use filter drop-shadow so the blue gradient reads with
@@ -1232,7 +1232,7 @@ export function IpodScreen({
               />
             ) : (
               <div
-                className="w-full h-full"
+                className="size-full"
                 style={
                   effectiveDisplayMode !== DisplayMode.Video
                     ? { visibility: "hidden", pointerEvents: "none" }
@@ -1340,7 +1340,7 @@ export function IpodScreen({
                   <motion.img
                     src={coverUrl}
                     alt={currentTrack?.title}
-                    className="w-full h-full object-cover brightness-50 pointer-events-none"
+                    className="size-full object-cover brightness-50 pointer-events-none"
                     initial={{ opacity: 0 }}
                     animate={{ opacity: 1 }}
                     exit={{ opacity: 0 }}

--- a/src/apps/ipod/components/PipPlayer.tsx
+++ b/src/apps/ipod/components/PipPlayer.tsx
@@ -80,16 +80,16 @@ export function PipPlayer({
     >
       {/* Thumbnail */}
       <div
-        className="relative w-12 h-12 flex-shrink-0 overflow-hidden rounded"
+        className="relative size-12 flex-shrink-0 overflow-hidden rounded"
       >
         {thumbnailUrl ? (
           <img
             src={thumbnailUrl}
             alt={currentTrack?.title || ""}
-            className="w-full h-full object-cover"
+            className="size-full object-cover"
           />
         ) : (
-          <div className="w-full h-full flex items-center justify-center bg-white/10 text-white/40">
+          <div className="size-full flex items-center justify-center bg-white/10 text-white/40">
             <MusicNote size={24} weight="fill" />
           </div>
         )}
@@ -138,7 +138,7 @@ export function PipPlayer({
         <button
           onClick={onPreviousTrack}
           onTouchStart={(e) => e.stopPropagation()}
-          className="w-8 h-8 flex items-center justify-center rounded-full text-white/70 hover:text-white hover:bg-white/10 transition-colors touch-manipulation"
+          className="size-8 flex items-center justify-center rounded-full text-white/70 hover:text-white hover:bg-white/10 transition-colors touch-manipulation"
           aria-label={t("apps.ipod.ariaLabels.previousTrack")}
         >
           <SkipBack size={16} weight="fill" />
@@ -148,7 +148,7 @@ export function PipPlayer({
           onClick={onTogglePlay}
           onTouchStart={(e) => e.stopPropagation()}
           disabled={isOffline}
-          className="w-9 h-9 flex items-center justify-center rounded-full text-white/70 hover:text-white hover:bg-white/10 transition-colors disabled:opacity-50 touch-manipulation"
+          className="size-9 flex items-center justify-center rounded-full text-white/70 hover:text-white hover:bg-white/10 transition-colors disabled:opacity-50 touch-manipulation"
           aria-label={t("apps.ipod.ariaLabels.playPause")}
         >
           {isPlaying ? <Pause size={18} weight="fill" /> : <Play size={18} weight="fill" />}
@@ -157,7 +157,7 @@ export function PipPlayer({
         <button
           onClick={onNextTrack}
           onTouchStart={(e) => e.stopPropagation()}
-          className="w-8 h-8 flex items-center justify-center rounded-full text-white/70 hover:text-white hover:bg-white/10 transition-colors touch-manipulation"
+          className="size-8 flex items-center justify-center rounded-full text-white/70 hover:text-white hover:bg-white/10 transition-colors touch-manipulation"
           aria-label={t("apps.ipod.ariaLabels.nextTrack")}
         >
           <SkipForward size={16} weight="fill" />

--- a/src/apps/karaoke/components/KaraokeLibraryEmptyState.tsx
+++ b/src/apps/karaoke/components/KaraokeLibraryEmptyState.tsx
@@ -50,8 +50,8 @@ export function KaraokeLibraryEmptyState({
     : {};
 
   const buttonClasses = isMacTheme
-    ? "w-8 h-8 flex items-center justify-center rounded-full transition-colors focus:outline-none relative z-10"
-    : "w-8 h-8 flex items-center justify-center rounded-full text-white/70 hover:text-white hover:bg-white/10 transition-colors focus:outline-none";
+    ? "size-8 flex items-center justify-center rounded-full transition-colors focus:outline-none relative z-10"
+    : "size-8 flex items-center justify-center rounded-full text-white/70 hover:text-white hover:bg-white/10 transition-colors focus:outline-none";
 
   const iconClasses = isMacTheme
     ? "text-white/70 drop-shadow-[0_1px_2px_rgba(0,0,0,0.5)]"
@@ -73,7 +73,7 @@ export function KaraokeLibraryEmptyState({
       <ThemedIcon
         name="/icons/default/karaoke.png"
         alt=""
-        className="h-16 w-16 drop-shadow-[0_2px_8px_rgba(0,0,0,0.5)]"
+        className="size-16 drop-shadow-[0_2px_8px_rgba(0,0,0,0.5)]"
         aria-hidden
       />
       <div className="flex max-w-sm flex-col gap-1.5">

--- a/src/apps/maps/components/MapsAppComponent.tsx
+++ b/src/apps/maps/components/MapsAppComponent.tsx
@@ -1366,7 +1366,7 @@ export function MapsAppComponent({
           />
         }
       >
-        <div className="relative h-full w-full min-h-0 flex-1 overflow-hidden bg-transparent font-os-ui">
+        <div className="relative size-full min-h-0 flex-1 overflow-hidden bg-transparent font-os-ui">
           <div
             ref={mapContainerRef}
             className="absolute inset-0 bg-[#e5e3df]"
@@ -1450,7 +1450,7 @@ export function MapsAppComponent({
                             )}
                           >
                             <div
-                              className="aqua-icon-badge flex h-7 w-7 shrink-0 items-center justify-center text-white"
+                              className="aqua-icon-badge flex size-7 shrink-0 items-center justify-center text-white"
                               style={{
                                 backgroundImage: poiVisualGradient(visual),
                               }}

--- a/src/apps/maps/components/MapsPlaceCard.tsx
+++ b/src/apps/maps/components/MapsPlaceCard.tsx
@@ -200,7 +200,7 @@ function PlaceCardHeader({
   return (
     <div className="flex items-start gap-2.5">
       <div
-        className="aqua-icon-badge flex h-9 w-9 shrink-0 items-center justify-center text-white"
+        className="aqua-icon-badge flex size-9 shrink-0 items-center justify-center text-white"
         style={{ backgroundImage: poiVisualGradient(visual) }}
         aria-hidden="true"
       >
@@ -227,7 +227,7 @@ function PlaceCardHeader({
         type="button"
         onClick={onClose}
         className={cn(
-          "shrink-0 -mr-0.5 -mt-0.5 flex h-6 w-6 items-center justify-center rounded-full",
+          "shrink-0 -mr-0.5 -mt-0.5 flex size-6 items-center justify-center rounded-full",
           "text-black/55 hover:bg-black/10 hover:text-black/85",
           "focus:outline-none focus-visible:ring-1 focus-visible:ring-black/30"
         )}

--- a/src/apps/maps/components/MapsPlacesDrawer.tsx
+++ b/src/apps/maps/components/MapsPlacesDrawer.tsx
@@ -76,7 +76,7 @@ function PlaceRow({
       )}
     >
       <div
-        className="aqua-icon-badge flex h-6 w-6 shrink-0 items-center justify-center text-white"
+        className="aqua-icon-badge flex size-6 shrink-0 items-center justify-center text-white"
         style={{ backgroundImage: poiVisualGradient(visual) }}
         aria-hidden="true"
       >

--- a/src/apps/paint/components/PaintColorPalette.tsx
+++ b/src/apps/paint/components/PaintColorPalette.tsx
@@ -35,11 +35,11 @@ export const PaintColorPalette: React.FC<PaintColorPaletteProps> = ({
         <Button
           key={color}
           variant="ghost"
-          className="w-10 h-10 p-0.5"
+          className="size-10 p-0.5"
           onClick={() => onColorSelect(color)}
         >
           <div
-            className={`w-full h-full rounded-sm ${
+            className={`size-full rounded-sm ${
               selectedColor === color ? "ring-2 ring-blue-500" : ""
             }`}
             style={{ backgroundColor: color }}

--- a/src/apps/paint/components/PaintFiltersMenu.tsx
+++ b/src/apps/paint/components/PaintFiltersMenu.tsx
@@ -156,8 +156,8 @@ export const PaintFiltersMenu: React.FC<PaintFiltersMenuProps> = ({
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button variant="ghost" size="icon" className="h-8 w-8">
-          <Sliders className="h-4 w-4" weight="bold" />
+        <Button variant="ghost" size="icon" className="size-8">
+          <Sliders className="size-4" weight="bold" />
           <span className="sr-only">{t("apps.paint.filtersMenu.openFiltersMenu")}</span>
         </Button>
       </DropdownMenuTrigger>

--- a/src/apps/paint/components/PaintToolbar.tsx
+++ b/src/apps/paint/components/PaintToolbar.tsx
@@ -98,7 +98,7 @@ export const PaintToolbar: React.FC<PaintToolbarProps> = ({
                   <img
                     src={tool.icon}
                     alt={label}
-                    className="w-[36px] h-[36px] object-contain mix-blend-multiply"
+                    className="size-[36px] object-contain mix-blend-multiply"
                   />
                 </Button>
               </TooltipTrigger>

--- a/src/apps/soundboard/components/BoardList.tsx
+++ b/src/apps/soundboard/components/BoardList.tsx
@@ -58,9 +58,9 @@ export function BoardList({
             variant="ghost"
             size="sm"
             onClick={onNewBoard}
-            className="flex items-center text-xs hover:bg-black/5 w-[24px] h-[24px]"
+            className="flex items-center text-xs hover:bg-black/5 size-[24px]"
           >
-            <Plus className="w-3 h-3" weight="bold" />
+            <Plus className="size-3" weight="bold" />
           </Button>
         </div>
         <div

--- a/src/apps/stickies/components/StickyNote.tsx
+++ b/src/apps/stickies/components/StickyNote.tsx
@@ -334,7 +334,7 @@ export function StickyNote({
               e.stopPropagation();
               onDelete();
             }}
-            className="w-[9px] h-[9px] flex items-center justify-center"
+            className="size-[9px] flex items-center justify-center"
             style={{ 
               border: `1px solid ${colors.border}`,
               backgroundColor: colors.bg,
@@ -364,7 +364,7 @@ export function StickyNote({
       <div
         onMouseDown={handleResizeStart}
         onTouchStart={handleTouchResizeStart}
-        className="absolute bottom-0 right-0 w-3 h-3 cursor-se-resize opacity-70"
+        className="absolute bottom-0 right-0 size-3 cursor-se-resize opacity-70"
         style={{
           background: `linear-gradient(135deg, transparent 50%, ${colors.border} 50%)`,
           touchAction: "none",

--- a/src/apps/synth/components/SynthAppComponent.tsx
+++ b/src/apps/synth/components/SynthAppComponent.tsx
@@ -94,7 +94,7 @@ const PianoKey: FC<{
               isPressed ? "bg-[#ff33ff]" : "bg-black hover:bg-[#333333]"
             )
           : cn(
-              "h-full w-full border border-[#333333] rounded-b-md",
+              "size-full border border-[#333333] rounded-b-md",
               isPressed ? "bg-[#ff33ff]" : "bg-white hover:bg-[#f5f5f5]"
             )
       )}
@@ -208,7 +208,7 @@ export function SynthAppComponent({
         <div
           ref={appContainerRef}
           className={cn(
-            "flex flex-col h-full w-full text-white overflow-hidden select-none synth-force-font",
+            "flex flex-col size-full text-white overflow-hidden select-none synth-force-font",
             !isMacOSTheme && "bg-[#1a1a1a]"
           )}
         >
@@ -313,10 +313,10 @@ export function SynthAppComponent({
                 {isMacOSTheme ? (
                   <div className="metal-inset-btn-group">
                     <button type="button" className="metal-inset-btn metal-inset-icon select-none" onClick={handleOctaveDown}>
-                      <CaretLeft weight="bold" className="h-3 w-3" />
+                      <CaretLeft weight="bold" className="size-3" />
                     </button>
                     <button type="button" className="metal-inset-btn metal-inset-icon select-none" onClick={handleOctaveUp}>
-                      <CaretRight weight="bold" className="h-3 w-3" />
+                      <CaretRight weight="bold" className="size-3" />
                     </button>
                     <button type="button" className="metal-inset-btn font-geneva-12 !text-[11px] select-none" onClick={toggleControls}>
                       {t("apps.synth.controls")}
@@ -329,14 +329,14 @@ export function SynthAppComponent({
                       onClick={handleOctaveDown}
                       className={cn("h-[22px] px-2 select-none", isXpTheme && "text-black")}
                     >
-                      <CaretLeft weight="bold" className="h-3 w-3" />
+                      <CaretLeft weight="bold" className="size-3" />
                     </Button>
                     <Button
                       variant={isSystem7Theme ? "player" : "default"}
                       onClick={handleOctaveUp}
                       className={cn("h-[22px] px-2 select-none", isXpTheme && "text-black")}
                     >
-                      <CaretRight weight="bold" className="h-3 w-3" />
+                      <CaretRight weight="bold" className="size-3" />
                     </Button>
                     <Button
                       variant={isSystem7Theme ? "player" : "default"}
@@ -833,7 +833,7 @@ export function SynthAppComponent({
               "flex-grow flex flex-col justify-end min-h-[160px] w-full",
               isMacOSTheme ? "p-0" : "bg-black p-4"
             )}>
-              <div ref={keyboardContainerRef} className="relative h-full w-full">
+              <div ref={keyboardContainerRef} className="relative size-full">
                 {/* Keyboard */}
                 {/* White keys container */}
                 <div className="absolute inset-0 h-full flex w-full">
@@ -854,7 +854,7 @@ export function SynthAppComponent({
                 </div>
 
                 {/* Black keys container */}
-                <div className="absolute inset-0 h-full w-full flex pointer-events-none">
+                <div className="absolute inset-0 size-full flex pointer-events-none">
                   {blackKeys.map((note, index) => {
                     // Only hide black keys at the end of the visible range
                     if (visibleKeyCount > 0 && index === blackKeys.length - 1) {

--- a/src/apps/terminal/components/TerminalToolInvocation.tsx
+++ b/src/apps/terminal/components/TerminalToolInvocation.tsx
@@ -333,13 +333,13 @@ export function TerminalToolInvocation({
     >
       {state === "output-available" && displayResultMessage ? (
         <>
-          <Check className="h-3 w-3 text-green-400 flex-shrink-0" weight="bold" />
+          <Check className="size-3 text-green-400 flex-shrink-0" weight="bold" />
           <span className="italic">{displayResultMessage}</span>
         </>
       ) : state === "output-error" ? (
         <>
           <Check
-            className="h-3 w-3 shrink-0 text-neutral-500 flex-shrink-0"
+            className="size-3 shrink-0 text-neutral-500 flex-shrink-0"
             weight="bold"
             aria-hidden
           />

--- a/src/apps/textedit/components/EditorToolbar.tsx
+++ b/src/apps/textedit/components/EditorToolbar.tsx
@@ -137,7 +137,7 @@ export function EditorToolbar({
                     : getCurrentHeading() === "h3"
                     ? "H3"
                     : t("apps.textedit.text")}
-                  <CaretDown className="ml-1 h-3 w-3" weight="bold" />
+                  <CaretDown className="ml-1 size-3" weight="bold" />
                 </button>
               </DropdownMenuTrigger>
               <DropdownMenuContent align="start" className="w-[80px]">
@@ -290,7 +290,7 @@ export function EditorToolbar({
                 ) : isSpeaking ? (
                   <PlaybackBars color="black" />
                 ) : (
-                  <SpeakerHigh className="h-4 w-4" weight="bold" />
+                  <SpeakerHigh className="size-4" weight="bold" />
                 )}
               </button>
             )}
@@ -323,12 +323,12 @@ export function EditorToolbar({
         <Button
           variant="ghost"
           size="icon"
-          className="h-7 w-7"
+          className="size-7"
           onClick={() => editor?.chain().focus().toggleBold().run()}
           aria-label={t("apps.textedit.bold")}
         >
           <BoldIcon
-            className={`h-4 w-4 ${
+            className={`size-4 ${
               editor?.isActive("bold")
                 ? "text-black"
                 : "text-neutral-500"
@@ -339,12 +339,12 @@ export function EditorToolbar({
         <Button
           variant="ghost"
           size="icon"
-          className="h-7 w-7"
+          className="size-7"
           onClick={() => editor?.chain().focus().toggleItalic().run()}
           aria-label={t("apps.textedit.italic")}
         >
           <ItalicIcon
-            className={`h-4 w-4 ${
+            className={`size-4 ${
               editor?.isActive("italic")
                 ? "text-black"
                 : "text-neutral-500"
@@ -355,14 +355,14 @@ export function EditorToolbar({
         <Button
           variant="ghost"
           size="icon"
-          className="h-7 w-7"
+          className="size-7"
           onClick={() =>
             editor?.chain().focus().toggleUnderline().run()
           }
           aria-label={t("apps.textedit.underline")}
         >
           <UnderlineIcon
-            className={`h-4 w-4 ${
+            className={`size-4 ${
               editor?.isActive("underline")
                 ? "text-black"
                 : "text-neutral-500"
@@ -403,7 +403,7 @@ export function EditorToolbar({
                   : getCurrentHeading() === "h3"
                   ? "H3"
                   : t("apps.textedit.text")}
-                <CaretDown className="ml-1 h-3 w-3" weight="bold" />
+                <CaretDown className="ml-1 size-3" weight="bold" />
               </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="start" className="w-[120px]">
@@ -429,14 +429,14 @@ export function EditorToolbar({
         <Button
           variant="ghost"
           size="icon"
-          className="h-7 w-7"
+          className="size-7"
           onClick={() =>
             editor?.chain().focus().setTextAlign("left").run()
           }
           aria-label={t("apps.textedit.alignLeft")}
         >
           <AlignLeft
-            className={`h-4 w-4 ${
+            className={`size-4 ${
               editor?.isActive({ textAlign: "left" })
                 ? "text-black"
                 : "text-neutral-500"
@@ -447,14 +447,14 @@ export function EditorToolbar({
         <Button
           variant="ghost"
           size="icon"
-          className="h-7 w-7"
+          className="size-7"
           onClick={() =>
             editor?.chain().focus().setTextAlign("center").run()
           }
           aria-label={t("apps.textedit.alignCenter")}
         >
           <AlignCenter
-            className={`h-4 w-4 ${
+            className={`size-4 ${
               editor?.isActive({ textAlign: "center" })
                 ? "text-black"
                 : "text-neutral-500"
@@ -465,14 +465,14 @@ export function EditorToolbar({
         <Button
           variant="ghost"
           size="icon"
-          className="h-7 w-7"
+          className="size-7"
           onClick={() =>
             editor?.chain().focus().setTextAlign("right").run()
           }
           aria-label={t("apps.textedit.alignRight")}
         >
           <AlignRight
-            className={`h-4 w-4 ${
+            className={`size-4 ${
               editor?.isActive({ textAlign: "right" })
                 ? "text-black"
                 : "text-neutral-500"
@@ -487,14 +487,14 @@ export function EditorToolbar({
         <Button
           variant="ghost"
           size="icon"
-          className="h-7 w-7"
+          className="size-7"
           onClick={() =>
             editor?.chain().focus().toggleBulletList().run()
           }
           aria-label={t("apps.textedit.bulletList")}
         >
           <ListIcon
-            className={`h-4 w-4 ${
+            className={`size-4 ${
               editor?.isActive("bulletList")
                 ? "text-black"
                 : "text-neutral-500"
@@ -505,14 +505,14 @@ export function EditorToolbar({
         <Button
           variant="ghost"
           size="icon"
-          className="h-7 w-7"
+          className="size-7"
           onClick={() =>
             editor?.chain().focus().toggleOrderedList().run()
           }
           aria-label={t("apps.textedit.numberedList")}
         >
           <ListOrdered
-            className={`h-4 w-4 ${
+            className={`size-4 ${
               editor?.isActive("orderedList")
                 ? "text-black"
                 : "text-neutral-500"
@@ -528,14 +528,14 @@ export function EditorToolbar({
           onTranscriptionComplete={onTranscriptionComplete}
           onTranscriptionStart={onTranscriptionStart}
           isLoading={isTranscribing}
-          className="h-7 w-7 inline-flex items-center justify-center text-neutral-500 hover:text-black"
+          className="size-7 inline-flex items-center justify-center text-neutral-500 hover:text-black"
           silenceThreshold={10000}
         />
         {speechEnabled && (
           <Button
             variant="ghost"
             size="icon"
-            className="h-7 w-7"
+            className="size-7"
             onClick={onSpeak}
             aria-label={isSpeaking ? t("apps.textedit.stopSpeech") : t("apps.textedit.speak")}
           >
@@ -544,7 +544,7 @@ export function EditorToolbar({
             ) : isSpeaking ? (
               <PlaybackBars color="black" />
             ) : (
-              <SpeakerHigh className="h-4 w-4 text-neutral-500" weight="bold" />
+              <SpeakerHigh className="size-4 text-neutral-500" weight="bold" />
             )}
           </Button>
         )}

--- a/src/apps/textedit/extensions/SlashCommands.tsx
+++ b/src/apps/textedit/extensions/SlashCommands.tsx
@@ -102,8 +102,8 @@ const SlashMenuContent = ({
         >
           {getTranslatedTitle(item)}
           {isActive(item) && (
-            <span className="absolute right-2 flex h-3.5 w-3.5 items-center justify-center">
-              <Check className="h-4 w-4" weight="bold" />
+            <span className="absolute right-2 flex size-3.5 items-center justify-center">
+              <Check className="size-4" weight="bold" />
             </span>
           )}
         </button>

--- a/src/components/dialogs/AboutDialog.tsx
+++ b/src/components/dialogs/AboutDialog.tsx
@@ -58,7 +58,7 @@ export function AboutDialog({
         <ThemedIcon
           name={metadata.icon}
           alt="App Icon"
-          className="w-12 h-12 mx-auto [image-rendering:pixelated]"
+          className="size-12 mx-auto [image-rendering:pixelated]"
         />
       </div>
       <div

--- a/src/components/dialogs/AboutFinderDialog.tsx
+++ b/src/components/dialogs/AboutFinderDialog.tsx
@@ -139,7 +139,7 @@ export function AboutFinderDialog({
               <ThemedIcon
                 name="mac-classic.png"
                 alt="Happy Mac"
-                className="w-10 h-10 mb-1 mr-0"
+                className="size-10 mb-1 mr-0"
               />
               <div
                 className={cn(

--- a/src/components/dialogs/BootScreen.tsx
+++ b/src/components/dialogs/BootScreen.tsx
@@ -118,7 +118,7 @@ export function BootScreen({
             }}
           />
           <DialogPrimitive.Content
-            className="fixed inset-0 z-[80] bg-black p-0 w-full h-full max-w-none border-none shadow-none outline-none rounded-none m-0"
+            className="fixed inset-0 z-[80] bg-black p-0 size-full max-w-none border-none shadow-none outline-none rounded-none m-0"
             style={{ 
               position: "fixed",
               top: 0,
@@ -138,7 +138,7 @@ export function BootScreen({
               <DialogTitle>{localizedTitle}</DialogTitle>
             </VisuallyHidden>
             <div 
-              className="flex flex-col items-center justify-center w-full h-full bg-black"
+              className="flex flex-col items-center justify-center size-full bg-black"
               onClick={debugMode ? handleDone : undefined}
               style={{
                 width: "100%",
@@ -150,7 +150,7 @@ export function BootScreen({
               <img
                 src={getSplashImage()}
                 alt={isWinXp ? "Windows XP" : "Windows 98"}
-                className={isWin98 ? "w-full h-full object-fill" : "max-w-full max-h-full object-contain"}
+                className={isWin98 ? "size-full object-fill" : "max-w-full max-h-full object-contain"}
                 style={{ display: "block" }}
               />
             </div>
@@ -198,7 +198,7 @@ export function BootScreen({
               <img
                 src="/icons/macosx/apple.png"
                 alt="Apple"
-                className="w-[120px] h-[120px] object-contain"
+                className="size-[120px] object-contain"
                 style={{ marginBottom: "-30px", filter: "grayscale(50%) brightness(1.25)" }}
               />
               {/* ryOS X text */}

--- a/src/components/dialogs/ConfirmDialog.tsx
+++ b/src/components/dialogs/ConfirmDialog.tsx
@@ -50,7 +50,7 @@ export function ConfirmDialog({
         <ThemedIcon
           name="warn.png"
           alt="Warning"
-          className="w-[32px] h-[32px] mt-0.5 [image-rendering:pixelated]"
+          className="size-[32px] mt-0.5 [image-rendering:pixelated]"
           width={32}
           height={32}
         />

--- a/src/components/dialogs/ShareItemDialog.tsx
+++ b/src/components/dialogs/ShareItemDialog.tsx
@@ -132,7 +132,7 @@ export function ShareItemDialog({
       <div className="flex flex-col items-center space-y-3 w-full">
         {/* QR Code */}
         {isLoading ? (
-          <div className="w-32 h-32 flex items-center justify-center bg-gray-100 rounded">
+          <div className="size-32 flex items-center justify-center bg-gray-100 rounded">
             <p
               className={cn(
                 "text-gray-500",
@@ -151,17 +151,17 @@ export function ShareItemDialog({
             </p>
           </div>
         ) : shareUrl ? (
-          <div className="bg-white p-1.5 w-32 h-32 flex items-center justify-center">
+          <div className="bg-white p-1.5 size-32 flex items-center justify-center">
             <QRCodeSVG
               value={shareUrl}
               size={112}
               level="M"
               includeMargin={false}
-              className="w-28 h-28"
+              className="size-28"
             />
           </div>
         ) : (
-          <div className="w-32 h-32 flex items-center justify-center bg-gray-100 rounded">
+          <div className="size-32 flex items-center justify-center bg-gray-100 rounded">
             <p
               className={cn(
                 "text-gray-500",

--- a/src/components/dialogs/TelegramLinkDialog.tsx
+++ b/src/components/dialogs/TelegramLinkDialog.tsx
@@ -76,17 +76,17 @@ export function TelegramLinkDialog({
       <img
         src="/icons/mac-192.png"
         alt="ryOS"
-        className="h-8 w-8 shrink-0 object-contain"
+        className="size-8 shrink-0 object-contain"
       />
       <ArrowRight size={14} weight="bold" className="shrink-0 text-black/45" />
-      <div className="flex h-8 w-8 items-center justify-center rounded-full bg-[#229ED9] text-white shadow-[inset_0_1px_0_rgba(255,255,255,0.35),0_1px_2px_rgba(0,0,0,0.18)]">
+      <div className="flex size-8 items-center justify-center rounded-full bg-[#229ED9] text-white shadow-[inset_0_1px_0_rgba(255,255,255,0.35),0_1px_2px_rgba(0,0,0,0.18)]">
         <PaperPlaneRight size={16} weight="fill" />
       </div>
     </div>
   );
 
   const previewContent = isStatusLoading && !shouldShowLinkSession ? (
-    <div className="flex h-32 w-32 items-center justify-center rounded bg-gray-100">
+    <div className="flex size-32 items-center justify-center rounded bg-gray-100">
       <p
         className={cn(
           "text-gray-500",

--- a/src/components/errors/ErrorBoundaries.tsx
+++ b/src/components/errors/ErrorBoundaries.tsx
@@ -178,7 +178,7 @@ function CrashDialog({
         <ThemedIcon
           name="warn.png"
           alt={t("common.dialog.close", { defaultValue: "Warning" })}
-          className="mt-0.5 h-8 w-8 shrink-0 [image-rendering:pixelated]"
+          className="mt-0.5 size-8 shrink-0 [image-rendering:pixelated]"
           width={32}
           height={32}
         />

--- a/src/components/layout/AppSwitcher.tsx
+++ b/src/components/layout/AppSwitcher.tsx
@@ -49,14 +49,14 @@ export function AppSwitcher({ isVisible, apps, selectedIndex }: AppSwitcherProps
                     }`}
                   >
                     {isEmojiIcon ? (
-                      <span className="flex h-16 w-16 items-center justify-center text-5xl leading-none">
+                      <span className="flex size-16 items-center justify-center text-5xl leading-none">
                         {iconSrc}
                       </span>
                     ) : (
                       <ThemedIcon
                         name={iconSrc}
                         alt={appRegistry[appId]?.name ?? appId}
-                        className="w-16 h-16 object-contain"
+                        className="size-16 object-contain"
                         draggable={false}
                       />
                     )}

--- a/src/components/layout/AppleMenu.tsx
+++ b/src/components/layout/AppleMenu.tsx
@@ -207,14 +207,14 @@ export function AppleMenu() {
                       className="text-md h-6 px-3 flex items-center gap-2"
                     >
                       {typeof app.icon === "string" ? (
-                        <div className="w-4 h-4 flex items-center justify-center">
+                        <div className="size-4 flex items-center justify-center">
                           {app.icon}
                         </div>
                       ) : (
                         <ThemedIcon
                           name={app.icon.src}
                           alt={app.name}
-                          className="w-4 h-4 [image-rendering:pixelated]"
+                          className="size-4 [image-rendering:pixelated]"
                         />
                       )}
                       {getTranslatedAppName(recent.appId)}
@@ -250,14 +250,14 @@ export function AppleMenu() {
                       className="text-md h-6 px-3 flex items-center gap-2"
                     >
                       {isEmoji ? (
-                        <span className="w-4 h-4 flex items-center justify-center text-sm">
+                        <span className="size-4 flex items-center justify-center text-sm">
                           {recent.icon}
                         </span>
                       ) : (
                         <ThemedIcon
                           name={iconPath}
                           alt="Document"
-                          className="w-4 h-4 [image-rendering:pixelated]"
+                          className="size-4 [image-rendering:pixelated]"
                         />
                       )}
                       <span className="truncate max-w-[180px]">{recent.name}</span>

--- a/src/components/layout/ExposeView.tsx
+++ b/src/components/layout/ExposeView.tsx
@@ -258,7 +258,7 @@ export function ExposeView({ isOpen, onClose }: ExposeViewProps) {
                       <ThemedIcon
                         name={displayIcon}
                         alt=""
-                        className="w-6 h-6 [image-rendering:pixelated]"
+                        className="size-6 [image-rendering:pixelated]"
                       />
                     )}
                     {/* Title */}

--- a/src/components/layout/StartMenu.tsx
+++ b/src/components/layout/StartMenu.tsx
@@ -84,7 +84,7 @@ export function StartMenu({ apps }: StartMenuProps) {
               name="apple.png"
               alt="Start"
               className={`[image-rendering:pixelated] ${
-                isWinXp ? "w-5 h-4" : "w-5 h-5"
+                isWinXp ? "w-5 h-4" : "size-5"
               }`}
               style={{
                 filter:
@@ -191,7 +191,7 @@ export function StartMenu({ apps }: StartMenuProps) {
                   <ThemedIcon
                     name="info.png"
                     alt="About"
-                    className="w-6 h-6 [image-rendering:pixelated]"
+                    className="size-6 [image-rendering:pixelated]"
                   />
                   {t("common.startMenu.aboutThisComputer")}
                 </DropdownMenuItem>
@@ -210,7 +210,7 @@ export function StartMenu({ apps }: StartMenuProps) {
                     imageRendering: "pixelated",
                   }}
                 >
-                  <div className="w-6 h-6 flex items-center justify-center text-base">
+                  <div className="size-6 flex items-center justify-center text-base">
                     🔍
                   </div>
                   <span className="flex-1">{t("common.startMenu.run")}</span>
@@ -243,10 +243,10 @@ export function StartMenu({ apps }: StartMenuProps) {
                         <ThemedIcon
                           name={app.icon}
                           alt={app.name}
-                          className="w-6 h-6 [image-rendering:pixelated]"
+                          className="size-6 [image-rendering:pixelated]"
                         />
                       ) : (
-                        <div className="w-6 h-6 flex items-center justify-center">
+                        <div className="size-6 flex items-center justify-center">
                           {app.icon}
                         </div>
                       )
@@ -254,7 +254,7 @@ export function StartMenu({ apps }: StartMenuProps) {
                       <ThemedIcon
                         name={app.icon.src}
                         alt={app.name}
-                        className="w-6 h-6 [image-rendering:pixelated]"
+                        className="size-6 [image-rendering:pixelated]"
                       />
                     )}
                     {getTranslatedAppName(app.id as AppId)}

--- a/src/components/layout/WindowFrame.tsx
+++ b/src/components/layout/WindowFrame.tsx
@@ -545,7 +545,7 @@ export function WindowFrame({
 
     const isAquaNoTitlebar = variant === "aqua" && isNoTitlebar;
     const buttonClass = cn(
-      variant === "aqua" ? "w-5 h-5" : "mr-2 w-5 h-5",
+      variant === "aqua" ? "size-5" : "mr-2 size-5",
       "flex items-center justify-center",
       isAquaNoTitlebar
         ? "text-white/80"
@@ -573,7 +573,7 @@ export function WindowFrame({
         : undefined;
 
     if (!onCoverFlowToggle && !onFullscreenToggle) {
-      return variant === "aqua" ? <div style={{ width: 52 }} /> : <div className="mr-2 w-4 h-4" />;
+      return variant === "aqua" ? <div style={{ width: 52 }} /> : <div className="mr-2 size-4" />;
     }
 
     return (
@@ -1037,7 +1037,7 @@ export function WindowFrame({
       }}
     >
       <div
-        className="w-full h-full"
+        className="size-full"
         style={{
           border: "3px solid rgba(255, 255, 255, 0.8)",
           backgroundColor: "rgba(255, 255, 255, 0.1)",
@@ -1115,7 +1115,7 @@ export function WindowFrame({
           }}
           exit={getExitAnimation()}
           className={cn(
-            "w-full h-full select-none",
+            "size-full select-none",
             // Disable all pointer events when window is closing
             isClosing && "pointer-events-none",
             // For keepMountedWhenMinimized apps, also disable pointer events when minimized
@@ -1134,7 +1134,7 @@ export function WindowFrame({
             transformOrigin: "center",
           }}
         >
-      <div className="relative w-full h-full">
+      <div className="relative size-full">
         {/* Drawer slot — rendered first so the window paints over it
             when collapsed. The drawer itself is responsible for sliding
             out from behind the right edge via transform. */}
@@ -1237,8 +1237,8 @@ export function WindowFrame({
               debugMode && "bg-red-500/50",
               isMobile && "hidden",
               resizeType === "ne"
-                ? "top-[-100px] right-[-100px] w-[200px] h-[200px]"
-                : "top-0 right-0 w-6 h-6"
+                ? "top-[-100px] right-[-100px] size-[200px]"
+                : "top-0 right-0 size-6"
             )}
             onMouseDown={(e) =>
               handleResizeStartWithForeground(e, "ne" as ResizeType)
@@ -1254,8 +1254,8 @@ export function WindowFrame({
               debugMode && "bg-red-500/50",
               isMobile && "hidden",
               resizeType === "sw"
-                ? "bottom-[-100px] left-[-100px] w-[200px] h-[200px]"
-                : "bottom-0 left-0 w-6 h-6"
+                ? "bottom-[-100px] left-[-100px] size-[200px]"
+                : "bottom-0 left-0 size-6"
             )}
             onMouseDown={(e) =>
               handleResizeStartWithForeground(e, "sw" as ResizeType)
@@ -1271,8 +1271,8 @@ export function WindowFrame({
               debugMode && "bg-red-500/50",
               isMobile && "hidden",
               resizeType === "se"
-                ? "bottom-[-100px] right-[-100px] w-[200px] h-[200px]"
-                : "bottom-0 right-0 w-6 h-6"
+                ? "bottom-[-100px] right-[-100px] size-[200px]"
+                : "bottom-0 right-0 size-6"
             )}
             onMouseDown={(e) =>
               handleResizeStartWithForeground(e, "se" as ResizeType)
@@ -1288,8 +1288,8 @@ export function WindowFrame({
             isXpTheme
               ? "window flex flex-col h-full" // Use xp.css window class with flex layout
               : isNoTitlebar && isMacOSTheme
-              ? "window w-full h-full flex flex-col rounded-os overflow-hidden relative" // No border for notitlebar
-              : "window w-full h-full flex flex-col border-[length:var(--os-metrics-border-width)] border-os-window rounded-os overflow-hidden relative",
+              ? "window size-full flex flex-col rounded-os overflow-hidden relative" // No border for notitlebar
+              : "window size-full flex flex-col border-[length:var(--os-metrics-border-width)] border-os-window rounded-os overflow-hidden relative",
             !effectiveTransparentBackground && !isXpTheme && "bg-os-window-bg",
             !isXpTheme && (!isSystem7Theme || isForeground)
               ? "shadow-os-window"
@@ -1448,7 +1448,7 @@ export function WindowFrame({
                 <ThemedIcon
                   name={getAppIconPath(appId)}
                   alt={title}
-                  className="w-4 h-4 mr-1 shrink-0 [image-rendering:pixelated]"
+                  className="size-4 mr-1 shrink-0 [image-rendering:pixelated]"
                   style={{
                     filter: !isForeground ? "grayscale(100%)" : "none",
                   }}
@@ -1702,13 +1702,13 @@ export function WindowFrame({
                 onClick={handleClose}
                 onMouseDown={(e) => e.stopPropagation()}
                 onTouchStart={(e) => e.stopPropagation()}
-                className="relative ml-2 w-4 h-4 cursor-default select-none"
+                className="relative ml-2 size-4 cursor-default select-none"
                 data-titlebar-controls
               >
                 <div className="absolute inset-0 -m-2" />{" "}
                 {/* Larger click area */}
                 <div
-                  className={`w-4 h-4 ${
+                  className={`size-4 ${
                     !isTransparent &&
                     "bg-os-button-face shadow-[0_0_0_1px_var(--os-color-button-face)]"
                   } border-2 border-os-window hover:bg-gray-200 active:bg-gray-300 flex items-center justify-center ${

--- a/src/components/layout/dashboard/CalendarWidget.tsx
+++ b/src/components/layout/dashboard/CalendarWidget.tsx
@@ -246,7 +246,7 @@ export function CalendarWidget({ widgetId }: CalendarWidgetProps) {
                     {cell.events.slice(0, 2).map((ev, i) => (
                       <span
                         key={i}
-                        className="w-1 h-1 rounded-full"
+                        className="size-1 rounded-full"
                         style={{ backgroundColor: EVENT_COLOR_MAP[ev.color] || "#F0A060" }}
                       />
                     ))}

--- a/src/components/listen/ListenSessionInvite.tsx
+++ b/src/components/listen/ListenSessionInvite.tsx
@@ -82,13 +82,13 @@ export function ListenSessionInvite({
   const dialogContent = (
     <div className={isXpTheme ? "p-2 px-4" : "p-3"}>
       <div className="flex flex-col items-center space-y-3 w-full">
-        <div className="bg-white p-1.5 w-32 h-32 flex items-center justify-center">
+        <div className="bg-white p-1.5 size-32 flex items-center justify-center">
           <QRCodeSVG
             value={shareUrl || "placeholder"}
             size={112}
             level="M"
             includeMargin={false}
-            className="w-28 h-28"
+            className="size-28"
           />
         </div>
         <p

--- a/src/components/shared/CursorRepoAgentChatCard.tsx
+++ b/src/components/shared/CursorRepoAgentChatCard.tsx
@@ -100,8 +100,8 @@ export function CursorRepoAgentChatCard({
       {introMessage ? (
         <div className="mb-2 px-0.5">
           <div className="flex items-start gap-1 text-[12px] text-neutral-800 dark:text-neutral-200">
-            <span className="inline-flex h-3 w-3 shrink-0 items-center justify-center pt-0.5">
-              <Check className="h-3 w-3 text-blue-600 dark:text-blue-400" weight="bold" />
+            <span className="inline-flex size-3 shrink-0 items-center justify-center pt-0.5">
+              <Check className="size-3 text-blue-600 dark:text-blue-400" weight="bold" />
             </span>
             <span className="italic leading-snug">{introMessage}</span>
           </div>
@@ -117,13 +117,13 @@ export function CursorRepoAgentChatCard({
         style={isPanel ? undefined : { boxShadow: "0 0 0 1px rgba(0, 0, 0, 0.3)" }}
       >
         <div className="flex flex-shrink-0 items-center gap-3 border-b border-gray-300 bg-gray-100 px-3 py-2 dark:border-neutral-600 dark:bg-neutral-800/90">
-          <span className="relative inline-flex h-6 w-6 shrink-0 items-center justify-center" aria-hidden>
+          <span className="relative inline-flex size-6 shrink-0 items-center justify-center" aria-hidden>
             <img
               src="/brands/cursor-cube-2d-light.svg"
               alt=""
               width={24}
               height={24}
-              className="h-6 w-6 dark:hidden"
+              className="size-6 dark:hidden"
               draggable={false}
             />
             <img
@@ -131,7 +131,7 @@ export function CursorRepoAgentChatCard({
               alt=""
               width={24}
               height={24}
-              className="hidden h-6 w-6 dark:block"
+              className="hidden size-6 dark:block"
               draggable={false}
             />
           </span>
@@ -148,7 +148,7 @@ export function CursorRepoAgentChatCard({
                 title={prUrl}
                 aria-label={t("apps.chats.toolCalls.cursorCloudAgent.openPr")}
               >
-                <ArrowSquareOut className="h-3 w-3" weight="bold" />
+                <ArrowSquareOut className="size-3" weight="bold" />
                 <span>
                   {t("apps.chats.toolCalls.cursorCloudAgent.openPr")}
                 </span>
@@ -156,12 +156,12 @@ export function CursorRepoAgentChatCard({
             ) : null}
             {!done ? (
               <span className="inline-flex shrink-0 items-center gap-1 text-[10px] font-medium text-amber-900 dark:text-amber-200">
-                <span className="h-1.5 w-1.5 rounded-full bg-amber-500" aria-hidden />
+                <span className="size-1.5 rounded-full bg-amber-500" aria-hidden />
                 {t("apps.chats.toolCalls.cursorCloudAgent.running")}
               </span>
             ) : (
               <span className="inline-flex shrink-0 items-center gap-1 text-[10px] font-medium text-emerald-900 dark:text-emerald-200">
-                <span className="h-1.5 w-1.5 rounded-full bg-emerald-500" aria-hidden />
+                <span className="size-1.5 rounded-full bg-emerald-500" aria-hidden />
                 {t("apps.chats.toolCalls.cursorCloudAgent.finished")}
               </span>
             )}
@@ -308,9 +308,9 @@ export function CursorRepoAgentChatCard({
                 title={t(
                   "apps.chats.toolCalls.cursorCloudAgent.followupSend"
                 )}
-                className="inline-flex h-[26px] w-[26px] shrink-0 items-center justify-center self-end rounded border border-blue-500 bg-blue-500 text-white transition-colors hover:bg-blue-600 disabled:cursor-not-allowed disabled:border-neutral-300 disabled:bg-neutral-200 disabled:text-neutral-500 dark:disabled:border-neutral-700 dark:disabled:bg-neutral-800 dark:disabled:text-neutral-500"
+                className="inline-flex size-[26px] shrink-0 items-center justify-center self-end rounded border border-blue-500 bg-blue-500 text-white transition-colors hover:bg-blue-600 disabled:cursor-not-allowed disabled:border-neutral-300 disabled:bg-neutral-200 disabled:text-neutral-500 dark:disabled:border-neutral-700 dark:disabled:bg-neutral-800 dark:disabled:text-neutral-500"
               >
-                <ArrowUp className="h-3.5 w-3.5" weight="bold" />
+                <ArrowUp className="size-3.5" weight="bold" />
               </button>
             </form>
           </div>

--- a/src/components/shared/FullscreenMobileDismiss.tsx
+++ b/src/components/shared/FullscreenMobileDismiss.tsx
@@ -64,7 +64,7 @@ export function FullscreenMobileDismiss({
             onInteraction?.();
             onDismiss();
           }}
-          className="w-9 h-9 flex items-center justify-center rounded-full text-white/70 hover:text-white hover:bg-white/10 transition-colors focus:outline-none"
+          className="size-9 flex items-center justify-center rounded-full text-white/70 hover:text-white hover:bg-white/10 transition-colors focus:outline-none"
           aria-label={t("apps.ipod.ariaLabels.closeFullscreen")}
           title={t("common.dialog.close")}
         >

--- a/src/components/shared/HtmlPreview.tsx
+++ b/src/components/shared/HtmlPreview.tsx
@@ -1083,7 +1083,7 @@ export default function HtmlPreview({
             <button
               onClick={handleSaveAsApplet}
               onMouseDown={(e) => e.stopPropagation()}
-              className="flex items-center justify-center w-6 h-6 hover:bg-black/10 rounded mr-1 group"
+              className="flex items-center justify-center size-6 hover:bg-black/10 rounded mr-1 group"
               aria-label={t("common.htmlPreview.saveApplet")}
               disabled={isStreaming}
             >
@@ -1095,7 +1095,7 @@ export default function HtmlPreview({
             <button
               onClick={handleSaveToDisk}
               onMouseDown={(e) => e.stopPropagation()}
-              className="flex items-center justify-center w-6 h-6 hover:bg-black/10 rounded mr-1 group"
+              className="flex items-center justify-center size-6 hover:bg-black/10 rounded mr-1 group"
               aria-label={t("common.htmlPreview.downloadHtml")}
               disabled={isStreaming}
             >
@@ -1107,7 +1107,7 @@ export default function HtmlPreview({
             <button
               onClick={handleCopy}
               onMouseDown={(e) => e.stopPropagation()}
-              className="flex items-center justify-center w-6 h-6 hover:bg-black/10 rounded mr-1 group"
+              className="flex items-center justify-center size-6 hover:bg-black/10 rounded mr-1 group"
               aria-label={t("common.htmlPreview.copyHtml")}
               disabled={isStreaming}
             >
@@ -1126,7 +1126,7 @@ export default function HtmlPreview({
             <button
               onClick={toggleFullScreen}
               onMouseDown={(e) => e.stopPropagation()}
-              className="flex items-center justify-center w-6 h-6 hover:bg-black/10 rounded group"
+              className="flex items-center justify-center size-6 hover:bg-black/10 rounded group"
               aria-label={
                 isFullScreen
                   ? t("common.htmlPreview.minimizePreview")
@@ -1151,7 +1151,7 @@ export default function HtmlPreview({
         {/* Conditional Rendering: Text Stream or Iframe */}
         {isStreaming && htmlContent ? (
           <div
-            className={`h-full w-full relative overflow-auto ${
+            className={`size-full relative overflow-auto ${
               !isInternetExplorer && (appletTitle || appletIcon) ? "flex-1" : ""
             }`}
             style={{
@@ -1251,7 +1251,7 @@ export default function HtmlPreview({
               >
                 <div
                   ref={fullscreenWrapperRef}
-                  className="relative w-full h-full overflow-hidden"
+                  className="relative size-full overflow-hidden"
                 >
                   {/* Code view layer - always 100% width underneath */}
                   <AnimatePresence>
@@ -1306,7 +1306,7 @@ export default function HtmlPreview({
                     {/* Fullscreen Conditional Rendering: Text Stream or Iframe */}
                     {isStreaming && htmlContent ? (
                       <motion.div
-                        className="h-full w-full overflow-auto"
+                        className="size-full overflow-auto"
                         initial={{ opacity: 0.8, y: 3 }}
                         animate={{ opacity: 1, y: 0 }}
                         transition={{ duration: 0.15, ease: "easeOut" }}
@@ -1337,7 +1337,7 @@ export default function HtmlPreview({
                         // srcDoc is now set by useEffect after streaming finishes
                         // srcDoc={processedHtmlContent()}
                         title={t("common.htmlPreview.codePreviewTitleFullscreen")}
-                        className="border-0 bg-white w-full h-full"
+                        className="border-0 bg-white size-full"
                         sandbox={sandboxAttribute}
                         onClick={(e) => e.stopPropagation()}
                         onMouseDown={(e) => e.stopPropagation()}
@@ -1366,7 +1366,7 @@ export default function HtmlPreview({
                         style={{ opacity: 0.2 }}
                       >
                         <motion.div
-                          className="w-full h-full bg-gray-400"
+                          className="size-full bg-gray-400"
                           animate={{
                             opacity: [0.05, 0.2, 0.05],
                           }}
@@ -1429,7 +1429,7 @@ export default function HtmlPreview({
                     >
                       {/* Plus icon - only visible when collapsed */}
                       <motion.div
-                        className="absolute w-[40px] h-[40px] flex items-center justify-center group hover:scale-110 transition-all duration-200"
+                        className="absolute size-[40px] flex items-center justify-center group hover:scale-110 transition-all duration-200"
                         initial={false}
                         animate={{
                           opacity: isToolbarCollapsed ? 1 : 0,
@@ -1462,7 +1462,7 @@ export default function HtmlPreview({
                         }}
                       >
                         <div
-                          className="flex items-center justify-center w-8 h-8 hover:bg-white/10 rounded-full group cursor-move"
+                          className="flex items-center justify-center size-8 hover:bg-white/10 rounded-full group cursor-move"
                           onPointerDown={(e) => {
                             e.stopPropagation();
                             dragControls.start(e);
@@ -1512,7 +1512,7 @@ export default function HtmlPreview({
                               minimizeSound.play();
                             }
                           }}
-                          className="flex items-center justify-center w-8 h-8 hover:bg-white/10 rounded-full group"
+                          className="flex items-center justify-center size-8 hover:bg-white/10 rounded-full group"
                           aria-label={t("common.htmlPreview.toggleCode")}
                         >
                           <Code
@@ -1522,7 +1522,7 @@ export default function HtmlPreview({
                         </button>
                         <button
                           onClick={handleSaveAsApplet}
-                          className="flex items-center justify-center w-8 h-8 hover:bg-white/10 rounded-full group"
+                          className="flex items-center justify-center size-8 hover:bg-white/10 rounded-full group"
                           aria-label={t("common.htmlPreview.saveApplet")}
                         >
                           <DownloadSimple
@@ -1532,7 +1532,7 @@ export default function HtmlPreview({
                         </button>
                         <button
                           onClick={handleSaveToDisk}
-                          className="flex items-center justify-center w-8 h-8 hover:bg-white/10 rounded-full group"
+                          className="flex items-center justify-center size-8 hover:bg-white/10 rounded-full group"
                           aria-label={t("common.htmlPreview.downloadHtml")}
                         >
                           <Export
@@ -1542,7 +1542,7 @@ export default function HtmlPreview({
                         </button>
                         <button
                           onClick={handleCopy}
-                          className="flex items-center justify-center w-8 h-8 hover:bg-white/10 rounded-full group"
+                          className="flex items-center justify-center size-8 hover:bg-white/10 rounded-full group"
                           aria-label={t("common.htmlPreview.copyHtml")}
                         >
                           {copySuccess ? (
@@ -1563,7 +1563,7 @@ export default function HtmlPreview({
                             minimizeSound.play();
                             setIsFullScreen(false);
                           }}
-                          className="flex items-center justify-center w-8 h-8 hover:bg-white/10 rounded-full group"
+                          className="flex items-center justify-center size-8 hover:bg-white/10 rounded-full group"
                           aria-label={t("common.htmlPreview.exitFullscreen")}
                         >
                           <ArrowsIn

--- a/src/components/shared/LinkPreview.tsx
+++ b/src/components/shared/LinkPreview.tsx
@@ -311,7 +311,7 @@ export function LinkPreview({ url, className = "" }: LinkPreviewProps) {
         className={`flex items-center gap-2 p-3 bg-red-50 border border-red-200 text-sm font-geneva-12 max-w-[420px] ${className}`}
         style={{ borderRadius: "3px" }}
       >
-        <WarningCircle className="h-4 w-4 text-red-500" weight="bold" />
+        <WarningCircle className="size-4 text-red-500" weight="bold" />
         <span className="text-red-600">{error}</span>
       </motion.div>
     );
@@ -437,7 +437,7 @@ export function LinkPreview({ url, className = "" }: LinkPreviewProps) {
             <img
               src={metadata.image}
               alt={metadata.title || "Link preview"}
-              className="w-full h-full object-cover"
+              className="size-full object-cover"
               onError={(e) => {
                 // Hide image if it fails to load
                 e.currentTarget.style.display = "none";
@@ -450,7 +450,7 @@ export function LinkPreview({ url, className = "" }: LinkPreviewProps) {
                 <img
                   src={getFaviconUrl(url)}
                   alt="Site favicon"
-                  className="h-4 w-4 flex-shrink-0"
+                  className="size-4 flex-shrink-0"
                   onError={(e) => {
                     // Fallback to a simple circle if favicon fails to load
                     e.currentTarget.style.display = "none";
@@ -459,7 +459,7 @@ export function LinkPreview({ url, className = "" }: LinkPreviewProps) {
                     );
                   }}
                 />
-                <div className="h-4 w-4 bg-gray-300 rounded-full flex-shrink-0 hidden"></div>
+                <div className="size-4 bg-gray-300 rounded-full flex-shrink-0 hidden"></div>
                 {metadata.title && (
                   <h3 className="font-semibold text-white text-[10px] truncate">
                     {metadata.title}
@@ -485,7 +485,7 @@ export function LinkPreview({ url, className = "" }: LinkPreviewProps) {
                     title={t("components.linkPreview.openIpod")}
                     data-link-preview
                   >
-                    {!isMacOSTheme && <MusicNote className="h-3 w-3" weight="bold" />}
+                    {!isMacOSTheme && <MusicNote className="size-3" weight="bold" />}
                     <span>{t("components.linkPreview.openIpod")}</span>
                   </button>
                   <button
@@ -499,7 +499,7 @@ export function LinkPreview({ url, className = "" }: LinkPreviewProps) {
                     title={t("components.linkPreview.openYouTube")}
                     data-link-preview
                   >
-                    {!isMacOSTheme && <ArrowSquareOut className="h-3 w-3" weight="bold" />}
+                    {!isMacOSTheme && <ArrowSquareOut className="size-3" weight="bold" />}
                     <span>{t("components.linkPreview.openYouTube")}</span>
                   </button>
                 </div>
@@ -516,7 +516,7 @@ export function LinkPreview({ url, className = "" }: LinkPreviewProps) {
                     title={t("components.linkPreview.openKaraoke")}
                     data-link-preview
                   >
-                    {!isMacOSTheme && <Microphone className="h-3 w-3" weight="bold" />}
+                    {!isMacOSTheme && <Microphone className="size-3" weight="bold" />}
                     <span>{t("components.linkPreview.openKaraoke")}</span>
                   </button>
                   <button
@@ -530,7 +530,7 @@ export function LinkPreview({ url, className = "" }: LinkPreviewProps) {
                     title={t("components.linkPreview.openYouTube")}
                     data-link-preview
                   >
-                    {!isMacOSTheme && <ArrowSquareOut className="h-3 w-3" weight="bold" />}
+                    {!isMacOSTheme && <ArrowSquareOut className="size-3" weight="bold" />}
                     <span>{t("components.linkPreview.openYouTube")}</span>
                   </button>
                 </div>
@@ -547,7 +547,7 @@ export function LinkPreview({ url, className = "" }: LinkPreviewProps) {
                     title={t("components.linkPreview.addToIpod")}
                     data-link-preview
                   >
-                    {!isMacOSTheme && <MusicNote className="h-3 w-3" weight="bold" />}
+                    {!isMacOSTheme && <MusicNote className="size-3" weight="bold" />}
                     <span>{t("components.linkPreview.addToIpod")}</span>
                   </button>
                   <button
@@ -561,7 +561,7 @@ export function LinkPreview({ url, className = "" }: LinkPreviewProps) {
                     title={t("components.linkPreview.openYouTube")}
                     data-link-preview
                   >
-                    {!isMacOSTheme && <ArrowSquareOut className="h-3 w-3" weight="bold" />}
+                    {!isMacOSTheme && <ArrowSquareOut className="size-3" weight="bold" />}
                     <span>{t("components.linkPreview.openYouTube")}</span>
                   </button>
                 </div>
@@ -579,7 +579,7 @@ export function LinkPreview({ url, className = "" }: LinkPreviewProps) {
                   title="Open Externally"
                   data-link-preview
                 >
-                  {!isMacOSTheme && <ArrowSquareOut className="h-3 w-3" weight="bold" />}
+                  {!isMacOSTheme && <ArrowSquareOut className="size-3" weight="bold" />}
                   <span>Open Externally</span>
                 </button>
               </div>
@@ -593,14 +593,14 @@ export function LinkPreview({ url, className = "" }: LinkPreviewProps) {
             {metadata.image && (
               <div
                 className={cn(
-                  "w-18 h-18 bg-gray-100 relative overflow-hidden flex-shrink-0",
+                  "size-18 bg-gray-100 relative overflow-hidden flex-shrink-0",
                   isMacOSTheme && "hidden"
                 )}
               >
                 <img
                   src={metadata.image}
                   alt={metadata.title || "Link preview"}
-                  className="w-full h-full object-cover"
+                  className="size-full object-cover"
                   onError={(e) => {
                     // Hide image if it fails to load
                     e.currentTarget.style.display = "none";
@@ -660,7 +660,7 @@ export function LinkPreview({ url, className = "" }: LinkPreviewProps) {
                   <img
                     src={getFaviconUrl(url)}
                     alt="Site favicon"
-                    className="h-4 w-4 flex-shrink-0"
+                    className="size-4 flex-shrink-0"
                     onError={(e) => {
                       // Fallback to a simple circle if favicon fails to load
                       e.currentTarget.style.display = "none";
@@ -669,7 +669,7 @@ export function LinkPreview({ url, className = "" }: LinkPreviewProps) {
                       );
                     }}
                   />
-                  <div className="h-4 w-4 bg-gray-300 rounded-full flex-shrink-0 hidden"></div>
+                  <div className="size-4 bg-gray-300 rounded-full flex-shrink-0 hidden"></div>
                   <p className="text-[10px] text-gray-500 truncate">
                     {metadata.siteName || new URL(url).hostname}
                   </p>
@@ -700,7 +700,7 @@ export function LinkPreview({ url, className = "" }: LinkPreviewProps) {
                       title={t("components.linkPreview.openIpod")}
                       data-link-preview
                     >
-                      {!isMacOSTheme && <MusicNote className="h-3 w-3" weight="bold" />}
+                      {!isMacOSTheme && <MusicNote className="size-3" weight="bold" />}
                       <span>{t("components.linkPreview.openIpod")}</span>
                     </button>
                     <button
@@ -715,7 +715,7 @@ export function LinkPreview({ url, className = "" }: LinkPreviewProps) {
                       data-link-preview
                     >
                       {!isMacOSTheme && (
-                        <ArrowSquareOut className="h-3 w-3" weight="bold" />
+                        <ArrowSquareOut className="size-3" weight="bold" />
                       )}
                       <span>{t("components.linkPreview.openYouTube")}</span>
                     </button>
@@ -733,7 +733,7 @@ export function LinkPreview({ url, className = "" }: LinkPreviewProps) {
                       title={t("components.linkPreview.openKaraoke")}
                       data-link-preview
                     >
-                      {!isMacOSTheme && <Microphone className="h-3 w-3" weight="bold" />}
+                      {!isMacOSTheme && <Microphone className="size-3" weight="bold" />}
                       <span>{t("components.linkPreview.openKaraoke")}</span>
                     </button>
                     <button
@@ -748,7 +748,7 @@ export function LinkPreview({ url, className = "" }: LinkPreviewProps) {
                       data-link-preview
                     >
                       {!isMacOSTheme && (
-                        <ArrowSquareOut className="h-3 w-3" weight="bold" />
+                        <ArrowSquareOut className="size-3" weight="bold" />
                       )}
                       <span>{t("components.linkPreview.openYouTube")}</span>
                     </button>
@@ -766,7 +766,7 @@ export function LinkPreview({ url, className = "" }: LinkPreviewProps) {
                       title={t("components.linkPreview.addToIpod")}
                       data-link-preview
                     >
-                      {!isMacOSTheme && <MusicNote className="h-3 w-3" weight="bold" />}
+                      {!isMacOSTheme && <MusicNote className="size-3" weight="bold" />}
                       <span>{t("components.linkPreview.addToIpod")}</span>
                     </button>
                     <button
@@ -781,7 +781,7 @@ export function LinkPreview({ url, className = "" }: LinkPreviewProps) {
                       data-link-preview
                     >
                       {!isMacOSTheme && (
-                        <ArrowSquareOut className="h-3 w-3" weight="bold" />
+                        <ArrowSquareOut className="size-3" weight="bold" />
                       )}
                       <span>{t("components.linkPreview.openYouTube")}</span>
                     </button>
@@ -800,7 +800,7 @@ export function LinkPreview({ url, className = "" }: LinkPreviewProps) {
                     title="Open Externally"
                     data-link-preview
                   >
-                    {!isMacOSTheme && <ArrowSquareOut className="h-3 w-3" weight="bold" />}
+                    {!isMacOSTheme && <ArrowSquareOut className="size-3" weight="bold" />}
                     <span>Open Externally</span>
                   </button>
                 </div>

--- a/src/components/shared/LyricsSyncMode.tsx
+++ b/src/components/shared/LyricsSyncMode.tsx
@@ -348,7 +348,7 @@ export function LyricsSyncMode({
 
   return (
     <div
-      className="w-full h-full flex flex-col bg-black/90"
+      className="size-full flex flex-col bg-black/90"
       style={{ borderRadius: "inherit" }}
     >
       {/* Header - pt-7 to accommodate notitlebar hover titlebar */}
@@ -363,7 +363,7 @@ export function LyricsSyncMode({
               className="p-1.5 rounded-full hover:bg-white/10 active:bg-white/20 text-white"
               aria-label={t("apps.ipod.syncMode.decreaseOffset", "Decrease offset")}
             >
-              <Minus className="w-4 h-4" weight="bold" />
+              <Minus className="size-4" weight="bold" />
             </button>
             <div className="text-white text-sm font-medium min-w-[70px] text-center">
               {formatOffset(currentOffset)}
@@ -374,7 +374,7 @@ export function LyricsSyncMode({
               className="p-1.5 rounded-full hover:bg-white/10 active:bg-white/20 text-white"
               aria-label={t("apps.ipod.syncMode.increaseOffset", "Increase offset")}
             >
-              <Plus className="w-4 h-4" weight="bold" />
+              <Plus className="size-4" weight="bold" />
             </button>
           </div>
 
@@ -389,7 +389,7 @@ export function LyricsSyncMode({
               className="p-2 rounded-full bg-white/10 hover:bg-white/20 active:bg-white/30 text-white"
               aria-label={t("apps.ipod.syncMode.syncScroll", "Sync Scroll")}
             >
-              <CaretDoubleDown className="w-4 h-4" weight="bold" />
+              <CaretDoubleDown className="size-4" weight="bold" />
             </button>
           )}
 
@@ -401,7 +401,7 @@ export function LyricsSyncMode({
               className="p-2 rounded-full bg-white/10 hover:bg-white/20 active:bg-white/30 text-white"
               aria-label={t("apps.ipod.syncMode.searchLyrics", "Search Lyrics")}
             >
-              <MagnifyingGlass className="w-4 h-4" weight="bold" />
+              <MagnifyingGlass className="size-4" weight="bold" />
             </button>
           )}
 

--- a/src/components/shared/MapsSearchPlacesCard.tsx
+++ b/src/components/shared/MapsSearchPlacesCard.tsx
@@ -132,7 +132,7 @@ export function MapsSearchPlacesCard({
                 })}
               >
                 <div
-                  className="aqua-icon-badge flex h-9 w-9 shrink-0 items-center justify-center text-white"
+                  className="aqua-icon-badge flex size-9 shrink-0 items-center justify-center text-white"
                   style={{ backgroundImage: poiVisualGradient(visual) }}
                   aria-hidden="true"
                 >
@@ -154,7 +154,7 @@ export function MapsSearchPlacesCard({
                   rel="noopener noreferrer"
                   onClick={(e) => e.stopPropagation()}
                   className={cn(
-                    "shrink-0 -mr-0.5 flex h-7 w-7 items-center justify-center rounded-full",
+                    "shrink-0 -mr-0.5 flex size-7 items-center justify-center rounded-full",
                     "text-black/55 hover:bg-black/10 hover:text-black/85",
                     "focus:outline-none focus-visible:ring-1 focus-visible:ring-black/30"
                   )}

--- a/src/components/shared/ToolInvocationMessage.tsx
+++ b/src/components/shared/ToolInvocationMessage.tsx
@@ -59,7 +59,7 @@ function ToolInvocationStatusRow({
   const alignmentClass = align === "start" ? "items-start" : "items-center";
   return (
     <div className={`flex ${alignmentClass} gap-1 ${className || ""}`}>
-      <span className="inline-flex h-3 w-3 items-center justify-center shrink-0">
+      <span className="inline-flex size-3 items-center justify-center shrink-0">
         {icon}
       </span>
       {children}
@@ -775,7 +775,7 @@ export function ToolInvocationMessage({
       return (
         <div key={partKey} className="mb-0 px-1 py-0.5 text-[12px]">
           <ToolInvocationStatusRow
-            icon={<Check className="h-3 w-3 text-blue-600" weight="bold" />}
+            icon={<Check className="size-3 text-blue-600" weight="bold" />}
             className="text-gray-700"
             align="start"
           >
@@ -809,7 +809,7 @@ export function ToolInvocationMessage({
           <ToolInvocationStatusRow
             icon={
               <Check
-                className="h-3 w-3 shrink-0 text-neutral-400"
+                className="size-3 shrink-0 text-neutral-400"
                 weight="bold"
                 aria-hidden
               />
@@ -965,7 +965,7 @@ export function ToolInvocationMessage({
         )}
       {state === "output-available" && (
         <ToolInvocationStatusRow
-          icon={<Check className="h-3 w-3 text-blue-600" weight="bold" />}
+          icon={<Check className="size-3 text-blue-600" weight="bold" />}
           className="text-gray-700"
           align="start"
         >
@@ -986,7 +986,7 @@ export function ToolInvocationMessage({
         <ToolInvocationStatusRow
           icon={
             <Check
-              className="h-3 w-3 shrink-0 text-neutral-400"
+              className="size-3 shrink-0 text-neutral-400"
               weight="bold"
               aria-hidden
             />

--- a/src/components/ui/SwipeInstructions.tsx
+++ b/src/components/ui/SwipeInstructions.tsx
@@ -66,8 +66,8 @@ export function SwipeInstructions({ className }: SwipeInstructionsProps) {
 
       <div className="mt-2 flex items-center justify-center space-x-8 py-4">
         <div className="flex flex-col items-center">
-          <div className="relative w-16 h-16 flex items-center justify-center">
-            <div className="absolute border-2 border-black rounded-md w-12 h-12 bg-gray-100" />
+          <div className="relative size-16 flex items-center justify-center">
+            <div className="absolute border-2 border-black rounded-md size-12 bg-gray-100" />
             <svg
               width="24"
               height="24"
@@ -88,8 +88,8 @@ export function SwipeInstructions({ className }: SwipeInstructionsProps) {
         </div>
 
         <div className="flex flex-col items-center">
-          <div className="relative w-16 h-16 flex items-center justify-center">
-            <div className="absolute border-2 border-black rounded-md w-12 h-12 bg-gray-100" />
+          <div className="relative size-16 flex items-center justify-center">
+            <div className="absolute border-2 border-black rounded-md size-12 bg-gray-100" />
             <svg
               width="24"
               height="24"

--- a/src/components/ui/aqua-checkbox.tsx
+++ b/src/components/ui/aqua-checkbox.tsx
@@ -8,7 +8,7 @@ interface AquaCheckboxProps {
 export function AquaCheckbox({ checked, color }: AquaCheckboxProps) {
   return (
     <div
-      className="w-[14px] h-[14px] rounded-[3.5px] flex items-center justify-center shrink-0 relative overflow-hidden"
+      className="size-[14px] rounded-[3.5px] flex items-center justify-center shrink-0 relative overflow-hidden"
       style={checked ? {
         background: `linear-gradient(${color}, ${color}dd)`,
         boxShadow: `0 1px 2px rgba(0,0,0,0.3), 0 0.5px 0.5px rgba(0,0,0,0.2), inset 0 1px 2px rgba(0,0,0,0.2), inset 0 1.5px 2px 0.5px ${color}`,

--- a/src/components/ui/audio-input-button.tsx
+++ b/src/components/ui/audio-input-button.tsx
@@ -80,7 +80,7 @@ export const AudioInputButton = forwardRef<
               isSilent={isSilent}
             />
           ) : (
-            <Microphone className="h-4 w-4" weight="bold" />
+            <Microphone className="size-4" weight="bold" />
           )}
         </button>
       </div>

--- a/src/components/ui/dial.tsx
+++ b/src/components/ui/dial.tsx
@@ -136,9 +136,9 @@ const Dial = React.forwardRef<HTMLDivElement, DialProps>(
 
     // Size classes
     const sizeClasses = {
-      sm: "w-8 h-8",
-      md: "w-12 h-12",
-      lg: "w-14 h-14",
+      sm: "size-8",
+      md: "size-12",
+      lg: "size-14",
     };
 
     // Calculate the percentage for the background fill
@@ -184,7 +184,7 @@ const Dial = React.forwardRef<HTMLDivElement, DialProps>(
           onTouchStart={handleTouchStart}
         >
           {/* Center circle */}
-          <div className="absolute top-1/2 left-1/2 w-4 h-4 -translate-x-1/2 -translate-y-1/2 rounded-full bg-[#222]"></div>
+          <div className="absolute top-1/2 left-1/2 size-4 -translate-x-1/2 -translate-y-1/2 rounded-full bg-[#222]"></div>
         </div>
       </div>
     );

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -233,15 +233,15 @@ const DialogHeader = ({
       {...props}
     >
       <DialogPrimitive.Close asChild>
-        <div className="relative ml-2 w-4 h-4 cursor-default select-none">
+        <div className="relative ml-2 size-4 cursor-default select-none">
           <div className="absolute inset-0 -m-2" />
-          <div className="w-4 h-4 bg-os-button-face shadow-[0_0_0_1px_var(--os-color-button-face)] border-2 border-os-window hover:bg-gray-200 active:bg-gray-300 flex items-center justify-center" />
+          <div className="size-4 bg-os-button-face shadow-[0_0_0_1px_var(--os-color-button-face)] border-2 border-os-window hover:bg-gray-200 active:bg-gray-300 flex items-center justify-center" />
         </div>
       </DialogPrimitive.Close>
       <div className="select-none mx-auto bg-os-button-face px-2 py-0 h-full flex items-center justify-center text-os-titlebar-active-text">
         {children}
       </div>
-      <div className="mr-2 w-4 h-4" />
+      <div className="mr-2 size-4" />
     </div>
   );
 };

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -272,7 +272,7 @@ const DropdownMenuCheckboxItem = React.forwardRef<
       checked={checked}
       {...props}
     >
-      <span className="absolute left-3 flex h-3.5 w-3.5 items-center justify-center">
+      <span className="absolute left-3 flex size-3.5 items-center justify-center">
         <DropdownMenuPrimitive.ItemIndicator>
           <Check size={12} weight="bold" />
         </DropdownMenuPrimitive.ItemIndicator>
@@ -304,7 +304,7 @@ const DropdownMenuRadioItem = React.forwardRef<
       }}
       {...props}
     >
-      <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+      <span className="absolute left-2 flex size-3.5 items-center justify-center">
         <DropdownMenuPrimitive.ItemIndicator>
           <Circle size={8} weight="fill" />
         </DropdownMenuPrimitive.ItemIndicator>

--- a/src/components/ui/menubar.tsx
+++ b/src/components/ui/menubar.tsx
@@ -333,7 +333,7 @@ const MenubarCheckboxItem = React.forwardRef<
       checked={checked}
       {...props}
     >
-      <span className="absolute left-3 flex h-3.5 w-3.5 items-center justify-center">
+      <span className="absolute left-3 flex size-3.5 items-center justify-center">
         <MenubarPrimitive.ItemIndicator>
           <Check size={12} weight="bold" />
         </MenubarPrimitive.ItemIndicator>
@@ -390,7 +390,7 @@ const MenubarRadioItem = React.forwardRef<
       }}
       {...props}
     >
-      <span className="absolute left-3 flex h-3.5 w-3.5 items-center justify-center">
+      <span className="absolute left-3 flex size-3.5 items-center justify-center">
         <MenubarPrimitive.ItemIndicator>
           <Circle size={6} weight="fill" />
         </MenubarPrimitive.ItemIndicator>

--- a/src/components/ui/right-click-menu.tsx
+++ b/src/components/ui/right-click-menu.tsx
@@ -70,12 +70,12 @@ function renderItems(items: MenuItem[]): ReactNode {
             className={menuItemClass}
           >
             {item.icon && (
-              <div className="w-4 h-4 flex items-center justify-center flex-shrink-0">
+              <div className="size-4 flex items-center justify-center flex-shrink-0">
                 {item.icon.startsWith("/") || item.icon.startsWith("http") ? (
                   <ThemedIcon
                     name={item.icon}
                     alt={item.label}
-                    className="w-4 h-4 [image-rendering:pixelated]"
+                    className="size-4 [image-rendering:pixelated]"
                   />
                 ) : (
                   <span className="text-xs leading-none">{item.icon}</span>
@@ -97,12 +97,12 @@ function renderItems(items: MenuItem[]): ReactNode {
               className={menuItemClass}
             >
               {item.icon && (
-                <div className="w-4 h-4 flex items-center justify-center flex-shrink-0">
+                <div className="size-4 flex items-center justify-center flex-shrink-0">
                   {item.icon.startsWith("/") || item.icon.startsWith("http") ? (
                     <ThemedIcon
                       name={item.icon}
                       alt={item.label}
-                      className="w-4 h-4 [image-rendering:pixelated]"
+                      className="size-4 [image-rendering:pixelated]"
                     />
                   ) : (
                     <span className="text-xs leading-none">{item.icon}</span>

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -180,7 +180,7 @@ const SelectItem = React.forwardRef<
       }}
       {...props}
     >
-      <span className="absolute right-2 flex h-3.5 w-3.5 items-center justify-center">
+      <span className="absolute right-2 flex size-3.5 items-center justify-center">
         <SelectPrimitive.ItemIndicator>
           <Check size={12} weight="bold" />
         </SelectPrimitive.ItemIndicator>
@@ -215,7 +215,7 @@ const SelectItemWithDescription = React.forwardRef<
       }}
       {...props}
     >
-      <span className="absolute right-2 top-2 flex h-3.5 w-3.5 items-center justify-center">
+      <span className="absolute right-2 top-2 flex size-3.5 items-center justify-center">
         <SelectPrimitive.ItemIndicator>
           <Check size={12} weight="bold" />
         </SelectPrimitive.ItemIndicator>

--- a/src/components/ui/slider.tsx
+++ b/src/components/ui/slider.tsx
@@ -31,7 +31,7 @@ const Slider = React.forwardRef<
         )}
       />
     </SliderPrimitive.Track>
-    <SliderPrimitive.Thumb className="os-slider-thumb block h-4 w-4 border-2 border-primary bg-background shadow-[1px_1px_0px_0px_rgba(0,0,0,0.3)] transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50" />
+    <SliderPrimitive.Thumb className="os-slider-thumb block size-4 border-2 border-primary bg-background shadow-[1px_1px_0px_0px_rgba(0,0,0,0.3)] transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50" />
   </SliderPrimitive.Root>
 ));
 Slider.displayName = SliderPrimitive.Root.displayName;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- replace redundant Tailwind `w-*` + `h-*` pairs with `size-*` where both axes use the same scale value
- apply the cleanup across the files flagged by `design-no-redundant-size-axes`
- keep behavior unchanged while aligning class usage with Tailwind v3.4+

## Testing
- `bun run build`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f36dd7cf-4569-4f64-b8a4-e1e7b37dae82"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f36dd7cf-4569-4f64-b8a4-e1e7b37dae82"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

