### PR TITLE
Suppress Cursor agent dashboard URLs from chat link previews

### DIFF
--- a/src/apps/chats/components/chat-messages/chat-message-item/useChatMessageItem.ts
+++ b/src/apps/chats/components/chat-messages/chat-message-item/useChatMessageItem.ts
@@ -13,6 +13,7 @@ import {
   getUserColorClass,
   isUrgentMessage,
 } from "../utils";
+import { filterUrlsForChatLinkPreviews } from "@/utils/cursorAgentDashboardUrl";
 import { extractUrlsFromContent } from "./utils";
 
 export type ChatMessageItemViewModel = ReturnType<typeof useChatMessageItem>;
@@ -162,7 +163,7 @@ export function useChatMessageItem(props: ChatMessageItemProps) {
     } else {
       extractUrlsFromContent(displayContent).forEach((u) => allUrls.add(u));
     }
-    return Array.from(allUrls);
+    return filterUrlsForChatLinkPreviews(allUrls);
   })();
 
   return {

--- a/src/utils/cursorAgentDashboardUrl.ts
+++ b/src/utils/cursorAgentDashboardUrl.ts
@@ -1,0 +1,26 @@
+const CURSOR_AGENT_DASHBOARD_HOSTS = new Set(["cursor.com", "www.cursor.com"]);
+
+/**
+ * True when `url` is a Cursor Cloud agent dashboard link (e.g.
+ * https://cursor.com/agents/bc_…), matching shapes produced by
+ * `cursorCloudAgentDashboardUrl` / `listCursorCloudAgentRuns`.
+ */
+export function isCursorAgentDashboardUrl(
+  url: string | undefined | null
+): boolean {
+  if (!url?.trim()) return false;
+  try {
+    const parsed = new URL(url.trim());
+    const host = parsed.hostname.toLowerCase();
+    if (!CURSOR_AGENT_DASHBOARD_HOSTS.has(host)) return false;
+    const segments = parsed.pathname.split("/").filter(Boolean);
+    return segments.length >= 2 && segments[0] === "agents" && segments[1].length > 0;
+  } catch {
+    return false;
+  }
+}
+
+/** Omit Cursor agent dashboard URLs from chat link-preview cards. */
+export function filterUrlsForChatLinkPreviews(urls: Iterable<string>): string[] {
+  return Array.from(urls).filter((u) => !isCursorAgentDashboardUrl(u));
+}

--- a/tests/test-chat-link-preview-filter.test.ts
+++ b/tests/test-chat-link-preview-filter.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from "bun:test";
+import {
+  filterUrlsForChatLinkPreviews,
+  isCursorAgentDashboardUrl,
+} from "../src/utils/cursorAgentDashboardUrl";
+import { extractUrlsFromContent } from "../src/apps/chats/components/chat-messages/chat-message-item/utils";
+
+describe("isCursorAgentDashboardUrl", () => {
+  test("matches canonical Cursor agent dashboard URLs", () => {
+    expect(
+      isCursorAgentDashboardUrl("https://cursor.com/agents/bc_abc123")
+    ).toBe(true);
+    expect(isCursorAgentDashboardUrl("https://cursor.com/agents/ag1")).toBe(
+      true
+    );
+    expect(
+      isCursorAgentDashboardUrl("https://www.cursor.com/agents/foo/")
+    ).toBe(true);
+    expect(
+      isCursorAgentDashboardUrl(
+        "https://cursor.com/agents/bc_abc?tab=overview#section"
+      )
+    ).toBe(true);
+  });
+
+  test("rejects non-dashboard Cursor and other hosts", () => {
+    expect(isCursorAgentDashboardUrl("https://cursor.com/")).toBe(false);
+    expect(isCursorAgentDashboardUrl("https://cursor.com/agents")).toBe(false);
+    expect(isCursorAgentDashboardUrl("https://cursor.com/agents/")).toBe(
+      false
+    );
+    expect(isCursorAgentDashboardUrl("https://github.com/ryokun6/ryos")).toBe(
+      false
+    );
+    expect(isCursorAgentDashboardUrl("not-a-url")).toBe(false);
+  });
+});
+
+describe("filterUrlsForChatLinkPreviews", () => {
+  test("drops Cursor agent dashboard URLs only", () => {
+    const filtered = filterUrlsForChatLinkPreviews([
+      "https://cursor.com/agents/bc_1",
+      "https://example.com/docs",
+      "https://cursor.com/agents/bc_2/",
+    ]);
+    expect(filtered).toEqual(["https://example.com/docs"]);
+  });
+});
+
+describe("chat message link preview extraction", () => {
+  test("assistant text with agent dashboard + normal link keeps one preview", () => {
+    const content =
+      "Started the agent: https://cursor.com/agents/bc_xyz\n\nDetails: https://example.com/page";
+    const urls = filterUrlsForChatLinkPreviews(extractUrlsFromContent(content));
+    expect(urls).toEqual(["https://example.com/page"]);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

When Ryo replies with a Cursor Cloud agent dashboard URL alongside a cursorCloudAgent or listCursorCloudAgentRuns tool card, chat no longer renders a duplicate generic LinkPreview card. Normal links still preview as before; dashboard URLs remain clickable in message markdown.

## Changes

- Add isCursorAgentDashboardUrl and filterUrlsForChatLinkPreviews in src/utils/cursorAgentDashboardUrl.ts (matches cursorCloudAgentDashboardUrl host/path shape).
- Apply filter when building linkPreviewUrls in useChatMessageItem.
- Unit tests in tests/test-chat-link-preview-filter.test.ts.

## Testing

bun test tests/test-chat-link-preview-filter.test.ts — all 4 tests pass.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bf5fb67c-c97a-40c0-a399-e6710690e5e7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bf5fb67c-c97a-40c0-a399-e6710690e5e7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

