### PR TITLE
fix(build): import IpodAppComponent directly in standalone shell

### DIFF
--- a/api/_utils/og-share.ts
+++ b/api/_utils/og-share.ts
@@ -414,6 +414,35 @@ export async function createOgShareResponse(
     matched = true;
   }
 
+  const standaloneIpodMatch = pathname.match(/^\/standalone\/ipod\/([^/?#]+)$/);
+  if (standaloneIpodMatch) {
+    const songId = resolveSongShareId(standaloneIpodMatch[1]);
+    imageUrl = getAppIconUrl(publicOrigin, "ipod");
+
+    const songInfo = await (options.getSong || getSongFromRedis)(songId);
+    if (songInfo) {
+      imageUrl = formatMusicCoverUrl(songInfo.cover, 400) || imageUrl;
+      if (songInfo.artist) {
+        title = `${songInfo.title} - ${songInfo.artist}`;
+        description = "Listen on ryOS iPod";
+      } else {
+        title = songInfo.title;
+        description = "Listen on ryOS iPod";
+      }
+    } else {
+      title = "Shared Song - ryOS";
+      description = "Listen on ryOS iPod";
+    }
+    matched = true;
+  }
+
+  if (pathname === "/standalone/ipod") {
+    imageUrl = getAppIconUrl(publicOrigin, "ipod");
+    title = "iPod on ryOS";
+    description = APP_DESCRIPTIONS.ipod || "Open app in ryOS";
+    matched = true;
+  }
+
   const ipodMatch = pathname.match(/^\/ipod\/([^/?#]+)$/);
   if (ipodMatch) {
     const songId = resolveSongShareId(ipodMatch[1]);

--- a/middleware.ts
+++ b/middleware.ts
@@ -19,6 +19,8 @@ export const config = {
     "/videos/:path*",
     "/ipod",
     "/ipod/:path*",
+    "/standalone/ipod",
+    "/standalone/ipod/:path*",
     "/karaoke",
     "/karaoke/:path*",
     "/listen/:path*",

--- a/src/StandaloneIpodApp.tsx
+++ b/src/StandaloneIpodApp.tsx
@@ -1,0 +1,169 @@
+import { useEffect, useMemo, useRef } from "react";
+import { useTranslation } from "react-i18next";
+import { Toaster } from "@/components/ui/sonner";
+import { AppErrorBoundary } from "@/components/errors/ErrorBoundaries";
+import { DesktopErrorBoundary } from "@/components/errors/ErrorBoundaries";
+import { getAppComponent } from "@/config/appRegistry";
+import { getWindowConfig } from "@/config/appRegistry";
+import { appRegistry } from "@/config/appRegistry";
+import { useAppStoreShallow } from "@/stores/helpers";
+import { useThemeFlags } from "@/hooks/useThemeFlags";
+import { useIsMobile } from "@/hooks/useIsMobile";
+import { useOffline } from "@/hooks/useOffline";
+import { applyDisplayMode } from "@/utils/displayMode";
+import { useDisplaySettingsStoreShallow } from "@/stores/helpers";
+import { getTranslatedAppName } from "@/utils/i18n";
+import { parseStandaloneIpodRoute } from "@/utils/standaloneIpodRoute";
+import type { IpodInitialData } from "@/apps/base/types";
+
+const IPOD_APP_ID = "ipod" as const;
+
+export function StandaloneIpodApp() {
+  const { t } = useTranslation();
+  const displayMode = useDisplaySettingsStoreShallow((state) => state.displayMode);
+  const { isWindowsTheme, isMacOSTheme, isSystem7Theme } = useThemeFlags();
+  const isMobile = useIsMobile();
+  useOffline();
+
+  const routeInitialData = useMemo(
+    () =>
+      parseStandaloneIpodRoute(
+        window.location.pathname,
+        window.location.search
+      ) ?? {},
+    []
+  );
+
+  const launchedRef = useRef(false);
+  const instanceIdRef = useRef<string | null>(null);
+
+  const { instances, launchApp, updateInstanceWindowState } =
+    useAppStoreShallow((state) => ({
+      instances: state.instances,
+      launchApp: state.launchApp,
+      updateInstanceWindowState: state.updateInstanceWindowState,
+    }));
+
+  useEffect(() => {
+    applyDisplayMode(displayMode);
+  }, [displayMode]);
+
+  useEffect(() => {
+    document.documentElement.dataset.standaloneIpod = "true";
+    document.title = "iPod · ryOS";
+    return () => {
+      delete document.documentElement.dataset.standaloneIpod;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (launchedRef.current) return;
+    launchedRef.current = true;
+
+    const id = launchApp(IPOD_APP_ID, routeInitialData as IpodInitialData);
+    instanceIdRef.current = id;
+
+    const config = getWindowConfig(IPOD_APP_ID);
+    const width = config.defaultSize.width;
+    const height = config.defaultSize.height;
+    const position = {
+      x: Math.max(0, Math.round((window.innerWidth - width) / 2)),
+      y: Math.max(0, Math.round((window.innerHeight - height) / 2)),
+    };
+    updateInstanceWindowState(id, position, { width, height });
+
+    const onResize = () => {
+      updateInstanceWindowState(
+        id,
+        {
+          x: Math.max(0, Math.round((window.innerWidth - width) / 2)),
+          y: Math.max(0, Math.round((window.innerHeight - height) / 2)),
+        },
+        { width, height }
+      );
+    };
+    window.addEventListener("resize", onResize);
+    return () => window.removeEventListener("resize", onResize);
+  }, [launchApp, routeInitialData, updateInstanceWindowState]);
+
+  const ipodInstance = Object.values(instances).find(
+    (instance) => instance.appId === IPOD_APP_ID && instance.isOpen
+  );
+
+  const toastConfig = useMemo(() => {
+    const dockHeight = isMacOSTheme ? 56 : 0;
+    const taskbarHeight = isWindowsTheme ? 30 : 0;
+
+    if (isMobile) {
+      const bottomOffset = dockHeight + taskbarHeight + 16;
+      return {
+        position: "bottom-center" as const,
+        offset: `calc(env(safe-area-inset-bottom, 0px) + ${bottomOffset}px)`,
+      };
+    }
+
+    if (isWindowsTheme) {
+      return {
+        position: "bottom-right" as const,
+        offset: `calc(env(safe-area-inset-bottom, 0px) + 42px)`,
+      };
+    }
+
+    const menuBarHeight = isSystem7Theme ? 30 : 25;
+    return {
+      position: "top-right" as const,
+      offset: `${menuBarHeight + 12}px`,
+    };
+  }, [isWindowsTheme, isMacOSTheme, isSystem7Theme, isMobile]);
+
+  const AppComponent = getAppComponent(IPOD_APP_ID);
+  const appMeta = appRegistry[IPOD_APP_ID];
+  const translatedAppName = getTranslatedAppName(IPOD_APP_ID);
+  const crashDialogAppName =
+    translatedAppName !== IPOD_APP_ID ? translatedAppName : (appMeta?.name ?? IPOD_APP_ID);
+
+  const exitToDesktop = () => {
+    window.location.href = "/";
+  };
+
+  return (
+    <>
+      <DesktopErrorBoundary>
+        <div
+          className="standalone-ipod-root fixed inset-0 overflow-hidden bg-[#1a1a1a]"
+          data-standalone-ipod
+        >
+          {ipodInstance ? (
+            <div className="absolute inset-0" role="presentation">
+              <AppErrorBoundary
+                appId={IPOD_APP_ID}
+                appName={crashDialogAppName}
+                instanceId={ipodInstance.instanceId}
+                onQuit={exitToDesktop}
+                onRelaunch={() => {
+                  launchApp(IPOD_APP_ID, routeInitialData as IpodInitialData);
+                }}
+              >
+                <AppComponent
+                  isWindowOpen={ipodInstance.isOpen}
+                  isForeground
+                  onClose={exitToDesktop}
+                  className="pointer-events-auto"
+                  helpItems={appMeta?.helpItems}
+                  skipInitialSound
+                  initialData={ipodInstance.initialData as IpodInitialData}
+                  instanceId={ipodInstance.instanceId}
+                />
+              </AppErrorBoundary>
+            </div>
+          ) : (
+            <div className="flex h-full w-full items-center justify-center text-sm text-white/70">
+              {t("common.loading.openingSharedIpodTrack", "Opening iPod…")}
+            </div>
+          )}
+        </div>
+      </DesktopErrorBoundary>
+      <Toaster position={toastConfig.position} offset={toastConfig.offset} />
+    </>
+  );
+}

--- a/src/StandaloneIpodApp.tsx
+++ b/src/StandaloneIpodApp.tsx
@@ -3,9 +3,8 @@ import { useTranslation } from "react-i18next";
 import { Toaster } from "@/components/ui/sonner";
 import { AppErrorBoundary } from "@/components/errors/ErrorBoundaries";
 import { DesktopErrorBoundary } from "@/components/errors/ErrorBoundaries";
-import { getAppComponent } from "@/config/appRegistry";
-import { getWindowConfig } from "@/config/appRegistry";
-import { appRegistry } from "@/config/appRegistry";
+import { IpodAppComponent } from "@/apps/ipod/components/IpodAppComponent";
+import { getWindowConfig, appRegistry } from "@/config/appRegistry";
 import { useAppStoreShallow } from "@/stores/helpers";
 import { useThemeFlags } from "@/hooks/useThemeFlags";
 import { useIsMobile } from "@/hooks/useIsMobile";
@@ -116,7 +115,6 @@ export function StandaloneIpodApp() {
     };
   }, [isWindowsTheme, isMacOSTheme, isSystem7Theme, isMobile]);
 
-  const AppComponent = getAppComponent(IPOD_APP_ID);
   const appMeta = appRegistry[IPOD_APP_ID];
   const translatedAppName = getTranslatedAppName(IPOD_APP_ID);
   const crashDialogAppName =
@@ -144,7 +142,7 @@ export function StandaloneIpodApp() {
                   launchApp(IPOD_APP_ID, routeInitialData as IpodInitialData);
                 }}
               >
-                <AppComponent
+                <IpodAppComponent
                   isWindowOpen={ipodInstance.isOpen}
                   isForeground
                   onClose={exitToDesktop}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
 import { App } from "./App";
+import { StandaloneIpodApp } from "./StandaloneIpodApp";
+import { isStandaloneIpodPath } from "./utils/standaloneIpodRoute";
 import "./index.css";
 import { useThemeStore } from "./stores/useThemeStore";
 import { useLanguageStore } from "./stores/useLanguageStore";
@@ -139,9 +141,10 @@ preloadIpodData();
 
 const renderApp = () => {
   initializeAnalytics();
+  const RootComponent = isStandaloneIpodPath() ? StandaloneIpodApp : App;
   ReactDOM.createRoot(document.getElementById("root")!).render(
     <React.StrictMode>
-      <App />
+      <RootComponent />
     </React.StrictMode>
   );
 };

--- a/src/utils/standaloneIpodRoute.ts
+++ b/src/utils/standaloneIpodRoute.ts
@@ -1,0 +1,60 @@
+import type { IpodInitialData } from "@/apps/base/types";
+
+export const STANDALONE_IPOD_BASE_PATH = "/standalone/ipod";
+
+function normalizePathname(pathname: string): string {
+  if (!pathname || pathname === "/") return pathname;
+  return pathname.replace(/\/+$/, "") || "/";
+}
+
+/** True when the SPA should render only the iPod app (no desktop shell). */
+export function isStandaloneIpodPath(pathname?: string): boolean {
+  const path = normalizePathname(pathname ?? window.location.pathname);
+  return (
+    path === STANDALONE_IPOD_BASE_PATH ||
+    path.startsWith(`${STANDALONE_IPOD_BASE_PATH}/`)
+  );
+}
+
+/**
+ * Parse `/standalone/ipod` and `/standalone/ipod/:trackId` (and optional query).
+ * Returns null when the path is not a standalone iPod route.
+ */
+export function parseStandaloneIpodRoute(
+  pathname?: string,
+  search?: string
+): IpodInitialData | null {
+  const path = normalizePathname(pathname ?? window.location.pathname);
+  if (!isStandaloneIpodPath(path)) {
+    return null;
+  }
+
+  const initialData: IpodInitialData = {};
+
+  const trackMatch = path.match(
+    new RegExp(
+      `^${STANDALONE_IPOD_BASE_PATH.replace(/\//g, "\\/")}/([^/]+)$`
+    )
+  );
+  if (trackMatch?.[1]) {
+    initialData.videoId = decodeURIComponent(trackMatch[1]);
+  }
+
+  const searchParams =
+    typeof search === "string" && search.length > 0
+      ? new URLSearchParams(search.startsWith("?") ? search.slice(1) : search)
+      : null;
+
+  const listenSessionId = searchParams?.get("listen")?.trim();
+  if (listenSessionId) {
+    initialData.listenSessionId = listenSessionId;
+  }
+
+  return initialData;
+}
+
+/** Canonical path for linking to the standalone iPod experience. */
+export function standaloneIpodPath(trackId?: string): string {
+  if (!trackId) return STANDALONE_IPOD_BASE_PATH;
+  return `${STANDALONE_IPOD_BASE_PATH}/${encodeURIComponent(trackId)}`;
+}

--- a/tests/test-standalone-ipod-route.test.ts
+++ b/tests/test-standalone-ipod-route.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "bun:test";
+import {
+  STANDALONE_IPOD_BASE_PATH,
+  isStandaloneIpodPath,
+  parseStandaloneIpodRoute,
+} from "../src/utils/standaloneIpodRoute";
+import { standaloneIpodPath } from "../src/utils/standaloneIpodRoute";
+
+describe("standalone iPod route", () => {
+  test("isStandaloneIpodPath matches base and track paths", () => {
+    expect(isStandaloneIpodPath("/standalone/ipod")).toBe(true);
+    expect(isStandaloneIpodPath("/standalone/ipod/")).toBe(true);
+    expect(isStandaloneIpodPath("/standalone/ipod/abc123")).toBe(true);
+    expect(isStandaloneIpodPath("/ipod")).toBe(false);
+    expect(isStandaloneIpodPath("/ipod/track-id")).toBe(false);
+    expect(isStandaloneIpodPath("/")).toBe(false);
+  });
+
+  test("parseStandaloneIpodRoute extracts track and listen session", () => {
+    expect(parseStandaloneIpodRoute("/standalone/ipod")).toEqual({});
+    expect(parseStandaloneIpodRoute("/standalone/ipod/my-song-id")).toEqual({
+      videoId: "my-song-id",
+    });
+    expect(
+      parseStandaloneIpodRoute("/standalone/ipod/x", "?listen=session-42")
+    ).toEqual({
+      videoId: "x",
+      listenSessionId: "session-42",
+    });
+  });
+
+  test("standaloneIpodPath builds canonical URLs", () => {
+    expect(standaloneIpodPath()).toBe(STANDALONE_IPOD_BASE_PATH);
+    expect(standaloneIpodPath("a/b")).toBe("/standalone/ipod/a%2Fb");
+  });
+});

--- a/vercel.json
+++ b/vercel.json
@@ -240,6 +240,8 @@
     { "source": "/videos", "destination": "/" },
     { "source": "/tv", "destination": "/" },
     { "source": "/ipod", "destination": "/" },
+    { "source": "/standalone/ipod", "destination": "/" },
+    { "source": "/standalone/ipod/:track", "destination": "/" },
     { "source": "/karaoke", "destination": "/" },
     { "source": "/applet-viewer", "destination": "/" },
     { "source": "/synth", "destination": "/" },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes TypeScript build failure in `StandaloneIpodApp.tsx` when using `getAppComponent("ipod")`, whose return type is an intersection of all app `initialData` types.

## Fix

Import and render `IpodAppComponent` directly so `initialData` is typed as `IpodInitialData` instead of the broad registry component union.

## Testing

- `bun run build` (clean `tsc -b && vite build`) passes on this branch.

**Note:** This branch includes the standalone `/standalone/ipod` route feature from `cursor/standalone-ipod-route-A762`; the build fix is commit `81ef1a791`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-A1055109-0FF0-415F-BB42-D8B44B391E2F"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-A1055109-0FF0-415F-BB42-D8B44B391E2F"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

