### PR TITLE
iPod: velocity-based threshold for letter-jump fast scroll

### DIFF
--- a/src/apps/ipod/hooks/useIpodLogic.ts
+++ b/src/apps/ipod/hooks/useIpodLogic.ts
@@ -36,6 +36,7 @@ import {
   resolveLyricsOverrideTargetId as resolveLyricsOverrideTargetIdHelper,
   resolveLyricsTrackMetadata,
 } from "../utils/lyricsTrackMetadata";
+import { recordRotationAndEvaluate } from "../utils/fastScrollVelocity";
 import { useShallow } from "zustand/react/shallow";
 import {
   useIpodStoreShallow,
@@ -4191,27 +4192,36 @@ export function useIpodLogic({
   // -------------------------------------------------------------------
   // "Scroll by letter" fast-scroll affordance.
   //
-  // Classic iPod behavior: when the user spins the wheel through an
-  // alphabetic menu (Artists / Albums) for a sustained stretch, each
-  // rotation begins jumping to the next/previous letter group instead
-  // of one row at a time, and a letter chip appears on screen so the
-  // user can see which section they're skimming. After a brief idle
-  // period the iPod drops back to normal per-item scrolling.
+  // Classic iPod behavior: when the user spins the wheel quickly
+  // through an alphabetic menu (Artists / Albums), each rotation
+  // begins jumping to the next/previous letter group instead of one
+  // row at a time, and a letter chip appears on screen so the user
+  // can see which section they're skimming. After the user slows
+  // down or stops, the iPod drops back to normal per-item scrolling.
   //
-  // We count consecutive rotations (any rotation within
-  // `FAST_SCROLL_RESET_MS` of the previous counts). Letter mode kicks
-  // in after the user has scrolled at least `FAST_SCROLL_THRESHOLD`
-  // items in one continuous gesture — roughly five pages of the
-  // 6-row modern menu — so it never fires from a casual flick of the
-  // wheel. The mode is sticky until `FAST_SCROLL_IDLE_MS` of no
-  // rotation, so a brief pause between letter jumps still feels like
-  // one continuous fast scroll.
+  // Detection is velocity-based, not count-based: we keep a sliding
+  // window of the last `FAST_SCROLL_WINDOW_SIZE` rotation timestamps
+  // and only activate letter mode when that window spans at most
+  // `FAST_SCROLL_ACTIVATE_MAX_MS` (i.e. the user is currently
+  // spinning the wheel rapidly). This means deliberate slow browsing
+  // never triggers letter-jump — no matter how many items the user
+  // scrolls through — because the inter-rotation interval stays
+  // wide. Only sustained rapid wheel-turning qualifies.
+  //
+  // Hysteresis: once active, letter mode stays sticky until either
+  // (a) the recent-window velocity drops below
+  // `FAST_SCROLL_DEACTIVATE_MAX_MS` (the user slowed down on
+  // purpose), or (b) `FAST_SCROLL_IDLE_MS` elapses with no rotation
+  // (the user stopped). This keeps brief mid-spin jitter from
+  // bouncing out of fast mode while still letting an intentional
+  // slow-down return to per-item scrolling without waiting for the
+  // idle timer.
   // -------------------------------------------------------------------
-  const FAST_SCROLL_RESET_MS = 600;
-  const FAST_SCROLL_THRESHOLD = 30; // 5 pages × 6 rows per page
+  const FAST_SCROLL_WINDOW_SIZE = 6;
+  const FAST_SCROLL_ACTIVATE_MAX_MS = 500; // ~12 rotations/sec average
+  const FAST_SCROLL_DEACTIVATE_MAX_MS = 900; // drop out when avg slows past ~6.7 rot/sec
   const FAST_SCROLL_IDLE_MS = 900;
-  const rotationStreakCountRef = useRef(0);
-  const rotationStreakLastAtRef = useRef(0);
+  const rotationTimestampsRef = useRef<number[]>([]);
   const fastScrollIdleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
     null
   );
@@ -4234,8 +4244,7 @@ export function useIpodLogic({
     }
     fastScrollIdleTimerRef.current = setTimeout(() => {
       fastScrollActiveRef.current = false;
-      rotationStreakCountRef.current = 0;
-      rotationStreakLastAtRef.current = 0;
+      rotationTimestampsRef.current = [];
       setFastScrollLetter(null);
       fastScrollIdleTimerRef.current = null;
     }, FAST_SCROLL_IDLE_MS);
@@ -4258,8 +4267,7 @@ export function useIpodLogic({
     if (!menuMode || !top?.alphabetic) {
       if (fastScrollActiveRef.current || fastScrollLetter !== null) {
         fastScrollActiveRef.current = false;
-        rotationStreakCountRef.current = 0;
-        rotationStreakLastAtRef.current = 0;
+        rotationTimestampsRef.current = [];
         if (fastScrollIdleTimerRef.current) {
           clearTimeout(fastScrollIdleTimerRef.current);
           fastScrollIdleTimerRef.current = null;
@@ -4311,29 +4319,39 @@ export function useIpodLogic({
         const menuLength = currentMenu.items.length;
         if (menuLength === 0) return;
 
-        // Track rotation streak for the letter-jump affordance. We
-        // count consecutive rotations (any rotation within
-        // `FAST_SCROLL_RESET_MS` of the last) and trigger letter-jump
-        // mode once the user has scrolled enough rows in one
-        // continuous gesture (~3 pages of the modern 6-row menu).
-        const now = Date.now();
-        const sinceLast = now - rotationStreakLastAtRef.current;
-        if (
-          rotationStreakLastAtRef.current === 0 ||
-          sinceLast > FAST_SCROLL_RESET_MS
-        ) {
-          rotationStreakCountRef.current = 1;
-        } else {
-          rotationStreakCountRef.current += 1;
-        }
-        rotationStreakLastAtRef.current = now;
+        // Velocity-based letter-jump detection. `recordRotationAndEvaluate`
+        // pushes the current timestamp into a ring buffer and returns
+        // an activate/deactivate suggestion when the window-span
+        // crosses the configured thresholds. We deliberately ignore
+        // how many rotations the user has produced in total — only
+        // how quickly they're producing them right now — so a long,
+        // slow browse never trips into letter-skip mode the way the
+        // old count-based threshold could.
         const isAlphabetic = Boolean(currentMenu.alphabetic);
-        if (
-          isAlphabetic &&
-          !fastScrollActiveRef.current &&
-          rotationStreakCountRef.current >= FAST_SCROLL_THRESHOLD
-        ) {
-          fastScrollActiveRef.current = true;
+        if (isAlphabetic) {
+          const decision = recordRotationAndEvaluate(
+            rotationTimestampsRef.current,
+            Date.now(),
+            fastScrollActiveRef.current,
+            {
+              windowSize: FAST_SCROLL_WINDOW_SIZE,
+              activateMaxMs: FAST_SCROLL_ACTIVATE_MAX_MS,
+              deactivateMaxMs: FAST_SCROLL_DEACTIVATE_MAX_MS,
+            }
+          );
+          if (decision === "activate") {
+            fastScrollActiveRef.current = true;
+          } else if (decision === "deactivate") {
+            // User intentionally slowed down — leave letter mode
+            // immediately rather than waiting for the idle timer so
+            // deliberate row-by-row navigation feels responsive.
+            fastScrollActiveRef.current = false;
+            setFastScrollLetter(null);
+            if (fastScrollIdleTimerRef.current) {
+              clearTimeout(fastScrollIdleTimerRef.current);
+              fastScrollIdleTimerRef.current = null;
+            }
+          }
         }
         const useLetterJump = isAlphabetic && fastScrollActiveRef.current;
 

--- a/src/apps/ipod/utils/fastScrollVelocity.ts
+++ b/src/apps/ipod/utils/fastScrollVelocity.ts
@@ -1,0 +1,54 @@
+// Velocity-based detector for the iPod wheel's "scroll by letter"
+// affordance. Kept as a pure, stateful helper so the threshold logic
+// is unit-testable without mounting the full `useIpodLogic` hook.
+//
+// Semantics
+// ---------
+// Callers pass in a mutable ring buffer of timestamps for the most
+// recent rotation events on an alphabetic menu, the current
+// `Date.now()`, whether letter-jump mode is currently active, and a
+// configuration object. The helper:
+//
+//   1. Appends `now` to the buffer and trims it to `windowSize`.
+//   2. Returns the recommended state transition based on the time
+//      span across the (full) window:
+//        - "activate"   — was inactive, window span ≤ activateMaxMs
+//        - "deactivate" — was active, window span ≥ deactivateMaxMs
+//        - "none"       — neither edge crossed (or window not full)
+//
+// The asymmetric thresholds give natural hysteresis: a clearly rapid
+// spin is required to enter letter-jump mode, but a moderate slow-down
+// is enough to leave it. Slow browsing never activates because the
+// inter-rotation interval keeps the window span above activateMaxMs
+// regardless of how many rotations have happened in total.
+
+export interface FastScrollVelocityConfig {
+  windowSize: number;
+  activateMaxMs: number;
+  deactivateMaxMs: number;
+}
+
+export type FastScrollVelocityDecision = "activate" | "deactivate" | "none";
+
+export function recordRotationAndEvaluate(
+  timestamps: number[],
+  now: number,
+  active: boolean,
+  config: FastScrollVelocityConfig
+): FastScrollVelocityDecision {
+  timestamps.push(now);
+  if (timestamps.length > config.windowSize) {
+    timestamps.shift();
+  }
+  if (timestamps.length < config.windowSize) {
+    return "none";
+  }
+  const windowSpanMs = now - timestamps[0];
+  if (!active && windowSpanMs <= config.activateMaxMs) {
+    return "activate";
+  }
+  if (active && windowSpanMs >= config.deactivateMaxMs) {
+    return "deactivate";
+  }
+  return "none";
+}

--- a/tests/test-ipod-fast-scroll-velocity.test.ts
+++ b/tests/test-ipod-fast-scroll-velocity.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, test } from "bun:test";
+import { recordRotationAndEvaluate } from "../src/apps/ipod/utils/fastScrollVelocity";
+
+const config = {
+  windowSize: 6,
+  activateMaxMs: 500,
+  deactivateMaxMs: 900,
+};
+
+function feed(
+  intervals: number[],
+  startActive = false,
+  startAt = 1_000
+): {
+  decisions: string[];
+  finalTimestamps: number[];
+  finalActive: boolean;
+} {
+  const timestamps: number[] = [];
+  let active = startActive;
+  let now = startAt;
+  const decisions: string[] = [];
+  for (let i = 0; i < intervals.length; i++) {
+    now += intervals[i];
+    const decision = recordRotationAndEvaluate(timestamps, now, active, config);
+    decisions.push(decision);
+    if (decision === "activate") active = true;
+    if (decision === "deactivate") active = false;
+  }
+  return { decisions, finalTimestamps: timestamps, finalActive: active };
+}
+
+describe("recordRotationAndEvaluate", () => {
+  test("emits 'none' while window is not yet full", () => {
+    const timestamps: number[] = [];
+    let active = false;
+    // 5 ultra-fast rotations: still under windowSize=6, must stay "none".
+    for (let i = 0; i < 5; i++) {
+      const decision = recordRotationAndEvaluate(
+        timestamps,
+        1_000 + i * 50,
+        active,
+        config
+      );
+      expect(decision).toBe("none");
+      if (decision === "activate") active = true;
+    }
+    expect(active).toBe(false);
+    expect(timestamps.length).toBe(5);
+  });
+
+  test("slow browsing never activates letter mode, even after many rotations", () => {
+    // 500ms per rotation = right at the edge of the old 600ms reset
+    // window: under the old count-based logic this would have
+    // activated after 30 rotations. With the velocity-based logic the
+    // window span is 6 * 500ms = 2500ms — well above the 500ms
+    // activate threshold — so we never enter letter mode.
+    const intervals = new Array(60).fill(500);
+    const { decisions, finalActive } = feed(intervals);
+    expect(finalActive).toBe(false);
+    expect(decisions.some((d) => d === "activate")).toBe(false);
+  });
+
+  test("moderate browsing (200ms / rotation) does not activate either", () => {
+    const intervals = new Array(40).fill(200);
+    const { decisions, finalActive } = feed(intervals);
+    expect(finalActive).toBe(false);
+    expect(decisions.includes("activate")).toBe(false);
+  });
+
+  test("rapid wheel spin activates exactly once the window fills", () => {
+    // 70ms per rotation → 6 rotations span 350ms (≤ 500ms), so the
+    // sixth rotation should produce "activate".
+    const intervals = new Array(10).fill(70);
+    const { decisions } = feed(intervals);
+    // First five rotations: window not yet full -> "none".
+    expect(decisions.slice(0, 5).every((d) => d === "none")).toBe(true);
+    // Sixth rotation completes the window and triggers activation.
+    expect(decisions[5]).toBe("activate");
+    // Subsequent rotations stay in active mode (no further decisions
+    // from the helper, since "activate" is a one-shot edge).
+    expect(decisions.slice(6).every((d) => d === "none")).toBe(true);
+  });
+
+  test("once active, dropping to slow speed deactivates without waiting", () => {
+    // Warm up: six fast rotations to enter letter mode.
+    const fastIntervals = new Array(6).fill(60);
+    // Then six slow rotations (200ms each) → 6 * 200ms = 1200ms span
+    // > 900ms deactivate threshold once they dominate the window.
+    const slowIntervals = new Array(6).fill(200);
+    const { decisions, finalActive } = feed([
+      ...fastIntervals,
+      ...slowIntervals,
+    ]);
+    expect(decisions[5]).toBe("activate");
+    expect(decisions.slice(6)).toContain("deactivate");
+    expect(finalActive).toBe(false);
+  });
+
+  test("brief jitter inside the spin does not bounce out of fast mode", () => {
+    // Fast spin to engage…
+    const fastIntervals = new Array(6).fill(60);
+    // …then one slightly slower step (~120ms) — window span becomes
+    // 5 * 60 + 120 = 420ms, still well under deactivateMaxMs (900ms).
+    const jitter = [120];
+    const { decisions, finalActive } = feed([...fastIntervals, ...jitter]);
+    expect(decisions[5]).toBe("activate");
+    expect(decisions[6]).toBe("none");
+    expect(finalActive).toBe(true);
+  });
+
+  test("after deactivation, rapid scrolling can re-activate", () => {
+    const fast = new Array(6).fill(60);
+    const slow = new Array(6).fill(200);
+    const fastAgain = new Array(6).fill(60);
+    const { decisions, finalActive } = feed([...fast, ...slow, ...fastAgain]);
+    expect(decisions).toContain("activate");
+    expect(decisions).toContain("deactivate");
+    // Last segment should re-activate eventually as the fast
+    // timestamps push the slow ones out of the window.
+    const lastActivateIdx = decisions.lastIndexOf("activate");
+    const lastDeactivateIdx = decisions.lastIndexOf("deactivate");
+    expect(lastActivateIdx).toBeGreaterThan(lastDeactivateIdx);
+    expect(finalActive).toBe(true);
+  });
+
+  test("ring buffer is bounded by windowSize", () => {
+    const intervals = new Array(50).fill(80);
+    const { finalTimestamps } = feed(intervals);
+    expect(finalTimestamps.length).toBe(config.windowSize);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The iPod's "scroll by letter" fast-scroll affordance was activating during deliberate, slow browsing — not just rapid wheel spins.

The old detector in `useIpodLogic` was purely **count-based**: any rotation within 600ms of the previous one extended a streak, and after 30 consecutive counts letter-jump kicked in. That meant slowly stepping through a long alphabetic list at ~500ms/row would still ramp into letter-skip mode after ~15 seconds, surprising the user with sudden letter jumps they never asked for.

## Fix

Replace the count-based threshold with a **velocity-based** sliding window:

- Track the last `FAST_SCROLL_WINDOW_SIZE = 6` rotation timestamps on alphabetic menus.
- **Activate** letter mode only when those 6 rotations fit inside `FAST_SCROLL_ACTIVATE_MAX_MS = 500` (≈ 12 rotations / sec — a clearly rapid spin).
- **Deactivate** when the window span exceeds `FAST_SCROLL_DEACTIVATE_MAX_MS = 900` (≈ 6.7 rotations / sec — user intentionally slowed down), so deliberate row-by-row navigation feels responsive instead of waiting for the 900ms idle timer.
- Asymmetric thresholds give hysteresis: a brief mid-spin jitter does not bounce out of fast mode.

Because activation depends on *current spin velocity* rather than cumulative count, slow or moderate browsing never trips the threshold no matter how long it continues.

## Implementation

- New pure helper `src/apps/ipod/utils/fastScrollVelocity.ts` (`recordRotationAndEvaluate`) — ring buffer + threshold check. Easy to unit test without mounting the full hook.
- `useIpodLogic` now calls the helper, and the existing "exit alphabetic menu" / idle-timer cleanup paths were updated to clear the new ring buffer.
- Added `tests/test-ipod-fast-scroll-velocity.test.ts` covering the regression scenario and the new edges.

## Testing

- ✅ `bun test tests/test-ipod-fast-scroll-velocity.test.ts` (8 / 8 pass — includes the regression case "60 slow rotations never activate")
- ✅ `bun test tests/test-ipod-track-order.test.ts tests/test-ipod-lyrics-track-metadata.test.ts tests/test-ipod-apple-music.test.ts tests/test-ipod-apple-music-menu-loading.test.ts` (93 / 93 pass)
- ✅ `bun run test:unit` (234 / 234 pass)
- ✅ `bunx tsc -b --noEmit`
- ✅ `bun run lint src/apps/ipod/utils/fastScrollVelocity.ts src/apps/ipod/hooks/useIpodLogic.ts tests/test-ipod-fast-scroll-velocity.test.ts` (0 errors; same 140 pre-existing project-wide warnings as on `main`)

GUI testing was skipped per AGENTS.md (no user request for visual verification; behavior is logic-only and the unit tests exercise the exact threshold scenarios).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-214265A5-85BA-4840-99B1-BB5B964D42BD"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-214265A5-85BA-4840-99B1-BB5B964D42BD"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

