### PR TITLE
fix(synth): mobile preset UI — hide metal buttons, size select

### DIFF
--- a/src/apps/synth/components/SynthAppComponent.tsx
+++ b/src/apps/synth/components/SynthAppComponent.tsx
@@ -234,7 +234,6 @@ export function SynthAppComponent({
                       <SelectTrigger
                         className={cn(
                           "w-full min-w-0 h-[22px] font-geneva-12 text-[11px] leading-none px-2 py-0 gap-1 [&>span]:truncate",
-                          isSystem7Theme && "!font-geneva-12",
                           isClassicTheme && "text-black bg-transparent",
                           !isClassicTheme &&
                             "bg-black border-[#3a3a3a] text-white"
@@ -244,8 +243,6 @@ export function SynthAppComponent({
                       </SelectTrigger>
                       <SelectContent
                         className={cn(
-                          "font-geneva-12",
-                          isSystem7Theme && "!font-geneva-12",
                           isClassicTheme && "text-black",
                           !isClassicTheme &&
                             "bg-black border-[#3a3a3a] text-white"
@@ -257,7 +254,6 @@ export function SynthAppComponent({
                             value={preset.id}
                             className={cn(
                               "font-geneva-12 text-[11px] select-none",
-                              isSystem7Theme && "!font-geneva-12",
                               isClassicTheme && "text-black"
                             )}
                           >
@@ -406,7 +402,6 @@ export function SynthAppComponent({
                           <SelectTrigger
                             className={cn(
                               "w-full font-geneva-12 text-[12px] p-2",
-                              isSystem7Theme && "!font-geneva-12",
                               isClassicTheme && "text-black",
                               !isClassicTheme &&
                                 "bg-black border-[#3a3a3a] text-white"
@@ -416,8 +411,6 @@ export function SynthAppComponent({
                           </SelectTrigger>
                           <SelectContent
                             className={cn(
-                              "font-geneva-12",
-                              isSystem7Theme && "!font-geneva-12",
                               isClassicTheme && "text-black",
                               !isClassicTheme &&
                                 "bg-black border-[#3a3a3a] text-white"
@@ -427,7 +420,6 @@ export function SynthAppComponent({
                               value="sine"
                               className={cn(
                                 "font-geneva-12 text-[12px]",
-                                isSystem7Theme && "!font-geneva-12",
                                 isClassicTheme && "text-black"
                               )}
                             >
@@ -437,7 +429,6 @@ export function SynthAppComponent({
                               value="square"
                               className={cn(
                                 "font-geneva-12 text-[12px]",
-                                isSystem7Theme && "!font-geneva-12",
                                 isClassicTheme && "text-black"
                               )}
                             >
@@ -447,7 +438,6 @@ export function SynthAppComponent({
                               value="triangle"
                               className={cn(
                                 "font-geneva-12 text-[12px]",
-                                isSystem7Theme && "!font-geneva-12",
                                 isClassicTheme && "text-black"
                               )}
                             >
@@ -457,7 +447,6 @@ export function SynthAppComponent({
                               value="sawtooth"
                               className={cn(
                                 "font-geneva-12 text-[12px]",
-                                isSystem7Theme && "!font-geneva-12",
                                 isClassicTheme && "text-black"
                               )}
                             >

--- a/src/apps/synth/components/SynthAppComponent.tsx
+++ b/src/apps/synth/components/SynthAppComponent.tsx
@@ -234,6 +234,7 @@ export function SynthAppComponent({
                       <SelectTrigger
                         className={cn(
                           "w-full min-w-0 h-[22px] font-geneva-12 text-[11px] leading-none px-2 py-0 gap-1 [&>span]:truncate",
+                          isSystem7Theme && "!font-geneva-12",
                           isClassicTheme && "text-black bg-transparent",
                           !isClassicTheme &&
                             "bg-black border-[#3a3a3a] text-white"
@@ -243,6 +244,8 @@ export function SynthAppComponent({
                       </SelectTrigger>
                       <SelectContent
                         className={cn(
+                          "font-geneva-12",
+                          isSystem7Theme && "!font-geneva-12",
                           isClassicTheme && "text-black",
                           !isClassicTheme &&
                             "bg-black border-[#3a3a3a] text-white"
@@ -254,6 +257,7 @@ export function SynthAppComponent({
                             value={preset.id}
                             className={cn(
                               "font-geneva-12 text-[11px] select-none",
+                              isSystem7Theme && "!font-geneva-12",
                               isClassicTheme && "text-black"
                             )}
                           >
@@ -402,6 +406,7 @@ export function SynthAppComponent({
                           <SelectTrigger
                             className={cn(
                               "w-full font-geneva-12 text-[12px] p-2",
+                              isSystem7Theme && "!font-geneva-12",
                               isClassicTheme && "text-black",
                               !isClassicTheme &&
                                 "bg-black border-[#3a3a3a] text-white"
@@ -411,6 +416,8 @@ export function SynthAppComponent({
                           </SelectTrigger>
                           <SelectContent
                             className={cn(
+                              "font-geneva-12",
+                              isSystem7Theme && "!font-geneva-12",
                               isClassicTheme && "text-black",
                               !isClassicTheme &&
                                 "bg-black border-[#3a3a3a] text-white"
@@ -420,6 +427,7 @@ export function SynthAppComponent({
                               value="sine"
                               className={cn(
                                 "font-geneva-12 text-[12px]",
+                                isSystem7Theme && "!font-geneva-12",
                                 isClassicTheme && "text-black"
                               )}
                             >
@@ -429,6 +437,7 @@ export function SynthAppComponent({
                               value="square"
                               className={cn(
                                 "font-geneva-12 text-[12px]",
+                                isSystem7Theme && "!font-geneva-12",
                                 isClassicTheme && "text-black"
                               )}
                             >
@@ -438,6 +447,7 @@ export function SynthAppComponent({
                               value="triangle"
                               className={cn(
                                 "font-geneva-12 text-[12px]",
+                                isSystem7Theme && "!font-geneva-12",
                                 isClassicTheme && "text-black"
                               )}
                             >
@@ -447,6 +457,7 @@ export function SynthAppComponent({
                               value="sawtooth"
                               className={cn(
                                 "font-geneva-12 text-[12px]",
+                                isSystem7Theme && "!font-geneva-12",
                                 isClassicTheme && "text-black"
                               )}
                             >

--- a/src/apps/synth/components/SynthAppComponent.tsx
+++ b/src/apps/synth/components/SynthAppComponent.tsx
@@ -224,16 +224,16 @@ export function SynthAppComponent({
               )}
             >
               <div className="flex justify-between items-center">
-                <div className="flex gap-0">
+                <div className="flex gap-0 items-center min-w-0">
                   {/* Mobile preset selector */}
-                  <div className="md:hidden w-48">
+                  <div className="md:hidden flex-1 min-w-0 max-w-[min(100%,12rem)] sm:max-w-[min(100%,14rem)]">
                     <Select
                       value={currentPreset.id}
                       onValueChange={loadPresetById}
                     >
                       <SelectTrigger
                         className={cn(
-                          "w-full h-[22px] font-geneva-12 text-[12px] p-2",
+                          "w-full min-w-0 h-[22px] font-geneva-12 text-[11px] leading-none px-2 py-0 gap-1 [&>span]:truncate",
                           isClassicTheme && "text-black bg-transparent",
                           !isClassicTheme &&
                             "bg-black border-[#3a3a3a] text-white"
@@ -253,7 +253,7 @@ export function SynthAppComponent({
                             key={preset.id}
                             value={preset.id}
                             className={cn(
-                              "font-geneva-12 text-[12px] select-none",
+                              "font-geneva-12 text-[11px] select-none",
                               isClassicTheme && "text-black"
                             )}
                           >
@@ -264,26 +264,28 @@ export function SynthAppComponent({
                     </Select>
                   </div>
 
-                  {/* Desktop preset buttons */}
+                  {/* Desktop only: keep `metal-inset-btn-group` inner — its global `display:flex` breaks `hidden` on the same element. */}
                   {isMacOSTheme ? (
-                    <div className="hidden md:flex metal-inset-btn-group">
-                      {presets.length > 0 ? (
-                        presets.map((preset) => (
-                          <button
-                            key={preset.id}
-                            type="button"
-                            className="metal-inset-btn font-geneva-12 !text-[11px] whitespace-nowrap uppercase select-none"
-                            data-state={currentPreset.id === preset.id ? "on" : "off"}
-                            onClick={() => loadPreset(preset)}
-                          >
-                            {preset.name}
-                          </button>
-                        ))
-                      ) : (
-                        <p className="text-xs text-gray-400 font-geneva-12 select-none px-2">
-                          {t("apps.synth.noPresetsYet")}
-                        </p>
-                      )}
+                    <div className="hidden md:flex items-center min-w-0">
+                      <div className="metal-inset-btn-group">
+                        {presets.length > 0 ? (
+                          presets.map((preset) => (
+                            <button
+                              key={preset.id}
+                              type="button"
+                              className="metal-inset-btn font-geneva-12 !text-[11px] whitespace-nowrap uppercase select-none"
+                              data-state={currentPreset.id === preset.id ? "on" : "off"}
+                              onClick={() => loadPreset(preset)}
+                            >
+                              {preset.name}
+                            </button>
+                          ))
+                        ) : (
+                          <p className="text-xs text-gray-400 font-geneva-12 select-none px-2">
+                            {t("apps.synth.noPresetsYet")}
+                          </p>
+                        )}
+                      </div>
                     </div>
                   ) : (
                     <div className="hidden md:flex gap-0">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes a **mobile-only regression in the Synth app (macOS / brushed-metal theme)** where preset segment controls stayed visible next to the mobile preset dropdown.

## Root cause

The desktop preset row used a single element with both `hidden md:flex` and `metal-inset-btn-group`. Global styles for `.metal-inset-btn-group` set `display: flex` (see `src/styles/themes.css`), which **overrides** Tailwind’s `display: none` from `hidden` when both apply to the same node. The mobile `<Select>` (`md:hidden`) still showed, so **both** UIs appeared on small viewports.

## Fix

- Nest `metal-inset-btn-group` **inside** a plain wrapper that only handles responsive visibility (`hidden md:flex`). The inner group keeps brushed-metal layout; the outer element keeps `hidden` effective.
- Mobile preset `<Select>`: match **11px Geneva** / **22px** height with other toolbar controls, replace fixed `w-48` with a **capped flexible width**, tighter padding, and truncate long preset names.

## Testing

- `bun run build` (TypeScript + Vite) completed successfully.

## Acceptance

- [x] Mobile (&lt; `md`): only the preset `<Select>` for presets; no duplicate segment buttons.
- [x] `md` and up: unchanged desktop behavior (metal inset group or themed `Button`s).
- [x] Select sizing aligns with toolbar label text (11px, compact trigger).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6d616c3a-7ccc-4a85-94cc-c1ba4ea1b7fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6d616c3a-7ccc-4a85-94cc-c1ba4ea1b7fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

