### PR TITLE
Fix iPod Apple Music playlist menu collisions

### DIFF
--- a/src/apps/ipod/hooks/useIpodLogic.ts
+++ b/src/apps/ipod/hooks/useIpodLogic.ts
@@ -2246,8 +2246,6 @@ export function useIpodLogic({
       "apps.ipod.menuItems.favoriteSongs",
       "Favorite Songs"
     );
-    const playlistsLabel = t("apps.ipod.menuItems.playlists");
-    const radioLabel = t("apps.ipod.menuItems.radio", "Radio");
     const radioLabel = t("apps.ipod.menuItems.radio", "Radio");
     const geniusLabel = t("apps.ipod.menuItems.genius", "Genius");
 
@@ -2655,6 +2653,8 @@ export function useIpodLogic({
       "apps.ipod.menuItems.favoriteSongs",
       "Favorite Songs"
     );
+    const playlistsLabel = t("apps.ipod.menuItems.playlists");
+    const radioLabel = t("apps.ipod.menuItems.radio", "Radio");
     const matchFromHistory = (
       hist: MenuHistoryEntry[] | null
     ): NowPlayingPlaylistContext | null => {

--- a/src/apps/ipod/hooks/useIpodLogic.ts
+++ b/src/apps/ipod/hooks/useIpodLogic.ts
@@ -81,6 +81,11 @@ import {
   resolveAppleMusicMenuTitlebarLoading,
   shouldUseModernAppleMusicTitlebarLoading,
 } from "../utils/appleMusicMenuLoading";
+import {
+  getAppleMusicPlaylistIdFromMenuTitle,
+  getAppleMusicPlaylistMenuTitle,
+  resolveAppleMusicPlaylistMenu,
+} from "../utils/appleMusicPlaylistMenu";
 
 // User-agent sniffing is constant for the document lifetime, so compute once
 // at module load instead of re-running these regexes on every render of the
@@ -2202,7 +2207,8 @@ export function useIpodLogic({
             registerActivity();
             requestPlaylistTracksIfNeeded(playlist.id);
             pushMenuChild({
-              title: playlist.name,
+              title: getAppleMusicPlaylistMenuTitle(playlist.id),
+              displayTitle: playlist.name,
               items: applePlaylistTrackMenuItemsByPlaylist[playlist.id] ?? EMPTY_IPOD_MENU_ITEMS,
               selectedIndex: 0,
               modernMediaList: true,
@@ -2240,6 +2246,8 @@ export function useIpodLogic({
       "apps.ipod.menuItems.favoriteSongs",
       "Favorite Songs"
     );
+    const playlistsLabel = t("apps.ipod.menuItems.playlists");
+    const radioLabel = t("apps.ipod.menuItems.radio", "Radio");
     const radioLabel = t("apps.ipod.menuItems.radio", "Radio");
     const geniusLabel = t("apps.ipod.menuItems.genius", "Genius");
 
@@ -2672,10 +2680,14 @@ export function useIpodLogic({
         ) {
           return { kind: "system", system: "favorites" };
         }
-        const playlist = appleMusicPlaylists.find(
-          (candidate) => candidate.name === entry.title
-        );
-        if (playlist) return { kind: "userPlaylist", playlist };
+        const playlist = resolveAppleMusicPlaylistMenu(entry, appleMusicPlaylists);
+        const isAppleMusicPlaylistsMenu =
+          entry.title === playlistsLabel && parent?.title === musicLabel;
+        const isAppleMusicRadioMenu =
+          entry.title === radioLabel && parent?.title === musicLabel;
+        if (playlist && !isAppleMusicPlaylistsMenu && !isAppleMusicRadioMenu) {
+          return { kind: "userPlaylist", playlist };
+        }
       }
       return null;
     };
@@ -2862,7 +2874,8 @@ export function useIpodLogic({
           modernMediaList: true,
         },
         {
-          title: playlist.name,
+          title: getAppleMusicPlaylistMenuTitle(playlist.id),
+          displayTitle: playlist.name,
           items:
             applePlaylistTrackMenuItemsByPlaylist[playlist.id] ??
             EMPTY_IPOD_MENU_ITEMS,
@@ -3145,6 +3158,33 @@ export function useIpodLogic({
 
   // Helper function to rebuild menu items based on current tracks
   const rebuildMenuItems = useCallback((menu: typeof menuHistory[0]): typeof menuHistory[0]["items"] | null => {
+    const playlistsLabel = t("apps.ipod.menuItems.playlists");
+    const recentlyAddedLabel = t(
+      "apps.ipod.menuItems.recentlyAdded",
+      "Recently Added"
+    );
+    const favoriteSongsLabel = t(
+      "apps.ipod.menuItems.favoriteSongs",
+      "Favorite Songs"
+    );
+    const radioLabel = t("apps.ipod.menuItems.radio", "Radio");
+    const playlistMenu = resolveAppleMusicPlaylistMenu(menu, appleMusicPlaylists);
+    const playlistMenuUsesOpaqueTitle =
+      getAppleMusicPlaylistIdFromMenuTitle(menu.title) !== null;
+    if (
+      playlistMenu &&
+      (playlistMenuUsesOpaqueTitle ||
+        (menu.title !== playlistsLabel &&
+          menu.title !== recentlyAddedLabel &&
+          menu.title !== favoriteSongsLabel &&
+          menu.title !== radioLabel))
+    ) {
+      return (
+        applePlaylistTrackMenuItemsByPlaylist[playlistMenu.id] ??
+        EMPTY_IPOD_MENU_ITEMS
+      );
+    }
+
     if (menu.title === t("apps.ipod.menuItems.ipod")) {
       return mainMenuItems;
     } else if (menu.title === t("apps.ipod.menuItems.music")) {
@@ -3155,21 +3195,17 @@ export function useIpodLogic({
       return nowPlayingSongMenuItems;
     } else if (
       !isAppleMusic &&
-      (menu.title === t("apps.ipod.menuItems.recentlyAdded", "Recently Added") ||
-        menu.title === t("apps.ipod.menuItems.favoriteSongs", "Favorite Songs") ||
-        menu.title === t("apps.ipod.menuItems.radio", "Radio") ||
-        menu.title === t("apps.ipod.menuItems.playlists"))
+      (menu.title === recentlyAddedLabel ||
+        menu.title === favoriteSongsLabel ||
+        menu.title === radioLabel ||
+        menu.title === playlistsLabel)
     ) {
       return null;
-    } else if (
-      menu.title === t("apps.ipod.menuItems.recentlyAdded", "Recently Added")
-    ) {
+    } else if (menu.title === recentlyAddedLabel) {
       return appleMusicRecentlyAddedMenuItems;
-    } else if (
-      menu.title === t("apps.ipod.menuItems.favoriteSongs", "Favorite Songs")
-    ) {
+    } else if (menu.title === favoriteSongsLabel) {
       return appleMusicFavoritesMenuItems;
-    } else if (menu.title === t("apps.ipod.menuItems.radio", "Radio")) {
+    } else if (menu.title === radioLabel) {
       return appleMusicRadioMenuItems;
     } else if (menu.title === t("apps.ipod.menuItems.extras")) {
       // Extras submenu has stable items; keep existing references to avoid stale closures.
@@ -3181,7 +3217,7 @@ export function useIpodLogic({
       // Return the memoized array — same reference unless tracks changed,
       // so the menu-history sync effect skips a redundant setMenuHistory.
       return allSongsMenuItems;
-    } else if (menu.title === t("apps.ipod.menuItems.playlists")) {
+    } else if (menu.title === playlistsLabel) {
       return applePlaylistsMenuItems;
     } else if (menu.title === t("apps.ipod.menuItems.artists")) {
       return artistsListMenuItems;
@@ -3196,12 +3232,9 @@ export function useIpodLogic({
     } else if (albumMenuItemsByAlbum[menu.title]) {
       return albumMenuItemsByAlbum[menu.title];
     } else {
-      const playlist = appleMusicPlaylists.find(
-        (entry) => entry.name === menu.title
-      );
-      if (playlist) {
+      if (playlistMenu) {
         return (
-          applePlaylistTrackMenuItemsByPlaylist[playlist.id] ??
+          applePlaylistTrackMenuItemsByPlaylist[playlistMenu.id] ??
           EMPTY_IPOD_MENU_ITEMS
         );
       }

--- a/src/apps/ipod/utils/appleMusicPlaylistMenu.ts
+++ b/src/apps/ipod/utils/appleMusicPlaylistMenu.ts
@@ -1,0 +1,33 @@
+import type { AppleMusicPlaylist } from "@/stores/useIpodStore";
+import type { MenuHistoryEntry } from "../types";
+
+const APPLE_MUSIC_PLAYLIST_MENU_TITLE_PREFIX = "appleMusicPlaylist:";
+
+export function getAppleMusicPlaylistMenuTitle(playlistId: string): string {
+  return `${APPLE_MUSIC_PLAYLIST_MENU_TITLE_PREFIX}${playlistId}`;
+}
+
+export function getAppleMusicPlaylistIdFromMenuTitle(
+  title: string
+): string | null {
+  return title.startsWith(APPLE_MUSIC_PLAYLIST_MENU_TITLE_PREFIX)
+    ? title.slice(APPLE_MUSIC_PLAYLIST_MENU_TITLE_PREFIX.length)
+    : null;
+}
+
+export function resolveAppleMusicPlaylistMenu(
+  menu: Pick<MenuHistoryEntry, "title" | "displayTitle" | "modernMediaList">,
+  playlists: AppleMusicPlaylist[]
+): AppleMusicPlaylist | null {
+  const playlistId = getAppleMusicPlaylistIdFromMenuTitle(menu.title);
+  if (playlistId) {
+    return playlists.find((playlist) => playlist.id === playlistId) ?? null;
+  }
+
+  if (!menu.modernMediaList) {
+    return null;
+  }
+
+  const legacyName = menu.displayTitle ?? menu.title;
+  return playlists.find((playlist) => playlist.name === legacyName) ?? null;
+}

--- a/tests/test-ipod-apple-music-playlist-menu.test.ts
+++ b/tests/test-ipod-apple-music-playlist-menu.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from "bun:test";
+import type { AppleMusicPlaylist } from "../src/stores/useIpodStore";
+import {
+  getAppleMusicPlaylistIdFromMenuTitle,
+  getAppleMusicPlaylistMenuTitle,
+  resolveAppleMusicPlaylistMenu,
+} from "../src/apps/ipod/utils/appleMusicPlaylistMenu";
+
+const playlists: AppleMusicPlaylist[] = [
+  { id: "p-ipod", name: "iPod", trackCount: 2 },
+  { id: "p-road-trip", name: "Road Trip", trackCount: 12 },
+];
+
+describe("Apple Music playlist menu titles", () => {
+  test("uses an opaque playlist id title instead of the visible playlist name", () => {
+    const title = getAppleMusicPlaylistMenuTitle("p-ipod");
+
+    expect(title).not.toBe("iPod");
+    expect(getAppleMusicPlaylistIdFromMenuTitle(title)).toBe("p-ipod");
+  });
+
+  test("resolves a playlist named iPod without confusing it for the root menu", () => {
+    const playlist = resolveAppleMusicPlaylistMenu(
+      {
+        title: getAppleMusicPlaylistMenuTitle("p-ipod"),
+        displayTitle: "iPod",
+        modernMediaList: true,
+      },
+      playlists
+    );
+
+    expect(playlist?.id).toBe("p-ipod");
+  });
+
+  test("keeps legacy root breadcrumb titles from resolving as playlists", () => {
+    const playlist = resolveAppleMusicPlaylistMenu(
+      { title: "iPod", modernMediaList: false },
+      playlists
+    );
+
+    expect(playlist).toBeNull();
+  });
+
+  test("supports legacy playlist breadcrumbs that stored the visible name", () => {
+    const playlist = resolveAppleMusicPlaylistMenu(
+      { title: "iPod", modernMediaList: true },
+      playlists
+    );
+
+    expect(playlist?.id).toBe("p-ipod");
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Store Apple Music playlist menu levels with opaque playlist-id titles while preserving the visible playlist name in `displayTitle`.
- Resolve playlist menus by playlist id first and keep legacy visible-name breadcrumbs working when they are actual media-list entries.
- Add unit coverage for a playlist named `iPod` so it opens playlist tracks instead of rebuilding as the root menu.

### Testing
- `bun test tests/test-ipod-apple-music-playlist-menu.test.ts`
- `bun test tests/test-ipod-apple-music-menu-loading.test.ts`
- `bun run build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1F859311-C37A-4CBD-8141-70E0F5EB9BC7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1F859311-C37A-4CBD-8141-70E0F5EB9BC7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

