### PR TITLE
fix(aqua): dark mode polish — input focus, search results, progress bar, primary button

### DIFF
--- a/src/components/dialogs/SongSearchDialog.tsx
+++ b/src/components/dialogs/SongSearchDialog.tsx
@@ -492,14 +492,14 @@ export function SongSearchDialog({
             alignItems: "center",
             gap: "8px",
             boxSizing: "border-box",
-            background: selected
-              ? undefined
-              : index % 2 === 1
-              ? "#f3f4f6"
-              : "white",
-          }}
-        >
-          {result.cover && (
+          background: selected
+            ? undefined
+            : index % 2 === 1
+            ? "var(--os-color-list-row-alt-bg)"
+            : "var(--os-color-input-bg)",
+        }}
+      >
+        {result.cover && (
             <img
               src={result.cover}
               alt=""
@@ -518,7 +518,7 @@ export function SongSearchDialog({
               className="truncate"
               style={{
                 opacity: selected ? 0.8 : 1,
-                color: selected ? undefined : "#4b5563",
+                color: selected ? undefined : "var(--os-color-text-secondary)",
               }}
             >
               {[result.artist, result.album].filter(Boolean).join(" · ")}
@@ -555,8 +555,8 @@ export function SongSearchDialog({
           background: selected
             ? undefined
             : index % 2 === 1
-            ? "#f3f4f6"
-            : "white",
+            ? "var(--os-color-list-row-alt-bg)"
+            : "var(--os-color-input-bg)",
         }}
       >
         {result.thumbnail && (
@@ -574,7 +574,7 @@ export function SongSearchDialog({
             className="truncate"
             style={{
               opacity: selected ? 0.8 : 1,
-              color: selected ? undefined : "#4b5563",
+              color: selected ? undefined : "var(--os-color-text-secondary)",
             }}
           >
             {decodeHtmlEntities(result.channelTitle)}
@@ -612,9 +612,9 @@ export function SongSearchDialog({
           </p>
           <div
             style={{
-              border: "1px solid #d1d5db",
+              border: "1px solid var(--os-color-input-border)",
               borderRadius: "6px",
-              backgroundColor: "white",
+              backgroundColor: "var(--os-color-input-bg)",
               height: "280px",
               overflowY: "auto",
               overflowX: "hidden",

--- a/src/styles/themes.css
+++ b/src/styles/themes.css
@@ -2906,6 +2906,55 @@
     inset 0 1px 0 rgba(0, 0, 0, 0.3), inset 0 -1px 0 rgba(0, 0, 0, 0.3);
 }
 
+/* Dark mode: darken the gray track so the bright base gradient no longer
+   pops against the dark window. The blue Aqua fill keeps its identity
+   (matches Big Sur+ dark-mode progress bars). */
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"] .aqua-progress {
+  background:
+    /* Subtle top shine */
+    linear-gradient(
+      to bottom,
+      rgba(255, 255, 255, 0.12) 0%,
+      rgba(255, 255, 255, 0.04) 30%,
+      transparent 50%
+    ),
+    /* Recessed dark track */
+    linear-gradient(#1f1f22, #2c2c30);
+  box-shadow:
+    0 1px 1px rgba(0, 0, 0, 0.45),
+    inset 0 0 0 1px rgba(0, 0, 0, 0.6),
+    inset 0 1px 2px rgba(0, 0, 0, 0.55),
+    0 1px 0 rgba(255, 255, 255, 0.05);
+}
+
+/* Slightly dim the bright top highlights on the fill so it reads as a
+   recessed, lit element instead of a beaming light pill on the dark track. */
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"] .aqua-progress-fill {
+  background:
+    repeating-linear-gradient(
+      to right,
+      transparent 0px,
+      rgba(255, 255, 255, 0.12) 10px,
+      rgba(255, 255, 255, 0.16) 15px,
+      rgba(255, 255, 255, 0.12) 20px,
+      transparent 30px
+    ),
+    linear-gradient(
+      to bottom,
+      #1c4d86 0%,
+      #6ea6e6 8%,
+      #4d8dd6 25%,
+      #3d77c4 40%,
+      #4b8ed8 60%,
+      #5594db 80%,
+      #2f7ec7 100%
+    );
+  box-shadow:
+    inset 0 0 0 0.5px rgba(0, 0, 0, 0.55),
+    inset 0 1px 0 rgba(255, 255, 255, 0.18),
+    inset 0 -1px 0 rgba(0, 0, 0, 0.4);
+}
+
 /* -------------------------------------------------- */
 /* Sonner Toaster theme-aware typography               */
 /* Use OS theme font variables instead of per-component overrides */
@@ -3314,8 +3363,9 @@
    rgba(30,30,30,0.5)`) — so dropdown toggles and secondary buttons look
    like graphite chips instead of bright slabs.
 
-   `.aqua-button.primary` is intentionally left alone — primary OK buttons
-   keep their pulsing Aqua blue in both color schemes. */
+   `.aqua-button.primary` keeps its pulsing Aqua-blue gradient in both
+   color schemes; only its label color flips to white in dark mode (see
+   the `.aqua-button.primary` rule below). */
 :root[data-os-theme="macosx"][data-os-color-scheme="dark"] .macos-select-trigger,
 :root[data-os-theme="macosx"][data-os-color-scheme="dark"] .os-select-trigger-macos,
 :root[data-os-theme="macosx"][data-os-color-scheme="dark"] .os-btn-aqua-select,
@@ -3343,6 +3393,16 @@
 :root[data-os-theme="macosx"][data-os-color-scheme="dark"] .aqua-button.secondary span {
   color: rgba(255, 255, 255, 0.92) !important;
   text-shadow: 0 1px 0 rgba(0, 0, 0, 0.55) !important;
+}
+
+/* Primary (OK) button keeps its pulsing Aqua-blue gradient in dark mode,
+   but the baked-in `color: black` from `.aqua-button.primary` collapses
+   to near-invisible against the deep blue/cyan glow. Flip the label to
+   white with a soft dark shadow so the call-to-action stays readable. */
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"] .aqua-button.primary,
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"] .aqua-button.primary span {
+  color: #ffffff !important;
+  text-shadow: 0 1px 1px rgba(0, 0, 0, 0.55) !important;
 }
 
 /* Native <select> uses `background:` shorthand to layer a chevron SVG on

--- a/src/styles/themes.css
+++ b/src/styles/themes.css
@@ -44,6 +44,9 @@
   --os-color-sidebar-inset-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.25);
   --os-color-switch-track: #9ca3af;
   --os-color-switch-track-checked: #111827;
+  /* List surfaces (e.g. song / video search results). Container uses
+     `--os-color-input-bg`; alternating rows tint with this value. */
+  --os-color-list-row-alt-bg: #f3f4f6;
   --os-metrics-border-width: 2px;
   --os-metrics-radius: 0.5rem;
   --os-metrics-titlebar-height: 1.5rem;
@@ -1635,7 +1638,7 @@
 }
 
 .os-themed-input:focus {
-  background-color: #ffffff;
+  background-color: var(--os-color-input-bg);
   border-color: var(--os-color-input-focus-border);
   box-shadow: 0 0 0 3px var(--os-color-input-focus-ring);
   outline: none;
@@ -3141,6 +3144,10 @@
   --os-color-input-border: rgba(255, 255, 255, 0.18);
   --os-color-input-focus-border: rgba(95, 152, 247, 0.7);
   --os-color-input-focus-ring: rgba(95, 152, 247, 0.3);
+
+  /* List surfaces — slightly lifted off the input bg so alternating
+     rows still read against the dark surface. */
+  --os-color-list-row-alt-bg: rgba(255, 255, 255, 0.05);
 
   /* Sidebar / separators */
   --os-color-separator: rgba(255, 255, 255, 0.14);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

A cluster of macOS X dark-mode regressions reported by ryo:

1. **Focused input bg is white** — `.os-themed-input:focus` hardcoded `background-color: #ffffff`, so any focused field (e.g. iPod song search input) flashed paper-white over the dark window.
2. **Search result lists for songs / videos are still white** — `SongSearchDialog` drew its results scroller, alternating rows, secondary text, and border with hardcoded `#fff` / `#f3f4f6` / `#4b5563` / `#d1d5db` inline styles.
3. **Progress bar (boot screen + About Finder)** — `.aqua-progress` baked a `linear-gradient(#d0d0d0, #f5f5f5)` light track; on the dark pinstripe window it glowed like a fluorescent strip.
4. **Primary (blue) aqua button label was black** — `.aqua-button.primary` pinned `color: black`, which collapsed to near-invisible against the pulsing dark-blue gradient.

## Fix

`src/styles/themes.css`
- `.os-themed-input:focus` now uses `var(--os-color-input-bg)` instead of hardcoded `#ffffff`.
- Added a new `--os-color-list-row-alt-bg` token: `#f3f4f6` by default, `rgba(255, 255, 255, 0.05)` under `macosx` + dark.
- Added a dark-mode override for `.aqua-progress` (recessed dark track + dimmer top shine) and `.aqua-progress-fill` (slightly darker Aqua-blue gradient + softened top highlights).
- Added `.aqua-button.primary` dark-mode override: white label with a soft `rgba(0,0,0,0.55)` drop shadow. Gradient + glow are untouched so the button still pulses Aqua blue in both color schemes.

`src/components/dialogs/SongSearchDialog.tsx`
- Result list container background + border → `var(--os-color-input-bg)` / `var(--os-color-input-border)`.
- Alternating row backgrounds → `var(--os-color-input-bg)` and `var(--os-color-list-row-alt-bg)`.
- Secondary row label color (artist / album, channel) → `var(--os-color-text-secondary)`.
- Selected-row styling is unchanged — `[data-selected="true"]` already uses themed selection tokens.

No behavior change for any other theme (System 7, XP, Win98) or for macOS X light mode — the new tokens / overrides resolve to the same colors / treatment that were previously hardcoded.

## Walkthrough

![Focused input field uses dark themed background in macOS X dark mode](https://cursor.com/artifacts/c/art-c90868a1-5193-4bdc-85b6-31386cb3e503)
Focused input renders dark, not flashing white.

![About Finder progress bars with dark track + blue Aqua fill in dark mode](https://cursor.com/artifacts/c/art-02d1d72b-73f6-463a-a4fa-6a19e080f94d)
About Finder memory bars now have a dark recessed track; same `.aqua-progress` rule covers the boot screen progress bar.

![Primary Aqua button shows white label text on the pulsing blue gradient](https://cursor.com/artifacts/c/art-2e10ebc9-7a67-4e05-8a01-3aa01a7b1c9d)
Primary (default-variant) Aqua button label is now white, readable on the deep-blue pulse.

## Testing

- ✅ Manually exercised the iPod Add Song dialog (focused input + Add primary button) in macOS X dark mode.
- ✅ Opened "About This Computer" in macOS X dark mode — verified the memory progress bar tracks render dark.
- ✅ Verified the Apple Aqua primary button label flips to white via the System Preferences login button.
- ⚠️ Song search result list dark theming is code-verified only: the local VM has no `.env.local`, so YouTube / Apple Music searches return no results. The list consumes the same `--os-color-input-bg` token that fix #1 visually confirmed resolves to `#1f1f22` in dark mode, plus the new `--os-color-list-row-alt-bg` variable scoped to `:root[data-os-theme="macosx"][data-os-color-scheme="dark"]`.
- ✅ Light-mode aqua remains visually identical — all new tokens / overrides are scoped to `[data-os-color-scheme="dark"]` and the token defaults match the previous hardcoded values.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-A5E89E8F-E22F-464C-9332-F4E8D9E2FE5B"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-A5E89E8F-E22F-464C-9332-F4E8D9E2FE5B"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

