### PR TITLE
themes: add dark-mode support (macOS Aqua first)

### DIFF
--- a/.cursor/skills/ui-design-styling/SKILL.md
+++ b/.cursor/skills/ui-design-styling/SKILL.md
@@ -16,7 +16,9 @@ description: Design and style UI components for ryOS following the 4 OS themes (
 
 ## Essential Utilities
 
-Root attributes: `data-os-theme` (exact id), **`data-os-platform`** (`mac` | `windows`), and **`data-os-mac-chrome`** (`aqua` | `system7`, Mac only). Prefer Tailwind `os-mac:` / `os-windows:` / `os-mac-aqua:` / `os-mac-system7:` / `os-theme-*:` variants (see `docs/3.3.1-theme-architecture.md`). For Aqua global typography opt-out, use **`OS_NATIVE_CHROME_SKIP_CLASS`** from `@/lib/themeChrome`.
+Root attributes: `data-os-theme` (exact id), **`data-os-platform`** (`mac` | `windows`), **`data-os-mac-chrome`** (`aqua` | `system7`, Mac only), and **`data-os-color-scheme`** (`dark`, only when the theme supports it). Prefer Tailwind `os-mac:` / `os-windows:` / `os-mac-aqua:` / `os-mac-system7:` / `os-theme-*:` / `os-dark:` / `os-mac-aqua-dark:` variants (see `docs/3.3.1-theme-architecture.md`). For Aqua global typography opt-out, use **`OS_NATIVE_CHROME_SKIP_CLASS`** from `@/lib/themeChrome`.
+
+Dark mode today: only macOS Aqua (`macosx`) ships dark tokens; the toggle is hidden for other themes. Dark CSS lives in a single block at the bottom of `src/styles/themes.css`. Use the `os-dark:` Tailwind variant (or the `--os-color-*` tokens, which already swap automatically) instead of branching on `isDarkMode` whenever possible.
 
 ```tsx
 import { cn } from "@/lib/utils";

--- a/docs/3.3.1-theme-architecture.md
+++ b/docs/3.3.1-theme-architecture.md
@@ -4,10 +4,11 @@ This document describes how ryOS applies the four OS themes today and how to ext
 
 ## Flow
 
-1. **`useThemeStore`** persists `current` (`system7` | `macosx` | `xp` | `win98`) and calls **`applyRootThemeAttributes`** so `<html>` has:
+1. **`useThemeStore`** persists `current` (`system7` | `macosx` | `xp` | `win98`) plus a per-theme **`darkModeByTheme`** map (localStorage key **`ryos:theme:dark`**), and calls **`applyRootThemeAttributes`** so `<html>` has:
    - `data-os-theme` — exact theme id (drives token blocks and Tailwind `os-theme-*` variants).
    - `data-os-platform` — `mac` or `windows` (drives shared Luna + Classic rules and Tailwind `os-mac` / `os-windows` variants).
    - `data-os-mac-chrome` — `aqua` or `system7` when `data-os-platform="mac"`; attribute removed on Windows themes (see **`getOsMacChrome()`**).
+   - `data-os-color-scheme` — `dark` only when the active theme advertises **`metadata.supportsDarkMode = true`** AND the user has dark mode enabled for that theme. Removed (and `color-scheme` reset to `light`) otherwise. Drives the `:root[data-os-theme="…"][data-os-color-scheme="dark"] { … }` token blocks in `themes.css` and Tailwind `os-dark` / `os-mac-aqua-dark` / `os-theme-<id>-dark` variants.
 2. **`src/styles/themes.css`** defines CSS variables (`--os-*`) under `:root[data-os-theme="…"]`, plus structural rules (Aqua, brushed metal, innocuous third-party resets).
 3. **Legacy Windows** (`public/css/xp-custom.css`, `98-custom.css`) is loaded only for `xp` / `win98` by `ensureLegacyCss` in the theme store.
 4. **TypeScript** definitions in `src/themes/*.ts` hold canonical metadata (`ThemeMetadata`); use **`getThemeMetadata`**, **`isWindowsTheme`**, **`isMacTheme`**, **`isThemeWinXp`**, **`isThemeWin98`**, **`getOsPlatform`**, **`getOsMacChrome`**, or the **`useThemeFlags()`** hook instead of ad hoc `current === "xp"` chains in new code.
@@ -47,8 +48,18 @@ Typography tokens (`--os-typography-*`) live on the theme root. **`window-body`*
 - `os-mac-aqua:` → `:root[data-os-mac-chrome="aqua"] &` (Mac OS X only)
 - `os-mac-system7:` → `:root[data-os-mac-chrome="system7"] &`
 - `os-theme-system7:`, `os-theme-macosx:`, `os-theme-xp:`, `os-theme-win98:` → exact theme
+- `os-dark:` → `:root[data-os-color-scheme="dark"] &` (only attached when the active theme supports dark mode)
+- `os-mac-aqua-dark:` → `:root[data-os-mac-chrome="aqua"][data-os-color-scheme="dark"] &`
+- `os-theme-<id>-dark:` → `:root[data-os-theme="<id>"][data-os-color-scheme="dark"] &`
 
 Use these for small, theme-scoped utilities instead of growing `cn(...)` theme branches.
+
+## Dark mode
+
+- Today only `macosx` carries dark tokens (`metadata.supportsDarkMode: true`); the other themes opt out and the toggle is hidden in **Control Panels → Appearance**.
+- Dark CSS lives in a single block at the bottom of `src/styles/themes.css` so removing the attribute is a complete revert. Token overrides plus chrome that bakes in light hues (menubar gloss, brushed metal, drawer, traffic lights, Spotlight pinstripe) are all in that block — see comments there before adding new dark surfaces.
+- The user preference is per-theme (`darkModeByTheme`) so flipping back to a dark-supported theme remembers the previous choice. `useThemeFlags()` exposes `supportsDarkMode` and `isDarkMode` for component branches that genuinely need to differ from the token-driven path.
+- Settings sync ships the dark-mode map as part of the existing `theme` section payload (`{ theme, darkMode }` for new clients; old clients still get a plain string).
 
 ## HTML defaults
 

--- a/index.html
+++ b/index.html
@@ -211,8 +211,34 @@
     <script>
       (function () {
         try {
-          var theme = localStorage.getItem("ryos:theme") || localStorage.getItem("os_theme");
-          if (theme) document.documentElement.dataset.osTheme = theme;
+          var rawTheme = localStorage.getItem("ryos:theme") || localStorage.getItem("os_theme");
+          var allowed = { system7: 1, macosx: 1, xp: 1, win98: 1 };
+          var theme = rawTheme && allowed[rawTheme] ? rawTheme : "macosx";
+          var root = document.documentElement;
+          root.dataset.osTheme = theme;
+          // Mirror the platform/chrome attributes the React store will set later so first paint matches.
+          var isWindows = theme === "xp" || theme === "win98";
+          root.dataset.osPlatform = isWindows ? "windows" : "mac";
+          if (!isWindows) {
+            root.dataset.osMacChrome = theme === "macosx" ? "aqua" : "system7";
+          } else {
+            delete root.dataset.osMacChrome;
+          }
+          // Dark mode is per-theme, only honored when the theme advertises support.
+          // Today only macosx has dark tokens — see src/styles/themes.css.
+          var supportsDark = theme === "macosx";
+          if (supportsDark) {
+            try {
+              var rawDark = localStorage.getItem("ryos:theme:dark");
+              if (rawDark) {
+                var parsed = JSON.parse(rawDark);
+                if (parsed && parsed[theme] === true) {
+                  root.dataset.osColorScheme = "dark";
+                  root.style.colorScheme = "dark";
+                }
+              }
+            } catch (e) {}
+          }
         } catch (e) {}
       })();
     </script>

--- a/src/apps/admin/components/AdminAppComponent.tsx
+++ b/src/apps/admin/components/AdminAppComponent.tsx
@@ -627,16 +627,16 @@ export function AdminAppComponent({
                         <Table>
                           <TableHeader>
                             <TableRow className="text-[10px] border-none font-normal">
-                              <TableHead className="font-normal bg-gray-100/50 h-[28px]">
+                              <TableHead className="font-normal bg-neutral-100/50 h-[28px]">
                                 {t("apps.admin.tableHeaders.username")}
                               </TableHead>
-                              <TableHead className="font-normal bg-gray-100/50 h-[28px]">
+                              <TableHead className="font-normal bg-neutral-100/50 h-[28px]">
                                 {t("apps.admin.tableHeaders.status")}
                               </TableHead>
-                              <TableHead className="font-normal bg-gray-100/50 h-[28px] whitespace-nowrap">
+                              <TableHead className="font-normal bg-neutral-100/50 h-[28px] whitespace-nowrap">
                                 {t("apps.admin.tableHeaders.lastActive")}
                               </TableHead>
-                              <TableHead className="font-normal bg-gray-100/50 h-[28px] w-8"></TableHead>
+                              <TableHead className="font-normal bg-neutral-100/50 h-[28px] w-8"></TableHead>
                             </TableRow>
                           </TableHeader>
                           <TableBody className="text-[11px]">
@@ -644,7 +644,7 @@ export function AdminAppComponent({
                               <TableRow
                                 key={user.username}
                                 className={cn(
-                                  "border-none hover:bg-gray-100/50 transition-colors cursor-pointer odd:bg-gray-200/50 group",
+                                  "border-none hover:bg-neutral-100/50 transition-colors cursor-pointer odd:bg-neutral-200/50 group",
                                   user.banned && "bg-red-50/50 odd:bg-red-50/70"
                                 )}
                                 onClick={() =>
@@ -763,19 +763,19 @@ export function AdminAppComponent({
                       </div>
                     ) : (
                       <>
-                        <div className="w-full min-w-0 divide-y divide-gray-200">
+                        <div className="w-full min-w-0 divide-y divide-neutral-200">
                           {filteredSongs
                             .slice(0, visibleSongsCount)
                             .map((song) => (
                               <div
                                 key={song.youtubeId}
-                                className="flex w-full min-w-0 items-center gap-3 px-3 py-2 hover:bg-gray-100/50 transition-colors cursor-pointer group"
+                                className="flex w-full min-w-0 items-center gap-3 px-3 py-2 hover:bg-neutral-100/50 transition-colors cursor-pointer group"
                                 onClick={() =>
                                   setSelectedSongId(song.youtubeId)
                                 }
                               >
                                 {/* Cover Image */}
-                                <div className="size-10 flex-shrink-0 rounded overflow-hidden bg-gray-200">
+                                <div className="size-10 flex-shrink-0 rounded overflow-hidden bg-neutral-200">
                                   <img
                                     src={
                                       formatKugouImageUrl(song.cover, 100) ||
@@ -863,23 +863,23 @@ export function AdminAppComponent({
                     <Table>
                       <TableHeader>
                         <TableRow className="text-[10px] border-none font-normal">
-                          <TableHead className="font-normal bg-gray-100/50 h-[28px]">
+                          <TableHead className="font-normal bg-neutral-100/50 h-[28px]">
                             {t("apps.admin.tableHeaders.user")}
                           </TableHead>
-                          <TableHead className="font-normal bg-gray-100/50 h-[28px]">
+                          <TableHead className="font-normal bg-neutral-100/50 h-[28px]">
                             {t("apps.admin.tableHeaders.message")}
                           </TableHead>
-                          <TableHead className="font-normal bg-gray-100/50 h-[28px] whitespace-nowrap">
+                          <TableHead className="font-normal bg-neutral-100/50 h-[28px] whitespace-nowrap">
                             {t("apps.admin.tableHeaders.time")}
                           </TableHead>
-                          <TableHead className="font-normal bg-gray-100/50 h-[28px] w-8"></TableHead>
+                          <TableHead className="font-normal bg-neutral-100/50 h-[28px] w-8"></TableHead>
                         </TableRow>
                       </TableHeader>
                       <TableBody className="text-[11px]">
                         {roomMessages.map((message) => (
                           <TableRow
                             key={message.id}
-                            className="border-none hover:bg-gray-100/50 transition-colors cursor-default odd:bg-gray-200/50 group"
+                            className="border-none hover:bg-neutral-100/50 transition-colors cursor-default odd:bg-neutral-200/50 group"
                           >
                             <TableCell className="flex items-center gap-2 whitespace-nowrap">
                               <div className="size-4 rounded-full bg-neutral-200 flex items-center justify-center text-[9px] font-medium text-neutral-600">
@@ -919,7 +919,7 @@ export function AdminAppComponent({
             </ScrollArea>
 
             {/* Status Bar */}
-            <div className="os-status-bar os-status-bar-text flex items-center justify-between px-2 py-1 text-[10px] font-geneva-12 bg-gray-100 border-t border-gray-300">
+            <div className="os-status-bar os-status-bar-text flex items-center justify-between px-2 py-1 text-[10px] font-geneva-12 bg-neutral-100 border-t border-neutral-300">
               <span>
                 {activeSection === "dashboard"
                   ? t("apps.admin.sidebar.dashboard", "Dashboard")

--- a/src/apps/admin/components/CursorAgentsPanel.tsx
+++ b/src/apps/admin/components/CursorAgentsPanel.tsx
@@ -368,7 +368,7 @@ export function CursorAgentsPanel({
                   }
                 }}
                 className={cn(
-                  "border-none odd:bg-gray-200/50 cursor-pointer",
+                  "border-none odd:bg-neutral-200/50 cursor-pointer",
                   run.status === "running" && "bg-amber-50/60 odd:bg-amber-50/70",
                   selectedRunId === run.runId &&
                     "bg-blue-100/80 odd:bg-blue-100/80"

--- a/src/apps/admin/components/DashboardPanel.tsx
+++ b/src/apps/admin/components/DashboardPanel.tsx
@@ -170,7 +170,7 @@ function StatCard({
   trend?: { value: number; label: string };
 }) {
   return (
-    <div className="flex flex-col gap-1 p-3 bg-white rounded border border-gray-200">
+    <div className="flex flex-col gap-1 p-3 bg-white rounded border border-neutral-200">
       <span className="text-[10px] uppercase tracking-wide text-neutral-400">
         {label}
       </span>
@@ -248,14 +248,14 @@ function BreakdownList({
   }
   const max = items[0]?.count || 1;
   return (
-    <div className="divide-y divide-gray-100">
+    <div className="divide-y divide-neutral-100">
       {items.slice(0, 10).map((item) => (
         <div key={item.name} className="flex items-center gap-2 px-3 py-1.5">
           <span className={cn("text-[11px] text-neutral-600 flex-1 truncate", nameClassName)}>
             {renderName ? renderName(item.name) : item.name}
           </span>
           <div className="w-24 flex items-center gap-1.5">
-            <div className="flex-1 h-1.5 bg-gray-100 rounded-full overflow-hidden">
+            <div className="flex-1 h-1.5 bg-neutral-100 rounded-full overflow-hidden">
               <div
                 className={cn("h-full rounded-full", barClassName)}
                 style={{ width: `${(item.count / max) * 100}%` }}
@@ -469,7 +469,7 @@ export function DashboardPanel({ onRefresh }: DashboardPanelProps) {
 
         {showTimeSeriesCharts ? (
           <div className="grid grid-cols-1 md:grid-cols-2 gap-3 px-3 pb-3">
-            <div className="border border-gray-200 rounded p-3 bg-white">
+            <div className="border border-neutral-200 rounded p-3 bg-white">
               <div className="text-[10px] uppercase tracking-wide text-neutral-400 mb-2">
                 {t("apps.admin.dashboard.charts.apiCalls")}
               </div>
@@ -486,7 +486,7 @@ export function DashboardPanel({ onRefresh }: DashboardPanelProps) {
               </div>
             </div>
 
-            <div className="border border-gray-200 rounded p-3 bg-white">
+            <div className="border border-neutral-200 rounded p-3 bg-white">
               <div className="text-[10px] uppercase tracking-wide text-neutral-400 mb-2">
                 {t("apps.admin.dashboard.charts.uniqueVisitors")}
               </div>
@@ -508,7 +508,7 @@ export function DashboardPanel({ onRefresh }: DashboardPanelProps) {
               </div>
             </div>
 
-            <div className="border border-gray-200 rounded p-3 bg-white">
+            <div className="border border-neutral-200 rounded p-3 bg-white">
               <div className="text-[10px] uppercase tracking-wide text-neutral-400 mb-2">
                 {t("apps.admin.dashboard.charts.aiRequests")}
               </div>
@@ -525,7 +525,7 @@ export function DashboardPanel({ onRefresh }: DashboardPanelProps) {
               </div>
             </div>
 
-            <div className="border border-gray-200 rounded p-3 bg-white">
+            <div className="border border-neutral-200 rounded p-3 bg-white">
               <div className="text-[10px] uppercase tracking-wide text-neutral-400 mb-2">
                 {t("apps.admin.dashboard.charts.errors")}
               </div>
@@ -546,8 +546,8 @@ export function DashboardPanel({ onRefresh }: DashboardPanelProps) {
 
         {/* Top Endpoints */}
         <div className="px-3 pb-3">
-          <div className="border border-gray-200 rounded bg-white overflow-hidden">
-            <div className="px-3 py-2 border-b border-gray-100 bg-gray-50">
+          <div className="border border-neutral-200 rounded bg-white overflow-hidden">
+            <div className="px-3 py-2 border-b border-neutral-100 bg-neutral-50">
               <span className="text-[10px] uppercase tracking-wide text-neutral-400">
                 {t("apps.admin.dashboard.sections.topEndpoints")} ({rangeLabel})
               </span>
@@ -555,7 +555,7 @@ export function DashboardPanel({ onRefresh }: DashboardPanelProps) {
             {topEndpoints.length === 0 ? (
               <EmptyState message={t("apps.admin.dashboard.empty.noData")} />
             ) : (
-              <div className="divide-y divide-gray-100">
+              <div className="divide-y divide-neutral-100">
                 {topEndpoints.slice(0, 10).map((ep) => (
                   <div
                     key={ep.endpoint}
@@ -565,7 +565,7 @@ export function DashboardPanel({ onRefresh }: DashboardPanelProps) {
                       {ep.endpoint}
                     </span>
                     <div className="w-24 flex items-center gap-1.5">
-                      <div className="flex-1 h-1.5 bg-gray-100 rounded-full overflow-hidden">
+                      <div className="flex-1 h-1.5 bg-neutral-100 rounded-full overflow-hidden">
                         <div
                           className="h-full bg-indigo-400 rounded-full"
                           style={{
@@ -586,8 +586,8 @@ export function DashboardPanel({ onRefresh }: DashboardPanelProps) {
 
         {/* Status Codes & AI Usage */}
         <div className="grid grid-cols-1 md:grid-cols-2 gap-3 px-3 pb-3">
-          <div className="border border-gray-200 rounded bg-white overflow-hidden">
-            <div className="px-3 py-2 border-b border-gray-100 bg-gray-50">
+          <div className="border border-neutral-200 rounded bg-white overflow-hidden">
+            <div className="px-3 py-2 border-b border-neutral-100 bg-neutral-50">
               <span className="text-[10px] uppercase tracking-wide text-neutral-400">
                 {t("apps.admin.dashboard.sections.statusCodes")}
               </span>
@@ -595,7 +595,7 @@ export function DashboardPanel({ onRefresh }: DashboardPanelProps) {
             {statusCodes.length === 0 ? (
               <EmptyState message={t("apps.admin.dashboard.empty.noData")} />
             ) : (
-              <div className="divide-y divide-gray-100">
+              <div className="divide-y divide-neutral-100">
                 {statusCodes.map((sc) => (
                   <div
                     key={sc.status}
@@ -621,8 +621,8 @@ export function DashboardPanel({ onRefresh }: DashboardPanelProps) {
             )}
           </div>
 
-          <div className="border border-gray-200 rounded bg-white overflow-hidden">
-            <div className="px-3 py-2 border-b border-gray-100 bg-gray-50">
+          <div className="border border-neutral-200 rounded bg-white overflow-hidden">
+            <div className="px-3 py-2 border-b border-neutral-100 bg-neutral-50">
               <span className="text-[10px] uppercase tracking-wide text-neutral-400">
                 {t("apps.admin.dashboard.sections.aiUsageByUser")}
               </span>
@@ -630,7 +630,7 @@ export function DashboardPanel({ onRefresh }: DashboardPanelProps) {
             {aiByUser.length === 0 ? (
               <EmptyState message={t("apps.admin.dashboard.empty.noAiUsage")} />
             ) : (
-              <div className="divide-y divide-gray-100">
+              <div className="divide-y divide-neutral-100">
                 {aiByUser.map((entry) => {
                   const rl = aiRateLimits.find(
                     (r) => r.identifier === entry.username
@@ -677,7 +677,7 @@ export function DashboardPanel({ onRefresh }: DashboardPanelProps) {
 
         {showTimeSeriesCharts ? (
           <div className="px-3 pb-3">
-            <div className="border border-gray-200 rounded p-3 bg-white">
+            <div className="border border-neutral-200 rounded p-3 bg-white">
               <div className="text-[10px] uppercase tracking-wide text-neutral-400 mb-2">
                 {t("apps.admin.dashboard.charts.avgResponseTime")}
               </div>
@@ -786,9 +786,9 @@ export function DashboardPanel({ onRefresh }: DashboardPanelProps) {
               ).map((section) => (
                 <div
                   key={section.title}
-                  className="border border-gray-200 rounded bg-white overflow-hidden"
+                  className="border border-neutral-200 rounded bg-white overflow-hidden"
                 >
-                  <div className="px-3 py-2 border-b border-gray-100 bg-gray-50">
+                  <div className="px-3 py-2 border-b border-neutral-100 bg-neutral-50">
                     <span className="text-[10px] uppercase tracking-wide text-neutral-400">
                       {section.title}
                     </span>

--- a/src/apps/admin/components/DashboardServerCard.tsx
+++ b/src/apps/admin/components/DashboardServerCard.tsx
@@ -131,8 +131,8 @@ export function DashboardServerCard({ reloadKey = 0 }: { reloadKey?: number }) {
   const commitUrl = ryosGitHubCommitUrl(versionInfo);
 
   return (
-    <div className="overflow-hidden rounded border border-gray-200 bg-white">
-      <div className="border-b border-gray-100 bg-gray-50 px-3 py-2">
+    <div className="overflow-hidden rounded border border-neutral-200 bg-white">
+      <div className="border-b border-neutral-100 bg-neutral-50 px-3 py-2">
         <span className="text-[10px] uppercase tracking-wide text-neutral-400">
           {t("apps.admin.server.title", "Server")}
         </span>
@@ -153,7 +153,7 @@ export function DashboardServerCard({ reloadKey = 0 }: { reloadKey?: number }) {
           </Button>
         </div>
       ) : (
-        <div className="divide-y divide-gray-100">
+        <div className="divide-y divide-neutral-100">
           <InfoRow
             label={t("apps.admin.server.version", "Version")}
             value={versionInfo?.version ?? "—"}

--- a/src/apps/admin/components/SongDetailPanel.tsx
+++ b/src/apps/admin/components/SongDetailPanel.tsx
@@ -576,7 +576,7 @@ export const SongDetailPanel: React.FC<SongDetailPanelProps> = ({
   return (
     <div className="flex flex-col h-full font-geneva-12">
       {/* Header */}
-      <div className="flex items-center gap-2 px-3 py-2 border-b border-gray-200 bg-gray-50">
+      <div className="flex items-center gap-2 px-3 py-2 border-b border-neutral-200 bg-neutral-50">
         <Button
           variant="ghost"
           size="sm"

--- a/src/apps/admin/components/UserProfilePanel.tsx
+++ b/src/apps/admin/components/UserProfilePanel.tsx
@@ -528,7 +528,7 @@ export const UserProfilePanel: React.FC<UserProfilePanelProps> = ({
   return (
     <div className="flex flex-col h-full font-geneva-12">
       {/* Header */}
-      <div className="flex items-center gap-2 px-3 py-2 border-b border-gray-200 bg-gray-50">
+      <div className="flex items-center gap-2 px-3 py-2 border-b border-neutral-200 bg-neutral-50">
         <Button
           variant="ghost"
           size="sm"
@@ -763,13 +763,13 @@ export const UserProfilePanel: React.FC<UserProfilePanelProps> = ({
                         <Table className="table-fixed">
                           <TableHeader>
                             <TableRow className="text-[10px] border-none font-normal">
-                              <TableHead className="font-normal bg-gray-100/50 h-[24px] w-[30%]">
+                              <TableHead className="font-normal bg-neutral-100/50 h-[24px] w-[30%]">
                                 {t("apps.admin.profile.memoryKey")}
                               </TableHead>
-                              <TableHead className="font-normal bg-gray-100/50 h-[24px]">
+                              <TableHead className="font-normal bg-neutral-100/50 h-[24px]">
                                 {t("apps.admin.profile.memorySummary")}
                               </TableHead>
-                              <TableHead className="font-normal bg-gray-100/50 h-[24px] whitespace-nowrap w-[20%]">
+                              <TableHead className="font-normal bg-neutral-100/50 h-[24px] whitespace-nowrap w-[20%]">
                                 {t("apps.admin.tableHeaders.time")}
                               </TableHead>
                             </TableRow>
@@ -782,8 +782,8 @@ export const UserProfilePanel: React.FC<UserProfilePanelProps> = ({
                                   <TableRow
                                     onClick={() => toggleMemory(memory.key)}
                                     className={cn(
-                                      "border-none hover:bg-gray-100/50 transition-colors cursor-pointer",
-                                      index % 2 === 1 && "bg-gray-200/30"
+                                      "border-none hover:bg-neutral-100/50 transition-colors cursor-pointer",
+                                      index % 2 === 1 && "bg-neutral-200/30"
                                     )}
                                   >
                                     <TableCell>
@@ -807,7 +807,7 @@ export const UserProfilePanel: React.FC<UserProfilePanelProps> = ({
                                     <TableRow
                                       className={cn(
                                         "border-none",
-                                        index % 2 === 1 ? "bg-gray-200/30" : ""
+                                        index % 2 === 1 ? "bg-neutral-200/30" : ""
                                       )}
                                     >
                                       <TableCell colSpan={3} className="pt-0 pb-3">
@@ -859,7 +859,7 @@ export const UserProfilePanel: React.FC<UserProfilePanelProps> = ({
                                 <div key={note.date}>
                                   <button
                                     onClick={() => toggleDailyNote(note.date)}
-                                    className="flex items-center gap-1.5 w-full text-left text-[11px] hover:bg-gray-100/50 px-1 py-0.5 rounded transition-colors"
+                                    className="flex items-center gap-1.5 w-full text-left text-[11px] hover:bg-neutral-100/50 px-1 py-0.5 rounded transition-colors"
                                   >
                                     <CaretRight
                                       className={cn(
@@ -940,13 +940,13 @@ export const UserProfilePanel: React.FC<UserProfilePanelProps> = ({
                           <Table className="table-fixed">
                             <TableHeader>
                               <TableRow className="text-[10px] border-none font-normal">
-                                <TableHead className="font-normal bg-gray-100/50 h-[24px] w-[22%]">
+                                <TableHead className="font-normal bg-neutral-100/50 h-[24px] w-[22%]">
                                   {t("apps.admin.tableHeaders.status")}
                                 </TableHead>
-                                <TableHead className="font-normal bg-gray-100/50 h-[24px]">
+                                <TableHead className="font-normal bg-neutral-100/50 h-[24px]">
                                   {t("apps.admin.tableHeaders.message")}
                                 </TableHead>
-                                <TableHead className="font-normal bg-gray-100/50 h-[24px] whitespace-nowrap w-[25%]">
+                                <TableHead className="font-normal bg-neutral-100/50 h-[24px] whitespace-nowrap w-[25%]">
                                   {t("apps.admin.tableHeaders.time")}
                                 </TableHead>
                               </TableRow>
@@ -959,8 +959,8 @@ export const UserProfilePanel: React.FC<UserProfilePanelProps> = ({
                                     <TableRow
                                       onClick={() => toggleHeartbeat(hb.id)}
                                       className={cn(
-                                        "border-none hover:bg-gray-100/50 transition-colors cursor-pointer",
-                                        index % 2 === 1 && "bg-gray-200/30"
+                                        "border-none hover:bg-neutral-100/50 transition-colors cursor-pointer",
+                                        index % 2 === 1 && "bg-neutral-200/30"
                                       )}
                                     >
                                       <TableCell className="whitespace-nowrap">
@@ -993,7 +993,7 @@ export const UserProfilePanel: React.FC<UserProfilePanelProps> = ({
                                       <TableRow
                                         className={cn(
                                           "border-none",
-                                          index % 2 === 1 ? "bg-gray-200/30" : ""
+                                          index % 2 === 1 ? "bg-neutral-200/30" : ""
                                         )}
                                       >
                                         <TableCell colSpan={3} className="pt-0 pb-3">
@@ -1067,7 +1067,7 @@ export const UserProfilePanel: React.FC<UserProfilePanelProps> = ({
                       {profile?.rooms?.map((room) => (
                         <span
                           key={room.id}
-                          className="px-2 py-1 text-[10px] bg-gray-100 rounded"
+                          className="px-2 py-1 text-[10px] bg-neutral-100 rounded"
                         >
                           #{room.name}
                         </span>
@@ -1112,13 +1112,13 @@ export const UserProfilePanel: React.FC<UserProfilePanelProps> = ({
                     <Table className="table-fixed">
                       <TableHeader>
                         <TableRow className="text-[10px] border-none font-normal">
-                          <TableHead className="font-normal bg-gray-100/50 h-[24px] w-[25%]">
+                          <TableHead className="font-normal bg-neutral-100/50 h-[24px] w-[25%]">
                             {t("apps.admin.profile.room")}
                           </TableHead>
-                          <TableHead className="font-normal bg-gray-100/50 h-[24px]">
+                          <TableHead className="font-normal bg-neutral-100/50 h-[24px]">
                             {t("apps.admin.tableHeaders.message")}
                           </TableHead>
-                          <TableHead className="font-normal bg-gray-100/50 h-[24px] whitespace-nowrap w-[20%]">
+                          <TableHead className="font-normal bg-neutral-100/50 h-[24px] whitespace-nowrap w-[20%]">
                             {t("apps.admin.tableHeaders.time")}
                           </TableHead>
                         </TableRow>
@@ -1127,7 +1127,7 @@ export const UserProfilePanel: React.FC<UserProfilePanelProps> = ({
                         {messages.map((message) => (
                           <TableRow
                             key={message.id}
-                            className="border-none hover:bg-gray-100/50 transition-colors cursor-default odd:bg-gray-200/30"
+                            className="border-none hover:bg-neutral-100/50 transition-colors cursor-default odd:bg-neutral-200/30"
                           >
                             <TableCell>
                               <span className="text-neutral-500">#</span>

--- a/src/apps/applet-viewer/components/AppStore.tsx
+++ b/src/apps/applet-viewer/components/AppStore.tsx
@@ -614,7 +614,7 @@ export function AppStore({ theme, sharedAppletId, focusWindow }: AppStoreProps) 
         <div
           key={applet.id}
           className={`group flex items-center gap-3 px-3 py-2 rounded transition-colors ${
-            installed ? "cursor-pointer hover:bg-gray-100" : "cursor-pointer hover:bg-gray-100"
+            installed ? "cursor-pointer hover:bg-neutral-100" : "cursor-pointer hover:bg-neutral-100"
           }`}
           onClick={(e) => {
             // Don't trigger if clicking on buttons or admin actions
@@ -639,11 +639,11 @@ export function AppStore({ theme, sharedAppletId, focusWindow }: AppStoreProps) 
               </span>
             </div>
             {updateAvailable && applet.createdAt ? (
-              <div className="text-[10px] text-gray-500 font-geneva-12 truncate">
+              <div className="text-[10px] text-neutral-500 font-geneva-12 truncate">
                 {formatUpdateTime(applet.createdAt)}
               </div>
             ) : applet.createdBy ? (
-              <div className="text-[10px] text-gray-500 font-geneva-12 truncate">
+              <div className="text-[10px] text-neutral-500 font-geneva-12 truncate">
                 {applet.createdBy}
               </div>
             ) : null}
@@ -656,11 +656,11 @@ export function AppStore({ theme, sharedAppletId, focusWindow }: AppStoreProps) 
                     e.stopPropagation();
                     handleToggleFeatured(applet.id, applet.featured || false);
                   }}
-                  className="p-1 hover:bg-gray-200 rounded transition-all inline-flex md:hidden md:group-hover:inline-flex"
+                  className="p-1 hover:bg-neutral-200 rounded transition-all inline-flex md:hidden md:group-hover:inline-flex"
                   title={applet.featured ? t("apps.applet-viewer.labels.removeFromFeatured") : t("apps.applet-viewer.labels.addToFeatured")}
                 >
                   <Star
-                    className={`size-4 ${applet.featured ? "text-yellow-400" : "text-gray-400"}`}
+                    className={`size-4 ${applet.featured ? "text-yellow-400" : "text-neutral-400"}`}
                     weight={applet.featured ? "fill" : "bold"}
                   />
                 </button>
@@ -669,7 +669,7 @@ export function AppStore({ theme, sharedAppletId, focusWindow }: AppStoreProps) 
                     e.stopPropagation();
                     handleDelete(applet.id);
                   }}
-                  className="p-1 hover:bg-gray-200 rounded transition-all text-gray-400 inline-flex md:hidden md:group-hover:inline-flex"
+                  className="p-1 hover:bg-neutral-200 rounded transition-all text-neutral-400 inline-flex md:hidden md:group-hover:inline-flex"
                   title={t("apps.applet-viewer.labels.deleteApplet")}
                 >
                   <Trash className="size-4" weight="bold" />
@@ -741,8 +741,8 @@ export function AppStore({ theme, sharedAppletId, focusWindow }: AppStoreProps) 
                 : isMacChrome
                 ? ""
                 : isSystem7Chrome
-                ? "bg-gray-100 border-b border-black"
-                : "bg-gray-100 border-b border-gray-200"
+                ? "bg-neutral-100 border-b border-black"
+                : "bg-neutral-100 border-b border-neutral-200"
             }`}
             style={{
               background: isXpTheme ? "transparent" : undefined,
@@ -877,8 +877,8 @@ export function AppStore({ theme, sharedAppletId, focusWindow }: AppStoreProps) 
                   : isMacChrome
                   ? ""
                   : isSystem7Chrome
-                  ? "bg-gray-100 border-b border-black"
-                  : "bg-gray-100 border-b border-gray-200"
+                  ? "bg-neutral-100 border-b border-black"
+                  : "bg-neutral-100 border-b border-neutral-200"
               }`}
               style={{
                 background: isXpTheme ? "transparent" : undefined,

--- a/src/apps/applet-viewer/components/AppStoreFeed.tsx
+++ b/src/apps/applet-viewer/components/AppStoreFeed.tsx
@@ -567,13 +567,13 @@ const renderAppletCard = (applet: Applet, index: number) => {
             );
           })()
         ) : isLoadingContent ? (
-          <div className="flex items-center justify-center h-full bg-gray-50">
+          <div className="flex items-center justify-center h-full bg-neutral-50">
             <div className="text-center">
               <p className="text-sm text-neutral-600 font-geneva-12 shimmer-gray">{t("apps.applet-viewer.dialogs.loading")}</p>
             </div>
           </div>
         ) : (
-          <div className="h-full w-full bg-gray-50" />
+          <div className="h-full w-full bg-neutral-50" />
         )}
       </div>
 
@@ -585,8 +585,8 @@ const renderAppletCard = (applet: Applet, index: number) => {
             : isMacTheme
             ? ""
             : isSystem7Theme
-            ? "bg-gray-100 border-b border-black"
-            : "bg-gray-100 border-b border-gray-200"
+            ? "bg-neutral-100 border-b border-black"
+            : "bg-neutral-100 border-b border-neutral-200"
         }`}
         style={{
           flexWrap: "nowrap",
@@ -609,7 +609,7 @@ const renderAppletCard = (applet: Applet, index: number) => {
             {displayName}
           </div>
           {applet.createdBy && (
-            <div className="text-[10px] text-gray-500 font-geneva-12 truncate">
+            <div className="text-[10px] text-neutral-500 font-geneva-12 truncate">
               {applet.createdBy}
             </div>
           )}

--- a/src/apps/calendar/components/CalendarMenuBar.tsx
+++ b/src/apps/calendar/components/CalendarMenuBar.tsx
@@ -89,14 +89,14 @@ export function CalendarMenuBar({
           <MenubarItem
             onClick={undo}
             disabled={!canUndo}
-            className={`text-md h-6 px-3 ${!canUndo ? "text-gray-500" : ""}`}
+            className={`text-md h-6 px-3 ${!canUndo ? "text-neutral-500" : ""}`}
           >
             {t("common.menu.undo")}
           </MenubarItem>
           <MenubarItem
             onClick={redo}
             disabled={!canRedo}
-            className={`text-md h-6 px-3 ${!canRedo ? "text-gray-500" : ""}`}
+            className={`text-md h-6 px-3 ${!canRedo ? "text-neutral-500" : ""}`}
           >
             {t("common.menu.redo")}
           </MenubarItem>

--- a/src/apps/chats/components/ChatInput.tsx
+++ b/src/apps/chats/components/ChatInput.tsx
@@ -882,7 +882,7 @@ export const ChatInput = memo(function ChatInput({
                       onManualStop?.();
                     }
                   }}
-                  className={`text-xs size-9 p-0 flex items-center justify-center ${
+                  className={`chat-stop-btn text-xs size-9 p-0 flex items-center justify-center ${
                     isMacTheme ? "rounded-full" : "rounded-none"
                   } ${
                     isMacTheme
@@ -936,7 +936,7 @@ export const ChatInput = memo(function ChatInput({
                     </>
                   )}
                   <Square
-                    className={`size-4 ${
+                    className={`chat-stop-glyph size-4 ${
                       isMacTheme
                         ? "text-black/70 relative z-10"
                         : isXpTheme

--- a/src/apps/chats/components/ChatInput.tsx
+++ b/src/apps/chats/components/ChatInput.tsx
@@ -539,10 +539,10 @@ export const ChatInput = memo(function ChatInput({
                 <div
                   className={`relative overflow-hidden ${
                     isMacTheme 
-                      ? "chat-bubble macosx-link-preview rounded-[16px] bg-gray-100" 
+                      ? "chat-bubble macosx-link-preview rounded-[16px] bg-neutral-100" 
                       : isXpTheme 
                       ? "rounded-none border border-[#7f9db9] bg-white" 
-                      : "rounded-md border border-gray-200 bg-white"
+                      : "rounded-md border border-neutral-200 bg-white"
                   }`}
                 >
                   {/* Full bleed image for macOS */}
@@ -726,7 +726,7 @@ export const ChatInput = memo(function ChatInput({
                       ? t("apps.chats.status.typeMessage")
                       : t("apps.chats.status.typeOrPushSpace")
                   }
-                  className={`w-full border-1 border-gray-800 text-xs font-geneva-12 h-9 ${
+                  className={`w-full border-1 border-neutral-800 text-xs font-geneva-12 h-9 ${
                     isMacTheme ? "pl-3 pr-[88px] rounded-full" : "pl-2 pr-[88px]"
                   } backdrop-blur-lg bg-white/80 ${
                     isFocused ? "input--focused" : ""
@@ -752,7 +752,7 @@ export const ChatInput = memo(function ChatInput({
                       transition={{ duration: 0.15 }}
                       className="absolute top-0 left-0 size-full pointer-events-none flex items-center pl-3"
                     >
-                      <span className="text-gray-500 opacity-70 shimmer-gray text-[13px] font-geneva-12">
+                      <span className="text-neutral-500 opacity-70 shimmer-gray text-[13px] font-geneva-12">
                         {t("apps.chats.status.thinking")}
                         <AnimatedEllipsis />
                       </span>
@@ -889,7 +889,7 @@ export const ChatInput = memo(function ChatInput({
                       ? "relative overflow-hidden transition-transform hover:scale-105"
                       : isXpTheme
                       ? "text-black"
-                      : "bg-black hover:bg-black/80 text-white border-2 border-gray-800"
+                      : "bg-black hover:bg-black/80 text-white border-2 border-neutral-800"
                   }`}
                   style={
                     isMacTheme
@@ -964,7 +964,7 @@ export const ChatInput = memo(function ChatInput({
                       ? "relative overflow-hidden transition-transform hover:scale-105"
                       : isXpTheme
                       ? "text-black"
-                      : "bg-black hover:bg-black/80 text-white border-2 border-gray-800"
+                      : "bg-black hover:bg-black/80 text-white border-2 border-neutral-800"
                   }`}
                   style={
                     isMacTheme

--- a/src/apps/chats/components/ChatMessages.tsx
+++ b/src/apps/chats/components/ChatMessages.tsx
@@ -70,7 +70,7 @@ const userColors = [
 
 const getUserColorClass = (username?: string): string => {
   if (!username) {
-    return "bg-gray-100 text-black"; // Default or fallback color
+    return "bg-neutral-100 text-black"; // Default or fallback color
   }
   // Simple hash function
   const hash = username
@@ -630,7 +630,7 @@ const ChatMessageItem = memo(function ChatMessageItem(props: ChatMessageItemProp
       <div
         className={`${
           isMacOSTheme ? "text-[10px]" : "text-[16px]"
-        } chat-messages-meta text-gray-500 mb-0.5 font-['Geneva-9'] mb-[-2px] select-text flex items-center gap-2`}
+        } chat-messages-meta text-neutral-500 mb-0.5 font-['Geneva-9'] mb-[-2px] select-text flex items-center gap-2`}
       >
         {message.role === "user" && (
           <>
@@ -644,7 +644,7 @@ const ChatMessageItem = memo(function ChatMessageItem(props: ChatMessageItemProp
                         opacity: isHovered ? 1 : 0,
                         scale: 1,
                       }}
-                      className="size-3 text-gray-400 hover:text-red-600 transition-colors"
+                      className="size-3 text-neutral-400 hover:text-red-600 transition-colors"
                       onClick={() => onDeleteMessage(message)}
                       aria-label={t("apps.chats.ariaLabels.deleteMessage")}
                     >
@@ -663,7 +663,7 @@ const ChatMessageItem = memo(function ChatMessageItem(props: ChatMessageItemProp
                 opacity: isHovered ? 1 : 0,
                 scale: 1,
               }}
-              className="size-3 text-gray-400 hover:text-neutral-600 transition-colors"
+              className="size-3 text-neutral-400 hover:text-neutral-600 transition-colors"
               onClick={() => onCopyMessage(message)}
               aria-label={t("apps.chats.ariaLabels.copyMessage")}
             >
@@ -689,7 +689,7 @@ const ChatMessageItem = memo(function ChatMessageItem(props: ChatMessageItemProp
               ? t("apps.chats.messages.you")
               : t("apps.chats.messages.ryo"))}
         </span>{" "}
-        <span className="text-gray-400 select-text">
+        <span className="text-neutral-400 select-text">
           {message.metadata?.createdAt ? (
             (() => {
               const messageDate = new Date(message.metadata.createdAt);
@@ -720,7 +720,7 @@ const ChatMessageItem = memo(function ChatMessageItem(props: ChatMessageItemProp
                 opacity: isHovered ? 1 : 0,
                 scale: 1,
               }}
-              className="size-3 text-gray-400 hover:text-neutral-600 transition-colors"
+              className="size-3 text-neutral-400 hover:text-neutral-600 transition-colors"
               onClick={() => onCopyMessage(message)}
               aria-label={t("apps.chats.ariaLabels.copyMessage")}
             >
@@ -737,7 +737,7 @@ const ChatMessageItem = memo(function ChatMessageItem(props: ChatMessageItemProp
                   opacity: isHovered ? 1 : 0,
                   scale: 1,
                 }}
-                className="size-3 text-gray-400 hover:text-neutral-600 transition-colors"
+                className="size-3 text-neutral-400 hover:text-neutral-600 transition-colors"
                 onClick={() => {
                   if (playingMessageId === messageKey) {
                     stopSpeech();
@@ -801,7 +801,7 @@ const ChatMessageItem = memo(function ChatMessageItem(props: ChatMessageItemProp
                       opacity: isHovered ? 1 : 0,
                       scale: 1,
                     }}
-                    className="size-3 text-gray-400 hover:text-blue-600 transition-colors"
+                    className="size-3 text-neutral-400 hover:text-blue-600 transition-colors"
                     onClick={() => onSendMessage(message.username!)}
                     aria-label={t("apps.chats.ariaLabels.messageUser", {
                       username: message.username,
@@ -830,7 +830,7 @@ const ChatMessageItem = memo(function ChatMessageItem(props: ChatMessageItemProp
                     opacity: isHovered ? 1 : 0,
                     scale: 1,
                   }}
-                  className="size-3 text-gray-400 hover:text-red-600 transition-colors"
+                  className="size-3 text-neutral-400 hover:text-red-600 transition-colors"
                   onClick={() => onDeleteMessage(message)}
                   aria-label={t("apps.chats.ariaLabels.deleteMessage")}
                 >
@@ -1330,7 +1330,7 @@ function ChatMessagesContent({
         <motion.div
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
-          className="flex items-center gap-2 text-gray-500 font-['Geneva-9'] text-[16px] antialiased h-[12px]"
+          className="flex items-center gap-2 text-neutral-500 font-['Geneva-9'] text-[16px] antialiased h-[12px]"
         >
           <ChatCircle className="size-3" weight="bold" />
           <span>{t("apps.chats.status.startNewConversation")}</span>
@@ -1339,7 +1339,7 @@ function ChatMessagesContent({
               size="sm"
               variant="link"
               onClick={onClear}
-              className="m-0 p-0 text-[16px] h-0 text-gray-500 hover:text-gray-700"
+              className="m-0 p-0 text-[16px] h-0 text-neutral-500 hover:text-neutral-700"
             >
               {t("apps.chats.status.newChat")}
             </Button>
@@ -1438,7 +1438,7 @@ function ChatMessagesContent({
                 key="login-message"
                 initial={{ opacity: 0, y: 20 }}
                 animate={{ opacity: 1, y: 0 }}
-                className="flex items-center gap-2 text-gray-500 font-['Geneva-9'] text-[16px] antialiased h-[12px]"
+                className="flex items-center gap-2 text-neutral-500 font-['Geneva-9'] text-[16px] antialiased h-[12px]"
               >
                 <ChatCircle className="size-3" weight="bold" />
                 <span>{errorMessage}</span>

--- a/src/apps/chats/components/ChatRoomSidebar.tsx
+++ b/src/apps/chats/components/ChatRoomSidebar.tsx
@@ -133,7 +133,7 @@ export const ChatRoomSidebar = React.memo(function ChatRoomSidebar({
           onDeleteRoom && (
             <button
               className={cn(
-                "absolute right-1 top-1/2 transform -translate-y-1/2 transition-opacity text-gray-500 hover:text-red-500 p-1 rounded hover:bg-black/5",
+                "absolute right-1 top-1/2 transform -translate-y-1/2 transition-opacity text-neutral-500 hover:text-red-500 p-1 rounded hover:bg-black/5",
                 currentRoom?.id === room.id
                   ? "opacity-100"
                   : "opacity-0 group-hover:opacity-100"

--- a/src/apps/chats/components/CreateRoomDialog.tsx
+++ b/src/apps/chats/components/CreateRoomDialog.tsx
@@ -557,7 +557,7 @@ export function CreateRoomDialog({
               <div className="space-y-2">
                 <Label
                   htmlFor="room-name"
-                  className={cn("text-gray-700", themeFont)}
+                  className={cn("text-neutral-700", themeFont)}
                   style={themeFontStyle}
                 >
                   {t("apps.chats.dialogs.roomName")}
@@ -565,7 +565,7 @@ export function CreateRoomDialog({
                 <div className="relative">
                   <span
                     className={cn(
-                      "absolute left-3 top-1/2 -translate-y-1/2 text-gray-500 pointer-events-none",
+                      "absolute left-3 top-1/2 -translate-y-1/2 text-neutral-500 pointer-events-none",
                       themeFont
                     )}
                     style={themeFontStyle}
@@ -597,7 +597,7 @@ export function CreateRoomDialog({
               <div className="space-y-2">
                 <Label
                   htmlFor="irc-server"
-                  className={cn("text-gray-700", themeFont)}
+                  className={cn("text-neutral-700", themeFont)}
                   style={themeFontStyle}
                 >
                   Server
@@ -691,9 +691,9 @@ export function CreateRoomDialog({
 
               {/* Inline "add server" form */}
               {isAdmin && showAddServerForm && (
-                <div className="space-y-2 border border-gray-300 rounded p-3 bg-gray-50">
+                <div className="space-y-2 border border-neutral-300 rounded p-3 bg-neutral-50">
                   <Label
-                    className={cn("text-gray-700 font-semibold", themeFont)}
+                    className={cn("text-neutral-700 font-semibold", themeFont)}
                     style={themeFontStyle}
                   >
                     Add a server
@@ -788,7 +788,7 @@ export function CreateRoomDialog({
                 <div className="space-y-2">
                   {!isAdmin && (
                     <p
-                      className={cn("text-gray-500 text-[11px]", themeFont)}
+                      className={cn("text-neutral-500 text-[11px]", themeFont)}
                       style={themeFontStyle}
                     >
                       IRC servers are managed by an admin. Choose a channel
@@ -798,7 +798,7 @@ export function CreateRoomDialog({
                   <div className="flex items-center justify-between">
                     <Label
                       htmlFor="irc-channel-filter"
-                      className={cn("text-gray-700", themeFont)}
+                      className={cn("text-neutral-700", themeFont)}
                       style={themeFontStyle}
                     >
                       Channel
@@ -855,7 +855,7 @@ export function CreateRoomDialog({
                       {isLoadingChannels && (
                         <ActivityIndicator
                           size="sm"
-                          className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-500"
+                          className="absolute right-2 top-1/2 -translate-y-1/2 text-neutral-500"
                         />
                       )}
                     </div>
@@ -879,7 +879,7 @@ export function CreateRoomDialog({
                       {isLoadingChannels && (
                         <ActivityIndicator
                           size="sm"
-                          className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-500"
+                          className="absolute right-2 top-1/2 -translate-y-1/2 text-neutral-500"
                         />
                       )}
                     </div>
@@ -893,13 +893,13 @@ export function CreateRoomDialog({
                     </p>
                   )}
                   {!isLoadingChannels && !channelsError && (
-                    <ScrollArea className="h-[200px] w-full min-w-0 max-w-full overflow-x-hidden border border-gray-300 rounded-md bg-white">
+                    <ScrollArea className="h-[200px] w-full min-w-0 max-w-full overflow-x-hidden border border-neutral-300 rounded-md bg-white">
                       <div className="min-w-0 max-w-full overflow-x-hidden">
                         {filteredChannels.length === 0 &&
                           !(isAdmin && customChannel) && (
                             <p
                               className={cn(
-                                "text-gray-500 px-2 py-1.5",
+                                "text-neutral-500 px-2 py-1.5",
                                 themeFont
                               )}
                               style={themeFontStyle}
@@ -950,7 +950,7 @@ export function CreateRoomDialog({
                                   ? "cursor-not-allowed opacity-60"
                                   : "cursor-pointer",
                                 !isSelected &&
-                                  (index % 2 === 1 ? "bg-gray-100" : "bg-white"),
+                                  (index % 2 === 1 ? "bg-neutral-100" : "bg-white"),
                                 themeFont
                               )}
                               style={themeFontStyle}
@@ -979,7 +979,7 @@ export function CreateRoomDialog({
                   {channelsTruncated && (
                     <p
                       className={cn(
-                        "text-gray-500 min-w-0 max-w-full break-words",
+                        "text-neutral-500 min-w-0 max-w-full break-words",
                         themeFont
                       )}
                       style={themeFontStyle}
@@ -993,7 +993,7 @@ export function CreateRoomDialog({
                     (!isAdmin && selectedChannel)) && (
                     <p
                       className={cn(
-                        "text-gray-500 min-w-0 max-w-full break-words",
+                        "text-neutral-500 min-w-0 max-w-full break-words",
                         themeFont
                       )}
                       style={themeFontStyle}
@@ -1022,7 +1022,7 @@ export function CreateRoomDialog({
               <div className="space-y-2">
                 <Label
                   htmlFor="search-users"
-                  className={cn("text-gray-700", themeFont)}
+                  className={cn("text-neutral-700", themeFont)}
                   style={themeFontStyle}
                 >
                   {t("apps.chats.dialogs.addUsersToPrivateChat")}
@@ -1042,7 +1042,7 @@ export function CreateRoomDialog({
                   {isSearching && searchTerm.length >= 2 && (
                     <ActivityIndicator
                       size="sm"
-                      className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-500"
+                      className="absolute right-2 top-1/2 -translate-y-1/2 text-neutral-500"
                     />
                   )}
                 </div>
@@ -1055,7 +1055,7 @@ export function CreateRoomDialog({
                         key={username}
                         variant="secondary"
                         className={cn(
-                          "py-0.5 pl-2 pr-1 bg-gray-100 hover:bg-gray-200 border-gray-300",
+                          "py-0.5 pl-2 pr-1 bg-neutral-100 hover:bg-neutral-200 border-neutral-300",
                           isXpTheme
                             ? "font-['Pixelated_MS_Sans_Serif',Arial] text-[10px]"
                             : "font-geneva-12 text-[11px]"
@@ -1074,7 +1074,7 @@ export function CreateRoomDialog({
                         <button
                           type="button"
                           onClick={() => toggleUserSelection(username)}
-                          className="ml-1 hover:bg-gray-300 rounded-sm p-0.5"
+                          className="ml-1 hover:bg-neutral-300 rounded-sm p-0.5"
                           disabled={isLoading}
                         >
                           <X className="size-3" weight="bold" />
@@ -1087,13 +1087,13 @@ export function CreateRoomDialog({
 
               {/* Show results */}
               {!isSearching && searchTerm.length >= 2 && users.length > 0 && (
-                <div className="border border-gray-300 rounded max-h-[180px] overflow-y-auto bg-white">
+                <div className="border border-neutral-300 rounded max-h-[180px] overflow-y-auto bg-white">
                   <div className="p-1">
                     {users.map((user) => (
                       <label
                         key={user.username}
                         className={cn(
-                          "flex items-center p-2 hover:bg-gray-100 cursor-pointer rounded",
+                          "flex items-center p-2 hover:bg-neutral-100 cursor-pointer rounded",
                           themeFont
                         )}
                         style={themeFontStyle}

--- a/src/apps/control-panels/components/ControlPanelsAppComponent.tsx
+++ b/src/apps/control-panels/components/ControlPanelsAppComponent.tsx
@@ -281,6 +281,9 @@ export function ControlPanelsAppComponent({
     setShaderEffectEnabled,
     currentTheme,
     setTheme,
+    supportsDarkMode,
+    isDarkMode,
+    setDarkMode,
     currentLanguage,
     setLanguage,
     tabStyles,
@@ -515,6 +518,23 @@ export function ControlPanelsAppComponent({
                     </SelectContent>
                   </Select>
                 </div>
+
+                {/* Dark Mode toggle — only shown for themes that ship dark tokens */}
+                {supportsDarkMode && (
+                  <div className="flex items-center justify-between gap-2">
+                    <div className="flex flex-col gap-1">
+                      <Label>{t("apps.control-panels.darkMode")}</Label>
+                      <Label className="text-[11px] text-neutral-600 font-geneva-12">
+                        {t("apps.control-panels.darkModeDescription")}
+                      </Label>
+                    </div>
+                    <Switch
+                      checked={isDarkMode}
+                      onCheckedChange={(checked) => setDarkMode(checked)}
+                      className="data-[state=checked]:bg-[#000000]"
+                    />
+                  </div>
+                )}
 
                 {/* Language Selector */}
                 <div className="flex items-center justify-between gap-2">

--- a/src/apps/control-panels/components/ControlPanelsAppComponent.tsx
+++ b/src/apps/control-panels/components/ControlPanelsAppComponent.tsx
@@ -519,23 +519,6 @@ export function ControlPanelsAppComponent({
                   </Select>
                 </div>
 
-                {/* Dark Mode toggle — only shown for themes that ship dark tokens */}
-                {supportsDarkMode && (
-                  <div className="flex items-center justify-between gap-2">
-                    <div className="flex flex-col gap-1">
-                      <Label>{t("apps.control-panels.darkMode")}</Label>
-                      <Label className="text-[11px] text-neutral-600 font-geneva-12">
-                        {t("apps.control-panels.darkModeDescription")}
-                      </Label>
-                    </div>
-                    <Switch
-                      checked={isDarkMode}
-                      onCheckedChange={(checked) => setDarkMode(checked)}
-                      className="data-[state=checked]:bg-[#000000]"
-                    />
-                  </div>
-                )}
-
                 {/* Language Selector */}
                 <div className="flex items-center justify-between gap-2">
                   <div className="flex flex-col gap-1">
@@ -611,6 +594,23 @@ export function ControlPanelsAppComponent({
                 </div>
 
                 <ScreenSaverPicker />
+
+                {/* Dark Mode toggle — only shown for themes that ship dark tokens */}
+                {supportsDarkMode && (
+                  <div className="flex items-center justify-between gap-2">
+                    <div className="flex flex-col gap-1">
+                      <Label>{t("apps.control-panels.darkMode")}</Label>
+                      <Label className="text-[11px] text-neutral-600 font-geneva-12">
+                        {t("apps.control-panels.darkModeDescription")}
+                      </Label>
+                    </div>
+                    <Switch
+                      checked={isDarkMode}
+                      onCheckedChange={(checked) => setDarkMode(checked)}
+                      className="data-[state=checked]:bg-[#000000]"
+                    />
+                  </div>
+                )}
 
                 <div
                   className="border-t my-4"

--- a/src/apps/control-panels/components/ScreenSaverPicker.tsx
+++ b/src/apps/control-panels/components/ScreenSaverPicker.tsx
@@ -171,7 +171,7 @@ function ScreenSaverPreview({ type, onClick, disabled, label }: ScreenSaverPrevi
       {useEmbeddedPreview ? (
         <div
           ref={embeddedContainerRef}
-          className="relative overflow-hidden rounded border border-gray-600 group-hover:border-gray-400 transition-colors bg-black"
+          className="relative overflow-hidden rounded border border-neutral-600 group-hover:border-neutral-400 transition-colors bg-black"
           style={{ width: 120, height: 85 }}
         >
           {type === "starfield" && (
@@ -189,7 +189,7 @@ function ScreenSaverPreview({ type, onClick, disabled, label }: ScreenSaverPrevi
           ref={canvasRef}
           width={120}
           height={85}
-          className="rounded border border-gray-600 group-hover:border-gray-400 transition-colors"
+          className="rounded border border-neutral-600 group-hover:border-neutral-400 transition-colors"
           style={{ imageRendering: "pixelated" }}
         />
       )}
@@ -310,7 +310,7 @@ export function ScreenSaverPicker({ onPreview }: ScreenSaverPickerProps) {
                   step={1}
                   className="w-full"
                 />
-                <div className="flex justify-between text-[10px] text-gray-500 font-geneva-12 os-slider-labels">
+                <div className="flex justify-between text-[10px] text-neutral-500 font-geneva-12 os-slider-labels">
                   <span>1 {t("apps.control-panels.min")}</span>
                   <span>30 {t("apps.control-panels.min")}</span>
                 </div>

--- a/src/apps/control-panels/components/WallpaperPicker.tsx
+++ b/src/apps/control-panels/components/WallpaperPicker.tsx
@@ -87,7 +87,7 @@ function WallpaperItem({
         }}
       >
         {isLoading && (
-          <div className="absolute inset-0 bg-gray-700/30">
+          <div className="absolute inset-0 bg-neutral-700/30">
             <div
               className="absolute inset-0 bg-gradient-to-r from-transparent via-white/10 to-transparent opacity-50"
               style={{
@@ -526,7 +526,7 @@ export function WallpaperPicker({ onSelect }: WallpaperPickerProps) {
             <>
               <button
                 type="button"
-                className="preview-button w-full aspect-video !border-[2px] !border-dotted !border-gray-400 cursor-pointer hover:opacity-90 flex items-center justify-center"
+                className="preview-button w-full aspect-video !border-[2px] !border-dotted !border-neutral-400 cursor-pointer hover:opacity-90 flex items-center justify-center"
                 onClick={() => fileInputRef.current?.click()}
                 onKeyDown={(e) => {
                   if (e.key === "Enter" || e.key === " ") {
@@ -535,7 +535,7 @@ export function WallpaperPicker({ onSelect }: WallpaperPickerProps) {
                   }
                 }}
               >
-                <Plus className="size-5 text-gray-500" weight="bold" />
+                <Plus className="size-5 text-neutral-500" weight="bold" />
               </button>
               {customWallpaperRefs.length > 0 ? (
                 customWallpaperRefs.map((path) => (
@@ -573,7 +573,7 @@ export function WallpaperPicker({ onSelect }: WallpaperPickerProps) {
               />
             ))
           ) : (
-            <div className="col-span-4 text-center py-8 text-gray-500">
+            <div className="col-span-4 text-center py-8 text-neutral-500">
               {t("apps.control-panels.noWallpapers")}
             </div>
           )}

--- a/src/apps/control-panels/hooks/useControlPanelsLogic.ts
+++ b/src/apps/control-panels/hooks/useControlPanelsLogic.ts
@@ -283,8 +283,9 @@ export function useControlPanelsLogic({
   }));
 
   // Theme state
-  const { currentTheme } = useThemeFlags();
+  const { currentTheme, supportsDarkMode, isDarkMode } = useThemeFlags();
   const setTheme = useThemeStore((state) => state.setTheme);
+  const setDarkMode = useThemeStore((state) => state.setDarkMode);
 
   // Language state
   const currentLanguage = useLanguageStore((state) => state.current);
@@ -1603,6 +1604,9 @@ export function useControlPanelsLogic({
     setShaderEffectEnabled,
     currentTheme,
     setTheme,
+    supportsDarkMode,
+    isDarkMode,
+    setDarkMode,
     currentLanguage,
     setLanguage,
     tabStyles,

--- a/src/apps/finder/components/FileIcon.tsx
+++ b/src/apps/finder/components/FileIcon.tsx
@@ -346,6 +346,12 @@ export function FileIcon({
               ? "bg-white text-black"
               : (isXpTheme || isMacOSXTheme) && !isFinderContext
               ? "bg-transparent text-white"
+              : isMacOSXTheme && isFinderContext
+              ? // Finder file labels (Mac OS X): transparent so the label
+                // blends with the file pane background. This also lets dark
+                // mode stay clean — text inherits the window-body color
+                // cascade instead of stamping a white pill on every icon.
+                "bg-transparent text-os-text-primary"
               : "bg-white text-black"
           }`}
           data-selected={isSelected ? "true" : undefined}

--- a/src/apps/finder/components/FileList.tsx
+++ b/src/apps/finder/components/FileList.tsx
@@ -172,7 +172,7 @@ const ListRowItem = memo(function ListRowItem({
       className={`border-none cursor-default ${
         isSelected || dropTargetPath === file.path
           ? ""
-          : "odd:bg-gray-200/50 hover:bg-gray-100/50 transition-colors"
+          : "odd:bg-neutral-200/50 hover:bg-neutral-100/50 transition-colors"
       }`}
       data-selected={isSelected || dropTargetPath === file.path ? "true" : undefined}
       onClick={handleClick}
@@ -892,16 +892,16 @@ export function FileList({
         <Table key={listTableKey} className="min-w-[480px]">
           <TableHeader>
             <TableRow className={`${listHeaderTextClass} border-none font-normal`}>
-              <TableHead className="font-normal bg-gray-100/50 h-[28px]">
+              <TableHead className="font-normal bg-neutral-100/50 h-[28px]">
                 {t("apps.finder.tableHeaders.name")}
               </TableHead>
-              <TableHead className="font-normal bg-gray-100/50 h-[28px]">
+              <TableHead className="font-normal bg-neutral-100/50 h-[28px]">
                 {t("apps.finder.tableHeaders.type")}
               </TableHead>
-              <TableHead className="font-normal bg-gray-100/50 h-[28px] whitespace-nowrap">
+              <TableHead className="font-normal bg-neutral-100/50 h-[28px] whitespace-nowrap">
                 {t("apps.finder.tableHeaders.size")}
               </TableHead>
-              <TableHead className="font-normal bg-gray-100/50 h-[28px] whitespace-nowrap">
+              <TableHead className="font-normal bg-neutral-100/50 h-[28px] whitespace-nowrap">
                 {t("apps.finder.tableHeaders.modified")}
               </TableHead>
             </TableRow>

--- a/src/apps/finder/components/FinderAppComponent.tsx
+++ b/src/apps/finder/components/FinderAppComponent.tsx
@@ -390,8 +390,8 @@ export function FinderAppComponent({
                 isXpTheme
                   ? "border-b border-[#919b9c]"
                   : currentTheme === "system7"
-                  ? "bg-gray-100 border-b border-black"
-                  : "bg-gray-100 border-b border-gray-300"
+                  ? "bg-neutral-100 border-b border-black"
+                  : "bg-neutral-100 border-b border-neutral-300"
               )}
               style={{
                 background: isXpTheme ? "transparent" : undefined,
@@ -548,7 +548,7 @@ export function FinderAppComponent({
           ) : (
             <>
               {isAirDropView ? (
-                <div className="flex-1 bg-gradient-to-b from-gray-100 to-gray-200">
+                <div className="flex-1 bg-gradient-to-b from-neutral-100 to-neutral-200">
                   <AirDropView
                     onSendFile={handleAirDropSendFile}
                     onRequestLogin={promptVerifyToken}
@@ -591,7 +591,7 @@ export function FinderAppComponent({
                   )}
                 </div>
               )}
-              <div className="os-status-bar os-status-bar-text flex items-center justify-between px-2 py-1 text-[10px] font-geneva-12 bg-gray-100 border-t border-gray-300">
+              <div className="os-status-bar os-status-bar-text flex items-center justify-between px-2 py-1 text-[10px] font-geneva-12 bg-neutral-100 border-t border-neutral-300">
                 <span>
                   {sortedFiles.length}{" "}
                   {sortedFiles.length !== 1

--- a/src/apps/finder/components/FinderMenuBar.tsx
+++ b/src/apps/finder/components/FinderMenuBar.tsx
@@ -189,14 +189,14 @@ export function FinderMenuBar({
           <MenubarItem
             onClick={undo}
             disabled={!canUndo}
-            className={`text-md h-6 px-3 ${!canUndo ? "text-gray-500" : ""}`}
+            className={`text-md h-6 px-3 ${!canUndo ? "text-neutral-500" : ""}`}
           >
             {t("common.menu.undo")}
           </MenubarItem>
           <MenubarItem
             onClick={redo}
             disabled={!canRedo}
-            className={`text-md h-6 px-3 ${!canRedo ? "text-gray-500" : ""}`}
+            className={`text-md h-6 px-3 ${!canRedo ? "text-neutral-500" : ""}`}
           >
             {t("common.menu.redo")}
           </MenubarItem>

--- a/src/apps/infinite-mac/components/InfiniteMacAppComponent.tsx
+++ b/src/apps/infinite-mac/components/InfiniteMacAppComponent.tsx
@@ -154,7 +154,7 @@ export function InfiniteMacAppComponent({
           ? "text-transparent cursor-default"
           : isDarkTitlebar
             ? "text-white/80 hover:text-white cursor-pointer"
-            : "text-gray-600 hover:text-gray-800 cursor-pointer"
+            : "text-neutral-600 hover:text-neutral-800 cursor-pointer"
       }`}
       style={{
         filter: selectedPreset && isDarkTitlebar
@@ -221,7 +221,7 @@ export function InfiniteMacAppComponent({
                     <div className="font-apple-garamond text-white text-lg">
                       {t("apps.infinite-mac.title")}
                     </div>
-                    <div className="font-geneva-12 text-gray-400 text-[12px]">
+                    <div className="font-geneva-12 text-neutral-400 text-[12px]">
                       {t("apps.infinite-mac.systemsAvailable", {
                         count: MAC_PRESETS.length,
                       })}

--- a/src/apps/infinite-pc/components/InfinitePcAppComponent.tsx
+++ b/src/apps/infinite-pc/components/InfinitePcAppComponent.tsx
@@ -293,7 +293,7 @@ export function InfinitePcAppComponent({
           ? "text-transparent cursor-default"
           : isDarkTitlebar
             ? "text-white/80 hover:text-white cursor-pointer"
-            : "text-gray-600 hover:text-gray-800 cursor-pointer"
+            : "text-neutral-600 hover:text-neutral-800 cursor-pointer"
       }`}
       style={{
         filter: inSession && isDarkTitlebar

--- a/src/apps/infinite-pc/components/InfinitePcBrowseHeader.tsx
+++ b/src/apps/infinite-pc/components/InfinitePcBrowseHeader.tsx
@@ -23,7 +23,7 @@ export function InfinitePcBrowseHeader({
     `font-apple-garamond !text-[18px] leading-tight transition-colors border-0 bg-transparent p-0 cursor-pointer ${
       active
         ? "text-white"
-        : "text-gray-500 hover:text-gray-300"
+        : "text-neutral-500 hover:text-neutral-300"
     }`;
 
   return (
@@ -38,7 +38,7 @@ export function InfinitePcBrowseHeader({
             {t("apps.pc.tabs.os")}
           </button>
           <span
-            className="font-apple-garamond !text-[18px] leading-tight text-gray-600 select-none"
+            className="font-apple-garamond !text-[18px] leading-tight text-neutral-600 select-none"
             aria-hidden
           >
             |
@@ -51,7 +51,7 @@ export function InfinitePcBrowseHeader({
             {t("apps.pc.tabs.games")}
           </button>
         </div>
-        <div className="font-geneva-12 text-gray-400 text-[12px] shrink-0 text-right">
+        <div className="font-geneva-12 text-neutral-400 text-[12px] shrink-0 text-right">
           {tab === "os"
             ? t("apps.pc.systemsAvailable", { count: osCount })
             : gamesReady

--- a/src/apps/infinite-pc/components/InfinitePcMenuBar.tsx
+++ b/src/apps/infinite-pc/components/InfinitePcMenuBar.tsx
@@ -98,7 +98,7 @@ export function InfinitePcMenuBar({
                     key={game.id}
                     onClick={() => onLoadGame(game)}
                     className={`text-md h-6 px-3 ${
-                      selectedGame.id === game.id ? "bg-gray-100" : ""
+                      selectedGame.id === game.id ? "bg-neutral-100" : ""
                     }`}
                   >
                     {game.name}
@@ -152,7 +152,7 @@ export function InfinitePcMenuBar({
                     key={sensitivity}
                     onClick={() => onSetMouseSensitivity?.(sensitivity)}
                     className={`text-md h-6 px-3 ${
-                      mouseSensitivity === sensitivity ? "bg-gray-100" : ""
+                      mouseSensitivity === sensitivity ? "bg-neutral-100" : ""
                     }`}
                   >
                     {sensitivity}x
@@ -171,7 +171,7 @@ export function InfinitePcMenuBar({
                     key={aspect}
                     onClick={() => onSetRenderAspect?.(aspect)}
                     className={`text-md h-6 px-3 ${
-                      currentRenderAspect === aspect ? "bg-gray-100" : ""
+                      currentRenderAspect === aspect ? "bg-neutral-100" : ""
                     }`}
                   >
                     {t(`apps.pc.aspectRatios.${aspect}`, { defaultValue: aspect })}

--- a/src/apps/internet-explorer/components/InternetExplorerAppComponent.tsx
+++ b/src/apps/internet-explorer/components/InternetExplorerAppComponent.tsx
@@ -74,7 +74,7 @@ function ErrorPage({
       <p className="mb-3">{primaryMessage}</p>
       {secondaryMessage && <p className="mb-3">{secondaryMessage}</p>}
 
-      <div className="h-px bg-gray-300 my-5"></div>
+      <div className="h-px bg-neutral-300 my-5"></div>
 
       <p className="mb-3">Please try the following:</p>
 
@@ -163,12 +163,12 @@ function ErrorPage({
       </ul>
 
       {details && !footerText.includes("HTTP") && (
-        <div className="p-3 bg-gray-100 border border-gray-300 rounded mb-5">
+        <div className="p-3 bg-neutral-100 border border-neutral-300 rounded mb-5">
           {details}
         </div>
       )}
 
-      <div className="mt-10 text-gray-700 whitespace-pre-wrap">
+      <div className="mt-10 text-neutral-700 whitespace-pre-wrap">
         {footerText}
       </div>
     </div>
@@ -389,8 +389,8 @@ export function InternetExplorerAppComponent({
                   : currentTheme === "macosx"
                   ? "bg-transparent"
                   : currentTheme === "system7"
-                  ? "bg-gray-100 border-b border-black"
-                  : "bg-gray-100 border-b border-gray-300"
+                  ? "bg-neutral-100 border-b border-black"
+                  : "bg-neutral-100 border-b border-neutral-300"
               }`}
               style={{
                 borderBottom:
@@ -598,7 +598,7 @@ export function InternetExplorerAppComponent({
                             return (
                               <div
                                 key={suggestionKey}
-                                className="px-2 py-1.5 hover:bg-gray-100 focus:bg-gray-200 cursor-pointer flex items-center gap-2 text-sm outline-none"
+                                className="px-2 py-1.5 hover:bg-neutral-100 focus:bg-neutral-200 cursor-pointer flex items-center gap-2 text-sm outline-none"
                                 onClick={() => {
                                   setSelectedSuggestionIndex(index);
                                   if (suggestion.type === "search") {
@@ -692,18 +692,18 @@ export function InternetExplorerAppComponent({
                                     {suggestion.title}
                                     {suggestion.year &&
                                       suggestion.year !== "current" && (
-                                        <span className="font-normal text-gray-500 ml-1">
+                                        <span className="font-normal text-neutral-500 ml-1">
                                           ({suggestion.year})
                                         </span>
                                       )}
                                   </div>
-                                  <div className="font-geneva-12 text-[10px] text-gray-500 truncate">
+                                  <div className="font-geneva-12 text-[10px] text-neutral-500 truncate">
                                     {suggestion.type === "search"
                                       ? "bing.com"
                                       : stripProtocol(suggestion.url)}
                                   </div>
                                 </div>
-                                <div className="font-geneva-12 text-[10px] ml-2 text-gray-500 whitespace-nowrap hidden sm:block">
+                                <div className="font-geneva-12 text-[10px] ml-2 text-neutral-500 whitespace-nowrap hidden sm:block">
                                   {suggestion.type === "favorite" && "Favorite"}
                                   {suggestion.type === "history" && "History"}
                                   {suggestion.type === "search" && "Search"}
@@ -775,14 +775,14 @@ export function InternetExplorerAppComponent({
                         <SelectItem
                           key={y}
                           value={y}
-                          className="text-md h-6 px-3 active:bg-gray-900 active:text-white text-blue-600"
+                          className="text-md h-6 px-3 active:bg-neutral-900 active:text-white text-blue-600"
                         >
                           {y}
                         </SelectItem>
                       ))}
                       <SelectItem
                         value="current"
-                        className="text-md h-6 px-3 active:bg-gray-900 active:text-white"
+                        className="text-md h-6 px-3 active:bg-neutral-900 active:text-white"
                       >
                         {t("apps.internet-explorer.now")}
                       </SelectItem>
@@ -790,7 +790,7 @@ export function InternetExplorerAppComponent({
                         <SelectItem
                           key={y}
                           value={y}
-                          className={`text-md h-6 px-3 active:bg-gray-900 active:text-white ${
+                          className={`text-md h-6 px-3 active:bg-neutral-900 active:text-white ${
                             parseInt(y) <= 1995 ? "text-blue-600" : ""
                           }`}
                         >
@@ -824,7 +824,7 @@ export function InternetExplorerAppComponent({
                               <Button
                                 variant="ghost"
                                 size="sm"
-                                className="whitespace-nowrap hover:bg-gray-200 font-geneva-12 text-[10px] gap-1 px-1 mr-1 w-content min-w-[60px] max-w-[120px] flex-shrink-0"
+                                className="whitespace-nowrap hover:bg-neutral-200 font-geneva-12 text-[10px] gap-1 px-1 mr-1 w-content min-w-[60px] max-w-[120px] flex-shrink-0"
                               >
                                 <ThemedIcon
                                   name="directory.png"
@@ -851,7 +851,7 @@ export function InternetExplorerAppComponent({
                                       child.year
                                     )
                                   }
-                                  className="text-md h-6 px-3 active:bg-gray-900 active:text-white flex items-center gap-2"
+                                  className="text-md h-6 px-3 active:bg-neutral-900 active:text-white flex items-center gap-2"
                                 >
                                   {child.favicon && !isOffline ? (
                                     <img
@@ -872,7 +872,7 @@ export function InternetExplorerAppComponent({
                                   )}
                                   {child.title}
                                   {child.year && child.year !== "current" && (
-                                    <span className="text-xs text-gray-500 ml-1">
+                                    <span className="text-xs text-neutral-500 ml-1">
                                       ({child.year})
                                     </span>
                                   )}
@@ -888,7 +888,7 @@ export function InternetExplorerAppComponent({
                             key={favoriteKey}
                             variant="ghost"
                             size="sm"
-                            className="whitespace-nowrap hover:bg-gray-200 font-geneva-12 text-[10px] gap-1 px-1 mr-1 w-content min-w-[60px] max-w-[120px] flex-shrink-0"
+                            className="whitespace-nowrap hover:bg-neutral-200 font-geneva-12 text-[10px] gap-1 px-1 mr-1 w-content min-w-[60px] max-w-[120px] flex-shrink-0"
                             onClick={(e) => {
                               const normalizedFavUrl = normalizeUrlForHistory(
                                 favorite.url!
@@ -932,7 +932,7 @@ export function InternetExplorerAppComponent({
                   </div>
                 </div>
                 {favorites.length > 0 && hasMoreToScroll && (
-                  <div className="absolute right-0 top-0 bottom-0 w-8 bg-gradient-to-l from-gray-100 to-transparent pointer-events-none" />
+                  <div className="absolute right-0 top-0 bottom-0 w-8 bg-gradient-to-l from-neutral-100 to-transparent pointer-events-none" />
                 )}
               </div>
             </div>
@@ -1035,10 +1035,10 @@ export function InternetExplorerAppComponent({
                   animate={{ opacity: 1, y: 0 }}
                   exit={{ opacity: 0, y: 20 }}
                   transition={{ duration: 0.15 }}
-                  className={`os-status-bar os-status-bar-text font-geneva-12 absolute bottom-0 left-0 right-0 bg-gray-100 text-[10px] px-2 py-1 flex items-center z-50 ${
+                  className={`os-status-bar os-status-bar-text font-geneva-12 absolute bottom-0 left-0 right-0 bg-neutral-100 text-[10px] px-2 py-1 flex items-center z-50 ${
                     currentTheme === "system7"
                       ? "border-t border-black"
-                      : "border-t border-gray-300"
+                      : "border-t border-neutral-300"
                   }`}
                 >
                   <div className="flex-1 truncate">

--- a/src/apps/internet-explorer/components/InternetExplorerMenuBar.tsx
+++ b/src/apps/internet-explorer/components/InternetExplorerMenuBar.tsx
@@ -109,7 +109,7 @@ const renderFavoriteItem = (
         )}
         {favorite.title}
         {favorite.year && favorite.year !== "current" && (
-          <span className="text-xs text-gray-500 ml-1">({favorite.year})</span>
+          <span className="text-xs text-neutral-500 ml-1">({favorite.year})</span>
         )}
       </MenubarItem>
     );
@@ -255,7 +255,7 @@ export function InternetExplorerMenuBar({
             disabled={!isLoading}
             className={
               !isLoading
-                ? "text-gray-400 text-md h-6 px-3"
+                ? "text-neutral-400 text-md h-6 px-3"
                 : "text-md h-6 px-3"
             }
           >
@@ -681,7 +681,7 @@ export function InternetExplorerMenuBar({
             disabled={!canGoBack}
             className={
               !canGoBack
-                ? "text-gray-400 text-md h-6 px-3"
+                ? "text-neutral-400 text-md h-6 px-3"
                 : "text-md h-6 px-3"
             }
           >
@@ -692,7 +692,7 @@ export function InternetExplorerMenuBar({
             disabled={!canGoForward}
             className={
               !canGoForward
-                ? "text-gray-400 text-md h-6 px-3"
+                ? "text-neutral-400 text-md h-6 px-3"
                 : "text-md h-6 px-3"
             }
           >
@@ -729,7 +729,7 @@ export function InternetExplorerMenuBar({
                   <span className="truncate">
                     {entry.title}
                     {entry.year && entry.year !== "current" && (
-                      <span className="text-xs text-gray-500 ml-1">
+                      <span className="text-xs text-neutral-500 ml-1">
                         ({entry.year})
                       </span>
                     )}

--- a/src/apps/internet-explorer/hooks/useInternetExplorerLogic.ts
+++ b/src/apps/internet-explorer/hooks/useInternetExplorerLogic.ts
@@ -1910,7 +1910,7 @@ export function useInternetExplorerLogic({
         debugMode &&
           React.createElement(
             "span",
-            { className: "text-gray-500" },
+            { className: "text-neutral-500" },
             t("apps.internet-explorer.fetch")
           ),
         React.createElement(
@@ -1931,7 +1931,7 @@ export function useInternetExplorerLogic({
           debugMode &&
             React.createElement(
               "span",
-              { className: "text-gray-500" },
+              { className: "text-neutral-500" },
               modelInfo,
               language !== "auto" && ` ${languageDisplayName}`,
               location !== "auto" && ` ${locationDisplayName}`
@@ -1953,7 +1953,7 @@ export function useInternetExplorerLogic({
             debugMode &&
               React.createElement(
                 "span",
-                { className: "text-gray-500" },
+                { className: "text-neutral-500" },
                 modelInfo,
                 language !== "auto" && ` ${languageDisplayName}`,
                 location !== "auto" && ` ${locationDisplayName}`

--- a/src/apps/ipod/components/CoverFlow.tsx
+++ b/src/apps/ipod/components/CoverFlow.tsx
@@ -625,7 +625,7 @@ function CoverImage({
           }}
         />
         {!showSleeveBitmap ? (
-          <div className="w-full h-full flex items-center justify-center bg-gradient-to-br from-gray-700 to-gray-900">
+          <div className="w-full h-full flex items-center justify-center bg-gradient-to-br from-neutral-700 to-neutral-900">
             <svg
               xmlns="http://www.w3.org/2000/svg"
               width="32"

--- a/src/apps/ipod/components/IpodAppComponent.tsx
+++ b/src/apps/ipod/components/IpodAppComponent.tsx
@@ -337,7 +337,7 @@ export function IpodAppComponent({
       >
         <div
           ref={containerRef}
-          className="ipod-force-font flex flex-col items-center justify-center w-full h-full bg-gradient-to-b from-gray-100/20 to-gray-300/20 backdrop-blur-lg p-4 select-none"
+          className="ipod-force-font flex flex-col items-center justify-center w-full h-full bg-gradient-to-b from-neutral-100/20 to-neutral-300/20 backdrop-blur-lg p-4 select-none"
           style={{ position: "relative", overflow: "hidden", contain: "layout style paint" }}
         >
           <div

--- a/src/apps/ipod/components/IpodWheel.tsx
+++ b/src/apps/ipod/components/IpodWheel.tsx
@@ -375,7 +375,7 @@ export function IpodWheel({
       className={cn(
         "mt-6 relative w-[180px] h-[180px] rounded-full flex items-center justify-center select-none no-select-gesture",
         theme === "classic"
-          ? "bg-gray-300/60"
+          ? "bg-neutral-300/60"
           : theme === "u2"
           ? "bg-red-700/60"
           : "bg-neutral-800/50"

--- a/src/apps/ipod/hooks/useIpodLogic.ts
+++ b/src/apps/ipod/hooks/useIpodLogic.ts
@@ -26,6 +26,7 @@ import {
 } from "./useAppleMusicLibrary";
 import { useMusicKit } from "@/hooks/useMusicKit";
 import { clearAppleMusicLibrary } from "@/utils/appleMusicLibraryCache";
+import { useThemeStore } from "@/stores/useThemeStore";
 import {
   useIpodStore,
   Track,
@@ -157,7 +158,7 @@ export function useIpodLogic({
   } = useIpodActiveLibrary();
 
   const {
-    theme,
+    theme: persistedTheme,
     backlightTimeout,
     lcdFilterOn,
     displayMode,
@@ -236,6 +237,16 @@ export function useIpodLogic({
     setLyricOffset: s.setLyricOffset,
     setCurrentFuriganaMap: s.setCurrentFuriganaMap,
   }));
+
+  // System dark-mode override for the iPod skin: when the OS is in dark mode
+  // and the user's persisted iPod theme is "classic" (the only one with a
+  // light shell), render as "black" so the iPod fits the rest of the dark
+  // chrome. The persisted preference itself isn't mutated — flip dark mode off
+  // and the classic skin returns. Menu radio checks read the persisted value
+  // directly so the user always sees what they actually picked.
+  const isSystemDark = useThemeStore((s) => s.isDark);
+  const theme: typeof persistedTheme =
+    isSystemDark && persistedTheme === "classic" ? "black" : persistedTheme;
 
   // Pick navigation methods + setter based on the active library. Apple
   // Music has its own queue / shuffle pointers in the store so YouTube

--- a/src/apps/maps/components/MapsMenuBar.tsx
+++ b/src/apps/maps/components/MapsMenuBar.tsx
@@ -44,7 +44,7 @@ export function MapsMenuBar({
           <MenubarItem
             onClick={onLocateMe}
             disabled={!canUseMap}
-            className={`text-md h-6 px-3 ${!canUseMap ? "text-gray-500" : ""}`}
+            className={`text-md h-6 px-3 ${!canUseMap ? "text-neutral-500" : ""}`}
           >
             {t("apps.maps.menu.locateMe")}
           </MenubarItem>

--- a/src/apps/minesweeper/components/MinesweeperAppComponent.tsx
+++ b/src/apps/minesweeper/components/MinesweeperAppComponent.tsx
@@ -243,7 +243,7 @@ export function MinesweeperAppComponent({
             )}
           >
             <div
-              className="flex-1 bg-[#8a9a8a] text-[#1a2a1a] text-lg px-2 py-0.5 border border-t-gray-800 border-l-gray-800 border-r-white border-b-white shadow-inner [text-shadow:1px_1px_0px_rgba(0,0,0,0.2)] h-[48px] flex items-center"
+              className="flex-1 bg-[#8a9a8a] text-[#1a2a1a] text-lg px-2 py-0.5 border border-t-neutral-800 border-l-neutral-800 border-r-white border-b-white shadow-inner [text-shadow:1px_1px_0px_rgba(0,0,0,0.2)] h-[48px] flex items-center"
             >
               <div className="flex items-center justify-between text-sm relative w-full">
                 <div className="flex flex-col items-start w-[80px]">
@@ -274,7 +274,7 @@ export function MinesweeperAppComponent({
                     className={
                       isMacTheme
                         ? "!w-[34px] !h-[34px] aspect-square !rounded-full overflow-hidden flex items-center justify-center text-xl leading-none !p-0"
-                        : "aspect-square h-[34px] flex items-center justify-center text-xl leading-none bg-[#c0c0c0] hover:bg-[#d0d0d0] border-2 border-t-white border-l-white border-r-gray-800 border-b-gray-800 active:border active:border-gray-600 shadow-none p-0"
+                        : "aspect-square h-[34px] flex items-center justify-center text-xl leading-none bg-[#c0c0c0] hover:bg-[#d0d0d0] border-2 border-t-white border-l-white border-r-neutral-800 border-b-neutral-800 active:border active:border-neutral-600 shadow-none p-0"
                     }
                   >
                     {gameOver ? "💀" : gameWon ? "😎" : "🙂"}
@@ -304,7 +304,7 @@ export function MinesweeperAppComponent({
               "grid grid-cols-9 gap-0 m-auto w-fit",
               isMacTheme
                 ? "p-[2px] rounded-[4px] bg-[#b7bcc1]"
-                : "bg-gray-800 p-[1px] border border-t-gray-800 border-l-gray-800 border-r-white border-b-white max-w-[250px]"
+                : "bg-neutral-800 p-[1px] border border-t-neutral-800 border-l-neutral-800 border-r-white border-b-white max-w-[250px]"
             )}
             style={boardFrameStyle}
           >

--- a/src/apps/paint/components/PaintAppComponent.tsx
+++ b/src/apps/paint/components/PaintAppComponent.tsx
@@ -123,7 +123,11 @@ export const PaintAppComponent: React.FC<AppProps<PaintInitialData>> = ({
         keepMountedWhenMinimized
       >
         <div
-          className="flex flex-col h-full w-full min-h-0 p-2"
+          // Paint UI is intentionally skinned for the classic Paint look in
+          // every theme — opt out of the macOS Aqua dark coverage layer so
+          // toolbars, the canvas chrome, and the pattern palette keep their
+          // light surfaces in dark mode too.
+          className="flex flex-col h-full w-full min-h-0 p-2 os-native-chrome-skip"
           style={{
             backgroundImage: 'url("/patterns/Property 1=7.svg")',
             backgroundRepeat: "repeat",

--- a/src/apps/paint/components/PaintAppComponent.tsx
+++ b/src/apps/paint/components/PaintAppComponent.tsx
@@ -153,7 +153,7 @@ export const PaintAppComponent: React.FC<AppProps<PaintInitialData>> = ({
             <div className="flex flex-col flex-1 gap-2 min-h-0 min-w-0">
               <div className="flex-1 bg-white min-h-0 min-w-0 border border-black border-2 shadow-[2px_2px_0px_0px_rgba(0,0,0,0.5)] overflow-auto relative">
                 {error && (
-                  <div className="absolute inset-0 flex items-center justify-center bg-gray-200 text-red-500 p-4">
+                  <div className="absolute inset-0 flex items-center justify-center bg-neutral-200 text-red-500 p-4">
                     Error: {error}
                   </div>
                 )}

--- a/src/apps/paint/components/PaintMenuBar.tsx
+++ b/src/apps/paint/components/PaintMenuBar.tsx
@@ -744,7 +744,7 @@ export function PaintMenuBar({
             onClick={onUndo}
             disabled={!canUndo}
             className={`text-md h-6 px-3 ${
-              !canUndo ? "text-gray-500" : ""
+              !canUndo ? "text-neutral-500" : ""
             }`}
           >
             {t("common.menu.undo")}
@@ -753,7 +753,7 @@ export function PaintMenuBar({
             onClick={onRedo}
             disabled={!canRedo}
             className={`text-md h-6 px-3 ${
-              !canRedo ? "text-gray-500" : ""
+              !canRedo ? "text-neutral-500" : ""
             }`}
           >
             {t("common.menu.redo")}

--- a/src/apps/paint/components/PaintPatternPalette.tsx
+++ b/src/apps/paint/components/PaintPatternPalette.tsx
@@ -20,7 +20,7 @@ export const PaintPatternPalette: React.FC<PaintPatternPaletteProps> = ({
           <button
             key={num}
             className={` hover:opacity-70 border-1 border-black ${
-              selectedPattern === `pattern-${num}` ? "" : "border-gray-800"
+              selectedPattern === `pattern-${num}` ? "" : "border-neutral-800"
             }`}
             onClick={() => onPatternSelect(`pattern-${num}`)}
           >

--- a/src/apps/paint/components/PaintStrokeSettings.tsx
+++ b/src/apps/paint/components/PaintStrokeSettings.tsx
@@ -11,7 +11,7 @@ export const PaintStrokeSettings: React.FC<PaintStrokeSettingsProps> = ({
   onStrokeWidthChange,
 }) => {
   return (
-    <div className="space-y-2 p-2 py-3 border-t border-gray-200">
+    <div className="space-y-2 p-2 py-3 border-t border-neutral-200">
       <Slider
         value={[strokeWidth]}
         onValueChange={(value) => onStrokeWidthChange(value[0])}

--- a/src/apps/pc/components/PcAppComponent.tsx
+++ b/src/apps/pc/components/PcAppComponent.tsx
@@ -170,7 +170,7 @@ export function PcAppComponent({
           ? "text-transparent cursor-default"
           : isDarkTitlebar
             ? "text-white/80 hover:text-white cursor-pointer"
-            : "text-gray-600 hover:text-gray-800 cursor-pointer"
+            : "text-neutral-600 hover:text-neutral-800 cursor-pointer"
       }`}
       style={{
         filter: isGameRunning && isDarkTitlebar
@@ -226,12 +226,12 @@ export function PcAppComponent({
                     <div className="font-apple-garamond text-white text-lg">
                       {t("apps.pc.virtualPc")}
                     </div>
-                    <div className="font-geneva-12 text-gray-400 text-[12px] flex items-center gap-2">
+                    <div className="font-geneva-12 text-neutral-400 text-[12px] flex items-center gap-2">
                       {isScriptLoaded ? (
                         t("apps.pc.programsAvailable", { count: games.length })
                       ) : (
                         <>
-                          <ActivityIndicator size="xs" className="text-gray-400" />
+                          <ActivityIndicator size="xs" className="text-neutral-400" />
                           {t("apps.pc.loadingEmulator")}
                         </>
                       )}

--- a/src/apps/pc/components/PcMenuBar.tsx
+++ b/src/apps/pc/components/PcMenuBar.tsx
@@ -81,7 +81,7 @@ export function PcMenuBar({
                   key={game.id}
                   onClick={() => onLoadGame(game)}
                   className={`text-md h-6 px-3 ${
-                    selectedGame.id === game.id ? "bg-gray-100" : ""
+                    selectedGame.id === game.id ? "bg-neutral-100" : ""
                   }`}
                 >
                   {game.name}
@@ -147,7 +147,7 @@ export function PcMenuBar({
                   key={sensitivity}
                   onClick={() => onSetMouseSensitivity(sensitivity)}
                   className={`text-md h-6 px-3 ${
-                    mouseSensitivity === sensitivity ? "bg-gray-100" : ""
+                    mouseSensitivity === sensitivity ? "bg-neutral-100" : ""
                   }`}
                 >
                   {sensitivity}x
@@ -166,7 +166,7 @@ export function PcMenuBar({
                   key={aspect}
                   onClick={() => onSetRenderAspect(aspect)}
                   className={`text-md h-6 px-3 ${
-                    currentRenderAspect === aspect ? "bg-gray-100" : ""
+                    currentRenderAspect === aspect ? "bg-neutral-100" : ""
                   }`}
                 >
                   {aspect}

--- a/src/apps/photo-booth/components/PhotoBoothComponent.tsx
+++ b/src/apps/photo-booth/components/PhotoBoothComponent.tsx
@@ -490,7 +490,7 @@ export function PhotoBoothComponent({
                 isMacTheme
                   ? "transition-transform hover:scale-105"
                   : isMultiPhotoMode
-                  ? "bg-gray-500 cursor-not-allowed"
+                  ? "bg-neutral-500 cursor-not-allowed"
                   : "bg-red-500 hover:bg-red-600"
               )}
               style={

--- a/src/apps/soundboard/components/BoardList.tsx
+++ b/src/apps/soundboard/components/BoardList.tsx
@@ -82,7 +82,7 @@ export function BoardList({
         {micPermissionGranted && (
           <div
             className={`mt-auto pt-2 border-t px-3 pb-3 ${
-              isWindowsLegacyTheme ? "border-[#919b9c]" : "border-gray-300"
+              isWindowsLegacyTheme ? "border-[#919b9c]" : "border-neutral-300"
             }`}
           >
             <Select value={selectedDeviceId} onValueChange={onDeviceSelect}>

--- a/src/apps/soundboard/components/SoundboardMenuBar.tsx
+++ b/src/apps/soundboard/components/SoundboardMenuBar.tsx
@@ -147,7 +147,7 @@ export function SoundboardMenuBar({
             disabled={!canDeleteBoard}
             className={
               !canDeleteBoard
-                ? "text-gray-400 text-md h-6 px-3"
+                ? "text-neutral-400 text-md h-6 px-3"
                 : "text-md h-6 px-3"
             }
           >

--- a/src/apps/synth/components/SynthAppComponent.tsx
+++ b/src/apps/synth/components/SynthAppComponent.tsx
@@ -281,7 +281,7 @@ export function SynthAppComponent({
                             </button>
                           ))
                         ) : (
-                          <p className="text-xs text-gray-400 font-geneva-12 select-none px-2">
+                          <p className="text-xs text-neutral-400 font-geneva-12 select-none px-2">
                             {t("apps.synth.noPresetsYet")}
                           </p>
                         )}
@@ -305,7 +305,7 @@ export function SynthAppComponent({
                           </Button>
                         ))
                       ) : (
-                        <p className="text-xs text-gray-400 font-geneva-12 select-none">
+                        <p className="text-xs text-neutral-400 font-geneva-12 select-none">
                           {t("apps.synth.noPresetsYet")}
                         </p>
                       )}

--- a/src/apps/terminal/components/TerminalAppComponent.tsx
+++ b/src/apps/terminal/components/TerminalAppComponent.tsx
@@ -279,17 +279,17 @@ export function TerminalAppComponent({
                 (item.toolInvocations && item.toolInvocations.length > 0)) && (
                 <div
                   className={`ml-0 select-text ${
-                    item.path === "ai-thinking" ? "text-gray-400" : ""
+                    item.path === "ai-thinking" ? "text-neutral-400" : ""
                   } ${item.path === "ai-assistant" ? "text-purple-100" : ""} ${
                     item.path === "ai-error" ? "text-red-400" : ""
-                  } ${item.path === "welcome-message" ? "text-gray-400" : ""} ${
+                  } ${item.path === "welcome-message" ? "text-neutral-400" : ""} ${
                     // Add urgent message styling
                     item.output && isUrgentMessage(item.output)
                       ? "text-red-400"
                       : ""
                   } ${
                     // System messages (errors, usage hints) styled in gray
-                    item.isSystemMessage ? "text-gray-400" : ""
+                    item.isSystemMessage ? "text-neutral-400" : ""
                   }`}
                 >
                   {item.path === "ai-thinking" ? (
@@ -300,7 +300,7 @@ export function TerminalAppComponent({
                         </span>{" "}
                         ryo
                       </span>
-                      <span className="text-gray-500 italic shimmer-subtle">
+                      <span className="text-neutral-500 italic shimmer-subtle">
                         {" "}
                         {i18n.t("apps.terminal.output.isThinking")}
                         <AnimatedEllipsis />
@@ -368,7 +368,7 @@ export function TerminalAppComponent({
                                     : isSpin
                                       ? "gradient-spin italic"
                                       : isRes
-                                        ? "text-gray-400"
+                                        ? "text-neutral-400"
                                         : "text-purple-300";
                                   return (
                                     <span
@@ -524,7 +524,7 @@ export function TerminalAppComponent({
               />
               {isAiLoading && isInAiMode && (
                 <div className="absolute top-0 left-0 w-full h-full pointer-events-none flex items-center">
-                  <span className="text-gray-400/40 opacity-30 shimmer">
+                  <span className="text-neutral-400/40 opacity-30 shimmer">
                     {i18n.t("apps.terminal.output.isThinking")}
                     <AnimatedEllipsis />
                   </span>

--- a/src/apps/terminal/components/TerminalToolInvocation.tsx
+++ b/src/apps/terminal/components/TerminalToolInvocation.tsx
@@ -328,7 +328,7 @@ export function TerminalToolInvocation({
 
   return (
     <div
-      className="flex items-center gap-1.5 text-gray-400 py-0.5 select-text terminal-tool-invocation"
+      className="flex items-center gap-1.5 text-neutral-400 py-0.5 select-text terminal-tool-invocation"
       style={fontSize ? { fontSize: `${fontSize}px` } : undefined}
     >
       {state === "output-available" && displayResultMessage ? (

--- a/src/apps/terminal/components/VimEditor.tsx
+++ b/src/apps/terminal/components/VimEditor.tsx
@@ -109,7 +109,7 @@ export function VimEditor({
             key={`line-${lineNumber}`}
             className={`vim-line flex ${isCursorLine ? "bg-white/10" : ""} ${isVisualSelected ? "bg-blue-900/40" : ""}`}
           >
-            <span className="text-gray-500 w-6 text-right mr-2 shrink-0">
+            <span className="text-neutral-500 w-6 text-right mr-2 shrink-0">
               {isFiller ? "" : lineNumber + 1}
             </span>
             {isCursorLine ? (

--- a/src/apps/textedit/components/EditorToolbar.tsx
+++ b/src/apps/textedit/components/EditorToolbar.tsx
@@ -308,8 +308,8 @@ export function EditorToolbar({
           : isMacOSTheme
           ? "bg-transparent"
           : currentTheme === "system7"
-          ? "bg-gray-100 border-b border-black"
-          : "bg-gray-100 border-b border-gray-300"
+          ? "bg-neutral-100 border-b border-black"
+          : "bg-neutral-100 border-b border-neutral-300"
       }`}
       style={{
         borderBottom:

--- a/src/apps/textedit/components/SlashCommandsList.tsx
+++ b/src/apps/textedit/components/SlashCommandsList.tsx
@@ -68,18 +68,18 @@ export const SlashCommandsList = (
   }));
 
   return (
-    <div className="z-50 h-auto max-h-[330px] w-72 overflow-y-auto rounded-lg border border-gray-200 bg-white p-1 shadow-lg">
+    <div className="z-50 h-auto max-h-[330px] w-72 overflow-y-auto rounded-lg border border-neutral-200 bg-white p-1 shadow-lg">
       {props.items.map((item, index) => (
         <button
           key={`${item.title}-${item.description}`}
           className={`flex w-full items-start gap-2 rounded-md px-2 py-1 text-left ${
-            index === selectedIndex ? "bg-gray-100" : ""
+            index === selectedIndex ? "bg-neutral-100" : ""
           }`}
           onClick={() => selectItem(index)}
         >
           <div className="flex flex-col">
             <span className="text-sm font-medium">{item.title}</span>
-            <span className="text-xs text-gray-500">{item.description}</span>
+            <span className="text-xs text-neutral-500">{item.description}</span>
           </div>
         </button>
       ))}

--- a/src/apps/textedit/components/TextEditMenuBar.tsx
+++ b/src/apps/textedit/components/TextEditMenuBar.tsx
@@ -141,14 +141,14 @@ export function TextEditMenuBar({
           <MenubarItem
             onClick={undo}
             disabled={!canUndo}
-            className={`text-md h-6 px-3 ${!canUndo ? "text-gray-500" : ""}`}
+            className={`text-md h-6 px-3 ${!canUndo ? "text-neutral-500" : ""}`}
           >
             {t("common.menu.undo")}
           </MenubarItem>
           <MenubarItem
             onClick={redo}
             disabled={!canRedo}
-            className={`text-md h-6 px-3 ${!canRedo ? "text-gray-500" : ""}`}
+            className={`text-md h-6 px-3 ${!canRedo ? "text-neutral-500" : ""}`}
           >
             {t("common.menu.redo")}
           </MenubarItem>

--- a/src/apps/textedit/extensions/SlashCommands.tsx
+++ b/src/apps/textedit/extensions/SlashCommands.tsx
@@ -97,7 +97,7 @@ const SlashMenuContent = ({
           onClick={() => onCommand(item)}
           onMouseEnter={() => setSelectedIndex(index)}
           className={`relative flex w-full items-center h-8 px-2 text-sm ${
-            index === selectedIndex ? "bg-gray-100" : ""
+            index === selectedIndex ? "bg-neutral-100" : ""
           }`}
         >
           {getTranslatedTitle(item)}

--- a/src/apps/tv/components/CreateChannelDialog.tsx
+++ b/src/apps/tv/components/CreateChannelDialog.tsx
@@ -161,7 +161,7 @@ export function CreateChannelDialog({
 
   const dialogContent = (
     <div className={cn(isXpTheme ? "p-2 px-4" : "p-4 px-6")}>
-      <p className={cn("text-gray-500 mb-2", fontClass)} style={fontStyle}>
+      <p className={cn("text-neutral-500 mb-2", fontClass)} style={fontStyle}>
         {t("apps.tv.create.description")}
       </p>
 
@@ -191,8 +191,8 @@ export function CreateChannelDialog({
               dispatch({ type: "patch", payload: { description: s } })
             }
             className={cn(
-              "px-2 py-0.5 rounded-full border text-gray-700",
-              "border-gray-300 hover:bg-gray-100 disabled:opacity-50"
+              "px-2 py-0.5 rounded-full border text-neutral-700",
+              "border-neutral-300 hover:bg-neutral-100 disabled:opacity-50"
             )}
           >
             {s}

--- a/src/apps/videos/components/VideosAppComponent.tsx
+++ b/src/apps/videos/components/VideosAppComponent.tsx
@@ -634,7 +634,7 @@ export function VideosAppComponent({
                 </AnimatePresence>
               </div>
             ) : (
-              <div className="flex items-center justify-center h-full text-gray-400 font-geneva-12 text-sm">
+              <div className="flex items-center justify-center h-full text-neutral-400 font-geneva-12 text-sm">
                 <a
                   onClick={() => setIsAddDialogOpen(true)}
                   className="text-[#ff00ff] hover:underline cursor-pointer"

--- a/src/apps/videos/components/VideosMenuBar.tsx
+++ b/src/apps/videos/components/VideosMenuBar.tsx
@@ -224,7 +224,7 @@ export function VideosMenuBar({
                       onClick={() => onPlayVideo(video.id)}
                       className={cn(
                         "text-md h-6 px-3 max-w-[220px] truncate",
-                        video.id === currentVideoId && "bg-gray-200"
+                        video.id === currentVideoId && "bg-neutral-200"
                       )}
                     >
                       <div className="flex items-center w-full">
@@ -258,7 +258,7 @@ export function VideosMenuBar({
                         onClick={() => onPlayVideo(video.id)}
                         className={cn(
                           "text-md h-6 px-3 max-w-[160px] sm:max-w-[200px] truncate",
-                          video.id === currentVideoId && "bg-gray-200"
+                          video.id === currentVideoId && "bg-neutral-200"
                         )}
                       >
                         <div className="flex items-center w-full">

--- a/src/components/dialogs/AboutDialog.tsx
+++ b/src/components/dialogs/AboutDialog.tsx
@@ -87,7 +87,7 @@ export function AboutDialog({
         >
           {displayName}
         </div>
-        <p className="text-gray-500 mb-2">{t("common.dialog.version")} {metadata.version}</p>
+        <p className="text-neutral-500 mb-2">{t("common.dialog.version")} {metadata.version}</p>
         <p>
           {t("common.dialog.madeBy")}{" "}
           <a

--- a/src/components/dialogs/AboutFinderDialog.tsx
+++ b/src/components/dialogs/AboutFinderDialog.tsx
@@ -258,7 +258,11 @@ export function AboutFinderDialog({
               </div>
             </div>
           </div>
-          <hr className="border-neutral-300" />
+          <hr
+            // Theme-aware divider so dark mode lifts the rule to a faint
+            // white-on-dark hairline instead of the bright neutral-300 stripe.
+            style={{ borderTopColor: "var(--os-color-separator)" }}
+          />
 
           {/* Memory usage bars */}
           <div className={cn("space-y-2 p-2 px-4 pb-4", aboutFinderSmallClass)}>

--- a/src/components/dialogs/AboutFinderDialog.tsx
+++ b/src/components/dialogs/AboutFinderDialog.tsx
@@ -178,7 +178,7 @@ export function AboutFinderDialog({
               <div
                 className={cn(
                   aboutFinderSmallClass,
-                  "cursor-pointer select-none transition-opacity hover:opacity-70 text-gray-500"
+                  "cursor-pointer select-none transition-opacity hover:opacity-70 text-neutral-500"
                 )}
                 style={
                   isXpTheme
@@ -210,7 +210,7 @@ export function AboutFinderDialog({
               </div>
               <div
                 className={cn(
-                  "text-gray-500",
+                  "text-neutral-500",
                   isXpTheme
                     ? "font-['Pixelated_MS_Sans_Serif',Arial] text-[10px]"
                     : currentTheme === "macosx"
@@ -258,7 +258,7 @@ export function AboutFinderDialog({
               </div>
             </div>
           </div>
-          <hr className="border-gray-300" />
+          <hr className="border-neutral-300" />
 
           {/* Memory usage bars */}
           <div className={cn("space-y-2 p-2 px-4 pb-4", aboutFinderSmallClass)}>
@@ -271,7 +271,7 @@ export function AboutFinderDialog({
                 <div
                   className={cn(
                     "h-2 w-full",
-                    currentTheme === "macosx" ? "aqua-progress" : "bg-gray-200"
+                    currentTheme === "macosx" ? "aqua-progress" : "bg-neutral-200"
                   )}
                 >
                   <div

--- a/src/components/dialogs/BootScreen.tsx
+++ b/src/components/dialogs/BootScreen.tsx
@@ -222,7 +222,9 @@ export function BootScreen({
               <h1 
                 className="text-[52px] mb-6"
                 style={{ 
-                  color: "#333333",
+                  // Theme tokens so dark mode flips the boot title to a
+                  // light glyph against the dark pinstripe surface.
+                  color: "var(--os-color-text-primary, #333333)",
                   fontFamily: "AppleGaramond, 'Apple Garamond', 'Times New Roman', serif",
                   letterSpacing: "1px",
                   textShadow: "0 1px 2px rgba(0, 0, 0, 0.15)"
@@ -241,7 +243,7 @@ export function BootScreen({
               <p 
                 className="text-[12px] mt-5"
                 style={{ 
-                  color: "#000000",
+                  color: "var(--os-color-text-primary, #000000)",
                   fontFamily: "LucidaGrande, 'Lucida Grande', sans-serif"
                 }}
               >

--- a/src/components/dialogs/ChangePasswordDialog.tsx
+++ b/src/components/dialogs/ChangePasswordDialog.tsx
@@ -190,7 +190,7 @@ export function ChangePasswordDialog({
       {hasPassword && (
         <div className="space-y-2">
           <Label
-            className={cn("text-gray-700", themeFont)}
+            className={cn("text-neutral-700", themeFont)}
             style={themeFontStyle}
             htmlFor="change-password-current"
           >
@@ -214,7 +214,7 @@ export function ChangePasswordDialog({
 
       <div className="space-y-2">
         <Label
-          className={cn("text-gray-700", themeFont)}
+          className={cn("text-neutral-700", themeFont)}
           style={themeFontStyle}
           htmlFor="change-password-new"
         >
@@ -235,7 +235,7 @@ export function ChangePasswordDialog({
 
       <div className="space-y-2">
         <Label
-          className={cn("text-gray-700", themeFont)}
+          className={cn("text-neutral-700", themeFont)}
           style={themeFontStyle}
           htmlFor="change-password-confirm"
         >
@@ -296,7 +296,7 @@ export function ChangePasswordDialog({
   const dialogBody = (
     <div className={isXpTheme ? "p-2 px-4" : "p-4 px-6"}>
       <p
-        className={cn("text-gray-500 mb-3", themeFont)}
+        className={cn("text-neutral-500 mb-3", themeFont)}
         style={themeFontStyle}
         id="change-password-description"
       >

--- a/src/components/dialogs/ConfirmDialog.tsx
+++ b/src/components/dialogs/ConfirmDialog.tsx
@@ -56,7 +56,7 @@ export function ConfirmDialog({
         />
         <p
           className={cn(
-            "text-gray-900 mb-2 leading-tight",
+            "text-neutral-900 mb-2 leading-tight",
             isXpTheme
               ? "font-['Pixelated_MS_Sans_Serif',Arial] text-[11px]"
               : "font-geneva-12 text-[12px]"

--- a/src/components/dialogs/EmojiDialog.tsx
+++ b/src/components/dialogs/EmojiDialog.tsx
@@ -240,7 +240,7 @@ export function EmojiDialog({
       <p
         id="dialog-description"
         className={cn(
-          "mb-2 text-gray-500",
+          "mb-2 text-neutral-500",
           isXpTheme
             ? "font-['Pixelated_MS_Sans_Serif',Arial] text-[11px]"
             : "font-geneva-12 text-[12px]"

--- a/src/components/dialogs/FutureSettingsDialog.tsx
+++ b/src/components/dialogs/FutureSettingsDialog.tsx
@@ -104,7 +104,7 @@ const FutureSettingsDialog = ({
         <div className="flex items-center gap-2">
           <span
             className={cn(
-              "text-gray-900",
+              "text-neutral-900",
               isXpTheme
                 ? "font-['Pixelated_MS_Sans_Serif',Arial] text-[11px]"
                 : "font-geneva-12 text-[12px]"

--- a/src/components/dialogs/HelpDialog.tsx
+++ b/src/components/dialogs/HelpDialog.tsx
@@ -52,7 +52,7 @@ function HelpCard({ icon, title, description }: HelpCardProps) {
       </h3>
       <p
         className={cn(
-          "text-gray-700",
+          "text-neutral-700",
           isXpTheme
             ? "font-['Pixelated_MS_Sans_Serif',Arial] text-[10px]"
             : "font-geneva-12 text-[10px]"

--- a/src/components/dialogs/InputDialog.tsx
+++ b/src/components/dialogs/InputDialog.tsx
@@ -78,7 +78,7 @@ export function InputDialog({
     <div className={isXpTheme ? "p-2 px-4" : "p-4 px-6"}>
       <p
         className={cn(
-          "text-gray-500 mb-2",
+          "text-neutral-500 mb-2",
           isXpTheme
             ? "font-['Pixelated_MS_Sans_Serif',Arial] text-[11px]"
             : "font-geneva-12 text-[12px]"

--- a/src/components/dialogs/LoginDialog.tsx
+++ b/src/components/dialogs/LoginDialog.tsx
@@ -108,7 +108,7 @@ export function LoginDialog({
     <div className="space-y-3">
       <div className="space-y-2">
         <Label
-          className={cn("text-gray-700", themeFont)}
+          className={cn("text-neutral-700", themeFont)}
           style={themeFontStyle}
         >
           {t("common.auth.username")}
@@ -124,7 +124,7 @@ export function LoginDialog({
       </div>
       <div className="space-y-2">
         <Label
-          className={cn("text-gray-700", themeFont)}
+          className={cn("text-neutral-700", themeFont)}
           style={themeFontStyle}
         >
           {t("common.auth.password")}
@@ -145,7 +145,7 @@ export function LoginDialog({
     <div className="space-y-3">
       <div className="space-y-2">
         <Label
-          className={cn("text-gray-700", themeFont)}
+          className={cn("text-neutral-700", themeFont)}
           style={themeFontStyle}
         >
           {t("common.auth.username")}
@@ -161,7 +161,7 @@ export function LoginDialog({
       </div>
       <div className="space-y-2">
         <Label
-          className={cn("text-gray-700", themeFont)}
+          className={cn("text-neutral-700", themeFont)}
           style={themeFontStyle}
         >
           {t("common.auth.password")}

--- a/src/components/dialogs/LyricsSearchDialog.tsx
+++ b/src/components/dialogs/LyricsSearchDialog.tsx
@@ -211,7 +211,7 @@ export function LyricsSearchDialog({
     <div className={isXpTheme ? "p-2 px-4" : "p-4 px-6"}>
       <p
         className={cn(
-          "text-gray-500 mb-2",
+          "text-neutral-500 mb-2",
           isXpTheme
             ? "font-['Pixelated_MS_Sans_Serif',Arial] text-[11px]"
             : "font-geneva-12 text-[12px]"
@@ -287,7 +287,7 @@ export function LyricsSearchDialog({
         <div className="mb-3">
           <p
             className={cn(
-              "text-gray-500 mb-2",
+              "text-neutral-500 mb-2",
               isXpTheme
                 ? "font-['Pixelated_MS_Sans_Serif',Arial] text-[11px]"
                 : "font-geneva-12 text-[12px]"
@@ -301,7 +301,7 @@ export function LyricsSearchDialog({
           >
             {t("apps.ipod.dialogs.lyricsSearchCurrentSelection")}
           </p>
-          <div className="border border-gray-300 rounded-md overflow-hidden bg-white">
+          <div className="border border-neutral-300 rounded-md overflow-hidden bg-white">
             <div
               className={cn(
                 "flex items-center gap-2 px-2 py-1.5",
@@ -322,8 +322,8 @@ export function LyricsSearchDialog({
                 return (
                   <div
                     className={cn(
-                      "flex-shrink-0 w-9 h-9 overflow-hidden bg-gray-200",
-                      isXpTheme ? "border border-gray-400" : "rounded-sm"
+                      "flex-shrink-0 w-9 h-9 overflow-hidden bg-neutral-200",
+                      isXpTheme ? "border border-neutral-400" : "rounded-sm"
                     )}
                     aria-hidden="true"
                   >
@@ -377,7 +377,7 @@ export function LyricsSearchDialog({
         <div className="mb-3">
           <p
             className={cn(
-              "text-gray-500 mb-2",
+              "text-neutral-500 mb-2",
               isXpTheme
                 ? "font-['Pixelated_MS_Sans_Serif',Arial] text-[11px]"
                 : "font-geneva-12 text-[12px]"
@@ -391,7 +391,7 @@ export function LyricsSearchDialog({
           >
             {t("apps.ipod.dialogs.lyricsSearchSelectResult")}
           </p>
-          <ScrollArea className="h-[200px] border border-gray-300 rounded-md overflow-hidden bg-white">
+          <ScrollArea className="h-[200px] border border-neutral-300 rounded-md overflow-hidden bg-white">
             <div>
               {results.map((result, index) => {
                 const coverUrl = formatKugouImageUrl(result.cover, 100);
@@ -414,7 +414,7 @@ export function LyricsSearchDialog({
                       selectedIndex === index
                         ? "" // Selection styling handled by inline style
                         : index % 2 === 1
-                          ? "bg-gray-100"
+                          ? "bg-neutral-100"
                           : "bg-white",
                       isXpTheme
                         ? "font-['Pixelated_MS_Sans_Serif',Arial] text-[11px]"
@@ -430,8 +430,8 @@ export function LyricsSearchDialog({
                   >
                     <div
                       className={cn(
-                        "flex-shrink-0 w-9 h-9 overflow-hidden bg-gray-200",
-                        isXpTheme ? "border border-gray-400" : "rounded-sm"
+                        "flex-shrink-0 w-9 h-9 overflow-hidden bg-neutral-200",
+                        isXpTheme ? "border border-neutral-400" : "rounded-sm"
                       )}
                       aria-hidden="true"
                     >

--- a/src/components/dialogs/ShareItemDialog.tsx
+++ b/src/components/dialogs/ShareItemDialog.tsx
@@ -149,10 +149,10 @@ export function ShareItemDialog({
       <div className="flex flex-col items-center space-y-3 w-full">
         {/* QR Code */}
         {isLoading ? (
-          <div className="size-32 flex items-center justify-center bg-gray-100 rounded">
+          <div className="size-32 flex items-center justify-center bg-neutral-100 rounded">
             <p
               className={cn(
-                "text-gray-500",
+                "text-neutral-500",
                 isXpTheme
                   ? "font-['Pixelated_MS_Sans_Serif',Arial] text-[10px]"
                   : "font-geneva-12 text-[10px]"
@@ -178,10 +178,10 @@ export function ShareItemDialog({
             />
           </div>
         ) : (
-          <div className="size-32 flex items-center justify-center bg-gray-100 rounded">
+          <div className="size-32 flex items-center justify-center bg-neutral-100 rounded">
             <p
               className={cn(
-                "text-gray-500",
+                "text-neutral-500",
                 isXpTheme
                   ? "font-['Pixelated_MS_Sans_Serif',Arial] text-[10px]"
                   : "font-geneva-12 text-[10px]"

--- a/src/components/dialogs/SongSearchDialog.tsx
+++ b/src/components/dialogs/SongSearchDialog.tsx
@@ -587,7 +587,7 @@ export function SongSearchDialog({
   const dialogContent = (
     <div className={cn(isXpTheme ? "p-2 px-4" : "p-4 px-6", "overflow-hidden w-full box-border")}>
       {!isAppleMusicMode && (
-        <p className={cn("text-gray-500 mb-2", fontClass)} style={fontStyle}>
+        <p className={cn("text-neutral-500 mb-2", fontClass)} style={fontStyle}>
           {t("apps.ipod.dialogs.songSearchDescription")}
         </p>
       )}
@@ -602,7 +602,7 @@ export function SongSearchDialog({
 
       {hasResults && (
         <div style={{ marginBottom: "12px" }}>
-          <p className={cn("text-gray-500 mb-2", fontClass)} style={fontStyle}>
+          <p className={cn("text-neutral-500 mb-2", fontClass)} style={fontStyle}>
             {isAppleMusicMode
               ? t(
                   "apps.ipod.dialogs.appleMusicSearchSelectResult",

--- a/src/components/dialogs/TelegramLinkDialog.tsx
+++ b/src/components/dialogs/TelegramLinkDialog.tsx
@@ -86,10 +86,10 @@ export function TelegramLinkDialog({
   );
 
   const previewContent = isStatusLoading && !shouldShowLinkSession ? (
-    <div className="flex size-32 items-center justify-center rounded bg-gray-100">
+    <div className="flex size-32 items-center justify-center rounded bg-neutral-100">
       <p
         className={cn(
-          "text-gray-500",
+          "text-neutral-500",
           isXpTheme
             ? "font-['Pixelated_MS_Sans_Serif',Arial] text-[10px]"
             : "font-geneva-12 text-[10px]"

--- a/src/components/layout/AppleMenu.tsx
+++ b/src/components/layout/AppleMenu.tsx
@@ -222,7 +222,7 @@ export function AppleMenu() {
                   );
                 })
               ) : (
-                <MenubarItem disabled className="text-md h-6 px-3 text-gray-400">
+                <MenubarItem disabled className="text-md h-6 px-3 text-neutral-400">
                   {t("common.appleMenu.noRecentApps")}
                 </MenubarItem>
               )}
@@ -265,7 +265,7 @@ export function AppleMenu() {
                   );
                 })
               ) : (
-                <MenubarItem disabled className="text-md h-6 px-3 text-gray-400">
+                <MenubarItem disabled className="text-md h-6 px-3 text-neutral-400">
                   {t("common.appleMenu.noRecentDocuments")}
                 </MenubarItem>
               )}

--- a/src/components/layout/Dock.tsx
+++ b/src/components/layout/Dock.tsx
@@ -2089,10 +2089,13 @@ function MacDock() {
           }}
           style={{
             pointerEvents: isDockVisible ? "auto" : "none",
-            background: "rgba(248, 248, 248, 0.75)",
+            // Same tint variable as the menubar so light/dark switch in lockstep.
+            background:
+              "var(--os-color-dock-surface, rgba(248, 248, 248, 0.75))",
             backgroundImage: "var(--os-pinstripe-menubar)",
             border: "none",
-            boxShadow: "0 2px 8px rgba(0, 0, 0, 0.15)",
+            boxShadow:
+              "var(--os-color-dock-shadow, 0 2px 8px rgba(0, 0, 0, 0.15))",
             height: scaledDockHeight,
             padding: scaledPadding,
             maxWidth: "min(92vw, 980px)",

--- a/src/components/layout/MenuBar.tsx
+++ b/src/components/layout/MenuBar.tsx
@@ -580,14 +580,14 @@ function DefaultMenuItems() {
           <MenubarItem
             onClick={() => undoRedoEntry?.undo()}
             disabled={!undoRedoEntry?.canUndo}
-            className={`text-md h-6 px-3 ${!undoRedoEntry?.canUndo ? "text-gray-500" : ""}`}
+            className={`text-md h-6 px-3 ${!undoRedoEntry?.canUndo ? "text-neutral-500" : ""}`}
           >
             {t("common.menu.undo")}
           </MenubarItem>
           <MenubarItem
             onClick={() => undoRedoEntry?.redo()}
             disabled={!undoRedoEntry?.canRedo}
-            className={`text-md h-6 px-3 ${!undoRedoEntry?.canRedo ? "text-gray-500" : ""}`}
+            className={`text-md h-6 px-3 ${!undoRedoEntry?.canRedo ? "text-neutral-500" : ""}`}
           >
             {t("common.menu.redo")}
           </MenubarItem>

--- a/src/components/layout/MenuBar.tsx
+++ b/src/components/layout/MenuBar.tsx
@@ -1457,10 +1457,13 @@ export function MenuBar({ children, inWindowFrame = false }: MenuBarProps) {
     <div
       className={`fixed top-0 left-0 right-0 flex border-b-[length:var(--os-metrics-border-width)] border-os-menubar items-center font-os-ui ${exposeMode ? "z-[9997]" : "z-[10002]"}`}
       style={{
-        background:
-          isMacOSTheme
-            ? "rgba(248, 248, 248, 0.85)"
-            : "var(--os-color-menubar-bg)",
+        // Use the theme variable so dark mode can swap the surface tint.
+        // The Aqua light fallback (#f8f8f8 with 0.85 alpha) is published as
+        // `--os-color-menubar-surface` so dark mode can override just the
+        // tint without losing the pinstripe overlay.
+        background: isMacOSTheme
+          ? "var(--os-color-menubar-surface, rgba(248, 248, 248, 0.85))"
+          : "var(--os-color-menubar-bg)",
         backgroundImage:
           isMacOSTheme ? "var(--os-pinstripe-menubar)" : undefined,
         backdropFilter: isMacOSTheme ? "blur(20px)" : undefined,

--- a/src/components/layout/WindowFrame.tsx
+++ b/src/components/layout/WindowFrame.tsx
@@ -551,11 +551,11 @@ export function WindowFrame({
         ? "text-white/80"
         : variant === "aqua"
           ? isForeground
-            ? "text-gray-500"
-            : "text-gray-400"
+            ? "text-neutral-500"
+            : "text-neutral-400"
           : isForeground
-            ? "text-gray-600"
-            : "text-gray-400",
+            ? "text-neutral-600"
+            : "text-neutral-400",
       onCoverFlowToggle &&
         isCoverFlowActive &&
         (isAquaNoTitlebar ? "text-white" : "text-os-titlebar-active-text")
@@ -1669,7 +1669,7 @@ export function WindowFrame({
                     : "bg-os-titlebar-active-bg bg-os-titlebar-pattern bg-clip-content bg-[length:6.6666666667%_13.3333333333%] border-b-os-window"
                   : isTransparent
                   ? "bg-white/20 backdrop-blur-sm border-b-os-window"
-                  : "bg-os-titlebar-inactive-bg border-b-gray-400"
+                  : "bg-os-titlebar-inactive-bg border-b-neutral-400"
               )}
               onMouseDown={handleMouseDownWithForeground}
               onDoubleClick={(e) => {
@@ -1711,7 +1711,7 @@ export function WindowFrame({
                   className={`size-4 ${
                     !isTransparent &&
                     "bg-os-button-face shadow-[0_0_0_1px_var(--os-color-button-face)]"
-                  } border-2 border-os-window hover:bg-gray-200 active:bg-gray-300 flex items-center justify-center ${
+                  } border-2 border-os-window hover:bg-neutral-200 active:bg-neutral-300 flex items-center justify-center ${
                     !isForeground && "invisible"
                   }`}
                 />

--- a/src/components/layout/dashboard/DictionaryWidget.tsx
+++ b/src/components/layout/dashboard/DictionaryWidget.tsx
@@ -148,17 +148,17 @@ export function DictionaryWidget({ widgetId }: DictionaryWidgetProps) {
         {/* XP content */}
         <div className="flex-1 overflow-y-auto px-3 py-2" style={{ fontSize: 11, minHeight: 0, maxHeight: 200 }}>
           {loading && (
-            <div className="text-center text-gray-400 py-4" style={{ fontSize: 10 }}>
+            <div className="text-center text-neutral-400 py-4" style={{ fontSize: 10 }}>
               {t("apps.dashboard.dictionary.loading", "Looking up…")}
             </div>
           )}
           {!loading && error && (
-            <div className="text-center text-gray-400 py-4" style={{ fontSize: 10 }}>
+            <div className="text-center text-neutral-400 py-4" style={{ fontSize: 10 }}>
               {error}
             </div>
           )}
           {!loading && !error && !entry && (
-            <div className="text-center text-gray-400 py-6" style={{ fontSize: 10 }}>
+            <div className="text-center text-neutral-400 py-6" style={{ fontSize: 10 }}>
               {hasSearched ? t("apps.dashboard.dictionary.noResults", "No results.") : t("apps.dashboard.dictionary.placeholder", "Type a word to look it up.")}
             </div>
           )}

--- a/src/components/layout/dashboard/WeatherWidget.tsx
+++ b/src/components/layout/dashboard/WeatherWidget.tsx
@@ -295,7 +295,7 @@ export function WeatherWidget({ widgetId }: WeatherWidgetProps) {
     if (loading)
       return (
         <div
-          className="flex items-center justify-center p-4 text-xs text-gray-500"
+          className="flex items-center justify-center p-4 text-xs text-neutral-500"
           style={{ minHeight: 120 }}
         >
           {t("apps.dashboard.weather.loading")}
@@ -317,7 +317,7 @@ export function WeatherWidget({ widgetId }: WeatherWidgetProps) {
           />
           <div>
             <div className="text-xl font-light">{weather.temperature}°</div>
-            <div className="text-[10px] text-gray-500">
+            <div className="text-[10px] text-neutral-500">
               {t("apps.dashboard.weather.high")} {weather.temperatureMax}° {t("apps.dashboard.weather.low")} {weather.temperatureMin}°
             </div>
           </div>

--- a/src/components/listen/JoinSessionDialog.tsx
+++ b/src/components/listen/JoinSessionDialog.tsx
@@ -165,12 +165,12 @@ export function JoinSessionDialog({
     <div className={isXpTheme ? "p-2 px-4" : "p-4 px-6"}>
       {/* Session List - Primary view */}
       <div className="mb-3">
-        <ScrollArea className="h-[160px] border border-gray-300 rounded-md overflow-hidden bg-white">
+        <ScrollArea className="h-[160px] border border-neutral-300 rounded-md overflow-hidden bg-white">
           <div>
             {isLoading ? (
               <div
                 className={cn(
-                  "flex items-center justify-center h-[140px] text-gray-500",
+                  "flex items-center justify-center h-[140px] text-neutral-500",
                   isXpTheme
                     ? "font-['Pixelated_MS_Sans_Serif',Arial] text-[11px]"
                     : "font-geneva-12 text-[12px]"
@@ -204,7 +204,7 @@ export function JoinSessionDialog({
             ) : sessions.length === 0 ? (
               <div
                 className={cn(
-                  "flex items-center justify-center h-[140px] text-gray-500",
+                  "flex items-center justify-center h-[140px] text-neutral-500",
                   isXpTheme
                     ? "font-['Pixelated_MS_Sans_Serif',Arial] text-[11px]"
                     : "font-geneva-12 text-[12px]"
@@ -237,7 +237,7 @@ export function JoinSessionDialog({
                     selectedIndex === index
                       ? ""
                       : index % 2 === 1
-                        ? "bg-gray-100"
+                        ? "bg-neutral-100"
                         : "bg-white",
                     isXpTheme
                       ? "font-['Pixelated_MS_Sans_Serif',Arial] text-[11px]"
@@ -290,7 +290,7 @@ export function JoinSessionDialog({
       {/* Manual Entry - Secondary option */}
       <p
         className={cn(
-          "text-gray-500 mb-2",
+          "text-neutral-500 mb-2",
           isXpTheme
             ? "font-['Pixelated_MS_Sans_Serif',Arial] text-[11px]"
             : "font-geneva-12 text-[12px]"

--- a/src/components/shared/CursorRepoAgentChatCard.tsx
+++ b/src/components/shared/CursorRepoAgentChatCard.tsx
@@ -116,7 +116,7 @@ export function CursorRepoAgentChatCard({
         }
         style={isPanel ? undefined : { boxShadow: "0 0 0 1px rgba(0, 0, 0, 0.3)" }}
       >
-        <div className="flex flex-shrink-0 items-center gap-3 border-b border-gray-300 bg-gray-100 px-3 py-2 dark:border-neutral-600 dark:bg-neutral-800/90">
+        <div className="flex flex-shrink-0 items-center gap-3 border-b border-neutral-300 bg-neutral-100 px-3 py-2 dark:border-neutral-600 dark:bg-neutral-800/90">
           <span className="relative inline-flex size-6 shrink-0 items-center justify-center" aria-hidden>
             <img
               src="/brands/cursor-cube-2d-light.svg"
@@ -144,7 +144,7 @@ export function CursorRepoAgentChatCard({
                 href={prUrl}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="inline-flex shrink-0 items-center gap-1 rounded border border-gray-300 bg-white/85 px-1.5 py-0.5 text-[10px] font-medium text-neutral-700 transition-colors hover:bg-gray-100 dark:border-neutral-600 dark:bg-neutral-900/70 dark:text-neutral-200 dark:hover:bg-neutral-800"
+                className="inline-flex shrink-0 items-center gap-1 rounded border border-neutral-300 bg-white/85 px-1.5 py-0.5 text-[10px] font-medium text-neutral-700 transition-colors hover:bg-neutral-100 dark:border-neutral-600 dark:bg-neutral-900/70 dark:text-neutral-200 dark:hover:bg-neutral-800"
                 title={prUrl}
                 aria-label={t("apps.chats.toolCalls.cursorCloudAgent.openPr")}
               >
@@ -171,8 +171,8 @@ export function CursorRepoAgentChatCard({
         <div
           className={
             isPanel
-              ? "flex min-h-0 flex-1 flex-col border-t border-gray-200 bg-neutral-50/50 dark:border-neutral-600 dark:bg-neutral-900/40"
-              : "border-t border-gray-200 bg-neutral-50/50 dark:border-neutral-600 dark:bg-neutral-900/40"
+              ? "flex min-h-0 flex-1 flex-col border-t border-neutral-200 bg-neutral-50/50 dark:border-neutral-600 dark:bg-neutral-900/40"
+              : "border-t border-neutral-200 bg-neutral-50/50 dark:border-neutral-600 dark:bg-neutral-900/40"
           }
         >
           {error ? (
@@ -258,8 +258,8 @@ export function CursorRepoAgentChatCard({
           <div
             className={
               isPanel
-                ? "shrink-0 border-t border-gray-200 bg-white/80 px-2 py-1.5 dark:border-neutral-700 dark:bg-neutral-900/60"
-                : "border-t border-gray-200 bg-white/80 px-2 py-1.5 dark:border-neutral-700 dark:bg-neutral-900/60"
+                ? "shrink-0 border-t border-neutral-200 bg-white/80 px-2 py-1.5 dark:border-neutral-700 dark:bg-neutral-900/60"
+                : "border-t border-neutral-200 bg-white/80 px-2 py-1.5 dark:border-neutral-700 dark:bg-neutral-900/60"
             }
           >
             {followupError ? (
@@ -297,7 +297,7 @@ export function CursorRepoAgentChatCard({
                 aria-label={t(
                   "apps.chats.toolCalls.cursorCloudAgent.followupAriaLabel"
                 )}
-                className="min-h-[26px] flex-1 resize-none rounded border border-gray-300 bg-white px-2 py-1 text-[12px] leading-snug text-neutral-900 placeholder:text-neutral-400 focus:outline-none focus:ring-1 focus:ring-blue-400 disabled:cursor-not-allowed disabled:bg-gray-100 disabled:text-neutral-500 dark:border-neutral-700 dark:bg-neutral-950 dark:text-neutral-100 dark:placeholder:text-neutral-500 dark:disabled:bg-neutral-900"
+                className="min-h-[26px] flex-1 resize-none rounded border border-neutral-300 bg-white px-2 py-1 text-[12px] leading-snug text-neutral-900 placeholder:text-neutral-400 focus:outline-none focus:ring-1 focus:ring-blue-400 disabled:cursor-not-allowed disabled:bg-neutral-100 disabled:text-neutral-500 dark:border-neutral-700 dark:bg-neutral-950 dark:text-neutral-100 dark:placeholder:text-neutral-500 dark:disabled:bg-neutral-900"
               />
               <button
                 type="submit"

--- a/src/components/shared/CursorRunEventView.tsx
+++ b/src/components/shared/CursorRunEventView.tsx
@@ -37,7 +37,7 @@ function isRecord(v: unknown): v is Record<string, unknown> {
 }
 
 const markdownStreamClass =
-  "cursor-stream-md px-1 py-0.5 font-geneva-12 text-[12px] leading-snug text-gray-700 break-words dark:text-neutral-200";
+  "cursor-stream-md px-1 py-0.5 font-geneva-12 text-[12px] leading-snug text-neutral-700 break-words dark:text-neutral-200";
 
 const toolDisplayNameOverrides: Record<string, string> = {
   run_terminal_cmd: "Run terminal command",
@@ -223,10 +223,10 @@ function CursorToolInvocationRow({
 }) {
   return (
     <div className="mb-0 px-1 py-0.5 text-[12px]">
-      <div className="flex min-w-0 flex-nowrap items-baseline gap-1 text-gray-700">
+      <div className="flex min-w-0 flex-nowrap items-baseline gap-1 text-neutral-700">
         <span className={`shrink-0 ${done ? "" : "shimmer"}`}>{primary}</span>
         {secondary ? (
-          <span className="min-w-0 truncate text-gray-500 dark:text-neutral-400">
+          <span className="min-w-0 truncate text-neutral-500 dark:text-neutral-400">
             {secondary}
           </span>
         ) : null}
@@ -323,7 +323,7 @@ function ThinkingCollapsible({ text }: { text: string }) {
     );
   }
   return (
-    <div className="mb-0 px-1 py-0.5 text-[12px] text-gray-500 dark:text-neutral-500">
+    <div className="mb-0 px-1 py-0.5 text-[12px] text-neutral-500 dark:text-neutral-500">
       <button
         type="button"
         onClick={() => setOpen((v) => !v)}

--- a/src/components/shared/HtmlPreview.tsx
+++ b/src/components/shared/HtmlPreview.tsx
@@ -1020,7 +1020,7 @@ export default function HtmlPreview({
         {/* Loading PULSE overlay (now breathing effect) */}
         {isStreaming && (
           <motion.div
-            className="absolute inset-0 bg-gray-300 z-10 pointer-events-none"
+            className="absolute inset-0 bg-neutral-300 z-10 pointer-events-none"
             initial={{ opacity: 0.2 }} // Start at lower opacity
             animate={{
               opacity: [0.2, 0.6, 0.2], // Loop between 0.6 and 1
@@ -1035,7 +1035,7 @@ export default function HtmlPreview({
 
         {/* Applet banner - similar to AppStore detail view */}
           {!isInternetExplorer && (appletTitle || appletIcon) && (
-            <div className="flex items-center gap-3 px-3 py-2 bg-gray-100 border-b border-gray-300 flex-shrink-0">
+            <div className="flex items-center gap-3 px-3 py-2 bg-neutral-100 border-b border-neutral-300 flex-shrink-0">
               <div
                 className="!text-2xl flex-shrink-0 applet-icon"
                 style={{ fontSize: "1.5rem" }}
@@ -1173,7 +1173,7 @@ export default function HtmlPreview({
               <pre
                 className={`p-2 text-[12px] ${
                   isMacOsXTheme ? "font-mono" : "font-monaco"
-                } antialiased text-gray-700 whitespace-pre-wrap break-words`}
+                } antialiased text-neutral-700 whitespace-pre-wrap break-words`}
               >
                 {htmlContent.split("\n").slice(-8).join("\n")}
               </pre>
@@ -1265,7 +1265,7 @@ export default function HtmlPreview({
                         exit={{ opacity: 0 }}
                         transition={{ duration: 0.25 }}
                       >
-                        <pre className="text-[12px] font-monaco text-gray-300 whitespace-pre-wrap break-words m-0">
+                        <pre className="text-[12px] font-monaco text-neutral-300 whitespace-pre-wrap break-words m-0">
                           {finalProcessedHtmlRef.current || processedHtmlContent}
                         </pre>
                       </motion.div>
@@ -1324,7 +1324,7 @@ export default function HtmlPreview({
                           <pre
                             className={`p-4 text-xs ${
                               isMacOsXTheme ? "font-sans" : "font-geneva-12"
-                            } text-gray-700 whitespace-pre-wrap break-words`}
+                            } text-neutral-700 whitespace-pre-wrap break-words`}
                           >
                             {htmlContent.split("\n").slice(-15).join("\n")}
                           </pre>
@@ -1362,11 +1362,11 @@ export default function HtmlPreview({
                     {/* Loading PULSE overlay for fullscreen (kept for visual feedback) */}
                     {isStreaming && htmlContent && (
                       <div
-                        className="absolute inset-0 bg-gray-100 z-10 pointer-events-none"
+                        className="absolute inset-0 bg-neutral-100 z-10 pointer-events-none"
                         style={{ opacity: 0.2 }}
                       >
                         <motion.div
-                          className="size-full bg-gray-400"
+                          className="size-full bg-neutral-400"
                           animate={{
                             opacity: [0.05, 0.2, 0.05],
                           }}

--- a/src/components/shared/ImageAttachment.tsx
+++ b/src/components/shared/ImageAttachment.tsx
@@ -39,8 +39,8 @@ export function ImageAttachment({
         className={cn(
           "relative overflow-hidden",
           isMacTheme
-            ? "chat-bubble macosx-link-preview rounded-[16px] bg-gray-100"
-            : "bg-white border border-gray-200 rounded"
+            ? "chat-bubble macosx-link-preview rounded-[16px] bg-neutral-100"
+            : "bg-white border border-neutral-200 rounded"
         )}
       >
         {/* Full bleed image for macOS */}

--- a/src/components/shared/LinkPreview.tsx
+++ b/src/components/shared/LinkPreview.tsx
@@ -345,9 +345,9 @@ export function LinkPreview({ url, className = "" }: LinkPreviewProps) {
         className={cn(
           "h-[106px] w-full min-w-[280px] max-w-[420px]",
           "relative overflow-hidden",
-          "border border-gray-200 rounded",
+          "border border-neutral-200 rounded",
           "before:absolute before:inset-0",
-          "before:bg-gradient-to-r before:from-gray-200 before:via-gray-100 before:to-gray-200",
+          "before:bg-gradient-to-r before:from-neutral-200 before:via-neutral-100 before:to-neutral-200",
           "before:animate-[shimmer_2s_linear_infinite]",
           "before:bg-[length:200%_100%]",
           className
@@ -466,8 +466,8 @@ export function LinkPreview({ url, className = "" }: LinkPreviewProps) {
       className={cn(
         "link-preview-container relative overflow-hidden cursor-pointer font-geneva-12 group max-w-[420px]",
         isMacOSTheme
-          ? "chat-bubble macosx-link-preview bg-gray-100 border-none shadow-none"
-          : "bg-white border border-gray-200 rounded",
+          ? "chat-bubble macosx-link-preview bg-neutral-100 border-none shadow-none"
+          : "bg-white border border-neutral-200 rounded",
         className
       )}
       onClick={handleClick}
@@ -483,7 +483,7 @@ export function LinkPreview({ url, className = "" }: LinkPreviewProps) {
         <>
           <div
             className={cn(
-              "relative aspect-video bg-gray-100 overflow-hidden",
+              "relative aspect-video bg-neutral-100 overflow-hidden",
               isMacOSTheme && "-mx-3 -mt-[6px] rounded-t-[14px]"
             )}
           >
@@ -512,7 +512,7 @@ export function LinkPreview({ url, className = "" }: LinkPreviewProps) {
                     );
                   }}
                 />
-                <div className="size-4 bg-gray-300 rounded-full flex-shrink-0 hidden"></div>
+                <div className="size-4 bg-neutral-300 rounded-full flex-shrink-0 hidden"></div>
                 {metadata.title && (
                   <h3 className="font-semibold text-white text-[10px] truncate">
                     {metadata.title}
@@ -526,14 +526,14 @@ export function LinkPreview({ url, className = "" }: LinkPreviewProps) {
           <div className="px-2 pb-2">
             {isYouTubeUrl(url) ? (
               url.includes("/ipod/") ? (
-                <div className="flex gap-2 pt-2 border-t border-gray-100">
+                <div className="flex gap-2 pt-2 border-t border-neutral-100">
                   <button
                     onClick={handleAddToIpod}
                     onTouchStart={(e) => e.stopPropagation()}
                     className={cn(
                       isMacOSTheme
                         ? "aqua-button secondary flex-1"
-                        : "flex items-center justify-center gap-1.5 px-3 py-2 text-[12px] bg-gray-100 hover:bg-gray-200 rounded-md transition-colors flex-1"
+                        : "flex items-center justify-center gap-1.5 px-3 py-2 text-[12px] bg-neutral-100 hover:bg-neutral-200 rounded-md transition-colors flex-1"
                     )}
                     title={t("components.linkPreview.openIpod")}
                     data-link-preview
@@ -547,7 +547,7 @@ export function LinkPreview({ url, className = "" }: LinkPreviewProps) {
                     className={cn(
                       isMacOSTheme
                         ? "aqua-button secondary flex-1"
-                        : "flex items-center justify-center gap-1.5 px-3 py-2 text-[12px] bg-gray-100 hover:bg-gray-200 rounded-md transition-colors flex-1"
+                        : "flex items-center justify-center gap-1.5 px-3 py-2 text-[12px] bg-neutral-100 hover:bg-neutral-200 rounded-md transition-colors flex-1"
                     )}
                     title={t("components.linkPreview.openYouTube")}
                     data-link-preview
@@ -557,14 +557,14 @@ export function LinkPreview({ url, className = "" }: LinkPreviewProps) {
                   </button>
                 </div>
               ) : url.includes("/karaoke/") ? (
-                <div className="flex gap-2 pt-2 border-t border-gray-100">
+                <div className="flex gap-2 pt-2 border-t border-neutral-100">
                   <button
                     onClick={handleOpenInKaraoke}
                     onTouchStart={(e) => e.stopPropagation()}
                     className={cn(
                       isMacOSTheme
                         ? "aqua-button secondary flex-1"
-                        : "flex items-center justify-center gap-1.5 px-3 py-2 text-[12px] bg-gray-100 hover:bg-gray-200 rounded-md transition-colors flex-1"
+                        : "flex items-center justify-center gap-1.5 px-3 py-2 text-[12px] bg-neutral-100 hover:bg-neutral-200 rounded-md transition-colors flex-1"
                     )}
                     title={t("components.linkPreview.openKaraoke")}
                     data-link-preview
@@ -578,7 +578,7 @@ export function LinkPreview({ url, className = "" }: LinkPreviewProps) {
                     className={cn(
                       isMacOSTheme
                         ? "aqua-button secondary flex-1"
-                        : "flex items-center justify-center gap-1.5 px-3 py-2 text-[12px] bg-gray-100 hover:bg-gray-200 rounded-md transition-colors flex-1"
+                        : "flex items-center justify-center gap-1.5 px-3 py-2 text-[12px] bg-neutral-100 hover:bg-neutral-200 rounded-md transition-colors flex-1"
                     )}
                     title={t("components.linkPreview.openYouTube")}
                     data-link-preview
@@ -588,14 +588,14 @@ export function LinkPreview({ url, className = "" }: LinkPreviewProps) {
                   </button>
                 </div>
               ) : (
-                <div className="flex gap-2 pt-2 border-t border-gray-100">
+                <div className="flex gap-2 pt-2 border-t border-neutral-100">
                   <button
                     onClick={handleAddToIpod}
                     onTouchStart={(e) => e.stopPropagation()}
                     className={cn(
                       isMacOSTheme
                         ? "aqua-button secondary flex-1"
-                        : "flex items-center justify-center gap-1.5 px-3 py-2 text-[12px] bg-gray-100 hover:bg-gray-200 rounded-md transition-colors flex-1"
+                        : "flex items-center justify-center gap-1.5 px-3 py-2 text-[12px] bg-neutral-100 hover:bg-neutral-200 rounded-md transition-colors flex-1"
                     )}
                     title={t("components.linkPreview.addToIpod")}
                     data-link-preview
@@ -609,7 +609,7 @@ export function LinkPreview({ url, className = "" }: LinkPreviewProps) {
                     className={cn(
                       isMacOSTheme
                         ? "aqua-button secondary flex-1"
-                        : "flex items-center justify-center gap-1.5 px-3 py-2 text-[12px] bg-gray-100 hover:bg-gray-200 rounded-md transition-colors flex-1"
+                        : "flex items-center justify-center gap-1.5 px-3 py-2 text-[12px] bg-neutral-100 hover:bg-neutral-200 rounded-md transition-colors flex-1"
                     )}
                     title={t("components.linkPreview.openYouTube")}
                     data-link-preview
@@ -620,14 +620,14 @@ export function LinkPreview({ url, className = "" }: LinkPreviewProps) {
                 </div>
               )
             ) : (
-              <div className="flex gap-2 pt-2 border-t border-gray-100">
+              <div className="flex gap-2 pt-2 border-t border-neutral-100">
                 <button
                   onClick={handleOpenExternally}
                   onTouchStart={(e) => e.stopPropagation()}
                   className={cn(
                     isMacOSTheme
                       ? "aqua-button secondary w-full"
-                      : "flex items-center justify-center gap-1.5 px-3 py-2 text-[12px] bg-gray-100 hover:bg-gray-200 rounded-md transition-colors w-full"
+                      : "flex items-center justify-center gap-1.5 px-3 py-2 text-[12px] bg-neutral-100 hover:bg-neutral-200 rounded-md transition-colors w-full"
                   )}
                   title="Open Externally"
                   data-link-preview
@@ -646,7 +646,7 @@ export function LinkPreview({ url, className = "" }: LinkPreviewProps) {
             {metadata.image && (
               <div
                 className={cn(
-                  "size-18 bg-gray-100 relative overflow-hidden flex-shrink-0",
+                  "size-18 bg-neutral-100 relative overflow-hidden flex-shrink-0",
                   isMacOSTheme && "hidden"
                 )}
               >
@@ -683,7 +683,7 @@ export function LinkPreview({ url, className = "" }: LinkPreviewProps) {
             >
               {metadata.title && (
                 <h3
-                  className="font-semibold text-gray-900 text-[10px]"
+                  className="font-semibold text-neutral-900 text-[10px]"
                   style={{
                     display: "-webkit-box",
                     WebkitLineClamp: 1,
@@ -725,8 +725,8 @@ export function LinkPreview({ url, className = "" }: LinkPreviewProps) {
                       );
                     }}
                   />
-                  <div className="size-4 bg-gray-300 rounded-full flex-shrink-0 hidden"></div>
-                  <p className="text-[10px] text-gray-500 truncate">
+                  <div className="size-4 bg-neutral-300 rounded-full flex-shrink-0 hidden"></div>
+                  <p className="text-[10px] text-neutral-500 truncate">
                     {metadata.siteName || new URL(url).hostname}
                   </p>
                 </div>
@@ -738,8 +738,8 @@ export function LinkPreview({ url, className = "" }: LinkPreviewProps) {
           <div className={cn(
             "pb-2 border-t",
             isMacOSTheme 
-              ? "border-gray-300" 
-              : "border-gray-200"
+              ? "border-neutral-300" 
+              : "border-neutral-200"
           )}>
             <div className="px-2 pt-2">
               {isYouTubeUrl(url) ? (
@@ -751,7 +751,7 @@ export function LinkPreview({ url, className = "" }: LinkPreviewProps) {
                       className={cn(
                         isMacOSTheme
                           ? "aqua-button secondary flex-1"
-                          : "flex items-center justify-center gap-1.5 px-3 py-2 text-[12px] bg-gray-100 hover:bg-gray-200 rounded-md transition-colors flex-1"
+                          : "flex items-center justify-center gap-1.5 px-3 py-2 text-[12px] bg-neutral-100 hover:bg-neutral-200 rounded-md transition-colors flex-1"
                       )}
                       title={t("components.linkPreview.openIpod")}
                       data-link-preview
@@ -765,7 +765,7 @@ export function LinkPreview({ url, className = "" }: LinkPreviewProps) {
                       className={cn(
                         isMacOSTheme
                           ? "aqua-button secondary flex-1"
-                          : "flex items-center justify-center gap-1.5 px-3 py-2 text-[12px] bg-gray-100 hover:bg-gray-200 rounded-md transition-colors flex-1"
+                          : "flex items-center justify-center gap-1.5 px-3 py-2 text-[12px] bg-neutral-100 hover:bg-neutral-200 rounded-md transition-colors flex-1"
                       )}
                       title={t("components.linkPreview.openYouTube")}
                       data-link-preview
@@ -784,7 +784,7 @@ export function LinkPreview({ url, className = "" }: LinkPreviewProps) {
                       className={cn(
                         isMacOSTheme
                           ? "aqua-button secondary flex-1"
-                          : "flex items-center justify-center gap-1.5 px-3 py-2 text-[12px] bg-gray-100 hover:bg-gray-200 rounded-md transition-colors flex-1"
+                          : "flex items-center justify-center gap-1.5 px-3 py-2 text-[12px] bg-neutral-100 hover:bg-neutral-200 rounded-md transition-colors flex-1"
                       )}
                       title={t("components.linkPreview.openKaraoke")}
                       data-link-preview
@@ -798,7 +798,7 @@ export function LinkPreview({ url, className = "" }: LinkPreviewProps) {
                       className={cn(
                         isMacOSTheme
                           ? "aqua-button secondary flex-1"
-                          : "flex items-center justify-center gap-1.5 px-3 py-2 text-[12px] bg-gray-100 hover:bg-gray-200 rounded-md transition-colors flex-1"
+                          : "flex items-center justify-center gap-1.5 px-3 py-2 text-[12px] bg-neutral-100 hover:bg-neutral-200 rounded-md transition-colors flex-1"
                       )}
                       title={t("components.linkPreview.openYouTube")}
                       data-link-preview
@@ -817,7 +817,7 @@ export function LinkPreview({ url, className = "" }: LinkPreviewProps) {
                       className={cn(
                         isMacOSTheme
                           ? "aqua-button secondary flex-1"
-                          : "flex items-center justify-center gap-1.5 px-3 py-2 text-[12px] bg-gray-100 hover:bg-gray-200 rounded-md transition-colors flex-1"
+                          : "flex items-center justify-center gap-1.5 px-3 py-2 text-[12px] bg-neutral-100 hover:bg-neutral-200 rounded-md transition-colors flex-1"
                       )}
                       title={t("components.linkPreview.addToIpod")}
                       data-link-preview
@@ -831,7 +831,7 @@ export function LinkPreview({ url, className = "" }: LinkPreviewProps) {
                       className={cn(
                         isMacOSTheme
                           ? "aqua-button secondary flex-1"
-                          : "flex items-center justify-center gap-1.5 px-3 py-2 text-[12px] bg-gray-100 hover:bg-gray-200 rounded-md transition-colors flex-1"
+                          : "flex items-center justify-center gap-1.5 px-3 py-2 text-[12px] bg-neutral-100 hover:bg-neutral-200 rounded-md transition-colors flex-1"
                       )}
                       title={t("components.linkPreview.openYouTube")}
                       data-link-preview
@@ -851,7 +851,7 @@ export function LinkPreview({ url, className = "" }: LinkPreviewProps) {
                     className={cn(
                       isMacOSTheme
                         ? "aqua-button secondary w-full"
-                        : "flex items-center justify-center gap-1.5 px-3 py-2 text-[12px] bg-gray-100 hover:bg-gray-200 rounded-md transition-colors w-full"
+                        : "flex items-center justify-center gap-1.5 px-3 py-2 text-[12px] bg-neutral-100 hover:bg-neutral-200 rounded-md transition-colors w-full"
                     )}
                     title="Open Externally"
                     data-link-preview

--- a/src/components/shared/ToolInvocationMessage.tsx
+++ b/src/components/shared/ToolInvocationMessage.tsx
@@ -776,7 +776,7 @@ export function ToolInvocationMessage({
         <div key={partKey} className="mb-0 px-1 py-0.5 text-[12px]">
           <ToolInvocationStatusRow
             icon={<Check className="size-3 text-blue-600" weight="bold" />}
-            className="text-gray-700"
+            className="text-neutral-700"
             align="start"
           >
             <span>
@@ -899,7 +899,7 @@ export function ToolInvocationMessage({
       return (
         <div key={partKey} className="mb-0 px-1 py-0.5 italic text-[12px]">
           <ToolInvocationStatusRow
-            icon={<ActivityIndicator size="xs" className="text-gray-500" />}
+            icon={<ActivityIndicator size="xs" className="text-neutral-500" />}
             className="text-neutral-600"
           >
             <span className="shimmer">
@@ -929,8 +929,8 @@ export function ToolInvocationMessage({
       return (
         <div key={partKey} className="mb-0 px-1 py-0.5 italic text-[12px]">
           <ToolInvocationStatusRow
-            icon={<ActivityIndicator size="xs" className="text-gray-500" />}
-            className="text-gray-500"
+            icon={<ActivityIndicator size="xs" className="text-neutral-500" />}
+            className="text-neutral-500"
           >
             <span>{t("apps.chats.toolCalls.preparingHtmlPreview")}</span>
           </ToolInvocationStatusRow>
@@ -949,8 +949,8 @@ export function ToolInvocationMessage({
       {(state === "input-streaming" || state === "input-available") &&
         !output && (
           <ToolInvocationStatusRow
-            icon={<ActivityIndicator size="xs" className="text-gray-500" />}
-            className="text-gray-700"
+            icon={<ActivityIndicator size="xs" className="text-neutral-500" />}
+            className="text-neutral-700"
           >
             {displayCallMessage ? (
               <span className="shimmer">{displayCallMessage}</span>
@@ -966,7 +966,7 @@ export function ToolInvocationMessage({
       {state === "output-available" && (
         <ToolInvocationStatusRow
           icon={<Check className="size-3 text-blue-600" weight="bold" />}
-          className="text-gray-700"
+          className="text-neutral-700"
           align="start"
         >
           {displayResultMessage ? (
@@ -974,7 +974,7 @@ export function ToolInvocationMessage({
           ) : (
             <div className="flex flex-col">
               {typeof output === "string" && output.length > 0 ? (
-                <span className="text-gray-500">{output}</span>
+                <span className="text-neutral-500">{output}</span>
               ) : (
                 <span>{formatToolName(toolName)}</span>
               )}

--- a/src/components/ui/SwipeInstructions.tsx
+++ b/src/components/ui/SwipeInstructions.tsx
@@ -92,7 +92,7 @@ export function SwipeInstructions({ className }: SwipeInstructionsProps) {
         <h3 className="font-bold text-lg">{t("common.swipeInstructions.title")}</h3>
         <button
           onClick={handleDismiss}
-          className="bg-transparent p-1 rounded-full hover:bg-gray-100"
+          className="bg-transparent p-1 rounded-full hover:bg-neutral-100"
         >
           <X size={18} weight="bold" />
         </button>
@@ -101,7 +101,7 @@ export function SwipeInstructions({ className }: SwipeInstructionsProps) {
       <div className="mt-2 flex items-center justify-center space-x-8 py-4">
         <div className="flex flex-col items-center">
           <div className="relative size-16 flex items-center justify-center">
-            <div className="absolute border-2 border-black rounded-md size-12 bg-gray-100" />
+            <div className="absolute border-2 border-black rounded-md size-12 bg-neutral-100" />
             <svg
               width="24"
               height="24"
@@ -123,7 +123,7 @@ export function SwipeInstructions({ className }: SwipeInstructionsProps) {
 
         <div className="flex flex-col items-center">
           <div className="relative size-16 flex items-center justify-center">
-            <div className="absolute border-2 border-black rounded-md size-12 bg-gray-100" />
+            <div className="absolute border-2 border-black rounded-md size-12 bg-neutral-100" />
             <svg
               width="24"
               height="24"
@@ -144,7 +144,7 @@ export function SwipeInstructions({ className }: SwipeInstructionsProps) {
         </div>
       </div>
 
-      <p className="text-xs text-gray-500 mt-2 text-center">
+      <p className="text-xs text-neutral-500 mt-2 text-center">
         {t("common.swipeInstructions.description")}
       </p>
     </div>

--- a/src/components/ui/dial.tsx
+++ b/src/components/ui/dial.tsx
@@ -162,7 +162,7 @@ const Dial = (
           onMouseDown={handleValueMouseDown}
           onTouchStart={handleValueTouchStart}
         >
-          <div className="text-[10px] text-gray-400">{label}</div>
+          <div className="text-[10px] text-neutral-400">{label}</div>
           {showValue && (
             <div className="text-xs">{valueFormatter(value)}</div>
           )}

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -242,7 +242,7 @@ const DialogHeader = ({
       <DialogPrimitive.Close asChild>
         <div className="relative ml-2 size-4 cursor-default select-none">
           <div className="absolute inset-0 -m-2" />
-          <div className="size-4 bg-os-button-face shadow-[0_0_0_1px_var(--os-color-button-face)] border-2 border-os-window hover:bg-gray-200 active:bg-gray-300 flex items-center justify-center" />
+          <div className="size-4 bg-os-button-face shadow-[0_0_0_1px_var(--os-color-button-face)] border-2 border-os-window hover:bg-neutral-200 active:bg-neutral-300 flex items-center justify-center" />
         </div>
       </DialogPrimitive.Close>
       <div className="select-none mx-auto bg-os-button-face px-2 py-0 h-full flex items-center justify-center text-os-titlebar-active-text">

--- a/src/components/ui/right-click-menu.tsx
+++ b/src/components/ui/right-click-menu.tsx
@@ -55,7 +55,7 @@ interface RightClickMenuProps {
 }
 
 export const menuItemClass =
-  "text-md h-6 px-3 active:bg-gray-900 active:text-white min-w-[140px] flex items-center gap-2";
+  "text-md h-6 px-3 active:bg-neutral-900 active:text-white min-w-[140px] flex items-center gap-2";
 
 const menuItemKeyCache = new WeakMap<object, string>();
 let menuItemKeySeed = 0;

--- a/src/components/ui/search-input.tsx
+++ b/src/components/ui/search-input.tsx
@@ -33,7 +33,7 @@ export function SearchInput({
         size={13}
         weight="bold"
         className={cn(
-          "pointer-events-none absolute left-2 top-1/2 -translate-y-1/2",
+          "pointer-events-none absolute left-2 top-1/2 -translate-y-1/2 os-search-icon",
           isMacOSTheme ? "text-black/45" : "text-black/35"
         )}
       />
@@ -44,6 +44,7 @@ export function SearchInput({
         onKeyDown={onKeyDown}
         aria-label={ariaLabel}
         placeholder={placeholder}
+        data-os-search-input="true"
         className={cn(
           "w-full outline-none min-w-0",
           isMacOSTheme
@@ -57,7 +58,7 @@ export function SearchInput({
           onMouseDown={(e) => e.preventDefault()}
           onClick={() => onChange("")}
           className={cn(
-            "absolute right-1.5 top-1/2 flex -translate-y-1/2 items-center justify-center",
+            "absolute right-1.5 top-1/2 flex -translate-y-1/2 items-center justify-center os-search-clear",
             isMacOSTheme
               ? "text-black/40 hover:text-black/60"
               : "text-black/35 hover:text-black/55"

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -258,7 +258,7 @@ const SelectItemWithDescription = (
       <div className="flex flex-col gap-0.5">
         <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
         {description && (
-          <span className="text-[11px] text-gray-500 group-focus:text-inherit font-normal leading-tight">
+          <span className="text-[11px] text-neutral-500 group-focus:text-inherit font-normal leading-tight">
             {description}
           </span>
         )}

--- a/src/components/ui/volume-bar.tsx
+++ b/src/components/ui/volume-bar.tsx
@@ -11,7 +11,7 @@ export function VolumeBar({ volume, className = "" }: VolumeBarProps) {
 
   return (
     <div
-      className={`h-1 bg-gray-200 rounded-full overflow-hidden ${className}`}
+      className={`h-1 bg-neutral-200 rounded-full overflow-hidden ${className}`}
     >
       <motion.div
         className="h-full bg-black rounded-full"

--- a/src/hooks/useThemeFlags.ts
+++ b/src/hooks/useThemeFlags.ts
@@ -5,6 +5,7 @@ import type { OsMacChrome, OsPlatform } from "@/themes/types";
 
 export function useThemeFlags() {
   const currentTheme = useThemeStore((state) => state.current);
+  const isDark = useThemeStore((state) => state.isDark);
   const metadata = useMemo(() => getThemeMetadata(currentTheme), [currentTheme]);
   const osPlatform: OsPlatform = getOsPlatform(currentTheme);
   const macChrome: OsMacChrome | null = getOsMacChrome(currentTheme);
@@ -19,6 +20,9 @@ export function useThemeFlags() {
   const isClassicTheme = isXpTheme || isSystem7Theme;
   /** Menu / menubar styling for Mac OS X Aqua only (not System 7). */
   const isAquaMenuChrome = isMacOSTheme;
+  const supportsDarkMode = metadata.supportsDarkMode;
+  /** True only when dark mode is both supported by the active theme AND enabled. */
+  const isDarkMode = supportsDarkMode && isDark;
 
   return {
     currentTheme,
@@ -35,5 +39,7 @@ export function useThemeFlags() {
     isXpTheme,
     isClassicTheme,
     isAquaMenuChrome,
+    supportsDarkMode,
+    isDarkMode,
   };
 }

--- a/src/lib/locales/de/translation.json
+++ b/src/lib/locales/de/translation.json
@@ -1319,6 +1319,8 @@
       "crashDesktop": "Desktop abstürzen",
       "crt": "CRT",
       "custom": "Benutzerdefiniert",
+      "darkMode": "Dunkelmodus",
+      "darkModeDescription": "Die dunkle Variante des aktuellen Designs verwenden",
       "debugMode": "Debug-Modus",
       "debugModeDescription": "Debugging-Einstellungen aktivieren",
       "default": "Standard",
@@ -2319,6 +2321,7 @@
         "albums": "Alben",
         "all": "Alle",
         "allSongs": "Alle Lieder",
+        "alwaysOn": "Eingeschaltet lassen",
         "appleMusicSignIn": "Apple Music",
         "appleMusicSignOut": "Apple Music",
         "artists": "Interpreten",
@@ -2478,6 +2481,8 @@
           "title": "Mit iPod geteilt"
         }
       },
+      "ktvRoomFx": "Publikumsreaktionen",
+      "ktvRoomFxHint": "Schwebende Publikumsreaktionen im Vollbild umschalten",
       "liveListen": {
         "activeSessions": "Aktive KTV-Räume",
         "anonymous": "{{count}} anonym",
@@ -2540,9 +2545,7 @@
         "view": "Ansicht"
       },
       "name": "Karaoke",
-      "noTrack": "Kein Titel geladen. Öffne den iPod, um einen Titel auszuwählen.",
-      "ktvRoomFx": "Publikumsreaktionen",
-      "ktvRoomFxHint": "Schwebende Publikumsreaktionen im Vollbild umschalten"
+      "noTrack": "Kein Titel geladen. Öffne den iPod, um einen Titel auszuwählen."
     },
     "maps": {
       "description": "Orte mit Apple Karten finden",

--- a/src/lib/locales/en/translation.json
+++ b/src/lib/locales/en/translation.json
@@ -2823,6 +2823,8 @@
       "system": "System",
       "theme": "Theme",
       "themeDescription": "Changes the appearance of windows, menus, and controls",
+      "darkMode": "Dark Mode",
+      "darkModeDescription": "Use the dark variant of the current theme",
       "select": "Select",
       "uiSounds": "UI Sounds",
       "terminalIeAmbientSynth": "Synth",

--- a/src/lib/locales/es/translation.json
+++ b/src/lib/locales/es/translation.json
@@ -1319,6 +1319,8 @@
       "crashDesktop": "Bloquear escritorio",
       "crt": "CRT",
       "custom": "Personalizado",
+      "darkMode": "Modo oscuro",
+      "darkModeDescription": "Usar la variante oscura del tema actual",
       "debugMode": "Modo de depuración",
       "debugModeDescription": "Habilitar ajustes de depuración",
       "default": "Predeterminado",
@@ -2319,6 +2321,7 @@
         "albums": "Álbumes",
         "all": "Todas",
         "allSongs": "Todas las canciones",
+        "alwaysOn": "Mantener activado",
         "appleMusicSignIn": "Apple Music",
         "appleMusicSignOut": "Apple Music",
         "artists": "Artistas",
@@ -2478,6 +2481,8 @@
           "title": "Compartido con iPod"
         }
       },
+      "ktvRoomFx": "Reacciones del público",
+      "ktvRoomFxHint": "Activa las reacciones flotantes del público en pantalla completa",
       "liveListen": {
         "activeSessions": "Salas KTV activas",
         "anonymous": "{{count}} anónimos",
@@ -2540,9 +2545,7 @@
         "view": "Ver"
       },
       "name": "Karaoke",
-      "noTrack": "No hay pista cargada. Abre el iPod para seleccionar una canción.",
-      "ktvRoomFx": "Reacciones del público",
-      "ktvRoomFxHint": "Activa las reacciones flotantes del público en pantalla completa"
+      "noTrack": "No hay pista cargada. Abre el iPod para seleccionar una canción."
     },
     "maps": {
       "description": "Busca lugares con Apple Maps",

--- a/src/lib/locales/fr/translation.json
+++ b/src/lib/locales/fr/translation.json
@@ -1319,6 +1319,8 @@
       "crashDesktop": "Planter le bureau",
       "crt": "CRT",
       "custom": "Personnalisé",
+      "darkMode": "Mode sombre",
+      "darkModeDescription": "Utiliser la variante sombre du thème actuel",
       "debugMode": "Mode débogage",
       "debugModeDescription": "Activer les réglages de débogage",
       "default": "Par défaut",
@@ -2319,6 +2321,7 @@
         "albums": "Albums",
         "all": "Tout",
         "allSongs": "Toutes les chansons",
+        "alwaysOn": "Maintenir activé",
         "appleMusicSignIn": "Apple Music",
         "appleMusicSignOut": "Apple Music",
         "artists": "Artistes",
@@ -2478,6 +2481,8 @@
           "title": "Partagé avec l'iPod"
         }
       },
+      "ktvRoomFx": "Réactions du public",
+      "ktvRoomFxHint": "Activer les réactions du public flottantes en karaoké plein écran",
       "liveListen": {
         "activeSessions": "Salles KTV actives",
         "anonymous": "{{count}} anonymes",
@@ -2540,9 +2545,7 @@
         "view": "Affichage"
       },
       "name": "Karaoké",
-      "noTrack": "Aucun morceau n'est chargé. Ouvrez l'iPod pour sélectionner un morceau.",
-      "ktvRoomFx": "Réactions du public",
-      "ktvRoomFxHint": "Activer les réactions du public flottantes en karaoké plein écran"
+      "noTrack": "Aucun morceau n'est chargé. Ouvrez l'iPod pour sélectionner un morceau."
     },
     "maps": {
       "description": "Trouvez des lieux avec Apple Maps",

--- a/src/lib/locales/it/translation.json
+++ b/src/lib/locales/it/translation.json
@@ -1319,6 +1319,8 @@
       "crashDesktop": "Arresta desktop",
       "crt": "CRT",
       "custom": "Personalizzato",
+      "darkMode": "Modalità scura",
+      "darkModeDescription": "Usa la variante scura del tema attuale",
       "debugMode": "Modalità Debug",
       "debugModeDescription": "Abilita impostazioni di debug",
       "default": "Predefinito",
@@ -2319,6 +2321,7 @@
         "albums": "Album",
         "all": "Tutti",
         "allSongs": "Tutti i brani",
+        "alwaysOn": "Mantieni attivo",
         "appleMusicSignIn": "Apple Music",
         "appleMusicSignOut": "Apple Music",
         "artists": "Artisti",
@@ -2478,6 +2481,8 @@
           "title": "Condiviso con iPod"
         }
       },
+      "ktvRoomFx": "Reazioni del pubblico",
+      "ktvRoomFxHint": "Attiva le reazioni del pubblico fluttuanti a schermo intero",
       "liveListen": {
         "activeSessions": "Sale KTV attive",
         "anonymous": "{{count}} anonimi",
@@ -2540,9 +2545,7 @@
         "view": "Visualizza"
       },
       "name": "Karaoke",
-      "noTrack": "Nessun brano caricato. Apri iPod per selezionare un brano.",
-      "ktvRoomFx": "Reazioni del pubblico",
-      "ktvRoomFxHint": "Attiva le reazioni del pubblico fluttuanti a schermo intero"
+      "noTrack": "Nessun brano caricato. Apri iPod per selezionare un brano."
     },
     "maps": {
       "description": "Trova luoghi con Mappe Apple",

--- a/src/lib/locales/ja/translation.json
+++ b/src/lib/locales/ja/translation.json
@@ -1319,6 +1319,8 @@
       "crashDesktop": "デスクトップをクラッシュ",
       "crt": "CRT",
       "custom": "カスタム",
+      "darkMode": "ダークモード",
+      "darkModeDescription": "現在のテーマのダークバリアントを使用する",
       "debugMode": "デバッグモード",
       "debugModeDescription": "デバッグ設定を有効にする",
       "default": "デフォルト",
@@ -2319,6 +2321,7 @@
         "albums": "アルバム",
         "all": "すべて",
         "allSongs": "すべての曲",
+        "alwaysOn": "オンのままにする",
         "appleMusicSignIn": "Apple Music",
         "appleMusicSignOut": "Apple Music",
         "artists": "アーティスト",
@@ -2478,6 +2481,8 @@
           "title": "iPodと共有"
         }
       },
+      "ktvRoomFx": "観客のリアクション",
+      "ktvRoomFxHint": "全画面カラオケの観客リアクション効果を切り替え",
       "liveListen": {
         "activeSessions": "アクティブなカラオケルーム",
         "anonymous": "{{count}} 匿名",
@@ -2540,9 +2545,7 @@
         "view": "表示"
       },
       "name": "カラオケ",
-      "noTrack": "トラックが読み込まれていません。曲を選択するにはiPodを開いてください。",
-      "ktvRoomFx": "観客のリアクション",
-      "ktvRoomFxHint": "全画面カラオケの観客リアクション効果を切り替え"
+      "noTrack": "トラックが読み込まれていません。曲を選択するにはiPodを開いてください。"
     },
     "maps": {
       "description": "Apple マップで場所を検索",

--- a/src/lib/locales/ko/translation.json
+++ b/src/lib/locales/ko/translation.json
@@ -1319,6 +1319,8 @@
       "crashDesktop": "데스크톱 충돌",
       "crt": "CRT",
       "custom": "사용자 설정",
+      "darkMode": "다크 모드",
+      "darkModeDescription": "현재 테마의 어두운 버전을 사용합니다",
       "debugMode": "디버그 모드",
       "debugModeDescription": "디버깅 설정을 활성화합니다.",
       "default": "기본값",
@@ -2319,6 +2321,7 @@
         "albums": "앨범",
         "all": "모두",
         "allSongs": "모든 노래",
+        "alwaysOn": "켜짐 유지",
         "appleMusicSignIn": "Apple Music",
         "appleMusicSignOut": "Apple Music",
         "artists": "아티스트",
@@ -2478,6 +2481,8 @@
           "title": "iPod과 공유됨"
         }
       },
+      "ktvRoomFx": "관중 반응",
+      "ktvRoomFxHint": "전체 화면 노래방에서 플로팅 관중 반응 표시 전환",
       "liveListen": {
         "activeSessions": "활성 노래방",
         "anonymous": "{{count}}명 익명",
@@ -2540,9 +2545,7 @@
         "view": "보기"
       },
       "name": "노래방",
-      "noTrack": "로드된 트랙이 없습니다. iPod을 열어 곡을 선택하세요.",
-      "ktvRoomFx": "관중 반응",
-      "ktvRoomFxHint": "전체 화면 노래방에서 플로팅 관중 반응 표시 전환"
+      "noTrack": "로드된 트랙이 없습니다. iPod을 열어 곡을 선택하세요."
     },
     "maps": {
       "description": "Apple 지도로 장소 찾기",

--- a/src/lib/locales/pt/translation.json
+++ b/src/lib/locales/pt/translation.json
@@ -1319,6 +1319,8 @@
       "crashDesktop": "Travar Desktop",
       "crt": "CRT",
       "custom": "Personalizado",
+      "darkMode": "Modo Escuro",
+      "darkModeDescription": "Usar a variante escura do tema atual",
       "debugMode": "Modo Depuração",
       "debugModeDescription": "Ativar configurações de depuração",
       "default": "Padrão",
@@ -2319,6 +2321,7 @@
         "albums": "Álbuns",
         "all": "Todas",
         "allSongs": "Todas as Músicas",
+        "alwaysOn": "Manter Ativado",
         "appleMusicSignIn": "Apple Music",
         "appleMusicSignOut": "Apple Music",
         "artists": "Artistas",
@@ -2478,6 +2481,8 @@
           "title": "Compartilhado com iPod"
         }
       },
+      "ktvRoomFx": "Reações da plateia",
+      "ktvRoomFxHint": "Ativar reações flutuantes da plateia em tela cheia",
       "liveListen": {
         "activeSessions": "Salas KTV ativas",
         "anonymous": "{{count}} anónimos",
@@ -2540,9 +2545,7 @@
         "view": "Ver"
       },
       "name": "Karaoke",
-      "noTrack": "Nenhuma faixa carregada. Abra o iPod para selecionar uma música.",
-      "ktvRoomFx": "Reações da plateia",
-      "ktvRoomFxHint": "Ativar reações flutuantes da plateia em tela cheia"
+      "noTrack": "Nenhuma faixa carregada. Abra o iPod para selecionar uma música."
     },
     "maps": {
       "description": "Encontre lugares com o Apple Mapas",

--- a/src/lib/locales/ru/translation.json
+++ b/src/lib/locales/ru/translation.json
@@ -1319,6 +1319,8 @@
       "crashDesktop": "Сбой рабочего стола",
       "crt": "ЭЛТ",
       "custom": "Пользовательский",
+      "darkMode": "Тёмный режим",
+      "darkModeDescription": "Использовать тёмный вариант текущей темы",
       "debugMode": "Режим отладки",
       "debugModeDescription": "Включить параметры отладки",
       "default": "По умолчанию",
@@ -2319,6 +2321,7 @@
         "albums": "Альбомы",
         "all": "Все",
         "allSongs": "Все песни",
+        "alwaysOn": "Оставить включённым",
         "appleMusicSignIn": "Apple Music",
         "appleMusicSignOut": "Apple Music",
         "artists": "Артисты",
@@ -2478,6 +2481,8 @@
           "title": "Общий доступ с iPod"
         }
       },
+      "ktvRoomFx": "Реакции зала",
+      "ktvRoomFxHint": "Плавающие реакции зала в полноэкранном караоке",
       "liveListen": {
         "activeSessions": "Активные караоке-комнаты",
         "anonymous": "{{count}} анонимов",
@@ -2540,9 +2545,7 @@
         "view": "Вид"
       },
       "name": "Караоке",
-      "noTrack": "Трек не загружен. Откройте iPod, чтобы выбрать песню.",
-      "ktvRoomFx": "Реакции зала",
-      "ktvRoomFxHint": "Плавающие реакции зала в полноэкранном караоке"
+      "noTrack": "Трек не загружен. Откройте iPod, чтобы выбрать песню."
     },
     "maps": {
       "description": "Ищите места в Apple Maps",

--- a/src/lib/locales/zh-TW/translation.json
+++ b/src/lib/locales/zh-TW/translation.json
@@ -1319,6 +1319,8 @@
       "crashDesktop": "桌面崩潰",
       "crt": "CRT",
       "custom": "自訂",
+      "darkMode": "深色模式",
+      "darkModeDescription": "使用目前主題的深色版本",
       "debugMode": "偵錯模式",
       "debugModeDescription": "啟用偵錯設定",
       "default": "預設",
@@ -2319,6 +2321,7 @@
         "albums": "專輯",
         "all": "全部",
         "allSongs": "所有歌曲",
+        "alwaysOn": "保持開啟",
         "appleMusicSignIn": "Apple Music",
         "appleMusicSignOut": "Apple Music",
         "artists": "演出者",
@@ -2478,6 +2481,8 @@
           "title": "與 iPod 共享"
         }
       },
+      "ktvRoomFx": "觀眾反應",
+      "ktvRoomFxHint": "切換全螢幕卡拉 OK 漂浮觀眾反應",
       "liveListen": {
         "activeSessions": "進行中的包房",
         "anonymous": "{{count}} 位匿名使用者",
@@ -2540,9 +2545,7 @@
         "view": "檢視"
       },
       "name": "卡拉 OK",
-      "noTrack": "未載入任何曲目。開啟 iPod 以選取歌曲。",
-      "ktvRoomFx": "觀眾反應",
-      "ktvRoomFxHint": "切換全螢幕卡拉 OK 漂浮觀眾反應"
+      "noTrack": "未載入任何曲目。開啟 iPod 以選取歌曲。"
     },
     "maps": {
       "description": "使用 Apple 地圖尋找地點",

--- a/src/stores/useThemeStore.ts
+++ b/src/stores/useThemeStore.ts
@@ -1,5 +1,10 @@
 import { create } from "zustand";
-import { getOsMacChrome, getOsPlatform, themes } from "@/themes";
+import {
+  getOsMacChrome,
+  getOsPlatform,
+  themes,
+  themeSupportsDarkMode,
+} from "@/themes";
 import type { OsThemeId } from "@/themes/types";
 import { SETTINGS_ANALYTICS, track } from "@/utils/analytics";
 
@@ -10,9 +15,43 @@ function sanitizeStoredTheme(id: string | null | undefined): OsThemeId {
   return "macosx";
 }
 
+/** Per-theme dark-mode preference (only honored when the theme supports it). */
+type DarkModeMap = Partial<Record<OsThemeId, boolean>>;
+
+function safeReadDarkModeMap(): DarkModeMap {
+  try {
+    const raw = localStorage.getItem(DARK_MODE_KEY);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object") return {};
+    const out: DarkModeMap = {};
+    for (const id of Object.keys(themes) as OsThemeId[]) {
+      const v = (parsed as Record<string, unknown>)[id];
+      if (typeof v === "boolean") out[id] = v;
+    }
+    return out;
+  } catch {
+    return {};
+  }
+}
+
+function writeDarkModeMap(map: DarkModeMap) {
+  try {
+    localStorage.setItem(DARK_MODE_KEY, JSON.stringify(map));
+  } catch {
+    // ignore quota / private-mode errors
+  }
+}
+
 interface ThemeState {
   current: OsThemeId;
+  /** Effective dark-mode flag for the active theme (false if the theme has no dark tokens). */
+  isDark: boolean;
+  /** Per-theme dark-mode preferences; persisted so each theme remembers its own choice. */
+  darkModeByTheme: DarkModeMap;
   setTheme: (theme: OsThemeId) => void;
+  setDarkMode: (enabled: boolean, theme?: OsThemeId) => void;
+  toggleDarkMode: () => void;
   hydrate: () => void;
 }
 
@@ -59,26 +98,50 @@ async function ensureLegacyCss(theme: OsThemeId) {
 // Storage keys
 const THEME_KEY = "ryos:theme";
 const LEGACY_THEME_KEY = "os_theme";
+/**
+ * Per-theme dark-mode preferences, keyed by theme id.
+ * Stored as a single JSON blob so settings sync (which round-trips localStorage)
+ * picks it up alongside `ryos:theme` without needing a new sync section.
+ */
+const DARK_MODE_KEY = "ryos:theme:dark";
 
-function applyRootThemeAttributes(theme: OsThemeId) {
+function applyRootThemeAttributes(theme: OsThemeId, isDark: boolean) {
   const root = document.documentElement;
   root.dataset.osTheme = theme;
   root.dataset.osPlatform = getOsPlatform(theme);
   const macChrome = getOsMacChrome(theme);
   if (macChrome) root.dataset.osMacChrome = macChrome;
   else delete root.dataset.osMacChrome;
+  // Color-scheme attribute is only applied when the theme supports dark mode AND it's enabled.
+  // This keeps the existing light-mode CSS the single source of truth for unsupported themes.
+  if (isDark && themeSupportsDarkMode(theme)) {
+    root.dataset.osColorScheme = "dark";
+    root.style.colorScheme = "dark";
+  } else {
+    delete root.dataset.osColorScheme;
+    root.style.colorScheme = "light";
+  }
+}
+
+function effectiveDarkFor(theme: OsThemeId, map: DarkModeMap): boolean {
+  if (!themeSupportsDarkMode(theme)) return false;
+  return map[theme] === true;
 }
 
 const createThemeStore = () => create<ThemeState>((set) => ({
   current: "macosx",
+  isDark: false,
+  darkModeByTheme: {},
   setTheme: (theme) => {
     const safe = sanitizeStoredTheme(theme);
     const previousTheme = useThemeStore.getState().current;
-    set({ current: safe });
+    const map = useThemeStore.getState().darkModeByTheme;
+    const nextDark = effectiveDarkFor(safe, map);
+    set({ current: safe, isDark: nextDark });
     localStorage.setItem(THEME_KEY, safe);
     // Clean up legacy key
     localStorage.removeItem(LEGACY_THEME_KEY);
-    applyRootThemeAttributes(safe);
+    applyRootThemeAttributes(safe, nextDark);
     ensureLegacyCss(safe);
     // Note: No need to invalidate icon cache on theme switch.
     // Theme switching changes the icon PATH (e.g., /icons/default/ → /icons/macosx/),
@@ -89,6 +152,38 @@ const createThemeStore = () => create<ThemeState>((set) => ({
         previousTheme,
       });
     }
+  },
+  setDarkMode: (enabled, theme) => {
+    const state = useThemeStore.getState();
+    const target = theme ?? state.current;
+    if (!themeSupportsDarkMode(target)) {
+      // Persist the preference anyway so it's remembered if the theme later gains support,
+      // but never apply it. This also avoids surprising the user when they toggle the
+      // Dark Mode switch on a theme that doesn't support it.
+      const nextMap = { ...state.darkModeByTheme, [target]: enabled };
+      writeDarkModeMap(nextMap);
+      set({ darkModeByTheme: nextMap });
+      return;
+    }
+    const nextMap = { ...state.darkModeByTheme, [target]: enabled };
+    writeDarkModeMap(nextMap);
+    const isCurrent = target === state.current;
+    const nextDark = isCurrent ? enabled : state.isDark;
+    set({
+      darkModeByTheme: nextMap,
+      isDark: nextDark,
+    });
+    if (isCurrent) {
+      applyRootThemeAttributes(state.current, nextDark);
+      track(SETTINGS_ANALYTICS.THEME_CHANGE, {
+        theme: state.current,
+        darkMode: enabled,
+      });
+    }
+  },
+  toggleDarkMode: () => {
+    const state = useThemeStore.getState();
+    state.setDarkMode(!state.isDark);
   },
   hydrate: () => {
     let saved = localStorage.getItem(THEME_KEY);
@@ -103,8 +198,10 @@ const createThemeStore = () => create<ThemeState>((set) => ({
     if (saved && theme !== saved) {
       localStorage.setItem(THEME_KEY, theme);
     }
-    set({ current: theme });
-    applyRootThemeAttributes(theme);
+    const map = safeReadDarkModeMap();
+    const isDark = effectiveDarkFor(theme, map);
+    set({ current: theme, isDark, darkModeByTheme: map });
+    applyRootThemeAttributes(theme, isDark);
     ensureLegacyCss(theme);
   },
 }));

--- a/src/styles/themes.css
+++ b/src/styles/themes.css
@@ -3025,3 +3025,232 @@
   filter: blur(1px);
   pointer-events: none;
 }
+
+/* ============================================================================
+ * Dark mode — Mac OS X (Aqua)
+ *
+ * Controlled by `data-os-color-scheme="dark"` on `<html>`, which is only set by
+ * `useThemeStore` when the active theme advertises `supportsDarkMode = true`.
+ * This block redefines the per-theme `--os-*` tokens for dark and adds
+ * structural overrides for chrome that bakes in light-mode hues (menubar gloss,
+ * brushed metal, drawer panels, traffic lights, spotlight pinstripe, etc.).
+ *
+ * Light tokens stay the canonical defaults. Anything new should layer on top
+ * here using `[data-os-color-scheme="dark"]` so removing the attribute is a
+ * complete revert. Other themes are NOT yet covered — see
+ * `docs/3.3.1-theme-architecture.md`.
+ * ============================================================================ */
+
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"] {
+  color-scheme: dark;
+
+  /* Surfaces */
+  --os-color-window-bg: #2b2b2e;
+  --os-color-panel-bg: #2b2b2e;
+  --os-color-menubar-bg: linear-gradient(to bottom, #3b3b40, #232327);
+  --os-color-menubar-border: rgba(0, 0, 0, 0.7);
+  --os-color-menubar-text: #f4f4f5;
+
+  /* Window borders + titlebar */
+  --os-color-window-border: rgba(0, 0, 0, 0.85);
+  --os-color-window-border-inactive: rgba(0, 0, 0, 0.55);
+  --os-color-titlebar-border: rgba(0, 0, 0, 0.65);
+  --os-color-titlebar-border-inactive: rgba(0, 0, 0, 0.45);
+  --os-color-titlebar-active-bg: linear-gradient(
+    to bottom,
+    #4a4a50 0%,
+    #2e2e33 100%
+  );
+  --os-color-titlebar-inactive-bg: linear-gradient(
+    to bottom,
+    #3a3a3f,
+    #2a2a2e
+  );
+  --os-color-titlebar-text: #f4f4f5;
+  --os-color-titlebar-text-inactive: #8b8b90;
+
+  /* Buttons */
+  --os-color-button-face: #4a4a50;
+  --os-color-button-highlight: rgba(255, 255, 255, 0.15);
+  --os-color-button-shadow: rgba(0, 0, 0, 0.6);
+  --os-color-button-active-face: #5a5a60;
+
+  /* Text */
+  --os-color-text-primary: #f4f4f5;
+  --os-color-text-secondary: #c8c8cc;
+  --os-color-text-disabled: #6b6b70;
+
+  /* Selection — keep the Aqua blue so highlights stay readable */
+  --os-color-selection-bg: rgba(48, 103, 218, 0.85);
+  --os-color-selection-text: #ffffff;
+  --os-color-selection-glow: rgba(48, 103, 218, 0.55);
+
+  /* Inputs */
+  --os-color-input-bg: #1f1f22;
+  --os-color-input-border: rgba(255, 255, 255, 0.18);
+  --os-color-input-focus-border: rgba(95, 152, 247, 0.7);
+  --os-color-input-focus-ring: rgba(95, 152, 247, 0.3);
+
+  /* Sidebar / separators */
+  --os-color-separator: rgba(255, 255, 255, 0.14);
+  --os-color-sidebar-border: rgba(255, 255, 255, 0.22);
+  --os-color-sidebar-inset-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.55);
+
+  /* Switch */
+  --os-color-switch-track: #4a4a50;
+  --os-color-switch-track-checked: #3067da;
+
+  /* Window shadow on dark wallpaper needs more spread to read at all */
+  --os-window-shadow: 0 8px 28px rgba(0, 0, 0, 0.55);
+
+  /* Pinstripes — invert the brightness so the subtle stripes still register */
+  --os-pinstripe-window: repeating-linear-gradient(
+      0deg,
+      transparent 0px,
+      transparent 1.5px,
+      rgba(255, 255, 255, 0.04) 1.5px,
+      rgba(255, 255, 255, 0.04) 4px
+    ),
+    linear-gradient(to bottom, #2b2b2e 0%, #2b2b2e 100%);
+  --os-pinstripe-menubar: repeating-linear-gradient(
+    0deg,
+    transparent 0px,
+    transparent 1.5px,
+    rgba(255, 255, 255, 0.05) 1.5px,
+    rgba(255, 255, 255, 0.05) 4px
+  );
+  --os-pinstripe-titlebar: linear-gradient(
+    to bottom,
+    rgba(255, 255, 255, 0.08) 0%,
+    rgba(255, 255, 255, 0.04) 70%,
+    rgba(0, 0, 0, 0.18) 100%
+  );
+
+  /* Traffic-light glyph color — dimmer arrows on darker buttons */
+  --os-color-traffic-light-close: #2a0606;
+  --os-color-traffic-light-minimize: #3a2a08;
+  --os-color-traffic-light-maximize: #062c0e;
+}
+
+/* Background-window selection in dark mode (keeps inactive windows muted but legible) */
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"] .window:not(.is-foreground) {
+  --os-color-selection-bg: rgba(120, 120, 124, 0.55);
+  --os-color-selection-text: #f4f4f5;
+  --os-color-selection-glow: rgba(0, 0, 0, 0.35);
+}
+
+/* Menubar gloss — replace the ::before white-on-white sheen with a darker overlay */
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"] .menubar {
+  text-shadow: 0 1px 1px rgba(0, 0, 0, 0.7);
+  box-shadow: 0 1px 0 rgba(255, 255, 255, 0.06) inset,
+    0 -1px 0 rgba(0, 0, 0, 0.45) inset;
+}
+
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"] .menubar::before {
+  background: linear-gradient(
+    to bottom,
+    rgba(255, 255, 255, 0.06),
+    rgba(255, 255, 255, 0.02)
+  );
+}
+
+/* Brushed metal in dark mode — desaturate + darken the texture so the chrome reads
+   like graphite instead of glowing brushed steel. */
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"]
+  .window-material-brushedmetal::before {
+  filter: contrast(0.9) brightness(0.35) saturate(0.4);
+}
+
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"]
+  .window-material-brushedmetal:not(.is-foreground)::before {
+  filter: contrast(0.7) brightness(0.45) saturate(0.3);
+}
+
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"]
+  .window-material-brushedmetal.is-foreground {
+  border: 0.5px solid rgba(0, 0, 0, 0.85) !important;
+  box-shadow: 0 12px 35px rgba(0, 0, 0, 0.7) !important;
+}
+
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"]
+  .window-material-brushedmetal.is-foreground::after {
+  box-shadow:
+    inset 0 2px 2px rgba(255, 255, 255, 0.18),
+    inset 0 8px 14px rgba(255, 255, 255, 0.04),
+    inset 0 -1px 0 rgba(255, 255, 255, 0.05),
+    inset 1px 0 0 rgba(255, 255, 255, 0.06),
+    inset -1px 0 0 rgba(255, 255, 255, 0.06);
+}
+
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"]
+  .window.window-material-brushedmetal.is-foreground .title-bar {
+  text-shadow: 0 1px 0 rgba(0, 0, 0, 0.85) !important;
+}
+
+/* Side drawer (AppDrawer / TV drawer) reuses the brushed-metal stack */
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"] .os-drawer-metal {
+  border: 0.5px solid rgba(0, 0, 0, 0.85) !important;
+  box-shadow:
+    0 8px 22px rgba(0, 0, 0, 0.55),
+    inset 0 1px 0 rgba(255, 255, 255, 0.12),
+    inset 0 -1px 0 rgba(255, 255, 255, 0.04);
+}
+
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"] .os-drawer-metal::before {
+  filter: contrast(0.9) brightness(0.35) saturate(0.4);
+}
+
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"] .os-drawer-metal::after {
+  box-shadow:
+    inset 0 2px 2px rgba(255, 255, 255, 0.16),
+    inset 0 8px 12px rgba(255, 255, 255, 0.03),
+    inset 0 -1px 0 rgba(255, 255, 255, 0.05),
+    inset 1px 0 0 rgba(255, 255, 255, 0.05),
+    inset -1px 0 0 rgba(255, 255, 255, 0.05);
+}
+
+/* Recessed list well inside the drawer — match the dark window surface */
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"] .os-drawer-list-well {
+  background: #1f1f22;
+  border: 1px solid rgba(0, 0, 0, 0.7);
+  box-shadow:
+    inset 0 1px 2px rgba(0, 0, 0, 0.55),
+    inset 0 0 1px rgba(0, 0, 0, 0.4),
+    0 1px 0 rgba(255, 255, 255, 0.05);
+}
+
+/* Spotlight pinstripe panel uses --os-pinstripe-window which we've already
+   redefined above; ensure the panel's input/text stay light-on-dark. */
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"] .spotlight-panel {
+  color: var(--os-color-text-primary);
+}
+
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"]
+  .spotlight-panel
+  input.spotlight-input {
+  color: var(--os-color-text-primary);
+  caret-color: var(--os-color-text-primary);
+}
+
+/* Aqua select trigger uses light gradients hard-coded in CSS — soften them so
+   they read on dark window chrome (full Aqua-button pulse stays light blue,
+   so leave that alone). */
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"] .macos-select-trigger,
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"]
+  select:where(:not(.dashboard-overlay *):not(.ipod-force-font *):not(.karaoke-force-font *):not(.tv-cc-force-font *):not(.os-native-chrome-skip *)) {
+  color: var(--os-color-text-primary);
+  background-color: var(--os-color-input-bg);
+}
+
+/* Ensure body / html paint the dark surface even before any window mounts */
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"] body {
+  background-color: var(--os-color-window-bg);
+  color: var(--os-color-text-primary);
+}
+
+/* Dialogs / cards rendered through Radix portals don't inherit window-body tokens.
+   Provide a minimal default surface so portaled popovers don't blast white. */
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"]
+  [data-radix-popper-content-wrapper] {
+  color: var(--os-color-text-primary);
+}

--- a/src/styles/themes.css
+++ b/src/styles/themes.css
@@ -4006,19 +4006,30 @@
 }
 
 /* --- Finder list view: zebra + header bg ---------------------------------- */
-/* The list view uses `odd:bg-gray-200/50` for zebra rows and `bg-gray-100/50`
-   for table headers. Those compile to `rgb(229, 231, 235, 0.5)` /
-   `rgb(243, 244, 246, 0.5)` which are very bright on the dark window. Tone
-   them down to faint white-on-dark stripes. */
+/* The list view uses `odd:bg-neutral-200/50` for zebra rows and
+   `bg-neutral-100/50` for table headers. Those compile to a near-white
+   alpha that's bright on the dark window. Tone them down to faint
+   white-on-dark stripes. (Both `gray` and `neutral` listed here so the
+   rules stay matched after the project-wide `gray → neutral` rename.) */
 :root[data-os-theme="macosx"][data-os-color-scheme="dark"]
   .window-body
-  :where(.bg-gray-200\/50, .odd\:bg-gray-200\/50:nth-child(odd)) {
+  :where(
+    .bg-gray-200\/50,
+    .odd\:bg-gray-200\/50:nth-child(odd),
+    .bg-neutral-200\/50,
+    .odd\:bg-neutral-200\/50:nth-child(odd)
+  ) {
   background-color: rgba(255, 255, 255, 0.04) !important;
 }
 
 :root[data-os-theme="macosx"][data-os-color-scheme="dark"]
   .window-body
-  :where(.bg-gray-100\/50, .hover\:bg-gray-100\/50:hover) {
+  :where(
+    .bg-gray-100\/50,
+    .hover\:bg-gray-100\/50:hover,
+    .bg-neutral-100\/50,
+    .hover\:bg-neutral-100\/50:hover
+  ) {
   background-color: rgba(255, 255, 255, 0.06) !important;
 }
 

--- a/src/styles/themes.css
+++ b/src/styles/themes.css
@@ -3254,3 +3254,304 @@
   [data-radix-popper-content-wrapper] {
   color: var(--os-color-text-primary);
 }
+
+/* ============================================================================
+ * Dark mode — Mac OS X (Aqua) — broader coverage layer
+ *
+ * Components hardcode Tailwind utilities like `bg-white`, `text-black`,
+ * `text-neutral-600`, etc. that bake light-mode assumptions into the markup.
+ * Rewriting them all would be invasive and easy to regress; instead, we pin
+ * the most-used utilities to dark-friendly values inside the macOS Aqua dark
+ * window surface using `:where()` so specificity stays low and per-component
+ * overrides keep winning. Everything here is scoped to the dark color scheme —
+ * remove the attribute and the original light styles return verbatim.
+ *
+ * Rules of thumb when extending this block:
+ *   1. Don't recolor Tailwind tinted utilities (`bg-pink-100`, `bg-blue-100`,
+ *      etc.) — those carry their own readable foregrounds and are commonly
+ *      used inside chat bubbles, badges, etc.
+ *   2. Prefer remapping shadcn CSS variables (`--popover`, `--card`,
+ *      `--background`) over targeting `bg-popover` etc. directly so any
+ *      foreground/border tokens flow through together.
+ *   3. Always exclude opt-out containers (dashboard overlay, iPod / karaoke /
+ *      TV CC force-font, os-native-chrome-skip) so legacy chrome that bakes
+ *      in its own colors (Webamp, iPod LCD, etc.) is left alone.
+ * ============================================================================ */
+
+/* -----------------------------------------------------------------------
+ * shadcn/Tailwind theme tokens consumed via `bg-background`, `bg-popover`,
+ * `bg-card`, `text-foreground`, `border-border`. The `index.css` `.dark`
+ * class block already defines dark equivalents — we re-publish them here so
+ * the dark scheme kicks in based on the OS attribute (independent of the
+ * `.dark` class chain).
+ * ----------------------------------------------------------------------- */
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"] {
+  --background: 240 4% 18%;
+  --foreground: 0 0% 96%;
+  --card: 240 4% 18%;
+  --card-foreground: 0 0% 96%;
+  --popover: 240 4% 16%;
+  --popover-foreground: 0 0% 96%;
+  --primary: 0 0% 96%;
+  --primary-foreground: 0 0% 8%;
+  --secondary: 240 4% 22%;
+  --secondary-foreground: 0 0% 96%;
+  --muted: 240 4% 22%;
+  --muted-foreground: 0 0% 70%;
+  --accent: 240 4% 26%;
+  --accent-foreground: 0 0% 96%;
+  --destructive: 0 62.8% 50%;
+  --destructive-foreground: 0 0% 96%;
+  --border: 0 0% 100% / 0.14;
+  --input: 240 4% 14%;
+  --ring: 217 91% 65%;
+}
+
+/* -----------------------------------------------------------------------
+ * Window-body content surface. `.window-body` already gets
+ * `--os-color-window-bg` from the dark token block above, but many app
+ * chrome panels paint their own `bg-white` over it. Override the most
+ * common variants inside `.window-body` so the surface goes dark while
+ * tinted Tailwind colors (pink-100, blue-100, etc.) keep rendering.
+ *
+ * We DO NOT touch:
+ *   - `.bg-pink-*`, `.bg-blue-*`, `.bg-yellow-*` etc. (chat bubbles, badges)
+ *   - Anything inside iPod / karaoke / TV closed-caption surfaces
+ *   - Brushed-metal windows (texture handles its own dark variant)
+ *   - Webamp (`#webamp` is fully isolated)
+ * ----------------------------------------------------------------------- */
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"]
+  .window-body
+  :where(
+    .bg-white,
+    .bg-\[\#FFFFFF\],
+    .bg-\[\#ffffff\]
+  ):not(.ipod-force-font *):not(.karaoke-force-font *):not(.tv-cc-force-font *):not(.os-native-chrome-skip *):not(.dashboard-overlay *) {
+  background-color: var(--os-color-window-bg) !important;
+}
+
+/* Translucent white panels used as content surfaces (`/85`, `/80`, `/70`, `/40`).
+   These are used by the Chats conversation pane, Finder file list, and similar
+   "soft pane" surfaces. Map them to a slightly translucent dark shade so the
+   pane reads as a recessed surface instead of a paper-white slab. */
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"]
+  .window-body
+  :where(
+    .bg-white\/90,
+    .bg-white\/85,
+    .bg-white\/80,
+    .bg-white\/70,
+    .bg-white\/60,
+    .bg-white\/50,
+    .bg-white\/40,
+    .bg-white\/30,
+    .bg-white\/20,
+    .bg-white\/10
+  ):not(.ipod-force-font *):not(.karaoke-force-font *):not(.tv-cc-force-font *):not(.os-native-chrome-skip *):not(.dashboard-overlay *) {
+  background-color: rgba(31, 31, 34, 0.92) !important;
+}
+
+/* Inputs / textareas often use `bg-white` directly — keep them distinct from
+   the surrounding window background so the field still reads as an input. */
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"]
+  .window-body
+  input.bg-white,
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"]
+  .window-body
+  textarea.bg-white,
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"]
+  .window-body
+  select.bg-white {
+  background-color: var(--os-color-input-bg) !important;
+  color: var(--os-color-text-primary) !important;
+  border-color: var(--os-color-input-border);
+}
+
+/* Default text color for `.window-body` content — anything not explicitly
+   recolored falls back to the dark theme's primary text token. */
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"] .window-body {
+  color: var(--os-color-text-primary);
+}
+
+/* Common hardcoded text utilities. We keep this list narrow and only touch
+   the neutral / black variants — colored text utilities (`text-red-*`,
+   `text-blue-*`, etc.) stay as authored so error text, links, and tinted
+   labels keep their semantics. */
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"]
+  .window-body
+  :where(
+    .text-black,
+    .text-\[\#000\],
+    .text-\[\#000000\]
+  ):not(.ipod-force-font *):not(.karaoke-force-font *):not(.tv-cc-force-font *):not(.os-native-chrome-skip *):not(.dashboard-overlay *):not([class*="bg-pink-"]):not([class*="bg-blue-"]):not([class*="bg-yellow-"]):not([class*="bg-purple-"]):not([class*="bg-indigo-"]):not([class*="bg-teal-"]):not([class*="bg-lime-"]):not([class*="bg-amber-"]):not([class*="bg-cyan-"]):not([class*="bg-rose-"]):not([class*="bg-green-"]):not([class*="bg-orange-"]):not([class*="bg-red-"]):not([class*="bg-gray-1"]):not([class*="bg-neutral-1"]):not([class*="bg-zinc-1"]):not([class*="bg-slate-1"]) {
+  color: var(--os-color-text-primary) !important;
+}
+
+/* Black-with-alpha utilities (`text-black/70`, etc.) used for de-emphasized
+   labels / icons. Map them to the secondary text color. */
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"]
+  .window-body
+  :where(
+    .text-black\/80,
+    .text-black\/70,
+    .text-black\/60,
+    .text-black\/50,
+    .text-black\/40,
+    .text-black\/30,
+    .text-black\/20
+  ):not(.ipod-force-font *):not(.karaoke-force-font *):not(.tv-cc-force-font *):not(.os-native-chrome-skip *):not(.dashboard-overlay *):not([class*="bg-pink-"]):not([class*="bg-blue-"]):not([class*="bg-yellow-"]):not([class*="bg-purple-"]):not([class*="bg-indigo-"]):not([class*="bg-teal-"]):not([class*="bg-lime-"]):not([class*="bg-amber-"]):not([class*="bg-cyan-"]):not([class*="bg-rose-"]):not([class*="bg-green-"]):not([class*="bg-orange-"]):not([class*="bg-red-"]) {
+  color: var(--os-color-text-secondary) !important;
+}
+
+/* Mid-gray neutrals used for secondary/muted copy. Map them all to the
+   secondary text token so the contrast stays consistent inside the window. */
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"]
+  .window-body
+  :where(
+    .text-neutral-500,
+    .text-neutral-600,
+    .text-neutral-700,
+    .text-neutral-800,
+    .text-gray-500,
+    .text-gray-600,
+    .text-gray-700,
+    .text-gray-800,
+    .text-zinc-500,
+    .text-zinc-600,
+    .text-zinc-700,
+    .text-zinc-800,
+    .text-slate-500,
+    .text-slate-600,
+    .text-slate-700,
+    .text-slate-800
+  ):not(.ipod-force-font *):not(.karaoke-force-font *):not(.tv-cc-force-font *):not(.os-native-chrome-skip *):not(.dashboard-overlay *):not([class*="bg-pink-"]):not([class*="bg-blue-"]):not([class*="bg-yellow-"]):not([class*="bg-purple-"]):not([class*="bg-indigo-"]):not([class*="bg-teal-"]):not([class*="bg-lime-"]):not([class*="bg-amber-"]):not([class*="bg-cyan-"]):not([class*="bg-rose-"]):not([class*="bg-green-"]):not([class*="bg-orange-"]):not([class*="bg-red-"]):not([class*="bg-gray-1"]):not([class*="bg-neutral-1"]):not([class*="bg-zinc-1"]):not([class*="bg-slate-1"]) {
+  color: var(--os-color-text-secondary) !important;
+}
+
+/* Disabled / placeholder gray (gray-400 et al.). Map to the disabled text
+   token so it still recedes against the dark surface. */
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"]
+  .window-body
+  :where(
+    .text-neutral-400,
+    .text-gray-400,
+    .text-zinc-400,
+    .text-slate-400
+  ):not(.ipod-force-font *):not(.karaoke-force-font *):not(.tv-cc-force-font *):not(.os-native-chrome-skip *):not(.dashboard-overlay *):not([class*="bg-pink-"]):not([class*="bg-blue-"]):not([class*="bg-yellow-"]):not([class*="bg-purple-"]):not([class*="bg-indigo-"]):not([class*="bg-teal-"]):not([class*="bg-lime-"]):not([class*="bg-amber-"]):not([class*="bg-cyan-"]):not([class*="bg-rose-"]):not([class*="bg-green-"]):not([class*="bg-orange-"]):not([class*="bg-red-"]) {
+  color: var(--os-color-text-disabled) !important;
+}
+
+/* Hairline borders defined as `border-black/*` or low-alpha black look
+   invisible on the dark surface. Lift them to a faint white-on-dark
+   hairline so dividers still read. */
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"]
+  .window-body
+  :where(
+    .border-black,
+    .border-black\/5,
+    .border-black\/10,
+    .border-black\/20,
+    .border-black\/30,
+    .border-black\/40,
+    .border-black\/50,
+    .border-black\/60,
+    .border-neutral-200,
+    .border-neutral-300,
+    .border-gray-200,
+    .border-gray-300
+  ):not(.ipod-force-font *):not(.karaoke-force-font *):not(.tv-cc-force-font *):not(.os-native-chrome-skip *):not(.dashboard-overlay *) {
+  border-color: rgba(255, 255, 255, 0.18) !important;
+}
+
+/* `bg-neutral-100` / `bg-gray-100` are commonly used for secondary panes
+   (sidebars, recessed surfaces). Map them to a slightly lighter shade than
+   the window background so layered surfaces still have depth. */
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"]
+  .window-body
+  :where(
+    .bg-neutral-50,
+    .bg-neutral-100,
+    .bg-neutral-200,
+    .bg-gray-50,
+    .bg-gray-100,
+    .bg-gray-200,
+    .bg-zinc-50,
+    .bg-zinc-100,
+    .bg-zinc-200,
+    .bg-slate-50,
+    .bg-slate-100,
+    .bg-slate-200
+  ):not(.ipod-force-font *):not(.karaoke-force-font *):not(.tv-cc-force-font *):not(.os-native-chrome-skip *):not(.dashboard-overlay *) {
+  background-color: #353539 !important;
+}
+
+/* Status-bar shell used by Finder etc. — explicit `color: #333` and white
+   text-shadow bake light-mode assumptions in inline styles. Override them
+   so the bar reads on the dark window. */
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"] .os-status-bar {
+  color: var(--os-color-text-secondary) !important;
+  text-shadow: 0 1px 0 rgba(0, 0, 0, 0.5) !important;
+  border-top-color: rgba(255, 255, 255, 0.12);
+}
+
+/* -----------------------------------------------------------------------
+ * Menu / dropdown popovers (Radix portaled). They render outside any
+ * `.window-body`, so the rules above don't reach them. Repaint the surface,
+ * separators, items, and hover/highlight states. The selection rule keeps
+ * using the existing Aqua blue token so highlights remain branded.
+ * ----------------------------------------------------------------------- */
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"]
+  [data-radix-popper-content-wrapper]
+  :where(
+    [role="menu"],
+    [role="listbox"],
+    [data-radix-menu-content],
+    [data-radix-popover-content],
+    [data-radix-select-content]
+  ) {
+  background-color: #2f2f33 !important;
+  color: var(--os-color-text-primary) !important;
+  border-color: rgba(255, 255, 255, 0.12) !important;
+}
+
+/* Menubar (top bar) dropdown items — Radix exposes
+   `[data-radix-collection-item]` for menu items. Default items inherit dark
+   surface; only repaint disabled items. */
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"]
+  [data-radix-popper-content-wrapper]
+  [data-disabled] {
+  color: var(--os-color-text-disabled) !important;
+}
+
+/* Separator strokes inside dropdowns. */
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"]
+  [data-radix-popper-content-wrapper]
+  [role="separator"],
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"]
+  [data-radix-popper-content-wrapper]
+  hr {
+  background-color: rgba(255, 255, 255, 0.12) !important;
+  border-color: rgba(255, 255, 255, 0.12) !important;
+}
+
+/* Toast surface (Sonner) — dark scheme. The light theme toast styling lives
+   higher up in this file under generic and per-theme rules; redirect it to
+   the dark surface when the OS attribute flips. */
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"] [data-sonner-toast] {
+  background-color: #303035 !important;
+  color: var(--os-color-text-primary) !important;
+  border-color: rgba(255, 255, 255, 0.12) !important;
+}
+
+/* Tabs — the active tab indicator uses light gradients. Soften so it reads
+   on the dark window surface. (Affects ThemedTabsTrigger + Radix Tabs.) */
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"]
+  .window-body
+  [role="tab"] {
+  color: var(--os-color-text-secondary);
+}
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"]
+  .window-body
+  [role="tab"][data-state="active"] {
+  color: var(--os-color-text-primary);
+}

--- a/src/styles/themes.css
+++ b/src/styles/themes.css
@@ -4147,3 +4147,84 @@
   background-color: rgb(0 0 0) !important;
   color: #fff !important;
 }
+
+/* --- Toast title / description in dark mode ------------------------------ */
+/* The light-mode rule pins toast title/description to `rgba(0, 0, 0, 0.9)` —
+   that wins over the container's `color` token in dark mode. Re-pin the
+   inner text colors so the dark toast actually reads as light-on-dark. */
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"]
+  .toaster [data-sonner-toast] [data-title],
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"]
+  .toaster [data-sonner-toast] [data-description] {
+  color: var(--os-color-text-primary) !important;
+}
+
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"]
+  .toaster [data-sonner-toast] [data-description] {
+  color: var(--os-color-text-secondary) !important;
+}
+
+/* --- Dialog body content in dark mode (HelpDialog, About, etc.) ---------- */
+/* HelpDialog renders its HelpCards directly inside `.macosx-dialog` (no
+   `.window-body` wrapper for the mac theme), so the broad `.window-body`
+   coverage doesn't reach. Mirror the most common patterns inside the
+   dialog surface so help cards / about cards / form rows read correctly. */
+
+/* Card-like soft tinted backgrounds (`bg-black/5` / `/10` / `/20`) inside a
+   dialog read as nearly invisible against the dark window — lift them to a
+   faint white wash so the card silhouette is still visible. */
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"]
+  .macosx-dialog
+  :where(.bg-black\/5, .bg-black\/10, .bg-black\/15, .bg-black\/20):not(.ipod-force-font *):not(.karaoke-force-font *):not(.tv-cc-force-font *):not(.os-native-chrome-skip *):not(.synth-force-font *) {
+  background-color: rgba(255, 255, 255, 0.06) !important;
+}
+
+/* Body / secondary copy inside dialogs. The `text-gray-700` class lands
+   too dark on the dark dialog surface; lift to the secondary token. */
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"]
+  .macosx-dialog
+  :where(
+    .text-gray-500,
+    .text-gray-600,
+    .text-gray-700,
+    .text-gray-800,
+    .text-neutral-500,
+    .text-neutral-600,
+    .text-neutral-700,
+    .text-neutral-800,
+    .text-zinc-600,
+    .text-zinc-700,
+    .text-slate-600,
+    .text-slate-700
+  ):not(.ipod-force-font *):not(.karaoke-force-font *):not(.tv-cc-force-font *):not(.os-native-chrome-skip *):not(.synth-force-font *):not([class*="bg-pink-"]):not([class*="bg-blue-"]):not([class*="bg-yellow-"]):not([class*="bg-purple-"]):not([class*="bg-indigo-"]):not([class*="bg-teal-"]):not([class*="bg-amber-"]) {
+  color: var(--os-color-text-secondary) !important;
+}
+
+/* Primary headings inside dialogs default to inheriting `text-foreground`,
+   but `text-black` and `.text-[#000]` variants used in custom titles need
+   the same flip we apply inside `.window-body`. */
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"]
+  .macosx-dialog
+  :where(.text-black, .text-\[\#000\], .text-\[\#000000\]):not(.ipod-force-font *):not(.karaoke-force-font *):not(.tv-cc-force-font *):not(.os-native-chrome-skip *):not(.synth-force-font *):not([class*="bg-pink-"]):not([class*="bg-blue-"]):not([class*="bg-yellow-"]):not([class*="bg-purple-"]):not([class*="bg-indigo-"]):not([class*="bg-teal-"]):not([class*="bg-amber-"]) {
+  color: var(--os-color-text-primary) !important;
+}
+
+/* Inline `bg-white(/alpha)` surfaces inside a dialog (e.g. AboutDialog
+   sub-cards) — same recipe as the .window-body rule. */
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"]
+  .macosx-dialog
+  :where(.bg-white):not(.ipod-force-font *):not(.karaoke-force-font *):not(.tv-cc-force-font *):not(.os-native-chrome-skip *):not(.synth-force-font *) {
+  background-color: var(--os-color-window-bg) !important;
+}
+
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"]
+  .macosx-dialog
+  :where(.bg-white\/90, .bg-white\/85, .bg-white\/80, .bg-white\/70, .bg-white\/60, .bg-white\/50, .bg-white\/40, .bg-white\/30, .bg-white\/20, .bg-white\/10):not(.ipod-force-font *):not(.karaoke-force-font *):not(.tv-cc-force-font *):not(.os-native-chrome-skip *):not(.synth-force-font *) {
+  background-color: rgba(31, 31, 34, 0.92) !important;
+}
+
+/* Ensure `.macosx-dialog` itself paints the right primary text fallback so
+   anything not explicitly recolored falls through to the dark scheme. */
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"] .macosx-dialog {
+  color: var(--os-color-text-primary);
+}

--- a/src/styles/themes.css
+++ b/src/styles/themes.css
@@ -4021,3 +4021,129 @@
   :where(.bg-gray-100\/50, .hover\:bg-gray-100\/50:hover) {
   background-color: rgba(255, 255, 255, 0.06) !important;
 }
+
+/* --- Chat stop button ----------------------------------------------------- */
+/* The send/stop pair use Aqua-styled gradient pills inline. The stop button's
+   light pink gradient reads more like "send (red theme)" than "stop"; tighten
+   it to a deeper, more saturated red across themes and flip the glyph white
+   so the stop affordance is unambiguous. */
+.chat-stop-btn {
+  background: linear-gradient(
+    rgba(220, 38, 38, 0.95),
+    rgba(159, 18, 24, 0.95)
+  ) !important;
+  box-shadow:
+    0 2px 3px rgba(0, 0, 0, 0.3),
+    0 1px 1px rgba(0, 0, 0, 0.35),
+    inset 0 0 0 0.5px rgba(0, 0, 0, 0.45),
+    inset 0 1px 2px rgba(0, 0, 0, 0.4),
+    inset 0 2px 3px 1px rgba(220, 38, 38, 0.45) !important;
+}
+
+.chat-stop-glyph {
+  color: #ffffff !important;
+}
+
+/* Dark mode keeps the same red but slightly less luminous so it doesn't
+   over-pop against the dim window. */
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"] .chat-stop-btn {
+  background: linear-gradient(
+    rgba(185, 28, 28, 0.9),
+    rgba(127, 14, 19, 0.95)
+  ) !important;
+  box-shadow:
+    0 2px 3px rgba(0, 0, 0, 0.55),
+    0 1px 1px rgba(0, 0, 0, 0.45),
+    inset 0 0 0 0.5px rgba(0, 0, 0, 0.6),
+    inset 0 1px 2px rgba(0, 0, 0, 0.45),
+    inset 0 2px 3px 1px rgba(185, 28, 28, 0.4) !important;
+}
+
+/* --- Inline search/text inputs that don't use the shared SearchInput ----- */
+/* TV / Contacts / Calendar / TrayDetails / etc. inline their own inputs with
+   hardcoded `bg-white border-black/40` (or /20) Tailwind classes — they
+   don't carry the `data-os-search-input` marker the shared SearchInput
+   uses. Catch the broader pattern here so dark mode lands consistently:
+   any inline-styled input/textarea inside `.window-body` with `bg-white`,
+   `bg-white/{alpha}`, or `bg-white/60`-style class lands on the dark
+   input surface, and `border-black/{alpha}` borders get a faint white
+   hairline. */
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"]
+  .window-body
+  :where(input, textarea, select):where(
+    .bg-white,
+    .bg-white\/90,
+    .bg-white\/85,
+    .bg-white\/80,
+    .bg-white\/70,
+    .bg-white\/60,
+    .bg-white\/50,
+    .bg-white\/40,
+    .bg-white\/30,
+    .bg-white\/20,
+    .bg-white\/10
+  ):not(.ipod-force-font *):not(.karaoke-force-font *):not(.tv-cc-force-font *):not(.os-native-chrome-skip *):not(.synth-force-font *):not(.dashboard-overlay *) {
+  background-color: var(--os-color-input-bg) !important;
+  color: var(--os-color-text-primary) !important;
+}
+
+/* `border-black/{alpha}` and similar on inputs read as nearly invisible on
+   the dark window. Lift to a faint white-on-dark hairline. */
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"]
+  .window-body
+  :where(input, textarea, select):where(
+    .border-black,
+    .border-black\/40,
+    .border-black\/30,
+    .border-black\/20,
+    .border-black\/10,
+    .border-\[\#7f9db9\]
+  ):not(.ipod-force-font *):not(.karaoke-force-font *):not(.tv-cc-force-font *):not(.os-native-chrome-skip *):not(.synth-force-font *):not(.dashboard-overlay *) {
+  border-color: rgba(255, 255, 255, 0.18) !important;
+}
+
+/* Placeholders. Contacts/TV/Calendar set `placeholder:text-black/40` etc.
+   inline; remap to the disabled-text token. The `::placeholder` pseudo
+   sits at the very end after all class / negation selectors. */
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"]
+  .window-body
+  :where(input, textarea):where(
+    .placeholder\:text-black\/30,
+    .placeholder\:text-black\/40,
+    .placeholder\:text-black\/50,
+    .placeholder\:text-black\/60
+  ):not(.ipod-force-font *):not(.karaoke-force-font *):not(.tv-cc-force-font *):not(.os-native-chrome-skip *):not(.synth-force-font *):not(.dashboard-overlay *)::placeholder {
+  color: var(--os-color-text-disabled) !important;
+}
+/* Note: `:not(.x *)::placeholder` is valid — `::placeholder` attaches to the
+   compound selector, and `:not()` is part of that compound. */
+
+/* Inline magnifier / clear-icon glyphs that use `text-black/{alpha}` next to
+   inline inputs (Contacts, ChannelPromptInput, etc.). Recolor to a soft
+   white so the icon is visible against the dark input pill. */
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"]
+  .window-body
+  :where(.text-black\/35, .text-black\/45, .text-black\/55):not(.ipod-force-font *):not(.karaoke-force-font *):not(.tv-cc-force-font *):not(.os-native-chrome-skip *):not(.synth-force-font *):not(.dashboard-overlay *) {
+  color: rgba(255, 255, 255, 0.55) !important;
+}
+
+/* --- Synth piano keys & paint toolbar opt-out --------------------------- */
+/* Synth piano keys carry their own authored bg colors (`bg-white` for white
+   keys, `bg-black` for black keys) and the pressed-state magenta. The
+   broad dark-mode coverage above remaps `bg-white`, but a piano key MUST
+   stay white regardless of OS color scheme. Pin the authored colors with
+   a higher-specificity selector. The light-mode rules in `index.css`
+   already enforce `!important`; mirror them here for dark mode parity. */
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"] button.piano-key.bg-white,
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"] button.piano-key.bg-white.bg-white {
+  background: rgb(255 255 255) !important;
+  background-color: rgb(255 255 255) !important;
+  color: #000 !important;
+}
+
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"] button.piano-key.bg-black,
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"] button.piano-key.bg-black.bg-black {
+  background: rgb(0 0 0) !important;
+  background-color: rgb(0 0 0) !important;
+  color: #fff !important;
+}

--- a/src/styles/themes.css
+++ b/src/styles/themes.css
@@ -3659,23 +3659,54 @@
   background: linear-gradient(transparent, rgba(255, 255, 255, 0.08));
 }
 
-/* Active tab keeps its branded blue gradient — but the under-tab strip
-   (`.aqua-tab-bar:after`) is a light-blue/white seam by default, which reads
-   as an unwelcome glow on dark windows. Darken to a deeper indigo seam. */
+/* Active tab — keep the same Aqua-blue gradient family the light theme uses,
+   just dimmer so it doesn't blast out against the dark window. Stops mirror
+   the light gradient (deep blue → mid → light) but each step is shifted into
+   the lower-saturation / darker half of the family. */
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"] .aqua-tab[data-state="active"] {
+  background: linear-gradient(
+    rgb(28, 76, 130),
+    rgb(70, 117, 168),
+    rgb(132, 178, 224)
+  );
+  box-shadow:
+    inset 0 1px 3px rgba(0, 0, 0, 0.7),
+    inset 0 2px 3px 1px rgba(0, 50, 120, 0.55),
+    0 2px 3px rgba(0, 0, 0, 0.5),
+    0 1px 1px rgba(0, 60, 140, 0.45);
+  text-shadow: 0 1px 1px rgba(0, 0, 0, 0.5);
+  border-bottom: 1px solid rgb(132, 178, 224) !important;
+}
+
+/* Soften the active-tab top shine to match the dimmer base. */
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"] .aqua-tab[data-state="active"]:before {
+  background: linear-gradient(
+    rgba(255, 255, 255, 0.32),
+    rgba(255, 255, 255, 0.1)
+  );
+}
+
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"] .aqua-tab[data-state="active"]:after {
+  background: linear-gradient(transparent, rgba(255, 255, 255, 0.18));
+}
+
+/* Under-tab seam — same Aqua-blue family as the light theme but with the
+   stops dragged toward the darker / less-saturated end so it reads as a
+   continuation of the dimmer active tab above. */
 :root[data-os-theme="macosx"][data-os-color-scheme="dark"] .aqua-tab-bar:after {
   background: linear-gradient(
     to bottom,
-    #082c5a 0%,
-    #1a4f8c 8%,
-    #1a4276 25%,
-    #133861 40%,
-    #1a4683 60%,
-    #1a4683 80%,
-    #205a9c 100%
+    #16345c 0%,
+    #6e9bcb 8%,
+    #5a85b8 25%,
+    #4670a3 40%,
+    #5a85b8 60%,
+    #6090c0 80%,
+    #4d80b4 100%
   );
   box-shadow:
-    inset 0 1px 0 rgba(0, 0, 0, 0.55),
-    inset 0 -1px 0 rgba(0, 0, 0, 0.55);
+    inset 0 1px 0 rgba(0, 0, 0, 0.45),
+    inset 0 -1px 0 rgba(0, 0, 0, 0.45);
 }
 
 /* --- Search input + icon -------------------------------------------------- */
@@ -3737,42 +3768,101 @@
 
 :root[data-os-theme="macosx"][data-os-color-scheme="dark"] .metal-inset-btn:active,
 :root[data-os-theme="macosx"][data-os-color-scheme="dark"] .metal-inset-btn[data-state="on"] {
-  /* Toggled state — keep the Aqua blue family (matches the active-tab gloss
-     and selection bg) but clip the highlights so the gradient reads on the
-     darker chrome around it. */
+  /* Toggled state — same Aqua-blue family as the active tab, dimmer than the
+     light theme's sky-blue gradient so it doesn't pop against the dark chrome. */
   background: linear-gradient(
     to bottom,
-    #1f4d8a 0%,
-    #2864a8 49%,
-    #1c4f87 50%,
-    #2a76c2 100%
+    #1a3a66 0%,
+    #2a528a 49%,
+    #1f3f6f 50%,
+    #355d96 100%
   );
-  color: #ffffff;
-  text-shadow: 0 1px 0 rgba(0, 0, 0, 0.4);
-  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.4);
-  border-right-color: rgba(0, 0, 0, 0.4);
+  color: rgba(255, 255, 255, 0.92);
+  text-shadow: 0 1px 0 rgba(0, 0, 0, 0.5);
+  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.45);
+  border-right-color: rgba(0, 0, 0, 0.45);
+}
+
+/* macOS Aqua switch — the thumb's "checked" gradient comes from
+   `.aqua-button.primary` which is a vivid blue intentional for light mode.
+   In dark mode, dim it to match the rest of the toggled-on chrome above. */
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"]
+  .os-switch[data-state="checked"]
+  .os-switch-thumb,
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"] .os-slider-thumb {
+  background: linear-gradient(
+    rgba(0, 50, 130, 0.7),
+    rgba(40, 95, 165, 0.7),
+    rgba(70, 135, 195, 0.7)
+  );
+  box-shadow:
+    0 2px 3px rgba(0, 0, 0, 0.45),
+    0 1px 1px rgba(0, 35, 90, 0.55),
+    inset 0 1px 3px rgba(0, 12, 35, 0.65),
+    inset 0 2px 3px 1px rgba(0, 50, 130, 0.7);
+}
+
+/* Off thumb on the dark switch track — the existing
+   `.os-switch:not([data-state="checked"]) .os-switch-thumb` light gradient
+   blends fine with the existing track surface, but the track itself is the
+   light Aqua `linear-gradient(#d0d0d0,#f5f5f5)` which would scream against
+   the dark window. Tone the track to a darker pill while keeping the same
+   inset-recess shading. */
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"] .os-switch,
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"] .os-switch[data-state="checked"] {
+  background: linear-gradient(#3a3a3f, #4d4d52);
+  box-shadow:
+    inset 0 1px 2px rgba(0, 0, 0, 0.6),
+    0 1px 0 rgba(255, 255, 255, 0.06);
+}
+
+/* Generic shadcn Switch (non-aqua) — Control Panels uses
+   `data-[state=checked]:bg-[#000000]` inline; in dark mode that solid black
+   pill disappears against the window. Lift it to match the `--switch-track`
+   token instead. */
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"]
+  .window-body
+  [data-state="checked"].bg-\[\#000000\]:not(.os-switch) {
+  background-color: #5a5a60 !important;
+}
+
+/* Aqua segmented selector (`aqua-select-btn.aqua-selected`) — the light theme
+   darkens the gradient + outline against a bright window. In dark mode its
+   gray-on-gray reads as bright; soften both the gradient and the outline. */
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"]
+  .aqua-select-btn.aqua-selected {
+  background: linear-gradient(
+    rgb(70 75 80 / 92%),
+    rgb(95 102 108 / 80%)
+  ) !important;
+  color: rgba(255, 255, 255, 0.92) !important;
+  text-shadow: 0 1px 0 rgba(0, 0, 0, 0.55) !important;
+  box-shadow:
+    0 2px 3px rgba(0, 0, 0, 0.4),
+    0 1px 1px rgba(0, 0, 0, 0.5),
+    0 0 0 1px rgba(0, 0, 0, 0.6) !important;
 }
 
 /* --- LCD displays (Videos / TV / Minesweeper) ----------------------------- */
 /* Override the `--videos-lcd-*` variables so the existing `.videos-lcd` rules
-   automatically pick up the dark CRT palette (deep green-black background,
-   muted phosphor-green glyphs, inverted text-shadow). The rules already use
-   `var(--videos-lcd-bg)` and `var(--videos-lcd-text)`. */
+   automatically pick up the dark CRT palette. The light theme uses a sage-
+   green panel with near-black text; dark mode mirrors that contrast inversion
+   but with a subdued, near-monochrome graphite tint instead of vivid phosphor
+   green so the LCD blends with the rest of the dark chrome. */
 :root[data-os-theme="macosx"][data-os-color-scheme="dark"] {
-  --videos-lcd-bg: #0d1d0d;
-  --videos-lcd-text: #6fd07a;
-  --videos-lcd-text-muted: #4ea355;
-  --videos-lcd-fade: #0d1d0d;
-  --videos-lcd-border-dark: #000000d0;
+  --videos-lcd-bg: #1c1f1c;
+  --videos-lcd-text: #b6c0b6;
+  --videos-lcd-text-muted: #889088;
+  --videos-lcd-fade: #1c1f1c;
+  --videos-lcd-border-dark: #000000c0;
   --videos-lcd-border-light: rgba(255, 255, 255, 0.05);
 }
 
 /* Existing rule baked in `1px 1px 0 rgba(0, 0, 0, 0.2)` text-shadow that
-   only reads on a light background; swap to a dark drop-shadow that adds
-   a faint green glow under each glyph. */
+   only reads on a light background; swap to a soft black drop-shadow without
+   the bright phosphor glow. */
 :root[data-os-theme="macosx"][data-os-color-scheme="dark"] .videos-lcd {
-  text-shadow: 0 0 4px rgba(111, 208, 122, 0.35),
-    1px 1px 0 rgba(0, 0, 0, 0.85) !important;
+  text-shadow: 1px 1px 0 rgba(0, 0, 0, 0.7) !important;
 }
 
 /* TV LCD wraps the `.videos-lcd` div in `bg-black` for its strip layout —
@@ -3786,19 +3876,18 @@
 :root[data-os-theme="macosx"][data-os-color-scheme="dark"]
   .window-body
   :where(.bg-\[\#8a9a8a\]) {
-  background-color: #0d1d0d !important;
+  background-color: #1c1f1c !important;
   border-top-color: #000 !important;
   border-left-color: #000 !important;
   border-right-color: rgba(255, 255, 255, 0.08) !important;
   border-bottom-color: rgba(255, 255, 255, 0.08) !important;
-  text-shadow: 0 0 4px rgba(111, 208, 122, 0.35),
-    1px 1px 0 rgba(0, 0, 0, 0.85) !important;
+  text-shadow: 1px 1px 0 rgba(0, 0, 0, 0.7) !important;
 }
 
 :root[data-os-theme="macosx"][data-os-color-scheme="dark"]
   .window-body
   :where(.text-\[\#1a2a1a\]) {
-  color: #6fd07a !important;
+  color: #b6c0b6 !important;
 }
 
 /* Minesweeper face/bezel + cell tray (light gray `bg-[#c0c0c0]` and the
@@ -3822,4 +3911,82 @@
   .window-body
   :where(.hover\:bg-\[\#d0d0d0\]:hover) {
   background-color: #45454a !important;
+}
+
+/* --- Chat bubbles — dark themed ------------------------------------------ */
+/* Light theme uses bright pastel role colors (`bg-yellow-100` for user,
+   `bg-blue-100` for assistant, hashed pastels for human). In dark mode,
+   recolor the bubble fills to dim, low-saturation versions of the same hue
+   family so role identification is preserved without the bright pastels.
+   Text inside the bubble flips to near-white so contrast holds. */
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"] .chat-bubble.bg-yellow-100 {
+  background-color: #5a4a1c !important; /* dim amber */
+}
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"] .chat-bubble.bg-blue-100 {
+  background-color: #1f3a5c !important; /* dim slate-blue */
+}
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"] .chat-bubble.bg-pink-100,
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"] .chat-bubble.bg-pink-200 {
+  background-color: #5a2a3a !important;
+}
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"] .chat-bubble.bg-purple-100,
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"] .chat-bubble.bg-purple-200 {
+  background-color: #3d2c5a !important;
+}
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"] .chat-bubble.bg-indigo-100,
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"] .chat-bubble.bg-indigo-200 {
+  background-color: #2a3260 !important;
+}
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"] .chat-bubble.bg-teal-100 {
+  background-color: #1d4a48 !important;
+}
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"] .chat-bubble.bg-lime-100 {
+  background-color: #2e4a1c !important;
+}
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"] .chat-bubble.bg-amber-100 {
+  background-color: #5a4a1c !important;
+}
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"] .chat-bubble.bg-cyan-100 {
+  background-color: #1c454d !important;
+}
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"] .chat-bubble.bg-rose-100 {
+  background-color: #5a2630 !important;
+}
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"] .chat-bubble.bg-gray-100,
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"] .chat-bubble.bg-neutral-200 {
+  background-color: #353539 !important;
+}
+
+/* Bubble text — recolor light Tailwind `text-black` and `text-current`
+   variants so they land on the dim role colors with comfortable contrast. */
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"] .chat-bubble,
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"] .chat-bubble * {
+  color: rgba(255, 255, 255, 0.92);
+}
+
+/* Top shine — the light-mode shine is white-on-pastel (`rgba(255,255,255,0.9)`
+   → `rgba(255,255,255,0.25)`). On dark fills the same alpha would create a
+   harsh white smear; clip it down so the shine stays subtle. */
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"] .chat-bubble:before {
+  background: linear-gradient(
+    rgba(255, 255, 255, 0.18),
+    rgba(255, 255, 255, 0.05)
+  );
+}
+
+/* Bottom shine — dim AND larger radius (matches the bubble's outer 16px).
+   Light theme used `border-radius: 4px` which felt too tight inside the
+   16px bubble; bumping it now also reads better on the dim fills. */
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"] .chat-bubble:after {
+  background: linear-gradient(
+    rgba(255, 255, 255, 0),
+    rgba(255, 255, 255, 0.12)
+  );
+  border-radius: 4px 4px 14px 14px;
+}
+
+/* Same larger bottom radius for the light theme too — keeps the two modes
+   visually consistent and addresses the request to grow the radius. */
+:root[data-os-theme="macosx"] .chat-bubble:after {
+  border-radius: 4px 4px 14px 14px;
 }

--- a/src/styles/themes.css
+++ b/src/styles/themes.css
@@ -3182,9 +3182,23 @@
     inset -1px 0 0 rgba(255, 255, 255, 0.06);
 }
 
+/* Brushed-metal titlebar text in dark mode — the brushed texture is darker
+   than the regular Aqua titlebar gradient, so the title needs a punchier
+   black drop-shadow (no white halo) to keep the label from sinking into the
+   metal. Stack a sharp 1px drop with a softer 2px blur so it reads as cut
+   through the chrome. */
 :root[data-os-theme="macosx"][data-os-color-scheme="dark"]
-  .window.window-material-brushedmetal.is-foreground .title-bar {
-  text-shadow: 0 1px 0 rgba(0, 0, 0, 0.85) !important;
+  .window.window-material-brushedmetal.is-foreground .title-bar,
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"]
+  .window.window-material-brushedmetal:not(.is-foreground) .title-bar {
+  text-shadow:
+    0 1px 0 rgba(0, 0, 0, 0.95),
+    0 1px 2px rgba(0, 0, 0, 0.65) !important;
+}
+
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"]
+  .window.window-material-brushedmetal .title-bar :where(span, h1, h2, h3) {
+  text-shadow: inherit !important;
 }
 
 /* Side drawer (AppDrawer / TV drawer) reuses the brushed-metal stack */
@@ -3989,4 +4003,21 @@
    visually consistent and addresses the request to grow the radius. */
 :root[data-os-theme="macosx"] .chat-bubble:after {
   border-radius: 4px 4px 14px 14px;
+}
+
+/* --- Finder list view: zebra + header bg ---------------------------------- */
+/* The list view uses `odd:bg-gray-200/50` for zebra rows and `bg-gray-100/50`
+   for table headers. Those compile to `rgb(229, 231, 235, 0.5)` /
+   `rgb(243, 244, 246, 0.5)` which are very bright on the dark window. Tone
+   them down to faint white-on-dark stripes. */
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"]
+  .window-body
+  :where(.bg-gray-200\/50, .odd\:bg-gray-200\/50:nth-child(odd)) {
+  background-color: rgba(255, 255, 255, 0.04) !important;
+}
+
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"]
+  .window-body
+  :where(.bg-gray-100\/50, .hover\:bg-gray-100\/50:hover) {
+  background-color: rgba(255, 255, 255, 0.06) !important;
 }

--- a/src/styles/themes.css
+++ b/src/styles/themes.css
@@ -3139,9 +3139,10 @@
   --os-color-selection-glow: rgba(0, 0, 0, 0.35);
 }
 
-/* Menubar gloss — replace the ::before white-on-white sheen with a darker overlay */
+/* Menubar gloss — replace the ::before white-on-white sheen with a darker
+   overlay. Keep the light-mode `text-shadow` (already a dark drop) so the
+   menubar and dropdown labels read the same way they do in light mode. */
 :root[data-os-theme="macosx"][data-os-color-scheme="dark"] .menubar {
-  text-shadow: 0 1px 1px rgba(0, 0, 0, 0.7);
   box-shadow: 0 1px 0 rgba(255, 255, 255, 0.06) inset,
     0 -1px 0 rgba(0, 0, 0, 0.45) inset;
 }
@@ -3615,26 +3616,11 @@
 }
 
 /* --- Title bar text-shadow ------------------------------------------------ */
-/* The light-mode rule on `.menubar` text uses a bright drop-shadow; on dark
-   surfaces we want a soft black halo so the labels still pop without the
-   "embossed white" look. The titlebar inherits the same. */
-:root[data-os-theme="macosx"][data-os-color-scheme="dark"] .menubar {
-  text-shadow: 0 1px 1px rgba(0, 0, 0, 0.65) !important;
-}
-
-:root[data-os-theme="macosx"][data-os-color-scheme="dark"] .title-bar {
-  text-shadow: 0 1px 0 rgba(0, 0, 0, 0.55) !important;
-}
-
-/* Generic light-on-dark titlebar text fallback for any direct children that
-   still inherit the light-mode `text-shadow: 0 1px 0 rgba(255,255,255,0.7)`
-   from elsewhere — strip the white halo. */
-:root[data-os-theme="macosx"][data-os-color-scheme="dark"]
-  .window
-  .title-bar
-  :where(span, h1, h2, h3) {
-  text-shadow: inherit;
-}
+/* Regular (non-brushed-metal) windows keep the light-mode dark-colored
+   text-shadow on titlebar / menubar labels so dark mode looks visually
+   continuous with light mode. The brushed-metal variant (white halo in
+   light mode) is the one exception — its dark-mode override stays in the
+   brushed-metal block above. */
 
 /* --- Aqua tabs ------------------------------------------------------------ */
 /* Inactive tab: dark graphite gradient instead of light gray-to-white. Active

--- a/src/styles/themes.css
+++ b/src/styles/themes.css
@@ -3555,3 +3555,271 @@
   [role="tab"][data-state="active"] {
   color: var(--os-color-text-primary);
 }
+
+/* ============================================================================
+ * Dark mode — Mac OS X (Aqua) — chrome polish (round 3)
+ *
+ * Fixes surfaced by app-by-app survey:
+ *   - Menubar / Dock surface tint goes dark (Apple logo PNG keeps its colors).
+ *   - Aqua tabs' inactive-state gradient + text-shadow flipped for dark.
+ *   - Title bar text-shadow loses its white halo and gains a soft drop.
+ *   - SearchInput field, magnifier glyph, and clear button switch to
+ *     light-on-dark.
+ *   - Brushed-metal `metal-inset-btn` / `metal-inset-btn-group` get a graphite
+ *     gradient with the same inset-recess feel, and the toggled / active state
+ *     keeps the Aqua-blue selection but on a darker base.
+ *   - Videos LCD + Minesweeper LCD swap to a dark green CRT look with light
+ *     glyphs (and an inverted text-shadow).
+ * ============================================================================ */
+
+/* --- Menubar + Dock surface tint ----------------------------------------- */
+:root[data-os-theme="macosx"] {
+  /* Light defaults — matches the previous inline values in MenuBar.tsx / Dock.tsx. */
+  --os-color-menubar-surface: rgba(248, 248, 248, 0.85);
+  --os-color-dock-surface: rgba(248, 248, 248, 0.75);
+  --os-color-dock-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+}
+
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"] {
+  /* Dark translucent panel — picks up the desktop wallpaper through the blur,
+     similar to how macOS Big Sur+ dark mode tints the menubar. */
+  --os-color-menubar-surface: rgba(28, 28, 30, 0.78);
+  --os-color-dock-surface: rgba(28, 28, 30, 0.72);
+  --os-color-dock-shadow: 0 2px 10px rgba(0, 0, 0, 0.55);
+  /* Menubar text + separator on the new dark tint. */
+  --os-color-menubar-text: #f4f4f5;
+  --os-color-menubar-border: rgba(0, 0, 0, 0.85);
+}
+
+/* The Apple logo is a PNG asset (`apple.png`) — explicitly leave it alone so
+   it keeps its color in dark mode. We only neutralize image-rendering filters
+   that some opt-out themes apply globally. */
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"]
+  .menubar
+  img[alt="Apple Menu"] {
+  filter: none !important;
+}
+
+/* --- Title bar text-shadow ------------------------------------------------ */
+/* The light-mode rule on `.menubar` text uses a bright drop-shadow; on dark
+   surfaces we want a soft black halo so the labels still pop without the
+   "embossed white" look. The titlebar inherits the same. */
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"] .menubar {
+  text-shadow: 0 1px 1px rgba(0, 0, 0, 0.65) !important;
+}
+
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"] .title-bar {
+  text-shadow: 0 1px 0 rgba(0, 0, 0, 0.55) !important;
+}
+
+/* Generic light-on-dark titlebar text fallback for any direct children that
+   still inherit the light-mode `text-shadow: 0 1px 0 rgba(255,255,255,0.7)`
+   from elsewhere — strip the white halo. */
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"]
+  .window
+  .title-bar
+  :where(span, h1, h2, h3) {
+  text-shadow: inherit;
+}
+
+/* --- Aqua tabs ------------------------------------------------------------ */
+/* Inactive tab: dark graphite gradient instead of light gray-to-white. Active
+   tab keeps its blue gloss (matches macOS dark mode behavior — the active
+   selection stays branded). The dropshadow text-shadow under the label loses
+   its `rgba(0,0,0,0.25)` and switches to a soft black + light highlight so
+   inactive-tab labels are readable on the dark base. */
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"] .aqua-tab {
+  background: linear-gradient(rgb(64, 64, 68), rgb(40, 40, 44));
+  box-shadow:
+    inset 0 1px 2px rgba(0, 0, 0, 0.55),
+    inset 0 2px 3px 1px rgba(0, 0, 0, 0.3),
+    0 1px 1px rgba(0, 0, 0, 0.45);
+  color: var(--os-color-text-primary);
+  text-shadow: 0 1px 0 rgba(0, 0, 0, 0.55);
+  border-color: rgba(255, 255, 255, 0.18);
+}
+
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"] .aqua-tab:hover:not([data-state="active"]) {
+  box-shadow:
+    inset 0 1px 2px rgba(0, 0, 0, 0.45),
+    inset 0 2px 3px 1px rgba(0, 0, 0, 0.22),
+    0 1px 1px rgba(0, 0, 0, 0.35);
+}
+
+/* Inactive-tab top-shine becomes a faint light wash (was `rgba(255,255,255,0.55)`
+   which would create a glaring stripe on the dark gradient). */
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"] .aqua-tab:before {
+  background: linear-gradient(
+    rgba(255, 255, 255, 0.12),
+    rgba(255, 255, 255, 0.04)
+  );
+}
+
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"] .aqua-tab:after {
+  background: linear-gradient(transparent, rgba(255, 255, 255, 0.08));
+}
+
+/* Active tab keeps its branded blue gradient — but the under-tab strip
+   (`.aqua-tab-bar:after`) is a light-blue/white seam by default, which reads
+   as an unwelcome glow on dark windows. Darken to a deeper indigo seam. */
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"] .aqua-tab-bar:after {
+  background: linear-gradient(
+    to bottom,
+    #082c5a 0%,
+    #1a4f8c 8%,
+    #1a4276 25%,
+    #133861 40%,
+    #1a4683 60%,
+    #1a4683 80%,
+    #205a9c 100%
+  );
+  box-shadow:
+    inset 0 1px 0 rgba(0, 0, 0, 0.55),
+    inset 0 -1px 0 rgba(0, 0, 0, 0.55);
+}
+
+/* --- Search input + icon -------------------------------------------------- */
+/* The `SearchInput` component pins `bg-white`, `border-black/40`, and a
+   white-glow inset. Override per-attribute so the field reads as a recessed
+   dark pill with a light glyph. */
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"]
+  input[data-os-search-input="true"] {
+  background-color: var(--os-color-input-bg) !important;
+  color: var(--os-color-text-primary) !important;
+  border-color: rgba(255, 255, 255, 0.18) !important;
+  box-shadow:
+    inset 0 1px 2px rgba(0, 0, 0, 0.55),
+    inset 0 0 1px rgba(0, 0, 0, 0.3),
+    0 1px 0 rgba(255, 255, 255, 0.05) !important;
+}
+
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"]
+  input[data-os-search-input="true"]::placeholder {
+  color: var(--os-color-text-disabled);
+}
+
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"] .os-search-icon {
+  color: rgba(255, 255, 255, 0.55) !important;
+}
+
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"] .os-search-clear {
+  color: rgba(255, 255, 255, 0.45) !important;
+}
+
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"] .os-search-clear:hover {
+  color: rgba(255, 255, 255, 0.7) !important;
+}
+
+/* --- Brushed-metal inset toggle buttons (toolbars) ------------------------ */
+/* The `.metal-inset-btn-group` reads as a recessed pill on light brushed
+   metal. In dark mode, swap the metal-stack gradients for a graphite stack
+   so the same depth illusion lands on the dark window. */
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"] .metal-inset-btn-group {
+  box-shadow:
+    inset 0 1px 2px rgba(0, 0, 0, 0.7),
+    inset 0 0 1px rgba(0, 0, 0, 0.45),
+    0 1px 0 rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(0, 0, 0, 0.85);
+}
+
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"] .metal-inset-btn {
+  color: rgba(255, 255, 255, 0.85);
+  background: linear-gradient(
+    to bottom,
+    #4a4a50 0%,
+    #3e3e44 49%,
+    #2f2f33 50%,
+    #3a3a3f 100%
+  );
+  border-right-color: rgba(0, 0, 0, 0.5);
+  text-shadow: 0 1px 0 rgba(0, 0, 0, 0.55);
+}
+
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"] .metal-inset-btn:active,
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"] .metal-inset-btn[data-state="on"] {
+  /* Toggled state — keep the Aqua blue family (matches the active-tab gloss
+     and selection bg) but clip the highlights so the gradient reads on the
+     darker chrome around it. */
+  background: linear-gradient(
+    to bottom,
+    #1f4d8a 0%,
+    #2864a8 49%,
+    #1c4f87 50%,
+    #2a76c2 100%
+  );
+  color: #ffffff;
+  text-shadow: 0 1px 0 rgba(0, 0, 0, 0.4);
+  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.4);
+  border-right-color: rgba(0, 0, 0, 0.4);
+}
+
+/* --- LCD displays (Videos / TV / Minesweeper) ----------------------------- */
+/* Override the `--videos-lcd-*` variables so the existing `.videos-lcd` rules
+   automatically pick up the dark CRT palette (deep green-black background,
+   muted phosphor-green glyphs, inverted text-shadow). The rules already use
+   `var(--videos-lcd-bg)` and `var(--videos-lcd-text)`. */
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"] {
+  --videos-lcd-bg: #0d1d0d;
+  --videos-lcd-text: #6fd07a;
+  --videos-lcd-text-muted: #4ea355;
+  --videos-lcd-fade: #0d1d0d;
+  --videos-lcd-border-dark: #000000d0;
+  --videos-lcd-border-light: rgba(255, 255, 255, 0.05);
+}
+
+/* Existing rule baked in `1px 1px 0 rgba(0, 0, 0, 0.2)` text-shadow that
+   only reads on a light background; swap to a dark drop-shadow that adds
+   a faint green glow under each glyph. */
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"] .videos-lcd {
+  text-shadow: 0 0 4px rgba(111, 208, 122, 0.35),
+    1px 1px 0 rgba(0, 0, 0, 0.85) !important;
+}
+
+/* TV LCD wraps the `.videos-lcd` div in `bg-black` for its strip layout —
+   leave that as-is (the CRT body is meant to be black). The fade-edges
+   inherited from `--videos-lcd-bg` already swap. */
+
+/* Minesweeper LCD — its panel is rendered with hardcoded `bg-[#8a9a8a]
+   text-[#1a2a1a]` Tailwind classes (so the same panel can stay green in
+   light mode for all four themes). Target those exact arbitrary classes
+   only inside the Aqua dark surface. */
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"]
+  .window-body
+  :where(.bg-\[\#8a9a8a\]) {
+  background-color: #0d1d0d !important;
+  border-top-color: #000 !important;
+  border-left-color: #000 !important;
+  border-right-color: rgba(255, 255, 255, 0.08) !important;
+  border-bottom-color: rgba(255, 255, 255, 0.08) !important;
+  text-shadow: 0 0 4px rgba(111, 208, 122, 0.35),
+    1px 1px 0 rgba(0, 0, 0, 0.85) !important;
+}
+
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"]
+  .window-body
+  :where(.text-\[\#1a2a1a\]) {
+  color: #6fd07a !important;
+}
+
+/* Minesweeper face/bezel + cell tray (light gray `bg-[#c0c0c0]` and the
+   `bg-[#b7bcc1]` rounded outer plate) need a graphite skin so the bevels
+   still read. Only swap the panel; cell content uses Geneva-12 numerals
+   that stay readable on the slightly lighter graphite base. */
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"]
+  .window-body
+  :where(.bg-\[\#c0c0c0\]) {
+  background-color: #3a3a3f !important;
+  color: var(--os-color-text-primary) !important;
+}
+
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"]
+  .window-body
+  :where(.bg-\[\#b7bcc1\]) {
+  background-color: #2f2f33 !important;
+}
+
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"]
+  .window-body
+  :where(.hover\:bg-\[\#d0d0d0\]:hover) {
+  background-color: #45454a !important;
+}

--- a/src/sync/domains.ts
+++ b/src/sync/domains.ts
@@ -477,6 +477,10 @@ function serializeSettingsSnapshot(): SettingsSnapshotData {
 
   return {
     theme: useThemeStore.getState().current,
+    themeDarkMode: useThemeStore.getState().darkModeByTheme as Record<
+      string,
+      boolean
+    >,
     language: useLanguageStore.getState().current,
     languageInitialized:
       localStorage.getItem("ryos:language-initialized") === "true",
@@ -989,7 +993,20 @@ async function applySettingsSnapshot(
   try {
     if (sectionsToApply.includes("theme")) {
       try {
-        useThemeStore.getState().setTheme(normalizedData.theme as never);
+        const themeStore = useThemeStore.getState();
+        themeStore.setTheme(normalizedData.theme as never);
+        // Apply per-theme dark-mode preferences in a separate pass so each
+        // entry is only set when the theme advertises support. The store
+        // itself guards against unsupported themes — this loop is purely a
+        // bulk setter for the persisted map.
+        const remoteDarkMap = normalizedData.themeDarkMode;
+        if (remoteDarkMap && typeof remoteDarkMap === "object") {
+          for (const [themeId, enabled] of Object.entries(remoteDarkMap)) {
+            useThemeStore
+              .getState()
+              .setDarkMode(Boolean(enabled), themeId as never);
+          }
+        }
         appliedSections.push("theme");
       } catch (e) {
         console.error("[CloudSync] Failed to apply remote theme:", e);

--- a/src/themes/index.ts
+++ b/src/themes/index.ts
@@ -2,7 +2,13 @@ import { system7 } from "./system7";
 import { macosx } from "./macosx";
 import { xp } from "./xp";
 import { win98 } from "./win98";
-import { OsMacChrome, OsPlatform, OsTheme, OsThemeId, ThemeMetadata } from "./types";
+import {
+  OsMacChrome,
+  OsPlatform,
+  OsTheme,
+  OsThemeId,
+  ThemeMetadata,
+} from "./types";
 
 export const themes: Record<OsThemeId, OsTheme> = {
   system7,
@@ -69,7 +75,16 @@ export function isMacTheme(id: OsThemeId): boolean {
   return themes[id].metadata.isMac;
 }
 
+/**
+ * Whether a theme has dark-mode tokens defined in `themes.css`.
+ * Themes without dark-mode coverage ignore the dark-mode preference at apply time.
+ */
+export function themeSupportsDarkMode(id: OsThemeId): boolean {
+  return themes[id].metadata.supportsDarkMode;
+}
+
 export type {
+  OsColorScheme,
   OsMacChrome,
   OsPlatform,
   OsTheme,

--- a/src/themes/macosx.ts
+++ b/src/themes/macosx.ts
@@ -13,6 +13,7 @@ export const macosx: OsTheme = {
     menuBarHeight: 25,
     taskbarHeight: 0,
     baseDockHeight: 56,
+    supportsDarkMode: true,
   },
   fonts: {
     ui: "LucidaGrande, 'Lucida Grande', ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, sans-serif",

--- a/src/themes/system7.ts
+++ b/src/themes/system7.ts
@@ -13,6 +13,7 @@ export const system7: OsTheme = {
     menuBarHeight: 30,
     taskbarHeight: 0,
     baseDockHeight: 0,
+    supportsDarkMode: false,
   },
   fonts: {
     ui: "Geneva, Chicago, -apple-system, BlinkMacSystemFont, sans-serif",

--- a/src/themes/types.ts
+++ b/src/themes/types.ts
@@ -6,6 +6,9 @@ export type OsPlatform = "mac" | "windows";
 /** Mac subset for Aqua vs System 7 (`data-os-mac-chrome` on `<html>`); unset on Windows themes. */
 export type OsMacChrome = "aqua" | "system7";
 
+/** Color-scheme variant (`data-os-color-scheme` on `<html>`); attribute is omitted in light mode. */
+export type OsColorScheme = "light" | "dark";
+
 /**
  * Theme metadata for conditional rendering and layout decisions.
  * Centralizes theme-based checks that were previously scattered throughout the codebase.
@@ -29,6 +32,8 @@ export interface ThemeMetadata {
   taskbarHeight: number;
   /** Base dock height before scaling (0 if no dock) */
   baseDockHeight: number;
+  /** Whether this theme has dark-mode tokens defined in `themes.css`. */
+  supportsDarkMode: boolean;
 }
 
 export interface OsTheme {

--- a/src/themes/win98.ts
+++ b/src/themes/win98.ts
@@ -13,6 +13,7 @@ export const win98: OsTheme = {
     menuBarHeight: 0,
     taskbarHeight: 30,
     baseDockHeight: 0,
+    supportsDarkMode: false,
   },
   fonts: {
     ui: "Tahoma, MS Sans Serif, sans-serif",

--- a/src/themes/xp.ts
+++ b/src/themes/xp.ts
@@ -13,6 +13,7 @@ export const xp: OsTheme = {
     menuBarHeight: 0,
     taskbarHeight: 30,
     baseDockHeight: 0,
+    supportsDarkMode: false,
   },
   fonts: {
     ui: "Tahoma, Segoe UI, sans-serif",

--- a/src/utils/cloudSyncSettingsMerge.ts
+++ b/src/utils/cloudSyncSettingsMerge.ts
@@ -11,6 +11,8 @@ import {
 
 export interface SettingsSnapshotData {
   theme: string;
+  /** Per-theme dark-mode preferences. Optional for backward compatibility. */
+  themeDarkMode?: Record<string, boolean>;
   language: LanguageCode;
   languageInitialized: boolean;
   aiModel: AIModel | null;
@@ -143,6 +145,9 @@ export function mergeSettingsSnapshotData(
     normalizedRemote.theme !== undefined
   ) {
     merged.theme = normalizedRemote.theme;
+    if (normalizedRemote.themeDarkMode !== undefined) {
+      merged.themeDarkMode = normalizedRemote.themeDarkMode;
+    }
     merged.sectionUpdatedAt!.theme = remoteSectionUpdatedAt.theme;
   }
 
@@ -229,6 +234,12 @@ export function getSectionPayloadForSettingsPatch(
 ): unknown {
   switch (section) {
     case "theme":
+      // Older clients only read this as a string. New clients can also send a
+      // dark-mode map alongside; the receiving side's `applyRemote` handles both
+      // shapes (string-only OR `{ theme, darkMode }`).
+      if (data.themeDarkMode && Object.keys(data.themeDarkMode).length > 0) {
+        return { theme: data.theme, darkMode: data.themeDarkMode };
+      }
       return data.theme;
     case "language":
       return {
@@ -350,7 +361,20 @@ export function applySettingsRedisPatch(
     const val = patch.sections[section];
     switch (section) {
       case "theme":
-        next.theme = val as string;
+        // Backward compat: older patches sent a plain string id. New patches send
+        // `{ theme, darkMode }` so both pieces are written atomically.
+        if (typeof val === "string") {
+          next.theme = val;
+        } else if (val && typeof val === "object") {
+          const v = val as {
+            theme?: string;
+            darkMode?: Record<string, boolean>;
+          };
+          if (typeof v.theme === "string") next.theme = v.theme;
+          if (v.darkMode && typeof v.darkMode === "object") {
+            next.themeDarkMode = { ...v.darkMode };
+          }
+        }
         break;
       case "language": {
         const v = val as {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -238,8 +238,20 @@ module.exports = {
       addVariant("os-windows", ':root[data-os-platform="windows"] &');
       addVariant("os-mac-aqua", ':root[data-os-mac-chrome="aqua"] &');
       addVariant("os-mac-system7", ':root[data-os-mac-chrome="system7"] &');
+      // OS-level color-scheme variants. Only attached when the active theme
+      // supports dark mode (see useThemeStore#applyRootThemeAttributes), so
+      // these never accidentally fire on themes without dark tokens.
+      addVariant("os-dark", ':root[data-os-color-scheme="dark"] &');
+      addVariant(
+        "os-mac-aqua-dark",
+        ':root[data-os-mac-chrome="aqua"][data-os-color-scheme="dark"] &'
+      );
       for (const id of ["system7", "macosx", "xp", "win98"]) {
         addVariant(`os-theme-${id}`, `:root[data-os-theme="${id}"] &`);
+        addVariant(
+          `os-theme-${id}-dark`,
+          `:root[data-os-theme="${id}"][data-os-color-scheme="dark"] &`
+        );
       }
     },
     function ({ addBase }) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Extends the theme system to support opt-in dark mode, starting with macOS Aqua. The plumbing is generic so future themes can light up by setting `metadata.supportsDarkMode = true` and adding a `:root[data-os-theme="…"][data-os-color-scheme="dark"]` token block in `src/styles/themes.css`.

## What changes

**Plumbing**
- `ThemeMetadata` gains `supportsDarkMode`. macOS Aqua = `true`, others = `false`.
- `useThemeStore` now tracks a per-theme `darkModeByTheme` map (persisted as `ryos:theme:dark`), exposes `setDarkMode` / `toggleDarkMode`, and applies a new `data-os-color-scheme="dark"` attribute (plus CSS `color-scheme`) on `<html>` — only when the current theme advertises dark support.
- `index.html` pre-hydrates the new attribute alongside `data-os-theme` / `data-os-platform` / `data-os-mac-chrome` so first paint matches the saved preference.
- Tailwind picks up new `os-dark:`, `os-mac-aqua-dark:`, and `os-theme-<id>-dark:` variants.
- `useThemeFlags()` exposes `supportsDarkMode` and `isDarkMode`.
- Cloud settings sync round-trips the dark-mode map alongside the theme id; old clients still receive a plain string theme.

**Visual: macOS Aqua dark CSS**
- Token block (window/menubar/titlebar/buttons/text/selection/inputs/separators/switch/shadow/pinstripes/traffic-light glyphs) plus structural fixes for menubar gloss, brushed-metal windows, side drawer, drawer list well, and Spotlight panel.
- A second, broader coverage layer remaps shadcn tokens (`--popover`, `--card`, `--background`, `--input`, `--border`) and recolors common hardcoded Tailwind utilities (`bg-white`, `text-black`, `text-neutral-{500..800}`, `border-black/*`) inside `.window-body` so apps that inline those classes still render correctly. The layer explicitly skips tinted utilities (`bg-pink-*`, `bg-blue-*`, etc.) so chat bubbles, badges, and similar tinted surfaces keep their authored colors and readable foregrounds. Force-font shells (iPod, karaoke, TV CC, dashboard overlay, Webamp) are excluded so legacy chrome that bakes in its own colors is left alone.
- Repaints Radix-portaled dropdown / select / popover surfaces, separators, disabled items. Sonner toasts and Finder's status bar updated.

**UI**
- Control Panels → Appearance gets a Dark Mode switch that only appears when the active theme supports dark mode.

**Docs**
- `docs/3.3.1-theme-architecture.md` and `.cursor/skills/ui-design-styling/SKILL.md` updated.

## Why per-theme

The preference is stored per theme so flipping back to a dark-supported theme remembers the previous choice, and so toggling the switch on an unsupported theme never silently mutates that theme's chrome.

## Walkthrough

Light mode (baseline):

![macOS Aqua light desktop](https://cursor.com/artifacts/c/art-6a67ad14-44f9-450e-aca0-ddffb4892584)

Control Panels → Appearance with the new Dark Mode toggle:

![Control Panels with Dark Mode toggle off](https://cursor.com/artifacts/c/art-8f8a4179-eb4f-4a67-95b0-4c83e144802c)
![Control Panels Appearance tab in dark mode](https://cursor.com/artifacts/c/art-62a4b12e-aa0f-4631-8eab-de236a1a56b5)

Dark mode after the broader coverage pass — menubar dropdown, Finder, Chats, TextEdit, and Control Panels System tab:

![Menubar dropdown in dark mode](https://cursor.com/artifacts/c/art-79d58504-ed9b-49a6-8126-ac49ba2f42c2)
![Finder in dark mode](https://cursor.com/artifacts/c/art-9facc2e7-fde5-4219-a41c-4da99b186f17)
![Chats in dark mode](https://cursor.com/artifacts/c/art-cbf9cac1-c2ef-4958-8f81-e56813933ae6)
![TextEdit in dark mode](https://cursor.com/artifacts/c/art-aefb94e8-2dbd-4416-8614-785c4c31ab69)
![Control Panels System tab in dark mode](https://cursor.com/artifacts/c/art-6a174532-8890-4706-a231-cff1c5ec92c5)

Before the coverage pass (first iteration — kept for reference) Finder and Chats still painted white over the dark window:

![Finder before coverage pass](https://cursor.com/artifacts/c/art-5e0ccf67-2dc6-497f-9f24-ca520f2a77fb)
![Chats before coverage pass](https://cursor.com/artifacts/c/art-0a9c9c90-96e5-4a37-8a40-1adc1c3d8922)

## Testing

- ✅ `bun x tsc -b --noEmit`
- ✅ `bun run test:unit` (236 / 236 pass)
- ✅ `bun x eslint` on touched files (no new errors)
- ✅ `bun run build`
- ✅ Manual visual survey across menubar dropdown, Finder, Chats, TextEdit, Control Panels (Appearance + System), and Internet Explorer — see screenshots above

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7E69CCB4-60F4-4811-AAFC-A727ABBD7AAC"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7E69CCB4-60F4-4811-AAFC-A727ABBD7AAC"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

