### PR TITLE
Fix calendar tray mobile bottom clipping

### DIFF
--- a/src/apps/calendar/components/TrayDetails.tsx
+++ b/src/apps/calendar/components/TrayDetails.tsx
@@ -328,7 +328,7 @@ function EventTrayEditor({
 
   const panelShell = cn(
     "flex-1 flex flex-col min-h-0 overflow-y-auto",
-    "bg-white pl-2.5 pr-2.5 pt-2 pb-2",
+    "bg-white pl-2.5 pr-2.5 pt-2",
     !isMacOSTheme && "rounded-sm border border-black/10"
   );
 
@@ -339,7 +339,10 @@ function EventTrayEditor({
   );
 
   return (
-    <div className={panelShell}>
+    <div
+      className={panelShell}
+      style={{ paddingBottom: "calc(1rem + env(safe-area-inset-bottom, 0px))" }}
+    >
       {/* Title + location (iCal header block) */}
       <div
         className={cn(
@@ -600,7 +603,7 @@ function TodoDetails({
 
   const panelShell = cn(
     "flex-1 flex flex-col min-h-0 overflow-y-auto",
-    "bg-white pl-2.5 pr-2.5 pt-2 pb-2",
+    "bg-white pl-2.5 pr-2.5 pt-2",
     !isMacOSTheme && "rounded-sm border border-black/10"
   );
 
@@ -617,7 +620,10 @@ function TodoDetails({
   ));
 
   return (
-    <div className={panelShell}>
+    <div
+      className={panelShell}
+      style={{ paddingBottom: "calc(1rem + env(safe-area-inset-bottom, 0px))" }}
+    >
       <div
         className={cn(
           "shrink-0 border-b border-black/20 pb-2 mb-2",

--- a/src/apps/calendar/components/TrayDetails.tsx
+++ b/src/apps/calendar/components/TrayDetails.tsx
@@ -22,6 +22,8 @@ const EVENT_COLOR_MAP: Record<string, string> = {
   purple: "#9B59B6",
 };
 
+const TRAY_SCROLLER_BOTTOM_PADDING = "calc(3rem + env(safe-area-inset-bottom, 0px))";
+
 interface TrayDetailsProps {
   selectedEvent: CalendarEvent | null;
   selectedTodo: TodoItem | null;
@@ -341,7 +343,7 @@ function EventTrayEditor({
   return (
     <div
       className={panelShell}
-      style={{ paddingBottom: "calc(1rem + env(safe-area-inset-bottom, 0px))" }}
+      style={{ paddingBottom: TRAY_SCROLLER_BOTTOM_PADDING }}
     >
       {/* Title + location (iCal header block) */}
       <div
@@ -622,7 +624,7 @@ function TodoDetails({
   return (
     <div
       className={panelShell}
-      style={{ paddingBottom: "calc(1rem + env(safe-area-inset-bottom, 0px))" }}
+      style={{ paddingBottom: TRAY_SCROLLER_BOTTOM_PADDING }}
     >
       <div
         className={cn(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add explicit tray scroller bottom inset (`3rem + safe-area`) for both event and todo detail panes
- ensure the bottom Delete action remains fully visible in compact/mobile drawer mode

## Testing
- `bun run build`
- manual mobile viewport validation in Calendar drawer

## Walkthrough
<a href="https://cursor.com/agents/bc-d7ba5af9-0752-4ad1-8f94-92ad80559414/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcalendar_mobile_tray_delete_spacing_fixed_demo.mp4"><img src="https://cursor.com/artifacts/c/art-6cf557ff-4851-4e2f-ba01-72a81d2f162c" alt="calendar_mobile_tray_delete_spacing_fixed_demo.mp4" /></a>
![Calendar mobile tray bottom spacing](https://cursor.com/artifacts/c/art-3d5bcfdd-e475-413c-8c9d-eb53401a36c9)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d7ba5af9-0752-4ad1-8f94-92ad80559414"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d7ba5af9-0752-4ad1-8f94-92ad80559414"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

