### PR TITLE
fix(shell): disable accidental Dashboard triggers on mobile

### DIFF
--- a/src/apps/base/AppManager.tsx
+++ b/src/apps/base/AppManager.tsx
@@ -21,11 +21,10 @@ import { isTextEditInitialData } from "@/types/appInitialData";
 import {
   emitAppUpdate,
   onAppLaunchRequest,
-  onExposeToggle,
-  onSpotlightToggle,
   requestAppLaunch,
   toggleSpotlightSearch,
 } from "@/utils/appEventBus";
+import { useDashboardShellTriggers } from "@/hooks/useDashboardShellTriggers";
 import { prefetchAppChunk, prefetchLikelyAppChunks } from "@/config/lazyAppComponent";
 import { useAppStore } from "@/stores/useAppStore";
 import { useGlobalUndoRedo } from "@/hooks/useGlobalUndoRedo";
@@ -354,53 +353,30 @@ export function AppManager({ apps }: AppManagerProps) {
     }
   }, [closeAppInstance]);
 
-  // Listen for expose view toggle events (e.g., from keyboard shortcut, dock menu)
-  useEffect(() => {
-    const handleExposeToggle = () => {
-      closeDashboardIfOpen();
+  const closeOverlaysForSpotlight = useCallback(() => {
+    setIsExposeViewOpen(false);
+    closeDashboardIfOpen();
+  }, [closeDashboardIfOpen]);
+
+  useDashboardShellTriggers({
+    closeDashboardIfOpen,
+    toggleExposeFromKeyboard: () => {
       setIsExposeViewOpen((prev) => !prev);
-    };
-
-    const handleKeyDown = (e: KeyboardEvent) => {
-      // F3 key to toggle Expose view (Mission Control)
-      if (e.key === "F3" || (e.key === "f" && e.metaKey)) {
-        e.preventDefault();
-        // Close Dashboard if open
-        closeDashboardIfOpen();
-        setIsExposeViewOpen((prev) => !prev);
-      }
-      // F4 key to toggle Dashboard
-      if (e.key === "F4") {
-        e.preventDefault();
-        // Close Expose if open
-        setIsExposeViewOpen(false);
-        toggleDashboard();
-      }
-      // ⌘+Space / Ctrl+Space to toggle Spotlight Search
-      if (e.key === " " && (e.metaKey || e.ctrlKey)) {
-        e.preventDefault();
-        // Close Expose and Dashboard if open before toggling Spotlight
-        setIsExposeViewOpen(false);
-        closeDashboardIfOpen();
-        toggleSpotlightSearch();
-      }
-    };
-
-    // Close Expose when Spotlight opens via any trigger (icon click, Start Menu "Run...")
-    const handleSpotlightToggle = () => {
+    },
+    toggleExposeFromEvent: () => {
+      setIsExposeViewOpen((prev) => !prev);
+    },
+    toggleDashboardFromKeyboard: () => {
+      setIsExposeViewOpen(false);
+      toggleDashboard();
+    },
+    toggleSpotlightFromKeyboard: () => {
       setIsExposeViewOpen(false);
       closeDashboardIfOpen();
-    };
-
-    const unsubscribeExposeToggle = onExposeToggle(handleExposeToggle);
-    const unsubscribeSpotlightToggle = onSpotlightToggle(handleSpotlightToggle);
-    window.addEventListener("keydown", handleKeyDown);
-    return () => {
-      unsubscribeExposeToggle();
-      unsubscribeSpotlightToggle();
-      window.removeEventListener("keydown", handleKeyDown);
-    };
-  }, [closeDashboardIfOpen, toggleDashboard]);
+      toggleSpotlightSearch();
+    },
+    closeOverlaysForSpotlightEvent: closeOverlaysForSpotlight,
+  });
 
   // Global macOS-style window management and app switcher keyboard shortcuts
   useEffect(() => {

--- a/src/components/layout/Dock.tsx
+++ b/src/components/layout/Dock.tsx
@@ -39,6 +39,11 @@ import {
 import { useShallow } from "zustand/react/shallow";
 import { toggleExposeView } from "@/utils/appEventBus";
 import { prefetchAppChunk } from "@/config/lazyAppComponent";
+import { useMediaQuery } from "@/hooks/useMediaQuery";
+import {
+  isClientYInBottomZone,
+  shouldRevealDockFromSwipeUp,
+} from "@/utils/dockRevealGesture";
 
 const MAX_SCALE = 2.3; // peak multiplier at cursor center
 const DISTANCE = 140; // px range where magnification is applied
@@ -590,6 +595,10 @@ const MULTI_WINDOW_APPS: AppId[] = ["textedit", "finder", "applet-viewer"];
 function MacDock() {
   const { t } = useTranslation();
   const isPhone = useIsPhone();
+  const isCompactHeight = useMediaQuery("(max-height: 520px)");
+  const hasCoarsePointer = useMediaQuery("(pointer: coarse)");
+  /** Touch + phone width, or touch + short viewport (e.g. phone landscape). */
+  const useSwipeToRevealDock = isPhone || (hasCoarsePointer && isCompactHeight);
   const { instances, instanceOrder, bringInstanceToForeground, restoreInstance, minimizeInstance, closeAppInstance } =
     useAppStoreShallow((s) => ({
       instances: s.instances,
@@ -906,6 +915,77 @@ function MacDock() {
     
     setIsDockVisible(false);
   }, [dockHiding, draggingItemId, externalDragIndex, trashContextMenuPos, applicationsContextMenuPos, appContextMenu, dividerContextMenuPos]);
+
+  // Mobile / small-height: swipe up from bottom reveals dock; taps pass through (no overlay).
+  useEffect(() => {
+    if (!dockHiding || isDockVisible || !useSwipeToRevealDock) {
+      return;
+    }
+
+    const getZoneHeightPx = () => {
+      const safeInset = parseInt(
+        getComputedStyle(document.documentElement).getPropertyValue(
+          "--sat-safe-area-bottom",
+        ),
+        10,
+      );
+      const safeBottom = Number.isFinite(safeInset) ? safeInset : 0;
+      return scaledDockHeight + safeBottom;
+    };
+
+    let activePointer: {
+      pointerId: number;
+      startX: number;
+      startY: number;
+    } | null = null;
+
+    const clearActivePointer = () => {
+      activePointer = null;
+    };
+
+    const onPointerDown = (e: PointerEvent) => {
+      if (e.pointerType === "mouse") return;
+      const zoneHeight = getZoneHeightPx();
+      if (!isClientYInBottomZone(e.clientY, window.innerHeight, zoneHeight)) {
+        return;
+      }
+      activePointer = {
+        pointerId: e.pointerId,
+        startX: e.clientX,
+        startY: e.clientY,
+      };
+    };
+
+    const onPointerUp = (e: PointerEvent) => {
+      if (!activePointer || e.pointerId !== activePointer.pointerId) {
+        return;
+      }
+      const deltaX = e.clientX - activePointer.startX;
+      const deltaY = e.clientY - activePointer.startY;
+      clearActivePointer();
+
+      if (shouldRevealDockFromSwipeUp(deltaX, deltaY)) {
+        showDock();
+      }
+    };
+
+    window.addEventListener("pointerdown", onPointerDown);
+    window.addEventListener("pointerup", onPointerUp);
+    window.addEventListener("pointercancel", clearActivePointer);
+
+    return () => {
+      window.removeEventListener("pointerdown", onPointerDown);
+      window.removeEventListener("pointerup", onPointerUp);
+      window.removeEventListener("pointercancel", clearActivePointer);
+      clearActivePointer();
+    };
+  }, [
+    dockHiding,
+    isDockVisible,
+    useSwipeToRevealDock,
+    scaledDockHeight,
+    showDock,
+  ]);
 
   // Divider context menu handler
   const handleDividerContextMenu = useCallback((e: React.MouseEvent) => {
@@ -2548,25 +2628,18 @@ function MacDock() {
         </motion.div>
       </div>
       
-      {/* Invisible hover zone at bottom edge to trigger dock reveal when hiding is enabled */}
-      {dockHiding && !isDockVisible && (
+      {/* Desktop: hover zone reveals hidden dock. Mobile uses swipe (see effect above). */}
+      {dockHiding && !isDockVisible && !useSwipeToRevealDock && (
         <div
           className="fixed left-0 right-0 z-40"
           style={{
             bottom: 0,
-            // Desktop: half dock height, Mobile: full dock height + safe area
-            height: isPhone 
-              ? `calc(${scaledDockHeight}px + env(safe-area-inset-bottom, 0px))` 
-              : Math.max(Math.round(scaledDockHeight / 2), 8),
+            height: Math.max(Math.round(scaledDockHeight / 2), 8),
             pointerEvents: "auto",
             // Debug: uncomment to visualize hover zone
             // backgroundColor: "rgba(255, 0, 0, 0.2)",
           }}
           onMouseEnter={showDock}
-          onTouchStart={(e) => {
-            e.preventDefault();
-            showDock();
-          }}
         />
       )}
       

--- a/src/hooks/useDashboardShellInputDisabled.ts
+++ b/src/hooks/useDashboardShellInputDisabled.ts
@@ -1,0 +1,22 @@
+import { useIsMobile } from "@/hooks/useIsMobile";
+import { useMediaQuery } from "@/hooks/useMediaQuery";
+import { shouldDisableDashboardAccidentalShellTriggers } from "@/utils/dashboardShellGuards";
+
+/**
+ * True when Dashboard shell shortcuts / edge triggers should not fire accidentally
+ * (mobile, coarse pointer, or compact viewport). Dock and desktop icons still work.
+ */
+export function useDashboardShellInputDisabled(): boolean {
+  const isMobile = useIsMobile();
+  const hasCoarsePointer = useMediaQuery("(pointer: coarse)");
+  const hasHoverNone = useMediaQuery("(hover: none)");
+  const isNarrowWidth = useMediaQuery("(max-width: 767px)");
+  const isCompactHeight = useMediaQuery("(max-height: 520px)");
+
+  return shouldDisableDashboardAccidentalShellTriggers({
+    isMobile,
+    hasCoarsePointer,
+    hasHoverNone,
+    isCompactViewport: isNarrowWidth || isCompactHeight,
+  });
+}

--- a/src/hooks/useDashboardShellTriggers.ts
+++ b/src/hooks/useDashboardShellTriggers.ts
@@ -1,0 +1,93 @@
+import { useEffect } from "react";
+import { useDashboardShellInputDisabled } from "@/hooks/useDashboardShellInputDisabled";
+import { onExposeToggle, onSpotlightToggle } from "@/utils/appEventBus";
+import { shouldEnableDashboardShellKeyboardTriggers } from "@/utils/dashboardShellGuards";
+
+export type DashboardShellTriggerHandlers = {
+  /** Toggle Dashboard (caller should close Expose first when opening via keyboard). */
+  toggleDashboardFromKeyboard: () => void;
+  closeDashboardIfOpen: () => void;
+  toggleExposeFromKeyboard: () => void;
+  toggleExposeFromEvent: () => void;
+  toggleSpotlightFromKeyboard: () => void;
+  closeOverlaysForSpotlightEvent: () => void;
+};
+
+/**
+ * Registers global shell shortcuts for Dashboard, Expose, and Spotlight.
+ * F4 Dashboard toggle is disabled on mobile / coarse pointer / compact viewports.
+ * No hot-corner or corner-swipe Dashboard triggers exist in the shell today.
+ */
+export function useDashboardShellTriggers({
+  toggleDashboardFromKeyboard,
+  closeDashboardIfOpen,
+  toggleExposeFromKeyboard,
+  toggleExposeFromEvent,
+  toggleSpotlightFromKeyboard,
+  closeOverlaysForSpotlightEvent,
+}: DashboardShellTriggerHandlers): void {
+  const shellInputDisabled = useDashboardShellInputDisabled();
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      // Ignore stray function keys while typing in form controls (virtual keyboard / focus).
+      const target = e.target;
+      if (
+        target instanceof HTMLElement &&
+        (target.isContentEditable ||
+          target.tagName === "INPUT" ||
+          target.tagName === "TEXTAREA" ||
+          target.tagName === "SELECT")
+      ) {
+        return;
+      }
+
+      // F3 key to toggle Expose view (Mission Control)
+      if (e.key === "F3" || (e.key === "f" && e.metaKey)) {
+        e.preventDefault();
+        closeDashboardIfOpen();
+        toggleExposeFromKeyboard();
+        return;
+      }
+
+      // F4 key to toggle Dashboard (desktop / non-touch-first only)
+      if (e.key === "F4") {
+        if (!shouldEnableDashboardShellKeyboardTriggers(shellInputDisabled)) {
+          return;
+        }
+        e.preventDefault();
+        toggleDashboardFromKeyboard();
+        return;
+      }
+
+      // ⌘+Space / Ctrl+Space to toggle Spotlight Search
+      if (e.key === " " && (e.metaKey || e.ctrlKey)) {
+        e.preventDefault();
+        toggleSpotlightFromKeyboard();
+      }
+    };
+
+    const unsubscribeExposeToggle = onExposeToggle(() => {
+      closeDashboardIfOpen();
+      toggleExposeFromEvent();
+    });
+    const unsubscribeSpotlightToggle = onSpotlightToggle(
+      closeOverlaysForSpotlightEvent,
+    );
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => {
+      unsubscribeExposeToggle();
+      unsubscribeSpotlightToggle();
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [
+    shellInputDisabled,
+    toggleDashboardFromKeyboard,
+    closeDashboardIfOpen,
+    toggleExposeFromKeyboard,
+    toggleExposeFromEvent,
+    toggleSpotlightFromKeyboard,
+    closeOverlaysForSpotlightEvent,
+  ]);
+}

--- a/src/utils/dashboardShellGuards.ts
+++ b/src/utils/dashboardShellGuards.ts
@@ -1,0 +1,31 @@
+/**
+ * Shared guards for Dashboard shell triggers (F4, future hot corners / edge zones).
+ * Intentional launches (dock icon, desktop shortcut, Spotlight) are unaffected.
+ */
+
+export type DashboardShellGuardSignals = {
+  /** Touch and/or narrow layout — see useIsMobile. */
+  isMobile: boolean;
+  /** Viewport width under 768px or height under 520px (phone landscape). */
+  isCompactViewport: boolean;
+  /** Primary pointer is coarse (typical touch screens). */
+  hasCoarsePointer: boolean;
+  /** Device cannot hover (touch-first UIs). */
+  hasHoverNone: boolean;
+};
+
+/** When true, disable accidental shell openers; keep explicit UI launch paths. */
+export function shouldDisableDashboardAccidentalShellTriggers(
+  signals: DashboardShellGuardSignals,
+): boolean {
+  if (signals.isMobile) return true;
+  if (signals.isCompactViewport) return true;
+  if (signals.hasCoarsePointer && signals.hasHoverNone) return true;
+  return false;
+}
+
+export function shouldEnableDashboardShellKeyboardTriggers(
+  shellInputDisabled: boolean,
+): boolean {
+  return !shellInputDisabled;
+}

--- a/src/utils/dockRevealGesture.ts
+++ b/src/utils/dockRevealGesture.ts
@@ -1,0 +1,36 @@
+/** Minimum upward movement (px) to reveal a hidden dock via swipe. */
+export const DOCK_SWIPE_UP_THRESHOLD_PX = 48;
+
+/** Movement below this (px) is treated as a tap, not a swipe. */
+export const DOCK_SWIPE_MOVE_THRESHOLD_PX = 12;
+
+export function shouldRevealDockFromSwipeUp(
+  deltaX: number,
+  deltaY: number,
+  options?: {
+    swipeUpThreshold?: number;
+    moveThreshold?: number;
+  },
+): boolean {
+  const swipeUpThreshold =
+    options?.swipeUpThreshold ?? DOCK_SWIPE_UP_THRESHOLD_PX;
+  const moveThreshold =
+    options?.moveThreshold ?? DOCK_SWIPE_MOVE_THRESHOLD_PX;
+
+  const absDx = Math.abs(deltaX);
+  const absDy = Math.abs(deltaY);
+
+  if (absDx < moveThreshold && absDy < moveThreshold) {
+    return false;
+  }
+
+  return deltaY < -swipeUpThreshold && absDy > absDx;
+}
+
+export function isClientYInBottomZone(
+  clientY: number,
+  viewportHeight: number,
+  zoneHeightPx: number,
+): boolean {
+  return clientY >= viewportHeight - zoneHeightPx;
+}

--- a/tests/test-dashboard-shell-triggers.test.ts
+++ b/tests/test-dashboard-shell-triggers.test.ts
@@ -1,0 +1,57 @@
+#!/usr/bin/env bun
+
+import { describe, expect, test } from "bun:test";
+import {
+  shouldDisableDashboardAccidentalShellTriggers,
+  shouldEnableDashboardShellKeyboardTriggers,
+} from "../src/utils/dashboardShellGuards";
+
+describe("dashboard shell guards", () => {
+  test("F4 keyboard shortcut is disabled when mobile layout", () => {
+    expect(
+      shouldEnableDashboardShellKeyboardTriggers(
+        shouldDisableDashboardAccidentalShellTriggers({
+          isMobile: true,
+          isCompactViewport: false,
+          hasCoarsePointer: false,
+          hasHoverNone: false,
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  test("F4 keyboard shortcut is enabled on desktop pointer", () => {
+    expect(
+      shouldEnableDashboardShellKeyboardTriggers(
+        shouldDisableDashboardAccidentalShellTriggers({
+          isMobile: false,
+          isCompactViewport: false,
+          hasCoarsePointer: false,
+          hasHoverNone: false,
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  test("disables on coarse pointer without hover", () => {
+    expect(
+      shouldDisableDashboardAccidentalShellTriggers({
+        isMobile: false,
+        isCompactViewport: false,
+        hasCoarsePointer: true,
+        hasHoverNone: true,
+      }),
+    ).toBe(true);
+  });
+
+  test("disables on compact viewport without mobile flag", () => {
+    expect(
+      shouldDisableDashboardAccidentalShellTriggers({
+        isMobile: false,
+        isCompactViewport: true,
+        hasCoarsePointer: false,
+        hasHoverNone: false,
+      }),
+    ).toBe(true);
+  });
+});

--- a/tests/test-dock-reveal-gesture.test.ts
+++ b/tests/test-dock-reveal-gesture.test.ts
@@ -1,0 +1,32 @@
+#!/usr/bin/env bun
+
+import { describe, expect, test } from "bun:test";
+import {
+  isClientYInBottomZone,
+  shouldRevealDockFromSwipeUp,
+} from "../src/utils/dockRevealGesture";
+
+describe("shouldRevealDockFromSwipeUp", () => {
+  test("returns false for taps with negligible movement", () => {
+    expect(shouldRevealDockFromSwipeUp(0, 0)).toBe(false);
+    expect(shouldRevealDockFromSwipeUp(5, -8)).toBe(false);
+  });
+
+  test("returns true for upward swipes past threshold", () => {
+    expect(shouldRevealDockFromSwipeUp(10, -60)).toBe(true);
+    expect(shouldRevealDockFromSwipeUp(-5, -50)).toBe(true);
+  });
+
+  test("returns false for downward or mostly horizontal movement", () => {
+    expect(shouldRevealDockFromSwipeUp(0, 60)).toBe(false);
+    expect(shouldRevealDockFromSwipeUp(80, -20)).toBe(false);
+  });
+});
+
+describe("isClientYInBottomZone", () => {
+  test("detects coordinates in the bottom band", () => {
+    expect(isClientYInBottomZone(950, 1000, 80)).toBe(true);
+    expect(isClientYInBottomZone(900, 1000, 80)).toBe(false);
+    expect(isClientYInBottomZone(920, 1000, 80)).toBe(true);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Investigated Dashboard shell trigger paths on `main`. The only global opener today is **F4** in `AppManager` (no hot-corner or corner-swipe Dashboard triggers in the tree). Accidental opens on mobile were addressed by gating F4 and hardening dock auto-hide reveal on touch-first viewports.

## Changes

- **`useDashboardShellTriggers`** — Extracted shell keyboard wiring; **F4 is disabled** when `useDashboardShellInputDisabled()` is true (mobile via `useIsMobile`, compact viewport, or coarse pointer + no hover).
- **`dashboardShellGuards`** — Shared pure helpers for tests and future edge/corner triggers.
- **Form-focus guard** — Ignores F3/F4/Spotlight shortcuts while focus is in `input` / `textarea` / `select` / `contentEditable` (virtual keyboard / focus misfires).
- **Dock auto-hide (mobile)** — Replaced bottom blocking overlay + `touchstart` reveal with **swipe-up** gesture (`dockRevealGesture`); desktop keeps **mouse-hover** half-height zone. Taps pass through when the dock is hidden.

Intentional Dashboard launch (dock icon, desktop shortcut, Spotlight) is unchanged.

## Testing

- `bun test tests/test-dashboard-shell-triggers.test.ts tests/test-dock-reveal-gesture.test.ts` — 8 pass

## Notes

- Dock swipe-up behavior matches the prior `fix(dock): swipe-up reveal…` approach to avoid regressing tap pass-through when the dock is hidden.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-227dde75-53dd-43a1-8d7e-33aabd75678a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-227dde75-53dd-43a1-8d7e-33aabd75678a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

