### PR TITLE
fix(test): repair `bun test --filter` scripts that silently matched no files

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "telegram:webhook": "bun run scripts/setup-telegram-webhook.ts",
     "test": "bun test",
     "test:unit": "bun test tests/test-chat-notification-logic.test.ts tests/test-chat-notification-integration-wiring.test.ts tests/test-chat-broadcast-wiring.test.ts tests/test-chat-hook-channel-lifecycle-wiring.test.ts tests/test-chat-store-guards-wiring.test.ts tests/test-pusher-client-refcount.test.ts tests/test-pusher-client-constructor-wiring.test.ts tests/test-song-import-batching.test.ts tests/test-memory-system.test.ts tests/test-error-boundary-wiring.test.ts tests/test-self-host-runtime-config.test.ts tests/test-self-host-redis-config.test.ts tests/test-self-host-storage-config.test.ts tests/test-og-share.test.ts tests/test-custom-wallpaper-processing.test.ts tests/test-lyrics-parsing.test.ts tests/test-song-lyrics-match.test.ts tests/test-furigana-line-detection.test.ts tests/test-furigana-word-spacing.test.ts tests/test-cloud-sync-persist-domain-status.test.ts tests/test-geolocation-fallback.test.ts tests/test-app-drawer-layout.test.ts tests/test-ipod-apple-music.test.ts tests/test-musickit-token.test.ts",
-    "test:api": "bun test --filter 'new-api|admin|iframe|link-preview|parse-title|song|speech|share-applet|ai|media|auth-extra|rooms-extra|listen-security'",
+    "test:api": "bun test --filter new-api --filter admin --filter iframe --filter link-preview --filter parse-title --filter song --filter speech --filter share-applet --filter ai --filter media --filter auth-extra --filter rooms-extra --filter listen-security",
     "test:new-api": "bun test tests/test-new-api.test.ts",
     "test:chat-rooms": "bun test tests/test-new-api.test.ts",
     "test:admin": "bun test tests/test-admin.test.ts",
@@ -59,11 +59,11 @@
     "test:chat-broadcast-wiring": "bun test tests/test-chat-broadcast-wiring.test.ts",
     "test:chat-hook-lifecycle": "bun test tests/test-chat-hook-channel-lifecycle-wiring.test.ts",
     "test:chat-store-guards": "bun test tests/test-chat-store-guards-wiring.test.ts",
-    "test:chat-wiring": "bun test --filter 'chat-notification|chat-broadcast|chat-hook|chat-store'",
+    "test:chat-wiring": "bun test --filter chat-notification --filter chat-broadcast --filter chat-hook --filter chat-store",
     "test:pusher-client": "bun test tests/test-pusher-client-refcount.test.ts",
     "test:pusher-constructor-wiring": "bun test tests/test-pusher-client-constructor-wiring.test.ts",
-    "test:pusher-regression": "bun test --filter 'pusher'",
-    "test:chat-regression": "bun test --filter 'chat-|pusher'"
+    "test:pusher-regression": "bun test --filter pusher",
+    "test:chat-regression": "bun test --filter chat- --filter pusher"
   },
   "dependencies": {
     "@ai-sdk/anthropic": "^3.0.23",

--- a/tests/test-chat-tools-songs.test.ts
+++ b/tests/test-chat-tools-songs.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, mock, test } from "bun:test";
+import { afterAll, beforeAll, describe, expect, mock, test } from "bun:test";
 import type { Redis } from "@upstash/redis";
 import { createChatTools } from "../api/chat/tools/index.js";
 import {
@@ -195,6 +195,27 @@ async function seedSongs(redis: FakeRedis): Promise<void> {
 }
 
 describe("song library chat tools", () => {
+  const ORIGIN_ENV_KEYS = ["APP_PUBLIC_ORIGIN", "PUBLIC_APP_ORIGIN"] as const;
+  const savedOriginEnv: Partial<Record<(typeof ORIGIN_ENV_KEYS)[number], string | undefined>> = {};
+
+  beforeAll(() => {
+    for (const key of ORIGIN_ENV_KEYS) {
+      savedOriginEnv[key] = process.env[key];
+      delete process.env[key];
+    }
+  });
+
+  afterAll(() => {
+    for (const key of ORIGIN_ENV_KEYS) {
+      const prev = savedOriginEnv[key];
+      if (prev === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = prev;
+      }
+    }
+  });
+
   test("all profile does not expose songLibraryControl", () => {
     const tools = createChatTools(createContext(new FakeRedis()), { profile: "all" });
     expect("songLibraryControl" in tools).toBe(false);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

While running a bugs/build-errors sweep against `main`, three test scripts in `package.json` turned out to be silently broken:

- `test:api`
- `test:chat-wiring`
- `test:chat-regression`

All three used regex-style alternation inside a single `--filter` argument, e.g.

```jsonc
"test:api": "bun test --filter 'new-api|admin|iframe|link-preview|parse-title|song|speech|share-applet|ai|media|auth-extra|rooms-extra|listen-security'"
```

`bun test --filter` treats its argument as a **literal substring** of the file path, not a regex. The pipe-separated value `new-api|admin|…` is a substring that does not appear in any file name, so bun exits with:

```
The following filters did not match any test files:
 new-api|admin|iframe|link-preview|parse-title|song|speech|share-applet|ai|media|auth-extra|rooms-extra|listen-security
4026 files were searched [108.00ms]
```

Net effect: `bun run test:api` has been running **zero** API integration tests (silently exiting non-zero) since the `bun:test` migration. `test:chat-wiring` and `test:chat-regression` were in the same boat.

## Fix

Replace each pipe-separated `--filter 'a|b|c'` with repeated flags `--filter a --filter b --filter c`, which bun OR's together as substring matches:

| Script | Before | After |
|---|---|---|
| `test:api` | 0 files | 287 tests / 24 files |
| `test:chat-wiring` | 0 files | 30 tests / 5 files |
| `test:pusher-regression` | 19 tests (worked) | 19 tests (normalized for consistency) |
| `test:chat-regression` | 0 files | 77 tests / 13 files |

## Secondary fix — `tests/test-chat-tools-songs.test.ts`

Re-enabling `test:chat-regression` surfaced three latent failures in `test-chat-tools-songs.test.ts` (`searches the user library and returns canonical ryOS links`, `gets combined metadata when a song exists in user and global libraries`, `adds a searched YouTube song into the user's library and cache`).

Those tests hardcode `https://os.ryo.lu` as the expected `ipodUrl` / `karaokeUrl` prefix, but the underlying helper reads `APP_PUBLIC_ORIGIN` / `PUBLIC_APP_ORIGIN` via `getAppPublicOrigin()` and only falls back to that default when both env vars are unset. So the assertions fail in any environment that sets either var (cloud agent VMs, self-hosted, preview branches).

Added `beforeAll` / `afterAll` hooks to that suite to clear and restore those two env vars, keeping the canonical-URL assertions hermetic.

## Testing

- ✅ `bun run build` (21s, no errors)
- ✅ `bun run lint` (0 errors; 142 pre-existing warnings)
- ✅ `bun run test:unit` — 236 pass / 0 fail
- ✅ `bun run test:api` (against `bun run dev:api`) — 287 pass / 0 fail
- ✅ `bun run test:chat-wiring` — 30 pass / 0 fail
- ✅ `bun run test:pusher-regression` — 19 pass / 0 fail
- ✅ `bun run test:chat-regression` — 77 pass / 0 fail
- ✅ `bun test tests/test-chat-tools-songs.test.ts` — 8 pass / 0 fail (was 5 pass / 3 fail before the env-isolation fix)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-BC32BE9E-7579-49B3-BD0D-62259228ACAA"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-BC32BE9E-7579-49B3-BD0D-62259228ACAA"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

