### PR TITLE
fix(ipod): restore Apple Music playback after setQueue pause race

### DIFF
--- a/src/apps/ipod/components/AppleMusicPlayerBridge.tsx
+++ b/src/apps/ipod/components/AppleMusicPlayerBridge.tsx
@@ -1,11 +1,12 @@
 import { useEffect, useImperativeHandle, useMemo, useRef, useState } from "react";
 import type { Track } from "@/stores/useIpodStore";
-import { onMusicKitReady } from "@/hooks/useMusicKit";
+import { getMusicKitInstance, onMusicKitReady } from "@/hooks/useMusicKit";
 import { PLAYER_PROGRESS_INTERVAL_MS } from "../constants";
 import {
   getMusicKitEventItemId,
   isWithinEndedFanoutDedupWindow,
   shouldFireEndedForPlaybackState,
+  shouldSuppressPlaybackStateFanoutWhileQueueLoading,
 } from "./appleMusicPlayerBridgeUtils";
 
 /**
@@ -130,8 +131,12 @@ export const AppleMusicPlayerBridge = function AppleMusicPlayerBridge(
     ref?: React.Ref<AppleMusicPlayerBridgeHandle>;
   }
 ) {
-  const instanceRef = useRef<MusicKit.MusicKitInstance | null>(null);
-  const [instanceReadyTick, setInstanceReadyTick] = useState(0);
+  const instanceRef = useRef<MusicKit.MusicKitInstance | null>(
+    getMusicKitInstance()
+  );
+  const [instanceReadyTick, setInstanceReadyTick] = useState(() =>
+    getMusicKitInstance() ? 1 : 0
+  );
   const lastQueuedTrackIdRef = useRef<string | null>(null);
   const queueLoadingRef = useRef<Promise<void> | null>(null);
   const onReadyRef = useRef(onReady);
@@ -234,6 +239,14 @@ export const AppleMusicPlayerBridge = function AppleMusicPlayerBridge(
 
     const handleState = (event: MusicKit.PlaybackStateDidChangeEvent) => {
       const state = event?.state ?? activeInstance?.playbackState;
+      if (
+        shouldSuppressPlaybackStateFanoutWhileQueueLoading(
+          queueLoadingRef.current !== null,
+          state
+        )
+      ) {
+        return;
+      }
       if (state === 2) {
         onPlayRef.current?.();
         return;
@@ -480,6 +493,11 @@ export const AppleMusicPlayerBridge = function AppleMusicPlayerBridge(
     const previousQueueLoading = queueLoadingRef.current;
     let thisLoad: Promise<void> | null = null;
     thisLoad = (async () => {
+      // Capture play intent up front. MusicKit emits `paused` while
+      // `setQueue({ startPlaying: false })` runs; if we forwarded that to
+      // the store, `playingRef` would flip false before this async block
+      // finishes and we'd skip the post-queue `play()` call.
+      const shouldPlayAfterQueue = playingRef.current;
       if (previousQueueLoading) {
         // Best-effort wait — failures of the previous queue load
         // shouldn't block a fresh user action.
@@ -513,7 +531,7 @@ export const AppleMusicPlayerBridge = function AppleMusicPlayerBridge(
           onDurationRef.current?.(currentTrack.durationMs / 1000);
         }
         lastQueuedTrackIdRef.current = localQueueKey;
-        if (playingRef.current) {
+        if (shouldPlayAfterQueue) {
           await inst.play().catch((err) => {
             // Browsers block autoplay until the user interacts; surface as
             // a paused state so the iPod's play button shows the right icon.
@@ -525,6 +543,7 @@ export const AppleMusicPlayerBridge = function AppleMusicPlayerBridge(
           });
         }
       } catch (err) {
+        lastQueuedTrackIdRef.current = null;
         console.error("[apple music] setQueue failed", err);
       } finally {
         // Only clear the shared ref when *we* are still the most recent
@@ -564,7 +583,9 @@ export const AppleMusicPlayerBridge = function AppleMusicPlayerBridge(
             });
           }
           await inst.play();
-        } else {
+        } else if (!queueLoadingRef.current) {
+          // Don't race `setQueue({ startPlaying: false })` with an
+          // immediate `pause()` from a transient `playing=false` render.
           inst.pause();
         }
       } catch (err) {
@@ -572,7 +593,7 @@ export const AppleMusicPlayerBridge = function AppleMusicPlayerBridge(
       }
     };
     void apply();
-  }, [playing, currentTrack]);
+  }, [playing, currentTrack, instanceReadyTick]);
 
   useImperativeHandle(
     ref,

--- a/src/apps/ipod/components/AppleMusicPlayerBridge.tsx
+++ b/src/apps/ipod/components/AppleMusicPlayerBridge.tsx
@@ -4,6 +4,7 @@ import { getMusicKitInstance, onMusicKitReady } from "@/hooks/useMusicKit";
 import { PLAYER_PROGRESS_INTERVAL_MS } from "../constants";
 import {
   getMusicKitEventItemId,
+  isStaleQueueLoad,
   isWithinEndedFanoutDedupWindow,
   shouldFireEndedForPlaybackState,
   shouldSuppressPlaybackStateFanoutWhileQueueLoading,
@@ -138,6 +139,7 @@ export const AppleMusicPlayerBridge = function AppleMusicPlayerBridge(
     getMusicKitInstance() ? 1 : 0
   );
   const lastQueuedTrackIdRef = useRef<string | null>(null);
+  const queueGenerationRef = useRef(0);
   const queueLoadingRef = useRef<Promise<void> | null>(null);
   const onReadyRef = useRef(onReady);
   onReadyRef.current = onReady;
@@ -480,6 +482,15 @@ export const AppleMusicPlayerBridge = function AppleMusicPlayerBridge(
     }
 
     const localQueueKey = queueKey;
+    const loadGeneration = ++queueGenerationRef.current;
+    // Silence the outgoing track immediately so the user doesn't keep
+    // hearing song A while the UI already shows song B and we're waiting
+    // for a serialized `setQueue` or a prior in-flight load to settle.
+    try {
+      inst.pause();
+    } catch {
+      /* ignore — best-effort */
+    }
     // Serialize back-to-back queue swaps. If another track change is
     // already in flight (rapid `nextTrack` clicks, an `onEnded` advance
     // racing a user press, etc.), wait for it to settle before issuing
@@ -493,6 +504,12 @@ export const AppleMusicPlayerBridge = function AppleMusicPlayerBridge(
     const previousQueueLoading = queueLoadingRef.current;
     let thisLoad: Promise<void> | null = null;
     thisLoad = (async () => {
+      const isStale = () =>
+        isStaleQueueLoad(
+          loadGeneration,
+          queueGenerationRef.current,
+          cancelled
+        );
       // Capture play intent up front. MusicKit emits `paused` while
       // `setQueue({ startPlaying: false })` runs; if we forwarded that to
       // the store, `playingRef` would flip false before this async block
@@ -506,7 +523,7 @@ export const AppleMusicPlayerBridge = function AppleMusicPlayerBridge(
         } catch {
           /* ignore — the previous load already logged its own error */
         }
-        if (cancelled) return;
+        if (isStale()) return;
       }
       try {
         const resumeSeconds = getSafeStartSeconds(
@@ -520,13 +537,13 @@ export const AppleMusicPlayerBridge = function AppleMusicPlayerBridge(
           // before any audible playback starts.
           startPlaying: false,
         });
-        if (cancelled) return;
+        if (isStale()) return;
         if (resumeSeconds != null) {
           await inst.seekToTime(resumeSeconds).catch((err) => {
             console.warn("[apple music] resume seek failed", err);
           });
         }
-        if (cancelled) return;
+        if (isStale()) return;
         if (currentTrack.durationMs && currentTrack.durationMs > 0) {
           onDurationRef.current?.(currentTrack.durationMs / 1000);
         }
@@ -543,7 +560,9 @@ export const AppleMusicPlayerBridge = function AppleMusicPlayerBridge(
           });
         }
       } catch (err) {
-        lastQueuedTrackIdRef.current = null;
+        if (!isStale()) {
+          lastQueuedTrackIdRef.current = null;
+        }
         console.error("[apple music] setQueue failed", err);
       } finally {
         // Only clear the shared ref when *we* are still the most recent
@@ -563,18 +582,26 @@ export const AppleMusicPlayerBridge = function AppleMusicPlayerBridge(
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [queueKey, instanceReadyTick]);
 
-  // Sync play/pause without re-queueing.
+  // Sync play/pause without re-queueing. Track changes are owned entirely
+  // by the `setQueue` effect above — resuming playback here when
+  // `currentTrack` flips would call `play()` on whatever queue MusicKit
+  // still holds (often the previous song) before the new `setQueue`
+  // resolves, which is the classic audio/UI mismatch on fast skips.
   useEffect(() => {
     const inst = instanceRef.current;
     if (!inst) return;
-    if (!currentTrack) return;
+    const track = currentTrackRef.current;
+    if (!track) return;
     const pending = queueLoadingRef.current;
     const apply = async () => {
       try {
         if (pending) await pending;
+        if (queueLoadingRef.current) return;
+        const queuedTrackId = lastQueuedTrackIdRef.current;
+        if (queuedTrackId !== track.id) return;
         if (playing) {
           const startSeconds = getSafeStartSeconds(
-            currentTrack,
+            track,
             resumeAtSecondsRef.current
           );
           if (startSeconds != null) {
@@ -583,9 +610,7 @@ export const AppleMusicPlayerBridge = function AppleMusicPlayerBridge(
             });
           }
           await inst.play();
-        } else if (!queueLoadingRef.current) {
-          // Don't race `setQueue({ startPlaying: false })` with an
-          // immediate `pause()` from a transient `playing=false` render.
+        } else {
           inst.pause();
         }
       } catch (err) {
@@ -593,7 +618,7 @@ export const AppleMusicPlayerBridge = function AppleMusicPlayerBridge(
       }
     };
     void apply();
-  }, [playing, currentTrack, instanceReadyTick]);
+  }, [playing, instanceReadyTick]);
 
   useImperativeHandle(
     ref,

--- a/src/apps/ipod/components/appleMusicPlayerBridgeUtils.ts
+++ b/src/apps/ipod/components/appleMusicPlayerBridgeUtils.ts
@@ -80,6 +80,25 @@ export function isWithinEndedFanoutDedupWindow(
  * (`item.id`, `item.attributes.playParams.id`,
  * `item.attributes.playParams.catalogId`).
  */
+/**
+ * While `setQueue` runs with `startPlaying: false`, MusicKit JS commonly
+ * emits `loading` / `paused` / `stopped` playback states before we call
+ * `play()`. Forwarding those to the iPod store flips `isPlaying` off, so
+ * the post-queue `play()` is skipped and the user hears silence even
+ * though they just tapped a song. Suppress parent fan-out for non-terminal
+ * states until the queue load settles.
+ */
+export function shouldSuppressPlaybackStateFanoutWhileQueueLoading(
+  queueLoading: boolean,
+  state: number | undefined
+): boolean {
+  if (!queueLoading) return false;
+  // Terminal states are still unexpected mid-load, but ended/completed
+  // should never be swallowed if they somehow arrive.
+  if (state === 5 || state === 10) return false;
+  return true;
+}
+
 export function getMusicKitEventItemId(
   item:
     | {

--- a/src/apps/ipod/components/appleMusicPlayerBridgeUtils.ts
+++ b/src/apps/ipod/components/appleMusicPlayerBridgeUtils.ts
@@ -99,6 +99,21 @@ export function shouldSuppressPlaybackStateFanoutWhileQueueLoading(
   return true;
 }
 
+/**
+ * Returns true when an in-flight queue load should abandon further work.
+ * Each explicit track selection bumps `currentGeneration`; stale async
+ * blocks must not call `play()` or stamp `lastQueuedTrackId` after a
+ * newer selection has already started — otherwise MusicKit can keep
+ * playing the previous song while the iPod UI shows the latest pick.
+ */
+export function isStaleQueueLoad(
+  loadGeneration: number,
+  currentGeneration: number,
+  cancelled: boolean
+): boolean {
+  return cancelled || loadGeneration !== currentGeneration;
+}
+
 export function getMusicKitEventItemId(
   item:
     | {

--- a/tests/test-ipod-apple-music.test.ts
+++ b/tests/test-ipod-apple-music.test.ts
@@ -52,6 +52,7 @@ const {
   isWithinEndedFanoutDedupWindow,
   ENDED_FANOUT_DEDUP_WINDOW_MS,
   getMusicKitEventItemId,
+  shouldSuppressPlaybackStateFanoutWhileQueueLoading,
 } = await import(
   "../src/apps/ipod/components/appleMusicPlayerBridgeUtils"
 );
@@ -932,6 +933,35 @@ describe("AppleMusicPlayerBridge ended fan-out dedup window", () => {
   test("custom window override works (used by tests + future hardening)", () => {
     expect(isWithinEndedFanoutDedupWindow(100, 50, 100)).toBe(true);
     expect(isWithinEndedFanoutDedupWindow(150, 50, 100)).toBe(false);
+  });
+});
+
+describe("AppleMusicPlayerBridge queue-load playback-state fan-out", () => {
+  // Regression: `setQueue({ startPlaying: false })` makes MusicKit emit
+  // paused/loading/stopped before we call `play()`. Forwarding those
+  // states to the iPod store flips `isPlaying` off so the post-queue
+  // `play()` is skipped — the user taps a song and hears nothing.
+  test("suppresses non-terminal states while a queue load is in flight", () => {
+    for (const state of [0, 1, 2, 3, 4, 6, 8, 9, undefined]) {
+      expect(
+        shouldSuppressPlaybackStateFanoutWhileQueueLoading(true, state)
+      ).toBe(true);
+    }
+  });
+
+  test("does not suppress when no queue load is active", () => {
+    expect(
+      shouldSuppressPlaybackStateFanoutWhileQueueLoading(false, 3)
+    ).toBe(false);
+  });
+
+  test("still allows ended/completed through during queue load", () => {
+    expect(
+      shouldSuppressPlaybackStateFanoutWhileQueueLoading(true, 5)
+    ).toBe(false);
+    expect(
+      shouldSuppressPlaybackStateFanoutWhileQueueLoading(true, 10)
+    ).toBe(false);
   });
 });
 

--- a/tests/test-ipod-apple-music.test.ts
+++ b/tests/test-ipod-apple-music.test.ts
@@ -53,6 +53,7 @@ const {
   ENDED_FANOUT_DEDUP_WINDOW_MS,
   getMusicKitEventItemId,
   shouldSuppressPlaybackStateFanoutWhileQueueLoading,
+  isStaleQueueLoad,
 } = await import(
   "../src/apps/ipod/components/appleMusicPlayerBridgeUtils"
 );
@@ -962,6 +963,20 @@ describe("AppleMusicPlayerBridge queue-load playback-state fan-out", () => {
     expect(
       shouldSuppressPlaybackStateFanoutWhileQueueLoading(true, 10)
     ).toBe(false);
+  });
+});
+
+describe("AppleMusicPlayerBridge queue-load generation guard", () => {
+  test("stale when cancelled even if generation still matches", () => {
+    expect(isStaleQueueLoad(3, 3, true)).toBe(true);
+  });
+
+  test("stale when a newer selection bumped the generation", () => {
+    expect(isStaleQueueLoad(2, 3, false)).toBe(true);
+  });
+
+  test("fresh when generation matches and effect is still active", () => {
+    expect(isStaleQueueLoad(3, 3, false)).toBe(false);
   });
 });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes two related Apple Music playback bugs in the iPod:

1. **Songs not playing after selection** — `setQueue({ startPlaying: false })` made MusicKit emit transient paused states that flipped `isPlaying` off before post-queue `play()` ran.
2. **Previous song keeps playing while UI shows the new song** — stale in-flight `setQueue` work and the play/pause sync effect could call `play()` on the old queue before the new one finished loading.

## Changes

### Playback not starting
- Suppress parent play/pause fan-out while a queue load is in flight
- Capture play intent at queue-start (`shouldPlayAfterQueue`) instead of after MusicKit may emit a transient pause
- Initialize MusicKit synchronously on mount; re-sync when instance becomes ready

### Audio/UI mismatch on track skip
- Add a per-selection **queue generation guard** so stale async loads cannot stamp `lastQueuedTrackId` or call `play()` for an outdated pick
- **Pause immediately** when a new track is selected so the outgoing song does not keep playing during serialized queue swaps
- Restrict play/pause sync to play/pause toggles on the **already-queued** track; track changes are owned solely by the `setQueue` effect (removing `currentTrack` from play/pause deps)

## Testing

- ✅ `bun test tests/test-ipod-apple-music.test.ts` (queue-load suppression + generation guard regression tests)
- ✅ `bun run test:unit` (222 pass)
- ✅ `bun run build`
- ⚠️ End-to-end Apple Music playback requires valid Apple ID sign-in locally
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6c479560-c95d-4ec8-b5eb-bd3774346b45"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6c479560-c95d-4ec8-b5eb-bd3774346b45"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

