### PR TITLE
Improve Cursor Cloud agent link previews in ryOS chat

### DIFF
--- a/api/chat/tools/cursor-repo-agent.ts
+++ b/api/chat/tools/cursor-repo-agent.ts
@@ -257,6 +257,8 @@ export type CursorCloudAgentToolOutput =
       agentDashboardUrl: string;
       /** Cloud catalog display name when available (`Agent.get`) */
       agentTitle?: string;
+      /** Epoch ms when the run was queued (for chat card header) */
+      createdAt?: number;
       message: string;
       pollHint: string;
     }
@@ -903,11 +905,13 @@ export async function executeCursorCloudAgent(
       notifyTelegram: context.notifyTelegram,
     });
 
+    const createdAt = Date.now();
     return {
       async: true,
       runId,
       agentId,
       agentDashboardUrl: cursorCloudAgentDashboardUrl(agentId),
+      createdAt,
       ...(agentTitle ? { agentTitle } : {}),
       message: "Started — live progress streams in the chat card below.",
       pollHint:

--- a/src/apps/chats/components/ChatMessages.tsx
+++ b/src/apps/chats/components/ChatMessages.tsx
@@ -25,6 +25,14 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { LinkPreview } from "@/components/shared/LinkPreview";
+import { CursorAgentRunSummaryCard } from "@/components/shared/CursorAgentRunSummaryCard";
+import {
+  collectCursorAgentCoverageFromParts,
+  isCursorAgentUrlCoveredByMessage,
+  parseCursorAgentDashboardUrl,
+  partitionMessageUrlsForPreviews,
+  type CursorAgentRunPreviewData,
+} from "@/lib/cursorAgentChatPreview";
 import { ImageAttachment } from "@/components/shared/ImageAttachment";
 import { useThemeFlags } from "@/hooks/useThemeFlags";
 import EmojiAquarium from "@/components/shared/EmojiAquarium";
@@ -1070,13 +1078,39 @@ const ChatMessageItem = memo(function ChatMessageItem(props: ChatMessageItemProp
           extractUrls(displayContent).forEach((u) => allUrls.add(u));
         }
         if (allUrls.size === 0) return null;
+
+        const coverage = collectCursorAgentCoverageFromParts(message.parts);
+        const uncoveredUrls = Array.from(allUrls).filter(
+          (url) => !isCursorAgentUrlCoveredByMessage(url, coverage)
+        );
+        const { genericUrls, cursorAgentUrls } =
+          partitionMessageUrlsForPreviews(uncoveredUrls);
+
+        if (genericUrls.length === 0 && cursorAgentUrls.length === 0) {
+          return null;
+        }
+
         return (
           <div
             className={`flex flex-col gap-2 w-full ${
               !isUrlOnly(displayContent) ? "mt-2" : ""
             } ${message.role === "user" ? "items-end" : "items-start"}`}
           >
-            {Array.from(allUrls).map((url, index) => (
+            {cursorAgentUrls.map((url, index) => {
+              const agentId = parseCursorAgentDashboardUrl(url);
+              const run: CursorAgentRunPreviewData = {
+                agentId: agentId ?? undefined,
+                agentDashboardUrl: url,
+              };
+              return (
+                <CursorAgentRunSummaryCard
+                  key={`${messageKey}-cursor-${index}`}
+                  run={run}
+                  className="max-w-[90%]"
+                />
+              );
+            })}
+            {genericUrls.map((url, index) => (
               <LinkPreview
                 key={`${messageKey}-link-${index}`}
                 url={url}

--- a/src/components/shared/CursorAgentRunSummaryCard.tsx
+++ b/src/components/shared/CursorAgentRunSummaryCard.tsx
@@ -1,0 +1,166 @@
+import { ArrowSquareOut } from "@phosphor-icons/react";
+import { useTranslation } from "react-i18next";
+import { cn } from "@/lib/utils";
+import {
+  cursorAgentDisplaySummary,
+  cursorAgentDisplayTitle,
+  cursorAgentStatusTone,
+  cursorAgentDashboardUrl,
+  formatCursorAgentTimestamp,
+  type CursorAgentRunPreviewData,
+} from "@/lib/cursorAgentChatPreview";
+import { useCursorAgentRunStatusBadge } from "@/components/shared/useCursorAgentRunStatusBadge";
+
+export interface CursorAgentRunSummaryCardProps {
+  run: CursorAgentRunPreviewData;
+  /** When true and run is still running, poll meta for live status (list/history rows). */
+  enableLiveStatus?: boolean;
+  className?: string;
+}
+
+function statusDotClass(tone: ReturnType<typeof cursorAgentStatusTone>): string {
+  switch (tone) {
+    case "running":
+      return "bg-amber-500";
+    case "finished":
+      return "bg-emerald-500";
+    case "error":
+      return "bg-red-500";
+    default:
+      return "bg-neutral-400";
+  }
+}
+
+function statusLabelKey(tone: ReturnType<typeof cursorAgentStatusTone>): string {
+  switch (tone) {
+    case "running":
+      return "apps.chats.toolCalls.cursorCloudAgent.running";
+    case "finished":
+      return "apps.chats.toolCalls.cursorCloudAgent.finished";
+    case "error":
+      return "apps.chats.toolCalls.cursorCloudAgent.statusError";
+    default:
+      return "apps.chats.toolCalls.cursorCloudAgent.statusUnknown";
+  }
+}
+
+/**
+ * Compact Cursor agent preview for chat: list rows, dashboard-only links, etc.
+ */
+export function CursorAgentRunSummaryCard({
+  run,
+  enableLiveStatus = false,
+  className,
+}: CursorAgentRunSummaryCardProps) {
+  const { t, i18n } = useTranslation();
+  const live = useCursorAgentRunStatusBadge(
+    enableLiveStatus ? run.runId : undefined,
+    run.status
+  );
+  const status = live.status ?? run.status;
+  const tone = cursorAgentStatusTone(status);
+  const title =
+    cursorAgentDisplayTitle(run) ||
+    t("apps.chats.toolCalls.cursorCloudAgent.panelTitle");
+  const summary = cursorAgentDisplaySummary(run);
+  const dashboardUrl =
+    run.agentDashboardUrl?.trim() ||
+    (run.agentId?.trim() ? cursorAgentDashboardUrl(run.agentId) : undefined);
+  const createdLabel = formatCursorAgentTimestamp(
+    run.createdAt ?? run.updatedAt,
+    i18n.language
+  );
+  const prUrl = (live.prUrl ?? run.prUrl)?.trim();
+
+  return (
+    <div
+      className={cn(
+        "my-1 overflow-hidden rounded bg-white font-geneva-12 dark:bg-neutral-950",
+        className
+      )}
+      style={{ boxShadow: "0 0 0 1px rgba(0, 0, 0, 0.3)" }}
+      data-cursor-agent-preview
+    >
+      <div className="flex items-start gap-2 border-b border-neutral-300 bg-neutral-100 px-2.5 py-2 dark:border-neutral-600 dark:bg-neutral-800/90">
+        <span className="relative inline-flex size-5 shrink-0 items-center justify-center pt-0.5" aria-hidden>
+          <img
+            src="/brands/cursor-cube-2d-light.svg"
+            alt=""
+            width={20}
+            height={20}
+            className="size-5 dark:hidden"
+            draggable={false}
+          />
+          <img
+            src="/brands/cursor-cube-2d-dark.svg"
+            alt=""
+            width={20}
+            height={20}
+            className="hidden size-5 dark:block"
+            draggable={false}
+          />
+        </span>
+        <div className="min-w-0 flex-1">
+          <div
+            className="truncate text-[12px] font-medium text-neutral-900 dark:text-neutral-100"
+            title={title}
+          >
+            {title}
+          </div>
+          {summary ? (
+            <div className="mt-0.5 line-clamp-2 text-[10px] leading-snug text-neutral-600 dark:text-neutral-400">
+              {summary}
+            </div>
+          ) : null}
+          <div className="mt-1 flex flex-wrap items-center gap-x-2 gap-y-0.5 text-[10px] text-neutral-600 dark:text-neutral-400">
+            <span className="inline-flex items-center gap-1">
+              <span
+                className={cn("size-1.5 rounded-full", statusDotClass(tone))}
+                aria-hidden
+              />
+              <span>{t(statusLabelKey(tone))}</span>
+              {live.isPolling ? (
+                <span className="text-neutral-400 dark:text-neutral-500">
+                  · {t("apps.chats.toolCalls.cursorCloudAgent.live")}
+                </span>
+              ) : null}
+            </span>
+            {createdLabel ? (
+              <span className="text-neutral-500 dark:text-neutral-500">
+                {t("apps.chats.toolCalls.cursorCloudAgent.createdAt", {
+                  time: createdLabel,
+                })}
+              </span>
+            ) : null}
+          </div>
+        </div>
+      </div>
+      {(dashboardUrl || prUrl) && (
+        <div className="flex flex-wrap items-center gap-1.5 border-t border-neutral-200 px-2.5 py-1.5 dark:border-neutral-700">
+          {dashboardUrl ? (
+            <a
+              href={dashboardUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex shrink-0 items-center gap-1 rounded border border-neutral-300 bg-white/85 px-1.5 py-0.5 text-[10px] font-medium text-neutral-700 transition-colors hover:bg-neutral-100 dark:border-neutral-600 dark:bg-neutral-900/70 dark:text-neutral-200 dark:hover:bg-neutral-800"
+            >
+              <ArrowSquareOut className="size-3" weight="bold" />
+              {t("apps.chats.toolCalls.cursorCloudAgent.openDashboard")}
+            </a>
+          ) : null}
+          {prUrl ? (
+            <a
+              href={prUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex shrink-0 items-center gap-1 rounded border border-neutral-300 bg-white/85 px-1.5 py-0.5 text-[10px] font-medium text-neutral-700 transition-colors hover:bg-neutral-100 dark:border-neutral-600 dark:bg-neutral-900/70 dark:text-neutral-200 dark:hover:bg-neutral-800"
+            >
+              <ArrowSquareOut className="size-3" weight="bold" />
+              {t("apps.chats.toolCalls.cursorCloudAgent.openPr")}
+            </a>
+          ) : null}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/shared/CursorCloudAgentRunsListCard.tsx
+++ b/src/components/shared/CursorCloudAgentRunsListCard.tsx
@@ -1,0 +1,43 @@
+import { useTranslation } from "react-i18next";
+import { CursorAgentRunSummaryCard } from "@/components/shared/CursorAgentRunSummaryCard";
+import type { CursorAgentRunPreviewData } from "@/lib/cursorAgentChatPreview";
+
+export interface CursorCloudAgentRunsListCardProps {
+  runs: CursorAgentRunPreviewData[];
+  truncated?: boolean;
+}
+
+/**
+ * Inline chat card for `listCursorCloudAgentRuns` tool output.
+ */
+export function CursorCloudAgentRunsListCard({
+  runs,
+  truncated,
+}: CursorCloudAgentRunsListCardProps) {
+  const { t } = useTranslation();
+
+  if (!runs.length) {
+    return (
+      <div className="my-1 px-0.5 text-[12px] text-neutral-600 dark:text-neutral-400">
+        {t("apps.chats.toolCalls.listCursorCloudAgentRuns.empty")}
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-1.5" data-cursor-agent-list-preview>
+      {truncated ? (
+        <p className="px-0.5 text-[10px] text-amber-800 dark:text-amber-200">
+          {t("apps.chats.toolCalls.listCursorCloudAgentRuns.truncatedHint")}
+        </p>
+      ) : null}
+      {runs.map((run) => (
+        <CursorAgentRunSummaryCard
+          key={run.runId}
+          run={run}
+          enableLiveStatus
+        />
+      ))}
+    </div>
+  );
+}

--- a/src/components/shared/CursorRepoAgentChatCard.tsx
+++ b/src/components/shared/CursorRepoAgentChatCard.tsx
@@ -1,5 +1,9 @@
 import { ArrowSquareOut, ArrowUp, Check } from "@phosphor-icons/react";
 import {
+  cursorAgentDashboardUrl,
+  formatCursorAgentTimestamp,
+} from "@/lib/cursorAgentChatPreview";
+import {
   KeyboardEvent,
   useCallback,
   useEffect,
@@ -25,6 +29,10 @@ interface CursorRepoAgentChatCardProps {
   headerTitle: string;
   /** Intro line shown above the card (outside applet chrome) */
   introMessage?: string;
+  /** https://cursor.com/agents/… from tool JSON when meta is still loading */
+  agentDashboardUrl?: string;
+  /** Epoch ms from tool start payload */
+  createdAt?: number;
   /** Admin side panel: fill parent height, no chat card chrome (margin/shadow/rounded). */
   variant?: "chat" | "panel";
 }
@@ -39,10 +47,12 @@ export function CursorRepoAgentChatCard({
   runId,
   headerTitle,
   introMessage,
+  agentDashboardUrl: agentDashboardUrlProp,
+  createdAt: createdAtProp,
   variant = "chat",
 }: CursorRepoAgentChatCardProps) {
   const isPanel = variant === "panel";
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const {
     events,
     done,
@@ -68,6 +78,19 @@ export function CursorRepoAgentChatCard({
   }, [events]);
 
   const prUrl = meta.prUrl;
+  const dashboardUrl =
+    agentDashboardUrlProp?.trim() ||
+    (meta.agentId ? cursorAgentDashboardUrl(meta.agentId) : undefined);
+  const createdLabel = formatCursorAgentTimestamp(
+    meta.createdAt ?? createdAtProp,
+    i18n.language
+  );
+  const headerSummary =
+    done && meta.summary?.trim()
+      ? meta.summary.trim().length > 120
+        ? `${meta.summary.trim().slice(0, 117)}…`
+        : meta.summary.trim()
+      : "";
   const canFollowup = done && !isSendingFollowup;
   const items = useMemo(
     () =>
@@ -115,6 +138,7 @@ export function CursorRepoAgentChatCard({
             : "my-1 flex flex-col overflow-hidden rounded bg-white font-geneva-12 dark:bg-neutral-950"
         }
         style={isPanel ? undefined : { boxShadow: "0 0 0 1px rgba(0, 0, 0, 0.3)" }}
+        data-cursor-agent-stream-card
       >
         <div className="flex flex-shrink-0 items-center gap-3 border-b border-neutral-300 bg-neutral-100 px-3 py-2 dark:border-neutral-600 dark:bg-neutral-800/90">
           <span className="relative inline-flex size-6 shrink-0 items-center justify-center" aria-hidden>
@@ -135,10 +159,25 @@ export function CursorRepoAgentChatCard({
               draggable={false}
             />
           </span>
-          <div className="flex min-w-0 flex-1 items-center gap-2">
+          <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+            <div className="flex min-w-0 flex-1 items-center gap-2">
             <div className="min-w-0 flex-1 truncate text-sm font-medium text-neutral-900 dark:text-neutral-100" title={displayTitle}>
               {displayTitle}
             </div>
+            {dashboardUrl ? (
+              <a
+                href={dashboardUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex shrink-0 items-center gap-1 rounded border border-neutral-300 bg-white/85 px-1.5 py-0.5 text-[10px] font-medium text-neutral-700 transition-colors hover:bg-neutral-100 dark:border-neutral-600 dark:bg-neutral-900/70 dark:text-neutral-200 dark:hover:bg-neutral-800"
+                title={dashboardUrl}
+              >
+                <ArrowSquareOut className="size-3" weight="bold" />
+                <span>
+                  {t("apps.chats.toolCalls.cursorCloudAgent.openDashboard")}
+                </span>
+              </a>
+            ) : null}
             {prUrl ? (
               <a
                 href={prUrl}
@@ -165,6 +204,23 @@ export function CursorRepoAgentChatCard({
                 {t("apps.chats.toolCalls.cursorCloudAgent.finished")}
               </span>
             )}
+            </div>
+            {(createdLabel || headerSummary) ? (
+              <div className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-0 text-[10px] text-neutral-600 dark:text-neutral-400">
+                {createdLabel ? (
+                  <span>
+                    {t("apps.chats.toolCalls.cursorCloudAgent.createdAt", {
+                      time: createdLabel,
+                    })}
+                  </span>
+                ) : null}
+                {headerSummary ? (
+                  <span className="min-w-0 truncate italic" title={meta.summary}>
+                    {headerSummary}
+                  </span>
+                ) : null}
+              </div>
+            ) : null}
           </div>
         </div>
 

--- a/src/components/shared/ToolInvocationMessage.tsx
+++ b/src/components/shared/ToolInvocationMessage.tsx
@@ -2,6 +2,8 @@ import { Check } from "@phosphor-icons/react";
 import type { ReactNode } from "react";
 import HtmlPreview from "@/components/shared/HtmlPreview";
 import { CursorRepoAgentChatCard } from "@/components/shared/CursorRepoAgentChatCard";
+import { CursorCloudAgentRunsListCard } from "@/components/shared/CursorCloudAgentRunsListCard";
+import { parseListCursorCloudAgentRunsOutput } from "@/lib/cursorAgentChatPreview";
 import {
   MapsSearchPlacesCard,
   type MapsSearchPlaceCardData,
@@ -737,7 +739,9 @@ export function ToolInvocationMessage({
       runId: string;
       agentId?: string;
       agentTitle?: string;
+      agentDashboardUrl?: string;
       message?: string;
+      createdAt?: number;
     };
     const headerTitle =
       typeof out.agentTitle === "string" && out.agentTitle.trim().length > 0
@@ -750,8 +754,37 @@ export function ToolInvocationMessage({
         runId={out.runId}
         headerTitle={headerTitle}
         introMessage={out.message}
+        agentDashboardUrl={out.agentDashboardUrl}
+        createdAt={out.createdAt}
       />
     );
+  }
+
+  if (state === "output-available" && toolName === "listCursorCloudAgentRuns") {
+    const runs = parseListCursorCloudAgentRunsOutput(output);
+    const truncated = Boolean(
+      output &&
+        typeof output === "object" &&
+        (output as { truncated?: boolean }).truncated
+    );
+    if (runs.length > 0) {
+      return (
+        <div key={partKey} className="mb-0 px-1 py-0.5 text-[12px]">
+          <ToolInvocationStatusRow
+            icon={<Check className="size-3 text-blue-600 dark:text-blue-400" weight="bold" />}
+            className="text-neutral-700 dark:text-neutral-200"
+            align="start"
+          >
+            <span>
+              {t("apps.chats.toolCalls.listCursorCloudAgentRuns.listed", {
+                count: runs.length,
+              })}
+            </span>
+          </ToolInvocationStatusRow>
+          <CursorCloudAgentRunsListCard runs={runs} truncated={truncated} />
+        </div>
+      );
+    }
   }
 
   // Special handling for mapsSearchPlaces — render a rich place-card list

--- a/src/components/shared/useCursorAgentRunPoll.ts
+++ b/src/components/shared/useCursorAgentRunPoll.ts
@@ -6,6 +6,9 @@ export interface CursorAgentRunMeta {
   agentId?: string;
   agentTitle?: string;
   prUrl?: string;
+  createdAt?: number;
+  summary?: string;
+  promptPreview?: string;
   /** Set on the meta when a follow-up has been queued; UI follows the chain. */
   nextRunId?: string;
   /** When non-null, a run is in flight on this agent. */
@@ -23,6 +26,9 @@ interface CursorRunStatusResponse {
     nextRunId?: unknown;
     activeRunId?: unknown;
     terminalStatus?: unknown;
+    createdAt?: unknown;
+    summary?: unknown;
+    promptPreview?: unknown;
   };
   terminal?: { prUrl?: unknown } | null;
 }
@@ -54,6 +60,15 @@ function pickMeta(raw: CursorRunStatusResponse | null): CursorAgentRunMeta {
   }
   if (typeof m.terminalStatus === "string") {
     next.terminalStatus = m.terminalStatus;
+  }
+  if (typeof m.createdAt === "number" && Number.isFinite(m.createdAt)) {
+    next.createdAt = m.createdAt;
+  }
+  if (typeof m.summary === "string" && m.summary.trim().length > 0) {
+    next.summary = m.summary.trim();
+  }
+  if (typeof m.promptPreview === "string" && m.promptPreview.trim().length > 0) {
+    next.promptPreview = m.promptPreview.trim();
   }
   return next;
 }

--- a/src/components/shared/useCursorAgentRunStatusBadge.ts
+++ b/src/components/shared/useCursorAgentRunStatusBadge.ts
@@ -1,0 +1,106 @@
+import { useEffect, useState } from "react";
+import { abortableFetch } from "@/utils/abortableFetch";
+import { getApiUrl } from "@/utils/platform";
+
+interface LiveBadgeState {
+  status: string | undefined;
+  prUrl: string | undefined;
+  isPolling: boolean;
+}
+
+/**
+ * Lightweight poll for list/history summary cards: only meta status + PR, not full event stream.
+ */
+export function useCursorAgentRunStatusBadge(
+  runId: string | undefined,
+  initialStatus: string | undefined
+): LiveBadgeState {
+  const [state, setState] = useState<LiveBadgeState>({
+    status: initialStatus,
+    prUrl: undefined,
+    isPolling: false,
+  });
+
+  useEffect(() => {
+    setState({
+      status: initialStatus,
+      prUrl: undefined,
+      isPolling: false,
+    });
+  }, [runId, initialStatus]);
+
+  useEffect(() => {
+    const id = runId?.trim();
+    const initial = (initialStatus ?? "").toLowerCase();
+    if (!id || initial !== "running") return undefined;
+
+    let cancelled = false;
+    let interval: number | null = null;
+
+    async function tick() {
+      try {
+        const res = await abortableFetch(
+          `${getApiUrl("/api/ai/cursor-run-status")}?runId=${encodeURIComponent(id!)}`,
+          {
+            credentials: "include",
+            timeout: 15000,
+            retry: { maxAttempts: 1, initialDelayMs: 200 },
+          }
+        );
+        if (!res.ok || cancelled) return;
+        const data = (await res.json()) as {
+          done?: boolean;
+          meta?: {
+            terminalStatus?: unknown;
+            prUrl?: unknown;
+            activeRunId?: unknown;
+          };
+          terminal?: { prUrl?: unknown } | null;
+        };
+        if (cancelled) return;
+
+        const meta = data.meta ?? {};
+        let status = "running";
+        if (data.done) {
+          const term =
+            typeof meta.terminalStatus === "string"
+              ? meta.terminalStatus
+              : "finished";
+          status = term === "finished" ? "finished" : term;
+        }
+
+        let prUrl: string | undefined;
+        if (typeof meta.prUrl === "string" && meta.prUrl.trim()) {
+          prUrl = meta.prUrl.trim();
+        } else if (
+          data.terminal &&
+          typeof data.terminal === "object" &&
+          typeof (data.terminal as { prUrl?: unknown }).prUrl === "string"
+        ) {
+          const tp = (data.terminal as { prUrl: string }).prUrl.trim();
+          if (tp) prUrl = tp;
+        }
+
+        setState({ status, prUrl, isPolling: !data.done });
+
+        if (data.done && interval !== null) {
+          window.clearInterval(interval);
+          interval = null;
+        }
+      } catch {
+        if (!cancelled) setState((s) => ({ ...s, isPolling: false }));
+      }
+    }
+
+    setState((s) => ({ ...s, isPolling: true }));
+    void tick();
+    interval = window.setInterval(() => void tick(), 3000);
+
+    return () => {
+      cancelled = true;
+      if (interval !== null) window.clearInterval(interval);
+    };
+  }, [runId, initialStatus]);
+
+  return state;
+}

--- a/src/lib/cursorAgentChatPreview.ts
+++ b/src/lib/cursorAgentChatPreview.ts
@@ -1,0 +1,230 @@
+/**
+ * Cursor Cloud agent dashboard URLs and chat preview helpers.
+ * Used to render compact cards and suppress duplicate generic link previews.
+ */
+
+import type { ToolInvocationPart } from "@/components/shared/ToolInvocationMessage";
+
+export const CURSOR_AGENT_DASHBOARD_ORIGIN = "https://cursor.com";
+
+/** Agent id segment in https://cursor.com/agents/{id} */
+const AGENT_PATH_RE = /^\/agents\/([^/?#]+)\/?$/i;
+
+export function cursorAgentDashboardUrl(agentId: string): string {
+  const id = agentId.trim();
+  return `${CURSOR_AGENT_DASHBOARD_ORIGIN}/agents/${encodeURIComponent(id)}`;
+}
+
+export function parseCursorAgentDashboardUrl(url: string): string | null {
+  const raw = url.trim();
+  if (!raw) return null;
+  try {
+    const parsed = new URL(raw.startsWith("http") ? raw : `https://${raw}`);
+    if (parsed.hostname.replace(/^www\./i, "") !== "cursor.com") return null;
+    const match = AGENT_PATH_RE.exec(parsed.pathname);
+    if (!match?.[1]) return null;
+    return decodeURIComponent(match[1]);
+  } catch {
+    return null;
+  }
+}
+
+export function isCursorAgentDashboardUrl(url: string): boolean {
+  return parseCursorAgentDashboardUrl(url) !== null;
+}
+
+export function normalizeCursorAgentDashboardUrl(url: string): string | null {
+  const agentId = parseCursorAgentDashboardUrl(url);
+  return agentId ? cursorAgentDashboardUrl(agentId) : null;
+}
+
+export interface CursorAgentRunPreviewData {
+  runId?: string;
+  agentId?: string;
+  agentDashboardUrl?: string;
+  agentTitle?: string;
+  status?: string;
+  createdAt?: number | null;
+  updatedAt?: number | null;
+  promptPreview?: string;
+  summaryPreview?: string;
+  errorPreview?: string;
+  prUrl?: string;
+}
+
+function dashboardUrlFromRow(row: CursorAgentRunPreviewData): string | undefined {
+  const fromField = row.agentDashboardUrl?.trim();
+  if (fromField) return fromField;
+  const id = row.agentId?.trim();
+  return id ? cursorAgentDashboardUrl(id) : undefined;
+}
+
+export interface CursorAgentChatCoverage {
+  /** Normalized dashboard URLs already shown by a dedicated card */
+  dashboardUrls: Set<string>;
+  /** Agent ids (same agents as dashboardUrls) */
+  agentIds: Set<string>;
+  /** Run ids tied to a live stream card */
+  runIds: Set<string>;
+}
+
+function addDashboardCoverage(
+  coverage: CursorAgentChatCoverage,
+  agentId?: string,
+  agentDashboardUrl?: string
+): void {
+  const id = agentId?.trim();
+  const url =
+    agentDashboardUrl?.trim() ||
+    (id ? cursorAgentDashboardUrl(id) : undefined);
+  if (url) {
+    const normalized = normalizeCursorAgentDashboardUrl(url) ?? url;
+    coverage.dashboardUrls.add(normalized);
+  }
+  if (id) coverage.agentIds.add(id);
+}
+
+export function collectCursorAgentCoverageFromParts(
+  parts: Array<ToolInvocationPart | { type: string; text?: string }> | undefined
+): CursorAgentChatCoverage {
+  const coverage: CursorAgentChatCoverage = {
+    dashboardUrls: new Set(),
+    agentIds: new Set(),
+    runIds: new Set(),
+  };
+  if (!parts) return coverage;
+
+  for (const part of parts) {
+    if (!part.type.startsWith("tool-")) continue;
+    const toolName = part.type.slice(5);
+    const toolPart = part as ToolInvocationPart;
+    if (toolPart.state !== "output-available") continue;
+    const output = toolPart.output;
+    if (!output || typeof output !== "object") continue;
+
+    if (toolName === "cursorCloudAgent") {
+      const o = output as {
+        async?: boolean;
+        runId?: string;
+        agentId?: string;
+        agentDashboardUrl?: string;
+      };
+      if (o.async && typeof o.runId === "string") {
+        coverage.runIds.add(o.runId);
+      }
+      addDashboardCoverage(coverage, o.agentId, o.agentDashboardUrl);
+      continue;
+    }
+
+    if (toolName === "listCursorCloudAgentRuns") {
+      const o = output as { runs?: CursorAgentRunPreviewData[] };
+      if (!Array.isArray(o.runs)) continue;
+      for (const run of o.runs) {
+        if (typeof run.runId === "string") coverage.runIds.add(run.runId);
+        addDashboardCoverage(
+          coverage,
+          run.agentId,
+          dashboardUrlFromRow(run)
+        );
+      }
+    }
+  }
+
+  return coverage;
+}
+
+export function isCursorAgentUrlCoveredByMessage(
+  url: string,
+  coverage: CursorAgentChatCoverage
+): boolean {
+  const normalized = normalizeCursorAgentDashboardUrl(url);
+  if (normalized && coverage.dashboardUrls.has(normalized)) return true;
+  const agentId = parseCursorAgentDashboardUrl(url);
+  return agentId != null && coverage.agentIds.has(agentId);
+}
+
+export function partitionMessageUrlsForPreviews(urls: string[]): {
+  genericUrls: string[];
+  cursorAgentUrls: string[];
+} {
+  const genericUrls: string[] = [];
+  const cursorAgentUrls: string[] = [];
+  const seenCursor = new Set<string>();
+
+  for (const url of urls) {
+    if (isCursorAgentDashboardUrl(url)) {
+      const key = normalizeCursorAgentDashboardUrl(url) ?? url;
+      if (!seenCursor.has(key)) {
+        seenCursor.add(key);
+        cursorAgentUrls.push(url);
+      }
+    } else {
+      genericUrls.push(url);
+    }
+  }
+  return { genericUrls, cursorAgentUrls };
+}
+
+export function formatCursorAgentTimestamp(
+  ms: number | null | undefined,
+  locale?: string
+): string {
+  if (ms == null || !Number.isFinite(ms)) return "";
+  try {
+    return new Date(ms).toLocaleString(locale, {
+      month: "short",
+      day: "numeric",
+      hour: "numeric",
+      minute: "2-digit",
+    });
+  } catch {
+    return "";
+  }
+}
+
+export type CursorAgentStatusTone = "running" | "finished" | "error" | "unknown";
+
+export function cursorAgentStatusTone(status: string | undefined): CursorAgentStatusTone {
+  const s = (status ?? "").trim().toLowerCase();
+  if (s === "running") return "running";
+  if (s === "finished" || s === "completed" || s === "success") return "finished";
+  if (
+    s === "error" ||
+    s === "failed" ||
+    s === "cancelled" ||
+    s === "canceled"
+  ) {
+    return "error";
+  }
+  return "unknown";
+}
+
+export function cursorAgentDisplayTitle(row: CursorAgentRunPreviewData): string {
+  const title = row.agentTitle?.trim();
+  if (title) return title;
+  const prompt = row.promptPreview?.trim();
+  if (prompt) {
+    return prompt.length > 80 ? `${prompt.slice(0, 77)}…` : prompt;
+  }
+  return "";
+}
+
+export function cursorAgentDisplaySummary(row: CursorAgentRunPreviewData): string {
+  const summary = row.summaryPreview?.trim();
+  if (summary) return summary;
+  const err = row.errorPreview?.trim();
+  if (err) return err;
+  return "";
+}
+
+export function parseListCursorCloudAgentRunsOutput(
+  output: unknown
+): CursorAgentRunPreviewData[] {
+  if (!output || typeof output !== "object") return [];
+  const o = output as { success?: boolean; runs?: unknown[] };
+  if (o.success === false || !Array.isArray(o.runs)) return [];
+  return o.runs.filter(
+    (r): r is CursorAgentRunPreviewData =>
+      typeof r === "object" && r !== null && typeof (r as { runId?: unknown }).runId === "string"
+  );
+}

--- a/src/lib/locales/en/translation.json
+++ b/src/lib/locales/en/translation.json
@@ -1016,6 +1016,11 @@
           "panelTitle": "Cursor Cloud agent",
           "running": "Running",
           "finished": "Finished",
+          "live": "live",
+          "statusError": "Error",
+          "statusUnknown": "Unknown",
+          "createdAt": "{{time}}",
+          "openDashboard": "Open agent",
           "noEventsYet": "Waiting for stream events…",
           "openPr": "Open PR",
           "followupPlaceholder": "Reply to the agent…",
@@ -1041,7 +1046,8 @@
         "listCursorCloudAgentRuns": {
           "loading": "Listing Cursor Cloud agent runs…",
           "listed": "Listed {{count}} recent run(s).",
-          "truncatedHint": "(list may be truncated)"
+          "truncatedHint": "(list may be truncated)",
+          "empty": "No recent Cursor agent runs found."
         },
         "searchedWebFor": "Searched the web for {{query}}",
         "foundVideos": "Found {{count}} videos",

--- a/tests/test-cursor-agent-chat-preview.test.ts
+++ b/tests/test-cursor-agent-chat-preview.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, test } from "bun:test";
+import {
+  collectCursorAgentCoverageFromParts,
+  cursorAgentDashboardUrl,
+  formatCursorAgentTimestamp,
+  isCursorAgentDashboardUrl,
+  isCursorAgentUrlCoveredByMessage,
+  parseCursorAgentDashboardUrl,
+  parseListCursorCloudAgentRunsOutput,
+  partitionMessageUrlsForPreviews,
+} from "../src/lib/cursorAgentChatPreview.js";
+
+describe("cursorAgentChatPreview URLs", () => {
+  test("parses cursor.com/agents dashboard links", () => {
+    expect(parseCursorAgentDashboardUrl("https://cursor.com/agents/bc_abc")).toBe(
+      "bc_abc"
+    );
+    expect(parseCursorAgentDashboardUrl("http://www.cursor.com/agents/x%2Fy")).toBe(
+      "x/y"
+    );
+    expect(isCursorAgentDashboardUrl("https://github.com/foo")).toBe(false);
+    expect(cursorAgentDashboardUrl("bc_1")).toBe(
+      "https://cursor.com/agents/bc_1"
+    );
+  });
+
+  test("partitions cursor agent URLs from generic previews", () => {
+    const { genericUrls, cursorAgentUrls } = partitionMessageUrlsForPreviews([
+      "https://example.com/a",
+      "https://cursor.com/agents/bc_1",
+      "https://cursor.com/agents/bc_1",
+    ]);
+    expect(genericUrls).toEqual(["https://example.com/a"]);
+    expect(cursorAgentUrls).toEqual(["https://cursor.com/agents/bc_1"]);
+  });
+});
+
+describe("cursorAgentChatPreview message coverage", () => {
+  test("collects dashboard URLs from cursorCloudAgent and list tools", () => {
+    const coverage = collectCursorAgentCoverageFromParts([
+      {
+        type: "tool-cursorCloudAgent",
+        toolCallId: "1",
+        state: "output-available",
+        output: {
+          async: true,
+          runId: "run-a",
+          agentId: "ag-a",
+          agentDashboardUrl: "https://cursor.com/agents/ag-a",
+        },
+      },
+      {
+        type: "tool-listCursorCloudAgentRuns",
+        toolCallId: "2",
+        state: "output-available",
+        output: {
+          success: true,
+          runs: [
+            {
+              runId: "run-b",
+              agentId: "ag-b",
+              agentDashboardUrl: "https://cursor.com/agents/ag-b",
+              status: "finished",
+            },
+          ],
+        },
+      },
+    ]);
+    expect(coverage.runIds.has("run-a")).toBe(true);
+    expect(coverage.runIds.has("run-b")).toBe(true);
+    expect(
+      isCursorAgentUrlCoveredByMessage(
+        "https://cursor.com/agents/ag-a",
+        coverage
+      )
+    ).toBe(true);
+    expect(
+      isCursorAgentUrlCoveredByMessage(
+        "https://cursor.com/agents/ag-b",
+        coverage
+      )
+    ).toBe(true);
+    expect(
+      isCursorAgentUrlCoveredByMessage(
+        "https://cursor.com/agents/other",
+        coverage
+      )
+    ).toBe(false);
+  });
+
+  test("parseListCursorCloudAgentRunsOutput filters invalid rows", () => {
+    const runs = parseListCursorCloudAgentRunsOutput({
+      success: true,
+      runs: [
+        { runId: "r1", agentId: "a1", status: "running" },
+        { agentId: "no-run-id" },
+        null,
+      ],
+    });
+    expect(runs).toHaveLength(1);
+    expect(runs[0]?.runId).toBe("r1");
+  });
+});
+
+describe("formatCursorAgentTimestamp", () => {
+  test("returns empty for invalid input", () => {
+    expect(formatCursorAgentTimestamp(null)).toBe("");
+    expect(formatCursorAgentTimestamp(Number.NaN)).toBe("");
+  });
+
+  test("formats valid epoch ms", () => {
+    const label = formatCursorAgentTimestamp(0, "en-US");
+    expect(label.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Improves how Cursor Cloud agent runs started from ryOS appear in Chats: richer compact cards, a clearer live stream header, and no duplicate generic link previews when a dedicated card is already present.

## Changes

- **`CursorRepoAgentChatCard`**: Open agent button, created time, finished summary in header; polls `createdAt` / `summary` from run meta.
- **`CursorCloudAgentRunsListCard` + `CursorAgentRunSummaryCard`**: Rich rows for `listCursorCloudAgentRuns` (title/summary, status, timestamps, dashboard + PR actions, lightweight live poll for running jobs).
- **`ChatMessages`**: `cursor.com/agents/…` URLs covered by tool cards skip `LinkPreview`; uncovered agent URLs get the compact summary card; normal URLs unchanged.
- **`cursorAgentChatPreview` helpers** + **`test-cursor-agent-chat-preview.test.ts`**
- Tool start payload includes **`createdAt`** for immediate header display.

## Testing

- `bun test tests/test-cursor-agent-chat-preview.test.ts tests/test-cursor-agent-tool-display.test.ts` — pass
- `bun run build` — pass

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a69c7fc3-b5e0-43f2-99b3-46948f43ff52"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a69c7fc3-b5e0-43f2-99b3-46948f43ff52"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

