### PR TITLE
themes(dark): dialog text, lighter stop button, graphite chat bubbles, darker select toggles

### DIFF
--- a/src/styles/themes.css
+++ b/src/styles/themes.css
@@ -3391,13 +3391,19 @@
 /* Common hardcoded text utilities. We keep this list narrow and only touch
    the neutral / black variants — colored text utilities (`text-red-*`,
    `text-blue-*`, etc.) stay as authored so error text, links, and tinted
-   labels keep their semantics. */
+   labels keep their semantics. `text-neutral-900` / `text-gray-900` /
+   `text-zinc-900` / `text-slate-900` are near-black ramp tops used by
+   confirm/input dialogs and similar prompts; treat them as primary text. */
 :root[data-os-theme="macosx"][data-os-color-scheme="dark"]
   .window-body
   :where(
     .text-black,
     .text-\[\#000\],
-    .text-\[\#000000\]
+    .text-\[\#000000\],
+    .text-neutral-900,
+    .text-gray-900,
+    .text-zinc-900,
+    .text-slate-900
   ):not(.ipod-force-font *):not(.karaoke-force-font *):not(.tv-cc-force-font *):not(.os-native-chrome-skip *):not(.dashboard-overlay *):not([class*="bg-pink-"]):not([class*="bg-blue-"]):not([class*="bg-yellow-"]):not([class*="bg-purple-"]):not([class*="bg-indigo-"]):not([class*="bg-teal-"]):not([class*="bg-lime-"]):not([class*="bg-amber-"]):not([class*="bg-cyan-"]):not([class*="bg-rose-"]):not([class*="bg-green-"]):not([class*="bg-orange-"]):not([class*="bg-red-"]):not([class*="bg-gray-1"]):not([class*="bg-neutral-1"]):not([class*="bg-zinc-1"]):not([class*="bg-slate-1"]) {
   color: var(--os-color-text-primary) !important;
 }
@@ -3826,21 +3832,68 @@
   background-color: #5a5a60 !important;
 }
 
-/* Aqua segmented selector (`aqua-select-btn.aqua-selected`) — the light theme
-   darkens the gradient + outline against a bright window. In dark mode its
-   gray-on-gray reads as bright; soften both the gradient and the outline. */
+/* Aqua segmented selectors (`.aqua-select-btn` + `.aqua-selected`) — in
+   light mode the unselected pill uses the bright `.aqua-button.secondary`
+   gradient (`rgba(160,160,160) → rgba(255,255,255,0.625)`) and the
+   selected pill darkens to mid-gray. On the dark window both states glow
+   white; remap them so the segmented control reads like the brushed-metal
+   inset toggle group (same graphite stack as `.metal-inset-btn`). The
+   selected state stays one step darker than unselected so the active
+   segment is still legible without lighting up. */
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"]
+  .aqua-select-btn {
+  background: linear-gradient(
+    to bottom,
+    #4a4a50 0%,
+    #3e3e44 49%,
+    #2f2f33 50%,
+    #3a3a3f 100%
+  ) !important;
+  color: rgba(255, 255, 255, 0.85) !important;
+  text-shadow: 0 1px 0 rgba(0, 0, 0, 0.55) !important;
+  box-shadow:
+    0 1px 1px rgba(0, 0, 0, 0.45),
+    inset 0 1px 0 rgba(255, 255, 255, 0.06),
+    0 0 0 1px rgba(0, 0, 0, 0.65) !important;
+}
+
+/* Dim the top gloss strip so the dark gradient reads as brushed graphite
+   instead of a glossy aqua pill. */
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"]
+  .aqua-select-btn::before {
+  background: linear-gradient(
+    to bottom,
+    rgba(255, 255, 255, 0.1) 0%,
+    rgba(255, 255, 255, 0.04) 60%,
+    rgba(255, 255, 255, 0) 100%
+  ) !important;
+}
+
 :root[data-os-theme="macosx"][data-os-color-scheme="dark"]
   .aqua-select-btn.aqua-selected {
   background: linear-gradient(
-    rgb(70 75 80 / 92%),
-    rgb(95 102 108 / 80%)
+    to bottom,
+    #2a2a2f 0%,
+    #232327 49%,
+    #1a1a1e 50%,
+    #232327 100%
   ) !important;
-  color: rgba(255, 255, 255, 0.92) !important;
-  text-shadow: 0 1px 0 rgba(0, 0, 0, 0.55) !important;
+  color: rgba(255, 255, 255, 0.95) !important;
+  text-shadow: 0 1px 0 rgba(0, 0, 0, 0.6) !important;
   box-shadow:
-    0 2px 3px rgba(0, 0, 0, 0.4),
-    0 1px 1px rgba(0, 0, 0, 0.5),
-    0 0 0 1px rgba(0, 0, 0, 0.6) !important;
+    inset 0 1px 2px rgba(0, 0, 0, 0.7),
+    inset 0 2px 3px 1px rgba(0, 0, 0, 0.4),
+    0 0 0 1px rgba(0, 0, 0, 0.75) !important;
+}
+
+/* Even on the recessed selected state, kill the bright top shine. */
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"]
+  .aqua-select-btn.aqua-selected::before {
+  background: linear-gradient(
+    to bottom,
+    rgba(255, 255, 255, 0.05) 0%,
+    rgba(255, 255, 255, 0) 100%
+  ) !important;
 }
 
 /* --- LCD displays (Videos / TV / Minesweeper) ----------------------------- */
@@ -3915,46 +3968,47 @@
 
 /* --- Chat bubbles — dark themed ------------------------------------------ */
 /* Light theme uses bright pastel role colors (`bg-yellow-100` for user,
-   `bg-blue-100` for assistant, hashed pastels for human). In dark mode,
-   recolor the bubble fills to dim, low-saturation versions of the same hue
-   family so role identification is preserved without the bright pastels.
-   Text inside the bubble flips to near-white so contrast holds. */
-:root[data-os-theme="macosx"][data-os-color-scheme="dark"] .chat-bubble.bg-yellow-100 {
-  background-color: #5a4a1c !important; /* dim amber */
+   `bg-blue-100` for assistant, hashed pastels for human). In dark mode we
+   pull every role color toward graphite — fills sit in the same ~#3a-#42
+   value range as the metal-button gradient (`#4a4a50` → `#3a3a3f`), with
+   only a faint hue shift so role identity is hinted at rather than colored
+   in. This trades vivid role tinting for a calmer, more uniform graphite
+   conversation surface. Text inside the bubble flips to near-white so
+   contrast still reads. */
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"] .chat-bubble.bg-yellow-100,
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"] .chat-bubble.bg-amber-100 {
+  background-color: #423d33 !important; /* graphite + faint warm wash */
 }
 :root[data-os-theme="macosx"][data-os-color-scheme="dark"] .chat-bubble.bg-blue-100 {
-  background-color: #1f3a5c !important; /* dim slate-blue */
+  background-color: #353a42 !important; /* graphite + faint cool wash */
 }
 :root[data-os-theme="macosx"][data-os-color-scheme="dark"] .chat-bubble.bg-pink-100,
 :root[data-os-theme="macosx"][data-os-color-scheme="dark"] .chat-bubble.bg-pink-200 {
-  background-color: #5a2a3a !important;
+  background-color: #423739 !important;
 }
 :root[data-os-theme="macosx"][data-os-color-scheme="dark"] .chat-bubble.bg-purple-100,
 :root[data-os-theme="macosx"][data-os-color-scheme="dark"] .chat-bubble.bg-purple-200 {
-  background-color: #3d2c5a !important;
+  background-color: #3c3842 !important;
 }
 :root[data-os-theme="macosx"][data-os-color-scheme="dark"] .chat-bubble.bg-indigo-100,
 :root[data-os-theme="macosx"][data-os-color-scheme="dark"] .chat-bubble.bg-indigo-200 {
-  background-color: #2a3260 !important;
+  background-color: #383a44 !important;
 }
 :root[data-os-theme="macosx"][data-os-color-scheme="dark"] .chat-bubble.bg-teal-100 {
-  background-color: #1d4a48 !important;
+  background-color: #343e3d !important;
 }
 :root[data-os-theme="macosx"][data-os-color-scheme="dark"] .chat-bubble.bg-lime-100 {
-  background-color: #2e4a1c !important;
-}
-:root[data-os-theme="macosx"][data-os-color-scheme="dark"] .chat-bubble.bg-amber-100 {
-  background-color: #5a4a1c !important;
+  background-color: #3a3e34 !important;
 }
 :root[data-os-theme="macosx"][data-os-color-scheme="dark"] .chat-bubble.bg-cyan-100 {
-  background-color: #1c454d !important;
+  background-color: #343c3e !important;
 }
 :root[data-os-theme="macosx"][data-os-color-scheme="dark"] .chat-bubble.bg-rose-100 {
-  background-color: #5a2630 !important;
+  background-color: #423739 !important;
 }
 :root[data-os-theme="macosx"][data-os-color-scheme="dark"] .chat-bubble.bg-gray-100,
 :root[data-os-theme="macosx"][data-os-color-scheme="dark"] .chat-bubble.bg-neutral-200 {
-  background-color: #353539 !important;
+  background-color: #3a3a3f !important;
 }
 
 /* Bubble text — recolor light Tailwind `text-black` and `text-current`
@@ -4020,42 +4074,39 @@
 }
 
 /* --- Chat stop button ----------------------------------------------------- */
-/* The send/stop pair use Aqua-styled gradient pills inline. Light mode now
-   uses a pale red gradient (matches the original ChatInput inline pinkish
-   stop) so the stop affordance still reads as "warning red" but doesn't
-   blast the bright Aqua chat input; dark mode swaps to a deeper red.
-   In both modes the glyph stays white so the icon is unambiguous against
-   the gradient. */
+/* The send/stop pair use Aqua-styled gradient pills inline. We keep the
+   pale pink → light red pastel range in BOTH light and dark mode (matches
+   the original ChatInput inline values, since the request is to keep the
+   stop affordance soft rather than a punchy crimson). The glyph stays
+   black/70 from `chat-stop-glyph` so the icon is unambiguous on either
+   surface. */
 .chat-stop-btn {
   background: linear-gradient(
-    rgba(252, 165, 165, 0.95),
-    rgba(220, 38, 38, 0.92)
+    rgba(254, 205, 211, 0.9),
+    rgba(252, 165, 165, 0.9)
   ) !important;
   box-shadow:
-    0 2px 3px rgba(0, 0, 0, 0.22),
-    0 1px 1px rgba(0, 0, 0, 0.28),
-    inset 0 0 0 0.5px rgba(127, 14, 19, 0.4),
-    inset 0 1px 2px rgba(220, 38, 38, 0.25),
-    inset 0 2px 3px 1px rgba(254, 205, 211, 0.55) !important;
+    0 2px 3px rgba(0, 0, 0, 0.2),
+    0 1px 1px rgba(0, 0, 0, 0.3),
+    inset 0 0 0 0.5px rgba(0, 0, 0, 0.3),
+    inset 0 1px 2px rgba(0, 0, 0, 0.4),
+    inset 0 2px 3px 1px rgba(254, 205, 211, 0.5) !important;
 }
 
-.chat-stop-glyph {
-  color: #ffffff !important;
-}
-
-/* Dark mode uses a darker, more saturated red so the stop pill reads
-   against the dim window chrome. */
+/* Dark mode: keep the pastel red family but nudge the gradient slightly
+   warmer/denser so it still reads on the dim window chrome. The shadow
+   gets a touch more depth (no black inset) so the pill looks lifted. */
 :root[data-os-theme="macosx"][data-os-color-scheme="dark"] .chat-stop-btn {
   background: linear-gradient(
-    rgba(185, 28, 28, 0.9),
-    rgba(127, 14, 19, 0.95)
+    rgba(252, 165, 165, 0.92),
+    rgba(248, 113, 113, 0.92)
   ) !important;
   box-shadow:
-    0 2px 3px rgba(0, 0, 0, 0.55),
-    0 1px 1px rgba(0, 0, 0, 0.45),
-    inset 0 0 0 0.5px rgba(0, 0, 0, 0.6),
-    inset 0 1px 2px rgba(0, 0, 0, 0.45),
-    inset 0 2px 3px 1px rgba(185, 28, 28, 0.4) !important;
+    0 2px 3px rgba(0, 0, 0, 0.45),
+    0 1px 1px rgba(0, 0, 0, 0.35),
+    inset 0 0 0 0.5px rgba(0, 0, 0, 0.35),
+    inset 0 1px 2px rgba(0, 0, 0, 0.3),
+    inset 0 2px 3px 1px rgba(254, 205, 211, 0.45) !important;
 }
 
 /* --- Chat submit (send) glyph --------------------------------------------- */
@@ -4210,21 +4261,57 @@
     .text-neutral-600,
     .text-neutral-700,
     .text-neutral-800,
+    .text-zinc-500,
     .text-zinc-600,
     .text-zinc-700,
+    .text-zinc-800,
+    .text-slate-500,
     .text-slate-600,
-    .text-slate-700
+    .text-slate-700,
+    .text-slate-800
   ):not(.ipod-force-font *):not(.karaoke-force-font *):not(.tv-cc-force-font *):not(.os-native-chrome-skip *):not(.synth-force-font *):not([class*="bg-pink-"]):not([class*="bg-blue-"]):not([class*="bg-yellow-"]):not([class*="bg-purple-"]):not([class*="bg-indigo-"]):not([class*="bg-teal-"]):not([class*="bg-amber-"]) {
   color: var(--os-color-text-secondary) !important;
 }
 
-/* Primary headings inside dialogs default to inheriting `text-foreground`,
-   but `text-black` and `.text-[#000]` variants used in custom titles need
-   the same flip we apply inside `.window-body`. */
+/* Primary headings + near-black body copy (`text-black`, `text-neutral-900`,
+   etc.) inside dialogs need the same flip we apply inside `.window-body`.
+   `ConfirmDialog` paints its description with `text-neutral-900`, so adding
+   the 900-step neutrals makes "clear chats" and other confirm prompts read
+   on the dark dialog surface. */
 :root[data-os-theme="macosx"][data-os-color-scheme="dark"]
   .macosx-dialog
-  :where(.text-black, .text-\[\#000\], .text-\[\#000000\]):not(.ipod-force-font *):not(.karaoke-force-font *):not(.tv-cc-force-font *):not(.os-native-chrome-skip *):not(.synth-force-font *):not([class*="bg-pink-"]):not([class*="bg-blue-"]):not([class*="bg-yellow-"]):not([class*="bg-purple-"]):not([class*="bg-indigo-"]):not([class*="bg-teal-"]):not([class*="bg-amber-"]) {
+  :where(
+    .text-black,
+    .text-\[\#000\],
+    .text-\[\#000000\],
+    .text-neutral-900,
+    .text-gray-900,
+    .text-zinc-900,
+    .text-slate-900
+  ):not(.ipod-force-font *):not(.karaoke-force-font *):not(.tv-cc-force-font *):not(.os-native-chrome-skip *):not(.synth-force-font *):not([class*="bg-pink-"]):not([class*="bg-blue-"]):not([class*="bg-yellow-"]):not([class*="bg-purple-"]):not([class*="bg-indigo-"]):not([class*="bg-teal-"]):not([class*="bg-amber-"]) {
   color: var(--os-color-text-primary) !important;
+}
+
+/* `text-black/{alpha}` utilities inside dialogs (used for de-emphasized
+   inline labels / pill text inside HelpDialog cards, LoginDialog headers,
+   etc.). Map to the secondary token so they stay readable on the dark
+   dialog surface — mirror of the `.window-body` rule above. */
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"]
+  .macosx-dialog
+  :where(
+    .text-black\/90,
+    .text-black\/80,
+    .text-black\/70,
+    .text-black\/60,
+    .text-black\/55,
+    .text-black\/50,
+    .text-black\/45,
+    .text-black\/40,
+    .text-black\/35,
+    .text-black\/30,
+    .text-black\/20
+  ):not(.ipod-force-font *):not(.karaoke-force-font *):not(.tv-cc-force-font *):not(.os-native-chrome-skip *):not(.synth-force-font *):not([class*="bg-pink-"]):not([class*="bg-blue-"]):not([class*="bg-yellow-"]):not([class*="bg-purple-"]):not([class*="bg-indigo-"]):not([class*="bg-teal-"]):not([class*="bg-amber-"]) {
+  color: var(--os-color-text-secondary) !important;
 }
 
 /* Inline `bg-white(/alpha)` surfaces inside a dialog (e.g. AboutDialog


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Follow-up dark-mode pass on macOS Aqua, targeting visual issues called out in feedback.

## Changes

### 1. Dialog text (e.g. "Clear Chats" confirm)

`ConfirmDialog` paints its description with `text-neutral-900`, which wasn't covered by the existing `.macosx-dialog` / `.window-body` dark remap (only the 500–800 steps were). In dark mode the prompt body stayed near-black on dark.

- Extend the `.window-body` and `.macosx-dialog` dark text remaps to include the **900 step** for neutral / gray / zinc / slate so the description flips to the primary token.
- Extend the dialog block to also cover `text-black/{alpha}` variants and the 500/800 steps for zinc/slate that were missing.

### 2. Chat stop button — back to lighter reds

Reverted `.chat-stop-btn` from red-300 → red-600 (introduced in #1314) back to the original pastel pink → light red (`rgba(254,205,211) → rgba(252,165,165)`). Dark mode now sits at red-300 → red-400 (still pastel, slightly warmer) with a softer shadow so it still reads on dim chrome. Removed the white `.chat-stop-glyph` color pin so the existing `text-black/70` JSX class wins on both modes.

### 3. Chat bubbles — graphite / muted

Pulled every dark-mode role color toward graphite (same ~#3a–#42 range as the metal-button gradient) with only a faint hue hint instead of saturated mid-tones (e.g. `bg-yellow-100` was `#5a4a1c`, now `#423d33`). Calmer, more uniform conversation surface.

### 4. Select toggles darker — match metal buttons

In dark mode the unselected `.aqua-select-btn` was picking up the bright `.aqua-button.secondary` light gradient. Remapped both states to the same graphite stack used by `.metal-inset-btn`:

- Unselected: `#4a4a50` → `#3e3e44` → `#2f2f33` → `#3a3a3f` (brushed metal stack).
- Selected: one step darker, near-black recessed pill so the active segment still reads without lighting up.
- Dimmed the top `::before` gloss on both states so the gradient reads as brushed graphite, not a glossy aqua pill.

## Testing

See screenshots in the walkthrough below — toggled dark mode in macOS Aqua and exercised the Chats app (clear-chats dialog + bubble surface + stop button) and a few select toggles.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-DD7F0DB1-7895-4821-B574-EA9008634A88"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-DD7F0DB1-7895-4821-B574-EA9008634A88"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

