### PR TITLE
fix(theme): macOSX menubar, Finder list view, and shared dialogs font sizing

### DIFF
--- a/src/apps/finder/components/FileList.tsx
+++ b/src/apps/finder/components/FileList.tsx
@@ -873,6 +873,13 @@ export function FileList({
   // ------------------- Render -------------------
 
   if (viewType === "list") {
+    // macOS theme list view picks up larger Lucida Grande sizing so rows match the
+    // icon-view label scale (12px). System 7 / Windows themes keep the pixel-font sizing
+    // they were tuned for. Previously a global `:root[data-os-theme="macosx"] div { font-size: 13px !important }`
+    // rule made these look right; that rule was removed during the typography refactor,
+    // so we opt in explicitly here.
+    const listHeaderTextClass = isMacOSXTheme ? "text-[12px]" : "text-[10px]";
+    const listBodyTextClass = isMacOSXTheme ? "text-[12px]" : "text-[11px]";
     return (
       <div
         ref={containerRef}
@@ -884,7 +891,7 @@ export function FileList({
       >
         <Table key={listTableKey} className="min-w-[480px]">
           <TableHeader>
-            <TableRow className="text-[10px] border-none font-normal">
+            <TableRow className={`${listHeaderTextClass} border-none font-normal`}>
               <TableHead className="font-normal bg-gray-100/50 h-[28px]">
                 {t("apps.finder.tableHeaders.name")}
               </TableHead>
@@ -899,7 +906,7 @@ export function FileList({
               </TableHead>
             </TableRow>
           </TableHeader>
-          <TableBody className="text-[11px]">
+          <TableBody className={listBodyTextClass}>
             {files.map((file) => (
               <ListRowItem
                 key={file.path}

--- a/src/components/dialogs/AboutDialog.tsx
+++ b/src/components/dialogs/AboutDialog.tsx
@@ -40,7 +40,7 @@ export function AboutDialog({
   appId,
 }: AboutDialogProps) {
   const { t } = useTranslation();
-  const { isWindowsTheme: isXpTheme, isMacOSTheme } = useThemeFlags();
+  const { isWindowsTheme: isXpTheme, isMacOSTheme, isSystem7Theme } = useThemeFlags();
   const launchApp = useAppStore((state) => state.launchApp);
   
   // Use translated app name if appId is provided, otherwise fall back to metadata.name
@@ -66,7 +66,9 @@ export function AboutDialog({
           "space-y-0 text-center",
           isXpTheme
             ? "font-['Pixelated_MS_Sans_Serif',Arial] text-[11px]"
-            : "font-geneva-12 text-[10px]"
+            : isSystem7Theme
+            ? "font-geneva-12 text-[10px]"
+            : "font-os-ui text-[12px]"
         )}
         style={{
           fontFamily: isXpTheme

--- a/src/components/layout/MenuBar.tsx
+++ b/src/components/layout/MenuBar.tsx
@@ -1471,6 +1471,11 @@ export function MenuBar({ children, inWindowFrame = false }: MenuBarProps) {
             ? "0 2px 8px rgba(0, 0, 0, 0.15)"
             : undefined,
         fontFamily: "var(--os-font-ui)",
+        // Match clock + non-button text to menubar trigger button size in macOS theme.
+        // The macOS button rule (themes.css) sizes triggers to --os-typography-button via !important;
+        // setting the same here means inheritors (Clock div, Finder app-menu-trigger which is excluded
+        // from the button rule, etc.) line up at 13px instead of falling back to the 12px body size.
+        fontSize: isMacOSTheme ? "var(--os-typography-button)" : undefined,
         color: "var(--os-color-menubar-text)",
         // Add extra left padding for macOS traffic lights in Tauri
         paddingLeft: needsTrafficLightClearance 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
After the macOSX typography refactor removed the global `div`/`p` `font-size: 13px !important` fallback, several pieces of shell UI stopped matching their neighbours because they relied on the catch-all rule to upsize their nested Tailwind pixel utilities.

### Fixes

**MenuBar (macOSX top menubar)** — the menu trigger buttons (`File`/`Edit`/`View`/`Go`/`Help`, volume, Spotlight) still get `--os-typography-button` (13px) from the macOSX `button` rule, but the `Clock` `div` (and the `Finder` app-menu-trigger, which is excluded from that rule) fell back to the body's `--os-typography-root` (12px). Set `font-size: var(--os-typography-button)` on the macOSX menubar shell so every text node inside the bar inherits the same 13px the trigger buttons already render at.

**Finder `FileList` (list view)** — rows used `text-[11px]` and the header row used `text-[10px]`, which read noticeably smaller than the icon-view labels. Lift both to `text-[12px]` in the macOSX theme so list rows line up with the large icon-view label size. System 7 / Windows themes keep the pixel-font sizing they were tuned for.

**Shared dialogs (`AboutDialog`, `AboutFinderDialog`, `HelpDialog`, `ShareItemDialog`, `TelegramLinkDialog`)** — every one of these branched on `isXpTheme` vs. everything else and applied `font-geneva-12 text-[10px]`/`text-[11px]` to the non-XP branch. Because macOSX remaps `.font-geneva-12` to Lucida Grande (via `themes.css`), this rendered as 10–11px Lucida — visibly tiny next to the rest of the dialog chrome (most noticeable in `AboutFinderDialog`'s memory readouts and app memory list). Split the non-XP branch into:
- System 7 → keep `font-geneva-12 text-[10px]` (Geneva pixel font, intentional).
- everything else (macOSX today) → `font-os-ui text-[12px]` (or `text-[11px]` for secondary gray text that already lands at 11px via the existing `.macosx-dialog .text-gray-500` rule).

### Files
- `src/components/layout/MenuBar.tsx`: add `fontSize: var(--os-typography-button)` to the macOSX menubar shell's inline `style`.
- `src/apps/finder/components/FileList.tsx`: pick the `TableHeader` / `TableBody` text class based on `isMacOSTheme`.
- `src/components/dialogs/AboutDialog.tsx`, `AboutFinderDialog.tsx`, `HelpDialog.tsx`, `ShareItemDialog.tsx`, `TelegramLinkDialog.tsx`: scope `font-geneva-12 text-[10px]` to `isSystem7Theme`; macOSX falls through to `font-os-ui text-[12px]` (or `text-[11px]` for gray-text rows).

### Testing
- ✅ `bun run build` (no TS or Vite errors)
- Manual visual verification skipped per `AGENTS.md` ("skip computer use / GUI-driven testing unless the user explicitly requests it"); each fix is a small, theme-scoped edit with no impact outside macOSX (System 7 / Windows themes keep their existing pixel-font sizing).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2fa51de0-57a9-448a-834f-57f2cfa7d9a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2fa51de0-57a9-448a-834f-57f2cfa7d9a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

