### PR TITLE
Improve iPod input handling and sync code quality

### DIFF
--- a/src/apps/ipod/components/IpodAppComponent.tsx
+++ b/src/apps/ipod/components/IpodAppComponent.tsx
@@ -257,6 +257,60 @@ export function IpodAppComponent({
     [isAppleMusic, setDisplayMode, showStatus, t]
   );
 
+  const clearScreenLongPressTimer = useCallback(() => {
+    if (screenLongPressTimerRef.current) {
+      clearTimeout(screenLongPressTimerRef.current);
+      screenLongPressTimerRef.current = null;
+    }
+  }, [screenLongPressTimerRef]);
+
+  const startScreenLongPress = useCallback(
+    (x: number, y: number) => {
+      clearScreenLongPressTimer();
+      screenLongPressFiredRef.current = false;
+      screenLongPressStartPos.current = { x, y };
+      screenLongPressTimerRef.current = setTimeout(() => {
+        screenLongPressFiredRef.current = true;
+        handleCenterLongPress();
+      }, 500);
+    },
+    [
+      clearScreenLongPressTimer,
+      screenLongPressFiredRef,
+      screenLongPressStartPos,
+      screenLongPressTimerRef,
+      handleCenterLongPress,
+    ]
+  );
+
+  const cancelScreenLongPressOnMove = useCallback(
+    (x: number, y: number) => {
+      if (!screenLongPressStartPos.current || !screenLongPressTimerRef.current) {
+        return;
+      }
+      const dx = x - screenLongPressStartPos.current.x;
+      const dy = y - screenLongPressStartPos.current.y;
+      if (
+        Math.abs(dx) > SCREEN_LONG_PRESS_MOVE_THRESHOLD ||
+        Math.abs(dy) > SCREEN_LONG_PRESS_MOVE_THRESHOLD
+      ) {
+        clearScreenLongPressTimer();
+        screenLongPressStartPos.current = null;
+      }
+    },
+    [
+      clearScreenLongPressTimer,
+      screenLongPressStartPos,
+      screenLongPressTimerRef,
+      SCREEN_LONG_PRESS_MOVE_THRESHOLD,
+    ]
+  );
+
+  const stopScreenLongPress = useCallback(() => {
+    clearScreenLongPressTimer();
+    screenLongPressStartPos.current = null;
+  }, [clearScreenLongPressTimer, screenLongPressStartPos]);
+
   const menuBar = (
     <IpodMenuBar
       onClose={handleClose}
@@ -342,78 +396,24 @@ export function IpodAppComponent({
                 maxHeight: IPOD_MODERN_SCREEN_HEIGHT_PX,
               }}
               onMouseDown={(e) => {
-                // Start long press timer for Now Playing song menu
-                if (screenLongPressTimerRef.current) clearTimeout(screenLongPressTimerRef.current);
-                screenLongPressFiredRef.current = false;
-                screenLongPressStartPos.current = { x: e.clientX, y: e.clientY };
-                screenLongPressTimerRef.current = setTimeout(() => {
-                  screenLongPressFiredRef.current = true;
-                  handleCenterLongPress();
-                }, 500);
+                // Start long press timer for Now Playing song menu.
+                startScreenLongPress(e.clientX, e.clientY);
               }}
               onMouseMove={(e) => {
-                // Cancel long press if moved too far from start position
-                if (screenLongPressStartPos.current && screenLongPressTimerRef.current) {
-                  const dx = e.clientX - screenLongPressStartPos.current.x;
-                  const dy = e.clientY - screenLongPressStartPos.current.y;
-                  if (Math.abs(dx) > SCREEN_LONG_PRESS_MOVE_THRESHOLD || Math.abs(dy) > SCREEN_LONG_PRESS_MOVE_THRESHOLD) {
-                    clearTimeout(screenLongPressTimerRef.current);
-                    screenLongPressTimerRef.current = null;
-                    screenLongPressStartPos.current = null;
-                  }
-                }
+                cancelScreenLongPressOnMove(e.clientX, e.clientY);
               }}
-              onMouseUp={() => {
-                if (screenLongPressTimerRef.current) {
-                  clearTimeout(screenLongPressTimerRef.current);
-                  screenLongPressTimerRef.current = null;
-                }
-                screenLongPressStartPos.current = null;
-              }}
-              onMouseLeave={() => {
-                if (screenLongPressTimerRef.current) {
-                  clearTimeout(screenLongPressTimerRef.current);
-                  screenLongPressTimerRef.current = null;
-                }
-                screenLongPressStartPos.current = null;
-              }}
+              onMouseUp={stopScreenLongPress}
+              onMouseLeave={stopScreenLongPress}
               onTouchStart={(e) => {
-                if (screenLongPressTimerRef.current) clearTimeout(screenLongPressTimerRef.current);
-                screenLongPressFiredRef.current = false;
                 const touch = e.touches[0];
-                screenLongPressStartPos.current = { x: touch.clientX, y: touch.clientY };
-                screenLongPressTimerRef.current = setTimeout(() => {
-                  screenLongPressFiredRef.current = true;
-                  handleCenterLongPress();
-                }, 500);
+                startScreenLongPress(touch.clientX, touch.clientY);
               }}
               onTouchMove={(e) => {
-                // Cancel long press if moved too far from start position
-                if (screenLongPressStartPos.current && screenLongPressTimerRef.current) {
-                  const touch = e.touches[0];
-                  const dx = touch.clientX - screenLongPressStartPos.current.x;
-                  const dy = touch.clientY - screenLongPressStartPos.current.y;
-                  if (Math.abs(dx) > SCREEN_LONG_PRESS_MOVE_THRESHOLD || Math.abs(dy) > SCREEN_LONG_PRESS_MOVE_THRESHOLD) {
-                    clearTimeout(screenLongPressTimerRef.current);
-                    screenLongPressTimerRef.current = null;
-                    screenLongPressStartPos.current = null;
-                  }
-                }
+                const touch = e.touches[0];
+                cancelScreenLongPressOnMove(touch.clientX, touch.clientY);
               }}
-              onTouchEnd={() => {
-                if (screenLongPressTimerRef.current) {
-                  clearTimeout(screenLongPressTimerRef.current);
-                  screenLongPressTimerRef.current = null;
-                }
-                screenLongPressStartPos.current = null;
-              }}
-              onTouchCancel={() => {
-                if (screenLongPressTimerRef.current) {
-                  clearTimeout(screenLongPressTimerRef.current);
-                  screenLongPressTimerRef.current = null;
-                }
-                screenLongPressStartPos.current = null;
-              }}
+              onTouchEnd={stopScreenLongPress}
+              onTouchCancel={stopScreenLongPress}
             >
               {!isMusicQuizOpen && !isBrickGameOpen && (
                 <IpodScreen

--- a/src/apps/ipod/components/IpodWheel.tsx
+++ b/src/apps/ipod/components/IpodWheel.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef } from "react";
+import { useRef } from "react";
 import { cn } from "@/lib/utils";
 import { useTranslation } from "react-i18next";
 
@@ -33,8 +33,9 @@ export function IpodWheel({
 }: IpodWheelProps) {
   const { t } = useTranslation();
   const wheelRef = useRef<HTMLDivElement>(null);
-  // Accumulated mouse wheel delta (for desktop scrolling)
-  const [wheelDelta, setWheelDelta] = useState(0);
+  // Accumulated mouse wheel delta (for desktop scrolling). Keep this in a
+  // ref so high-frequency wheel events don't trigger component re-renders.
+  const wheelDeltaRef = useRef(0);
 
   // Refs for tracking continuous touch rotation
   const lastAngleRef = useRef<number | null>(null); // Last touch angle in radians
@@ -255,18 +256,17 @@ export function IpodWheel({
   // Handle mouse wheel scroll for rotation
   const handleMouseWheel = (e: React.WheelEvent) => {
     // Accumulate delta and only trigger when it reaches threshold
-    const newDelta = wheelDelta + Math.abs(e.deltaY);
-    setWheelDelta(newDelta);
+    wheelDeltaRef.current += Math.abs(e.deltaY);
 
     // Using a threshold of 50 to reduce sensitivity
-    if (newDelta >= 50) {
+    if (wheelDeltaRef.current >= 50) {
       if (e.deltaY < 0) {
         onWheelRotation("counterclockwise");
       } else {
         onWheelRotation("clockwise");
       }
       // Reset delta after triggering action
-      setWheelDelta(0);
+      wheelDeltaRef.current = 0;
     }
   };
 

--- a/src/apps/ipod/hooks/useLibraryUpdateChecker.ts
+++ b/src/apps/ipod/hooks/useLibraryUpdateChecker.ts
@@ -182,79 +182,52 @@ export function useLibraryUpdateChecker(isActive: boolean) {
     };
   }, [isActive, syncLibrary, debugMode, t]);
 
-  // Manual check function that can be called externally
-  const manualCheck = async () => {
-    try {
-      const wasEmptyBefore = useIpodStore.getState().tracks.length === 0;
-      const result = await syncLibrary();
-
-      if (result.newTracksAdded > 0 || result.tracksUpdated > 0) {
-        const message =
-          wasEmptyBefore && result.newTracksAdded > 0
-            ? t("apps.ipod.dialogs.addedSongsToTop", {
-                count: result.newTracksAdded,
-                plural: result.newTracksAdded === 1 ? "" : "s",
-              })
-            : t("apps.ipod.dialogs.addedNewSongsToTop", {
-                newCount: result.newTracksAdded,
-                newPlural: result.newTracksAdded === 1 ? "" : "s",
-                updatedText:
-                  result.tracksUpdated > 0
-                    ? t("apps.ipod.dialogs.andUpdated", {
-                        count: result.tracksUpdated,
-                        plural: result.tracksUpdated === 1 ? "" : "s",
-                      })
-                    : "",
-                total: result.totalTracks,
-              });
-
-        toast.success(t("apps.ipod.dialogs.libraryUpdated"), {
-          description: message,
-        });
-        return true;
-      } else {
-        toast.info(t("apps.ipod.dialogs.noUpdates"), {
-          description: t("apps.ipod.dialogs.libraryAlreadyUpToDate"),
-        });
-        return false;
-      }
-    } catch (error) {
-      console.error("Error during manual library update check:", error);
-      toast.error(t("apps.ipod.dialogs.updateCheckFailed"), {
-        description: t("apps.ipod.dialogs.failedToCheckForLibraryUpdates"),
+  const buildSyncDescription = (
+    wasEmptyBefore: boolean,
+    result: Awaited<ReturnType<typeof syncLibrary>>
+  ) => {
+    if (wasEmptyBefore && result.newTracksAdded > 0) {
+      return t("apps.ipod.dialogs.addedSongsToTop", {
+        count: result.newTracksAdded,
+        plural: result.newTracksAdded === 1 ? "" : "s",
       });
-      return false;
     }
+    return t("apps.ipod.dialogs.addedNewSongsToTop", {
+      newCount: result.newTracksAdded,
+      newPlural: result.newTracksAdded === 1 ? "" : "s",
+      updatedText:
+        result.tracksUpdated > 0
+          ? t("apps.ipod.dialogs.andUpdated", {
+              count: result.tracksUpdated,
+              plural: result.tracksUpdated === 1 ? "" : "s",
+            })
+          : "",
+      total: result.totalTracks,
+    });
   };
 
-  // Manual sync function that syncs with server library
-  const manualSync = async () => {
+  const runManualSync = async (mode: "check" | "sync") => {
     try {
       const wasEmptyBefore = useIpodStore.getState().tracks.length === 0;
       const result = await syncLibrary();
 
       if (result.newTracksAdded > 0 || result.tracksUpdated > 0) {
-        const message =
-          wasEmptyBefore && result.newTracksAdded > 0
-            ? t("apps.ipod.dialogs.addedSongsToTop", {
-                count: result.newTracksAdded,
-                plural: result.newTracksAdded === 1 ? "" : "s",
-              })
-            : t("apps.ipod.dialogs.addedNewSongsToTop", {
-                newCount: result.newTracksAdded,
-                newPlural: result.newTracksAdded === 1 ? "" : "s",
-                updatedText:
-                  result.tracksUpdated > 0
-                    ? t("apps.ipod.dialogs.andUpdated", {
-                        count: result.tracksUpdated,
-                        plural: result.tracksUpdated === 1 ? "" : "s",
-                      })
-                    : "",
-                total: result.totalTracks,
-              });
+        toast.success(
+          t(
+            mode === "check"
+              ? "apps.ipod.dialogs.libraryUpdated"
+              : "apps.ipod.dialogs.librarySynced"
+          ),
+          {
+            description: buildSyncDescription(wasEmptyBefore, result),
+          }
+        );
+        return true;
+      }
 
-        toast.success(t("apps.ipod.dialogs.librarySynced"), {
-          description: message,
+      if (mode === "check") {
+        toast.info(t("apps.ipod.dialogs.noUpdates"), {
+          description: t("apps.ipod.dialogs.libraryAlreadyUpToDate"),
         });
       } else {
         toast.info(t("apps.ipod.dialogs.librarySynced"), {
@@ -263,15 +236,38 @@ export function useLibraryUpdateChecker(isActive: boolean) {
           }),
         });
       }
-      return true;
+      return false;
     } catch (error) {
-      console.error("Error during library sync:", error);
-      toast.error(t("apps.ipod.dialogs.syncFailed"), {
-        description: t("apps.ipod.dialogs.failedToSyncWithServerLibrary"),
-      });
+      const isCheck = mode === "check";
+      console.error(
+        isCheck
+          ? "Error during manual library update check:"
+          : "Error during library sync:",
+        error
+      );
+      toast.error(
+        t(
+          isCheck
+            ? "apps.ipod.dialogs.updateCheckFailed"
+            : "apps.ipod.dialogs.syncFailed"
+        ),
+        {
+          description: t(
+            isCheck
+              ? "apps.ipod.dialogs.failedToCheckForLibraryUpdates"
+              : "apps.ipod.dialogs.failedToSyncWithServerLibrary"
+          ),
+        }
+      );
       return false;
     }
   };
+
+  // Manual check function that can be called externally
+  const manualCheck = async () => runManualSync("check");
+
+  // Manual sync function that syncs with server library
+  const manualSync = async () => runManualSync("sync");
 
   return { manualCheck, manualSync };
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- replace `IpodWheel` mouse-wheel delta state with a ref to avoid render churn on high-frequency wheel input
- refactor `IpodAppComponent` screen long-press handlers into shared callbacks to remove duplicated touch/mouse timer logic
- deduplicate iPod library manual check/sync flow in `useLibraryUpdateChecker` with a single shared execution path

## Testing
- `bun run test:unit`
- `bun run lint`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3F1263F3-DBC8-4BFF-B98F-01943077ECB5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3F1263F3-DBC8-4BFF-B98F-01943077ECB5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

