### PR TITLE
localize(ipod): modern menus and Now Playing song menu strings

### DIFF
--- a/src/apps/ipod/components/IpodAppComponent.tsx
+++ b/src/apps/ipod/components/IpodAppComponent.tsx
@@ -250,7 +250,7 @@ export function IpodAppComponent({
         [DisplayMode.Water]: t("apps.ipod.menu.displayWater"),
       };
       const label = labels[nextMode] ?? nextMode;
-      showStatus(`${t("apps.ipod.menu.display", "Display")}: ${label}`);
+      showStatus(`${t("apps.ipod.menu.display")}: ${label}`);
     },
     [isAppleMusic, setDisplayMode, showStatus, t]
   );

--- a/src/apps/ipod/components/IpodMenuBar.tsx
+++ b/src/apps/ipod/components/IpodMenuBar.tsx
@@ -23,6 +23,7 @@ import { useThemeFlags } from "@/hooks/useThemeFlags";
 import { ShareItemDialog } from "@/components/dialogs/ShareItemDialog";
 import { appRegistry } from "@/config/appRegistry";
 import { useTranslation } from "react-i18next";
+import { TRANSLATION_LANGUAGES } from "../constants";
 
 // Caps for the in-menubar library browser. Radix's MenubarSub doesn't
 // virtualize, so a 5,000-song library would commit thousands of DOM
@@ -76,21 +77,15 @@ export function IpodMenuBar({
   const appId = "ipod";
   const appName = appRegistry[appId as keyof typeof appRegistry]?.name || appId;
 
-  const translationLanguages = [
-    { label: t("apps.ipod.translationLanguages.original"), code: null },
-    { label: t("apps.ipod.translationLanguages.auto"), code: "auto" },
-    { separator: true },
-    { label: "English", code: "en" },
-    { label: "中文", code: "zh-TW" },
-    { label: "日本語", code: "ja" },
-    { label: "한국어", code: "ko" },
-    { label: "Español", code: "es" },
-    { label: "Français", code: "fr" },
-    { label: "Deutsch", code: "de" },
-    { label: "Português", code: "pt" },
-    { label: "Italiano", code: "it" },
-    { label: "Русский", code: "ru" },
-  ];
+  const translationLanguages = useMemo(
+    () =>
+      TRANSLATION_LANGUAGES.map((lang) => ({
+        label: lang.labelKey ? t(lang.labelKey) : lang.label || "",
+        code: lang.code,
+        separator: lang.separator,
+      })),
+    [t]
+  );
   const {
     youtubeTracks,
     youtubeCurrentSongId,

--- a/src/apps/ipod/components/IpodScreen.tsx
+++ b/src/apps/ipod/components/IpodScreen.tsx
@@ -1060,17 +1060,20 @@ export function IpodScreen({
                     >
                       <span>
                         {currentTrack?.appleMusicPlayParams?.stationId
-                          ? "LIVE"
+                          ? t("apps.ipod.playback.live")
                           : isAppleMusicCollectionShell
-                            ? "MIX"
-                            : `${currentIndex + 1} of ${tracksLength}`}
+                            ? t("apps.ipod.playback.mix")
+                            : t("apps.ipod.playback.trackOf", {
+                                current: currentIndex + 1,
+                                total: tracksLength,
+                              })}
                       </span>
                       {isShuffled && (
                         <Shuffle
                           className="shrink-0"
                           size={isModernUi ? 12 : 13}
                           weight="bold"
-                          aria-label="shuffle on"
+                          aria-label={t("apps.ipod.ariaLabels.shuffleOn")}
                         />
                       )}
                     </div>

--- a/src/apps/ipod/constants.ts
+++ b/src/apps/ipod/constants.ts
@@ -71,16 +71,16 @@ export const TRANSLATION_LANGUAGES: TranslationLanguage[] = [
   { labelKey: "apps.ipod.translationLanguages.original", code: null },
   { labelKey: "apps.ipod.translationLanguages.auto", code: "auto" },
   { separator: true, code: null, label: "" }, // Separator
-  { label: "English", code: "en" },
-  { label: "中文", code: "zh-TW" },
-  { label: "日本語", code: "ja" },
-  { label: "한국어", code: "ko" },
-  { label: "Español", code: "es" },
-  { label: "Français", code: "fr" },
-  { label: "Deutsch", code: "de" },
-  { label: "Português", code: "pt" },
-  { label: "Italiano", code: "it" },
-  { label: "Русский", code: "ru" },
+  { labelKey: "apps.ipod.translationLanguages.english", code: "en" },
+  { labelKey: "apps.ipod.translationLanguages.chinese", code: "zh-TW" },
+  { labelKey: "apps.ipod.translationLanguages.japanese", code: "ja" },
+  { labelKey: "apps.ipod.translationLanguages.korean", code: "ko" },
+  { labelKey: "apps.ipod.translationLanguages.spanish", code: "es" },
+  { labelKey: "apps.ipod.translationLanguages.french", code: "fr" },
+  { labelKey: "apps.ipod.translationLanguages.german", code: "de" },
+  { labelKey: "apps.ipod.translationLanguages.portuguese", code: "pt" },
+  { labelKey: "apps.ipod.translationLanguages.italian", code: "it" },
+  { labelKey: "apps.ipod.translationLanguages.russian", code: "ru" },
 ];
 
 // Translation badge mappings

--- a/src/apps/ipod/hooks/useIpodLogic.ts
+++ b/src/apps/ipod/hooks/useIpodLogic.ts
@@ -420,7 +420,7 @@ export function useIpodLogic({
   const isAppleMusicFavoritesLoading = useIpodStore(
     (s) => s.appleMusicFavoritesLoading
   );
-  const radioMenuTitleForRestore = t("apps.ipod.menuItems.radio", "Radio");
+  const radioMenuTitleForRestore = t("apps.ipod.menuItems.radio");
   const [shouldHydrateRadioOnRestore] = useState(() => {
     const state = useIpodStore.getState();
     const currentAppleMusicTrack = state.appleMusicCurrentSongId
@@ -433,8 +433,7 @@ export function useIpodLogic({
         (currentAppleMusicTrack?.appleMusicPlayParams?.stationId ||
           state.ipodMenuBreadcrumb?.some(
             (entry) =>
-              entry.title === radioMenuTitleForRestore ||
-              entry.title === "Radio"
+              entry.title === radioMenuTitleForRestore || entry.title === "Radio"
           ))
     );
   });
@@ -944,9 +943,8 @@ export function useIpodLogic({
   const handleAppleMusicSignIn = useCallback(async () => {
     registerActivity();
     if (musicKitStatus === "missing-token") {
-      toast.error("Apple Music is not configured", {
-        description:
-          "Set MUSICKIT_TEAM_ID, MUSICKIT_KEY_ID, and MUSICKIT_PRIVATE_KEY.",
+      toast.error(t("apps.ipod.dialogs.appleMusicNotConfigured"), {
+        description: t("apps.ipod.dialogs.appleMusicNotConfiguredDescription"),
       });
       return;
     }
@@ -954,11 +952,11 @@ export function useIpodLogic({
       await musicKitAuthorize();
       showStatus(t("apps.ipod.status.appleMusicSignedIn", "Apple Music ✓"));
     } catch (err) {
-      toast.error("Sign in failed", {
+      toast.error(t("apps.ipod.dialogs.appleMusicSignInFailed"), {
         description: err instanceof Error ? err.message : String(err),
       });
     }
-  }, [musicKitAuthorize, musicKitStatus, registerActivity, showStatus, menuLocale]);
+  }, [musicKitAuthorize, musicKitStatus, registerActivity, showStatus, t]);
 
   const handleAppleMusicSignOut = useCallback(async () => {
     registerActivity();
@@ -1325,9 +1323,10 @@ export function useIpodLogic({
       t("apps.ipod.status.libraryAppleMusic", "Library: Apple Music")
     );
     if (musicKitStatus === "missing-token") {
-      toast.error("Apple Music is not configured", {
-        description:
-          "Set MUSICKIT_TEAM_ID / MUSICKIT_KEY_ID / MUSICKIT_PRIVATE_KEY",
+      toast.error(t("apps.ipod.dialogs.appleMusicNotConfigured"), {
+        description: t(
+          "apps.ipod.dialogs.appleMusicNotConfiguredDescriptionShort"
+        ),
       });
       return;
     }
@@ -1346,7 +1345,7 @@ export function useIpodLogic({
     setDisplayMode,
     setLibrarySource,
     showStatus,
-    menuLocale,
+    t,
   ]);
 
   useEffect(() => {
@@ -2694,14 +2693,11 @@ export function useIpodLogic({
     const track = tracks[currentIndex];
     if (!track) return EMPTY_IPOD_MENU_ITEMS;
 
-    const coverFlowLabel = t("apps.ipod.menu.coverFlow", "Cover Flow");
-    const addToFavoritesLabel = t(
-      "apps.ipod.menu.addToFavorites",
-      "Add to Favorites"
-    );
-    const goToPlaylistLabel = t("apps.ipod.menu.goToPlaylist", "Go to Playlist");
-    const goToAlbumLabel = t("apps.ipod.menu.goToAlbum", "Go to Album");
-    const goToArtistLabel = t("apps.ipod.menu.goToArtist", "Go to Artist");
+    const coverFlowLabel = t("apps.ipod.menu.coverFlow");
+    const addToFavoritesLabel = t("apps.ipod.menu.addToFavorites");
+    const goToPlaylistLabel = t("apps.ipod.menu.goToPlaylist");
+    const goToAlbumLabel = t("apps.ipod.menu.goToAlbum");
+    const goToArtistLabel = t("apps.ipod.menu.goToArtist");
     const playlistContext = isAppleMusic
       ? findPlaylistContextForNowPlaying()
       : null;

--- a/src/lib/locales/de/translation.json
+++ b/src/lib/locales/de/translation.json
@@ -2075,6 +2075,7 @@
         "playPause": "Wiedergabe/Pause",
         "previousTrack": "Vorheriger Titel",
         "select": "Auswählen",
+        "shuffleOn": "Zufallswiedergabe ein",
         "toggleFurigana": "Furigana umschalten",
         "toggleHangulRomanization": "Hangul / Romanisierung umschalten",
         "toggleRomanization": "Romanisierung umschalten",
@@ -2116,6 +2117,9 @@
         "appleMusicLibraryProgress": "Apple Music-Mediathek wird geladen … {{loaded}} Titel",
         "appleMusicLibraryProgressOf": "Apple Music-Mediathek wird geladen … {{loaded}} von {{total}}",
         "appleMusicNoRecommendations": "Noch keine Apple Music-Empfehlungen verfügbar",
+        "appleMusicNotConfigured": "Apple Music ist nicht konfiguriert",
+        "appleMusicNotConfiguredDescription": "Legen Sie MUSICKIT_TEAM_ID, MUSICKIT_KEY_ID und MUSICKIT_PRIVATE_KEY fest.",
+        "appleMusicNotConfiguredDescriptionShort": "Legen Sie MUSICKIT_TEAM_ID / MUSICKIT_KEY_ID / MUSICKIT_PRIVATE_KEY fest",
         "appleMusicRadioFailed": "Apple Music-Radio konnte nicht geladen werden",
         "appleMusicRecentlyAddedFailed": "Fehler beim Laden der zuletzt hinzugefügten Titel",
         "appleMusicSearchAppleMusic": "Apple Music",
@@ -2124,6 +2128,7 @@
         "appleMusicSearchSelectResult": "Wähle einen Titel zum Hinzufügen aus:",
         "appleMusicSearchSignInRequired": "Bei Apple Music anmelden, um zu suchen",
         "appleMusicSearchUnavailable": "Apple Music-Suche ist nicht verfügbar",
+        "appleMusicSignInFailed": "Anmeldung fehlgeschlagen",
         "autoUpdateFailed": "Auto-Update fehlgeschlagen",
         "autoUpdatedLibraryAddedSongs": "Bibliothek automatisch aktualisiert: {{newCount}} Song{{newPlural}} neu an den Anfang hinzugefügt{{updatedText}}",
         "autoUpdatedTrackMetadata": "{{count}} Track-Metadaten automatisch aktualisiert",
@@ -2255,6 +2260,9 @@
         "fontSerifRed": "Serif (Rot)",
         "fullScreen": "Vollbild",
         "furigana": "Furigana",
+        "goToAlbum": "Zum Album",
+        "goToArtist": "Zum Künstler",
+        "goToPlaylist": "Zur Playlist",
         "importLibrary": "Mediathek importieren...",
         "ipodHelp": "iPod-Hilfe",
         "japaneseFurigana": "Japanisch (Furigana)",
@@ -2364,6 +2372,11 @@
         "wrong": "Nicht ganz!"
       },
       "name": "iPod",
+      "playback": {
+        "live": "LIVE",
+        "mix": "MIX",
+        "trackOf": "{{current}} von {{total}}"
+      },
       "status": {
         "added": "♬ Hinzugefügt",
         "appleMusicAddedToFavorites": "Zu Favoriten hinzugefügt",

--- a/src/lib/locales/en/translation.json
+++ b/src/lib/locales/en/translation.json
@@ -1842,6 +1842,11 @@
         "goToAlbum": "Go to Album",
         "goToArtist": "Go to Artist"
       },
+      "playback": {
+        "live": "LIVE",
+        "mix": "MIX",
+        "trackOf": "{{current}} of {{total}}"
+      },
       "status": {
         "shuffleOn": "Shuffle ON",
         "shuffleOff": "Shuffle OFF",
@@ -1944,6 +1949,10 @@
         "appleMusicRadioFailed": "Failed to load Apple Music radio",
         "appleMusicGeniusFailed": "Failed to play Apple Music recommendations",
         "appleMusicNoRecommendations": "No Apple Music recommendations are available yet",
+        "appleMusicNotConfigured": "Apple Music is not configured",
+        "appleMusicNotConfiguredDescription": "Set MUSICKIT_TEAM_ID, MUSICKIT_KEY_ID, and MUSICKIT_PRIVATE_KEY.",
+        "appleMusicNotConfiguredDescriptionShort": "Set MUSICKIT_TEAM_ID / MUSICKIT_KEY_ID / MUSICKIT_PRIVATE_KEY",
+        "appleMusicSignInFailed": "Sign in failed",
         "lyricsSearchTitle": "Search Lyrics",
         "lyricsSearchDescription": "Search for lyrics for \"{{title}}\" by {{artist}}",
         "lyricsSearchPlaceholder": "Enter search query (e.g., song title, artist)",
@@ -2071,7 +2080,8 @@
         "toggleFurigana": "Toggle Furigana",
         "toggleRomanization": "Toggle Romanization",
         "translateLyrics": "Translate lyrics",
-        "select": "Select"
+        "select": "Select",
+        "shuffleOn": "Shuffle on"
       },
       "keys": {
         "escape": "Escape",

--- a/src/lib/locales/es/translation.json
+++ b/src/lib/locales/es/translation.json
@@ -2075,6 +2075,7 @@
         "playPause": "Reproducir/Pausar",
         "previousTrack": "Pista anterior",
         "select": "Seleccionar",
+        "shuffleOn": "Aleatorio activado",
         "toggleFurigana": "Alternar Furigana",
         "toggleHangulRomanization": "Alternar Hangul / Romanización",
         "toggleRomanization": "Alternar Romanización",
@@ -2116,6 +2117,9 @@
         "appleMusicLibraryProgress": "Cargando biblioteca de Apple Music… {{loaded}} canciones",
         "appleMusicLibraryProgressOf": "Cargando biblioteca de Apple Music… {{loaded}} de {{total}}",
         "appleMusicNoRecommendations": "Aún no hay recomendaciones de Apple Music disponibles",
+        "appleMusicNotConfigured": "Apple Music no está configurado",
+        "appleMusicNotConfiguredDescription": "Configure MUSICKIT_TEAM_ID, MUSICKIT_KEY_ID y MUSICKIT_PRIVATE_KEY.",
+        "appleMusicNotConfiguredDescriptionShort": "Configure MUSICKIT_TEAM_ID / MUSICKIT_KEY_ID / MUSICKIT_PRIVATE_KEY",
         "appleMusicRadioFailed": "Error al cargar la radio de Apple Music",
         "appleMusicRecentlyAddedFailed": "Error al cargar las canciones añadidas recientemente",
         "appleMusicSearchAppleMusic": "Apple Music",
@@ -2124,6 +2128,7 @@
         "appleMusicSearchSelectResult": "Selecciona una canción para añadir:",
         "appleMusicSearchSignInRequired": "Inicia sesión en Apple Music para buscar",
         "appleMusicSearchUnavailable": "La búsqueda de Apple Music no está disponible",
+        "appleMusicSignInFailed": "Error al iniciar sesión",
         "autoUpdateFailed": "Error de Autoactualización",
         "autoUpdatedLibraryAddedSongs": "Biblioteca autoactualizada: se añadió{{newPlural}} {{newCount}} canción{{newPlural}} nueva{{newPlural}} al inicio{{updatedText}}",
         "autoUpdatedTrackMetadata": "Metadatos de {{count}} pista{{plural}} actualizados automáticamente",
@@ -2255,6 +2260,9 @@
         "fontSerifRed": "Serif (Rojo)",
         "fullScreen": "Pantalla completa",
         "furigana": "Furigana",
+        "goToAlbum": "Ir al álbum",
+        "goToArtist": "Ir al artista",
+        "goToPlaylist": "Ir a la lista",
         "importLibrary": "Importar biblioteca...",
         "ipodHelp": "Ayuda del iPod",
         "japaneseFurigana": "Japonés (Furigana)",
@@ -2364,6 +2372,11 @@
         "wrong": "¡Casi!"
       },
       "name": "iPod",
+      "playback": {
+        "live": "LIVE",
+        "mix": "MIX",
+        "trackOf": "{{current}} de {{total}}"
+      },
       "status": {
         "added": "♬ Añadido",
         "appleMusicAddedToFavorites": "Añadido a Favoritos",

--- a/src/lib/locales/fr/translation.json
+++ b/src/lib/locales/fr/translation.json
@@ -2075,6 +2075,7 @@
         "playPause": "Lecture/Pause",
         "previousTrack": "Piste précédente",
         "select": "Sélectionner",
+        "shuffleOn": "Lecture aléatoire activée",
         "toggleFurigana": "Basculer Furigana",
         "toggleHangulRomanization": "Basculer Hangul / Romanisation",
         "toggleRomanization": "Basculer la romanisation",
@@ -2116,6 +2117,9 @@
         "appleMusicLibraryProgress": "Chargement de la bibliothèque Apple Music… {{loaded}} morceaux",
         "appleMusicLibraryProgressOf": "Chargement de la bibliothèque Apple Music… {{loaded}} sur {{total}}",
         "appleMusicNoRecommendations": "Aucune recommandation Apple Music n'est encore disponible",
+        "appleMusicNotConfigured": "Apple Music n'est pas configuré",
+        "appleMusicNotConfiguredDescription": "Définissez MUSICKIT_TEAM_ID, MUSICKIT_KEY_ID et MUSICKIT_PRIVATE_KEY.",
+        "appleMusicNotConfiguredDescriptionShort": "Définissez MUSICKIT_TEAM_ID / MUSICKIT_KEY_ID / MUSICKIT_PRIVATE_KEY",
         "appleMusicRadioFailed": "Échec du chargement de la radio Apple Music",
         "appleMusicRecentlyAddedFailed": "Échec du chargement des morceaux ajoutés récemment",
         "appleMusicSearchAppleMusic": "Apple Music",
@@ -2124,6 +2128,7 @@
         "appleMusicSearchSelectResult": "Sélectionnez un morceau à ajouter :",
         "appleMusicSearchSignInRequired": "Connectez-vous à Apple Music pour effectuer une recherche",
         "appleMusicSearchUnavailable": "La recherche Apple Music est indisponible",
+        "appleMusicSignInFailed": "Échec de la connexion",
         "autoUpdateFailed": "Échec de la mise à jour automatique",
         "autoUpdatedLibraryAddedSongs": "Bibliothèque mise à jour automatiquement : ajouté {{newCount}} nouvelle{{newPlural}} chanson{{newPlural}} en haut{{updatedText}}",
         "autoUpdatedTrackMetadata": "Mise à jour automatique des métadonnées de {{count}} piste{{plural}}",
@@ -2255,6 +2260,9 @@
         "fontSerifRed": "Serif (Rouge)",
         "fullScreen": "Plein écran",
         "furigana": "Furigana",
+        "goToAlbum": "Aller à l'album",
+        "goToArtist": "Aller à l'artiste",
+        "goToPlaylist": "Aller à la playlist",
         "importLibrary": "Importer la bibliothèque...",
         "ipodHelp": "Aide iPod",
         "japaneseFurigana": "Japonais (Furigana)",
@@ -2364,6 +2372,11 @@
         "wrong": "Pas tout à fait !"
       },
       "name": "iPod",
+      "playback": {
+        "live": "LIVE",
+        "mix": "MIX",
+        "trackOf": "{{current}} sur {{total}}"
+      },
       "status": {
         "added": "♬ Ajouté",
         "appleMusicAddedToFavorites": "Ajouté aux favoris",

--- a/src/lib/locales/it/translation.json
+++ b/src/lib/locales/it/translation.json
@@ -2075,6 +2075,7 @@
         "playPause": "Riproduci/Pausa",
         "previousTrack": "Traccia precedente",
         "select": "Seleziona",
+        "shuffleOn": "Riproduzione casuale attiva",
         "toggleFurigana": "Alterna Furigana",
         "toggleHangulRomanization": "Alterna Hangul / Romanizzazione",
         "toggleRomanization": "Alterna romanizzazione",
@@ -2116,6 +2117,9 @@
         "appleMusicLibraryProgress": "Caricamento libreria di Apple Music… {{loaded}} brani",
         "appleMusicLibraryProgressOf": "Caricamento libreria di Apple Music… {{loaded}} di {{total}}",
         "appleMusicNoRecommendations": "Non sono ancora disponibili consigli di Apple Music",
+        "appleMusicNotConfigured": "Apple Music non è configurato",
+        "appleMusicNotConfiguredDescription": "Imposta MUSICKIT_TEAM_ID, MUSICKIT_KEY_ID e MUSICKIT_PRIVATE_KEY.",
+        "appleMusicNotConfiguredDescriptionShort": "Imposta MUSICKIT_TEAM_ID / MUSICKIT_KEY_ID / MUSICKIT_PRIVATE_KEY",
         "appleMusicRadioFailed": "Impossibile caricare la radio di Apple Music",
         "appleMusicRecentlyAddedFailed": "Impossibile caricare i brani aggiunti di recente",
         "appleMusicSearchAppleMusic": "Apple Music",
@@ -2124,6 +2128,7 @@
         "appleMusicSearchSelectResult": "Seleziona un brano da aggiungere:",
         "appleMusicSearchSignInRequired": "Accedi ad Apple Music per cercare",
         "appleMusicSearchUnavailable": "La ricerca su Apple Music non è disponibile",
+        "appleMusicSignInFailed": "Accesso non riuscito",
         "autoUpdateFailed": "Aggiornamento automatico non riuscito",
         "autoUpdatedLibraryAddedSongs": "Libreria aggiornata automaticamente: aggiunti {{newCount}} nuovi brano{{newPlural}} in cima{{updatedText}}",
         "autoUpdatedTrackMetadata": "Aggiornati automaticamente i metadati di {{count}} brani",
@@ -2255,6 +2260,9 @@
         "fontSerifRed": "Serif (Rosso)",
         "fullScreen": "Schermo intero",
         "furigana": "Furigana",
+        "goToAlbum": "Vai all'album",
+        "goToArtist": "Vai all'artista",
+        "goToPlaylist": "Vai alla playlist",
         "importLibrary": "Importa libreria...",
         "ipodHelp": "Aiuto iPod",
         "japaneseFurigana": "Giapponese (Furigana)",
@@ -2364,6 +2372,11 @@
         "wrong": "Non proprio!"
       },
       "name": "iPod",
+      "playback": {
+        "live": "LIVE",
+        "mix": "MIX",
+        "trackOf": "{{current}} di {{total}}"
+      },
       "status": {
         "added": "♬ Aggiunta",
         "appleMusicAddedToFavorites": "Aggiunto ai preferiti",

--- a/src/lib/locales/ja/translation.json
+++ b/src/lib/locales/ja/translation.json
@@ -2075,6 +2075,7 @@
         "playPause": "再生/一時停止",
         "previousTrack": "前の曲",
         "select": "選択",
+        "shuffleOn": "シャッフルオン",
         "toggleFurigana": "フリガナ切り替え",
         "toggleHangulRomanization": "ハングル / ローマ字表記を切り替える",
         "toggleRomanization": "読み仮名の切り替え",
@@ -2116,6 +2117,9 @@
         "appleMusicLibraryProgress": "Apple Musicライブラリを読み込み中… {{loaded}}曲",
         "appleMusicLibraryProgressOf": "Apple Musicライブラリを読み込み中… {{loaded}} / {{total}}",
         "appleMusicNoRecommendations": "Apple Music のおすすめはまだありません",
+        "appleMusicNotConfigured": "Apple Musicが設定されていません",
+        "appleMusicNotConfiguredDescription": "MUSICKIT_TEAM_ID、MUSICKIT_KEY_ID、MUSICKIT_PRIVATE_KEYを設定してください。",
+        "appleMusicNotConfiguredDescriptionShort": "MUSICKIT_TEAM_ID / MUSICKIT_KEY_ID / MUSICKIT_PRIVATE_KEY を設定してください",
         "appleMusicRadioFailed": "Apple Music ラジオの読み込みに失敗しました",
         "appleMusicRecentlyAddedFailed": "最近追加した曲の読み込みに失敗しました",
         "appleMusicSearchAppleMusic": "Apple Music",
@@ -2124,6 +2128,7 @@
         "appleMusicSearchSelectResult": "追加する曲を選択してください:",
         "appleMusicSearchSignInRequired": "検索するにはApple Musicにサインインしてください",
         "appleMusicSearchUnavailable": "Apple Music検索は利用できません",
+        "appleMusicSignInFailed": "サインインに失敗しました",
         "autoUpdateFailed": "自動更新失敗",
         "autoUpdatedLibraryAddedSongs": "ライブラリを自動更新しました：先頭に {{newCount}} 曲の新しい曲を追加しました{{updatedText}}",
         "autoUpdatedTrackMetadata": "{{count}} 曲のメタデータを自動更新しました",
@@ -2255,6 +2260,9 @@
         "fontSerifRed": "明朝（赤）",
         "fullScreen": "全画面表示",
         "furigana": "フリガナ",
+        "goToAlbum": "アルバムへ",
+        "goToArtist": "アーティストへ",
+        "goToPlaylist": "プレイリストへ",
         "importLibrary": "ライブラリを読み込む...",
         "ipodHelp": "iPod ヘルプ",
         "japaneseFurigana": "日本語（フリガナ）",
@@ -2364,6 +2372,11 @@
         "wrong": "残念！"
       },
       "name": "iPod",
+      "playback": {
+        "live": "LIVE",
+        "mix": "MIX",
+        "trackOf": "{{total}}曲中{{current}}曲"
+      },
       "status": {
         "added": "♬ 追加しました",
         "appleMusicAddedToFavorites": "お気に入りに追加しました",

--- a/src/lib/locales/ko/translation.json
+++ b/src/lib/locales/ko/translation.json
@@ -2075,6 +2075,7 @@
         "playPause": "재생/일시 정지",
         "previousTrack": "이전 곡",
         "select": "선택",
+        "shuffleOn": "셔플 켜짐",
         "toggleFurigana": "후리가나 전환",
         "toggleHangulRomanization": "한글 / 로마자 표기 전환",
         "toggleRomanization": "발음 표기 전환",
@@ -2116,6 +2117,9 @@
         "appleMusicLibraryProgress": "Apple Music 보관함 불러오는 중… 노래 {{loaded}}곡",
         "appleMusicLibraryProgressOf": "Apple Music 보관함 불러오는 중… {{total}}개 중 {{loaded}}개",
         "appleMusicNoRecommendations": "아직 사용할 수 있는 Apple Music 추천이 없습니다",
+        "appleMusicNotConfigured": "Apple Music이 구성되지 않았습니다",
+        "appleMusicNotConfiguredDescription": "MUSICKIT_TEAM_ID, MUSICKIT_KEY_ID, MUSICKIT_PRIVATE_KEY를 설정하세요.",
+        "appleMusicNotConfiguredDescriptionShort": "MUSICKIT_TEAM_ID / MUSICKIT_KEY_ID / MUSICKIT_PRIVATE_KEY를 설정하세요",
         "appleMusicRadioFailed": "Apple Music 라디오를 불러오지 못했습니다",
         "appleMusicRecentlyAddedFailed": "최근 추가된 노래를 불러오지 못했습니다",
         "appleMusicSearchAppleMusic": "Apple Music",
@@ -2124,6 +2128,7 @@
         "appleMusicSearchSelectResult": "추가할 노래 선택:",
         "appleMusicSearchSignInRequired": "검색하려면 Apple Music에 로그인하세요",
         "appleMusicSearchUnavailable": "Apple Music 검색을 사용할 수 없습니다",
+        "appleMusicSignInFailed": "로그인 실패",
         "autoUpdateFailed": "자동 업데이트 실패",
         "autoUpdatedLibraryAddedSongs": "라이브러리 자동 업데이트됨: 새로운 곡 {{newCount}}개가 상단에 추가되었습니다{{updatedText}}",
         "autoUpdatedTrackMetadata": "트랙 메타데이터 {{count}}개 자동 업데이트됨",
@@ -2255,6 +2260,9 @@
         "fontSerifRed": "세리프 (빨강)",
         "fullScreen": "전체 화면",
         "furigana": "후리가나",
+        "goToAlbum": "앨범으로 이동",
+        "goToArtist": "아티스트로 이동",
+        "goToPlaylist": "재생목록으로 이동",
         "importLibrary": "보관함 가져오기...",
         "ipodHelp": "iPod 도움말",
         "japaneseFurigana": "일본어 (후리가나)",
@@ -2364,6 +2372,11 @@
         "wrong": "아쉽네요!"
       },
       "name": "iPod",
+      "playback": {
+        "live": "LIVE",
+        "mix": "MIX",
+        "trackOf": "{{total}}곡 중 {{current}}곡"
+      },
       "status": {
         "added": "♬ 추가됨",
         "appleMusicAddedToFavorites": "즐겨찾기에 추가됨",

--- a/src/lib/locales/pt/translation.json
+++ b/src/lib/locales/pt/translation.json
@@ -2075,6 +2075,7 @@
         "playPause": "Reproduzir/Pausar",
         "previousTrack": "Faixa anterior",
         "select": "Selecionar",
+        "shuffleOn": "Aleatório ativado",
         "toggleFurigana": "Alternar Furigana",
         "toggleHangulRomanization": "Alternar Hangul / Romanização",
         "toggleRomanization": "Alternar Romanização",
@@ -2116,6 +2117,9 @@
         "appleMusicLibraryProgress": "Carregando biblioteca do Apple Music… {{loaded}} músicas",
         "appleMusicLibraryProgressOf": "Carregando biblioteca do Apple Music… {{loaded}} de {{total}}",
         "appleMusicNoRecommendations": "Ainda não há recomendações do Apple Music disponíveis",
+        "appleMusicNotConfigured": "Apple Music não está configurado",
+        "appleMusicNotConfiguredDescription": "Defina MUSICKIT_TEAM_ID, MUSICKIT_KEY_ID e MUSICKIT_PRIVATE_KEY.",
+        "appleMusicNotConfiguredDescriptionShort": "Defina MUSICKIT_TEAM_ID / MUSICKIT_KEY_ID / MUSICKIT_PRIVATE_KEY",
         "appleMusicRadioFailed": "Falha ao carregar a rádio do Apple Music",
         "appleMusicRecentlyAddedFailed": "Falha ao carregar músicas adicionadas recentemente",
         "appleMusicSearchAppleMusic": "Apple Music",
@@ -2124,6 +2128,7 @@
         "appleMusicSearchSelectResult": "Selecione uma música para adicionar:",
         "appleMusicSearchSignInRequired": "Inicie sessão no Apple Music para buscar",
         "appleMusicSearchUnavailable": "A busca do Apple Music está indisponível",
+        "appleMusicSignInFailed": "Falha ao entrar",
         "autoUpdateFailed": "Falha na Atualização Automática",
         "autoUpdatedLibraryAddedSongs": "Biblioteca atualizada automaticamente: adicionada{{newPlural}} {{newCount}} nova{{newPlural}} música{{newPlural}} ao topo{{updatedText}}",
         "autoUpdatedTrackMetadata": "Metadados de {{count}} faixa{{plural}} atualizados automaticamente",
@@ -2255,6 +2260,9 @@
         "fontSerifRed": "Serifa (Vermelho)",
         "fullScreen": "Tela Cheia",
         "furigana": "Furigana",
+        "goToAlbum": "Ir para o álbum",
+        "goToArtist": "Ir para o artista",
+        "goToPlaylist": "Ir para a playlist",
         "importLibrary": "Importar Biblioteca...",
         "ipodHelp": "Ajuda do iPod",
         "japaneseFurigana": "Japonês (Furigana)",
@@ -2364,6 +2372,11 @@
         "wrong": "Quase!"
       },
       "name": "iPod",
+      "playback": {
+        "live": "LIVE",
+        "mix": "MIX",
+        "trackOf": "{{current}} de {{total}}"
+      },
       "status": {
         "added": "♬ Adicionada",
         "appleMusicAddedToFavorites": "Adicionado aos Favoritos",

--- a/src/lib/locales/ru/translation.json
+++ b/src/lib/locales/ru/translation.json
@@ -2075,6 +2075,7 @@
         "playPause": "Воспроизвести/Пауза",
         "previousTrack": "Предыдущий трек",
         "select": "Выбрать",
+        "shuffleOn": "Случайный порядок включён",
         "toggleFurigana": "Переключить фуригану",
         "toggleHangulRomanization": "Переключить хангыль / романизацию",
         "toggleRomanization": "Переключить романизацию",
@@ -2116,6 +2117,9 @@
         "appleMusicLibraryProgress": "Загрузка медиатеки Apple Music… {{loaded}} песен",
         "appleMusicLibraryProgressOf": "Загрузка медиатеки Apple Music… {{loaded}} из {{total}}",
         "appleMusicNoRecommendations": "Рекомендации Apple Music пока недоступны",
+        "appleMusicNotConfigured": "Apple Music не настроен",
+        "appleMusicNotConfiguredDescription": "Укажите MUSICKIT_TEAM_ID, MUSICKIT_KEY_ID и MUSICKIT_PRIVATE_KEY.",
+        "appleMusicNotConfiguredDescriptionShort": "Укажите MUSICKIT_TEAM_ID / MUSICKIT_KEY_ID / MUSICKIT_PRIVATE_KEY",
         "appleMusicRadioFailed": "Не удалось загрузить радио Apple Music",
         "appleMusicRecentlyAddedFailed": "Не удалось загрузить недавно добавленные песни",
         "appleMusicSearchAppleMusic": "Apple Music",
@@ -2124,6 +2128,7 @@
         "appleMusicSearchSelectResult": "Выберите песню для добавления:",
         "appleMusicSearchSignInRequired": "Войдите в Apple Music для поиска",
         "appleMusicSearchUnavailable": "Поиск в Apple Music недоступен",
+        "appleMusicSignInFailed": "Не удалось войти",
         "autoUpdateFailed": "Сбой автообновления",
         "autoUpdatedLibraryAddedSongs": "Библиотека автоматически обновлена: добавлено {{newCount}} новая песня{{newPlural}} в начало{{updatedText}}",
         "autoUpdatedTrackMetadata": "Автоматически обновлены метаданные {{count}} трек{{plural}}",
@@ -2255,6 +2260,9 @@
         "fontSerifRed": "Serif (Красный)",
         "fullScreen": "На весь экран",
         "furigana": "Фуригана",
+        "goToAlbum": "К альбому",
+        "goToArtist": "К исполнителю",
+        "goToPlaylist": "К плейлисту",
         "importLibrary": "Импорт медиатеки...",
         "ipodHelp": "Справка iPod",
         "japaneseFurigana": "Японский (Фуригана)",
@@ -2364,6 +2372,11 @@
         "wrong": "Не совсем!"
       },
       "name": "iPod",
+      "playback": {
+        "live": "LIVE",
+        "mix": "MIX",
+        "trackOf": "{{current}} из {{total}}"
+      },
       "status": {
         "added": "♬ Добавлено",
         "appleMusicAddedToFavorites": "Добавлено в избранное",

--- a/src/lib/locales/zh-TW/translation.json
+++ b/src/lib/locales/zh-TW/translation.json
@@ -2075,6 +2075,7 @@
         "playPause": "播放/暫停",
         "previousTrack": "上一首",
         "select": "選取",
+        "shuffleOn": "隨機播放已開啟",
         "toggleFurigana": "切換振假名",
         "toggleHangulRomanization": "切換韓文 / 羅馬拼音",
         "toggleRomanization": "切換羅馬拼音",
@@ -2116,6 +2117,9 @@
         "appleMusicLibraryProgress": "正在載入 Apple Music 資料庫… {{loaded}} 首歌曲",
         "appleMusicLibraryProgressOf": "正在載入 Apple Music 資料庫… {{loaded}} / {{total}}",
         "appleMusicNoRecommendations": "目前尚無可用的 Apple Music 推薦",
+        "appleMusicNotConfigured": "尚未設定 Apple Music",
+        "appleMusicNotConfiguredDescription": "請設定 MUSICKIT_TEAM_ID、MUSICKIT_KEY_ID 與 MUSICKIT_PRIVATE_KEY。",
+        "appleMusicNotConfiguredDescriptionShort": "請設定 MUSICKIT_TEAM_ID / MUSICKIT_KEY_ID / MUSICKIT_PRIVATE_KEY",
         "appleMusicRadioFailed": "無法載入 Apple Music 廣播",
         "appleMusicRecentlyAddedFailed": "無法載入最近加入的歌曲",
         "appleMusicSearchAppleMusic": "Apple Music",
@@ -2124,6 +2128,7 @@
         "appleMusicSearchSelectResult": "選擇要加入的歌曲：",
         "appleMusicSearchSignInRequired": "登入 Apple Music 以進行搜尋",
         "appleMusicSearchUnavailable": "Apple Music 搜尋目前無法使用",
+        "appleMusicSignInFailed": "登入失敗",
         "autoUpdateFailed": "自動更新失敗",
         "autoUpdatedLibraryAddedSongs": "資料庫已自動更新：新增了 {{newCount}} 首新歌到頂部{{updatedText}}",
         "autoUpdatedTrackMetadata": "已自動更新 {{count}} 首曲目的中繼資料",
@@ -2255,6 +2260,9 @@
         "fontSerifRed": "襯線（紅）",
         "fullScreen": "全螢幕",
         "furigana": "假名標音",
+        "goToAlbum": "前往專輯",
+        "goToArtist": "前往藝人",
+        "goToPlaylist": "前往播放清單",
         "importLibrary": "匯入資料庫...",
         "ipodHelp": "iPod 輔助說明",
         "japaneseFurigana": "日文（假名）",
@@ -2364,6 +2372,11 @@
         "wrong": "不太對！"
       },
       "name": "iPod",
+      "playback": {
+        "live": "LIVE",
+        "mix": "MIX",
+        "trackOf": "第 {{current}} 首，共 {{total}} 首"
+      },
       "status": {
         "added": "♬ 已新增",
         "appleMusicAddedToFavorites": "已加入最愛",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Localizes strings used by the modern iPod UI, including the long-press **Now Playing song menu** (Cover Flow, Add to Favorites, Go to Playlist/Album/Artist), modern **Now Playing** status line (LIVE / MIX / track counter), and related Apple Music configuration toasts.

## Changes

- Added `apps.ipod.playback.*`, `apps.ipod.menu.goTo*`, dialog keys for Apple Music setup/sign-in errors, and `ariaLabels.shuffleOn` in `en/translation.json`
- Replaced hardcoded strings in `IpodScreen.tsx`, `useIpodLogic.ts`, `IpodMenuBar.tsx`, and `IpodAppComponent.tsx`
- Pointed `TRANSLATION_LANGUAGES` at existing `translationLanguages.*` label keys (menubar + fullscreen/karaoke consumers)
- Synced and hand-translated the 11 new keys across `zh-TW`, `ja`, `ko`, `fr`, `de`, `es`, `pt`, `it`, and `ru`

## Testing

- `bun run build`
- `bun run test:unit`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-03550F04-2D73-40E7-9134-33E323085BE5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-03550F04-2D73-40E7-9134-33E323085BE5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

