### PR TITLE
themes(dark): fix Aqua dark-mode visual issues across Chats / Contacts / Calendar / TV / Maps / Spotlight

### DIFF
--- a/src/apps/chats/components/ChatInput.tsx
+++ b/src/apps/chats/components/ChatInput.tsx
@@ -1012,7 +1012,7 @@ export const ChatInput = memo(function ChatInput({
                     </>
                   )}
                   <ArrowUp
-                    className={`size-4 ${
+                    className={`chat-submit-glyph size-4 ${
                       isMacTheme
                         ? "text-black/70 relative z-10"
                         : isXpTheme

--- a/src/apps/contacts/components/ContactsAppComponent.tsx
+++ b/src/apps/contacts/components/ContactsAppComponent.tsx
@@ -357,6 +357,7 @@ export function ContactsAppComponent({
                       onChange={(event) => setSearchQuery(event.target.value)}
                       aria-label={t("apps.contacts.searchPlaceholder")}
                       title={t("apps.contacts.searchPlaceholder")}
+                      data-os-search-input="true"
                       className="w-full rounded-full border border-black/40 bg-white pl-7 pr-7 py-[3px] text-[11px] shadow-[inset_0_1px_2px_rgba(0,0,0,0.3),inset_0_0_1px_rgba(0,0,0,0.15),0_1px_0_rgba(255,255,255,0.45)] outline-none font-geneva-12"
                     />
                     {searchQuery && (
@@ -431,6 +432,7 @@ export function ContactsAppComponent({
                       onChange={(event) => setSearchQuery(event.target.value)}
                       aria-label={t("apps.contacts.searchPlaceholder")}
                       title={t("apps.contacts.searchPlaceholder")}
+                      data-os-search-input="true"
                       className="w-full rounded-full border border-black/20 bg-white pl-7 pr-7 py-1 text-[11px] shadow-[inset_0_1px_2px_rgba(0,0,0,0.12)] outline-none min-w-0"
                     />
                     {searchQuery && (

--- a/src/apps/tv/components/ChannelPromptInput.tsx
+++ b/src/apps/tv/components/ChannelPromptInput.tsx
@@ -90,6 +90,9 @@ export function ChannelPromptInput({
         }}
         aria-label={ariaLabel}
         aria-busy={isLoading || undefined}
+        // Mark as a "search-shaped" pill so the dark-mode rule in themes.css
+        // applies the subtle dark recess instead of the light inset shadow.
+        data-os-search-input="true"
         // Keep a single space as the placeholder while loading so the
         // browser doesn't render the static placeholder text underneath
         // the shimmer overlay.

--- a/src/components/layout/SpotlightSearch.tsx
+++ b/src/components/layout/SpotlightSearch.tsx
@@ -718,6 +718,7 @@ export function SpotlightSearch() {
                                             result.type !== "ai" &&
                                             result.subtitle !== sectionLabel && (
                                               <span
+                                                className="spotlight-row-subtitle"
                                                 style={{
                                                   color: isSelected
                                                       ? "rgba(255,255,255,0.6)"
@@ -874,6 +875,7 @@ export function SpotlightSearch() {
                                 {result.title}
                                 {result.subtitle && result.type !== "ai" && (
                                   <span
+                                    className="spotlight-row-subtitle"
                                     style={{
                                       color: isSelected
                                         ? "rgba(255,255,255,0.6)"

--- a/src/styles/themes.css
+++ b/src/styles/themes.css
@@ -4020,29 +4020,31 @@
 }
 
 /* --- Chat stop button ----------------------------------------------------- */
-/* The send/stop pair use Aqua-styled gradient pills inline. The stop button's
-   light pink gradient reads more like "send (red theme)" than "stop"; tighten
-   it to a deeper, more saturated red across themes and flip the glyph white
-   so the stop affordance is unambiguous. */
+/* The send/stop pair use Aqua-styled gradient pills inline. Light mode now
+   uses a pale red gradient (matches the original ChatInput inline pinkish
+   stop) so the stop affordance still reads as "warning red" but doesn't
+   blast the bright Aqua chat input; dark mode swaps to a deeper red.
+   In both modes the glyph stays white so the icon is unambiguous against
+   the gradient. */
 .chat-stop-btn {
   background: linear-gradient(
-    rgba(220, 38, 38, 0.95),
-    rgba(159, 18, 24, 0.95)
+    rgba(252, 165, 165, 0.95),
+    rgba(220, 38, 38, 0.92)
   ) !important;
   box-shadow:
-    0 2px 3px rgba(0, 0, 0, 0.3),
-    0 1px 1px rgba(0, 0, 0, 0.35),
-    inset 0 0 0 0.5px rgba(0, 0, 0, 0.45),
-    inset 0 1px 2px rgba(0, 0, 0, 0.4),
-    inset 0 2px 3px 1px rgba(220, 38, 38, 0.45) !important;
+    0 2px 3px rgba(0, 0, 0, 0.22),
+    0 1px 1px rgba(0, 0, 0, 0.28),
+    inset 0 0 0 0.5px rgba(127, 14, 19, 0.4),
+    inset 0 1px 2px rgba(220, 38, 38, 0.25),
+    inset 0 2px 3px 1px rgba(254, 205, 211, 0.55) !important;
 }
 
 .chat-stop-glyph {
   color: #ffffff !important;
 }
 
-/* Dark mode keeps the same red but slightly less luminous so it doesn't
-   over-pop against the dim window. */
+/* Dark mode uses a darker, more saturated red so the stop pill reads
+   against the dim window chrome. */
 :root[data-os-theme="macosx"][data-os-color-scheme="dark"] .chat-stop-btn {
   background: linear-gradient(
     rgba(185, 28, 28, 0.9),
@@ -4054,6 +4056,16 @@
     inset 0 0 0 0.5px rgba(0, 0, 0, 0.6),
     inset 0 1px 2px rgba(0, 0, 0, 0.45),
     inset 0 2px 3px 1px rgba(185, 28, 28, 0.4) !important;
+}
+
+/* --- Chat submit (send) glyph --------------------------------------------- */
+/* The send button uses a bright Aqua-green gradient with a dark glyph on
+   top. In dark mode the broader `.window-body` rules remap `text-black/70`
+   to the secondary-text token (#c8c8cc), which sinks the arrow into the
+   green pill. Pin the glyph back to black so the submit affordance keeps
+   its high-contrast dark icon against the green gradient. */
+.chat-submit-glyph {
+  color: rgba(0, 0, 0, 0.75) !important;
 }
 
 /* --- Inline search/text inputs that don't use the shared SearchInput ----- */
@@ -4224,4 +4236,242 @@
    anything not explicitly recolored falls through to the dark scheme. */
 :root[data-os-theme="macosx"][data-os-color-scheme="dark"] .macosx-dialog {
   color: var(--os-color-text-primary);
+}
+
+/* ============================================================================
+ * Dark mode — Mac OS X (Aqua) — round 4 polish
+ *
+ * Fixes from per-app survey:
+ *   - Chats: bubble top inset highlight + TTS highlight dimmed for dark
+ *   - Sidebar headers (Contacts/Calendar) get a dark gradient strip
+ *   - Drawer inner content (Calendar tray, TV strip+rows, Maps list) is
+ *     outside `.window-body`, so the broad dark utility remaps don't reach
+ *     it. Add scoped overrides on `.os-drawer-metal` so drawer content
+ *     darkens to match the drawer shell.
+ *   - Spotlight section headers (hardcoded inline `rgba(0,0,0,…)`) need
+ *     `!important` overrides to beat inline styles in dark mode.
+ * ============================================================================ */
+
+/* --- Chats: bubble top inset highlight (the bright top "shine" stroke
+   baked into `.chat-bubble`'s `box-shadow`). Light mode uses a
+   `rgba(255,255,255,0.6)` inset that creates a glossy top edge; on dim
+   dark fills this reads as a bright stripe. Repaint the entire box-shadow
+   stack with a softer top inset so the bubble keeps its 3D affordance
+   without screaming on the dark window. */
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"] .chat-bubble {
+  box-shadow:
+    0 2px 4px rgba(0, 0, 0, 0.35),
+    0 1px 1px rgba(0, 0, 0, 0.4),
+    inset 0 1px 2px rgba(255, 255, 255, 0.22),
+    inset 0 0 4px rgba(0, 0, 0, 0.18),
+    inset 0 0 0 0.5px rgba(255, 255, 255, 0.18),
+    inset 0 0 0 1px rgba(0, 0, 0, 0.35) !important;
+}
+
+/* --- Chats: TTS highlight ------------------------------------------------ */
+/* The light TTS highlight uses `rgba(255, 241, 118, 0.85)` (saturated
+   sunshine yellow). On dim dark bubble fills the same alpha is too bright
+   and recolors the underlying text. Dim the alpha so the highlight reads
+   as a soft amber wash instead of a glaring stripe. */
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"] ::highlight(ryos-chat-tts) {
+  background-color: rgba(255, 222, 110, 0.35);
+}
+
+/* --- Sidebar panel headers (Contacts "Name", Calendar "To Do Items",
+   "Calendars") ----------------------------------------------------------- */
+/* These render via inline `style={{ background: "linear-gradient(...)",
+   color: "#222", textShadow: "0 1px 0 #e1e1e1", borderTop: "1px solid
+   rgba(255,255,255,0.5)", borderBottom: "1px solid #787878" }}` on a div
+   with the `text-[11px] font-regular text-center` Tailwind shape. Inline
+   styles win over class rules, so the only reliable hook is the unique
+   class combination + `!important`.
+
+   The headers don't share a class, but the inline gradient
+   `linear-gradient(to bottom, #e6e5e5, #aeadad)` AND `text-center` shape
+   only show up on these panel headers (Contacts, Calendar TodoSidebar,
+   Calendar list). Target `.window-body` descendants matching that exact
+   pattern via the `text-center text-[11px] font-regular` class chain that
+   is unique to these headers. */
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"]
+  .os-sidebar
+  > .text-\[11px\].text-center,
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"]
+  .os-sidebar
+  .text-\[11px\].text-center.font-regular,
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"]
+  .os-sidebar
+  .relative.text-\[11px\].text-center {
+  background: linear-gradient(to bottom, #3d3d42, #2a2a2e) !important;
+  color: var(--os-color-text-primary) !important;
+  text-shadow: 0 1px 0 rgba(0, 0, 0, 0.55) !important;
+  border-top-color: rgba(255, 255, 255, 0.08) !important;
+  border-bottom-color: rgba(0, 0, 0, 0.7) !important;
+}
+
+/* --- Drawer inner content (Calendar / TV / Maps) ------------------------- */
+/* Drawers render as a sibling of `.window-body` (inside `.window` but
+   outside the body), so the broad dark remap rules don't reach their
+   content. The drawer shell (`.os-drawer-metal` / `.os-drawer-list-well`)
+   already has dark rules; here we extend the same remaps to drawer
+   children so list rows, panels, toolbars, etc. align with the dark
+   chrome. We mirror the exclusion list used by the `.window-body` block
+   so per-app opt-out containers still work. */
+
+/* Default text color inside the drawer well falls back to the dark token. */
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"] .os-drawer-list-well {
+  color: var(--os-color-text-primary);
+}
+
+/* White surfaces inside the drawer (Calendar TrayDetails `panelShell`) — keep
+   distinct from the well by lifting one shade so the panel still reads as
+   layered content above the recessed well. */
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"]
+  .os-drawer-list-well
+  :where(.bg-white, .bg-\[\#FFFFFF\], .bg-\[\#ffffff\]):not(.ipod-force-font *):not(.karaoke-force-font *):not(.tv-cc-force-font *):not(.os-native-chrome-skip *) {
+  background-color: #2b2b2e !important;
+}
+
+/* Translucent whites inside the drawer (TV channel-strip button face). */
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"]
+  .os-drawer-list-well
+  :where(
+    .bg-white\/95,
+    .bg-white\/90,
+    .bg-white\/85,
+    .bg-white\/80,
+    .bg-white\/70,
+    .bg-white\/60,
+    .bg-white\/50,
+    .bg-white\/40,
+    .bg-white\/30,
+    .bg-white\/20,
+    .bg-white\/10
+  ):not(.ipod-force-font *):not(.karaoke-force-font *):not(.tv-cc-force-font *):not(.os-native-chrome-skip *) {
+  background-color: rgba(58, 58, 63, 0.92) !important;
+}
+
+/* TV drawer top channel strip (`bg-[#f7f7f7]/95`) — light platinum surface
+   that needs a graphite analog in dark mode. */
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"]
+  .os-drawer-list-well
+  :where(.bg-\[\#f7f7f7\]\/95, .bg-\[\#f7f7f7\]) {
+  background-color: rgba(40, 40, 44, 0.95) !important;
+  border-color: rgba(255, 255, 255, 0.08) !important;
+}
+
+/* Inputs / textareas inside drawer (Calendar event editor field). */
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"]
+  .os-drawer-list-well
+  :where(input, textarea, select):where(
+    .bg-white,
+    .bg-white\/95,
+    .bg-white\/90,
+    .bg-white\/85,
+    .bg-white\/80,
+    .bg-white\/70,
+    .bg-white\/60,
+    .bg-white\/50
+  ):not(.ipod-force-font *):not(.karaoke-force-font *):not(.tv-cc-force-font *):not(.os-native-chrome-skip *) {
+  background-color: var(--os-color-input-bg) !important;
+  color: var(--os-color-text-primary) !important;
+  border-color: rgba(255, 255, 255, 0.18) !important;
+}
+
+/* Black-text utilities inside the drawer — flip to light text tokens. */
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"]
+  .os-drawer-list-well
+  :where(.text-black, .text-\[\#000\], .text-\[\#000000\], .text-\[\#222\]):not(.ipod-force-font *):not(.karaoke-force-font *):not(.tv-cc-force-font *):not(.os-native-chrome-skip *) {
+  color: var(--os-color-text-primary) !important;
+}
+
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"]
+  .os-drawer-list-well
+  :where(
+    .text-black\/90,
+    .text-black\/80,
+    .text-black\/70,
+    .text-black\/60,
+    .text-black\/55,
+    .text-black\/50,
+    .text-black\/45,
+    .text-black\/40,
+    .text-black\/35,
+    .text-black\/30
+  ):not(.ipod-force-font *):not(.karaoke-force-font *):not(.tv-cc-force-font *):not(.os-native-chrome-skip *) {
+  color: var(--os-color-text-secondary) !important;
+}
+
+/* Hover wash defined as `hover:bg-black/5` — invisible on dark drawer.
+   Lift to a faint white-on-dark hover so list rows have a hover affordance. */
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"]
+  .os-drawer-list-well
+  :where(.hover\:bg-black\/5):hover,
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"]
+  .os-drawer-list-well
+  :where(.hover\:bg-black\/10):hover {
+  background-color: rgba(255, 255, 255, 0.06) !important;
+}
+
+/* Hairline borders defined as `border-black/*` inside the drawer — lift to
+   faint white-on-dark hairline so dividers still read. */
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"]
+  .os-drawer-list-well
+  :where(
+    .border-black,
+    .border-black\/5,
+    .border-black\/10,
+    .border-black\/15,
+    .border-black\/20,
+    .border-black\/30,
+    .border-black\/40,
+    .border-black\/50,
+    .border-black\/60
+  ):not(.ipod-force-font *):not(.karaoke-force-font *):not(.tv-cc-force-font *):not(.os-native-chrome-skip *) {
+  border-color: rgba(255, 255, 255, 0.18) !important;
+}
+
+/* Placeholders inside drawer inputs. */
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"]
+  .os-drawer-list-well
+  :where(input, textarea):where(
+    .placeholder\:text-black\/30,
+    .placeholder\:text-black\/40,
+    .placeholder\:text-black\/45,
+    .placeholder\:text-black\/50,
+    .placeholder\:text-black\/55,
+    .placeholder\:text-black\/60
+  )::placeholder {
+  color: var(--os-color-text-disabled) !important;
+}
+
+/* TV drawer active row uses a sky-blue gradient (`.tv-drawer-mac-row-active`)
+   that pops too hard against dark chrome. Dim it to the same Aqua-blue family
+   the dark active tab uses elsewhere. */
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"] .tv-drawer-mac-row-active {
+  background: linear-gradient(
+    rgba(28, 76, 130, 0.85),
+    rgba(40, 95, 165, 0.85)
+  ) !important;
+  color: rgba(255, 255, 255, 0.95) !important;
+  text-shadow: 0 1px 0 rgba(0, 0, 0, 0.45);
+}
+
+/* --- Spotlight section headers ------------------------------------------ */
+/* Headers use inline `style.color: "rgba(0,0,0,0.4)"` (single-column) or
+   `"rgba(0,0,0,0.5)"` (two-column table cell). Inline styles beat
+   non-`!important` rules, so use `!important` on the class. Selected rows
+   already set `color` via the same inline style, so the selection-text
+   path keeps working (inline still wins for that case). */
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"]
+  .spotlight-panel
+  .spotlight-section-header {
+  color: rgba(255, 255, 255, 0.55) !important;
+}
+
+/* Two-column header right border (`borderRight: "1px solid rgba(0,0,0,0.1)"`)
+   disappears on dark chrome. Lift to a faint white hairline. */
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"]
+  .spotlight-panel
+  .spotlight-section-header[style*="border-right"] {
+  border-right-color: rgba(255, 255, 255, 0.12) !important;
 }

--- a/src/styles/themes.css
+++ b/src/styles/themes.css
@@ -3414,7 +3414,7 @@
     .text-black\/40,
     .text-black\/30,
     .text-black\/20
-  ):not(.ipod-force-font *):not(.karaoke-force-font *):not(.tv-cc-force-font *):not(.os-native-chrome-skip *):not(.dashboard-overlay *):not([class*="bg-pink-"]):not([class*="bg-blue-"]):not([class*="bg-yellow-"]):not([class*="bg-purple-"]):not([class*="bg-indigo-"]):not([class*="bg-teal-"]):not([class*="bg-lime-"]):not([class*="bg-amber-"]):not([class*="bg-cyan-"]):not([class*="bg-rose-"]):not([class*="bg-green-"]):not([class*="bg-orange-"]):not([class*="bg-red-"]) {
+  ):not(.chat-submit-glyph):not(.chat-stop-glyph):not(.ipod-force-font *):not(.karaoke-force-font *):not(.tv-cc-force-font *):not(.os-native-chrome-skip *):not(.dashboard-overlay *):not([class*="bg-pink-"]):not([class*="bg-blue-"]):not([class*="bg-yellow-"]):not([class*="bg-purple-"]):not([class*="bg-indigo-"]):not([class*="bg-teal-"]):not([class*="bg-lime-"]):not([class*="bg-amber-"]):not([class*="bg-cyan-"]):not([class*="bg-rose-"]):not([class*="bg-green-"]):not([class*="bg-orange-"]):not([class*="bg-red-"]) {
   color: var(--os-color-text-secondary) !important;
 }
 
@@ -4061,16 +4061,12 @@
 /* --- Chat submit (send) glyph --------------------------------------------- */
 /* The send button uses a bright Aqua-green gradient with a dark glyph on
    top. In dark mode the broader `.window-body` rules remap `text-black/70`
-   to the secondary-text token (#c8c8cc), which sinks the arrow into the
-   green pill. Pin the glyph back to black so the submit affordance keeps
-   its high-contrast dark icon against the green gradient.
-   We need the same root-attribute specificity the dark-mode `text-black/*`
-   remap uses, otherwise the broader rule wins on the cascade. */
-.chat-submit-glyph,
-:root[data-os-theme="macosx"] .window-body .chat-submit-glyph,
-:root[data-os-theme="macosx"][data-os-color-scheme="dark"]
-  .window-body
-  .chat-submit-glyph {
+   to the secondary-text token (#c8c8cc), which would sink the arrow into
+   the green pill. The dark `text-black/*` rule now explicitly excludes
+   `.chat-submit-glyph` (and `.chat-stop-glyph`), so this lightweight pin
+   wins across all themes / both color schemes. The Phosphor glyph uses
+   `fill="currentColor"`, so setting color is enough. */
+.chat-submit-glyph {
   color: rgba(0, 0, 0, 0.85) !important;
 }
 

--- a/src/styles/themes.css
+++ b/src/styles/themes.css
@@ -4063,9 +4063,15 @@
    top. In dark mode the broader `.window-body` rules remap `text-black/70`
    to the secondary-text token (#c8c8cc), which sinks the arrow into the
    green pill. Pin the glyph back to black so the submit affordance keeps
-   its high-contrast dark icon against the green gradient. */
-.chat-submit-glyph {
-  color: rgba(0, 0, 0, 0.75) !important;
+   its high-contrast dark icon against the green gradient.
+   We need the same root-attribute specificity the dark-mode `text-black/*`
+   remap uses, otherwise the broader rule wins on the cascade. */
+.chat-submit-glyph,
+:root[data-os-theme="macosx"] .window-body .chat-submit-glyph,
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"]
+  .window-body
+  .chat-submit-glyph {
+  color: rgba(0, 0, 0, 0.85) !important;
 }
 
 /* --- Inline search/text inputs that don't use the shared SearchInput ----- */
@@ -4091,9 +4097,16 @@
     .bg-white\/30,
     .bg-white\/20,
     .bg-white\/10
-  ):not(.ipod-force-font *):not(.karaoke-force-font *):not(.tv-cc-force-font *):not(.os-native-chrome-skip *):not(.synth-force-font *):not(.dashboard-overlay *) {
+  ):not([data-os-search-input="true"]):not(.ipod-force-font *):not(.karaoke-force-font *):not(.tv-cc-force-font *):not(.os-native-chrome-skip *):not(.synth-force-font *):not(.dashboard-overlay *) {
   background-color: var(--os-color-input-bg) !important;
   color: var(--os-color-text-primary) !important;
+  /* Subtle inset recess — matches the canonical Finder SearchInput dark
+     treatment so inline inputs (Contacts/Calendar/TV sidebar fields) get
+     the same gentle dark recess instead of the original heavy light shadow. */
+  box-shadow:
+    inset 0 1px 2px rgba(0, 0, 0, 0.45),
+    inset 0 0 1px rgba(0, 0, 0, 0.25),
+    0 1px 0 rgba(255, 255, 255, 0.04) !important;
 }
 
 /* `border-black/{alpha}` and similar on inputs read as nearly invisible on
@@ -4359,7 +4372,11 @@
   border-color: rgba(255, 255, 255, 0.08) !important;
 }
 
-/* Inputs / textareas inside drawer (Calendar event editor field). */
+/* Inputs / textareas inside drawer (Calendar event editor field). The
+   light-mode style on these fields is a flat `border-black/25 bg-white` with
+   no inset shadow; on the dark surface we mirror the canonical Finder
+   search-input dark treatment so the field reads as a subtle recess instead
+   of a flat solid pill. */
 :root[data-os-theme="macosx"][data-os-color-scheme="dark"]
   .os-drawer-list-well
   :where(input, textarea, select):where(
@@ -4375,6 +4392,10 @@
   background-color: var(--os-color-input-bg) !important;
   color: var(--os-color-text-primary) !important;
   border-color: rgba(255, 255, 255, 0.18) !important;
+  box-shadow:
+    inset 0 1px 2px rgba(0, 0, 0, 0.45),
+    inset 0 0 1px rgba(0, 0, 0, 0.25),
+    0 1px 0 rgba(255, 255, 255, 0.04) !important;
 }
 
 /* Black-text utilities inside the drawer — flip to light text tokens. */
@@ -4456,7 +4477,7 @@
   text-shadow: 0 1px 0 rgba(0, 0, 0, 0.45);
 }
 
-/* --- Spotlight section headers ------------------------------------------ */
+/* --- Spotlight section headers + secondary text ------------------------- */
 /* Headers use inline `style.color: "rgba(0,0,0,0.4)"` (single-column) or
    `"rgba(0,0,0,0.5)"` (two-column table cell). Inline styles beat
    non-`!important` rules, so use `!important` on the class. Selected rows
@@ -4474,4 +4495,35 @@
   .spotlight-panel
   .spotlight-section-header[style*="border-right"] {
   border-right-color: rgba(255, 255, 255, 0.12) !important;
+}
+
+/* Result-row subtitle text ("Title — Subtitle"). The component sets an
+   inline `style.color: "rgba(0,0,0,0.4)"` for the subtitle span; remap it
+   to a light tone on the dark pinstripe panel. The selected-row branch
+   (`isSelected` uses `rgba(255,255,255,0.6)` — already light) doesn't need
+   to change. */
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"]
+  .spotlight-panel
+  .spotlight-row-subtitle {
+  color: rgba(255, 255, 255, 0.45) !important;
+}
+
+/* No-results helper text ("No results for …") — inline `rgba(0,0,0,0.4)`. */
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"]
+  .spotlight-panel
+  .spotlight-no-results {
+  color: rgba(255, 255, 255, 0.55) !important;
+}
+
+/* Two-column table column backgrounds + row borders (`rgba(0,0,0,0.04)` /
+   `rgba(0,0,0,0.1)`) baked inline. Lift to faint white-on-dark so the
+   table column gutter and per-row separator still register on the dark
+   pinstripe panel. */
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"]
+  .spotlight-panel
+  td[style*="rgba(0, 0, 0, 0.04)"],
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"]
+  .spotlight-panel
+  td[style*="rgba(0,0,0,0.04)"] {
+  background-color: rgba(255, 255, 255, 0.03) !important;
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes a batch of visual regressions in the new macOS Aqua (`macosx`) dark theme surfaced by an app-by-app pass.

### Chats
- **Stop button** now uses a pale-red gradient in light mode and a deeper, more saturated red in dark mode.
- **Submit (send) glyph** stays black in dark mode. The `ArrowUp` glyph was using `text-black/70` which got remapped to the secondary-text token (`#c8c8cc`) by the broad dark-mode rules, sinking the arrow into the green pill. Added a `chat-submit-glyph` class pinned to `rgba(0,0,0,0.85)` and **excluded** `.chat-submit-glyph` / `.chat-stop-glyph` from the broader `text-black/*` remap so the dedicated pin wins the cascade. Verified via computed style.
- **Chat-bubble inset top highlight** dimmed in dark mode (60% white -> 22%) so the glossy top stroke doesn't pop against dim role colors.
- **TTS highlight** (`::highlight(ryos-chat-tts)`) opacity reduced in dark mode so the playing-line wash reads as a soft amber instead of a saturated yellow stripe.

### Contacts / Calendar
- Theme `.os-sidebar` panel headers ("Name", "Group", "To Do Items", "Calendars") with a dark gradient strip + dark border colors instead of the baked-in light `#e6e5e5 -> #aeadad` gradient.

### Calendar / TV / Maps drawers
Drawers render as a sibling of `.window-body`, so the broad dark-mode utility remaps don't reach them. Extended the same patterns to `.os-drawer-list-well` content: white surfaces, translucent whites, TV channel strip (`bg-[#f7f7f7]/95`), inputs / textareas / selects, `text-black*` family, `border-black*` family, placeholders, `hover:bg-black/5` lifted to a faint white wash, and the TV drawer active-row gradient dimmed to the dark Aqua-blue family.

### Spotlight
- **Section headers** override the hardcoded inline `color: rgba(0,0,0,0.4/0.5)` with light text (using `!important` to beat inline styles).
- **Result-row subtitle** ("Title — Subtitle") tagged with a new `.spotlight-row-subtitle` class and themed to a light tone in dark mode (was inline `rgba(0,0,0,0.4)` and invisible on the dark pinstripe panel).
- **No-results helper text** ("No results for …") themed via the existing `.spotlight-no-results` class.
- Two-column header right border lifted to a faint white hairline.

### Inline rounded inputs
The Finder `SearchInput` already gets a clean dark recess via `input[data-os-search-input="true"]`. Other inline rounded inputs (TV `ChannelPromptInput`, Contacts toolbar search) used the same Tailwind classes but lacked the marker, so they kept the hardcoded light `inset 0 1px 2px rgba(0,0,0,0.3)` shadow in dark mode — which read as a heavy/glaring stripe on the dark window.
- Tagged TV `ChannelPromptInput` and Contacts toolbar search inputs with `data-os-search-input="true"` so they inherit the canonical Finder dark recess.
- Extended the broad `.window-body input.bg-white` dark rule with the same subtle inset-recess shadow + `0 1px 0 rgba(255,255,255,0.04)` highlight so Calendar event tray fields, Calendar sidebar todo input, and other inline rounded inputs all match the canonical Finder feel.

### Walkthrough — dark-mode screenshots

Chats submit glyph stays high-contrast black on the green pill in dark mode (verified `color: rgba(0, 0, 0, 0.85)` via headless Chrome computed style):
![Chats submit glyph black on green pill in dark mode](https://cursor.com/artifacts/c/art-4bfce096-56b3-419e-aff5-4e61b866339c)

Zoom on the submit pill — the `ArrowUp` glyph is unmistakably black, not gray:
![Zoom on submit pill](https://cursor.com/artifacts/c/art-7e49ad52-daf4-4eb5-93df-9c353b2ee58a)

Spotlight result subtitles are now light on the dark pinstripe panel — see "Apple — apple.com" and "NewJeans — newjeans.jp" entries. Calendar event drawer (right side window) also shows the subtle dark recess on the date / calendar select / Notes inputs:
![Spotlight result subtitles + calendar drawer in dark mode](https://cursor.com/artifacts/c/art-8948fa75-d8d9-4937-ac5f-197c96702d8f)

Contacts toolbar search input now uses the canonical Finder dark recess (was a heavy light inset shadow before):
![Contacts toolbar search dark recess](https://cursor.com/artifacts/c/art-06b2656f-3305-4c4a-b785-b5a4d21410ef)

TV "Make a new channel…" input now uses the same canonical Finder dark recess:
![TV channel prompt input dark recess](https://cursor.com/artifacts/c/art-8e615c6c-8a0e-48bf-adc2-738b7e59111c)

Calendar new-event drawer with subtle dark recess on date / select / textarea inputs:
![Calendar new-event drawer in dark mode](https://cursor.com/artifacts/c/art-80d6deca-5430-4b63-96be-4c5fb2fada9e)

Spotlight section headers ("Applications", "Documents", "Applets", "Sites") readable on the dark pinstripe panel (round 1 baseline):
![Spotlight section headers in dark mode](https://cursor.com/artifacts/c/art-a635cb0d-1215-41e1-a334-5014610cfa12)

Contacts sidebar — "Group" and "Name" panel headers use a dark gradient strip:
![Contacts sidebar dark headers](https://cursor.com/artifacts/c/art-541ffcb3-efe1-46bf-871c-5ed61b238bba)

TV drawer — top channel logo strip and video list rows darkened; active row uses the dimmed Aqua-blue family:
![TV drawer in dark mode](https://cursor.com/artifacts/c/art-b431ac13-760d-480e-bc40-4534a07be537)

Chat bubbles in dark mode — dim role colors, no bright top shine:
![Chat bubbles in dark mode](https://cursor.com/artifacts/c/art-92ea8bfd-75cb-4fe3-bbd6-f954f4f11313)

### Files
- `src/styles/themes.css` — appended a "round 4 polish" block (sidebar headers, drawer content, spotlight headers, chat-stop-btn pair, chat-bubble shadow, TTS highlight) and a "round 5" pass (chat-submit-glyph exclusion, spotlight subtitle/no-results, subtle dark input recess for `.window-body` and `.os-drawer-list-well` rounded inputs).
- `src/apps/chats/components/ChatInput.tsx` — added `chat-submit-glyph` class to the `ArrowUp` glyph.
- `src/apps/tv/components/ChannelPromptInput.tsx` — added `data-os-search-input="true"`.
- `src/apps/contacts/components/ContactsAppComponent.tsx` — added `data-os-search-input="true"` to both toolbar search inputs.
- `src/components/layout/SpotlightSearch.tsx` — added `spotlight-row-subtitle` class to the subtitle span.

### Testing
- `bun run build` — passes.
- Programmatically verified via Playwright + headless Chrome computed styles:
  - `.chat-submit-glyph` resolves to `rgba(0, 0, 0, 0.85)` (was `rgb(200, 200, 204)`).
  - `.spotlight-row-subtitle` resolves to `rgba(255, 255, 255, 0.45)` (was `rgba(0, 0, 0, 0.4)`).
  - `.spotlight-section-header` resolves to `rgba(255, 255, 255, 0.55)`.
  - Contacts / TV inputs render with `box-shadow: 0 1px 2px rgba(0,0,0,0.55) inset, 0 0 1px rgba(0,0,0,0.3) inset, 0 1px 0 rgba(255,255,255,0.05)` — matches canonical Finder.
- Captured fresh dark-mode screenshots; all artifact MD5s verified unique.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-75A96A95-C29B-45EE-B89B-9377E927F16A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-75A96A95-C29B-45EE-B89B-9377E927F16A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

