### PR TITLE
Remove ellipsis from iPod "Search Songs" menu label

### DIFF
--- a/src/apps/ipod/hooks/useIpodLogic.ts
+++ b/src/apps/ipod/hooks/useIpodLogic.ts
@@ -2530,7 +2530,7 @@ export function useIpodLogic({
               showChevron: true,
             },
             {
-              label: t("apps.ipod.menu.searchSongs", "Search Songs..."),
+              label: t("apps.ipod.menu.searchSongs", "Search Songs"),
               action: () => {
                 registerActivity();
                 setIsSongSearchDialogOpen(true);

--- a/src/lib/locales/de/translation.json
+++ b/src/lib/locales/de/translation.json
@@ -2297,7 +2297,7 @@
         "screen": "Bildschirm",
         "screenClassic": "Klassisch",
         "screenModern": "Modern",
-        "searchSongs": "Lieder suchen...",
+        "searchSongs": "Lieder suchen",
         "shareApp": "App teilen...",
         "shareSong": "Titel teilen...",
         "showLyrics": "Liedtext anzeigen",

--- a/src/lib/locales/en/translation.json
+++ b/src/lib/locales/en/translation.json
@@ -1753,7 +1753,7 @@
       "description": "Music player",
       "menu": {
         "addSong": "Add Song...",
-        "searchSongs": "Search Songs...",
+        "searchSongs": "Search Songs",
         "shareSong": "Share Song...",
         "exportLibrary": "Export Library...",
         "importLibrary": "Import Library...",

--- a/src/lib/locales/es/translation.json
+++ b/src/lib/locales/es/translation.json
@@ -2297,7 +2297,7 @@
         "screen": "Pantalla",
         "screenClassic": "Clásico",
         "screenModern": "Moderno",
-        "searchSongs": "Buscar canciones...",
+        "searchSongs": "Buscar canciones",
         "shareApp": "Compartir aplicación...",
         "shareSong": "Compartir canción...",
         "showLyrics": "Mostrar letras",

--- a/src/lib/locales/fr/translation.json
+++ b/src/lib/locales/fr/translation.json
@@ -2297,7 +2297,7 @@
         "screen": "Écran",
         "screenClassic": "Classique",
         "screenModern": "Moderne",
-        "searchSongs": "Rechercher des morceaux...",
+        "searchSongs": "Rechercher des morceaux",
         "shareApp": "Partager l'app...",
         "shareSong": "Partager le morceau...",
         "showLyrics": "Afficher les paroles",

--- a/src/lib/locales/it/translation.json
+++ b/src/lib/locales/it/translation.json
@@ -2297,7 +2297,7 @@
         "screen": "Schermo",
         "screenClassic": "Classico",
         "screenModern": "Moderno",
-        "searchSongs": "Cerca brani...",
+        "searchSongs": "Cerca brani",
         "shareApp": "Condividi app...",
         "shareSong": "Condividi brano...",
         "showLyrics": "Mostra testo",

--- a/src/lib/locales/ja/translation.json
+++ b/src/lib/locales/ja/translation.json
@@ -2297,7 +2297,7 @@
         "screen": "画面",
         "screenClassic": "クラシック",
         "screenModern": "モダン",
-        "searchSongs": "曲を検索...",
+        "searchSongs": "曲を検索",
         "shareApp": "アプリを共有...",
         "shareSong": "曲を共有...",
         "showLyrics": "歌詞を表示",

--- a/src/lib/locales/ko/translation.json
+++ b/src/lib/locales/ko/translation.json
@@ -2297,7 +2297,7 @@
         "screen": "화면",
         "screenClassic": "클래식",
         "screenModern": "모던",
-        "searchSongs": "노래 검색...",
+        "searchSongs": "노래 검색",
         "shareApp": "앱 공유...",
         "shareSong": "노래 공유...",
         "showLyrics": "가사 보기",

--- a/src/lib/locales/pt/translation.json
+++ b/src/lib/locales/pt/translation.json
@@ -2297,7 +2297,7 @@
         "screen": "Tela",
         "screenClassic": "Clássico",
         "screenModern": "Moderno",
-        "searchSongs": "Pesquisar Músicas...",
+        "searchSongs": "Pesquisar Músicas",
         "shareApp": "Compartilhar App...",
         "shareSong": "Compartilhar Música...",
         "showLyrics": "Mostrar Letras",

--- a/src/lib/locales/ru/translation.json
+++ b/src/lib/locales/ru/translation.json
@@ -2297,7 +2297,7 @@
         "screen": "Экран",
         "screenClassic": "Классический",
         "screenModern": "Современный",
-        "searchSongs": "Поиск песен...",
+        "searchSongs": "Поиск песен",
         "shareApp": "Поделиться приложением...",
         "shareSong": "Поделиться песней...",
         "showLyrics": "Показать текст",

--- a/src/lib/locales/zh-TW/translation.json
+++ b/src/lib/locales/zh-TW/translation.json
@@ -2297,7 +2297,7 @@
         "screen": "螢幕",
         "screenClassic": "經典",
         "screenModern": "現代",
-        "searchSongs": "搜尋歌曲...",
+        "searchSongs": "搜尋歌曲",
         "shareApp": "分享應用程式…",
         "shareSong": "分享歌曲...",
         "showLyrics": "顯示歌詞",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Removes the trailing `...` from the iPod settings menu's "Search Songs" item, per request.

Updated the default label in `src/apps/ipod/hooks/useIpodLogic.ts` and all locale translations in `src/lib/locales/*/translation.json`.

### Testing
- Visual change only; the menu label text now reads "Search Songs" (no ellipsis) across all 10 supported locales.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-BE059075-237E-428E-BC89-7E521E98C120"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-BE059075-237E-428E-BC89-7E521E98C120"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

