### PR TITLE
Migrate deprecated React 19 APIs in UI and app components

### DIFF
--- a/src/apps/applet-viewer/components/AppStoreFeed.tsx
+++ b/src/apps/applet-viewer/components/AppStoreFeed.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useImperativeHandle, forwardRef, useCallback } from "react";
+import { useState, useEffect, useRef, useImperativeHandle, useCallback } from "react";
 import { Button } from "@/components/ui/button";
 import { useThemeFlags } from "@/hooks/useThemeFlags";
 import { useLatestRef } from "@/hooks/useLatestRef";
@@ -26,853 +26,860 @@ export interface AppStoreFeedRef {
   goToPrevious: () => void;
 }
 
-export const AppStoreFeed = forwardRef<AppStoreFeedRef, AppStoreFeedProps>(
-  ({ theme, focusWindow, onAppletSelect }, ref) => {
-  const { t } = useTranslation();
-  const [applets, setApplets] = useState<Applet[]>([]);
-  const [isLoading, setIsLoading] = useState(true);
-  const [currentIndex, setCurrentIndex] = useState(0);
-  const [navigationDirection, setNavigationDirection] = useState<"forward" | "backward" | "none">("none");
-  const [appletContents, setAppletContents] = useState<Map<string, string>>(new Map());
-  const [loadingContents, setLoadingContents] = useState<Set<string>>(new Set());
-  const feedRef = useRef<HTMLDivElement>(null);
-  const loadingRef = useRef<Set<string>>(new Set());
-  const loadedRef = useRef<Set<string>>(new Set());
-  // Use useLatestRef to keep refs in sync with state without effects
-  const currentIndexRef = useLatestRef(currentIndex);
-  const appletsLengthRef = useLatestRef(applets.length);
-  const hasFetchedRef = useRef(false);
-  const sessionSeedRef = useRef(Math.floor(Math.random() * 1000000));
-  const {
-    isMacOSTheme: osIsMac,
-    isSystem7Theme: osIsSystem7,
-    isWindowsTheme: osIsXp,
-  } = useThemeFlags();
-  const { username, isAuthenticated } = useChatsStoreShallow((state) => ({
-    username: state.username,
-    isAuthenticated: state.isAuthenticated,
-  }));
+export const AppStoreFeed = (
+  {
+    ref,
+    theme,
+    focusWindow,
+    onAppletSelect
+  }: AppStoreFeedProps & {
+    ref: React.RefObject<AppStoreFeedRef>;
+  }
+) => {
+const { t } = useTranslation();
+const [applets, setApplets] = useState<Applet[]>([]);
+const [isLoading, setIsLoading] = useState(true);
+const [currentIndex, setCurrentIndex] = useState(0);
+const [navigationDirection, setNavigationDirection] = useState<"forward" | "backward" | "none">("none");
+const [appletContents, setAppletContents] = useState<Map<string, string>>(new Map());
+const [loadingContents, setLoadingContents] = useState<Set<string>>(new Set());
+const feedRef = useRef<HTMLDivElement>(null);
+const loadingRef = useRef<Set<string>>(new Set());
+const loadedRef = useRef<Set<string>>(new Set());
+// Use useLatestRef to keep refs in sync with state without effects
+const currentIndexRef = useLatestRef(currentIndex);
+const appletsLengthRef = useLatestRef(applets.length);
+const hasFetchedRef = useRef(false);
+const sessionSeedRef = useRef(Math.floor(Math.random() * 1000000));
+const {
+  isMacOSTheme: osIsMac,
+  isSystem7Theme: osIsSystem7,
+  isWindowsTheme: osIsXp,
+} = useThemeFlags();
+const { username, isAuthenticated } = useChatsStoreShallow((state) => ({
+  username: state.username,
+  isAuthenticated: state.isAuthenticated,
+}));
 
-  // Stacking constants (similar to TimeMachineView)
-  const MAX_VISIBLE_PREVIEWS = 4;
-  const PREVIEW_Z_SPACING = -80;
-  const PREVIEW_SCALE_FACTOR = 0.05;
-  const PREVIEW_Y_SPACING = -28;
-  const isMacTheme = theme === "macosx" || osIsMac;
-  const isSystem7Theme = theme === "system7" || osIsSystem7;
-  const isXpTheme = osIsXp;
+// Stacking constants (similar to TimeMachineView)
+const MAX_VISIBLE_PREVIEWS = 4;
+const PREVIEW_Z_SPACING = -80;
+const PREVIEW_SCALE_FACTOR = 0.05;
+const PREVIEW_Y_SPACING = -28;
+const isMacTheme = theme === "macosx" || osIsMac;
+const isSystem7Theme = theme === "system7" || osIsSystem7;
+const isXpTheme = osIsXp;
 
-  const actions = useAppletActions();
+const actions = useAppletActions();
 
-  // Add CSS to ensure emoji size doesn't get overridden by theme styles
-  const appletIconStyles = `
-    .applet-icon {
-      font-size: 2.25rem !important;
-      display: flex !important;
-      align-items: center !important;
-      justify-content: center !important;
-    }
-  `;
+// Add CSS to ensure emoji size doesn't get overridden by theme styles
+const appletIconStyles = `
+  .applet-icon {
+    font-size: 2.25rem !important;
+    display: flex !important;
+    align-items: center !important;
+    justify-content: center !important;
+  }
+`;
 
-  // Ensure macOSX theme uses Lucida Grande/system/emoji-safe fonts inside
-  // iframe content. The auth bridge script is only injected for trusted
-  // (ryo-authored) applets — untrusted previews must remain inert in
-  // their sandboxed-without-`allow-same-origin` iframes.
-  const ensureMacFonts = (content: string, trusted: boolean): string => {
-    if (!content) return content;
-    
-    const preload = `<link rel="stylesheet" href="/fonts/fonts.css">`;
-    const fontStyle = isMacTheme ? `<style data-ryos-applet-font-fix>
-      html,body{font-family:"LucidaGrande","Lucida Grande",-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,"Apple Color Emoji","Noto Color Emoji",sans-serif!important}
-      *{font-family:inherit!important}
-      h1,h2,h3,h4,h5,h6,p,div,span,a,li,ul,ol,button,input,select,textarea,label,code,pre,blockquote,small,strong,em,table,th,td{font-family:"LucidaGrande","Lucida Grande",-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,"Apple Color Emoji","Noto Color Emoji",sans-serif!important}
-    </style>` : '';
+// Ensure macOSX theme uses Lucida Grande/system/emoji-safe fonts inside
+// iframe content. The auth bridge script is only injected for trusted
+// (ryo-authored) applets — untrusted previews must remain inert in
+// their sandboxed-without-`allow-same-origin` iframes.
+const ensureMacFonts = (content: string, trusted: boolean): string => {
+  if (!content) return content;
+  
+  const preload = `<link rel="stylesheet" href="/fonts/fonts.css">`;
+  const fontStyle = isMacTheme ? `<style data-ryos-applet-font-fix>
+    html,body{font-family:"LucidaGrande","Lucida Grande",-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,"Apple Color Emoji","Noto Color Emoji",sans-serif!important}
+    *{font-family:inherit!important}
+    h1,h2,h3,h4,h5,h6,p,div,span,a,li,ul,ol,button,input,select,textarea,label,code,pre,blockquote,small,strong,em,table,th,td{font-family:"LucidaGrande","Lucida Grande",-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,"Apple Color Emoji","Noto Color Emoji",sans-serif!important}
+  </style>` : '';
 
-    const authBridge = trusted ? APPLET_AUTH_BRIDGE_SCRIPT : "";
-    const injectedContent = `${authBridge}${preload}${fontStyle}`;
+  const authBridge = trusted ? APPLET_AUTH_BRIDGE_SCRIPT : "";
+  const injectedContent = `${authBridge}${preload}${fontStyle}`;
 
-    const headCloseIdx = content.toLowerCase().lastIndexOf("</head>");
-    if (headCloseIdx !== -1) {
-      return (
-        content.slice(0, headCloseIdx) +
-        injectedContent +
-        content.slice(headCloseIdx)
+  const headCloseIdx = content.toLowerCase().lastIndexOf("</head>");
+  if (headCloseIdx !== -1) {
+    return (
+      content.slice(0, headCloseIdx) +
+      injectedContent +
+      content.slice(headCloseIdx)
+    );
+  }
+
+  const bodyOpenIdx = content.toLowerCase().indexOf("<body");
+  if (bodyOpenIdx !== -1) {
+    const bodyTagEnd = content.indexOf(">", bodyOpenIdx) + 1;
+    return (
+      content.slice(0, bodyTagEnd) +
+      injectedContent +
+      content.slice(bodyTagEnd)
+    );
+  }
+
+  return injectedContent + content;
+};
+
+// Send auth payload to iframe
+const sendAuthPayload = useCallback(
+  (target: Window | null | undefined) => {
+    if (!target) return;
+    try {
+      target.postMessage(
+        {
+          type: APPLET_AUTH_MESSAGE_TYPE,
+          action: "response",
+          payload: { username: username ?? null },
+        },
+        window.location.origin
       );
+    } catch (error) {
+      console.warn("[AppStoreFeed] Failed to post auth payload:", error);
+    }
+  },
+  [username]
+);
+
+// Listen for auth requests from iframes
+useEffect(() => {
+  const handleMessage = (event: MessageEvent) => {
+    const data = event?.data;
+    if (
+      !data ||
+      data.type !== APPLET_AUTH_MESSAGE_TYPE ||
+      data.action !== "request"
+    ) {
+      return;
     }
 
-    const bodyOpenIdx = content.toLowerCase().indexOf("<body");
-    if (bodyOpenIdx !== -1) {
-      const bodyTagEnd = content.indexOf(">", bodyOpenIdx) + 1;
-      return (
-        content.slice(0, bodyTagEnd) +
-        injectedContent +
-        content.slice(bodyTagEnd)
-      );
+    if (event.origin !== window.location.origin) {
+      return;
     }
 
-    return injectedContent + content;
-  };
+    const sourceWindow = event.source as Window | null;
+    if (!sourceWindow) {
+      return;
+    }
 
-  // Send auth payload to iframe
-  const sendAuthPayload = useCallback(
-    (target: Window | null | undefined) => {
-      if (!target) return;
-      try {
-        target.postMessage(
-          {
-            type: APPLET_AUTH_MESSAGE_TYPE,
-            action: "response",
-            payload: { username: username ?? null },
-          },
-          window.location.origin
-        );
-      } catch (error) {
-        console.warn("[AppStoreFeed] Failed to post auth payload:", error);
-      }
-    },
-    [username]
-  );
-
-  // Listen for auth requests from iframes
-  useEffect(() => {
-    const handleMessage = (event: MessageEvent) => {
-      const data = event?.data;
-      if (
-        !data ||
-        data.type !== APPLET_AUTH_MESSAGE_TYPE ||
-        data.action !== "request"
-      ) {
-        return;
-      }
-
-      if (event.origin !== window.location.origin) {
-        return;
-      }
-
-      const sourceWindow = event.source as Window | null;
-      if (!sourceWindow) {
-        return;
-      }
-
-      // Only respond to messages from our trusted applet preview iframes.
-      // Untrusted iframes are sandboxed without `allow-same-origin`, so
-      // their `event.origin` would be `"null"` and never match
-      // `window.location.origin` above — this loop is a defence-in-depth
-      // check that we additionally ignore them by element identity.
-      const iframes = feedRef.current?.querySelectorAll<HTMLIFrameElement>(
-        "iframe[data-ryos-trusted-applet='1']"
-      );
-      const frameWindows: Window[] = [];
-      iframes?.forEach((iframe) => {
-        if (iframe.contentWindow) {
-          frameWindows.push(iframe.contentWindow);
-        }
-      });
-
-      if (!frameWindows.includes(sourceWindow)) {
-        return;
-      }
-
-      sendAuthPayload(sourceWindow);
-    };
-
-    window.addEventListener("message", handleMessage);
-    return () => {
-      window.removeEventListener("message", handleMessage);
-    };
-  }, [sendAuthPayload]);
-
-  // Send auth payload to all iframes when auth changes.
-  // Only trusted iframes are tagged with `data-ryos-trusted-applet="1"`
-  // (set in renderAppletCard); skip the rest so an untrusted preview never
-  // even receives an attempted postMessage from us.
-  useEffect(() => {
+    // Only respond to messages from our trusted applet preview iframes.
+    // Untrusted iframes are sandboxed without `allow-same-origin`, so
+    // their `event.origin` would be `"null"` and never match
+    // `window.location.origin` above — this loop is a defence-in-depth
+    // check that we additionally ignore them by element identity.
     const iframes = feedRef.current?.querySelectorAll<HTMLIFrameElement>(
       "iframe[data-ryos-trusted-applet='1']"
     );
+    const frameWindows: Window[] = [];
     iframes?.forEach((iframe) => {
-      sendAuthPayload(iframe.contentWindow || undefined);
+      if (iframe.contentWindow) {
+        frameWindows.push(iframe.contentWindow);
+      }
     });
-  }, [username, isAuthenticated, sendAuthPayload, appletContents]);
 
-  const fetchApplets = useCallback(async () => {
-    // Check if offline
-    if (typeof navigator !== "undefined" && "onLine" in navigator && !navigator.onLine) {
-      setIsLoading(false);
+    if (!frameWindows.includes(sourceWindow)) {
       return;
     }
-    // Seeded random number generator for deterministic shuffling
-    const seededRandom = (seed: number) => {
-      let value = seed;
-      return () => {
-        value = (value * 9301 + 49297) % 233280;
-        return value / 233280;
-      };
-    };
 
-    // Deterministic shuffle using session seed + category identifier
-    const deterministicShuffle = <T extends { id: string }>(array: T[], categorySeed: number): T[] => {
-      if (array.length === 0) return array;
-      
-      // Combine session seed with category seed for stable but random order
-      const seed = (sessionSeedRef.current + categorySeed) % 1000000;
-      const random = seededRandom(seed);
-      
-      const shuffled = [...array];
-      for (let i = shuffled.length - 1; i > 0; i--) {
-        const j = Math.floor(random() * (i + 1));
-        [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
-      }
-      return shuffled;
+    sendAuthPayload(sourceWindow);
+  };
+
+  window.addEventListener("message", handleMessage);
+  return () => {
+    window.removeEventListener("message", handleMessage);
+  };
+}, [sendAuthPayload]);
+
+// Send auth payload to all iframes when auth changes.
+// Only trusted iframes are tagged with `data-ryos-trusted-applet="1"`
+// (set in renderAppletCard); skip the rest so an untrusted preview never
+// even receives an attempted postMessage from us.
+useEffect(() => {
+  const iframes = feedRef.current?.querySelectorAll<HTMLIFrameElement>(
+    "iframe[data-ryos-trusted-applet='1']"
+  );
+  iframes?.forEach((iframe) => {
+    sendAuthPayload(iframe.contentWindow || undefined);
+  });
+}, [username, isAuthenticated, sendAuthPayload, appletContents]);
+
+const fetchApplets = useCallback(async () => {
+  // Check if offline
+  if (typeof navigator !== "undefined" && "onLine" in navigator && !navigator.onLine) {
+    setIsLoading(false);
+    return;
+  }
+  // Seeded random number generator for deterministic shuffling
+  const seededRandom = (seed: number) => {
+    let value = seed;
+    return () => {
+      value = (value * 9301 + 49297) % 233280;
+      return value / 233280;
     };
+  };
+
+  // Deterministic shuffle using session seed + category identifier
+  const deterministicShuffle = <T extends { id: string }>(array: T[], categorySeed: number): T[] => {
+    if (array.length === 0) return array;
+    
+    // Combine session seed with category seed for stable but random order
+    const seed = (sessionSeedRef.current + categorySeed) % 1000000;
+    const random = seededRandom(seed);
+    
+    const shuffled = [...array];
+    for (let i = shuffled.length - 1; i > 0; i--) {
+      const j = Math.floor(random() * (i + 1));
+      [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
+    }
+    return shuffled;
+  };
+  try {
+    const response = await abortableFetch(
+      getApiUrl("/api/share-applet?list=true"),
+      {
+        timeout: 15000,
+        retry: { maxAttempts: 2, initialDelayMs: 500 },
+      }
+    );
+    const data = await response.json();
+    const allApplets = data.applets || [];
+      
+      // Categorize applets by priority
+      const featured: Applet[] = [];
+      const withUpdates: Applet[] = [];
+      const notInstalled: Applet[] = [];
+      const others: Applet[] = [];
+      
+      allApplets.forEach((applet: Applet) => {
+        const installed = actions.isAppletInstalled(applet.id);
+        const needsUpdate = actions.needsUpdate(applet);
+        const isFeatured = applet.featured === true;
+        
+        if (isFeatured) {
+          featured.push(applet);
+        } else if (needsUpdate && installed) {
+          withUpdates.push(applet);
+        } else if (!installed) {
+          notInstalled.push(applet);
+        } else {
+          others.push(applet);
+        }
+      });
+      
+      // Shuffle each category deterministically using category-specific seeds
+      // Combine in priority order: featured, updates, not installed, others
+      const sortedApplets = [
+        ...deterministicShuffle(featured, 1),
+        ...deterministicShuffle(withUpdates, 2),
+        ...deterministicShuffle(notInstalled, 3),
+        ...deterministicShuffle(others, 4),
+      ];
+      
+    setApplets(sortedApplets);
+  } catch (error) {
+    console.error("Error fetching applets:", error);
+  } finally {
+    setIsLoading(false);
+  }
+}, [actions]);
+
+useEffect(() => {
+  if (!hasFetchedRef.current) {
+    hasFetchedRef.current = true;
+    fetchApplets();
+  }
+}, [fetchApplets]);
+
+// Fetch applet content only for the current applet
+useEffect(() => {
+  const abortController = new AbortController();
+  let isActive = true;
+
+  const fetchAppletContent = async (appletId: string) => {
+    if (loadedRef.current.has(appletId) || loadingRef.current.has(appletId)) {
+      return;
+    }
+
+    loadingRef.current.add(appletId);
+    setLoadingContents((prev) => new Set(prev).add(appletId));
+
     try {
       const response = await abortableFetch(
-        getApiUrl("/api/share-applet?list=true"),
+        getApiUrl(`/api/share-applet?id=${encodeURIComponent(appletId)}`),
         {
+          signal: abortController.signal,
           timeout: 15000,
           retry: { maxAttempts: 2, initialDelayMs: 500 },
         }
       );
+      if (!isActive || abortController.signal.aborted) return;
+
       const data = await response.json();
-      const allApplets = data.applets || [];
-        
-        // Categorize applets by priority
-        const featured: Applet[] = [];
-        const withUpdates: Applet[] = [];
-        const notInstalled: Applet[] = [];
-        const others: Applet[] = [];
-        
-        allApplets.forEach((applet: Applet) => {
-          const installed = actions.isAppletInstalled(applet.id);
-          const needsUpdate = actions.needsUpdate(applet);
-          const isFeatured = applet.featured === true;
-          
-          if (isFeatured) {
-            featured.push(applet);
-          } else if (needsUpdate && installed) {
-            withUpdates.push(applet);
-          } else if (!installed) {
-            notInstalled.push(applet);
-          } else {
-            others.push(applet);
-          }
-        });
-        
-        // Shuffle each category deterministically using category-specific seeds
-        // Combine in priority order: featured, updates, not installed, others
-        const sortedApplets = [
-          ...deterministicShuffle(featured, 1),
-          ...deterministicShuffle(withUpdates, 2),
-          ...deterministicShuffle(notInstalled, 3),
-          ...deterministicShuffle(others, 4),
-        ];
-        
-      setApplets(sortedApplets);
+      if (!isActive || abortController.signal.aborted) return;
+
+      loadedRef.current.add(appletId);
+      setAppletContents((prev) => {
+        const next = new Map(prev);
+        next.set(appletId, data.content || "");
+        return next;
+      });
     } catch (error) {
-      console.error("Error fetching applets:", error);
-    } finally {
-      setIsLoading(false);
-    }
-  }, [actions]);
-
-  useEffect(() => {
-    if (!hasFetchedRef.current) {
-      hasFetchedRef.current = true;
-      fetchApplets();
-    }
-  }, [fetchApplets]);
-
-  // Fetch applet content only for the current applet
-  useEffect(() => {
-    const abortController = new AbortController();
-    let isActive = true;
-
-    const fetchAppletContent = async (appletId: string) => {
-      if (loadedRef.current.has(appletId) || loadingRef.current.has(appletId)) {
+      if (error instanceof Error && error.name === "AbortError") {
         return;
       }
-
-      loadingRef.current.add(appletId);
-      setLoadingContents((prev) => new Set(prev).add(appletId));
-
-      try {
-        const response = await abortableFetch(
-          getApiUrl(`/api/share-applet?id=${encodeURIComponent(appletId)}`),
-          {
-            signal: abortController.signal,
-            timeout: 15000,
-            retry: { maxAttempts: 2, initialDelayMs: 500 },
-          }
-        );
-        if (!isActive || abortController.signal.aborted) return;
-
-        const data = await response.json();
-        if (!isActive || abortController.signal.aborted) return;
-
-        loadedRef.current.add(appletId);
-        setAppletContents((prev) => {
-          const next = new Map(prev);
-          next.set(appletId, data.content || "");
-          return next;
-        });
-      } catch (error) {
-        if (error instanceof Error && error.name === "AbortError") {
-          return;
-        }
-        console.error(`Error fetching applet content for ${appletId}:`, error);
-      } finally {
-        loadingRef.current.delete(appletId);
-        setLoadingContents((prev) => {
-          const next = new Set(prev);
-          next.delete(appletId);
-          return next;
-        });
-      }
-    };
-
-    // Only load the current applet
-    if (applets.length > 0 && applets[currentIndex]) {
-      void fetchAppletContent(applets[currentIndex].id);
-    }
-    return () => {
-      isActive = false;
-      abortController.abort();
-    };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [currentIndex, applets.length]);
-
-  const scrollToIndex = useCallback((index: number) => {
-    if (index >= 0 && index < appletsLengthRef.current) {
-      const prevIndex = currentIndexRef.current;
-      setCurrentIndex(index);
-      // Note: currentIndexRef.current is automatically updated by useLatestRef
-      
-      // Determine navigation direction
-      if (index > prevIndex) {
-        setNavigationDirection("forward");
-      } else if (index < prevIndex) {
-        setNavigationDirection("backward");
-      } else {
-        setNavigationDirection("none");
-      }
-    }
-  }, [appletsLengthRef, currentIndexRef]);
-
-  // Handle wheel navigation for edge detection and toolbar
-  useEffect(() => {
-    const container = feedRef.current;
-    if (!container) return;
-
-    const handleWheel = (e: WheelEvent) => {
-      const containerRect = container.getBoundingClientRect();
-      const isInToolbar = e.clientY - containerRect.top < 60;
-      
-      // If in toolbar, navigate
-      if (isInToolbar && Math.abs(e.deltaY) > 30) {
-        e.preventDefault();
-        if (e.deltaY > 0 && currentIndex < applets.length - 1) {
-          scrollToIndex(currentIndex + 1);
-        } else if (e.deltaY < 0 && currentIndex > 0) {
-          scrollToIndex(currentIndex - 1);
-        }
-      }
-    };
-
-    container.addEventListener("wheel", handleWheel, { passive: false });
-    return () => {
-      container.removeEventListener("wheel", handleWheel);
-    };
-  }, [currentIndex, applets.length, scrollToIndex]);
-
-  // Handle keyboard navigation
-  useEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === "ArrowDown" || e.key === "PageDown") {
-        e.preventDefault();
-        if (currentIndex < applets.length - 1) {
-          scrollToIndex(currentIndex + 1);
-        }
-      } else if (e.key === "ArrowUp" || e.key === "PageUp") {
-        e.preventDefault();
-        if (currentIndex > 0) {
-          scrollToIndex(currentIndex - 1);
-        }
-      }
-    };
-
-    window.addEventListener("keydown", handleKeyDown);
-    return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [currentIndex, applets.length, scrollToIndex]);
-
-  // Note: Removed useEffect hooks that synced refs with state
-  // useLatestRef handles this automatically during render
-
-  useImperativeHandle(ref, () => ({
-    goToNext: () => {
-      if (currentIndexRef.current < appletsLengthRef.current - 1) {
-        scrollToIndex(currentIndexRef.current + 1);
-      }
-    },
-    goToPrevious: () => {
-      if (currentIndexRef.current > 0) {
-        scrollToIndex(currentIndexRef.current - 1);
-      }
-    },
-  }), [appletsLengthRef, currentIndexRef, scrollToIndex]);
-
-  const handleInstall = async (applet: Applet) => {
-    focusWindow?.();
-    await actions.handleInstall(applet, () => {
-      // Reset fetch flag to allow refresh after install
-      hasFetchedRef.current = false;
-      fetchApplets();
-    });
-  };
-
-  const handleAppletClick = async (applet: Applet) => {
-    focusWindow?.();
-    const result = await actions.handleAppletClick(applet);
-    if (result && onAppletSelect) {
-      onAppletSelect(result);
+      console.error(`Error fetching applet content for ${appletId}:`, error);
+    } finally {
+      loadingRef.current.delete(appletId);
+      setLoadingContents((prev) => {
+        const next = new Set(prev);
+        next.delete(appletId);
+        return next;
+      });
     }
   };
 
-  const handlePreviewClick = async (applet: Applet) => {
-    focusWindow?.();
-    const installed = actions.isAppletInstalled(applet.id);
-    if (installed) {
-      // If installed, bring window to foreground
-      await handleAppletClick(applet);
-    }
-  };
-
-  if (isLoading) {
-    return (
-      <div className="h-full w-full flex items-center justify-center">
-        <div className="text-center">
-          <p className="text-sm text-neutral-600 font-geneva-12 shimmer-gray">{t("apps.applet-viewer.dialogs.loading")}</p>
-        </div>
-      </div>
-    );
+  // Only load the current applet
+  if (applets.length > 0 && applets[currentIndex]) {
+    void fetchAppletContent(applets[currentIndex].id);
   }
+  return () => {
+    isActive = false;
+    abortController.abort();
+  };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+}, [currentIndex, applets.length]);
 
-  if (applets.length === 0) {
-    return (
-      <div className="h-full w-full flex items-center justify-center">
-        <div className="text-center px-6 font-geneva-12">
-          <p className="text-[11px] text-neutral-600 font-geneva-12">
-            {t("apps.applet-viewer.dialogs.noAppletsAvailable")}
-          </p>
-        </div>
-      </div>
-    );
+const scrollToIndex = useCallback((index: number) => {
+  if (index >= 0 && index < appletsLengthRef.current) {
+    const prevIndex = currentIndexRef.current;
+    setCurrentIndex(index);
+    // Note: currentIndexRef.current is automatically updated by useLatestRef
+    
+    // Determine navigation direction
+    if (index > prevIndex) {
+      setNavigationDirection("forward");
+    } else if (index < prevIndex) {
+      setNavigationDirection("backward");
+    } else {
+      setNavigationDirection("none");
+    }
   }
+}, [appletsLengthRef, currentIndexRef]);
 
-  const renderAppletCard = (applet: Applet, index: number) => {
-    const displayName = applet.title || applet.name || t("apps.applet-viewer.dialogs.untitledApplet");
-    const displayIcon = applet.icon || "📱";
-    const installed = actions.isAppletInstalled(applet.id);
-    const updateAvailable = actions.needsUpdate(applet);
-    const content = appletContents.get(applet.id);
-    const isLoadingContent = loadingContents.has(applet.id);
+// Handle wheel navigation for edge detection and toolbar
+useEffect(() => {
+  const container = feedRef.current;
+  if (!container) return;
 
-    return (
-      <div
-        key={applet.id}
-        data-applet-index={index}
-        data-applet-card
-        className="h-full w-full relative"
-        style={{ minHeight: "100%" }}
-      >
-        {/* Applet Preview iframe */}
-        <div 
-          className="absolute inset-0" 
-          style={{ paddingTop: "54px" }}
-          onClick={() => {
-            // Only handle click for installed applets to bring window to foreground
-            if (index === currentIndex) {
-              handlePreviewClick(applet);
-            }
-          }}
-          onWheel={(e) => {
-            // Only handle wheel for the current applet
-            if (index !== currentIndex) return;
-
-            // Let the iframe handle its own scrolling first
-            const iframe = e.currentTarget.querySelector('iframe') as HTMLIFrameElement;
-            if (!iframe) return;
-
-            // Check scroll state after a short delay to let iframe scroll first
-            setTimeout(() => {
-              try {
-                const iframeDoc = iframe.contentDocument || iframe.contentWindow?.document;
-                if (!iframeDoc) return;
-
-                const scrollTop = iframeDoc.documentElement.scrollTop || iframeDoc.body.scrollTop || 0;
-                const scrollHeight = iframeDoc.documentElement.scrollHeight || iframeDoc.body.scrollHeight || 0;
-                const clientHeight = iframeDoc.documentElement.clientHeight || iframeDoc.body.clientHeight || 0;
-                
-                const atTop = scrollTop <= 5;
-                const atBottom = scrollTop + clientHeight >= scrollHeight - 5;
-                const canScroll = scrollHeight > clientHeight;
-
-                // If at edge and trying to scroll further, navigate
-                if (e.deltaY < 0 && atTop && currentIndex > 0 && canScroll) {
-                  scrollToIndex(currentIndex - 1);
-                } else if (e.deltaY > 0 && atBottom && currentIndex < applets.length - 1 && canScroll) {
-                  scrollToIndex(currentIndex + 1);
-                } else if (!canScroll && Math.abs(e.deltaY) > 30) {
-                  // If can't scroll, navigate based on wheel direction
-                  if (e.deltaY > 0 && currentIndex < applets.length - 1) {
-                    scrollToIndex(currentIndex + 1);
-                  } else if (e.deltaY < 0 && currentIndex > 0) {
-                    scrollToIndex(currentIndex - 1);
-                  }
-                }
-              } catch {
-                // Cross-origin or other error - allow navigation if no scroll
-                if (Math.abs(e.deltaY) > 30) {
-                  if (e.deltaY > 0 && currentIndex < applets.length - 1) {
-                    scrollToIndex(currentIndex + 1);
-                  } else if (e.deltaY < 0 && currentIndex > 0) {
-                    scrollToIndex(currentIndex - 1);
-                  }
-                }
-              }
-            }, 100);
-          }}
-        >
-          {content ? (
-            (() => {
-              const trusted = isTrustedAppletAuthor(applet.createdBy);
-              return (
-                <iframe
-                  srcDoc={ensureMacFonts(content, trusted)}
-                  title={displayName}
-                  className="w-full h-full border-0"
-                  sandbox={getAppletSandboxAttribute(trusted)}
-                  data-ryos-trusted-applet={trusted ? "1" : "0"}
-                  style={{
-                    display: "block",
-                  }}
-                />
-              );
-            })()
-          ) : isLoadingContent ? (
-            <div className="flex items-center justify-center h-full bg-gray-50">
-              <div className="text-center">
-                <p className="text-sm text-neutral-600 font-geneva-12 shimmer-gray">{t("apps.applet-viewer.dialogs.loading")}</p>
-              </div>
-            </div>
-          ) : (
-            <div className="h-full w-full bg-gray-50" />
-          )}
-        </div>
-
-        {/* Header toolbar with applet info and button */}
-        <div
-          className={`absolute top-0 left-0 right-0 z-10 flex items-center gap-3 px-3 py-2 ${
-            isXpTheme
-              ? "border-b border-[#919b9c]"
-              : isMacTheme
-              ? ""
-              : isSystem7Theme
-              ? "bg-gray-100 border-b border-black"
-              : "bg-gray-100 border-b border-gray-200"
-          }`}
-          style={{
-            flexWrap: "nowrap",
-            background: isXpTheme ? "transparent" : undefined,
-            backgroundImage: isMacTheme ? "var(--os-pinstripe-window)" : undefined,
-            borderBottom:
-              isMacTheme
-                ? `var(--os-metrics-titlebar-border-width, 1px) solid var(--os-color-titlebar-border-inactive, rgba(0, 0, 0, 0.2))`
-                : undefined,
-          }}
-        >
-          <div 
-            className="!text-2xl flex-shrink-0 applet-icon flex items-center justify-center"
-            style={{ fontSize: '1.5rem' }}
-          >
-            {displayIcon}
-          </div>
-          <div className="flex-1 min-w-0">
-            <div className="font-medium text-sm font-geneva-12 truncate">
-              {displayName}
-            </div>
-            {applet.createdBy && (
-              <div className="text-[10px] text-gray-500 font-geneva-12 truncate">
-                {applet.createdBy}
-              </div>
-            )}
-          </div>
-          <Button
-            size="sm"
-            variant={
-              updateAvailable
-                ? "default"
-                : isMacTheme
-                ? "secondary"
-                : isSystem7Theme
-                ? "retro"
-                : "default"
-            }
-            onClick={(e) => {
-              e.stopPropagation();
-              if (installed) {
-                if (updateAvailable) {
-                  handleInstall(applet);
-                } else {
-                  handleAppletClick(applet);
-                }
-              } else {
-                handleInstall(applet);
-              }
-            }}
-            className="flex-shrink-0 whitespace-nowrap"
-          >
-            {installed ? (updateAvailable ? t("apps.applet-viewer.status.update") : t("apps.applet-viewer.status.open")) : t("apps.applet-viewer.status.get")}
-          </Button>
-        </div>
-      </div>
-    );
+  const handleWheel = (e: WheelEvent) => {
+    const containerRect = container.getBoundingClientRect();
+    const isInToolbar = e.clientY - containerRect.top < 60;
+    
+    // If in toolbar, navigate
+    if (isInToolbar && Math.abs(e.deltaY) > 30) {
+      e.preventDefault();
+      if (e.deltaY > 0 && currentIndex < applets.length - 1) {
+        scrollToIndex(currentIndex + 1);
+      } else if (e.deltaY < 0 && currentIndex > 0) {
+        scrollToIndex(currentIndex - 1);
+      }
+    }
   };
 
-  // Calculate visible applets (similar to TimeMachineView)
-  const startIndex = Math.max(0, currentIndex);
-  const endIndexExclusive = Math.min(
-    applets.length,
-    currentIndex + MAX_VISIBLE_PREVIEWS + 1
+  container.addEventListener("wheel", handleWheel, { passive: false });
+  return () => {
+    container.removeEventListener("wheel", handleWheel);
+  };
+}, [currentIndex, applets.length, scrollToIndex]);
+
+// Handle keyboard navigation
+useEffect(() => {
+  const handleKeyDown = (e: KeyboardEvent) => {
+    if (e.key === "ArrowDown" || e.key === "PageDown") {
+      e.preventDefault();
+      if (currentIndex < applets.length - 1) {
+        scrollToIndex(currentIndex + 1);
+      }
+    } else if (e.key === "ArrowUp" || e.key === "PageUp") {
+      e.preventDefault();
+      if (currentIndex > 0) {
+        scrollToIndex(currentIndex - 1);
+      }
+    }
+  };
+
+  window.addEventListener("keydown", handleKeyDown);
+  return () => window.removeEventListener("keydown", handleKeyDown);
+}, [currentIndex, applets.length, scrollToIndex]);
+
+// Note: Removed useEffect hooks that synced refs with state
+// useLatestRef handles this automatically during render
+
+useImperativeHandle(ref, () => ({
+  goToNext: () => {
+    if (currentIndexRef.current < appletsLengthRef.current - 1) {
+      scrollToIndex(currentIndexRef.current + 1);
+    }
+  },
+  goToPrevious: () => {
+    if (currentIndexRef.current > 0) {
+      scrollToIndex(currentIndexRef.current - 1);
+    }
+  },
+}), [appletsLengthRef, currentIndexRef, scrollToIndex]);
+
+const handleInstall = async (applet: Applet) => {
+  focusWindow?.();
+  await actions.handleInstall(applet, () => {
+    // Reset fetch flag to allow refresh after install
+    hasFetchedRef.current = false;
+    fetchApplets();
+  });
+};
+
+const handleAppletClick = async (applet: Applet) => {
+  focusWindow?.();
+  const result = await actions.handleAppletClick(applet);
+  if (result && onAppletSelect) {
+    onAppletSelect(result);
+  }
+};
+
+const handlePreviewClick = async (applet: Applet) => {
+  focusWindow?.();
+  const installed = actions.isAppletInstalled(applet.id);
+  if (installed) {
+    // If installed, bring window to foreground
+    await handleAppletClick(applet);
+  }
+};
+
+if (isLoading) {
+  return (
+    <div className="h-full w-full flex items-center justify-center">
+      <div className="text-center">
+        <p className="text-sm text-neutral-600 font-geneva-12 shimmer-gray">{t("apps.applet-viewer.dialogs.loading")}</p>
+      </div>
+    </div>
   );
-  const visibleApplets = applets.slice(startIndex, endIndexExclusive);
+}
 
-  // Exit animation variants
-  const exitVariants = {
-    exit: (direction: "forward" | "backward" | "none") => {
-      if (direction === "backward") {
-        return {
-          opacity: 0,
-          z: PREVIEW_Z_SPACING,
-          scale: 1 - PREVIEW_SCALE_FACTOR,
-          y: PREVIEW_Y_SPACING,
-          transition: { type: "spring" as const, stiffness: 150, damping: 25 },
-        };
-      } else {
-        return {
-          opacity: 0,
-          z: 50,
-          scale: 1.05,
-          y: -PREVIEW_Y_SPACING,
-          transition: { type: "spring" as const, stiffness: 150, damping: 25 },
-        };
-      }
-    },
-  };
+if (applets.length === 0) {
+  return (
+    <div className="h-full w-full flex items-center justify-center">
+      <div className="text-center px-6 font-geneva-12">
+        <p className="text-[11px] text-neutral-600 font-geneva-12">
+          {t("apps.applet-viewer.dialogs.noAppletsAvailable")}
+        </p>
+      </div>
+    </div>
+  );
+}
+
+const renderAppletCard = (applet: Applet, index: number) => {
+  const displayName = applet.title || applet.name || t("apps.applet-viewer.dialogs.untitledApplet");
+  const displayIcon = applet.icon || "📱";
+  const installed = actions.isAppletInstalled(applet.id);
+  const updateAvailable = actions.needsUpdate(applet);
+  const content = appletContents.get(applet.id);
+  const isLoadingContent = loadingContents.has(applet.id);
 
   return (
-    <>
-      <style>{appletIconStyles}</style>
-      <div
-        ref={feedRef}
-        className="h-full w-full overflow-hidden bg-black/20 flex items-center justify-center"
-        style={{
-          position: "relative",
-          perspective: "calc(100vh * 1.25)",
-          transformStyle: "preserve-3d",
+    <div
+      key={applet.id}
+      data-applet-index={index}
+      data-applet-card
+      className="h-full w-full relative"
+      style={{ minHeight: "100%" }}
+    >
+      {/* Applet Preview iframe */}
+      <div 
+        className="absolute inset-0" 
+        style={{ paddingTop: "54px" }}
+        onClick={() => {
+          // Only handle click for installed applets to bring window to foreground
+          if (index === currentIndex) {
+            handlePreviewClick(applet);
+          }
         }}
-        >
-          <div 
-            className="relative w-full flex items-center justify-center"
-            style={{ 
-              transformStyle: "preserve-3d",
-              height: "100%",
-              maxHeight: "1200px",
-            }}
-          >
-            <AnimatePresence initial={false} custom={navigationDirection}>
-              {visibleApplets.map((applet, indexInSlice) => {
-                const originalIndex = startIndex + indexInSlice;
-                const distance = originalIndex - currentIndex;
-                const opacity = 1 / (distance + 1);
-                const zIndex = applets.length - originalIndex;
+        onWheel={(e) => {
+          // Only handle wheel for the current applet
+          if (index !== currentIndex) return;
 
-                return (
-                  <motion.div
-                    key={applet.id}
-                    className="absolute w-[90%] h-[75%] max-w-4xl rounded-2xl shadow-2xl overflow-hidden bg-white"
-                    style={{
-                      boxShadow: "0 0 0 1px rgba(0,0,0,0.05)",
-                      transformStyle: "preserve-3d",
-                      clipPath: "inset(0 round 1rem)",
-                      zIndex: zIndex,
-                      transformOrigin: "center center",
-                      rotateX: distance !== 0 ? -5 : 0,
-                      pointerEvents: distance === 0 ? "auto" : "none",
-                      maxHeight: "720px",
-                      top: "12.5%",
-                    }}
-                  initial={(() => {
-                    const base = {
-                      z: distance * PREVIEW_Z_SPACING,
-                      scale: 1 - distance * PREVIEW_SCALE_FACTOR,
-                      y: distance * PREVIEW_Y_SPACING,
+          // Let the iframe handle its own scrolling first
+          const iframe = e.currentTarget.querySelector('iframe') as HTMLIFrameElement;
+          if (!iframe) return;
+
+          // Check scroll state after a short delay to let iframe scroll first
+          setTimeout(() => {
+            try {
+              const iframeDoc = iframe.contentDocument || iframe.contentWindow?.document;
+              if (!iframeDoc) return;
+
+              const scrollTop = iframeDoc.documentElement.scrollTop || iframeDoc.body.scrollTop || 0;
+              const scrollHeight = iframeDoc.documentElement.scrollHeight || iframeDoc.body.scrollHeight || 0;
+              const clientHeight = iframeDoc.documentElement.clientHeight || iframeDoc.body.clientHeight || 0;
+              
+              const atTop = scrollTop <= 5;
+              const atBottom = scrollTop + clientHeight >= scrollHeight - 5;
+              const canScroll = scrollHeight > clientHeight;
+
+              // If at edge and trying to scroll further, navigate
+              if (e.deltaY < 0 && atTop && currentIndex > 0 && canScroll) {
+                scrollToIndex(currentIndex - 1);
+              } else if (e.deltaY > 0 && atBottom && currentIndex < applets.length - 1 && canScroll) {
+                scrollToIndex(currentIndex + 1);
+              } else if (!canScroll && Math.abs(e.deltaY) > 30) {
+                // If can't scroll, navigate based on wheel direction
+                if (e.deltaY > 0 && currentIndex < applets.length - 1) {
+                  scrollToIndex(currentIndex + 1);
+                } else if (e.deltaY < 0 && currentIndex > 0) {
+                  scrollToIndex(currentIndex - 1);
+                }
+              }
+            } catch {
+              // Cross-origin or other error - allow navigation if no scroll
+              if (Math.abs(e.deltaY) > 30) {
+                if (e.deltaY > 0 && currentIndex < applets.length - 1) {
+                  scrollToIndex(currentIndex + 1);
+                } else if (e.deltaY < 0 && currentIndex > 0) {
+                  scrollToIndex(currentIndex - 1);
+                }
+              }
+            }
+          }, 100);
+        }}
+      >
+        {content ? (
+          (() => {
+            const trusted = isTrustedAppletAuthor(applet.createdBy);
+            return (
+              <iframe
+                srcDoc={ensureMacFonts(content, trusted)}
+                title={displayName}
+                className="w-full h-full border-0"
+                sandbox={getAppletSandboxAttribute(trusted)}
+                data-ryos-trusted-applet={trusted ? "1" : "0"}
+                style={{
+                  display: "block",
+                }}
+              />
+            );
+          })()
+        ) : isLoadingContent ? (
+          <div className="flex items-center justify-center h-full bg-gray-50">
+            <div className="text-center">
+              <p className="text-sm text-neutral-600 font-geneva-12 shimmer-gray">{t("apps.applet-viewer.dialogs.loading")}</p>
+            </div>
+          </div>
+        ) : (
+          <div className="h-full w-full bg-gray-50" />
+        )}
+      </div>
+
+      {/* Header toolbar with applet info and button */}
+      <div
+        className={`absolute top-0 left-0 right-0 z-10 flex items-center gap-3 px-3 py-2 ${
+          isXpTheme
+            ? "border-b border-[#919b9c]"
+            : isMacTheme
+            ? ""
+            : isSystem7Theme
+            ? "bg-gray-100 border-b border-black"
+            : "bg-gray-100 border-b border-gray-200"
+        }`}
+        style={{
+          flexWrap: "nowrap",
+          background: isXpTheme ? "transparent" : undefined,
+          backgroundImage: isMacTheme ? "var(--os-pinstripe-window)" : undefined,
+          borderBottom:
+            isMacTheme
+              ? `var(--os-metrics-titlebar-border-width, 1px) solid var(--os-color-titlebar-border-inactive, rgba(0, 0, 0, 0.2))`
+              : undefined,
+        }}
+      >
+        <div 
+          className="!text-2xl flex-shrink-0 applet-icon flex items-center justify-center"
+          style={{ fontSize: '1.5rem' }}
+        >
+          {displayIcon}
+        </div>
+        <div className="flex-1 min-w-0">
+          <div className="font-medium text-sm font-geneva-12 truncate">
+            {displayName}
+          </div>
+          {applet.createdBy && (
+            <div className="text-[10px] text-gray-500 font-geneva-12 truncate">
+              {applet.createdBy}
+            </div>
+          )}
+        </div>
+        <Button
+          size="sm"
+          variant={
+            updateAvailable
+              ? "default"
+              : isMacTheme
+              ? "secondary"
+              : isSystem7Theme
+              ? "retro"
+              : "default"
+          }
+          onClick={(e) => {
+            e.stopPropagation();
+            if (installed) {
+              if (updateAvailable) {
+                handleInstall(applet);
+              } else {
+                handleAppletClick(applet);
+              }
+            } else {
+              handleInstall(applet);
+            }
+          }}
+          className="flex-shrink-0 whitespace-nowrap"
+        >
+          {installed ? (updateAvailable ? t("apps.applet-viewer.status.update") : t("apps.applet-viewer.status.open")) : t("apps.applet-viewer.status.get")}
+        </Button>
+      </div>
+    </div>
+  );
+};
+
+// Calculate visible applets (similar to TimeMachineView)
+const startIndex = Math.max(0, currentIndex);
+const endIndexExclusive = Math.min(
+  applets.length,
+  currentIndex + MAX_VISIBLE_PREVIEWS + 1
+);
+const visibleApplets = applets.slice(startIndex, endIndexExclusive);
+
+// Exit animation variants
+const exitVariants = {
+  exit: (direction: "forward" | "backward" | "none") => {
+    if (direction === "backward") {
+      return {
+        opacity: 0,
+        z: PREVIEW_Z_SPACING,
+        scale: 1 - PREVIEW_SCALE_FACTOR,
+        y: PREVIEW_Y_SPACING,
+        transition: { type: "spring" as const, stiffness: 150, damping: 25 },
+      };
+    } else {
+      return {
+        opacity: 0,
+        z: 50,
+        scale: 1.05,
+        y: -PREVIEW_Y_SPACING,
+        transition: { type: "spring" as const, stiffness: 150, damping: 25 },
+      };
+    }
+  },
+};
+
+return (
+  <>
+    <style>{appletIconStyles}</style>
+    <div
+      ref={feedRef}
+      className="h-full w-full overflow-hidden bg-black/20 flex items-center justify-center"
+      style={{
+        position: "relative",
+        perspective: "calc(100vh * 1.25)",
+        transformStyle: "preserve-3d",
+      }}
+      >
+        <div 
+          className="relative w-full flex items-center justify-center"
+          style={{ 
+            transformStyle: "preserve-3d",
+            height: "100%",
+            maxHeight: "1200px",
+          }}
+        >
+          <AnimatePresence initial={false} custom={navigationDirection}>
+            {visibleApplets.map((applet, indexInSlice) => {
+              const originalIndex = startIndex + indexInSlice;
+              const distance = originalIndex - currentIndex;
+              const opacity = 1 / (distance + 1);
+              const zIndex = applets.length - originalIndex;
+
+              return (
+                <motion.div
+                  key={applet.id}
+                  className="absolute w-[90%] h-[75%] max-w-4xl rounded-2xl shadow-2xl overflow-hidden bg-white"
+                  style={{
+                    boxShadow: "0 0 0 1px rgba(0,0,0,0.05)",
+                    transformStyle: "preserve-3d",
+                    clipPath: "inset(0 round 1rem)",
+                    zIndex: zIndex,
+                    transformOrigin: "center center",
+                    rotateX: distance !== 0 ? -5 : 0,
+                    pointerEvents: distance === 0 ? "auto" : "none",
+                    maxHeight: "720px",
+                    top: "12.5%",
+                  }}
+                initial={(() => {
+                  const base = {
+                    z: distance * PREVIEW_Z_SPACING,
+                    scale: 1 - distance * PREVIEW_SCALE_FACTOR,
+                    y: distance * PREVIEW_Y_SPACING,
+                    opacity: 0,
+                  } as const;
+
+                  if (distance === 0 && navigationDirection === "forward") {
+                    return {
+                      z: 50,
+                      scale: 1.05,
+                      y: -PREVIEW_Y_SPACING,
                       opacity: 0,
                     } as const;
+                  }
 
-                    if (distance === 0 && navigationDirection === "forward") {
-                      return {
-                        z: 50,
-                        scale: 1.05,
-                        y: -PREVIEW_Y_SPACING,
-                        opacity: 0,
-                      } as const;
-                    }
-
-                    return base;
-                  })()}
-                  animate={{
-                    z: distance * PREVIEW_Z_SPACING,
-                    y: distance * PREVIEW_Y_SPACING,
-                    scale: 1 - distance * PREVIEW_SCALE_FACTOR,
-                    opacity: opacity,
-                  }}
-                  variants={exitVariants}
-                  exit="exit"
-                  transition={{
-                    type: "spring",
-                    stiffness: 150,
-                    damping: 25,
-                  }}
-                  drag={distance === 0 ? true : false}
-                  dragConstraints={{ top: 0, bottom: 0, left: 0, right: 0 }}
-                  dragElastic={0.4}
-                  dragPropagation={false}
-                  dragDirectionLock={true}
-                  dragMomentum={false}
-                  onDragStart={(event) => {
-                    if (distance !== 0) return;
+                  return base;
+                })()}
+                animate={{
+                  z: distance * PREVIEW_Z_SPACING,
+                  y: distance * PREVIEW_Y_SPACING,
+                  scale: 1 - distance * PREVIEW_SCALE_FACTOR,
+                  opacity: opacity,
+                }}
+                variants={exitVariants}
+                exit="exit"
+                transition={{
+                  type: "spring",
+                  stiffness: 150,
+                  damping: 25,
+                }}
+                drag={distance === 0 ? true : false}
+                dragConstraints={{ top: 0, bottom: 0, left: 0, right: 0 }}
+                dragElastic={0.4}
+                dragPropagation={false}
+                dragDirectionLock={true}
+                dragMomentum={false}
+                onDragStart={(event) => {
+                  if (distance !== 0) return;
+                  
+                  // Store drag start position to check if it's on toolbar
+                  const target = event.target as HTMLElement;
+                  const card = target.closest('[data-applet-card]') as HTMLElement;
+                  if (!card) return;
+                  
+                  const cardRect = card.getBoundingClientRect();
+                  const dragY = 'touches' in event 
+                    ? event.touches[0]?.clientY 
+                    : (event as MouseEvent).clientY;
+                  
+                  // Mark if drag started on toolbar
+                  (card as HTMLElement & { __dragOnToolbar?: boolean }).__dragOnToolbar = dragY ? (dragY - cardRect.top < 60) : false;
+                }}
+                onDrag={(event, info) => {
+                  if (distance !== 0) return;
+                  
+                  // Determine primary drag direction
+                  const target = event.target as HTMLElement;
+                  const card = target.closest('[data-applet-card]') as HTMLElement & { _primaryDragAxis?: 'x' | 'y' };
+                  if (card) {
+                    const absX = Math.abs(info.offset.x);
+                    const absY = Math.abs(info.offset.y);
+                    card._primaryDragAxis = absX > absY ? 'x' : 'y';
+                  }
+                }}
+                onDragEnd={(event, info) => {
+                  if (distance !== 0) return;
+                  
+                  const target = event.target as HTMLElement;
+                  const card = target.closest('[data-applet-card]') as HTMLElement & { __dragOnToolbar?: boolean; _primaryDragAxis?: 'x' | 'y' } | null;
+                  const dragOnToolbar = card?.__dragOnToolbar;
+                  const primaryAxis = card?._primaryDragAxis || 'y';
+                  
+                  // Handle horizontal swipe (left/right) - both go to next
+                  if (primaryAxis === 'x') {
+                    const threshold = 30; // Lower threshold for easier swiping
+                    const velocity = info.velocity.x;
                     
-                    // Store drag start position to check if it's on toolbar
-                    const target = event.target as HTMLElement;
-                    const card = target.closest('[data-applet-card]') as HTMLElement;
-                    if (!card) return;
-                    
-                    const cardRect = card.getBoundingClientRect();
-                    const dragY = 'touches' in event 
-                      ? event.touches[0]?.clientY 
-                      : (event as MouseEvent).clientY;
-                    
-                    // Mark if drag started on toolbar
-                    (card as HTMLElement & { __dragOnToolbar?: boolean }).__dragOnToolbar = dragY ? (dragY - cardRect.top < 60) : false;
-                  }}
-                  onDrag={(event, info) => {
-                    if (distance !== 0) return;
-                    
-                    // Determine primary drag direction
-                    const target = event.target as HTMLElement;
-                    const card = target.closest('[data-applet-card]') as HTMLElement & { _primaryDragAxis?: 'x' | 'y' };
-                    if (card) {
-                      const absX = Math.abs(info.offset.x);
-                      const absY = Math.abs(info.offset.y);
-                      card._primaryDragAxis = absX > absY ? 'x' : 'y';
-                    }
-                  }}
-                  onDragEnd={(event, info) => {
-                    if (distance !== 0) return;
-                    
-                    const target = event.target as HTMLElement;
-                    const card = target.closest('[data-applet-card]') as HTMLElement & { __dragOnToolbar?: boolean; _primaryDragAxis?: 'x' | 'y' } | null;
-                    const dragOnToolbar = card?.__dragOnToolbar;
-                    const primaryAxis = card?._primaryDragAxis || 'y';
-                    
-                    // Handle horizontal swipe (left/right) - both go to next
-                    if (primaryAxis === 'x') {
-                      const threshold = 30; // Lower threshold for easier swiping
-                      const velocity = info.velocity.x;
-                      
-                      // Both left and right swipes go to next card
-                      if (currentIndex < applets.length - 1) {
-                        // Check velocity first (fast swipe) - lower threshold
-                        if (Math.abs(velocity) > 300) {
-                          scrollToIndex(currentIndex + 1);
-                          return;
-                        }
-                        
-                        // Check drag distance - lower threshold
-                        if (Math.abs(info.offset.x) > threshold) {
-                          scrollToIndex(currentIndex + 1);
-                        }
+                    // Both left and right swipes go to next card
+                    if (currentIndex < applets.length - 1) {
+                      // Check velocity first (fast swipe) - lower threshold
+                      if (Math.abs(velocity) > 300) {
+                        scrollToIndex(currentIndex + 1);
+                        return;
                       }
-                      return;
+                      
+                      // Check drag distance - lower threshold
+                      if (Math.abs(info.offset.x) > threshold) {
+                        scrollToIndex(currentIndex + 1);
+                      }
                     }
-                    
-                    // Handle vertical swipe (up/down) - only if not dragging on toolbar
-                    if (!dragOnToolbar) {
-                      const iframe = card?.querySelector('iframe') as HTMLIFrameElement;
-                      if (iframe) {
-                        try {
-                          const iframeDoc = iframe.contentDocument || iframe.contentWindow?.document;
-                          if (iframeDoc) {
-                            const scrollTop = iframeDoc.documentElement.scrollTop || iframeDoc.body.scrollTop || 0;
-                            const scrollHeight = iframeDoc.documentElement.scrollHeight || iframeDoc.body.scrollHeight || 0;
-                            const clientHeight = iframeDoc.documentElement.clientHeight || iframeDoc.body.clientHeight || 0;
+                    return;
+                  }
+                  
+                  // Handle vertical swipe (up/down) - only if not dragging on toolbar
+                  if (!dragOnToolbar) {
+                    const iframe = card?.querySelector('iframe') as HTMLIFrameElement;
+                    if (iframe) {
+                      try {
+                        const iframeDoc = iframe.contentDocument || iframe.contentWindow?.document;
+                        if (iframeDoc) {
+                          const scrollTop = iframeDoc.documentElement.scrollTop || iframeDoc.body.scrollTop || 0;
+                          const scrollHeight = iframeDoc.documentElement.scrollHeight || iframeDoc.body.scrollHeight || 0;
+                          const clientHeight = iframeDoc.documentElement.clientHeight || iframeDoc.body.clientHeight || 0;
+                          
+                          const atTop = scrollTop <= 5;
+                          const atBottom = scrollTop + clientHeight >= scrollHeight - 5;
+                          const canScroll = scrollHeight > clientHeight;
+                          
+                          // Only navigate if at edge or can't scroll
+                          if (canScroll) {
+                            const draggingUp = info.offset.y < 0;
+                            const draggingDown = info.offset.y > 0;
                             
-                            const atTop = scrollTop <= 5;
-                            const atBottom = scrollTop + clientHeight >= scrollHeight - 5;
-                            const canScroll = scrollHeight > clientHeight;
-                            
-                            // Only navigate if at edge or can't scroll
-                            if (canScroll) {
-                              const draggingUp = info.offset.y < 0;
-                              const draggingDown = info.offset.y > 0;
-                              
-                              if ((draggingUp && !atTop) || (draggingDown && !atBottom)) {
-                                // Not at edge, don't navigate
-                                return;
-                              }
+                            if ((draggingUp && !atTop) || (draggingDown && !atBottom)) {
+                              // Not at edge, don't navigate
+                              return;
                             }
                           }
-                        } catch {
-                          // Cross-origin - allow navigation
                         }
+                      } catch {
+                        // Cross-origin - allow navigation
                       }
                     }
-                    
-                    const threshold = 30; // Lower threshold for easier swiping
-                    const velocity = info.velocity.y;
-                    
-                    // Check velocity first (fast swipe) - lower threshold
-                    if (Math.abs(velocity) > 300) {
-                      if (velocity > 0 && currentIndex < applets.length - 1) {
-                        scrollToIndex(currentIndex + 1);
-                      } else if (velocity < 0 && currentIndex > 0) {
-                        scrollToIndex(currentIndex - 1);
-                      }
-                      return;
+                  }
+                  
+                  const threshold = 30; // Lower threshold for easier swiping
+                  const velocity = info.velocity.y;
+                  
+                  // Check velocity first (fast swipe) - lower threshold
+                  if (Math.abs(velocity) > 300) {
+                    if (velocity > 0 && currentIndex < applets.length - 1) {
+                      scrollToIndex(currentIndex + 1);
+                    } else if (velocity < 0 && currentIndex > 0) {
+                      scrollToIndex(currentIndex - 1);
                     }
-                    
-                    // Check drag distance - lower threshold
-                    if (Math.abs(info.offset.y) > threshold) {
-                      if (info.offset.y > 0 && currentIndex < applets.length - 1) {
-                        scrollToIndex(currentIndex + 1);
-                      } else if (info.offset.y < 0 && currentIndex > 0) {
-                        scrollToIndex(currentIndex - 1);
-                      }
+                    return;
+                  }
+                  
+                  // Check drag distance - lower threshold
+                  if (Math.abs(info.offset.y) > threshold) {
+                    if (info.offset.y > 0 && currentIndex < applets.length - 1) {
+                      scrollToIndex(currentIndex + 1);
+                    } else if (info.offset.y < 0 && currentIndex > 0) {
+                      scrollToIndex(currentIndex - 1);
                     }
-                  }}
-                  whileDrag={{
-                    scale: 0.98,
-                    transition: { duration: 0.1 },
-                  }}
-                >
-                  {renderAppletCard(applet, originalIndex)}
-                </motion.div>
-              );
-            })}
-          </AnimatePresence>
-        </div>
+                  }
+                }}
+                whileDrag={{
+                  scale: 0.98,
+                  transition: { duration: 0.1 },
+                }}
+              >
+                {renderAppletCard(applet, originalIndex)}
+              </motion.div>
+            );
+          })}
+        </AnimatePresence>
       </div>
-    </>
-  );
-  }
+    </div>
+  </>
 );
+};

--- a/src/apps/applet-viewer/components/AppStoreFeed.tsx
+++ b/src/apps/applet-viewer/components/AppStoreFeed.tsx
@@ -33,7 +33,7 @@ export const AppStoreFeed = (
     focusWindow,
     onAppletSelect
   }: AppStoreFeedProps & {
-    ref: React.RefObject<AppStoreFeedRef>;
+    ref?: React.Ref<AppStoreFeedRef>;
   }
 ) => {
 const { t } = useTranslation();

--- a/src/apps/ipod/components/AppleMusicPlayerBridge.tsx
+++ b/src/apps/ipod/components/AppleMusicPlayerBridge.tsx
@@ -1,11 +1,4 @@
-import {
-  forwardRef,
-  useEffect,
-  useImperativeHandle,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
+import { useEffect, useImperativeHandle, useMemo, useRef, useState } from "react";
 import type { Track } from "@/stores/useIpodStore";
 import { onMusicKitReady } from "@/hooks/useMusicKit";
 import { PLAYER_PROGRESS_INTERVAL_MS } from "../constants";
@@ -119,11 +112,9 @@ function mediaItemToNowPlayingMetadata(
   };
 }
 
-export const AppleMusicPlayerBridge = forwardRef<
-  AppleMusicPlayerBridgeHandle,
-  AppleMusicPlayerBridgeProps
->(function AppleMusicPlayerBridge(
+export const AppleMusicPlayerBridge = function AppleMusicPlayerBridge(
   {
+    ref,
     currentTrack,
     playing,
     resumeAtSeconds,
@@ -134,9 +125,10 @@ export const AppleMusicPlayerBridge = forwardRef<
     onPause,
     onEnded,
     onReady,
-    onNowPlayingItemChange,
-  },
-  ref
+    onNowPlayingItemChange
+  }: AppleMusicPlayerBridgeProps & {
+    ref: React.RefObject<AppleMusicPlayerBridgeHandle>;
+  }
 ) {
   const instanceRef = useRef<MusicKit.MusicKitInstance | null>(null);
   const [instanceReadyTick, setInstanceReadyTick] = useState(0);
@@ -608,4 +600,4 @@ export const AppleMusicPlayerBridge = forwardRef<
   );
 
   return null;
-});
+};

--- a/src/apps/ipod/components/AppleMusicPlayerBridge.tsx
+++ b/src/apps/ipod/components/AppleMusicPlayerBridge.tsx
@@ -127,7 +127,7 @@ export const AppleMusicPlayerBridge = function AppleMusicPlayerBridge(
     onReady,
     onNowPlayingItemChange
   }: AppleMusicPlayerBridgeProps & {
-    ref: React.RefObject<AppleMusicPlayerBridgeHandle>;
+    ref?: React.Ref<AppleMusicPlayerBridgeHandle>;
   }
 ) {
   const instanceRef = useRef<MusicKit.MusicKitInstance | null>(null);

--- a/src/apps/ipod/components/BrickGame.tsx
+++ b/src/apps/ipod/components/BrickGame.tsx
@@ -169,7 +169,7 @@ export const BrickGame = function BrickGame(
     playScroll: _playScroll,
     vibrate
   }: BrickGameProps & {
-    ref: React.RefObject<BrickGameRef>;
+    ref?: React.Ref<BrickGameRef>;
   }
 ) {
   const { t } = useTranslation();

--- a/src/apps/ipod/components/BrickGame.tsx
+++ b/src/apps/ipod/components/BrickGame.tsx
@@ -1,11 +1,4 @@
-import {
-  useEffect,
-  useRef,
-  useState,
-  useImperativeHandle,
-  forwardRef,
-  useCallback,
-} from "react";
+import { useEffect, useRef, useState, useImperativeHandle, useCallback } from "react";
 import { useTranslation } from "react-i18next";
 import { cn } from "@/lib/utils";
 import { useIpodStore } from "@/stores/useIpodStore";
@@ -164,8 +157,9 @@ function launchBall(state: GameState) {
   state.ballVY = -Math.sin(angle) * speed;
 }
 
-export const BrickGame = forwardRef<BrickGameRef, BrickGameProps>(function BrickGame(
+export const BrickGame = function BrickGame(
   {
+    ref,
     isVisible,
     onExit: _onExit,
     lcdFilterOn = false,
@@ -173,9 +167,10 @@ export const BrickGame = forwardRef<BrickGameRef, BrickGameProps>(function Brick
     onEnter,
     playClick,
     playScroll: _playScroll,
-    vibrate,
-  },
-  ref
+    vibrate
+  }: BrickGameProps & {
+    ref: React.RefObject<BrickGameRef>;
+  }
 ) {
   const { t } = useTranslation();
   const uiVariant = useIpodStore((s) => s.uiVariant ?? "modern");
@@ -823,4 +818,4 @@ export const BrickGame = forwardRef<BrickGameRef, BrickGameProps>(function Brick
       </div>
     </div>
   );
-});
+};

--- a/src/apps/ipod/components/CoverFlow.tsx
+++ b/src/apps/ipod/components/CoverFlow.tsx
@@ -1053,7 +1053,7 @@ export const CoverFlow = function CoverFlow(
     groupAppleMusicAlbums = false,
     inline = false
   }: CoverFlowProps & {
-    ref: React.RefObject<CoverFlowRef>;
+    ref?: React.Ref<CoverFlowRef>;
   }
 ) {
   const { t } = useTranslation();

--- a/src/apps/ipod/components/CoverFlow.tsx
+++ b/src/apps/ipod/components/CoverFlow.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, useCallback, useImperativeHandle, forwardRef, useMemo } from "react";
+import { useEffect, useRef, useState, useCallback, useImperativeHandle, useMemo } from "react";
 import { motion, AnimatePresence, PanInfo, useMotionValue, animate } from "framer-motion";
 import {
   getYouTubeVideoId,
@@ -1037,20 +1037,25 @@ function AlbumFlipFaces({
   );
 }
 
-export const CoverFlow = forwardRef<CoverFlowRef, CoverFlowProps>(function CoverFlow({
-  tracks,
-  currentIndex,
-  onSelectTrack,
-  onExit,
-  onRotation,
-  isVisible,
-  ipodMode = true,
-  isPlaying = false,
-  onTogglePlay,
-  onPlayTrackInPlace,
-  groupAppleMusicAlbums = false,
-  inline = false,
-}, ref) {
+export const CoverFlow = function CoverFlow(
+  {
+    ref,
+    tracks,
+    currentIndex,
+    onSelectTrack,
+    onExit,
+    onRotation,
+    isVisible,
+    ipodMode = true,
+    isPlaying = false,
+    onTogglePlay,
+    onPlayTrackInPlace,
+    groupAppleMusicAlbums = false,
+    inline = false
+  }: CoverFlowProps & {
+    ref: React.RefObject<CoverFlowRef>;
+  }
+) {
   const { t } = useTranslation();
   const unknownArtistLabel = t("apps.ipod.menu.unknownArtist");
   const unknownAlbumLabel = t("apps.ipod.menuItems.unknownAlbum");
@@ -2113,4 +2118,4 @@ export const CoverFlow = forwardRef<CoverFlowRef, CoverFlowProps>(function Cover
       )}
     </AnimatePresence>
   );
-});
+};

--- a/src/apps/ipod/components/MusicQuiz.tsx
+++ b/src/apps/ipod/components/MusicQuiz.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, useMemo, useCallback, useImperativeHandle, forwardRef } from "react";
+import { useEffect, useRef, useState, useMemo, useCallback, useImperativeHandle } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import ReactPlayer from "react-player";
 import { useTranslation } from "react-i18next";
@@ -92,8 +92,9 @@ function pickRound(tracks: Track[]): { options: Track[]; correctIndex: number; c
   return { options, correctIndex, correct: options[correctIndex] };
 }
 
-export const MusicQuiz = forwardRef<MusicQuizRef, MusicQuizProps>(function MusicQuiz(
+export const MusicQuiz = function MusicQuiz(
   {
+    ref,
     isVisible,
     onExit: _onExit,
     lcdFilterOn = false,
@@ -101,9 +102,10 @@ export const MusicQuiz = forwardRef<MusicQuizRef, MusicQuizProps>(function Music
     onEnter,
     playClick,
     playScroll,
-    vibrate,
-  },
-  ref
+    vibrate
+  }: MusicQuizProps & {
+    ref: React.RefObject<MusicQuizRef>;
+  }
 ) {
   const { t } = useTranslation();
   const tracks = useIpodStore((s) =>
@@ -862,7 +864,7 @@ export const MusicQuiz = forwardRef<MusicQuizRef, MusicQuizProps>(function Music
       )}
     </div>
   );
-});
+};
 
 function formatOption(track: Track): string {
   const artist = track.artist ? ` — ${track.artist}` : "";

--- a/src/apps/ipod/components/MusicQuiz.tsx
+++ b/src/apps/ipod/components/MusicQuiz.tsx
@@ -104,7 +104,7 @@ export const MusicQuiz = function MusicQuiz(
     playScroll,
     vibrate
   }: MusicQuizProps & {
-    ref: React.RefObject<MusicQuizRef>;
+    ref?: React.Ref<MusicQuizRef>;
   }
 ) {
   const { t } = useTranslation();

--- a/src/apps/karaoke/components/KaraokeLyricsPlayback.tsx
+++ b/src/apps/karaoke/components/KaraokeLyricsPlayback.tsx
@@ -2,7 +2,7 @@ import {
   createContext,
   memo,
   useCallback,
-  useContext,
+  use,
   useEffect,
   useMemo,
   type CSSProperties,
@@ -51,7 +51,7 @@ const KaraokeLyricsPlaybackContext = createContext<KaraokeLyricsPlaybackContextV
 );
 
 export function useKaraokeLyricsPlayback(): KaraokeLyricsPlaybackContextValue {
-  const ctx = useContext(KaraokeLyricsPlaybackContext);
+  const ctx = use(KaraokeLyricsPlaybackContext);
   if (!ctx) {
     throw new Error("useKaraokeLyricsPlayback must be used within KaraokeLyricsPlaybackProvider");
   }

--- a/src/apps/paint/components/PaintCanvas.tsx
+++ b/src/apps/paint/components/PaintCanvas.tsx
@@ -1,11 +1,4 @@
-import React, {
-  useEffect,
-  useRef,
-  forwardRef,
-  useImperativeHandle,
-  useState,
-  useCallback,
-} from "react";
+import React, { useEffect, useRef, useImperativeHandle, useState, useCallback } from "react";
 import { motion } from "framer-motion";
 import { Filter } from "./PaintFiltersMenu";
 
@@ -67,1226 +60,1167 @@ const compareImageData = (img1: ImageData, img2: ImageData): boolean => {
   return true;
 };
 
-export const PaintCanvas = forwardRef<PaintCanvasRef, PaintCanvasProps>(
-  (
-    {
-      selectedTool,
-      selectedPattern,
-      strokeWidth,
-      onCanUndoChange,
-      onCanRedoChange,
-      onContentChange,
-      canvasWidth = 589,
-      canvasHeight = 418,
-      isForeground = false,
-    },
-    ref
-  ) => {
-    const canvasRef = useRef<HTMLCanvasElement>(null);
-    const contextRef = useRef<CanvasRenderingContext2D | null>(null);
-    const isDrawing = useRef(false);
-    const historyRef = useRef<ImageData[]>([]);
-    const historyIndexRef = useRef(-1);
-    const patternRef = useRef<HTMLCanvasElement | HTMLImageElement | null>(
-      null
-    );
-    const startPointRef = useRef<Point | null>(null);
-    const lastImageRef = useRef<ImageData | null>(null);
-    const [isTyping, setIsTyping] = useState(false);
-    const [textPosition, setTextPosition] = useState<Point | null>(null);
-    const textInputRef = useRef<HTMLInputElement | null>(null);
-    const [selection, setSelection] = useState<Selection | null>(null);
-    const [isDraggingSelection, setIsDraggingSelection] = useState(false);
-    const dragStartRef = useRef<Point | null>(null);
-    const dashOffsetRef = useRef(0);
-    const animationFrameRef = useRef<number | null>(null);
-    const touchStartRef = useRef<Point | null>(null);
-    const [isLoadingFile] = useState(false);
-    const containerRef = useRef<HTMLDivElement>(null);
-    const lassoPathRef = useRef<Point[]>([]);
+export const PaintCanvas = (
+  {
+    ref,
+    selectedTool,
+    selectedPattern,
+    strokeWidth,
+    onCanUndoChange,
+    onCanRedoChange,
+    onContentChange,
+    canvasWidth = 589,
+    canvasHeight = 418,
+    isForeground = false
+  }: PaintCanvasProps & {
+    ref: React.RefObject<PaintCanvasRef>;
+  }
+) => {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const contextRef = useRef<CanvasRenderingContext2D | null>(null);
+  const isDrawing = useRef(false);
+  const historyRef = useRef<ImageData[]>([]);
+  const historyIndexRef = useRef(-1);
+  const patternRef = useRef<HTMLCanvasElement | HTMLImageElement | null>(
+    null
+  );
+  const startPointRef = useRef<Point | null>(null);
+  const lastImageRef = useRef<ImageData | null>(null);
+  const [isTyping, setIsTyping] = useState(false);
+  const [textPosition, setTextPosition] = useState<Point | null>(null);
+  const textInputRef = useRef<HTMLInputElement | null>(null);
+  const [selection, setSelection] = useState<Selection | null>(null);
+  const [isDraggingSelection, setIsDraggingSelection] = useState(false);
+  const dragStartRef = useRef<Point | null>(null);
+  const dashOffsetRef = useRef(0);
+  const animationFrameRef = useRef<number | null>(null);
+  const touchStartRef = useRef<Point | null>(null);
+  const [isLoadingFile] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const lassoPathRef = useRef<Point[]>([]);
 
-    // Handle canvas resize — preserve content at original position (no scaling)
-    useEffect(() => {
-      const canvas = canvasRef.current;
-      if (!canvas) return;
+  // Handle canvas resize — preserve content at original position (no scaling)
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
 
-      const resizeObserver = new ResizeObserver((entries) => {
-        for (const entry of entries) {
-          const { width, height } = entry.contentRect;
-          const newW = Math.round(width);
-          const newH = Math.round(height);
+    const resizeObserver = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        const { width, height } = entry.contentRect;
+        const newW = Math.round(width);
+        const newH = Math.round(height);
 
-          if (canvas.width === newW && canvas.height === newH) return;
+        if (canvas.width === newW && canvas.height === newH) return;
 
-          // Snapshot current content at 1:1 (no scaling)
-          const tempCanvas = document.createElement("canvas");
-          const tempContext = tempCanvas.getContext("2d", {
-            willReadFrequently: true,
-          });
-          if (tempContext && contextRef.current) {
-            tempCanvas.width = canvas.width;
-            tempCanvas.height = canvas.height;
-            tempContext.drawImage(canvas, 0, 0);
-          }
+        // Snapshot current content at 1:1 (no scaling)
+        const tempCanvas = document.createElement("canvas");
+        const tempContext = tempCanvas.getContext("2d", {
+          willReadFrequently: true,
+        });
+        if (tempContext && contextRef.current) {
+          tempCanvas.width = canvas.width;
+          tempCanvas.height = canvas.height;
+          tempContext.drawImage(canvas, 0, 0);
+        }
 
-          // Update canvas pixel dimensions
-          canvas.width = newW;
-          canvas.height = newH;
+        // Update canvas pixel dimensions
+        canvas.width = newW;
+        canvas.height = newH;
 
-          // Restore context properties (setting canvas.width resets the context)
-          const context = canvas.getContext("2d", { willReadFrequently: true });
-          if (context) {
-            context.lineCap = "round";
-            context.lineJoin = "round";
-            context.lineWidth = strokeWidth;
-            contextRef.current = context;
+        // Restore context properties (setting canvas.width resets the context)
+        const context = canvas.getContext("2d", { willReadFrequently: true });
+        if (context) {
+          context.lineCap = "round";
+          context.lineJoin = "round";
+          context.lineWidth = strokeWidth;
+          contextRef.current = context;
 
-            if (patternRef.current) {
-              const pattern = context.createPattern(
-                patternRef.current,
-                "repeat"
-              );
-              if (pattern) {
-                context.strokeStyle = pattern;
-                context.fillStyle = pattern;
-              }
-            }
-
-            // Fill new area with white, then paste old content at 1:1
-            context.fillStyle = "#FFFFFF";
-            context.fillRect(0, 0, newW, newH);
-            if (tempContext) {
-              context.drawImage(tempCanvas, 0, 0);
+          if (patternRef.current) {
+            const pattern = context.createPattern(
+              patternRef.current,
+              "repeat"
+            );
+            if (pattern) {
+              context.strokeStyle = pattern;
+              context.fillStyle = pattern;
             }
           }
-        }
-      });
 
-      resizeObserver.observe(canvas);
-      return () => resizeObserver.disconnect();
-    }, [strokeWidth]);
-
-    // Handle ESC key for selection
-    const handleKeyDown = useCallback(
-      (event: KeyboardEvent) => {
-        if (event.key === "Escape" && selection) {
-          if (lastImageRef.current && contextRef.current) {
-            contextRef.current.putImageData(lastImageRef.current, 0, 0);
+          // Fill new area with white, then paste old content at 1:1
+          context.fillStyle = "#FFFFFF";
+          context.fillRect(0, 0, newW, newH);
+          if (tempContext) {
+            context.drawImage(tempCanvas, 0, 0);
           }
-          setSelection(null);
         }
-      },
-      [selection]
-    );
+      }
+    });
 
-    useEffect(() => {
-      if (!isForeground) return;
-      window.addEventListener("keydown", handleKeyDown);
-      return () => window.removeEventListener("keydown", handleKeyDown);
-    }, [isForeground, handleKeyDown]);
+    resizeObserver.observe(canvas);
+    return () => resizeObserver.disconnect();
+  }, [strokeWidth]);
 
-    // Animate selection dashes
-    useEffect(() => {
-      if (!selection) {
-        if (animationFrameRef.current !== null) {
-          cancelAnimationFrame(animationFrameRef.current);
-          animationFrameRef.current = null;
-        }
-        // Restore canvas to state before selection was made
+  // Handle ESC key for selection
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent) => {
+      if (event.key === "Escape" && selection) {
         if (lastImageRef.current && contextRef.current) {
           contextRef.current.putImageData(lastImageRef.current, 0, 0);
         }
-        return;
+        setSelection(null);
       }
+    },
+    [selection]
+  );
 
-      const animate = () => {
-        if (
-          !contextRef.current ||
-          !canvasRef.current ||
-          !selection ||
-          !lastImageRef.current
-        )
-          return;
+  useEffect(() => {
+    if (!isForeground) return;
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [isForeground, handleKeyDown]);
 
-        // Always restore the original canvas state before drawing selection
-        contextRef.current.putImageData(lastImageRef.current, 0, 0);
-
-        // Draw animated selection outline
-        contextRef.current.save();
-        contextRef.current.strokeStyle = "#000";
-        contextRef.current.lineWidth = 1;
-        contextRef.current.setLineDash([5, 5]);
-        contextRef.current.lineDashOffset = dashOffsetRef.current;
-
-        if (selection.type === "rectangle") {
-          // Draw rectangle selection
-          contextRef.current.strokeRect(
-            selection.startX,
-            selection.startY,
-            selection.width,
-            selection.height
-          );
-        } else if (selection.type === "lasso" && selection.path && selection.path.length > 0) {
-          // Draw lasso selection path
-          contextRef.current.beginPath();
-          contextRef.current.moveTo(selection.path[0].x, selection.path[0].y);
-          for (let i = 1; i < selection.path.length; i++) {
-            contextRef.current.lineTo(selection.path[i].x, selection.path[i].y);
-          }
-          contextRef.current.closePath();
-          contextRef.current.stroke();
-        }
-
-        contextRef.current.restore();
-
-        // Update dash offset
-        dashOffsetRef.current = (dashOffsetRef.current + 1) % 10;
-        animationFrameRef.current = requestAnimationFrame(animate);
-      };
-
-      animate();
-
-      return () => {
-        if (animationFrameRef.current !== null) {
-          cancelAnimationFrame(animationFrameRef.current);
-          animationFrameRef.current = null;
-        }
-      };
-    }, [selection]);
-
-    useEffect(() => {
-      const canvas = canvasRef.current;
-      if (!canvas) return;
-
-      // Only set up the canvas dimensions and context once
-      if (!contextRef.current) {
-        canvas.width = canvasWidth;
-        canvas.height = canvasHeight;
-
-        const context = canvas.getContext("2d", { willReadFrequently: true });
-        if (!context) return;
-
-        context.lineCap = "round";
-        context.lineJoin = "round";
-        context.lineWidth = strokeWidth;
-        contextRef.current = context;
-
-        // Fill canvas with white background initially
-        context.fillStyle = "#FFFFFF";
-        context.fillRect(0, 0, canvas.width, canvas.height);
-
-        // Save initial canvas state
-        const initialImageData = context.getImageData(
-          0,
-          0,
-          canvas.width,
-          canvas.height
-        );
-        historyRef.current = [initialImageData];
-        historyIndexRef.current = 0;
-        onCanUndoChange(false);
-        onCanRedoChange(false);
+  // Animate selection dashes
+  useEffect(() => {
+    if (!selection) {
+      if (animationFrameRef.current !== null) {
+        cancelAnimationFrame(animationFrameRef.current);
+        animationFrameRef.current = null;
       }
-
-      // Load and update the pattern
-      const patternNum = selectedPattern.split("-")[1];
-      const img = new Image();
-      img.crossOrigin = "anonymous"; // Add cross-origin attribute before setting src
-
-      img.onload = () => {
-        // Create a temporary canvas to draw the pattern
-        const patternCanvas = document.createElement("canvas");
-        const patternContext = patternCanvas.getContext("2d");
-        if (!patternContext || !contextRef.current) return;
-
-        // Set pattern canvas size to match the pattern size
-        patternCanvas.width = img.width;
-        patternCanvas.height = img.height;
-
-        // Draw the pattern onto the temporary canvas
-        patternContext.drawImage(img, 0, 0);
-
-        // Store the pattern canvas instead of the image
-        patternRef.current = patternCanvas;
-
-        // Create pattern from the temporary canvas
-        const pattern = contextRef.current.createPattern(
-          patternCanvas,
-          "repeat"
-        );
-        if (pattern) {
-          contextRef.current.strokeStyle = pattern;
-          contextRef.current.fillStyle = pattern;
-        }
-      };
-
-      img.onerror = (e) => {
-        console.error("Error loading pattern:", e);
-      };
-
-      img.src = `/patterns/Property 1=${patternNum}.svg`;
-    }, [
-      selectedPattern,
-      canvasHeight,
-      canvasWidth,
-      onCanRedoChange,
-      onCanUndoChange,
-      strokeWidth,
-    ]);
-
-    useEffect(() => {
-      if (contextRef.current) {
-        contextRef.current.lineWidth = strokeWidth;
-      }
-    }, [strokeWidth]);
-
-    const sprayAtPoint = useCallback(
-      (point: Point) => {
-        if (!contextRef.current) return;
-
-        const radius = strokeWidth * 2;
-        const density = radius * 2;
-
-        for (let i = 0; i < density; i++) {
-          const angle = Math.random() * Math.PI * 2;
-          const r = Math.random() * radius;
-          const x = point.x + r * Math.cos(angle);
-          const y = point.y + r * Math.sin(angle);
-          contextRef.current.fillRect(x, y, 1, 1);
-        }
-      },
-      [strokeWidth]
-    );
-
-    const saveToHistory = useCallback(() => {
-      const canvas = canvasRef.current;
-      if (!canvas || !contextRef.current) return;
-
-      // If there's an active selection, use the clean state from lastImageRef
-      // to avoid saving the selection ring overlay into history
-      let newImageData: ImageData;
-      if (selection && lastImageRef.current) {
-        newImageData = lastImageRef.current;
-      } else {
-        newImageData = contextRef.current.getImageData(
-          0,
-          0,
-          canvas.width,
-          canvas.height
-        );
-      }
-
-      // Check if there are actual changes before saving to history
-      const hasChanges =
-        historyIndexRef.current < 0 ||
-        !historyRef.current[historyIndexRef.current] ||
-        !compareImageData(
-          newImageData,
-          historyRef.current[historyIndexRef.current]
-        );
-
-      if (!hasChanges) return;
-
-      // Remove any redo states
-      historyRef.current = historyRef.current.slice(
-        0,
-        historyIndexRef.current + 1
-      );
-
-      // Add current state to history
-      historyRef.current.push(newImageData);
-      historyIndexRef.current++;
-
-      // Limit history size to prevent memory issues (keep last 50 states)
-      if (historyRef.current.length > 50) {
-        historyRef.current = historyRef.current.slice(-50);
-        historyIndexRef.current = Math.min(historyIndexRef.current, 49);
-      }
-
-      // Update undo/redo availability
-      onCanUndoChange(historyIndexRef.current > 0);
-      onCanRedoChange(historyIndexRef.current < historyRef.current.length - 1);
-
-      // Notify content change
-      if (!isLoadingFile) {
-        onContentChange?.();
-      }
-    }, [onCanUndoChange, onCanRedoChange, onContentChange, isLoadingFile, selection]);
-
-    // Helper function to extract selection region with mask support
-    const extractSelectionRegion = useCallback(() => {
-      if (!contextRef.current || !canvasRef.current || !selection) return null;
-
-      const { startX, startY, width, height, type, path } = selection;
-
-      // Normalize selection bounds to integers so we don't end up indexing
-      // image data with fractional coordinates (which returns undefined and
-      // yields a transparent copy).
-      const intStartX = Math.floor(startX);
-      const intStartY = Math.floor(startY);
-      const intEndX = Math.ceil(startX + width);
-      const intEndY = Math.ceil(startY + height);
-      const intWidth = Math.max(1, intEndX - intStartX);
-      const intHeight = Math.max(1, intEndY - intStartY);
-
-      // Create a temporary canvas for the selection
-      const tempCanvas = document.createElement("canvas");
-      tempCanvas.width = intWidth;
-      tempCanvas.height = intHeight;
-      const tempCtx = tempCanvas.getContext("2d", { willReadFrequently: true });
-      if (!tempCtx) return null;
-
-      if (type === "rectangle") {
-        // Simple rectangle extraction
-        const imageData = contextRef.current.getImageData(
-          intStartX,
-          intStartY,
-          intWidth,
-          intHeight
-        );
-        tempCtx.putImageData(imageData, 0, 0);
-      } else if (type === "lasso" && path && path.length > 0) {
-        // Lasso selection: extract pixels within the path
-        // Get the full canvas image data
-        const fullImageData = contextRef.current.getImageData(
-          0,
-          0,
-          canvasRef.current.width,
-          canvasRef.current.height
-        );
-
-        // Create a mask for the lasso path
-        const maskCanvas = document.createElement("canvas");
-        maskCanvas.width = canvasRef.current.width;
-        maskCanvas.height = canvasRef.current.height;
-        const maskCtx = maskCanvas.getContext("2d");
-        if (!maskCtx) return null;
-
-        // Draw the path as a filled shape
-        maskCtx.beginPath();
-        maskCtx.moveTo(path[0].x, path[0].y);
-        for (let i = 1; i < path.length; i++) {
-          maskCtx.lineTo(path[i].x, path[i].y);
-        }
-        maskCtx.closePath();
-        maskCtx.fillStyle = "white";
-        maskCtx.fill();
-
-        // Extract pixels that are within the mask
-        const maskData = maskCtx.getImageData(0, 0, maskCanvas.width, maskCanvas.height);
-        const outputData = tempCtx.createImageData(intWidth, intHeight);
-
-        for (let y = 0; y < intHeight; y++) {
-          for (let x = 0; x < intWidth; x++) {
-            const canvasX = intStartX + x;
-            const canvasY = intStartY + y;
-            const canvasIdx =
-              (canvasY * canvasRef.current.width + canvasX) * 4;
-            const outputIdx = (y * intWidth + x) * 4;
-
-            // Check if pixel is within mask
-            if (maskData.data[canvasIdx + 3] > 0) {
-              // Copy pixel
-              outputData.data[outputIdx] = fullImageData.data[canvasIdx];
-              outputData.data[outputIdx + 1] = fullImageData.data[canvasIdx + 1];
-              outputData.data[outputIdx + 2] = fullImageData.data[canvasIdx + 2];
-              outputData.data[outputIdx + 3] = fullImageData.data[canvasIdx + 3];
-            } else {
-              // Transparent pixel
-              outputData.data[outputIdx] = 0;
-              outputData.data[outputIdx + 1] = 0;
-              outputData.data[outputIdx + 2] = 0;
-              outputData.data[outputIdx + 3] = 0;
-            }
-          }
-        }
-
-        tempCtx.putImageData(outputData, 0, 0);
-      }
-
-      return tempCanvas;
-    }, [selection]);
-
-    // Clipboard methods
-    const copySelectionToClipboard = useCallback(async () => {
-      if (!contextRef.current || !canvasRef.current) {
-        console.error("Canvas not available for copy");
-        return;
-      }
-
-      // Restore canvas to show actual content (not selection overlay)
-      if (lastImageRef.current && selection) {
+      // Restore canvas to state before selection was made
+      if (lastImageRef.current && contextRef.current) {
         contextRef.current.putImageData(lastImageRef.current, 0, 0);
       }
+      return;
+    }
 
-      let tempCanvas: HTMLCanvasElement | null = null;
-
-      if (selection) {
-        // Extract selection region
-        tempCanvas = extractSelectionRegion();
-        if (!tempCanvas) {
-          console.error("Failed to extract selection region");
-          return;
-        }
-      } else {
-        // If no selection, copy entire canvas
-        tempCanvas = document.createElement("canvas");
-        tempCanvas.width = canvasRef.current.width;
-        tempCanvas.height = canvasRef.current.height;
-        const tempCtx = tempCanvas.getContext("2d");
-        if (!tempCtx) {
-          console.error("Failed to create temp canvas context");
-          return;
-        }
-        tempCtx.drawImage(canvasRef.current, 0, 0);
-      }
-
-      // Convert to blob and copy to clipboard
-      return new Promise<void>((resolve, reject) => {
-        if (!tempCanvas) {
-          reject(new Error("Failed to create temp canvas"));
-          return;
-        }
-        tempCanvas.toBlob((blob) => {
-          if (!blob) {
-            console.error("Failed to create blob from canvas");
-            reject(new Error("Failed to create blob"));
-            return;
-          }
-          
-          const item = new ClipboardItem({ "image/png": blob });
-          navigator.clipboard
-            .write([item])
-            .then(() => {
-              console.log("Successfully copied to clipboard");
-              resolve();
-            })
-            .catch((err) => {
-              console.error("Failed to write to clipboard:", err);
-              reject(err);
-            });
-        }, "image/png");
-      });
-    }, [selection, extractSelectionRegion]);
-
-    const handlePaste = useCallback(async () => {
-      if (!contextRef.current || !canvasRef.current) {
-        console.error("Canvas not available for paste");
+    const animate = () => {
+      if (
+        !contextRef.current ||
+        !canvasRef.current ||
+        !selection ||
+        !lastImageRef.current
+      )
         return;
-      }
 
-      try {
-        // Restore canvas to actual state (remove selection overlay if present)
-        if (lastImageRef.current && selection) {
-          contextRef.current.putImageData(lastImageRef.current, 0, 0);
-        }
+      // Always restore the original canvas state before drawing selection
+      contextRef.current.putImageData(lastImageRef.current, 0, 0);
 
-        const clipboardItems = await navigator.clipboard.read();
-        for (const clipboardItem of clipboardItems) {
-          for (const type of clipboardItem.types) {
-            if (type.startsWith("image/")) {
-              const blob = await clipboardItem.getType(type);
-              const blobUrl = URL.createObjectURL(blob);
-              const img = new Image();
-              img.src = blobUrl;
-              try {
-                await new Promise<void>((resolve, reject) => {
-                  img.onload = () => {
-                    if (!contextRef.current || !canvasRef.current) {
-                      reject(new Error("Canvas not available"));
-                      return;
-                    }
-
-                    // Restore the clean canvas state again right before drawing.
-                    // The selection outline animation may have drawn additional
-                    // strokes while we were waiting on the clipboard/image load,
-                    // so re-applying the clean snapshot prevents baking the
-                    // marching-ants box into the canvas when pasting.
-                    if (selection && lastImageRef.current) {
-                      contextRef.current.putImageData(lastImageRef.current, 0, 0);
-                    }
-
-                    // If there's a selection, paste into the selection area (scaled to fit)
-                    if (selection) {
-                      // Calculate scaling to fit selection while maintaining aspect ratio
-                      const scaleX = selection.width / img.width;
-                      const scaleY = selection.height / img.height;
-                      const scale = Math.min(scaleX, scaleY);
-                      const scaledWidth = img.width * scale;
-                      const scaledHeight = img.height * scale;
-                      const offsetX = (selection.width - scaledWidth) / 2;
-                      const offsetY = (selection.height - scaledHeight) / 2;
-
-                      // For lasso selections, we need to clip to the path
-                      if (selection.type === "lasso" && selection.path) {
-                        // Save current state
-                        contextRef.current.save();
-                        
-                        // Create clipping path
-                        contextRef.current.beginPath();
-                        contextRef.current.moveTo(
-                          selection.path[0].x,
-                          selection.path[0].y
-                        );
-                        for (let i = 1; i < selection.path.length; i++) {
-                          contextRef.current.lineTo(
-                            selection.path[i].x,
-                            selection.path[i].y
-                          );
-                        }
-                        contextRef.current.closePath();
-                        contextRef.current.clip();
-
-                        // Draw image scaled to fit
-                        contextRef.current.drawImage(
-                          img,
-                          selection.startX + offsetX,
-                          selection.startY + offsetY,
-                          scaledWidth,
-                          scaledHeight
-                        );
-
-                        contextRef.current.restore();
-                      } else {
-                        // Rectangle selection - simple draw
-                        contextRef.current.drawImage(
-                          img,
-                          selection.startX + offsetX,
-                          selection.startY + offsetY,
-                          scaledWidth,
-                          scaledHeight
-                        );
-                      }
-                    } else {
-                      // If no selection, paste at center
-                      const x = (canvasRef.current.width - img.width) / 2;
-                      const y = (canvasRef.current.height - img.height) / 2;
-                      contextRef.current.drawImage(img, x, y);
-                    }
-                    
-                    // Clear selection FIRST to stop the animation from drawing the selection box
-                    // This must happen before updating lastImageRef to prevent race conditions
-                    setSelection(null);
-                    
-                    // Update lastImageRef to reflect the pasted state (without selection box)
-                    if (canvasRef.current && contextRef.current) {
-                      lastImageRef.current = contextRef.current.getImageData(
-                        0,
-                        0,
-                        canvasRef.current.width,
-                        canvasRef.current.height
-                      );
-                    }
-                    
-                    saveToHistory();
-                    if (onContentChange) onContentChange();
-                    
-                    resolve();
-                  };
-                  img.onerror = () => {
-                    reject(new Error("Failed to load image from clipboard"));
-                  };
-                });
-              } finally {
-                URL.revokeObjectURL(blobUrl);
-              }
-              break;
-            }
-          }
-        }
-      } catch (err) {
-        console.error("Failed to read clipboard contents: ", err);
-        // Show user-friendly error message
-        if (err instanceof Error && err.name === "NotAllowedError") {
-          console.error("Clipboard access denied. Please grant clipboard permissions.");
-        }
-      }
-    }, [selection, saveToHistory, onContentChange]);
-
-    const clearSelection = useCallback(() => {
-      if (!contextRef.current || !canvasRef.current || !selection) return;
-
-      // Restore canvas to actual state (remove selection overlay)
-      if (lastImageRef.current) {
-        contextRef.current.putImageData(lastImageRef.current, 0, 0);
-      }
-
+      // Draw animated selection outline
       contextRef.current.save();
+      contextRef.current.strokeStyle = "#000";
+      contextRef.current.lineWidth = 1;
+      contextRef.current.setLineDash([5, 5]);
+      contextRef.current.lineDashOffset = dashOffsetRef.current;
 
-      if (selection.type === "lasso" && selection.path && selection.path.length > 0) {
-        // For lasso, fill the path shape with white
+      if (selection.type === "rectangle") {
+        // Draw rectangle selection
+        contextRef.current.strokeRect(
+          selection.startX,
+          selection.startY,
+          selection.width,
+          selection.height
+        );
+      } else if (selection.type === "lasso" && selection.path && selection.path.length > 0) {
+        // Draw lasso selection path
         contextRef.current.beginPath();
         contextRef.current.moveTo(selection.path[0].x, selection.path[0].y);
         for (let i = 1; i < selection.path.length; i++) {
           contextRef.current.lineTo(selection.path[i].x, selection.path[i].y);
         }
         contextRef.current.closePath();
-        contextRef.current.fillStyle = "#FFFFFF";
-        contextRef.current.fill();
-      } else {
-        // Rectangle selection - fill with white
-        contextRef.current.fillStyle = "#FFFFFF";
-        contextRef.current.fillRect(
-          selection.startX,
-          selection.startY,
-          selection.width,
-          selection.height
-        );
+        contextRef.current.stroke();
       }
 
       contextRef.current.restore();
-      
-      // Update lastImageRef to reflect the cleared state
-      if (canvasRef.current && contextRef.current) {
-        lastImageRef.current = contextRef.current.getImageData(
-          0,
-          0,
-          canvasRef.current.width,
-          canvasRef.current.height
-        );
-      }
-      
-      saveToHistory();
-      if (onContentChange) onContentChange();
-      
-      // Clear selection after cut
-      setSelection(null);
-    }, [selection, saveToHistory, onContentChange]);
 
-    // Expose methods via ref
-    useImperativeHandle(
-      ref,
-      () => ({
-        undo: () => {
-          if (historyIndexRef.current > 0) {
-            historyIndexRef.current--;
-            const imageData = historyRef.current[historyIndexRef.current];
-            if (contextRef.current && imageData) {
-              contextRef.current.putImageData(imageData, 0, 0);
-              onCanUndoChange(historyIndexRef.current > 0);
-              onCanRedoChange(true);
-            }
-          }
-        },
-        redo: () => {
-          if (historyIndexRef.current < historyRef.current.length - 1) {
-            historyIndexRef.current++;
-            const imageData = historyRef.current[historyIndexRef.current];
-            if (contextRef.current && imageData) {
-              contextRef.current.putImageData(imageData, 0, 0);
-              onCanUndoChange(true);
-              onCanRedoChange(
-                historyIndexRef.current < historyRef.current.length - 1
-              );
-            }
-          }
-        },
-        clear: () => {
-          if (!contextRef.current || !canvasRef.current) return;
-          contextRef.current.fillStyle = "#FFFFFF";
-          contextRef.current.fillRect(
-            0,
-            0,
-            canvasRef.current.width,
-            canvasRef.current.height
-          );
-          saveToHistory();
-        },
-        exportCanvas: () => {
-          const canvas = canvasRef.current;
-          if (!canvas) {
-            return Promise.reject(new Error("Canvas not available"));
-          }
-
-          return new Promise<Blob>((resolve, reject) => {
-            // If selection is active, use clean state from lastImageRef
-            if (selection && lastImageRef.current && contextRef.current) {
-              const tempCanvas = document.createElement("canvas");
-              tempCanvas.width = canvas.width;
-              tempCanvas.height = canvas.height;
-              const tempCtx = tempCanvas.getContext("2d");
-              if (!tempCtx) {
-                reject(new Error("Failed to create temp canvas"));
-                return;
-              }
-              tempCtx.putImageData(lastImageRef.current, 0, 0);
-              tempCanvas.toBlob((blob) => {
-                if (blob) resolve(blob);
-                else reject(new Error("Failed to create blob"));
-              }, "image/png");
-              return;
-            }
-
-            canvas.toBlob((blob) => {
-              if (blob) {
-                resolve(blob);
-              } else {
-                reject(new Error("Failed to create blob from canvas"));
-              }
-            }, "image/png");
-          });
-        },
-        importImage: (source: string | HTMLImageElement) => {
-          const drawOnCanvas = (img: HTMLImageElement) => {
-            if (!canvasRef.current) return;
-
-            const canvas = canvasRef.current;
-
-            // Set canvas pixel dimensions to match the target size
-            canvas.width = canvasWidth;
-            canvas.height = canvasHeight;
-
-            // Re-acquire context after resizing (resets all state)
-            const ctx = canvas.getContext("2d", { willReadFrequently: true });
-            if (!ctx) return;
-            ctx.lineCap = "round";
-            ctx.lineJoin = "round";
-            ctx.lineWidth = strokeWidth;
-            contextRef.current = ctx;
-
-            if (patternRef.current) {
-              const pattern = ctx.createPattern(patternRef.current, "repeat");
-              if (pattern) {
-                ctx.strokeStyle = pattern;
-                ctx.fillStyle = pattern;
-              }
-            }
-
-            ctx.fillStyle = "#FFFFFF";
-            ctx.fillRect(0, 0, canvas.width, canvas.height);
-            ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
-            saveToHistory();
-          };
-
-          if (source instanceof HTMLImageElement) {
-            drawOnCanvas(source);
-          } else {
-            const img = new Image();
-            img.src = source;
-            img.onload = () => drawOnCanvas(img);
-          }
-        },
-        cut: async () => {
-          if (selection) {
-            try {
-              await copySelectionToClipboard();
-              clearSelection();
-            } catch (err) {
-              console.error("Failed to cut selection:", err);
-            }
-          }
-        },
-        copy: async () => {
-          try {
-            await copySelectionToClipboard();
-          } catch (err) {
-            console.error("Failed to copy selection:", err);
-          }
-        },
-        paste: handlePaste,
-        applyFilter: (filter: Filter) => {
-          if (canvasRef.current) {
-            saveToHistory();
-            filter.apply(canvasRef.current);
-            onContentChange?.();
-          }
-        },
-      }),
-      [
-        onCanUndoChange,
-        onCanRedoChange,
-        saveToHistory,
-        copySelectionToClipboard,
-        clearSelection,
-        handlePaste,
-        onContentChange,
-        selection,
-        canvasWidth,
-        canvasHeight,
-        strokeWidth,
-      ]
-    );
-
-    // Add keyboard shortcuts for clipboard operations
-    useEffect(() => {
-      if (!isForeground) return; // Only register clipboard shortcuts when foreground
-      const handleClipboardShortcuts = (e: KeyboardEvent) => {
-        const isMac = navigator.platform.toUpperCase().indexOf("MAC") >= 0;
-        const cmdKey = isMac ? e.metaKey : e.ctrlKey;
-
-        if (cmdKey && !e.shiftKey && !e.altKey) {
-          if (e.key.toLowerCase() === "x") {
-            e.preventDefault();
-            copySelectionToClipboard();
-            clearSelection();
-          } else if (e.key.toLowerCase() === "c") {
-            e.preventDefault();
-            copySelectionToClipboard();
-          } else if (e.key.toLowerCase() === "v") {
-            e.preventDefault();
-            handlePaste();
-          }
-        }
-      };
-
-      window.addEventListener("keydown", handleClipboardShortcuts);
-      return () =>
-        window.removeEventListener("keydown", handleClipboardShortcuts);
-    }, [isForeground, copySelectionToClipboard, clearSelection, handlePaste]);
-
-    const getCanvasPoint = (
-      event:
-        | React.MouseEvent<HTMLCanvasElement>
-        | React.TouchEvent<HTMLCanvasElement>
-    ): Point => {
-      const canvas = canvasRef.current;
-      if (!canvas) return { x: 0, y: 0 };
-      const rect = canvas.getBoundingClientRect();
-
-      // Handle both mouse and touch events
-      let clientX: number;
-      let clientY: number;
-
-      if ("touches" in event) {
-        // For touchend/touchcancel, touches list will be empty, so use changedTouches
-        if (event.touches.length === 0 && event.changedTouches?.length > 0) {
-          clientX = event.changedTouches[0].clientX;
-          clientY = event.changedTouches[0].clientY;
-        } else if (event.touches.length > 0) {
-          clientX = event.touches[0].clientX;
-          clientY = event.touches[0].clientY;
-        } else {
-          // If no touch data available, return the last known point or a default
-          return startPointRef.current || { x: 0, y: 0 };
-        }
-      } else {
-        clientX = event.clientX;
-        clientY = event.clientY;
-      }
-
-      return {
-        x: clientX - rect.left,
-        y: clientY - rect.top,
-      };
+      // Update dash offset
+      dashOffsetRef.current = (dashOffsetRef.current + 1) % 10;
+      animationFrameRef.current = requestAnimationFrame(animate);
     };
 
-    // Point-in-polygon test for lasso selection
-    const isPointInLassoPath = useCallback((point: Point, path: Point[]): boolean => {
-      if (path.length < 3) return false;
+    animate();
 
-      let inside = false;
-      for (let i = 0, j = path.length - 1; i < path.length; j = i++) {
-        const xi = path[i].x;
-        const yi = path[i].y;
-        const xj = path[j].x;
-        const yj = path[j].y;
-
-        const intersect =
-          yi > point.y !== yj > point.y &&
-          point.x < ((xj - xi) * (point.y - yi)) / (yj - yi) + xi;
-        if (intersect) inside = !inside;
+    return () => {
+      if (animationFrameRef.current !== null) {
+        cancelAnimationFrame(animationFrameRef.current);
+        animationFrameRef.current = null;
       }
-      return inside;
-    }, []);
+    };
+  }, [selection]);
 
-    const isPointInSelection = useCallback((point: Point, sel: Selection): boolean => {
-      if (sel.type === "rectangle") {
-        return (
-          point.x >= sel.startX &&
-          point.x <= sel.startX + sel.width &&
-          point.y >= sel.startY &&
-          point.y <= sel.startY + sel.height
-        );
-      }
-      if (sel.type === "lasso" && sel.path) {
-        return isPointInLassoPath(point, sel.path);
-      }
-      return false;
-    }, [isPointInLassoPath]);
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
 
-    const floodFill = useCallback((startX: number, startY: number) => {
-      const canvas = canvasRef.current;
-      const context = contextRef.current;
-      if (!canvas || !context || !patternRef.current) return;
+    // Only set up the canvas dimensions and context once
+    if (!contextRef.current) {
+      canvas.width = canvasWidth;
+      canvas.height = canvasHeight;
 
-      // Get the image data
-      const imageData = context.getImageData(0, 0, canvas.width, canvas.height);
-      const pixels = imageData.data;
+      const context = canvas.getContext("2d", { willReadFrequently: true });
+      if (!context) return;
 
-      // Get the color at target pixel
-      const startPos = (startY * canvas.width + startX) * 4;
-      const startR = pixels[startPos];
-      const startG = pixels[startPos + 1];
-      const startB = pixels[startPos + 2];
-      const startA = pixels[startPos + 3];
+      context.lineCap = "round";
+      context.lineJoin = "round";
+      context.lineWidth = strokeWidth;
+      contextRef.current = context;
 
-      // Create a temporary canvas to draw the pattern
-      const tempCanvas = document.createElement("canvas");
-      tempCanvas.width = canvas.width;
-      tempCanvas.height = canvas.height;
-      const tempContext = tempCanvas.getContext("2d", {
-        willReadFrequently: true,
-      });
-      if (!tempContext) return;
+      // Fill canvas with white background initially
+      context.fillStyle = "#FFFFFF";
+      context.fillRect(0, 0, canvas.width, canvas.height);
 
-      // Fill the temporary canvas with the pattern
-      const pattern = tempContext.createPattern(patternRef.current, "repeat");
-      if (!pattern) return;
-      tempContext.fillStyle = pattern;
-      tempContext.fillRect(0, 0, canvas.width, canvas.height);
-      const patternData = tempContext.getImageData(
+      // Save initial canvas state
+      const initialImageData = context.getImageData(
         0,
         0,
         canvas.width,
         canvas.height
       );
+      historyRef.current = [initialImageData];
+      historyIndexRef.current = 0;
+      onCanUndoChange(false);
+      onCanRedoChange(false);
+    }
 
-      // Performance optimization: Check if we're trying to fill with the same color
-      const targetPos = (startY * canvas.width + startX) * 4;
-      if (
-        pixels[targetPos] === patternData.data[targetPos] &&
-        pixels[targetPos + 1] === patternData.data[targetPos + 1] &&
-        pixels[targetPos + 2] === patternData.data[targetPos + 2] &&
-        pixels[targetPos + 3] === patternData.data[targetPos + 3]
-      ) {
-        return; // No need to fill if the colors are the same
-      }
+    // Load and update the pattern
+    const patternNum = selectedPattern.split("-")[1];
+    const img = new Image();
+    img.crossOrigin = "anonymous"; // Add cross-origin attribute before setting src
 
-      // Performance optimization: Limit the maximum area to fill (e.g., 80% of canvas)
-      const maxPixels = Math.floor(canvas.width * canvas.height * 0.8);
-      let filledPixels = 0;
+    img.onload = () => {
+      // Create a temporary canvas to draw the pattern
+      const patternCanvas = document.createElement("canvas");
+      const patternContext = patternCanvas.getContext("2d");
+      if (!patternContext || !contextRef.current) return;
 
-      // Helper to check if a pixel matches the start color
-      const matchesStart = (pos: number) => {
-        return (
-          pixels[pos] === startR &&
-          pixels[pos + 1] === startG &&
-          pixels[pos + 2] === startB &&
-          pixels[pos + 3] === startA
-        );
-      };
+      // Set pattern canvas size to match the pattern size
+      patternCanvas.width = img.width;
+      patternCanvas.height = img.height;
 
-      // Helper to set a pixel to the pattern color
-      const setPixel = (pos: number) => {
-        pixels[pos] = patternData.data[pos];
-        pixels[pos + 1] = patternData.data[pos + 1];
-        pixels[pos + 2] = patternData.data[pos + 2];
-        pixels[pos + 3] = patternData.data[pos + 3];
-        filledPixels++;
-      };
+      // Draw the pattern onto the temporary canvas
+      patternContext.drawImage(img, 0, 0);
 
-      // Scanline stack for flood fill (more efficient than pixel stack)
-      interface ScanLine {
-        y: number;
-        leftX: number;
-        rightX: number;
-        direction: number; // 1 for up, -1 for down
-      }
-      const scanlines: ScanLine[] = [];
+      // Store the pattern canvas instead of the image
+      patternRef.current = patternCanvas;
 
-      // Add initial scanline
-      scanlines.push({
-        y: startY,
-        leftX: startX,
-        rightX: startX,
-        direction: 1,
-      });
-      scanlines.push({
-        y: startY,
-        leftX: startX,
-        rightX: startX,
-        direction: -1,
-      });
-
-      while (scanlines.length > 0 && filledPixels < maxPixels) {
-        const { y, leftX, rightX, direction } = scanlines.pop()!;
-        const newY = y + direction;
-
-        // Skip if we're out of bounds
-        if (newY < 0 || newY >= canvas.height) continue;
-
-        // Find the extents of the current scanline
-        let x1 = leftX;
-        let x2 = rightX;
-
-        // Extend left
-        while (x1 > 0 && matchesStart((y * canvas.width + (x1 - 1)) * 4)) {
-          x1--;
-        }
-
-        // Extend right
-        while (
-          x2 < canvas.width - 1 &&
-          matchesStart((y * canvas.width + (x2 + 1)) * 4)
-        ) {
-          x2++;
-        }
-
-        // Fill the current scanline
-        for (let x = x1; x <= x2; x++) {
-          setPixel((y * canvas.width + x) * 4);
-        }
-
-        // Look for new scanlines above/below
-        let inRange = false;
-        for (let x = x1; x <= x2; x++) {
-          const newPos = (newY * canvas.width + x) * 4;
-          const matchesNow = matchesStart(newPos);
-
-          if (!inRange && matchesNow) {
-            scanlines.push({
-              y: newY,
-              leftX: x,
-              rightX: x,
-              direction: direction,
-            });
-            inRange = true;
-          } else if (inRange && !matchesNow) {
-            scanlines[scanlines.length - 1].rightX = x - 1;
-            inRange = false;
-          }
-        }
-        if (inRange) {
-          scanlines[scanlines.length - 1].rightX = x2;
-        }
-      }
-
-      // Put the modified image data back
-      context.putImageData(imageData, 0, 0);
-      saveToHistory();
-    }, [saveToHistory]);
-
-    const renderText = (text: string) => {
-      if (!contextRef.current || !patternRef.current || !textPosition) return;
-
-      const context = contextRef.current;
-      context.save();
-
-      // Set up text rendering
-      context.font = `16px Geneva-12`;
-      context.textBaseline = "top";
-
-      // Create pattern from the pattern canvas
-      const pattern = context.createPattern(patternRef.current, "repeat");
+      // Create pattern from the temporary canvas
+      const pattern = contextRef.current.createPattern(
+        patternCanvas,
+        "repeat"
+      );
       if (pattern) {
-        context.fillStyle = pattern;
-        context.fillText(text, textPosition.x, textPosition.y);
-      }
-
-      context.restore();
-      saveToHistory();
-    };
-
-    const handleTextInput = (event: React.KeyboardEvent<HTMLInputElement>) => {
-      if (event.key === "Enter") {
-        const text = event.currentTarget.value;
-        if (!text) {
-          setIsTyping(false);
-          return;
-        }
-
-        renderText(text);
-        event.currentTarget.value = "";
-        setIsTyping(false);
+        contextRef.current.strokeStyle = pattern;
+        contextRef.current.fillStyle = pattern;
       }
     };
 
-    const handleTextBlur = (event: React.FocusEvent<HTMLInputElement>) => {
-      const text = event.currentTarget.value;
-      if (text) {
-        renderText(text);
-      }
-      setIsTyping(false);
+    img.onerror = (e) => {
+      console.error("Error loading pattern:", e);
     };
 
-    const startDrawing = useCallback(
-      (
-        event:
-          | React.MouseEvent<HTMLCanvasElement>
-          | React.TouchEvent<HTMLCanvasElement>
-      ) => {
-        const canvas = canvasRef.current;
-        if (!canvas || !contextRef.current) return;
+    img.src = `/patterns/Property 1=${patternNum}.svg`;
+  }, [
+    selectedPattern,
+    canvasHeight,
+    canvasWidth,
+    onCanRedoChange,
+    onCanUndoChange,
+    strokeWidth,
+  ]);
 
-        const point = getCanvasPoint(event);
+  useEffect(() => {
+    if (contextRef.current) {
+      contextRef.current.lineWidth = strokeWidth;
+    }
+  }, [strokeWidth]);
 
-        // Don't handle panning here anymore, let Framer Motion handle it
-        if (selectedTool === "hand") return;
+  const sprayAtPoint = useCallback(
+    (point: Point) => {
+      if (!contextRef.current) return;
 
-        // Store touch start position for tap detection
-        if ("touches" in event) {
-          touchStartRef.current = point;
-          // Execute bucket fill immediately on touch for better responsiveness
-          if (selectedTool === "bucket") {
-            floodFill(Math.floor(point.x), Math.floor(point.y));
-            return;
+      const radius = strokeWidth * 2;
+      const density = radius * 2;
+
+      for (let i = 0; i < density; i++) {
+        const angle = Math.random() * Math.PI * 2;
+        const r = Math.random() * radius;
+        const x = point.x + r * Math.cos(angle);
+        const y = point.y + r * Math.sin(angle);
+        contextRef.current.fillRect(x, y, 1, 1);
+      }
+    },
+    [strokeWidth]
+  );
+
+  const saveToHistory = useCallback(() => {
+    const canvas = canvasRef.current;
+    if (!canvas || !contextRef.current) return;
+
+    // If there's an active selection, use the clean state from lastImageRef
+    // to avoid saving the selection ring overlay into history
+    let newImageData: ImageData;
+    if (selection && lastImageRef.current) {
+      newImageData = lastImageRef.current;
+    } else {
+      newImageData = contextRef.current.getImageData(
+        0,
+        0,
+        canvas.width,
+        canvas.height
+      );
+    }
+
+    // Check if there are actual changes before saving to history
+    const hasChanges =
+      historyIndexRef.current < 0 ||
+      !historyRef.current[historyIndexRef.current] ||
+      !compareImageData(
+        newImageData,
+        historyRef.current[historyIndexRef.current]
+      );
+
+    if (!hasChanges) return;
+
+    // Remove any redo states
+    historyRef.current = historyRef.current.slice(
+      0,
+      historyIndexRef.current + 1
+    );
+
+    // Add current state to history
+    historyRef.current.push(newImageData);
+    historyIndexRef.current++;
+
+    // Limit history size to prevent memory issues (keep last 50 states)
+    if (historyRef.current.length > 50) {
+      historyRef.current = historyRef.current.slice(-50);
+      historyIndexRef.current = Math.min(historyIndexRef.current, 49);
+    }
+
+    // Update undo/redo availability
+    onCanUndoChange(historyIndexRef.current > 0);
+    onCanRedoChange(historyIndexRef.current < historyRef.current.length - 1);
+
+    // Notify content change
+    if (!isLoadingFile) {
+      onContentChange?.();
+    }
+  }, [onCanUndoChange, onCanRedoChange, onContentChange, isLoadingFile, selection]);
+
+  // Helper function to extract selection region with mask support
+  const extractSelectionRegion = useCallback(() => {
+    if (!contextRef.current || !canvasRef.current || !selection) return null;
+
+    const { startX, startY, width, height, type, path } = selection;
+
+    // Normalize selection bounds to integers so we don't end up indexing
+    // image data with fractional coordinates (which returns undefined and
+    // yields a transparent copy).
+    const intStartX = Math.floor(startX);
+    const intStartY = Math.floor(startY);
+    const intEndX = Math.ceil(startX + width);
+    const intEndY = Math.ceil(startY + height);
+    const intWidth = Math.max(1, intEndX - intStartX);
+    const intHeight = Math.max(1, intEndY - intStartY);
+
+    // Create a temporary canvas for the selection
+    const tempCanvas = document.createElement("canvas");
+    tempCanvas.width = intWidth;
+    tempCanvas.height = intHeight;
+    const tempCtx = tempCanvas.getContext("2d", { willReadFrequently: true });
+    if (!tempCtx) return null;
+
+    if (type === "rectangle") {
+      // Simple rectangle extraction
+      const imageData = contextRef.current.getImageData(
+        intStartX,
+        intStartY,
+        intWidth,
+        intHeight
+      );
+      tempCtx.putImageData(imageData, 0, 0);
+    } else if (type === "lasso" && path && path.length > 0) {
+      // Lasso selection: extract pixels within the path
+      // Get the full canvas image data
+      const fullImageData = contextRef.current.getImageData(
+        0,
+        0,
+        canvasRef.current.width,
+        canvasRef.current.height
+      );
+
+      // Create a mask for the lasso path
+      const maskCanvas = document.createElement("canvas");
+      maskCanvas.width = canvasRef.current.width;
+      maskCanvas.height = canvasRef.current.height;
+      const maskCtx = maskCanvas.getContext("2d");
+      if (!maskCtx) return null;
+
+      // Draw the path as a filled shape
+      maskCtx.beginPath();
+      maskCtx.moveTo(path[0].x, path[0].y);
+      for (let i = 1; i < path.length; i++) {
+        maskCtx.lineTo(path[i].x, path[i].y);
+      }
+      maskCtx.closePath();
+      maskCtx.fillStyle = "white";
+      maskCtx.fill();
+
+      // Extract pixels that are within the mask
+      const maskData = maskCtx.getImageData(0, 0, maskCanvas.width, maskCanvas.height);
+      const outputData = tempCtx.createImageData(intWidth, intHeight);
+
+      for (let y = 0; y < intHeight; y++) {
+        for (let x = 0; x < intWidth; x++) {
+          const canvasX = intStartX + x;
+          const canvasY = intStartY + y;
+          const canvasIdx =
+            (canvasY * canvasRef.current.width + canvasX) * 4;
+          const outputIdx = (y * intWidth + x) * 4;
+
+          // Check if pixel is within mask
+          if (maskData.data[canvasIdx + 3] > 0) {
+            // Copy pixel
+            outputData.data[outputIdx] = fullImageData.data[canvasIdx];
+            outputData.data[outputIdx + 1] = fullImageData.data[canvasIdx + 1];
+            outputData.data[outputIdx + 2] = fullImageData.data[canvasIdx + 2];
+            outputData.data[outputIdx + 3] = fullImageData.data[canvasIdx + 3];
+          } else {
+            // Transparent pixel
+            outputData.data[outputIdx] = 0;
+            outputData.data[outputIdx + 1] = 0;
+            outputData.data[outputIdx + 2] = 0;
+            outputData.data[outputIdx + 3] = 0;
           }
         }
+      }
 
-        // Handle rectangle selection tool
-        if (selectedTool === "rect-select") {
-          // If clicking outside selection, clear it
-          if (selection && !isPointInSelection(point, selection)) {
-            // Restore canvas to state before selection
-            if (lastImageRef.current) {
-              contextRef.current.putImageData(lastImageRef.current, 0, 0);
+      tempCtx.putImageData(outputData, 0, 0);
+    }
+
+    return tempCanvas;
+  }, [selection]);
+
+  // Clipboard methods
+  const copySelectionToClipboard = useCallback(async () => {
+    if (!contextRef.current || !canvasRef.current) {
+      console.error("Canvas not available for copy");
+      return;
+    }
+
+    // Restore canvas to show actual content (not selection overlay)
+    if (lastImageRef.current && selection) {
+      contextRef.current.putImageData(lastImageRef.current, 0, 0);
+    }
+
+    let tempCanvas: HTMLCanvasElement | null = null;
+
+    if (selection) {
+      // Extract selection region
+      tempCanvas = extractSelectionRegion();
+      if (!tempCanvas) {
+        console.error("Failed to extract selection region");
+        return;
+      }
+    } else {
+      // If no selection, copy entire canvas
+      tempCanvas = document.createElement("canvas");
+      tempCanvas.width = canvasRef.current.width;
+      tempCanvas.height = canvasRef.current.height;
+      const tempCtx = tempCanvas.getContext("2d");
+      if (!tempCtx) {
+        console.error("Failed to create temp canvas context");
+        return;
+      }
+      tempCtx.drawImage(canvasRef.current, 0, 0);
+    }
+
+    // Convert to blob and copy to clipboard
+    return new Promise<void>((resolve, reject) => {
+      if (!tempCanvas) {
+        reject(new Error("Failed to create temp canvas"));
+        return;
+      }
+      tempCanvas.toBlob((blob) => {
+        if (!blob) {
+          console.error("Failed to create blob from canvas");
+          reject(new Error("Failed to create blob"));
+          return;
+        }
+        
+        const item = new ClipboardItem({ "image/png": blob });
+        navigator.clipboard
+          .write([item])
+          .then(() => {
+            console.log("Successfully copied to clipboard");
+            resolve();
+          })
+          .catch((err) => {
+            console.error("Failed to write to clipboard:", err);
+            reject(err);
+          });
+      }, "image/png");
+    });
+  }, [selection, extractSelectionRegion]);
+
+  const handlePaste = useCallback(async () => {
+    if (!contextRef.current || !canvasRef.current) {
+      console.error("Canvas not available for paste");
+      return;
+    }
+
+    try {
+      // Restore canvas to actual state (remove selection overlay if present)
+      if (lastImageRef.current && selection) {
+        contextRef.current.putImageData(lastImageRef.current, 0, 0);
+      }
+
+      const clipboardItems = await navigator.clipboard.read();
+      for (const clipboardItem of clipboardItems) {
+        for (const type of clipboardItem.types) {
+          if (type.startsWith("image/")) {
+            const blob = await clipboardItem.getType(type);
+            const blobUrl = URL.createObjectURL(blob);
+            const img = new Image();
+            img.src = blobUrl;
+            try {
+              await new Promise<void>((resolve, reject) => {
+                img.onload = () => {
+                  if (!contextRef.current || !canvasRef.current) {
+                    reject(new Error("Canvas not available"));
+                    return;
+                  }
+
+                  // Restore the clean canvas state again right before drawing.
+                  // The selection outline animation may have drawn additional
+                  // strokes while we were waiting on the clipboard/image load,
+                  // so re-applying the clean snapshot prevents baking the
+                  // marching-ants box into the canvas when pasting.
+                  if (selection && lastImageRef.current) {
+                    contextRef.current.putImageData(lastImageRef.current, 0, 0);
+                  }
+
+                  // If there's a selection, paste into the selection area (scaled to fit)
+                  if (selection) {
+                    // Calculate scaling to fit selection while maintaining aspect ratio
+                    const scaleX = selection.width / img.width;
+                    const scaleY = selection.height / img.height;
+                    const scale = Math.min(scaleX, scaleY);
+                    const scaledWidth = img.width * scale;
+                    const scaledHeight = img.height * scale;
+                    const offsetX = (selection.width - scaledWidth) / 2;
+                    const offsetY = (selection.height - scaledHeight) / 2;
+
+                    // For lasso selections, we need to clip to the path
+                    if (selection.type === "lasso" && selection.path) {
+                      // Save current state
+                      contextRef.current.save();
+                      
+                      // Create clipping path
+                      contextRef.current.beginPath();
+                      contextRef.current.moveTo(
+                        selection.path[0].x,
+                        selection.path[0].y
+                      );
+                      for (let i = 1; i < selection.path.length; i++) {
+                        contextRef.current.lineTo(
+                          selection.path[i].x,
+                          selection.path[i].y
+                        );
+                      }
+                      contextRef.current.closePath();
+                      contextRef.current.clip();
+
+                      // Draw image scaled to fit
+                      contextRef.current.drawImage(
+                        img,
+                        selection.startX + offsetX,
+                        selection.startY + offsetY,
+                        scaledWidth,
+                        scaledHeight
+                      );
+
+                      contextRef.current.restore();
+                    } else {
+                      // Rectangle selection - simple draw
+                      contextRef.current.drawImage(
+                        img,
+                        selection.startX + offsetX,
+                        selection.startY + offsetY,
+                        scaledWidth,
+                        scaledHeight
+                      );
+                    }
+                  } else {
+                    // If no selection, paste at center
+                    const x = (canvasRef.current.width - img.width) / 2;
+                    const y = (canvasRef.current.height - img.height) / 2;
+                    contextRef.current.drawImage(img, x, y);
+                  }
+                  
+                  // Clear selection FIRST to stop the animation from drawing the selection box
+                  // This must happen before updating lastImageRef to prevent race conditions
+                  setSelection(null);
+                  
+                  // Update lastImageRef to reflect the pasted state (without selection box)
+                  if (canvasRef.current && contextRef.current) {
+                    lastImageRef.current = contextRef.current.getImageData(
+                      0,
+                      0,
+                      canvasRef.current.width,
+                      canvasRef.current.height
+                    );
+                  }
+                  
+                  saveToHistory();
+                  if (onContentChange) onContentChange();
+                  
+                  resolve();
+                };
+                img.onerror = () => {
+                  reject(new Error("Failed to load image from clipboard"));
+                };
+              });
+            } finally {
+              URL.revokeObjectURL(blobUrl);
             }
-            setSelection(null);
+            break;
           }
+        }
+      }
+    } catch (err) {
+      console.error("Failed to read clipboard contents: ", err);
+      // Show user-friendly error message
+      if (err instanceof Error && err.name === "NotAllowedError") {
+        console.error("Clipboard access denied. Please grant clipboard permissions.");
+      }
+    }
+  }, [selection, saveToHistory, onContentChange]);
 
-          // If clicking inside existing selection, prepare for drag
-          if (selection && isPointInSelection(point, selection)) {
-            setIsDraggingSelection(true);
-            dragStartRef.current = point;
-            return;
+  const clearSelection = useCallback(() => {
+    if (!contextRef.current || !canvasRef.current || !selection) return;
+
+    // Restore canvas to actual state (remove selection overlay)
+    if (lastImageRef.current) {
+      contextRef.current.putImageData(lastImageRef.current, 0, 0);
+    }
+
+    contextRef.current.save();
+
+    if (selection.type === "lasso" && selection.path && selection.path.length > 0) {
+      // For lasso, fill the path shape with white
+      contextRef.current.beginPath();
+      contextRef.current.moveTo(selection.path[0].x, selection.path[0].y);
+      for (let i = 1; i < selection.path.length; i++) {
+        contextRef.current.lineTo(selection.path[i].x, selection.path[i].y);
+      }
+      contextRef.current.closePath();
+      contextRef.current.fillStyle = "#FFFFFF";
+      contextRef.current.fill();
+    } else {
+      // Rectangle selection - fill with white
+      contextRef.current.fillStyle = "#FFFFFF";
+      contextRef.current.fillRect(
+        selection.startX,
+        selection.startY,
+        selection.width,
+        selection.height
+      );
+    }
+
+    contextRef.current.restore();
+    
+    // Update lastImageRef to reflect the cleared state
+    if (canvasRef.current && contextRef.current) {
+      lastImageRef.current = contextRef.current.getImageData(
+        0,
+        0,
+        canvasRef.current.width,
+        canvasRef.current.height
+      );
+    }
+    
+    saveToHistory();
+    if (onContentChange) onContentChange();
+    
+    // Clear selection after cut
+    setSelection(null);
+  }, [selection, saveToHistory, onContentChange]);
+
+  // Expose methods via ref
+  useImperativeHandle(
+    ref,
+    () => ({
+      undo: () => {
+        if (historyIndexRef.current > 0) {
+          historyIndexRef.current--;
+          const imageData = historyRef.current[historyIndexRef.current];
+          if (contextRef.current && imageData) {
+            contextRef.current.putImageData(imageData, 0, 0);
+            onCanUndoChange(historyIndexRef.current > 0);
+            onCanRedoChange(true);
           }
-
-          // Start new selection
-          startPointRef.current = point;
-          // Store the current canvas state before starting new selection
-          lastImageRef.current = contextRef.current.getImageData(
-            0,
-            0,
-            canvas.width,
-            canvas.height
-          );
-          return;
+        }
+      },
+      redo: () => {
+        if (historyIndexRef.current < historyRef.current.length - 1) {
+          historyIndexRef.current++;
+          const imageData = historyRef.current[historyIndexRef.current];
+          if (contextRef.current && imageData) {
+            contextRef.current.putImageData(imageData, 0, 0);
+            onCanUndoChange(true);
+            onCanRedoChange(
+              historyIndexRef.current < historyRef.current.length - 1
+            );
+          }
+        }
+      },
+      clear: () => {
+        if (!contextRef.current || !canvasRef.current) return;
+        contextRef.current.fillStyle = "#FFFFFF";
+        contextRef.current.fillRect(
+          0,
+          0,
+          canvasRef.current.width,
+          canvasRef.current.height
+        );
+        saveToHistory();
+      },
+      exportCanvas: () => {
+        const canvas = canvasRef.current;
+        if (!canvas) {
+          return Promise.reject(new Error("Canvas not available"));
         }
 
-        // Handle lasso selection tool
-        if (selectedTool === "select") {
-          // If clicking outside selection, clear it
-          if (selection && selection.type === "lasso" && selection.path) {
-            const isInside = isPointInLassoPath(point, selection.path);
-            if (!isInside) {
-              // Restore canvas to state before selection
-              if (lastImageRef.current) {
-                contextRef.current.putImageData(lastImageRef.current, 0, 0);
-              }
-              setSelection(null);
-            } else {
-              // If clicking inside existing selection, prepare for drag
-              setIsDraggingSelection(true);
-              dragStartRef.current = point;
+        return new Promise<Blob>((resolve, reject) => {
+          // If selection is active, use clean state from lastImageRef
+          if (selection && lastImageRef.current && contextRef.current) {
+            const tempCanvas = document.createElement("canvas");
+            tempCanvas.width = canvas.width;
+            tempCanvas.height = canvas.height;
+            const tempCtx = tempCanvas.getContext("2d");
+            if (!tempCtx) {
+              reject(new Error("Failed to create temp canvas"));
               return;
             }
+            tempCtx.putImageData(lastImageRef.current, 0, 0);
+            tempCanvas.toBlob((blob) => {
+              if (blob) resolve(blob);
+              else reject(new Error("Failed to create blob"));
+            }, "image/png");
+            return;
           }
 
-          // Start new lasso selection
-          lassoPathRef.current = [point];
-          // Store the current canvas state before starting new selection
-          lastImageRef.current = contextRef.current.getImageData(
-            0,
-            0,
-            canvas.width,
-            canvas.height
-          );
-          isDrawing.current = true;
+          canvas.toBlob((blob) => {
+            if (blob) {
+              resolve(blob);
+            } else {
+              reject(new Error("Failed to create blob from canvas"));
+            }
+          }, "image/png");
+        });
+      },
+      importImage: (source: string | HTMLImageElement) => {
+        const drawOnCanvas = (img: HTMLImageElement) => {
+          if (!canvasRef.current) return;
+
+          const canvas = canvasRef.current;
+
+          // Set canvas pixel dimensions to match the target size
+          canvas.width = canvasWidth;
+          canvas.height = canvasHeight;
+
+          // Re-acquire context after resizing (resets all state)
+          const ctx = canvas.getContext("2d", { willReadFrequently: true });
+          if (!ctx) return;
+          ctx.lineCap = "round";
+          ctx.lineJoin = "round";
+          ctx.lineWidth = strokeWidth;
+          contextRef.current = ctx;
+
+          if (patternRef.current) {
+            const pattern = ctx.createPattern(patternRef.current, "repeat");
+            if (pattern) {
+              ctx.strokeStyle = pattern;
+              ctx.fillStyle = pattern;
+            }
+          }
+
+          ctx.fillStyle = "#FFFFFF";
+          ctx.fillRect(0, 0, canvas.width, canvas.height);
+          ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
+          saveToHistory();
+        };
+
+        if (source instanceof HTMLImageElement) {
+          drawOnCanvas(source);
+        } else {
+          const img = new Image();
+          img.src = source;
+          img.onload = () => drawOnCanvas(img);
+        }
+      },
+      cut: async () => {
+        if (selection) {
+          try {
+            await copySelectionToClipboard();
+            clearSelection();
+          } catch (err) {
+            console.error("Failed to cut selection:", err);
+          }
+        }
+      },
+      copy: async () => {
+        try {
+          await copySelectionToClipboard();
+        } catch (err) {
+          console.error("Failed to copy selection:", err);
+        }
+      },
+      paste: handlePaste,
+      applyFilter: (filter: Filter) => {
+        if (canvasRef.current) {
+          saveToHistory();
+          filter.apply(canvasRef.current);
+          onContentChange?.();
+        }
+      },
+    }),
+    [
+      onCanUndoChange,
+      onCanRedoChange,
+      saveToHistory,
+      copySelectionToClipboard,
+      clearSelection,
+      handlePaste,
+      onContentChange,
+      selection,
+      canvasWidth,
+      canvasHeight,
+      strokeWidth,
+    ]
+  );
+
+  // Add keyboard shortcuts for clipboard operations
+  useEffect(() => {
+    if (!isForeground) return; // Only register clipboard shortcuts when foreground
+    const handleClipboardShortcuts = (e: KeyboardEvent) => {
+      const isMac = navigator.platform.toUpperCase().indexOf("MAC") >= 0;
+      const cmdKey = isMac ? e.metaKey : e.ctrlKey;
+
+      if (cmdKey && !e.shiftKey && !e.altKey) {
+        if (e.key.toLowerCase() === "x") {
+          e.preventDefault();
+          copySelectionToClipboard();
+          clearSelection();
+        } else if (e.key.toLowerCase() === "c") {
+          e.preventDefault();
+          copySelectionToClipboard();
+        } else if (e.key.toLowerCase() === "v") {
+          e.preventDefault();
+          handlePaste();
+        }
+      }
+    };
+
+    window.addEventListener("keydown", handleClipboardShortcuts);
+    return () =>
+      window.removeEventListener("keydown", handleClipboardShortcuts);
+  }, [isForeground, copySelectionToClipboard, clearSelection, handlePaste]);
+
+  const getCanvasPoint = (
+    event:
+      | React.MouseEvent<HTMLCanvasElement>
+      | React.TouchEvent<HTMLCanvasElement>
+  ): Point => {
+    const canvas = canvasRef.current;
+    if (!canvas) return { x: 0, y: 0 };
+    const rect = canvas.getBoundingClientRect();
+
+    // Handle both mouse and touch events
+    let clientX: number;
+    let clientY: number;
+
+    if ("touches" in event) {
+      // For touchend/touchcancel, touches list will be empty, so use changedTouches
+      if (event.touches.length === 0 && event.changedTouches?.length > 0) {
+        clientX = event.changedTouches[0].clientX;
+        clientY = event.changedTouches[0].clientY;
+      } else if (event.touches.length > 0) {
+        clientX = event.touches[0].clientX;
+        clientY = event.touches[0].clientY;
+      } else {
+        // If no touch data available, return the last known point or a default
+        return startPointRef.current || { x: 0, y: 0 };
+      }
+    } else {
+      clientX = event.clientX;
+      clientY = event.clientY;
+    }
+
+    return {
+      x: clientX - rect.left,
+      y: clientY - rect.top,
+    };
+  };
+
+  // Point-in-polygon test for lasso selection
+  const isPointInLassoPath = useCallback((point: Point, path: Point[]): boolean => {
+    if (path.length < 3) return false;
+
+    let inside = false;
+    for (let i = 0, j = path.length - 1; i < path.length; j = i++) {
+      const xi = path[i].x;
+      const yi = path[i].y;
+      const xj = path[j].x;
+      const yj = path[j].y;
+
+      const intersect =
+        yi > point.y !== yj > point.y &&
+        point.x < ((xj - xi) * (point.y - yi)) / (yj - yi) + xi;
+      if (intersect) inside = !inside;
+    }
+    return inside;
+  }, []);
+
+  const isPointInSelection = useCallback((point: Point, sel: Selection): boolean => {
+    if (sel.type === "rectangle") {
+      return (
+        point.x >= sel.startX &&
+        point.x <= sel.startX + sel.width &&
+        point.y >= sel.startY &&
+        point.y <= sel.startY + sel.height
+      );
+    }
+    if (sel.type === "lasso" && sel.path) {
+      return isPointInLassoPath(point, sel.path);
+    }
+    return false;
+  }, [isPointInLassoPath]);
+
+  const floodFill = useCallback((startX: number, startY: number) => {
+    const canvas = canvasRef.current;
+    const context = contextRef.current;
+    if (!canvas || !context || !patternRef.current) return;
+
+    // Get the image data
+    const imageData = context.getImageData(0, 0, canvas.width, canvas.height);
+    const pixels = imageData.data;
+
+    // Get the color at target pixel
+    const startPos = (startY * canvas.width + startX) * 4;
+    const startR = pixels[startPos];
+    const startG = pixels[startPos + 1];
+    const startB = pixels[startPos + 2];
+    const startA = pixels[startPos + 3];
+
+    // Create a temporary canvas to draw the pattern
+    const tempCanvas = document.createElement("canvas");
+    tempCanvas.width = canvas.width;
+    tempCanvas.height = canvas.height;
+    const tempContext = tempCanvas.getContext("2d", {
+      willReadFrequently: true,
+    });
+    if (!tempContext) return;
+
+    // Fill the temporary canvas with the pattern
+    const pattern = tempContext.createPattern(patternRef.current, "repeat");
+    if (!pattern) return;
+    tempContext.fillStyle = pattern;
+    tempContext.fillRect(0, 0, canvas.width, canvas.height);
+    const patternData = tempContext.getImageData(
+      0,
+      0,
+      canvas.width,
+      canvas.height
+    );
+
+    // Performance optimization: Check if we're trying to fill with the same color
+    const targetPos = (startY * canvas.width + startX) * 4;
+    if (
+      pixels[targetPos] === patternData.data[targetPos] &&
+      pixels[targetPos + 1] === patternData.data[targetPos + 1] &&
+      pixels[targetPos + 2] === patternData.data[targetPos + 2] &&
+      pixels[targetPos + 3] === patternData.data[targetPos + 3]
+    ) {
+      return; // No need to fill if the colors are the same
+    }
+
+    // Performance optimization: Limit the maximum area to fill (e.g., 80% of canvas)
+    const maxPixels = Math.floor(canvas.width * canvas.height * 0.8);
+    let filledPixels = 0;
+
+    // Helper to check if a pixel matches the start color
+    const matchesStart = (pos: number) => {
+      return (
+        pixels[pos] === startR &&
+        pixels[pos + 1] === startG &&
+        pixels[pos + 2] === startB &&
+        pixels[pos + 3] === startA
+      );
+    };
+
+    // Helper to set a pixel to the pattern color
+    const setPixel = (pos: number) => {
+      pixels[pos] = patternData.data[pos];
+      pixels[pos + 1] = patternData.data[pos + 1];
+      pixels[pos + 2] = patternData.data[pos + 2];
+      pixels[pos + 3] = patternData.data[pos + 3];
+      filledPixels++;
+    };
+
+    // Scanline stack for flood fill (more efficient than pixel stack)
+    interface ScanLine {
+      y: number;
+      leftX: number;
+      rightX: number;
+      direction: number; // 1 for up, -1 for down
+    }
+    const scanlines: ScanLine[] = [];
+
+    // Add initial scanline
+    scanlines.push({
+      y: startY,
+      leftX: startX,
+      rightX: startX,
+      direction: 1,
+    });
+    scanlines.push({
+      y: startY,
+      leftX: startX,
+      rightX: startX,
+      direction: -1,
+    });
+
+    while (scanlines.length > 0 && filledPixels < maxPixels) {
+      const { y, leftX, rightX, direction } = scanlines.pop()!;
+      const newY = y + direction;
+
+      // Skip if we're out of bounds
+      if (newY < 0 || newY >= canvas.height) continue;
+
+      // Find the extents of the current scanline
+      let x1 = leftX;
+      let x2 = rightX;
+
+      // Extend left
+      while (x1 > 0 && matchesStart((y * canvas.width + (x1 - 1)) * 4)) {
+        x1--;
+      }
+
+      // Extend right
+      while (
+        x2 < canvas.width - 1 &&
+        matchesStart((y * canvas.width + (x2 + 1)) * 4)
+      ) {
+        x2++;
+      }
+
+      // Fill the current scanline
+      for (let x = x1; x <= x2; x++) {
+        setPixel((y * canvas.width + x) * 4);
+      }
+
+      // Look for new scanlines above/below
+      let inRange = false;
+      for (let x = x1; x <= x2; x++) {
+        const newPos = (newY * canvas.width + x) * 4;
+        const matchesNow = matchesStart(newPos);
+
+        if (!inRange && matchesNow) {
+          scanlines.push({
+            y: newY,
+            leftX: x,
+            rightX: x,
+            direction: direction,
+          });
+          inRange = true;
+        } else if (inRange && !matchesNow) {
+          scanlines[scanlines.length - 1].rightX = x - 1;
+          inRange = false;
+        }
+      }
+      if (inRange) {
+        scanlines[scanlines.length - 1].rightX = x2;
+      }
+    }
+
+    // Put the modified image data back
+    context.putImageData(imageData, 0, 0);
+    saveToHistory();
+  }, [saveToHistory]);
+
+  const renderText = (text: string) => {
+    if (!contextRef.current || !patternRef.current || !textPosition) return;
+
+    const context = contextRef.current;
+    context.save();
+
+    // Set up text rendering
+    context.font = `16px Geneva-12`;
+    context.textBaseline = "top";
+
+    // Create pattern from the pattern canvas
+    const pattern = context.createPattern(patternRef.current, "repeat");
+    if (pattern) {
+      context.fillStyle = pattern;
+      context.fillText(text, textPosition.x, textPosition.y);
+    }
+
+    context.restore();
+    saveToHistory();
+  };
+
+  const handleTextInput = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === "Enter") {
+      const text = event.currentTarget.value;
+      if (!text) {
+        setIsTyping(false);
+        return;
+      }
+
+      renderText(text);
+      event.currentTarget.value = "";
+      setIsTyping(false);
+    }
+  };
+
+  const handleTextBlur = (event: React.FocusEvent<HTMLInputElement>) => {
+    const text = event.currentTarget.value;
+    if (text) {
+      renderText(text);
+    }
+    setIsTyping(false);
+  };
+
+  const startDrawing = useCallback(
+    (
+      event:
+        | React.MouseEvent<HTMLCanvasElement>
+        | React.TouchEvent<HTMLCanvasElement>
+    ) => {
+      const canvas = canvasRef.current;
+      if (!canvas || !contextRef.current) return;
+
+      const point = getCanvasPoint(event);
+
+      // Don't handle panning here anymore, let Framer Motion handle it
+      if (selectedTool === "hand") return;
+
+      // Store touch start position for tap detection
+      if ("touches" in event) {
+        touchStartRef.current = point;
+        // Execute bucket fill immediately on touch for better responsiveness
+        if (selectedTool === "bucket") {
+          floodFill(Math.floor(point.x), Math.floor(point.y));
           return;
         }
+      }
 
-        // Clear any existing selection when starting to draw with other tools
-        if (selection) {
+      // Handle rectangle selection tool
+      if (selectedTool === "rect-select") {
+        // If clicking outside selection, clear it
+        if (selection && !isPointInSelection(point, selection)) {
           // Restore canvas to state before selection
           if (lastImageRef.current) {
             contextRef.current.putImageData(lastImageRef.current, 0, 0);
@@ -1294,541 +1228,600 @@ export const PaintCanvas = forwardRef<PaintCanvasRef, PaintCanvasProps>(
           setSelection(null);
         }
 
-        if (selectedTool === "text") {
-          if (!isTyping) {
-            // Only set new position when starting new text input
-            setTextPosition(point);
-          }
-          setIsTyping(true);
-          // Focus the input after a short delay to ensure it's mounted
-          setTimeout(() => {
-            if (textInputRef.current) {
-              textInputRef.current.focus();
-            }
-          }, 0);
-          return;
-        }
-
-        // Handle bucket fill for mouse click
-        if (selectedTool === "bucket" && !("touches" in event)) {
-          floodFill(Math.floor(point.x), Math.floor(point.y));
-          return;
-        }
-
-        if (["line", "rectangle", "oval"].includes(selectedTool)) {
-          // Store the current canvas state for shape preview
-          lastImageRef.current = contextRef.current.getImageData(
-            0,
-            0,
-            canvas.width,
-            canvas.height
-          );
-          startPointRef.current = point;
-        } else {
-          // Set up context based on tool
-          if (selectedTool === "eraser") {
-            contextRef.current.globalCompositeOperation = "destination-out";
-            contextRef.current.strokeStyle = "#FFFFFF"; // Use white color for eraser
-          } else {
-            contextRef.current.globalCompositeOperation = "source-over";
-            // Restore pattern for drawing tools
-            if (patternRef.current) {
-              const pattern = contextRef.current.createPattern(
-                patternRef.current,
-                "repeat"
-              );
-              if (pattern) {
-                contextRef.current.strokeStyle = pattern;
-                contextRef.current.fillStyle = pattern;
-              }
-            }
-          }
-
-          contextRef.current.beginPath();
-          if (selectedTool !== "spray") {
-            contextRef.current.moveTo(point.x, point.y);
-          } else {
-            sprayAtPoint(point);
-          }
-        }
-
-        isDrawing.current = true;
-      },
-      [
-        selectedTool,
-        selection,
-        isTyping,
-        floodFill,
-        isPointInSelection,
-        isPointInLassoPath,
-        setSelection,
-        setTextPosition,
-        setIsTyping,
-        sprayAtPoint,
-      ]
-    );
-
-    const draw = useCallback(
-      (
-        event:
-          | React.MouseEvent<HTMLCanvasElement>
-          | React.TouchEvent<HTMLCanvasElement>
-      ) => {
-        if (!contextRef.current || !canvasRef.current) return;
-
-        const point = getCanvasPoint(event);
-
-        if (selectedTool === "hand") return;
-
-        if (isDraggingSelection && selection && dragStartRef.current) {
-          const dx = point.x - dragStartRef.current.x;
-          const dy = point.y - dragStartRef.current.y;
-
-          setSelection((prev) => {
-            if (!prev) return null;
-            if (prev.type === "rectangle") {
-              return {
-                ...prev,
-                startX: prev.startX + dx,
-                startY: prev.startY + dy,
-              };
-            } else if (prev.type === "lasso" && prev.path) {
-              // Move all path points
-              const newPath = prev.path.map((p) => ({
-                x: p.x + dx,
-                y: p.y + dy,
-              }));
-              return {
-                ...prev,
-                startX: prev.startX + dx,
-                startY: prev.startY + dy,
-                path: newPath,
-              };
-            }
-            return prev;
-          });
-
+        // If clicking inside existing selection, prepare for drag
+        if (selection && isPointInSelection(point, selection)) {
+          setIsDraggingSelection(true);
           dragStartRef.current = point;
           return;
         }
 
-        // Handle lasso selection drawing
-        if (selectedTool === "select" && isDrawing.current && lastImageRef.current) {
-          // Add point to lasso path
-          lassoPathRef.current.push(point);
+        // Start new selection
+        startPointRef.current = point;
+        // Store the current canvas state before starting new selection
+        lastImageRef.current = contextRef.current.getImageData(
+          0,
+          0,
+          canvas.width,
+          canvas.height
+        );
+        return;
+      }
 
-          // Restore canvas and draw lasso preview
+      // Handle lasso selection tool
+      if (selectedTool === "select") {
+        // If clicking outside selection, clear it
+        if (selection && selection.type === "lasso" && selection.path) {
+          const isInside = isPointInLassoPath(point, selection.path);
+          if (!isInside) {
+            // Restore canvas to state before selection
+            if (lastImageRef.current) {
+              contextRef.current.putImageData(lastImageRef.current, 0, 0);
+            }
+            setSelection(null);
+          } else {
+            // If clicking inside existing selection, prepare for drag
+            setIsDraggingSelection(true);
+            dragStartRef.current = point;
+            return;
+          }
+        }
+
+        // Start new lasso selection
+        lassoPathRef.current = [point];
+        // Store the current canvas state before starting new selection
+        lastImageRef.current = contextRef.current.getImageData(
+          0,
+          0,
+          canvas.width,
+          canvas.height
+        );
+        isDrawing.current = true;
+        return;
+      }
+
+      // Clear any existing selection when starting to draw with other tools
+      if (selection) {
+        // Restore canvas to state before selection
+        if (lastImageRef.current) {
           contextRef.current.putImageData(lastImageRef.current, 0, 0);
+        }
+        setSelection(null);
+      }
 
-          contextRef.current.save();
-          contextRef.current.strokeStyle = "#000";
-          contextRef.current.lineWidth = 1;
-          contextRef.current.setLineDash([5, 5]);
-          contextRef.current.lineDashOffset = dashOffsetRef.current;
+      if (selectedTool === "text") {
+        if (!isTyping) {
+          // Only set new position when starting new text input
+          setTextPosition(point);
+        }
+        setIsTyping(true);
+        // Focus the input after a short delay to ensure it's mounted
+        setTimeout(() => {
+          if (textInputRef.current) {
+            textInputRef.current.focus();
+          }
+        }, 0);
+        return;
+      }
 
-          if (lassoPathRef.current.length > 1) {
-            contextRef.current.beginPath();
-            contextRef.current.moveTo(
+      // Handle bucket fill for mouse click
+      if (selectedTool === "bucket" && !("touches" in event)) {
+        floodFill(Math.floor(point.x), Math.floor(point.y));
+        return;
+      }
+
+      if (["line", "rectangle", "oval"].includes(selectedTool)) {
+        // Store the current canvas state for shape preview
+        lastImageRef.current = contextRef.current.getImageData(
+          0,
+          0,
+          canvas.width,
+          canvas.height
+        );
+        startPointRef.current = point;
+      } else {
+        // Set up context based on tool
+        if (selectedTool === "eraser") {
+          contextRef.current.globalCompositeOperation = "destination-out";
+          contextRef.current.strokeStyle = "#FFFFFF"; // Use white color for eraser
+        } else {
+          contextRef.current.globalCompositeOperation = "source-over";
+          // Restore pattern for drawing tools
+          if (patternRef.current) {
+            const pattern = contextRef.current.createPattern(
+              patternRef.current,
+              "repeat"
+            );
+            if (pattern) {
+              contextRef.current.strokeStyle = pattern;
+              contextRef.current.fillStyle = pattern;
+            }
+          }
+        }
+
+        contextRef.current.beginPath();
+        if (selectedTool !== "spray") {
+          contextRef.current.moveTo(point.x, point.y);
+        } else {
+          sprayAtPoint(point);
+        }
+      }
+
+      isDrawing.current = true;
+    },
+    [
+      selectedTool,
+      selection,
+      isTyping,
+      floodFill,
+      isPointInSelection,
+      isPointInLassoPath,
+      setSelection,
+      setTextPosition,
+      setIsTyping,
+      sprayAtPoint,
+    ]
+  );
+
+  const draw = useCallback(
+    (
+      event:
+        | React.MouseEvent<HTMLCanvasElement>
+        | React.TouchEvent<HTMLCanvasElement>
+    ) => {
+      if (!contextRef.current || !canvasRef.current) return;
+
+      const point = getCanvasPoint(event);
+
+      if (selectedTool === "hand") return;
+
+      if (isDraggingSelection && selection && dragStartRef.current) {
+        const dx = point.x - dragStartRef.current.x;
+        const dy = point.y - dragStartRef.current.y;
+
+        setSelection((prev) => {
+          if (!prev) return null;
+          if (prev.type === "rectangle") {
+            return {
+              ...prev,
+              startX: prev.startX + dx,
+              startY: prev.startY + dy,
+            };
+          } else if (prev.type === "lasso" && prev.path) {
+            // Move all path points
+            const newPath = prev.path.map((p) => ({
+              x: p.x + dx,
+              y: p.y + dy,
+            }));
+            return {
+              ...prev,
+              startX: prev.startX + dx,
+              startY: prev.startY + dy,
+              path: newPath,
+            };
+          }
+          return prev;
+        });
+
+        dragStartRef.current = point;
+        return;
+      }
+
+      // Handle lasso selection drawing
+      if (selectedTool === "select" && isDrawing.current && lastImageRef.current) {
+        // Add point to lasso path
+        lassoPathRef.current.push(point);
+
+        // Restore canvas and draw lasso preview
+        contextRef.current.putImageData(lastImageRef.current, 0, 0);
+
+        contextRef.current.save();
+        contextRef.current.strokeStyle = "#000";
+        contextRef.current.lineWidth = 1;
+        contextRef.current.setLineDash([5, 5]);
+        contextRef.current.lineDashOffset = dashOffsetRef.current;
+
+        if (lassoPathRef.current.length > 1) {
+          contextRef.current.beginPath();
+          contextRef.current.moveTo(
+            lassoPathRef.current[0].x,
+            lassoPathRef.current[0].y
+          );
+          for (let i = 1; i < lassoPathRef.current.length; i++) {
+            contextRef.current.lineTo(
+              lassoPathRef.current[i].x,
+              lassoPathRef.current[i].y
+            );
+          }
+          // Draw line back to start if path is long enough
+          if (lassoPathRef.current.length > 2) {
+            contextRef.current.lineTo(
               lassoPathRef.current[0].x,
               lassoPathRef.current[0].y
             );
-            for (let i = 1; i < lassoPathRef.current.length; i++) {
-              contextRef.current.lineTo(
-                lassoPathRef.current[i].x,
-                lassoPathRef.current[i].y
-              );
-            }
-            // Draw line back to start if path is long enough
-            if (lassoPathRef.current.length > 2) {
-              contextRef.current.lineTo(
-                lassoPathRef.current[0].x,
-                lassoPathRef.current[0].y
-              );
-            }
-            contextRef.current.stroke();
           }
-
-          contextRef.current.restore();
-          return;
+          contextRef.current.stroke();
         }
 
-        if (
-          selectedTool === "rect-select" &&
-          startPointRef.current &&
-          lastImageRef.current
-        ) {
-          contextRef.current.putImageData(lastImageRef.current, 0, 0);
+        contextRef.current.restore();
+        return;
+      }
 
+      if (
+        selectedTool === "rect-select" &&
+        startPointRef.current &&
+        lastImageRef.current
+      ) {
+        contextRef.current.putImageData(lastImageRef.current, 0, 0);
+
+        const width = point.x - startPointRef.current.x;
+        const height = point.y - startPointRef.current.y;
+
+        contextRef.current.save();
+        contextRef.current.strokeStyle = "#000";
+        contextRef.current.lineWidth = 1;
+        contextRef.current.setLineDash([5, 5]);
+        contextRef.current.strokeRect(
+          startPointRef.current.x,
+          startPointRef.current.y,
+          width,
+          height
+        );
+        contextRef.current.restore();
+        return;
+      }
+
+      if (!isDrawing.current) return;
+
+      if (
+        ["line", "rectangle", "oval"].includes(selectedTool) &&
+        startPointRef.current &&
+        lastImageRef.current
+      ) {
+        contextRef.current.putImageData(lastImageRef.current, 0, 0);
+
+        contextRef.current.globalCompositeOperation = "source-over";
+        if (patternRef.current) {
+          const pattern = contextRef.current.createPattern(
+            patternRef.current,
+            "repeat"
+          );
+          if (pattern) {
+            contextRef.current.strokeStyle = pattern;
+          }
+        }
+
+        contextRef.current.beginPath();
+
+        if (selectedTool === "line") {
+          contextRef.current.moveTo(
+            startPointRef.current.x,
+            startPointRef.current.y
+          );
+          contextRef.current.lineTo(point.x, point.y);
+        } else if (selectedTool === "rectangle") {
           const width = point.x - startPointRef.current.x;
           const height = point.y - startPointRef.current.y;
-
-          contextRef.current.save();
-          contextRef.current.strokeStyle = "#000";
-          contextRef.current.lineWidth = 1;
-          contextRef.current.setLineDash([5, 5]);
-          contextRef.current.strokeRect(
+          contextRef.current.rect(
             startPointRef.current.x,
             startPointRef.current.y,
             width,
             height
           );
-          contextRef.current.restore();
-          return;
+        } else if (selectedTool === "oval") {
+          const centerX = (startPointRef.current.x + point.x) / 2;
+          const centerY = (startPointRef.current.y + point.y) / 2;
+          const radiusX = Math.abs(point.x - startPointRef.current.x) / 2;
+          const radiusY = Math.abs(point.y - startPointRef.current.y) / 2;
+
+          contextRef.current.ellipse(
+            centerX,
+            centerY,
+            radiusX,
+            radiusY,
+            0,
+            0,
+            2 * Math.PI
+          );
         }
 
-        if (!isDrawing.current) return;
-
-        if (
-          ["line", "rectangle", "oval"].includes(selectedTool) &&
-          startPointRef.current &&
-          lastImageRef.current
-        ) {
-          contextRef.current.putImageData(lastImageRef.current, 0, 0);
-
-          contextRef.current.globalCompositeOperation = "source-over";
-          if (patternRef.current) {
-            const pattern = contextRef.current.createPattern(
-              patternRef.current,
-              "repeat"
-            );
-            if (pattern) {
-              contextRef.current.strokeStyle = pattern;
-            }
-          }
-
-          contextRef.current.beginPath();
-
-          if (selectedTool === "line") {
-            contextRef.current.moveTo(
-              startPointRef.current.x,
-              startPointRef.current.y
-            );
-            contextRef.current.lineTo(point.x, point.y);
-          } else if (selectedTool === "rectangle") {
-            const width = point.x - startPointRef.current.x;
-            const height = point.y - startPointRef.current.y;
-            contextRef.current.rect(
-              startPointRef.current.x,
-              startPointRef.current.y,
-              width,
-              height
-            );
-          } else if (selectedTool === "oval") {
-            const centerX = (startPointRef.current.x + point.x) / 2;
-            const centerY = (startPointRef.current.y + point.y) / 2;
-            const radiusX = Math.abs(point.x - startPointRef.current.x) / 2;
-            const radiusY = Math.abs(point.y - startPointRef.current.y) / 2;
-
-            contextRef.current.ellipse(
-              centerX,
-              centerY,
-              radiusX,
-              radiusY,
-              0,
-              0,
-              2 * Math.PI
-            );
-          }
-
+        contextRef.current.stroke();
+      } else if (!["line", "rectangle", "oval"].includes(selectedTool)) {
+        if (selectedTool === "spray") {
+          sprayAtPoint(point);
+        } else {
+          contextRef.current.lineTo(point.x, point.y);
           contextRef.current.stroke();
-        } else if (!["line", "rectangle", "oval"].includes(selectedTool)) {
-          if (selectedTool === "spray") {
-            sprayAtPoint(point);
-          } else {
-            contextRef.current.lineTo(point.x, point.y);
-            contextRef.current.stroke();
-          }
         }
-      },
-      [selectedTool, isDraggingSelection, selection, sprayAtPoint]
-    );
+      }
+    },
+    [selectedTool, isDraggingSelection, selection, sprayAtPoint]
+  );
 
-    const stopDrawing = useCallback(
-      (
-        event:
-          | React.MouseEvent<HTMLCanvasElement>
-          | React.TouchEvent<HTMLCanvasElement>
-      ) => {
-        const canvas = canvasRef.current;
-        if (!canvas || !contextRef.current) return;
-
-        if (selectedTool === "hand") return;
-
-        const point = getCanvasPoint(event);
-
-        touchStartRef.current = null;
-
-        // Handle lasso selection completion
-        if (selectedTool === "select" && lassoPathRef.current.length > 2) {
-          const path = [...lassoPathRef.current];
-          
-          // Calculate bounding box
-          let minX = path[0].x;
-          let minY = path[0].y;
-          let maxX = path[0].x;
-          let maxY = path[0].y;
-
-          for (const p of path) {
-            minX = Math.min(minX, p.x);
-            minY = Math.min(minY, p.y);
-            maxX = Math.max(maxX, p.x);
-            maxY = Math.max(maxY, p.y);
-          }
-
-          const width = maxX - minX;
-          const height = maxY - minY;
-
-          if (width > 0 && height > 0) {
-            if (lastImageRef.current) {
-              contextRef.current.putImageData(lastImageRef.current, 0, 0);
-            }
-
-            // Extract selection region (will be used for copy/cut)
-            const selectionImageData = contextRef.current.getImageData(
-              minX,
-              minY,
-              width,
-              height
-            );
-
-            setSelection({
-              type: "lasso",
-              startX: minX,
-              startY: minY,
-              width,
-              height,
-              path,
-              imageData: selectionImageData,
-            });
-          } else {
-            if (lastImageRef.current) {
-              contextRef.current.putImageData(lastImageRef.current, 0, 0);
-            }
-            setSelection(null);
-          }
-
-          lassoPathRef.current = [];
-          isDrawing.current = false;
-        }
-
-        if (selectedTool === "rect-select" && startPointRef.current) {
-          const width = point.x - startPointRef.current.x;
-          const height = point.y - startPointRef.current.y;
-
-          const startX = Math.min(point.x, startPointRef.current.x);
-          const startY = Math.min(point.y, startPointRef.current.y);
-          const absWidth = Math.abs(width);
-          const absHeight = Math.abs(height);
-
-          if (absWidth > 0 && absHeight > 0) {
-            if (lastImageRef.current) {
-              contextRef.current.putImageData(lastImageRef.current, 0, 0);
-            }
-
-            const selectionImageData = contextRef.current.getImageData(
-              startX,
-              startY,
-              absWidth,
-              absHeight
-            );
-
-            setSelection({
-              type: "rectangle",
-              startX,
-              startY,
-              width: absWidth,
-              height: absHeight,
-              imageData: selectionImageData,
-            });
-          } else {
-            if (lastImageRef.current) {
-              contextRef.current.putImageData(lastImageRef.current, 0, 0);
-            }
-            setSelection(null);
-          }
-        }
-
-        if (isDraggingSelection) {
-          setIsDraggingSelection(false);
-          dragStartRef.current = null;
-        }
-
-        if (
-          isDrawing.current ||
-          isDraggingSelection ||
-          selectedTool === "bucket"
-        ) {
-          saveToHistory();
-        }
-
-        isDrawing.current = false;
-        startPointRef.current = null;
-
-        if (contextRef.current && selectedTool === "eraser") {
-          contextRef.current.globalCompositeOperation = "source-over";
-          if (patternRef.current) {
-            const pattern = contextRef.current.createPattern(
-              patternRef.current,
-              "repeat"
-            );
-            if (pattern) {
-              contextRef.current.strokeStyle = pattern;
-            }
-          }
-        }
-      },
-      [
-        selectedTool,
-        isDraggingSelection,
-        setSelection,
-        setIsDraggingSelection,
-        saveToHistory,
-      ]
-    );
-
-    // Unified pointer event handlers
-    const handlePointerDown = useCallback(
-      (
-        event:
-          | React.MouseEvent<HTMLCanvasElement>
-          | React.TouchEvent<HTMLCanvasElement>
-      ) => {
-        event.preventDefault();
-        startDrawing(event);
-      },
-      [startDrawing]
-    );
-
-    const handlePointerMove = useCallback(
-      (
-        event:
-          | React.MouseEvent<HTMLCanvasElement>
-          | React.TouchEvent<HTMLCanvasElement>
-      ) => {
-        event.preventDefault();
-        draw(event);
-      },
-      [draw]
-    );
-
-    const handlePointerUp = useCallback(
-      (
-        event:
-          | React.MouseEvent<HTMLCanvasElement>
-          | React.TouchEvent<HTMLCanvasElement>
-      ) => {
-        event.preventDefault();
-        stopDrawing(event);
-      },
-      [stopDrawing]
-    );
-
-    useEffect(() => {
+  const stopDrawing = useCallback(
+    (
+      event:
+        | React.MouseEvent<HTMLCanvasElement>
+        | React.TouchEvent<HTMLCanvasElement>
+    ) => {
       const canvas = canvasRef.current;
-      if (!canvas) return;
+      if (!canvas || !contextRef.current) return;
 
-      const touchStartHandler = (e: TouchEvent) =>
-        handlePointerDown(e as unknown as React.TouchEvent<HTMLCanvasElement>);
-      const touchMoveHandler = (e: TouchEvent) =>
-        handlePointerMove(e as unknown as React.TouchEvent<HTMLCanvasElement>);
-      const touchEndHandler = (e: TouchEvent) =>
-        handlePointerUp(e as unknown as React.TouchEvent<HTMLCanvasElement>);
+      if (selectedTool === "hand") return;
 
-      canvas.addEventListener("touchstart", touchStartHandler, {
-        passive: false,
-      });
-      canvas.addEventListener("touchmove", touchMoveHandler, {
-        passive: false,
-      });
-      canvas.addEventListener("touchend", touchEndHandler, {
-        passive: false,
-      });
+      const point = getCanvasPoint(event);
 
-      return () => {
-        canvas.removeEventListener("touchstart", touchStartHandler);
-        canvas.removeEventListener("touchmove", touchMoveHandler);
-        canvas.removeEventListener("touchend", touchEndHandler);
-      };
-    }, [handlePointerDown, handlePointerMove, handlePointerUp]);
+      touchStartRef.current = null;
 
-    return (
-      <div
-        ref={containerRef}
-        className="relative w-full h-full overflow-auto"
+      // Handle lasso selection completion
+      if (selectedTool === "select" && lassoPathRef.current.length > 2) {
+        const path = [...lassoPathRef.current];
+        
+        // Calculate bounding box
+        let minX = path[0].x;
+        let minY = path[0].y;
+        let maxX = path[0].x;
+        let maxY = path[0].y;
+
+        for (const p of path) {
+          minX = Math.min(minX, p.x);
+          minY = Math.min(minY, p.y);
+          maxX = Math.max(maxX, p.x);
+          maxY = Math.max(maxY, p.y);
+        }
+
+        const width = maxX - minX;
+        const height = maxY - minY;
+
+        if (width > 0 && height > 0) {
+          if (lastImageRef.current) {
+            contextRef.current.putImageData(lastImageRef.current, 0, 0);
+          }
+
+          // Extract selection region (will be used for copy/cut)
+          const selectionImageData = contextRef.current.getImageData(
+            minX,
+            minY,
+            width,
+            height
+          );
+
+          setSelection({
+            type: "lasso",
+            startX: minX,
+            startY: minY,
+            width,
+            height,
+            path,
+            imageData: selectionImageData,
+          });
+        } else {
+          if (lastImageRef.current) {
+            contextRef.current.putImageData(lastImageRef.current, 0, 0);
+          }
+          setSelection(null);
+        }
+
+        lassoPathRef.current = [];
+        isDrawing.current = false;
+      }
+
+      if (selectedTool === "rect-select" && startPointRef.current) {
+        const width = point.x - startPointRef.current.x;
+        const height = point.y - startPointRef.current.y;
+
+        const startX = Math.min(point.x, startPointRef.current.x);
+        const startY = Math.min(point.y, startPointRef.current.y);
+        const absWidth = Math.abs(width);
+        const absHeight = Math.abs(height);
+
+        if (absWidth > 0 && absHeight > 0) {
+          if (lastImageRef.current) {
+            contextRef.current.putImageData(lastImageRef.current, 0, 0);
+          }
+
+          const selectionImageData = contextRef.current.getImageData(
+            startX,
+            startY,
+            absWidth,
+            absHeight
+          );
+
+          setSelection({
+            type: "rectangle",
+            startX,
+            startY,
+            width: absWidth,
+            height: absHeight,
+            imageData: selectionImageData,
+          });
+        } else {
+          if (lastImageRef.current) {
+            contextRef.current.putImageData(lastImageRef.current, 0, 0);
+          }
+          setSelection(null);
+        }
+      }
+
+      if (isDraggingSelection) {
+        setIsDraggingSelection(false);
+        dragStartRef.current = null;
+      }
+
+      if (
+        isDrawing.current ||
+        isDraggingSelection ||
+        selectedTool === "bucket"
+      ) {
+        saveToHistory();
+      }
+
+      isDrawing.current = false;
+      startPointRef.current = null;
+
+      if (contextRef.current && selectedTool === "eraser") {
+        contextRef.current.globalCompositeOperation = "source-over";
+        if (patternRef.current) {
+          const pattern = contextRef.current.createPattern(
+            patternRef.current,
+            "repeat"
+          );
+          if (pattern) {
+            contextRef.current.strokeStyle = pattern;
+          }
+        }
+      }
+    },
+    [
+      selectedTool,
+      isDraggingSelection,
+      setSelection,
+      setIsDraggingSelection,
+      saveToHistory,
+    ]
+  );
+
+  // Unified pointer event handlers
+  const handlePointerDown = useCallback(
+    (
+      event:
+        | React.MouseEvent<HTMLCanvasElement>
+        | React.TouchEvent<HTMLCanvasElement>
+    ) => {
+      event.preventDefault();
+      startDrawing(event);
+    },
+    [startDrawing]
+  );
+
+  const handlePointerMove = useCallback(
+    (
+      event:
+        | React.MouseEvent<HTMLCanvasElement>
+        | React.TouchEvent<HTMLCanvasElement>
+    ) => {
+      event.preventDefault();
+      draw(event);
+    },
+    [draw]
+  );
+
+  const handlePointerUp = useCallback(
+    (
+      event:
+        | React.MouseEvent<HTMLCanvasElement>
+        | React.TouchEvent<HTMLCanvasElement>
+    ) => {
+      event.preventDefault();
+      stopDrawing(event);
+    },
+    [stopDrawing]
+  );
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+
+    const touchStartHandler = (e: TouchEvent) =>
+      handlePointerDown(e as unknown as React.TouchEvent<HTMLCanvasElement>);
+    const touchMoveHandler = (e: TouchEvent) =>
+      handlePointerMove(e as unknown as React.TouchEvent<HTMLCanvasElement>);
+    const touchEndHandler = (e: TouchEvent) =>
+      handlePointerUp(e as unknown as React.TouchEvent<HTMLCanvasElement>);
+
+    canvas.addEventListener("touchstart", touchStartHandler, {
+      passive: false,
+    });
+    canvas.addEventListener("touchmove", touchMoveHandler, {
+      passive: false,
+    });
+    canvas.addEventListener("touchend", touchEndHandler, {
+      passive: false,
+    });
+
+    return () => {
+      canvas.removeEventListener("touchstart", touchStartHandler);
+      canvas.removeEventListener("touchmove", touchMoveHandler);
+      canvas.removeEventListener("touchend", touchEndHandler);
+    };
+  }, [handlePointerDown, handlePointerMove, handlePointerUp]);
+
+  return (
+    <div
+      ref={containerRef}
+      className="relative w-full h-full overflow-auto"
+      style={{
+        cursor:
+          selectedTool === "hand"
+            ? "grab"
+            : selectedTool === "rect-select"
+            ? "crosshair"
+            : selection
+            ? "move"
+            : "crosshair",
+      }}
+    >
+      <motion.div
+        className="bg-white"
         style={{
-          cursor:
-            selectedTool === "hand"
-              ? "grab"
-              : selectedTool === "rect-select"
-              ? "crosshair"
-              : selection
-              ? "move"
-              : "crosshair",
+          minWidth: `${canvasWidth}px`,
+          minHeight: `${canvasHeight}px`,
+        }}
+        drag={selectedTool === "hand"}
+        dragConstraints={containerRef}
+        dragElastic={0.2}
+        dragMomentum={true}
+        dragTransition={{
+          bounceStiffness: 300,
+          bounceDamping: 20,
+          min: 0,
+          max: 100,
         }}
       >
-        <motion.div
-          className="bg-white"
-          style={{
-            minWidth: `${canvasWidth}px`,
-            minHeight: `${canvasHeight}px`,
-          }}
-          drag={selectedTool === "hand"}
-          dragConstraints={containerRef}
-          dragElastic={0.2}
-          dragMomentum={true}
-          dragTransition={{
-            bounceStiffness: 300,
-            bounceDamping: 20,
-            min: 0,
-            max: 100,
-          }}
+        <div
+          className="relative"
+          style={{ width: `${canvasWidth}px`, height: `${canvasHeight}px` }}
         >
-          <div
-            className="relative"
-            style={{ width: `${canvasWidth}px`, height: `${canvasHeight}px` }}
-          >
-            <canvas
-              ref={canvasRef}
+          <canvas
+            ref={canvasRef}
+            style={{
+              imageRendering: "pixelated",
+              width: "100%",
+              height: "100%",
+              touchAction: selectedTool === "hand" ? "none" : "none",
+              cursor: selectedTool === "hand" ? "grab" : "crosshair",
+            }}
+            className={`${
+              selectedTool === "rect-select"
+                ? "cursor-crosshair"
+                : selection
+                ? "cursor-move"
+                : "cursor-crosshair"
+            }`}
+            onMouseDown={handlePointerDown}
+            onMouseMove={handlePointerMove}
+            onMouseUp={handlePointerUp}
+            onMouseLeave={handlePointerUp}
+          />
+          {isTyping && textPosition && (
+            <input
+              ref={textInputRef}
+              type="text"
+              className="absolute bg-transparent border-none outline-none font-geneva-12 text-black pointer-events-auto"
               style={{
-                imageRendering: "pixelated",
-                width: "100%",
-                height: "100%",
-                touchAction: selectedTool === "hand" ? "none" : "none",
-                cursor: selectedTool === "hand" ? "grab" : "crosshair",
+                left: `${textPosition.x}px`,
+                top: `${textPosition.y}px`,
+                fontSize: `16px`,
+                minWidth: "100px",
+                padding: 0,
+                margin: 0,
+                transform: "translateZ(0)",
               }}
-              className={`${
-                selectedTool === "rect-select"
-                  ? "cursor-crosshair"
-                  : selection
-                  ? "cursor-move"
-                  : "cursor-crosshair"
-              }`}
-              onMouseDown={handlePointerDown}
-              onMouseMove={handlePointerMove}
-              onMouseUp={handlePointerUp}
-              onMouseLeave={handlePointerUp}
+              onKeyDown={handleTextInput}
+              onBlur={handleTextBlur}
             />
-            {isTyping && textPosition && (
-              <input
-                ref={textInputRef}
-                type="text"
-                className="absolute bg-transparent border-none outline-none font-geneva-12 text-black pointer-events-auto"
-                style={{
-                  left: `${textPosition.x}px`,
-                  top: `${textPosition.y}px`,
-                  fontSize: `16px`,
-                  minWidth: "100px",
-                  padding: 0,
-                  margin: 0,
-                  transform: "translateZ(0)",
-                }}
-                onKeyDown={handleTextInput}
-                onBlur={handleTextBlur}
-              />
-            )}
-          </div>
-        </motion.div>
-      </div>
-    );
-  }
-);
+          )}
+        </div>
+      </motion.div>
+    </div>
+  );
+};

--- a/src/apps/paint/components/PaintCanvas.tsx
+++ b/src/apps/paint/components/PaintCanvas.tsx
@@ -73,7 +73,7 @@ export const PaintCanvas = (
     canvasHeight = 418,
     isForeground = false
   }: PaintCanvasProps & {
-    ref: React.RefObject<PaintCanvasRef>;
+    ref?: React.Ref<PaintCanvasRef>;
   }
 ) => {
   const canvasRef = useRef<HTMLCanvasElement>(null);

--- a/src/apps/soundboard/components/Waveform.tsx
+++ b/src/apps/soundboard/components/Waveform.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, useEffect, useRef } from "react";
+import { useEffect, useRef } from "react";
 import type { MutableRefObject } from "react";
 import { createWaveform } from "@/utils/audio";
 import type WaveSurfer from "wavesurfer.js";
@@ -12,98 +12,107 @@ interface WaveformProps {
   isPlaying?: boolean;
 }
 
-export const Waveform = forwardRef<HTMLDivElement, WaveformProps>(
-  ({ className = "", audioData, audioFormat, onWaveformCreate, isPlaying = false }, ref) => {
-    const { t } = useTranslation();
-    const waveformRef = useRef<WaveSurfer | null>(null);
-    const containerRef = useRef<HTMLDivElement | null>(null);
-
-    useEffect(() => {
-      let isMounted = true;
-      const currentContainer = containerRef.current;
-
-      // Cleanup function to destroy waveform
-      const cleanup = () => {
-        if (waveformRef.current) {
-          waveformRef.current.destroy();
-          waveformRef.current = null;
-        }
-      };
-
-      if (!audioData || !currentContainer) {
-        cleanup(); // Clean up if no data or container
-        return;
-      }
-
-      const initWaveform = async () => {
-        cleanup(); // Clean up previous instance before creating new one
-
-        if (!currentContainer || !isMounted) return; // Check again before async operation
-
-        currentContainer.innerHTML = ""; // Clear container
-
-        try {
-          const wavesurfer = await createWaveform(currentContainer, audioData, audioFormat);
-
-          if (isMounted) {
-            wavesurfer.setMuted(true);
-            waveformRef.current = wavesurfer;
-            onWaveformCreate?.(wavesurfer);
-
-            // Set initial play state
-            // createWaveform now ensures the instance is ready when the promise resolves
-            if (isPlaying) {
-              wavesurfer.play();
-            } else {
-              wavesurfer.seekTo(0);
-              // Per v7 docs, use setOptions to trigger redraw instead of drawBuffer
-              wavesurfer.setOptions({});
-            }
-          } else {
-            wavesurfer.destroy(); // Destroy if unmounted during creation
-          }
-        } catch (error) {
-          console.error("Failed to initialize waveform:", error);
-          if (isMounted && currentContainer) {
-            currentContainer.innerHTML = t("apps.soundboard.waveform.errorLoading");
-          }
-          cleanup(); // Ensure cleanup on error
-        }
-      };
-
-      // Defer heavy waveform decoding to idle time / next tick to avoid blocking mobile Safari UI thread
-      const schedule = (cb: () => void) => {
-        if ("requestIdleCallback" in window) {
-          window.requestIdleCallback(cb, { timeout: 750 });
-        } else {
-          setTimeout(cb, 0);
-        }
-      };
-      schedule(initWaveform);
-
-      return () => {
-        isMounted = false;
-        cleanup(); // Cleanup on unmount
-      };
-    }, [audioData, audioFormat, onWaveformCreate, isPlaying, t]); // isPlaying is now a dependency
-
-    return (
-      <div
-        ref={(node) => {
-          containerRef.current = node;
-          if (ref) {
-            if (typeof ref === "function") {
-              ref(node);
-            } else if (typeof ref === "object" && ref !== null) {
-              (ref as MutableRefObject<HTMLDivElement | null>).current = node;
-            }
-          }
-        }}
-        className={`w-full h-12 flex-shrink-0 overflow-hidden ${className}`}
-        aria-label={t("apps.soundboard.waveform.label")}
-      />
-    );
+export const Waveform = (
+  {
+    ref,
+    className = "",
+    audioData,
+    audioFormat,
+    onWaveformCreate,
+    isPlaying = false
+  }: WaveformProps & {
+    ref: React.RefObject<HTMLDivElement>;
   }
-);
+) => {
+  const { t } = useTranslation();
+  const waveformRef = useRef<WaveSurfer | null>(null);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    let isMounted = true;
+    const currentContainer = containerRef.current;
+
+    // Cleanup function to destroy waveform
+    const cleanup = () => {
+      if (waveformRef.current) {
+        waveformRef.current.destroy();
+        waveformRef.current = null;
+      }
+    };
+
+    if (!audioData || !currentContainer) {
+      cleanup(); // Clean up if no data or container
+      return;
+    }
+
+    const initWaveform = async () => {
+      cleanup(); // Clean up previous instance before creating new one
+
+      if (!currentContainer || !isMounted) return; // Check again before async operation
+
+      currentContainer.innerHTML = ""; // Clear container
+
+      try {
+        const wavesurfer = await createWaveform(currentContainer, audioData, audioFormat);
+
+        if (isMounted) {
+          wavesurfer.setMuted(true);
+          waveformRef.current = wavesurfer;
+          onWaveformCreate?.(wavesurfer);
+
+          // Set initial play state
+          // createWaveform now ensures the instance is ready when the promise resolves
+          if (isPlaying) {
+            wavesurfer.play();
+          } else {
+            wavesurfer.seekTo(0);
+            // Per v7 docs, use setOptions to trigger redraw instead of drawBuffer
+            wavesurfer.setOptions({});
+          }
+        } else {
+          wavesurfer.destroy(); // Destroy if unmounted during creation
+        }
+      } catch (error) {
+        console.error("Failed to initialize waveform:", error);
+        if (isMounted && currentContainer) {
+          currentContainer.innerHTML = t("apps.soundboard.waveform.errorLoading");
+        }
+        cleanup(); // Ensure cleanup on error
+      }
+    };
+
+    // Defer heavy waveform decoding to idle time / next tick to avoid blocking mobile Safari UI thread
+    const schedule = (cb: () => void) => {
+      if ("requestIdleCallback" in window) {
+        window.requestIdleCallback(cb, { timeout: 750 });
+      } else {
+        setTimeout(cb, 0);
+      }
+    };
+    schedule(initWaveform);
+
+    return () => {
+      isMounted = false;
+      cleanup(); // Cleanup on unmount
+    };
+  }, [audioData, audioFormat, onWaveformCreate, isPlaying, t]); // isPlaying is now a dependency
+
+  return (
+    <div
+      ref={(node) => {
+        containerRef.current = node;
+        if (ref) {
+          if (typeof ref === "function") {
+            ref(node);
+          } else if (typeof ref === "object" && ref !== null) {
+            (ref as MutableRefObject<HTMLDivElement | null>).current = node;
+          }
+        }
+      }}
+      className={`w-full h-12 flex-shrink-0 overflow-hidden ${className}`}
+      aria-label={t("apps.soundboard.waveform.label")}
+    />
+  );
+};
 
 Waveform.displayName = "Waveform";

--- a/src/apps/soundboard/components/Waveform.tsx
+++ b/src/apps/soundboard/components/Waveform.tsx
@@ -21,7 +21,7 @@ export const Waveform = (
     onWaveformCreate,
     isPlaying = false
   }: WaveformProps & {
-    ref: React.RefObject<HTMLDivElement>;
+    ref?: React.Ref<HTMLDivElement>;
   }
 ) => {
   const { t } = useTranslation();

--- a/src/apps/textedit/components/EditorContext.ts
+++ b/src/apps/textedit/components/EditorContext.ts
@@ -1,10 +1,10 @@
-import { createContext, useContext } from "react";
+import { createContext, use } from "react";
 import { Editor } from "@tiptap/core";
 
 export const EditorContext = createContext<Editor | null>(null);
 
 export function useEditorContext() {
-  const editor = useContext(EditorContext);
+  const editor = use(EditorContext);
   if (!editor) {
     throw new Error("useEditorContext must be used within EditorProvider");
   }

--- a/src/apps/textedit/components/SlashCommandsList.tsx
+++ b/src/apps/textedit/components/SlashCommandsList.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useImperativeHandle, useState } from "react";
+import { type Ref, useEffect, useImperativeHandle, useState } from "react";
 import { Editor } from "@tiptap/react";
 
 interface CommandItem {
@@ -20,6 +20,8 @@ export const SlashCommandsList = (
   {
     ref,
     ...props
+  }: SlashCommandsListProps & {
+    ref?: Ref<{ onKeyDown: (event: KeyboardEvent) => boolean }>;
   }
 ) => {
   const [selectedIndex, setSelectedIndex] = useState(0);

--- a/src/apps/textedit/components/SlashCommandsList.tsx
+++ b/src/apps/textedit/components/SlashCommandsList.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, useEffect, useImperativeHandle, useState } from "react";
+import { useEffect, useImperativeHandle, useState } from "react";
 import { Editor } from "@tiptap/react";
 
 interface CommandItem {
@@ -16,10 +16,12 @@ interface SlashCommandsListProps {
   command: (props: CommandProps) => void;
 }
 
-export const SlashCommandsList = forwardRef<
-  { onKeyDown: (event: KeyboardEvent) => boolean },
-  SlashCommandsListProps
->((props, ref) => {
+export const SlashCommandsList = (
+  {
+    ref,
+    ...props
+  }
+) => {
   const [selectedIndex, setSelectedIndex] = useState(0);
 
   const selectItem = (index: number) => {
@@ -81,4 +83,4 @@ export const SlashCommandsList = forwardRef<
       ))}
     </div>
   );
-});
+};

--- a/src/components/layout/Dock.tsx
+++ b/src/components/layout/Dock.tsx
@@ -80,7 +80,7 @@ const DockSpacer = (
     magnifyEnabled,
     baseSize: baseSizeProp
   }: DockSpacerProps & {
-    ref: React.RefObject<HTMLDivElement>;
+    ref?: React.Ref<HTMLDivElement>;
   }
 ) => {
   const wrapperRef = useRef<HTMLDivElement | null>(null);
@@ -197,7 +197,7 @@ const IconButton = memo((
     isDraggedOutside = false,
     baseSize: baseSizeProp
   }: IconButtonProps & {
-    ref: React.RefObject<HTMLDivElement>;
+    ref?: React.Ref<HTMLDivElement>;
   }
 ) => {
   const baseButtonSize = baseSizeProp ?? BASE_BUTTON_SIZE;
@@ -480,7 +480,7 @@ const Divider = (
     onTouchMove,
     onTouchCancel
   }: DividerProps & {
-    ref: React.RefObject<HTMLDivElement>;
+    ref?: React.Ref<HTMLDivElement>;
   }
 ) => {
   const baseWidth = 1;

--- a/src/components/layout/Dock.tsx
+++ b/src/components/layout/Dock.tsx
@@ -1,12 +1,4 @@
-import React, {
-  useMemo,
-  useRef,
-  useState,
-  useCallback,
-  useEffect,
-  forwardRef,
-  memo,
-} from "react";
+import React, { useMemo, useRef, useState, useCallback, useEffect, memo } from "react";
 import { useTranslation } from "react-i18next";
 import { useThemeFlags } from "@/hooks/useThemeFlags";
 import { useAppStoreShallow } from "@/stores/helpers";
@@ -80,372 +72,380 @@ interface DockSpacerProps {
   baseSize?: number;
 }
 
-const DockSpacer = forwardRef<HTMLDivElement, DockSpacerProps>(
-  ({ idKey, mouseX, magnifyEnabled, baseSize: baseSizeProp }, ref) => {
-    const wrapperRef = useRef<HTMLDivElement | null>(null);
-    const baseSize = baseSizeProp ?? BASE_BUTTON_SIZE;
-    const maxSize = Math.round(baseSize * MAX_SCALE);
+const DockSpacer = (
+  {
+    ref,
+    idKey,
+    mouseX,
+    magnifyEnabled,
+    baseSize: baseSizeProp
+  }: DockSpacerProps & {
+    ref: React.RefObject<HTMLDivElement>;
+  }
+) => {
+  const wrapperRef = useRef<HTMLDivElement | null>(null);
+  const baseSize = baseSizeProp ?? BASE_BUTTON_SIZE;
+  const maxSize = Math.round(baseSize * MAX_SCALE);
+  
+  // Use a motion value for target size that we can imperatively update
+  const targetSize = useMotionValue(baseSize);
+  
+  // Update target size when base size changes or magnification is disabled
+  useEffect(() => {
+    if (!magnifyEnabled) {
+      targetSize.set(baseSize);
+    }
+  }, [baseSize, magnifyEnabled, targetSize]);
+  
+  const distanceCalc = useTransform(mouseX, (val) => {
+    const bounds = wrapperRef.current?.getBoundingClientRect();
+    if (!bounds || !Number.isFinite(val)) return Infinity;
+    return val - (bounds.left + bounds.width / 2);
+  });
+  
+  // Update target size based on cursor distance when magnification is enabled
+  useEffect(() => {
+    if (!magnifyEnabled) return;
     
-    // Use a motion value for target size that we can imperatively update
-    const targetSize = useMotionValue(baseSize);
-    
-    // Update target size when base size changes or magnification is disabled
-    useEffect(() => {
-      if (!magnifyEnabled) {
+    const unsubscribe = distanceCalc.on("change", (dist) => {
+      if (!Number.isFinite(dist)) {
         targetSize.set(baseSize);
+        return;
       }
-    }, [baseSize, magnifyEnabled, targetSize]);
-    
-    const distanceCalc = useTransform(mouseX, (val) => {
-      const bounds = wrapperRef.current?.getBoundingClientRect();
-      if (!bounds || !Number.isFinite(val)) return Infinity;
-      return val - (bounds.left + bounds.width / 2);
+      const absDist = Math.abs(dist);
+      if (absDist > DISTANCE) {
+        targetSize.set(baseSize);
+      } else {
+        const t = 1 - absDist / DISTANCE;
+        targetSize.set(baseSize + t * (maxSize - baseSize));
+      }
     });
     
-    // Update target size based on cursor distance when magnification is enabled
-    useEffect(() => {
-      if (!magnifyEnabled) return;
-      
-      const unsubscribe = distanceCalc.on("change", (dist) => {
-        if (!Number.isFinite(dist)) {
-          targetSize.set(baseSize);
-          return;
-        }
-        const absDist = Math.abs(dist);
-        if (absDist > DISTANCE) {
-          targetSize.set(baseSize);
-        } else {
-          const t = 1 - absDist / DISTANCE;
-          targetSize.set(baseSize + t * (maxSize - baseSize));
-        }
-      });
-      
-      return unsubscribe;
-    }, [magnifyEnabled, baseSize, maxSize, distanceCalc, targetSize]);
+    return unsubscribe;
+  }, [magnifyEnabled, baseSize, maxSize, distanceCalc, targetSize]);
+  
+  const sizeSpring = useSpring(targetSize, {
+    mass: 0.15,
+    stiffness: 160,
+    damping: 18,
+  });
+  
+  const widthValue = sizeSpring;
+  
+  const setCombinedRef = useCallback(
+    (node: HTMLDivElement | null) => {
+      wrapperRef.current = node;
+      if (typeof ref === "function") {
+        ref(node);
+      } else if (ref && "current" in (ref as object)) {
+        (ref as React.MutableRefObject<HTMLDivElement | null>).current = node;
+      }
+    },
+    [ref]
+  );
+  
+  return (
+    <motion.div
+      ref={setCombinedRef}
+      layout
+      layoutId={`dock-spacer-${idKey}`}
+      initial={{ width: 0, height: 0 }}
+      animate={{ width: baseSize + 8, height: baseSize }} // Base size for layout, actual size controlled by style
+      exit={{ width: 0, height: 0 }}
+      transition={{
+        type: "spring",
+        stiffness: 400,
+        damping: 30,
+      }}
+      className="flex-shrink-0"
+      style={{
+        width: widthValue,
+        height: widthValue,
+        marginLeft: 4,
+        marginRight: 4,
+        transformOrigin: "bottom center",
+      }}
+    />
+  );
+};
+
+const IconButton = memo((
+  {
+    ref: forwardedRef,
+    label,
+    onClick,
+    icon,
+    idKey,
+    showIndicator = false,
+    isLoading = false,
+    isEmoji = false,
+    onDragOver,
+    onDrop,
+    onDragLeave,
+    onContextMenu,
+    mouseX,
+    magnifyEnabled,
+    isNew,
+    isHovered,
+    isSwapping,
+    onHover,
+    onLeave,
+    draggable = false,
+    onDragStart,
+    onDragEnd,
+    isDragging = false,
+    isDraggedOutside = false,
+    baseSize: baseSizeProp
+  }: IconButtonProps & {
+    ref: React.RefObject<HTMLDivElement>;
+  }
+) => {
+  const baseButtonSize = baseSizeProp ?? BASE_BUTTON_SIZE;
+  const maxButtonSize = Math.round(baseButtonSize * MAX_SCALE);
+  const wrapperRef = useRef<HTMLDivElement | null>(null);
+  const isPresent = useIsPresent();
+  
+  // Use a motion value for target size that we can imperatively update
+  const targetSize = useMotionValue(baseButtonSize);
+  
+  // Update target size when base size changes or magnification is disabled
+  useEffect(() => {
+    if (!magnifyEnabled) {
+      targetSize.set(baseButtonSize);
+    }
+  }, [baseButtonSize, magnifyEnabled, targetSize]);
+  
+  // Calculate distance from cursor to icon center
+  const distanceCalc = useTransform(mouseX, (val) => {
+    const bounds = wrapperRef.current?.getBoundingClientRect();
+    if (!bounds || !Number.isFinite(val)) return Infinity;
+    return val - (bounds.left + bounds.width / 2);
+  });
+  
+  // Update target size based on cursor distance when magnification is enabled
+  useEffect(() => {
+    if (!magnifyEnabled) return;
     
-    const sizeSpring = useSpring(targetSize, {
-      mass: 0.15,
-      stiffness: 160,
-      damping: 18,
+    const unsubscribe = distanceCalc.on("change", (dist) => {
+      if (!Number.isFinite(dist)) {
+        targetSize.set(baseButtonSize);
+        return;
+      }
+      const absDist = Math.abs(dist);
+      if (absDist > DISTANCE) {
+        targetSize.set(baseButtonSize);
+      } else {
+        const t = 1 - absDist / DISTANCE;
+        targetSize.set(baseButtonSize + t * (maxButtonSize - baseButtonSize));
+      }
     });
     
-    const widthValue = sizeSpring;
-    
-    const setCombinedRef = useCallback(
-      (node: HTMLDivElement | null) => {
-        wrapperRef.current = node;
-        if (typeof ref === "function") {
-          ref(node);
-        } else if (ref && "current" in (ref as object)) {
-          (ref as React.MutableRefObject<HTMLDivElement | null>).current = node;
-        }
-      },
-      [ref]
-    );
-    
-    return (
-      <motion.div
-        ref={setCombinedRef}
-        layout
-        layoutId={`dock-spacer-${idKey}`}
-        initial={{ width: 0, height: 0 }}
-        animate={{ width: baseSize + 8, height: baseSize }} // Base size for layout, actual size controlled by style
-        exit={{ width: 0, height: 0 }}
-        transition={{
+    return unsubscribe;
+  }, [magnifyEnabled, baseButtonSize, maxButtonSize, distanceCalc, targetSize]);
+  
+  const sizeSpring = useSpring(targetSize, {
+    mass: 0.15,
+    stiffness: 160,
+    damping: 18,
+  });
+  const widthValue = isPresent ? sizeSpring : 0;
+
+  // Scale factor for emoji to match magnification (relative to baseButtonSize)
+  const emojiScale = useTransform(sizeSpring, (val) => val / baseButtonSize);
+
+  // Add long-press support for context menu on mobile
+  const longPressHandlers = useLongPress<HTMLButtonElement>((touchEvent) => {
+    if (onContextMenu) {
+      const touch = touchEvent.touches[0];
+      const syntheticEvent = {
+        preventDefault: () => {},
+        stopPropagation: () => {},
+        clientX: touch.clientX,
+        clientY: touch.clientY,
+      } as unknown as React.MouseEvent<HTMLButtonElement>;
+      onContextMenu(syntheticEvent);
+    }
+  });
+
+  const setCombinedRef = useCallback(
+    (node: HTMLDivElement | null) => {
+      wrapperRef.current = node;
+      if (typeof forwardedRef === "function") {
+        forwardedRef(node);
+      } else if (forwardedRef && "current" in (forwardedRef as object)) {
+        (
+          forwardedRef as React.MutableRefObject<HTMLDivElement | null>
+        ).current = node;
+      }
+    },
+    [forwardedRef]
+  );
+
+  // When dragged outside dock, shrink to 0; when dragging inside, use normal size
+  const dragWidth = isDraggedOutside ? 0 : widthValue;
+  const dragHeight = isDraggedOutside ? 0 : widthValue;
+  const dragMargin = isDraggedOutside ? 0 : (isPresent ? 4 : 0);
+
+  return (
+    <motion.div
+      ref={setCombinedRef}
+      layout
+      layoutId={`dock-icon-${idKey}`}
+      data-dock-icon={idKey}
+      initial={isNew ? { scale: 0, opacity: 0 } : undefined}
+      animate={{
+        scale: 1,
+        // Hide icon completely when dragging
+        opacity: isDragging ? 0 : 1,
+      }}
+      exit={{
+        scale: 0,
+        opacity: 0,
+      }}
+      transition={{
+        type: "spring",
+        stiffness: 500,
+        damping: 36,
+        mass: 0.7,
+        // Snappier layout transition for reorder snap effect
+        layout: {
           type: "spring",
           stiffness: 400,
           damping: 30,
-        }}
-        className="flex-shrink-0"
+        },
+      }}
+      style={{
+        transformOrigin: "bottom center",
+        willChange: "width, height, transform",
+        width: dragWidth,
+        height: dragHeight,
+        marginLeft: dragMargin,
+        marginRight: dragMargin,
+        overflow: "visible",
+        cursor: draggable ? (isDragging ? "grabbing" : "grab") : "pointer",
+      }}
+      className="flex-shrink-0 relative"
+    >
+      <AnimatePresence>
+        {isHovered && (
+          <motion.div
+            initial={{ opacity: 0, y: 10, x: "-50%" }}
+            animate={{ 
+              opacity: 1, 
+              y: 0, 
+              x: "-50%",
+              transition: { duration: isSwapping ? 0 : 0.05 }
+            }}
+            exit={{ 
+              opacity: 0, 
+              y: 5, 
+              x: "-50%",
+              transition: { duration: isSwapping ? 0 : 0.15 }
+            }}
+            className="absolute bottom-full mb-3 left-1/2 px-3 py-1 bg-neutral-800 text-white/90 text-sm font-medium rounded-full shadow-xl whitespace-nowrap pointer-events-none z-50"
+          >
+            {label}
+            <div className="absolute top-full left-1/2 -translate-x-1/2 w-[10px] h-[5px] bg-neutral-800" style={{ clipPath: "polygon(50% 100%, 0% 0%, 100% 0%)" }} />
+          </motion.div>
+        )}
+      </AnimatePresence>
+
+      <button
+        aria-label={label}
+        title="" // remove native tooltip
+        onClick={onClick}
+        onContextMenu={onContextMenu}
+        onMouseEnter={onHover}
+        onMouseLeave={onLeave}
+        draggable={draggable}
+        onDragStart={onDragStart}
+        onDragEnd={onDragEnd}
+        onDragOver={onDragOver}
+        onDrop={onDrop}
+        onDragLeave={onDragLeave}
+        {...longPressHandlers}
+        className="relative flex items-end justify-center w-full h-full"
         style={{
-          width: widthValue,
-          height: widthValue,
-          marginLeft: 4,
-          marginRight: 4,
-          transformOrigin: "bottom center",
+          willChange: "transform",
         }}
-      />
-    );
-  }
-);
-
-const IconButton = memo(forwardRef<HTMLDivElement, IconButtonProps>(
-  (
-    {
-      label,
-      onClick,
-      icon,
-      idKey,
-      showIndicator = false,
-      isLoading = false,
-      isEmoji = false,
-      onDragOver,
-      onDrop,
-      onDragLeave,
-      onContextMenu,
-      mouseX,
-      magnifyEnabled,
-      isNew,
-      isHovered,
-      isSwapping,
-      onHover,
-      onLeave,
-      draggable = false,
-      onDragStart,
-      onDragEnd,
-      isDragging = false,
-      isDraggedOutside = false,
-      baseSize: baseSizeProp,
-    },
-    forwardedRef
-  ) => {
-    const baseButtonSize = baseSizeProp ?? BASE_BUTTON_SIZE;
-    const maxButtonSize = Math.round(baseButtonSize * MAX_SCALE);
-    const wrapperRef = useRef<HTMLDivElement | null>(null);
-    const isPresent = useIsPresent();
-    
-    // Use a motion value for target size that we can imperatively update
-    const targetSize = useMotionValue(baseButtonSize);
-    
-    // Update target size when base size changes or magnification is disabled
-    useEffect(() => {
-      if (!magnifyEnabled) {
-        targetSize.set(baseButtonSize);
-      }
-    }, [baseButtonSize, magnifyEnabled, targetSize]);
-    
-    // Calculate distance from cursor to icon center
-    const distanceCalc = useTransform(mouseX, (val) => {
-      const bounds = wrapperRef.current?.getBoundingClientRect();
-      if (!bounds || !Number.isFinite(val)) return Infinity;
-      return val - (bounds.left + bounds.width / 2);
-    });
-    
-    // Update target size based on cursor distance when magnification is enabled
-    useEffect(() => {
-      if (!magnifyEnabled) return;
-      
-      const unsubscribe = distanceCalc.on("change", (dist) => {
-        if (!Number.isFinite(dist)) {
-          targetSize.set(baseButtonSize);
-          return;
-        }
-        const absDist = Math.abs(dist);
-        if (absDist > DISTANCE) {
-          targetSize.set(baseButtonSize);
-        } else {
-          const t = 1 - absDist / DISTANCE;
-          targetSize.set(baseButtonSize + t * (maxButtonSize - baseButtonSize));
-        }
-      });
-      
-      return unsubscribe;
-    }, [magnifyEnabled, baseButtonSize, maxButtonSize, distanceCalc, targetSize]);
-    
-    const sizeSpring = useSpring(targetSize, {
-      mass: 0.15,
-      stiffness: 160,
-      damping: 18,
-    });
-    const widthValue = isPresent ? sizeSpring : 0;
-
-    // Scale factor for emoji to match magnification (relative to baseButtonSize)
-    const emojiScale = useTransform(sizeSpring, (val) => val / baseButtonSize);
-
-    // Add long-press support for context menu on mobile
-    const longPressHandlers = useLongPress<HTMLButtonElement>((touchEvent) => {
-      if (onContextMenu) {
-        const touch = touchEvent.touches[0];
-        const syntheticEvent = {
-          preventDefault: () => {},
-          stopPropagation: () => {},
-          clientX: touch.clientX,
-          clientY: touch.clientY,
-        } as unknown as React.MouseEvent<HTMLButtonElement>;
-        onContextMenu(syntheticEvent);
-      }
-    });
-
-    const setCombinedRef = useCallback(
-      (node: HTMLDivElement | null) => {
-        wrapperRef.current = node;
-        if (typeof forwardedRef === "function") {
-          forwardedRef(node);
-        } else if (forwardedRef && "current" in (forwardedRef as object)) {
-          (
-            forwardedRef as React.MutableRefObject<HTMLDivElement | null>
-          ).current = node;
-        }
-      },
-      [forwardedRef]
-    );
-
-    // When dragged outside dock, shrink to 0; when dragging inside, use normal size
-    const dragWidth = isDraggedOutside ? 0 : widthValue;
-    const dragHeight = isDraggedOutside ? 0 : widthValue;
-    const dragMargin = isDraggedOutside ? 0 : (isPresent ? 4 : 0);
-
-    return (
-      <motion.div
-        ref={setCombinedRef}
-        layout
-        layoutId={`dock-icon-${idKey}`}
-        data-dock-icon={idKey}
-        initial={isNew ? { scale: 0, opacity: 0 } : undefined}
-        animate={{
-          scale: 1,
-          // Hide icon completely when dragging
-          opacity: isDragging ? 0 : 1,
-        }}
-        exit={{
-          scale: 0,
-          opacity: 0,
-        }}
-        transition={{
-          type: "spring",
-          stiffness: 500,
-          damping: 36,
-          mass: 0.7,
-          // Snappier layout transition for reorder snap effect
-          layout: {
-            type: "spring",
-            stiffness: 400,
-            damping: 30,
-          },
-        }}
-        style={{
-          transformOrigin: "bottom center",
-          willChange: "width, height, transform",
-          width: dragWidth,
-          height: dragHeight,
-          marginLeft: dragMargin,
-          marginRight: dragMargin,
-          overflow: "visible",
-          cursor: draggable ? (isDragging ? "grabbing" : "grab") : "pointer",
-        }}
-        className="flex-shrink-0 relative"
       >
-        <AnimatePresence>
-          {isHovered && (
-            <motion.div
-              initial={{ opacity: 0, y: 10, x: "-50%" }}
-              animate={{ 
-                opacity: 1, 
-                y: 0, 
-                x: "-50%",
-                transition: { duration: isSwapping ? 0 : 0.05 }
-              }}
-              exit={{ 
-                opacity: 0, 
-                y: 5, 
-                x: "-50%",
-                transition: { duration: isSwapping ? 0 : 0.15 }
-              }}
-              className="absolute bottom-full mb-3 left-1/2 px-3 py-1 bg-neutral-800 text-white/90 text-sm font-medium rounded-full shadow-xl whitespace-nowrap pointer-events-none z-50"
-            >
-              {label}
-              <div className="absolute top-full left-1/2 -translate-x-1/2 w-[10px] h-[5px] bg-neutral-800" style={{ clipPath: "polygon(50% 100%, 0% 0%, 100% 0%)" }} />
-            </motion.div>
-          )}
-        </AnimatePresence>
-
-        <button
-          aria-label={label}
-          title="" // remove native tooltip
-          onClick={onClick}
-          onContextMenu={onContextMenu}
-          onMouseEnter={onHover}
-          onMouseLeave={onLeave}
-          draggable={draggable}
-          onDragStart={onDragStart}
-          onDragEnd={onDragEnd}
-          onDragOver={onDragOver}
-          onDrop={onDrop}
-          onDragLeave={onDragLeave}
-          {...longPressHandlers}
-          className="relative flex items-end justify-center w-full h-full"
-          style={{
-            willChange: "transform",
+        <motion.div
+          className="w-full h-full flex items-end justify-center"
+          animate={
+            isLoading
+              ? {
+                  y: [0, -20, 0],
+                  transition: {
+                    y: {
+                      repeat: Infinity,
+                      duration: 0.8,
+                      ease: "easeInOut",
+                      repeatType: "loop",
+                    },
+                  },
+                }
+              : { y: 0 }
+          }
+          transition={{
+            y: {
+              type: "spring",
+              stiffness: 200,
+              damping: 20,
+            },
           }}
         >
-          <motion.div
-            className="w-full h-full flex items-end justify-center"
-            animate={
-              isLoading
-                ? {
-                    y: [0, -20, 0],
-                    transition: {
-                      y: {
-                        repeat: Infinity,
-                        duration: 0.8,
-                        ease: "easeInOut",
-                        repeatType: "loop",
-                      },
-                    },
-                  }
-                : { y: 0 }
-            }
-            transition={{
-              y: {
-                type: "spring",
-                stiffness: 200,
-                damping: 20,
-              },
-            }}
-          >
-            {isEmoji ? (
-              <motion.span
-                className="select-none pointer-events-none flex items-end justify-center"
-                style={{
-                  // Slightly larger base size so initial (non-hover) emoji isn't too small
-                  fontSize: baseButtonSize * 0.84,
-                  lineHeight: 1,
-                  originY: 1,
-                  originX: 0.5,
-                  scale: magnifyEnabled ? emojiScale : 1,
-                  // Lift a couple px so it's not too tight against the bottom
-                  y: -5,
-                  width: "100%",
-                  height: "100%",
-                }}
-              >
-                {icon}
-              </motion.span>
-            ) : (
-              <ThemedIcon
-                name={icon}
-                alt={label}
-                className="select-none pointer-events-none"
-                draggable={false}
-                style={{
-                  imageRendering: "-webkit-optimize-contrast",
-                  width: "100%",
-                  height: "100%",
-                }}
-              />
-            )}
-          </motion.div>
-          {showIndicator ? (
-            <span
-              aria-hidden
-              className="absolute"
+          {isEmoji ? (
+            <motion.span
+              className="select-none pointer-events-none flex items-end justify-center"
               style={{
-                bottom: -3,
-                width: 0,
-                height: 0,
-                borderLeft: "4px solid transparent",
-                borderRight: "4px solid transparent",
-                borderTop: "0",
-                borderBottom: "4px solid #000",
-                filter: "none",
+                // Slightly larger base size so initial (non-hover) emoji isn't too small
+                fontSize: baseButtonSize * 0.84,
+                lineHeight: 1,
+                originY: 1,
+                originX: 0.5,
+                scale: magnifyEnabled ? emojiScale : 1,
+                // Lift a couple px so it's not too tight against the bottom
+                y: -5,
+                width: "100%",
+                height: "100%",
+              }}
+            >
+              {icon}
+            </motion.span>
+          ) : (
+            <ThemedIcon
+              name={icon}
+              alt={label}
+              className="select-none pointer-events-none"
+              draggable={false}
+              style={{
+                imageRendering: "-webkit-optimize-contrast",
+                width: "100%",
+                height: "100%",
               }}
             />
-          ) : null}
-        </button>
-      </motion.div>
-    );
-  }
-));
+          )}
+        </motion.div>
+        {showIndicator ? (
+          <span
+            aria-hidden
+            className="absolute"
+            style={{
+              bottom: -3,
+              width: 0,
+              height: 0,
+              borderLeft: "4px solid transparent",
+              borderRight: "4px solid transparent",
+              borderTop: "0",
+              borderBottom: "4px solid #000",
+              filter: "none",
+            }}
+          />
+        ) : null}
+      </button>
+    </motion.div>
+  );
+});
 
 interface DividerProps {
   idKey: string;
@@ -463,84 +463,101 @@ interface DividerProps {
   onTouchCancel?: React.TouchEventHandler;
 }
 
-const Divider = forwardRef<HTMLDivElement, DividerProps>(
-  ({ idKey, onDragOver, onDrop, onDragLeave, isDropTarget, height = 48, resizable, onResizeStart, onContextMenu, onTouchStart, onTouchEnd, onTouchMove, onTouchCancel }, ref) => {
-    const baseWidth = 1;
-    
-    // Wrap handlers to stop propagation and prevent icon menus from triggering
-    const handleContextMenu = (e: React.MouseEvent) => {
-      e.stopPropagation();
-      onContextMenu?.(e);
-    };
-    
-    const handleTouchStart = (e: React.TouchEvent) => {
-      e.stopPropagation();
-      onTouchStart?.(e);
-    };
-    
-    const handleTouchEnd = (e: React.TouchEvent) => {
-      e.stopPropagation();
-      onTouchEnd?.(e);
-    };
-    
-    const handleTouchMove = (e: React.TouchEvent) => {
-      e.stopPropagation();
-      onTouchMove?.(e);
-    };
-    
-    const handleTouchCancel = (e: React.TouchEvent) => {
-      e.stopPropagation();
-      onTouchCancel?.(e);
-    };
-    
-    return (
-      <motion.div
-        ref={ref}
-        layout
-        layoutId={`dock-divider-${idKey}`}
-        initial={{ opacity: 0, scaleY: 0.8 }}
-        animate={{ 
-          opacity: 0.9, 
-          scaleY: 1,
-        }}
-        exit={{ opacity: 0, scaleY: 0.8 }}
-        transition={{ type: "spring", stiffness: 260, damping: 26 }}
-        onDragOver={onDragOver as React.DragEventHandler<HTMLDivElement>}
-        onDrop={onDrop as React.DragEventHandler<HTMLDivElement>}
-        onDragLeave={onDragLeave as React.DragEventHandler<HTMLDivElement>}
-        onMouseDown={resizable ? onResizeStart : undefined}
-        onContextMenu={handleContextMenu}
-        onTouchStart={handleTouchStart}
-        onTouchEnd={handleTouchEnd}
-        onTouchMove={handleTouchMove}
-        onTouchCancel={handleTouchCancel}
-        style={{
-          height,
-          // Wider touch area with padding, visual line is the inner element
-          padding: "0 10px",
-          alignSelf: "center",
-          cursor: resizable ? "ns-resize" : undefined,
-          position: "relative",
-          zIndex: 5,
-          display: "flex",
-          alignItems: "center",
-          justifyContent: "center",
-        }}
-      >
-        {/* Visual divider line */}
-        <div
-          style={{
-            width: isDropTarget ? 4 : baseWidth,
-            height: "100%",
-            backgroundColor: isDropTarget ? "rgba(255, 255, 255, 0.5)" : "rgba(0, 0, 0, 0.2)",
-            borderRadius: 2,
-            transition: "width 0.15s ease, background-color 0.15s ease",
-          }}
-        />
-      </motion.div>
-    );
+const Divider = (
+  {
+    ref,
+    idKey,
+    onDragOver,
+    onDrop,
+    onDragLeave,
+    isDropTarget,
+    height = 48,
+    resizable,
+    onResizeStart,
+    onContextMenu,
+    onTouchStart,
+    onTouchEnd,
+    onTouchMove,
+    onTouchCancel
+  }: DividerProps & {
+    ref: React.RefObject<HTMLDivElement>;
   }
-);
+) => {
+  const baseWidth = 1;
+  
+  // Wrap handlers to stop propagation and prevent icon menus from triggering
+  const handleContextMenu = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    onContextMenu?.(e);
+  };
+  
+  const handleTouchStart = (e: React.TouchEvent) => {
+    e.stopPropagation();
+    onTouchStart?.(e);
+  };
+  
+  const handleTouchEnd = (e: React.TouchEvent) => {
+    e.stopPropagation();
+    onTouchEnd?.(e);
+  };
+  
+  const handleTouchMove = (e: React.TouchEvent) => {
+    e.stopPropagation();
+    onTouchMove?.(e);
+  };
+  
+  const handleTouchCancel = (e: React.TouchEvent) => {
+    e.stopPropagation();
+    onTouchCancel?.(e);
+  };
+  
+  return (
+    <motion.div
+      ref={ref}
+      layout
+      layoutId={`dock-divider-${idKey}`}
+      initial={{ opacity: 0, scaleY: 0.8 }}
+      animate={{ 
+        opacity: 0.9, 
+        scaleY: 1,
+      }}
+      exit={{ opacity: 0, scaleY: 0.8 }}
+      transition={{ type: "spring", stiffness: 260, damping: 26 }}
+      onDragOver={onDragOver as React.DragEventHandler<HTMLDivElement>}
+      onDrop={onDrop as React.DragEventHandler<HTMLDivElement>}
+      onDragLeave={onDragLeave as React.DragEventHandler<HTMLDivElement>}
+      onMouseDown={resizable ? onResizeStart : undefined}
+      onContextMenu={handleContextMenu}
+      onTouchStart={handleTouchStart}
+      onTouchEnd={handleTouchEnd}
+      onTouchMove={handleTouchMove}
+      onTouchCancel={handleTouchCancel}
+      style={{
+        height,
+        // Wider touch area with padding, visual line is the inner element
+        padding: "0 10px",
+        alignSelf: "center",
+        cursor: resizable ? "ns-resize" : undefined,
+        position: "relative",
+        zIndex: 5,
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+      }}
+    >
+      {/* Visual divider line */}
+      <div
+        style={{
+          width: isDropTarget ? 4 : baseWidth,
+          height: "100%",
+          backgroundColor: isDropTarget ? "rgba(255, 255, 255, 0.5)" : "rgba(0, 0, 0, 0.2)",
+          borderRadius: 2,
+          transition: "width 0.15s ease, background-color 0.15s ease",
+        }}
+      />
+    </motion.div>
+  );
+};
 
 // Apps that support multi-window
 const MULTI_WINDOW_APPS: AppId[] = ["textedit", "finder", "applet-viewer"];

--- a/src/components/shared/WindowFrameDrawerContext.tsx
+++ b/src/components/shared/WindowFrameDrawerContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext } from "react";
+import { createContext, use } from "react";
 import type { WindowInsets } from "@/hooks/useWindowInsets";
 
 /**
@@ -50,5 +50,5 @@ export const WindowFrameDrawerContext =
 export function useWindowFrameDrawerContext():
   | WindowFrameDrawerContextValue
   | null {
-  return useContext(WindowFrameDrawerContext);
+  return use(WindowFrameDrawerContext);
 }

--- a/src/components/shared/YouTubePlayer.tsx
+++ b/src/components/shared/YouTubePlayer.tsx
@@ -1,37 +1,42 @@
-import { forwardRef } from "react";
 import ReactPlayer from "react-player";
 import type ReactPlayerType from "react-player";
 
 export type YouTubePlayerProps = React.ComponentProps<typeof ReactPlayer>;
 
-export const YouTubePlayer = forwardRef<ReactPlayerType, YouTubePlayerProps>(
-  function YouTubePlayer({ config, ...props }, ref) {
-    return (
-      <ReactPlayer
-        ref={ref}
-        playsinline
-        config={{
-          youtube: {
-            playerVars: {
-              modestbranding: 1,
-              rel: 0,
-              showinfo: 0,
-              iv_load_policy: 3,
-              disablekb: 1,
-              playsinline: 1,
-              enablejsapi: 1,
-              origin: window.location.origin,
-              ...config?.youtube?.playerVars,
-            },
-            embedOptions: {
-              referrerPolicy: "strict-origin-when-cross-origin",
-              ...config?.youtube?.embedOptions,
-            },
-          },
-          ...config,
-        }}
-        {...props}
-      />
-    );
+export const YouTubePlayer = function YouTubePlayer(
+  {
+    ref,
+    config,
+    ...props
+  }: YouTubePlayerProps & {
+    ref: React.RefObject<ReactPlayerType>;
   }
-);
+) {
+  return (
+    <ReactPlayer
+      ref={ref}
+      playsinline
+      config={{
+        youtube: {
+          playerVars: {
+            modestbranding: 1,
+            rel: 0,
+            showinfo: 0,
+            iv_load_policy: 3,
+            disablekb: 1,
+            playsinline: 1,
+            enablejsapi: 1,
+            origin: window.location.origin,
+            ...config?.youtube?.playerVars,
+          },
+          embedOptions: {
+            referrerPolicy: "strict-origin-when-cross-origin",
+            ...config?.youtube?.embedOptions,
+          },
+        },
+        ...config,
+      }}
+      {...props}
+    />
+  );
+};

--- a/src/components/shared/YouTubePlayer.tsx
+++ b/src/components/shared/YouTubePlayer.tsx
@@ -9,7 +9,7 @@ export const YouTubePlayer = function YouTubePlayer(
     config,
     ...props
   }: YouTubePlayerProps & {
-    ref: React.RefObject<ReactPlayerType>;
+    ref?: React.Ref<ReactPlayerType>;
   }
 ) {
   return (

--- a/src/components/ui/alert.tsx
+++ b/src/components/ui/alert.tsx
@@ -19,41 +19,49 @@ const alertVariants = cva(
   }
 )
 
-const Alert = React.forwardRef<
-  HTMLDivElement,
-  React.HTMLAttributes<HTMLDivElement> & VariantProps<typeof alertVariants>
->(({ className, variant, ...props }, ref) => (
-  <div
-    ref={ref}
-    role="alert"
-    className={cn(alertVariants({ variant }), className)}
-    {...props}
-  />
-))
+const Alert = (
+  {
+    ref,
+    className,
+    variant,
+    ...props
+  }
+) => (<div
+  ref={ref}
+  role="alert"
+  className={cn(alertVariants({ variant }), className)}
+  {...props}
+/>)
 Alert.displayName = "Alert"
 
-const AlertTitle = React.forwardRef<
-  HTMLParagraphElement,
-  React.HTMLAttributes<HTMLHeadingElement>
->(({ className, ...props }, ref) => (
-  <h5
-    ref={ref}
-    className={cn("mb-1 font-medium leading-none tracking-tight", className)}
-    {...props}
-  />
-))
+const AlertTitle = (
+  {
+    ref,
+    className,
+    ...props
+  }: React.HTMLAttributes<HTMLHeadingElement> & {
+    ref: React.RefObject<HTMLParagraphElement>;
+  }
+) => (<h5
+  ref={ref}
+  className={cn("mb-1 font-medium leading-none tracking-tight", className)}
+  {...props}
+/>)
 AlertTitle.displayName = "AlertTitle"
 
-const AlertDescription = React.forwardRef<
-  HTMLParagraphElement,
-  React.HTMLAttributes<HTMLParagraphElement>
->(({ className, ...props }, ref) => (
-  <div
-    ref={ref}
-    className={cn("text-sm [&_p]:leading-relaxed", className)}
-    {...props}
-  />
-))
+const AlertDescription = (
+  {
+    ref,
+    className,
+    ...props
+  }: React.HTMLAttributes<HTMLParagraphElement> & {
+    ref: React.RefObject<HTMLParagraphElement>;
+  }
+) => (<div
+  ref={ref}
+  className={cn("text-sm [&_p]:leading-relaxed", className)}
+  {...props}
+/>)
 AlertDescription.displayName = "AlertDescription"
 
 export { Alert, AlertTitle, AlertDescription }

--- a/src/components/ui/alert.tsx
+++ b/src/components/ui/alert.tsx
@@ -25,7 +25,10 @@ const Alert = (
     className,
     variant,
     ...props
-  }
+  }: React.HTMLAttributes<HTMLDivElement> &
+    VariantProps<typeof alertVariants> & {
+      ref?: React.Ref<HTMLDivElement>
+    }
 ) => (<div
   ref={ref}
   role="alert"
@@ -40,7 +43,7 @@ const AlertTitle = (
     className,
     ...props
   }: React.HTMLAttributes<HTMLHeadingElement> & {
-    ref: React.RefObject<HTMLParagraphElement>;
+    ref?: React.Ref<HTMLHeadingElement>;
   }
 ) => (<h5
   ref={ref}
@@ -55,7 +58,7 @@ const AlertDescription = (
     className,
     ...props
   }: React.HTMLAttributes<HTMLParagraphElement> & {
-    ref: React.RefObject<HTMLParagraphElement>;
+    ref?: React.Ref<HTMLDivElement>;
   }
 ) => (<div
   ref={ref}

--- a/src/components/ui/audio-input-button.tsx
+++ b/src/components/ui/audio-input-button.tsx
@@ -2,7 +2,6 @@ import { Microphone } from "@phosphor-icons/react";
 import { useAudioTranscription } from "@/hooks/useAudioTranscription";
 import { AudioBars } from "./audio-bars";
 import { ActivityIndicator } from "./activity-indicator";
-import { forwardRef } from "react";
 
 interface AudioInputButtonProps {
   onTranscriptionComplete: (text: string) => void;
@@ -18,72 +17,69 @@ interface AudioInputButtonProps {
   frequencyBands?: number;
 }
 
-export const AudioInputButton = forwardRef<
-  HTMLButtonElement,
-  AudioInputButtonProps
->(
-  (
-    {
-      onTranscriptionComplete,
-      onTranscriptionStart,
-      onRecordingStateChange,
-      onFrequenciesChange,
-      isLoading = false,
-      className = "",
-      silenceThreshold = 1000,
-      externalWaveform = false,
-      frequencyBands = 4,
-    },
-    ref
-  ) => {
-    const {
-      isRecording,
-      frequencies,
-      isSilent,
-      startRecording,
-      stopRecording,
-    } = useAudioTranscription({
-      onTranscriptionComplete: (text) => {
-        onTranscriptionComplete(text);
-      },
-      onTranscriptionStart: () => {
-        onTranscriptionStart?.();
-      },
-      onError: (error) => {
-        console.error("Audio transcription error:", error);
-        onTranscriptionComplete(""); // This will trigger the error UI in ChatInput
-      },
-      silenceThreshold,
-      minRecordingDuration: 500, // Ensure we get at least 0.5s of audio
-      frequencyBands,
-      // Pass callbacks directly to the hook - called inline when state changes
-      // instead of using useEffect to notify parent (React anti-pattern)
-      onRecordingStateChange,
-      onFrequenciesChange,
-    });
-
-    return (
-      <div className="relative">
-        <button
-          ref={ref}
-          type="button"
-          onClick={isRecording ? stopRecording : startRecording}
-          className={className}
-          disabled={isLoading}
-        >
-          {isLoading ? (
-            <ActivityIndicator size="sm" />
-          ) : isRecording && !externalWaveform ? (
-            <AudioBars
-              frequencies={frequencies}
-              color="black"
-              isSilent={isSilent}
-            />
-          ) : (
-            <Microphone className="h-4 w-4" weight="bold" />
-          )}
-        </button>
-      </div>
-    );
+export const AudioInputButton = (
+  {
+    ref,
+    onTranscriptionComplete,
+    onTranscriptionStart,
+    onRecordingStateChange,
+    onFrequenciesChange,
+    isLoading = false,
+    className = "",
+    silenceThreshold = 1000,
+    externalWaveform = false,
+    frequencyBands = 4
+  }: AudioInputButtonProps & {
+    ref: React.RefObject<HTMLButtonElement>;
   }
-);
+) => {
+  const {
+    isRecording,
+    frequencies,
+    isSilent,
+    startRecording,
+    stopRecording,
+  } = useAudioTranscription({
+    onTranscriptionComplete: (text) => {
+      onTranscriptionComplete(text);
+    },
+    onTranscriptionStart: () => {
+      onTranscriptionStart?.();
+    },
+    onError: (error) => {
+      console.error("Audio transcription error:", error);
+      onTranscriptionComplete(""); // This will trigger the error UI in ChatInput
+    },
+    silenceThreshold,
+    minRecordingDuration: 500, // Ensure we get at least 0.5s of audio
+    frequencyBands,
+    // Pass callbacks directly to the hook - called inline when state changes
+    // instead of using useEffect to notify parent (React anti-pattern)
+    onRecordingStateChange,
+    onFrequenciesChange,
+  });
+
+  return (
+    <div className="relative">
+      <button
+        ref={ref}
+        type="button"
+        onClick={isRecording ? stopRecording : startRecording}
+        className={className}
+        disabled={isLoading}
+      >
+        {isLoading ? (
+          <ActivityIndicator size="sm" />
+        ) : isRecording && !externalWaveform ? (
+          <AudioBars
+            frequencies={frequencies}
+            color="black"
+            isSilent={isSilent}
+          />
+        ) : (
+          <Microphone className="h-4 w-4" weight="bold" />
+        )}
+      </button>
+    </div>
+  );
+};

--- a/src/components/ui/audio-input-button.tsx
+++ b/src/components/ui/audio-input-button.tsx
@@ -30,7 +30,7 @@ export const AudioInputButton = (
     externalWaveform = false,
     frequencyBands = 4
   }: AudioInputButtonProps & {
-    ref: React.RefObject<HTMLButtonElement>;
+    ref?: React.Ref<HTMLButtonElement>;
   }
 ) => {
   const {

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -48,64 +48,73 @@ export interface ButtonProps
   asChild?: boolean;
 }
 
-const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
-  ({ className, variant, size, asChild = false, ...props }, ref) => {
-    const { play: playButtonClick } = useSound(Sounds.BUTTON_CLICK);
-    const Comp = asChild ? Slot : "button";
-    const { isXpTheme, isMacOSTheme } = useThemeFlags();
-
-    const handleClick = (e: React.MouseEvent<HTMLButtonElement>) => {
-      playButtonClick();
-      props.onClick?.(e);
-    };
-
-    const resolvedClassName = (() => {
-      // macOS: default/secondary/retro → aqua-button
-      if (isMacOSTheme && variant === "default") return cn("aqua-button primary", className);
-      if (isMacOSTheme && variant === "secondary") return cn("aqua-button secondary", className);
-      if (isMacOSTheme && variant === "retro") return cn("aqua-button secondary", className);
-
-      // macOS: aqua_select → CSS-driven aqua select button
-      if (isMacOSTheme && variant === "aqua_select") {
-        const dataState = (props as Record<string, unknown>)["data-state"];
-        const ariaPressed = (props as Record<string, unknown>)["aria-pressed"];
-        const isActiveSelected = dataState === "on" || ariaPressed === true;
-        return cn(
-          "macos-select-trigger no-chevron aqua-select-btn os-btn-aqua-select inline-flex w-auto items-center justify-center whitespace-nowrap rounded px-2 py-1 text-sm gap-0",
-          isActiveSelected && "aqua-selected",
-          className
-        );
-      }
-
-      // XP/Win98: default/aqua_select → xp.css button class
-      if (isXpTheme && (variant === "default" || variant === "aqua_select")) return cn("button", className);
-
-      // XP/Win98 + macOS: ghost → transparent reset to fight global button styles
-      if ((isXpTheme || isMacOSTheme) && variant === "ghost") {
-        return cn(buttonVariants({ variant, size }), "os-btn-ghost-reset", className);
-      }
-
-      return cn(buttonVariants({ variant, size, className }));
-    })();
-
-    const resolvedStyle = (() => {
-      if (isMacOSTheme && (variant === "default" || variant === "secondary" || variant === "retro")) {
-        return { position: "relative" as const, zIndex: 1, ...props.style };
-      }
-      return props.style;
-    })();
-
-    return (
-      <Comp
-        className={resolvedClassName}
-        ref={ref}
-        style={resolvedStyle}
-        {...props}
-        onClick={handleClick}
-      />
-    );
+const Button = (
+  {
+    ref,
+    className,
+    variant,
+    size,
+    asChild = false,
+    ...props
+  }: ButtonProps & {
+    ref: React.RefObject<HTMLButtonElement>;
   }
-);
+) => {
+  const { play: playButtonClick } = useSound(Sounds.BUTTON_CLICK);
+  const Comp = asChild ? Slot : "button";
+  const { isXpTheme, isMacOSTheme } = useThemeFlags();
+
+  const handleClick = (e: React.MouseEvent<HTMLButtonElement>) => {
+    playButtonClick();
+    props.onClick?.(e);
+  };
+
+  const resolvedClassName = (() => {
+    // macOS: default/secondary/retro → aqua-button
+    if (isMacOSTheme && variant === "default") return cn("aqua-button primary", className);
+    if (isMacOSTheme && variant === "secondary") return cn("aqua-button secondary", className);
+    if (isMacOSTheme && variant === "retro") return cn("aqua-button secondary", className);
+
+    // macOS: aqua_select → CSS-driven aqua select button
+    if (isMacOSTheme && variant === "aqua_select") {
+      const dataState = (props as Record<string, unknown>)["data-state"];
+      const ariaPressed = (props as Record<string, unknown>)["aria-pressed"];
+      const isActiveSelected = dataState === "on" || ariaPressed === true;
+      return cn(
+        "macos-select-trigger no-chevron aqua-select-btn os-btn-aqua-select inline-flex w-auto items-center justify-center whitespace-nowrap rounded px-2 py-1 text-sm gap-0",
+        isActiveSelected && "aqua-selected",
+        className
+      );
+    }
+
+    // XP/Win98: default/aqua_select → xp.css button class
+    if (isXpTheme && (variant === "default" || variant === "aqua_select")) return cn("button", className);
+
+    // XP/Win98 + macOS: ghost → transparent reset to fight global button styles
+    if ((isXpTheme || isMacOSTheme) && variant === "ghost") {
+      return cn(buttonVariants({ variant, size }), "os-btn-ghost-reset", className);
+    }
+
+    return cn(buttonVariants({ variant, size, className }));
+  })();
+
+  const resolvedStyle = (() => {
+    if (isMacOSTheme && (variant === "default" || variant === "secondary" || variant === "retro")) {
+      return { position: "relative" as const, zIndex: 1, ...props.style };
+    }
+    return props.style;
+  })();
+
+  return (
+    <Comp
+      className={resolvedClassName}
+      ref={ref}
+      style={resolvedStyle}
+      {...props}
+      onClick={handleClick}
+    />
+  );
+};
 Button.displayName = "Button";
 
 export { Button };

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -57,7 +57,7 @@ const Button = (
     asChild = false,
     ...props
   }: ButtonProps & {
-    ref: React.RefObject<HTMLButtonElement>;
+    ref?: React.Ref<HTMLButtonElement>;
   }
 ) => {
   const { play: playButtonClick } = useSound(Sounds.BUTTON_CLICK);

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -2,75 +2,93 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-const Card = React.forwardRef<
-  HTMLDivElement,
-  React.HTMLAttributes<HTMLDivElement>
->(({ className, ...props }, ref) => (
-  <div
-    ref={ref}
-    className={cn(
-      "rounded-xl border bg-card text-card-foreground shadow",
-      className
-    )}
-    {...props}
-  />
-))
+const Card = (
+  {
+    ref,
+    className,
+    ...props
+  }: React.HTMLAttributes<HTMLDivElement> & {
+    ref: React.RefObject<HTMLDivElement>;
+  }
+) => (<div
+  ref={ref}
+  className={cn(
+    "rounded-xl border bg-card text-card-foreground shadow",
+    className
+  )}
+  {...props}
+/>)
 Card.displayName = "Card"
 
-const CardHeader = React.forwardRef<
-  HTMLDivElement,
-  React.HTMLAttributes<HTMLDivElement>
->(({ className, ...props }, ref) => (
-  <div
-    ref={ref}
-    className={cn("flex flex-col space-y-1.5 p-6", className)}
-    {...props}
-  />
-))
+const CardHeader = (
+  {
+    ref,
+    className,
+    ...props
+  }: React.HTMLAttributes<HTMLDivElement> & {
+    ref: React.RefObject<HTMLDivElement>;
+  }
+) => (<div
+  ref={ref}
+  className={cn("flex flex-col space-y-1.5 p-6", className)}
+  {...props}
+/>)
 CardHeader.displayName = "CardHeader"
 
-const CardTitle = React.forwardRef<
-  HTMLDivElement,
-  React.HTMLAttributes<HTMLDivElement>
->(({ className, ...props }, ref) => (
-  <div
-    ref={ref}
-    className={cn("font-semibold leading-none tracking-tight", className)}
-    {...props}
-  />
-))
+const CardTitle = (
+  {
+    ref,
+    className,
+    ...props
+  }: React.HTMLAttributes<HTMLDivElement> & {
+    ref: React.RefObject<HTMLDivElement>;
+  }
+) => (<div
+  ref={ref}
+  className={cn("font-semibold leading-none tracking-tight", className)}
+  {...props}
+/>)
 CardTitle.displayName = "CardTitle"
 
-const CardDescription = React.forwardRef<
-  HTMLDivElement,
-  React.HTMLAttributes<HTMLDivElement>
->(({ className, ...props }, ref) => (
-  <div
-    ref={ref}
-    className={cn("text-sm text-muted-foreground", className)}
-    {...props}
-  />
-))
+const CardDescription = (
+  {
+    ref,
+    className,
+    ...props
+  }: React.HTMLAttributes<HTMLDivElement> & {
+    ref: React.RefObject<HTMLDivElement>;
+  }
+) => (<div
+  ref={ref}
+  className={cn("text-sm text-muted-foreground", className)}
+  {...props}
+/>)
 CardDescription.displayName = "CardDescription"
 
-const CardContent = React.forwardRef<
-  HTMLDivElement,
-  React.HTMLAttributes<HTMLDivElement>
->(({ className, ...props }, ref) => (
-  <div ref={ref} className={cn("p-6 pt-0", className)} {...props} />
-))
+const CardContent = (
+  {
+    ref,
+    className,
+    ...props
+  }: React.HTMLAttributes<HTMLDivElement> & {
+    ref: React.RefObject<HTMLDivElement>;
+  }
+) => (<div ref={ref} className={cn("p-6 pt-0", className)} {...props} />)
 CardContent.displayName = "CardContent"
 
-const CardFooter = React.forwardRef<
-  HTMLDivElement,
-  React.HTMLAttributes<HTMLDivElement>
->(({ className, ...props }, ref) => (
-  <div
-    ref={ref}
-    className={cn("flex items-center p-6 pt-0", className)}
-    {...props}
-  />
-))
+const CardFooter = (
+  {
+    ref,
+    className,
+    ...props
+  }: React.HTMLAttributes<HTMLDivElement> & {
+    ref: React.RefObject<HTMLDivElement>;
+  }
+) => (<div
+  ref={ref}
+  className={cn("flex items-center p-6 pt-0", className)}
+  {...props}
+/>)
 CardFooter.displayName = "CardFooter"
 
 export { Card, CardHeader, CardFooter, CardTitle, CardDescription, CardContent }

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -8,7 +8,7 @@ const Card = (
     className,
     ...props
   }: React.HTMLAttributes<HTMLDivElement> & {
-    ref: React.RefObject<HTMLDivElement>;
+    ref?: React.Ref<HTMLDivElement>;
   }
 ) => (<div
   ref={ref}
@@ -26,7 +26,7 @@ const CardHeader = (
     className,
     ...props
   }: React.HTMLAttributes<HTMLDivElement> & {
-    ref: React.RefObject<HTMLDivElement>;
+    ref?: React.Ref<HTMLDivElement>;
   }
 ) => (<div
   ref={ref}
@@ -41,7 +41,7 @@ const CardTitle = (
     className,
     ...props
   }: React.HTMLAttributes<HTMLDivElement> & {
-    ref: React.RefObject<HTMLDivElement>;
+    ref?: React.Ref<HTMLDivElement>;
   }
 ) => (<div
   ref={ref}
@@ -56,7 +56,7 @@ const CardDescription = (
     className,
     ...props
   }: React.HTMLAttributes<HTMLDivElement> & {
-    ref: React.RefObject<HTMLDivElement>;
+    ref?: React.Ref<HTMLDivElement>;
   }
 ) => (<div
   ref={ref}
@@ -71,7 +71,7 @@ const CardContent = (
     className,
     ...props
   }: React.HTMLAttributes<HTMLDivElement> & {
-    ref: React.RefObject<HTMLDivElement>;
+    ref?: React.Ref<HTMLDivElement>;
   }
 ) => (<div ref={ref} className={cn("p-6 pt-0", className)} {...props} />)
 CardContent.displayName = "CardContent"
@@ -82,7 +82,7 @@ const CardFooter = (
     className,
     ...props
   }: React.HTMLAttributes<HTMLDivElement> & {
-    ref: React.RefObject<HTMLDivElement>;
+    ref?: React.Ref<HTMLDivElement>;
   }
 ) => (<div
   ref={ref}

--- a/src/components/ui/dial.tsx
+++ b/src/components/ui/dial.tsx
@@ -15,181 +15,181 @@ interface DialProps {
   className?: string;
 }
 
-const Dial = React.forwardRef<HTMLDivElement, DialProps>(
-  (
-    {
-      className,
-      value,
-      min,
-      max,
-      step = 0.01,
-      onChange,
-      size = "md",
-      color = "#ff8800",
-      label,
-      showValue = true,
-      valueFormatter = (value) => value.toFixed(2),
-    },
-    ref
-  ) => {
-    const dialRef = React.useRef<HTMLDivElement>(null);
-    const valueRef = React.useRef<HTMLDivElement>(null);
-    const [isDragging, setIsDragging] = React.useState(false);
-    const [isDraggingValue, setIsDraggingValue] = React.useState(false);
-    const [startX, setStartX] = React.useState(0);
-    const [startValue, setStartValue] = React.useState(0);
+const Dial = (
+  {
+    ref,
+    className,
+    value,
+    min,
+    max,
+    step = 0.01,
+    onChange,
+    size = "md",
+    color = "#ff8800",
+    label,
+    showValue = true,
+    valueFormatter = (value) => value.toFixed(2)
+  }: DialProps & {
+    ref: React.RefObject<HTMLDivElement>;
+  }
+) => {
+  const dialRef = React.useRef<HTMLDivElement>(null);
+  const valueRef = React.useRef<HTMLDivElement>(null);
+  const [isDragging, setIsDragging] = React.useState(false);
+  const [isDraggingValue, setIsDraggingValue] = React.useState(false);
+  const [startX, setStartX] = React.useState(0);
+  const [startValue, setStartValue] = React.useState(0);
 
-    const handleMouseDown = (e: React.MouseEvent) => {
-      e.preventDefault();
-      setIsDragging(true);
-      setStartX(e.clientX);
-      setStartValue(value);
-    };
+  const handleMouseDown = (e: React.MouseEvent) => {
+    e.preventDefault();
+    setIsDragging(true);
+    setStartX(e.clientX);
+    setStartValue(value);
+  };
 
-    const handleValueMouseDown = (e: React.MouseEvent) => {
-      e.preventDefault();
-      e.stopPropagation();
-      setIsDraggingValue(true);
-      setStartX(e.clientX);
-      setStartValue(value);
-    };
+  const handleValueMouseDown = (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setIsDraggingValue(true);
+    setStartX(e.clientX);
+    setStartValue(value);
+  };
 
-    const handleTouchStart = (e: React.TouchEvent) => {
-      e.preventDefault();
-      setIsDragging(true);
-      setStartX(e.touches[0].clientX);
-      setStartValue(value);
-    };
+  const handleTouchStart = (e: React.TouchEvent) => {
+    e.preventDefault();
+    setIsDragging(true);
+    setStartX(e.touches[0].clientX);
+    setStartValue(value);
+  };
 
-    const handleValueTouchStart = (e: React.TouchEvent) => {
-      e.preventDefault();
-      e.stopPropagation();
-      setIsDraggingValue(true);
-      setStartX(e.touches[0].clientX);
-      setStartValue(value);
-    };
+  const handleValueTouchStart = (e: React.TouchEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setIsDraggingValue(true);
+    setStartX(e.touches[0].clientX);
+    setStartValue(value);
+  };
 
-    const handleMove = React.useCallback(
-      (clientX: number, isDraggingTarget: boolean) => {
-        if (!isDraggingTarget) return;
+  const handleMove = React.useCallback(
+    (clientX: number, isDraggingTarget: boolean) => {
+      if (!isDraggingTarget) return;
 
-        // Calculate horizontal movement (positive = right, negative = left)
-        const deltaX = clientX - startX;
+      // Calculate horizontal movement (positive = right, negative = left)
+      const deltaX = clientX - startX;
 
-        // Sensitivity factor - higher means more movement per pixel
-        const sensitivity = 2;
+      // Sensitivity factor - higher means more movement per pixel
+      const sensitivity = 2;
 
-        // Calculate new value based on movement
-        const range = max - min;
-        const valueChange = (deltaX * sensitivity * range) / 200;
-        let newValue = startValue + valueChange;
+      // Calculate new value based on movement
+      const range = max - min;
+      const valueChange = (deltaX * sensitivity * range) / 200;
+      let newValue = startValue + valueChange;
 
-        // Clamp value to min/max
-        newValue = Math.max(min, Math.min(max, newValue));
+      // Clamp value to min/max
+      newValue = Math.max(min, Math.min(max, newValue));
 
-        // Round to nearest step
-        if (step) {
-          newValue = Math.round(newValue / step) * step;
-        }
-
-        onChange(newValue);
-      },
-      [max, min, onChange, startValue, startX, step]
-    );
-
-    // Add and remove event listeners
-    React.useEffect(() => {
-      const handleGlobalMouseMove = (e: MouseEvent) => {
-        handleMove(e.clientX, isDragging);
-        handleMove(e.clientX, isDraggingValue);
-      };
-
-      const handleGlobalTouchMove = (e: TouchEvent) => {
-        handleMove(e.touches[0].clientX, isDragging);
-        handleMove(e.touches[0].clientX, isDraggingValue);
-      };
-
-      const handleGlobalMouseUp = () => {
-        setIsDragging(false);
-        setIsDraggingValue(false);
-      };
-
-      const handleGlobalTouchEnd = () => {
-        setIsDragging(false);
-        setIsDraggingValue(false);
-      };
-
-      if (isDragging || isDraggingValue) {
-        document.addEventListener("mousemove", handleGlobalMouseMove);
-        document.addEventListener("touchmove", handleGlobalTouchMove);
-        document.addEventListener("mouseup", handleGlobalMouseUp);
-        document.addEventListener("touchend", handleGlobalTouchEnd);
+      // Round to nearest step
+      if (step) {
+        newValue = Math.round(newValue / step) * step;
       }
 
-      return () => {
-        document.removeEventListener("mousemove", handleGlobalMouseMove);
-        document.removeEventListener("touchmove", handleGlobalTouchMove);
-        document.removeEventListener("mouseup", handleGlobalMouseUp);
-        document.removeEventListener("touchend", handleGlobalTouchEnd);
-      };
-    }, [isDragging, isDraggingValue, startX, startValue, min, max, step, handleMove]);
+      onChange(newValue);
+    },
+    [max, min, onChange, startValue, startX, step]
+  );
 
-    // Size classes
-    const sizeClasses = {
-      sm: "w-8 h-8",
-      md: "w-12 h-12",
-      lg: "w-14 h-14",
+  // Add and remove event listeners
+  React.useEffect(() => {
+    const handleGlobalMouseMove = (e: MouseEvent) => {
+      handleMove(e.clientX, isDragging);
+      handleMove(e.clientX, isDraggingValue);
     };
 
-    // Calculate the percentage for the background fill
-    const percentage = ((value - min) / (max - min)) * 100;
+    const handleGlobalTouchMove = (e: TouchEvent) => {
+      handleMove(e.touches[0].clientX, isDragging);
+      handleMove(e.touches[0].clientX, isDraggingValue);
+    };
 
-    return (
-      <div className={cn("flex flex-col items-center no-select-gesture", className)} ref={ref}>
-        {label && (
-          <div
-            ref={valueRef}
-            className={cn(
-              "mb-1 font-geneva-12 text-center cursor-ew-resize select-none no-select-gesture",
-              isDraggingValue && "text-[#ff00ff]"
-            )}
-            style={{
-              touchAction: "none",
-              WebkitUserSelect: "none",
-              WebkitTouchCallout: "none",
-            }}
-            onMouseDown={handleValueMouseDown}
-            onTouchStart={handleValueTouchStart}
-          >
-            <div className="text-[10px] text-gray-400">{label}</div>
-            {showValue && (
-              <div className="text-xs">{valueFormatter(value)}</div>
-            )}
-          </div>
-        )}
+    const handleGlobalMouseUp = () => {
+      setIsDragging(false);
+      setIsDraggingValue(false);
+    };
+
+    const handleGlobalTouchEnd = () => {
+      setIsDragging(false);
+      setIsDraggingValue(false);
+    };
+
+    if (isDragging || isDraggingValue) {
+      document.addEventListener("mousemove", handleGlobalMouseMove);
+      document.addEventListener("touchmove", handleGlobalTouchMove);
+      document.addEventListener("mouseup", handleGlobalMouseUp);
+      document.addEventListener("touchend", handleGlobalTouchEnd);
+    }
+
+    return () => {
+      document.removeEventListener("mousemove", handleGlobalMouseMove);
+      document.removeEventListener("touchmove", handleGlobalTouchMove);
+      document.removeEventListener("mouseup", handleGlobalMouseUp);
+      document.removeEventListener("touchend", handleGlobalTouchEnd);
+    };
+  }, [isDragging, isDraggingValue, startX, startValue, min, max, step, handleMove]);
+
+  // Size classes
+  const sizeClasses = {
+    sm: "w-8 h-8",
+    md: "w-12 h-12",
+    lg: "w-14 h-14",
+  };
+
+  // Calculate the percentage for the background fill
+  const percentage = ((value - min) / (max - min)) * 100;
+
+  return (
+    <div className={cn("flex flex-col items-center no-select-gesture", className)} ref={ref}>
+      {label && (
         <div
-          ref={dialRef}
+          ref={valueRef}
           className={cn(
-            "relative rounded-full bg-[#333] cursor-ew-resize select-none no-select-gesture",
-            sizeClasses[size],
-            isDragging && "ring-1 ring-[#ff00ff]"
+            "mb-1 font-geneva-12 text-center cursor-ew-resize select-none no-select-gesture",
+            isDraggingValue && "text-[#ff00ff]"
           )}
           style={{
-            background: `conic-gradient(${color} 0% ${percentage}%, #333 ${percentage}% 100%)`,
             touchAction: "none",
             WebkitUserSelect: "none",
             WebkitTouchCallout: "none",
           }}
-          onMouseDown={handleMouseDown}
-          onTouchStart={handleTouchStart}
+          onMouseDown={handleValueMouseDown}
+          onTouchStart={handleValueTouchStart}
         >
-          {/* Center circle */}
-          <div className="absolute top-1/2 left-1/2 w-4 h-4 -translate-x-1/2 -translate-y-1/2 rounded-full bg-[#222]"></div>
+          <div className="text-[10px] text-gray-400">{label}</div>
+          {showValue && (
+            <div className="text-xs">{valueFormatter(value)}</div>
+          )}
         </div>
+      )}
+      <div
+        ref={dialRef}
+        className={cn(
+          "relative rounded-full bg-[#333] cursor-ew-resize select-none no-select-gesture",
+          sizeClasses[size],
+          isDragging && "ring-1 ring-[#ff00ff]"
+        )}
+        style={{
+          background: `conic-gradient(${color} 0% ${percentage}%, #333 ${percentage}% 100%)`,
+          touchAction: "none",
+          WebkitUserSelect: "none",
+          WebkitTouchCallout: "none",
+        }}
+        onMouseDown={handleMouseDown}
+        onTouchStart={handleTouchStart}
+      >
+        {/* Center circle */}
+        <div className="absolute top-1/2 left-1/2 w-4 h-4 -translate-x-1/2 -translate-y-1/2 rounded-full bg-[#222]"></div>
       </div>
-    );
-  }
-);
+    </div>
+  );
+};
 
 Dial.displayName = "Dial";
 

--- a/src/components/ui/dial.tsx
+++ b/src/components/ui/dial.tsx
@@ -30,7 +30,7 @@ const Dial = (
     showValue = true,
     valueFormatter = (value) => value.toFixed(2)
   }: DialProps & {
-    ref: React.RefObject<HTMLDivElement>;
+    ref?: React.Ref<HTMLDivElement>;
   }
 ) => {
   const dialRef = React.useRef<HTMLDivElement>(null);

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -68,7 +68,7 @@ const DialogContent = (
     overlayClassName,
     ...props
   }: DialogContentProps & {
-    ref: React.RefObject<React.ElementRef<typeof DialogPrimitive.Content>>;
+    ref?: React.Ref<React.ElementRef<typeof DialogPrimitive.Content>>;
   }
 ) => {
   const { isXpTheme, isMacOSTheme, isSystem7Theme } = useThemeFlags();
@@ -274,7 +274,7 @@ const DialogTitle = (
     className,
     ...props
   }: React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title> & {
-    ref: React.RefObject<React.ElementRef<typeof DialogPrimitive.Title>>;
+    ref?: React.Ref<React.ElementRef<typeof DialogPrimitive.Title>>;
   }
 ) => (<DialogPrimitive.Title
   ref={ref}
@@ -292,7 +292,7 @@ const DialogDescription = (
     className,
     ...props
   }: React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description> & {
-    ref: React.RefObject<React.ElementRef<typeof DialogPrimitive.Description>>;
+    ref?: React.Ref<React.ElementRef<typeof DialogPrimitive.Description>>;
   }
 ) => (<DialogPrimitive.Description
   ref={ref}

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -60,10 +60,17 @@ interface DialogContentProps
   overlayClassName?: string;
 }
 
-const DialogContent = React.forwardRef<
-  React.ElementRef<typeof DialogPrimitive.Content>,
-  DialogContentProps
->(({ className, children, overlayClassName, ...props }, ref) => {
+const DialogContent = (
+  {
+    ref,
+    className,
+    children,
+    overlayClassName,
+    ...props
+  }: DialogContentProps & {
+    ref: React.RefObject<React.ElementRef<typeof DialogPrimitive.Content>>;
+  }
+) => {
   const { isXpTheme, isMacOSTheme, isSystem7Theme } = useThemeFlags();
 
   // Function to clean up pointer-events
@@ -137,7 +144,7 @@ const DialogContent = React.forwardRef<
       </DialogPrimitive.Content>
     </DialogPortal>
   );
-});
+};
 DialogContent.displayName = DialogPrimitive.Content.displayName;
 
 const DialogHeader = ({
@@ -261,31 +268,37 @@ const DialogFooter = ({
 );
 DialogFooter.displayName = "DialogFooter";
 
-const DialogTitle = React.forwardRef<
-  React.ElementRef<typeof DialogPrimitive.Title>,
-  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
->(({ className, ...props }, ref) => (
-  <DialogPrimitive.Title
-    ref={ref}
-    className={cn(
-      "text-lg font-semibold leading-none tracking-tight",
-      className
-    )}
-    {...props}
-  />
-));
+const DialogTitle = (
+  {
+    ref,
+    className,
+    ...props
+  }: React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title> & {
+    ref: React.RefObject<React.ElementRef<typeof DialogPrimitive.Title>>;
+  }
+) => (<DialogPrimitive.Title
+  ref={ref}
+  className={cn(
+    "text-lg font-semibold leading-none tracking-tight",
+    className
+  )}
+  {...props}
+/>);
 DialogTitle.displayName = DialogPrimitive.Title.displayName;
 
-const DialogDescription = React.forwardRef<
-  React.ElementRef<typeof DialogPrimitive.Description>,
-  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
->(({ className, ...props }, ref) => (
-  <DialogPrimitive.Description
-    ref={ref}
-    className={cn("text-sm text-muted-foreground", className)}
-    {...props}
-  />
-));
+const DialogDescription = (
+  {
+    ref,
+    className,
+    ...props
+  }: React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description> & {
+    ref: React.RefObject<React.ElementRef<typeof DialogPrimitive.Description>>;
+  }
+) => (<DialogPrimitive.Description
+  ref={ref}
+  className={cn("text-sm text-muted-foreground", className)}
+  {...props}
+/>);
 DialogDescription.displayName = DialogPrimitive.Description.displayName;
 
 export {

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -33,10 +33,16 @@ const DropdownMenu = ({
 };
 DropdownMenu.displayName = DropdownMenuPrimitive.Root.displayName;
 
-const DropdownMenuTrigger = React.forwardRef<
-  React.ElementRef<typeof DropdownMenuPrimitive.Trigger>,
-  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Trigger>
->(({ className, style, ...props }, ref) => {
+const DropdownMenuTrigger = (
+  {
+    ref,
+    className,
+    style,
+    ...props
+  }: React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Trigger> & {
+    ref: React.RefObject<React.ElementRef<typeof DropdownMenuPrimitive.Trigger>>;
+  }
+) => {
   const { isMacOSTheme } = useThemeFlags();
 
   const macosTextShadow = isMacOSTheme
@@ -53,7 +59,7 @@ const DropdownMenuTrigger = React.forwardRef<
       {...props}
     />
   );
-});
+};
 DropdownMenuTrigger.displayName = DropdownMenuPrimitive.Trigger.displayName;
 
 const DropdownMenuGroup = DropdownMenuPrimitive.Group;
@@ -64,12 +70,15 @@ const DropdownMenuSub = DropdownMenuPrimitive.Sub;
 
 const DropdownMenuRadioGroup = DropdownMenuPrimitive.RadioGroup;
 
-const DropdownMenuSubTrigger = React.forwardRef<
-  React.ElementRef<typeof DropdownMenuPrimitive.SubTrigger>,
-  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubTrigger> & {
-    inset?: boolean;
+const DropdownMenuSubTrigger = (
+  {
+    ref,
+    className,
+    inset,
+    children,
+    ...props
   }
->(({ className, inset, children, ...props }, ref) => {
+) => {
   const { isWindowsTheme, isMacOSTheme } = useThemeFlags();
 
   return (
@@ -103,14 +112,20 @@ const DropdownMenuSubTrigger = React.forwardRef<
       <CaretRight className="ml-auto" size={12} weight="bold" />
     </DropdownMenuPrimitive.SubTrigger>
   );
-});
+};
 DropdownMenuSubTrigger.displayName =
   DropdownMenuPrimitive.SubTrigger.displayName;
 
-const DropdownMenuSubContent = React.forwardRef<
-  React.ElementRef<typeof DropdownMenuPrimitive.SubContent>,
-  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubContent>
->(({ className, style, ...props }, ref) => {
+const DropdownMenuSubContent = (
+  {
+    ref,
+    className,
+    style,
+    ...props
+  }: React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubContent> & {
+    ref: React.RefObject<React.ElementRef<typeof DropdownMenuPrimitive.SubContent>>;
+  }
+) => {
   const { isMacOSTheme } = useThemeFlags();
   const isMobile = useMediaQuery("(max-width: 768px)");
 
@@ -140,16 +155,20 @@ const DropdownMenuSubContent = React.forwardRef<
       />
     </DropdownMenuPrimitive.Portal>
   );
-});
+};
 DropdownMenuSubContent.displayName =
   DropdownMenuPrimitive.SubContent.displayName;
 
-const DropdownMenuContent = React.forwardRef<
-  React.ElementRef<typeof DropdownMenuPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Content> & {
-    container?: HTMLElement | null;
+const DropdownMenuContent = (
+  {
+    ref,
+    className,
+    sideOffset = 4,
+    style,
+    container,
+    ...props
   }
->(({ className, sideOffset = 4, style, container, ...props }, ref) => {
+) => {
   const { isMacOSTheme } = useThemeFlags();
   const isMobile = useMediaQuery("(max-width: 768px)");
 
@@ -182,15 +201,17 @@ const DropdownMenuContent = React.forwardRef<
       />
     </DropdownMenuPrimitive.Portal>
   );
-});
+};
 DropdownMenuContent.displayName = DropdownMenuPrimitive.Content.displayName;
 
-const DropdownMenuItem = React.forwardRef<
-  React.ElementRef<typeof DropdownMenuPrimitive.Item>,
-  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Item> & {
-    inset?: boolean;
+const DropdownMenuItem = (
+  {
+    ref,
+    className,
+    inset,
+    ...props
   }
->(({ className, inset, ...props }, ref) => {
+) => {
   const { isWindowsTheme, isMacOSTheme } = useThemeFlags();
 
   return (
@@ -222,13 +243,20 @@ const DropdownMenuItem = React.forwardRef<
       {...props}
     />
   );
-});
+};
 DropdownMenuItem.displayName = DropdownMenuPrimitive.Item.displayName;
 
-const DropdownMenuCheckboxItem = React.forwardRef<
-  React.ElementRef<typeof DropdownMenuPrimitive.CheckboxItem>,
-  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.CheckboxItem>
->(({ className, children, checked, ...props }, ref) => {
+const DropdownMenuCheckboxItem = (
+  {
+    ref,
+    className,
+    children,
+    checked,
+    ...props
+  }: React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.CheckboxItem> & {
+    ref: React.RefObject<React.ElementRef<typeof DropdownMenuPrimitive.CheckboxItem>>;
+  }
+) => {
   const {
     isWindowsTheme,
     isMacOSTheme,
@@ -280,14 +308,20 @@ const DropdownMenuCheckboxItem = React.forwardRef<
       {children}
     </DropdownMenuPrimitive.CheckboxItem>
   );
-});
+};
 DropdownMenuCheckboxItem.displayName =
   DropdownMenuPrimitive.CheckboxItem.displayName;
 
-const DropdownMenuRadioItem = React.forwardRef<
-  React.ElementRef<typeof DropdownMenuPrimitive.RadioItem>,
-  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.RadioItem>
->(({ className, children, ...props }, ref) => {
+const DropdownMenuRadioItem = (
+  {
+    ref,
+    className,
+    children,
+    ...props
+  }: React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.RadioItem> & {
+    ref: React.RefObject<React.ElementRef<typeof DropdownMenuPrimitive.RadioItem>>;
+  }
+) => {
   const { isWindowsTheme, isMacOSTheme } = useThemeFlags();
 
   return (
@@ -312,15 +346,17 @@ const DropdownMenuRadioItem = React.forwardRef<
       {children}
     </DropdownMenuPrimitive.RadioItem>
   );
-});
+};
 DropdownMenuRadioItem.displayName = DropdownMenuPrimitive.RadioItem.displayName;
 
-const DropdownMenuLabel = React.forwardRef<
-  React.ElementRef<typeof DropdownMenuPrimitive.Label>,
-  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Label> & {
-    inset?: boolean;
+const DropdownMenuLabel = (
+  {
+    ref,
+    className,
+    inset,
+    ...props
   }
->(({ className, inset, ...props }, ref) => {
+) => {
   const { isWindowsTheme, isMacOSTheme } = useThemeFlags();
 
   return (
@@ -339,13 +375,18 @@ const DropdownMenuLabel = React.forwardRef<
       {...props}
     />
   );
-});
+};
 DropdownMenuLabel.displayName = DropdownMenuPrimitive.Label.displayName;
 
-const DropdownMenuSeparator = React.forwardRef<
-  React.ElementRef<typeof DropdownMenuPrimitive.Separator>,
-  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Separator>
->(({ className, ...props }, ref) => {
+const DropdownMenuSeparator = (
+  {
+    ref,
+    className,
+    ...props
+  }: React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Separator> & {
+    ref: React.RefObject<React.ElementRef<typeof DropdownMenuPrimitive.Separator>>;
+  }
+) => {
   const { isSystem7Theme, isMacOSTheme } = useThemeFlags();
 
   return (
@@ -369,7 +410,7 @@ const DropdownMenuSeparator = React.forwardRef<
       {...props}
     />
   );
-});
+};
 DropdownMenuSeparator.displayName = DropdownMenuPrimitive.Separator.displayName;
 
 const DropdownMenuShortcut = ({

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -40,7 +40,7 @@ const DropdownMenuTrigger = (
     style,
     ...props
   }: React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Trigger> & {
-    ref: React.RefObject<React.ElementRef<typeof DropdownMenuPrimitive.Trigger>>;
+    ref?: React.Ref<React.ElementRef<typeof DropdownMenuPrimitive.Trigger>>;
   }
 ) => {
   const { isMacOSTheme } = useThemeFlags();
@@ -77,6 +77,9 @@ const DropdownMenuSubTrigger = (
     inset,
     children,
     ...props
+  }: React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubTrigger> & {
+    inset?: boolean;
+    ref?: React.Ref<React.ElementRef<typeof DropdownMenuPrimitive.SubTrigger>>;
   }
 ) => {
   const { isWindowsTheme, isMacOSTheme } = useThemeFlags();
@@ -123,7 +126,7 @@ const DropdownMenuSubContent = (
     style,
     ...props
   }: React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubContent> & {
-    ref: React.RefObject<React.ElementRef<typeof DropdownMenuPrimitive.SubContent>>;
+    ref?: React.Ref<React.ElementRef<typeof DropdownMenuPrimitive.SubContent>>;
   }
 ) => {
   const { isMacOSTheme } = useThemeFlags();
@@ -167,6 +170,9 @@ const DropdownMenuContent = (
     style,
     container,
     ...props
+  }: React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Content> & {
+    container?: HTMLElement | null;
+    ref?: React.Ref<React.ElementRef<typeof DropdownMenuPrimitive.Content>>;
   }
 ) => {
   const { isMacOSTheme } = useThemeFlags();
@@ -210,6 +216,9 @@ const DropdownMenuItem = (
     className,
     inset,
     ...props
+  }: React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Item> & {
+    inset?: boolean;
+    ref?: React.Ref<React.ElementRef<typeof DropdownMenuPrimitive.Item>>;
   }
 ) => {
   const { isWindowsTheme, isMacOSTheme } = useThemeFlags();
@@ -254,7 +263,7 @@ const DropdownMenuCheckboxItem = (
     checked,
     ...props
   }: React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.CheckboxItem> & {
-    ref: React.RefObject<React.ElementRef<typeof DropdownMenuPrimitive.CheckboxItem>>;
+    ref?: React.Ref<React.ElementRef<typeof DropdownMenuPrimitive.CheckboxItem>>;
   }
 ) => {
   const {
@@ -319,7 +328,7 @@ const DropdownMenuRadioItem = (
     children,
     ...props
   }: React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.RadioItem> & {
-    ref: React.RefObject<React.ElementRef<typeof DropdownMenuPrimitive.RadioItem>>;
+    ref?: React.Ref<React.ElementRef<typeof DropdownMenuPrimitive.RadioItem>>;
   }
 ) => {
   const { isWindowsTheme, isMacOSTheme } = useThemeFlags();
@@ -355,6 +364,9 @@ const DropdownMenuLabel = (
     className,
     inset,
     ...props
+  }: React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Label> & {
+    inset?: boolean;
+    ref?: React.Ref<React.ElementRef<typeof DropdownMenuPrimitive.Label>>;
   }
 ) => {
   const { isWindowsTheme, isMacOSTheme } = useThemeFlags();
@@ -384,7 +396,7 @@ const DropdownMenuSeparator = (
     className,
     ...props
   }: React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Separator> & {
-    ref: React.RefObject<React.ElementRef<typeof DropdownMenuPrimitive.Separator>>;
+    ref?: React.Ref<React.ElementRef<typeof DropdownMenuPrimitive.Separator>>;
   }
 ) => {
   const { isSystem7Theme, isMacOSTheme } = useThemeFlags();

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -16,7 +16,7 @@ const Input = (
     style,
     ...props
   }: InputProps & {
-    ref: React.RefObject<HTMLInputElement>;
+    ref?: React.Ref<HTMLInputElement>;
   }
 ) => {
   const {

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -7,33 +7,42 @@ interface InputProps extends React.ComponentProps<"input"> {
   unstyled?: boolean;
 }
 
-const Input = React.forwardRef<HTMLInputElement, InputProps>(
-  ({ className, unstyled = false, type, style, ...props }, ref) => {
-    const {
-      currentTheme,
-      isMacOSTheme,
-      isSystem7Theme,
-      isWindowsTheme: isWinTheme,
-    } = useThemeFlags();
-
-    return (
-      <input
-        type={type}
-        data-theme-input={!unstyled ? currentTheme : undefined}
-        className={cn(
-          "flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-base transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
-          !unstyled && isMacOSTheme && "os-themed-input",
-          !unstyled && isSystem7Theme && "os-themed-input-system7",
-          !unstyled && isWinTheme && "os-themed-input-win",
-          className
-        )}
-        style={style}
-        ref={ref}
-        {...props}
-      />
-    );
+const Input = (
+  {
+    ref,
+    className,
+    unstyled = false,
+    type,
+    style,
+    ...props
+  }: InputProps & {
+    ref: React.RefObject<HTMLInputElement>;
   }
-);
+) => {
+  const {
+    currentTheme,
+    isMacOSTheme,
+    isSystem7Theme,
+    isWindowsTheme: isWinTheme,
+  } = useThemeFlags();
+
+  return (
+    <input
+      type={type}
+      data-theme-input={!unstyled ? currentTheme : undefined}
+      className={cn(
+        "flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-base transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        !unstyled && isMacOSTheme && "os-themed-input",
+        !unstyled && isSystem7Theme && "os-themed-input-system7",
+        !unstyled && isWinTheme && "os-themed-input-win",
+        className
+      )}
+      style={style}
+      ref={ref}
+      {...props}
+    />
+  );
+};
 Input.displayName = "Input";
 
 export { Input };

--- a/src/components/ui/label.tsx
+++ b/src/components/ui/label.tsx
@@ -10,17 +10,17 @@ const labelVariants = cva(
   "text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
 )
 
-const Label = React.forwardRef<
-  React.ElementRef<typeof LabelPrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root> &
-    VariantProps<typeof labelVariants>
->(({ className, ...props }, ref) => (
-  <LabelPrimitive.Root
-    ref={ref}
-    className={cn(labelVariants(), className)}
-    {...props}
-  />
-))
+const Label = (
+  {
+    ref,
+    className,
+    ...props
+  }
+) => (<LabelPrimitive.Root
+  ref={ref}
+  className={cn(labelVariants(), className)}
+  {...props}
+/>)
 Label.displayName = LabelPrimitive.Root.displayName
 
 export { Label }

--- a/src/components/ui/label.tsx
+++ b/src/components/ui/label.tsx
@@ -15,7 +15,10 @@ const Label = (
     ref,
     className,
     ...props
-  }
+  }: React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root> &
+    VariantProps<typeof labelVariants> & {
+      ref?: React.Ref<React.ElementRef<typeof LabelPrimitive.Root>>
+    }
 ) => (<LabelPrimitive.Root
   ref={ref}
   className={cn(labelVariants(), className)}

--- a/src/components/ui/menubar.tsx
+++ b/src/components/ui/menubar.tsx
@@ -20,10 +20,16 @@ const MenubarSub = MenubarPrimitive.Sub
 
 const MenubarRadioGroup = MenubarPrimitive.RadioGroup
 
-const Menubar = React.forwardRef<
-  React.ElementRef<typeof MenubarPrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof MenubarPrimitive.Root>
->(({ className, onValueChange, ...props }, ref) => {
+const Menubar = (
+  {
+    ref,
+    className,
+    onValueChange,
+    ...props
+  }: React.ComponentPropsWithoutRef<typeof MenubarPrimitive.Root> & {
+    ref: React.RefObject<React.ElementRef<typeof MenubarPrimitive.Root>>;
+  }
+) => {
   const { play: playMenuOpen } = useSound(Sounds.MENU_OPEN)
   const { play: playMenuClose } = useSound(Sounds.MENU_CLOSE)
   const [previousValue, setPreviousValue] = React.useState<string | undefined>(undefined)
@@ -60,13 +66,19 @@ const Menubar = React.forwardRef<
       />
     </MenubarSwitchingContext.Provider>
   )
-})
+}
 Menubar.displayName = MenubarPrimitive.Root.displayName
 
-const MenubarTrigger = React.forwardRef<
-  React.ElementRef<typeof MenubarPrimitive.Trigger>,
-  React.ComponentPropsWithoutRef<typeof MenubarPrimitive.Trigger>
->(({ className, style, ...props }, ref) => {
+const MenubarTrigger = (
+  {
+    ref,
+    className,
+    style,
+    ...props
+  }: React.ComponentPropsWithoutRef<typeof MenubarPrimitive.Trigger> & {
+    ref: React.RefObject<React.ElementRef<typeof MenubarPrimitive.Trigger>>;
+  }
+) => {
   const { isWindowsTheme, isSystem7Theme, isMacOSTheme } = useThemeFlags()
 
   // Theme-specific styles for the trigger
@@ -101,15 +113,18 @@ const MenubarTrigger = React.forwardRef<
       {...props}
     />
   )
-})
+}
 MenubarTrigger.displayName = MenubarPrimitive.Trigger.displayName
 
-const MenubarSubTrigger = React.forwardRef<
-  React.ElementRef<typeof MenubarPrimitive.SubTrigger>,
-  React.ComponentPropsWithoutRef<typeof MenubarPrimitive.SubTrigger> & {
-    inset?: boolean
+const MenubarSubTrigger = (
+  {
+    ref,
+    className,
+    inset,
+    children,
+    ...props
   }
->(({ className, inset, children, ...props }, ref) => {
+) => {
   const { isWindowsTheme, isMacOSTheme, isSystem7Theme } = useThemeFlags()
 
   return (
@@ -151,13 +166,19 @@ const MenubarSubTrigger = React.forwardRef<
       <CaretRight className="ml-auto" size={12} weight="bold" />
     </MenubarPrimitive.SubTrigger>
   )
-})
+}
 MenubarSubTrigger.displayName = MenubarPrimitive.SubTrigger.displayName
 
-const MenubarSubContent = React.forwardRef<
-  React.ElementRef<typeof MenubarPrimitive.SubContent>,
-  React.ComponentPropsWithoutRef<typeof MenubarPrimitive.SubContent>
->(({ className, style, ...props }, ref) => {
+const MenubarSubContent = (
+  {
+    ref,
+    className,
+    style,
+    ...props
+  }: React.ComponentPropsWithoutRef<typeof MenubarPrimitive.SubContent> & {
+    ref: React.RefObject<React.ElementRef<typeof MenubarPrimitive.SubContent>>;
+  }
+) => {
   const { isMacOSTheme } = useThemeFlags()
   const isMobile = useMediaQuery("(max-width: 768px)")
 
@@ -187,63 +208,69 @@ const MenubarSubContent = React.forwardRef<
       />
     </MenubarPrimitive.Portal>
   )
-})
+}
 MenubarSubContent.displayName = MenubarPrimitive.SubContent.displayName
 
-const MenubarContent = React.forwardRef<
-  React.ElementRef<typeof MenubarPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof MenubarPrimitive.Content>
->(
-  (
-    { className, align = "start", alignOffset = 0, sideOffset = 8, style, ...props },
-    ref
-  ) => {
-    const { isMacOSTheme } = useThemeFlags()
-    const isMobile = useMediaQuery("(max-width: 768px)")
-    const isSwitching = React.useContext(MenubarSwitchingContext)
-
-    return (
-      <MenubarPrimitive.Portal>
-        <MenubarPrimitive.Content
-          ref={ref}
-          align={align}
-          alignOffset={alignOffset}
-          sideOffset={sideOffset}
-          className={cn(
-            // Use z-[10003] to ensure menu content appears above the menubar (z-[10002])
-            // This is critical for Safari where backdrop-filter creates new stacking contexts
-            "z-[10003] min-w-[12rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md",
-            // Only animate when not switching between menus
-            !isSwitching && "data-[state=open]:animate-in data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
-            className
-          )}
-          style={{
-            ...(isMacOSTheme && {
-              border: "none",
-              borderRadius: "0px",
-              background: "var(--os-pinstripe-window)",
-              opacity: "0.92",
-              boxShadow: "0 4px 16px rgba(0, 0, 0, 0.4)",
-              padding: "4px 0px",
-              ...(isMobile ? {} : { minWidth: style?.minWidth ?? "180px" }),
-            }),
-            ...(isMobile && { minWidth: "unset" }),
-            ...style,
-          }}
-          {...props}
-        />
-      </MenubarPrimitive.Portal>
-    )
+const MenubarContent = (
+  {
+    ref,
+    className,
+    align = "start",
+    alignOffset = 0,
+    sideOffset = 8,
+    style,
+    ...props
+  }: React.ComponentPropsWithoutRef<typeof MenubarPrimitive.Content> & {
+    ref: React.RefObject<React.ElementRef<typeof MenubarPrimitive.Content>>;
   }
-)
+) => {
+  const { isMacOSTheme } = useThemeFlags()
+  const isMobile = useMediaQuery("(max-width: 768px)")
+  const isSwitching = React.use(MenubarSwitchingContext)
+
+  return (
+    <MenubarPrimitive.Portal>
+      <MenubarPrimitive.Content
+        ref={ref}
+        align={align}
+        alignOffset={alignOffset}
+        sideOffset={sideOffset}
+        className={cn(
+          // Use z-[10003] to ensure menu content appears above the menubar (z-[10002])
+          // This is critical for Safari where backdrop-filter creates new stacking contexts
+          "z-[10003] min-w-[12rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md",
+          // Only animate when not switching between menus
+          !isSwitching && "data-[state=open]:animate-in data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+          className
+        )}
+        style={{
+          ...(isMacOSTheme && {
+            border: "none",
+            borderRadius: "0px",
+            background: "var(--os-pinstripe-window)",
+            opacity: "0.92",
+            boxShadow: "0 4px 16px rgba(0, 0, 0, 0.4)",
+            padding: "4px 0px",
+            ...(isMobile ? {} : { minWidth: style?.minWidth ?? "180px" }),
+          }),
+          ...(isMobile && { minWidth: "unset" }),
+          ...style,
+        }}
+        {...props}
+      />
+    </MenubarPrimitive.Portal>
+  )
+}
 MenubarContent.displayName = MenubarPrimitive.Content.displayName
 
-const MenubarItem = React.forwardRef<
-  React.ElementRef<typeof MenubarPrimitive.Item>,
-  React.ComponentPropsWithoutRef<typeof MenubarPrimitive.Item> & {
-    inset?: boolean
+const MenubarItem = (
+  {
+    ref,
+    className,
+    inset,
+    ...props
   }
->(({ className, inset, ...props }, ref) => {
+) => {
   const { isWindowsTheme, isMacOSTheme, isSystem7Theme } = useThemeFlags()
 
   return (
@@ -283,13 +310,20 @@ const MenubarItem = React.forwardRef<
       {...props}
     />
   )
-})
+}
 MenubarItem.displayName = MenubarPrimitive.Item.displayName
 
-const MenubarCheckboxItem = React.forwardRef<
-  React.ElementRef<typeof MenubarPrimitive.CheckboxItem>,
-  React.ComponentPropsWithoutRef<typeof MenubarPrimitive.CheckboxItem>
->(({ className, children, checked, ...props }, ref) => {
+const MenubarCheckboxItem = (
+  {
+    ref,
+    className,
+    children,
+    checked,
+    ...props
+  }: React.ComponentPropsWithoutRef<typeof MenubarPrimitive.CheckboxItem> & {
+    ref: React.RefObject<React.ElementRef<typeof MenubarPrimitive.CheckboxItem>>;
+  }
+) => {
   const {
     isWindowsTheme,
     isMacOSTheme,
@@ -341,13 +375,19 @@ const MenubarCheckboxItem = React.forwardRef<
       {children}
     </MenubarPrimitive.CheckboxItem>
   )
-})
+}
 MenubarCheckboxItem.displayName = MenubarPrimitive.CheckboxItem.displayName
 
-const MenubarRadioItem = React.forwardRef<
-  React.ElementRef<typeof MenubarPrimitive.RadioItem>,
-  React.ComponentPropsWithoutRef<typeof MenubarPrimitive.RadioItem>
->(({ className, children, ...props }, ref) => {
+const MenubarRadioItem = (
+  {
+    ref,
+    className,
+    children,
+    ...props
+  }: React.ComponentPropsWithoutRef<typeof MenubarPrimitive.RadioItem> & {
+    ref: React.RefObject<React.ElementRef<typeof MenubarPrimitive.RadioItem>>;
+  }
+) => {
   const {
     isWindowsTheme,
     isMacOSTheme,
@@ -398,15 +438,17 @@ const MenubarRadioItem = React.forwardRef<
       {children}
     </MenubarPrimitive.RadioItem>
   )
-})
+}
 MenubarRadioItem.displayName = MenubarPrimitive.RadioItem.displayName
 
-const MenubarLabel = React.forwardRef<
-  React.ElementRef<typeof MenubarPrimitive.Label>,
-  React.ComponentPropsWithoutRef<typeof MenubarPrimitive.Label> & {
-    inset?: boolean
+const MenubarLabel = (
+  {
+    ref,
+    className,
+    inset,
+    ...props
   }
->(({ className, inset, ...props }, ref) => {
+) => {
   const { isWindowsTheme, isMacOSTheme } = useThemeFlags()
 
   return (
@@ -425,13 +467,18 @@ const MenubarLabel = React.forwardRef<
       {...props}
     />
   )
-})
+}
 MenubarLabel.displayName = MenubarPrimitive.Label.displayName
 
-const MenubarSeparator = React.forwardRef<
-  React.ElementRef<typeof MenubarPrimitive.Separator>,
-  React.ComponentPropsWithoutRef<typeof MenubarPrimitive.Separator>
->(({ className, ...props }, ref) => {
+const MenubarSeparator = (
+  {
+    ref,
+    className,
+    ...props
+  }: React.ComponentPropsWithoutRef<typeof MenubarPrimitive.Separator> & {
+    ref: React.RefObject<React.ElementRef<typeof MenubarPrimitive.Separator>>;
+  }
+) => {
   const { isSystem7Theme, isMacOSTheme } = useThemeFlags()
 
   return (
@@ -455,7 +502,7 @@ const MenubarSeparator = React.forwardRef<
       {...props}
     />
   )
-})
+}
 MenubarSeparator.displayName = MenubarPrimitive.Separator.displayName
 
 const MenubarShortcut = ({

--- a/src/components/ui/menubar.tsx
+++ b/src/components/ui/menubar.tsx
@@ -27,7 +27,7 @@ const Menubar = (
     onValueChange,
     ...props
   }: React.ComponentPropsWithoutRef<typeof MenubarPrimitive.Root> & {
-    ref: React.RefObject<React.ElementRef<typeof MenubarPrimitive.Root>>;
+    ref?: React.Ref<React.ElementRef<typeof MenubarPrimitive.Root>>;
   }
 ) => {
   const { play: playMenuOpen } = useSound(Sounds.MENU_OPEN)
@@ -76,7 +76,7 @@ const MenubarTrigger = (
     style,
     ...props
   }: React.ComponentPropsWithoutRef<typeof MenubarPrimitive.Trigger> & {
-    ref: React.RefObject<React.ElementRef<typeof MenubarPrimitive.Trigger>>;
+    ref?: React.Ref<React.ElementRef<typeof MenubarPrimitive.Trigger>>;
   }
 ) => {
   const { isWindowsTheme, isSystem7Theme, isMacOSTheme } = useThemeFlags()
@@ -123,6 +123,9 @@ const MenubarSubTrigger = (
     inset,
     children,
     ...props
+  }: React.ComponentPropsWithoutRef<typeof MenubarPrimitive.SubTrigger> & {
+    inset?: boolean
+    ref?: React.Ref<React.ElementRef<typeof MenubarPrimitive.SubTrigger>>
   }
 ) => {
   const { isWindowsTheme, isMacOSTheme, isSystem7Theme } = useThemeFlags()
@@ -176,7 +179,7 @@ const MenubarSubContent = (
     style,
     ...props
   }: React.ComponentPropsWithoutRef<typeof MenubarPrimitive.SubContent> & {
-    ref: React.RefObject<React.ElementRef<typeof MenubarPrimitive.SubContent>>;
+    ref?: React.Ref<React.ElementRef<typeof MenubarPrimitive.SubContent>>;
   }
 ) => {
   const { isMacOSTheme } = useThemeFlags()
@@ -221,7 +224,7 @@ const MenubarContent = (
     style,
     ...props
   }: React.ComponentPropsWithoutRef<typeof MenubarPrimitive.Content> & {
-    ref: React.RefObject<React.ElementRef<typeof MenubarPrimitive.Content>>;
+    ref?: React.Ref<React.ElementRef<typeof MenubarPrimitive.Content>>;
   }
 ) => {
   const { isMacOSTheme } = useThemeFlags()
@@ -269,6 +272,9 @@ const MenubarItem = (
     className,
     inset,
     ...props
+  }: React.ComponentPropsWithoutRef<typeof MenubarPrimitive.Item> & {
+    inset?: boolean
+    ref?: React.Ref<React.ElementRef<typeof MenubarPrimitive.Item>>
   }
 ) => {
   const { isWindowsTheme, isMacOSTheme, isSystem7Theme } = useThemeFlags()
@@ -321,7 +327,7 @@ const MenubarCheckboxItem = (
     checked,
     ...props
   }: React.ComponentPropsWithoutRef<typeof MenubarPrimitive.CheckboxItem> & {
-    ref: React.RefObject<React.ElementRef<typeof MenubarPrimitive.CheckboxItem>>;
+    ref?: React.Ref<React.ElementRef<typeof MenubarPrimitive.CheckboxItem>>;
   }
 ) => {
   const {
@@ -385,7 +391,7 @@ const MenubarRadioItem = (
     children,
     ...props
   }: React.ComponentPropsWithoutRef<typeof MenubarPrimitive.RadioItem> & {
-    ref: React.RefObject<React.ElementRef<typeof MenubarPrimitive.RadioItem>>;
+    ref?: React.Ref<React.ElementRef<typeof MenubarPrimitive.RadioItem>>;
   }
 ) => {
   const {
@@ -447,6 +453,9 @@ const MenubarLabel = (
     className,
     inset,
     ...props
+  }: React.ComponentPropsWithoutRef<typeof MenubarPrimitive.Label> & {
+    inset?: boolean
+    ref?: React.Ref<React.ElementRef<typeof MenubarPrimitive.Label>>
   }
 ) => {
   const { isWindowsTheme, isMacOSTheme } = useThemeFlags()
@@ -476,7 +485,7 @@ const MenubarSeparator = (
     className,
     ...props
   }: React.ComponentPropsWithoutRef<typeof MenubarPrimitive.Separator> & {
-    ref: React.RefObject<React.ElementRef<typeof MenubarPrimitive.Separator>>;
+    ref?: React.Ref<React.ElementRef<typeof MenubarPrimitive.Separator>>;
   }
 ) => {
   const { isSystem7Theme, isMacOSTheme } = useThemeFlags()

--- a/src/components/ui/scroll-area.tsx
+++ b/src/components/ui/scroll-area.tsx
@@ -10,7 +10,7 @@ const ScrollArea = (
     children,
     ...props
   }: React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.Root> & {
-    ref: React.RefObject<React.ElementRef<typeof ScrollAreaPrimitive.Root>>;
+    ref?: React.Ref<React.ElementRef<typeof ScrollAreaPrimitive.Root>>;
   }
 ) => (<ScrollAreaPrimitive.Root
   ref={ref}
@@ -32,7 +32,7 @@ const ScrollBar = (
     orientation = "vertical",
     ...props
   }: React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.ScrollAreaScrollbar> & {
-    ref: React.RefObject<React.ElementRef<typeof ScrollAreaPrimitive.ScrollAreaScrollbar>>;
+    ref?: React.Ref<React.ElementRef<typeof ScrollAreaPrimitive.ScrollAreaScrollbar>>;
   }
 ) => (<ScrollAreaPrimitive.ScrollAreaScrollbar
   ref={ref}

--- a/src/components/ui/scroll-area.tsx
+++ b/src/components/ui/scroll-area.tsx
@@ -3,44 +3,52 @@ import * as ScrollAreaPrimitive from "@radix-ui/react-scroll-area"
 
 import { cn } from "@/lib/utils"
 
-const ScrollArea = React.forwardRef<
-  React.ElementRef<typeof ScrollAreaPrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.Root>
->(({ className, children, ...props }, ref) => (
-  <ScrollAreaPrimitive.Root
-    ref={ref}
-    className={cn("relative overflow-hidden", className)}
-    {...props}
-  >
-    <ScrollAreaPrimitive.Viewport className="h-full w-full min-w-0 max-w-full rounded-[inherit] [&>div]:!block [&>div]:min-w-full">
-      {children}
-    </ScrollAreaPrimitive.Viewport>
-    <ScrollBar />
-    <ScrollAreaPrimitive.Corner />
-  </ScrollAreaPrimitive.Root>
-))
+const ScrollArea = (
+  {
+    ref,
+    className,
+    children,
+    ...props
+  }: React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.Root> & {
+    ref: React.RefObject<React.ElementRef<typeof ScrollAreaPrimitive.Root>>;
+  }
+) => (<ScrollAreaPrimitive.Root
+  ref={ref}
+  className={cn("relative overflow-hidden", className)}
+  {...props}
+>
+  <ScrollAreaPrimitive.Viewport className="h-full w-full min-w-0 max-w-full rounded-[inherit] [&>div]:!block [&>div]:min-w-full">
+    {children}
+  </ScrollAreaPrimitive.Viewport>
+  <ScrollBar />
+  <ScrollAreaPrimitive.Corner />
+</ScrollAreaPrimitive.Root>)
 ScrollArea.displayName = ScrollAreaPrimitive.Root.displayName
 
-const ScrollBar = React.forwardRef<
-  React.ElementRef<typeof ScrollAreaPrimitive.ScrollAreaScrollbar>,
-  React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.ScrollAreaScrollbar>
->(({ className, orientation = "vertical", ...props }, ref) => (
-  <ScrollAreaPrimitive.ScrollAreaScrollbar
-    ref={ref}
-    orientation={orientation}
-    className={cn(
-      "flex touch-none select-none transition-colors",
-      orientation === "vertical" &&
-        "h-full w-2.5 border-l border-l-transparent p-[1px]",
-      orientation === "horizontal" &&
-        "h-2.5 flex-col border-t border-t-transparent p-[1px]",
-      className
-    )}
-    {...props}
-  >
-    <ScrollAreaPrimitive.ScrollAreaThumb className="relative flex-1 rounded-full bg-border" />
-  </ScrollAreaPrimitive.ScrollAreaScrollbar>
-))
+const ScrollBar = (
+  {
+    ref,
+    className,
+    orientation = "vertical",
+    ...props
+  }: React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.ScrollAreaScrollbar> & {
+    ref: React.RefObject<React.ElementRef<typeof ScrollAreaPrimitive.ScrollAreaScrollbar>>;
+  }
+) => (<ScrollAreaPrimitive.ScrollAreaScrollbar
+  ref={ref}
+  orientation={orientation}
+  className={cn(
+    "flex touch-none select-none transition-colors",
+    orientation === "vertical" &&
+      "h-full w-2.5 border-l border-l-transparent p-[1px]",
+    orientation === "horizontal" &&
+      "h-2.5 flex-col border-t border-t-transparent p-[1px]",
+    className
+  )}
+  {...props}
+>
+  <ScrollAreaPrimitive.ScrollAreaThumb className="relative flex-1 rounded-full bg-border" />
+</ScrollAreaPrimitive.ScrollAreaScrollbar>)
 ScrollBar.displayName = ScrollAreaPrimitive.ScrollAreaScrollbar.displayName
 
 export { ScrollArea, ScrollBar }

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -31,10 +31,16 @@ const SelectGroup = SelectPrimitive.Group;
 
 const SelectValue = SelectPrimitive.Value;
 
-const SelectTrigger = React.forwardRef<
-  React.ElementRef<typeof SelectPrimitive.Trigger>,
-  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Trigger>
->(({ className, children, ...props }, ref) => {
+const SelectTrigger = (
+  {
+    ref,
+    className,
+    children,
+    ...props
+  }: React.ComponentPropsWithoutRef<typeof SelectPrimitive.Trigger> & {
+    ref: React.RefObject<React.ElementRef<typeof SelectPrimitive.Trigger>>;
+  }
+) => {
   const { play: playClick } = useSound(Sounds.BUTTON_CLICK, 0.3);
   const { isMacOSTheme, isWindowsTheme: isXpTheme } = useThemeFlags();
 
@@ -64,48 +70,61 @@ const SelectTrigger = React.forwardRef<
       )}
     </SelectPrimitive.Trigger>
   );
-});
+};
 SelectTrigger.displayName = SelectPrimitive.Trigger.displayName;
 
-const SelectScrollUpButton = React.forwardRef<
-  React.ElementRef<typeof SelectPrimitive.ScrollUpButton>,
-  React.ComponentPropsWithoutRef<typeof SelectPrimitive.ScrollUpButton>
->(({ className, ...props }, ref) => (
-  <SelectPrimitive.ScrollUpButton
-    ref={ref}
-    className={cn(
-      "flex cursor-default items-center justify-center py-1",
-      className
-    )}
-    {...props}
-  >
-    <CaretUp size={12} weight="bold" />
-  </SelectPrimitive.ScrollUpButton>
-));
+const SelectScrollUpButton = (
+  {
+    ref,
+    className,
+    ...props
+  }: React.ComponentPropsWithoutRef<typeof SelectPrimitive.ScrollUpButton> & {
+    ref: React.RefObject<React.ElementRef<typeof SelectPrimitive.ScrollUpButton>>;
+  }
+) => (<SelectPrimitive.ScrollUpButton
+  ref={ref}
+  className={cn(
+    "flex cursor-default items-center justify-center py-1",
+    className
+  )}
+  {...props}
+>
+  <CaretUp size={12} weight="bold" />
+</SelectPrimitive.ScrollUpButton>);
 SelectScrollUpButton.displayName = SelectPrimitive.ScrollUpButton.displayName;
 
-const SelectScrollDownButton = React.forwardRef<
-  React.ElementRef<typeof SelectPrimitive.ScrollDownButton>,
-  React.ComponentPropsWithoutRef<typeof SelectPrimitive.ScrollDownButton>
->(({ className, ...props }, ref) => (
-  <SelectPrimitive.ScrollDownButton
-    ref={ref}
-    className={cn(
-      "flex cursor-default items-center justify-center py-1",
-      className
-    )}
-    {...props}
-  >
-    <CaretDown size={12} weight="bold" />
-  </SelectPrimitive.ScrollDownButton>
-));
+const SelectScrollDownButton = (
+  {
+    ref,
+    className,
+    ...props
+  }: React.ComponentPropsWithoutRef<typeof SelectPrimitive.ScrollDownButton> & {
+    ref: React.RefObject<React.ElementRef<typeof SelectPrimitive.ScrollDownButton>>;
+  }
+) => (<SelectPrimitive.ScrollDownButton
+  ref={ref}
+  className={cn(
+    "flex cursor-default items-center justify-center py-1",
+    className
+  )}
+  {...props}
+>
+  <CaretDown size={12} weight="bold" />
+</SelectPrimitive.ScrollDownButton>);
 SelectScrollDownButton.displayName =
   SelectPrimitive.ScrollDownButton.displayName;
 
-const SelectContent = React.forwardRef<
-  React.ElementRef<typeof SelectPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Content>
->(({ className, children, position = "popper", ...props }, ref) => {
+const SelectContent = (
+  {
+    ref,
+    className,
+    children,
+    position = "popper",
+    ...props
+  }: React.ComponentPropsWithoutRef<typeof SelectPrimitive.Content> & {
+    ref: React.RefObject<React.ElementRef<typeof SelectPrimitive.Content>>;
+  }
+) => {
   const { isMacOSTheme } = useThemeFlags();
 
   return (
@@ -146,25 +165,34 @@ const SelectContent = React.forwardRef<
       </SelectPrimitive.Content>
     </SelectPrimitive.Portal>
   );
-});
+};
 SelectContent.displayName = SelectPrimitive.Content.displayName;
 
-const SelectLabel = React.forwardRef<
-  React.ElementRef<typeof SelectPrimitive.Label>,
-  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Label>
->(({ className, ...props }, ref) => (
-  <SelectPrimitive.Label
-    ref={ref}
-    className={cn("px-2 py-1.5 text-sm font-semibold", className)}
-    {...props}
-  />
-));
+const SelectLabel = (
+  {
+    ref,
+    className,
+    ...props
+  }: React.ComponentPropsWithoutRef<typeof SelectPrimitive.Label> & {
+    ref: React.RefObject<React.ElementRef<typeof SelectPrimitive.Label>>;
+  }
+) => (<SelectPrimitive.Label
+  ref={ref}
+  className={cn("px-2 py-1.5 text-sm font-semibold", className)}
+  {...props}
+/>);
 SelectLabel.displayName = SelectPrimitive.Label.displayName;
 
-const SelectItem = React.forwardRef<
-  React.ElementRef<typeof SelectPrimitive.Item>,
-  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Item>
->(({ className, children, ...props }, ref) => {
+const SelectItem = (
+  {
+    ref,
+    className,
+    children,
+    ...props
+  }: React.ComponentPropsWithoutRef<typeof SelectPrimitive.Item> & {
+    ref: React.RefObject<React.ElementRef<typeof SelectPrimitive.Item>>;
+  }
+) => {
   const { play: playClick } = useSound(Sounds.BUTTON_CLICK, 0.3);
 
   return (
@@ -188,7 +216,7 @@ const SelectItem = React.forwardRef<
       <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
     </SelectPrimitive.Item>
   );
-});
+};
 SelectItem.displayName = SelectPrimitive.Item.displayName;
 
 interface SelectItemWithDescriptionProps
@@ -196,10 +224,17 @@ interface SelectItemWithDescriptionProps
   description?: string;
 }
 
-const SelectItemWithDescription = React.forwardRef<
-  React.ElementRef<typeof SelectPrimitive.Item>,
-  SelectItemWithDescriptionProps
->(({ className, children, description, ...props }, ref) => {
+const SelectItemWithDescription = (
+  {
+    ref,
+    className,
+    children,
+    description,
+    ...props
+  }: SelectItemWithDescriptionProps & {
+    ref: React.RefObject<React.ElementRef<typeof SelectPrimitive.Item>>;
+  }
+) => {
   const { play: playClick } = useSound(Sounds.BUTTON_CLICK, 0.3);
 
   return (
@@ -230,19 +265,22 @@ const SelectItemWithDescription = React.forwardRef<
       </div>
     </SelectPrimitive.Item>
   );
-});
+};
 SelectItemWithDescription.displayName = "SelectItemWithDescription";
 
-const SelectSeparator = React.forwardRef<
-  React.ElementRef<typeof SelectPrimitive.Separator>,
-  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Separator>
->(({ className, ...props }, ref) => (
-  <SelectPrimitive.Separator
-    ref={ref}
-    className={cn("-mx-1 my-1 h-px bg-muted", className)}
-    {...props}
-  />
-));
+const SelectSeparator = (
+  {
+    ref,
+    className,
+    ...props
+  }: React.ComponentPropsWithoutRef<typeof SelectPrimitive.Separator> & {
+    ref: React.RefObject<React.ElementRef<typeof SelectPrimitive.Separator>>;
+  }
+) => (<SelectPrimitive.Separator
+  ref={ref}
+  className={cn("-mx-1 my-1 h-px bg-muted", className)}
+  {...props}
+/>);
 SelectSeparator.displayName = SelectPrimitive.Separator.displayName;
 
 export {

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -38,7 +38,7 @@ const SelectTrigger = (
     children,
     ...props
   }: React.ComponentPropsWithoutRef<typeof SelectPrimitive.Trigger> & {
-    ref: React.RefObject<React.ElementRef<typeof SelectPrimitive.Trigger>>;
+    ref?: React.Ref<React.ElementRef<typeof SelectPrimitive.Trigger>>;
   }
 ) => {
   const { play: playClick } = useSound(Sounds.BUTTON_CLICK, 0.3);
@@ -79,7 +79,7 @@ const SelectScrollUpButton = (
     className,
     ...props
   }: React.ComponentPropsWithoutRef<typeof SelectPrimitive.ScrollUpButton> & {
-    ref: React.RefObject<React.ElementRef<typeof SelectPrimitive.ScrollUpButton>>;
+    ref?: React.Ref<React.ElementRef<typeof SelectPrimitive.ScrollUpButton>>;
   }
 ) => (<SelectPrimitive.ScrollUpButton
   ref={ref}
@@ -99,7 +99,7 @@ const SelectScrollDownButton = (
     className,
     ...props
   }: React.ComponentPropsWithoutRef<typeof SelectPrimitive.ScrollDownButton> & {
-    ref: React.RefObject<React.ElementRef<typeof SelectPrimitive.ScrollDownButton>>;
+    ref?: React.Ref<React.ElementRef<typeof SelectPrimitive.ScrollDownButton>>;
   }
 ) => (<SelectPrimitive.ScrollDownButton
   ref={ref}
@@ -122,7 +122,7 @@ const SelectContent = (
     position = "popper",
     ...props
   }: React.ComponentPropsWithoutRef<typeof SelectPrimitive.Content> & {
-    ref: React.RefObject<React.ElementRef<typeof SelectPrimitive.Content>>;
+    ref?: React.Ref<React.ElementRef<typeof SelectPrimitive.Content>>;
   }
 ) => {
   const { isMacOSTheme } = useThemeFlags();
@@ -174,7 +174,7 @@ const SelectLabel = (
     className,
     ...props
   }: React.ComponentPropsWithoutRef<typeof SelectPrimitive.Label> & {
-    ref: React.RefObject<React.ElementRef<typeof SelectPrimitive.Label>>;
+    ref?: React.Ref<React.ElementRef<typeof SelectPrimitive.Label>>;
   }
 ) => (<SelectPrimitive.Label
   ref={ref}
@@ -190,7 +190,7 @@ const SelectItem = (
     children,
     ...props
   }: React.ComponentPropsWithoutRef<typeof SelectPrimitive.Item> & {
-    ref: React.RefObject<React.ElementRef<typeof SelectPrimitive.Item>>;
+    ref?: React.Ref<React.ElementRef<typeof SelectPrimitive.Item>>;
   }
 ) => {
   const { play: playClick } = useSound(Sounds.BUTTON_CLICK, 0.3);
@@ -232,7 +232,7 @@ const SelectItemWithDescription = (
     description,
     ...props
   }: SelectItemWithDescriptionProps & {
-    ref: React.RefObject<React.ElementRef<typeof SelectPrimitive.Item>>;
+    ref?: React.Ref<React.ElementRef<typeof SelectPrimitive.Item>>;
   }
 ) => {
   const { play: playClick } = useSound(Sounds.BUTTON_CLICK, 0.3);
@@ -274,7 +274,7 @@ const SelectSeparator = (
     className,
     ...props
   }: React.ComponentPropsWithoutRef<typeof SelectPrimitive.Separator> & {
-    ref: React.RefObject<React.ElementRef<typeof SelectPrimitive.Separator>>;
+    ref?: React.Ref<React.ElementRef<typeof SelectPrimitive.Separator>>;
   }
 ) => (<SelectPrimitive.Separator
   ref={ref}

--- a/src/components/ui/selectable-list-item.tsx
+++ b/src/components/ui/selectable-list-item.tsx
@@ -8,21 +8,26 @@ interface SelectableListItemProps
   className?: string;
 }
 
-export const SelectableListItem = React.forwardRef<
-  HTMLDivElement,
-  SelectableListItemProps
->(({ isSelected, children, className, ...props }, ref) => (
-  <div
-    ref={ref}
-    className={cn(
-      "py-1 px-5 cursor-pointer",
-      !isSelected && "hover:bg-black/5",
-      className
-    )}
-    data-selected={isSelected ? "true" : undefined}
-    {...props}
-  >
-    {children}
-  </div>
-));
+export const SelectableListItem = (
+  {
+    ref,
+    isSelected,
+    children,
+    className,
+    ...props
+  }: SelectableListItemProps & {
+    ref: React.RefObject<HTMLDivElement>;
+  }
+) => (<div
+  ref={ref}
+  className={cn(
+    "py-1 px-5 cursor-pointer",
+    !isSelected && "hover:bg-black/5",
+    className
+  )}
+  data-selected={isSelected ? "true" : undefined}
+  {...props}
+>
+  {children}
+</div>);
 SelectableListItem.displayName = "SelectableListItem";

--- a/src/components/ui/selectable-list-item.tsx
+++ b/src/components/ui/selectable-list-item.tsx
@@ -16,7 +16,7 @@ export const SelectableListItem = (
     className,
     ...props
   }: SelectableListItemProps & {
-    ref: React.RefObject<HTMLDivElement>;
+    ref?: React.Ref<HTMLDivElement>;
   }
 ) => (<div
   ref={ref}

--- a/src/components/ui/slider.tsx
+++ b/src/components/ui/slider.tsx
@@ -3,37 +3,40 @@ import * as SliderPrimitive from "@radix-ui/react-slider";
 
 import { cn } from "@/lib/utils";
 
-const Slider = React.forwardRef<
-  React.ElementRef<typeof SliderPrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof SliderPrimitive.Root>
->(({ className, ...props }, ref) => (
-  <SliderPrimitive.Root
-    ref={ref}
+const Slider = (
+  {
+    ref,
+    className,
+    ...props
+  }: React.ComponentPropsWithoutRef<typeof SliderPrimitive.Root> & {
+    ref: React.RefObject<React.ElementRef<typeof SliderPrimitive.Root>>;
+  }
+) => (<SliderPrimitive.Root
+  ref={ref}
+  className={cn(
+    "os-slider relative flex touch-none select-none items-center",
+    props.orientation === "vertical"
+      ? "h-full w-auto flex-col"
+      : "w-full items-center",
+    className
+  )}
+  {...props}
+>
+  <SliderPrimitive.Track
     className={cn(
-      "os-slider relative flex touch-none select-none items-center",
-      props.orientation === "vertical"
-        ? "h-full w-auto flex-col"
-        : "w-full items-center",
-      className
+      "os-slider-track relative grow overflow-hidden bg-primary/20",
+      props.orientation === "vertical" ? "h-full w-1.5" : "h-1.5 w-full"
     )}
-    {...props}
   >
-    <SliderPrimitive.Track
+    <SliderPrimitive.Range
       className={cn(
-        "os-slider-track relative grow overflow-hidden bg-primary/20",
-        props.orientation === "vertical" ? "h-full w-1.5" : "h-1.5 w-full"
+        "os-slider-range absolute bg-primary",
+        props.orientation === "vertical" ? "w-full" : "h-full"
       )}
-    >
-      <SliderPrimitive.Range
-        className={cn(
-          "os-slider-range absolute bg-primary",
-          props.orientation === "vertical" ? "w-full" : "h-full"
-        )}
-      />
-    </SliderPrimitive.Track>
-    <SliderPrimitive.Thumb className="os-slider-thumb block h-4 w-4 border-2 border-primary bg-background shadow-[1px_1px_0px_0px_rgba(0,0,0,0.3)] transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50" />
-  </SliderPrimitive.Root>
-));
+    />
+  </SliderPrimitive.Track>
+  <SliderPrimitive.Thumb className="os-slider-thumb block h-4 w-4 border-2 border-primary bg-background shadow-[1px_1px_0px_0px_rgba(0,0,0,0.3)] transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50" />
+</SliderPrimitive.Root>);
 Slider.displayName = SliderPrimitive.Root.displayName;
 
 export { Slider };

--- a/src/components/ui/slider.tsx
+++ b/src/components/ui/slider.tsx
@@ -9,7 +9,7 @@ const Slider = (
     className,
     ...props
   }: React.ComponentPropsWithoutRef<typeof SliderPrimitive.Root> & {
-    ref: React.RefObject<React.ElementRef<typeof SliderPrimitive.Root>>;
+    ref?: React.Ref<React.ElementRef<typeof SliderPrimitive.Root>>;
   }
 ) => (<SliderPrimitive.Root
   ref={ref}

--- a/src/components/ui/switch.tsx
+++ b/src/components/ui/switch.tsx
@@ -12,7 +12,7 @@ const Switch = (
     onCheckedChange,
     ...props
   }: React.ComponentPropsWithoutRef<typeof SwitchPrimitives.Root> & {
-    ref: React.RefObject<React.ElementRef<typeof SwitchPrimitives.Root>>;
+    ref?: React.Ref<React.ElementRef<typeof SwitchPrimitives.Root>>;
   }
 ) => {
   const { play: playClick } = useSound(Sounds.BUTTON_CLICK, 0.3);

--- a/src/components/ui/switch.tsx
+++ b/src/components/ui/switch.tsx
@@ -5,10 +5,16 @@ import { useThemeFlags } from "@/hooks/useThemeFlags";
 
 import { cn } from "@/lib/utils";
 
-const Switch = React.forwardRef<
-  React.ElementRef<typeof SwitchPrimitives.Root>,
-  React.ComponentPropsWithoutRef<typeof SwitchPrimitives.Root>
->(({ className, onCheckedChange, ...props }, ref) => {
+const Switch = (
+  {
+    ref,
+    className,
+    onCheckedChange,
+    ...props
+  }: React.ComponentPropsWithoutRef<typeof SwitchPrimitives.Root> & {
+    ref: React.RefObject<React.ElementRef<typeof SwitchPrimitives.Root>>;
+  }
+) => {
   const { play: playClick } = useSound(Sounds.BUTTON_CLICK, 0.3);
   const { isMacOSTheme } = useThemeFlags();
   const [isChecked, setIsChecked] = React.useState(
@@ -58,7 +64,7 @@ const Switch = React.forwardRef<
       />
     </SwitchPrimitives.Root>
   );
-});
+};
 Switch.displayName = SwitchPrimitives.Root.displayName;
 
 export { Switch };

--- a/src/components/ui/table.tsx
+++ b/src/components/ui/table.tsx
@@ -8,7 +8,7 @@ const Table = (
     className,
     ...props
   }: React.HTMLAttributes<HTMLTableElement> & {
-    ref: React.RefObject<HTMLTableElement>;
+    ref?: React.Ref<HTMLTableElement>;
   }
 ) => (<table
   ref={ref}
@@ -23,7 +23,7 @@ const TableHeader = (
     className,
     ...props
   }: React.HTMLAttributes<HTMLTableSectionElement> & {
-    ref: React.RefObject<HTMLTableSectionElement>;
+    ref?: React.Ref<HTMLTableSectionElement>;
   }
 ) => (<thead ref={ref} className={cn("[&_tr]:border-b", className)} {...props} />)
 TableHeader.displayName = "TableHeader"
@@ -34,7 +34,7 @@ const TableBody = (
     className,
     ...props
   }: React.HTMLAttributes<HTMLTableSectionElement> & {
-    ref: React.RefObject<HTMLTableSectionElement>;
+    ref?: React.Ref<HTMLTableSectionElement>;
   }
 ) => (<tbody
   ref={ref}
@@ -49,7 +49,7 @@ const TableFooter = (
     className,
     ...props
   }: React.HTMLAttributes<HTMLTableSectionElement> & {
-    ref: React.RefObject<HTMLTableSectionElement>;
+    ref?: React.Ref<HTMLTableSectionElement>;
   }
 ) => (<tfoot
   ref={ref}
@@ -67,7 +67,7 @@ const TableRow = (
     className,
     ...props
   }: React.HTMLAttributes<HTMLTableRowElement> & {
-    ref: React.RefObject<HTMLTableRowElement>;
+    ref?: React.Ref<HTMLTableRowElement>;
   }
 ) => (<tr
   ref={ref}
@@ -85,7 +85,7 @@ const TableHead = (
     className,
     ...props
   }: React.ThHTMLAttributes<HTMLTableCellElement> & {
-    ref: React.RefObject<HTMLTableCellElement>;
+    ref?: React.Ref<HTMLTableCellElement>;
   }
 ) => (<th
   ref={ref}
@@ -103,7 +103,7 @@ const TableCell = (
     className,
     ...props
   }: React.TdHTMLAttributes<HTMLTableCellElement> & {
-    ref: React.RefObject<HTMLTableCellElement>;
+    ref?: React.Ref<HTMLTableCellElement>;
   }
 ) => (<td
   ref={ref}
@@ -121,7 +121,7 @@ const TableCaption = (
     className,
     ...props
   }: React.HTMLAttributes<HTMLTableCaptionElement> & {
-    ref: React.RefObject<HTMLTableCaptionElement>;
+    ref?: React.Ref<HTMLTableCaptionElement>;
   }
 ) => (<caption
   ref={ref}

--- a/src/components/ui/table.tsx
+++ b/src/components/ui/table.tsx
@@ -2,108 +2,132 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-const Table = React.forwardRef<
-  HTMLTableElement,
-  React.HTMLAttributes<HTMLTableElement>
->(({ className, ...props }, ref) => (
-  <table
-    ref={ref}
-    className={cn("w-full caption-bottom text-sm", className)}
-    {...props}
-  />
-))
+const Table = (
+  {
+    ref,
+    className,
+    ...props
+  }: React.HTMLAttributes<HTMLTableElement> & {
+    ref: React.RefObject<HTMLTableElement>;
+  }
+) => (<table
+  ref={ref}
+  className={cn("w-full caption-bottom text-sm", className)}
+  {...props}
+/>)
 Table.displayName = "Table"
 
-const TableHeader = React.forwardRef<
-  HTMLTableSectionElement,
-  React.HTMLAttributes<HTMLTableSectionElement>
->(({ className, ...props }, ref) => (
-  <thead ref={ref} className={cn("[&_tr]:border-b", className)} {...props} />
-))
+const TableHeader = (
+  {
+    ref,
+    className,
+    ...props
+  }: React.HTMLAttributes<HTMLTableSectionElement> & {
+    ref: React.RefObject<HTMLTableSectionElement>;
+  }
+) => (<thead ref={ref} className={cn("[&_tr]:border-b", className)} {...props} />)
 TableHeader.displayName = "TableHeader"
 
-const TableBody = React.forwardRef<
-  HTMLTableSectionElement,
-  React.HTMLAttributes<HTMLTableSectionElement>
->(({ className, ...props }, ref) => (
-  <tbody
-    ref={ref}
-    className={cn("[&_tr:last-child]:border-0", className)}
-    {...props}
-  />
-))
+const TableBody = (
+  {
+    ref,
+    className,
+    ...props
+  }: React.HTMLAttributes<HTMLTableSectionElement> & {
+    ref: React.RefObject<HTMLTableSectionElement>;
+  }
+) => (<tbody
+  ref={ref}
+  className={cn("[&_tr:last-child]:border-0", className)}
+  {...props}
+/>)
 TableBody.displayName = "TableBody"
 
-const TableFooter = React.forwardRef<
-  HTMLTableSectionElement,
-  React.HTMLAttributes<HTMLTableSectionElement>
->(({ className, ...props }, ref) => (
-  <tfoot
-    ref={ref}
-    className={cn(
-      "border-t bg-muted/50 font-medium [&>tr]:last:border-b-0",
-      className
-    )}
-    {...props}
-  />
-))
+const TableFooter = (
+  {
+    ref,
+    className,
+    ...props
+  }: React.HTMLAttributes<HTMLTableSectionElement> & {
+    ref: React.RefObject<HTMLTableSectionElement>;
+  }
+) => (<tfoot
+  ref={ref}
+  className={cn(
+    "border-t bg-muted/50 font-medium [&>tr]:last:border-b-0",
+    className
+  )}
+  {...props}
+/>)
 TableFooter.displayName = "TableFooter"
 
-const TableRow = React.forwardRef<
-  HTMLTableRowElement,
-  React.HTMLAttributes<HTMLTableRowElement>
->(({ className, ...props }, ref) => (
-  <tr
-    ref={ref}
-    className={cn(
-      "border-b transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted",
-      className
-    )}
-    {...props}
-  />
-))
+const TableRow = (
+  {
+    ref,
+    className,
+    ...props
+  }: React.HTMLAttributes<HTMLTableRowElement> & {
+    ref: React.RefObject<HTMLTableRowElement>;
+  }
+) => (<tr
+  ref={ref}
+  className={cn(
+    "border-b transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted",
+    className
+  )}
+  {...props}
+/>)
 TableRow.displayName = "TableRow"
 
-const TableHead = React.forwardRef<
-  HTMLTableCellElement,
-  React.ThHTMLAttributes<HTMLTableCellElement>
->(({ className, ...props }, ref) => (
-  <th
-    ref={ref}
-    className={cn(
-      "h-10 px-2 text-left align-middle font-medium text-muted-foreground [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
-      className
-    )}
-    {...props}
-  />
-))
+const TableHead = (
+  {
+    ref,
+    className,
+    ...props
+  }: React.ThHTMLAttributes<HTMLTableCellElement> & {
+    ref: React.RefObject<HTMLTableCellElement>;
+  }
+) => (<th
+  ref={ref}
+  className={cn(
+    "h-10 px-2 text-left align-middle font-medium text-muted-foreground [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+    className
+  )}
+  {...props}
+/>)
 TableHead.displayName = "TableHead"
 
-const TableCell = React.forwardRef<
-  HTMLTableCellElement,
-  React.TdHTMLAttributes<HTMLTableCellElement>
->(({ className, ...props }, ref) => (
-  <td
-    ref={ref}
-    className={cn(
-      "p-2 align-middle [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
-      className
-    )}
-    {...props}
-  />
-))
+const TableCell = (
+  {
+    ref,
+    className,
+    ...props
+  }: React.TdHTMLAttributes<HTMLTableCellElement> & {
+    ref: React.RefObject<HTMLTableCellElement>;
+  }
+) => (<td
+  ref={ref}
+  className={cn(
+    "p-2 align-middle [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+    className
+  )}
+  {...props}
+/>)
 TableCell.displayName = "TableCell"
 
-const TableCaption = React.forwardRef<
-  HTMLTableCaptionElement,
-  React.HTMLAttributes<HTMLTableCaptionElement>
->(({ className, ...props }, ref) => (
-  <caption
-    ref={ref}
-    className={cn("mt-4 text-sm text-muted-foreground", className)}
-    {...props}
-  />
-))
+const TableCaption = (
+  {
+    ref,
+    className,
+    ...props
+  }: React.HTMLAttributes<HTMLTableCaptionElement> & {
+    ref: React.RefObject<HTMLTableCaptionElement>;
+  }
+) => (<caption
+  ref={ref}
+  className={cn("mt-4 text-sm text-muted-foreground", className)}
+  {...props}
+/>)
 TableCaption.displayName = "TableCaption"
 
 export {

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -12,7 +12,7 @@ const TabsList = (
     className,
     ...props
   }: React.ComponentPropsWithoutRef<typeof TabsPrimitive.List> & {
-    ref: React.RefObject<React.ElementRef<typeof TabsPrimitive.List>>;
+    ref?: React.Ref<React.ElementRef<typeof TabsPrimitive.List>>;
   }
 ) => (<TabsPrimitive.List
   ref={ref}
@@ -31,7 +31,7 @@ const TabsTrigger = (
     onClick,
     ...props
   }: React.ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger> & {
-    ref: React.RefObject<React.ElementRef<typeof TabsPrimitive.Trigger>>;
+    ref?: React.Ref<React.ElementRef<typeof TabsPrimitive.Trigger>>;
   }
 ) => {
   const { play: playClick } = useSound(Sounds.BUTTON_CLICK, 0.3);
@@ -61,7 +61,7 @@ const TabsContent = (
     className,
     ...props
   }: React.ComponentPropsWithoutRef<typeof TabsPrimitive.Content> & {
-    ref: React.RefObject<React.ElementRef<typeof TabsPrimitive.Content>>;
+    ref?: React.Ref<React.ElementRef<typeof TabsPrimitive.Content>>;
   }
 ) => (<TabsPrimitive.Content
   ref={ref}

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -6,25 +6,34 @@ import { cn } from "@/lib/utils";
 
 const Tabs = TabsPrimitive.Root;
 
-const TabsList = React.forwardRef<
-  React.ElementRef<typeof TabsPrimitive.List>,
-  React.ComponentPropsWithoutRef<typeof TabsPrimitive.List>
->(({ className, ...props }, ref) => (
-  <TabsPrimitive.List
-    ref={ref}
-    className={cn(
-      "inline-flex h-9 items-center justify-center rounded-lg bg-muted p-1 text-muted-foreground",
-      className
-    )}
-    {...props}
-  />
-));
+const TabsList = (
+  {
+    ref,
+    className,
+    ...props
+  }: React.ComponentPropsWithoutRef<typeof TabsPrimitive.List> & {
+    ref: React.RefObject<React.ElementRef<typeof TabsPrimitive.List>>;
+  }
+) => (<TabsPrimitive.List
+  ref={ref}
+  className={cn(
+    "inline-flex h-9 items-center justify-center rounded-lg bg-muted p-1 text-muted-foreground",
+    className
+  )}
+  {...props}
+/>);
 TabsList.displayName = TabsPrimitive.List.displayName;
 
-const TabsTrigger = React.forwardRef<
-  React.ElementRef<typeof TabsPrimitive.Trigger>,
-  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger>
->(({ className, onClick, ...props }, ref) => {
+const TabsTrigger = (
+  {
+    ref,
+    className,
+    onClick,
+    ...props
+  }: React.ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger> & {
+    ref: React.RefObject<React.ElementRef<typeof TabsPrimitive.Trigger>>;
+  }
+) => {
   const { play: playClick } = useSound(Sounds.BUTTON_CLICK, 0.3);
 
   const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
@@ -43,22 +52,25 @@ const TabsTrigger = React.forwardRef<
       {...props}
     />
   );
-});
+};
 TabsTrigger.displayName = TabsPrimitive.Trigger.displayName;
 
-const TabsContent = React.forwardRef<
-  React.ElementRef<typeof TabsPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Content>
->(({ className, ...props }, ref) => (
-  <TabsPrimitive.Content
-    ref={ref}
-    className={cn(
-      "mt-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
-      className
-    )}
-    {...props}
-  />
-));
+const TabsContent = (
+  {
+    ref,
+    className,
+    ...props
+  }: React.ComponentPropsWithoutRef<typeof TabsPrimitive.Content> & {
+    ref: React.RefObject<React.ElementRef<typeof TabsPrimitive.Content>>;
+  }
+) => (<TabsPrimitive.Content
+  ref={ref}
+  className={cn(
+    "mt-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+    className
+  )}
+  {...props}
+/>);
 TabsContent.displayName = TabsPrimitive.Content.displayName;
 
 export { Tabs, TabsList, TabsTrigger, TabsContent };

--- a/src/components/ui/toolbar-button.tsx
+++ b/src/components/ui/toolbar-button.tsx
@@ -14,7 +14,7 @@ export const ToolbarButton = (
     children,
     ...props
   }: ToolbarButtonProps & {
-    ref: React.RefObject<HTMLButtonElement>;
+    ref?: React.Ref<HTMLButtonElement>;
   }
 ) => (<button
   ref={ref}
@@ -42,7 +42,7 @@ export const ToolbarButtonGroup = (
     children,
     ...props
   }: ToolbarButtonGroupProps & {
-    ref: React.RefObject<HTMLDivElement>;
+    ref?: React.Ref<HTMLDivElement>;
   }
 ) => (<div
   ref={ref}

--- a/src/components/ui/toolbar-button.tsx
+++ b/src/components/ui/toolbar-button.tsx
@@ -6,23 +6,28 @@ interface ToolbarButtonProps
   icon?: boolean;
 }
 
-export const ToolbarButton = React.forwardRef<
-  HTMLButtonElement,
-  ToolbarButtonProps
->(({ className, icon = false, children, ...props }, ref) => (
-  <button
-    ref={ref}
-    type="button"
-    className={cn(
-      "metal-inset-btn",
-      icon && "metal-inset-icon",
-      className
-    )}
-    {...props}
-  >
-    {children}
-  </button>
-));
+export const ToolbarButton = (
+  {
+    ref,
+    className,
+    icon = false,
+    children,
+    ...props
+  }: ToolbarButtonProps & {
+    ref: React.RefObject<HTMLButtonElement>;
+  }
+) => (<button
+  ref={ref}
+  type="button"
+  className={cn(
+    "metal-inset-btn",
+    icon && "metal-inset-icon",
+    className
+  )}
+  {...props}
+>
+  {children}
+</button>);
 ToolbarButton.displayName = "ToolbarButton";
 
 interface ToolbarButtonGroupProps
@@ -30,16 +35,20 @@ interface ToolbarButtonGroupProps
   children: React.ReactNode;
 }
 
-export const ToolbarButtonGroup = React.forwardRef<
-  HTMLDivElement,
-  ToolbarButtonGroupProps
->(({ className, children, ...props }, ref) => (
-  <div
-    ref={ref}
-    className={cn("metal-inset-btn-group", className)}
-    {...props}
-  >
-    {children}
-  </div>
-));
+export const ToolbarButtonGroup = (
+  {
+    ref,
+    className,
+    children,
+    ...props
+  }: ToolbarButtonGroupProps & {
+    ref: React.RefObject<HTMLDivElement>;
+  }
+) => (<div
+  ref={ref}
+  className={cn("metal-inset-btn-group", className)}
+  {...props}
+>
+  {children}
+</div>);
 ToolbarButtonGroup.displayName = "ToolbarButtonGroup";

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -9,22 +9,26 @@ const Tooltip = TooltipPrimitive.Root;
 
 const TooltipTrigger = TooltipPrimitive.Trigger;
 
-const TooltipContent = React.forwardRef<
-  React.ElementRef<typeof TooltipPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content>
->(({ className, sideOffset = 4, ...props }, ref) => (
-  <TooltipPrimitive.Portal>
-    <TooltipPrimitive.Content
-      ref={ref}
-      sideOffset={sideOffset}
-      className={cn(
-        "z-50 overflow-hidden rounded-md bg-primary px-3 py-1.5 text-xs text-primary-foreground animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 font-geneva-12 text-[12px]",
-        className
-      )}
-      {...props}
-    />
-  </TooltipPrimitive.Portal>
-));
+const TooltipContent = (
+  {
+    ref,
+    className,
+    sideOffset = 4,
+    ...props
+  }: React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content> & {
+    ref: React.RefObject<React.ElementRef<typeof TooltipPrimitive.Content>>;
+  }
+) => (<TooltipPrimitive.Portal>
+  <TooltipPrimitive.Content
+    ref={ref}
+    sideOffset={sideOffset}
+    className={cn(
+      "z-50 overflow-hidden rounded-md bg-primary px-3 py-1.5 text-xs text-primary-foreground animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 font-geneva-12 text-[12px]",
+      className
+    )}
+    {...props}
+  />
+</TooltipPrimitive.Portal>);
 TooltipContent.displayName = TooltipPrimitive.Content.displayName;
 
 export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider };

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -16,7 +16,7 @@ const TooltipContent = (
     sideOffset = 4,
     ...props
   }: React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content> & {
-    ref: React.RefObject<React.ElementRef<typeof TooltipPrimitive.Content>>;
+    ref?: React.Ref<React.ElementRef<typeof TooltipPrimitive.Content>>;
   }
 ) => (<TooltipPrimitive.Portal>
   <TooltipPrimitive.Content


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- migrate the targeted React 19 deprecations by replacing `forwardRef(...)` wrappers with ref-as-prop component signatures across the listed UI/app/shared components
- replace `useContext(...)` / `React.useContext(...)` reads with `use(...)` for branch-aware context access
- restore optional custom props and ref typings where the codemod over-constrained component APIs (to preserve existing call sites)

## Validation
- `bun run build`
- `bun run test:unit`
- repo scan confirms no remaining `forwardRef`/`useContext(...)` usages in `src/`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4b5375bb-f459-42b5-9168-372485c37c93"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4b5375bb-f459-42b5-9168-372485c37c93"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

