### PR TITLE
fix(ipod,karaoke): unify fullscreen Cover Flow styling across OS themes

### DIFF
--- a/src/apps/ipod/components/CoverFlow.tsx
+++ b/src/apps/ipod/components/CoverFlow.tsx
@@ -17,8 +17,22 @@ import {
 import type { Track } from "@/stores/useIpodStore";
 import { useIpodStore } from "@/stores/useIpodStore";
 import { Play, Pause, VinylRecord } from "@phosphor-icons/react";
-import { useThemeFlags } from "@/hooks/useThemeFlags";
 import { useEventListener } from "@/hooks/useEventListener";
+import {
+  COVERFLOW_MODERN_FLOOR_GRADIENT,
+  COVERFLOW_SHARED_CONTROL_BUTTON_ACTIVE_STYLE,
+  COVERFLOW_SHARED_CONTROL_BUTTON_CLASS,
+  COVERFLOW_SHARED_CONTROL_BUTTON_STYLE,
+  COVERFLOW_SHARED_FLOOR_GRADIENT,
+  COVERFLOW_SHARED_STAGE_ARTIST_CLASS,
+  COVERFLOW_SHARED_STAGE_CLASS,
+  COVERFLOW_SHARED_STAGE_TITLE_CLASS,
+  coverFlowArtistTextClass,
+  coverFlowLabelFontClass,
+  coverFlowSharedStageRootClass,
+  coverFlowTitleTextClass,
+  isCoverFlowSharedStage,
+} from "../coverflowStage";
 import { useTranslation } from "react-i18next";
 import { cn } from "@/lib/utils";
 import {
@@ -102,20 +116,6 @@ function formatTrackDuration(durationMs?: number): string {
   const minutes = Math.floor(totalSeconds / 60);
   const seconds = totalSeconds % 60;
   return `${minutes}:${String(seconds).padStart(2, "0")}`;
-}
-
-// Aqua-style shine overlay for macOS X theme buttons
-function AquaShineOverlay() {
-  return (
-    <div
-      className="pointer-events-none absolute top-[3px] blur-[0.5px] left-1/2 -translate-x-1/2 rounded-full"
-      style={{
-        width: "40%",
-        height: "35%",
-        background: "linear-gradient(to bottom, rgba(255, 255, 255, 0.3), rgba(255, 255, 255, 0))",
-      }}
-    />
-  );
 }
 
 // Spinning CD component using Framer Motion exclusively
@@ -764,7 +764,11 @@ function AlbumTracklist({
       className={cn(
         "absolute inset-0 flex flex-col",
         isModern ? "bg-white" : "bg-black",
-        ipodMode ? "ipod-force-font" : "karaoke-force-font"
+        isModern
+          ? ipodMode
+            ? "ipod-force-font"
+            : "karaoke-force-font"
+          : cn(COVERFLOW_SHARED_STAGE_CLASS, "karaoke-force-font")
       )}
     >
       {/* Album header — muted blue gradient on modern, deep blue on
@@ -785,11 +789,7 @@ function AlbumTracklist({
           // uses Geneva-12 (the 1st-gen iPod's own UI bitmap font);
           // karaoke uses the theme-aware OS sans-serif so it blends
           // with whichever desktop theme is active.
-          isModern
-            ? "font-ipod-modern-ui"
-            : ipodMode
-              ? "font-geneva-12"
-              : "font-os-ui"
+          isModern ? "font-ipod-modern-ui" : "font-os-ui"
         )}
         style={{
           minHeight: isModern ? 26 : 22,
@@ -871,11 +871,7 @@ function AlbumTracklist({
                 // Same font policy as the header: modern → iPod-
                 // modern UI font; classic iPod → Geneva-12 bitmap;
                 // karaoke → theme-aware OS sans.
-                isModern
-                  ? "font-ipod-modern-ui"
-                  : ipodMode
-                    ? "font-geneva-12"
-                    : "font-os-ui",
+                isModern ? "font-ipod-modern-ui" : "font-os-ui",
                 isSelected
                   ? isModern
                     ? "ipod-modern-row-selected"
@@ -1247,9 +1243,17 @@ export const CoverFlow = function CoverFlow(
     []
   );
   const containerRef = useRef<HTMLDivElement>(null);
-  const { isMacOSTheme: isMacTheme } = useThemeFlags();
   const uiVariant = useIpodStore((s) => s.uiVariant);
   const isModernIpodCoverFlow = ipodMode && uiVariant === "modern";
+  const sharedStage = isCoverFlowSharedStage(isModernIpodCoverFlow);
+  const stageRootClass = coverFlowSharedStageRootClass(
+    ipodMode,
+    isModernIpodCoverFlow
+  );
+  const labelFontClass = coverFlowLabelFontClass(isModernIpodCoverFlow);
+  const floorGradient = isModernIpodCoverFlow
+    ? COVERFLOW_MODERN_FLOOR_GRADIENT
+    : COVERFLOW_SHARED_FLOOR_GRADIENT;
 
   // Track swipe state
   const swipeStartX = useRef<number | null>(null);
@@ -1625,7 +1629,7 @@ export const CoverFlow = function CoverFlow(
         className={cn(
           "relative w-full h-full overflow-hidden",
           isModernIpodCoverFlow ? "bg-white" : "bg-black",
-          ipodMode ? "ipod-force-font" : "karaoke-force-font",
+          stageRootClass,
         )}
         style={{ containerType: "size" }}
       >
@@ -1633,9 +1637,7 @@ export const CoverFlow = function CoverFlow(
         <div
           className="absolute inset-0"
           style={{
-            background: isModernIpodCoverFlow
-              ? "linear-gradient(to bottom, transparent 55%, rgba(0,0,0,0.06) 78%, rgba(0,0,0,0.12) 100%)"
-              : "linear-gradient(to bottom, transparent 40%, rgba(38,38,38,0.5) 70%, rgba(64,64,64,0.3) 100%)",
+            background: floorGradient,
             pointerEvents: "none",
           }}
         />
@@ -1734,7 +1736,7 @@ export const CoverFlow = function CoverFlow(
         <div
           className={cn(
             "absolute left-0 right-0 flex items-center justify-center gap-2 pointer-events-none",
-            isModernIpodCoverFlow ? "font-ipod-modern-ui" : "font-geneva-12",
+            labelFontClass,
             ipodMode ? "px-2" : "px-6",
           )}
           style={{
@@ -1755,25 +1757,18 @@ export const CoverFlow = function CoverFlow(
             )}
           >
             <div
-              className={cn(
-                "truncate",
-                isModernIpodCoverFlow
-                  ? "text-black text-[12px] font-semibold tracking-tight"
-                  : "text-white",
-                ipodMode && !isModernIpodCoverFlow && "text-[10px]",
+              className={coverFlowTitleTextClass(
+                isModernIpodCoverFlow,
+                ipodMode
               )}
             >
               {currentItem?.title || t("apps.ipod.coverFlow.noTrack")}
             </div>
             {currentItem?.artist && (
               <div
-                className={cn(
-                  "truncate",
-                  isModernIpodCoverFlow &&
-                    "text-[10px] text-[rgb(99,101,103)] tracking-tight",
-                  ipodMode &&
-                    !isModernIpodCoverFlow &&
-                    "text-white/60 text-[8px]",
+                className={coverFlowArtistTextClass(
+                  isModernIpodCoverFlow,
+                  ipodMode
                 )}
               >
                 {currentItem.artist}
@@ -1849,15 +1844,12 @@ export const CoverFlow = function CoverFlow(
             // skin (Music + Now Playing, settings menus). Classic /
             // karaoke variants keep the original deep-black backdrop.
             isModernIpodCoverFlow ? "bg-white" : "bg-black",
-            // Retain the iPod screen's black bezel + rounded corners
-            // when Cover Flow is open. The overlay is rendered as a
-            // sibling of `IpodScreen` (not a child), so without its
-            // own border it would obscure the bezel and the carousel
-            // would read as a different frame than every other view.
-            // Karaoke Cover Flow opens full-bleed inside its own
-            // window chrome and skips the bezel.
-            ipodMode && "border border-black border-2 rounded-[2px]",
-            ipodMode ? "ipod-force-font" : "karaoke-force-font",
+            // Classic / shared stage matches Karaoke full-bleed Cover
+            // Flow. Only the modern inline panel keeps the device bezel.
+            !sharedStage &&
+              ipodMode &&
+              "border border-black border-2 rounded-[2px]",
+            stageRootClass,
           )}
           style={{ containerType: "size" }}
           initial={{ opacity: 0, scale: ipodMode ? 1 : 1.05 }}
@@ -1872,9 +1864,7 @@ export const CoverFlow = function CoverFlow(
           <div
             className="absolute inset-0"
             style={{
-              background: isModernIpodCoverFlow
-                ? "linear-gradient(to bottom, transparent 55%, rgba(0,0,0,0.06) 78%, rgba(0,0,0,0.12) 100%)"
-                : "linear-gradient(to bottom, transparent 40%, rgba(38,38,38,0.5) 70%, rgba(64,64,64,0.3) 100%)",
+              background: floorGradient,
               pointerEvents: "none",
             }}
           />
@@ -2027,7 +2017,7 @@ export const CoverFlow = function CoverFlow(
           <motion.div
             className={cn(
               "absolute left-0 right-0 flex items-center justify-center gap-2",
-              isModernIpodCoverFlow ? "font-ipod-modern-ui" : "font-geneva-12",
+              labelFontClass,
               ipodMode ? "px-2" : "px-6"
             )}
             style={{
@@ -2055,20 +2045,10 @@ export const CoverFlow = function CoverFlow(
                     onTogglePlay?.();
                   }
                 }}
-                className="relative flex-shrink-0 rounded-full transition-all text-white/80 hover:text-white hover:brightness-110 p-3"
-                style={{
-                  width: "clamp(40px, 8cqmin, 48px)",
-                  height: "clamp(40px, 8cqmin, 48px)",
-                  ...(isMacTheme ? {
-                    background: "linear-gradient(to bottom, rgba(60, 60, 60, 0.6), rgba(30, 30, 30, 0.5))",
-                    boxShadow: "0 2px 4px rgba(0, 0, 0, 0.2), inset 0 0 0 0.5px rgba(255, 255, 255, 0.1), inset 0 1px 0 rgba(255, 255, 255, 0.15)",
-                  } : {
-                    background: "rgba(255, 255, 255, 0.08)",
-                  }),
-                }}
+                className={COVERFLOW_SHARED_CONTROL_BUTTON_CLASS}
+                style={COVERFLOW_SHARED_CONTROL_BUTTON_STYLE}
                 title={isPlaying && selectedIndex === currentCoverIndex ? t("apps.ipod.menu.pause") : t("apps.ipod.menu.play")}
               >
-                {isMacTheme && <AquaShineOverlay />}
                 {isPlaying && selectedIndex === currentCoverIndex ? (
                   <Pause className="w-full h-full relative z-10" weight="fill" />
                 ) : (
@@ -2094,36 +2074,18 @@ export const CoverFlow = function CoverFlow(
             >
               <div
                 className={cn(
-                  "truncate",
-                  isModernIpodCoverFlow
-                    ? "text-black text-[12px] font-semibold tracking-tight"
-                    : "text-white",
-                  ipodMode && !isModernIpodCoverFlow && "text-[10px]",
+                  coverFlowTitleTextClass(isModernIpodCoverFlow, ipodMode),
+                  !ipodMode && COVERFLOW_SHARED_STAGE_TITLE_CLASS
                 )}
-                style={ipodMode ? undefined : { fontSize: "clamp(14px, 5cqmin, 24px)" }}
               >
                 {currentItem?.title || t("apps.ipod.coverFlow.noTrack")}
               </div>
               {currentItem?.artist && (
                 <div
                   className={cn(
-                    "truncate",
-                    isModernIpodCoverFlow
-                      ? "text-[10px] text-[rgb(99,101,103)] tracking-tight"
-                      : // Classic iPod and karaoke share the same
-                        // light-on-black treatment — the parent
-                        // backdrop is `bg-black` and the title above
-                        // is already `text-white`, so the artist
-                        // sits one rung down at 60% white. Without
-                        // this, karaoke artist text inherited the
-                        // default near-black colour and disappeared
-                        // against the black Cover Flow stage.
-                        "text-white/60",
-                    ipodMode && !isModernIpodCoverFlow && "text-[8px]",
+                    coverFlowArtistTextClass(isModernIpodCoverFlow, ipodMode),
+                    !ipodMode && COVERFLOW_SHARED_STAGE_ARTIST_CLASS
                   )}
-                  style={
-                    ipodMode ? undefined : { fontSize: "clamp(12px, 4cqmin, 18px)" }
-                  }
                 >
                   {currentItem.artist}
                 </div>
@@ -2137,24 +2099,17 @@ export const CoverFlow = function CoverFlow(
                   e.stopPropagation();
                   setShowCD(!showCD);
                 }}
-                className={`relative flex-shrink-0 rounded-full transition-all hover:brightness-110 p-3 ${
+                className={cn(
+                  COVERFLOW_SHARED_CONTROL_BUTTON_CLASS,
                   showCD ? "text-white" : "text-white/80 hover:text-white"
-                }`}
-                style={{
-                  width: "clamp(40px, 8cqmin, 48px)",
-                  height: "clamp(40px, 8cqmin, 48px)",
-                  ...(isMacTheme ? {
-                    background: showCD 
-                      ? "linear-gradient(to bottom, rgba(80, 80, 80, 0.7), rgba(50, 50, 50, 0.6))"
-                      : "linear-gradient(to bottom, rgba(60, 60, 60, 0.6), rgba(30, 30, 30, 0.5))",
-                    boxShadow: "0 2px 4px rgba(0, 0, 0, 0.2), inset 0 0 0 0.5px rgba(255, 255, 255, 0.1), inset 0 1px 0 rgba(255, 255, 255, 0.15)",
-                  } : {
-                    background: showCD ? "rgba(255, 255, 255, 0.15)" : "rgba(255, 255, 255, 0.08)",
-                  }),
-                }}
+                )}
+                style={
+                  showCD
+                    ? COVERFLOW_SHARED_CONTROL_BUTTON_ACTIVE_STYLE
+                    : COVERFLOW_SHARED_CONTROL_BUTTON_STYLE
+                }
                 title={showCD ? t("apps.ipod.coverFlow.hideMedia") : t("apps.ipod.coverFlow.showMedia")}
               >
-                {isMacTheme && <AquaShineOverlay />}
                 <VinylRecord className="w-full h-full relative z-10" weight="fill" />
               </button>
             )}

--- a/src/apps/ipod/components/IpodAppComponent.tsx
+++ b/src/apps/ipod/components/IpodAppComponent.tsx
@@ -540,7 +540,7 @@ export function IpodAppComponent({
                *  the standalone overlay there to avoid double-mounting
                *  the carousel and to let the menu panel's width
                *  transition own the entry/exit animation. */}
-              {!isModernIpodUi && isCoverFlowOpen && (
+              {!isModernIpodUi && isCoverFlowOpen && !isFullScreen && (
                 <Suspense fallback={null}>
                   <CoverFlow
                     ref={coverFlowRef}
@@ -868,6 +868,35 @@ export function IpodAppComponent({
                   {/* Lyrics overlays - positioned relative to viewport, not video container */}
                   {showLyrics && tracks[currentIndex] && (
                     <div className="fixed inset-0 bg-black/50 z-10 pointer-events-none" />
+                  )}
+
+                  {/* Cover Flow — same shared stage as Karaoke (below toolbar) */}
+                  {coverFlowTracks.length > 0 && (
+                    <div
+                      className={cn(
+                        "absolute inset-0 z-[45]",
+                        isCoverFlowOpen
+                          ? "pointer-events-auto"
+                          : "pointer-events-none"
+                      )}
+                    >
+                      <Suspense fallback={null}>
+                        <CoverFlow
+                          ref={coverFlowRef}
+                          tracks={coverFlowTracks}
+                          currentIndex={coverFlowCurrentIndex}
+                          onSelectTrack={handleCoverFlowSelect}
+                          onExit={handleCoverFlowExit}
+                          onRotation={handleCoverFlowRotation}
+                          isVisible={isCoverFlowOpen}
+                          ipodMode={false}
+                          isPlaying={isPlaying}
+                          onTogglePlay={togglePlay}
+                          onPlayTrackInPlace={handleCoverFlowPlayInPlace}
+                          groupAppleMusicAlbums={isAppleMusic}
+                        />
+                      </Suspense>
+                    </div>
                   )}
 
                   {showLyrics && tracks[currentIndex] && (

--- a/src/apps/ipod/coverflowStage.ts
+++ b/src/apps/ipod/coverflowStage.ts
@@ -1,0 +1,84 @@
+import { cn } from "@/lib/utils";
+
+/**
+ * Shared Cover Flow stage used by Karaoke and by iPod classic / fullscreen
+ * surfaces. Visuals are isolated from OS chrome (System 7 / macOS / Windows)
+ * so the black stage, label typography, and control buttons stay consistent.
+ */
+export const COVERFLOW_SHARED_STAGE_CLASS = "coverflow-shared-stage";
+
+/** Root font scope for shared-stage Cover Flow (karaoke-force-font rules). */
+export function coverFlowSharedStageRootClass(
+  ipodMode: boolean,
+  isModernIpodCoverFlow: boolean
+): string {
+  const sharedStage = !isModernIpodCoverFlow;
+  if (!sharedStage) {
+    return ipodMode ? "ipod-force-font" : "karaoke-force-font";
+  }
+  return cn(COVERFLOW_SHARED_STAGE_CLASS, "karaoke-force-font");
+}
+
+export function isCoverFlowSharedStage(isModernIpodCoverFlow: boolean): boolean {
+  return !isModernIpodCoverFlow;
+}
+
+/** Label row font — Lucida Grande on macOS via font-os-ui. */
+export function coverFlowLabelFontClass(
+  isModernIpodCoverFlow: boolean
+): string {
+  return isModernIpodCoverFlow ? "font-ipod-modern-ui" : "font-os-ui";
+}
+
+export function coverFlowTitleTextClass(
+  isModernIpodCoverFlow: boolean,
+  ipodMode: boolean
+): string {
+  return cn(
+    "truncate",
+    isModernIpodCoverFlow
+      ? "text-black text-[12px] font-semibold tracking-tight"
+      : "text-white",
+    ipodMode && !isModernIpodCoverFlow && "text-[10px]"
+  );
+}
+
+export function coverFlowArtistTextClass(
+  isModernIpodCoverFlow: boolean,
+  ipodMode: boolean
+): string {
+  return cn(
+    "truncate",
+    isModernIpodCoverFlow
+      ? "text-[10px] text-[rgb(99,101,103)] tracking-tight"
+      : "text-white/60",
+    ipodMode && !isModernIpodCoverFlow && "text-[8px]"
+  );
+}
+
+export const COVERFLOW_SHARED_CONTROL_BUTTON_CLASS =
+  "relative flex-shrink-0 rounded-full transition-all text-white/80 hover:text-white hover:brightness-110 p-3 os-native-chrome-skip";
+
+export const COVERFLOW_SHARED_CONTROL_BUTTON_STYLE = {
+  width: "clamp(40px, 8cqmin, 48px)",
+  height: "clamp(40px, 8cqmin, 48px)",
+  background: "rgba(255, 255, 255, 0.08)",
+} as const;
+
+export const COVERFLOW_SHARED_CONTROL_BUTTON_ACTIVE_STYLE = {
+  ...COVERFLOW_SHARED_CONTROL_BUTTON_STYLE,
+  background: "rgba(255, 255, 255, 0.15)",
+} as const;
+
+export const COVERFLOW_SHARED_FLOOR_GRADIENT =
+  "linear-gradient(to bottom, transparent 40%, rgba(38,38,38,0.5) 70%, rgba(64,64,64,0.3) 100%)";
+
+export const COVERFLOW_MODERN_FLOOR_GRADIENT =
+  "linear-gradient(to bottom, transparent 55%, rgba(0,0,0,0.06) 78%, rgba(0,0,0,0.12) 100%)";
+
+/** Responsive title/artist sizes for shared stage (window + fullscreen). */
+export const COVERFLOW_SHARED_STAGE_TITLE_CLASS =
+  "coverflow-shared-stage-title";
+
+export const COVERFLOW_SHARED_STAGE_ARTIST_CLASS =
+  "coverflow-shared-stage-artist";

--- a/src/apps/karaoke/components/KaraokeAppComponent.tsx
+++ b/src/apps/karaoke/components/KaraokeAppComponent.tsx
@@ -639,7 +639,7 @@ export function KaraokeAppComponent({
           </KaraokeLyricsPlaybackProvider>
 
           {/* CoverFlow overlay - full height, below notitlebar (z-50) */}
-          {tracks.length > 0 && (
+          {tracks.length > 0 && !isFullScreen && (
             <div className={`absolute inset-0 z-40 ${isCoverFlowOpen ? "pointer-events-auto" : "pointer-events-none"}`}>
               <CoverFlow
                 ref={coverFlowRef}
@@ -1089,6 +1089,31 @@ export function KaraokeAppComponent({
                   onSwipeUp={handleFullscreenLyricsSwipeUp}
                   onSwipeDown={handleFullscreenLyricsSwipeDown}
                 />
+
+                {tracks.length > 0 && (
+                  <div
+                    className={cn(
+                      "absolute inset-0 z-[45]",
+                      isCoverFlowOpen
+                        ? "pointer-events-auto"
+                        : "pointer-events-none"
+                    )}
+                  >
+                    <CoverFlow
+                      ref={coverFlowRef}
+                      tracks={tracks}
+                      currentIndex={currentIndex}
+                      onSelectTrack={handleCoverFlowSelectTrack}
+                      onExit={() => setIsCoverFlowOpen(false)}
+                      onRotation={handleCoverFlowRotation}
+                      isVisible={isCoverFlowOpen}
+                      ipodMode={false}
+                      isPlaying={isPlaying}
+                      onTogglePlay={handlePlayPause}
+                      onPlayTrackInPlace={handleCoverFlowPlayInPlace}
+                    />
+                  </div>
+                )}
               </div>
             </div>
           )}

--- a/src/index.css
+++ b/src/index.css
@@ -522,6 +522,19 @@ button.piano-key.piano-key[class*="bg-[#ff33ff]"] {
     container-type: inline-size;
   }
 
+  /* Shared Cover Flow stage (Karaoke + iPod classic / fullscreen) */
+  .coverflow-shared-stage {
+    container-type: size;
+  }
+
+  .coverflow-shared-stage-title {
+    font-size: clamp(14px, 5cqmin, 24px);
+  }
+
+  .coverflow-shared-stage-artist {
+    font-size: clamp(12px, 4cqmin, 18px);
+  }
+
   /* Karaoke lyrics text - uses container query units for window-relative sizing */
   .karaoke-lyrics-text {
     font-size: clamp(32px, 8cqw, 96px);

--- a/src/styles/themes.css
+++ b/src/styles/themes.css
@@ -1782,6 +1782,32 @@
   font-size: 12px !important;
 }
 
+/* Shared Cover Flow stage labels — Lucida Grande on macOS (font-os-ui) */
+:root[data-os-theme="macosx"] .coverflow-shared-stage .font-os-ui,
+:root[data-os-theme="macosx"] .karaoke-force-font.coverflow-shared-stage .font-os-ui {
+  font-family: "LucidaGrande", "Lucida Grande", "AquaKana", "Hiragino Sans",
+    "Hiragino Sans GB", "Heiti SC", ui-sans-serif, system-ui, -apple-system,
+    BlinkMacSystemFont, "SF Pro Display", "SF Pro Text", sans-serif !important;
+  -webkit-font-smoothing: antialiased !important;
+  font-smooth: auto !important;
+}
+
+:root[data-os-theme="macosx"] .coverflow-shared-stage .text-\[10px\] {
+  font-size: 10px !important;
+}
+
+:root[data-os-theme="macosx"] .coverflow-shared-stage .text-\[8px\] {
+  font-size: 8px !important;
+}
+
+:root[data-os-theme="macosx"] .coverflow-shared-stage .coverflow-shared-stage-title {
+  font-size: clamp(14px, 5cqmin, 24px) !important;
+}
+
+:root[data-os-theme="macosx"] .coverflow-shared-stage .coverflow-shared-stage-artist {
+  font-size: clamp(12px, 4cqmin, 18px) !important;
+}
+
 :root[data-os-theme="macosx"] .synth-force-font .font-geneva-12 {
   font-family: "LucidaGrande", "Lucida Grande", "AquaKana", "Hiragino Sans",
     "Hiragino Sans GB", "Heiti SC", ui-sans-serif, system-ui, -apple-system,

--- a/tests/test-coverflow-stage.test.ts
+++ b/tests/test-coverflow-stage.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "bun:test";
+import {
+  COVERFLOW_SHARED_STAGE_CLASS,
+  coverFlowArtistTextClass,
+  coverFlowLabelFontClass,
+  coverFlowSharedStageRootClass,
+  coverFlowTitleTextClass,
+  isCoverFlowSharedStage,
+} from "../src/apps/ipod/coverflowStage";
+
+describe("coverflowStage", () => {
+  test("shared stage is used for karaoke and classic iPod, not modern inline", () => {
+    expect(isCoverFlowSharedStage(false)).toBe(true);
+    expect(isCoverFlowSharedStage(true)).toBe(false);
+  });
+
+  test("shared stage root uses coverflow-shared-stage + karaoke-force-font", () => {
+    expect(coverFlowSharedStageRootClass(false, false)).toContain(
+      COVERFLOW_SHARED_STAGE_CLASS
+    );
+    expect(coverFlowSharedStageRootClass(false, false)).toContain(
+      "karaoke-force-font"
+    );
+    expect(coverFlowSharedStageRootClass(true, true)).toContain(
+      "ipod-force-font"
+    );
+  });
+
+  test("shared stage labels use font-os-ui (Lucida on macOS)", () => {
+    expect(coverFlowLabelFontClass(false)).toBe("font-os-ui");
+    expect(coverFlowLabelFontClass(true)).toBe("font-ipod-modern-ui");
+  });
+
+  test("shared stage title/artist use light-on-black colors", () => {
+    expect(coverFlowTitleTextClass(false, true)).toContain("text-white");
+    expect(coverFlowArtistTextClass(false, false)).toContain("text-white/60");
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Aligns iPod and Karaoke Cover Flow fullscreen / shared-stage presentation so it looks the same on System 7, macOS Aqua, and Windows, matching the Karaoke black-stage Cover Flow treatment.

## Changes

- Add `coverflowStage.ts` with shared stage tokens (background, floor gradient, `font-os-ui` labels, theme-neutral control buttons)
- Refactor `CoverFlow.tsx` to use the shared stage for classic iPod + Karaoke (`!modern`), removing macOS-only Aqua button overrides that caused cross-theme inconsistency
- macOS: preserve **Lucida Grande** for shared-stage labels via `font-os-ui` + `themes.css` overrides (including clamped title/artist sizes)
- Mount Cover Flow inside **iPod** and **Karaoke** `FullScreenPortal` when open; hide window/device duplicates while fullscreen to keep a single `coverFlowRef`
- Modern inline iPod Cover Flow (white skin) unchanged

## Testing

- `bun test tests/test-coverflow-stage.test.ts`
- `bun run test:unit`
- `bun run build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-611c0239-5a08-42cf-9592-4828129471e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-611c0239-5a08-42cf-9592-4828129471e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

