### PR TITLE
refactor(menubar): add AppMenuBarShell + share iPod/Karaoke View/Library helpers

### DIFF
--- a/src/apps/ipod/components/ipod-menu-bar/IpodMenuBar.tsx
+++ b/src/apps/ipod/components/ipod-menu-bar/IpodMenuBar.tsx
@@ -1,36 +1,31 @@
-import { MenuBar } from "@/components/layout/MenuBar";
-import { AppShareItemDialog } from "@/components/shared/menubar/AppShareItemDialog";
+import { AppMenuBarShell } from "@/components/shared/menubar/AppMenuBarShell";
 import type { IpodMenuBarProps } from "./types";
 import { useIpodMenuBar } from "./useIpodMenuBar";
 import { IpodMenuBarFileMenu } from "./IpodMenuBarFileMenu";
 import { IpodMenuBarControlsMenu } from "./IpodMenuBarControlsMenu";
 import { IpodMenuBarViewMenu } from "./IpodMenuBarViewMenu";
 import { IpodMenuBarLibraryMenu } from "./IpodMenuBarLibraryMenu";
-import { AppMenuBarHelpMenu } from "@/components/shared/menubar/AppMenuBarHelpMenu";
 
 export function IpodMenuBar(props: IpodMenuBarProps) {
   const vm = useIpodMenuBar(props);
   return (
-    <MenuBar inWindowFrame={vm.isXpTheme}>
+    <AppMenuBarShell
+      appId={vm.appId}
+      appName={vm.appName}
+      isXpTheme={vm.isXpTheme}
+      isMacOsxTheme={vm.isMacOsxTheme}
+      isShareDialogOpen={vm.isShareDialogOpen}
+      onShareDialogOpenChange={vm.setIsShareDialogOpen}
+      helpItemLabel={vm.t("apps.ipod.menu.ipodHelp")}
+      aboutItemLabel={vm.t("apps.ipod.menu.aboutIpod")}
+      shareItemLabel={vm.t("apps.ipod.menu.shareApp")}
+      onShowHelp={vm.onShowHelp}
+      onShowAbout={vm.onShowAbout}
+    >
       <IpodMenuBarFileMenu vm={vm} />
       <IpodMenuBarControlsMenu vm={vm} />
       <IpodMenuBarViewMenu vm={vm} />
       <IpodMenuBarLibraryMenu vm={vm} />
-      <AppMenuBarHelpMenu
-        helpItemLabel={vm.t("apps.ipod.menu.ipodHelp")}
-        aboutItemLabel={vm.t("apps.ipod.menu.aboutIpod")}
-        shareItemLabel={vm.t("apps.ipod.menu.shareApp")}
-        isMacOsxTheme={vm.isMacOsxTheme}
-        onShowHelp={vm.onShowHelp}
-        onShowAbout={vm.onShowAbout}
-        onOpenShareDialog={() => vm.setIsShareDialogOpen(true)}
-      />
-      <AppShareItemDialog
-        appId={vm.appId}
-        appName={vm.appName}
-        isOpen={vm.isShareDialogOpen}
-        onClose={() => vm.setIsShareDialogOpen(false)}
-      />
-    </MenuBar>
+    </AppMenuBarShell>
   );
 }

--- a/src/apps/ipod/components/ipod-menu-bar/IpodMenuBarLibraryMenu.tsx
+++ b/src/apps/ipod/components/ipod-menu-bar/IpodMenuBarLibraryMenu.tsx
@@ -4,11 +4,8 @@ import {
   MenubarContent,
   MenubarItem,
   MenubarSeparator,
-  MenubarSub,
-  MenubarSubTrigger,
-  MenubarSubContent,
-  MenubarCheckboxItem,
 } from "@/components/ui/menubar";
+import { LyricsLibraryTrackList } from "@/components/shared/menubar/lyrics/LyricsLibraryTrackList";
 import { MENUBAR_TRACK_LIMIT, MENUBAR_ARTIST_LIMIT } from "./constants";
 import { IpodMenuBarLibrarySourceActions } from "./IpodMenuBarLibrarySourceActions";
 import { IpodMenuBarLibrarySwitchItem } from "./IpodMenuBarLibrarySwitchItem";
@@ -40,82 +37,30 @@ export function IpodMenuBarLibraryMenu({ vm }: { vm: IpodMenuBarViewModel }) {
 
           {tracks.length > 0 && (
             <>
-              <MenubarSub>
-                <MenubarSubTrigger className="text-md h-6 px-3">
-                  <div className="flex justify-between w-full items-center overflow-hidden">
-                    <span className="truncate min-w-0">{t("apps.ipod.menu.allSongs")}</span>
-                  </div>
-                </MenubarSubTrigger>
-                <MenubarSubContent className="px-0 max-w-[180px] sm:max-w-[220px] max-h-[400px] overflow-y-auto">
-                  {tracks.slice(0, MENUBAR_TRACK_LIMIT).map((track, index) => (
-                    <MenubarCheckboxItem
-                      key={`all-${track.id}`}
-                      checked={index === currentIndex}
-                      onCheckedChange={() => handlePlayTrack(index)}
-                      className="text-md h-6 pr-3 max-w-[220px] truncate"
-                    >
-                      <span className="truncate min-w-0">{track.title}</span>
-                    </MenubarCheckboxItem>
-                  ))}
-                  {tracks.length > MENUBAR_TRACK_LIMIT && (
-                    <MenubarItem
-                      disabled
-                      className="text-md h-6 px-3 italic opacity-70"
-                    >
-                      {t(
-                        "apps.ipod.menu.menubarTrackLimit",
-                        `Showing ${MENUBAR_TRACK_LIMIT} of ${tracks.length} — open iPod to browse all`,
-                        {
-                          limit: MENUBAR_TRACK_LIMIT,
-                          total: tracks.length,
-                        }
-                      )}
-                    </MenubarItem>
-                  )}
-                </MenubarSubContent>
-              </MenubarSub>
-              <div className="max-h-[300px] overflow-y-auto">
-                {artists.slice(0, MENUBAR_ARTIST_LIMIT).map((artist) => (
-                  <MenubarSub key={artist}>
-                    <MenubarSubTrigger className="text-md h-6 px-3">
-                      <div className="flex justify-between w-full items-center overflow-hidden">
-                        <span className="truncate min-w-0">{artist}</span>
-                      </div>
-                    </MenubarSubTrigger>
-                    <MenubarSubContent className="px-0 max-w-[180px] sm:max-w-[220px] max-h-[200px] overflow-y-auto">
-                      {tracksByArtist[artist]
-                        .slice(0, MENUBAR_TRACK_LIMIT)
-                        .map(({ track, index }) => (
-                          <MenubarCheckboxItem
-                            key={`${artist}-${track.id}`}
-                            checked={index === currentIndex}
-                            onCheckedChange={() => handlePlayTrack(index)}
-                            className="text-md h-6 pr-3 max-w-[160px] sm:max-w-[200px] truncate"
-                          >
-                            <span className="truncate min-w-0">
-                              {track.title}
-                            </span>
-                          </MenubarCheckboxItem>
-                        ))}
-                    </MenubarSubContent>
-                  </MenubarSub>
-                ))}
-                {artists.length > MENUBAR_ARTIST_LIMIT && (
-                  <MenubarItem
-                    disabled
-                    className="text-md h-6 px-3 italic opacity-70"
-                  >
-                    {t(
-                      "apps.ipod.menu.menubarArtistLimit",
-                      `Showing ${MENUBAR_ARTIST_LIMIT} of ${artists.length} artists`,
-                      {
-                        limit: MENUBAR_ARTIST_LIMIT,
-                        total: artists.length,
-                      }
-                    )}
-                  </MenubarItem>
-                )}
-              </div>
+              <LyricsLibraryTrackList
+                allSongsLabel={t("apps.ipod.menu.allSongs")}
+                tracks={tracks}
+                currentIndex={currentIndex}
+                artists={artists}
+                tracksByArtist={tracksByArtist}
+                onPlayTrack={handlePlayTrack}
+                trackLimit={MENUBAR_TRACK_LIMIT}
+                artistLimit={MENUBAR_ARTIST_LIMIT}
+                renderTrackLimitNotice={(limit, total) =>
+                  t(
+                    "apps.ipod.menu.menubarTrackLimit",
+                    `Showing ${limit} of ${total} — open iPod to browse all`,
+                    { limit, total }
+                  )
+                }
+                renderArtistLimitNotice={(limit, total) =>
+                  t(
+                    "apps.ipod.menu.menubarArtistLimit",
+                    `Showing ${limit} of ${total} artists`,
+                    { limit, total }
+                  )
+                }
+              />
 
               <MenubarSeparator className="h-[2px] bg-black my-1" />
             </>

--- a/src/apps/ipod/components/ipod-menu-bar/IpodMenuBarViewMenu.tsx
+++ b/src/apps/ipod/components/ipod-menu-bar/IpodMenuBarViewMenu.tsx
@@ -12,11 +12,12 @@ import {
   MenubarRadioItem,
 } from "@/components/ui/menubar";
 import { LyricsAlignmentMenuItems } from "@/components/shared/menubar/lyrics/LyricsAlignmentMenuItems";
+import { LyricsDisplayModeSubmenu } from "@/components/shared/menubar/lyrics/LyricsDisplayModeSubmenu";
 import { LyricsPronunciationSubmenu } from "@/components/shared/menubar/lyrics/LyricsPronunciationSubmenu";
 import { LyricsTranslationLanguageSubmenu } from "@/components/shared/menubar/lyrics/LyricsTranslationLanguageSubmenu";
 import { MENUBAR_SEPARATOR_CLASS } from "@/components/shared/menubar/menubarStyles";
 import { toast } from "sonner";
-import { DisplayMode, LyricsFont } from "@/types/lyrics";
+import { LyricsFont } from "@/types/lyrics";
 import type { IpodMenuBarViewModel } from "./useIpodMenuBar";
 
 export function IpodMenuBarViewMenu({ vm }: { vm: IpodMenuBarViewModel }) {
@@ -113,69 +114,18 @@ export function IpodMenuBarViewMenu({ vm }: { vm: IpodMenuBarViewModel }) {
             romanization={vm.romanization}
             setRomanization={vm.setRomanization}
           />
-          <MenubarSub>
-            <MenubarSubTrigger className="text-md h-6 px-3">
-              {vm.t("apps.ipod.menu.display")}
-            </MenubarSubTrigger>
-            <MenubarSubContent className="px-0">
-              {!vm.isAppleMusic && (
-                <MenubarCheckboxItem
-                  checked={vm.effectiveDisplayMode === DisplayMode.Video}
-                  onCheckedChange={(checked) => {
-                    if (checked) vm.setDisplayMode(DisplayMode.Video);
-                  }}
-                  className="text-md h-6 pr-3"
-                >
-                  {vm.t("apps.ipod.menu.displayVideo")}
-                </MenubarCheckboxItem>
-              )}
-              <MenubarCheckboxItem
-                checked={vm.effectiveDisplayMode === DisplayMode.Mesh}
-                onCheckedChange={(checked) => {
-                  if (checked) vm.setDisplayMode(DisplayMode.Mesh);
-                }}
-                className="text-md h-6 pr-3"
-              >
-                {vm.t("apps.ipod.menu.displayGradient")}
-              </MenubarCheckboxItem>
-              <MenubarCheckboxItem
-                checked={vm.effectiveDisplayMode === DisplayMode.Water}
-                onCheckedChange={(checked) => {
-                  if (checked) vm.setDisplayMode(DisplayMode.Water);
-                }}
-                className="text-md h-6 pr-3"
-              >
-                {vm.t("apps.ipod.menu.displayWater")}
-              </MenubarCheckboxItem>
-              <MenubarCheckboxItem
-                checked={vm.effectiveDisplayMode === DisplayMode.Shader}
-                onCheckedChange={(checked) => {
-                  if (checked) vm.setDisplayMode(DisplayMode.Shader);
-                }}
-                className="text-md h-6 pr-3"
-              >
-                {vm.t("apps.ipod.menu.displayShader")}
-              </MenubarCheckboxItem>
-              <MenubarCheckboxItem
-                checked={vm.effectiveDisplayMode === DisplayMode.Landscapes}
-                onCheckedChange={(checked) => {
-                  if (checked) vm.setDisplayMode(DisplayMode.Landscapes);
-                }}
-                className="text-md h-6 pr-3"
-              >
-                {vm.t("apps.ipod.menu.displayLandscapes")}
-              </MenubarCheckboxItem>
-              <MenubarCheckboxItem
-                checked={vm.effectiveDisplayMode === DisplayMode.Cover}
-                onCheckedChange={(checked) => {
-                  if (checked) vm.setDisplayMode(DisplayMode.Cover);
-                }}
-                className="text-md h-6 pr-3"
-              >
-                {vm.t("apps.ipod.menu.displayCover")}
-              </MenubarCheckboxItem>
-            </MenubarSubContent>
-          </MenubarSub>
+          <LyricsDisplayModeSubmenu
+            submenuLabel={vm.t("apps.ipod.menu.display")}
+            displayMode={vm.effectiveDisplayMode}
+            setDisplayMode={vm.setDisplayMode}
+            includeVideo={!vm.isAppleMusic}
+            videoLabel={vm.t("apps.ipod.menu.displayVideo")}
+            gradientLabel={vm.t("apps.ipod.menu.displayGradient")}
+            waterLabel={vm.t("apps.ipod.menu.displayWater")}
+            shaderLabel={vm.t("apps.ipod.menu.displayShader")}
+            landscapesLabel={vm.t("apps.ipod.menu.displayLandscapes")}
+            coverLabel={vm.t("apps.ipod.menu.displayCover")}
+          />
 
           <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
 

--- a/src/apps/karaoke/components/karaoke-menu-bar/KaraokeMenuBar.tsx
+++ b/src/apps/karaoke/components/karaoke-menu-bar/KaraokeMenuBar.tsx
@@ -1,36 +1,31 @@
-import { MenuBar } from "@/components/layout/MenuBar";
-import { AppShareItemDialog } from "@/components/shared/menubar/AppShareItemDialog";
+import { AppMenuBarShell } from "@/components/shared/menubar/AppMenuBarShell";
 import type { KaraokeMenuBarProps } from "./types";
 import { useKaraokeMenuBar } from "./useKaraokeMenuBar";
 import { KaraokeMenuBarFileMenu } from "./KaraokeMenuBarFileMenu";
 import { KaraokeMenuBarControlsMenu } from "./KaraokeMenuBarControlsMenu";
 import { KaraokeMenuBarViewMenu } from "./KaraokeMenuBarViewMenu";
 import { KaraokeMenuBarLibraryMenu } from "./KaraokeMenuBarLibraryMenu";
-import { AppMenuBarHelpMenu } from "@/components/shared/menubar/AppMenuBarHelpMenu";
 
 export function KaraokeMenuBar(props: KaraokeMenuBarProps) {
   const vm = useKaraokeMenuBar(props);
   return (
-    <MenuBar inWindowFrame={vm.isXpTheme}>
+    <AppMenuBarShell
+      appId={vm.appId}
+      appName={vm.appName}
+      isXpTheme={vm.isXpTheme}
+      isMacOsxTheme={vm.isMacOsxTheme}
+      isShareDialogOpen={vm.isShareDialogOpen}
+      onShareDialogOpenChange={vm.setIsShareDialogOpen}
+      helpItemLabel={vm.t("apps.karaoke.menu.karaokeHelp")}
+      aboutItemLabel={vm.t("apps.karaoke.menu.aboutKaraoke")}
+      shareItemLabel={vm.t("apps.karaoke.menu.shareApp")}
+      onShowHelp={vm.onShowHelp}
+      onShowAbout={vm.onShowAbout}
+    >
       <KaraokeMenuBarFileMenu vm={vm} />
       <KaraokeMenuBarControlsMenu vm={vm} />
       <KaraokeMenuBarViewMenu vm={vm} />
       <KaraokeMenuBarLibraryMenu vm={vm} />
-      <AppMenuBarHelpMenu
-        helpItemLabel={vm.t("apps.karaoke.menu.karaokeHelp")}
-        aboutItemLabel={vm.t("apps.karaoke.menu.aboutKaraoke")}
-        shareItemLabel={vm.t("apps.karaoke.menu.shareApp")}
-        isMacOsxTheme={vm.isMacOsxTheme}
-        onShowHelp={vm.onShowHelp}
-        onShowAbout={vm.onShowAbout}
-        onOpenShareDialog={() => vm.setIsShareDialogOpen(true)}
-      />
-      <AppShareItemDialog
-        appId={vm.appId}
-        appName={vm.appName}
-        isOpen={vm.isShareDialogOpen}
-        onClose={() => vm.setIsShareDialogOpen(false)}
-      />
-    </MenuBar>
+    </AppMenuBarShell>
   );
 }

--- a/src/apps/karaoke/components/karaoke-menu-bar/KaraokeMenuBarLibraryMenu.tsx
+++ b/src/apps/karaoke/components/karaoke-menu-bar/KaraokeMenuBarLibraryMenu.tsx
@@ -4,11 +4,8 @@ import {
   MenubarContent,
   MenubarItem,
   MenubarSeparator,
-  MenubarSub,
-  MenubarSubTrigger,
-  MenubarSubContent,
-  MenubarCheckboxItem,
 } from "@/components/ui/menubar";
+import { LyricsLibraryTrackList } from "@/components/shared/menubar/lyrics/LyricsLibraryTrackList";
 import type { KaraokeMenuBarViewModel } from "./useKaraokeMenuBar";
 
 export function KaraokeMenuBarLibraryMenu({
@@ -46,51 +43,14 @@ export function KaraokeMenuBarLibraryMenu({
           <>
             <MenubarSeparator className="h-[2px] bg-black my-1" />
 
-            <MenubarSub>
-              <MenubarSubTrigger className="text-md h-6 px-3">
-                <div className="flex justify-between w-full items-center overflow-hidden">
-                  <span className="truncate min-w-0">
-                    {t("apps.ipod.menu.allSongs")}
-                  </span>
-                </div>
-              </MenubarSubTrigger>
-              <MenubarSubContent className="px-0 max-w-[180px] sm:max-w-[220px] max-h-[400px] overflow-y-auto">
-                {tracks.map((track, index) => (
-                  <MenubarCheckboxItem
-                    key={`all-${track.id}`}
-                    checked={index === currentIndex}
-                    onCheckedChange={() => onPlayTrack(index)}
-                    className="text-md h-6 pr-3 max-w-[220px] truncate"
-                  >
-                    <span className="truncate min-w-0">{track.title}</span>
-                  </MenubarCheckboxItem>
-                ))}
-              </MenubarSubContent>
-            </MenubarSub>
-
-            <div className="max-h-[300px] overflow-y-auto">
-              {artists.map((artist) => (
-                <MenubarSub key={artist}>
-                  <MenubarSubTrigger className="text-md h-6 px-3">
-                    <div className="flex justify-between w-full items-center overflow-hidden">
-                      <span className="truncate min-w-0">{artist}</span>
-                    </div>
-                  </MenubarSubTrigger>
-                  <MenubarSubContent className="px-0 max-w-[180px] sm:max-w-[220px] max-h-[200px] overflow-y-auto">
-                    {tracksByArtist[artist].map(({ track, index }) => (
-                      <MenubarCheckboxItem
-                        key={`${artist}-${track.id}`}
-                        checked={index === currentIndex}
-                        onCheckedChange={() => onPlayTrack(index)}
-                        className="text-md h-6 pr-3 max-w-[160px] sm:max-w-[200px] truncate"
-                      >
-                        <span className="truncate min-w-0">{track.title}</span>
-                      </MenubarCheckboxItem>
-                    ))}
-                  </MenubarSubContent>
-                </MenubarSub>
-              ))}
-            </div>
+            <LyricsLibraryTrackList
+              allSongsLabel={t("apps.ipod.menu.allSongs")}
+              tracks={tracks}
+              currentIndex={currentIndex}
+              artists={artists}
+              tracksByArtist={tracksByArtist}
+              onPlayTrack={onPlayTrack}
+            />
 
             <MenubarSeparator className="h-[2px] bg-black my-1" />
           </>

--- a/src/apps/karaoke/components/karaoke-menu-bar/KaraokeMenuBarViewMenu.tsx
+++ b/src/apps/karaoke/components/karaoke-menu-bar/KaraokeMenuBarViewMenu.tsx
@@ -10,11 +10,12 @@ import {
   MenubarCheckboxItem,
 } from "@/components/ui/menubar";
 import { LyricsAlignmentMenuItems } from "@/components/shared/menubar/lyrics/LyricsAlignmentMenuItems";
+import { LyricsDisplayModeSubmenu } from "@/components/shared/menubar/lyrics/LyricsDisplayModeSubmenu";
 import { LyricsPronunciationSubmenu } from "@/components/shared/menubar/lyrics/LyricsPronunciationSubmenu";
 import { LyricsTranslationLanguageSubmenu } from "@/components/shared/menubar/lyrics/LyricsTranslationLanguageSubmenu";
 import { MENUBAR_SEPARATOR_CLASS, MENUBAR_TRIGGER_CLASS } from "@/components/shared/menubar/menubarStyles";
 import { toast } from "sonner";
-import { LyricsFont, DisplayMode } from "@/types/lyrics";
+import { LyricsFont } from "@/types/lyrics";
 import type { KaraokeMenuBarViewModel } from "./useKaraokeMenuBar";
 
 export function KaraokeMenuBarViewMenu({ vm }: { vm: KaraokeMenuBarViewModel }) {
@@ -127,67 +128,18 @@ export function KaraokeMenuBarViewMenu({ vm }: { vm: KaraokeMenuBarViewModel }) 
           setRomanization={vm.setRomanization}
         />
 
-        <MenubarSub>
-          <MenubarSubTrigger className="text-md h-6 px-3">
-            {vm.t("apps.ipod.menu.display")}
-          </MenubarSubTrigger>
-          <MenubarSubContent className="px-0">
-            <MenubarCheckboxItem
-              checked={vm.displayMode === DisplayMode.Video}
-              onCheckedChange={(checked) => {
-                if (checked) vm.setDisplayMode(DisplayMode.Video);
-              }}
-              className="text-md h-6 pr-3"
-            >
-              {vm.t("apps.ipod.menu.displayVideo")}
-            </MenubarCheckboxItem>
-            <MenubarCheckboxItem
-              checked={vm.displayMode === DisplayMode.Mesh}
-              onCheckedChange={(checked) => {
-                if (checked) vm.setDisplayMode(DisplayMode.Mesh);
-              }}
-              className="text-md h-6 pr-3"
-            >
-              {vm.t("apps.ipod.menu.displayGradient")}
-            </MenubarCheckboxItem>
-            <MenubarCheckboxItem
-              checked={vm.displayMode === DisplayMode.Water}
-              onCheckedChange={(checked) => {
-                if (checked) vm.setDisplayMode(DisplayMode.Water);
-              }}
-              className="text-md h-6 pr-3"
-            >
-              {vm.t("apps.ipod.menu.displayWater")}
-            </MenubarCheckboxItem>
-            <MenubarCheckboxItem
-              checked={vm.displayMode === DisplayMode.Shader}
-              onCheckedChange={(checked) => {
-                if (checked) vm.setDisplayMode(DisplayMode.Shader);
-              }}
-              className="text-md h-6 pr-3"
-            >
-              {vm.t("apps.ipod.menu.displayShader")}
-            </MenubarCheckboxItem>
-            <MenubarCheckboxItem
-              checked={vm.displayMode === DisplayMode.Landscapes}
-              onCheckedChange={(checked) => {
-                if (checked) vm.setDisplayMode(DisplayMode.Landscapes);
-              }}
-              className="text-md h-6 pr-3"
-            >
-              {vm.t("apps.ipod.menu.displayLandscapes")}
-            </MenubarCheckboxItem>
-            <MenubarCheckboxItem
-              checked={vm.displayMode === DisplayMode.Cover}
-              onCheckedChange={(checked) => {
-                if (checked) vm.setDisplayMode(DisplayMode.Cover);
-              }}
-              className="text-md h-6 pr-3"
-            >
-              {vm.t("apps.ipod.menu.displayCover")}
-            </MenubarCheckboxItem>
-          </MenubarSubContent>
-        </MenubarSub>
+        <LyricsDisplayModeSubmenu
+          submenuLabel={vm.t("apps.ipod.menu.display")}
+          displayMode={vm.displayMode}
+          setDisplayMode={vm.setDisplayMode}
+          includeVideo
+          videoLabel={vm.t("apps.ipod.menu.displayVideo")}
+          gradientLabel={vm.t("apps.ipod.menu.displayGradient")}
+          waterLabel={vm.t("apps.ipod.menu.displayWater")}
+          shaderLabel={vm.t("apps.ipod.menu.displayShader")}
+          landscapesLabel={vm.t("apps.ipod.menu.displayLandscapes")}
+          coverLabel={vm.t("apps.ipod.menu.displayCover")}
+        />
 
         <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
 

--- a/src/components/shared/menubar/AppMenuBarShell.tsx
+++ b/src/components/shared/menubar/AppMenuBarShell.tsx
@@ -1,0 +1,64 @@
+import { type ReactNode } from "react";
+import { MenuBar } from "@/components/layout/MenuBar";
+import { AppMenuBarHelpMenu } from "@/components/shared/menubar/AppMenuBarHelpMenu";
+import { AppShareItemDialog } from "@/components/shared/menubar/AppShareItemDialog";
+import type { AppId } from "@/config/appRegistry";
+
+interface AppMenuBarShellProps {
+  /** App identity + theme flags, typically spread from useAppMenuBarChrome. */
+  appId: AppId;
+  appName: string;
+  isXpTheme: boolean;
+  isMacOsxTheme: boolean;
+  isShareDialogOpen: boolean;
+  onShareDialogOpenChange: (open: boolean) => void;
+  /** Help menu labels + actions. */
+  helpItemLabel: string;
+  aboutItemLabel: string;
+  shareItemLabel?: string;
+  onShowHelp?: () => void;
+  onShowAbout?: () => void;
+  /** App-specific menus rendered before the shared Help menu. */
+  children: ReactNode;
+}
+
+/**
+ * Standard app menubar wrapper: the app's own menus followed by the shared
+ * Help menu and Share dialog, all inside the themed MenuBar frame. Lets each
+ * app skip the identical boilerplate around its menus.
+ */
+export function AppMenuBarShell({
+  appId,
+  appName,
+  isXpTheme,
+  isMacOsxTheme,
+  isShareDialogOpen,
+  onShareDialogOpenChange,
+  helpItemLabel,
+  aboutItemLabel,
+  shareItemLabel,
+  onShowHelp,
+  onShowAbout,
+  children,
+}: AppMenuBarShellProps) {
+  return (
+    <MenuBar inWindowFrame={isXpTheme}>
+      {children}
+      <AppMenuBarHelpMenu
+        helpItemLabel={helpItemLabel}
+        aboutItemLabel={aboutItemLabel}
+        shareItemLabel={shareItemLabel}
+        isMacOsxTheme={isMacOsxTheme}
+        onShowHelp={onShowHelp}
+        onShowAbout={onShowAbout}
+        onOpenShareDialog={() => onShareDialogOpenChange(true)}
+      />
+      <AppShareItemDialog
+        appId={appId}
+        appName={appName}
+        isOpen={isShareDialogOpen}
+        onClose={() => onShareDialogOpenChange(false)}
+      />
+    </MenuBar>
+  );
+}

--- a/src/components/shared/menubar/lyrics/LyricsDisplayModeSubmenu.tsx
+++ b/src/components/shared/menubar/lyrics/LyricsDisplayModeSubmenu.tsx
@@ -1,0 +1,64 @@
+import {
+  MenubarSub,
+  MenubarSubTrigger,
+  MenubarSubContent,
+  MenubarCheckboxItem,
+} from "@/components/ui/menubar";
+import { DisplayMode } from "@/types/lyrics";
+
+export type LyricsDisplayModeSubmenuProps = {
+  submenuLabel: string;
+  displayMode: DisplayMode;
+  setDisplayMode: (mode: DisplayMode) => void;
+  /** Hidden by the iPod when an Apple Music library is active. */
+  includeVideo: boolean;
+  videoLabel: string;
+  gradientLabel: string;
+  waterLabel: string;
+  shaderLabel: string;
+  landscapesLabel: string;
+  coverLabel: string;
+};
+
+const DISPLAY_ITEM_CLASS = "text-md h-6 pr-3";
+
+export function LyricsDisplayModeSubmenu({
+  submenuLabel,
+  displayMode,
+  setDisplayMode,
+  includeVideo,
+  videoLabel,
+  gradientLabel,
+  waterLabel,
+  shaderLabel,
+  landscapesLabel,
+  coverLabel,
+}: LyricsDisplayModeSubmenuProps) {
+  const item = (mode: DisplayMode, label: string) => (
+    <MenubarCheckboxItem
+      checked={displayMode === mode}
+      onCheckedChange={(checked) => {
+        if (checked) setDisplayMode(mode);
+      }}
+      className={DISPLAY_ITEM_CLASS}
+    >
+      {label}
+    </MenubarCheckboxItem>
+  );
+
+  return (
+    <MenubarSub>
+      <MenubarSubTrigger className="text-md h-6 px-3">
+        {submenuLabel}
+      </MenubarSubTrigger>
+      <MenubarSubContent className="px-0">
+        {includeVideo && item(DisplayMode.Video, videoLabel)}
+        {item(DisplayMode.Mesh, gradientLabel)}
+        {item(DisplayMode.Water, waterLabel)}
+        {item(DisplayMode.Shader, shaderLabel)}
+        {item(DisplayMode.Landscapes, landscapesLabel)}
+        {item(DisplayMode.Cover, coverLabel)}
+      </MenubarSubContent>
+    </MenubarSub>
+  );
+}

--- a/src/components/shared/menubar/lyrics/LyricsLibraryTrackList.tsx
+++ b/src/components/shared/menubar/lyrics/LyricsLibraryTrackList.tsx
@@ -1,0 +1,121 @@
+import { type ReactNode } from "react";
+import {
+  MenubarItem,
+  MenubarSub,
+  MenubarSubTrigger,
+  MenubarSubContent,
+  MenubarCheckboxItem,
+} from "@/components/ui/menubar";
+import type { TrackWithIndex } from "@/utils/groupTracksByArtist";
+
+type LibraryTrack = { id: string; title: string; artist?: string };
+
+export type LyricsLibraryTrackListProps<T extends LibraryTrack> = {
+  allSongsLabel: string;
+  tracks: T[];
+  currentIndex: number;
+  artists: string[];
+  tracksByArtist: Record<string, TrackWithIndex<T>[]>;
+  onPlayTrack: (index: number) => void;
+  /** Optional cap on rendered tracks per list (iPod uses this for big libraries). */
+  trackLimit?: number;
+  /** Optional cap on rendered artists. */
+  artistLimit?: number;
+  /** Rendered as a disabled row when the track list is truncated. */
+  renderTrackLimitNotice?: (shown: number, total: number) => ReactNode;
+  /** Rendered as a disabled row when the artist list is truncated. */
+  renderArtistLimitNotice?: (shown: number, total: number) => ReactNode;
+};
+
+/**
+ * Shared "All Songs" + per-artist submenus used by the iPod and Karaoke
+ * library menus. iPod passes limits to cap DOM nodes for huge libraries;
+ * Karaoke omits them to render the full list.
+ */
+export function LyricsLibraryTrackList<T extends LibraryTrack>({
+  allSongsLabel,
+  tracks,
+  currentIndex,
+  artists,
+  tracksByArtist,
+  onPlayTrack,
+  trackLimit,
+  artistLimit,
+  renderTrackLimitNotice,
+  renderArtistLimitNotice,
+}: LyricsLibraryTrackListProps<T>) {
+  const shownTracks =
+    trackLimit !== undefined ? tracks.slice(0, trackLimit) : tracks;
+  const shownArtists =
+    artistLimit !== undefined ? artists.slice(0, artistLimit) : artists;
+
+  return (
+    <>
+      <MenubarSub>
+        <MenubarSubTrigger className="text-md h-6 px-3">
+          <div className="flex justify-between w-full items-center overflow-hidden">
+            <span className="truncate min-w-0">{allSongsLabel}</span>
+          </div>
+        </MenubarSubTrigger>
+        <MenubarSubContent className="px-0 max-w-[180px] sm:max-w-[220px] max-h-[400px] overflow-y-auto">
+          {shownTracks.map((track, index) => (
+            <MenubarCheckboxItem
+              key={`all-${track.id}`}
+              checked={index === currentIndex}
+              onCheckedChange={() => onPlayTrack(index)}
+              className="text-md h-6 pr-3 max-w-[220px] truncate"
+            >
+              <span className="truncate min-w-0">{track.title}</span>
+            </MenubarCheckboxItem>
+          ))}
+          {trackLimit !== undefined &&
+            tracks.length > trackLimit &&
+            renderTrackLimitNotice && (
+              <MenubarItem
+                disabled
+                className="text-md h-6 px-3 italic opacity-70"
+              >
+                {renderTrackLimitNotice(trackLimit, tracks.length)}
+              </MenubarItem>
+            )}
+        </MenubarSubContent>
+      </MenubarSub>
+      <div className="max-h-[300px] overflow-y-auto">
+        {shownArtists.map((artist) => (
+          <MenubarSub key={artist}>
+            <MenubarSubTrigger className="text-md h-6 px-3">
+              <div className="flex justify-between w-full items-center overflow-hidden">
+                <span className="truncate min-w-0">{artist}</span>
+              </div>
+            </MenubarSubTrigger>
+            <MenubarSubContent className="px-0 max-w-[180px] sm:max-w-[220px] max-h-[200px] overflow-y-auto">
+              {(trackLimit !== undefined
+                ? tracksByArtist[artist].slice(0, trackLimit)
+                : tracksByArtist[artist]
+              ).map(({ track, index }) => (
+                <MenubarCheckboxItem
+                  key={`${artist}-${track.id}`}
+                  checked={index === currentIndex}
+                  onCheckedChange={() => onPlayTrack(index)}
+                  className="text-md h-6 pr-3 max-w-[160px] sm:max-w-[200px] truncate"
+                >
+                  <span className="truncate min-w-0">{track.title}</span>
+                </MenubarCheckboxItem>
+              ))}
+            </MenubarSubContent>
+          </MenubarSub>
+        ))}
+        {artistLimit !== undefined &&
+          artists.length > artistLimit &&
+          renderArtistLimitNotice && (
+            <MenubarItem
+              disabled
+              className="text-md h-6 px-3 italic opacity-70"
+            >
+              {renderArtistLimitNotice(artistLimit, artists.length)}
+            </MenubarItem>
+          )}
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Continues the React split (post #1342). Adds a reusable `AppMenuBarShell` and dedupes the iPod + Karaoke **View** (display modes) and **Library** (All Songs / per-artist) menus into shared helpers. This is a behavior-preserving refactor — no UI or logic changes intended.

### New shared components
- `AppMenuBarShell` (`src/components/shared/menubar/AppMenuBarShell.tsx`) — wraps the themed `MenuBar` + app menus + shared `AppMenuBarHelpMenu` + `AppShareItemDialog`, removing the identical boilerplate each app repeated.
- `LyricsDisplayModeSubmenu` (`.../lyrics/LyricsDisplayModeSubmenu.tsx`) — the Display sub-menu (Video/Gradient/Water/Shader/Landscapes/Cover). `includeVideo` handles the iPod hiding Video while an Apple Music library is active.
- `LyricsLibraryTrackList` (`.../lyrics/LyricsLibraryTrackList.tsx`) — the "All Songs" + per-artist sub-menus. Optional `trackLimit`/`artistLimit` (+ notice renderers) preserve the iPod's DOM caps for huge libraries; Karaoke omits them to render the full list.

### Consumers refactored
- iPod: `IpodMenuBar`, `IpodMenuBarViewMenu`, `IpodMenuBarLibraryMenu`.
- Karaoke: `KaraokeMenuBar`, `KaraokeMenuBarViewMenu`, `KaraokeMenuBarLibraryMenu`.

Re-export stubs at old paths are untouched. App-specific divergences (font radio-vs-checkbox, iPod backlight/theme submenus, library source actions/limits) stay in their own files.

## Testing
- `bun run build` — passes (type-checks all new prop wiring).
- `bun run test:unit` — 238 pass / 0 fail.
- `bunx eslint` on all touched files — clean.

No GUI testing per `AGENTS.md` (skip computer-use unless explicitly requested); the change is a structural refactor fully covered by the type-checking build.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019e7dde-fab6-7d61-98a5-c28346416139"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019e7dde-fab6-7d61-98a5-c28346416139"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

