### PR TITLE
feat(ipod): Now Playing center hold opens song menu

### DIFF
--- a/src/apps/ipod/components/IpodAppComponent.tsx
+++ b/src/apps/ipod/components/IpodAppComponent.tsx
@@ -333,7 +333,7 @@ export function IpodAppComponent({
               className="relative w-full" 
               style={{ height: "150px", minHeight: "150px", maxHeight: "150px" }}
               onMouseDown={(e) => {
-                // Start long press timer for CoverFlow toggle
+                // Start long press timer for Now Playing song menu
                 if (screenLongPressTimerRef.current) clearTimeout(screenLongPressTimerRef.current);
                 screenLongPressFiredRef.current = false;
                 screenLongPressStartPos.current = { x: e.clientX, y: e.clientY };

--- a/src/apps/ipod/hooks/useIpodLogic.ts
+++ b/src/apps/ipod/hooks/useIpodLogic.ts
@@ -94,6 +94,9 @@ const IS_IOS_SAFARI = IS_IOS && IS_SAFARI;
 /** Stable fallback so `rebuildMenuItems` never returns a fresh `[]` per call. */
 const EMPTY_IPOD_MENU_ITEMS: MenuItem[] = [];
 
+/** Internal breadcrumb key for the Now Playing long-press song menu. */
+const NOW_PLAYING_SONG_MENU_KEY = "__nowPlayingSongMenu__";
+
 export interface UseIpodLogicOptions {
   isWindowOpen: boolean;
   isForeground: boolean | undefined;
@@ -2455,6 +2458,337 @@ export function useIpodLogic({
     ];
   }, [registerActivity, toggleVideo, memoizedToggleShuffle, memoizedToggleBacklight, menuLocale, isOffline, showOfflineStatus, setIsPlaying, pushMenuChild]);
 
+  const findMenuItemIndexByLabel = useCallback(
+    (items: MenuItem[], label: string) =>
+      Math.max(0, items.findIndex((item) => item.label === label)),
+    []
+  );
+
+  const isNowPlayingSongMenuOpen =
+    menuMode &&
+    menuHistory.length > 0 &&
+    menuHistory[menuHistory.length - 1]?.title === NOW_PLAYING_SONG_MENU_KEY;
+
+  const findPlaylistContextForNowPlaying = useCallback(() => {
+    const matchFromHistory = (hist: MenuHistoryEntry[] | null) => {
+      if (!hist) return null;
+      for (let i = hist.length - 1; i >= 0; i--) {
+        const playlist = appleMusicPlaylists.find(
+          (entry) => entry.name === hist[i].title
+        );
+        if (playlist) return playlist;
+      }
+      return null;
+    };
+    return (
+      matchFromHistory(menuHistoryBeforeNowPlayingRef.current) ??
+      matchFromHistory(
+        menuHistory.length > 0 &&
+          menuHistory[menuHistory.length - 1]?.title !== NOW_PLAYING_SONG_MENU_KEY
+          ? menuHistory
+          : null
+      )
+    );
+  }, [appleMusicPlaylists, menuHistory]);
+
+  const enterMenuNavigationFromNowPlaying = useCallback(
+    (entries: MenuHistoryEntry[]) => {
+      registerActivity();
+      if (useIpodStore.getState().showVideo) toggleVideo();
+      setMenuDirection("forward");
+      setMenuMode(true);
+      setCameFromNowPlayingMenuItem(false);
+      setMenuHistory(entries);
+      const last = entries[entries.length - 1];
+      setSelectedMenuItem(last?.selectedIndex ?? 0);
+    },
+    [registerActivity, toggleVideo, setCameFromNowPlayingMenuItem]
+  );
+
+  const navigateToAlbumFromNowPlaying = useCallback(
+    (track: Track) => {
+      const ipodLabel = t("apps.ipod.menuItems.ipod");
+      const musicLabel = t("apps.ipod.menuItems.music");
+      const albumsLabel = t("apps.ipod.menuItems.albums");
+      const albumKey = getAlbumGroupingKey(
+        track,
+        unknownAlbumLabel,
+        unknownArtistLabel
+      );
+      const albumDisplay =
+        albumGroupsByKey[albumKey]?.album ?? track.album ?? unknownAlbumLabel;
+      const albumTracks = albumGroupsByKey[albumKey]?.tracks ?? [];
+      const trackIdx = Math.max(
+        0,
+        albumTracks.findIndex(({ track: candidate }) => candidate.id === track.id)
+      );
+      const albumListIdx = sortedAlbums.indexOf(albumKey);
+      const albumRowIdx = albumListIdx >= 0 ? albumListIdx + 1 : 1;
+
+      enterMenuNavigationFromNowPlaying([
+        {
+          title: ipodLabel,
+          items: mainMenuItems,
+          selectedIndex: findMenuItemIndexByLabel(mainMenuItems, musicLabel),
+        },
+        {
+          title: musicLabel,
+          items: musicMenuItems,
+          selectedIndex: findMenuItemIndexByLabel(musicMenuItems, albumsLabel),
+        },
+        {
+          title: albumsLabel,
+          items: albumsListMenuItems,
+          selectedIndex: albumRowIdx,
+        },
+        {
+          title: albumKey,
+          displayTitle: albumDisplay,
+          items: albumMenuItemsByAlbum[albumKey] ?? EMPTY_IPOD_MENU_ITEMS,
+          selectedIndex: trackIdx,
+        },
+      ]);
+    },
+    [
+      t,
+      unknownAlbumLabel,
+      unknownArtistLabel,
+      albumGroupsByKey,
+      sortedAlbums,
+      enterMenuNavigationFromNowPlaying,
+      mainMenuItems,
+      musicMenuItems,
+      albumsListMenuItems,
+      albumMenuItemsByAlbum,
+      findMenuItemIndexByLabel,
+    ]
+  );
+
+  const navigateToArtistFromNowPlaying = useCallback(
+    (track: Track) => {
+      const ipodLabel = t("apps.ipod.menuItems.ipod");
+      const musicLabel = t("apps.ipod.menuItems.music");
+      const artistsLabel = t("apps.ipod.menuItems.artists");
+      const artist = track.artist || unknownArtistLabel;
+      const artistRowIdx = sortedArtists.indexOf(artist);
+      const artistListIdx = artistRowIdx >= 0 ? artistRowIdx + 1 : 1;
+
+      enterMenuNavigationFromNowPlaying([
+        {
+          title: ipodLabel,
+          items: mainMenuItems,
+          selectedIndex: findMenuItemIndexByLabel(mainMenuItems, musicLabel),
+        },
+        {
+          title: musicLabel,
+          items: musicMenuItems,
+          selectedIndex: findMenuItemIndexByLabel(musicMenuItems, artistsLabel),
+        },
+        {
+          title: artistsLabel,
+          items: artistsListMenuItems,
+          selectedIndex: artistListIdx,
+        },
+        {
+          title: artist,
+          items: artistMenuItemsByArtist[artist] ?? EMPTY_IPOD_MENU_ITEMS,
+          selectedIndex: 0,
+          modernMediaList: true,
+        },
+      ]);
+    },
+    [
+      t,
+      unknownArtistLabel,
+      sortedArtists,
+      enterMenuNavigationFromNowPlaying,
+      mainMenuItems,
+      musicMenuItems,
+      artistsListMenuItems,
+      artistMenuItemsByArtist,
+      findMenuItemIndexByLabel,
+    ]
+  );
+
+  const navigateToPlaylistFromNowPlaying = useCallback(
+    (track: Track, playlist: { id: string; name: string }) => {
+      const ipodLabel = t("apps.ipod.menuItems.ipod");
+      const musicLabel = t("apps.ipod.menuItems.music");
+      const playlistsLabel = t("apps.ipod.menuItems.playlists");
+      requestPlaylistTracksIfNeeded(playlist.id);
+      const playlistTracks = appleMusicPlaylistTracks[playlist.id] ?? [];
+      const trackIdx = Math.max(
+        0,
+        playlistTracks.findIndex((candidate) => candidate.id === track.id)
+      );
+      const playlistListIdx = Math.max(
+        0,
+        appleMusicPlaylists.findIndex((entry) => entry.id === playlist.id)
+      );
+
+      enterMenuNavigationFromNowPlaying([
+        {
+          title: ipodLabel,
+          items: mainMenuItems,
+          selectedIndex: findMenuItemIndexByLabel(mainMenuItems, musicLabel),
+        },
+        {
+          title: musicLabel,
+          items: musicMenuItems,
+          selectedIndex: findMenuItemIndexByLabel(musicMenuItems, playlistsLabel),
+        },
+        {
+          title: playlistsLabel,
+          items: applePlaylistsMenuItems,
+          selectedIndex: playlistListIdx,
+          modernMediaList: true,
+        },
+        {
+          title: playlist.name,
+          items:
+            applePlaylistTrackMenuItemsByPlaylist[playlist.id] ??
+            EMPTY_IPOD_MENU_ITEMS,
+          selectedIndex: trackIdx,
+          modernMediaList: true,
+        },
+      ]);
+    },
+    [
+      t,
+      requestPlaylistTracksIfNeeded,
+      appleMusicPlaylistTracks,
+      appleMusicPlaylists,
+      applePlaylistsMenuItems,
+      applePlaylistTrackMenuItemsByPlaylist,
+      enterMenuNavigationFromNowPlaying,
+      mainMenuItems,
+      musicMenuItems,
+      findMenuItemIndexByLabel,
+    ]
+  );
+
+  const nowPlayingSongMenuItems = useMemo(() => {
+    const track = tracks[currentIndex];
+    if (!track) return EMPTY_IPOD_MENU_ITEMS;
+
+    const coverFlowLabel = t("apps.ipod.menu.coverFlow", "Cover Flow");
+    const addToFavoritesLabel = t(
+      "apps.ipod.menu.addToFavorites",
+      "Add to Favorites"
+    );
+    const goToPlaylistLabel = t("apps.ipod.menu.goToPlaylist", "Go to Playlist");
+    const goToAlbumLabel = t("apps.ipod.menu.goToAlbum", "Go to Album");
+    const goToArtistLabel = t("apps.ipod.menu.goToArtist", "Go to Artist");
+    const playlistContext = isAppleMusic
+      ? findPlaylistContextForNowPlaying()
+      : null;
+
+    const items: MenuItem[] = [
+      {
+        label: coverFlowLabel,
+        action: () => {
+          registerActivity();
+          setMenuMode(false);
+          setMenuDirection("forward");
+          setIsCoverFlowOpen(true);
+        },
+        showChevron: true,
+      },
+    ];
+
+    if (isAppleMusic && track.source === "appleMusic") {
+      items.push({
+        label: addToFavoritesLabel,
+        action: () => {
+          setMenuMode(false);
+          setMenuDirection("backward");
+          void handleAppleMusicAddToFavorites();
+        },
+        showChevron: false,
+      });
+    }
+
+    if (playlistContext) {
+      items.push({
+        label: goToPlaylistLabel,
+        action: () => navigateToPlaylistFromNowPlaying(track, playlistContext),
+        showChevron: true,
+      });
+    }
+
+    items.push(
+      {
+        label: goToAlbumLabel,
+        action: () => navigateToAlbumFromNowPlaying(track),
+        showChevron: true,
+      },
+      {
+        label: goToArtistLabel,
+        action: () => navigateToArtistFromNowPlaying(track),
+        showChevron: true,
+      }
+    );
+
+    return items;
+  }, [
+    tracks,
+    currentIndex,
+    t,
+    isAppleMusic,
+    findPlaylistContextForNowPlaying,
+    registerActivity,
+    setIsCoverFlowOpen,
+    handleAppleMusicAddToFavorites,
+    navigateToPlaylistFromNowPlaying,
+    navigateToAlbumFromNowPlaying,
+    navigateToArtistFromNowPlaying,
+    menuLocale,
+  ]);
+
+  const openNowPlayingSongMenu = useCallback(() => {
+    const track = tracks[currentIndex];
+    if (!track || browsableTracks.length === 0) return;
+    registerActivity();
+    setMenuDirection("forward");
+    setMenuMode(true);
+    setMenuHistory([
+      {
+        title: NOW_PLAYING_SONG_MENU_KEY,
+        displayTitle: track.title,
+        items: nowPlayingSongMenuItems,
+        selectedIndex: 0,
+      },
+    ]);
+    setSelectedMenuItem(0);
+  }, [
+    tracks,
+    currentIndex,
+    browsableTracks.length,
+    registerActivity,
+    nowPlayingSongMenuItems,
+  ]);
+
+  const closeNowPlayingSongMenu = useCallback(() => {
+    setMenuDirection("backward");
+    setMenuMode(false);
+    const saved = menuHistoryBeforeNowPlayingRef.current;
+    if (saved && saved.length > 0) {
+      setMenuHistory(saved);
+      const last = saved[saved.length - 1];
+      setSelectedMenuItem(last?.selectedIndex ?? 0);
+      return;
+    }
+    const ipodLabel = t("apps.ipod.menuItems.ipod");
+    setMenuHistory([
+      {
+        title: ipodLabel,
+        items: mainMenuItems,
+        selectedIndex: 0,
+      },
+    ]);
+    setSelectedMenuItem(0);
+  }, [mainMenuItems, t]);
+
   const mainMenuItemsRef = useRef(mainMenuItems);
   mainMenuItemsRef.current = mainMenuItems;
   const suppressMenuSyncRef = useRef(false);
@@ -2494,6 +2828,8 @@ export function useIpodLogic({
       return musicMenuItems;
     } else if (menu.title === t("apps.ipod.menuItems.settings")) {
       return settingsMenuItems;
+    } else if (menu.title === NOW_PLAYING_SONG_MENU_KEY) {
+      return nowPlayingSongMenuItems;
     } else if (
       !isAppleMusic &&
       (menu.title === t("apps.ipod.menuItems.recentlyAdded", "Recently Added") ||
@@ -2566,6 +2902,7 @@ export function useIpodLogic({
     applePlaylistsMenuItems,
     applePlaylistTrackMenuItemsByPlaylist,
     appleMusicPlaylists,
+    nowPlayingSongMenuItems,
     menuLocale,
   ]);
 
@@ -3186,6 +3523,11 @@ export function useIpodLogic({
       return;
     }
 
+    if (isNowPlayingSongMenuOpen) {
+      closeNowPlayingSongMenu();
+      return;
+    }
+
     if (showVideo) toggleVideo();
 
     if (menuMode) {
@@ -3255,11 +3597,10 @@ export function useIpodLogic({
       }
       setMenuMode(true);
     }
-  }, [playClickSound, vibrate, registerActivity, isCoverFlowOpen, isMusicQuizOpen, isBrickGameOpen, showVideo, toggleVideo, menuMode, menuHistory, mainMenuItems, musicMenuItems, allSongsMenuItems, browseCurrentIndex, cameFromNowPlayingMenuItem, t]);
+  }, [playClickSound, vibrate, registerActivity, isCoverFlowOpen, isMusicQuizOpen, isBrickGameOpen, isNowPlayingSongMenuOpen, closeNowPlayingSongMenu, showVideo, toggleVideo, menuMode, menuHistory, mainMenuItems, musicMenuItems, allSongsMenuItems, browseCurrentIndex, cameFromNowPlayingMenuItem, t]);
 
   // Cover Flow handlers
   const handleCenterLongPress = useCallback(() => {
-    // Toggle cover flow on long press of center button
     playClickSound();
     vibrate();
     registerActivity();
@@ -3270,19 +3611,34 @@ export function useIpodLogic({
       // slides back in from the left.
       setMenuDirection("backward");
       setIsCoverFlowOpen(false);
-    } else if (
+      return;
+    }
+
+    if (isNowPlayingSongMenuOpen) {
+      return;
+    }
+
+    if (
       !menuMode &&
       !isMusicQuizOpen &&
       !isBrickGameOpen &&
-      browsableTracks.length > 0
+      tracks[currentIndex]
     ) {
-      // Enter cover flow only when in Now Playing mode and no overlay is active.
-      // Forward direction so the modern UI's inline Cover Flow slides in
-      // from the right (matching menu→now-playing).
-      setMenuDirection("forward");
-      setIsCoverFlowOpen(true);
+      openNowPlayingSongMenu();
     }
-  }, [playClickSound, vibrate, registerActivity, isCoverFlowOpen, menuMode, isMusicQuizOpen, isBrickGameOpen, browsableTracks.length]);
+  }, [
+    playClickSound,
+    vibrate,
+    registerActivity,
+    isCoverFlowOpen,
+    isNowPlayingSongMenuOpen,
+    menuMode,
+    isMusicQuizOpen,
+    isBrickGameOpen,
+    tracks,
+    currentIndex,
+    openNowPlayingSongMenu,
+  ]);
 
   const getAppleMusicAlbumQueueIds = useCallback(
     (track: Track) => {

--- a/src/apps/ipod/hooks/useIpodLogic.ts
+++ b/src/apps/ipod/hooks/useIpodLogic.ts
@@ -641,6 +641,17 @@ export function useIpodLogic({
   }, []);
   // Save menu history before entering Now Playing from a song selection
   const menuHistoryBeforeNowPlayingRef = useRef<typeof menuHistory | null>(null);
+  /** When set, Menu pops back to the Now Playing song menu (not up the browse stack). */
+  const returnToNowPlayingSongMenuRef = useRef(false);
+  const nowPlayingSongMenuSnapshotRef = useRef<{
+    displayTitle: string;
+    selectedIndex: number;
+  } | null>(null);
+
+  const clearReturnToNowPlayingSongMenu = useCallback(() => {
+    returnToNowPlayingSongMenuRef.current = false;
+    nowPlayingSongMenuSnapshotRef.current = null;
+  }, []);
 
   // Mirror the latest cursor position for use inside callbacks (especially
   // setMenuHistory updaters) without forcing every menu-item factory to
@@ -844,6 +855,7 @@ export function useIpodLogic({
         showOfflineStatus();
         return;
       }
+      clearReturnToNowPlayingSongMenu();
       setMenuHistory((prev) => {
         const updatedHist = [...prev];
         if (updatedHist.length > 0) {
@@ -876,6 +888,7 @@ export function useIpodLogic({
       setCurrentSongId,
       setIsPlaying,
       toggleVideo,
+      clearReturnToNowPlayingSongMenu,
     ]
   );
 
@@ -2505,6 +2518,21 @@ export function useIpodLogic({
     [registerActivity, toggleVideo, setCameFromNowPlayingMenuItem]
   );
 
+  const navigateFromNowPlayingSongMenu = useCallback(
+    (entries: MenuHistoryEntry[]) => {
+      const track = tracks[currentIndex];
+      if (track) {
+        nowPlayingSongMenuSnapshotRef.current = {
+          displayTitle: track.title,
+          selectedIndex: selectedMenuItemRef.current,
+        };
+        returnToNowPlayingSongMenuRef.current = true;
+      }
+      enterMenuNavigationFromNowPlaying(entries);
+    },
+    [tracks, currentIndex, enterMenuNavigationFromNowPlaying]
+  );
+
   const navigateToAlbumFromNowPlaying = useCallback(
     (track: Track) => {
       const ipodLabel = t("apps.ipod.menuItems.ipod");
@@ -2525,7 +2553,7 @@ export function useIpodLogic({
       const albumListIdx = sortedAlbums.indexOf(albumKey);
       const albumRowIdx = albumListIdx >= 0 ? albumListIdx + 1 : 1;
 
-      enterMenuNavigationFromNowPlaying([
+      navigateFromNowPlayingSongMenu([
         {
           title: ipodLabel,
           items: mainMenuItems,
@@ -2555,7 +2583,7 @@ export function useIpodLogic({
       unknownArtistLabel,
       albumGroupsByKey,
       sortedAlbums,
-      enterMenuNavigationFromNowPlaying,
+      navigateFromNowPlayingSongMenu,
       mainMenuItems,
       musicMenuItems,
       albumsListMenuItems,
@@ -2573,7 +2601,7 @@ export function useIpodLogic({
       const artistRowIdx = sortedArtists.indexOf(artist);
       const artistListIdx = artistRowIdx >= 0 ? artistRowIdx + 1 : 1;
 
-      enterMenuNavigationFromNowPlaying([
+      navigateFromNowPlayingSongMenu([
         {
           title: ipodLabel,
           items: mainMenuItems,
@@ -2601,7 +2629,7 @@ export function useIpodLogic({
       t,
       unknownArtistLabel,
       sortedArtists,
-      enterMenuNavigationFromNowPlaying,
+      navigateFromNowPlayingSongMenu,
       mainMenuItems,
       musicMenuItems,
       artistsListMenuItems,
@@ -2626,7 +2654,7 @@ export function useIpodLogic({
         appleMusicPlaylists.findIndex((entry) => entry.id === playlist.id)
       );
 
-      enterMenuNavigationFromNowPlaying([
+      navigateFromNowPlayingSongMenu([
         {
           title: ipodLabel,
           items: mainMenuItems,
@@ -2660,7 +2688,7 @@ export function useIpodLogic({
       appleMusicPlaylists,
       applePlaylistsMenuItems,
       applePlaylistTrackMenuItemsByPlaylist,
-      enterMenuNavigationFromNowPlaying,
+      navigateFromNowPlayingSongMenu,
       mainMenuItems,
       musicMenuItems,
       findMenuItemIndexByLabel,
@@ -2768,7 +2796,31 @@ export function useIpodLogic({
     nowPlayingSongMenuItems,
   ]);
 
+  const restoreNowPlayingSongMenu = useCallback(() => {
+    clearReturnToNowPlayingSongMenu();
+    const snapshot = nowPlayingSongMenuSnapshotRef.current;
+    const track = tracks[currentIndex];
+    const selectedIndex = snapshot?.selectedIndex ?? 0;
+    setMenuDirection("backward");
+    setMenuMode(true);
+    setMenuHistory([
+      {
+        title: NOW_PLAYING_SONG_MENU_KEY,
+        displayTitle: snapshot?.displayTitle ?? track?.title ?? "",
+        items: nowPlayingSongMenuItems,
+        selectedIndex,
+      },
+    ]);
+    setSelectedMenuItem(selectedIndex);
+  }, [
+    clearReturnToNowPlayingSongMenu,
+    tracks,
+    currentIndex,
+    nowPlayingSongMenuItems,
+  ]);
+
   const closeNowPlayingSongMenu = useCallback(() => {
+    clearReturnToNowPlayingSongMenu();
     setMenuDirection("backward");
     setMenuMode(false);
     const saved = menuHistoryBeforeNowPlayingRef.current;
@@ -2787,7 +2839,7 @@ export function useIpodLogic({
       },
     ]);
     setSelectedMenuItem(0);
-  }, [mainMenuItems, t]);
+  }, [mainMenuItems, t, clearReturnToNowPlayingSongMenu]);
 
   const mainMenuItemsRef = useRef(mainMenuItems);
   mainMenuItemsRef.current = mainMenuItems;
@@ -2814,11 +2866,12 @@ export function useIpodLogic({
       },
     ]);
     menuHistoryBeforeNowPlayingRef.current = null;
+    clearReturnToNowPlayingSongMenu();
     setIsCoverFlowOpen(false);
     queueMicrotask(() => {
       suppressMenuSyncRef.current = false;
     });
-  }, [librarySource, menuLocale, setIsCoverFlowOpen, setMenuDirection, setSelectedMenuItem, t]);
+  }, [librarySource, menuLocale, setIsCoverFlowOpen, setMenuDirection, setSelectedMenuItem, clearReturnToNowPlayingSongMenu, t]);
 
   // Helper function to rebuild menu items based on current tracks
   const rebuildMenuItems = useCallback((menu: typeof menuHistory[0]): typeof menuHistory[0]["items"] | null => {
@@ -3531,6 +3584,10 @@ export function useIpodLogic({
     if (showVideo) toggleVideo();
 
     if (menuMode) {
+      if (returnToNowPlayingSongMenuRef.current) {
+        restoreNowPlayingSongMenu();
+        return;
+      }
       if (menuHistory.length > 1) {
         setMenuDirection("backward");
         setMenuHistory((prev) => prev.slice(0, -1));
@@ -3597,7 +3654,7 @@ export function useIpodLogic({
       }
       setMenuMode(true);
     }
-  }, [playClickSound, vibrate, registerActivity, isCoverFlowOpen, isMusicQuizOpen, isBrickGameOpen, isNowPlayingSongMenuOpen, closeNowPlayingSongMenu, showVideo, toggleVideo, menuMode, menuHistory, mainMenuItems, musicMenuItems, allSongsMenuItems, browseCurrentIndex, cameFromNowPlayingMenuItem, t]);
+  }, [playClickSound, vibrate, registerActivity, isCoverFlowOpen, isMusicQuizOpen, isBrickGameOpen, isNowPlayingSongMenuOpen, closeNowPlayingSongMenu, restoreNowPlayingSongMenu, showVideo, toggleVideo, menuMode, menuHistory, mainMenuItems, musicMenuItems, allSongsMenuItems, browseCurrentIndex, cameFromNowPlayingMenuItem, t]);
 
   // Cover Flow handlers
   const handleCenterLongPress = useCallback(() => {

--- a/src/lib/locales/en/translation.json
+++ b/src/lib/locales/en/translation.json
@@ -1837,7 +1837,10 @@
         "libraryYoutube": "YouTube Library",
         "libraryAppleMusic": "Apple Music",
         "librarySource": "Library",
-        "addToFavorites": "Add to Favorites"
+        "addToFavorites": "Add to Favorites",
+        "goToPlaylist": "Go to Playlist",
+        "goToAlbum": "Go to Album",
+        "goToArtist": "Go to Artist"
       },
       "status": {
         "shuffleOn": "Shuffle ON",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Long-pressing the center button (click wheel) or the Now Playing screen opens a song options menu for the current track.

## Menu items

- **Cover Flow** — opens Cover Flow from the menu action
- **Add to Favorites** — Apple Music tracks only
- **Go to Playlist** — when playback started from an Apple Music playlist
- **Go to Album** / **Go to Artist** — jump to the matching browse screens

## Navigation

- Press **Menu** on the song menu → return to Now Playing
- Press **Menu** after **Go to Album**, **Go to Artist**, or **Go to Playlist** → return to the song menu (not up the Music breadcrumb one level at a time)
- Selecting a different track from those browse lists clears the return path and behaves like normal playback

## Testing

- `bun run build`
- `bun run test:unit`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9E4EA1A1-434C-479C-B3CA-122D6EA7DB59"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9E4EA1A1-434C-479C-B3CA-122D6EA7DB59"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

