### PR TITLE
iPod: Shuffle Songs menu always starts a fresh shuffle

### DIFF
--- a/src/apps/ipod/hooks/useIpodLogic.ts
+++ b/src/apps/ipod/hooks/useIpodLogic.ts
@@ -2655,13 +2655,61 @@ export function useIpodLogic({
         label: t("apps.ipod.menuItems.shuffleSongs"),
         action: () => {
           registerActivity();
-          if (useIpodStore.getState().showVideo) toggleVideo();
-          // Shuffle across the full library — drop any contextual queue.
-          if (useIpodStore.getState().librarySource === "appleMusic") {
-            useIpodStore.getState().setAppleMusicPlaybackQueue(null);
+          const store = useIpodStore.getState();
+          if (store.showVideo) toggleVideo();
+          // Always force shuffle ON (don't toggle off if already on) so the
+          // root "Shuffle Songs" item starts a fresh shuffle every time.
+          if (!store.isShuffled) {
+            store.toggleShuffle();
           }
-          memoizedToggleShuffle();
+          // Shuffle across the full library — drop any contextual queue.
+          const isAppleMusicSource = store.librarySource === "appleMusic";
+          if (isAppleMusicSource) {
+            store.setAppleMusicPlaybackQueue(null);
+          }
+
+          // Pick a random track from the active library and play it. Avoid
+          // landing on the current song when there are alternatives so the
+          // user gets a fresh start every time.
+          const refreshed = useIpodStore.getState();
+          let pool: Track[];
+          let currentId: string | null;
+          if (isAppleMusicSource) {
+            pool = refreshed.appleMusicTracks.filter(
+              (track) => !isAppleMusicCollectionTrack(track)
+            );
+            currentId = refreshed.appleMusicCurrentSongId;
+          } else {
+            pool = refreshed.tracks;
+            currentId = refreshed.currentSongId;
+          }
+
+          if (pool.length === 0) {
+            setMenuMode(false);
+            return;
+          }
+
+          const candidates =
+            pool.length > 1
+              ? pool.filter((track) => track.id !== currentId)
+              : pool;
+          const picked =
+            candidates[Math.floor(Math.random() * candidates.length)] ?? null;
+
+          if (picked) {
+            if (isAppleMusicSource) {
+              useIpodStore.getState().setAppleMusicCurrentSongId(picked.id);
+            } else {
+              useIpodStore.getState().setCurrentSongId(picked.id);
+            }
+            setIsPlaying(true);
+          }
+
+          showStatus(t("apps.ipod.status.shuffleOn"));
+          setMenuDirection("forward");
           setMenuMode(false);
+          setCameFromNowPlayingMenuItem(false);
+          clearReturnToNowPlayingSongMenu();
         },
         showChevron: false,
       },
@@ -2681,7 +2729,7 @@ export function useIpodLogic({
         showChevron: true,
       },
     ];
-  }, [registerActivity, toggleVideo, memoizedToggleShuffle, memoizedToggleBacklight, menuLocale, isOffline, showOfflineStatus, setIsPlaying, pushMenuChild]);
+  }, [registerActivity, toggleVideo, memoizedToggleBacklight, menuLocale, isOffline, showOfflineStatus, setIsPlaying, pushMenuChild, showStatus, clearReturnToNowPlayingSongMenu]);
 
   const findMenuItemIndexByLabel = useCallback(
     (items: MenuItem[], label: string) =>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
The root iPod menu's **Shuffle Songs** entry previously just called `toggleShuffle`, which:
- toggled shuffle OFF on the second invocation, and
- never picked a new song — so the user was left looking at the same track they had paused.

Real iPods treat *Shuffle Songs* as an action: enable shuffle and start playing a random song. This PR matches that behaviour.

### Changes
- `src/apps/ipod/hooks/useIpodLogic.ts`: rewrite the root **Shuffle Songs** menu item action.
  - Force `isShuffled = true` (only call `toggleShuffle` if shuffle is currently off — never turns it back off).
  - Drop any contextual Apple Music playback queue so the shuffle spans the full library, same as before.
  - Pick a random track from the active library (YouTube `tracks` or Apple Music `appleMusicTracks` minus collection rows), avoiding the current track when there's more than one option.
  - Set the picked track as current (using the active library's setter) and start playback.
  - Exit the menu, clear the now-playing breadcrumb, and show the existing "Shuffle on" status string.

### Testing
- ✅ `bun run test:unit` (236 tests, 24 files)
- ✅ `tsc --noEmit` (clean)
- ✅ `eslint src/apps/ipod/hooks/useIpodLogic.ts` (0 errors; pre-existing `react-hooks/exhaustive-deps` warnings only)

Manual GUI testing was skipped per the repo's `AGENTS.md` ("Skip computer use / GUI-driven testing unless the user explicitly requests it"). The change is contained to a single menu callback that delegates to existing, already-tested store actions (`toggleShuffle`, `setCurrentSongId` / `setAppleMusicCurrentSongId`, `setAppleMusicPlaybackQueue`).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-219DD479-9001-4269-9D81-281BDC288799"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-219DD479-9001-4269-9D81-281BDC288799"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

