### PR TITLE
feat(dashboard): Terrarium widget (land biome)

### DIFF
--- a/docs/2-apps.md
+++ b/docs/2-apps.md
@@ -28,7 +28,7 @@ ryOS includes 25 built-in applications, each designed to replicate classic deskt
 | [Stickies](/docs/stickies) | Sticky notes for quick reminders | Productivity |
 | [Calendar](/docs/calendar) | iCal-style calendar with month, week, and day views, todos, and cloud sync | Productivity |
 | [Contacts](/docs/contacts) | Address book with vCard import and cloud sync | Productivity |
-| [Dashboard](/docs/dashboard) | Tiger-style widget overlay with clock, calendar, weather, stocks, iPod, translation, dictionary, sticky notes, and aquarium | Utilities |
+| [Dashboard](/docs/dashboard) | Tiger-style widget overlay with clock, calendar, weather, stocks, iPod, translation, dictionary, sticky notes, aquarium, and terrarium | Utilities |
 | [Maps](/docs/maps) | Apple MapKit search and pins; directions open in a new tab (Apple Maps); Chats can open results in-app | Utilities |
 | [Admin](/docs/admin) | Usage analytics dashboard with server info and user management (admin only) | System |
 

--- a/docs/2.22-dashboard.md
+++ b/docs/2.22-dashboard.md
@@ -1,14 +1,14 @@
 # Dashboard
 
-Dashboard is a Tiger-style widget overlay for ryOS with draggable widgets for at-a-glance information. Press F4 to toggle. Includes 9 widgets: Clock, Calendar, Weather, Stocks, iPod, Translation, Dictionary, Sticky Note, and Aquarium.
+Dashboard is a Tiger-style widget overlay for ryOS with draggable widgets for at-a-glance information. Press F4 to toggle. Includes 10 widgets: Clock, Calendar, Weather, Stocks, iPod, Translation, Dictionary, Sticky Note, Aquarium, and Terrarium.
 
 ## Overview
 
-Dashboard provides a Tiger-style widget overlay for ryOS with draggable widgets for at-a-glance information. It includes 9 widgets—Clock (analog with digital time, auto dark mode), Calendar (mini month view with events), Weather (geolocation-based), Stocks (real market data via yahoo-finance2), iPod (playback controls), Translation, Dictionary, Sticky Note, and Aquarium (animated emoji aquarium). Widgets can be flipped to show settings, added via a + button or menu bar, and dragged to rearrange (touch and mouse support). Framer Motion powers the animations.
+Dashboard provides a Tiger-style widget overlay for ryOS with draggable widgets for at-a-glance information. It includes 10 widgets—Clock (analog with digital time, auto dark mode), Calendar (mini month view with events), Weather (geolocation-based), Stocks (real market data via yahoo-finance2), iPod (playback controls), Translation, Dictionary, Sticky Note, Aquarium (animated emoji aquarium), and Terrarium (compact land biome with moss, wandering critters, and fireflies). Widgets can be flipped to show settings, added via a + button or menu bar, and dragged to rearrange (touch and mouse support). Framer Motion powers the animations.
 
 ## Features
 
-- **9 Widgets:** Clock (analog with digital time, auto dark mode), Calendar (mini month view with events), Weather (geolocation-based), Stocks (real market data via yahoo-finance2), iPod (playback controls), Translation, Dictionary, Sticky Note, Aquarium
+- **10 Widgets:** Clock (analog with digital time, auto dark mode), Calendar (mini month view with events), Weather (geolocation-based), Stocks (real market data via yahoo-finance2), iPod (playback controls), Translation, Dictionary, Sticky Note, Aquarium, Terrarium
 - **Widget back panels with settings:** Flip widgets to configure (timezone, stocks symbols, languages, etc.)
 - **Add widgets:** Use the + button or menu bar to add widgets
 - **Drag to rearrange:** Touch and mouse support for repositioning
@@ -52,6 +52,7 @@ Dashboard typically runs as an overlay or full-screen panel rather than a standa
   - `DictionaryWidget.tsx` — Dictionary lookup widget
   - `StickyNoteWidget.tsx` — Sticky note widget
   - `AquariumWidget.tsx` — Animated emoji aquarium widget
+  - `TerrariumWidget.tsx` — Animated emoji terrarium (land) widget
   - `WidgetChrome.tsx` — Shared widget wrapper with drag, flip, and settings
 
 ### Hooks & Utilities

--- a/docs/3.5-component-architecture.md
+++ b/docs/3.5-component-architecture.md
@@ -435,13 +435,24 @@ interface TrafficLightButtonProps {
 
 ### EmojiAquarium
 
-Decorative animated emoji display.
+Animated emoji aquarium in `src/components/shared/EmojiAquarium.tsx`; used by Chats bubbles and the Dashboard aquarium widget.
 
 ```typescript
 interface EmojiAquariumProps {
-  emojis: string[];
-  containerRef: RefObject<HTMLDivElement>;
-  speed?: number;
+  seed?: string;
+  className?: string;
+  variant?: "chat" | "widget";
+}
+```
+
+### EmojiTerrarium
+
+Land-biome companion in `src/components/shared/EmojiTerrarium.tsx` for the Dashboard terrarium widget: soil/moss strata, floating motes and fireflies, snail, frog, butterfly, and ladybug. Seeded placements and CSS/Framer motion only (no canvas).
+
+```typescript
+interface EmojiTerrariumProps {
+  seed?: string;
+  className?: string;
 }
 ```
 

--- a/docs/7.1-component-library.md
+++ b/docs/7.1-component-library.md
@@ -107,6 +107,7 @@ Built on React with Tailwind CSS and shadcn/ui.
 |-----------|---------|
 | `src/components/shared/AmbientBackground.tsx` | Animated ambient gradient background |
 | `src/components/shared/EmojiAquarium.tsx` | Animated emoji aquarium display |
+| `src/components/shared/EmojiTerrarium.tsx` | Dashboard terrarium: land-biome emoji scene |
 | `src/components/shared/FullscreenPlayerControls.tsx` | Media player controls for fullscreen mode |
 | `src/components/shared/GalaxyBackground.tsx` | Animated galaxy shader background |
 | `src/components/shared/HtmlPreview.tsx` | HTML/applet preview with code view |

--- a/src/apps/dashboard/components/DashboardAppComponent.tsx
+++ b/src/apps/dashboard/components/DashboardAppComponent.tsx
@@ -17,6 +17,7 @@ import { CurrencyWidget, CurrencyBackPanel } from "@/components/layout/dashboard
 import { StickyNoteWidget, StickyNoteBackPanel } from "@/components/layout/dashboard/StickyNoteWidget";
 import { DictionaryWidget, DictionaryBackPanel } from "@/components/layout/dashboard/DictionaryWidget";
 import { AquariumWidget, AquariumBubbleOverflow } from "@/components/layout/dashboard/AquariumWidget";
+import { TerrariumWidget, TerrariumFireflyOverflow } from "@/components/layout/dashboard/TerrariumWidget";
 import { DashboardMenuBar } from "./DashboardMenuBar";
 import { useAppStore } from "@/stores/useAppStore";
 import { useTranslation } from "react-i18next";
@@ -47,6 +48,8 @@ function WidgetContent({ type, widgetId, isFlipped }: { type: string; widgetId: 
       return <DictionaryWidget widgetId={widgetId} />;
     case "aquarium":
       return <AquariumWidget widgetId={widgetId} />;
+    case "terrarium":
+      return <TerrariumWidget widgetId={widgetId} />;
     default:
       return null;
   }
@@ -80,6 +83,7 @@ function WidgetBackContent({ type, widgetId, onDone }: { type: string; widgetId:
 function WidgetOverflow({ type, widgetId }: { type: string; widgetId: string }) {
   if (type === "weather") return <WeatherEmojiOverflow widgetId={widgetId} />;
   if (type === "aquarium") return <AquariumBubbleOverflow widgetId={widgetId} />;
+  if (type === "terrarium") return <TerrariumFireflyOverflow widgetId={widgetId} />;
   return null;
 }
 
@@ -94,6 +98,7 @@ const WIDGET_ICONS: Record<WidgetType, string> = {
   stickynote: "📝",
   dictionary: "📖",
   aquarium: "🐠",
+  terrarium: "🌿",
 };
 
 function WidgetStrip({
@@ -133,6 +138,7 @@ function WidgetStrip({
     { type: "stickynote", label: t("apps.dashboard.widgets.stickyNote", "Sticky Note") },
     { type: "dictionary", label: t("apps.dashboard.widgets.dictionary", "Dictionary") },
     { type: "aquarium", label: t("apps.dashboard.widgets.aquarium", "Aquarium") },
+    { type: "terrarium", label: t("apps.dashboard.widgets.terrarium", "Terrarium") },
   ];
 
   return (
@@ -314,6 +320,7 @@ export function DashboardAppComponent({
       onAddStickyNote={() => handleAddWidget("stickynote")}
       onAddDictionary={() => handleAddWidget("dictionary")}
       onAddAquarium={() => handleAddWidget("aquarium")}
+      onAddTerrarium={() => handleAddWidget("terrarium")}
       onResetWidgets={resetToDefaults}
     />
   );

--- a/src/apps/dashboard/components/DashboardMenuBar.tsx
+++ b/src/apps/dashboard/components/DashboardMenuBar.tsx
@@ -27,6 +27,7 @@ interface DashboardMenuBarProps {
   onAddStickyNote: () => void;
   onAddDictionary: () => void;
   onAddAquarium: () => void;
+  onAddTerrarium: () => void;
   onResetWidgets: () => void;
 }
 
@@ -44,6 +45,7 @@ export function DashboardMenuBar({
   onAddStickyNote,
   onAddDictionary,
   onAddAquarium,
+  onAddTerrarium,
   onResetWidgets,
 }: DashboardMenuBarProps) {
   const { t } = useTranslation();
@@ -102,6 +104,10 @@ export function DashboardMenuBar({
               <MenubarItem onClick={onAddAquarium} className="text-md h-6 px-3 gap-1.5">
                 <Emoji emoji="🐠" size={14} />
                 {t("apps.dashboard.widgets.aquarium", "Aquarium")}
+              </MenubarItem>
+              <MenubarItem onClick={onAddTerrarium} className="text-md h-6 px-3 gap-1.5">
+                <Emoji emoji="🌿" size={14} />
+                {t("apps.dashboard.widgets.terrarium", "Terrarium")}
               </MenubarItem>
             </MenubarSubContent>
           </MenubarSub>

--- a/src/apps/dashboard/hooks/useDashboardLogic.tsx
+++ b/src/apps/dashboard/hooks/useDashboardLogic.tsx
@@ -53,6 +53,7 @@ export function useDashboardLogic() {
         weather: { width: 340, height: 180 },
         stocks: { width: 240, height: 340 },
         aquarium: { width: 340, height: 200 },
+        terrarium: { width: 340, height: 200 },
         ipod: { width: 320, height: 125 },
         dictionary: { width: 340, height: 220 },
         stickynote: { width: 200, height: 200 },

--- a/src/apps/dashboard/metadata.ts
+++ b/src/apps/dashboard/metadata.ts
@@ -20,7 +20,7 @@ export const helpItems = [
     icon: "🧩",
     title: "Widget Library",
     description:
-      "Add clock, weather, calendar, stocks, mini iPod, sticky note, dictionary, and more",
+      "Add clock, weather, calendar, stocks, mini iPod, aquarium, terrarium, sticky note, dictionary, and more",
   },
   {
     icon: "🌤️",

--- a/src/components/layout/dashboard/TerrariumWidget.tsx
+++ b/src/components/layout/dashboard/TerrariumWidget.tsx
@@ -1,0 +1,34 @@
+import EmojiTerrarium, {
+  TerrariumFireflyOverflowLayer,
+} from "@/components/shared/EmojiTerrarium";
+import { useDashboardStore } from "@/stores/useDashboardStore";
+
+interface TerrariumWidgetProps {
+  widgetId: string;
+}
+
+export function TerrariumWidget({ widgetId }: TerrariumWidgetProps) {
+  return (
+    <div className="flex h-full min-h-[inherit] items-stretch rounded-[inherit] bg-[#b9c8b4] shadow-[inset_0_1px_8px_rgba(255,255,255,0.28)]">
+      <EmojiTerrarium
+        seed={widgetId}
+        className="h-full min-h-[inherit] rounded-[inherit] shadow-[inset_0_-8px_16px_rgba(45,40,34,0.12)]"
+      />
+    </div>
+  );
+}
+
+export function TerrariumFireflyOverflow({ widgetId }: TerrariumWidgetProps) {
+  const widget = useDashboardStore((s) => s.widgets.find((w) => w.id === widgetId));
+  if (!widget) return null;
+
+  return (
+    <TerrariumFireflyOverflowLayer
+      seed={`${widgetId}:dashboard-firefly-overflow`}
+      width={widget.size.width}
+      height={widget.size.height}
+      count={9}
+      className="z-50"
+    />
+  );
+}

--- a/src/components/shared/EmojiTerrarium.tsx
+++ b/src/components/shared/EmojiTerrarium.tsx
@@ -1,0 +1,497 @@
+import { useMemo, useLayoutEffect, useRef, useState, useEffect } from "react";
+import { motion, MotionConfig } from "framer-motion";
+import { cn } from "@/lib/utils";
+import { Emoji } from "@/components/shared/Emoji";
+
+interface EmojiTerrariumProps {
+  seed?: string;
+  className?: string;
+}
+
+interface TerrariumFireflyOverflowLayerProps {
+  seed?: string;
+  width: number;
+  height: number;
+  count?: number;
+  className?: string;
+}
+
+const FIREFLY_EMOJI = "✨";
+
+function createSeededRandom(seed?: string) {
+  let a = 0;
+  if (seed && seed.length > 0) {
+    for (let i = 0; i < seed.length; i++) a = (a + seed.charCodeAt(i)) | 0;
+  } else {
+    a = Math.floor(Math.random() * 2 ** 31);
+  }
+  return () => {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+/** Soft sparks that drift upward past the jar lip (paired with AquariumBubbleOverflow). */
+export function TerrariumFireflyOverflowLayer({
+  seed,
+  width,
+  height,
+  count = 4,
+  className,
+}: TerrariumFireflyOverflowLayerProps) {
+  const rand = createSeededRandom(seed);
+  const lift = Math.max(24, Math.round(height * 0.16));
+  const safeWidth = Math.max(1, width);
+
+  return (
+    <div
+      className={cn("pointer-events-none overflow-visible", className)}
+      style={{
+        position: "absolute",
+        left: 0,
+        top: 0,
+        width: safeWidth,
+        height,
+        zIndex: 60,
+      }}
+      aria-hidden="true"
+    >
+      {Array.from({ length: count }).map((_, i) => {
+        const edgePad = 10;
+        const x = edgePad + rand() * Math.max(0, safeWidth - edgePad * 2);
+        const startFromSoil = i % 3 !== 1;
+        const startY = startFromSoil
+          ? height - rand() * Math.max(20, height * 0.22)
+          : 16 + rand() * Math.max(12, height * 0.2);
+        const drift = (rand() - 0.5) * 28;
+        const dur = 9 + rand() * 10;
+        const delay = i * 0.7 + rand() * 2;
+        const dot = 14 + rand() * 8;
+        const endY = -(8 + rand() * lift);
+
+        return (
+          <motion.span
+            key={`terrarium-glow-overflow-${i}`}
+            initial={{ x, y: startY, opacity: 0, scale: 0.55 }}
+            animate={{
+              x: [x, x + drift * 0.35, x + drift],
+              y: [startY, startY - lift * 0.35, endY],
+              opacity: [0, 0.75, 0.55, 0],
+              scale: [0.55, 1, 0.85],
+            }}
+            transition={{
+              duration: dur,
+              ease: "easeOut",
+              repeat: Infinity,
+              delay,
+            }}
+            style={{
+              position: "absolute",
+              willChange: "transform, opacity",
+              filter:
+                "drop-shadow(0 0 10px rgba(255,248,220,0.55)) drop-shadow(0 0 3px rgba(235,215,155,0.45))",
+            }}
+            className="select-none"
+          >
+            <Emoji emoji={FIREFLY_EMOJI} size={dot} />
+          </motion.span>
+        );
+      })}
+    </div>
+  );
+}
+
+const PLANTS = ["🌿", "🌱", "🍀", "🌸", "🌼", "🌾", "🪴"];
+const ROCK_COUNT = 4;
+const PLANT_COUNT = 7;
+const MOTE_COUNT = 5;
+
+/** Mini land biome: mossy soil, stones, plants, crawling critters, and soft glow (dashboard-first). */
+export function EmojiTerrarium({ seed, className }: EmojiTerrariumProps) {
+  const seedRef = useRef<string | undefined>(seed);
+  if (seedRef.current === undefined) {
+    seedRef.current = Math.floor(Math.random() * 2 ** 31).toString();
+  }
+  useEffect(() => {
+    if (seed && seed !== seedRef.current) {
+      seedRef.current = seed;
+    }
+  }, [seed]);
+
+  const stableSeed = seedRef.current ?? "0";
+
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [containerSize, setContainerSize] = useState({ width: 420, height: 0 });
+  useLayoutEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    const update = () =>
+      setContainerSize({
+        width: el.clientWidth || 420,
+        height: el.clientHeight || 0,
+      });
+    update();
+    const ro = new ResizeObserver(() => update());
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
+
+  const aspect = 200 / 420;
+  const width = containerSize.width;
+  const aspectHeight = Math.round(containerSize.width * aspect);
+  const height = Math.max(120, containerSize.height || aspectHeight);
+
+  const soilHeight = Math.max(28, Math.round(height * 0.34));
+  const groundY = height - soilHeight;
+
+  const floorXs = useMemo(() => {
+    const rnd = createSeededRandom(`${stableSeed}:terrarium-floor-xs:${width}`);
+    const xs: number[] = [];
+    const n = Math.max(PLANT_COUNT, ROCK_COUNT);
+    if (n <= 0) return xs;
+    const leftPad = 10;
+    const rightPad = 14;
+    const usable = Math.max(0, width - leftPad - rightPad);
+    const seg = usable / (n + 1);
+    for (let i = 0; i < n; i++) {
+      const base = leftPad + seg * (i + 1);
+      const jitter = (rnd() - 0.5) * seg * 0.55;
+      let x = Math.max(leftPad, Math.min(width - rightPad, base + jitter));
+      if (i > 0) {
+        const minGap = Math.min(36, seg * 0.55);
+        if (x - xs[i - 1] < minGap) {
+          x = xs[i - 1] + minGap;
+          if (x > width - rightPad) x = width - rightPad;
+        }
+      }
+      xs.push(x);
+    }
+    return xs;
+  }, [stableSeed, width]);
+
+  const decor = createSeededRandom(`${stableSeed}:terrarium-decor:${width}:${height}`);
+  const moth = createSeededRandom(`${stableSeed}:terrarium-moth:${width}:${height}`);
+  const bug = createSeededRandom(`${stableSeed}:terrarium-bug:${width}:${height}`);
+
+  const mothStartX = moth() > 0.5 ? width * 0.14 + moth() * 30 : width * 0.48 + moth() * 48;
+
+  const ladyPath = [
+    width * (0.1 + bug() * 0.04),
+    width * (0.35 + bug() * 0.04),
+    width * (0.52 + bug() * 0.06),
+    width * (0.14 + bug() * 0.04),
+  ];
+
+  const frogLeft = width * (0.38 + bug() * 0.22);
+  const snailLaneY = Math.min(height - 18, groundY + soilHeight * 0.52);
+  const bugBandY = Math.min(height - 12, groundY + soilHeight * 0.35);
+
+  return (
+    <MotionConfig reducedMotion="never">
+      <div
+        className={cn(
+          "relative h-full min-h-[inherit] w-full overflow-visible rounded-[inherit]",
+          "bg-[#c4cfbc] text-neutral-900",
+          className
+        )}
+        ref={containerRef}
+      >
+        <div
+          className="relative z-0 overflow-hidden rounded-[inherit]"
+          style={{ width: "100%", height }}
+        >
+          <div
+            className="pointer-events-none absolute inset-x-0 top-0 z-0 opacity-55"
+            style={{
+              height: Math.max(32, Math.round(height * 0.22)),
+              backgroundColor: "#9cb09a",
+            }}
+            aria-hidden
+          />
+
+          {Array.from({ length: MOTE_COUNT }).map((_, i) => {
+            const x = 12 + decor() * (width - 24);
+            const yBase = 10 + decor() * (height * 0.52);
+            const driftX = (decor() - 0.5) * 30;
+            const dur = 14 + decor() * 16;
+            const delay = decor() * 5;
+            return (
+              <motion.span
+                key={`mote-${i}`}
+                initial={{ x, y: yBase, opacity: 0 }}
+                animate={{
+                  x: [x, x + driftX],
+                  y: [yBase, yBase - height * 0.08],
+                  opacity: [0, 0.2, 0.12, 0],
+                }}
+                transition={{
+                  duration: dur,
+                  repeat: Infinity,
+                  delay,
+                  ease: "linear",
+                }}
+                style={{
+                  position: "absolute",
+                  width: 3,
+                  height: 3,
+                  borderRadius: "50%",
+                  backgroundColor: "rgba(255,255,255,0.72)",
+                  willChange: "transform, opacity",
+                }}
+                className="pointer-events-none z-10 select-none"
+                aria-hidden
+              />
+            );
+          })}
+
+          <div
+            className="pointer-events-none absolute inset-x-0 bottom-0 z-[1]"
+            style={{
+              height: soilHeight,
+              backgroundColor: "#5c4d40",
+              boxShadow: "inset 0 12px 0 rgba(62,52,46,0.35)",
+            }}
+            aria-hidden
+          />
+
+          <div
+            className="pointer-events-none absolute inset-x-0 z-[2]"
+            style={{
+              top: groundY - 4,
+              height: 14,
+              background:
+                "repeating-linear-gradient(90deg, transparent 0 6px, rgba(124,154,114,0.35) 6px 8px)",
+            }}
+            aria-hidden
+          />
+
+          {Array.from({ length: ROCK_COUNT }).map((_, i) => {
+            const x = floorXs[i] ?? 14 + decor() * (width - 28);
+            const sizePx = 20 + Math.round(decor() * 13);
+            const yPos =
+              groundY + 4 + decor() * Math.max(2, soilHeight - sizePx - 16);
+            const swaySeed = decor();
+            const sway = (swaySeed - 0.5) * 3;
+            const rotDur = 7 + decor() * 8;
+            return (
+              <motion.span
+                key={`rock-${i}`}
+                className="z-[15] select-none"
+                initial={{ opacity: 0, y: yPos + 14 }}
+                animate={{
+                  opacity: 1,
+                  y: yPos,
+                  rotate: [sway - 2.5, sway + 2.5, sway - 2.5],
+                }}
+                transition={{
+                  opacity: { duration: 0.45, delay: 0.05 * i },
+                  y: { type: "spring", stiffness: 420, damping: 22 },
+                  rotate: {
+                    duration: rotDur,
+                    repeat: Infinity,
+                    ease: "easeInOut",
+                  },
+                }}
+                style={{ position: "absolute", left: x }}
+              >
+                <Emoji emoji="🪨" size={sizePx} />
+              </motion.span>
+            );
+          })}
+
+          {Array.from({ length: PLANT_COUNT }).map((_, i) => {
+            const emoji = PLANTS[Math.floor(decor() * PLANTS.length)];
+            const x = floorXs[i] ?? 12 + decor() * (width - 24);
+            const sizePx = 20 + Math.round(decor() * 11);
+            const top = Math.max(groundY - sizePx + 10 + decor() * 12, 16);
+            const sway = decor() > 0.55 ? [-4, 4, -4] : [4, -4, 4];
+            const delay = 0.12 + decor() * 0.4;
+            const swayDur = 6 + decor() * 4;
+            return (
+              <motion.span
+                key={`plant-${i}`}
+                className="z-20 select-none"
+                initial={{ opacity: 0, scale: 0.93 }}
+                animate={{
+                  opacity: 1,
+                  scale: [0.93, 1, 0.96, 1],
+                  rotate: sway,
+                }}
+                transition={{
+                  opacity: { duration: 0.4 },
+                  rotate: {
+                    duration: swayDur,
+                    repeat: Infinity,
+                    ease: "easeInOut",
+                    delay,
+                  },
+                  scale: {
+                    duration: swayDur,
+                    repeat: Infinity,
+                  },
+                }}
+                style={{ position: "absolute", left: x, top }}
+              >
+                <Emoji emoji={emoji} size={sizePx} />
+              </motion.span>
+            );
+          })}
+
+          <motion.span
+            key="bfly"
+            className="z-25 select-none"
+            initial={{
+              x: mothStartX,
+              y: groundY - 62 - moth() * (height * 0.06),
+              rotate: moth() > 0.5 ? 9 : -8,
+              scaleX: 1,
+            }}
+            animate={{
+              x: [
+                mothStartX,
+                mothStartX + width * 0.32,
+                mothStartX - width * 0.05,
+              ],
+              y: [
+                groundY - 54,
+                groundY - height * 0.4,
+                groundY - 48,
+              ],
+              rotate: [6, -7, 5, -6],
+              scaleX: [1, -1, -1, 1],
+            }}
+            transition={{
+              duration: 24 + moth() * 16,
+              repeat: Infinity,
+              ease: "easeInOut",
+            }}
+            style={{ position: "absolute", left: 0 }}
+          >
+            <Emoji emoji="🦋" size={26} />
+          </motion.span>
+
+          <motion.span
+            className="z-26 select-none"
+            initial={{ x: -42 + bug() * 18 }}
+            animate={{ x: [-42, width + 42] }}
+            transition={{
+              duration: 42 + bug() * 28,
+              repeat: Infinity,
+              ease: "linear",
+              delay: bug() * 4,
+            }}
+            style={{
+              position: "absolute",
+              left: 0,
+              top: snailLaneY,
+              filter: "drop-shadow(0 1px 2px rgba(0,0,0,0.25))",
+            }}
+          >
+            <Emoji emoji="🐌" size={26} />
+          </motion.span>
+
+          <motion.span
+            className="z-27 select-none"
+            style={{
+              position: "absolute",
+              left: frogLeft,
+              top: bugBandY + 10,
+              filter: "drop-shadow(0 1px 2px rgba(0,0,0,0.2))",
+            }}
+            animate={{
+              y: [0, -8, 0],
+              scale: [1, 1.05, 1],
+            }}
+            transition={{
+              duration: 6 + bug() * 3,
+              repeat: Infinity,
+              ease: [0.45, 0, 0.55, 1],
+              delay: bug() * 2,
+            }}
+          >
+            <Emoji emoji="🐸" size={26} />
+          </motion.span>
+
+          <motion.span
+            className="z-28 select-none"
+            initial={{
+              x: ladyPath[0],
+              y: bugBandY,
+              rotate: bug() > 0.5 ? 14 : -10,
+            }}
+            animate={{
+              x: ladyPath,
+              rotate: [10, -10, 8, -8],
+              y: [bugBandY, bugBandY + 2, bugBandY, bugBandY + 1],
+            }}
+            transition={{
+              duration: 54 + bug() * 30,
+              repeat: Infinity,
+              ease: "linear",
+              delay: bug() * 8,
+            }}
+            style={{
+              position: "absolute",
+              left: 0,
+              filter: "drop-shadow(0 1px 1px rgba(0,0,0,0.2))",
+            }}
+          >
+            <Emoji emoji="🐞" size={22} />
+          </motion.span>
+
+          <motion.span
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            transition={{ duration: 0.45 }}
+            className="absolute right-3 top-2 select-none z-35"
+          >
+            <Emoji emoji="🫙" size={22} />
+          </motion.span>
+
+          {Array.from({ length: 6 }).map((_, i) => {
+            const x = 16 + decor() * (width - 32);
+            const yMin = 12;
+            const yMax = Math.max(yMin + 28, groundY - 42);
+            const y = yMin + decor() * (yMax - yMin);
+            const roam = 22 + decor() * 36;
+            const baseDur = 8 + decor() * 10;
+            const blinkDur = 2.8 + decor() * 1.8;
+            return (
+              <motion.span
+                key={`ffi-${i}`}
+                initial={{ x, y }}
+                animate={{
+                  x: [x, x + roam * 0.4, x - roam * 0.32, x],
+                  y: [y, y - roam * 0.16, y + roam * 0.06, y],
+                  opacity: [0.22, 0.88, 0.5, 0.28],
+                }}
+                transition={{
+                  duration: baseDur,
+                  repeat: Infinity,
+                  ease: "easeInOut",
+                  delay: i * 1.2 + decor() * 3,
+                  opacity: { duration: blinkDur, repeat: Infinity },
+                }}
+                style={{
+                  position: "absolute",
+                  left: 0,
+                  willChange: "transform, opacity",
+                  filter:
+                    "drop-shadow(0 0 8px rgba(255,246,205,0.45)) drop-shadow(0 0 2px rgba(255,220,140,0.35))",
+                }}
+                className="select-none z-[38]"
+              >
+                <Emoji emoji={FIREFLY_EMOJI} size={16 + Math.round(decor() * 10)} />
+              </motion.span>
+            );
+          })}
+        </div>
+      </div>
+    </MotionConfig>
+  );
+}
+
+export default EmojiTerrarium;

--- a/src/lib/locales/de/translation.json
+++ b/src/lib/locales/de/translation.json
@@ -1662,6 +1662,7 @@
         "removeWidget": "Widget entfernen",
         "stickyNote": "Haftnotiz",
         "stocks": "Aktien",
+        "terrarium": "Terrarium",
         "translation": "Übersetzung",
         "weather": "Wetter"
       }

--- a/src/lib/locales/en/translation.json
+++ b/src/lib/locales/en/translation.json
@@ -3434,6 +3434,7 @@
         "weather": "Weather",
         "stocks": "Stocks",
         "aquarium": "Aquarium",
+        "terrarium": "Terrarium",
         "stickyNote": "Sticky Note",
         "ipod": "iPod",
         "dictionary": "Dictionary",

--- a/src/lib/locales/es/translation.json
+++ b/src/lib/locales/es/translation.json
@@ -1662,6 +1662,7 @@
         "removeWidget": "Eliminar widget",
         "stickyNote": "Nota adhesiva",
         "stocks": "Bolsa",
+        "terrarium": "Terrario",
         "translation": "Traducción",
         "weather": "Tiempo"
       }

--- a/src/lib/locales/fr/translation.json
+++ b/src/lib/locales/fr/translation.json
@@ -1662,6 +1662,7 @@
         "removeWidget": "Supprimer le widget",
         "stickyNote": "Note adhésive",
         "stocks": "Bourse",
+        "terrarium": "Terrarium",
         "translation": "Traduction",
         "weather": "Météo"
       }

--- a/src/lib/locales/it/translation.json
+++ b/src/lib/locales/it/translation.json
@@ -1662,6 +1662,7 @@
         "removeWidget": "Rimuovi widget",
         "stickyNote": "Nota adesiva",
         "stocks": "Borsa",
+        "terrarium": "Terrario",
         "translation": "Traduzione",
         "weather": "Meteo"
       }

--- a/src/lib/locales/ja/translation.json
+++ b/src/lib/locales/ja/translation.json
@@ -1662,6 +1662,7 @@
         "removeWidget": "ウィジェットを削除",
         "stickyNote": "付箋",
         "stocks": "株価",
+        "terrarium": "テラリウム",
         "translation": "翻訳",
         "weather": "天気"
       }

--- a/src/lib/locales/ko/translation.json
+++ b/src/lib/locales/ko/translation.json
@@ -1662,6 +1662,7 @@
         "removeWidget": "위젯 제거",
         "stickyNote": "스티커 메모",
         "stocks": "주식",
+        "terrarium": "테라리움",
         "translation": "번역",
         "weather": "날씨"
       }

--- a/src/lib/locales/pt/translation.json
+++ b/src/lib/locales/pt/translation.json
@@ -1662,6 +1662,7 @@
         "removeWidget": "Remover Widget",
         "stickyNote": "Nota Autoadesiva",
         "stocks": "Ações",
+        "terrarium": "Terrário",
         "translation": "Tradução",
         "weather": "Tempo"
       }

--- a/src/lib/locales/ru/translation.json
+++ b/src/lib/locales/ru/translation.json
@@ -1662,6 +1662,7 @@
         "removeWidget": "Удалить виджет",
         "stickyNote": "Стикер",
         "stocks": "Акции",
+        "terrarium": "Террариум",
         "translation": "Перевод",
         "weather": "Погода"
       }

--- a/src/lib/locales/zh-TW/translation.json
+++ b/src/lib/locales/zh-TW/translation.json
@@ -1662,6 +1662,7 @@
         "removeWidget": "移除小工具",
         "stickyNote": "便利貼",
         "stocks": "股票",
+        "terrarium": "生態缸",
         "translation": "翻譯",
         "weather": "天氣"
       }

--- a/src/stores/useDashboardStore.ts
+++ b/src/stores/useDashboardStore.ts
@@ -2,7 +2,18 @@ import { create } from "zustand";
 import { persist } from "zustand/middleware";
 import type { EventColor } from "./useCalendarStore";
 
-export type WidgetType = "clock" | "weather" | "calendar" | "stocks" | "ipod" | "dictionary" | "stickynote" | "translation" | "currency" | "aquarium";
+export type WidgetType =
+  | "clock"
+  | "weather"
+  | "calendar"
+  | "stocks"
+  | "ipod"
+  | "dictionary"
+  | "stickynote"
+  | "translation"
+  | "currency"
+  | "aquarium"
+  | "terrarium";
 
 export interface WeatherWidgetConfig {
   cityName?: string;
@@ -113,6 +124,7 @@ const DEFAULT_WIDGET_SIZES: Record<WidgetType, { width: number; height: number }
   weather: { width: 340, height: 180 },
   stocks: { width: 240, height: 340 },
   aquarium: { width: 340, height: 200 },
+  terrarium: { width: 340, height: 200 },
   ipod: { width: 320, height: 125 },
   dictionary: { width: 340, height: 220 },
   stickynote: { width: 200, height: 200 },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a tenth **Dashboard terrarium** widget—a land analogue to Aquarium: seeded emoji scene (plants, snail, frog, butterfly, ladybug, motes/fireflies), optional spark overflow past `WidgetChrome`, and parity wiring (widget strip **+**, menubar → Add Widget, `WidgetType`, default 340×200).

**Adds**
- `src/components/shared/EmojiTerrarium.tsx` — reusable terrarium visuals (emoji + Framer Motion; flat sage/soil backdrop, no noisy gradients).
- `src/components/layout/dashboard/TerrariumWidget.tsx` — widget shell + overflow layer keyed to widget dimensions.

Locales add `apps.dashboard.widgets.terrarium` (synced across languages).

Docs refreshed: Dashboard overview/apps index, architecture + component-library entries.

**Verification**
`bun run lint` reports no errors (existing repo warnings unchanged). `bun run test:unit` passes (234 tests). None of the Dashboard widget registration paths had existing automated coverage.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5274a7e5-98cb-43d0-878d-b5c71055a3c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5274a7e5-98cb-43d0-878d-b5c71055a3c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

