### PR TITLE
feat(ipod): Apple Music loading spinner in modern titlebar

### DIFF
--- a/src/apps/ipod/components/IpodAppComponent.tsx
+++ b/src/apps/ipod/components/IpodAppComponent.tsx
@@ -85,6 +85,7 @@ export function IpodAppComponent({
     selectedMenuItem,
     menuDirection,
     menuHistory,
+    appleMusicMenuTitlebarLoading,
     isCoverFlowOpen,
     isMusicQuizOpen,
     setIsMusicQuizOpen,
@@ -448,6 +449,7 @@ export function IpodAppComponent({
                   furiganaMap={furiganaMap}
                   soramimiMap={soramimiMap}
                   activityState={activityState}
+                  appleMusicMenuTitlebarLoading={appleMusicMenuTitlebarLoading}
                   isCoverFlowOpen={isCoverFlowOpen}
                   // Modern UI: render Cover Flow inline inside the menu
                   // panel so the panel's own width transition (50%↔100%

--- a/src/apps/ipod/components/IpodScreen.tsx
+++ b/src/apps/ipod/components/IpodScreen.tsx
@@ -18,6 +18,7 @@ import {
   AppleMusicPlayerBridge,
 } from "./AppleMusicPlayerBridge";
 import { ActivityIndicatorWithLabel } from "@/components/ui/activity-indicator-with-label";
+import { ActivityIndicator } from "@/components/ui/activity-indicator";
 import { useTranslation } from "react-i18next";
 import {
   BatteryIndicator,
@@ -316,6 +317,7 @@ export function IpodScreen({
   furiganaMap,
   soramimiMap,
   activityState,
+  appleMusicMenuTitlebarLoading = false,
   isCoverFlowOpen = false,
   coverFlowSlot,
 }: IpodScreenProps) {
@@ -847,6 +849,12 @@ export function IpodScreen({
               : "px-1"
           )}
         />
+        {isModernUi && menuMode && appleMusicMenuTitlebarLoading ? (
+          <ActivityIndicator
+            size={12}
+            className="shrink-0 text-[#636567] [filter:drop-shadow(0_1px_0_rgba(255,255,255,0.9))]"
+          />
+        ) : null}
         <div
           className={cn(
             "flex items-center justify-end",

--- a/src/apps/ipod/hooks/useAppleMusicLibrary.ts
+++ b/src/apps/ipod/hooks/useAppleMusicLibrary.ts
@@ -1070,12 +1070,7 @@ export async function refreshAppleMusicRecentlyAdded(
     return store.appleMusicRecentlyAddedTracks;
   }
 
-  // Only flip the loading flag when there's nothing to display yet — a
-  // background refresh of an existing list should not flash "Loading…".
-  const hadCached = store.appleMusicRecentlyAddedTracks.length > 0;
-  if (!hadCached) {
-    store.setAppleMusicRecentlyAddedLoading(true);
-  }
+  store.setAppleMusicRecentlyAddedLoading(true);
 
   inFlightRecentlyAddedRefresh = (async () => {
     try {
@@ -1093,9 +1088,7 @@ export async function refreshAppleMusicRecentlyAdded(
       return tracks;
     } finally {
       inFlightRecentlyAddedRefresh = null;
-      if (!hadCached) {
-        useIpodStore.getState().setAppleMusicRecentlyAddedLoading(false);
-      }
+      useIpodStore.getState().setAppleMusicRecentlyAddedLoading(false);
     }
   })();
 
@@ -1131,10 +1124,7 @@ export async function refreshAppleMusicFavorites(
     return store.appleMusicFavoriteTracks;
   }
 
-  const hadCached = store.appleMusicFavoriteTracks.length > 0;
-  if (!hadCached) {
-    store.setAppleMusicFavoritesLoading(true);
-  }
+  store.setAppleMusicFavoritesLoading(true);
 
   inFlightFavoritesRefresh = (async () => {
     try {
@@ -1149,9 +1139,7 @@ export async function refreshAppleMusicFavorites(
       return tracks;
     } finally {
       inFlightFavoritesRefresh = null;
-      if (!hadCached) {
-        useIpodStore.getState().setAppleMusicFavoritesLoading(false);
-      }
+      useIpodStore.getState().setAppleMusicFavoritesLoading(false);
     }
   })();
 

--- a/src/apps/ipod/hooks/useIpodLogic.ts
+++ b/src/apps/ipod/hooks/useIpodLogic.ts
@@ -75,6 +75,11 @@ import type { MusicQuizRef } from "../components/MusicQuiz";
 import type { BrickGameRef } from "../components/BrickGame";
 import type { SongSearchResult } from "@/components/dialogs/SongSearchDialog";
 import { helpItems } from "..";
+import {
+  appleMusicLoadingPlaceholderMenuItems,
+  resolveAppleMusicMenuTitlebarLoading,
+  shouldUseModernAppleMusicTitlebarLoading,
+} from "../utils/appleMusicMenuLoading";
 
 // User-agent sniffing is constant for the document lifetime, so compute once
 // at module load instead of re-running these regexes on every render of the
@@ -444,6 +449,10 @@ export function useIpodLogic({
   const hasAttemptedRadioRestoreHydrationRef = useRef(false);
   const [isAppleMusicGeniusLoading, setIsAppleMusicGeniusLoading] =
     useState(false);
+
+  const uiVariant = useIpodStore((s) => s.uiVariant);
+  const useModernAppleMusicTitlebarLoading =
+    shouldUseModernAppleMusicTitlebarLoading(uiVariant);
   
   // Cover Flow state
   const [isCoverFlowOpen, setIsCoverFlowOpen] = useState(false);
@@ -897,8 +906,8 @@ export function useIpodLogic({
   const requestPlaylistTracksIfNeeded = useCallback((playlistId: string) => {
     // Always trigger a background refresh on playlist open. The fetcher
     // dedupes in-flight calls via `appleMusicPlaylistTracksLoading`, and
-    // the menu builder gates "Loading…" behind
-    // `playlistTracks.length === 0`, so cached tracks render
+    // the modern UI shows a titlebar spinner instead of a list
+    // placeholder; cached tracks render immediately while a
     // immediately while the refresh updates them in place. This gives
     // users a true SWR experience: opening a playlist shows cached
     // contents instantly AND silently picks up any new songs added
@@ -1034,10 +1043,9 @@ export function useIpodLogic({
   // Reads cached tracks straight from the store (already populated via
   // the IndexedDB hydration in `useAppleMusicLibrary`) and kicks off a
   // background refresh that updates the store in-place when it
-  // resolves. The menu builder gates "Loading…" on cache emptiness, so
-  // the only time the user sees the placeholder is the very first
-  // load — every subsequent open shows cached entries instantly while
-  // the refresh runs invisibly.
+  // resolves. The modern UI uses a titlebar spinner (not a list row)
+  // on first load; every subsequent open shows cached entries while
+  // the refresh runs and updates the list when done.
   const loadAppleMusicRecentlyAdded = useCallback(async () => {
     if (!appleMusicAuthorized) {
       void handleAppleMusicSignIn();
@@ -1108,7 +1116,7 @@ export function useIpodLogic({
     const promptForAuth = options?.promptForAuth ?? true;
     const showErrors = options?.showErrors ?? true;
     const hadCached = appleMusicRadioTracks.length > 0;
-    if (!hadCached) setIsAppleMusicRadioLoading(true);
+    setIsAppleMusicRadioLoading(true);
     try {
       const stations = await fetchAppleMusicRadioStations();
       setAppleMusicRadioTracks(stations);
@@ -1137,7 +1145,7 @@ export function useIpodLogic({
         );
       }
     } finally {
-      if (!hadCached) setIsAppleMusicRadioLoading(false);
+      setIsAppleMusicRadioLoading(false);
     }
   }, [
     appleMusicAuthorized,
@@ -1574,15 +1582,14 @@ export function useIpodLogic({
 
   const appleMusicRecentlyAddedMenuItems = useMemo(() => {
     const loadingLabel = t("apps.ipod.menuItems.loading", "Loading…");
-    if (isAppleMusicRecentlyAddedLoading && appleMusicRecentlyAddedTracks.length === 0) {
-      return [
-        {
-          label: loadingLabel,
-          action: () => {},
-          showChevron: false,
-          isLoading: true,
-        },
-      ];
+    if (
+      isAppleMusicRecentlyAddedLoading &&
+      appleMusicRecentlyAddedTracks.length === 0
+    ) {
+      return appleMusicLoadingPlaceholderMenuItems(
+        loadingLabel,
+        useModernAppleMusicTitlebarLoading
+      );
     }
 
     if (appleMusicRecentlyAddedTracks.length === 0) {
@@ -1618,19 +1625,16 @@ export function useIpodLogic({
     isAppleMusicRecentlyAddedLoading,
     playAppleMusicTrackFromMenu,
     menuLocale,
+    useModernAppleMusicTitlebarLoading,
   ]);
 
   const appleMusicFavoritesMenuItems = useMemo(() => {
     const loadingLabel = t("apps.ipod.menuItems.loading", "Loading…");
     if (isAppleMusicFavoritesLoading && appleMusicFavoriteTracks.length === 0) {
-      return [
-        {
-          label: loadingLabel,
-          action: () => {},
-          showChevron: false,
-          isLoading: true,
-        },
-      ];
+      return appleMusicLoadingPlaceholderMenuItems(
+        loadingLabel,
+        useModernAppleMusicTitlebarLoading
+      );
     }
 
     if (appleMusicFavoriteTracks.length === 0) {
@@ -1666,19 +1670,16 @@ export function useIpodLogic({
     isAppleMusicFavoritesLoading,
     playAppleMusicTrackFromMenu,
     menuLocale,
+    useModernAppleMusicTitlebarLoading,
   ]);
 
   const appleMusicRadioMenuItems = useMemo(() => {
     const loadingLabel = t("apps.ipod.menuItems.loading", "Loading…");
     if (isAppleMusicRadioLoading && appleMusicRadioTracks.length === 0) {
-      return [
-        {
-          label: loadingLabel,
-          action: () => {},
-          showChevron: false,
-          isLoading: true,
-        },
-      ];
+      return appleMusicLoadingPlaceholderMenuItems(
+        loadingLabel,
+        useModernAppleMusicTitlebarLoading
+      );
     }
 
     if (appleMusicRadioTracks.length === 0) {
@@ -1703,6 +1704,7 @@ export function useIpodLogic({
     isAppleMusicRadioLoading,
     playAppleMusicTrackFromMenu,
     menuLocale,
+    useModernAppleMusicTitlebarLoading,
   ]);
 
   const artistAllSongsMenuItemsByTitle = useMemo(() => {
@@ -1943,29 +1945,17 @@ export function useIpodLogic({
 
   const loadingLabel = t("apps.ipod.menuItems.loading", "Loading…");
   const applePlaylistTrackMenuItemsByPlaylist = useMemo(() => {
-    const result: Record<
-      string,
-      {
-        label: string;
-        action: () => void;
-        showChevron: boolean;
-        isLoading?: boolean;
-      }[]
-    > = {};
+    const result: Record<string, MenuItem[]> = {};
     for (const playlist of appleMusicPlaylists) {
       const playlistTracks = appleMusicPlaylistTracks[playlist.id] ?? [];
       const isLoading =
         appleMusicPlaylistTracksLoading[playlist.id] === true &&
         playlistTracks.length === 0;
       if (isLoading) {
-        result[playlist.id] = [
-          {
-            label: loadingLabel,
-            action: () => {},
-            showChevron: false,
-            isLoading: true,
-          },
-        ];
+        result[playlist.id] = appleMusicLoadingPlaceholderMenuItems(
+          loadingLabel,
+          useModernAppleMusicTitlebarLoading
+        );
       } else {
         const queueIds = playlistTracks.map((t) => t.id);
         result[playlist.id] = playlistTracks.map((track, trackListIndex) => {
@@ -1993,6 +1983,52 @@ export function useIpodLogic({
     appleMusicPlaylistTracksLoading,
     playAppleMusicTrackFromMenu,
     loadingLabel,
+    useModernAppleMusicTitlebarLoading,
+  ]);
+
+  const appleMusicMenuTitlebarLoading = useMemo(() => {
+    if (
+      !useModernAppleMusicTitlebarLoading ||
+      !isAppleMusic ||
+      !menuMode ||
+      menuHistory.length === 0
+    ) {
+      return false;
+    }
+    const currentMenu = menuHistory[menuHistory.length - 1];
+    const menuTitle = currentMenu.displayTitle ?? currentMenu.title;
+    return resolveAppleMusicMenuTitlebarLoading({
+      menuTitle,
+      recentlyAddedTitle: t(
+        "apps.ipod.menuItems.recentlyAdded",
+        "Recently Added"
+      ),
+      favoriteSongsTitle: t(
+        "apps.ipod.menuItems.favoriteSongs",
+        "Favorite Songs"
+      ),
+      radioTitle: t("apps.ipod.menuItems.radio", "Radio"),
+      playlistsTitle: t("apps.ipod.menuItems.playlists"),
+      isRecentlyAddedLoading: isAppleMusicRecentlyAddedLoading,
+      isFavoritesLoading: isAppleMusicFavoritesLoading,
+      isRadioLoading: isAppleMusicRadioLoading,
+      isLibraryLoading: appleMusicLibraryLoading,
+      playlistTracksLoading: appleMusicPlaylistTracksLoading,
+      playlists: appleMusicPlaylists,
+      playlistsCount: appleMusicPlaylists.length,
+    });
+  }, [
+    useModernAppleMusicTitlebarLoading,
+    isAppleMusic,
+    menuMode,
+    menuHistory,
+    isAppleMusicRecentlyAddedLoading,
+    isAppleMusicFavoritesLoading,
+    isAppleMusicRadioLoading,
+    appleMusicLibraryLoading,
+    appleMusicPlaylistTracksLoading,
+    appleMusicPlaylists,
+    menuLocale,
   ]);
 
   const applePlaylistsMenuItems = useMemo(
@@ -4137,6 +4173,7 @@ export function useIpodLogic({
     selectedMenuItem,
     menuDirection,
     menuHistory,
+    appleMusicMenuTitlebarLoading,
     cameFromNowPlayingMenuItem,
     isCoverFlowOpen,
     isMusicQuizOpen,

--- a/src/apps/ipod/types.ts
+++ b/src/apps/ipod/types.ts
@@ -152,6 +152,11 @@ export interface IpodScreenProps {
   /** Activity state for loading indicators */
   activityState: ActivityInfo;
   /**
+   * Modern UI: show a titlebar spinner while an Apple Music submenu
+   * (playlist tracks, Recently Added, etc.) is loading or refreshing.
+   */
+  appleMusicMenuTitlebarLoading?: boolean;
+  /**
    * Whether Cover Flow is open. In the modern iPod UI we render Cover
    * Flow inline inside the menu panel so the menu↔nowplaying chrome
    * width transition (50%↔100%) seamlessly carries the user into and

--- a/src/apps/ipod/utils/appleMusicMenuLoading.ts
+++ b/src/apps/ipod/utils/appleMusicMenuLoading.ts
@@ -1,0 +1,69 @@
+import type { MenuItem } from "../types";
+
+export function shouldUseModernAppleMusicTitlebarLoading(
+  uiVariant: string | undefined
+): boolean {
+  return (uiVariant ?? "modern") === "modern";
+}
+
+export function resolveAppleMusicMenuTitlebarLoading(options: {
+  menuTitle: string;
+  recentlyAddedTitle: string;
+  favoriteSongsTitle: string;
+  radioTitle: string;
+  playlistsTitle: string;
+  isRecentlyAddedLoading: boolean;
+  isFavoritesLoading: boolean;
+  isRadioLoading: boolean;
+  isLibraryLoading: boolean;
+  playlistTracksLoading: Record<string, boolean>;
+  playlists: { id: string; name: string }[];
+  playlistsCount: number;
+}): boolean {
+  const {
+    menuTitle,
+    recentlyAddedTitle,
+    favoriteSongsTitle,
+    radioTitle,
+    playlistsTitle,
+    isRecentlyAddedLoading,
+    isFavoritesLoading,
+    isRadioLoading,
+    isLibraryLoading,
+    playlistTracksLoading,
+    playlists,
+    playlistsCount,
+  } = options;
+
+  if (menuTitle === recentlyAddedTitle) return isRecentlyAddedLoading;
+  if (menuTitle === favoriteSongsTitle) return isFavoritesLoading;
+  if (menuTitle === radioTitle) return isRadioLoading;
+  if (menuTitle === playlistsTitle) {
+    return isLibraryLoading && playlistsCount === 0;
+  }
+
+  const playlist = playlists.find((entry) => entry.name === menuTitle);
+  if (playlist) {
+    return playlistTracksLoading[playlist.id] === true;
+  }
+
+  return false;
+}
+
+/** Classic LCD: one non-interactive "Loading…" row; modern: empty list + titlebar spinner. */
+export function appleMusicLoadingPlaceholderMenuItems(
+  loadingLabel: string,
+  useModernTitlebarLoading: boolean
+): MenuItem[] {
+  if (useModernTitlebarLoading) {
+    return [];
+  }
+  return [
+    {
+      label: loadingLabel,
+      action: () => {},
+      showChevron: false,
+      isLoading: true,
+    },
+  ];
+}

--- a/tests/test-ipod-apple-music-menu-loading.test.ts
+++ b/tests/test-ipod-apple-music-menu-loading.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from "bun:test";
+import {
+  appleMusicLoadingPlaceholderMenuItems,
+  resolveAppleMusicMenuTitlebarLoading,
+  shouldUseModernAppleMusicTitlebarLoading,
+} from "../src/apps/ipod/utils/appleMusicMenuLoading";
+
+describe("appleMusicMenuLoading", () => {
+  test("shouldUseModernAppleMusicTitlebarLoading is true only for modern uiVariant", () => {
+    expect(shouldUseModernAppleMusicTitlebarLoading("modern")).toBe(true);
+    expect(shouldUseModernAppleMusicTitlebarLoading("classic")).toBe(false);
+    expect(shouldUseModernAppleMusicTitlebarLoading(undefined)).toBe(true);
+  });
+
+  test("appleMusicLoadingPlaceholderMenuItems returns empty list for modern", () => {
+    expect(
+      appleMusicLoadingPlaceholderMenuItems("Loading…", true)
+    ).toEqual([]);
+  });
+
+  test("appleMusicLoadingPlaceholderMenuItems returns loading row for classic", () => {
+    const items = appleMusicLoadingPlaceholderMenuItems("Loading…", false);
+    expect(items).toHaveLength(1);
+    expect(items[0]?.label).toBe("Loading…");
+    expect(items[0]?.isLoading).toBe(true);
+  });
+
+  test("resolveAppleMusicMenuTitlebarLoading matches playlist track fetch", () => {
+    expect(
+      resolveAppleMusicMenuTitlebarLoading({
+        menuTitle: "Road Trip",
+        recentlyAddedTitle: "Recently Added",
+        favoriteSongsTitle: "Favorite Songs",
+        radioTitle: "Radio",
+        playlistsTitle: "Playlists",
+        isRecentlyAddedLoading: false,
+        isFavoritesLoading: false,
+        isRadioLoading: false,
+        isLibraryLoading: false,
+        playlistTracksLoading: { "p:1": true },
+        playlists: [{ id: "p:1", name: "Road Trip" }],
+        playlistsCount: 3,
+      })
+    ).toBe(true);
+  });
+
+  test("resolveAppleMusicMenuTitlebarLoading ignores playlist loading for unrelated menus", () => {
+    expect(
+      resolveAppleMusicMenuTitlebarLoading({
+        menuTitle: "Artists",
+        recentlyAddedTitle: "Recently Added",
+        favoriteSongsTitle: "Favorite Songs",
+        radioTitle: "Radio",
+        playlistsTitle: "Playlists",
+        isRecentlyAddedLoading: false,
+        isFavoritesLoading: false,
+        isRadioLoading: false,
+        isLibraryLoading: false,
+        playlistTracksLoading: { "p:1": true },
+        playlists: [{ id: "p:1", name: "Road Trip" }],
+        playlistsCount: 3,
+      })
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

On the **modern** iPod skin, Apple Music submenu loading (playlist tracks, Recently Added, Favorite Songs, Radio, and the Playlists list while the library syncs) now shows a **titlebar spinner** beside the menu title instead of a `Loading…` row in the list.

- **First load (empty cache):** empty list + titlebar spinner until data arrives.
- **Playlist refresh (cached tracks):** existing tracks stay visible while the spinner shows in the titlebar; the menu sync updates the list when the fetch completes (unchanged SWR behavior, better feedback).
- **Classic LCD skin:** unchanged — still uses the in-list `Loading…` placeholder row.

## Testing

- `bun run build`
- `bun test tests/test-ipod-apple-music-menu-loading.test.ts tests/test-ipod-apple-music.test.ts`

## Notes

`refreshAppleMusicRecentlyAdded` / `refreshAppleMusicFavorites` now set the store loading flag for the whole in-flight refresh (not only when the cache is empty), so the modern titlebar spinner also appears during background updates.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4f109839-3a24-4c0d-89da-fdf4dae33023"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4f109839-3a24-4c0d-89da-fdf4dae33023"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

