### PR TITLE
Lazy-sync Apple Music iPod playlists on demand

### DIFF
--- a/src/apps/ipod/hooks/useAppleMusicLibrary.ts
+++ b/src/apps/ipod/hooks/useAppleMusicLibrary.ts
@@ -1327,8 +1327,9 @@ export async function fetchAppleMusicLibrary(
 }
 
 /**
- * Lazy-load tracks for one library playlist. Uses a 24h stale-while-revalidate
- * window keyed per playlist id.
+ * Lazy-load tracks for one library playlist. Uses playlist-track freshness
+ * policy (`APPLE_MUSIC_PLAYLIST_TRACKS_OPPORTUNISTIC_TTL_MS`) keyed per
+ * playlist id.
  */
 export async function fetchAppleMusicPlaylistTracks(
   playlistId: string,

--- a/src/apps/ipod/hooks/useAppleMusicLibrary.ts
+++ b/src/apps/ipod/hooks/useAppleMusicLibrary.ts
@@ -8,7 +8,6 @@ import {
 } from "@/stores/useIpodStore";
 import { getMusicKitInstance } from "@/hooks/useMusicKit";
 import {
-  loadAllAppleMusicPlaylistTracks,
   loadAppleMusicLibrary,
   loadAppleMusicPlaylists,
   loadAppleMusicPlaylistTracks,
@@ -1520,34 +1519,6 @@ export function useAppleMusicLibrary({
           }
         }
 
-        // Per-playlist tracks (bulk hydrate every cached playlist) -------
-        if (
-          Object.keys(useIpodStore.getState().appleMusicPlaylistTracks)
-            .length === 0
-        ) {
-          const all = await loadAllAppleMusicPlaylistTracks();
-          if (cancelled) return;
-          const playlistIds = Object.keys(all);
-          if (playlistIds.length > 0) {
-            useIpodStore.setState((state) => {
-              const tracksMap = { ...state.appleMusicPlaylistTracks };
-              const loadedAtMap = {
-                ...state.appleMusicPlaylistTracksLoadedAt,
-              };
-              for (const id of playlistIds) {
-                if (!tracksMap[id] || tracksMap[id].length === 0) {
-                  tracksMap[id] = all[id].tracks;
-                  loadedAtMap[id] = all[id].loadedAt;
-                }
-              }
-              return {
-                appleMusicPlaylistTracks: tracksMap,
-                appleMusicPlaylistTracksLoadedAt: loadedAtMap,
-              };
-            });
-          }
-        }
-
         // Recently Added & Favorites (each persisted under its own
         // IndexedDB key by `saveAppleMusicTrackCollection`). Hydrating
         // here means the menu shows cached entries instantly on iPod
@@ -1701,14 +1672,11 @@ export function useAppleMusicLibrary({
     if (!isAuthorized) hasLoadedRef.current = false;
   }, [isAuthorized]);
 
-  // Opportunistic background refresh of the playlists list and per-playlist
-  // tracks.
+  // Opportunistic background refresh of the playlist list.
   //
   // The full library fetcher above only re-fetches when the library is
-  // older than 24h, and per-playlist tracks were only refreshed when the
-  // user explicitly opened that playlist. So a user who plays the iPod
-  // every day for a month and never reopens a playlist would see month-old
-  // playlist contents.
+  // older than 24h, so this keeps the top-level playlist list current
+  // without requiring a full library reload.
   //
   // This effect closes that gap by:
   //   1. Running once a few seconds after the hook becomes enabled+authed
@@ -1720,14 +1688,10 @@ export function useAppleMusicLibrary({
   //
   // All paths are silent (no toast). The refresh helpers themselves
   // short-circuit when the cache is fresh enough, so this is essentially
-  // free when nothing has actually expired. Track refresh uses bounded
-  // concurrency so a user with many cached playlists doesn't hammer the
-  // Apple Music API on every visibility change.
+  // free when nothing has actually expired.
   //
-  // Playback is unaffected: only the playlists list and per-playlist
-  // tracks map are mutated, neither of which is read by the
-  // AppleMusicPlayerBridge. The active queue stores ids, so swapping a
-  // playlist's tracks while one of them is playing keeps playback going.
+  // Playback is unaffected: only playlist metadata is mutated, which is
+  // not read by the AppleMusicPlayerBridge.
   useEffect(() => {
     if (!enabled || !isAuthorized) return;
 
@@ -1744,8 +1708,6 @@ export function useAppleMusicLibrary({
       lastRunAt = now;
       try {
         await refreshAppleMusicPlaylists();
-        if (cancelled) return;
-        await refreshStaleAppleMusicPlaylistTracks();
         if (cancelled) return;
         // Recently Added and Favorites have their own freshness windows
         // (handled inside each helper). Run them in parallel since they

--- a/src/apps/ipod/hooks/useAppleMusicLibrary.ts
+++ b/src/apps/ipod/hooks/useAppleMusicLibrary.ts
@@ -1187,46 +1187,65 @@ export type AppleMusicSyncResource =
   | { kind: "favorites"; force?: boolean }
   | { kind: "radio"; force?: boolean };
 
-type AppleMusicSyncResultByKind = {
-  library: number;
-  playlists: AppleMusicPlaylist[];
-  playlistTracks: Track[];
-  recentlyAdded: Track[];
-  favorites: Track[];
-  radio: Track[];
-};
-
-export async function syncAppleMusicResource<
-  K extends AppleMusicSyncResource["kind"],
->(
-  resource: Extract<AppleMusicSyncResource, { kind: K }>
-): Promise<AppleMusicSyncResultByKind[K]> {
+export function syncAppleMusicResource(resource: {
+  kind: "library";
+  force?: boolean;
+}): Promise<number>;
+export function syncAppleMusicResource(resource: {
+  kind: "playlists";
+  force?: boolean;
+  allowEmpty?: boolean;
+}): Promise<AppleMusicPlaylist[]>;
+export function syncAppleMusicResource(resource: {
+  kind: "playlistTracks";
+  playlistId: string;
+  force?: boolean;
+}): Promise<Track[]>;
+export function syncAppleMusicResource(resource: {
+  kind: "recentlyAdded";
+  force?: boolean;
+}): Promise<Track[]>;
+export function syncAppleMusicResource(resource: {
+  kind: "favorites";
+  force?: boolean;
+}): Promise<Track[]>;
+export function syncAppleMusicResource(resource: {
+  kind: "radio";
+  force?: boolean;
+}): Promise<Track[]>;
+export async function syncAppleMusicResource(
+  resource: AppleMusicSyncResource
+): Promise<number | AppleMusicPlaylist[] | Track[]> {
   switch (resource.kind) {
     case "library":
       return fetchAppleMusicLibrary({
         force: resource.force,
-      }) as Promise<AppleMusicSyncResultByKind[K]>;
+      });
     case "playlists":
       return refreshAppleMusicPlaylists({
         force: resource.force,
         allowEmpty: resource.allowEmpty,
-      }) as Promise<AppleMusicSyncResultByKind[K]>;
+      });
     case "playlistTracks":
       return fetchAppleMusicPlaylistTracks(resource.playlistId, {
         force: resource.force,
-      }) as Promise<AppleMusicSyncResultByKind[K]>;
+      });
     case "recentlyAdded":
       return refreshAppleMusicRecentlyAdded({
         force: resource.force,
-      }) as Promise<AppleMusicSyncResultByKind[K]>;
+      });
     case "favorites":
       return refreshAppleMusicFavorites({
         force: resource.force,
-      }) as Promise<AppleMusicSyncResultByKind[K]>;
+      });
     case "radio":
       return fetchAppleMusicRadioStations({
         force: resource.force,
-      }) as Promise<AppleMusicSyncResultByKind[K]>;
+      });
+    default: {
+      const _exhaustive: never = resource;
+      throw new Error(`Unknown Apple Music sync resource: ${String(_exhaustive)}`);
+    }
   }
 }
 

--- a/src/apps/ipod/hooks/useAppleMusicLibrary.ts
+++ b/src/apps/ipod/hooks/useAppleMusicLibrary.ts
@@ -924,7 +924,7 @@ let inFlightPlaylistsRefresh: Promise<AppleMusicPlaylist[]> | null = null;
  * fetcher so a flaky network response can't wipe the cached list.
  */
 export async function refreshAppleMusicPlaylists(
-  options: { force?: boolean } = {}
+  options: { force?: boolean; allowEmpty?: boolean } = {}
 ): Promise<AppleMusicPlaylist[]> {
   const store = useIpodStore.getState();
 
@@ -954,7 +954,11 @@ export async function refreshAppleMusicPlaylists(
       // refresh result. Apple Music occasionally returns 0 playlists when
       // a token is mid-rotation; preserving the cached list keeps the
       // menu populated.
-      if (playlists.length === 0 && existing.length > 0) {
+      if (
+        playlists.length === 0 &&
+        existing.length > 0 &&
+        !options.allowEmpty
+      ) {
         console.warn(
           "[apple music] playlist refresh returned 0; keeping cached list"
         );

--- a/src/apps/ipod/hooks/useAppleMusicLibrary.ts
+++ b/src/apps/ipod/hooks/useAppleMusicLibrary.ts
@@ -12,6 +12,7 @@ import {
   loadAppleMusicPlaylists,
   loadAppleMusicPlaylistTracks,
   loadAppleMusicTrackCollection,
+  pruneAppleMusicPlaylistTracksCache,
   saveAppleMusicPlaylists,
   saveAppleMusicPlaylistTracks,
   saveAppleMusicTrackCollection,
@@ -408,13 +409,6 @@ function getCatalogStorefront(instance: MusicKit.MusicKitInstance): string {
   );
 }
 
-function isAppleMusicCacheFresh(loadedAt: number | undefined): boolean {
-  return (
-    typeof loadedAt === "number" &&
-    Date.now() - loadedAt < APPLE_MUSIC_LIBRARY_STALE_AFTER_MS
-  );
-}
-
 export async function searchAppleMusicTracks(
   query: string,
   scope: AppleMusicSearchScope
@@ -477,7 +471,11 @@ export async function fetchAppleMusicRadioStations(
   const cached = await loadAppleMusicTrackCollection(
     RADIO_STATIONS_COLLECTION_KEY
   );
-  if (!options.force && cached) {
+  if (
+    !options.force &&
+    cached &&
+    isFreshByTtl(cached.loadedAt, APPLE_MUSIC_SYNC_TTL_MS.radio)
+  ) {
     return cached.tracks;
   }
 
@@ -660,7 +658,7 @@ export async function fetchAppleMusicRecentlyAddedTracks(
   if (
     !options.force &&
     cached?.tracks.length &&
-    isAppleMusicCacheFresh(cached.loadedAt)
+    isFreshByTtl(cached.loadedAt, APPLE_MUSIC_SYNC_TTL_MS.recentlyAdded)
   ) {
     return cached.tracks;
   }
@@ -737,7 +735,7 @@ export async function fetchAppleMusicFavoriteSongTracks(
   if (
     !options.force &&
     cached?.tracks.length &&
-    isAppleMusicCacheFresh(cached.loadedAt)
+    isFreshByTtl(cached.loadedAt, APPLE_MUSIC_SYNC_TTL_MS.favorites)
   ) {
     return cached.tracks;
   }
@@ -908,6 +906,22 @@ export const APPLE_MUSIC_PLAYLISTS_OPPORTUNISTIC_TTL_MS = 15 * 60 * 1000; // 15 
 export const APPLE_MUSIC_PLAYLIST_TRACKS_OPPORTUNISTIC_TTL_MS =
   60 * 60 * 1000; // 1h
 
+const APPLE_MUSIC_SYNC_TTL_MS = {
+  library: APPLE_MUSIC_LIBRARY_STALE_AFTER_MS,
+  playlists: APPLE_MUSIC_PLAYLISTS_OPPORTUNISTIC_TTL_MS,
+  playlistTracks: APPLE_MUSIC_PLAYLIST_TRACKS_OPPORTUNISTIC_TTL_MS,
+  recentlyAdded: APPLE_MUSIC_PLAYLIST_TRACKS_OPPORTUNISTIC_TTL_MS,
+  favorites: APPLE_MUSIC_PLAYLIST_TRACKS_OPPORTUNISTIC_TTL_MS,
+  radio: 6 * 60 * 60 * 1000,
+} as const;
+
+function isFreshByTtl(
+  loadedAt: number | null | undefined,
+  ttlMs: number
+): boolean {
+  return typeof loadedAt === "number" && Date.now() - loadedAt < ttlMs;
+}
+
 let inFlightPlaylistsRefresh: Promise<AppleMusicPlaylist[]> | null = null;
 
 /**
@@ -930,10 +944,9 @@ export async function refreshAppleMusicPlaylists(
 
   if (!options.force) {
     const loadedAt = store.appleMusicPlaylistsLoadedAt;
-    const ageMs = loadedAt ? Date.now() - loadedAt : Infinity;
     if (
       store.appleMusicPlaylists.length > 0 &&
-      ageMs < APPLE_MUSIC_PLAYLISTS_OPPORTUNISTIC_TTL_MS
+      isFreshByTtl(loadedAt, APPLE_MUSIC_SYNC_TTL_MS.playlists)
     ) {
       return store.appleMusicPlaylists;
     }
@@ -967,6 +980,7 @@ export async function refreshAppleMusicPlaylists(
       const loadedAt = Date.now();
       useIpodStore.getState().setAppleMusicPlaylists(playlists, loadedAt);
       void saveAppleMusicPlaylists({ playlists, loadedAt });
+      void pruneAppleMusicPlaylistTracksCache(playlists.map((p) => p.id));
       return playlists;
     } finally {
       inFlightPlaylistsRefresh = null;
@@ -1075,10 +1089,9 @@ export async function refreshAppleMusicRecentlyAdded(
 
   if (!options.force) {
     const loadedAt = store.appleMusicRecentlyAddedLoadedAt;
-    const ageMs = loadedAt ? Date.now() - loadedAt : Infinity;
     if (
       store.appleMusicRecentlyAddedTracks.length > 0 &&
-      ageMs < APPLE_MUSIC_PLAYLIST_TRACKS_OPPORTUNISTIC_TTL_MS
+      isFreshByTtl(loadedAt, APPLE_MUSIC_SYNC_TTL_MS.recentlyAdded)
     ) {
       return store.appleMusicRecentlyAddedTracks;
     }
@@ -1129,10 +1142,9 @@ export async function refreshAppleMusicFavorites(
 
   if (!options.force) {
     const loadedAt = store.appleMusicFavoriteTracksLoadedAt;
-    const ageMs = loadedAt ? Date.now() - loadedAt : Infinity;
     if (
       store.appleMusicFavoriteTracks.length > 0 &&
-      ageMs < APPLE_MUSIC_PLAYLIST_TRACKS_OPPORTUNISTIC_TTL_MS
+      isFreshByTtl(loadedAt, APPLE_MUSIC_SYNC_TTL_MS.favorites)
     ) {
       return store.appleMusicFavoriteTracks;
     }
@@ -1165,6 +1177,57 @@ export async function refreshAppleMusicFavorites(
   })();
 
   return inFlightFavoritesRefresh;
+}
+
+export type AppleMusicSyncResource =
+  | { kind: "library"; force?: boolean }
+  | { kind: "playlists"; force?: boolean; allowEmpty?: boolean }
+  | { kind: "playlistTracks"; playlistId: string; force?: boolean }
+  | { kind: "recentlyAdded"; force?: boolean }
+  | { kind: "favorites"; force?: boolean }
+  | { kind: "radio"; force?: boolean };
+
+type AppleMusicSyncResultByKind = {
+  library: number;
+  playlists: AppleMusicPlaylist[];
+  playlistTracks: Track[];
+  recentlyAdded: Track[];
+  favorites: Track[];
+  radio: Track[];
+};
+
+export async function syncAppleMusicResource<
+  K extends AppleMusicSyncResource["kind"],
+>(
+  resource: Extract<AppleMusicSyncResource, { kind: K }>
+): Promise<AppleMusicSyncResultByKind[K]> {
+  switch (resource.kind) {
+    case "library":
+      return fetchAppleMusicLibrary({
+        force: resource.force,
+      }) as Promise<AppleMusicSyncResultByKind[K]>;
+    case "playlists":
+      return refreshAppleMusicPlaylists({
+        force: resource.force,
+        allowEmpty: resource.allowEmpty,
+      }) as Promise<AppleMusicSyncResultByKind[K]>;
+    case "playlistTracks":
+      return fetchAppleMusicPlaylistTracks(resource.playlistId, {
+        force: resource.force,
+      }) as Promise<AppleMusicSyncResultByKind[K]>;
+    case "recentlyAdded":
+      return refreshAppleMusicRecentlyAdded({
+        force: resource.force,
+      }) as Promise<AppleMusicSyncResultByKind[K]>;
+    case "favorites":
+      return refreshAppleMusicFavorites({
+        force: resource.force,
+      }) as Promise<AppleMusicSyncResultByKind[K]>;
+    case "radio":
+      return fetchAppleMusicRadioStations({
+        force: resource.force,
+      }) as Promise<AppleMusicSyncResultByKind[K]>;
+  }
 }
 
 /**
@@ -1299,8 +1362,7 @@ export async function fetchAppleMusicPlaylistTracks(
     }
   }
 
-  const ageMs = loadedAt ? Date.now() - loadedAt : Infinity;
-  const isFresh = ageMs < APPLE_MUSIC_LIBRARY_STALE_AFTER_MS;
+  const isFresh = isFreshByTtl(loadedAt, APPLE_MUSIC_SYNC_TTL_MS.playlistTracks);
 
   if (!options.force && isFresh && cachedTracks && cachedTracks.length > 0) {
     return cachedTracks;
@@ -1687,8 +1749,6 @@ export function useAppleMusicLibrary({
   //      (hydration has had time to seed the in-memory store first).
   //   2. Re-running whenever the document becomes visible (fast path for
   //      "user came back to the tab").
-  //   3. Polling on a 15-min timer while the iPod is open as a backstop
-  //      for long-lived sessions.
   //
   // All paths are silent (no toast). The refresh helpers themselves
   // short-circuit when the cache is fresh enough, so this is essentially
@@ -1702,8 +1762,6 @@ export function useAppleMusicLibrary({
     let cancelled = false;
     let lastRunAt = 0;
     const MIN_INTERVAL_MS = 60 * 1000; // throttle visibility-driven calls
-    const POLL_INTERVAL_MS = 15 * 60 * 1000;
-
     const runOpportunisticRefresh = async () => {
       if (cancelled) return;
       if (typeof document !== "undefined" && document.hidden) return;
@@ -1741,10 +1799,6 @@ export function useAppleMusicLibrary({
       void runOpportunisticRefresh();
     }, 3000);
 
-    const interval = setInterval(() => {
-      void runOpportunisticRefresh();
-    }, POLL_INTERVAL_MS);
-
     const onVisibilityChange = () => {
       if (typeof document === "undefined" || document.hidden) return;
       void runOpportunisticRefresh();
@@ -1756,7 +1810,6 @@ export function useAppleMusicLibrary({
     return () => {
       cancelled = true;
       clearTimeout(initialTimeout);
-      clearInterval(interval);
       if (typeof document !== "undefined") {
         document.removeEventListener(
           "visibilitychange",

--- a/src/apps/ipod/hooks/useAppleMusicLibrary.ts
+++ b/src/apps/ipod/hooks/useAppleMusicLibrary.ts
@@ -860,6 +860,18 @@ function isAppleMusicNotFoundError(err: unknown): boolean {
   return err instanceof Error && /\b404\b/.test(err.message);
 }
 
+function isAppleMusicBadRequestError(err: unknown): boolean {
+  if (typeof err === "object" && err !== null) {
+    const maybeStatus = (err as { status?: unknown; statusCode?: unknown });
+    if (maybeStatus.status === 400 || maybeStatus.statusCode === 400) {
+      return true;
+    }
+    const maybeResponse = (err as { response?: { status?: unknown } }).response;
+    if (maybeResponse?.status === 400) return true;
+  }
+  return err instanceof Error && /\b400\b/.test(err.message);
+}
+
 async function fetchAppleMusicPlaylistsList(): Promise<AppleMusicPlaylist[]> {
   const instance = getMusicKitInstance();
   if (!instance) throw new Error("MusicKit instance is not configured");
@@ -1395,6 +1407,7 @@ export async function fetchAppleMusicPlaylistTracks(
   store.setAppleMusicPlaylistTracksLoading(playlistId, true);
 
   const aggregated: Track[] = [];
+  let triedWithoutInclude = false;
   try {
     let offset = 0;
     let total: number | undefined;
@@ -1410,6 +1423,19 @@ export async function fetchAppleMusicPlaylistTracks(
           }
         );
       } catch (err) {
+        // Some Apple Music library playlists reject include[library-songs]
+        // with 400. Retry once per fetch cycle without include params so
+        // those playlists still load instead of hard-failing the menu.
+        if (!triedWithoutInclude && isAppleMusicBadRequestError(err)) {
+          triedWithoutInclude = true;
+          response = await instance.api.music<LibraryPlaylistTracksResponse>(
+            `/v1/me/library/playlists/${encodeURIComponent(playlistId)}/tracks`,
+            {
+              limit: PAGE_SIZE,
+              offset,
+            }
+          );
+        } else {
         if (offset > 0 && isAppleMusicNotFoundError(err)) {
           console.warn(
             `[apple music] playlist ${playlistId} returned 404 after ${aggregated.length} tracks; treating as end of pagination`
@@ -1417,6 +1443,7 @@ export async function fetchAppleMusicPlaylistTracks(
           break;
         }
         throw err;
+        }
       }
       const data = response?.data as LibraryPlaylistTracksResponse | undefined;
       const items = data?.data ?? [];

--- a/src/apps/ipod/hooks/useAppleMusicLibrary.ts
+++ b/src/apps/ipod/hooks/useAppleMusicLibrary.ts
@@ -881,17 +881,37 @@ async function fetchAppleMusicPlaylistsList(): Promise<AppleMusicPlaylist[]> {
 
   const aggregated: AppleMusicPlaylist[] = [];
   let offset = 0;
+  let triedWithoutTrackInclude = false;
   for (let page = 0; page < MAX_PAGES; page++) {
-    const response = await instance.api.music<LibraryPlaylistsResponse>(
-      "/v1/me/library/playlists",
-      {
-        limit: PAGE_SIZE,
-        offset,
-        // Track totals without loading every song (for playlist row subtitles).
-        include: "tracks",
-        "limit[tracks]": 0,
+    let response: { data: LibraryPlaylistsResponse };
+    try {
+      response = await instance.api.music<LibraryPlaylistsResponse>(
+        "/v1/me/library/playlists",
+        {
+          limit: PAGE_SIZE,
+          offset,
+          // Track totals without loading every song (for playlist row subtitles).
+          include: "tracks",
+          "limit[tracks]": 0,
+        }
+      );
+    } catch (err) {
+      // Some Apple Music accounts reject the include/limit[tracks] query shape
+      // for playlist-list requests with HTTP 400. Retry without track includes
+      // so the list still loads, even if row-level trackCount metadata is absent.
+      if (!triedWithoutTrackInclude && isAppleMusicBadRequestError(err)) {
+        triedWithoutTrackInclude = true;
+        response = await instance.api.music<LibraryPlaylistsResponse>(
+          "/v1/me/library/playlists",
+          {
+            limit: PAGE_SIZE,
+            offset,
+          }
+        );
+      } else {
+        throw err;
       }
-    );
+    }
     const data = response?.data as LibraryPlaylistsResponse | undefined;
     const items = data?.data ?? [];
 

--- a/src/apps/ipod/hooks/useIpodLogic.ts
+++ b/src/apps/ipod/hooks/useIpodLogic.ts
@@ -15,12 +15,8 @@ import { useCustomEventListener, useEventListener } from "@/hooks/useEventListen
 import { useLibraryUpdateChecker } from "./useLibraryUpdateChecker";
 import {
   useAppleMusicLibrary,
-  fetchAppleMusicPlaylistTracks,
-  refreshAppleMusicPlaylists,
-  refreshAppleMusicRecentlyAdded,
-  refreshAppleMusicFavorites,
+  syncAppleMusicResource,
   searchAppleMusicTracks,
-  fetchAppleMusicRadioStations,
   fetchAppleMusicGeniusTrack,
   addAppleMusicTrackToFavorites,
   cacheAppleMusicFavoriteSongTrack,
@@ -337,7 +333,7 @@ export function useIpodLogic({
 
   // Auto-load library after auth + when Apple Music is the active source.
   const { refresh: refreshAppleMusicLibrary } = useAppleMusicLibrary({
-    enabled: isAppleMusic,
+    enabled: enableMusicKit,
     isAuthorized: appleMusicAuthorized,
   });
 
@@ -923,8 +919,9 @@ export function useIpodLogic({
   const requestPlaylistTracksIfNeeded = useCallback((playlistId: string) => {
     // Lazy per-playlist sync: only fetch when this playlist has never
     // been loaded (in-memory or IndexedDB) or its cache is stale.
-    // `fetchAppleMusicPlaylistTracks` handles SWR + in-flight dedupe.
-    void fetchAppleMusicPlaylistTracks(playlistId).catch(
+    // `syncAppleMusicResource` routes through the playlist-track SWR fetcher
+    // and shares dedupe behavior with other Apple Music resources.
+    void syncAppleMusicResource({ kind: "playlistTracks", playlistId }).catch(
       (err) => {
         console.warn(
           `[apple music] failed to load playlist tracks for ${playlistId}`,
@@ -1063,7 +1060,10 @@ export function useIpodLogic({
       return;
     }
     try {
-      const tracks = await refreshAppleMusicRecentlyAdded({ force: true });
+      const tracks = await syncAppleMusicResource({
+        kind: "recentlyAdded",
+        force: true,
+      });
       mergeAppleMusicTracks(tracks);
     } catch (err) {
       // Only surface the toast when there's no cached content to fall
@@ -1096,7 +1096,10 @@ export function useIpodLogic({
       return;
     }
     try {
-      const tracks = await refreshAppleMusicFavorites({ force: true });
+      const tracks = await syncAppleMusicResource({
+        kind: "favorites",
+        force: true,
+      });
       mergeAppleMusicTracks(tracks);
     } catch (err) {
       const hasCached =
@@ -1128,7 +1131,11 @@ export function useIpodLogic({
     try {
       // Always revalidate when opening the Playlists menu so additions/
       // deletions on other devices appear promptly.
-      await refreshAppleMusicPlaylists({ force: true, allowEmpty: true });
+      await syncAppleMusicResource({
+        kind: "playlists",
+        force: true,
+        allowEmpty: true,
+      });
     } catch (err) {
       const hasCached = useIpodStore.getState().appleMusicPlaylists.length > 0;
       if (!hasCached) {
@@ -1159,7 +1166,9 @@ export function useIpodLogic({
     const hadCached = appleMusicRadioTracks.length > 0;
     setIsAppleMusicRadioLoading(true);
     try {
-      const stations = await fetchAppleMusicRadioStations();
+      const stations = await syncAppleMusicResource({
+        kind: "radio",
+      });
       setAppleMusicRadioTracks(stations);
       mergeAppleMusicTracks(stations);
     } catch (err) {

--- a/src/apps/ipod/hooks/useIpodLogic.ts
+++ b/src/apps/ipod/hooks/useIpodLogic.ts
@@ -920,15 +920,10 @@ export function useIpodLogic({
   );
 
   const requestPlaylistTracksIfNeeded = useCallback((playlistId: string) => {
-    // Always trigger a background refresh on playlist open. The fetcher
-    // dedupes in-flight calls via `appleMusicPlaylistTracksLoading`, and
-    // the modern UI shows a titlebar spinner instead of a list
-    // placeholder; cached tracks render immediately while a
-    // immediately while the refresh updates them in place. This gives
-    // users a true SWR experience: opening a playlist shows cached
-    // contents instantly AND silently picks up any new songs added
-    // since the last view.
-    void fetchAppleMusicPlaylistTracks(playlistId, { force: true }).catch(
+    // Lazy per-playlist sync: only fetch when this playlist has never
+    // been loaded (in-memory or IndexedDB) or its cache is stale.
+    // `fetchAppleMusicPlaylistTracks` handles SWR + in-flight dedupe.
+    void fetchAppleMusicPlaylistTracks(playlistId).catch(
       (err) => {
         console.warn(
           `[apple music] failed to load playlist tracks for ${playlistId}`,

--- a/src/apps/ipod/hooks/useIpodLogic.ts
+++ b/src/apps/ipod/hooks/useIpodLogic.ts
@@ -16,6 +16,7 @@ import { useLibraryUpdateChecker } from "./useLibraryUpdateChecker";
 import {
   useAppleMusicLibrary,
   fetchAppleMusicPlaylistTracks,
+  refreshAppleMusicPlaylists,
   refreshAppleMusicRecentlyAdded,
   refreshAppleMusicFavorites,
   searchAppleMusicTracks,
@@ -1119,6 +1120,36 @@ export function useIpodLogic({
     }
   }, [appleMusicAuthorized, handleAppleMusicSignIn, mergeAppleMusicTracks, menuLocale]);
 
+  const loadAppleMusicPlaylists = useCallback(async () => {
+    if (!appleMusicAuthorized) {
+      void handleAppleMusicSignIn();
+      return;
+    }
+    try {
+      // Always revalidate when opening the Playlists menu so additions/
+      // deletions on other devices appear promptly.
+      await refreshAppleMusicPlaylists({ force: true, allowEmpty: true });
+    } catch (err) {
+      const hasCached = useIpodStore.getState().appleMusicPlaylists.length > 0;
+      if (!hasCached) {
+        toast.error(
+          t(
+            "apps.ipod.dialogs.appleMusicPlaylistsFailed",
+            "Failed to load playlists"
+          ),
+          {
+            description: err instanceof Error ? err.message : String(err),
+          }
+        );
+      } else {
+        console.warn(
+          "[apple music] playlist refresh failed (using cached playlist list)",
+          err
+        );
+      }
+    }
+  }, [appleMusicAuthorized, handleAppleMusicSignIn, menuLocale]);
+
   const loadAppleMusicRadioStations = useCallback(async (options?: {
     promptForAuth?: boolean;
     showErrors?: boolean;
@@ -2208,10 +2239,12 @@ export function useIpodLogic({
         },
         {
           label: playlistsLabel,
-          action: () =>
+          action: () => {
             pushSubmenu(playlistsLabel, applePlaylistsMenuItems, {
               modernMediaList: true,
-            }),
+            });
+            void loadAppleMusicPlaylists();
+          },
           showChevron: true,
         },
         {
@@ -2280,6 +2313,7 @@ export function useIpodLogic({
     albumsListMenuItems,
     applePlaylistsMenuItems,
     loadAppleMusicFavorites,
+    loadAppleMusicPlaylists,
     loadAppleMusicRecentlyAdded,
     loadAppleMusicRadioStations,
     playAppleMusicGenius,

--- a/src/stores/useIpodStore.ts
+++ b/src/stores/useIpodStore.ts
@@ -2110,13 +2110,36 @@ export const useIpodStore = create<IpodState>()(
         });
       },
       setAppleMusicPlaylists: (playlists, loadedAt) =>
-        set({
-          appleMusicPlaylists: playlists,
-          // `null` is reserved for "never synced". When the caller doesn't
-          // pass a timestamp, treat this as a fresh sync (default behavior
-          // for opportunistic / foreground refresh paths).
-          appleMusicPlaylistsLoadedAt:
-            loadedAt === undefined ? Date.now() : loadedAt,
+        set((state) => {
+          const activeIds = new Set(playlists.map((playlist) => playlist.id));
+          const nextPlaylistTracks: Record<string, Track[]> = {};
+          const nextPlaylistTracksLoadedAt: Record<string, number> = {};
+          const nextPlaylistTracksLoading: Record<string, boolean> = {};
+          for (const [playlistId, tracks] of Object.entries(
+            state.appleMusicPlaylistTracks
+          )) {
+            if (!activeIds.has(playlistId)) continue;
+            nextPlaylistTracks[playlistId] = tracks;
+            const cachedLoadedAt = state.appleMusicPlaylistTracksLoadedAt[playlistId];
+            if (typeof cachedLoadedAt === "number") {
+              nextPlaylistTracksLoadedAt[playlistId] = cachedLoadedAt;
+            }
+            if (state.appleMusicPlaylistTracksLoading[playlistId]) {
+              nextPlaylistTracksLoading[playlistId] = true;
+            }
+          }
+          return {
+            appleMusicPlaylists: playlists,
+            // `null` is reserved for "never synced". When the caller doesn't
+            // pass a timestamp, treat this as a fresh sync (default behavior
+            // for opportunistic / foreground refresh paths).
+            appleMusicPlaylistsLoadedAt:
+              loadedAt === undefined ? Date.now() : loadedAt,
+            // Keep only tracks for playlists that still exist on the server.
+            appleMusicPlaylistTracks: nextPlaylistTracks,
+            appleMusicPlaylistTracksLoadedAt: nextPlaylistTracksLoadedAt,
+            appleMusicPlaylistTracksLoading: nextPlaylistTracksLoading,
+          };
         }),
       setAppleMusicPlaylistTracks: (playlistId, tracks) =>
         set((state) => ({

--- a/src/utils/appleMusicLibraryCache.ts
+++ b/src/utils/appleMusicLibraryCache.ts
@@ -252,9 +252,14 @@ export async function pruneAppleMusicPlaylistTracksCache(
   try {
     const { ensureIndexedDBInitialized } = await import("@/utils/indexedDB");
     db = await ensureIndexedDBInitialized();
+    const database = db;
+    if (!database) return;
     await new Promise<void>((resolve, reject) => {
       try {
-        const tx = db.transaction(STORES.APPLE_MUSIC_PLAYLIST_TRACKS, "readwrite");
+        const tx = database.transaction(
+          STORES.APPLE_MUSIC_PLAYLIST_TRACKS,
+          "readwrite"
+        );
         const store = tx.objectStore(STORES.APPLE_MUSIC_PLAYLIST_TRACKS);
         const keysReq = store.getAllKeys();
         const active = new Set(activePlaylistIds);

--- a/src/utils/appleMusicLibraryCache.ts
+++ b/src/utils/appleMusicLibraryCache.ts
@@ -241,6 +241,47 @@ export async function loadAllAppleMusicPlaylistTracks(): Promise<
   }
 }
 
+/**
+ * Remove cached per-playlist track payloads whose playlist IDs are no longer
+ * present in the latest playlist list response.
+ */
+export async function pruneAppleMusicPlaylistTracksCache(
+  activePlaylistIds: readonly string[]
+): Promise<void> {
+  let db: IDBDatabase | null = null;
+  try {
+    const { ensureIndexedDBInitialized } = await import("@/utils/indexedDB");
+    db = await ensureIndexedDBInitialized();
+    await new Promise<void>((resolve, reject) => {
+      try {
+        const tx = db.transaction(STORES.APPLE_MUSIC_PLAYLIST_TRACKS, "readwrite");
+        const store = tx.objectStore(STORES.APPLE_MUSIC_PLAYLIST_TRACKS);
+        const keysReq = store.getAllKeys();
+        const active = new Set(activePlaylistIds);
+
+        keysReq.onsuccess = () => {
+          const keys = (keysReq.result || []) as IDBValidKey[];
+          for (const key of keys) {
+            if (typeof key !== "string") continue;
+            if (key.startsWith(TRACK_COLLECTION_KEY_PREFIX)) continue;
+            if (active.has(key)) continue;
+            store.delete(key);
+          }
+        };
+        keysReq.onerror = () => reject(keysReq.error);
+        tx.oncomplete = () => resolve();
+        tx.onerror = () => reject(tx.error);
+      } catch (err) {
+        reject(err);
+      }
+    });
+  } catch (err) {
+    console.warn("[apple music cache] failed to prune playlist track cache", err);
+  } finally {
+    db?.close();
+  }
+}
+
 async function clearAppleMusicPlaylists(): Promise<void> {
   try {
     await dbOperations.delete(STORES.APPLE_MUSIC_PLAYLISTS, PLAYLISTS_KEY);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add a unified `syncAppleMusicResource(...)` entrypoint for Apple Music resource sync (library/playlists/playlist-tracks/recent/favorites/radio) and switch iPod menu-triggered sync paths to use it
- normalize cache freshness checks with a single TTL policy map (including playlist-track and radio-specific TTL behavior)
- prune stale playlist-track caches when the playlist list syncs: in-memory maps are trimmed in `setAppleMusicPlaylists`, and IndexedDB per-playlist track keys are pruned against current playlist IDs
- simplify opportunistic background behavior by removing the playlist polling interval and using initial + visibility-triggered revalidation
- run Apple Music hydration/sync hooks whenever MusicKit is enabled (window open/current session), not only when Apple Music is currently the active library
- fix build-time TypeScript issues by adding typed overloads for `syncAppleMusicResource(...)` and tightening IndexedDB nullability handling in playlist-cache pruning
- harden Apple Music 400 handling in both places:
  - playlist list fetch retries once without `include: tracks` / `limit[tracks]` params
  - playlist-track fetch retries once without `include[library-songs]` params

## Testing
- `bun run build`
- `bun test tests/test-ipod-apple-music.test.ts tests/test-ipod-apple-music-menu-loading.test.ts`
- `bun test tests/test-ipod-apple-music.test.ts`

## Notes
- playlist list foreground refresh still supports `allowEmpty` for real deletion propagation
- deleted playlists now stop retaining orphaned per-playlist track caches
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-FAF83ECA-7743-40E7-9E00-CB3003F63A70"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-FAF83ECA-7743-40E7-9E00-CB3003F63A70"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

