### PR TITLE
Remove ryOS boot splash loader; keep black startup screen

### DIFF
--- a/index.html
+++ b/index.html
@@ -207,42 +207,7 @@
       })();
     </script>
   </head>
-  <body style="background-color: black; margin: 0">
-    <div id="ryos-boot-splash" role="status" aria-live="polite" aria-busy="true">
-      <style>
-        #ryos-boot-splash {
-          position: fixed;
-          inset: 0;
-          z-index: 2147483646;
-          display: flex;
-          flex-direction: column;
-          align-items: center;
-          justify-content: center;
-          gap: 1.25rem;
-          background: #000;
-          color: #c0c0c0;
-          font-family: "Lucida Grande", "Geneva", system-ui, sans-serif;
-        }
-        #ryos-boot-splash .ryos-boot-spinner {
-          width: 32px;
-          height: 32px;
-          border: 3px solid rgba(255, 255, 255, 0.15);
-          border-top-color: rgba(255, 255, 255, 0.85);
-          border-radius: 50%;
-          animation: ryos-boot-spin 0.85s linear infinite;
-        }
-        @keyframes ryos-boot-spin {
-          to { transform: rotate(360deg); }
-        }
-        html[data-os-theme="xp"] #ryos-boot-splash,
-        html[data-os-theme="win98"] #ryos-boot-splash {
-          background: #245edb;
-          color: #fff;
-        }
-      </style>
-      <div class="ryos-boot-spinner" aria-hidden="true"></div>
-      <span style="font-size: 13px; letter-spacing: 0.02em">ryOS</span>
-    </div>
+  <body style="background-color: #000; margin: 0">
     <script>
       (function () {
         try {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -137,12 +137,7 @@ if (import.meta.hot) {
 preloadFileSystemData();
 preloadIpodData();
 
-function hideBootSplash(): void {
-  document.getElementById("ryos-boot-splash")?.remove();
-}
-
 const renderApp = () => {
-  hideBootSplash();
   initializeAnalytics();
   ReactDOM.createRoot(document.getElementById("root")!).render(
     <React.StrictMode>
@@ -152,7 +147,7 @@ const renderApp = () => {
 };
 
 const bootstrap = async () => {
-  // Theme attributes for boot splash + first paint (before React)
+  // Theme attributes for first paint (before React)
   useThemeStore.getState().hydrate();
 
   try {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Removes the initial HTML boot splash (spinner + "ryOS" label) shown before React mounts. Startup now stays on the existing black page background until the app renders.

## Changes

- **`index.html`**: Removed `#ryos-boot-splash` overlay, spinner, and branding. Body keeps `background-color: #000`.
- **`src/main.tsx`**: Removed `hideBootSplash()` (no longer needed).

The in-app `BootScreen` dialog is unchanged — it still appears only for system operations (reset, restore, format, debug) via `setNextBootMessage`.

## Testing

- `bun run build` — passes
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8fe76218-a442-4516-9654-778b99086c00"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8fe76218-a442-4516-9654-778b99086c00"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

