### PR TITLE
fix(redis): add lindex to standard Redis adapter (Time Machine 500)

### DIFF
--- a/api/_utils/redis.ts
+++ b/api/_utils/redis.ts
@@ -69,6 +69,7 @@ export interface RedisLike {
   ltrim(key: string, start: number, stop: number): Promise<string>;
   lrem(key: string, count: number, value: string): Promise<number>;
   llen(key: string): Promise<number>;
+  lindex<T = unknown>(key: string, index: number): Promise<T | null>;
   mget<T = unknown>(...keys: string[]): Promise<(T | null)[]>;
   hincrby(key: string, field: string, increment: number): Promise<number>;
   hgetall<T = Record<string, string>>(key: string): Promise<T | null>;
@@ -356,6 +357,10 @@ class StandardRedisAdapter implements RedisLike {
 
   async llen(key: string): Promise<number> {
     return await this.client.llen(key);
+  }
+
+  async lindex<T = unknown>(key: string, index: number): Promise<T | null> {
+    return (await this.client.lindex(key, index)) as T | null;
   }
 
   async mget<T = unknown>(...keys: string[]): Promise<(T | null)[]> {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Problem

Opening the **Time Machine** in Internet Explorer and previewing any year that resolves to the AI cache (year `< 1996`, or any BC/CE year) returned an `HTTP 500` from `/api/iframe-check?mode=ai`:

```
{"error":"redis.lindex is not a function. (In 'redis.lindex(key, 0)', 'redis.lindex' is undefined)"}
```

Generating a page (`POST /api/ie-generate`) was fine because the write path only uses `lpush` / `ltrim`, which the standard Redis adapter already implements.

### Root cause

`api/iframe-check.ts` (AI cache mode) calls:

```ts
const html = (await redis.lindex(key, 0)) as string | null;
```

`lindex` exists on the Upstash REST client out of the box, but the `StandardRedisAdapter` in `api/_utils/redis.ts` (used when `REDIS_PROVIDER=redis-url`, i.e. self-host / Coolify / Docker / plain Bun deployments) was missing both the `RedisLike` interface entry and the implementation. The other list ops (`lpush`, `lrange`, `ltrim`, `lrem`, `llen`) were all present — `lindex` was simply overlooked when the adapter was added.

### Fix

Add `lindex` to both the `RedisLike` interface and `StandardRedisAdapter`, delegating to `ioredis.lindex`. Matches the shape of the existing `lrange` / `llen` wrappers.

```ts
async lindex<T = unknown>(key: string, index: number): Promise<T | null> {
  return (await this.client.lindex(key, index)) as T | null;
}
```

### Verification

Reproduced the 500 against production (`https://os.ryo.lu`):

```
$ curl 'https://os.ryo.lu/api/iframe-check?mode=ai&url=https%3A%2F%2Fryo.lu&year=500'
HTTP 500
{"error":"redis.lindex is not a function. ..."}
```

Then ran the standalone Bun API locally with `REDIS_PROVIDER=redis-url REDIS_URL=redis://127.0.0.1:6379/0` against a fresh `redis-server`, seeded one cached entry, and confirmed every Time Machine code path is healthy:

```
=== list-cache (https://example.com) ===
HTTP 200
{"years":["1995"]}

=== AI cache hit (year=1995) ===
HTTP 200
<!-- TITLE: Hello 1995 -->\n<h1>Hello from 1995</h1>

=== AI cache miss (year=500) ===
HTTP 404
{"aiCache":false}
```

### Testing

- ✅ `bun test tests/test-self-host-redis-config.test.ts tests/test-self-host-runtime-config.test.ts tests/test-self-host-storage-config.test.ts tests/test-iframe-check.test.ts` — 27/27 pass
- ✅ `bun run test:unit` — 236/236 pass
- ✅ Manual end-to-end against standalone Bun API + local `redis-server` (output above)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6C82A993-444F-43A8-8EEA-6FE596733AA2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6C82A993-444F-43A8-8EEA-6FE596733AA2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

