### PR TITLE
fix(shell): strengthen Dashboard mobile guards and dock swipe reveal

### DIFF
--- a/src/components/layout/Dock.tsx
+++ b/src/components/layout/Dock.tsx
@@ -39,11 +39,11 @@ import {
 import { useShallow } from "zustand/react/shallow";
 import { toggleExposeView } from "@/utils/appEventBus";
 import { prefetchAppChunk } from "@/config/lazyAppComponent";
-import { useMediaQuery } from "@/hooks/useMediaQuery";
 import {
   isClientYInBottomZone,
   shouldRevealDockFromSwipeUp,
 } from "@/utils/dockRevealGesture";
+import { useDashboardShellInputDisabled } from "@/hooks/useDashboardShellInputDisabled";
 
 const MAX_SCALE = 2.3; // peak multiplier at cursor center
 const DISTANCE = 140; // px range where magnification is applied
@@ -595,10 +595,8 @@ const MULTI_WINDOW_APPS: AppId[] = ["textedit", "finder", "applet-viewer"];
 function MacDock() {
   const { t } = useTranslation();
   const isPhone = useIsPhone();
-  const isCompactHeight = useMediaQuery("(max-height: 520px)");
-  const hasCoarsePointer = useMediaQuery("(pointer: coarse)");
-  /** Touch + phone width, or touch + short viewport (e.g. phone landscape). */
-  const useSwipeToRevealDock = isPhone || (hasCoarsePointer && isCompactHeight);
+  // Match Dashboard shell guards: no bottom hover capture zone on touch-first viewports.
+  const useSwipeToRevealDock = useDashboardShellInputDisabled();
   const { instances, instanceOrder, bringInstanceToForeground, restoreInstance, minimizeInstance, closeAppInstance } =
     useAppStoreShallow((s) => ({
       instances: s.instances,

--- a/src/hooks/useDashboardShellInputDisabled.ts
+++ b/src/hooks/useDashboardShellInputDisabled.ts
@@ -1,6 +1,9 @@
 import { useIsMobile } from "@/hooks/useIsMobile";
 import { useMediaQuery } from "@/hooks/useMediaQuery";
-import { shouldDisableDashboardAccidentalShellTriggers } from "@/utils/dashboardShellGuards";
+import {
+  collectDashboardShellGuardSignals,
+  shouldDisableDashboardAccidentalShellTriggers,
+} from "@/utils/dashboardShellGuards";
 
 /**
  * True when Dashboard shell shortcuts / edge triggers should not fire accidentally
@@ -19,4 +22,11 @@ export function useDashboardShellInputDisabled(): boolean {
     hasHoverNone,
     isCompactViewport: isNarrowWidth || isCompactHeight,
   });
+}
+
+/** Synchronous guard for event handlers (avoids stale hook snapshot on keydown). */
+export function isDashboardShellInputDisabledNow(): boolean {
+  return shouldDisableDashboardAccidentalShellTriggers(
+    collectDashboardShellGuardSignals(),
+  );
 }

--- a/src/hooks/useDashboardShellTriggers.ts
+++ b/src/hooks/useDashboardShellTriggers.ts
@@ -1,5 +1,8 @@
 import { useEffect } from "react";
-import { useDashboardShellInputDisabled } from "@/hooks/useDashboardShellInputDisabled";
+import {
+  isDashboardShellInputDisabledNow,
+  useDashboardShellInputDisabled,
+} from "@/hooks/useDashboardShellInputDisabled";
 import { onExposeToggle, onSpotlightToggle } from "@/utils/appEventBus";
 import { shouldEnableDashboardShellKeyboardTriggers } from "@/utils/dashboardShellGuards";
 
@@ -51,8 +54,11 @@ export function useDashboardShellTriggers({
       }
 
       // F4 key to toggle Dashboard (desktop / non-touch-first only)
-      if (e.key === "F4") {
-        if (!shouldEnableDashboardShellKeyboardTriggers(shellInputDisabled)) {
+      if (e.key === "F4" || e.code === "F4") {
+        if (
+          !shouldEnableDashboardShellKeyboardTriggers(shellInputDisabled) ||
+          isDashboardShellInputDisabledNow()
+        ) {
           return;
         }
         e.preventDefault();

--- a/src/utils/dashboardShellGuards.ts
+++ b/src/utils/dashboardShellGuards.ts
@@ -1,10 +1,10 @@
 /**
- * Shared guards for Dashboard shell triggers (F4, future hot corners / edge zones).
+ * Shared guards for Dashboard shell triggers (F4, hot corners / edge zones).
  * Intentional launches (dock icon, desktop shortcut, Spotlight) are unaffected.
  */
 
 export type DashboardShellGuardSignals = {
-  /** Touch and/or narrow layout — see useIsMobile. */
+  /** Touch and/or narrow layout — see useIsMobile / collectDashboardShellGuardSignals. */
   isMobile: boolean;
   /** Viewport width under 768px or height under 520px (phone landscape). */
   isCompactViewport: boolean;
@@ -14,13 +14,41 @@ export type DashboardShellGuardSignals = {
   hasHoverNone: boolean;
 };
 
-/** When true, disable accidental shell openers; keep explicit UI launch paths. */
+/** Read current viewport/pointer signals (safe for keydown/pointer handlers). */
+export function collectDashboardShellGuardSignals(): DashboardShellGuardSignals {
+  if (typeof window === "undefined") {
+    return {
+      isMobile: false,
+      isCompactViewport: false,
+      hasCoarsePointer: false,
+      hasHoverNone: false,
+    };
+  }
+
+  const hasTouchScreen =
+    "ontouchstart" in window || navigator.maxTouchPoints > 0;
+  const isNarrowWidth = window.innerWidth < 768;
+  const isCompactHeight = window.innerHeight < 520;
+
+  return {
+    isMobile: hasTouchScreen || isNarrowWidth,
+    isCompactViewport: isNarrowWidth || isCompactHeight,
+    hasCoarsePointer: window.matchMedia("(pointer: coarse)").matches,
+    hasHoverNone: window.matchMedia("(hover: none)").matches,
+  };
+}
+
+/**
+ * When true, disable accidental shell openers (F4, edge/corner gestures); keep explicit UI launch paths.
+ * Mobile gesture Dashboard opens are disabled because F4 misfires on virtual keyboards, bottom-edge
+ * touches are common on Android, and System 7 / hidden-dock layouts have no stable hot-corner target.
+ */
 export function shouldDisableDashboardAccidentalShellTriggers(
   signals: DashboardShellGuardSignals,
 ): boolean {
   if (signals.isMobile) return true;
   if (signals.isCompactViewport) return true;
-  if (signals.hasCoarsePointer && signals.hasHoverNone) return true;
+  if (signals.hasCoarsePointer) return true;
   return false;
 }
 
@@ -28,4 +56,11 @@ export function shouldEnableDashboardShellKeyboardTriggers(
   shellInputDisabled: boolean,
 ): boolean {
   return !shellInputDisabled;
+}
+
+/** Hidden dock should use swipe-up reveal (not a hover capture zone) on touch-first viewports. */
+export function shouldUseDockSwipeReveal(
+  signals: DashboardShellGuardSignals,
+): boolean {
+  return shouldDisableDashboardAccidentalShellTriggers(signals);
 }

--- a/tests/test-dashboard-shell-triggers.test.ts
+++ b/tests/test-dashboard-shell-triggers.test.ts
@@ -2,8 +2,10 @@
 
 import { describe, expect, test } from "bun:test";
 import {
+  collectDashboardShellGuardSignals,
   shouldDisableDashboardAccidentalShellTriggers,
   shouldEnableDashboardShellKeyboardTriggers,
+  shouldUseDockSwipeReveal,
 } from "../src/utils/dashboardShellGuards";
 
 describe("dashboard shell guards", () => {
@@ -33,15 +35,63 @@ describe("dashboard shell guards", () => {
     ).toBe(true);
   });
 
-  test("disables on coarse pointer without hover", () => {
+  test("disables on coarse pointer alone (typical Android)", () => {
     expect(
       shouldDisableDashboardAccidentalShellTriggers({
         isMobile: false,
         isCompactViewport: false,
         hasCoarsePointer: true,
-        hasHoverNone: true,
+        hasHoverNone: false,
       }),
     ).toBe(true);
+  });
+
+  test("collectDashboardShellGuardSignals marks touch + narrow as mobile", () => {
+    const original = globalThis.window;
+    Object.defineProperty(globalThis, "window", {
+      configurable: true,
+      value: {
+        innerWidth: 400,
+        innerHeight: 800,
+        matchMedia: (query: string) => ({
+          matches:
+            query === "(pointer: coarse)" || query === "(hover: none)",
+        }),
+        ontouchstart: true,
+      },
+    });
+    Object.defineProperty(globalThis, "navigator", {
+      configurable: true,
+      value: { maxTouchPoints: 5 },
+    });
+
+    const signals = collectDashboardShellGuardSignals();
+    expect(signals.isMobile).toBe(true);
+    expect(shouldDisableDashboardAccidentalShellTriggers(signals)).toBe(true);
+
+    Object.defineProperty(globalThis, "window", {
+      configurable: true,
+      value: original,
+    });
+  });
+
+  test("dock swipe reveal tracks accidental-shell guard", () => {
+    expect(
+      shouldUseDockSwipeReveal({
+        isMobile: false,
+        isCompactViewport: false,
+        hasCoarsePointer: true,
+        hasHoverNone: false,
+      }),
+    ).toBe(true);
+    expect(
+      shouldUseDockSwipeReveal({
+        isMobile: false,
+        isCompactViewport: false,
+        hasCoarsePointer: false,
+        hasHoverNone: false,
+      }),
+    ).toBe(false);
   });
 
   test("disables on compact viewport without mobile flag", () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up to #1335: hardens accidental Dashboard shell triggers on Android/mobile and removes a hidden-dock hover trap on touch-first viewports (including System 7 with no Dock).

## Changes

- **F4 / keyboard:** `shouldDisableDashboardAccidentalShellTriggers` now treats any coarse primary pointer as touch-first (typical Android). Keydown re-checks guards synchronously via `isDashboardShellInputDisabledNow()` and matches `e.code === "F4"`.
- **Hidden Dock:** `useSwipeToRevealDock` is tied to the same shell guard hook so tablets in landscape no longer get a bottom `pointer-events: auto` hover zone when the Dock is hidden.
- **Docs/tests:** Comment in `dashboardShellGuards.ts` explains why mobile gesture opens are disabled; unit tests cover coarse-pointer-only and dock swipe alignment.

## Intentional paths unchanged

Dock icon, desktop icon (double-tap / explicit tap), Spotlight, and menu launches still open Dashboard.

## Testing

- `bun test tests/test-dashboard-shell-triggers.test.ts tests/test-dock-reveal-gesture.test.ts`
- `bun run test:unit`
- `bunx tsc --noEmit`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-248ad289-091f-4215-9ebf-59527ecc9918"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-248ad289-091f-4215-9ebf-59527ecc9918"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

