### PR TITLE
refactor: replace Tailwind gray palette with neutral

### DIFF
--- a/src/apps/admin/components/AdminAppComponent.tsx
+++ b/src/apps/admin/components/AdminAppComponent.tsx
@@ -627,16 +627,16 @@ export function AdminAppComponent({
                         <Table>
                           <TableHeader>
                             <TableRow className="text-[10px] border-none font-normal">
-                              <TableHead className="font-normal bg-gray-100/50 h-[28px]">
+                              <TableHead className="font-normal bg-neutral-100/50 h-[28px]">
                                 {t("apps.admin.tableHeaders.username")}
                               </TableHead>
-                              <TableHead className="font-normal bg-gray-100/50 h-[28px]">
+                              <TableHead className="font-normal bg-neutral-100/50 h-[28px]">
                                 {t("apps.admin.tableHeaders.status")}
                               </TableHead>
-                              <TableHead className="font-normal bg-gray-100/50 h-[28px] whitespace-nowrap">
+                              <TableHead className="font-normal bg-neutral-100/50 h-[28px] whitespace-nowrap">
                                 {t("apps.admin.tableHeaders.lastActive")}
                               </TableHead>
-                              <TableHead className="font-normal bg-gray-100/50 h-[28px] w-8"></TableHead>
+                              <TableHead className="font-normal bg-neutral-100/50 h-[28px] w-8"></TableHead>
                             </TableRow>
                           </TableHeader>
                           <TableBody className="text-[11px]">
@@ -644,7 +644,7 @@ export function AdminAppComponent({
                               <TableRow
                                 key={user.username}
                                 className={cn(
-                                  "border-none hover:bg-gray-100/50 transition-colors cursor-pointer odd:bg-gray-200/50 group",
+                                  "border-none hover:bg-neutral-100/50 transition-colors cursor-pointer odd:bg-neutral-200/50 group",
                                   user.banned && "bg-red-50/50 odd:bg-red-50/70"
                                 )}
                                 onClick={() =>
@@ -763,19 +763,19 @@ export function AdminAppComponent({
                       </div>
                     ) : (
                       <>
-                        <div className="w-full min-w-0 divide-y divide-gray-200">
+                        <div className="w-full min-w-0 divide-y divide-neutral-200">
                           {filteredSongs
                             .slice(0, visibleSongsCount)
                             .map((song) => (
                               <div
                                 key={song.youtubeId}
-                                className="flex w-full min-w-0 items-center gap-3 px-3 py-2 hover:bg-gray-100/50 transition-colors cursor-pointer group"
+                                className="flex w-full min-w-0 items-center gap-3 px-3 py-2 hover:bg-neutral-100/50 transition-colors cursor-pointer group"
                                 onClick={() =>
                                   setSelectedSongId(song.youtubeId)
                                 }
                               >
                                 {/* Cover Image */}
-                                <div className="size-10 flex-shrink-0 rounded overflow-hidden bg-gray-200">
+                                <div className="size-10 flex-shrink-0 rounded overflow-hidden bg-neutral-200">
                                   <img
                                     src={
                                       formatKugouImageUrl(song.cover, 100) ||
@@ -863,23 +863,23 @@ export function AdminAppComponent({
                     <Table>
                       <TableHeader>
                         <TableRow className="text-[10px] border-none font-normal">
-                          <TableHead className="font-normal bg-gray-100/50 h-[28px]">
+                          <TableHead className="font-normal bg-neutral-100/50 h-[28px]">
                             {t("apps.admin.tableHeaders.user")}
                           </TableHead>
-                          <TableHead className="font-normal bg-gray-100/50 h-[28px]">
+                          <TableHead className="font-normal bg-neutral-100/50 h-[28px]">
                             {t("apps.admin.tableHeaders.message")}
                           </TableHead>
-                          <TableHead className="font-normal bg-gray-100/50 h-[28px] whitespace-nowrap">
+                          <TableHead className="font-normal bg-neutral-100/50 h-[28px] whitespace-nowrap">
                             {t("apps.admin.tableHeaders.time")}
                           </TableHead>
-                          <TableHead className="font-normal bg-gray-100/50 h-[28px] w-8"></TableHead>
+                          <TableHead className="font-normal bg-neutral-100/50 h-[28px] w-8"></TableHead>
                         </TableRow>
                       </TableHeader>
                       <TableBody className="text-[11px]">
                         {roomMessages.map((message) => (
                           <TableRow
                             key={message.id}
-                            className="border-none hover:bg-gray-100/50 transition-colors cursor-default odd:bg-gray-200/50 group"
+                            className="border-none hover:bg-neutral-100/50 transition-colors cursor-default odd:bg-neutral-200/50 group"
                           >
                             <TableCell className="flex items-center gap-2 whitespace-nowrap">
                               <div className="size-4 rounded-full bg-neutral-200 flex items-center justify-center text-[9px] font-medium text-neutral-600">
@@ -919,7 +919,7 @@ export function AdminAppComponent({
             </ScrollArea>
 
             {/* Status Bar */}
-            <div className="os-status-bar os-status-bar-text flex items-center justify-between px-2 py-1 text-[10px] font-geneva-12 bg-gray-100 border-t border-gray-300">
+            <div className="os-status-bar os-status-bar-text flex items-center justify-between px-2 py-1 text-[10px] font-geneva-12 bg-neutral-100 border-t border-neutral-300">
               <span>
                 {activeSection === "dashboard"
                   ? t("apps.admin.sidebar.dashboard", "Dashboard")

--- a/src/apps/admin/components/CursorAgentsPanel.tsx
+++ b/src/apps/admin/components/CursorAgentsPanel.tsx
@@ -368,7 +368,7 @@ export function CursorAgentsPanel({
                   }
                 }}
                 className={cn(
-                  "border-none odd:bg-gray-200/50 cursor-pointer",
+                  "border-none odd:bg-neutral-200/50 cursor-pointer",
                   run.status === "running" && "bg-amber-50/60 odd:bg-amber-50/70",
                   selectedRunId === run.runId &&
                     "bg-blue-100/80 odd:bg-blue-100/80"

--- a/src/apps/admin/components/DashboardPanel.tsx
+++ b/src/apps/admin/components/DashboardPanel.tsx
@@ -170,7 +170,7 @@ function StatCard({
   trend?: { value: number; label: string };
 }) {
   return (
-    <div className="flex flex-col gap-1 p-3 bg-white rounded border border-gray-200">
+    <div className="flex flex-col gap-1 p-3 bg-white rounded border border-neutral-200">
       <span className="text-[10px] uppercase tracking-wide text-neutral-400">
         {label}
       </span>
@@ -248,14 +248,14 @@ function BreakdownList({
   }
   const max = items[0]?.count || 1;
   return (
-    <div className="divide-y divide-gray-100">
+    <div className="divide-y divide-neutral-100">
       {items.slice(0, 10).map((item) => (
         <div key={item.name} className="flex items-center gap-2 px-3 py-1.5">
           <span className={cn("text-[11px] text-neutral-600 flex-1 truncate", nameClassName)}>
             {renderName ? renderName(item.name) : item.name}
           </span>
           <div className="w-24 flex items-center gap-1.5">
-            <div className="flex-1 h-1.5 bg-gray-100 rounded-full overflow-hidden">
+            <div className="flex-1 h-1.5 bg-neutral-100 rounded-full overflow-hidden">
               <div
                 className={cn("h-full rounded-full", barClassName)}
                 style={{ width: `${(item.count / max) * 100}%` }}
@@ -469,7 +469,7 @@ export function DashboardPanel({ onRefresh }: DashboardPanelProps) {
 
         {showTimeSeriesCharts ? (
           <div className="grid grid-cols-1 md:grid-cols-2 gap-3 px-3 pb-3">
-            <div className="border border-gray-200 rounded p-3 bg-white">
+            <div className="border border-neutral-200 rounded p-3 bg-white">
               <div className="text-[10px] uppercase tracking-wide text-neutral-400 mb-2">
                 {t("apps.admin.dashboard.charts.apiCalls")}
               </div>
@@ -486,7 +486,7 @@ export function DashboardPanel({ onRefresh }: DashboardPanelProps) {
               </div>
             </div>
 
-            <div className="border border-gray-200 rounded p-3 bg-white">
+            <div className="border border-neutral-200 rounded p-3 bg-white">
               <div className="text-[10px] uppercase tracking-wide text-neutral-400 mb-2">
                 {t("apps.admin.dashboard.charts.uniqueVisitors")}
               </div>
@@ -508,7 +508,7 @@ export function DashboardPanel({ onRefresh }: DashboardPanelProps) {
               </div>
             </div>
 
-            <div className="border border-gray-200 rounded p-3 bg-white">
+            <div className="border border-neutral-200 rounded p-3 bg-white">
               <div className="text-[10px] uppercase tracking-wide text-neutral-400 mb-2">
                 {t("apps.admin.dashboard.charts.aiRequests")}
               </div>
@@ -525,7 +525,7 @@ export function DashboardPanel({ onRefresh }: DashboardPanelProps) {
               </div>
             </div>
 
-            <div className="border border-gray-200 rounded p-3 bg-white">
+            <div className="border border-neutral-200 rounded p-3 bg-white">
               <div className="text-[10px] uppercase tracking-wide text-neutral-400 mb-2">
                 {t("apps.admin.dashboard.charts.errors")}
               </div>
@@ -546,8 +546,8 @@ export function DashboardPanel({ onRefresh }: DashboardPanelProps) {
 
         {/* Top Endpoints */}
         <div className="px-3 pb-3">
-          <div className="border border-gray-200 rounded bg-white overflow-hidden">
-            <div className="px-3 py-2 border-b border-gray-100 bg-gray-50">
+          <div className="border border-neutral-200 rounded bg-white overflow-hidden">
+            <div className="px-3 py-2 border-b border-neutral-100 bg-neutral-50">
               <span className="text-[10px] uppercase tracking-wide text-neutral-400">
                 {t("apps.admin.dashboard.sections.topEndpoints")} ({rangeLabel})
               </span>
@@ -555,7 +555,7 @@ export function DashboardPanel({ onRefresh }: DashboardPanelProps) {
             {topEndpoints.length === 0 ? (
               <EmptyState message={t("apps.admin.dashboard.empty.noData")} />
             ) : (
-              <div className="divide-y divide-gray-100">
+              <div className="divide-y divide-neutral-100">
                 {topEndpoints.slice(0, 10).map((ep) => (
                   <div
                     key={ep.endpoint}
@@ -565,7 +565,7 @@ export function DashboardPanel({ onRefresh }: DashboardPanelProps) {
                       {ep.endpoint}
                     </span>
                     <div className="w-24 flex items-center gap-1.5">
-                      <div className="flex-1 h-1.5 bg-gray-100 rounded-full overflow-hidden">
+                      <div className="flex-1 h-1.5 bg-neutral-100 rounded-full overflow-hidden">
                         <div
                           className="h-full bg-indigo-400 rounded-full"
                           style={{
@@ -586,8 +586,8 @@ export function DashboardPanel({ onRefresh }: DashboardPanelProps) {
 
         {/* Status Codes & AI Usage */}
         <div className="grid grid-cols-1 md:grid-cols-2 gap-3 px-3 pb-3">
-          <div className="border border-gray-200 rounded bg-white overflow-hidden">
-            <div className="px-3 py-2 border-b border-gray-100 bg-gray-50">
+          <div className="border border-neutral-200 rounded bg-white overflow-hidden">
+            <div className="px-3 py-2 border-b border-neutral-100 bg-neutral-50">
               <span className="text-[10px] uppercase tracking-wide text-neutral-400">
                 {t("apps.admin.dashboard.sections.statusCodes")}
               </span>
@@ -595,7 +595,7 @@ export function DashboardPanel({ onRefresh }: DashboardPanelProps) {
             {statusCodes.length === 0 ? (
               <EmptyState message={t("apps.admin.dashboard.empty.noData")} />
             ) : (
-              <div className="divide-y divide-gray-100">
+              <div className="divide-y divide-neutral-100">
                 {statusCodes.map((sc) => (
                   <div
                     key={sc.status}
@@ -621,8 +621,8 @@ export function DashboardPanel({ onRefresh }: DashboardPanelProps) {
             )}
           </div>
 
-          <div className="border border-gray-200 rounded bg-white overflow-hidden">
-            <div className="px-3 py-2 border-b border-gray-100 bg-gray-50">
+          <div className="border border-neutral-200 rounded bg-white overflow-hidden">
+            <div className="px-3 py-2 border-b border-neutral-100 bg-neutral-50">
               <span className="text-[10px] uppercase tracking-wide text-neutral-400">
                 {t("apps.admin.dashboard.sections.aiUsageByUser")}
               </span>
@@ -630,7 +630,7 @@ export function DashboardPanel({ onRefresh }: DashboardPanelProps) {
             {aiByUser.length === 0 ? (
               <EmptyState message={t("apps.admin.dashboard.empty.noAiUsage")} />
             ) : (
-              <div className="divide-y divide-gray-100">
+              <div className="divide-y divide-neutral-100">
                 {aiByUser.map((entry) => {
                   const rl = aiRateLimits.find(
                     (r) => r.identifier === entry.username
@@ -677,7 +677,7 @@ export function DashboardPanel({ onRefresh }: DashboardPanelProps) {
 
         {showTimeSeriesCharts ? (
           <div className="px-3 pb-3">
-            <div className="border border-gray-200 rounded p-3 bg-white">
+            <div className="border border-neutral-200 rounded p-3 bg-white">
               <div className="text-[10px] uppercase tracking-wide text-neutral-400 mb-2">
                 {t("apps.admin.dashboard.charts.avgResponseTime")}
               </div>
@@ -786,9 +786,9 @@ export function DashboardPanel({ onRefresh }: DashboardPanelProps) {
               ).map((section) => (
                 <div
                   key={section.title}
-                  className="border border-gray-200 rounded bg-white overflow-hidden"
+                  className="border border-neutral-200 rounded bg-white overflow-hidden"
                 >
-                  <div className="px-3 py-2 border-b border-gray-100 bg-gray-50">
+                  <div className="px-3 py-2 border-b border-neutral-100 bg-neutral-50">
                     <span className="text-[10px] uppercase tracking-wide text-neutral-400">
                       {section.title}
                     </span>

--- a/src/apps/admin/components/DashboardServerCard.tsx
+++ b/src/apps/admin/components/DashboardServerCard.tsx
@@ -131,8 +131,8 @@ export function DashboardServerCard({ reloadKey = 0 }: { reloadKey?: number }) {
   const commitUrl = ryosGitHubCommitUrl(versionInfo);
 
   return (
-    <div className="overflow-hidden rounded border border-gray-200 bg-white">
-      <div className="border-b border-gray-100 bg-gray-50 px-3 py-2">
+    <div className="overflow-hidden rounded border border-neutral-200 bg-white">
+      <div className="border-b border-neutral-100 bg-neutral-50 px-3 py-2">
         <span className="text-[10px] uppercase tracking-wide text-neutral-400">
           {t("apps.admin.server.title", "Server")}
         </span>
@@ -153,7 +153,7 @@ export function DashboardServerCard({ reloadKey = 0 }: { reloadKey?: number }) {
           </Button>
         </div>
       ) : (
-        <div className="divide-y divide-gray-100">
+        <div className="divide-y divide-neutral-100">
           <InfoRow
             label={t("apps.admin.server.version", "Version")}
             value={versionInfo?.version ?? "—"}

--- a/src/apps/admin/components/SongDetailPanel.tsx
+++ b/src/apps/admin/components/SongDetailPanel.tsx
@@ -576,7 +576,7 @@ export const SongDetailPanel: React.FC<SongDetailPanelProps> = ({
   return (
     <div className="flex flex-col h-full font-geneva-12">
       {/* Header */}
-      <div className="flex items-center gap-2 px-3 py-2 border-b border-gray-200 bg-gray-50">
+      <div className="flex items-center gap-2 px-3 py-2 border-b border-neutral-200 bg-neutral-50">
         <Button
           variant="ghost"
           size="sm"

--- a/src/apps/admin/components/UserProfilePanel.tsx
+++ b/src/apps/admin/components/UserProfilePanel.tsx
@@ -528,7 +528,7 @@ export const UserProfilePanel: React.FC<UserProfilePanelProps> = ({
   return (
     <div className="flex flex-col h-full font-geneva-12">
       {/* Header */}
-      <div className="flex items-center gap-2 px-3 py-2 border-b border-gray-200 bg-gray-50">
+      <div className="flex items-center gap-2 px-3 py-2 border-b border-neutral-200 bg-neutral-50">
         <Button
           variant="ghost"
           size="sm"
@@ -763,13 +763,13 @@ export const UserProfilePanel: React.FC<UserProfilePanelProps> = ({
                         <Table className="table-fixed">
                           <TableHeader>
                             <TableRow className="text-[10px] border-none font-normal">
-                              <TableHead className="font-normal bg-gray-100/50 h-[24px] w-[30%]">
+                              <TableHead className="font-normal bg-neutral-100/50 h-[24px] w-[30%]">
                                 {t("apps.admin.profile.memoryKey")}
                               </TableHead>
-                              <TableHead className="font-normal bg-gray-100/50 h-[24px]">
+                              <TableHead className="font-normal bg-neutral-100/50 h-[24px]">
                                 {t("apps.admin.profile.memorySummary")}
                               </TableHead>
-                              <TableHead className="font-normal bg-gray-100/50 h-[24px] whitespace-nowrap w-[20%]">
+                              <TableHead className="font-normal bg-neutral-100/50 h-[24px] whitespace-nowrap w-[20%]">
                                 {t("apps.admin.tableHeaders.time")}
                               </TableHead>
                             </TableRow>
@@ -782,8 +782,8 @@ export const UserProfilePanel: React.FC<UserProfilePanelProps> = ({
                                   <TableRow
                                     onClick={() => toggleMemory(memory.key)}
                                     className={cn(
-                                      "border-none hover:bg-gray-100/50 transition-colors cursor-pointer",
-                                      index % 2 === 1 && "bg-gray-200/30"
+                                      "border-none hover:bg-neutral-100/50 transition-colors cursor-pointer",
+                                      index % 2 === 1 && "bg-neutral-200/30"
                                     )}
                                   >
                                     <TableCell>
@@ -807,7 +807,7 @@ export const UserProfilePanel: React.FC<UserProfilePanelProps> = ({
                                     <TableRow
                                       className={cn(
                                         "border-none",
-                                        index % 2 === 1 ? "bg-gray-200/30" : ""
+                                        index % 2 === 1 ? "bg-neutral-200/30" : ""
                                       )}
                                     >
                                       <TableCell colSpan={3} className="pt-0 pb-3">
@@ -859,7 +859,7 @@ export const UserProfilePanel: React.FC<UserProfilePanelProps> = ({
                                 <div key={note.date}>
                                   <button
                                     onClick={() => toggleDailyNote(note.date)}
-                                    className="flex items-center gap-1.5 w-full text-left text-[11px] hover:bg-gray-100/50 px-1 py-0.5 rounded transition-colors"
+                                    className="flex items-center gap-1.5 w-full text-left text-[11px] hover:bg-neutral-100/50 px-1 py-0.5 rounded transition-colors"
                                   >
                                     <CaretRight
                                       className={cn(
@@ -940,13 +940,13 @@ export const UserProfilePanel: React.FC<UserProfilePanelProps> = ({
                           <Table className="table-fixed">
                             <TableHeader>
                               <TableRow className="text-[10px] border-none font-normal">
-                                <TableHead className="font-normal bg-gray-100/50 h-[24px] w-[22%]">
+                                <TableHead className="font-normal bg-neutral-100/50 h-[24px] w-[22%]">
                                   {t("apps.admin.tableHeaders.status")}
                                 </TableHead>
-                                <TableHead className="font-normal bg-gray-100/50 h-[24px]">
+                                <TableHead className="font-normal bg-neutral-100/50 h-[24px]">
                                   {t("apps.admin.tableHeaders.message")}
                                 </TableHead>
-                                <TableHead className="font-normal bg-gray-100/50 h-[24px] whitespace-nowrap w-[25%]">
+                                <TableHead className="font-normal bg-neutral-100/50 h-[24px] whitespace-nowrap w-[25%]">
                                   {t("apps.admin.tableHeaders.time")}
                                 </TableHead>
                               </TableRow>
@@ -959,8 +959,8 @@ export const UserProfilePanel: React.FC<UserProfilePanelProps> = ({
                                     <TableRow
                                       onClick={() => toggleHeartbeat(hb.id)}
                                       className={cn(
-                                        "border-none hover:bg-gray-100/50 transition-colors cursor-pointer",
-                                        index % 2 === 1 && "bg-gray-200/30"
+                                        "border-none hover:bg-neutral-100/50 transition-colors cursor-pointer",
+                                        index % 2 === 1 && "bg-neutral-200/30"
                                       )}
                                     >
                                       <TableCell className="whitespace-nowrap">
@@ -993,7 +993,7 @@ export const UserProfilePanel: React.FC<UserProfilePanelProps> = ({
                                       <TableRow
                                         className={cn(
                                           "border-none",
-                                          index % 2 === 1 ? "bg-gray-200/30" : ""
+                                          index % 2 === 1 ? "bg-neutral-200/30" : ""
                                         )}
                                       >
                                         <TableCell colSpan={3} className="pt-0 pb-3">
@@ -1067,7 +1067,7 @@ export const UserProfilePanel: React.FC<UserProfilePanelProps> = ({
                       {profile?.rooms?.map((room) => (
                         <span
                           key={room.id}
-                          className="px-2 py-1 text-[10px] bg-gray-100 rounded"
+                          className="px-2 py-1 text-[10px] bg-neutral-100 rounded"
                         >
                           #{room.name}
                         </span>
@@ -1112,13 +1112,13 @@ export const UserProfilePanel: React.FC<UserProfilePanelProps> = ({
                     <Table className="table-fixed">
                       <TableHeader>
                         <TableRow className="text-[10px] border-none font-normal">
-                          <TableHead className="font-normal bg-gray-100/50 h-[24px] w-[25%]">
+                          <TableHead className="font-normal bg-neutral-100/50 h-[24px] w-[25%]">
                             {t("apps.admin.profile.room")}
                           </TableHead>
-                          <TableHead className="font-normal bg-gray-100/50 h-[24px]">
+                          <TableHead className="font-normal bg-neutral-100/50 h-[24px]">
                             {t("apps.admin.tableHeaders.message")}
                           </TableHead>
-                          <TableHead className="font-normal bg-gray-100/50 h-[24px] whitespace-nowrap w-[20%]">
+                          <TableHead className="font-normal bg-neutral-100/50 h-[24px] whitespace-nowrap w-[20%]">
                             {t("apps.admin.tableHeaders.time")}
                           </TableHead>
                         </TableRow>
@@ -1127,7 +1127,7 @@ export const UserProfilePanel: React.FC<UserProfilePanelProps> = ({
                         {messages.map((message) => (
                           <TableRow
                             key={message.id}
-                            className="border-none hover:bg-gray-100/50 transition-colors cursor-default odd:bg-gray-200/30"
+                            className="border-none hover:bg-neutral-100/50 transition-colors cursor-default odd:bg-neutral-200/30"
                           >
                             <TableCell>
                               <span className="text-neutral-500">#</span>

--- a/src/apps/applet-viewer/components/AppStore.tsx
+++ b/src/apps/applet-viewer/components/AppStore.tsx
@@ -614,7 +614,7 @@ export function AppStore({ theme, sharedAppletId, focusWindow }: AppStoreProps) 
         <div
           key={applet.id}
           className={`group flex items-center gap-3 px-3 py-2 rounded transition-colors ${
-            installed ? "cursor-pointer hover:bg-gray-100" : "cursor-pointer hover:bg-gray-100"
+            installed ? "cursor-pointer hover:bg-neutral-100" : "cursor-pointer hover:bg-neutral-100"
           }`}
           onClick={(e) => {
             // Don't trigger if clicking on buttons or admin actions
@@ -639,11 +639,11 @@ export function AppStore({ theme, sharedAppletId, focusWindow }: AppStoreProps) 
               </span>
             </div>
             {updateAvailable && applet.createdAt ? (
-              <div className="text-[10px] text-gray-500 font-geneva-12 truncate">
+              <div className="text-[10px] text-neutral-500 font-geneva-12 truncate">
                 {formatUpdateTime(applet.createdAt)}
               </div>
             ) : applet.createdBy ? (
-              <div className="text-[10px] text-gray-500 font-geneva-12 truncate">
+              <div className="text-[10px] text-neutral-500 font-geneva-12 truncate">
                 {applet.createdBy}
               </div>
             ) : null}
@@ -656,11 +656,11 @@ export function AppStore({ theme, sharedAppletId, focusWindow }: AppStoreProps) 
                     e.stopPropagation();
                     handleToggleFeatured(applet.id, applet.featured || false);
                   }}
-                  className="p-1 hover:bg-gray-200 rounded transition-all inline-flex md:hidden md:group-hover:inline-flex"
+                  className="p-1 hover:bg-neutral-200 rounded transition-all inline-flex md:hidden md:group-hover:inline-flex"
                   title={applet.featured ? t("apps.applet-viewer.labels.removeFromFeatured") : t("apps.applet-viewer.labels.addToFeatured")}
                 >
                   <Star
-                    className={`size-4 ${applet.featured ? "text-yellow-400" : "text-gray-400"}`}
+                    className={`size-4 ${applet.featured ? "text-yellow-400" : "text-neutral-400"}`}
                     weight={applet.featured ? "fill" : "bold"}
                   />
                 </button>
@@ -669,7 +669,7 @@ export function AppStore({ theme, sharedAppletId, focusWindow }: AppStoreProps) 
                     e.stopPropagation();
                     handleDelete(applet.id);
                   }}
-                  className="p-1 hover:bg-gray-200 rounded transition-all text-gray-400 inline-flex md:hidden md:group-hover:inline-flex"
+                  className="p-1 hover:bg-neutral-200 rounded transition-all text-neutral-400 inline-flex md:hidden md:group-hover:inline-flex"
                   title={t("apps.applet-viewer.labels.deleteApplet")}
                 >
                   <Trash className="size-4" weight="bold" />
@@ -741,8 +741,8 @@ export function AppStore({ theme, sharedAppletId, focusWindow }: AppStoreProps) 
                 : isMacChrome
                 ? ""
                 : isSystem7Chrome
-                ? "bg-gray-100 border-b border-black"
-                : "bg-gray-100 border-b border-gray-200"
+                ? "bg-neutral-100 border-b border-black"
+                : "bg-neutral-100 border-b border-neutral-200"
             }`}
             style={{
               background: isXpTheme ? "transparent" : undefined,
@@ -877,8 +877,8 @@ export function AppStore({ theme, sharedAppletId, focusWindow }: AppStoreProps) 
                   : isMacChrome
                   ? ""
                   : isSystem7Chrome
-                  ? "bg-gray-100 border-b border-black"
-                  : "bg-gray-100 border-b border-gray-200"
+                  ? "bg-neutral-100 border-b border-black"
+                  : "bg-neutral-100 border-b border-neutral-200"
               }`}
               style={{
                 background: isXpTheme ? "transparent" : undefined,

--- a/src/apps/applet-viewer/components/AppStoreFeed.tsx
+++ b/src/apps/applet-viewer/components/AppStoreFeed.tsx
@@ -567,13 +567,13 @@ const renderAppletCard = (applet: Applet, index: number) => {
             );
           })()
         ) : isLoadingContent ? (
-          <div className="flex items-center justify-center h-full bg-gray-50">
+          <div className="flex items-center justify-center h-full bg-neutral-50">
             <div className="text-center">
               <p className="text-sm text-neutral-600 font-geneva-12 shimmer-gray">{t("apps.applet-viewer.dialogs.loading")}</p>
             </div>
           </div>
         ) : (
-          <div className="h-full w-full bg-gray-50" />
+          <div className="h-full w-full bg-neutral-50" />
         )}
       </div>
 
@@ -585,8 +585,8 @@ const renderAppletCard = (applet: Applet, index: number) => {
             : isMacTheme
             ? ""
             : isSystem7Theme
-            ? "bg-gray-100 border-b border-black"
-            : "bg-gray-100 border-b border-gray-200"
+            ? "bg-neutral-100 border-b border-black"
+            : "bg-neutral-100 border-b border-neutral-200"
         }`}
         style={{
           flexWrap: "nowrap",
@@ -609,7 +609,7 @@ const renderAppletCard = (applet: Applet, index: number) => {
             {displayName}
           </div>
           {applet.createdBy && (
-            <div className="text-[10px] text-gray-500 font-geneva-12 truncate">
+            <div className="text-[10px] text-neutral-500 font-geneva-12 truncate">
               {applet.createdBy}
             </div>
           )}

--- a/src/apps/calendar/components/CalendarMenuBar.tsx
+++ b/src/apps/calendar/components/CalendarMenuBar.tsx
@@ -89,14 +89,14 @@ export function CalendarMenuBar({
           <MenubarItem
             onClick={undo}
             disabled={!canUndo}
-            className={`text-md h-6 px-3 ${!canUndo ? "text-gray-500" : ""}`}
+            className={`text-md h-6 px-3 ${!canUndo ? "text-neutral-500" : ""}`}
           >
             {t("common.menu.undo")}
           </MenubarItem>
           <MenubarItem
             onClick={redo}
             disabled={!canRedo}
-            className={`text-md h-6 px-3 ${!canRedo ? "text-gray-500" : ""}`}
+            className={`text-md h-6 px-3 ${!canRedo ? "text-neutral-500" : ""}`}
           >
             {t("common.menu.redo")}
           </MenubarItem>

--- a/src/apps/chats/components/ChatInput.tsx
+++ b/src/apps/chats/components/ChatInput.tsx
@@ -539,10 +539,10 @@ export const ChatInput = memo(function ChatInput({
                 <div
                   className={`relative overflow-hidden ${
                     isMacTheme 
-                      ? "chat-bubble macosx-link-preview rounded-[16px] bg-gray-100" 
+                      ? "chat-bubble macosx-link-preview rounded-[16px] bg-neutral-100" 
                       : isXpTheme 
                       ? "rounded-none border border-[#7f9db9] bg-white" 
-                      : "rounded-md border border-gray-200 bg-white"
+                      : "rounded-md border border-neutral-200 bg-white"
                   }`}
                 >
                   {/* Full bleed image for macOS */}
@@ -726,7 +726,7 @@ export const ChatInput = memo(function ChatInput({
                       ? t("apps.chats.status.typeMessage")
                       : t("apps.chats.status.typeOrPushSpace")
                   }
-                  className={`w-full border-1 border-gray-800 text-xs font-geneva-12 h-9 ${
+                  className={`w-full border-1 border-neutral-800 text-xs font-geneva-12 h-9 ${
                     isMacTheme ? "pl-3 pr-[88px] rounded-full" : "pl-2 pr-[88px]"
                   } backdrop-blur-lg bg-white/80 ${
                     isFocused ? "input--focused" : ""
@@ -752,7 +752,7 @@ export const ChatInput = memo(function ChatInput({
                       transition={{ duration: 0.15 }}
                       className="absolute top-0 left-0 size-full pointer-events-none flex items-center pl-3"
                     >
-                      <span className="text-gray-500 opacity-70 shimmer-gray text-[13px] font-geneva-12">
+                      <span className="text-neutral-500 opacity-70 shimmer-gray text-[13px] font-geneva-12">
                         {t("apps.chats.status.thinking")}
                         <AnimatedEllipsis />
                       </span>
@@ -889,7 +889,7 @@ export const ChatInput = memo(function ChatInput({
                       ? "relative overflow-hidden transition-transform hover:scale-105"
                       : isXpTheme
                       ? "text-black"
-                      : "bg-black hover:bg-black/80 text-white border-2 border-gray-800"
+                      : "bg-black hover:bg-black/80 text-white border-2 border-neutral-800"
                   }`}
                   style={
                     isMacTheme
@@ -964,7 +964,7 @@ export const ChatInput = memo(function ChatInput({
                       ? "relative overflow-hidden transition-transform hover:scale-105"
                       : isXpTheme
                       ? "text-black"
-                      : "bg-black hover:bg-black/80 text-white border-2 border-gray-800"
+                      : "bg-black hover:bg-black/80 text-white border-2 border-neutral-800"
                   }`}
                   style={
                     isMacTheme

--- a/src/apps/chats/components/ChatMessages.tsx
+++ b/src/apps/chats/components/ChatMessages.tsx
@@ -70,7 +70,7 @@ const userColors = [
 
 const getUserColorClass = (username?: string): string => {
   if (!username) {
-    return "bg-gray-100 text-black"; // Default or fallback color
+    return "bg-neutral-100 text-black"; // Default or fallback color
   }
   // Simple hash function
   const hash = username
@@ -630,7 +630,7 @@ const ChatMessageItem = memo(function ChatMessageItem(props: ChatMessageItemProp
       <div
         className={`${
           isMacOSTheme ? "text-[10px]" : "text-[16px]"
-        } chat-messages-meta text-gray-500 mb-0.5 font-['Geneva-9'] mb-[-2px] select-text flex items-center gap-2`}
+        } chat-messages-meta text-neutral-500 mb-0.5 font-['Geneva-9'] mb-[-2px] select-text flex items-center gap-2`}
       >
         {message.role === "user" && (
           <>
@@ -644,7 +644,7 @@ const ChatMessageItem = memo(function ChatMessageItem(props: ChatMessageItemProp
                         opacity: isHovered ? 1 : 0,
                         scale: 1,
                       }}
-                      className="size-3 text-gray-400 hover:text-red-600 transition-colors"
+                      className="size-3 text-neutral-400 hover:text-red-600 transition-colors"
                       onClick={() => onDeleteMessage(message)}
                       aria-label={t("apps.chats.ariaLabels.deleteMessage")}
                     >
@@ -663,7 +663,7 @@ const ChatMessageItem = memo(function ChatMessageItem(props: ChatMessageItemProp
                 opacity: isHovered ? 1 : 0,
                 scale: 1,
               }}
-              className="size-3 text-gray-400 hover:text-neutral-600 transition-colors"
+              className="size-3 text-neutral-400 hover:text-neutral-600 transition-colors"
               onClick={() => onCopyMessage(message)}
               aria-label={t("apps.chats.ariaLabels.copyMessage")}
             >
@@ -689,7 +689,7 @@ const ChatMessageItem = memo(function ChatMessageItem(props: ChatMessageItemProp
               ? t("apps.chats.messages.you")
               : t("apps.chats.messages.ryo"))}
         </span>{" "}
-        <span className="text-gray-400 select-text">
+        <span className="text-neutral-400 select-text">
           {message.metadata?.createdAt ? (
             (() => {
               const messageDate = new Date(message.metadata.createdAt);
@@ -720,7 +720,7 @@ const ChatMessageItem = memo(function ChatMessageItem(props: ChatMessageItemProp
                 opacity: isHovered ? 1 : 0,
                 scale: 1,
               }}
-              className="size-3 text-gray-400 hover:text-neutral-600 transition-colors"
+              className="size-3 text-neutral-400 hover:text-neutral-600 transition-colors"
               onClick={() => onCopyMessage(message)}
               aria-label={t("apps.chats.ariaLabels.copyMessage")}
             >
@@ -737,7 +737,7 @@ const ChatMessageItem = memo(function ChatMessageItem(props: ChatMessageItemProp
                   opacity: isHovered ? 1 : 0,
                   scale: 1,
                 }}
-                className="size-3 text-gray-400 hover:text-neutral-600 transition-colors"
+                className="size-3 text-neutral-400 hover:text-neutral-600 transition-colors"
                 onClick={() => {
                   if (playingMessageId === messageKey) {
                     stopSpeech();
@@ -801,7 +801,7 @@ const ChatMessageItem = memo(function ChatMessageItem(props: ChatMessageItemProp
                       opacity: isHovered ? 1 : 0,
                       scale: 1,
                     }}
-                    className="size-3 text-gray-400 hover:text-blue-600 transition-colors"
+                    className="size-3 text-neutral-400 hover:text-blue-600 transition-colors"
                     onClick={() => onSendMessage(message.username!)}
                     aria-label={t("apps.chats.ariaLabels.messageUser", {
                       username: message.username,
@@ -830,7 +830,7 @@ const ChatMessageItem = memo(function ChatMessageItem(props: ChatMessageItemProp
                     opacity: isHovered ? 1 : 0,
                     scale: 1,
                   }}
-                  className="size-3 text-gray-400 hover:text-red-600 transition-colors"
+                  className="size-3 text-neutral-400 hover:text-red-600 transition-colors"
                   onClick={() => onDeleteMessage(message)}
                   aria-label={t("apps.chats.ariaLabels.deleteMessage")}
                 >
@@ -1330,7 +1330,7 @@ function ChatMessagesContent({
         <motion.div
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
-          className="flex items-center gap-2 text-gray-500 font-['Geneva-9'] text-[16px] antialiased h-[12px]"
+          className="flex items-center gap-2 text-neutral-500 font-['Geneva-9'] text-[16px] antialiased h-[12px]"
         >
           <ChatCircle className="size-3" weight="bold" />
           <span>{t("apps.chats.status.startNewConversation")}</span>
@@ -1339,7 +1339,7 @@ function ChatMessagesContent({
               size="sm"
               variant="link"
               onClick={onClear}
-              className="m-0 p-0 text-[16px] h-0 text-gray-500 hover:text-gray-700"
+              className="m-0 p-0 text-[16px] h-0 text-neutral-500 hover:text-neutral-700"
             >
               {t("apps.chats.status.newChat")}
             </Button>
@@ -1438,7 +1438,7 @@ function ChatMessagesContent({
                 key="login-message"
                 initial={{ opacity: 0, y: 20 }}
                 animate={{ opacity: 1, y: 0 }}
-                className="flex items-center gap-2 text-gray-500 font-['Geneva-9'] text-[16px] antialiased h-[12px]"
+                className="flex items-center gap-2 text-neutral-500 font-['Geneva-9'] text-[16px] antialiased h-[12px]"
               >
                 <ChatCircle className="size-3" weight="bold" />
                 <span>{errorMessage}</span>

--- a/src/apps/chats/components/ChatRoomSidebar.tsx
+++ b/src/apps/chats/components/ChatRoomSidebar.tsx
@@ -133,7 +133,7 @@ export const ChatRoomSidebar = React.memo(function ChatRoomSidebar({
           onDeleteRoom && (
             <button
               className={cn(
-                "absolute right-1 top-1/2 transform -translate-y-1/2 transition-opacity text-gray-500 hover:text-red-500 p-1 rounded hover:bg-black/5",
+                "absolute right-1 top-1/2 transform -translate-y-1/2 transition-opacity text-neutral-500 hover:text-red-500 p-1 rounded hover:bg-black/5",
                 currentRoom?.id === room.id
                   ? "opacity-100"
                   : "opacity-0 group-hover:opacity-100"

--- a/src/apps/chats/components/CreateRoomDialog.tsx
+++ b/src/apps/chats/components/CreateRoomDialog.tsx
@@ -557,7 +557,7 @@ export function CreateRoomDialog({
               <div className="space-y-2">
                 <Label
                   htmlFor="room-name"
-                  className={cn("text-gray-700", themeFont)}
+                  className={cn("text-neutral-700", themeFont)}
                   style={themeFontStyle}
                 >
                   {t("apps.chats.dialogs.roomName")}
@@ -565,7 +565,7 @@ export function CreateRoomDialog({
                 <div className="relative">
                   <span
                     className={cn(
-                      "absolute left-3 top-1/2 -translate-y-1/2 text-gray-500 pointer-events-none",
+                      "absolute left-3 top-1/2 -translate-y-1/2 text-neutral-500 pointer-events-none",
                       themeFont
                     )}
                     style={themeFontStyle}
@@ -597,7 +597,7 @@ export function CreateRoomDialog({
               <div className="space-y-2">
                 <Label
                   htmlFor="irc-server"
-                  className={cn("text-gray-700", themeFont)}
+                  className={cn("text-neutral-700", themeFont)}
                   style={themeFontStyle}
                 >
                   Server
@@ -691,9 +691,9 @@ export function CreateRoomDialog({
 
               {/* Inline "add server" form */}
               {isAdmin && showAddServerForm && (
-                <div className="space-y-2 border border-gray-300 rounded p-3 bg-gray-50">
+                <div className="space-y-2 border border-neutral-300 rounded p-3 bg-neutral-50">
                   <Label
-                    className={cn("text-gray-700 font-semibold", themeFont)}
+                    className={cn("text-neutral-700 font-semibold", themeFont)}
                     style={themeFontStyle}
                   >
                     Add a server
@@ -788,7 +788,7 @@ export function CreateRoomDialog({
                 <div className="space-y-2">
                   {!isAdmin && (
                     <p
-                      className={cn("text-gray-500 text-[11px]", themeFont)}
+                      className={cn("text-neutral-500 text-[11px]", themeFont)}
                       style={themeFontStyle}
                     >
                       IRC servers are managed by an admin. Choose a channel
@@ -798,7 +798,7 @@ export function CreateRoomDialog({
                   <div className="flex items-center justify-between">
                     <Label
                       htmlFor="irc-channel-filter"
-                      className={cn("text-gray-700", themeFont)}
+                      className={cn("text-neutral-700", themeFont)}
                       style={themeFontStyle}
                     >
                       Channel
@@ -855,7 +855,7 @@ export function CreateRoomDialog({
                       {isLoadingChannels && (
                         <ActivityIndicator
                           size="sm"
-                          className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-500"
+                          className="absolute right-2 top-1/2 -translate-y-1/2 text-neutral-500"
                         />
                       )}
                     </div>
@@ -879,7 +879,7 @@ export function CreateRoomDialog({
                       {isLoadingChannels && (
                         <ActivityIndicator
                           size="sm"
-                          className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-500"
+                          className="absolute right-2 top-1/2 -translate-y-1/2 text-neutral-500"
                         />
                       )}
                     </div>
@@ -893,13 +893,13 @@ export function CreateRoomDialog({
                     </p>
                   )}
                   {!isLoadingChannels && !channelsError && (
-                    <ScrollArea className="h-[200px] w-full min-w-0 max-w-full overflow-x-hidden border border-gray-300 rounded-md bg-white">
+                    <ScrollArea className="h-[200px] w-full min-w-0 max-w-full overflow-x-hidden border border-neutral-300 rounded-md bg-white">
                       <div className="min-w-0 max-w-full overflow-x-hidden">
                         {filteredChannels.length === 0 &&
                           !(isAdmin && customChannel) && (
                             <p
                               className={cn(
-                                "text-gray-500 px-2 py-1.5",
+                                "text-neutral-500 px-2 py-1.5",
                                 themeFont
                               )}
                               style={themeFontStyle}
@@ -950,7 +950,7 @@ export function CreateRoomDialog({
                                   ? "cursor-not-allowed opacity-60"
                                   : "cursor-pointer",
                                 !isSelected &&
-                                  (index % 2 === 1 ? "bg-gray-100" : "bg-white"),
+                                  (index % 2 === 1 ? "bg-neutral-100" : "bg-white"),
                                 themeFont
                               )}
                               style={themeFontStyle}
@@ -979,7 +979,7 @@ export function CreateRoomDialog({
                   {channelsTruncated && (
                     <p
                       className={cn(
-                        "text-gray-500 min-w-0 max-w-full break-words",
+                        "text-neutral-500 min-w-0 max-w-full break-words",
                         themeFont
                       )}
                       style={themeFontStyle}
@@ -993,7 +993,7 @@ export function CreateRoomDialog({
                     (!isAdmin && selectedChannel)) && (
                     <p
                       className={cn(
-                        "text-gray-500 min-w-0 max-w-full break-words",
+                        "text-neutral-500 min-w-0 max-w-full break-words",
                         themeFont
                       )}
                       style={themeFontStyle}
@@ -1022,7 +1022,7 @@ export function CreateRoomDialog({
               <div className="space-y-2">
                 <Label
                   htmlFor="search-users"
-                  className={cn("text-gray-700", themeFont)}
+                  className={cn("text-neutral-700", themeFont)}
                   style={themeFontStyle}
                 >
                   {t("apps.chats.dialogs.addUsersToPrivateChat")}
@@ -1042,7 +1042,7 @@ export function CreateRoomDialog({
                   {isSearching && searchTerm.length >= 2 && (
                     <ActivityIndicator
                       size="sm"
-                      className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-500"
+                      className="absolute right-2 top-1/2 -translate-y-1/2 text-neutral-500"
                     />
                   )}
                 </div>
@@ -1055,7 +1055,7 @@ export function CreateRoomDialog({
                         key={username}
                         variant="secondary"
                         className={cn(
-                          "py-0.5 pl-2 pr-1 bg-gray-100 hover:bg-gray-200 border-gray-300",
+                          "py-0.5 pl-2 pr-1 bg-neutral-100 hover:bg-neutral-200 border-neutral-300",
                           isXpTheme
                             ? "font-['Pixelated_MS_Sans_Serif',Arial] text-[10px]"
                             : "font-geneva-12 text-[11px]"
@@ -1074,7 +1074,7 @@ export function CreateRoomDialog({
                         <button
                           type="button"
                           onClick={() => toggleUserSelection(username)}
-                          className="ml-1 hover:bg-gray-300 rounded-sm p-0.5"
+                          className="ml-1 hover:bg-neutral-300 rounded-sm p-0.5"
                           disabled={isLoading}
                         >
                           <X className="size-3" weight="bold" />
@@ -1087,13 +1087,13 @@ export function CreateRoomDialog({
 
               {/* Show results */}
               {!isSearching && searchTerm.length >= 2 && users.length > 0 && (
-                <div className="border border-gray-300 rounded max-h-[180px] overflow-y-auto bg-white">
+                <div className="border border-neutral-300 rounded max-h-[180px] overflow-y-auto bg-white">
                   <div className="p-1">
                     {users.map((user) => (
                       <label
                         key={user.username}
                         className={cn(
-                          "flex items-center p-2 hover:bg-gray-100 cursor-pointer rounded",
+                          "flex items-center p-2 hover:bg-neutral-100 cursor-pointer rounded",
                           themeFont
                         )}
                         style={themeFontStyle}

--- a/src/apps/control-panels/components/ScreenSaverPicker.tsx
+++ b/src/apps/control-panels/components/ScreenSaverPicker.tsx
@@ -171,7 +171,7 @@ function ScreenSaverPreview({ type, onClick, disabled, label }: ScreenSaverPrevi
       {useEmbeddedPreview ? (
         <div
           ref={embeddedContainerRef}
-          className="relative overflow-hidden rounded border border-gray-600 group-hover:border-gray-400 transition-colors bg-black"
+          className="relative overflow-hidden rounded border border-neutral-600 group-hover:border-neutral-400 transition-colors bg-black"
           style={{ width: 120, height: 85 }}
         >
           {type === "starfield" && (
@@ -189,7 +189,7 @@ function ScreenSaverPreview({ type, onClick, disabled, label }: ScreenSaverPrevi
           ref={canvasRef}
           width={120}
           height={85}
-          className="rounded border border-gray-600 group-hover:border-gray-400 transition-colors"
+          className="rounded border border-neutral-600 group-hover:border-neutral-400 transition-colors"
           style={{ imageRendering: "pixelated" }}
         />
       )}
@@ -310,7 +310,7 @@ export function ScreenSaverPicker({ onPreview }: ScreenSaverPickerProps) {
                   step={1}
                   className="w-full"
                 />
-                <div className="flex justify-between text-[10px] text-gray-500 font-geneva-12 os-slider-labels">
+                <div className="flex justify-between text-[10px] text-neutral-500 font-geneva-12 os-slider-labels">
                   <span>1 {t("apps.control-panels.min")}</span>
                   <span>30 {t("apps.control-panels.min")}</span>
                 </div>

--- a/src/apps/control-panels/components/WallpaperPicker.tsx
+++ b/src/apps/control-panels/components/WallpaperPicker.tsx
@@ -87,7 +87,7 @@ function WallpaperItem({
         }}
       >
         {isLoading && (
-          <div className="absolute inset-0 bg-gray-700/30">
+          <div className="absolute inset-0 bg-neutral-700/30">
             <div
               className="absolute inset-0 bg-gradient-to-r from-transparent via-white/10 to-transparent opacity-50"
               style={{
@@ -526,7 +526,7 @@ export function WallpaperPicker({ onSelect }: WallpaperPickerProps) {
             <>
               <button
                 type="button"
-                className="preview-button w-full aspect-video !border-[2px] !border-dotted !border-gray-400 cursor-pointer hover:opacity-90 flex items-center justify-center"
+                className="preview-button w-full aspect-video !border-[2px] !border-dotted !border-neutral-400 cursor-pointer hover:opacity-90 flex items-center justify-center"
                 onClick={() => fileInputRef.current?.click()}
                 onKeyDown={(e) => {
                   if (e.key === "Enter" || e.key === " ") {
@@ -535,7 +535,7 @@ export function WallpaperPicker({ onSelect }: WallpaperPickerProps) {
                   }
                 }}
               >
-                <Plus className="size-5 text-gray-500" weight="bold" />
+                <Plus className="size-5 text-neutral-500" weight="bold" />
               </button>
               {customWallpaperRefs.length > 0 ? (
                 customWallpaperRefs.map((path) => (
@@ -573,7 +573,7 @@ export function WallpaperPicker({ onSelect }: WallpaperPickerProps) {
               />
             ))
           ) : (
-            <div className="col-span-4 text-center py-8 text-gray-500">
+            <div className="col-span-4 text-center py-8 text-neutral-500">
               {t("apps.control-panels.noWallpapers")}
             </div>
           )}

--- a/src/apps/finder/components/FileList.tsx
+++ b/src/apps/finder/components/FileList.tsx
@@ -172,7 +172,7 @@ const ListRowItem = memo(function ListRowItem({
       className={`border-none cursor-default ${
         isSelected || dropTargetPath === file.path
           ? ""
-          : "odd:bg-gray-200/50 hover:bg-gray-100/50 transition-colors"
+          : "odd:bg-neutral-200/50 hover:bg-neutral-100/50 transition-colors"
       }`}
       data-selected={isSelected || dropTargetPath === file.path ? "true" : undefined}
       onClick={handleClick}
@@ -892,16 +892,16 @@ export function FileList({
         <Table key={listTableKey} className="min-w-[480px]">
           <TableHeader>
             <TableRow className={`${listHeaderTextClass} border-none font-normal`}>
-              <TableHead className="font-normal bg-gray-100/50 h-[28px]">
+              <TableHead className="font-normal bg-neutral-100/50 h-[28px]">
                 {t("apps.finder.tableHeaders.name")}
               </TableHead>
-              <TableHead className="font-normal bg-gray-100/50 h-[28px]">
+              <TableHead className="font-normal bg-neutral-100/50 h-[28px]">
                 {t("apps.finder.tableHeaders.type")}
               </TableHead>
-              <TableHead className="font-normal bg-gray-100/50 h-[28px] whitespace-nowrap">
+              <TableHead className="font-normal bg-neutral-100/50 h-[28px] whitespace-nowrap">
                 {t("apps.finder.tableHeaders.size")}
               </TableHead>
-              <TableHead className="font-normal bg-gray-100/50 h-[28px] whitespace-nowrap">
+              <TableHead className="font-normal bg-neutral-100/50 h-[28px] whitespace-nowrap">
                 {t("apps.finder.tableHeaders.modified")}
               </TableHead>
             </TableRow>

--- a/src/apps/finder/components/FinderAppComponent.tsx
+++ b/src/apps/finder/components/FinderAppComponent.tsx
@@ -390,8 +390,8 @@ export function FinderAppComponent({
                 isXpTheme
                   ? "border-b border-[#919b9c]"
                   : currentTheme === "system7"
-                  ? "bg-gray-100 border-b border-black"
-                  : "bg-gray-100 border-b border-gray-300"
+                  ? "bg-neutral-100 border-b border-black"
+                  : "bg-neutral-100 border-b border-neutral-300"
               )}
               style={{
                 background: isXpTheme ? "transparent" : undefined,
@@ -548,7 +548,7 @@ export function FinderAppComponent({
           ) : (
             <>
               {isAirDropView ? (
-                <div className="flex-1 bg-gradient-to-b from-gray-100 to-gray-200">
+                <div className="flex-1 bg-gradient-to-b from-neutral-100 to-neutral-200">
                   <AirDropView
                     onSendFile={handleAirDropSendFile}
                     onRequestLogin={promptVerifyToken}
@@ -591,7 +591,7 @@ export function FinderAppComponent({
                   )}
                 </div>
               )}
-              <div className="os-status-bar os-status-bar-text flex items-center justify-between px-2 py-1 text-[10px] font-geneva-12 bg-gray-100 border-t border-gray-300">
+              <div className="os-status-bar os-status-bar-text flex items-center justify-between px-2 py-1 text-[10px] font-geneva-12 bg-neutral-100 border-t border-neutral-300">
                 <span>
                   {sortedFiles.length}{" "}
                   {sortedFiles.length !== 1

--- a/src/apps/finder/components/FinderMenuBar.tsx
+++ b/src/apps/finder/components/FinderMenuBar.tsx
@@ -189,14 +189,14 @@ export function FinderMenuBar({
           <MenubarItem
             onClick={undo}
             disabled={!canUndo}
-            className={`text-md h-6 px-3 ${!canUndo ? "text-gray-500" : ""}`}
+            className={`text-md h-6 px-3 ${!canUndo ? "text-neutral-500" : ""}`}
           >
             {t("common.menu.undo")}
           </MenubarItem>
           <MenubarItem
             onClick={redo}
             disabled={!canRedo}
-            className={`text-md h-6 px-3 ${!canRedo ? "text-gray-500" : ""}`}
+            className={`text-md h-6 px-3 ${!canRedo ? "text-neutral-500" : ""}`}
           >
             {t("common.menu.redo")}
           </MenubarItem>

--- a/src/apps/infinite-mac/components/InfiniteMacAppComponent.tsx
+++ b/src/apps/infinite-mac/components/InfiniteMacAppComponent.tsx
@@ -154,7 +154,7 @@ export function InfiniteMacAppComponent({
           ? "text-transparent cursor-default"
           : isDarkTitlebar
             ? "text-white/80 hover:text-white cursor-pointer"
-            : "text-gray-600 hover:text-gray-800 cursor-pointer"
+            : "text-neutral-600 hover:text-neutral-800 cursor-pointer"
       }`}
       style={{
         filter: selectedPreset && isDarkTitlebar
@@ -221,7 +221,7 @@ export function InfiniteMacAppComponent({
                     <div className="font-apple-garamond text-white text-lg">
                       {t("apps.infinite-mac.title")}
                     </div>
-                    <div className="font-geneva-12 text-gray-400 text-[12px]">
+                    <div className="font-geneva-12 text-neutral-400 text-[12px]">
                       {t("apps.infinite-mac.systemsAvailable", {
                         count: MAC_PRESETS.length,
                       })}

--- a/src/apps/infinite-pc/components/InfinitePcAppComponent.tsx
+++ b/src/apps/infinite-pc/components/InfinitePcAppComponent.tsx
@@ -293,7 +293,7 @@ export function InfinitePcAppComponent({
           ? "text-transparent cursor-default"
           : isDarkTitlebar
             ? "text-white/80 hover:text-white cursor-pointer"
-            : "text-gray-600 hover:text-gray-800 cursor-pointer"
+            : "text-neutral-600 hover:text-neutral-800 cursor-pointer"
       }`}
       style={{
         filter: inSession && isDarkTitlebar

--- a/src/apps/infinite-pc/components/InfinitePcBrowseHeader.tsx
+++ b/src/apps/infinite-pc/components/InfinitePcBrowseHeader.tsx
@@ -23,7 +23,7 @@ export function InfinitePcBrowseHeader({
     `font-apple-garamond !text-[18px] leading-tight transition-colors border-0 bg-transparent p-0 cursor-pointer ${
       active
         ? "text-white"
-        : "text-gray-500 hover:text-gray-300"
+        : "text-neutral-500 hover:text-neutral-300"
     }`;
 
   return (
@@ -38,7 +38,7 @@ export function InfinitePcBrowseHeader({
             {t("apps.pc.tabs.os")}
           </button>
           <span
-            className="font-apple-garamond !text-[18px] leading-tight text-gray-600 select-none"
+            className="font-apple-garamond !text-[18px] leading-tight text-neutral-600 select-none"
             aria-hidden
           >
             |
@@ -51,7 +51,7 @@ export function InfinitePcBrowseHeader({
             {t("apps.pc.tabs.games")}
           </button>
         </div>
-        <div className="font-geneva-12 text-gray-400 text-[12px] shrink-0 text-right">
+        <div className="font-geneva-12 text-neutral-400 text-[12px] shrink-0 text-right">
           {tab === "os"
             ? t("apps.pc.systemsAvailable", { count: osCount })
             : gamesReady

--- a/src/apps/infinite-pc/components/InfinitePcMenuBar.tsx
+++ b/src/apps/infinite-pc/components/InfinitePcMenuBar.tsx
@@ -98,7 +98,7 @@ export function InfinitePcMenuBar({
                     key={game.id}
                     onClick={() => onLoadGame(game)}
                     className={`text-md h-6 px-3 ${
-                      selectedGame.id === game.id ? "bg-gray-100" : ""
+                      selectedGame.id === game.id ? "bg-neutral-100" : ""
                     }`}
                   >
                     {game.name}
@@ -152,7 +152,7 @@ export function InfinitePcMenuBar({
                     key={sensitivity}
                     onClick={() => onSetMouseSensitivity?.(sensitivity)}
                     className={`text-md h-6 px-3 ${
-                      mouseSensitivity === sensitivity ? "bg-gray-100" : ""
+                      mouseSensitivity === sensitivity ? "bg-neutral-100" : ""
                     }`}
                   >
                     {sensitivity}x
@@ -171,7 +171,7 @@ export function InfinitePcMenuBar({
                     key={aspect}
                     onClick={() => onSetRenderAspect?.(aspect)}
                     className={`text-md h-6 px-3 ${
-                      currentRenderAspect === aspect ? "bg-gray-100" : ""
+                      currentRenderAspect === aspect ? "bg-neutral-100" : ""
                     }`}
                   >
                     {t(`apps.pc.aspectRatios.${aspect}`, { defaultValue: aspect })}

--- a/src/apps/internet-explorer/components/InternetExplorerAppComponent.tsx
+++ b/src/apps/internet-explorer/components/InternetExplorerAppComponent.tsx
@@ -74,7 +74,7 @@ function ErrorPage({
       <p className="mb-3">{primaryMessage}</p>
       {secondaryMessage && <p className="mb-3">{secondaryMessage}</p>}
 
-      <div className="h-px bg-gray-300 my-5"></div>
+      <div className="h-px bg-neutral-300 my-5"></div>
 
       <p className="mb-3">Please try the following:</p>
 
@@ -163,12 +163,12 @@ function ErrorPage({
       </ul>
 
       {details && !footerText.includes("HTTP") && (
-        <div className="p-3 bg-gray-100 border border-gray-300 rounded mb-5">
+        <div className="p-3 bg-neutral-100 border border-neutral-300 rounded mb-5">
           {details}
         </div>
       )}
 
-      <div className="mt-10 text-gray-700 whitespace-pre-wrap">
+      <div className="mt-10 text-neutral-700 whitespace-pre-wrap">
         {footerText}
       </div>
     </div>
@@ -389,8 +389,8 @@ export function InternetExplorerAppComponent({
                   : currentTheme === "macosx"
                   ? "bg-transparent"
                   : currentTheme === "system7"
-                  ? "bg-gray-100 border-b border-black"
-                  : "bg-gray-100 border-b border-gray-300"
+                  ? "bg-neutral-100 border-b border-black"
+                  : "bg-neutral-100 border-b border-neutral-300"
               }`}
               style={{
                 borderBottom:
@@ -598,7 +598,7 @@ export function InternetExplorerAppComponent({
                             return (
                               <div
                                 key={suggestionKey}
-                                className="px-2 py-1.5 hover:bg-gray-100 focus:bg-gray-200 cursor-pointer flex items-center gap-2 text-sm outline-none"
+                                className="px-2 py-1.5 hover:bg-neutral-100 focus:bg-neutral-200 cursor-pointer flex items-center gap-2 text-sm outline-none"
                                 onClick={() => {
                                   setSelectedSuggestionIndex(index);
                                   if (suggestion.type === "search") {
@@ -692,18 +692,18 @@ export function InternetExplorerAppComponent({
                                     {suggestion.title}
                                     {suggestion.year &&
                                       suggestion.year !== "current" && (
-                                        <span className="font-normal text-gray-500 ml-1">
+                                        <span className="font-normal text-neutral-500 ml-1">
                                           ({suggestion.year})
                                         </span>
                                       )}
                                   </div>
-                                  <div className="font-geneva-12 text-[10px] text-gray-500 truncate">
+                                  <div className="font-geneva-12 text-[10px] text-neutral-500 truncate">
                                     {suggestion.type === "search"
                                       ? "bing.com"
                                       : stripProtocol(suggestion.url)}
                                   </div>
                                 </div>
-                                <div className="font-geneva-12 text-[10px] ml-2 text-gray-500 whitespace-nowrap hidden sm:block">
+                                <div className="font-geneva-12 text-[10px] ml-2 text-neutral-500 whitespace-nowrap hidden sm:block">
                                   {suggestion.type === "favorite" && "Favorite"}
                                   {suggestion.type === "history" && "History"}
                                   {suggestion.type === "search" && "Search"}
@@ -775,14 +775,14 @@ export function InternetExplorerAppComponent({
                         <SelectItem
                           key={y}
                           value={y}
-                          className="text-md h-6 px-3 active:bg-gray-900 active:text-white text-blue-600"
+                          className="text-md h-6 px-3 active:bg-neutral-900 active:text-white text-blue-600"
                         >
                           {y}
                         </SelectItem>
                       ))}
                       <SelectItem
                         value="current"
-                        className="text-md h-6 px-3 active:bg-gray-900 active:text-white"
+                        className="text-md h-6 px-3 active:bg-neutral-900 active:text-white"
                       >
                         {t("apps.internet-explorer.now")}
                       </SelectItem>
@@ -790,7 +790,7 @@ export function InternetExplorerAppComponent({
                         <SelectItem
                           key={y}
                           value={y}
-                          className={`text-md h-6 px-3 active:bg-gray-900 active:text-white ${
+                          className={`text-md h-6 px-3 active:bg-neutral-900 active:text-white ${
                             parseInt(y) <= 1995 ? "text-blue-600" : ""
                           }`}
                         >
@@ -824,7 +824,7 @@ export function InternetExplorerAppComponent({
                               <Button
                                 variant="ghost"
                                 size="sm"
-                                className="whitespace-nowrap hover:bg-gray-200 font-geneva-12 text-[10px] gap-1 px-1 mr-1 w-content min-w-[60px] max-w-[120px] flex-shrink-0"
+                                className="whitespace-nowrap hover:bg-neutral-200 font-geneva-12 text-[10px] gap-1 px-1 mr-1 w-content min-w-[60px] max-w-[120px] flex-shrink-0"
                               >
                                 <ThemedIcon
                                   name="directory.png"
@@ -851,7 +851,7 @@ export function InternetExplorerAppComponent({
                                       child.year
                                     )
                                   }
-                                  className="text-md h-6 px-3 active:bg-gray-900 active:text-white flex items-center gap-2"
+                                  className="text-md h-6 px-3 active:bg-neutral-900 active:text-white flex items-center gap-2"
                                 >
                                   {child.favicon && !isOffline ? (
                                     <img
@@ -872,7 +872,7 @@ export function InternetExplorerAppComponent({
                                   )}
                                   {child.title}
                                   {child.year && child.year !== "current" && (
-                                    <span className="text-xs text-gray-500 ml-1">
+                                    <span className="text-xs text-neutral-500 ml-1">
                                       ({child.year})
                                     </span>
                                   )}
@@ -888,7 +888,7 @@ export function InternetExplorerAppComponent({
                             key={favoriteKey}
                             variant="ghost"
                             size="sm"
-                            className="whitespace-nowrap hover:bg-gray-200 font-geneva-12 text-[10px] gap-1 px-1 mr-1 w-content min-w-[60px] max-w-[120px] flex-shrink-0"
+                            className="whitespace-nowrap hover:bg-neutral-200 font-geneva-12 text-[10px] gap-1 px-1 mr-1 w-content min-w-[60px] max-w-[120px] flex-shrink-0"
                             onClick={(e) => {
                               const normalizedFavUrl = normalizeUrlForHistory(
                                 favorite.url!
@@ -932,7 +932,7 @@ export function InternetExplorerAppComponent({
                   </div>
                 </div>
                 {favorites.length > 0 && hasMoreToScroll && (
-                  <div className="absolute right-0 top-0 bottom-0 w-8 bg-gradient-to-l from-gray-100 to-transparent pointer-events-none" />
+                  <div className="absolute right-0 top-0 bottom-0 w-8 bg-gradient-to-l from-neutral-100 to-transparent pointer-events-none" />
                 )}
               </div>
             </div>
@@ -1035,10 +1035,10 @@ export function InternetExplorerAppComponent({
                   animate={{ opacity: 1, y: 0 }}
                   exit={{ opacity: 0, y: 20 }}
                   transition={{ duration: 0.15 }}
-                  className={`os-status-bar os-status-bar-text font-geneva-12 absolute bottom-0 left-0 right-0 bg-gray-100 text-[10px] px-2 py-1 flex items-center z-50 ${
+                  className={`os-status-bar os-status-bar-text font-geneva-12 absolute bottom-0 left-0 right-0 bg-neutral-100 text-[10px] px-2 py-1 flex items-center z-50 ${
                     currentTheme === "system7"
                       ? "border-t border-black"
-                      : "border-t border-gray-300"
+                      : "border-t border-neutral-300"
                   }`}
                 >
                   <div className="flex-1 truncate">

--- a/src/apps/internet-explorer/components/InternetExplorerMenuBar.tsx
+++ b/src/apps/internet-explorer/components/InternetExplorerMenuBar.tsx
@@ -109,7 +109,7 @@ const renderFavoriteItem = (
         )}
         {favorite.title}
         {favorite.year && favorite.year !== "current" && (
-          <span className="text-xs text-gray-500 ml-1">({favorite.year})</span>
+          <span className="text-xs text-neutral-500 ml-1">({favorite.year})</span>
         )}
       </MenubarItem>
     );
@@ -255,7 +255,7 @@ export function InternetExplorerMenuBar({
             disabled={!isLoading}
             className={
               !isLoading
-                ? "text-gray-400 text-md h-6 px-3"
+                ? "text-neutral-400 text-md h-6 px-3"
                 : "text-md h-6 px-3"
             }
           >
@@ -681,7 +681,7 @@ export function InternetExplorerMenuBar({
             disabled={!canGoBack}
             className={
               !canGoBack
-                ? "text-gray-400 text-md h-6 px-3"
+                ? "text-neutral-400 text-md h-6 px-3"
                 : "text-md h-6 px-3"
             }
           >
@@ -692,7 +692,7 @@ export function InternetExplorerMenuBar({
             disabled={!canGoForward}
             className={
               !canGoForward
-                ? "text-gray-400 text-md h-6 px-3"
+                ? "text-neutral-400 text-md h-6 px-3"
                 : "text-md h-6 px-3"
             }
           >
@@ -729,7 +729,7 @@ export function InternetExplorerMenuBar({
                   <span className="truncate">
                     {entry.title}
                     {entry.year && entry.year !== "current" && (
-                      <span className="text-xs text-gray-500 ml-1">
+                      <span className="text-xs text-neutral-500 ml-1">
                         ({entry.year})
                       </span>
                     )}

--- a/src/apps/internet-explorer/hooks/useInternetExplorerLogic.ts
+++ b/src/apps/internet-explorer/hooks/useInternetExplorerLogic.ts
@@ -1910,7 +1910,7 @@ export function useInternetExplorerLogic({
         debugMode &&
           React.createElement(
             "span",
-            { className: "text-gray-500" },
+            { className: "text-neutral-500" },
             t("apps.internet-explorer.fetch")
           ),
         React.createElement(
@@ -1931,7 +1931,7 @@ export function useInternetExplorerLogic({
           debugMode &&
             React.createElement(
               "span",
-              { className: "text-gray-500" },
+              { className: "text-neutral-500" },
               modelInfo,
               language !== "auto" && ` ${languageDisplayName}`,
               location !== "auto" && ` ${locationDisplayName}`
@@ -1953,7 +1953,7 @@ export function useInternetExplorerLogic({
             debugMode &&
               React.createElement(
                 "span",
-                { className: "text-gray-500" },
+                { className: "text-neutral-500" },
                 modelInfo,
                 language !== "auto" && ` ${languageDisplayName}`,
                 location !== "auto" && ` ${locationDisplayName}`

--- a/src/apps/ipod/components/CoverFlow.tsx
+++ b/src/apps/ipod/components/CoverFlow.tsx
@@ -625,7 +625,7 @@ function CoverImage({
           }}
         />
         {!showSleeveBitmap ? (
-          <div className="w-full h-full flex items-center justify-center bg-gradient-to-br from-gray-700 to-gray-900">
+          <div className="w-full h-full flex items-center justify-center bg-gradient-to-br from-neutral-700 to-neutral-900">
             <svg
               xmlns="http://www.w3.org/2000/svg"
               width="32"

--- a/src/apps/ipod/components/IpodAppComponent.tsx
+++ b/src/apps/ipod/components/IpodAppComponent.tsx
@@ -337,7 +337,7 @@ export function IpodAppComponent({
       >
         <div
           ref={containerRef}
-          className="ipod-force-font flex flex-col items-center justify-center w-full h-full bg-gradient-to-b from-gray-100/20 to-gray-300/20 backdrop-blur-lg p-4 select-none"
+          className="ipod-force-font flex flex-col items-center justify-center w-full h-full bg-gradient-to-b from-neutral-100/20 to-neutral-300/20 backdrop-blur-lg p-4 select-none"
           style={{ position: "relative", overflow: "hidden", contain: "layout style paint" }}
         >
           <div

--- a/src/apps/ipod/components/IpodWheel.tsx
+++ b/src/apps/ipod/components/IpodWheel.tsx
@@ -375,7 +375,7 @@ export function IpodWheel({
       className={cn(
         "mt-6 relative w-[180px] h-[180px] rounded-full flex items-center justify-center select-none no-select-gesture",
         theme === "classic"
-          ? "bg-gray-300/60"
+          ? "bg-neutral-300/60"
           : theme === "u2"
           ? "bg-red-700/60"
           : "bg-neutral-800/50"

--- a/src/apps/maps/components/MapsMenuBar.tsx
+++ b/src/apps/maps/components/MapsMenuBar.tsx
@@ -44,7 +44,7 @@ export function MapsMenuBar({
           <MenubarItem
             onClick={onLocateMe}
             disabled={!canUseMap}
-            className={`text-md h-6 px-3 ${!canUseMap ? "text-gray-500" : ""}`}
+            className={`text-md h-6 px-3 ${!canUseMap ? "text-neutral-500" : ""}`}
           >
             {t("apps.maps.menu.locateMe")}
           </MenubarItem>

--- a/src/apps/minesweeper/components/MinesweeperAppComponent.tsx
+++ b/src/apps/minesweeper/components/MinesweeperAppComponent.tsx
@@ -243,7 +243,7 @@ export function MinesweeperAppComponent({
             )}
           >
             <div
-              className="flex-1 bg-[#8a9a8a] text-[#1a2a1a] text-lg px-2 py-0.5 border border-t-gray-800 border-l-gray-800 border-r-white border-b-white shadow-inner [text-shadow:1px_1px_0px_rgba(0,0,0,0.2)] h-[48px] flex items-center"
+              className="flex-1 bg-[#8a9a8a] text-[#1a2a1a] text-lg px-2 py-0.5 border border-t-neutral-800 border-l-neutral-800 border-r-white border-b-white shadow-inner [text-shadow:1px_1px_0px_rgba(0,0,0,0.2)] h-[48px] flex items-center"
             >
               <div className="flex items-center justify-between text-sm relative w-full">
                 <div className="flex flex-col items-start w-[80px]">
@@ -274,7 +274,7 @@ export function MinesweeperAppComponent({
                     className={
                       isMacTheme
                         ? "!w-[34px] !h-[34px] aspect-square !rounded-full overflow-hidden flex items-center justify-center text-xl leading-none !p-0"
-                        : "aspect-square h-[34px] flex items-center justify-center text-xl leading-none bg-[#c0c0c0] hover:bg-[#d0d0d0] border-2 border-t-white border-l-white border-r-gray-800 border-b-gray-800 active:border active:border-gray-600 shadow-none p-0"
+                        : "aspect-square h-[34px] flex items-center justify-center text-xl leading-none bg-[#c0c0c0] hover:bg-[#d0d0d0] border-2 border-t-white border-l-white border-r-neutral-800 border-b-neutral-800 active:border active:border-neutral-600 shadow-none p-0"
                     }
                   >
                     {gameOver ? "💀" : gameWon ? "😎" : "🙂"}
@@ -304,7 +304,7 @@ export function MinesweeperAppComponent({
               "grid grid-cols-9 gap-0 m-auto w-fit",
               isMacTheme
                 ? "p-[2px] rounded-[4px] bg-[#b7bcc1]"
-                : "bg-gray-800 p-[1px] border border-t-gray-800 border-l-gray-800 border-r-white border-b-white max-w-[250px]"
+                : "bg-neutral-800 p-[1px] border border-t-neutral-800 border-l-neutral-800 border-r-white border-b-white max-w-[250px]"
             )}
             style={boardFrameStyle}
           >
@@ -365,7 +365,7 @@ function getNumberColor(num: number): string {
     "red-800",
     "cyan-600",
     "black",
-    "gray-600",
+    "neutral-600",
   ];
   return colors[num] || "black";
 }

--- a/src/apps/paint/components/PaintAppComponent.tsx
+++ b/src/apps/paint/components/PaintAppComponent.tsx
@@ -149,7 +149,7 @@ export const PaintAppComponent: React.FC<AppProps<PaintInitialData>> = ({
             <div className="flex flex-col flex-1 gap-2 min-h-0 min-w-0">
               <div className="flex-1 bg-white min-h-0 min-w-0 border border-black border-2 shadow-[2px_2px_0px_0px_rgba(0,0,0,0.5)] overflow-auto relative">
                 {error && (
-                  <div className="absolute inset-0 flex items-center justify-center bg-gray-200 text-red-500 p-4">
+                  <div className="absolute inset-0 flex items-center justify-center bg-neutral-200 text-red-500 p-4">
                     Error: {error}
                   </div>
                 )}

--- a/src/apps/paint/components/PaintMenuBar.tsx
+++ b/src/apps/paint/components/PaintMenuBar.tsx
@@ -744,7 +744,7 @@ export function PaintMenuBar({
             onClick={onUndo}
             disabled={!canUndo}
             className={`text-md h-6 px-3 ${
-              !canUndo ? "text-gray-500" : ""
+              !canUndo ? "text-neutral-500" : ""
             }`}
           >
             {t("common.menu.undo")}
@@ -753,7 +753,7 @@ export function PaintMenuBar({
             onClick={onRedo}
             disabled={!canRedo}
             className={`text-md h-6 px-3 ${
-              !canRedo ? "text-gray-500" : ""
+              !canRedo ? "text-neutral-500" : ""
             }`}
           >
             {t("common.menu.redo")}

--- a/src/apps/paint/components/PaintPatternPalette.tsx
+++ b/src/apps/paint/components/PaintPatternPalette.tsx
@@ -20,7 +20,7 @@ export const PaintPatternPalette: React.FC<PaintPatternPaletteProps> = ({
           <button
             key={num}
             className={` hover:opacity-70 border-1 border-black ${
-              selectedPattern === `pattern-${num}` ? "" : "border-gray-800"
+              selectedPattern === `pattern-${num}` ? "" : "border-neutral-800"
             }`}
             onClick={() => onPatternSelect(`pattern-${num}`)}
           >

--- a/src/apps/paint/components/PaintStrokeSettings.tsx
+++ b/src/apps/paint/components/PaintStrokeSettings.tsx
@@ -11,7 +11,7 @@ export const PaintStrokeSettings: React.FC<PaintStrokeSettingsProps> = ({
   onStrokeWidthChange,
 }) => {
   return (
-    <div className="space-y-2 p-2 py-3 border-t border-gray-200">
+    <div className="space-y-2 p-2 py-3 border-t border-neutral-200">
       <Slider
         value={[strokeWidth]}
         onValueChange={(value) => onStrokeWidthChange(value[0])}

--- a/src/apps/pc/components/PcAppComponent.tsx
+++ b/src/apps/pc/components/PcAppComponent.tsx
@@ -170,7 +170,7 @@ export function PcAppComponent({
           ? "text-transparent cursor-default"
           : isDarkTitlebar
             ? "text-white/80 hover:text-white cursor-pointer"
-            : "text-gray-600 hover:text-gray-800 cursor-pointer"
+            : "text-neutral-600 hover:text-neutral-800 cursor-pointer"
       }`}
       style={{
         filter: isGameRunning && isDarkTitlebar
@@ -226,12 +226,12 @@ export function PcAppComponent({
                     <div className="font-apple-garamond text-white text-lg">
                       {t("apps.pc.virtualPc")}
                     </div>
-                    <div className="font-geneva-12 text-gray-400 text-[12px] flex items-center gap-2">
+                    <div className="font-geneva-12 text-neutral-400 text-[12px] flex items-center gap-2">
                       {isScriptLoaded ? (
                         t("apps.pc.programsAvailable", { count: games.length })
                       ) : (
                         <>
-                          <ActivityIndicator size="xs" className="text-gray-400" />
+                          <ActivityIndicator size="xs" className="text-neutral-400" />
                           {t("apps.pc.loadingEmulator")}
                         </>
                       )}

--- a/src/apps/pc/components/PcMenuBar.tsx
+++ b/src/apps/pc/components/PcMenuBar.tsx
@@ -81,7 +81,7 @@ export function PcMenuBar({
                   key={game.id}
                   onClick={() => onLoadGame(game)}
                   className={`text-md h-6 px-3 ${
-                    selectedGame.id === game.id ? "bg-gray-100" : ""
+                    selectedGame.id === game.id ? "bg-neutral-100" : ""
                   }`}
                 >
                   {game.name}
@@ -147,7 +147,7 @@ export function PcMenuBar({
                   key={sensitivity}
                   onClick={() => onSetMouseSensitivity(sensitivity)}
                   className={`text-md h-6 px-3 ${
-                    mouseSensitivity === sensitivity ? "bg-gray-100" : ""
+                    mouseSensitivity === sensitivity ? "bg-neutral-100" : ""
                   }`}
                 >
                   {sensitivity}x
@@ -166,7 +166,7 @@ export function PcMenuBar({
                   key={aspect}
                   onClick={() => onSetRenderAspect(aspect)}
                   className={`text-md h-6 px-3 ${
-                    currentRenderAspect === aspect ? "bg-gray-100" : ""
+                    currentRenderAspect === aspect ? "bg-neutral-100" : ""
                   }`}
                 >
                   {aspect}

--- a/src/apps/photo-booth/components/PhotoBoothComponent.tsx
+++ b/src/apps/photo-booth/components/PhotoBoothComponent.tsx
@@ -490,7 +490,7 @@ export function PhotoBoothComponent({
                 isMacTheme
                   ? "transition-transform hover:scale-105"
                   : isMultiPhotoMode
-                  ? "bg-gray-500 cursor-not-allowed"
+                  ? "bg-neutral-500 cursor-not-allowed"
                   : "bg-red-500 hover:bg-red-600"
               )}
               style={

--- a/src/apps/soundboard/components/BoardList.tsx
+++ b/src/apps/soundboard/components/BoardList.tsx
@@ -82,7 +82,7 @@ export function BoardList({
         {micPermissionGranted && (
           <div
             className={`mt-auto pt-2 border-t px-3 pb-3 ${
-              isWindowsLegacyTheme ? "border-[#919b9c]" : "border-gray-300"
+              isWindowsLegacyTheme ? "border-[#919b9c]" : "border-neutral-300"
             }`}
           >
             <Select value={selectedDeviceId} onValueChange={onDeviceSelect}>

--- a/src/apps/soundboard/components/SoundboardMenuBar.tsx
+++ b/src/apps/soundboard/components/SoundboardMenuBar.tsx
@@ -147,7 +147,7 @@ export function SoundboardMenuBar({
             disabled={!canDeleteBoard}
             className={
               !canDeleteBoard
-                ? "text-gray-400 text-md h-6 px-3"
+                ? "text-neutral-400 text-md h-6 px-3"
                 : "text-md h-6 px-3"
             }
           >

--- a/src/apps/synth/components/SynthAppComponent.tsx
+++ b/src/apps/synth/components/SynthAppComponent.tsx
@@ -281,7 +281,7 @@ export function SynthAppComponent({
                             </button>
                           ))
                         ) : (
-                          <p className="text-xs text-gray-400 font-geneva-12 select-none px-2">
+                          <p className="text-xs text-neutral-400 font-geneva-12 select-none px-2">
                             {t("apps.synth.noPresetsYet")}
                           </p>
                         )}
@@ -305,7 +305,7 @@ export function SynthAppComponent({
                           </Button>
                         ))
                       ) : (
-                        <p className="text-xs text-gray-400 font-geneva-12 select-none">
+                        <p className="text-xs text-neutral-400 font-geneva-12 select-none">
                           {t("apps.synth.noPresetsYet")}
                         </p>
                       )}

--- a/src/apps/terminal/components/TerminalAppComponent.tsx
+++ b/src/apps/terminal/components/TerminalAppComponent.tsx
@@ -279,17 +279,17 @@ export function TerminalAppComponent({
                 (item.toolInvocations && item.toolInvocations.length > 0)) && (
                 <div
                   className={`ml-0 select-text ${
-                    item.path === "ai-thinking" ? "text-gray-400" : ""
+                    item.path === "ai-thinking" ? "text-neutral-400" : ""
                   } ${item.path === "ai-assistant" ? "text-purple-100" : ""} ${
                     item.path === "ai-error" ? "text-red-400" : ""
-                  } ${item.path === "welcome-message" ? "text-gray-400" : ""} ${
+                  } ${item.path === "welcome-message" ? "text-neutral-400" : ""} ${
                     // Add urgent message styling
                     item.output && isUrgentMessage(item.output)
                       ? "text-red-400"
                       : ""
                   } ${
                     // System messages (errors, usage hints) styled in gray
-                    item.isSystemMessage ? "text-gray-400" : ""
+                    item.isSystemMessage ? "text-neutral-400" : ""
                   }`}
                 >
                   {item.path === "ai-thinking" ? (
@@ -300,7 +300,7 @@ export function TerminalAppComponent({
                         </span>{" "}
                         ryo
                       </span>
-                      <span className="text-gray-500 italic shimmer-subtle">
+                      <span className="text-neutral-500 italic shimmer-subtle">
                         {" "}
                         {i18n.t("apps.terminal.output.isThinking")}
                         <AnimatedEllipsis />
@@ -368,7 +368,7 @@ export function TerminalAppComponent({
                                     : isSpin
                                       ? "gradient-spin italic"
                                       : isRes
-                                        ? "text-gray-400"
+                                        ? "text-neutral-400"
                                         : "text-purple-300";
                                   return (
                                     <span
@@ -524,7 +524,7 @@ export function TerminalAppComponent({
               />
               {isAiLoading && isInAiMode && (
                 <div className="absolute top-0 left-0 w-full h-full pointer-events-none flex items-center">
-                  <span className="text-gray-400/40 opacity-30 shimmer">
+                  <span className="text-neutral-400/40 opacity-30 shimmer">
                     {i18n.t("apps.terminal.output.isThinking")}
                     <AnimatedEllipsis />
                   </span>

--- a/src/apps/terminal/components/TerminalToolInvocation.tsx
+++ b/src/apps/terminal/components/TerminalToolInvocation.tsx
@@ -328,7 +328,7 @@ export function TerminalToolInvocation({
 
   return (
     <div
-      className="flex items-center gap-1.5 text-gray-400 py-0.5 select-text terminal-tool-invocation"
+      className="flex items-center gap-1.5 text-neutral-400 py-0.5 select-text terminal-tool-invocation"
       style={fontSize ? { fontSize: `${fontSize}px` } : undefined}
     >
       {state === "output-available" && displayResultMessage ? (

--- a/src/apps/terminal/components/VimEditor.tsx
+++ b/src/apps/terminal/components/VimEditor.tsx
@@ -109,7 +109,7 @@ export function VimEditor({
             key={`line-${lineNumber}`}
             className={`vim-line flex ${isCursorLine ? "bg-white/10" : ""} ${isVisualSelected ? "bg-blue-900/40" : ""}`}
           >
-            <span className="text-gray-500 w-6 text-right mr-2 shrink-0">
+            <span className="text-neutral-500 w-6 text-right mr-2 shrink-0">
               {isFiller ? "" : lineNumber + 1}
             </span>
             {isCursorLine ? (

--- a/src/apps/textedit/components/EditorToolbar.tsx
+++ b/src/apps/textedit/components/EditorToolbar.tsx
@@ -308,8 +308,8 @@ export function EditorToolbar({
           : isMacOSTheme
           ? "bg-transparent"
           : currentTheme === "system7"
-          ? "bg-gray-100 border-b border-black"
-          : "bg-gray-100 border-b border-gray-300"
+          ? "bg-neutral-100 border-b border-black"
+          : "bg-neutral-100 border-b border-neutral-300"
       }`}
       style={{
         borderBottom:

--- a/src/apps/textedit/components/SlashCommandsList.tsx
+++ b/src/apps/textedit/components/SlashCommandsList.tsx
@@ -68,18 +68,18 @@ export const SlashCommandsList = (
   }));
 
   return (
-    <div className="z-50 h-auto max-h-[330px] w-72 overflow-y-auto rounded-lg border border-gray-200 bg-white p-1 shadow-lg">
+    <div className="z-50 h-auto max-h-[330px] w-72 overflow-y-auto rounded-lg border border-neutral-200 bg-white p-1 shadow-lg">
       {props.items.map((item, index) => (
         <button
           key={`${item.title}-${item.description}`}
           className={`flex w-full items-start gap-2 rounded-md px-2 py-1 text-left ${
-            index === selectedIndex ? "bg-gray-100" : ""
+            index === selectedIndex ? "bg-neutral-100" : ""
           }`}
           onClick={() => selectItem(index)}
         >
           <div className="flex flex-col">
             <span className="text-sm font-medium">{item.title}</span>
-            <span className="text-xs text-gray-500">{item.description}</span>
+            <span className="text-xs text-neutral-500">{item.description}</span>
           </div>
         </button>
       ))}

--- a/src/apps/textedit/components/TextEditMenuBar.tsx
+++ b/src/apps/textedit/components/TextEditMenuBar.tsx
@@ -141,14 +141,14 @@ export function TextEditMenuBar({
           <MenubarItem
             onClick={undo}
             disabled={!canUndo}
-            className={`text-md h-6 px-3 ${!canUndo ? "text-gray-500" : ""}`}
+            className={`text-md h-6 px-3 ${!canUndo ? "text-neutral-500" : ""}`}
           >
             {t("common.menu.undo")}
           </MenubarItem>
           <MenubarItem
             onClick={redo}
             disabled={!canRedo}
-            className={`text-md h-6 px-3 ${!canRedo ? "text-gray-500" : ""}`}
+            className={`text-md h-6 px-3 ${!canRedo ? "text-neutral-500" : ""}`}
           >
             {t("common.menu.redo")}
           </MenubarItem>

--- a/src/apps/textedit/extensions/SlashCommands.tsx
+++ b/src/apps/textedit/extensions/SlashCommands.tsx
@@ -97,7 +97,7 @@ const SlashMenuContent = ({
           onClick={() => onCommand(item)}
           onMouseEnter={() => setSelectedIndex(index)}
           className={`relative flex w-full items-center h-8 px-2 text-sm ${
-            index === selectedIndex ? "bg-gray-100" : ""
+            index === selectedIndex ? "bg-neutral-100" : ""
           }`}
         >
           {getTranslatedTitle(item)}

--- a/src/apps/tv/components/CreateChannelDialog.tsx
+++ b/src/apps/tv/components/CreateChannelDialog.tsx
@@ -161,7 +161,7 @@ export function CreateChannelDialog({
 
   const dialogContent = (
     <div className={cn(isXpTheme ? "p-2 px-4" : "p-4 px-6")}>
-      <p className={cn("text-gray-500 mb-2", fontClass)} style={fontStyle}>
+      <p className={cn("text-neutral-500 mb-2", fontClass)} style={fontStyle}>
         {t("apps.tv.create.description")}
       </p>
 
@@ -191,8 +191,8 @@ export function CreateChannelDialog({
               dispatch({ type: "patch", payload: { description: s } })
             }
             className={cn(
-              "px-2 py-0.5 rounded-full border text-gray-700",
-              "border-gray-300 hover:bg-gray-100 disabled:opacity-50"
+              "px-2 py-0.5 rounded-full border text-neutral-700",
+              "border-neutral-300 hover:bg-neutral-100 disabled:opacity-50"
             )}
           >
             {s}

--- a/src/apps/videos/components/VideosAppComponent.tsx
+++ b/src/apps/videos/components/VideosAppComponent.tsx
@@ -634,7 +634,7 @@ export function VideosAppComponent({
                 </AnimatePresence>
               </div>
             ) : (
-              <div className="flex items-center justify-center h-full text-gray-400 font-geneva-12 text-sm">
+              <div className="flex items-center justify-center h-full text-neutral-400 font-geneva-12 text-sm">
                 <a
                   onClick={() => setIsAddDialogOpen(true)}
                   className="text-[#ff00ff] hover:underline cursor-pointer"

--- a/src/apps/videos/components/VideosMenuBar.tsx
+++ b/src/apps/videos/components/VideosMenuBar.tsx
@@ -224,7 +224,7 @@ export function VideosMenuBar({
                       onClick={() => onPlayVideo(video.id)}
                       className={cn(
                         "text-md h-6 px-3 max-w-[220px] truncate",
-                        video.id === currentVideoId && "bg-gray-200"
+                        video.id === currentVideoId && "bg-neutral-200"
                       )}
                     >
                       <div className="flex items-center w-full">
@@ -258,7 +258,7 @@ export function VideosMenuBar({
                         onClick={() => onPlayVideo(video.id)}
                         className={cn(
                           "text-md h-6 px-3 max-w-[160px] sm:max-w-[200px] truncate",
-                          video.id === currentVideoId && "bg-gray-200"
+                          video.id === currentVideoId && "bg-neutral-200"
                         )}
                       >
                         <div className="flex items-center w-full">

--- a/src/components/dialogs/AboutDialog.tsx
+++ b/src/components/dialogs/AboutDialog.tsx
@@ -87,7 +87,7 @@ export function AboutDialog({
         >
           {displayName}
         </div>
-        <p className="text-gray-500 mb-2">{t("common.dialog.version")} {metadata.version}</p>
+        <p className="text-neutral-500 mb-2">{t("common.dialog.version")} {metadata.version}</p>
         <p>
           {t("common.dialog.madeBy")}{" "}
           <a

--- a/src/components/dialogs/AboutFinderDialog.tsx
+++ b/src/components/dialogs/AboutFinderDialog.tsx
@@ -178,7 +178,7 @@ export function AboutFinderDialog({
               <div
                 className={cn(
                   aboutFinderSmallClass,
-                  "cursor-pointer select-none transition-opacity hover:opacity-70 text-gray-500"
+                  "cursor-pointer select-none transition-opacity hover:opacity-70 text-neutral-500"
                 )}
                 style={
                   isXpTheme
@@ -210,7 +210,7 @@ export function AboutFinderDialog({
               </div>
               <div
                 className={cn(
-                  "text-gray-500",
+                  "text-neutral-500",
                   isXpTheme
                     ? "font-['Pixelated_MS_Sans_Serif',Arial] text-[10px]"
                     : currentTheme === "macosx"
@@ -258,7 +258,7 @@ export function AboutFinderDialog({
               </div>
             </div>
           </div>
-          <hr className="border-gray-300" />
+          <hr className="border-neutral-300" />
 
           {/* Memory usage bars */}
           <div className={cn("space-y-2 p-2 px-4 pb-4", aboutFinderSmallClass)}>
@@ -271,7 +271,7 @@ export function AboutFinderDialog({
                 <div
                   className={cn(
                     "h-2 w-full",
-                    currentTheme === "macosx" ? "aqua-progress" : "bg-gray-200"
+                    currentTheme === "macosx" ? "aqua-progress" : "bg-neutral-200"
                   )}
                 >
                   <div

--- a/src/components/dialogs/ChangePasswordDialog.tsx
+++ b/src/components/dialogs/ChangePasswordDialog.tsx
@@ -190,7 +190,7 @@ export function ChangePasswordDialog({
       {hasPassword && (
         <div className="space-y-2">
           <Label
-            className={cn("text-gray-700", themeFont)}
+            className={cn("text-neutral-700", themeFont)}
             style={themeFontStyle}
             htmlFor="change-password-current"
           >
@@ -214,7 +214,7 @@ export function ChangePasswordDialog({
 
       <div className="space-y-2">
         <Label
-          className={cn("text-gray-700", themeFont)}
+          className={cn("text-neutral-700", themeFont)}
           style={themeFontStyle}
           htmlFor="change-password-new"
         >
@@ -235,7 +235,7 @@ export function ChangePasswordDialog({
 
       <div className="space-y-2">
         <Label
-          className={cn("text-gray-700", themeFont)}
+          className={cn("text-neutral-700", themeFont)}
           style={themeFontStyle}
           htmlFor="change-password-confirm"
         >
@@ -296,7 +296,7 @@ export function ChangePasswordDialog({
   const dialogBody = (
     <div className={isXpTheme ? "p-2 px-4" : "p-4 px-6"}>
       <p
-        className={cn("text-gray-500 mb-3", themeFont)}
+        className={cn("text-neutral-500 mb-3", themeFont)}
         style={themeFontStyle}
         id="change-password-description"
       >

--- a/src/components/dialogs/ConfirmDialog.tsx
+++ b/src/components/dialogs/ConfirmDialog.tsx
@@ -56,7 +56,7 @@ export function ConfirmDialog({
         />
         <p
           className={cn(
-            "text-gray-900 mb-2 leading-tight",
+            "text-neutral-900 mb-2 leading-tight",
             isXpTheme
               ? "font-['Pixelated_MS_Sans_Serif',Arial] text-[11px]"
               : "font-geneva-12 text-[12px]"

--- a/src/components/dialogs/EmojiDialog.tsx
+++ b/src/components/dialogs/EmojiDialog.tsx
@@ -240,7 +240,7 @@ export function EmojiDialog({
       <p
         id="dialog-description"
         className={cn(
-          "mb-2 text-gray-500",
+          "mb-2 text-neutral-500",
           isXpTheme
             ? "font-['Pixelated_MS_Sans_Serif',Arial] text-[11px]"
             : "font-geneva-12 text-[12px]"

--- a/src/components/dialogs/FutureSettingsDialog.tsx
+++ b/src/components/dialogs/FutureSettingsDialog.tsx
@@ -104,7 +104,7 @@ const FutureSettingsDialog = ({
         <div className="flex items-center gap-2">
           <span
             className={cn(
-              "text-gray-900",
+              "text-neutral-900",
               isXpTheme
                 ? "font-['Pixelated_MS_Sans_Serif',Arial] text-[11px]"
                 : "font-geneva-12 text-[12px]"

--- a/src/components/dialogs/HelpDialog.tsx
+++ b/src/components/dialogs/HelpDialog.tsx
@@ -52,7 +52,7 @@ function HelpCard({ icon, title, description }: HelpCardProps) {
       </h3>
       <p
         className={cn(
-          "text-gray-700",
+          "text-neutral-700",
           isXpTheme
             ? "font-['Pixelated_MS_Sans_Serif',Arial] text-[10px]"
             : "font-geneva-12 text-[10px]"

--- a/src/components/dialogs/InputDialog.tsx
+++ b/src/components/dialogs/InputDialog.tsx
@@ -78,7 +78,7 @@ export function InputDialog({
     <div className={isXpTheme ? "p-2 px-4" : "p-4 px-6"}>
       <p
         className={cn(
-          "text-gray-500 mb-2",
+          "text-neutral-500 mb-2",
           isXpTheme
             ? "font-['Pixelated_MS_Sans_Serif',Arial] text-[11px]"
             : "font-geneva-12 text-[12px]"

--- a/src/components/dialogs/LoginDialog.tsx
+++ b/src/components/dialogs/LoginDialog.tsx
@@ -108,7 +108,7 @@ export function LoginDialog({
     <div className="space-y-3">
       <div className="space-y-2">
         <Label
-          className={cn("text-gray-700", themeFont)}
+          className={cn("text-neutral-700", themeFont)}
           style={themeFontStyle}
         >
           {t("common.auth.username")}
@@ -124,7 +124,7 @@ export function LoginDialog({
       </div>
       <div className="space-y-2">
         <Label
-          className={cn("text-gray-700", themeFont)}
+          className={cn("text-neutral-700", themeFont)}
           style={themeFontStyle}
         >
           {t("common.auth.password")}
@@ -145,7 +145,7 @@ export function LoginDialog({
     <div className="space-y-3">
       <div className="space-y-2">
         <Label
-          className={cn("text-gray-700", themeFont)}
+          className={cn("text-neutral-700", themeFont)}
           style={themeFontStyle}
         >
           {t("common.auth.username")}
@@ -161,7 +161,7 @@ export function LoginDialog({
       </div>
       <div className="space-y-2">
         <Label
-          className={cn("text-gray-700", themeFont)}
+          className={cn("text-neutral-700", themeFont)}
           style={themeFontStyle}
         >
           {t("common.auth.password")}

--- a/src/components/dialogs/LyricsSearchDialog.tsx
+++ b/src/components/dialogs/LyricsSearchDialog.tsx
@@ -211,7 +211,7 @@ export function LyricsSearchDialog({
     <div className={isXpTheme ? "p-2 px-4" : "p-4 px-6"}>
       <p
         className={cn(
-          "text-gray-500 mb-2",
+          "text-neutral-500 mb-2",
           isXpTheme
             ? "font-['Pixelated_MS_Sans_Serif',Arial] text-[11px]"
             : "font-geneva-12 text-[12px]"
@@ -287,7 +287,7 @@ export function LyricsSearchDialog({
         <div className="mb-3">
           <p
             className={cn(
-              "text-gray-500 mb-2",
+              "text-neutral-500 mb-2",
               isXpTheme
                 ? "font-['Pixelated_MS_Sans_Serif',Arial] text-[11px]"
                 : "font-geneva-12 text-[12px]"
@@ -301,7 +301,7 @@ export function LyricsSearchDialog({
           >
             {t("apps.ipod.dialogs.lyricsSearchCurrentSelection")}
           </p>
-          <div className="border border-gray-300 rounded-md overflow-hidden bg-white">
+          <div className="border border-neutral-300 rounded-md overflow-hidden bg-white">
             <div
               className={cn(
                 "flex items-center gap-2 px-2 py-1.5",
@@ -322,8 +322,8 @@ export function LyricsSearchDialog({
                 return (
                   <div
                     className={cn(
-                      "flex-shrink-0 w-9 h-9 overflow-hidden bg-gray-200",
-                      isXpTheme ? "border border-gray-400" : "rounded-sm"
+                      "flex-shrink-0 w-9 h-9 overflow-hidden bg-neutral-200",
+                      isXpTheme ? "border border-neutral-400" : "rounded-sm"
                     )}
                     aria-hidden="true"
                   >
@@ -377,7 +377,7 @@ export function LyricsSearchDialog({
         <div className="mb-3">
           <p
             className={cn(
-              "text-gray-500 mb-2",
+              "text-neutral-500 mb-2",
               isXpTheme
                 ? "font-['Pixelated_MS_Sans_Serif',Arial] text-[11px]"
                 : "font-geneva-12 text-[12px]"
@@ -391,7 +391,7 @@ export function LyricsSearchDialog({
           >
             {t("apps.ipod.dialogs.lyricsSearchSelectResult")}
           </p>
-          <ScrollArea className="h-[200px] border border-gray-300 rounded-md overflow-hidden bg-white">
+          <ScrollArea className="h-[200px] border border-neutral-300 rounded-md overflow-hidden bg-white">
             <div>
               {results.map((result, index) => {
                 const coverUrl = formatKugouImageUrl(result.cover, 100);
@@ -414,7 +414,7 @@ export function LyricsSearchDialog({
                       selectedIndex === index
                         ? "" // Selection styling handled by inline style
                         : index % 2 === 1
-                          ? "bg-gray-100"
+                          ? "bg-neutral-100"
                           : "bg-white",
                       isXpTheme
                         ? "font-['Pixelated_MS_Sans_Serif',Arial] text-[11px]"
@@ -430,8 +430,8 @@ export function LyricsSearchDialog({
                   >
                     <div
                       className={cn(
-                        "flex-shrink-0 w-9 h-9 overflow-hidden bg-gray-200",
-                        isXpTheme ? "border border-gray-400" : "rounded-sm"
+                        "flex-shrink-0 w-9 h-9 overflow-hidden bg-neutral-200",
+                        isXpTheme ? "border border-neutral-400" : "rounded-sm"
                       )}
                       aria-hidden="true"
                     >

--- a/src/components/dialogs/ShareItemDialog.tsx
+++ b/src/components/dialogs/ShareItemDialog.tsx
@@ -149,10 +149,10 @@ export function ShareItemDialog({
       <div className="flex flex-col items-center space-y-3 w-full">
         {/* QR Code */}
         {isLoading ? (
-          <div className="size-32 flex items-center justify-center bg-gray-100 rounded">
+          <div className="size-32 flex items-center justify-center bg-neutral-100 rounded">
             <p
               className={cn(
-                "text-gray-500",
+                "text-neutral-500",
                 isXpTheme
                   ? "font-['Pixelated_MS_Sans_Serif',Arial] text-[10px]"
                   : "font-geneva-12 text-[10px]"
@@ -178,10 +178,10 @@ export function ShareItemDialog({
             />
           </div>
         ) : (
-          <div className="size-32 flex items-center justify-center bg-gray-100 rounded">
+          <div className="size-32 flex items-center justify-center bg-neutral-100 rounded">
             <p
               className={cn(
-                "text-gray-500",
+                "text-neutral-500",
                 isXpTheme
                   ? "font-['Pixelated_MS_Sans_Serif',Arial] text-[10px]"
                   : "font-geneva-12 text-[10px]"

--- a/src/components/dialogs/SongSearchDialog.tsx
+++ b/src/components/dialogs/SongSearchDialog.tsx
@@ -587,7 +587,7 @@ export function SongSearchDialog({
   const dialogContent = (
     <div className={cn(isXpTheme ? "p-2 px-4" : "p-4 px-6", "overflow-hidden w-full box-border")}>
       {!isAppleMusicMode && (
-        <p className={cn("text-gray-500 mb-2", fontClass)} style={fontStyle}>
+        <p className={cn("text-neutral-500 mb-2", fontClass)} style={fontStyle}>
           {t("apps.ipod.dialogs.songSearchDescription")}
         </p>
       )}
@@ -602,7 +602,7 @@ export function SongSearchDialog({
 
       {hasResults && (
         <div style={{ marginBottom: "12px" }}>
-          <p className={cn("text-gray-500 mb-2", fontClass)} style={fontStyle}>
+          <p className={cn("text-neutral-500 mb-2", fontClass)} style={fontStyle}>
             {isAppleMusicMode
               ? t(
                   "apps.ipod.dialogs.appleMusicSearchSelectResult",

--- a/src/components/dialogs/TelegramLinkDialog.tsx
+++ b/src/components/dialogs/TelegramLinkDialog.tsx
@@ -86,10 +86,10 @@ export function TelegramLinkDialog({
   );
 
   const previewContent = isStatusLoading && !shouldShowLinkSession ? (
-    <div className="flex size-32 items-center justify-center rounded bg-gray-100">
+    <div className="flex size-32 items-center justify-center rounded bg-neutral-100">
       <p
         className={cn(
-          "text-gray-500",
+          "text-neutral-500",
           isXpTheme
             ? "font-['Pixelated_MS_Sans_Serif',Arial] text-[10px]"
             : "font-geneva-12 text-[10px]"

--- a/src/components/layout/AppleMenu.tsx
+++ b/src/components/layout/AppleMenu.tsx
@@ -222,7 +222,7 @@ export function AppleMenu() {
                   );
                 })
               ) : (
-                <MenubarItem disabled className="text-md h-6 px-3 text-gray-400">
+                <MenubarItem disabled className="text-md h-6 px-3 text-neutral-400">
                   {t("common.appleMenu.noRecentApps")}
                 </MenubarItem>
               )}
@@ -265,7 +265,7 @@ export function AppleMenu() {
                   );
                 })
               ) : (
-                <MenubarItem disabled className="text-md h-6 px-3 text-gray-400">
+                <MenubarItem disabled className="text-md h-6 px-3 text-neutral-400">
                   {t("common.appleMenu.noRecentDocuments")}
                 </MenubarItem>
               )}

--- a/src/components/layout/MenuBar.tsx
+++ b/src/components/layout/MenuBar.tsx
@@ -580,14 +580,14 @@ function DefaultMenuItems() {
           <MenubarItem
             onClick={() => undoRedoEntry?.undo()}
             disabled={!undoRedoEntry?.canUndo}
-            className={`text-md h-6 px-3 ${!undoRedoEntry?.canUndo ? "text-gray-500" : ""}`}
+            className={`text-md h-6 px-3 ${!undoRedoEntry?.canUndo ? "text-neutral-500" : ""}`}
           >
             {t("common.menu.undo")}
           </MenubarItem>
           <MenubarItem
             onClick={() => undoRedoEntry?.redo()}
             disabled={!undoRedoEntry?.canRedo}
-            className={`text-md h-6 px-3 ${!undoRedoEntry?.canRedo ? "text-gray-500" : ""}`}
+            className={`text-md h-6 px-3 ${!undoRedoEntry?.canRedo ? "text-neutral-500" : ""}`}
           >
             {t("common.menu.redo")}
           </MenubarItem>

--- a/src/components/layout/WindowFrame.tsx
+++ b/src/components/layout/WindowFrame.tsx
@@ -551,11 +551,11 @@ export function WindowFrame({
         ? "text-white/80"
         : variant === "aqua"
           ? isForeground
-            ? "text-gray-500"
-            : "text-gray-400"
+            ? "text-neutral-500"
+            : "text-neutral-400"
           : isForeground
-            ? "text-gray-600"
-            : "text-gray-400",
+            ? "text-neutral-600"
+            : "text-neutral-400",
       onCoverFlowToggle &&
         isCoverFlowActive &&
         (isAquaNoTitlebar ? "text-white" : "text-os-titlebar-active-text")
@@ -1669,7 +1669,7 @@ export function WindowFrame({
                     : "bg-os-titlebar-active-bg bg-os-titlebar-pattern bg-clip-content bg-[length:6.6666666667%_13.3333333333%] border-b-os-window"
                   : isTransparent
                   ? "bg-white/20 backdrop-blur-sm border-b-os-window"
-                  : "bg-os-titlebar-inactive-bg border-b-gray-400"
+                  : "bg-os-titlebar-inactive-bg border-b-neutral-400"
               )}
               onMouseDown={handleMouseDownWithForeground}
               onDoubleClick={(e) => {
@@ -1711,7 +1711,7 @@ export function WindowFrame({
                   className={`size-4 ${
                     !isTransparent &&
                     "bg-os-button-face shadow-[0_0_0_1px_var(--os-color-button-face)]"
-                  } border-2 border-os-window hover:bg-gray-200 active:bg-gray-300 flex items-center justify-center ${
+                  } border-2 border-os-window hover:bg-neutral-200 active:bg-neutral-300 flex items-center justify-center ${
                     !isForeground && "invisible"
                   }`}
                 />

--- a/src/components/layout/dashboard/DictionaryWidget.tsx
+++ b/src/components/layout/dashboard/DictionaryWidget.tsx
@@ -148,17 +148,17 @@ export function DictionaryWidget({ widgetId }: DictionaryWidgetProps) {
         {/* XP content */}
         <div className="flex-1 overflow-y-auto px-3 py-2" style={{ fontSize: 11, minHeight: 0, maxHeight: 200 }}>
           {loading && (
-            <div className="text-center text-gray-400 py-4" style={{ fontSize: 10 }}>
+            <div className="text-center text-neutral-400 py-4" style={{ fontSize: 10 }}>
               {t("apps.dashboard.dictionary.loading", "Looking up…")}
             </div>
           )}
           {!loading && error && (
-            <div className="text-center text-gray-400 py-4" style={{ fontSize: 10 }}>
+            <div className="text-center text-neutral-400 py-4" style={{ fontSize: 10 }}>
               {error}
             </div>
           )}
           {!loading && !error && !entry && (
-            <div className="text-center text-gray-400 py-6" style={{ fontSize: 10 }}>
+            <div className="text-center text-neutral-400 py-6" style={{ fontSize: 10 }}>
               {hasSearched ? t("apps.dashboard.dictionary.noResults", "No results.") : t("apps.dashboard.dictionary.placeholder", "Type a word to look it up.")}
             </div>
           )}

--- a/src/components/layout/dashboard/WeatherWidget.tsx
+++ b/src/components/layout/dashboard/WeatherWidget.tsx
@@ -295,7 +295,7 @@ export function WeatherWidget({ widgetId }: WeatherWidgetProps) {
     if (loading)
       return (
         <div
-          className="flex items-center justify-center p-4 text-xs text-gray-500"
+          className="flex items-center justify-center p-4 text-xs text-neutral-500"
           style={{ minHeight: 120 }}
         >
           {t("apps.dashboard.weather.loading")}
@@ -317,7 +317,7 @@ export function WeatherWidget({ widgetId }: WeatherWidgetProps) {
           />
           <div>
             <div className="text-xl font-light">{weather.temperature}°</div>
-            <div className="text-[10px] text-gray-500">
+            <div className="text-[10px] text-neutral-500">
               {t("apps.dashboard.weather.high")} {weather.temperatureMax}° {t("apps.dashboard.weather.low")} {weather.temperatureMin}°
             </div>
           </div>

--- a/src/components/listen/JoinSessionDialog.tsx
+++ b/src/components/listen/JoinSessionDialog.tsx
@@ -165,12 +165,12 @@ export function JoinSessionDialog({
     <div className={isXpTheme ? "p-2 px-4" : "p-4 px-6"}>
       {/* Session List - Primary view */}
       <div className="mb-3">
-        <ScrollArea className="h-[160px] border border-gray-300 rounded-md overflow-hidden bg-white">
+        <ScrollArea className="h-[160px] border border-neutral-300 rounded-md overflow-hidden bg-white">
           <div>
             {isLoading ? (
               <div
                 className={cn(
-                  "flex items-center justify-center h-[140px] text-gray-500",
+                  "flex items-center justify-center h-[140px] text-neutral-500",
                   isXpTheme
                     ? "font-['Pixelated_MS_Sans_Serif',Arial] text-[11px]"
                     : "font-geneva-12 text-[12px]"
@@ -204,7 +204,7 @@ export function JoinSessionDialog({
             ) : sessions.length === 0 ? (
               <div
                 className={cn(
-                  "flex items-center justify-center h-[140px] text-gray-500",
+                  "flex items-center justify-center h-[140px] text-neutral-500",
                   isXpTheme
                     ? "font-['Pixelated_MS_Sans_Serif',Arial] text-[11px]"
                     : "font-geneva-12 text-[12px]"
@@ -237,7 +237,7 @@ export function JoinSessionDialog({
                     selectedIndex === index
                       ? ""
                       : index % 2 === 1
-                        ? "bg-gray-100"
+                        ? "bg-neutral-100"
                         : "bg-white",
                     isXpTheme
                       ? "font-['Pixelated_MS_Sans_Serif',Arial] text-[11px]"
@@ -290,7 +290,7 @@ export function JoinSessionDialog({
       {/* Manual Entry - Secondary option */}
       <p
         className={cn(
-          "text-gray-500 mb-2",
+          "text-neutral-500 mb-2",
           isXpTheme
             ? "font-['Pixelated_MS_Sans_Serif',Arial] text-[11px]"
             : "font-geneva-12 text-[12px]"

--- a/src/components/shared/CursorRepoAgentChatCard.tsx
+++ b/src/components/shared/CursorRepoAgentChatCard.tsx
@@ -116,7 +116,7 @@ export function CursorRepoAgentChatCard({
         }
         style={isPanel ? undefined : { boxShadow: "0 0 0 1px rgba(0, 0, 0, 0.3)" }}
       >
-        <div className="flex flex-shrink-0 items-center gap-3 border-b border-gray-300 bg-gray-100 px-3 py-2 dark:border-neutral-600 dark:bg-neutral-800/90">
+        <div className="flex flex-shrink-0 items-center gap-3 border-b border-neutral-300 bg-neutral-100 px-3 py-2 dark:border-neutral-600 dark:bg-neutral-800/90">
           <span className="relative inline-flex size-6 shrink-0 items-center justify-center" aria-hidden>
             <img
               src="/brands/cursor-cube-2d-light.svg"
@@ -144,7 +144,7 @@ export function CursorRepoAgentChatCard({
                 href={prUrl}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="inline-flex shrink-0 items-center gap-1 rounded border border-gray-300 bg-white/85 px-1.5 py-0.5 text-[10px] font-medium text-neutral-700 transition-colors hover:bg-gray-100 dark:border-neutral-600 dark:bg-neutral-900/70 dark:text-neutral-200 dark:hover:bg-neutral-800"
+                className="inline-flex shrink-0 items-center gap-1 rounded border border-neutral-300 bg-white/85 px-1.5 py-0.5 text-[10px] font-medium text-neutral-700 transition-colors hover:bg-neutral-100 dark:border-neutral-600 dark:bg-neutral-900/70 dark:text-neutral-200 dark:hover:bg-neutral-800"
                 title={prUrl}
                 aria-label={t("apps.chats.toolCalls.cursorCloudAgent.openPr")}
               >
@@ -171,8 +171,8 @@ export function CursorRepoAgentChatCard({
         <div
           className={
             isPanel
-              ? "flex min-h-0 flex-1 flex-col border-t border-gray-200 bg-neutral-50/50 dark:border-neutral-600 dark:bg-neutral-900/40"
-              : "border-t border-gray-200 bg-neutral-50/50 dark:border-neutral-600 dark:bg-neutral-900/40"
+              ? "flex min-h-0 flex-1 flex-col border-t border-neutral-200 bg-neutral-50/50 dark:border-neutral-600 dark:bg-neutral-900/40"
+              : "border-t border-neutral-200 bg-neutral-50/50 dark:border-neutral-600 dark:bg-neutral-900/40"
           }
         >
           {error ? (
@@ -258,8 +258,8 @@ export function CursorRepoAgentChatCard({
           <div
             className={
               isPanel
-                ? "shrink-0 border-t border-gray-200 bg-white/80 px-2 py-1.5 dark:border-neutral-700 dark:bg-neutral-900/60"
-                : "border-t border-gray-200 bg-white/80 px-2 py-1.5 dark:border-neutral-700 dark:bg-neutral-900/60"
+                ? "shrink-0 border-t border-neutral-200 bg-white/80 px-2 py-1.5 dark:border-neutral-700 dark:bg-neutral-900/60"
+                : "border-t border-neutral-200 bg-white/80 px-2 py-1.5 dark:border-neutral-700 dark:bg-neutral-900/60"
             }
           >
             {followupError ? (
@@ -297,7 +297,7 @@ export function CursorRepoAgentChatCard({
                 aria-label={t(
                   "apps.chats.toolCalls.cursorCloudAgent.followupAriaLabel"
                 )}
-                className="min-h-[26px] flex-1 resize-none rounded border border-gray-300 bg-white px-2 py-1 text-[12px] leading-snug text-neutral-900 placeholder:text-neutral-400 focus:outline-none focus:ring-1 focus:ring-blue-400 disabled:cursor-not-allowed disabled:bg-gray-100 disabled:text-neutral-500 dark:border-neutral-700 dark:bg-neutral-950 dark:text-neutral-100 dark:placeholder:text-neutral-500 dark:disabled:bg-neutral-900"
+                className="min-h-[26px] flex-1 resize-none rounded border border-neutral-300 bg-white px-2 py-1 text-[12px] leading-snug text-neutral-900 placeholder:text-neutral-400 focus:outline-none focus:ring-1 focus:ring-blue-400 disabled:cursor-not-allowed disabled:bg-neutral-100 disabled:text-neutral-500 dark:border-neutral-700 dark:bg-neutral-950 dark:text-neutral-100 dark:placeholder:text-neutral-500 dark:disabled:bg-neutral-900"
               />
               <button
                 type="submit"

--- a/src/components/shared/CursorRunEventView.tsx
+++ b/src/components/shared/CursorRunEventView.tsx
@@ -37,7 +37,7 @@ function isRecord(v: unknown): v is Record<string, unknown> {
 }
 
 const markdownStreamClass =
-  "cursor-stream-md px-1 py-0.5 font-geneva-12 text-[12px] leading-snug text-gray-700 break-words dark:text-neutral-200";
+  "cursor-stream-md px-1 py-0.5 font-geneva-12 text-[12px] leading-snug text-neutral-700 break-words dark:text-neutral-200";
 
 const toolDisplayNameOverrides: Record<string, string> = {
   run_terminal_cmd: "Run terminal command",
@@ -223,10 +223,10 @@ function CursorToolInvocationRow({
 }) {
   return (
     <div className="mb-0 px-1 py-0.5 text-[12px]">
-      <div className="flex min-w-0 flex-nowrap items-baseline gap-1 text-gray-700">
+      <div className="flex min-w-0 flex-nowrap items-baseline gap-1 text-neutral-700">
         <span className={`shrink-0 ${done ? "" : "shimmer"}`}>{primary}</span>
         {secondary ? (
-          <span className="min-w-0 truncate text-gray-500 dark:text-neutral-400">
+          <span className="min-w-0 truncate text-neutral-500 dark:text-neutral-400">
             {secondary}
           </span>
         ) : null}
@@ -323,7 +323,7 @@ function ThinkingCollapsible({ text }: { text: string }) {
     );
   }
   return (
-    <div className="mb-0 px-1 py-0.5 text-[12px] text-gray-500 dark:text-neutral-500">
+    <div className="mb-0 px-1 py-0.5 text-[12px] text-neutral-500 dark:text-neutral-500">
       <button
         type="button"
         onClick={() => setOpen((v) => !v)}

--- a/src/components/shared/HtmlPreview.tsx
+++ b/src/components/shared/HtmlPreview.tsx
@@ -1020,7 +1020,7 @@ export default function HtmlPreview({
         {/* Loading PULSE overlay (now breathing effect) */}
         {isStreaming && (
           <motion.div
-            className="absolute inset-0 bg-gray-300 z-10 pointer-events-none"
+            className="absolute inset-0 bg-neutral-300 z-10 pointer-events-none"
             initial={{ opacity: 0.2 }} // Start at lower opacity
             animate={{
               opacity: [0.2, 0.6, 0.2], // Loop between 0.6 and 1
@@ -1035,7 +1035,7 @@ export default function HtmlPreview({
 
         {/* Applet banner - similar to AppStore detail view */}
           {!isInternetExplorer && (appletTitle || appletIcon) && (
-            <div className="flex items-center gap-3 px-3 py-2 bg-gray-100 border-b border-gray-300 flex-shrink-0">
+            <div className="flex items-center gap-3 px-3 py-2 bg-neutral-100 border-b border-neutral-300 flex-shrink-0">
               <div
                 className="!text-2xl flex-shrink-0 applet-icon"
                 style={{ fontSize: "1.5rem" }}
@@ -1173,7 +1173,7 @@ export default function HtmlPreview({
               <pre
                 className={`p-2 text-[12px] ${
                   isMacOsXTheme ? "font-mono" : "font-monaco"
-                } antialiased text-gray-700 whitespace-pre-wrap break-words`}
+                } antialiased text-neutral-700 whitespace-pre-wrap break-words`}
               >
                 {htmlContent.split("\n").slice(-8).join("\n")}
               </pre>
@@ -1265,7 +1265,7 @@ export default function HtmlPreview({
                         exit={{ opacity: 0 }}
                         transition={{ duration: 0.25 }}
                       >
-                        <pre className="text-[12px] font-monaco text-gray-300 whitespace-pre-wrap break-words m-0">
+                        <pre className="text-[12px] font-monaco text-neutral-300 whitespace-pre-wrap break-words m-0">
                           {finalProcessedHtmlRef.current || processedHtmlContent}
                         </pre>
                       </motion.div>
@@ -1324,7 +1324,7 @@ export default function HtmlPreview({
                           <pre
                             className={`p-4 text-xs ${
                               isMacOsXTheme ? "font-sans" : "font-geneva-12"
-                            } text-gray-700 whitespace-pre-wrap break-words`}
+                            } text-neutral-700 whitespace-pre-wrap break-words`}
                           >
                             {htmlContent.split("\n").slice(-15).join("\n")}
                           </pre>
@@ -1362,11 +1362,11 @@ export default function HtmlPreview({
                     {/* Loading PULSE overlay for fullscreen (kept for visual feedback) */}
                     {isStreaming && htmlContent && (
                       <div
-                        className="absolute inset-0 bg-gray-100 z-10 pointer-events-none"
+                        className="absolute inset-0 bg-neutral-100 z-10 pointer-events-none"
                         style={{ opacity: 0.2 }}
                       >
                         <motion.div
-                          className="size-full bg-gray-400"
+                          className="size-full bg-neutral-400"
                           animate={{
                             opacity: [0.05, 0.2, 0.05],
                           }}

--- a/src/components/shared/ImageAttachment.tsx
+++ b/src/components/shared/ImageAttachment.tsx
@@ -39,8 +39,8 @@ export function ImageAttachment({
         className={cn(
           "relative overflow-hidden",
           isMacTheme
-            ? "chat-bubble macosx-link-preview rounded-[16px] bg-gray-100"
-            : "bg-white border border-gray-200 rounded"
+            ? "chat-bubble macosx-link-preview rounded-[16px] bg-neutral-100"
+            : "bg-white border border-neutral-200 rounded"
         )}
       >
         {/* Full bleed image for macOS */}

--- a/src/components/shared/LinkPreview.tsx
+++ b/src/components/shared/LinkPreview.tsx
@@ -345,9 +345,9 @@ export function LinkPreview({ url, className = "" }: LinkPreviewProps) {
         className={cn(
           "h-[106px] w-full min-w-[280px] max-w-[420px]",
           "relative overflow-hidden",
-          "border border-gray-200 rounded",
+          "border border-neutral-200 rounded",
           "before:absolute before:inset-0",
-          "before:bg-gradient-to-r before:from-gray-200 before:via-gray-100 before:to-gray-200",
+          "before:bg-gradient-to-r before:from-neutral-200 before:via-neutral-100 before:to-neutral-200",
           "before:animate-[shimmer_2s_linear_infinite]",
           "before:bg-[length:200%_100%]",
           className
@@ -466,8 +466,8 @@ export function LinkPreview({ url, className = "" }: LinkPreviewProps) {
       className={cn(
         "link-preview-container relative overflow-hidden cursor-pointer font-geneva-12 group max-w-[420px]",
         isMacOSTheme
-          ? "chat-bubble macosx-link-preview bg-gray-100 border-none shadow-none"
-          : "bg-white border border-gray-200 rounded",
+          ? "chat-bubble macosx-link-preview bg-neutral-100 border-none shadow-none"
+          : "bg-white border border-neutral-200 rounded",
         className
       )}
       onClick={handleClick}
@@ -483,7 +483,7 @@ export function LinkPreview({ url, className = "" }: LinkPreviewProps) {
         <>
           <div
             className={cn(
-              "relative aspect-video bg-gray-100 overflow-hidden",
+              "relative aspect-video bg-neutral-100 overflow-hidden",
               isMacOSTheme && "-mx-3 -mt-[6px] rounded-t-[14px]"
             )}
           >
@@ -512,7 +512,7 @@ export function LinkPreview({ url, className = "" }: LinkPreviewProps) {
                     );
                   }}
                 />
-                <div className="size-4 bg-gray-300 rounded-full flex-shrink-0 hidden"></div>
+                <div className="size-4 bg-neutral-300 rounded-full flex-shrink-0 hidden"></div>
                 {metadata.title && (
                   <h3 className="font-semibold text-white text-[10px] truncate">
                     {metadata.title}
@@ -526,14 +526,14 @@ export function LinkPreview({ url, className = "" }: LinkPreviewProps) {
           <div className="px-2 pb-2">
             {isYouTubeUrl(url) ? (
               url.includes("/ipod/") ? (
-                <div className="flex gap-2 pt-2 border-t border-gray-100">
+                <div className="flex gap-2 pt-2 border-t border-neutral-100">
                   <button
                     onClick={handleAddToIpod}
                     onTouchStart={(e) => e.stopPropagation()}
                     className={cn(
                       isMacOSTheme
                         ? "aqua-button secondary flex-1"
-                        : "flex items-center justify-center gap-1.5 px-3 py-2 text-[12px] bg-gray-100 hover:bg-gray-200 rounded-md transition-colors flex-1"
+                        : "flex items-center justify-center gap-1.5 px-3 py-2 text-[12px] bg-neutral-100 hover:bg-neutral-200 rounded-md transition-colors flex-1"
                     )}
                     title={t("components.linkPreview.openIpod")}
                     data-link-preview
@@ -547,7 +547,7 @@ export function LinkPreview({ url, className = "" }: LinkPreviewProps) {
                     className={cn(
                       isMacOSTheme
                         ? "aqua-button secondary flex-1"
-                        : "flex items-center justify-center gap-1.5 px-3 py-2 text-[12px] bg-gray-100 hover:bg-gray-200 rounded-md transition-colors flex-1"
+                        : "flex items-center justify-center gap-1.5 px-3 py-2 text-[12px] bg-neutral-100 hover:bg-neutral-200 rounded-md transition-colors flex-1"
                     )}
                     title={t("components.linkPreview.openYouTube")}
                     data-link-preview
@@ -557,14 +557,14 @@ export function LinkPreview({ url, className = "" }: LinkPreviewProps) {
                   </button>
                 </div>
               ) : url.includes("/karaoke/") ? (
-                <div className="flex gap-2 pt-2 border-t border-gray-100">
+                <div className="flex gap-2 pt-2 border-t border-neutral-100">
                   <button
                     onClick={handleOpenInKaraoke}
                     onTouchStart={(e) => e.stopPropagation()}
                     className={cn(
                       isMacOSTheme
                         ? "aqua-button secondary flex-1"
-                        : "flex items-center justify-center gap-1.5 px-3 py-2 text-[12px] bg-gray-100 hover:bg-gray-200 rounded-md transition-colors flex-1"
+                        : "flex items-center justify-center gap-1.5 px-3 py-2 text-[12px] bg-neutral-100 hover:bg-neutral-200 rounded-md transition-colors flex-1"
                     )}
                     title={t("components.linkPreview.openKaraoke")}
                     data-link-preview
@@ -578,7 +578,7 @@ export function LinkPreview({ url, className = "" }: LinkPreviewProps) {
                     className={cn(
                       isMacOSTheme
                         ? "aqua-button secondary flex-1"
-                        : "flex items-center justify-center gap-1.5 px-3 py-2 text-[12px] bg-gray-100 hover:bg-gray-200 rounded-md transition-colors flex-1"
+                        : "flex items-center justify-center gap-1.5 px-3 py-2 text-[12px] bg-neutral-100 hover:bg-neutral-200 rounded-md transition-colors flex-1"
                     )}
                     title={t("components.linkPreview.openYouTube")}
                     data-link-preview
@@ -588,14 +588,14 @@ export function LinkPreview({ url, className = "" }: LinkPreviewProps) {
                   </button>
                 </div>
               ) : (
-                <div className="flex gap-2 pt-2 border-t border-gray-100">
+                <div className="flex gap-2 pt-2 border-t border-neutral-100">
                   <button
                     onClick={handleAddToIpod}
                     onTouchStart={(e) => e.stopPropagation()}
                     className={cn(
                       isMacOSTheme
                         ? "aqua-button secondary flex-1"
-                        : "flex items-center justify-center gap-1.5 px-3 py-2 text-[12px] bg-gray-100 hover:bg-gray-200 rounded-md transition-colors flex-1"
+                        : "flex items-center justify-center gap-1.5 px-3 py-2 text-[12px] bg-neutral-100 hover:bg-neutral-200 rounded-md transition-colors flex-1"
                     )}
                     title={t("components.linkPreview.addToIpod")}
                     data-link-preview
@@ -609,7 +609,7 @@ export function LinkPreview({ url, className = "" }: LinkPreviewProps) {
                     className={cn(
                       isMacOSTheme
                         ? "aqua-button secondary flex-1"
-                        : "flex items-center justify-center gap-1.5 px-3 py-2 text-[12px] bg-gray-100 hover:bg-gray-200 rounded-md transition-colors flex-1"
+                        : "flex items-center justify-center gap-1.5 px-3 py-2 text-[12px] bg-neutral-100 hover:bg-neutral-200 rounded-md transition-colors flex-1"
                     )}
                     title={t("components.linkPreview.openYouTube")}
                     data-link-preview
@@ -620,14 +620,14 @@ export function LinkPreview({ url, className = "" }: LinkPreviewProps) {
                 </div>
               )
             ) : (
-              <div className="flex gap-2 pt-2 border-t border-gray-100">
+              <div className="flex gap-2 pt-2 border-t border-neutral-100">
                 <button
                   onClick={handleOpenExternally}
                   onTouchStart={(e) => e.stopPropagation()}
                   className={cn(
                     isMacOSTheme
                       ? "aqua-button secondary w-full"
-                      : "flex items-center justify-center gap-1.5 px-3 py-2 text-[12px] bg-gray-100 hover:bg-gray-200 rounded-md transition-colors w-full"
+                      : "flex items-center justify-center gap-1.5 px-3 py-2 text-[12px] bg-neutral-100 hover:bg-neutral-200 rounded-md transition-colors w-full"
                   )}
                   title="Open Externally"
                   data-link-preview
@@ -646,7 +646,7 @@ export function LinkPreview({ url, className = "" }: LinkPreviewProps) {
             {metadata.image && (
               <div
                 className={cn(
-                  "size-18 bg-gray-100 relative overflow-hidden flex-shrink-0",
+                  "size-18 bg-neutral-100 relative overflow-hidden flex-shrink-0",
                   isMacOSTheme && "hidden"
                 )}
               >
@@ -683,7 +683,7 @@ export function LinkPreview({ url, className = "" }: LinkPreviewProps) {
             >
               {metadata.title && (
                 <h3
-                  className="font-semibold text-gray-900 text-[10px]"
+                  className="font-semibold text-neutral-900 text-[10px]"
                   style={{
                     display: "-webkit-box",
                     WebkitLineClamp: 1,
@@ -725,8 +725,8 @@ export function LinkPreview({ url, className = "" }: LinkPreviewProps) {
                       );
                     }}
                   />
-                  <div className="size-4 bg-gray-300 rounded-full flex-shrink-0 hidden"></div>
-                  <p className="text-[10px] text-gray-500 truncate">
+                  <div className="size-4 bg-neutral-300 rounded-full flex-shrink-0 hidden"></div>
+                  <p className="text-[10px] text-neutral-500 truncate">
                     {metadata.siteName || new URL(url).hostname}
                   </p>
                 </div>
@@ -738,8 +738,8 @@ export function LinkPreview({ url, className = "" }: LinkPreviewProps) {
           <div className={cn(
             "pb-2 border-t",
             isMacOSTheme 
-              ? "border-gray-300" 
-              : "border-gray-200"
+              ? "border-neutral-300" 
+              : "border-neutral-200"
           )}>
             <div className="px-2 pt-2">
               {isYouTubeUrl(url) ? (
@@ -751,7 +751,7 @@ export function LinkPreview({ url, className = "" }: LinkPreviewProps) {
                       className={cn(
                         isMacOSTheme
                           ? "aqua-button secondary flex-1"
-                          : "flex items-center justify-center gap-1.5 px-3 py-2 text-[12px] bg-gray-100 hover:bg-gray-200 rounded-md transition-colors flex-1"
+                          : "flex items-center justify-center gap-1.5 px-3 py-2 text-[12px] bg-neutral-100 hover:bg-neutral-200 rounded-md transition-colors flex-1"
                       )}
                       title={t("components.linkPreview.openIpod")}
                       data-link-preview
@@ -765,7 +765,7 @@ export function LinkPreview({ url, className = "" }: LinkPreviewProps) {
                       className={cn(
                         isMacOSTheme
                           ? "aqua-button secondary flex-1"
-                          : "flex items-center justify-center gap-1.5 px-3 py-2 text-[12px] bg-gray-100 hover:bg-gray-200 rounded-md transition-colors flex-1"
+                          : "flex items-center justify-center gap-1.5 px-3 py-2 text-[12px] bg-neutral-100 hover:bg-neutral-200 rounded-md transition-colors flex-1"
                       )}
                       title={t("components.linkPreview.openYouTube")}
                       data-link-preview
@@ -784,7 +784,7 @@ export function LinkPreview({ url, className = "" }: LinkPreviewProps) {
                       className={cn(
                         isMacOSTheme
                           ? "aqua-button secondary flex-1"
-                          : "flex items-center justify-center gap-1.5 px-3 py-2 text-[12px] bg-gray-100 hover:bg-gray-200 rounded-md transition-colors flex-1"
+                          : "flex items-center justify-center gap-1.5 px-3 py-2 text-[12px] bg-neutral-100 hover:bg-neutral-200 rounded-md transition-colors flex-1"
                       )}
                       title={t("components.linkPreview.openKaraoke")}
                       data-link-preview
@@ -798,7 +798,7 @@ export function LinkPreview({ url, className = "" }: LinkPreviewProps) {
                       className={cn(
                         isMacOSTheme
                           ? "aqua-button secondary flex-1"
-                          : "flex items-center justify-center gap-1.5 px-3 py-2 text-[12px] bg-gray-100 hover:bg-gray-200 rounded-md transition-colors flex-1"
+                          : "flex items-center justify-center gap-1.5 px-3 py-2 text-[12px] bg-neutral-100 hover:bg-neutral-200 rounded-md transition-colors flex-1"
                       )}
                       title={t("components.linkPreview.openYouTube")}
                       data-link-preview
@@ -817,7 +817,7 @@ export function LinkPreview({ url, className = "" }: LinkPreviewProps) {
                       className={cn(
                         isMacOSTheme
                           ? "aqua-button secondary flex-1"
-                          : "flex items-center justify-center gap-1.5 px-3 py-2 text-[12px] bg-gray-100 hover:bg-gray-200 rounded-md transition-colors flex-1"
+                          : "flex items-center justify-center gap-1.5 px-3 py-2 text-[12px] bg-neutral-100 hover:bg-neutral-200 rounded-md transition-colors flex-1"
                       )}
                       title={t("components.linkPreview.addToIpod")}
                       data-link-preview
@@ -831,7 +831,7 @@ export function LinkPreview({ url, className = "" }: LinkPreviewProps) {
                       className={cn(
                         isMacOSTheme
                           ? "aqua-button secondary flex-1"
-                          : "flex items-center justify-center gap-1.5 px-3 py-2 text-[12px] bg-gray-100 hover:bg-gray-200 rounded-md transition-colors flex-1"
+                          : "flex items-center justify-center gap-1.5 px-3 py-2 text-[12px] bg-neutral-100 hover:bg-neutral-200 rounded-md transition-colors flex-1"
                       )}
                       title={t("components.linkPreview.openYouTube")}
                       data-link-preview
@@ -851,7 +851,7 @@ export function LinkPreview({ url, className = "" }: LinkPreviewProps) {
                     className={cn(
                       isMacOSTheme
                         ? "aqua-button secondary w-full"
-                        : "flex items-center justify-center gap-1.5 px-3 py-2 text-[12px] bg-gray-100 hover:bg-gray-200 rounded-md transition-colors w-full"
+                        : "flex items-center justify-center gap-1.5 px-3 py-2 text-[12px] bg-neutral-100 hover:bg-neutral-200 rounded-md transition-colors w-full"
                     )}
                     title="Open Externally"
                     data-link-preview

--- a/src/components/shared/ToolInvocationMessage.tsx
+++ b/src/components/shared/ToolInvocationMessage.tsx
@@ -776,7 +776,7 @@ export function ToolInvocationMessage({
         <div key={partKey} className="mb-0 px-1 py-0.5 text-[12px]">
           <ToolInvocationStatusRow
             icon={<Check className="size-3 text-blue-600" weight="bold" />}
-            className="text-gray-700"
+            className="text-neutral-700"
             align="start"
           >
             <span>
@@ -899,7 +899,7 @@ export function ToolInvocationMessage({
       return (
         <div key={partKey} className="mb-0 px-1 py-0.5 italic text-[12px]">
           <ToolInvocationStatusRow
-            icon={<ActivityIndicator size="xs" className="text-gray-500" />}
+            icon={<ActivityIndicator size="xs" className="text-neutral-500" />}
             className="text-neutral-600"
           >
             <span className="shimmer">
@@ -929,8 +929,8 @@ export function ToolInvocationMessage({
       return (
         <div key={partKey} className="mb-0 px-1 py-0.5 italic text-[12px]">
           <ToolInvocationStatusRow
-            icon={<ActivityIndicator size="xs" className="text-gray-500" />}
-            className="text-gray-500"
+            icon={<ActivityIndicator size="xs" className="text-neutral-500" />}
+            className="text-neutral-500"
           >
             <span>{t("apps.chats.toolCalls.preparingHtmlPreview")}</span>
           </ToolInvocationStatusRow>
@@ -949,8 +949,8 @@ export function ToolInvocationMessage({
       {(state === "input-streaming" || state === "input-available") &&
         !output && (
           <ToolInvocationStatusRow
-            icon={<ActivityIndicator size="xs" className="text-gray-500" />}
-            className="text-gray-700"
+            icon={<ActivityIndicator size="xs" className="text-neutral-500" />}
+            className="text-neutral-700"
           >
             {displayCallMessage ? (
               <span className="shimmer">{displayCallMessage}</span>
@@ -966,7 +966,7 @@ export function ToolInvocationMessage({
       {state === "output-available" && (
         <ToolInvocationStatusRow
           icon={<Check className="size-3 text-blue-600" weight="bold" />}
-          className="text-gray-700"
+          className="text-neutral-700"
           align="start"
         >
           {displayResultMessage ? (
@@ -974,7 +974,7 @@ export function ToolInvocationMessage({
           ) : (
             <div className="flex flex-col">
               {typeof output === "string" && output.length > 0 ? (
-                <span className="text-gray-500">{output}</span>
+                <span className="text-neutral-500">{output}</span>
               ) : (
                 <span>{formatToolName(toolName)}</span>
               )}

--- a/src/components/ui/SwipeInstructions.tsx
+++ b/src/components/ui/SwipeInstructions.tsx
@@ -92,7 +92,7 @@ export function SwipeInstructions({ className }: SwipeInstructionsProps) {
         <h3 className="font-bold text-lg">{t("common.swipeInstructions.title")}</h3>
         <button
           onClick={handleDismiss}
-          className="bg-transparent p-1 rounded-full hover:bg-gray-100"
+          className="bg-transparent p-1 rounded-full hover:bg-neutral-100"
         >
           <X size={18} weight="bold" />
         </button>
@@ -101,7 +101,7 @@ export function SwipeInstructions({ className }: SwipeInstructionsProps) {
       <div className="mt-2 flex items-center justify-center space-x-8 py-4">
         <div className="flex flex-col items-center">
           <div className="relative size-16 flex items-center justify-center">
-            <div className="absolute border-2 border-black rounded-md size-12 bg-gray-100" />
+            <div className="absolute border-2 border-black rounded-md size-12 bg-neutral-100" />
             <svg
               width="24"
               height="24"
@@ -123,7 +123,7 @@ export function SwipeInstructions({ className }: SwipeInstructionsProps) {
 
         <div className="flex flex-col items-center">
           <div className="relative size-16 flex items-center justify-center">
-            <div className="absolute border-2 border-black rounded-md size-12 bg-gray-100" />
+            <div className="absolute border-2 border-black rounded-md size-12 bg-neutral-100" />
             <svg
               width="24"
               height="24"
@@ -144,7 +144,7 @@ export function SwipeInstructions({ className }: SwipeInstructionsProps) {
         </div>
       </div>
 
-      <p className="text-xs text-gray-500 mt-2 text-center">
+      <p className="text-xs text-neutral-500 mt-2 text-center">
         {t("common.swipeInstructions.description")}
       </p>
     </div>

--- a/src/components/ui/dial.tsx
+++ b/src/components/ui/dial.tsx
@@ -162,7 +162,7 @@ const Dial = (
           onMouseDown={handleValueMouseDown}
           onTouchStart={handleValueTouchStart}
         >
-          <div className="text-[10px] text-gray-400">{label}</div>
+          <div className="text-[10px] text-neutral-400">{label}</div>
           {showValue && (
             <div className="text-xs">{valueFormatter(value)}</div>
           )}

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -242,7 +242,7 @@ const DialogHeader = ({
       <DialogPrimitive.Close asChild>
         <div className="relative ml-2 size-4 cursor-default select-none">
           <div className="absolute inset-0 -m-2" />
-          <div className="size-4 bg-os-button-face shadow-[0_0_0_1px_var(--os-color-button-face)] border-2 border-os-window hover:bg-gray-200 active:bg-gray-300 flex items-center justify-center" />
+          <div className="size-4 bg-os-button-face shadow-[0_0_0_1px_var(--os-color-button-face)] border-2 border-os-window hover:bg-neutral-200 active:bg-neutral-300 flex items-center justify-center" />
         </div>
       </DialogPrimitive.Close>
       <div className="select-none mx-auto bg-os-button-face px-2 py-0 h-full flex items-center justify-center text-os-titlebar-active-text">

--- a/src/components/ui/right-click-menu.tsx
+++ b/src/components/ui/right-click-menu.tsx
@@ -55,7 +55,7 @@ interface RightClickMenuProps {
 }
 
 export const menuItemClass =
-  "text-md h-6 px-3 active:bg-gray-900 active:text-white min-w-[140px] flex items-center gap-2";
+  "text-md h-6 px-3 active:bg-neutral-900 active:text-white min-w-[140px] flex items-center gap-2";
 
 const menuItemKeyCache = new WeakMap<object, string>();
 let menuItemKeySeed = 0;

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -258,7 +258,7 @@ const SelectItemWithDescription = (
       <div className="flex flex-col gap-0.5">
         <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
         {description && (
-          <span className="text-[11px] text-gray-500 group-focus:text-inherit font-normal leading-tight">
+          <span className="text-[11px] text-neutral-500 group-focus:text-inherit font-normal leading-tight">
             {description}
           </span>
         )}

--- a/src/components/ui/volume-bar.tsx
+++ b/src/components/ui/volume-bar.tsx
@@ -11,7 +11,7 @@ export function VolumeBar({ volume, className = "" }: VolumeBarProps) {
 
   return (
     <div
-      className={`h-1 bg-gray-200 rounded-full overflow-hidden ${className}`}
+      className={`h-1 bg-neutral-200 rounded-full overflow-hidden ${className}`}
     >
       <motion.div
         className="h-full bg-black rounded-full"

--- a/src/styles/themes.css
+++ b/src/styles/themes.css
@@ -1049,12 +1049,12 @@
 /* Preserve bookmark bar button text size in Internet Explorer */
 /* Target bookmark buttons with highest specificity */
 :root[data-os-theme="macosx"]
-  button.whitespace-nowrap.hover\:bg-gray-200.font-geneva-12.text-\[10px\] {
+  button.whitespace-nowrap.hover\:bg-neutral-200.font-geneva-12.text-\[10px\] {
   font-size: 10px !important;
 }
 
 :root[data-os-theme="macosx"]
-  button.whitespace-nowrap.hover\:bg-gray-200.font-geneva-12.text-\[10px\]
+  button.whitespace-nowrap.hover\:bg-neutral-200.font-geneva-12.text-\[10px\]
   span {
   font-size: 10px !important;
 }
@@ -1121,9 +1121,9 @@
   font-size: 10px !important;
 }
 
-:root[data-os-theme="macosx"] p.text-\[10px\].text-gray-700.font-geneva-12,
+:root[data-os-theme="macosx"] p.text-\[10px\].text-neutral-700.font-geneva-12,
 :root[data-os-theme="macosx"]
-  .text-\[10px\].text-gray-700.font-geneva-12:not(
+  .text-\[10px\].text-neutral-700.font-geneva-12:not(
     .ipod-force-font .font-geneva-12
   ):not(.videos-lcd .font-geneva-12) {
   font-size: 11px !important;
@@ -2526,7 +2526,7 @@
   font-size: 13px !important;
 }
 
-:root[data-os-theme="macosx"] .macosx-dialog .text-gray-500 {
+:root[data-os-theme="macosx"] .macosx-dialog .text-neutral-500 {
   font-size: 11px !important;
 }
 
@@ -2816,8 +2816,8 @@
 :root[data-os-theme="macosx"] .chat-bubble.bg-rose-100 {
   background-color: #fecdd3 !important; /* rose-200 */
 }
-:root[data-os-theme="macosx"] .chat-bubble.bg-gray-100 {
-  background-color: #e5e7eb !important; /* gray-200 */
+:root[data-os-theme="macosx"] .chat-bubble.bg-neutral-100 {
+  background-color: #e5e7eb !important; /* neutral-200 */
 }
 
 :root[data-os-theme="macosx"] .macosx-link-preview.chat-bubble:before {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Replaces all Tailwind `gray` color utilities with `neutral` across the codebase for a consistent neutral color scale.

## Changes

- Migrated `-gray-` class segments to `-neutral-` in 82 files under `src/` (components, apps, and `themes.css`)
- Updated standalone Tailwind shade strings (e.g. Minesweeper `"gray-600"` → `"neutral-600"`)
- Left non-Tailwind `gray` references unchanged (`shimmer-gray`, `grayscale` filters, SVG fills, comments)

## Testing

- `bun run test:unit` — 236 pass, 0 fail
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-632DA621-D98C-40FD-A165-98DA8B912819"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-632DA621-D98C-40FD-A165-98DA8B912819"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

