### PR TITLE
fix(ipod): prevent alternating lyrics double-shift on overlay re-entry

### DIFF
--- a/src/apps/ipod/components/LyricsDisplay.tsx
+++ b/src/apps/ipod/components/LyricsDisplay.tsx
@@ -2201,8 +2201,13 @@ export function LyricsDisplay({
     const linesChanged = prevLinesRef.current !== displayOriginalLines;
     prevLinesRef.current = displayOriginalLines;
 
-    // Instantly update on song load, translation switch, or initial state
-    if (linesChanged || actualCurrentLine < 0) {
+    // Instantly update on song load, translation switch, initial state, or while
+    // the overlay is hidden. Keeping the pair in sync with the current line
+    // whenever the lyrics are not on screen prevents a stale pair from being
+    // rendered on the first paint after the user re-enters the lyrics view,
+    // which would otherwise cause a second visible animation right after the
+    // entry animation (the "double shift" bug).
+    if (linesChanged || actualCurrentLine < 0 || !visible) {
       setAltLines(computeAltVisibleLines(displayOriginalLines, actualCurrentLine));
       return;
     }
@@ -2231,7 +2236,7 @@ export function LyricsDisplay({
     }, delayMs);
 
     return () => clearTimeout(timer);
-  }, [alignment, displayOriginalLines, actualCurrentLine]);
+  }, [alignment, displayOriginalLines, actualCurrentLine, visible]);
 
   const nonAltVisibleLines = useMemo(() => {
     if (!displayOriginalLines.length) return [] as LyricLine[];


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

When the iPod lyrics overlay is re-entered (`Show Lyrics` toggled off then on, or the now-playing screen is re-entered) while the alternating-pair update timer from a previous line transition is still pending, the freshly-mounted `AnimatePresence` renders the **stale** pair for one paint and then immediately swaps to the correct pair. That second swap fights with the entry animation and looks like the lyrics shift twice when entering.

The user-visible symptom is exactly what the issue reports — "lyrics played in iPod screen would shift twice when entering".

## Root cause

`LyricsDisplay` keeps the visible alternating pair in `altLines` state. The state is updated either:
- instantly when lyrics load / song changes / `actualCurrentLine < 0`, or
- via a 20–400 ms `setTimeout` for normal line transitions (intentional delay so the current line lingers briefly before the swap).

The `useEffect` that schedules that timer did not depend on `visible`, so:
1. While the lyrics were visible, a line transition scheduled a delayed `setAltLines`.
2. The user toggled the overlay off before the timeout fired.
3. The `AnimatePresence` subtree unmounted, but `altLines` was now stale (still pointing at the previous pair).
4. The user toggled the overlay on; the freshly-mounted `AnimatePresence` rendered the stale pair, then a few ms later the original (still-pending) state update — or the next `useEffect` run — swapped to the correct pair, triggering a second visible enter/exit animation right on top of the first.

## Fix

Make `useEffect` also depend on `visible` and treat `!visible` as an "instant sync" case. That way, whenever the overlay is hidden the pair is kept in sync with the current line (with no delay), so the first paint after re-entry already shows the correct pair and `AnimatePresence` runs a single coherent entry animation.

```diff
-    if (linesChanged || actualCurrentLine < 0) {
+    if (linesChanged || actualCurrentLine < 0 || !visible) {
       setAltLines(computeAltVisibleLines(displayOriginalLines, actualCurrentLine));
       return;
     }
     ...
-  }, [alignment, displayOriginalLines, actualCurrentLine]);
+  }, [alignment, displayOriginalLines, actualCurrentLine, visible]);
```

## Verification

Reproduced the bug end-to-end in a headless Chromium against `bun run dev`, instrumenting `LyricsDisplay` to log the live computed transform/opacity of each lyric row on every `requestAnimationFrame`.

**Before the fix** — re-entering the overlay during the delayed transition window renders 3 motion divs in quick succession (old top **exiting** + new top **entering** + bottom **staying**), producing two visible animations:

```
tick=0 divs=2: 柴火寫了序… (stale top)        + 遠方的煙囪… (bottom)
tick=1 divs=3: 柴火寫了序… (exiting)          + 該不會是我的卡片… (entering) + 遠方的煙囪…
...
tick=30 divs=2: 該不會是我的卡片…              + 遠方的煙囪…
```

**After the fix** — same scenario renders the correct pair from the very first frame and animates in once:

```
tick=0 divs=2: 該不會是我的卡片… (correct top) + 遠方的煙囪… (bottom)
tick=1 divs=2: 該不會是我的卡片…              + 遠方的煙囪…
tick=22 divs=2: 該不會是我的卡片…             + 遠方的煙囪… (settled, transform=none)
```

Normal in-place line transitions during playback are unaffected — the delayed 20–400 ms window still applies and only the line that's leaving / entering animates while the staying line keeps its position.

![iPod lyrics after the fix — correct pair shown immediately on overlay re-entry](https://cursor.com/artifacts/c/art-d977d3e3-6f98-4650-9d4b-f5eaac81a70c)

**Testing**
- ✅ `bun test tests/test-lyrics-parsing.test.ts tests/test-ipod-lyrics-track-metadata.test.ts` — 20 pass / 0 fail
- ✅ `bun run lint` — 0 errors (pre-existing warnings only)
- ✅ Manual reproduction in headless Chromium: confirmed double-shift before fix, single smooth entry after fix

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-89170999-4C60-40D3-AA31-574243A05840"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-89170999-4C60-40D3-AA31-574243A05840"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

