### PR TITLE
fix(ipod): support Apple Music agent context

### DIFF
--- a/api/_utils/_aiPrompts.ts
+++ b/api/_utils/_aiPrompts.ts
@@ -290,7 +290,7 @@ ryOS uses a unified virtual file system model. All file operations use path-base
 - \`/Applets\` - Local saved applets (HTML mini-apps)
 - \`/Documents\` - User documents (markdown files)
 - \`/Applications\` - Installed system applications
-- \`/Music\` - Songs in the iPod library (virtual)
+- \`/Music\` - Songs in the active iPod library (YouTube or Apple Music; virtual)
 - \`/Applets Store\` - Shared applets from the Applet Store
 
 ### LIST - Discover Available Items
@@ -298,7 +298,7 @@ Use \`list\` to discover what's available before opening or reading:
 - \`list({ path: "/Applets" })\` → List local applets
 - \`list({ path: "/Documents" })\` → List user documents  
 - \`list({ path: "/Applications" })\` → List system apps
-- \`list({ path: "/Music" })\` → List songs in iPod
+- \`list({ path: "/Music", query: "song or artist" })\` → Search/list songs in the active iPod library
 - \`list({ path: "/Applets Store" })\` → List shared applets (use \`query\` to search)
 CRITICAL: ONLY reference items returned in the tool result. DO NOT guess or make up items.
 
@@ -346,9 +346,10 @@ Use \`edit\` to make targeted changes to existing documents or applets:
 
 ### iPod
 **When user asks to play a song:**
-1. FIRST: Check library with \`list({ path: "/Music" })\` to see if the song exists
-2. If found: Use \`ipodControl\` with action "playKnown" and the track's id/title/artist
-3. If NOT found: Use \`searchSongs\` to find the song on YouTube, then use \`ipodControl\` with action "addAndPlay" and the videoId from the search results
+1. FIRST: Check the active iPod library with \`list({ path: "/Music", query: "song or artist" })\` to see if the song exists
+2. If found: Use \`ipodControl\` with action "playKnown" and the track's id/title/artist (Apple Music IDs start with \`am:\` and are valid here)
+3. If NOT found and the active library is YouTube: Use \`searchSongs\` to find the song on YouTube, then use \`ipodControl\` with action "addAndPlay" and the videoId from the search results
+4. If NOT found and the active library is Apple Music: Do not use \`addAndPlay\` for Apple Music IDs; say you can only play Apple Music tracks already returned from \`/Music\`
 
 - Use \`ipodControl\` for playback control (toggle/play/pause/next/previous)
 - Use \`open({ path: "/Music/{songId}" })\` as alternative to play a specific song by ID
@@ -358,12 +359,12 @@ Use \`edit\` to make targeted changes to existing documents or applets:
 
 ### Karaoke
 **When user asks to play a song in karaoke:**
-1. FIRST: Check library with \`list({ path: "/Music" })\` to see if the song exists (shared library with iPod)
-2. If found: Use \`karaokeControl\` with action "playKnown" and the track's id/title/artist
+1. FIRST: Check library with \`list({ path: "/Music", query: "song or artist" })\` to see if the song exists
+2. If found with source \`youtube\`: Use \`karaokeControl\` with action "playKnown" and the track's id/title/artist
 3. If NOT found: Use \`searchSongs\` to find the song on YouTube, then use \`karaokeControl\` with action "addAndPlay" and the videoId from the search results
 
 - Use \`karaokeControl\` for playback control (toggle/play/pause/next/previous)
-- Karaoke shares the same music library as iPod but has independent playback state
+- Karaoke uses the YouTube iPod library and has independent playback state; it cannot play Apple Music \`am:\` IDs
 - Optional flag: \`enableFullscreen\`
 - **LYRICS**: Keep lyrics in ORIGINAL language by default. Only use \`enableTranslation\` when user EXPLICITLY asks for translated lyrics.
 - **iOS RESTRICTION**: Same as iPod - do NOT auto-play on iOS devices.

--- a/api/_utils/ryo-conversation.ts
+++ b/api/_utils/ryo-conversation.ts
@@ -65,9 +65,12 @@ export interface RyoConversationSystemState {
   ipod?: {
     currentTrack: {
       id: string;
+      url?: string;
       title: string;
       artist?: string;
+      source?: "youtube" | "appleMusic";
     } | null;
+    librarySource?: "youtube" | "appleMusic";
     isPlaying: boolean;
     currentLyrics?: {
       lines: Array<{
@@ -560,8 +563,12 @@ Video: ${effectiveState.video.currentVideo.title}${videoArtist} (Playing)`;
       const trackArtist = effectiveState.ipod.currentTrack.artist
         ? ` by ${effectiveState.ipod.currentTrack.artist}`
         : "";
+      const libraryLabel =
+        effectiveState.ipod.librarySource === "appleMusic"
+          ? "Apple Music"
+          : "YouTube";
       prompt += `
-iPod: ${effectiveState.ipod.currentTrack.title}${trackArtist} (${playingStatus})`;
+iPod (${libraryLabel}): ${effectiveState.ipod.currentTrack.title}${trackArtist} (${playingStatus})`;
 
       if (effectiveState.ipod.currentLyrics?.lines) {
         const lyricsText = effectiveState.ipod.currentLyrics.lines

--- a/api/chat/tools/schemas.ts
+++ b/api/chat/tools/schemas.ts
@@ -262,14 +262,14 @@ export const listSchema = z.object({
   path: z
     .enum(VFS_PATHS)
     .describe(
-      "The directory path to list: '/Applets' for local applets, '/Documents' for documents, '/Applications' for apps, '/Music' for iPod songs, '/Applets Store' for shared applets"
+      "The directory path to list: '/Applets' for local applets, '/Documents' for documents, '/Applications' for apps, '/Music' for songs in the active iPod library, '/Applets Store' for shared applets"
     ),
   query: z
     .string()
     .max(200)
     .optional()
     .describe(
-      "Optional search query to filter results (only used for '/Applets Store' path). Case-insensitive substring match on title, name, or creator."
+      "Optional search query to filter results. For '/Music', searches id/title/artist/album in the active iPod library. For '/Applets Store', searches title, name, or creator."
     ),
   limit: z
     .number()
@@ -278,7 +278,7 @@ export const listSchema = z.object({
     .max(50)
     .optional()
     .describe(
-      "Optional maximum number of results to return (default 25, only used for '/Applets Store' path)."
+      "Optional maximum number of results to return (default 25 for '/Music', 50 for '/Applets Store')."
     ),
 });
 

--- a/src/apps/chats/hooks/useAiChat.ts
+++ b/src/apps/chats/hooks/useAiChat.ts
@@ -11,7 +11,12 @@ import { useAudioSettingsStore } from "@/stores/useAudioSettingsStore";
 import { useInternetExplorerStore } from "@/stores/useInternetExplorerStore";
 import { getApiUrl } from "@/utils/platform";
 import { useVideoStore } from "@/stores/useVideoStore";
-import { useIpodStore } from "@/stores/useIpodStore";
+import {
+  getActiveIpodTracks,
+  getIpodChatContextTrack,
+  setActiveIpodCurrentSongId,
+  useIpodStore,
+} from "@/stores/useIpodStore";
 import { useKaraokeStore } from "@/stores/useKaraokeStore";
 import { useTvStore } from "@/stores/useTvStore";
 import { buildTvChannelLineup, DEFAULT_CHANNELS } from "@/apps/tv/data/channels";
@@ -336,9 +341,7 @@ const getSystemState = () => {
   const tvStore = useTvStore.getState();
 
   const currentVideo = videoStore.getCurrentVideo();
-  const currentTrack = ipodStore.currentSongId
-    ? ipodStore.tracks.find((t) => t.id === ipodStore.currentSongId)
-    : ipodStore.tracks[0] ?? null;
+  const currentTrack = getIpodChatContextTrack(ipodStore);
   
   // Karaoke uses the shared track library from iPod store
   const karaokeCurrentTrack = karaokeStore.currentSongId
@@ -542,8 +545,10 @@ const getSystemState = () => {
             id: currentTrack.id,
             title: currentTrack.title,
             artist: currentTrack.artist,
+          source: currentTrack.source,
           }
         : null,
+      librarySource: ipodStore.librarySource,
       isPlaying: ipodStore.isPlaying,
       currentLyrics: ipodStore.currentLyrics,
     },
@@ -938,21 +943,64 @@ export function useAiChat(onPromptSetUsername?: () => void) {
             try {
               // Route based on path
               if (path === "/Music") {
-                // List iPod library
+                // List the currently active iPod library.
                 const ipodStore = useIpodStore.getState();
-                const library = ipodStore.tracks.map((track) => ({
+                const normalizedQuery = query
+                  ? normalizeSearchText(query.trim())
+                  : "";
+                const queryTokens = normalizedQuery
+                  ? normalizedQuery.split(/\s+/).filter(Boolean)
+                  : [];
+                const hasQuery = normalizedQuery.length > 0;
+                const maxResults = limit
+                  ? Math.min(Math.max(limit, 1), 50)
+                  : 25;
+                const activeTracks = getActiveIpodTracks(ipodStore);
+                const scoredTracks = activeTracks.map((track) => {
+                  const fields = [
+                    track.id,
+                    track.title,
+                    track.artist ?? "",
+                    track.album ?? "",
+                  ].map(normalizeSearchText);
+                  const score = hasQuery
+                    ? fields.reduce(
+                        (best, field) =>
+                          Math.max(best, computeMatchScore(field, normalizedQuery, queryTokens)),
+                        0
+                      )
+                    : 1;
+                  return { track, score };
+                });
+                const scoreThreshold = hasQuery
+                  ? deriveScoreThreshold(normalizedQuery.length)
+                  : 0;
+                const matchingTracks = scoredTracks
+                  .filter(({ score }) => score >= scoreThreshold)
+                  .sort((a, b) => (hasQuery ? b.score - a.score : 0));
+                const library = matchingTracks.slice(0, maxResults).map(({ track }) => ({
                   path: `/Music/${track.id}`,
                   id: track.id,
                   title: track.title,
                   artist: track.artist,
+                  source: track.source ?? ipodStore.librarySource,
                 }));
+                const hiddenCount = Math.max(matchingTracks.length - library.length, 0);
+                const libraryName =
+                  ipodStore.librarySource === "appleMusic" ? "Apple Music" : "iPod";
 
                 const resultMessage =
                   library.length > 0
                     ? `${library.length === 1 
                         ? i18n.t("apps.chats.toolCalls.foundSongsInMusic", { count: library.length })
-                        : i18n.t("apps.chats.toolCalls.foundSongsInMusicPlural", { count: library.length })}:\n${JSON.stringify(library, null, 2)}`
-                    : i18n.t("apps.chats.toolCalls.musicLibraryEmpty");
+                        : i18n.t("apps.chats.toolCalls.foundSongsInMusicPlural", { count: library.length })} (${libraryName})${
+                        hiddenCount > 0
+                          ? `; showing ${library.length} of ${matchingTracks.length}. Use query or limit to narrow results.`
+                          : ""
+                      }:\n${JSON.stringify(library, null, 2)}`
+                    : hasQuery
+                      ? `No songs matched "${query}" in ${libraryName}.`
+                      : i18n.t("apps.chats.toolCalls.musicLibraryEmpty");
 
                 addToolResult({
                   tool: toolCall.toolName,
@@ -1140,7 +1188,7 @@ export function useAiChat(onPromptSetUsername?: () => void) {
                 // Play iPod song by ID
                 const songId = path.replace("/Music/", "");
                 const ipodState = useIpodStore.getState();
-                const track = ipodState.tracks.find((t) => t.id === songId);
+                const track = getActiveIpodTracks(ipodState).find((t) => t.id === songId);
 
                 if (!track) {
                   throw new Error(`Song not found: ${songId}`);
@@ -1153,7 +1201,7 @@ export function useAiChat(onPromptSetUsername?: () => void) {
                   launchApp("ipod");
                 }
 
-                ipodState.setCurrentSongId(songId);
+                setActiveIpodCurrentSongId(ipodState, songId);
                 ipodState.setIsPlaying(true);
 
                 const playingMessage = track.artist

--- a/src/apps/chats/hooks/useAiChat.ts
+++ b/src/apps/chats/hooks/useAiChat.ts
@@ -545,7 +545,7 @@ const getSystemState = () => {
             id: currentTrack.id,
             title: currentTrack.title,
             artist: currentTrack.artist,
-          source: currentTrack.source,
+            source: currentTrack.source,
           }
         : null,
       librarySource: ipodStore.librarySource,
@@ -966,7 +966,10 @@ export function useAiChat(onPromptSetUsername?: () => void) {
                   const score = hasQuery
                     ? fields.reduce(
                         (best, field) =>
-                          Math.max(best, computeMatchScore(field, normalizedQuery, queryTokens)),
+                          Math.max(
+                            best,
+                            computeMatchScore(field, normalizedQuery, queryTokens)
+                          ),
                         0
                       )
                     : 1;
@@ -978,13 +981,15 @@ export function useAiChat(onPromptSetUsername?: () => void) {
                 const matchingTracks = scoredTracks
                   .filter(({ score }) => score >= scoreThreshold)
                   .sort((a, b) => (hasQuery ? b.score - a.score : 0));
-                const library = matchingTracks.slice(0, maxResults).map(({ track }) => ({
-                  path: `/Music/${track.id}`,
-                  id: track.id,
-                  title: track.title,
-                  artist: track.artist,
-                  source: track.source ?? ipodStore.librarySource,
-                }));
+                const library = matchingTracks
+                  .slice(0, maxResults)
+                  .map(({ track }) => ({
+                    path: `/Music/${track.id}`,
+                    id: track.id,
+                    title: track.title,
+                    artist: track.artist,
+                    source: track.source ?? ipodStore.librarySource,
+                  }));
                 const hiddenCount = Math.max(matchingTracks.length - library.length, 0);
                 const libraryName =
                   ipodStore.librarySource === "appleMusic" ? "Apple Music" : "iPod";

--- a/src/apps/chats/hooks/useRyoChat.ts
+++ b/src/apps/chats/hooks/useRyoChat.ts
@@ -5,7 +5,7 @@ import { useTranslation } from "react-i18next";
 import { useAppStore } from "@/stores/useAppStore";
 import { useInternetExplorerStore } from "@/stores/useInternetExplorerStore";
 import { useVideoStore } from "@/stores/useVideoStore";
-import { useIpodStore } from "@/stores/useIpodStore";
+import { getIpodChatContextTrack, useIpodStore } from "@/stores/useIpodStore";
 import { useChatsStore } from "@/stores/useChatsStore";
 import { useLanguageStore } from "@/stores/useLanguageStore";
 import { getApiUrl } from "@/utils/platform";
@@ -21,9 +21,7 @@ const getSystemState = () => {
   const languageStore = useLanguageStore.getState();
 
   const currentVideo = videoStore.getCurrentVideo();
-  const currentTrack = ipodStore.currentSongId
-    ? ipodStore.tracks.find((t) => t.id === ipodStore.currentSongId)
-    : ipodStore.tracks[0] ?? null;
+  const currentTrack = getIpodChatContextTrack(ipodStore);
 
   // Use new instance-based model
   const openInstances = Object.values(appStore.instances).filter(
@@ -85,8 +83,10 @@ const getSystemState = () => {
             url: currentTrack.url,
             title: currentTrack.title,
             artist: currentTrack.artist,
+            source: currentTrack.source,
           }
         : null,
+      librarySource: ipodStore.librarySource,
       isPlaying: ipodStore.isPlaying,
       loopAll: ipodStore.loopAll,
       loopCurrent: ipodStore.loopCurrent,

--- a/src/apps/chats/tools/ipodHandler.ts
+++ b/src/apps/chats/tools/ipodHandler.ts
@@ -3,7 +3,13 @@
  */
 
 import { useAppStore } from "@/stores/useAppStore";
-import { useIpodStore } from "@/stores/useIpodStore";
+import {
+  getActiveIpodCurrentTrack,
+  getActiveIpodTracks,
+  navigateActiveIpodTrack,
+  setActiveIpodCurrentSongId,
+  useIpodStore,
+} from "@/stores/useIpodStore";
 import i18n from "@/lib/i18n";
 import type { ToolContext } from "./types";
 import {
@@ -143,9 +149,7 @@ const handlePlaybackState = (
   );
   const updatedIpod = useIpodStore.getState();
   const nowPlaying = updatedIpod.isPlaying;
-  const track = updatedIpod.currentSongId 
-    ? updatedIpod.tracks.find((t) => t.id === updatedIpod.currentSongId)
-    : updatedIpod.tracks[0];
+  const track = getActiveIpodCurrentTrack(updatedIpod);
 
   let playbackState: string;
   if (track) {
@@ -181,7 +185,7 @@ const handlePlayKnown = (
 ): void => {
   const { id, title, artist, enableVideo, enableTranslation, enableFullscreen } = input;
   const ipodState = useIpodStore.getState();
-  const { tracks } = ipodState;
+  const tracks = getActiveIpodTracks(ipodState);
 
   // If no identifiers provided, fall back to toggle/play behavior
   if (!id && !title && !artist) {
@@ -238,8 +242,19 @@ const handlePlayKnown = (
     finalCandidateIndices[Math.floor(Math.random() * finalCandidateIndices.length)];
 
   const track = tracks[randomIndexFromArray];
-  const { setCurrentSongId, setIsPlaying } = useIpodStore.getState();
-  setCurrentSongId(track?.id ?? null);
+  if (!track) {
+    const errorMsg = i18n.t("apps.chats.toolCalls.ipodSongNotFound");
+    context.addToolResult({
+      tool: "ipodControl",
+      toolCallId,
+      output: errorMsg,
+    });
+    return;
+  }
+
+  const activeIpodState = useIpodStore.getState();
+  setActiveIpodCurrentSongId(activeIpodState, track.id);
+  const { setIsPlaying } = useIpodStore.getState();
   const trackDescForLog = formatTrackDescription(track.title, track.artist);
 
   // On iOS, don't auto-play - just select the track
@@ -308,7 +323,24 @@ const handleAddAndPlay = async (
     return;
   }
 
+  if (id.startsWith("am:")) {
+    const errorMsg =
+      "Apple Music tracks are already in the active library. Use playKnown with the Apple Music track ID instead of addAndPlay.";
+    context.addToolResult({
+      tool: "ipodControl",
+      toolCallId,
+      output: errorMsg,
+    });
+    console.error(`[ToolCall] ${errorMsg}`);
+    return;
+  }
+
   try {
+    const ipodState = useIpodStore.getState();
+    if (ipodState.librarySource !== "youtube") {
+      ipodState.setLibrarySource("youtube");
+    }
+
     // On iOS, use addTrackFromVideoId with autoPlay=false
     const addedTrack = await useIpodStore
       .getState()
@@ -379,18 +411,12 @@ const handleNavigation = (
 ): void => {
   const { enableVideo, enableTranslation, enableFullscreen } = input;
   const ipodState = useIpodStore.getState();
-  const navigate = action === "next" ? ipodState.nextTrack : ipodState.previousTrack;
-
-  if (typeof navigate === "function") {
-    navigate();
-  }
+  navigateActiveIpodTrack(ipodState, action);
 
   const stateChanges = applyIpodSettings(enableVideo, enableTranslation, enableFullscreen);
 
   const updatedIpod = useIpodStore.getState();
-  const track = updatedIpod.currentSongId 
-    ? updatedIpod.tracks.find((t) => t.id === updatedIpod.currentSongId)
-    : updatedIpod.tracks[0];
+  const track = getActiveIpodCurrentTrack(updatedIpod);
 
   if (track) {
     const desc = formatTrackDescription(track.title, track.artist);

--- a/src/stores/useIpodStore.ts
+++ b/src/stores/useIpodStore.ts
@@ -625,6 +625,133 @@ export interface IpodState extends IpodData {
   setIpodMenuMode: (menuMode: boolean | null) => void;
 }
 
+export interface IpodChatContextTrack {
+  id: string;
+  url?: string;
+  title: string;
+  artist?: string;
+  album?: string;
+  source: LibrarySource;
+}
+
+export function getActiveIpodTracks(
+  state: Pick<IpodState, "librarySource" | "tracks" | "appleMusicTracks">
+): Track[] {
+  return state.librarySource === "appleMusic"
+    ? state.appleMusicTracks
+    : state.tracks;
+}
+
+export function getActiveIpodCurrentSongId(
+  state: Pick<
+    IpodState,
+    "librarySource" | "currentSongId" | "appleMusicCurrentSongId"
+  >
+): string | null {
+  return state.librarySource === "appleMusic"
+    ? state.appleMusicCurrentSongId
+    : state.currentSongId;
+}
+
+export function getActiveIpodCurrentTrack(
+  state: Pick<
+    IpodState,
+    | "librarySource"
+    | "tracks"
+    | "currentSongId"
+    | "appleMusicTracks"
+    | "appleMusicCurrentSongId"
+  >
+): Track | null {
+  const tracks = getActiveIpodTracks(state);
+  const currentSongId = getActiveIpodCurrentSongId(state);
+  if (!currentSongId) return tracks[0] ?? null;
+  return tracks.find((track) => track.id === currentSongId) ?? null;
+}
+
+export function getIpodChatContextTrack(
+  state: Pick<
+    IpodState,
+    | "librarySource"
+    | "tracks"
+    | "currentSongId"
+    | "appleMusicTracks"
+    | "appleMusicCurrentSongId"
+    | "appleMusicKitNowPlaying"
+  >
+): IpodChatContextTrack | null {
+  const currentTrack = getActiveIpodCurrentTrack(state);
+  if (state.librarySource === "appleMusic" && state.appleMusicKitNowPlaying) {
+    const snapshot = state.appleMusicKitNowPlaying;
+    return {
+      id: snapshot.id
+        ? appleMusicKitIdToLyricsSongId(snapshot.id)
+        : currentTrack?.id ?? "apple-music-now-playing",
+      url: currentTrack?.url,
+      title: snapshot.title,
+      artist: snapshot.artist,
+      album: snapshot.album,
+      source: "appleMusic",
+    };
+  }
+
+  return currentTrack
+    ? {
+        id: currentTrack.id,
+        url: currentTrack.url,
+        title: currentTrack.title,
+        artist: currentTrack.artist,
+        album: currentTrack.album,
+        source: state.librarySource,
+      }
+    : null;
+}
+
+export function setActiveIpodCurrentSongId(
+  state: Pick<
+    IpodState,
+    | "librarySource"
+    | "setCurrentSongId"
+    | "setAppleMusicCurrentSongId"
+    | "setAppleMusicPlaybackQueue"
+  >,
+  songId: string | null
+): void {
+  if (state.librarySource === "appleMusic") {
+    state.setAppleMusicPlaybackQueue(null);
+    state.setAppleMusicCurrentSongId(songId);
+    return;
+  }
+  state.setCurrentSongId(songId);
+}
+
+export function navigateActiveIpodTrack(
+  state: Pick<
+    IpodState,
+    | "librarySource"
+    | "nextTrack"
+    | "previousTrack"
+    | "appleMusicNextTrack"
+    | "appleMusicPreviousTrack"
+  >,
+  direction: "next" | "previous"
+): void {
+  if (state.librarySource === "appleMusic") {
+    if (direction === "next") {
+      state.appleMusicNextTrack();
+    } else {
+      state.appleMusicPreviousTrack();
+    }
+    return;
+  }
+
+  if (direction === "next") {
+    state.nextTrack();
+  } else {
+    state.previousTrack();
+  }
+}
+
 const CURRENT_IPOD_STORE_VERSION = 37; // Breadcrumb may include modernMediaList for iPod media rows
 
 // Helper function to get unplayed track IDs from history

--- a/tests/test-ipod-apple-music.test.ts
+++ b/tests/test-ipod-apple-music.test.ts
@@ -32,9 +32,14 @@ const browserGlobals = globalThis as typeof globalThis & {
 if (!browserGlobals.localStorage) {
   browserGlobals.localStorage = new MemoryStorage();
 }
-if (!browserGlobals.navigator) {
-  browserGlobals.navigator = { onLine: true, userAgent: "test" } as Navigator;
-}
+Object.defineProperty(browserGlobals, "navigator", {
+  value: {
+    ...(browserGlobals.navigator ?? {}),
+    onLine: true,
+    userAgent: "test",
+  },
+  configurable: true,
+});
 
 const {
   appleMusicPlayableResourceToTrack,

--- a/tests/test-ipod-apple-music.test.ts
+++ b/tests/test-ipod-apple-music.test.ts
@@ -46,7 +46,14 @@ const {
   APPLE_MUSIC_PLAYLISTS_OPPORTUNISTIC_TTL_MS,
   APPLE_MUSIC_PLAYLIST_TRACKS_OPPORTUNISTIC_TTL_MS,
 } = await import("../src/apps/ipod/hooks/useAppleMusicLibrary");
-const { useIpodStore, appleMusicKitIdToLyricsSongId } = await import("../src/stores/useIpodStore");
+const {
+  useIpodStore,
+  appleMusicKitIdToLyricsSongId,
+  getActiveIpodCurrentTrack,
+  getActiveIpodTracks,
+  getIpodChatContextTrack,
+} = await import("../src/stores/useIpodStore");
+const { handleIpodControl } = await import("../src/apps/chats/tools/ipodHandler");
 const {
   shouldFireEndedForPlaybackState,
   isWithinEndedFanoutDedupWindow,
@@ -337,6 +344,7 @@ describe("useIpodStore Apple Music slice", () => {
       appleMusicTracks: [],
       appleMusicPlaybackQueue: null,
       appleMusicCurrentSongId: null,
+      appleMusicKitNowPlaying: null,
       isPlaying: false,
       currentSongId: null,
       tracks: [],
@@ -595,6 +603,106 @@ describe("useIpodStore Apple Music slice", () => {
     useIpodStore.getState().appleMusicNextTrack();
 
     expect(useIpodStore.getState().appleMusicCurrentSongId).toBe("am:q2");
+  });
+
+  test("active iPod helpers resolve the Apple Music slice and live MusicKit context", () => {
+    useIpodStore.setState({
+      tracks: [{ id: "yt1", url: "youtube:1", title: "YouTube One" }],
+      currentSongId: "yt1",
+      appleMusicTracks: [
+        { id: "am:1", url: "applemusic:1", title: "Apple One", source: "appleMusic" },
+        { id: "am:2", url: "applemusic:2", title: "Apple Two", source: "appleMusic" },
+      ],
+      appleMusicCurrentSongId: "am:2",
+      librarySource: "appleMusic",
+      appleMusicKitNowPlaying: {
+        id: "1616228595",
+        title: "Live Radio Song",
+        artist: "Live Artist",
+        album: "Live Album",
+      },
+    });
+
+    expect(getActiveIpodTracks(useIpodStore.getState()).map((track) => track.id)).toEqual([
+      "am:1",
+      "am:2",
+    ]);
+    expect(getActiveIpodCurrentTrack(useIpodStore.getState())?.id).toBe("am:2");
+    expect(getIpodChatContextTrack(useIpodStore.getState())).toEqual({
+      id: "am:1616228595",
+      url: "applemusic:2",
+      title: "Live Radio Song",
+      artist: "Live Artist",
+      album: "Live Album",
+      source: "appleMusic",
+    });
+  });
+
+  test("ipodControl playKnown selects Apple Music tracks when Apple Music is active", async () => {
+    useIpodStore.setState({
+      tracks: [{ id: "yt1", url: "youtube:1", title: "YouTube One" }],
+      currentSongId: "yt1",
+      appleMusicTracks: [
+        { id: "am:1", url: "applemusic:1", title: "Apple One", source: "appleMusic" },
+        {
+          id: "am:2",
+          url: "applemusic:2",
+          title: "Apple Two",
+          artist: "Apple Artist",
+          source: "appleMusic",
+        },
+      ],
+      appleMusicCurrentSongId: "am:1",
+      librarySource: "appleMusic",
+      appleMusicPlaybackQueue: ["am:1"],
+    });
+    const results: unknown[] = [];
+
+    await handleIpodControl(
+      { action: "playKnown", id: "am:2" },
+      "call-1",
+      {
+        launchApp: () => "ipod-instance",
+        addToolResult: (result) => results.push(result),
+        detectUserOS: () => "Linux",
+      }
+    );
+
+    const state = useIpodStore.getState();
+    expect(state.appleMusicCurrentSongId).toBe("am:2");
+    expect(state.appleMusicPlaybackQueue).toBeNull();
+    expect(state.currentSongId).toBe("yt1");
+    expect(state.isPlaying).toBe(true);
+    expect(results).toHaveLength(1);
+  });
+
+  test("ipodControl next follows Apple Music navigation when Apple Music is active", async () => {
+    useIpodStore.setState({
+      tracks: [{ id: "yt1", url: "youtube:1", title: "YouTube One" }],
+      currentSongId: "yt1",
+      appleMusicTracks: [
+        { id: "am:1", url: "applemusic:1", title: "Apple One", source: "appleMusic" },
+        { id: "am:2", url: "applemusic:2", title: "Apple Two", source: "appleMusic" },
+      ],
+      appleMusicCurrentSongId: "am:1",
+      librarySource: "appleMusic",
+      loopAll: true,
+      isShuffled: false,
+    });
+
+    await handleIpodControl(
+      { action: "next" },
+      "call-2",
+      {
+        launchApp: () => "ipod-instance",
+        addToolResult: () => {},
+        detectUserOS: () => "Linux",
+      }
+    );
+
+    const state = useIpodStore.getState();
+    expect(state.appleMusicCurrentSongId).toBe("am:2");
+    expect(state.currentSongId).toBe("yt1");
   });
 });
 

--- a/tests/test-ryo-conversation-prompt-caching.test.ts
+++ b/tests/test-ryo-conversation-prompt-caching.test.ts
@@ -28,6 +28,7 @@ const baseSystemState: RyoConversationSystemState = {
   },
   ipod: {
     currentTrack: { id: "track1", title: "Test Song", artist: "Test Artist" },
+    librarySource: "youtube",
     isPlaying: true,
   },
 };
@@ -103,8 +104,30 @@ describe("prompt caching structure", () => {
     expect(prompt).toContain("RUNNING APPLICATIONS");
     expect(prompt).toContain("Foreground: chats (Chats)");
     expect(prompt).toContain("MEDIA PLAYBACK");
-    expect(prompt).toContain("iPod: Test Song by Test Artist");
+    expect(prompt).toContain("iPod (YouTube): Test Song by Test Artist");
     expect(prompt).toContain("</system_state>");
+  });
+
+  test("buildVolatileStatePrompt labels Apple Music iPod context", () => {
+    const prompt = buildVolatileStatePrompt({
+      channel: "chat",
+      systemState: {
+        ...baseSystemState,
+        ipod: {
+          currentTrack: {
+            id: "am:1616228595",
+            title: "Apple Song",
+            artist: "Apple Artist",
+            source: "appleMusic",
+          },
+          librarySource: "appleMusic",
+          isPlaying: true,
+        },
+      },
+      username: "testuser",
+    });
+
+    expect(prompt).toContain("iPod (Apple Music): Apple Song by Apple Artist");
   });
 
   test("buildVolatileStatePrompt does not contain memory data", () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Route iPod agent controls through the active YouTube or Apple Music library.
- Include the active iPod library source and live Apple Music now-playing metadata in chat context.
- Let `/Music` list/open target the active iPod library with query/limit support, and clarify tool prompts/schema for Apple Music.
- Add focused regressions for Apple Music helper resolution, iPod tool control, and Ryo prompt labeling.

## Testing
- `bun test tests/test-ipod-apple-music.test.ts tests/test-ryo-conversation-prompt-caching.test.ts`
- `bun run build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-90113869-66F9-44E9-AC47-29F9D2932404"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-90113869-66F9-44E9-AC47-29F9D2932404"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

