### PR TITLE
Fix karaoke lyrics offset when iPod uses Apple Music library

### DIFF
--- a/src/apps/karaoke/hooks/useKaraokeLogic.ts
+++ b/src/apps/karaoke/hooks/useKaraokeLogic.ts
@@ -86,7 +86,6 @@ export function useKaraokeLogic({
     refreshLyrics,
     setTrackLyricsSource,
     clearTrackLyricsSource,
-    setLyricOffset,
     addTrackFromVideoId,
   } = useIpodStoreShallow((s) => ({
     setLyricsAlignment: s.setLyricsAlignment,
@@ -98,7 +97,6 @@ export function useKaraokeLogic({
     refreshLyrics: s.refreshLyrics,
     setTrackLyricsSource: s.setTrackLyricsSource,
     clearTrackLyricsSource: s.clearTrackLyricsSource,
-    setLyricOffset: s.setLyricOffset,
     addTrackFromVideoId: s.addTrackFromVideoId,
   }));
 
@@ -1571,7 +1569,7 @@ export function useKaraokeLogic({
       } else if (e.key === "[" || e.key === "]") {
         // Offset adjustment: [ = lyrics earlier (negative), ] = lyrics later (positive)
         const delta = e.key === "[" ? -50 : 50;
-        useIpodStore.getState().adjustLyricOffset(currentIndex, delta);
+        useIpodStore.getState().adjustLyricOffset(currentIndex, delta, "youtube");
         const newOffset = (currentTrack?.lyricOffset ?? 0) + delta;
         const sign = newOffset > 0 ? "+" : newOffset < 0 ? "" : "";
         showStatus(`${t("apps.ipod.status.offset")} ${sign}${(newOffset / 1000).toFixed(2)}s`);
@@ -1872,11 +1870,13 @@ export function useKaraokeLogic({
     handleCoverFlowPlayInPlace,
     handleCoverFlowRotation,
     clearLibrary,
-    setLyricOffset,
+    setLyricOffset: (index: number, offsetMs: number) => {
+      useIpodStore.getState().setLyricOffset(index, offsetMs, "youtube");
+    },
     isXpTheme,
     getCurrentKaraokeTrack,
     adjustLyricOffset: (index: number, delta: number) => {
-      useIpodStore.getState().adjustLyricOffset(index, delta);
+      useIpodStore.getState().adjustLyricOffset(index, delta, "youtube");
     },
   };
 }

--- a/src/stores/useIpodStore.ts
+++ b/src/stores/useIpodStore.ts
@@ -529,9 +529,17 @@ export interface IpodState extends IpodData {
   /** Set the furigana map for current lyrics */
   setCurrentFuriganaMap: (map: Record<string, FuriganaSegment[]> | null) => void;
   /** Adjust the lyric offset (in ms) for the track at the given index. */
-  adjustLyricOffset: (trackIndex: number, deltaMs: number) => void;
+  adjustLyricOffset: (
+    trackIndex: number,
+    deltaMs: number,
+    library?: IpodLibrarySelection
+  ) => void;
   /** Set the lyric offset (in ms) for the track at the given index to an absolute value. */
-  setLyricOffset: (trackIndex: number, offsetMs: number) => void;
+  setLyricOffset: (
+    trackIndex: number,
+    offsetMs: number,
+    library?: IpodLibrarySelection
+  ) => void;
   /** Set lyrics alignment mode */
   setLyricsAlignment: (alignment: LyricsAlignment) => void;
   /** Set lyrics font style */
@@ -1380,13 +1388,12 @@ export const useIpodStore = create<IpodState>()(
         }));
       },
       setCurrentFuriganaMap: (map) => set({ currentFuriganaMap: map }),
-      adjustLyricOffset: (trackIndex, deltaMs) => {
+      adjustLyricOffset: (trackIndex, deltaMs, library = "active") => {
         // Validate before calling set() to avoid unnecessary state updates
         const state = get();
-        const sourceTracks =
-          state.librarySource === "appleMusic"
-            ? state.appleMusicTracks
-            : state.tracks;
+        const resolvedLibrary =
+          library === "active" ? state.librarySource : library;
+        const sourceTracks = getIpodTracksForLibrary(state, library);
         if (
           trackIndex < 0 ||
           trackIndex >= sourceTracks.length ||
@@ -1398,7 +1405,7 @@ export const useIpodStore = create<IpodState>()(
         const current = sourceTracks[trackIndex];
         const newOffset = (current.lyricOffset || 0) + deltaMs;
 
-        if (state.librarySource === "appleMusic") {
+        if (resolvedLibrary === "appleMusic") {
           set((s) => ({
             appleMusicTracks: s.appleMusicTracks.map((track, i) =>
               i === trackIndex ? { ...track, lyricOffset: newOffset } : track
@@ -1416,13 +1423,12 @@ export const useIpodStore = create<IpodState>()(
         // and Apple Music (`am:<id>`) keys via the relaxed validator.
         debouncedSaveLyricOffset(current.id, newOffset);
       },
-      setLyricOffset: (trackIndex, offsetMs) => {
+      setLyricOffset: (trackIndex, offsetMs, library = "active") => {
         // Validate before calling set() to avoid unnecessary state updates
         const state = get();
-        const sourceTracks =
-          state.librarySource === "appleMusic"
-            ? state.appleMusicTracks
-            : state.tracks;
+        const resolvedLibrary =
+          library === "active" ? state.librarySource : library;
+        const sourceTracks = getIpodTracksForLibrary(state, library);
         if (
           trackIndex < 0 ||
           trackIndex >= sourceTracks.length ||
@@ -1433,7 +1439,7 @@ export const useIpodStore = create<IpodState>()(
 
         const trackId = sourceTracks[trackIndex].id;
 
-        if (state.librarySource === "appleMusic") {
+        if (resolvedLibrary === "appleMusic") {
           set((s) => ({
             appleMusicTracks: s.appleMusicTracks.map((track, i) =>
               i === trackIndex ? { ...track, lyricOffset: offsetMs } : track

--- a/tests/test-ipod-apple-music.test.ts
+++ b/tests/test-ipod-apple-music.test.ts
@@ -505,6 +505,58 @@ describe("useIpodStore Apple Music slice", () => {
     expect(useIpodStore.getState().tracks).toEqual([]);
   });
 
+  test("adjustLyricOffset with youtube library updates YouTube slice while Apple Music is active", () => {
+    useIpodStore.setState({
+      tracks: [
+        {
+          id: "yt1",
+          url: "https://www.youtube.com/watch?v=yt1",
+          title: "YouTube One",
+          lyricOffset: 100,
+        },
+      ],
+      appleMusicTracks: [
+        {
+          id: "am:1",
+          url: "applemusic:1",
+          title: "Apple One",
+          source: "appleMusic",
+          lyricOffset: 0,
+        },
+      ],
+      librarySource: "appleMusic",
+    });
+    useIpodStore.getState().adjustLyricOffset(0, 50, "youtube");
+    expect(useIpodStore.getState().tracks[0].lyricOffset).toBe(150);
+    expect(useIpodStore.getState().appleMusicTracks[0].lyricOffset).toBe(0);
+  });
+
+  test("setLyricOffset with youtube library updates YouTube slice while Apple Music is active", () => {
+    useIpodStore.setState({
+      tracks: [
+        {
+          id: "yt1",
+          url: "https://www.youtube.com/watch?v=yt1",
+          title: "YouTube One",
+          lyricOffset: 100,
+        },
+      ],
+      appleMusicTracks: [
+        {
+          id: "am:1",
+          url: "applemusic:1",
+          title: "Apple One",
+          source: "appleMusic",
+          lyricOffset: 500,
+        },
+      ],
+      librarySource: "appleMusic",
+    });
+    useIpodStore.getState().setLyricOffset(0, 900, "youtube");
+    expect(useIpodStore.getState().tracks[0].lyricOffset).toBe(900);
+    expect(useIpodStore.getState().appleMusicTracks[0].lyricOffset).toBe(500);
+  });
+
   test("setAppleMusicTracks preserves active contextual queue tracks", () => {
     useIpodStore.setState({
       appleMusicTracks: [


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Karaoke always reads and plays from the YouTube track list (`useIpodStore.tracks`), but lyric offset adjustments (`adjustLyricOffset` / `setLyricOffset`) followed the iPod **active** `librarySource`. With Apple Music selected in iPod, `[` / `]`, sync mode, and drag offset updates could modify `appleMusicTracks[index]` instead of the YouTube track Karaoke was actually playing—causing lyrics to appear out of sync.

## Solution

- Add optional `library` parameter to `adjustLyricOffset` and `setLyricOffset` (defaults to `"active"` for iPod behavior).
- Route all Karaoke offset paths through `"youtube"` explicitly (keyboard, sync mode, lyrics overlays).

## Testing

- `bun test tests/test-ipod-apple-music.test.ts` — new cases verify YouTube offsets update while Apple Music is active; existing Apple Music active-source test unchanged.
- `bun test tests/test-karaoke-title-card.test.ts tests/test-karaoke-interlude-display.test.ts`

## Regression notes

- iPod offset behavior unchanged (still uses active library by default).
- `karaokeControl` already used YouTube tracks; no change needed there.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0b1f3c06-bbdf-4444-ad66-7f3afe8f9762"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0b1f3c06-bbdf-4444-ad66-7f3afe8f9762"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

