### PR TITLE
fix(ipod): restore lyric offset for Apple Music fullscreen and lyrics timing

### DIFF
--- a/src/apps/ipod/components/FullScreenPortal.tsx
+++ b/src/apps/ipod/components/FullScreenPortal.tsx
@@ -373,11 +373,20 @@ export function FullScreenPortal({
         // Offset adjustment: [ = lyrics earlier (negative), ] = lyrics later (positive)
         const delta = e.key === "[" ? -50 : 50;
         const store = useIpodStore.getState();
-        const currentTrack = store.currentSongId
-          ? store.tracks.find((t) => t.id === store.currentSongId)
-          : store.tracks[0];
+        // Must match `adjustLyricOffset` / `setLyricOffset`: they index the active
+        // library slice (`appleMusicTracks` when Apple Music is selected), not
+        // always `tracks` (YouTube). Using YouTube ids here was a regression where
+        // fullscreen `[` / `]` updated the wrong row or no-op'd out of range.
+        const isApple = store.librarySource === "appleMusic";
+        const activeSongId = isApple
+          ? store.appleMusicCurrentSongId
+          : store.currentSongId;
+        const sourceTracks = isApple ? store.appleMusicTracks : store.tracks;
+        const currentTrack = activeSongId
+          ? sourceTracks.find((t) => t.id === activeSongId)
+          : sourceTracks[0];
         const currentTrackIndex = currentTrack
-          ? store.tracks.findIndex((t) => t.id === currentTrack.id)
+          ? sourceTracks.findIndex((t) => t.id === currentTrack.id)
           : -1;
         if (currentTrackIndex >= 0) {
           store.adjustLyricOffset(currentTrackIndex, delta);

--- a/src/apps/ipod/components/FullScreenPortal.tsx
+++ b/src/apps/ipod/components/FullScreenPortal.tsx
@@ -373,10 +373,6 @@ export function FullScreenPortal({
         // Offset adjustment: [ = lyrics earlier (negative), ] = lyrics later (positive)
         const delta = e.key === "[" ? -50 : 50;
         const store = useIpodStore.getState();
-        // Must match `adjustLyricOffset` / `setLyricOffset`: they index the active
-        // library slice (`appleMusicTracks` when Apple Music is selected), not
-        // always `tracks` (YouTube). Using YouTube ids here was a regression where
-        // fullscreen `[` / `]` updated the wrong row or no-op'd out of range.
         const isApple = store.librarySource === "appleMusic";
         const activeSongId = isApple
           ? store.appleMusicCurrentSongId

--- a/src/apps/ipod/hooks/useIpodLogic.ts
+++ b/src/apps/ipod/hooks/useIpodLogic.ts
@@ -3740,15 +3740,14 @@ export function useIpodLogic({
   const { title: lyricsTitle, artist: lyricsArtist, songId: lyricsSongId } =
     lyricsMetadata;
 
-  const lyricsTimingOffsetMs = useMemo(() => {
-    if (
-      isAppleMusicCollectionTrack(currentTrack) &&
-      appleMusicKitNowPlaying?.id
-    ) {
-      return 0;
-    }
-    return currentTrack?.lyricOffset ?? 0;
-  }, [currentTrack, appleMusicKitNowPlaying?.id]);
+  // Use the playing row's `lyricOffset` for lyrics timing (including Apple Music
+  // station/playlist shells). Forcing 0 for collection + live MusicKit metadata
+  // made user offsets never apply to `useLyrics` while fullscreen still added the
+  // offset in `LyricsDisplay`, which broke sync / status feedback.
+  const lyricsTimingOffsetMs = useMemo(
+    () => currentTrack?.lyricOffset ?? 0,
+    [currentTrack?.id, currentTrack?.lyricOffset]
+  );
 
   const fullScreenLyricsControls = useLyrics({
     songId: lyricsSongId,

--- a/src/apps/ipod/hooks/useIpodLogic.ts
+++ b/src/apps/ipod/hooks/useIpodLogic.ts
@@ -3740,10 +3740,6 @@ export function useIpodLogic({
   const { title: lyricsTitle, artist: lyricsArtist, songId: lyricsSongId } =
     lyricsMetadata;
 
-  // Use the playing row's `lyricOffset` for lyrics timing (including Apple Music
-  // station/playlist shells). Forcing 0 for collection + live MusicKit metadata
-  // made user offsets never apply to `useLyrics` while fullscreen still added the
-  // offset in `LyricsDisplay`, which broke sync / status feedback.
   const lyricsTimingOffsetMs = useMemo(
     () => currentTrack?.lyricOffset ?? 0,
     [currentTrack?.id, currentTrack?.lyricOffset]

--- a/src/apps/karaoke/hooks/useKaraokeLogic.ts
+++ b/src/apps/karaoke/hooks/useKaraokeLogic.ts
@@ -104,9 +104,6 @@ export function useKaraokeLogic({
     setDisplayMode: s.setDisplayMode,
   }));
 
-  // Karaoke always reads/writes the YouTube library slice (`tracks`), even when
-  // the iPod UI is left on Apple Music — offsets and metadata must not bleed
-  // across sources.
   const setLyricOffset = useCallback(
     (index: number, offsetMs: number) =>
       useIpodStore.getState().setLyricOffset(index, offsetMs, "youtube"),

--- a/src/apps/karaoke/hooks/useKaraokeLogic.ts
+++ b/src/apps/karaoke/hooks/useKaraokeLogic.ts
@@ -88,7 +88,6 @@ export function useKaraokeLogic({
     refreshLyrics,
     setTrackLyricsSource,
     clearTrackLyricsSource,
-    setLyricOffset,
     addTrackFromVideoId,
     setDisplayMode,
   } = useIpodStoreShallow((s) => ({
@@ -101,10 +100,23 @@ export function useKaraokeLogic({
     refreshLyrics: s.refreshLyrics,
     setTrackLyricsSource: s.setTrackLyricsSource,
     clearTrackLyricsSource: s.clearTrackLyricsSource,
-    setLyricOffset: s.setLyricOffset,
     addTrackFromVideoId: s.addTrackFromVideoId,
     setDisplayMode: s.setDisplayMode,
   }));
+
+  // Karaoke always reads/writes the YouTube library slice (`tracks`), even when
+  // the iPod UI is left on Apple Music — offsets and metadata must not bleed
+  // across sources.
+  const setLyricOffset = useCallback(
+    (index: number, offsetMs: number) =>
+      useIpodStore.getState().setLyricOffset(index, offsetMs, "youtube"),
+    []
+  );
+  const adjustLyricOffset = useCallback(
+    (index: number, delta: number) =>
+      useIpodStore.getState().adjustLyricOffset(index, delta, "youtube"),
+    []
+  );
 
   // Library update checker
   const { manualSync } = useLibraryUpdateChecker(
@@ -1567,7 +1579,7 @@ export function useKaraokeLogic({
       } else if (e.key === "[" || e.key === "]") {
         // Offset adjustment: [ = lyrics earlier (negative), ] = lyrics later (positive)
         const delta = e.key === "[" ? -50 : 50;
-        useIpodStore.getState().adjustLyricOffset(currentIndex, delta);
+        useIpodStore.getState().adjustLyricOffset(currentIndex, delta, "youtube");
         const newOffset = (currentTrack?.lyricOffset ?? 0) + delta;
         const sign = newOffset > 0 ? "+" : newOffset < 0 ? "" : "";
         showStatus(`${t("apps.ipod.status.offset")} ${sign}${(newOffset / 1000).toFixed(2)}s`);
@@ -1869,8 +1881,6 @@ export function useKaraokeLogic({
     setLyricOffset,
     isXpTheme,
     getCurrentKaraokeTrack,
-    adjustLyricOffset: (index: number, delta: number) => {
-      useIpodStore.getState().adjustLyricOffset(index, delta);
-    },
+    adjustLyricOffset,
   };
 }

--- a/src/stores/useIpodStore.ts
+++ b/src/stores/useIpodStore.ts
@@ -502,24 +502,13 @@ export interface IpodState extends IpodData {
   clearLyricsCache: () => void;
   /** Set the furigana map for current lyrics */
   setCurrentFuriganaMap: (map: Record<string, FuriganaSegment[]> | null) => void;
-  /**
-   * Adjust the lyric offset (in ms) for the track at the given index.
-   * @param librarySlice When set (e.g. `"youtube"` for Karaoke), mutates that
-   * slice regardless of the iPod's active `librarySource`. Omit to follow the
-   * active source (iPod / fullscreen).
-   */
+  /** Optional `librarySlice` targets `tracks` or `appleMusicTracks` regardless of active iPod mode (Karaoke passes `"youtube"`). */
   adjustLyricOffset: (
     trackIndex: number,
     deltaMs: number,
     librarySlice?: LibrarySource
   ) => void;
-  /**
-   * Set the lyric offset (in ms) for the track at the given index.
-   * @param librarySlice When set (e.g. `"youtube"` for Karaoke), mutates that
-   * slice regardless of the iPod's active `librarySource`. Omit to follow the
-   * active source (iPod / fullscreen). Same semantics as `adjustLyricOffset`'s
-   * optional third argument.
-   */
+  /** Same optional `librarySlice` as `adjustLyricOffset`. */
   setLyricOffset: (
     trackIndex: number,
     offsetMs: number,

--- a/src/stores/useIpodStore.ts
+++ b/src/stores/useIpodStore.ts
@@ -502,10 +502,29 @@ export interface IpodState extends IpodData {
   clearLyricsCache: () => void;
   /** Set the furigana map for current lyrics */
   setCurrentFuriganaMap: (map: Record<string, FuriganaSegment[]> | null) => void;
-  /** Adjust the lyric offset (in ms) for the track at the given index. */
-  adjustLyricOffset: (trackIndex: number, deltaMs: number) => void;
-  /** Set the lyric offset (in ms) for the track at the given index to an absolute value. */
-  setLyricOffset: (trackIndex: number, offsetMs: number) => void;
+  /**
+   * Adjust the lyric offset (in ms) for the track at the given index.
+   * @param librarySlice When set (e.g. `"youtube"` for Karaoke), mutates that
+   * slice regardless of the iPod's active `librarySource`. Omit to follow the
+   * active source (iPod / fullscreen).
+   */
+  adjustLyricOffset: (
+    trackIndex: number,
+    deltaMs: number,
+    librarySlice?: LibrarySource
+  ) => void;
+  /**
+   * Set the lyric offset (in ms) for the track at the given index.
+   * @param librarySlice When set (e.g. `"youtube"` for Karaoke), mutates that
+   * slice regardless of the iPod's active `librarySource`. Omit to follow the
+   * active source (iPod / fullscreen). Same semantics as `adjustLyricOffset`'s
+   * optional third argument.
+   */
+  setLyricOffset: (
+    trackIndex: number,
+    offsetMs: number,
+    librarySlice?: LibrarySource
+  ) => void;
   /** Set lyrics alignment mode */
   setLyricsAlignment: (alignment: LyricsAlignment) => void;
   /** Set lyrics font style */
@@ -1215,13 +1234,12 @@ export const useIpodStore = create<IpodState>()(
         }));
       },
       setCurrentFuriganaMap: (map) => set({ currentFuriganaMap: map }),
-      adjustLyricOffset: (trackIndex, deltaMs) => {
+      adjustLyricOffset: (trackIndex, deltaMs, librarySlice) => {
         // Validate before calling set() to avoid unnecessary state updates
         const state = get();
+        const slice = librarySlice ?? state.librarySource;
         const sourceTracks =
-          state.librarySource === "appleMusic"
-            ? state.appleMusicTracks
-            : state.tracks;
+          slice === "appleMusic" ? state.appleMusicTracks : state.tracks;
         if (
           trackIndex < 0 ||
           trackIndex >= sourceTracks.length ||
@@ -1233,7 +1251,7 @@ export const useIpodStore = create<IpodState>()(
         const current = sourceTracks[trackIndex];
         const newOffset = (current.lyricOffset || 0) + deltaMs;
 
-        if (state.librarySource === "appleMusic") {
+        if (slice === "appleMusic") {
           set((s) => ({
             appleMusicTracks: s.appleMusicTracks.map((track, i) =>
               i === trackIndex ? { ...track, lyricOffset: newOffset } : track
@@ -1251,13 +1269,12 @@ export const useIpodStore = create<IpodState>()(
         // and Apple Music (`am:<id>`) keys via the relaxed validator.
         debouncedSaveLyricOffset(current.id, newOffset);
       },
-      setLyricOffset: (trackIndex, offsetMs) => {
+      setLyricOffset: (trackIndex, offsetMs, librarySlice) => {
         // Validate before calling set() to avoid unnecessary state updates
         const state = get();
+        const slice = librarySlice ?? state.librarySource;
         const sourceTracks =
-          state.librarySource === "appleMusic"
-            ? state.appleMusicTracks
-            : state.tracks;
+          slice === "appleMusic" ? state.appleMusicTracks : state.tracks;
         if (
           trackIndex < 0 ||
           trackIndex >= sourceTracks.length ||
@@ -1268,7 +1285,7 @@ export const useIpodStore = create<IpodState>()(
 
         const trackId = sourceTracks[trackIndex].id;
 
-        if (state.librarySource === "appleMusic") {
+        if (slice === "appleMusic") {
           set((s) => ({
             appleMusicTracks: s.appleMusicTracks.map((track, i) =>
               i === trackIndex ? { ...track, lyricOffset: offsetMs } : track

--- a/tests/test-ipod-apple-music.test.ts
+++ b/tests/test-ipod-apple-music.test.ts
@@ -417,6 +417,32 @@ describe("useIpodStore Apple Music slice", () => {
     expect(useIpodStore.getState().tracks).toEqual([]);
   });
 
+  test("adjustLyricOffset(..., 'youtube') updates the YouTube slice while Apple Music is active (Karaoke)", () => {
+    useIpodStore.setState({
+      librarySource: "appleMusic",
+      tracks: [
+        {
+          id: "dQw4w9WgXcQ",
+          url: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+          title: "YT",
+          lyricOffset: 100,
+        },
+      ],
+      appleMusicTracks: [
+        {
+          id: "am:1",
+          url: "applemusic:1",
+          title: "One",
+          source: "appleMusic",
+          lyricOffset: 0,
+        },
+      ],
+    });
+    useIpodStore.getState().adjustLyricOffset(0, 50, "youtube");
+    expect(useIpodStore.getState().tracks[0].lyricOffset).toBe(150);
+    expect(useIpodStore.getState().appleMusicTracks[0].lyricOffset).toBe(0);
+  });
+
   test("setAppleMusicTracks preserves active contextual queue tracks", () => {
     useIpodStore.setState({
       appleMusicTracks: [


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- **Fullscreen `[` / `]`**: Resolve the playing row from the **active** library slice (`appleMusicTracks` + `appleMusicCurrentSongId` when Apple Music is selected), matching `adjustLyricOffset` so fullscreen offset keys work in Apple Music mode.
- **`useLyrics` timing**: Stop forcing lyric offset to `0` for Apple Music station/playlist shells when MusicKit reports a live item — that prevented `useLyrics` from respecting `lyricOffset` while the lyrics overlay still did.
- **Karaoke vs iPod source**: Karaoke only ever uses the YouTube `tracks` slice, but `adjustLyricOffset` / `setLyricOffset` previously followed global `librarySource`, so with the iPod left on Apple Music, Karaoke offset adjustments mutated the wrong rows. The store now accepts an optional `librarySlice` (`"youtube"` | `"appleMusic"`); Karaoke always passes `"youtube"`.

## Testing

- `bun run build`
- `bun test tests/test-ipod-apple-music.test.ts` (includes regression: Apple Music active + `adjustLyricOffset(..., "youtube")` only touches `tracks`)

No UI video: logic-only fixes; build + targeted unit suite provide coverage.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e9f738ee-f7e5-4954-819a-cb93856b1d28"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e9f738ee-f7e5-4954-819a-cb93856b1d28"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

