### PR TITLE
fix(ipod): match music quiz snippet bar to now-playing aqua-progress in modern UI

### DIFF
--- a/src/apps/ipod/components/MusicQuiz.tsx
+++ b/src/apps/ipod/components/MusicQuiz.tsx
@@ -1020,24 +1020,29 @@ function SnippetProgressBar({
   running: boolean;
   isModernUi: boolean;
 }) {
-  return (
-    <div
-      className={cn(
-        "h-[6px] w-full shrink-0 rounded-full overflow-hidden",
-        isModernUi
-          ? "border border-[rgb(200,200,205)] bg-[rgb(245,245,247)]"
-          : "border border-[#0a3667]"
-      )}
-    >
+  // Modern UI uses the same aqua-progress chrome as the Now Playing screen
+  // (see `IpodScreen.tsx` — `aqua-progress` + `aqua-progress-fill`, 9px tall,
+  // square corners) so the quiz countdown reads as the same glossy aqua bar
+  // the player shows during normal playback. Classic skin keeps the
+  // monochrome 1st-gen LCD outline.
+  return isModernUi ? (
+    <div className="aqua-progress h-[9px] w-full shrink-0 rounded-none">
       <AnimatePresence mode="wait">
         <motion.div
           key={running ? "run" : "stop"}
-          className={cn(
-            "h-full",
-            isModernUi
-              ? "bg-gradient-to-b from-[rgb(96,176,246)] to-[rgb(52,122,181)]"
-              : "bg-[#0a3667]"
-          )}
+          className="aqua-progress-fill h-full rounded-none"
+          initial={{ width: "0%" }}
+          animate={{ width: running ? "100%" : "0%" }}
+          transition={{ duration: running ? durationMs / 1000 : 0, ease: "linear" }}
+        />
+      </AnimatePresence>
+    </div>
+  ) : (
+    <div className="h-[6px] w-full shrink-0 rounded-full overflow-hidden border border-[#0a3667]">
+      <AnimatePresence mode="wait">
+        <motion.div
+          key={running ? "run" : "stop"}
+          className="h-full bg-[#0a3667]"
           initial={{ width: "0%" }}
           animate={{ width: running ? "100%" : "0%" }}
           transition={{ duration: running ? durationMs / 1000 : 0, ease: "linear" }}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The Music Quiz snippet progress bar in the iPod **Modern UI** previously used a custom 6px rounded-full bar with a flat blue gradient. The Now Playing screen in the same Modern UI uses the glossy 9px `aqua-progress` track + `aqua-progress-fill` chrome (the same Aqua bar used by About This Finder / boot screen). These two bars sit next to each other in the same app and now read as the same component family.

This change updates `SnippetProgressBar` so the modern variant renders with `aqua-progress` / `aqua-progress-fill` (9px tall, square corners), matching the Now Playing progress bar exactly. Classic skin is unchanged.

## Implementation notes

- Only the modern branch of `SnippetProgressBar` is changed; the classic 1st-gen-LCD bar (`h-[6px]`, `#0a3667`) is preserved.
- The width is still driven by `framer-motion` so the countdown stays linear over the snippet duration; only the surrounding CSS classes change.
- The `.aqua-progress` selector is already scoped to `.ipod-modern-screen` in `src/styles/themes.css`, so no new CSS is needed — the quiz screen carries that class in modern UI.

## Testing

- `bun test tests/test-music-quiz-scoring.test.ts` — ✅ 4 pass
- `bunx tsc --noEmit -p tsconfig.app.json` — ✅ no errors

Per `AGENTS.md`, GUI/computer-use testing is skipped unless explicitly requested; the change is a scoped CSS swap that reuses an existing styled component.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4B6D4FC4-8139-422E-A80F-BC9119412FF4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4B6D4FC4-8139-422E-A80F-BC9119412FF4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

