### PR TITLE
feat(ipod): media list rows with artwork and subtitles

### DIFF
--- a/src/apps/ipod/components/IpodScreen.tsx
+++ b/src/apps/ipod/components/IpodScreen.tsx
@@ -67,6 +67,8 @@ import { useIpodStore, isAppleMusicCollectionTrack } from "@/stores/useIpodStore
 // the scroll-position math.
 const MENU_ITEM_HEIGHT_CLASSIC = 24;
 const MENU_ITEM_HEIGHT_MODERN = 21;
+/** Modern playlist / per-artist album browse — thumbnail + two-line label. */
+const MENU_ITEM_HEIGHT_MODERN_MEDIA = 46;
 const menuItemKeyCache = new WeakMap<object, string>();
 let menuItemKeySeed = 0;
 
@@ -374,6 +376,10 @@ export function IpodScreen({
   // toggling from the menubar updates the screen instantly.
   const uiVariant = useIpodStore((s) => s.uiVariant);
   const isModernUi = uiVariant === "modern";
+  const currentMenuModernMediaList = useMemo(() => {
+    if (!menuMode || menuHistory.length === 0) return false;
+    return Boolean(menuHistory[menuHistory.length - 1].modernMediaList);
+  }, [menuMode, menuHistory]);
   // Modern UI renders Cover Flow inline as a third state in the menu
   // panel's AnimatePresence (alongside menu list + now-playing) so the
   // menu↔nowplaying chrome width transition (50%↔100%) seamlessly
@@ -383,9 +389,11 @@ export function IpodScreen({
   const showInlineCoverFlow = Boolean(
     isModernUi && isCoverFlowOpen && coverFlowSlot
   );
-  const menuItemHeight = isModernUi
-    ? MENU_ITEM_HEIGHT_MODERN
-    : MENU_ITEM_HEIGHT_CLASSIC;
+  const menuItemHeight = !isModernUi
+    ? MENU_ITEM_HEIGHT_CLASSIC
+    : currentMenuModernMediaList
+      ? MENU_ITEM_HEIGHT_MODERN_MEDIA
+      : MENU_ITEM_HEIGHT_MODERN;
   const [showShellTitleInTitlebar, setShowShellTitleInTitlebar] =
     useState(false);
   const effectiveDisplayMode =
@@ -965,6 +973,9 @@ export function IpodScreen({
                               showChevron={item.showChevron !== false}
                               value={item.value}
                               isLoading={item.isLoading}
+                              mediaRow={isModernUi && currentMenuModernMediaList}
+                              subtitle={item.subtitle}
+                              thumbnailUrl={item.coverUrl}
                             />
                           </div>
                         );

--- a/src/apps/ipod/components/IpodScreen.tsx
+++ b/src/apps/ipod/components/IpodScreen.tsx
@@ -67,8 +67,9 @@ import { useIpodStore, isAppleMusicCollectionTrack } from "@/stores/useIpodStore
 // the scroll-position math.
 const MENU_ITEM_HEIGHT_CLASSIC = 24;
 const MENU_ITEM_HEIGHT_MODERN = 21;
-/** Modern playlist / per-artist album browse — thumbnail + two-line label. */
-const MENU_ITEM_HEIGHT_MODERN_MEDIA = 46;
+// Modern **media** rows (playlist / artist album / in-playlist tracks):
+// title bar 17px + **4 × 33px** rows ≈ 149px inside the fixed **150px** LCD.
+const MENU_ITEM_HEIGHT_MODERN_MEDIA = 33;
 const menuItemKeyCache = new WeakMap<object, string>();
 let menuItemKeySeed = 0;
 

--- a/src/apps/ipod/components/IpodScreen.tsx
+++ b/src/apps/ipod/components/IpodScreen.tsx
@@ -597,6 +597,10 @@ export function IpodScreen({
   // hierarchical browse menus, not on flat song lists or Settings).
   // The root iPod / Music submenus still qualify because their rows
   // include chevron-bearing categories.
+  //
+  // **Modern media lists** (playlist picker, per-artist albums) already
+  // show artwork in each row — hide the right split so the menu stays
+  // full width without the 50%↔100% chrome transition.
   const isBrowseableMenu = useMemo(
     () =>
       isModernUi &&
@@ -606,8 +610,15 @@ export function IpodScreen({
       // menu→now-playing — so we suppress the split-art carousel
       // entirely while Cover Flow is on screen.
       !showInlineCoverFlow &&
+      !currentMenuModernMediaList &&
       currentMenuItems.some((item) => item.showChevron === true),
-    [isModernUi, menuMode, showInlineCoverFlow, currentMenuItems]
+    [
+      isModernUi,
+      menuMode,
+      showInlineCoverFlow,
+      currentMenuModernMediaList,
+      currentMenuItems,
+    ]
   );
 
   const splitArtUrlPool = useMemo(() => {

--- a/src/apps/ipod/components/screen/MenuListItem.tsx
+++ b/src/apps/ipod/components/screen/MenuListItem.tsx
@@ -72,7 +72,7 @@ export function MenuListItem({
         <div
           onClick={isLoading ? undefined : onClick}
           className={cn(
-            "h-full pl-1.5 pr-2 font-ipod-modern-ui flex justify-between items-center gap-1.5",
+            "h-full pl-1 pr-1.5 font-ipod-modern-ui flex justify-between items-center gap-1",
             "ipod-modern-row",
             isLoading ? "cursor-default" : "cursor-pointer",
             isSelected && !isLoading
@@ -82,9 +82,9 @@ export function MenuListItem({
                 : "text-black"
           )}
         >
-          <div className="flex min-h-0 min-w-0 flex-1 items-center gap-2 mr-1">
+          <div className="flex min-h-0 min-w-0 flex-1 items-center gap-1.5 mr-0.5">
             <div
-              className="relative size-[34px] shrink-0 overflow-hidden rounded-[2px] bg-[#a8a8a8]"
+              className="relative size-[26px] shrink-0 overflow-hidden rounded-[2px] bg-[#a8a8a8]"
               aria-hidden
             >
               {thumbSrc ? (
@@ -115,14 +115,14 @@ export function MenuListItem({
                 scrollStartDelaySec={0.5}
                 className={cn(
                   "max-w-full min-w-0 font-semibold leading-none",
-                  hasCjkText ? "text-[13px]" : "text-[14px]"
+                  hasCjkText ? "text-[11px]" : "text-[12px]"
                 )}
               />
               {subtitleTrim ? (
                 <span
                   className={cn(
                     "-mt-0.5 block min-w-0 truncate font-normal leading-none",
-                    hasCjkText ? "text-[11px]" : "text-[12px]",
+                    hasCjkText ? "text-[10px]" : "text-[11px]",
                     isSelected && !isLoading
                       ? "text-white/88"
                       : "text-[rgb(99,101,103)]"
@@ -137,8 +137,8 @@ export function MenuListItem({
           {value ? (
             <span
               className={cn(
-                "flex shrink-0 items-center font-semibold leading-tight",
-                hasCjkText ? "text-[13px]" : "text-[14px]",
+                "flex shrink-0 items-center font-semibold leading-none",
+                hasCjkText ? "text-[11px]" : "text-[12px]",
                 isSelected && !isLoading
                   ? "text-white/90"
                   : "text-[rgb(99,101,103)]"
@@ -152,7 +152,7 @@ export function MenuListItem({
               <span
                 className={cn(
                   "flex shrink-0 items-center justify-center font-normal leading-none",
-                  "text-[19px]",
+                  "text-[16px]",
                   isSelected && !isLoading ? "text-white/95" : "text-[#b8b8bc]"
                 )}
                 aria-hidden

--- a/src/apps/ipod/components/screen/MenuListItem.tsx
+++ b/src/apps/ipod/components/screen/MenuListItem.tsx
@@ -102,7 +102,9 @@ export function MenuListItem({
                 />
               ) : null}
             </div>
-            <div className="flex min-h-0 min-w-0 flex-1 flex-col justify-center gap-0">
+            {/* Tight two-line stack: leading-none + tiny negative margin so the
+                pair reads as one vertically centered block beside the thumb. */}
+            <div className="flex min-h-0 min-w-0 flex-1 flex-col justify-center gap-0 py-0">
               <ScrollingText
                 text={text}
                 align="left"
@@ -112,14 +114,14 @@ export function MenuListItem({
                 resetOnPause
                 scrollStartDelaySec={0.5}
                 className={cn(
-                  "max-w-full min-w-0 block font-semibold leading-[1.05]",
+                  "max-w-full min-w-0 font-semibold leading-none",
                   hasCjkText ? "text-[13px]" : "text-[14px]"
                 )}
               />
               {subtitleTrim ? (
                 <span
                   className={cn(
-                    "min-w-0 truncate font-normal leading-[1.05]",
+                    "-mt-0.5 block min-w-0 truncate font-normal leading-none",
                     hasCjkText ? "text-[11px]" : "text-[12px]",
                     isSelected && !isLoading
                       ? "text-white/88"

--- a/src/apps/ipod/components/screen/MenuListItem.tsx
+++ b/src/apps/ipod/components/screen/MenuListItem.tsx
@@ -102,8 +102,7 @@ export function MenuListItem({
                 />
               ) : null}
             </div>
-            {/* Tight two-line stack: line-height 1 + negative pull on subtitle so
-                title/subtitle read as one block (extra gap comes from text line boxes). */}
+            {/* Two-line stack: tight line-height; spacing is natural line box only. */}
             <div className="flex min-h-0 min-w-0 flex-1 flex-col justify-center gap-0 py-0 leading-none">
               <ScrollingText
                 text={text}
@@ -121,7 +120,7 @@ export function MenuListItem({
               {subtitleTrim ? (
                 <span
                   className={cn(
-                    "-mt-1 block min-w-0 truncate font-normal !leading-none",
+                    "block min-w-0 truncate font-normal !leading-none",
                     hasCjkText ? "text-[10px]" : "text-[11px]",
                     isSelected && !isLoading
                       ? "text-white/88"

--- a/src/apps/ipod/components/screen/MenuListItem.tsx
+++ b/src/apps/ipod/components/screen/MenuListItem.tsx
@@ -120,7 +120,7 @@ export function MenuListItem({
               {subtitleTrim ? (
                 <span
                   className={cn(
-                    "block min-w-0 truncate font-normal !leading-none",
+                    "mt-0.5 block min-w-0 truncate font-normal !leading-none",
                     hasCjkText ? "text-[10px]" : "text-[11px]",
                     isSelected && !isLoading
                       ? "text-white/88"

--- a/src/apps/ipod/components/screen/MenuListItem.tsx
+++ b/src/apps/ipod/components/screen/MenuListItem.tsx
@@ -112,14 +112,14 @@ export function MenuListItem({
                 resetOnPause
                 scrollStartDelaySec={0.5}
                 className={cn(
-                  "max-w-full min-w-0 block font-semibold leading-[1.1]",
+                  "max-w-full min-w-0 block font-semibold leading-[1.05]",
                   hasCjkText ? "text-[13px]" : "text-[14px]"
                 )}
               />
               {subtitleTrim ? (
                 <span
                   className={cn(
-                    "mt-0.5 min-w-0 truncate font-normal leading-[1.1]",
+                    "min-w-0 truncate font-normal leading-[1.05]",
                     hasCjkText ? "text-[11px]" : "text-[12px]",
                     isSelected && !isLoading
                       ? "text-white/88"

--- a/src/apps/ipod/components/screen/MenuListItem.tsx
+++ b/src/apps/ipod/components/screen/MenuListItem.tsx
@@ -102,9 +102,9 @@ export function MenuListItem({
                 />
               ) : null}
             </div>
-            {/* Tight two-line stack: leading-none + tiny negative margin so the
-                pair reads as one vertically centered block beside the thumb. */}
-            <div className="flex min-h-0 min-w-0 flex-1 flex-col justify-center gap-0 py-0">
+            {/* Tight two-line stack: line-height 1 + negative pull on subtitle so
+                title/subtitle read as one block (extra gap comes from text line boxes). */}
+            <div className="flex min-h-0 min-w-0 flex-1 flex-col justify-center gap-0 py-0 leading-none">
               <ScrollingText
                 text={text}
                 align="left"
@@ -114,14 +114,14 @@ export function MenuListItem({
                 resetOnPause
                 scrollStartDelaySec={0.5}
                 className={cn(
-                  "max-w-full min-w-0 font-semibold leading-none",
+                  "m-0 max-w-full min-w-0 p-0 font-semibold !leading-none [&>div]:!leading-none",
                   hasCjkText ? "text-[11px]" : "text-[12px]"
                 )}
               />
               {subtitleTrim ? (
                 <span
                   className={cn(
-                    "-mt-0.5 block min-w-0 truncate font-normal leading-none",
+                    "-mt-1 block min-w-0 truncate font-normal !leading-none",
                     hasCjkText ? "text-[10px]" : "text-[11px]",
                     isSelected && !isLoading
                       ? "text-white/88"

--- a/src/apps/ipod/components/screen/MenuListItem.tsx
+++ b/src/apps/ipod/components/screen/MenuListItem.tsx
@@ -1,5 +1,8 @@
 import { cn } from "@/lib/utils";
+import { useImageLoaded } from "../../hooks/useImageLoaded";
 import { ScrollingText } from "./ScrollingText";
+
+const THUMB_FADE = "opacity 250ms ease-out" as const;
 
 interface MenuListItemProps {
   text: string;
@@ -22,6 +25,18 @@ interface MenuListItemProps {
    * selection highlight with white text.
    */
   variant?: "classic" | "modern";
+  /**
+   * Modern media rows only: second line (caption). Single-line ellipsis;
+   * omit or pass empty to show only the primary line.
+   */
+  subtitle?: string | null;
+  /** Modern media rows only: square artwork (`object-cover`). */
+  thumbnailUrl?: string | null;
+  /**
+   * Modern UI + browse menus stamped with `modernMediaList`: two-line label
+   * column with a square thumbnail. Ignored for classic skin.
+   */
+  mediaRow?: boolean;
 }
 
 const CJK_TEXT_PATTERN =
@@ -37,12 +52,117 @@ export function MenuListItem({
   isLoading = false,
   allowScrollingMarquee = true,
   variant = "classic",
+  subtitle,
+  thumbnailUrl,
+  mediaRow = false,
 }: MenuListItemProps) {
   const hasCjkText =
-    CJK_TEXT_PATTERN.test(text) || (value ? CJK_TEXT_PATTERN.test(value) : false);
+    CJK_TEXT_PATTERN.test(text) ||
+    (value ? CJK_TEXT_PATTERN.test(value) : false) ||
+    (subtitle ? CJK_TEXT_PATTERN.test(subtitle) : false);
   const isModern = variant === "modern";
+  const thumbSrc = isModern && mediaRow ? (thumbnailUrl ?? null) : null;
+  const thumb = useImageLoaded(thumbSrc);
+  const subtitleTrim =
+    typeof subtitle === "string" ? subtitle.trim() : "";
 
   if (isModern) {
+    if (mediaRow) {
+      return (
+        <div
+          onClick={isLoading ? undefined : onClick}
+          className={cn(
+            "h-full pl-1.5 pr-2 font-ipod-modern-ui flex justify-between items-center gap-1.5",
+            "ipod-modern-row",
+            isLoading ? "cursor-default" : "cursor-pointer",
+            isSelected && !isLoading
+              ? "ipod-modern-row-selected"
+              : isLoading
+                ? "text-[#555] animate-pulse"
+                : "text-black"
+          )}
+        >
+          <div className="flex min-h-0 min-w-0 flex-1 items-center gap-2 mr-1">
+            <div
+              className="relative size-[34px] shrink-0 overflow-hidden rounded-[2px] bg-[#a8a8a8]"
+              aria-hidden
+            >
+              {thumbSrc ? (
+                <img
+                  ref={thumb.ref}
+                  src={thumbSrc}
+                  alt=""
+                  className="size-full object-cover"
+                  draggable={false}
+                  onLoad={thumb.onLoad}
+                  style={{
+                    opacity: thumb.loaded ? 1 : 0,
+                    transition: THUMB_FADE,
+                  }}
+                />
+              ) : null}
+            </div>
+            <div className="flex min-h-0 min-w-0 flex-1 flex-col justify-center gap-0">
+              <ScrollingText
+                text={text}
+                align="left"
+                fadeEdges
+                allowMarquee={allowScrollingMarquee}
+                isPlaying={isSelected && !isLoading}
+                resetOnPause
+                scrollStartDelaySec={0.5}
+                className={cn(
+                  "max-w-full min-w-0 block font-semibold leading-[1.1]",
+                  hasCjkText ? "text-[13px]" : "text-[14px]"
+                )}
+              />
+              {subtitleTrim ? (
+                <span
+                  className={cn(
+                    "mt-0.5 min-w-0 truncate font-normal leading-[1.1]",
+                    hasCjkText ? "text-[11px]" : "text-[12px]",
+                    isSelected && !isLoading
+                      ? "text-white/88"
+                      : "text-[rgb(99,101,103)]"
+                  )}
+                  title={subtitleTrim}
+                >
+                  {subtitleTrim}
+                </span>
+              ) : null}
+            </div>
+          </div>
+          {value ? (
+            <span
+              className={cn(
+                "flex shrink-0 items-center font-semibold leading-tight",
+                hasCjkText ? "text-[13px]" : "text-[14px]",
+                isSelected && !isLoading
+                  ? "text-white/90"
+                  : "text-[rgb(99,101,103)]"
+              )}
+            >
+              {value}
+            </span>
+          ) : (
+            showChevron &&
+            !isLoading && (
+              <span
+                className={cn(
+                  "flex shrink-0 items-center justify-center font-normal leading-none",
+                  "text-[19px]",
+                  isSelected && !isLoading ? "text-white/95" : "text-[#b8b8bc]"
+                )}
+                aria-hidden
+              >
+                {"›"}
+              </span>
+            )
+          )}
+        </div>
+      );
+    }
+
     // iPod-classic-js SelectableListItem: white row, blue gradient
     // selection highlight, no separator. Rows are compact (**21px**) with **15px** type so
     // titlebar + six rows fit inside the 150px screen (nano 6G/7G density).
@@ -68,8 +188,8 @@ export function MenuListItem({
           isSelected && !isLoading
             ? "ipod-modern-row-selected"
             : isLoading
-            ? "text-[#555] animate-pulse"
-            : "text-black"
+              ? "text-[#555] animate-pulse"
+              : "text-black"
         )}
       >
         <span className="flex min-h-0 min-w-0 flex-1 items-center mr-2">
@@ -96,7 +216,8 @@ export function MenuListItem({
             {value}
           </span>
         ) : (
-          showChevron && !isLoading && (
+          showChevron &&
+          !isLoading && (
             // Right-arrow chevron: thin and light grey when idle, white
             // when the row is selected — same affordance as the
             // arrow_right.svg used in iPod-classic-js.
@@ -131,8 +252,8 @@ export function MenuListItem({
             ? "bg-[#0a3667] text-[#c5e0f5] [text-shadow:1px_1px_0_rgba(0,0,0,0.15)]"
             : "bg-[#0a3667] text-[#8a9da9] [text-shadow:1px_1px_0_rgba(0,0,0,0.15)]"
           : isLoading
-          ? "text-[#0a3667] [text-shadow:1px_1px_0_rgba(0,0,0,0.15)] animate-pulse"
-          : "text-[#0a3667] hover:bg-[#c0d8f0] [text-shadow:1px_1px_0_rgba(0,0,0,0.15)]"
+            ? "text-[#0a3667] [text-shadow:1px_1px_0_rgba(0,0,0,0.15)] animate-pulse"
+            : "text-[#0a3667] hover:bg-[#c0d8f0] [text-shadow:1px_1px_0_rgba(0,0,0,0.15)]"
       )}
     >
       <span
@@ -153,7 +274,8 @@ export function MenuListItem({
           {value}
         </span>
       ) : (
-        showChevron && !isLoading && (
+        showChevron &&
+        !isLoading && (
           <span className="flex-shrink-0 text-[16px] leading-none">{">"}</span>
         )
       )}

--- a/src/apps/ipod/hooks/useAppleMusicLibrary.ts
+++ b/src/apps/ipod/hooks/useAppleMusicLibrary.ts
@@ -89,11 +89,29 @@ interface LibrarySongsResponse {
   };
 }
 
+function normalizePlaylistDescription(raw: unknown): string | undefined {
+  if (typeof raw === "string") {
+    const trimmed = raw.trim();
+    return trimmed.length > 0 ? trimmed : undefined;
+  }
+  if (raw && typeof raw === "object") {
+    const o = raw as { standard?: unknown; short?: unknown };
+    if (typeof o.standard === "string" && o.standard.trim()) {
+      return o.standard.trim();
+    }
+    if (typeof o.short === "string" && o.short.trim()) {
+      return o.short.trim();
+    }
+  }
+  return undefined;
+}
+
 interface AppleMusicLibraryPlaylistResource {
   id: string;
   type: string;
   attributes?: {
     name?: string;
+    description?: unknown;
     artwork?: {
       url?: string;
       width?: number;
@@ -279,6 +297,7 @@ function libraryPlaylistResourceToPlaylist(
     globalId: playParams?.globalId,
     name: attrs.name,
     artworkUrl: resolveArtworkUrl(attrs.artwork, 300),
+    description: normalizePlaylistDescription(attrs.description),
     trackCount: attrs.trackCount,
     canEdit: attrs.canEdit,
   };

--- a/src/apps/ipod/hooks/useIpodLogic.ts
+++ b/src/apps/ipod/hooks/useIpodLogic.ts
@@ -1958,18 +1958,22 @@ export function useIpodLogic({
         ];
       } else {
         const queueIds = playlistTracks.map((t) => t.id);
-        result[playlist.id] = playlistTracks.map((track, trackListIndex) => ({
-          label: track.title,
-          action: () =>
-            playAppleMusicTrackFromMenu(
-              track,
-              trackListIndex,
-              queueIds,
-              playlistTracks
-            ),
-          showChevron: false,
-          coverUrl: resolveTrackCoverUrl(track),
-        }));
+        result[playlist.id] = playlistTracks.map((track, trackListIndex) => {
+          const displayArtist = (track.albumArtist || track.artist)?.trim();
+          return {
+            label: track.title,
+            subtitle: displayArtist && displayArtist.length > 0 ? displayArtist : undefined,
+            action: () =>
+              playAppleMusicTrackFromMenu(
+                track,
+                trackListIndex,
+                queueIds,
+                playlistTracks
+              ),
+            showChevron: false,
+            coverUrl: resolveTrackCoverUrl(track),
+          };
+        });
       }
     }
     return result;
@@ -2005,6 +2009,7 @@ export function useIpodLogic({
               title: playlist.name,
               items: applePlaylistTrackMenuItemsByPlaylist[playlist.id] ?? EMPTY_IPOD_MENU_ITEMS,
               selectedIndex: 0,
+              modernMediaList: true,
             });
           },
           showChevron: true,

--- a/src/apps/ipod/hooks/useIpodLogic.ts
+++ b/src/apps/ipod/hooks/useIpodLogic.ts
@@ -63,7 +63,12 @@ import {
   getAlbumGroupingKey,
   resolveTrackCoverUrl,
 } from "../constants";
-import type { WheelArea, RotationDirection } from "../types";
+import type {
+  MenuHistoryEntry,
+  MenuItem,
+  WheelArea,
+  RotationDirection,
+} from "../types";
 import type { IpodInitialData } from "../../base/types";
 import type { CoverFlowRef } from "../components/CoverFlow";
 import type { MusicQuizRef } from "../components/MusicQuiz";
@@ -82,11 +87,7 @@ const IS_SAFARI =
 const IS_IOS_SAFARI = IS_IOS && IS_SAFARI;
 
 /** Stable fallback so `rebuildMenuItems` never returns a fresh `[]` per call. */
-const EMPTY_IPOD_MENU_ITEMS: {
-  label: string;
-  action: () => void;
-  showChevron: boolean;
-}[] = [];
+const EMPTY_IPOD_MENU_ITEMS: MenuItem[] = [];
 
 export interface UseIpodLogicOptions {
   isWindowOpen: boolean;
@@ -622,19 +623,7 @@ export function useIpodLogic({
   const setMenuDirection = useCallback((value: "forward" | "backward") => {
     dispatchMenuUi({ type: "setMenuDirection", value });
   }, []);
-  const [menuHistory, setMenuHistory] = useState<
-    {
-      title: string;
-      displayTitle?: string;
-      items: {
-        label: string;
-        action: () => void;
-        showChevron?: boolean;
-        value?: string;
-      }[];
-      selectedIndex: number;
-    }[]
-  >([]);
+  const [menuHistory, setMenuHistory] = useState<MenuHistoryEntry[]>([]);
   const setCameFromNowPlayingMenuItem = useCallback((value: boolean) => {
     dispatchMenuUi({ type: "setCameFromNowPlayingMenuItem", value });
   }, []);
@@ -1777,6 +1766,7 @@ export function useIpodLogic({
         )?.track ?? albumTracks[0]?.track ?? null;
         return {
           label: album,
+          subtitle: artist,
           action: () => {
             registerActivity();
             pushMenuChild({
@@ -1794,6 +1784,7 @@ export function useIpodLogic({
       result[artist] = [
         {
           label: allLabel,
+          subtitle: allSongsLabel,
           action: () => {
             registerActivity();
             pushMenuChild({
@@ -1920,6 +1911,7 @@ export function useIpodLogic({
                 title: artist,
                 items: artistMenuItemsByArtist[artist],
                 selectedIndex: 0,
+                modernMediaList: true,
               });
             },
             showChevron: true,
@@ -2005,6 +1997,7 @@ export function useIpodLogic({
           (firstTrackWithCover ? resolveTrackCoverUrl(firstTrackWithCover) : null);
         return {
           label: playlist.name,
+          subtitle: playlist.description,
           action: () => {
             registerActivity();
             requestPlaylistTracksIfNeeded(playlist.id);
@@ -2049,10 +2042,16 @@ export function useIpodLogic({
 
     const pushSubmenu = (
       title: string,
-      items: { label: string; action: () => void; showChevron: boolean }[]
+      items: MenuItem[],
+      options?: { modernMediaList?: boolean }
     ) => {
       registerActivity();
-      pushMenuChild({ title, items, selectedIndex: 0 });
+      pushMenuChild({
+        title,
+        items,
+        selectedIndex: 0,
+        ...options,
+      });
     };
 
     const coverFlowItem = {
@@ -2099,7 +2098,10 @@ export function useIpodLogic({
         },
         {
           label: playlistsLabel,
-          action: () => pushSubmenu(playlistsLabel, applePlaylistsMenuItems),
+          action: () =>
+            pushSubmenu(playlistsLabel, applePlaylistsMenuItems, {
+              modernMediaList: true,
+            }),
           showChevron: true,
         },
         {
@@ -2572,6 +2574,7 @@ export function useIpodLogic({
       restored.push({
         title: entry.title,
         displayTitle: entry.displayTitle,
+        modernMediaList: entry.modernMediaList,
         items: rebuilt,
         selectedIndex: safeIdx,
       });
@@ -2686,6 +2689,7 @@ export function useIpodLogic({
     const breadcrumb = menuHistory.map((menu, i) => ({
       title: menu.title,
       displayTitle: menu.displayTitle,
+      modernMediaList: menu.modernMediaList,
       selectedIndex:
         i === menuHistory.length - 1 ? selectedMenuItem : menu.selectedIndex,
     }));
@@ -2703,6 +2707,7 @@ export function useIpodLogic({
         (entry, i) =>
           entry.title === breadcrumb[i].title &&
           entry.displayTitle === breadcrumb[i].displayTitle &&
+          entry.modernMediaList === breadcrumb[i].modernMediaList &&
           entry.selectedIndex === breadcrumb[i].selectedIndex
       );
     if (!isSame) store.setIpodMenuBreadcrumb(breadcrumb);

--- a/src/apps/ipod/hooks/useIpodLogic.ts
+++ b/src/apps/ipod/hooks/useIpodLogic.ts
@@ -1596,18 +1596,23 @@ export function useIpodLogic({
     }
 
     const queueIds = appleMusicRecentlyAddedTracks.map((track) => track.id);
-    return appleMusicRecentlyAddedTracks.map((track, index) => ({
-      label: track.title,
-      action: () =>
-        playAppleMusicTrackFromMenu(
-          track,
-          index,
-          queueIds,
-          appleMusicRecentlyAddedTracks
-        ),
-      showChevron: false,
-      coverUrl: resolveTrackCoverUrl(track),
-    }));
+    return appleMusicRecentlyAddedTracks.map((track, index) => {
+      const displayArtist = (track.albumArtist || track.artist)?.trim();
+      return {
+        label: track.title,
+        subtitle:
+          displayArtist && displayArtist.length > 0 ? displayArtist : undefined,
+        action: () =>
+          playAppleMusicTrackFromMenu(
+            track,
+            index,
+            queueIds,
+            appleMusicRecentlyAddedTracks
+          ),
+        showChevron: false,
+        coverUrl: resolveTrackCoverUrl(track),
+      };
+    });
   }, [
     appleMusicRecentlyAddedTracks,
     isAppleMusicRecentlyAddedLoading,
@@ -1639,18 +1644,23 @@ export function useIpodLogic({
     }
 
     const queueIds = appleMusicFavoriteTracks.map((track) => track.id);
-    return appleMusicFavoriteTracks.map((track, index) => ({
-      label: track.title,
-      action: () =>
-        playAppleMusicTrackFromMenu(
-          track,
-          index,
-          queueIds,
-          appleMusicFavoriteTracks
-        ),
-      showChevron: false,
-      coverUrl: resolveTrackCoverUrl(track),
-    }));
+    return appleMusicFavoriteTracks.map((track, index) => {
+      const displayArtist = (track.albumArtist || track.artist)?.trim();
+      return {
+        label: track.title,
+        subtitle:
+          displayArtist && displayArtist.length > 0 ? displayArtist : undefined,
+        action: () =>
+          playAppleMusicTrackFromMenu(
+            track,
+            index,
+            queueIds,
+            appleMusicFavoriteTracks
+          ),
+        showChevron: false,
+        coverUrl: resolveTrackCoverUrl(track),
+      };
+    });
   }, [
     appleMusicFavoriteTracks,
     isAppleMusicFavoritesLoading,
@@ -2083,6 +2093,7 @@ export function useIpodLogic({
               title: recentlyAddedLabel,
               items: appleMusicRecentlyAddedMenuItems,
               selectedIndex: 0,
+              modernMediaList: true,
             });
             void loadAppleMusicRecentlyAdded();
           },
@@ -2096,6 +2107,7 @@ export function useIpodLogic({
               title: favoriteSongsLabel,
               items: appleMusicFavoritesMenuItems,
               selectedIndex: 0,
+              modernMediaList: true,
             });
             void loadAppleMusicFavorites();
           },

--- a/src/apps/ipod/hooks/useIpodLogic.ts
+++ b/src/apps/ipod/hooks/useIpodLogic.ts
@@ -2009,9 +2009,20 @@ export function useIpodLogic({
         const coverUrl =
           playlist.artworkUrl ??
           (firstTrackWithCover ? resolveTrackCoverUrl(firstTrackWithCover) : null);
+        const description = playlist.description?.trim();
+        const trackCountLine =
+          typeof playlist.trackCount === "number" && playlist.trackCount >= 0
+            ? t("apps.ipod.menuItems.playlistTrackCount", {
+                count: playlist.trackCount,
+              })
+            : undefined;
+        const subtitle =
+          description && description.length > 0
+            ? description
+            : trackCountLine;
         return {
           label: playlist.name,
-          subtitle: playlist.description,
+          subtitle,
           action: () => {
             registerActivity();
             requestPlaylistTracksIfNeeded(playlist.id);
@@ -2033,6 +2044,7 @@ export function useIpodLogic({
       registerActivity,
       requestPlaylistTracksIfNeeded,
       pushMenuChild,
+      menuLocale,
     ]
   );
 

--- a/src/apps/ipod/types.ts
+++ b/src/apps/ipod/types.ts
@@ -17,6 +17,12 @@ export interface MenuItem {
   action: () => void;
   showChevron?: boolean;
   value?: string;
+  /**
+   * Second line under `label` for modern **media** list layouts (square
+   * artwork + two-line rows). Ignored for classic rows and default
+   * single-line modern rows.
+   */
+  subtitle?: string | null;
   /** When true, the row renders as a non-interactive loading placeholder. */
   isLoading?: boolean;
   /**
@@ -37,6 +43,11 @@ export interface MenuHistoryEntry {
   displayTitle?: string;
   items: MenuItem[];
   selectedIndex: number;
+  /**
+   * Modern UI only: taller rows with thumbnail + primary/subtitle text.
+   * Used for playlist and per-artist album browses.
+   */
+  modernMediaList?: boolean;
 }
 
 // PIP Player props

--- a/src/lib/locales/de/translation.json
+++ b/src/lib/locales/de/translation.json
@@ -2327,6 +2327,8 @@
         "off": "Aus",
         "on": "Ein",
         "one": "Eins",
+        "playlistTrackCount_one": "{{count}} song",
+        "playlistTrackCount_other": "{{count}} songs",
         "playlists": "Playlists",
         "radio": "Radio",
         "recentlyAdded": "Zuletzt hinzugefügt",

--- a/src/lib/locales/en/translation.json
+++ b/src/lib/locales/en/translation.json
@@ -2005,7 +2005,9 @@
         "appleMusicSignOut": "Apple Music",
         "unconfigured": "Unconfigured",
         "signedIn": "Signed In",
-        "signedOut": "Signed Out"
+        "signedOut": "Signed Out",
+        "playlistTrackCount_one": "{{count}} song",
+        "playlistTrackCount_other": "{{count}} songs"
       },
       "musicQuiz": {
         "title": "Music Quiz",

--- a/src/lib/locales/es/translation.json
+++ b/src/lib/locales/es/translation.json
@@ -2327,6 +2327,8 @@
         "off": "Desactivado",
         "on": "Activado",
         "one": "Una",
+        "playlistTrackCount_one": "{{count}} song",
+        "playlistTrackCount_other": "{{count}} songs",
         "playlists": "Listas de reproducción",
         "radio": "Radio",
         "recentlyAdded": "Añadidas recientemente",

--- a/src/lib/locales/fr/translation.json
+++ b/src/lib/locales/fr/translation.json
@@ -2327,6 +2327,8 @@
         "off": "Désactivé",
         "on": "Activé",
         "one": "Un",
+        "playlistTrackCount_one": "{{count}} song",
+        "playlistTrackCount_other": "{{count}} songs",
         "playlists": "Playlists",
         "radio": "Radio",
         "recentlyAdded": "Ajouts récents",

--- a/src/lib/locales/it/translation.json
+++ b/src/lib/locales/it/translation.json
@@ -2327,6 +2327,8 @@
         "off": "Disattivo",
         "on": "Attivo",
         "one": "Uno",
+        "playlistTrackCount_one": "{{count}} song",
+        "playlistTrackCount_other": "{{count}} songs",
         "playlists": "Playlist",
         "radio": "Radio",
         "recentlyAdded": "Aggiunti di recente",

--- a/src/lib/locales/ja/translation.json
+++ b/src/lib/locales/ja/translation.json
@@ -2327,6 +2327,8 @@
         "off": "オフ",
         "on": "オン",
         "one": "1曲",
+        "playlistTrackCount_one": "{{count}} song",
+        "playlistTrackCount_other": "{{count}} songs",
         "playlists": "プレイリスト",
         "radio": "ラジオ",
         "recentlyAdded": "最近追加した項目",

--- a/src/lib/locales/ko/translation.json
+++ b/src/lib/locales/ko/translation.json
@@ -2327,6 +2327,8 @@
         "off": "끔",
         "on": "켬",
         "one": "하나",
+        "playlistTrackCount_one": "{{count}} song",
+        "playlistTrackCount_other": "{{count}} songs",
         "playlists": "플레이리스트",
         "radio": "라디오",
         "recentlyAdded": "최근 추가된 항목",

--- a/src/lib/locales/pt/translation.json
+++ b/src/lib/locales/pt/translation.json
@@ -2327,6 +2327,8 @@
         "off": "Desligado",
         "on": "Ligado",
         "one": "Uma",
+        "playlistTrackCount_one": "{{count}} song",
+        "playlistTrackCount_other": "{{count}} songs",
         "playlists": "Playlists",
         "radio": "Rádio",
         "recentlyAdded": "Adicionadas Recentemente",

--- a/src/lib/locales/ru/translation.json
+++ b/src/lib/locales/ru/translation.json
@@ -2327,6 +2327,8 @@
         "off": "Выкл.",
         "on": "Вкл.",
         "one": "Один",
+        "playlistTrackCount_one": "{{count}} song",
+        "playlistTrackCount_other": "{{count}} songs",
         "playlists": "Плейлисты",
         "radio": "Радио",
         "recentlyAdded": "Недавно добавленные",

--- a/src/lib/locales/zh-TW/translation.json
+++ b/src/lib/locales/zh-TW/translation.json
@@ -2327,6 +2327,8 @@
         "off": "關閉",
         "on": "開啟",
         "one": "單一",
+        "playlistTrackCount_one": "{{count}} song",
+        "playlistTrackCount_other": "{{count}} songs",
         "playlists": "播放清單",
         "radio": "廣播",
         "recentlyAdded": "最近加入",

--- a/src/stores/useIpodStore.ts
+++ b/src/stores/useIpodStore.ts
@@ -42,6 +42,8 @@ export interface AppleMusicPlaylist {
   globalId?: string;
   name: string;
   artworkUrl?: string;
+  /** Editorial / user-visible description when the API supplies one. */
+  description?: string;
   trackCount?: number;
   canEdit?: boolean;
 }
@@ -252,7 +254,12 @@ interface IpodData {
    * top-level menu.
    */
   ipodMenuBreadcrumb:
-    | { title: string; displayTitle?: string; selectedIndex: number }[]
+    | {
+        title: string;
+        displayTitle?: string;
+        selectedIndex: number;
+        modernMediaList?: boolean;
+      }[]
     | null;
   /**
    * Whether the iPod was last in menu mode (true) or Now Playing mode
@@ -606,14 +613,19 @@ export interface IpodState extends IpodData {
   /** Persist the user's current menu navigation breadcrumb. */
   setIpodMenuBreadcrumb: (
     breadcrumb:
-      | { title: string; displayTitle?: string; selectedIndex: number }[]
+      | {
+          title: string;
+          displayTitle?: string;
+          selectedIndex: number;
+          modernMediaList?: boolean;
+        }[]
       | null
   ) => void;
   /** Persist whether the iPod was last in menu mode. */
   setIpodMenuMode: (menuMode: boolean | null) => void;
 }
 
-const CURRENT_IPOD_STORE_VERSION = 36; // Persist new uiVariant ("classic" | "modern") screen skin
+const CURRENT_IPOD_STORE_VERSION = 37; // Breadcrumb may include modernMediaList for iPod media rows
 
 // Helper function to get unplayed track IDs from history
 function getUnplayedTrackIds(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Modern **Playlists** and **per-artist** album browses now use a compact double-decker row: square thumbnail, bold primary line, and a muted secondary line. Classic skin and other modern menus keep the existing single-line layout.

## Follow-up UX

- **Modern media lists** (playlists + per-artist albums) keep the menu **full width** — the right-hand Ken Burns split is suppressed since each row already shows artwork.
- **Subtitle** sits closer to the title (`leading-[1.05]`, no extra top margin).

## Details

- **Playlists:** primary = playlist name, secondary = playlist description when the Apple Music library resource includes one (normalized from string or `standard` / `short` editorial-style objects).
- **Artist → albums:** primary = album title, secondary = artist name; the **All** row uses localized **All Songs** as the subtitle for a consistent two-line block.
- **Menu history** gains optional `modernMediaList`, persisted on the slim `ipodMenuBreadcrumb` (store version **37**) so reopening the app restores the taller row virtualizer geometry.
- **MenuListItem** handles `mediaRow` + `subtitle` + `thumbnailUrl` for modern UI only; virtualization row height is **46px** for these menus vs **21px** for default modern lists.

## Testing

- `bun run build` (tsc + vite) — pass  
- `bun run test:unit` — pass  

## Files

`src/apps/ipod/types.ts`, `src/apps/ipod/hooks/useIpodLogic.ts`, `src/apps/ipod/hooks/useAppleMusicLibrary.ts`, `src/apps/ipod/components/screen/MenuListItem.tsx`, `src/apps/ipod/components/IpodScreen.tsx`, `src/stores/useIpodStore.ts`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3547290e-a0f2-4517-b4f4-167d96531cd7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3547290e-a0f2-4517-b4f4-167d96531cd7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

