### PR TITLE
feat(ipod,karaoke): Cover Flow on fullscreen long-press

### DIFF
--- a/src/apps/ipod/components/CoverFlow.tsx
+++ b/src/apps/ipod/components/CoverFlow.tsx
@@ -2027,7 +2027,11 @@ export const CoverFlow = function CoverFlow(
           <motion.div
             className={cn(
               "absolute left-0 right-0 flex items-center justify-center gap-2",
-              isModernIpodCoverFlow ? "font-ipod-modern-ui" : "font-geneva-12",
+              isModernIpodCoverFlow
+                ? "font-ipod-modern-ui"
+                : ipodMode
+                  ? "font-geneva-12"
+                  : "font-os-ui",
               ipodMode ? "px-2" : "px-6"
             )}
             style={{

--- a/src/apps/ipod/components/FullScreenPortal.tsx
+++ b/src/apps/ipod/components/FullScreenPortal.tsx
@@ -1,4 +1,5 @@
-import { useState, useRef, useEffect, useCallback, useMemo } from "react";
+import { useState, useRef, useEffect, useCallback, useMemo, type ReactNode } from "react";
+import { usePointerLongPress } from "@/hooks/usePointerLongPress";
 import { motion, AnimatePresence } from "framer-motion";
 import { createPortal } from "react-dom";
 import { cn } from "@/lib/utils";
@@ -52,6 +53,9 @@ export function FullScreenPortal({
   karaokeKtvRoomFxEnabled,
   onToggleKaraokeKtvRoomFx,
   activityState,
+  onSurfaceLongPress,
+  surfaceLongPressEnabled = true,
+  suppressToolbar = false,
 }: FullScreenPortalProps) {
   const isAnyActivityActive = activityState
     ? activityState.isLoadingLyrics ||
@@ -181,6 +185,32 @@ export function FullScreenPortal({
     onCycleLyricsFont,
   ]);
 
+  const shouldIgnoreLongPressTarget = useCallback((target: EventTarget | null) => {
+    const el = target as HTMLElement | null;
+    if (!el?.closest) return false;
+    return Boolean(
+      el.closest("[data-toolbar]") ||
+        el.closest("[data-lyrics]") ||
+        el.closest("[data-cover-flow]") ||
+        el.closest("button") ||
+        el.closest("a") ||
+        el.closest("input") ||
+        el.closest("select") ||
+        el.closest("textarea")
+    );
+  }, []);
+
+  const surfaceLongPress = usePointerLongPress(
+    () => {
+      handlersRef.current.registerActivity();
+      onSurfaceLongPress?.();
+    },
+    {
+      enabled: Boolean(onSurfaceLongPress) && surfaceLongPressEnabled,
+      shouldIgnoreTarget: shouldIgnoreLongPressTarget,
+    }
+  );
+
   // Touch handling for swipe gestures
   const touchStartRef = useRef<{ x: number; y: number; time: number } | null>(
     null
@@ -191,7 +221,7 @@ export function FullScreenPortal({
     (e: TouchEvent) => {
       // Don't handle touches on toolbar or lyrics elements
       const target = e.target as HTMLElement;
-      if (target.closest("[data-toolbar]") || target.closest("[data-lyrics]")) {
+      if (shouldIgnoreLongPressTarget(target)) {
         return;
       }
 
@@ -207,7 +237,7 @@ export function FullScreenPortal({
         time: Date.now(),
       };
     },
-    [hasUserInteracted]
+    [hasUserInteracted, shouldIgnoreLongPressTarget]
   );
 
   const handleTouchEnd = useCallback(
@@ -216,7 +246,7 @@ export function FullScreenPortal({
 
       // Don't handle touches on toolbar or lyrics elements
       const target = e.target as HTMLElement;
-      if (target.closest("[data-toolbar]") || target.closest("[data-lyrics]")) {
+      if (shouldIgnoreLongPressTarget(target)) {
         touchStartRef.current = null;
         return;
       }
@@ -248,7 +278,7 @@ export function FullScreenPortal({
 
       touchStartRef.current = null;
     },
-    []
+    [shouldIgnoreLongPressTarget]
   );
 
   // Effect to request fullscreen when component mounts
@@ -402,11 +432,10 @@ export function FullScreenPortal({
       className="ipod-force-font fixed inset-0 z-[9999] bg-black select-none flex flex-col"
       onClick={(e) => {
         const target = e.target as HTMLElement;
-        if (target.closest("[data-toolbar]")) {
+        if (shouldIgnoreLongPressTarget(target)) {
           return;
         }
-        // Don't handle clicks on lyrics (let them handle their own click events for seeking)
-        if (target.closest("[data-lyrics]")) {
+        if (surfaceLongPress.consumeClickIfLongPressFired()) {
           return;
         }
 
@@ -500,17 +529,35 @@ export function FullScreenPortal({
         />
       )}
 
-      <div className="flex-1 min-h-0">
+      <div
+        className="flex-1 min-h-0"
+        {...(onSurfaceLongPress
+          ? {
+              onMouseDown: surfaceLongPress.onMouseDown,
+              onMouseMove: surfaceLongPress.onMouseMove,
+              onMouseUp: surfaceLongPress.onMouseUp,
+              onMouseLeave: surfaceLongPress.onMouseLeave,
+              onTouchStart: surfaceLongPress.onTouchStart,
+              onTouchMove: surfaceLongPress.onTouchMove,
+              onTouchEnd: surfaceLongPress.onTouchEnd,
+              onTouchCancel: surfaceLongPress.onTouchCancel,
+            }
+          : {})}
+      >
         {typeof children === "function"
           ? (
               children as (ctx: {
                 controlsVisible: boolean;
                 isLangMenuOpen: boolean;
-              }) => React.ReactNode
+                consumeSurfaceLongPressClick?: () => boolean;
+              }) => ReactNode
             )({
                 controlsVisible:
                   showControls || anyMenuOpen || !getActualPlayerState(),
                 isLangMenuOpen,
+                consumeSurfaceLongPressClick: onSurfaceLongPress
+                  ? surfaceLongPress.consumeClickIfLongPressFired
+                  : undefined,
             })
           : children}
       </div>
@@ -520,7 +567,8 @@ export function FullScreenPortal({
         data-toolbar
         className={cn(
           "fixed bottom-0 left-0 right-0 flex justify-center z-[10001] transition-opacity duration-200",
-          showControls || anyMenuOpen || !getActualPlayerState()
+          !suppressToolbar &&
+          (showControls || anyMenuOpen || !getActualPlayerState())
             ? "opacity-100 pointer-events-auto"
             : "opacity-0 pointer-events-none"
         )}

--- a/src/apps/ipod/components/IpodAppComponent.tsx
+++ b/src/apps/ipod/components/IpodAppComponent.tsx
@@ -313,6 +313,20 @@ export function IpodAppComponent({
   const shouldRenderFullScreenAnimatedVisuals =
     shouldAnimateFullScreenVisuals && effectiveDisplayMode !== DisplayMode.Video;
 
+  const handleFullscreenSurfaceLongPress = useCallback(() => {
+    if (coverFlowTracks.length === 0) return;
+    playClickSound();
+    vibrate();
+    registerActivity();
+    setIsCoverFlowOpen((open) => !open);
+  }, [
+    coverFlowTracks.length,
+    playClickSound,
+    vibrate,
+    registerActivity,
+    setIsCoverFlowOpen,
+  ]);
+
   if (!isWindowOpen) return null;
 
   return (
@@ -701,8 +715,11 @@ export function IpodAppComponent({
             }
             fullScreenPlayerRef={fullScreenPlayerRef}
             activityState={activityState}
+            onSurfaceLongPress={handleFullscreenSurfaceLongPress}
+            surfaceLongPressEnabled={coverFlowTracks.length > 0}
+            suppressToolbar={isCoverFlowOpen}
           >
-            {({ controlsVisible }) => (
+            {({ controlsVisible, consumeSurfaceLongPressClick }) => (
               <div className="flex flex-col w-full h-full">
                 <div className="relative w-full h-full overflow-hidden">
                   <div
@@ -848,6 +865,7 @@ export function IpodAppComponent({
                         exit={{ opacity: 0 }}
                         transition={{ duration: 0.3 }}
                         onClick={(e) => {
+                          if (consumeSurfaceLongPressClick?.()) return;
                           e.stopPropagation();
                           togglePlay();
                         }}
@@ -934,6 +952,34 @@ export function IpodAppComponent({
                         onSeekToTime={seekToTime}
                         coverUrl={fullscreenCoverUrl}
                       />
+                    </div>
+                  )}
+
+                  {coverFlowTracks.length > 0 && (
+                    <div
+                      data-cover-flow
+                      className={`absolute inset-0 z-[45] ${
+                        isCoverFlowOpen
+                          ? "pointer-events-auto"
+                          : "pointer-events-none"
+                      }`}
+                    >
+                      <Suspense fallback={null}>
+                        <CoverFlow
+                          ref={coverFlowRef}
+                          tracks={coverFlowTracks}
+                          currentIndex={coverFlowCurrentIndex}
+                          onSelectTrack={handleCoverFlowSelect}
+                          onExit={handleCoverFlowExit}
+                          onRotation={handleCoverFlowRotation}
+                          isVisible={isCoverFlowOpen}
+                          isPlaying={isPlaying}
+                          onTogglePlay={togglePlay}
+                          onPlayTrackInPlace={handleCoverFlowPlayInPlace}
+                          groupAppleMusicAlbums={isAppleMusic}
+                          ipodMode
+                        />
+                      </Suspense>
                     </div>
                   )}
                 </div>

--- a/src/apps/ipod/components/IpodAppComponent.tsx
+++ b/src/apps/ipod/components/IpodAppComponent.tsx
@@ -977,7 +977,7 @@ export function IpodAppComponent({
                           onTogglePlay={togglePlay}
                           onPlayTrackInPlace={handleCoverFlowPlayInPlace}
                           groupAppleMusicAlbums={isAppleMusic}
-                          ipodMode
+                          ipodMode={false}
                         />
                       </Suspense>
                     </div>

--- a/src/apps/ipod/types.ts
+++ b/src/apps/ipod/types.ts
@@ -101,6 +101,8 @@ export interface FullScreenPortalProps {
     | ((ctx: {
         controlsVisible: boolean;
         isLangMenuOpen: boolean;
+        /** Skip surface clicks (e.g. album art tap) right after a long-press. */
+        consumeSurfaceLongPressClick?: () => boolean;
       }) => React.ReactNode);
   onClose: () => void;
   togglePlay: () => void;
@@ -138,6 +140,15 @@ export interface FullScreenPortalProps {
   fullScreenPlayerRef: React.RefObject<ReactPlayer | null>;
   /** Activity state for loading indicators (optional — karaoke supplies from lyrics subtree) */
   activityState?: ActivityInfo;
+  /**
+   * Long-press on the main fullscreen surface (album art / background).
+   * Ignored on toolbar and lyrics. Scoped to fullscreen portal only.
+   */
+  onSurfaceLongPress?: () => void;
+  /** When false, surface long-press is disabled (e.g. no library tracks). */
+  surfaceLongPressEnabled?: boolean;
+  /** Hide bottom player toolbar (e.g. while Cover Flow is open). */
+  suppressToolbar?: boolean;
 }
 
 // IpodScreen props

--- a/src/apps/karaoke/components/KaraokeAppComponent.tsx
+++ b/src/apps/karaoke/components/KaraokeAppComponent.tsx
@@ -911,8 +911,11 @@ export function KaraokeAppComponent({
             />
           }
           fullScreenPlayerRef={fullScreenPlayerRef}
+          onSurfaceLongPress={handleToggleCoverFlow}
+          surfaceLongPressEnabled={tracks.length > 0}
+          suppressToolbar={isCoverFlowOpen}
         >
-          {({ controlsVisible }) => (
+          {({ controlsVisible, consumeSurfaceLongPressClick }) => (
             <div className="flex flex-col w-full h-full">
               <div className="relative w-full h-full overflow-hidden">
                 <div
@@ -1027,6 +1030,7 @@ export function KaraokeAppComponent({
                       exit={{ opacity: 0 }}
                       transition={{ duration: 0.3 }}
                       onClick={(e) => {
+                        if (consumeSurfaceLongPressClick?.()) return;
                         e.stopPropagation();
                         registerActivity();
                       }}
@@ -1089,6 +1093,31 @@ export function KaraokeAppComponent({
                   onSwipeUp={handleFullscreenLyricsSwipeUp}
                   onSwipeDown={handleFullscreenLyricsSwipeDown}
                 />
+
+                {tracks.length > 0 && (
+                  <div
+                    data-cover-flow
+                    className={`absolute inset-0 z-[45] ${
+                      isCoverFlowOpen
+                        ? "pointer-events-auto"
+                        : "pointer-events-none"
+                    }`}
+                  >
+                    <CoverFlow
+                      ref={coverFlowRef}
+                      tracks={tracks}
+                      currentIndex={currentIndex}
+                      onSelectTrack={handleCoverFlowSelectTrack}
+                      onExit={() => setIsCoverFlowOpen(false)}
+                      onRotation={handleCoverFlowRotation}
+                      isVisible={isCoverFlowOpen}
+                      ipodMode={false}
+                      isPlaying={isPlaying}
+                      onTogglePlay={handlePlayPause}
+                      onPlayTrackInPlace={handleCoverFlowPlayInPlace}
+                    />
+                  </div>
+                )}
               </div>
             </div>
           )}

--- a/src/hooks/usePointerLongPress.ts
+++ b/src/hooks/usePointerLongPress.ts
@@ -1,0 +1,154 @@
+import { useCallback, useRef } from "react";
+
+const DEFAULT_DELAY_MS = 500;
+const DEFAULT_MOVE_THRESHOLD_PX = 10;
+
+export type PointerLongPressBindings = {
+  onMouseDown: (e: React.MouseEvent) => void;
+  onMouseMove: (e: React.MouseEvent) => void;
+  onMouseUp: () => void;
+  onMouseLeave: () => void;
+  onTouchStart: (e: React.TouchEvent) => void;
+  onTouchMove: (e: React.TouchEvent) => void;
+  onTouchEnd: () => void;
+  onTouchCancel: () => void;
+  /** Returns true once after a long press so click handlers can skip. */
+  consumeClickIfLongPressFired: () => boolean;
+};
+
+/**
+ * Long-press for mouse and touch with movement cancellation.
+ * Use `consumeClickIfLongPressFired` in click handlers to avoid accidental taps.
+ */
+export function usePointerLongPress(
+  onLongPress: () => void,
+  {
+    delay = DEFAULT_DELAY_MS,
+    moveThreshold = DEFAULT_MOVE_THRESHOLD_PX,
+    enabled = true,
+    shouldIgnoreTarget,
+  }: {
+    delay?: number;
+    moveThreshold?: number;
+    enabled?: boolean;
+    shouldIgnoreTarget?: (target: EventTarget | null) => boolean;
+  } = {}
+): PointerLongPressBindings {
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const firedRef = useRef(false);
+  const startPosRef = useRef<{ x: number; y: number } | null>(null);
+
+  const clearTimer = useCallback(() => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+  }, []);
+
+  const cancel = useCallback(() => {
+    clearTimer();
+    startPosRef.current = null;
+  }, [clearTimer]);
+
+  const isIgnored = useCallback(
+    (target: EventTarget | null) => !enabled || shouldIgnoreTarget?.(target),
+    [enabled, shouldIgnoreTarget]
+  );
+
+  const start = useCallback(
+    (x: number, y: number, target: EventTarget | null) => {
+      if (isIgnored(target)) return;
+      clearTimer();
+      firedRef.current = false;
+      startPosRef.current = { x, y };
+      timerRef.current = setTimeout(() => {
+        firedRef.current = true;
+        onLongPress();
+      }, delay);
+    },
+    [clearTimer, delay, isIgnored, onLongPress]
+  );
+
+  const checkMoveCancel = useCallback(
+    (x: number, y: number) => {
+      if (!startPosRef.current || !timerRef.current) return;
+      const dx = x - startPosRef.current.x;
+      const dy = y - startPosRef.current.y;
+      if (
+        Math.abs(dx) > moveThreshold ||
+        Math.abs(dy) > moveThreshold
+      ) {
+        cancel();
+      }
+    },
+    [cancel, moveThreshold]
+  );
+
+  const onMouseDown = useCallback(
+    (e: React.MouseEvent) => {
+      if (isIgnored(e.target)) return;
+      start(e.clientX, e.clientY, e.target);
+    },
+    [isIgnored, start]
+  );
+
+  const onMouseMove = useCallback(
+    (e: React.MouseEvent) => {
+      checkMoveCancel(e.clientX, e.clientY);
+    },
+    [checkMoveCancel]
+  );
+
+  const onMouseUp = useCallback(() => {
+    cancel();
+  }, [cancel]);
+
+  const onMouseLeave = useCallback(() => {
+    cancel();
+  }, [cancel]);
+
+  const onTouchStart = useCallback(
+    (e: React.TouchEvent) => {
+      if (isIgnored(e.target)) return;
+      const touch = e.touches[0];
+      if (!touch) return;
+      start(touch.clientX, touch.clientY, e.target);
+    },
+    [isIgnored, start]
+  );
+
+  const onTouchMove = useCallback(
+    (e: React.TouchEvent) => {
+      const touch = e.touches[0];
+      if (!touch) return;
+      checkMoveCancel(touch.clientX, touch.clientY);
+    },
+    [checkMoveCancel]
+  );
+
+  const onTouchEnd = useCallback(() => {
+    cancel();
+  }, [cancel]);
+
+  const onTouchCancel = useCallback(() => {
+    cancel();
+  }, [cancel]);
+
+  const consumeClickIfLongPressFired = useCallback(() => {
+    if (!firedRef.current) return false;
+    firedRef.current = false;
+    return true;
+  }, []);
+
+  return {
+    onMouseDown,
+    onMouseMove,
+    onMouseUp,
+    onMouseLeave,
+    onTouchStart,
+    onTouchMove,
+    onTouchEnd,
+    onTouchCancel,
+    consumeClickIfLongPressFired,
+  };
+}

--- a/src/styles/themes.css
+++ b/src/styles/themes.css
@@ -1782,6 +1782,17 @@
   font-size: 12px !important;
 }
 
+/* iPod fullscreen Cover Flow uses karaoke-force-font (black stage, no
+   device titlebar). Theme-aware UI text must follow macOS Lucida, not
+   the device-scoped Geneva override above. */
+:root[data-os-theme="macosx"] .ipod-force-font .karaoke-force-font,
+:root[data-os-theme="macosx"] .ipod-force-font .karaoke-force-font .font-os-ui,
+:root[data-os-theme="macosx"] .ipod-force-font .karaoke-force-font .font-geneva-12 {
+  font-family: var(--os-font-ui) !important;
+  -webkit-font-smoothing: antialiased !important;
+  font-smooth: auto !important;
+}
+
 :root[data-os-theme="macosx"] .synth-force-font .font-geneva-12 {
   font-family: "LucidaGrande", "Lucida Grande", "AquaKana", "Hiragino Sans",
     "Hiragino Sans GB", "Heiti SC", ui-sans-serif, system-ui, -apple-system,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Long-pressing the main fullscreen surface (album art / background) in iPod and Karaoke opens Cover Flow. iPod fullscreen Cover Flow now matches Karaoke presentation (black stage, no modern titlebar).

## Changes

- **`usePointerLongPress`**: shared mouse + touch long-press with movement cancellation and click suppression after fire.
- **`FullScreenPortal`**: optional `onSurfaceLongPress`, ignores toolbar/lyrics/Cover Flow/controls, passes `consumeSurfaceLongPressClick` to children, `suppressToolbar` while Cover Flow is open.
- **iPod / Karaoke fullscreen**: Cover Flow overlay + long-press toggle.
- **iPod fullscreen styling**: `ipodMode={false}` so Cover Flow uses the Karaoke black full-bleed layout (no modern white skin / titlebar).
- **macOS theme fonts**: Cover Flow track info uses `font-os-ui` when not in device mode; nested `.karaoke-force-font` under `.ipod-force-font` maps to Lucida Grande instead of Geneva.

## Testing

- `bun run build` — pass
- `bun run test:unit` — pass (prior run)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9af8beee-4edc-4ba4-b92c-b8c20a56a0e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9af8beee-4edc-4ba4-b92c-b8c20a56a0e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

