### PR TITLE
BootScreen(macOS): paint boot backdrop black in dark mode

### DIFF
--- a/src/components/dialogs/BootScreen.tsx
+++ b/src/components/dialogs/BootScreen.tsx
@@ -50,6 +50,7 @@ export function BootScreen({
     isMacOSTheme: isMacOSX,
     isWinXp,
     isWin98,
+    isDarkMode,
   } = useThemeFlags();
   const localizedTitle = title ?? t("common.system.systemRestoring");
 
@@ -190,7 +191,10 @@ export function BootScreen({
               left: 0, 
               right: 0, 
               bottom: 0,
-              backgroundColor: "#4566a0"
+              // Light mode keeps the classic Aqua blue boot backdrop;
+              // dark mode falls back to a near-black surface so the
+              // boot screen doesn't blast bright blue on a dark desktop.
+              backgroundColor: isDarkMode ? "#0a0a0c" : "#4566a0"
             }}
           />
           <DialogContent
@@ -216,7 +220,15 @@ export function BootScreen({
                 src="/icons/macosx/apple.png"
                 alt="Apple"
                 className="size-[120px] object-contain"
-                style={{ marginBottom: "-30px", filter: "grayscale(50%) brightness(1.25)" }}
+                style={{
+                  marginBottom: "-30px",
+                  // Light mode: soft gray Apple. Dark mode: invert the
+                  // dark logo to a light glyph so it reads against the
+                  // dark pinstripe surface instead of disappearing.
+                  filter: isDarkMode
+                    ? "grayscale(50%) brightness(1.25) invert(1)"
+                    : "grayscale(50%) brightness(1.25)",
+                }}
               />
               {/* ryOS X text */}
               <h1 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The macOS X boot screen hard-coded the overlay to the classic Aqua blue (`#4566a0`) and rendered the Apple glyph with a brightening grayscale filter tuned for the light pinstripe window. In dark mode, that left the boot/start screen looking blasted-blue with an almost-white Apple logo against the dark pinstripe — exactly the "inverted white" appearance reported.

## Changes

`src/components/dialogs/BootScreen.tsx` (macOS X branch only — the only theme with `supportsDarkMode: true`):

- **Overlay**: now falls back to a near-black surface (`#0a0a0c`) when `isDarkMode`, so the boot screen reads as dark and matches the rest of the macOS dark scheme. Light mode keeps the canonical Aqua blue backdrop.
- **Apple logo**: gains an extra `invert(1)` in dark mode so the dark glyph flips to a light Apple on the dark pinstripe instead of bleaching out or disappearing.

The `ryOS X` title, status text, and dialog pinstripe already use `--os-color-text-primary` / `--os-pinstripe-window`, which adapt to the dark scheme automatically once the surrounding surface is dark.

System 7, Windows XP, and Windows 98 boot screens are untouched — those themes don't support dark mode (`supportsDarkMode: false` in their metadata).

## Testing

- ✅ `bun run lint` — 0 errors, 142 pre-existing warnings (unchanged).
- Skipped GUI/computer-use verification per the project's `AGENTS.md` ("Skip computer use / GUI-driven testing unless the user explicitly requests it"). The change is gated on the existing `isDarkMode` flag from `useThemeFlags`, which already drives every other dark-mode branch in the macOS theme.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-A342C7C8-7F86-4F5E-88B5-328A351BC4DA"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-A342C7C8-7F86-4F5E-88B5-328A351BC4DA"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

