### PR TITLE
Karaoke: Apple Music library + MusicKit playback (iPod parity)

### DIFF
--- a/src/apps/karaoke/components/KaraokeAppComponent.tsx
+++ b/src/apps/karaoke/components/KaraokeAppComponent.tsx
@@ -1,6 +1,8 @@
 import { useCallback, useMemo } from "react";
+import type { RefObject } from "react";
 import { AnimatePresence, motion } from "framer-motion";
 import ReactPlayer from "react-player";
+import { AppleMusicPlayerBridge } from "@/apps/ipod/components/AppleMusicPlayerBridge";
 import { cn } from "@/lib/utils";
 import { AppProps, KaraokeInitialData } from "../../base/types";
 import { WindowFrame } from "@/components/layout/WindowFrame";
@@ -40,6 +42,55 @@ import { WaterBackground } from "@/components/shared/WaterBackground";
 import { PLAYER_PROGRESS_INTERVAL_MS } from "@/apps/ipod/constants";
 import { useChatsStore } from "@/stores/useChatsStore";
 import { useShallow } from "zustand/react/shallow";
+import { useKaraokeStore } from "@/stores/useKaraokeStore";
+import type { Track, AppleMusicKitNowPlaying } from "@/stores/useIpodStore";
+import type { AppleMusicPlayerBridgeHandle } from "@/apps/ipod/components/AppleMusicPlayerBridge";
+
+function KaraokeAppleMusicBridgeHost({
+  bridgeRef,
+  currentTrack,
+  playing,
+  progressEnabled,
+  ipodVolume,
+  onProgress,
+  onDuration,
+  onPlay,
+  onPause,
+  onEnded,
+  onReady,
+  setAppleMusicKitNowPlaying,
+}: {
+  bridgeRef: RefObject<AppleMusicPlayerBridgeHandle | null>;
+  currentTrack: Track;
+  playing: boolean;
+  progressEnabled: boolean;
+  ipodVolume: number;
+  onProgress?: (state: { playedSeconds: number }) => void;
+  onDuration?: (duration: number) => void;
+  onPlay?: () => void;
+  onPause?: () => void;
+  onEnded?: () => void;
+  onReady?: () => void;
+  setAppleMusicKitNowPlaying: (metadata: AppleMusicKitNowPlaying | null) => void;
+}) {
+  const elapsedTime = useKaraokeStore((s) => s.elapsedTime);
+  return (
+    <AppleMusicPlayerBridge
+      ref={bridgeRef as unknown as React.RefObject<never>}
+      currentTrack={currentTrack}
+      playing={playing}
+      resumeAtSeconds={elapsedTime}
+      volume={ipodVolume * useAudioSettingsStore.getState().masterVolume}
+      onProgress={progressEnabled ? onProgress : undefined}
+      onDuration={progressEnabled ? onDuration : undefined}
+      onPlay={progressEnabled ? onPlay : undefined}
+      onPause={progressEnabled ? onPause : undefined}
+      onEnded={progressEnabled ? onEnded : undefined}
+      onReady={progressEnabled ? onReady : undefined}
+      onNowPlayingItemChange={setAppleMusicKitNowPlaying}
+    />
+  );
+}
 
 export function KaraokeAppComponent({
   isWindowOpen,
@@ -56,6 +107,11 @@ export function KaraokeAppComponent({
     translatedHelpItems,
     tracks,
     currentIndex,
+    coverFlowCurrentIndex,
+    librarySource,
+    isAppleMusicPlaybackTrack,
+    lyricsQuery,
+    setAppleMusicKitNowPlaying,
     loopCurrent,
     loopAll,
     isShuffled,
@@ -112,6 +168,8 @@ export function KaraokeAppComponent({
     LONG_PRESS_MOVE_THRESHOLD,
     fullScreenPlayerRef,
     playerRef,
+    appleMusicBridgeWindowRef,
+    appleMusicBridgeFullscreenRef,
     lyricsPlaybackSyncRef,
     duration,
     setDuration,
@@ -141,6 +199,7 @@ export function KaraokeAppComponent({
     closeSyncMode,
     handleTrackEnd,
     handleProgress,
+    handleDuration,
     handlePlay,
     handlePause,
     handleMainPlayerPause,
@@ -238,7 +297,7 @@ export function KaraokeAppComponent({
       handleNext();
       if (!isListenSessionRemoteOnly) {
         setTimeout(() => {
-          const newIndex = (currentIndex + 1) % tracks.length;
+          const newIndex = (coverFlowCurrentIndex + 1) % tracks.length;
           const newTrack = tracks[newIndex];
           if (newTrack) {
             const artistInfo = newTrack.artist ? ` - ${newTrack.artist}` : "";
@@ -248,7 +307,7 @@ export function KaraokeAppComponent({
       }
     }
   }, [
-    currentIndex,
+    coverFlowCurrentIndex,
     handleNext,
     isListenSessionRemoteOnly,
     isOffline,
@@ -264,7 +323,8 @@ export function KaraokeAppComponent({
       handlePrevious();
       if (!isListenSessionRemoteOnly) {
         setTimeout(() => {
-          const newIndex = currentIndex === 0 ? tracks.length - 1 : currentIndex - 1;
+          const newIndex =
+            coverFlowCurrentIndex === 0 ? tracks.length - 1 : coverFlowCurrentIndex - 1;
           const newTrack = tracks[newIndex];
           if (newTrack) {
             const artistInfo = newTrack.artist ? ` - ${newTrack.artist}` : "";
@@ -274,7 +334,7 @@ export function KaraokeAppComponent({
       }
     }
   }, [
-    currentIndex,
+    coverFlowCurrentIndex,
     handlePrevious,
     isListenSessionRemoteOnly,
     isOffline,
@@ -310,7 +370,7 @@ export function KaraokeAppComponent({
       onRefreshLyrics={handleRefreshLyrics}
       onAdjustTiming={() => setIsSyncModeOpen(true)}
       tracks={tracks}
-      currentIndex={currentIndex}
+      currentTrackId={currentTrack?.id ?? null}
       onToggleCoverFlow={handleToggleCoverFlow}
       onStartListenSession={handleStartListenSession}
       onJoinListenSession={() => setIsJoinListenDialogOpen(true)}
@@ -461,47 +521,67 @@ export function KaraokeAppComponent({
               }
             >
               <div className="w-full h-[calc(100%+400px)] mt-[-200px]">
-                <ReactPlayer
-                  ref={playerRef}
-                  url={currentTrack.url}
-                  playing={isPlaying && !isFullScreen && !isListenSessionRemoteOnly}
-                  width="100%"
-                  height="100%"
-                  volume={ipodVolume * useAudioSettingsStore.getState().masterVolume}
-                  loop={loopCurrent}
-                  onEnded={handleTrackEnd}
-                  onProgress={handleProgress}
-                  onDuration={setDuration}
-                  progressInterval={PLAYER_PROGRESS_INTERVAL_MS}
-                  onPlay={handlePlay}
-                  onPause={handleMainPlayerPause}
-                  onReady={!isFullScreen ? handleReady : undefined}
-                  style={{ pointerEvents: "none" }}
-                  config={{
-                    youtube: {
-                      playerVars: {
-                        modestbranding: 1,
-                        rel: 0,
-                        showinfo: 0,
-                        iv_load_policy: 3,
-                        cc_load_policy: 0,
-                        fs: 0,
-                        playsinline: 1,
-                        enablejsapi: 1,
-                        origin: window.location.origin,
-                        controls: 0,
+                {isAppleMusicPlaybackTrack ? (
+                  <KaraokeAppleMusicBridgeHost
+                    bridgeRef={appleMusicBridgeWindowRef}
+                    currentTrack={currentTrack}
+                    playing={isPlaying && !isFullScreen && !isListenSessionRemoteOnly}
+                    progressEnabled={!isFullScreen}
+                    ipodVolume={ipodVolume}
+                    onProgress={handleProgress}
+                    onDuration={handleDuration}
+                    onPlay={handlePlay}
+                    onPause={handleMainPlayerPause}
+                    onEnded={handleTrackEnd}
+                    onReady={!isFullScreen ? handleReady : undefined}
+                    setAppleMusicKitNowPlaying={setAppleMusicKitNowPlaying}
+                  />
+                ) : (
+                  <ReactPlayer
+                    ref={playerRef}
+                    url={currentTrack.url}
+                    playing={isPlaying && !isFullScreen && !isListenSessionRemoteOnly}
+                    width="100%"
+                    height="100%"
+                    volume={ipodVolume * useAudioSettingsStore.getState().masterVolume}
+                    loop={loopCurrent}
+                    onEnded={handleTrackEnd}
+                    onProgress={handleProgress}
+                    onDuration={setDuration}
+                    progressInterval={PLAYER_PROGRESS_INTERVAL_MS}
+                    onPlay={handlePlay}
+                    onPause={handleMainPlayerPause}
+                    onReady={!isFullScreen ? handleReady : undefined}
+                    style={{ pointerEvents: "none" }}
+                    config={{
+                      youtube: {
+                        playerVars: {
+                          modestbranding: 1,
+                          rel: 0,
+                          showinfo: 0,
+                          iv_load_policy: 3,
+                          cc_load_policy: 0,
+                          fs: 0,
+                          playsinline: 1,
+                          enablejsapi: 1,
+                          origin: window.location.origin,
+                          controls: 0,
+                        },
+                        embedOptions: {
+                          referrerPolicy: "strict-origin-when-cross-origin",
+                        },
                       },
-                      embedOptions: {
-                        referrerPolicy: "strict-origin-when-cross-origin",
-                      },
-                    },
-                  }}
-                />
+                    }}
+                  />
+                )}
               </div>
             </div>
           ) : showEmptyLibrary ? (
             <div className="absolute inset-0 z-[1]">
-              <KaraokeLibraryEmptyState onAddSongs={handleAddSong} />
+              <KaraokeLibraryEmptyState
+                onAddSongs={handleAddSong}
+                librarySource={librarySource}
+              />
             </div>
           ) : (
             <div className="absolute inset-0 flex items-center justify-center text-white/50 font-geneva-12">
@@ -585,6 +665,7 @@ export function KaraokeAppComponent({
 
           <KaraokeLyricsPlaybackProvider
             currentTrack={currentTrack}
+            lyricsQuery={lyricsQuery}
             lyricsFont={lyricsFont}
             romanization={romanization}
             lyricsTranslationLanguage={lyricsTranslationLanguage}
@@ -641,7 +722,7 @@ export function KaraokeAppComponent({
               <CoverFlow
                 ref={coverFlowRef}
                 tracks={tracks}
-                currentIndex={currentIndex}
+                currentIndex={coverFlowCurrentIndex}
                 onSelectTrack={handleCoverFlowSelectTrack}
                 onExit={() => setIsCoverFlowOpen(false)}
                 onRotation={handleCoverFlowRotation}
@@ -650,6 +731,7 @@ export function KaraokeAppComponent({
                 isPlaying={isPlaying}
                 onTogglePlay={handlePlayPause}
                 onPlayTrackInPlace={handleCoverFlowPlayInPlace}
+                groupAppleMusicAlbums={librarySource === "appleMusic"}
               />
             </div>
           )}
@@ -786,9 +868,9 @@ export function KaraokeAppComponent({
           isOpen={isShareDialogOpen}
           onClose={() => setIsShareDialogOpen(false)}
           itemType="Song"
-          itemIdentifier={tracks[currentIndex]?.id || ""}
-          title={tracks[currentIndex]?.title}
-          details={tracks[currentIndex]?.artist}
+          itemIdentifier={currentTrack?.id || ""}
+          title={currentTrack?.title}
+          details={currentTrack?.artist}
           generateShareUrl={karaokeGenerateShareUrl}
         />
         {currentTrack && (
@@ -834,6 +916,7 @@ export function KaraokeAppComponent({
       {isFullScreen && (
         <KaraokeLyricsPlaybackProvider
           currentTrack={currentTrack}
+          lyricsQuery={lyricsQuery}
           lyricsFont={lyricsFont}
           romanization={romanization}
           lyricsTranslationLanguage={lyricsTranslationLanguage}
@@ -925,44 +1008,63 @@ export function KaraokeAppComponent({
                       top: "calc(clamp(240px, 30dvh, 400px) * -1)",
                     }}
                   >
-                    {currentTrack && (
-                      <div className="w-full h-full pointer-events-none">
-                        <ReactPlayer
-                          ref={fullScreenPlayerRef}
-                          url={currentTrack.url}
-                          playing={isPlaying && isFullScreen && !isListenSessionRemoteOnly}
-                          controls
-                          width="100%"
-                          height="100%"
-                          volume={ipodVolume * useAudioSettingsStore.getState().masterVolume}
-                          loop={loopCurrent}
-                          onEnded={handleTrackEnd}
-                          onProgress={handleProgress}
-                          progressInterval={PLAYER_PROGRESS_INTERVAL_MS}
-                          onPlay={handlePlay}
-                          onPause={handlePause}
-                          onReady={isFullScreen ? handleReady : undefined}
-                          config={{
-                            youtube: {
-                              playerVars: {
-                                modestbranding: 1,
-                                rel: 0,
-                                showinfo: 0,
-                                iv_load_policy: 3,
-                                cc_load_policy: 0,
-                                fs: 1,
-                                playsinline: 1,
-                                enablejsapi: 1,
-                                origin: window.location.origin,
+                    {currentTrack &&
+                      (isAppleMusicPlaybackTrack ? (
+                        <div className="w-full h-full pointer-events-none">
+                          <KaraokeAppleMusicBridgeHost
+                            bridgeRef={appleMusicBridgeFullscreenRef}
+                            currentTrack={currentTrack}
+                            playing={isPlaying && isFullScreen && !isListenSessionRemoteOnly}
+                            progressEnabled={isFullScreen}
+                            ipodVolume={ipodVolume}
+                            onProgress={handleProgress}
+                            onDuration={handleDuration}
+                            onPlay={handlePlay}
+                            onPause={handlePause}
+                            onEnded={handleTrackEnd}
+                            onReady={isFullScreen ? handleReady : undefined}
+                            setAppleMusicKitNowPlaying={setAppleMusicKitNowPlaying}
+                          />
+                        </div>
+                      ) : (
+                        <div className="w-full h-full pointer-events-none">
+                          <ReactPlayer
+                            ref={fullScreenPlayerRef}
+                            url={currentTrack.url}
+                            playing={isPlaying && isFullScreen && !isListenSessionRemoteOnly}
+                            controls
+                            width="100%"
+                            height="100%"
+                            volume={ipodVolume * useAudioSettingsStore.getState().masterVolume}
+                            loop={loopCurrent}
+                            onEnded={handleTrackEnd}
+                            onProgress={handleProgress}
+                            onDuration={handleDuration}
+                            progressInterval={PLAYER_PROGRESS_INTERVAL_MS}
+                            onPlay={handlePlay}
+                            onPause={handlePause}
+                            onReady={isFullScreen ? handleReady : undefined}
+                            config={{
+                              youtube: {
+                                playerVars: {
+                                  modestbranding: 1,
+                                  rel: 0,
+                                  showinfo: 0,
+                                  iv_load_policy: 3,
+                                  cc_load_policy: 0,
+                                  fs: 1,
+                                  playsinline: 1,
+                                  enablejsapi: 1,
+                                  origin: window.location.origin,
+                                },
+                                embedOptions: {
+                                  referrerPolicy: "strict-origin-when-cross-origin",
+                                },
                               },
-                              embedOptions: {
-                                referrerPolicy: "strict-origin-when-cross-origin",
-                              },
-                            },
-                          }}
-                        />
-                      </div>
-                    )}
+                            }}
+                          />
+                        </div>
+                      ))}
                   </div>
                 </div>
 
@@ -1041,7 +1143,10 @@ export function KaraokeAppComponent({
 
                 {showEmptyLibrary && (
                   <div className="absolute inset-0 z-[22] bg-black">
-                    <KaraokeLibraryEmptyState onAddSongs={handleAddSong} />
+                    <KaraokeLibraryEmptyState
+                onAddSongs={handleAddSong}
+                librarySource={librarySource}
+              />
                   </div>
                 )}
 

--- a/src/apps/karaoke/components/KaraokeLibraryEmptyState.tsx
+++ b/src/apps/karaoke/components/KaraokeLibraryEmptyState.tsx
@@ -1,3 +1,4 @@
+import type { LibrarySource } from "@/stores/useIpodStore";
 import type { CSSProperties, MouseEvent } from "react";
 import { useTranslation } from "react-i18next";
 import { cn } from "@/lib/utils";
@@ -25,11 +26,14 @@ function KaraokeToolbarShine() {
 
 interface KaraokeLibraryEmptyStateProps {
   onAddSongs: () => void;
+  /** When Apple Music is the active iPod library, prompt to use iPod to load music. */
+  librarySource?: LibrarySource;
   className?: string;
 }
 
 export function KaraokeLibraryEmptyState({
   onAddSongs,
+  librarySource = "youtube",
   className,
 }: KaraokeLibraryEmptyStateProps) {
   const { t } = useTranslation();
@@ -81,23 +85,27 @@ export function KaraokeLibraryEmptyState({
           {t("apps.karaoke.emptyLibrary.title")}
         </p>
         <p className="text-xs leading-snug text-white/50">
-          {t("apps.karaoke.emptyLibrary.subtitle")}
+          {librarySource === "appleMusic"
+            ? t("apps.karaoke.emptyLibrary.subtitleAppleMusic")
+            : t("apps.karaoke.emptyLibrary.subtitle")}
         </p>
       </div>
-      <div className="relative flex items-center justify-center">
-        <div className={segmentClasses} style={aquaSegmentStyle}>
-          {isMacTheme && <KaraokeToolbarShine />}
-          <button
-            type="button"
-            onClick={handleAddSongs}
-            className={cn(buttonClasses, "gap-1 px-2 w-auto")}
-          >
-            <span className={cn("text-sm", iconClasses)}>
-              {t("apps.karaoke.emptyLibrary.addSongs")}
-            </span>
-          </button>
+      {librarySource === "youtube" && (
+        <div className="relative flex items-center justify-center">
+          <div className={segmentClasses} style={aquaSegmentStyle}>
+            {isMacTheme && <KaraokeToolbarShine />}
+            <button
+              type="button"
+              onClick={handleAddSongs}
+              className={cn(buttonClasses, "gap-1 px-2 w-auto")}
+            >
+              <span className={cn("text-sm", iconClasses)}>
+                {t("apps.karaoke.emptyLibrary.addSongs")}
+              </span>
+            </button>
+          </div>
         </div>
-      </div>
+      )}
     </div>
   );
 }

--- a/src/apps/karaoke/components/KaraokeLyricsPlayback.tsx
+++ b/src/apps/karaoke/components/KaraokeLyricsPlayback.tsx
@@ -61,6 +61,13 @@ export function useKaraokeLyricsPlayback(): KaraokeLyricsPlaybackContextValue {
 interface ProviderProps {
   children: ReactNode;
   currentTrack: Track | null;
+  /** Resolved id/title/artist/offset for lyrics APIs (Apple Music station shells). */
+  lyricsQuery: {
+    songId: string;
+    title: string;
+    artist: string;
+    timingOffsetMs: number;
+  };
   lyricsFont: LyricsFont | undefined;
   romanization: RomanizationSettings;
   lyricsTranslationLanguage: string | null;
@@ -76,7 +83,8 @@ interface ProviderProps {
 
 export function KaraokeLyricsPlaybackProvider({
   children,
-  currentTrack,
+  currentTrack: _currentTrack,
+  lyricsQuery,
   lyricsFont,
   romanization,
   lyricsTranslationLanguage,
@@ -110,10 +118,10 @@ export function KaraokeLyricsPlaybackProvider({
   );
 
   const lyricsControls = useLyrics({
-    songId: currentTrack?.id ?? "",
-    title: currentTrack?.title ?? "",
-    artist: currentTrack?.artist ?? "",
-    currentTime: elapsedTime + (currentTrack?.lyricOffset ?? 0) / 1000,
+    songId: lyricsQuery.songId,
+    title: lyricsQuery.title,
+    artist: lyricsQuery.artist,
+    currentTime: elapsedTime + lyricsQuery.timingOffsetMs / 1000,
     translateTo: effectiveTranslationLanguage,
     selectedMatch: selectedMatchForLyrics,
     includeFurigana: true,
@@ -124,7 +132,7 @@ export function KaraokeLyricsPlaybackProvider({
 
   useLyricsErrorToast({
     error: lyricsControls.error,
-    songId: currentTrack?.id,
+    songId: lyricsQuery.songId || undefined,
     onSearchClick: () => setIsLyricsSearchDialogOpen(true),
     t,
     appId: "karaoke",
@@ -138,7 +146,7 @@ export function KaraokeLyricsPlaybackProvider({
     furiganaProgress,
     soramimiProgress,
   } = useFurigana({
-    songId: currentTrack?.id ?? "",
+    songId: lyricsQuery.songId,
     lines: lyricsControls.originalLines,
     isShowingOriginal: true,
     romanization,

--- a/src/apps/karaoke/components/KaraokeMenuBar.tsx
+++ b/src/apps/karaoke/components/KaraokeMenuBar.tsx
@@ -62,7 +62,8 @@ interface KaraokeMenuBarProps {
   onToggleCoverFlow?: () => void;
   // Tracks
   tracks: Track[];
-  currentIndex: number;
+  /** Active track id for library menu selection (may differ from menu index when browsing Apple Music). */
+  currentTrackId: string | null;
 }
 
 export function KaraokeMenuBar({
@@ -97,7 +98,7 @@ export function KaraokeMenuBar({
   onAdjustTiming,
   onToggleCoverFlow,
   tracks,
-  currentIndex,
+  currentTrackId,
 }: KaraokeMenuBarProps) {
   const { t } = useTranslation();
   const [isShareDialogOpen, setIsShareDialogOpen] = useState(false);
@@ -236,7 +237,7 @@ export function KaraokeMenuBar({
           <MenubarItem
             onClick={onShareSong}
             className="text-md h-6 px-3"
-            disabled={tracks.length === 0 || currentIndex === -1}
+            disabled={tracks.length === 0 || !currentTrackId}
           >
             {t("apps.ipod.menu.shareSong")}
           </MenubarItem>
@@ -647,14 +648,14 @@ export function KaraokeMenuBar({
           <MenubarItem
             onClick={onRefreshLyrics || refreshLyrics}
             className="text-md h-6 px-3"
-            disabled={tracks.length === 0 || currentIndex === -1}
+            disabled={tracks.length === 0 || !currentTrackId}
           >
             {t("apps.ipod.menu.refreshLyrics")}
           </MenubarItem>
           <MenubarItem
             onClick={onAdjustTiming}
             className="text-md h-6 px-3"
-            disabled={tracks.length === 0 || currentIndex === -1}
+            disabled={tracks.length === 0 || !currentTrackId}
           >
             {t("apps.ipod.menu.adjustTiming")}
           </MenubarItem>
@@ -666,7 +667,7 @@ export function KaraokeMenuBar({
                 toast.success(t("apps.ipod.menu.cacheCleared"));
               }}
               className="text-md h-6 px-3"
-              disabled={tracks.length === 0 || currentIndex === -1}
+              disabled={tracks.length === 0 || !currentTrackId}
             >
               {t("apps.ipod.menu.clearCache")}
             </MenubarItem>
@@ -722,7 +723,7 @@ export function KaraokeMenuBar({
                   {tracks.map((track, index) => (
                     <MenubarCheckboxItem
                       key={`all-${track.id}`}
-                      checked={index === currentIndex}
+                      checked={track.id === currentTrackId}
                       onCheckedChange={() => onPlayTrack(index)}
                       className="text-md h-6 pr-3 max-w-[220px] truncate"
                     >
@@ -745,7 +746,7 @@ export function KaraokeMenuBar({
                       {tracksByArtist[artist].map(({ track, index }) => (
                         <MenubarCheckboxItem
                           key={`${artist}-${track.id}`}
-                          checked={index === currentIndex}
+                          checked={track.id === currentTrackId}
                           onCheckedChange={() => onPlayTrack(index)}
                           className="text-md h-6 pr-3 max-w-[160px] sm:max-w-[200px] truncate"
                         >

--- a/src/apps/karaoke/hooks/useKaraokeLogic.ts
+++ b/src/apps/karaoke/hooks/useKaraokeLogic.ts
@@ -3,8 +3,13 @@ import ReactPlayer from "react-player";
 import { toast } from "sonner";
 import { useTranslation } from "react-i18next";
 import { useTranslatedHelpItems } from "@/hooks/useTranslatedHelpItems";
-import { useIpodStore, Track, flushPendingLyricOffsetSave } from "@/stores/useIpodStore";
-import { useKaraokeStore } from "@/stores/useKaraokeStore";
+import {
+  useIpodStore,
+  Track,
+  flushPendingLyricOffsetSave,
+  isAppleMusicCollectionTrack,
+} from "@/stores/useIpodStore";
+import { getKaraokeActivePlaylistTracks, useKaraokeStore } from "@/stores/useKaraokeStore";
 import { useShallow } from "zustand/react/shallow";
 import {
   useIpodStoreShallow,
@@ -14,7 +19,9 @@ import {
 import { useThemeFlags } from "@/hooks/useThemeFlags";
 import { LyricsAlignment, LyricsFont, DisplayMode } from "@/types/lyrics";
 import { useOffline } from "@/hooks/useOffline";
-import { useListenSync } from "@/hooks/useListenSync";
+import { useListenSync, type ListenSyncPlayer } from "@/hooks/useListenSync";
+import { useMusicKit } from "@/hooks/useMusicKit";
+import { resolveLyricsTrackMetadata } from "@/apps/ipod/utils/lyricsTrackMetadata";
 import { TRANSLATION_LANGUAGES, getYouTubeVideoId, formatKugouImageUrl } from "@/apps/ipod/constants";
 import { useLibraryUpdateChecker } from "@/apps/ipod/hooks/useLibraryUpdateChecker";
 import { saveSongMetadataFromTrack } from "@/utils/songMetadataCache";
@@ -22,6 +29,7 @@ import { useChatsStore } from "@/stores/useChatsStore";
 import { useListenSessionStore } from "@/stores/useListenSessionStore";
 import type { KaraokeInitialData } from "../../base/types";
 import type { CoverFlowRef } from "@/apps/ipod/components/CoverFlow";
+import type { AppleMusicPlayerBridgeHandle } from "@/apps/ipod/components/AppleMusicPlayerBridge";
 import type { SongSearchResult } from "@/components/dialogs/SongSearchDialog";
 import { helpItems } from "..";
 import { onAppUpdate } from "@/utils/appEventBus";
@@ -55,7 +63,10 @@ export function useKaraokeLogic({
 
   // Shared state from iPod store (library and display preferences only)
   const {
-    tracks,
+    youtubeTracks,
+    appleMusicTracks,
+    librarySource,
+    appleMusicKitNowPlaying,
     showLyrics,
     lyricsAlignment,
     lyricsFont,
@@ -66,7 +77,10 @@ export function useKaraokeLogic({
     displayMode,
   } = useIpodStore(
     useShallow((s) => ({
-      tracks: s.tracks,
+      youtubeTracks: s.tracks,
+      appleMusicTracks: s.appleMusicTracks,
+      librarySource: s.librarySource,
+      appleMusicKitNowPlaying: s.appleMusicKitNowPlaying,
       showLyrics: s.showLyrics,
       lyricsAlignment: s.lyricsAlignment,
       lyricsFont: s.lyricsFont,
@@ -77,6 +91,25 @@ export function useKaraokeLogic({
       displayMode: s.displayMode ?? DisplayMode.Video,
     }))
   );
+
+  const isAppleMusic = librarySource === "appleMusic";
+  const libraryTracks = isAppleMusic ? appleMusicTracks : youtubeTracks;
+  const browsableTracks = useMemo(
+    () =>
+      isAppleMusic
+        ? libraryTracks.filter((track) => !isAppleMusicCollectionTrack(track))
+        : libraryTracks,
+    [isAppleMusic, libraryTracks]
+  );
+  /** Browsable slice (matches iPod Cover Flow / library menus). */
+  const tracks = browsableTracks;
+
+  const enableMusicKit = isAppleMusic && isWindowOpen;
+  const {
+    instance: _musicKitInstance,
+    status: _musicKitStatus,
+    authorize: _musicKitAuthorize,
+  } = useMusicKit({ enabled: enableMusicKit });
 
   const {
     setLyricsAlignment,
@@ -91,6 +124,7 @@ export function useKaraokeLogic({
     setLyricOffset,
     addTrackFromVideoId,
     setDisplayMode,
+    setAppleMusicKitNowPlaying,
   } = useIpodStoreShallow((s) => ({
     setLyricsAlignment: s.setLyricsAlignment,
     setLyricsFont: s.setLyricsFont,
@@ -104,6 +138,7 @@ export function useKaraokeLogic({
     setLyricOffset: s.setLyricOffset,
     addTrackFromVideoId: s.addTrackFromVideoId,
     setDisplayMode: s.setDisplayMode,
+    setAppleMusicKitNowPlaying: s.setAppleMusicKitNowPlaying,
   }));
 
   // Library update checker
@@ -221,12 +256,18 @@ export function useKaraokeLogic({
   // In remote-only listen mode, the session track is the source of truth.
   const currentIndex = useMemo(() => {
     if (!activeTrackId) {
-      return listenRemoteOnly ? -1 : (tracks.length > 0 ? 0 : -1);
+      return listenRemoteOnly ? -1 : (libraryTracks.length > 0 ? 0 : -1);
     }
-    const index = tracks.findIndex((t) => t.id === activeTrackId);
+    const index = libraryTracks.findIndex((t) => t.id === activeTrackId);
     if (index >= 0) return index;
-    return listenRemoteOnly ? -1 : (tracks.length > 0 ? 0 : -1);
-  }, [activeTrackId, listenRemoteOnly, tracks]);
+    return listenRemoteOnly ? -1 : (libraryTracks.length > 0 ? 0 : -1);
+  }, [activeTrackId, listenRemoteOnly, libraryTracks]);
+
+  const browseCurrentIndex = useMemo(() => {
+    if (!activeTrackId) return browsableTracks.length > 0 ? 0 : -1;
+    return browsableTracks.findIndex((track) => track.id === activeTrackId);
+  }, [browsableTracks, activeTrackId]);
+  const coverFlowCurrentIndex = browseCurrentIndex >= 0 ? browseCurrentIndex : 0;
 
   const [uiState, dispatchUi] = useReducer(
     (
@@ -386,6 +427,8 @@ export function useKaraokeLogic({
     setStoreTotalTime(d);
   }, [setStoreTotalTime]);
   const playerRef = useRef<ReactPlayer | null>(null);
+  const appleMusicBridgeWindowRef = useRef<AppleMusicPlayerBridgeHandle | null>(null);
+  const appleMusicBridgeFullscreenRef = useRef<AppleMusicPlayerBridgeHandle | null>(null);
   const [statusMessage, setStatusMessage] = useState<string | null>(null);
   const statusTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const [showControls, setShowControls] = useState(true);
@@ -407,7 +450,7 @@ export function useKaraokeLogic({
   // Current track
   const currentTrack = useMemo<Track | null>(() => {
     if (activeTrackId) {
-      const matchedTrack = tracks.find((track) => track.id === activeTrackId);
+      const matchedTrack = libraryTracks.find((track) => track.id === activeTrackId);
       if (matchedTrack) return matchedTrack;
     }
     if (listenRemoteOnly && activeTrackId && activeListenTrackMeta) {
@@ -421,7 +464,7 @@ export function useKaraokeLogic({
       };
     }
     if (!listenRemoteOnly && currentIndex >= 0) {
-      return tracks[currentIndex] ?? null;
+      return libraryTracks[currentIndex] ?? null;
     }
     return null;
   }, [
@@ -429,7 +472,7 @@ export function useKaraokeLogic({
     activeTrackId,
     currentIndex,
     listenRemoteOnly,
-    tracks,
+    libraryTracks,
   ]);
   const currentTrackMeta = useMemo(
     () =>
@@ -441,6 +484,34 @@ export function useKaraokeLogic({
           }
         : null,
     [currentTrack]
+  );
+
+  const isAppleMusicPlaybackTrack = currentTrack?.source === "appleMusic";
+
+  const lyricsMetadata = useMemo(
+    () => resolveLyricsTrackMetadata(currentTrack, appleMusicKitNowPlaying),
+    [currentTrack, appleMusicKitNowPlaying]
+  );
+  const { title: lyricsLineTitle, artist: lyricsLineArtist, songId: lyricsLineSongId } =
+    lyricsMetadata;
+  const lyricsTimingOffsetMs = useMemo(() => {
+    if (
+      isAppleMusicCollectionTrack(currentTrack) &&
+      appleMusicKitNowPlaying?.id
+    ) {
+      return 0;
+    }
+    return currentTrack?.lyricOffset ?? 0;
+  }, [currentTrack, appleMusicKitNowPlaying?.id]);
+
+  const lyricsQuery = useMemo(
+    () => ({
+      songId: lyricsLineSongId,
+      title: lyricsLineTitle,
+      artist: lyricsLineArtist,
+      timingOffsetMs: lyricsTimingOffsetMs,
+    }),
+    [lyricsLineSongId, lyricsLineTitle, lyricsLineArtist, lyricsTimingOffsetMs]
   );
 
   useEffect(() => {
@@ -457,7 +528,7 @@ export function useKaraokeLogic({
       return;
     }
 
-    if (tracks.some((track) => track.id === activeTrackId)) {
+    if (libraryTracks.some((track) => track.id === activeTrackId)) {
       pendingRemoteTrackHydrationRef.current = null;
       if (currentSongId !== activeTrackId) {
         setCurrentSongId(activeTrackId);
@@ -498,13 +569,19 @@ export function useKaraokeLogic({
     currentSongId,
     listenRemoteOnly,
     setCurrentSongId,
-    tracks,
+    libraryTracks,
   ]);
 
-  const getActivePlayer = useCallback(
-    () => (isFullScreen ? fullScreenPlayerRef.current : playerRef.current),
-    [isFullScreen]
-  );
+  const getActivePlayer = useCallback((): ListenSyncPlayer => {
+    if (isAppleMusicPlaybackTrack) {
+      const b = isFullScreen
+        ? appleMusicBridgeFullscreenRef.current
+        : appleMusicBridgeWindowRef.current;
+      return b as unknown as ListenSyncPlayer;
+    }
+    const p = isFullScreen ? fullScreenPlayerRef.current : playerRef.current;
+    return p as unknown as ListenSyncPlayer;
+  }, [isFullScreen, isAppleMusicPlaybackTrack]);
 
   const pushListenState = useCallback(async () => {
     const activePlayer = getActivePlayer();
@@ -709,7 +786,7 @@ export function useKaraokeLogic({
       }
       
       // Get the new track's offset
-      const newTrack = tracks[currentIndex];
+      const newTrack = libraryTracks[currentIndex];
       const newLyricOffset = newTrack?.lyricOffset ?? 0;
       
       // For negative offset, auto-skip to where lyrics time = 0
@@ -724,7 +801,7 @@ export function useKaraokeLogic({
         
         timeoutId = setTimeout(() => {
           isTrackSwitchingRef.current = false;
-          const activePlayer = isFullScreen ? fullScreenPlayerRef.current : playerRef.current;
+          const activePlayer = getActivePlayer();
           if (activePlayer) {
             activePlayer.seekTo(seekTarget);
             showStatus(`▶ ${Math.floor(seekTarget / 60)}:${String(Math.floor(seekTarget % 60)).padStart(2, "0")}`);
@@ -749,7 +826,7 @@ export function useKaraokeLogic({
         }
       }
     };
-  }, [currentIndex, tracks, isFullScreen, showStatus, setStoreElapsedTime]);
+  }, [currentIndex, libraryTracks, isFullScreen, showStatus, setStoreElapsedTime, getActivePlayer]);
 
   // Cleanup
   useEffect(() => {
@@ -813,50 +890,68 @@ export function useKaraokeLogic({
       
       if (isFullScreen) {
         trackAnalytics(MEDIA_ANALYTICS.FULLSCREEN, { appId: "karaoke", isOpen: true });
-        // Entering fullscreen - sync position from main player to fullscreen player
-        const currentTime = playerRef.current?.getCurrentTime() ?? useKaraokeStore.getState().elapsedTime;
-        const wasPlaying = isPlaying;
+        if (!isAppleMusicPlaybackTrack) {
+          // Entering fullscreen - sync position from main player to fullscreen player
+          const currentTime =
+            playerRef.current?.getCurrentTime() ?? useKaraokeStore.getState().elapsedTime;
+          const wasPlaying = isPlaying;
 
-        // Wait for fullscreen player to be ready before seeking
-        const checkAndSync = () => {
-          const internalPlayer = fullScreenPlayerRef.current?.getInternalPlayer?.();
-          if (internalPlayer && typeof internalPlayer.getPlayerState === "function") {
-            const playerState = internalPlayer.getPlayerState();
-            // -1 = unstarted, 3 = buffering, 5 = cued are "not ready" states
-            if (playerState !== -1) {
-              fullScreenPlayerRef.current?.seekTo(currentTime);
-              if (wasPlaying && typeof internalPlayer.playVideo === "function") {
-                internalPlayer.playVideo();
+          // Wait for fullscreen player to be ready before seeking
+          const checkAndSync = () => {
+            const ytPlayer = fullScreenPlayerRef.current as ReactPlayer | null;
+            const internalPlayer = ytPlayer?.getInternalPlayer?.() as
+              | { getPlayerState?: () => number; playVideo?: () => void }
+              | undefined;
+            if (internalPlayer && typeof internalPlayer.getPlayerState === "function") {
+              const playerState = internalPlayer.getPlayerState();
+              // -1 = unstarted, 3 = buffering, 5 = cued are "not ready" states
+              if (playerState !== -1) {
+                fullScreenPlayerRef.current?.seekTo(currentTime);
+                if (wasPlaying && typeof internalPlayer.playVideo === "function") {
+                  internalPlayer.playVideo();
+                }
+                // End track switch after sync complete
+                trackSwitchTimeoutRef.current = scheduleTimeout(() => {
+                  isTrackSwitchingRef.current = false;
+                }, 500);
+                return;
               }
-              // End track switch after sync complete
-              trackSwitchTimeoutRef.current = scheduleTimeout(() => {
-                isTrackSwitchingRef.current = false;
-              }, 500);
-              return;
             }
-          }
-          // Player not ready, retry
+            // Player not ready, retry
+            scheduleTimeout(checkAndSync, 100);
+          };
           scheduleTimeout(checkAndSync, 100);
-        };
-        scheduleTimeout(checkAndSync, 100);
-      } else {
-        trackAnalytics(MEDIA_ANALYTICS.FULLSCREEN, { appId: "karaoke", isOpen: false });
-        // Exiting fullscreen - sync position from fullscreen player to main player
-        const currentTime = fullScreenPlayerRef.current?.getCurrentTime() ?? useKaraokeStore.getState().elapsedTime;
-        const wasPlaying = isPlaying;
-
-        scheduleTimeout(() => {
-          if (playerRef.current) {
-            playerRef.current.seekTo(currentTime);
-            if (wasPlaying) {
-              setIsPlaying(true);
-            }
-          }
-          // End track switch after sync complete
+        } else {
           trackSwitchTimeoutRef.current = scheduleTimeout(() => {
             isTrackSwitchingRef.current = false;
-          }, 500);
-        }, 200);
+          }, 350);
+        }
+      } else {
+        trackAnalytics(MEDIA_ANALYTICS.FULLSCREEN, { appId: "karaoke", isOpen: false });
+        if (!isAppleMusicPlaybackTrack) {
+          // Exiting fullscreen - sync position from fullscreen player to main player
+          const currentTime =
+            fullScreenPlayerRef.current?.getCurrentTime() ??
+            useKaraokeStore.getState().elapsedTime;
+          const wasPlaying = isPlaying;
+
+          scheduleTimeout(() => {
+            if (playerRef.current) {
+              playerRef.current.seekTo(currentTime);
+              if (wasPlaying) {
+                setIsPlaying(true);
+              }
+            }
+            // End track switch after sync complete
+            trackSwitchTimeoutRef.current = scheduleTimeout(() => {
+              isTrackSwitchingRef.current = false;
+            }, 500);
+          }, 200);
+        } else {
+          trackSwitchTimeoutRef.current = scheduleTimeout(() => {
+            isTrackSwitchingRef.current = false;
+          }, 350);
+        }
       }
       prevFullScreenRef.current = isFullScreen;
     }
@@ -864,17 +959,17 @@ export function useKaraokeLogic({
       timeoutIds.forEach((timeoutId) => clearTimeout(timeoutId));
       timeoutIds.clear();
     };
-  }, [isFullScreen, isPlaying, setIsPlaying]);
+  }, [isFullScreen, isPlaying, setIsPlaying, isAppleMusicPlaybackTrack]);
 
   // Handle closing sync mode - flush pending offset saves
   const closeSyncMode = useCallback(async () => {
     // Flush any pending lyric offset save for the current track
-    const currentTrackId = tracks[currentIndex]?.id;
+    const currentTrackId = libraryTracks[currentIndex]?.id;
     if (currentTrackId) {
       await flushPendingLyricOffsetSave(currentTrackId);
     }
     setIsSyncModeOpen(false);
-  }, [tracks, currentIndex]);
+  }, [libraryTracks, currentIndex]);
 
   // Playback handlers
   const handleTrackEnd = useCallback(() => {
@@ -896,6 +991,13 @@ export function useKaraokeLogic({
     [listenRemoteOnly, setStoreElapsedTime]
   );
 
+  const handleDuration = useCallback(
+    (d: number) => {
+      setDuration(d);
+    },
+    [setDuration]
+  );
+
   const handlePlay = useCallback(() => {
     if (listenRemoteOnly) return;
     // Don't update state if we're in the middle of a track switch
@@ -903,7 +1005,6 @@ export function useKaraokeLogic({
       return;
     }
     setIsPlaying(true);
-    const currentTrack = tracks[currentIndex];
     if (currentTrack) {
       trackAnalytics(MEDIA_ANALYTICS.SONG_PLAY, {
         appId: "karaoke",
@@ -912,7 +1013,7 @@ export function useKaraokeLogic({
         artist: currentTrack.artist || "",
       });
     }
-  }, [currentIndex, listenRemoteOnly, setIsPlaying, tracks]);
+  }, [currentTrack, listenRemoteOnly, setIsPlaying]);
 
   const handlePause = useCallback(() => {
     if (listenRemoteOnly) return;
@@ -940,7 +1041,7 @@ export function useKaraokeLogic({
   const seekTime = useCallback(
     (delta: number) => {
       if (listenRemoteOnly) return;
-      const activePlayer = isFullScreen ? fullScreenPlayerRef.current : playerRef.current;
+      const activePlayer = getActivePlayer();
       if (activePlayer) {
         const currentTime = activePlayer.getCurrentTime() || 0;
         const newTime = Math.max(0, currentTime + delta);
@@ -950,7 +1051,7 @@ export function useKaraokeLogic({
         );
       }
     },
-    [listenRemoteOnly, showStatus, isFullScreen]
+    [getActivePlayer, listenRemoteOnly, showStatus]
   );
 
   const seekActivePlayerToMs = useCallback(
@@ -968,9 +1069,11 @@ export function useKaraokeLogic({
 
       if (!isPlaying) {
         setIsPlaying(true);
-        const internalPlayer = activePlayer.getInternalPlayer?.();
-        if (internalPlayer && typeof internalPlayer.playVideo === "function") {
-          internalPlayer.playVideo();
+        if (!isAppleMusicPlaybackTrack) {
+          const internalPlayer = (activePlayer as unknown as ReactPlayer).getInternalPlayer?.();
+          if (internalPlayer && typeof (internalPlayer as { playVideo?: () => void }).playVideo === "function") {
+            (internalPlayer as { playVideo: () => void }).playVideo();
+          }
         }
       }
 
@@ -980,7 +1083,7 @@ export function useKaraokeLogic({
 
       return true;
     },
-    [getActivePlayer, isPlaying, setIsPlaying]
+    [getActivePlayer, isAppleMusicPlaybackTrack, isPlaying, setIsPlaying]
   );
 
   // Seek to absolute time (in ms) and start playing
@@ -1107,21 +1210,18 @@ export function useKaraokeLogic({
 
   // Share song handler
   const handleShareSong = useCallback(() => {
-    if (tracks.length > 0 && currentIndex >= 0) {
-      const track = tracks[currentIndex];
+    if (currentTrack) {
       trackAnalytics(MEDIA_ANALYTICS.SHARE, { appId: "karaoke", itemType: "song" });
       // Save song metadata to cache when sharing (requires auth)
       // Pass isShare: true to update createdBy (if allowed)
-      if (track) {
-        const { username, isAuthenticated } = useChatsStore.getState();
-        const auth = username && isAuthenticated ? { username, isAuthenticated } : null;
-        saveSongMetadataFromTrack(track, auth, { isShare: true }).catch((error) => {
-          console.error("[Karaoke] Error saving song metadata to cache:", error);
-        });
-      }
+      const { username, isAuthenticated } = useChatsStore.getState();
+      const auth = username && isAuthenticated ? { username, isAuthenticated } : null;
+      saveSongMetadataFromTrack(currentTrack, auth, { isShare: true }).catch((error) => {
+        console.error("[Karaoke] Error saving song metadata to cache:", error);
+      });
       setIsShareDialogOpen(true);
     }
-  }, [tracks, currentIndex]);
+  }, [currentTrack]);
 
   const handleStartListenSession = useCallback(async () => {
     if (!username) {
@@ -1342,27 +1442,25 @@ export function useKaraokeLogic({
 
   // Lyrics search handlers
   const handleRefreshLyrics = useCallback(() => {
-    if (tracks.length > 0 && currentIndex >= 0) setIsLyricsSearchDialogOpen(true);
-  }, [tracks, currentIndex]);
+    if (currentTrack) setIsLyricsSearchDialogOpen(true);
+  }, [currentTrack]);
 
   const handleLyricsSearchSelect = useCallback(
     (result: { hash: string; albumId: string | number; title: string; artist: string; album?: string }) => {
-      const track = tracks[currentIndex];
-      if (track) {
-        setTrackLyricsSource(track.id, result);
+      if (currentTrack) {
+        setTrackLyricsSource(currentTrack.id, result);
         refreshLyrics();
       }
     },
-    [tracks, currentIndex, setTrackLyricsSource, refreshLyrics]
+    [currentTrack, setTrackLyricsSource, refreshLyrics]
   );
 
   const handleLyricsSearchReset = useCallback(() => {
-    const track = tracks[currentIndex];
-    if (track) {
-      clearTrackLyricsSource(track.id);
+    if (currentTrack) {
+      clearTrackLyricsSource(currentTrack.id);
       refreshLyrics();
     }
-  }, [tracks, currentIndex, clearTrackLyricsSource, refreshLyrics]);
+  }, [currentTrack, clearTrackLyricsSource, refreshLyrics]);
 
   // Song search/add handlers
   const handleAddSong = useCallback(() => {
@@ -1616,15 +1714,15 @@ export function useKaraokeLogic({
           });
       }, 100);
       lastProcessedInitialDataRef.current = initialData;
-    } else if (
-      isWindowOpen &&
-      !listenRemoteOnly &&
-      tracks.length > 0 &&
-      currentSongId &&
-      !tracks.some((t) => t.id === currentSongId)
-    ) {
-      // Reset to first track if current song no longer exists in library
-      setCurrentSongId(tracks[0]?.id ?? null);
+    } else if (isWindowOpen && !listenRemoteOnly) {
+      const playlist = getKaraokeActivePlaylistTracks();
+      if (
+        playlist.length > 0 &&
+        currentSongId &&
+        !playlist.some((t) => t.id === currentSongId)
+      ) {
+        setCurrentSongId(playlist[0]?.id ?? null);
+      }
     }
     return () => {
       if (timeoutId !== null) {
@@ -1638,7 +1736,7 @@ export function useKaraokeLogic({
     processVideoId,
     clearInstanceInitialData,
     instanceId,
-    tracks,
+    libraryTracks,
     currentSongId,
     setCurrentSongId,
   ]);
@@ -1742,6 +1840,11 @@ export function useKaraokeLogic({
     tracks,
     currentSongId,
     currentIndex,
+    coverFlowCurrentIndex,
+    librarySource,
+    isAppleMusicPlaybackTrack,
+    lyricsQuery,
+    setAppleMusicKitNowPlaying,
     loopCurrent,
     loopAll,
     isShuffled,
@@ -1805,6 +1908,8 @@ export function useKaraokeLogic({
     LONG_PRESS_MOVE_THRESHOLD,
     fullScreenPlayerRef,
     playerRef,
+    appleMusicBridgeWindowRef,
+    appleMusicBridgeFullscreenRef,
     lyricsPlaybackSyncRef,
     duration,
     setDuration,
@@ -1827,6 +1932,7 @@ export function useKaraokeLogic({
     closeSyncMode,
     handleTrackEnd,
     handleProgress,
+    handleDuration,
     handlePlay,
     handlePause,
     handleMainPlayerPause,

--- a/src/hooks/useListenSync.ts
+++ b/src/hooks/useListenSync.ts
@@ -7,13 +7,19 @@ import {
 } from "@/stores/useListenSessionStore";
 import { toast } from "sonner";
 
+/** Minimal player surface used for position sync (ReactPlayer or AppleMusicPlayerBridge). */
+export type ListenSyncPlayer = Pick<
+  ReactPlayer,
+  "getCurrentTime" | "seekTo"
+> | null;
+
 interface ListenSyncOptions {
   currentTrackId: string | null;
   currentTrackMeta: ListenTrackMeta | null;
   isPlaying: boolean;
   setIsPlaying: (playing: boolean) => void;
   setCurrentTrackId: (trackId: string | null) => void;
-  getActivePlayer: () => ReactPlayer | null;
+  getActivePlayer: () => ListenSyncPlayer;
   addTrackFromId?: (trackId: string) => Promise<unknown> | void;
   /** When false, listener shows session state only (no local A/V sync). */
   applyListenerPlayback?: boolean;
@@ -164,11 +170,12 @@ export function useListenSync({
   }, [canBroadcast]);
 
   // Helper to set playback rate on the internal player
-  const setPlaybackRate = useCallback((player: ReactPlayer, rate: number) => {
+  const setPlaybackRate = useCallback((player: ListenSyncPlayer, rate: number) => {
     if (currentPlaybackRateRef.current === rate) return;
 
     try {
-      const internalPlayer = player.getInternalPlayer();
+      const reactPlayer = player as unknown as ReactPlayer;
+      const internalPlayer = reactPlayer.getInternalPlayer?.();
       if (internalPlayer && typeof internalPlayer.playbackRate !== "undefined") {
         internalPlayer.playbackRate = rate;
         currentPlaybackRateRef.current = rate;

--- a/src/lib/locales/de/translation.json
+++ b/src/lib/locales/de/translation.json
@@ -2431,6 +2431,7 @@
       "emptyLibrary": {
         "addSongs": "Songs hinzufügen",
         "subtitle": "Füge Musik von YouTube hinzu, um loszulegen.",
+        "subtitleAppleMusic": "[TODO] Open the iPod, switch the library to Apple Music, and sign in to load your songs here.",
         "title": "Keine Songs in Karaoke"
       },
       "help": {

--- a/src/lib/locales/en/translation.json
+++ b/src/lib/locales/en/translation.json
@@ -2115,6 +2115,7 @@
       "emptyLibrary": {
         "title": "No songs in Karaoke",
         "subtitle": "Add music from YouTube to get started.",
+        "subtitleAppleMusic": "Open the iPod, switch the library to Apple Music, and sign in to load your songs here.",
         "addSongs": "Add Songs"
       },
       "noTrack": "No track loaded. Open iPod to select a song.",

--- a/src/lib/locales/es/translation.json
+++ b/src/lib/locales/es/translation.json
@@ -2431,6 +2431,7 @@
       "emptyLibrary": {
         "addSongs": "Añadir canciones",
         "subtitle": "Añade música desde YouTube para empezar.",
+        "subtitleAppleMusic": "[TODO] Open the iPod, switch the library to Apple Music, and sign in to load your songs here.",
         "title": "No hay canciones en Karaoke"
       },
       "help": {

--- a/src/lib/locales/fr/translation.json
+++ b/src/lib/locales/fr/translation.json
@@ -2431,6 +2431,7 @@
       "emptyLibrary": {
         "addSongs": "Ajouter des morceaux",
         "subtitle": "Ajoutez de la musique depuis YouTube pour commencer.",
+        "subtitleAppleMusic": "[TODO] Open the iPod, switch the library to Apple Music, and sign in to load your songs here.",
         "title": "Aucun morceau dans Karaoké"
       },
       "help": {

--- a/src/lib/locales/it/translation.json
+++ b/src/lib/locales/it/translation.json
@@ -2431,6 +2431,7 @@
       "emptyLibrary": {
         "addSongs": "Aggiungi brani",
         "subtitle": "Aggiungi musica da YouTube per iniziare.",
+        "subtitleAppleMusic": "[TODO] Open the iPod, switch the library to Apple Music, and sign in to load your songs here.",
         "title": "Nessun brano in Karaoke"
       },
       "help": {

--- a/src/lib/locales/ja/translation.json
+++ b/src/lib/locales/ja/translation.json
@@ -2431,6 +2431,7 @@
       "emptyLibrary": {
         "addSongs": "曲を追加",
         "subtitle": "YouTube から音楽を追加して始めましょう。",
+        "subtitleAppleMusic": "[TODO] Open the iPod, switch the library to Apple Music, and sign in to load your songs here.",
         "title": "カラオケに曲がありません"
       },
       "help": {

--- a/src/lib/locales/ko/translation.json
+++ b/src/lib/locales/ko/translation.json
@@ -2431,6 +2431,7 @@
       "emptyLibrary": {
         "addSongs": "노래 추가",
         "subtitle": "YouTube에서 음악을 추가해 시작하세요.",
+        "subtitleAppleMusic": "[TODO] Open the iPod, switch the library to Apple Music, and sign in to load your songs here.",
         "title": "노래방에 곡이 없습니다"
       },
       "help": {

--- a/src/lib/locales/pt/translation.json
+++ b/src/lib/locales/pt/translation.json
@@ -2431,6 +2431,7 @@
       "emptyLibrary": {
         "addSongs": "Adicionar músicas",
         "subtitle": "Adicione músicas do YouTube para começar.",
+        "subtitleAppleMusic": "[TODO] Open the iPod, switch the library to Apple Music, and sign in to load your songs here.",
         "title": "Nenhuma música no Karaoke"
       },
       "help": {

--- a/src/lib/locales/ru/translation.json
+++ b/src/lib/locales/ru/translation.json
@@ -2431,6 +2431,7 @@
       "emptyLibrary": {
         "addSongs": "Добавить песни",
         "subtitle": "Добавьте музыку с YouTube, чтобы начать.",
+        "subtitleAppleMusic": "[TODO] Open the iPod, switch the library to Apple Music, and sign in to load your songs here.",
         "title": "В караоке нет песен"
       },
       "help": {

--- a/src/lib/locales/zh-TW/translation.json
+++ b/src/lib/locales/zh-TW/translation.json
@@ -2431,6 +2431,7 @@
       "emptyLibrary": {
         "addSongs": "新增歌曲",
         "subtitle": "從 YouTube 新增音樂即可開始。",
+        "subtitleAppleMusic": "[TODO] Open the iPod, switch the library to Apple Music, and sign in to load your songs here.",
         "title": "卡拉OK 中尚無歌曲"
       },
       "help": {

--- a/src/stores/useIpodStore.ts
+++ b/src/stores/useIpodStore.ts
@@ -433,7 +433,7 @@ function normalizeAppleMusicPlaybackQueue(
   return ids.length > 0 ? ids : null;
 }
 
-function resolveAppleMusicQueueTracks(state: IpodData): Track[] {
+export function resolveAppleMusicQueueTracks(state: IpodData): Track[] {
   const libraryTracks = state.appleMusicTracks;
   const queue = normalizeAppleMusicPlaybackQueue(state.appleMusicPlaybackQueue);
   if (!queue) {

--- a/src/stores/useKaraokeStore.ts
+++ b/src/stores/useKaraokeStore.ts
@@ -1,7 +1,20 @@
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
 import type { SetStateAction } from "react";
-import { useIpodStore, Track } from "./useIpodStore";
+import {
+  useIpodStore,
+  Track,
+  resolveAppleMusicQueueTracks,
+} from "./useIpodStore";
+
+/** Active playlist for Karaoke: YouTube library or Apple Music queue slice. */
+export function getKaraokeActivePlaylistTracks(): Track[] {
+  const ipod = useIpodStore.getState();
+  if (ipod.librarySource === "appleMusic") {
+    return resolveAppleMusicQueueTracks(ipod);
+  }
+  return ipod.tracks;
+}
 
 /** Helper to get current index from song ID */
 function getIndexFromSongId(tracks: Track[], songId: string | null): number {
@@ -83,7 +96,7 @@ export const useKaraokeStore = create<KaraokeState>()(
       // Getter to get current track from iPod library
       getCurrentTrack: () => {
         const { currentSongId } = get();
-        const tracks = useIpodStore.getState().tracks;
+        const tracks = getKaraokeActivePlaylistTracks();
         if (!currentSongId) return tracks[0] ?? null;
         return tracks.find((t) => t.id === currentSongId) ?? null;
       },
@@ -91,7 +104,7 @@ export const useKaraokeStore = create<KaraokeState>()(
       // Getter to get current index (computed from currentSongId)
       getCurrentIndex: () => {
         const { currentSongId } = get();
-        const tracks = useIpodStore.getState().tracks;
+        const tracks = getKaraokeActivePlaylistTracks();
         return getIndexFromSongId(tracks, currentSongId);
       },
 
@@ -125,7 +138,7 @@ export const useKaraokeStore = create<KaraokeState>()(
 
       nextTrack: () =>
         set((state) => {
-          const tracks = useIpodStore.getState().tracks;
+          const tracks = getKaraokeActivePlaylistTracks();
           if (tracks.length === 0) return { currentSongId: null };
 
           let nextSongId: string | null;
@@ -169,7 +182,7 @@ export const useKaraokeStore = create<KaraokeState>()(
 
       previousTrack: () =>
         set((state) => {
-          const tracks = useIpodStore.getState().tracks;
+          const tracks = getKaraokeActivePlaylistTracks();
           if (tracks.length === 0) return { currentSongId: null };
 
           let prevSongId: string | null;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Karaoke now follows the iPod’s **active library** (`librarySource`): YouTube songs use `tracks` and the ReactPlayer path; **Apple Music** uses the same cached library / playback queue resolution as the iPod (`resolveAppleMusicQueueTracks`) plus **MusicKit** via `AppleMusicPlayerBridge` (window + fullscreen), with lyrics driven by `resolveLyricsTrackMetadata` and live `appleMusicKitNowPlaying` like the iPod.

## Details

- **`useKaraokeStore`**: `getCurrentTrack` / `nextTrack` / `previousTrack` use `getKaraokeActivePlaylistTracks()` so shuffle and sequential navigation match the Apple Music queue when applicable.
- **`useIpodStore`**: `resolveAppleMusicQueueTracks` is **exported** for reuse.
- **`useListenSync`**: `ListenSyncPlayer` type so DJ/listen sync can call `getCurrentTime` / `seekTo` on either ReactPlayer or the bridge.
- **UI**: Cover Flow uses `coverFlowCurrentIndex` + `groupAppleMusicAlbums` when the library is Apple Music; library menu marks selection by **track id**; empty state explains loading Apple Music via iPod (new `subtitleAppleMusic` string, synced locales).

## Testing

- `bun run build` (tsc + vite production build)
- `bun run test:unit`

No browser recording (AGENTS.md: skip GUI walkthrough unless requested).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3e9a1a0a-ea57-4c7a-9eb9-4486fa4d6272"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3e9a1a0a-ea57-4c7a-9eb9-4486fa4d6272"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

