### PR TITLE
Make iPod root "Shuffle Songs" start fresh random playback

### DIFF
--- a/src/apps/ipod/hooks/useIpodLogic.ts
+++ b/src/apps/ipod/hooks/useIpodLogic.ts
@@ -2655,12 +2655,22 @@ export function useIpodLogic({
         label: t("apps.ipod.menuItems.shuffleSongs"),
         action: () => {
           registerActivity();
-          if (useIpodStore.getState().showVideo) toggleVideo();
+          const store = useIpodStore.getState();
+          if (store.showVideo) toggleVideo();
           // Shuffle across the full library — drop any contextual queue.
-          if (useIpodStore.getState().librarySource === "appleMusic") {
-            useIpodStore.getState().setAppleMusicPlaybackQueue(null);
+          if (store.librarySource === "appleMusic") {
+            store.setAppleMusicPlaybackQueue(null);
           }
-          memoizedToggleShuffle();
+          useIpodStore.setState({
+            isShuffled: true,
+            playbackHistory: [],
+            historyPosition: -1,
+          });
+          if (store.librarySource === "appleMusic") {
+            store.appleMusicNextTrack();
+          } else {
+            store.nextTrack();
+          }
           setMenuMode(false);
         },
         showChevron: false,
@@ -2681,7 +2691,7 @@ export function useIpodLogic({
         showChevron: true,
       },
     ];
-  }, [registerActivity, toggleVideo, memoizedToggleShuffle, memoizedToggleBacklight, menuLocale, isOffline, showOfflineStatus, setIsPlaying, pushMenuChild]);
+  }, [registerActivity, toggleVideo, memoizedToggleBacklight, menuLocale, isOffline, showOfflineStatus, setIsPlaying, pushMenuChild]);
 
   const findMenuItemIndexByLabel = useCallback(
     (items: MenuItem[], label: string) =>

--- a/tests/test-ipod-apple-music.test.ts
+++ b/tests/test-ipod-apple-music.test.ts
@@ -638,6 +638,63 @@ describe("useIpodStore Apple Music slice", () => {
     expect(useIpodStore.getState().appleMusicCurrentSongId).toBe("am:q2");
   });
 
+  test("fresh shuffle flow advances YouTube playback without toggling shuffle off", () => {
+    useIpodStore.setState({
+      librarySource: "youtube",
+      tracks: [
+        { id: "yt:1", url: "youtube:1", title: "One" },
+        { id: "yt:2", url: "youtube:2", title: "Two" },
+        { id: "yt:3", url: "youtube:3", title: "Three" },
+      ],
+      currentSongId: "yt:1",
+      isShuffled: false,
+      playbackHistory: ["stale"],
+      historyPosition: 0,
+    });
+
+    useIpodStore.setState({
+      isShuffled: true,
+      playbackHistory: [],
+      historyPosition: -1,
+    });
+    useIpodStore.getState().nextTrack();
+
+    const state = useIpodStore.getState();
+    expect(state.isShuffled).toBe(true);
+    expect(state.currentSongId).not.toBe("yt:1");
+    expect(state.playbackHistory).toEqual(["yt:1"]);
+    expect(state.isPlaying).toBe(true);
+  });
+
+  test("fresh shuffle flow clears Apple Music queue and advances playback", () => {
+    useIpodStore.setState({
+      librarySource: "appleMusic",
+      appleMusicTracks: [
+        { id: "am:1", url: "applemusic:1", title: "One", source: "appleMusic" },
+        { id: "am:2", url: "applemusic:2", title: "Two", source: "appleMusic" },
+        { id: "am:3", url: "applemusic:3", title: "Three", source: "appleMusic" },
+      ],
+      appleMusicPlaybackQueue: ["am:2"],
+      appleMusicCurrentSongId: "am:2",
+      isShuffled: false,
+    });
+
+    useIpodStore.getState().setAppleMusicPlaybackQueue(null);
+    useIpodStore.setState({
+      isShuffled: true,
+      playbackHistory: [],
+      historyPosition: -1,
+    });
+    useIpodStore.getState().appleMusicNextTrack();
+
+    const state = useIpodStore.getState();
+    expect(state.appleMusicPlaybackQueue).toBeNull();
+    expect(state.isShuffled).toBe(true);
+    expect(state.appleMusicCurrentSongId).not.toBe("am:2");
+    expect(["am:1", "am:2", "am:3"]).toContain(state.appleMusicCurrentSongId);
+    expect(state.isPlaying).toBe(true);
+  });
+
   test("active iPod helpers resolve the Apple Music slice and live MusicKit context", () => {
     useIpodStore.setState({
       tracks: [{ id: "yt1", url: "youtube:1", title: "YouTube One" }],


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- change iPod root menu `Shuffle Songs` action to always start a new shuffle session instead of toggling shuffle state
- force shuffle on, clear shuffle playback history, and immediately advance playback to a random song
- clear Apple Music contextual playback queue before the fresh shuffle so random selection uses the full library
- add regression tests for fresh-shuffle behavior in both YouTube and Apple Music modes

## Testing
- `bun test tests/test-ipod-apple-music.test.ts`
- `bun test tests/test-ipod-menu-identity.test.ts tests/test-ipod-apple-music-playlist-menu.test.ts`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-98467ADD-CCD7-4983-B076-76BABBAFEC32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-98467ADD-CCD7-4983-B076-76BABBAFEC32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

