### PR TITLE
feat(ipod): alphabet-scroll letter overlay when spinning the wheel fast

### DIFF
--- a/src/apps/ipod/components/IpodScreen.tsx
+++ b/src/apps/ipod/components/IpodScreen.tsx
@@ -28,6 +28,8 @@ import {
   StatusDisplay,
   IpodModernPlayPauseIcon,
   IpodArtworkPlaceholder,
+  AlphabetScrollOverlay,
+  useAlphabetScrollLetter,
 } from "./screen";
 import { useImageLoaded } from "../hooks/useImageLoaded";
 
@@ -691,6 +693,27 @@ export function IpodScreen({
     [menuMode, menuHistory]
   );
 
+  // Whether the current menu is sorted alphabetically — drives the
+  // big-letter scrubber overlay rendered below the titlebar while the
+  // wheel is being spun quickly.
+  const isAlphabeticalMenu = useMemo(() => {
+    if (!menuMode || menuHistory.length === 0) return false;
+    return Boolean(menuHistory[menuHistory.length - 1].alphabetical);
+  }, [menuMode, menuHistory]);
+
+  // Currently-displayed alphabet letter (or null when the overlay
+  // should be hidden). The hook owns timing + activation thresholds so
+  // tapping the wheel slowly never flashes it; spinning fast smoothly
+  // pops it in and lets the letter follow the wheel until the user
+  // pauses for ~420ms.
+  const alphabetScrollLetter = useAlphabetScrollLetter({
+    isAlphabeticalMenu,
+    menuMode,
+    menuDepth: menuHistory.length,
+    selectedIndex: selectedMenuItem,
+    items: currentMenuItems,
+  });
+
   // Track scroll position + container height so we can compute the
   // visible window for virtualization.
   const [menuScrollState, dispatchMenuScroll] = useReducer(
@@ -1206,6 +1229,10 @@ export function IpodScreen({
                   containerRef={menuScrollRef}
                   backlightOn={backlightOn}
                   menuMode={menuMode}
+                  variant={uiVariant}
+                />
+                <AlphabetScrollOverlay
+                  letter={alphabetScrollLetter}
                   variant={uiVariant}
                 />
               </div>

--- a/src/apps/ipod/components/screen/AlphabetScrollOverlay.tsx
+++ b/src/apps/ipod/components/screen/AlphabetScrollOverlay.tsx
@@ -1,0 +1,86 @@
+import { motion, AnimatePresence } from "framer-motion";
+import { cn } from "@/lib/utils";
+
+interface AlphabetScrollOverlayProps {
+  /** Single character to display, or null to hide the overlay. */
+  letter: string | null;
+  /** Selected UI skin — drives typography + chrome. */
+  variant?: "classic" | "modern";
+}
+
+/**
+ * Large semi-transparent letter rendered in the center of the iPod
+ * LCD while the user is spinning the wheel fast through an
+ * alphabetically-sorted list (Albums / Artists / Playlists / All
+ * Songs). Mirrors the iOS contacts / iPod classic "alphabet scrubber"
+ * affordance: a chunky letter the user can latch onto as feedback
+ * for where they are in A→Z without each row's full label having to
+ * be readable at speed.
+ *
+ * The letter is owned by the parent — this component only handles
+ * presentation and the fade-in / fade-out transition.
+ */
+export function AlphabetScrollOverlay({
+  letter,
+  variant = "classic",
+}: AlphabetScrollOverlayProps) {
+  const isModern = variant === "modern";
+  return (
+    <AnimatePresence>
+      {letter ? (
+        <motion.div
+          key="alphabet-overlay"
+          className={cn(
+            // Match the menu body's stacking — sit above virtualized
+            // rows and the split-art column, below the titlebar (z-20)
+            // so the silver header is never occluded.
+            "absolute inset-0 z-[15] pointer-events-none",
+            "flex items-center justify-center"
+          )}
+          initial={{ opacity: 0, scale: 0.85 }}
+          animate={{ opacity: 1, scale: 1 }}
+          exit={{ opacity: 0, scale: 0.92 }}
+          transition={{ duration: 0.15, ease: "easeOut" }}
+        >
+          <div
+            className={cn(
+              "flex items-center justify-center select-none",
+              isModern
+                ? cn(
+                    "size-[68px] rounded-2xl",
+                    // Dark glassy pill matching the iOS 6 status-bar
+                    // tinted overlay style used elsewhere in the
+                    // modern skin (e.g. fullscreen status messages).
+                    "bg-black/55 text-white",
+                    "backdrop-blur-[2px]",
+                    "shadow-[0_2px_6px_rgba(0,0,0,0.25)]"
+                  )
+                : cn(
+                    "size-[60px] rounded-md",
+                    // Classic LCD: deep iPod blue fill so the letter
+                    // reads against the cyan backlight; outlined with
+                    // a 1px hairline to match the rest of the chrome.
+                    "bg-[#0a3667]/85 text-[#c5e0f5]",
+                    "border border-[#0a3667]",
+                    "shadow-[0_1px_0_rgba(255,255,255,0.4)]"
+                  )
+            )}
+          >
+            <span
+              className={cn(
+                "leading-none font-bold",
+                isModern
+                  ? "font-ipod-modern-ui text-[44px]"
+                  : "font-chicago text-[40px]"
+              )}
+              style={{ transform: "translateY(-1px)" }}
+              aria-hidden
+            >
+              {letter}
+            </span>
+          </div>
+        </motion.div>
+      ) : null}
+    </AnimatePresence>
+  );
+}

--- a/src/apps/ipod/components/screen/index.ts
+++ b/src/apps/ipod/components/screen/index.ts
@@ -9,3 +9,10 @@ export {
   IpodArtworkPlaceholder,
   type IpodEmptyArtworkKind,
 } from "./IpodArtworkPlaceholder";
+export { AlphabetScrollOverlay } from "./AlphabetScrollOverlay";
+export {
+  useAlphabetScrollLetter,
+  ALPHABET_SCROLL_FAST_WINDOW_MS,
+  ALPHABET_SCROLL_MIN_TICKS,
+  ALPHABET_SCROLL_HIDE_DELAY_MS,
+} from "./useAlphabetScrollLetter";

--- a/src/apps/ipod/components/screen/useAlphabetScrollLetter.ts
+++ b/src/apps/ipod/components/screen/useAlphabetScrollLetter.ts
@@ -1,0 +1,157 @@
+import { useEffect, useRef, useState } from "react";
+import type { MenuItem } from "../../types";
+
+/**
+ * Sliding window inside which we count consecutive selection changes
+ * to decide whether the wheel is being spun "fast enough" to merit
+ * popping the alphabet-scroll letter overlay.
+ *
+ * Tuned for the iPod virtual wheel: each tick of `rotationStepDeg`
+ * (15°) shifts the selection by one, so a comfortable thumb spin
+ * easily produces 4+ ticks within 220ms.
+ */
+export const ALPHABET_SCROLL_FAST_WINDOW_MS = 220;
+/** Minimum recent selection changes within {@link ALPHABET_SCROLL_FAST_WINDOW_MS} to trigger the overlay. */
+export const ALPHABET_SCROLL_MIN_TICKS = 4;
+/** Cooldown after the last selection change before the overlay fades back out. */
+export const ALPHABET_SCROLL_HIDE_DELAY_MS = 420;
+
+/**
+ * Returns a single uppercase character to render in the alphabet-scroll
+ * overlay (or `null` when the overlay should be hidden).
+ *
+ * Behavior:
+ *  - Activates only while the current menu has `alphabetical: true`
+ *    and the user is in menu mode.
+ *  - Ramps up after {@link ALPHABET_SCROLL_MIN_TICKS} selection
+ *    changes inside {@link ALPHABET_SCROLL_FAST_WINDOW_MS} so casual
+ *    one-at-a-time taps never flash the overlay.
+ *  - Updates the displayed letter on every subsequent selection
+ *    change so it tracks the current row.
+ *  - Decays back to `null` {@link ALPHABET_SCROLL_HIDE_DELAY_MS}
+ *    after the last selection change.
+ *  - Resets immediately when the menu depth changes (entering /
+ *    leaving a submenu) so the overlay never lingers across menu
+ *    transitions.
+ */
+export function useAlphabetScrollLetter({
+  isAlphabeticalMenu,
+  menuMode,
+  menuDepth,
+  selectedIndex,
+  items,
+}: {
+  isAlphabeticalMenu: boolean;
+  menuMode: boolean;
+  menuDepth: number;
+  selectedIndex: number;
+  items: MenuItem[];
+}): string | null {
+  const [letter, setLetter] = useState<string | null>(null);
+  const tickTimestampsRef = useRef<number[]>([]);
+  const hideTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const prevSelectedRef = useRef<number>(selectedIndex);
+  const prevDepthRef = useRef<number>(menuDepth);
+  const prevAlphabeticalRef = useRef<boolean>(isAlphabeticalMenu);
+  const isActiveRef = useRef<boolean>(false);
+
+  // Tear-down on unmount.
+  useEffect(() => {
+    return () => {
+      if (hideTimerRef.current !== null) {
+        clearTimeout(hideTimerRef.current);
+        hideTimerRef.current = null;
+      }
+    };
+  }, []);
+
+  useEffect(() => {
+    const clearHideTimer = () => {
+      if (hideTimerRef.current !== null) {
+        clearTimeout(hideTimerRef.current);
+        hideTimerRef.current = null;
+      }
+    };
+
+    // Reset whenever we cross a menu boundary or alphabetical-ness
+    // flips — entering or leaving a submenu should never show stale
+    // letters from the previous list.
+    if (
+      prevDepthRef.current !== menuDepth ||
+      prevAlphabeticalRef.current !== isAlphabeticalMenu
+    ) {
+      prevDepthRef.current = menuDepth;
+      prevAlphabeticalRef.current = isAlphabeticalMenu;
+      prevSelectedRef.current = selectedIndex;
+      tickTimestampsRef.current = [];
+      isActiveRef.current = false;
+      clearHideTimer();
+      setLetter(null);
+      return;
+    }
+
+    if (!menuMode || !isAlphabeticalMenu) {
+      // Menu closed or list isn't alphabetical → ensure overlay is
+      // hidden and stay quiet.
+      setLetter((prev) => (prev !== null ? null : prev));
+      tickTimestampsRef.current = [];
+      isActiveRef.current = false;
+      clearHideTimer();
+      prevSelectedRef.current = selectedIndex;
+      return;
+    }
+
+    // Same menu / same selection → nothing to do (initial render or
+    // an unrelated re-render).
+    if (prevSelectedRef.current === selectedIndex) {
+      return;
+    }
+    prevSelectedRef.current = selectedIndex;
+
+    const now =
+      typeof performance !== "undefined" ? performance.now() : Date.now();
+    const cutoff = now - ALPHABET_SCROLL_FAST_WINDOW_MS;
+    const trimmed = tickTimestampsRef.current.filter((t) => t >= cutoff);
+    trimmed.push(now);
+    tickTimestampsRef.current = trimmed;
+
+    if (
+      !isActiveRef.current &&
+      trimmed.length >= ALPHABET_SCROLL_MIN_TICKS
+    ) {
+      isActiveRef.current = true;
+    }
+
+    if (isActiveRef.current) {
+      const next = firstDisplayLetter(items[selectedIndex]?.label);
+      if (next) setLetter(next);
+    }
+
+    clearHideTimer();
+    hideTimerRef.current = setTimeout(() => {
+      hideTimerRef.current = null;
+      isActiveRef.current = false;
+      tickTimestampsRef.current = [];
+      setLetter(null);
+    }, ALPHABET_SCROLL_HIDE_DELAY_MS);
+  }, [selectedIndex, isAlphabeticalMenu, menuMode, menuDepth, items]);
+
+  return letter;
+}
+
+/**
+ * Extract the first user-meaningful character from a menu row label
+ * and uppercase it. Handles surrogate pairs (emoji, CJK extensions)
+ * so a single grapheme is returned even when the label starts with a
+ * 4-byte code point. Returns `null` when the label is empty or only
+ * whitespace.
+ */
+function firstDisplayLetter(label: string | undefined): string | null {
+  if (!label) return null;
+  const trimmed = label.trim();
+  if (trimmed.length === 0) return null;
+  const codePoint = trimmed.codePointAt(0);
+  if (codePoint === undefined) return null;
+  const ch = String.fromCodePoint(codePoint);
+  return ch.toLocaleUpperCase();
+}

--- a/src/apps/ipod/hooks/useIpodLogic.ts
+++ b/src/apps/ipod/hooks/useIpodLogic.ts
@@ -1637,17 +1637,38 @@ export function useIpodLogic({
   // Memoize the entire "All Songs" submenu items array. Without this,
   // every render rebuilt N closures, the menu-history sync effect saw a
   // new `items` reference, called `setMenuHistory(updated)`, and re-ran.
+  //
+  // Items are sorted alphabetically by title — matching iPod classic
+  // "Songs" behavior so the alphabet-scroll letter overlay reads A→Z
+  // as the wheel spins. Tracks are still played by their stable
+  // `track.id`, so reordering the displayed rows does not affect
+  // playback; the `sortedIndex` passed through to `playTrackFromMenu`
+  // is the row index in the visible (sorted) list so menu history's
+  // `selectedIndex` lands on the correct row.
+  const allSongsSortedTracks = useMemo(
+    () =>
+      [...browsableTracks].sort((a, b) =>
+        a.title.localeCompare(b.title, undefined, { sensitivity: "base" })
+      ),
+    [browsableTracks]
+  );
   const allSongsMenuItems = useMemo(
     () =>
-      browsableTracks.map((track, index) => ({
+      allSongsSortedTracks.map((track, sortedIndex) => ({
         label: track.title,
         // Full library queue → pass null to clear any contextual queue.
-        action: () => playTrackFromMenu(track, index, null),
+        action: () => playTrackFromMenu(track, sortedIndex, null),
         showChevron: false,
         coverUrl: resolveTrackCoverUrl(track),
       })),
-    [browsableTracks, playTrackFromMenu]
+    [allSongsSortedTracks, playTrackFromMenu]
   );
+  /** Row in the sorted All Songs list for the currently-playing track. */
+  const allSongsSortedCurrentIndex = useMemo(() => {
+    if (!currentSongId) return 0;
+    const idx = allSongsSortedTracks.findIndex((t) => t.id === currentSongId);
+    return idx >= 0 ? idx : 0;
+  }, [allSongsSortedTracks, currentSongId]);
 
   const appleMusicRecentlyAddedMenuItems = useMemo(() => {
     const loadingLabel = t("apps.ipod.menuItems.loading", "Loading…");
@@ -1941,6 +1962,7 @@ export function useIpodLogic({
               title: allSongsLabel,
               items: allSongsMenuItems,
               selectedIndex: 0,
+              alphabetical: true,
             });
           },
           showChevron: true,
@@ -1991,6 +2013,7 @@ export function useIpodLogic({
               title: albumsLabel,
               items: albumsListMenuItems,
               selectedIndex: 0,
+              alphabetical: true,
             });
           },
           showChevron: true,
@@ -2117,9 +2140,22 @@ export function useIpodLogic({
     menuLocale,
   ]);
 
+  // Playlists are sorted alphabetically by name for display so the
+  // alphabet-scroll overlay reads A→Z, matching iPod classic behavior.
+  // The underlying `appleMusicPlaylists` array in the store is left in
+  // its Apple Music API order; anywhere we need a *display* index
+  // (e.g. `navigateToPlaylistFromNowPlaying`) uses `sortedApplePlaylists`
+  // instead so the row index matches the rendered list.
+  const sortedApplePlaylists = useMemo(
+    () =>
+      [...appleMusicPlaylists].sort((a, b) =>
+        a.name.localeCompare(b.name, undefined, { sensitivity: "base" })
+      ),
+    [appleMusicPlaylists]
+  );
   const applePlaylistsMenuItems = useMemo(
     (): MenuItem[] =>
-      appleMusicPlaylists.map((playlist) => {
+      sortedApplePlaylists.map((playlist) => {
         // Prefer the playlist's own artwork (Apple Music supplies it
         // directly via MusicKit). Fall back to the first cached track
         // with usable artwork so playlists imported before the artwork
@@ -2159,7 +2195,7 @@ export function useIpodLogic({
         };
       }),
     [
-      appleMusicPlaylists,
+      sortedApplePlaylists,
       appleMusicPlaylistTracks,
       applePlaylistTrackMenuItemsByPlaylist,
       registerActivity,
@@ -2191,7 +2227,7 @@ export function useIpodLogic({
     const pushSubmenu = (
       title: string,
       items: MenuItem[],
-      options?: { modernMediaList?: boolean }
+      options?: { modernMediaList?: boolean; alphabetical?: boolean }
     ) => {
       registerActivity();
       pushMenuChild({
@@ -2251,6 +2287,7 @@ export function useIpodLogic({
           action: () => {
             pushSubmenu(playlistsLabel, applePlaylistsMenuItems, {
               modernMediaList: true,
+              alphabetical: true,
             });
             void loadAppleMusicPlaylists();
           },
@@ -2258,17 +2295,26 @@ export function useIpodLogic({
         },
         {
           label: artistsLabel,
-          action: () => pushSubmenu(artistsLabel, artistsListMenuItems),
+          action: () =>
+            pushSubmenu(artistsLabel, artistsListMenuItems, {
+              alphabetical: true,
+            }),
           showChevron: true,
         },
         {
           label: albumsLabel,
-          action: () => pushSubmenu(albumsLabel, albumsListMenuItems),
+          action: () =>
+            pushSubmenu(albumsLabel, albumsListMenuItems, {
+              alphabetical: true,
+            }),
           showChevron: true,
         },
         {
           label: songsLabel,
-          action: () => pushSubmenu(songsLabel, allSongsMenuItems),
+          action: () =>
+            pushSubmenu(songsLabel, allSongsMenuItems, {
+              alphabetical: true,
+            }),
           showChevron: true,
         },
         {
@@ -2298,17 +2344,26 @@ export function useIpodLogic({
       coverFlowItem,
       {
         label: artistsLabel,
-        action: () => pushSubmenu(artistsLabel, artistsListMenuItems),
+        action: () =>
+          pushSubmenu(artistsLabel, artistsListMenuItems, {
+            alphabetical: true,
+          }),
         showChevron: true,
       },
       {
         label: albumsLabel,
-        action: () => pushSubmenu(albumsLabel, albumsListMenuItems),
+        action: () =>
+          pushSubmenu(albumsLabel, albumsListMenuItems, {
+            alphabetical: true,
+          }),
         showChevron: true,
       },
       {
         label: songsLabel,
-        action: () => pushSubmenu(allSongsLabel, allSongsMenuItems),
+        action: () =>
+          pushSubmenu(allSongsLabel, allSongsMenuItems, {
+            alphabetical: true,
+          }),
         showChevron: true,
       },
     ];
@@ -2640,6 +2695,7 @@ export function useIpodLogic({
           title: albumsLabel,
           items: albumsListMenuItems,
           selectedIndex: albumRowIdx,
+          alphabetical: true,
         },
         {
           title: albumKey,
@@ -2691,6 +2747,7 @@ export function useIpodLogic({
           title: artistsLabel,
           items: artistsListMenuItems,
           selectedIndex: artistListIdx,
+          alphabetical: true,
         },
         {
           title: artistKey,
@@ -2727,7 +2784,7 @@ export function useIpodLogic({
       );
       const playlistListIdx = Math.max(
         0,
-        appleMusicPlaylists.findIndex((entry) => entry.id === playlist.id)
+        sortedApplePlaylists.findIndex((entry) => entry.id === playlist.id)
       );
 
       navigateFromNowPlayingSongMenu([
@@ -2746,6 +2803,7 @@ export function useIpodLogic({
           items: applePlaylistsMenuItems,
           selectedIndex: playlistListIdx,
           modernMediaList: true,
+          alphabetical: true,
         },
         {
           title: playlist.name,
@@ -2761,7 +2819,7 @@ export function useIpodLogic({
       t,
       requestPlaylistTracksIfNeeded,
       appleMusicPlaylistTracks,
-      appleMusicPlaylists,
+      sortedApplePlaylists,
       applePlaylistsMenuItems,
       applePlaylistTrackMenuItemsByPlaylist,
       navigateFromNowPlayingSongMenu,
@@ -3725,14 +3783,15 @@ export function useIpodLogic({
           {
             title: allSongsLabel,
             items: allSongsMenuItems,
-            selectedIndex: Math.max(0, browseCurrentIndex),
+            selectedIndex: allSongsSortedCurrentIndex,
+            alphabetical: true,
           },
         ]);
-        setSelectedMenuItem(Math.max(0, browseCurrentIndex));
+        setSelectedMenuItem(allSongsSortedCurrentIndex);
       }
       setMenuMode(true);
     }
-  }, [playClickSound, vibrate, registerActivity, isCoverFlowOpen, isMusicQuizOpen, isBrickGameOpen, isNowPlayingSongMenuOpen, closeNowPlayingSongMenu, restoreNowPlayingSongMenu, showVideo, toggleVideo, menuMode, menuHistory, mainMenuItems, musicMenuItems, allSongsMenuItems, browseCurrentIndex, cameFromNowPlayingMenuItem, t]);
+  }, [playClickSound, vibrate, registerActivity, isCoverFlowOpen, isMusicQuizOpen, isBrickGameOpen, isNowPlayingSongMenuOpen, closeNowPlayingSongMenu, restoreNowPlayingSongMenu, showVideo, toggleVideo, menuMode, menuHistory, mainMenuItems, musicMenuItems, allSongsMenuItems, allSongsSortedCurrentIndex, cameFromNowPlayingMenuItem, t]);
 
   // Cover Flow handlers
   const handleCenterLongPress = useCallback(() => {

--- a/src/apps/ipod/types.ts
+++ b/src/apps/ipod/types.ts
@@ -50,6 +50,14 @@ export interface MenuHistoryEntry {
    * Used for playlist and per-artist album browses.
    */
   modernMediaList?: boolean;
+  /**
+   * When true, this menu's rows are sorted alphabetically by their
+   * label, so the iPod can pop a large letter overlay (similar to the
+   * iPhone contacts index) on top of the list while the wheel is being
+   * spun quickly. Used for the All Songs / Albums / Artists / Playlists
+   * browses. The overlay is hidden again after a short rest.
+   */
+  alphabetical?: boolean;
 }
 
 // PIP Player props


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

When the click wheel is spun fast through a long alphabetically-sorted list, the iPod now pops a big translucent letter in the center of the screen — same affordance as the iPod classic / iOS contacts alphabet scrubber. The letter tracks the highlighted row so the user can latch onto A, B, C… without each row's full label needing to be readable at speed. It fades back out after a short rest.

Applies to the four browses the user listed:

- **Albums** — already alphabetical
- **Artists** — already alphabetical
- **Playlists** — Apple Music playlists are now sorted alphabetically by name for display so the letter reads A→Z. The underlying store array order is preserved; only the menu render and the "Go to Playlist" shortcut consume the sorted view.
- **All Songs** — now sorted alphabetically by title (matches iPod classic behavior). Tracks are still played by stable `track.id`, so reordering display rows doesn't change playback.

## What changed

### Type + menu metadata

- `MenuHistoryEntry` gains an `alphabetical?: boolean` flag (`src/apps/ipod/types.ts`).
- `pushSubmenu(...)` and every push site for Albums / Artists / Playlists / All Songs (including the "All" rollups and the "Go to …" jumps from Now Playing's song menu) now stamp `alphabetical: true`.

### Sort order

- `allSongsMenuItems` reads from a new `allSongsSortedTracks` memo and passes the *sorted* row index to `playTrackFromMenu`, so `selectedIndex` in menu history lands on the displayed row.
- `allSongsSortedCurrentIndex` replaces the old `browseCurrentIndex` lookup in the Now Playing → All Songs fallback restore so it still highlights the current track.
- `applePlaylistsMenuItems` reads from a new `sortedApplePlaylists` memo; `navigateToPlaylistFromNowPlaying` switches its `findIndex` to that sorted view.

### Overlay

- `useAlphabetScrollLetter` is a small hook that watches `selectedIndex` changes inside the active menu. Activation rule: ≥ 4 ticks within 220ms flips the overlay on; the letter then tracks the selected row until 420ms of rest, at which point it fades out. Menu depth or alphabetical-flag changes reset state instantly so the overlay never lingers across menu transitions. Uses `String.fromCodePoint(...).toLocaleUpperCase()` so emoji / CJK first characters render as a single grapheme.
- `AlphabetScrollOverlay` renders the big letter in both UI skins:
  - **Classic** — `#0a3667` blue pill, cyan Chicago glyph at 40px.
  - **Modern** — dark glassy rounded square with `backdrop-blur`, white Helvetica Neue glyph at 44px.
  - Sits at `z-[15]` inside the menu body so it covers virtualized rows + the split-art column but never the silver titlebar (`z-20`).

## Testing

- ✅ `npx tsc -b --noEmit`
- ✅ `bun run test:unit` (234 tests pass)
- ✅ `bun run lint` (0 new errors; the only iPod warnings are pre-existing `react-hooks/exhaustive-deps` notes unrelated to this change)

Manual GUI verification was skipped per the repo's "Skip computer use / GUI-driven testing unless the user explicitly requests it" guideline. The Vite dev server is left running on http://localhost:3000 for the user to drive a quick visual check (open the iPod app → Music → Albums / Artists / Playlists / Songs → spin the wheel fast).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2E9AD52C-D500-4ED2-BD5C-154194833E8F"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2E9AD52C-D500-4ED2-BD5C-154194833E8F"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

