### PR TITLE
Fix misheard lyrics loading stuck state

### DIFF
--- a/api/songs/[id].ts
+++ b/api/songs/[id].ts
@@ -90,6 +90,12 @@ import {
 
 import { streamText } from "ai";
 import { openai } from "@ai-sdk/openai";
+import {
+  FURIGANA_STREAM_MODEL,
+  SORAMIMI_STREAM_MODEL,
+  TRANSLATE_STREAM_MODEL,
+  withStreamChunkTimeout,
+} from "./_streamModels.js";
 
 export const runtime = "nodejs";
 /** Soramimi/furigana/translate streams can run long on full songs (gpt-5.5). */
@@ -944,7 +950,7 @@ export default apiHandler<Record<string, unknown>>(
 
           // Use streamText with GPT-5.2
           const result = streamText({
-            model: openai("gpt-5.5"),
+            model: openai(TRANSLATE_STREAM_MODEL),
             messages: [
               { role: "system", content: getTranslationSystemPrompt(language) },
               { role: "user", content: textsToProcess },
@@ -952,11 +958,13 @@ export default apiHandler<Record<string, unknown>>(
             temperature: 0.3,
           });
 
-          // Manually iterate textStream to process and emit custom events
-          for await (const textChunk of result.textStream) {
+          for await (const textChunk of withStreamChunkTimeout(
+            result.textStream,
+            undefined,
+            "Translation stream"
+          )) {
             currentLineBuffer += textChunk;
             
-            // Process complete lines
             let newlineIdx;
             while ((newlineIdx = currentLineBuffer.indexOf("\n")) !== -1) {
               const completeLine = currentLineBuffer.slice(0, newlineIdx);
@@ -965,7 +973,6 @@ export default apiHandler<Record<string, unknown>>(
             }
           }
           
-          // Process any remaining buffer
           if (currentLineBuffer.trim()) {
             processLine(currentLineBuffer);
           }
@@ -1172,7 +1179,7 @@ export default apiHandler<Record<string, unknown>>(
           };
 
           const result = streamText({
-            model: openai("gpt-5.5"),
+            model: openai(FURIGANA_STREAM_MODEL),
             messages: [
               { role: "system", content: FURIGANA_STREAM_SYSTEM_PROMPT },
               { role: "user", content: textsToProcess },
@@ -1180,11 +1187,13 @@ export default apiHandler<Record<string, unknown>>(
             temperature: 0.1,
           });
 
-          // Manually iterate textStream to process and emit custom events
-          for await (const textChunk of result.textStream) {
+          for await (const textChunk of withStreamChunkTimeout(
+            result.textStream,
+            undefined,
+            "Furigana stream"
+          )) {
             currentLineBuffer += textChunk;
             
-            // Process complete lines
             let newlineIdx;
             while ((newlineIdx = currentLineBuffer.indexOf("\n")) !== -1) {
               const completeLine = currentLineBuffer.slice(0, newlineIdx);
@@ -1193,7 +1202,6 @@ export default apiHandler<Record<string, unknown>>(
             }
           }
           
-          // Process any remaining buffer
           if (currentLineBuffer.trim()) {
             processLine(currentLineBuffer);
           }
@@ -1466,7 +1474,7 @@ export default apiHandler<Record<string, unknown>>(
 
           // Use streamText
           const result = streamText({
-            model: openai("gpt-5.5"),
+            model: openai(SORAMIMI_STREAM_MODEL),
             messages: [
               { role: "system", content: systemPrompt },
               { role: "user", content: textsToProcess },
@@ -1474,11 +1482,15 @@ export default apiHandler<Record<string, unknown>>(
             temperature: 0.7,
           });
 
-          // Manually iterate textStream to process and emit custom events
-          for await (const textChunk of result.textStream) {
+          logger.info("Soramimi streamText model", { model: SORAMIMI_STREAM_MODEL });
+
+          for await (const textChunk of withStreamChunkTimeout(
+            result.textStream,
+            undefined,
+            "Soramimi stream"
+          )) {
             currentLineBuffer += textChunk;
             
-            // Process complete lines
             let newlineIdx;
             while ((newlineIdx = currentLineBuffer.indexOf("\n")) !== -1) {
               const completeLine = currentLineBuffer.slice(0, newlineIdx);
@@ -1487,7 +1499,6 @@ export default apiHandler<Record<string, unknown>>(
             }
           }
           
-          // Process any remaining buffer
           if (currentLineBuffer.trim()) {
             processLine(currentLineBuffer);
           }

--- a/api/songs/[id].ts
+++ b/api/songs/[id].ts
@@ -92,7 +92,8 @@ import { streamText } from "ai";
 import { openai } from "@ai-sdk/openai";
 
 export const runtime = "nodejs";
-export const maxDuration = 120;
+/** Soramimi/furigana/translate streams can run long on full songs (gpt-5.5). */
+export const maxDuration = 300;
 
 // Helper for SSE responses with Node.js VercelResponse
 function sendSSEResponse(res: VercelResponse, origin: string | null, data: unknown): void {

--- a/api/songs/_streamModels.ts
+++ b/api/songs/_streamModels.ts
@@ -24,15 +24,18 @@ export async function* withStreamChunkTimeout<T>(
 ): AsyncGenerator<T> {
   const iterator = source[Symbol.asyncIterator]();
   while (true) {
+    let timer: ReturnType<typeof setTimeout> | undefined;
     const next = await Promise.race([
       iterator.next(),
       new Promise<IteratorResult<T>>((_, reject) => {
-        setTimeout(
+        timer = setTimeout(
           () => reject(new Error(`${label} timed out waiting for data`)),
           timeoutMs
         );
       }),
-    ]);
+    ]).finally(() => {
+      if (timer !== undefined) clearTimeout(timer);
+    });
     if (next.done) {
       return;
     }

--- a/api/songs/_streamModels.ts
+++ b/api/songs/_streamModels.ts
@@ -1,0 +1,41 @@
+/**
+ * OpenAI models for lyrics annotation SSE streams (furigana / soramimi / translate).
+ * Override via env for experiments — soramimi defaults to gpt-5.4 after gpt-5.5 stall reports.
+ */
+export const FURIGANA_STREAM_MODEL =
+  process.env.FURIGANA_STREAM_MODEL?.trim() || "gpt-5.4";
+
+export const SORAMIMI_STREAM_MODEL =
+  process.env.SORAMIMI_STREAM_MODEL?.trim() || "gpt-5.4";
+
+export const TRANSLATE_STREAM_MODEL =
+  process.env.TRANSLATE_STREAM_MODEL?.trim() || "gpt-5.5";
+
+/** Abort if streamText yields no chunks for this long (prevents hung SSE). */
+export const STREAM_TEXT_CHUNK_TIMEOUT_MS = 90_000;
+
+/**
+ * Wrap an async iterable with a per-chunk timeout so hung model streams fail fast.
+ */
+export async function* withStreamChunkTimeout<T>(
+  source: AsyncIterable<T>,
+  timeoutMs: number = STREAM_TEXT_CHUNK_TIMEOUT_MS,
+  label = "Model stream"
+): AsyncGenerator<T> {
+  const iterator = source[Symbol.asyncIterator]();
+  while (true) {
+    const next = await Promise.race([
+      iterator.next(),
+      new Promise<IteratorResult<T>>((_, reject) => {
+        setTimeout(
+          () => reject(new Error(`${label} timed out waiting for data`)),
+          timeoutMs
+        );
+      }),
+    ]);
+    if (next.done) {
+      return;
+    }
+    yield next.value;
+  }
+}

--- a/src/apps/ipod/hooks/useIpodLogic.ts
+++ b/src/apps/ipod/hooks/useIpodLogic.ts
@@ -4973,6 +4973,7 @@ export function useIpodLogic({
     isFetchingSoramimi,
     furiganaProgress,
     soramimiProgress,
+    soramimiError,
   } = useFurigana({
     songId: lyricsSongId,
     lines: fullScreenLyricsControls.originalLines,
@@ -4995,6 +4996,7 @@ export function useIpodLogic({
       furiganaProgress,
       isFetchingSoramimi,
       soramimiProgress,
+      soramimiError: soramimiError ?? null,
     },
     translationLanguage: effectiveTranslationLanguage,
     isAddingSong,

--- a/src/apps/karaoke/components/KaraokeLyricsPlayback.tsx
+++ b/src/apps/karaoke/components/KaraokeLyricsPlayback.tsx
@@ -137,6 +137,7 @@ export function KaraokeLyricsPlaybackProvider({
     isFetchingSoramimi,
     furiganaProgress,
     soramimiProgress,
+    soramimiError,
   } = useFurigana({
     songId: currentTrack?.id ?? "",
     lines: lyricsControls.originalLines,
@@ -158,6 +159,7 @@ export function KaraokeLyricsPlaybackProvider({
       furiganaProgress,
       isFetchingSoramimi,
       soramimiProgress,
+      soramimiError: soramimiError ?? null,
     },
     translationLanguage: effectiveTranslationLanguage,
     isAddingSong,

--- a/src/components/ui/activity-indicator-with-label.tsx
+++ b/src/components/ui/activity-indicator-with-label.tsx
@@ -30,7 +30,7 @@ export function ActivityIndicatorWithLabel({
   showLabel = true,
 }: ActivityIndicatorWithLabelProps) {
   const { t } = useTranslation();
-  const { isActive, label } = getActivityLabel(state, t);
+  const { isActive, label, isError } = getActivityLabel(state, t);
 
   if (!isActive) {
     return null;
@@ -41,7 +41,8 @@ export function ActivityIndicatorWithLabel({
       {showLabel && label && (
         <span
           className={cn(
-            "font-geneva-12 text-white whitespace-nowrap",
+            "font-geneva-12 whitespace-nowrap",
+            isError ? "text-amber-200/95" : "text-white",
             "drop-shadow-[0_1px_2px_rgba(0,0,0,0.9)]",
             "[text-shadow:_0_1px_0_rgba(0,0,0,0.8),_0_-1px_0_rgba(0,0,0,0.8),_1px_0_0_rgba(0,0,0,0.8),_-1px_0_0_rgba(0,0,0,0.8)]",
             labelClassName
@@ -50,10 +51,12 @@ export function ActivityIndicatorWithLabel({
           {label}
         </span>
       )}
-      <ActivityIndicator
-        size={size}
-        className="text-white drop-shadow-[0_2px_4px_rgba(0,0,0,0.8)] flex-shrink-0"
-      />
+      {!isError && (
+        <ActivityIndicator
+          size={size}
+          className="text-white drop-shadow-[0_2px_4px_rgba(0,0,0,0.8)] flex-shrink-0"
+        />
+      )}
     </div>
   );
 }

--- a/src/hooks/useActivityLabel.ts
+++ b/src/hooks/useActivityLabel.ts
@@ -27,6 +27,8 @@ export interface ActivityInfo {
   furiganaProgress?: number;
   isFetchingSoramimi?: boolean;
   soramimiProgress?: number;
+  /** Shown when misheard lyrics failed (non-blocking; no spinner) */
+  soramimiError?: string | null;
   isAddingSong?: boolean;
 }
 
@@ -35,6 +37,8 @@ export interface ActivityLabelResult {
   isActive: boolean;
   /** Label to display (e.g., "45% English") */
   label: string | null;
+  /** When true, show label only (no spinner) — e.g. soramimi fetch error */
+  isError?: boolean;
 }
 
 /** Translation function type */
@@ -56,17 +60,41 @@ export function getActivityLabel(info: ActivityInfo, t?: TranslationFn): Activit
     furiganaProgress,
     isFetchingSoramimi,
     soramimiProgress,
+    soramimiError,
     isAddingSong,
   } = info;
 
-  const isActive = !!(isLoadingLyrics || isTranslating || isFetchingFurigana || isFetchingSoramimi || isAddingSong);
+  const translate = (key: string, fallback: string) =>
+    t ? t(key, { defaultValue: fallback }) : fallback;
+
+  const soramimiErrorLabel =
+    soramimiError && !isFetchingSoramimi
+      ? translate("common.activity.soramimiError", "Misheard unavailable")
+      : null;
+
+  const isActive = !!(
+    isLoadingLyrics ||
+    isTranslating ||
+    isFetchingFurigana ||
+    isFetchingSoramimi ||
+    isAddingSong ||
+    soramimiErrorLabel
+  );
   
   if (!isActive) {
     return { isActive: false, label: null };
   }
 
-  // Helper to translate or return fallback
-  const translate = (key: string, fallback: string) => t ? t(key, { defaultValue: fallback }) : fallback;
+  if (
+    soramimiErrorLabel &&
+    !isLoadingLyrics &&
+    !isTranslating &&
+    !isFetchingFurigana &&
+    !isFetchingSoramimi &&
+    !isAddingSong
+  ) {
+    return { isActive: true, label: soramimiErrorLabel, isError: true };
+  }
 
   let label: string | null = null;
 

--- a/src/hooks/useActivityState.ts
+++ b/src/hooks/useActivityState.ts
@@ -16,6 +16,7 @@ export interface UseFuriganaState {
   furiganaProgress?: number;
   isFetchingSoramimi: boolean;
   soramimiProgress?: number;
+  soramimiError?: string | null;
 }
 
 export interface UseActivityStateParams {
@@ -58,6 +59,7 @@ export function useActivityState({
       furiganaProgress: furiganaState.furiganaProgress,
       isFetchingSoramimi: furiganaState.isFetchingSoramimi,
       soramimiProgress: furiganaState.soramimiProgress,
+      soramimiError: furiganaState.soramimiError ?? null,
       isAddingSong,
     }),
     [
@@ -69,6 +71,7 @@ export function useActivityState({
       furiganaState.furiganaProgress,
       furiganaState.isFetchingSoramimi,
       furiganaState.soramimiProgress,
+      furiganaState.soramimiError,
       isAddingSong,
     ]
   );

--- a/src/hooks/useFurigana.tsx
+++ b/src/hooks/useFurigana.tsx
@@ -213,6 +213,15 @@ export function useFurigana({
   } | null>(null);
 
   const prefetchedSoramimiInfoRef = useLatestRef(prefetchedSoramimiInfo);
+  const prefetchedFuriganaInfoRef = useLatestRef(prefetchedInfo);
+
+  const abortActiveFuriganaRequest = useCallback(() => {
+    const active = furiganaForceRequestRef.current;
+    if (active && !active.controller.signal.aborted) {
+      active.controller.abort();
+    }
+    furiganaForceRequestRef.current = null;
+  }, []);
 
   const abortActiveSoramimiRequest = useCallback(() => {
     const active = soramimiForceRequestRef.current;
@@ -231,19 +240,22 @@ export function useFurigana({
     onLoadingChangeRef.current?.(isFetchingFurigana || isFetchingSoramimi);
   }, [isFetchingFurigana, isFetchingSoramimi, onLoadingChangeRef]);
 
-  // Compute cache key outside effect - only when lines actually change
+  // Content signature (not array reference) so effects don't restart on parent re-renders
+  const linesSignature =
+    lines.length === 0
+      ? ""
+      : lines.map((l) => `${l.startTimeMs}:${l.words.slice(0, 20)}`).join("|");
+
   const cacheKey = useMemo(() => {
-    if (!songId || lines.length === 0) return "";
-    return `song:${songId}:` + lines.map((l) => `${l.startTimeMs}:${l.words.slice(0, 20)}`).join("|");
-  }, [songId, lines]);
-  
-  // Compute soramimi-specific cache key that includes target language
-  // This ensures switching between Chinese and English soramimi triggers a refetch
+    if (!songId || !linesSignature) return "";
+    return `song:${songId}:${linesSignature}`;
+  }, [songId, linesSignature]);
+
   const soramimiTargetLanguage = romanization.soramamiTargetLanguage;
   const soramimiCacheKey = useMemo(() => {
-    if (!songId || lines.length === 0) return "";
+    if (!cacheKey) return "";
     return `${cacheKey}:soramimi:${soramimiTargetLanguage}`;
-  }, [cacheKey, songId, lines.length, soramimiTargetLanguage]);
+  }, [cacheKey, soramimiTargetLanguage]);
 
   // Clear force request refs when songId changes to prevent cross-song pollution
   useEffect(() => {
@@ -286,101 +298,93 @@ export function useFurigana({
 
     // If completely disabled, no songId, or no lines, handle cleanup
     if (!effectSongId || !shouldFetchFurigana || !hasLines) {
-      // Only clear cache if songId actually changed (not just temporarily empty lines during re-fetch)
+      abortActiveFuriganaRequest();
       const songChanged = effectSongId !== lastFuriganaSongIdRef.current;
       if (songChanged && furiganaCacheKeyRef.current !== "") {
         setFuriganaMap(new Map());
         furiganaCacheKeyRef.current = "";
         lastFuriganaSongIdRef.current = effectSongId || "";
-        setIsFetchingFurigana(false);
-        setProgress(undefined);
-        setError(undefined);
-        // Mark handled to keep ref in sync for next song
         markFuriganaHandled();
       }
+      finishFuriganaFetch();
+      setError(undefined);
       return;
     }
     
-    // Update last songId when we have data
     lastFuriganaSongIdRef.current = effectSongId;
 
-    // If not showing original, don't fetch new data but keep existing furigana cached
     if (!isShowingOriginal) {
-      setIsFetchingFurigana(false);
+      abortActiveFuriganaRequest();
+      finishFuriganaFetch();
       return;
     }
 
-    // Check if any lines are Japanese text (has both kanji and kana)
     const hasJapanese = lines.some((line) => isJapaneseText(line.words));
     if (!hasJapanese) {
+      abortActiveFuriganaRequest();
       setFuriganaMap(new Map());
-      furiganaCacheKeyRef.current = "";  // Clear cache key to prevent stale cache detection
-      setIsFetchingFurigana(false);
-      setProgress(undefined);
+      furiganaCacheKeyRef.current = "";
+      finishFuriganaFetch();
       setError(undefined);
-      // Mark handled even when skipping to keep ref in sync for next song
       markFuriganaHandled();
       return;
     }
 
-    // Check if offline
     if (isOffline()) {
+      abortActiveFuriganaRequest();
+      finishFuriganaFetch();
       setError("iPod requires an internet connection");
-      setIsFetchingFurigana(false);
       return;
     }
 
-    // Skip if we already have this data and it's not a force request
     if (!isFuriganaForceRequest && cacheKey === furiganaCacheKeyRef.current) {
+      finishFuriganaFetch();
       return;
     }
 
-    // If we have cached furigana from initial fetch, use it immediately
-    if (prefetchedInfo?.cached && prefetchedInfo.data && !isFuriganaForceRequest) {
+    const prefetchedFurigana = prefetchedFuriganaInfoRef.current;
+    if (prefetchedFurigana?.cached && prefetchedFurigana.data && !isFuriganaForceRequest) {
+      abortActiveFuriganaRequest();
       const finalMap = new Map<string, FuriganaSegment[]>();
-      prefetchedInfo.data.forEach((segments, index) => {
+      prefetchedFurigana.data.forEach((segments, index) => {
         if (index < lines.length && segments) {
           finalMap.set(lines[index].startTimeMs, normalizeClientFuriganaSegments(segments));
         }
       });
       setFuriganaMap(finalMap);
       furiganaCacheKeyRef.current = cacheKey;
-      setIsFetchingFurigana(false);
+      finishFuriganaFetch();
       return;
     }
 
-    // If there's already a request in flight for this song, skip this effect run
-    // This prevents duplicate requests when React re-runs the effect
-    const existingReq = furiganaForceRequestRef.current;
-    if (existingReq && !existingReq.controller.signal.aborted) {
-      return;
-    }
-    // Clear stale aborted ref so we can start fresh
-    if (existingReq?.controller.signal.aborted) {
-      furiganaForceRequestRef.current = null;
-    }
+    abortActiveFuriganaRequest();
 
-    // Generate a unique requestId for this effect run
     const requestId = `${effectSongId}-${lyricsCacheBustTrigger}-${Date.now()}`;
+    let timedOut = false;
 
-    // Start loading
     setIsFetchingFurigana(true);
     setProgress(0);
     setFuriganaProgress(0);
     setError(undefined);
     
     const controller = new AbortController();
+    const timeoutId = window.setTimeout(() => {
+      timedOut = true;
+      controller.abort();
+    }, SORAMIMI_FETCH_TIMEOUT_MS);
 
-    // Track this request so we can detect duplicates
     furiganaForceRequestRef.current = { controller, requestId };
 
-    // Use line-by-line streaming for furigana
     const progressiveMap = new Map<string, FuriganaSegment[]>();
     
+    if (import.meta.env.DEV) {
+      console.log("[Furigana] Starting SSE", { songId: effectSongId, lines: lines.length });
+    }
+
     processFuriganaSSE(effectSongId, {
       force: isFuriganaForceRequest,
       signal: controller.signal,
-      prefetchedInfo: !isFuriganaForceRequest ? prefetchedInfo : undefined,
+      prefetchedInfo: !isFuriganaForceRequest ? prefetchedFurigana : undefined,
       auth,
       onProgress: (progress) => {
         if (!controller.signal.aborted) {
@@ -431,6 +435,9 @@ export function useFurigana({
         if (effectSongId !== currentSongIdRef.current) return;
         
         if (err instanceof Error && err.name === "AbortError") {
+          if (timedOut) {
+            setError(i18n.t("common.errors.failedToFetchFurigana"));
+          }
           return;
         }
 
@@ -438,31 +445,29 @@ export function useFurigana({
         setError(err instanceof Error ? err.message : i18n.t("common.errors.failedToFetchFurigana"));
       })
       .finally(() => {
-        // Clear force request ref when this request completes
+        window.clearTimeout(timeoutId);
         if (furiganaForceRequestRef.current?.requestId === requestId) {
           furiganaForceRequestRef.current = null;
         }
 
-        if (!controller.signal.aborted && effectSongId === currentSongIdRef.current) {
-          setIsFetchingFurigana(false);
-          setProgress(undefined);
-          setFuriganaProgress(undefined);
+        if (effectSongId === currentSongIdRef.current) {
+          finishFuriganaFetch();
         }
       });
 
     return () => {
-      // Always abort this request on cleanup - this controller is scoped to this effect run
+      window.clearTimeout(timeoutId);
       controller.abort();
-      // Only clear the ref if this is still the current request
       const isThisRequest = furiganaForceRequestRef.current?.requestId === requestId;
       if (isThisRequest) {
         furiganaForceRequestRef.current = null;
       }
-      setIsFetchingFurigana(false);
-      setFuriganaProgress(undefined);
+      if (effectSongId === currentSongIdRef.current) {
+        finishFuriganaFetch();
+      }
     };
-  // eslint-disable-next-line react-hooks/exhaustive-deps -- cacheKey captures lines content, shouldFetchFurigana captures romanization settings
-  }, [songId, cacheKey, shouldFetchFurigana, hasLines, isShowingOriginal, lyricsCacheBustTrigger, prefetchedInfo]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- cacheKey uses linesSignature; prefetched furigana read via ref
+  }, [songId, cacheKey, shouldFetchFurigana, hasLines, isShowingOriginal, lyricsCacheBustTrigger, finishFuriganaFetch, abortActiveFuriganaRequest]);
 
   // Check conditions for soramimi fetching
   const shouldFetchSoramimi = romanization.enabled && romanization.soramimi;
@@ -473,7 +478,10 @@ export function useFurigana({
   // Determine if lyrics are Japanese (have both kanji and kana)
   // For Japanese songs, we need to wait for furigana to complete before fetching soramimi
   // so we can pass the furigana readings to help the AI know how to pronounce kanji
-  const isJapanese = useMemo(() => lyricsHaveJapanese(lines), [lines]);
+  const isJapanese = useMemo(
+    () => (linesSignature ? lyricsHaveJapanese(lines) : false),
+    [lines, linesSignature]
+  );
   
   // For Japanese songs, check if furigana is ready (needed for accurate soramimi)
   // For non-Japanese songs (Korean, etc.), we can start soramimi immediately
@@ -486,6 +494,17 @@ export function useFurigana({
   // Keep a ref to furiganaMap so we can access it in the effect without adding it as a dependency
   // This prevents the soramimi effect from re-running during furigana streaming
   const furiganaMapRef = useLatestRef(furiganaMap);
+
+  const finishFuriganaFetch = useCallback(
+    (clearProgress = true) => {
+      setIsFetchingFurigana(false);
+      if (clearProgress) {
+        setProgress(undefined);
+        setFuriganaProgress(undefined);
+      }
+    },
+    [setIsFetchingFurigana, setProgress, setFuriganaProgress]
+  );
 
   const finishSoramimiFetch = useCallback(
     (clearProgress = true) => {
@@ -553,6 +572,16 @@ export function useFurigana({
 
     const prefetchedSoramimi = prefetchedSoramimiInfoRef.current;
 
+    if (prefetchedSoramimi?.skipped && !isSoramimiForceRequest) {
+      abortActiveSoramimiRequest();
+      setSoramimiMap(new Map());
+      soramimiCacheKeyRef.current = soramimiCacheKey;
+      finishSoramimiFetch();
+      setSoramimiError(undefined);
+      markSoramimiHandled();
+      return;
+    }
+
     // If we have cached soramimi from initial fetch, use it immediately
     // Only use if the cached data is for the same language we're requesting
     const prefetchedIsCorrectLanguage =
@@ -599,7 +628,15 @@ export function useFurigana({
 
     soramimiForceRequestRef.current = { controller, requestId };
 
-    // Use line-by-line streaming for soramimi
+    if (import.meta.env.DEV) {
+      console.log("[Soramimi] Starting SSE", {
+        songId: effectSongId,
+        targetLanguage: soramimiTargetLanguage,
+        isJapanese,
+        hasFurigana: furiganaMapRef.current.size > 0,
+      });
+    }
+
     const progressiveMap = new Map<string, FuriganaSegment[]>();
     
     // For Japanese songs, convert furigana map to array format for the API
@@ -665,6 +702,9 @@ export function useFurigana({
         setSoramimiMap(finalMap);
         soramimiCacheKeyRef.current = soramimiCacheKey;
         markSoramimiHandled();
+        if (import.meta.env.DEV) {
+          console.log("[Soramimi] SSE complete", { lines: finalMap.size });
+        }
       })
       .catch((err) => {
         if (controller.signal.aborted) return;
@@ -677,7 +717,7 @@ export function useFurigana({
           return;
         }
 
-        console.error("Failed to fetch soramimi:", err);
+        console.error("[Soramimi] Failed to fetch soramimi:", err);
         setSoramimiError(
           err instanceof Error
             ? err.message

--- a/src/hooks/useFurigana.tsx
+++ b/src/hooks/useFurigana.tsx
@@ -16,6 +16,11 @@ import {
   type FuriganaResult,
   type SoramimiResult,
 } from "@/utils/chunkedStream";
+import {
+  isFuriganaReadyForSoramimi,
+  SORAMIMI_FETCH_TIMEOUT_MS,
+  SORAMIMI_INFLIGHT_MAX_MS,
+} from "@/utils/soramimiFetch";
 import { renderLyricsWithAnnotations } from "@/utils/renderLyricsWithAnnotations";
 
 // Re-export FuriganaSegment for consumers
@@ -57,8 +62,10 @@ interface UseFuriganaReturn {
   furiganaProgress?: number;
   /** Soramimi progress percentage (0-100) */
   soramimiProgress?: number;
-  /** Error message if any */
+  /** Error message if furigana fetch failed */
   error?: string;
+  /** Non-blocking soramimi (misheard lyrics) fetch error */
+  soramimiError?: string;
   /** Render helper that wraps text with ruby elements (including all romanization types) */
   renderWithFurigana: (line: LyricLine, processedText: string) => React.ReactNode;
 }
@@ -97,6 +104,7 @@ export function useFurigana({
     furiganaProgress: number | undefined;
     soramimiProgress: number | undefined;
     error: string | undefined;
+    soramimiError: string | undefined;
   }
 
   const initialState: FuriganaState = {
@@ -108,6 +116,7 @@ export function useFurigana({
     furiganaProgress: undefined,
     soramimiProgress: undefined,
     error: undefined,
+    soramimiError: undefined,
   };
 
   type FuriganaAction = { type: "patch"; payload: Partial<FuriganaState> };
@@ -150,6 +159,7 @@ export function useFurigana({
     furiganaProgress,
     soramimiProgress,
     error,
+    soramimiError,
   } = state;
 
   const setFuriganaMap = useCallback((value: Map<string, FuriganaSegment[]>) => {
@@ -176,6 +186,9 @@ export function useFurigana({
   const setError = useCallback((value: string | undefined) => {
     dispatch({ type: "patch", payload: { error: value } });
   }, []);
+  const setSoramimiError = useCallback((value: string | undefined) => {
+    dispatch({ type: "patch", payload: { soramimiError: value } });
+  }, []);
   
   // Combined fetching state for backwards compatibility
   const isFetching = isFetchingFurigana || isFetchingSoramimi;
@@ -195,7 +208,11 @@ export function useFurigana({
   // Track in-flight force requests to prevent premature abort on effect re-runs
   // Store both the controller and a unique requestId to distinguish new vs duplicate requests
   const furiganaForceRequestRef = useRef<{ controller: AbortController; requestId: string } | null>(null);
-  const soramimiForceRequestRef = useRef<{ controller: AbortController; requestId: string } | null>(null);
+  const soramimiForceRequestRef = useRef<{
+    controller: AbortController;
+    requestId: string;
+    startedAt: number;
+  } | null>(null);
   
   // Stable refs for callbacks to avoid effect re-runs
   const onLoadingChangeRef = useLatestRef(onLoadingChange);
@@ -236,6 +253,7 @@ export function useFurigana({
       furiganaCacheKeyRef.current = "";
       soramimiCacheKeyRef.current = "";
       setError(undefined);
+      setSoramimiError(undefined);
       // Clear force request refs to prevent stale state blocking new requests
       furiganaForceRequestRef.current = null;
       soramimiForceRequestRef.current = null;
@@ -453,13 +471,24 @@ export function useFurigana({
   // For non-Japanese songs (Korean, etc.), we can start soramimi immediately
   // Memoized to avoid recalculating on every render
   const furiganaReadyForSoramimi = useMemo(
-    () => !isJapanese || (!isFetchingFurigana && furiganaMap.size > 0),
-    [isJapanese, isFetchingFurigana, furiganaMap]
+    () => isFuriganaReadyForSoramimi(isJapanese, isFetchingFurigana),
+    [isJapanese, isFetchingFurigana]
   );
   
   // Keep a ref to furiganaMap so we can access it in the effect without adding it as a dependency
   // This prevents the soramimi effect from re-running during furigana streaming
   const furiganaMapRef = useLatestRef(furiganaMap);
+
+  const finishSoramimiFetch = useCallback(
+    (clearProgress = true) => {
+      setIsFetchingSoramimi(false);
+      if (clearProgress) {
+        setProgress(undefined);
+        setSoramimiProgress(undefined);
+      }
+    },
+    [setIsFetchingSoramimi, setProgress, setSoramimiProgress]
+  );
 
   // Fetch soramimi for lyrics when enabled using line-by-line streaming
   // For Japanese songs, waits for furigana to complete first so we can pass readings to the AI
@@ -476,9 +505,10 @@ export function useFurigana({
         setSoramimiMap(new Map());
         soramimiCacheKeyRef.current = "";
         lastSoramimiSongIdRef.current = effectSongId || "";
-        // Mark handled to keep ref in sync for next song
         markSoramimiHandled();
       }
+      finishSoramimiFetch();
+      setSoramimiError(undefined);
       return;
     }
     
@@ -487,23 +517,25 @@ export function useFurigana({
 
     // If not showing original, don't fetch new data but keep existing soramimi cached
     if (!isShowingOriginal) {
+      finishSoramimiFetch();
       return;
     }
 
     // Check if offline
     if (isOffline()) {
+      finishSoramimiFetch();
+      setSoramimiError("iPod requires an internet connection");
       return;
     }
     
-    // For Japanese songs, wait for furigana to be ready before fetching soramimi
-    // This allows us to pass furigana readings to the AI for accurate kanji pronunciation
-    if (isJapanese && !furiganaReadyForSoramimi) {
-      console.log('[Soramimi] Waiting for furigana to complete for Japanese song...');
+    // For Japanese songs, wait for furigana to complete before fetching soramimi
+    if (!furiganaReadyForSoramimi) {
       return;
     }
 
     // Skip if we already have this data and it's not a force request
     if (!isSoramimiForceRequest && soramimiCacheKey === soramimiCacheKeyRef.current) {
+      finishSoramimiFetch();
       return;
     }
 
@@ -519,34 +551,44 @@ export function useFurigana({
       });
       setSoramimiMap(finalMap);
       soramimiCacheKeyRef.current = soramimiCacheKey;
+      finishSoramimiFetch();
+      setSoramimiError(undefined);
       return;
     }
 
-    // If there's already a request in flight for this song, skip this effect run
-    // This prevents duplicate requests when React re-runs the effect
+    // If there's already a request in flight, reuse it or abort if it stalled
     const existingReq = soramimiForceRequestRef.current;
     if (existingReq && !existingReq.controller.signal.aborted) {
-      return;
+      const ageMs = Date.now() - existingReq.startedAt;
+      if (ageMs < SORAMIMI_INFLIGHT_MAX_MS) {
+        setIsFetchingSoramimi(true);
+        return;
+      }
+      existingReq.controller.abort();
+      soramimiForceRequestRef.current = null;
     }
-    // Clear stale aborted ref so we can start fresh
     if (existingReq?.controller.signal.aborted) {
       soramimiForceRequestRef.current = null;
     }
     
     // Generate a unique requestId for this effect run
     const requestId = `${effectSongId}-${lyricsCacheBustTrigger}-${Date.now()}`;
+    const startedAt = Date.now();
     
     // Start loading - clear old soramimi map to avoid showing stale data while fetching
     setIsFetchingSoramimi(true);
     setProgress(0);
     setSoramimiProgress(0);
-    setError(undefined);
+    setSoramimiError(undefined);
     setSoramimiMap(new Map());
     
     const controller = new AbortController();
+    const timeoutId = window.setTimeout(() => {
+      controller.abort();
+    }, SORAMIMI_FETCH_TIMEOUT_MS);
     
     // Track this request so we can detect duplicates
-    soramimiForceRequestRef.current = { controller, requestId };
+    soramimiForceRequestRef.current = { controller, requestId, startedAt };
 
     // Use line-by-line streaming for soramimi
     const progressiveMap = new Map<string, FuriganaSegment[]>();
@@ -617,42 +659,43 @@ export function useFurigana({
       })
       .catch((err) => {
         if (controller.signal.aborted) return;
-        // Check for stale request
         if (effectSongId !== currentSongIdRef.current) return;
-        
+
         if (err instanceof Error && err.name === "AbortError") {
           return;
         }
 
         console.error("Failed to fetch soramimi:", err);
-        setError(err instanceof Error ? err.message : i18n.t("common.errors.failedToFetchSoramimi"));
+        setSoramimiError(
+          err instanceof Error
+            ? err.message
+            : i18n.t("common.errors.failedToFetchSoramimi")
+        );
       })
       .finally(() => {
-        // Clear force request ref when this request completes
+        window.clearTimeout(timeoutId);
         if (soramimiForceRequestRef.current?.requestId === requestId) {
           soramimiForceRequestRef.current = null;
         }
-        
-        if (!controller.signal.aborted && effectSongId === currentSongIdRef.current) {
-          setIsFetchingSoramimi(false);
-          setProgress(undefined);
-          setSoramimiProgress(undefined);
+
+        if (effectSongId === currentSongIdRef.current) {
+          finishSoramimiFetch();
         }
       });
 
     return () => {
-      // Always abort this request on cleanup - this controller is scoped to this effect run
+      window.clearTimeout(timeoutId);
       controller.abort();
-      // Only clear the ref if this is still the current request
       const isThisRequest = soramimiForceRequestRef.current?.requestId === requestId;
       if (isThisRequest) {
         soramimiForceRequestRef.current = null;
       }
-      setIsFetchingSoramimi(false);
-      setSoramimiProgress(undefined);
+      if (effectSongId === currentSongIdRef.current) {
+        finishSoramimiFetch();
+      }
     };
   // eslint-disable-next-line react-hooks/exhaustive-deps -- soramimiCacheKey captures lines content + target language, shouldFetchSoramimi captures romanization settings, furiganaReadyForSoramimi handles furigana sequencing, furiganaMapRef accessed via ref to avoid re-runs during streaming
-  }, [songId, soramimiCacheKey, shouldFetchSoramimi, hasLines, isShowingOriginal, lyricsCacheBustTrigger, prefetchedSoramimiInfo, isJapanese, furiganaReadyForSoramimi, soramimiTargetLanguage]);
+  }, [songId, soramimiCacheKey, shouldFetchSoramimi, hasLines, isShowingOriginal, lyricsCacheBustTrigger, prefetchedSoramimiInfo, isJapanese, furiganaReadyForSoramimi, soramimiTargetLanguage, finishSoramimiFetch]);
 
   // Unified render function that handles all romanization types
   // Delegates to extracted utility for better separation of concerns
@@ -678,6 +721,7 @@ export function useFurigana({
     furiganaProgress,
     soramimiProgress,
     error,
+    soramimiError,
     renderWithFurigana,
   };
 }

--- a/src/hooks/useFurigana.tsx
+++ b/src/hooks/useFurigana.tsx
@@ -73,6 +73,37 @@ function normalizeClientFuriganaSegments(segments: FuriganaSegment[]): FuriganaS
   return normalizeFuriganaSegments(segments);
 }
 
+type StreamRequestSlot = React.MutableRefObject<{
+  controller: AbortController;
+  requestId: string;
+} | null>;
+
+function abortStreamRequest(slot: StreamRequestSlot) {
+  const active = slot.current;
+  if (active && !active.controller.signal.aborted) {
+    active.controller.abort();
+  }
+  slot.current = null;
+}
+
+function buildSegmentsMap(
+  lines: LyricLine[],
+  rows: Array<Array<FuriganaSegment>> | undefined,
+  normalizeReadings: boolean
+): Map<string, FuriganaSegment[]> {
+  const map = new Map<string, FuriganaSegment[]>();
+  if (!rows) return map;
+  rows.forEach((segments, index) => {
+    if (index < lines.length && segments) {
+      map.set(
+        lines[index].startTimeMs,
+        normalizeReadings ? normalizeClientFuriganaSegments(segments) : segments
+      );
+    }
+  });
+  return map;
+}
+
 /**
  * Hook for fetching and managing Japanese furigana annotations and other romanization
  * 
@@ -215,22 +246,28 @@ export function useFurigana({
   const prefetchedSoramimiInfoRef = useLatestRef(prefetchedSoramimiInfo);
   const prefetchedFuriganaInfoRef = useLatestRef(prefetchedInfo);
 
-  const abortActiveFuriganaRequest = useCallback(() => {
-    const active = furiganaForceRequestRef.current;
-    if (active && !active.controller.signal.aborted) {
-      active.controller.abort();
-    }
-    furiganaForceRequestRef.current = null;
-  }, []);
+  const finishFuriganaFetch = useCallback(
+    (clearProgress = true) => {
+      setIsFetchingFurigana(false);
+      if (clearProgress) {
+        setProgress(undefined);
+        setFuriganaProgress(undefined);
+      }
+    },
+    [setIsFetchingFurigana, setProgress, setFuriganaProgress]
+  );
 
-  const abortActiveSoramimiRequest = useCallback(() => {
-    const active = soramimiForceRequestRef.current;
-    if (active && !active.controller.signal.aborted) {
-      active.controller.abort();
-    }
-    soramimiForceRequestRef.current = null;
-  }, []);
-  
+  const finishSoramimiFetch = useCallback(
+    (clearProgress = true) => {
+      setIsFetchingSoramimi(false);
+      if (clearProgress) {
+        setProgress(undefined);
+        setSoramimiProgress(undefined);
+      }
+    },
+    [setIsFetchingSoramimi, setProgress, setSoramimiProgress]
+  );
+
   // Stable refs for callbacks to avoid effect re-runs
   const onLoadingChangeRef = useLatestRef(onLoadingChange);
 
@@ -298,7 +335,7 @@ export function useFurigana({
 
     // If completely disabled, no songId, or no lines, handle cleanup
     if (!effectSongId || !shouldFetchFurigana || !hasLines) {
-      abortActiveFuriganaRequest();
+      abortStreamRequest(furiganaForceRequestRef);
       const songChanged = effectSongId !== lastFuriganaSongIdRef.current;
       if (songChanged && furiganaCacheKeyRef.current !== "") {
         setFuriganaMap(new Map());
@@ -314,14 +351,14 @@ export function useFurigana({
     lastFuriganaSongIdRef.current = effectSongId;
 
     if (!isShowingOriginal) {
-      abortActiveFuriganaRequest();
+      abortStreamRequest(furiganaForceRequestRef);
       finishFuriganaFetch();
       return;
     }
 
     const hasJapanese = lines.some((line) => isJapaneseText(line.words));
     if (!hasJapanese) {
-      abortActiveFuriganaRequest();
+      abortStreamRequest(furiganaForceRequestRef);
       setFuriganaMap(new Map());
       furiganaCacheKeyRef.current = "";
       finishFuriganaFetch();
@@ -331,7 +368,7 @@ export function useFurigana({
     }
 
     if (isOffline()) {
-      abortActiveFuriganaRequest();
+      abortStreamRequest(furiganaForceRequestRef);
       finishFuriganaFetch();
       setError("iPod requires an internet connection");
       return;
@@ -344,20 +381,14 @@ export function useFurigana({
 
     const prefetchedFurigana = prefetchedFuriganaInfoRef.current;
     if (prefetchedFurigana?.cached && prefetchedFurigana.data && !isFuriganaForceRequest) {
-      abortActiveFuriganaRequest();
-      const finalMap = new Map<string, FuriganaSegment[]>();
-      prefetchedFurigana.data.forEach((segments, index) => {
-        if (index < lines.length && segments) {
-          finalMap.set(lines[index].startTimeMs, normalizeClientFuriganaSegments(segments));
-        }
-      });
-      setFuriganaMap(finalMap);
+      abortStreamRequest(furiganaForceRequestRef);
+      setFuriganaMap(buildSegmentsMap(lines, prefetchedFurigana.data, true));
       furiganaCacheKeyRef.current = cacheKey;
       finishFuriganaFetch();
       return;
     }
 
-    abortActiveFuriganaRequest();
+    abortStreamRequest(furiganaForceRequestRef);
 
     const requestId = `${effectSongId}-${lyricsCacheBustTrigger}-${Date.now()}`;
     let timedOut = false;
@@ -399,7 +430,6 @@ export function useFurigana({
         
         const currentLines = linesRef.current;
         if (lineIndex < currentLines.length && segments) {
-          console.log(`[Furigana] Line ${lineIndex} received:`, segments.length, 'segments');
           progressiveMap.set(
             currentLines[lineIndex].startTimeMs,
             normalizeClientFuriganaSegments(segments)
@@ -467,7 +497,7 @@ export function useFurigana({
       }
     };
   // eslint-disable-next-line react-hooks/exhaustive-deps -- cacheKey uses linesSignature; prefetched furigana read via ref
-  }, [songId, cacheKey, shouldFetchFurigana, hasLines, isShowingOriginal, lyricsCacheBustTrigger, finishFuriganaFetch, abortActiveFuriganaRequest]);
+  }, [songId, cacheKey, shouldFetchFurigana, hasLines, isShowingOriginal, lyricsCacheBustTrigger, finishFuriganaFetch]);
 
   // Check conditions for soramimi fetching
   const shouldFetchSoramimi = romanization.enabled && romanization.soramimi;
@@ -495,28 +525,6 @@ export function useFurigana({
   // This prevents the soramimi effect from re-running during furigana streaming
   const furiganaMapRef = useLatestRef(furiganaMap);
 
-  const finishFuriganaFetch = useCallback(
-    (clearProgress = true) => {
-      setIsFetchingFurigana(false);
-      if (clearProgress) {
-        setProgress(undefined);
-        setFuriganaProgress(undefined);
-      }
-    },
-    [setIsFetchingFurigana, setProgress, setFuriganaProgress]
-  );
-
-  const finishSoramimiFetch = useCallback(
-    (clearProgress = true) => {
-      setIsFetchingSoramimi(false);
-      if (clearProgress) {
-        setProgress(undefined);
-        setSoramimiProgress(undefined);
-      }
-    },
-    [setIsFetchingSoramimi, setProgress, setSoramimiProgress]
-  );
-
   // Fetch soramimi for lyrics when enabled using line-by-line streaming
   // For Japanese songs, waits for furigana to complete first so we can pass readings to the AI
   // biome-ignore lint/correctness/useExhaustiveDependencies: cacheKey captures lines content, shouldFetchSoramimi captures romanization settings
@@ -526,7 +534,7 @@ export function useFurigana({
 
     // If completely disabled, no songId, or no lines, handle cleanup
     if (!effectSongId || !shouldFetchSoramimi || !hasLines) {
-      abortActiveSoramimiRequest();
+      abortStreamRequest(soramimiForceRequestRef);
       // Only clear cache if songId actually changed (not just temporarily empty lines during re-fetch)
       const songChanged = effectSongId !== lastSoramimiSongIdRef.current;
       if (songChanged && soramimiCacheKeyRef.current !== "") {
@@ -545,14 +553,14 @@ export function useFurigana({
 
     // If not showing original, don't fetch new data but keep existing soramimi cached
     if (!isShowingOriginal) {
-      abortActiveSoramimiRequest();
+      abortStreamRequest(soramimiForceRequestRef);
       finishSoramimiFetch();
       return;
     }
 
     // Check if offline
     if (isOffline()) {
-      abortActiveSoramimiRequest();
+      abortStreamRequest(soramimiForceRequestRef);
       finishSoramimiFetch();
       setSoramimiError("iPod requires an internet connection");
       return;
@@ -573,7 +581,7 @@ export function useFurigana({
     const prefetchedSoramimi = prefetchedSoramimiInfoRef.current;
 
     if (prefetchedSoramimi?.skipped && !isSoramimiForceRequest) {
-      abortActiveSoramimiRequest();
+      abortStreamRequest(soramimiForceRequestRef);
       setSoramimiMap(new Map());
       soramimiCacheKeyRef.current = soramimiCacheKey;
       finishSoramimiFetch();
@@ -592,14 +600,8 @@ export function useFurigana({
       !isSoramimiForceRequest &&
       prefetchedIsCorrectLanguage
     ) {
-      abortActiveSoramimiRequest();
-      const finalMap = new Map<string, FuriganaSegment[]>();
-      prefetchedSoramimi.data.forEach((segments, index) => {
-        if (index < lines.length && segments) {
-          finalMap.set(lines[index].startTimeMs, segments);
-        }
-      });
-      setSoramimiMap(finalMap);
+      abortStreamRequest(soramimiForceRequestRef);
+      setSoramimiMap(buildSegmentsMap(lines, prefetchedSoramimi.data, false));
       soramimiCacheKeyRef.current = soramimiCacheKey;
       finishSoramimiFetch();
       setSoramimiError(undefined);
@@ -607,7 +609,7 @@ export function useFurigana({
     }
 
     // Abort any prior stream before starting a new one (effect re-runs must not orphan requests)
-    abortActiveSoramimiRequest();
+    abortStreamRequest(soramimiForceRequestRef);
 
     // Generate a unique requestId for this effect run
     const requestId = `${effectSongId}-${lyricsCacheBustTrigger}-${Date.now()}`;
@@ -650,11 +652,8 @@ export function useFurigana({
         furiganaForApi.push(segments || [{ text: currentLines[i].words }]);
       }
       // Only include if there's actual reading data
-      const hasReadings = furiganaForApi.some(line => line.some(seg => seg.reading));
-      if (!hasReadings) {
+      if (!furiganaForApi.some((line) => line.some((seg) => seg.reading))) {
         furiganaForApi = undefined;
-      } else {
-        console.log('[Soramimi] Starting with furigana data for Japanese song');
       }
     }
     
@@ -679,7 +678,6 @@ export function useFurigana({
         
         const currentLines = linesRef.current;
         if (lineIndex < currentLines.length && segments) {
-          console.log(`[Soramimi] Line ${lineIndex} received:`, segments.length, 'segments');
           progressiveMap.set(currentLines[lineIndex].startTimeMs, segments);
           setSoramimiMap(new Map(progressiveMap));
         }
@@ -747,7 +745,7 @@ export function useFurigana({
       }
     };
   // eslint-disable-next-line react-hooks/exhaustive-deps -- soramimiCacheKey captures lines content + target language; prefetched soramimi read via ref to avoid abort/restart loops when useLyrics metadata updates
-  }, [songId, soramimiCacheKey, shouldFetchSoramimi, hasLines, isShowingOriginal, lyricsCacheBustTrigger, isJapanese, furiganaReadyForSoramimi, soramimiTargetLanguage, finishSoramimiFetch, abortActiveSoramimiRequest]);
+  }, [songId, soramimiCacheKey, shouldFetchSoramimi, hasLines, isShowingOriginal, lyricsCacheBustTrigger, isJapanese, furiganaReadyForSoramimi, soramimiTargetLanguage, finishSoramimiFetch]);
 
   // Unified render function that handles all romanization types
   // Delegates to extracted utility for better separation of concerns

--- a/src/hooks/useFurigana.tsx
+++ b/src/hooks/useFurigana.tsx
@@ -19,7 +19,6 @@ import {
 import {
   isFuriganaReadyForSoramimi,
   SORAMIMI_FETCH_TIMEOUT_MS,
-  SORAMIMI_INFLIGHT_MAX_MS,
 } from "@/utils/soramimiFetch";
 import { renderLyricsWithAnnotations } from "@/utils/renderLyricsWithAnnotations";
 
@@ -211,8 +210,17 @@ export function useFurigana({
   const soramimiForceRequestRef = useRef<{
     controller: AbortController;
     requestId: string;
-    startedAt: number;
   } | null>(null);
+
+  const prefetchedSoramimiInfoRef = useLatestRef(prefetchedSoramimiInfo);
+
+  const abortActiveSoramimiRequest = useCallback(() => {
+    const active = soramimiForceRequestRef.current;
+    if (active && !active.controller.signal.aborted) {
+      active.controller.abort();
+    }
+    soramimiForceRequestRef.current = null;
+  }, []);
   
   // Stable refs for callbacks to avoid effect re-runs
   const onLoadingChangeRef = useLatestRef(onLoadingChange);
@@ -499,6 +507,7 @@ export function useFurigana({
 
     // If completely disabled, no songId, or no lines, handle cleanup
     if (!effectSongId || !shouldFetchSoramimi || !hasLines) {
+      abortActiveSoramimiRequest();
       // Only clear cache if songId actually changed (not just temporarily empty lines during re-fetch)
       const songChanged = effectSongId !== lastSoramimiSongIdRef.current;
       if (songChanged && soramimiCacheKeyRef.current !== "") {
@@ -517,12 +526,14 @@ export function useFurigana({
 
     // If not showing original, don't fetch new data but keep existing soramimi cached
     if (!isShowingOriginal) {
+      abortActiveSoramimiRequest();
       finishSoramimiFetch();
       return;
     }
 
     // Check if offline
     if (isOffline()) {
+      abortActiveSoramimiRequest();
       finishSoramimiFetch();
       setSoramimiError("iPod requires an internet connection");
       return;
@@ -530,6 +541,7 @@ export function useFurigana({
     
     // For Japanese songs, wait for furigana to complete before fetching soramimi
     if (!furiganaReadyForSoramimi) {
+      finishSoramimiFetch();
       return;
     }
 
@@ -539,12 +551,21 @@ export function useFurigana({
       return;
     }
 
+    const prefetchedSoramimi = prefetchedSoramimiInfoRef.current;
+
     // If we have cached soramimi from initial fetch, use it immediately
     // Only use if the cached data is for the same language we're requesting
-    const prefetchedIsCorrectLanguage = prefetchedSoramimiInfo?.targetLanguage === soramimiTargetLanguage;
-    if (prefetchedSoramimiInfo?.cached && prefetchedSoramimiInfo.data && !isSoramimiForceRequest && prefetchedIsCorrectLanguage) {
+    const prefetchedIsCorrectLanguage =
+      prefetchedSoramimi?.targetLanguage === soramimiTargetLanguage;
+    if (
+      prefetchedSoramimi?.cached &&
+      prefetchedSoramimi.data &&
+      !isSoramimiForceRequest &&
+      prefetchedIsCorrectLanguage
+    ) {
+      abortActiveSoramimiRequest();
       const finalMap = new Map<string, FuriganaSegment[]>();
-      prefetchedSoramimiInfo.data.forEach((segments, index) => {
+      prefetchedSoramimi.data.forEach((segments, index) => {
         if (index < lines.length && segments) {
           finalMap.set(lines[index].startTimeMs, segments);
         }
@@ -556,39 +577,27 @@ export function useFurigana({
       return;
     }
 
-    // If there's already a request in flight, reuse it or abort if it stalled
-    const existingReq = soramimiForceRequestRef.current;
-    if (existingReq && !existingReq.controller.signal.aborted) {
-      const ageMs = Date.now() - existingReq.startedAt;
-      if (ageMs < SORAMIMI_INFLIGHT_MAX_MS) {
-        setIsFetchingSoramimi(true);
-        return;
-      }
-      existingReq.controller.abort();
-      soramimiForceRequestRef.current = null;
-    }
-    if (existingReq?.controller.signal.aborted) {
-      soramimiForceRequestRef.current = null;
-    }
-    
+    // Abort any prior stream before starting a new one (effect re-runs must not orphan requests)
+    abortActiveSoramimiRequest();
+
     // Generate a unique requestId for this effect run
     const requestId = `${effectSongId}-${lyricsCacheBustTrigger}-${Date.now()}`;
-    const startedAt = Date.now();
-    
+    let timedOut = false;
+
     // Start loading - clear old soramimi map to avoid showing stale data while fetching
     setIsFetchingSoramimi(true);
     setProgress(0);
     setSoramimiProgress(0);
     setSoramimiError(undefined);
     setSoramimiMap(new Map());
-    
+
     const controller = new AbortController();
     const timeoutId = window.setTimeout(() => {
+      timedOut = true;
       controller.abort();
     }, SORAMIMI_FETCH_TIMEOUT_MS);
-    
-    // Track this request so we can detect duplicates
-    soramimiForceRequestRef.current = { controller, requestId, startedAt };
+
+    soramimiForceRequestRef.current = { controller, requestId };
 
     // Use line-by-line streaming for soramimi
     const progressiveMap = new Map<string, FuriganaSegment[]>();
@@ -615,7 +624,7 @@ export function useFurigana({
     processSoramimiSSE(effectSongId, {
       force: isSoramimiForceRequest,
       signal: controller.signal,
-      prefetchedInfo: !isSoramimiForceRequest ? prefetchedSoramimiInfo : undefined,
+      prefetchedInfo: !isSoramimiForceRequest ? prefetchedSoramimi : undefined,
       // Pass furigana data for Japanese songs so AI knows kanji pronunciation
       furigana: furiganaForApi,
       targetLanguage: soramimiTargetLanguage,
@@ -662,6 +671,9 @@ export function useFurigana({
         if (effectSongId !== currentSongIdRef.current) return;
 
         if (err instanceof Error && err.name === "AbortError") {
+          if (timedOut) {
+            setSoramimiError(i18n.t("common.errors.failedToFetchSoramimi"));
+          }
           return;
         }
 
@@ -694,8 +706,8 @@ export function useFurigana({
         finishSoramimiFetch();
       }
     };
-  // eslint-disable-next-line react-hooks/exhaustive-deps -- soramimiCacheKey captures lines content + target language, shouldFetchSoramimi captures romanization settings, furiganaReadyForSoramimi handles furigana sequencing, furiganaMapRef accessed via ref to avoid re-runs during streaming
-  }, [songId, soramimiCacheKey, shouldFetchSoramimi, hasLines, isShowingOriginal, lyricsCacheBustTrigger, prefetchedSoramimiInfo, isJapanese, furiganaReadyForSoramimi, soramimiTargetLanguage, finishSoramimiFetch]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- soramimiCacheKey captures lines content + target language; prefetched soramimi read via ref to avoid abort/restart loops when useLyrics metadata updates
+  }, [songId, soramimiCacheKey, shouldFetchSoramimi, hasLines, isShowingOriginal, lyricsCacheBustTrigger, isJapanese, furiganaReadyForSoramimi, soramimiTargetLanguage, finishSoramimiFetch, abortActiveSoramimiRequest]);
 
   // Unified render function that handles all romanization types
   // Delegates to extracted utility for better separation of concerns

--- a/src/lib/locales/en/translation.json
+++ b/src/lib/locales/en/translation.json
@@ -12,6 +12,7 @@
     "activity": {
       "adding": "Adding",
       "soramimi": "Misheard",
+      "soramimiError": "Misheard unavailable",
       "furigana": "Furigana"
     },
     "window": {

--- a/src/utils/chunkedStream.ts
+++ b/src/utils/chunkedStream.ts
@@ -13,6 +13,8 @@ import { abortableFetch } from "@/utils/abortableFetch";
 const MAX_BUFFER_SIZE = 1024 * 1024; // 1MB
 const MAX_RETRIES = 3;
 const INITIAL_DELAY_MS = 1000;
+/** Abort SSE body reads if the server sends no data for this long. */
+export const SSE_STREAM_IDLE_TIMEOUT_MS = 120_000;
 
 // =============================================================================
 // Types
@@ -657,6 +659,14 @@ export async function processSoramimiSSE(
         let totalLines = 0;
         let completedLines = 0;
         let finalSoramimi: SoramimiResult | null = null;
+        let lastChunkAt = Date.now();
+
+        const assertStreamNotIdle = () => {
+          if (Date.now() - lastChunkAt > SSE_STREAM_IDLE_TIMEOUT_MS) {
+            reader.cancel();
+            throw new Error("SSE stream timed out waiting for data");
+          }
+        };
 
         const processLine = (line: string) => {
           if (!line.startsWith("data: ")) return;
@@ -741,6 +751,7 @@ export async function processSoramimiSSE(
         };
 
         while (true) {
+          assertStreamNotIdle();
           const { done, value } = await reader.read();
           
           if (done) {
@@ -752,6 +763,7 @@ export async function processSoramimiSSE(
             break;
           }
 
+          lastChunkAt = Date.now();
           buffer += decoder.decode(value, { stream: true });
           
           // Check buffer size limit

--- a/src/utils/chunkedStream.ts
+++ b/src/utils/chunkedStream.ts
@@ -14,7 +14,7 @@ const MAX_BUFFER_SIZE = 1024 * 1024; // 1MB
 const MAX_RETRIES = 3;
 const INITIAL_DELAY_MS = 1000;
 /** Abort SSE body reads if the server sends no data for this long. */
-export const SSE_STREAM_IDLE_TIMEOUT_MS = 120_000;
+export const SSE_STREAM_IDLE_TIMEOUT_MS = 90_000;
 
 // =============================================================================
 // Types
@@ -706,9 +706,15 @@ export async function processSoramimiSSE(
                 }
                 break;
 
-              case "error":
-                console.warn("SSE: Soramimi stream error:", eventData.error || rawData.error);
-                break;
+              case "error": {
+                const message =
+                  (typeof eventData.error === "string" && eventData.error) ||
+                  (typeof rawData.error === "string" && rawData.error) ||
+                  "Soramimi stream error";
+                console.warn("SSE: Soramimi stream error:", message);
+                reader.cancel();
+                throw new Error(message);
+              }
 
               case "cached":
                 finalSoramimi = { data: eventData.soramimi, success: true };

--- a/src/utils/soramimiFetch.ts
+++ b/src/utils/soramimiFetch.ts
@@ -10,8 +10,8 @@ export function isFuriganaReadyForSoramimi(
   return !isJapanese || !isFetchingFurigana;
 }
 
-/** Default in-flight guard: abort and restart if a prior request exceeds this age. */
-export const SORAMIMI_INFLIGHT_MAX_MS = 5 * 60 * 1000;
-
-/** Effect-level safety timeout for a single soramimi fetch attempt. */
-export const SORAMIMI_FETCH_TIMEOUT_MS = 5 * 60 * 1000;
+/**
+ * Client safety timeout — slightly above api/songs/[id].ts maxDuration (120s)
+ * so we clear UI loading when the platform cuts the SSE stream.
+ */
+export const SORAMIMI_FETCH_TIMEOUT_MS = 130_000;

--- a/src/utils/soramimiFetch.ts
+++ b/src/utils/soramimiFetch.ts
@@ -1,0 +1,17 @@
+/**
+ * Pure helpers for soramimi (misheard lyrics) fetch sequencing in useFurigana.
+ */
+
+/** Max time to wait for furigana before starting soramimi on Japanese tracks. */
+export function isFuriganaReadyForSoramimi(
+  isJapanese: boolean,
+  isFetchingFurigana: boolean
+): boolean {
+  return !isJapanese || !isFetchingFurigana;
+}
+
+/** Default in-flight guard: abort and restart if a prior request exceeds this age. */
+export const SORAMIMI_INFLIGHT_MAX_MS = 5 * 60 * 1000;
+
+/** Effect-level safety timeout for a single soramimi fetch attempt. */
+export const SORAMIMI_FETCH_TIMEOUT_MS = 5 * 60 * 1000;

--- a/tests/test-soramimi-loading.test.ts
+++ b/tests/test-soramimi-loading.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from "bun:test";
+import { getActivityLabel } from "@/hooks/useActivityLabel";
+import {
+  isFuriganaReadyForSoramimi,
+  SORAMIMI_FETCH_TIMEOUT_MS,
+  SORAMIMI_INFLIGHT_MAX_MS,
+} from "@/utils/soramimiFetch";
+import { SSE_STREAM_IDLE_TIMEOUT_MS } from "@/utils/chunkedStream";
+
+describe("soramimi fetch sequencing", () => {
+  test("waits for furigana only on Japanese tracks while furigana is in flight", () => {
+    expect(isFuriganaReadyForSoramimi(false, true)).toBe(true);
+    expect(isFuriganaReadyForSoramimi(true, true)).toBe(false);
+    expect(isFuriganaReadyForSoramimi(true, false)).toBe(true);
+  });
+
+  test("uses conservative timeout constants", () => {
+    expect(SORAMIMI_INFLIGHT_MAX_MS).toBeGreaterThanOrEqual(60_000);
+    expect(SORAMIMI_FETCH_TIMEOUT_MS).toBeGreaterThanOrEqual(SORAMIMI_INFLIGHT_MAX_MS);
+    expect(SSE_STREAM_IDLE_TIMEOUT_MS).toBeGreaterThanOrEqual(30_000);
+  });
+});
+
+describe("getActivityLabel soramimi errors", () => {
+  test("shows non-spinner error label when soramimi failed", () => {
+    const result = getActivityLabel({
+      soramimiError: "SSE stream timed out",
+      isFetchingSoramimi: false,
+    });
+
+    expect(result.isActive).toBe(true);
+    expect(result.isError).toBe(true);
+    expect(result.label).toBe("Misheard unavailable");
+  });
+
+  test("prefers loading label over stale error while soramimi is fetching", () => {
+    const result = getActivityLabel({
+      soramimiError: "old error",
+      isFetchingSoramimi: true,
+      soramimiProgress: 40,
+    });
+
+    expect(result.isActive).toBe(true);
+    expect(result.isError).toBeUndefined();
+    expect(result.label).toContain("Misheard");
+    expect(result.label).toContain("40%");
+  });
+});

--- a/tests/test-soramimi-loading.test.ts
+++ b/tests/test-soramimi-loading.test.ts
@@ -3,7 +3,6 @@ import { getActivityLabel } from "@/hooks/useActivityLabel";
 import {
   isFuriganaReadyForSoramimi,
   SORAMIMI_FETCH_TIMEOUT_MS,
-  SORAMIMI_INFLIGHT_MAX_MS,
 } from "@/utils/soramimiFetch";
 import { SSE_STREAM_IDLE_TIMEOUT_MS } from "@/utils/chunkedStream";
 
@@ -14,10 +13,11 @@ describe("soramimi fetch sequencing", () => {
     expect(isFuriganaReadyForSoramimi(true, false)).toBe(true);
   });
 
-  test("uses conservative timeout constants", () => {
-    expect(SORAMIMI_INFLIGHT_MAX_MS).toBeGreaterThanOrEqual(60_000);
-    expect(SORAMIMI_FETCH_TIMEOUT_MS).toBeGreaterThanOrEqual(SORAMIMI_INFLIGHT_MAX_MS);
+  test("uses conservative timeout constants aligned with API maxDuration", () => {
+    expect(SORAMIMI_FETCH_TIMEOUT_MS).toBeGreaterThan(120_000);
+    expect(SORAMIMI_FETCH_TIMEOUT_MS).toBeLessThanOrEqual(180_000);
     expect(SSE_STREAM_IDLE_TIMEOUT_MS).toBeGreaterThanOrEqual(30_000);
+    expect(SSE_STREAM_IDLE_TIMEOUT_MS).toBeLessThan(SORAMIMI_FETCH_TIMEOUT_MS);
   });
 });
 

--- a/tests/test-stream-chunk-timeout.test.ts
+++ b/tests/test-stream-chunk-timeout.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, test } from "bun:test";
+import { withStreamChunkTimeout } from "../api/songs/_streamModels";
+
+describe("withStreamChunkTimeout", () => {
+  test("throws when source stalls between chunks", async () => {
+    async function* slow() {
+      yield "a";
+      await new Promise((r) => setTimeout(r, 50));
+    }
+
+    const iter = withStreamChunkTimeout(slow(), 20, "Test stream");
+    await expect(iter.next()).resolves.toEqual({ value: "a", done: false });
+    await expect(iter.next()).rejects.toThrow("Test stream timed out waiting for data");
+  });
+});

--- a/tests/test-stream-models.test.ts
+++ b/tests/test-stream-models.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, test } from "bun:test";
+import {
+  FURIGANA_STREAM_MODEL,
+  SORAMIMI_STREAM_MODEL,
+  TRANSLATE_STREAM_MODEL,
+} from "../api/songs/_streamModels";
+
+describe("lyrics stream model defaults", () => {
+  test("soramimi and furigana default to gpt-5.4; translate stays on gpt-5.5", () => {
+    expect(SORAMIMI_STREAM_MODEL).toBe("gpt-5.4");
+    expect(FURIGANA_STREAM_MODEL).toBe("gpt-5.4");
+    expect(TRANSLATE_STREAM_MODEL).toBe("gpt-5.5");
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Misheard lyrics loading stuck because **gpt-5.5 `streamText` often emits SSE `start` then never yields chunks** on Japanese soramimi jobs. The UI stays on “Misheard …%” until timeout.

## Reproduced on PR preview (before this commit)

**Preview:** https://1326-preview.os.ryo.lu (deployed build may still be on gpt-5.5 until Coolify redeploys latest branch)

```bash
# Japanese track — hung ~60s+ with only start, no lines (gpt-5.5)
curl -N -X POST "https://1326-preview.os.ryo.lu/api/songs/am:1877180113" \
  -H "Content-Type: application/json" \
  -d '{"action":"soramimi-stream","targetLanguage":"en"}'
# => data: {"type":"start",...} then silence (0 line events)
```

**Local with gpt-5.4 (same song):** completes in ~44s with 38 `line` events + `complete`.

## Model defaults (new)

| Stream | Model | Override env |
|--------|-------|----------------|
| Soramimi (misheard) | **gpt-5.4** | `SORAMIMI_STREAM_MODEL` |
| Furigana | **gpt-5.4** | `FURIGANA_STREAM_MODEL` |
| Translate | gpt-5.5 | `TRANSLATE_STREAM_MODEL` |

## Fixes

- Server: `withStreamChunkTimeout` (90s) on furigana/soramimi/translate SSE loops → emits `error` event instead of hanging forever; clear pending timers on each chunk
- Client: furigana parity fixes (same as soramimi), stable `linesSignature` cache keys
- Client: loading cleanup, 130s safety timeout, “Misheard unavailable” on failure
- Build: move `finishFuriganaFetch` / `finishSoramimiFetch` above furigana effect; shared `abortStreamRequest` + `buildSegmentsMap` (`ba009f695`)

## Testing

```bash
bun run build
bun test tests/test-soramimi-loading.test.ts tests/test-stream-models.test.ts tests/test-stream-chunk-timeout.test.ts
bun run test:unit
```

After preview redeploy, enable Misheard on a Japanese track and confirm Network shows `soramimi-stream` line events + `complete`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-645b9773-7ac8-40de-aa4d-ebf3dd47dc28"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-645b9773-7ac8-40de-aa4d-ebf3dd47dc28"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

