### PR TITLE
fix(api): harden applet rate limiting after validation

### DIFF
--- a/api/applet-ai.ts
+++ b/api/applet-ai.ts
@@ -9,10 +9,12 @@ import {
   google,
   type GoogleGenerativeAIProviderOptions,
 } from "@ai-sdk/google";
+import type { VercelResponse } from "@vercel/node";
 import { z } from "zod";
 import * as RateLimit from "./_utils/_rate-limit.js";
 import { getClientIp } from "./_utils/_rate-limit.js";
 import { apiHandler } from "./_utils/api-handler.js";
+import type { initLogger } from "./_utils/_logging.js";
 import { isAllowedAppHost } from "./_utils/runtime-config.js";
 
 export const runtime = "nodejs";
@@ -290,6 +292,130 @@ const buildModelMessages = (
   return messages;
 };
 
+type AppletAiLogger = ReturnType<typeof initLogger>["logger"];
+
+const setAppletAiRateLimitHeaders = (
+  res: VercelResponse,
+  limit: number,
+  count: number,
+  resetSeconds: number
+): void => {
+  res.setHeader("X-RateLimit-Limit", String(limit));
+  res.setHeader(
+    "X-RateLimit-Remaining",
+    String(Math.max(0, limit - count))
+  );
+  res.setHeader("X-RateLimit-Reset", String(resetSeconds));
+};
+
+/**
+ * Enforce hourly text/image counters after request validation so malformed
+ * payloads do not consume quota. Returns false when a response was already sent.
+ */
+const enforceAppletAiRateLimit = async ({
+  res,
+  logger,
+  startTime,
+  mode,
+  rateLimitBypass,
+  isAuthenticatedUser,
+  usernameHeader,
+  ip,
+  identifier,
+}: {
+  res: VercelResponse;
+  logger: AppletAiLogger;
+  startTime: number;
+  mode: "text" | "image";
+  rateLimitBypass: boolean;
+  isAuthenticatedUser: boolean;
+  usernameHeader: string | null;
+  ip: string;
+  identifier: string;
+}): Promise<boolean> => {
+  const scope: RateLimitScope = mode === "image" ? "image-hour" : "text-hour";
+  const limit =
+    scope === "image-hour"
+      ? isAuthenticatedUser
+        ? AUTH_IMAGE_LIMIT_PER_HOUR
+        : ANON_IMAGE_LIMIT_PER_HOUR
+      : isAuthenticatedUser
+        ? AUTH_TEXT_LIMIT_PER_HOUR
+        : ANON_TEXT_LIMIT_PER_HOUR;
+
+  if (rateLimitBypass) {
+    logger.info("[rate-limit] Bypass enabled for trusted user", {
+      scope,
+      identifier,
+      wouldHaveLimit: limit,
+    });
+    return true;
+  }
+
+  try {
+    const key = RateLimit.makeKey([
+      "rl",
+      "applet-ai",
+      scope,
+      isAuthenticatedUser ? "user" : "ip",
+      isAuthenticatedUser ? usernameHeader! : ip,
+    ]);
+
+    const result = await RateLimit.checkCounterLimit({
+      key,
+      windowSeconds: RATE_LIMIT_WINDOW_SECONDS,
+      limit,
+    });
+
+    const resetSeconds =
+      typeof result.resetSeconds === "number" && result.resetSeconds > 0
+        ? result.resetSeconds
+        : result.windowSeconds;
+
+    logger.info("[rate-limit] Check", {
+      scope,
+      identifier,
+      isAuthenticatedUser,
+      count: result.count,
+      limit: result.limit,
+      remaining: Math.max(0, result.limit - result.count),
+      resetSeconds,
+      allowed: result.allowed,
+    });
+
+    setAppletAiRateLimitHeaders(res, result.limit, result.count, resetSeconds);
+
+    if (!result.allowed) {
+      logger.info("[rate-limit] Limit exceeded", {
+        scope,
+        identifier,
+        count: result.count,
+        limit: result.limit,
+        resetSeconds,
+      });
+
+      res.setHeader("Retry-After", String(resetSeconds));
+      logger.response(429, Date.now() - startTime);
+      res.status(429).json({
+        error: "rate_limit_exceeded",
+        scope,
+        limit: result.limit,
+        windowSeconds: result.windowSeconds,
+        resetSeconds,
+        identifier,
+      });
+      return false;
+    }
+
+    return true;
+  } catch (error) {
+    logger.error("Rate limit check failed:", error);
+    logger.response(503, Date.now() - startTime);
+    res.status(503).json({ error: "rate_limit_unavailable" });
+    return false;
+  }
+};
+
 // ============================================================================
 // Route Handler
 // ============================================================================
@@ -369,91 +495,8 @@ export default apiHandler<z.infer<typeof RequestSchema>>(
     temperature: typeof temperature === "number" ? temperature : "default",
   });
 
-  if (rateLimitBypass) {
-    const scope: RateLimitScope = mode === "image" ? "image-hour" : "text-hour";
-    const limit =
-      scope === "image-hour"
-        ? AUTH_IMAGE_LIMIT_PER_HOUR
-        : AUTH_TEXT_LIMIT_PER_HOUR;
-    logger.info("[rate-limit] Bypass enabled for trusted user", {
-      scope,
-      identifier,
-      wouldHaveLimit: limit,
-    });
-  }
-
-  if (!rateLimitBypass) {
-    try {
-      const scope: RateLimitScope = mode === "image" ? "image-hour" : "text-hour";
-      const limit =
-        scope === "image-hour"
-          ? isAuthenticatedUser
-            ? AUTH_IMAGE_LIMIT_PER_HOUR
-            : ANON_IMAGE_LIMIT_PER_HOUR
-          : isAuthenticatedUser
-          ? AUTH_TEXT_LIMIT_PER_HOUR
-          : ANON_TEXT_LIMIT_PER_HOUR;
-
-      const key = RateLimit.makeKey([
-        "rl",
-        "applet-ai",
-        scope,
-        isAuthenticatedUser ? "user" : "ip",
-        isAuthenticatedUser ? usernameHeader! : ip,
-      ]);
-
-      const result = await RateLimit.checkCounterLimit({
-        key,
-        windowSeconds: RATE_LIMIT_WINDOW_SECONDS,
-        limit,
-      });
-
-      const remaining = Math.max(0, result.limit - result.count);
-      const resetSeconds =
-        typeof result.resetSeconds === "number" && result.resetSeconds > 0
-          ? result.resetSeconds
-          : result.windowSeconds;
-
-      // Log rate limit information for all requests
-      logger.info("[rate-limit] Check", {
-        scope,
-        identifier,
-        isAuthenticatedUser,
-        count: result.count,
-        limit: result.limit,
-        remaining,
-        resetSeconds,
-        allowed: result.allowed,
-      });
-
-      if (!result.allowed) {
-        logger.info("[rate-limit] Limit exceeded", {
-          scope,
-          identifier,
-          count: result.count,
-          limit: result.limit,
-          resetSeconds,
-        });
-        
-        res.setHeader("Retry-After", String(resetSeconds));
-        res.setHeader("X-RateLimit-Limit", String(result.limit));
-        res.setHeader("X-RateLimit-Remaining", String(Math.max(0, result.limit - result.count)));
-        res.setHeader("X-RateLimit-Reset", String(resetSeconds));
-        
-        logger.response(429, Date.now() - startTime);
-        return res.status(429).json({
-          error: "rate_limit_exceeded",
-          scope,
-          limit: result.limit,
-          windowSeconds: result.windowSeconds,
-          resetSeconds,
-          identifier,
-        });
-      }
-    } catch (error) {
-      logger.error("Rate limit check failed:", error);
-    }
-  }
+  let imagePromptParts: Array<TextPart | ImagePart> | null = null;
+  let textGenerationMessages: ModelMessage[] | null = null;
 
   if (mode === "image") {
     const promptText = prompt?.trim() ?? "";
@@ -500,8 +543,47 @@ export default apiHandler<z.infer<typeof RequestSchema>>(
     if (promptParts.length === 0) {
       logger.warn("Image generation requires instructions or image attachments");
       logger.response(400, Date.now() - startTime);
-      return res.status(400).json({ error: "Image generation requires instructions or image attachments." });
+      return res.status(400).json({
+        error: "Image generation requires instructions or image attachments.",
+      });
     }
+
+    imagePromptParts = promptParts;
+  } else {
+    const conversation: ParsedMessage[] =
+      messages && messages.length > 0
+        ? messages
+        : [{ role: "user", content: prompt!.trim() }];
+
+    try {
+      textGenerationMessages = buildModelMessages(conversation, context);
+    } catch (error) {
+      logger.error("Message preparation failed:", error);
+      logger.response(400, Date.now() - startTime);
+      return res.status(400).json({
+        error: "Invalid attachments in request body",
+        ...(error instanceof Error ? { details: error.message } : {}),
+      });
+    }
+  }
+
+  const rateLimitAllowed = await enforceAppletAiRateLimit({
+    res,
+    logger,
+    startTime,
+    mode,
+    rateLimitBypass,
+    isAuthenticatedUser,
+    usernameHeader,
+    ip,
+    identifier,
+  });
+  if (!rateLimitAllowed) {
+    return;
+  }
+
+  if (mode === "image" && imagePromptParts) {
+    const promptParts = imagePromptParts;
 
     try {
       logger.info("Starting image generation (Gemini)", { promptPartsCount: promptParts.length });
@@ -557,22 +639,7 @@ export default apiHandler<z.infer<typeof RequestSchema>>(
     }
   }
 
-  const conversation: ParsedMessage[] =
-    messages && messages.length > 0
-      ? messages
-      : [{ role: "user", content: prompt!.trim() }];
-
-  let finalMessages: ModelMessage[];
-  try {
-    finalMessages = buildModelMessages(conversation, context);
-  } catch (error) {
-    logger.error("Message preparation failed:", error);
-    logger.response(400, Date.now() - startTime);
-    return res.status(400).json({
-      error: "Invalid attachments in request body",
-      ...(error instanceof Error ? { details: error.message } : {}),
-    });
-  }
+  const finalMessages = textGenerationMessages!;
 
   try {
     logger.info("Starting text generation", { messageCount: finalMessages.length });

--- a/api/share-applet.ts
+++ b/api/share-applet.ts
@@ -51,23 +51,26 @@ export default apiHandler<Record<string, unknown>>(
     if (req.method === "GET") {
       const listParam = req.query.list as string | undefined;
       const ip = getClientIp(req);
-      const rlConfig = listParam === "true" ? RATE_LIMITS.list : RATE_LIMITS.get;
-      const rlKey = RateLimit.makeKey(["rl", "applet", listParam === "true" ? "list" : "get", "ip", ip]);
-      const rlResult = await RateLimit.checkCounterLimit({
-        key: rlKey,
-        windowSeconds: rlConfig.windowSeconds,
-        limit: rlConfig.limit,
-      });
-      
-      if (!rlResult.allowed) {
-        logger.warn("Rate limit exceeded", { ip });
-        logger.response(429, Date.now() - startTime);
-        res.setHeader("Retry-After", String(rlResult.resetSeconds));
-        res.status(429).json({ error: "rate_limit_exceeded", limit: rlResult.limit, retryAfter: rlResult.resetSeconds });
-        return;
-      }
-      
+
       if (listParam === "true") {
+        const rlResult = await RateLimit.checkCounterLimit({
+          key: RateLimit.makeKey(["rl", "applet", "list", "ip", ip]),
+          windowSeconds: RATE_LIMITS.list.windowSeconds,
+          limit: RATE_LIMITS.list.limit,
+        });
+
+        if (!rlResult.allowed) {
+          logger.warn("Rate limit exceeded", { ip, scope: "list" });
+          logger.response(429, Date.now() - startTime);
+          res.setHeader("Retry-After", String(rlResult.resetSeconds));
+          res.status(429).json({
+            error: "rate_limit_exceeded",
+            limit: rlResult.limit,
+            retryAfter: rlResult.resetSeconds,
+          });
+          return;
+        }
+
         const appletIds: string[] = [];
         let cursor = 0;
         
@@ -117,11 +120,29 @@ export default apiHandler<Record<string, unknown>>(
         res.status(200).json({ applets });
         return;
       }
-      
+
       const id = req.query.id as string | undefined;
       if (!id) {
         logger.response(400, Date.now() - startTime);
         res.status(400).json({ error: "Missing id parameter" });
+        return;
+      }
+
+      const getRlResult = await RateLimit.checkCounterLimit({
+        key: RateLimit.makeKey(["rl", "applet", "get", "ip", ip]),
+        windowSeconds: RATE_LIMITS.get.windowSeconds,
+        limit: RATE_LIMITS.get.limit,
+      });
+
+      if (!getRlResult.allowed) {
+        logger.warn("Rate limit exceeded", { ip, scope: "get" });
+        logger.response(429, Date.now() - startTime);
+        res.setHeader("Retry-After", String(getRlResult.resetSeconds));
+        res.status(429).json({
+          error: "rate_limit_exceeded",
+          limit: getRlResult.limit,
+          retryAfter: getRlResult.resetSeconds,
+        });
         return;
       }
 
@@ -159,25 +180,25 @@ export default apiHandler<Record<string, unknown>>(
         return;
       }
 
+      const validation = SaveAppletRequestSchema.safeParse(body);
+      if (!validation.success) {
+        logger.response(400, Date.now() - startTime);
+        res.status(400).json({ error: "Invalid request body", details: validation.error.format() });
+        return;
+      }
+
       const rlKey = RateLimit.makeKey(["rl", "applet", "save", "user", username || "unknown"]);
       const rlResult = await RateLimit.checkCounterLimit({
         key: rlKey,
         windowSeconds: RATE_LIMITS.save.windowSeconds,
         limit: RATE_LIMITS.save.limit,
       });
-      
+
       if (!rlResult.allowed) {
         logger.warn("Rate limit exceeded", { username });
         logger.response(429, Date.now() - startTime);
         res.setHeader("Retry-After", String(rlResult.resetSeconds));
         res.status(429).json({ error: "rate_limit_exceeded", limit: rlResult.limit, retryAfter: rlResult.resetSeconds });
-        return;
-      }
-
-      const validation = SaveAppletRequestSchema.safeParse(body);
-      if (!validation.success) {
-        logger.response(400, Date.now() - startTime);
-        res.status(400).json({ error: "Invalid request body", details: validation.error.format() });
         return;
       }
 
@@ -243,24 +264,24 @@ export default apiHandler<Record<string, unknown>>(
         return;
       }
 
+      const id = req.query.id as string | undefined;
+      if (!id) {
+        logger.response(400, Date.now() - startTime);
+        res.status(400).json({ error: "Missing id parameter" });
+        return;
+      }
+
       const rlKey = RateLimit.makeKey(["rl", "applet", "delete", "user", username || "unknown"]);
       const rlResult = await RateLimit.checkCounterLimit({
         key: rlKey,
         windowSeconds: RATE_LIMITS.delete.windowSeconds,
         limit: RATE_LIMITS.delete.limit,
       });
-      
+
       if (!rlResult.allowed) {
         logger.response(429, Date.now() - startTime);
         res.setHeader("Retry-After", String(rlResult.resetSeconds));
         res.status(429).json({ error: "rate_limit_exceeded", limit: rlResult.limit, retryAfter: rlResult.resetSeconds });
-        return;
-      }
-
-      const id = req.query.id as string | undefined;
-      if (!id) {
-        logger.response(400, Date.now() - startTime);
-        res.status(400).json({ error: "Missing id parameter" });
         return;
       }
 
@@ -289,20 +310,6 @@ export default apiHandler<Record<string, unknown>>(
         return;
       }
 
-      const rlKey = RateLimit.makeKey(["rl", "applet", "patch", "user", username || "unknown"]);
-      const rlResult = await RateLimit.checkCounterLimit({
-        key: rlKey,
-        windowSeconds: RATE_LIMITS.patch.windowSeconds,
-        limit: RATE_LIMITS.patch.limit,
-      });
-      
-      if (!rlResult.allowed) {
-        logger.response(429, Date.now() - startTime);
-        res.setHeader("Retry-After", String(rlResult.resetSeconds));
-        res.status(429).json({ error: "rate_limit_exceeded", limit: rlResult.limit, retryAfter: rlResult.resetSeconds });
-        return;
-      }
-
       const id = req.query.id as string | undefined;
       if (!id) {
         logger.response(400, Date.now() - startTime);
@@ -314,6 +321,23 @@ export default apiHandler<Record<string, unknown>>(
       if (typeof featured !== "boolean") {
         logger.response(400, Date.now() - startTime);
         res.status(400).json({ error: "Invalid request body: featured must be boolean" });
+        return;
+      }
+
+      const patchRlResult = await RateLimit.checkCounterLimit({
+        key: RateLimit.makeKey(["rl", "applet", "patch", "user", username || "unknown"]),
+        windowSeconds: RATE_LIMITS.patch.windowSeconds,
+        limit: RATE_LIMITS.patch.limit,
+      });
+
+      if (!patchRlResult.allowed) {
+        logger.response(429, Date.now() - startTime);
+        res.setHeader("Retry-After", String(patchRlResult.resetSeconds));
+        res.status(429).json({
+          error: "rate_limit_exceeded",
+          limit: patchRlResult.limit,
+          retryAfter: patchRlResult.resetSeconds,
+        });
         return;
       }
 

--- a/tests/test-applet-rate-limit.test.ts
+++ b/tests/test-applet-rate-limit.test.ts
@@ -1,0 +1,102 @@
+#!/usr/bin/env bun
+/**
+ * Regression tests for applet endpoint rate limiting.
+ */
+
+import { describe, test, expect, beforeAll } from "bun:test";
+import {
+  BASE_URL,
+  fetchWithOrigin,
+  fetchWithAuth,
+  ensureUserAuth,
+} from "./test-utils";
+
+describe("applet rate limits", () => {
+  let testToken: string | null = null;
+  let testUsername: string | null = null;
+
+  beforeAll(async () => {
+    testUsername = `rlsave${Math.floor(Math.random() * 100000)}`;
+    testToken = await ensureUserAuth(testUsername, "testpassword123");
+  });
+
+  test("share-applet POST: invalid body does not consume save quota", async () => {
+    if (!testToken || !testUsername) {
+      console.log("  ⚠️  Skipped (test user not set up)");
+      return;
+    }
+
+    for (let i = 0; i < 25; i++) {
+      const invalid = await fetchWithAuth(
+        `${BASE_URL}/api/share-applet`,
+        testUsername,
+        testToken,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ title: "missing content" }),
+        }
+      );
+      expect(invalid.status).toBe(400);
+    }
+
+    const valid = await fetchWithAuth(
+      `${BASE_URL}/api/share-applet`,
+      testUsername,
+      testToken,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          content: "<html><body>rate limit regression</body></html>",
+          title: "Rate limit regression",
+        }),
+      }
+    );
+
+    expect(valid.status).toBe(200);
+  });
+
+  test("share-applet GET: missing id does not consume get quota", async () => {
+    for (let i = 0; i < 30; i++) {
+      const res = await fetchWithOrigin(`${BASE_URL}/api/share-applet`);
+      expect(res.status).toBe(400);
+    }
+
+    const res = await fetchWithOrigin(
+      `${BASE_URL}/api/share-applet?id=nonexistent${Date.now()}`
+    );
+    expect(res.status).toBe(404);
+  });
+
+  test("applet-ai: invalid image attachment does not consume image quota", async () => {
+    const badRequests = Array.from({ length: 5 }, () =>
+      fetchWithOrigin(`${BASE_URL}/api/applet-ai`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          mode: "image",
+          prompt: "draw something",
+          images: [{ mediaType: "image/png", data: "not-valid-base64!!!" }],
+        }),
+      })
+    );
+
+    const results = await Promise.all(badRequests);
+    for (const res of results) {
+      expect(res.status).toBe(400);
+    }
+
+    const ok = await fetchWithOrigin(`${BASE_URL}/api/applet-ai`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ prompt: "Reply with exactly: pong" }),
+    });
+
+    expect(ok.status === 200 || ok.status === 429).toBe(true);
+    if (ok.status === 200) {
+      const limitHeader = ok.headers.get("X-RateLimit-Limit");
+      expect(limitHeader !== null).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Audited applet-related rate limiting on `/api/applet-ai` and `/api/share-applet` and fixed several correctness issues.

### Bugs found

1. **`/api/share-applet` consumed quota on invalid requests** — POST rate limiting ran before Zod validation, so malformed save payloads (missing `content`) burned the per-user save budget. GET rate limiting ran before checking `id`, so repeated `400` responses consumed the per-IP get budget.
2. **`/api/applet-ai` consumed quota on invalid image payloads** — hourly counters incremented before base64/image attachment validation, so bad `mode: "image"` requests could exhaust the image limit without calling the model.
3. **`/api/applet-ai` failed open on Redis errors** — a rate-limit check exception logged and continued into Gemini generation, bypassing limits during Redis outages.
4. **Missing rate-limit headers on successful applet-ai responses** — docs advertise `X-RateLimit-*` headers, but they were only set on `429`.

### Fixes

- Centralized applet-ai enforcement in `enforceAppletAiRateLimit()` and call it only after request validation (including image attachment parsing and text message preparation).
- Return `503` with `rate_limit_unavailable` when the limiter cannot run (fail closed for this costly endpoint).
- Set `X-RateLimit-*` headers on allowed applet-ai responses.
- Reordered share-applet limits: validate auth/body/params first, then increment counters.
- Added `tests/test-applet-rate-limit.test.ts` regression coverage.

### Notes (unchanged by design)

- Untrusted applets still use anonymous `/api/applet-ai` buckets (no auth bridge) per the sandboxing model in #1171.
- Self-hosted deployments without trusted proxy headers still bucket unknown clients under `untrusted-shared-ip` (intentional anti-spoofing behavior).

## Testing

- `bun run build`
- `bun test tests/test-applet-rate-limit.test.ts`
- `bun test tests/test-ai.test.ts` (applet-ai sections)
- `bun test tests/test-share-applet.test.ts` (GET paths; POST flows skipped in this environment due to auth registration rate limits)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-55FB8DE6-1B50-4471-8229-16A52C9FCA83"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-55FB8DE6-1B50-4471-8229-16A52C9FCA83"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

