### PR TITLE
refactor(ipod,karaoke): unify duplicated media app code paths

### DIFF
--- a/src/apps/admin/components/AdminAppComponent.tsx
+++ b/src/apps/admin/components/AdminAppComponent.tsx
@@ -1,1 +1,0 @@
-export { AdminAppComponent } from "./admin-app/AdminAppComponent";

--- a/src/apps/admin/components/AdminMenuBar.tsx
+++ b/src/apps/admin/components/AdminMenuBar.tsx
@@ -1,4 +1,3 @@
-import { MenuBar } from "@/components/layout/MenuBar";
 import {
   MenubarCheckboxItem,
   MenubarContent,
@@ -7,8 +6,7 @@ import {
   MenubarSeparator,
   MenubarTrigger,
 } from "@/components/ui/menubar";
-import { AppMenuBarHelpMenu } from "@/components/shared/menubar/AppMenuBarHelpMenu";
-import { AppShareItemDialog } from "@/components/shared/menubar/AppShareItemDialog";
+import { AppMenuBarShell } from "@/components/shared/menubar/AppMenuBarShell";
 import {
   MENUBAR_ITEM_CLASS,
   MENUBAR_SEPARATOR_CLASS,
@@ -50,7 +48,18 @@ export function AdminMenuBar({
   } = useAppMenuBarChrome("admin");
 
   return (
-    <MenuBar inWindowFrame={isXpTheme}>
+    <AppMenuBarShell
+      isXpTheme={isXpTheme}
+      isMacOsxTheme={isMacOsxTheme}
+      appId={appId}
+      appName={appName}
+      isShareDialogOpen={isShareDialogOpen}
+      setIsShareDialogOpen={setIsShareDialogOpen}
+      helpItemLabel={t("apps.admin.menu.adminHelp")}
+      aboutItemLabel={t("apps.admin.menu.aboutAdmin")}
+      onShowHelp={onShowHelp}
+      onShowAbout={onShowAbout}
+    >
       {/* File Menu */}
       <MenubarMenu>
         <MenubarTrigger className={MENUBAR_TRIGGER_CLASS}>
@@ -133,21 +142,6 @@ export function AdminMenuBar({
           </MenubarCheckboxItem>
         </MenubarContent>
       </MenubarMenu>
-
-      <AppMenuBarHelpMenu
-        helpItemLabel={t("apps.admin.menu.adminHelp")}
-        aboutItemLabel={t("apps.admin.menu.aboutAdmin")}
-        isMacOsxTheme={isMacOsxTheme}
-        onShowHelp={onShowHelp}
-        onShowAbout={onShowAbout}
-        onOpenShareDialog={() => setIsShareDialogOpen(true)}
-      />
-      <AppShareItemDialog
-        appId={appId}
-        appName={appName}
-        isOpen={isShareDialogOpen}
-        onClose={() => setIsShareDialogOpen(false)}
-      />
-    </MenuBar>
+    </AppMenuBarShell>
   );
 }

--- a/src/apps/admin/components/admin-app/AdminAppDialogs.tsx
+++ b/src/apps/admin/components/admin-app/AdminAppDialogs.tsx
@@ -1,7 +1,7 @@
 import type { ComponentProps } from "react";
 import { HelpDialog } from "@/components/dialogs/HelpDialog";
-import { AboutDialog } from "@/components/dialogs/AboutDialog";
 import { ConfirmDialog } from "@/components/dialogs/ConfirmDialog";
+import { AppHelpAboutDialogs } from "@/components/shared/AppHelpAboutDialogs";
 import { appMetadata } from "../..";
 import type { TFunction } from "i18next";
 
@@ -40,17 +40,14 @@ export function AdminAppDialogs({
 }: AdminAppDialogsProps) {
   return (
     <>
-      <HelpDialog
-        isOpen={isHelpDialogOpen}
-        onOpenChange={setIsHelpDialogOpen}
+      <AppHelpAboutDialogs
+        appId="admin"
         helpItems={translatedHelpItems}
-        appId="admin"
-      />
-      <AboutDialog
-        isOpen={isAboutDialogOpen}
-        onOpenChange={setIsAboutDialogOpen}
         metadata={appMetadata}
-        appId="admin"
+        isHelpOpen={isHelpDialogOpen}
+        onHelpOpenChange={setIsHelpDialogOpen}
+        isAboutOpen={isAboutDialogOpen}
+        onAboutOpenChange={setIsAboutDialogOpen}
       />
       <ConfirmDialog
         isOpen={isDeleteDialogOpen}

--- a/src/apps/admin/components/song-detail-panel/utils.ts
+++ b/src/apps/admin/components/song-detail-panel/utils.ts
@@ -1,16 +1,4 @@
-/**
- * Replace {size} placeholder in Kugou image URL with actual size.
- * Also ensures HTTPS is used to avoid mixed content issues.
- */
-export function formatKugouImageUrl(
-  imgUrl: string | undefined,
-  size: number = 400
-): string | null {
-  if (!imgUrl) return null;
-  let url = imgUrl.replace("{size}", String(size));
-  url = url.replace(/^http:\/\//, "https://");
-  return url;
-}
+export { formatKugouImageUrl } from "@/utils/coverArt";
 
 export function formatOffset(ms: number | undefined): string {
   if (ms === undefined) return "0ms";

--- a/src/apps/admin/index.ts
+++ b/src/apps/admin/index.ts
@@ -1,5 +1,5 @@
 import { BaseApp } from "../base/types";
-import { AdminAppComponent } from "./components/AdminAppComponent";
+import { AdminAppComponent } from "./components/admin-app/AdminAppComponent";
 
 // Re-export metadata from separate file to avoid eager loading of components
 export { appMetadata, helpItems } from "./metadata";

--- a/src/apps/applet-viewer/components/AppletViewerAppComponent.tsx
+++ b/src/apps/applet-viewer/components/AppletViewerAppComponent.tsx
@@ -1,7 +1,6 @@
 import { AppWindowShell } from "@/components/shared/AppWindowShell";
 import { AppProps } from "@/apps/base/types";
-import { HelpDialog } from "@/components/dialogs/HelpDialog";
-import { AboutDialog } from "@/components/dialogs/AboutDialog";
+import { AppHelpAboutDialogs } from "@/components/shared/AppHelpAboutDialogs";
 import { ShareItemDialog } from "@/components/dialogs/ShareItemDialog";
 import { LoginDialog } from "@/components/dialogs/LoginDialog";
 import { AppletViewerMenuBar } from "./AppletViewerMenuBar";
@@ -109,17 +108,14 @@ export function AppletViewerAppComponent({
       }}
       trailing={
         <>
-          <HelpDialog
-            isOpen={isHelpDialogOpen}
-            onOpenChange={setIsHelpDialogOpen}
+          <AppHelpAboutDialogs
             appId="applet-viewer"
             helpItems={translatedHelpItems}
-          />
-          <AboutDialog
-            isOpen={isAboutDialogOpen}
-            onOpenChange={setIsAboutDialogOpen}
             metadata={appMetadata}
-            appId="applet-viewer"
+            isHelpOpen={isHelpDialogOpen}
+            onHelpOpenChange={setIsHelpDialogOpen}
+            isAboutOpen={isAboutDialogOpen}
+            onAboutOpenChange={setIsAboutDialogOpen}
           />
           <ShareItemDialog
             isOpen={isShareDialogOpen}

--- a/src/apps/applet-viewer/components/AppletViewerMenuBar.tsx
+++ b/src/apps/applet-viewer/components/AppletViewerMenuBar.tsx
@@ -10,9 +10,8 @@ import {
   MenubarSubContent,
   MenubarCheckboxItem,
 } from "@/components/ui/menubar";
-import { MenuBar } from "@/components/layout/MenuBar";
-import { AppMenuBarHelpMenu } from "@/components/shared/menubar/AppMenuBarHelpMenu";
-import { AppShareItemDialog } from "@/components/shared/menubar/AppShareItemDialog";
+import { AppMenuBarShell } from "@/components/shared/menubar/AppMenuBarShell";
+import { MENUBAR_SEPARATOR_CLASS } from "@/components/shared/menubar/menubarStyles";
 import { useAppMenuBarChrome } from "@/hooks/useAppMenuBarChrome";
 import { useLaunchApp } from "@/hooks/useLaunchApp";
 import React from "react";
@@ -82,7 +81,18 @@ export function AppletViewerMenuBar({
   const isLoggedIn = !!(username && isAuthenticated);
 
   return (
-    <MenuBar inWindowFrame={isXpTheme}>
+    <AppMenuBarShell
+      isXpTheme={isXpTheme}
+      isMacOsxTheme={isMacOsxTheme}
+      appId={appId}
+      appName={appName}
+      isShareDialogOpen={isShareDialogOpen}
+      setIsShareDialogOpen={setIsShareDialogOpen}
+      helpItemLabel={t("apps.applet-viewer.menu.appletsHelp")}
+      aboutItemLabel={t("apps.applet-viewer.menu.aboutApplets")}
+      onShowHelp={onShowHelp}
+      onShowAbout={onShowAbout}
+    >
       <input
         type="file"
         ref={fileInputRef}
@@ -110,7 +120,7 @@ export function AppletViewerMenuBar({
               {t("apps.applet-viewer.menu.shareApplet")}
             </MenubarItem>
           )}
-          <MenubarSeparator className="h-[2px] bg-black my-1" />
+          <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
           <MenubarItem
             onClick={() => fileInputRef.current?.click()}
             className="text-md h-6 px-3"
@@ -138,7 +148,7 @@ export function AppletViewerMenuBar({
               </MenubarSubContent>
             </MenubarSub>
           )}
-          <MenubarSeparator className="h-[2px] bg-black my-1" />
+          <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
           <MenubarItem
             onClick={onClose}
             className="text-md h-6 px-3"
@@ -178,7 +188,7 @@ export function AppletViewerMenuBar({
                 : t("apps.applet-viewer.menu.updateAppletsPlural", { count: updateCount })
               : t("apps.applet-viewer.menu.checkForUpdates")}
           </MenubarItem>
-          <MenubarSeparator className="h-[2px] bg-black my-1" />
+          <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
           {username && isAuthenticated ? (
             <MenubarItem
               onClick={() => onLogout?.()}
@@ -243,21 +253,6 @@ export function AppletViewerMenuBar({
           )}
         </MenubarContent>
       </MenubarMenu>
-
-      <AppMenuBarHelpMenu
-        helpItemLabel={t("apps.applet-viewer.menu.appletsHelp")}
-        aboutItemLabel={t("apps.applet-viewer.menu.aboutApplets")}
-        isMacOsxTheme={isMacOsxTheme}
-        onShowHelp={onShowHelp}
-        onShowAbout={onShowAbout}
-        onOpenShareDialog={() => setIsShareDialogOpen(true)}
-      />
-      <AppShareItemDialog
-        appId={appId}
-        appName={appName}
-        isOpen={isShareDialogOpen}
-        onClose={() => setIsShareDialogOpen(false)}
-      />
-    </MenuBar>
+    </AppMenuBarShell>
   );
 }

--- a/src/apps/calendar/components/CalendarAppComponent.tsx
+++ b/src/apps/calendar/components/CalendarAppComponent.tsx
@@ -1,1 +1,0 @@
-export { CalendarAppComponent } from "./calendar-app/CalendarAppComponent";

--- a/src/apps/calendar/components/CalendarMenuBar.tsx
+++ b/src/apps/calendar/components/CalendarMenuBar.tsx
@@ -1,4 +1,3 @@
-import { MenuBar } from "@/components/layout/MenuBar";
 import {
   MenubarMenu,
   MenubarTrigger,
@@ -7,8 +6,7 @@ import {
   MenubarSeparator,
   MenubarCheckboxItem,
 } from "@/components/ui/menubar";
-import { AppMenuBarHelpMenu } from "@/components/shared/menubar/AppMenuBarHelpMenu";
-import { AppShareItemDialog } from "@/components/shared/menubar/AppShareItemDialog";
+import { AppMenuBarShell } from "@/components/shared/menubar/AppMenuBarShell";
 import {
   MENUBAR_ITEM_CLASS,
   MENUBAR_SEPARATOR_CLASS,
@@ -68,7 +66,18 @@ export function CalendarMenuBar({
   const { canUndo, canRedo, undo, redo } = useInstanceUndoRedo(instanceId || "");
 
   return (
-    <MenuBar inWindowFrame={isXpTheme}>
+    <AppMenuBarShell
+      isXpTheme={isXpTheme}
+      isMacOsxTheme={isMacOsxTheme}
+      appId={appId}
+      appName={appName}
+      isShareDialogOpen={isShareDialogOpen}
+      setIsShareDialogOpen={setIsShareDialogOpen}
+      helpItemLabel={t("apps.calendar.menu.help")}
+      aboutItemLabel={t("apps.calendar.menu.about")}
+      onShowHelp={onShowHelp}
+      onShowAbout={onShowAbout}
+    >
       <MenubarMenu>
         <MenubarTrigger className={MENUBAR_TRIGGER_CLASS}>
           {t("common.menu.file")}
@@ -183,21 +192,6 @@ export function CalendarMenuBar({
           </MenubarItem>
         </MenubarContent>
       </MenubarMenu>
-
-      <AppMenuBarHelpMenu
-        helpItemLabel={t("apps.calendar.menu.help")}
-        aboutItemLabel={t("apps.calendar.menu.about")}
-        isMacOsxTheme={isMacOsxTheme}
-        onShowHelp={onShowHelp}
-        onShowAbout={onShowAbout}
-        onOpenShareDialog={() => setIsShareDialogOpen(true)}
-      />
-      <AppShareItemDialog
-        appId={appId}
-        appName={appName}
-        isOpen={isShareDialogOpen}
-        onClose={() => setIsShareDialogOpen(false)}
-      />
-    </MenuBar>
+    </AppMenuBarShell>
   );
 }

--- a/src/apps/calendar/components/calendar-app/CalendarAppComponent.tsx
+++ b/src/apps/calendar/components/calendar-app/CalendarAppComponent.tsx
@@ -3,8 +3,7 @@ import { AppProps } from "@/apps/base/types";
 import { AppWindowShell } from "@/components/shared/AppWindowShell";
 import { CalendarMenuBar } from "../CalendarMenuBar";
 import { requestCloudSyncDomainCheck } from "@/utils/cloudSyncEvents";
-import { HelpDialog } from "@/components/dialogs/HelpDialog";
-import { AboutDialog } from "@/components/dialogs/AboutDialog";
+import { AppHelpAboutDialogs } from "@/components/shared/AppHelpAboutDialogs";
 import { appMetadata } from "../../metadata";
 import { useCalendarLogic } from "../../hooks/useCalendarLogic";
 import { DEFAULT_TIME_GRID_HOUR_HEIGHT } from "../../hooks/useTimeScaleGestures";
@@ -278,8 +277,15 @@ export function CalendarAppComponent({
       }}
       trailing={
         <>
-          <HelpDialog isOpen={isHelpDialogOpen} onOpenChange={setIsHelpDialogOpen} appId="calendar" helpItems={translatedHelpItems} />
-          <AboutDialog isOpen={isAboutDialogOpen} onOpenChange={setIsAboutDialogOpen} metadata={appMetadata} appId="calendar" />
+          <AppHelpAboutDialogs
+            appId="calendar"
+            helpItems={translatedHelpItems}
+            metadata={appMetadata}
+            isHelpOpen={isHelpDialogOpen}
+            onHelpOpenChange={setIsHelpDialogOpen}
+            isAboutOpen={isAboutDialogOpen}
+            onAboutOpenChange={setIsAboutDialogOpen}
+          />
           <input
             ref={fileInputRef}
             type="file"

--- a/src/apps/chats/components/ChatsAppComponent.tsx
+++ b/src/apps/chats/components/ChatsAppComponent.tsx
@@ -1,1 +1,0 @@
-export { ChatsAppComponent } from "./chats-app/ChatsAppComponent";

--- a/src/apps/chats/components/ChatsDialogs.tsx
+++ b/src/apps/chats/components/ChatsDialogs.tsx
@@ -1,6 +1,5 @@
 import { memo, useCallback, useMemo } from "react";
-import { HelpDialog } from "@/components/dialogs/HelpDialog";
-import { AboutDialog } from "@/components/dialogs/AboutDialog";
+import { AppHelpAboutDialogs } from "@/components/shared/AppHelpAboutDialogs";
 import { ConfirmDialog } from "@/components/dialogs/ConfirmDialog";
 import { InputDialog } from "@/components/dialogs/InputDialog";
 import { LoginDialog } from "@/components/dialogs/LoginDialog";
@@ -175,17 +174,14 @@ export const ChatsDialogs = memo(function ChatsDialogs({
 
   return (
     <>
-      <HelpDialog
-        isOpen={isHelpDialogOpen}
-        onOpenChange={setIsHelpDialogOpen}
+      <AppHelpAboutDialogs
+        appId="chats"
         helpItems={translatedHelpItems}
-        appId="chats"
-      />
-      <AboutDialog
-        isOpen={isAboutDialogOpen}
-        onOpenChange={setIsAboutDialogOpen}
         metadata={appMetadata}
-        appId="chats"
+        isHelpOpen={isHelpDialogOpen}
+        onHelpOpenChange={setIsHelpDialogOpen}
+        isAboutOpen={isAboutDialogOpen}
+        onAboutOpenChange={setIsAboutDialogOpen}
       />
       <ConfirmDialog
         isOpen={isClearDialogOpen}

--- a/src/apps/chats/components/ChatsMenuBar.tsx
+++ b/src/apps/chats/components/ChatsMenuBar.tsx
@@ -1,5 +1,4 @@
 import { memo, useCallback, useState } from "react";
-import { MenuBar } from "@/components/layout/MenuBar";
 import {
   MenubarMenu,
   MenubarTrigger,
@@ -13,8 +12,8 @@ import { useAudioSettingsStoreShallow } from "@/stores/helpers";
 import { SYNTH_PRESETS } from "@/hooks/useChatSynth";
 import { getPrivateRoomDisplayName } from "@/utils/chat";
 import { LoginDialog } from "@/components/dialogs/LoginDialog";
-import { AppMenuBarHelpMenu } from "@/components/shared/menubar/AppMenuBarHelpMenu";
-import { AppShareItemDialog } from "@/components/shared/menubar/AppShareItemDialog";
+import { AppMenuBarShell } from "@/components/shared/menubar/AppMenuBarShell";
+import { MENUBAR_SEPARATOR_CLASS } from "@/components/shared/menubar/menubarStyles";
 import { useAppMenuBarChrome } from "@/hooks/useAppMenuBarChrome";
 import { useTranslation } from "react-i18next";
 import { TelegramLinkDialog } from "@/components/dialogs/TelegramLinkDialog";
@@ -182,7 +181,18 @@ export const ChatsMenuBar = memo(function ChatsMenuBar({
 
   return (
     <>
-      <MenuBar inWindowFrame={isXpTheme}>
+      <AppMenuBarShell
+        isXpTheme={isXpTheme}
+        isMacOsxTheme={isMacOsxTheme}
+        appId={appId}
+        appName={appName}
+        isShareDialogOpen={isShareDialogOpen}
+        setIsShareDialogOpen={setIsShareDialogOpen}
+        helpItemLabel={t("apps.chats.menu.chatsHelp")}
+        aboutItemLabel={t("apps.chats.menu.aboutChats")}
+        onShowHelp={onShowHelp}
+        onShowAbout={onShowAbout}
+      >
         {/* File Menu */}
         <MenubarMenu>
           <MenubarTrigger className="text-md px-2 py-1 border-none focus-visible:ring-0">
@@ -202,7 +212,7 @@ export const ChatsMenuBar = memo(function ChatsMenuBar({
             >
               {t("apps.chats.menu.clearChat")}
             </MenubarItem>
-            <MenubarSeparator className="h-[2px] bg-black my-1" />
+            <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
 
             {/* Account Section */}
             {username && isAuthenticated ? (
@@ -238,7 +248,7 @@ export const ChatsMenuBar = memo(function ChatsMenuBar({
               </>
             )}
 
-            <MenubarSeparator className="h-[2px] bg-black my-1" />
+            <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
             <MenubarItem
               onClick={onClose}
               className="text-md h-6 px-3"
@@ -268,7 +278,7 @@ export const ChatsMenuBar = memo(function ChatsMenuBar({
 
             {/* Show separator between menu actions and chat list */}
             {rooms.length > 0 && (
-              <MenubarSeparator className="h-[2px] bg-black my-1" />
+              <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
             )}
 
             {/* Ryo Chat Option */}
@@ -330,7 +340,7 @@ export const ChatsMenuBar = memo(function ChatsMenuBar({
                 {preset.name}
               </MenubarCheckboxItem>
             ))}
-            <MenubarSeparator className="h-[2px] bg-black my-1" />
+            <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
             <MenubarCheckboxItem
               checked={speechEnabled}
               onCheckedChange={(checked) => setSpeechEnabled(checked)}
@@ -345,7 +355,7 @@ export const ChatsMenuBar = memo(function ChatsMenuBar({
             >
               {t("apps.chats.menu.typingSynth")}
             </MenubarCheckboxItem>
-            <MenubarSeparator className="h-[2px] bg-black my-1" />
+            <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
             <MenubarCheckboxItem
               checked={keepTalkingEnabled}
               onCheckedChange={(checked) => setKeepTalkingEnabled(checked)}
@@ -375,14 +385,14 @@ export const ChatsMenuBar = memo(function ChatsMenuBar({
             >
               {t("apps.chats.menu.decreaseFontSize")}
             </MenubarItem>
-            <MenubarSeparator className="h-[2px] bg-black my-1" />
+            <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
             <MenubarItem
               onClick={onResetFontSize}
               className="text-md h-6 px-3"
             >
               {t("apps.chats.menu.resetFontSize")}
             </MenubarItem>
-            <MenubarSeparator className="h-[2px] bg-black my-1" />
+            <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
             {/* Sidebar Toggle */}
             <MenubarCheckboxItem
               checked={isSidebarVisible}
@@ -395,7 +405,7 @@ export const ChatsMenuBar = memo(function ChatsMenuBar({
             </MenubarCheckboxItem>
             {isNotificationApiAvailable() && (
               <>
-                <MenubarSeparator className="h-[2px] bg-black my-1" />
+                <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
                 <MenubarCheckboxItem
                   checked={notificationPermission === "granted"}
                   disabled={notificationPermission === "denied"}
@@ -412,16 +422,7 @@ export const ChatsMenuBar = memo(function ChatsMenuBar({
             )}
           </MenubarContent>
         </MenubarMenu>
-
-        <AppMenuBarHelpMenu
-          helpItemLabel={t("apps.chats.menu.chatsHelp")}
-          aboutItemLabel={t("apps.chats.menu.aboutChats")}
-          isMacOsxTheme={isMacOsxTheme}
-          onShowHelp={onShowHelp}
-          onShowAbout={onShowAbout}
-          onOpenShareDialog={() => setIsShareDialogOpen(true)}
-        />
-      </MenuBar>
+      </AppMenuBarShell>
 
       {/* Log In / Sign Up Dialog */}
       <LoginDialog
@@ -443,12 +444,6 @@ export const ChatsMenuBar = memo(function ChatsMenuBar({
         onSignUpSubmit={handleSignUpSubmit}
         isSignUpLoading={false}
         signUpError={null}
-      />
-      <AppShareItemDialog
-        appId={appId}
-        appName={appName}
-        isOpen={isShareDialogOpen}
-        onClose={() => setIsShareDialogOpen(false)}
       />
       <TelegramLinkDialog
         isOpen={isTelegramDialogOpen}

--- a/src/apps/chats/index.tsx
+++ b/src/apps/chats/index.tsx
@@ -1,5 +1,5 @@
 import { BaseApp } from "../base/types";
-import { ChatsAppComponent } from "./components/ChatsAppComponent";
+import { ChatsAppComponent } from "./components/chats-app/ChatsAppComponent";
 
 // Re-export metadata from separate file to avoid eager loading of components
 export { appMetadata, helpItems } from "./metadata";

--- a/src/apps/chats/tools/tvHandler.ts
+++ b/src/apps/chats/tools/tvHandler.ts
@@ -20,6 +20,7 @@ import {
 import type { Video } from "@/stores/useVideoStore";
 import { isYouTubeUrl, parseYouTubeId } from "@/apps/tv/utils";
 import { abortableFetch } from "@/utils/abortableFetch";
+import { fetchYouTubeOembed } from "@/utils/youtubeMetadata";
 import { getApiUrl } from "@/utils/platform";
 import { createShortIdMap, resolveId, type ShortIdMap } from "./helpers";
 
@@ -80,21 +81,11 @@ const extractVideoId = (input: string): string | null => parseYouTubeId(input);
 const fetchVideoMetadata = async (
   videoId: string
 ): Promise<{ title: string; artist?: string }> => {
-  const youtubeUrl = `https://www.youtube.com/watch?v=${videoId}`;
   try {
-    const oembedUrl = `https://www.youtube.com/oembed?url=${encodeURIComponent(
-      youtubeUrl
-    )}&format=json`;
-    const res = await abortableFetch(oembedUrl, {
-      timeout: 12000,
-      throwOnHttpError: false,
-      credentials: "omit",
-      retry: { maxAttempts: 1, initialDelayMs: 250 },
-    });
-    if (res.ok) {
-      const data = (await res.json()) as { title?: string; author_name?: string };
-      const rawTitle = data.title || `Video ID: ${videoId}`;
-      const authorName = data.author_name;
+    const oembed = await fetchYouTubeOembed(videoId);
+    if (oembed.ok) {
+      const rawTitle = oembed.rawTitle || `Video ID: ${videoId}`;
+      const authorName = oembed.authorName;
 
       // Best-effort AI title parse for cleaner title/artist split — if it
       // fails, we just keep the oEmbed values (still better than nothing).

--- a/src/apps/contacts/components/ContactsAppComponent.tsx
+++ b/src/apps/contacts/components/ContactsAppComponent.tsx
@@ -1,1 +1,0 @@
-export { ContactsAppComponent } from "./contacts-app/ContactsAppComponent";

--- a/src/apps/contacts/components/ContactsMenuBar.tsx
+++ b/src/apps/contacts/components/ContactsMenuBar.tsx
@@ -1,4 +1,3 @@
-import { MenuBar } from "@/components/layout/MenuBar";
 import {
   MenubarCheckboxItem,
   MenubarContent,
@@ -7,8 +6,7 @@ import {
   MenubarSeparator,
   MenubarTrigger,
 } from "@/components/ui/menubar";
-import { AppMenuBarHelpMenu } from "@/components/shared/menubar/AppMenuBarHelpMenu";
-import { AppShareItemDialog } from "@/components/shared/menubar/AppShareItemDialog";
+import { AppMenuBarShell } from "@/components/shared/menubar/AppMenuBarShell";
 import {
   MENUBAR_ITEM_CLASS,
   MENUBAR_SEPARATOR_CLASS,
@@ -52,7 +50,18 @@ export function ContactsMenuBar({
   } = useAppMenuBarChrome("contacts");
 
   return (
-    <MenuBar inWindowFrame={isXpTheme}>
+    <AppMenuBarShell
+      isXpTheme={isXpTheme}
+      isMacOsxTheme={isMacOsxTheme}
+      appId={appId}
+      appName={appName}
+      isShareDialogOpen={isShareDialogOpen}
+      setIsShareDialogOpen={setIsShareDialogOpen}
+      helpItemLabel={t("apps.contacts.menu.help")}
+      aboutItemLabel={t("apps.contacts.menu.about")}
+      onShowHelp={onShowHelp}
+      onShowAbout={onShowAbout}
+    >
       <MenubarMenu>
         <MenubarTrigger className={MENUBAR_TRIGGER_CLASS}>
           {t("common.menu.file")}
@@ -103,21 +112,6 @@ export function ContactsMenuBar({
           </MenubarItem>
         </MenubarContent>
       </MenubarMenu>
-
-      <AppMenuBarHelpMenu
-        helpItemLabel={t("apps.contacts.menu.help")}
-        aboutItemLabel={t("apps.contacts.menu.about")}
-        isMacOsxTheme={isMacOsxTheme}
-        onShowHelp={onShowHelp}
-        onShowAbout={onShowAbout}
-        onOpenShareDialog={() => setIsShareDialogOpen(true)}
-      />
-      <AppShareItemDialog
-        appId={appId}
-        appName={appName}
-        isOpen={isShareDialogOpen}
-        onClose={() => setIsShareDialogOpen(false)}
-      />
-    </MenuBar>
+    </AppMenuBarShell>
   );
 }

--- a/src/apps/contacts/components/contacts-app/ContactsAppDialogs.tsx
+++ b/src/apps/contacts/components/contacts-app/ContactsAppDialogs.tsx
@@ -1,5 +1,4 @@
-import { AboutDialog } from "@/components/dialogs/AboutDialog";
-import { HelpDialog } from "@/components/dialogs/HelpDialog";
+import { AppHelpAboutDialogs } from "@/components/shared/AppHelpAboutDialogs";
 import { appMetadata } from "../../";
 import { UserPicturePicker } from "../UserPicturePicker";
 import type { ContactsAppController } from "./useContactsAppController";
@@ -25,17 +24,14 @@ export function ContactsAppDialogs({ c }: ContactsAppDialogsProps) {
 
   return (
     <>
-      <HelpDialog
-        isOpen={isHelpDialogOpen}
-        onOpenChange={setIsHelpDialogOpen}
+      <AppHelpAboutDialogs
         appId="contacts"
         helpItems={translatedHelpItems}
-      />
-      <AboutDialog
-        isOpen={isAboutDialogOpen}
-        onOpenChange={setIsAboutDialogOpen}
         metadata={appMetadata}
-        appId="contacts"
+        isHelpOpen={isHelpDialogOpen}
+        onHelpOpenChange={setIsHelpDialogOpen}
+        isAboutOpen={isAboutDialogOpen}
+        onAboutOpenChange={setIsAboutDialogOpen}
       />
       <UserPicturePicker
         isOpen={isPicturePickerOpen}

--- a/src/apps/control-panels/components/ControlPanelsAppComponent.tsx
+++ b/src/apps/control-panels/components/ControlPanelsAppComponent.tsx
@@ -1,1 +1,0 @@
-export { ControlPanelsAppComponent } from "./control-panels-app/ControlPanelsAppComponent";

--- a/src/apps/control-panels/components/ControlPanelsMenuBar.tsx
+++ b/src/apps/control-panels/components/ControlPanelsMenuBar.tsx
@@ -1,12 +1,10 @@
-import { MenuBar } from "@/components/layout/MenuBar";
 import {
   MenubarMenu,
   MenubarTrigger,
   MenubarContent,
   MenubarItem,
 } from "@/components/ui/menubar";
-import { AppMenuBarHelpMenu } from "@/components/shared/menubar/AppMenuBarHelpMenu";
-import { AppShareItemDialog } from "@/components/shared/menubar/AppShareItemDialog";
+import { AppMenuBarShell } from "@/components/shared/menubar/AppMenuBarShell";
 import { useAppMenuBarChrome } from "@/hooks/useAppMenuBarChrome";
 import { useTranslation } from "react-i18next";
 
@@ -32,7 +30,18 @@ export function ControlPanelsMenuBar({
   } = useAppMenuBarChrome("control-panels");
 
   return (
-    <MenuBar inWindowFrame={isXpTheme}>
+    <AppMenuBarShell
+      isXpTheme={isXpTheme}
+      isMacOsxTheme={isMacOsxTheme}
+      appId={appId}
+      appName={appName}
+      isShareDialogOpen={isShareDialogOpen}
+      setIsShareDialogOpen={setIsShareDialogOpen}
+      helpItemLabel={t("apps.control-panels.menu.controlPanelsHelp")}
+      aboutItemLabel={t("apps.control-panels.menu.aboutControlPanels")}
+      onShowHelp={onShowHelp}
+      onShowAbout={onShowAbout}
+    >
       <MenubarMenu>
         <MenubarTrigger className="text-md px-2 py-1 border-none focus-visible:ring-0">
           {t("common.menu.file")}
@@ -46,21 +55,6 @@ export function ControlPanelsMenuBar({
           </MenubarItem>
         </MenubarContent>
       </MenubarMenu>
-
-      <AppMenuBarHelpMenu
-        helpItemLabel={t("apps.control-panels.menu.controlPanelsHelp")}
-        aboutItemLabel={t("apps.control-panels.menu.aboutControlPanels")}
-        isMacOsxTheme={isMacOsxTheme}
-        onShowHelp={onShowHelp}
-        onShowAbout={onShowAbout}
-        onOpenShareDialog={() => setIsShareDialogOpen(true)}
-      />
-      <AppShareItemDialog
-        appId={appId}
-        appName={appName}
-        isOpen={isShareDialogOpen}
-        onClose={() => setIsShareDialogOpen(false)}
-      />
-    </MenuBar>
+    </AppMenuBarShell>
   );
 }

--- a/src/apps/control-panels/components/control-panels-app/ControlPanelsDialogs.tsx
+++ b/src/apps/control-panels/components/control-panels-app/ControlPanelsDialogs.tsx
@@ -1,5 +1,4 @@
-import { HelpDialog } from "@/components/dialogs/HelpDialog";
-import { AboutDialog } from "@/components/dialogs/AboutDialog";
+import { AppHelpAboutDialogs } from "@/components/shared/AppHelpAboutDialogs";
 import { ConfirmDialog } from "@/components/dialogs/ConfirmDialog";
 import { LoginDialog } from "@/components/dialogs/LoginDialog";
 import { ChangePasswordDialog } from "@/components/dialogs/ChangePasswordDialog";
@@ -151,17 +150,14 @@ export function ControlPanelsDialogs(props: ControlPanelsDialogsProps) {
 
   return (
     <>
-      <HelpDialog
-        isOpen={isHelpDialogOpen}
-        onOpenChange={setIsHelpDialogOpen}
+      <AppHelpAboutDialogs
+        appId="control-panels"
         helpItems={translatedHelpItems}
-        appId="control-panels"
-      />
-      <AboutDialog
-        isOpen={isAboutDialogOpen}
-        onOpenChange={setIsAboutDialogOpen}
         metadata={appMetadata}
-        appId="control-panels"
+        isHelpOpen={isHelpDialogOpen}
+        onHelpOpenChange={setIsHelpDialogOpen}
+        isAboutOpen={isAboutDialogOpen}
+        onAboutOpenChange={setIsAboutDialogOpen}
       />
       <ConfirmDialog
         isOpen={isConfirmResetOpen}

--- a/src/apps/dashboard/components/DashboardAppComponent.tsx
+++ b/src/apps/dashboard/components/DashboardAppComponent.tsx
@@ -3,8 +3,7 @@ import { createPortal } from "react-dom";
 import { motion, AnimatePresence } from "framer-motion";
 import { AppProps } from "@/apps/base/types";
 import { AppWindowShell } from "@/components/shared/AppWindowShell";
-import { HelpDialog } from "@/components/dialogs/HelpDialog";
-import { AboutDialog } from "@/components/dialogs/AboutDialog";
+import { AppHelpAboutDialogs } from "@/components/shared/AppHelpAboutDialogs";
 import { appMetadata } from "../metadata";
 import { useDashboardLogic } from "../hooks/useDashboardLogic";
 import { WidgetChrome } from "@/components/layout/dashboard/WidgetChrome";
@@ -385,17 +384,14 @@ export function DashboardAppComponent({
       menuBar={menuBar}
       trailing={
         <>
-          <HelpDialog
-            isOpen={isHelpDialogOpen}
-            onOpenChange={setIsHelpDialogOpen}
+          <AppHelpAboutDialogs
             appId="dashboard"
             helpItems={translatedHelpItems}
-          />
-          <AboutDialog
-            isOpen={isAboutDialogOpen}
-            onOpenChange={setIsAboutDialogOpen}
             metadata={appMetadata}
-            appId="dashboard"
+            isHelpOpen={isHelpDialogOpen}
+            onHelpOpenChange={setIsHelpDialogOpen}
+            isAboutOpen={isAboutDialogOpen}
+            onAboutOpenChange={setIsAboutDialogOpen}
           />
         </>
       }

--- a/src/apps/dashboard/components/DashboardMenuBar.tsx
+++ b/src/apps/dashboard/components/DashboardMenuBar.tsx
@@ -1,4 +1,3 @@
-import { MenuBar } from "@/components/layout/MenuBar";
 import {
   MenubarMenu,
   MenubarTrigger,
@@ -9,8 +8,7 @@ import {
   MenubarSubTrigger,
   MenubarSubContent,
 } from "@/components/ui/menubar";
-import { AppMenuBarHelpMenu } from "@/components/shared/menubar/AppMenuBarHelpMenu";
-import { AppShareItemDialog } from "@/components/shared/menubar/AppShareItemDialog";
+import { AppMenuBarShell } from "@/components/shared/menubar/AppMenuBarShell";
 import {
   MENUBAR_ITEM_CLASS,
   MENUBAR_SEPARATOR_CLASS,
@@ -69,7 +67,18 @@ export function DashboardMenuBar({
   } = useAppMenuBarChrome("dashboard");
 
   return (
-    <MenuBar inWindowFrame={isXpTheme}>
+    <AppMenuBarShell
+      isXpTheme={isXpTheme}
+      isMacOsxTheme={isMacOsxTheme}
+      appId={appId}
+      appName={appName}
+      isShareDialogOpen={isShareDialogOpen}
+      setIsShareDialogOpen={setIsShareDialogOpen}
+      helpItemLabel={t("apps.dashboard.menu.help")}
+      aboutItemLabel={t("apps.dashboard.menu.about")}
+      onShowHelp={onShowHelp}
+      onShowAbout={onShowAbout}
+    >
       <MenubarMenu>
         <MenubarTrigger className={MENUBAR_TRIGGER_CLASS}>
           {t("common.menu.file")}
@@ -148,21 +157,6 @@ export function DashboardMenuBar({
           </MenubarItem>
         </MenubarContent>
       </MenubarMenu>
-
-      <AppMenuBarHelpMenu
-        helpItemLabel={t("apps.dashboard.menu.help")}
-        aboutItemLabel={t("apps.dashboard.menu.about")}
-        isMacOsxTheme={isMacOsxTheme}
-        onShowHelp={onShowHelp}
-        onShowAbout={onShowAbout}
-        onOpenShareDialog={() => setIsShareDialogOpen(true)}
-      />
-      <AppShareItemDialog
-        appId={appId}
-        appName={appName}
-        isOpen={isShareDialogOpen}
-        onClose={() => setIsShareDialogOpen(false)}
-      />
-    </MenuBar>
+    </AppMenuBarShell>
   );
 }

--- a/src/apps/finder/components/FinderAppComponent.tsx
+++ b/src/apps/finder/components/FinderAppComponent.tsx
@@ -1,1 +1,0 @@
-export { FinderAppComponent } from "./finder-app/FinderAppComponent";

--- a/src/apps/finder/components/FinderMenuBar.tsx
+++ b/src/apps/finder/components/FinderMenuBar.tsx
@@ -1,4 +1,3 @@
-import { MenuBar } from "@/components/layout/MenuBar";
 import {
   MenubarMenu,
   MenubarTrigger,
@@ -7,8 +6,8 @@ import {
   MenubarSeparator,
   MenubarCheckboxItem,
 } from "@/components/ui/menubar";
-import { AppMenuBarHelpMenu } from "@/components/shared/menubar/AppMenuBarHelpMenu";
-import { AppShareItemDialog } from "@/components/shared/menubar/AppShareItemDialog";
+import { AppMenuBarShell } from "@/components/shared/menubar/AppMenuBarShell";
+import { MENUBAR_SEPARATOR_CLASS } from "@/components/shared/menubar/menubarStyles";
 import { useAppMenuBarChrome } from "@/hooks/useAppMenuBarChrome";
 import { FileItem } from "./FileList";
 import { ThemedIcon } from "@/components/shared/ThemedIcon";
@@ -106,7 +105,18 @@ export function FinderMenuBar({
   const canDuplicate = selectedFile && onDuplicate && !selectedFile.isDirectory;
 
   return (
-    <MenuBar inWindowFrame={isXpTheme}>
+    <AppMenuBarShell
+      isXpTheme={isXpTheme}
+      isMacOsxTheme={isMacOsxTheme}
+      appId={appId}
+      appName={appName}
+      isShareDialogOpen={isShareDialogOpen}
+      setIsShareDialogOpen={setIsShareDialogOpen}
+      helpItemLabel={t("apps.finder.menu.finderHelp")}
+      aboutItemLabel={t("apps.finder.menu.aboutFinder")}
+      onShowHelp={onShowHelp}
+      onShowAbout={onShowAbout}
+    >
       {/* File Menu */}
       <MenubarMenu>
         <MenubarTrigger className="text-md px-2 py-1 border-none focus-visible:ring-0">
@@ -132,7 +142,7 @@ export function FinderMenuBar({
           >
             {t("apps.finder.menu.importFromDevice")}
           </MenubarItem>
-          <MenubarSeparator className="h-[2px] bg-black my-1" />
+          <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
           <MenubarItem
             onClick={onRename}
             disabled={!canRename}
@@ -147,7 +157,7 @@ export function FinderMenuBar({
           >
             {t("apps.finder.menu.duplicate")}
           </MenubarItem>
-          <MenubarSeparator className="h-[2px] bg-black my-1" />
+          <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
           {isInTrash ? (
             <MenubarItem
               onClick={onRestore}
@@ -171,7 +181,7 @@ export function FinderMenuBar({
           >
             {t("apps.finder.menu.emptyTrash")}
           </MenubarItem>
-          <MenubarSeparator className="h-[2px] bg-black my-1" />
+          <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
           <MenubarItem
             onClick={onClose}
             className="text-md h-6 px-3"
@@ -201,7 +211,7 @@ export function FinderMenuBar({
           >
             {t("common.menu.redo")}
           </MenubarItem>
-          <MenubarSeparator className="h-[2px] bg-black my-1" />
+          <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
           <MenubarItem className="text-md h-6 px-3">
             {t("common.menu.cut")}
           </MenubarItem>
@@ -214,7 +224,7 @@ export function FinderMenuBar({
           <MenubarItem className="text-md h-6 px-3">
             {t("common.menu.clear")}
           </MenubarItem>
-          <MenubarSeparator className="h-[2px] bg-black my-1" />
+          <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
           <MenubarItem className="text-md h-6 px-3">
             {t("common.menu.selectAll")}
           </MenubarItem>
@@ -236,7 +246,7 @@ export function FinderMenuBar({
               >
                 {t("apps.finder.menu.sidebar")}
               </MenubarCheckboxItem>
-              <MenubarSeparator className="h-[2px] bg-black my-1" />
+              <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
             </>
           )}
           <MenubarCheckboxItem
@@ -266,7 +276,7 @@ export function FinderMenuBar({
           >
             {t("apps.finder.menu.byList")}
           </MenubarCheckboxItem>
-          <MenubarSeparator className="h-[2px] bg-black my-1" />
+          <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
           <MenubarCheckboxItem
             checked={sortType === "name"}
             onCheckedChange={(checked) => {
@@ -326,7 +336,7 @@ export function FinderMenuBar({
           >
             {t("apps.finder.menu.forward")}
           </MenubarItem>
-          <MenubarSeparator className="h-[2px] bg-black my-1" />
+          <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
           <MenubarItem
             onClick={onNavigateToAirDrop}
             className="text-md h-6 px-3 flex items-center gap-2"
@@ -338,7 +348,7 @@ export function FinderMenuBar({
             />
             {t("apps.finder.airdrop.title")}
           </MenubarItem>
-          <MenubarSeparator className="h-[2px] bg-black my-1" />
+          <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
 
           {/* Root directory folders */}
           {rootFolders?.map((folder) => (
@@ -374,21 +384,6 @@ export function FinderMenuBar({
           </MenubarItem>
         </MenubarContent>
       </MenubarMenu>
-
-      <AppMenuBarHelpMenu
-        helpItemLabel={t("apps.finder.menu.finderHelp")}
-        aboutItemLabel={t("apps.finder.menu.aboutFinder")}
-        isMacOsxTheme={isMacOsxTheme}
-        onShowHelp={onShowHelp}
-        onShowAbout={onShowAbout}
-        onOpenShareDialog={() => setIsShareDialogOpen(true)}
-      />
-      <AppShareItemDialog
-        appId={appId}
-        appName={appName}
-        isOpen={isShareDialogOpen}
-        onClose={() => setIsShareDialogOpen(false)}
-      />
-    </MenuBar>
+    </AppMenuBarShell>
   );
 }

--- a/src/apps/finder/components/finder-app/FinderAppDialogs.tsx
+++ b/src/apps/finder/components/finder-app/FinderAppDialogs.tsx
@@ -1,6 +1,6 @@
 import type { ComponentProps } from "react";
 import { HelpDialog } from "@/components/dialogs/HelpDialog";
-import { AboutDialog } from "@/components/dialogs/AboutDialog";
+import { AppHelpAboutDialogs } from "@/components/shared/AppHelpAboutDialogs";
 import { ConfirmDialog } from "@/components/dialogs/ConfirmDialog";
 import { InputDialog } from "@/components/dialogs/InputDialog";
 import { LoginDialog } from "@/components/dialogs/LoginDialog";
@@ -107,17 +107,14 @@ export function FinderAppDialogs({
 }: FinderAppDialogsProps) {
   return (
     <>
-      <HelpDialog
-        isOpen={isHelpDialogOpen}
-        onOpenChange={setIsHelpDialogOpen}
+      <AppHelpAboutDialogs
         appId="finder"
         helpItems={translatedHelpItems}
-      />
-      <AboutDialog
-        isOpen={isAboutDialogOpen}
-        onOpenChange={setIsAboutDialogOpen}
         metadata={appMetadata}
-        appId="finder"
+        isHelpOpen={isHelpDialogOpen}
+        onHelpOpenChange={setIsHelpDialogOpen}
+        isAboutOpen={isAboutDialogOpen}
+        onAboutOpenChange={setIsAboutDialogOpen}
       />
       <ConfirmDialog
         isOpen={isEmptyTrashDialogOpen}

--- a/src/apps/finder/hooks/useFileSystem.ts
+++ b/src/apps/finder/hooks/useFileSystem.ts
@@ -18,7 +18,7 @@ import {
   useIpodStoreShallow,
   useVideoStoreShallow,
 } from "@/stores/helpers";
-import { formatKugouImageUrl } from "@/apps/ipod/constants";
+import { formatKugouImageUrl } from "@/utils/coverArt";
 import { abortableFetch } from "@/utils/abortableFetch";
 import { getStoreForFile } from "@/utils/indexedDBOperations";
 import {

--- a/src/apps/finder/index.ts
+++ b/src/apps/finder/index.ts
@@ -1,5 +1,5 @@
 import { BaseApp, FinderInitialData } from "../base/types";
-import { FinderAppComponent } from "./components/FinderAppComponent";
+import { FinderAppComponent } from "./components/finder-app/FinderAppComponent";
 
 // Re-export metadata from separate file to avoid eager loading of components
 export { appMetadata, helpItems } from "./metadata";

--- a/src/apps/infinite-mac/components/InfiniteMacAppComponent.tsx
+++ b/src/apps/infinite-mac/components/InfiniteMacAppComponent.tsx
@@ -1,8 +1,7 @@
 import { useState } from "react";
 import { AppProps } from "@/apps/base/types";
 import { AppWindowShell } from "@/components/shared/AppWindowShell";
-import { HelpDialog } from "@/components/dialogs/HelpDialog";
-import { AboutDialog } from "@/components/dialogs/AboutDialog";
+import { AppHelpAboutDialogs } from "@/components/shared/AppHelpAboutDialogs";
 import { appMetadata } from "../metadata";
 import { motion } from "framer-motion";
 import { useInfiniteMacLogic } from "../hooks/useInfiniteMacLogic";
@@ -247,17 +246,14 @@ export function InfiniteMacAppComponent({
             )}
           </div>
         </div>
-        <HelpDialog
-          isOpen={isHelpDialogOpen}
-          onOpenChange={setIsHelpDialogOpen}
+        <AppHelpAboutDialogs
+          appId="infinite-mac"
           helpItems={translatedHelpItems}
-          appId="infinite-mac"
-        />
-        <AboutDialog
-          isOpen={isAboutDialogOpen}
-          onOpenChange={setIsAboutDialogOpen}
           metadata={appMetadata}
-          appId="infinite-mac"
+          isHelpOpen={isHelpDialogOpen}
+          onHelpOpenChange={setIsHelpDialogOpen}
+          isAboutOpen={isAboutDialogOpen}
+          onAboutOpenChange={setIsAboutDialogOpen}
         />
     </AppWindowShell>
   );

--- a/src/apps/infinite-mac/components/InfiniteMacMenuBar.tsx
+++ b/src/apps/infinite-mac/components/InfiniteMacMenuBar.tsx
@@ -1,4 +1,3 @@
-import { MenuBar } from "@/components/layout/MenuBar";
 import {
   MenubarMenu,
   MenubarTrigger,
@@ -10,8 +9,7 @@ import {
   MenubarSubContent,
   MenubarCheckboxItem,
 } from "@/components/ui/menubar";
-import { AppMenuBarHelpMenu } from "@/components/shared/menubar/AppMenuBarHelpMenu";
-import { AppShareItemDialog } from "@/components/shared/menubar/AppShareItemDialog";
+import { AppMenuBarShell } from "@/components/shared/menubar/AppMenuBarShell";
 import {
   MENUBAR_ITEM_CLASS,
   MENUBAR_SEPARATOR_CLASS,
@@ -59,7 +57,18 @@ export function InfiniteMacMenuBar({
   } = useAppMenuBarChrome("infinite-mac");
 
   return (
-    <MenuBar inWindowFrame={isXpTheme}>
+    <AppMenuBarShell
+      isXpTheme={isXpTheme}
+      isMacOsxTheme={isMacOsxTheme}
+      appId={appId}
+      appName={appName}
+      isShareDialogOpen={isShareDialogOpen}
+      setIsShareDialogOpen={setIsShareDialogOpen}
+      helpItemLabel={t("apps.infinite-mac.menu.infiniteMacHelp")}
+      aboutItemLabel={t("apps.infinite-mac.menu.aboutInfiniteMac")}
+      onShowHelp={onShowHelp}
+      onShowAbout={onShowAbout}
+    >
       <MenubarMenu>
         <MenubarTrigger className={MENUBAR_TRIGGER_CLASS}>
           {t("common.menu.file")}
@@ -131,21 +140,6 @@ export function InfiniteMacMenuBar({
           </MenubarItem>
         </MenubarContent>
       </MenubarMenu>
-
-      <AppMenuBarHelpMenu
-        helpItemLabel={t("apps.infinite-mac.menu.infiniteMacHelp")}
-        aboutItemLabel={t("apps.infinite-mac.menu.aboutInfiniteMac")}
-        isMacOsxTheme={isMacOsxTheme}
-        onShowHelp={onShowHelp}
-        onShowAbout={onShowAbout}
-        onOpenShareDialog={() => setIsShareDialogOpen(true)}
-      />
-      <AppShareItemDialog
-        appId={appId}
-        appName={appName}
-        isOpen={isShareDialogOpen}
-        onClose={() => setIsShareDialogOpen(false)}
-      />
-    </MenuBar>
+    </AppMenuBarShell>
   );
 }

--- a/src/apps/infinite-pc/components/InfinitePcAppComponent.tsx
+++ b/src/apps/infinite-pc/components/InfinitePcAppComponent.tsx
@@ -2,8 +2,7 @@ import { useCallback, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { AppProps } from "@/apps/base/types";
 import { AppWindowShell } from "@/components/shared/AppWindowShell";
-import { HelpDialog } from "@/components/dialogs/HelpDialog";
-import { AboutDialog } from "@/components/dialogs/AboutDialog";
+import { AppHelpAboutDialogs } from "@/components/shared/AppHelpAboutDialogs";
 import { ConfirmDialog } from "@/components/dialogs/ConfirmDialog";
 import { appMetadata } from "../metadata";
 import { motion } from "framer-motion";
@@ -412,17 +411,14 @@ export function InfinitePcAppComponent({
             ) : null}
           </div>
         </div>
-        <HelpDialog
-          isOpen={isHelpDialogOpen}
-          onOpenChange={setIsHelpDialogOpen}
+        <AppHelpAboutDialogs
+          appId="pc"
           helpItems={translatedHelpItems}
-          appId="pc"
-        />
-        <AboutDialog
-          isOpen={isAboutDialogOpen}
-          onOpenChange={setIsAboutDialogOpen}
           metadata={appMetadata}
-          appId="pc"
+          isHelpOpen={isHelpDialogOpen}
+          onHelpOpenChange={setIsHelpDialogOpen}
+          isAboutOpen={isAboutDialogOpen}
+          onAboutOpenChange={setIsAboutDialogOpen}
         />
         <ConfirmDialog
           isOpen={isResetDialogOpen}

--- a/src/apps/infinite-pc/components/InfinitePcMenuBar.tsx
+++ b/src/apps/infinite-pc/components/InfinitePcMenuBar.tsx
@@ -1,4 +1,3 @@
-import { MenuBar } from "@/components/layout/MenuBar";
 import {
   MenubarMenu,
   MenubarTrigger,
@@ -9,8 +8,8 @@ import {
   MenubarSubTrigger,
   MenubarSubContent,
 } from "@/components/ui/menubar";
-import { AppMenuBarHelpMenu } from "@/components/shared/menubar/AppMenuBarHelpMenu";
-import { AppShareItemDialog } from "@/components/shared/menubar/AppShareItemDialog";
+import { AppMenuBarShell } from "@/components/shared/menubar/AppMenuBarShell";
+import { MENUBAR_SEPARATOR_CLASS } from "@/components/shared/menubar/menubarStyles";
 import { useAppMenuBarChrome } from "@/hooks/useAppMenuBarChrome";
 import { useTranslation } from "react-i18next";
 import { Game, loadGames } from "@/stores/usePcStore";
@@ -78,7 +77,18 @@ export function InfinitePcMenuBar({
 
   if (isGameRunning && selectedGame && onLoadGame && onReset) {
     return (
-      <MenuBar inWindowFrame={isXpTheme}>
+      <AppMenuBarShell
+        isXpTheme={isXpTheme}
+        isMacOsxTheme={isMacOsxTheme}
+        appId={appId}
+        appName={appName}
+        isShareDialogOpen={isShareDialogOpen}
+        setIsShareDialogOpen={setIsShareDialogOpen}
+        helpItemLabel={t("apps.pc.menu.virtualPcHelp")}
+        aboutItemLabel={t("apps.pc.menu.aboutVirtualPc")}
+        onShowHelp={onShowHelp}
+        onShowAbout={onShowAbout}
+      >
         <MenubarMenu>
           <MenubarTrigger className="text-md px-2 py-1 border-none focus-visible:ring-0">
             {t("common.menu.file")}
@@ -90,7 +100,7 @@ export function InfinitePcMenuBar({
             >
               {t("apps.pc.menu.backToBrowse")}
             </MenubarItem>
-            <MenubarSeparator className="h-[2px] bg-black my-1" />
+            <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
             <MenubarSub>
               <MenubarSubTrigger className="text-md h-6 px-3">
                 {t("apps.pc.menu.loadGame")}
@@ -109,18 +119,18 @@ export function InfinitePcMenuBar({
                 ))}
               </MenubarSubContent>
             </MenubarSub>
-            <MenubarSeparator className="h-[2px] bg-black my-1" />
+            <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
             <MenubarItem onClick={onSaveState} className="text-md h-6 px-3">
               {t("apps.pc.menu.saveState")}
             </MenubarItem>
             <MenubarItem onClick={onLoadState} className="text-md h-6 px-3">
               {t("apps.pc.menu.loadState")}
             </MenubarItem>
-            <MenubarSeparator className="h-[2px] bg-black my-1" />
+            <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
             <MenubarItem onClick={onReset} className="text-md h-6 px-3">
               {t("apps.pc.menu.reset")}
             </MenubarItem>
-            <MenubarSeparator className="h-[2px] bg-black my-1" />
+            <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
             <MenubarItem onClick={onClose} className="text-md h-6 px-3">
               {t("common.menu.close")}
             </MenubarItem>
@@ -138,7 +148,7 @@ export function InfinitePcMenuBar({
             >
               {t("apps.pc.menu.fullScreen")}
             </MenubarItem>
-            <MenubarSeparator className="h-[2px] bg-black my-1" />
+            <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
             <MenubarItem
               onClick={() => onSetMouseCapture?.(!isMouseCaptured)}
               className="text-md h-6 px-3"
@@ -163,7 +173,7 @@ export function InfinitePcMenuBar({
                 ))}
               </MenubarSubContent>
             </MenubarSub>
-            <MenubarSeparator className="h-[2px] bg-black my-1" />
+            <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
             <MenubarSub>
               <MenubarSubTrigger className="text-md h-6 px-3">
                 {t("apps.pc.menu.aspectRatio")}
@@ -184,27 +194,23 @@ export function InfinitePcMenuBar({
             </MenubarSub>
           </MenubarContent>
         </MenubarMenu>
-
-        <AppMenuBarHelpMenu
-          helpItemLabel={t("apps.pc.menu.virtualPcHelp")}
-          aboutItemLabel={t("apps.pc.menu.aboutVirtualPc")}
-          isMacOsxTheme={isMacOsxTheme}
-          onShowHelp={onShowHelp}
-          onShowAbout={onShowAbout}
-          onOpenShareDialog={() => setIsShareDialogOpen(true)}
-        />
-        <AppShareItemDialog
-          appId={appId}
-          appName={appName}
-          isOpen={isShareDialogOpen}
-          onClose={() => setIsShareDialogOpen(false)}
-        />
-      </MenuBar>
+      </AppMenuBarShell>
     );
   }
 
   return (
-    <MenuBar inWindowFrame={isXpTheme}>
+    <AppMenuBarShell
+      isXpTheme={isXpTheme}
+      isMacOsxTheme={isMacOsxTheme}
+      appId={appId}
+      appName={appName}
+      isShareDialogOpen={isShareDialogOpen}
+      setIsShareDialogOpen={setIsShareDialogOpen}
+      helpItemLabel={t("apps.pc.menu.virtualPcHelp")}
+      aboutItemLabel={t("apps.pc.menu.aboutVirtualPc")}
+      onShowHelp={onShowHelp}
+      onShowAbout={onShowAbout}
+    >
       <MenubarMenu>
         <MenubarTrigger className="text-md px-2 py-1 border-none focus-visible:ring-0">
           {t("common.menu.file")}
@@ -218,7 +224,7 @@ export function InfinitePcMenuBar({
               >
                 {t("apps.pc.menu.backToBrowse")}
               </MenubarItem>
-              <MenubarSeparator className="h-[2px] bg-black my-1" />
+              <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
             </>
           )}
           <MenubarItem onClick={onClose} className="text-md h-6 px-3">
@@ -248,21 +254,6 @@ export function InfinitePcMenuBar({
           </MenubarItem>
         </MenubarContent>
       </MenubarMenu>
-
-      <AppMenuBarHelpMenu
-        helpItemLabel={t("apps.pc.menu.virtualPcHelp")}
-        aboutItemLabel={t("apps.pc.menu.aboutVirtualPc")}
-        isMacOsxTheme={isMacOsxTheme}
-        onShowHelp={onShowHelp}
-        onShowAbout={onShowAbout}
-        onOpenShareDialog={() => setIsShareDialogOpen(true)}
-      />
-      <AppShareItemDialog
-        appId={appId}
-        appName={appName}
-        isOpen={isShareDialogOpen}
-        onClose={() => setIsShareDialogOpen(false)}
-      />
-    </MenuBar>
+    </AppMenuBarShell>
   );
 }

--- a/src/apps/internet-explorer/components/InternetExplorerAppComponent.tsx
+++ b/src/apps/internet-explorer/components/InternetExplorerAppComponent.tsx
@@ -1,1 +1,0 @@
-export { InternetExplorerAppComponent } from "./internet-explorer-app/InternetExplorerAppComponent";

--- a/src/apps/internet-explorer/components/ie-menu-bar/InternetExplorerMenuBar.tsx
+++ b/src/apps/internet-explorer/components/ie-menu-bar/InternetExplorerMenuBar.tsx
@@ -1,38 +1,31 @@
-import { MenuBar } from "@/components/layout/MenuBar";
-import { AppShareItemDialog } from "@/components/shared/menubar/AppShareItemDialog";
+import { AppMenuBarShell } from "@/components/shared/menubar/AppMenuBarShell";
 import type { InternetExplorerMenuBarProps } from "./types";
 import { useInternetExplorerMenuBar } from "./useInternetExplorerMenuBar";
 import { IeMenuBarFileMenu } from "./IeMenuBarFileMenu";
 import { IeMenuBarEditMenu } from "./IeMenuBarEditMenu";
 import { IeMenuBarFavoritesMenu } from "./IeMenuBarFavoritesMenu";
 import { IeMenuBarHistoryMenu } from "./IeMenuBarHistoryMenu";
-import { AppMenuBarHelpMenu } from "@/components/shared/menubar/AppMenuBarHelpMenu";
 
 export function InternetExplorerMenuBar(props: InternetExplorerMenuBarProps) {
   const vm = useInternetExplorerMenuBar(props);
 
   return (
-    <MenuBar inWindowFrame={vm.isXpTheme}>
+    <AppMenuBarShell
+      isXpTheme={vm.isXpTheme}
+      isMacOsxTheme={vm.isMacOsxTheme}
+      appId={vm.appId}
+      appName={vm.appName}
+      isShareDialogOpen={vm.isShareDialogOpen}
+      setIsShareDialogOpen={vm.setIsShareDialogOpen}
+      helpItemLabel={vm.t("apps.internet-explorer.menu.internetExplorerHelp")}
+      aboutItemLabel={vm.t("apps.internet-explorer.menu.aboutInternetExplorer")}
+      onShowHelp={vm.onShowHelp}
+      onShowAbout={vm.onShowAbout}
+    >
       <IeMenuBarFileMenu vm={vm} />
       <IeMenuBarEditMenu vm={vm} />
       <IeMenuBarFavoritesMenu vm={vm} />
       <IeMenuBarHistoryMenu vm={vm} />
-      <AppMenuBarHelpMenu
-        helpItemLabel={vm.t("apps.internet-explorer.menu.internetExplorerHelp")}
-        aboutItemLabel={vm.t(
-          "apps.internet-explorer.menu.aboutInternetExplorer"
-        )}
-        isMacOsxTheme={vm.isMacOsxTheme}
-        onShowHelp={vm.onShowHelp}
-        onShowAbout={vm.onShowAbout}
-        onOpenShareDialog={() => vm.setIsShareDialogOpen(true)}
-      />
-      <AppShareItemDialog
-        appId={vm.appId}
-        appName={vm.appName}
-        isOpen={vm.isShareDialogOpen}
-        onClose={() => vm.setIsShareDialogOpen(false)}
-      />
-    </MenuBar>
+    </AppMenuBarShell>
   );
 }

--- a/src/apps/internet-explorer/components/internet-explorer-app/InternetExplorerAppDialogs.tsx
+++ b/src/apps/internet-explorer/components/internet-explorer-app/InternetExplorerAppDialogs.tsx
@@ -1,6 +1,5 @@
 import { InputDialog } from "@/components/dialogs/InputDialog";
-import { HelpDialog } from "@/components/dialogs/HelpDialog";
-import { AboutDialog } from "@/components/dialogs/AboutDialog";
+import { AppHelpAboutDialogs } from "@/components/shared/AppHelpAboutDialogs";
 import { ConfirmDialog } from "@/components/dialogs/ConfirmDialog";
 import FutureSettingsDialog from "@/components/dialogs/FutureSettingsDialog";
 import TimeMachineView from "../TimeMachineView";
@@ -77,17 +76,14 @@ export function InternetExplorerAppDialogs({
         value={newFavoriteTitle}
         onChange={setNewFavoriteTitle}
       />
-      <HelpDialog
-        isOpen={isHelpDialogOpen}
-        onOpenChange={setHelpDialogOpen}
+      <AppHelpAboutDialogs
+        appId="internet-explorer"
         helpItems={translatedHelpItems}
-        appId="internet-explorer"
-      />
-      <AboutDialog
-        isOpen={isAboutDialogOpen}
-        onOpenChange={setAboutDialogOpen}
         metadata={appMetadata}
-        appId="internet-explorer"
+        isHelpOpen={isHelpDialogOpen}
+        onHelpOpenChange={setHelpDialogOpen}
+        isAboutOpen={isAboutDialogOpen}
+        onAboutOpenChange={setAboutDialogOpen}
       />
       <ConfirmDialog
         isOpen={isClearFavoritesDialogOpen}

--- a/src/apps/internet-explorer/index.tsx
+++ b/src/apps/internet-explorer/index.tsx
@@ -1,5 +1,5 @@
 import { BaseApp, InternetExplorerInitialData } from "../base/types";
-import { InternetExplorerAppComponent } from "./components/InternetExplorerAppComponent";
+import { InternetExplorerAppComponent } from "./components/internet-explorer-app/InternetExplorerAppComponent";
 
 // Re-export metadata from separate file to avoid eager loading of components
 export { appMetadata, helpItems } from "./metadata";

--- a/src/apps/ipod/components/BrickGame.tsx
+++ b/src/apps/ipod/components/BrickGame.tsx
@@ -1,2 +1,0 @@
-export { BrickGame } from "./brick-game/BrickGame";
-export type { BrickGameRef, BrickGameProps } from "./brick-game/types";

--- a/src/apps/ipod/components/CoverFlow.tsx
+++ b/src/apps/ipod/components/CoverFlow.tsx
@@ -1,2 +1,0 @@
-export { CoverFlow } from "./cover-flow/CoverFlow";
-export type { CoverFlowRef } from "./cover-flow/types";

--- a/src/apps/ipod/components/IpodAppComponent.tsx
+++ b/src/apps/ipod/components/IpodAppComponent.tsx
@@ -1,1 +1,0 @@
-export { IpodAppComponent } from "./ipod-app/IpodAppComponent";

--- a/src/apps/ipod/components/IpodMenuBar.tsx
+++ b/src/apps/ipod/components/IpodMenuBar.tsx
@@ -1,1 +1,0 @@
-export { IpodMenuBar } from "./ipod-menu-bar/IpodMenuBar";

--- a/src/apps/ipod/components/IpodScreen.tsx
+++ b/src/apps/ipod/components/IpodScreen.tsx
@@ -1,1 +1,0 @@
-export { IpodScreen } from "./ipod-screen/IpodScreen";

--- a/src/apps/ipod/components/LyricsDisplay.tsx
+++ b/src/apps/ipod/components/LyricsDisplay.tsx
@@ -1,1 +1,0 @@
-export { LyricsDisplay } from "./lyrics-display/LyricsDisplay";

--- a/src/apps/ipod/components/MusicQuiz.tsx
+++ b/src/apps/ipod/components/MusicQuiz.tsx
@@ -1,6 +1,0 @@
-export { MusicQuiz } from "./music-quiz/MusicQuiz";
-export type {
-  MusicQuizRef,
-  MusicQuizProps,
-  MusicQuizRound,
-} from "./music-quiz/types";

--- a/src/apps/ipod/components/PipPlayer.tsx
+++ b/src/apps/ipod/components/PipPlayer.tsx
@@ -7,6 +7,7 @@ import { useOffline } from "@/hooks/useOffline";
 import { useTranslation } from "react-i18next";
 import { useIsPhone } from "@/hooks/useIsPhone";
 import { getYouTubeVideoId, formatKugouImageUrl } from "../constants";
+import { youtubeThumbnailUrl } from "@/utils/youtubeUrl";
 import type { PipPlayerProps } from "../types";
 import { SkipBack, SkipForward, Play, Pause, MusicNote } from "@phosphor-icons/react";
 
@@ -45,7 +46,7 @@ export function PipPlayer({
     ? getYouTubeVideoId(currentTrack.url)
     : null;
   const youtubeThumbnail = youtubeVideoId
-    ? `https://img.youtube.com/vi/${youtubeVideoId}/mqdefault.jpg`
+    ? youtubeThumbnailUrl(youtubeVideoId, "mqdefault")
     : null;
   const thumbnailUrl = formatKugouImageUrl(currentTrack?.cover) ?? youtubeThumbnail;
 

--- a/src/apps/ipod/components/cover-flow/utils.ts
+++ b/src/apps/ipod/components/cover-flow/utils.ts
@@ -2,6 +2,7 @@ import {
   getYouTubeVideoId,
   formatKugouImageUrl,
 } from "../../constants";
+import { youtubeThumbnailUrl } from "@/utils/youtubeUrl";
 import type { Track } from "@/stores/useIpodStore";
 import type { CoverFlowItem } from "./types";
 
@@ -29,7 +30,7 @@ export function resolveCoverUrl(
   if (!track) return null;
   const videoId = track.url ? getYouTubeVideoId(track.url) : null;
   const youtubeThumbnail = videoId
-    ? `https://img.youtube.com/vi/${videoId}/${ipodMode ? "mqdefault" : "hqdefault"}.jpg`
+    ? youtubeThumbnailUrl(videoId, ipodMode ? "mqdefault" : "hqdefault")
     : null;
   const kugouImageSize = ipodMode ? 400 : 800;
   return track.source === "appleMusic"

--- a/src/apps/ipod/components/ipod-app/IpodAppDialogs.tsx
+++ b/src/apps/ipod/components/ipod-app/IpodAppDialogs.tsx
@@ -1,5 +1,4 @@
-import { HelpDialog } from "@/components/dialogs/HelpDialog";
-import { AboutDialog } from "@/components/dialogs/AboutDialog";
+import { AppHelpAboutDialogs } from "@/components/shared/AppHelpAboutDialogs";
 import { ConfirmDialog } from "@/components/dialogs/ConfirmDialog";
 import { ShareItemDialog } from "@/components/dialogs/ShareItemDialog";
 import { LyricsSearchDialog } from "@/components/dialogs/LyricsSearchDialog";
@@ -62,17 +61,14 @@ export function IpodAppDialogs({ c }: IpodAppDialogsProps) {
 
   return (
     <>
-      <HelpDialog
-        isOpen={isHelpDialogOpen}
-        onOpenChange={setIsHelpDialogOpen}
+      <AppHelpAboutDialogs
+        appId="ipod"
         helpItems={translatedHelpItems}
-        appId="ipod"
-      />
-      <AboutDialog
-        isOpen={isAboutDialogOpen}
-        onOpenChange={setIsAboutDialogOpen}
         metadata={appMetadata}
-        appId="ipod"
+        isHelpOpen={isHelpDialogOpen}
+        onHelpOpenChange={setIsHelpDialogOpen}
+        isAboutOpen={isAboutDialogOpen}
+        onAboutOpenChange={setIsAboutDialogOpen}
       />
       <ConfirmDialog
         isOpen={isConfirmClearOpen}

--- a/src/apps/ipod/components/ipod-app/IpodFullScreenView.tsx
+++ b/src/apps/ipod/components/ipod-app/IpodFullScreenView.tsx
@@ -7,7 +7,7 @@ import { LyricsSyncMode } from "@/components/shared/LyricsSyncMode";
 import { PLAYER_PROGRESS_INTERVAL_MS } from "../../constants";
 import { AppleMusicPlayerBridge } from "../AppleMusicPlayerBridge";
 import { FullScreenPortal } from "../FullScreenPortal";
-import { LyricsDisplay } from "../LyricsDisplay";
+import { LyricsDisplay } from "../lyrics-display/LyricsDisplay";
 import type { IpodAppController } from "./useIpodAppController";
 import {
   AmbientBackground,

--- a/src/apps/ipod/components/ipod-app/IpodScreenArea.tsx
+++ b/src/apps/ipod/components/ipod-app/IpodScreenArea.tsx
@@ -1,7 +1,7 @@
 import { AnimatePresence, motion } from "framer-motion";
 import { Suspense } from "react";
 import { IPOD_MODERN_SCREEN_HEIGHT_PX } from "../../constants";
-import { IpodScreen } from "../IpodScreen";
+import { IpodScreen } from "../ipod-screen/IpodScreen";
 import type { IpodAppController } from "./useIpodAppController";
 import { useIpodScreenLongPressHandlers } from "./useIpodScreenLongPressHandlers";
 import { BrickGame, CoverFlow, MusicQuiz } from "./ipodLazyImports";

--- a/src/apps/ipod/components/ipod-app/ipodLazyImports.ts
+++ b/src/apps/ipod/components/ipod-app/ipodLazyImports.ts
@@ -1,13 +1,19 @@
 import { lazy } from "react";
 
 export const CoverFlow = lazy(() =>
-  import("../CoverFlow").then(({ CoverFlow }) => ({ default: CoverFlow }))
+  import("../cover-flow/CoverFlow").then(({ CoverFlow }) => ({
+    default: CoverFlow,
+  }))
 );
 export const MusicQuiz = lazy(() =>
-  import("../MusicQuiz").then(({ MusicQuiz }) => ({ default: MusicQuiz }))
+  import("../music-quiz/MusicQuiz").then(({ MusicQuiz }) => ({
+    default: MusicQuiz,
+  }))
 );
 export const BrickGame = lazy(() =>
-  import("../BrickGame").then(({ BrickGame }) => ({ default: BrickGame }))
+  import("../brick-game/BrickGame").then(({ BrickGame }) => ({
+    default: BrickGame,
+  }))
 );
 export const LandscapeVideoBackground = lazy(() =>
   import("@/components/shared/LandscapeVideoBackground").then(

--- a/src/apps/ipod/components/ipod-app/useIpodAppController.tsx
+++ b/src/apps/ipod/components/ipod-app/useIpodAppController.tsx
@@ -1,9 +1,13 @@
-import { useCallback, useMemo } from "react";
+import { useCallback } from "react";
 import type { AppProps, IpodInitialData } from "@/apps/base/types";
 import { useAudioSettingsStore } from "@/stores/useAudioSettingsStore";
 import { useIpodStore } from "@/stores/useIpodStore";
 import { DisplayMode } from "@/types/lyrics";
-import { IpodMenuBar } from "../IpodMenuBar";
+import {
+  useDisplayModeOptions,
+  useDisplayModeSelect,
+} from "@/hooks/useDisplayModeMenu";
+import { IpodMenuBar } from "../ipod-menu-bar/IpodMenuBar";
 import { useIpodLogic } from "../../hooks/useIpodLogic";
 
 export type UseIpodAppControllerArgs = Pick<
@@ -66,45 +70,16 @@ export function useIpodAppController({
       ? DisplayMode.Cover
       : displayMode;
 
-  const displayModeOptions = useMemo(
-    () => {
-      const options = [
-        { value: DisplayMode.Video, label: t("apps.ipod.menu.displayVideo") },
-        { value: DisplayMode.Mesh, label: t("apps.ipod.menu.displayGradient") },
-        { value: DisplayMode.Water, label: t("apps.ipod.menu.displayWater") },
-        { value: DisplayMode.Shader, label: t("apps.ipod.menu.displayShader") },
-        {
-          value: DisplayMode.Landscapes,
-          label: t("apps.ipod.menu.displayLandscapes"),
-        },
-        { value: DisplayMode.Cover, label: t("apps.ipod.menu.displayCover") },
-      ];
+  const displayModeOptions = useDisplayModeOptions(t, {
+    hideVideoOption: isAppleMusic,
+  });
 
-      return isAppleMusic
-        ? options.filter((option) => option.value !== DisplayMode.Video)
-        : options;
-    },
-    [isAppleMusic, t]
-  );
-
-  const handleDisplayModeSelect = useCallback(
-    (value: DisplayMode) => {
-      const nextMode =
-        isAppleMusic && value === DisplayMode.Video ? DisplayMode.Cover : value;
-      setDisplayMode(nextMode);
-      const labels: Record<DisplayMode, string> = {
-        [DisplayMode.Video]: t("apps.ipod.menu.displayVideo"),
-        [DisplayMode.Cover]: t("apps.ipod.menu.displayCover"),
-        [DisplayMode.Landscapes]: t("apps.ipod.menu.displayLandscapes"),
-        [DisplayMode.Shader]: t("apps.ipod.menu.displayShader"),
-        [DisplayMode.Mesh]: t("apps.ipod.menu.displayGradient"),
-        [DisplayMode.Water]: t("apps.ipod.menu.displayWater"),
-      };
-      const label = labels[nextMode] ?? nextMode;
-      showStatus(`${t("apps.ipod.menu.display", "Display")}: ${label}`);
-    },
-    [isAppleMusic, setDisplayMode, showStatus, t]
-  );
+  const handleDisplayModeSelect = useDisplayModeSelect({
+    t,
+    setDisplayMode,
+    showStatus,
+    coerceVideoToCover: isAppleMusic,
+  });
 
   const menuBar = (
     <IpodMenuBar

--- a/src/apps/ipod/components/ipod-menu-bar/IpodMenuBar.tsx
+++ b/src/apps/ipod/components/ipod-menu-bar/IpodMenuBar.tsx
@@ -1,36 +1,31 @@
-import { MenuBar } from "@/components/layout/MenuBar";
-import { AppShareItemDialog } from "@/components/shared/menubar/AppShareItemDialog";
+import { AppMenuBarShell } from "@/components/shared/menubar/AppMenuBarShell";
 import type { IpodMenuBarProps } from "./types";
 import { useIpodMenuBar } from "./useIpodMenuBar";
 import { IpodMenuBarFileMenu } from "./IpodMenuBarFileMenu";
 import { IpodMenuBarControlsMenu } from "./IpodMenuBarControlsMenu";
 import { IpodMenuBarViewMenu } from "./IpodMenuBarViewMenu";
 import { IpodMenuBarLibraryMenu } from "./IpodMenuBarLibraryMenu";
-import { AppMenuBarHelpMenu } from "@/components/shared/menubar/AppMenuBarHelpMenu";
 
 export function IpodMenuBar(props: IpodMenuBarProps) {
   const vm = useIpodMenuBar(props);
   return (
-    <MenuBar inWindowFrame={vm.isXpTheme}>
+    <AppMenuBarShell
+      isXpTheme={vm.isXpTheme}
+      isMacOsxTheme={vm.isMacOsxTheme}
+      appId={vm.appId}
+      appName={vm.appName}
+      isShareDialogOpen={vm.isShareDialogOpen}
+      setIsShareDialogOpen={vm.setIsShareDialogOpen}
+      helpItemLabel={vm.t("apps.ipod.menu.ipodHelp")}
+      aboutItemLabel={vm.t("apps.ipod.menu.aboutIpod")}
+      shareItemLabel={vm.t("apps.ipod.menu.shareApp")}
+      onShowHelp={vm.onShowHelp}
+      onShowAbout={vm.onShowAbout}
+    >
       <IpodMenuBarFileMenu vm={vm} />
       <IpodMenuBarControlsMenu vm={vm} />
       <IpodMenuBarViewMenu vm={vm} />
       <IpodMenuBarLibraryMenu vm={vm} />
-      <AppMenuBarHelpMenu
-        helpItemLabel={vm.t("apps.ipod.menu.ipodHelp")}
-        aboutItemLabel={vm.t("apps.ipod.menu.aboutIpod")}
-        shareItemLabel={vm.t("apps.ipod.menu.shareApp")}
-        isMacOsxTheme={vm.isMacOsxTheme}
-        onShowHelp={vm.onShowHelp}
-        onShowAbout={vm.onShowAbout}
-        onOpenShareDialog={() => vm.setIsShareDialogOpen(true)}
-      />
-      <AppShareItemDialog
-        appId={vm.appId}
-        appName={vm.appName}
-        isOpen={vm.isShareDialogOpen}
-        onClose={() => vm.setIsShareDialogOpen(false)}
-      />
-    </MenuBar>
+    </AppMenuBarShell>
   );
 }

--- a/src/apps/ipod/components/ipod-menu-bar/IpodMenuBarFileMenu.tsx
+++ b/src/apps/ipod/components/ipod-menu-bar/IpodMenuBarFileMenu.tsx
@@ -5,6 +5,7 @@ import {
   MenubarItem,
   MenubarSeparator,
 } from "@/components/ui/menubar";
+import { MENUBAR_SEPARATOR_CLASS } from "@/components/shared/menubar/menubarStyles";
 import { IpodMenuBarLibrarySourceActions } from "./IpodMenuBarLibrarySourceActions";
 import { IpodMenuBarLibrarySwitchItem } from "./IpodMenuBarLibrarySwitchItem";
 import type { IpodMenuBarViewModel } from "./useIpodMenuBar";
@@ -50,7 +51,7 @@ export function IpodMenuBarFileMenu({ vm }: { vm: IpodMenuBarViewModel }) {
           )}
           {!isAppleMusic && (
             <>
-              <MenubarSeparator className="h-[2px] bg-black my-1" />
+              <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
               <MenubarItem
                 onClick={handleExportLibrary}
                 className="text-md h-6 px-3"
@@ -66,11 +67,11 @@ export function IpodMenuBarFileMenu({ vm }: { vm: IpodMenuBarViewModel }) {
               </MenubarItem>
             </>
           )}
-          <MenubarSeparator className="h-[2px] bg-black my-1" />
+          <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
           <IpodMenuBarLibrarySourceActions vm={vm} />
-          <MenubarSeparator className="h-[2px] bg-black my-1" />
+          <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
           <IpodMenuBarLibrarySwitchItem vm={vm} />
-          <MenubarSeparator className="h-[2px] bg-black my-1" />
+          <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
           <MenubarItem
             onClick={onClose}
             className="text-md h-6 px-3"

--- a/src/apps/ipod/components/ipod-menu-bar/IpodMenuBarLibraryMenu.tsx
+++ b/src/apps/ipod/components/ipod-menu-bar/IpodMenuBarLibraryMenu.tsx
@@ -10,6 +10,7 @@ import {
   MenubarCheckboxItem,
 } from "@/components/ui/menubar";
 import { MENUBAR_TRACK_LIMIT, MENUBAR_ARTIST_LIMIT } from "./constants";
+import { MENUBAR_SEPARATOR_CLASS } from "@/components/shared/menubar/menubarStyles";
 import { IpodMenuBarLibrarySourceActions } from "./IpodMenuBarLibrarySourceActions";
 import { IpodMenuBarLibrarySwitchItem } from "./IpodMenuBarLibrarySwitchItem";
 import type { IpodMenuBarViewModel } from "./useIpodMenuBar";
@@ -36,7 +37,7 @@ export function IpodMenuBarLibraryMenu({ vm }: { vm: IpodMenuBarViewModel }) {
 
           <IpodMenuBarLibrarySourceActions vm={vm} />
 
-          <MenubarSeparator className="h-[2px] bg-black my-1" />
+          <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
 
           {tracks.length > 0 && (
             <>
@@ -117,7 +118,7 @@ export function IpodMenuBarLibraryMenu({ vm }: { vm: IpodMenuBarViewModel }) {
                 )}
               </div>
 
-              <MenubarSeparator className="h-[2px] bg-black my-1" />
+              <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
             </>
           )}
 

--- a/src/apps/ipod/components/ipod-menu-bar/IpodMenuBarLibraryMenu.tsx
+++ b/src/apps/ipod/components/ipod-menu-bar/IpodMenuBarLibraryMenu.tsx
@@ -4,13 +4,9 @@ import {
   MenubarContent,
   MenubarItem,
   MenubarSeparator,
-  MenubarSub,
-  MenubarSubTrigger,
-  MenubarSubContent,
-  MenubarCheckboxItem,
 } from "@/components/ui/menubar";
-import { MENUBAR_TRACK_LIMIT, MENUBAR_ARTIST_LIMIT } from "./constants";
 import { MENUBAR_SEPARATOR_CLASS } from "@/components/shared/menubar/menubarStyles";
+import { LibraryTrackBrowser } from "@/components/shared/menubar/LibraryTrackBrowser";
 import { IpodMenuBarLibrarySourceActions } from "./IpodMenuBarLibrarySourceActions";
 import { IpodMenuBarLibrarySwitchItem } from "./IpodMenuBarLibrarySwitchItem";
 import type { IpodMenuBarViewModel } from "./useIpodMenuBar";
@@ -41,82 +37,14 @@ export function IpodMenuBarLibraryMenu({ vm }: { vm: IpodMenuBarViewModel }) {
 
           {tracks.length > 0 && (
             <>
-              <MenubarSub>
-                <MenubarSubTrigger className="text-md h-6 px-3">
-                  <div className="flex justify-between w-full items-center overflow-hidden">
-                    <span className="truncate min-w-0">{t("apps.ipod.menu.allSongs")}</span>
-                  </div>
-                </MenubarSubTrigger>
-                <MenubarSubContent className="px-0 max-w-[180px] sm:max-w-[220px] max-h-[400px] overflow-y-auto">
-                  {tracks.slice(0, MENUBAR_TRACK_LIMIT).map((track, index) => (
-                    <MenubarCheckboxItem
-                      key={`all-${track.id}`}
-                      checked={index === currentIndex}
-                      onCheckedChange={() => handlePlayTrack(index)}
-                      className="text-md h-6 pr-3 max-w-[220px] truncate"
-                    >
-                      <span className="truncate min-w-0">{track.title}</span>
-                    </MenubarCheckboxItem>
-                  ))}
-                  {tracks.length > MENUBAR_TRACK_LIMIT && (
-                    <MenubarItem
-                      disabled
-                      className="text-md h-6 px-3 italic opacity-70"
-                    >
-                      {t(
-                        "apps.ipod.menu.menubarTrackLimit",
-                        `Showing ${MENUBAR_TRACK_LIMIT} of ${tracks.length} — open iPod to browse all`,
-                        {
-                          limit: MENUBAR_TRACK_LIMIT,
-                          total: tracks.length,
-                        }
-                      )}
-                    </MenubarItem>
-                  )}
-                </MenubarSubContent>
-              </MenubarSub>
-              <div className="max-h-[300px] overflow-y-auto">
-                {artists.slice(0, MENUBAR_ARTIST_LIMIT).map((artist) => (
-                  <MenubarSub key={artist}>
-                    <MenubarSubTrigger className="text-md h-6 px-3">
-                      <div className="flex justify-between w-full items-center overflow-hidden">
-                        <span className="truncate min-w-0">{artist}</span>
-                      </div>
-                    </MenubarSubTrigger>
-                    <MenubarSubContent className="px-0 max-w-[180px] sm:max-w-[220px] max-h-[200px] overflow-y-auto">
-                      {tracksByArtist[artist]
-                        .slice(0, MENUBAR_TRACK_LIMIT)
-                        .map(({ track, index }) => (
-                          <MenubarCheckboxItem
-                            key={`${artist}-${track.id}`}
-                            checked={index === currentIndex}
-                            onCheckedChange={() => handlePlayTrack(index)}
-                            className="text-md h-6 pr-3 max-w-[160px] sm:max-w-[200px] truncate"
-                          >
-                            <span className="truncate min-w-0">
-                              {track.title}
-                            </span>
-                          </MenubarCheckboxItem>
-                        ))}
-                    </MenubarSubContent>
-                  </MenubarSub>
-                ))}
-                {artists.length > MENUBAR_ARTIST_LIMIT && (
-                  <MenubarItem
-                    disabled
-                    className="text-md h-6 px-3 italic opacity-70"
-                  >
-                    {t(
-                      "apps.ipod.menu.menubarArtistLimit",
-                      `Showing ${MENUBAR_ARTIST_LIMIT} of ${artists.length} artists`,
-                      {
-                        limit: MENUBAR_ARTIST_LIMIT,
-                        total: artists.length,
-                      }
-                    )}
-                  </MenubarItem>
-                )}
-              </div>
+              <LibraryTrackBrowser
+                tracks={tracks}
+                currentIndex={currentIndex}
+                tracksByArtist={tracksByArtist}
+                artists={artists}
+                onPlayTrack={handlePlayTrack}
+                t={t}
+              />
 
               <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
             </>

--- a/src/apps/ipod/components/ipod-menu-bar/IpodMenuBarViewMenu.tsx
+++ b/src/apps/ipod/components/ipod-menu-bar/IpodMenuBarViewMenu.tsx
@@ -7,16 +7,11 @@ import {
   MenubarSub,
   MenubarSubTrigger,
   MenubarSubContent,
-  MenubarCheckboxItem,
   MenubarRadioGroup,
   MenubarRadioItem,
 } from "@/components/ui/menubar";
-import { LyricsAlignmentMenuItems } from "@/components/shared/menubar/lyrics/LyricsAlignmentMenuItems";
-import { LyricsPronunciationSubmenu } from "@/components/shared/menubar/lyrics/LyricsPronunciationSubmenu";
-import { LyricsTranslationLanguageSubmenu } from "@/components/shared/menubar/lyrics/LyricsTranslationLanguageSubmenu";
+import { MediaLyricsViewMenuItems } from "@/components/shared/menubar/MediaLyricsViewMenuItems";
 import { MENUBAR_SEPARATOR_CLASS } from "@/components/shared/menubar/menubarStyles";
-import { toast } from "sonner";
-import { DisplayMode, LyricsFont } from "@/types/lyrics";
 import type { IpodMenuBarViewModel } from "./useIpodMenuBar";
 
 export function IpodMenuBarViewMenu({ vm }: { vm: IpodMenuBarViewModel }) {
@@ -27,185 +22,31 @@ export function IpodMenuBarViewMenu({ vm }: { vm: IpodMenuBarViewModel }) {
           {vm.t("apps.ipod.menu.view")}
         </MenubarTrigger>
         <MenubarContent align="start" sideOffset={1} className="px-0">
-          <MenubarSub>
-            <MenubarSubTrigger className="text-md h-6 px-3">
-              {vm.t("apps.ipod.menu.lyrics")}
-            </MenubarSubTrigger>
-            <MenubarSubContent className="px-0">
-              <MenubarCheckboxItem
-                checked={vm.showLyrics}
-                onCheckedChange={() => vm.toggleLyrics()}
-                className="text-md h-6 px-3"
-              >
-                {vm.t("apps.ipod.menu.showLyrics")}
-              </MenubarCheckboxItem>
-
-              <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
-              <LyricsAlignmentMenuItems
-                lyricsAlignment={vm.lyricsAlignment}
-                setLyricsAlignment={vm.setLyricsAlignment}
-                multiLabel={vm.t("apps.ipod.menu.multi")}
-                singleLabel={vm.t("apps.ipod.menu.single")}
-                alternatingLabel={vm.t("apps.ipod.menu.alternating")}
-              />
-
-              <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
-
-              <MenubarRadioGroup
-                value={vm.lyricsFont}
-                onValueChange={(v) => vm.setLyricsFont(v as LyricsFont)}
-              >
-                <MenubarRadioItem
-                  value={LyricsFont.Rounded}
-                  className="text-md h-6 pr-3"
-                >
-                  {vm.t("apps.ipod.menu.fontRounded")}
-                </MenubarRadioItem>
-                <MenubarRadioItem
-                  value={LyricsFont.Serif}
-                  className="text-md h-6 pr-3"
-                >
-                  {vm.t("apps.ipod.menu.fontSerif")}
-                </MenubarRadioItem>
-                <MenubarRadioItem
-                  value={LyricsFont.SansSerif}
-                  className="text-md h-6 pr-3"
-                >
-                  {vm.t("apps.ipod.menu.fontSansSerif")}
-                </MenubarRadioItem>
-                <MenubarRadioItem
-                  value={LyricsFont.SerifRed}
-                  className="text-md h-6 pr-3"
-                >
-                  {vm.t("apps.ipod.menu.fontSerifRed")}
-                </MenubarRadioItem>
-                <MenubarRadioItem
-                  value={LyricsFont.GoldGlow}
-                  className="text-md h-6 pr-3"
-                >
-                  {vm.t("apps.ipod.menu.fontGoldGlow")}
-                </MenubarRadioItem>
-                <MenubarRadioItem
-                  value={LyricsFont.Gradient}
-                  className="text-md h-6 pr-3"
-                >
-                  {vm.t("apps.ipod.menu.fontGradient")}
-                </MenubarRadioItem>
-              </MenubarRadioGroup>
-            </MenubarSubContent>
-          </MenubarSub>
-          <LyricsTranslationLanguageSubmenu
-            submenuLabel={vm.t("apps.ipod.menu.translate")}
-            translationLanguages={vm.translationLanguages}
-            lyricsTranslationLanguage={vm.lyricsTranslationLanguage}
-            setLyricsTranslationLanguage={vm.setLyricsTranslationLanguage}
-          />
-          <LyricsPronunciationSubmenu
-            submenuLabel={vm.t("apps.ipod.menu.pronunciation")}
-            pronunciationLabel={vm.t("apps.ipod.menu.pronunciation")}
-            pronunciationOnlyLabel={vm.t("apps.ipod.menu.pronunciationOnly")}
-            japaneseFuriganaLabel={vm.t("apps.ipod.menu.japaneseFurigana")}
-            japaneseRomajiLabel={vm.t("apps.ipod.menu.japaneseRomaji")}
-            koreanRomanizationLabel={vm.t("apps.ipod.menu.koreanRomanization")}
-            chinesePinyinLabel={vm.t("apps.ipod.menu.chinesePinyin")}
-            chineseSoramimiLabel={vm.t("apps.ipod.menu.chineseSoramimi")}
-            soramimiLabel={vm.t("apps.ipod.menu.soramimi")}
+          <MediaLyricsViewMenuItems
+            t={vm.t}
+            showLyricsLabel={vm.t("apps.ipod.menu.showLyrics")}
+            showLyrics={vm.showLyrics}
+            onToggleLyrics={() => vm.toggleLyrics()}
+            lyricsAlignment={vm.lyricsAlignment}
+            setLyricsAlignment={vm.setLyricsAlignment}
+            lyricsFont={vm.lyricsFont}
+            setLyricsFont={vm.setLyricsFont}
             romanization={vm.romanization}
             setRomanization={vm.setRomanization}
+            lyricsTranslationLanguage={vm.lyricsTranslationLanguage}
+            setLyricsTranslationLanguage={vm.setLyricsTranslationLanguage}
+            translationLanguages={vm.translationLanguages}
+            displayMode={vm.effectiveDisplayMode}
+            setDisplayMode={vm.setDisplayMode}
+            hideVideoOption={vm.isAppleMusic}
+            onRefreshLyrics={vm.onRefreshLyrics || vm.refreshLyrics}
+            onAdjustTiming={vm.onAdjustTiming}
+            clearLyricsCache={vm.clearLyricsCache}
+            tracks={vm.tracks}
+            currentIndex={vm.currentIndex}
+            debugMode={vm.debugMode}
+            isAdmin={vm.isAdmin}
           />
-          <MenubarSub>
-            <MenubarSubTrigger className="text-md h-6 px-3">
-              {vm.t("apps.ipod.menu.display")}
-            </MenubarSubTrigger>
-            <MenubarSubContent className="px-0">
-              {!vm.isAppleMusic && (
-                <MenubarCheckboxItem
-                  checked={vm.effectiveDisplayMode === DisplayMode.Video}
-                  onCheckedChange={(checked) => {
-                    if (checked) vm.setDisplayMode(DisplayMode.Video);
-                  }}
-                  className="text-md h-6 pr-3"
-                >
-                  {vm.t("apps.ipod.menu.displayVideo")}
-                </MenubarCheckboxItem>
-              )}
-              <MenubarCheckboxItem
-                checked={vm.effectiveDisplayMode === DisplayMode.Mesh}
-                onCheckedChange={(checked) => {
-                  if (checked) vm.setDisplayMode(DisplayMode.Mesh);
-                }}
-                className="text-md h-6 pr-3"
-              >
-                {vm.t("apps.ipod.menu.displayGradient")}
-              </MenubarCheckboxItem>
-              <MenubarCheckboxItem
-                checked={vm.effectiveDisplayMode === DisplayMode.Water}
-                onCheckedChange={(checked) => {
-                  if (checked) vm.setDisplayMode(DisplayMode.Water);
-                }}
-                className="text-md h-6 pr-3"
-              >
-                {vm.t("apps.ipod.menu.displayWater")}
-              </MenubarCheckboxItem>
-              <MenubarCheckboxItem
-                checked={vm.effectiveDisplayMode === DisplayMode.Shader}
-                onCheckedChange={(checked) => {
-                  if (checked) vm.setDisplayMode(DisplayMode.Shader);
-                }}
-                className="text-md h-6 pr-3"
-              >
-                {vm.t("apps.ipod.menu.displayShader")}
-              </MenubarCheckboxItem>
-              <MenubarCheckboxItem
-                checked={vm.effectiveDisplayMode === DisplayMode.Landscapes}
-                onCheckedChange={(checked) => {
-                  if (checked) vm.setDisplayMode(DisplayMode.Landscapes);
-                }}
-                className="text-md h-6 pr-3"
-              >
-                {vm.t("apps.ipod.menu.displayLandscapes")}
-              </MenubarCheckboxItem>
-              <MenubarCheckboxItem
-                checked={vm.effectiveDisplayMode === DisplayMode.Cover}
-                onCheckedChange={(checked) => {
-                  if (checked) vm.setDisplayMode(DisplayMode.Cover);
-                }}
-                className="text-md h-6 pr-3"
-              >
-                {vm.t("apps.ipod.menu.displayCover")}
-              </MenubarCheckboxItem>
-            </MenubarSubContent>
-          </MenubarSub>
-
-          <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
-
-          <MenubarItem
-            onClick={vm.onRefreshLyrics || vm.refreshLyrics}
-            className="text-md h-6 px-3"
-            disabled={vm.tracks.length === 0 || vm.currentIndex === -1}
-          >
-            {vm.t("apps.ipod.menu.refreshLyrics")}
-          </MenubarItem>
-          <MenubarItem
-            onClick={vm.onAdjustTiming}
-            className="text-md h-6 px-3"
-            disabled={vm.tracks.length === 0 || vm.currentIndex === -1}
-          >
-            {vm.t("apps.ipod.menu.adjustTiming")}
-          </MenubarItem>
-
-          {(vm.debugMode || vm.isAdmin) && (
-            <MenubarItem
-              onClick={() => {
-                vm.clearLyricsCache();
-                toast.success(vm.t("apps.ipod.menu.cacheCleared"));
-              }}
-              className="text-md h-6 px-3"
-              disabled={vm.tracks.length === 0 || vm.currentIndex === -1}
-            >
-              {vm.t("apps.ipod.menu.clearCache")}
-            </MenubarItem>
-          )}
 
           <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
           <MenubarSub>

--- a/src/apps/ipod/components/ipod-menu-bar/constants.ts
+++ b/src/apps/ipod/components/ipod-menu-bar/constants.ts
@@ -1,6 +1,4 @@
-// Caps for the in-menubar library browser. Radix's MenubarSub doesn't
-// virtualize, so a 5,000-song library would commit thousands of DOM
-// nodes the moment the user opens the dropdown. The full library is
-// always available inside the iPod itself (which IS virtualized).
-export const MENUBAR_TRACK_LIMIT = 200;
-export const MENUBAR_ARTIST_LIMIT = 100;
+export {
+  MENUBAR_TRACK_LIMIT,
+  MENUBAR_ARTIST_LIMIT,
+} from "@/components/shared/menubar/libraryMenuConstants";

--- a/src/apps/ipod/components/ipod-screen/IpodScreen.tsx
+++ b/src/apps/ipod/components/ipod-screen/IpodScreen.tsx
@@ -17,6 +17,7 @@ import {
   IPOD_MODERN_SCREEN_HEIGHT_PX,
   IPOD_NOW_PLAYING_SONG_MENU_KEY,
 } from "../../constants";
+import { youtubeThumbnailUrl } from "@/utils/youtubeUrl";
 import { DisplayMode } from "@/types/lyrics";
 import type { IpodScreenProps } from "../../types";
 import { useIpodStore, isAppleMusicCollectionTrack } from "@/stores/useIpodStore";
@@ -231,9 +232,7 @@ export function IpodScreen({
       return nowPlayingDisplayTrack.cover ?? null;
     }
     const videoId = getYouTubeVideoId(nowPlayingDisplayTrack.url);
-    const youtubeThumbnail = videoId
-      ? `https://img.youtube.com/vi/${videoId}/maxresdefault.jpg`
-      : null;
+    const youtubeThumbnail = videoId ? youtubeThumbnailUrl(videoId) : null;
     return (
       formatKugouImageUrl(nowPlayingDisplayTrack.cover, 400) ?? youtubeThumbnail
     );

--- a/src/apps/ipod/components/ipod-screen/IpodScreenMediaOverlay.tsx
+++ b/src/apps/ipod/components/ipod-screen/IpodScreenMediaOverlay.tsx
@@ -7,7 +7,7 @@ import { AmbientBackground } from "@/components/shared/AmbientBackground";
 import { MeshGradientBackground } from "@/components/shared/MeshGradientBackground";
 import { WaterBackground } from "@/components/shared/WaterBackground";
 import { DisplayMode } from "@/types/lyrics";
-import { LyricsDisplay } from "../LyricsDisplay";
+import { LyricsDisplay } from "../lyrics-display/LyricsDisplay";
 import {
   AppleMusicPlayerBridge,
 } from "../AppleMusicPlayerBridge";

--- a/src/apps/ipod/constants.ts
+++ b/src/apps/ipod/constants.ts
@@ -1,8 +1,19 @@
 // Shared constants for the iPod app
 
 import { LyricsAlignment } from "@/types/lyrics";
-import i18n from "@/lib/i18n";
 import type { Track } from "@/stores/useIpodStore";
+import { parseYouTubeVideoId } from "@/utils/youtubeUrl";
+import { formatKugouImageUrl } from "@/utils/coverArt";
+
+// Re-exported from shared utils so existing iPod-internal imports keep working
+// while the canonical implementations live under `src/utils/`.
+export { formatKugouImageUrl } from "@/utils/coverArt";
+export {
+  type TranslationLanguage,
+  TRANSLATION_LANGUAGES,
+  TRANSLATION_BADGES,
+  getTranslationBadge,
+} from "@/utils/lyricsTranslation";
 
 /** Fixed modern iPod LCD outer height (px), including `border-2` on the screen element. */
 export const IPOD_MODERN_SCREEN_HEIGHT_PX = 152;
@@ -59,44 +70,6 @@ export const IPOD_MODERN_MEDIA_ROW_HEIGHT_PX =
 /** Internal breadcrumb key for the Now Playing long-press song menu. */
 export const IPOD_NOW_PLAYING_SONG_MENU_KEY = "__nowPlayingSongMenu__";
 
-// Translation language options
-export interface TranslationLanguage {
-  labelKey?: string;
-  label?: string;
-  code: string | null;
-  separator?: boolean;
-}
-
-export const TRANSLATION_LANGUAGES: TranslationLanguage[] = [
-  { labelKey: "apps.ipod.translationLanguages.original", code: null },
-  { labelKey: "apps.ipod.translationLanguages.auto", code: "auto" },
-  { separator: true, code: null, label: "" }, // Separator
-  { labelKey: "apps.ipod.translationLanguages.english", code: "en" },
-  { labelKey: "apps.ipod.translationLanguages.chinese", code: "zh-TW" },
-  { labelKey: "apps.ipod.translationLanguages.japanese", code: "ja" },
-  { labelKey: "apps.ipod.translationLanguages.korean", code: "ko" },
-  { labelKey: "apps.ipod.translationLanguages.spanish", code: "es" },
-  { labelKey: "apps.ipod.translationLanguages.french", code: "fr" },
-  { labelKey: "apps.ipod.translationLanguages.german", code: "de" },
-  { labelKey: "apps.ipod.translationLanguages.portuguese", code: "pt" },
-  { labelKey: "apps.ipod.translationLanguages.italian", code: "it" },
-  { labelKey: "apps.ipod.translationLanguages.russian", code: "ru" },
-];
-
-// Translation badge mappings
-export const TRANSLATION_BADGES: Record<string, string> = {
-  "zh-TW": "中",
-  en: "En",
-  ja: "日",
-  ko: "한",
-  es: "Es",
-  fr: "Fr",
-  de: "De",
-  pt: "Pt",
-  it: "It",
-  ru: "Ru",
-};
-
 // iPod themes
 export const IPOD_THEMES = ["classic", "black", "u2"] as const;
 export type IpodTheme = (typeof IPOD_THEMES)[number];
@@ -123,25 +96,10 @@ export const LYRICS_ALIGNMENT_CYCLE: LyricsAlignment[] = [
   LyricsAlignment.Alternating,
 ];
 
-// Helper to extract YouTube video ID from URL
+// Helper to extract YouTube video ID from URL. Delegates to the canonical,
+// host-safe parser in `@/utils/youtubeUrl`.
 export function getYouTubeVideoId(url: string): string | null {
-  const match = url.match(
-    /(?:youtube\.com\/(?:[^/]+\/.+\/|(?:v|e(?:mbed)?)\/|.*[?&]v=)|youtu\.be\/)([^"&?/\s]{11})/
-  );
-  return match ? match[1] : null;
-}
-
-/**
- * Replace {size} placeholder in Kugou image URL with actual size
- * Kugou image URLs contain {size} that needs to be replaced with: 100, 150, 240, 400, etc.
- * Also ensures HTTPS is used to avoid mixed content issues
- */
-export function formatKugouImageUrl(imgUrl: string | undefined, size: number = 400): string | null {
-  if (!imgUrl) return null;
-  let url = imgUrl.replace("{size}", String(size));
-  // Ensure HTTPS
-  url = url.replace(/^http:\/\//, "https://");
-  return url;
+  return parseYouTubeVideoId(url);
 }
 
 /**
@@ -171,17 +129,6 @@ export function resolveTrackCoverUrl(
     ? `https://img.youtube.com/vi/${videoId}/maxresdefault.jpg`
     : null;
   return formatKugouImageUrl(track.cover, 400) ?? youtubeThumbnail;
-}
-
-// Helper to get translation badge from code
-export function getTranslationBadge(code: string | null): string | null {
-  if (!code) return null;
-  // For "auto", resolve to the actual ryOS language
-  if (code === "auto") {
-    const actualLang = i18n.language;
-    return TRANSLATION_BADGES[actualLang] || actualLang[0]?.toUpperCase() || "?";
-  }
-  return TRANSLATION_BADGES[code] || code[0]?.toUpperCase() || "?";
 }
 
 export function getAlbumGroupingKey(

--- a/src/apps/ipod/constants.ts
+++ b/src/apps/ipod/constants.ts
@@ -2,7 +2,7 @@
 
 import { LyricsAlignment } from "@/types/lyrics";
 import type { Track } from "@/stores/useIpodStore";
-import { parseYouTubeVideoId } from "@/utils/youtubeUrl";
+import { parseYouTubeVideoId, youtubeThumbnailUrl } from "@/utils/youtubeUrl";
 import { formatKugouImageUrl } from "@/utils/coverArt";
 
 // Re-exported from shared utils so existing iPod-internal imports keep working
@@ -125,9 +125,7 @@ export function resolveTrackCoverUrl(
     return track.cover ?? null;
   }
   const videoId = track.url ? getYouTubeVideoId(track.url) : null;
-  const youtubeThumbnail = videoId
-    ? `https://img.youtube.com/vi/${videoId}/maxresdefault.jpg`
-    : null;
+  const youtubeThumbnail = videoId ? youtubeThumbnailUrl(videoId) : null;
   return formatKugouImageUrl(track.cover, 400) ?? youtubeThumbnail;
 }
 

--- a/src/apps/ipod/hooks/useIpodLogic.ts
+++ b/src/apps/ipod/hooks/useIpodLogic.ts
@@ -51,6 +51,7 @@ import { useThemeFlags } from "@/hooks/useThemeFlags";
 import { LyricsAlignment, LyricsFont, DisplayMode, getLyricsFontClassName } from "@/types/lyrics";
 import { IPOD_ANALYTICS } from "@/utils/analytics";
 import { saveSongMetadataFromTrack } from "@/utils/songMetadataCache";
+import { youtubeThumbnailUrl } from "@/utils/youtubeUrl";
 import {
   generateIpodSongShareUrl,
   shouldCacheSongMetadataForShare,
@@ -4813,9 +4814,7 @@ export function useIpodLogic({
       return currentTrack.cover ?? null;
     }
     const videoId = getYouTubeVideoId(currentTrack.url);
-    const youtubeThumbnail = videoId
-      ? `https://img.youtube.com/vi/${videoId}/maxresdefault.jpg`
-      : null;
+    const youtubeThumbnail = videoId ? youtubeThumbnailUrl(videoId) : null;
     return formatKugouImageUrl(currentTrack.cover, 800) ?? youtubeThumbnail;
   }, [currentTrack]);
 

--- a/src/apps/ipod/hooks/useIpodLogic.ts
+++ b/src/apps/ipod/hooks/useIpodLogic.ts
@@ -73,9 +73,9 @@ import type {
   RotationDirection,
 } from "../types";
 import type { IpodInitialData } from "../../base/types";
-import type { CoverFlowRef } from "../components/CoverFlow";
-import type { MusicQuizRef } from "../components/MusicQuiz";
-import type { BrickGameRef } from "../components/BrickGame";
+import type { CoverFlowRef } from "../components/cover-flow/types";
+import type { MusicQuizRef } from "../components/music-quiz/types";
+import type { BrickGameRef } from "../components/brick-game/types";
 import type { SongSearchResult } from "@/components/dialogs/SongSearchDialog";
 import { helpItems } from "..";
 import {

--- a/src/apps/ipod/index.tsx
+++ b/src/apps/ipod/index.tsx
@@ -1,5 +1,5 @@
 import { BaseApp, IpodInitialData } from "../base/types";
-import { IpodAppComponent } from "./components/IpodAppComponent";
+import { IpodAppComponent } from "./components/ipod-app/IpodAppComponent";
 
 // Re-export metadata from separate file to avoid eager loading of components
 export { appMetadata, helpItems } from "./metadata";

--- a/src/apps/karaoke/components/KaraokeAppComponent.tsx
+++ b/src/apps/karaoke/components/KaraokeAppComponent.tsx
@@ -1,1 +1,0 @@
-export { KaraokeAppComponent } from "./karaoke-app/KaraokeAppComponent";

--- a/src/apps/karaoke/components/KaraokeMenuBar.tsx
+++ b/src/apps/karaoke/components/KaraokeMenuBar.tsx
@@ -1,1 +1,0 @@
-export { KaraokeMenuBar } from "./karaoke-menu-bar/KaraokeMenuBar";

--- a/src/apps/karaoke/components/karaoke-app/KaraokeAppDialogs.tsx
+++ b/src/apps/karaoke/components/karaoke-app/KaraokeAppDialogs.tsx
@@ -1,5 +1,4 @@
-import { HelpDialog } from "@/components/dialogs/HelpDialog";
-import { AboutDialog } from "@/components/dialogs/AboutDialog";
+import { AppHelpAboutDialogs } from "@/components/shared/AppHelpAboutDialogs";
 import { ConfirmDialog } from "@/components/dialogs/ConfirmDialog";
 import { ShareItemDialog } from "@/components/dialogs/ShareItemDialog";
 import { LyricsSearchDialog } from "@/components/dialogs/LyricsSearchDialog";
@@ -50,17 +49,14 @@ export function KaraokeAppDialogs({ c }: KaraokeAppDialogsProps) {
 
   return (
     <>
-      <HelpDialog
-        isOpen={isHelpDialogOpen}
-        onOpenChange={setIsHelpDialogOpen}
+      <AppHelpAboutDialogs
+        appId="karaoke"
         helpItems={translatedHelpItems}
-        appId="karaoke"
-      />
-      <AboutDialog
-        isOpen={isAboutDialogOpen}
-        onOpenChange={setIsAboutDialogOpen}
         metadata={appMetadata}
-        appId="karaoke"
+        isHelpOpen={isHelpDialogOpen}
+        onHelpOpenChange={setIsHelpDialogOpen}
+        isAboutOpen={isAboutDialogOpen}
+        onAboutOpenChange={setIsAboutDialogOpen}
       />
       <ConfirmDialog
         isOpen={isConfirmClearOpen}

--- a/src/apps/karaoke/components/karaoke-app/KaraokeWindowContent.tsx
+++ b/src/apps/karaoke/components/karaoke-app/KaraokeWindowContent.tsx
@@ -1,7 +1,7 @@
 import ReactPlayer from "react-player";
 import { AnimatePresence, motion } from "framer-motion";
 import { cn } from "@/lib/utils";
-import { CoverFlow } from "@/apps/ipod/components/CoverFlow";
+import { CoverFlow } from "@/apps/ipod/components/cover-flow/CoverFlow";
 import { ReactionOverlay } from "@/components/listen/ReactionOverlay";
 import { ListenSessionToolbar } from "@/components/listen/ListenSessionToolbar";
 import { FullscreenPlayerControls } from "@/components/shared/FullscreenPlayerControls";

--- a/src/apps/karaoke/components/karaoke-app/useKaraokeAppController.tsx
+++ b/src/apps/karaoke/components/karaoke-app/useKaraokeAppController.tsx
@@ -3,7 +3,11 @@ import { useShallow } from "zustand/react/shallow";
 import type { AppProps, KaraokeInitialData } from "@/apps/base/types";
 import { useChatsStore } from "@/stores/useChatsStore";
 import { DisplayMode } from "@/types/lyrics";
-import { KaraokeMenuBar } from "../KaraokeMenuBar";
+import {
+  useDisplayModeOptions,
+  useDisplayModeSelect,
+} from "@/hooks/useDisplayModeMenu";
+import { KaraokeMenuBar } from "../karaoke-menu-bar/KaraokeMenuBar";
 import { useKaraokeLogic } from "../../hooks/useKaraokeLogic";
 
 export type UseKaraokeAppControllerArgs = Pick<
@@ -81,34 +85,13 @@ export function useKaraokeAppController({
 
   const showEmptyLibrary = tracks.length === 0 && !logic.currentTrack;
 
-  const displayModeOptions = useMemo(
-    () => [
-      { value: DisplayMode.Video, label: t("apps.ipod.menu.displayVideo") },
-      { value: DisplayMode.Mesh, label: t("apps.ipod.menu.displayGradient") },
-      { value: DisplayMode.Water, label: t("apps.ipod.menu.displayWater") },
-      { value: DisplayMode.Shader, label: t("apps.ipod.menu.displayShader") },
-      { value: DisplayMode.Landscapes, label: t("apps.ipod.menu.displayLandscapes") },
-      { value: DisplayMode.Cover, label: t("apps.ipod.menu.displayCover") },
-    ],
-    [t]
-  );
+  const displayModeOptions = useDisplayModeOptions(t);
 
-  const handleDisplayModeSelect = useCallback(
-    (value: DisplayMode) => {
-      setDisplayMode(value);
-      const labels: Record<DisplayMode, string> = {
-        [DisplayMode.Video]: t("apps.ipod.menu.displayVideo"),
-        [DisplayMode.Cover]: t("apps.ipod.menu.displayCover"),
-        [DisplayMode.Landscapes]: t("apps.ipod.menu.displayLandscapes"),
-        [DisplayMode.Shader]: t("apps.ipod.menu.displayShader"),
-        [DisplayMode.Mesh]: t("apps.ipod.menu.displayGradient"),
-        [DisplayMode.Water]: t("apps.ipod.menu.displayWater"),
-      };
-      const label = labels[value] ?? value;
-      showStatus(`${t("apps.ipod.menu.display", "Display")}: ${label}`);
-    },
-    [setDisplayMode, showStatus, t]
-  );
+  const handleDisplayModeSelect = useDisplayModeSelect({
+    t,
+    setDisplayMode,
+    showStatus,
+  });
 
   const handleOpenCoverFlowFromTitleCard = useCallback(() => {
     if (tracks.length === 0) return;

--- a/src/apps/karaoke/components/karaoke-lyrics-playback/KaraokeFullscreenLyricsOverlay.tsx
+++ b/src/apps/karaoke/components/karaoke-lyrics-playback/KaraokeFullscreenLyricsOverlay.tsx
@@ -2,7 +2,7 @@ import { useCallback, type CSSProperties } from "react";
 import type { TFunction } from "i18next";
 import { AnimatePresence } from "framer-motion";
 import type { Track } from "@/stores/useIpodStore";
-import { LyricsDisplay } from "@/apps/ipod/components/LyricsDisplay";
+import { LyricsDisplay } from "@/apps/ipod/components/lyrics-display/LyricsDisplay";
 import { shouldShowKaraokeTitleCard } from "@/apps/karaoke/utils/titleCard";
 import type {
   JapaneseFurigana,

--- a/src/apps/karaoke/components/karaoke-lyrics-playback/KaraokeWindowLyricsOverlay.tsx
+++ b/src/apps/karaoke/components/karaoke-lyrics-playback/KaraokeWindowLyricsOverlay.tsx
@@ -2,7 +2,7 @@ import { useCallback, type CSSProperties } from "react";
 import type { TFunction } from "i18next";
 import { AnimatePresence } from "framer-motion";
 import type { Track } from "@/stores/useIpodStore";
-import { LyricsDisplay } from "@/apps/ipod/components/LyricsDisplay";
+import { LyricsDisplay } from "@/apps/ipod/components/lyrics-display/LyricsDisplay";
 import { shouldShowKaraokeTitleCard } from "@/apps/karaoke/utils/titleCard";
 import type {
   JapaneseFurigana,

--- a/src/apps/karaoke/components/karaoke-menu-bar/KaraokeMenuBar.tsx
+++ b/src/apps/karaoke/components/karaoke-menu-bar/KaraokeMenuBar.tsx
@@ -1,36 +1,31 @@
-import { MenuBar } from "@/components/layout/MenuBar";
-import { AppShareItemDialog } from "@/components/shared/menubar/AppShareItemDialog";
+import { AppMenuBarShell } from "@/components/shared/menubar/AppMenuBarShell";
 import type { KaraokeMenuBarProps } from "./types";
 import { useKaraokeMenuBar } from "./useKaraokeMenuBar";
 import { KaraokeMenuBarFileMenu } from "./KaraokeMenuBarFileMenu";
 import { KaraokeMenuBarControlsMenu } from "./KaraokeMenuBarControlsMenu";
 import { KaraokeMenuBarViewMenu } from "./KaraokeMenuBarViewMenu";
 import { KaraokeMenuBarLibraryMenu } from "./KaraokeMenuBarLibraryMenu";
-import { AppMenuBarHelpMenu } from "@/components/shared/menubar/AppMenuBarHelpMenu";
 
 export function KaraokeMenuBar(props: KaraokeMenuBarProps) {
   const vm = useKaraokeMenuBar(props);
   return (
-    <MenuBar inWindowFrame={vm.isXpTheme}>
+    <AppMenuBarShell
+      isXpTheme={vm.isXpTheme}
+      isMacOsxTheme={vm.isMacOsxTheme}
+      appId={vm.appId}
+      appName={vm.appName}
+      isShareDialogOpen={vm.isShareDialogOpen}
+      setIsShareDialogOpen={vm.setIsShareDialogOpen}
+      helpItemLabel={vm.t("apps.karaoke.menu.karaokeHelp")}
+      aboutItemLabel={vm.t("apps.karaoke.menu.aboutKaraoke")}
+      shareItemLabel={vm.t("apps.karaoke.menu.shareApp")}
+      onShowHelp={vm.onShowHelp}
+      onShowAbout={vm.onShowAbout}
+    >
       <KaraokeMenuBarFileMenu vm={vm} />
       <KaraokeMenuBarControlsMenu vm={vm} />
       <KaraokeMenuBarViewMenu vm={vm} />
       <KaraokeMenuBarLibraryMenu vm={vm} />
-      <AppMenuBarHelpMenu
-        helpItemLabel={vm.t("apps.karaoke.menu.karaokeHelp")}
-        aboutItemLabel={vm.t("apps.karaoke.menu.aboutKaraoke")}
-        shareItemLabel={vm.t("apps.karaoke.menu.shareApp")}
-        isMacOsxTheme={vm.isMacOsxTheme}
-        onShowHelp={vm.onShowHelp}
-        onShowAbout={vm.onShowAbout}
-        onOpenShareDialog={() => vm.setIsShareDialogOpen(true)}
-      />
-      <AppShareItemDialog
-        appId={vm.appId}
-        appName={vm.appName}
-        isOpen={vm.isShareDialogOpen}
-        onClose={() => vm.setIsShareDialogOpen(false)}
-      />
-    </MenuBar>
+    </AppMenuBarShell>
   );
 }

--- a/src/apps/karaoke/components/karaoke-menu-bar/KaraokeMenuBarFileMenu.tsx
+++ b/src/apps/karaoke/components/karaoke-menu-bar/KaraokeMenuBarFileMenu.tsx
@@ -5,6 +5,7 @@ import {
   MenubarItem,
   MenubarSeparator,
 } from "@/components/ui/menubar";
+import { MENUBAR_SEPARATOR_CLASS } from "@/components/shared/menubar/menubarStyles";
 import type { KaraokeMenuBarViewModel } from "./useKaraokeMenuBar";
 
 export function KaraokeMenuBarFileMenu({ vm }: { vm: KaraokeMenuBarViewModel }) {
@@ -41,7 +42,7 @@ export function KaraokeMenuBarFileMenu({ vm }: { vm: KaraokeMenuBarViewModel }) 
         >
           {t("apps.ipod.menu.shareSong")}
         </MenubarItem>
-        <MenubarSeparator className="h-[2px] bg-black my-1" />
+        <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
         {!isInListenSession ? (
           <>
             <MenubarItem
@@ -75,7 +76,7 @@ export function KaraokeMenuBarFileMenu({ vm }: { vm: KaraokeMenuBarViewModel }) 
             </MenubarItem>
           </>
         )}
-        <MenubarSeparator className="h-[2px] bg-black my-1" />
+        <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
         <MenubarItem
           onClick={handleExportLibrary}
           className="text-md h-6 px-3"
@@ -89,7 +90,7 @@ export function KaraokeMenuBarFileMenu({ vm }: { vm: KaraokeMenuBarViewModel }) 
         >
           {t("apps.ipod.menu.importLibrary")}
         </MenubarItem>
-        <MenubarSeparator className="h-[2px] bg-black my-1" />
+        <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
         <MenubarItem onClick={onClose} className="text-md h-6 px-3">
           {t("common.menu.close")}
         </MenubarItem>

--- a/src/apps/karaoke/components/karaoke-menu-bar/KaraokeMenuBarLibraryMenu.tsx
+++ b/src/apps/karaoke/components/karaoke-menu-bar/KaraokeMenuBarLibraryMenu.tsx
@@ -9,6 +9,11 @@ import {
   MenubarSubContent,
   MenubarCheckboxItem,
 } from "@/components/ui/menubar";
+import {
+  MENUBAR_TRACK_LIMIT,
+  MENUBAR_ARTIST_LIMIT,
+} from "@/components/shared/menubar/libraryMenuConstants";
+import { MENUBAR_SEPARATOR_CLASS } from "@/components/shared/menubar/menubarStyles";
 import type { KaraokeMenuBarViewModel } from "./useKaraokeMenuBar";
 
 export function KaraokeMenuBarLibraryMenu({
@@ -44,7 +49,7 @@ export function KaraokeMenuBarLibraryMenu({
 
         {tracks.length > 0 && (
           <>
-            <MenubarSeparator className="h-[2px] bg-black my-1" />
+            <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
 
             <MenubarSub>
               <MenubarSubTrigger className="text-md h-6 px-3">
@@ -55,7 +60,7 @@ export function KaraokeMenuBarLibraryMenu({
                 </div>
               </MenubarSubTrigger>
               <MenubarSubContent className="px-0 max-w-[180px] sm:max-w-[220px] max-h-[400px] overflow-y-auto">
-                {tracks.map((track, index) => (
+                {tracks.slice(0, MENUBAR_TRACK_LIMIT).map((track, index) => (
                   <MenubarCheckboxItem
                     key={`all-${track.id}`}
                     checked={index === currentIndex}
@@ -65,11 +70,26 @@ export function KaraokeMenuBarLibraryMenu({
                     <span className="truncate min-w-0">{track.title}</span>
                   </MenubarCheckboxItem>
                 ))}
+                {tracks.length > MENUBAR_TRACK_LIMIT && (
+                  <MenubarItem
+                    disabled
+                    className="text-md h-6 px-3 italic opacity-70"
+                  >
+                    {t(
+                      "apps.ipod.menu.menubarTrackLimit",
+                      `Showing ${MENUBAR_TRACK_LIMIT} of ${tracks.length} — open to browse all`,
+                      {
+                        limit: MENUBAR_TRACK_LIMIT,
+                        total: tracks.length,
+                      }
+                    )}
+                  </MenubarItem>
+                )}
               </MenubarSubContent>
             </MenubarSub>
 
             <div className="max-h-[300px] overflow-y-auto">
-              {artists.map((artist) => (
+              {artists.slice(0, MENUBAR_ARTIST_LIMIT).map((artist) => (
                 <MenubarSub key={artist}>
                   <MenubarSubTrigger className="text-md h-6 px-3">
                     <div className="flex justify-between w-full items-center overflow-hidden">
@@ -77,22 +97,41 @@ export function KaraokeMenuBarLibraryMenu({
                     </div>
                   </MenubarSubTrigger>
                   <MenubarSubContent className="px-0 max-w-[180px] sm:max-w-[220px] max-h-[200px] overflow-y-auto">
-                    {tracksByArtist[artist].map(({ track, index }) => (
-                      <MenubarCheckboxItem
-                        key={`${artist}-${track.id}`}
-                        checked={index === currentIndex}
-                        onCheckedChange={() => onPlayTrack(index)}
-                        className="text-md h-6 pr-3 max-w-[160px] sm:max-w-[200px] truncate"
-                      >
-                        <span className="truncate min-w-0">{track.title}</span>
-                      </MenubarCheckboxItem>
-                    ))}
+                    {tracksByArtist[artist]
+                      .slice(0, MENUBAR_TRACK_LIMIT)
+                      .map(({ track, index }) => (
+                        <MenubarCheckboxItem
+                          key={`${artist}-${track.id}`}
+                          checked={index === currentIndex}
+                          onCheckedChange={() => onPlayTrack(index)}
+                          className="text-md h-6 pr-3 max-w-[160px] sm:max-w-[200px] truncate"
+                        >
+                          <span className="truncate min-w-0">
+                            {track.title}
+                          </span>
+                        </MenubarCheckboxItem>
+                      ))}
                   </MenubarSubContent>
                 </MenubarSub>
               ))}
+              {artists.length > MENUBAR_ARTIST_LIMIT && (
+                <MenubarItem
+                  disabled
+                  className="text-md h-6 px-3 italic opacity-70"
+                >
+                  {t(
+                    "apps.ipod.menu.menubarArtistLimit",
+                    `Showing ${MENUBAR_ARTIST_LIMIT} of ${artists.length} artists`,
+                    {
+                      limit: MENUBAR_ARTIST_LIMIT,
+                      total: artists.length,
+                    }
+                  )}
+                </MenubarItem>
+              )}
             </div>
 
-            <MenubarSeparator className="h-[2px] bg-black my-1" />
+            <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
           </>
         )}
 

--- a/src/apps/karaoke/components/karaoke-menu-bar/KaraokeMenuBarLibraryMenu.tsx
+++ b/src/apps/karaoke/components/karaoke-menu-bar/KaraokeMenuBarLibraryMenu.tsx
@@ -4,16 +4,9 @@ import {
   MenubarContent,
   MenubarItem,
   MenubarSeparator,
-  MenubarSub,
-  MenubarSubTrigger,
-  MenubarSubContent,
-  MenubarCheckboxItem,
 } from "@/components/ui/menubar";
-import {
-  MENUBAR_TRACK_LIMIT,
-  MENUBAR_ARTIST_LIMIT,
-} from "@/components/shared/menubar/libraryMenuConstants";
 import { MENUBAR_SEPARATOR_CLASS } from "@/components/shared/menubar/menubarStyles";
+import { LibraryTrackBrowser } from "@/components/shared/menubar/LibraryTrackBrowser";
 import type { KaraokeMenuBarViewModel } from "./useKaraokeMenuBar";
 
 export function KaraokeMenuBarLibraryMenu({
@@ -51,85 +44,14 @@ export function KaraokeMenuBarLibraryMenu({
           <>
             <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
 
-            <MenubarSub>
-              <MenubarSubTrigger className="text-md h-6 px-3">
-                <div className="flex justify-between w-full items-center overflow-hidden">
-                  <span className="truncate min-w-0">
-                    {t("apps.ipod.menu.allSongs")}
-                  </span>
-                </div>
-              </MenubarSubTrigger>
-              <MenubarSubContent className="px-0 max-w-[180px] sm:max-w-[220px] max-h-[400px] overflow-y-auto">
-                {tracks.slice(0, MENUBAR_TRACK_LIMIT).map((track, index) => (
-                  <MenubarCheckboxItem
-                    key={`all-${track.id}`}
-                    checked={index === currentIndex}
-                    onCheckedChange={() => onPlayTrack(index)}
-                    className="text-md h-6 pr-3 max-w-[220px] truncate"
-                  >
-                    <span className="truncate min-w-0">{track.title}</span>
-                  </MenubarCheckboxItem>
-                ))}
-                {tracks.length > MENUBAR_TRACK_LIMIT && (
-                  <MenubarItem
-                    disabled
-                    className="text-md h-6 px-3 italic opacity-70"
-                  >
-                    {t(
-                      "apps.ipod.menu.menubarTrackLimit",
-                      `Showing ${MENUBAR_TRACK_LIMIT} of ${tracks.length} — open to browse all`,
-                      {
-                        limit: MENUBAR_TRACK_LIMIT,
-                        total: tracks.length,
-                      }
-                    )}
-                  </MenubarItem>
-                )}
-              </MenubarSubContent>
-            </MenubarSub>
-
-            <div className="max-h-[300px] overflow-y-auto">
-              {artists.slice(0, MENUBAR_ARTIST_LIMIT).map((artist) => (
-                <MenubarSub key={artist}>
-                  <MenubarSubTrigger className="text-md h-6 px-3">
-                    <div className="flex justify-between w-full items-center overflow-hidden">
-                      <span className="truncate min-w-0">{artist}</span>
-                    </div>
-                  </MenubarSubTrigger>
-                  <MenubarSubContent className="px-0 max-w-[180px] sm:max-w-[220px] max-h-[200px] overflow-y-auto">
-                    {tracksByArtist[artist]
-                      .slice(0, MENUBAR_TRACK_LIMIT)
-                      .map(({ track, index }) => (
-                        <MenubarCheckboxItem
-                          key={`${artist}-${track.id}`}
-                          checked={index === currentIndex}
-                          onCheckedChange={() => onPlayTrack(index)}
-                          className="text-md h-6 pr-3 max-w-[160px] sm:max-w-[200px] truncate"
-                        >
-                          <span className="truncate min-w-0">
-                            {track.title}
-                          </span>
-                        </MenubarCheckboxItem>
-                      ))}
-                  </MenubarSubContent>
-                </MenubarSub>
-              ))}
-              {artists.length > MENUBAR_ARTIST_LIMIT && (
-                <MenubarItem
-                  disabled
-                  className="text-md h-6 px-3 italic opacity-70"
-                >
-                  {t(
-                    "apps.ipod.menu.menubarArtistLimit",
-                    `Showing ${MENUBAR_ARTIST_LIMIT} of ${artists.length} artists`,
-                    {
-                      limit: MENUBAR_ARTIST_LIMIT,
-                      total: artists.length,
-                    }
-                  )}
-                </MenubarItem>
-              )}
-            </div>
+            <LibraryTrackBrowser
+              tracks={tracks}
+              currentIndex={currentIndex}
+              tracksByArtist={tracksByArtist}
+              artists={artists}
+              onPlayTrack={onPlayTrack}
+              t={t}
+            />
 
             <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
           </>

--- a/src/apps/karaoke/components/karaoke-menu-bar/KaraokeMenuBarViewMenu.tsx
+++ b/src/apps/karaoke/components/karaoke-menu-bar/KaraokeMenuBarViewMenu.tsx
@@ -4,19 +4,9 @@ import {
   MenubarContent,
   MenubarItem,
   MenubarSeparator,
-  MenubarSub,
-  MenubarSubTrigger,
-  MenubarSubContent,
-  MenubarCheckboxItem,
-  MenubarRadioGroup,
-  MenubarRadioItem,
 } from "@/components/ui/menubar";
-import { LyricsAlignmentMenuItems } from "@/components/shared/menubar/lyrics/LyricsAlignmentMenuItems";
-import { LyricsPronunciationSubmenu } from "@/components/shared/menubar/lyrics/LyricsPronunciationSubmenu";
-import { LyricsTranslationLanguageSubmenu } from "@/components/shared/menubar/lyrics/LyricsTranslationLanguageSubmenu";
+import { MediaLyricsViewMenuItems } from "@/components/shared/menubar/MediaLyricsViewMenuItems";
 import { MENUBAR_SEPARATOR_CLASS, MENUBAR_TRIGGER_CLASS } from "@/components/shared/menubar/menubarStyles";
-import { toast } from "sonner";
-import { LyricsFont, DisplayMode } from "@/types/lyrics";
 import type { KaraokeMenuBarViewModel } from "./useKaraokeMenuBar";
 
 export function KaraokeMenuBarViewMenu({ vm }: { vm: KaraokeMenuBarViewModel }) {
@@ -26,187 +16,30 @@ export function KaraokeMenuBarViewMenu({ vm }: { vm: KaraokeMenuBarViewModel }) 
         {vm.t("apps.karaoke.menu.view")}
       </MenubarTrigger>
       <MenubarContent align="start" sideOffset={1} className="px-0">
-        <MenubarSub>
-          <MenubarSubTrigger className="text-md h-6 px-3">
-            {vm.t("apps.ipod.menu.lyrics")}
-          </MenubarSubTrigger>
-          <MenubarSubContent className="px-0">
-            <MenubarCheckboxItem
-              checked={vm.showLyrics}
-              onCheckedChange={vm.onToggleLyrics}
-              className="text-md h-6 px-3"
-            >
-              {vm.t("apps.karaoke.menu.showLyrics")}
-            </MenubarCheckboxItem>
-
-            <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
-
-            <LyricsAlignmentMenuItems
-              lyricsAlignment={vm.lyricsAlignment}
-              setLyricsAlignment={vm.setLyricsAlignment}
-              multiLabel={vm.t("apps.ipod.menu.multi")}
-              singleLabel={vm.t("apps.ipod.menu.single")}
-              alternatingLabel={vm.t("apps.ipod.menu.alternating")}
-            />
-
-            <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
-
-            <MenubarRadioGroup
-              value={vm.lyricsFont}
-              onValueChange={(v) => vm.setLyricsFont(v as LyricsFont)}
-            >
-              <MenubarRadioItem
-                value={LyricsFont.Rounded}
-                className="text-md h-6 pr-3"
-              >
-                {vm.t("apps.ipod.menu.fontRounded")}
-              </MenubarRadioItem>
-              <MenubarRadioItem
-                value={LyricsFont.Serif}
-                className="text-md h-6 pr-3"
-              >
-                {vm.t("apps.ipod.menu.fontSerif")}
-              </MenubarRadioItem>
-              <MenubarRadioItem
-                value={LyricsFont.SansSerif}
-                className="text-md h-6 pr-3"
-              >
-                {vm.t("apps.ipod.menu.fontSansSerif")}
-              </MenubarRadioItem>
-              <MenubarRadioItem
-                value={LyricsFont.SerifRed}
-                className="text-md h-6 pr-3"
-              >
-                {vm.t("apps.ipod.menu.fontSerifRed")}
-              </MenubarRadioItem>
-              <MenubarRadioItem
-                value={LyricsFont.GoldGlow}
-                className="text-md h-6 pr-3"
-              >
-                {vm.t("apps.ipod.menu.fontGoldGlow")}
-              </MenubarRadioItem>
-              <MenubarRadioItem
-                value={LyricsFont.Gradient}
-                className="text-md h-6 pr-3"
-              >
-                {vm.t("apps.ipod.menu.fontGradient")}
-              </MenubarRadioItem>
-            </MenubarRadioGroup>
-          </MenubarSubContent>
-        </MenubarSub>
-
-        <LyricsTranslationLanguageSubmenu
-          submenuLabel={vm.t("apps.ipod.menu.translate")}
-          translationLanguages={vm.translationLanguages}
-          lyricsTranslationLanguage={vm.lyricsTranslationLanguage}
-          setLyricsTranslationLanguage={vm.setLyricsTranslationLanguage}
-        />
-
-        <LyricsPronunciationSubmenu
-          submenuLabel={vm.t("apps.ipod.menu.pronunciation")}
-          pronunciationLabel={vm.t("apps.ipod.menu.pronunciation")}
-          pronunciationOnlyLabel={vm.t("apps.ipod.menu.pronunciationOnly")}
-          japaneseFuriganaLabel={vm.t("apps.ipod.menu.japaneseFurigana")}
-          japaneseRomajiLabel={vm.t("apps.ipod.menu.japaneseRomaji")}
-          koreanRomanizationLabel={vm.t("apps.ipod.menu.koreanRomanization")}
-          chinesePinyinLabel={vm.t("apps.ipod.menu.chinesePinyin")}
-          chineseSoramimiLabel={vm.t("apps.ipod.menu.chineseSoramimi")}
-          soramimiLabel={vm.t("apps.ipod.menu.soramimi")}
+        <MediaLyricsViewMenuItems
+          t={vm.t}
+          showLyricsLabel={vm.t("apps.karaoke.menu.showLyrics")}
+          showLyrics={vm.showLyrics}
+          onToggleLyrics={vm.onToggleLyrics}
+          lyricsAlignment={vm.lyricsAlignment}
+          setLyricsAlignment={vm.setLyricsAlignment}
+          lyricsFont={vm.lyricsFont}
+          setLyricsFont={vm.setLyricsFont}
           romanization={vm.romanization}
           setRomanization={vm.setRomanization}
+          lyricsTranslationLanguage={vm.lyricsTranslationLanguage}
+          setLyricsTranslationLanguage={vm.setLyricsTranslationLanguage}
+          translationLanguages={vm.translationLanguages}
+          displayMode={vm.displayMode}
+          setDisplayMode={vm.setDisplayMode}
+          onRefreshLyrics={vm.onRefreshLyrics || vm.refreshLyrics}
+          onAdjustTiming={vm.onAdjustTiming}
+          clearLyricsCache={vm.clearLyricsCache}
+          tracks={vm.tracks}
+          currentIndex={vm.currentIndex}
+          debugMode={vm.debugMode}
+          isAdmin={vm.isAdmin}
         />
-
-        <MenubarSub>
-          <MenubarSubTrigger className="text-md h-6 px-3">
-            {vm.t("apps.ipod.menu.display")}
-          </MenubarSubTrigger>
-          <MenubarSubContent className="px-0">
-            <MenubarCheckboxItem
-              checked={vm.displayMode === DisplayMode.Video}
-              onCheckedChange={(checked) => {
-                if (checked) vm.setDisplayMode(DisplayMode.Video);
-              }}
-              className="text-md h-6 pr-3"
-            >
-              {vm.t("apps.ipod.menu.displayVideo")}
-            </MenubarCheckboxItem>
-            <MenubarCheckboxItem
-              checked={vm.displayMode === DisplayMode.Mesh}
-              onCheckedChange={(checked) => {
-                if (checked) vm.setDisplayMode(DisplayMode.Mesh);
-              }}
-              className="text-md h-6 pr-3"
-            >
-              {vm.t("apps.ipod.menu.displayGradient")}
-            </MenubarCheckboxItem>
-            <MenubarCheckboxItem
-              checked={vm.displayMode === DisplayMode.Water}
-              onCheckedChange={(checked) => {
-                if (checked) vm.setDisplayMode(DisplayMode.Water);
-              }}
-              className="text-md h-6 pr-3"
-            >
-              {vm.t("apps.ipod.menu.displayWater")}
-            </MenubarCheckboxItem>
-            <MenubarCheckboxItem
-              checked={vm.displayMode === DisplayMode.Shader}
-              onCheckedChange={(checked) => {
-                if (checked) vm.setDisplayMode(DisplayMode.Shader);
-              }}
-              className="text-md h-6 pr-3"
-            >
-              {vm.t("apps.ipod.menu.displayShader")}
-            </MenubarCheckboxItem>
-            <MenubarCheckboxItem
-              checked={vm.displayMode === DisplayMode.Landscapes}
-              onCheckedChange={(checked) => {
-                if (checked) vm.setDisplayMode(DisplayMode.Landscapes);
-              }}
-              className="text-md h-6 pr-3"
-            >
-              {vm.t("apps.ipod.menu.displayLandscapes")}
-            </MenubarCheckboxItem>
-            <MenubarCheckboxItem
-              checked={vm.displayMode === DisplayMode.Cover}
-              onCheckedChange={(checked) => {
-                if (checked) vm.setDisplayMode(DisplayMode.Cover);
-              }}
-              className="text-md h-6 pr-3"
-            >
-              {vm.t("apps.ipod.menu.displayCover")}
-            </MenubarCheckboxItem>
-          </MenubarSubContent>
-        </MenubarSub>
-
-        <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
-
-        <MenubarItem
-          onClick={vm.onRefreshLyrics || vm.refreshLyrics}
-          className="text-md h-6 px-3"
-          disabled={vm.tracks.length === 0 || vm.currentIndex === -1}
-        >
-          {vm.t("apps.ipod.menu.refreshLyrics")}
-        </MenubarItem>
-        <MenubarItem
-          onClick={vm.onAdjustTiming}
-          className="text-md h-6 px-3"
-          disabled={vm.tracks.length === 0 || vm.currentIndex === -1}
-        >
-          {vm.t("apps.ipod.menu.adjustTiming")}
-        </MenubarItem>
-
-        {(vm.debugMode || vm.isAdmin) && (
-          <MenubarItem
-            onClick={() => {
-              vm.clearLyricsCache();
-              toast.success(vm.t("apps.ipod.menu.cacheCleared"));
-            }}
-            className="text-md h-6 px-3"
-            disabled={vm.tracks.length === 0 || vm.currentIndex === -1}
-          >
-            {vm.t("apps.ipod.menu.clearCache")}
-          </MenubarItem>
-        )}
 
         <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
 

--- a/src/apps/karaoke/components/karaoke-menu-bar/KaraokeMenuBarViewMenu.tsx
+++ b/src/apps/karaoke/components/karaoke-menu-bar/KaraokeMenuBarViewMenu.tsx
@@ -8,6 +8,8 @@ import {
   MenubarSubTrigger,
   MenubarSubContent,
   MenubarCheckboxItem,
+  MenubarRadioGroup,
+  MenubarRadioItem,
 } from "@/components/ui/menubar";
 import { LyricsAlignmentMenuItems } from "@/components/shared/menubar/lyrics/LyricsAlignmentMenuItems";
 import { LyricsPronunciationSubmenu } from "@/components/shared/menubar/lyrics/LyricsPronunciationSubmenu";
@@ -49,60 +51,47 @@ export function KaraokeMenuBarViewMenu({ vm }: { vm: KaraokeMenuBarViewModel }) 
 
             <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
 
-            <MenubarCheckboxItem
-              checked={vm.lyricsFont === LyricsFont.Rounded}
-              onCheckedChange={(checked) => {
-                if (checked) vm.setLyricsFont(LyricsFont.Rounded);
-              }}
-              className="text-md h-6 pr-3"
+            <MenubarRadioGroup
+              value={vm.lyricsFont}
+              onValueChange={(v) => vm.setLyricsFont(v as LyricsFont)}
             >
-              {vm.t("apps.ipod.menu.fontRounded")}
-            </MenubarCheckboxItem>
-            <MenubarCheckboxItem
-              checked={vm.lyricsFont === LyricsFont.Serif}
-              onCheckedChange={(checked) => {
-                if (checked) vm.setLyricsFont(LyricsFont.Serif);
-              }}
-              className="text-md h-6 pr-3"
-            >
-              {vm.t("apps.ipod.menu.fontSerif")}
-            </MenubarCheckboxItem>
-            <MenubarCheckboxItem
-              checked={vm.lyricsFont === LyricsFont.SansSerif}
-              onCheckedChange={(checked) => {
-                if (checked) vm.setLyricsFont(LyricsFont.SansSerif);
-              }}
-              className="text-md h-6 pr-3"
-            >
-              {vm.t("apps.ipod.menu.fontSansSerif")}
-            </MenubarCheckboxItem>
-            <MenubarCheckboxItem
-              checked={vm.lyricsFont === LyricsFont.SerifRed}
-              onCheckedChange={(checked) => {
-                if (checked) vm.setLyricsFont(LyricsFont.SerifRed);
-              }}
-              className="text-md h-6 pr-3"
-            >
-              {vm.t("apps.ipod.menu.fontSerifRed")}
-            </MenubarCheckboxItem>
-            <MenubarCheckboxItem
-              checked={vm.lyricsFont === LyricsFont.GoldGlow}
-              onCheckedChange={(checked) => {
-                if (checked) vm.setLyricsFont(LyricsFont.GoldGlow);
-              }}
-              className="text-md h-6 pr-3"
-            >
-              {vm.t("apps.ipod.menu.fontGoldGlow")}
-            </MenubarCheckboxItem>
-            <MenubarCheckboxItem
-              checked={vm.lyricsFont === LyricsFont.Gradient}
-              onCheckedChange={(checked) => {
-                if (checked) vm.setLyricsFont(LyricsFont.Gradient);
-              }}
-              className="text-md h-6 pr-3"
-            >
-              {vm.t("apps.ipod.menu.fontGradient")}
-            </MenubarCheckboxItem>
+              <MenubarRadioItem
+                value={LyricsFont.Rounded}
+                className="text-md h-6 pr-3"
+              >
+                {vm.t("apps.ipod.menu.fontRounded")}
+              </MenubarRadioItem>
+              <MenubarRadioItem
+                value={LyricsFont.Serif}
+                className="text-md h-6 pr-3"
+              >
+                {vm.t("apps.ipod.menu.fontSerif")}
+              </MenubarRadioItem>
+              <MenubarRadioItem
+                value={LyricsFont.SansSerif}
+                className="text-md h-6 pr-3"
+              >
+                {vm.t("apps.ipod.menu.fontSansSerif")}
+              </MenubarRadioItem>
+              <MenubarRadioItem
+                value={LyricsFont.SerifRed}
+                className="text-md h-6 pr-3"
+              >
+                {vm.t("apps.ipod.menu.fontSerifRed")}
+              </MenubarRadioItem>
+              <MenubarRadioItem
+                value={LyricsFont.GoldGlow}
+                className="text-md h-6 pr-3"
+              >
+                {vm.t("apps.ipod.menu.fontGoldGlow")}
+              </MenubarRadioItem>
+              <MenubarRadioItem
+                value={LyricsFont.Gradient}
+                className="text-md h-6 pr-3"
+              >
+                {vm.t("apps.ipod.menu.fontGradient")}
+              </MenubarRadioItem>
+            </MenubarRadioGroup>
           </MenubarSubContent>
         </MenubarSub>
 

--- a/src/apps/karaoke/hooks/useKaraokeLogic.ts
+++ b/src/apps/karaoke/hooks/useKaraokeLogic.ts
@@ -15,7 +15,7 @@ import { useThemeFlags } from "@/hooks/useThemeFlags";
 import { LyricsAlignment, LyricsFont, DisplayMode } from "@/types/lyrics";
 import { useOffline } from "@/hooks/useOffline";
 import { useListenSync } from "@/hooks/useListenSync";
-import { parseYouTubeVideoId } from "@/utils/youtubeUrl";
+import { parseYouTubeVideoId, youtubeThumbnailUrl } from "@/utils/youtubeUrl";
 import { formatKugouImageUrl } from "@/utils/coverArt";
 import { TRANSLATION_LANGUAGES } from "@/utils/lyricsTranslation";
 import { useLibraryUpdateChecker } from "@/apps/ipod/hooks/useLibraryUpdateChecker";
@@ -544,9 +544,7 @@ export function useKaraokeLogic({
   const coverUrl = useMemo(() => {
     if (!currentTrack) return null;
     const videoId = parseYouTubeVideoId(currentTrack.url);
-    const youtubeThumbnail = videoId
-      ? `https://img.youtube.com/vi/${videoId}/maxresdefault.jpg`
-      : null;
+    const youtubeThumbnail = videoId ? youtubeThumbnailUrl(videoId) : null;
     return formatKugouImageUrl(currentTrack.cover, 800) ?? youtubeThumbnail;
   }, [currentTrack]);
 

--- a/src/apps/karaoke/hooks/useKaraokeLogic.ts
+++ b/src/apps/karaoke/hooks/useKaraokeLogic.ts
@@ -15,13 +15,15 @@ import { useThemeFlags } from "@/hooks/useThemeFlags";
 import { LyricsAlignment, LyricsFont, DisplayMode } from "@/types/lyrics";
 import { useOffline } from "@/hooks/useOffline";
 import { useListenSync } from "@/hooks/useListenSync";
-import { TRANSLATION_LANGUAGES, getYouTubeVideoId, formatKugouImageUrl } from "@/apps/ipod/constants";
+import { parseYouTubeVideoId } from "@/utils/youtubeUrl";
+import { formatKugouImageUrl } from "@/utils/coverArt";
+import { TRANSLATION_LANGUAGES } from "@/utils/lyricsTranslation";
 import { useLibraryUpdateChecker } from "@/apps/ipod/hooks/useLibraryUpdateChecker";
 import { saveSongMetadataFromTrack } from "@/utils/songMetadataCache";
 import { useChatsStore } from "@/stores/useChatsStore";
 import { useListenSessionStore } from "@/stores/useListenSessionStore";
 import type { KaraokeInitialData } from "../../base/types";
-import type { CoverFlowRef } from "@/apps/ipod/components/CoverFlow";
+import type { CoverFlowRef } from "@/apps/ipod/components/cover-flow/types";
 import type { SongSearchResult } from "@/components/dialogs/SongSearchDialog";
 import { helpItems } from "..";
 import { onAppUpdate } from "@/utils/appEventBus";
@@ -541,7 +543,7 @@ export function useKaraokeLogic({
   // Cover URL for paused state overlay
   const coverUrl = useMemo(() => {
     if (!currentTrack) return null;
-    const videoId = getYouTubeVideoId(currentTrack.url);
+    const videoId = parseYouTubeVideoId(currentTrack.url);
     const youtubeThumbnail = videoId
       ? `https://img.youtube.com/vi/${videoId}/maxresdefault.jpg`
       : null;
@@ -1401,7 +1403,7 @@ export function useKaraokeLogic({
   const handleAddUrl = useCallback(
     async (url: string) => {
       if (listenRemoteOnly) {
-        const id = getYouTubeVideoId(url);
+        const id = parseYouTubeVideoId(url);
         if (!id) {
           toast.error("Only YouTube links can be queued remotely");
           return;

--- a/src/apps/karaoke/index.ts
+++ b/src/apps/karaoke/index.ts
@@ -1,5 +1,5 @@
 import { BaseApp, IpodInitialData } from "../base/types";
-import { KaraokeAppComponent } from "./components/KaraokeAppComponent";
+import { KaraokeAppComponent } from "./components/karaoke-app/KaraokeAppComponent";
 
 // Re-export metadata from separate file to avoid eager loading of components
 export { appMetadata, helpItems } from "./metadata";

--- a/src/apps/maps/components/MapsAppComponent.tsx
+++ b/src/apps/maps/components/MapsAppComponent.tsx
@@ -1,1 +1,0 @@
-export { MapsAppComponent } from "./maps-app/MapsAppComponent";

--- a/src/apps/maps/components/MapsMenuBar.tsx
+++ b/src/apps/maps/components/MapsMenuBar.tsx
@@ -1,4 +1,3 @@
-import { MenuBar } from "@/components/layout/MenuBar";
 import {
   MenubarMenu,
   MenubarTrigger,
@@ -7,8 +6,7 @@ import {
   MenubarSeparator,
   MenubarCheckboxItem,
 } from "@/components/ui/menubar";
-import { AppMenuBarHelpMenu } from "@/components/shared/menubar/AppMenuBarHelpMenu";
-import { AppShareItemDialog } from "@/components/shared/menubar/AppShareItemDialog";
+import { AppMenuBarShell } from "@/components/shared/menubar/AppMenuBarShell";
 import {
   MENUBAR_ITEM_CLASS,
   MENUBAR_SEPARATOR_CLASS,
@@ -49,7 +47,18 @@ export function MapsMenuBar({
   } = useAppMenuBarChrome("maps");
 
   return (
-    <MenuBar inWindowFrame={isXpTheme}>
+    <AppMenuBarShell
+      isXpTheme={isXpTheme}
+      isMacOsxTheme={isMacOsxTheme}
+      appId={appId}
+      appName={appName}
+      isShareDialogOpen={isShareDialogOpen}
+      setIsShareDialogOpen={setIsShareDialogOpen}
+      helpItemLabel={t("apps.maps.menu.help")}
+      aboutItemLabel={t("apps.maps.menu.about")}
+      onShowHelp={onShowHelp}
+      onShowAbout={onShowAbout}
+    >
       <MenubarMenu>
         <MenubarTrigger className={MENUBAR_TRIGGER_CLASS}>
           {t("common.menu.file")}
@@ -107,21 +116,6 @@ export function MapsMenuBar({
           </MenubarCheckboxItem>
         </MenubarContent>
       </MenubarMenu>
-
-      <AppMenuBarHelpMenu
-        helpItemLabel={t("apps.maps.menu.help")}
-        aboutItemLabel={t("apps.maps.menu.about")}
-        isMacOsxTheme={isMacOsxTheme}
-        onShowHelp={onShowHelp}
-        onShowAbout={onShowAbout}
-        onOpenShareDialog={() => setIsShareDialogOpen(true)}
-      />
-      <AppShareItemDialog
-        appId={appId}
-        appName={appName}
-        isOpen={isShareDialogOpen}
-        onClose={() => setIsShareDialogOpen(false)}
-      />
-    </MenuBar>
+    </AppMenuBarShell>
   );
 }

--- a/src/apps/maps/components/maps-app/MapsAppComponent.tsx
+++ b/src/apps/maps/components/maps-app/MapsAppComponent.tsx
@@ -1,6 +1,5 @@
 import { AppWindowShell } from "@/components/shared/AppWindowShell";
-import { HelpDialog } from "@/components/dialogs/HelpDialog";
-import { AboutDialog } from "@/components/dialogs/AboutDialog";
+import { AppHelpAboutDialogs } from "@/components/shared/AppHelpAboutDialogs";
 import { cn } from "@/lib/utils";
 import type { AppProps } from "@/apps/base/types";
 import { appMetadata } from "../..";
@@ -106,20 +105,15 @@ export function MapsAppComponent({
         ),
       }}
       trailing={
-        <>
-          <HelpDialog
-            isOpen={isHelpDialogOpen}
-            onOpenChange={setIsHelpDialogOpen}
-            appId="maps"
-            helpItems={translatedHelpItems}
-          />
-          <AboutDialog
-            isOpen={isAboutDialogOpen}
-            onOpenChange={setIsAboutDialogOpen}
-            metadata={appMetadata}
-            appId="maps"
-          />
-        </>
+        <AppHelpAboutDialogs
+          appId="maps"
+          helpItems={translatedHelpItems}
+          metadata={appMetadata}
+          isHelpOpen={isHelpDialogOpen}
+          onHelpOpenChange={setIsHelpDialogOpen}
+          isAboutOpen={isAboutDialogOpen}
+          onAboutOpenChange={setIsAboutDialogOpen}
+        />
       }
     >
         <div className="relative size-full min-h-0 flex-1 overflow-hidden bg-transparent font-os-ui">

--- a/src/apps/minesweeper/components/MinesweeperAppComponent.tsx
+++ b/src/apps/minesweeper/components/MinesweeperAppComponent.tsx
@@ -2,8 +2,7 @@ import { useState, useCallback, useRef } from "react";
 import { AppProps } from "../../base/types";
 import { AppWindowShell } from "@/components/shared/AppWindowShell";
 import { MinesweeperMenuBar } from "./MinesweeperMenuBar";
-import { HelpDialog } from "@/components/dialogs/HelpDialog";
-import { AboutDialog } from "@/components/dialogs/AboutDialog";
+import { AppHelpAboutDialogs } from "@/components/shared/AppHelpAboutDialogs";
 import { ConfirmDialog } from "@/components/dialogs/ConfirmDialog";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
@@ -324,15 +323,9 @@ export function MinesweeperAppComponent({
             )}
           </div>
         </div>
-        <HelpDialog
-          isOpen={isHelpDialogOpen}
-          onOpenChange={setIsHelpDialogOpen}
-          helpItems={translatedHelpItems}
+        <AppHelpAboutDialogs
           appId="minesweeper"
-        />
-        <AboutDialog
-          isOpen={isAboutDialogOpen}
-          onOpenChange={setIsAboutDialogOpen}
+          helpItems={translatedHelpItems}
           metadata={
             appMetadata || {
               name: "Minesweeper",
@@ -342,7 +335,10 @@ export function MinesweeperAppComponent({
               icon: "/icons/default/minesweeper.png",
             }
           }
-          appId="minesweeper"
+          isHelpOpen={isHelpDialogOpen}
+          onHelpOpenChange={setIsHelpDialogOpen}
+          isAboutOpen={isAboutDialogOpen}
+          onAboutOpenChange={setIsAboutDialogOpen}
         />
         <ConfirmDialog
           isOpen={isNewGameDialogOpen}

--- a/src/apps/minesweeper/components/MinesweeperMenuBar.tsx
+++ b/src/apps/minesweeper/components/MinesweeperMenuBar.tsx
@@ -1,4 +1,3 @@
-import { MenuBar } from "@/components/layout/MenuBar";
 import {
   MenubarMenu,
   MenubarTrigger,
@@ -6,8 +5,8 @@ import {
   MenubarItem,
   MenubarSeparator,
 } from "@/components/ui/menubar";
-import { AppMenuBarHelpMenu } from "@/components/shared/menubar/AppMenuBarHelpMenu";
-import { AppShareItemDialog } from "@/components/shared/menubar/AppShareItemDialog";
+import { AppMenuBarShell } from "@/components/shared/menubar/AppMenuBarShell";
+import { MENUBAR_SEPARATOR_CLASS } from "@/components/shared/menubar/menubarStyles";
 import { useAppMenuBarChrome } from "@/hooks/useAppMenuBarChrome";
 import { useTranslation } from "react-i18next";
 
@@ -35,7 +34,18 @@ export function MinesweeperMenuBar({
   } = useAppMenuBarChrome("minesweeper");
 
   return (
-    <MenuBar inWindowFrame={isXpTheme}>
+    <AppMenuBarShell
+      isXpTheme={isXpTheme}
+      isMacOsxTheme={isMacOsxTheme}
+      appId={appId}
+      appName={appName}
+      isShareDialogOpen={isShareDialogOpen}
+      setIsShareDialogOpen={setIsShareDialogOpen}
+      helpItemLabel={t("apps.minesweeper.menu.minesweeperHelp")}
+      aboutItemLabel={t("apps.minesweeper.menu.aboutMinesweeper")}
+      onShowHelp={onShowHelp}
+      onShowAbout={onShowAbout}
+    >
       {/* Game Menu */}
       <MenubarMenu>
         <MenubarTrigger className="text-md px-2 py-1 border-none focus-visible:ring-0">
@@ -48,7 +58,7 @@ export function MinesweeperMenuBar({
           >
             {t("apps.minesweeper.menu.newGame")}
           </MenubarItem>
-          <MenubarSeparator className="h-[2px] bg-black my-1" />
+          <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
           <MenubarItem
             onClick={onClose}
             className="text-md h-6 px-3"
@@ -57,21 +67,6 @@ export function MinesweeperMenuBar({
           </MenubarItem>
         </MenubarContent>
       </MenubarMenu>
-
-      <AppMenuBarHelpMenu
-        helpItemLabel={t("apps.minesweeper.menu.minesweeperHelp")}
-        aboutItemLabel={t("apps.minesweeper.menu.aboutMinesweeper")}
-        isMacOsxTheme={isMacOsxTheme}
-        onShowHelp={onShowHelp}
-        onShowAbout={onShowAbout}
-        onOpenShareDialog={() => setIsShareDialogOpen(true)}
-      />
-      <AppShareItemDialog
-        appId={appId}
-        appName={appName}
-        isOpen={isShareDialogOpen}
-        onClose={() => setIsShareDialogOpen(false)}
-      />
-    </MenuBar>
+    </AppMenuBarShell>
   );
 }

--- a/src/apps/paint/components/PaintAppComponent.tsx
+++ b/src/apps/paint/components/PaintAppComponent.tsx
@@ -6,8 +6,7 @@ import { PaintPatternPalette } from "./PaintPatternPalette";
 import { PaintStrokeSettings } from "./PaintStrokeSettings";
 import { AppWindowShell } from "@/components/shared/AppWindowShell";
 import { AppProps, PaintInitialData } from "../../base/types";
-import { HelpDialog } from "@/components/dialogs/HelpDialog";
-import { AboutDialog } from "@/components/dialogs/AboutDialog";
+import { AppHelpAboutDialogs } from "@/components/shared/AppHelpAboutDialogs";
 import { ConfirmDialog } from "@/components/dialogs/ConfirmDialog";
 import { InputDialog } from "@/components/dialogs/InputDialog";
 import { appMetadata } from "..";
@@ -133,17 +132,14 @@ export const PaintAppComponent: React.FC<AppProps<PaintInitialData>> = ({
             value={saveFileName}
             onChange={setSaveFileName}
           />
-          <HelpDialog
-            isOpen={isHelpDialogOpen}
-            onOpenChange={setIsHelpDialogOpen}
+          <AppHelpAboutDialogs
+            appId="paint"
             helpItems={translatedHelpItems}
-            appId="paint"
-          />
-          <AboutDialog
-            isOpen={isAboutDialogOpen}
-            onOpenChange={setIsAboutDialogOpen}
             metadata={appMetadata}
-            appId="paint"
+            isHelpOpen={isHelpDialogOpen}
+            onHelpOpenChange={setIsHelpDialogOpen}
+            isAboutOpen={isAboutDialogOpen}
+            onAboutOpenChange={setIsAboutDialogOpen}
           />
           <ConfirmDialog
             isOpen={isConfirmNewDialogOpen}

--- a/src/apps/paint/components/paint-menu-bar/PaintMenuBar.tsx
+++ b/src/apps/paint/components/paint-menu-bar/PaintMenuBar.tsx
@@ -1,11 +1,9 @@
-import { MenuBar } from "@/components/layout/MenuBar";
-import { AppShareItemDialog } from "@/components/shared/menubar/AppShareItemDialog";
+import { AppMenuBarShell } from "@/components/shared/menubar/AppMenuBarShell";
 import type { PaintMenuBarProps } from "./types";
 import { usePaintMenuBar } from "./usePaintMenuBar";
 import { PaintMenuBarFileMenu } from "./PaintMenuBarFileMenu";
 import { PaintMenuBarEditMenu } from "./PaintMenuBarEditMenu";
 import { PaintMenuBarFiltersMenu } from "./PaintMenuBarFiltersMenu";
-import { AppMenuBarHelpMenu } from "@/components/shared/menubar/AppMenuBarHelpMenu";
 
 export function PaintMenuBar(props: PaintMenuBarProps) {
   const vm = usePaintMenuBar(props);
@@ -13,24 +11,21 @@ export function PaintMenuBar(props: PaintMenuBarProps) {
   if (!vm.isWindowOpen) return null;
 
   return (
-    <MenuBar inWindowFrame={vm.isXpTheme}>
+    <AppMenuBarShell
+      isXpTheme={vm.isXpTheme}
+      isMacOsxTheme={vm.isMacOsxTheme}
+      appId={vm.appId}
+      appName={vm.appName}
+      isShareDialogOpen={vm.isShareDialogOpen}
+      setIsShareDialogOpen={vm.setIsShareDialogOpen}
+      helpItemLabel={vm.t("apps.paint.menu.paintHelp")}
+      aboutItemLabel={vm.t("apps.paint.menu.aboutPaint")}
+      onShowHelp={vm.onShowHelp}
+      onShowAbout={vm.onShowAbout}
+    >
       <PaintMenuBarFileMenu vm={vm} />
       <PaintMenuBarEditMenu vm={vm} />
       <PaintMenuBarFiltersMenu vm={vm} />
-      <AppMenuBarHelpMenu
-        helpItemLabel={vm.t("apps.paint.menu.paintHelp")}
-        aboutItemLabel={vm.t("apps.paint.menu.aboutPaint")}
-        isMacOsxTheme={vm.isMacOsxTheme}
-        onShowHelp={vm.onShowHelp}
-        onShowAbout={vm.onShowAbout}
-        onOpenShareDialog={() => vm.setIsShareDialogOpen(true)}
-      />
-      <AppShareItemDialog
-        appId={vm.appId}
-        appName={vm.appName}
-        isOpen={vm.isShareDialogOpen}
-        onClose={() => vm.setIsShareDialogOpen(false)}
-      />
-    </MenuBar>
+    </AppMenuBarShell>
   );
 }

--- a/src/apps/pc/components/PcAppComponent.tsx
+++ b/src/apps/pc/components/PcAppComponent.tsx
@@ -2,8 +2,7 @@ import { useState } from "react";
 import { AppProps } from "@/apps/base/types";
 import { AppWindowShell } from "@/components/shared/AppWindowShell";
 import { PcMenuBar } from "./PcMenuBar";
-import { HelpDialog } from "@/components/dialogs/HelpDialog";
-import { AboutDialog } from "@/components/dialogs/AboutDialog";
+import { AppHelpAboutDialogs } from "@/components/shared/AppHelpAboutDialogs";
 import { ConfirmDialog } from "@/components/dialogs/ConfirmDialog";
 import { appMetadata } from "..";
 import { getTranslatedAppName } from "@/utils/i18n";
@@ -263,17 +262,14 @@ export function PcAppComponent({
             )}
           </div>
         </div>
-        <HelpDialog
-          isOpen={isHelpDialogOpen}
-          onOpenChange={setIsHelpDialogOpen}
+        <AppHelpAboutDialogs
+          appId="pc"
           helpItems={translatedHelpItems}
-          appId="pc"
-        />
-        <AboutDialog
-          isOpen={isAboutDialogOpen}
-          onOpenChange={setIsAboutDialogOpen}
           metadata={appMetadata}
-          appId="pc"
+          isHelpOpen={isHelpDialogOpen}
+          onHelpOpenChange={setIsHelpDialogOpen}
+          isAboutOpen={isAboutDialogOpen}
+          onAboutOpenChange={setIsAboutDialogOpen}
         />
         <ConfirmDialog
           isOpen={isResetDialogOpen}

--- a/src/apps/pc/components/PcMenuBar.tsx
+++ b/src/apps/pc/components/PcMenuBar.tsx
@@ -1,4 +1,3 @@
-import { MenuBar } from "@/components/layout/MenuBar";
 import {
   MenubarMenu,
   MenubarTrigger,
@@ -9,8 +8,8 @@ import {
   MenubarSubTrigger,
   MenubarSubContent,
 } from "@/components/ui/menubar";
-import { AppMenuBarHelpMenu } from "@/components/shared/menubar/AppMenuBarHelpMenu";
-import { AppShareItemDialog } from "@/components/shared/menubar/AppShareItemDialog";
+import { AppMenuBarShell } from "@/components/shared/menubar/AppMenuBarShell";
+import { MENUBAR_SEPARATOR_CLASS } from "@/components/shared/menubar/menubarStyles";
 import { useAppMenuBarChrome } from "@/hooks/useAppMenuBarChrome";
 import { Game, loadGames } from "@/stores/usePcStore";
 import { useTranslation } from "react-i18next";
@@ -66,7 +65,18 @@ export function PcMenuBar({
   const sensitivityOptions = [0.25, 0.5, 0.75, 1.0, 1.25, 1.5, 2.0];
 
   return (
-    <MenuBar inWindowFrame={isXpTheme}>
+    <AppMenuBarShell
+      isXpTheme={isXpTheme}
+      isMacOsxTheme={isMacOsxTheme}
+      appId={appId}
+      appName={appName}
+      isShareDialogOpen={isShareDialogOpen}
+      setIsShareDialogOpen={setIsShareDialogOpen}
+      helpItemLabel={t("apps.pc.menu.virtualPcHelp")}
+      aboutItemLabel={t("apps.pc.menu.aboutVirtualPc")}
+      onShowHelp={onShowHelp}
+      onShowAbout={onShowAbout}
+    >
       <MenubarMenu>
         <MenubarTrigger className="text-md px-2 py-1 border-none focus-visible:ring-0">
           {t("common.menu.file")}
@@ -90,7 +100,7 @@ export function PcMenuBar({
               ))}
             </MenubarSubContent>
           </MenubarSub>
-          <MenubarSeparator className="h-[2px] bg-black my-1" />
+          <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
           <MenubarItem
             onClick={onSaveState}
             className="text-md h-6 px-3"
@@ -103,14 +113,14 @@ export function PcMenuBar({
           >
             {t("apps.pc.menu.loadState")}
           </MenubarItem>
-          <MenubarSeparator className="h-[2px] bg-black my-1" />
+          <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
           <MenubarItem
             onClick={onReset}
             className="text-md h-6 px-3"
           >
             {t("apps.pc.menu.reset")}
           </MenubarItem>
-          <MenubarSeparator className="h-[2px] bg-black my-1" />
+          <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
           <MenubarItem
             onClick={onClose}
             className="text-md h-6 px-3"
@@ -131,7 +141,7 @@ export function PcMenuBar({
           >
             {t("apps.pc.menu.fullScreen")}
           </MenubarItem>
-          <MenubarSeparator className="h-[2px] bg-black my-1" />
+          <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
           <MenubarItem
             onClick={() => onSetMouseCapture(!isMouseCaptured)}
             className="text-md h-6 px-3"
@@ -156,7 +166,7 @@ export function PcMenuBar({
               ))}
             </MenubarSubContent>
           </MenubarSub>
-          <MenubarSeparator className="h-[2px] bg-black my-1" />
+          <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
           <MenubarSub>
             <MenubarSubTrigger className="text-md h-6 px-3">
               {t("apps.pc.menu.aspectRatio")}
@@ -177,21 +187,6 @@ export function PcMenuBar({
           </MenubarSub>
         </MenubarContent>
       </MenubarMenu>
-
-      <AppMenuBarHelpMenu
-        helpItemLabel={t("apps.pc.menu.virtualPcHelp")}
-        aboutItemLabel={t("apps.pc.menu.aboutVirtualPc")}
-        isMacOsxTheme={isMacOsxTheme}
-        onShowHelp={onShowHelp}
-        onShowAbout={onShowAbout}
-        onOpenShareDialog={() => setIsShareDialogOpen(true)}
-      />
-      <AppShareItemDialog
-        appId={appId}
-        appName={appName}
-        isOpen={isShareDialogOpen}
-        onClose={() => setIsShareDialogOpen(false)}
-      />
-    </MenuBar>
+    </AppMenuBarShell>
   );
 }

--- a/src/apps/photo-booth/components/PhotoBoothComponent.tsx
+++ b/src/apps/photo-booth/components/PhotoBoothComponent.tsx
@@ -1,7 +1,6 @@
 import { Button } from "@/components/ui/button";
 import { AppWindowShell } from "@/components/shared/AppWindowShell";
-import { HelpDialog } from "@/components/dialogs/HelpDialog";
-import { AboutDialog } from "@/components/dialogs/AboutDialog";
+import { AppHelpAboutDialogs } from "@/components/shared/AppHelpAboutDialogs";
 import { appMetadata } from "..";
 import { PhotoBoothMenuBar } from "./PhotoBoothMenuBar";
 import { AppProps } from "../../base/types";
@@ -624,17 +623,14 @@ export function PhotoBoothComponent({
             </div>
           </div>
 
-          <HelpDialog
-            isOpen={showHelp}
-            onOpenChange={setShowHelp}
+          <AppHelpAboutDialogs
+            appId="photo-booth"
             helpItems={translatedHelpItems}
-            appId="photo-booth"
-          />
-          <AboutDialog
-            isOpen={showAbout}
-            onOpenChange={setShowAbout}
             metadata={appMetadata}
-            appId="photo-booth"
+            isHelpOpen={showHelp}
+            onHelpOpenChange={setShowHelp}
+            isAboutOpen={showAbout}
+            onAboutOpenChange={setShowAbout}
           />
         </div>
     </AppWindowShell>

--- a/src/apps/photo-booth/components/PhotoBoothMenuBar.tsx
+++ b/src/apps/photo-booth/components/PhotoBoothMenuBar.tsx
@@ -1,4 +1,3 @@
-import { MenuBar } from "@/components/layout/MenuBar";
 import {
   MenubarMenu,
   MenubarTrigger,
@@ -7,8 +6,8 @@ import {
   MenubarSeparator,
   MenubarCheckboxItem,
 } from "@/components/ui/menubar";
-import { AppMenuBarHelpMenu } from "@/components/shared/menubar/AppMenuBarHelpMenu";
-import { AppShareItemDialog } from "@/components/shared/menubar/AppShareItemDialog";
+import { AppMenuBarShell } from "@/components/shared/menubar/AppMenuBarShell";
+import { MENUBAR_SEPARATOR_CLASS } from "@/components/shared/menubar/menubarStyles";
 import { useAppMenuBarChrome } from "@/hooks/useAppMenuBarChrome";
 import { useTranslation } from "react-i18next";
 
@@ -56,7 +55,18 @@ export function PhotoBoothMenuBar({
   } = useAppMenuBarChrome("photo-booth");
 
   return (
-    <MenuBar inWindowFrame={isXpTheme}>
+    <AppMenuBarShell
+      isXpTheme={isXpTheme}
+      isMacOsxTheme={isMacOsxTheme}
+      appId={appId}
+      appName={appName}
+      isShareDialogOpen={isShareDialogOpen}
+      setIsShareDialogOpen={setIsShareDialogOpen}
+      helpItemLabel={t("apps.photo-booth.menu.photoBoothHelp")}
+      aboutItemLabel={t("apps.photo-booth.menu.aboutPhotoBooth")}
+      onShowHelp={onShowHelp}
+      onShowAbout={onShowAbout}
+    >
       {/* File Menu */}
       <MenubarMenu>
         <MenubarTrigger className="text-md px-2 py-1 border-none focus-visible:ring-0">
@@ -69,14 +79,14 @@ export function PhotoBoothMenuBar({
           >
             {t("apps.photo-booth.menu.exportPhotos")}
           </MenubarItem>
-          <MenubarSeparator className="h-[2px] bg-black my-1" />
+          <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
           <MenubarItem
             onClick={onClearPhotos}
             className="text-md h-6 px-3"
           >
             {t("apps.photo-booth.menu.clearAllPhotos")}
           </MenubarItem>
-          <MenubarSeparator className="h-[2px] bg-black my-1" />
+          <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
           <MenubarItem
             onClick={onClose}
             className="text-md h-6 px-3"
@@ -125,21 +135,6 @@ export function PhotoBoothMenuBar({
           ))}
         </MenubarContent>
       </MenubarMenu>
-
-      <AppMenuBarHelpMenu
-        helpItemLabel={t("apps.photo-booth.menu.photoBoothHelp")}
-        aboutItemLabel={t("apps.photo-booth.menu.aboutPhotoBooth")}
-        isMacOsxTheme={isMacOsxTheme}
-        onShowHelp={onShowHelp}
-        onShowAbout={onShowAbout}
-        onOpenShareDialog={() => setIsShareDialogOpen(true)}
-      />
-      <AppShareItemDialog
-        appId={appId}
-        appName={appName}
-        isOpen={isShareDialogOpen}
-        onClose={() => setIsShareDialogOpen(false)}
-      />
-    </MenuBar>
+    </AppMenuBarShell>
   );
 }

--- a/src/apps/soundboard/components/SoundboardAppComponent.tsx
+++ b/src/apps/soundboard/components/SoundboardAppComponent.tsx
@@ -3,8 +3,7 @@ import { BoardList } from "./BoardList";
 import { SoundGrid } from "./SoundGrid";
 import { EmojiDialog } from "@/components/dialogs/EmojiDialog";
 import { InputDialog } from "@/components/dialogs/InputDialog";
-import { HelpDialog } from "@/components/dialogs/HelpDialog";
-import { AboutDialog } from "@/components/dialogs/AboutDialog";
+import { AppHelpAboutDialogs } from "@/components/shared/AppHelpAboutDialogs";
 import { AppProps } from "../../base/types";
 import { SoundboardMenuBar } from "./SoundboardMenuBar";
 import { appMetadata } from "..";
@@ -211,17 +210,14 @@ export function SoundboardAppComponent({
           onChange={(value) => setDialogState((prev) => ({ ...prev, value }))}
         />
 
-        <HelpDialog
-          isOpen={helpDialogOpen}
-          onOpenChange={setHelpDialogOpen}
+        <AppHelpAboutDialogs
+          appId="soundboard"
           helpItems={translatedHelpItems}
-          appId="soundboard"
-        />
-        <AboutDialog
-          isOpen={aboutDialogOpen}
-          onOpenChange={setAboutDialogOpen}
           metadata={appMetadata}
-          appId="soundboard"
+          isHelpOpen={helpDialogOpen}
+          onHelpOpenChange={setHelpDialogOpen}
+          isAboutOpen={aboutDialogOpen}
+          onAboutOpenChange={setAboutDialogOpen}
         />
         </>
       )}

--- a/src/apps/soundboard/components/SoundboardMenuBar.tsx
+++ b/src/apps/soundboard/components/SoundboardMenuBar.tsx
@@ -7,10 +7,9 @@ import {
   MenubarCheckboxItem,
 } from "@/components/ui/menubar";
 import { AppProps } from "../../base/types";
-import { MenuBar } from "@/components/layout/MenuBar";
 import { useState, useEffect } from "react";
-import { AppMenuBarHelpMenu } from "@/components/shared/menubar/AppMenuBarHelpMenu";
-import { AppShareItemDialog } from "@/components/shared/menubar/AppShareItemDialog";
+import { AppMenuBarShell } from "@/components/shared/menubar/AppMenuBarShell";
+import { MENUBAR_SEPARATOR_CLASS } from "@/components/shared/menubar/menubarStyles";
 import { useAppMenuBarChrome } from "@/hooks/useAppMenuBarChrome";
 import { useTranslation } from "react-i18next";
 
@@ -82,7 +81,18 @@ export function SoundboardMenuBar({
   }, []);
 
   return (
-    <MenuBar inWindowFrame={isXpTheme}>
+    <AppMenuBarShell
+      isXpTheme={isXpTheme}
+      isMacOsxTheme={isMacOsxTheme}
+      appId={appId}
+      appName={appName}
+      isShareDialogOpen={isShareDialogOpen}
+      setIsShareDialogOpen={setIsShareDialogOpen}
+      helpItemLabel={t("apps.soundboard.menu.soundboardHelp")}
+      aboutItemLabel={t("apps.soundboard.menu.aboutSoundboard")}
+      onShowHelp={onShowHelp}
+      onShowAbout={onShowAbout}
+    >
       {/* File Menu */}
       <MenubarMenu>
         <MenubarTrigger className="text-md px-2 py-1 border-none focus-visible:ring-0">
@@ -95,7 +105,7 @@ export function SoundboardMenuBar({
           >
             {t("apps.soundboard.menu.newSoundboard")}
           </MenubarItem>
-          <MenubarSeparator className="h-[2px] bg-black my-1" />
+          <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
           <MenubarItem
             onClick={onImportBoard}
             className="text-md h-6 px-3"
@@ -122,7 +132,7 @@ export function SoundboardMenuBar({
               {t("apps.soundboard.menu.loadSpecialSoundboards")}
             </MenubarItem>
           )}
-          <MenubarSeparator className="h-[2px] bg-black my-1" />
+          <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
           <MenubarItem
             onClick={onClose}
             className="text-md h-6 px-3"
@@ -180,21 +190,6 @@ export function SoundboardMenuBar({
           </MenubarCheckboxItem>
         </MenubarContent>
       </MenubarMenu>
-
-      <AppMenuBarHelpMenu
-        helpItemLabel={t("apps.soundboard.menu.soundboardHelp")}
-        aboutItemLabel={t("apps.soundboard.menu.aboutSoundboard")}
-        isMacOsxTheme={isMacOsxTheme}
-        onShowHelp={onShowHelp}
-        onShowAbout={onShowAbout}
-        onOpenShareDialog={() => setIsShareDialogOpen(true)}
-      />
-      <AppShareItemDialog
-        appId={appId}
-        appName={appName}
-        isOpen={isShareDialogOpen}
-        onClose={() => setIsShareDialogOpen(false)}
-      />
-    </MenuBar>
+    </AppMenuBarShell>
   );
 }

--- a/src/apps/stickies/components/StickiesAppComponent.tsx
+++ b/src/apps/stickies/components/StickiesAppComponent.tsx
@@ -6,8 +6,7 @@ import { StickiesMenuBar } from "./StickiesMenuBar";
 import { AppProps } from "@/apps/base/types";
 import { AppWindowShell } from "@/components/shared/AppWindowShell";
 import { useStickiesLogic } from "../hooks/useStickiesLogic";
-import { HelpDialog } from "@/components/dialogs/HelpDialog";
-import { AboutDialog } from "@/components/dialogs/AboutDialog";
+import { AppHelpAboutDialogs } from "@/components/shared/AppHelpAboutDialogs";
 import { appMetadata } from "..";
 import { useAppStore } from "@/stores/useAppStore";
 import { requestCloudSyncDomainCheck } from "@/utils/cloudSyncEvents";
@@ -117,17 +116,14 @@ export function StickiesAppComponent({
       menuBar={menuBar}
       trailing={
         <>
-          <HelpDialog
-            isOpen={isHelpDialogOpen}
-            onOpenChange={setIsHelpDialogOpen}
+          <AppHelpAboutDialogs
             appId="stickies"
             helpItems={translatedHelpItems}
-          />
-          <AboutDialog
-            isOpen={isAboutDialogOpen}
-            onOpenChange={setIsAboutDialogOpen}
             metadata={appMetadata}
-            appId="stickies"
+            isHelpOpen={isHelpDialogOpen}
+            onHelpOpenChange={setIsHelpDialogOpen}
+            isAboutOpen={isAboutDialogOpen}
+            onAboutOpenChange={setIsAboutDialogOpen}
           />
         </>
       }

--- a/src/apps/stickies/components/StickiesMenuBar.tsx
+++ b/src/apps/stickies/components/StickiesMenuBar.tsx
@@ -1,4 +1,3 @@
-import { MenuBar } from "@/components/layout/MenuBar";
 import {
   MenubarMenu,
   MenubarTrigger,
@@ -9,8 +8,7 @@ import {
   MenubarSubTrigger,
   MenubarSubContent,
 } from "@/components/ui/menubar";
-import { AppMenuBarHelpMenu } from "@/components/shared/menubar/AppMenuBarHelpMenu";
-import { AppShareItemDialog } from "@/components/shared/menubar/AppShareItemDialog";
+import { AppMenuBarShell } from "@/components/shared/menubar/AppMenuBarShell";
 import {
   MENUBAR_ITEM_CLASS,
   MENUBAR_SEPARATOR_CLASS,
@@ -62,7 +60,18 @@ export function StickiesMenuBar({
   } = useAppMenuBarChrome("stickies");
 
   return (
-    <MenuBar inWindowFrame={isXpTheme}>
+    <AppMenuBarShell
+      isXpTheme={isXpTheme}
+      isMacOsxTheme={isMacOsxTheme}
+      appId={appId}
+      appName={appName}
+      isShareDialogOpen={isShareDialogOpen}
+      setIsShareDialogOpen={setIsShareDialogOpen}
+      helpItemLabel={t("apps.stickies.menu.help")}
+      aboutItemLabel={t("apps.stickies.menu.about")}
+      onShowHelp={onShowHelp}
+      onShowAbout={onShowAbout}
+    >
       <MenubarMenu>
         <MenubarTrigger className={MENUBAR_TRIGGER_CLASS}>
           {t("common.menu.file")}
@@ -131,21 +140,6 @@ export function StickiesMenuBar({
           </MenubarItem>
         </MenubarContent>
       </MenubarMenu>
-
-      <AppMenuBarHelpMenu
-        helpItemLabel={t("apps.stickies.menu.help")}
-        aboutItemLabel={t("apps.stickies.menu.about")}
-        isMacOsxTheme={isMacOsxTheme}
-        onShowHelp={onShowHelp}
-        onShowAbout={onShowAbout}
-        onOpenShareDialog={() => setIsShareDialogOpen(true)}
-      />
-      <AppShareItemDialog
-        appId={appId}
-        appName={appName}
-        isOpen={isShareDialogOpen}
-        onClose={() => setIsShareDialogOpen(false)}
-      />
-    </MenuBar>
+    </AppMenuBarShell>
   );
 }

--- a/src/apps/synth/components/SynthAppComponent.tsx
+++ b/src/apps/synth/components/SynthAppComponent.tsx
@@ -1,1 +1,0 @@
-export { SynthAppComponent } from "./synth-app/SynthAppComponent";

--- a/src/apps/synth/components/SynthMenuBar.tsx
+++ b/src/apps/synth/components/SynthMenuBar.tsx
@@ -1,4 +1,3 @@
-import { MenuBar } from "@/components/layout/MenuBar";
 import {
   MenubarMenu,
   MenubarTrigger,
@@ -7,8 +6,8 @@ import {
   MenubarSeparator,
   MenubarCheckboxItem,
 } from "@/components/ui/menubar";
-import { AppMenuBarHelpMenu } from "@/components/shared/menubar/AppMenuBarHelpMenu";
-import { AppShareItemDialog } from "@/components/shared/menubar/AppShareItemDialog";
+import { AppMenuBarShell } from "@/components/shared/menubar/AppMenuBarShell";
+import { MENUBAR_SEPARATOR_CLASS } from "@/components/shared/menubar/menubarStyles";
 import { useAppMenuBarChrome } from "@/hooks/useAppMenuBarChrome";
 import type { NoteLabelType } from "@/stores/useSynthStore";
 import { useTranslation } from "react-i18next";
@@ -49,7 +48,18 @@ export function SynthMenuBar({
   } = useAppMenuBarChrome("synth");
 
   return (
-    <MenuBar inWindowFrame={isXpTheme}>
+    <AppMenuBarShell
+      isXpTheme={isXpTheme}
+      isMacOsxTheme={isMacOsxTheme}
+      appId={appId}
+      appName={appName}
+      isShareDialogOpen={isShareDialogOpen}
+      setIsShareDialogOpen={setIsShareDialogOpen}
+      helpItemLabel={t("apps.synth.menu.synthHelp")}
+      aboutItemLabel={t("apps.synth.menu.aboutSynth")}
+      onShowHelp={onShowHelp}
+      onShowAbout={onShowAbout}
+    >
       {/* File Menu */}
       <MenubarMenu>
         <MenubarTrigger className="text-md px-2 py-1 border-none focus-visible:ring-0">
@@ -68,7 +78,7 @@ export function SynthMenuBar({
           >
             {t("apps.synth.menu.resetSynth")}
           </MenubarItem>
-          <MenubarSeparator className="h-[2px] bg-black my-1" />
+          <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
           <MenubarItem
             onClick={onClose}
             className="text-md h-6 px-3"
@@ -135,20 +145,6 @@ export function SynthMenuBar({
         </MenubarContent>
       </MenubarMenu>
 
-      <AppMenuBarHelpMenu
-        helpItemLabel={t("apps.synth.menu.synthHelp")}
-        aboutItemLabel={t("apps.synth.menu.aboutSynth")}
-        isMacOsxTheme={isMacOsxTheme}
-        onShowHelp={onShowHelp}
-        onShowAbout={onShowAbout}
-        onOpenShareDialog={() => setIsShareDialogOpen(true)}
-      />
-      <AppShareItemDialog
-        appId={appId}
-        appName={appName}
-        isOpen={isShareDialogOpen}
-        onClose={() => setIsShareDialogOpen(false)}
-      />
-    </MenuBar>
+    </AppMenuBarShell>
   );
 }

--- a/src/apps/synth/components/synth-app/SynthAppDialogs.tsx
+++ b/src/apps/synth/components/synth-app/SynthAppDialogs.tsx
@@ -1,5 +1,4 @@
-import { HelpDialog } from "@/components/dialogs/HelpDialog";
-import { AboutDialog } from "@/components/dialogs/AboutDialog";
+import { AppHelpAboutDialogs } from "@/components/shared/AppHelpAboutDialogs";
 import { InputDialog } from "@/components/dialogs/InputDialog";
 import { appMetadata } from "../..";
 import type { SynthAppController } from "./useSynthAppController";
@@ -36,18 +35,14 @@ export function SynthAppDialogs({
 }: SynthAppDialogsProps) {
   return (
     <>
-      <HelpDialog
-        isOpen={isHelpOpen}
-        onOpenChange={setIsHelpOpen}
+      <AppHelpAboutDialogs
+        appId="synth"
         helpItems={translatedHelpItems}
-        appId="synth"
-      />
-
-      <AboutDialog
-        isOpen={isAboutOpen}
-        onOpenChange={setIsAboutOpen}
         metadata={appMetadata}
-        appId="synth"
+        isHelpOpen={isHelpOpen}
+        onHelpOpenChange={setIsHelpOpen}
+        isAboutOpen={isAboutOpen}
+        onAboutOpenChange={setIsAboutOpen}
       />
 
       <InputDialog

--- a/src/apps/synth/index.tsx
+++ b/src/apps/synth/index.tsx
@@ -1,5 +1,5 @@
 import { BaseApp } from "../base/types";
-import { SynthAppComponent } from "./components/SynthAppComponent";
+import { SynthAppComponent } from "./components/synth-app/SynthAppComponent";
 
 // Re-export metadata from separate file to avoid eager loading of components
 export { appMetadata, helpItems } from "./metadata";

--- a/src/apps/terminal/components/TerminalAppComponent.tsx
+++ b/src/apps/terminal/components/TerminalAppComponent.tsx
@@ -3,8 +3,7 @@ import { motion, AnimatePresence } from "framer-motion";
 import { AppWindowShell } from "@/components/shared/AppWindowShell";
 import { AppProps } from "@/apps/base/types";
 import type { TerminalInitialData } from "@/apps/base/types";
-import { HelpDialog } from "@/components/dialogs/HelpDialog";
-import { AboutDialog } from "@/components/dialogs/AboutDialog";
+import { AppHelpAboutDialogs } from "@/components/shared/AppHelpAboutDialogs";
 import { TerminalMenuBar } from "./TerminalMenuBar";
 import { appMetadata } from "../index";
 import HtmlPreview from "@/components/shared/HtmlPreview";
@@ -569,31 +568,26 @@ export function TerminalAppComponent({
         onNavigatePrevious,
       }}
       trailing={
-        <>
-          <HelpDialog
-            isOpen={isHelpDialogOpen}
-            onOpenChange={setIsHelpDialogOpen}
-            appId="terminal"
-            helpItems={translatedHelpItems}
-          />
-          <AboutDialog
-            isOpen={isAboutDialogOpen}
-            onOpenChange={setIsAboutDialogOpen}
-            metadata={
-              appMetadata || {
-                name: "Terminal",
-                version: "1.0",
-                creator: {
-                  name: "Ryo Lu",
-                  url: "https://ryo.lu",
-                },
-                github: "https://github.com/ryokun6/ryos",
-                icon: "/icons/default/terminal.png",
-              }
+        <AppHelpAboutDialogs
+          appId="terminal"
+          helpItems={translatedHelpItems}
+          metadata={
+            appMetadata || {
+              name: "Terminal",
+              version: "1.0",
+              creator: {
+                name: "Ryo Lu",
+                url: "https://ryo.lu",
+              },
+              github: "https://github.com/ryokun6/ryos",
+              icon: "/icons/default/terminal.png",
             }
-            appId="terminal"
-          />
-        </>
+          }
+          isHelpOpen={isHelpDialogOpen}
+          onHelpOpenChange={setIsHelpDialogOpen}
+          isAboutOpen={isAboutDialogOpen}
+          onAboutOpenChange={setIsAboutDialogOpen}
+        />
       }
     >
         <motion.div

--- a/src/apps/terminal/components/TerminalMenuBar.tsx
+++ b/src/apps/terminal/components/TerminalMenuBar.tsx
@@ -1,4 +1,3 @@
-import { MenuBar } from "@/components/layout/MenuBar";
 import {
   MenubarMenu,
   MenubarTrigger,
@@ -7,8 +6,8 @@ import {
   MenubarSeparator,
   MenubarCheckboxItem,
 } from "@/components/ui/menubar";
-import { AppMenuBarHelpMenu } from "@/components/shared/menubar/AppMenuBarHelpMenu";
-import { AppShareItemDialog } from "@/components/shared/menubar/AppShareItemDialog";
+import { AppMenuBarShell } from "@/components/shared/menubar/AppMenuBarShell";
+import { MENUBAR_SEPARATOR_CLASS } from "@/components/shared/menubar/menubarStyles";
 import { useAppMenuBarChrome } from "@/hooks/useAppMenuBarChrome";
 import { useTranslation } from "react-i18next";
 
@@ -46,7 +45,18 @@ export function TerminalMenuBar({
   } = useAppMenuBarChrome("terminal");
 
   return (
-    <MenuBar inWindowFrame={isXpTheme}>
+    <AppMenuBarShell
+      isXpTheme={isXpTheme}
+      isMacOsxTheme={isMacOsxTheme}
+      appId={appId}
+      appName={appName}
+      isShareDialogOpen={isShareDialogOpen}
+      setIsShareDialogOpen={setIsShareDialogOpen}
+      helpItemLabel={t("apps.terminal.menu.terminalHelp")}
+      aboutItemLabel={t("apps.terminal.menu.aboutTerminal")}
+      onShowHelp={onShowHelp}
+      onShowAbout={onShowAbout}
+    >
       {/* File Menu */}
       <MenubarMenu>
         <MenubarTrigger className="text-md px-2 py-1 border-none focus-visible:ring-0">
@@ -59,7 +69,7 @@ export function TerminalMenuBar({
           >
             {t("apps.terminal.menu.clearTerminal")}
           </MenubarItem>
-          <MenubarSeparator className="h-[2px] bg-black my-1" />
+          <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
           <MenubarItem
             onClick={onClose}
             className="text-md h-6 px-3"
@@ -81,7 +91,7 @@ export function TerminalMenuBar({
           <MenubarItem className="text-md h-6 px-3">
             {t("common.menu.paste")}
           </MenubarItem>
-          <MenubarSeparator className="h-[2px] bg-black my-1" />
+          <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
           <MenubarItem className="text-md h-6 px-3">
             {t("common.menu.selectAll")}
           </MenubarItem>
@@ -106,7 +116,7 @@ export function TerminalMenuBar({
           >
             {t("apps.terminal.menu.decreaseFontSize")}
           </MenubarItem>
-          <MenubarSeparator className="h-[2px] bg-black my-1" />
+          <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
           <MenubarItem
             onClick={onResetFontSize}
             className="text-md h-6 px-3"
@@ -115,7 +125,7 @@ export function TerminalMenuBar({
           </MenubarItem>
           {onToggleMute && (
             <>
-              <MenubarSeparator className="h-[2px] bg-black my-1" />
+              <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
               <MenubarCheckboxItem
                 checked={isMuted}
                 onCheckedChange={(checked) => {
@@ -130,20 +140,6 @@ export function TerminalMenuBar({
         </MenubarContent>
       </MenubarMenu>
 
-      <AppMenuBarHelpMenu
-        helpItemLabel={t("apps.terminal.menu.terminalHelp")}
-        aboutItemLabel={t("apps.terminal.menu.aboutTerminal")}
-        isMacOsxTheme={isMacOsxTheme}
-        onShowHelp={onShowHelp}
-        onShowAbout={onShowAbout}
-        onOpenShareDialog={() => setIsShareDialogOpen(true)}
-      />
-      <AppShareItemDialog
-        appId={appId}
-        appName={appName}
-        isOpen={isShareDialogOpen}
-        onClose={() => setIsShareDialogOpen(false)}
-      />
-    </MenuBar>
+    </AppMenuBarShell>
   );
 }

--- a/src/apps/textedit/components/DialogManager.tsx
+++ b/src/apps/textedit/components/DialogManager.tsx
@@ -1,6 +1,5 @@
 import React, { useMemo, useState } from "react";
-import { HelpDialog } from "@/components/dialogs/HelpDialog";
-import { AboutDialog } from "@/components/dialogs/AboutDialog";
+import { AppHelpAboutDialogs } from "@/components/shared/AppHelpAboutDialogs";
 import { InputDialog } from "@/components/dialogs/InputDialog";
 import { ConfirmDialog } from "@/components/dialogs/ConfirmDialog";
 import { appMetadata, helpItems } from "..";
@@ -127,18 +126,14 @@ export function DialogManager({
         ]}
       />
 
-      <HelpDialog
-        isOpen={isHelpDialogOpen}
-        onOpenChange={setIsHelpDialogOpen}
+      <AppHelpAboutDialogs
+        appId="textedit"
         helpItems={translatedHelpItems}
-        appId="textedit"
-      />
-
-      <AboutDialog
-        isOpen={isAboutDialogOpen}
-        onOpenChange={setIsAboutDialogOpen}
         metadata={appMetadata}
-        appId="textedit"
+        isHelpOpen={isHelpDialogOpen}
+        onHelpOpenChange={setIsHelpDialogOpen}
+        isAboutOpen={isAboutDialogOpen}
+        onAboutOpenChange={setIsAboutDialogOpen}
       />
     </>
   );

--- a/src/apps/textedit/components/TextEditMenuBar.tsx
+++ b/src/apps/textedit/components/TextEditMenuBar.tsx
@@ -1,5 +1,4 @@
 import { Editor } from "@tiptap/react";
-import { MenuBar } from "@/components/layout/MenuBar";
 import {
   MenubarMenu,
   MenubarTrigger,
@@ -11,8 +10,8 @@ import {
   MenubarSubContent,
   MenubarCheckboxItem,
 } from "@/components/ui/menubar";
-import { AppMenuBarHelpMenu } from "@/components/shared/menubar/AppMenuBarHelpMenu";
-import { AppShareItemDialog } from "@/components/shared/menubar/AppShareItemDialog";
+import { AppMenuBarShell } from "@/components/shared/menubar/AppMenuBarShell";
+import { MENUBAR_SEPARATOR_CLASS } from "@/components/shared/menubar/menubarStyles";
 import { useAppMenuBarChrome } from "@/hooks/useAppMenuBarChrome";
 import React from "react";
 import { useTranslation } from "react-i18next";
@@ -61,7 +60,18 @@ export function TextEditMenuBar({
   const fileInputRef = React.useRef<HTMLInputElement>(null);
 
   return (
-    <MenuBar inWindowFrame={isXpTheme}>
+    <AppMenuBarShell
+      isXpTheme={isXpTheme}
+      isMacOsxTheme={isMacOsxTheme}
+      appId={appId}
+      appName={appName}
+      isShareDialogOpen={isShareDialogOpen}
+      setIsShareDialogOpen={setIsShareDialogOpen}
+      helpItemLabel={t("apps.textedit.menu.texteditHelp")}
+      aboutItemLabel={t("apps.textedit.menu.aboutTextEdit")}
+      onShowHelp={onShowHelp}
+      onShowAbout={onShowAbout}
+    >
       <input
         type="file"
         ref={fileInputRef}
@@ -80,7 +90,7 @@ export function TextEditMenuBar({
           >
             {t("apps.textedit.menu.newFile")}
           </MenubarItem>
-          <MenubarSeparator className="h-[2px] bg-black my-1" />
+          <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
           <MenubarItem
             onClick={onImportFile}
             className="text-md h-6 px-3"
@@ -93,7 +103,7 @@ export function TextEditMenuBar({
           >
             {currentFilePath ? t("apps.textedit.menu.save") : t("apps.textedit.menu.saveEllipsis")}
           </MenubarItem>
-          <MenubarSeparator className="h-[2px] bg-black my-1" />
+          <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
           <MenubarItem
             onClick={() => fileInputRef.current?.click()}
             className="text-md h-6 px-3"
@@ -125,7 +135,7 @@ export function TextEditMenuBar({
               </MenubarItem>
             </MenubarSubContent>
           </MenubarSub>
-          <MenubarSeparator className="h-[2px] bg-black my-1" />
+          <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
           <MenubarItem
             onClick={onClose}
             className="text-md h-6 px-3"
@@ -154,7 +164,7 @@ export function TextEditMenuBar({
           >
             {t("common.menu.redo")}
           </MenubarItem>
-          <MenubarSeparator className="h-[2px] bg-black my-1" />
+          <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
           <MenubarItem
             onClick={() => {
               if (window.getSelection()?.toString()) {
@@ -181,7 +191,7 @@ export function TextEditMenuBar({
           >
             {t("common.menu.paste")}
           </MenubarItem>
-          <MenubarSeparator className="h-[2px] bg-black my-1" />
+          <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
           <MenubarItem
             onClick={() => editor?.chain().focus().selectAll().run()}
             className="text-md h-6 px-3"
@@ -217,7 +227,7 @@ export function TextEditMenuBar({
           >
             {t("apps.textedit.menu.underline")}
           </MenubarCheckboxItem>
-          <MenubarSeparator className="h-[2px] bg-black my-1" />
+          <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
           <MenubarCheckboxItem
             checked={editor?.isActive("paragraph") ?? false}
             onCheckedChange={() => editor?.chain().focus().setParagraph().run()}
@@ -246,7 +256,7 @@ export function TextEditMenuBar({
           >
             {t("apps.textedit.menu.heading3")}
           </MenubarCheckboxItem>
-          <MenubarSeparator className="h-[2px] bg-black my-1" />
+          <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
           <MenubarCheckboxItem
             checked={editor?.isActive({ textAlign: "left" }) ?? false}
             onCheckedChange={() => editor?.chain().focus().setTextAlign("left").run()}
@@ -268,7 +278,7 @@ export function TextEditMenuBar({
           >
             {t("apps.textedit.menu.alignRight")}
           </MenubarCheckboxItem>
-          <MenubarSeparator className="h-[2px] bg-black my-1" />
+          <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
           <MenubarCheckboxItem
             checked={editor?.isActive("bulletList") ?? false}
             onCheckedChange={() => editor?.chain().focus().toggleBulletList().run()}
@@ -293,20 +303,6 @@ export function TextEditMenuBar({
         </MenubarContent>
       </MenubarMenu>
 
-      <AppMenuBarHelpMenu
-        helpItemLabel={t("apps.textedit.menu.texteditHelp")}
-        aboutItemLabel={t("apps.textedit.menu.aboutTextEdit")}
-        isMacOsxTheme={isMacOsxTheme}
-        onShowHelp={onShowHelp}
-        onShowAbout={onShowAbout}
-        onOpenShareDialog={() => setIsShareDialogOpen(true)}
-      />
-      <AppShareItemDialog
-        appId={appId}
-        appName={appName}
-        isOpen={isShareDialogOpen}
-        onClose={() => setIsShareDialogOpen(false)}
-      />
-    </MenuBar>
+    </AppMenuBarShell>
   );
 }

--- a/src/apps/tv/components/TvAppComponent.tsx
+++ b/src/apps/tv/components/TvAppComponent.tsx
@@ -1,1 +1,0 @@
-export { TvAppComponent } from "./tv-app/TvAppComponent";

--- a/src/apps/tv/components/TvMenuBar.tsx
+++ b/src/apps/tv/components/TvMenuBar.tsx
@@ -1,4 +1,3 @@
-import { MenuBar } from "@/components/layout/MenuBar";
 import {
   MenubarMenu,
   MenubarTrigger,
@@ -9,8 +8,7 @@ import {
   MenubarRadioGroup,
   MenubarRadioItem,
 } from "@/components/ui/menubar";
-import { AppMenuBarHelpMenu } from "@/components/shared/menubar/AppMenuBarHelpMenu";
-import { AppShareItemDialog } from "@/components/shared/menubar/AppShareItemDialog";
+import { AppMenuBarShell } from "@/components/shared/menubar/AppMenuBarShell";
 import {
   MENUBAR_ITEM_CLASS,
   MENUBAR_SEPARATOR_CLASS,
@@ -88,7 +86,18 @@ export function TvMenuBar({
   } = useAppMenuBarChrome("tv");
 
   return (
-    <MenuBar inWindowFrame={isXpTheme}>
+    <AppMenuBarShell
+      isXpTheme={isXpTheme}
+      isMacOsxTheme={isMacOsxTheme}
+      appId={appId}
+      appName={appName}
+      isShareDialogOpen={isShareDialogOpen}
+      setIsShareDialogOpen={setIsShareDialogOpen}
+      helpItemLabel={t("apps.tv.menu.tvHelp")}
+      aboutItemLabel={t("apps.tv.menu.about")}
+      onShowHelp={onShowHelp}
+      onShowAbout={onShowAbout}
+    >
       <MenubarMenu>
         <MenubarTrigger className={MENUBAR_TRIGGER_CLASS}>
           {t("common.menu.file")}
@@ -204,20 +213,6 @@ export function TvMenuBar({
         </MenubarContent>
       </MenubarMenu>
 
-      <AppMenuBarHelpMenu
-        helpItemLabel={t("apps.tv.menu.tvHelp")}
-        aboutItemLabel={t("apps.tv.menu.about")}
-        isMacOsxTheme={isMacOsxTheme}
-        onShowHelp={onShowHelp}
-        onShowAbout={onShowAbout}
-        onOpenShareDialog={() => setIsShareDialogOpen(true)}
-      />
-      <AppShareItemDialog
-        appId={appId}
-        appName={appName}
-        isOpen={isShareDialogOpen}
-        onClose={() => setIsShareDialogOpen(false)}
-      />
-    </MenuBar>
+    </AppMenuBarShell>
   );
 }

--- a/src/apps/tv/components/tv-app/TvAppComponent.tsx
+++ b/src/apps/tv/components/tv-app/TvAppComponent.tsx
@@ -8,8 +8,7 @@ import { ChannelPromptInput } from "../ChannelPromptInput";
 import { TvCrtEffects } from "../TvCrtEffects";
 import { TvVideoDrawer } from "../TvVideoDrawer";
 import { LoginDialog } from "@/components/dialogs/LoginDialog";
-import { HelpDialog } from "@/components/dialogs/HelpDialog";
-import { AboutDialog } from "@/components/dialogs/AboutDialog";
+import { AppHelpAboutDialogs } from "@/components/shared/AppHelpAboutDialogs";
 import { ConfirmDialog } from "@/components/dialogs/ConfirmDialog";
 import { appMetadata } from "../..";
 import { Button } from "@/components/ui/button";
@@ -85,17 +84,14 @@ export function TvAppComponent(props: AppProps) {
       }}
       trailing={
         <>
-          <HelpDialog
-            isOpen={c.isHelpDialogOpen}
-            onOpenChange={c.setIsHelpDialogOpen}
+          <AppHelpAboutDialogs
             appId="tv"
             helpItems={c.translatedHelpItems}
-          />
-          <AboutDialog
-            isOpen={c.isAboutDialogOpen}
-            onOpenChange={c.setIsAboutDialogOpen}
             metadata={appMetadata}
-            appId="tv"
+            isHelpOpen={c.isHelpDialogOpen}
+            onHelpOpenChange={c.setIsHelpDialogOpen}
+            isAboutOpen={c.isAboutDialogOpen}
+            onAboutOpenChange={c.setIsAboutDialogOpen}
           />
           <CreateChannelDialog
             isOpen={c.isCreateChannelOpen}

--- a/src/apps/tv/components/tv-app/TvLcdWidgets.tsx
+++ b/src/apps/tv/components/tv-app/TvLcdWidgets.tsx
@@ -1,11 +1,7 @@
-import {
-  memo,
-  useEffect,
-  useRef,
-  useState,
-} from "react";
+import { memo, useRef } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { cn } from "@/lib/utils";
+import { useTextOverflow } from "@/hooks/useTextOverflow";
 import {
   MARQUEE_INITIAL,
   MARQUEE_NAME_TRANSITION,
@@ -72,20 +68,7 @@ export const ScrollingChannelName = memo(function ScrollingChannelName({
 }) {
   const containerRef = useRef<HTMLDivElement>(null);
   const contentRef = useRef<HTMLSpanElement>(null);
-  const [overflows, setOverflows] = useState(false);
-
-  useEffect(() => {
-    const container = containerRef.current;
-    const content = contentRef.current;
-    if (!container || !content) return;
-    const check = () => {
-      setOverflows(content.scrollWidth > container.clientWidth + 1);
-    };
-    check();
-    const ro = new ResizeObserver(check);
-    ro.observe(container);
-    return () => ro.disconnect();
-  }, [name]);
+  const overflows = useTextOverflow(containerRef, contentRef, [name]);
 
   const shouldAnimate = overflows && isPlaying;
   const marqueeAnimate = shouldAnimate

--- a/src/apps/tv/index.tsx
+++ b/src/apps/tv/index.tsx
@@ -1,5 +1,5 @@
 import { BaseApp } from "../base/types";
-import { TvAppComponent } from "./components/TvAppComponent";
+import { TvAppComponent } from "./components/tv-app/TvAppComponent";
 
 export { appMetadata, helpItems } from "./metadata";
 import { appMetadata, helpItems } from "./metadata";

--- a/src/apps/tv/utils.ts
+++ b/src/apps/tv/utils.ts
@@ -4,8 +4,8 @@
  */
 
 import {
-  isYouTubeHostname,
   isYouTubeUrl as isYouTubeHostUrl,
+  parseYouTubeVideoId,
 } from "@/utils/youtubeUrl";
 
 /** @see {@link isYouTubeHostUrl} in `@/utils/youtubeUrl` */
@@ -13,38 +13,9 @@ export function isYouTubeUrl(url: string | undefined | null): boolean {
   return isYouTubeHostUrl(url);
 }
 
-/**
- * Extract a YouTube video id from a raw 11-char id or any supported
- * YouTube URL (watch, youtu.be, embed, shorts, v/). Returns null for
- * unsupported hosts or invalid input.
- *
- * Host validation uses the same exact-match allow-list as `isYouTubeUrl`,
- * so substring-confusable hosts like `evil-youtube.com` cannot slip
- * through.
- */
+/** @see {@link parseYouTubeVideoId} in `@/utils/youtubeUrl` */
 export function parseYouTubeId(input: string | undefined | null): string | null {
-  if (!input) return null;
-  const trimmed = input.trim();
-  if (!trimmed) return null;
-  if (/^[a-zA-Z0-9_-]{11}$/.test(trimmed)) return trimmed;
-  try {
-    const url = new URL(trimmed);
-    const hostname = url.hostname.toLowerCase();
-    if (!isYouTubeHostname(hostname)) return null;
-
-    const v = url.searchParams.get("v");
-    if (v && /^[a-zA-Z0-9_-]{11}$/.test(v)) return v;
-    if (hostname === "youtu.be") {
-      const id = url.pathname.slice(1).split("/")[0] ?? "";
-      return /^[a-zA-Z0-9_-]{11}$/.test(id) ? id : null;
-    }
-    const m = url.pathname.match(
-      /\/(?:embed\/|v\/|shorts\/)?([a-zA-Z0-9_-]{11})/
-    );
-    return m ? m[1] : null;
-  } catch {
-    return null;
-  }
+  return parseYouTubeVideoId(input);
 }
 
 /**

--- a/src/apps/tv/utils/youtubeFromPrompt.ts
+++ b/src/apps/tv/utils/youtubeFromPrompt.ts
@@ -1,7 +1,6 @@
 import type { Video } from "@/stores/useVideoStore";
-import { abortableFetch } from "@/utils/abortableFetch";
-import { getApiUrl } from "@/utils/platform";
 import { isYouTubeUrl, parseYouTubeId } from "@/apps/tv/utils";
+import { fetchYouTubeOembed, parseYouTubeTitle } from "@/utils/youtubeMetadata";
 
 /**
  * Returns the pasted substring that should be treated as a single YouTube
@@ -27,49 +26,11 @@ export async function fetchYoutubeVideoForTvPrompt(
       ? rawInput.trim()
       : `https://www.youtube.com/watch?v=${id}`;
 
-  const oembedUrl = `https://www.youtube.com/oembed?url=${encodeURIComponent(`https://www.youtube.com/watch?v=${id}`)}&format=json`;
-  const oembedResponse = await abortableFetch(oembedUrl, {
-    timeout: 15000,
-    throwOnHttpError: false,
-    credentials: "omit",
-    retry: { maxAttempts: 1, initialDelayMs: 250 },
-  });
-  if (!oembedResponse.ok) return null;
+  const oembed = await fetchYouTubeOembed(id);
+  if (!oembed.ok) return null;
 
-  const oembedData = await oembedResponse.json();
-  const rawTitle = (oembedData.title as string) || `Video ${id}`;
-  const authorName = oembedData.author_name as string | undefined;
+  const rawTitle = oembed.rawTitle || `Video ${id}`;
+  const { title, artist } = await parseYouTubeTitle(rawTitle, oembed.authorName);
 
-  const videoInfo: Partial<Video> = {
-    title: rawTitle,
-    artist: undefined,
-  };
-
-  try {
-    const parseResponse = await abortableFetch(getApiUrl("/api/parse-title"), {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        title: rawTitle,
-        author_name: authorName,
-      }),
-      timeout: 15000,
-      throwOnHttpError: false,
-      retry: { maxAttempts: 1, initialDelayMs: 250 },
-    });
-    if (parseResponse.ok) {
-      const parsedData = await parseResponse.json();
-      videoInfo.title = parsedData.title || rawTitle;
-      videoInfo.artist = parsedData.artist;
-    }
-  } catch {
-    // ignore — keep oEmbed title
-  }
-
-  return {
-    id,
-    url,
-    title: videoInfo.title!,
-    artist: videoInfo.artist,
-  };
+  return { id, url, title, artist };
 }

--- a/src/apps/videos/components/VideosAppComponent.tsx
+++ b/src/apps/videos/components/VideosAppComponent.tsx
@@ -1,1 +1,0 @@
-export { VideosAppComponent } from "./videos-app/VideosAppComponent";

--- a/src/apps/videos/components/VideosMenuBar.tsx
+++ b/src/apps/videos/components/VideosMenuBar.tsx
@@ -1,4 +1,3 @@
-import { MenuBar } from "@/components/layout/MenuBar";
 import {
   MenubarMenu,
   MenubarTrigger,
@@ -10,8 +9,8 @@ import {
   MenubarSubContent,
   MenubarCheckboxItem,
 } from "@/components/ui/menubar";
-import { AppMenuBarHelpMenu } from "@/components/shared/menubar/AppMenuBarHelpMenu";
-import { AppShareItemDialog } from "@/components/shared/menubar/AppShareItemDialog";
+import { AppMenuBarShell } from "@/components/shared/menubar/AppMenuBarShell";
+import { MENUBAR_SEPARATOR_CLASS } from "@/components/shared/menubar/menubarStyles";
 import { useAppMenuBarChrome } from "@/hooks/useAppMenuBarChrome";
 import { cn } from "@/lib/utils";
 import { useTranslation } from "react-i18next";
@@ -99,7 +98,18 @@ export function VideosMenuBar({
   const artists = Object.keys(videosByArtist).sort();
 
   return (
-    <MenuBar inWindowFrame={isXpTheme}>
+    <AppMenuBarShell
+      isXpTheme={isXpTheme}
+      isMacOsxTheme={isMacOsxTheme}
+      appId={appId}
+      appName={appName}
+      isShareDialogOpen={isShareDialogOpen}
+      setIsShareDialogOpen={setIsShareDialogOpen}
+      helpItemLabel={t("apps.videos.menu.videosHelp")}
+      aboutItemLabel={t("apps.videos.menu.aboutVideos")}
+      onShowHelp={onShowHelp}
+      onShowAbout={onShowAbout}
+    >
       {/* File Menu */}
       <MenubarMenu>
         <MenubarTrigger className="text-md px-2 py-1 border-none focus-visible:ring-0">
@@ -119,7 +129,7 @@ export function VideosMenuBar({
           >
             {t("apps.videos.menu.shareVideo")}
           </MenubarItem>
-          <MenubarSeparator className="h-[2px] bg-black my-1" />
+          <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
           <MenubarItem
             onClick={onClose}
             className="text-md h-6 px-3"
@@ -156,14 +166,14 @@ export function VideosMenuBar({
           >
             {t("apps.videos.menu.next")}
           </MenubarItem>
-          <MenubarSeparator className="h-[2px] bg-black my-1" />
+          <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
           <MenubarItem
             onClick={onFullScreen}
             className="text-md h-6 px-3"
           >
             {t("apps.videos.menu.fullScreen")}
           </MenubarItem>
-          <MenubarSeparator className="h-[2px] bg-black my-1" />
+          <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
           <MenubarCheckboxItem
             checked={isShuffled}
             onCheckedChange={(checked) => {
@@ -209,7 +219,7 @@ export function VideosMenuBar({
           
           {videos.length > 0 && (
             <>
-              <MenubarSeparator className="h-[2px] bg-black my-1" />
+              <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
               
               {/* All Videos section */}
               <MenubarSub>
@@ -279,7 +289,7 @@ export function VideosMenuBar({
                 </MenubarSub>
               ))}
               
-              <MenubarSeparator className="h-[2px] bg-black my-1" />
+              <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
             </>
           )}
           
@@ -298,20 +308,6 @@ export function VideosMenuBar({
         </MenubarContent>
       </MenubarMenu>
 
-      <AppMenuBarHelpMenu
-        helpItemLabel={t("apps.videos.menu.videosHelp")}
-        aboutItemLabel={t("apps.videos.menu.aboutVideos")}
-        isMacOsxTheme={isMacOsxTheme}
-        onShowHelp={onShowHelp}
-        onShowAbout={onShowAbout}
-        onOpenShareDialog={() => setIsShareDialogOpen(true)}
-      />
-      <AppShareItemDialog
-        appId={appId}
-        appName={appName}
-        isOpen={isShareDialogOpen}
-        onClose={() => setIsShareDialogOpen(false)}
-      />
-    </MenuBar>
+    </AppMenuBarShell>
   );
 }

--- a/src/apps/videos/components/VideosMenuBar.tsx
+++ b/src/apps/videos/components/VideosMenuBar.tsx
@@ -7,9 +7,9 @@ import {
   MenubarSub,
   MenubarSubTrigger,
   MenubarSubContent,
-  MenubarCheckboxItem,
 } from "@/components/ui/menubar";
 import { AppMenuBarShell } from "@/components/shared/menubar/AppMenuBarShell";
+import { MediaControlsMenu } from "@/components/shared/menubar/MediaControlsMenu";
 import { MENUBAR_SEPARATOR_CLASS } from "@/components/shared/menubar/menubarStyles";
 import { useAppMenuBarChrome } from "@/hooks/useAppMenuBarChrome";
 import { cn } from "@/lib/utils";
@@ -140,69 +140,36 @@ export function VideosMenuBar({
       </MenubarMenu>
 
       {/* Controls Menu */}
-      <MenubarMenu>
-        <MenubarTrigger className="px-2 py-1 text-md focus-visible:ring-0">
-          {t("apps.videos.menu.controls")}
-        </MenubarTrigger>
-        <MenubarContent align="start" sideOffset={1} className="px-0">
-          <MenubarItem
-            onClick={onTogglePlay}
-            className="text-md h-6 px-3"
-            disabled={videos.length === 0}
-          >
-            {isPlaying ? t("apps.videos.menu.pause") : t("apps.videos.menu.play")}
-          </MenubarItem>
-          <MenubarItem
-            onClick={onPrevious}
-            className="text-md h-6 px-3"
-            disabled={videos.length === 0}
-          >
-            {t("apps.videos.menu.previous")}
-          </MenubarItem>
-          <MenubarItem
-            onClick={onNext}
-            className="text-md h-6 px-3"
-            disabled={videos.length === 0}
-          >
-            {t("apps.videos.menu.next")}
-          </MenubarItem>
-          <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
-          <MenubarItem
-            onClick={onFullScreen}
-            className="text-md h-6 px-3"
-          >
-            {t("apps.videos.menu.fullScreen")}
-          </MenubarItem>
-          <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
-          <MenubarCheckboxItem
-            checked={isShuffled}
-            onCheckedChange={(checked) => {
-              if (checked !== isShuffled) onShufflePlaylist();
-            }}
-            className="text-md h-6 px-3"
-          >
-            {t("apps.videos.menu.shuffle")}
-          </MenubarCheckboxItem>
-          <MenubarCheckboxItem
-            checked={isLoopAll}
-            onCheckedChange={(checked) => {
-              if (checked !== isLoopAll) onToggleLoopAll();
-            }}
-            className="text-md h-6 px-3"
-          >
-            {t("apps.videos.menu.repeatAll")}
-          </MenubarCheckboxItem>
-          <MenubarCheckboxItem
-            checked={isLoopCurrent}
-            onCheckedChange={(checked) => {
-              if (checked !== isLoopCurrent) onToggleLoopCurrent();
-            }}
-            className="text-md h-6 px-3"
-          >
-            {t("apps.videos.menu.repeatOne")}
-          </MenubarCheckboxItem>
-        </MenubarContent>
-      </MenubarMenu>
+      <MediaControlsMenu
+        menuLabel={t("apps.videos.menu.controls")}
+        triggerClassName="px-2 py-1 text-md focus-visible:ring-0"
+        tracksCount={videos.length}
+        isPlaying={isPlaying}
+        onTogglePlay={onTogglePlay}
+        onPreviousTrack={onPrevious}
+        onNextTrack={onNext}
+        playLabel={t("apps.videos.menu.play")}
+        pauseLabel={t("apps.videos.menu.pause")}
+        previousLabel={t("apps.videos.menu.previous")}
+        nextLabel={t("apps.videos.menu.next")}
+        shuffleLabel={t("apps.videos.menu.shuffle")}
+        repeatAllLabel={t("apps.videos.menu.repeatAll")}
+        repeatOneLabel={t("apps.videos.menu.repeatOne")}
+        isShuffled={isShuffled}
+        onToggleShuffle={onShufflePlaylist}
+        isLoopAll={isLoopAll}
+        onToggleLoopAll={onToggleLoopAll}
+        isLoopCurrent={isLoopCurrent}
+        onToggleLoopCurrent={onToggleLoopCurrent}
+        extraItems={
+          <>
+            <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
+            <MenubarItem onClick={onFullScreen} className="text-md h-6 px-3">
+              {t("apps.videos.menu.fullScreen")}
+            </MenubarItem>
+          </>
+        }
+      />
 
       {/* Library Menu */}
       <MenubarMenu>

--- a/src/apps/videos/components/videos-app/VideosAppDialogs.tsx
+++ b/src/apps/videos/components/videos-app/VideosAppDialogs.tsx
@@ -1,5 +1,4 @@
-import { HelpDialog } from "@/components/dialogs/HelpDialog";
-import { AboutDialog } from "@/components/dialogs/AboutDialog";
+import { AppHelpAboutDialogs } from "@/components/shared/AppHelpAboutDialogs";
 import { InputDialog } from "@/components/dialogs/InputDialog";
 import { ConfirmDialog } from "@/components/dialogs/ConfirmDialog";
 import { ShareItemDialog } from "@/components/dialogs/ShareItemDialog";
@@ -42,17 +41,14 @@ export function VideosAppDialogs({ c }: VideosAppDialogsProps) {
 
   return (
     <>
-      <HelpDialog
-        isOpen={isHelpDialogOpen}
-        onOpenChange={setIsHelpDialogOpen}
+      <AppHelpAboutDialogs
+        appId="videos"
         helpItems={translatedHelpItems}
-        appId="videos"
-      />
-      <AboutDialog
-        isOpen={isAboutDialogOpen}
-        onOpenChange={setIsAboutDialogOpen}
         metadata={appMetadata}
-        appId="videos"
+        isHelpOpen={isHelpDialogOpen}
+        onHelpOpenChange={setIsHelpDialogOpen}
+        isAboutOpen={isAboutDialogOpen}
+        onAboutOpenChange={setIsAboutDialogOpen}
       />
       <ConfirmDialog
         isOpen={isConfirmClearOpen}

--- a/src/apps/videos/hooks/useVideosLogic.ts
+++ b/src/apps/videos/hooks/useVideosLogic.ts
@@ -6,12 +6,12 @@ import { useTranslatedHelpItems } from "@/hooks/useTranslatedHelpItems";
 import { useVideoStore, DEFAULT_VIDEOS } from "@/stores/useVideoStore";
 import { useSound, Sounds } from "@/hooks/useSound";
 import { useAppStore } from "@/stores/useAppStore";
-import { getApiUrl } from "@/utils/platform";
 import { useAudioSettingsStore } from "@/stores/useAudioSettingsStore";
 import { useCustomEventListener } from "@/hooks/useEventListener";
 import { helpItems } from "..";
 import type { VideosInitialData } from "../../base/types";
-import { abortableFetch } from "@/utils/abortableFetch";
+import { parseYouTubeVideoId } from "@/utils/youtubeUrl";
+import { fetchYouTubeOembed, parseYouTubeTitle } from "@/utils/youtubeMetadata";
 import { onAppUpdate } from "@/utils/appEventBus";
 import { MEDIA_ANALYTICS, track } from "@/utils/analytics";
 import { useThemeFlags } from "@/hooks/useThemeFlags";
@@ -323,25 +323,10 @@ export function useVideosLogic({
     ).padStart(2, "0")}`;
   }, []);
 
-  const extractVideoId = useCallback((url: string): string | null => {
-    if (/^[a-zA-Z0-9_-]{11}$/.test(url)) return url;
-    try {
-      const parsed = new URL(url);
-      if (parsed.hostname.includes("youtube.com") || parsed.hostname.includes("youtu.be")) {
-        const vParam = parsed.searchParams.get("v");
-        if (vParam && /^[a-zA-Z0-9_-]{11}$/.test(vParam)) return vParam;
-        if (parsed.hostname === "youtu.be") {
-          const id = parsed.pathname.slice(1);
-          return /^[a-zA-Z0-9_-]{11}$/.test(id) ? id : null;
-        }
-        const pathMatch = parsed.pathname.match(/\/(?:embed\/|v\/|shorts\/)?([a-zA-Z0-9_-]{11})/);
-        if (pathMatch) return pathMatch[1];
-      }
-      return null;
-    } catch {
-      return null;
-    }
-  }, []);
+  const extractVideoId = useCallback(
+    (url: string): string | null => parseYouTubeVideoId(url),
+    []
+  );
 
   const addVideo = useCallback(
     async (url: string) => {
@@ -369,68 +354,25 @@ export function useVideosLogic({
         }
 
         // 1. Fetch initial info from oEmbed
-        const oembedUrl = `https://www.youtube.com/oembed?url=${encodeURIComponent(`https://www.youtube.com/watch?v=${videoId}`)}&format=json`;
-        const oembedResponse = await abortableFetch(oembedUrl, {
-          timeout: 15000,
-          throwOnHttpError: false,
-          credentials: "omit",
-          retry: { maxAttempts: 1, initialDelayMs: 250 },
-        });
-        if (!oembedResponse.ok) {
+        const oembed = await fetchYouTubeOembed(videoId);
+        if (!oembed.ok) {
           throw new Error(
-            `Failed to fetch video info (${oembedResponse.status}). Please check the YouTube URL.`
+            `Failed to fetch video info (${oembed.status}). Please check the YouTube URL.`
           );
         }
-        const oembedData = await oembedResponse.json();
-        const rawTitle = oembedData.title || `Video ID: ${videoId}`;
-        const authorName = oembedData.author_name;
+        const rawTitle = oembed.rawTitle || `Video ID: ${videoId}`;
 
-        const videoInfo: Partial<Video> = {
-          title: rawTitle,
-          artist: undefined,
-        };
-
-        try {
-          // 2. Call our API to parse the title using AI
-          const parseResponse = await abortableFetch(
-            getApiUrl("/api/parse-title"),
-            {
-              method: "POST",
-              headers: {
-                "Content-Type": "application/json",
-              },
-              body: JSON.stringify({
-                title: rawTitle,
-                author_name: authorName,
-              }),
-              timeout: 15000,
-              throwOnHttpError: false,
-              retry: { maxAttempts: 1, initialDelayMs: 250 },
-            }
-          );
-
-          if (parseResponse.ok) {
-            const parsedData = await parseResponse.json();
-            videoInfo.title = parsedData.title || rawTitle;
-            videoInfo.artist = parsedData.artist;
-          } else {
-            console.warn(
-              "Failed to parse title with AI, using raw title:",
-              await parseResponse.text()
-            );
-          }
-        } catch (parseError) {
-          console.warn(
-            "Error calling parse-title API, using raw title:",
-            parseError
-          );
-        }
+        // 2. Resolve a cleaned title/artist via /api/parse-title
+        const { title, artist } = await parseYouTubeTitle(
+          rawTitle,
+          oembed.authorName
+        );
 
         const newVideo: Video = {
           id: videoId,
           url,
-          title: videoInfo.title!,
-          artist: videoInfo.artist,
+          title,
+          artist,
         };
 
         // Add video to store

--- a/src/apps/videos/index.tsx
+++ b/src/apps/videos/index.tsx
@@ -1,5 +1,5 @@
 import { BaseApp, VideosInitialData } from "../base/types";
-import { VideosAppComponent } from "./components/VideosAppComponent";
+import { VideosAppComponent } from "./components/videos-app/VideosAppComponent";
 
 // Re-export metadata from separate file to avoid eager loading of components
 export { appMetadata, helpItems } from "./metadata";

--- a/src/apps/winamp/components/WinampAppComponent.tsx
+++ b/src/apps/winamp/components/WinampAppComponent.tsx
@@ -5,8 +5,7 @@ import { WinampMenuBar } from "./WinampMenuBar";
 import { AppProps } from "@/apps/base/types";
 import { AppWindowShell } from "@/components/shared/AppWindowShell";
 import { useWinampLogic } from "../hooks/useWinampLogic";
-import { HelpDialog } from "@/components/dialogs/HelpDialog";
-import { AboutDialog } from "@/components/dialogs/AboutDialog";
+import { AppHelpAboutDialogs } from "@/components/shared/AppHelpAboutDialogs";
 import { appMetadata } from "..";
 import { useAppStore } from "@/stores/useAppStore";
 import { useIpodStore, type Track } from "@/stores/useIpodStore";
@@ -330,20 +329,15 @@ export function WinampAppComponent({
       isForeground={isForeground}
       menuBar={menuBar}
       trailing={
-        <>
-          <HelpDialog
-            isOpen={isHelpDialogOpen}
-            onOpenChange={setIsHelpDialogOpen}
-            appId="winamp"
-            helpItems={translatedHelpItems}
-          />
-          <AboutDialog
-            isOpen={isAboutDialogOpen}
-            onOpenChange={setIsAboutDialogOpen}
-            metadata={appMetadata}
-            appId="winamp"
-          />
-        </>
+        <AppHelpAboutDialogs
+          appId="winamp"
+          helpItems={translatedHelpItems}
+          metadata={appMetadata}
+          isHelpOpen={isHelpDialogOpen}
+          onHelpOpenChange={setIsHelpDialogOpen}
+          isAboutOpen={isAboutDialogOpen}
+          onAboutOpenChange={setIsAboutDialogOpen}
+        />
       }
     >
       {createPortal(<div />, document.body)}

--- a/src/apps/winamp/components/WinampAppComponent.tsx
+++ b/src/apps/winamp/components/WinampAppComponent.tsx
@@ -13,7 +13,7 @@ import { useIpodStore, type Track } from "@/stores/useIpodStore";
 import { YouTubeMedia } from "../utils/youtubeMedia";
 import { WEBAMP_SKINS } from "../skins";
 import { useTranslation } from "react-i18next";
-import { getYouTubeVideoId } from "@/apps/ipod/constants";
+import { parseYouTubeVideoId } from "@/utils/youtubeUrl";
 import { WINAMP_ANALYTICS, track } from "@/utils/analytics";
 
 const MAIN_WINDOW_WIDTH = 275;
@@ -23,7 +23,7 @@ const PLAYLIST_HEIGHT = 116;
 /** Convert iPod tracks to Webamp-compatible track objects */
 function ipodTracksToWebamp(tracks: Track[], unknownArtist: string) {
   return tracks.map((track) => ({
-    url: getYouTubeVideoId(track.url) ?? track.url,
+    url: parseYouTubeVideoId(track.url) ?? track.url,
     metaData: {
       artist: track.artist ?? unknownArtist,
       title: track.title,

--- a/src/apps/winamp/components/WinampMenuBar.tsx
+++ b/src/apps/winamp/components/WinampMenuBar.tsx
@@ -1,4 +1,3 @@
-import { MenuBar } from "@/components/layout/MenuBar";
 import {
   MenubarMenu,
   MenubarTrigger,
@@ -9,8 +8,7 @@ import {
   MenubarRadioGroup,
   MenubarRadioItem,
 } from "@/components/ui/menubar";
-import { AppMenuBarHelpMenu } from "@/components/shared/menubar/AppMenuBarHelpMenu";
-import { AppShareItemDialog } from "@/components/shared/menubar/AppShareItemDialog";
+import { AppMenuBarShell } from "@/components/shared/menubar/AppMenuBarShell";
 import {
   MENUBAR_ITEM_CLASS,
   MENUBAR_SEPARATOR_CLASS,
@@ -64,7 +62,18 @@ export function WinampMenuBar({
   } = useAppMenuBarChrome("winamp");
 
   return (
-    <MenuBar inWindowFrame={isXpTheme}>
+    <AppMenuBarShell
+      isXpTheme={isXpTheme}
+      isMacOsxTheme={isMacOsxTheme}
+      appId={appId}
+      appName={appName}
+      isShareDialogOpen={isShareDialogOpen}
+      setIsShareDialogOpen={setIsShareDialogOpen}
+      helpItemLabel={t("apps.winamp.menu.help")}
+      aboutItemLabel={t("apps.winamp.menu.about")}
+      onShowHelp={onShowHelp}
+      onShowAbout={onShowAbout}
+    >
       <MenubarMenu>
         <MenubarTrigger className={MENUBAR_TRIGGER_CLASS}>
           {t("common.menu.file")}
@@ -139,20 +148,6 @@ export function WinampMenuBar({
         </MenubarContent>
       </MenubarMenu>
 
-      <AppMenuBarHelpMenu
-        helpItemLabel={t("apps.winamp.menu.help")}
-        aboutItemLabel={t("apps.winamp.menu.about")}
-        isMacOsxTheme={isMacOsxTheme}
-        onShowHelp={onShowHelp}
-        onShowAbout={onShowAbout}
-        onOpenShareDialog={() => setIsShareDialogOpen(true)}
-      />
-      <AppShareItemDialog
-        appId={appId}
-        appName={appName}
-        isOpen={isShareDialogOpen}
-        onClose={() => setIsShareDialogOpen(false)}
-      />
-    </MenuBar>
+    </AppMenuBarShell>
   );
 }

--- a/src/components/dialogs/LyricsSearchDialog.tsx
+++ b/src/components/dialogs/LyricsSearchDialog.tsx
@@ -15,7 +15,7 @@ import { useTranslation } from "react-i18next";
 import { getApiUrl } from "@/utils/platform";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { abortableFetch } from "@/utils/abortableFetch";
-import { formatKugouImageUrl } from "@/apps/ipod/constants";
+import { formatKugouImageUrl } from "@/utils/coverArt";
 
 export interface LyricsSearchResult {
   title: string;

--- a/src/components/shared/AppHelpAboutDialogs.tsx
+++ b/src/components/shared/AppHelpAboutDialogs.tsx
@@ -1,0 +1,45 @@
+import { ComponentProps } from "react";
+import { HelpDialog } from "@/components/dialogs/HelpDialog";
+import { AboutDialog } from "@/components/dialogs/AboutDialog";
+import type { AppId } from "@/config/appRegistry";
+
+interface AppHelpAboutDialogsProps {
+  appId: AppId;
+  helpItems: ComponentProps<typeof HelpDialog>["helpItems"];
+  metadata: ComponentProps<typeof AboutDialog>["metadata"];
+  isHelpOpen: boolean;
+  onHelpOpenChange: (open: boolean) => void;
+  isAboutOpen: boolean;
+  onAboutOpenChange: (open: boolean) => void;
+}
+
+/**
+ * Shared Help + About dialog pair rendered by nearly every app. Replaces the
+ * repeated two-dialog block wired to `isHelpDialogOpen` / `isAboutDialogOpen`.
+ */
+export function AppHelpAboutDialogs({
+  appId,
+  helpItems,
+  metadata,
+  isHelpOpen,
+  onHelpOpenChange,
+  isAboutOpen,
+  onAboutOpenChange,
+}: AppHelpAboutDialogsProps) {
+  return (
+    <>
+      <HelpDialog
+        isOpen={isHelpOpen}
+        onOpenChange={onHelpOpenChange}
+        helpItems={helpItems}
+        appId={appId}
+      />
+      <AboutDialog
+        isOpen={isAboutOpen}
+        onOpenChange={onAboutOpenChange}
+        metadata={metadata}
+        appId={appId}
+      />
+    </>
+  );
+}

--- a/src/components/shared/fullscreen-player-controls/LyricsControlsIsland.tsx
+++ b/src/components/shared/fullscreen-player-controls/LyricsControlsIsland.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from "react-i18next";
 import { cn } from "@/lib/utils";
-import { getTranslationBadge } from "@/apps/ipod/constants";
+import { getTranslationBadge } from "@/utils/lyricsTranslation";
 import type { LyricsAlignment, RomanizationSettings } from "@/types/lyrics";
 import { getLyricsFontClassName, LyricsFont } from "@/types/lyrics";
 import {

--- a/src/components/shared/lcd/LcdAnimatedTitle.tsx
+++ b/src/components/shared/lcd/LcdAnimatedTitle.tsx
@@ -1,6 +1,7 @@
-import { memo, useEffect, useRef, useState } from "react";
+import { memo, useRef } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { cn } from "@/lib/utils";
+import { useTextOverflow } from "@/hooks/useTextOverflow";
 import {
   MARQUEE_INITIAL,
   MARQUEE_TITLE_ANIMATE,
@@ -35,19 +36,7 @@ export const LcdAnimatedTitle = memo(function LcdAnimatedTitle({
 
   const containerRef = useRef<HTMLDivElement>(null);
   const measureRef = useRef<HTMLSpanElement>(null);
-  const [overflows, setOverflows] = useState(false);
-  useEffect(() => {
-    const container = containerRef.current;
-    const measure = measureRef.current;
-    if (!container || !measure) return;
-    const check = () => {
-      setOverflows(measure.scrollWidth > container.clientWidth + 1);
-    };
-    check();
-    const ro = new ResizeObserver(check);
-    ro.observe(container);
-    return () => ro.disconnect();
-  }, [title]);
+  const overflows = useTextOverflow(containerRef, measureRef, [title]);
 
   const showStaticFade = overflows && !isPlaying;
 

--- a/src/components/shared/menubar/AppMenuBarShell.tsx
+++ b/src/components/shared/menubar/AppMenuBarShell.tsx
@@ -15,7 +15,8 @@ interface AppMenuBarShellProps {
   setIsShareDialogOpen: (open: boolean) => void;
   helpItemLabel: string;
   aboutItemLabel: string;
-  shareItemLabel: string;
+  /** Optional override; defaults to the shared `common.menu.shareApp` label. */
+  shareItemLabel?: string;
   onShowHelp?: () => void;
   onShowAbout?: () => void;
 }

--- a/src/components/shared/menubar/AppMenuBarShell.tsx
+++ b/src/components/shared/menubar/AppMenuBarShell.tsx
@@ -1,0 +1,62 @@
+import type { ReactNode } from "react";
+import { MenuBar } from "@/components/layout/MenuBar";
+import { AppMenuBarHelpMenu } from "@/components/shared/menubar/AppMenuBarHelpMenu";
+import { AppShareItemDialog } from "@/components/shared/menubar/AppShareItemDialog";
+import type { AppId } from "@/config/appRegistry";
+
+interface AppMenuBarShellProps {
+  /** App-specific menus (File, Controls, View, Library, ...). */
+  children: ReactNode;
+  isXpTheme: boolean;
+  isMacOsxTheme: boolean;
+  appId: AppId;
+  appName: string;
+  isShareDialogOpen: boolean;
+  setIsShareDialogOpen: (open: boolean) => void;
+  helpItemLabel: string;
+  aboutItemLabel: string;
+  shareItemLabel: string;
+  onShowHelp?: () => void;
+  onShowAbout?: () => void;
+}
+
+/**
+ * Standard ryOS media-app menubar: app menus followed by the shared
+ * Help/About/Share menu and the share dialog. Apps pass their own menu
+ * components as children and supply translation-key-driven labels.
+ */
+export function AppMenuBarShell({
+  children,
+  isXpTheme,
+  isMacOsxTheme,
+  appId,
+  appName,
+  isShareDialogOpen,
+  setIsShareDialogOpen,
+  helpItemLabel,
+  aboutItemLabel,
+  shareItemLabel,
+  onShowHelp,
+  onShowAbout,
+}: AppMenuBarShellProps) {
+  return (
+    <MenuBar inWindowFrame={isXpTheme}>
+      {children}
+      <AppMenuBarHelpMenu
+        helpItemLabel={helpItemLabel}
+        aboutItemLabel={aboutItemLabel}
+        shareItemLabel={shareItemLabel}
+        isMacOsxTheme={isMacOsxTheme}
+        onShowHelp={onShowHelp}
+        onShowAbout={onShowAbout}
+        onOpenShareDialog={() => setIsShareDialogOpen(true)}
+      />
+      <AppShareItemDialog
+        appId={appId}
+        appName={appName}
+        isOpen={isShareDialogOpen}
+        onClose={() => setIsShareDialogOpen(false)}
+      />
+    </MenuBar>
+  );
+}

--- a/src/components/shared/menubar/LibraryTrackBrowser.tsx
+++ b/src/components/shared/menubar/LibraryTrackBrowser.tsx
@@ -1,0 +1,117 @@
+import type { TFunction } from "i18next";
+import {
+  MenubarItem,
+  MenubarSub,
+  MenubarSubTrigger,
+  MenubarSubContent,
+  MenubarCheckboxItem,
+} from "@/components/ui/menubar";
+import {
+  MENUBAR_TRACK_LIMIT,
+  MENUBAR_ARTIST_LIMIT,
+} from "@/components/shared/menubar/libraryMenuConstants";
+import type { TrackWithIndex } from "@/utils/groupTracksByArtist";
+import type { Track } from "@/stores/useIpodStore";
+
+export function LibraryTrackBrowser({
+  tracks,
+  currentIndex,
+  tracksByArtist,
+  artists,
+  onPlayTrack,
+  t,
+}: {
+  tracks: Track[];
+  currentIndex: number;
+  tracksByArtist: Record<string, TrackWithIndex<Track>[]>;
+  artists: string[];
+  onPlayTrack: (index: number) => void;
+  t: TFunction;
+}) {
+  if (tracks.length === 0) {
+    return null;
+  }
+
+  return (
+    <>
+      <MenubarSub>
+        <MenubarSubTrigger className="text-md h-6 px-3">
+          <div className="flex justify-between w-full items-center overflow-hidden">
+            <span className="truncate min-w-0">
+              {t("apps.ipod.menu.allSongs")}
+            </span>
+          </div>
+        </MenubarSubTrigger>
+        <MenubarSubContent className="px-0 max-w-[180px] sm:max-w-[220px] max-h-[400px] overflow-y-auto">
+          {tracks.slice(0, MENUBAR_TRACK_LIMIT).map((track, index) => (
+            <MenubarCheckboxItem
+              key={`all-${track.id}`}
+              checked={index === currentIndex}
+              onCheckedChange={() => onPlayTrack(index)}
+              className="text-md h-6 pr-3 max-w-[220px] truncate"
+            >
+              <span className="truncate min-w-0">{track.title}</span>
+            </MenubarCheckboxItem>
+          ))}
+          {tracks.length > MENUBAR_TRACK_LIMIT && (
+            <MenubarItem
+              disabled
+              className="text-md h-6 px-3 italic opacity-70"
+            >
+              {t(
+                "apps.ipod.menu.menubarTrackLimit",
+                `Showing ${MENUBAR_TRACK_LIMIT} of ${tracks.length} — open iPod to browse all`,
+                {
+                  limit: MENUBAR_TRACK_LIMIT,
+                  total: tracks.length,
+                }
+              )}
+            </MenubarItem>
+          )}
+        </MenubarSubContent>
+      </MenubarSub>
+      <div className="max-h-[300px] overflow-y-auto">
+        {artists.slice(0, MENUBAR_ARTIST_LIMIT).map((artist) => (
+          <MenubarSub key={artist}>
+            <MenubarSubTrigger className="text-md h-6 px-3">
+              <div className="flex justify-between w-full items-center overflow-hidden">
+                <span className="truncate min-w-0">{artist}</span>
+              </div>
+            </MenubarSubTrigger>
+            <MenubarSubContent className="px-0 max-w-[180px] sm:max-w-[220px] max-h-[200px] overflow-y-auto">
+              {tracksByArtist[artist]
+                .slice(0, MENUBAR_TRACK_LIMIT)
+                .map(({ track, index }) => (
+                  <MenubarCheckboxItem
+                    key={`${artist}-${track.id}`}
+                    checked={index === currentIndex}
+                    onCheckedChange={() => onPlayTrack(index)}
+                    className="text-md h-6 pr-3 max-w-[160px] sm:max-w-[200px] truncate"
+                  >
+                    <span className="truncate min-w-0">
+                      {track.title}
+                    </span>
+                  </MenubarCheckboxItem>
+                ))}
+            </MenubarSubContent>
+          </MenubarSub>
+        ))}
+        {artists.length > MENUBAR_ARTIST_LIMIT && (
+          <MenubarItem
+            disabled
+            className="text-md h-6 px-3 italic opacity-70"
+          >
+            {t(
+              "apps.ipod.menu.menubarArtistLimit",
+              `Showing ${MENUBAR_ARTIST_LIMIT} of ${artists.length} artists`,
+              {
+                limit: MENUBAR_ARTIST_LIMIT,
+                total: artists.length,
+              }
+            )}
+          </MenubarItem>
+        )}
+      </div>
+    </>
+  );
+}

--- a/src/components/shared/menubar/MediaControlsMenu.tsx
+++ b/src/components/shared/menubar/MediaControlsMenu.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from "react";
 import {
   MenubarMenu,
   MenubarTrigger,
@@ -29,6 +30,8 @@ export type MediaControlsMenuProps = {
   onToggleLoopAll: () => void;
   isLoopCurrent: boolean;
   onToggleLoopCurrent: () => void;
+  /** Extra items rendered between the transport items and the shuffle/repeat block. */
+  extraItems?: ReactNode;
 };
 
 export function MediaControlsMenu({
@@ -52,6 +55,7 @@ export function MediaControlsMenu({
   onToggleLoopAll,
   isLoopCurrent,
   onToggleLoopCurrent,
+  extraItems,
 }: MediaControlsMenuProps) {
   const tracksDisabled = tracksCount === 0;
 
@@ -80,6 +84,7 @@ export function MediaControlsMenu({
         >
           {nextLabel}
         </MenubarItem>
+        {extraItems}
         <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
         <MenubarCheckboxItem
           checked={isShuffled}

--- a/src/components/shared/menubar/MediaLyricsViewMenuItems.tsx
+++ b/src/components/shared/menubar/MediaLyricsViewMenuItems.tsx
@@ -1,0 +1,267 @@
+import {
+  MenubarItem,
+  MenubarSeparator,
+  MenubarSub,
+  MenubarSubTrigger,
+  MenubarSubContent,
+  MenubarCheckboxItem,
+  MenubarRadioGroup,
+  MenubarRadioItem,
+} from "@/components/ui/menubar";
+import { LyricsAlignmentMenuItems } from "@/components/shared/menubar/lyrics/LyricsAlignmentMenuItems";
+import { LyricsPronunciationSubmenu } from "@/components/shared/menubar/lyrics/LyricsPronunciationSubmenu";
+import { LyricsTranslationLanguageSubmenu } from "@/components/shared/menubar/lyrics/LyricsTranslationLanguageSubmenu";
+import { MENUBAR_SEPARATOR_CLASS } from "@/components/shared/menubar/menubarStyles";
+import { toast } from "sonner";
+import {
+  DisplayMode,
+  LyricsFont,
+  type LyricsAlignment,
+  type RomanizationSettings,
+} from "@/types/lyrics";
+import type { TranslatedLyricsLanguage } from "@/hooks/useTranslatedLyricsLanguages";
+import type { TFunction } from "i18next";
+
+export type MediaLyricsViewMenuItemsProps = {
+  t: TFunction;
+  /** Label for the "Show Lyrics" toggle (iPod and Karaoke use different keys). */
+  showLyricsLabel: string;
+  showLyrics: boolean;
+  onToggleLyrics: () => void;
+  lyricsAlignment: LyricsAlignment;
+  setLyricsAlignment: (alignment: LyricsAlignment) => void;
+  lyricsFont: LyricsFont;
+  setLyricsFont: (font: LyricsFont) => void;
+  romanization: RomanizationSettings | undefined;
+  setRomanization: (patch: Partial<RomanizationSettings>) => void;
+  lyricsTranslationLanguage: string | null;
+  setLyricsTranslationLanguage: (code: string | null) => void;
+  translationLanguages: TranslatedLyricsLanguage[];
+  displayMode: DisplayMode;
+  setDisplayMode: (mode: DisplayMode) => void;
+  /** When true, omit the Video display option (iPod Apple Music behavior). */
+  hideVideoOption?: boolean;
+  onRefreshLyrics: () => void;
+  onAdjustTiming?: () => void;
+  clearLyricsCache: () => void;
+  tracks: { length: number };
+  currentIndex: number;
+  debugMode: boolean;
+  isAdmin: boolean;
+};
+
+export function MediaLyricsViewMenuItems({
+  t,
+  showLyricsLabel,
+  showLyrics,
+  onToggleLyrics,
+  lyricsAlignment,
+  setLyricsAlignment,
+  lyricsFont,
+  setLyricsFont,
+  romanization,
+  setRomanization,
+  lyricsTranslationLanguage,
+  setLyricsTranslationLanguage,
+  translationLanguages,
+  displayMode,
+  setDisplayMode,
+  hideVideoOption,
+  onRefreshLyrics,
+  onAdjustTiming,
+  clearLyricsCache,
+  tracks,
+  currentIndex,
+  debugMode,
+  isAdmin,
+}: MediaLyricsViewMenuItemsProps) {
+  const lyricsDisabled = tracks.length === 0 || currentIndex === -1;
+
+  return (
+    <>
+      <MenubarSub>
+        <MenubarSubTrigger className="text-md h-6 px-3">
+          {t("apps.ipod.menu.lyrics")}
+        </MenubarSubTrigger>
+        <MenubarSubContent className="px-0">
+          <MenubarCheckboxItem
+            checked={showLyrics}
+            onCheckedChange={onToggleLyrics}
+            className="text-md h-6 px-3"
+          >
+            {showLyricsLabel}
+          </MenubarCheckboxItem>
+
+          <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
+
+          <LyricsAlignmentMenuItems
+            lyricsAlignment={lyricsAlignment}
+            setLyricsAlignment={setLyricsAlignment}
+            multiLabel={t("apps.ipod.menu.multi")}
+            singleLabel={t("apps.ipod.menu.single")}
+            alternatingLabel={t("apps.ipod.menu.alternating")}
+          />
+
+          <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
+
+          <MenubarRadioGroup
+            value={lyricsFont}
+            onValueChange={(v) => setLyricsFont(v as LyricsFont)}
+          >
+            <MenubarRadioItem
+              value={LyricsFont.Rounded}
+              className="text-md h-6 pr-3"
+            >
+              {t("apps.ipod.menu.fontRounded")}
+            </MenubarRadioItem>
+            <MenubarRadioItem
+              value={LyricsFont.Serif}
+              className="text-md h-6 pr-3"
+            >
+              {t("apps.ipod.menu.fontSerif")}
+            </MenubarRadioItem>
+            <MenubarRadioItem
+              value={LyricsFont.SansSerif}
+              className="text-md h-6 pr-3"
+            >
+              {t("apps.ipod.menu.fontSansSerif")}
+            </MenubarRadioItem>
+            <MenubarRadioItem
+              value={LyricsFont.SerifRed}
+              className="text-md h-6 pr-3"
+            >
+              {t("apps.ipod.menu.fontSerifRed")}
+            </MenubarRadioItem>
+            <MenubarRadioItem
+              value={LyricsFont.GoldGlow}
+              className="text-md h-6 pr-3"
+            >
+              {t("apps.ipod.menu.fontGoldGlow")}
+            </MenubarRadioItem>
+            <MenubarRadioItem
+              value={LyricsFont.Gradient}
+              className="text-md h-6 pr-3"
+            >
+              {t("apps.ipod.menu.fontGradient")}
+            </MenubarRadioItem>
+          </MenubarRadioGroup>
+        </MenubarSubContent>
+      </MenubarSub>
+
+      <LyricsTranslationLanguageSubmenu
+        submenuLabel={t("apps.ipod.menu.translate")}
+        translationLanguages={translationLanguages}
+        lyricsTranslationLanguage={lyricsTranslationLanguage}
+        setLyricsTranslationLanguage={setLyricsTranslationLanguage}
+      />
+
+      <LyricsPronunciationSubmenu
+        submenuLabel={t("apps.ipod.menu.pronunciation")}
+        pronunciationLabel={t("apps.ipod.menu.pronunciation")}
+        pronunciationOnlyLabel={t("apps.ipod.menu.pronunciationOnly")}
+        japaneseFuriganaLabel={t("apps.ipod.menu.japaneseFurigana")}
+        japaneseRomajiLabel={t("apps.ipod.menu.japaneseRomaji")}
+        koreanRomanizationLabel={t("apps.ipod.menu.koreanRomanization")}
+        chinesePinyinLabel={t("apps.ipod.menu.chinesePinyin")}
+        chineseSoramimiLabel={t("apps.ipod.menu.chineseSoramimi")}
+        soramimiLabel={t("apps.ipod.menu.soramimi")}
+        romanization={romanization}
+        setRomanization={setRomanization}
+      />
+
+      <MenubarSub>
+        <MenubarSubTrigger className="text-md h-6 px-3">
+          {t("apps.ipod.menu.display")}
+        </MenubarSubTrigger>
+        <MenubarSubContent className="px-0">
+          {!hideVideoOption && (
+            <MenubarCheckboxItem
+              checked={displayMode === DisplayMode.Video}
+              onCheckedChange={(checked) => {
+                if (checked) setDisplayMode(DisplayMode.Video);
+              }}
+              className="text-md h-6 pr-3"
+            >
+              {t("apps.ipod.menu.displayVideo")}
+            </MenubarCheckboxItem>
+          )}
+          <MenubarCheckboxItem
+            checked={displayMode === DisplayMode.Mesh}
+            onCheckedChange={(checked) => {
+              if (checked) setDisplayMode(DisplayMode.Mesh);
+            }}
+            className="text-md h-6 pr-3"
+          >
+            {t("apps.ipod.menu.displayGradient")}
+          </MenubarCheckboxItem>
+          <MenubarCheckboxItem
+            checked={displayMode === DisplayMode.Water}
+            onCheckedChange={(checked) => {
+              if (checked) setDisplayMode(DisplayMode.Water);
+            }}
+            className="text-md h-6 pr-3"
+          >
+            {t("apps.ipod.menu.displayWater")}
+          </MenubarCheckboxItem>
+          <MenubarCheckboxItem
+            checked={displayMode === DisplayMode.Shader}
+            onCheckedChange={(checked) => {
+              if (checked) setDisplayMode(DisplayMode.Shader);
+            }}
+            className="text-md h-6 pr-3"
+          >
+            {t("apps.ipod.menu.displayShader")}
+          </MenubarCheckboxItem>
+          <MenubarCheckboxItem
+            checked={displayMode === DisplayMode.Landscapes}
+            onCheckedChange={(checked) => {
+              if (checked) setDisplayMode(DisplayMode.Landscapes);
+            }}
+            className="text-md h-6 pr-3"
+          >
+            {t("apps.ipod.menu.displayLandscapes")}
+          </MenubarCheckboxItem>
+          <MenubarCheckboxItem
+            checked={displayMode === DisplayMode.Cover}
+            onCheckedChange={(checked) => {
+              if (checked) setDisplayMode(DisplayMode.Cover);
+            }}
+            className="text-md h-6 pr-3"
+          >
+            {t("apps.ipod.menu.displayCover")}
+          </MenubarCheckboxItem>
+        </MenubarSubContent>
+      </MenubarSub>
+
+      <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
+
+      <MenubarItem
+        onClick={onRefreshLyrics}
+        className="text-md h-6 px-3"
+        disabled={lyricsDisabled}
+      >
+        {t("apps.ipod.menu.refreshLyrics")}
+      </MenubarItem>
+      <MenubarItem
+        onClick={onAdjustTiming}
+        className="text-md h-6 px-3"
+        disabled={lyricsDisabled}
+      >
+        {t("apps.ipod.menu.adjustTiming")}
+      </MenubarItem>
+
+      {(debugMode || isAdmin) && (
+        <MenubarItem
+          onClick={() => {
+            clearLyricsCache();
+            toast.success(t("apps.ipod.menu.cacheCleared"));
+          }}
+          className="text-md h-6 px-3"
+          disabled={lyricsDisabled}
+        >
+          {t("apps.ipod.menu.clearCache")}
+        </MenubarItem>
+      )}
+    </>
+  );
+}

--- a/src/components/shared/menubar/libraryMenuConstants.ts
+++ b/src/components/shared/menubar/libraryMenuConstants.ts
@@ -1,0 +1,6 @@
+// Caps for the in-menubar library browser shared by media apps (iPod,
+// Karaoke). Radix's MenubarSub doesn't virtualize, so a 5,000-song library
+// would commit thousands of DOM nodes the moment the user opens the dropdown.
+// The full library is always available inside the app itself (virtualized).
+export const MENUBAR_TRACK_LIMIT = 200;
+export const MENUBAR_ARTIST_LIMIT = 100;

--- a/src/config/appRegistry.tsx
+++ b/src/config/appRegistry.tsx
@@ -98,12 +98,12 @@ const LazySynthApp = createLazyComponent<unknown>(
 );
 
 const LazyIpodApp = createLazyComponent<IpodInitialData>(
-  () => import("@/apps/ipod/components/IpodAppComponent").then(m => ({ default: m.IpodAppComponent })),
+  () => import("@/apps/ipod/components/ipod-app/IpodAppComponent").then(m => ({ default: m.IpodAppComponent })),
   "ipod"
 );
 
 const LazyKaraokeApp = createLazyComponent<IpodInitialData>(
-  () => import("@/apps/karaoke/components/KaraokeAppComponent").then(m => ({ default: m.KaraokeAppComponent })),
+  () => import("@/apps/karaoke/components/karaoke-app/KaraokeAppComponent").then(m => ({ default: m.KaraokeAppComponent })),
   "karaoke"
 );
 

--- a/src/config/appRegistry.tsx
+++ b/src/config/appRegistry.tsx
@@ -38,7 +38,7 @@ const defaultWindowConstraints: WindowConstraints = {
 
 // Critical apps (load immediately for perceived performance)
 // Finder is critical - users see it on desktop
-import { FinderAppComponent } from "@/apps/finder/components/FinderAppComponent";
+import { FinderAppComponent } from "@/apps/finder/components/finder-app/FinderAppComponent";
 
 // Lazy-loaded apps (loaded on-demand when opened)
 // Each uses a cache key to maintain stable references across HMR
@@ -48,17 +48,17 @@ const LazyTextEditApp = createLazyComponent<unknown>(
 );
 
 const LazyInternetExplorerApp = createLazyComponent<InternetExplorerInitialData>(
-  () => import("@/apps/internet-explorer/components/InternetExplorerAppComponent").then(m => ({ default: m.InternetExplorerAppComponent })),
+  () => import("@/apps/internet-explorer/components/internet-explorer-app/InternetExplorerAppComponent").then(m => ({ default: m.InternetExplorerAppComponent })),
   "internet-explorer"
 );
 
 const LazyChatsApp = createLazyComponent<unknown>(
-  () => import("@/apps/chats/components/ChatsAppComponent").then(m => ({ default: m.ChatsAppComponent })),
+  () => import("@/apps/chats/components/chats-app/ChatsAppComponent").then(m => ({ default: m.ChatsAppComponent })),
   "chats"
 );
 
 const LazyControlPanelsApp = createLazyComponent<ControlPanelsInitialData>(
-  () => import("@/apps/control-panels/components/ControlPanelsAppComponent").then(m => ({ default: m.ControlPanelsAppComponent })),
+  () => import("@/apps/control-panels/components/control-panels-app/ControlPanelsAppComponent").then(m => ({ default: m.ControlPanelsAppComponent })),
   "control-panels"
 );
 
@@ -78,12 +78,12 @@ const LazyPaintApp = createLazyComponent<PaintInitialData>(
 );
 
 const LazyVideosApp = createLazyComponent<VideosInitialData>(
-  () => import("@/apps/videos/components/VideosAppComponent").then(m => ({ default: m.VideosAppComponent })),
+  () => import("@/apps/videos/components/videos-app/VideosAppComponent").then(m => ({ default: m.VideosAppComponent })),
   "videos"
 );
 
 const LazyTvApp = createLazyComponent<unknown>(
-  () => import("@/apps/tv/components/TvAppComponent").then(m => ({ default: m.TvAppComponent })),
+  () => import("@/apps/tv/components/tv-app/TvAppComponent").then(m => ({ default: m.TvAppComponent })),
   "tv"
 );
 
@@ -93,7 +93,7 @@ const LazyPhotoBoothApp = createLazyComponent<unknown>(
 );
 
 const LazySynthApp = createLazyComponent<unknown>(
-  () => import("@/apps/synth/components/SynthAppComponent").then(m => ({ default: m.SynthAppComponent })),
+  () => import("@/apps/synth/components/synth-app/SynthAppComponent").then(m => ({ default: m.SynthAppComponent })),
   "synth"
 );
 
@@ -118,7 +118,7 @@ const LazyAppletViewerApp = createLazyComponent<AppletViewerInitialData>(
 );
 
 const LazyAdminApp = createLazyComponent<unknown>(
-  () => import("@/apps/admin/components/AdminAppComponent").then(m => ({ default: m.AdminAppComponent })),
+  () => import("@/apps/admin/components/admin-app/AdminAppComponent").then(m => ({ default: m.AdminAppComponent })),
   "admin"
 );
 
@@ -143,12 +143,12 @@ const LazyWinampApp = createLazyComponent<unknown>(
 );
 
 const LazyCalendarApp = createLazyComponent<unknown>(
-  () => import("@/apps/calendar/components/CalendarAppComponent").then(m => ({ default: m.CalendarAppComponent })),
+  () => import("@/apps/calendar/components/calendar-app/CalendarAppComponent").then(m => ({ default: m.CalendarAppComponent })),
   "calendar"
 );
 
 const LazyContactsApp = createLazyComponent<unknown>(
-  () => import("@/apps/contacts/components/ContactsAppComponent").then(m => ({ default: m.ContactsAppComponent })),
+  () => import("@/apps/contacts/components/contacts-app/ContactsAppComponent").then(m => ({ default: m.ContactsAppComponent })),
   "contacts"
 );
 
@@ -158,7 +158,7 @@ const LazyDashboardApp = createLazyComponent<unknown>(
 );
 
 const LazyMapsApp = createLazyComponent<unknown>(
-  () => import("@/apps/maps/components/MapsAppComponent").then(m => ({ default: m.MapsAppComponent })),
+  () => import("@/apps/maps/components/maps-app/MapsAppComponent").then(m => ({ default: m.MapsAppComponent })),
   "maps"
 );
 

--- a/src/hooks/useDisplayModeMenu.ts
+++ b/src/hooks/useDisplayModeMenu.ts
@@ -1,0 +1,61 @@
+import { useCallback, useMemo } from "react";
+import type { TFunction } from "i18next";
+import { DisplayMode } from "@/types/lyrics";
+
+export interface DisplayModeOption {
+  value: DisplayMode;
+  label: string;
+}
+
+export function useDisplayModeOptions(
+  t: TFunction,
+  options?: { hideVideoOption?: boolean }
+): DisplayModeOption[] {
+  const hideVideoOption = options?.hideVideoOption ?? false;
+  return useMemo(() => {
+    const allOptions: DisplayModeOption[] = [
+      { value: DisplayMode.Video, label: t("apps.ipod.menu.displayVideo") },
+      { value: DisplayMode.Mesh, label: t("apps.ipod.menu.displayGradient") },
+      { value: DisplayMode.Water, label: t("apps.ipod.menu.displayWater") },
+      { value: DisplayMode.Shader, label: t("apps.ipod.menu.displayShader") },
+      {
+        value: DisplayMode.Landscapes,
+        label: t("apps.ipod.menu.displayLandscapes"),
+      },
+      { value: DisplayMode.Cover, label: t("apps.ipod.menu.displayCover") },
+    ];
+
+    return hideVideoOption
+      ? allOptions.filter((option) => option.value !== DisplayMode.Video)
+      : allOptions;
+  }, [hideVideoOption, t]);
+}
+
+export function useDisplayModeSelect(params: {
+  t: TFunction;
+  setDisplayMode: (mode: DisplayMode) => void;
+  showStatus: (message: string) => void;
+  coerceVideoToCover?: boolean;
+}): (value: DisplayMode) => void {
+  const { t, setDisplayMode, showStatus, coerceVideoToCover } = params;
+  return useCallback(
+    (value: DisplayMode) => {
+      const nextMode =
+        coerceVideoToCover && value === DisplayMode.Video
+          ? DisplayMode.Cover
+          : value;
+      setDisplayMode(nextMode);
+      const labels: Record<DisplayMode, string> = {
+        [DisplayMode.Video]: t("apps.ipod.menu.displayVideo"),
+        [DisplayMode.Cover]: t("apps.ipod.menu.displayCover"),
+        [DisplayMode.Landscapes]: t("apps.ipod.menu.displayLandscapes"),
+        [DisplayMode.Shader]: t("apps.ipod.menu.displayShader"),
+        [DisplayMode.Mesh]: t("apps.ipod.menu.displayGradient"),
+        [DisplayMode.Water]: t("apps.ipod.menu.displayWater"),
+      };
+      const label = labels[nextMode] ?? nextMode;
+      showStatus(`${t("apps.ipod.menu.display", "Display")}: ${label}`);
+    },
+    [coerceVideoToCover, setDisplayMode, showStatus, t]
+  );
+}

--- a/src/hooks/useSongCover.ts
+++ b/src/hooks/useSongCover.ts
@@ -5,23 +5,11 @@
 import { useReducer, useEffect } from "react";
 import { ApiRequestError } from "@/api/core";
 import { getSongById } from "@/api/songs";
+import { formatKugouImageUrl } from "@/utils/coverArt";
 
 interface SongMetadataResponse {
   id: string;
   cover?: string;
-}
-
-/**
- * Replace {size} placeholder in Kugou image URL with actual size
- * Kugou image URLs contain {size} that needs to be replaced with: 100, 150, 240, 400, etc.
- * Also ensures HTTPS is used to avoid mixed content issues
- */
-function formatKugouImageUrl(imgUrl: string | undefined, size: number = 400): string | null {
-  if (!imgUrl) return null;
-  let url = imgUrl.replace("{size}", String(size));
-  // Ensure HTTPS
-  url = url.replace(/^http:\/\//, "https://");
-  return url;
 }
 
 // Simple in-memory cache for cover URLs to avoid repeated fetches

--- a/src/hooks/useTextOverflow.ts
+++ b/src/hooks/useTextOverflow.ts
@@ -1,0 +1,28 @@
+import { RefObject, useEffect, useState } from "react";
+
+/**
+ * Returns true when `contentRef`'s scroll width exceeds `containerRef`'s client
+ * width (i.e. the text is clipped). Re-measures on mount, on `deps` changes,
+ * and on container resize. Shared by the LCD marquee surfaces.
+ */
+export function useTextOverflow(
+  containerRef: RefObject<HTMLElement | null>,
+  contentRef: RefObject<HTMLElement | null>,
+  deps: unknown[]
+): boolean {
+  const [overflows, setOverflows] = useState(false);
+  useEffect(() => {
+    const container = containerRef.current;
+    const content = contentRef.current;
+    if (!container || !content) return;
+    const check = () => {
+      setOverflows(content.scrollWidth > container.clientWidth + 1);
+    };
+    check();
+    const ro = new ResizeObserver(check);
+    ro.observe(container);
+    return () => ro.disconnect();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, deps);
+  return overflows;
+}

--- a/src/hooks/useTranslatedLyricsLanguages.ts
+++ b/src/hooks/useTranslatedLyricsLanguages.ts
@@ -1,6 +1,6 @@
 import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
-import { TRANSLATION_LANGUAGES } from "@/apps/ipod/constants";
+import { TRANSLATION_LANGUAGES } from "@/utils/lyricsTranslation";
 
 export type TranslatedLyricsLanguage = {
   label: string;

--- a/src/stores/useIpodStore.ts
+++ b/src/stores/useIpodStore.ts
@@ -17,6 +17,10 @@ import { getCachedSongMetadata, listAllCachedSongMetadata } from "@/utils/songMe
 import i18n from "@/lib/i18n";
 import { useChatsStore } from "./useChatsStore";
 import { abortableFetch } from "@/utils/abortableFetch";
+import {
+  fetchYouTubeOembed,
+  parseYouTubeTitle,
+} from "@/utils/youtubeMetadata";
 import { emitCloudSyncDomainChange } from "@/utils/cloudSyncEvents";
 import { sortTracksLikeServerOrder } from "@/stores/ipodTrackOrder";
 import { saveAppleMusicLibrary } from "@/utils/appleMusicLibraryCache";
@@ -1657,24 +1661,13 @@ export const useIpodStore = create<IpodState>()(
         let authorName: string | undefined = undefined; // Store author_name
 
         try {
-          // Fetch oEmbed data
-          const oembedUrl = `https://www.youtube.com/oembed?url=${encodeURIComponent(
-            youtubeUrl
-          )}&format=json`;
-          const oembedResponse = await abortableFetch(oembedUrl, {
-            timeout: 15000,
-            throwOnHttpError: false,
-            credentials: "omit",
-            retry: { maxAttempts: 1, initialDelayMs: 250 },
-          });
-
-          if (oembedResponse.ok) {
-            const oembedData = await oembedResponse.json();
-            rawTitle = oembedData.title || rawTitle;
-            authorName = oembedData.author_name; // Extract author_name
+          const oembed = await fetchYouTubeOembed(videoId);
+          if (oembed.ok) {
+            rawTitle = oembed.rawTitle || rawTitle;
+            authorName = oembed.authorName; // Extract author_name
           } else {
             throw new Error(
-              `Failed to fetch video info (${oembedResponse.status}). Please check the YouTube URL.`
+              `Failed to fetch video info (${oembed.status}). Please check the YouTube URL.`
             );
           }
         } catch (error) {
@@ -1741,36 +1734,10 @@ export const useIpodStore = create<IpodState>()(
         // If no Kugou match found (no lyricsSource), fall back to AI title parsing
         if (!trackInfo.lyricsSource) {
           console.log(`[iPod Store] No Kugou match for ${videoId}, falling back to AI parse`);
-          try {
-            // Call /api/parse-title
-            const parseResponse = await abortableFetch(
-              getApiUrl("/api/parse-title"),
-              {
-                method: "POST",
-                headers: { "Content-Type": "application/json" },
-                body: JSON.stringify({
-                  title: rawTitle,
-                  author_name: authorName,
-                }),
-                timeout: 15000,
-                throwOnHttpError: false,
-                retry: { maxAttempts: 1, initialDelayMs: 250 },
-              }
-            );
-
-            if (parseResponse.ok) {
-              const parsedData = await parseResponse.json();
-              trackInfo.title = parsedData.title || rawTitle;
-              trackInfo.artist = parsedData.artist;
-              trackInfo.album = parsedData.album;
-            } else {
-              console.warn(
-                `Failed to parse title with AI (status: ${parseResponse.status}), using raw title from oEmbed/default.`
-              );
-            }
-          } catch (error) {
-            console.error("Error calling /api/parse-title:", error);
-          }
+          const parsed = await parseYouTubeTitle(rawTitle, authorName);
+          trackInfo.title = parsed.title;
+          trackInfo.artist = parsed.artist;
+          trackInfo.album = parsed.album;
         }
 
         const newTrack: Track = {

--- a/src/utils/coverArt.ts
+++ b/src/utils/coverArt.ts
@@ -1,0 +1,15 @@
+/**
+ * Replace the `{size}` placeholder in a Kugou image URL with an actual size.
+ * Kugou image URLs contain `{size}` that needs to be replaced with: 100, 150,
+ * 240, 400, etc. Also upgrades `http://` to `https://` to avoid mixed-content
+ * issues. Returns null when no URL is provided.
+ */
+export function formatKugouImageUrl(
+  imgUrl: string | undefined,
+  size: number = 400
+): string | null {
+  if (!imgUrl) return null;
+  let url = imgUrl.replace("{size}", String(size));
+  url = url.replace(/^http:\/\//, "https://");
+  return url;
+}

--- a/src/utils/lyricsTranslation.ts
+++ b/src/utils/lyricsTranslation.ts
@@ -1,0 +1,53 @@
+import i18n from "@/lib/i18n";
+
+// Translation language options shared by the lyrics surfaces (iPod, Karaoke,
+// lyrics menus and dialogs).
+export interface TranslationLanguage {
+  labelKey?: string;
+  label?: string;
+  code: string | null;
+  separator?: boolean;
+}
+
+export const TRANSLATION_LANGUAGES: TranslationLanguage[] = [
+  { labelKey: "apps.ipod.translationLanguages.original", code: null },
+  { labelKey: "apps.ipod.translationLanguages.auto", code: "auto" },
+  { separator: true, code: null, label: "" }, // Separator
+  { labelKey: "apps.ipod.translationLanguages.english", code: "en" },
+  { labelKey: "apps.ipod.translationLanguages.chinese", code: "zh-TW" },
+  { labelKey: "apps.ipod.translationLanguages.japanese", code: "ja" },
+  { labelKey: "apps.ipod.translationLanguages.korean", code: "ko" },
+  { labelKey: "apps.ipod.translationLanguages.spanish", code: "es" },
+  { labelKey: "apps.ipod.translationLanguages.french", code: "fr" },
+  { labelKey: "apps.ipod.translationLanguages.german", code: "de" },
+  { labelKey: "apps.ipod.translationLanguages.portuguese", code: "pt" },
+  { labelKey: "apps.ipod.translationLanguages.italian", code: "it" },
+  { labelKey: "apps.ipod.translationLanguages.russian", code: "ru" },
+];
+
+// Translation badge mappings
+export const TRANSLATION_BADGES: Record<string, string> = {
+  "zh-TW": "中",
+  en: "En",
+  ja: "日",
+  ko: "한",
+  es: "Es",
+  fr: "Fr",
+  de: "De",
+  pt: "Pt",
+  it: "It",
+  ru: "Ru",
+};
+
+// Helper to get translation badge from code
+export function getTranslationBadge(code: string | null): string | null {
+  if (!code) return null;
+  // For "auto", resolve to the actual ryOS language
+  if (code === "auto") {
+    const actualLang = i18n.language;
+    return (
+      TRANSLATION_BADGES[actualLang] || actualLang[0]?.toUpperCase() || "?"
+    );
+  }
+  return TRANSLATION_BADGES[code] || code[0]?.toUpperCase() || "?";
+}

--- a/src/utils/youtubeMetadata.ts
+++ b/src/utils/youtubeMetadata.ts
@@ -1,0 +1,80 @@
+import { abortableFetch } from "@/utils/abortableFetch";
+import { getApiUrl } from "@/utils/platform";
+
+const FETCH_OPTS = {
+  timeout: 15000,
+  throwOnHttpError: false as const,
+  retry: { maxAttempts: 1, initialDelayMs: 250 },
+};
+
+export interface YouTubeOembedResult {
+  ok: boolean;
+  status: number;
+  /** oEmbed video title (present when `ok`). */
+  rawTitle?: string;
+  /** oEmbed channel/author name (present when `ok`). */
+  authorName?: string;
+}
+
+/**
+ * Fetch YouTube oEmbed title/author for a video id. Does not throw on HTTP
+ * errors (returns `{ ok: false, status }`); network errors propagate.
+ */
+export async function fetchYouTubeOembed(
+  videoId: string
+): Promise<YouTubeOembedResult> {
+  const oembedUrl = `https://www.youtube.com/oembed?url=${encodeURIComponent(
+    `https://www.youtube.com/watch?v=${videoId}`
+  )}&format=json`;
+  const res = await abortableFetch(oembedUrl, {
+    ...FETCH_OPTS,
+    credentials: "omit",
+  });
+  if (!res.ok) return { ok: false, status: res.status };
+  const data = (await res.json()) as { title?: string; author_name?: string };
+  return {
+    ok: true,
+    status: res.status,
+    rawTitle: data.title,
+    authorName: data.author_name,
+  };
+}
+
+export interface ParsedYouTubeTitle {
+  title: string;
+  artist?: string;
+  album?: string;
+}
+
+/**
+ * Resolve a cleaned title/artist via `/api/parse-title`. Never throws: on any
+ * HTTP/network failure it falls back to `{ title: rawTitle }`.
+ */
+export async function parseYouTubeTitle(
+  rawTitle: string,
+  authorName?: string
+): Promise<ParsedYouTubeTitle> {
+  try {
+    const res = await abortableFetch(getApiUrl("/api/parse-title"), {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ title: rawTitle, author_name: authorName }),
+      ...FETCH_OPTS,
+    });
+    if (res.ok) {
+      const data = (await res.json()) as {
+        title?: string;
+        artist?: string;
+        album?: string;
+      };
+      return {
+        title: data.title || rawTitle,
+        artist: data.artist,
+        album: data.album,
+      };
+    }
+  } catch {
+    // ignore — fall back to the raw oEmbed title
+  }
+  return { title: rawTitle };
+}

--- a/src/utils/youtubeUrl.ts
+++ b/src/utils/youtubeUrl.ts
@@ -22,3 +22,39 @@ export function isYouTubeUrl(url: string | undefined | null): boolean {
     return false;
   }
 }
+
+const YOUTUBE_ID_RE = /^[a-zA-Z0-9_-]{11}$/;
+
+/**
+ * Canonical YouTube video-id extractor. Accepts a raw 11-char id or any
+ * supported YouTube URL (watch, youtu.be, embed, shorts, v/). Returns null
+ * for unsupported hosts or invalid input.
+ *
+ * Host validation uses the same exact-match allow-list as {@link isYouTubeUrl}
+ * (not substring checks), so substring-confusable hosts like
+ * `evil-youtube.com` cannot slip through.
+ */
+export function parseYouTubeVideoId(
+  input: string | undefined | null
+): string | null {
+  if (!input) return null;
+  const trimmed = input.trim();
+  if (!trimmed) return null;
+  if (YOUTUBE_ID_RE.test(trimmed)) return trimmed;
+  try {
+    const url = new URL(trimmed);
+    const hostname = url.hostname.toLowerCase();
+    if (!isYouTubeHostname(hostname)) return null;
+
+    const v = url.searchParams.get("v");
+    if (v && YOUTUBE_ID_RE.test(v)) return v;
+    if (hostname === "youtu.be") {
+      const id = url.pathname.slice(1).split("/")[0] ?? "";
+      return YOUTUBE_ID_RE.test(id) ? id : null;
+    }
+    const m = url.pathname.match(/\/(?:embed\/|v\/|shorts\/)?([a-zA-Z0-9_-]{11})/);
+    return m ? m[1] : null;
+  } catch {
+    return null;
+  }
+}

--- a/src/utils/youtubeUrl.ts
+++ b/src/utils/youtubeUrl.ts
@@ -25,6 +25,21 @@ export function isYouTubeUrl(url: string | undefined | null): boolean {
 
 const YOUTUBE_ID_RE = /^[a-zA-Z0-9_-]{11}$/;
 
+export type YouTubeThumbnailQuality =
+  | "default"
+  | "mqdefault"
+  | "hqdefault"
+  | "sddefault"
+  | "maxresdefault";
+
+/** Build the `img.youtube.com` thumbnail URL for a video id. */
+export function youtubeThumbnailUrl(
+  videoId: string,
+  quality: YouTubeThumbnailQuality = "maxresdefault"
+): string {
+  return `https://img.youtube.com/vi/${videoId}/${quality}.jpg`;
+}
+
 /**
  * Canonical YouTube video-id extractor. Accepts a raw 11-char id or any
  * supported YouTube URL (watch, youtu.be, embed, shorts, v/). Returns null


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Unifies parallel code paths created by the #1342 component split. Two phases: iPod/Karaoke unification, then a cross-app rollout. Each tier is a separate commit.

## iPod / Karaoke (Tiers 1–3)
- **Tier 1:** shared `AppMenuBarShell`; Karaoke font picker → radio (parity); shared `libraryMenuConstants` + Karaoke library truncation; `MENUBAR_SEPARATOR_CLASS` adoption.
- **Tier 2:** `MediaLyricsViewMenuItems`, `LibraryTrackBrowser`, `useDisplayModeMenu`; promote `formatKugouImageUrl`/`lyricsTranslation`/`parseYouTubeVideoId` out of `apps/ipod/constants` into `src/utils/`; consolidate YouTube id extraction on host-safe `parseYouTubeVideoId`; remove iPod/Karaoke re-export stubs.
- **Tier 3:** `youtubeThumbnailUrl` helper adoption; dedupe `useSongCover` `formatKugouImageUrl`. iPod/Karaoke keep independent playback/history state (no transport-store unification).

## Cross-app (Tiers 1–3)
- **Tier 1:** roll **all 24** remaining app menubars onto `AppMenuBarShell` (+ `MENUBAR_SEPARATOR_CLASS`); add `AppHelpAboutDialogs` bundle, adopted across **26** dialog sites; add shared `youtubeMetadata` (`fetchYouTubeOembed` + `parseYouTubeTitle`), dedupe the oEmbed/parse-title pipeline in Videos, TV-prompt, iPod store, chats `tvHandler`; route Videos `extractVideoId` through host-safe `parseYouTubeVideoId`; dedupe admin `formatKugouImageUrl`.
- **Tier 2:** Videos adopts `MediaControlsMenu` (added a backward-compatible `extraItems` slot to preserve the Full Screen item position).
- **Tier 3:** extract `useTextOverflow` (shared by `LcdAnimatedTitle` + TV `ScrollingChannelName`, output-identical); remove **11** app-component re-export stubs and repoint the lazy registry + app indexes to real `*-app/` paths.

### Deferred / declined (with rationale)
- **Visual/interaction merges** — shared Videos/TV LCD transport bar, full marquee-component merge, and the `VideoFullScreenPortal`↔iPod `FullScreenPortal` shell — were assessed but **deferred**: they change rendered/interaction structure and their correctness requires GUI validation, which `AGENTS.md` says to skip unless explicitly requested. Doing them blind risks regressions in primary media UX. (The safe, output-identical subsets — `MediaControlsMenu` adoption and `useTextOverflow` — were completed.)
- **Expanding `use*AppController` to the remaining 17 apps** — **declined** as net-negative churn/regression risk with no dedup benefit.
- Remaining shared-barrel stubs (e.g. `WindowFrame`, `HtmlPreview`, `LinkPreview`) kept as intentional public import paths.

### Testing
- `npx tsc -b` — passes (every tier)
- `bun run build` — passes (all app lazy chunks build)
- `bun test tests/test-tv-utils.test.ts tests/test-song-lyrics-match.test.ts` — pass (YouTube parser consolidation behavior-safe)
- `eslint` on changed files — 0 errors (only pre-existing `exhaustive-deps` warnings)

Per `AGENTS.md`, GUI testing is skipped unless explicitly requested; all changes here are structural/logic dedups verified by typecheck + build (output-preserving).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019e7de2-e16b-71b2-9ac8-4ffe900e1225"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019e7de2-e16b-71b2-9ac8-4ffe900e1225"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

