### PR TITLE
fix(macosx): normalize Apple menu Recent submenu typography

### DIFF
--- a/src/styles/themes.css
+++ b/src/styles/themes.css
@@ -252,7 +252,7 @@
   --os-metrics-menubar-height: 25px;
   --os-window-shadow: 0 3px 10px rgba(0, 0, 0, 0.3);
   --os-menu-item-font-size: 13px;
-  --os-menu-subtrigger-font-size: 12px;
+  --os-menu-subtrigger-font-size: var(--os-menu-item-font-size);
   /* Shared texture variables */
   --os-texture-toolbar-image: url("/assets/brushed-metal.jpg");
   --os-texture-toolbar-size: cover;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

In the macOS X (Aqua) theme, **Recent Items** and other submenu triggers (`MenubarSubTrigger` / `DropdownMenuSubTrigger`) rendered at **12px** while sibling menu rows used **13px** via `--os-menu-item-font-size`.

## Fix

Alias `--os-menu-subtrigger-font-size` to `var(--os-menu-item-font-size)` in the `macosx` theme token block so nested submenu labels share the same typography as regular menu items.

## Scope

- **Changed:** `src/styles/themes.css` (macosx tokens only)
- **Unchanged:** Windows (`11px` / `11px`), System 7 (`inherit`), and shared menubar/dropdown components

## Testing

- `bun run test:unit` — 238 pass, 0 fail
- Verified token values: Windows 11px/11px; Aqua 13px with subtrigger aliased to item size

## Acceptance

- [x] Apple menu Recent row matches other Apple menu items (font size / weight)
- [x] Other macOS X submenu triggers normalized via shared token
- [x] No changes to System 7, Windows XP, or Windows 98 token blocks
- [x] Minimal diff (one line)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bf73eafa-11da-40fc-8b7b-03077c7a2f26"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bf73eafa-11da-40fc-8b7b-03077c7a2f26"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

