### PR TITLE
Revert lyrics stream models from gpt-5.5 back to gpt-5.4

### DIFF
--- a/api/songs/[id].ts
+++ b/api/songs/[id].ts
@@ -941,9 +941,9 @@ export default apiHandler<Record<string, unknown>>(
             }
           };
 
-          // Use streamText with GPT-5.2
+          // Use streamText with GPT-5.4
           const result = streamText({
-            model: openai("gpt-5.5"),
+            model: openai("gpt-5.4"),
             messages: [
               { role: "system", content: getTranslationSystemPrompt(language) },
               { role: "user", content: textsToProcess },
@@ -1171,7 +1171,7 @@ export default apiHandler<Record<string, unknown>>(
           };
 
           const result = streamText({
-            model: openai("gpt-5.5"),
+            model: openai("gpt-5.4"),
             messages: [
               { role: "system", content: FURIGANA_STREAM_SYSTEM_PROMPT },
               { role: "user", content: textsToProcess },
@@ -1465,7 +1465,7 @@ export default apiHandler<Record<string, unknown>>(
 
           // Use streamText
           const result = streamText({
-            model: openai("gpt-5.5"),
+            model: openai("gpt-5.4"),
             messages: [
               { role: "system", content: systemPrompt },
               { role: "user", content: textsToProcess },

--- a/api/songs/_furigana.ts
+++ b/api/songs/_furigana.ts
@@ -253,7 +253,7 @@ export async function streamFurigana(
 
   try {
     const result = streamText({
-      model: openai("gpt-5.5"),
+      model: openai("gpt-5.4"),
       messages: [
         { role: "system", content: systemPrompt },
         { role: "user", content: textsToProcess },

--- a/api/songs/_lyrics.ts
+++ b/api/songs/_lyrics.ts
@@ -522,7 +522,7 @@ export async function streamTranslation(
 
   try {
     const result = streamText({
-      model: openai("gpt-5.5"),
+      model: openai("gpt-5.4"),
       messages: [
         { role: "system", content: systemPrompt },
         { role: "user", content: textsToProcess },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Switches the OpenAI model used by the translation, furigana, and soramimi streaming endpoints back to `gpt-5.4`. `gpt-5.5` was observed to hang the soramimi / furigana streams on some tracks (start event fires, but no `line` events follow), causing the misheard-lyrics UI to get stuck loading.

## Changes

- `api/songs/[id].ts`: translation, furigana, and soramimi `streamText` calls now use `openai("gpt-5.4")`.
- `api/songs/_furigana.ts`: furigana stream uses `openai("gpt-5.4")`.
- `api/songs/_lyrics.ts`: translation stream uses `openai("gpt-5.4")`.

No behavioral changes other than the model swap.

## Testing

- `bun run lint` — 0 errors (pre-existing warnings unchanged).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-B3D56565-4BAF-49FA-964B-FCF7CB638854"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-B3D56565-4BAF-49FA-964B-FCF7CB638854"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

