### PR TITLE
fix(ipod): vertical-only scrolling on modern UI screen

### DIFF
--- a/src/apps/ipod/components/IpodScreen.tsx
+++ b/src/apps/ipod/components/IpodScreen.tsx
@@ -946,7 +946,7 @@ export function IpodScreen({
               <div className="flex-1 relative">
                 <div
                   ref={setMenuScrollRef}
-                  className="absolute inset-0 overflow-auto ipod-menu-container"
+                  className="absolute inset-0 overflow-y-auto overflow-x-hidden ipod-menu-container"
                 >
                   <div
                     style={{
@@ -1032,8 +1032,10 @@ export function IpodScreen({
             >
               <div
                 className={cn(
-                  "flex-1 flex flex-col overflow-visible px-2",
-                  isModernUi ? "pt-1.5 pb-0.5" : "py-1"
+                  "flex-1 flex flex-col px-2",
+                  isModernUi
+                    ? "overflow-x-hidden overflow-y-visible pt-1.5 pb-0.5"
+                    : "overflow-visible py-1"
                 )}
               >
                 {currentTrack && nowPlayingDisplayTrack ? (

--- a/src/apps/ipod/components/MusicQuiz.tsx
+++ b/src/apps/ipod/components/MusicQuiz.tsx
@@ -866,7 +866,7 @@ export const MusicQuiz = function MusicQuiz(
             </div>
 
             {/* Options */}
-            <div className="flex-1 overflow-auto">
+            <div className="flex-1 overflow-y-auto overflow-x-hidden ipod-menu-container">
               {round?.options.map((option, idx) => {
                 const isSelected = idx === selectedIndex;
                 const isCorrectOption = phase === "feedback" && idx === round.correctIndex;

--- a/src/apps/ipod/components/screen/ScrollingText.tsx
+++ b/src/apps/ipod/components/screen/ScrollingText.tsx
@@ -131,7 +131,7 @@ export function ScrollingText({
     <div
       ref={containerRef}
       className={cn(
-        "relative overflow-visible",
+        "relative overflow-x-hidden overflow-y-visible",
         !showMarquee && "flex",
         !showMarquee && alignClass,
         className

--- a/src/index.css
+++ b/src/index.css
@@ -1350,6 +1350,10 @@ button.piano-key.piano-key[class*="bg-[#ff33ff]"] {
 
 /* Hide default scrollbars for custom implementation */
 .ipod-menu-container {
+  overflow-x: hidden;
+  overscroll-behavior-x: none;
+  /* Touch/trackpad: vertical list scroll only (marquee text must not drag the menu sideways). */
+  touch-action: pan-y;
   scrollbar-width: none; /* Firefox */
   -ms-overflow-style: none; /* IE/Edge */
 }
@@ -1408,6 +1412,8 @@ button.piano-key.piano-key[class*="bg-[#ff33ff]"] {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   color: black;
+  overflow-x: hidden;
+  overscroll-behavior-x: none;
 }
 
 /* iPod-classic-js Header (sampled from app/components/Header/index.tsx):


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Modern iPod menus could be scrolled horizontally when marquee labels or wide row content extended past the viewport. This felt like free-form panning instead of the intended vertical list behavior.

## Changes

- Menu list scroll container: `overflow-y-auto overflow-x-hidden` (was `overflow-auto`)
- `.ipod-menu-container`: `touch-action: pan-y`, `overscroll-behavior-x: none`, explicit `overflow-x: hidden`
- `ScrollingText`: clip horizontal overflow so marquee tracks do not widen the scrollable area
- Modern now playing body: `overflow-x-hidden` on the content column
- `.ipod-modern-screen`: horizontal overscroll guard
- Music Quiz options list: same vertical-only scroll classes

## Testing

- `bun run build` — passes
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-76549757-aeae-4f08-91a6-8ff2814517b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-76549757-aeae-4f08-91a6-8ff2814517b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

