### PR TITLE
fix(themes): paint empty iframe surfaces dark in dark mode

### DIFF
--- a/src/apps/applet-viewer/components/AppStore.tsx
+++ b/src/apps/applet-viewer/components/AppStore.tsx
@@ -122,6 +122,7 @@ export function AppStore({ theme, sharedAppletId, focusWindow }: AppStoreProps) 
     isMacOSTheme: osIsMac,
     isSystem7Theme: osIsSystem7,
     isWindowsTheme: isXpTheme,
+    isDarkMode,
   } = useThemeFlags();
   const isMacChrome = theme === "macosx" || osIsMac;
   const isSystem7Chrome = theme === "system7" || osIsSystem7;
@@ -804,6 +805,7 @@ export function AppStore({ theme, sharedAppletId, focusWindow }: AppStoreProps) 
                 )}
                 style={{
                   display: "block",
+                  ...(isDarkMode ? { colorScheme: "dark" as const } : {}),
                 }}
               />
             ) : (

--- a/src/apps/applet-viewer/components/AppStoreFeed.tsx
+++ b/src/apps/applet-viewer/components/AppStoreFeed.tsx
@@ -55,6 +55,7 @@ const {
   isMacOSTheme: osIsMac,
   isSystem7Theme: osIsSystem7,
   isWindowsTheme: osIsXp,
+  isDarkMode,
 } = useThemeFlags();
 const { username, isAuthenticated } = useChatsStoreShallow((state) => ({
   username: state.username,
@@ -562,6 +563,7 @@ const renderAppletCard = (applet: Applet, index: number) => {
                 data-ryos-trusted-applet={trusted ? "1" : "0"}
                 style={{
                   display: "block",
+                  ...(isDarkMode ? { colorScheme: "dark" as const } : {}),
                 }}
               />
             );

--- a/src/apps/applet-viewer/components/AppletViewerAppComponent.tsx
+++ b/src/apps/applet-viewer/components/AppletViewerAppComponent.tsx
@@ -33,6 +33,7 @@ export function AppletViewerAppComponent({
     currentTheme,
     isXpTheme,
     isMacTheme,
+    isDarkMode,
     hasAppletContent,
     htmlContent,
     shareCode,
@@ -107,7 +108,14 @@ export function AppletViewerAppComponent({
         instanceId={instanceId}
         menuBar={isXpTheme ? menuBar : undefined}
       >
-        <div className="w-full h-full bg-white overflow-hidden">
+        <div
+          className="w-full h-full bg-white overflow-hidden"
+          style={
+            isDarkMode
+              ? { backgroundColor: "var(--os-color-window-bg)" }
+              : undefined
+          }
+        >
           {hasAppletContent ? (
             <div className="relative h-full w-full">
               <iframe
@@ -122,6 +130,10 @@ export function AppletViewerAppComponent({
                   padding: 0,
                   width: "calc(100% + 1px)",
                   height: "calc(100% + 1px)",
+                  // Hint UA stylesheet so applets that don't paint their own
+                  // body bg render dark instead of flashing browser-default
+                  // white while srcdoc is being applied.
+                  ...(isDarkMode ? { colorScheme: "dark" as const } : {}),
                 }}
                 onLoad={() =>
                   sendAuthPayload(iframeRef.current?.contentWindow || null)

--- a/src/apps/applet-viewer/hooks/useAppletViewerLogic.ts
+++ b/src/apps/applet-viewer/hooks/useAppletViewerLogic.ts
@@ -155,6 +155,7 @@ export function useAppletViewerLogic({
     currentTheme,
     isWindowsTheme: isXpTheme,
     isMacOSTheme: isMacTheme,
+    isDarkMode,
   } = useThemeFlags();
   const username = useChatsStore((state) => state.username);
   const isAuthenticated = useChatsStore((state) => state.isAuthenticated);
@@ -1616,6 +1617,7 @@ export function useAppletViewerLogic({
     currentTheme,
     isXpTheme,
     isMacTheme,
+    isDarkMode,
     hasAppletContent,
     htmlContent,
     shareCode,

--- a/src/apps/internet-explorer/components/InternetExplorerAppComponent.tsx
+++ b/src/apps/internet-explorer/components/InternetExplorerAppComponent.tsx
@@ -236,6 +236,7 @@ export function InternetExplorerAppComponent({
     playDingSound,
     currentTheme,
     isXpTheme,
+    isDarkMode,
     isOffline,
     pastYears,
     futureYears,
@@ -937,7 +938,17 @@ export function InternetExplorerAppComponent({
               </div>
             </div>
 
-            <div className="flex-1 relative bg-white">
+            <div
+              className="flex-1 relative bg-white"
+              style={
+                isDarkMode
+                  ? {
+                      backgroundColor: "var(--os-color-window-bg)",
+                      colorScheme: "dark",
+                    }
+                  : undefined
+              }
+            >
               {errorDetails ? (
                 renderErrorPage()
               ) : isFutureYear ||
@@ -976,6 +987,11 @@ export function InternetExplorerAppComponent({
                   style={{
                     width: "calc(100% + 1px)",
                     height: "calc(100% + 1px)",
+                    // In dark mode, hint the iframe's UA stylesheet so empty
+                    // documents (about:blank, data:, slow-loading pages) paint
+                    // dark instead of flashing the browser-default white slab.
+                    // Loaded pages that set their own background override this.
+                    ...(isDarkMode ? { colorScheme: "dark" } : {}),
                   }}
                   sandbox="allow-scripts allow-forms allow-same-origin allow-popups allow-pointer-lock"
                   onLoad={handleIframeLoad}

--- a/src/apps/internet-explorer/hooks/useInternetExplorerLogic.ts
+++ b/src/apps/internet-explorer/hooks/useInternetExplorerLogic.ts
@@ -513,7 +513,8 @@ export function useInternetExplorerLogic({
   const { playElevatorMusic, stopElevatorMusic, playDingSound } =
     useTerminalSounds();
 
-  const { currentTheme, isWindowsTheme: isXpTheme } = useThemeFlags();
+  const { currentTheme, isWindowsTheme: isXpTheme, isDarkMode } =
+    useThemeFlags();
 
   const currentYear = new Date().getFullYear();
   const pastYears = [
@@ -2089,6 +2090,7 @@ export function useInternetExplorerLogic({
     // Theme and settings
     currentTheme,
     isXpTheme,
+    isDarkMode,
     debugMode,
     terminalSoundsEnabled,
     isOffline,

--- a/src/components/shared/HtmlPreview.tsx
+++ b/src/components/shared/HtmlPreview.tsx
@@ -126,7 +126,7 @@ export default function HtmlPreview({
   const terminalSoundsEnabled = useAudioSettingsStore(
     (state) => state.terminalSoundsEnabled
   );
-  const { isMacOSTheme: isMacOsXTheme } = useThemeFlags();
+  const { isMacOSTheme: isMacOsXTheme, isDarkMode } = useThemeFlags();
 
   const sendAuthPayload = useCallback(
     (target: Window | null | undefined) => {
@@ -1205,6 +1205,11 @@ export default function HtmlPreview({
               // pointerEvents: isStreaming ? "none" : "auto", // Already handled by parent div conditional
               position: "relative",
               zIndex: 1,
+              // In OS dark mode, propagate `color-scheme: dark` so the iframe's
+              // UA stylesheet paints empty / about:blank documents dark instead
+              // of the browser-default white slab. Content that sets its own
+              // background still wins inside the document.
+              ...(isDarkMode ? { colorScheme: "dark" as const } : {}),
               }}
               onMouseDown={(e) => e.stopPropagation()}
               onLoad={() =>
@@ -1274,7 +1279,9 @@ export default function HtmlPreview({
 
                   {/* Preview iframe layer - positioned above code OR Text stream */}
                   <motion.div
-                    className="absolute z-100 bg-white" // Added bg-white for text stream background
+                    className={`absolute z-100 ${
+                      isDarkMode ? "" : "bg-white"
+                    }`} // Added bg-white for text stream background (dark mode uses window bg instead)
                     initial={false}
                     animate={{
                       width:
@@ -1301,6 +1308,9 @@ export default function HtmlPreview({
                       top: showCode && isSplitView && isMobile ? "50%" : 0,
                       right: 0,
                       overflow: "hidden", // Clip content
+                      ...(isDarkMode
+                        ? { backgroundColor: "var(--os-color-window-bg)" }
+                        : {}),
                     }}
                   >
                     {/* Fullscreen Conditional Rendering: Text Stream or Iframe */}
@@ -1337,7 +1347,9 @@ export default function HtmlPreview({
                         // srcDoc is now set by useEffect after streaming finishes
                         // srcDoc={processedHtmlContent()}
                         title={t("common.htmlPreview.codePreviewTitleFullscreen")}
-                        className="border-0 bg-white size-full"
+                        className={`border-0 size-full ${
+                          isDarkMode ? "" : "bg-white"
+                        }`}
                         sandbox={sandboxAttribute}
                         onClick={(e) => e.stopPropagation()}
                         onMouseDown={(e) => e.stopPropagation()}
@@ -1351,6 +1363,13 @@ export default function HtmlPreview({
                           margin: 0,
                           padding: 0,
                           pointerEvents: isDragging ? "none" : "auto",
+                          ...(isDarkMode
+                            ? {
+                                colorScheme: "dark" as const,
+                                backgroundColor:
+                                  "var(--os-color-window-bg)",
+                              }
+                            : {}),
                           ...(isInternetExplorer && {
                             position: "absolute",
                             inset: 0,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
In OS dark mode (macOS Aqua), empty / `about:blank` / `data:text/html` iframes flashed white because the iframe document inherits the browser-default UA color scheme (light) regardless of the parent OS chrome. Set `color-scheme: dark` on the iframe element so the UA stylesheet paints the document dark when content does not specify its own background, and switch the iframe-wrapping `bg-white` surfaces to the OS window background token while dark mode is active.

Covers:

- Internet Explorer content iframe + its `bg-white` wrapper.
- `HtmlPreview` inline iframe, fullscreen iframe, and the fullscreen wrapper that paints behind the iframe during text-stream mode.
- Applet Viewer iframe + its `bg-white` container (the empty-store fallback also picks up the dark surface).
- App Store applet detail iframe + App Store feed iframes.

Loaded pages that paint their own body background still win — this fix only addresses the UA-default white-flash case.

### Verification

Used a headless Chromium driven by Playwright against the dev server (`bun run dev:vite`) to confirm both the runtime attributes and the rendered state, since the in-VM GUI screenshotter was returning a stale cached image and could not be relied on.

Inspection of the IE iframe with OS dark mode ON (Mac OS X Aqua + Dark Mode):

```json
{
  "src": "/api/iframe-check?url=https%3A%2F%2Fabout%3Ablank&theme=macosx",
  "styleColorScheme": "dark",
  "computedColorScheme": "dark",
  "parentBackground": "rgb(43, 43, 46)",
  "parentClass": "flex-1 relative bg-white"
}
```

Same iframe with dark mode OFF (control):

```json
{
  "styleColorScheme": null,
  "computedColorScheme": "light"
}
```

Applet Viewer empty store fallback in dark mode (no iframe rendered — the empty surface goes through the wrapping div):

![Applet Store empty state painted dark in dark mode](https://cursor.com/artifacts/c/art-565a6ce3-b24e-4d8a-bb93-c5d6b8f1984c)

Internet Explorer with dark mode enabled, navigating to `data:text/html,empty-iframe-test`:

![Internet Explorer with empty data URL in dark mode](https://cursor.com/artifacts/c/art-2de3b37e-a443-44d4-a223-5c067fa3bbe6)

Internet Explorer with dark mode disabled (control / before-style):

![Internet Explorer with empty data URL in light mode (control)](https://cursor.com/artifacts/c/art-3b0bd381-40ae-4dd3-8dae-8052dbb41127)

(The IE iframe area shows the desktop wallpaper through it in the dev-mode screenshot because `/api/iframe-check` falls back to `index.html` under Vite — in production the same iframe paints the dark Canvas UA color since `color-scheme: dark` is now set on the element.)

Additional checks:

- `bun run lint` — 0 errors, 142 pre-existing warnings, no new ones introduced.
- `bunx tsc --noEmit -p tsconfig.app.json` — clean.
- `bun run test:unit` — 236 / 236 pass.
- `bun run build` — succeeds; bundle contains the new `colorScheme: "dark"` branch in `InternetExplorerAppComponent`, `AppletViewerAppComponent`, and the main `index` chunk (where `HtmlPreview` lives).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-124120A3-4E6D-46FC-BADE-4B9C961CDFED"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-124120A3-4E6D-46FC-BADE-4B9C961CDFED"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

