### PR TITLE
fix(desktop): fire right-click menu actions on touch pointerup

### DIFF
--- a/src/components/ui/right-click-menu.tsx
+++ b/src/components/ui/right-click-menu.tsx
@@ -9,7 +9,7 @@ import {
   DropdownMenuSubContent,
   DropdownMenuCheckboxItem,
 } from "@/components/ui/dropdown-menu";
-import { ReactNode, useEffect } from "react";
+import React, { MutableRefObject, ReactNode, useEffect, useRef } from "react";
 import { ThemedIcon } from "@/components/shared/ThemedIcon";
 import { useSound, Sounds } from "@/hooks/useSound";
 
@@ -79,8 +79,51 @@ function getMenuItemKey(item: MenuItem): string {
   return uniqueKey;
 }
 
+// Touch fallback: Radix MenuItem's onSelect relies on the browser firing a
+// synthesized `click` after pointerdown→pointerup. On touch devices (real iOS
+// Safari with `touch-action: none` on body, Chrome's mobile emulation, etc.)
+// that synthesized click is sometimes never dispatched — the user sees the
+// item highlight but onSelect never runs. We fire the action manually on
+// pointerup for touch/pen. A shared "lastFired" timestamp dedupes against any
+// late-arriving synthesized click that would otherwise re-trigger onSelect.
+const DOUBLE_FIRE_GUARD_MS = 500;
+
+function makeTouchSelectHandler(
+  onSelect: (() => void) | undefined,
+  onClose: () => void,
+  lastFiredRef: MutableRefObject<number>
+) {
+  if (!onSelect) return undefined;
+  return (event: React.PointerEvent<HTMLDivElement>) => {
+    if (event.pointerType !== "touch" && event.pointerType !== "pen") return;
+    const now = performance.now();
+    if (now - lastFiredRef.current < DOUBLE_FIRE_GUARD_MS) return;
+    lastFiredRef.current = now;
+    event.preventDefault();
+    onSelect();
+    onClose();
+  };
+}
+
+function makeGuardedSelect(
+  onSelect: (() => void) | undefined,
+  lastFiredRef: MutableRefObject<number>
+) {
+  if (!onSelect) return undefined;
+  return () => {
+    const now = performance.now();
+    if (now - lastFiredRef.current < DOUBLE_FIRE_GUARD_MS) return;
+    lastFiredRef.current = now;
+    onSelect();
+  };
+}
+
 // ------------------ Renderer helpers ------------------
-function renderItems(items: MenuItem[]): ReactNode {
+function renderItems(
+  items: MenuItem[],
+  onClose: () => void,
+  lastFiredRef: MutableRefObject<number>
+): ReactNode {
   return items.map((item) => {
     const itemKey = getMenuItemKey(item);
     switch (item.type) {
@@ -88,7 +131,12 @@ function renderItems(items: MenuItem[]): ReactNode {
         return (
           <DropdownMenuItem
             key={itemKey}
-            onSelect={item.onSelect}
+            onSelect={makeGuardedSelect(item.onSelect, lastFiredRef)}
+            onPointerUp={makeTouchSelectHandler(
+              item.onSelect,
+              onClose,
+              lastFiredRef
+            )}
             disabled={item.disabled}
             className={menuItemClass}
           >
@@ -135,7 +183,7 @@ function renderItems(items: MenuItem[]): ReactNode {
               <span>{item.label}</span>
             </DropdownMenuSubTrigger>
             <DropdownMenuSubContent className="px-0">
-              {renderItems(item.items)}
+              {renderItems(item.items, onClose, lastFiredRef)}
             </DropdownMenuSubContent>
           </DropdownMenuSub>
         );
@@ -144,7 +192,12 @@ function renderItems(items: MenuItem[]): ReactNode {
           <DropdownMenuCheckboxItem
             key={itemKey}
             checked={item.checked}
-            onSelect={item.onSelect}
+            onSelect={makeGuardedSelect(item.onSelect, lastFiredRef)}
+            onPointerUp={makeTouchSelectHandler(
+              item.onSelect,
+              onClose,
+              lastFiredRef
+            )}
             disabled={item.disabled}
             className="text-md h-6 min-w-[140px]"
           >
@@ -153,21 +206,27 @@ function renderItems(items: MenuItem[]): ReactNode {
         );
       case "radioGroup":
         return (
-          <>
+          <React.Fragment key={itemKey}>
             {item.items.map((ri) => {
               const isActive = item.value === ri.value;
+              const handleSelect = () => item.onChange(ri.value);
               return (
                 <DropdownMenuCheckboxItem
                   key={ri.value}
                   checked={isActive}
-                  onSelect={() => item.onChange(ri.value)}
+                  onSelect={makeGuardedSelect(handleSelect, lastFiredRef)}
+                  onPointerUp={makeTouchSelectHandler(
+                    handleSelect,
+                    onClose,
+                    lastFiredRef
+                  )}
                   className="text-md h-6 min-w-[140px]"
                 >
                   {ri.label}
                 </DropdownMenuCheckboxItem>
               );
             })}
-          </>
+          </React.Fragment>
         );
       default:
         return null;
@@ -183,10 +242,11 @@ export function RightClickMenu({
   align = "start",
 }: RightClickMenuProps) {
   const { play: playMenuOpen } = useSound(Sounds.MENU_OPEN);
+  const lastFiredRef = useRef(0);
 
-  // Play open sound when menu appears
   useEffect(() => {
     if (position) {
+      lastFiredRef.current = 0;
       playMenuOpen();
     }
   }, [position, playMenuOpen]);
@@ -212,7 +272,7 @@ export function RightClickMenu({
         alignOffset={4}
         className="px-0"
       >
-        {renderItems(items)}
+        {renderItems(items, onClose, lastFiredRef)}
       </DropdownMenuContent>
     </DropdownMenu>
   );


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Long-pressing the desktop on mobile opens the right-click menu (Sort By / Empty Trash / Set Wallpaper…) but tapping any item only highlights it — `onSelect` never runs, so nothing happens.

## Root cause

Radix `DropdownMenu.Item`'s `onSelect` chain runs from `onClick`, which the browser is supposed to synthesize after `pointerdown → pointerup`. On touch devices — real iOS Safari with `touch-action: none` on `body` (set globally in `src/index.css`), Chrome's mobile-emulation, etc. — that synthesized click is sometimes never dispatched. The user sees the item highlight via `:active` / `data-highlighted` but `onSelect` never fires.

## Fix

In `RightClickMenu`, wire an `onPointerUp` handler on `item` / `checkbox` / `radioGroup` rows that, when `pointerType` is `touch` or `pen`:

1. `preventDefault()` and explicitly invokes `onSelect`
2. Calls `onClose()` so the menu unmounts immediately

A shared `lastFiredRef` timestamp (500 ms window) dedupes against any late-arriving synthesized click that would otherwise re-trigger `onSelect`. Mouse and keyboard paths continue through Radix's normal chain unchanged. The ref resets each time the menu re-opens.

## Scope

- `src/components/ui/right-click-menu.tsx` only — fixes every right-click / long-press menu in the OS shell (Desktop, Dock, Finder, …) without touching call sites.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-FD54D8F9-51DD-47A0-AFBD-943B27A5F883"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-FD54D8F9-51DD-47A0-AFBD-943B27A5F883"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

