### PR TITLE
fix: standalone /standalone/ipod route loads without ryOS shell

### DIFF
--- a/api/_utils/og-share.ts
+++ b/api/_utils/og-share.ts
@@ -414,6 +414,35 @@ export async function createOgShareResponse(
     matched = true;
   }
 
+  const standaloneIpodMatch = pathname.match(/^\/standalone\/ipod\/([^/?#]+)$/);
+  if (standaloneIpodMatch) {
+    const songId = resolveSongShareId(standaloneIpodMatch[1]);
+    imageUrl = getAppIconUrl(publicOrigin, "ipod");
+
+    const songInfo = await (options.getSong || getSongFromRedis)(songId);
+    if (songInfo) {
+      imageUrl = formatMusicCoverUrl(songInfo.cover, 400) || imageUrl;
+      if (songInfo.artist) {
+        title = `${songInfo.title} - ${songInfo.artist}`;
+        description = "Listen on ryOS iPod";
+      } else {
+        title = songInfo.title;
+        description = "Listen on ryOS iPod";
+      }
+    } else {
+      title = "Shared Song - ryOS";
+      description = "Listen on ryOS iPod";
+    }
+    matched = true;
+  }
+
+  if (pathname === "/standalone/ipod") {
+    imageUrl = getAppIconUrl(publicOrigin, "ipod");
+    title = "iPod on ryOS";
+    description = APP_DESCRIPTIONS.ipod || "Open app in ryOS";
+    matched = true;
+  }
+
   const ipodMatch = pathname.match(/^\/ipod\/([^/?#]+)$/);
   if (ipodMatch) {
     const songId = resolveSongShareId(ipodMatch[1]);

--- a/api/_utils/og-share.ts
+++ b/api/_utils/og-share.ts
@@ -365,6 +365,14 @@ async function getYouTubeInfo(
   }
 }
 
+/** Link-preview crawlers that need OG HTML; normal browsers should receive the SPA directly. */
+export function isSocialPreviewCrawler(userAgent: string | null): boolean {
+  if (!userAgent) return false;
+  return /facebookexternalhit|Facebot|Twitterbot|Slackbot|Discordbot|LinkedInBot|WhatsApp|TelegramBot|Googlebot|bingbot|Pinterest|Embedly|preview|bot|crawler|spider/i.test(
+    userAgent
+  );
+}
+
 export async function createOgShareResponse(
   request: Request,
   options: {
@@ -378,6 +386,11 @@ export async function createOgShareResponse(
   const url = new URL(request.url);
   const pathname = url.pathname;
   const publicOrigin = getAppPublicOrigin(url.origin);
+
+  // Browsers should load the SPA shell directly (see StandaloneIpodApp / appRouteRegistry).
+  if (!isSocialPreviewCrawler(request.headers.get("user-agent"))) {
+    return null;
+  }
 
   // Skip if already redirected (has _ryo param)
   if (url.searchParams.has("_ryo")) {

--- a/api/_utils/og-share.ts
+++ b/api/_utils/og-share.ts
@@ -449,6 +449,34 @@ export async function createOgShareResponse(
     matched = true;
   }
 
+
+  const standaloneKaraokeMatch = pathname.match(/^\/standalone\/karaoke\/([^/?#]+)$/);
+  if (standaloneKaraokeMatch) {
+    const songId = resolveSongShareId(standaloneKaraokeMatch[1]);
+    imageUrl = getAppIconUrl(publicOrigin, "karaoke");
+
+    const songInfo = await (options.getSong || getSongFromRedis)(songId);
+    if (songInfo) {
+      imageUrl = formatMusicCoverUrl(songInfo.cover, 400) || imageUrl;
+      const songDisplay = songInfo.artist
+        ? `${songInfo.title} - ${songInfo.artist}`
+        : songInfo.title;
+      title = `Sing ${songDisplay} on ryOS`;
+      description = "Sing along on ryOS Karaoke";
+    } else {
+      title = "Sing on ryOS Karaoke";
+      description = "Sing along on ryOS Karaoke";
+    }
+    matched = true;
+  }
+
+  if (pathname === "/standalone/karaoke") {
+    imageUrl = getAppIconUrl(publicOrigin, "karaoke");
+    title = "Karaoke on ryOS";
+    description = APP_DESCRIPTIONS.karaoke || "Open app in ryOS";
+    matched = true;
+  }
+
   if (pathname === "/standalone/ipod") {
     imageUrl = getAppIconUrl(publicOrigin, "ipod");
     title = "iPod on ryOS";

--- a/api/_utils/runtime-config.ts
+++ b/api/_utils/runtime-config.ts
@@ -65,12 +65,34 @@ export function getConfiguredPublicOrigin(): string | null {
   );
 }
 
+/** True when the browser-facing request host should win over APP_PUBLIC_ORIGIN. */
+export function shouldPreferRequestPublicOrigin(
+  fallbackOrigin?: string | null
+): boolean {
+  const fallback = normalizeOrigin(fallbackOrigin);
+  if (!fallback) return false;
+
+  try {
+    const host = new URL(fallback).host.toLowerCase();
+    // Local dev API probes (127.0.0.1, localhost) should still use configured origin.
+    if (/^localhost(:\d+)?$/.test(host)) return false;
+    if (/^127\.0\.0\.1(:\d+)?$/.test(host)) return false;
+    if (/^\[::1\](:\d+)?$/.test(host)) return false;
+    return isAllowedAppHost(host);
+  } catch {
+    return false;
+  }
+}
+
 export function getAppPublicOrigin(fallbackOrigin?: string | null): string {
-  return (
-    getConfiguredPublicOrigin() ||
-    normalizeOrigin(fallbackOrigin) ||
-    DEFAULT_PUBLIC_ORIGIN
-  );
+  const configured = getConfiguredPublicOrigin();
+  const fallback = normalizeOrigin(fallbackOrigin);
+
+  if (fallback && shouldPreferRequestPublicOrigin(fallback)) {
+    return fallback;
+  }
+
+  return configured || fallback || DEFAULT_PUBLIC_ORIGIN;
 }
 
 export function getDocsBaseUrl(fallbackOrigin?: string | null): string {
@@ -161,7 +183,8 @@ export function getAllowedAppHosts(): {
     ...(configuredHost ? [configuredHost] : []),
   ];
 
-  const subdomainSuffixes: string[] = [];
+  // PR / preview deploys (e.g. 1331-preview.os.ryo.lu) share this suffix.
+  const subdomainSuffixes: string[] = [".os.ryo.lu"];
 
   for (const token of tokens) {
     const wildcard = token.match(/^\*\.(.+)$/);

--- a/docs/1.3-self-hosting-vps.md
+++ b/docs/1.3-self-hosting-vps.md
@@ -39,8 +39,9 @@ Important runtime envs:
 
 - `PORT` or `API_PORT` — listening port (defaults to `3000`)
 - `API_HOST` — bind host (defaults to `0.0.0.0`)
-- `APP_PUBLIC_ORIGIN` — canonical browser origin, e.g. `https://your-domain.com`
+- `APP_PUBLIC_ORIGIN` — canonical browser origin, e.g. `https://your-domain.com` (used when the request host is localhost or not on the allowlist)
 - `API_ALLOWED_ORIGINS` — comma-separated allowed browser origins for `/api/*`; supports wildcard subdomain patterns (e.g. `*.example.com`), and `*` to allow all origins
+- **Dynamic PR previews** on `*.os.ryo.lu` (e.g. `1331-preview.os.ryo.lu`): OG share redirects and `/app-config.js` automatically use the **request host** instead of `APP_PUBLIC_ORIGIN`, so preview URLs stay on the preview hostname. Add `APP_ALLOWED_HOSTS=*.your-domain.com` for other preview suffixes.
 - `STORAGE_PROVIDER` — optional explicit storage backend (`s3`, `vercel-blob`); auto-detected if unset
 
 ---

--- a/middleware.ts
+++ b/middleware.ts
@@ -21,6 +21,8 @@ export const config = {
     "/ipod/:path*",
     "/standalone/ipod",
     "/standalone/ipod/:path*",
+    "/standalone/karaoke",
+    "/standalone/karaoke/:path*",
     "/karaoke",
     "/karaoke/:path*",
     "/listen/:path*",

--- a/middleware.ts
+++ b/middleware.ts
@@ -19,6 +19,8 @@ export const config = {
     "/videos/:path*",
     "/ipod",
     "/ipod/:path*",
+    "/standalone/ipod",
+    "/standalone/ipod/:path*",
     "/karaoke",
     "/karaoke/:path*",
     "/listen/:path*",

--- a/scripts/api-standalone-server.ts
+++ b/scripts/api-standalone-server.ts
@@ -33,6 +33,7 @@ import {
   discoverApiRouteManifest,
   type ApiRouteManifestEntry,
 } from "./api-route-manifest";
+import { shouldServeSpaFallback } from "./spa-static-fallback";
 
 type QueryValue = string | string[];
 type QueryMap = Record<string, QueryValue>;
@@ -604,13 +605,6 @@ async function serveSpaIndex(): Promise<Response> {
     },
     503
   );
-}
-
-function shouldServeSpaFallback(pathname: string): boolean {
-  if (pathname === "/" || pathname === "") return true;
-  if (pathname.startsWith("/api/")) return false;
-  if (pathname === "/api") return false;
-  return !path.posix.basename(pathname).includes(".");
 }
 
 function buildAppConfigScript(origin: string): string {

--- a/scripts/api-standalone-server.ts
+++ b/scripts/api-standalone-server.ts
@@ -15,7 +15,7 @@ import { fileURLToPath, pathToFileURL } from "node:url";
 import { getRedisBackend } from "../api/_utils/redis.js";
 import {
   buildClientRuntimeConfig,
-  getConfiguredPublicOrigin,
+  getAppPublicOrigin,
   getRealtimeProvider,
   getRealtimeWebSocketPath,
   shouldEnableLocalRealtime,
@@ -766,10 +766,9 @@ async function bootstrap(): Promise<void> {
       }
 
       if (pathname === "/app-config.js") {
-        const origin =
-          getConfiguredPublicOrigin() ||
-          (url.origin && !url.origin.includes(",") ? url.origin : null) ||
-          "https://os.ryo.lu";
+        const origin = getAppPublicOrigin(
+          url.origin && !url.origin.includes(",") ? url.origin : null
+        );
         return jsResponse(buildAppConfigScript(origin), 200);
       }
 

--- a/scripts/spa-static-fallback.ts
+++ b/scripts/spa-static-fallback.ts
@@ -1,0 +1,12 @@
+import path from "node:path";
+
+/**
+ * Whether a non-API GET path should fall back to the SPA shell (index.html).
+ * Used by the standalone Bun production server (non-Vercel deploys).
+ */
+export function shouldServeSpaFallback(pathname: string): boolean {
+  if (pathname === "/" || pathname === "") return true;
+  if (pathname.startsWith("/api/")) return false;
+  if (pathname === "/api") return false;
+  return !path.posix.basename(pathname).includes(".");
+}

--- a/src/StandaloneIpodApp.tsx
+++ b/src/StandaloneIpodApp.tsx
@@ -4,10 +4,8 @@ import { Toaster } from "@/components/ui/sonner";
 import { AppErrorBoundary } from "@/components/errors/ErrorBoundaries";
 import { DesktopErrorBoundary } from "@/components/errors/ErrorBoundaries";
 import { IpodAppComponent } from "@/apps/ipod/components/IpodAppComponent";
-import { getWindowConfig, appRegistry } from "@/config/appRegistry";
+import { appRegistry } from "@/config/appRegistry";
 import { useAppStoreShallow } from "@/stores/helpers";
-import { useThemeFlags } from "@/hooks/useThemeFlags";
-import { useIsMobile } from "@/hooks/useIsMobile";
 import { useOffline } from "@/hooks/useOffline";
 import { applyDisplayMode } from "@/utils/displayMode";
 import { useDisplaySettingsStoreShallow } from "@/stores/helpers";
@@ -20,8 +18,6 @@ const IPOD_APP_ID = "ipod" as const;
 export function StandaloneIpodApp() {
   const { t } = useTranslation();
   const displayMode = useDisplaySettingsStoreShallow((state) => state.displayMode);
-  const { isWindowsTheme, isMacOSTheme, isSystem7Theme } = useThemeFlags();
-  const isMobile = useIsMobile();
   useOffline();
 
   const routeInitialData = useMemo(
@@ -34,14 +30,11 @@ export function StandaloneIpodApp() {
   );
 
   const launchedRef = useRef(false);
-  const instanceIdRef = useRef<string | null>(null);
 
-  const { instances, launchApp, updateInstanceWindowState } =
-    useAppStoreShallow((state) => ({
-      instances: state.instances,
-      launchApp: state.launchApp,
-      updateInstanceWindowState: state.updateInstanceWindowState,
-    }));
+  const { instances, launchApp } = useAppStoreShallow((state) => ({
+    instances: state.instances,
+    launchApp: state.launchApp,
+  }));
 
   useEffect(() => {
     applyDisplayMode(displayMode);
@@ -58,110 +51,51 @@ export function StandaloneIpodApp() {
   useEffect(() => {
     if (launchedRef.current) return;
     launchedRef.current = true;
-
-    const id = launchApp(IPOD_APP_ID, routeInitialData as IpodInitialData);
-    instanceIdRef.current = id;
-
-    const config = getWindowConfig(IPOD_APP_ID);
-    const width = config.defaultSize.width;
-    const height = config.defaultSize.height;
-    const position = {
-      x: Math.max(0, Math.round((window.innerWidth - width) / 2)),
-      y: Math.max(0, Math.round((window.innerHeight - height) / 2)),
-    };
-    updateInstanceWindowState(id, position, { width, height });
-
-    const onResize = () => {
-      updateInstanceWindowState(
-        id,
-        {
-          x: Math.max(0, Math.round((window.innerWidth - width) / 2)),
-          y: Math.max(0, Math.round((window.innerHeight - height) / 2)),
-        },
-        { width, height }
-      );
-    };
-    window.addEventListener("resize", onResize);
-    return () => window.removeEventListener("resize", onResize);
-  }, [launchApp, routeInitialData, updateInstanceWindowState]);
+    launchApp(IPOD_APP_ID, routeInitialData as IpodInitialData);
+  }, [launchApp, routeInitialData]);
 
   const ipodInstance = Object.values(instances).find(
     (instance) => instance.appId === IPOD_APP_ID && instance.isOpen
   );
-
-  const toastConfig = useMemo(() => {
-    const dockHeight = isMacOSTheme ? 56 : 0;
-    const taskbarHeight = isWindowsTheme ? 30 : 0;
-
-    if (isMobile) {
-      const bottomOffset = dockHeight + taskbarHeight + 16;
-      return {
-        position: "bottom-center" as const,
-        offset: `calc(env(safe-area-inset-bottom, 0px) + ${bottomOffset}px)`,
-      };
-    }
-
-    if (isWindowsTheme) {
-      return {
-        position: "bottom-right" as const,
-        offset: `calc(env(safe-area-inset-bottom, 0px) + 42px)`,
-      };
-    }
-
-    const menuBarHeight = isSystem7Theme ? 30 : 25;
-    return {
-      position: "top-right" as const,
-      offset: `${menuBarHeight + 12}px`,
-    };
-  }, [isWindowsTheme, isMacOSTheme, isSystem7Theme, isMobile]);
 
   const appMeta = appRegistry[IPOD_APP_ID];
   const translatedAppName = getTranslatedAppName(IPOD_APP_ID);
   const crashDialogAppName =
     translatedAppName !== IPOD_APP_ID ? translatedAppName : (appMeta?.name ?? IPOD_APP_ID);
 
-  const exitToDesktop = () => {
-    window.location.href = "/";
-  };
-
   return (
     <>
       <DesktopErrorBoundary>
-        <div
-          className="standalone-ipod-root fixed inset-0 overflow-hidden bg-[#1a1a1a]"
-          data-standalone-ipod
-        >
-          {ipodInstance ? (
-            <div className="absolute inset-0" role="presentation">
-              <AppErrorBoundary
-                appId={IPOD_APP_ID}
-                appName={crashDialogAppName}
-                instanceId={ipodInstance.instanceId}
-                onQuit={exitToDesktop}
-                onRelaunch={() => {
-                  launchApp(IPOD_APP_ID, routeInitialData as IpodInitialData);
-                }}
-              >
-                <IpodAppComponent
-                  isWindowOpen={ipodInstance.isOpen}
-                  isForeground
-                  onClose={exitToDesktop}
-                  className="pointer-events-auto"
-                  helpItems={appMeta?.helpItems}
-                  skipInitialSound
-                  initialData={ipodInstance.initialData as IpodInitialData}
-                  instanceId={ipodInstance.instanceId}
-                />
-              </AppErrorBoundary>
-            </div>
-          ) : (
-            <div className="flex h-full w-full items-center justify-center text-sm text-white/70">
-              {t("common.loading.openingSharedIpodTrack", "Opening iPod…")}
-            </div>
-          )}
-        </div>
+        {ipodInstance ? (
+          <AppErrorBoundary
+            appId={IPOD_APP_ID}
+            appName={crashDialogAppName}
+            instanceId={ipodInstance.instanceId}
+            onQuit={() => {
+              window.location.href = "/";
+            }}
+            onRelaunch={() => {
+              launchApp(IPOD_APP_ID, routeInitialData as IpodInitialData);
+            }}
+          >
+            <IpodAppComponent
+              standalone
+              isWindowOpen={ipodInstance.isOpen}
+              isForeground
+              onClose={() => {}}
+              helpItems={appMeta?.helpItems}
+              skipInitialSound
+              initialData={ipodInstance.initialData as IpodInitialData}
+              instanceId={ipodInstance.instanceId}
+            />
+          </AppErrorBoundary>
+        ) : (
+          <div className="fixed inset-0 flex items-center justify-center bg-[#1a1a1a] text-sm text-white/70">
+            {t("common.loading.openingSharedIpodTrack", "Opening iPod…")}
+          </div>
+        )}
       </DesktopErrorBoundary>
-      <Toaster position={toastConfig.position} offset={toastConfig.offset} />
+      <Toaster position="bottom-center" offset="16px" />
     </>
   );
 }

--- a/src/StandaloneIpodApp.tsx
+++ b/src/StandaloneIpodApp.tsx
@@ -1,0 +1,169 @@
+import { useEffect, useMemo, useRef } from "react";
+import { useTranslation } from "react-i18next";
+import { Toaster } from "@/components/ui/sonner";
+import { AppErrorBoundary } from "@/components/errors/ErrorBoundaries";
+import { DesktopErrorBoundary } from "@/components/errors/ErrorBoundaries";
+import { getAppComponent } from "@/config/appRegistry";
+import { getWindowConfig } from "@/config/appRegistry";
+import { appRegistry } from "@/config/appRegistry";
+import { useAppStoreShallow } from "@/stores/helpers";
+import { useThemeFlags } from "@/hooks/useThemeFlags";
+import { useIsMobile } from "@/hooks/useIsMobile";
+import { useOffline } from "@/hooks/useOffline";
+import { applyDisplayMode } from "@/utils/displayMode";
+import { useDisplaySettingsStoreShallow } from "@/stores/helpers";
+import { getTranslatedAppName } from "@/utils/i18n";
+import { parseStandaloneIpodRoute } from "@/utils/standaloneIpodRoute";
+import type { IpodInitialData } from "@/apps/base/types";
+
+const IPOD_APP_ID = "ipod" as const;
+
+export function StandaloneIpodApp() {
+  const { t } = useTranslation();
+  const displayMode = useDisplaySettingsStoreShallow((state) => state.displayMode);
+  const { isWindowsTheme, isMacOSTheme, isSystem7Theme } = useThemeFlags();
+  const isMobile = useIsMobile();
+  useOffline();
+
+  const routeInitialData = useMemo(
+    () =>
+      parseStandaloneIpodRoute(
+        window.location.pathname,
+        window.location.search
+      ) ?? {},
+    []
+  );
+
+  const launchedRef = useRef(false);
+  const instanceIdRef = useRef<string | null>(null);
+
+  const { instances, launchApp, updateInstanceWindowState } =
+    useAppStoreShallow((state) => ({
+      instances: state.instances,
+      launchApp: state.launchApp,
+      updateInstanceWindowState: state.updateInstanceWindowState,
+    }));
+
+  useEffect(() => {
+    applyDisplayMode(displayMode);
+  }, [displayMode]);
+
+  useEffect(() => {
+    document.documentElement.dataset.standaloneIpod = "true";
+    document.title = "iPod · ryOS";
+    return () => {
+      delete document.documentElement.dataset.standaloneIpod;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (launchedRef.current) return;
+    launchedRef.current = true;
+
+    const id = launchApp(IPOD_APP_ID, routeInitialData as IpodInitialData);
+    instanceIdRef.current = id;
+
+    const config = getWindowConfig(IPOD_APP_ID);
+    const width = config.defaultSize.width;
+    const height = config.defaultSize.height;
+    const position = {
+      x: Math.max(0, Math.round((window.innerWidth - width) / 2)),
+      y: Math.max(0, Math.round((window.innerHeight - height) / 2)),
+    };
+    updateInstanceWindowState(id, position, { width, height });
+
+    const onResize = () => {
+      updateInstanceWindowState(
+        id,
+        {
+          x: Math.max(0, Math.round((window.innerWidth - width) / 2)),
+          y: Math.max(0, Math.round((window.innerHeight - height) / 2)),
+        },
+        { width, height }
+      );
+    };
+    window.addEventListener("resize", onResize);
+    return () => window.removeEventListener("resize", onResize);
+  }, [launchApp, routeInitialData, updateInstanceWindowState]);
+
+  const ipodInstance = Object.values(instances).find(
+    (instance) => instance.appId === IPOD_APP_ID && instance.isOpen
+  );
+
+  const toastConfig = useMemo(() => {
+    const dockHeight = isMacOSTheme ? 56 : 0;
+    const taskbarHeight = isWindowsTheme ? 30 : 0;
+
+    if (isMobile) {
+      const bottomOffset = dockHeight + taskbarHeight + 16;
+      return {
+        position: "bottom-center" as const,
+        offset: `calc(env(safe-area-inset-bottom, 0px) + ${bottomOffset}px)`,
+      };
+    }
+
+    if (isWindowsTheme) {
+      return {
+        position: "bottom-right" as const,
+        offset: `calc(env(safe-area-inset-bottom, 0px) + 42px)`,
+      };
+    }
+
+    const menuBarHeight = isSystem7Theme ? 30 : 25;
+    return {
+      position: "top-right" as const,
+      offset: `${menuBarHeight + 12}px`,
+    };
+  }, [isWindowsTheme, isMacOSTheme, isSystem7Theme, isMobile]);
+
+  const AppComponent = getAppComponent(IPOD_APP_ID);
+  const appMeta = appRegistry[IPOD_APP_ID];
+  const translatedAppName = getTranslatedAppName(IPOD_APP_ID);
+  const crashDialogAppName =
+    translatedAppName !== IPOD_APP_ID ? translatedAppName : (appMeta?.name ?? IPOD_APP_ID);
+
+  const exitToDesktop = () => {
+    window.location.href = "/";
+  };
+
+  return (
+    <>
+      <DesktopErrorBoundary>
+        <div
+          className="standalone-ipod-root fixed inset-0 overflow-hidden bg-[#1a1a1a]"
+          data-standalone-ipod
+        >
+          {ipodInstance ? (
+            <div className="absolute inset-0" role="presentation">
+              <AppErrorBoundary
+                appId={IPOD_APP_ID}
+                appName={crashDialogAppName}
+                instanceId={ipodInstance.instanceId}
+                onQuit={exitToDesktop}
+                onRelaunch={() => {
+                  launchApp(IPOD_APP_ID, routeInitialData as IpodInitialData);
+                }}
+              >
+                <AppComponent
+                  isWindowOpen={ipodInstance.isOpen}
+                  isForeground
+                  onClose={exitToDesktop}
+                  className="pointer-events-auto"
+                  helpItems={appMeta?.helpItems}
+                  skipInitialSound
+                  initialData={ipodInstance.initialData as IpodInitialData}
+                  instanceId={ipodInstance.instanceId}
+                />
+              </AppErrorBoundary>
+            </div>
+          ) : (
+            <div className="flex h-full w-full items-center justify-center text-sm text-white/70">
+              {t("common.loading.openingSharedIpodTrack", "Opening iPod…")}
+            </div>
+          )}
+        </div>
+      </DesktopErrorBoundary>
+      <Toaster position={toastConfig.position} offset={toastConfig.offset} />
+    </>
+  );
+}

--- a/src/StandaloneIpodApp.tsx
+++ b/src/StandaloneIpodApp.tsx
@@ -3,9 +3,8 @@ import { useTranslation } from "react-i18next";
 import { Toaster } from "@/components/ui/sonner";
 import { AppErrorBoundary } from "@/components/errors/ErrorBoundaries";
 import { DesktopErrorBoundary } from "@/components/errors/ErrorBoundaries";
-import { getAppComponent } from "@/config/appRegistry";
-import { getWindowConfig } from "@/config/appRegistry";
-import { appRegistry } from "@/config/appRegistry";
+import { IpodAppComponent } from "@/apps/ipod/components/IpodAppComponent";
+import { getWindowConfig, appRegistry } from "@/config/appRegistry";
 import { useAppStoreShallow } from "@/stores/helpers";
 import { useThemeFlags } from "@/hooks/useThemeFlags";
 import { useIsMobile } from "@/hooks/useIsMobile";
@@ -116,7 +115,6 @@ export function StandaloneIpodApp() {
     };
   }, [isWindowsTheme, isMacOSTheme, isSystem7Theme, isMobile]);
 
-  const AppComponent = getAppComponent(IPOD_APP_ID);
   const appMeta = appRegistry[IPOD_APP_ID];
   const translatedAppName = getTranslatedAppName(IPOD_APP_ID);
   const crashDialogAppName =
@@ -144,7 +142,7 @@ export function StandaloneIpodApp() {
                   launchApp(IPOD_APP_ID, routeInitialData as IpodInitialData);
                 }}
               >
-                <AppComponent
+                <IpodAppComponent
                   isWindowOpen={ipodInstance.isOpen}
                   isForeground
                   onClose={exitToDesktop}

--- a/src/StandaloneKaraokeApp.tsx
+++ b/src/StandaloneKaraokeApp.tsx
@@ -1,0 +1,103 @@
+import { useEffect, useMemo, useRef } from "react";
+import { useTranslation } from "react-i18next";
+import { Toaster } from "@/components/ui/sonner";
+import { AppErrorBoundary } from "@/components/errors/ErrorBoundaries";
+import { DesktopErrorBoundary } from "@/components/errors/ErrorBoundaries";
+import { KaraokeAppComponent } from "@/apps/karaoke/components/KaraokeAppComponent";
+import { appRegistry } from "@/config/appRegistry";
+import { useAppStoreShallow } from "@/stores/helpers";
+import { useOffline } from "@/hooks/useOffline";
+import { applyDisplayMode } from "@/utils/displayMode";
+import { useDisplaySettingsStoreShallow } from "@/stores/helpers";
+import { getTranslatedAppName } from "@/utils/i18n";
+import { parseStandaloneKaraokeRoute } from "@/utils/standaloneKaraokeRoute";
+import type { KaraokeInitialData } from "@/apps/base/types";
+
+const KARAOKE_APP_ID = "karaoke" as const;
+
+export function StandaloneKaraokeApp() {
+  const { t } = useTranslation();
+  const displayMode = useDisplaySettingsStoreShallow((state) => state.displayMode);
+  useOffline();
+
+  const routeInitialData = useMemo(
+    () =>
+      parseStandaloneKaraokeRoute(
+        window.location.pathname,
+        window.location.search
+      ) ?? {},
+    []
+  );
+
+  const launchedRef = useRef(false);
+
+  const { instances, launchApp } = useAppStoreShallow((state) => ({
+    instances: state.instances,
+    launchApp: state.launchApp,
+  }));
+
+  useEffect(() => {
+    applyDisplayMode(displayMode);
+  }, [displayMode]);
+
+  useEffect(() => {
+    document.documentElement.dataset.standaloneKaraoke = "true";
+    document.title = "Karaoke · ryOS";
+    return () => {
+      delete document.documentElement.dataset.standaloneKaraoke;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (launchedRef.current) return;
+    launchedRef.current = true;
+    launchApp(KARAOKE_APP_ID, routeInitialData as KaraokeInitialData);
+  }, [launchApp, routeInitialData]);
+
+  const karaokeInstance = Object.values(instances).find(
+    (instance) => instance.appId === KARAOKE_APP_ID && instance.isOpen
+  );
+
+  const appMeta = appRegistry[KARAOKE_APP_ID];
+  const translatedAppName = getTranslatedAppName(KARAOKE_APP_ID);
+  const crashDialogAppName =
+    translatedAppName !== KARAOKE_APP_ID
+      ? translatedAppName
+      : (appMeta?.name ?? KARAOKE_APP_ID);
+
+  return (
+    <>
+      <DesktopErrorBoundary>
+        {karaokeInstance ? (
+          <AppErrorBoundary
+            appId={KARAOKE_APP_ID}
+            appName={crashDialogAppName}
+            instanceId={karaokeInstance.instanceId}
+            onQuit={() => {
+              window.location.href = "/";
+            }}
+            onRelaunch={() => {
+              launchApp(KARAOKE_APP_ID, routeInitialData as KaraokeInitialData);
+            }}
+          >
+            <KaraokeAppComponent
+              standalone
+              isWindowOpen={karaokeInstance.isOpen}
+              isForeground
+              onClose={() => {}}
+              helpItems={appMeta?.helpItems}
+              skipInitialSound
+              initialData={karaokeInstance.initialData as KaraokeInitialData}
+              instanceId={karaokeInstance.instanceId}
+            />
+          </AppErrorBoundary>
+        ) : (
+          <div className="fixed inset-0 flex items-center justify-center bg-black text-sm text-white/70">
+            {t("common.loading.openingSharedKaraokeTrack", "Opening Karaoke…")}
+          </div>
+        )}
+      </DesktopErrorBoundary>
+      <Toaster position="bottom-center" offset="16px" />
+    </>
+  );
+}

--- a/src/apps/base/appRouteRegistry.ts
+++ b/src/apps/base/appRouteRegistry.ts
@@ -1,6 +1,7 @@
 import { appIds, appNames, resolveAppId, type AppId } from "@/config/appRegistryData";
 import type { AppLaunchRequest } from "@/utils/appEventBus";
 import { isStandaloneIpodPath } from "@/utils/standaloneIpodRoute";
+import { isStandaloneKaraokePath } from "@/utils/standaloneKaraokeRoute";
 
 export interface RouteToastDescriptor {
   type: "translation" | "text";
@@ -56,8 +57,8 @@ export function resolveInitialRoute(
     return null;
   }
 
-  // Standalone iPod is handled in main.tsx (StandaloneIpodApp); never rewrite the URL to /.
-  if (isStandaloneIpodPath(pathname)) {
+  // Standalone apps are handled in main.tsx; never rewrite these URLs to /.
+  if (isStandaloneIpodPath(pathname) || isStandaloneKaraokePath(pathname)) {
     return null;
   }
 

--- a/src/apps/base/appRouteRegistry.ts
+++ b/src/apps/base/appRouteRegistry.ts
@@ -1,5 +1,6 @@
 import { appIds, appNames, resolveAppId, type AppId } from "@/config/appRegistryData";
 import type { AppLaunchRequest } from "@/utils/appEventBus";
+import { isStandaloneIpodPath } from "@/utils/standaloneIpodRoute";
 
 export interface RouteToastDescriptor {
   type: "translation" | "text";
@@ -52,6 +53,11 @@ export function resolveInitialRoute(
 ): RouteAction | null {
   pathname = normalizePathname(pathname);
   if (!pathname || pathname === "/") {
+    return null;
+  }
+
+  // Standalone iPod is handled in main.tsx (StandaloneIpodApp); never rewrite the URL to /.
+  if (isStandaloneIpodPath(pathname)) {
     return null;
   }
 

--- a/src/apps/ipod/components/IpodAppComponent.tsx
+++ b/src/apps/ipod/components/IpodAppComponent.tsx
@@ -68,7 +68,8 @@ export function IpodAppComponent({
   instanceId,
   onNavigateNext,
   onNavigatePrevious,
-}: AppProps<IpodInitialData>) {
+  standalone = false,
+}: AppProps<IpodInitialData> & { standalone?: boolean }) {
   const {
     t,
     translatedHelpItems,
@@ -315,29 +316,17 @@ export function IpodAppComponent({
 
   if (!isWindowOpen) return null;
 
-  return (
+  const ipodShellContent = (
     <>
-      {!isXpTheme && isForeground && menuBar}
-      <WindowFrame
-        title={getTranslatedAppName("ipod")}
-        onClose={handleClose}
-        isForeground={isForeground}
-        appId="ipod"
-        interceptClose
-        material="transparent"
-        skipInitialSound={skipInitialSound}
-        instanceId={instanceId}
-        onNavigateNext={onNavigateNext}
-        onNavigatePrevious={onNavigatePrevious}
-        menuBar={isXpTheme ? menuBar : undefined}
-        keepMountedWhenMinimized
-        onFullscreenToggle={toggleFullScreen}
-        onCoverFlowToggle={() => setIsCoverFlowOpen(!isCoverFlowOpen)}
-        isCoverFlowActive={isCoverFlowOpen}
-      >
         <div
           ref={containerRef}
-          className="ipod-force-font flex flex-col items-center justify-center w-full h-full bg-gradient-to-b from-neutral-100/20 to-neutral-300/20 backdrop-blur-lg p-4 select-none"
+          className={cn(
+            "ipod-force-font flex flex-col items-center justify-center w-full h-full select-none",
+            standalone
+              ? "bg-[#1a1a1a] p-0"
+              : "bg-gradient-to-b from-neutral-100/20 to-neutral-300/20 backdrop-blur-lg p-4",
+            standalone && isFullScreen && "hidden"
+          )}
           style={{ position: "relative", overflow: "hidden", contain: "layout style paint" }}
         >
           <div
@@ -1044,11 +1033,46 @@ export function IpodAppComponent({
             />
           </div>
         )}
-      </WindowFrame>
+    </>
+  );
+
+  return (
+    <>
+      {!standalone && !isXpTheme && isForeground && menuBar}
+      {standalone ? (
+        <div
+          className={cn(
+            "fixed inset-0 z-0 overflow-hidden",
+            isFullScreen ? "bg-black" : "bg-[#1a1a1a]"
+          )}
+        >
+          {ipodShellContent}
+        </div>
+      ) : (
+        <WindowFrame
+          title={getTranslatedAppName("ipod")}
+          onClose={handleClose}
+          isForeground={isForeground}
+          appId="ipod"
+          interceptClose
+          material="transparent"
+          skipInitialSound={skipInitialSound}
+          instanceId={instanceId}
+          onNavigateNext={onNavigateNext}
+          onNavigatePrevious={onNavigatePrevious}
+          menuBar={isXpTheme ? menuBar : undefined}
+          keepMountedWhenMinimized
+          onFullscreenToggle={toggleFullScreen}
+          onCoverFlowToggle={() => setIsCoverFlowOpen(!isCoverFlowOpen)}
+          isCoverFlowActive={isCoverFlowOpen}
+        >
+          {ipodShellContent}
+        </WindowFrame>
+      )}
 
       {/* PIP Player */}
       <AnimatePresence>
-        {isMinimized && !isFullScreen && tracks.length > 0 && currentIndex >= 0 && (
+        {!standalone && isMinimized && !isFullScreen && tracks.length > 0 && currentIndex >= 0 && (
           <PipPlayer
             currentTrack={tracks[currentIndex] || null}
             isPlaying={isPlaying}

--- a/src/apps/karaoke/components/KaraokeAppComponent.tsx
+++ b/src/apps/karaoke/components/KaraokeAppComponent.tsx
@@ -51,7 +51,8 @@ export function KaraokeAppComponent({
   instanceId,
   onNavigateNext,
   onNavigatePrevious,
-}: AppProps<KaraokeInitialData>) {
+  standalone = false,
+}: AppProps<KaraokeInitialData> & { standalone?: boolean }) {
   const {
     t,
     translatedHelpItems,
@@ -335,24 +336,8 @@ export function KaraokeAppComponent({
 
   if (!isWindowOpen) return null;
 
-  return (
+  const karaokeShellBody = (
     <>
-      {!isXpTheme && isForeground && menuBar}
-      <WindowFrame
-        title={currentTrack ? `${currentTrack.title}${currentTrack.artist ? ` - ${currentTrack.artist}` : ""}` : getTranslatedAppName("karaoke")}
-        onClose={onClose}
-        isForeground={isForeground}
-        appId="karaoke"
-        material="notitlebar"
-        skipInitialSound={skipInitialSound}
-        instanceId={instanceId}
-        onNavigateNext={onNavigateNext}
-        onNavigatePrevious={onNavigatePrevious}
-        menuBar={isXpTheme ? menuBar : undefined}
-        onFullscreenToggle={toggleFullScreen}
-        onCoverFlowToggle={handleToggleCoverFlow}
-        isCoverFlowActive={isCoverFlowOpen}
-      >
         <div
           className="relative w-full h-full bg-black select-none overflow-hidden @container"
           onMouseMove={(e) => {
@@ -830,10 +815,37 @@ export function KaraokeAppComponent({
           isOpen={isJoinListenDialogOpen}
           onClose={() => setIsJoinListenDialogOpen(false)}
           onJoin={handleJoinListenSession}
-        />
-      </WindowFrame>
+        />    </>
+  );
 
-      {/* Full screen portal */}
+  return (
+    <>
+      {!standalone && !isXpTheme && isForeground && menuBar}
+      {standalone ? (
+        <div className={cn("fixed inset-0 z-0 overflow-hidden bg-black")}>
+          {karaokeShellBody}
+        </div>
+      ) : (
+      <WindowFrame
+        title={currentTrack ? `${currentTrack.title}${currentTrack.artist ? ` - ${currentTrack.artist}` : ""}` : getTranslatedAppName("karaoke")}
+        onClose={onClose}
+        isForeground={isForeground}
+        appId="karaoke"
+        material="notitlebar"
+        skipInitialSound={skipInitialSound}
+        instanceId={instanceId}
+        onNavigateNext={onNavigateNext}
+        onNavigatePrevious={onNavigatePrevious}
+        menuBar={isXpTheme ? menuBar : undefined}
+        onFullscreenToggle={toggleFullScreen}
+        onCoverFlowToggle={handleToggleCoverFlow}
+        isCoverFlowActive={isCoverFlowOpen}
+      >
+          {karaokeShellBody}
+      </WindowFrame>
+      )}
+
+
       {isFullScreen && (
         <KaraokeLyricsPlaybackProvider
           currentTrack={currentTrack}

--- a/src/apps/karaoke/hooks/useKaraokeLogic.ts
+++ b/src/apps/karaoke/hooks/useKaraokeLogic.ts
@@ -1337,10 +1337,14 @@ export function useKaraokeLogic({
   );
 
   // Generate share URL for song
-  const karaokeGenerateShareUrl = useCallback(
-    (videoId: string): string => `${window.location.origin}/karaoke/${videoId}`,
-    []
-  );
+  const karaokeGenerateShareUrl = useCallback((videoId: string): string => {
+    const base =
+      typeof document !== "undefined" &&
+      document.documentElement.dataset.standaloneKaraoke === "true"
+        ? "/standalone/karaoke"
+        : "/karaoke";
+    return `${window.location.origin}${base}/${encodeURIComponent(videoId)}`;
+  }, []);
 
   // Lyrics search handlers
   const handleRefreshLyrics = useCallback(() => {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
 import { App } from "./App";
+import { StandaloneIpodApp } from "./StandaloneIpodApp";
+import { isStandaloneIpodPath } from "./utils/standaloneIpodRoute";
 import "./index.css";
 import { useThemeStore } from "./stores/useThemeStore";
 import { useLanguageStore } from "./stores/useLanguageStore";
@@ -139,9 +141,10 @@ preloadIpodData();
 
 const renderApp = () => {
   initializeAnalytics();
+  const RootComponent = isStandaloneIpodPath() ? StandaloneIpodApp : App;
   ReactDOM.createRoot(document.getElementById("root")!).render(
     <React.StrictMode>
-      <App />
+      <RootComponent />
     </React.StrictMode>
   );
 };

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,7 +2,9 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import { App } from "./App";
 import { StandaloneIpodApp } from "./StandaloneIpodApp";
+import { StandaloneKaraokeApp } from "./StandaloneKaraokeApp";
 import { isStandaloneIpodPath } from "./utils/standaloneIpodRoute";
+import { isStandaloneKaraokePath } from "./utils/standaloneKaraokeRoute";
 import "./index.css";
 import { useThemeStore } from "./stores/useThemeStore";
 import { useLanguageStore } from "./stores/useLanguageStore";
@@ -12,6 +14,12 @@ import { initPrefetch } from "./utils/prefetch";
 import { initializeI18n } from "./lib/i18n";
 import { primeReactResources } from "./lib/reactResources";
 import { initializeAnalytics } from "./utils/analytics";
+
+function resolveRootComponent() {
+  if (isStandaloneIpodPath()) return StandaloneIpodApp;
+  if (isStandaloneKaraokePath()) return StandaloneKaraokeApp;
+  return App;
+}
 
 // Prime React 19 resource hints before anything else runs
 primeReactResources();
@@ -141,7 +149,7 @@ preloadIpodData();
 
 const renderApp = () => {
   initializeAnalytics();
-  const RootComponent = isStandaloneIpodPath() ? StandaloneIpodApp : App;
+  const RootComponent = resolveRootComponent();
   ReactDOM.createRoot(document.getElementById("root")!).render(
     <React.StrictMode>
       <RootComponent />

--- a/src/utils/standaloneIpodRoute.ts
+++ b/src/utils/standaloneIpodRoute.ts
@@ -31,13 +31,12 @@ export function parseStandaloneIpodRoute(
 
   const initialData: IpodInitialData = {};
 
-  const trackMatch = path.match(
-    new RegExp(
-      `^${STANDALONE_IPOD_BASE_PATH.replace(/\//g, "\\/")}/([^/]+)$`
-    )
-  );
-  if (trackMatch?.[1]) {
-    initialData.videoId = decodeURIComponent(trackMatch[1]);
+  const trackPrefix = `${STANDALONE_IPOD_BASE_PATH}/`;
+  if (path.startsWith(trackPrefix)) {
+    const segment = path.slice(trackPrefix.length);
+    if (segment.length > 0 && !segment.includes("/")) {
+      initialData.videoId = decodeURIComponent(segment);
+    }
   }
 
   const searchParams =

--- a/src/utils/standaloneIpodRoute.ts
+++ b/src/utils/standaloneIpodRoute.ts
@@ -1,0 +1,60 @@
+import type { IpodInitialData } from "@/apps/base/types";
+
+export const STANDALONE_IPOD_BASE_PATH = "/standalone/ipod";
+
+function normalizePathname(pathname: string): string {
+  if (!pathname || pathname === "/") return pathname;
+  return pathname.replace(/\/+$/, "") || "/";
+}
+
+/** True when the SPA should render only the iPod app (no desktop shell). */
+export function isStandaloneIpodPath(pathname?: string): boolean {
+  const path = normalizePathname(pathname ?? window.location.pathname);
+  return (
+    path === STANDALONE_IPOD_BASE_PATH ||
+    path.startsWith(`${STANDALONE_IPOD_BASE_PATH}/`)
+  );
+}
+
+/**
+ * Parse `/standalone/ipod` and `/standalone/ipod/:trackId` (and optional query).
+ * Returns null when the path is not a standalone iPod route.
+ */
+export function parseStandaloneIpodRoute(
+  pathname?: string,
+  search?: string
+): IpodInitialData | null {
+  const path = normalizePathname(pathname ?? window.location.pathname);
+  if (!isStandaloneIpodPath(path)) {
+    return null;
+  }
+
+  const initialData: IpodInitialData = {};
+
+  const trackMatch = path.match(
+    new RegExp(
+      `^${STANDALONE_IPOD_BASE_PATH.replace(/\//g, "\\/")}/([^/]+)$`
+    )
+  );
+  if (trackMatch?.[1]) {
+    initialData.videoId = decodeURIComponent(trackMatch[1]);
+  }
+
+  const searchParams =
+    typeof search === "string" && search.length > 0
+      ? new URLSearchParams(search.startsWith("?") ? search.slice(1) : search)
+      : null;
+
+  const listenSessionId = searchParams?.get("listen")?.trim();
+  if (listenSessionId) {
+    initialData.listenSessionId = listenSessionId;
+  }
+
+  return initialData;
+}
+
+/** Canonical path for linking to the standalone iPod experience. */
+export function standaloneIpodPath(trackId?: string): string {
+  if (!trackId) return STANDALONE_IPOD_BASE_PATH;
+  return `${STANDALONE_IPOD_BASE_PATH}/${encodeURIComponent(trackId)}`;
+}

--- a/src/utils/standaloneKaraokeRoute.ts
+++ b/src/utils/standaloneKaraokeRoute.ts
@@ -1,0 +1,59 @@
+import type { KaraokeInitialData } from "@/apps/base/types";
+
+export const STANDALONE_KARAOKE_BASE_PATH = "/standalone/karaoke";
+
+function normalizePathname(pathname: string): string {
+  if (!pathname || pathname === "/") return pathname;
+  return pathname.replace(/\/+$/, "") || "/";
+}
+
+/** True when the SPA should render only the Karaoke app (no desktop shell). */
+export function isStandaloneKaraokePath(pathname?: string): boolean {
+  const path = normalizePathname(pathname ?? window.location.pathname);
+  return (
+    path === STANDALONE_KARAOKE_BASE_PATH ||
+    path.startsWith(`${STANDALONE_KARAOKE_BASE_PATH}/`)
+  );
+}
+
+/**
+ * Parse `/standalone/karaoke` and `/standalone/karaoke/:trackId` (and optional query).
+ * Returns null when the path is not a standalone Karaoke route.
+ */
+export function parseStandaloneKaraokeRoute(
+  pathname?: string,
+  search?: string
+): KaraokeInitialData | null {
+  const path = normalizePathname(pathname ?? window.location.pathname);
+  if (!isStandaloneKaraokePath(path)) {
+    return null;
+  }
+
+  const initialData: KaraokeInitialData = {};
+
+  const trackPrefix = `${STANDALONE_KARAOKE_BASE_PATH}/`;
+  if (path.startsWith(trackPrefix)) {
+    const segment = path.slice(trackPrefix.length);
+    if (segment.length > 0 && !segment.includes("/")) {
+      initialData.videoId = decodeURIComponent(segment);
+    }
+  }
+
+  const searchParams =
+    typeof search === "string" && search.length > 0
+      ? new URLSearchParams(search.startsWith("?") ? search.slice(1) : search)
+      : null;
+
+  const listenSessionId = searchParams?.get("listen")?.trim();
+  if (listenSessionId) {
+    initialData.listenSessionId = listenSessionId;
+  }
+
+  return initialData;
+}
+
+/** Canonical path for linking to the standalone Karaoke experience. */
+export function standaloneKaraokePath(trackId?: string): string {
+  if (!trackId) return STANDALONE_KARAOKE_BASE_PATH;
+  return `${STANDALONE_KARAOKE_BASE_PATH}/${encodeURIComponent(trackId)}`;
+}

--- a/tests/test-api-standalone-spa-routing.test.ts
+++ b/tests/test-api-standalone-spa-routing.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from "bun:test";
+import { shouldServeSpaFallback } from "../scripts/spa-static-fallback";
+
+describe("standalone Bun server SPA fallback (non-Vercel)", () => {
+  test("serves index.html for standalone iPod app routes", () => {
+    expect(shouldServeSpaFallback("/standalone/ipod")).toBe(true);
+    expect(shouldServeSpaFallback("/standalone/ipod/")).toBe(true);
+    expect(shouldServeSpaFallback("/standalone/ipod/my-track-id")).toBe(true);
+    expect(shouldServeSpaFallback("/ipod")).toBe(true);
+    expect(shouldServeSpaFallback("/ipod/shared-song")).toBe(true);
+  });
+
+  test("does not SPA-fallback API or static asset paths", () => {
+    expect(shouldServeSpaFallback("/api/health")).toBe(false);
+    expect(shouldServeSpaFallback("/api")).toBe(false);
+    expect(shouldServeSpaFallback("/assets/index-DOUbUONm.js")).toBe(false);
+    expect(shouldServeSpaFallback("/favicon.ico")).toBe(false);
+  });
+});

--- a/tests/test-api-standalone-spa-routing.test.ts
+++ b/tests/test-api-standalone-spa-routing.test.ts
@@ -2,11 +2,15 @@ import { describe, expect, test } from "bun:test";
 import { shouldServeSpaFallback } from "../scripts/spa-static-fallback";
 
 describe("standalone Bun server SPA fallback (non-Vercel)", () => {
-  test("serves index.html for standalone iPod app routes", () => {
+  test("serves index.html for standalone media app routes", () => {
     expect(shouldServeSpaFallback("/standalone/ipod")).toBe(true);
     expect(shouldServeSpaFallback("/standalone/ipod/")).toBe(true);
     expect(shouldServeSpaFallback("/standalone/ipod/my-track-id")).toBe(true);
+    expect(shouldServeSpaFallback("/standalone/karaoke")).toBe(true);
+    expect(shouldServeSpaFallback("/standalone/karaoke/my-track-id")).toBe(true);
     expect(shouldServeSpaFallback("/ipod")).toBe(true);
+    expect(shouldServeSpaFallback("/karaoke")).toBe(true);
+    expect(shouldServeSpaFallback("/karaoke/shared-song")).toBe(true);
     expect(shouldServeSpaFallback("/ipod/shared-song")).toBe(true);
   });
 

--- a/tests/test-app-route-registry-standalone-ipod.test.ts
+++ b/tests/test-app-route-registry-standalone-ipod.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, test } from "bun:test";
+import { resolveInitialRoute } from "../src/apps/base/appRouteRegistry";
+
+describe("resolveInitialRoute standalone iPod", () => {
+  test("does not rewrite standalone iPod URLs to /", () => {
+    expect(resolveInitialRoute("/standalone/ipod")).toBeNull();
+    expect(resolveInitialRoute("/standalone/ipod/my-track")).toBeNull();
+    expect(resolveInitialRoute("/standalone/ipod/track", "?listen=abc")).toBeNull();
+  });
+});

--- a/tests/test-app-route-registry-standalone-karaoke.test.ts
+++ b/tests/test-app-route-registry-standalone-karaoke.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, test } from "bun:test";
+import { resolveInitialRoute } from "../src/apps/base/appRouteRegistry";
+
+describe("resolveInitialRoute standalone Karaoke", () => {
+  test("does not rewrite standalone Karaoke URLs to /", () => {
+    expect(resolveInitialRoute("/standalone/karaoke")).toBeNull();
+    expect(resolveInitialRoute("/standalone/karaoke/my-track")).toBeNull();
+    expect(resolveInitialRoute("/standalone/karaoke/track", "?listen=abc")).toBeNull();
+  });
+});

--- a/tests/test-og-share.test.ts
+++ b/tests/test-og-share.test.ts
@@ -107,6 +107,38 @@ describe("og share response", () => {
     expect(body).toContain("/standalone/ipod/track-1?_ryo=1");
   });
 
+
+  test("skips OG HTML for standalone Karaoke in normal browsers", async () => {
+    const response = await createOgShareResponse(
+      new Request("https://coolify.example.com/standalone/karaoke", {
+        headers: { "User-Agent": BROWSER_UA },
+      })
+    );
+
+    expect(response).toBeNull();
+  });
+
+  test("serves OG HTML for standalone Karaoke routes when requested by crawlers", async () => {
+    process.env.APP_PUBLIC_ORIGIN = "https://os.example.com";
+
+    const response = await createOgShareResponse(
+      new Request("https://os.example.com/standalone/karaoke/track-1", {
+        headers: { "User-Agent": CRAWLER_UA },
+      }),
+      {
+        getSong: async (songId) => {
+          expect(songId).toBe("track-1");
+          return { title: "Karaoke Song", artist: "Karaoke Artist", cover: "" };
+        },
+      }
+    );
+
+    expect(response).not.toBeNull();
+    const body = await response!.text();
+    expect(body).toContain("Sing Karaoke Song - Karaoke Artist on ryOS");
+    expect(body).toContain("/standalone/karaoke/track-1?_ryo=1");
+  });
+
   test("uses stored iPod song metadata and formatted Kugou cover for OG tags", async () => {
     process.env.APP_PUBLIC_ORIGIN = "https://os.example.com";
     const fetchMock = mock(() => {

--- a/tests/test-og-share.test.ts
+++ b/tests/test-og-share.test.ts
@@ -2,9 +2,14 @@ import { afterEach, describe, expect, mock, test } from "bun:test";
 import {
   createOgShareResponse,
   getSongShareMetadataFromRaw,
+  isSocialPreviewCrawler,
   resolveSongShareId,
 } from "../api/_utils/og-share";
 import { UpdateSongSchema } from "../api/songs/_constants";
+
+const CRAWLER_UA = "Mozilla/5.0 (compatible; Twitterbot/1.0)";
+const BROWSER_UA =
+  "Mozilla/5.0 (Linux; Android 14) AppleWebKit/537.36 Chrome/120.0.0.0 Mobile Safari/537.36";
 
 const ORIGINAL_ENV = { ...process.env };
 
@@ -21,29 +26,29 @@ afterEach(() => {
 });
 
 describe("og share response", () => {
-  test("keeps OG redirect on PR preview host when APP_PUBLIC_ORIGIN is canonical dev", async () => {
-    process.env.APP_PUBLIC_ORIGIN = "https://canonical.example.com"; // pragma: allowlist secret
+  test("isSocialPreviewCrawler detects link-preview bots", () => {
+    expect(isSocialPreviewCrawler(CRAWLER_UA)).toBe(true);
+    expect(isSocialPreviewCrawler(BROWSER_UA)).toBe(false);
+    expect(isSocialPreviewCrawler(null)).toBe(false);
+  });
 
+  test("skips OG HTML for normal browsers (SPA loads directly)", async () => {
     const response = await createOgShareResponse(
-      new Request("https://1331-preview.os.ryo.lu/standalone/ipod")
+      new Request("https://coolify.example.com/standalone/ipod", {
+        headers: { "User-Agent": BROWSER_UA },
+      })
     );
 
-    expect(response).not.toBeNull();
-    const body = await response!.text();
-    expect(body).toContain(
-      '<meta property="og:url" content="https://1331-preview.os.ryo.lu/standalone/ipod">'
-    );
-    expect(body).toContain(
-      'location.replace("https://1331-preview.os.ryo.lu/standalone/ipod?_ryo=1")'
-    );
-    expect(body).not.toContain("canonical.example.com/standalone/ipod");
+    expect(response).toBeNull();
   });
 
   test("uses configured public origin for Coolify/self-host share pages", async () => {
     process.env.APP_PUBLIC_ORIGIN = "https://coolify.example.com";
 
     const response = await createOgShareResponse(
-      new Request("http://127.0.0.1:4010/finder")
+      new Request("http://127.0.0.1:4010/finder", {
+        headers: { "User-Agent": CRAWLER_UA },
+      })
     );
 
     expect(response).not.toBeNull();
@@ -63,7 +68,9 @@ describe("og share response", () => {
 
   test("skips requests that already include the bypass query", async () => {
     const response = await createOgShareResponse(
-      new Request("https://coolify.example.com/finder?_ryo=1")
+      new Request("https://coolify.example.com/finder?_ryo=1", {
+        headers: { "User-Agent": CRAWLER_UA },
+      })
     );
 
     expect(response).toBeNull();
@@ -71,10 +78,33 @@ describe("og share response", () => {
 
   test("skips unrelated routes", async () => {
     const response = await createOgShareResponse(
-      new Request("https://coolify.example.com/api/health")
+      new Request("https://coolify.example.com/api/health", {
+        headers: { "User-Agent": CRAWLER_UA },
+      })
     );
 
     expect(response).toBeNull();
+  });
+
+  test("serves OG HTML for standalone iPod routes when requested by crawlers", async () => {
+    process.env.APP_PUBLIC_ORIGIN = "https://os.example.com";
+
+    const response = await createOgShareResponse(
+      new Request("https://os.example.com/standalone/ipod/track-1", {
+        headers: { "User-Agent": CRAWLER_UA },
+      }),
+      {
+        getSong: async (songId) => {
+          expect(songId).toBe("track-1");
+          return { title: "Test Song", artist: "Test Artist", cover: "" };
+        },
+      }
+    );
+
+    expect(response).not.toBeNull();
+    const body = await response!.text();
+    expect(body).toContain("Test Song - Test Artist");
+    expect(body).toContain("/standalone/ipod/track-1?_ryo=1");
   });
 
   test("uses stored iPod song metadata and formatted Kugou cover for OG tags", async () => {
@@ -87,7 +117,9 @@ describe("og share response", () => {
 
     try {
       const response = await createOgShareResponse(
-        new Request("https://os.example.com/ipod/abc123DEF45"),
+        new Request("https://os.example.com/ipod/abc123DEF45", {
+          headers: { "User-Agent": CRAWLER_UA },
+        }),
         {
           getSong: async (songId) => {
             expect(songId).toBe("abc123DEF45");
@@ -119,7 +151,9 @@ describe("og share response", () => {
     process.env.APP_PUBLIC_ORIGIN = "https://os.example.com";
 
     const response = await createOgShareResponse(
-      new Request("https://os.example.com/karaoke/am%3A1616228595"),
+      new Request("https://os.example.com/karaoke/am%3A1616228595", {
+        headers: { "User-Agent": CRAWLER_UA },
+      }),
       {
         getSong: async (songId) => {
           expect(songId).toBe("am:1616228595");
@@ -150,7 +184,9 @@ describe("og share response", () => {
     );
 
     const response = await createOgShareResponse(
-      new Request(`https://os.example.com/karaoke/${encodedUrl}`),
+      new Request(`https://os.example.com/karaoke/${encodedUrl}`, {
+        headers: { "User-Agent": CRAWLER_UA },
+      }),
       {
         getSong: async (songId) => {
           expect(songId).toBe("abc123DEF45");

--- a/tests/test-og-share.test.ts
+++ b/tests/test-og-share.test.ts
@@ -21,6 +21,24 @@ afterEach(() => {
 });
 
 describe("og share response", () => {
+  test("keeps OG redirect on PR preview host when APP_PUBLIC_ORIGIN is canonical dev", async () => {
+    process.env.APP_PUBLIC_ORIGIN = "https://canonical.example.com"; // pragma: allowlist secret
+
+    const response = await createOgShareResponse(
+      new Request("https://1331-preview.os.ryo.lu/standalone/ipod")
+    );
+
+    expect(response).not.toBeNull();
+    const body = await response!.text();
+    expect(body).toContain(
+      '<meta property="og:url" content="https://1331-preview.os.ryo.lu/standalone/ipod">'
+    );
+    expect(body).toContain(
+      'location.replace("https://1331-preview.os.ryo.lu/standalone/ipod?_ryo=1")'
+    );
+    expect(body).not.toContain("canonical.example.com/standalone/ipod");
+  });
+
   test("uses configured public origin for Coolify/self-host share pages", async () => {
     process.env.APP_PUBLIC_ORIGIN = "https://coolify.example.com";
 

--- a/tests/test-self-host-runtime-config.test.ts
+++ b/tests/test-self-host-runtime-config.test.ts
@@ -6,6 +6,7 @@ import {
   getRealtimeProvider,
   getRealtimeWebSocketPath,
   isAllowedAppHost,
+  shouldPreferRequestPublicOrigin,
 } from "../api/_utils/runtime-config";
 
 const ORIGINAL_ENV = { ...process.env };
@@ -55,5 +56,23 @@ describe("self-host runtime config", () => {
     expect(isAllowedAppHost("ryos.example.net")).toBe(true);
     expect(isAllowedAppHost("localhost:3000")).toBe(true);
     expect(isAllowedAppHost("evil.example.net")).toBe(false);
+  });
+
+  test("prefers request origin for os.ryo.lu preview deploys over APP_PUBLIC_ORIGIN", () => {
+    process.env.APP_PUBLIC_ORIGIN = "https://canonical.example.com"; // pragma: allowlist secret
+
+    expect(isAllowedAppHost("1331-preview.os.ryo.lu")).toBe(true);
+    expect(
+      shouldPreferRequestPublicOrigin("https://1331-preview.os.ryo.lu")
+    ).toBe(true);
+    expect(getAppPublicOrigin("https://1331-preview.os.ryo.lu")).toBe(
+      "https://1331-preview.os.ryo.lu"
+    );
+    expect(shouldPreferRequestPublicOrigin("http://127.0.0.1:4010")).toBe(
+      false
+    );
+    expect(getAppPublicOrigin("http://127.0.0.1:4010")).toBe(
+      "https://canonical.example.com"
+    );
   });
 });

--- a/tests/test-standalone-ipod-route.test.ts
+++ b/tests/test-standalone-ipod-route.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "bun:test";
+import {
+  STANDALONE_IPOD_BASE_PATH,
+  isStandaloneIpodPath,
+  parseStandaloneIpodRoute,
+} from "../src/utils/standaloneIpodRoute";
+import { standaloneIpodPath } from "../src/utils/standaloneIpodRoute";
+
+describe("standalone iPod route", () => {
+  test("isStandaloneIpodPath matches base and track paths", () => {
+    expect(isStandaloneIpodPath("/standalone/ipod")).toBe(true);
+    expect(isStandaloneIpodPath("/standalone/ipod/")).toBe(true);
+    expect(isStandaloneIpodPath("/standalone/ipod/abc123")).toBe(true);
+    expect(isStandaloneIpodPath("/ipod")).toBe(false);
+    expect(isStandaloneIpodPath("/ipod/track-id")).toBe(false);
+    expect(isStandaloneIpodPath("/")).toBe(false);
+  });
+
+  test("parseStandaloneIpodRoute extracts track and listen session", () => {
+    expect(parseStandaloneIpodRoute("/standalone/ipod")).toEqual({});
+    expect(parseStandaloneIpodRoute("/standalone/ipod/my-song-id")).toEqual({
+      videoId: "my-song-id",
+    });
+    expect(
+      parseStandaloneIpodRoute("/standalone/ipod/x", "?listen=session-42")
+    ).toEqual({
+      videoId: "x",
+      listenSessionId: "session-42",
+    });
+  });
+
+  test("standaloneIpodPath builds canonical URLs", () => {
+    expect(standaloneIpodPath()).toBe(STANDALONE_IPOD_BASE_PATH);
+    expect(standaloneIpodPath("a/b")).toBe("/standalone/ipod/a%2Fb");
+  });
+});

--- a/tests/test-standalone-karaoke-route.test.ts
+++ b/tests/test-standalone-karaoke-route.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "bun:test";
+import {
+  STANDALONE_KARAOKE_BASE_PATH,
+  isStandaloneKaraokePath,
+  parseStandaloneKaraokeRoute,
+  standaloneKaraokePath,
+} from "../src/utils/standaloneKaraokeRoute";
+
+describe("standalone Karaoke route", () => {
+  test("isStandaloneKaraokePath matches base and track paths", () => {
+    expect(isStandaloneKaraokePath("/standalone/karaoke")).toBe(true);
+    expect(isStandaloneKaraokePath("/standalone/karaoke/")).toBe(true);
+    expect(isStandaloneKaraokePath("/standalone/karaoke/abc123")).toBe(true);
+    expect(isStandaloneKaraokePath("/karaoke")).toBe(false);
+    expect(isStandaloneKaraokePath("/standalone/ipod")).toBe(false);
+    expect(isStandaloneKaraokePath("/")).toBe(false);
+  });
+
+  test("parseStandaloneKaraokeRoute extracts track and listen session", () => {
+    expect(parseStandaloneKaraokeRoute("/standalone/karaoke")).toEqual({});
+    expect(parseStandaloneKaraokeRoute("/standalone/karaoke/my-song-id")).toEqual({
+      videoId: "my-song-id",
+    });
+    expect(
+      parseStandaloneKaraokeRoute("/standalone/karaoke/x", "?listen=session-42")
+    ).toEqual({
+      videoId: "x",
+      listenSessionId: "session-42",
+    });
+  });
+
+  test("standaloneKaraokePath builds canonical URLs", () => {
+    expect(standaloneKaraokePath()).toBe(STANDALONE_KARAOKE_BASE_PATH);
+    expect(standaloneKaraokePath("a/b")).toBe("/standalone/karaoke/a%2Fb");
+  });
+});

--- a/vercel.json
+++ b/vercel.json
@@ -242,6 +242,8 @@
     { "source": "/ipod", "destination": "/" },
     { "source": "/standalone/ipod", "destination": "/" },
     { "source": "/standalone/ipod/:track", "destination": "/" },
+    { "source": "/standalone/karaoke", "destination": "/" },
+    { "source": "/standalone/karaoke/:track", "destination": "/" },
     { "source": "/karaoke", "destination": "/" },
     { "source": "/applet-viewer", "destination": "/" },
     { "source": "/synth", "destination": "/" },

--- a/vercel.json
+++ b/vercel.json
@@ -240,6 +240,8 @@
     { "source": "/videos", "destination": "/" },
     { "source": "/tv", "destination": "/" },
     { "source": "/ipod", "destination": "/" },
+    { "source": "/standalone/ipod", "destination": "/" },
+    { "source": "/standalone/ipod/:track", "destination": "/" },
     { "source": "/karaoke", "destination": "/" },
     { "source": "/applet-viewer", "destination": "/" },
     { "source": "/synth", "destination": "/" },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -295,6 +295,7 @@ export default defineConfig({
           /^\/videos(\/|$)/,
           /^\/tv$/,
           /^\/ipod(\/|$)/,
+          /^\/standalone\/ipod(\/|$)/,
           /^\/karaoke(\/|$)/,
           /^\/listen(\/|$)/,
           /^\/synth$/,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -296,6 +296,7 @@ export default defineConfig({
           /^\/tv$/,
           /^\/ipod(\/|$)/,
           /^\/standalone\/ipod(\/|$)/,
+          /^\/standalone\/karaoke(\/|$)/,
           /^\/karaoke(\/|$)/,
           /^\/listen(\/|$)/,
           /^\/synth$/,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a shell-free Karaoke experience at **`/standalone/karaoke`** (and `/standalone/karaoke/:trackId`), using the same routing fixes as standalone iPod.

## Standalone Karaoke

- **`src/utils/standaloneKaraokeRoute.ts`** — path detection, track/listen parsing, canonical URLs
- **`src/StandaloneKaraokeApp.tsx`** — launches Karaoke only (no AppManager / dock / menubar)
- **`src/main.tsx`** — `resolveRootComponent()` picks iPod, Karaoke, or full desktop
- **`KaraokeAppComponent`** — `standalone` prop: fullscreen black shell instead of `WindowFrame`
- **Share URLs** from standalone use `/standalone/karaoke/...` when `data-standalone-karaoke` is set

## Routing / deploy (shared with iPod fix)

- **`og-share`**: OG redirect HTML only for crawlers; browsers get SPA on first load
- **`appRouteRegistry`**: no URL cleanup to `/` for `/standalone/karaoke` or `/standalone/ipod`
- **Vercel rewrites**, **middleware matcher**, **Vite PWA denylist**, **SPA fallback** tests updated

## Verification

- `bun test` on standalone route/registry/og-share/spa suites
- `bun run build`

## Usage

- Standalone: `/standalone/karaoke`, `/standalone/karaoke/:trackId`, `?listen=` for live sessions
- In-OS Karaoke at `/karaoke` unchanged

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-97680453-41ca-489b-b742-4e59993bdeff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-97680453-41ca-489b-b742-4e59993bdeff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

