### PR TITLE
fix(chats): force-clear TTS highlight when last spoken segment ends

### DIFF
--- a/src/apps/chats/hooks/useChatSpeechSync.ts
+++ b/src/apps/chats/hooks/useChatSpeechSync.ts
@@ -100,7 +100,24 @@ export function useChatSpeechSync({
         if (queueIndex !== -1) {
           highlightQueueRef.current.splice(queueIndex, 1);
         }
-        setCurrentHighlightSegment(highlightQueueRef.current[0] || null);
+        const next = highlightQueueRef.current[0] || null;
+        setCurrentHighlightSegment(next);
+        // When the last spoken segment ends, force-clear the global CSS Custom
+        // Highlight registry directly instead of relying solely on the per-
+        // message effect cleanup. React's `setHighlightSegment(null)` schedules
+        // a re-render, but the commit (and the cleanup that calls
+        // `clearTtsHighlight(ownerToken)`) can be delayed — most reproducibly
+        // when the chat window is backgrounded inside ryOS or the browser tab
+        // is in another foreground, since `setTimeout`/`requestAnimationFrame`
+        // are throttled there and React's commit can sit on the scheduler
+        // queue. That gap is what users see as "the highlight for done lines
+        // lingers until I switch the window in and out of focus": the
+        // foreground switch forces a fresh render that finally runs the
+        // cleanup. Wiping the registry here removes the overlay immediately,
+        // mirroring what `stopSpeech` already does for user-initiated stops.
+        if (next === null) {
+          clearTtsHighlight();
+        }
         onComplete?.();
       });
     },

--- a/tests/test-chat-tts-highlight.test.ts
+++ b/tests/test-chat-tts-highlight.test.ts
@@ -1,5 +1,10 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
 import { describe, expect, test } from "bun:test";
 import { stripMarkdownForMatching } from "../src/apps/chats/utils/ttsHighlight";
+
+const readSource = (relativePath: string): string =>
+  readFileSync(resolve(process.cwd(), relativePath), "utf-8");
 
 // stripMarkdownForMatching converts a slice of markdown source into the
 // plain text we expect to find in the rendered DOM, so the CSS Custom
@@ -56,5 +61,38 @@ describe("stripMarkdownForMatching", () => {
   test("does not mangle stray asterisks/underscores", () => {
     expect(stripMarkdownForMatching("a * b * c")).toBe("a * b * c");
     expect(stripMarkdownForMatching("snake_case_var")).toBe("snake_case_var");
+  });
+});
+
+// When the final spoken segment ends, the per-message React effect cleanup
+// in ChatMessages.tsx is responsible for calling `clearTtsHighlight`. In
+// practice that cleanup can be deferred — backgrounded tabs throttle the
+// scheduler, and ryOS app windows can sit on a stale commit until something
+// else forces a re-render. The fallback is to wipe the global CSS Custom
+// Highlight registry directly from the speak() onEnd callback as soon as the
+// queue empties, mirroring what `stopSpeech` already does for user stops.
+//
+// This source-level check ensures the fallback stays in place so we don't
+// regress to "highlight lingers on the last spoken line until you switch the
+// window in/out of focus".
+describe("useChatSpeechSync force-clears highlight on natural end", () => {
+  const source = readSource("src/apps/chats/hooks/useChatSpeechSync.ts");
+
+  test("imports clearTtsHighlight from the ttsHighlight utility", () => {
+    expect(source).toMatch(
+      /import\s*\{[^}]*\bclearTtsHighlight\b[^}]*\}\s*from\s*"\.\.\/utils\/ttsHighlight"/
+    );
+  });
+
+  test("stopSpeech still force-clears the registry for user-initiated stops", () => {
+    expect(source).toMatch(
+      /const\s+stopSpeech\s*=\s*useCallback\([\s\S]*?clearTtsHighlight\(\)/
+    );
+  });
+
+  test("speak() onEnd calls clearTtsHighlight when the queue is empty", () => {
+    expect(source).toMatch(
+      /speak\([^,]+,\s*\(\)\s*=>\s*\{[\s\S]*?next\s*===\s*null[\s\S]*?clearTtsHighlight\(\)/
+    );
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

In Chats, the TTS line highlight on the most recently spoken sentence could linger after audio playback finished. The overlay only cleared once something else forced a re-render — most reproducibly: switching the ryOS chat window (or browser tab) into the background and then back to the foreground.

## Root Cause

`useChatSpeechSync.stopSpeech` already force-clears the global CSS Custom Highlight registry to sidestep the React commit gap for user-initiated stops, but the **natural-end** path relied solely on the per-message effect cleanup in `ChatMessages.tsx`:

1. The audio source's `onended` fires, queue gets spliced, `setCurrentHighlightSegment(null)` is called.
2. React schedules a re-render.
3. The per-message `useEffect` cleanup runs and calls `clearTtsHighlight(ownerToken)`, which finally deletes the entry from `CSS.highlights`.

Steps 2–3 can be deferred when the scheduler is throttled (backgrounded browser tab, or a non-foreground ryOS app window), so the painted overlay stays visible on the last spoken line until the next commit. A foreground switch forces a fresh render that finally runs the cleanup, which is why the symptom "clears after I switch the window background then foreground" matches exactly.

## Fix

Mirror the `stopSpeech` fallback inside `speak()`'s `onEnd` callback in `enqueueHighlightSpeech`: when the highlight queue empties after splicing the just-finished segment, call `clearTtsHighlight()` directly so the painted overlay is removed immediately, without waiting for the React commit. Inter-segment transitions still flow through the owner-token-scoped React cleanup, so we don't introduce any new flicker between segments.

## Testing

- ✅ `bun test tests/test-chat-tts-highlight.test.ts` (8 existing + 3 new regression tests asserting the natural-end clear is wired up)
- ✅ `bun run test:unit` (234 / 234 pass)
- ✅ `bun run lint` (0 errors; pre-existing warnings unchanged)

Manual verification of the actual lingering symptom requires a live TTS provider + a backgrounded chat window, which isn't reliably reproducible in this cloud agent environment (no audio output, no `.env.local`); the regression test locks the fallback in place at the source level so the symptom can't silently come back.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-E37D7121-0BBD-439F-941D-1F320499E5A7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-E37D7121-0BBD-439F-941D-1F320499E5A7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

