### PR TITLE
Use song cover metadata for music OG shares

### DIFF
--- a/api/_utils/og-share.ts
+++ b/api/_utils/og-share.ts
@@ -76,6 +76,12 @@ const APP_ICONS: Record<string, string> = {
   dashboard: "dashboard.png",
 };
 
+export type SongShareMetadata = {
+  title: string;
+  artist: string | null;
+  cover: string | null;
+};
+
 function generateOgHtml(options: {
   title: string;
   description: string;
@@ -123,10 +129,32 @@ function escapeHtml(str: string): string {
     .replace(/'/g, "&#039;");
 }
 
+function getAppIconUrl(publicOrigin: string, appId: string): string {
+  return `${publicOrigin}/icons/macosx/${APP_ICONS[appId]}`;
+}
+
+function decodeRouteId(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}
+
+function asNonEmptyString(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function getRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object"
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
 // Fetch song metadata from Redis song library
 async function getSongFromRedis(
-  videoId: string
-): Promise<{ title: string; artist: string | null; cover: string | null } | null> {
+  songId: string
+): Promise<SongShareMetadata | null> {
   try {
     // Skip if no Redis credentials
     if (
@@ -142,18 +170,30 @@ async function getSongFromRedis(
     });
 
     // Fetch from song:meta:{id} (split storage format)
-    const metaKey = `song:meta:${videoId}`;
+    const metaKey = `song:meta:${songId}`;
     const raw = await redis.get(metaKey);
 
     if (!raw) return null;
 
-    const meta = typeof raw === "string" ? JSON.parse(raw) : raw;
-    if (!meta?.title) return null;
+    const meta = getRecord(typeof raw === "string" ? JSON.parse(raw) : raw);
+    if (!meta) return null;
+
+    const lyricsSource = getRecord(meta.lyricsSource);
+    const artwork = getRecord(meta.artwork);
+    const title =
+      asNonEmptyString(lyricsSource?.title) || asNonEmptyString(meta?.title);
+    if (!title) return null;
 
     return {
-      title: meta.title,
-      artist: meta.artist || null,
-      cover: meta.cover || null,
+      title,
+      artist:
+        asNonEmptyString(lyricsSource?.artist) ||
+        asNonEmptyString(meta?.artist),
+      cover:
+        asNonEmptyString(meta?.cover) ||
+        asNonEmptyString(meta?.artworkUrl) ||
+        asNonEmptyString(artwork?.url) ||
+        asNonEmptyString(meta?.image),
     };
   } catch {
     return null;
@@ -161,15 +201,18 @@ async function getSongFromRedis(
 }
 
 /**
- * Format Kugou image URL by replacing {size} placeholder
- * Ensures HTTPS is used to avoid mixed content issues
+ * Format music cover URLs by replacing Kugou / Apple Music placeholders.
+ * Ensures HTTPS is used to avoid mixed content issues.
  */
-function formatKugouImageUrl(
+function formatMusicCoverUrl(
   imgUrl: string | null,
   size: number = 400
 ): string | null {
   if (!imgUrl) return null;
-  let url = imgUrl.replace("{size}", String(size));
+  let url = imgUrl
+    .replace("{size}", String(size))
+    .replace("{w}", String(size))
+    .replace("{h}", String(size));
   url = url.replace(/^http:\/\//, "https://");
   return url;
 }
@@ -233,7 +276,10 @@ async function getYouTubeInfo(
 }
 
 export async function createOgShareResponse(
-  request: Request
+  request: Request,
+  options: {
+    getSong?: (songId: string) => Promise<SongShareMetadata | null>;
+  } = {}
 ): Promise<Response | null> {
   if (request.method !== "GET" && request.method !== "HEAD") {
     return null;
@@ -256,7 +302,7 @@ export async function createOgShareResponse(
   const appMatch = pathname.match(/^\/([a-z-]+)$/);
   if (appMatch && APP_NAMES[appMatch[1]]) {
     const appId = appMatch[1];
-    imageUrl = `${publicOrigin}/icons/macosx/${APP_ICONS[appId]}`;
+    imageUrl = getAppIconUrl(publicOrigin, appId);
     title = `${APP_NAMES[appId]} on ryOS`;
     description = APP_DESCRIPTIONS[appId] || "Open app in ryOS";
     matched = true;
@@ -278,14 +324,14 @@ export async function createOgShareResponse(
     matched = true;
   }
 
-  const ipodMatch = pathname.match(/^\/ipod\/([a-zA-Z0-9_-]+)$/);
+  const ipodMatch = pathname.match(/^\/ipod\/([^/?#]+)$/);
   if (ipodMatch) {
-    const videoId = ipodMatch[1];
-    const youtubeThumbnail = `https://i.ytimg.com/vi/${videoId}/hqdefault.jpg`;
+    const songId = decodeRouteId(ipodMatch[1]);
+    imageUrl = getAppIconUrl(publicOrigin, "ipod");
 
-    const songInfo = await getSongFromRedis(videoId);
+    const songInfo = await (options.getSong || getSongFromRedis)(songId);
     if (songInfo) {
-      imageUrl = formatKugouImageUrl(songInfo.cover, 400) || youtubeThumbnail;
+      imageUrl = formatMusicCoverUrl(songInfo.cover, 400) || imageUrl;
       if (songInfo.artist) {
         title = `${songInfo.title} - ${songInfo.artist}`;
         description = "Listen on ryOS iPod";
@@ -294,50 +340,28 @@ export async function createOgShareResponse(
         description = "Listen on ryOS iPod";
       }
     } else {
-      const ytInfo = await getYouTubeInfo(videoId);
-      imageUrl = youtubeThumbnail;
-      if (ytInfo) {
-        if (ytInfo.artist) {
-          title = `${ytInfo.title} - ${ytInfo.artist}`;
-          description = "Listen on ryOS iPod";
-        } else {
-          title = ytInfo.title;
-          description = "Listen on ryOS iPod";
-        }
-      } else {
-        title = "Shared Song - ryOS";
-        description = "Listen on ryOS iPod";
-      }
+      title = "Shared Song - ryOS";
+      description = "Listen on ryOS iPod";
     }
     matched = true;
   }
 
-  const karaokeMatch = pathname.match(/^\/karaoke\/([a-zA-Z0-9_-]+)$/);
+  const karaokeMatch = pathname.match(/^\/karaoke\/([^/?#]+)$/);
   if (karaokeMatch) {
-    const videoId = karaokeMatch[1];
-    const youtubeThumbnail = `https://i.ytimg.com/vi/${videoId}/hqdefault.jpg`;
+    const songId = decodeRouteId(karaokeMatch[1]);
+    imageUrl = getAppIconUrl(publicOrigin, "karaoke");
 
-    const songInfo = await getSongFromRedis(videoId);
+    const songInfo = await (options.getSong || getSongFromRedis)(songId);
     if (songInfo) {
-      imageUrl = formatKugouImageUrl(songInfo.cover, 400) || youtubeThumbnail;
+      imageUrl = formatMusicCoverUrl(songInfo.cover, 400) || imageUrl;
       const songDisplay = songInfo.artist
         ? `${songInfo.title} - ${songInfo.artist}`
         : songInfo.title;
       title = `Sing ${songDisplay} on ryOS`;
       description = "Sing along on ryOS Karaoke";
     } else {
-      const ytInfo = await getYouTubeInfo(videoId);
-      imageUrl = youtubeThumbnail;
-      if (ytInfo) {
-        const songDisplay = ytInfo.artist
-          ? `${ytInfo.title} - ${ytInfo.artist}`
-          : ytInfo.title;
-        title = `Sing ${songDisplay} on ryOS`;
-        description = "Sing along on ryOS Karaoke";
-      } else {
-        title = "Sing on ryOS Karaoke";
-        description = "Sing along on ryOS Karaoke";
-      }
+      title = "Sing on ryOS Karaoke";
+      description = "Sing along on ryOS Karaoke";
     }
     matched = true;
   }

--- a/api/_utils/og-share.ts
+++ b/api/_utils/og-share.ts
@@ -453,11 +453,12 @@ export async function createOgShareResponse(
         description = "Listen on ryOS iPod";
       }
     } else {
-      const ytInfo = isYouTubeVideoId(songId)
-        ? await getYouTubeInfo(songId)
-        : null;
-      if (ytInfo) {
+      const isYouTubeSong = isYouTubeVideoId(songId);
+      const ytInfo = isYouTubeSong ? await getYouTubeInfo(songId) : null;
+      if (isYouTubeSong) {
         imageUrl = getOgSongCoverProxyUrl(publicOrigin, "ipod", songId);
+      }
+      if (ytInfo) {
         if (ytInfo.artist) {
           title = `${ytInfo.title} - ${ytInfo.artist}`;
           description = "Listen on ryOS iPod";
@@ -487,11 +488,12 @@ export async function createOgShareResponse(
       title = `Sing ${songDisplay} on ryOS`;
       description = "Sing along on ryOS Karaoke";
     } else {
-      const ytInfo = isYouTubeVideoId(songId)
-        ? await getYouTubeInfo(songId)
-        : null;
-      if (ytInfo) {
+      const isYouTubeSong = isYouTubeVideoId(songId);
+      const ytInfo = isYouTubeSong ? await getYouTubeInfo(songId) : null;
+      if (isYouTubeSong) {
         imageUrl = getOgSongCoverProxyUrl(publicOrigin, "karaoke", songId);
+      }
+      if (ytInfo) {
         const songDisplay = ytInfo.artist
           ? `${ytInfo.title} - ${ytInfo.artist}`
           : ytInfo.title;

--- a/api/_utils/og-share.ts
+++ b/api/_utils/og-share.ts
@@ -1,5 +1,7 @@
-import { Redis } from "@upstash/redis";
+import { createRedis } from "./redis.js";
+import type { Redis } from "./redis.js";
 import { getAppPublicOrigin } from "./runtime-config.js";
+import { safeFetchWithRedirects } from "./_ssrf.js";
 
 // App display names for OG titles
 const APP_NAMES: Record<string, string> = {
@@ -82,6 +84,18 @@ export type SongShareMetadata = {
   cover: string | null;
 };
 
+const OG_SONG_COVER_PATH = "/api/og-song-cover";
+const OG_COVER_IMAGE_SIZE = 600;
+const OG_IMAGE_FETCH_TIMEOUT_MS = 10_000;
+const OG_IMAGE_MAX_BYTES = 5 * 1024 * 1024;
+const YOUTUBE_VIDEO_ID_REGEX = /^[a-zA-Z0-9_-]{11}$/;
+
+type SongMetadataReader = (
+  songId: string
+) => Promise<SongShareMetadata | null>;
+
+type FetchImage = (url: string) => Promise<Response>;
+
 function generateOgHtml(options: {
   title: string;
   description: string;
@@ -133,6 +147,17 @@ function getAppIconUrl(publicOrigin: string, appId: string): string {
   return `${publicOrigin}/icons/macosx/${APP_ICONS[appId]}`;
 }
 
+function getOgSongCoverProxyUrl(
+  publicOrigin: string,
+  appId: "ipod" | "karaoke",
+  songId: string
+): string {
+  const url = new URL(OG_SONG_COVER_PATH, publicOrigin);
+  url.searchParams.set("app", appId);
+  url.searchParams.set("id", songId);
+  return url.toString();
+}
+
 function decodeRouteId(value: string): string {
   try {
     return decodeURIComponent(value);
@@ -151,27 +176,25 @@ function getRecord(value: unknown): Record<string, unknown> | null {
     : null;
 }
 
+function isYouTubeVideoId(value: string): boolean {
+  return YOUTUBE_VIDEO_ID_REGEX.test(value);
+}
+
+function getYouTubeThumbnailUrl(videoId: string): string {
+  return `https://i.ytimg.com/vi/${videoId}/hqdefault.jpg`;
+}
+
 // Fetch song metadata from Redis song library
-async function getSongFromRedis(
-  songId: string
+export async function getSongFromRedis(
+  songId: string,
+  redis?: Pick<Redis, "get">
 ): Promise<SongShareMetadata | null> {
   try {
-    // Skip if no Redis credentials
-    if (
-      !process.env.REDIS_KV_REST_API_URL ||
-      !process.env.REDIS_KV_REST_API_TOKEN
-    ) {
-      return null;
-    }
-
-    const redis = new Redis({
-      url: process.env.REDIS_KV_REST_API_URL,
-      token: process.env.REDIS_KV_REST_API_TOKEN,
-    });
+    const client = redis || createRedis();
 
     // Fetch from song:meta:{id} (split storage format)
     const metaKey = `song:meta:${songId}`;
-    const raw = await redis.get(metaKey);
+    const raw = await client.get(metaKey);
 
     if (!raw) return null;
 
@@ -204,9 +227,9 @@ async function getSongFromRedis(
  * Format music cover URLs by replacing Kugou / Apple Music placeholders.
  * Ensures HTTPS is used to avoid mixed content issues.
  */
-function formatMusicCoverUrl(
+export function formatMusicCoverUrl(
   imgUrl: string | null,
-  size: number = 400
+  size: number = OG_COVER_IMAGE_SIZE
 ): string | null {
   if (!imgUrl) return null;
   let url = imgUrl
@@ -215,6 +238,96 @@ function formatMusicCoverUrl(
     .replace("{h}", String(size));
   url = url.replace(/^http:\/\//, "https://");
   return url;
+}
+
+async function fetchRemoteImage(
+  imageUrl: string,
+  fetchImage?: FetchImage
+): Promise<Response> {
+  const upstream = fetchImage
+    ? await fetchImage(imageUrl)
+    : (
+        await safeFetchWithRedirects(
+          imageUrl,
+          {
+            method: "GET",
+            headers: {
+              Accept: "image/avif,image/webp,image/png,image/jpeg,image/*,*/*;q=0.8",
+              "User-Agent": "ryOS-OG-Image-Proxy/1.0",
+            },
+            signal: AbortSignal.timeout(OG_IMAGE_FETCH_TIMEOUT_MS),
+          },
+          { maxRedirects: 3 }
+        )
+      ).response;
+
+  if (!upstream.ok) {
+    throw new Error(`Image upstream failed (${upstream.status})`);
+  }
+
+  const contentType = upstream.headers.get("content-type") || "image/jpeg";
+  if (!contentType.toLowerCase().startsWith("image/")) {
+    throw new Error(`Image upstream returned ${contentType}`);
+  }
+
+  const contentLength = Number(upstream.headers.get("content-length"));
+  if (Number.isFinite(contentLength) && contentLength > OG_IMAGE_MAX_BYTES) {
+    throw new Error("Image upstream response is too large");
+  }
+
+  const bytes = await upstream.arrayBuffer();
+  if (bytes.byteLength > OG_IMAGE_MAX_BYTES) {
+    throw new Error("Image upstream response is too large");
+  }
+
+  return new Response(bytes, {
+    status: 200,
+    headers: {
+      "Content-Type": contentType,
+      "Cache-Control": "public, max-age=3600, s-maxage=86400",
+    },
+  });
+}
+
+function redirectToAppIcon(publicOrigin: string, appId: "ipod" | "karaoke") {
+  return Response.redirect(getAppIconUrl(publicOrigin, appId), 302);
+}
+
+export async function createOgSongCoverResponse(
+  request: Request,
+  options: {
+    getSong?: SongMetadataReader;
+    fetchImage?: FetchImage;
+  } = {}
+): Promise<Response> {
+  const url = new URL(request.url);
+  const publicOrigin = getAppPublicOrigin(url.origin);
+  const appParam = url.searchParams.get("app");
+  const appId: "ipod" | "karaoke" =
+    appParam === "karaoke" ? "karaoke" : "ipod";
+  const songId = url.searchParams.get("id") || "";
+
+  if (!songId) {
+    return redirectToAppIcon(publicOrigin, appId);
+  }
+
+  const getSong = options.getSong || getSongFromRedis;
+  const songInfo = await getSong(songId);
+  const coverUrl = formatMusicCoverUrl(songInfo?.cover ?? null);
+  const youtubeThumbnail = isYouTubeVideoId(songId)
+    ? getYouTubeThumbnailUrl(songId)
+    : null;
+
+  for (const candidate of [coverUrl, youtubeThumbnail]) {
+    if (!candidate) continue;
+    try {
+      return await fetchRemoteImage(candidate, options.fetchImage);
+    } catch {
+      // Try the next candidate so a flaky cover host doesn't break previews.
+    }
+  }
+
+  return redirectToAppIcon(publicOrigin, appId);
 }
 
 // Simple title parser - extracts artist and title from common YouTube formats
@@ -278,7 +391,7 @@ async function getYouTubeInfo(
 export async function createOgShareResponse(
   request: Request,
   options: {
-    getSong?: (songId: string) => Promise<SongShareMetadata | null>;
+    getSong?: SongMetadataReader;
   } = {}
 ): Promise<Response | null> {
   if (request.method !== "GET" && request.method !== "HEAD") {
@@ -331,7 +444,7 @@ export async function createOgShareResponse(
 
     const songInfo = await (options.getSong || getSongFromRedis)(songId);
     if (songInfo) {
-      imageUrl = formatMusicCoverUrl(songInfo.cover, 400) || imageUrl;
+      imageUrl = getOgSongCoverProxyUrl(publicOrigin, "ipod", songId);
       if (songInfo.artist) {
         title = `${songInfo.title} - ${songInfo.artist}`;
         description = "Listen on ryOS iPod";
@@ -340,8 +453,22 @@ export async function createOgShareResponse(
         description = "Listen on ryOS iPod";
       }
     } else {
-      title = "Shared Song - ryOS";
-      description = "Listen on ryOS iPod";
+      const ytInfo = isYouTubeVideoId(songId)
+        ? await getYouTubeInfo(songId)
+        : null;
+      if (ytInfo) {
+        imageUrl = getOgSongCoverProxyUrl(publicOrigin, "ipod", songId);
+        if (ytInfo.artist) {
+          title = `${ytInfo.title} - ${ytInfo.artist}`;
+          description = "Listen on ryOS iPod";
+        } else {
+          title = ytInfo.title;
+          description = "Listen on ryOS iPod";
+        }
+      } else {
+        title = "Shared Song - ryOS";
+        description = "Listen on ryOS iPod";
+      }
     }
     matched = true;
   }
@@ -353,15 +480,27 @@ export async function createOgShareResponse(
 
     const songInfo = await (options.getSong || getSongFromRedis)(songId);
     if (songInfo) {
-      imageUrl = formatMusicCoverUrl(songInfo.cover, 400) || imageUrl;
+      imageUrl = getOgSongCoverProxyUrl(publicOrigin, "karaoke", songId);
       const songDisplay = songInfo.artist
         ? `${songInfo.title} - ${songInfo.artist}`
         : songInfo.title;
       title = `Sing ${songDisplay} on ryOS`;
       description = "Sing along on ryOS Karaoke";
     } else {
-      title = "Sing on ryOS Karaoke";
-      description = "Sing along on ryOS Karaoke";
+      const ytInfo = isYouTubeVideoId(songId)
+        ? await getYouTubeInfo(songId)
+        : null;
+      if (ytInfo) {
+        imageUrl = getOgSongCoverProxyUrl(publicOrigin, "karaoke", songId);
+        const songDisplay = ytInfo.artist
+          ? `${ytInfo.title} - ${ytInfo.artist}`
+          : ytInfo.title;
+        title = `Sing ${songDisplay} on ryOS`;
+        description = "Sing along on ryOS Karaoke";
+      } else {
+        title = "Sing on ryOS Karaoke";
+        description = "Sing along on ryOS Karaoke";
+      }
     }
     matched = true;
   }

--- a/api/og-song-cover.ts
+++ b/api/og-song-cover.ts
@@ -1,0 +1,41 @@
+import { apiHandler } from "./_utils/api-handler.js";
+import { createOgSongCoverResponse } from "./_utils/og-share.js";
+
+export const runtime = "nodejs";
+export const maxDuration = 15;
+
+function headerValue(value: string | string[] | undefined): string | undefined {
+  return Array.isArray(value) ? value[0] : value;
+}
+
+function requestOrigin(req: { headers: Record<string, string | string[] | undefined> }): string {
+  const proto = headerValue(req.headers["x-forwarded-proto"]) || "https";
+  const host =
+    headerValue(req.headers["x-forwarded-host"]) ||
+    headerValue(req.headers.host) ||
+    "localhost";
+  return `${proto}://${host}`;
+}
+
+export default apiHandler(
+  { methods: ["GET", "HEAD"], contentType: null, analytics: false },
+  async ({ req, res }) => {
+    const requestUrl = new URL(req.url || "/api/og-song-cover", requestOrigin(req));
+    const response = await createOgSongCoverResponse(
+      new Request(requestUrl, { method: req.method || "GET" })
+    );
+
+    response.headers.forEach((value, key) => {
+      res.setHeader(key, value);
+    });
+    res.status(response.status);
+
+    if (req.method === "HEAD") {
+      res.end();
+      return;
+    }
+
+    const body = await response.arrayBuffer();
+    res.send(Buffer.from(body));
+  }
+);

--- a/api/songs/_constants.ts
+++ b/api/songs/_constants.ts
@@ -63,6 +63,7 @@ export const UpdateSongSchema = z.object({
   title: z.string().max(500).optional(),
   artist: z.string().max(500).optional(),
   album: z.string().max(500).optional(),
+  cover: z.string().max(2000).optional(),
   lyricOffset: z.number().min(-300000).max(300000).optional(),
   lyricsSource: LyricsSourceSchema.optional(),
   // Options to clear cached data when lyrics source changes

--- a/api/songs/index.ts
+++ b/api/songs/index.ts
@@ -69,6 +69,7 @@ const CreateSongSchema = z.object({
   title: z.string().min(1),
   artist: z.string().optional(),
   album: z.string().optional(),
+  cover: z.string().max(2000).optional(),
   lyricOffset: z.number().optional(),
   lyricsSource: LyricsSourceSchema.optional(),
 });
@@ -99,6 +100,7 @@ const BulkImportSchema = z.object({
       title: z.string().min(1),
       artist: z.string().optional(),
       album: z.string().optional(),
+      cover: z.string().max(2000).optional(),
       lyricOffset: z.number().optional(),
       lyricsSource: LyricsSourceSchema.optional(),
       // Legacy format support
@@ -333,7 +335,7 @@ export default apiHandler<Record<string, unknown>>(
           const lyricsValue = getFieldValue<{ lrc?: string; krc?: string; cover?: string }>(songData.lyrics);
           
           // Cover: prefer from lyrics data (backwards compat), otherwise from existing, otherwise fetch later
-          const cover = lyricsValue?.cover || existing?.cover;
+          const cover = songData.cover || lyricsValue?.cover || existing?.cover;
 
           // Build metadata (cover is now in metadata, not lyrics)
           // For imports, respect the original createdBy from the export file
@@ -516,6 +518,7 @@ export default apiHandler<Record<string, unknown>>(
           title: songData.title,
           artist: songData.artist,
           album: songData.album,
+          cover: songData.cover,
           lyricOffset: songData.lyricOffset,
           lyricsSource: songData.lyricsSource as LyricsSource | undefined,
           createdBy: existing?.createdBy || username || undefined,

--- a/src/utils/songMetadataCache.ts
+++ b/src/utils/songMetadataCache.ts
@@ -88,6 +88,7 @@ type BulkImportSong = {
   title: string;
   artist?: string;
   album?: string;
+  cover?: string;
   lyricOffset?: number;
   lyricsSource?: CachedLyricsSource;
   // Content fields (may be compressed gzip:base64 strings or raw objects)
@@ -332,6 +333,7 @@ export async function saveSongMetadata(
     title: string;
     artist?: string;
     album?: string;
+    cover?: string;
     lyricOffset?: number;
     lyricsSource?: CachedLyricsSource;
   },
@@ -345,6 +347,7 @@ export async function saveSongMetadata(
         title: metadata.title,
         artist: metadata.artist,
         album: metadata.album,
+        cover: metadata.cover,
         lyricOffset: metadata.lyricOffset,
         lyricsSource: metadata.lyricsSource,
         isShare: options?.isShare,
@@ -694,6 +697,7 @@ export async function saveSongMetadataFromTrack(
     title: string;
     artist?: string;
     album?: string;
+    cover?: string;
     lyricOffset?: number;
     lyricsSource?: {
       hash: string;
@@ -718,6 +722,7 @@ export async function saveSongMetadataFromTrack(
       title: track.title,
       artist: track.artist,
       album: track.album,
+      cover: track.cover,
       lyricOffset: track.lyricOffset,
       lyricsSource: track.lyricsSource,
     },

--- a/tests/test-og-share.test.ts
+++ b/tests/test-og-share.test.ts
@@ -1,5 +1,8 @@
 import { afterEach, describe, expect, mock, test } from "bun:test";
-import { createOgShareResponse } from "../api/_utils/og-share";
+import {
+  createOgShareResponse,
+  createOgSongCoverResponse,
+} from "../api/_utils/og-share";
 import { UpdateSongSchema } from "../api/songs/_constants";
 
 const ORIGINAL_ENV = { ...process.env };
@@ -55,7 +58,7 @@ describe("og share response", () => {
     expect(response).toBeNull();
   });
 
-  test("uses stored iPod song metadata and formatted Kugou cover for OG tags", async () => {
+  test("uses stored iPod song metadata and ryOS-hosted cover proxy for OG tags", async () => {
     process.env.APP_PUBLIC_ORIGIN = "https://os.example.com";
     const fetchMock = mock(() => {
       throw new Error("YouTube metadata should not be fetched for song OG");
@@ -84,8 +87,9 @@ describe("og share response", () => {
         '<meta property="og:title" content="七里香 - 周杰倫">'
       );
       expect(body).toContain(
-        '<meta property="og:image" content="https://imge.kugou.com/stdmusic/400/album.jpg">'
+        '<meta property="og:image" content="https://os.example.com/api/og-song-cover?app=ipod&amp;id=abc123DEF45">'
       );
+      expect(body).not.toContain("imge.kugou.com");
       expect(body).not.toContain("i.ytimg.com");
       expect(fetchMock).not.toHaveBeenCalled();
     } finally {
@@ -116,9 +120,97 @@ describe("og share response", () => {
       '<meta property="og:title" content="Sing Bohemian Rhapsody - Queen on ryOS">'
     );
     expect(body).toContain(
-      '<meta property="og:image" content="https://is1-ssl.mzstatic.com/image/400x400bb.jpg">'
+      '<meta property="og:image" content="https://os.example.com/api/og-song-cover?app=karaoke&amp;id=am%3A1616228595">'
     );
+    expect(body).not.toContain("mzstatic.com");
     expect(body).not.toContain("i.ytimg.com");
+  });
+
+  test("falls back to YouTube metadata when no song metadata exists", async () => {
+    process.env.APP_PUBLIC_ORIGIN = "https://os.example.com";
+    const originalFetch = globalThis.fetch;
+    const fetchMock = mock(async () => {
+      return new Response(
+        JSON.stringify({ title: "Rick Astley - Never Gonna Give You Up" }),
+        { status: 200, headers: { "content-type": "application/json" } }
+      );
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    try {
+      const response = await createOgShareResponse(
+        new Request("https://os.example.com/ipod/dQw4w9WgXcQ"),
+        { getSong: async () => null }
+      );
+
+      expect(response).not.toBeNull();
+      const body = await response!.text();
+      expect(body).toContain(
+        '<meta property="og:title" content="Never Gonna Give You Up - Rick Astley">'
+      );
+      expect(body).toContain(
+        '<meta property="og:image" content="https://os.example.com/api/og-song-cover?app=ipod&amp;id=dQw4w9WgXcQ">'
+      );
+      expect(body).not.toContain("Shared Song - ryOS");
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("song cover proxy serves formatted Kugou artwork through ryOS", async () => {
+    const fetchImage = mock(async (url: string) => {
+      expect(url).toBe("https://imge.kugou.com/stdmusic/600/album.jpg");
+      return new Response(new Uint8Array([1, 2, 3]), {
+        status: 200,
+        headers: {
+          "content-type": "image/jpeg",
+          "content-length": "3",
+        },
+      });
+    });
+
+    const response = await createOgSongCoverResponse(
+      new Request(
+        "https://os.example.com/api/og-song-cover?app=ipod&id=abc123DEF45"
+      ),
+      {
+        getSong: async () => ({
+          title: "七里香",
+          artist: "周杰倫",
+          cover: "http://imge.kugou.com/stdmusic/{size}/album.jpg",
+        }),
+        fetchImage,
+      }
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe("image/jpeg");
+    expect(new Uint8Array(await response.arrayBuffer())).toEqual(
+      new Uint8Array([1, 2, 3])
+    );
+    expect(fetchImage).toHaveBeenCalledTimes(1);
+  });
+
+  test("song cover proxy falls back to YouTube thumbnail for uncached YouTube songs", async () => {
+    const fetchImage = mock(async (url: string) => {
+      expect(url).toBe("https://i.ytimg.com/vi/dQw4w9WgXcQ/hqdefault.jpg");
+      return new Response(new Uint8Array([4, 5]), {
+        status: 200,
+        headers: { "content-type": "image/jpeg" },
+      });
+    });
+
+    const response = await createOgSongCoverResponse(
+      new Request(
+        "https://os.example.com/api/og-song-cover?app=karaoke&id=dQw4w9WgXcQ"
+      ),
+      { getSong: async () => null, fetchImage }
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe("image/jpeg");
+    expect(fetchImage).toHaveBeenCalledTimes(1);
   });
 
   test("song metadata updates accept cover art for share-backed OG pages", () => {

--- a/tests/test-og-share.test.ts
+++ b/tests/test-og-share.test.ts
@@ -1,5 +1,6 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, mock, test } from "bun:test";
 import { createOgShareResponse } from "../api/_utils/og-share";
+import { UpdateSongSchema } from "../api/songs/_constants";
 
 const ORIGINAL_ENV = { ...process.env };
 
@@ -52,5 +53,80 @@ describe("og share response", () => {
     );
 
     expect(response).toBeNull();
+  });
+
+  test("uses stored iPod song metadata and formatted Kugou cover for OG tags", async () => {
+    process.env.APP_PUBLIC_ORIGIN = "https://os.example.com";
+    const fetchMock = mock(() => {
+      throw new Error("YouTube metadata should not be fetched for song OG");
+    });
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    try {
+      const response = await createOgShareResponse(
+        new Request("https://os.example.com/ipod/abc123DEF45"),
+        {
+          getSong: async (songId) => {
+            expect(songId).toBe("abc123DEF45");
+            return {
+              title: "七里香",
+              artist: "周杰倫",
+              cover: "http://imge.kugou.com/stdmusic/{size}/album.jpg",
+            };
+          },
+        }
+      );
+
+      expect(response).not.toBeNull();
+      const body = await response!.text();
+      expect(body).toContain(
+        '<meta property="og:title" content="七里香 - 周杰倫">'
+      );
+      expect(body).toContain(
+        '<meta property="og:image" content="https://imge.kugou.com/stdmusic/400/album.jpg">'
+      );
+      expect(body).not.toContain("i.ytimg.com");
+      expect(fetchMock).not.toHaveBeenCalled();
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("uses decoded Apple Music song ids and artwork templates for Karaoke OG tags", async () => {
+    process.env.APP_PUBLIC_ORIGIN = "https://os.example.com";
+
+    const response = await createOgShareResponse(
+      new Request("https://os.example.com/karaoke/am%3A1616228595"),
+      {
+        getSong: async (songId) => {
+          expect(songId).toBe("am:1616228595");
+          return {
+            title: "Bohemian Rhapsody",
+            artist: "Queen",
+            cover: "https://is1-ssl.mzstatic.com/image/{w}x{h}bb.jpg",
+          };
+        },
+      }
+    );
+
+    expect(response).not.toBeNull();
+    const body = await response!.text();
+    expect(body).toContain(
+      '<meta property="og:title" content="Sing Bohemian Rhapsody - Queen on ryOS">'
+    );
+    expect(body).toContain(
+      '<meta property="og:image" content="https://is1-ssl.mzstatic.com/image/400x400bb.jpg">'
+    );
+    expect(body).not.toContain("i.ytimg.com");
+  });
+
+  test("song metadata updates accept cover art for share-backed OG pages", () => {
+    expect(
+      UpdateSongSchema.parse({
+        title: "Song",
+        cover: "https://example.com/cover.jpg",
+      }).cover
+    ).toBe("https://example.com/cover.jpg");
   });
 });

--- a/tests/test-og-share.test.ts
+++ b/tests/test-og-share.test.ts
@@ -158,6 +158,32 @@ describe("og share response", () => {
     }
   });
 
+  test("keeps YouTube thumbnail proxy when iPod oEmbed metadata is unavailable", async () => {
+    process.env.APP_PUBLIC_ORIGIN = "https://os.example.com";
+    const originalFetch = globalThis.fetch;
+    const fetchMock = mock(async () => {
+      return new Response("unavailable", { status: 500 });
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    try {
+      const response = await createOgShareResponse(
+        new Request("https://os.example.com/ipod/dQw4w9WgXcQ"),
+        { getSong: async () => null }
+      );
+
+      expect(response).not.toBeNull();
+      const body = await response!.text();
+      expect(body).toContain(
+        '<meta property="og:image" content="https://os.example.com/api/og-song-cover?app=ipod&amp;id=dQw4w9WgXcQ">'
+      );
+      expect(body).not.toContain("/icons/macosx/ipod.png");
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
   test("song cover proxy serves formatted Kugou artwork through ryOS", async () => {
     const fetchImage = mock(async (url: string) => {
       expect(url).toBe("https://imge.kugou.com/stdmusic/600/album.jpg");
@@ -211,6 +237,43 @@ describe("og share response", () => {
     expect(response.status).toBe(200);
     expect(response.headers.get("content-type")).toBe("image/jpeg");
     expect(fetchImage).toHaveBeenCalledTimes(1);
+  });
+
+  test("song cover proxy falls back to YouTube thumbnail when stored cover fails", async () => {
+    const attempts: string[] = [];
+    const fetchImage = mock(async (url: string) => {
+      attempts.push(url);
+      if (url.includes("kugou.com")) {
+        return new Response("missing", { status: 404 });
+      }
+      return new Response(new Uint8Array([6, 7]), {
+        status: 200,
+        headers: { "content-type": "image/jpeg" },
+      });
+    });
+
+    const response = await createOgSongCoverResponse(
+      new Request(
+        "https://os.example.com/api/og-song-cover?app=ipod&id=dQw4w9WgXcQ"
+      ),
+      {
+        getSong: async () => ({
+          title: "Never Gonna Give You Up",
+          artist: "Rick Astley",
+          cover: "https://imge.kugou.com/stdmusic/{size}/missing.jpg",
+        }),
+        fetchImage,
+      }
+    );
+
+    expect(response.status).toBe(200);
+    expect(new Uint8Array(await response.arrayBuffer())).toEqual(
+      new Uint8Array([6, 7])
+    );
+    expect(attempts).toEqual([
+      "https://imge.kugou.com/stdmusic/600/missing.jpg",
+      "https://i.ytimg.com/vi/dQw4w9WgXcQ/hqdefault.jpg",
+    ]);
   });
 
   test("song metadata updates accept cover art for share-backed OG pages", () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Persist cover art when iPod/Karaoke shares save song metadata.
- Render iPod and Karaoke OG tags from stored song metadata while pointing `og:image` at a ryOS-hosted cover proxy instead of direct Kugou/Apple artwork URLs.
- Add `/api/og-song-cover` to proxy stored covers with SSRF-safe fetching, response size/type checks, CDN cache headers, and YouTube thumbnail fallback for uncached YouTube songs or failed stored covers.
- Restore YouTube oEmbed metadata fallback when a shared YouTube song is not present in Redis, and keep the thumbnail proxy even when oEmbed is unavailable.
- Add focused OG coverage for Kugou covers, Apple Music artwork templates, decoded song IDs, YouTube fallback metadata, oEmbed failure fallback, proxied cover responses, and cover update schema support.

### Testing
- `bun -e "import { createOgShareResponse } from './api/_utils/og-share.ts'; const originalFetch = globalThis.fetch; globalThis.fetch = async () => new Response('oembed unavailable', { status: 500 }); const r = await createOgShareResponse(new Request('https://os.example.com/ipod/dQw4w9WgXcQ'), { getSong: async () => null }); const body = await r!.text(); console.log(JSON.stringify({ status: r!.status, usesProxy: body.includes('/api/og-song-cover'), usesAppIcon: body.includes('/icons/macosx/ipod.png') })); globalThis.fetch = originalFetch;"`
- `bun test tests/test-og-share.test.ts`
- `bun test tests/test-og-share.test.ts tests/test-ipod-apple-music.test.ts`
- `bun run build`
- `bun run test:unit`
- `git diff --check && bun test tests/test-og-share.test.ts`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-69765ce4-d951-4656-9935-a7deb5eeec6d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-69765ce4-d951-4656-9935-a7deb5eeec6d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

