### PR TITLE
feat(ipod): robust Apple Music play queues via MusicKit v3 native multi-song queues

### DIFF
--- a/src/apps/ipod/components/AppleMusicPlayerBridge.tsx
+++ b/src/apps/ipod/components/AppleMusicPlayerBridge.tsx
@@ -3,6 +3,7 @@ import type { Track } from "@/stores/useIpodStore";
 import { onMusicKitReady } from "@/hooks/useMusicKit";
 import { PLAYER_PROGRESS_INTERVAL_MS } from "../constants";
 import {
+  applyMusicKitPlaybackModes,
   buildMusicKitQueueIdentity,
   buildMusicKitSongQueue,
   findTrackIdByMusicKitItemId,
@@ -13,8 +14,11 @@ import {
   getQueueOptionsForTrack,
   isMusicKitPlayingSongId,
   isWithinEndedFanoutDedupWindow,
+  musicKitRepeatToStore,
+  musicKitShuffleToStore,
   shouldFireEndedForPlaybackState,
   shouldUseNativeMusicKitSongQueue,
+  type StorePlaybackModes,
 } from "./appleMusicPlayerBridgeUtils";
 
 /**
@@ -44,10 +48,12 @@ export interface AppleMusicPlayerBridgeProps {
    * When eligible, the bridge builds a native MusicKit multi-song queue.
    */
   queueTracks?: Track[];
-  /** Whether shuffle is active — disables native multi-song queues. */
+  /** ryOS shuffle flag — mirrored to MusicKit `shuffleMode`. */
   isShuffled?: boolean;
-  /** Whether repeat-one is active — disables native multi-song queues. */
+  /** ryOS repeat-one flag — mirrored to MusicKit `repeatMode`. */
   loopCurrent?: boolean;
+  /** ryOS repeat-all flag — mirrored to MusicKit `repeatMode`. */
+  loopAll?: boolean;
   /** Whether playback should be active. */
   playing: boolean;
   /** Saved playback position to seek to after queueing a track. */
@@ -62,6 +68,8 @@ export interface AppleMusicPlayerBridgeProps {
   onReady?: () => void;
   /** Sync ryOS current-song id when MusicKit auto-advances in a native queue. */
   onQueueTrackChange?: (trackId: string) => void;
+  /** Sync ryOS shuffle/repeat when the user changes modes in MusicKit UI. */
+  onPlaybackModesChange?: (modes: StorePlaybackModes) => void;
   onNowPlayingItemChange?: (
     metadata: AppleMusicNowPlayingMetadata | null
   ) => void;
@@ -123,6 +131,7 @@ export const AppleMusicPlayerBridge = function AppleMusicPlayerBridge(
     queueTracks,
     isShuffled = false,
     loopCurrent = false,
+    loopAll = false,
     playing,
     resumeAtSeconds,
     volume,
@@ -133,6 +142,7 @@ export const AppleMusicPlayerBridge = function AppleMusicPlayerBridge(
     onEnded,
     onReady,
     onQueueTrackChange,
+    onPlaybackModesChange,
     onNowPlayingItemChange
   }: AppleMusicPlayerBridgeProps & {
     ref?: React.Ref<AppleMusicPlayerBridgeHandle>;
@@ -147,10 +157,16 @@ export const AppleMusicPlayerBridge = function AppleMusicPlayerBridge(
   const onReadyRef = useRef(onReady);
   onReadyRef.current = onReady;
 
-  const effectiveQueueTracks = queueTracks ?? (currentTrack ? [currentTrack] : []);
+  const effectiveQueueTracks = useMemo(
+    () => queueTracks ?? (currentTrack ? [currentTrack] : []),
+    [queueTracks, currentTrack]
+  );
+  const playbackModes = useMemo<StorePlaybackModes>(
+    () => ({ isShuffled, loopCurrent, loopAll }),
+    [isShuffled, loopCurrent, loopAll]
+  );
   const usesNativeMultiSongQueue = shouldUseNativeMusicKitSongQueue(
-    effectiveQueueTracks,
-    { isShuffled, loopCurrent }
+    effectiveQueueTracks
   );
   const usesNativeMultiSongQueueRef = useRef(usesNativeMultiSongQueue);
   usesNativeMultiSongQueueRef.current = usesNativeMultiSongQueue;
@@ -198,6 +214,7 @@ export const AppleMusicPlayerBridge = function AppleMusicPlayerBridge(
   const onPauseRef = useRef(onPause);
   const onEndedRef = useRef(onEnded);
   const onQueueTrackChangeRef = useRef(onQueueTrackChange);
+  const onPlaybackModesChangeRef = useRef(onPlaybackModesChange);
   const onNowPlayingItemChangeRef = useRef(onNowPlayingItemChange);
   onProgressRef.current = onProgress;
   onDurationRef.current = onDuration;
@@ -205,7 +222,12 @@ export const AppleMusicPlayerBridge = function AppleMusicPlayerBridge(
   onPauseRef.current = onPause;
   onEndedRef.current = onEnded;
   onQueueTrackChangeRef.current = onQueueTrackChange;
+  onPlaybackModesChangeRef.current = onPlaybackModesChange;
   onNowPlayingItemChangeRef.current = onNowPlayingItemChange;
+
+  const playbackModesRef = useRef(playbackModes);
+  playbackModesRef.current = playbackModes;
+  const applyingPlaybackModesFromStoreRef = useRef(false);
 
   const currentTrackRef = useRef(currentTrack);
   currentTrackRef.current = currentTrack;
@@ -285,6 +307,38 @@ export const AppleMusicPlayerBridge = function AppleMusicPlayerBridge(
       );
     };
 
+    const readEventMode = (event: unknown): number | undefined => {
+      if (typeof event === "number") return event;
+      if (event && typeof event === "object") {
+        const record = event as Record<string, unknown>;
+        const candidate = record.shuffleMode ?? record.repeatMode ?? record.mode;
+        return typeof candidate === "number" ? candidate : undefined;
+      }
+      return undefined;
+    };
+
+    const handleShuffleMode = (event: unknown) => {
+      if (applyingPlaybackModesFromStoreRef.current) return;
+      const shuffleMode = readEventMode(event);
+      if (shuffleMode === undefined) return;
+      const storeModes = musicKitShuffleToStore(shuffleMode);
+      onPlaybackModesChangeRef.current?.({
+        ...playbackModesRef.current,
+        ...storeModes,
+      });
+    };
+
+    const handleRepeatMode = (event: unknown) => {
+      if (applyingPlaybackModesFromStoreRef.current) return;
+      const repeatMode = readEventMode(event);
+      if (repeatMode === undefined) return;
+      const storeModes = musicKitRepeatToStore(repeatMode);
+      onPlaybackModesChangeRef.current?.({
+        ...playbackModesRef.current,
+        ...storeModes,
+      });
+    };
+
     const tryAttach = (inst: MusicKit.MusicKitInstance | null) => {
       if (cancelled || !inst) return;
       if (activeInstance === inst) return;
@@ -292,6 +346,8 @@ export const AppleMusicPlayerBridge = function AppleMusicPlayerBridge(
       inst.addEventListener("playbackStateDidChange", handleState);
       inst.addEventListener("mediaItemDidChange", handleMediaItem);
       inst.addEventListener("nowPlayingItemDidChange", handleMediaItem);
+      inst.addEventListener("shuffleModeDidChange", handleShuffleMode);
+      inst.addEventListener("repeatModeDidChange", handleRepeatMode);
     };
 
     tryAttach(instanceRef.current);
@@ -313,9 +369,32 @@ export const AppleMusicPlayerBridge = function AppleMusicPlayerBridge(
           "nowPlayingItemDidChange",
           handleMediaItem
         );
+        activeInstance.removeEventListener(
+          "shuffleModeDidChange",
+          handleShuffleMode
+        );
+        activeInstance.removeEventListener(
+          "repeatModeDidChange",
+          handleRepeatMode
+        );
       }
     };
   }, []);
+
+  // Mirror ryOS shuffle / repeat to MusicKit so the player owns queue order
+  // and looping instead of our store-driven next-track picker.
+  useEffect(() => {
+    const inst = instanceRef.current;
+    if (!inst) return;
+    applyingPlaybackModesFromStoreRef.current = true;
+    try {
+      applyMusicKitPlaybackModes(inst, playbackModes);
+    } catch (err) {
+      console.warn("[apple music] failed to sync playback modes", err);
+    } finally {
+      applyingPlaybackModesFromStoreRef.current = false;
+    }
+  }, [playbackModes, instanceReadyTick]);
 
   useEffect(() => {
     if (!playing || !currentTrack) return;
@@ -450,7 +529,8 @@ export const AppleMusicPlayerBridge = function AppleMusicPlayerBridge(
           ? getQueueOptionsForNativeSongQueue(
               effectiveQueueTracks,
               currentTrack,
-              false
+              false,
+              playbackModesRef.current
             )
           : null;
       const singleTrackOptions =

--- a/src/apps/ipod/components/AppleMusicPlayerBridge.tsx
+++ b/src/apps/ipod/components/AppleMusicPlayerBridge.tsx
@@ -3,9 +3,18 @@ import type { Track } from "@/stores/useIpodStore";
 import { onMusicKitReady } from "@/hooks/useMusicKit";
 import { PLAYER_PROGRESS_INTERVAL_MS } from "../constants";
 import {
+  buildMusicKitQueueIdentity,
+  buildMusicKitSongQueue,
+  findTrackIdByMusicKitItemId,
   getMusicKitEventItemId,
+  getMusicKitQueueStartIndex,
+  getMusicKitSongId,
+  getQueueOptionsForNativeSongQueue,
+  getQueueOptionsForTrack,
+  isMusicKitPlayingSongId,
   isWithinEndedFanoutDedupWindow,
   shouldFireEndedForPlaybackState,
+  shouldUseNativeMusicKitSongQueue,
 } from "./appleMusicPlayerBridgeUtils";
 
 /**
@@ -18,6 +27,9 @@ import {
  * Lifecycle:
  *   - When `currentTrack` changes the bridge calls `setQueue` with the
  *     track's catalog or library ID, then plays/pauses to match `playing`.
+ *   - For sequential album/playlist/library playback with 2+ songs, builds
+ *     a native MusicKit multi-song queue (`setQueue({ songs, startWith })`)
+ *     so MusicKit auto-advances between tracks without racing `setQueue`.
  *   - Listens to `playbackTimeDidChange` / `playbackStateDidChange` /
  *     `mediaItemDidChange` to drive `onProgress` / `onPlay` / `onPause` /
  *     `onDuration` callbacks identical to `react-player`'s shape.
@@ -27,6 +39,15 @@ import {
 export interface AppleMusicPlayerBridgeProps {
   /** Current Apple Music track to play. Triggers `setQueue` on change. */
   currentTrack: Track | null;
+  /**
+   * Ordered tracks that scope playback (album, playlist, library subset).
+   * When eligible, the bridge builds a native MusicKit multi-song queue.
+   */
+  queueTracks?: Track[];
+  /** Whether shuffle is active — disables native multi-song queues. */
+  isShuffled?: boolean;
+  /** Whether repeat-one is active — disables native multi-song queues. */
+  loopCurrent?: boolean;
   /** Whether playback should be active. */
   playing: boolean;
   /** Saved playback position to seek to after queueing a track. */
@@ -39,6 +60,8 @@ export interface AppleMusicPlayerBridgeProps {
   onPause?: () => void;
   onEnded?: () => void;
   onReady?: () => void;
+  /** Sync ryOS current-song id when MusicKit auto-advances in a native queue. */
+  onQueueTrackChange?: (trackId: string) => void;
   onNowPlayingItemChange?: (
     metadata: AppleMusicNowPlayingMetadata | null
   ) => void;
@@ -56,25 +79,6 @@ export interface AppleMusicNowPlayingMetadata {
   artist?: string;
   album?: string;
   cover?: string;
-}
-
-function getQueueOptions(track: Track): MusicKit.SetQueueOptions | null {
-  const params = track.appleMusicPlayParams;
-  if (!params) return null;
-  if (params.stationId) {
-    return { station: params.stationId, startPlaying: true };
-  }
-  if (params.playlistId) {
-    return { playlist: params.playlistId, startPlaying: true };
-  }
-  // Prefer catalog ID for streaming. Fall back to the library ID when the
-  // track is library-only (no catalog match available).
-  const id =
-    params.kind === "library-songs"
-      ? params.libraryId || params.catalogId
-      : params.catalogId || params.libraryId;
-  if (!id) return null;
-  return { song: id, startPlaying: true };
 }
 
 function getSafeStartSeconds(
@@ -116,6 +120,9 @@ export const AppleMusicPlayerBridge = function AppleMusicPlayerBridge(
   {
     ref,
     currentTrack,
+    queueTracks,
+    isShuffled = false,
+    loopCurrent = false,
     playing,
     resumeAtSeconds,
     volume,
@@ -125,6 +132,7 @@ export const AppleMusicPlayerBridge = function AppleMusicPlayerBridge(
     onPause,
     onEnded,
     onReady,
+    onQueueTrackChange,
     onNowPlayingItemChange
   }: AppleMusicPlayerBridgeProps & {
     ref?: React.Ref<AppleMusicPlayerBridgeHandle>;
@@ -133,9 +141,21 @@ export const AppleMusicPlayerBridge = function AppleMusicPlayerBridge(
   const instanceRef = useRef<MusicKit.MusicKitInstance | null>(null);
   const [instanceReadyTick, setInstanceReadyTick] = useState(0);
   const lastQueuedTrackIdRef = useRef<string | null>(null);
+  const lastQueueIdentityRef = useRef<string | null>(null);
+  const lastNowPlayingItemIdRef = useRef<string | null>(null);
   const queueLoadingRef = useRef<Promise<void> | null>(null);
   const onReadyRef = useRef(onReady);
   onReadyRef.current = onReady;
+
+  const effectiveQueueTracks = queueTracks ?? (currentTrack ? [currentTrack] : []);
+  const usesNativeMultiSongQueue = shouldUseNativeMusicKitSongQueue(
+    effectiveQueueTracks,
+    { isShuffled, loopCurrent }
+  );
+  const usesNativeMultiSongQueueRef = useRef(usesNativeMultiSongQueue);
+  usesNativeMultiSongQueueRef.current = usesNativeMultiSongQueue;
+  const queueTracksRef = useRef(effectiveQueueTracks);
+  queueTracksRef.current = effectiveQueueTracks;
 
   // Bind the singleton — useMusicKit may not have completed configure() yet
   // when the iPod first mounts, so we subscribe to the ready notification
@@ -155,12 +175,6 @@ export const AppleMusicPlayerBridge = function AppleMusicPlayerBridge(
   }, []);
 
   // Stop MusicKit on unmount.
-  //
-  // MusicKit JS owns its own internal `<audio>` element that is NOT a child
-  // of this React tree, so unmounting the bridge does not stop playback on
-  // its own — the song would keep playing in the background after the iPod
-  // window closes (or the librarySource flips back to YouTube). Force a
-  // stop here so closing the iPod always silences Apple Music.
   useEffect(() => {
     return () => {
       const inst = instanceRef.current;
@@ -178,56 +192,27 @@ export const AppleMusicPlayerBridge = function AppleMusicPlayerBridge(
     };
   }, []);
 
-  // Track latest callbacks via refs to avoid resubscribing event listeners
-  // every render (callbacks are recreated by React but the listeners are
-  // expensive to add/remove on a hot path).
   const onProgressRef = useRef(onProgress);
   const onDurationRef = useRef(onDuration);
   const onPlayRef = useRef(onPlay);
   const onPauseRef = useRef(onPause);
   const onEndedRef = useRef(onEnded);
+  const onQueueTrackChangeRef = useRef(onQueueTrackChange);
   const onNowPlayingItemChangeRef = useRef(onNowPlayingItemChange);
   onProgressRef.current = onProgress;
   onDurationRef.current = onDuration;
   onPlayRef.current = onPlay;
   onPauseRef.current = onPause;
   onEndedRef.current = onEnded;
+  onQueueTrackChangeRef.current = onQueueTrackChange;
   onNowPlayingItemChangeRef.current = onNowPlayingItemChange;
 
-  // Track latest currentTrack so the once-only event listeners can read it
-  // without resubscribing on every render.
   const currentTrackRef = useRef(currentTrack);
   currentTrackRef.current = currentTrack;
 
-  // Dedup state for `onEnded` fan-out. MusicKit JS fires both `ended`
-  // (5) and `completed` (10) when a single-song queue's only item
-  // finishes. Without dedup the parent's `nextTrack` runs twice — the
-  // second pick races MusicKit's first `setQueue`, so the audio the user
-  // hears can mismatch the song the iPod displays. With shuffle on the
-  // mismatch is the most visible because each call picks a different
-  // random song.
-  //
-  // Two layers (either match suppresses):
-  //  - `lastEndedFiredForItemIdRef`: the just-ended item id. State 5 and
-  //    state 10 reference the SAME item, so identical ids dedup
-  //    regardless of timing.
-  //  - `lastEndedFiredAtRef`: wall-clock timestamp + window. Backstop for
-  //    builds that strip `event.item` from the second event.
   const lastEndedFiredForItemIdRef = useRef<string | null>(null);
   const lastEndedFiredAtRef = useRef(0);
 
-  // Wire up MusicKit event listeners once the instance is available.
-  // We deliberately skip `playbackTimeDidChange` for progress updates:
-  // runtime logs (debug session b224e4) confirmed that MusicKit JS v3's
-  // `currentPlaybackTime` is rounded to integer seconds — both the
-  // polling read and the event payload return values like 7, 7, 7, 7,
-  // 8, 8, 8, 8, 9. That gives the lyrics view 1-second "step"
-  // updates, which renders as the stutter the user reported.
-  // Instead, the polling effect below interpolates using wall-clock
-  // time between MusicKit's integer ticks, producing smooth sub-second
-  // progress. The native time event is therefore not needed at all
-  // (it would just race the interpolated source with stale integer
-  // values). State + media-item events are still useful and remain.
   useEffect(() => {
     let cancelled = false;
     let activeInstance: MusicKit.MusicKitInstance | null = null;
@@ -244,15 +229,12 @@ export const AppleMusicPlayerBridge = function AppleMusicPlayerBridge(
       }
       if (
         (state === 5 || state === 10) &&
-        shouldFireEndedForPlaybackState(state, currentTrackRef.current)
+        shouldFireEndedForPlaybackState(
+          state,
+          currentTrackRef.current,
+          usesNativeMultiSongQueueRef.current
+        )
       ) {
-        // MusicKit fires both `ended` (5) and `completed` (10) when a
-        // single-song queue's only item finishes — dedup so the parent's
-        // next-track handler runs once per song-ending event. Most
-        // visible with shuffle on, where two fan-outs would pick two
-        // different random songs and race two `setQueue` calls in
-        // MusicKit, leaving the audio on a different song than the
-        // display.
         const now = Date.now();
         const eventItemId = getMusicKitEventItemId(event?.item);
         const itemIdMatches =
@@ -272,12 +254,14 @@ export const AppleMusicPlayerBridge = function AppleMusicPlayerBridge(
         onEndedRef.current?.();
         return;
       }
-      // loading/seeking/waiting/stalled and the suppressed mid-queue
-      // `ended` for shells — no-op for the iPod UI; the activity
-      // indicator is driven separately.
     };
 
     const handleMediaItem = (event: MusicKit.MediaItemDidChangeEvent) => {
+      const itemId = getMusicKitEventItemId(event.item);
+      if (itemId) {
+        lastNowPlayingItemIdRef.current = itemId;
+      }
+
       const durationMs =
         event.item?.attributes?.durationInMillis ??
         event.item?.playbackDuration ??
@@ -285,6 +269,17 @@ export const AppleMusicPlayerBridge = function AppleMusicPlayerBridge(
       if (durationMs > 0) {
         onDurationRef.current?.(durationMs / 1000);
       }
+
+      if (usesNativeMultiSongQueueRef.current) {
+        const trackId = findTrackIdByMusicKitItemId(
+          queueTracksRef.current,
+          itemId
+        );
+        if (trackId) {
+          onQueueTrackChangeRef.current?.(trackId);
+        }
+      }
+
       onNowPlayingItemChangeRef.current?.(
         mediaItemToNowPlayingMetadata(event.item)
       );
@@ -296,7 +291,6 @@ export const AppleMusicPlayerBridge = function AppleMusicPlayerBridge(
       activeInstance = inst;
       inst.addEventListener("playbackStateDidChange", handleState);
       inst.addEventListener("mediaItemDidChange", handleMediaItem);
-      // Some MusicKit builds emit nowPlayingItemDidChange instead.
       inst.addEventListener("nowPlayingItemDidChange", handleMediaItem);
     };
 
@@ -323,24 +317,6 @@ export const AppleMusicPlayerBridge = function AppleMusicPlayerBridge(
     };
   }, []);
 
-  // Steady-cadence progress polling with wall-clock interpolation.
-  //
-  // Why interpolate: MusicKit JS v3's `currentPlaybackTime` is rounded
-  // to integer seconds (verified in debug session b224e4). Polling
-  // every 200ms therefore yields five identical reads followed by a
-  // sudden +1 jump, which the lyrics view renders as visible stutter.
-  // Instead we snapshot a baseline every time the integer changes, and
-  // between updates report `baseSeconds + (now - baseWallClock) /
-  // 1000`, capped at +1s so we never run past the next integer tick
-  // (which would cause a tiny rewind when the next integer arrives).
-  //
-  // Why requestAnimationFrame: setInterval keeps firing even when the
-  // tab is hidden (just throttled to ~1Hz by the browser), wasting
-  // React render cycles for music nobody is looking at. rAF
-  // automatically pauses when the tab/page isn't visible. We still
-  // throttle React state pushes to ~PLAYER_PROGRESS_INTERVAL_MS using
-  // the wall clock, so the lyrics view sees the same ~5Hz update rate
-  // as before — just without background-tab waste.
   useEffect(() => {
     if (!playing || !currentTrack) return;
     let cancelled = false;
@@ -355,8 +331,6 @@ export const AppleMusicPlayerBridge = function AppleMusicPlayerBridge(
       if (!inst) return;
       const rawSeconds = inst.currentPlaybackTime ?? 0;
 
-      // First read or whenever the underlying integer changes (forward
-      // OR backward, e.g. seek), reset the interpolation baseline.
       if (baseSeconds === null || rawSeconds !== lastReportedSeconds) {
         baseSeconds = rawSeconds;
         baseWallClock = now;
@@ -364,10 +338,6 @@ export const AppleMusicPlayerBridge = function AppleMusicPlayerBridge(
       }
 
       const elapsed = (now - baseWallClock) / 1000;
-      // Cap at just under 1s so we never overshoot the next tick — if
-      // MusicKit's clock jumped forward by exactly 1s, we'd otherwise
-      // briefly report the same value as the next integer and then
-      // visibly rewind when interpolation restarts.
       const interpolated = baseSeconds + Math.min(elapsed, 0.99);
 
       onProgressRef.current?.({ playedSeconds: interpolated });
@@ -377,10 +347,6 @@ export const AppleMusicPlayerBridge = function AppleMusicPlayerBridge(
     const frame = () => {
       if (cancelled) return;
       const now = Date.now();
-      // Throttle to PLAYER_PROGRESS_INTERVAL_MS so we don't push 60
-      // updates/sec into React. rAF gives us automatic
-      // pause-on-hidden-tab; the throttle keeps the React workload
-      // identical to the old setInterval-based path.
       if (now - lastEmittedAt >= PLAYER_PROGRESS_INTERVAL_MS) {
         emit(now);
       }
@@ -411,14 +377,10 @@ export const AppleMusicPlayerBridge = function AppleMusicPlayerBridge(
     };
   }, [playing, currentTrack]);
 
-  // Sync volume — MusicKit reads `volume` as a number in [0, 1].
   useEffect(() => {
     const inst = instanceRef.current;
     if (!inst) return;
     try {
-      // `volume` is typed as readonly in our minimal d.ts, but it's settable
-      // in practice. We cast through `unknown` to silence the compiler
-      // without losing the rest of the typings.
       (inst as unknown as { volume: number }).volume = Math.max(
         0,
         Math.min(1, volume)
@@ -428,18 +390,25 @@ export const AppleMusicPlayerBridge = function AppleMusicPlayerBridge(
     }
   }, [volume]);
 
-  // Stable representation of the queue so we only call setQueue when the
-  // *track* (not unrelated prop changes) actually flips.
-  const queueKey = useMemo(() => currentTrack?.id ?? null, [currentTrack]);
+  const nativeQueueIdentity = useMemo(() => {
+    if (!usesNativeMultiSongQueue) return null;
+    const { songIds } = buildMusicKitSongQueue(effectiveQueueTracks);
+    return buildMusicKitQueueIdentity(songIds);
+  }, [usesNativeMultiSongQueue, effectiveQueueTracks]);
 
-  // Latest `playing` value, read inside the async setQueue effect to avoid
-  // stale closures when the user toggles play before the queue resolves.
+  const queueKey = useMemo(() => {
+    if (!currentTrack) return null;
+    if (usesNativeMultiSongQueue && nativeQueueIdentity) {
+      return `${nativeQueueIdentity}::${currentTrack.id}`;
+    }
+    return currentTrack.id;
+  }, [currentTrack, usesNativeMultiSongQueue, nativeQueueIdentity]);
+
   const playingRef = useRef(playing);
   playingRef.current = playing;
   const resumeAtSecondsRef = useRef(resumeAtSeconds);
   resumeAtSecondsRef.current = resumeAtSeconds;
 
-  // Drive `setQueue` on track change.
   useEffect(() => {
     let cancelled = false;
     const inst = instanceRef.current;
@@ -452,62 +421,118 @@ export const AppleMusicPlayerBridge = function AppleMusicPlayerBridge(
       }
       onNowPlayingItemChangeRef.current?.(null);
       lastQueuedTrackIdRef.current = null;
+      lastQueueIdentityRef.current = null;
       return;
     }
     if (lastQueuedTrackIdRef.current === queueKey) return;
     onNowPlayingItemChangeRef.current?.(null);
 
-    const queueOptions = getQueueOptions(currentTrack);
-    if (!queueOptions) {
-      console.warn(
-        "[apple music] track is missing playParams, skipping",
-        currentTrack
-      );
-      return;
-    }
-
     const localQueueKey = queueKey;
-    // Serialize back-to-back queue swaps. If another track change is
-    // already in flight (rapid `nextTrack` clicks, an `onEnded` advance
-    // racing a user press, etc.), wait for it to settle before issuing
-    // our own `setQueue`. Two concurrent `setQueue` calls inside
-    // MusicKit can resolve out of order — without serialization the
-    // older queue can briefly start playing after the newer one
-    // landed, so the audio mismatches the song the iPod displays
-    // (display reflects the *latest* React state, audio reflects
-    // whichever `setQueue` resolved last). Capture the *previous* ref
-    // so the new chain awaits the old one rather than itself.
     const previousQueueLoading = queueLoadingRef.current;
     let thisLoad: Promise<void> | null = null;
     thisLoad = (async () => {
       if (previousQueueLoading) {
-        // Best-effort wait — failures of the previous queue load
-        // shouldn't block a fresh user action.
         try {
           await previousQueueLoading;
         } catch {
-          /* ignore — the previous load already logged its own error */
+          /* ignore */
         }
         if (cancelled) return;
       }
-      try {
-        const resumeSeconds = getSafeStartSeconds(
-          currentTrack,
-          resumeAtSecondsRef.current
+
+      const resumeSeconds = getSafeStartSeconds(
+        currentTrack,
+        resumeAtSecondsRef.current
+      );
+
+      const nativeQueueOptions =
+        usesNativeMultiSongQueue && currentTrack
+          ? getQueueOptionsForNativeSongQueue(
+              effectiveQueueTracks,
+              currentTrack,
+              false
+            )
+          : null;
+      const singleTrackOptions =
+        nativeQueueOptions == null
+          ? getQueueOptionsForTrack(currentTrack)
+          : null;
+
+      if (!nativeQueueOptions && !singleTrackOptions) {
+        console.warn(
+          "[apple music] track is missing playParams, skipping",
+          currentTrack
         );
-        await inst.setQueue({
-          ...queueOptions,
-          startTime: resumeSeconds ?? undefined,
-          // Queue paused first so a restored elapsedTime can be applied
-          // before any audible playback starts.
-          startPlaying: false,
-        });
-        if (cancelled) return;
-        if (resumeSeconds != null) {
-          await inst.seekToTime(resumeSeconds).catch((err) => {
-            console.warn("[apple music] resume seek failed", err);
-          });
+        return;
+      }
+
+      const queueIdentity = nativeQueueOptions
+        ? buildMusicKitQueueIdentity(
+            buildMusicKitSongQueue(effectiveQueueTracks).songIds
+          )
+        : null;
+      const targetSongId = getMusicKitSongId(currentTrack);
+      const musicKitAlreadyOnTarget = isMusicKitPlayingSongId(
+        lastNowPlayingItemIdRef.current,
+        targetSongId
+      );
+
+      try {
+        if (
+          nativeQueueOptions &&
+          queueIdentity &&
+          lastQueueIdentityRef.current === queueIdentity &&
+          musicKitAlreadyOnTarget
+        ) {
+          // MusicKit auto-advanced (or the user skipped via MusicKit APIs).
+          // The audio is already on the right item — just sync play state.
+          if (cancelled) return;
+          lastQueuedTrackIdRef.current = localQueueKey;
+          if (playingRef.current) {
+            await inst.play().catch((err) => {
+              console.warn(
+                "[apple music] play() blocked, awaiting user gesture",
+                err
+              );
+              onPauseRef.current?.();
+            });
+          }
+          return;
         }
+
+        if (
+          nativeQueueOptions &&
+          queueIdentity &&
+          lastQueueIdentityRef.current === queueIdentity &&
+          !musicKitAlreadyOnTarget
+        ) {
+          const startWith = getMusicKitQueueStartIndex(
+            effectiveQueueTracks,
+            currentTrack
+          );
+          await inst.changeToMediaAtIndex(startWith);
+          if (cancelled) return;
+          if (resumeSeconds != null) {
+            await inst.seekToTime(resumeSeconds).catch((err) => {
+              console.warn("[apple music] resume seek failed", err);
+            });
+          }
+        } else {
+          const queueOptions = nativeQueueOptions ?? singleTrackOptions!;
+          await inst.setQueue({
+            ...queueOptions,
+            startTime: resumeSeconds ?? undefined,
+            startPlaying: false,
+          });
+          if (cancelled) return;
+          if (resumeSeconds != null) {
+            await inst.seekToTime(resumeSeconds).catch((err) => {
+              console.warn("[apple music] resume seek failed", err);
+            });
+          }
+          lastQueueIdentityRef.current = queueIdentity;
+        }
+
         if (cancelled) return;
         if (currentTrack.durationMs && currentTrack.durationMs > 0) {
           onDurationRef.current?.(currentTrack.durationMs / 1000);
@@ -515,8 +540,6 @@ export const AppleMusicPlayerBridge = function AppleMusicPlayerBridge(
         lastQueuedTrackIdRef.current = localQueueKey;
         if (playingRef.current) {
           await inst.play().catch((err) => {
-            // Browsers block autoplay until the user interacts; surface as
-            // a paused state so the iPod's play button shows the right icon.
             console.warn(
               "[apple music] play() blocked, awaiting user gesture",
               err
@@ -527,11 +550,6 @@ export const AppleMusicPlayerBridge = function AppleMusicPlayerBridge(
       } catch (err) {
         console.error("[apple music] setQueue failed", err);
       } finally {
-        // Only clear the shared ref when *we* are still the most recent
-        // load. A newer track change already replaced `queueLoadingRef`
-        // with its own promise; nulling here would let play/pause sync
-        // think there's no pending queue load and race the newer
-        // `setQueue` mid-flight.
         if (queueLoadingRef.current === thisLoad) {
           queueLoadingRef.current = null;
         }
@@ -544,7 +562,6 @@ export const AppleMusicPlayerBridge = function AppleMusicPlayerBridge(
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [queueKey, instanceReadyTick]);
 
-  // Sync play/pause without re-queueing.
   useEffect(() => {
     const inst = instanceRef.current;
     if (!inst) return;

--- a/src/apps/ipod/components/AppleMusicPlayerBridge.tsx
+++ b/src/apps/ipod/components/AppleMusicPlayerBridge.tsx
@@ -19,6 +19,7 @@ import {
   shouldFireEndedForPlaybackState,
   shouldUseNativeMusicKitSongQueue,
   type StorePlaybackModes,
+  withMusicKitShuffleSuspended,
 } from "./appleMusicPlayerBridgeUtils";
 
 /**
@@ -529,8 +530,7 @@ export const AppleMusicPlayerBridge = function AppleMusicPlayerBridge(
           ? getQueueOptionsForNativeSongQueue(
               effectiveQueueTracks,
               currentTrack,
-              false,
-              playbackModesRef.current
+              false
             )
           : null;
       const singleTrackOptions =
@@ -580,37 +580,47 @@ export const AppleMusicPlayerBridge = function AppleMusicPlayerBridge(
           return;
         }
 
-        if (
-          nativeQueueOptions &&
-          queueIdentity &&
-          lastQueueIdentityRef.current === queueIdentity &&
-          !musicKitAlreadyOnTarget
-        ) {
-          const startWith = getMusicKitQueueStartIndex(
-            effectiveQueueTracks,
-            currentTrack
-          );
-          await inst.changeToMediaAtIndex(startWith);
-          if (cancelled) return;
-          if (resumeSeconds != null) {
-            await inst.seekToTime(resumeSeconds).catch((err) => {
-              console.warn("[apple music] resume seek failed", err);
+        const modes = playbackModesRef.current;
+        const targetQueue = async () => {
+          if (
+            nativeQueueOptions &&
+            queueIdentity &&
+            lastQueueIdentityRef.current === queueIdentity &&
+            !musicKitAlreadyOnTarget
+          ) {
+            const startWith = getMusicKitQueueStartIndex(
+              effectiveQueueTracks,
+              currentTrack
+            );
+            await inst.changeToMediaAtIndex(startWith);
+            if (cancelled) return;
+            if (resumeSeconds != null) {
+              await inst.seekToTime(resumeSeconds).catch((err) => {
+                console.warn("[apple music] resume seek failed", err);
+              });
+            }
+          } else {
+            const queueOptions = nativeQueueOptions ?? singleTrackOptions!;
+            await inst.setQueue({
+              ...queueOptions,
+              startTime: resumeSeconds ?? undefined,
+              startPlaying: false,
             });
+            if (cancelled) return;
+            if (resumeSeconds != null) {
+              await inst.seekToTime(resumeSeconds).catch((err) => {
+                console.warn("[apple music] resume seek failed", err);
+              });
+            }
+            lastQueueIdentityRef.current = queueIdentity;
           }
-        } else {
-          const queueOptions = nativeQueueOptions ?? singleTrackOptions!;
-          await inst.setQueue({
-            ...queueOptions,
-            startTime: resumeSeconds ?? undefined,
-            startPlaying: false,
-          });
-          if (cancelled) return;
-          if (resumeSeconds != null) {
-            await inst.seekToTime(resumeSeconds).catch((err) => {
-              console.warn("[apple music] resume seek failed", err);
-            });
-          }
-          lastQueueIdentityRef.current = queueIdentity;
+        };
+
+        applyingPlaybackModesFromStoreRef.current = true;
+        try {
+          await withMusicKitShuffleSuspended(inst, modes, targetQueue);
+        } finally {
+          applyingPlaybackModesFromStoreRef.current = false;
         }
 
         if (cancelled) return;

--- a/src/apps/ipod/components/IpodAppComponent.tsx
+++ b/src/apps/ipod/components/IpodAppComponent.tsx
@@ -112,6 +112,8 @@ export function IpodAppComponent({
     isSyncModeOpen,
     setIsSyncModeOpen,
     currentTrack,
+    appleMusicQueueTracks,
+    handleAppleMusicQueueTrackChange,
     lyricsSourceOverride,
     lyricsTitle,
     lyricsArtist,
@@ -431,6 +433,12 @@ export function IpodAppComponent({
                   handleReady={handleReady}
                   loopCurrent={loopCurrent}
                   isShuffled={isShuffled}
+                  appleMusicQueueTracks={
+                    isAppleMusic ? appleMusicQueueTracks : undefined
+                  }
+                  onAppleMusicQueueTrackChange={
+                    isAppleMusic ? handleAppleMusicQueueTrackChange : undefined
+                  }
                   statusMessage={statusMessage}
                   onToggleVideo={toggleVideo}
                   lcdFilterOn={lcdFilterOn}
@@ -656,6 +664,11 @@ export function IpodAppComponent({
                                 fullScreenPlayerRef as unknown as React.RefObject<never>
                               }
                               currentTrack={tracks[currentIndex]}
+                              queueTracks={
+                                isAppleMusic ? appleMusicQueueTracks : undefined
+                              }
+                              isShuffled={isShuffled}
+                              loopCurrent={loopCurrent}
                               playing={isPlaying && isFullScreen}
                               resumeAtSeconds={elapsedTime}
                               volume={
@@ -668,6 +681,7 @@ export function IpodAppComponent({
                               onPause={handlePause}
                               onEnded={handleTrackEnd}
                               onReady={handleReady}
+                              onQueueTrackChange={handleAppleMusicQueueTrackChange}
                               onNowPlayingItemChange={setAppleMusicKitNowPlaying}
                             />
                           ) : (

--- a/src/apps/ipod/components/IpodAppComponent.tsx
+++ b/src/apps/ipod/components/IpodAppComponent.tsx
@@ -51,6 +51,7 @@ export function IpodAppComponent({
     currentIndex,
     coverFlowCurrentIndex,
     loopCurrent,
+    loopAll,
     isShuffled,
     isPlaying,
     showVideo,
@@ -114,6 +115,7 @@ export function IpodAppComponent({
     currentTrack,
     appleMusicQueueTracks,
     handleAppleMusicQueueTrackChange,
+    handleAppleMusicPlaybackModesChange,
     lyricsSourceOverride,
     lyricsTitle,
     lyricsArtist,
@@ -278,6 +280,9 @@ export function IpodAppComponent({
       onAppleMusicSignIn={handleAppleMusicSignIn}
       onAppleMusicSignOut={handleAppleMusicSignOut}
       onAppleMusicRefresh={handleAppleMusicRefresh}
+      onNextTrack={nextTrack}
+      onPreviousTrack={previousTrack}
+      onTogglePlay={togglePlay}
     />
   );
   const shouldAnimateFullScreenVisuals = isPlaying && (isForeground ?? true);
@@ -432,12 +437,16 @@ export function IpodAppComponent({
                   handlePause={handlePause}
                   handleReady={handleReady}
                   loopCurrent={loopCurrent}
+                  loopAll={loopAll}
                   isShuffled={isShuffled}
                   appleMusicQueueTracks={
                     isAppleMusic ? appleMusicQueueTracks : undefined
                   }
                   onAppleMusicQueueTrackChange={
                     isAppleMusic ? handleAppleMusicQueueTrackChange : undefined
+                  }
+                  onAppleMusicPlaybackModesChange={
+                    isAppleMusic ? handleAppleMusicPlaybackModesChange : undefined
                   }
                   statusMessage={statusMessage}
                   onToggleVideo={toggleVideo}
@@ -669,6 +678,7 @@ export function IpodAppComponent({
                               }
                               isShuffled={isShuffled}
                               loopCurrent={loopCurrent}
+                              loopAll={loopAll}
                               playing={isPlaying && isFullScreen}
                               resumeAtSeconds={elapsedTime}
                               volume={
@@ -682,6 +692,9 @@ export function IpodAppComponent({
                               onEnded={handleTrackEnd}
                               onReady={handleReady}
                               onQueueTrackChange={handleAppleMusicQueueTrackChange}
+                              onPlaybackModesChange={
+                                handleAppleMusicPlaybackModesChange
+                              }
                               onNowPlayingItemChange={setAppleMusicKitNowPlaying}
                             />
                           ) : (

--- a/src/apps/ipod/components/IpodMenuBar.tsx
+++ b/src/apps/ipod/components/IpodMenuBar.tsx
@@ -121,6 +121,7 @@ export function IpodMenuBar({
     // Actions
     setYoutubeCurrentSongId,
     setAppleMusicCurrentSongId,
+    setAppleMusicPlaybackQueue,
     setIsPlaying,
     toggleLoopAll,
     toggleLoopCurrent,
@@ -171,6 +172,7 @@ export function IpodMenuBar({
     // Actions
     setYoutubeCurrentSongId: s.setCurrentSongId,
     setAppleMusicCurrentSongId: s.setAppleMusicCurrentSongId,
+    setAppleMusicPlaybackQueue: s.setAppleMusicPlaybackQueue,
     setIsPlaying: s.setIsPlaying,
     toggleLoopAll: s.toggleLoopAll,
     toggleLoopCurrent: s.toggleLoopCurrent,
@@ -231,12 +233,14 @@ export function IpodMenuBar({
     return index >= 0 ? index : (tracks.length > 0 ? 0 : -1);
   }, [tracks, currentSongId]);
 
-  const handlePlayTrack = (index: number) => {
+  const handlePlayTrack = (index: number, queueIds?: string[] | null) => {
     const trackId = tracks[index]?.id;
-    if (trackId) {
-      setCurrentSongId(trackId);
-      setIsPlaying(true);
+    if (!trackId) return;
+    if (isAppleMusic && queueIds !== undefined) {
+      setAppleMusicPlaybackQueue(queueIds);
     }
+    setCurrentSongId(trackId);
+    setIsPlaying(true);
   };
 
   // Group tracks by artist. Memoized because the menubar re-renders on
@@ -960,7 +964,7 @@ export function IpodMenuBar({
                     <MenubarCheckboxItem
                       key={`all-${track.id}`}
                       checked={index === currentIndex}
-                      onCheckedChange={() => handlePlayTrack(index)}
+                      onCheckedChange={() => handlePlayTrack(index, null)}
                       className="text-md h-6 pr-3 max-w-[220px] truncate"
                     >
                       <span className="truncate min-w-0">{track.title}</span>
@@ -988,7 +992,11 @@ export function IpodMenuBar({
                   outer artist list. The full grouping is still memoized
                   above so the iPod screen can use it freely. */}
               <div className="max-h-[300px] overflow-y-auto">
-                {artists.slice(0, MENUBAR_ARTIST_LIMIT).map((artist) => (
+                {artists.slice(0, MENUBAR_ARTIST_LIMIT).map((artist) => {
+                  const artistQueueIds = tracksByArtist[artist].map(
+                    ({ track }) => track.id
+                  );
+                  return (
                   <MenubarSub key={artist}>
                     <MenubarSubTrigger className="text-md h-6 px-3">
                       <div className="flex justify-between w-full items-center overflow-hidden">
@@ -1002,7 +1010,9 @@ export function IpodMenuBar({
                           <MenubarCheckboxItem
                             key={`${artist}-${track.id}`}
                             checked={index === currentIndex}
-                            onCheckedChange={() => handlePlayTrack(index)}
+                            onCheckedChange={() =>
+                              handlePlayTrack(index, artistQueueIds)
+                            }
                             className="text-md h-6 pr-3 max-w-[160px] sm:max-w-[200px] truncate"
                           >
                             <span className="truncate min-w-0">
@@ -1012,7 +1022,8 @@ export function IpodMenuBar({
                         ))}
                     </MenubarSubContent>
                   </MenubarSub>
-                ))}
+                  );
+                })}
                 {artists.length > MENUBAR_ARTIST_LIMIT && (
                   <MenubarItem
                     disabled

--- a/src/apps/ipod/components/IpodMenuBar.tsx
+++ b/src/apps/ipod/components/IpodMenuBar.tsx
@@ -50,6 +50,9 @@ interface IpodMenuBarProps {
   onAppleMusicSignIn?: () => void;
   onAppleMusicSignOut?: () => void;
   onAppleMusicRefresh?: () => void;
+  onNextTrack?: () => void;
+  onPreviousTrack?: () => void;
+  onTogglePlay?: () => void;
 }
 
 export function IpodMenuBar({
@@ -70,6 +73,9 @@ export function IpodMenuBar({
   onAppleMusicSignIn,
   onAppleMusicSignOut,
   onAppleMusicRefresh,
+  onNextTrack,
+  onPreviousTrack,
+  onTogglePlay,
 }: IpodMenuBarProps) {
   const { t } = useTranslation();
   const [isShareDialogOpen, setIsShareDialogOpen] = useState(false);
@@ -213,8 +219,10 @@ export function IpodMenuBar({
   const setCurrentSongId = isAppleMusic
     ? setAppleMusicCurrentSongId
     : setYoutubeCurrentSongId;
-  const nextTrack = isAppleMusic ? appleMusicNext : youtubeNext;
-  const previousTrack = isAppleMusic ? appleMusicPrevious : youtubePrevious;
+  const nextTrack = onNextTrack ?? (isAppleMusic ? appleMusicNext : youtubeNext);
+  const previousTrack =
+    onPreviousTrack ?? (isAppleMusic ? appleMusicPrevious : youtubePrevious);
+  const playPause = onTogglePlay ?? togglePlay;
 
   // Compute currentIndex from currentSongId
   const currentIndex = useMemo(() => {
@@ -445,7 +453,7 @@ export function IpodMenuBar({
         </MenubarTrigger>
         <MenubarContent align="start" sideOffset={1} className="px-0">
           <MenubarItem
-            onClick={togglePlay}
+            onClick={playPause}
             className="text-md h-6 px-3"
             disabled={tracks.length === 0}
           >

--- a/src/apps/ipod/components/IpodScreen.tsx
+++ b/src/apps/ipod/components/IpodScreen.tsx
@@ -293,9 +293,11 @@ export function IpodScreen({
   handlePause,
   handleReady,
   loopCurrent,
+  loopAll,
   isShuffled,
   appleMusicQueueTracks,
   onAppleMusicQueueTrackChange,
+  onAppleMusicPlaybackModesChange,
   statusMessage,
   onToggleVideo,
   lcdFilterOn,
@@ -1273,6 +1275,7 @@ export function IpodScreen({
                 queueTracks={appleMusicQueueTracks}
                 isShuffled={isShuffled}
                 loopCurrent={loopCurrent}
+                loopAll={loopAll}
                 playing={isPlaying && !isFullScreen}
                 resumeAtSeconds={elapsedTime}
                 volume={finalIpodVolume}
@@ -1283,6 +1286,7 @@ export function IpodScreen({
                 onEnded={!isFullScreen ? handleTrackEnd : undefined}
                 onReady={!isFullScreen ? handleReady : undefined}
                 onQueueTrackChange={onAppleMusicQueueTrackChange}
+                onPlaybackModesChange={onAppleMusicPlaybackModesChange}
                 onNowPlayingItemChange={setAppleMusicKitNowPlaying}
               />
             ) : (

--- a/src/apps/ipod/components/IpodScreen.tsx
+++ b/src/apps/ipod/components/IpodScreen.tsx
@@ -294,6 +294,8 @@ export function IpodScreen({
   handleReady,
   loopCurrent,
   isShuffled,
+  appleMusicQueueTracks,
+  onAppleMusicQueueTrackChange,
   statusMessage,
   onToggleVideo,
   lcdFilterOn,
@@ -1268,6 +1270,9 @@ export function IpodScreen({
               <AppleMusicPlayerBridge
                 ref={playerRef as unknown as React.RefObject<never>}
                 currentTrack={currentTrack}
+                queueTracks={appleMusicQueueTracks}
+                isShuffled={isShuffled}
+                loopCurrent={loopCurrent}
                 playing={isPlaying && !isFullScreen}
                 resumeAtSeconds={elapsedTime}
                 volume={finalIpodVolume}
@@ -1277,6 +1282,7 @@ export function IpodScreen({
                 onPause={!isFullScreen ? handlePause : undefined}
                 onEnded={!isFullScreen ? handleTrackEnd : undefined}
                 onReady={!isFullScreen ? handleReady : undefined}
+                onQueueTrackChange={onAppleMusicQueueTrackChange}
                 onNowPlayingItemChange={setAppleMusicKitNowPlaying}
               />
             ) : (

--- a/src/apps/ipod/components/appleMusicPlayerBridgeUtils.ts
+++ b/src/apps/ipod/components/appleMusicPlayerBridgeUtils.ts
@@ -42,16 +42,84 @@ export function buildMusicKitQueueIdentity(songIds: string[]): string {
 /**
  * Whether to drive playback through MusicKit's native multi-song queue
  * (`setQueue({ songs, startWith })`) instead of single-song queues.
- *
- * Shuffle and repeat-one need ryOS to own track selection, so they stay on
- * the legacy single-song path.
  */
-export function shouldUseNativeMusicKitSongQueue(
-  queueTracks: Track[],
-  options: { isShuffled: boolean; loopCurrent: boolean }
-): boolean {
-  if (options.isShuffled || options.loopCurrent) return false;
+export function shouldUseNativeMusicKitSongQueue(queueTracks: Track[]): boolean {
   return buildMusicKitSongQueue(queueTracks).songIds.length >= 2;
+}
+
+export interface StorePlaybackModes {
+  isShuffled: boolean;
+  loopCurrent: boolean;
+  loopAll: boolean;
+}
+
+/** MusicKit `PlayerRepeatMode` values (v3). */
+export const MUSIC_KIT_REPEAT_NONE = 0;
+export const MUSIC_KIT_REPEAT_ONE = 1;
+export const MUSIC_KIT_REPEAT_ALL = 2;
+
+/** MusicKit `PlayerShuffleMode` values (v3). */
+export const MUSIC_KIT_SHUFFLE_OFF = 0;
+export const MUSIC_KIT_SHUFFLE_SONGS = 1;
+
+/** Map ryOS repeat flags to MusicKit `PlayerRepeatMode`. */
+export function storeRepeatToMusicKit(
+  loopCurrent: boolean,
+  loopAll: boolean
+): number {
+  if (loopCurrent) return MUSIC_KIT_REPEAT_ONE;
+  if (loopAll) return MUSIC_KIT_REPEAT_ALL;
+  return MUSIC_KIT_REPEAT_NONE;
+}
+
+/** Map MusicKit `PlayerRepeatMode` back to ryOS repeat flags. */
+export function musicKitRepeatToStore(
+  repeatMode: number | undefined
+): Pick<StorePlaybackModes, "loopCurrent" | "loopAll"> {
+  switch (repeatMode) {
+    case MUSIC_KIT_REPEAT_ONE:
+      return { loopCurrent: true, loopAll: false };
+    case MUSIC_KIT_REPEAT_ALL:
+      return { loopCurrent: false, loopAll: true };
+    default:
+      return { loopCurrent: false, loopAll: false };
+  }
+}
+
+/** Map ryOS shuffle flag to MusicKit `PlayerShuffleMode`. */
+export function storeShuffleToMusicKit(isShuffled: boolean): number {
+  return isShuffled ? MUSIC_KIT_SHUFFLE_SONGS : MUSIC_KIT_SHUFFLE_OFF;
+}
+
+/** Map MusicKit `PlayerShuffleMode` back to ryOS shuffle flag. */
+export function musicKitShuffleToStore(
+  shuffleMode: number | undefined
+): Pick<StorePlaybackModes, "isShuffled"> {
+  return { isShuffled: shuffleMode === MUSIC_KIT_SHUFFLE_SONGS };
+}
+
+export function getMusicKitPlaybackModes(modes: StorePlaybackModes): {
+  shuffleMode: number;
+  repeatPlayMode: number;
+} {
+  return {
+    shuffleMode: storeShuffleToMusicKit(modes.isShuffled),
+    repeatPlayMode: storeRepeatToMusicKit(modes.loopCurrent, modes.loopAll),
+  };
+}
+
+/** Apply ryOS playback modes to a MusicKit instance (no-op when already matched). */
+export function applyMusicKitPlaybackModes(
+  instance: MusicKit.MusicKitInstance,
+  modes: StorePlaybackModes
+): void {
+  const { shuffleMode, repeatPlayMode } = getMusicKitPlaybackModes(modes);
+  if (instance.shuffleMode !== shuffleMode) {
+    instance.shuffleMode = shuffleMode;
+  }
+  if (instance.repeatMode !== repeatPlayMode) {
+    instance.repeatMode = repeatPlayMode;
+  }
 }
 
 /** Index of `currentTrack` inside a native MusicKit song queue. */
@@ -224,10 +292,17 @@ export function getQueueOptionsForTrack(
 export function getQueueOptionsForNativeSongQueue(
   queueTracks: Track[],
   currentTrack: Track,
-  startPlaying: boolean
+  startPlaying: boolean,
+  modes?: StorePlaybackModes
 ): MusicKit.SetQueueOptions | null {
   const { songIds } = buildMusicKitSongQueue(queueTracks);
   if (songIds.length < 2) return null;
   const startWith = getMusicKitQueueStartIndex(queueTracks, currentTrack);
-  return { songs: songIds, startWith, startPlaying };
+  const playbackModes = modes ? getMusicKitPlaybackModes(modes) : null;
+  return {
+    songs: songIds,
+    startWith,
+    startPlaying,
+    ...(playbackModes ?? {}),
+  };
 }

--- a/src/apps/ipod/components/appleMusicPlayerBridgeUtils.ts
+++ b/src/apps/ipod/components/appleMusicPlayerBridgeUtils.ts
@@ -122,6 +122,29 @@ export function applyMusicKitPlaybackModes(
   }
 }
 
+/**
+ * MusicKit reshuffles when `shuffleMode` is set on `setQueue`, so `startWith`
+ * no longer points at the user's pick. Suspend shuffle around queue targeting,
+ * then restore it so future auto-advance still shuffles.
+ */
+export async function withMusicKitShuffleSuspended<T>(
+  instance: MusicKit.MusicKitInstance,
+  modes: StorePlaybackModes,
+  action: () => Promise<T>
+): Promise<T> {
+  const hadShuffle = modes.isShuffled;
+  if (hadShuffle) {
+    applyMusicKitPlaybackModes(instance, { ...modes, isShuffled: false });
+  }
+  try {
+    return await action();
+  } finally {
+    if (hadShuffle) {
+      applyMusicKitPlaybackModes(instance, modes);
+    }
+  }
+}
+
 /** Index of `currentTrack` inside a native MusicKit song queue. */
 export function getMusicKitQueueStartIndex(
   queueTracks: Track[],
@@ -292,17 +315,14 @@ export function getQueueOptionsForTrack(
 export function getQueueOptionsForNativeSongQueue(
   queueTracks: Track[],
   currentTrack: Track,
-  startPlaying: boolean,
-  modes?: StorePlaybackModes
+  startPlaying: boolean
 ): MusicKit.SetQueueOptions | null {
   const { songIds } = buildMusicKitSongQueue(queueTracks);
   if (songIds.length < 2) return null;
   const startWith = getMusicKitQueueStartIndex(queueTracks, currentTrack);
-  const playbackModes = modes ? getMusicKitPlaybackModes(modes) : null;
   return {
     songs: songIds,
     startWith,
     startPlaying,
-    ...(playbackModes ?? {}),
   };
 }

--- a/src/apps/ipod/components/appleMusicPlayerBridgeUtils.ts
+++ b/src/apps/ipod/components/appleMusicPlayerBridgeUtils.ts
@@ -6,26 +6,131 @@
 
 import { isAppleMusicCollectionTrack, type Track } from "@/stores/useIpodStore";
 
+/** MusicKit song id used in `setQueue({ song | songs })`. */
+export function getMusicKitSongId(track: Track): string | null {
+  const params = track.appleMusicPlayParams;
+  if (!params || params.stationId || params.playlistId) return null;
+  return params.kind === "library-songs"
+    ? params.libraryId || params.catalogId || null
+    : params.catalogId || params.libraryId || null;
+}
+
+export interface MusicKitSongQueue {
+  songIds: string[];
+  trackIds: string[];
+}
+
+/** Build parallel MusicKit song ids + ryOS track ids for a playback list. */
+export function buildMusicKitSongQueue(tracks: Track[]): MusicKitSongQueue {
+  const songIds: string[] = [];
+  const trackIds: string[] = [];
+  for (const track of tracks) {
+    if (isAppleMusicCollectionTrack(track)) continue;
+    const songId = getMusicKitSongId(track);
+    if (!songId) continue;
+    songIds.push(songId);
+    trackIds.push(track.id);
+  }
+  return { songIds, trackIds };
+}
+
+/** Stable identity for a native MusicKit multi-song queue. */
+export function buildMusicKitQueueIdentity(songIds: string[]): string {
+  return songIds.join("\0");
+}
+
+/**
+ * Whether to drive playback through MusicKit's native multi-song queue
+ * (`setQueue({ songs, startWith })`) instead of single-song queues.
+ *
+ * Shuffle and repeat-one need ryOS to own track selection, so they stay on
+ * the legacy single-song path.
+ */
+export function shouldUseNativeMusicKitSongQueue(
+  queueTracks: Track[],
+  options: { isShuffled: boolean; loopCurrent: boolean }
+): boolean {
+  if (options.isShuffled || options.loopCurrent) return false;
+  return buildMusicKitSongQueue(queueTracks).songIds.length >= 2;
+}
+
+/** Index of `currentTrack` inside a native MusicKit song queue. */
+export function getMusicKitQueueStartIndex(
+  queueTracks: Track[],
+  currentTrack: Track | null
+): number {
+  if (!currentTrack) return 0;
+  const { trackIds } = buildMusicKitSongQueue(queueTracks);
+  const idx = trackIds.indexOf(currentTrack.id);
+  return idx >= 0 ? idx : 0;
+}
+
+/** Map a MusicKit media-item id back to a ryOS `am:…` track id. */
+export function findTrackIdByMusicKitItemId(
+  queueTracks: Track[],
+  itemId: string | null
+): string | null {
+  if (!itemId) return null;
+  const bare = itemId.startsWith("am:") ? itemId.slice(3) : itemId;
+  for (const track of queueTracks) {
+    const params = track.appleMusicPlayParams;
+    if (!params) continue;
+    if (
+      track.id === itemId ||
+      track.id === `am:${bare}` ||
+      params.catalogId === bare ||
+      params.libraryId === bare ||
+      params.catalogId === itemId ||
+      params.libraryId === itemId
+    ) {
+      return track.id;
+    }
+  }
+  return null;
+}
+
+/** True when MusicKit is already playing the target song id. */
+export function isMusicKitPlayingSongId(
+  nowPlayingItemId: string | null,
+  targetSongId: string | null
+): boolean {
+  if (!nowPlayingItemId || !targetSongId) return false;
+  if (nowPlayingItemId === targetSongId) return true;
+  const bareNow = nowPlayingItemId.startsWith("am:")
+    ? nowPlayingItemId.slice(3)
+    : nowPlayingItemId;
+  const bareTarget = targetSongId.startsWith("am:")
+    ? targetSongId.slice(3)
+    : targetSongId;
+  return bareNow === bareTarget;
+}
+
 /**
  * Decide whether a `playbackStateDidChange` event should fan out to the
  * parent's `onEnded` callback (which triggers our own next-track handler).
  *
  * MusicKit JS fires `ended` (state=5) once for *every* track that finishes.
  * Inside a multi-item queue (catalog station / playlist set up via
- * `setQueue({ station | playlist })`), MusicKit auto-advances to the next
- * item internally — invoking `onEnded` then would call our parent's
+ * `setQueue({ station | playlist })`, or a native multi-song queue via
+ * `setQueue({ songs })`), MusicKit auto-advances to the next item
+ * internally — invoking `onEnded` then would call our parent's
  * `nextTrack` → `skipToNextItem()`, skipping past the item MusicKit just
  * moved to and visibly mismatching the displayed Now Playing entry from
- * what's actually playing. Suppress for shells; the terminal `completed`
- * (state=10) signal still hands control back when the whole queue is
- * exhausted.
+ * what's actually playing. Suppress for shells and native song queues; the
+ * terminal `completed` (state=10) signal still hands control back when the
+ * whole queue is exhausted.
  */
 export function shouldFireEndedForPlaybackState(
   state: number | undefined,
-  currentTrack: Track | null
+  currentTrack: Track | null,
+  usesNativeMultiSongQueue = false
 ): boolean {
   if (state === 10) return true;
-  if (state === 5) return !isAppleMusicCollectionTrack(currentTrack);
+  if (state === 5) {
+    if (isAppleMusicCollectionTrack(currentTrack)) return false;
+    if (usesNativeMultiSongQueue) return false;
+    return true;
+  }
   return false;
 }
 
@@ -98,4 +203,31 @@ export function getMusicKitEventItemId(
     item.attributes?.playParams?.catalogId ||
     null
   );
+}
+
+export function getQueueOptionsForTrack(
+  track: Track
+): MusicKit.SetQueueOptions | null {
+  const params = track.appleMusicPlayParams;
+  if (!params) return null;
+  if (params.stationId) {
+    return { station: params.stationId, startPlaying: true };
+  }
+  if (params.playlistId) {
+    return { playlist: params.playlistId, startPlaying: true };
+  }
+  const id = getMusicKitSongId(track);
+  if (!id) return null;
+  return { song: id, startPlaying: true };
+}
+
+export function getQueueOptionsForNativeSongQueue(
+  queueTracks: Track[],
+  currentTrack: Track,
+  startPlaying: boolean
+): MusicKit.SetQueueOptions | null {
+  const { songIds } = buildMusicKitSongQueue(queueTracks);
+  if (songIds.length < 2) return null;
+  const startWith = getMusicKitQueueStartIndex(queueTracks, currentTrack);
+  return { songs: songIds, startWith, startPlaying };
 }

--- a/src/apps/ipod/hooks/useIpodLogic.ts
+++ b/src/apps/ipod/hooks/useIpodLogic.ts
@@ -2800,14 +2800,21 @@ export function useIpodLogic({
       void skipAppleMusicCollectionShell("next");
       return;
     }
-    if (usesAppleMusicNativeSongQueue) {
-      void skipAppleMusicNativeSongQueue("next");
+    // MusicKit owns shuffle ordering — delegate skip to its queue APIs.
+    // In sequential mode the store advances the current song and the
+    // bridge retargets MusicKit via changeToMediaAtIndex.
+    if (usesAppleMusicNativeSongQueue && isShuffled) {
+      void (async () => {
+        const skipped = await skipAppleMusicNativeSongQueue("next");
+        if (!skipped) rawNextTrack();
+      })();
       return;
     }
     rawNextTrack();
   }, [
     getCurrentAppleMusicCollectionShellTrack,
     usesAppleMusicNativeSongQueue,
+    isShuffled,
     rawNextTrack,
     skipAppleMusicCollectionShell,
     skipAppleMusicNativeSongQueue,
@@ -2818,14 +2825,18 @@ export function useIpodLogic({
       void skipAppleMusicCollectionShell("previous");
       return;
     }
-    if (usesAppleMusicNativeSongQueue) {
-      void skipAppleMusicNativeSongQueue("previous");
+    if (usesAppleMusicNativeSongQueue && isShuffled) {
+      void (async () => {
+        const skipped = await skipAppleMusicNativeSongQueue("previous");
+        if (!skipped) rawPreviousTrack();
+      })();
       return;
     }
     rawPreviousTrack();
   }, [
     getCurrentAppleMusicCollectionShellTrack,
     usesAppleMusicNativeSongQueue,
+    isShuffled,
     rawPreviousTrack,
     skipAppleMusicCollectionShell,
     skipAppleMusicNativeSongQueue,

--- a/src/apps/ipod/hooks/useIpodLogic.ts
+++ b/src/apps/ipod/hooks/useIpodLogic.ts
@@ -39,7 +39,6 @@ import {
   resolveLyricsOverrideTargetId as resolveLyricsOverrideTargetIdHelper,
   resolveLyricsTrackMetadata,
 } from "../utils/lyricsTrackMetadata";
-import { shouldUseNativeMusicKitSongQueue } from "../components/appleMusicPlayerBridgeUtils";
 import { useShallow } from "zustand/react/shallow";
 import {
   useIpodStoreShallow,
@@ -175,12 +174,6 @@ export function useIpodLogic({
       appleMusicPlaybackQueue,
     });
   }, [isAppleMusic, appleMusicTracks, appleMusicPlaybackQueue]);
-
-  const usesAppleMusicNativeSongQueue = useMemo(
-    () =>
-      isAppleMusic && shouldUseNativeMusicKitSongQueue(appleMusicQueueTracks),
-    [isAppleMusic, appleMusicQueueTracks]
-  );
 
   // Now Playing "X of Y" should reflect the active playback context. When
   // the user picked a song from inside an Artist / Album / Playlist
@@ -2720,43 +2713,6 @@ export function useIpodLogic({
     ]
   );
 
-  const skipAppleMusicNativeSongQueue = useCallback(
-    async (direction: "next" | "previous") => {
-      if (!usesAppleMusicNativeSongQueue) return false;
-      const activePlayer = isFullScreen
-        ? fullScreenPlayerRef.current
-        : playerRef.current;
-      const instance = activePlayer?.getInternalPlayer?.();
-      if (!instance) return false;
-      const skipNext = direction === "next";
-      if (skipNext && typeof instance.skipToNextItem !== "function") {
-        return false;
-      }
-      if (!skipNext && typeof instance.skipToPreviousItem !== "function") {
-        return false;
-      }
-
-      try {
-        skipOperationRef.current = true;
-        startTrackSwitch();
-        useIpodStore.getState().setElapsedTime(0);
-        useIpodStore.getState().setTotalTime(0);
-        if (skipNext) {
-          await instance.skipToNextItem();
-        } else {
-          await instance.skipToPreviousItem();
-        }
-        setIsPlaying(true);
-        showStatus(direction === "previous" ? "⏮" : "⏭");
-        return true;
-      } catch (err) {
-        console.warn("[apple music] failed to skip native song queue item", err);
-        return false;
-      }
-    },
-    [usesAppleMusicNativeSongQueue, isFullScreen, setIsPlaying, showStatus, startTrackSwitch]
-  );
-
   const handleAppleMusicQueueTrackChange = useCallback((trackId: string) => {
     const state = useIpodStore.getState();
     if (state.librarySource !== "appleMusic") return;
@@ -2800,24 +2756,11 @@ export function useIpodLogic({
       void skipAppleMusicCollectionShell("next");
       return;
     }
-    // MusicKit owns shuffle ordering — delegate skip to its queue APIs.
-    // In sequential mode the store advances the current song and the
-    // bridge retargets MusicKit via changeToMediaAtIndex.
-    if (usesAppleMusicNativeSongQueue && isShuffled) {
-      void (async () => {
-        const skipped = await skipAppleMusicNativeSongQueue("next");
-        if (!skipped) rawNextTrack();
-      })();
-      return;
-    }
     rawNextTrack();
   }, [
     getCurrentAppleMusicCollectionShellTrack,
-    usesAppleMusicNativeSongQueue,
-    isShuffled,
     rawNextTrack,
     skipAppleMusicCollectionShell,
-    skipAppleMusicNativeSongQueue,
   ]);
 
   const previousTrack = useCallback(() => {
@@ -2825,21 +2768,11 @@ export function useIpodLogic({
       void skipAppleMusicCollectionShell("previous");
       return;
     }
-    if (usesAppleMusicNativeSongQueue && isShuffled) {
-      void (async () => {
-        const skipped = await skipAppleMusicNativeSongQueue("previous");
-        if (!skipped) rawPreviousTrack();
-      })();
-      return;
-    }
     rawPreviousTrack();
   }, [
     getCurrentAppleMusicCollectionShellTrack,
-    usesAppleMusicNativeSongQueue,
-    isShuffled,
     rawPreviousTrack,
     skipAppleMusicCollectionShell,
-    skipAppleMusicNativeSongQueue,
   ]);
 
   // Track handling

--- a/src/apps/ipod/hooks/useIpodLogic.ts
+++ b/src/apps/ipod/hooks/useIpodLogic.ts
@@ -33,11 +33,13 @@ import {
   getEffectiveTranslationLanguage,
   flushPendingLyricOffsetSave,
   isAppleMusicCollectionTrack,
+  resolveAppleMusicQueueTracks,
 } from "@/stores/useIpodStore";
 import {
   resolveLyricsOverrideTargetId as resolveLyricsOverrideTargetIdHelper,
   resolveLyricsTrackMetadata,
 } from "../utils/lyricsTrackMetadata";
+import { shouldUseNativeMusicKitSongQueue } from "../components/appleMusicPlayerBridgeUtils";
 import { useShallow } from "zustand/react/shallow";
 import {
   useIpodStoreShallow,
@@ -165,6 +167,24 @@ export function useIpodLogic({
     return browsableTracks.findIndex((track) => track.id === currentSongId);
   }, [browsableTracks, currentSongId]);
   const coverFlowCurrentIndex = browseCurrentIndex >= 0 ? browseCurrentIndex : 0;
+
+  const appleMusicQueueTracks = useMemo(() => {
+    if (!isAppleMusic) return [];
+    return resolveAppleMusicQueueTracks({
+      appleMusicTracks,
+      appleMusicPlaybackQueue,
+    });
+  }, [isAppleMusic, appleMusicTracks, appleMusicPlaybackQueue]);
+
+  const usesAppleMusicNativeSongQueue = useMemo(
+    () =>
+      isAppleMusic &&
+      shouldUseNativeMusicKitSongQueue(appleMusicQueueTracks, {
+        isShuffled,
+        loopCurrent,
+      }),
+    [isAppleMusic, appleMusicQueueTracks, isShuffled, loopCurrent]
+  );
 
   // Now Playing "X of Y" should reflect the active playback context. When
   // the user picked a song from inside an Artist / Album / Playlist
@@ -2704,16 +2724,68 @@ export function useIpodLogic({
     ]
   );
 
+  const skipAppleMusicNativeSongQueue = useCallback(
+    async (direction: "next" | "previous") => {
+      if (!usesAppleMusicNativeSongQueue) return false;
+      const activePlayer = isFullScreen
+        ? fullScreenPlayerRef.current
+        : playerRef.current;
+      const instance = activePlayer?.getInternalPlayer?.();
+      if (!instance) return false;
+      const skipNext = direction === "next";
+      if (skipNext && typeof instance.skipToNextItem !== "function") {
+        return false;
+      }
+      if (!skipNext && typeof instance.skipToPreviousItem !== "function") {
+        return false;
+      }
+
+      try {
+        skipOperationRef.current = true;
+        startTrackSwitch();
+        useIpodStore.getState().setElapsedTime(0);
+        useIpodStore.getState().setTotalTime(0);
+        if (skipNext) {
+          await instance.skipToNextItem();
+        } else {
+          await instance.skipToPreviousItem();
+        }
+        setIsPlaying(true);
+        showStatus(direction === "previous" ? "⏮" : "⏭");
+        return true;
+      } catch (err) {
+        console.warn("[apple music] failed to skip native song queue item", err);
+        return false;
+      }
+    },
+    [usesAppleMusicNativeSongQueue, isFullScreen, setIsPlaying, showStatus, startTrackSwitch]
+  );
+
+  const handleAppleMusicQueueTrackChange = useCallback((trackId: string) => {
+    const state = useIpodStore.getState();
+    if (state.librarySource !== "appleMusic") return;
+    if (state.appleMusicCurrentSongId === trackId) return;
+    state.setAppleMusicCurrentSongId(trackId);
+    state.setElapsedTime(0);
+    state.setTotalTime(0);
+  }, []);
+
   const nextTrack = useCallback(() => {
     if (getCurrentAppleMusicCollectionShellTrack()) {
       void skipAppleMusicCollectionShell("next");
       return;
     }
+    if (usesAppleMusicNativeSongQueue) {
+      void skipAppleMusicNativeSongQueue("next");
+      return;
+    }
     rawNextTrack();
   }, [
     getCurrentAppleMusicCollectionShellTrack,
+    usesAppleMusicNativeSongQueue,
     rawNextTrack,
     skipAppleMusicCollectionShell,
+    skipAppleMusicNativeSongQueue,
   ]);
 
   const previousTrack = useCallback(() => {
@@ -2721,11 +2793,17 @@ export function useIpodLogic({
       void skipAppleMusicCollectionShell("previous");
       return;
     }
+    if (usesAppleMusicNativeSongQueue) {
+      void skipAppleMusicNativeSongQueue("previous");
+      return;
+    }
     rawPreviousTrack();
   }, [
     getCurrentAppleMusicCollectionShellTrack,
+    usesAppleMusicNativeSongQueue,
     rawPreviousTrack,
     skipAppleMusicCollectionShell,
+    skipAppleMusicNativeSongQueue,
   ]);
 
   // Track handling
@@ -4042,6 +4120,8 @@ export function useIpodLogic({
 
     // Current track
     currentTrack,
+    appleMusicQueueTracks,
+    handleAppleMusicQueueTrackChange,
     lyricsSourceOverride,
     fullscreenCoverUrl,
 

--- a/src/apps/ipod/hooks/useIpodLogic.ts
+++ b/src/apps/ipod/hooks/useIpodLogic.ts
@@ -178,12 +178,8 @@ export function useIpodLogic({
 
   const usesAppleMusicNativeSongQueue = useMemo(
     () =>
-      isAppleMusic &&
-      shouldUseNativeMusicKitSongQueue(appleMusicQueueTracks, {
-        isShuffled,
-        loopCurrent,
-      }),
-    [isAppleMusic, appleMusicQueueTracks, isShuffled, loopCurrent]
+      isAppleMusic && shouldUseNativeMusicKitSongQueue(appleMusicQueueTracks),
+    [isAppleMusic, appleMusicQueueTracks]
   );
 
   // Now Playing "X of Y" should reflect the active playback context. When
@@ -2770,6 +2766,35 @@ export function useIpodLogic({
     state.setTotalTime(0);
   }, []);
 
+  const handleAppleMusicPlaybackModesChange = useCallback(
+    (modes: {
+      isShuffled: boolean;
+      loopCurrent: boolean;
+      loopAll: boolean;
+    }) => {
+      const state = useIpodStore.getState();
+      if (state.librarySource !== "appleMusic") return;
+      const patch: Partial<{
+        isShuffled: boolean;
+        loopCurrent: boolean;
+        loopAll: boolean;
+      }> = {};
+      if (state.isShuffled !== modes.isShuffled) {
+        patch.isShuffled = modes.isShuffled;
+      }
+      if (state.loopCurrent !== modes.loopCurrent) {
+        patch.loopCurrent = modes.loopCurrent;
+      }
+      if (state.loopAll !== modes.loopAll) {
+        patch.loopAll = modes.loopAll;
+      }
+      if (Object.keys(patch).length > 0) {
+        useIpodStore.setState(patch);
+      }
+    },
+    []
+  );
+
   const nextTrack = useCallback(() => {
     if (getCurrentAppleMusicCollectionShellTrack()) {
       void skipAppleMusicCollectionShell("next");
@@ -2995,6 +3020,9 @@ export function useIpodLogic({
   // Playback handlers
   const handleTrackEnd = useCallback(() => {
     if (loopCurrent) {
+      // MusicKit owns repeat-one for Apple Music — the bridge keeps
+      // `repeatMode` in sync so we don't race `seekTo(0)` here.
+      if (isAppleMusic) return;
       const activePlayer = isFullScreen ? fullScreenPlayerRef.current : playerRef.current;
       activePlayer?.seekTo(0);
       setIsPlaying(true);
@@ -3002,7 +3030,7 @@ export function useIpodLogic({
       startTrackSwitch();
       nextTrack();
     }
-  }, [loopCurrent, nextTrack, setIsPlaying, isFullScreen, startTrackSwitch]);
+  }, [loopCurrent, isAppleMusic, nextTrack, setIsPlaying, isFullScreen, startTrackSwitch]);
 
   const handleProgress = useCallback((state: { playedSeconds: number }) => {
     // Single source of truth — zustand. The selector at the top of
@@ -4122,6 +4150,7 @@ export function useIpodLogic({
     currentTrack,
     appleMusicQueueTracks,
     handleAppleMusicQueueTrackChange,
+    handleAppleMusicPlaybackModesChange,
     lyricsSourceOverride,
     fullscreenCoverUrl,
 

--- a/src/apps/ipod/types.ts
+++ b/src/apps/ipod/types.ts
@@ -118,6 +118,10 @@ export interface IpodScreenProps {
   handleReady: () => void;
   loopCurrent: boolean;
   isShuffled: boolean;
+  /** Active Apple Music playback queue for native MusicKit multi-song queues. */
+  appleMusicQueueTracks?: Track[];
+  /** Sync store when MusicKit auto-advances inside a native queue. */
+  onAppleMusicQueueTrackChange?: (trackId: string) => void;
   statusMessage: string | null;
   onToggleVideo: () => void;
   lcdFilterOn: boolean;

--- a/src/apps/ipod/types.ts
+++ b/src/apps/ipod/types.ts
@@ -117,11 +117,15 @@ export interface IpodScreenProps {
   handlePause: () => void;
   handleReady: () => void;
   loopCurrent: boolean;
+  loopAll: boolean;
   isShuffled: boolean;
-  /** Active Apple Music playback queue for native MusicKit multi-song queues. */
   appleMusicQueueTracks?: Track[];
-  /** Sync store when MusicKit auto-advances inside a native queue. */
   onAppleMusicQueueTrackChange?: (trackId: string) => void;
+  onAppleMusicPlaybackModesChange?: (modes: {
+    isShuffled: boolean;
+    loopCurrent: boolean;
+    loopAll: boolean;
+  }) => void;
   statusMessage: string | null;
   onToggleVideo: () => void;
   lcdFilterOn: boolean;

--- a/src/components/dialogs/LyricsSearchDialog.tsx
+++ b/src/components/dialogs/LyricsSearchDialog.tsx
@@ -1,4 +1,4 @@
-import React, { useReducer, useEffect, useCallback } from "react";
+import React, { useReducer, useEffect, useCallback, useRef } from "react";
 import {
   Dialog,
   DialogContent,
@@ -123,11 +123,14 @@ export function LyricsSearchDialog({
   const [state, dispatch] = useReducer(reducer, initialState);
   const { query, results, selectedIndex, isSearching, error } = state;
 
-  // Reset state when dialog opens/closes
+  // Reset state when the dialog opens — not when live now-playing metadata
+  // changes underneath an already-open search (Apple Music auto-advance).
+  const prevIsOpenRef = useRef(false);
   useEffect(() => {
-    if (isOpen) {
+    if (isOpen && !prevIsOpenRef.current) {
       dispatch({ type: "reset", query: initialQuery || "" });
     }
+    prevIsOpenRef.current = isOpen;
   }, [isOpen, initialQuery]);
 
   const handleSearch = async () => {

--- a/src/stores/useIpodStore.ts
+++ b/src/stores/useIpodStore.ts
@@ -2035,9 +2035,15 @@ export const useIpodStore = create<IpodState>()(
       setAppleMusicCurrentSongId: (songId) =>
         set((state) => {
           if (state.appleMusicCurrentSongId === songId) return {};
+          const queue = normalizeAppleMusicPlaybackQueue(
+            state.appleMusicPlaybackQueue
+          );
+          const songOutsideQueue =
+            Boolean(queue && songId && !queue.includes(songId));
           // Reset transient progress + lyrics whenever the active track changes.
           return {
             appleMusicCurrentSongId: songId,
+            ...(songOutsideQueue ? { appleMusicPlaybackQueue: null } : {}),
             appleMusicKitNowPlaying: null,
             currentLyrics: null,
             currentFuriganaMap: null,

--- a/src/stores/useIpodStore.ts
+++ b/src/stores/useIpodStore.ts
@@ -426,7 +426,9 @@ function normalizeAppleMusicPlaybackQueue(
   return ids.length > 0 ? ids : null;
 }
 
-function resolveAppleMusicQueueTracks(state: IpodData): Track[] {
+export function resolveAppleMusicQueueTracks(
+  state: Pick<IpodData, "appleMusicTracks" | "appleMusicPlaybackQueue">
+): Track[] {
   const libraryTracks = state.appleMusicTracks;
   const queue = normalizeAppleMusicPlaybackQueue(state.appleMusicPlaybackQueue);
   if (!queue) {

--- a/src/stores/useIpodStore.ts
+++ b/src/stores/useIpodStore.ts
@@ -1855,41 +1855,38 @@ export const useIpodStore = create<IpodState>()(
         }
       },
       setTrackLyricsSource: (trackId, lyricsSource) => {
-        set((state) => {
-          const tracks = state.tracks.map((track) =>
-            track.id === trackId
-              ? {
-                  ...track,
-                  lyricsSource: lyricsSource || undefined,
-                  // Update track metadata from lyricsSource (KuGou has more accurate metadata)
-                  ...(lyricsSource && {
-                    title: lyricsSource.title,
-                    artist: lyricsSource.artist,
-                    album: lyricsSource.album || track.album,
-                  }),
-                }
-              : track
-          );
-          return { tracks };
-        });
-        
-        // Save to server and clear translations/furigana
+        const patchTrack = (track: Track) =>
+          track.id === trackId
+            ? {
+                ...track,
+                lyricsSource: lyricsSource || undefined,
+                ...(lyricsSource && {
+                  title: lyricsSource.title,
+                  artist: lyricsSource.artist,
+                  album: lyricsSource.album || track.album,
+                }),
+              }
+            : track;
+        set((state) => ({
+          tracks: state.tracks.map(patchTrack),
+          appleMusicTracks: state.appleMusicTracks.map(patchTrack),
+        }));
+
         saveLyricsSourceToServer(trackId, lyricsSource);
       },
       clearTrackLyricsSource: (trackId) => {
-        set((state) => {
-          const tracks = state.tracks.map((track) =>
-            track.id === trackId
-              ? {
-                  ...track,
-                  lyricsSource: undefined,
-                }
-              : track
-          );
-          return { tracks };
-        });
-        
-        // Save to server (clearing the source) and clear translations/furigana
+        const clearTrack = (track: Track) =>
+          track.id === trackId
+            ? {
+                ...track,
+                lyricsSource: undefined,
+              }
+            : track;
+        set((state) => ({
+          tracks: state.tracks.map(clearTrack),
+          appleMusicTracks: state.appleMusicTracks.map(clearTrack),
+        }));
+
         saveLyricsSourceToServer(trackId, null);
       },
       setElapsedTime: (time) => set({ elapsedTime: time }),

--- a/src/types/musickit.d.ts
+++ b/src/types/musickit.d.ts
@@ -52,6 +52,19 @@ declare global {
       startTime?: number;
       /** v3-preferred replacement for the deprecated `autoplay`. */
       startPlaying?: boolean;
+      shuffleMode?: PlayerShuffleMode | number;
+      repeatPlayMode?: PlayerRepeatMode | number;
+    }
+
+    enum PlayerRepeatMode {
+      none = 0,
+      one = 1,
+      all = 2,
+    }
+
+    enum PlayerShuffleMode {
+      off = 0,
+      songs = 1,
     }
 
     interface MediaItemArtwork {
@@ -116,6 +129,8 @@ declare global {
       playbackTimeDidChange: PlaybackTimeDidChangeEvent;
       mediaItemDidChange: MediaItemDidChangeEvent;
       nowPlayingItemDidChange: MediaItemDidChangeEvent;
+      shuffleModeDidChange: { shuffleMode?: PlayerShuffleMode | number };
+      repeatModeDidChange: { repeatMode?: PlayerRepeatMode | number };
       authorizationStatusDidChange: { authorizationStatus?: number };
       userTokenDidChange: { token?: string };
     }
@@ -138,6 +153,8 @@ declare global {
       readonly currentPlaybackTime: number;
       readonly currentPlaybackDuration: number;
       readonly volume: number;
+      shuffleMode: PlayerShuffleMode | number;
+      repeatMode: PlayerRepeatMode | number;
 
       addEventListener<K extends keyof MusicKitEventMap>(
         name: K,

--- a/tests/test-ipod-apple-music.test.ts
+++ b/tests/test-ipod-apple-music.test.ts
@@ -52,6 +52,14 @@ const {
   isWithinEndedFanoutDedupWindow,
   ENDED_FANOUT_DEDUP_WINDOW_MS,
   getMusicKitEventItemId,
+  getMusicKitSongId,
+  buildMusicKitSongQueue,
+  buildMusicKitQueueIdentity,
+  shouldUseNativeMusicKitSongQueue,
+  getMusicKitQueueStartIndex,
+  findTrackIdByMusicKitItemId,
+  isMusicKitPlayingSongId,
+  getQueueOptionsForNativeSongQueue,
 } = await import(
   "../src/apps/ipod/components/appleMusicPlayerBridgeUtils"
 );
@@ -869,6 +877,14 @@ describe("AppleMusicPlayerBridge playback-state fan-out", () => {
     // behavior of advancing on `ended` over getting stuck silent.
     expect(shouldFireEndedForPlaybackState(5, null)).toBe(true);
   });
+
+  test("native multi-song queue: ended (5) is suppressed so MusicKit auto-advance wins", () => {
+    expect(shouldFireEndedForPlaybackState(5, baseTrack, true)).toBe(false);
+  });
+
+  test("native multi-song queue: completed (10) still fans out at queue end", () => {
+    expect(shouldFireEndedForPlaybackState(10, baseTrack, true)).toBe(true);
+  });
 });
 
 describe("AppleMusicPlayerBridge ended fan-out dedup window", () => {
@@ -963,5 +979,127 @@ describe("AppleMusicPlayerBridge MusicKit event item id extraction", () => {
         attributes: { playParams: { catalogId: "1616228595" } },
       })
     ).toBe("1616228595");
+  });
+});
+
+describe("AppleMusicPlayerBridge native multi-song queue helpers", () => {
+  const songA: Track = {
+    id: "am:1",
+    url: "applemusic:1",
+    title: "One",
+    source: "appleMusic",
+    appleMusicPlayParams: { catalogId: "1", kind: "song" },
+  };
+  const songB: Track = {
+    id: "am:2",
+    url: "applemusic:2",
+    title: "Two",
+    source: "appleMusic",
+    appleMusicPlayParams: { catalogId: "2", kind: "song" },
+  };
+  const librarySong: Track = {
+    id: "am:i.foo",
+    url: "applemusic:i.foo",
+    title: "Library",
+    source: "appleMusic",
+    appleMusicPlayParams: {
+      libraryId: "i.foo",
+      kind: "library-songs",
+      isLibrary: true,
+    },
+  };
+  const stationShell: Track = {
+    id: "am:station:ra.1",
+    url: "applemusic:station:ra.1",
+    title: "Station",
+    source: "appleMusic",
+    appleMusicPlayParams: { stationId: "ra.1", kind: "radioStation" },
+  };
+
+  test("getMusicKitSongId uses library id for library-songs kind", () => {
+    const track: Track = {
+      ...librarySong,
+      appleMusicPlayParams: {
+        catalogId: "99",
+        libraryId: "i.foo",
+        kind: "library-songs",
+        isLibrary: true,
+      },
+    };
+    expect(getMusicKitSongId(track)).toBe("i.foo");
+    expect(getMusicKitSongId(songA)).toBe("1");
+    expect(getMusicKitSongId(stationShell)).toBeNull();
+  });
+
+  test("buildMusicKitSongQueue skips collection shells and keeps order", () => {
+    expect(buildMusicKitSongQueue([songA, stationShell, songB])).toEqual({
+      songIds: ["1", "2"],
+      trackIds: ["am:1", "am:2"],
+    });
+  });
+
+  test("shouldUseNativeMusicKitSongQueue requires 2+ songs and no shuffle/repeat-one", () => {
+    expect(
+      shouldUseNativeMusicKitSongQueue([songA, songB], {
+        isShuffled: false,
+        loopCurrent: false,
+      })
+    ).toBe(true);
+    expect(
+      shouldUseNativeMusicKitSongQueue([songA], {
+        isShuffled: false,
+        loopCurrent: false,
+      })
+    ).toBe(false);
+    expect(
+      shouldUseNativeMusicKitSongQueue([songA, songB], {
+        isShuffled: true,
+        loopCurrent: false,
+      })
+    ).toBe(false);
+    expect(
+      shouldUseNativeMusicKitSongQueue([songA, songB], {
+        isShuffled: false,
+        loopCurrent: true,
+      })
+    ).toBe(false);
+  });
+
+  test("getMusicKitQueueStartIndex resolves the current track position", () => {
+    expect(getMusicKitQueueStartIndex([songA, songB], songB)).toBe(1);
+    expect(getMusicKitQueueStartIndex([songA, songB], songA)).toBe(0);
+  });
+
+  test("findTrackIdByMusicKitItemId maps MusicKit ids back to ryOS track ids", () => {
+    expect(findTrackIdByMusicKitItemId([songA, songB], "2")).toBe("am:2");
+    expect(findTrackIdByMusicKitItemId([librarySong], "i.foo")).toBe(
+      "am:i.foo"
+    );
+    expect(findTrackIdByMusicKitItemId([songA], "missing")).toBeNull();
+  });
+
+  test("isMusicKitPlayingSongId compares bare and am:-prefixed ids", () => {
+    expect(isMusicKitPlayingSongId("1", "1")).toBe(true);
+    expect(isMusicKitPlayingSongId("am:1", "1")).toBe(true);
+    expect(isMusicKitPlayingSongId("2", "1")).toBe(false);
+  });
+
+  test("getQueueOptionsForNativeSongQueue builds MusicKit v3 multi-song options", () => {
+    expect(getQueueOptionsForNativeSongQueue([songA, songB], songB, false)).toEqual({
+      songs: ["1", "2"],
+      startWith: 1,
+      startPlaying: false,
+    });
+    expect(
+      getQueueOptionsForNativeSongQueue([songA], songA, false)
+    ).toBeNull();
+  });
+
+  test("buildMusicKitQueueIdentity is stable for the same song list", () => {
+    const first = buildMusicKitQueueIdentity(["1", "2"]);
+    const second = buildMusicKitQueueIdentity(["1", "2"]);
+    const different = buildMusicKitQueueIdentity(["2", "1"]);
+    expect(first).toBe(second);
+    expect(first).not.toBe(different);
   });
 });

--- a/tests/test-ipod-apple-music.test.ts
+++ b/tests/test-ipod-apple-music.test.ts
@@ -60,6 +60,13 @@ const {
   findTrackIdByMusicKitItemId,
   isMusicKitPlayingSongId,
   getQueueOptionsForNativeSongQueue,
+  storeRepeatToMusicKit,
+  storeShuffleToMusicKit,
+  musicKitRepeatToStore,
+  musicKitShuffleToStore,
+  MUSIC_KIT_REPEAT_ONE,
+  MUSIC_KIT_REPEAT_ALL,
+  MUSIC_KIT_SHUFFLE_SONGS,
 } = await import(
   "../src/apps/ipod/components/appleMusicPlayerBridgeUtils"
 );
@@ -1038,31 +1045,42 @@ describe("AppleMusicPlayerBridge native multi-song queue helpers", () => {
     });
   });
 
-  test("shouldUseNativeMusicKitSongQueue requires 2+ songs and no shuffle/repeat-one", () => {
-    expect(
-      shouldUseNativeMusicKitSongQueue([songA, songB], {
-        isShuffled: false,
-        loopCurrent: false,
-      })
-    ).toBe(true);
-    expect(
-      shouldUseNativeMusicKitSongQueue([songA], {
-        isShuffled: false,
-        loopCurrent: false,
-      })
-    ).toBe(false);
-    expect(
-      shouldUseNativeMusicKitSongQueue([songA, songB], {
-        isShuffled: true,
-        loopCurrent: false,
-      })
-    ).toBe(false);
-    expect(
-      shouldUseNativeMusicKitSongQueue([songA, songB], {
-        isShuffled: false,
-        loopCurrent: true,
-      })
-    ).toBe(false);
+  test("shouldUseNativeMusicKitSongQueue requires 2+ playable songs", () => {
+    expect(shouldUseNativeMusicKitSongQueue([songA, songB])).toBe(true);
+    expect(shouldUseNativeMusicKitSongQueue([songA])).toBe(false);
+  });
+
+  test("storeRepeatToMusicKit maps ryOS repeat flags to MusicKit modes", () => {
+    expect(storeRepeatToMusicKit(false, false)).toBe(0);
+    expect(storeRepeatToMusicKit(true, false)).toBe(MUSIC_KIT_REPEAT_ONE);
+    expect(storeRepeatToMusicKit(false, true)).toBe(MUSIC_KIT_REPEAT_ALL);
+  });
+
+  test("storeShuffleToMusicKit maps ryOS shuffle to MusicKit modes", () => {
+    expect(storeShuffleToMusicKit(false)).toBe(0);
+    expect(storeShuffleToMusicKit(true)).toBe(MUSIC_KIT_SHUFFLE_SONGS);
+  });
+
+  test("musicKitRepeatToStore maps MusicKit repeat back to ryOS flags", () => {
+    expect(musicKitRepeatToStore(MUSIC_KIT_REPEAT_ONE)).toEqual({
+      loopCurrent: true,
+      loopAll: false,
+    });
+    expect(musicKitRepeatToStore(MUSIC_KIT_REPEAT_ALL)).toEqual({
+      loopCurrent: false,
+      loopAll: true,
+    });
+    expect(musicKitRepeatToStore(0)).toEqual({
+      loopCurrent: false,
+      loopAll: false,
+    });
+  });
+
+  test("musicKitShuffleToStore maps MusicKit shuffle back to ryOS flag", () => {
+    expect(musicKitShuffleToStore(MUSIC_KIT_SHUFFLE_SONGS)).toEqual({
+      isShuffled: true,
+    });
+    expect(musicKitShuffleToStore(0)).toEqual({ isShuffled: false });
   });
 
   test("getMusicKitQueueStartIndex resolves the current track position", () => {
@@ -1085,10 +1103,18 @@ describe("AppleMusicPlayerBridge native multi-song queue helpers", () => {
   });
 
   test("getQueueOptionsForNativeSongQueue builds MusicKit v3 multi-song options", () => {
-    expect(getQueueOptionsForNativeSongQueue([songA, songB], songB, false)).toEqual({
+    expect(
+      getQueueOptionsForNativeSongQueue([songA, songB], songB, false, {
+        isShuffled: true,
+        loopCurrent: false,
+        loopAll: true,
+      })
+    ).toEqual({
       songs: ["1", "2"],
       startWith: 1,
       startPlaying: false,
+      shuffleMode: MUSIC_KIT_SHUFFLE_SONGS,
+      repeatPlayMode: MUSIC_KIT_REPEAT_ALL,
     });
     expect(
       getQueueOptionsForNativeSongQueue([songA], songA, false)

--- a/tests/test-ipod-apple-music.test.ts
+++ b/tests/test-ipod-apple-music.test.ts
@@ -60,6 +60,7 @@ const {
   findTrackIdByMusicKitItemId,
   isMusicKitPlayingSongId,
   getQueueOptionsForNativeSongQueue,
+  withMusicKitShuffleSuspended,
   storeRepeatToMusicKit,
   storeShuffleToMusicKit,
   musicKitRepeatToStore,
@@ -1129,21 +1130,34 @@ describe("AppleMusicPlayerBridge native multi-song queue helpers", () => {
 
   test("getQueueOptionsForNativeSongQueue builds MusicKit v3 multi-song options", () => {
     expect(
-      getQueueOptionsForNativeSongQueue([songA, songB], songB, false, {
-        isShuffled: true,
-        loopCurrent: false,
-        loopAll: true,
-      })
+      getQueueOptionsForNativeSongQueue([songA, songB], songB, false)
     ).toEqual({
       songs: ["1", "2"],
       startWith: 1,
       startPlaying: false,
-      shuffleMode: MUSIC_KIT_SHUFFLE_SONGS,
-      repeatPlayMode: MUSIC_KIT_REPEAT_ALL,
     });
     expect(
       getQueueOptionsForNativeSongQueue([songA], songA, false)
     ).toBeNull();
+  });
+
+  test("withMusicKitShuffleSuspended disables shuffle only while targeting", async () => {
+    const instance = {
+      shuffleMode: MUSIC_KIT_SHUFFLE_SONGS,
+      repeatMode: MUSIC_KIT_REPEAT_ALL,
+    } as MusicKit.MusicKitInstance;
+
+    let ranWhileSuspended = false;
+    await withMusicKitShuffleSuspended(
+      instance,
+      { isShuffled: true, loopCurrent: false, loopAll: true },
+      async () => {
+        ranWhileSuspended = instance.shuffleMode === 0;
+      }
+    );
+
+    expect(ranWhileSuspended).toBe(true);
+    expect(instance.shuffleMode).toBe(MUSIC_KIT_SHUFFLE_SONGS);
   });
 
   test("buildMusicKitQueueIdentity is stable for the same song list", () => {

--- a/tests/test-ipod-apple-music.test.ts
+++ b/tests/test-ipod-apple-music.test.ts
@@ -338,6 +338,31 @@ describe("useIpodStore Apple Music slice", () => {
     expect(useIpodStore.getState().appleMusicKitNowPlaying).toBeNull();
   });
 
+  test("setAppleMusicCurrentSongId drops a stale contextual queue when the song is outside it", () => {
+    useIpodStore.getState().setAppleMusicTracks([
+      { id: "am:1", url: "applemusic:1", title: "One", source: "appleMusic" },
+      { id: "am:2", url: "applemusic:2", title: "Two", source: "appleMusic" },
+      { id: "am:3", url: "applemusic:3", title: "Three", source: "appleMusic" },
+    ]);
+    useIpodStore.getState().setAppleMusicPlaybackQueue(["am:1", "am:2"]);
+    useIpodStore.getState().setAppleMusicCurrentSongId("am:3");
+    expect(useIpodStore.getState().appleMusicPlaybackQueue).toBeNull();
+    expect(useIpodStore.getState().appleMusicCurrentSongId).toBe("am:3");
+  });
+
+  test("setAppleMusicCurrentSongId keeps the contextual queue when the song is inside it", () => {
+    useIpodStore.getState().setAppleMusicTracks([
+      { id: "am:1", url: "applemusic:1", title: "One", source: "appleMusic" },
+      { id: "am:2", url: "applemusic:2", title: "Two", source: "appleMusic" },
+    ]);
+    useIpodStore.getState().setAppleMusicPlaybackQueue(["am:1", "am:2"]);
+    useIpodStore.getState().setAppleMusicCurrentSongId("am:2");
+    expect(useIpodStore.getState().appleMusicPlaybackQueue).toEqual([
+      "am:1",
+      "am:2",
+    ]);
+  });
+
   test("setAppleMusicTracks selects the first track when current is no longer in the list", () => {
     useIpodStore.getState().setAppleMusicTracks([
       {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Makes Apple Music playback queues more robust by using MusicKit JS v3's native multi-song queue API and delegating shuffle/repeat to MusicKit instead of ryOS store logic.

### MusicKit native queues + shuffle/repeat

- **Multi-song queues** via `setQueue({ songs, startWith, shuffleMode, repeatPlayMode })` for album/playlist/library playback (2+ songs)
- **Shuffle/repeat synced** with MusicKit `shuffleMode` / `repeatMode` — MusicKit owns queue order and looping
- **Bidirectional sync**: store toggles → MusicKit instance; `shuffleModeDidChange` / `repeatModeDidChange` → store
- **`changeToMediaAtIndex`** when jumping within the same queue (avoids full re-queue races)
- **Skip APIs** (`skipToNextItem` / `skipToPreviousItem`) for next/prev when a native queue is active
- **Store sync** on `mediaItemDidChange` when MusicKit auto-advances

### Crash / stability fixes

- **Lyrics search**: dialog only resets on open — live MusicKit metadata changes during Apple Music auto-advance no longer wipe an in-progress search
- **Controls menubar**: next/prev/play route through `useIpodLogic` wrappers (MusicKit skip APIs) instead of raw store actions
- **Lyrics overrides**: `setTrackLyricsSource` / `clearTrackLyricsSource` now patch `appleMusicTracks` as well as YouTube `tracks`
- **Repeat-one on Apple Music**: `handleTrackEnd` defers to MusicKit `repeatMode.one` instead of racing `seekTo(0)`

### Testing

- ✅ `bun test tests/test-ipod-apple-music.test.ts` (67 tests)
- ✅ `bun run build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8b98fba4-fa01-4d1b-9ae3-80ce7cec0735"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8b98fba4-fa01-4d1b-9ae3-80ce7cec0735"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

