### PR TITLE
fix(ipod): avoid album-art fallback flash while covers load

### DIFF
--- a/src/apps/ipod/components/CoverFlow.tsx
+++ b/src/apps/ipod/components/CoverFlow.tsx
@@ -225,6 +225,7 @@ function SpinningCD({ coverUrl, size, isPlaying, onClick }: { coverUrl: string |
               alt=""
               draggable={false}
               onLoad={albumArt.onLoad}
+              onError={albumArt.onError}
               className="w-full h-full object-cover"
               style={{
                 opacity: albumArt.loaded ? 1 : 0,
@@ -431,6 +432,7 @@ function CoverImage({
   // contained — neither depends on the other firing onLoad.
   const sleeve = useImageLoaded(coverUrl);
   const reflection = useImageLoaded(coverUrl);
+  const showSleeveBitmap = Boolean(coverUrl) && !sleeve.failed;
 
   // Handle disc click - play track if different, otherwise toggle play/pause
   const handleDiscClick = useCallback(() => {
@@ -622,20 +624,7 @@ function CoverImage({
             ease: "easeOut",
           }}
         />
-        {coverUrl ? (
-          <img
-            ref={sleeve.ref}
-            src={coverUrl}
-            alt={track?.title || ""}
-            draggable={false}
-            onLoad={sleeve.onLoad}
-            className="w-full h-full object-cover"
-            style={{
-              opacity: sleeve.loaded ? 1 : 0,
-              transition: COVER_FADE_TRANSITION,
-            }}
-          />
-        ) : (
+        {!showSleeveBitmap ? (
           <div className="w-full h-full flex items-center justify-center bg-gradient-to-br from-gray-700 to-gray-900">
             <svg
               xmlns="http://www.w3.org/2000/svg"
@@ -647,6 +636,20 @@ function CoverImage({
               <path d="M12 3v10.55c-.59-.34-1.27-.55-2-.55-2.21 0-4 1.79-4 4s1.79 4 4 4 4-1.79 4-4V7h4V3h-6z" />
             </svg>
           </div>
+        ) : (
+          <img
+            ref={sleeve.ref}
+            src={coverUrl!}
+            alt={track?.title || ""}
+            draggable={false}
+            onLoad={sleeve.onLoad}
+            onError={sleeve.onError}
+            className="w-full h-full object-cover"
+            style={{
+              opacity: sleeve.loaded ? 1 : 0,
+              transition: COVER_FADE_TRANSITION,
+            }}
+          />
         )}
       </motion.div>
       
@@ -689,14 +692,16 @@ function CoverImage({
           alt=""
           draggable={false}
           onLoad={reflection.onLoad}
+          onError={reflection.onError}
           className="w-full h-auto"
           style={{
             transform: "scaleY(-1)",
-            opacity: coverUrl && reflection.loaded ? 0.3 : 0,
+            opacity:
+              coverUrl && !reflection.failed && reflection.loaded ? 0.3 : 0,
             transition: COVER_FADE_TRANSITION,
             maskImage: "linear-gradient(to top, rgba(0,0,0,1) 0%, transparent 50%)",
             WebkitMaskImage: "linear-gradient(to top, rgba(0,0,0,1) 0%, transparent 50%)",
-            display: coverUrl ? "block" : "none",
+            display: coverUrl && !sleeve.failed ? "block" : "none",
             borderRadius: "1%",
           }}
         />

--- a/src/apps/ipod/components/IpodScreen.tsx
+++ b/src/apps/ipod/components/IpodScreen.tsx
@@ -31,10 +31,72 @@ import {
 } from "./screen";
 import { useImageLoaded } from "../hooks/useImageLoaded";
 
-// Shared cross-fade for cover images: stay invisible while
-// loading (the wrapping element's gray background reads as the
-// placeholder), then fade up to the loaded state in 250ms.
-const COVER_FADE_TRANSITION = "opacity 250ms ease-out" as const;
+// Cross-fades for layered cover `<img>`s (now playing / fullscreen overlay paths).
+const NP_CROSSFADE_MS = 320;
+const COVER_FADE_EASING = "cubic-bezier(0.4, 0, 0.2, 1)" as const;
+const COVER_FADE_TRANSITION =
+  `opacity ${NP_CROSSFADE_MS}ms ${COVER_FADE_EASING}` as const;
+
+type NowPlayingPingState = {
+  slots: [string | null, string | null];
+  front: 0 | 1;
+  crossfading: boolean;
+};
+
+function nowPlayingArtReducer(
+  state: NowPlayingPingState,
+  action:
+    | { type: "reset" }
+    | { type: "cover"; payload: string }
+    | { type: "abort-back" }
+    | { type: "begin-fade" }
+    | { type: "commit" }
+): NowPlayingPingState {
+  switch (action.type) {
+    case "reset":
+      return { slots: [null, null], front: 0, crossfading: false };
+    case "cover": {
+      const url = action.payload;
+      const [s0, s1] = state.slots;
+      const fu = state.front === 0 ? s0 : s1;
+      if (fu === url) {
+        return { ...state, crossfading: false };
+      }
+      if (fu === null) {
+        return state.front === 0
+          ? { ...state, slots: [url, s1], crossfading: false }
+          : { ...state, slots: [s0, url], crossfading: false };
+      }
+      const back = 1 - state.front;
+      return back === 0
+        ? { ...state, slots: [url, s1], crossfading: false }
+        : { ...state, slots: [s0, url], crossfading: false };
+    }
+    case "abort-back": {
+      const back = 1 - state.front;
+      return back === 0
+        ? { ...state, slots: [null, state.slots[1]], crossfading: false }
+        : { ...state, slots: [state.slots[0], null], crossfading: false };
+    }
+    case "begin-fade":
+      return { ...state, crossfading: true };
+    case "commit": {
+      const back = 1 - state.front;
+      const won = state.slots[back];
+      if (won === null) {
+        return { ...state, crossfading: false };
+      }
+      return {
+        slots: back === 0 ? [won, null] : [null, won],
+        front: back as 0 | 1,
+        crossfading: false,
+      };
+    }
+    default:
+      return state;
+  }
+}
+
 import {
   PLAYER_PROGRESS_INTERVAL_MS,
   getYouTubeVideoId,
@@ -175,196 +237,105 @@ const MODERN_NOW_PLAYING_ART_3D: CSSProperties = {
   width: MODERN_NOW_PLAYING_ART_PX,
 };
 
-function modernNowPlayingReflectLayerOpacity(
-  layerLoaded: boolean,
-  fading: boolean,
-  isIncoming: boolean,
-  targetOpacity: number
-): number {
-  if (!layerLoaded) return 0;
-  if (!fading) return isIncoming ? 0 : targetOpacity;
-  return isIncoming ? targetOpacity : 0;
-}
-
-/** Sleeve + reflection in one `preserve-3d` group tipped with rotateY + perspective. */
+/** Sleeve + reflection: URLs ping-pong between two fixed `<img>` slots so committing a cross-fade
+ * never re-points the displayed bitmap at the same `<img>` with a freshly reset decode hook (avoids gray flicker). */
 function ModernNowPlayingArtwork({ coverUrl }: { coverUrl: string | null }) {
   const reflectH = MODERN_NOW_PLAYING_ART_PX * MODERN_NOW_PLAYING_REFLECT_RATIO;
   const reflectTargetOpacity =
     MODERN_NOW_PLAYING_REFLECT_IMG.opacity as number;
 
-  /** Bottom = last committed bitmap; optional top cross-fades over it while fetching a new URL. */
-  const stackRef = useRef<{ bottom: string | null; top: string | null }>({
-    bottom: null,
-    top: null,
-  });
-  const [, setVersion] = useState(0);
-  const repaint = () => setVersion((v) => v + 1);
-  const [crossfading, setCrossfading] = useState(false);
-  const crossfadeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const pendingCommitSrcRef = useRef<string | null>(null);
+  const [{ slots, front, crossfading }, dispatch] = useReducer(
+    nowPlayingArtReducer,
+    { slots: [null, null], front: 0, crossfading: false }
+  );
+
+  const fadeCommitTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null
+  );
+  const back = 1 - front;
+  const backUrl = slots[back];
+  const frontUrl = slots[front];
 
   useLayoutEffect(() => {
-    const clearCrossfadeTimer = () => {
-      if (crossfadeTimerRef.current) {
-        clearTimeout(crossfadeTimerRef.current);
-        crossfadeTimerRef.current = null;
-      }
-    };
-
+    if (fadeCommitTimerRef.current !== null) {
+      clearTimeout(fadeCommitTimerRef.current);
+      fadeCommitTimerRef.current = null;
+    }
     if (!coverUrl) {
-      clearCrossfadeTimer();
-      stackRef.current = { bottom: null, top: null };
-      setCrossfading(false);
-      repaint();
+      dispatch({ type: "reset" });
       return;
     }
-
-    const s = stackRef.current;
-
-    if (s.bottom === null) {
-      stackRef.current = { bottom: coverUrl, top: null };
-      clearCrossfadeTimer();
-      setCrossfading(false);
-      repaint();
-      return;
-    }
-
-    if (s.bottom === coverUrl && s.top === null) {
-      return;
-    }
-
-    if (s.bottom === coverUrl && s.top !== null) {
-      stackRef.current = { bottom: coverUrl, top: null };
-      clearCrossfadeTimer();
-      setCrossfading(false);
-      repaint();
-      return;
-    }
-
-    if (s.top === coverUrl) {
-      return;
-    }
-
-    stackRef.current = { bottom: s.bottom, top: coverUrl };
-    clearCrossfadeTimer();
-    setCrossfading(false);
-    repaint();
+    dispatch({ type: "cover", payload: coverUrl });
   }, [coverUrl]);
 
+  const load0 = useImageLoaded(slots[0]);
+  const load1 = useImageLoaded(slots[1]);
+  const refl0 = useImageLoaded(slots[0]);
+  const refl1 = useImageLoaded(slots[1]);
+
+  const backLoaded = back === 0 ? load0.loaded : load1.loaded;
+  const frontHook = front === 0 ? load0 : load1;
+
   useEffect(() => {
+    if (!backUrl || !coverUrl || backUrl !== coverUrl || !backLoaded) {
+      return;
+    }
+
+    dispatch({ type: "begin-fade" });
+    fadeCommitTimerRef.current = setTimeout(() => {
+      fadeCommitTimerRef.current = null;
+      dispatch({ type: "commit" });
+    }, NP_CROSSFADE_MS);
+
     return () => {
-      if (crossfadeTimerRef.current) {
-        clearTimeout(crossfadeTimerRef.current);
+      if (fadeCommitTimerRef.current !== null) {
+        clearTimeout(fadeCommitTimerRef.current);
+        fadeCommitTimerRef.current = null;
       }
     };
-  }, []);
+  }, [backUrl, coverUrl, backLoaded]);
 
-  const { bottom, top } = stackRef.current;
-  const hasIncoming = Boolean(top);
+  function sleeveOpacity(slot: 0 | 1): number {
+    const u = slots[slot];
+    if (!u) return 0;
+    const L = slot === 0 ? load0 : load1;
+    if (!L.loaded) return 0;
+    if (!crossfading) return slot === front ? 1 : 0;
+    return slot === back ? 1 : 0;
+  }
 
-  const bottomSleeve = useImageLoaded(bottom);
-  const topSleeve = useImageLoaded(top);
-  const bottomRefl = useImageLoaded(bottom);
-  const topRefl = useImageLoaded(top);
+  function sleeveZ(slot: 0 | 1): number {
+    if (!crossfading) return slot === front ? 1 : 0;
+    return slot === back ? 2 : 1;
+  }
 
-  const scheduleCommit = useCallback(() => {
-    const incomingTop = stackRef.current.top;
-    if (!incomingTop) return;
+  function reflOpacity(slot: 0 | 1): number {
+    return sleeveOpacity(slot) > 0 ? reflectTargetOpacity : 0;
+  }
 
-    pendingCommitSrcRef.current = incomingTop;
-    setCrossfading(true);
-
-    if (crossfadeTimerRef.current) {
-      clearTimeout(crossfadeTimerRef.current);
-    }
-    crossfadeTimerRef.current = setTimeout(() => {
-      crossfadeTimerRef.current = null;
-      const want = pendingCommitSrcRef.current;
-      pendingCommitSrcRef.current = null;
-      if (want !== null && stackRef.current.top === want) {
-        stackRef.current = { bottom: want, top: null };
-      }
-      setCrossfading(false);
-      repaint();
-    }, 250);
-  }, []);
-
-  useEffect(() => {
-    if (!top) return;
-    if (!topSleeve.loaded) return;
-    if (crossfading) return;
-    scheduleCommit();
-  }, [top, topSleeve.loaded, crossfading, scheduleCommit]);
-
-  const cancelIncomingArt = () => {
-    const s = stackRef.current;
-    if (!s.top) return;
-    stackRef.current = { bottom: s.bottom, top: null };
-    if (crossfadeTimerRef.current) {
-      clearTimeout(crossfadeTimerRef.current);
-      crossfadeTimerRef.current = null;
-    }
-    pendingCommitSrcRef.current = null;
-    setCrossfading(false);
-    repaint();
-  };
+  function reflectionImgStyle(slot: 0 | 1): CSSProperties {
+    return {
+      ...MODERN_NOW_PLAYING_REFLECT_IMG,
+      opacity: reflOpacity(slot),
+      transition: COVER_FADE_TRANSITION,
+    };
+  }
 
   const showFallbackArt =
     !coverUrl ||
-    (!hasIncoming &&
-      Boolean(bottom) &&
-      bottom === coverUrl &&
-      bottomSleeve.failed);
+    (Boolean(frontUrl) &&
+      frontUrl === coverUrl &&
+      frontHook.failed &&
+      !crossfading);
 
   const showPrimeLoadingBackdrop =
-    !hasIncoming &&
-    Boolean(bottom) &&
-    bottom === coverUrl &&
-    !bottomSleeve.failed &&
-    !bottomSleeve.loaded;
+    Boolean(frontUrl) &&
+    frontUrl === coverUrl &&
+    !frontHook.failed &&
+    !frontHook.loaded &&
+    !crossfading;
 
-  const sleeveBottomOpacity = hasIncoming
-    ? crossfading
-      ? 0
-      : 1
-    : bottomSleeve.loaded
-      ? 1
-      : 0;
-
-  const sleeveTopOpacity = hasIncoming
-    ? crossfading && topSleeve.loaded
-      ? 1
-      : 0
-    : 0;
-
-  const reflBottomOpacity = hasIncoming
-    ? modernNowPlayingReflectLayerOpacity(
-        bottomRefl.loaded,
-        crossfading,
-        false,
-        reflectTargetOpacity
-      )
-    : bottomRefl.loaded
-      ? reflectTargetOpacity
-      : 0;
-
-  const reflTopOpacity = hasIncoming
-    ? modernNowPlayingReflectLayerOpacity(
-        topRefl.loaded,
-        crossfading,
-        true,
-        reflectTargetOpacity
-      )
-    : 0;
-
-  const reflectionImgStyle = (opacity: number): CSSProperties => ({
-    ...MODERN_NOW_PLAYING_REFLECT_IMG,
-    opacity,
-    transition: COVER_FADE_TRANSITION,
-  });
-
-  const showReflectStack =
-    Boolean(bottom) && (!bottomSleeve.failed || Boolean(top));
+  const showReflectStack = slots[0] !== null || slots[1] !== null;
 
   return (
     <div
@@ -397,38 +368,46 @@ function ModernNowPlayingArtwork({ coverUrl }: { coverUrl: string | null }) {
               aria-hidden
             />
           ) : null}
-          {bottom && (!hasIncoming ? !bottomSleeve.failed : true) ? (
+          {slots[0] ? (
             <img
-              ref={bottomSleeve.ref}
-              src={bottom}
+              ref={load0.ref}
+              src={slots[0]!}
               alt=""
               draggable={false}
-              onLoad={bottomSleeve.onLoad}
+              onLoad={load0.onLoad}
               onError={() => {
-                if (hasIncoming) return;
-                bottomSleeve.onError();
+                if (front !== 0) {
+                  dispatch({ type: "abort-back" });
+                } else {
+                  load0.onError();
+                }
               }}
               className="absolute inset-0 size-full object-cover"
               style={{
-                opacity: sleeveBottomOpacity,
+                opacity: sleeveOpacity(0),
+                zIndex: sleeveZ(0),
                 transition: COVER_FADE_TRANSITION,
               }}
             />
           ) : null}
-          {top ? (
+          {slots[1] ? (
             <img
-              ref={topSleeve.ref}
-              src={top}
+              ref={load1.ref}
+              src={slots[1]!}
               alt=""
               draggable={false}
-              onLoad={topSleeve.onLoad}
+              onLoad={load1.onLoad}
               onError={() => {
-                topSleeve.onError();
-                cancelIncomingArt();
+                if (front !== 1) {
+                  dispatch({ type: "abort-back" });
+                } else {
+                  load1.onError();
+                }
               }}
-              className="absolute inset-0 size-full object-cover z-[1]"
+              className="absolute inset-0 size-full object-cover"
               style={{
-                opacity: sleeveTopOpacity,
+                opacity: sleeveOpacity(1),
+                zIndex: sleeveZ(1),
                 transition: COVER_FADE_TRANSITION,
               }}
             />
@@ -440,31 +419,46 @@ function ModernNowPlayingArtwork({ coverUrl }: { coverUrl: string | null }) {
             className="relative pointer-events-none mt-0 w-full overflow-hidden"
             style={{ height: reflectH }}
           >
-            {bottom && (!hasIncoming ? !bottomSleeve.failed : true) ? (
+            {slots[0] ? (
               <img
-                ref={bottomRefl.ref}
-                src={bottom}
+                ref={refl0.ref}
+                src={slots[0]!}
                 alt=""
                 draggable={false}
-                onLoad={bottomRefl.onLoad}
+                onLoad={refl0.onLoad}
                 onError={() => {
-                  if (hasIncoming) return;
-                  bottomRefl.onError();
+                  if (front !== 0) {
+                    dispatch({ type: "abort-back" });
+                  } else {
+                    refl0.onError();
+                  }
                 }}
                 className="pointer-events-none absolute left-0 top-0 block w-full h-auto max-w-none"
-                style={reflectionImgStyle(reflBottomOpacity)}
+                style={{
+                  ...reflectionImgStyle(0),
+                  zIndex: sleeveZ(0),
+                }}
               />
             ) : null}
-            {top ? (
+            {slots[1] ? (
               <img
-                ref={topRefl.ref}
-                src={top}
+                ref={refl1.ref}
+                src={slots[1]!}
                 alt=""
                 draggable={false}
-                onLoad={topRefl.onLoad}
-                onError={cancelIncomingArt}
-                className="pointer-events-none absolute left-0 top-0 z-[1] block w-full h-auto max-w-none"
-                style={reflectionImgStyle(reflTopOpacity)}
+                onLoad={refl1.onLoad}
+                onError={() => {
+                  if (front !== 1) {
+                    dispatch({ type: "abort-back" });
+                  } else {
+                    refl1.onError();
+                  }
+                }}
+                className="pointer-events-none absolute left-0 top-0 block w-full h-auto max-w-none"
+                style={{
+                  ...reflectionImgStyle(1),
+                  zIndex: sleeveZ(1),
+                }}
               />
             ) : null}
           </div>
@@ -1645,14 +1639,11 @@ export function IpodScreen({
                     handlePlay();
                   }}
                 >
-                  <motion.img
+                  {/* Single opacity animation (wrapper only) — nesting motion.img hid the overlay twice */}
+                  <img
                     src={coverUrl}
                     alt={currentTrack?.title}
                     className="size-full object-cover brightness-50 pointer-events-none"
-                    initial={{ opacity: 0 }}
-                    animate={{ opacity: 1 }}
-                    exit={{ opacity: 0 }}
-                    transition={{ duration: 0.3 }}
                   />
                 </motion.div>
               )}

--- a/src/apps/ipod/components/IpodScreen.tsx
+++ b/src/apps/ipod/components/IpodScreen.tsx
@@ -175,17 +175,196 @@ const MODERN_NOW_PLAYING_ART_3D: CSSProperties = {
   width: MODERN_NOW_PLAYING_ART_PX,
 };
 
+function modernNowPlayingReflectLayerOpacity(
+  layerLoaded: boolean,
+  fading: boolean,
+  isIncoming: boolean,
+  targetOpacity: number
+): number {
+  if (!layerLoaded) return 0;
+  if (!fading) return isIncoming ? 0 : targetOpacity;
+  return isIncoming ? targetOpacity : 0;
+}
+
 /** Sleeve + reflection in one `preserve-3d` group tipped with rotateY + perspective. */
 function ModernNowPlayingArtwork({ coverUrl }: { coverUrl: string | null }) {
   const reflectH = MODERN_NOW_PLAYING_ART_PX * MODERN_NOW_PLAYING_REFLECT_RATIO;
-  const sleeve = useImageLoaded(coverUrl);
-  const reflection = useImageLoaded(coverUrl);
   const reflectTargetOpacity =
     MODERN_NOW_PLAYING_REFLECT_IMG.opacity as number;
 
-  const showFallback = !coverUrl || sleeve.failed;
-  const showLoadingBackdrop =
-    Boolean(coverUrl) && !sleeve.failed && !sleeve.loaded;
+  /** Bottom = last committed bitmap; optional top cross-fades over it while fetching a new URL. */
+  const stackRef = useRef<{ bottom: string | null; top: string | null }>({
+    bottom: null,
+    top: null,
+  });
+  const [, setVersion] = useState(0);
+  const repaint = () => setVersion((v) => v + 1);
+  const [crossfading, setCrossfading] = useState(false);
+  const crossfadeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const pendingCommitSrcRef = useRef<string | null>(null);
+
+  useLayoutEffect(() => {
+    const clearCrossfadeTimer = () => {
+      if (crossfadeTimerRef.current) {
+        clearTimeout(crossfadeTimerRef.current);
+        crossfadeTimerRef.current = null;
+      }
+    };
+
+    if (!coverUrl) {
+      clearCrossfadeTimer();
+      stackRef.current = { bottom: null, top: null };
+      setCrossfading(false);
+      repaint();
+      return;
+    }
+
+    const s = stackRef.current;
+
+    if (s.bottom === null) {
+      stackRef.current = { bottom: coverUrl, top: null };
+      clearCrossfadeTimer();
+      setCrossfading(false);
+      repaint();
+      return;
+    }
+
+    if (s.bottom === coverUrl && s.top === null) {
+      return;
+    }
+
+    if (s.bottom === coverUrl && s.top !== null) {
+      stackRef.current = { bottom: coverUrl, top: null };
+      clearCrossfadeTimer();
+      setCrossfading(false);
+      repaint();
+      return;
+    }
+
+    if (s.top === coverUrl) {
+      return;
+    }
+
+    stackRef.current = { bottom: s.bottom, top: coverUrl };
+    clearCrossfadeTimer();
+    setCrossfading(false);
+    repaint();
+  }, [coverUrl]);
+
+  useEffect(() => {
+    return () => {
+      if (crossfadeTimerRef.current) {
+        clearTimeout(crossfadeTimerRef.current);
+      }
+    };
+  }, []);
+
+  const { bottom, top } = stackRef.current;
+  const hasIncoming = Boolean(top);
+
+  const bottomSleeve = useImageLoaded(bottom);
+  const topSleeve = useImageLoaded(top);
+  const bottomRefl = useImageLoaded(bottom);
+  const topRefl = useImageLoaded(top);
+
+  const scheduleCommit = useCallback(() => {
+    const incomingTop = stackRef.current.top;
+    if (!incomingTop) return;
+
+    pendingCommitSrcRef.current = incomingTop;
+    setCrossfading(true);
+
+    if (crossfadeTimerRef.current) {
+      clearTimeout(crossfadeTimerRef.current);
+    }
+    crossfadeTimerRef.current = setTimeout(() => {
+      crossfadeTimerRef.current = null;
+      const want = pendingCommitSrcRef.current;
+      pendingCommitSrcRef.current = null;
+      if (want !== null && stackRef.current.top === want) {
+        stackRef.current = { bottom: want, top: null };
+      }
+      setCrossfading(false);
+      repaint();
+    }, 250);
+  }, []);
+
+  useEffect(() => {
+    if (!top) return;
+    if (!topSleeve.loaded) return;
+    if (crossfading) return;
+    scheduleCommit();
+  }, [top, topSleeve.loaded, crossfading, scheduleCommit]);
+
+  const cancelIncomingArt = () => {
+    const s = stackRef.current;
+    if (!s.top) return;
+    stackRef.current = { bottom: s.bottom, top: null };
+    if (crossfadeTimerRef.current) {
+      clearTimeout(crossfadeTimerRef.current);
+      crossfadeTimerRef.current = null;
+    }
+    pendingCommitSrcRef.current = null;
+    setCrossfading(false);
+    repaint();
+  };
+
+  const showFallbackArt =
+    !coverUrl ||
+    (!hasIncoming &&
+      Boolean(bottom) &&
+      bottom === coverUrl &&
+      bottomSleeve.failed);
+
+  const showPrimeLoadingBackdrop =
+    !hasIncoming &&
+    Boolean(bottom) &&
+    bottom === coverUrl &&
+    !bottomSleeve.failed &&
+    !bottomSleeve.loaded;
+
+  const sleeveBottomOpacity = hasIncoming
+    ? crossfading
+      ? 0
+      : 1
+    : bottomSleeve.loaded
+      ? 1
+      : 0;
+
+  const sleeveTopOpacity = hasIncoming
+    ? crossfading && topSleeve.loaded
+      ? 1
+      : 0
+    : 0;
+
+  const reflBottomOpacity = hasIncoming
+    ? modernNowPlayingReflectLayerOpacity(
+        bottomRefl.loaded,
+        crossfading,
+        false,
+        reflectTargetOpacity
+      )
+    : bottomRefl.loaded
+      ? reflectTargetOpacity
+      : 0;
+
+  const reflTopOpacity = hasIncoming
+    ? modernNowPlayingReflectLayerOpacity(
+        topRefl.loaded,
+        crossfading,
+        true,
+        reflectTargetOpacity
+      )
+    : 0;
+
+  const reflectionImgStyle = (opacity: number): CSSProperties => ({
+    ...MODERN_NOW_PLAYING_REFLECT_IMG,
+    opacity,
+    transition: COVER_FADE_TRANSITION,
+  });
+
+  const showReflectStack =
+    Boolean(bottom) && (!bottomSleeve.failed || Boolean(top));
 
   return (
     <div
@@ -206,51 +385,88 @@ function ModernNowPlayingArtwork({ coverUrl }: { coverUrl: string | null }) {
             width: MODERN_NOW_PLAYING_ART_PX,
           }}
         >
-          {showFallback ? (
-            <IpodArtworkPlaceholder kind="album" className="absolute inset-0 size-full" />
+          {showFallbackArt ? (
+            <IpodArtworkPlaceholder
+              kind="album"
+              className="absolute inset-0 size-full"
+            />
           ) : null}
-          {showLoadingBackdrop ? (
+          {showPrimeLoadingBackdrop ? (
             <div
               className="ipod-empty-artwork absolute inset-0 size-full"
               aria-hidden
             />
           ) : null}
-          {coverUrl && !sleeve.failed ? (
+          {bottom && (!hasIncoming ? !bottomSleeve.failed : true) ? (
             <img
-              ref={sleeve.ref}
-              src={coverUrl}
+              ref={bottomSleeve.ref}
+              src={bottom}
               alt=""
               draggable={false}
-              onLoad={sleeve.onLoad}
-              onError={sleeve.onError}
+              onLoad={bottomSleeve.onLoad}
+              onError={() => {
+                if (hasIncoming) return;
+                bottomSleeve.onError();
+              }}
               className="absolute inset-0 size-full object-cover"
               style={{
-                opacity: sleeve.loaded ? 1 : 0,
+                opacity: sleeveBottomOpacity,
+                transition: COVER_FADE_TRANSITION,
+              }}
+            />
+          ) : null}
+          {top ? (
+            <img
+              ref={topSleeve.ref}
+              src={top}
+              alt=""
+              draggable={false}
+              onLoad={topSleeve.onLoad}
+              onError={() => {
+                topSleeve.onError();
+                cancelIncomingArt();
+              }}
+              className="absolute inset-0 size-full object-cover z-[1]"
+              style={{
+                opacity: sleeveTopOpacity,
                 transition: COVER_FADE_TRANSITION,
               }}
             />
           ) : null}
         </div>
-        {coverUrl && !sleeve.failed ? (
+        {showReflectStack ? (
           <div
             aria-hidden
-            className="pointer-events-none mt-0 w-full overflow-hidden"
+            className="relative pointer-events-none mt-0 w-full overflow-hidden"
             style={{ height: reflectH }}
           >
-            <img
-              ref={reflection.ref}
-              src={coverUrl}
-              alt=""
-              draggable={false}
-              onLoad={reflection.onLoad}
-              onError={reflection.onError}
-              className="block w-full h-auto"
-              style={{
-                ...MODERN_NOW_PLAYING_REFLECT_IMG,
-                opacity: reflection.loaded ? reflectTargetOpacity : 0,
-                transition: COVER_FADE_TRANSITION,
-              }}
-            />
+            {bottom && (!hasIncoming ? !bottomSleeve.failed : true) ? (
+              <img
+                ref={bottomRefl.ref}
+                src={bottom}
+                alt=""
+                draggable={false}
+                onLoad={bottomRefl.onLoad}
+                onError={() => {
+                  if (hasIncoming) return;
+                  bottomRefl.onError();
+                }}
+                className="pointer-events-none absolute left-0 top-0 block w-full h-auto max-w-none"
+                style={reflectionImgStyle(reflBottomOpacity)}
+              />
+            ) : null}
+            {top ? (
+              <img
+                ref={topRefl.ref}
+                src={top}
+                alt=""
+                draggable={false}
+                onLoad={topRefl.onLoad}
+                onError={cancelIncomingArt}
+                className="pointer-events-none absolute left-0 top-0 z-[1] block w-full h-auto max-w-none"
+                style={reflectionImgStyle(reflTopOpacity)}
+              />
+            ) : null}
           </div>
         ) : null}
       </div>

--- a/src/apps/ipod/components/IpodScreen.tsx
+++ b/src/apps/ipod/components/IpodScreen.tsx
@@ -178,14 +178,14 @@ const MODERN_NOW_PLAYING_ART_3D: CSSProperties = {
 /** Sleeve + reflection in one `preserve-3d` group tipped with rotateY + perspective. */
 function ModernNowPlayingArtwork({ coverUrl }: { coverUrl: string | null }) {
   const reflectH = MODERN_NOW_PLAYING_ART_PX * MODERN_NOW_PLAYING_REFLECT_RATIO;
-  // Sleeve and reflection each track their own load. Same URL, so
-  // the browser cache lands them within a frame in practice, but
-  // each fade is self-contained — `IpodArtworkPlaceholder` reads as the
-  // chrome until the bitmap arrives.
   const sleeve = useImageLoaded(coverUrl);
   const reflection = useImageLoaded(coverUrl);
   const reflectTargetOpacity =
     MODERN_NOW_PLAYING_REFLECT_IMG.opacity as number;
+
+  const showFallback = !coverUrl || sleeve.failed;
+  const showLoadingBackdrop =
+    Boolean(coverUrl) && !sleeve.failed && !sleeve.loaded;
 
   return (
     <div
@@ -206,14 +206,23 @@ function ModernNowPlayingArtwork({ coverUrl }: { coverUrl: string | null }) {
             width: MODERN_NOW_PLAYING_ART_PX,
           }}
         >
-          <IpodArtworkPlaceholder kind="album" className="absolute inset-0 size-full" />
-          {coverUrl ? (
+          {showFallback ? (
+            <IpodArtworkPlaceholder kind="album" className="absolute inset-0 size-full" />
+          ) : null}
+          {showLoadingBackdrop ? (
+            <div
+              className="ipod-empty-artwork absolute inset-0 size-full"
+              aria-hidden
+            />
+          ) : null}
+          {coverUrl && !sleeve.failed ? (
             <img
               ref={sleeve.ref}
               src={coverUrl}
               alt=""
               draggable={false}
               onLoad={sleeve.onLoad}
+              onError={sleeve.onError}
               className="absolute inset-0 size-full object-cover"
               style={{
                 opacity: sleeve.loaded ? 1 : 0,
@@ -222,7 +231,7 @@ function ModernNowPlayingArtwork({ coverUrl }: { coverUrl: string | null }) {
             />
           ) : null}
         </div>
-        {coverUrl ? (
+        {coverUrl && !sleeve.failed ? (
           <div
             aria-hidden
             className="pointer-events-none mt-0 w-full overflow-hidden"
@@ -234,6 +243,7 @@ function ModernNowPlayingArtwork({ coverUrl }: { coverUrl: string | null }) {
               alt=""
               draggable={false}
               onLoad={reflection.onLoad}
+              onError={reflection.onError}
               className="block w-full h-auto"
               style={{
                 ...MODERN_NOW_PLAYING_REFLECT_IMG,

--- a/src/apps/ipod/components/screen/IpodArtworkPlaceholder.tsx
+++ b/src/apps/ipod/components/screen/IpodArtworkPlaceholder.tsx
@@ -1,4 +1,4 @@
-import { Disc, MusicNote } from "@phosphor-icons/react";
+import { MusicNote } from "@phosphor-icons/react";
 import { cn } from "@/lib/utils";
 
 export type IpodEmptyArtworkKind = "album" | "playlist";
@@ -18,12 +18,11 @@ interface IpodArtworkPlaceholderProps {
  * the neutral silver tile appears under a zero-opacity `<img>`.
  */
 export function IpodArtworkPlaceholder({
-  kind = "album",
   selected = false,
   hideGlyph = false,
   className,
 }: IpodArtworkPlaceholderProps) {
-  const Icon = kind === "playlist" ? MusicNote : Disc;
+  const Icon = MusicNote;
   return (
     <div
       aria-hidden

--- a/src/apps/ipod/components/screen/IpodArtworkPlaceholder.tsx
+++ b/src/apps/ipod/components/screen/IpodArtworkPlaceholder.tsx
@@ -7,16 +7,20 @@ interface IpodArtworkPlaceholderProps {
   kind?: IpodEmptyArtworkKind;
   /** Blue selection row — lightens the chrome and tints the glyph. */
   selected?: boolean;
+  /** Gradient tile only — use while an image URL exists but bits are still in flight (avoids a false “missing art” glyph). */
+  hideGlyph?: boolean;
   className?: string;
 }
 
 /**
  * Empty-state artwork for the modern iPod skin (missing album / playlist
- * covers). Sits under real cover images while they load or on its own.
+ * covers). While a real JPEG is downloading, callers may set `hideGlyph` so only
+ * the neutral silver tile appears under a zero-opacity `<img>`.
  */
 export function IpodArtworkPlaceholder({
   kind = "album",
   selected = false,
+  hideGlyph = false,
   className,
 }: IpodArtworkPlaceholderProps) {
   const Icon = kind === "playlist" ? MusicNote : Disc;
@@ -29,13 +33,15 @@ export function IpodArtworkPlaceholder({
         className
       )}
     >
-      <Icon
-        className={cn(
-          "h-[52%] w-[52%] shrink-0",
-          selected ? "text-white/80" : "text-[#6a6f76]"
-        )}
-        weight="fill"
-      />
+      {hideGlyph ? null : (
+        <Icon
+          className={cn(
+            "h-[52%] w-[52%] shrink-0",
+            selected ? "text-white/80" : "text-[#6a6f76]"
+          )}
+          weight="fill"
+        />
+      )}
     </div>
   );
 }

--- a/src/apps/ipod/components/screen/MenuListItem.tsx
+++ b/src/apps/ipod/components/screen/MenuListItem.tsx
@@ -1,4 +1,3 @@
-import { useEffect, useState } from "react";
 import { cn } from "@/lib/utils";
 import { useImageLoaded } from "../../hooks/useImageLoaded";
 import { IPOD_MODERN_MEDIA_THUMB_PX } from "../../constants";
@@ -72,11 +71,10 @@ export function MenuListItem({
   const isModern = variant === "modern";
   const thumbSrc = isModern && mediaRow ? (thumbnailUrl ?? null) : null;
   const thumb = useImageLoaded(thumbSrc);
-  const [thumbFailed, setThumbFailed] = useState(false);
-  useEffect(() => {
-    setThumbFailed(false);
-  }, [thumbSrc]);
-  const showThumbImage = Boolean(thumbSrc) && !thumbFailed;
+  const showThumbImage = Boolean(thumbSrc) && !thumb.failed;
+  const showMissingOrFailedArt = !thumbSrc || thumb.failed;
+  const showThumbLoadingBackdrop =
+    Boolean(thumbSrc) && !thumb.failed && !thumb.loaded;
   const subtitleTrim =
     typeof subtitle === "string" ? subtitle.trim() : "";
 
@@ -115,11 +113,21 @@ export function MenuListItem({
               }}
               aria-hidden
             >
-              <IpodArtworkPlaceholder
-                kind={emptyArtworkKind}
-                selected={isSelected && !isLoading}
-                className="size-full rounded-[2px]"
-              />
+              {showMissingOrFailedArt ? (
+                <IpodArtworkPlaceholder
+                  kind={emptyArtworkKind}
+                  selected={isSelected && !isLoading}
+                  className="size-full rounded-[2px]"
+                />
+              ) : null}
+              {showThumbLoadingBackdrop ? (
+                <IpodArtworkPlaceholder
+                  kind={emptyArtworkKind}
+                  hideGlyph
+                  selected={isSelected && !isLoading}
+                  className="absolute inset-0 size-full rounded-[2px]"
+                />
+              ) : null}
               {showThumbImage ? (
                 <img
                   ref={thumb.ref}
@@ -128,7 +136,7 @@ export function MenuListItem({
                   className="absolute inset-0 size-full object-cover"
                   draggable={false}
                   onLoad={thumb.onLoad}
-                  onError={() => setThumbFailed(true)}
+                  onError={thumb.onError}
                   style={{
                     opacity: thumb.loaded ? 1 : 0,
                     transition: THUMB_FADE,

--- a/src/apps/ipod/hooks/useImageLoaded.ts
+++ b/src/apps/ipod/hooks/useImageLoaded.ts
@@ -21,31 +21,51 @@ import { useLayoutEffect, useRef, useState } from "react";
  *     ref={cover.ref}
  *     src={coverUrl}
  *     onLoad={cover.onLoad}
+ *     onError={cover.onError}
  *     style={{
  *       opacity: cover.loaded ? 1 : 0,
  *       transition: "opacity 250ms ease-out",
  *     }}
  *   />
  *
- * The caller supplies the placeholder (typically as the wrapping
- * element's `background`) so this hook stays purely about load
- * state, not chrome.
+ * `failed` turns true after `onError` or when a cached/decoded `<img>`
+ * reports `complete` but `naturalWidth === 0` (broken bitmap).
+ *
+ * The caller overlays real bitmaps vs empty states; this hook only
+ * tracks load lifecycle.
  */
 export function useImageLoaded(src: string | null | undefined) {
   const ref = useRef<HTMLImageElement>(null);
   const [loaded, setLoaded] = useState(false);
+  const [failed, setFailed] = useState(false);
 
   useLayoutEffect(() => {
     setLoaded(false);
+    setFailed(false);
+    if (src == null || src === "") {
+      return;
+    }
     const img = ref.current;
-    if (img && img.complete && img.naturalWidth > 0) {
-      setLoaded(true);
+    if (img && img.complete) {
+      if (img.naturalWidth > 0) {
+        setLoaded(true);
+      } else {
+        setFailed(true);
+      }
     }
   }, [src]);
 
   return {
     ref,
     loaded,
-    onLoad: () => setLoaded(true),
+    failed,
+    onLoad: () => {
+      setFailed(false);
+      setLoaded(true);
+    },
+    onError: () => {
+      setLoaded(false);
+      setFailed(true);
+    },
   };
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Loads are no longer represented as missing art: placeholders render only when there is no URL, the image fails (`onError` or decoded `naturalWidth === 0`), or hooks report failure.

**Latest fixes (smooth transitions / no double flashes):**

- Modern now-playing sleeve uses **two fixed `<img>` slots** (`useReducer`): new art always loads into the inactive slot while the outgoing bitmap stays decoded on the other element. Committing clears the loser slot instead of pointing the sleeve you were already staring at at a fresh URL (that pattern was resetting `useImageLoaded` and flashing grey).
- The cross-fade timer no longer depended on **`crossfading`** in React state, so flipping `crossfading` true didn’t instantly **clean up** the pending `setTimeout` (Strict Mode + that bug made the fade stutter).
- Video **cover overlay**: removed duplicate **nested** `motion` opacity animations (wrapper + `<motion.img>`) so cover mode doesn’t “double breathe.”
- Shared sleeve timing: **320 ms**, `cubic-bezier(0.4, 0, 0.2, 1)` via `COVER_FADE_TRANSITION`.

**Verification:** `bun run build` succeeds on this branch.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-09f13338-4738-46f8-8b7b-6f774f1d7697"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-09f13338-4738-46f8-8b7b-6f774f1d7697"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

