### PR TITLE
Set iPod Apple Music streaming quality to 256kbps

### DIFF
--- a/src/hooks/useMusicKit.ts
+++ b/src/hooks/useMusicKit.ts
@@ -19,6 +19,18 @@ const MUSICKIT_SCRIPT_SRC = "https://js-cdn.music.apple.com/musickit/v3/musickit
 const MUSICKIT_SCRIPT_ID = "ryos-musickit-js-v3";
 const MUSICKIT_TOKEN_ENDPOINT = "/api/musickit-token";
 const TOKEN_REFRESH_BUFFER_MS = 60 * 60 * 1000; // refresh if <1h left
+export const APPLE_MUSIC_STREAMING_BITRATE_KBPS = 256;
+
+export function buildMusicKitConfigureOptions(
+  developerToken: string,
+  app: MusicKit.AppMetadata
+): MusicKit.ConfigureOptions {
+  return {
+    developerToken,
+    app,
+    bitrate: APPLE_MUSIC_STREAMING_BITRATE_KBPS,
+  };
+}
 
 export type MusicKitStatus =
   | "idle"
@@ -209,10 +221,9 @@ async function configureMusicKit(
     // `configure()` returns a Promise in MusicKit JS v3. Awaiting also
     // forces script-side init to complete before we hand the instance back.
     const result = await Promise.resolve(
-      window.MusicKit!.configure({
-        developerToken,
-        app,
-      })
+      window.MusicKit!.configure(
+        buildMusicKitConfigureOptions(developerToken, app)
+      )
     );
     const instance = result ?? window.MusicKit!.getInstance?.();
     if (!instance) {

--- a/tests/test-ipod-apple-music.test.ts
+++ b/tests/test-ipod-apple-music.test.ts
@@ -71,6 +71,23 @@ const {
 const { getArtistGroupingDisplayName, getArtistGroupingKey } = await import(
   "../src/apps/ipod/constants"
 );
+const {
+  APPLE_MUSIC_STREAMING_BITRATE_KBPS,
+  buildMusicKitConfigureOptions,
+} = await import("../src/hooks/useMusicKit");
+
+describe("MusicKit configuration", () => {
+  test("requests 256kbps Apple Music streaming quality", () => {
+    const app = { name: "ryOS iPod", build: "1.0.0" };
+
+    expect(buildMusicKitConfigureOptions("developer-token", app)).toEqual({
+      developerToken: "developer-token",
+      app,
+      bitrate: 256,
+    });
+    expect(APPLE_MUSIC_STREAMING_BITRATE_KBPS).toBe(256);
+  });
+});
 
 describe("Apple Music song ID validation", () => {
   test("accepts the canonical YouTube video ID format", () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Set MusicKit configuration to request 256kbps Apple Music streaming.
- Added a focused unit test for the MusicKit configure options.

## Testing
- `bun test tests/test-ipod-apple-music.test.ts`
- `bun run build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-BE16702A-DDCF-4DC6-8D89-B68EF879F1E9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-BE16702A-DDCF-4DC6-8D89-B68EF879F1E9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

