### PR TITLE
Update iPod settings backlight timer and add UI Theme toggle

### DIFF
--- a/src/apps/ipod/components/IpodMenuBar.tsx
+++ b/src/apps/ipod/components/IpodMenuBar.tsx
@@ -815,11 +815,14 @@ export function IpodMenuBar({
               <MenubarRadioGroup
                 value={backlightTimeout}
                 onValueChange={(value) => {
-                  const timeout = value as "2s" | "10s" | "off";
+                  const timeout = value as "2s" | "10s" | "always-on" | "off";
                   setBacklightTimeout(timeout);
                   if (timeout === "off" && isBacklightOn) {
                     toggleBacklight();
-                  } else if ((timeout === "2s" || timeout === "10s") && !isBacklightOn) {
+                  } else if (
+                    (timeout === "2s" || timeout === "10s" || timeout === "always-on") &&
+                    !isBacklightOn
+                  ) {
                     toggleBacklight();
                   }
                 }}
@@ -829,6 +832,9 @@ export function IpodMenuBar({
                 </MenubarRadioItem>
                 <MenubarRadioItem value="10s" className="text-md h-6 pr-3">
                   10s
+                </MenubarRadioItem>
+                <MenubarRadioItem value="always-on" className="text-md h-6 pr-3">
+                  {t("apps.ipod.menuItems.alwaysOn", "Always On")}
                 </MenubarRadioItem>
                 <MenubarRadioItem value="off" className="text-md h-6 pr-3">
                   {t("apps.ipod.menuItems.off")}

--- a/src/apps/ipod/components/IpodMenuBar.tsx
+++ b/src/apps/ipod/components/IpodMenuBar.tsx
@@ -834,7 +834,7 @@ export function IpodMenuBar({
                   10s
                 </MenubarRadioItem>
                 <MenubarRadioItem value="always-on" className="text-md h-6 pr-3">
-                  {t("apps.ipod.menuItems.alwaysOn", "Always On")}
+                  {t("apps.ipod.menuItems.alwaysOn", "Keep On")}
                 </MenubarRadioItem>
                 <MenubarRadioItem value="off" className="text-md h-6 pr-3">
                   {t("apps.ipod.menuItems.off")}

--- a/src/apps/ipod/components/IpodMenuBar.tsx
+++ b/src/apps/ipod/components/IpodMenuBar.tsx
@@ -97,9 +97,8 @@ export function IpodMenuBar({
     isPlaying,
     isShuffled,
     isBacklightOn,
-    isVideoOn,
+    backlightTimeout,
     displayMode,
-    isLcdFilterOn,
     currentTheme,
     uiVariant,
     showLyrics,
@@ -120,9 +119,8 @@ export function IpodMenuBar({
     appleMusicNext,
     appleMusicPrevious,
     toggleBacklight,
-    toggleVideo,
+    setBacklightTimeout,
     setDisplayMode,
-    toggleLcdFilter,
     toggleFullScreen,
     setTheme,
     setUiVariant,
@@ -147,9 +145,8 @@ export function IpodMenuBar({
     isPlaying: s.isPlaying,
     isShuffled: s.isShuffled,
     isBacklightOn: s.backlightOn,
-    isVideoOn: s.showVideo,
+    backlightTimeout: s.backlightTimeout,
     displayMode: s.displayMode ?? DisplayMode.Video,
-    isLcdFilterOn: s.lcdFilterOn,
     currentTheme: s.theme,
     uiVariant: s.uiVariant ?? "modern",
     showLyrics: s.showLyrics,
@@ -170,9 +167,8 @@ export function IpodMenuBar({
     appleMusicNext: s.appleMusicNextTrack,
     appleMusicPrevious: s.appleMusicPreviousTrack,
     toggleBacklight: s.toggleBacklight,
-    toggleVideo: s.toggleVideo,
+    setBacklightTimeout: s.setBacklightTimeout,
     setDisplayMode: s.setDisplayMode,
-    toggleLcdFilter: s.toggleLcdFilter,
     toggleFullScreen: s.toggleFullScreen,
     setTheme: s.setTheme,
     setUiVariant: s.setUiVariant,
@@ -810,36 +806,34 @@ export function IpodMenuBar({
 
           <MenubarSeparator className="h-[2px] bg-black my-1" />
 
-          {/* Screen: backlight, monochrome filter, embedded video */}
+          {/* Backlight timeout options */}
           <MenubarSub>
             <MenubarSubTrigger className="text-md h-6 px-3">
-              {t("apps.ipod.menu.screen")}
+              {t("apps.ipod.menu.backlight")}
             </MenubarSubTrigger>
             <MenubarSubContent className="px-0">
-              <MenubarCheckboxItem
-                checked={isBacklightOn}
-                onCheckedChange={() => toggleBacklight()}
-                className="text-md h-6 px-3"
+              <MenubarRadioGroup
+                value={backlightTimeout}
+                onValueChange={(value) => {
+                  const timeout = value as "2s" | "10s" | "off";
+                  setBacklightTimeout(timeout);
+                  if (timeout === "off" && isBacklightOn) {
+                    toggleBacklight();
+                  } else if ((timeout === "2s" || timeout === "10s") && !isBacklightOn) {
+                    toggleBacklight();
+                  }
+                }}
               >
-                {t("apps.ipod.menu.backlight")}
-              </MenubarCheckboxItem>
-
-              <MenubarCheckboxItem
-                checked={isLcdFilterOn}
-                onCheckedChange={() => toggleLcdFilter()}
-                className="text-md h-6 px-3"
-              >
-                {t("apps.ipod.menu.lcdFilter")}
-              </MenubarCheckboxItem>
-
-              <MenubarCheckboxItem
-                checked={isVideoOn}
-                onCheckedChange={() => toggleVideo()}
-                className="text-md h-6 px-3"
-                disabled={!isPlaying}
-              >
-                {t("apps.ipod.menu.video")}
-              </MenubarCheckboxItem>
+                <MenubarRadioItem value="2s" className="text-md h-6 pr-3">
+                  2s
+                </MenubarRadioItem>
+                <MenubarRadioItem value="10s" className="text-md h-6 pr-3">
+                  10s
+                </MenubarRadioItem>
+                <MenubarRadioItem value="off" className="text-md h-6 pr-3">
+                  {t("apps.ipod.menuItems.off")}
+                </MenubarRadioItem>
+              </MenubarRadioGroup>
             </MenubarSubContent>
           </MenubarSub>
 

--- a/src/apps/ipod/components/IpodScreen.tsx
+++ b/src/apps/ipod/components/IpodScreen.tsx
@@ -10,7 +10,7 @@ import {
 } from "react";
 import ReactPlayer from "react-player";
 import { motion, AnimatePresence } from "framer-motion";
-import { Repeat, Shuffle } from "@phosphor-icons/react";
+import { Repeat, RepeatOnce, Shuffle } from "@phosphor-icons/react";
 import { cn } from "@/lib/utils";
 import { useAudioSettingsStore } from "@/stores/useAudioSettingsStore";
 import { LyricsDisplay } from "./LyricsDisplay";
@@ -1281,29 +1281,29 @@ export function IpodScreen({
                               })}
                       </span>
                       <span className="flex shrink-0 items-center gap-1">
-                        {loopCurrent ? (
-                          <Shuffle
-                            className="shrink-0"
-                            size={isModernUi ? 12 : 13}
-                            weight="bold"
-                            aria-label={t("apps.ipod.menu.repeatOne")}
-                          />
-                        ) : loopAll ? (
-                          <Shuffle
-                            className="shrink-0"
-                            size={isModernUi ? 12 : 13}
-                            weight="bold"
-                            aria-label={t("apps.ipod.menu.repeatAll")}
-                          />
-                        ) : null}
                         {isShuffled && (
-                          <Repeat
+                          <Shuffle
                             className="shrink-0"
                             size={isModernUi ? 12 : 13}
                             weight="bold"
                             aria-label={t("apps.ipod.ariaLabels.shuffleOn")}
                           />
                         )}
+                        {loopCurrent ? (
+                          <RepeatOnce
+                            className="shrink-0"
+                            size={isModernUi ? 12 : 13}
+                            weight="bold"
+                            aria-label={t("apps.ipod.menu.repeatOne")}
+                          />
+                        ) : loopAll ? (
+                          <Repeat
+                            className="shrink-0"
+                            size={isModernUi ? 12 : 13}
+                            weight="bold"
+                            aria-label={t("apps.ipod.menu.repeatAll")}
+                          />
+                        ) : null}
                       </span>
                     </div>
                     {isModernUi ? (

--- a/src/apps/ipod/components/IpodScreen.tsx
+++ b/src/apps/ipod/components/IpodScreen.tsx
@@ -10,7 +10,7 @@ import {
 } from "react";
 import ReactPlayer from "react-player";
 import { motion, AnimatePresence } from "framer-motion";
-import { Repeat, RepeatOnce, Shuffle } from "@phosphor-icons/react";
+import { Repeat, Shuffle } from "@phosphor-icons/react";
 import { cn } from "@/lib/utils";
 import { useAudioSettingsStore } from "@/stores/useAudioSettingsStore";
 import { LyricsDisplay } from "./LyricsDisplay";
@@ -1282,14 +1282,14 @@ export function IpodScreen({
                       </span>
                       <span className="flex shrink-0 items-center gap-1">
                         {loopCurrent ? (
-                          <RepeatOnce
+                          <Shuffle
                             className="shrink-0"
                             size={isModernUi ? 12 : 13}
                             weight="bold"
                             aria-label={t("apps.ipod.menu.repeatOne")}
                           />
                         ) : loopAll ? (
-                          <Repeat
+                          <Shuffle
                             className="shrink-0"
                             size={isModernUi ? 12 : 13}
                             weight="bold"
@@ -1297,7 +1297,7 @@ export function IpodScreen({
                           />
                         ) : null}
                         {isShuffled && (
-                          <Shuffle
+                          <Repeat
                             className="shrink-0"
                             size={isModernUi ? 12 : 13}
                             weight="bold"

--- a/src/apps/ipod/hooks/useIpodLogic.ts
+++ b/src/apps/ipod/hooks/useIpodLogic.ts
@@ -29,6 +29,7 @@ import { clearAppleMusicLibrary } from "@/utils/appleMusicLibraryCache";
 import {
   useIpodStore,
   Track,
+  IpodBacklightTimeout,
   getEffectiveTranslationLanguage,
   flushPendingLyricOffsetSave,
   isAppleMusicCollectionTrack,
@@ -55,7 +56,6 @@ import {
 } from "@/utils/sharedUrl";
 import { onAppUpdate } from "@/utils/appEventBus";
 import {
-  BACKLIGHT_TIMEOUT_MS,
   SEEK_AMOUNT_SECONDS,
   IPOD_NOW_PLAYING_SONG_MENU_KEY as NOW_PLAYING_SONG_MENU_KEY,
   getYouTubeVideoId,
@@ -101,6 +101,10 @@ const IS_IOS_SAFARI = IS_IOS && IS_SAFARI;
 
 /** Stable fallback so `rebuildMenuItems` never returns a fresh `[]` per call. */
 const EMPTY_IPOD_MENU_ITEMS: MenuItem[] = [];
+const BACKLIGHT_TIMEOUT_BY_SETTING: Record<Exclude<IpodBacklightTimeout, "off">, number> = {
+  "2s": 2000,
+  "10s": 10000,
+};
 
 export interface UseIpodLogicOptions {
   isWindowOpen: boolean;
@@ -151,6 +155,7 @@ export function useIpodLogic({
 
   const {
     theme,
+    backlightTimeout,
     lcdFilterOn,
     displayMode,
     showLyrics,
@@ -174,7 +179,9 @@ export function useIpodLogic({
     setDisplayMode,
     toggleVideo,
     toggleBacklight,
+    setBacklightTimeout,
     setTheme,
+    setUiVariant,
     clearLibrary,
     // addTrackFromVideoId - accessed via store.getState() directly
     youtubeNextTrack,
@@ -188,6 +195,7 @@ export function useIpodLogic({
     setCurrentFuriganaMap,
   } = useIpodStoreShallow((s) => ({
     theme: s.theme,
+    backlightTimeout: s.backlightTimeout,
     lcdFilterOn: s.lcdFilterOn,
     displayMode: s.displayMode ?? DisplayMode.Video,
     showLyrics: s.showLyrics,
@@ -210,7 +218,9 @@ export function useIpodLogic({
     setIsPlaying: s.setIsPlaying,
     toggleVideo: s.toggleVideo,
     toggleBacklight: s.toggleBacklight,
+    setBacklightTimeout: s.setBacklightTimeout,
     setTheme: s.setTheme,
+    setUiVariant: s.setUiVariant,
     clearLibrary: s.clearLibrary,
     youtubeNextTrack: s.nextTrack,
     youtubePreviousTrack: s.previousTrack,
@@ -682,7 +692,9 @@ export function useIpodLogic({
   const registerActivity = useCallback(() => {
     setLastActivityTime(Date.now());
     userHasInteractedRef.current = true;
-    if (!useIpodStore.getState().backlightOn) {
+    const { backlightOn: isBacklightOn, backlightTimeout: timeoutSetting } =
+      useIpodStore.getState();
+    if (timeoutSetting !== "off" && !isBacklightOn) {
       toggleBacklight();
     }
   }, [toggleBacklight]);
@@ -710,6 +722,27 @@ export function useIpodLogic({
     }
   }, [toggleBacklight, showStatus, registerActivity, menuLocale]);
 
+  const memoizedCycleBacklightTimeout = useCallback(() => {
+    const currentSetting = useIpodStore.getState().backlightTimeout;
+    const nextSetting: IpodBacklightTimeout =
+      currentSetting === "2s" ? "10s" : currentSetting === "10s" ? "off" : "2s";
+    setBacklightTimeout(nextSetting);
+
+    if (nextSetting === "off") {
+      if (useIpodStore.getState().backlightOn) {
+        toggleBacklight();
+      }
+      showStatus(t("apps.ipod.menuItems.off"));
+      return;
+    }
+
+    if (!useIpodStore.getState().backlightOn) {
+      toggleBacklight();
+    }
+    showStatus(nextSetting);
+    registerActivity();
+  }, [setBacklightTimeout, toggleBacklight, showStatus, registerActivity, menuLocale]);
+
   const memoizedChangeTheme = useCallback(
     (newTheme: "classic" | "black" | "u2") => {
       setTheme(newTheme);
@@ -727,14 +760,14 @@ export function useIpodLogic({
 
   const handleMenuItemAction = useCallback(
     (action: () => void) => {
-      if (action === memoizedToggleBacklight) {
+      if (action === memoizedToggleBacklight || action === memoizedCycleBacklightTimeout) {
         action();
       } else {
         registerActivity();
         action();
       }
     },
-    [registerActivity, memoizedToggleBacklight]
+    [registerActivity, memoizedToggleBacklight, memoizedCycleBacklightTimeout]
   );
 
   const memoizedToggleRepeat = useCallback(() => {
@@ -765,6 +798,18 @@ export function useIpodLogic({
         : "classic";
     memoizedChangeTheme(nextTheme);
   }, [memoizedChangeTheme]);
+
+  const memoizedHandleUiThemeChange = useCallback(() => {
+    const currentVariant = useIpodStore.getState().uiVariant;
+    const nextVariant = currentVariant === "modern" ? "classic" : "modern";
+    setUiVariant(nextVariant);
+    showStatus(
+      nextVariant === "modern"
+        ? t("apps.ipod.menu.screenModern")
+        : t("apps.ipod.menu.screenClassic")
+    );
+    registerActivity();
+  }, [setUiVariant, showStatus, registerActivity, menuLocale]);
 
   // Stable callback used by every "play this track from a menu" entry. We
   // factor this out so per-track menu items can be memoized — without it,
@@ -1341,19 +1386,24 @@ export function useIpodLogic({
       clearTimeout(backlightTimerRef.current);
     }
 
-    if (backlightOn) {
+    const timeoutMs =
+      backlightTimeout === "off"
+        ? null
+        : BACKLIGHT_TIMEOUT_BY_SETTING[backlightTimeout];
+
+    if (backlightOn && timeoutMs !== null) {
       backlightTimerRef.current = setTimeout(() => {
         const currentShowVideo = useIpodStore.getState().showVideo;
         const currentIsPlaying = useIpodStore.getState().isPlaying;
         const isGameOpen = isMusicQuizOpen || isBrickGameOpen;
         if (
-          Date.now() - lastActivityTime >= BACKLIGHT_TIMEOUT_MS &&
+          Date.now() - lastActivityTime >= timeoutMs &&
           !(currentShowVideo && currentIsPlaying) &&
           !isGameOpen
         ) {
           toggleBacklight();
         }
-      }, BACKLIGHT_TIMEOUT_MS);
+      }, timeoutMs);
     }
 
     return () => {
@@ -1363,6 +1413,7 @@ export function useIpodLogic({
     };
   }, [
     backlightOn,
+    backlightTimeout,
     isBrickGameOpen,
     isMusicQuizOpen,
     lastActivityTime,
@@ -1372,7 +1423,9 @@ export function useIpodLogic({
   // Foreground handling
   useEffect(() => {
     if (isForeground && !prevIsForeground.current) {
-      if (!useIpodStore.getState().backlightOn) {
+      const { backlightOn: isBacklightOn, backlightTimeout: timeoutSetting } =
+        useIpodStore.getState();
+      if (!isBacklightOn && timeoutSetting !== "off") {
         toggleBacklight();
       }
       registerActivity();
@@ -2402,9 +2455,14 @@ export function useIpodLogic({
       },
       {
         label: t("apps.ipod.menuItems.backlight"),
-        action: memoizedToggleBacklight,
+        action: memoizedCycleBacklightTimeout,
         showChevron: false,
-        value: backlightOn ? t("apps.ipod.menuItems.on") : t("apps.ipod.menuItems.off"),
+        value:
+          backlightTimeout === "2s"
+            ? "2s"
+            : backlightTimeout === "10s"
+            ? "10s"
+            : t("apps.ipod.menuItems.off"),
       },
       {
         label: t("apps.ipod.menuItems.theme"),
@@ -2416,6 +2474,15 @@ export function useIpodLogic({
             : theme === "black"
             ? t("apps.ipod.menu.black")
             : t("apps.ipod.menu.u2"),
+      },
+      {
+        label: t("apps.ipod.menu.uiTheme", "UI Theme"),
+        action: memoizedHandleUiThemeChange,
+        showChevron: false,
+        value:
+          uiVariant === "modern"
+            ? t("apps.ipod.menu.screenModern")
+            : t("apps.ipod.menu.screenClassic"),
       },
       {
         label: t("apps.ipod.menuItems.librarySource", "Library"),
@@ -2449,12 +2516,14 @@ export function useIpodLogic({
     loopCurrent,
     loopAll,
     isShuffled,
-    backlightOn,
+    backlightTimeout,
     theme,
+    uiVariant,
     memoizedToggleRepeat,
     memoizedToggleShuffle,
-    memoizedToggleBacklight,
+    memoizedCycleBacklightTimeout,
     memoizedHandleThemeChange,
+    memoizedHandleUiThemeChange,
     isAppleMusic,
     appleMusicAuthorized,
     musicKitStatus,

--- a/src/apps/ipod/hooks/useIpodLogic.ts
+++ b/src/apps/ipod/hooks/useIpodLogic.ts
@@ -749,7 +749,7 @@ export function useIpodLogic({
       if (!useIpodStore.getState().backlightOn) {
         toggleBacklight();
       }
-      showStatus(t("apps.ipod.menuItems.alwaysOn", "Always On"));
+      showStatus(t("apps.ipod.menuItems.alwaysOn", "Keep On"));
       registerActivity();
       return;
     }
@@ -2481,7 +2481,7 @@ export function useIpodLogic({
             : backlightTimeout === "10s"
             ? "10s"
             : backlightTimeout === "always-on"
-            ? t("apps.ipod.menuItems.alwaysOn", "Always On")
+            ? t("apps.ipod.menuItems.alwaysOn", "Keep On")
             : t("apps.ipod.menuItems.off"),
       },
       {

--- a/src/apps/ipod/hooks/useIpodLogic.ts
+++ b/src/apps/ipod/hooks/useIpodLogic.ts
@@ -101,7 +101,10 @@ const IS_IOS_SAFARI = IS_IOS && IS_SAFARI;
 
 /** Stable fallback so `rebuildMenuItems` never returns a fresh `[]` per call. */
 const EMPTY_IPOD_MENU_ITEMS: MenuItem[] = [];
-const BACKLIGHT_TIMEOUT_BY_SETTING: Record<Exclude<IpodBacklightTimeout, "off">, number> = {
+const BACKLIGHT_TIMEOUT_BY_SETTING: Record<
+  Exclude<IpodBacklightTimeout, "off" | "always-on">,
+  number
+> = {
   "2s": 2000,
   "10s": 10000,
 };
@@ -725,7 +728,13 @@ export function useIpodLogic({
   const memoizedCycleBacklightTimeout = useCallback(() => {
     const currentSetting = useIpodStore.getState().backlightTimeout;
     const nextSetting: IpodBacklightTimeout =
-      currentSetting === "2s" ? "10s" : currentSetting === "10s" ? "off" : "2s";
+      currentSetting === "2s"
+        ? "10s"
+        : currentSetting === "10s"
+        ? "always-on"
+        : currentSetting === "always-on"
+        ? "off"
+        : "2s";
     setBacklightTimeout(nextSetting);
 
     if (nextSetting === "off") {
@@ -733,6 +742,15 @@ export function useIpodLogic({
         toggleBacklight();
       }
       showStatus(t("apps.ipod.menuItems.off"));
+      return;
+    }
+
+    if (nextSetting === "always-on") {
+      if (!useIpodStore.getState().backlightOn) {
+        toggleBacklight();
+      }
+      showStatus(t("apps.ipod.menuItems.alwaysOn", "Always On"));
+      registerActivity();
       return;
     }
 
@@ -1387,7 +1405,7 @@ export function useIpodLogic({
     }
 
     const timeoutMs =
-      backlightTimeout === "off"
+      backlightTimeout === "off" || backlightTimeout === "always-on"
         ? null
         : BACKLIGHT_TIMEOUT_BY_SETTING[backlightTimeout];
 
@@ -2462,6 +2480,8 @@ export function useIpodLogic({
             ? "2s"
             : backlightTimeout === "10s"
             ? "10s"
+            : backlightTimeout === "always-on"
+            ? t("apps.ipod.menuItems.alwaysOn", "Always On")
             : t("apps.ipod.menuItems.off"),
       },
       {

--- a/src/lib/locales/en/translation.json
+++ b/src/lib/locales/en/translation.json
@@ -1999,6 +1999,7 @@
         "backlight": "Backlight",
         "theme": "Theme",
         "on": "On",
+        "alwaysOn": "Always On",
         "off": "Off",
         "one": "One",
         "all": "All",

--- a/src/lib/locales/en/translation.json
+++ b/src/lib/locales/en/translation.json
@@ -1999,7 +1999,7 @@
         "backlight": "Backlight",
         "theme": "Theme",
         "on": "On",
-        "alwaysOn": "Always On",
+        "alwaysOn": "Keep On",
         "off": "Off",
         "one": "One",
         "all": "All",

--- a/src/stores/useIpodStore.ts
+++ b/src/stores/useIpodStore.ts
@@ -36,6 +36,9 @@ export interface LyricsSource {
 /** Library source the iPod is currently displaying. */
 export type LibrarySource = "youtube" | "appleMusic";
 
+export const IPOD_BACKLIGHT_TIMEOUT_OPTIONS = ["2s", "10s", "off"] as const;
+export type IpodBacklightTimeout = (typeof IPOD_BACKLIGHT_TIMEOUT_OPTIONS)[number];
+
 /** User playlist from the Apple Music library. */
 export interface AppleMusicPlaylist {
   id: string;
@@ -135,6 +138,7 @@ interface IpodData {
   /** Display mode for visual background (video, cover art, or landscapes) */
   displayMode: DisplayMode;
   backlightOn: boolean;
+  backlightTimeout: IpodBacklightTimeout;
   theme: "classic" | "black" | "u2";
   /**
    * On-screen UI variant for the iPod display.
@@ -388,6 +392,7 @@ const initialIpodData: IpodData = {
   showVideo: false,
   displayMode: DisplayMode.Video,
   backlightOn: true,
+  backlightTimeout: "2s",
   theme: "classic",
   uiVariant: "modern",
   lcdFilterOn: true,
@@ -502,6 +507,7 @@ export interface IpodState extends IpodData {
   /** Set the display mode for visual background */
   setDisplayMode: (mode: DisplayMode) => void;
   toggleBacklight: () => void;
+  setBacklightTimeout: (timeout: IpodBacklightTimeout) => void;
   toggleLcdFilter: () => void;
   toggleFullScreen: () => void;
   setTheme: (theme: "classic" | "black" | "u2") => void;
@@ -783,7 +789,7 @@ export function navigateActiveIpodTrack(
   }
 }
 
-const CURRENT_IPOD_STORE_VERSION = 38; // Breadcrumb may include alphabetic flag so fast scroll-by-letter mode survives reopen
+const CURRENT_IPOD_STORE_VERSION = 39; // Add persisted iPod backlight timeout preference
 
 // Helper function to get unplayed track IDs from history
 function getUnplayedTrackIds(
@@ -1135,6 +1141,7 @@ export const useIpodStore = create<IpodState>()(
       setDisplayMode: (mode) => set({ displayMode: mode }),
       toggleBacklight: () =>
         set((state) => ({ backlightOn: !state.backlightOn })),
+      setBacklightTimeout: (timeout) => set({ backlightTimeout: timeout }),
       toggleLcdFilter: () =>
         set((state) => ({ lcdFilterOn: !state.lcdFilterOn })),
       toggleFullScreen: () =>
@@ -2374,6 +2381,7 @@ export const useIpodStore = create<IpodState>()(
         loopAll: state.loopAll,
         loopCurrent: state.loopCurrent,
         isShuffled: state.isShuffled,
+        backlightTimeout: state.backlightTimeout,
         theme: state.theme,
         uiVariant: state.uiVariant,
         lcdFilterOn: state.lcdFilterOn,
@@ -2490,6 +2498,12 @@ export const useIpodStore = create<IpodState>()(
           loopAll: state.loopAll,
           loopCurrent: state.loopCurrent,
           isShuffled: state.isShuffled,
+          backlightTimeout:
+            state.backlightTimeout === "2s" ||
+            state.backlightTimeout === "10s" ||
+            state.backlightTimeout === "off"
+              ? state.backlightTimeout
+              : "2s",
           theme: state.theme,
           uiVariant:
             state.uiVariant === "modern" || state.uiVariant === "classic"

--- a/src/stores/useIpodStore.ts
+++ b/src/stores/useIpodStore.ts
@@ -36,7 +36,7 @@ export interface LyricsSource {
 /** Library source the iPod is currently displaying. */
 export type LibrarySource = "youtube" | "appleMusic";
 
-export const IPOD_BACKLIGHT_TIMEOUT_OPTIONS = ["2s", "10s", "off"] as const;
+export const IPOD_BACKLIGHT_TIMEOUT_OPTIONS = ["2s", "10s", "always-on", "off"] as const;
 export type IpodBacklightTimeout = (typeof IPOD_BACKLIGHT_TIMEOUT_OPTIONS)[number];
 
 /** User playlist from the Apple Music library. */
@@ -2501,6 +2501,7 @@ export const useIpodStore = create<IpodState>()(
           backlightTimeout:
             state.backlightTimeout === "2s" ||
             state.backlightTimeout === "10s" ||
+            state.backlightTimeout === "always-on" ||
             state.backlightTimeout === "off"
               ? state.backlightTimeout
               : "2s",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- change iPod `Settings > Backlight` to cycle across `2s` → `10s` → `Keep On` → `Off`
- persist backlight timeout setting in the iPod store (default remains `2s`), including `always-on` mode backing the `Keep On` label
- add a `UI Theme` setting immediately after `Theme`, toggling between `Modern` and `Classic`
- update iPod menu bar: replace `Screen` submenu with `Backlight` options (`2s`, `10s`, `Keep On`, `Off`) and remove `LCD Filter` + `Video`
- now playing indicators: keep original shuffle/repeat icon mapping, but swap their display positions (shuffle appears before repeat)

## Testing
- ✅ `bun run test:unit`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-96A0F977-3DCB-451D-95A6-84BBCF84817A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-96A0F977-3DCB-451D-95A6-84BBCF84817A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

