### PR TITLE
Prevent page scrolling while dragging calendar events on mobile

### DIFF
--- a/src/apps/calendar/components/TimedEventBlock.tsx
+++ b/src/apps/calendar/components/TimedEventBlock.tsx
@@ -280,6 +280,8 @@ export function TimedEventBlock({
         height,
         backgroundColor: washColor,
         borderLeft: `3px solid ${accentColor}`,
+        // Prevent mobile touch panning while dragging/resizing timed events.
+        touchAction: "none",
         boxShadow:
           selectedEventId === event.id
             ? `0 0 0 1px ${accentColor}`


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- set `touch-action: none` on timed calendar event blocks so touch drag/resize gestures do not trigger native scrolling while users reposition events on mobile

## Testing
- `bun run build`
- Manual validation in Chrome mobile emulation (iPhone 14 Pro Max): dragged and resized a day-view event multiple times; no unintended scroll occurred

## Walkthrough artifacts
<a href="https://cursor.com/agents/bc-ebdf84b7-c0a7-4656-afb5-ff7812d48f3a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcalendar_mobile_drag_no_scroll.mp4"><img src="https://cursor.com/artifacts/c/art-a774b890-ea60-4d9a-a857-d6eeebf8efea" alt="calendar_mobile_drag_no_scroll.mp4" /></a>
![Mobile drag result](https://cursor.com/artifacts/c/art-83e260ce-ac0e-4d93-812e-3e57bbaefda2)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ebdf84b7-c0a7-4656-afb5-ff7812d48f3a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ebdf84b7-c0a7-4656-afb5-ff7812d48f3a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

