### PR TITLE
Fix music OG song metadata resolution

### DIFF
--- a/api/_utils/og-share.ts
+++ b/api/_utils/og-share.ts
@@ -151,50 +151,140 @@ function getRecord(value: unknown): Record<string, unknown> | null {
     : null;
 }
 
+const YOUTUBE_VIDEO_ID_REGEX = /^[a-zA-Z0-9_-]{11}$/;
+const APPLE_MUSIC_ID_REGEX = /^am:[A-Za-z0-9._-]{1,64}$/;
+
+function extractYouTubeVideoId(value: string): string | null {
+  if (YOUTUBE_VIDEO_ID_REGEX.test(value)) {
+    return value;
+  }
+
+  try {
+    const parsed = new URL(value);
+    if (parsed.hostname.includes("youtube.com")) {
+      const vParam = parsed.searchParams.get("v");
+      if (vParam && YOUTUBE_VIDEO_ID_REGEX.test(vParam)) {
+        return vParam;
+      }
+
+      const pathMatch = parsed.pathname.match(
+        /\/(?:embed\/|v\/|shorts\/)?([a-zA-Z0-9_-]{11})/
+      );
+      if (pathMatch) {
+        return pathMatch[1];
+      }
+    }
+
+    if (parsed.hostname === "youtu.be") {
+      const videoId = parsed.pathname.slice(1).split("/")[0];
+      if (YOUTUBE_VIDEO_ID_REGEX.test(videoId)) {
+        return videoId;
+      }
+    }
+  } catch {
+    // Fall through to regex extraction for URL-like strings without a scheme.
+  }
+
+  const match = value.match(
+    /(?:youtube\.com\/(?:[^/]+\/.+\/|(?:v|e(?:mbed)?)\/|shorts\/|.*[?&]v=)|youtu\.be\/)([a-zA-Z0-9_-]{11})/
+  );
+  return match?.[1] ?? null;
+}
+
+function extractAppleMusicSongId(value: string): string | null {
+  if (APPLE_MUSIC_ID_REGEX.test(value)) {
+    return value;
+  }
+
+  try {
+    const parsed = new URL(value);
+    if (!parsed.hostname.endsWith("music.apple.com")) {
+      return null;
+    }
+
+    const iParam = parsed.searchParams.get("i");
+    if (iParam) {
+      return `am:${iParam}`;
+    }
+
+    const pathId = parsed.pathname.split("/").filter(Boolean).at(-1);
+    return pathId ? `am:${pathId}` : null;
+  } catch {
+    return null;
+  }
+}
+
+export function resolveSongShareId(routeId: string): string {
+  const decoded = decodeRouteId(routeId);
+  return (
+    extractYouTubeVideoId(decoded) ||
+    extractAppleMusicSongId(decoded) ||
+    decoded
+  );
+}
+
+export function getSongShareMetadataFromRaw(
+  raw: unknown
+): SongShareMetadata | null {
+  if (!raw) return null;
+
+  const meta = getRecord(typeof raw === "string" ? JSON.parse(raw) : raw);
+  if (!meta) return null;
+
+  const lyricsSource = getRecord(meta.lyricsSource);
+  const artwork = getRecord(meta.artwork);
+  const title =
+    asNonEmptyString(lyricsSource?.title) || asNonEmptyString(meta?.title);
+  if (!title) return null;
+
+  return {
+    title,
+    artist:
+      asNonEmptyString(lyricsSource?.artist) ||
+      asNonEmptyString(meta?.artist),
+    cover:
+      asNonEmptyString(meta?.cover) ||
+      asNonEmptyString(meta?.artworkUrl) ||
+      asNonEmptyString(meta?.albumArtworkUrl) ||
+      asNonEmptyString(artwork?.url) ||
+      asNonEmptyString(meta?.artwork) ||
+      asNonEmptyString(meta?.image),
+  };
+}
+
+async function createSongRedisClient(): Promise<{
+  get<T = unknown>(key: string): Promise<T | null>;
+} | null> {
+  if (
+    process.env.REDIS_KV_REST_API_URL?.trim() &&
+    process.env.REDIS_KV_REST_API_TOKEN?.trim()
+  ) {
+    return new Redis({
+      url: process.env.REDIS_KV_REST_API_URL,
+      token: process.env.REDIS_KV_REST_API_TOKEN,
+    });
+  }
+
+  if (process.env.REDIS_URL?.trim()) {
+    const { createRedis } = await import("./redis.js");
+    return createRedis();
+  }
+
+  return null;
+}
+
 // Fetch song metadata from Redis song library
 async function getSongFromRedis(
   songId: string
 ): Promise<SongShareMetadata | null> {
   try {
-    // Skip if no Redis credentials
-    if (
-      !process.env.REDIS_KV_REST_API_URL ||
-      !process.env.REDIS_KV_REST_API_TOKEN
-    ) {
-      return null;
-    }
-
-    const redis = new Redis({
-      url: process.env.REDIS_KV_REST_API_URL,
-      token: process.env.REDIS_KV_REST_API_TOKEN,
-    });
+    const redis = await createSongRedisClient();
+    if (!redis) return null;
 
     // Fetch from song:meta:{id} (split storage format)
     const metaKey = `song:meta:${songId}`;
     const raw = await redis.get(metaKey);
-
-    if (!raw) return null;
-
-    const meta = getRecord(typeof raw === "string" ? JSON.parse(raw) : raw);
-    if (!meta) return null;
-
-    const lyricsSource = getRecord(meta.lyricsSource);
-    const artwork = getRecord(meta.artwork);
-    const title =
-      asNonEmptyString(lyricsSource?.title) || asNonEmptyString(meta?.title);
-    if (!title) return null;
-
-    return {
-      title,
-      artist:
-        asNonEmptyString(lyricsSource?.artist) ||
-        asNonEmptyString(meta?.artist),
-      cover:
-        asNonEmptyString(meta?.cover) ||
-        asNonEmptyString(meta?.artworkUrl) ||
-        asNonEmptyString(artwork?.url) ||
-        asNonEmptyString(meta?.image),
-    };
+    return getSongShareMetadataFromRaw(raw);
   } catch {
     return null;
   }
@@ -326,7 +416,7 @@ export async function createOgShareResponse(
 
   const ipodMatch = pathname.match(/^\/ipod\/([^/?#]+)$/);
   if (ipodMatch) {
-    const songId = decodeRouteId(ipodMatch[1]);
+    const songId = resolveSongShareId(ipodMatch[1]);
     imageUrl = getAppIconUrl(publicOrigin, "ipod");
 
     const songInfo = await (options.getSong || getSongFromRedis)(songId);
@@ -348,7 +438,7 @@ export async function createOgShareResponse(
 
   const karaokeMatch = pathname.match(/^\/karaoke\/([^/?#]+)$/);
   if (karaokeMatch) {
-    const songId = decodeRouteId(karaokeMatch[1]);
+    const songId = resolveSongShareId(karaokeMatch[1]);
     imageUrl = getAppIconUrl(publicOrigin, "karaoke");
 
     const songInfo = await (options.getSong || getSongFromRedis)(songId);

--- a/tests/test-og-share.test.ts
+++ b/tests/test-og-share.test.ts
@@ -1,5 +1,9 @@
 import { afterEach, describe, expect, mock, test } from "bun:test";
-import { createOgShareResponse } from "../api/_utils/og-share";
+import {
+  createOgShareResponse,
+  getSongShareMetadataFromRaw,
+  resolveSongShareId,
+} from "../api/_utils/og-share";
 import { UpdateSongSchema } from "../api/songs/_constants";
 
 const ORIGINAL_ENV = { ...process.env };
@@ -119,6 +123,79 @@ describe("og share response", () => {
       '<meta property="og:image" content="https://is1-ssl.mzstatic.com/image/400x400bb.jpg">'
     );
     expect(body).not.toContain("i.ytimg.com");
+  });
+
+  test("uses the YouTube id from encoded share URL routes for song OG lookups", async () => {
+    process.env.APP_PUBLIC_ORIGIN = "https://os.example.com";
+    const encodedUrl = encodeURIComponent(
+      "https://www.youtube.com/watch?v=abc123DEF45"
+    );
+
+    const response = await createOgShareResponse(
+      new Request(`https://os.example.com/karaoke/${encodedUrl}`),
+      {
+        getSong: async (songId) => {
+          expect(songId).toBe("abc123DEF45");
+          return {
+            title: "Stored Song",
+            artist: "Stored Artist",
+            cover: "https://example.com/album-art.jpg",
+          };
+        },
+      }
+    );
+
+    expect(response).not.toBeNull();
+    const body = await response!.text();
+    expect(body).toContain(
+      '<meta property="og:title" content="Sing Stored Song - Stored Artist on ryOS">'
+    );
+    expect(body).toContain(
+      '<meta property="og:image" content="https://example.com/album-art.jpg">'
+    );
+  });
+
+  test("normalizes supported song share route IDs", () => {
+    expect(resolveSongShareId("abc123DEF45")).toBe("abc123DEF45");
+    expect(resolveSongShareId("am%3A1616228595")).toBe("am:1616228595");
+    expect(
+      resolveSongShareId(
+        "https%3A%2F%2Fyoutu.be%2Fabc123DEF45%3Fsi%3Dshare"
+      )
+    ).toBe("abc123DEF45");
+    expect(
+      resolveSongShareId(
+        "https%3A%2F%2Fmusic.apple.com%2Fus%2Falbum%2Falbum%2F123%3Fi%3D1616228595"
+      )
+    ).toBe("am:1616228595");
+  });
+
+  test("extracts album artwork fields from stored song metadata", () => {
+    expect(
+      getSongShareMetadataFromRaw({
+        title: "Album Track",
+        artist: "Album Artist",
+        albumArtworkUrl: "https://example.com/album-artwork.jpg",
+      })
+    ).toEqual({
+      title: "Album Track",
+      artist: "Album Artist",
+      cover: "https://example.com/album-artwork.jpg",
+    });
+
+    expect(
+      getSongShareMetadataFromRaw(
+        JSON.stringify({
+          title: "Artwork Track",
+          artist: "Artwork Artist",
+          artwork: "https://example.com/artwork.jpg",
+        })
+      )
+    ).toEqual({
+      title: "Artwork Track",
+      artist: "Artwork Artist",
+      cover: "https://example.com/artwork.jpg",
+    });
   });
 
   test("song metadata updates accept cover art for share-backed OG pages", () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Normalize iPod/Karaoke share route values to stored song IDs before Redis lookup.
- Resolve stored song metadata from Redis for OG title/artist and album artwork fields.
- Add targeted OG coverage for YouTube URL IDs, Apple Music IDs, and artwork metadata.

### Testing
- `bun test tests/test-og-share.test.ts`
- `bun run build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a780971e-11c2-4cd2-b4d9-3274c1e0598a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a780971e-11c2-4cd2-b4d9-3274c1e0598a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

