### PR TITLE
fix(dock): swipe-up reveal on small-height mobile with tap-through

### DIFF
--- a/src/components/layout/Dock.tsx
+++ b/src/components/layout/Dock.tsx
@@ -39,6 +39,11 @@ import {
 import { useShallow } from "zustand/react/shallow";
 import { toggleExposeView } from "@/utils/appEventBus";
 import { prefetchAppChunk } from "@/config/lazyAppComponent";
+import { useMediaQuery } from "@/hooks/useMediaQuery";
+import {
+  isClientYInBottomZone,
+  shouldRevealDockFromSwipeUp,
+} from "@/utils/dockRevealGesture";
 
 const MAX_SCALE = 2.3; // peak multiplier at cursor center
 const DISTANCE = 140; // px range where magnification is applied
@@ -590,6 +595,10 @@ const MULTI_WINDOW_APPS: AppId[] = ["textedit", "finder", "applet-viewer"];
 function MacDock() {
   const { t } = useTranslation();
   const isPhone = useIsPhone();
+  const isCompactHeight = useMediaQuery("(max-height: 520px)");
+  const hasCoarsePointer = useMediaQuery("(pointer: coarse)");
+  /** Touch + phone width, or touch + short viewport (e.g. phone landscape). */
+  const useSwipeToRevealDock = isPhone || (hasCoarsePointer && isCompactHeight);
   const { instances, instanceOrder, bringInstanceToForeground, restoreInstance, minimizeInstance, closeAppInstance } =
     useAppStoreShallow((s) => ({
       instances: s.instances,
@@ -906,6 +915,77 @@ function MacDock() {
     
     setIsDockVisible(false);
   }, [dockHiding, draggingItemId, externalDragIndex, trashContextMenuPos, applicationsContextMenuPos, appContextMenu, dividerContextMenuPos]);
+
+  // Mobile / small-height: swipe up from bottom reveals dock; taps pass through.
+  useEffect(() => {
+    if (!dockHiding || isDockVisible || !useSwipeToRevealDock) {
+      return;
+    }
+
+    const getZoneHeightPx = () => {
+      const safeInset = parseInt(
+        getComputedStyle(document.documentElement).getPropertyValue(
+          "--sat-safe-area-bottom",
+        ),
+        10,
+      );
+      const safeBottom = Number.isFinite(safeInset) ? safeInset : 0;
+      return scaledDockHeight + safeBottom;
+    };
+
+    let activePointer: {
+      pointerId: number;
+      startX: number;
+      startY: number;
+    } | null = null;
+
+    const clearActivePointer = () => {
+      activePointer = null;
+    };
+
+    const onPointerDown = (e: PointerEvent) => {
+      if (e.pointerType === "mouse") return;
+      const zoneHeight = getZoneHeightPx();
+      if (!isClientYInBottomZone(e.clientY, window.innerHeight, zoneHeight)) {
+        return;
+      }
+      activePointer = {
+        pointerId: e.pointerId,
+        startX: e.clientX,
+        startY: e.clientY,
+      };
+    };
+
+    const onPointerUp = (e: PointerEvent) => {
+      if (!activePointer || e.pointerId !== activePointer.pointerId) {
+        return;
+      }
+      const deltaX = e.clientX - activePointer.startX;
+      const deltaY = e.clientY - activePointer.startY;
+      clearActivePointer();
+
+      if (shouldRevealDockFromSwipeUp(deltaX, deltaY)) {
+        showDock();
+      }
+    };
+
+    window.addEventListener("pointerdown", onPointerDown);
+    window.addEventListener("pointerup", onPointerUp);
+    window.addEventListener("pointercancel", clearActivePointer);
+
+    return () => {
+      window.removeEventListener("pointerdown", onPointerDown);
+      window.removeEventListener("pointerup", onPointerUp);
+      window.removeEventListener("pointercancel", clearActivePointer);
+      clearActivePointer();
+    };
+  }, [
+    dockHiding,
+    isDockVisible,
+    useSwipeToRevealDock,
+    scaledDockHeight,
+    showDock,
+  ]);
 
   // Divider context menu handler
   const handleDividerContextMenu = useCallback((e: React.MouseEvent) => {
@@ -2548,25 +2628,18 @@ function MacDock() {
         </motion.div>
       </div>
       
-      {/* Invisible hover zone at bottom edge to trigger dock reveal when hiding is enabled */}
-      {dockHiding && !isDockVisible && (
+      {/* Desktop: hover zone reveals hidden dock. Mobile uses swipe (see effect above). */}
+      {dockHiding && !isDockVisible && !useSwipeToRevealDock && (
         <div
           className="fixed left-0 right-0 z-40"
           style={{
             bottom: 0,
-            // Desktop: half dock height, Mobile: full dock height + safe area
-            height: isPhone 
-              ? `calc(${scaledDockHeight}px + env(safe-area-inset-bottom, 0px))` 
-              : Math.max(Math.round(scaledDockHeight / 2), 8),
+            height: Math.max(Math.round(scaledDockHeight / 2), 8),
             pointerEvents: "auto",
             // Debug: uncomment to visualize hover zone
             // backgroundColor: "rgba(255, 0, 0, 0.2)",
           }}
           onMouseEnter={showDock}
-          onTouchStart={(e) => {
-            e.preventDefault();
-            showDock();
-          }}
         />
       )}
       

--- a/src/utils/dockRevealGesture.ts
+++ b/src/utils/dockRevealGesture.ts
@@ -1,0 +1,36 @@
+/** Minimum upward movement (px) to reveal a hidden dock via swipe. */
+export const DOCK_SWIPE_UP_THRESHOLD_PX = 48;
+
+/** Movement below this (px) is treated as a tap, not a swipe. */
+export const DOCK_SWIPE_MOVE_THRESHOLD_PX = 12;
+
+export function shouldRevealDockFromSwipeUp(
+  deltaX: number,
+  deltaY: number,
+  options?: {
+    swipeUpThreshold?: number;
+    moveThreshold?: number;
+  },
+): boolean {
+  const swipeUpThreshold =
+    options?.swipeUpThreshold ?? DOCK_SWIPE_UP_THRESHOLD_PX;
+  const moveThreshold =
+    options?.moveThreshold ?? DOCK_SWIPE_MOVE_THRESHOLD_PX;
+
+  const absDx = Math.abs(deltaX);
+  const absDy = Math.abs(deltaY);
+
+  if (absDx < moveThreshold && absDy < moveThreshold) {
+    return false;
+  }
+
+  return deltaY < -swipeUpThreshold && absDy > absDx;
+}
+
+export function isClientYInBottomZone(
+  clientY: number,
+  viewportHeight: number,
+  zoneHeightPx: number,
+): boolean {
+  return clientY >= viewportHeight - zoneHeightPx;
+}

--- a/tests/test-dock-reveal-gesture.test.ts
+++ b/tests/test-dock-reveal-gesture.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "bun:test";
+import {
+  isClientYInBottomZone,
+  shouldRevealDockFromSwipeUp,
+} from "../src/utils/dockRevealGesture";
+
+describe("shouldRevealDockFromSwipeUp", () => {
+  test("returns false for taps with negligible movement", () => {
+    expect(shouldRevealDockFromSwipeUp(0, 0)).toBe(false);
+    expect(shouldRevealDockFromSwipeUp(5, -8)).toBe(false);
+  });
+
+  test("returns true for upward swipes past threshold", () => {
+    expect(shouldRevealDockFromSwipeUp(10, -60)).toBe(true);
+    expect(shouldRevealDockFromSwipeUp(-5, -50)).toBe(true);
+  });
+
+  test("returns false for downward or mostly horizontal movement", () => {
+    expect(shouldRevealDockFromSwipeUp(0, 60)).toBe(false);
+    expect(shouldRevealDockFromSwipeUp(80, -20)).toBe(false);
+  });
+});
+
+describe("isClientYInBottomZone", () => {
+  test("detects coordinates in the bottom band", () => {
+    expect(isClientYInBottomZone(950, 1000, 80)).toBe(true);
+    expect(isClientYInBottomZone(900, 1000, 80)).toBe(false);
+    expect(isClientYInBottomZone(920, 1000, 80)).toBe(true);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

When dock auto-hide is enabled on touch devices (phone width or coarse pointer + short viewport), the hidden dock now reveals only on an **upward swipe** from the bottom hot zone—not on tap.

- Removed the full-height mobile overlay that called `preventDefault` + `showDock()` on `touchstart`, which blocked underlying clicks.
- Added document-level pointer handlers with `pointer-events` pass-through semantics (no overlay on mobile).
- Desktop behavior unchanged: half-height bottom edge still reveals via `mouseenter`.

## Testing

- `bun test tests/test-dock-reveal-gesture.test.ts` — gesture threshold + zone helpers
- `bun run test:unit` — all unit suites pass (238 tests)

## Files

- `src/components/layout/Dock.tsx` — swipe reveal effect + desktop-only hover zone
- `src/utils/dockRevealGesture.ts` — pure swipe/zone helpers
- `tests/test-dock-reveal-gesture.test.ts` — unit coverage
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8e9d1f27-0271-43f5-b7f2-a6061a4e9a73"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8e9d1f27-0271-43f5-b7f2-a6061a4e9a73"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

