### PR TITLE
fix(aqua): exclude iPod screen from dark progress bar + lighten dark track

### DIFF
--- a/src/styles/themes.css
+++ b/src/styles/themes.css
@@ -2908,28 +2908,37 @@
 
 /* Dark mode: darken the gray track so the bright base gradient no longer
    pops against the dark window. The blue Aqua fill keeps its identity
-   (matches Big Sur+ dark-mode progress bars). */
-:root[data-os-theme="macosx"][data-os-color-scheme="dark"] .aqua-progress {
+   (matches Big Sur+ dark-mode progress bars).
+
+   `:not(.ipod-modern-screen *)` excludes any `.aqua-progress` rendered
+   inside the iPod's modern screen — the iPod chrome runs its own
+   self-contained "backlight" theme that is intentionally independent
+   from the OS dark-mode setting, so the bar must keep its light look. */
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"]
+  .aqua-progress:not(.ipod-modern-screen *) {
   background:
     /* Subtle top shine */
     linear-gradient(
       to bottom,
-      rgba(255, 255, 255, 0.12) 0%,
-      rgba(255, 255, 255, 0.04) 30%,
+      rgba(255, 255, 255, 0.14) 0%,
+      rgba(255, 255, 255, 0.05) 30%,
       transparent 50%
     ),
-    /* Recessed dark track */
-    linear-gradient(#1f1f22, #2c2c30);
+    /* Recessed dark track — keyed off Big Sur+ progress track (~#3a3a3c)
+       so the bar reads as a graphite recess rather than near-black. */
+    linear-gradient(#3a3a3e, #48484c);
   box-shadow:
-    0 1px 1px rgba(0, 0, 0, 0.45),
-    inset 0 0 0 1px rgba(0, 0, 0, 0.6),
-    inset 0 1px 2px rgba(0, 0, 0, 0.55),
-    0 1px 0 rgba(255, 255, 255, 0.05);
+    0 1px 1px rgba(0, 0, 0, 0.4),
+    inset 0 0 0 1px rgba(0, 0, 0, 0.55),
+    inset 0 1px 2px rgba(0, 0, 0, 0.45),
+    0 1px 0 rgba(255, 255, 255, 0.06);
 }
 
 /* Slightly dim the bright top highlights on the fill so it reads as a
-   recessed, lit element instead of a beaming light pill on the dark track. */
-:root[data-os-theme="macosx"][data-os-color-scheme="dark"] .aqua-progress-fill {
+   recessed, lit element instead of a beaming light pill on the dark track.
+   Scoped away from the iPod screen for the same reason as the track rule. */
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"]
+  .aqua-progress-fill:not(.ipod-modern-screen *) {
   background:
     repeating-linear-gradient(
       to right,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Follow-up to the recent `fix(aqua): dark mode for progress bar + primary button label` change.

## Why

- The dark-mode `.aqua-progress` / `.aqua-progress-fill` override was leaking into the iPod's modern UI. The iPod's `ipod-modern-screen` runs its own self-contained "backlight" theme that is **intentionally independent** from the OS dark-mode setting, so its Now Playing scrubber and the Music Quiz countdown shouldn't flip to the dark Aqua treatment when the system is dark.
- The dark track gradient (`#1f1f22 → #2c2c30`) was reading as near-black against window chrome — closer to a void than a recessed control.

## What

- Scope the dark-mode `.aqua-progress` and `.aqua-progress-fill` rules with `:not(.ipod-modern-screen *)` so anything rendered inside the iPod screen keeps its original aqua look in either color scheme. Both `IpodScreen.tsx` and `MusicQuiz.tsx` wrap their content in `.ipod-modern-screen`, so this covers both progress bar usages inside the iPod chassis.
- Lighten the dark track gradient to `#3a3a3e → #48484c` (keyed off Big Sur+ progress track `~#3a3a3c`) and nudge the shine/box-shadow values so OS-level progress bars (Boot screen, About Finder memory rows, Control Panels, Admin) read as a graphite recess rather than a near-black sliver. Inset/outer shadows softened slightly to match.

## Affected surfaces

- Unchanged in dark mode (now): iPod Now Playing scrubber, Music Quiz countdown.
- Still dark-themed: Boot screen progress, About This Finder memory bars, any other `.aqua-progress` outside the iPod.

## Test plan

- ✅ `bun run build` — CSS compiles, build succeeds, both `.aqua-progress:not(.ipod-modern-screen *)` and `.aqua-progress-fill:not(.ipod-modern-screen *)` are present in the emitted CSS bundle.
- Skipped GUI verification per `AGENTS.md` cloud-environment guidance ("Skip computer use / GUI-driven testing unless the user explicitly requests it"). The change is CSS-only and the selector scoping is mechanical.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5B6D4833-CF53-47E3-8D1E-3F506DA8F7CE"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5B6D4833-CF53-47E3-8D1E-3F506DA8F7CE"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

