### PR TITLE
fix(shell): disable F4 Dashboard shortcut on mobile

### DIFF
--- a/src/apps/base/AppManager.tsx
+++ b/src/apps/base/AppManager.tsx
@@ -21,11 +21,10 @@ import { isTextEditInitialData } from "@/types/appInitialData";
 import {
   emitAppUpdate,
   onAppLaunchRequest,
-  onExposeToggle,
-  onSpotlightToggle,
   requestAppLaunch,
   toggleSpotlightSearch,
 } from "@/utils/appEventBus";
+import { useDashboardShellTriggers } from "@/hooks/useDashboardShellTriggers";
 import { prefetchAppChunk, prefetchLikelyAppChunks } from "@/config/lazyAppComponent";
 import { useAppStore } from "@/stores/useAppStore";
 import { useGlobalUndoRedo } from "@/hooks/useGlobalUndoRedo";
@@ -354,53 +353,30 @@ export function AppManager({ apps }: AppManagerProps) {
     }
   }, [closeAppInstance]);
 
-  // Listen for expose view toggle events (e.g., from keyboard shortcut, dock menu)
-  useEffect(() => {
-    const handleExposeToggle = () => {
-      closeDashboardIfOpen();
+  const closeOverlaysForSpotlight = useCallback(() => {
+    setIsExposeViewOpen(false);
+    closeDashboardIfOpen();
+  }, [closeDashboardIfOpen]);
+
+  useDashboardShellTriggers({
+    closeDashboardIfOpen,
+    toggleExposeFromKeyboard: () => {
       setIsExposeViewOpen((prev) => !prev);
-    };
-
-    const handleKeyDown = (e: KeyboardEvent) => {
-      // F3 key to toggle Expose view (Mission Control)
-      if (e.key === "F3" || (e.key === "f" && e.metaKey)) {
-        e.preventDefault();
-        // Close Dashboard if open
-        closeDashboardIfOpen();
-        setIsExposeViewOpen((prev) => !prev);
-      }
-      // F4 key to toggle Dashboard
-      if (e.key === "F4") {
-        e.preventDefault();
-        // Close Expose if open
-        setIsExposeViewOpen(false);
-        toggleDashboard();
-      }
-      // ⌘+Space / Ctrl+Space to toggle Spotlight Search
-      if (e.key === " " && (e.metaKey || e.ctrlKey)) {
-        e.preventDefault();
-        // Close Expose and Dashboard if open before toggling Spotlight
-        setIsExposeViewOpen(false);
-        closeDashboardIfOpen();
-        toggleSpotlightSearch();
-      }
-    };
-
-    // Close Expose when Spotlight opens via any trigger (icon click, Start Menu "Run...")
-    const handleSpotlightToggle = () => {
+    },
+    toggleExposeFromEvent: () => {
+      setIsExposeViewOpen((prev) => !prev);
+    },
+    toggleDashboardFromKeyboard: () => {
+      setIsExposeViewOpen(false);
+      toggleDashboard();
+    },
+    toggleSpotlightFromKeyboard: () => {
       setIsExposeViewOpen(false);
       closeDashboardIfOpen();
-    };
-
-    const unsubscribeExposeToggle = onExposeToggle(handleExposeToggle);
-    const unsubscribeSpotlightToggle = onSpotlightToggle(handleSpotlightToggle);
-    window.addEventListener("keydown", handleKeyDown);
-    return () => {
-      unsubscribeExposeToggle();
-      unsubscribeSpotlightToggle();
-      window.removeEventListener("keydown", handleKeyDown);
-    };
-  }, [closeDashboardIfOpen, toggleDashboard]);
+      toggleSpotlightSearch();
+    },
+    closeOverlaysForSpotlightEvent: closeOverlaysForSpotlight,
+  });
 
   // Global macOS-style window management and app switcher keyboard shortcuts
   useEffect(() => {

--- a/src/hooks/useDashboardShellTriggers.ts
+++ b/src/hooks/useDashboardShellTriggers.ts
@@ -1,0 +1,84 @@
+import { useEffect } from "react";
+import { useIsMobile } from "@/hooks/useIsMobile";
+import { onExposeToggle, onSpotlightToggle } from "@/utils/appEventBus";
+
+export type DashboardShellTriggerHandlers = {
+  /** Toggle Dashboard (caller should close Expose first when opening via keyboard). */
+  toggleDashboardFromKeyboard: () => void;
+  closeDashboardIfOpen: () => void;
+  toggleExposeFromKeyboard: () => void;
+  toggleExposeFromEvent: () => void;
+  toggleSpotlightFromKeyboard: () => void;
+  closeOverlaysForSpotlightEvent: () => void;
+};
+
+/** F4 Dashboard shortcut is desktop-only; no corner/gesture shell triggers on mobile. */
+export function shouldEnableDashboardShellKeyboardTriggers(isMobile: boolean): boolean {
+  return !isMobile;
+}
+
+/**
+ * Registers global shell shortcuts for Dashboard, Expose, and Spotlight.
+ * F4 Dashboard toggle is disabled on mobile (touch / narrow viewports).
+ */
+export function useDashboardShellTriggers({
+  toggleDashboardFromKeyboard,
+  closeDashboardIfOpen,
+  toggleExposeFromKeyboard,
+  toggleExposeFromEvent,
+  toggleSpotlightFromKeyboard,
+  closeOverlaysForSpotlightEvent,
+}: DashboardShellTriggerHandlers): void {
+  const isMobile = useIsMobile();
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      // F3 key to toggle Expose view (Mission Control)
+      if (e.key === "F3" || (e.key === "f" && e.metaKey)) {
+        e.preventDefault();
+        closeDashboardIfOpen();
+        toggleExposeFromKeyboard();
+        return;
+      }
+
+      // F4 key to toggle Dashboard (desktop / non-mobile only)
+      if (e.key === "F4") {
+        if (!shouldEnableDashboardShellKeyboardTriggers(isMobile)) {
+          return;
+        }
+        e.preventDefault();
+        toggleDashboardFromKeyboard();
+        return;
+      }
+
+      // ⌘+Space / Ctrl+Space to toggle Spotlight Search
+      if (e.key === " " && (e.metaKey || e.ctrlKey)) {
+        e.preventDefault();
+        toggleSpotlightFromKeyboard();
+      }
+    };
+
+    const unsubscribeExposeToggle = onExposeToggle(() => {
+      closeDashboardIfOpen();
+      toggleExposeFromEvent();
+    });
+    const unsubscribeSpotlightToggle = onSpotlightToggle(
+      closeOverlaysForSpotlightEvent
+    );
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => {
+      unsubscribeExposeToggle();
+      unsubscribeSpotlightToggle();
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [
+    isMobile,
+    toggleDashboardFromKeyboard,
+    closeDashboardIfOpen,
+    toggleExposeFromKeyboard,
+    toggleExposeFromEvent,
+    toggleSpotlightFromKeyboard,
+    closeOverlaysForSpotlightEvent,
+  ]);
+}

--- a/tests/test-dashboard-shell-triggers.test.ts
+++ b/tests/test-dashboard-shell-triggers.test.ts
@@ -1,0 +1,14 @@
+#!/usr/bin/env bun
+
+import { describe, expect, test } from "bun:test";
+import { shouldEnableDashboardShellKeyboardTriggers } from "../src/hooks/useDashboardShellTriggers";
+
+describe("dashboard shell triggers", () => {
+  test("F4 keyboard shortcut is disabled on mobile", () => {
+    expect(shouldEnableDashboardShellKeyboardTriggers(true)).toBe(false);
+  });
+
+  test("F4 keyboard shortcut is enabled on desktop", () => {
+    expect(shouldEnableDashboardShellKeyboardTriggers(false)).toBe(true);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Investigated Dashboard shell open triggers across `main` and related branches.

- **Corner / gesture triggers:** None found (no hot-corner zones, edge swipes, or pointer handlers that launch Dashboard).
- **Global keyboard trigger:** F4 in `AppManager` toggles Dashboard (documented in help metadata).

This change disables the F4 Dashboard shortcut on mobile (`useIsMobile`: touch or viewport &lt; 768px) and extracts shell shortcut wiring into `useDashboardShellTriggers`.

Expose (F3) and Spotlight shortcuts are unchanged.

## Testing

- `bun test tests/test-dashboard-shell-triggers.test.ts`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-E210AE2B-B7FF-4449-9C69-724F691DCD1C"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-E210AE2B-B7FF-4449-9C69-724F691DCD1C"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

