### PR TITLE
maps: adapt MapKit color scheme to ryOS dark mode

### DIFF
--- a/src/apps/maps/components/MapsAppComponent.tsx
+++ b/src/apps/maps/components/MapsAppComponent.tsx
@@ -70,6 +70,14 @@ interface MapKitMapInstance {
   showsUserLocation: boolean;
   tracksUserLocation: boolean;
   mapType: string;
+  /**
+   * MapKit JS color scheme — accepts the string values from
+   * `mapkit.Map.ColorSchemes` (`"light"` / `"dark"` / `"adaptive"`).
+   * Only honored when `mapType` is `Standard` or `MutedStandard`;
+   * Hybrid / Satellite ignore the value but accept assignments.
+   *   https://developer.apple.com/documentation/mapkitjs/map/colorscheme
+   */
+  colorScheme: string;
   region: unknown;
   setRegionAnimated: (region: unknown, animated?: boolean) => void;
   setCenterAnimated: (
@@ -181,6 +189,19 @@ function mapTypeToMapKit(type: MapsMapType): string {
     default:
       return "standard";
   }
+}
+
+// Mirror MapKit JS's `mapkit.Map.ColorSchemes` runtime values. We use plain
+// string literals for the same reason as `mapTypeToMapKit` above — the
+// enum lives under `mapkit.Map` and may not be populated synchronously
+// during the first construction. ryOS exposes a single `isDarkMode` flag
+// (only the Aqua theme supports dark mode today) so we collapse straight
+// to "dark" / "light" rather than using "adaptive" — that way an explicit
+// per-theme light/dark override in the ryOS theme store always wins over
+// the OS-level `prefers-color-scheme`.
+//   https://developer.apple.com/documentation/mapkitjs/colorscheme
+function isDarkModeToMapKit(isDarkMode: boolean): string {
+  return isDarkMode ? "dark" : "light";
 }
 
 interface MapsSearchResult {
@@ -361,6 +382,7 @@ export function MapsAppComponent({
     translatedHelpItems,
     isXpTheme,
     isMacOSTheme,
+    isDarkMode,
     isHelpDialogOpen,
     setIsHelpDialogOpen,
     isAboutDialogOpen,
@@ -544,8 +566,10 @@ export function MapsAppComponent({
       // filter" sentinel which means every POI category is rendered.
       pointOfInterestFilter: null,
       region,
+      colorScheme: isDarkModeToMapKit(isDarkMode),
     });
     map.mapType = mapTypeToMapKit(mapType);
+    map.colorScheme = isDarkModeToMapKit(isDarkMode);
     map.showsUserLocation = false;
     map.tracksUserLocation = false;
     map.annotationForCluster = (cluster) => {
@@ -615,6 +639,17 @@ export function MapsAppComponent({
     if (!map) return;
     map.mapType = mapTypeToMapKit(mapType);
   }, [mapType]);
+
+  // Sync MapKit's `colorScheme` when the ryOS theme's dark-mode flag flips
+  // (Aqua is the only theme that supports dark mode today). MapKit only
+  // applies the value to `Standard`/`MutedStandard`, but assigning while
+  // on Hybrid/Satellite is harmless — the new value sticks and takes
+  // effect the next time the user switches back to a standard map type.
+  useEffect(() => {
+    const map = mapInstanceRef.current;
+    if (!map) return;
+    map.colorScheme = isDarkModeToMapKit(isDarkMode);
+  }, [isDarkMode, mapReadyTick]);
 
   // Tear down the map instance when the window closes or the component
   // unmounts so repeated open/close cycles don't leak DOM nodes.
@@ -1489,7 +1524,13 @@ export function MapsAppComponent({
         <div className="relative size-full min-h-0 flex-1 overflow-hidden bg-transparent font-os-ui">
           <div
             ref={attachMapSurfaceRef}
-            className="absolute inset-0 bg-[#e5e3df]"
+            className={cn(
+              "absolute inset-0",
+              // Tile-load placeholder. Light: Apple-Maps tan. Dark: dim
+              // neutral that matches the map's dark color scheme so the
+              // window doesn't flash a bright fill before MapKit paints.
+              isDarkMode ? "bg-[#1c1c1e]" : "bg-[#e5e3df]"
+            )}
             role="application"
             aria-label={t("apps.maps.mapAriaLabel", {
               defaultValue: "Map",
@@ -1501,16 +1542,27 @@ export function MapsAppComponent({
               className={cn(
                 "absolute inset-0 z-[5] flex items-center justify-center px-6 text-center",
                 "bg-os-window-bg/90 backdrop-blur-sm",
-                "font-os-ui text-[12px] text-black/70"
+                "font-os-ui text-[12px]",
+                isDarkMode ? "text-white/70" : "text-black/70"
               )}
             >
               <div className="max-w-[360px] space-y-2">
-                <div className="text-[14px] font-semibold text-black">
+                <div
+                  className={cn(
+                    "text-[14px] font-semibold",
+                    isDarkMode ? "text-white" : "text-black"
+                  )}
+                >
                   {t("apps.maps.title", { defaultValue: "Maps" })}
                 </div>
                 <div>{overlayMessage}</div>
                 {!hasToken && (
-                  <div className="text-[11px] text-black/60">
+                  <div
+                    className={cn(
+                      "text-[11px]",
+                      isDarkMode ? "text-white/60" : "text-black/60"
+                    )}
+                  >
                     {t("apps.maps.status.tokenHint", {
                       defaultValue:
                         "The server signs short-lived MapKit tokens automatically once credentials are configured.",

--- a/src/apps/maps/hooks/useMapsLogic.ts
+++ b/src/apps/maps/hooks/useMapsLogic.ts
@@ -30,6 +30,7 @@ export function useMapsLogic() {
     isMacOSTheme,
     isSystem7Theme,
     isClassicTheme,
+    isDarkMode,
   } = useThemeFlags();
 
   const [isHelpDialogOpen, setIsHelpDialogOpen] = useState(false);
@@ -46,6 +47,7 @@ export function useMapsLogic() {
     isMacOSTheme,
     isSystem7Theme,
     isClassicTheme,
+    isDarkMode,
     isHelpDialogOpen,
     setIsHelpDialogOpen,
     isAboutDialogOpen,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The Maps app always rendered with MapKit's default light tiles, even when the Aqua theme had dark mode enabled. This wires MapKit JS's [`map.colorScheme`](https://developer.apple.com/documentation/mapkitjs/map/colorscheme) up to the unified `isDarkMode` flag from `useThemeFlags` so the map repaints in dark or light to match the rest of the ryOS chrome.

## Approach

- **Source of truth: ryOS `isDarkMode`, not OS `prefers-color-scheme`.** MapKit also ships an `Adaptive` value that mirrors the OS, but our `useThemeStore` already resolves "system" → resolved dark/light per-theme and respects the user's explicit per-theme override. Slaving the map to `isDarkMode` keeps it consistent with the rest of the OS chrome even when the user forces a mode opposite to the OS preference.
- **Two attach points.** Set `colorScheme` in the `mapkit.Map` constructor options so the very first paint is correct, and re-assign in a `useEffect` so toggling dark/light at runtime (or after the map instance is rebuilt on minimize/restore) repaints immediately. Aqua is the only theme that opts into dark mode today, so the effect is a no-op for the other three themes.
- **String literals over enum lookup.** We pass plain `"dark"`/`"light"` rather than `mapkit.Map.ColorSchemes.Dark/Light`, for the same reason the existing `mapTypeToMapKit` helper uses literals — the static enum lives under `mapkit.Map` and isn't guaranteed to be populated synchronously after `mapkit.init()`. Apple's runtime values are stable.
- **Caveat baked into the comment:** MapKit only applies `colorScheme` to `Standard`/`MutedStandard`. Hybrid/Satellite quietly ignore the value but accept assignments, so we don't gate the sync effect on `mapType`.
- **Surrounding chrome.** Repainted the pre-tile-load placeholder behind the map (was a hardcoded light tan `#e5e3df`) and the loading overlay text so the window doesn't flash a bright surface before dark tiles paint in.

## Files changed

- `src/apps/maps/hooks/useMapsLogic.ts` — surfaces `isDarkMode` from `useThemeFlags`.
- `src/apps/maps/components/MapsAppComponent.tsx`
  - Adds `colorScheme: string` to the local `MapKitMapInstance` type.
  - Adds `isDarkModeToMapKit` helper (mirrors the existing `mapTypeToMapKit` style).
  - Passes `colorScheme` in the `new mk.Map(...)` options and re-assigns in a sync `useEffect` keyed on `[isDarkMode, mapReadyTick]`.
  - Switches the placeholder bg and overlay text colors to theme-aware variants.

## Out of scope

The search results dropdown and `MapsPlaceCard` use hardcoded `text-black` utilities that may need a separate dark-mode pass — left untouched here to keep the surface focused on the map itself, per the request.

## Testing

- `bun run build` — passes (TS compile + Vite build).
- `bun x eslint` on the two changed files — clean.
- Manual visual verification of the dark/light toggle in the Aqua theme is queued in this turn.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5BA7C0A0-57F6-4136-AB0A-79F490EB690B"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5BA7C0A0-57F6-4136-AB0A-79F490EB690B"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

