### PR TITLE
iPod: phosphor filled wheel glyphs & MyriadPro MENU label

### DIFF
--- a/src/apps/ipod/components/IpodWheel.tsx
+++ b/src/apps/ipod/components/IpodWheel.tsx
@@ -1,4 +1,5 @@
 import { useRef } from "react";
+import { PlayPause, SkipBack, SkipForward } from "@phosphor-icons/react";
 import { cn } from "@/lib/utils";
 import { useTranslation } from "react-i18next";
 
@@ -453,7 +454,7 @@ export function IpodWheel({
       >
         {/* Wheel labels - no click handlers */}
         <div
-          className="absolute top-1.5 text-center left-1/2 transform -translate-x-1/2 font-chicago text-xs text-white menu-button cursor-default select-none no-select-gesture"
+          className="absolute top-1 text-center left-1/2 transform -translate-x-1/2 font-ipod-modern-ui font-semibold text-[15px] leading-none tracking-wide text-white menu-button cursor-default select-none no-select-gesture"
           onClick={(e) => {
             if (recentTouchRef.current || isInTouchDragRef.current || isInMouseDragRef.current) return;
             e.stopPropagation(); // Prevent triggering wheel mousedown
@@ -462,14 +463,14 @@ export function IpodWheel({
         >
           MENU
         </div>
-        <div className="absolute right-2 text-right top-1/2 transform -translate-y-1/2 font-chicago text-[12px] text-white cursor-default select-none no-select-gesture">
-          ⏭
+        <div className="absolute right-2 top-1/2 transform -translate-y-1/2 text-white cursor-default select-none no-select-gesture">
+          <SkipForward size={16} weight="fill" />
         </div>
-        <div className="absolute bottom-1 text-center left-1/2 transform -translate-x-1/2 font-chicago text-[12px] text-white cursor-default select-none no-select-gesture">
-          ⏯
+        <div className="absolute bottom-1.5 left-1/2 transform -translate-x-1/2 text-white cursor-default select-none no-select-gesture">
+          <PlayPause size={16} weight="fill" />
         </div>
-        <div className="absolute left-2 text-left top-1/2 transform -translate-y-1/2 font-chicago text-[12px] text-white cursor-default select-none no-select-gesture">
-          ⏮
+        <div className="absolute left-2 top-1/2 transform -translate-y-1/2 text-white cursor-default select-none no-select-gesture">
+          <SkipBack size={16} weight="fill" />
         </div>
       </div>
     </div>

--- a/src/apps/ipod/components/IpodWheel.tsx
+++ b/src/apps/ipod/components/IpodWheel.tsx
@@ -454,7 +454,7 @@ export function IpodWheel({
       >
         {/* Wheel labels - no click handlers */}
         <div
-          className="absolute top-1 text-center left-1/2 transform -translate-x-1/2 font-ipod-modern-ui font-semibold text-[15px] leading-none tracking-wide text-white menu-button cursor-default select-none no-select-gesture"
+          className="absolute top-1.5 text-center left-1/2 transform -translate-x-1/2 font-ipod-modern-ui font-semibold text-[12px] leading-none tracking-wide text-white menu-button cursor-default select-none no-select-gesture"
           onClick={(e) => {
             if (recentTouchRef.current || isInTouchDragRef.current || isInMouseDragRef.current) return;
             e.stopPropagation(); // Prevent triggering wheel mousedown


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Swaps the three unicode playback glyphs on the iPod click wheel (⏮ ⏯ ⏭) for crisp Phosphor `fill`-variant icons (`SkipBack`, `PlayPause`, `SkipForward`) and switches the **MENU** label from Chicago to MyriadPro, matching the modern iPod nano / iOS 6 system face we already ship for the modern skin.

### Result

![iPod click wheel after](https://cursor.com/artifacts/c/art-0022467f-ee9b-441e-978e-01c0772bbec3)

### Previous (Chicago + unicode glyphs)

![iPod click wheel before](https://cursor.com/artifacts/c/art-f60bc235-44a9-4293-add5-7d58b32a5ea3)

### Changes

- `src/apps/ipod/components/IpodWheel.tsx`
  - Import `PlayPause`, `SkipBack`, `SkipForward` from `@phosphor-icons/react` and render them with `weight="fill"` size 16.
  - Replace `font-chicago text-xs` on the **MENU** label with `font-ipod-modern-ui font-semibold text-[12px] leading-none tracking-wide`.

No behavior changes — click handlers, drag tracking, and accessibility labels are untouched.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3AB2BBF5-1C20-443E-AF6B-0D77E380817F"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3AB2BBF5-1C20-443E-AF6B-0D77E380817F"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

