### PR TITLE
fix: show menubar menus in browser fullscreen mode

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -114,9 +114,9 @@
     -webkit-overscroll-behavior-x: none;
     -webkit-overscroll-behavior-y: none;
   }
-  /* Browser fullscreen for the entire ryOS shell (#root) */
-  #root:fullscreen,
-  #root:-webkit-full-screen {
+  /* Browser fullscreen for the entire ryOS page (html, so body portals/menus stay visible) */
+  html:fullscreen,
+  html:-webkit-full-screen {
     width: 100%;
     height: 100%;
     background-color: #000;

--- a/src/utils/ryosFullscreen.ts
+++ b/src/utils/ryosFullscreen.ts
@@ -1,6 +1,14 @@
 /** DOM id of the React root that hosts the full ryOS shell. */
 export const RYOS_FULLSCREEN_ROOT_ID = "root";
 
+/** Element that enters browser fullscreen for the whole ryOS page. */
+export function getRyosFullscreenElement(): HTMLElement | null {
+  if (typeof document === "undefined") {
+    return null;
+  }
+  return document.documentElement;
+}
+
 export function getRyosFullscreenRoot(): HTMLElement | null {
   if (typeof document === "undefined") {
     return null;
@@ -10,40 +18,37 @@ export function getRyosFullscreenRoot(): HTMLElement | null {
 
 /** Whether the browser exposes a usable Fullscreen API. */
 export function isRyosFullscreenSupported(): boolean {
-  if (typeof document === "undefined") {
-    return false;
-  }
-  const root = getRyosFullscreenRoot();
-  if (!root) {
+  const target = getRyosFullscreenElement();
+  if (!target || !getRyosFullscreenRoot()) {
     return false;
   }
   return (
     typeof document.fullscreenEnabled === "boolean" &&
     document.fullscreenEnabled &&
-    typeof root.requestFullscreen === "function" &&
+    typeof target.requestFullscreen === "function" &&
     typeof document.exitFullscreen === "function"
   );
 }
 
-/** True when the ryOS shell root is the active fullscreen element. */
+/** True when the ryOS page is in browser fullscreen. */
 export function isRyosFullscreenActive(): boolean {
-  const root = getRyosFullscreenRoot();
-  if (!root) {
+  const target = getRyosFullscreenElement();
+  if (!target) {
     return false;
   }
-  return document.fullscreenElement === root;
+  return document.fullscreenElement === target;
 }
 
 export async function enterRyosFullscreen(): Promise<void> {
   if (!isRyosFullscreenSupported()) {
     return;
   }
-  const root = getRyosFullscreenRoot();
-  if (!root || isRyosFullscreenActive()) {
+  const target = getRyosFullscreenElement();
+  if (!target || isRyosFullscreenActive()) {
     return;
   }
   try {
-    await root.requestFullscreen();
+    await target.requestFullscreen();
   } catch (err) {
     console.warn("[ryOS] Failed to enter fullscreen:", err);
   }

--- a/tests/test-ryos-fullscreen.test.ts
+++ b/tests/test-ryos-fullscreen.test.ts
@@ -3,6 +3,7 @@
 import { describe, expect, test, beforeEach, afterEach } from "bun:test";
 import {
   RYOS_FULLSCREEN_ROOT_ID,
+  getRyosFullscreenElement,
   getRyosFullscreenRoot,
   isRyosFullscreenActive,
   isRyosFullscreenSupported,
@@ -26,14 +27,26 @@ describe("ryosFullscreen", () => {
     }
     root.remove();
     root = null;
+    Object.defineProperty(document, "fullscreenElement", {
+      configurable: true,
+      get: () => null,
+    });
   });
 
-  test("getRyosFullscreenRoot returns the shell root element", () => {
+  test("getRyosFullscreenRoot returns the React shell root", () => {
     if (typeof document === "undefined") {
       expect(true).toBe(true);
       return;
     }
     expect(getRyosFullscreenRoot()).toBe(root);
+  });
+
+  test("getRyosFullscreenElement returns documentElement", () => {
+    if (typeof document === "undefined") {
+      expect(true).toBe(true);
+      return;
+    }
+    expect(getRyosFullscreenElement()).toBe(document.documentElement);
   });
 
   test("isRyosFullscreenActive is false when another element is fullscreen", () => {
@@ -49,29 +62,21 @@ describe("ryosFullscreen", () => {
     });
     expect(isRyosFullscreenActive()).toBe(false);
     other.remove();
-    Object.defineProperty(document, "fullscreenElement", {
-      configurable: true,
-      get: () => null,
-    });
   });
 
-  test("isRyosFullscreenActive is true when shell root is fullscreen", () => {
-    if (typeof document === "undefined" || !root) {
+  test("isRyosFullscreenActive is true when documentElement is fullscreen", () => {
+    if (typeof document === "undefined") {
       expect(true).toBe(true);
       return;
     }
     Object.defineProperty(document, "fullscreenElement", {
       configurable: true,
-      get: () => root,
+      get: () => document.documentElement,
     });
     expect(isRyosFullscreenActive()).toBe(true);
-    Object.defineProperty(document, "fullscreenElement", {
-      configurable: true,
-      get: () => null,
-    });
   });
 
-  test("isRyosFullscreenSupported requires fullscreenEnabled and requestFullscreen", () => {
+  test("isRyosFullscreenSupported requires fullscreenEnabled and requestFullscreen on html", () => {
     if (typeof document === "undefined" || !root) {
       expect(true).toBe(true);
       return;
@@ -81,7 +86,7 @@ describe("ryosFullscreen", () => {
       configurable: true,
       value: true,
     });
-    root.requestFullscreen = async () => {};
+    document.documentElement.requestFullscreen = async () => {};
     document.exitFullscreen = async () => {};
     expect(isRyosFullscreenSupported()).toBe(true);
     Object.defineProperty(document, "fullscreenEnabled", {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Shell fullscreen targeted `#root`, but Radix menubar menus portal to `document.body`. Siblings of `#root` are not painted in element fullscreen, so Apple/app menus disappeared.

## Fix

Request fullscreen on `document.documentElement` instead so body-mounted portals remain inside the fullscreen subtree.

## Verification

- `bun test tests/test-ryos-fullscreen.test.ts` — pass
- Playwright: enter fullscreen → open Apple menu → **Exit Full Screen** menuitem visible

![Apple menu visible in fullscreen](https://cursor.com/artifacts/c/art-928fa34e-0dc9-4755-a62f-027ad8594967)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-23d26a16-b239-4443-a6e7-fcb8aa445c5a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-23d26a16-b239-4443-a6e7-fcb8aa445c5a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

