### PR TITLE
fix(chats): clear TTS highlight when audio ends even if `onended` is delayed

### DIFF
--- a/src/hooks/useTtsQueue.ts
+++ b/src/hooks/useTtsQueue.ts
@@ -47,6 +47,16 @@ export function useTtsQueue(endpoint: string = "/api/speech") {
   const { isSpeaking } = state;
   // Track any sources currently playing so we can stop them
   const playingSourcesRef = useRef<Set<AudioBufferSourceNode>>(new Set());
+  // Pending fallback timers keyed by source. We schedule a timer based on the
+  // known audio buffer duration so `onEnd` still fires even when `src.onended`
+  // is throttled or delayed (background tabs, AudioContext briefly suspended,
+  // iOS Safari quirks, etc.). Without this, the chats TTS highlight overlay
+  // could linger on a finished sentence until something else (e.g. the user
+  // bringing the window back to foreground, which fires `focusHandler` and
+  // resumes the AudioContext) flushes the pending audio events.
+  const fallbackTimersRef = useRef<
+    Map<AudioBufferSourceNode, ReturnType<typeof setTimeout>>
+  >(new Map());
   // Promise chain that guarantees *scheduling* order while still allowing
   // individual fetches to run in parallel.
   const scheduleChainRef = useRef<Promise<void>>(Promise.resolve());
@@ -280,8 +290,23 @@ export function useTtsQueue(endpoint: string = "/api/speech") {
           playingSourcesRef.current.add(src);
           dispatch({ type: "setIsSpeaking", value: true });
 
-          src.onended = () => {
-            // Disconnect the source node to prevent memory leaks
+          // Idempotent end handler — must be safe to invoke from either the
+          // native `src.onended` event OR the fallback timer below. The
+          // fallback exists because some browsers (notably iOS Safari, and
+          // any browser when its AudioContext briefly suspends or the page
+          // loses focus) defer the `ended` dispatch until the page is
+          // brought back to focus. That delay is what made the chats TTS
+          // highlight visually stick on a finished sentence until the user
+          // switched the window background and back to foreground.
+          let ended = false;
+          const finishSrc = () => {
+            if (ended) return;
+            ended = true;
+            const timer = fallbackTimersRef.current.get(src);
+            if (timer) {
+              clearTimeout(timer);
+              fallbackTimersRef.current.delete(src);
+            }
             try {
               src.disconnect();
             } catch {
@@ -293,10 +318,50 @@ export function useTtsQueue(endpoint: string = "/api/speech") {
             }
             if (onEnd) onEnd();
           };
+          src.onended = finishSrc;
 
           src.start(start);
 
           nextStartRef.current = start + audioBuf.duration;
+
+          // Schedule a fallback that fires `finishSrc` shortly after the
+          // source is *expected* to finish playing. We re-check against
+          // `ctx.currentTime` (audio-clock time, which only advances while
+          // the context is running) instead of just trusting wall-clock
+          // time, so a briefly suspended/interrupted AudioContext doesn't
+          // cause us to clear the highlight before the audio has actually
+          // played. The 250ms cushion gives the native `onended` a tiny
+          // grace period to win the race in the happy path; `finishSrc` is
+          // idempotent so whichever path fires first wins and the other
+          // becomes a no-op.
+          const expectedEndTime = start + audioBuf.duration;
+          const scheduleFallback = (delayMs: number) => {
+            const timer = setTimeout(() => {
+              if (ended) return;
+              const ctxState = ctx.state as
+                | AudioContextState
+                | "interrupted";
+              if (ctxState === "closed") {
+                finishSrc();
+                return;
+              }
+              const remainingSec = expectedEndTime - ctx.currentTime;
+              if (remainingSec <= 0.05) {
+                finishSrc();
+                return;
+              }
+              // Audio clock hasn't caught up yet (context paused, or our
+              // initial estimate underestimated decode latency). Try again
+              // once the remaining audio should have played.
+              scheduleFallback(remainingSec * 1000 + 250);
+            }, Math.max(0, delayMs));
+            fallbackTimersRef.current.set(src, timer);
+          };
+          const initialDelayMs = Math.max(
+            0,
+            (expectedEndTime - ctx.currentTime) * 1000
+          );
+          scheduleFallback(initialDelayMs + 250);
         } catch (err) {
           if ((err as DOMException)?.name !== "AbortError") {
             console.error("Error during speak()", err);
@@ -344,6 +409,13 @@ export function useTtsQueue(endpoint: string = "/api/speech") {
     if (stopTimeoutRef.current) {
       clearTimeout(stopTimeoutRef.current);
     }
+
+    // Cancel any pending fallback timers — `src.stop()` below should make
+    // each source dispatch `onended` (and our handler is idempotent), so the
+    // fallback path is no longer needed for these sources. Leaving the timers
+    // running would just queue up stale no-op work.
+    fallbackTimersRef.current.forEach((timer) => clearTimeout(timer));
+    fallbackTimersRef.current.clear();
 
     // Small delay before stopping sources to allow fade
     stopTimeoutRef.current = setTimeout(() => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Problem

In Chats, the TTS highlight overlay can linger on a finished sentence after the audio has played, only clearing when the user toggles the chats window background → foreground.

### Root cause

The highlight overlay advances (and clears) inside the `onEnd` callback of `useTtsQueue.speak()`, which is wired to Web Audio API's `src.onended`:

- `useChatSpeechSync` enqueues a highlight segment per sentence.
- Each segment's `speak(text, onEnd)` registers an `onEnd` that splices the segment from the queue and calls `setCurrentHighlightSegment(queue[0] || null)`.
- The per-message effect in `ChatMessages.tsx` paints/clears the registry via the CSS Custom Highlight API based on `highlightSegment`.

Some browsers defer or throttle the `ended` event in a few specific scenarios that all map onto the user's repro:

- The page (or its iframe / worker scheduling) loses focus.
- The `AudioContext` briefly suspends/interrupts.
- iOS Safari quirks around audio output going to background.

When that happens, the audio actually played to completion but `src.onended` fires only later — typically when something forces the audio context back to a running state, e.g. `audioContext.ts`'s `focusHandler` calling `resumeAudioContext()` on window focus. That's exactly why switching the chats window to background and back unsticks the highlight.

### Fix

Add an audio-clock-aware fallback timer alongside `src.onended` so `onEnd` still fires shortly after the source is *expected* to finish playing:

- Wrap the existing end handler in an idempotent `finishSrc` (guarded by a single `ended` flag) and assign it to `src.onended`.
- After `src.start(start)`, schedule a fallback timer keyed on the source.
- On fire, the fallback re-checks against `ctx.currentTime` (which only advances while the context is running). If the audio clock hasn't caught up — context paused, or our initial estimate underestimated decode latency — we re-schedule for the remaining duration so we don't prematurely clear the highlight while audio is still pending playback.
- Whichever path wins the race fires `onEnd` once; the other becomes a no-op. The 250 ms cushion gives the native event a tiny grace period to win in the happy path.
- `stop()` cancels any pending fallback timers since `src.stop()` will dispatch `onended` for each source (and `finishSrc` is idempotent).

### Why this is safe

- The native `onended` path is preserved and still wins in the typical case.
- The fallback uses `ctx.currentTime` rather than wall-clock so a suspended/interrupted context doesn't trip it early.
- All `onEnd` invocations are idempotent (`ended` flag), so the highlight queue advances exactly once per source.
- Pending timers are tracked per-source in a `Map` and cleared in `finishSrc` and `stop()`, so they never leak across `unmount` / hot reload.

### Test plan

- ✅ `bunx tsc --noEmit -p tsconfig.app.json`
- ✅ `bun run test:unit` (234 tests pass, 0 fail)
- ✅ `bun test tests/test-chat-tts-highlight.test.ts tests/test-chat-speech-utils.test.ts`
- Manual: cloud env doesn't reliably play audio so a visual highlight repro wasn't possible; the fix is targeted at the `src.onended` delivery path verified via code review and matches the user's repro exactly (window background→foreground unsticking the overlay = `focusHandler` → `resumeAudioContext()` flushing the pending audio events).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-31571C81-5A35-4207-8F50-7E31D6966B79"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-31571C81-5A35-4207-8F50-7E31D6966B79"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

