### PR TITLE
fix(cursor-sdk): default Composer 2.5 fast and upgrade @cursor/sdk

### DIFF
--- a/api/chat/tools/cursor-repo-agent.ts
+++ b/api/chat/tools/cursor-repo-agent.ts
@@ -52,6 +52,71 @@ export function pickPrUrlFromRunGit(git: unknown): string | undefined {
 /** Default repo for ryOS Cursor Cloud runs (override with CURSOR_CLOUD_REPO_URL). */
 export const DEFAULT_RYOS_GITHUB_REPO_URL = "https://github.com/ryokun6/ryos";
 
+/** Default cloud model — Composer 2.5 Fast (`fast` is default; set explicitly for clarity). */
+export const DEFAULT_CURSOR_SDK_MODEL_ID = "composer-2.5";
+
+export const DEFAULT_CURSOR_SDK_MODEL: import("@cursor/sdk").ModelSelection = {
+  id: DEFAULT_CURSOR_SDK_MODEL_ID,
+  params: [{ id: "fast", value: "true" }],
+};
+
+const LEGACY_FAST_MODEL_IDS = new Set(["composer-2.5-fast", "composer-2-fast"]);
+
+/**
+ * Resolve a dashboard/env model id to SDK `ModelSelection`.
+ * Maps legacy `composer-2` / `composer-*-fast` aliases to Composer 2.5 Fast.
+ */
+export function resolveCursorSdkModelSelection(
+  modelIdOverride?: string | null
+): import("@cursor/sdk").ModelSelection {
+  const raw =
+    modelIdOverride?.trim() ||
+    process.env.CURSOR_SDK_MODEL?.trim() ||
+    "";
+  if (!raw) return DEFAULT_CURSOR_SDK_MODEL;
+  if (raw === "composer-2") {
+    return DEFAULT_CURSOR_SDK_MODEL;
+  }
+  if (LEGACY_FAST_MODEL_IDS.has(raw)) {
+    return {
+      id: raw.replace(/-fast$/, ""),
+      params: [{ id: "fast", value: "true" }],
+    };
+  }
+  if (raw === DEFAULT_CURSOR_SDK_MODEL_ID) {
+    return DEFAULT_CURSOR_SDK_MODEL;
+  }
+  return { id: raw };
+}
+
+function modelSelectionFromMeta(
+  meta: Record<string, unknown>
+): import("@cursor/sdk").ModelSelection | undefined {
+  const id = typeof meta.modelId === "string" ? meta.modelId.trim() : "";
+  if (!id) return undefined;
+  const params = meta.modelParams;
+  if (Array.isArray(params) && params.length > 0) {
+    const normalized: import("@cursor/sdk").ModelParameterValue[] = [];
+    for (const p of params) {
+      if (
+        p &&
+        typeof p === "object" &&
+        typeof (p as { id?: unknown }).id === "string" &&
+        typeof (p as { value?: unknown }).value === "string"
+      ) {
+        normalized.push({
+          id: (p as { id: string }).id,
+          value: (p as { value: string }).value,
+        });
+      }
+    }
+    if (normalized.length > 0) {
+      return { id, params: normalized };
+    }
+  }
+  return resolveCursorSdkModelSelection(id);
+}
+
 /** Cursor dashboard URL for a cloud agent (`bc_…` id from the SDK). */
 export function cursorCloudAgentDashboardUrl(agentId: string): string {
   const id = agentId.trim();
@@ -76,7 +141,7 @@ export const cursorCloudAgentSchema = z.object({
     .min(1)
     .optional()
     .describe(
-      "Optional model id (default composer-2). Use Cursor.models from dashboard-valid IDs."
+      "Optional model id (default composer-2.5 fast). Use Cursor.models.list() for valid ids; fast is a param on composer-2.5, not a separate id."
     ),
 });
 
@@ -480,13 +545,13 @@ async function executeBlockingPrompt(
     repoUrl: string;
     startingRef: string;
     autoCreatePR: boolean;
-    modelId: string;
+    model: import("@cursor/sdk").ModelSelection;
   }
 ): Promise<CursorCloudAgentToolOutput> {
   const { Agent } = await import("@cursor/sdk");
   const result = await Agent.prompt(input.prompt, {
     apiKey: context.apiKey,
-    model: { id: cloudOpts.modelId },
+    model: cloudOpts.model,
     cloud: {
       repos: [{ url: cloudOpts.repoUrl, startingRef: cloudOpts.startingRef }],
       autoCreatePR: cloudOpts.autoCreatePR,
@@ -715,10 +780,8 @@ export async function executeCursorCloudAgent(
     };
   }
 
-  const modelId =
-    input.modelId?.trim() ||
-    process.env.CURSOR_SDK_MODEL?.trim() ||
-    "composer-2";
+  const model = resolveCursorSdkModelSelection(input.modelId);
+  const modelId = model.id;
 
   const repoUrl =
     process.env.CURSOR_CLOUD_REPO_URL?.trim() || DEFAULT_RYOS_GITHUB_REPO_URL;
@@ -742,7 +805,7 @@ export async function executeCursorCloudAgent(
         repoUrl,
         startingRef,
         autoCreatePR,
-        modelId,
+        model,
       });
     } catch (e) {
       context.logError("[cursorCloudAgent] Agent.prompt failed", e);
@@ -757,7 +820,7 @@ export async function executeCursorCloudAgent(
     const { Agent } = await import("@cursor/sdk");
     const agent = await Agent.create({
       apiKey: context.apiKey,
-      model: { id: modelId },
+      model,
       cloud: {
         repos: [{ url: repoUrl, startingRef }],
         autoCreatePR,
@@ -802,6 +865,7 @@ export async function executeCursorCloudAgent(
         repoUrl,
         startingRef,
         modelId,
+        ...(model.params?.length ? { modelParams: model.params } : {}),
         autoCreatePR,
         createdAt: Date.now(),
         promptPreview: input.prompt.slice(0, 280),
@@ -953,8 +1017,8 @@ export async function sendCursorAgentFollowup(input: {
     typeof prevMeta.startingRef === "string"
       ? prevMeta.startingRef
       : undefined;
-  const modelId =
-    typeof prevMeta.modelId === "string" ? prevMeta.modelId : undefined;
+  const modelFromMeta = modelSelectionFromMeta(prevMeta);
+  const modelId = modelFromMeta?.id;
   const autoCreatePR =
     typeof prevMeta.autoCreatePR === "boolean"
       ? prevMeta.autoCreatePR
@@ -967,7 +1031,7 @@ export async function sendCursorAgentFollowup(input: {
     const { Agent } = await import("@cursor/sdk");
     const resumeOptions: Partial<import("@cursor/sdk").AgentOptions> = {
       apiKey,
-      ...(modelId ? { model: { id: modelId } } : {}),
+      ...(modelFromMeta ? { model: modelFromMeta } : {}),
     };
     agent = await Agent.resume(agentId, resumeOptions);
   } catch (e) {
@@ -983,6 +1047,15 @@ export async function sendCursorAgentFollowup(input: {
   try {
     run = await agent.send(prompt);
   } catch (e) {
+    const { AgentBusyError } = await import("@cursor/sdk");
+    if (e instanceof AgentBusyError) {
+      log("[cursorCloudAgent] follow-up rejected: agent busy (SDK)", { agentId });
+      return {
+        ok: false,
+        status: 409,
+        error: "Agent is busy with another run",
+      };
+    }
     logError("[cursorCloudAgent] follow-up send failed", e);
     try {
       const dispose = agent[Symbol.asyncDispose];
@@ -1014,6 +1087,9 @@ export async function sendCursorAgentFollowup(input: {
       ...(repoUrl ? { repoUrl } : {}),
       ...(startingRef ? { startingRef } : {}),
       ...(modelId ? { modelId } : {}),
+      ...(modelFromMeta?.params?.length
+        ? { modelParams: modelFromMeta.params }
+        : {}),
       ...(typeof autoCreatePR === "boolean" ? { autoCreatePR } : {}),
       ...(inheritedPrUrl ? { prUrl: inheritedPrUrl } : {}),
       createdAt: Date.now(),

--- a/bun.lock
+++ b/bun.lock
@@ -11,7 +11,7 @@
         "@ai-sdk/react": "^3.0.51",
         "@aws-sdk/client-s3": "^3.1041.0",
         "@aws-sdk/s3-request-presigner": "^3.1041.0",
-        "@cursor/sdk": "^1.0.9",
+        "@cursor/sdk": "1.0.15",
         "@paper-design/shaders-react": "^0.0.71",
         "@phosphor-icons/react": "^2.1.10",
         "@radix-ui/react-checkbox": "^1.3.3",
@@ -435,17 +435,17 @@
 
     "@connectrpc/connect-node": ["@connectrpc/connect-node@1.7.0", "", { "dependencies": { "undici": "^5.28.4" }, "peerDependencies": { "@bufbuild/protobuf": "^1.10.0", "@connectrpc/connect": "1.7.0" } }, "sha512-6vaPIkG/NyhxlYgytLoR9KYbPhczEboFB2OYWkA9qvUz1K7efXfeGrlRxoLtpa+r8VxyIOw73w5ktNe743nD+A=="],
 
-    "@cursor/sdk": ["@cursor/sdk@1.0.9", "", { "dependencies": { "@bufbuild/protobuf": "1.10.0", "@connectrpc/connect": "^1.6.1", "@connectrpc/connect-node": "^1.6.1", "@statsig/js-client": "3.31.0", "sqlite3": "^5.1.7", "zod": "^3.25.0" }, "optionalDependencies": { "@cursor/sdk-darwin-arm64": "1.0.9", "@cursor/sdk-darwin-x64": "1.0.9", "@cursor/sdk-linux-arm64": "1.0.9", "@cursor/sdk-linux-x64": "1.0.9", "@cursor/sdk-win32-x64": "1.0.9" } }, "sha512-UYoWWnVqmS5mA6nteR8iyxRQrscSvqZUFYyaboQkCWNvETLTm2JI7tTx/RhCprEToukqufhF2pINOBJmPeFfdA=="],
+    "@cursor/sdk": ["@cursor/sdk@1.0.15", "", { "dependencies": { "@bufbuild/protobuf": "1.10.0", "@connectrpc/connect": "^1.6.1", "@connectrpc/connect-node": "^1.6.1", "@statsig/js-client": "3.31.0", "sqlite3": "^5.1.7", "zod": "^3.25.0" }, "optionalDependencies": { "@cursor/sdk-darwin-arm64": "1.0.15", "@cursor/sdk-darwin-x64": "1.0.15", "@cursor/sdk-linux-arm64": "1.0.15", "@cursor/sdk-linux-x64": "1.0.15", "@cursor/sdk-win32-x64": "1.0.15" } }, "sha512-O8ItVzKZX4L0veS/PH0vwA/0/sxV5doTprrDiBo6llBcTqRMZCj83e227lSoWg45f8wLDc8pVYaWktfE/B2rEw=="],
 
-    "@cursor/sdk-darwin-arm64": ["@cursor/sdk-darwin-arm64@1.0.9", "", { "os": "darwin", "cpu": "arm64" }, "sha512-C9O4WGRt4u0f/qFXgYYdrfEi2zui53Ax21JrdvliQd9mzKje+fjxwGWy37SHxqE4hSMR7G/+L7rqf0dyIdtUBQ=="],
+    "@cursor/sdk-darwin-arm64": ["@cursor/sdk-darwin-arm64@1.0.15", "", { "os": "darwin", "cpu": "arm64", "bin": { "rg": "bin/rg" } }, "sha512-4xr9nE8komOcUmYX8XYT0tgP5tX9Psy6WOVncST4B+W6rRAjpqRhJMCe0ArTXARsC+OFojPhUjbe+BHzC6MNTQ=="],
 
-    "@cursor/sdk-darwin-x64": ["@cursor/sdk-darwin-x64@1.0.9", "", { "os": "darwin", "cpu": "x64" }, "sha512-ct81x1xEyx5tL+tJHpxdwDE0qpMJtey6VHyLxUHjrCMeJTZvFhmAwu6jcv88KgXsimXkBAwQ9E4n0O6gS9ND9Q=="],
+    "@cursor/sdk-darwin-x64": ["@cursor/sdk-darwin-x64@1.0.15", "", { "os": "darwin", "cpu": "x64", "bin": { "rg": "bin/rg" } }, "sha512-/JKlPTj6JweK2K0EKJAHhpOTbE7IPU5Hw2MCbYtYgyfEI1u/X/8lkAV3KYT/VdnYH0nX8cLuQe8SDJ3MXMSiPg=="],
 
-    "@cursor/sdk-linux-arm64": ["@cursor/sdk-linux-arm64@1.0.9", "", { "os": "linux", "cpu": "arm64" }, "sha512-EO8rQaEItCzNnR5OKQms364Tuz6CwceP2CAZH7RKgoai+detIQfkNjxqBnChhKA1Sq+8QERCZkrdNEFD+Slk4g=="],
+    "@cursor/sdk-linux-arm64": ["@cursor/sdk-linux-arm64@1.0.15", "", { "os": "linux", "cpu": "arm64", "bin": { "rg": "bin/rg" } }, "sha512-0jA3/Y5SpU65wITttFenM3wfk+ab2/xhTVevbo439WOOA+blK0iU+2Dv2wjRJB6TI6R5kfLuEJuk6w1VJV4PQA=="],
 
-    "@cursor/sdk-linux-x64": ["@cursor/sdk-linux-x64@1.0.9", "", { "os": "linux", "cpu": "x64" }, "sha512-hTtRyZBKz3WMM7xmuDSvlIhYkOUQCgG+JsCKerY3RDeOW2Fqwh5Vj8qpBKS13+T1NNNRFA4kLnPnh9WxqI9vLg=="],
+    "@cursor/sdk-linux-x64": ["@cursor/sdk-linux-x64@1.0.15", "", { "os": "linux", "cpu": "x64", "bin": { "rg": "bin/rg" } }, "sha512-WoYAq3zKKhBT/PlTkU4c3vDHQOU/UlBD6iErHLXEwNWmLjdTSS7EDD0tMrtdVBlEiT/naRt+yMvwqX7TvO3oDA=="],
 
-    "@cursor/sdk-win32-x64": ["@cursor/sdk-win32-x64@1.0.9", "", { "os": "win32", "cpu": "x64" }, "sha512-XM4nQUNgwsykAhd8Dil9PKACfiGJPXTZXmsjrkIyBtnjTFqNRPsPHpHoq++a3RQ6ZAvcgje03SgNSLE39WE6uA=="],
+    "@cursor/sdk-win32-x64": ["@cursor/sdk-win32-x64@1.0.15", "", { "os": "win32", "cpu": "x64", "bin": { "rg": "bin/rg.exe" } }, "sha512-eqUVz+mfUmCqS1iUcqbRUbml9wsFzYAwxwLNg9s4d6xTbj9VIJaOdVejxhYN6U4dvqmGwTHhgmB0z5b7oKw0jA=="],
 
     "@deno/shim-deno": ["@deno/shim-deno@0.18.2", "", { "dependencies": { "@deno/shim-deno-test": "^0.5.0", "which": "^4.0.0" } }, "sha512-oQ0CVmOio63wlhwQF75zA4ioolPvOwAoK0yuzcS5bDC1JUvH3y1GS8xPh8EOpcoDQRU4FTG8OQfxhpR+c6DrzA=="],
 

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "@ai-sdk/react": "^3.0.51",
     "@aws-sdk/client-s3": "^3.1041.0",
     "@aws-sdk/s3-request-presigner": "^3.1041.0",
-    "@cursor/sdk": "^1.0.9",
+    "@cursor/sdk": "1.0.15",
     "@paper-design/shaders-react": "^0.0.71",
     "@phosphor-icons/react": "^2.1.10",
     "@radix-ui/react-checkbox": "^1.3.3",

--- a/tests/test-cursor-repo-agent-tool.test.ts
+++ b/tests/test-cursor-repo-agent-tool.test.ts
@@ -1,12 +1,15 @@
-import { describe, expect, test } from "bun:test";
+import { afterAll, describe, expect, test } from "bun:test";
 import {
   cursorSdkMetaKey,
+  DEFAULT_CURSOR_SDK_MODEL,
+  DEFAULT_CURSOR_SDK_MODEL_ID,
   DEFAULT_RYOS_GITHUB_REPO_URL,
   executeCursorCloudAgent,
   executeListCursorCloudAgentRuns,
   formatCursorRunCompletionTelegramMessage,
   listCursorSdkRunsFromRedis,
   pickPrUrlFromRunGit,
+  resolveCursorSdkModelSelection,
   sendCursorAgentFollowup,
 } from "../api/chat/tools/cursor-repo-agent.js";
 import type { Redis } from "../api/_utils/redis.js";
@@ -47,6 +50,43 @@ describe("cursorCloudAgent gate", () => {
     expect(DEFAULT_RYOS_GITHUB_REPO_URL).toBe(
       "https://github.com/ryokun6/ryos"
     );
+  });
+});
+
+describe("resolveCursorSdkModelSelection", () => {
+  const prevEnv = process.env.CURSOR_SDK_MODEL;
+
+  test("defaults to Composer 2.5 fast when unset", () => {
+    delete process.env.CURSOR_SDK_MODEL;
+    expect(resolveCursorSdkModelSelection()).toEqual(DEFAULT_CURSOR_SDK_MODEL);
+    expect(DEFAULT_CURSOR_SDK_MODEL_ID).toBe("composer-2.5");
+  });
+
+  test("maps legacy composer-2 to Composer 2.5 fast", () => {
+    expect(resolveCursorSdkModelSelection("composer-2")).toEqual(
+      DEFAULT_CURSOR_SDK_MODEL
+    );
+  });
+
+  test("maps composer-2.5-fast alias to ModelSelection params", () => {
+    expect(resolveCursorSdkModelSelection("composer-2.5-fast")).toEqual({
+      id: "composer-2.5",
+      params: [{ id: "fast", value: "true" }],
+    });
+  });
+
+  test("respects explicit non-composer model ids", () => {
+    expect(resolveCursorSdkModelSelection("claude-4.6-sonnet")).toEqual({
+      id: "claude-4.6-sonnet",
+    });
+  });
+
+  afterAll(() => {
+    if (prevEnv === undefined) {
+      delete process.env.CURSOR_SDK_MODEL;
+    } else {
+      process.env.CURSOR_SDK_MODEL = prevEnv;
+    }
   });
 });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Aligns ryOS Cursor Cloud agent integration with current [Cursor TypeScript SDK](https://cursor.com/docs/sdk/typescript.md) model selection:

- Upgrades `@cursor/sdk` from 1.0.9 → **1.0.15**
- Defaults cloud runs to **Composer 2.5 Fast** via `{ id: "composer-2.5", params: [{ id: "fast", value: "true" }] }` (not a separate `composer-2.5-fast` id)
- Maps legacy `composer-2` and `composer-*-fast` aliases
- Persists `modelParams` in Redis run meta so follow-ups resume with the same selection
- Maps SDK `AgentBusyError` on follow-up send to HTTP **409**

## Testing

- `bun test tests/test-cursor-repo-agent-tool.test.ts`
- `bun test tests/test-cursor-sdk-run-coalesce.test.ts`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-E3B78333-D2D7-45AF-AA41-B55C57F58D9A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-E3B78333-D2D7-45AF-AA41-B55C57F58D9A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

