### PR TITLE
fix(ipod): modern menu label overflow fade and chevron-aware measurement

### DIFF
--- a/src/apps/ipod/components/IpodScreen.tsx
+++ b/src/apps/ipod/components/IpodScreen.tsx
@@ -597,6 +597,8 @@ export function IpodScreen({
   // **Modern media lists** (playlist picker, Apple Music browses) show
   // artwork in each row — hide the right split so the menu stays full
   // width. Per-artist album lists use the same split preview as Albums.
+  const isNowPlayingSongMenu =
+    menuHistory[menuHistory.length - 1]?.title === IPOD_NOW_PLAYING_SONG_MENU_KEY;
   const isBrowseableMenu = useMemo(
     () =>
       isModernUi &&
@@ -607,12 +609,14 @@ export function IpodScreen({
       // entirely while Cover Flow is on screen.
       !showInlineCoverFlow &&
       !currentMenuModernMediaList &&
+      !isNowPlayingSongMenu &&
       currentMenuItems.some((item) => item.showChevron === true),
     [
       isModernUi,
       menuMode,
       showInlineCoverFlow,
       currentMenuModernMediaList,
+      isNowPlayingSongMenu,
       currentMenuItems,
     ]
   );
@@ -734,13 +738,11 @@ export function IpodScreen({
       setModernChromeWidthMarqueeBlocked(false);
     }, 320);
     return () => window.clearTimeout(id);
-  }, [showSplitMenuArt, menuMode, isModernUi]);
+  }, [showSplitMenuArt, menuMode, isModernUi, isNowPlayingSongMenu]);
 
   const skipModernMenuRouteMarqueeCooldown = useRef(true);
   const [modernMenuRouteMarqueeBlocked, setModernMenuRouteMarqueeBlocked] =
     useState(false);
-  const isNowPlayingSongMenu =
-    menuHistory[menuHistory.length - 1]?.title === IPOD_NOW_PLAYING_SONG_MENU_KEY;
 
   useEffect(() => {
     if (!isModernUi) {

--- a/src/apps/ipod/components/IpodScreen.tsx
+++ b/src/apps/ipod/components/IpodScreen.tsx
@@ -721,6 +721,10 @@ export function IpodScreen({
       setModernChromeWidthMarqueeBlocked(false);
       return;
     }
+    if (isNowPlayingSongMenu) {
+      setModernChromeWidthMarqueeBlocked(false);
+      return;
+    }
     if (skipModernChromeMarqueeCooldown.current) {
       skipModernChromeMarqueeCooldown.current = false;
       return;

--- a/src/apps/ipod/components/IpodScreen.tsx
+++ b/src/apps/ipod/components/IpodScreen.tsx
@@ -986,7 +986,6 @@ export function IpodScreen({
                               backlightOn={backlightOn}
                               variant={uiVariant}
                               allowScrollingMarquee={modernScrollingMarqueeAllowed}
-                              fadeEdges={!isNowPlayingSongMenu}
                               onClick={() => {
                                 onSelectMenuItem(index);
                                 onMenuItemAction(item.action);

--- a/src/apps/ipod/components/IpodScreen.tsx
+++ b/src/apps/ipod/components/IpodScreen.tsx
@@ -609,14 +609,12 @@ export function IpodScreen({
       // entirely while Cover Flow is on screen.
       !showInlineCoverFlow &&
       !currentMenuModernMediaList &&
-      !isNowPlayingSongMenu &&
       currentMenuItems.some((item) => item.showChevron === true),
     [
       isModernUi,
       menuMode,
       showInlineCoverFlow,
       currentMenuModernMediaList,
-      isNowPlayingSongMenu,
       currentMenuItems,
     ]
   );
@@ -725,10 +723,6 @@ export function IpodScreen({
       setModernChromeWidthMarqueeBlocked(false);
       return;
     }
-    if (isNowPlayingSongMenu) {
-      setModernChromeWidthMarqueeBlocked(false);
-      return;
-    }
     if (skipModernChromeMarqueeCooldown.current) {
       skipModernChromeMarqueeCooldown.current = false;
       return;
@@ -738,7 +732,7 @@ export function IpodScreen({
       setModernChromeWidthMarqueeBlocked(false);
     }, 320);
     return () => window.clearTimeout(id);
-  }, [showSplitMenuArt, menuMode, isModernUi, isNowPlayingSongMenu]);
+  }, [showSplitMenuArt, menuMode, isModernUi]);
 
   const skipModernMenuRouteMarqueeCooldown = useRef(true);
   const [modernMenuRouteMarqueeBlocked, setModernMenuRouteMarqueeBlocked] =
@@ -992,6 +986,7 @@ export function IpodScreen({
                               backlightOn={backlightOn}
                               variant={uiVariant}
                               allowScrollingMarquee={modernScrollingMarqueeAllowed}
+                              fadeEdges={!isNowPlayingSongMenu}
                               onClick={() => {
                                 onSelectMenuItem(index);
                                 onMenuItemAction(item.action);

--- a/src/apps/ipod/components/screen/MenuListItem.tsx
+++ b/src/apps/ipod/components/screen/MenuListItem.tsx
@@ -125,21 +125,19 @@ export function MenuListItem({
             </div>
             {/* Two-line stack: 12+1+11 px fits under 26px thumb inside a 33px row. */}
             <div className="flex min-h-0 min-w-0 flex-1 flex-col justify-center gap-px py-0 leading-none">
-              <div className="flex h-[12px] min-h-0 min-w-0 items-center">
-                <ScrollingText
-                  text={text}
-                  align="left"
-                  fadeEdges
-                  allowMarquee={allowScrollingMarquee}
-                  isPlaying={isSelected && !isLoading}
-                  resetOnPause
-                  scrollStartDelaySec={0.5}
-                  className={cn(
-                    "h-full m-0 w-full min-w-0 p-0 font-semibold leading-none",
-                    hasCjkText ? "text-[11px]" : "text-[12px]"
-                  )}
-                />
-              </div>
+              <ScrollingText
+                text={text}
+                align="left"
+                fadeEdges
+                allowMarquee={allowScrollingMarquee}
+                isPlaying={isSelected && !isLoading}
+                resetOnPause
+                scrollStartDelaySec={0.5}
+                className={cn(
+                  "m-0 w-full min-w-0 p-0 font-semibold leading-none",
+                  hasCjkText ? "text-[11px]" : "text-[12px]"
+                )}
+              />
               {subtitleTrim ? (
                 <span
                   className={cn(
@@ -216,7 +214,7 @@ export function MenuListItem({
               : "text-black"
         )}
       >
-        <span className="flex min-h-0 min-w-0 flex-1 items-center self-stretch mr-2 overflow-y-hidden">
+        <span className="flex h-full min-h-0 min-w-0 flex-1 items-center self-stretch mr-2">
           <ScrollingText
             text={text}
             align="left"
@@ -225,7 +223,7 @@ export function MenuListItem({
             isPlaying={isSelected && !isLoading}
             resetOnPause
             scrollStartDelaySec={0.5}
-            className="w-full min-w-0 text-[15px] font-semibold leading-none"
+            className="h-full w-full min-w-0 text-[15px] font-semibold leading-none"
           />
         </span>
         {value ? (

--- a/src/apps/ipod/components/screen/MenuListItem.tsx
+++ b/src/apps/ipod/components/screen/MenuListItem.tsx
@@ -125,19 +125,21 @@ export function MenuListItem({
             </div>
             {/* Two-line stack: 12+1+11 px fits under 26px thumb inside a 33px row. */}
             <div className="flex min-h-0 min-w-0 flex-1 flex-col justify-center gap-px py-0 leading-none">
-              <ScrollingText
-                text={text}
-                align="left"
-                fadeEdges
-                allowMarquee={allowScrollingMarquee}
-                isPlaying={isSelected && !isLoading}
-                resetOnPause
-                scrollStartDelaySec={0.5}
-                className={cn(
-                  "m-0 w-full min-w-0 p-0 font-semibold leading-none",
-                  hasCjkText ? "text-[11px]" : "text-[12px]"
-                )}
-              />
+              <div className="flex h-[12px] min-h-0 min-w-0 items-center">
+                <ScrollingText
+                  text={text}
+                  align="left"
+                  fadeEdges
+                  allowMarquee={allowScrollingMarquee}
+                  isPlaying={isSelected && !isLoading}
+                  resetOnPause
+                  scrollStartDelaySec={0.5}
+                  className={cn(
+                    "h-full m-0 w-full min-w-0 p-0 font-semibold leading-none",
+                    hasCjkText ? "text-[11px]" : "text-[12px]"
+                  )}
+                />
+              </div>
               {subtitleTrim ? (
                 <span
                   className={cn(

--- a/src/apps/ipod/components/screen/MenuListItem.tsx
+++ b/src/apps/ipod/components/screen/MenuListItem.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { cn } from "@/lib/utils";
 import { useImageLoaded } from "../../hooks/useImageLoaded";
 import { IPOD_MODERN_MEDIA_THUMB_PX } from "../../constants";
@@ -62,6 +62,7 @@ export function MenuListItem({
   emptyArtworkKind = "album",
   mediaRow = false,
 }: MenuListItemProps) {
+  const rowRef = useRef<HTMLDivElement>(null);
   const hasCjkText =
     CJK_TEXT_PATTERN.test(text) ||
     (value ? CJK_TEXT_PATTERN.test(value) : false) ||
@@ -81,6 +82,7 @@ export function MenuListItem({
     if (mediaRow) {
       return (
         <div
+          ref={rowRef}
           onClick={isLoading ? undefined : onClick}
           className={cn(
             "h-full overflow-x-visible overflow-y-hidden pl-1 pr-1.5 font-ipod-modern-ui flex justify-between items-center gap-1",
@@ -123,12 +125,12 @@ export function MenuListItem({
                 />
               ) : null}
             </div>
-            {/* Two-line stack: 12+1+11 px fits under 26px thumb inside a 33px row. */}
             <div className="flex min-h-0 min-w-0 flex-1 flex-col justify-center gap-px py-0 leading-none">
               <ScrollingText
                 text={text}
                 align="left"
                 fadeEdges
+                rowRef={rowRef}
                 allowMarquee={allowScrollingMarquee}
                 isPlaying={isSelected && !isLoading}
                 resetOnPause
@@ -156,6 +158,7 @@ export function MenuListItem({
           </div>
           {value ? (
             <span
+              data-ipod-menu-row-end
               className={cn(
                 "flex shrink-0 items-center font-semibold leading-none",
                 hasCjkText ? "text-[11px]" : "text-[12px]",
@@ -170,6 +173,7 @@ export function MenuListItem({
             showChevron &&
             !isLoading && (
               <span
+                data-ipod-menu-row-end
                 className={cn(
                   "flex shrink-0 items-center justify-center font-normal leading-none",
                   "text-[16px]",
@@ -185,25 +189,11 @@ export function MenuListItem({
       );
     }
 
-    // iPod-classic-js SelectableListItem: white row, blue gradient
-    // selection highlight, no separator. Rows are **22px** with **15px** type so
-    // 16px status bar + six rows fill the 132px menu body (constants.ts).
-    //
-    // Long labels truncate via `ScrollingText` with `fadeEdges`:
-    //   - When the label fits, ScrollingText renders static text.
-    //   - When it overflows, a fade-to-transparent mask appears on the
-    //     right edge (truncation hint) instead of an ellipsis.
-    //   - When the row is also `isSelected`, the marquee animates and
-    //     both edges fade — matches the iPod nano 6G/7G's behavior of
-    //     scrolling the highlighted row's text horizontally.
-    //   - `resetOnPause` is enabled so deselecting a row snaps the
-    //     marquee back to translate(0) instead of leaving the text
-    //     frozen at whatever offset it had scrolled to.
     return (
       <div
+        ref={rowRef}
         onClick={isLoading ? undefined : onClick}
         className={cn(
-          /* overflow-y-hidden: row slot height; overflow-x-visible: horizontal marquee. */
           "h-full overflow-x-visible overflow-y-hidden pl-1.5 pr-2 font-ipod-modern-ui flex justify-between items-center",
           "ipod-modern-row",
           isLoading ? "cursor-default" : "cursor-pointer",
@@ -219,15 +209,17 @@ export function MenuListItem({
             text={text}
             align="left"
             fadeEdges
+            rowRef={rowRef}
             allowMarquee={allowScrollingMarquee}
             isPlaying={isSelected && !isLoading}
             resetOnPause
             scrollStartDelaySec={0.5}
-            className="h-full w-full min-w-0 text-[15px] font-semibold leading-none"
+            className="w-full min-w-0 text-[15px] font-semibold leading-none"
           />
         </span>
         {value ? (
           <span
+            data-ipod-menu-row-end
             className={cn(
               "flex shrink-0 items-center text-[15px] font-semibold leading-none",
               isSelected && !isLoading
@@ -240,10 +232,8 @@ export function MenuListItem({
         ) : (
           showChevron &&
           !isLoading && (
-            // Right-arrow chevron: thin and light grey when idle, white
-            // when the row is selected — same affordance as the
-            // arrow_right.svg used in iPod-classic-js.
             <span
+              data-ipod-menu-row-end
               className={cn(
                 "flex shrink-0 items-center justify-center font-normal leading-none",
                 "text-[19px]",
@@ -263,10 +253,6 @@ export function MenuListItem({
     <div
       onClick={isLoading ? undefined : onClick}
       className={cn(
-        // h-full makes the row exactly fill its
-        // virtualization wrapper (MENU_ITEM_HEIGHT in IpodScreen) so
-        // items in every menu — main, music, artist, and All Songs —
-        // share the same vertical rhythm.
         "h-full pl-2 pr-3 font-chicago flex justify-between items-center",
         isLoading ? "cursor-default" : "cursor-pointer",
         isSelected && !isLoading

--- a/src/apps/ipod/components/screen/MenuListItem.tsx
+++ b/src/apps/ipod/components/screen/MenuListItem.tsx
@@ -20,8 +20,6 @@ interface MenuListItemProps {
    * parent layout has settled — e.g. during split-menu width animation.
    */
   allowScrollingMarquee?: boolean;
-  /** Modern rows: edge fades when overflowing (song menu in split uses marquee only). */
-  fadeEdges?: boolean;
   /**
    * Visual skin. `"classic"` keeps the monochrome blue-on-blue
    * Chicago-font row from the original 1st-gen LCD. `"modern"` switches
@@ -58,7 +56,6 @@ export function MenuListItem({
   value,
   isLoading = false,
   allowScrollingMarquee = true,
-  fadeEdges = true,
   variant = "classic",
   subtitle,
   thumbnailUrl,
@@ -131,7 +128,7 @@ export function MenuListItem({
               <ScrollingText
                 text={text}
                 align="left"
-                fadeEdges={fadeEdges}
+                fadeEdges
                 allowMarquee={allowScrollingMarquee}
                 isPlaying={isSelected && !isLoading}
                 resetOnPause
@@ -221,7 +218,7 @@ export function MenuListItem({
           <ScrollingText
             text={text}
             align="left"
-            fadeEdges={fadeEdges}
+            fadeEdges
             allowMarquee={allowScrollingMarquee}
             isPlaying={isSelected && !isLoading}
             resetOnPause

--- a/src/apps/ipod/components/screen/MenuListItem.tsx
+++ b/src/apps/ipod/components/screen/MenuListItem.tsx
@@ -20,6 +20,8 @@ interface MenuListItemProps {
    * parent layout has settled — e.g. during split-menu width animation.
    */
   allowScrollingMarquee?: boolean;
+  /** Modern rows: edge fades when overflowing (song menu in split uses marquee only). */
+  fadeEdges?: boolean;
   /**
    * Visual skin. `"classic"` keeps the monochrome blue-on-blue
    * Chicago-font row from the original 1st-gen LCD. `"modern"` switches
@@ -56,6 +58,7 @@ export function MenuListItem({
   value,
   isLoading = false,
   allowScrollingMarquee = true,
+  fadeEdges = true,
   variant = "classic",
   subtitle,
   thumbnailUrl,
@@ -128,7 +131,7 @@ export function MenuListItem({
               <ScrollingText
                 text={text}
                 align="left"
-                fadeEdges
+                fadeEdges={fadeEdges}
                 allowMarquee={allowScrollingMarquee}
                 isPlaying={isSelected && !isLoading}
                 resetOnPause
@@ -218,7 +221,7 @@ export function MenuListItem({
           <ScrollingText
             text={text}
             align="left"
-            fadeEdges
+            fadeEdges={fadeEdges}
             allowMarquee={allowScrollingMarquee}
             isPlaying={isSelected && !isLoading}
             resetOnPause

--- a/src/apps/ipod/components/screen/ScrollingText.tsx
+++ b/src/apps/ipod/components/screen/ScrollingText.tsx
@@ -129,7 +129,7 @@ export function ScrollingText({
     <div
       ref={containerRef}
       className={cn(
-        "relative flex min-h-0 min-w-0 items-center overflow-x-hidden overflow-y-visible",
+        "relative flex h-full min-h-0 min-w-0 items-center overflow-x-hidden overflow-y-hidden",
         alignClass,
         className
       )}

--- a/src/apps/ipod/components/screen/ScrollingText.tsx
+++ b/src/apps/ipod/components/screen/ScrollingText.tsx
@@ -5,6 +5,7 @@ import {
   useCallback,
   type AnimationEvent,
   type CSSProperties,
+  type RefObject,
 } from "react";
 import { cn } from "@/lib/utils";
 
@@ -31,6 +32,30 @@ interface ScrollingTextProps {
    */
   resetOnPause?: boolean;
   style?: CSSProperties;
+  /**
+   * Menu row element used to measure label width up to the chevron/value
+   * column (`[data-ipod-menu-row-end]`), including gap and row padding.
+   */
+  rowRef?: RefObject<HTMLElement | null>;
+}
+
+/** Visible label width from container left edge to the row end cap (chevron/value). */
+export function getLabelClipWidth(
+  container: HTMLElement,
+  row: HTMLElement | null
+): number {
+  if (!row) return container.clientWidth;
+
+  const endCap = row.querySelector<HTMLElement>("[data-ipod-menu-row-end]");
+  if (!endCap) return container.clientWidth;
+
+  const containerRect = container.getBoundingClientRect();
+  const endRect = endCap.getBoundingClientRect();
+  const clipWidth = endRect.left - containerRect.left;
+  if (!Number.isFinite(clipWidth) || clipWidth <= 0) {
+    return container.clientWidth;
+  }
+  return clipWidth;
 }
 
 export function ScrollingText({
@@ -43,6 +68,7 @@ export function ScrollingText({
   scrollStartDelaySec = 0,
   resetOnPause = false,
   style,
+  rowRef,
 }: ScrollingTextProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const textRef = useRef<HTMLDivElement>(null);
@@ -58,24 +84,18 @@ export function ScrollingText({
     const textElement = textRef.current;
     if (!container || !textElement) return;
 
-    const containerWidth = container.clientWidth;
+    const containerWidth = getLabelClipWidth(
+      container,
+      rowRef?.current ?? null
+    );
     if (containerWidth <= 0) {
       setShouldScroll(false);
       return;
     }
 
-    let contentWidth = textElement.scrollWidth;
-    if (textElement.closest(".scrolling-text-marquee-track")) {
-      contentWidth = Math.max(0, contentWidth - paddingWidth);
-    }
-
+    const contentWidth = textElement.scrollWidth;
     setShouldScroll(contentWidth > containerWidth + 1);
-  }, [paddingWidth]);
-
-  const isResetPaused = resetOnPause && !isPlaying;
-  const showMarquee = shouldScroll && allowMarquee && !isResetPaused;
-  const showStaticOverflowFade =
-    shouldScroll && allowMarquee && isResetPaused && fadeEdges;
+  }, [rowRef]);
 
   useEffect(() => {
     const container = containerRef.current;
@@ -84,17 +104,18 @@ export function ScrollingText({
 
     measureOverflow();
 
-    const resizeObserver = new ResizeObserver(() => measureOverflow());
+    const resizeObserver = new ResizeObserver(measureOverflow);
     resizeObserver.observe(container);
     resizeObserver.observe(textElement);
+    const row = rowRef?.current;
+    if (row) resizeObserver.observe(row);
 
     return () => resizeObserver.disconnect();
-  }, [text, allowMarquee, measureOverflow]);
+  }, [text, allowMarquee, measureOverflow, rowRef]);
 
-  useEffect(() => {
-    const id = requestAnimationFrame(() => measureOverflow());
-    return () => cancelAnimationFrame(id);
-  }, [showMarquee, measureOverflow]);
+  const isResetPaused = resetOnPause && !isPlaying;
+  const showMarquee = shouldScroll && allowMarquee && !isResetPaused;
+  const showStaticOverflowFade = shouldScroll && fadeEdges && !showMarquee;
 
   useEffect(() => {
     setEdgeFadeActive(false);

--- a/src/apps/ipod/components/screen/ScrollingText.tsx
+++ b/src/apps/ipod/components/screen/ScrollingText.tsx
@@ -61,9 +61,8 @@ export function ScrollingText({
 
     const measure = () => {
       const newContainerWidth = container.clientWidth;
-      if (newContainerWidth <= 0) return;
       const newContentWidth = textElement.scrollWidth;
-      setShouldScroll(newContentWidth > newContainerWidth + 1);
+      setShouldScroll(newContentWidth > newContainerWidth);
     };
 
     measure();

--- a/src/apps/ipod/components/screen/ScrollingText.tsx
+++ b/src/apps/ipod/components/screen/ScrollingText.tsx
@@ -53,34 +53,48 @@ export function ScrollingText({
 
   const durationSec = Math.max(text.length * 0.15, 8);
 
-  // Check if text needs to scroll (is wider than container)
+  const measureOverflow = useCallback(() => {
+    const container = containerRef.current;
+    const textElement = textRef.current;
+    if (!container || !textElement) return;
+
+    const containerWidth = container.clientWidth;
+    if (containerWidth <= 0) {
+      setShouldScroll(false);
+      return;
+    }
+
+    let contentWidth = textElement.scrollWidth;
+    if (textElement.closest(".scrolling-text-marquee-track")) {
+      contentWidth = Math.max(0, contentWidth - paddingWidth);
+    }
+
+    setShouldScroll(contentWidth > containerWidth + 1);
+  }, [paddingWidth]);
+
+  const isResetPaused = resetOnPause && !isPlaying;
+  const showMarquee = shouldScroll && allowMarquee && !isResetPaused;
+  const showStaticOverflowFade =
+    shouldScroll && allowMarquee && isResetPaused && fadeEdges;
+
   useEffect(() => {
     const container = containerRef.current;
     const textElement = textRef.current;
     if (!container || !textElement) return;
 
-    const measure = () => {
-      const newContainerWidth = container.clientWidth;
-      const newContentWidth = textElement.scrollWidth;
-      setShouldScroll(newContentWidth > newContainerWidth);
-    };
+    measureOverflow();
 
-    measure();
-
-    const resizeObserver = new ResizeObserver(measure);
+    const resizeObserver = new ResizeObserver(() => measureOverflow());
     resizeObserver.observe(container);
     resizeObserver.observe(textElement);
 
     return () => resizeObserver.disconnect();
-  }, [text, allowMarquee]);
+  }, [text, allowMarquee, measureOverflow]);
 
-  // When `resetOnPause` is enabled and we're paused, drop the marquee track
-  // entirely so the duplicated text snaps back to translate(0). The static
-  // branch still gets the right-edge truncation fade below.
-  const isResetPaused = resetOnPause && !isPlaying;
-  const showMarquee = shouldScroll && allowMarquee && !isResetPaused;
-  const showStaticOverflowFade =
-    shouldScroll && allowMarquee && isResetPaused && fadeEdges;
+  useEffect(() => {
+    const id = requestAnimationFrame(() => measureOverflow());
+    return () => cancelAnimationFrame(id);
+  }, [showMarquee, measureOverflow]);
 
   useEffect(() => {
     setEdgeFadeActive(false);
@@ -92,12 +106,7 @@ export function ScrollingText({
   }, []);
 
   const fadeInset = "0.75em";
-  // Right-only fade: keep text crisp on the left, hint overflow on the right.
-  // Used for the idle/pre-start frame of the marquee AND for the
-  // `resetOnPause` static fallback (so deselected overflowing rows still
-  // render a truncation hint instead of a hard cut).
   const rightOnlyFadeGradient = `linear-gradient(to right, black 0, black calc(100% - ${fadeInset}), transparent 100%)`;
-  // Full fade: hides the seam at both edges while the marquee loops.
   const bothEdgesFadeGradient = `linear-gradient(to right, transparent 0, black ${fadeInset}, black calc(100% - ${fadeInset}), transparent 100%)`;
   const maskImage = showMarquee && fadeEdges
     ? edgeFadeActive

--- a/src/apps/ipod/components/screen/ScrollingText.tsx
+++ b/src/apps/ipod/components/screen/ScrollingText.tsx
@@ -61,8 +61,9 @@ export function ScrollingText({
 
     const measure = () => {
       const newContainerWidth = container.clientWidth;
+      if (newContainerWidth <= 0) return;
       const newContentWidth = textElement.scrollWidth;
-      setShouldScroll(newContentWidth > newContainerWidth);
+      setShouldScroll(newContentWidth > newContainerWidth + 1);
     };
 
     measure();

--- a/tests/test-ipod-scrolling-text-clip.test.ts
+++ b/tests/test-ipod-scrolling-text-clip.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from "bun:test";
+import { getLabelClipWidth } from "../src/apps/ipod/components/screen/ScrollingText";
+
+function mockElement(
+  rect: Partial<DOMRect>,
+  opts?: { clientWidth?: number; endCap?: boolean }
+): HTMLElement {
+  const el = {
+    getBoundingClientRect: () =>
+      ({
+        left: 0,
+        top: 0,
+        right: 0,
+        bottom: 0,
+        width: 0,
+        height: 0,
+        x: 0,
+        y: 0,
+        toJSON: () => ({}),
+        ...rect,
+      }) as DOMRect,
+    clientWidth: opts?.clientWidth ?? 0,
+    querySelector: opts?.endCap
+      ? () => endCapEl
+      : () => null,
+  } as unknown as HTMLElement;
+
+  const endCapEl = {
+    getBoundingClientRect: () =>
+      ({
+        left: 70,
+        top: 0,
+        right: 80,
+        bottom: 20,
+        width: 10,
+        height: 20,
+        x: 70,
+        y: 0,
+        toJSON: () => ({}),
+      }) as DOMRect,
+  } as unknown as HTMLElement;
+
+  return el;
+}
+
+describe("getLabelClipWidth", () => {
+  test("uses row end cap left edge minus container left edge", () => {
+    const container = mockElement({ left: 10 }, { clientWidth: 200 });
+    const row = mockElement({}, { endCap: true });
+    expect(getLabelClipWidth(container, row)).toBe(60);
+  });
+
+  test("falls back to clientWidth when row has no end cap", () => {
+    const container = mockElement({}, { clientWidth: 42 });
+    expect(getLabelClipWidth(container, null)).toBe(42);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes modern iPod menu rows (including Now Playing song menu items like **Go to Album**) where long labels were **hard-clipped without a fade** because overflow measurement used the full flex label slot width instead of the visible area before the chevron.

## Changes

- **`ScrollingText`**: Measures available width with `getLabelClipWidth()` from the label container’s left edge to `[data-ipod-menu-row-end]` (chevron or value column), so `mr-2`, row `pr-2`, and chevron width are included in the budget.
- **Static overflow fade**: Right-edge fade when text overflows but marquee is not showing (deselected row, chrome width cooldown, or pre-scroll delay)—not only on `resetOnPause`.
- **`MenuListItem`**: Passes `rowRef`, marks end-cap elements with `data-ipod-menu-row-end`, and uses `h-full` on the label slot for vertical alignment.
- **Tests**: `tests/test-ipod-scrolling-text-clip.test.ts` for clip-width math.

## Testing

- `bun run build`
- `bun test tests/test-ipod-scrolling-text-clip.test.ts`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6E6AD6F4-4212-42E2-B8DD-3CC757D3F723"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6E6AD6F4-4212-42E2-B8DD-3CC757D3F723"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

