### PR TITLE
fix(tv): theme UI font for channel creation loading

### DIFF
--- a/src/apps/tv/components/ChannelPromptInput.tsx
+++ b/src/apps/tv/components/ChannelPromptInput.tsx
@@ -33,7 +33,8 @@ export function ChannelPromptInput({
   width,
   className,
 }: ChannelPromptInputProps) {
-  const { isMacOSTheme } = useThemeFlags();
+  const { isMacOSTheme, isSystem7Theme } = useThemeFlags();
+  const bodyFontClass = isSystem7Theme ? "font-geneva-12" : "font-os-ui";
   const inputRef = useRef<HTMLInputElement>(null);
   const inputId = useId();
 
@@ -95,7 +96,8 @@ export function ChannelPromptInput({
         placeholder={isLoading ? " " : placeholder}
         disabled={isLoading}
         className={cn(
-          "w-full outline-none min-w-0 transition-colors text-black placeholder:text-black/40 disabled:placeholder:text-black/30 disabled:bg-white font-os-ui",
+          "w-full outline-none min-w-0 transition-colors text-black placeholder:text-black/40 disabled:placeholder:text-black/30 disabled:bg-white",
+          bodyFontClass,
           isMacOSTheme
             ? "rounded-full border border-black/40 bg-white px-3 py-[3px] text-[11px] shadow-[inset_0_1px_2px_rgba(0,0,0,0.3),inset_0_0_1px_rgba(0,0,0,0.15),0_1px_0_rgba(255,255,255,0.45)]"
             : "rounded-full border border-black/20 bg-white px-3 py-1 text-[11px] shadow-[inset_0_1px_2px_rgba(0,0,0,0.12)]",
@@ -112,7 +114,7 @@ export function ChannelPromptInput({
             transition={{ duration: 0.15 }}
             className="absolute inset-0 pointer-events-none flex items-center px-3"
           >
-            <span className="shimmer-gray text-[11px] font-os-ui truncate">
+            <span className={cn("shimmer-gray text-[11px] truncate", bodyFontClass)}>
               {statusMessage}
               <AnimatedEllipsis />
             </span>

--- a/src/apps/tv/components/ChannelPromptInput.tsx
+++ b/src/apps/tv/components/ChannelPromptInput.tsx
@@ -95,10 +95,10 @@ export function ChannelPromptInput({
         placeholder={isLoading ? " " : placeholder}
         disabled={isLoading}
         className={cn(
-          "w-full outline-none min-w-0 transition-colors text-black placeholder:text-black/40 disabled:placeholder:text-black/30 disabled:bg-white",
+          "w-full outline-none min-w-0 transition-colors text-black placeholder:text-black/40 disabled:placeholder:text-black/30 disabled:bg-white font-os-ui",
           isMacOSTheme
-            ? "rounded-full border border-black/40 bg-white px-3 py-[3px] text-[11px] shadow-[inset_0_1px_2px_rgba(0,0,0,0.3),inset_0_0_1px_rgba(0,0,0,0.15),0_1px_0_rgba(255,255,255,0.45)] font-geneva-12"
-            : "rounded-full border border-black/20 bg-white px-3 py-1 text-[11px] shadow-[inset_0_1px_2px_rgba(0,0,0,0.12)] font-geneva-12",
+            ? "rounded-full border border-black/40 bg-white px-3 py-[3px] text-[11px] shadow-[inset_0_1px_2px_rgba(0,0,0,0.3),inset_0_0_1px_rgba(0,0,0,0.15),0_1px_0_rgba(255,255,255,0.45)]"
+            : "rounded-full border border-black/20 bg-white px-3 py-1 text-[11px] shadow-[inset_0_1px_2px_rgba(0,0,0,0.12)]",
           isLoading && "cursor-progress"
         )}
       />
@@ -112,7 +112,7 @@ export function ChannelPromptInput({
             transition={{ duration: 0.15 }}
             className="absolute inset-0 pointer-events-none flex items-center px-3"
           >
-            <span className="shimmer-gray text-[11px] font-geneva-12 truncate">
+            <span className="shimmer-gray text-[11px] font-os-ui truncate">
               {statusMessage}
               <AnimatedEllipsis />
             </span>

--- a/src/apps/tv/components/CreateChannelDialog.tsx
+++ b/src/apps/tv/components/CreateChannelDialog.tsx
@@ -154,7 +154,7 @@ export function CreateChannelDialog({
     : undefined;
   const fontClass = isXpTheme
     ? "font-['Pixelated_MS_Sans_Serif',Arial] text-[11px]"
-    : "font-geneva-12 text-[12px]";
+    : "font-os-ui text-[12px]";
 
   const dialogContent = (
     <div className={cn(isXpTheme ? "p-2 px-4" : "p-4 px-6")}>

--- a/src/apps/tv/components/CreateChannelDialog.tsx
+++ b/src/apps/tv/components/CreateChannelDialog.tsx
@@ -80,6 +80,7 @@ export function CreateChannelDialog({
   const {
     isWindowsTheme: isXpTheme,
     isMacOSTheme: isMacTheme,
+    isSystem7Theme,
   } = useThemeFlags();
 
   const { create } = useCreateTvChannel();
@@ -154,7 +155,9 @@ export function CreateChannelDialog({
     : undefined;
   const fontClass = isXpTheme
     ? "font-['Pixelated_MS_Sans_Serif',Arial] text-[11px]"
-    : "font-os-ui text-[12px]";
+    : isSystem7Theme
+      ? "font-geneva-12 text-[12px]"
+      : "font-os-ui text-[12px]";
 
   const dialogContent = (
     <div className={cn(isXpTheme ? "p-2 px-4" : "p-4 px-6")}>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Channel creation flows (inline prompt shimmer and Create Channel dialog) use `font-os-ui` so Aqua and other themes follow `--os-font-ui`. **System 7** uses `font-geneva-12` for these controls instead of Chicago, matching classic Geneva body text in this UI. XP pixel font path unchanged.

**Testing:** `bun run build` (tsc + vite) succeeded.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-30466eff-3573-424f-a121-555a22cd7a6e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-30466eff-3573-424f-a121-555a22cd7a6e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

