### PR TITLE
Optimize iPod library lookups

### DIFF
--- a/docs/2.3-ipod.md
+++ b/docs/2.3-ipod.md
@@ -73,9 +73,15 @@ The app consists of 14 component file(s):
 **Custom Hooks:**
 - `src/apps/ipod/hooks/index.ts`
 - `src/apps/ipod/hooks/useLibraryUpdateChecker.ts`
+- `src/apps/ipod/hooks/useIpodLogic.ts`
+- `src/apps/ipod/hooks/useAppleMusicLibrary.ts`
 
 **Utilities:**
-No dedicated utility files are listed for this application.
+- `src/apps/ipod/utils/appleMusicMenuLoading.ts`
+- `src/apps/ipod/utils/appleMusicPlaylistMenu.ts`
+- `src/apps/ipod/utils/ipodLibraryIndex.ts`
+- `src/apps/ipod/utils/lyricsTrackMetadata.ts`
+- `src/apps/ipod/utils/musicQuizScoring.ts`
 
 ### State Management
 The iPod app leverages Zustand for robust state management, utilizing several stores including `useIpodStore` for core music library and playback state, `useAudioSettingsStore` for audio preferences, `useThemeStore` for visual themes, and `useAppStore` for general application-level settings. This ensures a consistent and reactive user experience across the application.

--- a/src/apps/ipod/components/IpodAppComponent.tsx
+++ b/src/apps/ipod/components/IpodAppComponent.tsx
@@ -14,9 +14,6 @@ import { IpodWheel } from "./IpodWheel";
 import { PipPlayer } from "./PipPlayer";
 import { FullScreenPortal } from "./FullScreenPortal";
 import { LyricsDisplay } from "./LyricsDisplay";
-import { CoverFlow } from "./CoverFlow";
-import { MusicQuiz } from "./MusicQuiz";
-import { BrickGame } from "./BrickGame";
 import { LyricsSyncMode } from "@/components/shared/LyricsSyncMode";
 import { ShareItemDialog } from "@/components/dialogs/ShareItemDialog";
 import { LyricsSearchDialog } from "@/components/dialogs/LyricsSearchDialog";
@@ -26,15 +23,41 @@ import { useAudioSettingsStore } from "@/stores/useAudioSettingsStore";
 import { useIpodStore } from "@/stores/useIpodStore";
 import { useIpodLogic } from "../hooks/useIpodLogic";
 import { DisplayMode } from "@/types/lyrics";
-import { useCallback, useMemo } from "react";
-import { LandscapeVideoBackground } from "@/components/shared/LandscapeVideoBackground";
-import { AmbientBackground } from "@/components/shared/AmbientBackground";
-import { MeshGradientBackground } from "@/components/shared/MeshGradientBackground";
-import { WaterBackground } from "@/components/shared/WaterBackground";
+import { lazy, Suspense, useCallback, useMemo } from "react";
 import {
   IPOD_MODERN_SCREEN_HEIGHT_PX,
   PLAYER_PROGRESS_INTERVAL_MS,
 } from "../constants";
+
+const CoverFlow = lazy(() =>
+  import("./CoverFlow").then(({ CoverFlow }) => ({ default: CoverFlow }))
+);
+const MusicQuiz = lazy(() =>
+  import("./MusicQuiz").then(({ MusicQuiz }) => ({ default: MusicQuiz }))
+);
+const BrickGame = lazy(() =>
+  import("./BrickGame").then(({ BrickGame }) => ({ default: BrickGame }))
+);
+const LandscapeVideoBackground = lazy(() =>
+  import("@/components/shared/LandscapeVideoBackground").then(
+    ({ LandscapeVideoBackground }) => ({ default: LandscapeVideoBackground })
+  )
+);
+const AmbientBackground = lazy(() =>
+  import("@/components/shared/AmbientBackground").then(({ AmbientBackground }) => ({
+    default: AmbientBackground,
+  }))
+);
+const MeshGradientBackground = lazy(() =>
+  import("@/components/shared/MeshGradientBackground").then(
+    ({ MeshGradientBackground }) => ({ default: MeshGradientBackground })
+  )
+);
+const WaterBackground = lazy(() =>
+  import("@/components/shared/WaterBackground").then(({ WaterBackground }) => ({
+    default: WaterBackground,
+  }))
+);
 
 export function IpodAppComponent({
   isWindowOpen,
@@ -203,6 +226,8 @@ export function IpodAppComponent({
   // of `IpodScreen` because their chrome has no width transition.
   const uiVariant = useIpodStore((s) => s.uiVariant);
   const isModernIpodUi = uiVariant === "modern";
+  const masterVolume = useAudioSettingsStore((s) => s.masterVolume);
+  const finalIpodVolume = ipodVolume * masterVolume;
 
   const handleClose = useCallback(() => {
     pauseBeforeWindowClose();
@@ -470,20 +495,22 @@ export function IpodAppComponent({
                   // because it has no equivalent panel chrome.
                   coverFlowSlot={
                     isModernIpodUi ? (
-                      <CoverFlow
-                        ref={coverFlowRef}
-                        tracks={coverFlowTracks}
-                        currentIndex={coverFlowCurrentIndex}
-                        onSelectTrack={handleCoverFlowSelect}
-                        onExit={handleCoverFlowExit}
-                        onRotation={handleCoverFlowRotation}
-                        isVisible={isCoverFlowOpen}
-                        isPlaying={isPlaying}
-                        onTogglePlay={togglePlay}
-                        onPlayTrackInPlace={handleCoverFlowPlayInPlace}
-                        groupAppleMusicAlbums={isAppleMusic}
-                        inline
-                      />
+                      <Suspense fallback={null}>
+                        <CoverFlow
+                          ref={coverFlowRef}
+                          tracks={coverFlowTracks}
+                          currentIndex={coverFlowCurrentIndex}
+                          onSelectTrack={handleCoverFlowSelect}
+                          onExit={handleCoverFlowExit}
+                          onRotation={handleCoverFlowRotation}
+                          isVisible={isCoverFlowOpen}
+                          isPlaying={isPlaying}
+                          onTogglePlay={togglePlay}
+                          onPlayTrackInPlace={handleCoverFlowPlayInPlace}
+                          groupAppleMusicAlbums={isAppleMusic}
+                          inline
+                        />
+                      </Suspense>
                     ) : undefined
                   }
                   onNextTrack={() => {
@@ -515,45 +542,55 @@ export function IpodAppComponent({
                *  the standalone overlay there to avoid double-mounting
                *  the carousel and to let the menu panel's width
                *  transition own the entry/exit animation. */}
-              {!isModernIpodUi && (
-                <CoverFlow
-                  ref={coverFlowRef}
-                  tracks={coverFlowTracks}
-                  currentIndex={coverFlowCurrentIndex}
-                  onSelectTrack={handleCoverFlowSelect}
-                  onExit={handleCoverFlowExit}
-                  onRotation={handleCoverFlowRotation}
-                  isVisible={isCoverFlowOpen}
-                  isPlaying={isPlaying}
-                  onTogglePlay={togglePlay}
-                  onPlayTrackInPlace={handleCoverFlowPlayInPlace}
-                  groupAppleMusicAlbums={isAppleMusic}
-                />
+              {!isModernIpodUi && isCoverFlowOpen && (
+                <Suspense fallback={null}>
+                  <CoverFlow
+                    ref={coverFlowRef}
+                    tracks={coverFlowTracks}
+                    currentIndex={coverFlowCurrentIndex}
+                    onSelectTrack={handleCoverFlowSelect}
+                    onExit={handleCoverFlowExit}
+                    onRotation={handleCoverFlowRotation}
+                    isVisible={isCoverFlowOpen}
+                    isPlaying={isPlaying}
+                    onTogglePlay={togglePlay}
+                    onPlayTrackInPlace={handleCoverFlowPlayInPlace}
+                    groupAppleMusicAlbums={isAppleMusic}
+                  />
+                </Suspense>
               )}
 
               {/* Music Quiz overlay - positioned within screen bounds */}
-              <MusicQuiz
-                ref={musicQuizRef}
-                isVisible={isMusicQuizOpen}
-                onExit={() => setIsMusicQuizOpen(false)}
-                lcdFilterOn={lcdFilterOn}
-                backlightOn={backlightOn}
-                playClick={playClickSound}
-                playScroll={playScrollSound}
-                vibrate={vibrate}
-              />
+              {isMusicQuizOpen && (
+                <Suspense fallback={null}>
+                  <MusicQuiz
+                    ref={musicQuizRef}
+                    isVisible={isMusicQuizOpen}
+                    onExit={() => setIsMusicQuizOpen(false)}
+                    lcdFilterOn={lcdFilterOn}
+                    backlightOn={backlightOn}
+                    playClick={playClickSound}
+                    playScroll={playScrollSound}
+                    vibrate={vibrate}
+                  />
+                </Suspense>
+              )}
 
               {/* Brick Game overlay - positioned within screen bounds */}
-              <BrickGame
-                ref={brickGameRef}
-                isVisible={isBrickGameOpen}
-                onExit={() => setIsBrickGameOpen(false)}
-                lcdFilterOn={lcdFilterOn}
-                backlightOn={backlightOn}
-                playClick={playClickSound}
-                playScroll={playScrollSound}
-                vibrate={vibrate}
-              />
+              {isBrickGameOpen && (
+                <Suspense fallback={null}>
+                  <BrickGame
+                    ref={brickGameRef}
+                    isVisible={isBrickGameOpen}
+                    onExit={() => setIsBrickGameOpen(false)}
+                    lcdFilterOn={lcdFilterOn}
+                    backlightOn={backlightOn}
+                    playClick={playClickSound}
+                    playScroll={playScrollSound}
+                    vibrate={vibrate}
+                  />
+                </Suspense>
+              )}
             </div>
 
             <IpodWheel
@@ -671,10 +708,7 @@ export function IpodAppComponent({
                               currentTrack={tracks[currentIndex]}
                               playing={isPlaying && isFullScreen}
                               resumeAtSeconds={elapsedTime}
-                              volume={
-                                ipodVolume *
-                                useAudioSettingsStore.getState().masterVolume
-                              }
+                              volume={finalIpodVolume}
                               onProgress={handleProgress}
                               onDuration={handleDuration}
                               onPlay={handlePlay}
@@ -691,10 +725,7 @@ export function IpodAppComponent({
                               controls
                               width="100%"
                               height="100%"
-                              volume={
-                                ipodVolume *
-                                useAudioSettingsStore.getState().masterVolume
-                              }
+                              volume={finalIpodVolume}
                               loop={loopCurrent}
                               onEnded={handleTrackEnd}
                               onProgress={handleProgress}
@@ -733,44 +764,52 @@ export function IpodAppComponent({
                   {effectiveDisplayMode === DisplayMode.Landscapes &&
                     shouldRenderFullScreenAnimatedVisuals &&
                     tracks[currentIndex] && (
-                    <LandscapeVideoBackground
-                      isActive={shouldRenderFullScreenAnimatedVisuals}
-                      className="fixed inset-0 z-[5]"
-                    />
+                    <Suspense fallback={null}>
+                      <LandscapeVideoBackground
+                        isActive={shouldRenderFullScreenAnimatedVisuals}
+                        className="fixed inset-0 z-[5]"
+                      />
+                    </Suspense>
                   )}
 
                   {/* Warp shader background (fullscreen) */}
                   {effectiveDisplayMode === DisplayMode.Shader &&
                     shouldRenderFullScreenAnimatedVisuals &&
                     tracks[currentIndex] && (
-                    <AmbientBackground
-                      coverUrl={fullscreenCoverUrl}
-                      variant="warp"
-                      isActive={shouldRenderFullScreenAnimatedVisuals}
-                      className="fixed inset-0 z-[5]"
-                    />
+                    <Suspense fallback={null}>
+                      <AmbientBackground
+                        coverUrl={fullscreenCoverUrl}
+                        variant="warp"
+                        isActive={shouldRenderFullScreenAnimatedVisuals}
+                        className="fixed inset-0 z-[5]"
+                      />
+                    </Suspense>
                   )}
 
                   {/* Mesh gradient background (fullscreen) */}
                   {effectiveDisplayMode === DisplayMode.Mesh &&
                     shouldRenderFullScreenAnimatedVisuals &&
                     tracks[currentIndex] && (
-                    <MeshGradientBackground
-                      coverUrl={fullscreenCoverUrl}
-                      isActive={shouldRenderFullScreenAnimatedVisuals}
-                      className="fixed inset-0 z-[5]"
-                    />
+                    <Suspense fallback={null}>
+                      <MeshGradientBackground
+                        coverUrl={fullscreenCoverUrl}
+                        isActive={shouldRenderFullScreenAnimatedVisuals}
+                        className="fixed inset-0 z-[5]"
+                      />
+                    </Suspense>
                   )}
 
                   {/* Water shader background (fullscreen) */}
                   {effectiveDisplayMode === DisplayMode.Water &&
                     shouldRenderFullScreenAnimatedVisuals &&
                     tracks[currentIndex] && (
-                    <WaterBackground
-                      coverUrl={fullscreenCoverUrl}
-                      isActive={shouldRenderFullScreenAnimatedVisuals}
-                      className="fixed inset-0 z-[5]"
-                    />
+                    <Suspense fallback={null}>
+                      <WaterBackground
+                        coverUrl={fullscreenCoverUrl}
+                        isActive={shouldRenderFullScreenAnimatedVisuals}
+                        className="fixed inset-0 z-[5]"
+                      />
+                    </Suspense>
                   )}
 
                   {/* Cover overlay: shows when paused (any mode) or in Cover

--- a/src/apps/ipod/components/IpodScreen.tsx
+++ b/src/apps/ipod/components/IpodScreen.tsx
@@ -849,6 +849,7 @@ export function IpodScreen({
   );
 
   const isNowPlayingSongMenu =
+    menuHistory[menuHistory.length - 1]?.kind === "nowPlayingSong" ||
     menuHistory[menuHistory.length - 1]?.title === IPOD_NOW_PLAYING_SONG_MENU_KEY;
 
   const selectedRowSplitArtTarget = useMemo(() => {

--- a/src/apps/ipod/components/IpodWheel.tsx
+++ b/src/apps/ipod/components/IpodWheel.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef } from "react";
+import { useRef } from "react";
 import { cn } from "@/lib/utils";
 import { useTranslation } from "react-i18next";
 
@@ -33,8 +33,9 @@ export function IpodWheel({
 }: IpodWheelProps) {
   const { t } = useTranslation();
   const wheelRef = useRef<HTMLDivElement>(null);
-  // Accumulated mouse wheel delta (for desktop scrolling)
-  const [wheelDelta, setWheelDelta] = useState(0);
+  // Accumulated desktop wheel delta. Keep this out of React state so partial
+  // scroll gestures do not re-render the whole click wheel.
+  const wheelDeltaRef = useRef(0);
 
   // Refs for tracking continuous touch rotation
   const lastAngleRef = useRef<number | null>(null); // Last touch angle in radians
@@ -104,26 +105,27 @@ export function IpodWheel({
     }
   };
 
+  const getWheelCenter = (): { x: number; y: number } | null => {
+    if (!wheelRef.current) return null;
+    const rect = wheelRef.current.getBoundingClientRect();
+    return {
+      x: rect.left + rect.width / 2,
+      y: rect.top + rect.height / 2,
+    };
+  };
+
   // Calculate angle (in degrees) from the center of the wheel – used for click areas
   const getAngleFromCenterDeg = (x: number, y: number): number => {
-    if (!wheelRef.current) return 0;
-
-    const rect = wheelRef.current.getBoundingClientRect();
-    const centerX = rect.left + rect.width / 2;
-    const centerY = rect.top + rect.height / 2;
-
-    return (Math.atan2(y - centerY, x - centerX) * 180) / Math.PI;
+    const center = getWheelCenter();
+    if (!center) return 0;
+    return (Math.atan2(y - center.y, x - center.x) * 180) / Math.PI;
   };
 
   // Same as above but returns radians – used for rotation calculation
   const getAngleFromCenterRad = (x: number, y: number): number => {
-    if (!wheelRef.current) return 0;
-
-    const rect = wheelRef.current.getBoundingClientRect();
-    const centerX = rect.left + rect.width / 2;
-    const centerY = rect.top + rect.height / 2;
-
-    return Math.atan2(y - centerY, x - centerX);
+    const center = getWheelCenter();
+    if (!center) return 0;
+    return Math.atan2(y - center.y, x - center.x);
   };
 
   // Determine wheel section from angle
@@ -143,13 +145,9 @@ export function IpodWheel({
 
   // Check if touch point is in center button area
   const isTouchInCenter = (x: number, y: number): boolean => {
-    if (!wheelRef.current) return false;
-
-    const rect = wheelRef.current.getBoundingClientRect();
-    const centerX = rect.left + rect.width / 2;
-    const centerY = rect.top + rect.height / 2;
-
-    const distance = Math.sqrt((x - centerX) ** 2 + (y - centerY) ** 2);
+    const center = getWheelCenter();
+    if (!center) return false;
+    const distance = Math.sqrt((x - center.x) ** 2 + (y - center.y) ** 2);
     // Center button is w-16 h-16 (64px), so radius is 32px
     return distance <= 32;
   };
@@ -255,18 +253,17 @@ export function IpodWheel({
   // Handle mouse wheel scroll for rotation
   const handleMouseWheel = (e: React.WheelEvent) => {
     // Accumulate delta and only trigger when it reaches threshold
-    const newDelta = wheelDelta + Math.abs(e.deltaY);
-    setWheelDelta(newDelta);
+    wheelDeltaRef.current += Math.abs(e.deltaY);
 
     // Using a threshold of 50 to reduce sensitivity
-    if (newDelta >= 50) {
+    if (wheelDeltaRef.current >= 50) {
       if (e.deltaY < 0) {
         onWheelRotation("counterclockwise");
       } else {
         onWheelRotation("clockwise");
       }
       // Reset delta after triggering action
-      setWheelDelta(0);
+      wheelDeltaRef.current = 0;
     }
   };
 

--- a/src/apps/ipod/components/screen/ScrollingText.tsx
+++ b/src/apps/ipod/components/screen/ScrollingText.tsx
@@ -85,6 +85,13 @@ export function ScrollingText({
   }, []);
 
   useEffect(() => {
+    const shouldMeasureForMarquee =
+      allowMarquee && (!resetOnPause || isPlaying);
+    if (!shouldMeasureForMarquee) {
+      setShouldScroll((prev) => (prev ? false : prev));
+      return;
+    }
+
     const container = containerRef.current;
     if (!container) return;
 
@@ -115,7 +122,14 @@ export function ScrollingText({
       window.clearTimeout(settleTimeout);
       resizeObserver.disconnect();
     };
-  }, [text, allowMarquee, labelLayoutKey, measureOverflow]);
+  }, [
+    text,
+    allowMarquee,
+    resetOnPause,
+    isPlaying,
+    labelLayoutKey,
+    measureOverflow,
+  ]);
 
   // When `resetOnPause` is enabled and we're paused, drop the marquee track
   // entirely so the duplicated text snaps back to translate(0). The static

--- a/src/apps/ipod/hooks/index.ts
+++ b/src/apps/ipod/hooks/index.ts
@@ -1,2 +1,3 @@
 // Re-export all iPod hooks
+export { useIpodActiveLibrary } from "./useIpodActiveLibrary";
 export { useLibraryUpdateChecker } from "./useLibraryUpdateChecker";

--- a/src/apps/ipod/hooks/useIpodActiveLibrary.ts
+++ b/src/apps/ipod/hooks/useIpodActiveLibrary.ts
@@ -1,0 +1,142 @@
+import { useMemo } from "react";
+import { useShallow } from "zustand/react/shallow";
+import {
+  isAppleMusicCollectionTrack,
+  useIpodStore,
+} from "@/stores/useIpodStore";
+import {
+  buildIpodLibraryIndex,
+  resolveCurrentTrackIndex,
+} from "../utils/ipodLibraryIndex";
+
+export function useIpodActiveLibrary() {
+  const {
+    youtubeTracks,
+    youtubeCurrentSongId,
+    appleMusicTracks,
+    appleMusicPlaylists,
+    appleMusicPlaylistTracks,
+    appleMusicPlaylistTracksLoading,
+    appleMusicPlaylistsLoading,
+    appleMusicPlaybackQueue,
+    appleMusicCurrentSongId,
+    librarySource,
+    loopCurrent,
+    loopAll,
+    isShuffled,
+    isPlaying,
+    showVideo,
+    backlightOn,
+  } = useIpodStore(
+    useShallow((s) => ({
+      youtubeTracks: s.tracks,
+      youtubeCurrentSongId: s.currentSongId,
+      appleMusicTracks: s.appleMusicTracks,
+      appleMusicPlaylists: s.appleMusicPlaylists,
+      appleMusicPlaylistTracks: s.appleMusicPlaylistTracks,
+      appleMusicPlaylistTracksLoading: s.appleMusicPlaylistTracksLoading,
+      appleMusicPlaylistsLoading: s.appleMusicPlaylistsLoading,
+      appleMusicPlaybackQueue: s.appleMusicPlaybackQueue,
+      appleMusicCurrentSongId: s.appleMusicCurrentSongId,
+      librarySource: s.librarySource,
+      loopCurrent: s.loopCurrent,
+      loopAll: s.loopAll,
+      isShuffled: s.isShuffled,
+      isPlaying: s.isPlaying,
+      showVideo: s.showVideo,
+      backlightOn: s.backlightOn,
+    }))
+  );
+
+  const isAppleMusic = librarySource === "appleMusic";
+  const tracks = isAppleMusic ? appleMusicTracks : youtubeTracks;
+  const browsableTracks = useMemo(
+    () =>
+      isAppleMusic
+        ? tracks.filter((track) => !isAppleMusicCollectionTrack(track))
+        : tracks,
+    [isAppleMusic, tracks]
+  );
+  const currentSongId = isAppleMusic
+    ? appleMusicCurrentSongId
+    : youtubeCurrentSongId;
+  const trackIndex = useMemo(() => buildIpodLibraryIndex(tracks), [tracks]);
+  const browsableTrackIndex = useMemo(
+    () => buildIpodLibraryIndex(browsableTracks),
+    [browsableTracks]
+  );
+
+  const currentIndex = useMemo(
+    () =>
+      resolveCurrentTrackIndex(
+        trackIndex.indexById,
+        currentSongId,
+        tracks.length
+      ),
+    [trackIndex, currentSongId, tracks.length]
+  );
+  const browseCurrentIndex = useMemo(
+    () =>
+      resolveCurrentTrackIndex(
+        browsableTrackIndex.indexById,
+        currentSongId,
+        browsableTracks.length
+      ),
+    [browsableTrackIndex, currentSongId, browsableTracks.length]
+  );
+  const coverFlowCurrentIndex = browseCurrentIndex >= 0 ? browseCurrentIndex : 0;
+
+  const nowPlayingScope = useMemo(() => {
+    if (!isAppleMusic) {
+      return { index: currentIndex, total: tracks.length };
+    }
+    if (!appleMusicPlaybackQueue || appleMusicPlaybackQueue.length === 0) {
+      return {
+        index: browseCurrentIndex >= 0 ? browseCurrentIndex : currentIndex,
+        total: browsableTracks.length,
+      };
+    }
+    const queue = appleMusicPlaybackQueue.filter((id) =>
+      trackIndex.idSet.has(id)
+    );
+    if (queue.length === 0) {
+      return { index: currentIndex, total: tracks.length };
+    }
+    const idx = currentSongId ? queue.indexOf(currentSongId) : -1;
+    if (idx < 0) return { index: currentIndex, total: tracks.length };
+    return { index: idx, total: queue.length };
+  }, [
+    isAppleMusic,
+    appleMusicPlaybackQueue,
+    tracks.length,
+    trackIndex,
+    browsableTracks.length,
+    currentSongId,
+    currentIndex,
+    browseCurrentIndex,
+  ]);
+
+  return {
+    appleMusicTracks,
+    appleMusicPlaylists,
+    appleMusicPlaylistTracks,
+    appleMusicPlaylistTracksLoading,
+    appleMusicPlaylistsLoading,
+    appleMusicCurrentSongId,
+    librarySource,
+    isAppleMusic,
+    tracks,
+    browsableTracks,
+    currentSongId,
+    currentIndex,
+    browseCurrentIndex,
+    coverFlowCurrentIndex,
+    nowPlayingScope,
+    loopCurrent,
+    loopAll,
+    isShuffled,
+    isPlaying,
+    showVideo,
+    backlightOn,
+  };
+}

--- a/src/apps/ipod/hooks/useIpodLogic.ts
+++ b/src/apps/ipod/hooks/useIpodLogic.ts
@@ -90,6 +90,7 @@ import {
   buildIpodLibraryIndex,
   resolveCurrentTrackIndex,
 } from "../utils/ipodLibraryIndex";
+import { getMenuMemoryKey, isNowPlayingSongMenu } from "../utils/menuIdentity";
 
 // User-agent sniffing is constant for the document lifetime, so compute once
 // at module load instead of re-running these regexes on every render of the
@@ -461,6 +462,7 @@ export function useIpodLogic({
         (currentAppleMusicTrack?.appleMusicPlayParams?.stationId ||
           state.ipodMenuBreadcrumb?.some(
             (entry) =>
+              entry.kind === "radio" ||
               entry.title === radioMenuTitleForRestore ||
               entry.title === "Radio"
           ))
@@ -687,15 +689,16 @@ export function useIpodLogic({
     selectedMenuItemRef.current = selectedMenuItem;
   }, [selectedMenuItem]);
 
-  // Remember the last cursor position for each menu title. This keeps
+  // Remember the last cursor position for each stable menu identity. This keeps
   // forward navigation symmetric with back navigation: if the user backs
   // out of a playlist/artist/album and then enters it again, we restore
   // the item they were on instead of resetting that child menu to row 0.
   const rememberedMenuSelectedIndexRef = useRef<Record<string, number>>({});
 
   const getRememberedMenuSelectedIndex = useCallback(
-    (title: string, fallback: number, itemCount: number) => {
-      const remembered = rememberedMenuSelectedIndexRef.current[title];
+    (menu: MenuHistoryEntry, fallback: number, itemCount: number) => {
+      const remembered =
+        rememberedMenuSelectedIndexRef.current[getMenuMemoryKey(menu)];
       const next =
         typeof remembered === "number" && Number.isFinite(remembered)
           ? remembered
@@ -716,7 +719,7 @@ export function useIpodLogic({
       const childWithRememberedSelection = {
         ...child,
         selectedIndex: getRememberedMenuSelectedIndex(
-          child.title,
+          child,
           child.selectedIndex,
           child.items.length
         ),
@@ -725,7 +728,7 @@ export function useIpodLogic({
         if (prev.length === 0) return [childWithRememberedSelection];
         const updated = prev.slice();
         const parent = updated[updated.length - 1];
-        rememberedMenuSelectedIndexRef.current[parent.title] =
+        rememberedMenuSelectedIndexRef.current[getMenuMemoryKey(parent)] =
           selectedMenuItemRef.current;
         updated[updated.length - 1] = {
           ...parent,
@@ -1259,6 +1262,7 @@ export function useIpodLogic({
 
     const hasRadioMenuInHistory = menuHistory.some(
       (menu) =>
+        menu.kind === "radio" ||
         menu.title === radioMenuTitleForRestore || menu.title === "Radio"
     );
     const currentAppleMusicTrack = currentSongId
@@ -1932,6 +1936,8 @@ export function useIpodLogic({
           action: () => {
             registerActivity();
             pushMenuChild({
+              kind: "artistAlbum",
+              id: albumTitle,
               title: albumTitle,
               displayTitle: album,
               items: artistAlbumMenuItemsByTitle[albumTitle] ?? EMPTY_IPOD_MENU_ITEMS,
@@ -1950,6 +1956,8 @@ export function useIpodLogic({
           action: () => {
             registerActivity();
             pushMenuChild({
+              kind: "artistAllSongs",
+              id: artistKey,
               title: allSongsTitle,
               displayTitle: `${artist.name} - ${allSongsLabel}`,
               items: artistAllSongsMenuItemsByTitle[allSongsTitle] ?? EMPTY_IPOD_MENU_ITEMS,
@@ -2008,6 +2016,8 @@ export function useIpodLogic({
           action: () => {
             registerActivity();
             pushMenuChild({
+              kind: "songs",
+              id: "all",
               title: allSongsLabel,
               items: allSongsMenuItems,
               selectedIndex: 0,
@@ -2026,6 +2036,8 @@ export function useIpodLogic({
             action: () => {
               registerActivity();
               pushMenuChild({
+                kind: "album",
+                id: albumKey,
                 title: albumKey,
                 displayTitle: albumGroupsByKey[albumKey].album,
                 items: albumMenuItemsByAlbum[albumKey],
@@ -2059,6 +2071,8 @@ export function useIpodLogic({
           action: () => {
             registerActivity();
             pushMenuChild({
+              kind: "albums",
+              id: "all",
               title: albumsLabel,
               items: albumsListMenuItems,
               selectedIndex: 0,
@@ -2078,6 +2092,8 @@ export function useIpodLogic({
             action: () => {
               registerActivity();
               pushMenuChild({
+                kind: "artist",
+                id: artistKey,
                 title: artistKey,
                 displayTitle: artist.name,
                 items: artistMenuItemsByArtist[artistKey],
@@ -2228,6 +2244,8 @@ export function useIpodLogic({
             registerActivity();
             requestPlaylistTracksIfNeeded(playlist.id);
             pushMenuChild({
+              kind: "appleMusicPlaylist",
+              id: playlist.id,
               title: getAppleMusicPlaylistMenuTitle(playlist.id),
               displayTitle: playlist.name,
               items: applePlaylistTrackMenuItemsByPlaylist[playlist.id] ?? EMPTY_IPOD_MENU_ITEMS,
@@ -2273,7 +2291,12 @@ export function useIpodLogic({
     const pushSubmenu = (
       title: string,
       items: MenuItem[],
-      options?: { modernMediaList?: boolean; alphabetic?: boolean }
+      options?: {
+        kind?: MenuHistoryEntry["kind"];
+        id?: string;
+        modernMediaList?: boolean;
+        alphabetic?: boolean;
+      }
     ) => {
       registerActivity();
       pushMenuChild({
@@ -2305,6 +2328,8 @@ export function useIpodLogic({
           action: () => {
             registerActivity();
             pushMenuChild({
+              kind: "recentlyAdded",
+              id: "recentlyAdded",
               title: recentlyAddedLabel,
               items: appleMusicRecentlyAddedMenuItems,
               selectedIndex: 0,
@@ -2319,6 +2344,8 @@ export function useIpodLogic({
           action: () => {
             registerActivity();
             pushMenuChild({
+              kind: "favorites",
+              id: "favorites",
               title: favoriteSongsLabel,
               items: appleMusicFavoritesMenuItems,
               selectedIndex: 0,
@@ -2332,6 +2359,8 @@ export function useIpodLogic({
           label: playlistsLabel,
           action: () => {
             pushSubmenu(playlistsLabel, applePlaylistsMenuItems, {
+              kind: "playlists",
+              id: "playlists",
               modernMediaList: true,
             });
             void loadAppleMusicPlaylists();
@@ -2342,6 +2371,8 @@ export function useIpodLogic({
           label: artistsLabel,
           action: () =>
             pushSubmenu(artistsLabel, artistsListMenuItems, {
+              kind: "artists",
+              id: "artists",
               alphabetic: true,
             }),
           showChevron: true,
@@ -2350,6 +2381,8 @@ export function useIpodLogic({
           label: albumsLabel,
           action: () =>
             pushSubmenu(albumsLabel, albumsListMenuItems, {
+              kind: "albums",
+              id: "albums",
               alphabetic: true,
             }),
           showChevron: true,
@@ -2358,6 +2391,8 @@ export function useIpodLogic({
           label: songsLabel,
           action: () =>
             pushSubmenu(songsLabel, allSongsMenuItems, {
+              kind: "songs",
+              id: "songs",
               alphabetic: true,
             }),
           showChevron: true,
@@ -2367,6 +2402,8 @@ export function useIpodLogic({
           action: () => {
             registerActivity();
             pushMenuChild({
+              kind: "radio",
+              id: "radio",
               title: radioLabel,
               items: appleMusicRadioMenuItems,
               selectedIndex: 0,
@@ -2391,6 +2428,8 @@ export function useIpodLogic({
         label: artistsLabel,
         action: () =>
           pushSubmenu(artistsLabel, artistsListMenuItems, {
+            kind: "artists",
+            id: "artists",
             alphabetic: true,
           }),
         showChevron: true,
@@ -2399,6 +2438,8 @@ export function useIpodLogic({
         label: albumsLabel,
         action: () =>
           pushSubmenu(albumsLabel, albumsListMenuItems, {
+            kind: "albums",
+            id: "albums",
             alphabetic: true,
           }),
         showChevron: true,
@@ -2407,6 +2448,8 @@ export function useIpodLogic({
         label: songsLabel,
         action: () =>
           pushSubmenu(allSongsLabel, allSongsMenuItems, {
+            kind: "songs",
+            id: "all",
             alphabetic: true,
           }),
         showChevron: true,
@@ -2535,6 +2578,8 @@ export function useIpodLogic({
           registerActivity();
           if (useIpodStore.getState().showVideo) toggleVideo();
           pushMenuChild({
+            kind: "music",
+            id: "music",
             title: musicLabel,
             items: musicMenuItemsRef.current,
             selectedIndex: 0,
@@ -2591,6 +2636,8 @@ export function useIpodLogic({
             },
           ];
           pushMenuChild({
+            kind: "extras",
+            id: "extras",
             title: extrasLabel,
             items: extrasItems,
             selectedIndex: 0,
@@ -2604,6 +2651,8 @@ export function useIpodLogic({
           registerActivity();
           if (useIpodStore.getState().showVideo) toggleVideo();
           pushMenuChild({
+            kind: "settings",
+            id: "settings",
             title: settingsLabel,
             items: settingsMenuItemsRef.current,
             selectedIndex: 0,
@@ -2652,7 +2701,10 @@ export function useIpodLogic({
   const isNowPlayingSongMenuOpen =
     menuMode &&
     menuHistory.length > 0 &&
-    menuHistory[menuHistory.length - 1]?.title === NOW_PLAYING_SONG_MENU_KEY;
+    isNowPlayingSongMenu(
+      menuHistory[menuHistory.length - 1],
+      NOW_PLAYING_SONG_MENU_KEY
+    );
 
   // Source the user was browsing when they opened the now-playing
   // song menu. `userPlaylist` covers Music > Playlists > <name>; the
@@ -2689,6 +2741,12 @@ export function useIpodLogic({
         // `appleMusicPlaylists`) doesn't hijack Go to Playlist when the
         // user originally entered via Music > Favorite Songs instead of
         // Music > Playlists > Favorite Songs.
+        if (entry.kind === "recentlyAdded") {
+          return { kind: "system", system: "recentlyAdded" };
+        }
+        if (entry.kind === "favorites") {
+          return { kind: "system", system: "favorites" };
+        }
         if (
           entry.title === recentlyAddedLabel &&
           parent?.title === musicLabel
@@ -2716,7 +2774,10 @@ export function useIpodLogic({
       matchFromHistory(menuHistoryBeforeNowPlayingRef.current) ??
       matchFromHistory(
         menuHistory.length > 0 &&
-          menuHistory[menuHistory.length - 1]?.title !== NOW_PLAYING_SONG_MENU_KEY
+          !isNowPlayingSongMenu(
+            menuHistory[menuHistory.length - 1],
+            NOW_PLAYING_SONG_MENU_KEY
+          )
           ? menuHistory
           : null
       )
@@ -2774,21 +2835,29 @@ export function useIpodLogic({
 
       navigateFromNowPlayingSongMenu([
         {
+          kind: "root",
+          id: "ipod",
           title: ipodLabel,
           items: mainMenuItems,
           selectedIndex: findMenuItemIndexByLabel(mainMenuItems, musicLabel),
         },
         {
+          kind: "music",
+          id: "music",
           title: musicLabel,
           items: musicMenuItems,
           selectedIndex: findMenuItemIndexByLabel(musicMenuItems, albumsLabel),
         },
         {
+          kind: "albums",
+          id: "albums",
           title: albumsLabel,
           items: albumsListMenuItems,
           selectedIndex: albumRowIdx,
         },
         {
+          kind: "album",
+          id: albumKey,
           title: albumKey,
           displayTitle: albumDisplay,
           items: albumMenuItemsByAlbum[albumKey] ?? EMPTY_IPOD_MENU_ITEMS,
@@ -2825,21 +2894,29 @@ export function useIpodLogic({
 
       navigateFromNowPlayingSongMenu([
         {
+          kind: "root",
+          id: "ipod",
           title: ipodLabel,
           items: mainMenuItems,
           selectedIndex: findMenuItemIndexByLabel(mainMenuItems, musicLabel),
         },
         {
+          kind: "music",
+          id: "music",
           title: musicLabel,
           items: musicMenuItems,
           selectedIndex: findMenuItemIndexByLabel(musicMenuItems, artistsLabel),
         },
         {
+          kind: "artists",
+          id: "artists",
           title: artistsLabel,
           items: artistsListMenuItems,
           selectedIndex: artistListIdx,
         },
         {
+          kind: "artist",
+          id: artistKey,
           title: artistKey,
           displayTitle: artistDisplay,
           items: artistMenuItemsByArtist[artistKey] ?? EMPTY_IPOD_MENU_ITEMS,
@@ -2879,22 +2956,30 @@ export function useIpodLogic({
 
       navigateFromNowPlayingSongMenu([
         {
+          kind: "root",
+          id: "ipod",
           title: ipodLabel,
           items: mainMenuItems,
           selectedIndex: findMenuItemIndexByLabel(mainMenuItems, musicLabel),
         },
         {
+          kind: "music",
+          id: "music",
           title: musicLabel,
           items: musicMenuItems,
           selectedIndex: findMenuItemIndexByLabel(musicMenuItems, playlistsLabel),
         },
         {
+          kind: "playlists",
+          id: "playlists",
           title: playlistsLabel,
           items: applePlaylistsMenuItems,
           selectedIndex: playlistListIdx,
           modernMediaList: true,
         },
         {
+          kind: "appleMusicPlaylist",
+          id: playlist.id,
           title: getAppleMusicPlaylistMenuTitle(playlist.id),
           displayTitle: playlist.name,
           items:
@@ -2948,16 +3033,22 @@ export function useIpodLogic({
 
       navigateFromNowPlayingSongMenu([
         {
+          kind: "root",
+          id: "ipod",
           title: ipodLabel,
           items: mainMenuItems,
           selectedIndex: findMenuItemIndexByLabel(mainMenuItems, musicLabel),
         },
         {
+          kind: "music",
+          id: "music",
           title: musicLabel,
           items: musicMenuItems,
           selectedIndex: findMenuItemIndexByLabel(musicMenuItems, targetLabel),
         },
         {
+          kind: system === "recentlyAdded" ? "recentlyAdded" : "favorites",
+          id: system,
           title: targetLabel,
           items: sourceItems,
           selectedIndex: trackIdx,
@@ -3085,6 +3176,8 @@ export function useIpodLogic({
     setMenuMode(true);
     setMenuHistory([
       {
+        kind: "nowPlayingSong",
+        id: "nowPlayingSong",
         title: NOW_PLAYING_SONG_MENU_KEY,
         displayTitle: track.title,
         items: nowPlayingSongMenuItems,
@@ -3109,6 +3202,8 @@ export function useIpodLogic({
     setMenuMode(true);
     setMenuHistory([
       {
+        kind: "nowPlayingSong",
+        id: "nowPlayingSong",
         title: NOW_PLAYING_SONG_MENU_KEY,
         displayTitle: snapshot?.displayTitle ?? track?.title ?? "",
         items: nowPlayingSongMenuItems,
@@ -3137,6 +3232,8 @@ export function useIpodLogic({
     const ipodLabel = t("apps.ipod.menuItems.ipod");
     setMenuHistory([
       {
+        kind: "root",
+        id: "ipod",
         title: ipodLabel,
         items: mainMenuItems,
         selectedIndex: 0,
@@ -3164,6 +3261,8 @@ export function useIpodLogic({
     setSelectedMenuItem(0);
     setMenuHistory([
       {
+        kind: "root",
+        id: "ipod",
         title: ipodLabel,
         items: mainMenuItemsRef.current,
         selectedIndex: 0,
@@ -3189,6 +3288,59 @@ export function useIpodLogic({
       "Favorite Songs"
     );
     const radioLabel = t("apps.ipod.menuItems.radio", "Radio");
+
+    if (menu.kind) {
+      switch (menu.kind) {
+        case "root":
+          return mainMenuItems;
+        case "music":
+          return musicMenuItems;
+        case "settings":
+          return settingsMenuItems;
+        case "extras":
+          return menu.items;
+        case "nowPlayingSong":
+          return nowPlayingSongMenuItems;
+        case "recentlyAdded":
+          return isAppleMusic ? appleMusicRecentlyAddedMenuItems : null;
+        case "favorites":
+          return isAppleMusic ? appleMusicFavoritesMenuItems : null;
+        case "radio":
+          return isAppleMusic ? appleMusicRadioMenuItems : null;
+        case "songs":
+          return allSongsMenuItems;
+        case "playlists":
+          return isAppleMusic ? applePlaylistsMenuItems : null;
+        case "artists":
+          return artistsListMenuItems;
+        case "albums":
+          return albumsListMenuItems;
+        case "artistAllSongs": {
+          if (menu.id && artistAllSongsMenuItemsByTitle[menu.title]) {
+            return artistAllSongsMenuItemsByTitle[menu.title];
+          }
+          const fallbackTitle = menu.id ? `${menu.id} - ${t("apps.ipod.menuItems.allSongs")}` : menu.title;
+          return artistAllSongsMenuItemsByTitle[fallbackTitle] ?? null;
+        }
+        case "artistAlbum":
+          return menu.id ? artistAlbumMenuItemsByTitle[menu.id] ?? null : null;
+        case "artist":
+          return menu.id ? artistMenuItemsByArtist[menu.id] ?? null : null;
+        case "album":
+          return menu.id ? albumMenuItemsByAlbum[menu.id] ?? null : null;
+        case "appleMusicPlaylist": {
+          const playlistMenu = resolveAppleMusicPlaylistMenu(
+            menu,
+            appleMusicPlaylists
+          );
+          return playlistMenu
+            ? applePlaylistTrackMenuItemsByPlaylist[playlistMenu.id] ??
+                EMPTY_IPOD_MENU_ITEMS
+            : null;
+        }
+      }
+    }
+
     const playlistMenu = resolveAppleMusicPlaylistMenu(menu, appleMusicPlaylists);
     const playlistMenuUsesOpaqueTitle =
       getAppleMusicPlaylistIdFromMenuTitle(menu.title) !== null;
@@ -3304,6 +3456,8 @@ export function useIpodLogic({
     const breadcrumb = useIpodStore.getState().ipodMenuBreadcrumb;
     const ipodLabel = t("apps.ipod.menuItems.ipod");
     const baseMenu = {
+      kind: "root" as const,
+      id: "ipod",
       title: ipodLabel,
       items: mainMenuItems,
       selectedIndex: 0,
@@ -3315,7 +3469,7 @@ export function useIpodLogic({
       return;
     }
     for (const entry of breadcrumb) {
-      rememberedMenuSelectedIndexRef.current[entry.title] =
+      rememberedMenuSelectedIndexRef.current[getMenuMemoryKey(entry)] =
         entry.selectedIndex;
     }
 
@@ -3329,13 +3483,21 @@ export function useIpodLogic({
         // Force the first entry to be the localized root label so back
         // navigation always lands at the iPod main menu.
         restored.push({
+          kind: "root",
+          id: "ipod",
           title: ipodLabel,
           items: mainMenuItems,
           selectedIndex: Math.max(0, Math.min(entry.selectedIndex, mainMenuItems.length - 1)),
         });
         continue;
       }
-      const skeleton = { title: entry.title, items: [], selectedIndex: 0 };
+      const skeleton = {
+        kind: entry.kind,
+        id: entry.id,
+        title: entry.title,
+        items: [],
+        selectedIndex: 0,
+      };
       const rebuilt = rebuildMenuItems(skeleton);
       // If we can't rebuild a level (e.g. the menu shape changed after an
       // app update, or async data hasn't arrived yet), stop walking — the
@@ -3351,6 +3513,8 @@ export function useIpodLogic({
             )
           : Math.max(0, entry.selectedIndex);
       restored.push({
+        kind: entry.kind,
+        id: entry.id,
         title: entry.title,
         displayTitle: entry.displayTitle,
         modernMediaList: entry.modernMediaList,
@@ -3457,7 +3621,7 @@ export function useIpodLogic({
   }, [menuHistory, setSelectedMenuItem]);
 
   // Persist the menu navigation breadcrumb whenever the user moves around
-  // the menus or moves the cursor. We only store `{ title, selectedIndex }`
+  // the menus or moves the cursor. We only store identity/display fields
   // per level — actions and item arrays are recomputed on restore via
   // `rebuildMenuItems`. The deepest entry's `selectedIndex` mirrors the
   // live cursor (`selectedMenuItem`) so reopening lands the user on the
@@ -3467,6 +3631,8 @@ export function useIpodLogic({
     if (menuHistory.length === 0) return;
 
     const breadcrumb = menuHistory.map((menu, i) => ({
+      kind: menu.kind,
+      id: menu.id,
       title: menu.title,
       displayTitle: menu.displayTitle,
       modernMediaList: menu.modernMediaList,
@@ -3475,7 +3641,7 @@ export function useIpodLogic({
         i === menuHistory.length - 1 ? selectedMenuItem : menu.selectedIndex,
     }));
     for (const entry of breadcrumb) {
-      rememberedMenuSelectedIndexRef.current[entry.title] =
+      rememberedMenuSelectedIndexRef.current[getMenuMemoryKey(entry)] =
         entry.selectedIndex;
     }
 
@@ -3486,6 +3652,8 @@ export function useIpodLogic({
       prev.length === breadcrumb.length &&
       prev.every(
         (entry, i) =>
+          entry.kind === breadcrumb[i].kind &&
+          entry.id === breadcrumb[i].id &&
           entry.title === breadcrumb[i].title &&
           entry.displayTitle === breadcrumb[i].displayTitle &&
           entry.modernMediaList === breadcrumb[i].modernMediaList &&
@@ -3930,7 +4098,13 @@ export function useIpodLogic({
       const mainMenu =
         menuHistory.length > 0
           ? menuHistory[0]
-          : { title: t("apps.ipod.menuItems.ipod"), items: mainMenuItems, selectedIndex: 0 };
+          : {
+              kind: "root" as const,
+              id: "ipod",
+              title: t("apps.ipod.menuItems.ipod"),
+              items: mainMenuItems,
+              selectedIndex: 0,
+            };
 
       if (cameFromNowPlayingMenuItem) {
         setMenuHistory([mainMenu]);
@@ -3984,11 +4158,15 @@ export function useIpodLogic({
         setMenuHistory([
           mainMenu,
           {
+            kind: "music",
+            id: "music",
             title: t("apps.ipod.menuItems.music"),
             items: musicMenuItems,
             selectedIndex: songsMenuIndex,
           },
           {
+            kind: "songs",
+            id: "all",
             title: allSongsLabel,
             items: allSongsMenuItems,
             selectedIndex: allSongsSelectedIndex,

--- a/src/apps/ipod/hooks/useIpodLogic.ts
+++ b/src/apps/ipod/hooks/useIpodLogic.ts
@@ -86,6 +86,10 @@ import {
   getAppleMusicPlaylistMenuTitle,
   resolveAppleMusicPlaylistMenu,
 } from "../utils/appleMusicPlaylistMenu";
+import {
+  buildIpodLibraryIndex,
+  resolveCurrentTrackIndex,
+} from "../utils/ipodLibraryIndex";
 
 // User-agent sniffing is constant for the document lifetime, so compute once
 // at module load instead of re-running these regexes on every render of the
@@ -177,17 +181,32 @@ export function useIpodLogic({
   const currentSongId = isAppleMusic
     ? appleMusicCurrentSongId
     : youtubeCurrentSongId;
+  const trackIndex = useMemo(() => buildIpodLibraryIndex(tracks), [tracks]);
+  const browsableTrackIndex = useMemo(
+    () => buildIpodLibraryIndex(browsableTracks),
+    [browsableTracks]
+  );
 
-  // Compute currentIndex from currentSongId
-  const currentIndex = useMemo(() => {
-    if (!currentSongId) return tracks.length > 0 ? 0 : -1;
-    const index = tracks.findIndex((t) => t.id === currentSongId);
-    return index >= 0 ? index : (tracks.length > 0 ? 0 : -1);
-  }, [tracks, currentSongId]);
-  const browseCurrentIndex = useMemo(() => {
-    if (!currentSongId) return browsableTracks.length > 0 ? 0 : -1;
-    return browsableTracks.findIndex((track) => track.id === currentSongId);
-  }, [browsableTracks, currentSongId]);
+  // Resolve current indexes through memoized lookup tables so large Apple
+  // Music libraries don't pay repeated linear scans on each controller rebuild.
+  const currentIndex = useMemo(
+    () =>
+      resolveCurrentTrackIndex(
+        trackIndex.indexById,
+        currentSongId,
+        tracks.length
+      ),
+    [trackIndex, currentSongId, tracks.length]
+  );
+  const browseCurrentIndex = useMemo(
+    () =>
+      resolveCurrentTrackIndex(
+        browsableTrackIndex.indexById,
+        currentSongId,
+        browsableTracks.length
+      ),
+    [browsableTrackIndex, currentSongId, browsableTracks.length]
+  );
   const coverFlowCurrentIndex = browseCurrentIndex >= 0 ? browseCurrentIndex : 0;
 
   // Now Playing "X of Y" should reflect the active playback context. When
@@ -205,8 +224,9 @@ export function useIpodLogic({
         total: browsableTracks.length,
       };
     }
-    const validIds = new Set(tracks.map((t) => t.id));
-    const queue = appleMusicPlaybackQueue.filter((id) => validIds.has(id));
+    const queue = appleMusicPlaybackQueue.filter((id) =>
+      trackIndex.idSet.has(id)
+    );
     if (queue.length === 0) {
       return { index: currentIndex, total: tracks.length };
     }
@@ -219,6 +239,7 @@ export function useIpodLogic({
     isAppleMusic,
     appleMusicPlaybackQueue,
     tracks,
+    trackIndex,
     browsableTracks.length,
     currentSongId,
     currentIndex,

--- a/src/apps/ipod/hooks/useIpodLogic.ts
+++ b/src/apps/ipod/hooks/useIpodLogic.ts
@@ -13,6 +13,7 @@ import { useActivityState } from "@/hooks/useActivityState";
 import { useLyricsErrorToast } from "@/hooks/useLyricsErrorToast";
 import { useCustomEventListener, useEventListener } from "@/hooks/useEventListener";
 import { useLibraryUpdateChecker } from "./useLibraryUpdateChecker";
+import { useIpodActiveLibrary } from "./useIpodActiveLibrary";
 import {
   useAppleMusicLibrary,
   syncAppleMusicResource,
@@ -86,10 +87,6 @@ import {
   getAppleMusicPlaylistMenuTitle,
   resolveAppleMusicPlaylistMenu,
 } from "../utils/appleMusicPlaylistMenu";
-import {
-  buildIpodLibraryIndex,
-  resolveCurrentTrackIndex,
-} from "../utils/ipodLibraryIndex";
 import { getMenuMemoryKey, isNowPlayingSongMenu } from "../utils/menuIdentity";
 
 // User-agent sniffing is constant for the document lifetime, so compute once
@@ -128,124 +125,29 @@ export function useIpodLogic({
   const isOffline = useOffline();
   const translatedHelpItems = useTranslatedHelpItems("ipod", helpItems);
 
-  // Store state
+  // Active library and playback state
   const {
-    youtubeTracks,
-    youtubeCurrentSongId,
-    appleMusicTracks,
     appleMusicPlaylists,
     appleMusicPlaylistTracks,
     appleMusicPlaylistTracksLoading,
     appleMusicPlaylistsLoading,
-    appleMusicPlaybackQueue,
     appleMusicCurrentSongId,
     librarySource,
+    isAppleMusic,
+    tracks,
+    browsableTracks,
+    currentSongId,
+    currentIndex,
+    browseCurrentIndex,
+    coverFlowCurrentIndex,
+    nowPlayingScope,
     loopCurrent,
     loopAll,
     isShuffled,
     isPlaying,
     showVideo,
     backlightOn,
-  } = useIpodStore(
-    useShallow((s) => ({
-      youtubeTracks: s.tracks,
-      youtubeCurrentSongId: s.currentSongId,
-      appleMusicTracks: s.appleMusicTracks,
-      appleMusicPlaylists: s.appleMusicPlaylists,
-      appleMusicPlaylistTracks: s.appleMusicPlaylistTracks,
-      appleMusicPlaylistTracksLoading: s.appleMusicPlaylistTracksLoading,
-      appleMusicPlaylistsLoading: s.appleMusicPlaylistsLoading,
-      appleMusicPlaybackQueue: s.appleMusicPlaybackQueue,
-      appleMusicCurrentSongId: s.appleMusicCurrentSongId,
-      librarySource: s.librarySource,
-      loopCurrent: s.loopCurrent,
-      loopAll: s.loopAll,
-      isShuffled: s.isShuffled,
-      isPlaying: s.isPlaying,
-      showVideo: s.showVideo,
-      backlightOn: s.backlightOn,
-    }))
-  );
-
-  // Active library — when the user toggles between YouTube and Apple Music,
-  // the iPod displays whichever slice is selected without rewriting the rest
-  // of the hook's logic. Each slice has its own current-song pointer.
-  const isAppleMusic = librarySource === "appleMusic";
-  const tracks = isAppleMusic ? appleMusicTracks : youtubeTracks;
-  const browsableTracks = useMemo(
-    () =>
-      isAppleMusic
-        ? tracks.filter((track) => !isAppleMusicCollectionTrack(track))
-        : tracks,
-    [isAppleMusic, tracks]
-  );
-  const currentSongId = isAppleMusic
-    ? appleMusicCurrentSongId
-    : youtubeCurrentSongId;
-  const trackIndex = useMemo(() => buildIpodLibraryIndex(tracks), [tracks]);
-  const browsableTrackIndex = useMemo(
-    () => buildIpodLibraryIndex(browsableTracks),
-    [browsableTracks]
-  );
-
-  // Resolve current indexes through memoized lookup tables so large Apple
-  // Music libraries don't pay repeated linear scans on each controller rebuild.
-  const currentIndex = useMemo(
-    () =>
-      resolveCurrentTrackIndex(
-        trackIndex.indexById,
-        currentSongId,
-        tracks.length
-      ),
-    [trackIndex, currentSongId, tracks.length]
-  );
-  const browseCurrentIndex = useMemo(
-    () =>
-      resolveCurrentTrackIndex(
-        browsableTrackIndex.indexById,
-        currentSongId,
-        browsableTracks.length
-      ),
-    [browsableTrackIndex, currentSongId, browsableTracks.length]
-  );
-  const coverFlowCurrentIndex = browseCurrentIndex >= 0 ? browseCurrentIndex : 0;
-
-  // Now Playing "X of Y" should reflect the active playback context. When
-  // the user picked a song from inside an Artist / Album / Playlist
-  // submenu, an Apple Music playback queue is set on the store; in that
-  // case scope the counter to that ordered list. Otherwise fall back to
-  // the full library count.
-  const nowPlayingScope = useMemo(() => {
-    if (!isAppleMusic) {
-      return { index: currentIndex, total: tracks.length };
-    }
-    if (!appleMusicPlaybackQueue || appleMusicPlaybackQueue.length === 0) {
-      return {
-        index: browseCurrentIndex >= 0 ? browseCurrentIndex : currentIndex,
-        total: browsableTracks.length,
-      };
-    }
-    const queue = appleMusicPlaybackQueue.filter((id) =>
-      trackIndex.idSet.has(id)
-    );
-    if (queue.length === 0) {
-      return { index: currentIndex, total: tracks.length };
-    }
-    const idx = currentSongId ? queue.indexOf(currentSongId) : -1;
-    // If the current song isn't part of the active queue, fall back to
-    // the full-library counter rather than showing "0 of N".
-    if (idx < 0) return { index: currentIndex, total: tracks.length };
-    return { index: idx, total: queue.length };
-  }, [
-    isAppleMusic,
-    appleMusicPlaybackQueue,
-    tracks,
-    trackIndex,
-    browsableTracks.length,
-    currentSongId,
-    currentIndex,
-    browseCurrentIndex,
-  ]);
+  } = useIpodActiveLibrary();
 
   const {
     theme,

--- a/src/apps/ipod/types.ts
+++ b/src/apps/ipod/types.ts
@@ -40,7 +40,30 @@ export interface MenuItem {
 }
 
 // Menu history entry
+export type IpodMenuKind =
+  | "root"
+  | "music"
+  | "settings"
+  | "extras"
+  | "artists"
+  | "albums"
+  | "songs"
+  | "playlists"
+  | "recentlyAdded"
+  | "favorites"
+  | "radio"
+  | "artist"
+  | "album"
+  | "artistAllSongs"
+  | "artistAlbum"
+  | "appleMusicPlaylist"
+  | "nowPlayingSong";
+
 export interface MenuHistoryEntry {
+  /** Stable identity used for rebuild/restore. `title` remains for legacy breadcrumbs. */
+  kind?: IpodMenuKind;
+  /** Stable menu instance id (artist key, album key, playlist id, etc.). */
+  id?: string;
   title: string;
   displayTitle?: string;
   items: MenuItem[];

--- a/src/apps/ipod/utils/appleMusicPlaylistMenu.ts
+++ b/src/apps/ipod/utils/appleMusicPlaylistMenu.ts
@@ -16,9 +16,19 @@ export function getAppleMusicPlaylistIdFromMenuTitle(
 }
 
 export function resolveAppleMusicPlaylistMenu(
-  menu: Pick<MenuHistoryEntry, "title" | "displayTitle" | "modernMediaList">,
+  menu: Pick<
+    MenuHistoryEntry,
+    "kind" | "id" | "title" | "displayTitle" | "modernMediaList"
+  >,
   playlists: AppleMusicPlaylist[]
 ): AppleMusicPlaylist | null {
+  if (menu.kind === "appleMusicPlaylist" && menu.id) {
+    return playlists.find((playlist) => playlist.id === menu.id) ?? null;
+  }
+  if (menu.kind) {
+    return null;
+  }
+
   const playlistId = getAppleMusicPlaylistIdFromMenuTitle(menu.title);
   if (playlistId) {
     return playlists.find((playlist) => playlist.id === playlistId) ?? null;

--- a/src/apps/ipod/utils/ipodLibraryIndex.ts
+++ b/src/apps/ipod/utils/ipodLibraryIndex.ts
@@ -1,0 +1,35 @@
+import type { Track } from "@/stores/useIpodStore";
+
+export interface IpodLibraryIndex {
+  trackById: Map<string, Track>;
+  indexById: Map<string, number>;
+  idSet: Set<string>;
+}
+
+export function buildIpodLibraryIndex(
+  tracks: readonly Track[]
+): IpodLibraryIndex {
+  const trackById = new Map<string, Track>();
+  const indexById = new Map<string, number>();
+  const idSet = new Set<string>();
+
+  for (let index = 0; index < tracks.length; index++) {
+    const track = tracks[index];
+    if (!track || indexById.has(track.id)) continue;
+    trackById.set(track.id, track);
+    indexById.set(track.id, index);
+    idSet.add(track.id);
+  }
+
+  return { trackById, indexById, idSet };
+}
+
+export function resolveCurrentTrackIndex(
+  indexById: ReadonlyMap<string, number>,
+  currentSongId: string | null,
+  trackCount: number
+): number {
+  if (trackCount <= 0) return -1;
+  if (!currentSongId) return 0;
+  return indexById.get(currentSongId) ?? 0;
+}

--- a/src/apps/ipod/utils/menuIdentity.ts
+++ b/src/apps/ipod/utils/menuIdentity.ts
@@ -1,0 +1,15 @@
+import type { MenuHistoryEntry } from "../types";
+
+export function getMenuMemoryKey(
+  entry: Pick<MenuHistoryEntry, "kind" | "id" | "title">
+): string {
+  if (entry.kind) return `${entry.kind}:${entry.id ?? entry.title}`;
+  return entry.title;
+}
+
+export function isNowPlayingSongMenu(
+  entry: Pick<MenuHistoryEntry, "kind" | "title"> | undefined,
+  legacyTitle: string
+): boolean {
+  return entry?.kind === "nowPlayingSong" || entry?.title === legacyTitle;
+}

--- a/src/stores/useIpodStore.ts
+++ b/src/stores/useIpodStore.ts
@@ -117,6 +117,11 @@ export function appleMusicKitIdToLyricsSongId(
 }
 
 type LibraryState = "uninitialized" | "loaded" | "cleared";
+const PLAYBACK_TIME_UPDATE_EPSILON_SECONDS = 0.05;
+
+function shouldUpdatePlaybackTime(previous: number, next: number): boolean {
+  return Math.abs(previous - next) >= PLAYBACK_TIME_UPDATE_EPSILON_SECONDS;
+}
 
 interface IpodData {
   tracks: Track[];
@@ -2053,8 +2058,18 @@ export const useIpodStore = create<IpodState>()(
         // Save to server (clearing the source) and clear translations/furigana
         saveLyricsSourceToServer(trackId, null);
       },
-      setElapsedTime: (time) => set({ elapsedTime: time }),
-      setTotalTime: (time) => set({ totalTime: time }),
+      setElapsedTime: (time) =>
+        set((state) =>
+          shouldUpdatePlaybackTime(state.elapsedTime, time)
+            ? { elapsedTime: time }
+            : state
+        ),
+      setTotalTime: (time) =>
+        set((state) =>
+          shouldUpdatePlaybackTime(state.totalTime, time)
+            ? { totalTime: time }
+            : state
+        ),
 
       // -----------------------------------------------------------------
       // Apple Music actions

--- a/src/stores/useIpodStore.ts
+++ b/src/stores/useIpodStore.ts
@@ -265,6 +265,8 @@ interface IpodData {
    */
   ipodMenuBreadcrumb:
     | {
+        kind?: import("@/apps/ipod/types").IpodMenuKind;
+        id?: string;
         title: string;
         displayTitle?: string;
         selectedIndex: number;

--- a/tests/test-ipod-apple-music-playlist-menu.test.ts
+++ b/tests/test-ipod-apple-music-playlist-menu.test.ts
@@ -32,6 +32,30 @@ describe("Apple Music playlist menu titles", () => {
     expect(playlist?.id).toBe("p-ipod");
   });
 
+  test("resolves typed playlist breadcrumbs by id", () => {
+    const playlist = resolveAppleMusicPlaylistMenu(
+      {
+        kind: "appleMusicPlaylist",
+        id: "p-ipod",
+        title: "iPod",
+        displayTitle: "iPod",
+        modernMediaList: true,
+      },
+      playlists
+    );
+
+    expect(playlist?.id).toBe("p-ipod");
+  });
+
+  test("typed root breadcrumbs do not resolve as playlists", () => {
+    const playlist = resolveAppleMusicPlaylistMenu(
+      { kind: "root", id: "ipod", title: "iPod", modernMediaList: true },
+      playlists
+    );
+
+    expect(playlist).toBeNull();
+  });
+
   test("keeps legacy root breadcrumb titles from resolving as playlists", () => {
     const playlist = resolveAppleMusicPlaylistMenu(
       { title: "iPod", modernMediaList: false },

--- a/tests/test-ipod-library-index.test.ts
+++ b/tests/test-ipod-library-index.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from "bun:test";
+import type { Track } from "../src/stores/useIpodStore";
+import { useIpodStore } from "../src/stores/useIpodStore";
+import {
+  buildIpodLibraryIndex,
+  resolveCurrentTrackIndex,
+} from "../src/apps/ipod/utils/ipodLibraryIndex";
+
+function track(id: string): Track {
+  return {
+    id,
+    url: `https://example.com/${id}`,
+    title: id,
+  };
+}
+
+describe("iPod library index", () => {
+  test("builds stable id lookups for tracks", () => {
+    const first = track("a");
+    const duplicate = { ...track("a"), title: "duplicate" };
+    const second = track("b");
+
+    const index = buildIpodLibraryIndex([first, duplicate, second]);
+
+    expect(index.trackById.get("a")).toBe(first);
+    expect(index.indexById.get("a")).toBe(0);
+    expect(index.trackById.get("b")).toBe(second);
+    expect(index.indexById.get("b")).toBe(2);
+    expect(index.idSet.has("a")).toBe(true);
+    expect(index.idSet.has("missing")).toBe(false);
+  });
+
+  test("resolves current indexes without rescanning the track array", () => {
+    const index = buildIpodLibraryIndex([track("a"), track("b")]);
+
+    expect(resolveCurrentTrackIndex(index.indexById, "b", 2)).toBe(1);
+    expect(resolveCurrentTrackIndex(index.indexById, "missing", 2)).toBe(0);
+    expect(resolveCurrentTrackIndex(index.indexById, null, 2)).toBe(0);
+    expect(resolveCurrentTrackIndex(index.indexById, "a", 0)).toBe(-1);
+  });
+});
+
+describe("iPod playback time setters", () => {
+  test("ignore redundant sub-frame elapsed-time updates", () => {
+    useIpodStore.setState({ elapsedTime: 10 });
+    let elapsedTimeUpdates = 0;
+    const unsubscribe = useIpodStore.subscribe((state, previousState) => {
+      if (state.elapsedTime !== previousState.elapsedTime) elapsedTimeUpdates++;
+    });
+
+    useIpodStore.getState().setElapsedTime(10.01);
+    expect(useIpodStore.getState().elapsedTime).toBe(10);
+    expect(elapsedTimeUpdates).toBe(0);
+
+    useIpodStore.getState().setElapsedTime(10.1);
+    expect(useIpodStore.getState().elapsedTime).toBe(10.1);
+    expect(elapsedTimeUpdates).toBe(1);
+
+    unsubscribe();
+  });
+});

--- a/tests/test-ipod-menu-identity.test.ts
+++ b/tests/test-ipod-menu-identity.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "bun:test";
+import {
+  getMenuMemoryKey,
+  isNowPlayingSongMenu,
+} from "../src/apps/ipod/utils/menuIdentity";
+
+describe("iPod menu identity", () => {
+  test("uses kind and id for stable memory keys", () => {
+    expect(
+      getMenuMemoryKey({
+        kind: "appleMusicPlaylist",
+        id: "p-ipod",
+        title: "iPod",
+      })
+    ).toBe("appleMusicPlaylist:p-ipod");
+  });
+
+  test("falls back to title for legacy breadcrumbs", () => {
+    expect(getMenuMemoryKey({ title: "iPod" })).toBe("iPod");
+  });
+
+  test("recognizes typed and legacy now-playing song menus", () => {
+    expect(
+      isNowPlayingSongMenu(
+        { kind: "nowPlayingSong", title: "Renamed Track" },
+        "__nowPlayingSong"
+      )
+    ).toBe(true);
+    expect(
+      isNowPlayingSongMenu(
+        { title: "__nowPlayingSong" },
+        "__nowPlayingSong"
+      )
+    ).toBe(true);
+    expect(
+      isNowPlayingSongMenu({ kind: "root", title: "iPod" }, "__nowPlayingSong")
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add a shared iPod library index utility for stable `id -> track/index` lookups.
- Use the index in `useIpodLogic` to avoid repeated large-library scans when resolving the current song and active Apple Music queue.
- Ignore redundant sub-frame playback time updates in the iPod store.
- Lazy-load optional iPod surfaces and fullscreen visualizer backgrounds; make fullscreen volume reactive to master-volume changes.
- Add typed iPod menu identities (`kind`/`id`) while preserving legacy title-based breadcrumb fallback.
- Extract active-library selection/indexing/counter logic from `useIpodLogic` into `useIpodActiveLibrary`.
- Reduce click-wheel render churn by moving desktop wheel delta accumulation from React state to refs and centralizing wheel geometry reads.
- Reduce text measurement overhead by skipping marquee resize observers for inactive selection-driven rows.
- Refresh iPod docs to list current hooks and utilities.

### Walkthrough
<a href="https://cursor.com/agents/bc-F3ED6341-21D1-49DC-8141-729037155109/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fipod_menu_back_short_trimmed.mp4"><img src="https://cursor.com/artifacts/c/art-2e3784b2-ffb8-445e-b0c5-52fff4229882" alt="ipod_menu_back_short_trimmed.mp4" /></a>

### Testing
- Stage 1: `bun test tests/test-ipod-library-index.test.ts tests/test-ipod-apple-music-menu-loading.test.ts tests/test-ipod-apple-music-playlist-menu.test.ts tests/test-ipod-apple-music.test.ts tests/test-ipod-lyrics-track-metadata.test.ts tests/test-ipod-track-order.test.ts` — 102 pass, 0 fail.
- Stage 1: `git diff --check HEAD~1 HEAD` — pass.
- Stage 1: `bun run build` — pass.
- Stage 2: `bun test tests/test-ipod-library-index.test.ts tests/test-ipod-apple-music-menu-loading.test.ts tests/test-ipod-apple-music-playlist-menu.test.ts tests/test-ipod-apple-music.test.ts tests/test-ipod-lyrics-track-metadata.test.ts tests/test-ipod-track-order.test.ts` — 102 pass, 0 fail.
- Stage 2: `git diff --check` — pass.
- Stage 2: `bun run build` — pass; iPod app chunk reduced from ~231.72 kB to ~204.71 kB in local output.
- Stage 3: `bun test tests/test-ipod-menu-identity.test.ts tests/test-ipod-apple-music-playlist-menu.test.ts tests/test-ipod-library-index.test.ts tests/test-ipod-apple-music-menu-loading.test.ts tests/test-ipod-apple-music.test.ts tests/test-ipod-lyrics-track-metadata.test.ts tests/test-ipod-track-order.test.ts` — 107 pass, 0 fail.
- Stage 3: `git diff --check` — pass.
- Stage 3: `bun run build` — pass.
- Stage 4: `bun test tests/test-ipod-menu-identity.test.ts tests/test-ipod-apple-music-playlist-menu.test.ts tests/test-ipod-library-index.test.ts tests/test-ipod-apple-music-menu-loading.test.ts tests/test-ipod-apple-music.test.ts tests/test-ipod-lyrics-track-metadata.test.ts tests/test-ipod-track-order.test.ts` — 107 pass, 0 fail.
- Stage 4: `git diff --check` — pass.
- Stage 4: `bun run build` — pass.
- Stage 5: `bun test tests/test-ipod-menu-identity.test.ts tests/test-ipod-apple-music-playlist-menu.test.ts tests/test-ipod-library-index.test.ts tests/test-ipod-apple-music-menu-loading.test.ts tests/test-ipod-apple-music.test.ts tests/test-ipod-lyrics-track-metadata.test.ts tests/test-ipod-track-order.test.ts` — 107 pass, 0 fail.
- Stage 5: `git diff --check` — pass.
- Stage 5: `bun run build` — pass.
- Stage 6: `bun test tests/test-ipod-menu-identity.test.ts tests/test-ipod-apple-music-playlist-menu.test.ts tests/test-ipod-library-index.test.ts tests/test-ipod-apple-music-menu-loading.test.ts tests/test-ipod-apple-music.test.ts tests/test-ipod-lyrics-track-metadata.test.ts tests/test-ipod-track-order.test.ts` — 107 pass, 0 fail.
- Stage 6: `git diff --check` — pass.
- Stage 6: `bun run build` — pass.
- Final: `bun test tests/test-ipod-menu-identity.test.ts tests/test-ipod-apple-music-playlist-menu.test.ts tests/test-ipod-library-index.test.ts tests/test-ipod-apple-music-menu-loading.test.ts tests/test-ipod-apple-music.test.ts tests/test-ipod-lyrics-track-metadata.test.ts tests/test-ipod-track-order.test.ts` — 107 pass, 0 fail.
- Final: `git diff --check HEAD~6 HEAD` — pass.
- Final: `bun run build` — pass.
- Final: manual iPod menu smoke test — pass; see walkthrough video.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-F3ED6341-21D1-49DC-8141-729037155109"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-F3ED6341-21D1-49DC-8141-729037155109"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

