### PR TITLE
feat(ipod): modern UI backlight dim via CSS filter

### DIFF
--- a/src/apps/ipod/components/BrickGame.tsx
+++ b/src/apps/ipod/components/BrickGame.tsx
@@ -619,7 +619,10 @@ export const BrickGame = function BrickGame(
             // against the contrasting top while the paddle sits on a
             // calm light wash that doesn't compete with the bar's
             // graphite gloss.
-            "ipod-modern-screen bg-gradient-to-b from-[#5d97c4] via-[#a4cbe6] to-[#dcecf6]"
+            cn(
+              "ipod-modern-screen bg-gradient-to-b from-[#5d97c4] via-[#a4cbe6] to-[#dcecf6]",
+              !backlightOn && "ipod-modern-backlight-off"
+            )
           : backlightOn
           ? "bg-[#c5e0f5] bg-gradient-to-b from-[#d1e8fa] to-[#e0f0fc]"
           : "bg-[#8a9da9] contrast-65 saturate-50",

--- a/src/apps/ipod/components/IpodScreen.tsx
+++ b/src/apps/ipod/components/IpodScreen.tsx
@@ -1453,7 +1453,10 @@ export function IpodScreen({
         isModernUi
           ? // White table surface; avoid neutral chassis fills—they read as
             // gray stripes under the virtualized list and in empty space.
-            "ipod-modern-screen bg-white"
+            cn(
+              "ipod-modern-screen bg-white",
+              !backlightOn && "ipod-modern-backlight-off"
+            )
           : backlightOn
           ? "bg-[#c5e0f5] bg-gradient-to-b from-[#d1e8fa] to-[#e0f0fc]"
           : "bg-[#8a9da9] contrast-65 saturate-50",

--- a/src/apps/ipod/components/MusicQuiz.tsx
+++ b/src/apps/ipod/components/MusicQuiz.tsx
@@ -671,7 +671,10 @@ export const MusicQuiz = function MusicQuiz(
         "border border-black border-2 rounded-[2px]",
         lcdFilterOn && !isModernUi ? "lcd-screen" : "",
         isModernUi
-          ? "ipod-modern-screen bg-white"
+          ? cn(
+              "ipod-modern-screen bg-white",
+              !backlightOn && "ipod-modern-backlight-off"
+            )
           : backlightOn
           ? "bg-[#c5e0f5] bg-gradient-to-b from-[#d1e8fa] to-[#e0f0fc]"
           : "bg-[#8a9da9] contrast-65 saturate-50",

--- a/src/index.css
+++ b/src/index.css
@@ -1425,6 +1425,13 @@ button.piano-key.piano-key[class*="bg-[#ff33ff]"] {
   overscroll-behavior-x: none;
 }
 
+/* Modern LCD backlight-off: dims the full screen (menus, now playing,
+ * Cover Flow inline) while keeping the same white surface — matches the
+ * classic skin's timed backlight-off behavior without swapping backgrounds. */
+.ipod-modern-screen.ipod-modern-backlight-off {
+  filter: brightness(0.5) contrast(0.9);
+}
+
 /* iPod-classic-js Header (sampled from app/components/Header/index.tsx):
  *   background: linear-gradient(180deg, #feffff 0%, #b1b6b9 100%);
  *   reference border-bottom was #7995a3 (slightly blue); we use a neutral gray.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Modern iPod UI (`uiVariant === "modern"`) now respects the existing backlight state and `BACKLIGHT_TIMEOUT_MS` auto-off timer. When the backlight is off, the LCD keeps its normal white (or Brick gradient) surface and dims via a shared CSS filter instead of ignoring `backlightOn` like before.

## Changes

- Added `.ipod-modern-backlight-off` on `.ipod-modern-screen` (`brightness(0.5) contrast(0.9)`), animated with the screen’s existing `transition-all duration-500`.
- Applied the class when `!backlightOn` on:
  - `IpodScreen` (menus, now playing, inline Cover Flow)
  - `MusicQuiz` overlay
  - `BrickGame` overlay

Classic skin behavior is unchanged.

## Testing

- `bun run test:unit` — 234 pass
- `bun run build` — success

Timing/toggle behavior reuses `useIpodStore.backlightOn`, `toggleBacklight`, and the timer in `useIpodLogic.ts` (no logic changes).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6F3CE535-7935-47C7-9757-C9A3BB5164F1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6F3CE535-7935-47C7-9757-C9A3BB5164F1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

