### PR TITLE
fix(chats): simplify Cursor agent terminal tool display and dedupe end markers

### DIFF
--- a/src/components/shared/CursorRunEventView.tsx
+++ b/src/components/shared/CursorRunEventView.tsx
@@ -13,6 +13,10 @@ const LazyMarkdown = lazy(() =>
 );
 import type { AssistantStreamSegment } from "@/lib/cursorSdkRunCoalesce";
 import {
+  buildToolInvocationLabel,
+  shouldRenderTerminalMarkerInPlainStream,
+} from "@/lib/cursorAgentToolDisplay";
+import {
   mergeAssistantStream,
   mergeStatusParts,
   mergeThinkingText,
@@ -38,179 +42,6 @@ function isRecord(v: unknown): v is Record<string, unknown> {
 
 const markdownStreamClass =
   "cursor-stream-md px-1 py-0.5 font-geneva-12 text-[12px] leading-snug text-neutral-700 break-words dark:text-neutral-200";
-
-const toolDisplayNameOverrides: Record<string, string> = {
-  run_terminal_cmd: "Run terminal command",
-  read_file: "Read file",
-  edit_file: "Edit file",
-  list_dir: "List directory",
-  file_search: "Search files",
-  grep_search: "Search text",
-  web_search: "Search web",
-};
-
-function humanizeToolName(name: string): string {
-  const trimmed = name.trim();
-  if (!trimmed) return "Tool";
-  const override = toolDisplayNameOverrides[trimmed];
-  if (override) return override;
-
-  const words = trimmed
-    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
-    .replace(/[_-]+/g, " ")
-    .trim()
-    .split(/\s+/)
-    .map((word) => (word.toLowerCase() === "cmd" ? "command" : word.toLowerCase()));
-
-  if (words.length === 0) return "Tool";
-  return words
-    .map((word, idx) => (idx === 0 ? word.charAt(0).toUpperCase() + word.slice(1) : word))
-    .join(" ");
-}
-
-function truncateDetail(value: string): string {
-  const oneLine = value.replace(/\s+/g, " ").trim();
-  return oneLine.length > 120 ? `${oneLine.slice(0, 117)}...` : oneLine;
-}
-
-function getNestedRecord(value: unknown, key: string): Record<string, unknown> | null {
-  if (!isRecord(value)) return null;
-  const candidate = value[key];
-  return isRecord(candidate) ? candidate : null;
-}
-
-function pickString(value: Record<string, unknown>, keys: string[]): string {
-  for (const key of keys) {
-    const candidate = value[key];
-    if (typeof candidate === "string" && candidate.trim().length > 0) {
-      return candidate.trim();
-    }
-  }
-  return "";
-}
-
-function toolPayload(input: unknown): Record<string, unknown> | null {
-  if (!isRecord(input)) return null;
-  return (
-    getNestedRecord(input, "args") ??
-    getNestedRecord(input, "input") ??
-    getNestedRecord(input, "parameters") ??
-    input
-  );
-}
-
-function toolSecondaryInfo(input: unknown): string {
-  if (typeof input === "string") return truncateDetail(input);
-  const payload = toolPayload(input);
-  if (!payload) return "";
-  return pickString(payload, [
-    "command",
-    "cmd",
-    "shell_command",
-    "path",
-    "filePath",
-    "file_path",
-    "target_file",
-    "relative_workspace_path",
-    "query",
-    "pattern",
-    "url",
-    "description",
-  ]);
-}
-
-function fileNameFromPath(path: string): string {
-  return path.split(/[\\/]/).filter(Boolean).pop() || path;
-}
-
-function isToolCallDone(ev: Record<string, unknown>): boolean {
-  const status = typeof ev.status === "string" ? ev.status : "";
-  return (
-    status === "completed" ||
-    status === "success" ||
-    status === "finished" ||
-    status === "error" ||
-    ev.result !== undefined ||
-    ev.error !== undefined
-  );
-}
-
-function toolGroupSecondaryInfo(rows: Record<string, unknown>[]): string {
-  if (rows.length <= 1) {
-    const ev = isRecord(rows[0]?.ev) ? rows[0].ev : {};
-    return toolSecondaryInfo(ev);
-  }
-
-  const uniqueDetails = Array.from(
-    new Set(
-      rows.reduce<string[]>((acc, row) => {
-        const value = isRecord(row.ev) ? toolSecondaryInfo(row.ev) : "";
-        if (value.length > 0) {
-          acc.push(value);
-        }
-        return acc;
-      }, [])
-    )
-  );
-
-  if (uniqueDetails.length === 1) return truncateDetail(uniqueDetails[0]);
-  if (uniqueDetails.length > 1) {
-    const preview = uniqueDetails
-      .slice(0, 3)
-      .map((detail) => fileNameFromPath(detail))
-      .join(", ");
-    return uniqueDetails.length > 3 ? `${preview}, ...` : preview;
-  }
-  return "";
-}
-
-function toolPrimaryText(name: string, done: boolean, rows: Record<string, unknown>[]): string {
-  const count = rows.length;
-  const latest = rows[rows.length - 1];
-  const latestEv = isRecord(latest?.ev) ? latest.ev : {};
-  const detail = toolSecondaryInfo(latestEv);
-
-  if (name === "read_file" || name === "edit_file") {
-    const noun =
-      count > 1 ? `${count} files` : fileNameFromPath(detail) || "file";
-    if (name === "read_file") return `${done ? "Read" : "Reading"} ${noun}`;
-    return `${done ? "Edited" : "Editing"} ${noun}`;
-  }
-
-  if (name === "run_terminal_cmd") {
-    return done ? "Ran terminal command" : "Running terminal command";
-  }
-
-  if (name === "grep_search" || name === "file_search" || name === "web_search") {
-    return done ? humanizeToolName(name) : humanizeToolName(name);
-  }
-
-  if (count > 1) return `${humanizeToolName(name)} (${count})`;
-  return humanizeToolName(name);
-}
-
-function toolRowParts(rows: Record<string, unknown>[]): {
-  primary: string;
-  secondary: string;
-  done: boolean;
-} {
-  const events = rows.reduce<Record<string, unknown>[]>((acc, row) => {
-    if (isRecord(row.ev)) {
-      acc.push(row.ev);
-    }
-    return acc;
-  }, []);
-  const latest = events[events.length - 1] ?? {};
-  const name = typeof latest.name === "string" ? latest.name : "?";
-  const done = events.length > 0 && events.every(isToolCallDone);
-  const secondary = toolGroupSecondaryInfo(rows);
-  return {
-    primary: toolPrimaryText(name, done, rows),
-    secondary:
-      rows.length === 1 && secondary === fileNameFromPath(secondary) ? "" : secondary,
-    done,
-  };
-}
 
 function CursorToolInvocationRow({
   primary,
@@ -390,7 +221,7 @@ function ThinkingBody({
 }
 
 function ToolCallEvent({ ev }: { ev: Record<string, unknown> }) {
-  const parts = toolRowParts([{ ev }]);
+  const parts = buildToolInvocationLabel([{ ev }]);
   return (
     <CursorToolInvocationRow
       primary={parts.primary}
@@ -401,7 +232,7 @@ function ToolCallEvent({ ev }: { ev: Record<string, unknown> }) {
 }
 
 function ToolCallGroupEvent({ rows }: { rows: Record<string, unknown>[] }) {
-  const parts = toolRowParts(rows);
+  const parts = buildToolInvocationLabel(rows);
   return (
     <CursorToolInvocationRow
       primary={parts.primary}
@@ -430,6 +261,10 @@ function TerminalBanner({
 
   const bad = status === "error" || err;
 
+  if (plain && !shouldRenderTerminalMarkerInPlainStream(row)) {
+    return null;
+  }
+
   if (plain) {
     if (bad && err) {
       return (
@@ -447,15 +282,14 @@ function TerminalBanner({
         </div>
       );
     }
-    return (
-      <p className="text-[11px] leading-snug text-neutral-700 dark:text-neutral-300">
-        {bad
-          ? t("apps.chats.toolCalls.cursorCloudAgent.stream.runEndedError")
-          : t("apps.chats.toolCalls.cursorCloudAgent.stream.runEnded", {
-              status: status?.trim() ? status : "—",
-            })}
-      </p>
-    );
+    if (bad) {
+      return (
+        <p className="text-[11px] leading-snug text-neutral-700 dark:text-neutral-300">
+          {t("apps.chats.toolCalls.cursorCloudAgent.stream.runEndedError")}
+        </p>
+      );
+    }
+    return null;
   }
 
   return (

--- a/src/lib/cursorAgentToolDisplay.ts
+++ b/src/lib/cursorAgentToolDisplay.ts
@@ -57,14 +57,25 @@ function truncateDetail(value: string): string {
   return oneLine.length > 120 ? `${oneLine.slice(0, 117)}...` : oneLine;
 }
 
+const COMMAND_ARG_KEYS = ["command", "cmd", "shell_command"] as const;
+
+export function terminalCommandFromInput(input: unknown): string {
+  if (typeof input === "string") return truncateDetail(input);
+  const payload = toolPayload(input);
+  if (!payload) return "";
+  return truncateDetail(pickString(payload, [...COMMAND_ARG_KEYS]));
+}
+
+function terminalCommandFromEv(ev: Record<string, unknown>): string {
+  return terminalCommandFromInput(ev.args ?? ev.input ?? ev.parameters ?? ev);
+}
+
 export function toolSecondaryInfo(input: unknown): string {
   if (typeof input === "string") return truncateDetail(input);
   const payload = toolPayload(input);
   if (!payload) return "";
   return pickString(payload, [
-    "command",
-    "cmd",
-    "shell_command",
+    ...COMMAND_ARG_KEYS,
     "path",
     "filePath",
     "file_path",
@@ -81,11 +92,37 @@ function fileNameFromPath(path: string): string {
   return path.split(/[\\/]/).filter(Boolean).pop() || path;
 }
 
+function toolGroupTerminalCommandInfo(rows: Record<string, unknown>[]): string {
+  if (rows.length <= 1) {
+    const ev = isRecord(rows[0]?.ev) ? rows[0].ev : {};
+    return terminalCommandFromEv(ev);
+  }
+
+  const uniqueCommands = Array.from(
+    new Set(
+      rows.reduce<string[]>((acc, row) => {
+        const value = isRecord(row.ev) ? terminalCommandFromEv(row.ev) : "";
+        if (value.length > 0) acc.push(value);
+        return acc;
+      }, [])
+    )
+  );
+
+  if (uniqueCommands.length === 1) return uniqueCommands[0];
+  if (uniqueCommands.length > 1) {
+    const preview = uniqueCommands.slice(0, 2).join("; ");
+    return uniqueCommands.length > 2 ? `${preview}; ...` : preview;
+  }
+  return "";
+}
+
 function toolGroupSecondaryInfo(
   rows: Record<string, unknown>[],
   toolName: string
 ): string {
-  if (isTerminalToolName(toolName)) return "";
+  if (isTerminalToolName(toolName)) {
+    return toolGroupTerminalCommandInfo(rows);
+  }
 
   if (rows.length <= 1) {
     const ev = isRecord(rows[0]?.ev) ? rows[0].ev : {};
@@ -147,7 +184,7 @@ function toolPrimaryText(
   rows: Record<string, unknown>[]
 ): string {
   if (isTerminalToolName(name)) {
-    return done ? "Ran terminal command" : "Running terminal command";
+    return done ? "Ran" : "Running";
   }
 
   const count = rows.length;
@@ -185,8 +222,9 @@ export function buildToolInvocationLabel(rows: Record<string, unknown>[]): {
   return {
     primary: toolPrimaryText(name, done, rows),
     secondary:
-      isTerminalToolName(name) ||
-      (rows.length === 1 && secondary === fileNameFromPath(secondary))
+      !isTerminalToolName(name) &&
+      rows.length === 1 &&
+      secondary === fileNameFromPath(secondary)
         ? ""
         : secondary,
     done,

--- a/src/lib/cursorAgentToolDisplay.ts
+++ b/src/lib/cursorAgentToolDisplay.ts
@@ -1,0 +1,212 @@
+/**
+ * Display helpers for Cursor Cloud agent stream tool-call rows.
+ */
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null;
+}
+
+/** Tool names that represent shell/terminal execution (SDK + legacy aliases). */
+export function isTerminalToolName(name: string): boolean {
+  const n = name.trim();
+  if (!n) return false;
+  if (n === "run_terminal_cmd" || n === "run_terminal_command") return true;
+  return n.toLowerCase() === "shell";
+}
+
+export function isToolCallDone(ev: Record<string, unknown>): boolean {
+  const status = typeof ev.status === "string" ? ev.status : "";
+  return (
+    status === "completed" ||
+    status === "success" ||
+    status === "finished" ||
+    status === "error" ||
+    ev.result !== undefined ||
+    ev.error !== undefined
+  );
+}
+
+function getNestedRecord(value: unknown, key: string): Record<string, unknown> | null {
+  if (!isRecord(value)) return null;
+  const candidate = value[key];
+  return isRecord(candidate) ? candidate : null;
+}
+
+function pickString(value: Record<string, unknown>, keys: string[]): string {
+  for (const key of keys) {
+    const candidate = value[key];
+    if (typeof candidate === "string" && candidate.trim().length > 0) {
+      return candidate.trim();
+    }
+  }
+  return "";
+}
+
+function toolPayload(input: unknown): Record<string, unknown> | null {
+  if (!isRecord(input)) return null;
+  return (
+    getNestedRecord(input, "args") ??
+    getNestedRecord(input, "input") ??
+    getNestedRecord(input, "parameters") ??
+    input
+  );
+}
+
+function truncateDetail(value: string): string {
+  const oneLine = value.replace(/\s+/g, " ").trim();
+  return oneLine.length > 120 ? `${oneLine.slice(0, 117)}...` : oneLine;
+}
+
+export function toolSecondaryInfo(input: unknown): string {
+  if (typeof input === "string") return truncateDetail(input);
+  const payload = toolPayload(input);
+  if (!payload) return "";
+  return pickString(payload, [
+    "command",
+    "cmd",
+    "shell_command",
+    "path",
+    "filePath",
+    "file_path",
+    "target_file",
+    "relative_workspace_path",
+    "query",
+    "pattern",
+    "url",
+    "description",
+  ]);
+}
+
+function fileNameFromPath(path: string): string {
+  return path.split(/[\\/]/).filter(Boolean).pop() || path;
+}
+
+function toolGroupSecondaryInfo(
+  rows: Record<string, unknown>[],
+  toolName: string
+): string {
+  if (isTerminalToolName(toolName)) return "";
+
+  if (rows.length <= 1) {
+    const ev = isRecord(rows[0]?.ev) ? rows[0].ev : {};
+    return toolSecondaryInfo(ev);
+  }
+
+  const uniqueDetails = Array.from(
+    new Set(
+      rows.reduce<string[]>((acc, row) => {
+        const value = isRecord(row.ev) ? toolSecondaryInfo(row.ev) : "";
+        if (value.length > 0) acc.push(value);
+        return acc;
+      }, [])
+    )
+  );
+
+  if (uniqueDetails.length === 1) return truncateDetail(uniqueDetails[0]);
+  if (uniqueDetails.length > 1) {
+    const preview = uniqueDetails
+      .slice(0, 3)
+      .map((detail) => fileNameFromPath(detail))
+      .join(", ");
+    return uniqueDetails.length > 3 ? `${preview}, ...` : preview;
+  }
+  return "";
+}
+
+function humanizeToolName(name: string): string {
+  const trimmed = name.trim();
+  if (!trimmed) return "Tool";
+
+  const overrides: Record<string, string> = {
+    read_file: "Read file",
+    edit_file: "Edit file",
+    list_dir: "List directory",
+    file_search: "Search files",
+    grep_search: "Search text",
+    web_search: "Search web",
+  };
+  const override = overrides[trimmed];
+  if (override) return override;
+
+  const words = trimmed
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .replace(/[_-]+/g, " ")
+    .trim()
+    .split(/\s+/)
+    .map((word) => (word.toLowerCase() === "cmd" ? "command" : word.toLowerCase()));
+
+  if (words.length === 0) return "Tool";
+  return words
+    .map((word, idx) => (idx === 0 ? word.charAt(0).toUpperCase() + word.slice(1) : word))
+    .join(" ");
+}
+
+function toolPrimaryText(
+  name: string,
+  done: boolean,
+  rows: Record<string, unknown>[]
+): string {
+  if (isTerminalToolName(name)) {
+    return done ? "Ran terminal command" : "Running terminal command";
+  }
+
+  const count = rows.length;
+  const latest = rows[rows.length - 1];
+  const latestEv = isRecord(latest?.ev) ? latest.ev : {};
+  const detail = toolSecondaryInfo(latestEv);
+
+  if (name === "read_file" || name === "edit_file") {
+    const noun = count > 1 ? `${count} files` : fileNameFromPath(detail) || "file";
+    if (name === "read_file") return `${done ? "Read" : "Reading"} ${noun}`;
+    return `${done ? "Edited" : "Editing"} ${noun}`;
+  }
+
+  if (name === "grep_search" || name === "file_search" || name === "web_search") {
+    return humanizeToolName(name);
+  }
+
+  if (count > 1) return `${humanizeToolName(name)} (${count})`;
+  return humanizeToolName(name);
+}
+
+export function buildToolInvocationLabel(rows: Record<string, unknown>[]): {
+  primary: string;
+  secondary: string;
+  done: boolean;
+} {
+  const events = rows.reduce<Record<string, unknown>[]>((acc, row) => {
+    if (isRecord(row.ev)) acc.push(row.ev);
+    return acc;
+  }, []);
+  const latest = events[events.length - 1] ?? {};
+  const name = typeof latest.name === "string" ? latest.name : "?";
+  const done = events.length > 0 && events.every(isToolCallDone);
+  const secondary = toolGroupSecondaryInfo(rows, name);
+  return {
+    primary: toolPrimaryText(name, done, rows),
+    secondary:
+      isTerminalToolName(name) ||
+      (rows.length === 1 && secondary === fileNameFromPath(secondary))
+        ? ""
+        : secondary,
+    done,
+  };
+}
+
+/** Whether a Redis terminal marker should render in the chat card body (header already shows completion). */
+export function shouldRenderTerminalMarkerInPlainStream(
+  row: Record<string, unknown>
+): boolean {
+  const status = typeof row.status === "string" ? row.status.trim() : "";
+  const err =
+    typeof row.error === "string"
+      ? row.error.trim()
+      : row.error !== undefined
+        ? String(row.error)
+        : "";
+  const summary = typeof row.summary === "string" ? row.summary.trim() : "";
+  const bad = status === "error" || err.length > 0;
+  if (bad) return true;
+  // Success completion: omit generic end banner; keep body only when there is a non-empty summary.
+  return summary.length > 0;
+}

--- a/src/lib/cursorSdkRunCoalesce.ts
+++ b/src/lib/cursorSdkRunCoalesce.ts
@@ -219,6 +219,10 @@ function isToolCallRow(row: unknown): row is Record<string, unknown> {
   return isRecord(ev) && ev.type === "tool_call";
 }
 
+function isTerminalMarkerRow(row: unknown): row is Record<string, unknown> {
+  return isRecord(row) && row.type === "terminal";
+}
+
 function stableJson(value: unknown): string {
   try {
     return JSON.stringify(value, (_key, v) =>
@@ -234,11 +238,11 @@ function toolCallKey(row: Record<string, unknown>): string {
   if (!isRecord(ev)) return "";
 
   const idCandidates = [
-    ev.id,
+    ev.call_id,
+    ev.callId,
     ev.toolCallId,
     ev.tool_call_id,
-    ev.callId,
-    ev.call_id,
+    ev.id,
   ];
   const id = idCandidates.find((v): v is string => typeof v === "string" && v.length > 0);
   if (id) return `id:${id}`;
@@ -474,6 +478,19 @@ export function coalesceCursorRunRows(events: unknown[]): CoalescedCursorRow[] {
           if (k) toolKeyToLocation.set(k, { outIndex, rowIndex: idx });
         });
       }
+      continue;
+    }
+
+    if (isTerminalMarkerRow(row)) {
+      const terminalRow = row as Record<string, unknown>;
+      const last = out[out.length - 1];
+      if (last?.kind === "single" && isTerminalMarkerRow(last.row)) {
+        const prev = last.row as Record<string, unknown>;
+        last.row = { ...prev, ...terminalRow };
+      } else {
+        out.push({ kind: "single", row: terminalRow });
+      }
+      i++;
       continue;
     }
 

--- a/tests/test-cursor-agent-tool-display.test.ts
+++ b/tests/test-cursor-agent-tool-display.test.ts
@@ -13,7 +13,7 @@ describe("cursorAgentToolDisplay", () => {
     expect(isTerminalToolName("Read")).toBe(false);
   });
 
-  test("collapses terminal tool calls to running/ran without command detail", () => {
+  test("shows Running/Ran with the actual command", () => {
     const running = buildToolInvocationLabel([
       {
         ev: {
@@ -24,8 +24,8 @@ describe("cursorAgentToolDisplay", () => {
         },
       },
     ]);
-    expect(running.primary).toBe("Running terminal command");
-    expect(running.secondary).toBe("");
+    expect(running.primary).toBe("Running");
+    expect(running.secondary).toBe("cd /workspace && bun test");
     expect(running.done).toBe(false);
 
     const done = buildToolInvocationLabel([
@@ -39,8 +39,8 @@ describe("cursorAgentToolDisplay", () => {
         },
       },
     ]);
-    expect(done.primary).toBe("Ran terminal command");
-    expect(done.secondary).toBe("");
+    expect(done.primary).toBe("Ran");
+    expect(done.secondary).toBe("bun test");
     expect(done.done).toBe(true);
   });
 

--- a/tests/test-cursor-agent-tool-display.test.ts
+++ b/tests/test-cursor-agent-tool-display.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, test } from "bun:test";
+import {
+  buildToolInvocationLabel,
+  isTerminalToolName,
+  shouldRenderTerminalMarkerInPlainStream,
+} from "../src/lib/cursorAgentToolDisplay.js";
+import { coalesceCursorRunRows } from "../src/lib/cursorSdkRunCoalesce.js";
+
+describe("cursorAgentToolDisplay", () => {
+  test("recognizes SDK Shell and legacy run_terminal_cmd as terminal tools", () => {
+    expect(isTerminalToolName("Shell")).toBe(true);
+    expect(isTerminalToolName("run_terminal_cmd")).toBe(true);
+    expect(isTerminalToolName("Read")).toBe(false);
+  });
+
+  test("collapses terminal tool calls to running/ran without command detail", () => {
+    const running = buildToolInvocationLabel([
+      {
+        ev: {
+          type: "tool_call",
+          name: "Shell",
+          status: "running",
+          args: { command: "cd /workspace && bun test" },
+        },
+      },
+    ]);
+    expect(running.primary).toBe("Running terminal command");
+    expect(running.secondary).toBe("");
+    expect(running.done).toBe(false);
+
+    const done = buildToolInvocationLabel([
+      {
+        ev: {
+          type: "tool_call",
+          name: "run_terminal_cmd",
+          status: "completed",
+          args: { command: "bun test" },
+          result: "ok",
+        },
+      },
+    ]);
+    expect(done.primary).toBe("Ran terminal command");
+    expect(done.secondary).toBe("");
+    expect(done.done).toBe(true);
+  });
+
+  test("keeps file path secondary for non-terminal tools", () => {
+    const read = buildToolInvocationLabel([
+      {
+        ev: {
+          type: "tool_call",
+          name: "read_file",
+          status: "completed",
+          args: { target_file: "/workspace/src/foo.ts" },
+        },
+      },
+    ]);
+    expect(read.primary).toBe("Read foo.ts");
+    expect(read.secondary).toBe("/workspace/src/foo.ts");
+  });
+
+  test("shouldRenderTerminalMarkerInPlainStream hides success end banner", () => {
+    expect(
+      shouldRenderTerminalMarkerInPlainStream({
+        status: "finished",
+        summary: "",
+      })
+    ).toBe(false);
+    expect(
+      shouldRenderTerminalMarkerInPlainStream({
+        status: "error",
+        error: "boom",
+      })
+    ).toBe(true);
+    expect(
+      shouldRenderTerminalMarkerInPlainStream({
+        status: "finished",
+        summary: "Shipped the fix.",
+      })
+    ).toBe(true);
+  });
+});
+
+describe("coalesceCursorRunRows terminal markers", () => {
+  test("dedupes repeated terminal rows to a single entry", () => {
+    const rows = [
+      { ts: 1, type: "terminal", status: "running", summary: "" },
+      { ts: 2, type: "terminal", status: "finished", summary: "Done." },
+    ];
+    const out = coalesceCursorRunRows(rows);
+    expect(out).toHaveLength(1);
+    expect(out[0]?.kind).toBe("single");
+    if (out[0]?.kind === "single") {
+      expect(out[0].row).toMatchObject({
+        type: "terminal",
+        status: "finished",
+        summary: "Done.",
+      });
+    }
+  });
+});

--- a/tests/test-cursor-sdk-run-coalesce.test.ts
+++ b/tests/test-cursor-sdk-run-coalesce.test.ts
@@ -193,6 +193,40 @@ describe("coalesceCursorRunRows tool calls", () => {
     }
   });
 
+  test("collapses Shell tool lifecycle the same as run_terminal_cmd", () => {
+    const rows = [
+      {
+        ts: 1,
+        ev: {
+          type: "tool_call",
+          call_id: "shell-1",
+          name: "Shell",
+          status: "running",
+          args: { command: "bun test" },
+        },
+      },
+      {
+        ts: 2,
+        ev: {
+          type: "tool_call",
+          call_id: "shell-1",
+          name: "Shell",
+          status: "completed",
+          args: { command: "bun test" },
+        },
+      },
+    ];
+
+    const out = coalesceCursorRunRows(rows);
+    expect(out).toHaveLength(1);
+    if (out[0]?.kind === "merged_tool_call") {
+      expect(out[0].row.ev).toMatchObject({
+        name: "Shell",
+        status: "completed",
+      });
+    }
+  });
+
   test("does not duplicate when same id appears across non-adjacent tool batches", () => {
     const rows = [
       {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Improves the Cursor Cloud agent live stream card so shell activity is easy to scan and completion messaging is not repeated.

## Changes

- **Terminal tool calls** (`Shell`, `run_terminal_cmd`): show **Running** / **Ran** with the actual command on the same row (truncated when very long).
- **Other tools** (read/edit/search, etc.): unchanged concise labels and useful path/query details.
- **Stream coalescing**: prefer SDK `call_id` for lifecycle dedupe; merge duplicate `type: "terminal"` rows into one entry.
- **End-of-run UI**: in the chat card (`plainStream`), hide the generic “Run finished · …” banner when the header already shows **Finished**; still show errors and non-empty summaries.

## Testing

- `bun test tests/test-cursor-agent-tool-display.test.ts tests/test-cursor-sdk-run-coalesce.test.ts`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-86021214-ae48-42f2-801d-56a610104b0f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-86021214-ae48-42f2-801d-56a610104b0f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

