### PR TITLE
Refactor cascading setState usage to useReducer state objects

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,6 @@
 import { AppManager } from "./apps/base/AppManager";
 import { appRegistry } from "./config/appRegistry";
-import { useEffect, useState, useMemo } from "react";
+import { useEffect, useMemo, useReducer, useCallback } from "react";
 import { applyDisplayMode } from "./utils/displayMode";
 import { Toaster } from "./components/ui/sonner";
 import { toast } from "sonner";
@@ -25,6 +25,36 @@ import { ReactScanDebug } from "@/components/ReactScanDebug";
 
 // Convert registry to array
 const apps: AnyApp[] = Object.values(appRegistry);
+
+interface BootUiState {
+  bootScreenMessage: string | null;
+  showBootScreen: boolean;
+  bootDebugMode: boolean;
+}
+
+const bootUiInitialState: BootUiState = {
+  bootScreenMessage: null,
+  showBootScreen: false,
+  bootDebugMode: false,
+};
+
+type BootUiAction =
+  | { type: "setMessage"; value: string | null }
+  | { type: "setVisible"; value: boolean }
+  | { type: "setDebugMode"; value: boolean };
+
+function bootUiReducer(state: BootUiState, action: BootUiAction): BootUiState {
+  switch (action.type) {
+    case "setMessage":
+      return { ...state, bootScreenMessage: action.value };
+    case "setVisible":
+      return { ...state, showBootScreen: action.value };
+    case "setDebugMode":
+      return { ...state, bootDebugMode: action.value };
+    default:
+      return state;
+  }
+}
 
 export function App() {
   const { t } = useTranslation();
@@ -73,11 +103,20 @@ export function App() {
     }
   }, [isWindowsTheme, isMacOSTheme, isSystem7Theme, isMobile]);
 
-  const [bootScreenMessage, setBootScreenMessage] = useState<string | null>(
-    null
+  const [bootUiState, dispatchBootUi] = useReducer(
+    bootUiReducer,
+    bootUiInitialState
   );
-  const [showBootScreen, setShowBootScreen] = useState(false);
-  const [bootDebugMode, setBootDebugMode] = useState(false);
+  const { bootScreenMessage, showBootScreen, bootDebugMode } = bootUiState;
+  const setBootScreenMessage = useCallback((value: string | null) => {
+    dispatchBootUi({ type: "setMessage", value });
+  }, []);
+  const setShowBootScreen = useCallback((value: boolean) => {
+    dispatchBootUi({ type: "setVisible", value });
+  }, []);
+  const setBootDebugMode = useCallback((value: boolean) => {
+    dispatchBootUi({ type: "setDebugMode", value });
+  }, []);
 
   useEffect(() => {
     applyDisplayMode(displayMode);

--- a/src/apps/admin/components/SongDetailPanel.tsx
+++ b/src/apps/admin/components/SongDetailPanel.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from "react";
+import React, { useState, useEffect, useCallback, useReducer } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { ScrollArea } from "@/components/ui/scroll-area";
@@ -77,6 +77,92 @@ export const SongDetailPanel: React.FC<SongDetailPanelProps> = ({
   const { t } = useTranslation();
   const { username, isAuthenticated } = useAuth();
   const launchApp = useLaunchApp();
+  type SongEditState = {
+    isEditingTitle: boolean;
+    isEditingArtist: boolean;
+    isEditingAlbum: boolean;
+    isEditingOffset: boolean;
+    editTitle: string;
+    editArtist: string;
+    editAlbum: string;
+    editOffset: string;
+    isSaving: boolean;
+  };
+  type SongEditAction =
+    | { type: "startEdit"; field: "title" | "artist" | "album" | "offset"; value: string }
+    | {
+        type: "setValue";
+        field: "editTitle" | "editArtist" | "editAlbum" | "editOffset";
+        value: string;
+      }
+    | { type: "stopEditing"; field?: "title" | "artist" | "album" | "offset" }
+    | { type: "setSaving"; isSaving: boolean };
+  const initialEditState: SongEditState = {
+    isEditingTitle: false,
+    isEditingArtist: false,
+    isEditingAlbum: false,
+    isEditingOffset: false,
+    editTitle: "",
+    editArtist: "",
+    editAlbum: "",
+    editOffset: "",
+    isSaving: false,
+  };
+  const editReducer = (
+    state: SongEditState,
+    action: SongEditAction
+  ): SongEditState => {
+    switch (action.type) {
+      case "startEdit":
+        return {
+          ...state,
+          isEditingTitle: action.field === "title",
+          isEditingArtist: action.field === "artist",
+          isEditingAlbum: action.field === "album",
+          isEditingOffset: action.field === "offset",
+          editTitle: action.field === "title" ? action.value : state.editTitle,
+          editArtist:
+            action.field === "artist" ? action.value : state.editArtist,
+          editAlbum: action.field === "album" ? action.value : state.editAlbum,
+          editOffset:
+            action.field === "offset" ? action.value : state.editOffset,
+        };
+      case "setValue":
+        return { ...state, [action.field]: action.value };
+      case "stopEditing":
+        if (!action.field) {
+          return {
+            ...state,
+            isEditingTitle: false,
+            isEditingArtist: false,
+            isEditingAlbum: false,
+            isEditingOffset: false,
+          };
+        }
+        if (action.field === "title") return { ...state, isEditingTitle: false };
+        if (action.field === "artist") {
+          return { ...state, isEditingArtist: false };
+        }
+        if (action.field === "album") return { ...state, isEditingAlbum: false };
+        return { ...state, isEditingOffset: false };
+      case "setSaving":
+        return { ...state, isSaving: action.isSaving };
+      default:
+        return state;
+    }
+  };
+  const [editState, dispatchEdit] = useReducer(editReducer, initialEditState);
+  const {
+    isEditingTitle,
+    isEditingArtist,
+    isEditingAlbum,
+    isEditingOffset,
+    editTitle,
+    editArtist,
+    editAlbum,
+    editOffset,
+    isSaving,
+  } = editState;
   const [song, setSong] = useState<SongDetail | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [youtubeOembedTitle, setYoutubeOembedTitle] = useState<string | null>(null);
@@ -86,17 +172,6 @@ export const SongDetailPanel: React.FC<SongDetailPanelProps> = ({
   const [isUnsharing, setIsUnsharing] = useState(false);
   const [isForceRefreshing, setIsForceRefreshing] = useState(false);
   const [isLyricsSearchDialogOpen, setIsLyricsSearchDialogOpen] = useState(false);
-  
-  // Edit states
-  const [isEditingTitle, setIsEditingTitle] = useState(false);
-  const [isEditingArtist, setIsEditingArtist] = useState(false);
-  const [isEditingAlbum, setIsEditingAlbum] = useState(false);
-  const [isEditingOffset, setIsEditingOffset] = useState(false);
-  const [editTitle, setEditTitle] = useState("");
-  const [editArtist, setEditArtist] = useState("");
-  const [editAlbum, setEditAlbum] = useState("");
-  const [editOffset, setEditOffset] = useState("");
-  const [isSaving, setIsSaving] = useState(false);
 
   const fetchSong = useCallback(async () => {
     setIsLoading(true);
@@ -433,7 +508,7 @@ export const SongDetailPanel: React.FC<SongDetailPanelProps> = ({
   const saveField = async (field: "title" | "artist" | "album" | "lyricOffset", value: string) => {
     if (!song || !username || !isAuthenticated) return;
 
-    setIsSaving(true);
+    dispatchEdit({ type: "setSaving", isSaving: true });
     try {
       const updatedMetadata = {
         youtubeId: song.id,
@@ -456,11 +531,8 @@ export const SongDetailPanel: React.FC<SongDetailPanelProps> = ({
       console.error("Failed to update song:", error);
       toast.error(t("apps.admin.errors.failedToUpdateSong", "Failed to update song"));
     } finally {
-      setIsSaving(false);
-      setIsEditingTitle(false);
-      setIsEditingArtist(false);
-      setIsEditingAlbum(false);
-      setIsEditingOffset(false);
+      dispatchEdit({ type: "setSaving", isSaving: false });
+      dispatchEdit({ type: "stopEditing" });
     }
   };
 
@@ -669,7 +741,13 @@ export const SongDetailPanel: React.FC<SongDetailPanelProps> = ({
                     <div className="flex items-center gap-1 mt-1">
                       <Input
                         value={editTitle}
-                        onChange={(e) => setEditTitle(e.target.value)}
+                        onChange={(e) =>
+                          dispatchEdit({
+                            type: "setValue",
+                            field: "editTitle",
+                            value: e.target.value,
+                          })
+                        }
                         className="h-6 text-[11px] flex-1"
                         autoFocus
                       />
@@ -684,7 +762,9 @@ export const SongDetailPanel: React.FC<SongDetailPanelProps> = ({
                       <Button
                         size="sm"
                         variant="ghost"
-                        onClick={() => setIsEditingTitle(false)}
+                        onClick={() =>
+                          dispatchEdit({ type: "stopEditing", field: "title" })
+                        }
                         className="h-6 px-2 text-[10px]"
                       >
                         {t("common.dialog.cancel")}
@@ -694,8 +774,11 @@ export const SongDetailPanel: React.FC<SongDetailPanelProps> = ({
                     <div
                       className="text-[11px] cursor-pointer hover:text-blue-600 mt-0.5"
                       onClick={() => {
-                        setEditTitle(song?.title || "");
-                        setIsEditingTitle(true);
+                        dispatchEdit({
+                          type: "startEdit",
+                          field: "title",
+                          value: song?.title || "",
+                        });
                       }}
                     >
                       {song?.title}
@@ -715,7 +798,13 @@ export const SongDetailPanel: React.FC<SongDetailPanelProps> = ({
                     <div className="flex items-center gap-1 mt-1">
                       <Input
                         value={editArtist}
-                        onChange={(e) => setEditArtist(e.target.value)}
+                        onChange={(e) =>
+                          dispatchEdit({
+                            type: "setValue",
+                            field: "editArtist",
+                            value: e.target.value,
+                          })
+                        }
                         className="h-6 text-[11px] flex-1"
                         autoFocus
                       />
@@ -730,7 +819,9 @@ export const SongDetailPanel: React.FC<SongDetailPanelProps> = ({
                       <Button
                         size="sm"
                         variant="ghost"
-                        onClick={() => setIsEditingArtist(false)}
+                        onClick={() =>
+                          dispatchEdit({ type: "stopEditing", field: "artist" })
+                        }
                         className="h-6 px-2 text-[10px]"
                       >
                         {t("common.dialog.cancel")}
@@ -740,8 +831,11 @@ export const SongDetailPanel: React.FC<SongDetailPanelProps> = ({
                     <div
                       className="text-[11px] cursor-pointer hover:text-blue-600 mt-0.5"
                       onClick={() => {
-                        setEditArtist(song?.artist || "");
-                        setIsEditingArtist(true);
+                        dispatchEdit({
+                          type: "startEdit",
+                          field: "artist",
+                          value: song?.artist || "",
+                        });
                       }}
                     >
                       {song?.artist || <span className="text-neutral-400">-</span>}
@@ -761,7 +855,13 @@ export const SongDetailPanel: React.FC<SongDetailPanelProps> = ({
                     <div className="flex items-center gap-1 mt-1">
                       <Input
                         value={editAlbum}
-                        onChange={(e) => setEditAlbum(e.target.value)}
+                        onChange={(e) =>
+                          dispatchEdit({
+                            type: "setValue",
+                            field: "editAlbum",
+                            value: e.target.value,
+                          })
+                        }
                         className="h-6 text-[11px] flex-1"
                         autoFocus
                       />
@@ -776,7 +876,9 @@ export const SongDetailPanel: React.FC<SongDetailPanelProps> = ({
                       <Button
                         size="sm"
                         variant="ghost"
-                        onClick={() => setIsEditingAlbum(false)}
+                        onClick={() =>
+                          dispatchEdit({ type: "stopEditing", field: "album" })
+                        }
                         className="h-6 px-2 text-[10px]"
                       >
                         {t("common.dialog.cancel")}
@@ -786,8 +888,11 @@ export const SongDetailPanel: React.FC<SongDetailPanelProps> = ({
                     <div
                       className="text-[11px] cursor-pointer hover:text-blue-600 mt-0.5"
                       onClick={() => {
-                        setEditAlbum(song?.album || "");
-                        setIsEditingAlbum(true);
+                        dispatchEdit({
+                          type: "startEdit",
+                          field: "album",
+                          value: song?.album || "",
+                        });
                       }}
                     >
                       {song?.album || <span className="text-neutral-400">-</span>}
@@ -808,7 +913,13 @@ export const SongDetailPanel: React.FC<SongDetailPanelProps> = ({
                       <Input
                         type="number"
                         value={editOffset}
-                        onChange={(e) => setEditOffset(e.target.value)}
+                        onChange={(e) =>
+                          dispatchEdit({
+                            type: "setValue",
+                            field: "editOffset",
+                            value: e.target.value,
+                          })
+                        }
                         className="h-6 text-[11px] flex-1"
                         autoFocus
                       />
@@ -824,7 +935,9 @@ export const SongDetailPanel: React.FC<SongDetailPanelProps> = ({
                       <Button
                         size="sm"
                         variant="ghost"
-                        onClick={() => setIsEditingOffset(false)}
+                        onClick={() =>
+                          dispatchEdit({ type: "stopEditing", field: "offset" })
+                        }
                         className="h-6 px-2 text-[10px]"
                       >
                         {t("common.dialog.cancel")}
@@ -834,8 +947,11 @@ export const SongDetailPanel: React.FC<SongDetailPanelProps> = ({
                     <div
                       className="text-[11px] cursor-pointer hover:text-blue-600 mt-0.5"
                       onClick={() => {
-                        setEditOffset(String(song?.lyricOffset || 0));
-                        setIsEditingOffset(true);
+                        dispatchEdit({
+                          type: "startEdit",
+                          field: "offset",
+                          value: String(song?.lyricOffset || 0),
+                        });
                       }}
                     >
                       {formatOffset(song?.lyricOffset)}

--- a/src/apps/admin/components/UserProfilePanel.tsx
+++ b/src/apps/admin/components/UserProfilePanel.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from "react";
+import React, { useState, useEffect, useCallback, useReducer } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { ScrollArea } from "@/components/ui/scroll-area";
@@ -102,29 +102,103 @@ export const UserProfilePanel: React.FC<UserProfilePanelProps> = ({
 }) => {
   const { t } = useTranslation();
   const { username: currentUser, isAuthenticated } = useAuth();
+  type UserProfileUiState = {
+    expandedMemories: Set<string>;
+    expandedDailyNotes: Set<string>;
+    expandedHeartbeats: Set<string>;
+    banReason: string;
+    showBanInput: boolean;
+    isRoomsOpen: boolean;
+    isMessagesOpen: boolean;
+    isMemoriesOpen: boolean;
+    isHeartbeatsOpen: boolean;
+    hasLoadedMessages: boolean;
+    hasLoadedMemories: boolean;
+    hasLoadedHeartbeats: boolean;
+    isMessagesLoading: boolean;
+    isMemoriesLoading: boolean;
+    isHeartbeatsLoading: boolean;
+  };
+  type UserProfileUiAction =
+    | { type: "resetForUsername" }
+    | { type: "set"; payload: Partial<UserProfileUiState> }
+    | { type: "toggleMemory"; key: string }
+    | { type: "toggleDailyNote"; date: string }
+    | { type: "toggleHeartbeat"; id: string };
+  const initialUiState: UserProfileUiState = {
+    expandedMemories: new Set(),
+    expandedDailyNotes: new Set(),
+    expandedHeartbeats: new Set(),
+    banReason: "",
+    showBanInput: false,
+    isRoomsOpen: false,
+    isMessagesOpen: false,
+    isMemoriesOpen: false,
+    isHeartbeatsOpen: false,
+    hasLoadedMessages: false,
+    hasLoadedMemories: false,
+    hasLoadedHeartbeats: false,
+    isMessagesLoading: false,
+    isMemoriesLoading: false,
+    isHeartbeatsLoading: false,
+  };
+  const reducer = (
+    state: UserProfileUiState,
+    action: UserProfileUiAction
+  ): UserProfileUiState => {
+    switch (action.type) {
+      case "resetForUsername":
+        return initialUiState;
+      case "set":
+        return { ...state, ...action.payload };
+      case "toggleMemory": {
+        const next = new Set(state.expandedMemories);
+        if (next.has(action.key)) next.delete(action.key);
+        else next.add(action.key);
+        return { ...state, expandedMemories: next };
+      }
+      case "toggleDailyNote": {
+        const next = new Set(state.expandedDailyNotes);
+        if (next.has(action.date)) next.delete(action.date);
+        else next.add(action.date);
+        return { ...state, expandedDailyNotes: next };
+      }
+      case "toggleHeartbeat": {
+        const next = new Set(state.expandedHeartbeats);
+        if (next.has(action.id)) next.delete(action.id);
+        else next.add(action.id);
+        return { ...state, expandedHeartbeats: next };
+      }
+      default:
+        return state;
+    }
+  };
+  const [uiState, dispatchUi] = useReducer(reducer, initialUiState);
+  const {
+    expandedMemories,
+    expandedDailyNotes,
+    expandedHeartbeats,
+    banReason,
+    showBanInput,
+    isRoomsOpen,
+    isMessagesOpen,
+    isMemoriesOpen,
+    isHeartbeatsOpen,
+    hasLoadedMessages,
+    hasLoadedMemories,
+    hasLoadedHeartbeats,
+    isMessagesLoading,
+    isMemoriesLoading,
+    isHeartbeatsLoading,
+  } = uiState;
   const [profile, setProfile] = useState<UserProfile | null>(null);
   const [messages, setMessages] = useState<UserMessage[]>([]);
   const [memories, setMemories] = useState<UserMemory[]>([]);
   const [dailyNotes, setDailyNotes] = useState<DailyNote[]>([]);
   const [heartbeats, setHeartbeats] = useState<HeartbeatRecord[]>([]);
-  const [expandedMemories, setExpandedMemories] = useState<Set<string>>(new Set());
-  const [expandedDailyNotes, setExpandedDailyNotes] = useState<Set<string>>(new Set());
-  const [expandedHeartbeats, setExpandedHeartbeats] = useState<Set<string>>(new Set());
   const [isLoading, setIsLoading] = useState(true);
-  const [banReason, setBanReason] = useState("");
-  const [showBanInput, setShowBanInput] = useState(false);
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
   const [isBanDialogOpen, setIsBanDialogOpen] = useState(false);
-  const [isRoomsOpen, setIsRoomsOpen] = useState(false);
-  const [isMessagesOpen, setIsMessagesOpen] = useState(false);
-  const [isMemoriesOpen, setIsMemoriesOpen] = useState(false);
-  const [isHeartbeatsOpen, setIsHeartbeatsOpen] = useState(false);
-  const [hasLoadedMessages, setHasLoadedMessages] = useState(false);
-  const [hasLoadedMemories, setHasLoadedMemories] = useState(false);
-  const [hasLoadedHeartbeats, setHasLoadedHeartbeats] = useState(false);
-  const [isMessagesLoading, setIsMessagesLoading] = useState(false);
-  const [isMemoriesLoading, setIsMemoriesLoading] = useState(false);
-  const [isHeartbeatsLoading, setIsHeartbeatsLoading] = useState(false);
   const [isClearMemoryDialogOpen, setIsClearMemoryDialogOpen] = useState(false);
   const [isForceProcessDialogOpen, setIsForceProcessDialogOpen] = useState(false);
   const [isClearingMemory, setIsClearingMemory] = useState(false);
@@ -187,39 +261,15 @@ export const UserProfilePanel: React.FC<UserProfilePanelProps> = ({
   }, [username, isAuthenticated, currentUser]);
 
   const toggleMemory = useCallback((key: string) => {
-    setExpandedMemories((prev) => {
-      const next = new Set(prev);
-      if (next.has(key)) {
-        next.delete(key);
-      } else {
-        next.add(key);
-      }
-      return next;
-    });
+    dispatchUi({ type: "toggleMemory", key });
   }, []);
 
   const toggleDailyNote = useCallback((date: string) => {
-    setExpandedDailyNotes((prev) => {
-      const next = new Set(prev);
-      if (next.has(date)) {
-        next.delete(date);
-      } else {
-        next.add(date);
-      }
-      return next;
-    });
+    dispatchUi({ type: "toggleDailyNote", date });
   }, []);
 
   const toggleHeartbeat = useCallback((id: string) => {
-    setExpandedHeartbeats((prev) => {
-      const next = new Set(prev);
-      if (next.has(id)) {
-        next.delete(id);
-      } else {
-        next.add(id);
-      }
-      return next;
-    });
+    dispatchUi({ type: "toggleHeartbeat", id });
   }, []);
 
   useEffect(() => {
@@ -228,21 +278,7 @@ export const UserProfilePanel: React.FC<UserProfilePanelProps> = ({
     setMemories([]);
     setDailyNotes([]);
     setHeartbeats([]);
-    setExpandedMemories(new Set());
-    setExpandedDailyNotes(new Set());
-    setExpandedHeartbeats(new Set());
-    setShowBanInput(false);
-    setBanReason("");
-    setIsRoomsOpen(false);
-    setIsMessagesOpen(false);
-    setIsMemoriesOpen(false);
-    setIsHeartbeatsOpen(false);
-    setHasLoadedMessages(false);
-    setHasLoadedMemories(false);
-    setHasLoadedHeartbeats(false);
-    setIsMessagesLoading(false);
-    setIsMemoriesLoading(false);
-    setIsHeartbeatsLoading(false);
+    dispatchUi({ type: "resetForUsername" });
     setIsLoading(true);
     fetchProfile().finally(() => {
       setIsLoading(false);
@@ -251,46 +287,46 @@ export const UserProfilePanel: React.FC<UserProfilePanelProps> = ({
 
   const loadMessages = useCallback(async () => {
     if (hasLoadedMessages || isMessagesLoading) return;
-    setIsMessagesLoading(true);
+    dispatchUi({ type: "set", payload: { isMessagesLoading: true } });
     try {
       const didLoad = await fetchMessages();
       if (didLoad) {
-        setHasLoadedMessages(true);
+        dispatchUi({ type: "set", payload: { hasLoadedMessages: true } });
       }
     } finally {
-      setIsMessagesLoading(false);
+      dispatchUi({ type: "set", payload: { isMessagesLoading: false } });
     }
   }, [fetchMessages, hasLoadedMessages, isMessagesLoading]);
 
   const loadMemories = useCallback(async () => {
     if (hasLoadedMemories || isMemoriesLoading) return;
-    setIsMemoriesLoading(true);
+    dispatchUi({ type: "set", payload: { isMemoriesLoading: true } });
     try {
       const didLoad = await fetchMemories();
       if (didLoad) {
-        setHasLoadedMemories(true);
+        dispatchUi({ type: "set", payload: { hasLoadedMemories: true } });
       }
     } finally {
-      setIsMemoriesLoading(false);
+      dispatchUi({ type: "set", payload: { isMemoriesLoading: false } });
     }
   }, [fetchMemories, hasLoadedMemories, isMemoriesLoading]);
 
   const loadHeartbeats = useCallback(async () => {
     if (hasLoadedHeartbeats || isHeartbeatsLoading) return;
-    setIsHeartbeatsLoading(true);
+    dispatchUi({ type: "set", payload: { isHeartbeatsLoading: true } });
     try {
       const didLoad = await fetchHeartbeats();
       if (didLoad) {
-        setHasLoadedHeartbeats(true);
+        dispatchUi({ type: "set", payload: { hasLoadedHeartbeats: true } });
       }
     } finally {
-      setIsHeartbeatsLoading(false);
+      dispatchUi({ type: "set", payload: { isHeartbeatsLoading: false } });
     }
   }, [fetchHeartbeats, hasLoadedHeartbeats, isHeartbeatsLoading]);
 
   const toggleMessagesSection = useCallback(() => {
     const nextIsOpen = !isMessagesOpen;
-    setIsMessagesOpen(nextIsOpen);
+    dispatchUi({ type: "set", payload: { isMessagesOpen: nextIsOpen } });
     if (nextIsOpen && !hasLoadedMessages && !isMessagesLoading) {
       void loadMessages();
     }
@@ -298,7 +334,7 @@ export const UserProfilePanel: React.FC<UserProfilePanelProps> = ({
 
   const toggleMemoriesSection = useCallback(() => {
     const nextIsOpen = !isMemoriesOpen;
-    setIsMemoriesOpen(nextIsOpen);
+    dispatchUi({ type: "set", payload: { isMemoriesOpen: nextIsOpen } });
     if (nextIsOpen && !hasLoadedMemories && !isMemoriesLoading) {
       void loadMemories();
     }
@@ -306,7 +342,7 @@ export const UserProfilePanel: React.FC<UserProfilePanelProps> = ({
 
   const toggleHeartbeatsSection = useCallback(() => {
     const nextIsOpen = !isHeartbeatsOpen;
-    setIsHeartbeatsOpen(nextIsOpen);
+    dispatchUi({ type: "set", payload: { isHeartbeatsOpen: nextIsOpen } });
     if (nextIsOpen && !hasLoadedHeartbeats && !isHeartbeatsLoading) {
       void loadHeartbeats();
     }
@@ -317,8 +353,10 @@ export const UserProfilePanel: React.FC<UserProfilePanelProps> = ({
     try {
       await banAdminUser<{ success: boolean }>(username, banReason || undefined);
       toast.success(t("apps.admin.messages.userBanned", { username }));
-      setShowBanInput(false);
-      setBanReason("");
+      dispatchUi({
+        type: "set",
+        payload: { showBanInput: false, banReason: "" },
+      });
       fetchProfile();
     } catch (error) {
       console.error("Failed to ban user:", error);
@@ -610,7 +648,12 @@ export const UserProfilePanel: React.FC<UserProfilePanelProps> = ({
                           <Input
                             placeholder={t("apps.admin.profile.banReasonPlaceholder")}
                             value={banReason}
-                            onChange={(e) => setBanReason(e.target.value)}
+                            onChange={(e) =>
+                              dispatchUi({
+                                type: "set",
+                                payload: { banReason: e.target.value },
+                              })
+                            }
                             className="h-7 text-[11px] flex-1"
                           />
                           <button
@@ -622,8 +665,10 @@ export const UserProfilePanel: React.FC<UserProfilePanelProps> = ({
                           </button>
                           <button
                             onClick={() => {
-                              setShowBanInput(false);
-                              setBanReason("");
+                              dispatchUi({
+                                type: "set",
+                                payload: { showBanInput: false, banReason: "" },
+                              });
                             }}
                             className="aqua-button secondary h-7 px-3 text-[11px]"
                           >
@@ -632,7 +677,12 @@ export const UserProfilePanel: React.FC<UserProfilePanelProps> = ({
                         </div>
                       ) : (
                         <button
-                          onClick={() => setShowBanInput(true)}
+                          onClick={() =>
+                            dispatchUi({
+                              type: "set",
+                              payload: { showBanInput: true },
+                            })
+                          }
                           className={adminAquaIconButtonClass("orange")}
                           style={{ color: "#000", textShadow: "none" }}
                         >
@@ -996,7 +1046,12 @@ export const UserProfilePanel: React.FC<UserProfilePanelProps> = ({
           ) : (
             <div className="space-y-2">
               <SectionHeader
-                onClick={() => setIsRoomsOpen((prev) => !prev)}
+                onClick={() =>
+                  dispatchUi({
+                    type: "set",
+                    payload: { isRoomsOpen: !isRoomsOpen },
+                  })
+                }
                 isOpen={isRoomsOpen}
                 showCaret={true}
               >

--- a/src/apps/admin/hooks/useAdminLogic.ts
+++ b/src/apps/admin/hooks/useAdminLogic.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useReducer, useRef, useState } from "react";
 import type { ChangeEvent } from "react";
 import { useTranslation } from "react-i18next";
 import { useTranslatedHelpItems } from "@/hooks/useTranslatedHelpItems";
@@ -188,7 +188,6 @@ export function useAdminLogic({ isWindowOpen }: UseAdminLogicProps) {
 
   const [users, setUsers] = useState<User[]>([]);
   const [rooms, setRooms] = useState<Room[]>([]);
-  const [selectedRoomId, setSelectedRoomId] = useState<string | null>(null);
   const [roomMessages, setRoomMessages] = useState<Message[]>([]);
   const [userSearch, setUserSearch] = useState("");
   const [isLoading, setIsLoading] = useState(false);
@@ -199,13 +198,72 @@ export function useAdminLogic({ isWindowOpen }: UseAdminLogicProps) {
     totalMessages: 0,
   });
 
-  const [activeSection, setActiveSection] = useState<AdminSection>("dashboard");
+  type AdminNavigationState = {
+    activeSection: AdminSection;
+    selectedRoomId: string | null;
+    selectedUserProfile: string | null;
+    selectedSongId: string | null;
+  };
+  type AdminNavigationAction =
+    | { type: "setActiveSection"; activeSection: AdminSection }
+    | { type: "setSelectedRoomId"; selectedRoomId: string | null }
+    | { type: "setSelectedUserProfile"; selectedUserProfile: string | null }
+    | { type: "setSelectedSongId"; selectedSongId: string | null }
+    | {
+        type: "applyClearedSelection";
+        payload: Pick<
+          AdminNavigationState,
+          "selectedRoomId" | "selectedUserProfile" | "selectedSongId"
+        >;
+      };
+  const initialNavigationState: AdminNavigationState = {
+    activeSection: "dashboard",
+    selectedRoomId: null,
+    selectedUserProfile: null,
+    selectedSongId: null,
+  };
+  const navigationReducer = (
+    state: AdminNavigationState,
+    action: AdminNavigationAction
+  ): AdminNavigationState => {
+    switch (action.type) {
+      case "setActiveSection":
+        return { ...state, activeSection: action.activeSection };
+      case "setSelectedRoomId":
+        return { ...state, selectedRoomId: action.selectedRoomId };
+      case "setSelectedUserProfile":
+        return { ...state, selectedUserProfile: action.selectedUserProfile };
+      case "setSelectedSongId":
+        return { ...state, selectedSongId: action.selectedSongId };
+      case "applyClearedSelection":
+        return { ...state, ...action.payload };
+      default:
+        return state;
+    }
+  };
+  const [navigationState, dispatchNavigation] = useReducer(
+    navigationReducer,
+    initialNavigationState
+  );
+  const { activeSection, selectedRoomId, selectedUserProfile, selectedSongId } =
+    navigationState;
+  const setActiveSection = useCallback((nextSection: AdminSection) => {
+    dispatchNavigation({ type: "setActiveSection", activeSection: nextSection });
+  }, []);
+  const setSelectedRoomId = useCallback((roomId: string | null) => {
+    dispatchNavigation({ type: "setSelectedRoomId", selectedRoomId: roomId });
+  }, []);
+  const setSelectedUserProfile = useCallback((profile: string | null) => {
+    dispatchNavigation({
+      type: "setSelectedUserProfile",
+      selectedUserProfile: profile,
+    });
+  }, []);
+  const setSelectedSongId = useCallback((songId: string | null) => {
+    dispatchNavigation({ type: "setSelectedSongId", selectedSongId: songId });
+  }, []);
   const [cursorAgentsRefreshSignal, setCursorAgentsRefreshSignal] = useState(0);
   const [isRoomsExpanded, setIsRoomsExpanded] = useState(true);
-  const [selectedUserProfile, setSelectedUserProfile] = useState<string | null>(
-    null
-  );
-  const [selectedSongId, setSelectedSongId] = useState<string | null>(null);
   const [songs, setSongs] = useState<CachedSongMetadata[]>([]);
   const [songSearch, setSongSearch] = useState("");
   const [songsFilterByRyoOnly, setSongsFilterByRyoOnly] = useState(false);
@@ -1015,16 +1073,14 @@ export function useAdminLogic({ isWindowOpen }: UseAdminLogicProps) {
       selectedUserProfile,
       selectedSongId,
     });
-
-    if (nextSelectionState.selectedSongId !== selectedSongId) {
-      setSelectedSongId(nextSelectionState.selectedSongId);
-    }
-    if (nextSelectionState.selectedUserProfile !== selectedUserProfile) {
-      setSelectedUserProfile(nextSelectionState.selectedUserProfile);
-    }
-    if (nextSelectionState.selectedRoomId !== selectedRoomId) {
-      setSelectedRoomId(nextSelectionState.selectedRoomId);
-    }
+    dispatchNavigation({
+      type: "applyClearedSelection",
+      payload: {
+        selectedSongId: nextSelectionState.selectedSongId,
+        selectedUserProfile: nextSelectionState.selectedUserProfile,
+        selectedRoomId: nextSelectionState.selectedRoomId,
+      },
+    });
   }, [activeSection, selectedSongId, selectedUserProfile, selectedRoomId]);
 
   const handleRefresh = useCallback(() => {

--- a/src/apps/applet-viewer/components/AppStore.tsx
+++ b/src/apps/applet-viewer/components/AppStore.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useMemo, useCallback } from "react";
+import { useState, useEffect, useRef, useMemo, useCallback, useReducer } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { toast } from "sonner";
@@ -21,16 +21,99 @@ interface AppStoreProps {
   focusWindow?: () => void;
 }
 
+interface AppStoreUiState {
+  isLoading: boolean;
+  searchQuery: string;
+  selectedApplet: Applet | null;
+  selectedAppletContent: string;
+  isSharedApplet: boolean;
+  showListView: boolean;
+  isBulkUpdating: boolean;
+}
+
+const initialState: AppStoreUiState = {
+  isLoading: true,
+  searchQuery: "",
+  selectedApplet: null,
+  selectedAppletContent: "",
+  isSharedApplet: false,
+  showListView: false,
+  isBulkUpdating: false,
+};
+
+type AppStoreUiAction =
+  | { type: "setLoading"; value: boolean }
+  | { type: "setSearchQuery"; value: string }
+  | { type: "setSelectedApplet"; value: Applet | null }
+  | { type: "setSelectedAppletContent"; value: string }
+  | { type: "setShowListView"; value: boolean }
+  | { type: "setBulkUpdating"; value: boolean }
+  | { type: "setSelectedAppletDetail"; applet: Applet; content: string; isShared: boolean }
+  | { type: "clearSelectedAppletDetail" };
+
+function reducer(state: AppStoreUiState, action: AppStoreUiAction): AppStoreUiState {
+  switch (action.type) {
+    case "setLoading":
+      return { ...state, isLoading: action.value };
+    case "setSearchQuery":
+      return { ...state, searchQuery: action.value };
+    case "setSelectedApplet":
+      return { ...state, selectedApplet: action.value };
+    case "setSelectedAppletContent":
+      return { ...state, selectedAppletContent: action.value };
+    case "setShowListView":
+      return { ...state, showListView: action.value };
+    case "setBulkUpdating":
+      return { ...state, isBulkUpdating: action.value };
+    case "setSelectedAppletDetail":
+      return {
+        ...state,
+        selectedApplet: action.applet,
+        selectedAppletContent: action.content,
+        isSharedApplet: action.isShared,
+      };
+    case "clearSelectedAppletDetail":
+      return {
+        ...state,
+        selectedApplet: null,
+        isSharedApplet: false,
+      };
+    default:
+      return state;
+  }
+}
+
 export function AppStore({ theme, sharedAppletId, focusWindow }: AppStoreProps) {
   const { t } = useTranslation();
   const [applets, setApplets] = useState<Applet[]>([]);
-  const [isLoading, setIsLoading] = useState(true);
-  const [searchQuery, setSearchQuery] = useState("");
-  const [selectedApplet, setSelectedApplet] = useState<Applet | null>(null);
-  const [selectedAppletContent, setSelectedAppletContent] = useState<string>("");
-  const [isSharedApplet, setIsSharedApplet] = useState(false);
-  const [showListView, setShowListView] = useState(false);
-  const [isBulkUpdating, setIsBulkUpdating] = useState(false);
+  const [state, dispatch] = useReducer(reducer, initialState);
+  const {
+    isLoading,
+    searchQuery,
+    selectedApplet,
+    selectedAppletContent,
+    isSharedApplet,
+    showListView,
+    isBulkUpdating,
+  } = state;
+  const setIsLoading = useCallback((value: boolean) => {
+    dispatch({ type: "setLoading", value });
+  }, []);
+  const setSearchQuery = useCallback((value: string) => {
+    dispatch({ type: "setSearchQuery", value });
+  }, []);
+  const setSelectedApplet = useCallback((value: Applet | null) => {
+    dispatch({ type: "setSelectedApplet", value });
+  }, []);
+  const setSelectedAppletContent = useCallback((value: string) => {
+    dispatch({ type: "setSelectedAppletContent", value });
+  }, []);
+  const setShowListView = useCallback((value: boolean) => {
+    dispatch({ type: "setShowListView", value });
+  }, []);
+  const setIsBulkUpdating = useCallback((value: boolean) => {
+    dispatch({ type: "setBulkUpdating", value });
+  }, []);
   const feedRef = useRef<AppStoreFeedRef>(null);
   const username = useChatsStore((state) => state.username);
   const isAuthenticated = useChatsStore((state) => state.isAuthenticated);
@@ -225,9 +308,12 @@ export function AppStore({ theme, sharedAppletId, focusWindow }: AppStoreProps) 
             createdAt: data.createdAt || Date.now(),
             createdBy: data.createdBy,
           };
-          setSelectedApplet(applet);
-          setSelectedAppletContent(data.content || "");
-          setIsSharedApplet(true);
+          dispatch({
+            type: "setSelectedAppletDetail",
+            applet,
+            content: data.content || "",
+            isShared: true,
+          });
         } catch (error) {
           if (error instanceof Error && error.name === "AbortError") {
             return;
@@ -671,8 +757,7 @@ export function AppStore({ theme, sharedAppletId, focusWindow }: AppStoreProps) 
               variant="ghost"
               size="icon"
               onClick={() => {
-                setSelectedApplet(null);
-                setIsSharedApplet(false);
+                dispatch({ type: "clearSelectedAppletDetail" });
               }}
               className="h-7 w-7 flex-shrink-0"
             >

--- a/src/apps/applet-viewer/components/AppStoreFeed.tsx
+++ b/src/apps/applet-viewer/components/AppStoreFeed.tsx
@@ -1,4 +1,12 @@
-import { useState, useEffect, useRef, useImperativeHandle, forwardRef, useCallback } from "react";
+import {
+  useState,
+  useEffect,
+  useRef,
+  useImperativeHandle,
+  forwardRef,
+  useCallback,
+  useReducer,
+} from "react";
 import { Button } from "@/components/ui/button";
 import { useThemeFlags } from "@/hooks/useThemeFlags";
 import { useLatestRef } from "@/hooks/useLatestRef";
@@ -26,13 +34,55 @@ export interface AppStoreFeedRef {
   goToPrevious: () => void;
 }
 
+interface FeedUiState {
+  isLoading: boolean;
+  currentIndex: number;
+  navigationDirection: "forward" | "backward" | "none";
+}
+
+const initialState: FeedUiState = {
+  isLoading: true,
+  currentIndex: 0,
+  navigationDirection: "none",
+};
+
+type FeedUiAction =
+  | { type: "setLoading"; value: boolean }
+  | {
+      type: "setIndexWithDirection";
+      index: number;
+      previousIndex: number;
+    };
+
+function reducer(state: FeedUiState, action: FeedUiAction): FeedUiState {
+  switch (action.type) {
+    case "setLoading":
+      return { ...state, isLoading: action.value };
+    case "setIndexWithDirection":
+      return {
+        ...state,
+        currentIndex: action.index,
+        navigationDirection:
+          action.index > action.previousIndex
+            ? "forward"
+            : action.index < action.previousIndex
+            ? "backward"
+            : "none",
+      };
+    default:
+      return state;
+  }
+}
+
 export const AppStoreFeed = forwardRef<AppStoreFeedRef, AppStoreFeedProps>(
   ({ theme, focusWindow, onAppletSelect }, ref) => {
   const { t } = useTranslation();
   const [applets, setApplets] = useState<Applet[]>([]);
-  const [isLoading, setIsLoading] = useState(true);
-  const [currentIndex, setCurrentIndex] = useState(0);
-  const [navigationDirection, setNavigationDirection] = useState<"forward" | "backward" | "none">("none");
+  const [state, dispatch] = useReducer(reducer, initialState);
+  const { isLoading, currentIndex, navigationDirection } = state;
+  const setIsLoading = useCallback((value: boolean) => {
+    dispatch({ type: "setLoading", value });
+  }, []);
   const [appletContents, setAppletContents] = useState<Map<string, string>>(new Map());
   const [loadingContents, setLoadingContents] = useState<Set<string>>(new Set());
   const feedRef = useRef<HTMLDivElement>(null);
@@ -344,17 +394,8 @@ export const AppStoreFeed = forwardRef<AppStoreFeedRef, AppStoreFeedProps>(
   const scrollToIndex = useCallback((index: number) => {
     if (index >= 0 && index < appletsLengthRef.current) {
       const prevIndex = currentIndexRef.current;
-      setCurrentIndex(index);
+      dispatch({ type: "setIndexWithDirection", index, previousIndex: prevIndex });
       // Note: currentIndexRef.current is automatically updated by useLatestRef
-      
-      // Determine navigation direction
-      if (index > prevIndex) {
-        setNavigationDirection("forward");
-      } else if (index < prevIndex) {
-        setNavigationDirection("backward");
-      } else {
-        setNavigationDirection("none");
-      }
     }
   }, [appletsLengthRef, currentIndexRef]);
 

--- a/src/apps/applet-viewer/hooks/useAppletViewerLogic.ts
+++ b/src/apps/applet-viewer/hooks/useAppletViewerLogic.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useReducer, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { helpItems, AppletViewerInitialData } from "../index";
 import { useTranslatedHelpItems } from "@/hooks/useTranslatedHelpItems";
@@ -39,19 +39,116 @@ interface UseAppletViewerLogicProps {
   initialData?: AppletViewerInitialData;
 }
 
+interface ViewerUiState {
+  isHelpDialogOpen: boolean;
+  isAboutDialogOpen: boolean;
+  isShareDialogOpen: boolean;
+  shareId: string;
+  sharedContent: string;
+  sharedName: string | undefined;
+  sharedTitle: string | undefined;
+  sharedCreatedBy: string | null;
+}
+
+const initialState: ViewerUiState = {
+  isHelpDialogOpen: false,
+  isAboutDialogOpen: false,
+  isShareDialogOpen: false,
+  shareId: "",
+  sharedContent: "",
+  sharedName: undefined,
+  sharedTitle: undefined,
+  sharedCreatedBy: null,
+};
+
+type ViewerUiAction =
+  | { type: "setHelpDialogOpen"; value: boolean }
+  | { type: "setAboutDialogOpen"; value: boolean }
+  | { type: "setShareDialogOpen"; value: boolean }
+  | { type: "setShareId"; value: string }
+  | { type: "setSharedContent"; value: string }
+  | { type: "setSharedName"; value: string | undefined }
+  | { type: "setSharedTitle"; value: string | undefined }
+  | { type: "setSharedCreatedBy"; value: string | null }
+  | { type: "openShareDialog"; shareId: string }
+  | {
+      type: "setSharedAppletMeta";
+      content: string;
+      name: string | undefined;
+      title: string | undefined;
+      createdBy: string | null;
+    }
+  | { type: "resetSharedAppletMeta" };
+
+function reducer(state: ViewerUiState, action: ViewerUiAction): ViewerUiState {
+  switch (action.type) {
+    case "setHelpDialogOpen":
+      return { ...state, isHelpDialogOpen: action.value };
+    case "setAboutDialogOpen":
+      return { ...state, isAboutDialogOpen: action.value };
+    case "setShareDialogOpen":
+      return { ...state, isShareDialogOpen: action.value };
+    case "setShareId":
+      return { ...state, shareId: action.value };
+    case "setSharedContent":
+      return { ...state, sharedContent: action.value };
+    case "setSharedName":
+      return { ...state, sharedName: action.value };
+    case "setSharedTitle":
+      return { ...state, sharedTitle: action.value };
+    case "setSharedCreatedBy":
+      return { ...state, sharedCreatedBy: action.value };
+    case "openShareDialog":
+      return { ...state, shareId: action.shareId, isShareDialogOpen: true };
+    case "setSharedAppletMeta":
+      return {
+        ...state,
+        sharedContent: action.content,
+        sharedName: action.name,
+        sharedTitle: action.title,
+        sharedCreatedBy: action.createdBy,
+      };
+    case "resetSharedAppletMeta":
+      return {
+        ...state,
+        sharedContent: "",
+        sharedName: undefined,
+        sharedTitle: undefined,
+        sharedCreatedBy: null,
+      };
+    default:
+      return state;
+  }
+}
+
 export function useAppletViewerLogic({
   instanceId,
   initialData,
 }: UseAppletViewerLogicProps) {
   const translatedHelpItems = useTranslatedHelpItems("applet-viewer", helpItems);
-  const [isHelpDialogOpen, setIsHelpDialogOpen] = useState(false);
-  const [isAboutDialogOpen, setIsAboutDialogOpen] = useState(false);
-  const [isShareDialogOpen, setIsShareDialogOpen] = useState(false);
-  const [shareId, setShareId] = useState<string>("");
-  const [sharedContent, setSharedContent] = useState<string>("");
-  const [sharedName, setSharedName] = useState<string | undefined>(undefined);
-  const [sharedTitle, setSharedTitle] = useState<string | undefined>(undefined);
-  const [sharedCreatedBy, setSharedCreatedBy] = useState<string | null>(null);
+  const [uiState, dispatch] = useReducer(reducer, initialState);
+  const {
+    isHelpDialogOpen,
+    isAboutDialogOpen,
+    isShareDialogOpen,
+    shareId,
+    sharedContent,
+    sharedName,
+    sharedTitle,
+    sharedCreatedBy,
+  } = uiState;
+  const setIsHelpDialogOpen = useCallback((value: boolean) => {
+    dispatch({ type: "setHelpDialogOpen", value });
+  }, []);
+  const setIsAboutDialogOpen = useCallback((value: boolean) => {
+    dispatch({ type: "setAboutDialogOpen", value });
+  }, []);
+  const setIsShareDialogOpen = useCallback((value: boolean) => {
+    dispatch({ type: "setShareDialogOpen", value });
+  }, []);
+  const setShareId = useCallback((value: string) => {
+    dispatch({ type: "setShareId", value });
+  }, []);
   const iframeRef = useRef<HTMLIFrameElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const {
@@ -1190,8 +1287,7 @@ export function useAppletViewerLogic({
         fileCreatedBy.toLowerCase() === username.toLowerCase();
 
       if (existingShareId && !isAuthor) {
-        setShareId(existingShareId);
-        setIsShareDialogOpen(true);
+        dispatch({ type: "openShareDialog", shareId: existingShareId });
         toast.success(t("apps.applet-viewer.dialogs.appletAlreadyShared"), {
           description: t("apps.applet-viewer.dialogs.showingExistingShareLink"),
         });
@@ -1223,8 +1319,7 @@ export function useAppletViewerLogic({
       });
 
       const data = await response.json();
-      setShareId(data.id);
-      setIsShareDialogOpen(true);
+      dispatch({ type: "openShareDialog", shareId: data.id });
 
       if (appletPath && data.id) {
         const currentFileItem = getFileItem(appletPath);
@@ -1273,7 +1368,7 @@ export function useAppletViewerLogic({
 
   useEffect(() => {
     if (shareCode && appletPath) {
-      setSharedContent("");
+      dispatch({ type: "resetSharedAppletMeta" });
       const controller = new AbortController();
       let isActive = true;
 
@@ -1291,12 +1386,13 @@ export function useAppletViewerLogic({
 
           const data = await response.json();
           if (!isActive || controller.signal.aborted) return;
-          setSharedContent(data.content);
-          setSharedName(data.name);
-          setSharedTitle(data.title);
-          setSharedCreatedBy(
-            typeof data.createdBy === "string" ? data.createdBy : null
-          );
+          dispatch({
+            type: "setSharedAppletMeta",
+            content: data.content,
+            name: data.name,
+            title: data.title,
+            createdBy: typeof data.createdBy === "string" ? data.createdBy : null,
+          });
 
           if (instanceId && data.windowWidth && data.windowHeight) {
             const appStore = useAppStore.getState();
@@ -1421,10 +1517,7 @@ export function useAppletViewerLogic({
         controller.abort();
       };
     } else if (!shareCode) {
-      setSharedContent("");
-      setSharedName(undefined);
-      setSharedTitle(undefined);
-      setSharedCreatedBy(null);
+      dispatch({ type: "resetSharedAppletMeta" });
     }
   }, [
     shareCode,

--- a/src/apps/base/AppManager.tsx
+++ b/src/apps/base/AppManager.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useReducer, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import type { AnyApp } from "./types";
 import { MenuBar } from "@/components/layout/MenuBar";
@@ -33,6 +33,42 @@ interface AppManagerProps {
 }
 
 const BASE_Z_INDEX = 1;
+
+interface SwitcherState {
+  visible: boolean;
+  apps: SwitcherApp[];
+  index: number;
+}
+
+const switcherInitialState: SwitcherState = {
+  visible: false,
+  apps: [],
+  index: 0,
+};
+
+type SwitcherAction =
+  | { type: "setVisible"; value: boolean }
+  | { type: "setApps"; value: SwitcherApp[] }
+  | { type: "setIndex"; value: number }
+  | { type: "open"; apps: SwitcherApp[]; index: number }
+  | { type: "reset" };
+
+function switcherReducer(state: SwitcherState, action: SwitcherAction): SwitcherState {
+  switch (action.type) {
+    case "setVisible":
+      return { ...state, visible: action.value };
+    case "setApps":
+      return { ...state, apps: action.value };
+    case "setIndex":
+      return { ...state, index: action.value };
+    case "open":
+      return { visible: true, apps: action.apps, index: action.index };
+    case "reset":
+      return switcherInitialState;
+    default:
+      return state;
+  }
+}
 
 export function AppManager({ apps }: AppManagerProps) {
   const { t } = useTranslation();
@@ -86,9 +122,13 @@ export function AppManager({ apps }: AppManagerProps) {
   useGlobalUndoRedo();
 
   // App switcher state
-  const [switcherVisible, setSwitcherVisible] = useState(false);
-  const [switcherApps, setSwitcherApps] = useState<SwitcherApp[]>([]);
-  const [switcherIndex, setSwitcherIndex] = useState(0);
+  const [switcherState, dispatchSwitcher] = useReducer(
+    switcherReducer,
+    switcherInitialState
+  );
+  const switcherVisible = switcherState.visible;
+  const switcherApps = switcherState.apps;
+  const switcherIndex = switcherState.index;
 
   // Refs for stable event listener closures
   const instancesRef = useRef(instances);
@@ -357,9 +397,7 @@ export function AppManager({ apps }: AppManagerProps) {
         switcherVisibleRef.current = false;
         switcherIndexRef.current = 0;
         switcherAppsRef.current = [];
-        setSwitcherVisible(false);
-        setSwitcherIndex(0);
-        setSwitcherApps([]);
+        dispatchSwitcher({ type: "reset" });
         return;
       }
 
@@ -396,9 +434,7 @@ export function AppManager({ apps }: AppManagerProps) {
       switcherVisibleRef.current = false;
       switcherIndexRef.current = 0;
       switcherAppsRef.current = [];
-      setSwitcherVisible(false);
-      setSwitcherIndex(0);
-      setSwitcherApps([]);
+      dispatchSwitcher({ type: "reset" });
     };
 
     const handleKeyDown = (e: KeyboardEvent) => {
@@ -492,20 +528,18 @@ export function AppManager({ apps }: AppManagerProps) {
           const mruApps = buildMruApps();
           if (mruApps.length === 0) return;
           switcherAppsRef.current = mruApps;
-          setSwitcherApps(mruApps);
           switcherVisibleRef.current = true;
-          setSwitcherVisible(true);
           const startIndex =
             ((e.shiftKey ? -1 : 1) + mruApps.length) % mruApps.length;
           switcherIndexRef.current = startIndex;
-          setSwitcherIndex(startIndex);
+          dispatchSwitcher({ type: "open", apps: mruApps, index: startIndex });
         } else {
           // Subsequent press — cycle selection
           const len = switcherAppsRef.current.length;
           const cur = switcherIndexRef.current;
           const next = e.shiftKey ? (cur - 1 + len) % len : (cur + 1) % len;
           switcherIndexRef.current = next;
-          setSwitcherIndex(next);
+          dispatchSwitcher({ type: "setIndex", value: next });
         }
       }
     };

--- a/src/apps/calendar/components/TrayDetails.tsx
+++ b/src/apps/calendar/components/TrayDetails.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useRef } from "react";
+import { useEffect, useReducer, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { cn } from "@/lib/utils";
 import {
@@ -149,6 +149,60 @@ function TrayFieldRow({
 // EVENT TRAY (iCal-inspired: title block, fields, notes)
 // ============================================================================
 
+interface EventEditorState {
+  title: string;
+  location: string;
+  notes: string;
+  date: string;
+  startTime: string;
+  endTime: string;
+}
+
+const getEventEditorState = (event: CalendarEvent): EventEditorState => ({
+  title: event.title,
+  location: event.location || "",
+  notes: event.notes || "",
+  date: event.date,
+  startTime: event.startTime || "09:00",
+  endTime: event.endTime || "10:00",
+});
+
+type EventEditorAction =
+  | { type: "resetFromEvent"; event: CalendarEvent }
+  | { type: "setTitle"; value: string }
+  | { type: "setLocation"; value: string }
+  | { type: "setNotes"; value: string }
+  | { type: "setDate"; value: string }
+  | { type: "setStartTime"; value: string }
+  | { type: "setEndTime"; value: string }
+  | { type: "setTimes"; startTime: string; endTime: string };
+
+function eventEditorReducer(
+  state: EventEditorState,
+  action: EventEditorAction
+): EventEditorState {
+  switch (action.type) {
+    case "resetFromEvent":
+      return getEventEditorState(action.event);
+    case "setTitle":
+      return { ...state, title: action.value };
+    case "setLocation":
+      return { ...state, location: action.value };
+    case "setNotes":
+      return { ...state, notes: action.value };
+    case "setDate":
+      return { ...state, date: action.value };
+    case "setStartTime":
+      return { ...state, startTime: action.value };
+    case "setEndTime":
+      return { ...state, endTime: action.value };
+    case "setTimes":
+      return { ...state, startTime: action.startTime, endTime: action.endTime };
+    default:
+      return state;
+  }
+}
+
 function EventTrayEditor({
   event,
   calendars,
@@ -172,20 +226,15 @@ function EventTrayEditor({
   onUpdate: (id: string, updates: Partial<CalendarEvent>) => void;
   onDelete: (id: string) => void;
 }) {
-  const [title, setTitle] = useState(event.title);
-  const [location, setLocation] = useState(event.location || "");
-  const [notes, setNotes] = useState(event.notes || "");
-  const [date, setDate] = useState(event.date);
-  const [startTime, setStartTime] = useState(event.startTime || "09:00");
-  const [endTime, setEndTime] = useState(event.endTime || "10:00");
+  const [state, dispatch] = useReducer(eventEditorReducer, event, getEventEditorState);
+  const { title, location, notes, date, startTime, endTime } = state;
+  const setTitle = (value: string) => dispatch({ type: "setTitle", value });
+  const setLocation = (value: string) => dispatch({ type: "setLocation", value });
+  const setNotes = (value: string) => dispatch({ type: "setNotes", value });
+  const setDate = (value: string) => dispatch({ type: "setDate", value });
   const allDay = !event.startTime;
   useEffect(() => {
-    setTitle(event.title);
-    setLocation(event.location || "");
-    setNotes(event.notes || "");
-    setDate(event.date);
-    setStartTime(event.startTime || "09:00");
-    setEndTime(event.endTime || "10:00");
+    dispatch({ type: "resetFromEvent", event });
   }, [
     event.id,
     event.updatedAt,
@@ -237,8 +286,7 @@ function EventTrayEditor({
   };
 
   const commitTimes = (st: string, et: string) => {
-    setStartTime(st);
-    setEndTime(et);
+    dispatch({ type: "setTimes", startTime: st, endTime: et });
     if (!allDay && (st !== event.startTime || et !== (event.endTime || ""))) {
       onUpdate(event.id, { startTime: st, endTime: et });
     }

--- a/src/apps/chats/components/ChatInput.tsx
+++ b/src/apps/chats/components/ChatInput.tsx
@@ -1,4 +1,4 @@
-import { memo, useState, useRef, useEffect, useCallback } from "react";
+import { memo, useState, useRef, useEffect, useCallback, useReducer } from "react";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { ArrowUp, Square, Hand, At, Microphone, ImageSquare, X } from "@phosphor-icons/react";
@@ -93,6 +93,49 @@ interface ChatInputProps {
   resetTrigger?: number;
 }
 
+interface ComposerState {
+  input: string;
+  historyIndex: number;
+  selectedImage: string | null;
+}
+
+const composerInitialState: ComposerState = {
+  input: "",
+  historyIndex: -1,
+  selectedImage: null,
+};
+
+type ComposerAction =
+  | { type: "setInput"; value: string }
+  | { type: "setHistoryIndex"; value: number }
+  | { type: "setSelectedImage"; value: string | null }
+  | { type: "setInputAndResetHistory"; value: string }
+  | { type: "setHistoryNavigation"; value: { index: number; input: string } }
+  | { type: "clearComposer" };
+
+function composerReducer(state: ComposerState, action: ComposerAction): ComposerState {
+  switch (action.type) {
+    case "setInput":
+      return { ...state, input: action.value };
+    case "setHistoryIndex":
+      return { ...state, historyIndex: action.value };
+    case "setSelectedImage":
+      return { ...state, selectedImage: action.value };
+    case "setInputAndResetHistory":
+      return { ...state, input: action.value, historyIndex: -1 };
+    case "setHistoryNavigation":
+      return {
+        ...state,
+        historyIndex: action.value.index,
+        input: action.value.input,
+      };
+    case "clearComposer":
+      return { ...state, input: "", selectedImage: null };
+    default:
+      return state;
+  }
+}
+
 export const ChatInput = memo(function ChatInput({
   isLoading,
   isForeground = false,
@@ -113,7 +156,20 @@ export const ChatInput = memo(function ChatInput({
   resetTrigger = 0,
 }: ChatInputProps) {
   const { t } = useTranslation();
-  const [input, setInput] = useState("");
+  const [composerState, dispatchComposer] = useReducer(
+    composerReducer,
+    composerInitialState
+  );
+  const { input, historyIndex, selectedImage } = composerState;
+  const setInput = useCallback((value: string) => {
+    dispatchComposer({ type: "setInput", value });
+  }, []);
+  const setHistoryIndex = useCallback((value: number) => {
+    dispatchComposer({ type: "setHistoryIndex", value });
+  }, []);
+  const setSelectedImage = useCallback((value: string | null) => {
+    dispatchComposer({ type: "setSelectedImage", value });
+  }, []);
   const [isFocused, setIsFocused] = useState(false);
   const [isTranscribing, setIsTranscribing] = useState(false);
   const [isRecording, setIsRecording] = useState(false);
@@ -122,8 +178,6 @@ export const ChatInput = memo(function ChatInput({
   );
   const [isTouchDevice, setIsTouchDevice] = useState(false);
   const [lastTypingTime, setLastTypingTime] = useState(0);
-  const [historyIndex, setHistoryIndex] = useState(-1);
-  const [selectedImage, setSelectedImage] = useState<string | null>(null);
   const [isProcessingImage, setIsProcessingImage] = useState(false);
   const [waveformFrequencies, setWaveformFrequencies] = useState<number[]>(
     Array(WAVEFORM_BANDS).fill(0)
@@ -173,14 +227,21 @@ export const ChatInput = memo(function ChatInput({
         e.preventDefault();
         const nextIndex = historyIndex + 1;
         if (nextIndex < previousMessages.length) {
-          setHistoryIndex(nextIndex);
-          setInput(previousMessages[nextIndex]);
+          dispatchComposer({
+            type: "setHistoryNavigation",
+            value: { index: nextIndex, input: previousMessages[nextIndex] },
+          });
         }
       } else if (e.key === "ArrowDown" && historyIndex > -1) {
         e.preventDefault();
         const nextIndex = historyIndex - 1;
-        setHistoryIndex(nextIndex);
-        setInput(nextIndex === -1 ? "" : previousMessages[nextIndex]);
+        dispatchComposer({
+          type: "setHistoryNavigation",
+          value: {
+            index: nextIndex,
+            input: nextIndex === -1 ? "" : previousMessages[nextIndex],
+          },
+        });
       }
     };
 
@@ -204,8 +265,7 @@ export const ChatInput = memo(function ChatInput({
       didMountRef.current = true;
       return;
     }
-    setInput("");
-    setSelectedImage(null);
+    dispatchComposer({ type: "clearComposer" });
   }, [resetTrigger]);
 
   // Keep Talking Mode: Auto-start recording after AI response completes
@@ -237,8 +297,7 @@ export const ChatInput = memo(function ChatInput({
   const handleInputChangeWithSound = (
     e: React.ChangeEvent<HTMLInputElement>
   ) => {
-    setInput(e.target.value);
-    setHistoryIndex(-1);
+    dispatchComposer({ type: "setInputAndResetHistory", value: e.target.value });
 
     const now = Date.now();
     if (typingSynthEnabled && now - lastTypingTime > 50) {
@@ -553,8 +612,7 @@ export const ChatInput = memo(function ChatInput({
             e.preventDefault();
             const didSubmit = await onSubmitMessage(input, selectedImage);
             if (didSubmit) {
-              setInput("");
-              setSelectedImage(null);
+              dispatchComposer({ type: "clearComposer" });
             }
           }}
           className={`flex ${isMacTheme ? "gap-2" : "gap-1"}`}

--- a/src/apps/chats/components/CreateRoomDialog.tsx
+++ b/src/apps/chats/components/CreateRoomDialog.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useCallback } from "react";
+import { useState, useEffect, useRef, useCallback, useReducer } from "react";
 import {
   Dialog,
   DialogContent,
@@ -64,6 +64,62 @@ interface CreateRoomDialogProps {
   initialUsers?: string[]; // Optional prop to prefill users
 }
 
+interface IrcServerFormState {
+  showAddServerForm: boolean;
+  newServerHost: string;
+  newServerPort: number;
+  newServerTls: boolean;
+  newServerLabel: string;
+  isAddingServer: boolean;
+  addServerError: string | null;
+}
+
+const initialIrcServerFormState: IrcServerFormState = {
+  showAddServerForm: false,
+  newServerHost: "",
+  newServerPort: 6667,
+  newServerTls: false,
+  newServerLabel: "",
+  isAddingServer: false,
+  addServerError: null,
+};
+
+type IrcServerFormAction =
+  | { type: "setShowAddServerForm"; value: boolean }
+  | { type: "setNewServerHost"; value: string }
+  | { type: "setNewServerPort"; value: number }
+  | { type: "setNewServerTls"; value: boolean }
+  | { type: "setNewServerLabel"; value: string }
+  | { type: "setIsAddingServer"; value: boolean }
+  | { type: "setAddServerError"; value: string | null }
+  | { type: "resetForm" };
+
+function ircServerFormReducer(
+  state: IrcServerFormState,
+  action: IrcServerFormAction
+): IrcServerFormState {
+  switch (action.type) {
+    case "setShowAddServerForm":
+      return { ...state, showAddServerForm: action.value };
+    case "setNewServerHost":
+      return { ...state, newServerHost: action.value };
+    case "setNewServerPort":
+      return { ...state, newServerPort: action.value };
+    case "setNewServerTls":
+      return { ...state, newServerTls: action.value };
+    case "setNewServerLabel":
+      return { ...state, newServerLabel: action.value };
+    case "setIsAddingServer":
+      return { ...state, isAddingServer: action.value };
+    case "setAddServerError":
+      return { ...state, addServerError: action.value };
+    case "resetForm":
+      return initialIrcServerFormState;
+    default:
+      return state;
+  }
+}
+
 export function CreateRoomDialog({
   isOpen,
   onOpenChange,
@@ -89,13 +145,40 @@ export function CreateRoomDialog({
   const [selectedServerId, setSelectedServerId] = useState<string | null>(null);
   const [isLoadingServers, setIsLoadingServers] = useState(false);
   const [serversError, setServersError] = useState<string | null>(null);
-  const [showAddServerForm, setShowAddServerForm] = useState(false);
-  const [newServerHost, setNewServerHost] = useState("");
-  const [newServerPort, setNewServerPort] = useState(6667);
-  const [newServerTls, setNewServerTls] = useState(false);
-  const [newServerLabel, setNewServerLabel] = useState("");
-  const [isAddingServer, setIsAddingServer] = useState(false);
-  const [addServerError, setAddServerError] = useState<string | null>(null);
+  const [ircServerFormState, dispatchIrcServerForm] = useReducer(
+    ircServerFormReducer,
+    initialIrcServerFormState
+  );
+  const {
+    showAddServerForm,
+    newServerHost,
+    newServerPort,
+    newServerTls,
+    newServerLabel,
+    isAddingServer,
+    addServerError,
+  } = ircServerFormState;
+  const setShowAddServerForm = useCallback((value: boolean) => {
+    dispatchIrcServerForm({ type: "setShowAddServerForm", value });
+  }, []);
+  const setNewServerHost = useCallback((value: string) => {
+    dispatchIrcServerForm({ type: "setNewServerHost", value });
+  }, []);
+  const setNewServerPort = useCallback((value: number) => {
+    dispatchIrcServerForm({ type: "setNewServerPort", value });
+  }, []);
+  const setNewServerTls = useCallback((value: boolean) => {
+    dispatchIrcServerForm({ type: "setNewServerTls", value });
+  }, []);
+  const setNewServerLabel = useCallback((value: string) => {
+    dispatchIrcServerForm({ type: "setNewServerLabel", value });
+  }, []);
+  const setIsAddingServer = useCallback((value: boolean) => {
+    dispatchIrcServerForm({ type: "setIsAddingServer", value });
+  }, []);
+  const setAddServerError = useCallback((value: string | null) => {
+    dispatchIrcServerForm({ type: "setAddServerError", value });
+  }, []);
 
   // IRC channel browser state
   const [ircChannels, setIrcChannels] = useState<IrcChannelEntry[]>([]);
@@ -128,13 +211,7 @@ export function CreateRoomDialog({
     setIrcServers([]);
     setSelectedServerId(null);
     setServersError(null);
-    setShowAddServerForm(false);
-    setNewServerHost("");
-    setNewServerPort(6667);
-    setNewServerTls(false);
-    setNewServerLabel("");
-    setIsAddingServer(false);
-    setAddServerError(null);
+    dispatchIrcServerForm({ type: "resetForm" });
     setIrcChannels([]);
     setChannelsError(null);
     setChannelFilter("");
@@ -305,11 +382,7 @@ export function CreateRoomDialog({
         return next;
       });
       setSelectedServerId(data.server.id);
-      setShowAddServerForm(false);
-      setNewServerHost("");
-      setNewServerPort(6667);
-      setNewServerTls(false);
-      setNewServerLabel("");
+      dispatchIrcServerForm({ type: "resetForm" });
     } catch (err) {
       console.error("Failed to add IRC server:", err);
       setAddServerError(
@@ -687,8 +760,7 @@ export function CreateRoomDialog({
                       variant="retro"
                       size="sm"
                       onClick={() => {
-                        setShowAddServerForm(false);
-                        setAddServerError(null);
+                        dispatchIrcServerForm({ type: "resetForm" });
                       }}
                       disabled={isAddingServer}
                       className={cn("h-7", themeFont)}

--- a/src/apps/chats/hooks/useAiChat.ts
+++ b/src/apps/chats/hooks/useAiChat.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useRef, useMemo } from "react";
+import { useState, useEffect, useCallback, useRef, useMemo, useReducer } from "react";
 import { useChat, type UIMessage } from "@ai-sdk/react";
 import {
   DefaultChatTransport,
@@ -588,6 +588,49 @@ const showBackgroundedMessageNotification = (message: UIMessage) => {
   });
 };
 
+interface ChatUiState {
+  input: string;
+  selectedImage: string | null;
+  isClearDialogOpen: boolean;
+  isSaveDialogOpen: boolean;
+  saveFileName: string;
+}
+
+const initialChatUiState: ChatUiState = {
+  input: "",
+  selectedImage: null,
+  isClearDialogOpen: false,
+  isSaveDialogOpen: false,
+  saveFileName: "",
+};
+
+type ChatUiAction =
+  | { type: "setInput"; value: string }
+  | { type: "setSelectedImage"; value: string | null }
+  | { type: "setClearDialogOpen"; value: boolean }
+  | { type: "setSaveDialogOpen"; value: boolean }
+  | { type: "setSaveFileName"; value: string }
+  | { type: "clearComposer" };
+
+function chatUiReducer(state: ChatUiState, action: ChatUiAction): ChatUiState {
+  switch (action.type) {
+    case "setInput":
+      return { ...state, input: action.value };
+    case "setSelectedImage":
+      return { ...state, selectedImage: action.value };
+    case "setClearDialogOpen":
+      return { ...state, isClearDialogOpen: action.value };
+    case "setSaveDialogOpen":
+      return { ...state, isSaveDialogOpen: action.value };
+    case "setSaveFileName":
+      return { ...state, saveFileName: action.value };
+    case "clearComposer":
+      return { ...state, input: "", selectedImage: null };
+    default:
+      return state;
+  }
+}
+
 export function useAiChat(onPromptSetUsername?: () => void) {
   const { aiMessages, setAiMessages, username, isAuthenticated } =
     useChatsStoreShallow((state) => ({
@@ -603,8 +646,32 @@ export function useAiChat(onPromptSetUsername?: () => void) {
 
   // Local input state (SDK v5 no longer provides this)
   const { t } = useTranslation();
-  const [input, setInput] = useState("");
-  const [selectedImage, setSelectedImage] = useState<string | null>(null);
+  const [chatUiState, dispatchChatUi] = useReducer(
+    chatUiReducer,
+    initialChatUiState
+  );
+  const {
+    input,
+    selectedImage,
+    isClearDialogOpen,
+    isSaveDialogOpen,
+    saveFileName,
+  } = chatUiState;
+  const setInput = useCallback((value: string) => {
+    dispatchChatUi({ type: "setInput", value });
+  }, []);
+  const setSelectedImage = useCallback((value: string | null) => {
+    dispatchChatUi({ type: "setSelectedImage", value });
+  }, []);
+  const setIsClearDialogOpen = useCallback((value: boolean) => {
+    dispatchChatUi({ type: "setClearDialogOpen", value });
+  }, []);
+  const setIsSaveDialogOpen = useCallback((value: boolean) => {
+    dispatchChatUi({ type: "setSaveDialogOpen", value });
+  }, []);
+  const setSaveFileName = useCallback((value: string) => {
+    dispatchChatUi({ type: "setSaveFileName", value });
+  }, []);
   const handleInputChange = useCallback(
     (
       e:
@@ -2274,14 +2341,14 @@ export function useAiChat(onPromptSetUsername?: () => void) {
       e.preventDefault();
       const didSubmit = await handleSubmitMessage(input, selectedImage);
       if (didSubmit) {
-        setInput(""); // Clear input after sending
-        setSelectedImage(null); // Clear image after sending
+        dispatchChatUi({ type: "clearComposer" }); // Clear input and image after sending
       }
     },
     [
       handleSubmitMessage,
       input,
       selectedImage,
+      dispatchChatUi,
     ],
   );
 
@@ -2423,11 +2490,6 @@ export function useAiChat(onPromptSetUsername?: () => void) {
     setAiMessages([initialMessage]);
     setSdkMessages([initialMessage]);
   }, [setAiMessages, setSdkMessages, stopTts, aiMessages, username, isAuthenticated]);
-
-  // --- Dialog States & Handlers ---
-  const [isClearDialogOpen, setIsClearDialogOpen] = useState(false);
-  const [isSaveDialogOpen, setIsSaveDialogOpen] = useState(false);
-  const [saveFileName, setSaveFileName] = useState("");
 
   const confirmClearChats = useCallback(() => {
     setIsClearDialogOpen(false);

--- a/src/apps/control-panels/components/WallpaperPicker.tsx
+++ b/src/apps/control-panels/components/WallpaperPicker.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useMemo } from "react";
+import { useReducer, useEffect, useRef, useMemo, useState } from "react";
 import {
   Select,
   SelectContent,
@@ -166,10 +166,62 @@ export function WallpaperPicker({ onSelect }: WallpaperPickerProps) {
   const displayMode = useDisplaySettingsStore((s) => s.displayMode);
   const setDisplayMode = useDisplaySettingsStore((s) => s.setDisplayMode);
   const { t } = useTranslation();
-  const [customWallpaperRefs, setCustomWallpaperRefs] = useState<string[]>([]);
-  const [customWallpaperPreviews, setCustomWallpaperPreviews] = useState<
-    Record<string, string>
-  >({});
+  const deriveCategoryFromWallpaper = (
+    wallpaper: string
+  ): "tiles" | PhotoCategory => {
+    if (wallpaper.includes("/wallpapers/tiles/")) return "tiles";
+    if (wallpaper.startsWith(INDEXEDDB_PREFIX)) return "custom";
+    if (wallpaper.includes("/wallpapers/videos/")) return "videos";
+    const match = wallpaper.match(/\/wallpapers\/photos\/([^/]+)\//);
+    if (match) return match[1];
+    return "tiles";
+  };
+  type PickerState = {
+    customWallpaperRefs: string[];
+    customWallpaperPreviews: Record<string, string>;
+    selectedCategory: "tiles" | PhotoCategory;
+  };
+  type PickerAction =
+    | {
+        type: "setCustomData";
+        refs: string[];
+        previews: Record<string, string>;
+      }
+    | { type: "removeCustomWallpaper"; ref: string }
+    | { type: "setSelectedCategory"; category: "tiles" | PhotoCategory };
+  const initialState: PickerState = {
+    customWallpaperRefs: [],
+    customWallpaperPreviews: {},
+    selectedCategory: deriveCategoryFromWallpaper(currentWallpaper),
+  };
+  const reducer = (state: PickerState, action: PickerAction): PickerState => {
+    switch (action.type) {
+      case "setCustomData":
+        return {
+          ...state,
+          customWallpaperRefs: action.refs,
+          customWallpaperPreviews: action.previews,
+        };
+      case "removeCustomWallpaper": {
+        const nextPreviews = { ...state.customWallpaperPreviews };
+        delete nextPreviews[action.ref];
+        return {
+          ...state,
+          customWallpaperRefs: state.customWallpaperRefs.filter(
+            (ref) => ref !== action.ref
+          ),
+          customWallpaperPreviews: nextPreviews,
+        };
+      }
+      case "setSelectedCategory":
+        return { ...state, selectedCategory: action.category };
+      default:
+        return state;
+    }
+  };
+  const [state, dispatch] = useReducer(reducer, initialState);
+  const { customWallpaperRefs, customWallpaperPreviews, selectedCategory } =
+    state;
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const [manifest, setManifest] = useState<WallpaperManifestType | null>(null);
@@ -180,18 +232,26 @@ export function WallpaperPicker({ onSelect }: WallpaperPickerProps) {
   }, []);
 
   const tileWallpapers = useMemo(
-    () => (manifest ? manifest.tiles.map((p) => `/wallpapers/${p}`) : []),
+    () =>
+      manifest
+        ? (manifest.tiles as string[]).map((p: string) => `/wallpapers/${p}`)
+        : [],
     [manifest]
   );
   const videoWallpapers = useMemo(
-    () => (manifest ? manifest.videos.map((p) => `/wallpapers/${p}`) : []),
+    () =>
+      manifest
+        ? (manifest.videos as string[]).map((p: string) => `/wallpapers/${p}`)
+        : [],
     [manifest]
   );
   const photoWallpapers = useMemo(() => {
     if (!manifest) return {} as Record<string, string[]>;
     const r: Record<string, string[]> = {};
-    for (const [cat, arr] of Object.entries(manifest.photos)) {
-      r[cat] = arr.map((p) => `/wallpapers/${p}`);
+    for (const [cat, arr] of Object.entries(
+      manifest.photos as Record<string, string[]>
+    )) {
+      r[cat] = arr.map((p: string) => `/wallpapers/${p}`);
     }
     return r;
   }, [manifest]);
@@ -219,17 +279,6 @@ export function WallpaperPicker({ onSelect }: WallpaperPickerProps) {
     return cats.filter((c) => !mac.has(c)).sort((a, b) => a.localeCompare(b));
   }, [photoWallpapers]);
 
-  const [selectedCategory, setSelectedCategory] = useState<
-    "tiles" | PhotoCategory
-  >(() => {
-    if (currentWallpaper.includes("/wallpapers/tiles/")) return "tiles";
-    if (currentWallpaper.startsWith(INDEXEDDB_PREFIX)) return "custom";
-    if (currentWallpaper.includes("/wallpapers/videos/")) return "videos";
-    const match = currentWallpaper.match(/\/wallpapers\/photos\/([^/]+)\//);
-    if (match) return match[1];
-    return "tiles";
-  });
-
   // Load custom wallpapers from IndexedDB (just the references)
   useEffect(() => {
     let isActive = true;
@@ -238,8 +287,6 @@ export function WallpaperPicker({ onSelect }: WallpaperPickerProps) {
       try {
         const refs = await loadCustomWallpapers();
         if (!isActive) return;
-
-        setCustomWallpaperRefs(refs);
 
         // Load preview data in parallel
         const previewEntries = await Promise.all(
@@ -259,7 +306,7 @@ export function WallpaperPicker({ onSelect }: WallpaperPickerProps) {
           )
         ) as Record<string, string>;
 
-        setCustomWallpaperPreviews(previews);
+        dispatch({ type: "setCustomData", refs, previews });
       } catch (error) {
         if (!isActive) return;
         console.error("Error fetching custom wallpapers:", error);
@@ -288,12 +335,7 @@ export function WallpaperPicker({ onSelect }: WallpaperPickerProps) {
     e.stopPropagation();
     playClick();
     await deleteCustomWallpaper(ref);
-    setCustomWallpaperRefs((prev) => prev.filter((r) => r !== ref));
-    setCustomWallpaperPreviews((prev) => {
-      const next = { ...prev };
-      delete next[ref];
-      return next;
-    });
+    dispatch({ type: "removeCustomWallpaper", ref });
   };
 
   const handleFileUpload = async (
@@ -315,7 +357,6 @@ export function WallpaperPicker({ onSelect }: WallpaperPickerProps) {
 
       // Refresh the custom wallpapers list
       const refs = await loadCustomWallpapers();
-      setCustomWallpaperRefs(refs);
 
       // Refresh previews in one batch to avoid sequential requests and rerenders
       const previewEntries = await Promise.all(
@@ -330,10 +371,10 @@ export function WallpaperPicker({ onSelect }: WallpaperPickerProps) {
           (entry): entry is readonly [string, string] => entry !== null
         )
       ) as Record<string, string>;
-      setCustomWallpaperPreviews(previews);
+      dispatch({ type: "setCustomData", refs, previews });
 
       // Switch to custom category
-      setSelectedCategory("custom");
+      dispatch({ type: "setSelectedCategory", category: "custom" });
     } catch (error) {
       console.error("Error uploading wallpaper:", error);
       alert(t("apps.control-panels.alerts.errorUploadingWallpaper"));
@@ -347,16 +388,10 @@ export function WallpaperPicker({ onSelect }: WallpaperPickerProps) {
 
   // Force rerender when wallpaper changes
   useEffect(() => {
-    if (currentWallpaper.includes("/wallpapers/tiles/")) {
-      setSelectedCategory("tiles");
-    } else if (currentWallpaper.startsWith(INDEXEDDB_PREFIX)) {
-      setSelectedCategory("custom");
-    } else if (currentWallpaper.includes("/wallpapers/videos/")) {
-      setSelectedCategory("videos");
-    } else {
-      const match = currentWallpaper.match(/\/wallpapers\/photos\/([^/]+)\//);
-      if (match) setSelectedCategory(match[1]);
-    }
+    dispatch({
+      type: "setSelectedCategory",
+      category: deriveCategoryFromWallpaper(currentWallpaper),
+    });
   }, [currentWallpaper, INDEXEDDB_PREFIX]);
 
   const formatCategoryLabel = (category: string) => {
@@ -386,7 +421,10 @@ export function WallpaperPicker({ onSelect }: WallpaperPickerProps) {
           <Select
             value={selectedCategory}
             onValueChange={(value) =>
-              setSelectedCategory(value as typeof selectedCategory)
+              dispatch({
+                type: "setSelectedCategory",
+                category: value as typeof selectedCategory,
+              })
             }
           >
             <SelectTrigger>

--- a/src/apps/finder/components/FileIcon.tsx
+++ b/src/apps/finder/components/FileIcon.tsx
@@ -1,5 +1,5 @@
 import { useSound, Sounds } from "@/hooks/useSound";
-import { useEffect, useState, useRef } from "react";
+import { useEffect, useReducer, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { isTouchDevice } from "@/utils/device";
 import { useLongPress } from "@/hooks/useLongPress";
@@ -42,8 +42,32 @@ export function FileIcon({
   const { isWinXp: isXpTheme, isWin98: isWin98Theme, isMacOSTheme: isMacOSXTheme } =
     useThemeFlags();
   const isFinderContext = context === "finder";
-  const [imgSrc, setImgSrc] = useState<string | undefined>(contentUrl);
-  const [fallbackToIcon, setFallbackToIcon] = useState(false);
+  type PreviewState = {
+    imgSrc: string | undefined;
+    fallbackToIcon: boolean;
+  };
+  type PreviewAction =
+    | { type: "reset"; imgSrc: string | undefined }
+    | { type: "setImage"; imgSrc: string | undefined }
+    | { type: "fallback" };
+  const initialState: PreviewState = {
+    imgSrc: contentUrl,
+    fallbackToIcon: false,
+  };
+  const reducer = (state: PreviewState, action: PreviewAction): PreviewState => {
+    switch (action.type) {
+      case "reset":
+        return { imgSrc: action.imgSrc, fallbackToIcon: false };
+      case "setImage":
+        return { ...state, imgSrc: action.imgSrc };
+      case "fallback":
+        return { ...state, fallbackToIcon: true };
+      default:
+        return state;
+    }
+  };
+  const [previewState, dispatch] = useReducer(reducer, initialState);
+  const { imgSrc, fallbackToIcon } = previewState;
   const attemptedUrlsRef = useRef<Set<string>>(new Set());
   const blobUrlRef = useRef<string | null>(null);
   const contentRef = useRef(content);
@@ -68,6 +92,10 @@ export function FileIcon({
 
   // Setup image source once on mount, or when key props change
   useEffect(() => {
+    dispatch({ type: "reset", imgSrc: contentUrl });
+  }, [contentUrl, content]);
+
+  useEffect(() => {
     // Skip if we're already showing the icon
     if (fallbackToIcon) return;
 
@@ -77,7 +105,7 @@ export function FileIcon({
     // Try contentUrl first if available
     if (contentUrl && !attemptedUrlsRef.current.has(contentUrl)) {
       attemptedUrlsRef.current.add(contentUrl);
-      setImgSrc(contentUrl);
+      dispatch({ type: "setImage", imgSrc: contentUrl });
       return;
     }
 
@@ -93,13 +121,13 @@ export function FileIcon({
         const url = URL.createObjectURL(content);
         blobUrlRef.current = url;
         attemptedUrlsRef.current.add(url);
-        setImgSrc(url);
+        dispatch({ type: "setImage", imgSrc: url });
       } else if (
         typeof content === "string" &&
         !attemptedUrlsRef.current.has(content)
       ) {
         attemptedUrlsRef.current.add(content);
-        setImgSrc(content);
+        dispatch({ type: "setImage", imgSrc: content });
       }
     }
   }, [contentUrl, content, fallbackToIcon]);
@@ -176,7 +204,7 @@ export function FileIcon({
         // Create new URL from the same blob
         const newUrl = URL.createObjectURL(contentRef.current);
         blobUrlRef.current = newUrl;
-        setImgSrc(newUrl);
+        dispatch({ type: "setImage", imgSrc: newUrl });
         console.log(
           `[FileIcon] Created new URL for ${name}: ${newUrl.substring(
             0,
@@ -189,7 +217,7 @@ export function FileIcon({
 
     // Otherwise fall back to icon
     console.log(`[FileIcon] Falling back to icon for ${name}`);
-    setFallbackToIcon(true);
+    dispatch({ type: "fallback" });
   };
 
   const renderIcon = () => {

--- a/src/apps/infinite-mac/hooks/useInfiniteMacLogic.ts
+++ b/src/apps/infinite-mac/hooks/useInfiniteMacLogic.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useReducer, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useTranslatedHelpItems } from "@/hooks/useTranslatedHelpItems";
 import { useThemeFlags } from "@/hooks/useThemeFlags";
@@ -57,15 +57,47 @@ interface UseInfiniteMacLogicProps {
   instanceId?: string;
 }
 
+interface InfiniteMacUiState {
+  selectedPreset: MacPreset | null;
+  isEmulatorLoaded: boolean;
+  isPaused: boolean;
+}
+
+const initialState: InfiniteMacUiState = {
+  selectedPreset: null,
+  isEmulatorLoaded: false,
+  isPaused: false,
+};
+
+type InfiniteMacUiAction =
+  | { type: "setSelectedPreset"; value: MacPreset | null }
+  | { type: "setIsEmulatorLoaded"; value: boolean }
+  | { type: "setIsPaused"; value: boolean };
+
+function reducer(
+  state: InfiniteMacUiState,
+  action: InfiniteMacUiAction
+): InfiniteMacUiState {
+  switch (action.type) {
+    case "setSelectedPreset":
+      return { ...state, selectedPreset: action.value };
+    case "setIsEmulatorLoaded":
+      return { ...state, isEmulatorLoaded: action.value };
+    case "setIsPaused":
+      return { ...state, isPaused: action.value };
+    default:
+      return state;
+  }
+}
+
 export function useInfiniteMacLogic({
   isWindowOpen: _isWindowOpen,
   instanceId,
 }: UseInfiniteMacLogicProps) {
   const [isHelpDialogOpen, setIsHelpDialogOpen] = useState(false);
   const [isAboutDialogOpen, setIsAboutDialogOpen] = useState(false);
-  const [selectedPreset, setSelectedPresetLocal] = useState<MacPreset | null>(null);
-  const [isEmulatorLoaded, setIsEmulatorLoadedLocal] = useState(false);
-  const [isPaused, setIsPausedLocal] = useState(false);
+  const [state, dispatch] = useReducer(reducer, initialState);
+  const { selectedPreset, isEmulatorLoaded, isPaused } = state;
   const { 
     scale: currentScale, 
     setScale: setCurrentScale,
@@ -91,17 +123,17 @@ export function useInfiniteMacLogic({
 
   // Sync local state with store for AI tool access
   const setSelectedPreset = useCallback((preset: MacPreset | null) => {
-    setSelectedPresetLocal(preset);
+    dispatch({ type: "setSelectedPreset", value: preset });
     setSelectedPresetStore(preset);
   }, [setSelectedPresetStore]);
 
   const setIsEmulatorLoaded = useCallback((loaded: boolean) => {
-    setIsEmulatorLoadedLocal(loaded);
+    dispatch({ type: "setIsEmulatorLoaded", value: loaded });
     setIsEmulatorLoadedStore(loaded);
   }, [setIsEmulatorLoadedStore]);
 
   const setIsPaused = useCallback((paused: boolean) => {
-    setIsPausedLocal(paused);
+    dispatch({ type: "setIsPaused", value: paused });
     setIsPausedStore(paused);
   }, [setIsPausedStore]);
 

--- a/src/apps/infinite-pc/hooks/useInfinitePcLogic.ts
+++ b/src/apps/infinite-pc/hooks/useInfinitePcLogic.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useReducer, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useTranslatedHelpItems } from "@/hooks/useTranslatedHelpItems";
 import { useThemeFlags } from "@/hooks/useThemeFlags";
@@ -69,19 +69,67 @@ const INITIAL_PROGRESS: PcLoadProgress = {
   fileCount: 0,
 };
 
+interface InfinitePcUiState {
+  selectedPreset: PcPreset | null;
+  isEmulatorLoaded: boolean;
+  loadProgress: PcLoadProgress;
+  loadError: string | null;
+}
+
+const initialState: InfinitePcUiState = {
+  selectedPreset: null,
+  isEmulatorLoaded: false,
+  loadProgress: INITIAL_PROGRESS,
+  loadError: null,
+};
+
+type InfinitePcUiAction =
+  | { type: "setSelectedPreset"; value: PcPreset | null }
+  | { type: "setIsEmulatorLoaded"; value: boolean }
+  | { type: "setLoadProgress"; value: PcLoadProgress | ((prev: PcLoadProgress) => PcLoadProgress) }
+  | { type: "setLoadError"; value: string | null };
+
+function reducer(
+  state: InfinitePcUiState,
+  action: InfinitePcUiAction
+): InfinitePcUiState {
+  switch (action.type) {
+    case "setSelectedPreset":
+      return { ...state, selectedPreset: action.value };
+    case "setIsEmulatorLoaded":
+      return { ...state, isEmulatorLoaded: action.value };
+    case "setLoadProgress":
+      return {
+        ...state,
+        loadProgress:
+          typeof action.value === "function"
+            ? action.value(state.loadProgress)
+            : action.value,
+      };
+    case "setLoadError":
+      return { ...state, loadError: action.value };
+    default:
+      return state;
+  }
+}
+
 export function useInfinitePcLogic({
   isWindowOpen: _isWindowOpen,
   instanceId,
 }: UseInfinitePcLogicProps) {
   const [isHelpDialogOpen, setIsHelpDialogOpen] = useState(false);
   const [isAboutDialogOpen, setIsAboutDialogOpen] = useState(false);
-  const [selectedPreset, setSelectedPresetLocal] = useState<PcPreset | null>(
-    null
+  const [state, dispatch] = useReducer(reducer, initialState);
+  const { selectedPreset, isEmulatorLoaded, loadProgress, loadError } = state;
+  const setLoadProgress = useCallback(
+    (value: PcLoadProgress | ((prev: PcLoadProgress) => PcLoadProgress)) => {
+      dispatch({ type: "setLoadProgress", value });
+    },
+    []
   );
-  const [isEmulatorLoaded, setIsEmulatorLoadedLocal] = useState(false);
-  const [loadProgress, setLoadProgress] =
-    useState<PcLoadProgress>(INITIAL_PROGRESS);
-  const [loadError, setLoadError] = useState<string | null>(null);
+  const setLoadError = useCallback((value: string | null) => {
+    dispatch({ type: "setLoadError", value });
+  }, []);
   const iframeRef = useRef<HTMLIFrameElement>(null);
 
   const { setSelectedPreset: setSelectedPresetStore, setIsEmulatorLoaded: setIsEmulatorLoadedStore } =
@@ -94,7 +142,7 @@ export function useInfinitePcLogic({
 
   const setSelectedPreset = useCallback(
     (preset: PcPreset | null) => {
-      setSelectedPresetLocal(preset);
+      dispatch({ type: "setSelectedPreset", value: preset });
       setSelectedPresetStore(preset);
     },
     [setSelectedPresetStore]
@@ -102,7 +150,7 @@ export function useInfinitePcLogic({
 
   const setIsEmulatorLoaded = useCallback(
     (loaded: boolean) => {
-      setIsEmulatorLoadedLocal(loaded);
+      dispatch({ type: "setIsEmulatorLoaded", value: loaded });
       setIsEmulatorLoadedStore(loaded);
     },
     [setIsEmulatorLoadedStore]

--- a/src/apps/internet-explorer/components/TimeMachineView.tsx
+++ b/src/apps/internet-explorer/components/TimeMachineView.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback, useRef } from "react";
+import React, { useState, useEffect, useCallback, useReducer, useRef } from "react";
 import { createPortal } from "react-dom";
 import { motion, AnimatePresence } from "framer-motion";
 import { X, Sparkle, Export } from "@phosphor-icons/react";
@@ -37,6 +37,70 @@ interface TimeMachineViewProps {
   currentSelectedYear: string; // Add prop for the initially selected year
 }
 
+interface TimeMachineUiState {
+  activeYearIndex: number;
+  navigationDirection: "forward" | "backward" | "none";
+  previewYear: string | null;
+  previewContent: string | null;
+  previewSourceType: PreviewSource | null;
+  previewStatus: "idle" | "loading" | "success" | "error";
+  previewError: string | null;
+  isIframeLoaded: boolean;
+}
+
+const initialState: TimeMachineUiState = {
+  activeYearIndex: 0,
+  navigationDirection: "none",
+  previewYear: null,
+  previewContent: null,
+  previewSourceType: null,
+  previewStatus: "idle",
+  previewError: null,
+  isIframeLoaded: false,
+};
+
+type TimeMachineUiAction =
+  | { type: "setActiveYearIndex"; value: number | ((prev: number) => number) }
+  | { type: "setNavigationDirection"; value: "forward" | "backward" | "none" }
+  | { type: "setPreviewYear"; value: string | null }
+  | { type: "setPreviewContent"; value: string | null }
+  | { type: "setPreviewSourceType"; value: PreviewSource | null }
+  | { type: "setPreviewStatus"; value: "idle" | "loading" | "success" | "error" }
+  | { type: "setPreviewError"; value: string | null }
+  | { type: "setIsIframeLoaded"; value: boolean };
+
+function reducer(
+  state: TimeMachineUiState,
+  action: TimeMachineUiAction
+): TimeMachineUiState {
+  switch (action.type) {
+    case "setActiveYearIndex":
+      return {
+        ...state,
+        activeYearIndex:
+          typeof action.value === "function"
+            ? action.value(state.activeYearIndex)
+            : action.value,
+      };
+    case "setNavigationDirection":
+      return { ...state, navigationDirection: action.value };
+    case "setPreviewYear":
+      return { ...state, previewYear: action.value };
+    case "setPreviewContent":
+      return { ...state, previewContent: action.value };
+    case "setPreviewSourceType":
+      return { ...state, previewSourceType: action.value };
+    case "setPreviewStatus":
+      return { ...state, previewStatus: action.value };
+    case "setPreviewError":
+      return { ...state, previewError: action.value };
+    case "setIsIframeLoaded":
+      return { ...state, isIframeLoaded: action.value };
+    default:
+      return state;
+  }
+}
+
 const TimeMachineView: React.FC<TimeMachineViewProps> = ({
   isOpen,
   onClose,
@@ -47,29 +111,55 @@ const TimeMachineView: React.FC<TimeMachineViewProps> = ({
 }) => {
   const { t } = useTranslation();
   const { isMacOSTheme: isMacTheme } = useThemeFlags();
-  // Index of the year currently in focus (0 is the newest/frontmost)
-  const [activeYearIndex, setActiveYearIndex] = useState<number>(0);
+  const [state, dispatch] = useReducer(reducer, initialState);
+  const {
+    activeYearIndex,
+    navigationDirection,
+    previewYear,
+    previewContent,
+    previewSourceType,
+    previewStatus,
+    previewError,
+    isIframeLoaded,
+  } = state;
+  const setActiveYearIndex = useCallback(
+    (value: number | ((prev: number) => number)) => {
+      dispatch({ type: "setActiveYearIndex", value });
+    },
+    []
+  );
+  const setNavigationDirection = useCallback(
+    (value: "forward" | "backward" | "none") => {
+      dispatch({ type: "setNavigationDirection", value });
+    },
+    []
+  );
+  const setPreviewYear = useCallback((value: string | null) => {
+    dispatch({ type: "setPreviewYear", value });
+  }, []);
+  const setPreviewContent = useCallback((value: string | null) => {
+    dispatch({ type: "setPreviewContent", value });
+  }, []);
+  const setPreviewSourceType = useCallback((value: PreviewSource | null) => {
+    dispatch({ type: "setPreviewSourceType", value });
+  }, []);
+  const setPreviewStatus = useCallback(
+    (value: "idle" | "loading" | "success" | "error") => {
+      dispatch({ type: "setPreviewStatus", value });
+    },
+    []
+  );
+  const setPreviewError = useCallback((value: string | null) => {
+    dispatch({ type: "setPreviewError", value });
+  }, []);
+  const setIsIframeLoaded = useCallback((value: boolean) => {
+    dispatch({ type: "setIsIframeLoaded", value });
+  }, []);
   const [scrollState, setScrollState] = useState({
     isTop: true,
     isBottom: false,
     canScroll: false,
   });
-  // State to track navigation direction for animations
-  const [navigationDirection, setNavigationDirection] = useState<
-    "forward" | "backward" | "none"
-  >("none");
-
-  // --- Time Machine Local Preview State ---
-  const [previewYear, setPreviewYear] = useState<string | null>(null);
-  const [previewContent, setPreviewContent] = useState<string | null>(null);
-  const [previewSourceType, setPreviewSourceType] =
-    useState<PreviewSource | null>(null);
-  const [previewStatus, setPreviewStatus] = useState<
-    "idle" | "loading" | "success" | "error"
-  >("idle");
-  const [previewError, setPreviewError] = useState<string | null>(null);
-  const [isIframeLoaded, setIsIframeLoaded] = useState<boolean>(false); // State for iframe load status
-  // --- End Local Preview State ---
 
   const timelineRef = useRef<HTMLDivElement>(null);
   const previewContainerRef = useRef<HTMLDivElement>(null);

--- a/src/apps/internet-explorer/hooks/useInternetExplorerLogic.ts
+++ b/src/apps/internet-explorer/hooks/useInternetExplorerLogic.ts
@@ -1,6 +1,7 @@
 import React, {
   useEffect,
   useRef,
+  useReducer,
   useState,
   useCallback,
   useMemo,
@@ -156,6 +157,63 @@ type SuggestionItem = {
   favicon?: string;
   normalizedUrl?: string; // Optional prop for internal use
 };
+
+interface UrlBarUiState {
+  isUrlDropdownOpen: boolean;
+  filteredSuggestions: SuggestionItem[];
+  localUrl: string;
+  isSelectingText: boolean;
+  selectedSuggestionIndex: number;
+  dropdownStyle: CSSProperties;
+}
+
+const urlBarUiInitialState: UrlBarUiState = {
+  isUrlDropdownOpen: false,
+  filteredSuggestions: [],
+  localUrl: "",
+  isSelectingText: false,
+  selectedSuggestionIndex: 0,
+  dropdownStyle: {},
+};
+
+type UrlBarUiAction =
+  | { type: "setIsUrlDropdownOpen"; value: boolean }
+  | { type: "setFilteredSuggestions"; value: SuggestionItem[] }
+  | { type: "setLocalUrl"; value: string }
+  | { type: "setIsSelectingText"; value: boolean }
+  | { type: "setSelectedSuggestionIndex"; value: number }
+  | {
+      type: "setDropdownStyle";
+      value: CSSProperties | ((prev: CSSProperties) => CSSProperties);
+    };
+
+function urlBarUiReducer(
+  state: UrlBarUiState,
+  action: UrlBarUiAction
+): UrlBarUiState {
+  switch (action.type) {
+    case "setIsUrlDropdownOpen":
+      return { ...state, isUrlDropdownOpen: action.value };
+    case "setFilteredSuggestions":
+      return { ...state, filteredSuggestions: action.value };
+    case "setLocalUrl":
+      return { ...state, localUrl: action.value };
+    case "setIsSelectingText":
+      return { ...state, isSelectingText: action.value };
+    case "setSelectedSuggestionIndex":
+      return { ...state, selectedSuggestionIndex: action.value };
+    case "setDropdownStyle":
+      return {
+        ...state,
+        dropdownStyle:
+          typeof action.value === "function"
+            ? action.value(state.dropdownStyle)
+            : action.value,
+      };
+    default:
+      return state;
+  }
+}
 
 interface UseInternetExplorerLogicProps {
   isWindowOpen: boolean;
@@ -323,14 +381,39 @@ export function useInternetExplorerLogic({
 
   const abortControllerRef = useRef<AbortController | null>(null);
   const [hasMoreToScroll] = useState(false);
-  const [isUrlDropdownOpen, setIsUrlDropdownOpen] = useState(false);
-  const [filteredSuggestions, setFilteredSuggestions] = useState<
-    Array<SuggestionItem>
-  >([]);
-  const [localUrl, setLocalUrl] = useState<string>("");
-  const [isSelectingText, setIsSelectingText] = useState(false);
-  const [selectedSuggestionIndex, setSelectedSuggestionIndex] = useState(0);
-  const [dropdownStyle, setDropdownStyle] = useState<CSSProperties>({});
+  const [urlBarUiState, dispatchUrlBarUi] = useReducer(
+    urlBarUiReducer,
+    urlBarUiInitialState
+  );
+  const {
+    isUrlDropdownOpen,
+    filteredSuggestions,
+    localUrl,
+    isSelectingText,
+    selectedSuggestionIndex,
+    dropdownStyle,
+  } = urlBarUiState;
+  const setIsUrlDropdownOpen = useCallback((value: boolean) => {
+    dispatchUrlBarUi({ type: "setIsUrlDropdownOpen", value });
+  }, []);
+  const setFilteredSuggestions = useCallback((value: SuggestionItem[]) => {
+    dispatchUrlBarUi({ type: "setFilteredSuggestions", value });
+  }, []);
+  const setLocalUrl = useCallback((value: string) => {
+    dispatchUrlBarUi({ type: "setLocalUrl", value });
+  }, []);
+  const setIsSelectingText = useCallback((value: boolean) => {
+    dispatchUrlBarUi({ type: "setIsSelectingText", value });
+  }, []);
+  const setSelectedSuggestionIndex = useCallback((value: number) => {
+    dispatchUrlBarUi({ type: "setSelectedSuggestionIndex", value });
+  }, []);
+  const setDropdownStyle = useCallback(
+    (value: CSSProperties | ((prev: CSSProperties) => CSSProperties)) => {
+      dispatchUrlBarUi({ type: "setDropdownStyle", value });
+    },
+    []
+  );
 
   useEffect(() => {
     const updateDropdownStyle = () => {

--- a/src/apps/ipod/components/CoverFlow.tsx
+++ b/src/apps/ipod/components/CoverFlow.tsx
@@ -1,4 +1,12 @@
-import { useEffect, useRef, useState, useCallback, useImperativeHandle, forwardRef, useMemo } from "react";
+import {
+  useEffect,
+  useRef,
+  useCallback,
+  useImperativeHandle,
+  forwardRef,
+  useMemo,
+  useReducer,
+} from "react";
 import { motion, AnimatePresence, PanInfo, useMotionValue, animate } from "framer-motion";
 import {
   getYouTubeVideoId,
@@ -31,6 +39,59 @@ const MODERN_TITLEBAR_HEIGHT = 17;
 
 // Long press delay in milliseconds
 const LONG_PRESS_DELAY = 500;
+
+interface CoverFlowUiState {
+  selectedIndex: number;
+  showCD: boolean;
+  isFlipped: boolean;
+  isFlipAnimating: boolean;
+  selectedTrackInAlbum: number;
+}
+
+type CoverFlowUiAction =
+  | {
+      type: "setSelectedIndex";
+      value: number | ((prev: number) => number);
+    }
+  | { type: "setShowCD"; value: boolean }
+  | { type: "setIsFlipped"; value: boolean }
+  | { type: "setIsFlipAnimating"; value: boolean }
+  | {
+      type: "setSelectedTrackInAlbum";
+      value: number | ((prev: number) => number);
+    };
+
+function coverFlowUiReducer(
+  state: CoverFlowUiState,
+  action: CoverFlowUiAction
+): CoverFlowUiState {
+  switch (action.type) {
+    case "setSelectedIndex":
+      return {
+        ...state,
+        selectedIndex:
+          typeof action.value === "function"
+            ? action.value(state.selectedIndex)
+            : action.value,
+      };
+    case "setShowCD":
+      return { ...state, showCD: action.value };
+    case "setIsFlipped":
+      return { ...state, isFlipped: action.value };
+    case "setIsFlipAnimating":
+      return { ...state, isFlipAnimating: action.value };
+    case "setSelectedTrackInAlbum":
+      return {
+        ...state,
+        selectedTrackInAlbum:
+          typeof action.value === "function"
+            ? action.value(state.selectedTrackInAlbum)
+            : action.value,
+      };
+    default:
+      return state;
+  }
+}
 
 // Format a track duration in milliseconds as `m:ss`. Returns an empty
 // string when the duration is unknown so the tracklist row collapses
@@ -1109,13 +1170,33 @@ export const CoverFlow = forwardRef<CoverFlowRef, CoverFlowProps>(function Cover
     return index >= 0 ? index : Math.min(currentIndex, coverItems.length - 1);
   }, [coverItems, currentIndex]);
 
-  const [selectedIndex, setSelectedIndex] = useState(currentCoverIndex);
-  const [showCD, setShowCD] = useState(false);
+  const [uiState, dispatch] = useReducer(coverFlowUiReducer, {
+    selectedIndex: currentCoverIndex,
+    showCD: false,
+    isFlipped: false,
+    isFlipAnimating: false,
+    selectedTrackInAlbum: 0,
+  });
+  const {
+    selectedIndex,
+    showCD,
+    isFlipped,
+    isFlipAnimating,
+    selectedTrackInAlbum,
+  } = uiState;
+  const setSelectedIndex = useCallback(
+    (value: number | ((prev: number) => number)) => {
+      dispatch({ type: "setSelectedIndex", value });
+    },
+    []
+  );
+  const setShowCD = useCallback((value: boolean) => {
+    dispatch({ type: "setShowCD", value });
+  }, []);
   // When the user presses the wheel center on an album cover, the
   // cover flips over to reveal that album's tracklist. The flip is
   // album-scoped: navigating to a different cover snaps back to the
   // un-flipped state (matches the iPod nano/classic 6G behavior).
-  const [isFlipped, setIsFlipped] = useState(false);
   // True while the album-flip overlay is mid-rotation (in either
   // direction). Lets us keep the underlying carousel center sleeve
   // hidden for the full back-flip duration so the reverse animation
@@ -1123,7 +1204,12 @@ export const CoverFlow = forwardRef<CoverFlowRef, CoverFlowProps>(function Cover
   // sleeve pops back to visible the instant Menu is pressed and the
   // reverse rotation reads as "the tracklist just disappeared". Same
   // pattern the dashboard widget flip uses (`WidgetChrome.tsx`).
-  const [isFlipAnimating, setIsFlipAnimating] = useState(false);
+  const setIsFlipped = useCallback((value: boolean) => {
+    dispatch({ type: "setIsFlipped", value });
+  }, []);
+  const setIsFlipAnimating = useCallback((value: boolean) => {
+    dispatch({ type: "setIsFlipAnimating", value });
+  }, []);
   const flipAnimationTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
     null
   );
@@ -1142,7 +1228,12 @@ export const CoverFlow = forwardRef<CoverFlowRef, CoverFlowProps>(function Cover
   // the active album changes so wheel rotation always starts at the
   // currently-playing track (or the first track if none of this album
   // is playing).
-  const [selectedTrackInAlbum, setSelectedTrackInAlbum] = useState(0);
+  const setSelectedTrackInAlbum = useCallback(
+    (value: number | ((prev: number) => number)) => {
+      dispatch({ type: "setSelectedTrackInAlbum", value });
+    },
+    []
+  );
   const containerRef = useRef<HTMLDivElement>(null);
   const { isMacOSTheme: isMacTheme } = useThemeFlags();
   const uiVariant = useIpodStore((s) => s.uiVariant);

--- a/src/apps/ipod/components/IpodScreen.tsx
+++ b/src/apps/ipod/components/IpodScreen.tsx
@@ -3,6 +3,7 @@ import {
   useEffect,
   useLayoutEffect,
   useMemo,
+  useReducer,
   useState,
   useCallback,
   type CSSProperties,
@@ -92,6 +93,34 @@ const SPLIT_LAYOUT_TRANSITION_TIMING =
 // Render this many extra items above and below the visible window so
 // scrolling doesn't reveal blank rows before React reconciles.
 const OVERSCAN_ITEMS = 6;
+
+interface MenuScrollState {
+  scrollTop: number;
+  containerHeight: number;
+}
+
+const menuScrollInitialState: MenuScrollState = {
+  scrollTop: 0,
+  containerHeight: 0,
+};
+
+type MenuScrollAction =
+  | { type: "setScrollTop"; value: number }
+  | { type: "setContainerHeight"; value: number };
+
+function menuScrollReducer(
+  state: MenuScrollState,
+  action: MenuScrollAction
+): MenuScrollState {
+  switch (action.type) {
+    case "setScrollTop":
+      return { ...state, scrollTop: action.value };
+    case "setContainerHeight":
+      return { ...state, containerHeight: action.value };
+    default:
+      return state;
+  }
+}
 
 function formatPlaybackTime(totalSeconds: number): string {
   const safeSeconds = Math.max(0, Math.floor(totalSeconds));
@@ -431,8 +460,17 @@ export function IpodScreen({
 
   // Track scroll position + container height so we can compute the
   // visible window for virtualization.
-  const [scrollTop, setScrollTop] = useState(0);
-  const [containerHeight, setContainerHeight] = useState(0);
+  const [menuScrollState, dispatchMenuScroll] = useReducer(
+    menuScrollReducer,
+    menuScrollInitialState
+  );
+  const { scrollTop, containerHeight } = menuScrollState;
+  const setScrollTop = useCallback((value: number) => {
+    dispatchMenuScroll({ type: "setScrollTop", value });
+  }, []);
+  const setContainerHeight = useCallback((value: number) => {
+    dispatchMenuScroll({ type: "setContainerHeight", value });
+  }, []);
 
   useEffect(() => {
     const el = menuScrollRef.current;

--- a/src/apps/ipod/components/LyricsDisplay.tsx
+++ b/src/apps/ipod/components/LyricsDisplay.tsx
@@ -13,6 +13,7 @@ import { useTranslation } from "react-i18next";
 import {
   useMemo,
   useRef,
+  useReducer,
   useState,
   useEffect,
   useCallback,
@@ -1308,8 +1309,21 @@ function LyricsLineRowContent({
     timeMsForInterludeDots !== undefined &&
     interludeInlineCountdownStartMs !== undefined
   );
-  const [dotsExitDone, setDotsExitDone] = useState(true);
-  if (dotsActive && dotsExitDone) setDotsExitDone(false);
+  const [dotsState, dispatchDotsState] = useReducer(
+    (state: { dotsExitDone: boolean }, action: { type: "setDotsExitDone"; value: boolean }) => {
+      if (action.type === "setDotsExitDone") {
+        return { dotsExitDone: action.value };
+      }
+      return state;
+    },
+    { dotsExitDone: true }
+  );
+  const dotsExitDone = dotsState.dotsExitDone;
+  useEffect(() => {
+    if (dotsActive && dotsExitDone) {
+      dispatchDotsState({ type: "setDotsExitDone", value: false });
+    }
+  }, [dotsActive, dotsExitDone]);
 
   return (
     <>
@@ -1653,7 +1667,9 @@ function LyricsLineRowContent({
             >
               <AnimatePresence
                 initial={false}
-                onExitComplete={() => setDotsExitDone(true)}
+                onExitComplete={() =>
+                  dispatchDotsState({ type: "setDotsExitDone", value: true })
+                }
               >
                 {dotsActive && (
                   <motion.div

--- a/src/apps/ipod/components/MusicQuiz.tsx
+++ b/src/apps/ipod/components/MusicQuiz.tsx
@@ -1,4 +1,12 @@
-import { useEffect, useRef, useState, useMemo, useCallback, useImperativeHandle, forwardRef } from "react";
+import {
+  useEffect,
+  useRef,
+  useMemo,
+  useCallback,
+  useImperativeHandle,
+  forwardRef,
+  useReducer,
+} from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import ReactPlayer from "react-player";
 import { useTranslation } from "react-i18next";
@@ -51,6 +59,80 @@ type Phase =
   | "playing"
   | "feedback"
   | "finished";
+
+interface QuizUiState {
+  phase: Phase;
+  round: MusicQuizRound | null;
+  roundNumber: number;
+  score: number;
+  lastRoundPoints: number;
+  selectedIndex: number;
+  isPlayerReady: boolean;
+}
+
+const initialState: QuizUiState = {
+  phase: "idle",
+  round: null,
+  roundNumber: 0,
+  score: 0,
+  lastRoundPoints: 0,
+  selectedIndex: 0,
+  isPlayerReady: false,
+};
+
+type QuizUiAction =
+  | { type: "setPhase"; value: Phase }
+  | {
+      type: "setRound";
+      value: MusicQuizRound | null | ((prev: MusicQuizRound | null) => MusicQuizRound | null);
+    }
+  | { type: "setRoundNumber"; value: number | ((prev: number) => number) }
+  | { type: "setScore"; value: number | ((prev: number) => number) }
+  | { type: "setLastRoundPoints"; value: number }
+  | { type: "setSelectedIndex"; value: number | ((prev: number) => number) }
+  | { type: "setIsPlayerReady"; value: boolean };
+
+function reducer(state: QuizUiState, action: QuizUiAction): QuizUiState {
+  switch (action.type) {
+    case "setPhase":
+      return { ...state, phase: action.value };
+    case "setRound":
+      return {
+        ...state,
+        round: typeof action.value === "function" ? action.value(state.round) : action.value,
+      };
+    case "setRoundNumber":
+      return {
+        ...state,
+        roundNumber:
+          typeof action.value === "function"
+            ? action.value(state.roundNumber)
+            : action.value,
+      };
+    case "setScore":
+      return {
+        ...state,
+        score:
+          typeof action.value === "function"
+            ? action.value(state.score)
+            : action.value,
+      };
+    case "setLastRoundPoints":
+      return { ...state, lastRoundPoints: action.value };
+    case "setSelectedIndex":
+      return {
+        ...state,
+        selectedIndex:
+          typeof action.value === "function"
+            ? action.value(state.selectedIndex)
+            : action.value,
+      };
+    case "setIsPlayerReady":
+      return { ...state, isPlayerReady: action.value };
+    default:
+      return state;
+  }
+}
 
 export interface MusicQuizRef {
   /** Move selection up/down. Returns true if handled. */
@@ -121,13 +203,48 @@ export const MusicQuiz = forwardRef<MusicQuizRef, MusicQuizProps>(function Music
   const ipodVolume = useAudioSettingsStore((s) => s.ipodVolume);
   const finalVolume = ipodVolume * masterVolume;
 
-  const [phase, setPhase] = useState<Phase>("idle");
-  const [round, setRound] = useState<MusicQuizRound | null>(null);
-  const [roundNumber, setRoundNumber] = useState(0);
-  const [score, setScore] = useState(0);
-  const [lastRoundPoints, setLastRoundPoints] = useState(0);
-  const [selectedIndex, setSelectedIndex] = useState(0);
-  const [isPlayerReady, setIsPlayerReady] = useState(false);
+  const [state, dispatch] = useReducer(reducer, initialState);
+  const {
+    phase,
+    round,
+    roundNumber,
+    score,
+    lastRoundPoints,
+    selectedIndex,
+    isPlayerReady,
+  } = state;
+  const setPhase = useCallback((value: Phase) => {
+    dispatch({ type: "setPhase", value });
+  }, []);
+  const setRound = useCallback(
+    (
+      value:
+        | MusicQuizRound
+        | null
+        | ((prev: MusicQuizRound | null) => MusicQuizRound | null)
+    ) => {
+      dispatch({ type: "setRound", value });
+    },
+    []
+  );
+  const setRoundNumber = useCallback((value: number | ((prev: number) => number)) => {
+    dispatch({ type: "setRoundNumber", value });
+  }, []);
+  const setScore = useCallback((value: number | ((prev: number) => number)) => {
+    dispatch({ type: "setScore", value });
+  }, []);
+  const setLastRoundPoints = useCallback((value: number) => {
+    dispatch({ type: "setLastRoundPoints", value });
+  }, []);
+  const setSelectedIndex = useCallback(
+    (value: number | ((prev: number) => number)) => {
+      dispatch({ type: "setSelectedIndex", value });
+    },
+    []
+  );
+  const setIsPlayerReady = useCallback((value: boolean) => {
+    dispatch({ type: "setIsPlayerReady", value });
+  }, []);
 
   const youtubePlayerRef = useRef<ReactPlayer | null>(null);
   const appleMusicPlayerRef = useRef<AppleMusicPlayerBridgeHandle | null>(null);

--- a/src/apps/ipod/components/screen/BatteryIndicator.tsx
+++ b/src/apps/ipod/components/screen/BatteryIndicator.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useCallback, useEffect, useReducer } from "react";
 import { cn } from "@/lib/utils";
 import type { BatteryManager } from "../../types";
 
@@ -8,14 +8,71 @@ interface BatteryIndicatorProps {
   variant?: "classic" | "modern";
 }
 
+interface BatteryIndicatorState {
+  batteryLevel: number | null;
+  isCharging: boolean;
+  animationFrame: number;
+}
+
+const initialState: BatteryIndicatorState = {
+  batteryLevel: null,
+  isCharging: false,
+  animationFrame: 1,
+};
+
+type BatteryIndicatorAction =
+  | { type: "setBatteryLevel"; value: number | null }
+  | { type: "setIsCharging"; value: boolean }
+  | { type: "setAnimationFrame"; value: number | ((prev: number) => number) }
+  | { type: "setBatteryStatus"; batteryLevel: number; isCharging: boolean };
+
+function reducer(
+  state: BatteryIndicatorState,
+  action: BatteryIndicatorAction
+): BatteryIndicatorState {
+  switch (action.type) {
+    case "setBatteryLevel":
+      return { ...state, batteryLevel: action.value };
+    case "setIsCharging":
+      return { ...state, isCharging: action.value };
+    case "setAnimationFrame":
+      return {
+        ...state,
+        animationFrame:
+          typeof action.value === "function"
+            ? action.value(state.animationFrame)
+            : action.value,
+      };
+    case "setBatteryStatus":
+      return {
+        ...state,
+        batteryLevel: action.batteryLevel,
+        isCharging: action.isCharging,
+      };
+    default:
+      return state;
+  }
+}
+
 export function BatteryIndicator({
   backlightOn,
   variant = "classic",
 }: BatteryIndicatorProps) {
   const isModern = variant === "modern";
-  const [batteryLevel, setBatteryLevel] = useState<number | null>(null);
-  const [isCharging, setIsCharging] = useState<boolean>(false);
-  const [animationFrame, setAnimationFrame] = useState<number>(1);
+  const [state, dispatch] = useReducer(reducer, initialState);
+  const { batteryLevel, isCharging, animationFrame } = state;
+  const setBatteryLevel = useCallback((value: number | null) => {
+    dispatch({ type: "setBatteryLevel", value });
+  }, []);
+  const setIsCharging = useCallback((value: boolean) => {
+    dispatch({ type: "setIsCharging", value });
+  }, []);
+  const setAnimationFrame = useCallback(
+    (value: number | ((prev: number) => number)) => {
+      dispatch({ type: "setAnimationFrame", value });
+    },
+    []
+  );
 
   useEffect(() => {
     let removeBatteryListeners: (() => void) | undefined;
@@ -28,8 +85,11 @@ export function BatteryIndicator({
             navigator as unknown as { getBattery: () => Promise<BatteryManager> }
           ).getBattery();
           if (isDisposed) return;
-          setBatteryLevel(battery.level);
-          setIsCharging(battery.charging);
+          dispatch({
+            type: "setBatteryStatus",
+            batteryLevel: battery.level,
+            isCharging: battery.charging,
+          });
 
           const updateLevel = () => setBatteryLevel(battery.level);
           const updateCharging = () => setIsCharging(battery.charging);
@@ -45,8 +105,7 @@ export function BatteryIndicator({
       } catch {
         if (isDisposed) return;
         // Fallback to a default level
-        setBatteryLevel(1.0);
-        setIsCharging(false);
+        dispatch({ type: "setBatteryStatus", batteryLevel: 1.0, isCharging: false });
       }
     };
 

--- a/src/apps/ipod/hooks/useIpodLogic.ts
+++ b/src/apps/ipod/hooks/useIpodLogic.ts
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect, useLayoutEffect, useCallback, useMemo } from "react";
+import { useState, useRef, useEffect, useLayoutEffect, useCallback, useMemo, useReducer } from "react";
 import ReactPlayer from "react-player";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
@@ -539,9 +539,75 @@ export function useIpodLogic({
     return !hasValidTrack;
   }, []);
 
-  const [menuMode, setMenuMode] = useState(initialMenuMode);
-  const [selectedMenuItem, setSelectedMenuItem] = useState(0);
-  const [menuDirection, setMenuDirection] = useState<"forward" | "backward">("forward");
+  const [menuUiState, dispatchMenuUi] = useReducer(
+    (
+      state: {
+        menuMode: boolean;
+        selectedMenuItem: number;
+        menuDirection: "forward" | "backward";
+        cameFromNowPlayingMenuItem: boolean;
+      },
+      action:
+        | {
+            type: "setMenuMode";
+            value: boolean | ((prev: boolean) => boolean);
+          }
+        | {
+            type: "setSelectedMenuItem";
+            value: number | ((prev: number) => number);
+          }
+        | { type: "setMenuDirection"; value: "forward" | "backward" }
+        | { type: "setCameFromNowPlayingMenuItem"; value: boolean }
+    ) => {
+      switch (action.type) {
+        case "setMenuMode":
+          return {
+            ...state,
+            menuMode:
+              typeof action.value === "function"
+                ? action.value(state.menuMode)
+                : action.value,
+          };
+        case "setSelectedMenuItem":
+          return {
+            ...state,
+            selectedMenuItem:
+              typeof action.value === "function"
+                ? action.value(state.selectedMenuItem)
+                : action.value,
+          };
+        case "setMenuDirection":
+          return { ...state, menuDirection: action.value };
+        case "setCameFromNowPlayingMenuItem":
+          return { ...state, cameFromNowPlayingMenuItem: action.value };
+        default:
+          return state;
+      }
+    },
+    {
+      menuMode: initialMenuMode,
+      selectedMenuItem: 0,
+      menuDirection: "forward",
+      cameFromNowPlayingMenuItem: false,
+    }
+  );
+  const { menuMode, selectedMenuItem, menuDirection, cameFromNowPlayingMenuItem } =
+    menuUiState;
+  const setMenuMode = useCallback(
+    (value: boolean | ((prev: boolean) => boolean)) => {
+      dispatchMenuUi({ type: "setMenuMode", value });
+    },
+    []
+  );
+  const setSelectedMenuItem = useCallback(
+    (value: number | ((prev: number) => number)) => {
+      dispatchMenuUi({ type: "setSelectedMenuItem", value });
+    },
+    []
+  );
+  const setMenuDirection = useCallback((value: "forward" | "backward") => {
+    dispatchMenuUi({ type: "setMenuDirection", value });
+  }, []);
   const [menuHistory, setMenuHistory] = useState<
     {
       title: string;
@@ -555,7 +621,9 @@ export function useIpodLogic({
       selectedIndex: number;
     }[]
   >([]);
-  const [cameFromNowPlayingMenuItem, setCameFromNowPlayingMenuItem] = useState(false);
+  const setCameFromNowPlayingMenuItem = useCallback((value: boolean) => {
+    dispatchMenuUi({ type: "setCameFromNowPlayingMenuItem", value });
+  }, []);
   // Save menu history before entering Now Playing from a song selection
   const menuHistoryBeforeNowPlayingRef = useRef<typeof menuHistory | null>(null);
 

--- a/src/apps/karaoke/hooks/useKaraokeLogic.ts
+++ b/src/apps/karaoke/hooks/useKaraokeLogic.ts
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect, useCallback, useMemo } from "react";
+import { useState, useRef, useEffect, useCallback, useMemo, useReducer } from "react";
 import ReactPlayer from "react-player";
 import { toast } from "sonner";
 import { useTranslation } from "react-i18next";
@@ -228,25 +228,146 @@ export function useKaraokeLogic({
     return listenRemoteOnly ? -1 : (tracks.length > 0 ? 0 : -1);
   }, [activeTrackId, listenRemoteOnly, tracks]);
 
+  const [uiState, dispatchUi] = useReducer(
+    (
+      state: {
+        isHelpDialogOpen: boolean;
+        isAboutDialogOpen: boolean;
+        isLangMenuOpen: boolean;
+        isPronunciationMenuOpen: boolean;
+        isConfirmClearOpen: boolean;
+        isShareDialogOpen: boolean;
+        isLyricsSearchDialogOpen: boolean;
+        isSongSearchDialogOpen: boolean;
+        isSyncModeOpen: boolean;
+        isAddingSong: boolean;
+        isListenInviteOpen: boolean;
+        isJoinListenDialogOpen: boolean;
+        isCoverFlowOpen: boolean;
+      },
+      action: {
+        type: "set";
+        key: keyof typeof state;
+        value: boolean | ((prev: boolean) => boolean);
+      }
+    ) => ({
+      ...state,
+      [action.key]:
+        typeof action.value === "function"
+          ? action.value(state[action.key])
+          : action.value,
+    }),
+    {
+      isHelpDialogOpen: false,
+      isAboutDialogOpen: false,
+      isLangMenuOpen: false,
+      isPronunciationMenuOpen: false,
+      isConfirmClearOpen: false,
+      isShareDialogOpen: false,
+      isLyricsSearchDialogOpen: false,
+      isSongSearchDialogOpen: false,
+      isSyncModeOpen: false,
+      isAddingSong: false,
+      isListenInviteOpen: false,
+      isJoinListenDialogOpen: false,
+      isCoverFlowOpen: false,
+    }
+  );
+  const {
+    isHelpDialogOpen,
+    isAboutDialogOpen,
+    isLangMenuOpen,
+    isPronunciationMenuOpen,
+    isConfirmClearOpen,
+    isShareDialogOpen,
+    isLyricsSearchDialogOpen,
+    isSongSearchDialogOpen,
+    isSyncModeOpen,
+    isAddingSong,
+    isListenInviteOpen,
+    isJoinListenDialogOpen,
+    isCoverFlowOpen,
+  } = uiState;
+  const setBool = useCallback(
+    (
+      key: keyof typeof uiState,
+      value: boolean | ((prev: boolean) => boolean)
+    ) => {
+      dispatchUi({ type: "set", key, value });
+    },
+    []
+  );
   // Dialog state
-  const [isHelpDialogOpen, setIsHelpDialogOpen] = useState(false);
-  const [isAboutDialogOpen, setIsAboutDialogOpen] = useState(false);
-  const [isLangMenuOpen, setIsLangMenuOpen] = useState(false);
-  const [isPronunciationMenuOpen, setIsPronunciationMenuOpen] = useState(false);
+  const setIsHelpDialogOpen = useCallback(
+    (value: boolean | ((prev: boolean) => boolean)) =>
+      setBool("isHelpDialogOpen", value),
+    [setBool]
+  );
+  const setIsAboutDialogOpen = useCallback(
+    (value: boolean | ((prev: boolean) => boolean)) =>
+      setBool("isAboutDialogOpen", value),
+    [setBool]
+  );
+  const setIsLangMenuOpen = useCallback(
+    (value: boolean | ((prev: boolean) => boolean)) =>
+      setBool("isLangMenuOpen", value),
+    [setBool]
+  );
+  const setIsPronunciationMenuOpen = useCallback(
+    (value: boolean | ((prev: boolean) => boolean)) =>
+      setBool("isPronunciationMenuOpen", value),
+    [setBool]
+  );
   const anyMenuOpen = isLangMenuOpen || isPronunciationMenuOpen;
   
   // New dialogs for iPod menu features
-  const [isConfirmClearOpen, setIsConfirmClearOpen] = useState(false);
-  const [isShareDialogOpen, setIsShareDialogOpen] = useState(false);
-  const [isLyricsSearchDialogOpen, setIsLyricsSearchDialogOpen] = useState(false);
-  const [isSongSearchDialogOpen, setIsSongSearchDialogOpen] = useState(false);
-  const [isSyncModeOpen, setIsSyncModeOpen] = useState(false);
-  const [isAddingSong, setIsAddingSong] = useState(false);
-  const [isListenInviteOpen, setIsListenInviteOpen] = useState(false);
-  const [isJoinListenDialogOpen, setIsJoinListenDialogOpen] = useState(false);
+  const setIsConfirmClearOpen = useCallback(
+    (value: boolean | ((prev: boolean) => boolean)) =>
+      setBool("isConfirmClearOpen", value),
+    [setBool]
+  );
+  const setIsShareDialogOpen = useCallback(
+    (value: boolean | ((prev: boolean) => boolean)) =>
+      setBool("isShareDialogOpen", value),
+    [setBool]
+  );
+  const setIsLyricsSearchDialogOpen = useCallback(
+    (value: boolean | ((prev: boolean) => boolean)) =>
+      setBool("isLyricsSearchDialogOpen", value),
+    [setBool]
+  );
+  const setIsSongSearchDialogOpen = useCallback(
+    (value: boolean | ((prev: boolean) => boolean)) =>
+      setBool("isSongSearchDialogOpen", value),
+    [setBool]
+  );
+  const setIsSyncModeOpen = useCallback(
+    (value: boolean | ((prev: boolean) => boolean)) =>
+      setBool("isSyncModeOpen", value),
+    [setBool]
+  );
+  const setIsAddingSong = useCallback(
+    (value: boolean | ((prev: boolean) => boolean)) =>
+      setBool("isAddingSong", value),
+    [setBool]
+  );
+  const setIsListenInviteOpen = useCallback(
+    (value: boolean | ((prev: boolean) => boolean)) =>
+      setBool("isListenInviteOpen", value),
+    [setBool]
+  );
+  const setIsJoinListenDialogOpen = useCallback(
+    (value: boolean | ((prev: boolean) => boolean)) =>
+      setBool("isJoinListenDialogOpen", value),
+    [setBool]
+  );
   
   // CoverFlow state
-  const [isCoverFlowOpen, setIsCoverFlowOpen] = useState(false);
+  const setIsCoverFlowOpen = useCallback(
+    (value: boolean | ((prev: boolean) => boolean)) =>
+      setBool("isCoverFlowOpen", value),
+    [setBool]
+  );
   const coverFlowRef = useRef<CoverFlowRef>(null);
   
   // Long press refs for CoverFlow toggle

--- a/src/apps/maps/components/MapsAppComponent.tsx
+++ b/src/apps/maps/components/MapsAppComponent.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useReducer, useState } from "react";
 import { MapPin, Minus, NavigationArrow, Plus } from "@phosphor-icons/react";
 import { WindowFrame } from "@/components/layout/WindowFrame";
 import { HelpDialog } from "@/components/dialogs/HelpDialog";
@@ -201,6 +201,87 @@ interface MapsSearchResult {
   place?: MapKitPlace;
 }
 
+interface MapsUiState {
+  searchQuery: string;
+  searchResults: MapsSearchResult[];
+  isSearching: boolean;
+  searchError: string | null;
+  selectedResultId: string | null;
+  isShowingResults: boolean;
+  isPlacesDrawerOpen: boolean;
+  showLoadingOverlay: boolean;
+}
+
+type MapsUiAction =
+  | { type: "setSearchQuery"; query: string }
+  | { type: "searchReset" }
+  | { type: "searchStart" }
+  | { type: "searchSuccess"; results: MapsSearchResult[] }
+  | { type: "searchError"; error: string }
+  | { type: "setSelectedResultId"; id: string | null }
+  | { type: "setShowingResults"; isShowingResults: boolean }
+  | { type: "setPlacesDrawerOpen"; isOpen: boolean }
+  | { type: "togglePlacesDrawer" }
+  | { type: "setShowLoadingOverlay"; show: boolean };
+
+const initialUiState: MapsUiState = {
+  searchQuery: "",
+  searchResults: [],
+  isSearching: false,
+  searchError: null,
+  selectedResultId: null,
+  isShowingResults: false,
+  isPlacesDrawerOpen: false,
+  showLoadingOverlay: false,
+};
+
+function mapsUiReducer(state: MapsUiState, action: MapsUiAction): MapsUiState {
+  switch (action.type) {
+    case "setSearchQuery":
+      return { ...state, searchQuery: action.query };
+    case "searchReset":
+      return {
+        ...state,
+        searchResults: [],
+        searchError: null,
+        isSearching: false,
+        isShowingResults: false,
+      };
+    case "searchStart":
+      return {
+        ...state,
+        isSearching: true,
+        searchError: null,
+        isShowingResults: true,
+      };
+    case "searchSuccess":
+      return {
+        ...state,
+        isSearching: false,
+        searchResults: action.results,
+      };
+    case "searchError":
+      return {
+        ...state,
+        isSearching: false,
+        searchResults: [],
+        searchError: action.error,
+      };
+    case "setSelectedResultId":
+      return { ...state, selectedResultId: action.id };
+    case "setShowingResults":
+      return { ...state, isShowingResults: action.isShowingResults };
+    case "setPlacesDrawerOpen":
+      return { ...state, isPlacesDrawerOpen: action.isOpen };
+    case "togglePlacesDrawer":
+      return { ...state, isPlacesDrawerOpen: !state.isPlacesDrawerOpen };
+    case "setShowLoadingOverlay":
+      return { ...state, showLoadingOverlay: action.show };
+    default:
+      return state;
+  }
+}
+
 // Coordinate-degree span used when focusing on a single place (search hit,
 // saved-place tap, persisted selection re-center). ~0.012° ≈ 1.3 km wide
 // at the equator — neighborhood / street level — which mirrors how the
@@ -321,13 +402,17 @@ export function MapsAppComponent({
   // when status flipped to "ready" mid-render.
   const [mapReadyTick, setMapReadyTick] = useState(0);
 
-  const [searchQuery, setSearchQuery] = useState("");
-  const [searchResults, setSearchResults] = useState<MapsSearchResult[]>([]);
-  const [isSearching, setIsSearching] = useState(false);
-  const [searchError, setSearchError] = useState<string | null>(null);
-  const [selectedResultId, setSelectedResultId] = useState<string | null>(null);
-  const [isShowingResults, setIsShowingResults] = useState(false);
-  const [isPlacesDrawerOpen, setIsPlacesDrawerOpen] = useState(false);
+  const [uiState, dispatchUi] = useReducer(mapsUiReducer, initialUiState);
+  const {
+    searchQuery,
+    searchResults,
+    isSearching,
+    searchError,
+    selectedResultId,
+    isShowingResults,
+    isPlacesDrawerOpen,
+    showLoadingOverlay,
+  } = uiState;
 
   // Persistent Home / Work / Favorites / Recents + currently-open place.
   const homePlace = useMapsStore((s) => s.home);
@@ -514,9 +599,7 @@ export function MapsAppComponent({
     (query: string) => {
       const trimmed = query.trim();
       if (!trimmed) {
-        setSearchResults([]);
-        setSearchError(null);
-        setIsShowingResults(false);
+        dispatchUi({ type: "searchReset" });
         return;
       }
       const mk = getMapKit();
@@ -570,9 +653,7 @@ export function MapsAppComponent({
         : undefined;
 
       const requestId = ++searchRequestIdRef.current;
-      setIsSearching(true);
-      setSearchError(null);
-      setIsShowingResults(true);
+      dispatchUi({ type: "searchStart" });
       track(MAPS_ANALYTICS.SEARCH, {
         appId: "maps",
         queryLength: trimmed.length,
@@ -586,13 +667,13 @@ export function MapsAppComponent({
           // meantime). MapKit doesn't expose a cancel API, so we discard.
           if (requestId !== searchRequestIdRef.current) return;
 
-          setIsSearching(false);
           if (err) {
-            setSearchResults([]);
-            setSearchError(
-              err.message ||
-                t("apps.maps.searchFailed", { defaultValue: "Search failed" })
-            );
+            dispatchUi({
+              type: "searchError",
+              error:
+                err.message ||
+                t("apps.maps.searchFailed", { defaultValue: "Search failed" }),
+            });
             track("maps:search_error", {
               appId: "maps",
               queryLength: trimmed.length,
@@ -618,7 +699,7 @@ export function MapsAppComponent({
               placeId: p.id,
               place: p,
             }));
-          setSearchResults(mapped);
+          dispatchUi({ type: "searchSuccess", results: mapped });
         },
         region
           ? regionPriorityValue
@@ -668,7 +749,7 @@ export function MapsAppComponent({
 
       const coord = new mk.Coordinate(place.latitude, place.longitude);
       if (!alreadySaved) {
-        setSelectedResultId(place.id);
+        dispatchUi({ type: "setSelectedResultId", id: place.id });
         const annotation = new mk.MarkerAnnotation(
           coord,
           withMapPlaceClustering(
@@ -686,7 +767,7 @@ export function MapsAppComponent({
         map.addAnnotation(annotation);
         annotationRef.current = annotation;
       } else {
-        setSelectedResultId(null);
+        dispatchUi({ type: "setSelectedResultId", id: null });
       }
 
       const span = new mk.CoordinateSpan(
@@ -701,7 +782,7 @@ export function MapsAppComponent({
 
   const handleSelectResult = useCallback(
     (result: MapsSearchResult) => {
-      setIsShowingResults(false);
+      dispatchUi({ type: "setShowingResults", isShowingResults: false });
       track(MAPS_ANALYTICS.PLACE_SELECT, {
         appId: "maps",
         source: "search",
@@ -760,7 +841,7 @@ export function MapsAppComponent({
           // ignore
         }
         annotationRef.current = null;
-        setSelectedResultId(null);
+        dispatchUi({ type: "setSelectedResultId", id: null });
       }
       // Highlight the matching saved annotation so it's obvious which
       // pin corresponds to the now-open place card. `selected = true`
@@ -815,7 +896,7 @@ export function MapsAppComponent({
       }
     }
     annotationRef.current = null;
-    setSelectedResultId(null);
+    dispatchUi({ type: "setSelectedResultId", id: null });
   }, []);
 
   const handleClosePlaceCard = useCallback(() => {
@@ -1034,7 +1115,7 @@ export function MapsAppComponent({
       // ignore
     }
     annotationRef.current = null;
-    setSelectedResultId(null);
+    dispatchUi({ type: "setSelectedResultId", id: null });
   }, [selectedResultId, isPlaceSaved]);
 
   // On first map ready, frame the viewport so the user immediately sees
@@ -1263,10 +1344,7 @@ export function MapsAppComponent({
     if (!trimmed) {
       // Bump request id so any in-flight callback is ignored once it returns.
       searchRequestIdRef.current += 1;
-      setSearchResults([]);
-      setSearchError(null);
-      setIsSearching(false);
-      setIsShowingResults(false);
+      dispatchUi({ type: "searchReset" });
       return;
     }
     if (status !== "ready") return;
@@ -1286,7 +1364,7 @@ export function MapsAppComponent({
         e.preventDefault();
         performSearch(searchQuery);
       } else if (e.key === "Escape") {
-        setIsShowingResults(false);
+        dispatchUi({ type: "setShowingResults", isShowingResults: false });
       }
     },
     [performSearch, searchQuery]
@@ -1311,14 +1389,13 @@ export function MapsAppComponent({
   // loading overlay until we've actually been loading for `LOADING_OVERLAY_DELAY_MS`.
   // Error and missing-token states still render immediately.
   const LOADING_OVERLAY_DELAY_MS = 600;
-  const [showLoadingOverlay, setShowLoadingOverlay] = useState(false);
   useEffect(() => {
     if (status !== "loading") {
-      setShowLoadingOverlay(false);
+      dispatchUi({ type: "setShowLoadingOverlay", show: false });
       return;
     }
     const id = window.setTimeout(() => {
-      setShowLoadingOverlay(true);
+      dispatchUi({ type: "setShowLoadingOverlay", show: true });
     }, LOADING_OVERLAY_DELAY_MS);
     return () => window.clearTimeout(id);
   }, [status]);
@@ -1356,7 +1433,9 @@ export function MapsAppComponent({
         drawer={
           <MapsPlacesDrawer
             isOpen={isPlacesDrawerOpen}
-            onClose={() => setIsPlacesDrawerOpen(false)}
+            onClose={() =>
+              dispatchUi({ type: "setPlacesDrawerOpen", isOpen: false })
+            }
             home={homePlace}
             work={workPlace}
             favorites={favoritePlaces}
@@ -1519,11 +1598,9 @@ export function MapsAppComponent({
               <SearchInput
                 value={searchQuery}
                 onChange={(value) => {
-                  setSearchQuery(value);
+                  dispatchUi({ type: "setSearchQuery", query: value });
                   if (!value) {
-                    setSearchResults([]);
-                    setSearchError(null);
-                    setIsShowingResults(false);
+                    dispatchUi({ type: "searchReset" });
                   }
                 }}
                 onKeyDown={handleSearchKeyDown}
@@ -1590,7 +1667,7 @@ export function MapsAppComponent({
                   type="button"
                   variant={isMacOSTheme ? "aqua" : "retro"}
                   size="sm"
-                  onClick={() => setIsPlacesDrawerOpen((v) => !v)}
+                  onClick={() => dispatchUi({ type: "togglePlacesDrawer" })}
                   aria-pressed={isPlacesDrawerOpen}
                   title={t("apps.maps.places.title", { defaultValue: "Places" })}
                   aria-label={t("apps.maps.places.title", {

--- a/src/apps/maps/hooks/useMapKit.ts
+++ b/src/apps/maps/hooks/useMapKit.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useReducer } from "react";
 
 /**
  * Apple MapKit JS lazy loader.
@@ -220,26 +220,48 @@ export interface UseMapKitResult {
 export function useMapKit(options: UseMapKitOptions = {}): UseMapKitResult {
   const { enabled = true, language } = options;
 
-  const [status, setStatus] = useState<MapKitStatus>(() =>
-    initialized ? "ready" : "idle"
-  );
-  const [error, setError] = useState<string | null>(null);
-  const [hasToken, setHasToken] = useState<boolean>(() =>
-    Boolean(cachedServerToken || getEnvFallbackToken())
-  );
+  type MapKitHookState = {
+    status: MapKitStatus;
+    error: string | null;
+    hasToken: boolean;
+  };
+  type MapKitHookAction =
+    | { type: "set"; payload: Partial<MapKitHookState> }
+    | { type: "readyInitialized" }
+    | { type: "missingToken" };
+  const initialState: MapKitHookState = {
+    status: initialized ? "ready" : "idle",
+    error: null,
+    hasToken: Boolean(cachedServerToken || getEnvFallbackToken()),
+  };
+  const reducer = (
+    state: MapKitHookState,
+    action: MapKitHookAction
+  ): MapKitHookState => {
+    switch (action.type) {
+      case "set":
+        return { ...state, ...action.payload };
+      case "readyInitialized":
+        return { ...state, status: "ready", hasToken: true, error: null };
+      case "missingToken":
+        return { ...state, status: "missing-token", hasToken: false, error: null };
+      default:
+        return state;
+    }
+  };
+  const [state, dispatch] = useReducer(reducer, initialState);
+  const { status, error, hasToken } = state;
 
   useEffect(() => {
     if (!enabled) return;
 
     if (initialized) {
-      setStatus("ready");
-      setHasToken(true);
+      dispatch({ type: "readyInitialized" });
       return;
     }
 
     let cancelled = false;
-    setStatus("loading");
-    setError(null);
+    dispatch({ type: "set", payload: { status: "loading", error: null } });
 
     (async () => {
       try {
@@ -247,28 +269,37 @@ export function useMapKit(options: UseMapKitOptions = {}): UseMapKitResult {
         // bothering to load the MapKit script when nothing is configured.
         await resolveToken();
         if (cancelled) return;
-        setHasToken(true);
+        dispatch({ type: "set", payload: { hasToken: true } });
 
         await loadScript();
         if (cancelled) return;
 
         try {
           initMapKitWithCallback(language);
-          setStatus("ready");
+          dispatch({ type: "set", payload: { status: "ready", error: null } });
         } catch (err) {
-          setError(err instanceof Error ? err.message : String(err));
-          setStatus("error");
+          dispatch({
+            type: "set",
+            payload: {
+              error: err instanceof Error ? err.message : String(err),
+              status: "error",
+            },
+          });
         }
       } catch (err) {
         if (cancelled) return;
         const fallback = getEnvFallbackToken();
         if (!fallback) {
-          setHasToken(false);
-          setStatus("missing-token");
+          dispatch({ type: "missingToken" });
           return;
         }
-        setError(err instanceof Error ? err.message : String(err));
-        setStatus("error");
+        dispatch({
+          type: "set",
+          payload: {
+            error: err instanceof Error ? err.message : String(err),
+            status: "error",
+          },
+        });
       }
     })();
 

--- a/src/apps/stickies/components/StickyNote.tsx
+++ b/src/apps/stickies/components/StickyNote.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState, useCallback, useEffect } from "react";
+import { useRef, useReducer, useCallback, useEffect } from "react";
 import { motion } from "framer-motion";
 import { StickyNote as StickyNoteType, StickyColor } from "@/stores/useStickiesStore";
 import { cn } from "@/lib/utils";
@@ -73,11 +73,44 @@ export function StickyNote({
   
   const noteRef = useRef<HTMLDivElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
-  const [isDragging, setIsDragging] = useState(false);
-  const [isResizing, setIsResizing] = useState(false);
-  const [dragOffset, setDragOffset] = useState({ x: 0, y: 0 });
-  const [draftPosition, setDraftPosition] = useState(note.position);
-  const [draftSize, setDraftSize] = useState(note.size);
+  interface StickyNoteUiState {
+    isDragging: boolean;
+    isResizing: boolean;
+    dragOffset: { x: number; y: number };
+    draftPosition: StickyNoteType["position"];
+    draftSize: StickyNoteType["size"];
+  }
+
+  const initialState: StickyNoteUiState = {
+    isDragging: false,
+    isResizing: false,
+    dragOffset: { x: 0, y: 0 },
+    draftPosition: note.position,
+    draftSize: note.size,
+  };
+
+  type StickyNoteUiAction = { type: "patch"; payload: Partial<StickyNoteUiState> };
+
+  const reducer = (
+    state: StickyNoteUiState,
+    action: StickyNoteUiAction
+  ): StickyNoteUiState => {
+    switch (action.type) {
+      case "patch":
+        return { ...state, ...action.payload };
+      default:
+        return state;
+    }
+  };
+
+  const [state, dispatch] = useReducer(reducer, initialState);
+  const { isDragging, isResizing, dragOffset, draftPosition, draftSize } = state;
+  const setDraftPosition = useCallback((value: StickyNoteType["position"]) => {
+    dispatch({ type: "patch", payload: { draftPosition: value } });
+  }, []);
+  const setDraftSize = useCallback((value: StickyNoteType["size"]) => {
+    dispatch({ type: "patch", payload: { draftSize: value } });
+  }, []);
   const draftPositionRef = useRef(note.position);
   const draftSizeRef = useRef(note.size);
 
@@ -93,14 +126,14 @@ export function StickyNote({
 
   useEffect(() => {
     if (!isDragging) {
-      setDraftPosition(note.position);
+      dispatch({ type: "patch", payload: { draftPosition: note.position } });
       draftPositionRef.current = note.position;
     }
   }, [note.position, isDragging]);
 
   useEffect(() => {
     if (!isResizing) {
-      setDraftSize(note.size);
+      dispatch({ type: "patch", payload: { draftSize: note.size } });
       draftSizeRef.current = note.size;
     }
   }, [note.size, isResizing]);
@@ -112,10 +145,15 @@ export function StickyNote({
       if ((e.target as HTMLElement).closest("button")) return;
       e.preventDefault();
       onSelect();
-      setIsDragging(true);
-      setDragOffset({
-        x: e.clientX - draftPositionRef.current.x,
-        y: e.clientY - draftPositionRef.current.y,
+      dispatch({
+        type: "patch",
+        payload: {
+          isDragging: true,
+          dragOffset: {
+            x: e.clientX - draftPositionRef.current.x,
+            y: e.clientY - draftPositionRef.current.y,
+          },
+        },
       });
     },
     [onSelect]
@@ -130,10 +168,15 @@ export function StickyNote({
       e.preventDefault();
       onSelect();
       const touch = e.touches[0];
-      setIsDragging(true);
-      setDragOffset({
-        x: touch.clientX - draftPositionRef.current.x,
-        y: touch.clientY - draftPositionRef.current.y,
+      dispatch({
+        type: "patch",
+        payload: {
+          isDragging: true,
+          dragOffset: {
+            x: touch.clientX - draftPositionRef.current.x,
+            y: touch.clientY - draftPositionRef.current.y,
+          },
+        },
       });
     },
     [onSelect]
@@ -145,7 +188,7 @@ export function StickyNote({
       e.preventDefault();
       e.stopPropagation();
       onSelect();
-      setIsResizing(true);
+      dispatch({ type: "patch", payload: { isResizing: true } });
     },
     [onSelect]
   );
@@ -157,7 +200,7 @@ export function StickyNote({
       e.preventDefault();
       e.stopPropagation();
       onSelect();
-      setIsResizing(true);
+      dispatch({ type: "patch", payload: { isResizing: true } });
     },
     [onSelect]
   );
@@ -230,8 +273,13 @@ export function StickyNote({
         }
       }
 
-      setIsDragging(false);
-      setIsResizing(false);
+      dispatch({
+        type: "patch",
+        payload: {
+          isDragging: false,
+          isResizing: false,
+        },
+      });
 
       if (Object.keys(updates).length > 0) {
         onUpdate(updates);

--- a/src/apps/synth/hooks/useSynthLogic.ts
+++ b/src/apps/synth/hooks/useSynthLogic.ts
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect, useCallback } from "react";
+import { useState, useRef, useEffect, useCallback, useReducer } from "react";
 import type { PointerEvent as ReactPointerEvent } from "react";
 import * as Tone from "tone";
 import {
@@ -71,14 +71,82 @@ export const useSynthLogic = ({
   const handleKeyDownRef = useRef<(e: KeyboardEvent) => void>(() => {});
   const handleKeyUpRef = useRef<(e: KeyboardEvent) => void>(() => {});
 
-  // UI state
-  const [isHelpOpen, setIsHelpOpen] = useState(false);
-  const [isAboutOpen, setIsAboutOpen] = useState(false);
-  const [isPresetDialogOpen, setIsPresetDialogOpen] = useState(false);
-  const [isSavingNewPreset, setIsSavingNewPreset] = useState(true);
-  const [presetName, setPresetName] = useState("");
-  const [statusMessage, setStatusMessage] = useState("");
-  const [isControlsVisible, setIsControlsVisible] = useState(false);
+  interface SynthUiState {
+    isHelpOpen: boolean;
+    isAboutOpen: boolean;
+    isPresetDialogOpen: boolean;
+    isSavingNewPreset: boolean;
+    presetName: string;
+    statusMessage: string;
+    isControlsVisible: boolean;
+    visibleKeyCount: number;
+  }
+
+  const initialState: SynthUiState = {
+    isHelpOpen: false,
+    isAboutOpen: false,
+    isPresetDialogOpen: false,
+    isSavingNewPreset: true,
+    presetName: "",
+    statusMessage: "",
+    isControlsVisible: false,
+    visibleKeyCount: 8,
+  };
+
+  type SynthUiAction = { type: "patch"; payload: Partial<SynthUiState> };
+
+  const reducer = (state: SynthUiState, action: SynthUiAction): SynthUiState => {
+    switch (action.type) {
+      case "patch":
+        return { ...state, ...action.payload };
+      default:
+        return state;
+    }
+  };
+
+  const [uiState, dispatchUi] = useReducer(reducer, initialState);
+  const {
+    isHelpOpen,
+    isAboutOpen,
+    isPresetDialogOpen,
+    isSavingNewPreset,
+    presetName,
+    statusMessage,
+    isControlsVisible,
+    visibleKeyCount,
+  } = uiState;
+  const setIsHelpOpen = useCallback((value: boolean) => {
+    dispatchUi({ type: "patch", payload: { isHelpOpen: value } });
+  }, []);
+  const setIsAboutOpen = useCallback((value: boolean) => {
+    dispatchUi({ type: "patch", payload: { isAboutOpen: value } });
+  }, []);
+  const setIsPresetDialogOpen = useCallback((value: boolean) => {
+    dispatchUi({ type: "patch", payload: { isPresetDialogOpen: value } });
+  }, []);
+  const setPresetName = useCallback((value: string) => {
+    dispatchUi({ type: "patch", payload: { presetName: value } });
+  }, []);
+  const setStatusMessage = useCallback((value: string) => {
+    dispatchUi({ type: "patch", payload: { statusMessage: value } });
+  }, []);
+  const setIsControlsVisible = useCallback(
+    (value: boolean | ((prev: boolean) => boolean)) => {
+      dispatchUi({
+        type: "patch",
+        payload: {
+          isControlsVisible:
+            typeof value === "function"
+              ? value(uiState.isControlsVisible)
+              : value,
+        },
+      });
+    },
+    [uiState.isControlsVisible]
+  );
+  const setVisibleKeyCount = useCallback((value: number) => {
+    dispatchUi({ type: "patch", payload: { visibleKeyCount: value } });
+  }, []);
 
   // Use labelType and preset state from persisted store
   const {
@@ -175,9 +243,6 @@ export const useSynthLogic = ({
     null,
     "F#5",
   ];
-
-  // State for responsive keyboard
-  const [visibleKeyCount, setVisibleKeyCount] = useState(8);
 
   // Reference to the app container
   const appContainerRef = useRef<HTMLDivElement>(null);
@@ -693,9 +758,14 @@ export const useSynthLogic = ({
 
   // Preset handlers
   const addPreset = () => {
-    setIsSavingNewPreset(true);
-    setPresetName("");
-    setIsPresetDialogOpen(true);
+    dispatchUi({
+      type: "patch",
+      payload: {
+        isSavingNewPreset: true,
+        presetName: "",
+        isPresetDialogOpen: true,
+      },
+    });
     play();
   };
 

--- a/src/apps/terminal/components/TypewriterText.tsx
+++ b/src/apps/terminal/components/TypewriterText.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from "react";
+import { useReducer, useEffect, useRef } from "react";
 import { motion } from "framer-motion";
 import { parseSimpleMarkdown } from "./parseSimpleMarkdown";
 
@@ -9,26 +9,55 @@ interface TypewriterTextProps {
   renderMarkdown?: boolean;
 }
 
+interface TypewriterState {
+  displayedText: string;
+  isComplete: boolean;
+}
+
+const initialState: TypewriterState = {
+  displayedText: "",
+  isComplete: false,
+};
+
+type TypewriterAction =
+  | { type: "reset" }
+  | { type: "completeImmediately"; text: string }
+  | { type: "appendChunk"; chunk: string }
+  | { type: "complete" };
+
+function reducer(state: TypewriterState, action: TypewriterAction): TypewriterState {
+  switch (action.type) {
+    case "reset":
+      return initialState;
+    case "completeImmediately":
+      return { displayedText: action.text, isComplete: true };
+    case "appendChunk":
+      return { ...state, displayedText: state.displayedText + action.chunk };
+    case "complete":
+      return { ...state, isComplete: true };
+    default:
+      return state;
+  }
+}
+
 export function TypewriterText({
   text,
   className,
   speed = 15,
   renderMarkdown = false,
 }: TypewriterTextProps) {
-  const [displayedText, setDisplayedText] = useState("");
-  const [isComplete, setIsComplete] = useState(false);
+  const [state, dispatch] = useReducer(reducer, initialState);
+  const { displayedText, isComplete } = state;
   const textRef = useRef(text);
 
   useEffect(() => {
     // Reset when text changes
-    setDisplayedText("");
-    setIsComplete(false);
+    dispatch({ type: "reset" });
     textRef.current = text;
 
     // Skip animation for long text (performance)
     if (text.length > 200) {
-      setDisplayedText(text);
-      setIsComplete(true);
+      dispatch({ type: "completeImmediately", text });
       return;
     }
 
@@ -52,7 +81,7 @@ export function TypewriterText({
     const typeNextChunk = () => {
       if (currentIndex < chunks.length) {
         const chunk = chunks[currentIndex];
-        setDisplayedText((prev) => prev + chunk);
+        dispatch({ type: "appendChunk", chunk });
         currentIndex++;
 
         // Pause longer after punctuation for natural rhythm
@@ -61,7 +90,7 @@ export function TypewriterText({
 
         timeoutId = setTimeout(typeNextChunk, delay);
       } else {
-        setIsComplete(true);
+        dispatch({ type: "complete" });
       }
     };
 

--- a/src/apps/tv/components/CreateChannelDialog.tsx
+++ b/src/apps/tv/components/CreateChannelDialog.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useReducer, useRef } from "react";
 import {
   Dialog,
   DialogContent,
@@ -26,6 +26,41 @@ interface CreateChannelDialogProps {
 
 type DialogStage = "idle" | "loading" | "error";
 
+interface CreateChannelDialogState {
+  description: string;
+  stage: DialogStage;
+  error: string | null;
+  statusText: string;
+}
+
+const initialState: CreateChannelDialogState = {
+  description: "",
+  stage: "idle",
+  error: null,
+  statusText: "",
+};
+
+type CreateChannelDialogAction =
+  | { type: "patch"; payload: Partial<CreateChannelDialogState> }
+  | { type: "resetForOpen"; initialDescription: string };
+
+function reducer(
+  state: CreateChannelDialogState,
+  action: CreateChannelDialogAction
+): CreateChannelDialogState {
+  switch (action.type) {
+    case "patch":
+      return { ...state, ...action.payload };
+    case "resetForOpen":
+      return {
+        ...initialState,
+        description: action.initialDescription,
+      };
+    default:
+      return state;
+  }
+}
+
 const SUGGESTIONS = [
   "Skateboarding tricks and parks",
   "80s synthwave music",
@@ -49,10 +84,11 @@ export function CreateChannelDialog({
 
   const { create } = useCreateTvChannel();
 
-  const [description, setDescription] = useState(initialDescription);
-  const [stage, setStage] = useState<DialogStage>("idle");
-  const [error, setError] = useState<string | null>(null);
-  const [statusText, setStatusText] = useState<string>("");
+  const [state, dispatch] = useReducer(reducer, {
+    ...initialState,
+    description: initialDescription,
+  });
+  const { description, stage, error, statusText } = state;
 
   // Cycle status messages so the loading state feels alive during the
   // ~5-15s round-trip (AI plan + 2-4 YouTube searches).
@@ -71,10 +107,10 @@ export function CreateChannelDialog({
       t("apps.tv.create.statusTuning"),
     ];
     let i = 0;
-    setStatusText(messages[0]);
+    dispatch({ type: "patch", payload: { statusText: messages[0] } });
     statusIntervalRef.current = setInterval(() => {
       i = (i + 1) % messages.length;
-      setStatusText(messages[i]);
+      dispatch({ type: "patch", payload: { statusText: messages[i] } });
     }, 1800);
     return () => {
       if (statusIntervalRef.current) {
@@ -86,29 +122,30 @@ export function CreateChannelDialog({
 
   useEffect(() => {
     if (isOpen) {
-      setError(null);
-      setStage("idle");
-      setDescription(initialDescription);
+      dispatch({ type: "resetForOpen", initialDescription });
     }
   }, [isOpen, initialDescription]);
 
   const isLoading = stage === "loading";
 
   const handleSubmit = async () => {
-    setError(null);
-    setStage("loading");
+    dispatch({ type: "patch", payload: { error: null, stage: "loading" } });
 
     try {
       const { channel } = await create(description);
-      setDescription("");
+      dispatch({ type: "patch", payload: { description: "" } });
       onOpenChange(false);
       onChannelCreated?.(channel.id);
     } catch (err) {
       console.error("Create channel failed:", err);
-      setError(
-        err instanceof Error ? err.message : t("apps.tv.create.errorGeneric")
-      );
-      setStage("error");
+      dispatch({
+        type: "patch",
+        payload: {
+          error:
+            err instanceof Error ? err.message : t("apps.tv.create.errorGeneric"),
+          stage: "error",
+        },
+      });
     }
   };
 
@@ -128,7 +165,9 @@ export function CreateChannelDialog({
       <Input
         autoFocus
         value={description}
-        onChange={(e) => setDescription(e.target.value)}
+        onChange={(e) =>
+          dispatch({ type: "patch", payload: { description: e.target.value } })
+        }
         onKeyDown={(e) => {
           e.stopPropagation();
           if (e.key === "Enter" && !isLoading) handleSubmit();
@@ -145,7 +184,9 @@ export function CreateChannelDialog({
             key={s}
             type="button"
             disabled={isLoading}
-            onClick={() => setDescription(s)}
+            onClick={() =>
+              dispatch({ type: "patch", payload: { description: s } })
+            }
             className={cn(
               "px-2 py-0.5 rounded-full border text-gray-700",
               "border-gray-300 hover:bg-gray-100 disabled:opacity-50"

--- a/src/apps/tv/components/TvAppComponent.tsx
+++ b/src/apps/tv/components/TvAppComponent.tsx
@@ -3,6 +3,7 @@ import {
   useCallback,
   useEffect,
   useMemo,
+  useReducer,
   useRef,
   useState,
   type RefObject,
@@ -450,25 +451,170 @@ export function TvAppComponent({
   // early `return null` for a closed window happens AFTER the local hooks
   // below — moving the return above them violates the Rules of Hooks and
   // crashes on close (mismatched hook count between renders).
-  const [lcdSlot, setLcdSlot] = useState<"now" | "next">("now");
-  const [scheduleAnimDirection, setScheduleAnimDirection] = useState<
-    "next" | "prev"
-  >("next");
-  const [isCreateChannelOpen, setIsCreateChannelOpen] = useState(false);
-  const [pendingDeleteId, setPendingDeleteId] = useState<string | null>(null);
-  const [isResetConfirmOpen, setIsResetConfirmOpen] = useState(false);
+  const isMobileSafariDevice = useRef(isMobileSafari()).current;
+
+  interface TvLocalState {
+    lcdSlot: "now" | "next";
+    scheduleAnimDirection: "next" | "prev";
+    isCreateChannelOpen: boolean;
+    pendingDeleteId: string | null;
+    isResetConfirmOpen: boolean;
+    isDrawerOpen: boolean;
+    isYoutubePasteLoading: boolean;
+    powerOnKey: number;
+    channelSwitchKey: number;
+    poweringOff: boolean;
+    isBuffering: boolean;
+    screenOff: boolean;
+    isTransitioningCc: boolean;
+  }
+
+  const initialState: TvLocalState = {
+    lcdSlot: "now",
+    scheduleAnimDirection: "next",
+    isCreateChannelOpen: false,
+    pendingDeleteId: null,
+    isResetConfirmOpen: false,
+    isDrawerOpen: false,
+    isYoutubePasteLoading: false,
+    powerOnKey: 0,
+    channelSwitchKey: 0,
+    poweringOff: false,
+    isBuffering: false,
+    screenOff: isMobileSafariDevice,
+    isTransitioningCc: false,
+  };
+
+  type TvLocalAction =
+    | { type: "patch"; payload: Partial<TvLocalState> }
+    | {
+        type: "setField";
+        key: keyof TvLocalState;
+        value:
+          | TvLocalState[keyof TvLocalState]
+          | ((prev: TvLocalState[keyof TvLocalState]) => TvLocalState[keyof TvLocalState]);
+      }
+    | { type: "toggleLcdSlotWithDirection" };
+
+  const reducer = (state: TvLocalState, action: TvLocalAction): TvLocalState => {
+    switch (action.type) {
+      case "patch":
+        return { ...state, ...action.payload };
+      case "setField": {
+        const currentValue = state[action.key];
+        const nextValue =
+          typeof action.value === "function"
+            ? (
+                action.value as (
+                  prev: TvLocalState[keyof TvLocalState]
+                ) => TvLocalState[keyof TvLocalState]
+              )(currentValue)
+            : action.value;
+        return { ...state, [action.key]: nextValue } as TvLocalState;
+      }
+      case "toggleLcdSlotWithDirection": {
+        const nextSlot = state.lcdSlot === "now" ? "next" : "now";
+        return {
+          ...state,
+          lcdSlot: nextSlot,
+          scheduleAnimDirection: nextSlot === "next" ? "next" : "prev",
+        };
+      }
+      default:
+        return state;
+    }
+  };
+
+  const [localState, dispatchLocal] = useReducer(reducer, initialState);
+  const {
+    lcdSlot,
+    scheduleAnimDirection,
+    isCreateChannelOpen,
+    pendingDeleteId,
+    isResetConfirmOpen,
+    isDrawerOpen,
+    isYoutubePasteLoading,
+    powerOnKey,
+    channelSwitchKey,
+    poweringOff,
+    isBuffering,
+    screenOff,
+    isTransitioningCc,
+  } = localState;
+  const setField = useCallback(
+    <K extends keyof TvLocalState>(
+      key: K,
+      value: TvLocalState[K] | ((prev: TvLocalState[K]) => TvLocalState[K])
+    ) => {
+      dispatchLocal({
+        type: "setField",
+        key,
+        value: value as TvLocalState[keyof TvLocalState],
+      });
+    },
+    []
+  );
+  const setLcdSlot = useCallback(
+    (
+      value:
+        | TvLocalState["lcdSlot"]
+        | ((prev: TvLocalState["lcdSlot"]) => TvLocalState["lcdSlot"])
+    ) => setField("lcdSlot", value),
+    [setField]
+  );
+  const setIsCreateChannelOpen = useCallback(
+    (value: boolean) => setField("isCreateChannelOpen", value),
+    [setField]
+  );
+  const setPendingDeleteId = useCallback(
+    (value: string | null) => setField("pendingDeleteId", value),
+    [setField]
+  );
+  const setIsResetConfirmOpen = useCallback(
+    (value: boolean) => setField("isResetConfirmOpen", value),
+    [setField]
+  );
+  const setIsDrawerOpen = useCallback(
+    (value: boolean | ((prev: boolean) => boolean)) => setField("isDrawerOpen", value),
+    [setField]
+  );
+  const setIsYoutubePasteLoading = useCallback(
+    (value: boolean) => setField("isYoutubePasteLoading", value),
+    [setField]
+  );
+  const setPowerOnKey = useCallback(
+    (value: number | ((prev: number) => number)) => setField("powerOnKey", value),
+    [setField]
+  );
+  const setChannelSwitchKey = useCallback(
+    (value: number | ((prev: number) => number)) =>
+      setField("channelSwitchKey", value),
+    [setField]
+  );
+  const setPoweringOff = useCallback(
+    (value: boolean) => setField("poweringOff", value),
+    [setField]
+  );
+  const setIsBuffering = useCallback(
+    (value: boolean) => setField("isBuffering", value),
+    [setField]
+  );
+  const setScreenOff = useCallback(
+    (value: boolean) => setField("screenOff", value),
+    [setField]
+  );
+  const setIsTransitioningCc = useCallback(
+    (value: boolean) => setField("isTransitioningCc", value),
+    [setField]
+  );
+
   // Classic-Mac-OS-X-style drawer that lists every video on the
   // current channel. Closed by default so the picture-and-LCD layout
   // stays the focal point on first open.
-  const [isDrawerOpen, setIsDrawerOpen] = useState(false);
-  const [isYoutubePasteLoading, setIsYoutubePasteLoading] = useState(false);
 
   // CRT shader effect triggers. Bumping these counters re-keys the
   // animations inside TvCrtEffects so a new burst plays on every event.
-  const [powerOnKey, setPowerOnKey] = useState(0);
-  const [channelSwitchKey, setChannelSwitchKey] = useState(0);
-  const [poweringOff, setPoweringOff] = useState(false);
-  const [isBuffering, setIsBuffering] = useState(false);
+  
   // While true, the picture is squeezed away and a black "screen-off"
   // overlay holds until the user un-pauses. Driven by isPlaying
   // transitions below.
@@ -477,8 +623,6 @@ export function TvAppComponent({
   // their hooks). The user wakes it up by tapping play, which flips
   // `isPlaying` true and routes through the existing
   // `screenOff && isPlaying` resume path below.
-  const isMobileSafariDevice = useRef(isMobileSafari()).current;
-  const [screenOff, setScreenOff] = useState(isMobileSafariDevice);
 
   // Procedural CRT sound effects synced to the shader animations above.
   const {
@@ -814,7 +958,6 @@ export function TvAppComponent({
   // burst before the new video's lyrics load. Cleared after a short
   // timeout that's a touch longer than the channel-switch animation
   // so the overlay doesn't pop back in mid-burst.
-  const [isTransitioningCc, setIsTransitioningCc] = useState(false);
   const ccTransitionMountedRef = useRef(false);
   useEffect(() => {
     if (!ccTransitionMountedRef.current) {
@@ -951,11 +1094,7 @@ export function TvAppComponent({
   useEffect(() => {
     if (!isPlaying || !scheduleNextTitle) return;
     const id = window.setInterval(() => {
-      setLcdSlot((s) => {
-        const next = s === "now" ? "next" : "now";
-        setScheduleAnimDirection(next === "next" ? "next" : "prev");
-        return next;
-      });
+      dispatchLocal({ type: "toggleLcdSlotWithDirection" });
     }, 4500);
     return () => window.clearInterval(id);
   }, [isPlaying, scheduleNextTitle]);

--- a/src/apps/videos/hooks/useVideosLogic.ts
+++ b/src/apps/videos/hooks/useVideosLogic.ts
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useEffect, useCallback } from "react";
+import React, { useReducer, useRef, useEffect, useCallback } from "react";
 import ReactPlayer from "react-player";
 import { toast } from "sonner";
 import { useTranslation } from "react-i18next";
@@ -108,26 +108,131 @@ export function useVideosLogic({
   );
 
   // Component state
-  const [animationDirection, setAnimationDirection] = useState<"next" | "prev">(
-    "next"
-  );
-  const [originalOrder, setOriginalOrder] = useState<Video[]>(videos);
-  const [urlInput, setUrlInput] = useState("");
-  const [isAddDialogOpen, setIsAddDialogOpen] = useState(false);
-  const [isHelpDialogOpen, setIsHelpDialogOpen] = useState(false);
-  const [isAboutDialogOpen, setIsAboutDialogOpen] = useState(false);
-  const [isConfirmClearOpen, setIsConfirmClearOpen] = useState(false);
-  const [isConfirmResetOpen, setIsConfirmResetOpen] = useState(false);
-  const [isAddingVideo, setIsAddingVideo] = useState(false);
-  const [isFullScreen, setIsFullScreen] = useState(false);
-  const [elapsedTime, setElapsedTime] = useState(0);
-  const [statusMessage, setStatusMessage] = useState<string | null>(null);
-  const [isShareDialogOpen, setIsShareDialogOpen] = useState(false);
-  const [duration, setDuration] = useState(0);
-  const [playedSeconds, setPlayedSeconds] = useState(0);
-  const [isVideoHovered, setIsVideoHovered] = useState(false);
-  const [isDraggingSeek, setIsDraggingSeek] = useState(false);
-  const [dragSeekTime, setDragSeekTime] = useState(0);
+  interface VideosUiState {
+    animationDirection: "next" | "prev";
+    originalOrder: Video[];
+    urlInput: string;
+    isAddDialogOpen: boolean;
+    isHelpDialogOpen: boolean;
+    isAboutDialogOpen: boolean;
+    isConfirmClearOpen: boolean;
+    isConfirmResetOpen: boolean;
+    isAddingVideo: boolean;
+    isFullScreen: boolean;
+    elapsedTime: number;
+    statusMessage: string | null;
+    isShareDialogOpen: boolean;
+    duration: number;
+    playedSeconds: number;
+    isVideoHovered: boolean;
+    isDraggingSeek: boolean;
+    dragSeekTime: number;
+  }
+
+  const initialState: VideosUiState = {
+    animationDirection: "next",
+    originalOrder: videos,
+    urlInput: "",
+    isAddDialogOpen: false,
+    isHelpDialogOpen: false,
+    isAboutDialogOpen: false,
+    isConfirmClearOpen: false,
+    isConfirmResetOpen: false,
+    isAddingVideo: false,
+    isFullScreen: false,
+    elapsedTime: 0,
+    statusMessage: null,
+    isShareDialogOpen: false,
+    duration: 0,
+    playedSeconds: 0,
+    isVideoHovered: false,
+    isDraggingSeek: false,
+    dragSeekTime: 0,
+  };
+
+  type VideosUiAction = { type: "patch"; payload: Partial<VideosUiState> };
+
+  const reducer = (state: VideosUiState, action: VideosUiAction): VideosUiState => {
+    switch (action.type) {
+      case "patch":
+        return { ...state, ...action.payload };
+      default:
+        return state;
+    }
+  };
+
+  const [uiState, dispatchUi] = useReducer(reducer, initialState);
+  const {
+    animationDirection,
+    originalOrder,
+    urlInput,
+    isAddDialogOpen,
+    isHelpDialogOpen,
+    isAboutDialogOpen,
+    isConfirmClearOpen,
+    isConfirmResetOpen,
+    isAddingVideo,
+    isFullScreen,
+    elapsedTime,
+    statusMessage,
+    isShareDialogOpen,
+    duration,
+    playedSeconds,
+    isVideoHovered,
+    isDraggingSeek,
+    dragSeekTime,
+  } = uiState;
+  const setAnimationDirection = useCallback((value: "next" | "prev") => {
+    dispatchUi({ type: "patch", payload: { animationDirection: value } });
+  }, []);
+  const setOriginalOrder = useCallback((value: Video[]) => {
+    dispatchUi({ type: "patch", payload: { originalOrder: value } });
+  }, []);
+  const setUrlInput = useCallback((value: string) => {
+    dispatchUi({ type: "patch", payload: { urlInput: value } });
+  }, []);
+  const setIsAddDialogOpen = useCallback((value: boolean) => {
+    dispatchUi({ type: "patch", payload: { isAddDialogOpen: value } });
+  }, []);
+  const setIsHelpDialogOpen = useCallback((value: boolean) => {
+    dispatchUi({ type: "patch", payload: { isHelpDialogOpen: value } });
+  }, []);
+  const setIsAboutDialogOpen = useCallback((value: boolean) => {
+    dispatchUi({ type: "patch", payload: { isAboutDialogOpen: value } });
+  }, []);
+  const setIsConfirmClearOpen = useCallback((value: boolean) => {
+    dispatchUi({ type: "patch", payload: { isConfirmClearOpen: value } });
+  }, []);
+  const setIsConfirmResetOpen = useCallback((value: boolean) => {
+    dispatchUi({ type: "patch", payload: { isConfirmResetOpen: value } });
+  }, []);
+  const setIsAddingVideo = useCallback((value: boolean) => {
+    dispatchUi({ type: "patch", payload: { isAddingVideo: value } });
+  }, []);
+  const setIsFullScreen = useCallback((value: boolean) => {
+    dispatchUi({ type: "patch", payload: { isFullScreen: value } });
+  }, []);
+  const setElapsedTime = useCallback((value: number) => {
+    dispatchUi({ type: "patch", payload: { elapsedTime: value } });
+  }, []);
+  const setStatusMessage = useCallback((value: string | null) => {
+    dispatchUi({ type: "patch", payload: { statusMessage: value } });
+  }, []);
+  const setIsShareDialogOpen = useCallback((value: boolean) => {
+    dispatchUi({ type: "patch", payload: { isShareDialogOpen: value } });
+  }, []);
+  const setDuration = useCallback((value: number) => {
+    dispatchUi({ type: "patch", payload: { duration: value } });
+  }, []);
+  const setIsVideoHovered = useCallback((value: boolean) => {
+    dispatchUi({ type: "patch", payload: { isVideoHovered: value } });
+  }, []);
+  const setIsDraggingSeek = useCallback((value: boolean) => {
+    dispatchUi({ type: "patch", payload: { isDraggingSeek: value } });
+  }, []);
+  const setDragSeekTime = useCallback((value: number) => {
+    dispatchUi({ type: "patch", payload: { dragSeekTime: value } });
+  }, []);
 
   // Refs
   const playerRef = useRef<ReactPlayer | null>(null);
@@ -253,8 +358,13 @@ export function useVideosLogic({
           safeSetCurrentVideoId(existing.id);
           setIsPlaying(true);
           showStatus(t("apps.videos.status.videoAdded"));
-          setUrlInput("");
-          setIsAddDialogOpen(false);
+          dispatchUi({
+            type: "patch",
+            payload: {
+              urlInput: "",
+              isAddDialogOpen: false,
+            },
+          });
           return;
         }
 
@@ -353,8 +463,13 @@ export function useVideosLogic({
 
         showStatus(t("apps.videos.status.videoAdded"));
 
-        setUrlInput("");
-        setIsAddDialogOpen(false);
+        dispatchUi({
+          type: "patch",
+          payload: {
+            urlInput: "",
+            isAddDialogOpen: false,
+          },
+        });
       } catch (error) {
         console.error("Failed to add video:", error);
         showStatus(
@@ -556,8 +671,13 @@ export function useVideosLogic({
   }, [loopCurrent, setIsPlaying, nextVideo]);
 
   const handleProgress = useCallback((state: { playedSeconds: number }) => {
-    setPlayedSeconds(state.playedSeconds);
-    setElapsedTime(Math.floor(state.playedSeconds));
+    dispatchUi({
+      type: "patch",
+      payload: {
+        playedSeconds: state.playedSeconds,
+        elapsedTime: Math.floor(state.playedSeconds),
+      },
+    });
   }, []);
 
   const handleDuration = useCallback((duration: number) => {

--- a/src/components/dialogs/BootScreen.tsx
+++ b/src/components/dialogs/BootScreen.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useReducer } from "react";
 import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
 import * as DialogPrimitive from "@radix-ui/react-dialog";
 import { VisuallyHidden } from "@radix-ui/react-visually-hidden";
@@ -22,7 +22,27 @@ export function BootScreen({
   debugMode = false,
 }: BootScreenProps) {
   const { play } = useSound(Sounds.BOOT, 0.5);
-  const [progress, setProgress] = useState(0);
+  type BootState = { progress: number };
+  type BootAction =
+    | { type: "reset" }
+    | { type: "setProgress"; value: number }
+    | { type: "increment"; amount: number };
+  const initialState: BootState = { progress: 0 };
+  const reducer = (state: BootState, action: BootAction): BootState => {
+    switch (action.type) {
+      case "reset":
+        return initialState;
+      case "setProgress":
+        return { progress: Math.max(0, Math.min(100, action.value)) };
+      case "increment":
+        return {
+          progress: Math.min(100, state.progress + action.amount),
+        };
+      default:
+        return state;
+    }
+  };
+  const [{ progress }, dispatch] = useReducer(reducer, initialState);
   const { t } = useTranslation();
   const {
     currentTheme,
@@ -53,17 +73,14 @@ export function BootScreen({
 
       // Simulate boot progress
       interval = window.setInterval(() => {
-        setProgress((prev) => {
-          const newProgress = prev + Math.random() * 10;
-          return newProgress >= 100 ? 100 : newProgress;
-        });
+        dispatch({ type: "increment", amount: Math.random() * 10 });
       }, 100);
 
       // Close after boot completes (2 seconds) - skip in debug mode
       if (!debugMode) {
         timer = window.setTimeout(() => {
           window.clearInterval(interval);
-          setProgress(100);
+          dispatch({ type: "setProgress", value: 100 });
 
           // Wait a moment at 100% before completing
           const completeTimer = window.setTimeout(() => {
@@ -75,7 +92,7 @@ export function BootScreen({
         }, 2000);
       }
     } else {
-      setProgress(0);
+      dispatch({ type: "reset" });
     }
 
     return () => {

--- a/src/components/dialogs/ChangePasswordDialog.tsx
+++ b/src/components/dialogs/ChangePasswordDialog.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useReducer } from "react";
 import {
   Dialog,
   DialogContent,
@@ -61,17 +61,51 @@ export function ChangePasswordDialog({
     isMacOSTheme: isMacTheme,
   } = useThemeFlags();
 
-  const [currentPassword, setCurrentPassword] = useState("");
-  const [newPassword, setNewPassword] = useState("");
-  const [confirmPassword, setConfirmPassword] = useState("");
-  const [localError, setLocalError] = useState<string | null>(null);
+  type PasswordFormState = {
+    currentPassword: string;
+    newPassword: string;
+    confirmPassword: string;
+    localError: string | null;
+  };
+  type PasswordFormAction =
+    | { type: "reset" }
+    | {
+        type: "setField";
+        field: "currentPassword" | "newPassword" | "confirmPassword";
+        value: string;
+      }
+    | { type: "setLocalError"; value: string | null };
+  const initialState: PasswordFormState = {
+    currentPassword: "",
+    newPassword: "",
+    confirmPassword: "",
+    localError: null,
+  };
+  const reducer = (
+    state: PasswordFormState,
+    action: PasswordFormAction
+  ): PasswordFormState => {
+    switch (action.type) {
+      case "reset":
+        return initialState;
+      case "setField":
+        return {
+          ...state,
+          [action.field]: action.value,
+          localError: null,
+        };
+      case "setLocalError":
+        return { ...state, localError: action.value };
+      default:
+        return state;
+    }
+  };
+  const [state, dispatch] = useReducer(reducer, initialState);
+  const { currentPassword, newPassword, confirmPassword, localError } = state;
 
   useEffect(() => {
     if (isOpen) {
-      setCurrentPassword("");
-      setNewPassword("");
-      setConfirmPassword("");
-      setLocalError(null);
+      dispatch({ type: "reset" });
     }
   }, [isOpen]);
 
@@ -94,11 +128,10 @@ export function ChangePasswordDialog({
     : t("apps.control-panels.setPasswordDialog.description");
 
   const handleInputChange = (
-    setter: (value: string) => void,
+    field: "currentPassword" | "newPassword" | "confirmPassword",
     value: string
   ) => {
-    setter(value);
-    setLocalError(null);
+    dispatch({ type: "setField", field, value });
     onAnyInputChange?.();
   };
 
@@ -107,22 +140,34 @@ export function ChangePasswordDialog({
     if (isLoading) return;
 
     if (hasPassword && currentPassword.length === 0) {
-      setLocalError(t("common.auth.changePassword.currentPasswordRequired"));
+      dispatch({
+        type: "setLocalError",
+        value: t("common.auth.changePassword.currentPasswordRequired"),
+      });
       return;
     }
 
     if (newPassword.length < 8) {
-      setLocalError(t("common.auth.changePassword.tooShort"));
+      dispatch({
+        type: "setLocalError",
+        value: t("common.auth.changePassword.tooShort"),
+      });
       return;
     }
 
     if (newPassword !== confirmPassword) {
-      setLocalError(t("common.auth.changePassword.mismatch"));
+      dispatch({
+        type: "setLocalError",
+        value: t("common.auth.changePassword.mismatch"),
+      });
       return;
     }
 
     if (hasPassword && currentPassword === newPassword) {
-      setLocalError(t("common.auth.changePassword.sameAsCurrent"));
+      dispatch({
+        type: "setLocalError",
+        value: t("common.auth.changePassword.sameAsCurrent"),
+      });
       return;
     }
 
@@ -158,7 +203,7 @@ export function ChangePasswordDialog({
             autoFocus
             value={currentPassword}
             onChange={(e) =>
-              handleInputChange(setCurrentPassword, e.target.value)
+              handleInputChange("currentPassword", e.target.value)
             }
             className={cn("shadow-none h-8", themeFont)}
             style={themeFontStyle}
@@ -181,7 +226,7 @@ export function ChangePasswordDialog({
           autoComplete="new-password"
           autoFocus={!hasPassword}
           value={newPassword}
-          onChange={(e) => handleInputChange(setNewPassword, e.target.value)}
+          onChange={(e) => handleInputChange("newPassword", e.target.value)}
           className={cn("shadow-none h-8", themeFont)}
           style={themeFontStyle}
           disabled={isLoading}
@@ -202,7 +247,7 @@ export function ChangePasswordDialog({
           autoComplete="new-password"
           value={confirmPassword}
           onChange={(e) =>
-            handleInputChange(setConfirmPassword, e.target.value)
+            handleInputChange("confirmPassword", e.target.value)
           }
           className={cn("shadow-none h-8", themeFont)}
           style={themeFontStyle}

--- a/src/components/dialogs/LyricsSearchDialog.tsx
+++ b/src/components/dialogs/LyricsSearchDialog.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from "react";
+import React, { useReducer, useEffect, useCallback } from "react";
 import {
   Dialog,
   DialogContent,
@@ -67,32 +67,79 @@ export function LyricsSearchDialog({
     isMacOSTheme: isMacTheme,
   } = useThemeFlags();
 
-  const [query, setQuery] = useState(initialQuery || "");
-  const [results, setResults] = useState<LyricsSearchResult[]>([]);
-  const [selectedIndex, setSelectedIndex] = useState<number>(-1);
-  const [isSearching, setIsSearching] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  type LyricsSearchState = {
+    query: string;
+    results: LyricsSearchResult[];
+    selectedIndex: number;
+    isSearching: boolean;
+    error: string | null;
+  };
+  type LyricsSearchAction =
+    | { type: "reset"; query: string }
+    | { type: "setQuery"; query: string }
+    | { type: "searchStart" }
+    | { type: "searchSuccess"; results: LyricsSearchResult[] }
+    | { type: "searchError"; error: string }
+    | { type: "setSelectedIndex"; index: number };
+  const initialState: LyricsSearchState = {
+    query: initialQuery || "",
+    results: [],
+    selectedIndex: -1,
+    isSearching: false,
+    error: null,
+  };
+  const reducer = (
+    state: LyricsSearchState,
+    action: LyricsSearchAction
+  ): LyricsSearchState => {
+    switch (action.type) {
+      case "reset":
+        return { ...initialState, query: action.query };
+      case "setQuery":
+        return { ...state, query: action.query };
+      case "searchStart":
+        return {
+          ...state,
+          isSearching: true,
+          error: null,
+          results: [],
+          selectedIndex: -1,
+        };
+      case "searchSuccess":
+        return {
+          ...state,
+          isSearching: false,
+          results: action.results,
+          error: action.results.length === 0 ? t("apps.ipod.dialogs.lyricsSearchNoResults") : null,
+        };
+      case "searchError":
+        return { ...state, isSearching: false, error: action.error };
+      case "setSelectedIndex":
+        return { ...state, selectedIndex: action.index };
+      default:
+        return state;
+    }
+  };
+  const [state, dispatch] = useReducer(reducer, initialState);
+  const { query, results, selectedIndex, isSearching, error } = state;
 
   // Reset state when dialog opens/closes
   useEffect(() => {
     if (isOpen) {
-      setQuery(initialQuery || "");
-      setResults([]);
-      setSelectedIndex(-1);
-      setError(null);
+      dispatch({ type: "reset", query: initialQuery || "" });
     }
   }, [isOpen, initialQuery]);
 
   const handleSearch = async () => {
     if (!query.trim()) {
-      setError(t("apps.ipod.dialogs.lyricsSearchEmptyQuery"));
+      dispatch({
+        type: "searchError",
+        error: t("apps.ipod.dialogs.lyricsSearchEmptyQuery"),
+      });
       return;
     }
 
-    setIsSearching(true);
-    setError(null);
-    setResults([]);
-    setSelectedIndex(-1);
+    dispatch({ type: "searchStart" });
 
     try {
       const response = await abortableFetch(
@@ -120,22 +167,19 @@ export function LyricsSearchDialog({
 
       const data = await response.json();
       if (data.results && Array.isArray(data.results)) {
-        setResults(data.results);
-        if (data.results.length === 0) {
-          setError(t("apps.ipod.dialogs.lyricsSearchNoResults"));
-        }
+        dispatch({ type: "searchSuccess", results: data.results });
       } else {
         throw new Error(t("apps.ipod.dialogs.lyricsSearchInvalidResponse"));
       }
     } catch (err) {
       console.error("Lyrics search error:", err);
-      setError(
-        err instanceof Error
-          ? err.message
-          : t("apps.ipod.dialogs.lyricsSearchError")
-      );
-    } finally {
-      setIsSearching(false);
+      dispatch({
+        type: "searchError",
+        error:
+          err instanceof Error
+            ? err.message
+            : t("apps.ipod.dialogs.lyricsSearchError"),
+      });
     }
   };
 
@@ -148,7 +192,7 @@ export function LyricsSearchDialog({
 
   const handleSelectAndUse = useCallback((index: number) => {
     if (index >= 0 && index < results.length) {
-      setSelectedIndex(index);
+      dispatch({ type: "setSelectedIndex", index });
       onSelect(results[index]);
       onOpenChange(false);
     }
@@ -190,7 +234,9 @@ export function LyricsSearchDialog({
         <Input
           autoFocus
           value={query}
-          onChange={(e) => setQuery(e.target.value)}
+          onChange={(e) =>
+            dispatch({ type: "setQuery", query: e.target.value })
+          }
           onKeyDown={(e) => {
             e.stopPropagation();
             if (e.key === "Enter" && !isSearching) {
@@ -352,7 +398,9 @@ export function LyricsSearchDialog({
                 return (
                   <div
                     key={result.hash}
-                    onClick={() => setSelectedIndex(index)}
+                    onClick={() =>
+                      dispatch({ type: "setSelectedIndex", index })
+                    }
                     onKeyDown={(e: React.KeyboardEvent<HTMLDivElement>) => {
                       if (e.key === "Enter" || e.key === " ") {
                         e.preventDefault();

--- a/src/components/dialogs/ShareItemDialog.tsx
+++ b/src/components/dialogs/ShareItemDialog.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useEffect } from "react";
+import React, { useReducer, useRef, useEffect } from "react";
 import {
   Dialog,
   DialogContent,
@@ -41,8 +41,24 @@ export function ShareItemDialog({
   overlayClassName,
 }: ShareItemDialogProps) {
   const { t } = useTranslation();
-  const [isLoading, setIsLoading] = useState(false);
-  const [shareUrl, setShareUrl] = useState("");
+  type ShareDialogState = {
+    isLoading: boolean;
+    shareUrl: string;
+  };
+  type ShareDialogAction =
+    | { type: "reset" }
+    | { type: "set"; payload: Partial<ShareDialogState> };
+  const initialState: ShareDialogState = { isLoading: false, shareUrl: "" };
+  const reducer = (
+    state: ShareDialogState,
+    action: ShareDialogAction
+  ): ShareDialogState => {
+    if (action.type === "reset") return initialState;
+    return { ...state, ...action.payload };
+  };
+
+  const [state, dispatch] = useReducer(reducer, initialState);
+  const { isLoading, shareUrl } = state;
   const inputRef = useRef<HTMLInputElement>(null);
   const {
     isWindowsTheme: isXpTheme,
@@ -56,24 +72,25 @@ export function ShareItemDialog({
   // Generate the share link when the dialog opens or identifiers change
   useEffect(() => {
     if (isOpen && itemIdentifier) {
-      setIsLoading(true);
+      dispatch({ type: "set", payload: { isLoading: true, shareUrl: "" } });
       try {
         const generated = generateShareUrl(itemIdentifier, secondaryIdentifier);
-        setShareUrl(generated);
+        dispatch({
+          type: "set",
+          payload: { shareUrl: generated, isLoading: false },
+        });
       } catch (error) {
         console.error("Error generating share link:", error);
         toast.error(t("common.dialog.share.failedToGenerateShareLink", { itemType: translatedItemType }), {
           description: t("common.dialog.share.pleaseTryAgainLater"),
         });
-        setShareUrl(""); // Clear potentially stale URL
-      } finally {
-        setIsLoading(false);
+        dispatch({ type: "set", payload: { shareUrl: "", isLoading: false } });
       }
     }
     return () => {
       // Reset state when dialog closes
       if (!isOpen) {
-        setShareUrl("");
+        dispatch({ type: "reset" });
       }
     };
     // Include all dependencies that affect URL generation

--- a/src/components/dialogs/SongSearchDialog.tsx
+++ b/src/components/dialogs/SongSearchDialog.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useMemo } from "react";
+import { useReducer, useEffect, useCallback, useMemo } from "react";
 import {
   Dialog,
   DialogContent,
@@ -76,15 +76,112 @@ export function SongSearchDialog({
     isMacOSTheme: isMacTheme,
   } = useThemeFlags();
 
-  const [query, setQuery] = useState(initialQuery);
-  const [results, setResults] = useState<SongSearchResult[]>([]);
-  const [appleMusicResults, setAppleMusicResults] = useState<Track[]>([]);
-  const [activeAppleMusicTab, setActiveAppleMusicTab] =
-    useState<AppleMusicSearchScope>("catalog");
-  const [selectedIndex, setSelectedIndex] = useState<number>(-1);
-  const [isSearching, setIsSearching] = useState(false);
-  const [isAdding, setIsAdding] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  type SongSearchState = {
+    query: string;
+    results: SongSearchResult[];
+    appleMusicResults: Track[];
+    activeAppleMusicTab: AppleMusicSearchScope;
+    selectedIndex: number;
+    isSearching: boolean;
+    isAdding: boolean;
+    error: string | null;
+  };
+  type SongSearchAction =
+    | { type: "resetOnOpen"; query: string }
+    | { type: "setQuery"; query: string }
+    | { type: "setActiveAppleMusicTab"; tab: AppleMusicSearchScope }
+    | { type: "setSelectedIndex"; index: number }
+    | { type: "searchStart" }
+    | {
+        type: "searchFinish";
+        mode: "youtube" | "appleMusic";
+        results: SongSearchResult[] | Track[];
+        error: string | null;
+      }
+    | { type: "searchError"; error: string }
+    | { type: "setAdding"; isAdding: boolean }
+    | { type: "setError"; error: string | null };
+  const initialState: SongSearchState = {
+    query: initialQuery,
+    results: [],
+    appleMusicResults: [],
+    activeAppleMusicTab: "catalog",
+    selectedIndex: -1,
+    isSearching: false,
+    isAdding: false,
+    error: null,
+  };
+  const reducer = (
+    state: SongSearchState,
+    action: SongSearchAction
+  ): SongSearchState => {
+    switch (action.type) {
+      case "resetOnOpen":
+        return {
+          ...state,
+          query: action.query,
+          results: [],
+          appleMusicResults: [],
+          selectedIndex: -1,
+          error: null,
+        };
+      case "setQuery":
+        return { ...state, query: action.query };
+      case "setActiveAppleMusicTab":
+        return {
+          ...state,
+          activeAppleMusicTab: action.tab,
+          appleMusicResults: [],
+          selectedIndex: -1,
+          error: null,
+        };
+      case "setSelectedIndex":
+        return { ...state, selectedIndex: action.index };
+      case "searchStart":
+        return {
+          ...state,
+          isSearching: true,
+          error: null,
+          results: [],
+          appleMusicResults: [],
+          selectedIndex: -1,
+        };
+      case "searchFinish":
+        if (action.mode === "appleMusic") {
+          return {
+            ...state,
+            isSearching: false,
+            appleMusicResults: action.results as Track[],
+            error: action.error,
+          };
+        }
+        return {
+          ...state,
+          isSearching: false,
+          results: action.results as SongSearchResult[],
+          error: action.error,
+        };
+      case "searchError":
+        return { ...state, isSearching: false, error: action.error };
+      case "setAdding":
+        return { ...state, isAdding: action.isAdding };
+      case "setError":
+        return { ...state, error: action.error };
+      default:
+        return state;
+    }
+  };
+  const [state, dispatch] = useReducer(reducer, initialState);
+  const {
+    query,
+    results,
+    appleMusicResults,
+    activeAppleMusicTab,
+    selectedIndex,
+    isSearching,
+    isAdding,
+    error,
+  } = state;
   const isAppleMusicMode = mode === "appleMusic";
 
   // Detect if input is a YouTube URL
@@ -92,40 +189,39 @@ export function SongSearchDialog({
 
   useEffect(() => {
     if (isOpen) {
-      setQuery(initialQuery);
-      setResults([]);
-      setAppleMusicResults([]);
-      setSelectedIndex(-1);
-      setError(null);
+      dispatch({ type: "resetOnOpen", query: initialQuery });
     }
   }, [isOpen, initialQuery]);
-
-  useEffect(() => {
-    setAppleMusicResults([]);
-    setSelectedIndex(-1);
-    setError(null);
-  }, [activeAppleMusicTab]);
 
   const handleAddUrl = async () => {
     if (!onAddUrl || !query.trim()) return;
     
-    setIsAdding(true);
-    setError(null);
+    dispatch({ type: "setAdding", isAdding: true });
+    dispatch({ type: "setError", error: null });
     
     try {
       await onAddUrl(query.trim());
       onOpenChange(false);
     } catch (err) {
       console.error("Add URL error:", err);
-      setError(err instanceof Error ? err.message : t("apps.ipod.dialogs.songSearchError"));
+      dispatch({
+        type: "setError",
+        error:
+          err instanceof Error
+            ? err.message
+            : t("apps.ipod.dialogs.songSearchError"),
+      });
     } finally {
-      setIsAdding(false);
+      dispatch({ type: "setAdding", isAdding: false });
     }
   };
 
   const handleSearch = async () => {
     if (!query.trim()) {
-      setError(t("apps.ipod.dialogs.songSearchEmptyQuery"));
+      dispatch({
+        type: "searchError",
+        error: t("apps.ipod.dialogs.songSearchEmptyQuery"),
+      });
       return;
     }
 
@@ -135,11 +231,7 @@ export function SongSearchDialog({
       return;
     }
 
-    setIsSearching(true);
-    setError(null);
-    setResults([]);
-    setAppleMusicResults([]);
-    setSelectedIndex(-1);
+    dispatch({ type: "searchStart" });
 
     try {
       if (isAppleMusicMode) {
@@ -163,10 +255,15 @@ export function SongSearchDialog({
           query.trim(),
           activeAppleMusicTab
         );
-        setAppleMusicResults(appleResults);
-        if (appleResults.length === 0) {
-          setError(t("apps.ipod.dialogs.songSearchNoResults"));
-        }
+        dispatch({
+          type: "searchFinish",
+          mode: "appleMusic",
+          results: appleResults,
+          error:
+            appleResults.length === 0
+              ? t("apps.ipod.dialogs.songSearchNoResults")
+              : null,
+        });
         return;
       }
 
@@ -188,16 +285,27 @@ export function SongSearchDialog({
 
       const data = await response.json();
       if (data.results && Array.isArray(data.results)) {
-        setResults(data.results);
-        if (data.results.length === 0) setError(t("apps.ipod.dialogs.songSearchNoResults"));
+        dispatch({
+          type: "searchFinish",
+          mode: "youtube",
+          results: data.results,
+          error:
+            data.results.length === 0
+              ? t("apps.ipod.dialogs.songSearchNoResults")
+              : null,
+        });
       } else {
         throw new Error(t("apps.ipod.dialogs.songSearchInvalidResponse"));
       }
     } catch (err) {
       console.error("Song search error:", err);
-      setError(err instanceof Error ? err.message : t("apps.ipod.dialogs.songSearchError"));
-    } finally {
-      setIsSearching(false);
+      dispatch({
+        type: "searchError",
+        error:
+          err instanceof Error
+            ? err.message
+            : t("apps.ipod.dialogs.songSearchError"),
+      });
     }
   };
 
@@ -208,18 +316,20 @@ export function SongSearchDialog({
         selectedIndex < appleMusicResults.length &&
         onAppleMusicSelect
       ) {
-        setIsAdding(true);
+        dispatch({ type: "setAdding", isAdding: true });
         try {
           await onAppleMusicSelect(appleMusicResults[selectedIndex]);
           onOpenChange(false);
         } catch (err) {
-          setError(
-            err instanceof Error
-              ? err.message
-              : t("apps.ipod.dialogs.songSearchError")
-          );
+          dispatch({
+            type: "setError",
+            error:
+              err instanceof Error
+                ? err.message
+                : t("apps.ipod.dialogs.songSearchError"),
+          });
         } finally {
-          setIsAdding(false);
+          dispatch({ type: "setAdding", isAdding: false });
         }
       }
       return;
@@ -243,26 +353,28 @@ export function SongSearchDialog({
   const handleSelectAndAdd = useCallback(async (index: number) => {
     if (isAppleMusicMode) {
       if (index >= 0 && index < appleMusicResults.length && onAppleMusicSelect) {
-        setSelectedIndex(index);
-        setIsAdding(true);
+        dispatch({ type: "setSelectedIndex", index });
+        dispatch({ type: "setAdding", isAdding: true });
         try {
           await onAppleMusicSelect(appleMusicResults[index]);
           onOpenChange(false);
         } catch (err) {
-          setError(
-            err instanceof Error
-              ? err.message
-              : t("apps.ipod.dialogs.songSearchError")
-          );
+          dispatch({
+            type: "setError",
+            error:
+              err instanceof Error
+                ? err.message
+                : t("apps.ipod.dialogs.songSearchError"),
+          });
         } finally {
-          setIsAdding(false);
+          dispatch({ type: "setAdding", isAdding: false });
         }
       }
       return;
     }
 
     if (index >= 0 && index < results.length) {
-      setSelectedIndex(index);
+      dispatch({ type: "setSelectedIndex", index });
       onSelect(results[index]);
       onOpenChange(false);
     }
@@ -293,7 +405,10 @@ export function SongSearchDialog({
         <Tabs
           value={activeAppleMusicTab}
           onValueChange={(value) =>
-            setActiveAppleMusicTab(value as AppleMusicSearchScope)
+            dispatch({
+              type: "setActiveAppleMusicTab",
+              tab: value as AppleMusicSearchScope,
+            })
           }
           className="w-full"
         >
@@ -312,7 +427,9 @@ export function SongSearchDialog({
         <Input
           autoFocus
           value={query}
-          onChange={(e) => setQuery(e.target.value)}
+          onChange={(e) =>
+            dispatch({ type: "setQuery", query: e.target.value })
+          }
           onKeyDown={(e) => {
             e.stopPropagation();
             if (e.key === "Enter" && !isSearching && !isAdding) handleSearch();
@@ -355,7 +472,7 @@ export function SongSearchDialog({
       return (
         <div
           key={`${result.id}-${index}`}
-          onClick={() => setSelectedIndex(index)}
+          onClick={() => dispatch({ type: "setSelectedIndex", index })}
           onDoubleClick={() => void handleSelectAndAdd(index)}
           onKeyDown={(e) => {
             if (e.key === "Enter" || e.key === " ") {
@@ -415,7 +532,7 @@ export function SongSearchDialog({
     return (
       <div
         key={result.videoId}
-        onClick={() => setSelectedIndex(index)}
+        onClick={() => dispatch({ type: "setSelectedIndex", index })}
         onDoubleClick={() => void handleSelectAndAdd(index)}
         onKeyDown={(e) => {
           if (e.key === "Enter" || e.key === " ") {

--- a/src/components/layout/Dock.tsx
+++ b/src/components/layout/Dock.tsx
@@ -2,6 +2,7 @@ import React, {
   useMemo,
   useRef,
   useState,
+  useReducer,
   useCallback,
   useEffect,
   forwardRef,
@@ -630,8 +631,34 @@ function MacDock() {
     y: number;
   } | null>(null);
   
-  const [hoveredId, setHoveredId] = useState<string | null>(null);
-  const [isSwapping, setIsSwapping] = useState(false);
+  type HoverState = {
+    hoveredId: string | null;
+    isSwapping: boolean;
+  };
+  type HoverAction =
+    | { type: "hoverImmediate"; id: string }
+    | { type: "hoverUpdate"; id: string }
+    | { type: "clearHover" };
+  const hoverReducer = (state: HoverState, action: HoverAction): HoverState => {
+    switch (action.type) {
+      case "hoverImmediate":
+        return { hoveredId: action.id, isSwapping: true };
+      case "hoverUpdate":
+        return {
+          hoveredId: action.id,
+          isSwapping: state.hoveredId !== null && state.hoveredId !== action.id,
+        };
+      case "clearHover":
+        return { hoveredId: null, isSwapping: false };
+      default:
+        return state;
+    }
+  };
+  const [hoverState, dispatchHover] = useReducer(hoverReducer, {
+    hoveredId: null,
+    isSwapping: false,
+  });
+  const { hoveredId, isSwapping } = hoverState;
   const hoverTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   
   // Drag-and-drop state
@@ -663,26 +690,17 @@ function MacDock() {
     if (hoverTimeoutRef.current) {
       clearTimeout(hoverTimeoutRef.current);
       hoverTimeoutRef.current = null;
-      setIsSwapping(true);
-      setHoveredId(id);
+      dispatchHover({ type: "hoverImmediate", id });
       return;
     }
-    
-    setHoveredId((prev) => {
-      if (prev !== null && prev !== id) {
-        setIsSwapping(true);
-      } else {
-        setIsSwapping(false);
-      }
-      return id;
-    });
+
+    dispatchHover({ type: "hoverUpdate", id });
   }, []);
 
   const handleIconLeave = useCallback(() => {
     if (hoverTimeoutRef.current) clearTimeout(hoverTimeoutRef.current);
     hoverTimeoutRef.current = setTimeout(() => {
-      setHoveredId(null);
-      setIsSwapping(false);
+      dispatchHover({ type: "clearHover" });
       hoverTimeoutRef.current = null;
     }, 50);
   }, []);

--- a/src/components/layout/dashboard/ClockWidget.tsx
+++ b/src/components/layout/dashboard/ClockWidget.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useMemo, useCallback, useRef } from "react";
+import { useEffect, useState, useMemo, useCallback, useRef, useReducer } from "react";
 import { useDashboardStore, type ClockWidgetConfig } from "@/stores/useDashboardStore";
 import { MapPin, MagnifyingGlass, NavigationArrow } from "@phosphor-icons/react";
 import { useTranslation } from "react-i18next";
@@ -232,19 +232,49 @@ export function ClockBackPanel({ widgetId, onDone }: { widgetId: string; onDone?
   const { isWindowsTheme: isXpTheme } = useThemeFlags();
   const updateWidgetConfig = useDashboardStore((s) => s.updateWidgetConfig);
 
-  const [searchQuery, setSearchQuery] = useState("");
-  const [searchResults, setSearchResults] = useState<CityResult[]>([]);
-  const [searching, setSearching] = useState(false);
+  type ClockSearchState = {
+    searchQuery: string;
+    searchResults: CityResult[];
+    searching: boolean;
+  };
+  type ClockSearchAction =
+    | { type: "setQuery"; query: string }
+    | { type: "searchIdle" }
+    | { type: "searchStart" }
+    | { type: "searchResults"; results: CityResult[] };
+  const initialSearchState: ClockSearchState = {
+    searchQuery: "",
+    searchResults: [],
+    searching: false,
+  };
+  const searchReducer = (
+    state: ClockSearchState,
+    action: ClockSearchAction
+  ): ClockSearchState => {
+    switch (action.type) {
+      case "setQuery":
+        return { ...state, searchQuery: action.query };
+      case "searchIdle":
+        return { ...state, searchResults: [], searching: false };
+      case "searchStart":
+        return { ...state, searching: true };
+      case "searchResults":
+        return { ...state, searchResults: action.results, searching: false };
+      default:
+        return state;
+    }
+  };
+  const [searchState, dispatch] = useReducer(searchReducer, initialSearchState);
+  const { searchQuery, searchResults, searching } = searchState;
   const searchInputRef = useRef<HTMLInputElement>(null);
   const searchTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const searchCities = useCallback(async (query: string) => {
     if (query.length < 2) {
-      setSearchResults([]);
-      setSearching(false);
+      dispatch({ type: "searchIdle" });
       return;
     }
-    setSearching(true);
+    dispatch({ type: "searchStart" });
     try {
       const res = await fetch(
         `https://nominatim.openstreetmap.org/search?q=${encodeURIComponent(query)}&format=json&limit=6&addressdetails=1&featuretype=city`
@@ -263,12 +293,13 @@ export function ClockBackPanel({ widgetId, onDone }: { widgetId: string; onDone?
             lat: parseFloat(r.lat),
             lon: parseFloat(r.lon),
           }));
-        setSearchResults(results);
+        dispatch({ type: "searchResults", results });
+        return;
       }
     } catch {
       // search failed silently
     }
-    setSearching(false);
+    dispatch({ type: "searchResults", results: [] });
   }, []);
 
   useEffect(() => {
@@ -279,7 +310,7 @@ export function ClockBackPanel({ widgetId, onDone }: { widgetId: string; onDone?
 
   const handleSearchInput = useCallback(
     (value: string) => {
-      setSearchQuery(value);
+      dispatch({ type: "setQuery", query: value });
       if (searchTimerRef.current) clearTimeout(searchTimerRef.current);
       searchTimerRef.current = setTimeout(() => searchCities(value), 300);
     },

--- a/src/components/layout/dashboard/CurrencyWidget.tsx
+++ b/src/components/layout/dashboard/CurrencyWidget.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState, type ChangeEvent } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, useReducer, type ChangeEvent } from "react";
 import { useDashboardStore, type CurrencyWidgetConfig } from "@/stores/useDashboardStore";
 import { useTranslation } from "react-i18next";
 import { ArrowsDownUp, ArrowsLeftRight } from "@phosphor-icons/react";
@@ -65,32 +65,79 @@ export function CurrencyWidget({ widgetId }: CurrencyWidgetProps) {
   const updateWidgetConfig = useDashboardStore((s) => s.updateWidgetConfig);
   const config = widget?.config as CurrencyWidgetConfig | undefined;
 
-  const [fromCurrency, setFromCurrency] = useState(config?.fromCurrency ?? "USD");
-  const [toCurrency, setToCurrency] = useState(config?.toCurrency ?? "EUR");
-  const [amountStr, setAmountStr] = useState(() =>
-    normalizeAmountInput(
+  type CurrencyWidgetState = {
+    fromCurrency: string;
+    toCurrency: string;
+    amountStr: string;
+    rateData: RateCacheEntry | null;
+    loading: boolean;
+    error: string | null;
+    usingCache: boolean;
+  };
+  type CurrencyWidgetAction =
+    | { type: "set"; payload: Partial<CurrencyWidgetState> }
+    | { type: "swapCurrencies" };
+  const initialState: CurrencyWidgetState = {
+    fromCurrency: config?.fromCurrency ?? "USD",
+    toCurrency: config?.toCurrency ?? "EUR",
+    amountStr: normalizeAmountInput(
       config?.lastAmount ?? "100",
       getCurrencyMaxFractionDigits(config?.fromCurrency ?? "USD"),
       i18n.language
-    )
-  );
-  const [rateData, setRateData] = useState<RateCacheEntry | null>(null);
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const [usingCache, setUsingCache] = useState(false);
+    ),
+    rateData: null,
+    loading: false,
+    error: null,
+    usingCache: false,
+  };
+  const reducer = (
+    state: CurrencyWidgetState,
+    action: CurrencyWidgetAction
+  ): CurrencyWidgetState => {
+    switch (action.type) {
+      case "set":
+        return { ...state, ...action.payload };
+      case "swapCurrencies":
+        return {
+          ...state,
+          fromCurrency: state.toCurrency,
+          toCurrency: state.fromCurrency,
+        };
+      default:
+        return state;
+    }
+  };
+  const [state, dispatch] = useReducer(reducer, initialState);
+  const {
+    fromCurrency,
+    toCurrency,
+    amountStr,
+    rateData,
+    loading,
+    error,
+    usingCache,
+  } = state;
 
   const abortRef = useRef<AbortController | null>(null);
 
   useEffect(() => {
-    if (config?.fromCurrency && config.fromCurrency !== fromCurrency) setFromCurrency(config.fromCurrency);
-    if (config?.toCurrency && config.toCurrency !== toCurrency) setToCurrency(config.toCurrency);
+    const nextState: Partial<CurrencyWidgetState> = {};
+    if (config?.fromCurrency && config.fromCurrency !== fromCurrency) {
+      nextState.fromCurrency = config.fromCurrency;
+    }
+    if (config?.toCurrency && config.toCurrency !== toCurrency) {
+      nextState.toCurrency = config.toCurrency;
+    }
     if (config?.lastAmount != null) {
       const normalized = normalizeAmountInput(
         config.lastAmount,
         getCurrencyMaxFractionDigits(config.fromCurrency ?? fromCurrency),
         i18n.language
       );
-      if (normalized !== amountStr) setAmountStr(normalized);
+      if (normalized !== amountStr) nextState.amountStr = normalized;
+    }
+    if (Object.keys(nextState).length > 0) {
+      dispatch({ type: "set", payload: nextState });
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [config?.fromCurrency, config?.toCurrency, config?.lastAmount]);
@@ -112,20 +159,30 @@ export function CurrencyWidget({ widgetId }: CurrencyWidgetProps) {
           rateDate: new Date().toISOString().slice(0, 10),
           fetchedAt: Date.now(),
         };
-        setRateData(self);
-        setError(null);
-        setUsingCache(false);
-        setLoading(false);
+        dispatch({
+          type: "set",
+          payload: {
+            rateData: self,
+            error: null,
+            usingCache: false,
+            loading: false,
+          },
+        });
         return;
       }
 
       const mem = rateMemoryCache.get(key);
       const now = Date.now();
       if (mem && now - mem.fetchedAt < RATE_STALE_MS) {
-        setRateData(mem);
-        setUsingCache(false);
-        setError(null);
-        setLoading(false);
+        dispatch({
+          type: "set",
+          payload: {
+            rateData: mem,
+            usingCache: false,
+            error: null,
+            loading: false,
+          },
+        });
         return;
       }
 
@@ -133,29 +190,41 @@ export function CurrencyWidget({ widgetId }: CurrencyWidgetProps) {
       const controller = new AbortController();
       abortRef.current = controller;
 
-      setLoading(true);
-      setError(null);
-      setUsingCache(false);
+      dispatch({
+        type: "set",
+        payload: { loading: true, error: null, usingCache: false },
+      });
 
       try {
         const { rate, rateDate } = await fetchCurrencyRateForWidget(from, to, controller.signal);
         if (controller.signal.aborted) return;
         const entry: RateCacheEntry = { rate, rateDate, fetchedAt: Date.now() };
         rateMemoryCache.set(key, entry);
-        setRateData(entry);
-        setLoading(false);
+        dispatch({
+          type: "set",
+          payload: { rateData: entry, loading: false },
+        });
       } catch (err) {
         if (err instanceof DOMException && err.name === "AbortError") return;
         const cached = rateMemoryCache.get(key);
         if (!controller.signal.aborted) {
           if (cached) {
-            setRateData(cached);
-            setUsingCache(true);
-            setError(null);
+            dispatch({
+              type: "set",
+              payload: { rateData: cached, usingCache: true, error: null },
+            });
           } else {
-            setError(t("apps.dashboard.currency.error", "Could not load exchange rate"));
+            dispatch({
+              type: "set",
+              payload: {
+                error: t(
+                  "apps.dashboard.currency.error",
+                  "Could not load exchange rate"
+                ),
+              },
+            });
           }
-          setLoading(false);
+          dispatch({ type: "set", payload: { loading: false } });
         }
       }
     },
@@ -195,18 +264,23 @@ export function CurrencyWidget({ widgetId }: CurrencyWidgetProps) {
   }, [rateData, usingCache, i18n.language, t]);
 
   const handleFromChange = (code: string) => {
-    setFromCurrency(code);
     const renormalized = normalizeAmountInput(
       amountStr,
       getCurrencyMaxFractionDigits(code),
       i18n.language
     );
-    if (renormalized !== amountStr) setAmountStr(renormalized);
+    dispatch({
+      type: "set",
+      payload: {
+        fromCurrency: code,
+        amountStr: renormalized,
+      },
+    });
     persistFields({ fromCurrency: code, toCurrency, lastAmount: renormalized });
   };
 
   const handleToChange = (code: string) => {
-    setToCurrency(code);
+    dispatch({ type: "set", payload: { toCurrency: code } });
     persistFields({ fromCurrency, toCurrency: code, lastAmount: amountStr });
   };
 
@@ -237,7 +311,7 @@ export function CurrencyWidget({ widgetId }: CurrencyWidgetProps) {
       i18n.language
     );
 
-    setAmountStr(normalized);
+    dispatch({ type: "set", payload: { amountStr: normalized } });
     persistFields({ fromCurrency, toCurrency, lastAmount: normalized });
 
     // Restore caret to sit after the same digit count in the formatted output.
@@ -255,8 +329,7 @@ export function CurrencyWidget({ widgetId }: CurrencyWidgetProps) {
   const handleSwap = () => {
     const nf = toCurrency;
     const nt = fromCurrency;
-    setFromCurrency(nf);
-    setToCurrency(nt);
+    dispatch({ type: "swapCurrencies" });
     persistFields({ fromCurrency: nf, toCurrency: nt, lastAmount: amountStr });
   };
 

--- a/src/components/layout/dashboard/WeatherWidget.tsx
+++ b/src/components/layout/dashboard/WeatherWidget.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useRef, useMemo, useSyncExternalStore } from "react";
+import { useEffect, useCallback, useRef, useMemo, useSyncExternalStore, useReducer } from "react";
 import { useTranslation } from "react-i18next";
 import type { TFunction } from "i18next";
 import { useDashboardStore, type WeatherWidgetConfig } from "@/stores/useDashboardStore";
@@ -135,10 +135,42 @@ export function WeatherWidget({ widgetId }: WeatherWidgetProps) {
   const widget = useDashboardStore((s) => s.widgets.find((w) => w.id === widgetId));
   const cityConfig = widget?.config as WeatherWidgetConfig | undefined;
 
-  const [weather, setWeather] = useState<WeatherData | null>(null);
-  const [geoLocationName, setGeoLocationName] = useState<string>("");
-  const [error, setError] = useState<string | null>(null);
-  const [loading, setLoading] = useState(true);
+  type WeatherWidgetState = {
+    weather: WeatherData | null;
+    geoLocationName: string;
+    error: string | null;
+    loading: boolean;
+  };
+  type WeatherWidgetAction =
+    | { type: "reset" }
+    | { type: "setGeoLocationName"; geoLocationName: string }
+    | { type: "fetchSuccess"; weather: WeatherData }
+    | { type: "fetchError"; error: string };
+  const initialState: WeatherWidgetState = {
+    weather: null,
+    geoLocationName: "",
+    error: null,
+    loading: true,
+  };
+  const reducer = (
+    state: WeatherWidgetState,
+    action: WeatherWidgetAction
+  ): WeatherWidgetState => {
+    switch (action.type) {
+      case "reset":
+        return initialState;
+      case "setGeoLocationName":
+        return { ...state, geoLocationName: action.geoLocationName };
+      case "fetchSuccess":
+        return { ...state, weather: action.weather, loading: false, error: null };
+      case "fetchError":
+        return { ...state, loading: false, error: action.error };
+      default:
+        return state;
+    }
+  };
+  const [state, dispatch] = useReducer(reducer, initialState);
+  const { weather, geoLocationName, error, loading } = state;
 
   const locationName = useMemo(() => {
     if (cityConfig?.cityKey) return t(cityConfig.cityKey);
@@ -175,13 +207,13 @@ export function WeatherWidget({ widgetId }: WeatherWidgetProps) {
         temperatureMin: Math.round(data.daily.temperature_2m_min[0]),
         forecast,
       };
-      setWeather(weatherData);
+      dispatch({ type: "fetchSuccess", weather: weatherData });
       setWeatherCacheEntry(widgetId, weatherData);
-
-      setLoading(false);
     } catch {
-      setError(t("apps.dashboard.weather.unavailable"));
-      setLoading(false);
+      dispatch({
+        type: "fetchError",
+        error: t("apps.dashboard.weather.unavailable"),
+      });
     }
   }, [locale, t, widgetId]);
 
@@ -198,7 +230,7 @@ export function WeatherWidget({ widgetId }: WeatherWidgetProps) {
           geoData.address?.village ||
           geoData.address?.county ||
           "";
-        setGeoLocationName(city);
+        dispatch({ type: "setGeoLocationName", geoLocationName: city });
       }
     } catch {
       // Location name optional
@@ -206,16 +238,16 @@ export function WeatherWidget({ widgetId }: WeatherWidgetProps) {
   }, []);
 
   useEffect(() => {
-    setWeather(null);
-    setError(null);
-    setLoading(true);
-    setGeoLocationName("");
+    dispatch({ type: "reset" });
 
     const SF_LAT = 37.7749;
     const SF_LON = -122.4194;
 
     const fallbackToSF = () => {
-      setGeoLocationName(t("apps.dashboard.cities.sanFrancisco"));
+      dispatch({
+        type: "setGeoLocationName",
+        geoLocationName: t("apps.dashboard.cities.sanFrancisco"),
+      });
       fetchWeather(SF_LAT, SF_LON);
     };
 
@@ -439,19 +471,52 @@ export function WeatherBackPanel({ widgetId, onDone }: { widgetId: string; onDon
   const { isWindowsTheme: isXpTheme } = useThemeFlags();
   const updateWidgetConfig = useDashboardStore((s) => s.updateWidgetConfig);
 
-  const [searchQuery, setSearchQuery] = useState("");
-  const [searchResults, setSearchResults] = useState<CityResult[]>([]);
-  const [searching, setSearching] = useState(false);
+  type WeatherSearchState = {
+    searchQuery: string;
+    searchResults: CityResult[];
+    searching: boolean;
+  };
+  type WeatherSearchAction =
+    | { type: "setQuery"; query: string }
+    | { type: "searchIdle" }
+    | { type: "searchStart" }
+    | { type: "searchResults"; results: CityResult[] };
+  const initialSearchState: WeatherSearchState = {
+    searchQuery: "",
+    searchResults: [],
+    searching: false,
+  };
+  const searchReducer = (
+    state: WeatherSearchState,
+    action: WeatherSearchAction
+  ): WeatherSearchState => {
+    switch (action.type) {
+      case "setQuery":
+        return { ...state, searchQuery: action.query };
+      case "searchIdle":
+        return { ...state, searchResults: [], searching: false };
+      case "searchStart":
+        return { ...state, searching: true };
+      case "searchResults":
+        return { ...state, searchResults: action.results, searching: false };
+      default:
+        return state;
+    }
+  };
+  const [searchState, dispatchSearch] = useReducer(
+    searchReducer,
+    initialSearchState
+  );
+  const { searchQuery, searchResults, searching } = searchState;
   const searchInputRef = useRef<HTMLInputElement>(null);
   const searchTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const searchCities = useCallback(async (query: string) => {
     if (query.length < 2) {
-      setSearchResults([]);
-      setSearching(false);
+      dispatchSearch({ type: "searchIdle" });
       return;
     }
-    setSearching(true);
+    dispatchSearch({ type: "searchStart" });
     try {
       const res = await fetch(
         `https://nominatim.openstreetmap.org/search?q=${encodeURIComponent(query)}&format=json&limit=6&addressdetails=1&featuretype=city`
@@ -470,12 +535,13 @@ export function WeatherBackPanel({ widgetId, onDone }: { widgetId: string; onDon
             lat: parseFloat(r.lat),
             lon: parseFloat(r.lon),
           }));
-        setSearchResults(results);
+        dispatchSearch({ type: "searchResults", results });
+        return;
       }
     } catch {
       // search failed silently
     }
-    setSearching(false);
+    dispatchSearch({ type: "searchResults", results: [] });
   }, []);
 
   useEffect(() => {
@@ -486,7 +552,7 @@ export function WeatherBackPanel({ widgetId, onDone }: { widgetId: string; onDon
 
   const handleSearchInput = useCallback(
     (value: string) => {
-      setSearchQuery(value);
+      dispatchSearch({ type: "setQuery", query: value });
       if (searchTimerRef.current) clearTimeout(searchTimerRef.current);
       searchTimerRef.current = setTimeout(() => searchCities(value), 300);
     },

--- a/src/components/listen/JoinSessionDialog.tsx
+++ b/src/components/listen/JoinSessionDialog.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from "react";
+import { useReducer, useEffect, useCallback } from "react";
 import { useTranslation } from "react-i18next";
 import {
   Dialog,
@@ -54,35 +54,75 @@ export function JoinSessionDialog({
   onJoin,
 }: JoinSessionDialogProps) {
   const { t } = useTranslation();
-  const [value, setValue] = useState("");
-  const [sessions, setSessions] = useState<ListenSessionSummary[]>([]);
-  const [selectedIndex, setSelectedIndex] = useState<number>(-1);
-  const [isLoading, setIsLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  type JoinDialogState = {
+    value: string;
+    sessions: ListenSessionSummary[];
+    selectedIndex: number;
+    isLoading: boolean;
+    error: string | null;
+  };
+  type JoinDialogAction =
+    | { type: "resetOnOpen" }
+    | { type: "setValue"; value: string }
+    | { type: "setSelectedIndex"; index: number }
+    | { type: "loadStart" }
+    | { type: "loadSuccess"; sessions: ListenSessionSummary[] }
+    | { type: "loadError"; error: string }
+    | { type: "clearValue" };
+  const initialState: JoinDialogState = {
+    value: "",
+    sessions: [],
+    selectedIndex: -1,
+    isLoading: false,
+    error: null,
+  };
+  const reducer = (
+    state: JoinDialogState,
+    action: JoinDialogAction
+  ): JoinDialogState => {
+    switch (action.type) {
+      case "resetOnOpen":
+        return { ...state, value: "", selectedIndex: -1, error: null };
+      case "setValue":
+        return { ...state, value: action.value };
+      case "setSelectedIndex":
+        return { ...state, selectedIndex: action.index };
+      case "loadStart":
+        return { ...state, isLoading: true, error: null };
+      case "loadSuccess":
+        return { ...state, isLoading: false, sessions: action.sessions };
+      case "loadError":
+        return { ...state, isLoading: false, error: action.error, sessions: [] };
+      case "clearValue":
+        return { ...state, value: "" };
+      default:
+        return state;
+    }
+  };
+  const [state, dispatch] = useReducer(reducer, initialState);
+  const { value, sessions, selectedIndex, isLoading, error } = state;
 
   const { isWindowsTheme: isXpTheme, isMacOSTheme: isMacTheme } =
     useThemeFlags();
   const fetchSessions = useListenSessionStore((state) => state.fetchSessions);
 
   const loadSessions = useCallback(async () => {
-    setIsLoading(true);
-    setError(null);
+    dispatch({ type: "loadStart" });
     const result = await fetchSessions();
     if (result.ok && result.sessions) {
-      setSessions(result.sessions);
+      dispatch({ type: "loadSuccess", sessions: result.sessions });
     } else {
-      setError(result.error || "Failed to load sessions");
-      setSessions([]);
+      dispatch({
+        type: "loadError",
+        error: result.error || "Failed to load sessions",
+      });
     }
-    setIsLoading(false);
   }, [fetchSessions]);
 
   // Reset state when dialog opens
   useEffect(() => {
     if (isOpen) {
-      setValue("");
-      setSelectedIndex(-1);
-      setError(null);
+      dispatch({ type: "resetOnOpen" });
       loadSessions();
     }
   }, [isOpen, loadSessions]);
@@ -92,7 +132,7 @@ export function JoinSessionDialog({
       const id = sessionId || extractSessionId(value);
       if (!id) return;
       onJoin(id);
-      setValue("");
+      dispatch({ type: "clearValue" });
       onClose();
     },
     [value, onJoin, onClose]
@@ -107,7 +147,7 @@ export function JoinSessionDialog({
   const handleSelectAndJoin = useCallback(
     (index: number) => {
       if (index >= 0 && index < sessions.length) {
-        setSelectedIndex(index);
+        dispatch({ type: "setSelectedIndex", index });
         handleJoin(sessions[index].id);
       }
     },
@@ -182,7 +222,7 @@ export function JoinSessionDialog({
               sessions.map((session, index) => (
                 <div
                   key={session.id}
-                  onClick={() => setSelectedIndex(index)}
+                  onClick={() => dispatch({ type: "setSelectedIndex", index })}
                   onDoubleClick={() => handleSelectAndJoin(index)}
                   onKeyDown={(e: React.KeyboardEvent<HTMLDivElement>) => {
                     if (e.key === "Enter" || e.key === " ") {
@@ -267,7 +307,9 @@ export function JoinSessionDialog({
       <div className="flex gap-2">
         <Input
           value={value}
-          onChange={(e) => setValue(e.target.value)}
+          onChange={(e) =>
+            dispatch({ type: "setValue", value: e.target.value })
+          }
           onKeyDown={(e) => {
             e.stopPropagation();
             if (e.key === "Enter" && value.trim()) {

--- a/src/components/screensavers/BouncingLogo.tsx
+++ b/src/components/screensavers/BouncingLogo.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, useCallback } from "react";
+import { useEffect, useRef, useReducer, useCallback } from "react";
 
 const COLORS = [
   "#FF0000", // Red
@@ -15,13 +15,6 @@ const COLORS = [
 
 export function BouncingLogo() {
   const containerRef = useRef<HTMLDivElement>(null);
-  const [position, setPosition] = useState({ x: 100, y: 100 });
-  const [velocity, setVelocity] = useState({ x: 2, y: 2 });
-  const [colorIndex, setColorIndex] = useState(0);
-  const positionRef = useRef(position);
-  const velocityRef = useRef(velocity);
-  const colorIndexRef = useRef(colorIndex);
-
   // Calculate logo size based on viewport width (30% of viewport width)
   const getLogoSize = useCallback(() => {
     const vw = window.innerWidth;
@@ -30,14 +23,53 @@ export function BouncingLogo() {
     return { width, height };
   }, []);
 
-  const [logoSize, setLogoSize] = useState(getLogoSize);
+  type LogoState = {
+    position: { x: number; y: number };
+    velocity: { x: number; y: number };
+    colorIndex: number;
+    logoSize: { width: number; height: number };
+  };
+  type LogoAction =
+    | { type: "setLogoSize"; logoSize: { width: number; height: number } }
+    | {
+        type: "updateFrame";
+        position: { x: number; y: number };
+        velocity: { x: number; y: number };
+        colorIndex: number;
+      };
+  const initialState: LogoState = {
+    position: { x: 100, y: 100 },
+    velocity: { x: 2, y: 2 },
+    colorIndex: 0,
+    logoSize: getLogoSize(),
+  };
+  const reducer = (state: LogoState, action: LogoAction): LogoState => {
+    switch (action.type) {
+      case "setLogoSize":
+        return { ...state, logoSize: action.logoSize };
+      case "updateFrame":
+        return {
+          ...state,
+          position: action.position,
+          velocity: action.velocity,
+          colorIndex: action.colorIndex,
+        };
+      default:
+        return state;
+    }
+  };
+  const [state, dispatch] = useReducer(reducer, initialState);
+  const { position, velocity, colorIndex, logoSize } = state;
+  const positionRef = useRef(position);
+  const velocityRef = useRef(velocity);
+  const colorIndexRef = useRef(colorIndex);
   const logoSizeRef = useRef(logoSize);
 
   // Update logo size on window resize
   useEffect(() => {
     const handleResize = () => {
       const newSize = getLogoSize();
-      setLogoSize(newSize);
+      dispatch({ type: "setLogoSize", logoSize: newSize });
       logoSizeRef.current = newSize;
     };
     window.addEventListener("resize", handleResize);
@@ -76,14 +108,17 @@ export function BouncingLogo() {
       if (bounced) {
         currentColor = (currentColor + 1) % COLORS.length;
         colorIndexRef.current = currentColor;
-        setColorIndex(currentColor);
       }
 
       currentPos = { x: newX, y: newY };
       positionRef.current = currentPos;
       velocityRef.current = currentVel;
-      setPosition(currentPos);
-      setVelocity(currentVel);
+      dispatch({
+        type: "updateFrame",
+        position: currentPos,
+        velocity: { x: currentVel.x, y: currentVel.y },
+        colorIndex: currentColor,
+      });
 
       animationId = requestAnimationFrame(animate);
     };

--- a/src/components/screensavers/ScreenSaverOverlay.tsx
+++ b/src/components/screensavers/ScreenSaverOverlay.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useCallback, lazy, Suspense } from "react";
+import { useEffect, useReducer, useCallback, lazy, Suspense } from "react";
 import { useDisplaySettingsStoreShallow } from "@/stores/helpers";
 import { motion, AnimatePresence } from "framer-motion";
 import type { ScreenSaverType } from "./index";
@@ -33,15 +33,45 @@ export function ScreenSaverOverlay() {
     screenSaverIdleTime: s.screenSaverIdleTime,
   }));
 
-  const [isActive, setIsActive] = useState(false);
-  const [isPreviewMode, setIsPreviewMode] = useState(false);
-  const [previewType, setPreviewType] = useState<string | null>(null);
+  type ScreenSaverState = {
+    isActive: boolean;
+    isPreviewMode: boolean;
+    previewType: string | null;
+  };
+  type ScreenSaverAction =
+    | { type: "dismiss" }
+    | { type: "activateIdle" }
+    | { type: "activatePreview"; previewType: string };
+  const initialState: ScreenSaverState = {
+    isActive: false,
+    isPreviewMode: false,
+    previewType: null,
+  };
+  const reducer = (
+    state: ScreenSaverState,
+    action: ScreenSaverAction
+  ): ScreenSaverState => {
+    switch (action.type) {
+      case "dismiss":
+        return initialState;
+      case "activateIdle":
+        return { ...state, isActive: true, isPreviewMode: false, previewType: null };
+      case "activatePreview":
+        return {
+          isActive: true,
+          isPreviewMode: true,
+          previewType: action.previewType,
+        };
+      default:
+        return state;
+    }
+  };
+  const [state, dispatch] = useReducer(reducer, initialState);
+  const { isActive, isPreviewMode, previewType } = state;
 
   // Dismiss screen saver
   const dismiss = useCallback(() => {
-    setIsActive(false);
-    setIsPreviewMode(false);
-    setPreviewType(null);
+    dispatch({ type: "dismiss" });
     window.dispatchEvent(new CustomEvent("screenSaverDismiss"));
   }, []);
 
@@ -64,7 +94,7 @@ export function ScreenSaverOverlay() {
       const idleTimeMs = screenSaverIdleTime * 60 * 1000;
 
       if (idleTime >= idleTimeMs && !isActive) {
-        setIsActive(true);
+        dispatch({ type: "activateIdle" });
       }
 
       timeoutId = setTimeout(checkIdle, 1000);
@@ -90,9 +120,7 @@ export function ScreenSaverOverlay() {
   // Handle preview mode
   useEffect(() => {
     const handlePreview = (e: CustomEvent<{ type: string }>) => {
-      setPreviewType(e.detail.type);
-      setIsPreviewMode(true);
-      setIsActive(true);
+      dispatch({ type: "activatePreview", previewType: e.detail.type });
     };
 
     window.addEventListener("screenSaverPreview", handlePreview as EventListener);

--- a/src/components/shared/LandscapeVideoBackground.tsx
+++ b/src/components/shared/LandscapeVideoBackground.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useCallback } from "react";
+import { useReducer, useEffect, useRef, useCallback } from "react";
 import { loadWallpaperManifest } from "@/utils/wallpapers";
 
 /** Duration each landscape video plays before crossfading to the next (ms) */
@@ -24,17 +24,74 @@ export function LandscapeVideoBackground({
   isActive,
   className = "",
 }: LandscapeVideoBackgroundProps) {
-  const [videos, setVideos] = useState<string[]>([]);
-  const [currentIndex, setCurrentIndex] = useState(0);
-  const [showB, setShowB] = useState(false);
-  const [activeVideoDurationMs, setActiveVideoDurationMs] = useState<number | null>(null);
+  type BackgroundState = {
+    videos: string[];
+    currentIndex: number;
+    showB: boolean;
+    activeVideoDurationMs: number | null;
+    srcA: string;
+    srcB: string;
+  };
+  type BackgroundAction =
+    | { type: "initializeVideos"; videos: string[] }
+    | { type: "advanceVideo" }
+    | { type: "setActiveVideoDuration"; durationMs: number | null };
+  const initialState: BackgroundState = {
+    videos: [],
+    currentIndex: 0,
+    showB: false,
+    activeVideoDurationMs: null,
+    srcA: "",
+    srcB: "",
+  };
+  const reducer = (
+    state: BackgroundState,
+    action: BackgroundAction
+  ): BackgroundState => {
+    switch (action.type) {
+      case "initializeVideos": {
+        const videos = action.videos;
+        return {
+          ...state,
+          videos,
+          currentIndex: 0,
+          showB: false,
+          activeVideoDurationMs: null,
+          srcA: videos[0] ?? "",
+          srcB: videos[1] ?? "",
+        };
+      }
+      case "advanceVideo": {
+        if (state.videos.length <= 1) return state;
+        const nextIdx = (state.currentIndex + 1) % state.videos.length;
+        if (state.showB) {
+          return {
+            ...state,
+            currentIndex: nextIdx,
+            showB: false,
+            srcA: state.videos[nextIdx],
+            activeVideoDurationMs: null,
+          };
+        }
+        return {
+          ...state,
+          currentIndex: nextIdx,
+          showB: true,
+          srcB: state.videos[nextIdx],
+          activeVideoDurationMs: null,
+        };
+      }
+      case "setActiveVideoDuration":
+        return { ...state, activeVideoDurationMs: action.durationMs };
+      default:
+        return state;
+    }
+  };
+  const [state, dispatch] = useReducer(reducer, initialState);
+  const { videos, showB, activeVideoDurationMs, srcA, srcB } = state;
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const videoARef = useRef<HTMLVideoElement | null>(null);
   const videoBRef = useRef<HTMLVideoElement | null>(null);
-
-  // Track which src each slot holds
-  const [srcA, setSrcA] = useState<string>("");
-  const [srcB, setSrcB] = useState<string>("");
 
   // Load video wallpaper list from manifest
   useEffect(() => {
@@ -45,13 +102,7 @@ export function LandscapeVideoBackground({
         const videoPaths = manifest.videos.map((p) => `/wallpapers/${p}`);
         // Shuffle so it's different each session
         const shuffled = [...videoPaths].sort(() => Math.random() - 0.5);
-        setVideos(shuffled);
-        if (shuffled.length > 0) {
-          setSrcA(shuffled[0]);
-          if (shuffled.length > 1) {
-            setSrcB(shuffled[1]);
-          }
-        }
+        dispatch({ type: "initializeVideos", videos: shuffled });
       })
       .catch((err) => {
         console.warn("[LandscapeVideoBackground] Failed to load manifest:", err);
@@ -86,23 +137,8 @@ export function LandscapeVideoBackground({
 
   // Advance to next video with crossfade
   const advanceVideo = useCallback(() => {
-    if (videos.length <= 1) return;
-
-    const nextIdx = (currentIndex + 1) % videos.length;
-    setActiveVideoDurationMs(null);
-
-    if (showB) {
-      // B is visible → load next into A, then show A
-      setSrcA(videos[nextIdx]);
-      setShowB(false);
-    } else {
-      // A is visible → load next into B, then show B
-      setSrcB(videos[nextIdx]);
-      setShowB(true);
-    }
-
-    setCurrentIndex(nextIdx);
-  }, [videos, currentIndex, showB]);
+    dispatch({ type: "advanceVideo" });
+  }, []);
 
   // Schedule periodic advancement
   useEffect(() => {
@@ -176,7 +212,10 @@ export function LandscapeVideoBackground({
           if (showB) return;
           const durationMs = e.currentTarget.duration * 1000;
           if (Number.isFinite(durationMs) && durationMs > 0) {
-            setActiveVideoDurationMs(durationMs);
+            dispatch({
+              type: "setActiveVideoDuration",
+              durationMs,
+            });
           }
         }}
         className="absolute inset-0 w-full h-full object-cover"
@@ -206,7 +245,10 @@ export function LandscapeVideoBackground({
             if (!showB) return;
             const durationMs = e.currentTarget.duration * 1000;
             if (Number.isFinite(durationMs) && durationMs > 0) {
-              setActiveVideoDurationMs(durationMs);
+              dispatch({
+                type: "setActiveVideoDuration",
+                durationMs,
+              });
             }
           }}
           className="absolute inset-0 w-full h-full object-cover"

--- a/src/components/shared/LinkPreview.tsx
+++ b/src/components/shared/LinkPreview.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useReducer, useEffect } from "react";
 import { motion } from "framer-motion";
 import { WarningCircle, MusicNote, ArrowSquareOut, Microphone } from "@phosphor-icons/react";
 import { useLaunchApp } from "@/hooks/useLaunchApp";
@@ -31,13 +31,56 @@ export function LinkPreview({ url, className = "" }: LinkPreviewProps) {
     );
   };
 
-  const [metadata, setMetadata] = useState<LinkMetadata | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-  const [isFullWidthThumbnail, setIsFullWidthThumbnail] = useState(() => {
-    // YouTube links should always start as full width
-    return isYouTubeUrl(url);
-  });
+  type LinkPreviewState = {
+    metadata: LinkMetadata | null;
+    loading: boolean;
+    error: string | null;
+    isFullWidthThumbnail: boolean;
+  };
+  type LinkPreviewAction =
+    | { type: "resetForUrl"; isFullWidthThumbnail: boolean }
+    | { type: "fetchStart" }
+    | { type: "fetchSuccess"; metadata: LinkMetadata }
+    | { type: "fetchFailure"; error: string; metadata: LinkMetadata }
+    | { type: "setFullWidthThumbnail"; enabled: boolean };
+  const initialState: LinkPreviewState = {
+    metadata: null,
+    loading: true,
+    error: null,
+    isFullWidthThumbnail: isYouTubeUrl(url),
+  };
+  const reducer = (
+    state: LinkPreviewState,
+    action: LinkPreviewAction
+  ): LinkPreviewState => {
+    switch (action.type) {
+      case "resetForUrl":
+        return {
+          ...state,
+          isFullWidthThumbnail: action.isFullWidthThumbnail,
+          metadata: null,
+          loading: true,
+          error: null,
+        };
+      case "fetchStart":
+        return { ...state, loading: true, error: null };
+      case "fetchSuccess":
+        return { ...state, metadata: action.metadata, loading: false, error: null };
+      case "fetchFailure":
+        return {
+          ...state,
+          metadata: action.metadata,
+          loading: false,
+          error: action.error,
+        };
+      case "setFullWidthThumbnail":
+        return { ...state, isFullWidthThumbnail: action.enabled };
+      default:
+        return state;
+    }
+  };
+  const [state, dispatch] = useReducer(reducer, initialState);
+  const { metadata, loading, error, isFullWidthThumbnail } = state;
   const launchApp = useLaunchApp();
   const { isMacOSTheme } = useThemeFlags();
 
@@ -168,14 +211,17 @@ export function LinkPreview({ url, className = "" }: LinkPreviewProps) {
   };
 
   useEffect(() => {
+    dispatch({
+      type: "resetForUrl",
+      isFullWidthThumbnail: isYouTubeUrl(url),
+    });
     const abortController = new AbortController();
     let isActive = true;
 
     const fetchMetadata = async () => {
       try {
         if (!isActive || abortController.signal.aborted) return;
-        setLoading(true);
-        setError(null);
+        dispatch({ type: "fetchStart" });
 
         // Handle /ipod/ or /karaoke/ links specially - use YouTube metadata
         if (url.includes("/ipod/") || url.includes("/karaoke/")) {
@@ -196,14 +242,17 @@ export function LinkPreview({ url, className = "" }: LinkPreviewProps) {
 
               const youtubeData = await youtubeResponse.json();
               if (!youtubeData.error && isActive && !abortController.signal.aborted) {
-                setMetadata({
-                  title: youtubeData.title,
-                  description: youtubeData.description,
-                  image:
-                    youtubeData.image ||
-                    `https://img.youtube.com/vi/${videoId}/maxresdefault.jpg`,
-                  siteName: "YouTube",
-                  url: url,
+                dispatch({
+                  type: "fetchSuccess",
+                  metadata: {
+                    title: youtubeData.title,
+                    description: youtubeData.description,
+                    image:
+                      youtubeData.image ||
+                      `https://img.youtube.com/vi/${videoId}/maxresdefault.jpg`,
+                    siteName: "YouTube",
+                    url: url,
+                  },
                 });
                 return;
               }
@@ -222,12 +271,15 @@ export function LinkPreview({ url, className = "" }: LinkPreviewProps) {
 
             // Fallback to basic YouTube-style metadata
             if (!isActive || abortController.signal.aborted) return;
-            setMetadata({
-              title: `YouTube Video ${videoId}`,
-              description: "Watch on YouTube",
-              image: `https://img.youtube.com/vi/${videoId}/maxresdefault.jpg`,
-              siteName: "YouTube",
-              url: url,
+            dispatch({
+              type: "fetchSuccess",
+              metadata: {
+                title: `YouTube Video ${videoId}`,
+                description: "Watch on YouTube",
+                image: `https://img.youtube.com/vi/${videoId}/maxresdefault.jpg`,
+                siteName: "YouTube",
+                url: url,
+              },
             });
             return;
           }
@@ -250,12 +302,15 @@ export function LinkPreview({ url, className = "" }: LinkPreviewProps) {
           throw new Error(data.error);
         }
 
-        setMetadata({
-          title: data.title,
-          description: data.description,
-          image: data.image,
-          siteName: data.siteName,
-          url: url,
+        dispatch({
+          type: "fetchSuccess",
+          metadata: {
+            title: data.title,
+            description: data.description,
+            image: data.image,
+            siteName: data.siteName,
+            url: url,
+          },
         });
       } catch (err) {
         if (err instanceof Error && err.name === "AbortError") {
@@ -263,16 +318,14 @@ export function LinkPreview({ url, className = "" }: LinkPreviewProps) {
         }
         if (!isActive || abortController.signal.aborted) return;
         console.error("Error fetching link metadata:", err);
-        setError("Failed to load preview");
-        // Set basic metadata with just the URL
-        setMetadata({
-          title: url,
-          url: url,
+        dispatch({
+          type: "fetchFailure",
+          error: "Failed to load preview",
+          metadata: {
+            title: url,
+            url: url,
+          },
         });
-      } finally {
-        if (isActive && !abortController.signal.aborted) {
-          setLoading(false);
-        }
       }
     };
 
@@ -613,7 +666,10 @@ export function LinkPreview({ url, className = "" }: LinkPreviewProps) {
                       isYouTubeUrl(url) || aspectRatio > 1.5;
 
                     if (shouldBeFullWidth) {
-                      setIsFullWidthThumbnail(true);
+                      dispatch({
+                        type: "setFullWidthThumbnail",
+                        enabled: true,
+                      });
                     }
                   }}
                 />

--- a/src/components/shared/VideoFullScreenPortal.tsx
+++ b/src/components/shared/VideoFullScreenPortal.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect, useCallback, type ReactNode } from "react";
+import { useReducer, useRef, useEffect, useCallback, type ReactNode } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { createPortal } from "react-dom";
 import type ReactPlayer from "react-player";
@@ -43,6 +43,31 @@ interface VideoFullScreenPortalProps {
   videoOverlay?: ReactNode;
 }
 
+interface PortalUiState {
+  showControls: boolean;
+  isLangMenuOpen: boolean;
+}
+
+const initialState: PortalUiState = {
+  showControls: true,
+  isLangMenuOpen: false,
+};
+
+type PortalUiAction =
+  | { type: "setShowControls"; value: boolean }
+  | { type: "setLangMenuOpen"; value: boolean };
+
+function reducer(state: PortalUiState, action: PortalUiAction): PortalUiState {
+  switch (action.type) {
+    case "setShowControls":
+      return { ...state, showControls: action.value };
+    case "setLangMenuOpen":
+      return { ...state, isLangMenuOpen: action.value };
+    default:
+      return state;
+  }
+}
+
 export function VideoFullScreenPortal({
   isOpen,
   onClose,
@@ -71,8 +96,17 @@ export function VideoFullScreenPortal({
 }: VideoFullScreenPortalProps) {
   const { t } = useTranslation();
   const containerRef = useRef<HTMLDivElement>(null);
-  const [showControls, setShowControls] = useState(true);
-  const [isLangMenuOpen, setIsLangMenuOpen] = useState(false);
+  const [state, dispatch] = useReducer(reducer, initialState);
+  const { showControls, isLangMenuOpen } = state;
+  const setIsLangMenuOpen = useCallback(
+    (value: boolean | ((prev: boolean) => boolean)) => {
+      dispatch({
+        type: "setLangMenuOpen",
+        value: typeof value === "function" ? value(state.isLangMenuOpen) : value,
+      });
+    },
+    [state.isLangMenuOpen]
+  );
   const hideControlsTimeoutRef = useRef<number | null>(null);
 
   const getActualPlayerState = useCallback(() => {
@@ -85,14 +119,14 @@ export function VideoFullScreenPortal({
   }, [playerRef, isPlaying]);
 
   const restartAutoHideTimer = useCallback(() => {
-    setShowControls(true);
+    dispatch({ type: "setShowControls", value: true });
     if (hideControlsTimeoutRef.current) {
       clearTimeout(hideControlsTimeoutRef.current);
     }
     const actuallyPlaying = getActualPlayerState();
     if (actuallyPlaying && !isLangMenuOpen) {
       hideControlsTimeoutRef.current = window.setTimeout(() => {
-        setShowControls(false);
+        dispatch({ type: "setShowControls", value: false });
       }, 2000);
     }
   }, [getActualPlayerState, isLangMenuOpen]);
@@ -130,14 +164,14 @@ export function VideoFullScreenPortal({
     if (!isOpen) return;
 
     const handleActivity = () => {
-      setShowControls(true);
+      dispatch({ type: "setShowControls", value: true });
       if (hideControlsTimeoutRef.current) {
         clearTimeout(hideControlsTimeoutRef.current);
       }
       const actuallyPlaying = getActualPlayerState();
       if (actuallyPlaying && !isLangMenuOpen) {
         hideControlsTimeoutRef.current = window.setTimeout(() => {
-          setShowControls(false);
+          dispatch({ type: "setShowControls", value: false });
         }, 2000);
       }
     };
@@ -150,7 +184,7 @@ export function VideoFullScreenPortal({
     const actuallyPlayingOnMount = getActualPlayerState();
     if (actuallyPlayingOnMount && !isLangMenuOpen) {
       hideControlsTimeoutRef.current = window.setTimeout(() => {
-        setShowControls(false);
+        dispatch({ type: "setShowControls", value: false });
       }, 2000);
     }
 

--- a/src/components/shared/useCursorAgentRunPoll.ts
+++ b/src/components/shared/useCursorAgentRunPoll.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useReducer, useRef } from "react";
 import { abortableFetch } from "@/utils/abortableFetch";
 import { getApiUrl } from "@/utils/platform";
 
@@ -84,21 +84,75 @@ export interface UseCursorAgentRunPollResult {
 export function useCursorAgentRunPoll(
   initialRunId: string
 ): UseCursorAgentRunPollResult {
-  const [events, setEvents] = useState<unknown[]>([]);
-  const [done, setDone] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const [meta, setMeta] = useState<CursorAgentRunMeta>({});
-  const [activeRunId, setActiveRunId] = useState(initialRunId);
-  const [isSendingFollowup, setIsSendingFollowup] = useState(false);
-  const [followupError, setFollowupError] = useState<string | null>(null);
+  interface CursorAgentRunPollState {
+    events: unknown[];
+    done: boolean;
+    error: string | null;
+    meta: CursorAgentRunMeta;
+    activeRunId: string;
+    isSendingFollowup: boolean;
+    followupError: string | null;
+  }
+
+  const initialState: CursorAgentRunPollState = {
+    events: [],
+    done: false,
+    error: null,
+    meta: {},
+    activeRunId: initialRunId,
+    isSendingFollowup: false,
+    followupError: null,
+  };
+
+  type CursorAgentRunPollAction =
+    | { type: "patch"; payload: Partial<CursorAgentRunPollState> }
+    | { type: "resetForInitialRun"; initialRunId: string }
+    | { type: "mergeMeta"; payload: CursorAgentRunMeta };
+
+  const reducer = (
+    state: CursorAgentRunPollState,
+    action: CursorAgentRunPollAction
+  ): CursorAgentRunPollState => {
+    switch (action.type) {
+      case "patch":
+        return { ...state, ...action.payload };
+      case "resetForInitialRun":
+        return {
+          ...state,
+          activeRunId: action.initialRunId,
+          events: [],
+          done: false,
+          error: null,
+          meta: {},
+        };
+      case "mergeMeta": {
+        const merged: CursorAgentRunMeta = { ...state.meta, ...action.payload };
+        if (!merged.agentTitle && state.meta.agentTitle) {
+          merged.agentTitle = state.meta.agentTitle;
+        }
+        if (!merged.prUrl && state.meta.prUrl) merged.prUrl = state.meta.prUrl;
+        if (!merged.agentId && state.meta.agentId) merged.agentId = state.meta.agentId;
+        return { ...state, meta: merged };
+      }
+      default:
+        return state;
+    }
+  };
+
+  const [state, dispatch] = useReducer(reducer, initialState);
+  const {
+    events,
+    done,
+    error,
+    meta,
+    activeRunId,
+    isSendingFollowup,
+    followupError,
+  } = state;
   const tickRef = useRef<(force?: boolean) => Promise<void>>(async () => {});
 
   useEffect(() => {
-    setActiveRunId(initialRunId);
-    setEvents([]);
-    setDone(false);
-    setError(null);
-    setMeta({});
+    dispatch({ type: "resetForInitialRun", initialRunId });
   }, [initialRunId]);
 
   useEffect(() => {
@@ -121,36 +175,37 @@ export function useCursorAgentRunPoll(
         if (cancelled) return;
 
         const newEvents = Array.isArray(data.events) ? data.events : [];
-        setEvents(newEvents);
-        setError(null);
+        dispatch({
+          type: "patch",
+          payload: { events: newEvents, error: null },
+        });
 
         const m = pickMeta(data);
-        setMeta((prev) => {
-          const merged: CursorAgentRunMeta = { ...prev, ...m };
-          // Title once-set should not flip to undefined just because a poll missed it.
-          if (!merged.agentTitle && prev.agentTitle) {
-            merged.agentTitle = prev.agentTitle;
-          }
-          if (!merged.prUrl && prev.prUrl) merged.prUrl = prev.prUrl;
-          if (!merged.agentId && prev.agentId) merged.agentId = prev.agentId;
-          return merged;
-        });
+        dispatch({ type: "mergeMeta", payload: m });
 
         // If a follow-up has been queued, swap to it on the next tick.
         if (m.nextRunId && m.nextRunId !== activeRunId) {
-          setActiveRunId(m.nextRunId);
-          setDone(false);
-          setEvents([]);
+          dispatch({
+            type: "patch",
+            payload: {
+              activeRunId: m.nextRunId,
+              done: false,
+              events: [],
+            },
+          });
           return;
         }
 
-        if (data.done) setDone(true);
+        if (data.done) dispatch({ type: "patch", payload: { done: true } });
         // After a force-refresh ping, if the server reports the run is now
         // done, stop polling immediately on this tick.
-        if (force && data.done) setDone(true);
+        if (force && data.done) dispatch({ type: "patch", payload: { done: true } });
       } catch (e) {
         if (!cancelled) {
-          setError(e instanceof Error ? e.message : String(e));
+          dispatch({
+            type: "patch",
+            payload: { error: e instanceof Error ? e.message : String(e) },
+          });
         }
       }
     }
@@ -170,15 +225,23 @@ export function useCursorAgentRunPoll(
     async (prompt: string) => {
       const trimmed = prompt.trim();
       if (!trimmed) {
-        setFollowupError("Prompt is required");
+        dispatch({
+          type: "patch",
+          payload: { followupError: "Prompt is required" },
+        });
         return;
       }
       if (!activeRunId) {
-        setFollowupError("No active run");
+        dispatch({
+          type: "patch",
+          payload: { followupError: "No active run" },
+        });
         return;
       }
-      setIsSendingFollowup(true);
-      setFollowupError(null);
+      dispatch({
+        type: "patch",
+        payload: { isSendingFollowup: true, followupError: null },
+      });
       try {
         const res = await abortableFetch(
           getApiUrl("/api/ai/cursor-run-followup"),
@@ -202,24 +265,32 @@ export function useCursorAgentRunPoll(
         if (typeof data.runId !== "string" || data.runId.length === 0) {
           throw new Error("Server did not return a new runId");
         }
-        setActiveRunId(data.runId);
-        setEvents([]);
-        setDone(false);
-        setMeta((prev) => ({
-          ...prev,
-          nextRunId: undefined,
-          activeRunId: data.runId,
-          terminalStatus: undefined,
-        }));
+        dispatch({
+          type: "patch",
+          payload: {
+            activeRunId: data.runId,
+            events: [],
+            done: false,
+            meta: {
+              ...meta,
+              nextRunId: undefined,
+              activeRunId: data.runId,
+              terminalStatus: undefined,
+            },
+          },
+        });
         // Kick a quick refresh so the spinner shows immediately.
         void tickRef.current?.(true);
       } catch (e) {
-        setFollowupError(e instanceof Error ? e.message : String(e));
+        dispatch({
+          type: "patch",
+          payload: { followupError: e instanceof Error ? e.message : String(e) },
+        });
       } finally {
-        setIsSendingFollowup(false);
+        dispatch({ type: "patch", payload: { isSendingFollowup: false } });
       }
     },
-    [activeRunId]
+    [activeRunId, meta]
   );
 
   return {

--- a/src/components/ui/SwipeInstructions.tsx
+++ b/src/components/ui/SwipeInstructions.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useEffect, useReducer } from "react";
 import { useTranslation } from "react-i18next";
 import { X } from "@phosphor-icons/react";
 import { cn } from "@/lib/utils";
@@ -8,10 +8,41 @@ interface SwipeInstructionsProps {
   className?: string;
 }
 
+interface SwipeInstructionsState {
+  isVisible: boolean;
+  shouldRender: boolean;
+}
+
+const initialState: SwipeInstructionsState = {
+  isVisible: false,
+  shouldRender: false,
+};
+
+type SwipeInstructionsAction =
+  | { type: "showContainer" }
+  | { type: "setVisible"; value: boolean }
+  | { type: "hideContainer" };
+
+function reducer(
+  state: SwipeInstructionsState,
+  action: SwipeInstructionsAction
+): SwipeInstructionsState {
+  switch (action.type) {
+    case "showContainer":
+      return { ...state, shouldRender: true };
+    case "setVisible":
+      return { ...state, isVisible: action.value };
+    case "hideContainer":
+      return { ...state, shouldRender: false };
+    default:
+      return state;
+  }
+}
+
 export function SwipeInstructions({ className }: SwipeInstructionsProps) {
   const { t } = useTranslation();
-  const [isVisible, setIsVisible] = useState(false);
-  const [shouldRender, setShouldRender] = useState(false);
+  const [state, dispatch] = useReducer(reducer, initialState);
+  const { isVisible, shouldRender } = state;
   const isMobile = useIsMobile();
 
   useEffect(() => {
@@ -24,9 +55,12 @@ export function SwipeInstructions({ className }: SwipeInstructionsProps) {
     if (shouldShow) {
       // Delay showing the instructions to not interfere with initial app loading
       const timer = setTimeout(() => {
-        setShouldRender(true);
+        dispatch({ type: "showContainer" });
         // Use a separate state for animation
-        const animationTimer = setTimeout(() => setIsVisible(true), 100);
+        const animationTimer = setTimeout(
+          () => dispatch({ type: "setVisible", value: true }),
+          100
+        );
         return () => clearTimeout(animationTimer);
       }, 1500);
 
@@ -35,13 +69,13 @@ export function SwipeInstructions({ className }: SwipeInstructionsProps) {
   }, [isMobile]);
 
   const handleDismiss = () => {
-    setIsVisible(false);
+    dispatch({ type: "setVisible", value: false });
     localStorage.setItem("ryos:has-seen-swipe-instructions", "true");
     // Clean up legacy key
     localStorage.removeItem("hasSeenSwipeInstructions");
 
     // Remove from DOM after animation completes
-    setTimeout(() => setShouldRender(false), 300);
+    setTimeout(() => dispatch({ type: "hideContainer" }), 300);
   };
 
   if (!shouldRender) return null;

--- a/src/components/ui/dial.tsx
+++ b/src/components/ui/dial.tsx
@@ -15,6 +15,54 @@ interface DialProps {
   className?: string;
 }
 
+interface DialDragState {
+  isDragging: boolean;
+  isDraggingValue: boolean;
+  startX: number;
+  startValue: number;
+}
+
+const initialState: DialDragState = {
+  isDragging: false,
+  isDraggingValue: false,
+  startX: 0,
+  startValue: 0,
+};
+
+type DialDragAction =
+  | { type: "startDialDrag"; startX: number; startValue: number }
+  | { type: "startValueDrag"; startX: number; startValue: number }
+  | { type: "stopDragging" };
+
+function reducer(state: DialDragState, action: DialDragAction): DialDragState {
+  switch (action.type) {
+    case "startDialDrag":
+      return {
+        ...state,
+        isDragging: true,
+        isDraggingValue: false,
+        startX: action.startX,
+        startValue: action.startValue,
+      };
+    case "startValueDrag":
+      return {
+        ...state,
+        isDragging: false,
+        isDraggingValue: true,
+        startX: action.startX,
+        startValue: action.startValue,
+      };
+    case "stopDragging":
+      return {
+        ...state,
+        isDragging: false,
+        isDraggingValue: false,
+      };
+    default:
+      return state;
+  }
+}
+
 const Dial = React.forwardRef<HTMLDivElement, DialProps>(
   (
     {
@@ -34,39 +82,45 @@ const Dial = React.forwardRef<HTMLDivElement, DialProps>(
   ) => {
     const dialRef = React.useRef<HTMLDivElement>(null);
     const valueRef = React.useRef<HTMLDivElement>(null);
-    const [isDragging, setIsDragging] = React.useState(false);
-    const [isDraggingValue, setIsDraggingValue] = React.useState(false);
-    const [startX, setStartX] = React.useState(0);
-    const [startValue, setStartValue] = React.useState(0);
+    const [dragState, dispatch] = React.useReducer(reducer, initialState);
+    const { isDragging, isDraggingValue, startX, startValue } = dragState;
 
     const handleMouseDown = (e: React.MouseEvent) => {
       e.preventDefault();
-      setIsDragging(true);
-      setStartX(e.clientX);
-      setStartValue(value);
+      dispatch({
+        type: "startDialDrag",
+        startX: e.clientX,
+        startValue: value,
+      });
     };
 
     const handleValueMouseDown = (e: React.MouseEvent) => {
       e.preventDefault();
       e.stopPropagation();
-      setIsDraggingValue(true);
-      setStartX(e.clientX);
-      setStartValue(value);
+      dispatch({
+        type: "startValueDrag",
+        startX: e.clientX,
+        startValue: value,
+      });
     };
 
     const handleTouchStart = (e: React.TouchEvent) => {
       e.preventDefault();
-      setIsDragging(true);
-      setStartX(e.touches[0].clientX);
-      setStartValue(value);
+      dispatch({
+        type: "startDialDrag",
+        startX: e.touches[0].clientX,
+        startValue: value,
+      });
     };
 
     const handleValueTouchStart = (e: React.TouchEvent) => {
       e.preventDefault();
       e.stopPropagation();
-      setIsDraggingValue(true);
-      setStartX(e.touches[0].clientX);
-      setStartValue(value);
+      dispatch({
+        type: "startValueDrag",
+        startX: e.touches[0].clientX,
+        startValue: value,
+      });
     };
 
     const handleMove = React.useCallback(
@@ -110,13 +164,11 @@ const Dial = React.forwardRef<HTMLDivElement, DialProps>(
       };
 
       const handleGlobalMouseUp = () => {
-        setIsDragging(false);
-        setIsDraggingValue(false);
+        dispatch({ type: "stopDragging" });
       };
 
       const handleGlobalTouchEnd = () => {
-        setIsDragging(false);
-        setIsDraggingValue(false);
+        dispatch({ type: "stopDragging" });
       };
 
       if (isDragging || isDraggingValue) {

--- a/src/hooks/useCoverPalette.ts
+++ b/src/hooks/useCoverPalette.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useReducer, useEffect } from "react";
 
 const DEFAULT_PALETTE = [
   "#274754",
@@ -133,11 +133,34 @@ function extractPaletteFromImage(img: HTMLImageElement): string[] {
  * Returns default palette while loading or on CORS/load error.
  */
 export function useCoverPalette(coverUrl: string | null): string[] {
-  const [palette, setPalette] = useState<string[]>(DEFAULT_PALETTE);
+  interface CoverPaletteState {
+    palette: string[];
+  }
+
+  const initialState: CoverPaletteState = {
+    palette: DEFAULT_PALETTE,
+  };
+
+  type CoverPaletteAction = { type: "setPalette"; palette: string[] };
+
+  const reducer = (
+    state: CoverPaletteState,
+    action: CoverPaletteAction
+  ): CoverPaletteState => {
+    switch (action.type) {
+      case "setPalette":
+        return { ...state, palette: action.palette };
+      default:
+        return state;
+    }
+  };
+
+  const [state, dispatch] = useReducer(reducer, initialState);
+  const { palette } = state;
 
   useEffect(() => {
     if (!coverUrl) {
-      setPalette(DEFAULT_PALETTE);
+      dispatch({ type: "setPalette", palette: DEFAULT_PALETTE });
       return;
     }
 
@@ -146,14 +169,14 @@ export function useCoverPalette(coverUrl: string | null): string[] {
 
     img.onload = () => {
       try {
-        setPalette(extractPaletteFromImage(img));
+        dispatch({ type: "setPalette", palette: extractPaletteFromImage(img) });
       } catch {
-        setPalette(DEFAULT_PALETTE);
+        dispatch({ type: "setPalette", palette: DEFAULT_PALETTE });
       }
     };
 
     img.onerror = () => {
-      setPalette(DEFAULT_PALETTE);
+      dispatch({ type: "setPalette", palette: DEFAULT_PALETTE });
     };
 
     img.src = coverUrl;

--- a/src/hooks/useFurigana.tsx
+++ b/src/hooks/useFurigana.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect, useCallback, useMemo } from "react";
+import { useReducer, useRef, useEffect, useCallback, useMemo } from "react";
 import { useLatestRef } from "@/hooks/useLatestRef";
 import type { LyricLine, RomanizationSettings } from "@/types/lyrics";
 import { useCacheBustTrigger } from "@/hooks/useCacheBustTrigger";
@@ -88,14 +88,75 @@ export function useFurigana({
   prefetchedSoramimiInfo,
   auth,
 }: UseFuriganaParams): UseFuriganaReturn {
-  const [furiganaMap, setFuriganaMap] = useState<Map<string, FuriganaSegment[]>>(new Map());
-  const [soramimiMap, setSoramimiMap] = useState<Map<string, FuriganaSegment[]>>(new Map());
-  const [isFetchingFurigana, setIsFetchingFurigana] = useState(false);
-  const [isFetchingSoramimi, setIsFetchingSoramimi] = useState(false);
-  const [progress, setProgress] = useState<number | undefined>();
-  const [furiganaProgress, setFuriganaProgress] = useState<number | undefined>();
-  const [soramimiProgress, setSoramimiProgress] = useState<number | undefined>();
-  const [error, setError] = useState<string>();
+  interface FuriganaState {
+    furiganaMap: Map<string, FuriganaSegment[]>;
+    soramimiMap: Map<string, FuriganaSegment[]>;
+    isFetchingFurigana: boolean;
+    isFetchingSoramimi: boolean;
+    progress: number | undefined;
+    furiganaProgress: number | undefined;
+    soramimiProgress: number | undefined;
+    error: string | undefined;
+  }
+
+  const initialState: FuriganaState = {
+    furiganaMap: new Map(),
+    soramimiMap: new Map(),
+    isFetchingFurigana: false,
+    isFetchingSoramimi: false,
+    progress: undefined,
+    furiganaProgress: undefined,
+    soramimiProgress: undefined,
+    error: undefined,
+  };
+
+  type FuriganaAction = { type: "patch"; payload: Partial<FuriganaState> };
+
+  const reducer = (state: FuriganaState, action: FuriganaAction): FuriganaState => {
+    switch (action.type) {
+      case "patch":
+        return { ...state, ...action.payload };
+      default:
+        return state;
+    }
+  };
+
+  const [state, dispatch] = useReducer(reducer, initialState);
+  const {
+    furiganaMap,
+    soramimiMap,
+    isFetchingFurigana,
+    isFetchingSoramimi,
+    progress,
+    furiganaProgress,
+    soramimiProgress,
+    error,
+  } = state;
+
+  const setFuriganaMap = useCallback((value: Map<string, FuriganaSegment[]>) => {
+    dispatch({ type: "patch", payload: { furiganaMap: value } });
+  }, []);
+  const setSoramimiMap = useCallback((value: Map<string, FuriganaSegment[]>) => {
+    dispatch({ type: "patch", payload: { soramimiMap: value } });
+  }, []);
+  const setIsFetchingFurigana = useCallback((value: boolean) => {
+    dispatch({ type: "patch", payload: { isFetchingFurigana: value } });
+  }, []);
+  const setIsFetchingSoramimi = useCallback((value: boolean) => {
+    dispatch({ type: "patch", payload: { isFetchingSoramimi: value } });
+  }, []);
+  const setProgress = useCallback((value: number | undefined) => {
+    dispatch({ type: "patch", payload: { progress: value } });
+  }, []);
+  const setFuriganaProgress = useCallback((value: number | undefined) => {
+    dispatch({ type: "patch", payload: { furiganaProgress: value } });
+  }, []);
+  const setSoramimiProgress = useCallback((value: number | undefined) => {
+    dispatch({ type: "patch", payload: { soramimiProgress: value } });
+  }, []);
+  const setError = useCallback((value: string | undefined) => {
+    dispatch({ type: "patch", payload: { error: value } });
+  }, []);
   
   // Combined fetching state for backwards compatibility
   const isFetching = isFetchingFurigana || isFetchingSoramimi;

--- a/src/hooks/useLyrics.ts
+++ b/src/hooks/useLyrics.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState, useRef, useCallback, useMemo } from "react";
+import { useEffect, useReducer, useRef, useCallback, useMemo } from "react";
 import type { LyricLine } from "@/types/lyrics";
 import { useIpodStore } from "@/stores/useIpodStore";
 import { useCacheBustTrigger, useRefetchTrigger } from "@/hooks/useCacheBustTrigger";
@@ -97,18 +97,117 @@ export function useLyrics({
   selectedMatch,
   auth,
 }: UseLyricsParams): LyricsState {
-  // State
-  const [originalLines, setOriginalLines] = useState<LyricLine[]>([]);
-  const [translatedLines, setTranslatedLines] = useState<LyricLine[] | null>(null);
-  const [currentLine, setCurrentLine] = useState(-1);
-  const [isFetchingOriginal, setIsFetchingOriginal] = useState(false);
-  const [isTranslating, setIsTranslating] = useState(false);
-  const [translationProgress, setTranslationProgress] = useState<number | undefined>();
-  const [error, setError] = useState<string | undefined>();
-  const [errorSongId, setErrorSongId] = useState<string | null>(null);
-  const [loadedSongId, setLoadedSongId] = useState<string | null>(null);
-  const [furiganaInfo, setFuriganaInfo] = useState<FuriganaStreamInfo | undefined>();
-  const [soramimiInfo, setSoramimiInfo] = useState<SoramimiStreamInfo | undefined>();
+  interface LyricsLocalState {
+    originalLines: LyricLine[];
+    translatedLines: LyricLine[] | null;
+    currentLine: number;
+    isFetchingOriginal: boolean;
+    isTranslating: boolean;
+    translationProgress: number | undefined;
+    error: string | undefined;
+    errorSongId: string | null;
+    loadedSongId: string | null;
+    furiganaInfo: FuriganaStreamInfo | undefined;
+    soramimiInfo: SoramimiStreamInfo | undefined;
+  }
+
+  const initialState: LyricsLocalState = {
+    originalLines: [],
+    translatedLines: null,
+    currentLine: -1,
+    isFetchingOriginal: false,
+    isTranslating: false,
+    translationProgress: undefined,
+    error: undefined,
+    errorSongId: null,
+    loadedSongId: null,
+    furiganaInfo: undefined,
+    soramimiInfo: undefined,
+  };
+
+  type LyricsAction =
+    | { type: "patch"; payload: Partial<LyricsLocalState> }
+    | {
+        type: "setTranslatedLines";
+        updater:
+          | LyricLine[]
+          | null
+          | ((prev: LyricLine[] | null) => LyricLine[] | null);
+      }
+    | { type: "setCurrentLine"; updater: number | ((prev: number) => number) };
+
+  const reducer = (state: LyricsLocalState, action: LyricsAction): LyricsLocalState => {
+    switch (action.type) {
+      case "patch":
+        return { ...state, ...action.payload };
+      case "setTranslatedLines": {
+        const next =
+          typeof action.updater === "function"
+            ? (
+                action.updater as (prev: LyricLine[] | null) => LyricLine[] | null
+              )(state.translatedLines)
+            : action.updater;
+        return { ...state, translatedLines: next };
+      }
+      case "setCurrentLine": {
+        const next =
+          typeof action.updater === "function"
+            ? (action.updater as (prev: number) => number)(state.currentLine)
+            : action.updater;
+        return { ...state, currentLine: next };
+      }
+      default:
+        return state;
+    }
+  };
+
+  const [state, dispatch] = useReducer(reducer, initialState);
+  const {
+    originalLines,
+    translatedLines,
+    currentLine,
+    isFetchingOriginal,
+    isTranslating,
+    translationProgress,
+    error,
+    errorSongId,
+    loadedSongId,
+    furiganaInfo,
+    soramimiInfo,
+  } = state;
+
+  const setOriginalLines = useCallback((value: LyricLine[]) => {
+    dispatch({ type: "patch", payload: { originalLines: value } });
+  }, []);
+  const setTranslatedLines = useCallback(
+    (
+      value:
+        | LyricLine[]
+        | null
+        | ((prev: LyricLine[] | null) => LyricLine[] | null)
+    ) => {
+      dispatch({ type: "setTranslatedLines", updater: value });
+    },
+    []
+  );
+  const setCurrentLine = useCallback((value: number | ((prev: number) => number)) => {
+    dispatch({ type: "setCurrentLine", updater: value });
+  }, []);
+  const setIsFetchingOriginal = useCallback((value: boolean) => {
+    dispatch({ type: "patch", payload: { isFetchingOriginal: value } });
+  }, []);
+  const setTranslationProgress = useCallback((value: number | undefined) => {
+    dispatch({ type: "patch", payload: { translationProgress: value } });
+  }, []);
+  const setError = useCallback((value: string | undefined) => {
+    dispatch({ type: "patch", payload: { error: value } });
+  }, []);
+  const setFuriganaInfo = useCallback((value: FuriganaStreamInfo | undefined) => {
+    dispatch({ type: "patch", payload: { furiganaInfo: value } });
+  }, []);
+  const setSoramimiInfo = useCallback((value: SoramimiStreamInfo | undefined) => {
+    dispatch({ type: "patch", payload: { soramimiInfo: value } });
+  }, []);
 
   // Refs for tracking state across renders.
   //
@@ -143,10 +242,14 @@ export function useLyrics({
   useEffect(() => {
     if (isCacheBustRequest) {
       translationInfoRef.current = undefined;
-      setTranslatedLines(null);
-      // Also clear furigana and soramimi info so useFurigana refetches
-      setFuriganaInfo(undefined);
-      setSoramimiInfo(undefined);
+      dispatch({
+        type: "patch",
+        payload: {
+          translatedLines: null,
+          furiganaInfo: undefined,
+          soramimiInfo: undefined,
+        },
+      });
     }
   }, [isCacheBustRequest]);
 
@@ -167,24 +270,34 @@ export function useLyrics({
     const effectSongId = songId;
 
     if (!effectSongId) {
-      setOriginalLines([]);
-      setTranslatedLines(null);
-      setCurrentLine(-1);
-      setIsFetchingOriginal(false);
-      setError(undefined);
-      setErrorSongId(null);
-      setLoadedSongId(null);
-      setFuriganaInfo(undefined);
-      setSoramimiInfo(undefined);
+      dispatch({
+        type: "patch",
+        payload: {
+          originalLines: [],
+          translatedLines: null,
+          currentLine: -1,
+          isFetchingOriginal: false,
+          error: undefined,
+          errorSongId: null,
+          loadedSongId: null,
+          furiganaInfo: undefined,
+          soramimiInfo: undefined,
+        },
+      });
       cachedKeyRef.current = null;
       translationInfoRef.current = undefined;
       return;
     }
 
     if (isOffline()) {
-      setError("iPod requires an internet connection");
-      setErrorSongId(effectSongId);
-      setLoadedSongId(null);
+      dispatch({
+        type: "patch",
+        payload: {
+          error: "iPod requires an internet connection",
+          errorSongId: effectSongId,
+          loadedSongId: null,
+        },
+      });
       return;
     }
 
@@ -197,16 +310,21 @@ export function useLyrics({
     }
 
     // Clear ALL state before fetching to prevent stale data from previous song
-    setOriginalLines([]);
-    setTranslatedLines(null);
-    setCurrentLine(-1);
-    setIsFetchingOriginal(true);
-    setIsTranslating(false);
-    setError(undefined);
-    setErrorSongId(null);
-    setLoadedSongId(null);
-    setFuriganaInfo(undefined);
-    setSoramimiInfo(undefined);
+    dispatch({
+      type: "patch",
+      payload: {
+        originalLines: [],
+        translatedLines: null,
+        currentLine: -1,
+        isFetchingOriginal: true,
+        isTranslating: false,
+        error: undefined,
+        errorSongId: null,
+        loadedSongId: null,
+        furiganaInfo: undefined,
+        soramimiInfo: undefined,
+      },
+    });
     translationInfoRef.current = undefined;
 
     const controller = new AbortController();
@@ -263,9 +381,14 @@ export function useLyrics({
           wordTimings: line.wordTimings,
         }));
 
-        setOriginalLines(parsed);
-        setLoadedSongId(effectSongId);
-        setErrorSongId(null);
+        dispatch({
+          type: "patch",
+          payload: {
+            originalLines: parsed,
+            loadedSongId: effectSongId,
+            errorSongId: null,
+          },
+        });
         cachedKeyRef.current = cacheKey;
         useIpodStore.setState({ currentLyrics: { lines: parsed } });
 
@@ -279,7 +402,7 @@ export function useLyrics({
         // Store furigana info for useFurigana to use (or clear if not included)
         // This ensures we don't show stale furigana from a previous song
         setFuriganaInfo(json.furigana ?? undefined);
-        
+
         // Store soramimi info for useFurigana to use (or clear if not included)
         // This ensures we don't show stale soramimi from a previous song
         setSoramimiInfo(json.soramimi ?? undefined);
@@ -288,11 +411,15 @@ export function useLyrics({
         if (controller.signal.aborted) return;
         if (effectSongId !== currentSongIdRef.current) return;
         handleLyricsError(err, setError, setOriginalLines, setCurrentLine);
-        setErrorSongId(effectSongId);
-        setLoadedSongId(null);
-        // Clear furigana/soramimi info on error to avoid showing stale data
-        setFuriganaInfo(undefined);
-        setSoramimiInfo(undefined);
+        dispatch({
+          type: "patch",
+          payload: {
+            errorSongId: effectSongId,
+            loadedSongId: null,
+            furiganaInfo: undefined,
+            soramimiInfo: undefined,
+          },
+        });
       })
       .finally(() => {
         if (!controller.signal.aborted && effectSongId === currentSongIdRef.current) {
@@ -315,20 +442,30 @@ export function useLyrics({
     const effectSongId = songId;
 
     if (!effectSongId || !translateTo || originalLines.length === 0) {
-      setTranslatedLines(null);
-      setIsTranslating(false);
-      setTranslationProgress(undefined);
+      dispatch({
+        type: "patch",
+        payload: {
+          translatedLines: null,
+          isTranslating: false,
+          translationProgress: undefined,
+        },
+      });
       return;
     }
 
     if (isFetchingOriginal) {
-      setIsTranslating(false);
+      dispatch({ type: "patch", payload: { isTranslating: false } });
       return;
     }
 
     if (isOffline()) {
-      setIsTranslating(false);
-      setError("iPod requires an internet connection");
+      dispatch({
+        type: "patch",
+        payload: {
+          isTranslating: false,
+          error: "iPod requires an internet connection",
+        },
+      });
       return;
     }
 
@@ -343,14 +480,24 @@ export function useLyrics({
         ...line,
         words: translations[index] || line.words,
       }));
-      setTranslatedLines(translatedLines);
-      setIsTranslating(false);
+      dispatch({
+        type: "patch",
+        payload: {
+          translatedLines,
+          isTranslating: false,
+        },
+      });
       return;
     }
 
-    setIsTranslating(true);
-    setTranslationProgress(0);
-    setError(undefined);
+    dispatch({
+      type: "patch",
+      payload: {
+        isTranslating: true,
+        translationProgress: 0,
+        error: undefined,
+      },
+    });
 
     const controller = new AbortController();
 
@@ -395,8 +542,13 @@ export function useLyrics({
       })
       .finally(() => {
         if (!controller.signal.aborted && effectSongId === currentSongIdRef.current) {
-          setIsTranslating(false);
-          setTranslationProgress(undefined);
+          dispatch({
+            type: "patch",
+            payload: {
+              isTranslating: false,
+              translationProgress: undefined,
+            },
+          });
           markCacheBustHandled();
         }
       });
@@ -404,8 +556,13 @@ export function useLyrics({
     return () => {
       controller.abort();
       // Reset loading state on cleanup to prevent stuck indicators
-      setIsTranslating(false);
-      setTranslationProgress(undefined);
+      dispatch({
+        type: "patch",
+        payload: {
+          isTranslating: false,
+          translationProgress: undefined,
+        },
+      });
     };
   }, [songId, originalLines, translateTo, isFetchingOriginal, isCacheBustRequest, markCacheBustHandled, authCredentials]);
 

--- a/src/hooks/useMusicKit.ts
+++ b/src/hooks/useMusicKit.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useReducer } from "react";
 
 /**
  * Apple MusicKit JS v3 lazy loader / configurer.
@@ -377,19 +377,35 @@ export function useMusicKit(
 ): UseMusicKitResult {
   const { enabled = true, app = DEFAULT_APP_METADATA } = options;
 
-  const [status, setStatus] = useState<MusicKitStatus>(() =>
-    configuredInstance ? "ready" : "idle"
-  );
-  const [error, setError] = useState<string | null>(null);
-  const [hasToken, setHasToken] = useState<boolean>(() =>
-    Boolean(cachedDeveloperToken || getEnvFallbackToken())
-  );
-  const [instance, setInstance] = useState<MusicKit.MusicKitInstance | null>(
-    () => configuredInstance
-  );
-  const [isAuthorized, setIsAuthorized] = useState<boolean>(
-    () => configuredInstance?.isAuthorized ?? false
-  );
+  interface MusicKitState {
+    status: MusicKitStatus;
+    error: string | null;
+    hasToken: boolean;
+    instance: MusicKit.MusicKitInstance | null;
+    isAuthorized: boolean;
+  }
+
+  const initialState: MusicKitState = {
+    status: configuredInstance ? "ready" : "idle",
+    error: null,
+    hasToken: Boolean(cachedDeveloperToken || getEnvFallbackToken()),
+    instance: configuredInstance,
+    isAuthorized: configuredInstance?.isAuthorized ?? false,
+  };
+
+  type MusicKitAction = { type: "patch"; payload: Partial<MusicKitState> };
+
+  const reducer = (state: MusicKitState, action: MusicKitAction): MusicKitState => {
+    switch (action.type) {
+      case "patch":
+        return { ...state, ...action.payload };
+      default:
+        return state;
+    }
+  };
+
+  const [state, dispatch] = useReducer(reducer, initialState);
+  const { status, error, hasToken, instance, isAuthorized } = state;
 
   // Track auth state changes via authorizationStatusDidChange events. The
   // event payload isn't strongly typed by MusicKit, so we re-read the
@@ -399,7 +415,7 @@ export function useMusicKit(
     if (!instance) return;
     const refresh = (event?: unknown) => {
       const authorized = Boolean(instance.isAuthorized);
-      setIsAuthorized(authorized);
+      dispatch({ type: "patch", payload: { isAuthorized: authorized } });
       if (!authorized) return;
 
       const tokenFromEvent =
@@ -427,22 +443,26 @@ export function useMusicKit(
   useEffect(() => {
     if (!enabled) return;
     if (configuredInstance) {
-      setStatus("ready");
-      setHasToken(true);
-      setInstance(configuredInstance);
-      setIsAuthorized(Boolean(configuredInstance.isAuthorized));
+      dispatch({
+        type: "patch",
+        payload: {
+          status: "ready",
+          hasToken: true,
+          instance: configuredInstance,
+          isAuthorized: Boolean(configuredInstance.isAuthorized),
+        },
+      });
       return;
     }
 
     let cancelled = false;
-    setStatus("loading");
-    setError(null);
+    dispatch({ type: "patch", payload: { status: "loading", error: null } });
 
     (async () => {
       try {
         const token = await resolveDeveloperToken();
         if (cancelled) return;
-        setHasToken(true);
+        dispatch({ type: "patch", payload: { hasToken: true } });
 
         const musicUserToken = await fetchSyncedMusicUserToken();
         if (cancelled) return;
@@ -453,23 +473,40 @@ export function useMusicKit(
         try {
           const inst = await configureMusicKit(token, app, musicUserToken);
           if (cancelled) return;
-          setInstance(inst);
-          setIsAuthorized(Boolean(inst.isAuthorized));
-          setStatus("ready");
+          dispatch({
+            type: "patch",
+            payload: {
+              instance: inst,
+              isAuthorized: Boolean(inst.isAuthorized),
+              status: "ready",
+            },
+          });
         } catch (err) {
-          setError(err instanceof Error ? err.message : String(err));
-          setStatus("error");
+          dispatch({
+            type: "patch",
+            payload: {
+              error: err instanceof Error ? err.message : String(err),
+              status: "error",
+            },
+          });
         }
       } catch (err) {
         if (cancelled) return;
         const fallback = getEnvFallbackToken();
         if (!fallback) {
-          setHasToken(false);
-          setStatus("missing-token");
+          dispatch({
+            type: "patch",
+            payload: { hasToken: false, status: "missing-token" },
+          });
           return;
         }
-        setError(err instanceof Error ? err.message : String(err));
-        setStatus("error");
+        dispatch({
+          type: "patch",
+          payload: {
+            error: err instanceof Error ? err.message : String(err),
+            status: "error",
+          },
+        });
       }
     })();
 
@@ -487,7 +524,10 @@ export function useMusicKit(
     if (!inst) return null;
     try {
       const token = await inst.authorize();
-      setIsAuthorized(Boolean(inst.isAuthorized));
+      dispatch({
+        type: "patch",
+        payload: { isAuthorized: Boolean(inst.isAuthorized) },
+      });
       if (token) {
         void saveSyncedMusicUserToken(token).catch((err) => {
           console.warn("[musickit] failed to save synced user token", err);
@@ -496,7 +536,10 @@ export function useMusicKit(
       return token ?? null;
     } catch (err) {
       console.error("[musickit] authorize failed", err);
-      setError(err instanceof Error ? err.message : String(err));
+      dispatch({
+        type: "patch",
+        payload: { error: err instanceof Error ? err.message : String(err) },
+      });
       throw err;
     }
   }, [instance]);
@@ -506,7 +549,7 @@ export function useMusicKit(
     if (!inst) return;
     try {
       await inst.unauthorize();
-      setIsAuthorized(false);
+      dispatch({ type: "patch", payload: { isAuthorized: false } });
       void deleteSyncedMusicUserToken().catch((err) => {
         console.warn("[musickit] failed to delete synced user token", err);
       });

--- a/src/hooks/useRealtimeConnectionStatus.ts
+++ b/src/hooks/useRealtimeConnectionStatus.ts
@@ -1,9 +1,34 @@
-import { useEffect, useState } from "react";
+import { useEffect, useReducer } from "react";
 import {
   getPusherClient,
   getRealtimeConnectionState,
   type RealtimeConnectionState,
 } from "@/lib/pusherClient";
+
+interface RealtimeConnectionStatusState {
+  connectionState: RealtimeConnectionState;
+}
+
+const initialState: RealtimeConnectionStatusState = {
+  connectionState: getRealtimeConnectionState(),
+};
+
+type RealtimeConnectionStatusAction = {
+  type: "setConnectionState";
+  value: RealtimeConnectionState;
+};
+
+function reducer(
+  state: RealtimeConnectionStatusState,
+  action: RealtimeConnectionStatusAction
+): RealtimeConnectionStatusState {
+  switch (action.type) {
+    case "setConnectionState":
+      return { ...state, connectionState: action.value };
+    default:
+      return state;
+  }
+}
 
 /**
  * Subscribes to the shared realtime client and returns the current
@@ -11,22 +36,26 @@ import {
  * "disconnected".
  */
 export function useRealtimeConnectionStatus(): RealtimeConnectionState {
-  const [state, setState] = useState<RealtimeConnectionState>(
-    getRealtimeConnectionState
-  );
+  const [state, dispatch] = useReducer(reducer, initialState);
 
   useEffect(() => {
     const client = getPusherClient();
 
-    const onConnected = () => setState("connected");
-    const onConnecting = () => setState("connecting");
-    const onDisconnected = () => setState("disconnected");
+    const onConnected = () =>
+      dispatch({ type: "setConnectionState", value: "connected" });
+    const onConnecting = () =>
+      dispatch({ type: "setConnectionState", value: "connecting" });
+    const onDisconnected = () =>
+      dispatch({ type: "setConnectionState", value: "disconnected" });
 
     client.connection.bind("connected", onConnected);
     client.connection.bind("connecting", onConnecting);
     client.connection.bind("disconnected", onDisconnected);
 
-    setState(getRealtimeConnectionState());
+    dispatch({
+      type: "setConnectionState",
+      value: getRealtimeConnectionState(),
+    });
 
     return () => {
       client.connection.unbind("connected", onConnected);
@@ -35,5 +64,5 @@ export function useRealtimeConnectionStatus(): RealtimeConnectionState {
     };
   }, []);
 
-  return state;
+  return state.connectionState;
 }

--- a/src/hooks/useSongCover.ts
+++ b/src/hooks/useSongCover.ts
@@ -2,7 +2,7 @@
  * Hook to fetch song cover art from the song metadata cache.
  * Returns the Kugou cover URL if available, otherwise falls back to YouTube thumbnail.
  */
-import { useState, useEffect } from "react";
+import { useReducer, useEffect } from "react";
 import { ApiRequestError } from "@/api/core";
 import { getSongById } from "@/api/songs";
 
@@ -39,29 +39,49 @@ export function useSongCover(
   youtubeId: string | null | undefined,
   fallbackThumbnail?: string | null
 ): string | null {
-  const [coverUrl, setCoverUrl] = useState<string | null>(() => {
-    // Check cache first
-    if (youtubeId && coverCache.has(youtubeId)) {
-      return coverCache.get(youtubeId) ?? fallbackThumbnail ?? null;
+  interface SongCoverState {
+    coverUrl: string | null;
+  }
+
+  const initialState: SongCoverState = {
+    coverUrl:
+      youtubeId && coverCache.has(youtubeId)
+        ? coverCache.get(youtubeId) ?? fallbackThumbnail ?? null
+        : fallbackThumbnail ?? null,
+  };
+
+  type SongCoverAction = { type: "setCoverUrl"; coverUrl: string | null };
+
+  const reducer = (state: SongCoverState, action: SongCoverAction): SongCoverState => {
+    switch (action.type) {
+      case "setCoverUrl":
+        return { ...state, coverUrl: action.coverUrl };
+      default:
+        return state;
     }
-    return fallbackThumbnail ?? null;
-  });
+  };
+
+  const [state, dispatch] = useReducer(reducer, initialState);
+  const { coverUrl } = state;
 
   useEffect(() => {
     if (!youtubeId) {
-      setCoverUrl(null);
+      dispatch({ type: "setCoverUrl", coverUrl: null });
       return;
     }
 
     // Check cache first
     if (coverCache.has(youtubeId)) {
       const cached = coverCache.get(youtubeId);
-      setCoverUrl(cached ?? fallbackThumbnail ?? null);
+      dispatch({
+        type: "setCoverUrl",
+        coverUrl: cached ?? fallbackThumbnail ?? null,
+      });
       return;
     }
 
     // Set fallback immediately while fetching
-    setCoverUrl(fallbackThumbnail ?? null);
+    dispatch({ type: "setCoverUrl", coverUrl: fallbackThumbnail ?? null });
 
     // Fetch cover from song metadata API
     const controller = new AbortController();
@@ -74,19 +94,28 @@ export function useSongCover(
         });
         const formattedCover = formatKugouImageUrl(data.cover, 400);
         coverCache.set(youtubeId, formattedCover);
-        setCoverUrl(formattedCover ?? fallbackThumbnail ?? null);
+        dispatch({
+          type: "setCoverUrl",
+          coverUrl: formattedCover ?? fallbackThumbnail ?? null,
+        });
       } catch (error) {
         if (error instanceof Error && error.name === "AbortError") {
           return;
         }
         if (error instanceof ApiRequestError && error.status === 404) {
           coverCache.set(youtubeId, null);
-          setCoverUrl(fallbackThumbnail ?? null);
+          dispatch({
+            type: "setCoverUrl",
+            coverUrl: fallbackThumbnail ?? null,
+          });
           return;
         }
         console.warn(`[useSongCover] Failed to fetch cover for ${youtubeId}:`, error);
         coverCache.set(youtubeId, null);
-        setCoverUrl(fallbackThumbnail ?? null);
+        dispatch({
+          type: "setCoverUrl",
+          coverUrl: fallbackThumbnail ?? null,
+        });
       }
     })();
 

--- a/src/hooks/useSpotlightSearch.ts
+++ b/src/hooks/useSpotlightSearch.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useReducer, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { appRegistry, getAppIconPath, getNonFinderApps } from "@/config/appRegistry";
 import type { AppId } from "@/config/appRegistry";
@@ -275,8 +275,43 @@ export function useSpotlightSearch(query: string): SpotlightSearchState {
   const currentQueryRef = useRef(query);
   const latestQueryRequestIdRef = useRef(0);
   const hasPostedIndexRef = useRef(false);
-  const [dynamicResults, setDynamicResults] = useState<SpotlightWorkerResultPayload[]>([]);
-  const [isSearchingDynamicResults, setIsSearchingDynamicResults] = useState(false);
+  interface DynamicSearchState {
+    dynamicResults: SpotlightWorkerResultPayload[];
+    isSearchingDynamicResults: boolean;
+  }
+
+  const initialState: DynamicSearchState = {
+    dynamicResults: [],
+    isSearchingDynamicResults: false,
+  };
+
+  type DynamicSearchAction =
+    | { type: "setIdle" }
+    | { type: "startSearch" }
+    | { type: "setResults"; results: SpotlightWorkerResultPayload[] };
+
+  const reducer = (
+    state: DynamicSearchState,
+    action: DynamicSearchAction
+  ): DynamicSearchState => {
+    switch (action.type) {
+      case "setIdle":
+        return { ...state, dynamicResults: [], isSearchingDynamicResults: false };
+      case "startSearch":
+        return { ...state, dynamicResults: [], isSearchingDynamicResults: true };
+      case "setResults":
+        return {
+          ...state,
+          dynamicResults: action.results,
+          isSearchingDynamicResults: false,
+        };
+      default:
+        return state;
+    }
+  };
+
+  const [state, dispatch] = useReducer(reducer, initialState);
+  const { dynamicResults, isSearchingDynamicResults } = state;
 
   useEffect(() => {
     currentQueryRef.current = query;
@@ -302,15 +337,13 @@ export function useSpotlightSearch(query: string): SpotlightSearchState {
       latestQueryRequestIdRef.current += 1;
 
       if (!trimmedQuery) {
-        setDynamicResults([]);
-        setIsSearchingDynamicResults(false);
+        dispatch({ type: "setIdle" });
         return;
       }
 
       const worker = workerRef.current;
       if (!worker) {
-        setDynamicResults([]);
-        setIsSearchingDynamicResults(false);
+        dispatch({ type: "setIdle" });
         return;
       }
 
@@ -319,8 +352,7 @@ export function useSpotlightSearch(query: string): SpotlightSearchState {
       }
 
       const requestId = latestQueryRequestIdRef.current;
-      setDynamicResults([]);
-      setIsSearchingDynamicResults(true);
+      dispatch({ type: "startSearch" });
       worker.postMessage({
         type: "query",
         query: trimmedQuery,
@@ -350,8 +382,7 @@ export function useSpotlightSearch(query: string): SpotlightSearchState {
         return;
       }
 
-      setDynamicResults(message.results);
-      setIsSearchingDynamicResults(false);
+      dispatch({ type: "setResults", results: message.results });
     };
 
     const refreshWorkerIndex = () => {

--- a/src/hooks/useStreamingFetch.ts
+++ b/src/hooks/useStreamingFetch.ts
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect, useCallback } from "react";
+import { useReducer, useRef, useEffect, useCallback } from "react";
 import { useLatestRef } from "@/hooks/useLatestRef";
 import { useCacheBustTrigger } from "@/hooks/useCacheBustTrigger";
 import { isOffline } from "@/utils/offline";
@@ -92,11 +92,43 @@ export function useStreamingFetch<TResult, TLineData = unknown>({
   auth,
   debugLabel = "StreamingFetch",
 }: StreamingFetchOptions<TResult, TLineData>): StreamingFetchResult<TResult> {
+  interface StreamingFetchState {
+    data: TResult | null;
+    isLoading: boolean;
+    progress: number | undefined;
+    error: string | undefined;
+    refetchCounter: number;
+  }
+
+  const initialState: StreamingFetchState = {
+    data: null,
+    isLoading: false,
+    progress: undefined,
+    error: undefined,
+    refetchCounter: 0,
+  };
+
+  type StreamingFetchAction =
+    | { type: "patch"; payload: Partial<StreamingFetchState> }
+    | { type: "incrementRefetchCounter" };
+
+  const reducer = (
+    state: StreamingFetchState,
+    action: StreamingFetchAction
+  ): StreamingFetchState => {
+    switch (action.type) {
+      case "patch":
+        return { ...state, ...action.payload };
+      case "incrementRefetchCounter":
+        return { ...state, refetchCounter: state.refetchCounter + 1 };
+      default:
+        return state;
+    }
+  };
+
   // State
-  const [data, setData] = useState<TResult | null>(null);
-  const [isLoading, setIsLoading] = useState(false);
-  const [progress, setProgress] = useState<number | undefined>();
-  const [error, setError] = useState<string | undefined>();
+  const [state, dispatch] = useReducer(reducer, initialState);
+  const { data, isLoading, progress, error, refetchCounter } = state;
 
   // Refs for tracking state
   const cacheKeyRef = useRef<string>("");
@@ -116,16 +148,14 @@ export function useStreamingFetch<TResult, TLineData = unknown>({
   const onErrorRef = useLatestRef(onError);
 
   // Manual refetch trigger
-  const [refetchCounter, setRefetchCounter] = useState(0);
   const refetch = useCallback(() => {
-    setRefetchCounter((c) => c + 1);
+    dispatch({ type: "incrementRefetchCounter" });
   }, []);
 
   // Clear data
   const clear = useCallback(() => {
-    setData(null);
+    dispatch({ type: "patch", payload: { data: null, error: undefined } });
     cacheKeyRef.current = "";
-    setError(undefined);
   }, []);
 
   // Clear request ref when resourceId changes
@@ -136,9 +166,8 @@ export function useStreamingFetch<TResult, TLineData = unknown>({
   // Clear data when cache bust trigger changes
   useEffect(() => {
     if (isCacheBustRequest) {
-      setData(null);
+      dispatch({ type: "patch", payload: { data: null, error: undefined } });
       cacheKeyRef.current = "";
-      setError(undefined);
       requestRef.current = null;
     }
   }, [isCacheBustRequest]);
@@ -152,12 +181,17 @@ export function useStreamingFetch<TResult, TLineData = unknown>({
     if (!effectResourceId || !enabled || !cacheKey) {
       const resourceChanged = effectResourceId !== lastResourceIdRef.current;
       if (resourceChanged && cacheKeyRef.current !== "") {
-        setData(null);
+        dispatch({
+          type: "patch",
+          payload: {
+            data: null,
+            isLoading: false,
+            progress: undefined,
+            error: undefined,
+          },
+        });
         cacheKeyRef.current = "";
         lastResourceIdRef.current = effectResourceId || "";
-        setIsLoading(false);
-        setProgress(undefined);
-        setError(undefined);
       }
       return;
     }
@@ -166,8 +200,13 @@ export function useStreamingFetch<TResult, TLineData = unknown>({
 
     // Check if offline
     if (isOffline()) {
-      setError("Requires an internet connection");
-      setIsLoading(false);
+      dispatch({
+        type: "patch",
+        payload: {
+          error: "Requires an internet connection",
+          isLoading: false,
+        },
+      });
       return;
     }
 
@@ -178,9 +217,11 @@ export function useStreamingFetch<TResult, TLineData = unknown>({
 
     // Use prefetched data if available and not forcing
     if (prefetchedData?.cached && prefetchedData.data && !isCacheBustRequest) {
-      setData(prefetchedData.data);
+      dispatch({
+        type: "patch",
+        payload: { data: prefetchedData.data, isLoading: false },
+      });
       cacheKeyRef.current = cacheKey;
-      setIsLoading(false);
       onCompleteRef.current?.(prefetchedData.data);
       return;
     }
@@ -198,9 +239,14 @@ export function useStreamingFetch<TResult, TLineData = unknown>({
     const requestId = `${effectResourceId}-${lyricsCacheBustTrigger}-${Date.now()}`;
 
     // Start loading
-    setIsLoading(true);
-    setProgress(0);
-    setError(undefined);
+    dispatch({
+      type: "patch",
+      payload: {
+        isLoading: true,
+        progress: 0,
+        error: undefined,
+      },
+    });
 
     const controller = new AbortController();
     requestRef.current = { controller, requestId };
@@ -215,7 +261,7 @@ export function useStreamingFetch<TResult, TLineData = unknown>({
       onProgress: (prog) => {
         if (controller.signal.aborted) return;
         if (effectResourceId !== currentResourceIdRef.current) return;
-        setProgress(prog.percentage);
+        dispatch({ type: "patch", payload: { progress: prog.percentage } });
       },
       onLine: (lineIndex, lineData) => {
         if (controller.signal.aborted) return;
@@ -227,7 +273,7 @@ export function useStreamingFetch<TResult, TLineData = unknown>({
         if (controller.signal.aborted) return;
         if (effectResourceId !== currentResourceIdRef.current) return;
 
-        setData(result.data);
+        dispatch({ type: "patch", payload: { data: result.data } });
         cacheKeyRef.current = cacheKey;
         markCacheBustHandled();
         onCompleteRef.current?.(result.data);
@@ -242,7 +288,7 @@ export function useStreamingFetch<TResult, TLineData = unknown>({
 
         console.error(`[${debugLabel}] Fetch error:`, err);
         const errorMsg = err instanceof Error ? err.message : "Unknown error";
-        setError(errorMsg);
+        dispatch({ type: "patch", payload: { error: errorMsg } });
         onErrorRef.current?.(err instanceof Error ? err : new Error(errorMsg));
       })
       .finally(() => {
@@ -251,8 +297,13 @@ export function useStreamingFetch<TResult, TLineData = unknown>({
         }
 
         if (!controller.signal.aborted && effectResourceId === currentResourceIdRef.current) {
-          setIsLoading(false);
-          setProgress(undefined);
+          dispatch({
+            type: "patch",
+            payload: {
+              isLoading: false,
+              progress: undefined,
+            },
+          });
         }
       });
 
@@ -261,8 +312,13 @@ export function useStreamingFetch<TResult, TLineData = unknown>({
       if (requestRef.current?.requestId === requestId) {
         requestRef.current = null;
       }
-      setIsLoading(false);
-      setProgress(undefined);
+      dispatch({
+        type: "patch",
+        payload: {
+          isLoading: false,
+          progress: undefined,
+        },
+      });
     };
   }, [
     resourceId,

--- a/src/hooks/useSwipeNavigation.ts
+++ b/src/hooks/useSwipeNavigation.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useEffect, useReducer } from "react";
 import { AppId } from "@/config/appRegistry";
 
 interface SwipeNavigationOptions {
@@ -9,6 +9,54 @@ interface SwipeNavigationOptions {
   isActive: boolean;
 }
 
+interface SwipeState {
+  touchStartX: number | null;
+  touchEndX: number | null;
+  isSwiping: boolean;
+  swipeDirection: "left" | "right" | null;
+}
+
+const initialState: SwipeState = {
+  touchStartX: null,
+  touchEndX: null,
+  isSwiping: false,
+  swipeDirection: null,
+};
+
+type SwipeAction =
+  | { type: "reset" }
+  | { type: "touchStart"; x: number }
+  | { type: "touchMove"; x: number; direction: "left" | "right" | null }
+  | { type: "setIsSwiping"; value: boolean };
+
+function reducer(state: SwipeState, action: SwipeAction): SwipeState {
+  switch (action.type) {
+    case "reset":
+      return initialState;
+    case "touchStart":
+      return {
+        ...state,
+        touchStartX: action.x,
+        touchEndX: null,
+        isSwiping: true,
+        swipeDirection: null,
+      };
+    case "touchMove":
+      return {
+        ...state,
+        touchEndX: action.x,
+        swipeDirection: action.direction,
+      };
+    case "setIsSwiping":
+      return {
+        ...state,
+        isSwiping: action.value,
+      };
+    default:
+      return state;
+  }
+}
+
 export function useSwipeNavigation({
   threshold = 100,
   onSwipeLeft,
@@ -16,47 +64,36 @@ export function useSwipeNavigation({
   currentAppId,
   isActive,
 }: SwipeNavigationOptions) {
-  const [touchStartX, setTouchStartX] = useState<number | null>(null);
-  const [touchEndX, setTouchEndX] = useState<number | null>(null);
-  const [isSwiping, setIsSwiping] = useState(false);
-  const [swipeDirection, setSwipeDirection] = useState<"left" | "right" | null>(
-    null
-  );
+  const [state, dispatch] = useReducer(reducer, initialState);
+  const { touchStartX, touchEndX, isSwiping, swipeDirection } = state;
 
   // Reset swipe state when the currentAppId changes
   useEffect(() => {
-    setTouchStartX(null);
-    setTouchEndX(null);
-    setIsSwiping(false);
-    setSwipeDirection(null);
+    dispatch({ type: "reset" });
   }, [currentAppId]);
 
   const handleTouchStart = (e: React.TouchEvent<HTMLElement>) => {
     if (!isActive) return;
-    setTouchStartX(e.touches[0].clientX);
-    setIsSwiping(true);
-    setSwipeDirection(null);
+    dispatch({ type: "touchStart", x: e.touches[0].clientX });
   };
 
   const handleTouchMove = (e: React.TouchEvent<HTMLElement>) => {
     if (!isActive || touchStartX === null) return;
 
     const currentX = e.touches[0].clientX;
-    setTouchEndX(currentX);
 
     // Calculate direction for visual feedback
     const diff = touchStartX - currentX;
-    if (Math.abs(diff) > 20) {
-      // Small threshold for visual feedback
-      setSwipeDirection(diff > 0 ? "left" : "right");
-    } else {
-      setSwipeDirection(null);
-    }
+    dispatch({
+      type: "touchMove",
+      x: currentX,
+      direction: Math.abs(diff) > 20 ? (diff > 0 ? "left" : "right") : null,
+    });
   };
 
   const handleTouchEnd = () => {
     if (!isActive || touchStartX === null || touchEndX === null) {
-      setIsSwiping(false);
+      dispatch({ type: "setIsSwiping", value: false });
       return;
     }
 
@@ -74,10 +111,7 @@ export function useSwipeNavigation({
     }
 
     // Reset touch coordinates
-    setTouchStartX(null);
-    setTouchEndX(null);
-    setIsSwiping(false);
-    setSwipeDirection(null);
+    dispatch({ type: "reset" });
   };
 
   return {

--- a/src/hooks/useTtsQueue.ts
+++ b/src/hooks/useTtsQueue.ts
@@ -1,4 +1,4 @@
-import { useRef, useEffect, useCallback, useState } from "react";
+import { useRef, useEffect, useCallback, useReducer } from "react";
 import { useLatestRef } from "@/hooks/useLatestRef";
 import { getAudioContext, resumeAudioContext } from "@/lib/audioContext";
 import { useAudioSettingsStore } from "@/stores/useAudioSettingsStore";
@@ -23,8 +23,28 @@ export function useTtsQueue(endpoint: string = "/api/speech") {
   const nextStartRef = useRef(0);
   // Keep track of in-flight requests so we can cancel them if needed
   const controllersRef = useRef<Set<AbortController>>(new Set());
+  interface TtsQueueState {
+    isSpeaking: boolean;
+  }
+
+  const initialState: TtsQueueState = {
+    isSpeaking: false,
+  };
+
+  type TtsQueueAction = { type: "setIsSpeaking"; value: boolean };
+
+  const reducer = (state: TtsQueueState, action: TtsQueueAction): TtsQueueState => {
+    switch (action.type) {
+      case "setIsSpeaking":
+        return { ...state, isSpeaking: action.value };
+      default:
+        return state;
+    }
+  };
+
   // Expose whether any TTS audio is currently playing
-  const [isSpeaking, setIsSpeaking] = useState(false);
+  const [state, dispatch] = useReducer(reducer, initialState);
+  const { isSpeaking } = state;
   // Track any sources currently playing so we can stop them
   const playingSourcesRef = useRef<Set<AudioBufferSourceNode>>(new Set());
   // Promise chain that guarantees *scheduling* order while still allowing
@@ -246,7 +266,7 @@ export function useTtsQueue(endpoint: string = "/api/speech") {
 
           // Keep track of active sources so we can stop them later
           playingSourcesRef.current.add(src);
-          setIsSpeaking(true);
+          dispatch({ type: "setIsSpeaking", value: true });
 
           src.onended = () => {
             // Disconnect the source node to prevent memory leaks
@@ -257,7 +277,7 @@ export function useTtsQueue(endpoint: string = "/api/speech") {
             }
             playingSourcesRef.current.delete(src);
             if (playingSourcesRef.current.size === 0) {
-              setIsSpeaking(false);
+              dispatch({ type: "setIsSpeaking", value: false });
             }
             if (onEnd) onEnd();
           };
@@ -316,7 +336,7 @@ export function useTtsQueue(endpoint: string = "/api/speech") {
         }
       });
       playingSourcesRef.current.clear();
-      setIsSpeaking(false);
+      dispatch({ type: "setIsSpeaking", value: false });
       if (ctxRef.current) {
         nextStartRef.current = ctxRef.current.currentTime;
       }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Fetched latest `origin/main` and merged into this branch.
- Reviewed and classified merge conflicts from this merge pass.
- Resolved the only conflict in `src/apps/ipod/components/screen/BatteryIndicator.tsx`.

## Conflict classification
- **Simple conflicts (resolved):**
  - `src/apps/ipod/components/screen/BatteryIndicator.tsx`
    - Same behavioral intent on both sides (initialize battery level + charging state after `getBattery()`); only implementation style differed (`dispatch` combined update vs individual setters).
    - Resolved to reducer-style atomic update via `dispatch({ type: "setBatteryStatus", ... })` with correct `batteryRef` values.
- **Complicated conflicts:**
  - None in this merge pass.

## Testing
- `bun run build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3dafd0c6-13d6-4c33-8402-636df0e323b9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3dafd0c6-13d6-4c33-8402-636df0e323b9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

