### PR TITLE
iPod Apple Music: use MusicKit queue directly

### DIFF
--- a/src/apps/ipod/components/AppleMusicPlayerBridge.tsx
+++ b/src/apps/ipod/components/AppleMusicPlayerBridge.tsx
@@ -3,6 +3,8 @@ import type { Track } from "@/stores/useIpodStore";
 import { onMusicKitReady } from "@/hooks/useMusicKit";
 import { PLAYER_PROGRESS_INTERVAL_MS } from "../constants";
 import {
+  buildAppleMusicQueueOptions,
+  resolveAppleMusicQueueTrackIdFromMediaItem,
   getMusicKitEventItemId,
   isWithinEndedFanoutDedupWindow,
   shouldFireEndedForPlaybackState,
@@ -16,8 +18,9 @@ import {
  * logic depends on (`seekTo`, `getCurrentTime`, `getInternalPlayer`).
  *
  * Lifecycle:
- *   - When `currentTrack` changes the bridge calls `setQueue` with the
- *     track's catalog or library ID, then plays/pauses to match `playing`.
+ *   - When the iPod starts a track, the bridge calls `setQueue` with the
+ *     active MusicKit queue (song array, station, or playlist), then
+ *     plays/pauses to match `playing`.
  *   - Listens to `playbackTimeDidChange` / `playbackStateDidChange` /
  *     `mediaItemDidChange` to drive `onProgress` / `onPlay` / `onPause` /
  *     `onDuration` callbacks identical to `react-player`'s shape.
@@ -27,6 +30,8 @@ import {
 export interface AppleMusicPlayerBridgeProps {
   /** Current Apple Music track to play. Triggers `setQueue` on change. */
   currentTrack: Track | null;
+  /** Active iPod context queue. Song queues are handed to MusicKit as-is. */
+  queueTracks?: Track[] | null;
   /** Whether playback should be active. */
   playing: boolean;
   /** Saved playback position to seek to after queueing a track. */
@@ -42,6 +47,7 @@ export interface AppleMusicPlayerBridgeProps {
   onNowPlayingItemChange?: (
     metadata: AppleMusicNowPlayingMetadata | null
   ) => void;
+  onQueueTrackChange?: (trackId: string) => void;
 }
 
 export interface AppleMusicPlayerBridgeHandle {
@@ -56,25 +62,6 @@ export interface AppleMusicNowPlayingMetadata {
   artist?: string;
   album?: string;
   cover?: string;
-}
-
-function getQueueOptions(track: Track): MusicKit.SetQueueOptions | null {
-  const params = track.appleMusicPlayParams;
-  if (!params) return null;
-  if (params.stationId) {
-    return { station: params.stationId, startPlaying: true };
-  }
-  if (params.playlistId) {
-    return { playlist: params.playlistId, startPlaying: true };
-  }
-  // Prefer catalog ID for streaming. Fall back to the library ID when the
-  // track is library-only (no catalog match available).
-  const id =
-    params.kind === "library-songs"
-      ? params.libraryId || params.catalogId
-      : params.catalogId || params.libraryId;
-  if (!id) return null;
-  return { song: id, startPlaying: true };
 }
 
 function getSafeStartSeconds(
@@ -116,6 +103,7 @@ export const AppleMusicPlayerBridge = function AppleMusicPlayerBridge(
   {
     ref,
     currentTrack,
+    queueTracks,
     playing,
     resumeAtSeconds,
     volume,
@@ -125,14 +113,19 @@ export const AppleMusicPlayerBridge = function AppleMusicPlayerBridge(
     onPause,
     onEnded,
     onReady,
-    onNowPlayingItemChange
+    onNowPlayingItemChange,
+    onQueueTrackChange
   }: AppleMusicPlayerBridgeProps & {
     ref?: React.Ref<AppleMusicPlayerBridgeHandle>;
   }
 ) {
   const instanceRef = useRef<MusicKit.MusicKitInstance | null>(null);
   const [instanceReadyTick, setInstanceReadyTick] = useState(0);
-  const lastQueuedTrackIdRef = useRef<string | null>(null);
+  const lastQueuedRequestKeyRef = useRef<string | null>(null);
+  const lastQueuedDefinitionKeyRef = useRef<string | null>(null);
+  const queuedTrackIdsRef = useRef<string[]>([]);
+  const isMultiSongQueueRef = useRef(false);
+  const suppressedQueueTrackIdRef = useRef<string | null>(null);
   const queueLoadingRef = useRef<Promise<void> | null>(null);
   const onReadyRef = useRef(onReady);
   onReadyRef.current = onReady;
@@ -187,17 +180,21 @@ export const AppleMusicPlayerBridge = function AppleMusicPlayerBridge(
   const onPauseRef = useRef(onPause);
   const onEndedRef = useRef(onEnded);
   const onNowPlayingItemChangeRef = useRef(onNowPlayingItemChange);
+  const onQueueTrackChangeRef = useRef(onQueueTrackChange);
   onProgressRef.current = onProgress;
   onDurationRef.current = onDuration;
   onPlayRef.current = onPlay;
   onPauseRef.current = onPause;
   onEndedRef.current = onEnded;
   onNowPlayingItemChangeRef.current = onNowPlayingItemChange;
+  onQueueTrackChangeRef.current = onQueueTrackChange;
 
   // Track latest currentTrack so the once-only event listeners can read it
   // without resubscribing on every render.
   const currentTrackRef = useRef(currentTrack);
   currentTrackRef.current = currentTrack;
+  const queueTracksRef = useRef(queueTracks);
+  queueTracksRef.current = queueTracks;
 
   // Dedup state for `onEnded` fan-out. MusicKit JS fires both `ended`
   // (5) and `completed` (10) when a single-song queue's only item
@@ -244,7 +241,11 @@ export const AppleMusicPlayerBridge = function AppleMusicPlayerBridge(
       }
       if (
         (state === 5 || state === 10) &&
-        shouldFireEndedForPlaybackState(state, currentTrackRef.current)
+        shouldFireEndedForPlaybackState(
+          state,
+          currentTrackRef.current,
+          isMultiSongQueueRef.current
+        )
       ) {
         // MusicKit fires both `ended` (5) and `completed` (10) when a
         // single-song queue's only item finishes — dedup so the parent's
@@ -284,6 +285,18 @@ export const AppleMusicPlayerBridge = function AppleMusicPlayerBridge(
         0;
       if (durationMs > 0) {
         onDurationRef.current?.(durationMs / 1000);
+      }
+      if (queuedTrackIdsRef.current.length > 0) {
+        const trackId = resolveAppleMusicQueueTrackIdFromMediaItem(
+          event.item,
+          (queueTracksRef.current ?? []).filter((track) =>
+            queuedTrackIdsRef.current.includes(track.id)
+          )
+        );
+        if (trackId && queuedTrackIdsRef.current.includes(trackId)) {
+          suppressedQueueTrackIdRef.current = trackId;
+          onQueueTrackChangeRef.current?.(trackId);
+        }
       }
       onNowPlayingItemChangeRef.current?.(
         mediaItemToNowPlayingMetadata(event.item)
@@ -428,9 +441,16 @@ export const AppleMusicPlayerBridge = function AppleMusicPlayerBridge(
     }
   }, [volume]);
 
-  // Stable representation of the queue so we only call setQueue when the
-  // *track* (not unrelated prop changes) actually flips.
-  const queueKey = useMemo(() => currentTrack?.id ?? null, [currentTrack]);
+  // Stable representation of the queue so MusicKit only receives a fresh
+  // queue for explicit iPod selections, not for native auto-advances.
+  const queueBuild = useMemo(
+    () =>
+      currentTrack
+        ? buildAppleMusicQueueOptions(currentTrack, queueTracks)
+        : null,
+    [currentTrack, queueTracks]
+  );
+  const queueKey = queueBuild?.requestKey ?? null;
 
   // Latest `playing` value, read inside the async setQueue effect to avoid
   // stale closures when the user toggles play before the queue resolves.
@@ -451,22 +471,31 @@ export const AppleMusicPlayerBridge = function AppleMusicPlayerBridge(
         /* ignore */
       }
       onNowPlayingItemChangeRef.current?.(null);
-      lastQueuedTrackIdRef.current = null;
+      lastQueuedRequestKeyRef.current = null;
+      lastQueuedDefinitionKeyRef.current = null;
+      queuedTrackIdsRef.current = [];
+      isMultiSongQueueRef.current = false;
       return;
     }
-    if (lastQueuedTrackIdRef.current === queueKey) return;
-    onNowPlayingItemChangeRef.current?.(null);
-
-    const queueOptions = getQueueOptions(currentTrack);
-    if (!queueOptions) {
+    if (!queueBuild) {
       console.warn(
         "[apple music] track is missing playParams, skipping",
         currentTrack
       );
       return;
     }
+    if (lastQueuedRequestKeyRef.current === queueBuild.requestKey) return;
+    if (
+      suppressedQueueTrackIdRef.current === currentTrack.id &&
+      lastQueuedDefinitionKeyRef.current === queueBuild.definitionKey
+    ) {
+      suppressedQueueTrackIdRef.current = null;
+      lastQueuedRequestKeyRef.current = queueBuild.requestKey;
+      return;
+    }
+    onNowPlayingItemChangeRef.current?.(null);
 
-    const localQueueKey = queueKey;
+    const localQueueBuild = queueBuild;
     // Serialize back-to-back queue swaps. If another track change is
     // already in flight (rapid `nextTrack` clicks, an `onEnded` advance
     // racing a user press, etc.), wait for it to settle before issuing
@@ -496,7 +525,7 @@ export const AppleMusicPlayerBridge = function AppleMusicPlayerBridge(
           resumeAtSecondsRef.current
         );
         await inst.setQueue({
-          ...queueOptions,
+          ...localQueueBuild.options,
           startTime: resumeSeconds ?? undefined,
           // Queue paused first so a restored elapsedTime can be applied
           // before any audible playback starts.
@@ -512,7 +541,10 @@ export const AppleMusicPlayerBridge = function AppleMusicPlayerBridge(
         if (currentTrack.durationMs && currentTrack.durationMs > 0) {
           onDurationRef.current?.(currentTrack.durationMs / 1000);
         }
-        lastQueuedTrackIdRef.current = localQueueKey;
+        lastQueuedRequestKeyRef.current = localQueueBuild.requestKey;
+        lastQueuedDefinitionKeyRef.current = localQueueBuild.definitionKey;
+        queuedTrackIdsRef.current = localQueueBuild.queuedTrackIds;
+        isMultiSongQueueRef.current = localQueueBuild.isMultiSongQueue;
         if (playingRef.current) {
           await inst.play().catch((err) => {
             // Browsers block autoplay until the user interacts; surface as
@@ -542,7 +574,7 @@ export const AppleMusicPlayerBridge = function AppleMusicPlayerBridge(
       cancelled = true;
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [queueKey, instanceReadyTick]);
+  }, [queueKey, queueBuild, currentTrack, instanceReadyTick]);
 
   // Sync play/pause without re-queueing.
   useEffect(() => {

--- a/src/apps/ipod/components/AppleMusicPlayerBridge.tsx
+++ b/src/apps/ipod/components/AppleMusicPlayerBridge.tsx
@@ -599,6 +599,7 @@ export const AppleMusicPlayerBridge = function AppleMusicPlayerBridge(
       return;
     }
     onNowPlayingItemChangeRef.current?.(null);
+    // User explicitly picked a track — always allow a fresh queue load.
     suppressedQueueTrackIdRef.current = null;
     playbackTargetTrackIdRef.current = currentTrack.id;
 
@@ -641,30 +642,41 @@ export const AppleMusicPlayerBridge = function AppleMusicPlayerBridge(
             surface.changeToMediaAtIndex?.bind(surface) ??
             inst.changeToMediaAtIndex?.bind(inst);
           if (changeAtIndex) {
-            await changeAtIndex(inQueueIndex);
-            if (cancelled) return;
-            if (resumeSeconds != null) {
-              await inst.seekToTime(resumeSeconds).catch((err) => {
-                console.warn("[apple music] in-queue resume seek failed", err);
-              });
+            try {
+              await changeAtIndex(inQueueIndex);
+              if (cancelled) return;
+              if (resumeSeconds != null) {
+                await inst.seekToTime(resumeSeconds).catch((err) => {
+                  console.warn(
+                    "[apple music] in-queue resume seek failed",
+                    err
+                  );
+                });
+              }
+              if (cancelled) return;
+              if (currentTrack.durationMs && currentTrack.durationMs > 0) {
+                onDurationRef.current?.(currentTrack.durationMs / 1000);
+              }
+              lastQueuedRequestKeyRef.current = localQueueBuild.requestKey;
+              lastQueuedDefinitionKeyRef.current = localQueueBuild.definitionKey;
+              queuedTrackIdsRef.current = localQueueBuild.queuedTrackIds;
+              isMultiSongQueueRef.current = localQueueBuild.isMultiSongQueue;
+              if (playingRef.current) {
+                await inst.play().catch((err) => {
+                  console.warn(
+                    "[apple music] play() after in-queue jump blocked",
+                    err
+                  );
+                  onPauseRef.current?.();
+                });
+              }
+              return;
+            } catch (err) {
+              console.warn(
+                "[apple music] in-queue jump failed, falling back to setQueue",
+                err
+              );
             }
-            if (cancelled) return;
-            if (currentTrack.durationMs && currentTrack.durationMs > 0) {
-              onDurationRef.current?.(currentTrack.durationMs / 1000);
-            }
-            lastQueuedRequestKeyRef.current = localQueueBuild.requestKey;
-            queuedTrackIdsRef.current = localQueueBuild.queuedTrackIds;
-            isMultiSongQueueRef.current = localQueueBuild.isMultiSongQueue;
-            if (playingRef.current) {
-              await inst.play().catch((err) => {
-                console.warn(
-                  "[apple music] play() after in-queue jump blocked",
-                  err
-                );
-                onPauseRef.current?.();
-              });
-            }
-            return;
           }
         }
         await inst.setQueue({

--- a/src/apps/ipod/components/AppleMusicPlayerBridge.tsx
+++ b/src/apps/ipod/components/AppleMusicPlayerBridge.tsx
@@ -8,6 +8,7 @@ import {
   getMusicKitEventItemId,
   isWithinEndedFanoutDedupWindow,
   shouldFireEndedForPlaybackState,
+  shouldSyncQueueTrackFromMediaItem,
 } from "./appleMusicPlayerBridgeUtils";
 
 /**
@@ -126,6 +127,8 @@ export const AppleMusicPlayerBridge = function AppleMusicPlayerBridge(
   const queuedTrackIdsRef = useRef<string[]>([]);
   const isMultiSongQueueRef = useRef(false);
   const suppressedQueueTrackIdRef = useRef<string | null>(null);
+  /** Blocks MusicKit→iPod sync while a user-selected track is being queued. */
+  const playbackTargetTrackIdRef = useRef<string | null>(null);
   const queueLoadingRef = useRef<Promise<void> | null>(null);
   const onReadyRef = useRef(onReady);
   onReadyRef.current = onReady;
@@ -235,8 +238,12 @@ export const AppleMusicPlayerBridge = function AppleMusicPlayerBridge(
     );
     if (
       !trackId ||
-      !queuedTrackIdsRef.current.includes(trackId) ||
-      trackId === currentTrackRef.current?.id
+      !shouldSyncQueueTrackFromMediaItem(
+        trackId,
+        currentTrackRef.current?.id,
+        playbackTargetTrackIdRef.current,
+        queuedTrackIdsRef.current
+      )
     ) {
       return false;
     }
@@ -493,6 +500,7 @@ export const AppleMusicPlayerBridge = function AppleMusicPlayerBridge(
       lastQueuedDefinitionKeyRef.current = null;
       queuedTrackIdsRef.current = [];
       isMultiSongQueueRef.current = false;
+      playbackTargetTrackIdRef.current = null;
       return;
     }
     if (!queueBuild) {
@@ -512,6 +520,8 @@ export const AppleMusicPlayerBridge = function AppleMusicPlayerBridge(
       return;
     }
     onNowPlayingItemChangeRef.current?.(null);
+    suppressedQueueTrackIdRef.current = null;
+    playbackTargetTrackIdRef.current = currentTrack.id;
 
     const localQueueBuild = queueBuild;
     // Serialize back-to-back queue swaps. If another track change is
@@ -584,6 +594,9 @@ export const AppleMusicPlayerBridge = function AppleMusicPlayerBridge(
         // `setQueue` mid-flight.
         if (queueLoadingRef.current === thisLoad) {
           queueLoadingRef.current = null;
+        }
+        if (playbackTargetTrackIdRef.current === currentTrack.id) {
+          playbackTargetTrackIdRef.current = null;
         }
       }
     })();

--- a/src/apps/ipod/components/AppleMusicPlayerBridge.tsx
+++ b/src/apps/ipod/components/AppleMusicPlayerBridge.tsx
@@ -213,6 +213,39 @@ export const AppleMusicPlayerBridge = function AppleMusicPlayerBridge(
   const lastEndedFiredForItemIdRef = useRef<string | null>(null);
   const lastEndedFiredAtRef = useRef(0);
 
+  const emitDurationForMediaItem = (
+    item: MusicKit.MediaItem | null | undefined
+  ) => {
+    const durationMs =
+      item?.attributes?.durationInMillis ?? item?.playbackDuration ?? 0;
+    if (durationMs > 0) {
+      onDurationRef.current?.(durationMs / 1000);
+    }
+  };
+
+  const syncQueueTrackFromMediaItem = (
+    item: MusicKit.MediaItem | null | undefined
+  ): boolean => {
+    if (queuedTrackIdsRef.current.length === 0) return false;
+    const trackId = resolveAppleMusicQueueTrackIdFromMediaItem(
+      item,
+      (queueTracksRef.current ?? []).filter((track) =>
+        queuedTrackIdsRef.current.includes(track.id)
+      )
+    );
+    if (
+      !trackId ||
+      !queuedTrackIdsRef.current.includes(trackId) ||
+      trackId === currentTrackRef.current?.id
+    ) {
+      return false;
+    }
+    suppressedQueueTrackIdRef.current = trackId;
+    onQueueTrackChangeRef.current?.(trackId);
+    emitDurationForMediaItem(item);
+    return true;
+  };
+
   // Wire up MusicKit event listeners once the instance is available.
   // We deliberately skip `playbackTimeDidChange` for progress updates:
   // runtime logs (debug session b224e4) confirmed that MusicKit JS v3's
@@ -279,24 +312,8 @@ export const AppleMusicPlayerBridge = function AppleMusicPlayerBridge(
     };
 
     const handleMediaItem = (event: MusicKit.MediaItemDidChangeEvent) => {
-      const durationMs =
-        event.item?.attributes?.durationInMillis ??
-        event.item?.playbackDuration ??
-        0;
-      if (durationMs > 0) {
-        onDurationRef.current?.(durationMs / 1000);
-      }
-      if (queuedTrackIdsRef.current.length > 0) {
-        const trackId = resolveAppleMusicQueueTrackIdFromMediaItem(
-          event.item,
-          (queueTracksRef.current ?? []).filter((track) =>
-            queuedTrackIdsRef.current.includes(track.id)
-          )
-        );
-        if (trackId && queuedTrackIdsRef.current.includes(trackId)) {
-          suppressedQueueTrackIdRef.current = trackId;
-          onQueueTrackChangeRef.current?.(trackId);
-        }
+      if (!syncQueueTrackFromMediaItem(event.item)) {
+        emitDurationForMediaItem(event.item);
       }
       onNowPlayingItemChangeRef.current?.(
         mediaItemToNowPlayingMetadata(event.item)
@@ -367,6 +384,7 @@ export const AppleMusicPlayerBridge = function AppleMusicPlayerBridge(
       const inst = instanceRef.current;
       if (!inst) return;
       const rawSeconds = inst.currentPlaybackTime ?? 0;
+      syncQueueTrackFromMediaItem(inst.nowPlayingItem);
 
       // First read or whenever the underlying integer changes (forward
       // OR backward, e.g. seek), reset the interpolation baseline.

--- a/src/apps/ipod/components/AppleMusicPlayerBridge.tsx
+++ b/src/apps/ipod/components/AppleMusicPlayerBridge.tsx
@@ -4,12 +4,22 @@ import { onMusicKitReady } from "@/hooks/useMusicKit";
 import { PLAYER_PROGRESS_INTERVAL_MS } from "../constants";
 import {
   buildAppleMusicQueueOptions,
+  buildAppleMusicQueuePlacementOptions,
+  getAppleMusicSongQueueId,
+  getInQueueNavigationIndex,
   resolveAppleMusicQueueTrackIdFromMediaItem,
   getMusicKitEventItemId,
   isWithinEndedFanoutDedupWindow,
   shouldFireEndedForPlaybackState,
   shouldSyncQueueTrackFromMediaItem,
 } from "./appleMusicPlayerBridgeUtils";
+import {
+  applyMusicKitShuffleRepeat,
+  canShowMusicKitAirPlayPicker,
+  getMusicKitPlaybackSurface,
+  isMusicKitBufferingState,
+  showMusicKitAirPlayPicker,
+} from "../utils/musickitPlayerAccess";
 
 /**
  * Apple Music playback bridge.
@@ -39,6 +49,12 @@ export interface AppleMusicPlayerBridgeProps {
   resumeAtSeconds?: number;
   /** Volume in [0, 1]. */
   volume: number;
+  /** Mirror iPod shuffle to MusicKit when true. */
+  isShuffled?: boolean;
+  /** Mirror iPod repeat-one to MusicKit when true. */
+  loopCurrent?: boolean;
+  /** Mirror iPod repeat-all to MusicKit when true. */
+  loopAll?: boolean;
   onProgress?: (state: { playedSeconds: number }) => void;
   onDuration?: (duration: number) => void;
   onPlay?: () => void;
@@ -49,12 +65,19 @@ export interface AppleMusicPlayerBridgeProps {
     metadata: AppleMusicNowPlayingMetadata | null
   ) => void;
   onQueueTrackChange?: (trackId: string) => void;
+  onBufferingChange?: (buffering: boolean) => void;
 }
+
+export type AppleMusicQueuePlacement = "next" | "later";
 
 export interface AppleMusicPlayerBridgeHandle {
   seekTo(seconds: number): void;
   getCurrentTime(): number;
   getInternalPlayer(): MusicKit.MusicKitInstance | null;
+  queueTrack(track: Track, placement: AppleMusicQueuePlacement): Promise<void>;
+  showAirPlayPicker(): boolean;
+  addTrackToLibrary(track: Track): Promise<void>;
+  canShowAirPlayPicker(): boolean;
 }
 
 export interface AppleMusicNowPlayingMetadata {
@@ -108,6 +131,9 @@ export const AppleMusicPlayerBridge = function AppleMusicPlayerBridge(
     playing,
     resumeAtSeconds,
     volume,
+    isShuffled = false,
+    loopCurrent = false,
+    loopAll = true,
     onProgress,
     onDuration,
     onPlay,
@@ -115,7 +141,8 @@ export const AppleMusicPlayerBridge = function AppleMusicPlayerBridge(
     onEnded,
     onReady,
     onNowPlayingItemChange,
-    onQueueTrackChange
+    onQueueTrackChange,
+    onBufferingChange
   }: AppleMusicPlayerBridgeProps & {
     ref?: React.Ref<AppleMusicPlayerBridgeHandle>;
   }
@@ -184,6 +211,7 @@ export const AppleMusicPlayerBridge = function AppleMusicPlayerBridge(
   const onEndedRef = useRef(onEnded);
   const onNowPlayingItemChangeRef = useRef(onNowPlayingItemChange);
   const onQueueTrackChangeRef = useRef(onQueueTrackChange);
+  const onBufferingChangeRef = useRef(onBufferingChange);
   onProgressRef.current = onProgress;
   onDurationRef.current = onDuration;
   onPlayRef.current = onPlay;
@@ -191,6 +219,10 @@ export const AppleMusicPlayerBridge = function AppleMusicPlayerBridge(
   onEndedRef.current = onEnded;
   onNowPlayingItemChangeRef.current = onNowPlayingItemChange;
   onQueueTrackChangeRef.current = onQueueTrackChange;
+  onBufferingChangeRef.current = onBufferingChange;
+
+  const shuffleRepeatRef = useRef({ isShuffled, loopCurrent, loopAll });
+  shuffleRepeatRef.current = { isShuffled, loopCurrent, loopAll };
 
   // Track latest currentTrack so the once-only event listeners can read it
   // without resubscribing on every render.
@@ -271,6 +303,7 @@ export const AppleMusicPlayerBridge = function AppleMusicPlayerBridge(
 
     const handleState = (event: MusicKit.PlaybackStateDidChangeEvent) => {
       const state = event?.state ?? activeInstance?.playbackState;
+      onBufferingChangeRef.current?.(isMusicKitBufferingState(state));
       if (state === 2) {
         onPlayRef.current?.();
         return;
@@ -327,6 +360,27 @@ export const AppleMusicPlayerBridge = function AppleMusicPlayerBridge(
       );
     };
 
+    const handleQueueItemsDidChange = () => {
+      const inst = activeInstance;
+      if (!inst) return;
+      const surface = getMusicKitPlaybackSurface(inst);
+      const index = surface.nowPlayingItemIndex;
+      if (
+        typeof index === "number" &&
+        index >= 0 &&
+        index < queuedTrackIdsRef.current.length
+      ) {
+        const trackId = queuedTrackIdsRef.current[index];
+        if (trackId && trackId !== currentTrackRef.current?.id) {
+          syncQueueTrackFromMediaItem(surface.nowPlayingItem ?? inst.nowPlayingItem);
+        }
+      }
+    };
+
+    const handleQueueReady = () => {
+      queueLoadingRef.current = null;
+    };
+
     const tryAttach = (inst: MusicKit.MusicKitInstance | null) => {
       if (cancelled || !inst) return;
       if (activeInstance === inst) return;
@@ -335,6 +389,14 @@ export const AppleMusicPlayerBridge = function AppleMusicPlayerBridge(
       inst.addEventListener("mediaItemDidChange", handleMediaItem);
       // Some MusicKit builds emit nowPlayingItemDidChange instead.
       inst.addEventListener("nowPlayingItemDidChange", handleMediaItem);
+      inst.addEventListener("queueIsReady", handleQueueReady);
+      inst.addEventListener("queueItemsDidChange", handleQueueItemsDidChange);
+      const surface = getMusicKitPlaybackSurface(inst);
+      surface.queue?.addEventListener?.(
+        "queueItemsDidChange",
+        handleQueueItemsDidChange
+      );
+      applyMusicKitShuffleRepeat(inst, shuffleRepeatRef.current);
     };
 
     tryAttach(instanceRef.current);
@@ -355,6 +417,16 @@ export const AppleMusicPlayerBridge = function AppleMusicPlayerBridge(
         activeInstance.removeEventListener(
           "nowPlayingItemDidChange",
           handleMediaItem
+        );
+        activeInstance.removeEventListener("queueIsReady", handleQueueReady);
+        activeInstance.removeEventListener(
+          "queueItemsDidChange",
+          handleQueueItemsDidChange
+        );
+        const surface = getMusicKitPlaybackSurface(activeInstance);
+        surface.queue?.removeEventListener?.(
+          "queueItemsDidChange",
+          handleQueueItemsDidChange
         );
       }
     };
@@ -466,6 +538,13 @@ export const AppleMusicPlayerBridge = function AppleMusicPlayerBridge(
     }
   }, [volume]);
 
+  // Mirror iPod shuffle / repeat to MusicKit's native queue modes.
+  useEffect(() => {
+    const inst = instanceRef.current;
+    if (!inst) return;
+    applyMusicKitShuffleRepeat(inst, { isShuffled, loopCurrent, loopAll });
+  }, [isShuffled, loopCurrent, loopAll, instanceReadyTick]);
+
   // Stable representation of the queue so MusicKit only receives a fresh
   // queue for explicit iPod selections, not for native auto-advances.
   const queueBuild = useMemo(
@@ -524,6 +603,10 @@ export const AppleMusicPlayerBridge = function AppleMusicPlayerBridge(
     playbackTargetTrackIdRef.current = currentTrack.id;
 
     const localQueueBuild = queueBuild;
+    const inQueueIndex = getInQueueNavigationIndex(
+      localQueueBuild,
+      lastQueuedDefinitionKeyRef.current
+    );
     // Serialize back-to-back queue swaps. If another track change is
     // already in flight (rapid `nextTrack` clicks, an `onEnded` advance
     // racing a user press, etc.), wait for it to settle before issuing
@@ -552,6 +635,38 @@ export const AppleMusicPlayerBridge = function AppleMusicPlayerBridge(
           currentTrack,
           resumeAtSecondsRef.current
         );
+        if (inQueueIndex !== null) {
+          const surface = getMusicKitPlaybackSurface(inst);
+          const changeAtIndex =
+            surface.changeToMediaAtIndex?.bind(surface) ??
+            inst.changeToMediaAtIndex?.bind(inst);
+          if (changeAtIndex) {
+            await changeAtIndex(inQueueIndex);
+            if (cancelled) return;
+            if (resumeSeconds != null) {
+              await inst.seekToTime(resumeSeconds).catch((err) => {
+                console.warn("[apple music] in-queue resume seek failed", err);
+              });
+            }
+            if (cancelled) return;
+            if (currentTrack.durationMs && currentTrack.durationMs > 0) {
+              onDurationRef.current?.(currentTrack.durationMs / 1000);
+            }
+            lastQueuedRequestKeyRef.current = localQueueBuild.requestKey;
+            queuedTrackIdsRef.current = localQueueBuild.queuedTrackIds;
+            isMultiSongQueueRef.current = localQueueBuild.isMultiSongQueue;
+            if (playingRef.current) {
+              await inst.play().catch((err) => {
+                console.warn(
+                  "[apple music] play() after in-queue jump blocked",
+                  err
+                );
+                onPauseRef.current?.();
+              });
+            }
+            return;
+          }
+        }
         await inst.setQueue({
           ...localQueueBuild.options,
           startTime: resumeSeconds ?? undefined,
@@ -657,6 +772,51 @@ export const AppleMusicPlayerBridge = function AppleMusicPlayerBridge(
       },
       getInternalPlayer() {
         return instanceRef.current;
+      },
+      async queueTrack(track: Track, placement: AppleMusicQueuePlacement) {
+        const inst = instanceRef.current;
+        if (!inst) return;
+        const options = buildAppleMusicQueuePlacementOptions(track);
+        if (!options) {
+          throw new Error("Track is missing Apple Music play parameters");
+        }
+        const pending = queueLoadingRef.current;
+        if (pending) await pending;
+        const queueFn =
+          placement === "next"
+            ? inst.playNext?.bind(inst)
+            : inst.playLater?.bind(inst);
+        if (queueFn) {
+          await queueFn(options);
+          return;
+        }
+        const surface = getMusicKitPlaybackSurface(inst);
+        if (placement === "next") {
+          surface.queue?.prepend(options);
+        } else {
+          surface.queue?.append(options);
+        }
+      },
+      showAirPlayPicker() {
+        const inst = instanceRef.current;
+        if (!inst) return false;
+        return showMusicKitAirPlayPicker(inst);
+      },
+      canShowAirPlayPicker() {
+        const inst = instanceRef.current;
+        if (!inst) return false;
+        return canShowMusicKitAirPlayPicker(inst);
+      },
+      async addTrackToLibrary(track: Track) {
+        const inst = instanceRef.current;
+        if (!inst?.addToLibrary) {
+          throw new Error("MusicKit addToLibrary is unavailable");
+        }
+        const songId = getAppleMusicSongQueueId(track);
+        if (!songId) {
+          throw new Error("Track is missing a library/catalog song id");
+        }
+        await inst.addToLibrary(songId, "songs");
       },
     }),
     []

--- a/src/apps/ipod/components/IpodAppComponent.tsx
+++ b/src/apps/ipod/components/IpodAppComponent.tsx
@@ -52,6 +52,7 @@ export function IpodAppComponent({
     coverFlowCurrentIndex,
     loopCurrent,
     isShuffled,
+    loopAll,
     isPlaying,
     showVideo,
     backlightOn,
@@ -142,6 +143,9 @@ export function IpodAppComponent({
     handleAppleMusicSearch,
     handleAppleMusicSearchSelect,
     handleAppleMusicAddToFavorites,
+    handleAppleMusicAirPlay,
+    handleAppleMusicAddToLibrary,
+    handleAppleMusicBufferingChange,
     handleRefreshLyrics,
     handleLyricsSearchSelect,
     handleLyricsSearchReset,
@@ -263,6 +267,8 @@ export function IpodAppComponent({
       onAddSong={handleAddSong}
       onShareSong={handleShareSong}
       onAddToFavorites={handleAppleMusicAddToFavorites}
+      onAppleMusicAirPlay={handleAppleMusicAirPlay}
+      onAppleMusicAddToLibrary={handleAppleMusicAddToLibrary}
       onRefreshLyrics={handleRefreshLyrics}
       onAdjustTiming={() => setIsSyncModeOpen(true)}
       onToggleCoverFlow={() => setIsCoverFlowOpen(!isCoverFlowOpen)}
@@ -435,6 +441,7 @@ export function IpodAppComponent({
                   handleReady={handleReady}
                   loopCurrent={loopCurrent}
                   isShuffled={isShuffled}
+                  loopAll={loopAll}
                   statusMessage={statusMessage}
                   onToggleVideo={toggleVideo}
                   lcdFilterOn={lcdFilterOn}
@@ -454,6 +461,7 @@ export function IpodAppComponent({
                   activityState={activityState}
                   appleMusicQueueTracks={appleMusicQueueTracks}
                   onAppleMusicQueueTrackChange={handleAppleMusicQueueTrackChange}
+                  onAppleMusicBufferingChange={handleAppleMusicBufferingChange}
                   isCoverFlowOpen={isCoverFlowOpen}
                   // Modern UI: render Cover Flow inline inside the menu
                   // panel so the panel's own width transition (50%↔100%
@@ -669,6 +677,9 @@ export function IpodAppComponent({
                                 ipodVolume *
                                 useAudioSettingsStore.getState().masterVolume
                               }
+                              isShuffled={isShuffled}
+                              loopCurrent={loopCurrent}
+                              loopAll={loopAll}
                               onProgress={handleProgress}
                               onDuration={handleDuration}
                               onPlay={handlePlay}
@@ -677,6 +688,7 @@ export function IpodAppComponent({
                               onReady={handleReady}
                               onNowPlayingItemChange={setAppleMusicKitNowPlaying}
                               onQueueTrackChange={handleAppleMusicQueueTrackChange}
+                              onBufferingChange={handleAppleMusicBufferingChange}
                             />
                           ) : (
                             <ReactPlayer

--- a/src/apps/ipod/components/IpodAppComponent.tsx
+++ b/src/apps/ipod/components/IpodAppComponent.tsx
@@ -162,6 +162,8 @@ export function IpodAppComponent({
     setIsCoverFlowOpen,
     nextTrack,
     previousTrack,
+    appleMusicQueueTracks,
+    handleAppleMusicQueueTrackChange,
     clearLibrary,
     manualSync,
     restoreInstance,
@@ -276,6 +278,8 @@ export function IpodAppComponent({
       onAppleMusicSignIn={handleAppleMusicSignIn}
       onAppleMusicSignOut={handleAppleMusicSignOut}
       onAppleMusicRefresh={handleAppleMusicRefresh}
+      onNextTrack={nextTrack}
+      onPreviousTrack={previousTrack}
     />
   );
   const shouldAnimateFullScreenVisuals = isPlaying && (isForeground ?? true);
@@ -448,6 +452,8 @@ export function IpodAppComponent({
                   furiganaMap={furiganaMap}
                   soramimiMap={soramimiMap}
                   activityState={activityState}
+                  appleMusicQueueTracks={appleMusicQueueTracks}
+                  onAppleMusicQueueTrackChange={handleAppleMusicQueueTrackChange}
                   isCoverFlowOpen={isCoverFlowOpen}
                   // Modern UI: render Cover Flow inline inside the menu
                   // panel so the panel's own width transition (50%↔100%
@@ -656,6 +662,7 @@ export function IpodAppComponent({
                                 fullScreenPlayerRef as unknown as React.RefObject<never>
                               }
                               currentTrack={tracks[currentIndex]}
+                              queueTracks={appleMusicQueueTracks}
                               playing={isPlaying && isFullScreen}
                               resumeAtSeconds={elapsedTime}
                               volume={
@@ -669,6 +676,7 @@ export function IpodAppComponent({
                               onEnded={handleTrackEnd}
                               onReady={handleReady}
                               onNowPlayingItemChange={setAppleMusicKitNowPlaying}
+                              onQueueTrackChange={handleAppleMusicQueueTrackChange}
                             />
                           ) : (
                             <ReactPlayer

--- a/src/apps/ipod/components/IpodMenuBar.tsx
+++ b/src/apps/ipod/components/IpodMenuBar.tsx
@@ -43,6 +43,8 @@ interface IpodMenuBarProps {
   onRefreshLyrics?: () => void;
   onAdjustTiming?: () => void;
   onToggleCoverFlow?: () => void;
+  onNextTrack?: () => void;
+  onPreviousTrack?: () => void;
   // Apple Music integration
   appleMusicAuthorized?: boolean;
   musicKitConfigured?: boolean;
@@ -64,6 +66,8 @@ export function IpodMenuBar({
   onRefreshLyrics,
   onAdjustTiming,
   onToggleCoverFlow,
+  onNextTrack,
+  onPreviousTrack,
   appleMusicAuthorized = false,
   musicKitConfigured = true,
   onSwitchLibrary,
@@ -213,8 +217,9 @@ export function IpodMenuBar({
   const setCurrentSongId = isAppleMusic
     ? setAppleMusicCurrentSongId
     : setYoutubeCurrentSongId;
-  const nextTrack = isAppleMusic ? appleMusicNext : youtubeNext;
-  const previousTrack = isAppleMusic ? appleMusicPrevious : youtubePrevious;
+  const nextTrack = onNextTrack ?? (isAppleMusic ? appleMusicNext : youtubeNext);
+  const previousTrack =
+    onPreviousTrack ?? (isAppleMusic ? appleMusicPrevious : youtubePrevious);
 
   // Compute currentIndex from currentSongId
   const currentIndex = useMemo(() => {

--- a/src/apps/ipod/components/IpodMenuBar.tsx
+++ b/src/apps/ipod/components/IpodMenuBar.tsx
@@ -40,6 +40,8 @@ interface IpodMenuBarProps {
   onAddSong: () => void;
   onShareSong: () => void;
   onAddToFavorites?: () => void;
+  onAppleMusicAirPlay?: () => void;
+  onAppleMusicAddToLibrary?: () => void;
   onRefreshLyrics?: () => void;
   onAdjustTiming?: () => void;
   onToggleCoverFlow?: () => void;
@@ -63,6 +65,8 @@ export function IpodMenuBar({
   onAddSong,
   onShareSong,
   onAddToFavorites,
+  onAppleMusicAirPlay,
+  onAppleMusicAddToLibrary,
   onRefreshLyrics,
   onAdjustTiming,
   onToggleCoverFlow,
@@ -410,6 +414,29 @@ export function IpodMenuBar({
             >
               {t("apps.ipod.menu.addToFavorites", "Add to Favorites")}
             </MenubarItem>
+          )}
+          {isAppleMusic && (
+            <>
+              <MenubarItem
+                onClick={onAppleMusicAirPlay}
+                className="text-md h-6 px-3"
+                disabled={!appleMusicAuthorized || !onAppleMusicAirPlay}
+              >
+                {t("apps.ipod.menu.airPlay", "AirPlay")}
+              </MenubarItem>
+              <MenubarItem
+                onClick={onAppleMusicAddToLibrary}
+                className="text-md h-6 px-3"
+                disabled={
+                  !appleMusicAuthorized ||
+                  !onAppleMusicAddToLibrary ||
+                  tracks.length === 0 ||
+                  currentIndex === -1
+                }
+              >
+                {t("apps.ipod.menu.addToAppleMusicLibrary", "Add to Library")}
+              </MenubarItem>
+            </>
           )}
           {!isAppleMusic && (
             <>

--- a/src/apps/ipod/components/IpodScreen.tsx
+++ b/src/apps/ipod/components/IpodScreen.tsx
@@ -296,6 +296,8 @@ export function IpodScreen({
   handleReady,
   loopCurrent,
   isShuffled,
+  loopAll,
+  onAppleMusicBufferingChange,
   statusMessage,
   onToggleVideo,
   lcdFilterOn,
@@ -324,7 +326,8 @@ export function IpodScreen({
     activityState.isTranslating || 
     activityState.isFetchingFurigana || 
     activityState.isFetchingSoramimi || 
-    activityState.isAddingSong;
+    activityState.isAddingSong ||
+    activityState.isBufferingPlayback;
 
   // Current menu title — Cover Flow takes priority because it covers
   // the entire menu panel, regardless of the underlying menu/now-
@@ -1274,6 +1277,9 @@ export function IpodScreen({
                 playing={isPlaying && !isFullScreen}
                 resumeAtSeconds={elapsedTime}
                 volume={finalIpodVolume}
+                isShuffled={isShuffled}
+                loopCurrent={loopCurrent}
+                loopAll={loopAll}
                 onProgress={!isFullScreen ? handleProgress : undefined}
                 onDuration={!isFullScreen ? handleDuration : undefined}
                 onPlay={!isFullScreen ? handlePlay : undefined}
@@ -1282,6 +1288,7 @@ export function IpodScreen({
                 onReady={!isFullScreen ? handleReady : undefined}
                 onNowPlayingItemChange={setAppleMusicKitNowPlaying}
                 onQueueTrackChange={onAppleMusicQueueTrackChange}
+                onBufferingChange={onAppleMusicBufferingChange}
               />
             ) : (
               <div

--- a/src/apps/ipod/components/IpodScreen.tsx
+++ b/src/apps/ipod/components/IpodScreen.tsx
@@ -271,6 +271,8 @@ const menuVariants = {
 
 export function IpodScreen({
   currentTrack,
+  appleMusicQueueTracks,
+  onAppleMusicQueueTrackChange,
   isPlaying,
   elapsedTime,
   totalTime,
@@ -1268,6 +1270,7 @@ export function IpodScreen({
               <AppleMusicPlayerBridge
                 ref={playerRef as unknown as React.RefObject<never>}
                 currentTrack={currentTrack}
+                queueTracks={appleMusicQueueTracks}
                 playing={isPlaying && !isFullScreen}
                 resumeAtSeconds={elapsedTime}
                 volume={finalIpodVolume}
@@ -1278,6 +1281,7 @@ export function IpodScreen({
                 onEnded={!isFullScreen ? handleTrackEnd : undefined}
                 onReady={!isFullScreen ? handleReady : undefined}
                 onNowPlayingItemChange={setAppleMusicKitNowPlaying}
+                onQueueTrackChange={onAppleMusicQueueTrackChange}
               />
             ) : (
               <div

--- a/src/apps/ipod/components/appleMusicPlayerBridgeUtils.ts
+++ b/src/apps/ipod/components/appleMusicPlayerBridgeUtils.ts
@@ -109,6 +109,30 @@ export function buildAppleMusicQueueOptions(
   };
 }
 
+/**
+ * Whether MusicKit's `nowPlayingItem` should drive the iPod's current track.
+ * Skips while an explicit user selection is still being queued so polling
+ * does not revert the UI to the previous song mid-`setQueue`.
+ */
+export function shouldSyncQueueTrackFromMediaItem(
+  resolvedTrackId: string | null,
+  currentTrackId: string | null | undefined,
+  playbackTargetTrackId: string | null,
+  queuedTrackIds: string[]
+): boolean {
+  if (!resolvedTrackId || !queuedTrackIds.includes(resolvedTrackId)) {
+    return false;
+  }
+  if (resolvedTrackId === currentTrackId) return false;
+  if (
+    playbackTargetTrackId &&
+    resolvedTrackId !== playbackTargetTrackId
+  ) {
+    return false;
+  }
+  return true;
+}
+
 export function resolveAppleMusicQueueTrackIdFromMediaItem(
   item: MusicKit.MediaItem | null | undefined,
   queueTracks: Track[]

--- a/src/apps/ipod/components/appleMusicPlayerBridgeUtils.ts
+++ b/src/apps/ipod/components/appleMusicPlayerBridgeUtils.ts
@@ -18,6 +18,9 @@ export interface AppleMusicQueueBuildResult {
   /** iPod track ids represented by `options.songs`, in queue order. */
   queuedTrackIds: string[];
   isMultiSongQueue: boolean;
+  /** Index to pass to `changeToMediaAtIndex` when jumping inside a queue. */
+  startWithIndex: number | null;
+  queueKind: "song" | "songs" | "album" | "playlist" | "station";
 }
 
 export function getAppleMusicSongQueueId(track: Track): string | null {
@@ -44,6 +47,66 @@ function dedupeQueueTracks(tracks: Track[]): Track[] {
   });
 }
 
+/** Catalog album id when every track in the list shares one. */
+export function getSharedAlbumCatalogId(tracks: Track[]): string | null {
+  if (tracks.length < 2) return null;
+  const albumIds = tracks
+    .map((track) => track.appleMusicAlbumId)
+    .filter((id): id is string => Boolean(id));
+  if (albumIds.length !== tracks.length) return null;
+  const unique = new Set(albumIds);
+  if (unique.size !== 1) return null;
+  const albumId = albumIds[0]!;
+  // Library album ids (`l.*`) are not valid for `setQueue({ album })`.
+  if (albumId.startsWith("l.") || albumId.startsWith("i.")) return null;
+  return albumId;
+}
+
+export function buildAppleMusicSingleSongQueueOptions(
+  track: Track,
+  songId: string
+): AppleMusicQueueBuildResult {
+  return {
+    options: { song: songId, startPlaying: true },
+    definitionKey: `song:${track.id}`,
+    requestKey: `song:${track.id}`,
+    queuedTrackIds: [track.id],
+    isMultiSongQueue: false,
+    startWithIndex: null,
+    queueKind: "song",
+  };
+}
+
+export function buildAppleMusicQueuePlacementOptions(
+  track: Track
+): MusicKit.SetQueueOptions | null {
+  const built = buildAppleMusicQueueOptions(track, [track]);
+  return built?.options ?? null;
+}
+
+/**
+ * When only the start position changes inside an existing MusicKit queue,
+ * jump with `changeToMediaAtIndex` instead of rebuilding the queue.
+ */
+export function getInQueueNavigationIndex(
+  queueBuild: AppleMusicQueueBuildResult,
+  lastDefinitionKey: string | null
+): number | null {
+  if (!lastDefinitionKey || lastDefinitionKey !== queueBuild.definitionKey) {
+    return null;
+  }
+  if (queueBuild.startWithIndex == null || queueBuild.startWithIndex < 0) {
+    return null;
+  }
+  if (
+    queueBuild.queueKind !== "songs" &&
+    queueBuild.queueKind !== "album"
+  ) {
+    return null;
+  }
+  return queueBuild.startWithIndex;
+}
+
 export function buildAppleMusicQueueOptions(
   currentTrack: Track,
   queueTracks?: Track[] | null
@@ -58,6 +121,8 @@ export function buildAppleMusicQueueOptions(
       requestKey: `station:${params.stationId}`,
       queuedTrackIds: [],
       isMultiSongQueue: false,
+      startWithIndex: null,
+      queueKind: "station",
     };
   }
 
@@ -68,6 +133,8 @@ export function buildAppleMusicQueueOptions(
       requestKey: `playlist:${params.playlistId}`,
       queuedTrackIds: [],
       isMultiSongQueue: false,
+      startWithIndex: null,
+      queueKind: "playlist",
     };
   }
 
@@ -82,13 +149,28 @@ export function buildAppleMusicQueueOptions(
   );
 
   if (songQueueTracks.length > 1 && queueContainsCurrent) {
-    const songs = songQueueTracks
-      .map((track) => getAppleMusicSongQueueId(track))
-      .filter((id): id is string => Boolean(id));
     const startWith = songQueueTracks.findIndex(
       (track) => track.id === currentTrack.id
     );
     const queuedTrackIds = songQueueTracks.map((track) => track.id);
+    const albumQueueId = getSharedAlbumCatalogId(songQueueTracks);
+
+    if (albumQueueId && startWith >= 0) {
+      const definitionKey = `album:${albumQueueId}`;
+      return {
+        options: { album: albumQueueId, startWith, startPlaying: true },
+        definitionKey,
+        requestKey: `${definitionKey}:start:${currentTrack.id}`,
+        queuedTrackIds,
+        isMultiSongQueue: true,
+        startWithIndex: startWith,
+        queueKind: "album",
+      };
+    }
+
+    const songs = songQueueTracks
+      .map((track) => getAppleMusicSongQueueId(track))
+      .filter((id): id is string => Boolean(id));
     const definitionKey = `songs:${queuedTrackIds.join("\u0000")}`;
     return {
       options: { songs, startWith, startPlaying: true },
@@ -96,17 +178,12 @@ export function buildAppleMusicQueueOptions(
       requestKey: `${definitionKey}:start:${currentTrack.id}`,
       queuedTrackIds,
       isMultiSongQueue: true,
+      startWithIndex: startWith,
+      queueKind: "songs",
     };
   }
 
-  const trackId = currentTrack.id;
-  return {
-    options: { song: currentSongId, startPlaying: true },
-    definitionKey: `song:${trackId}`,
-    requestKey: `song:${trackId}`,
-    queuedTrackIds: [trackId],
-    isMultiSongQueue: false,
-  };
+  return buildAppleMusicSingleSongQueueOptions(currentTrack, currentSongId);
 }
 
 /**

--- a/src/apps/ipod/components/appleMusicPlayerBridgeUtils.ts
+++ b/src/apps/ipod/components/appleMusicPlayerBridgeUtils.ts
@@ -6,13 +6,145 @@
 
 import { isAppleMusicCollectionTrack, type Track } from "@/stores/useIpodStore";
 
+export interface AppleMusicQueueBuildResult {
+  options: MusicKit.SetQueueOptions;
+  /**
+   * Changes when the MusicKit queue contents change, but not when playback
+   * advances inside that queue.
+   */
+  definitionKey: string;
+  /** Changes for an explicit request to start at a different track. */
+  requestKey: string;
+  /** iPod track ids represented by `options.songs`, in queue order. */
+  queuedTrackIds: string[];
+  isMultiSongQueue: boolean;
+}
+
+export function getAppleMusicSongQueueId(track: Track): string | null {
+  const params = track.appleMusicPlayParams;
+  if (!params || params.stationId || params.playlistId) return null;
+  const id =
+    params.kind === "library-songs"
+      ? params.libraryId || params.catalogId
+      : params.catalogId || params.libraryId;
+  return id || null;
+}
+
+function normalizeAppleMusicTrackId(id: string | null | undefined): string | null {
+  if (!id) return null;
+  return id.startsWith("am:") ? id : `am:${id}`;
+}
+
+function dedupeQueueTracks(tracks: Track[]): Track[] {
+  const seen = new Set<string>();
+  return tracks.filter((track) => {
+    if (seen.has(track.id)) return false;
+    seen.add(track.id);
+    return true;
+  });
+}
+
+export function buildAppleMusicQueueOptions(
+  currentTrack: Track,
+  queueTracks?: Track[] | null
+): AppleMusicQueueBuildResult | null {
+  const params = currentTrack.appleMusicPlayParams;
+  if (!params) return null;
+
+  if (params.stationId) {
+    return {
+      options: { station: params.stationId, startPlaying: true },
+      definitionKey: `station:${params.stationId}`,
+      requestKey: `station:${params.stationId}`,
+      queuedTrackIds: [],
+      isMultiSongQueue: false,
+    };
+  }
+
+  if (params.playlistId) {
+    return {
+      options: { playlist: params.playlistId, startPlaying: true },
+      definitionKey: `playlist:${params.playlistId}`,
+      requestKey: `playlist:${params.playlistId}`,
+      queuedTrackIds: [],
+      isMultiSongQueue: false,
+    };
+  }
+
+  const currentSongId = getAppleMusicSongQueueId(currentTrack);
+  if (!currentSongId) return null;
+
+  const songQueueTracks = dedupeQueueTracks(
+    (queueTracks ?? []).filter((track) => getAppleMusicSongQueueId(track))
+  );
+  const queueContainsCurrent = songQueueTracks.some(
+    (track) => track.id === currentTrack.id
+  );
+
+  if (songQueueTracks.length > 1 && queueContainsCurrent) {
+    const songs = songQueueTracks
+      .map((track) => getAppleMusicSongQueueId(track))
+      .filter((id): id is string => Boolean(id));
+    const startWith = songQueueTracks.findIndex(
+      (track) => track.id === currentTrack.id
+    );
+    const queuedTrackIds = songQueueTracks.map((track) => track.id);
+    const definitionKey = `songs:${queuedTrackIds.join("\u0000")}`;
+    return {
+      options: { songs, startWith, startPlaying: true },
+      definitionKey,
+      requestKey: `${definitionKey}:start:${currentTrack.id}`,
+      queuedTrackIds,
+      isMultiSongQueue: true,
+    };
+  }
+
+  const trackId = currentTrack.id;
+  return {
+    options: { song: currentSongId, startPlaying: true },
+    definitionKey: `song:${trackId}`,
+    requestKey: `song:${trackId}`,
+    queuedTrackIds: [trackId],
+    isMultiSongQueue: false,
+  };
+}
+
+export function resolveAppleMusicQueueTrackIdFromMediaItem(
+  item: MusicKit.MediaItem | null | undefined,
+  queueTracks: Track[]
+): string | null {
+  if (!item) return null;
+  const candidates = [
+    item.id,
+    item.attributes?.playParams?.catalogId,
+    item.attributes?.playParams?.id,
+  ].filter((id): id is string => Boolean(id));
+
+  for (const track of queueTracks) {
+    const queueId = getAppleMusicSongQueueId(track);
+    if (
+      candidates.includes(track.id) ||
+      (queueId !== null && candidates.includes(queueId))
+    ) {
+      return track.id;
+    }
+  }
+
+  for (const candidate of candidates) {
+    const normalized = normalizeAppleMusicTrackId(candidate);
+    if (normalized) return normalized;
+  }
+
+  return null;
+}
+
 /**
  * Decide whether a `playbackStateDidChange` event should fan out to the
  * parent's `onEnded` callback (which triggers our own next-track handler).
  *
  * MusicKit JS fires `ended` (state=5) once for *every* track that finishes.
- * Inside a multi-item queue (catalog station / playlist set up via
- * `setQueue({ station | playlist })`), MusicKit auto-advances to the next
+ * Inside a multi-item MusicKit queue (song array, catalog station, or
+ * playlist), MusicKit auto-advances to the next
  * item internally — invoking `onEnded` then would call our parent's
  * `nextTrack` → `skipToNextItem()`, skipping past the item MusicKit just
  * moved to and visibly mismatching the displayed Now Playing entry from
@@ -22,9 +154,11 @@ import { isAppleMusicCollectionTrack, type Track } from "@/stores/useIpodStore";
  */
 export function shouldFireEndedForPlaybackState(
   state: number | undefined,
-  currentTrack: Track | null
+  currentTrack: Track | null,
+  isMultiItemMusicKitQueue = false
 ): boolean {
   if (state === 10) return true;
+  if (state === 5 && isMultiItemMusicKitQueue) return false;
   if (state === 5) return !isAppleMusicCollectionTrack(currentTrack);
   return false;
 }

--- a/src/apps/ipod/hooks/useIpodLogic.ts
+++ b/src/apps/ipod/hooks/useIpodLogic.ts
@@ -201,6 +201,19 @@ export function useIpodLogic({
     browseCurrentIndex,
   ]);
 
+  const appleMusicQueueTracks = useMemo(() => {
+    if (!isAppleMusic) return null;
+    if (!appleMusicPlaybackQueue || appleMusicPlaybackQueue.length === 0) {
+      return browsableTracks;
+    }
+    const tracksById = new Map(tracks.map((track) => [track.id, track]));
+    return appleMusicPlaybackQueue.reduce<Track[]>((acc, id) => {
+      const track = tracksById.get(id);
+      if (track) acc.push(track);
+      return acc;
+    }, []);
+  }, [isAppleMusic, appleMusicPlaybackQueue, tracks, browsableTracks]);
+
   const {
     theme,
     lcdFilterOn,
@@ -2639,36 +2652,17 @@ export function useIpodLogic({
     }, 2000);
   }, []);
 
-  const getCurrentAppleMusicCollectionShellTrack = useCallback(() => {
-    const state = useIpodStore.getState();
-    if (state.librarySource !== "appleMusic" || !state.appleMusicCurrentSongId) {
-      return null;
-    }
-    const track =
-      state.appleMusicTracks.find(
-        (candidate) => candidate.id === state.appleMusicCurrentSongId
-      ) ??
-      appleMusicRadioTracks.find(
-        (candidate) => candidate.id === state.appleMusicCurrentSongId
-      ) ??
-      null;
-    return track && isAppleMusicCollectionTrack(track) ? track : null;
-  }, [appleMusicRadioTracks]);
-
-  const skipAppleMusicCollectionShell = useCallback(
+  const skipAppleMusicMusicKitQueue = useCallback(
     async (direction: "next" | "previous") => {
-      const shellTrack = getCurrentAppleMusicCollectionShellTrack();
-      if (!shellTrack) return false;
+      if (useIpodStore.getState().librarySource !== "appleMusic") return false;
       const activePlayer = isFullScreen
         ? fullScreenPlayerRef.current
         : playerRef.current;
       const instance = activePlayer?.getInternalPlayer?.();
       if (!instance) return false;
 
-      const isStation = Boolean(shellTrack.appleMusicPlayParams?.stationId);
       const skipNext =
         direction === "next" ||
-        isStation ||
         typeof instance.skipToPreviousItem !== "function";
       if (skipNext && typeof instance.skipToNextItem !== "function") {
         return false;
@@ -2696,7 +2690,6 @@ export function useIpodLogic({
       }
     },
     [
-      getCurrentAppleMusicCollectionShellTrack,
       isFullScreen,
       setIsPlaying,
       showStatus,
@@ -2705,28 +2698,41 @@ export function useIpodLogic({
   );
 
   const nextTrack = useCallback(() => {
-    if (getCurrentAppleMusicCollectionShellTrack()) {
-      void skipAppleMusicCollectionShell("next");
+    if (useIpodStore.getState().librarySource === "appleMusic") {
+      void skipAppleMusicMusicKitQueue("next").then((skipped) => {
+        if (!skipped) rawNextTrack();
+      });
       return;
     }
     rawNextTrack();
   }, [
-    getCurrentAppleMusicCollectionShellTrack,
     rawNextTrack,
-    skipAppleMusicCollectionShell,
+    skipAppleMusicMusicKitQueue,
   ]);
 
   const previousTrack = useCallback(() => {
-    if (getCurrentAppleMusicCollectionShellTrack()) {
-      void skipAppleMusicCollectionShell("previous");
+    if (useIpodStore.getState().librarySource === "appleMusic") {
+      void skipAppleMusicMusicKitQueue("previous").then((skipped) => {
+        if (!skipped) rawPreviousTrack();
+      });
       return;
     }
     rawPreviousTrack();
   }, [
-    getCurrentAppleMusicCollectionShellTrack,
     rawPreviousTrack,
-    skipAppleMusicCollectionShell,
+    skipAppleMusicMusicKitQueue,
   ]);
+
+  const handleAppleMusicQueueTrackChange = useCallback((trackId: string) => {
+    const state = useIpodStore.getState();
+    if (
+      state.librarySource !== "appleMusic" ||
+      state.appleMusicCurrentSongId === trackId
+    ) {
+      return;
+    }
+    state.setAppleMusicCurrentSongId(trackId);
+  }, []);
 
   // Track handling
   const handleAddTrack = useCallback(
@@ -4113,6 +4119,8 @@ export function useIpodLogic({
     setIsCoverFlowOpen,
     nextTrack,
     previousTrack,
+    appleMusicQueueTracks,
+    handleAppleMusicQueueTrackChange,
     clearLibrary,
     manualSync,
     restoreInstance,

--- a/src/apps/ipod/hooks/useIpodLogic.ts
+++ b/src/apps/ipod/hooks/useIpodLogic.ts
@@ -219,7 +219,7 @@ export function useIpodLogic({
       if (track) acc.push(track);
       return acc;
     }, []);
-  }, [isAppleMusic, appleMusicPlaybackQueue, tracks, browsableTracks]);
+  }, [isAppleMusic, appleMusicPlaybackQueue, tracks]);
 
   const {
     theme,

--- a/src/apps/ipod/hooks/useIpodLogic.ts
+++ b/src/apps/ipod/hooks/useIpodLogic.ts
@@ -207,8 +207,11 @@ export function useIpodLogic({
 
   const appleMusicQueueTracks = useMemo(() => {
     if (!isAppleMusic) return null;
+    // Only pass a contextual queue (album / artist / playlist drill-down)
+    // to MusicKit. The full library uses single-song queues so we don't
+    // feed hundreds of ids into setQueue or trip in-queue navigation.
     if (!appleMusicPlaybackQueue || appleMusicPlaybackQueue.length === 0) {
-      return browsableTracks;
+      return null;
     }
     const tracksById = new Map(tracks.map((track) => [track.id, track]));
     return appleMusicPlaybackQueue.reduce<Track[]>((acc, id) => {
@@ -938,74 +941,20 @@ export function useIpodLogic({
       trackListIndex: number,
       queueIds?: string[] | null,
       queueTracks?: Track[]
-    ) => {
-      const playNow = () =>
+    ) => ({
+      label: track.title,
+      action: () =>
         playAppleMusicTrackFromMenu(
           track,
           trackListIndex,
           queueIds,
           queueTracks,
           "now"
-        );
-      if (!isAppleMusic) {
-        return {
-          label: track.title,
-          action: playNow,
-          showChevron: false,
-          coverUrl: resolveTrackCoverUrl(track),
-        };
-      }
-      return {
-        label: track.title,
-        action: () => {
-          registerActivity();
-          pushMenuChild({
-            title: track.title,
-            items: [
-              {
-                label: t("apps.ipod.menuItems.play", "Play"),
-                action: playNow,
-                showChevron: false,
-              },
-              {
-                label: t("apps.ipod.menuItems.playNext", "Play Next"),
-                action: () =>
-                  playAppleMusicTrackFromMenu(
-                    track,
-                    trackListIndex,
-                    queueIds,
-                    queueTracks,
-                    "next"
-                  ),
-                showChevron: false,
-              },
-              {
-                label: t("apps.ipod.menuItems.playLater", "Play Later"),
-                action: () =>
-                  playAppleMusicTrackFromMenu(
-                    track,
-                    trackListIndex,
-                    queueIds,
-                    queueTracks,
-                    "later"
-                  ),
-                showChevron: false,
-              },
-            ],
-            selectedIndex: 0,
-          });
-        },
-        showChevron: true,
-        coverUrl: resolveTrackCoverUrl(track),
-      };
-    },
-    [
-      isAppleMusic,
-      playAppleMusicTrackFromMenu,
-      pushMenuChild,
-      registerActivity,
-      t,
-    ]
+        ),
+      showChevron: false,
+      coverUrl: resolveTrackCoverUrl(track),
+    }),
+    [playAppleMusicTrackFromMenu]
   );
 
   const handleAppleMusicBufferingChange = useCallback((buffering: boolean) => {

--- a/src/apps/ipod/hooks/useIpodLogic.ts
+++ b/src/apps/ipod/hooks/useIpodLogic.ts
@@ -68,6 +68,10 @@ import type { IpodInitialData } from "../../base/types";
 import type { CoverFlowRef } from "../components/CoverFlow";
 import type { MusicQuizRef } from "../components/MusicQuiz";
 import type { BrickGameRef } from "../components/BrickGame";
+import type {
+  AppleMusicPlayerBridgeHandle,
+  AppleMusicQueuePlacement,
+} from "../components/AppleMusicPlayerBridge";
 import type { SongSearchResult } from "@/components/dialogs/SongSearchDialog";
 import { helpItems } from "..";
 
@@ -397,6 +401,7 @@ export function useIpodLogic({
   const [isSongSearchDialogOpen, setIsSongSearchDialogOpen] = useState(false);
   const [isSyncModeOpen, setIsSyncModeOpen] = useState(false);
   const [isAddingSong, setIsAddingSong] = useState(false);
+  const [isAppleMusicBuffering, setIsAppleMusicBuffering] = useState(false);
   // Recently Added + Favorites moved into the global iPod store (mirrored
   // from IndexedDB on iPod open) so the opportunistic refresh path in
   // `useAppleMusicLibrary` can update the same source the menu reads
@@ -882,12 +887,10 @@ export function useIpodLogic({
       track: Track,
       trackIndexInActiveMenu: number,
       queueIds?: string[] | null,
-      queueTracks?: Track[]
+      queueTracks?: Track[],
+      placement: "now" | AppleMusicQueuePlacement = "now"
     ) => {
       const state = useIpodStore.getState();
-      // Merge any queue tracks that aren't already in the cached
-      // library so next/previous can resolve them. Playlist drill-downs
-      // can include songs not present in the user's full library.
       const toMerge = queueTracks ?? [track];
       const existingIds = new Set(state.appleMusicTracks.map((t) => t.id));
       const additions = toMerge.filter((t) => !existingIds.has(t.id));
@@ -899,10 +902,162 @@ export function useIpodLogic({
           state.setAppleMusicTracks(nextTracks);
         }
       }
+      if (placement === "next" || placement === "later") {
+        const activePlayer = isFullScreen
+          ? fullScreenPlayerRef.current
+          : playerRef.current;
+        const bridge = activePlayer as AppleMusicPlayerBridgeHandle | null;
+        void bridge
+          ?.queueTrack(track, placement)
+          .then(() => {
+            showStatus(
+              placement === "next"
+                ? t("apps.ipod.status.queuedNext", "Queued Next")
+                : t("apps.ipod.status.queuedLater", "Queued Later")
+            );
+          })
+          .catch((err) => {
+            console.warn("[apple music] queue placement failed", err);
+            toast.error(
+              t("apps.ipod.dialogs.appleMusicQueueFailed", "Failed to queue song"),
+              {
+                description: err instanceof Error ? err.message : String(err),
+              }
+            );
+          });
+        return;
+      }
       playTrackFromMenu(track, trackIndexInActiveMenu, queueIds);
     },
-    [playTrackFromMenu]
+    [isFullScreen, playTrackFromMenu, showStatus, t]
   );
+
+  const makeAppleMusicTrackMenuItem = useCallback(
+    (
+      track: Track,
+      trackListIndex: number,
+      queueIds?: string[] | null,
+      queueTracks?: Track[]
+    ) => {
+      const playNow = () =>
+        playAppleMusicTrackFromMenu(
+          track,
+          trackListIndex,
+          queueIds,
+          queueTracks,
+          "now"
+        );
+      if (!isAppleMusic) {
+        return {
+          label: track.title,
+          action: playNow,
+          showChevron: false,
+          coverUrl: resolveTrackCoverUrl(track),
+        };
+      }
+      return {
+        label: track.title,
+        action: () => {
+          registerActivity();
+          pushMenuChild({
+            title: track.title,
+            items: [
+              {
+                label: t("apps.ipod.menuItems.play", "Play"),
+                action: playNow,
+                showChevron: false,
+              },
+              {
+                label: t("apps.ipod.menuItems.playNext", "Play Next"),
+                action: () =>
+                  playAppleMusicTrackFromMenu(
+                    track,
+                    trackListIndex,
+                    queueIds,
+                    queueTracks,
+                    "next"
+                  ),
+                showChevron: false,
+              },
+              {
+                label: t("apps.ipod.menuItems.playLater", "Play Later"),
+                action: () =>
+                  playAppleMusicTrackFromMenu(
+                    track,
+                    trackListIndex,
+                    queueIds,
+                    queueTracks,
+                    "later"
+                  ),
+                showChevron: false,
+              },
+            ],
+            selectedIndex: 0,
+          });
+        },
+        showChevron: true,
+        coverUrl: resolveTrackCoverUrl(track),
+      };
+    },
+    [
+      isAppleMusic,
+      playAppleMusicTrackFromMenu,
+      pushMenuChild,
+      registerActivity,
+      t,
+    ]
+  );
+
+  const handleAppleMusicBufferingChange = useCallback((buffering: boolean) => {
+    setIsAppleMusicBuffering(buffering);
+  }, []);
+
+  const handleAppleMusicAirPlay = useCallback(() => {
+    registerActivity();
+    const activePlayer = isFullScreen
+      ? fullScreenPlayerRef.current
+      : playerRef.current;
+    const bridge = activePlayer as AppleMusicPlayerBridgeHandle | null;
+    if (bridge?.showAirPlayPicker()) {
+      showStatus(t("apps.ipod.status.airPlay", "AirPlay"));
+      return;
+    }
+    toast.info(
+      t(
+        "apps.ipod.dialogs.airPlayUnavailable",
+        "No AirPlay speakers are available"
+      )
+    );
+  }, [isFullScreen, registerActivity, showStatus, t]);
+
+  const handleAppleMusicAddToLibrary = useCallback(async () => {
+    registerActivity();
+    const track = useIpodStore.getState().appleMusicTracks.find(
+      (candidate) =>
+        candidate.id === useIpodStore.getState().appleMusicCurrentSongId
+    );
+    if (!track) return;
+    const activePlayer = isFullScreen
+      ? fullScreenPlayerRef.current
+      : playerRef.current;
+    const bridge = activePlayer as AppleMusicPlayerBridgeHandle | null;
+    try {
+      if (bridge?.addTrackToLibrary) {
+        await bridge.addTrackToLibrary(track);
+      } else {
+        throw new Error("MusicKit addToLibrary is unavailable");
+      }
+      showStatus(t("apps.ipod.status.addedToLibrary", "Added to Library"));
+    } catch (err) {
+      console.warn("[apple music] addToLibrary failed", err);
+      toast.error(
+        t("apps.ipod.dialogs.addToLibraryFailed", "Failed to add to library"),
+        {
+          description: err instanceof Error ? err.message : String(err),
+        }
+      );
+    }
+  }, [isFullScreen, registerActivity, showStatus, t]);
 
   const requestPlaylistTracksIfNeeded = useCallback((playlistId: string) => {
     // Always trigger a background refresh on playlist open. The fetcher
@@ -1560,14 +1715,17 @@ export function useIpodLogic({
   // new `items` reference, called `setMenuHistory(updated)`, and re-ran.
   const allSongsMenuItems = useMemo(
     () =>
-      browsableTracks.map((track, index) => ({
-        label: track.title,
-        // Full library queue → pass null to clear any contextual queue.
-        action: () => playTrackFromMenu(track, index, null),
-        showChevron: false,
-        coverUrl: resolveTrackCoverUrl(track),
-      })),
-    [browsableTracks, playTrackFromMenu]
+      browsableTracks.map((track, index) =>
+        isAppleMusic
+          ? makeAppleMusicTrackMenuItem(track, index, null, browsableTracks)
+          : {
+              label: track.title,
+              action: () => playTrackFromMenu(track, index, null),
+              showChevron: false,
+              coverUrl: resolveTrackCoverUrl(track),
+            }
+      ),
+    [browsableTracks, isAppleMusic, makeAppleMusicTrackMenuItem, playTrackFromMenu]
   );
 
   const appleMusicRecentlyAddedMenuItems = useMemo(() => {
@@ -1594,22 +1752,18 @@ export function useIpodLogic({
     }
 
     const queueIds = appleMusicRecentlyAddedTracks.map((track) => track.id);
-    return appleMusicRecentlyAddedTracks.map((track, index) => ({
-      label: track.title,
-      action: () =>
-        playAppleMusicTrackFromMenu(
-          track,
-          index,
-          queueIds,
-          appleMusicRecentlyAddedTracks
-        ),
-      showChevron: false,
-      coverUrl: resolveTrackCoverUrl(track),
-    }));
+    return appleMusicRecentlyAddedTracks.map((track, index) =>
+      makeAppleMusicTrackMenuItem(
+        track,
+        index,
+        queueIds,
+        appleMusicRecentlyAddedTracks
+      )
+    );
   }, [
     appleMusicRecentlyAddedTracks,
     isAppleMusicRecentlyAddedLoading,
-    playAppleMusicTrackFromMenu,
+    makeAppleMusicTrackMenuItem,
     t,
   ]);
 
@@ -1637,22 +1791,18 @@ export function useIpodLogic({
     }
 
     const queueIds = appleMusicFavoriteTracks.map((track) => track.id);
-    return appleMusicFavoriteTracks.map((track, index) => ({
-      label: track.title,
-      action: () =>
-        playAppleMusicTrackFromMenu(
-          track,
-          index,
-          queueIds,
-          appleMusicFavoriteTracks
-        ),
-      showChevron: false,
-      coverUrl: resolveTrackCoverUrl(track),
-    }));
+    return appleMusicFavoriteTracks.map((track, index) =>
+      makeAppleMusicTrackMenuItem(
+        track,
+        index,
+        queueIds,
+        appleMusicFavoriteTracks
+      )
+    );
   }, [
     appleMusicFavoriteTracks,
     isAppleMusicFavoritesLoading,
-    playAppleMusicTrackFromMenu,
+    makeAppleMusicTrackMenuItem,
     t,
   ]);
 
@@ -1703,15 +1853,19 @@ export function useIpodLogic({
       const artistTracks = tracksByArtist[artist];
       const queueIds = artistTracks.map(({ track }) => track.id);
       const title = `${artist} - ${allSongsLabel}`;
-      result[title] = artistTracks.map(({ track }, trackListIndex) => ({
-        label: track.title,
-        action: () => playTrackFromMenu(track, trackListIndex, queueIds),
-        showChevron: false,
-        coverUrl: resolveTrackCoverUrl(track),
-      }));
+      result[title] = artistTracks.map(({ track }, trackListIndex) =>
+        isAppleMusic
+          ? makeAppleMusicTrackMenuItem(track, trackListIndex, queueIds, artistTracks.map(({ track: t2 }) => t2))
+          : {
+              label: track.title,
+              action: () => playTrackFromMenu(track, trackListIndex, queueIds),
+              showChevron: false,
+              coverUrl: resolveTrackCoverUrl(track),
+            }
+      );
     }
     return result;
-  }, [tracksByArtist, sortedArtists, playTrackFromMenu, t]);
+  }, [tracksByArtist, sortedArtists, isAppleMusic, makeAppleMusicTrackMenuItem, playTrackFromMenu, t]);
 
   const artistAlbumMenuItemsByTitle = useMemo(() => {
     const result: Record<
@@ -1724,12 +1878,16 @@ export function useIpodLogic({
         const albumTracks = tracksByArtistAlbum[artist]?.[albumKey] ?? [];
         const queueIds = albumTracks.map(({ track }) => track.id);
         const title = `${artist}\u0000${albumKey}`;
-        result[title] = albumTracks.map(({ track }, trackListIndex) => ({
-          label: track.title,
-          action: () => playTrackFromMenu(track, trackListIndex, queueIds),
-          showChevron: false,
-          coverUrl: resolveTrackCoverUrl(track),
-        }));
+        result[title] = albumTracks.map(({ track }, trackListIndex) =>
+          isAppleMusic
+            ? makeAppleMusicTrackMenuItem(track, trackListIndex, queueIds, albumTracks.map(({ track: t2 }) => t2))
+            : {
+                label: track.title,
+                action: () => playTrackFromMenu(track, trackListIndex, queueIds),
+                showChevron: false,
+                coverUrl: resolveTrackCoverUrl(track),
+              }
+        );
       }
     }
     return result;
@@ -1737,6 +1895,8 @@ export function useIpodLogic({
     sortedArtists,
     sortedAlbumsByArtist,
     tracksByArtistAlbum,
+    isAppleMusic,
+    makeAppleMusicTrackMenuItem,
     playTrackFromMenu,
   ]);
 
@@ -1817,15 +1977,30 @@ export function useIpodLogic({
     for (const albumKey of sortedAlbums) {
       const albumTracks = albumGroupsByKey[albumKey].tracks;
       const queueIds = albumTracks.map(({ track }) => track.id);
-      result[albumKey] = albumTracks.map(({ track }, trackListIndex) => ({
-        label: track.title,
-        action: () => playTrackFromMenu(track, trackListIndex, queueIds),
-        showChevron: false,
-        coverUrl: resolveTrackCoverUrl(track),
-      }));
+      result[albumKey] = albumTracks.map(({ track }, trackListIndex) =>
+        isAppleMusic
+          ? makeAppleMusicTrackMenuItem(
+              track,
+              trackListIndex,
+              queueIds,
+              albumTracks.map(({ track: t2 }) => t2)
+            )
+          : {
+              label: track.title,
+              action: () => playTrackFromMenu(track, trackListIndex, queueIds),
+              showChevron: false,
+              coverUrl: resolveTrackCoverUrl(track),
+            }
+      );
     }
     return result;
-  }, [albumGroupsByKey, sortedAlbums, playTrackFromMenu]);
+  }, [
+    albumGroupsByKey,
+    sortedAlbums,
+    isAppleMusic,
+    makeAppleMusicTrackMenuItem,
+    playTrackFromMenu,
+  ]);
 
   const albumsListMenuItems = useMemo(
     () => {
@@ -1953,18 +2128,14 @@ export function useIpodLogic({
         ];
       } else {
         const queueIds = playlistTracks.map((t) => t.id);
-        result[playlist.id] = playlistTracks.map((track, trackListIndex) => ({
-          label: track.title,
-          action: () =>
-            playAppleMusicTrackFromMenu(
-              track,
-              trackListIndex,
-              queueIds,
-              playlistTracks
-            ),
-          showChevron: false,
-          coverUrl: resolveTrackCoverUrl(track),
-        }));
+        result[playlist.id] = playlistTracks.map((track, trackListIndex) =>
+          makeAppleMusicTrackMenuItem(
+            track,
+            trackListIndex,
+            queueIds,
+            playlistTracks
+          )
+        );
       }
     }
     return result;
@@ -1972,7 +2143,7 @@ export function useIpodLogic({
     appleMusicPlaylists,
     appleMusicPlaylistTracks,
     appleMusicPlaylistTracksLoading,
-    playAppleMusicTrackFromMenu,
+    makeAppleMusicTrackMenuItem,
     loadingLabel,
   ]);
 
@@ -2231,6 +2402,23 @@ export function useIpodLogic({
             ? t("apps.ipod.menuItems.signedIn", "Signed In")
             : t("apps.ipod.menuItems.signedOut", "Signed Out"),
       },
+      ...(isAppleMusic && appleMusicAuthorized
+        ? [
+            {
+              label: t("apps.ipod.menuItems.airPlay", "AirPlay"),
+              action: () => void handleAppleMusicAirPlay(),
+              showChevron: false,
+            },
+            {
+              label: t(
+                "apps.ipod.menuItems.addToAppleMusicLibrary",
+                "Add Song to Library"
+              ),
+              action: () => void handleAppleMusicAddToLibrary(),
+              showChevron: false,
+            },
+          ]
+        : []),
     ];
   }, [
     loopCurrent,
@@ -2244,11 +2432,13 @@ export function useIpodLogic({
     memoizedHandleThemeChange,
     isAppleMusic,
     appleMusicAuthorized,
-    musicKitStatus,
-    handleSwitchToYoutube,
-    handleSwitchToAppleMusic,
+    handleAppleMusicAirPlay,
+    handleAppleMusicAddToLibrary,
     handleAppleMusicSignIn,
     handleAppleMusicSignOut,
+    handleSwitchToYoutube,
+    handleSwitchToAppleMusic,
+    musicKitStatus,
     t,
   ]);
 
@@ -2654,7 +2844,9 @@ export function useIpodLogic({
 
   const skipAppleMusicMusicKitQueue = useCallback(
     async (direction: "next" | "previous") => {
-      if (useIpodStore.getState().librarySource !== "appleMusic") return false;
+      const state = useIpodStore.getState();
+      if (state.librarySource !== "appleMusic") return false;
+      if (state.loopCurrent) return false;
       const activePlayer = isFullScreen
         ? fullScreenPlayerRef.current
         : playerRef.current;
@@ -2699,6 +2891,14 @@ export function useIpodLogic({
 
   const nextTrack = useCallback(() => {
     if (useIpodStore.getState().librarySource === "appleMusic") {
+      if (useIpodStore.getState().loopCurrent) {
+        const activePlayer = isFullScreen
+          ? fullScreenPlayerRef.current
+          : playerRef.current;
+        activePlayer?.seekTo(0);
+        setIsPlaying(true);
+        return;
+      }
       void skipAppleMusicMusicKitQueue("next").then((skipped) => {
         if (!skipped) rawNextTrack();
       });
@@ -2708,10 +2908,20 @@ export function useIpodLogic({
   }, [
     rawNextTrack,
     skipAppleMusicMusicKitQueue,
+    isFullScreen,
+    setIsPlaying,
   ]);
 
   const previousTrack = useCallback(() => {
     if (useIpodStore.getState().librarySource === "appleMusic") {
+      if (useIpodStore.getState().loopCurrent) {
+        const activePlayer = isFullScreen
+          ? fullScreenPlayerRef.current
+          : playerRef.current;
+        activePlayer?.seekTo(0);
+        setIsPlaying(true);
+        return;
+      }
       void skipAppleMusicMusicKitQueue("previous").then((skipped) => {
         if (!skipped) rawPreviousTrack();
       });
@@ -2721,6 +2931,8 @@ export function useIpodLogic({
   }, [
     rawPreviousTrack,
     skipAppleMusicMusicKitQueue,
+    isFullScreen,
+    setIsPlaying,
   ]);
 
   const handleAppleMusicQueueTrackChange = useCallback((trackId: string) => {
@@ -3688,6 +3900,7 @@ export function useIpodLogic({
     },
     translationLanguage: effectiveTranslationLanguage,
     isAddingSong,
+    isBufferingPlayback: isAppleMusic && isAppleMusicBuffering,
   });
 
   // Convert furiganaMap to Record for storage - only when content actually changes
@@ -4117,6 +4330,10 @@ export function useIpodLogic({
     previousTrack,
     appleMusicQueueTracks,
     handleAppleMusicQueueTrackChange,
+    handleAppleMusicBufferingChange,
+    handleAppleMusicAirPlay,
+    handleAppleMusicAddToLibrary,
+    isAppleMusicBuffering,
     clearLibrary,
     manualSync,
     restoreInstance,

--- a/src/apps/ipod/hooks/useIpodLogic.ts
+++ b/src/apps/ipod/hooks/useIpodLogic.ts
@@ -3237,8 +3237,6 @@ export function useIpodLogic({
           }
           if (isOffline) {
             showOfflineStatus();
-          } else if (getCurrentAppleMusicCollectionShellTrack()) {
-            void skipAppleMusicCollectionShell("next");
           } else {
             skipOperationRef.current = true;
             startTrackSwitch();
@@ -3275,8 +3273,6 @@ export function useIpodLogic({
           }
           if (isOffline) {
             showOfflineStatus();
-          } else if (getCurrentAppleMusicCollectionShellTrack()) {
-            void skipAppleMusicCollectionShell("previous");
           } else {
             skipOperationRef.current = true;
             startTrackSwitch();
@@ -3326,7 +3322,7 @@ export function useIpodLogic({
           break;
       }
     },
-    [playClickSound, vibrate, registerActivity, getCurrentAppleMusicCollectionShellTrack, skipAppleMusicCollectionShell, nextTrack, showStatus, togglePlay, previousTrack, menuMode, menuHistory, selectedMenuItem, tracks, currentIndex, isPlaying, toggleVideo, handleMenuButton, isOffline, showOfflineStatus, startTrackSwitch, isCoverFlowOpen, isMusicQuizOpen, isBrickGameOpen]
+    [playClickSound, vibrate, registerActivity, nextTrack, showStatus, togglePlay, previousTrack, menuMode, menuHistory, selectedMenuItem, tracks, currentIndex, isPlaying, toggleVideo, handleMenuButton, isOffline, showOfflineStatus, startTrackSwitch, isCoverFlowOpen, isMusicQuizOpen, isBrickGameOpen]
   );
 
   // Wheel rotation handler

--- a/src/apps/ipod/types.ts
+++ b/src/apps/ipod/types.ts
@@ -122,6 +122,8 @@ export interface IpodScreenProps {
   handleReady: () => void;
   loopCurrent: boolean;
   isShuffled: boolean;
+  loopAll: boolean;
+  onAppleMusicBufferingChange?: (buffering: boolean) => void;
   statusMessage: string | null;
   onToggleVideo: () => void;
   lcdFilterOn: boolean;

--- a/src/apps/ipod/types.ts
+++ b/src/apps/ipod/types.ts
@@ -97,6 +97,8 @@ export interface FullScreenPortalProps {
 // IpodScreen props
 export interface IpodScreenProps {
   currentTrack: Track | null;
+  appleMusicQueueTracks?: Track[] | null;
+  onAppleMusicQueueTrackChange?: (trackId: string) => void;
   isPlaying: boolean;
   elapsedTime: number;
   totalTime: number;

--- a/src/apps/ipod/types.ts
+++ b/src/apps/ipod/types.ts
@@ -42,6 +42,8 @@ export interface MenuHistoryEntry {
 // PIP Player props
 export interface PipPlayerProps {
   currentTrack: Track | null;
+  appleMusicQueueTracks?: Track[] | null;
+  onAppleMusicQueueTrackChange?: (trackId: string) => void;
   isPlaying: boolean;
   onTogglePlay: () => void;
   onNextTrack: () => void;

--- a/src/apps/ipod/utils/musickitPlayerAccess.ts
+++ b/src/apps/ipod/utils/musickitPlayerAccess.ts
@@ -1,0 +1,97 @@
+/**
+ * Helpers for reaching MusicKit playback controls across JS builds.
+ * v3 often flattens player methods onto the instance; older builds nest
+ * them under `instance.player`.
+ */
+
+export interface MusicKitShuffleRepeatState {
+  isShuffled: boolean;
+  loopCurrent: boolean;
+  loopAll: boolean;
+}
+
+type PlaybackSurface = {
+  shuffleMode?: MusicKit.PlayerShuffleMode;
+  repeatMode?: MusicKit.PlayerRepeatMode;
+  queue?: MusicKit.Queue;
+  nowPlayingItem?: MusicKit.MediaItem;
+  nowPlayingItemIndex?: number;
+  playbackTargetAvailable?: boolean;
+  showPlaybackTargetPicker?: () => void;
+  changeToMediaAtIndex?: (index: number) => Promise<unknown>;
+  changeToMediaItem?: (descriptor: string) => Promise<unknown>;
+};
+
+export function getMusicKitPlaybackSurface(
+  instance: MusicKit.MusicKitInstance
+): PlaybackSurface {
+  const nested = (
+    instance as MusicKit.MusicKitInstance & { player?: PlaybackSurface }
+  ).player;
+  if (nested) return nested;
+  return instance as unknown as PlaybackSurface;
+}
+
+export function mapIpodRepeatToMusicKit(
+  loopCurrent: boolean,
+  loopAll: boolean
+): MusicKit.PlayerRepeatMode {
+  if (loopCurrent) return 1;
+  if (loopAll) return 2;
+  return 0;
+}
+
+export function mapIpodShuffleToMusicKit(
+  isShuffled: boolean
+): MusicKit.PlayerShuffleMode {
+  return isShuffled ? 1 : 0;
+}
+
+export function applyMusicKitShuffleRepeat(
+  instance: MusicKit.MusicKitInstance,
+  state: MusicKitShuffleRepeatState
+): void {
+  const surface = getMusicKitPlaybackSurface(instance);
+  try {
+    surface.shuffleMode = mapIpodShuffleToMusicKit(state.isShuffled);
+    surface.repeatMode = mapIpodRepeatToMusicKit(
+      state.loopCurrent,
+      state.loopAll
+    );
+  } catch (err) {
+    console.warn("[apple music] failed to sync shuffle/repeat", err);
+  }
+}
+
+export function isMusicKitBufferingState(state: number | undefined): boolean {
+  return state === 1 || state === 6 || state === 8 || state === 9;
+}
+
+export function canShowMusicKitAirPlayPicker(
+  instance: MusicKit.MusicKitInstance
+): boolean {
+  const surface = getMusicKitPlaybackSurface(instance);
+  return Boolean(
+    surface.playbackTargetAvailable &&
+      typeof surface.showPlaybackTargetPicker === "function"
+  );
+}
+
+export function showMusicKitAirPlayPicker(
+  instance: MusicKit.MusicKitInstance
+): boolean {
+  const surface = getMusicKitPlaybackSurface(instance);
+  if (
+    !surface.playbackTargetAvailable ||
+    typeof surface.showPlaybackTargetPicker !== "function"
+  ) {
+    return false;
+  }
+  try {
+    surface.showPlaybackTargetPicker();
+    return true;
+  } catch (err) {
+    console.warn("[apple music] AirPlay picker failed", err);
+    return false;
+  }
+}

--- a/src/hooks/useActivityLabel.ts
+++ b/src/hooks/useActivityLabel.ts
@@ -28,6 +28,7 @@ export interface ActivityInfo {
   isFetchingSoramimi?: boolean;
   soramimiProgress?: number;
   isAddingSong?: boolean;
+  isBufferingPlayback?: boolean;
 }
 
 export interface ActivityLabelResult {

--- a/src/hooks/useActivityState.ts
+++ b/src/hooks/useActivityState.ts
@@ -27,6 +27,8 @@ export interface UseActivityStateParams {
   translationLanguage?: string | null;
   /** Whether currently adding a song */
   isAddingSong?: boolean;
+  /** Whether Apple Music playback is loading/buffering */
+  isBufferingPlayback?: boolean;
 }
 
 // =============================================================================
@@ -47,6 +49,7 @@ export function useActivityState({
   furiganaState,
   translationLanguage,
   isAddingSong = false,
+  isBufferingPlayback = false,
 }: UseActivityStateParams): ActivityInfo {
   const activityState: ActivityInfo = useMemo(
     () => ({
@@ -59,6 +62,7 @@ export function useActivityState({
       isFetchingSoramimi: furiganaState.isFetchingSoramimi,
       soramimiProgress: furiganaState.soramimiProgress,
       isAddingSong,
+      isBufferingPlayback,
     }),
     [
       lyricsState.isLoading,
@@ -70,6 +74,7 @@ export function useActivityState({
       furiganaState.isFetchingSoramimi,
       furiganaState.soramimiProgress,
       isAddingSong,
+      isBufferingPlayback,
     ]
   );
 
@@ -88,6 +93,7 @@ export function isAnyActivityActive(activityState: ActivityInfo): boolean {
     activityState.isTranslating ||
     activityState.isFetchingFurigana ||
     activityState.isFetchingSoramimi ||
-    activityState.isAddingSong
+    activityState.isAddingSong ||
+    activityState.isBufferingPlayback
   );
 }

--- a/src/hooks/useMusicKit.ts
+++ b/src/hooks/useMusicKit.ts
@@ -296,6 +296,7 @@ async function configureMusicKit(
       window.MusicKit!.configure({
         developerToken,
         app,
+        bitrate: MusicKit.PlaybackBitrate.HIGH,
         ...(musicUserToken ? { musicUserToken } : {}),
       })
     );

--- a/src/types/musickit.d.ts
+++ b/src/types/musickit.d.ts
@@ -137,6 +137,7 @@ declare global {
       readonly storefrontId: string;
       readonly currentPlaybackTime: number;
       readonly currentPlaybackDuration: number;
+      readonly nowPlayingItem?: MediaItem;
       readonly volume: number;
 
       addEventListener<K extends keyof MusicKitEventMap>(

--- a/src/types/musickit.d.ts
+++ b/src/types/musickit.d.ts
@@ -26,6 +26,14 @@ declare global {
       completed = 10,
     }
 
+    enum PlaybackBitrate {
+      STANDARD = 64,
+      HIGH = 256,
+    }
+
+    type PlayerRepeatMode = 0 | 1 | 2;
+    type PlayerShuffleMode = 0 | 1;
+
     interface AppMetadata {
       name: string;
       build: string;
@@ -35,7 +43,7 @@ declare global {
     interface ConfigureOptions {
       developerToken: string;
       app: AppMetadata;
-      bitrate?: number;
+      bitrate?: PlaybackBitrate | number;
       storefrontId?: string;
       /** Provided automatically by the JS once a user authorizes. */
       musicUserToken?: string;
@@ -48,6 +56,7 @@ declare global {
       playlist?: string;
       station?: string;
       url?: string;
+      musicVideo?: string;
       startWith?: number;
       startTime?: number;
       /** v3-preferred replacement for the deprecated `autoplay`. */
@@ -91,6 +100,21 @@ declare global {
       artworkURL?: string;
     }
 
+    interface Queue {
+      readonly isEmpty: boolean;
+      readonly items: MediaItem[];
+      readonly length: number;
+      readonly position: number;
+      readonly nextPlayableItem?: MediaItem;
+      readonly previousPlayableItem?: MediaItem;
+      append(descriptor: SetQueueOptions | string): void;
+      prepend(descriptor: SetQueueOptions | string): void;
+      indexForItem(descriptor: string | MediaItem): number;
+      item(index: number): MediaItem | null | undefined;
+      addEventListener(name: string, cb: (event?: unknown) => void): void;
+      removeEventListener(name: string, cb?: (event?: unknown) => void): void;
+    }
+
     /** v3 events emitted by `MusicKit.MusicKitInstance`. */
     interface PlaybackStateDidChangeEvent {
       state: PlaybackStates | number;
@@ -110,6 +134,10 @@ declare global {
       oldItem?: MediaItem;
     }
 
+    interface QueueEvent {
+      queue?: Queue;
+    }
+
     /** Map of MusicKit event names to their event payload types. */
     interface MusicKitEventMap {
       playbackStateDidChange: PlaybackStateDidChangeEvent;
@@ -118,6 +146,8 @@ declare global {
       nowPlayingItemDidChange: MediaItemDidChangeEvent;
       authorizationStatusDidChange: { authorizationStatus?: number };
       userTokenDidChange: { token?: string };
+      queueIsReady: QueueEvent;
+      queueItemsDidChange: QueueEvent;
     }
 
     interface MusicAPI {
@@ -128,17 +158,43 @@ declare global {
       ) => Promise<{ data: T }>;
     }
 
+    interface Player {
+      readonly bitrate?: PlaybackBitrate | number;
+      readonly currentPlaybackDuration: number;
+      readonly currentPlaybackTime: number;
+      readonly isPlaying: boolean;
+      readonly nowPlayingItem?: MediaItem;
+      readonly nowPlayingItemIndex?: number;
+      readonly playbackState: PlaybackStates;
+      readonly playbackTargetAvailable?: boolean;
+      readonly queue: Queue;
+      repeatMode: PlayerRepeatMode;
+      shuffleMode: PlayerShuffleMode;
+      volume: number;
+      changeToMediaAtIndex(index: number): Promise<unknown>;
+      changeToMediaItem(descriptor: string | MediaItem): Promise<unknown>;
+      pause(): void;
+      play(): Promise<void>;
+      seekToTime(time: number): Promise<void>;
+      showPlaybackTargetPicker(): void;
+      skipToNextItem(): Promise<void>;
+      skipToPreviousItem(): Promise<void>;
+      stop(): void;
+    }
+
     interface MusicKitInstance {
       readonly api: MusicAPI;
       readonly developerToken: string;
       readonly isAuthorized: boolean;
       readonly musicUserToken: string;
       readonly playbackState: PlaybackStates;
+      readonly playbackTargetAvailable?: boolean;
       readonly storefrontId: string;
       readonly currentPlaybackTime: number;
       readonly currentPlaybackDuration: number;
       readonly nowPlayingItem?: MediaItem;
       readonly volume: number;
+      readonly player?: Player;
 
       addEventListener<K extends keyof MusicKitEventMap>(
         name: K,
@@ -154,17 +210,19 @@ declare global {
       authorize(): Promise<string>;
       unauthorize(): Promise<void>;
 
+      addToLibrary?(id: string, type: string): Promise<unknown>;
       setQueue(options: SetQueueOptions): Promise<unknown>;
       play(): Promise<void>;
       pause(): void;
       stop(): void;
       seekToTime(time: number): Promise<void>;
-      changeToMediaAtIndex(index: number): Promise<void>;
+      changeToMediaAtIndex(index: number): Promise<unknown>;
+      changeToMediaItem?(descriptor: string | MediaItem): Promise<unknown>;
+      playNext?(options: SetQueueOptions): Promise<unknown>;
+      playLater?(options: SetQueueOptions): Promise<unknown>;
       skipToNextItem(): Promise<void>;
       skipToPreviousItem(): Promise<void>;
-
-      // Volume control (read-only on the type but settable in practice — we
-      // assign through the bridge to honour the iPod volume slider).
+      showPlaybackTargetPicker?(): void;
     }
 
     function configure(

--- a/tests/test-ipod-apple-music.test.ts
+++ b/tests/test-ipod-apple-music.test.ts
@@ -52,6 +52,9 @@ const {
   isWithinEndedFanoutDedupWindow,
   ENDED_FANOUT_DEDUP_WINDOW_MS,
   getMusicKitEventItemId,
+  getAppleMusicSongQueueId,
+  buildAppleMusicQueueOptions,
+  resolveAppleMusicQueueTrackIdFromMediaItem,
 } = await import(
   "../src/apps/ipod/components/appleMusicPlayerBridgeUtils"
 );
@@ -225,6 +228,79 @@ describe("Apple Music playable resources", () => {
       playlistId: "pl.pm-mix",
       kind: "playlist",
     });
+  });
+});
+
+describe("Apple Music MusicKit queue helpers", () => {
+  const makeAppleMusicTrack = (
+    id: string,
+    catalogId: string,
+    title = id
+  ): Track => ({
+    id,
+    url: `applemusic:${catalogId}`,
+    title,
+    source: "appleMusic",
+    appleMusicPlayParams: {
+      catalogId,
+      kind: "song",
+    },
+  });
+
+  test("builds a MusicKit song queue with the selected track as startWith", () => {
+    const one = makeAppleMusicTrack("am:1", "1", "One");
+    const two = makeAppleMusicTrack("am:2", "2", "Two");
+    const three = makeAppleMusicTrack("am:3", "3", "Three");
+
+    const queue = buildAppleMusicQueueOptions(two, [one, two, three]);
+
+    expect(queue?.options).toEqual({
+      songs: ["1", "2", "3"],
+      startWith: 1,
+      startPlaying: true,
+    });
+    expect(queue?.queuedTrackIds).toEqual(["am:1", "am:2", "am:3"]);
+    expect(queue?.isMultiSongQueue).toBe(true);
+  });
+
+  test("falls back to a single song queue when the context is not playable", () => {
+    const one = makeAppleMusicTrack("am:1", "1", "One");
+    const station: Track = {
+      id: "am:station:ra.1",
+      url: "applemusic:station:ra.1",
+      title: "Station",
+      source: "appleMusic",
+      appleMusicPlayParams: { stationId: "ra.1", kind: "radioStation" },
+    };
+
+    expect(getAppleMusicSongQueueId(station)).toBeNull();
+    expect(buildAppleMusicQueueOptions(one, [station])?.options).toEqual({
+      song: "1",
+      startPlaying: true,
+    });
+  });
+
+  test("resolves MusicKit media item IDs back to iPod track IDs", () => {
+    const one = makeAppleMusicTrack("am:1", "1", "One");
+
+    expect(
+      resolveAppleMusicQueueTrackIdFromMediaItem(
+        {
+          id: "1",
+          attributes: {
+            playParams: { id: "1", kind: "song" },
+          },
+        },
+        [one]
+      )
+    ).toBe("am:1");
+  });
+
+  test("suppresses per-song ended fan-out inside MusicKit song queues", () => {
+    const one = makeAppleMusicTrack("am:1", "1", "One");
+
+    expect(shouldFireEndedForPlaybackState(5, one, true)).toBe(false);
+    expect(shouldFireEndedForPlaybackState(10, one, true)).toBe(true);
   });
 });
 

--- a/tests/test-ipod-apple-music.test.ts
+++ b/tests/test-ipod-apple-music.test.ts
@@ -54,11 +54,19 @@ const {
   getMusicKitEventItemId,
   getAppleMusicSongQueueId,
   buildAppleMusicQueueOptions,
+  buildAppleMusicQueuePlacementOptions,
+  getSharedAlbumCatalogId,
+  getInQueueNavigationIndex,
   resolveAppleMusicQueueTrackIdFromMediaItem,
   shouldSyncQueueTrackFromMediaItem,
 } = await import(
   "../src/apps/ipod/components/appleMusicPlayerBridgeUtils"
 );
+const {
+  mapIpodRepeatToMusicKit,
+  mapIpodShuffleToMusicKit,
+  isMusicKitBufferingState,
+} = await import("../src/apps/ipod/utils/musickitPlayerAccess");
 type Track = import("../src/stores/useIpodStore").Track;
 const {
   isValidAppleMusicSongId,
@@ -236,12 +244,14 @@ describe("Apple Music MusicKit queue helpers", () => {
   const makeAppleMusicTrack = (
     id: string,
     catalogId: string,
-    title = id
+    title = id,
+    albumId?: string
   ): Track => ({
     id,
     url: `applemusic:${catalogId}`,
     title,
     source: "appleMusic",
+    appleMusicAlbumId: albumId,
     appleMusicPlayParams: {
       catalogId,
       kind: "song",
@@ -332,6 +342,60 @@ describe("Apple Music MusicKit queue helpers", () => {
     expect(
       shouldSyncQueueTrackFromMediaItem("am:2", "am:2", null, queueIds)
     ).toBe(false);
+  });
+
+  test("prefers native album queues when every track shares a catalog album id", () => {
+    const one = makeAppleMusicTrack("am:1", "1", "One", "album-42");
+    const two = makeAppleMusicTrack("am:2", "2", "Two", "album-42");
+
+    const queue = buildAppleMusicQueueOptions(two, [one, two]);
+
+    expect(queue?.options).toEqual({
+      album: "album-42",
+      startWith: 1,
+      startPlaying: true,
+    });
+    expect(queue?.queueKind).toBe("album");
+    expect(queue?.startWithIndex).toBe(1);
+  });
+
+  test("detects in-queue navigation without rebuilding the queue", () => {
+    const one = makeAppleMusicTrack("am:1", "1", "One");
+    const two = makeAppleMusicTrack("am:2", "2", "Two");
+    const queue = buildAppleMusicQueueOptions(two, [one, two]);
+
+    expect(
+      getInQueueNavigationIndex(queue!, queue!.definitionKey)
+    ).toBe(1);
+    expect(getInQueueNavigationIndex(queue!, "different")).toBeNull();
+  });
+
+  test("builds playNext/playLater placement options from a track", () => {
+    const one = makeAppleMusicTrack("am:1", "1", "One");
+    expect(buildAppleMusicQueuePlacementOptions(one)).toEqual({
+      song: "1",
+      startPlaying: true,
+    });
+  });
+
+  test("maps iPod shuffle/repeat settings to MusicKit modes", () => {
+    expect(mapIpodShuffleToMusicKit(true)).toBe(1);
+    expect(mapIpodShuffleToMusicKit(false)).toBe(0);
+    expect(mapIpodRepeatToMusicKit(true, false)).toBe(1);
+    expect(mapIpodRepeatToMusicKit(false, true)).toBe(2);
+    expect(mapIpodRepeatToMusicKit(false, false)).toBe(0);
+  });
+
+  test("treats loading and stalled states as buffering", () => {
+    expect(isMusicKitBufferingState(1)).toBe(true);
+    expect(isMusicKitBufferingState(9)).toBe(true);
+    expect(isMusicKitBufferingState(2)).toBe(false);
+  });
+
+  test("rejects library album ids for native album queues", () => {
+    const one = makeAppleMusicTrack("am:1", "1", "One", "l.album");
+    const two = makeAppleMusicTrack("am:2", "2", "Two", "l.album");
+    expect(getSharedAlbumCatalogId([one, two])).toBeNull();
   });
 });
 

--- a/tests/test-ipod-apple-music.test.ts
+++ b/tests/test-ipod-apple-music.test.ts
@@ -55,6 +55,7 @@ const {
   getAppleMusicSongQueueId,
   buildAppleMusicQueueOptions,
   resolveAppleMusicQueueTrackIdFromMediaItem,
+  shouldSyncQueueTrackFromMediaItem,
 } = await import(
   "../src/apps/ipod/components/appleMusicPlayerBridgeUtils"
 );
@@ -317,6 +318,20 @@ describe("Apple Music MusicKit queue helpers", () => {
 
     expect(shouldFireEndedForPlaybackState(5, one, true)).toBe(false);
     expect(shouldFireEndedForPlaybackState(10, one, true)).toBe(true);
+  });
+
+  test("blocks MusicKit sync while an explicit playback target is pending", () => {
+    const queueIds = ["am:1", "am:2", "am:3"];
+
+    expect(
+      shouldSyncQueueTrackFromMediaItem("am:2", "am:3", "am:3", queueIds)
+    ).toBe(false);
+    expect(
+      shouldSyncQueueTrackFromMediaItem("am:2", "am:1", null, queueIds)
+    ).toBe(true);
+    expect(
+      shouldSyncQueueTrackFromMediaItem("am:2", "am:2", null, queueIds)
+    ).toBe(false);
   });
 });
 

--- a/tests/test-ipod-apple-music.test.ts
+++ b/tests/test-ipod-apple-music.test.ts
@@ -296,6 +296,22 @@ describe("Apple Music MusicKit queue helpers", () => {
     ).toBe("am:1");
   });
 
+  test("resolves MusicKit nowPlayingItem catalog IDs when item.id is absent", () => {
+    const one = makeAppleMusicTrack("am:1", "1", "One");
+
+    expect(
+      resolveAppleMusicQueueTrackIdFromMediaItem(
+        {
+          attributes: {
+            playParams: { id: "library-only-id", catalogId: "1", kind: "song" },
+          },
+          playbackDuration: 180000,
+        },
+        [one]
+      )
+    ).toBe("am:1");
+  });
+
   test("suppresses per-song ended fan-out inside MusicKit song queues", () => {
     const one = makeAppleMusicTrack("am:1", "1", "One");
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes regressions from the MusicKit integration where Apple Music playback got stuck on one song and track clicks no longer played immediately.

### Root causes
- The full library was being passed to MusicKit as a multi-song queue when browsing **All Songs**, causing `setQueue` failures and broken in-queue navigation via `changeToMediaAtIndex`.
- Track clicks opened a **Play / Play Next / Play Later** submenu instead of playing immediately.

### Fixes
- Only pass contextual queues (album / artist / playlist drill-down) to MusicKit; use single-song queues for full-library browsing.
- Restore direct play on track click.
- Fall back to `setQueue` when `changeToMediaAtIndex` fails.
- Clear queue suppression on explicit user track selection.

Play Next / Play Later APIs remain available on the bridge for future UI wiring (menu bar, long-press, etc.).

**Testing**
- ✅ `bun test tests/test-ipod-apple-music.test.ts` (65 tests)
- ✅ `bun run build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-13682ed4-5186-4dd2-8b29-9d3d0928a9dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-13682ed4-5186-4dd2-8b29-9d3d0928a9dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

