### PR TITLE
Use song cover metadata for music OG shares

### DIFF
--- a/api/_utils/og-share.ts
+++ b/api/_utils/og-share.ts
@@ -76,6 +76,12 @@ const APP_ICONS: Record<string, string> = {
   dashboard: "dashboard.png",
 };
 
+export type SongShareMetadata = {
+  title: string;
+  artist: string | null;
+  cover: string | null;
+};
+
 function generateOgHtml(options: {
   title: string;
   description: string;
@@ -123,10 +129,32 @@ function escapeHtml(str: string): string {
     .replace(/'/g, "&#039;");
 }
 
+function getAppIconUrl(publicOrigin: string, appId: string): string {
+  return `${publicOrigin}/icons/macosx/${APP_ICONS[appId]}`;
+}
+
+function decodeRouteId(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}
+
+function asNonEmptyString(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function getRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object"
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
 // Fetch song metadata from Redis song library
 async function getSongFromRedis(
-  videoId: string
-): Promise<{ title: string; artist: string | null; cover: string | null } | null> {
+  songId: string
+): Promise<SongShareMetadata | null> {
   try {
     // Skip if no Redis credentials
     if (
@@ -142,18 +170,30 @@ async function getSongFromRedis(
     });
 
     // Fetch from song:meta:{id} (split storage format)
-    const metaKey = `song:meta:${videoId}`;
+    const metaKey = `song:meta:${songId}`;
     const raw = await redis.get(metaKey);
 
     if (!raw) return null;
 
-    const meta = typeof raw === "string" ? JSON.parse(raw) : raw;
-    if (!meta?.title) return null;
+    const meta = getRecord(typeof raw === "string" ? JSON.parse(raw) : raw);
+    if (!meta) return null;
+
+    const lyricsSource = getRecord(meta.lyricsSource);
+    const artwork = getRecord(meta.artwork);
+    const title =
+      asNonEmptyString(lyricsSource?.title) || asNonEmptyString(meta?.title);
+    if (!title) return null;
 
     return {
-      title: meta.title,
-      artist: meta.artist || null,
-      cover: meta.cover || null,
+      title,
+      artist:
+        asNonEmptyString(lyricsSource?.artist) ||
+        asNonEmptyString(meta?.artist),
+      cover:
+        asNonEmptyString(meta?.cover) ||
+        asNonEmptyString(meta?.artworkUrl) ||
+        asNonEmptyString(artwork?.url) ||
+        asNonEmptyString(meta?.image),
     };
   } catch {
     return null;
@@ -161,15 +201,18 @@ async function getSongFromRedis(
 }
 
 /**
- * Format Kugou image URL by replacing {size} placeholder
- * Ensures HTTPS is used to avoid mixed content issues
+ * Format music cover URLs by replacing Kugou / Apple Music placeholders.
+ * Ensures HTTPS is used to avoid mixed content issues.
  */
-function formatKugouImageUrl(
+function formatMusicCoverUrl(
   imgUrl: string | null,
   size: number = 400
 ): string | null {
   if (!imgUrl) return null;
-  let url = imgUrl.replace("{size}", String(size));
+  let url = imgUrl
+    .replace("{size}", String(size))
+    .replace("{w}", String(size))
+    .replace("{h}", String(size));
   url = url.replace(/^http:\/\//, "https://");
   return url;
 }
@@ -233,7 +276,10 @@ async function getYouTubeInfo(
 }
 
 export async function createOgShareResponse(
-  request: Request
+  request: Request,
+  options: {
+    getSong?: (songId: string) => Promise<SongShareMetadata | null>;
+  } = {}
 ): Promise<Response | null> {
   if (request.method !== "GET" && request.method !== "HEAD") {
     return null;
@@ -256,7 +302,7 @@ export async function createOgShareResponse(
   const appMatch = pathname.match(/^\/([a-z-]+)$/);
   if (appMatch && APP_NAMES[appMatch[1]]) {
     const appId = appMatch[1];
-    imageUrl = `${publicOrigin}/icons/macosx/${APP_ICONS[appId]}`;
+    imageUrl = getAppIconUrl(publicOrigin, appId);
     title = `${APP_NAMES[appId]} on ryOS`;
     description = APP_DESCRIPTIONS[appId] || "Open app in ryOS";
     matched = true;
@@ -278,14 +324,14 @@ export async function createOgShareResponse(
     matched = true;
   }
 
-  const ipodMatch = pathname.match(/^\/ipod\/([a-zA-Z0-9_-]+)$/);
+  const ipodMatch = pathname.match(/^\/ipod\/([^/?#]+)$/);
   if (ipodMatch) {
-    const videoId = ipodMatch[1];
-    const youtubeThumbnail = `https://i.ytimg.com/vi/${videoId}/hqdefault.jpg`;
+    const songId = decodeRouteId(ipodMatch[1]);
+    imageUrl = getAppIconUrl(publicOrigin, "ipod");
 
-    const songInfo = await getSongFromRedis(videoId);
+    const songInfo = await (options.getSong || getSongFromRedis)(songId);
     if (songInfo) {
-      imageUrl = formatKugouImageUrl(songInfo.cover, 400) || youtubeThumbnail;
+      imageUrl = formatMusicCoverUrl(songInfo.cover, 400) || imageUrl;
       if (songInfo.artist) {
         title = `${songInfo.title} - ${songInfo.artist}`;
         description = "Listen on ryOS iPod";
@@ -294,50 +340,28 @@ export async function createOgShareResponse(
         description = "Listen on ryOS iPod";
       }
     } else {
-      const ytInfo = await getYouTubeInfo(videoId);
-      imageUrl = youtubeThumbnail;
-      if (ytInfo) {
-        if (ytInfo.artist) {
-          title = `${ytInfo.title} - ${ytInfo.artist}`;
-          description = "Listen on ryOS iPod";
-        } else {
-          title = ytInfo.title;
-          description = "Listen on ryOS iPod";
-        }
-      } else {
-        title = "Shared Song - ryOS";
-        description = "Listen on ryOS iPod";
-      }
+      title = "Shared Song - ryOS";
+      description = "Listen on ryOS iPod";
     }
     matched = true;
   }
 
-  const karaokeMatch = pathname.match(/^\/karaoke\/([a-zA-Z0-9_-]+)$/);
+  const karaokeMatch = pathname.match(/^\/karaoke\/([^/?#]+)$/);
   if (karaokeMatch) {
-    const videoId = karaokeMatch[1];
-    const youtubeThumbnail = `https://i.ytimg.com/vi/${videoId}/hqdefault.jpg`;
+    const songId = decodeRouteId(karaokeMatch[1]);
+    imageUrl = getAppIconUrl(publicOrigin, "karaoke");
 
-    const songInfo = await getSongFromRedis(videoId);
+    const songInfo = await (options.getSong || getSongFromRedis)(songId);
     if (songInfo) {
-      imageUrl = formatKugouImageUrl(songInfo.cover, 400) || youtubeThumbnail;
+      imageUrl = formatMusicCoverUrl(songInfo.cover, 400) || imageUrl;
       const songDisplay = songInfo.artist
         ? `${songInfo.title} - ${songInfo.artist}`
         : songInfo.title;
       title = `Sing ${songDisplay} on ryOS`;
       description = "Sing along on ryOS Karaoke";
     } else {
-      const ytInfo = await getYouTubeInfo(videoId);
-      imageUrl = youtubeThumbnail;
-      if (ytInfo) {
-        const songDisplay = ytInfo.artist
-          ? `${ytInfo.title} - ${ytInfo.artist}`
-          : ytInfo.title;
-        title = `Sing ${songDisplay} on ryOS`;
-        description = "Sing along on ryOS Karaoke";
-      } else {
-        title = "Sing on ryOS Karaoke";
-        description = "Sing along on ryOS Karaoke";
-      }
+      title = "Sing on ryOS Karaoke";
+      description = "Sing along on ryOS Karaoke";
     }
     matched = true;
   }

--- a/api/songs/_constants.ts
+++ b/api/songs/_constants.ts
@@ -63,6 +63,7 @@ export const UpdateSongSchema = z.object({
   title: z.string().max(500).optional(),
   artist: z.string().max(500).optional(),
   album: z.string().max(500).optional(),
+  cover: z.string().max(2000).optional(),
   lyricOffset: z.number().min(-300000).max(300000).optional(),
   lyricsSource: LyricsSourceSchema.optional(),
   // Options to clear cached data when lyrics source changes

--- a/api/songs/index.ts
+++ b/api/songs/index.ts
@@ -69,6 +69,7 @@ const CreateSongSchema = z.object({
   title: z.string().min(1),
   artist: z.string().optional(),
   album: z.string().optional(),
+  cover: z.string().max(2000).optional(),
   lyricOffset: z.number().optional(),
   lyricsSource: LyricsSourceSchema.optional(),
 });
@@ -99,6 +100,7 @@ const BulkImportSchema = z.object({
       title: z.string().min(1),
       artist: z.string().optional(),
       album: z.string().optional(),
+      cover: z.string().max(2000).optional(),
       lyricOffset: z.number().optional(),
       lyricsSource: LyricsSourceSchema.optional(),
       // Legacy format support
@@ -333,7 +335,7 @@ export default apiHandler<Record<string, unknown>>(
           const lyricsValue = getFieldValue<{ lrc?: string; krc?: string; cover?: string }>(songData.lyrics);
           
           // Cover: prefer from lyrics data (backwards compat), otherwise from existing, otherwise fetch later
-          const cover = lyricsValue?.cover || existing?.cover;
+          const cover = songData.cover || lyricsValue?.cover || existing?.cover;
 
           // Build metadata (cover is now in metadata, not lyrics)
           // For imports, respect the original createdBy from the export file
@@ -516,6 +518,7 @@ export default apiHandler<Record<string, unknown>>(
           title: songData.title,
           artist: songData.artist,
           album: songData.album,
+          cover: songData.cover,
           lyricOffset: songData.lyricOffset,
           lyricsSource: songData.lyricsSource as LyricsSource | undefined,
           createdBy: existing?.createdBy || username || undefined,

--- a/src/utils/songMetadataCache.ts
+++ b/src/utils/songMetadataCache.ts
@@ -88,6 +88,7 @@ type BulkImportSong = {
   title: string;
   artist?: string;
   album?: string;
+  cover?: string;
   lyricOffset?: number;
   lyricsSource?: CachedLyricsSource;
   // Content fields (may be compressed gzip:base64 strings or raw objects)
@@ -332,6 +333,7 @@ export async function saveSongMetadata(
     title: string;
     artist?: string;
     album?: string;
+    cover?: string;
     lyricOffset?: number;
     lyricsSource?: CachedLyricsSource;
   },
@@ -345,6 +347,7 @@ export async function saveSongMetadata(
         title: metadata.title,
         artist: metadata.artist,
         album: metadata.album,
+        cover: metadata.cover,
         lyricOffset: metadata.lyricOffset,
         lyricsSource: metadata.lyricsSource,
         isShare: options?.isShare,
@@ -694,6 +697,7 @@ export async function saveSongMetadataFromTrack(
     title: string;
     artist?: string;
     album?: string;
+    cover?: string;
     lyricOffset?: number;
     lyricsSource?: {
       hash: string;
@@ -718,6 +722,7 @@ export async function saveSongMetadataFromTrack(
       title: track.title,
       artist: track.artist,
       album: track.album,
+      cover: track.cover,
       lyricOffset: track.lyricOffset,
       lyricsSource: track.lyricsSource,
     },

--- a/tests/test-og-share.test.ts
+++ b/tests/test-og-share.test.ts
@@ -1,5 +1,6 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, mock, test } from "bun:test";
 import { createOgShareResponse } from "../api/_utils/og-share";
+import { UpdateSongSchema } from "../api/songs/_constants";
 
 const ORIGINAL_ENV = { ...process.env };
 
@@ -52,5 +53,80 @@ describe("og share response", () => {
     );
 
     expect(response).toBeNull();
+  });
+
+  test("uses stored iPod song metadata and formatted Kugou cover for OG tags", async () => {
+    process.env.APP_PUBLIC_ORIGIN = "https://os.example.com";
+    const fetchMock = mock(() => {
+      throw new Error("YouTube metadata should not be fetched for song OG");
+    });
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    try {
+      const response = await createOgShareResponse(
+        new Request("https://os.example.com/ipod/abc123DEF45"),
+        {
+          getSong: async (songId) => {
+            expect(songId).toBe("abc123DEF45");
+            return {
+              title: "七里香",
+              artist: "周杰倫",
+              cover: "http://imge.kugou.com/stdmusic/{size}/album.jpg",
+            };
+          },
+        }
+      );
+
+      expect(response).not.toBeNull();
+      const body = await response!.text();
+      expect(body).toContain(
+        '<meta property="og:title" content="七里香 - 周杰倫">'
+      );
+      expect(body).toContain(
+        '<meta property="og:image" content="https://imge.kugou.com/stdmusic/400/album.jpg">'
+      );
+      expect(body).not.toContain("i.ytimg.com");
+      expect(fetchMock).not.toHaveBeenCalled();
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("uses decoded Apple Music song ids and artwork templates for Karaoke OG tags", async () => {
+    process.env.APP_PUBLIC_ORIGIN = "https://os.example.com";
+
+    const response = await createOgShareResponse(
+      new Request("https://os.example.com/karaoke/am%3A1616228595"),
+      {
+        getSong: async (songId) => {
+          expect(songId).toBe("am:1616228595");
+          return {
+            title: "Bohemian Rhapsody",
+            artist: "Queen",
+            cover: "https://is1-ssl.mzstatic.com/image/{w}x{h}bb.jpg",
+          };
+        },
+      }
+    );
+
+    expect(response).not.toBeNull();
+    const body = await response!.text();
+    expect(body).toContain(
+      '<meta property="og:title" content="Sing Bohemian Rhapsody - Queen on ryOS">'
+    );
+    expect(body).toContain(
+      '<meta property="og:image" content="https://is1-ssl.mzstatic.com/image/400x400bb.jpg">'
+    );
+    expect(body).not.toContain("i.ytimg.com");
+  });
+
+  test("song metadata updates accept cover art for share-backed OG pages", () => {
+    expect(
+      UpdateSongSchema.parse({
+        title: "Song",
+        cover: "https://example.com/cover.jpg",
+      }).cover
+    ).toBe("https://example.com/cover.jpg");
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Persist cover art when iPod/Karaoke shares save song metadata.
- Render iPod and Karaoke OG tags from stored song metadata and formatted Kugou/Apple Music cover URLs instead of YouTube thumbnails.
- Add focused OG coverage for Kugou covers, Apple Music artwork templates, decoded song IDs, and cover update schema support.

### Testing
- `bun test tests/test-og-share.test.ts`
- `bun test tests/test-og-share.test.ts tests/test-ipod-apple-music.test.ts`
- `bun run build`
- `bun run test:unit`
- `git diff --check && bun test tests/test-og-share.test.ts`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-69765ce4-d951-4656-9935-a7deb5eeec6d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-69765ce4-d951-4656-9935-a7deb5eeec6d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

