### PR TITLE
fix: restore minimize and dock-restore window animations

### DIFF
--- a/src/apps/base/instanceMountPolicy.ts
+++ b/src/apps/base/instanceMountPolicy.ts
@@ -1,20 +1,14 @@
 import type { AppInstance } from "@/stores/useAppStore";
 
 /**
- * Gate mounting of heavy per-instance app trees.
- * Open, non-minimized windows stay mounted so background apps remain visible when
- * another app is launched (only minimized instances are unmounted for perf).
+ * Whether to mount the heavy per-instance app tree.
+ *
+ * All open instances stay mounted (including minimized) so `WindowFrame` can run
+ * minimize exit and dock-restore animations. Callers already skip closed instances.
  */
 export function shouldMountInstance(
   instance: AppInstance,
-  exposeMode: boolean,
+  _exposeMode: boolean,
 ): boolean {
-  if (!instance.isOpen) return false;
-  if (instance.isLoading) return true;
-
-  if (exposeMode && !instance.isMinimized && instance.appId !== "stickies") {
-    return true;
-  }
-
-  return !instance.isMinimized;
+  return instance.isOpen;
 }

--- a/tests/test-should-mount-instance.test.ts
+++ b/tests/test-should-mount-instance.test.ts
@@ -23,13 +23,13 @@ describe("shouldMountInstance", () => {
     expect(shouldMountInstance(a, false)).toBe(true);
   });
 
-  test("does not mount minimized windows", () => {
+  test("mounts minimized windows for dock minimize/restore animations", () => {
     const a = makeInstance({
       instanceId: "1",
       appId: "textedit",
       isMinimized: true,
     });
-    expect(shouldMountInstance(a, false)).toBe(false);
+    expect(shouldMountInstance(a, false)).toBe(true);
   });
 
   test("mounts while lazy loading even if not foreground", () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

After the instance mount policy landed in #1250, `shouldMountInstance()` returned `false` for minimized windows. `AppManager` then unmounted the entire app tree (`{shouldMount ? <AppComponent /> : null}`), so `WindowFrame` never stayed in the tree to:

- Run **AnimatePresence exit** when minimizing (shrink to dock icon)
- Run **restore initial** animation when clicking the dock (expand from dock)

Windows appeared to “teleport” minimized/restored with no animation.

## Fix

Keep all **open** instances mounted (`shouldMountInstance` → `instance.isOpen`). Minimized windows remain in the React tree; `WindowFrame` continues to drive minimize/restore motion via existing Framer Motion logic.

## Testing

- `bun test tests/test-should-mount-instance.test.ts`
- `bun run build`

Manual: minimize a window (zoom to dock), restore from dock — animations should match pre-regression behavior.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-47270fdb-30e1-46de-888b-5d6251da1d65"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-47270fdb-30e1-46de-888b-5d6251da1d65"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

