### PR TITLE
Fix Macintosh HD desktop icon on Mac OS X theme

### DIFF
--- a/src/apps/finder/components/FileIcon.tsx
+++ b/src/apps/finder/components/FileIcon.tsx
@@ -157,6 +157,8 @@ export function FileIcon({
     if (!iconPath) return false;
     // Check if it's not a file path or URL
     if (iconPath.startsWith("/") || iconPath.startsWith("http")) return false;
+    // Logical asset names (e.g. disk.png) must render as images, not emoji text
+    if (/\.(png|jpe?g|gif|webp|svg|ico)$/i.test(iconPath)) return false;
     // Check if it's a short string (emojis are typically 1-4 characters including multi-byte)
     return iconPath.length <= 10;
   };

--- a/src/components/layout/Desktop.tsx
+++ b/src/components/layout/Desktop.tsx
@@ -22,6 +22,7 @@ import { useEventListener } from "@/hooks/useEventListener";
 import { cn } from "@/lib/utils";
 import { OS_SHELL_TEXT_SCALE_CLASS } from "@/lib/themeChrome";
 import { prefetchAppChunk } from "@/config/lazyAppComponent";
+import { useIconPath } from "@/utils/icons";
 import {
   createSelectionRect,
   getIntersectingSelectionIds,
@@ -108,7 +109,11 @@ export function Desktop({
 
   const { currentTheme, isWindowsTheme: isXpTheme, isMacOSTheme, isSystem7Theme } =
     useThemeFlags();
-  
+  const volumeDesktopIcon = useIconPath(
+    isXpTheme ? "pc.png" : "disk.png",
+    currentTheme
+  );
+
   // Check if running in Tauri
   const isTauriApp = typeof window !== "undefined" && "__TAURI__" in window;
 
@@ -1024,9 +1029,7 @@ export function Desktop({
             <FileIcon
               name={isXpTheme ? t("common.desktop.myComputer") : t("apps.finder.window.macintoshHd")}
               isDirectory={true}
-              icon={
-                isXpTheme ? "/icons/default/pc.png" : "/icons/default/disk.png"
-              }
+              icon={volumeDesktopIcon}
               onClick={(e) =>
                 handleDesktopItemClick(getDesktopAppItemId("macintosh-hd"), e)
               }

--- a/src/components/shared/ThemedIcon.tsx
+++ b/src/components/shared/ThemedIcon.tsx
@@ -1,5 +1,5 @@
-import React from "react";
-import { resolveIconLegacyAware, useIconPath } from "@/utils/icons";
+import React, { useEffect, useState } from "react";
+import { pickIconPath, resolveIconLegacyAware, useIconPath } from "@/utils/icons";
 import { useThemeFlags } from "@/hooks/useThemeFlags";
 import { cn } from "@/lib/utils";
 
@@ -79,23 +79,17 @@ export const ThemedIcon: React.FC<ThemedIconProps> = ({
   ...imgProps
 }) => {
   const { currentTheme } = useThemeFlags();
-  const { className, style, ...restImgProps } = imgProps;
+  const { className, style, onError, ...restImgProps } = imgProps;
   const composedClassName = cn("themed-icon", className);
 
-  // Check if name is a remote URL (for early return logic below)
   const isRemoteName = /^https?:\/\//i.test(name);
 
-  // Legacy-aware initial resolution (may already be themed path or absolute /icons/...)
-  // Skip resolution for remote URLs to avoid unnecessary processing
   const resolved = isRemoteName
     ? name
     : resolveIconLegacyAware(name, themeOverride ?? currentTheme);
 
-  // Check if resolved is a remote URL
   const isRemoteResolved = /^https?:\/\//i.test(resolved);
 
-  // Derive logical name for async theming only if inside /icons/ path.
-  // Strip any query string to avoid duplicating cache-busting params downstream.
   const withoutQuery = resolved.split("?")[0];
   const logical = withoutQuery.startsWith("/icons/")
     ? withoutQuery
@@ -103,10 +97,24 @@ export const ThemedIcon: React.FC<ThemedIconProps> = ({
         .replace(/^(?:\/icons\/[^/]+\/)/, "")
     : withoutQuery;
 
-  // Call hook unconditionally at the top level
   const themedPath = useIconPath(logical, themeOverride ?? currentTheme);
+  const activeTheme = themeOverride ?? currentTheme;
+  const primarySrc = themedPath || resolved;
+  const defaultFallbackSrc = pickIconPath(logical, {
+    theme: "default",
+    fallbackTheme: "default",
+  });
+  const [useDefaultFallback, setUseDefaultFallback] = useState(false);
 
-  // Simple passthrough for remote resources (avoid theming logic entirely)
+  useEffect(() => {
+    setUseDefaultFallback(false);
+  }, [primarySrc, defaultFallbackSrc, activeTheme, logical]);
+
+  const src =
+    useDefaultFallback && primarySrc !== defaultFallbackSrc
+      ? defaultFallbackSrc
+      : primarySrc;
+
   if (isRemoteName) {
     return (
       <img
@@ -114,12 +122,12 @@ export const ThemedIcon: React.FC<ThemedIconProps> = ({
         alt={alt || name}
         className={composedClassName}
         style={style}
+        onError={onError}
         {...restImgProps}
       />
     );
   }
 
-  // If result is a remote URL (in case resolver passed one through) just use it.
   if (isRemoteResolved) {
     return (
       <img
@@ -127,13 +135,12 @@ export const ThemedIcon: React.FC<ThemedIconProps> = ({
         alt={alt || name}
         className={composedClassName}
         style={style}
+        onError={onError}
         {...restImgProps}
       />
     );
   }
 
-  // Keep it simple: if async path still pending, show resolved immediately. Avoid switching for remote URLs.
-  const src = themedPath || resolved;
   const normalizedSrc = src.split("?")[0];
   const isThemedVariant =
     normalizedSrc.startsWith("/icons/") &&
@@ -150,6 +157,13 @@ export const ThemedIcon: React.FC<ThemedIconProps> = ({
       alt={alt || name}
       className={composedClassName}
       style={finalStyle}
+      onError={(event) => {
+        onError?.(event);
+        if (event.defaultPrevented) return;
+        if (primarySrc !== defaultFallbackSrc) {
+          setUseDefaultFallback(true);
+        }
+      }}
       {...restImgProps}
     />
   );

--- a/tests/test-desktop-volume-icon.test.ts
+++ b/tests/test-desktop-volume-icon.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from "bun:test";
+import { pickIconPath, resolveIconLegacyAware } from "@/utils/icons";
+
+describe("desktop volume icon theming", () => {
+  test("macosx theme resolves disk.png to macosx assets", () => {
+    expect(pickIconPath("disk.png", { theme: "macosx" })).toBe(
+      "/icons/macosx/disk.png"
+    );
+    expect(resolveIconLegacyAware("disk.png", "macosx")).toBe(
+      "/icons/macosx/disk.png"
+    );
+  });
+
+  test("legacy default disk path re-themes for macosx", () => {
+    expect(resolveIconLegacyAware("/icons/default/disk.png", "macosx")).toBe(
+      "/icons/macosx/disk.png"
+    );
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The Macintosh HD desktop shortcut hardcoded `/icons/default/disk.png`, so the Mac OS X theme did not consistently use the Aqua hard-disk asset (`/icons/macosx/disk.png`). In some cases (stale service-worker cache or failed themed fetch) the icon could appear broken.

## Changes

- **Desktop**: resolve the volume icon with `useIconPath("disk.png", currentTheme)` so Mac OS X gets the correct themed PNG.
- **ThemedIcon**: on image load error, fall back to the `default` theme asset for the same logical icon name.
- **FileIcon**: treat short names like `disk.png` as image assets, not emoji text.

## Testing

- `bun test ./tests/test-desktop-volume-icon.test.ts`
- `bun run build`
- Manual check on Mac OS X theme: Macintosh HD shows the silver Aqua hard drive icon.

![Macintosh HD icon on Mac OS X desktop](https://cursor.com/artifacts/c/art-04fc8b5d-9944-421d-8785-87865c1f1731)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-aadaffc3-c75e-46d8-9ef1-da84c0361df0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-aadaffc3-c75e-46d8-9ef1-da84c0361df0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

