### PR TITLE
Dark mode: tool/Maps cards + Tailwind dark sync for Aqua

### DIFF
--- a/index.html
+++ b/index.html
@@ -226,18 +226,41 @@
           }
           // Dark mode is per-theme, only honored when the theme advertises support.
           // Today only macosx has dark tokens — see src/styles/themes.css.
+          // Match useThemeStore#effectiveDarkFor (string prefs + legacy booleans + system).
           var supportsDark = theme === "macosx";
+          var systemDark = false;
+          try {
+            systemDark =
+              window.matchMedia &&
+              window.matchMedia("(prefers-color-scheme: dark)").matches;
+          } catch (e0) {}
+
+          var isDarkBoot = false;
           if (supportsDark) {
             try {
               var rawDark = localStorage.getItem("ryos:theme:dark");
+              var pref = null;
               if (rawDark) {
-                var parsed = JSON.parse(rawDark);
-                if (parsed && parsed[theme] === true) {
-                  root.dataset.osColorScheme = "dark";
-                  root.style.colorScheme = "dark";
+                var parsedDark = JSON.parse(rawDark);
+                if (
+                  parsedDark &&
+                  typeof parsedDark === "object" &&
+                  parsedDark[theme] !== undefined &&
+                  parsedDark[theme] !== null
+                ) {
+                  pref = parsedDark[theme];
                 }
               }
-            } catch (e) {}
+              if (pref === true || pref === "dark") isDarkBoot = true;
+              else if (pref === false || pref === "light") isDarkBoot = false;
+              else isDarkBoot = systemDark;
+            } catch (e1) {}
+
+            if (isDarkBoot) {
+              root.dataset.osColorScheme = "dark";
+              root.style.colorScheme = "dark";
+              root.classList.add("dark");
+            }
           }
         } catch (e) {}
       })();

--- a/src/apps/maps/components/MapsAppComponent.tsx
+++ b/src/apps/maps/components/MapsAppComponent.tsx
@@ -1581,7 +1581,7 @@ export function MapsAppComponent({
                   "pointer-events-auto min-h-0 w-full min-w-0 overflow-y-auto rounded-[0.4rem] border shadow-md",
                   "max-h-[min(50vh,24rem)]",
                   isMacOSTheme
-                    ? "maps-place-card-aqua border-black/20 text-black"
+                    ? "maps-place-card-aqua border-black/20 text-os-text-primary dark:border-white/15"
                     : "border-black/40 bg-white/95 backdrop-blur-sm"
                 )}
               >
@@ -1593,19 +1593,19 @@ export function MapsAppComponent({
                  * dropdown is empty until the first hit lands.
                  */}
                 {!isSearching && searchError && (
-                  <div className="px-3 py-2 text-[11px] text-red-700">
+                  <div className="px-3 py-2 text-[11px] text-red-700 dark:text-red-300">
                     {searchError}
                   </div>
                 )}
                 {!isSearching && !searchError && searchResults.length === 0 && (
-                  <div className="px-3 py-2 text-[11px] text-black/60">
+                  <div className="px-3 py-2 text-[11px] text-os-text-secondary">
                     {t("apps.maps.noResults", {
                       defaultValue: "No results",
                     })}
                   </div>
                 )}
                 {searchResults.length > 0 && (
-                  <ul className="divide-y divide-black/10">
+                  <ul className="divide-y divide-black/10 dark:divide-white/10">
                     {searchResults.map((result) => {
                       const isSelected = selectedResultId === result.id;
                       const visual = getPoiVisual(result.category);
@@ -1617,8 +1617,8 @@ export function MapsAppComponent({
                             onClick={() => handleSelectResult(result)}
                             className={cn(
                               "flex w-full items-center gap-3 px-3 py-2 text-left text-[12px]",
-                              "hover:bg-black/5",
-                              isSelected && "bg-black/5"
+                              "hover:bg-black/5 dark:hover:bg-white/10",
+                              isSelected && "bg-black/5 dark:bg-white/10"
                             )}
                           >
                             <div
@@ -1631,11 +1631,11 @@ export function MapsAppComponent({
                               <Icon size={17} weight="fill" />
                             </div>
                             <div className="min-w-0 flex-1">
-                              <div className="truncate font-medium text-black">
+                              <div className="truncate font-medium text-os-text-primary">
                                 {result.name}
                               </div>
                               {result.subtitle && (
-                                <div className="truncate text-[11px] text-black/55">
+                                <div className="truncate text-[11px] text-os-text-secondary">
                                   {result.subtitle}
                                 </div>
                               )}

--- a/src/apps/maps/components/MapsPlaceCard.tsx
+++ b/src/apps/maps/components/MapsPlaceCard.tsx
@@ -119,7 +119,7 @@ export function MapsPlaceCard({
               // other themes mirror their drawer panels so the surfaces look
               // like siblings.
               isMacOSTheme &&
-                "maps-place-card-aqua rounded-[0.5rem] text-black",
+                "maps-place-card-aqua rounded-[0.5rem] text-os-text-primary",
               !isMacOSTheme &&
                 isSystem7Theme &&
                 "rounded border-2 border-black bg-white text-black shadow-[2px_2px_0_0_rgba(0,0,0,0.5)]",
@@ -208,17 +208,17 @@ function PlaceCardHeader({
       </div>
       <div className="min-w-0 flex-1">
         <div className="flex items-baseline gap-1.5">
-          <div className="truncate text-[13px] font-semibold leading-tight text-black">
+          <div className="truncate text-[13px] font-semibold leading-tight text-os-text-primary">
             {title}
           </div>
           {categoryLabel && (
-            <div className="shrink-0 text-[11px] leading-tight text-black/45">
+            <div className="shrink-0 text-[11px] leading-tight text-os-text-secondary">
               {categoryLabel}
             </div>
           )}
         </div>
         {subtitle && (
-          <div className="line-clamp-2 text-[11px] leading-snug text-black/60">
+          <div className="line-clamp-2 text-[11px] leading-snug text-os-text-secondary">
             {subtitle}
           </div>
         )}
@@ -228,8 +228,9 @@ function PlaceCardHeader({
         onClick={onClose}
         className={cn(
           "shrink-0 -mr-0.5 -mt-0.5 flex size-6 items-center justify-center rounded-full",
-          "text-black/55 hover:bg-black/10 hover:text-black/85",
-          "focus:outline-none focus-visible:ring-1 focus-visible:ring-black/30"
+          "text-os-text-secondary hover:bg-black/10 hover:text-os-text-primary",
+          "focus:outline-none focus-visible:ring-1 focus-visible:ring-black/30",
+          "dark:hover:bg-white/10 dark:focus-visible:ring-white/35"
         )}
         aria-label={t("apps.maps.placeCard.close", {
           defaultValue: "Close place card",

--- a/src/components/shared/CursorRepoAgentChatCard.tsx
+++ b/src/components/shared/CursorRepoAgentChatCard.tsx
@@ -136,7 +136,7 @@ export function CursorRepoAgentChatCard({
             />
           </span>
           <div className="flex min-w-0 flex-1 items-center gap-2">
-            <div className="min-w-0 flex-1 truncate text-sm font-medium" title={displayTitle}>
+            <div className="min-w-0 flex-1 truncate text-sm font-medium text-neutral-900 dark:text-neutral-100" title={displayTitle}>
               {displayTitle}
             </div>
             {prUrl ? (

--- a/src/components/shared/CursorRunEventView.tsx
+++ b/src/components/shared/CursorRunEventView.tsx
@@ -223,7 +223,7 @@ function CursorToolInvocationRow({
 }) {
   return (
     <div className="mb-0 px-1 py-0.5 text-[12px]">
-      <div className="flex min-w-0 flex-nowrap items-baseline gap-1 text-neutral-700">
+      <div className="flex min-w-0 flex-nowrap items-baseline gap-1 text-neutral-700 dark:text-neutral-200">
         <span className={`shrink-0 ${done ? "" : "shimmer"}`}>{primary}</span>
         {secondary ? (
           <span className="min-w-0 truncate text-neutral-500 dark:text-neutral-400">

--- a/src/components/shared/MapsSearchPlacesCard.tsx
+++ b/src/components/shared/MapsSearchPlacesCard.tsx
@@ -75,14 +75,20 @@ export function MapsSearchPlacesCard({
     return (
       <div
         className={cn(
-          "my-1 px-2.5 py-2 text-[12px] text-black/70",
-          isMacOSTheme
-            ? "rounded-[0.5rem] bg-white/85 shadow-sm"
-            : isSystem7Theme
-              ? "rounded border-2 border-black bg-white shadow-[2px_2px_0_0_rgba(0,0,0,0.5)]"
-              : isXpTheme
-                ? "rounded-[0.4rem] border-2 border-[#0054E3] bg-[#ECE9D8]"
-                : "rounded border border-black/30 bg-white"
+          "my-1 px-2.5 py-2 text-[12px]",
+          isMacOSTheme &&
+            "maps-place-card-aqua rounded-[0.5rem] text-os-text-secondary shadow-sm",
+          !isMacOSTheme &&
+            isSystem7Theme &&
+            "rounded border-2 border-black bg-white text-black/70 shadow-[2px_2px_0_0_rgba(0,0,0,0.5)]",
+          !isMacOSTheme &&
+            !isSystem7Theme &&
+            isXpTheme &&
+            "rounded-[0.4rem] border-2 border-[#0054E3] bg-[#ECE9D8] text-black/70",
+          !isMacOSTheme &&
+            !isSystem7Theme &&
+            !isXpTheme &&
+            "rounded border border-black/30 bg-white text-black/70"
         )}
       >
         {t("apps.chats.toolCalls.maps.noResults", {
@@ -100,7 +106,7 @@ export function MapsSearchPlacesCard({
         // Theme shells mirror the in-app place card so the chat surface
         // looks like a sibling of the real Maps UI.
         isMacOSTheme &&
-          "maps-place-card-aqua rounded-[0.5rem] text-black",
+          "maps-place-card-aqua rounded-[0.5rem] text-os-text-primary",
         !isMacOSTheme &&
           isSystem7Theme &&
           "rounded border-2 border-black bg-white text-black shadow-[2px_2px_0_0_rgba(0,0,0,0.5)]",
@@ -112,7 +118,7 @@ export function MapsSearchPlacesCard({
           "rounded border border-black/30 bg-white text-black shadow-md"
       )}
     >
-      <ul className="divide-y divide-black/10">
+      <ul className="divide-y divide-black/10 dark:divide-white/10">
         {results.map((place) => {
           const visual = getPoiVisual(place.category);
           const Icon = visual.Icon;
@@ -123,8 +129,8 @@ export function MapsSearchPlacesCard({
                 onClick={() => handleOpenInMaps(place)}
                 className={cn(
                   "flex w-full items-center gap-2.5 px-2.5 py-2 text-left",
-                  "hover:bg-black/5 active:bg-black/10",
-                  "focus:outline-none focus-visible:ring-1 focus-visible:ring-black/30"
+                  "hover:bg-black/5 active:bg-black/10 dark:hover:bg-white/10 dark:active:bg-white/15",
+                  "focus:outline-none focus-visible:ring-1 focus-visible:ring-black/30 dark:focus-visible:ring-white/35"
                 )}
                 aria-label={t("apps.chats.toolCalls.maps.openInMaps", {
                   defaultValue: "Open {{name}} in Maps",
@@ -139,11 +145,11 @@ export function MapsSearchPlacesCard({
                   <Icon size={20} weight="fill" />
                 </div>
                 <div className="min-w-0 flex-1">
-                  <div className="truncate text-[13px] font-semibold leading-tight text-black">
+                  <div className="truncate text-[13px] font-semibold leading-tight text-os-text-primary">
                     {place.name}
                   </div>
                   {place.address && (
-                    <div className="line-clamp-2 text-[11px] leading-snug text-black/60">
+                    <div className="line-clamp-2 text-[11px] leading-snug text-os-text-secondary">
                       {place.address}
                     </div>
                   )}
@@ -155,8 +161,9 @@ export function MapsSearchPlacesCard({
                   onClick={(e) => e.stopPropagation()}
                   className={cn(
                     "shrink-0 -mr-0.5 flex size-7 items-center justify-center rounded-full",
-                    "text-black/55 hover:bg-black/10 hover:text-black/85",
-                    "focus:outline-none focus-visible:ring-1 focus-visible:ring-black/30"
+                    "text-os-text-secondary hover:bg-black/10 hover:text-os-text-primary",
+                    "dark:hover:bg-white/10",
+                    "focus:outline-none focus-visible:ring-1 focus-visible:ring-black/30 dark:focus-visible:ring-white/35"
                   )}
                   aria-label={t("apps.chats.toolCalls.maps.openInAppleMaps", {
                     defaultValue: "Open in Apple Maps",

--- a/src/components/shared/ToolInvocationMessage.tsx
+++ b/src/components/shared/ToolInvocationMessage.tsx
@@ -775,8 +775,8 @@ export function ToolInvocationMessage({
       return (
         <div key={partKey} className="mb-0 px-1 py-0.5 text-[12px]">
           <ToolInvocationStatusRow
-            icon={<Check className="size-3 text-blue-600" weight="bold" />}
-            className="text-neutral-700"
+            icon={<Check className="size-3 text-blue-600 dark:text-blue-400" weight="bold" />}
+            className="text-neutral-700 dark:text-neutral-200"
             align="start"
           >
             <span>
@@ -809,12 +809,12 @@ export function ToolInvocationMessage({
           <ToolInvocationStatusRow
             icon={
               <Check
-                className="size-3 shrink-0 text-neutral-400"
+                className="size-3 shrink-0 text-neutral-400 dark:text-neutral-500"
                 weight="bold"
                 aria-hidden
               />
             }
-            className="text-neutral-500"
+            className="text-neutral-500 dark:text-neutral-400"
             align="start"
           >
             <span>
@@ -899,8 +899,8 @@ export function ToolInvocationMessage({
       return (
         <div key={partKey} className="mb-0 px-1 py-0.5 italic text-[12px]">
           <ToolInvocationStatusRow
-            icon={<ActivityIndicator size="xs" className="text-neutral-500" />}
-            className="text-neutral-600"
+            icon={<ActivityIndicator size="xs" className="text-neutral-500 dark:text-neutral-400" />}
+            className="text-neutral-600 dark:text-neutral-300"
           >
             <span className="shimmer">
               {t("apps.chats.toolCalls.generating")}
@@ -929,8 +929,8 @@ export function ToolInvocationMessage({
       return (
         <div key={partKey} className="mb-0 px-1 py-0.5 italic text-[12px]">
           <ToolInvocationStatusRow
-            icon={<ActivityIndicator size="xs" className="text-neutral-500" />}
-            className="text-neutral-500"
+            icon={<ActivityIndicator size="xs" className="text-neutral-500 dark:text-neutral-400" />}
+            className="text-neutral-500 dark:text-neutral-400"
           >
             <span>{t("apps.chats.toolCalls.preparingHtmlPreview")}</span>
           </ToolInvocationStatusRow>
@@ -949,8 +949,8 @@ export function ToolInvocationMessage({
       {(state === "input-streaming" || state === "input-available") &&
         !output && (
           <ToolInvocationStatusRow
-            icon={<ActivityIndicator size="xs" className="text-neutral-500" />}
-            className="text-neutral-700"
+            icon={<ActivityIndicator size="xs" className="text-neutral-500 dark:text-neutral-400" />}
+            className="text-neutral-700 dark:text-neutral-200"
           >
             {displayCallMessage ? (
               <span className="shimmer">{displayCallMessage}</span>
@@ -965,8 +965,8 @@ export function ToolInvocationMessage({
         )}
       {state === "output-available" && (
         <ToolInvocationStatusRow
-          icon={<Check className="size-3 text-blue-600" weight="bold" />}
-          className="text-neutral-700"
+          icon={<Check className="size-3 text-blue-600 dark:text-blue-400" weight="bold" />}
+          className="text-neutral-700 dark:text-neutral-200"
           align="start"
         >
           {displayResultMessage ? (
@@ -974,7 +974,7 @@ export function ToolInvocationMessage({
           ) : (
             <div className="flex flex-col">
               {typeof output === "string" && output.length > 0 ? (
-                <span className="text-neutral-500">{output}</span>
+                <span className="text-neutral-500 dark:text-neutral-400">{output}</span>
               ) : (
                 <span>{formatToolName(toolName)}</span>
               )}
@@ -986,12 +986,12 @@ export function ToolInvocationMessage({
         <ToolInvocationStatusRow
           icon={
             <Check
-              className="size-3 shrink-0 text-neutral-400"
+              className="size-3 shrink-0 text-neutral-400 dark:text-neutral-500"
               weight="bold"
               aria-hidden
             />
           }
-          className="text-neutral-500"
+          className="text-neutral-500 dark:text-neutral-400"
         >
           <span>{toolAttemptedLabel}</span>
         </ToolInvocationStatusRow>

--- a/src/stores/useThemeStore.ts
+++ b/src/stores/useThemeStore.ts
@@ -161,12 +161,16 @@ function applyRootThemeAttributes(theme: OsThemeId, isDark: boolean) {
   else delete root.dataset.osMacChrome;
   // Color-scheme attribute is only applied when the theme supports dark mode AND it's enabled.
   // This keeps the existing light-mode CSS the single source of truth for unsupported themes.
+  // Mirror the same predicate on Tailwind's `dark` class so `dark:*` utilities match Aqua dark mode
+  // (Tailwind `darkMode: ["class"]` expects a `.dark` ancestor — `data-os-color-scheme` alone is insufficient).
   if (isDark && themeSupportsDarkMode(theme)) {
     root.dataset.osColorScheme = "dark";
     root.style.colorScheme = "dark";
+    root.classList.add("dark");
   } else {
     delete root.dataset.osColorScheme;
     root.style.colorScheme = "light";
+    root.classList.remove("dark");
   }
 }
 

--- a/src/styles/themes.css
+++ b/src/styles/themes.css
@@ -2939,6 +2939,24 @@
   color: #ffffff;
 }
 
+/* Aqua dark — same glass lineage as dock / Sonner toasts; keeps chat + Maps readable */
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"] .maps-place-card-aqua {
+  background: rgba(40, 40, 44, 0.82);
+  background-image: var(--os-pinstripe-menubar);
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.45);
+  border: none;
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+  color: var(--os-color-text-primary);
+}
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"] .maps-place-card-aqua .aqua-icon-badge,
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"]
+  .maps-place-card-aqua
+  .aqua-icon-badge
+  * {
+  color: #ffffff;
+}
+
 /* macOS: Style toast containers with semi-transparent pinstripes like dock */
 :root[data-os-theme="macosx"] .toaster [data-sonner-toast] {
   background: rgba(248, 248, 248, 0.75) !important;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- **Maps (Aqua dark):** `.maps-place-card-aqua` uses dark translucent glass aligned with upstream (color-mix, border, drawer row hover, desktop veil) plus explicit aqua-badge white glyphs in dark.
- **Chat + Maps UI:** Combines upstream `isMacOSTheme && isDarkMode` branching with `text-os-*` tokens and `border-transparent` where appropriate.
- **Tailwind ↔ OS scheme:** Branch still toggles `<html class="dark">` with `data-os-color-scheme` so `dark:*` utilities stay in sync.
- **`index.html` boot:** Matches string/boolean/system dark prefs (from prior commit on this branch).

## Merge note
Merged latest `main` (2026-05-27) and resolved conflicts in Maps components + `themes.css`.

## Verification
- `bun run build` — passes after conflict resolution.

## Screenshots
Not captured here; manual check: Aqua dark Maps search dropdown, place card, chat `mapsSearchPlaces` list.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dc26ecff-7e0e-4203-abf2-ae1917daad99"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dc26ecff-7e0e-4203-abf2-ae1917daad99"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

