### PR TITLE
Aqua dark: dim desktop wallpaper; fix Maps result/card surfaces

### DIFF
--- a/src/apps/maps/components/MapsAppComponent.tsx
+++ b/src/apps/maps/components/MapsAppComponent.tsx
@@ -1578,11 +1578,11 @@ export function MapsAppComponent({
             {isShowingResults && (
               <div
                 className={cn(
-                  "pointer-events-auto min-h-0 w-full min-w-0 overflow-y-auto rounded-[0.4rem] border shadow-md",
+                  "pointer-events-auto min-h-0 w-full min-w-0 overflow-y-auto rounded-[0.4rem] shadow-md",
                   "max-h-[min(50vh,24rem)]",
                   isMacOSTheme
-                    ? "maps-place-card-aqua border-black/20 text-black"
-                    : "border-black/40 bg-white/95 backdrop-blur-sm"
+                    ? "maps-place-card-aqua border-transparent text-[color:var(--os-color-text-primary)]"
+                    : "border border-black/40 bg-white/95 backdrop-blur-sm"
                 )}
               >
                 {/*
@@ -1593,19 +1593,37 @@ export function MapsAppComponent({
                  * dropdown is empty until the first hit lands.
                  */}
                 {!isSearching && searchError && (
-                  <div className="px-3 py-2 text-[11px] text-red-700">
+                  <div
+                    className={cn(
+                      "px-3 py-2 text-[11px]",
+                      isMacOSTheme && isDarkMode
+                        ? "text-red-300"
+                        : "text-red-700"
+                    )}
+                  >
                     {searchError}
                   </div>
                 )}
                 {!isSearching && !searchError && searchResults.length === 0 && (
-                  <div className="px-3 py-2 text-[11px] text-black/60">
+                  <div
+                    className={cn(
+                      "px-3 py-2 text-[11px] text-[color:var(--os-color-text-secondary)]"
+                    )}
+                  >
                     {t("apps.maps.noResults", {
                       defaultValue: "No results",
                     })}
                   </div>
                 )}
                 {searchResults.length > 0 && (
-                  <ul className="divide-y divide-black/10">
+                  <ul
+                    className={cn(
+                      "divide-y",
+                      isMacOSTheme && isDarkMode
+                        ? "divide-[color:var(--os-color-separator)]"
+                        : "divide-black/10"
+                    )}
+                  >
                     {searchResults.map((result) => {
                       const isSelected = selectedResultId === result.id;
                       const visual = getPoiVisual(result.category);
@@ -1617,8 +1635,13 @@ export function MapsAppComponent({
                             onClick={() => handleSelectResult(result)}
                             className={cn(
                               "flex w-full items-center gap-3 px-3 py-2 text-left text-[12px]",
-                              "hover:bg-black/5",
-                              isSelected && "bg-black/5"
+                              isMacOSTheme && isDarkMode
+                                ? "hover:bg-white/8"
+                                : "hover:bg-black/5",
+                              isSelected &&
+                                (isMacOSTheme && isDarkMode
+                                  ? "bg-white/10"
+                                  : "bg-black/5")
                             )}
                           >
                             <div
@@ -1631,11 +1654,11 @@ export function MapsAppComponent({
                               <Icon size={17} weight="fill" />
                             </div>
                             <div className="min-w-0 flex-1">
-                              <div className="truncate font-medium text-black">
+                              <div className="truncate font-medium text-[color:var(--os-color-text-primary)]">
                                 {result.name}
                               </div>
                               {result.subtitle && (
-                                <div className="truncate text-[11px] text-black/55">
+                                <div className="truncate text-[11px] text-[color:var(--os-color-text-secondary)]">
                                   {result.subtitle}
                                 </div>
                               )}

--- a/src/apps/maps/components/MapsPlaceCard.tsx
+++ b/src/apps/maps/components/MapsPlaceCard.tsx
@@ -95,7 +95,8 @@ export function MapsPlaceCard({
   onClose,
 }: MapsPlaceCardProps) {
   const { t } = useTranslation();
-  const { isMacOSTheme, isXpTheme, isSystem7Theme } = useThemeFlags();
+  const { isMacOSTheme, isXpTheme, isSystem7Theme, isDarkMode } = useThemeFlags();
+  const aquaDarkCard = isMacOSTheme && isDarkMode;
 
   return (
     <AnimatePresence>
@@ -119,7 +120,7 @@ export function MapsPlaceCard({
               // other themes mirror their drawer panels so the surfaces look
               // like siblings.
               isMacOSTheme &&
-                "maps-place-card-aqua rounded-[0.5rem] text-black",
+                "maps-place-card-aqua rounded-[0.5rem] text-[color:var(--os-color-text-primary)]",
               !isMacOSTheme &&
                 isSystem7Theme &&
                 "rounded border-2 border-black bg-white text-black shadow-[2px_2px_0_0_rgba(0,0,0,0.5)]",
@@ -138,6 +139,7 @@ export function MapsPlaceCard({
               isWork={isWork}
               onClose={onClose}
               t={t}
+              aquaDarkCard={aquaDarkCard}
             />
             <PlaceCardActions
               place={place}
@@ -165,6 +167,7 @@ interface PlaceCardHeaderProps {
   isWork: boolean;
   onClose: () => void;
   t: ReturnType<typeof useTranslation>["t"];
+  aquaDarkCard: boolean;
 }
 
 function PlaceCardHeader({
@@ -173,6 +176,7 @@ function PlaceCardHeader({
   isWork,
   onClose,
   t,
+  aquaDarkCard,
 }: PlaceCardHeaderProps) {
   const homeTitle = t("apps.maps.places.home", { defaultValue: "Home" });
   const workTitle = t("apps.maps.places.work", { defaultValue: "Work" });
@@ -208,17 +212,17 @@ function PlaceCardHeader({
       </div>
       <div className="min-w-0 flex-1">
         <div className="flex items-baseline gap-1.5">
-          <div className="truncate text-[13px] font-semibold leading-tight text-black">
+          <div className="truncate text-[13px] font-semibold leading-tight text-[color:var(--os-color-text-primary)]">
             {title}
           </div>
           {categoryLabel && (
-            <div className="shrink-0 text-[11px] leading-tight text-black/45">
+            <div className="shrink-0 text-[11px] leading-tight text-[color:var(--os-color-text-secondary)]">
               {categoryLabel}
             </div>
           )}
         </div>
         {subtitle && (
-          <div className="line-clamp-2 text-[11px] leading-snug text-black/60">
+          <div className="line-clamp-2 text-[11px] leading-snug text-[color:var(--os-color-text-secondary)]">
             {subtitle}
           </div>
         )}
@@ -228,8 +232,10 @@ function PlaceCardHeader({
         onClick={onClose}
         className={cn(
           "shrink-0 -mr-0.5 -mt-0.5 flex size-6 items-center justify-center rounded-full",
-          "text-black/55 hover:bg-black/10 hover:text-black/85",
-          "focus:outline-none focus-visible:ring-1 focus-visible:ring-black/30"
+          aquaDarkCard
+            ? "text-[color:var(--os-color-text-secondary)] hover:bg-white/12 hover:text-[color:var(--os-color-text-primary)] focus-visible:ring-1 focus-visible:ring-white/35"
+            : "text-black/55 hover:bg-black/10 hover:text-black/85 focus-visible:ring-1 focus-visible:ring-black/30",
+          "focus:outline-none"
         )}
         aria-label={t("apps.maps.placeCard.close", {
           defaultValue: "Close place card",

--- a/src/apps/maps/components/MapsPlacesDrawer.tsx
+++ b/src/apps/maps/components/MapsPlacesDrawer.tsx
@@ -35,7 +35,7 @@ interface SectionProps {
 function Section({ title, children }: SectionProps) {
   return (
     <div className="space-y-1">
-      <div className="px-2 pt-1 text-[11px] font-normal text-black/45">
+      <div className="px-2 pt-1 text-[11px] font-normal text-[color:var(--os-color-text-secondary)]">
         {title}
       </div>
       <div>{children}</div>
@@ -71,7 +71,7 @@ function PlaceRow({
       type="button"
       onClick={onClick}
       className={cn(
-        "flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-[12px]",
+        "maps-places-place-row flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-[12px]",
         "hover:bg-black/5"
       )}
     >
@@ -83,9 +83,11 @@ function PlaceRow({
         <Icon size={14} weight="fill" />
       </div>
       <div className="min-w-0 flex-1">
-        <div className="truncate font-medium text-black">{title}</div>
+        <div className="truncate font-medium text-[color:var(--os-color-text-primary)]">
+          {title}
+        </div>
         {subtitle && (
-          <div className="truncate text-[11px] text-black/55">
+          <div className="truncate text-[11px] text-[color:var(--os-color-text-secondary)]">
             {subtitle}
           </div>
         )}
@@ -96,7 +98,9 @@ function PlaceRow({
 
 function EmptyState({ message }: { message: string }) {
   return (
-    <div className="px-2 py-1 text-[11px] text-black/50">{message}</div>
+    <div className="px-2 py-1 text-[11px] text-[color:var(--os-color-text-secondary)]">
+      {message}
+    </div>
   );
 }
 

--- a/src/components/shared/MapsSearchPlacesCard.tsx
+++ b/src/components/shared/MapsSearchPlacesCard.tsx
@@ -49,7 +49,7 @@ export function MapsSearchPlacesCard({
   results,
 }: MapsSearchPlacesCardProps) {
   const { t } = useTranslation();
-  const { isMacOSTheme, isXpTheme, isSystem7Theme } = useThemeFlags();
+  const { isMacOSTheme, isXpTheme, isSystem7Theme, isDarkMode } = useThemeFlags();
   const launchApp = useLaunchApp();
 
   const handleOpenInMaps = useCallback(
@@ -75,20 +75,25 @@ export function MapsSearchPlacesCard({
     return (
       <div
         className={cn(
-          "my-1 px-2.5 py-2 text-[12px] text-black/70",
-          isMacOSTheme
-            ? "rounded-[0.5rem] bg-white/85 shadow-sm"
-            : isSystem7Theme
-              ? "rounded border-2 border-black bg-white shadow-[2px_2px_0_0_rgba(0,0,0,0.5)]"
-              : isXpTheme
-                ? "rounded-[0.4rem] border-2 border-[#0054E3] bg-[#ECE9D8]"
-                : "rounded border border-black/30 bg-white"
+          "my-1 px-2.5 py-2 text-[12px]",
+          isMacOSTheme && "maps-place-card-aqua rounded-[0.5rem] shadow-md",
+          !isMacOSTheme &&
+            isSystem7Theme &&
+            "rounded border-2 border-black bg-white text-black shadow-[2px_2px_0_0_rgba(0,0,0,0.5)]",
+          !isMacOSTheme &&
+            !isSystem7Theme &&
+            isXpTheme &&
+            "rounded-[0.4rem] border-2 border-[#0054E3] bg-[#ECE9D8] text-black",
+          !isMacOSTheme && !isSystem7Theme && !isXpTheme &&
+            "rounded border border-black/30 bg-white text-black"
         )}
       >
-        {t("apps.chats.toolCalls.maps.noResults", {
-          defaultValue: 'No places found for "{{query}}".',
-          query,
-        })}
+        <p className="text-[color:var(--os-color-text-secondary)]">
+          {t("apps.chats.toolCalls.maps.noResults", {
+            defaultValue: 'No places found for "{{query}}".',
+            query,
+          })}
+        </p>
       </div>
     );
   }
@@ -100,7 +105,7 @@ export function MapsSearchPlacesCard({
         // Theme shells mirror the in-app place card so the chat surface
         // looks like a sibling of the real Maps UI.
         isMacOSTheme &&
-          "maps-place-card-aqua rounded-[0.5rem] text-black",
+          "maps-place-card-aqua rounded-[0.5rem] text-[color:var(--os-color-text-primary)]",
         !isMacOSTheme &&
           isSystem7Theme &&
           "rounded border-2 border-black bg-white text-black shadow-[2px_2px_0_0_rgba(0,0,0,0.5)]",
@@ -112,7 +117,14 @@ export function MapsSearchPlacesCard({
           "rounded border border-black/30 bg-white text-black shadow-md"
       )}
     >
-      <ul className="divide-y divide-black/10">
+      <ul
+        className={cn(
+          "divide-y",
+          isMacOSTheme && isDarkMode
+            ? "divide-[color:var(--os-color-separator)]"
+            : "divide-black/10"
+        )}
+      >
         {results.map((place) => {
           const visual = getPoiVisual(place.category);
           const Icon = visual.Icon;
@@ -123,8 +135,13 @@ export function MapsSearchPlacesCard({
                 onClick={() => handleOpenInMaps(place)}
                 className={cn(
                   "flex w-full items-center gap-2.5 px-2.5 py-2 text-left",
-                  "hover:bg-black/5 active:bg-black/10",
-                  "focus:outline-none focus-visible:ring-1 focus-visible:ring-black/30"
+                  isMacOSTheme && isDarkMode
+                    ? "hover:bg-white/10 active:bg-white/14"
+                    : "hover:bg-black/5 active:bg-black/10",
+                  "focus:outline-none focus-visible:ring-1",
+                  isMacOSTheme && isDarkMode
+                    ? "focus-visible:ring-white/35"
+                    : "focus-visible:ring-black/30"
                 )}
                 aria-label={t("apps.chats.toolCalls.maps.openInMaps", {
                   defaultValue: "Open {{name}} in Maps",
@@ -139,11 +156,11 @@ export function MapsSearchPlacesCard({
                   <Icon size={20} weight="fill" />
                 </div>
                 <div className="min-w-0 flex-1">
-                  <div className="truncate text-[13px] font-semibold leading-tight text-black">
+                  <div className="truncate text-[13px] font-semibold leading-tight text-[color:var(--os-color-text-primary)]">
                     {place.name}
                   </div>
                   {place.address && (
-                    <div className="line-clamp-2 text-[11px] leading-snug text-black/60">
+                    <div className="line-clamp-2 text-[11px] leading-snug text-[color:var(--os-color-text-secondary)]">
                       {place.address}
                     </div>
                   )}
@@ -155,8 +172,10 @@ export function MapsSearchPlacesCard({
                   onClick={(e) => e.stopPropagation()}
                   className={cn(
                     "shrink-0 -mr-0.5 flex size-7 items-center justify-center rounded-full",
-                    "text-black/55 hover:bg-black/10 hover:text-black/85",
-                    "focus:outline-none focus-visible:ring-1 focus-visible:ring-black/30"
+                    isMacOSTheme && isDarkMode
+                      ? "text-[color:var(--os-color-text-secondary)] hover:bg-white/12 hover:text-[color:var(--os-color-text-primary)] focus-visible:ring-white/35"
+                      : "text-black/55 hover:bg-black/10 hover:text-black/85 focus-visible:ring-black/30",
+                    "focus:outline-none focus-visible:ring-1"
                   )}
                   aria-label={t("apps.chats.toolCalls.maps.openInAppleMaps", {
                     defaultValue: "Open in Apple Maps",

--- a/src/styles/themes.css
+++ b/src/styles/themes.css
@@ -2939,6 +2939,36 @@
   color: #ffffff;
 }
 
+/* Aqua dark: veil over the wallpaper so desktop icons/readability stay crisp */
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"] .desktop-background {
+  isolation: isolate;
+}
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"] .desktop-background::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  pointer-events: none;
+  background: rgb(0 0 0 / 0.36);
+}
+
+/* macOS dark: Maps search / place / chat tool cards — dark glass, not light pinstripe */
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"] .maps-place-card-aqua {
+  background: color-mix(in srgb, var(--os-color-panel-bg) 88%, transparent);
+  background-image: var(--os-pinstripe-window);
+  box-shadow: 0 6px 22px rgb(0 0 0 / 0.45);
+  border: 1px solid var(--os-color-sidebar-border);
+  color: var(--os-color-text-primary);
+  backdrop-filter: blur(14px);
+  -webkit-backdrop-filter: blur(14px);
+}
+
+/* macOS dark: Maps saved-places drawer rows (not on the light pinstripe card surface) */
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"]
+  .maps-places-place-row:hover {
+  background-color: rgb(255 255 255 / 0.08);
+}
+
 /* macOS: Style toast containers with semi-transparent pinstripes like dock */
 :root[data-os-theme="macosx"] .toaster [data-sonner-toast] {
   background: rgba(248, 248, 248, 0.75) !important;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Ships aqua/macOS-specific dark polish without touching System 7, XP, or Win98 styling.

**Desktop**
- `:root[data-os-theme="macosx"][data-os-color-scheme="dark"] .desktop-background` gains `isolation: isolate` plus a subtle `::after` black veil (36% opacity) so wallpaper stays visible but Icons/menubar/overlays stacked above (`z-[1+]`) remain legible.

**Maps (in-app + Chats maps tool cards)**
- Dark aqua overrides for `.maps-place-card-aqua`: dark translucent panel, `var(--os-pinstripe-window)`, bordered with `var(--os-color-sidebar-border)`, OS text hierarchy via `--os-color-text-primary` / `--os-color-secondary`, separators via `--os-color-separator`.
- Search results panel, Places drawer rows, place card typography, chat `MapsSearchPlacesCard`: token-based text colors (works in light aqua too); adjusted row hovers/select states and divides in aqua dark only where needed.
- Chat empty-state bubble for macosx now uses `maps-place-card-aqua` so dark mode stays consistent.

**Testing**
- `bunx tsc --noEmit`
- `bun run lint` (existing warnings only; no new errors on touched files)
- `bun run build` — completed successfully after these changes

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1e320132-69d3-432f-a13d-27b5cb16aeaa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1e320132-69d3-432f-a13d-27b5cb16aeaa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

