### PR TITLE
fix(prefetch): cache lazy app chunks for offline use

### DIFF
--- a/src/config/lazyAppComponent.tsx
+++ b/src/config/lazyAppComponent.tsx
@@ -29,6 +29,16 @@ export function prefetchLikelyAppChunks(appIds: readonly string[]): void {
   }
 }
 
+/**
+ * Warm every registered lazy app import (used after asset URL prefetch so chunks
+ * are in the service worker cache before going offline).
+ */
+export function prefetchAllRegisteredAppChunks(): void {
+  for (const loader of appChunkLoaders.values()) {
+    void loader();
+  }
+}
+
 // Helper to create a lazy-loaded component with Suspense
 // Uses a cache to maintain stable component references across HMR
 export function createLazyComponent<T = unknown>(

--- a/src/utils/prefetch.ts
+++ b/src/utils/prefetch.ts
@@ -20,6 +20,8 @@ import { setNextBootMessage } from "@/utils/bootMessage";
 import i18n from "@/lib/i18n";
 import { getApiUrl, isTauri } from "@/utils/platform";
 import { abortableFetch } from "@/utils/abortableFetch";
+import { prefetchAllRegisteredAppChunks } from "@/config/lazyAppComponent";
+import { discoverPrefetchAssetUrls } from "@/utils/prefetchChunkDiscovery";
 
 // Storage key for manifest timestamp (for cache invalidation)
 const MANIFEST_KEY = 'ryos:manifest-timestamp';
@@ -489,7 +491,7 @@ async function runPrefetchWithToast(
       }, prefetchOptions);
     }
     
-    // Prefetch JS chunks
+    // Prefetch JS chunks (app lazy entries + shared deps for offline use)
     if (jsUrls.length > 0) {
       const baseCompleted = overallCompleted;
       await prefetchUrlsWithProgress(jsUrls, 'Scripts', (completed, total) => {
@@ -497,6 +499,9 @@ async function runPrefetchWithToast(
         updateToast('scripts', completed, total);
       }, prefetchOptions);
     }
+
+    // Resolve registered app dynamic imports so chunks are in the SW/module graph
+    prefetchAllRegisteredAppChunks();
     
     // Prefetch static assets (textures, splash screens, etc.)
     if (assetUrls.length > 0) {
@@ -745,58 +750,41 @@ async function clearAllCaches(): Promise<void> {
 }
 
 /**
- * Discover all JS chunks by fetching the main bundle and parsing for dynamic imports
+ * Discover hashed JS/CSS assets for offline app support by parsing the main bundle
+ * (__vite__mapDeps + dynamic import targets from the main entry chunk).
  */
 async function discoverAllJsChunks(): Promise<string[]> {
   try {
-    // First, get the main bundle URL from index.html
-    const indexResponse = await abortableFetch('/index.html', {
-      method: 'GET',
+    const indexResponse = await abortableFetch("/index.html", {
+      method: "GET",
       timeout: 15000,
       throwOnHttpError: false,
       retry: { maxAttempts: 1, initialDelayMs: 250 },
     });
     if (!indexResponse.ok) return [];
-    
+
     const html = await indexResponse.text();
-    
-    // Find the main index bundle: /assets/index-XXXX.js
     const mainBundleMatch = html.match(/\/assets\/index-[A-Za-z0-9_-]+\.js/);
     if (!mainBundleMatch) {
-      // In development mode, Vite serves source directly (no bundled assets)
       if (import.meta.env.DEV) {
-        console.log('[Prefetch] Skipping JS chunk discovery in development mode');
+        console.log("[Prefetch] Skipping JS chunk discovery in development mode");
       } else {
-        console.warn('[Prefetch] Could not find main bundle in index.html');
+        console.warn("[Prefetch] Could not find main bundle in index.html");
       }
       return [];
     }
-    
-    // Fetch the main bundle to find dynamic import URLs
+
     const bundleResponse = await abortableFetch(mainBundleMatch[0], {
-      method: 'GET',
+      method: "GET",
       timeout: 15000,
       throwOnHttpError: false,
       retry: { maxAttempts: 1, initialDelayMs: 250 },
     });
     if (!bundleResponse.ok) return [];
-    
-    const bundleCode = await bundleResponse.text();
-    
-    // Find all asset URLs in the bundle
-    // Dynamic imports look like: "assets/ChatsAppComponent-BHyz_x7A.js" or "./ChatsAppComponent-..."
-    const assetPattern = /["'](?:\.\/|assets\/)([A-Za-z0-9_-]+)-[A-Za-z0-9_-]+\.js["']/g;
-    const matches = bundleCode.matchAll(assetPattern);
-    
-    // Extract just the filename part and build full URLs
-    const allAssets: string[] = [];
-    for (const match of matches) {
-      const filename = match[0].replace(/["']/g, '').replace(/^\.\//, '').replace(/^assets\//, '');
-      allAssets.push(`/assets/${filename}`);
-    }
-    
-    // Dedupe and return all JS chunks (includes locale translation-* chunks)
-    const uniqueAssets = [...new Set(allAssets)];
+
+    const mainBundleCode = await bundleResponse.text();
+    // __vite__mapDeps on the main bundle lists every lazy-app dependency (incl. Chats → mermaid).
+    const uniqueAssets = discoverPrefetchAssetUrls(mainBundleCode);
 
     const localeChunks = uniqueAssets.filter((url) =>
       /\/translation-[A-Za-z0-9_-]+\.js$/.test(url)
@@ -807,11 +795,15 @@ async function discoverAllJsChunks(): Promise<string[]> {
       );
     }
 
-    console.log(`[Prefetch] Discovered ${uniqueAssets.length} JS chunks from main bundle`);
+    const appChunks = uniqueAssets.filter((url) =>
+      /AppComponent-|PhotoBoothComponent-|\/mermaid-/.test(url)
+    );
+    console.log(
+      `[Prefetch] Discovered ${uniqueAssets.length} assets (${appChunks.length} app-related chunks)`
+    );
     return uniqueAssets;
-    
   } catch (error) {
-    console.warn('[Prefetch] Failed to discover JS chunks:', error);
+    console.warn("[Prefetch] Failed to discover JS chunks:", error);
     return [];
   }
 }

--- a/src/utils/prefetchChunkDiscovery.ts
+++ b/src/utils/prefetchChunkDiscovery.ts
@@ -1,0 +1,105 @@
+/**
+ * Discover hashed Vite asset URLs from built bundles for offline prefetch.
+ * Used by prefetch.ts after reading index.html + the main entry chunk.
+ */
+
+/** Normalize a path from a bundle string to a same-origin URL under /assets/. */
+export function normalizeViteAssetPath(raw: string): string | null {
+  const trimmed = raw.replace(/^["']|["']$/g, "").trim();
+  if (!trimmed) return null;
+
+  if (trimmed.startsWith("assets/")) {
+    return `/${trimmed}`;
+  }
+  if (trimmed.startsWith("./")) {
+    return `/assets/${trimmed.slice(2)}`;
+  }
+  if (trimmed.startsWith("/assets/")) {
+    return trimmed;
+  }
+  return null;
+}
+
+/** Parse __vite__mapDeps(..., d=(m.f||(m.f=[...]))) asset list from the main bundle. */
+export function extractUrlsFromViteMapDeps(bundleCode: string): string[] {
+  const marker = "m.f=[";
+  const start = bundleCode.indexOf(marker);
+  if (start === -1) return [];
+
+  let i = start + marker.length;
+  let depth = 1;
+  const urls: string[] = [];
+
+  while (i < bundleCode.length && depth > 0) {
+    const ch = bundleCode[i];
+    if (ch === "[") depth++;
+    else if (ch === "]") depth--;
+    i++;
+  }
+
+  if (depth !== 0) return urls;
+
+  const slice = bundleCode.slice(start + marker.length, i - 1);
+  const entryPattern = /["'](assets\/[^"']+)["']/g;
+  for (const match of slice.matchAll(entryPattern)) {
+    const url = normalizeViteAssetPath(match[1]);
+    if (url) urls.push(url);
+  }
+
+  return urls;
+}
+
+/** Extract ./foo.js and assets/foo.js references (JS + CSS) from bundle source text. */
+export function extractAssetUrlsFromBundle(bundleCode: string): string[] {
+  const urls: string[] = [];
+  const pattern =
+    /["'](?:\.\/|assets\/)([^"']+\.(?:js|css))["']/gi;
+
+  for (const match of bundleCode.matchAll(pattern)) {
+    const raw = match[0];
+    const url = normalizeViteAssetPath(raw);
+    if (url) urls.push(url);
+  }
+
+  return urls;
+}
+
+/** Lazy app entry chunks referenced via import("./ChunkName-….js") in the main bundle. */
+export function extractLazyEntryChunkPaths(bundleCode: string): string[] {
+  const paths: string[] = [];
+  const pattern = /import\(["'](\.\/[^"']+\.js)["']\)/g;
+  for (const match of bundleCode.matchAll(pattern)) {
+    const url = normalizeViteAssetPath(match[1]);
+    if (url) paths.push(url);
+  }
+  return paths;
+}
+
+export function mergeDiscoveredAssetUrls(...lists: readonly string[][]): string[] {
+  return [...new Set(lists.flat())];
+}
+
+/**
+ * Collect prefetch targets from the main bundle and optional follow-up chunks
+ * (lazy app entries and shared chunks like mermaid).
+ */
+export function discoverPrefetchAssetUrls(
+  mainBundleCode: string,
+  additionalBundleCodes: readonly string[] = []
+): string[] {
+  const fromMain = mergeDiscoveredAssetUrls(
+    extractUrlsFromViteMapDeps(mainBundleCode),
+    extractAssetUrlsFromBundle(mainBundleCode)
+  );
+
+  const entryChunks = extractLazyEntryChunkPaths(mainBundleCode);
+  const fromEntries: string[] = [];
+  for (const code of additionalBundleCodes) {
+    fromEntries.push(
+      ...extractUrlsFromViteMapDeps(code),
+      ...extractAssetUrlsFromBundle(code)
+    );
+  }
+
+  return mergeDiscoveredAssetUrls(fromMain, entryChunks, fromEntries);
+}

--- a/tests/test-prefetch-chunk-discovery.test.ts
+++ b/tests/test-prefetch-chunk-discovery.test.ts
@@ -1,0 +1,69 @@
+import { describe, test, expect } from "bun:test";
+import {
+  normalizeViteAssetPath,
+  extractUrlsFromViteMapDeps,
+  extractAssetUrlsFromBundle,
+  extractLazyEntryChunkPaths,
+  discoverPrefetchAssetUrls,
+  mergeDiscoveredAssetUrls,
+} from "../src/utils/prefetchChunkDiscovery";
+
+describe("normalizeViteAssetPath", () => {
+  test("normalizes assets/ and ./ paths", () => {
+    expect(normalizeViteAssetPath("assets/Foo-Bar.js")).toBe("/assets/Foo-Bar.js");
+    expect(normalizeViteAssetPath("./PhotoBoothComponent-X.js")).toBe(
+      "/assets/PhotoBoothComponent-X.js"
+    );
+    expect(normalizeViteAssetPath('"./mermaid-ABC-DEF.js"')).toBe(
+      "/assets/mermaid-ABC-DEF.js"
+    );
+  });
+});
+
+describe("extractUrlsFromViteMapDeps", () => {
+  test("parses phosphor .es chunks and css from mapDeps", () => {
+    const code = `__vite__mapDeps=(i,m=__vite__mapDeps,d=(m.f||(m.f=["assets/Microphone.es-DuLwkkSf.js","assets/mermaid-GHXKKRXX-Yd9OhMyU.css","assets/ChatsAppComponent-abc.js"])))`;
+    const urls = extractUrlsFromViteMapDeps(code);
+    expect(urls).toContain("/assets/Microphone.es-DuLwkkSf.js");
+    expect(urls).toContain("/assets/mermaid-GHXKKRXX-Yd9OhMyU.css");
+    expect(urls).toContain("/assets/ChatsAppComponent-abc.js");
+  });
+});
+
+describe("extractAssetUrlsFromBundle", () => {
+  test("finds .es.js chunks missed by legacy double-hash regex", () => {
+    const code = `import("./mermaid-GHXKKRXX-C6DgPKtK.js");"assets/SpeakerHigh.es-DaNzNEV6.js"`;
+    const urls = extractAssetUrlsFromBundle(code);
+    expect(urls).toContain("/assets/mermaid-GHXKKRXX-C6DgPKtK.js");
+    expect(urls).toContain("/assets/SpeakerHigh.es-DaNzNEV6.js");
+  });
+});
+
+describe("extractLazyEntryChunkPaths", () => {
+  test("collects lazy app import targets", () => {
+    const code = `import("./PaintAppComponent-DNkmEfwx.js"),import("./mermaid-GHXKKRXX-C6DgPKtK.js")`;
+    const paths = extractLazyEntryChunkPaths(code);
+    expect(paths).toContain("/assets/PaintAppComponent-DNkmEfwx.js");
+    expect(paths).toContain("/assets/mermaid-GHXKKRXX-C6DgPKtK.js");
+  });
+});
+
+describe("discoverPrefetchAssetUrls", () => {
+  test("merges mapDeps, regex assets, and nested bundle scans", () => {
+    const main = `m.f=["assets/TextEditAppComponent-B1.js","assets/ui-core-9j.js"]
+import("./mermaid-GHXKKRXX-C6DgPKtK.js")`;
+    const nested = `"assets/CursorRepoAgentChatCard-CqbmG3bY.js"`;
+    const urls = discoverPrefetchAssetUrls(main, [nested]);
+    expect(urls).toEqual(
+      mergeDiscoveredAssetUrls(
+        extractUrlsFromViteMapDeps(main),
+        extractAssetUrlsFromBundle(main),
+        extractLazyEntryChunkPaths(main),
+        extractUrlsFromViteMapDeps(nested),
+        extractAssetUrlsFromBundle(nested)
+      )
+    );
+    expect(urls).toContain("/assets/CursorRepoAgentChatCard-CqbmG3bY.js");
+    expect(urls).toContain("/assets/mermaid-GHXKKRXX-C6DgPKtK.js");
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Improves boot-time prefetch so lazy-loaded apps (including Chats via the shared mermaid chunk) are cached in the service worker and can open offline after a normal online session.

## Changes

- Parse `__vite__mapDeps` from the production main bundle so prefetch discovers **all** lazy-app dependencies (Phosphor `.es` chunks, locale CSS, shared chunks like mermaid).
- Broader asset URL extraction for paths the old double-hash regex missed.
- After script URL prefetch, call `prefetchAllRegisteredAppChunks()` so registered `import()` loaders resolve while assets are already in the SW cache.
- Unit tests for chunk discovery helpers.

## Testing

- `bun test tests/test-prefetch-chunk-discovery.test.ts`
- `bun run test:unit`
- `bun run build`
- Verified production bundle discovery: 95 mapDeps entries + lazy entry paths (~106 assets vs ~90 before).

## Notes

Intent-based `prefetchAppChunk()` (dock/desktop/Spotlight) is unchanged and still warms individual apps on pointer/hover. Full offline coverage depends on completing the boot prefetch flow once while online.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-14959EF1-9F67-4013-8F5B-6B643840F26B"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-14959EF1-9F67-4013-8F5B-6B643840F26B"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

