### PR TITLE
fix(ipod): Now Playing song menu split scrolling text

### DIFF
--- a/src/apps/ipod/components/IpodScreen.tsx
+++ b/src/apps/ipod/components/IpodScreen.tsx
@@ -383,6 +383,14 @@ export function IpodScreen({
     if (!menuMode || menuHistory.length === 0) return false;
     return Boolean(menuHistory[menuHistory.length - 1].modernMediaList);
   }, [menuMode, menuHistory]);
+  const currentMenuModernSplitMenu = useMemo(() => {
+    if (!menuMode || menuHistory.length === 0) return false;
+    return Boolean(menuHistory[menuHistory.length - 1].modernSplitMenu);
+  }, [menuMode, menuHistory]);
+  const activeMenuRouteKey =
+    menuMode && menuHistory.length > 0
+      ? menuHistory[menuHistory.length - 1].title
+      : "";
   // Modern UI renders Cover Flow inline as a third state in the menu
   // panel's AnimatePresence (alongside menu list + now-playing) so the
   // menu↔nowplaying chrome width transition (50%↔100%) seamlessly
@@ -614,12 +622,14 @@ export function IpodScreen({
       // entirely while Cover Flow is on screen.
       !showInlineCoverFlow &&
       !currentMenuModernMediaList &&
-      currentMenuItems.some((item) => item.showChevron === true),
+      (currentMenuModernSplitMenu ||
+        currentMenuItems.some((item) => item.showChevron === true)),
     [
       isModernUi,
       menuMode,
       showInlineCoverFlow,
       currentMenuModernMediaList,
+      currentMenuModernSplitMenu,
       currentMenuItems,
     ]
   );
@@ -739,6 +749,10 @@ export function IpodScreen({
       setModernChromeWidthMarqueeBlocked(false);
       return;
     }
+    if (currentMenuModernSplitMenu) {
+      setModernChromeWidthMarqueeBlocked(false);
+      return;
+    }
     if (skipModernChromeMarqueeCooldown.current) {
       skipModernChromeMarqueeCooldown.current = false;
       return;
@@ -748,13 +762,17 @@ export function IpodScreen({
       setModernChromeWidthMarqueeBlocked(false);
     }, 320);
     return () => window.clearTimeout(id);
-  }, [showSplitMenuArt, menuMode, isModernUi]);
+  }, [showSplitMenuArt, menuMode, isModernUi, currentMenuModernSplitMenu]);
 
   const skipModernMenuRouteMarqueeCooldown = useRef(true);
   const [modernMenuRouteMarqueeBlocked, setModernMenuRouteMarqueeBlocked] =
     useState(false);
   useEffect(() => {
     if (!isModernUi) {
+      setModernMenuRouteMarqueeBlocked(false);
+      return;
+    }
+    if (currentMenuModernSplitMenu) {
       setModernMenuRouteMarqueeBlocked(false);
       return;
     }
@@ -767,7 +785,7 @@ export function IpodScreen({
       setModernMenuRouteMarqueeBlocked(false);
     }, 240);
     return () => window.clearTimeout(id);
-  }, [menuMode, isModernUi]);
+  }, [menuMode, isModernUi, activeMenuRouteKey, currentMenuModernSplitMenu]);
 
   const modernScrollingMarqueeAllowed =
     !isModernUi ||

--- a/src/apps/ipod/hooks/useIpodLogic.ts
+++ b/src/apps/ipod/hooks/useIpodLogic.ts
@@ -2710,9 +2710,15 @@ export function useIpodLogic({
     const playlistContext = isAppleMusic
       ? findPlaylistContextForNowPlaying()
       : null;
+    const trackCoverUrl = resolveTrackCoverUrl(track);
+
+    const withTrackCover = (item: MenuItem): MenuItem => ({
+      ...item,
+      coverUrl: trackCoverUrl,
+    });
 
     const items: MenuItem[] = [
-      {
+      withTrackCover({
         label: coverFlowLabel,
         action: () => {
           registerActivity();
@@ -2721,40 +2727,44 @@ export function useIpodLogic({
           setIsCoverFlowOpen(true);
         },
         showChevron: true,
-      },
+      }),
     ];
 
     if (isAppleMusic && track.source === "appleMusic") {
-      items.push({
-        label: addToFavoritesLabel,
-        action: () => {
-          setMenuMode(false);
-          setMenuDirection("backward");
-          void handleAppleMusicAddToFavorites();
-        },
-        showChevron: false,
-      });
+      items.push(
+        withTrackCover({
+          label: addToFavoritesLabel,
+          action: () => {
+            setMenuMode(false);
+            setMenuDirection("backward");
+            void handleAppleMusicAddToFavorites();
+          },
+          showChevron: false,
+        })
+      );
     }
 
     if (playlistContext) {
-      items.push({
-        label: goToPlaylistLabel,
-        action: () => navigateToPlaylistFromNowPlaying(track, playlistContext),
-        showChevron: true,
-      });
+      items.push(
+        withTrackCover({
+          label: goToPlaylistLabel,
+          action: () => navigateToPlaylistFromNowPlaying(track, playlistContext),
+          showChevron: true,
+        })
+      );
     }
 
     items.push(
-      {
+      withTrackCover({
         label: goToAlbumLabel,
         action: () => navigateToAlbumFromNowPlaying(track),
         showChevron: true,
-      },
-      {
+      }),
+      withTrackCover({
         label: goToArtistLabel,
         action: () => navigateToArtistFromNowPlaying(track),
         showChevron: true,
-      }
+      })
     );
 
     return items;
@@ -2785,6 +2795,7 @@ export function useIpodLogic({
         displayTitle: track.title,
         items: nowPlayingSongMenuItems,
         selectedIndex: 0,
+        modernSplitMenu: true,
       },
     ]);
     setSelectedMenuItem(0);
@@ -2809,6 +2820,7 @@ export function useIpodLogic({
         displayTitle: snapshot?.displayTitle ?? track?.title ?? "",
         items: nowPlayingSongMenuItems,
         selectedIndex,
+        modernSplitMenu: true,
       },
     ]);
     setSelectedMenuItem(selectedIndex);

--- a/src/apps/ipod/types.ts
+++ b/src/apps/ipod/types.ts
@@ -48,6 +48,12 @@ export interface MenuHistoryEntry {
    * Used for playlist and per-artist album browses.
    */
   modernMediaList?: boolean;
+  /**
+   * Modern UI only: force the 50% split-menu chrome (Ken Burns art + narrow
+   * list column) so row labels get horizontal marquee like Music submenus,
+   * even when rows are action shortcuts rather than drill-down categories.
+   */
+  modernSplitMenu?: boolean;
 }
 
 // PIP Player props


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The Now Playing long-press song menu now uses the same modern split-menu chrome as Music browse menus, so row labels get horizontal marquee scrolling on the selected item.

## Changes

- Add `modernSplitMenu` on the song menu history entry so `IpodScreen` enables the 50% split layout (Ken Burns art + narrow list column)
- Attach the current track `coverUrl` on each song menu row for split-art
- Skip the short marquee cooldown when entering a `modernSplitMenu` so scrolling is not suppressed after opening from Now Playing

## Testing

- `bun run build`
- `bun run test:unit`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9E4EA1A1-434C-479C-B3CA-122D6EA7DB59"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9E4EA1A1-434C-479C-B3CA-122D6EA7DB59"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

