### PR TITLE
fix(calendar): add bottom padding to tray scroller so delete button isn't clipped

### DIFF
--- a/src/apps/calendar/components/TrayDetails.tsx
+++ b/src/apps/calendar/components/TrayDetails.tsx
@@ -328,7 +328,7 @@ function EventTrayEditor({
 
   const panelShell = cn(
     "flex-1 flex flex-col min-h-0 overflow-y-auto",
-    "bg-white pl-2.5 pr-2.5 pt-2 pb-2",
+    "bg-white pl-2.5 pr-2.5 pt-2 pb-4",
     !isMacOSTheme && "rounded-sm border border-black/10"
   );
 
@@ -600,7 +600,7 @@ function TodoDetails({
 
   const panelShell = cn(
     "flex-1 flex flex-col min-h-0 overflow-y-auto",
-    "bg-white pl-2.5 pr-2.5 pt-2 pb-2",
+    "bg-white pl-2.5 pr-2.5 pt-2 pb-4",
     !isMacOSTheme && "rounded-sm border border-black/10"
   );
 

--- a/src/apps/calendar/components/TrayDetails.tsx
+++ b/src/apps/calendar/components/TrayDetails.tsx
@@ -326,9 +326,13 @@ function EventTrayEditor({
     useGeneva ? "font-geneva-12 border-black/25" : "border-black/20"
   );
 
+  // NOTE: keep the scroller's own `pb-*` modest — Mobile Safari clips
+  // padding-bottom on overflow:auto containers when scrolled to the end.
+  // Real bottom breathing room is added below as a sibling spacer that
+  // lives inside the scroll content (reliably honored across browsers).
   const panelShell = cn(
     "flex-1 flex flex-col min-h-0 overflow-y-auto",
-    "bg-white pl-2.5 pr-2.5 pt-2 pb-4",
+    "bg-white pl-2.5 pr-2.5 pt-2 pb-2",
     !isMacOSTheme && "rounded-sm border border-black/10"
   );
 
@@ -522,6 +526,11 @@ function EventTrayEditor({
             {t("apps.calendar.event.delete")}
           </Button>
         </div>
+
+        {/* Trailing spacer: ensures the delete button keeps breathing room
+            above the scroller's bottom edge in browsers (Mobile Safari)
+            that don't honor `padding-bottom` on overflow containers. */}
+        <div aria-hidden className="shrink-0 h-4" />
       </div>
     </div>
   );
@@ -598,9 +607,11 @@ function TodoDetails({
     isXpTheme && "text-black"
   );
 
+  // See note on EventTrayEditor.panelShell: keep scroller `pb-*` minimal and
+  // rely on a trailing spacer below for cross-browser bottom breathing room.
   const panelShell = cn(
     "flex-1 flex flex-col min-h-0 overflow-y-auto",
-    "bg-white pl-2.5 pr-2.5 pt-2 pb-4",
+    "bg-white pl-2.5 pr-2.5 pt-2 pb-2",
     !isMacOSTheme && "rounded-sm border border-black/10"
   );
 
@@ -732,6 +743,11 @@ function TodoDetails({
             {t("apps.calendar.event.delete")}
           </Button>
         </div>
+
+        {/* Trailing spacer: ensures the delete button keeps breathing room
+            above the scroller's bottom edge in browsers (Mobile Safari)
+            that don't honor `padding-bottom` on overflow containers. */}
+        <div aria-hidden className="shrink-0 h-4" />
       </div>
     </div>
   );


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

In the Calendar app's tray details panel (event/todo editor), the **Delete** button at the bottom of the scrollable content was getting clipped against the drawer's bottom edge — most visibly on the mobile bottom-sheet layout where the drawer height is capped at `min(30dvh, 216px)`.

### Why a simple `pb-*` bump wasn't enough

Mobile Safari (WebKit) has a long-standing quirk: `padding-bottom` on a scroll container with `overflow-y: auto` is **not** honored when the user scrolls all the way to the end — the bottom padding gets clipped. Padding/margins on **scroll content** (children of the scroller), however, are honored reliably across all browsers.

### Fix

- Keep the scroller `panelShell` at a minimal `pb-2` (so it still looks balanced when content fits without scrolling).
- Append a trailing **spacer `<div className="shrink-0 h-4" />`** as the last child of the scroll content in both `EventTrayEditor` and `TodoDetails`. Because the spacer is part of the scroll content (not the scroll container's padding box), Mobile Safari extends the scrollable area to include it, giving the delete button reliable bottom breathing room across all browsers and themes.

The button is **not** sticky — it scrolls with the rest of the form as before, just with guaranteed padding below it.

## Files

- `src/apps/calendar/components/TrayDetails.tsx`
  - Reverted `panelShell` `pb-4` → `pb-2` in both editors.
  - Added trailing spacer (`<div aria-hidden className="shrink-0 h-4" />`) inside the scroll content of both `EventTrayEditor` and `TodoDetails`, with explanatory comments.

## Testing

- ✅ `bun run build` — clean compile.
- Layout-agnostic fix that applies on desktop side-drawer and mobile bottom-sheet alike, across all 4 OS themes.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-964b071b-9b57-4810-bc94-bd7e39fedc64"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-964b071b-9b57-4810-bc94-bd7e39fedc64"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

