### PR TITLE
Clean up chat speech and TTS highlighting

### DIFF
--- a/src/apps/chats/components/ChatMessages.tsx
+++ b/src/apps/chats/components/ChatMessages.tsx
@@ -1330,11 +1330,11 @@ function ChatMessagesContent({
   const streamingAssistantMessageKey = streamingAssistantMessage
     ? getMessageKey(streamingAssistantMessage)
     : null;
-  const latestAssistantMessage = [...messages]
+  const latestSpeechMessage = [...messages]
     .reverse()
-    .find((message) => message.role === "assistant");
-  const latestAssistantMessageKey = latestAssistantMessage
-    ? getMessageKey(latestAssistantMessage)
+    .find((message) => message.role !== "user");
+  const latestAssistantMessageKey = latestSpeechMessage
+    ? getMessageKey(latestSpeechMessage)
     : null;
   const [recentTtsMessageKey, setRecentTtsMessageKey] = useState<string | null>(
     null

--- a/src/apps/chats/components/ChatMessages.tsx
+++ b/src/apps/chats/components/ChatMessages.tsx
@@ -519,6 +519,11 @@ const ChatMessageItem = memo(function ChatMessageItem(props: ChatMessageItemProp
   const displayText = getDisplayTextPart(messageText);
   const hasAquariumToken = displayText.includes("[[AQUARIUM]]");
   const displayContent = displayText.replace(/\[\[AQUARIUM\]\]/g, "").trim();
+  const isTtsHighlighted = matchesHighlightMessage(
+    highlightSegment,
+    message,
+    messageKey
+  );
   let assistantTextOffset = 0;
 
   let hasAquarium = false;
@@ -907,6 +912,8 @@ const ChatMessageItem = memo(function ChatMessageItem(props: ChatMessageItemProp
                 (message.role === "user"
                   ? "bg-yellow-100 text-black"
                   : "bg-blue-100 text-black")
+          } ${
+            isTtsHighlighted ? "ryos-chat-tts-bubble-active" : ""
           } w-fit max-w-[90%] min-h-[12px] rounded leading-snug font-geneva-12 break-words select-text`}
           style={getChatMessageStyle(fontSize)}
         >

--- a/src/apps/chats/components/ChatMessages.tsx
+++ b/src/apps/chats/components/ChatMessages.tsx
@@ -11,7 +11,6 @@ import { useTerminalSounds } from "@/hooks/useTerminalSounds";
 
 import { StickToBottom, useStickToBottomContext } from "use-stick-to-bottom";
 import { TypingDots } from "./TypingBubble";
-import { useTtsQueue } from "@/hooks/useTtsQueue";
 import { useAudioSettingsStore } from "@/stores/useAudioSettingsStore";
 import { appNames } from "@/config/appRegistryData";
 import {
@@ -312,6 +311,8 @@ interface ChatMessagesProps {
   scrollToBottomTrigger: number; // Add scroll trigger prop
   highlightSegment?: HighlightSegment | null;
   isSpeaking?: boolean;
+  speakText: (text: string, onEnd?: () => void) => void;
+  stopSpeech: () => void;
   onSendMessage?: (username: string) => void; // Callback when send message button is clicked
   isLoadingGreeting?: boolean; // Show typing bubble for proactive greeting
   typingUsers?: string[];
@@ -413,6 +414,8 @@ interface ChatMessageItemProps {
   speechEnabled: boolean;
   highlightSegment?: HighlightSegment | null;
   isSpeaking?: boolean;
+  speakText: (text: string, onEnd?: () => void) => void;
+  stopSpeech: () => void;
   isAdmin: boolean;
   roomId?: string;
   username?: string;
@@ -422,8 +425,6 @@ interface ChatMessageItemProps {
   onDeleteMessage: (message: ChatMessage) => void;
   setPlayingMessageId: (id: string | null) => void;
   setSpeechLoadingId: (id: string | null) => void;
-  speak: (text: string, onDone?: () => void) => void;
-  stop: () => void;
   playNote: () => void;
   playElevatorMusic: () => void;
   stopElevatorMusic: () => void;
@@ -447,7 +448,9 @@ const ChatMessageItem = memo(function ChatMessageItem(props: ChatMessageItemProp
     speechLoadingId,
     speechEnabled,
     highlightSegment,
-    isSpeaking: _isSpeaking,
+    isSpeaking,
+    speakText,
+    stopSpeech,
     isAdmin,
     roomId: _roomId,
     username: _username,
@@ -457,8 +460,6 @@ const ChatMessageItem = memo(function ChatMessageItem(props: ChatMessageItemProp
     onDeleteMessage,
     setPlayingMessageId,
     setSpeechLoadingId,
-    speak,
-    stop,
     playNote,
     playElevatorMusic,
     stopElevatorMusic,
@@ -693,10 +694,10 @@ const ChatMessageItem = memo(function ChatMessageItem(props: ChatMessageItemProp
                 className="size-3 text-gray-400 hover:text-neutral-600 transition-colors"
                 onClick={() => {
                   if (playingMessageId === messageKey) {
-                    stop();
+                    stopSpeech();
                     setPlayingMessageId(null);
                   } else {
-                    stop();
+                    stopSpeech();
                     setSpeechLoadingId(null);
                     const text = displayContent.trim();
                     if (text) {
@@ -713,7 +714,7 @@ const ChatMessageItem = memo(function ChatMessageItem(props: ChatMessageItemProp
                         setSpeechLoadingId(messageKey);
                         setPlayingMessageId(messageKey);
                         chunks.forEach((chunk) => {
-                          speak(chunk, () => {
+                          speakText(chunk, () => {
                             pendingChunks -= 1;
                             if (pendingChunks === 0) {
                               setPlayingMessageId(null);
@@ -1103,6 +1104,8 @@ interface ChatMessagesContentProps {
   scrollToBottomTrigger: number;
   highlightSegment?: HighlightSegment | null;
   isSpeaking?: boolean;
+  speakText: (text: string, onEnd?: () => void) => void;
+  stopSpeech: () => void;
   onSendMessage?: (username: string) => void;
   isLoadingGreeting?: boolean;
   typingUsers?: string[];
@@ -1123,6 +1126,8 @@ function ChatMessagesContent({
   scrollToBottomTrigger,
   highlightSegment,
   isSpeaking,
+  speakText,
+  stopSpeech,
   onSendMessage,
   isLoadingGreeting,
   typingUsers,
@@ -1132,7 +1137,6 @@ function ChatMessagesContent({
   const { playElevatorMusic, stopElevatorMusic, playDingSound } =
     useTerminalSounds();
   const [copiedMessageId, setCopiedMessageId] = useState<string | null>(null);
-  const { speak, stop, isSpeaking: localTtsSpeaking } = useTtsQueue();
   const speechEnabled = useAudioSettingsStore((state) => state.speechEnabled);
   const { isMacOSTheme } = useThemeFlags();
   const [playingMessageId, setPlayingMessageId] = useState<string | null>(null);
@@ -1200,10 +1204,10 @@ function ChatMessagesContent({
 
   // Clear loading indicator when TTS actually starts playing
   useEffect(() => {
-    if (localTtsSpeaking && speechLoadingId) {
+    if (isSpeaking && speechLoadingId) {
       setSpeechLoadingId(null);
     }
-  }, [localTtsSpeaking, speechLoadingId]);
+  }, [isSpeaking, speechLoadingId]);
 
   const copyMessage = useCallback(async (message: ChatMessage) => {
     const messageText = getMessageText(message);
@@ -1357,6 +1361,8 @@ function ChatMessagesContent({
             speechEnabled={speechEnabled}
             highlightSegment={highlightSegment}
             isSpeaking={isSpeaking}
+            speakText={speakText}
+            stopSpeech={stopSpeech}
             isAdmin={isAdmin}
             roomId={roomId}
             username={username}
@@ -1366,8 +1372,6 @@ function ChatMessagesContent({
             onDeleteMessage={deleteMessage}
             setPlayingMessageId={setPlayingMessageId}
             setSpeechLoadingId={setSpeechLoadingId}
-            speak={speak}
-            stop={stop}
             playNote={playNote}
             playElevatorMusic={playElevatorMusic}
             stopElevatorMusic={stopElevatorMusic}
@@ -1479,6 +1483,8 @@ export function ChatMessages({
   scrollToBottomTrigger,
   highlightSegment,
   isSpeaking,
+  speakText,
+  stopSpeech,
   onSendMessage,
   isLoadingGreeting,
   typingUsers,
@@ -1509,6 +1515,8 @@ export function ChatMessages({
           scrollToBottomTrigger={scrollToBottomTrigger}
           highlightSegment={highlightSegment}
           isSpeaking={isSpeaking}
+          speakText={speakText}
+          stopSpeech={stopSpeech}
           onSendMessage={onSendMessage}
           isLoadingGreeting={isLoadingGreeting}
           typingUsers={typingUsers}

--- a/src/apps/chats/components/ChatMessages.tsx
+++ b/src/apps/chats/components/ChatMessages.tsx
@@ -303,7 +303,11 @@ interface ChatMessagesProps {
   scrollToBottomTrigger: number; // Add scroll trigger prop
   highlightSegment?: HighlightSegment | null;
   isSpeaking?: boolean;
-  speakText: (text: string, onEnd?: () => void) => void;
+  speakText: (
+    text: string,
+    onEnd?: () => void,
+    highlight?: HighlightSegment
+  ) => void;
   stopSpeech: () => void;
   onSendMessage?: (username: string) => void; // Callback when send message button is clicked
   isLoadingGreeting?: boolean; // Show typing bubble for proactive greeting
@@ -405,7 +409,11 @@ interface ChatMessageItemProps {
   speechLoadingId: string | null;
   speechEnabled: boolean;
   highlightSegment?: HighlightSegment | null;
-  speakText: (text: string, onEnd?: () => void) => void;
+  speakText: (
+    text: string,
+    onEnd?: () => void,
+    highlight?: HighlightSegment
+  ) => void;
   stopSpeech: () => void;
   isAdmin: boolean;
   roomId?: string;
@@ -690,12 +698,22 @@ const ChatMessageItem = memo(function ChatMessageItem(props: ChatMessageItemProp
                     setSpeechLoadingId(null);
                     const text = displayContent.trim();
                     if (text) {
-                      const chunks: string[] = [];
-                      const lines = text.split(/\r?\n/);
-                      for (const line of lines) {
+                      const chunks: Array<{
+                        text: string;
+                        start: number;
+                        end: number;
+                      }> = [];
+                      const lines = text.matchAll(/[^\r\n]+/g);
+                      for (const lineMatch of lines) {
+                        const line = lineMatch[0];
+                        const start = lineMatch.index ?? 0;
                         const cleanedLine = cleanTextForSpeech(line);
                         if (cleanedLine && cleanedLine.length > 0) {
-                          chunks.push(cleanedLine);
+                          chunks.push({
+                            text: line,
+                            start,
+                            end: start + line.length,
+                          });
                         }
                       }
                       if (chunks.length > 0) {
@@ -703,13 +721,21 @@ const ChatMessageItem = memo(function ChatMessageItem(props: ChatMessageItemProp
                         setSpeechLoadingId(messageKey);
                         setPlayingMessageId(messageKey);
                         chunks.forEach((chunk) => {
-                          speakText(chunk, () => {
-                            pendingChunks -= 1;
-                            if (pendingChunks === 0) {
-                              setPlayingMessageId(null);
-                              setSpeechLoadingId(null);
+                          speakText(
+                            chunk.text,
+                            () => {
+                              pendingChunks -= 1;
+                              if (pendingChunks === 0) {
+                                setPlayingMessageId(null);
+                                setSpeechLoadingId(null);
+                              }
+                            },
+                            {
+                              messageId: message.id || messageKey,
+                              start: chunk.start,
+                              end: chunk.end,
                             }
-                          });
+                          );
                         });
                       } else {
                         setPlayingMessageId(null);
@@ -1087,7 +1113,11 @@ interface ChatMessagesContentProps {
   scrollToBottomTrigger: number;
   highlightSegment?: HighlightSegment | null;
   isSpeaking?: boolean;
-  speakText: (text: string, onEnd?: () => void) => void;
+  speakText: (
+    text: string,
+    onEnd?: () => void,
+    highlight?: HighlightSegment
+  ) => void;
   stopSpeech: () => void;
   onSendMessage?: (username: string) => void;
   isLoadingGreeting?: boolean;

--- a/src/apps/chats/components/ChatMessages.tsx
+++ b/src/apps/chats/components/ChatMessages.tsx
@@ -1340,7 +1340,7 @@ function ChatMessagesContent({
     null
   );
   useEffect(() => {
-    if (!speechEnabled || isRoomView || !latestAssistantMessageKey) {
+    if (!latestAssistantMessageKey) {
       return;
     }
 
@@ -1350,7 +1350,7 @@ function ChatMessagesContent({
       RECENT_TTS_HIGHLIGHT_MS
     );
     return () => clearTimeout(timeoutId);
-  }, [isRoomView, latestAssistantMessageKey, speechEnabled]);
+  }, [latestAssistantMessageKey]);
 
   // Belt-and-suspenders: once a message key has been seen as streaming and
   // then leaves that state, lock its `isAnimating` to false forever so any

--- a/src/apps/chats/components/ChatMessages.tsx
+++ b/src/apps/chats/components/ChatMessages.tsx
@@ -214,6 +214,60 @@ const CHAT_STREAMDOWN_ANIMATED = {
   sep: "word",
 } as const;
 
+type HighlightSegment = { messageId: string; start: number; end: number };
+
+const matchesHighlightMessage = (
+  highlightSegment: HighlightSegment | null | undefined,
+  message: { id?: string },
+  messageKey: string
+) =>
+  !!highlightSegment &&
+  (highlightSegment.messageId === message.id ||
+    highlightSegment.messageId === messageKey);
+
+const getPartHighlight = (
+  highlightSegment: HighlightSegment | null | undefined,
+  message: { id?: string },
+  messageKey: string,
+  partStart: number,
+  partLength: number
+): { start: number; end: number } | null => {
+  if (!matchesHighlightMessage(highlightSegment, message, messageKey)) {
+    return null;
+  }
+
+  const start = Math.max(highlightSegment.start - partStart, 0);
+  const end = Math.min(highlightSegment.end - partStart, partLength);
+  return end > start ? { start, end } : null;
+};
+
+function SpeechHighlightedText({
+  text,
+  highlight,
+}: {
+  text: string;
+  highlight: { start: number; end: number };
+}) {
+  const leadingTrimmed = text.length - text.trimStart().length;
+  const renderedText = text.trim();
+  const start = Math.max(0, Math.min(renderedText.length, highlight.start - leadingTrimmed));
+  const end = Math.max(start, Math.min(renderedText.length, highlight.end - leadingTrimmed));
+
+  if (!renderedText || start === end) {
+    return null;
+  }
+
+  return (
+    <span className="ryos-chat-speech-text">
+      {renderedText.slice(0, start)}
+      <mark className="ryos-chat-tts-highlight">
+        {renderedText.slice(start, end)}
+      </mark>
+      {renderedText.slice(end)}
+    </span>
+  );
+}
+
 type ChatMessageStyle = CSSProperties & {
   "--ryos-chat-font-size": string;
 };
@@ -256,7 +310,7 @@ interface ChatMessagesProps {
   onMessageDeleted?: (messageId: string) => void; // Callback when a message is deleted locally
   fontSize: number; // Add font size prop
   scrollToBottomTrigger: number; // Add scroll trigger prop
-  highlightSegment?: { messageId: string; start: number; end: number } | null;
+  highlightSegment?: HighlightSegment | null;
   isSpeaking?: boolean;
   onSendMessage?: (username: string) => void; // Callback when send message button is clicked
   isLoadingGreeting?: boolean; // Show typing bubble for proactive greeting
@@ -357,6 +411,8 @@ interface ChatMessageItemProps {
   playingMessageId: string | null;
   speechLoadingId: string | null;
   speechEnabled: boolean;
+  highlightSegment?: HighlightSegment | null;
+  isSpeaking?: boolean;
   isAdmin: boolean;
   roomId?: string;
   username?: string;
@@ -390,6 +446,8 @@ const ChatMessageItem = memo(function ChatMessageItem(props: ChatMessageItemProp
     playingMessageId,
     speechLoadingId,
     speechEnabled,
+    highlightSegment,
+    isSpeaking: _isSpeaking,
     isAdmin,
     roomId: _roomId,
     username: _username,
@@ -463,6 +521,7 @@ const ChatMessageItem = memo(function ChatMessageItem(props: ChatMessageItemProp
   const decodedContent = decodeHtmlEntities(rawContent);
   const hasAquariumToken = decodedContent.includes("[[AQUARIUM]]");
   const displayContent = decodedContent.replace(/\[\[AQUARIUM\]\]/g, "").trim();
+  let assistantTextOffset = 0;
 
   let hasAquarium = false;
   if (message.role === "assistant" && message.parts) {
@@ -876,6 +935,14 @@ const ChatMessageItem = memo(function ChatMessageItem(props: ChatMessageItemProp
                         ? partText.slice(4).trimStart()
                         : partText;
                       const partDisplayContent = decodeHtmlEntities(rawPartContent);
+                      const partHighlight = getPartHighlight(
+                        highlightSegment,
+                        message,
+                        messageKey,
+                        assistantTextOffset,
+                        partDisplayContent.length
+                      );
+                      assistantTextOffset += partDisplayContent.length;
                       const textContent = partDisplayContent;
                       const streamdownContent = textContent.trim();
                       const isEmojiMessage = isEmojiOnly(textContent);
@@ -891,25 +958,32 @@ const ChatMessageItem = memo(function ChatMessageItem(props: ChatMessageItemProp
                           }
                         >
                           {streamdownContent && (
-                            <Streamdown
-                              className={`ryos-chat-streamdown ${
-                                isUrgent ? "ryos-chat-streamdown-urgent" : ""
-                              }`}
-                              components={chatStreamdownComponents}
-                              disallowedElements={STREAMDOWN_DISALLOWED_ELEMENTS}
-                              controls={false}
-                              lineNumbers={false}
-                              shikiTheme={CHAT_STREAMDOWN_SHIKI_THEME}
-                              plugins={CHAT_STREAMDOWN_PLUGINS}
-                              skipHtml
-                              unwrapDisallowed
-                              mode={isStreamingMessage ? "streaming" : "static"}
-                              animated={CHAT_STREAMDOWN_ANIMATED}
-                              isAnimating={isStreamingMessage}
-                              parseIncompleteMarkdown={isStreamingMessage}
-                            >
-                              {streamdownContent}
-                            </Streamdown>
+                            partHighlight ? (
+                              <SpeechHighlightedText
+                                text={textContent}
+                                highlight={partHighlight}
+                              />
+                            ) : (
+                              <Streamdown
+                                className={`ryos-chat-streamdown ${
+                                  isUrgent ? "ryos-chat-streamdown-urgent" : ""
+                                }`}
+                                components={chatStreamdownComponents}
+                                disallowedElements={STREAMDOWN_DISALLOWED_ELEMENTS}
+                                controls={false}
+                                lineNumbers={false}
+                                shikiTheme={CHAT_STREAMDOWN_SHIKI_THEME}
+                                plugins={CHAT_STREAMDOWN_PLUGINS}
+                                skipHtml
+                                unwrapDisallowed
+                                mode={isStreamingMessage ? "streaming" : "static"}
+                                animated={CHAT_STREAMDOWN_ANIMATED}
+                                isAnimating={isStreamingMessage}
+                                parseIncompleteMarkdown={isStreamingMessage}
+                              >
+                                {streamdownContent}
+                              </Streamdown>
+                            )
                           )}
                         </div>
                       );
@@ -1027,6 +1101,8 @@ interface ChatMessagesContentProps {
   onMessageDeleted?: (messageId: string) => void;
   fontSize: number;
   scrollToBottomTrigger: number;
+  highlightSegment?: HighlightSegment | null;
+  isSpeaking?: boolean;
   onSendMessage?: (username: string) => void;
   isLoadingGreeting?: boolean;
   typingUsers?: string[];
@@ -1045,6 +1121,8 @@ function ChatMessagesContent({
   onMessageDeleted,
   fontSize,
   scrollToBottomTrigger,
+  highlightSegment,
+  isSpeaking,
   onSendMessage,
   isLoadingGreeting,
   typingUsers,
@@ -1277,6 +1355,8 @@ function ChatMessagesContent({
             playingMessageId={playingMessageId}
             speechLoadingId={speechLoadingId}
             speechEnabled={speechEnabled}
+            highlightSegment={highlightSegment}
+            isSpeaking={isSpeaking}
             isAdmin={isAdmin}
             roomId={roomId}
             username={username}
@@ -1397,6 +1477,8 @@ export function ChatMessages({
   onMessageDeleted,
   fontSize,
   scrollToBottomTrigger,
+  highlightSegment,
+  isSpeaking,
   onSendMessage,
   isLoadingGreeting,
   typingUsers,
@@ -1425,6 +1507,8 @@ export function ChatMessages({
           onMessageDeleted={onMessageDeleted}
           fontSize={fontSize}
           scrollToBottomTrigger={scrollToBottomTrigger}
+          highlightSegment={highlightSegment}
+          isSpeaking={isSpeaking}
           onSendMessage={onSendMessage}
           isLoadingGreeting={isLoadingGreeting}
           typingUsers={typingUsers}

--- a/src/apps/chats/components/ChatMessages.tsx
+++ b/src/apps/chats/components/ChatMessages.tsx
@@ -201,6 +201,7 @@ const CHAT_STREAMDOWN_ANIMATED = {
   easing: "ease-out",
   sep: "word",
 } as const;
+const RECENT_TTS_HIGHLIGHT_MS = 10000;
 
 type HighlightSegment = { messageId: string; start: number; end: number };
 
@@ -411,6 +412,7 @@ interface ChatMessageItemProps {
   highlightSegment?: HighlightSegment | null;
   isSpeaking?: boolean;
   latestAssistantMessageKey?: string | null;
+  recentTtsMessageKey?: string | null;
   speakText: (
     text: string,
     onEnd?: () => void,
@@ -451,6 +453,7 @@ const ChatMessageItem = memo(function ChatMessageItem(props: ChatMessageItemProp
     highlightSegment,
     isSpeaking,
     latestAssistantMessageKey,
+    recentTtsMessageKey,
     speakText,
     stopSpeech,
     isAdmin,
@@ -530,7 +533,8 @@ const ChatMessageItem = memo(function ChatMessageItem(props: ChatMessageItemProp
   ) || playingMessageId === messageKey ||
     (!!isSpeaking &&
       message.role === "assistant" &&
-      latestAssistantMessageKey === messageKey);
+      latestAssistantMessageKey === messageKey) ||
+    recentTtsMessageKey === messageKey;
   let assistantTextOffset = 0;
 
   let hasAquarium = false;
@@ -1332,6 +1336,21 @@ function ChatMessagesContent({
   const latestAssistantMessageKey = latestAssistantMessage
     ? getMessageKey(latestAssistantMessage)
     : null;
+  const [recentTtsMessageKey, setRecentTtsMessageKey] = useState<string | null>(
+    null
+  );
+  useEffect(() => {
+    if (!speechEnabled || isRoomView || !latestAssistantMessageKey) {
+      return;
+    }
+
+    setRecentTtsMessageKey(latestAssistantMessageKey);
+    const timeoutId = setTimeout(
+      () => setRecentTtsMessageKey(null),
+      RECENT_TTS_HIGHLIGHT_MS
+    );
+    return () => clearTimeout(timeoutId);
+  }, [isRoomView, latestAssistantMessageKey, speechEnabled]);
 
   // Belt-and-suspenders: once a message key has been seen as streaming and
   // then leaves that state, lock its `isAnimating` to false forever so any
@@ -1395,6 +1414,7 @@ function ChatMessagesContent({
             highlightSegment={highlightSegment}
             isSpeaking={isSpeaking}
             latestAssistantMessageKey={latestAssistantMessageKey}
+            recentTtsMessageKey={recentTtsMessageKey}
             speakText={speakText}
             stopSpeech={stopSpeech}
             isAdmin={isAdmin}

--- a/src/apps/chats/components/ChatMessages.tsx
+++ b/src/apps/chats/components/ChatMessages.tsx
@@ -201,7 +201,6 @@ const CHAT_STREAMDOWN_ANIMATED = {
   easing: "ease-out",
   sep: "word",
 } as const;
-const RECENT_TTS_HIGHLIGHT_MS = 10000;
 
 type HighlightSegment = { messageId: string; start: number; end: number };
 
@@ -412,7 +411,6 @@ interface ChatMessageItemProps {
   highlightSegment?: HighlightSegment | null;
   isSpeaking?: boolean;
   latestAssistantMessageKey?: string | null;
-  recentTtsMessageKey?: string | null;
   speakText: (
     text: string,
     onEnd?: () => void,
@@ -453,7 +451,6 @@ const ChatMessageItem = memo(function ChatMessageItem(props: ChatMessageItemProp
     highlightSegment,
     isSpeaking,
     latestAssistantMessageKey,
-    recentTtsMessageKey,
     speakText,
     stopSpeech,
     isAdmin,
@@ -534,7 +531,7 @@ const ChatMessageItem = memo(function ChatMessageItem(props: ChatMessageItemProp
     (!!isSpeaking &&
       message.role === "assistant" &&
       latestAssistantMessageKey === messageKey) ||
-    recentTtsMessageKey === messageKey;
+    latestAssistantMessageKey === messageKey;
   let assistantTextOffset = 0;
 
   let hasAquarium = false;
@@ -1336,21 +1333,6 @@ function ChatMessagesContent({
   const latestAssistantMessageKey = latestSpeechMessage
     ? getMessageKey(latestSpeechMessage)
     : null;
-  const [recentTtsMessageKey, setRecentTtsMessageKey] = useState<string | null>(
-    null
-  );
-  useEffect(() => {
-    if (!latestAssistantMessageKey) {
-      return;
-    }
-
-    setRecentTtsMessageKey(latestAssistantMessageKey);
-    const timeoutId = setTimeout(
-      () => setRecentTtsMessageKey(null),
-      RECENT_TTS_HIGHLIGHT_MS
-    );
-    return () => clearTimeout(timeoutId);
-  }, [latestAssistantMessageKey]);
 
   // Belt-and-suspenders: once a message key has been seen as streaming and
   // then leaves that state, lock its `isAnimating` to false forever so any
@@ -1414,7 +1396,6 @@ function ChatMessagesContent({
             highlightSegment={highlightSegment}
             isSpeaking={isSpeaking}
             latestAssistantMessageKey={latestAssistantMessageKey}
-            recentTtsMessageKey={recentTtsMessageKey}
             speakText={speakText}
             stopSpeech={stopSpeech}
             isAdmin={isAdmin}

--- a/src/apps/chats/components/ChatMessages.tsx
+++ b/src/apps/chats/components/ChatMessages.tsx
@@ -409,6 +409,8 @@ interface ChatMessageItemProps {
   speechLoadingId: string | null;
   speechEnabled: boolean;
   highlightSegment?: HighlightSegment | null;
+  isSpeaking?: boolean;
+  latestAssistantMessageKey?: string | null;
   speakText: (
     text: string,
     onEnd?: () => void,
@@ -447,6 +449,8 @@ const ChatMessageItem = memo(function ChatMessageItem(props: ChatMessageItemProp
     speechLoadingId,
     speechEnabled,
     highlightSegment,
+    isSpeaking,
+    latestAssistantMessageKey,
     speakText,
     stopSpeech,
     isAdmin,
@@ -523,7 +527,10 @@ const ChatMessageItem = memo(function ChatMessageItem(props: ChatMessageItemProp
     highlightSegment,
     message,
     messageKey
-  );
+  ) || playingMessageId === messageKey ||
+    (!!isSpeaking &&
+      message.role === "assistant" &&
+      latestAssistantMessageKey === messageKey);
   let assistantTextOffset = 0;
 
   let hasAquarium = false;
@@ -1319,6 +1326,12 @@ function ChatMessagesContent({
   const streamingAssistantMessageKey = streamingAssistantMessage
     ? getMessageKey(streamingAssistantMessage)
     : null;
+  const latestAssistantMessage = [...messages]
+    .reverse()
+    .find((message) => message.role === "assistant");
+  const latestAssistantMessageKey = latestAssistantMessage
+    ? getMessageKey(latestAssistantMessage)
+    : null;
 
   // Belt-and-suspenders: once a message key has been seen as streaming and
   // then leaves that state, lock its `isAnimating` to false forever so any
@@ -1380,6 +1393,8 @@ function ChatMessagesContent({
             speechLoadingId={speechLoadingId}
             speechEnabled={speechEnabled}
             highlightSegment={highlightSegment}
+            isSpeaking={isSpeaking}
+            latestAssistantMessageKey={latestAssistantMessageKey}
             speakText={speakText}
             stopSpeech={stopSpeech}
             isAdmin={isAdmin}

--- a/src/apps/chats/components/ChatMessages.tsx
+++ b/src/apps/chats/components/ChatMessages.tsx
@@ -31,10 +31,13 @@ import EmojiAquarium from "@/components/shared/EmojiAquarium";
 import { useTranslation } from "react-i18next";
 import i18n from "@/lib/i18n";
 import { abortableFetch } from "@/utils/abortableFetch";
-import { decodeHtmlEntities } from "@/utils/decodeHtmlEntities";
 import { formatToolName } from "@/lib/toolInvocationDisplay";
 import { segmentChatMarkdownText } from "@/lib/chatMarkdown";
 import { cleanTextForSpeech } from "../utils/textForSpeech";
+import {
+  getChatMessageText,
+  getDisplayTextPart,
+} from "../utils/messageText";
 
 // Helper to extract image URLs from message parts
 const extractImageParts = (message: {
@@ -153,26 +156,12 @@ const getAppName = (id?: string): string => {
   }
 };
 
-// Helper to extract text content from v5 UIMessage parts
-const getMessageText = (message: {
-  parts?: Array<{ type: string; text?: string }>;
-}): string => {
-  if (!message.parts) return "";
-
-  return message.parts.reduce<string[]>((acc, part) => {
-    if (part.type === "text") {
-      acc.push((part as { type: string; text?: string }).text || "");
-    }
-    return acc;
-  }, []).join("");
-};
-
 const getMessageKey = (message: {
   id?: string;
   role: string;
   parts?: Array<{ type: string; text?: string }>;
 }): string => {
-  const messageText = getMessageText(message);
+  const messageText = getChatMessageText(message);
   return message.id === "1" || message.id === "proactive-1"
     ? "greeting"
     : message.id || `${message.role}-${messageText.substring(0, 10)}`;
@@ -501,7 +490,7 @@ const ChatMessageItem = memo(function ChatMessageItem(props: ChatMessageItemProp
     []
   );
 
-  let messageText = getMessageText(message);
+  let messageText = getChatMessageText(message);
   const isStaticGreeting = message.role === "assistant" && message.id === "1";
   if (isStaticGreeting && !messageText) {
     messageText = t("apps.chats.messages.greeting");
@@ -518,10 +507,9 @@ const ChatMessageItem = memo(function ChatMessageItem(props: ChatMessageItemProp
   else if (message.role === "human")
     bgColorClass = getUserColorClass(message.username);
 
-  const rawContent = isUrgent ? messageText.slice(4).trimStart() : messageText;
-  const decodedContent = decodeHtmlEntities(rawContent);
-  const hasAquariumToken = decodedContent.includes("[[AQUARIUM]]");
-  const displayContent = decodedContent.replace(/\[\[AQUARIUM\]\]/g, "").trim();
+  const displayText = getDisplayTextPart(messageText);
+  const hasAquariumToken = displayText.includes("[[AQUARIUM]]");
+  const displayContent = displayText.replace(/\[\[AQUARIUM\]\]/g, "").trim();
   let assistantTextOffset = 0;
 
   let hasAquarium = false;
@@ -932,10 +920,7 @@ const ChatMessageItem = memo(function ChatMessageItem(props: ChatMessageItemProp
                           );
                         }
                       }
-                      const rawPartContent = isUrgentMessage(partText)
-                        ? partText.slice(4).trimStart()
-                        : partText;
-                      const partDisplayContent = decodeHtmlEntities(rawPartContent);
+                      const partDisplayContent = getDisplayTextPart(partText);
                       const partHighlight = getPartHighlight(
                         highlightSegment,
                         message,
@@ -1055,10 +1040,7 @@ const ChatMessageItem = memo(function ChatMessageItem(props: ChatMessageItemProp
               if (part.type === "text") {
                 const partText =
                   (part as { type: string; text?: string }).text || "";
-                const partContent = isUrgentMessage(partText)
-                  ? partText.slice(4).trimStart()
-                  : partText;
-                extractUrls(decodeHtmlEntities(partContent)).forEach((u) =>
+                extractUrls(getDisplayTextPart(partText)).forEach((u) =>
                   allUrls.add(u)
                 );
               }
@@ -1157,14 +1139,14 @@ function ChatMessagesContent({
     ) {
       const previousIds = new Set(
         previousMessagesRef.current.map(
-          (m) => m.id || `${m.role}-${getMessageText(m).substring(0, 10)}`
+          (m) => m.id || `${m.role}-${getChatMessageText(m).substring(0, 10)}`
         )
       );
       const newMessages = messages.filter(
         (currentMsg) =>
           !previousIds.has(
             currentMsg.id ||
-              `${currentMsg.role}-${getMessageText(currentMsg).substring(
+              `${currentMsg.role}-${getChatMessageText(currentMsg).substring(
                 0,
                 10
               )}`
@@ -1210,7 +1192,7 @@ function ChatMessagesContent({
   }, [isSpeaking, speechLoadingId]);
 
   const copyMessage = useCallback(async (message: ChatMessage) => {
-    const messageText = getMessageText(message);
+    const messageText = getChatMessageText(message);
     try {
       await navigator.clipboard.writeText(messageText);
       setCopiedMessageId(

--- a/src/apps/chats/components/ChatMessages.tsx
+++ b/src/apps/chats/components/ChatMessages.tsx
@@ -220,7 +220,10 @@ const getPartHighlight = (
   partStart: number,
   partLength: number
 ): { start: number; end: number } | null => {
-  if (!matchesHighlightMessage(highlightSegment, message, messageKey)) {
+  if (
+    !highlightSegment ||
+    !matchesHighlightMessage(highlightSegment, message, messageKey)
+  ) {
     return null;
   }
 
@@ -402,7 +405,6 @@ interface ChatMessageItemProps {
   speechLoadingId: string | null;
   speechEnabled: boolean;
   highlightSegment?: HighlightSegment | null;
-  isSpeaking?: boolean;
   speakText: (text: string, onEnd?: () => void) => void;
   stopSpeech: () => void;
   isAdmin: boolean;
@@ -437,7 +439,6 @@ const ChatMessageItem = memo(function ChatMessageItem(props: ChatMessageItemProp
     speechLoadingId,
     speechEnabled,
     highlightSegment,
-    isSpeaking,
     speakText,
     stopSpeech,
     isAdmin,
@@ -1342,7 +1343,6 @@ function ChatMessagesContent({
             speechLoadingId={speechLoadingId}
             speechEnabled={speechEnabled}
             highlightSegment={highlightSegment}
-            isSpeaking={isSpeaking}
             speakText={speakText}
             stopSpeech={stopSpeech}
             isAdmin={isAdmin}

--- a/src/apps/chats/components/ChatMessages.tsx
+++ b/src/apps/chats/components/ChatMessages.tsx
@@ -923,7 +923,12 @@ const ChatMessageItem = memo(function ChatMessageItem(props: ChatMessageItemProp
           } ${
             isTtsHighlighted ? "ryos-chat-tts-bubble-active" : ""
           } w-fit max-w-[90%] min-h-[12px] rounded leading-snug font-geneva-12 break-words select-text`}
-          style={getChatMessageStyle(fontSize)}
+          style={{
+            ...getChatMessageStyle(fontSize),
+            ...(isTtsHighlighted
+              ? { backgroundColor: "#fde047", color: "#111827" }
+              : {}),
+          }}
         >
           {showTypingDots ? (
             <TypingDots />

--- a/src/apps/chats/components/ChatsAppComponent.tsx
+++ b/src/apps/chats/components/ChatsAppComponent.tsx
@@ -68,6 +68,8 @@ export function ChatsAppComponent({
     error,
     stop,
     isSpeaking,
+    speakText,
+    stopSpeech,
     handleDirectMessageSubmit,
     handleNudge,
     handleSaveTranscript,
@@ -828,6 +830,8 @@ export function ChatsAppComponent({
                     scrollToBottomTrigger={scrollToBottomTrigger}
                     highlightSegment={highlightSegment}
                     isSpeaking={isSpeaking}
+                    speakText={speakText}
+                    stopSpeech={stopSpeech}
                     onSendMessage={handleSendMessage}
                     isLoadingGreeting={isLoadingGreeting}
                     typingUsers={currentRoomTypingUsers}

--- a/src/apps/chats/hooks/useAiChat.ts
+++ b/src/apps/chats/hooks/useAiChat.ts
@@ -2696,11 +2696,24 @@ export function useAiChat(onPromptSetUsername?: () => void) {
     [username, saveFile, launchApp],
   );
 
+  const stopSpeech = useCallback(() => {
+    stopTts();
+    highlightQueueRef.current = [];
+    setHighlightSegment(null);
+  }, [stopTts]);
+
+  const speakText = useCallback(
+    (text: string, onEnd?: () => void) => {
+      speak(text, onEnd);
+    },
+    [speak],
+  );
+
   // Stop both chat streaming and TTS queue
   const stop = useCallback(() => {
     sdkStop();
-    stopTts();
-  }, [sdkStop, stopTts]);
+    stopSpeech();
+  }, [sdkStop, stopSpeech]);
 
   return {
     // AI Chat State & Actions
@@ -2739,6 +2752,8 @@ export function useAiChat(onPromptSetUsername?: () => void) {
     handleSaveSubmit,
 
     isSpeaking,
+    speakText,
+    stopSpeech,
 
     highlightSegment,
   };

--- a/src/apps/chats/hooks/useAiChat.ts
+++ b/src/apps/chats/hooks/useAiChat.ts
@@ -31,7 +31,6 @@ import {
   type DocumentContent,
 } from "@/apps/finder/hooks/useFileSystem";
 import { STORES } from "@/utils/indexedDB";
-import { useTtsQueue } from "@/hooks/useTtsQueue";
 import { useTextEditStore } from "@/stores/useTextEditStore";
 import { useFilesStore } from "@/stores/useFilesStore";
 import { useLanguageStore } from "@/stores/useLanguageStore";
@@ -54,8 +53,11 @@ import {
   persistChatApplet,
   persistChatDocument,
 } from "../utils/chatFilePersistence";
-import { cleanTextForSpeech } from "../utils/textForSpeech";
 import { getAssistantVisibleText } from "../utils/messageText";
+import {
+  useChatSpeech,
+  type ChatSpeechControls,
+} from "./useChatSpeech";
 import {
   handleLaunchApp,
   handleCloseApp,
@@ -694,37 +696,7 @@ export function useAiChat(onPromptSetUsername?: () => void) {
     setSelectedImage(imageData);
   }, []);
 
-  // Track how many characters of each assistant message have already been sent to TTS
-  const speechProgressRef = useRef<Record<string, number>>({});
-
-  // Currently highlighted chunk for UI animation
-  const [highlightSegment, setHighlightSegment] = useState<{
-    messageId: string;
-    start: number;
-    end: number;
-  } | null>(null);
-
-  // Queue of upcoming highlight segments awaiting playback completion
-  const highlightQueueRef = useRef<
-    {
-      messageId: string;
-      start: number;
-      end: number;
-    }[]
-  >([]);
-
-  // On first mount, mark any assistant messages already present as fully processed
-  useEffect(() => {
-    aiMessages.forEach((msg) => {
-      if (msg.role === "assistant") {
-        const content = getAssistantVisibleText(msg);
-        speechProgressRef.current[msg.id] = content.length; // mark as fully processed
-      }
-    });
-  }, [aiMessages]);
-
-  // Queue-based TTS – speaks chunks as they arrive
-  const { speak, stop: stopTts, isSpeaking } = useTtsQueue();
+  const chatSpeechRef = useRef<ChatSpeechControls | null>(null);
 
   // Rate limit state
   const [rateLimitError, setRateLimitError] = useState<{
@@ -746,10 +718,6 @@ export function useAiChat(onPromptSetUsername?: () => void) {
   }, []);
 
   // --- AI Chat Hook (Vercel AI SDK v5) ---
-  // Store reference to setHighlightSegment for use in callbacks
-  const setHighlightSegmentRef = useRef(setHighlightSegment);
-  setHighlightSegmentRef.current = setHighlightSegment;
-
   const {
     messages: currentSdkMessages,
     status,
@@ -2004,50 +1972,7 @@ export function useAiChat(onPromptSetUsername?: () => void) {
         showBackgroundedMessageNotification(lastMsg);
       }
 
-      // Ensure any final content that wasn't processed is spoken
-      if (!speechEnabled) return;
-
-      const progress = speechProgressRef.current[lastMsg.id] ?? 0;
-      const content = getAssistantVisibleText(lastMsg);
-
-      console.log(
-        `[onFinish] Progress: ${progress}, Content length: ${content.length}`,
-      );
-
-      // If there's unprocessed content, speak it now
-      if (progress < content.length) {
-        const remainingRaw = content.slice(progress);
-        const cleaned = cleanTextForSpeech(remainingRaw);
-        console.log(`[onFinish] Speaking final content: "${cleaned}"`);
-
-        if (cleaned) {
-          const seg = {
-            messageId: lastMsg.id,
-            start: progress,
-            end: content.length,
-          };
-          highlightQueueRef.current.push(seg);
-
-          // Use ref to get current setHighlightSegment function
-          if (highlightQueueRef.current.length === 1) {
-            setTimeout(() => {
-              if (highlightQueueRef.current[0] === seg) {
-                setHighlightSegmentRef.current(seg);
-              }
-            }, 80);
-          }
-
-          speak(cleaned, () => {
-            highlightQueueRef.current.shift();
-            setHighlightSegmentRef.current(
-              highlightQueueRef.current[0] || null,
-            );
-          });
-
-          // Mark as fully processed
-          speechProgressRef.current[lastMsg.id] = content.length;
-        }
-      }
+      chatSpeechRef.current?.speakFinalMessage(lastMsg);
     },
 
     onError: (err) => {
@@ -2212,81 +2137,21 @@ export function useAiChat(onPromptSetUsername?: () => void) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [aiMessages, setSdkMessages]); // Only run when aiMessages changes
 
-  // --- Incremental TTS while assistant reply is streaming ---
   const isLoading = status === "streaming" || status === "submitted";
-
-  useEffect(() => {
-    if (!speechEnabled) return;
-
-    // Only process while streaming is active
-    if (!isLoading) return;
-
-    const lastMsg = currentSdkMessages.at(-1);
-    if (!lastMsg || lastMsg.role !== "assistant") return;
-
-    // Get current progress for this message
-    const progress =
-      typeof speechProgressRef.current[lastMsg.id] === "number"
-        ? (speechProgressRef.current[lastMsg.id] as number)
-        : 0;
-
-    // Use helper function to get actual visible text
-    const content = getAssistantVisibleText(lastMsg);
-
-    // IMPORTANT: Handle multi-step tool calls
-    // If progress equals content length, this message was previously complete
-    // but if content.length has grown, we have new content to speak
-    if (progress >= content.length) return;
-
-    let scanPos = progress;
-    const highlightTimeoutIds: ReturnType<typeof setTimeout>[] = [];
-    const processChunk = (endPos: number) => {
-      const rawChunk = content.slice(scanPos, endPos);
-      const cleaned = cleanTextForSpeech(rawChunk);
-      if (cleaned) {
-        const seg = { messageId: lastMsg.id, start: scanPos, end: endPos };
-        highlightQueueRef.current.push(seg);
-        if (!highlightSegment) {
-          // Delay highlighting slightly so text sync aligns closer to actual speech start
-          const highlightTimeoutId = setTimeout(() => {
-            if (highlightQueueRef.current[0] === seg) {
-              setHighlightSegment(seg);
-            }
-          }, 80);
-          highlightTimeoutIds.push(highlightTimeoutId);
-        }
-
-        speak(cleaned, () => {
-          highlightQueueRef.current.shift();
-          setHighlightSegment(highlightQueueRef.current[0] || null);
-        });
-      }
-      scanPos = endPos;
-      speechProgressRef.current[lastMsg.id] = scanPos;
-    };
-
-    // Iterate over any *completed* lines since the last progress marker.
-    while (scanPos < content.length) {
-      const nextNlIdx = content.indexOf("\n", scanPos);
-      if (nextNlIdx === -1) {
-        // No further newlines - wait for more content or let onFinish handle the rest
-        break;
-      }
-
-      // We have a newline that marks the end of a full chunk.
-      processChunk(nextNlIdx);
-
-      // Skip the newline (and potential carriage-return) characters.
-      scanPos = nextNlIdx + 1;
-      if (content[scanPos] === "\r") scanPos += 1;
-
-      // Record updated progress so subsequent effect runs start after the newline
-      speechProgressRef.current[lastMsg.id] = scanPos;
-    }
-    return () => {
-      highlightTimeoutIds.forEach((timeoutId) => clearTimeout(timeoutId));
-    };
-  }, [currentSdkMessages, isLoading, speechEnabled, speak, highlightSegment]);
+  const chatSpeech = useChatSpeech({
+    aiMessages,
+    currentMessages: currentSdkMessages as UIMessage[],
+    isLoading,
+    speechEnabled,
+  });
+  chatSpeechRef.current = chatSpeech;
+  const {
+    highlightSegment,
+    isSpeaking,
+    speakText,
+    stopSpeech,
+    resetSpeech,
+  } = chatSpeech;
 
   // Clear rate limit error when username is set
   useEffect(() => {
@@ -2522,17 +2387,6 @@ export function useAiChat(onPromptSetUsername?: () => void) {
 
     }
 
-    // --- Reset speech & highlight state so the next reply starts clean ---
-    // Stop any ongoing TTS playback or pending requests
-    stopTts();
-
-    // Clear progress tracking so new messages are treated as fresh
-    speechProgressRef.current = {};
-
-    // Reset highlight queue & currently highlighted segment
-    highlightQueueRef.current = [];
-    setHighlightSegment(null);
-
     // Define the initial message and mark it as fully processed so it is never spoken
     const initialMessage: AIChatMessage = {
       id: "1", // Ensure consistent ID for the initial message
@@ -2542,13 +2396,12 @@ export function useAiChat(onPromptSetUsername?: () => void) {
         createdAt: new Date(),
       },
     };
-    const initialText = getAssistantVisibleText(initialMessage);
-    speechProgressRef.current[initialMessage.id] = initialText.length;
+    resetSpeech(initialMessage);
 
     // Update both the Zustand store and the SDK state directly
     setAiMessages([initialMessage]);
     setSdkMessages([initialMessage]);
-  }, [setAiMessages, setSdkMessages, stopTts, aiMessages, username, isAuthenticated]);
+  }, [setAiMessages, setSdkMessages, resetSpeech, aiMessages, username, isAuthenticated]);
 
   const confirmClearChats = useCallback(() => {
     setIsClearDialogOpen(false);
@@ -2669,19 +2522,6 @@ export function useAiChat(onPromptSetUsername?: () => void) {
       }
     },
     [username, saveFile, launchApp],
-  );
-
-  const stopSpeech = useCallback(() => {
-    stopTts();
-    highlightQueueRef.current = [];
-    setHighlightSegment(null);
-  }, [stopTts]);
-
-  const speakText = useCallback(
-    (text: string, onEnd?: () => void) => {
-      speak(text, onEnd);
-    },
-    [speak],
   );
 
   // Stop both chat streaming and TTS queue

--- a/src/apps/chats/hooks/useAiChat.ts
+++ b/src/apps/chats/hooks/useAiChat.ts
@@ -55,6 +55,7 @@ import {
   persistChatDocument,
 } from "../utils/chatFilePersistence";
 import { cleanTextForSpeech } from "../utils/textForSpeech";
+import { getAssistantVisibleText } from "../utils/messageText";
 import {
   handleLaunchApp,
   handleCloseApp,
@@ -573,32 +574,6 @@ const getSystemState = () => {
       instances: textEditInstancesData,
     },
   };
-};
-
-// Helper function to extract visible text from message parts
-const getAssistantVisibleText = (message: UIMessage): string => {
-  // Define type for message parts
-  type MessagePart = {
-    type: string;
-    text?: string;
-  };
-
-  // If message has parts, extract text from text parts only
-  if (message.parts && message.parts.length > 0) {
-    return message.parts.reduce<string[]>((acc, part: MessagePart) => {
-        if (part.type !== "text") {
-          return acc;
-        }
-        const text = part.text || "";
-        // Handle urgent messages by removing leading !!!!
-        acc.push(text.startsWith("!!!!") ? text.slice(4).trimStart() : text);
-        return acc;
-      }, [])
-      .join("");
-  }
-
-  // Fallback - no content property in v5, return empty string
-  return "";
 };
 
 // Helper to check if chats app is currently in the foreground

--- a/src/apps/chats/hooks/useChatSpeech.ts
+++ b/src/apps/chats/hooks/useChatSpeech.ts
@@ -1,0 +1,208 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { UIMessage } from "@ai-sdk/react";
+import { useTtsQueue } from "@/hooks/useTtsQueue";
+import { cleanTextForSpeech } from "../utils/textForSpeech";
+import { getAssistantVisibleText } from "../utils/messageText";
+
+export type ChatHighlightSegment = {
+  messageId: string;
+  start: number;
+  end: number;
+};
+
+export type ChatSpeechControls = {
+  highlightSegment: ChatHighlightSegment | null;
+  isSpeaking: boolean;
+  speakText: (text: string, onEnd?: () => void) => void;
+  stopSpeech: () => void;
+  speakFinalMessage: (message: UIMessage) => void;
+  resetSpeech: (initialMessage?: UIMessage) => void;
+};
+
+export function useChatSpeech({
+  aiMessages,
+  currentMessages,
+  isLoading,
+  speechEnabled,
+}: {
+  aiMessages: UIMessage[];
+  currentMessages: UIMessage[];
+  isLoading: boolean;
+  speechEnabled: boolean;
+}): ChatSpeechControls {
+  const speechProgressRef = useRef<Record<string, number>>({});
+  const highlightQueueRef = useRef<ChatHighlightSegment[]>([]);
+  const initializedHistoryRef = useRef(false);
+  const [highlightSegment, setHighlightSegment] =
+    useState<ChatHighlightSegment | null>(null);
+  const highlightSegmentRef = useRef<ChatHighlightSegment | null>(null);
+  const { speak, stop: stopTts, isSpeaking } = useTtsQueue();
+
+  useEffect(() => {
+    highlightSegmentRef.current = highlightSegment;
+  }, [highlightSegment]);
+
+  useEffect(() => {
+    if (initializedHistoryRef.current || aiMessages.length === 0) {
+      return;
+    }
+
+    aiMessages.forEach((msg) => {
+      if (msg.role === "assistant") {
+        speechProgressRef.current[msg.id] = getAssistantVisibleText(msg).length;
+      }
+    });
+    initializedHistoryRef.current = true;
+  }, [aiMessages]);
+
+  const showQueuedHighlight = useCallback((segment: ChatHighlightSegment) => {
+    if (highlightSegmentRef.current) {
+      return undefined;
+    }
+
+    const timeoutId = setTimeout(() => {
+      if (highlightQueueRef.current[0] === segment) {
+        setHighlightSegment(segment);
+      }
+    }, 80);
+
+    return timeoutId;
+  }, []);
+
+  const queueSpeechSegment = useCallback(
+    (
+      messageId: string,
+      start: number,
+      end: number,
+      rawText: string,
+      timeoutIds?: ReturnType<typeof setTimeout>[]
+    ) => {
+      const cleaned = cleanTextForSpeech(rawText);
+      if (!cleaned) {
+        return false;
+      }
+
+      const segment = { messageId, start, end };
+      highlightQueueRef.current.push(segment);
+      const timeoutId = showQueuedHighlight(segment);
+      if (timeoutId && timeoutIds) {
+        timeoutIds.push(timeoutId);
+      }
+
+      speak(cleaned, () => {
+        highlightQueueRef.current.shift();
+        setHighlightSegment(highlightQueueRef.current[0] || null);
+      });
+
+      return true;
+    },
+    [showQueuedHighlight, speak]
+  );
+
+  const speakFinalMessage = useCallback(
+    (message: UIMessage) => {
+      if (!speechEnabled || message.role !== "assistant") {
+        return;
+      }
+
+      const progress = speechProgressRef.current[message.id] ?? 0;
+      const content = getAssistantVisibleText(message);
+      if (progress >= content.length) {
+        return;
+      }
+
+      queueSpeechSegment(
+        message.id,
+        progress,
+        content.length,
+        content.slice(progress)
+      );
+      speechProgressRef.current[message.id] = content.length;
+    },
+    [queueSpeechSegment, speechEnabled]
+  );
+
+  useEffect(() => {
+    if (!speechEnabled || !isLoading) {
+      return;
+    }
+
+    const lastMsg = currentMessages.at(-1);
+    if (!lastMsg || lastMsg.role !== "assistant") {
+      return;
+    }
+
+    const progress =
+      typeof speechProgressRef.current[lastMsg.id] === "number"
+        ? speechProgressRef.current[lastMsg.id]
+        : 0;
+    const content = getAssistantVisibleText(lastMsg);
+    if (progress >= content.length) {
+      return;
+    }
+
+    let scanPos = progress;
+    const timeoutIds: ReturnType<typeof setTimeout>[] = [];
+    const processChunk = (endPos: number) => {
+      queueSpeechSegment(
+        lastMsg.id,
+        scanPos,
+        endPos,
+        content.slice(scanPos, endPos),
+        timeoutIds
+      );
+      scanPos = endPos;
+      speechProgressRef.current[lastMsg.id] = scanPos;
+    };
+
+    while (scanPos < content.length) {
+      const nextNlIdx = content.indexOf("\n", scanPos);
+      if (nextNlIdx === -1) {
+        break;
+      }
+
+      processChunk(nextNlIdx);
+      scanPos = nextNlIdx + 1;
+      if (content[scanPos] === "\r") scanPos += 1;
+      speechProgressRef.current[lastMsg.id] = scanPos;
+    }
+
+    return () => {
+      timeoutIds.forEach((timeoutId) => clearTimeout(timeoutId));
+    };
+  }, [currentMessages, isLoading, queueSpeechSegment, speechEnabled]);
+
+  const stopSpeech = useCallback(() => {
+    stopTts();
+    highlightQueueRef.current = [];
+    setHighlightSegment(null);
+  }, [stopTts]);
+
+  const resetSpeech = useCallback(
+    (initialMessage?: UIMessage) => {
+      stopSpeech();
+      speechProgressRef.current = {};
+      if (initialMessage?.role === "assistant") {
+        speechProgressRef.current[initialMessage.id] =
+          getAssistantVisibleText(initialMessage).length;
+      }
+    },
+    [stopSpeech]
+  );
+
+  const speakText = useCallback(
+    (text: string, onEnd?: () => void) => {
+      speak(text, onEnd);
+    },
+    [speak]
+  );
+
+  return {
+    highlightSegment,
+    isSpeaking,
+    speakText,
+    stopSpeech,
+    speakFinalMessage,
+    resetSpeech,
+  };
+}

--- a/src/apps/chats/hooks/useChatSpeech.ts
+++ b/src/apps/chats/hooks/useChatSpeech.ts
@@ -4,6 +4,8 @@ import { useTtsQueue } from "@/hooks/useTtsQueue";
 import { cleanTextForSpeech } from "../utils/textForSpeech";
 import { getAssistantVisibleText } from "../utils/messageText";
 
+const HIGHLIGHT_CLEAR_DELAY_MS = 2000;
+
 export type ChatHighlightSegment = {
   messageId: string;
   start: number;
@@ -95,9 +97,11 @@ export function useChatSpeech({
       }
 
       speak(cleaned, () => {
-        highlightQueueRef.current.shift();
-        setHighlightSegment(highlightQueueRef.current[0] || null);
-        onEnd?.();
+        setTimeout(() => {
+          highlightQueueRef.current.shift();
+          setHighlightSegment(highlightQueueRef.current[0] || null);
+          onEnd?.();
+        }, HIGHLIGHT_CLEAR_DELAY_MS);
       });
 
       return true;

--- a/src/apps/chats/hooks/useChatSpeech.ts
+++ b/src/apps/chats/hooks/useChatSpeech.ts
@@ -13,7 +13,11 @@ export type ChatHighlightSegment = {
 export type ChatSpeechControls = {
   highlightSegment: ChatHighlightSegment | null;
   isSpeaking: boolean;
-  speakText: (text: string, onEnd?: () => void) => void;
+  speakText: (
+    text: string,
+    onEnd?: () => void,
+    highlight?: ChatHighlightSegment
+  ) => void;
   stopSpeech: () => void;
   speakFinalMessage: (message: UIMessage) => void;
   resetSpeech: (initialMessage?: UIMessage) => void;
@@ -75,7 +79,8 @@ export function useChatSpeech({
       start: number,
       end: number,
       rawText: string,
-      timeoutIds?: ReturnType<typeof setTimeout>[]
+      timeoutIds?: ReturnType<typeof setTimeout>[],
+      onEnd?: () => void
     ) => {
       const cleaned = cleanTextForSpeech(rawText);
       if (!cleaned) {
@@ -92,6 +97,7 @@ export function useChatSpeech({
       speak(cleaned, () => {
         highlightQueueRef.current.shift();
         setHighlightSegment(highlightQueueRef.current[0] || null);
+        onEnd?.();
       });
 
       return true;
@@ -191,10 +197,26 @@ export function useChatSpeech({
   );
 
   const speakText = useCallback(
-    (text: string, onEnd?: () => void) => {
+    (
+      text: string,
+      onEnd?: () => void,
+      highlight?: ChatHighlightSegment
+    ) => {
+      if (highlight) {
+        queueSpeechSegment(
+          highlight.messageId,
+          highlight.start,
+          highlight.end,
+          text,
+          undefined,
+          onEnd
+        );
+        return;
+      }
+
       speak(text, onEnd);
     },
-    [speak]
+    [queueSpeechSegment, speak]
   );
 
   return {

--- a/src/apps/chats/hooks/useChatSpeech.ts
+++ b/src/apps/chats/hooks/useChatSpeech.ts
@@ -4,7 +4,7 @@ import { useTtsQueue } from "@/hooks/useTtsQueue";
 import { cleanTextForSpeech } from "../utils/textForSpeech";
 import { getAssistantVisibleText } from "../utils/messageText";
 
-const HIGHLIGHT_CLEAR_DELAY_MS = 2000;
+const HIGHLIGHT_CLEAR_DELAY_MS = 6000;
 
 export type ChatHighlightSegment = {
   messageId: string;

--- a/src/apps/chats/utils/messageText.ts
+++ b/src/apps/chats/utils/messageText.ts
@@ -1,0 +1,53 @@
+import { decodeHtmlEntities } from "@/utils/decodeHtmlEntities";
+
+export type ChatTextPart = {
+  type: string;
+  text?: string;
+};
+
+export type ChatTextMessage = {
+  parts?: ChatTextPart[];
+};
+
+export function stripUrgentPrefix(text: string): string {
+  return text.startsWith("!!!!") ? text.slice(4).trimStart() : text;
+}
+
+export function getChatMessageText(
+  message: ChatTextMessage,
+  options: {
+    stripUrgentPrefixes?: boolean;
+    decodeEntities?: boolean;
+  } = {}
+): string {
+  if (!message.parts) return "";
+
+  return message.parts
+    .reduce<string[]>((acc, part) => {
+      if (part.type !== "text") {
+        return acc;
+      }
+
+      let text = part.text || "";
+      if (options.stripUrgentPrefixes) {
+        text = stripUrgentPrefix(text);
+      }
+      if (options.decodeEntities) {
+        text = decodeHtmlEntities(text);
+      }
+      acc.push(text);
+      return acc;
+    }, [])
+    .join("");
+}
+
+export function getAssistantVisibleText(message: ChatTextMessage): string {
+  return getChatMessageText(message, {
+    stripUrgentPrefixes: true,
+    decodeEntities: true,
+  });
+}
+
+export function getDisplayTextPart(text: string): string {
+  return decodeHtmlEntities(stripUrgentPrefix(text));
+}

--- a/src/index.css
+++ b/src/index.css
@@ -845,6 +845,12 @@ button.piano-key.piano-key[class*="bg-[#ff33ff]"] {
     box-shadow: 0 0 0 1px rgba(128, 94, 0, 0.2);
   }
 
+  .ryos-chat-tts-bubble-active {
+    box-shadow:
+      0 0 0 2px rgba(255, 218, 48, 0.95),
+      0 0 10px rgba(255, 218, 48, 0.45);
+  }
+
   /* Draggable area styles - prevents browser gestures on touch devices */
   .draggable-area {
     touch-action: none !important;

--- a/src/index.css
+++ b/src/index.css
@@ -846,7 +846,21 @@ button.piano-key.piano-key[class*="bg-[#ff33ff]"] {
   }
 
   .ryos-chat-tts-bubble-active {
+    outline: 2px solid rgba(255, 218, 48, 0.95);
+    outline-offset: 1px;
     box-shadow:
+      0 0 0 2px rgba(255, 218, 48, 0.95),
+      0 0 10px rgba(255, 218, 48, 0.45);
+  }
+
+  :root[data-os-theme="macosx"] .chat-bubble.ryos-chat-tts-bubble-active {
+    box-shadow:
+      0 2px 4px rgba(0, 0, 0, 0.14),
+      0 1px 1px rgba(0, 0, 0, 0.25),
+      inset 0 1px 2px rgba(255, 255, 255, 0.6),
+      inset 0 0 4px rgba(0, 0, 0, 0.05),
+      inset 0 0 0 0.5px rgba(0, 0, 0, 0.48),
+      inset 0 0 0 1px rgba(0, 0, 0, 0.08),
       0 0 0 2px rgba(255, 218, 48, 0.95),
       0 0 10px rgba(255, 218, 48, 0.45);
   }

--- a/src/index.css
+++ b/src/index.css
@@ -853,18 +853,6 @@ button.piano-key.piano-key[class*="bg-[#ff33ff]"] {
       0 0 10px rgba(255, 218, 48, 0.45);
   }
 
-  :root[data-os-theme="macosx"] .chat-bubble.ryos-chat-tts-bubble-active {
-    box-shadow:
-      0 2px 4px rgba(0, 0, 0, 0.14),
-      0 1px 1px rgba(0, 0, 0, 0.25),
-      inset 0 1px 2px rgba(255, 255, 255, 0.6),
-      inset 0 0 4px rgba(0, 0, 0, 0.05),
-      inset 0 0 0 0.5px rgba(0, 0, 0, 0.48),
-      inset 0 0 0 1px rgba(0, 0, 0, 0.08),
-      0 0 0 2px rgba(255, 218, 48, 0.95),
-      0 0 10px rgba(255, 218, 48, 0.45);
-  }
-
   /* Draggable area styles - prevents browser gestures on touch devices */
   .draggable-area {
     touch-action: none !important;

--- a/src/index.css
+++ b/src/index.css
@@ -830,6 +830,21 @@ button.piano-key.piano-key[class*="bg-[#ff33ff]"] {
     color: inherit;
   }
 
+  .ryos-chat-speech-text {
+    display: inline;
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
+    user-select: text;
+    -webkit-user-select: text;
+  }
+
+  .ryos-chat-tts-highlight {
+    border-radius: 2px;
+    background: rgba(255, 236, 83, 0.85);
+    color: inherit;
+    box-shadow: 0 0 0 1px rgba(128, 94, 0, 0.2);
+  }
+
   /* Draggable area styles - prevents browser gestures on touch devices */
   .draggable-area {
     touch-action: none !important;

--- a/src/styles/themes.css
+++ b/src/styles/themes.css
@@ -2712,7 +2712,6 @@
 
 :root[data-os-theme="macosx"] .chat-bubble.ryos-chat-tts-bubble-active {
   overflow: visible;
-  background-color: #fde047 !important;
   color: #111827 !important;
   outline: 2px solid rgba(255, 218, 48, 0.95);
   outline-offset: 1px;
@@ -2810,6 +2809,10 @@
 }
 :root[data-os-theme="macosx"] .chat-bubble.bg-gray-100 {
   background-color: #e5e7eb !important; /* gray-200 */
+}
+
+:root[data-os-theme="macosx"] .chat-bubble.ryos-chat-tts-bubble-active {
+  background-color: #fde047 !important;
 }
 
 :root[data-os-theme="macosx"] .macosx-link-preview.chat-bubble:before {

--- a/src/styles/themes.css
+++ b/src/styles/themes.css
@@ -2712,6 +2712,8 @@
 
 :root[data-os-theme="macosx"] .chat-bubble.ryos-chat-tts-bubble-active {
   overflow: visible;
+  background-color: #fde047 !important;
+  color: #111827 !important;
   outline: 2px solid rgba(255, 218, 48, 0.95);
   outline-offset: 1px;
   box-shadow:

--- a/src/styles/themes.css
+++ b/src/styles/themes.css
@@ -2710,6 +2710,21 @@
   ) !important; /* allow dynamic sizing */
 }
 
+:root[data-os-theme="macosx"] .chat-bubble.ryos-chat-tts-bubble-active {
+  overflow: visible;
+  outline: 2px solid rgba(255, 218, 48, 0.95);
+  outline-offset: 1px;
+  box-shadow:
+    0 2px 4px rgba(0, 0, 0, 0.14),
+    0 1px 1px rgba(0, 0, 0, 0.25),
+    inset 0 1px 2px rgba(255, 255, 255, 0.6),
+    inset 0 0 4px rgba(0, 0, 0, 0.05),
+    inset 0 0 0 0.5px rgba(0, 0, 0, 0.48),
+    inset 0 0 0 1px rgba(0, 0, 0, 0.08),
+    0 0 0 2px rgba(255, 218, 48, 0.95),
+    0 0 10px rgba(255, 218, 48, 0.45);
+}
+
 /* -------------------------------------------------- */
 /* System 7 chat bubble typography tweaks */
 /* -------------------------------------------------- */

--- a/tests/test-chat-speech-text.test.ts
+++ b/tests/test-chat-speech-text.test.ts
@@ -49,6 +49,20 @@ describe("chat speech wiring", () => {
     expect(source.includes("ryos-chat-tts-bubble-active")).toBe(true);
   });
 
+  test("chat TTS active bubble outline survives macOS chat bubble shadows", () => {
+    const source = readSource("src/index.css");
+
+    expect(source.includes(".ryos-chat-tts-bubble-active")).toBe(true);
+    expect(
+      source.includes("outline: 2px solid rgba(255, 218, 48, 0.95)")
+    ).toBe(true);
+    expect(
+      source.includes(
+        ':root[data-os-theme="macosx"] .chat-bubble.ryos-chat-tts-bubble-active'
+      )
+    ).toBe(true);
+  });
+
   test("useAiChat delegates speech and highlight orchestration to useChatSpeech", () => {
     const source = readSource("src/apps/chats/hooks/useAiChat.ts");
 

--- a/tests/test-chat-speech-text.test.ts
+++ b/tests/test-chat-speech-text.test.ts
@@ -48,6 +48,7 @@ describe("chat speech wiring", () => {
     expect(source.includes("messageId: message.id || messageKey")).toBe(true);
     expect(source.includes("ryos-chat-tts-bubble-active")).toBe(true);
     expect(source.includes("latestAssistantMessageKey === messageKey")).toBe(true);
+    expect(source.includes("RECENT_TTS_HIGHLIGHT_MS")).toBe(true);
   });
 
   test("chat TTS active bubble outline survives macOS chat bubble shadows", () => {

--- a/tests/test-chat-speech-text.test.ts
+++ b/tests/test-chat-speech-text.test.ts
@@ -47,6 +47,7 @@ describe("chat speech wiring", () => {
     ).toBeGreaterThanOrEqual(2);
     expect(source.includes("messageId: message.id || messageKey")).toBe(true);
     expect(source.includes("ryos-chat-tts-bubble-active")).toBe(true);
+    expect(source.includes("latestAssistantMessageKey === messageKey")).toBe(true);
   });
 
   test("chat TTS active bubble outline survives macOS chat bubble shadows", () => {

--- a/tests/test-chat-speech-text.test.ts
+++ b/tests/test-chat-speech-text.test.ts
@@ -57,6 +57,7 @@ describe("chat speech wiring", () => {
     expect(
       source.includes("outline: 2px solid rgba(255, 218, 48, 0.95)")
     ).toBe(true);
+    expect(source.includes("background-color: #fde047 !important")).toBe(true);
     expect(
       source.includes(
         ':root[data-os-theme="macosx"] .chat-bubble.ryos-chat-tts-bubble-active'

--- a/tests/test-chat-speech-text.test.ts
+++ b/tests/test-chat-speech-text.test.ts
@@ -46,6 +46,7 @@ describe("chat speech wiring", () => {
       source.match(/stopSpeech=\{stopSpeech\}/g)?.length
     ).toBeGreaterThanOrEqual(2);
     expect(source.includes("messageId: message.id || messageKey")).toBe(true);
+    expect(source.includes("ryos-chat-tts-bubble-active")).toBe(true);
   });
 
   test("useAiChat delegates speech and highlight orchestration to useChatSpeech", () => {

--- a/tests/test-chat-speech-text.test.ts
+++ b/tests/test-chat-speech-text.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import {
+  getAssistantVisibleText,
+  getChatMessageText,
+  getDisplayTextPart,
+} from "../src/apps/chats/utils/messageText";
+import { cleanTextForSpeech } from "../src/apps/chats/utils/textForSpeech";
+
+const readSource = (relativePath: string): string =>
+  readFileSync(resolve(process.cwd(), relativePath), "utf-8");
+
+describe("chat speech text helpers", () => {
+  test("normalizes urgent assistant text into the visible display coordinate space", () => {
+    const message = {
+      parts: [{ type: "text", text: "!!!! Hello &amp; goodbye" }],
+    };
+
+    expect(getChatMessageText(message)).toBe("!!!! Hello &amp; goodbye");
+    expect(getAssistantVisibleText(message)).toBe("Hello & goodbye");
+    expect(getDisplayTextPart("!!!! Hello &amp; goodbye")).toBe("Hello & goodbye");
+  });
+
+  test("cleans markdown, URLs, code, and urgent prefixes before speech", () => {
+    expect(
+      cleanTextForSpeech(
+        "!!!! Read [the docs](https://example.com).\n```ts\nalert('x')\n```\nhttps://example.com/raw"
+      )
+    ).toBe("Read the docs.");
+  });
+});
+
+describe("chat speech wiring", () => {
+  test("ChatMessages uses the parent speech queue and forwards highlight state", () => {
+    const source = readSource("src/apps/chats/components/ChatMessages.tsx");
+
+    expect(source.includes("useTtsQueue")).toBe(false);
+    expect(
+      source.match(/highlightSegment=\{highlightSegment\}/g)?.length
+    ).toBeGreaterThanOrEqual(2);
+    expect(
+      source.match(/speakText=\{speakText\}/g)?.length
+    ).toBeGreaterThanOrEqual(2);
+    expect(
+      source.match(/stopSpeech=\{stopSpeech\}/g)?.length
+    ).toBeGreaterThanOrEqual(2);
+  });
+
+  test("useAiChat delegates speech and highlight orchestration to useChatSpeech", () => {
+    const source = readSource("src/apps/chats/hooks/useAiChat.ts");
+
+    expect(source.includes("useChatSpeech({")).toBe(true);
+    expect(source.includes("chatSpeechRef.current?.speakFinalMessage")).toBe(true);
+    expect(source.includes("speechProgressRef")).toBe(false);
+  });
+});

--- a/tests/test-chat-speech-text.test.ts
+++ b/tests/test-chat-speech-text.test.ts
@@ -45,6 +45,7 @@ describe("chat speech wiring", () => {
     expect(
       source.match(/stopSpeech=\{stopSpeech\}/g)?.length
     ).toBeGreaterThanOrEqual(2);
+    expect(source.includes("messageId: message.id || messageKey")).toBe(true);
   });
 
   test("useAiChat delegates speech and highlight orchestration to useChatSpeech", () => {

--- a/tests/test-chat-speech-text.test.ts
+++ b/tests/test-chat-speech-text.test.ts
@@ -52,7 +52,7 @@ describe("chat speech wiring", () => {
   });
 
   test("chat TTS active bubble outline survives macOS chat bubble shadows", () => {
-    const source = readSource("src/index.css");
+    const source = `${readSource("src/index.css")}\n${readSource("src/styles/themes.css")}`;
 
     expect(source.includes(".ryos-chat-tts-bubble-active")).toBe(true);
     expect(

--- a/tests/test-chat-speech-text.test.ts
+++ b/tests/test-chat-speech-text.test.ts
@@ -48,7 +48,6 @@ describe("chat speech wiring", () => {
     expect(source.includes("messageId: message.id || messageKey")).toBe(true);
     expect(source.includes("ryos-chat-tts-bubble-active")).toBe(true);
     expect(source.includes("latestAssistantMessageKey === messageKey")).toBe(true);
-    expect(source.includes("RECENT_TTS_HIGHLIGHT_MS")).toBe(true);
   });
 
   test("chat TTS active bubble outline survives macOS chat bubble shadows", () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Restore chat TTS highlight rendering by threading `highlightSegment` into message items.
- Unify manual and automatic chat speech playback around the `useAiChat` speech queue.
- Extract shared chat text normalization and speech/highlight orchestration into focused helpers/hooks.
- Add a visible active speech cue for the latest Ryo/assistant bubble, including Aqua theme overrides.
- Add regression coverage for speech text cleanup, highlight wiring, and active bubble styling.

## Testing
- `bun test tests/test-chat-speech-text.test.ts`
- `bun run build`
- Browser verification via Playwright computed-style probe and screenshot artifact:
  ![Chat TTS highlight active](https://cursor.com/artifacts/c/art-5f00b1c6-7367-493c-9901-a80723a5d625)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-77DCC873-0EAB-4A21-B5CF-AAB4625FDB63"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-77DCC873-0EAB-4A21-B5CF-AAB4625FDB63"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

