### PR TITLE
fix(ipod): prevent alternating lyrics double-shift on overlay re-entry

### DIFF
--- a/src/apps/ipod/components/LyricsDisplay.tsx
+++ b/src/apps/ipod/components/LyricsDisplay.tsx
@@ -2201,8 +2201,14 @@ export function LyricsDisplay({
     const linesChanged = prevLinesRef.current !== displayOriginalLines;
     prevLinesRef.current = displayOriginalLines;
 
-    // Instantly update on song load, translation switch, or initial state
-    if (linesChanged || actualCurrentLine < 0) {
+    // Instantly update on song load, translation switch, initial state, or
+    // while the overlay is hidden. Keeping the alternating pair in sync with
+    // the current line whenever the lyrics are off-screen prevents a stale
+    // pair from being painted on the first frame after the user re-enters
+    // the lyrics view (or switches songs while it is hidden), which would
+    // otherwise cause a second visible animation right after the entry
+    // animation — the "double shift" bug.
+    if (linesChanged || actualCurrentLine < 0 || !visible) {
       setAltLines(computeAltVisibleLines(displayOriginalLines, actualCurrentLine));
       return;
     }
@@ -2231,7 +2237,7 @@ export function LyricsDisplay({
     }, delayMs);
 
     return () => clearTimeout(timer);
-  }, [alignment, displayOriginalLines, actualCurrentLine]);
+  }, [alignment, displayOriginalLines, actualCurrentLine, visible]);
 
   const nonAltVisibleLines = useMemo(() => {
     if (!displayOriginalLines.length) return [] as LyricLine[];


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
When the iPod lyrics overlay is re-entered (or the song advances mid-line)
while the alternating-pair update timer is still pending, the freshly
mounted `AnimatePresence` renders the stale pair for one paint and then
immediately swaps to the correct pair. That second swap fights with the
entry animation and looks like the lyrics shift twice when entering.

### Root cause

`LyricsDisplay` keeps `altLines` (the visible pair in `Alternating` mode)
in a `useState` so a `setTimeout` can briefly defer per-line updates and
make the alternating layout feel less twitchy. The component remains
mounted while the overlay is hidden (it just returns `null` when
`!visible`), but the deferred update keeps running. If the song crosses
a line boundary while the user has the overlay hidden, the pending
`setAltLines` either fires after the next entry (causing a second
animation right after the entry) or, if the user re-enters during the
delay window, the first paint uses the stale pair and the deferred
timer flips it.

### Fix

Promote `visible` into the alternating effect's dependency list and take
the instant `setAltLines` branch whenever `!visible`. The pair is now
kept in sync with the current line whenever the lyrics are off-screen,
so the first paint after re-entering the lyrics view already shows the
correct pair and only the natural entry animation runs.

### Testing

- ✅ `bun run test:unit` (234 pass)
- Manually verified by toggling Show Lyrics on/off mid-song in the iPod
  app — only one entry animation now plays.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-C1BE57A7-E938-41B5-80F0-4A1193EC5E5F"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-C1BE57A7-E938-41B5-80F0-4A1193EC5E5F"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

