### PR TITLE
iPod: alphabetic fast scroll for Music &gt; Songs and All Albums &gt; All Songs

### DIFF
--- a/src/apps/ipod/hooks/useIpodLogic.ts
+++ b/src/apps/ipod/hooks/useIpodLogic.ts
@@ -1650,17 +1650,35 @@ export function useIpodLogic({
   // Memoize the entire "All Songs" submenu items array. Without this,
   // every render rebuilt N closures, the menu-history sync effect saw a
   // new `items` reference, called `setMenuHistory(updated)`, and re-ran.
-  const allSongsMenuItems = useMemo(
+  //
+  // The list is sorted by track title so the classic iPod "scroll by
+  // letter" affordance lands on the right alphabetic group (the menu
+  // pushes that surface this list — Music > Songs and Music > Albums >
+  // All — opt into `alphabetic: true` so the wheel switches into
+  // letter-jump mode after a sustained fast spin). The playback queue
+  // mirrors the displayed order: tapping a song sets an Apple Music
+  // contextual queue of the sorted ids so next/previous walks the list
+  // exactly as the user sees it.
+  const sortedBrowsableTracks = useMemo(
     () =>
-      browsableTracks.map((track, index) => ({
-        label: track.title,
-        // Full library queue → pass null to clear any contextual queue.
-        action: () => playTrackFromMenu(track, index, null),
-        showChevron: false,
-        coverUrl: resolveTrackCoverUrl(track),
-      })),
-    [browsableTracks, playTrackFromMenu]
+      [...browsableTracks].sort((a, b) => {
+        const byTitle = a.title.localeCompare(b.title, undefined, {
+          sensitivity: "base",
+        });
+        if (byTitle !== 0) return byTitle;
+        return a.id.localeCompare(b.id, undefined, { sensitivity: "base" });
+      }),
+    [browsableTracks]
   );
+  const allSongsMenuItems = useMemo(() => {
+    const queueIds = sortedBrowsableTracks.map((track) => track.id);
+    return sortedBrowsableTracks.map((track, index) => ({
+      label: track.title,
+      action: () => playTrackFromMenu(track, index, queueIds),
+      showChevron: false,
+      coverUrl: resolveTrackCoverUrl(track),
+    }));
+  }, [sortedBrowsableTracks, playTrackFromMenu]);
 
   const appleMusicRecentlyAddedMenuItems = useMemo(() => {
     const loadingLabel = t("apps.ipod.menuItems.loading", "Loading…");
@@ -1967,6 +1985,7 @@ export function useIpodLogic({
               title: allSongsLabel,
               items: allSongsMenuItems,
               selectedIndex: 0,
+              alphabetic: true,
             });
           },
           showChevron: true,
@@ -2310,7 +2329,10 @@ export function useIpodLogic({
         },
         {
           label: songsLabel,
-          action: () => pushSubmenu(songsLabel, allSongsMenuItems),
+          action: () =>
+            pushSubmenu(songsLabel, allSongsMenuItems, {
+              alphabetic: true,
+            }),
           showChevron: true,
         },
         {
@@ -2356,7 +2378,10 @@ export function useIpodLogic({
       },
       {
         label: songsLabel,
-        action: () => pushSubmenu(allSongsLabel, allSongsMenuItems),
+        action: () =>
+          pushSubmenu(allSongsLabel, allSongsMenuItems, {
+            alphabetic: true,
+          }),
         showChevron: true,
       },
     ];
@@ -3275,6 +3300,7 @@ export function useIpodLogic({
         title: entry.title,
         displayTitle: entry.displayTitle,
         modernMediaList: entry.modernMediaList,
+        alphabetic: entry.alphabetic,
         items: rebuilt,
         selectedIndex: safeIdx,
       });
@@ -3390,6 +3416,7 @@ export function useIpodLogic({
       title: menu.title,
       displayTitle: menu.displayTitle,
       modernMediaList: menu.modernMediaList,
+      alphabetic: menu.alphabetic,
       selectedIndex:
         i === menuHistory.length - 1 ? selectedMenuItem : menu.selectedIndex,
     }));
@@ -3408,6 +3435,7 @@ export function useIpodLogic({
           entry.title === breadcrumb[i].title &&
           entry.displayTitle === breadcrumb[i].displayTitle &&
           entry.modernMediaList === breadcrumb[i].modernMediaList &&
+          entry.alphabetic === breadcrumb[i].alphabetic &&
           entry.selectedIndex === breadcrumb[i].selectedIndex
       );
     if (!isSame) store.setIpodMenuBreadcrumb(breadcrumb);
@@ -3875,7 +3903,10 @@ export function useIpodLogic({
         setSelectedMenuItem(lastMenu?.selectedIndex || 0);
       } else {
         // Last-resort fallback (truly empty navigation history): go to
-        // All Songs with the current track highlighted.
+        // All Songs with the current track highlighted. `allSongsMenuItems`
+        // is sorted by title, so look up the current song's index in
+        // that sorted order rather than reusing `browseCurrentIndex`
+        // (which is an index into the unsorted browsable library).
         const allSongsLabel = t("apps.ipod.menuItems.allSongs");
         const songsLabel = t("apps.ipod.menuItems.songs");
         const songsMenuIndex = Math.max(
@@ -3884,6 +3915,18 @@ export function useIpodLogic({
             (item) => item.label === songsLabel || item.label === allSongsLabel
           )
         );
+        const currentBrowseTrack =
+          browseCurrentIndex >= 0
+            ? browsableTracks[browseCurrentIndex]
+            : null;
+        const allSongsSelectedIndex = currentBrowseTrack
+          ? Math.max(
+              0,
+              sortedBrowsableTracks.findIndex(
+                (track) => track.id === currentBrowseTrack.id
+              )
+            )
+          : 0;
         setMenuHistory([
           mainMenu,
           {
@@ -3894,14 +3937,15 @@ export function useIpodLogic({
           {
             title: allSongsLabel,
             items: allSongsMenuItems,
-            selectedIndex: Math.max(0, browseCurrentIndex),
+            selectedIndex: allSongsSelectedIndex,
+            alphabetic: true,
           },
         ]);
-        setSelectedMenuItem(Math.max(0, browseCurrentIndex));
+        setSelectedMenuItem(allSongsSelectedIndex);
       }
       setMenuMode(true);
     }
-  }, [playClickSound, vibrate, registerActivity, isCoverFlowOpen, isMusicQuizOpen, isBrickGameOpen, isNowPlayingSongMenuOpen, closeNowPlayingSongMenu, restoreNowPlayingSongMenu, showVideo, toggleVideo, menuMode, menuHistory, mainMenuItems, musicMenuItems, allSongsMenuItems, browseCurrentIndex, cameFromNowPlayingMenuItem, t]);
+  }, [playClickSound, vibrate, registerActivity, isCoverFlowOpen, isMusicQuizOpen, isBrickGameOpen, isNowPlayingSongMenuOpen, closeNowPlayingSongMenu, restoreNowPlayingSongMenu, showVideo, toggleVideo, menuMode, menuHistory, mainMenuItems, musicMenuItems, allSongsMenuItems, browsableTracks, sortedBrowsableTracks, browseCurrentIndex, cameFromNowPlayingMenuItem, t]);
 
   // Cover Flow handlers
   const handleCenterLongPress = useCallback(() => {

--- a/src/stores/useIpodStore.ts
+++ b/src/stores/useIpodStore.ts
@@ -264,6 +264,13 @@ interface IpodData {
         displayTitle?: string;
         selectedIndex: number;
         modernMediaList?: boolean;
+        /**
+         * Mirrors {@link MenuHistoryEntry.alphabetic} so the wheel's
+         * fast scroll-by-letter affordance survives reopening the
+         * iPod at a deep menu level (Artists, Albums, the new All
+         * Songs / Songs flows).
+         */
+        alphabetic?: boolean;
       }[]
     | null;
   /**
@@ -626,6 +633,7 @@ export interface IpodState extends IpodData {
           displayTitle?: string;
           selectedIndex: number;
           modernMediaList?: boolean;
+          alphabetic?: boolean;
         }[]
       | null
   ) => void;
@@ -760,7 +768,7 @@ export function navigateActiveIpodTrack(
   }
 }
 
-const CURRENT_IPOD_STORE_VERSION = 37; // Breadcrumb may include modernMediaList for iPod media rows
+const CURRENT_IPOD_STORE_VERSION = 38; // Breadcrumb may include alphabetic flag so fast scroll-by-letter mode survives reopen
 
 // Helper function to get unplayed track IDs from history
 function getUnplayedTrackIds(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Apply the iPod wheel's classic "scroll by letter" affordance to the two All-Songs entry points that were missing it:

- **Music &gt; Songs** (both YouTube and Apple Music modes)
- **Music &gt; Artists &gt; All Albums &gt; All Songs**

When the user spins the wheel through one of these menus for a sustained stretch, the wheel jumps to the next/previous letter group and a large letter overlay is painted on screen — same affordance Music &gt; Artists, Music &gt; Albums, and Music &gt; Artists &gt; [Artist] &gt; All Songs already have.

## How

- Sort the shared `allSongsMenuItems` array by track title (`localeCompare`, base sensitivity) so the rows line up under their alphabetic letter group.
- Build the Apple Music playback `queueIds` from the sorted order so next/previous walks the list exactly as the user sees it — this mirrors how `artistAllSongsMenuItemsByTitle` already wires up its queue.
- Pass `alphabetic: true` to the three pushes that surface this menu:
  - `Music > Albums > All` → All Songs
  - `Music > Songs` (Apple Music branch)
  - `Music > Songs` (non-Apple Music branch)
- Update the last-resort fallback push (back-from-Now-Playing with no breadcrumb) to look up the current track's index in the sorted order and also mark itself alphabetic.

## Other menus are untouched

The user explicitly called out that songs in albums and songs in playlists should NOT change. Verified:

- **Music &gt; Albums &gt; [specific album]** — pushed without `alphabetic`, items are `albumMenuItemsByAlbum[albumKey]` in album track order. Unchanged.
- **Music &gt; Artists &gt; [Artist] &gt; [Album]** — pushed without `alphabetic`, items are `artistAlbumMenuItemsByTitle` in album track order. Unchanged.
- **Music &gt; Playlists &gt; [Playlist]** (Apple Music) — pushed without `alphabetic`, items are `applePlaylistTrackMenuItemsByPlaylist` in the order Apple Music returns. Unchanged.
- **Music &gt; Recently Added / Favorite Songs / Radio** — none push with `alphabetic`. Unchanged.

## Bonus: alphabetic survives reopen

While we were here: the breadcrumb persistence schema didn't round-trip the `alphabetic` flag, so reopening the iPod at a deep alphabetic menu (Artists, Albums, the new flows) wouldn't enable fast scroll-by-letter until the user navigated again. Added `alphabetic` to the breadcrumb entry type, the save/equality check, and the restore loop. Bumps `CURRENT_IPOD_STORE_VERSION` from 37 → 38 (purely additive, no migration needed since the field is optional).

## Testing

- `bunx tsc -p tsconfig.app.json --noEmit` — clean.
- `bun run test:unit` — 234 pass / 0 fail.
- `bun run build` — clean.

Manual GUI testing skipped per the repo's `AGENTS.md` ("Skip computer use / GUI-driven testing unless the user explicitly requests it").

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-C61065AC-0235-45E2-A89A-8519E94A2158"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-C61065AC-0235-45E2-A89A-8519E94A2158"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

