### PR TITLE
fix(chats): subdued dark-mode shimmer on tool call loading states

### DIFF
--- a/src/components/shared/html-preview/HtmlPreview.tsx
+++ b/src/components/shared/html-preview/HtmlPreview.tsx
@@ -332,7 +332,7 @@ export default function HtmlPreview({
         ref={previewRef}
         className={`${
           isInternetExplorer ? "" : "rounded"
-        } bg-white m-0 relative ${className} ${
+        } bg-white dark:bg-neutral-950 m-0 relative ${className} ${
           isStreaming ? "loading-pulse" : ""
         } ${
           !isInternetExplorer && (appletTitle || appletIcon) ? "flex flex-col overflow-hidden" : isInternetExplorer ? "overflow-hidden" : "overflow-auto"

--- a/src/components/shared/html-preview/components/HtmlPreviewLoadingPulse.tsx
+++ b/src/components/shared/html-preview/components/HtmlPreviewLoadingPulse.tsx
@@ -3,9 +3,9 @@ import { motion } from "framer-motion";
 export function HtmlPreviewLoadingPulse() {
   return (
     <motion.div
-      className="absolute inset-0 bg-neutral-300 z-10 pointer-events-none"
-      initial={{ opacity: 0.2 }}
-      animate={{ opacity: [0.2, 0.6, 0.2] }}
+      className="absolute inset-0 z-10 pointer-events-none bg-neutral-300/80 dark:bg-neutral-800/70"
+      initial={{ opacity: 0.15 }}
+      animate={{ opacity: [0.15, 0.38, 0.15] }}
       transition={{ duration: 3, repeat: Infinity, ease: "easeInOut" }}
     />
   );

--- a/src/components/shared/link-preview/LinkPreview.tsx
+++ b/src/components/shared/link-preview/LinkPreview.tsx
@@ -43,7 +43,7 @@ export function LinkPreview({ url, className = "" }: LinkPreviewProps) {
       className={cn(
         "link-preview-container relative overflow-hidden cursor-pointer font-geneva-12 group max-w-[420px]",
         isMacOSTheme
-          ? "chat-bubble macosx-link-preview bg-neutral-100 border-none shadow-none dark:bg-neutral-800/90"
+          ? "chat-bubble macosx-link-preview rounded-[16px] bg-neutral-100 border-none shadow-none dark:bg-neutral-800/90"
           : "bg-white border border-neutral-200 rounded dark:border-neutral-700 dark:bg-neutral-950",
         className
       )}

--- a/src/components/shared/link-preview/LinkPreview.tsx
+++ b/src/components/shared/link-preview/LinkPreview.tsx
@@ -43,8 +43,8 @@ export function LinkPreview({ url, className = "" }: LinkPreviewProps) {
       className={cn(
         "link-preview-container relative overflow-hidden cursor-pointer font-geneva-12 group max-w-[420px]",
         isMacOSTheme
-          ? "chat-bubble macosx-link-preview bg-neutral-100 border-none shadow-none"
-          : "bg-white border border-neutral-200 rounded",
+          ? "chat-bubble macosx-link-preview bg-neutral-100 border-none shadow-none dark:bg-neutral-800/90"
+          : "bg-white border border-neutral-200 rounded dark:border-neutral-700 dark:bg-neutral-950",
         className
       )}
       onClick={handleClick}

--- a/src/components/shared/link-preview/components/LinkPreviewActionButtons.tsx
+++ b/src/components/shared/link-preview/components/LinkPreviewActionButtons.tsx
@@ -17,7 +17,7 @@ function actionButtonClass(
     );
   }
   return cn(
-    "flex items-center justify-center gap-1.5 px-3 py-2 text-[12px] bg-neutral-100 hover:bg-neutral-200 rounded-md transition-colors",
+    "flex items-center justify-center gap-1.5 px-3 py-2 text-[12px] bg-neutral-100 hover:bg-neutral-200 dark:bg-neutral-800 dark:hover:bg-neutral-700 dark:text-neutral-100 rounded-md transition-colors",
     variant === "pair" ? "flex-1" : "w-full"
   );
 }
@@ -145,7 +145,7 @@ export function LinkPreviewActionButtons({
   if (layout === "fullWidth") {
     return (
       <div className="px-2 pb-2">
-        <div className="flex gap-2 pt-2 border-t border-neutral-100">
+        <div className="flex gap-2 pt-2 border-t border-neutral-100 dark:border-neutral-700">
           {flexRow}
         </div>
       </div>
@@ -156,7 +156,9 @@ export function LinkPreviewActionButtons({
     <div
       className={cn(
         "pb-2 border-t",
-        isMacOSTheme ? "border-neutral-300" : "border-neutral-200"
+        isMacOSTheme
+          ? "border-neutral-300 dark:border-neutral-600"
+          : "border-neutral-200 dark:border-neutral-700"
       )}
     >
       <div className="px-2 pt-2">

--- a/src/components/shared/link-preview/components/LinkPreviewActionButtons.tsx
+++ b/src/components/shared/link-preview/components/LinkPreviewActionButtons.tsx
@@ -1,10 +1,26 @@
 import type { MouseEvent, TouchEvent } from "react";
 import { ArrowSquareOut, Microphone, MusicNote } from "@phosphor-icons/react";
 import { useTranslation } from "react-i18next";
+import { useThemeFlags } from "@/hooks/useThemeFlags";
 import { cn } from "@/lib/utils";
 import { isYouTubeUrl } from "../utils";
 
 type LayoutVariant = "fullWidth" | "sideBySide";
+
+/** Border above link-preview action rows — OS tokens on macOS Aqua, Tailwind elsewhere. */
+function linkPreviewActionsDividerClass(
+  isMacOSTheme: boolean,
+  isDarkMode: boolean
+) {
+  return cn(
+    "link-preview-actions-divider border-t",
+    isMacOSTheme
+      ? isDarkMode
+        ? "border-[color:var(--os-color-separator)]"
+        : "border-black/10"
+      : "border-neutral-200 dark:border-neutral-700"
+  );
+}
 
 function actionButtonClass(
   isMacOSTheme: boolean,
@@ -40,6 +56,8 @@ export function LinkPreviewActionButtons({
   handleOpenExternally: (e: MouseEvent | TouchEvent) => void;
 }) {
   const { t } = useTranslation();
+  const { isDarkMode } = useThemeFlags();
+  const dividerClass = linkPreviewActionsDividerClass(isMacOSTheme, isDarkMode);
   const stopTouch = (e: TouchEvent) => e.stopPropagation();
 
   const flexRow = (
@@ -145,7 +163,7 @@ export function LinkPreviewActionButtons({
   if (layout === "fullWidth") {
     return (
       <div className="px-2 pb-2">
-        <div className="flex gap-2 pt-2 border-t border-neutral-100 dark:border-neutral-700">
+        <div className={cn("flex gap-2 pt-2", dividerClass)}>
           {flexRow}
         </div>
       </div>
@@ -153,14 +171,7 @@ export function LinkPreviewActionButtons({
   }
 
   return (
-    <div
-      className={cn(
-        "pb-2 border-t",
-        isMacOSTheme
-          ? "border-neutral-300 dark:border-neutral-600"
-          : "border-neutral-200 dark:border-neutral-700"
-      )}
-    >
+    <div className={cn("pb-2", dividerClass)}>
       <div className="px-2 pt-2">
         <div className="flex gap-2">{flexRow}</div>
       </div>

--- a/src/components/shared/link-preview/components/LinkPreviewError.tsx
+++ b/src/components/shared/link-preview/components/LinkPreviewError.tsx
@@ -12,11 +12,11 @@ export function LinkPreviewError({
     <motion.div
       initial={{ opacity: 0, y: 10 }}
       animate={{ opacity: 1, y: 0 }}
-      className={`flex items-center gap-2 p-3 bg-red-50 border border-red-200 text-sm font-geneva-12 max-w-[420px] ${className}`}
+      className={`flex items-center gap-2 p-3 bg-red-50 border border-red-200 text-sm font-geneva-12 max-w-[420px] dark:border-red-900/50 dark:bg-red-950/35 ${className}`}
       style={{ borderRadius: "3px" }}
     >
-      <WarningCircle className="size-4 text-red-500" weight="bold" />
-      <span className="text-red-600">{error}</span>
+      <WarningCircle className="size-4 text-red-500 dark:text-red-400" weight="bold" />
+      <span className="text-red-600 dark:text-red-200">{error}</span>
     </motion.div>
   );
 }

--- a/src/components/shared/link-preview/components/LinkPreviewFullWidthContent.tsx
+++ b/src/components/shared/link-preview/components/LinkPreviewFullWidthContent.tsx
@@ -25,7 +25,7 @@ export function LinkPreviewFullWidthContent({
     <>
       <div
         className={cn(
-          "relative aspect-video bg-neutral-100 overflow-hidden",
+          "relative aspect-video bg-neutral-100 dark:bg-neutral-800 overflow-hidden",
           isMacOSTheme && "-mx-3 -mt-[6px] rounded-t-[14px]"
         )}
       >
@@ -49,7 +49,7 @@ export function LinkPreviewFullWidthContent({
                 e.currentTarget.nextElementSibling?.classList.remove("hidden");
               }}
             />
-            <div className="size-4 bg-neutral-300 rounded-full flex-shrink-0 hidden"></div>
+            <div className="size-4 bg-neutral-300 dark:bg-neutral-600 rounded-full flex-shrink-0 hidden"></div>
             {metadata.title && (
               <h3 className="font-semibold text-white text-[10px] truncate">
                 {metadata.title}

--- a/src/components/shared/link-preview/components/LinkPreviewLoading.tsx
+++ b/src/components/shared/link-preview/components/LinkPreviewLoading.tsx
@@ -13,7 +13,7 @@ export function LinkPreviewLoading({ className }: { className?: string }) {
         "link-preview-loading h-[106px] w-full min-w-[280px] max-w-[420px]",
         "relative overflow-hidden",
         isMacOSTheme
-          ? "chat-bubble macosx-link-preview bg-neutral-100 border-none shadow-none"
+          ? "chat-bubble macosx-link-preview rounded-[16px] bg-neutral-100 border-none shadow-none"
           : "rounded border border-neutral-200 dark:border-neutral-700",
         className
       )}
@@ -24,7 +24,7 @@ export function LinkPreviewLoading({ className }: { className?: string }) {
       <div
         className={cn(
           "link-preview-loading-skeleton absolute inset-0",
-          !isMacOSTheme && "rounded-[inherit]"
+          isMacOSTheme ? "rounded-[16px]" : "rounded-[inherit]"
         )}
         aria-hidden
       />

--- a/src/components/shared/link-preview/components/LinkPreviewLoading.tsx
+++ b/src/components/shared/link-preview/components/LinkPreviewLoading.tsx
@@ -13,7 +13,7 @@ export function LinkPreviewLoading({ className }: { className?: string }) {
         "link-preview-loading h-[106px] w-full min-w-[280px] max-w-[420px]",
         "relative overflow-hidden",
         isMacOSTheme
-          ? "chat-bubble macosx-link-preview rounded-[16px] bg-neutral-100 border-none shadow-none"
+          ? "chat-bubble macosx-link-preview rounded-[16px] border-none shadow-none bg-transparent"
           : "rounded border border-neutral-200 dark:border-neutral-700",
         className
       )}

--- a/src/components/shared/link-preview/components/LinkPreviewLoading.tsx
+++ b/src/components/shared/link-preview/components/LinkPreviewLoading.tsx
@@ -1,23 +1,33 @@
 import { motion } from "framer-motion";
+import { useThemeFlags } from "@/hooks/useThemeFlags";
 import { cn } from "@/lib/utils";
 
 export function LinkPreviewLoading({ className }: { className?: string }) {
+  const { isMacOSTheme } = useThemeFlags();
+
   return (
     <motion.div
       initial={{ opacity: 0, y: 10 }}
       animate={{ opacity: 1, y: 0 }}
       className={cn(
-        "h-[106px] w-full min-w-[280px] max-w-[420px]",
-        "relative overflow-hidden rounded",
-        "border border-neutral-200 bg-neutral-50/80",
-        "dark:border-neutral-700 dark:bg-neutral-900/80",
-        "before:absolute before:inset-0",
-        "before:bg-gradient-to-r before:from-neutral-200 before:via-neutral-100 before:to-neutral-200",
-        "dark:before:from-neutral-800 dark:before:via-neutral-700 dark:before:to-neutral-800",
-        "before:animate-[shimmer_2s_linear_infinite]",
-        "before:bg-[length:200%_100%]",
+        "link-preview-loading h-[106px] w-full min-w-[280px] max-w-[420px]",
+        "relative overflow-hidden",
+        isMacOSTheme
+          ? "chat-bubble macosx-link-preview bg-neutral-100 border-none shadow-none"
+          : "rounded border border-neutral-200 dark:border-neutral-700",
         className
       )}
-    />
+      data-link-preview
+      aria-busy="true"
+      aria-label="Loading link preview"
+    >
+      <div
+        className={cn(
+          "link-preview-loading-skeleton absolute inset-0",
+          !isMacOSTheme && "rounded-[inherit]"
+        )}
+        aria-hidden
+      />
+    </motion.div>
   );
 }

--- a/src/components/shared/link-preview/components/LinkPreviewLoading.tsx
+++ b/src/components/shared/link-preview/components/LinkPreviewLoading.tsx
@@ -13,7 +13,7 @@ export function LinkPreviewLoading({ className }: { className?: string }) {
         "link-preview-loading h-[106px] w-full min-w-[280px] max-w-[420px]",
         "relative overflow-hidden",
         isMacOSTheme
-          ? "chat-bubble macosx-link-preview rounded-[16px] border-none shadow-none bg-transparent"
+          ? "chat-bubble macosx-link-preview rounded-[16px] border-none shadow-none link-preview-loading-skeleton"
           : "rounded border border-neutral-200 dark:border-neutral-700",
         className
       )}
@@ -21,13 +21,14 @@ export function LinkPreviewLoading({ className }: { className?: string }) {
       aria-busy="true"
       aria-label="Loading link preview"
     >
-      <div
-        className={cn(
-          "link-preview-loading-skeleton absolute inset-0",
-          isMacOSTheme ? "rounded-[16px]" : "rounded-[inherit]"
-        )}
-        aria-hidden
-      />
+      {/* Non-macOS: overlay skeleton. macOS applies skeleton on the bubble itself
+          because `.chat-bubble > * { position: relative }` breaks absolute children. */}
+      {!isMacOSTheme ? (
+        <div
+          className="link-preview-loading-skeleton absolute inset-0 rounded-[inherit]"
+          aria-hidden
+        />
+      ) : null}
     </motion.div>
   );
 }

--- a/src/components/shared/link-preview/components/LinkPreviewLoading.tsx
+++ b/src/components/shared/link-preview/components/LinkPreviewLoading.tsx
@@ -8,10 +8,12 @@ export function LinkPreviewLoading({ className }: { className?: string }) {
       animate={{ opacity: 1, y: 0 }}
       className={cn(
         "h-[106px] w-full min-w-[280px] max-w-[420px]",
-        "relative overflow-hidden",
-        "border border-neutral-200 rounded",
+        "relative overflow-hidden rounded",
+        "border border-neutral-200 bg-neutral-50/80",
+        "dark:border-neutral-700 dark:bg-neutral-900/80",
         "before:absolute before:inset-0",
         "before:bg-gradient-to-r before:from-neutral-200 before:via-neutral-100 before:to-neutral-200",
+        "dark:before:from-neutral-800 dark:before:via-neutral-700 dark:before:to-neutral-800",
         "before:animate-[shimmer_2s_linear_infinite]",
         "before:bg-[length:200%_100%]",
         className

--- a/src/components/shared/link-preview/components/LinkPreviewSideBySideContent.tsx
+++ b/src/components/shared/link-preview/components/LinkPreviewSideBySideContent.tsx
@@ -29,7 +29,7 @@ export function LinkPreviewSideBySideContent({
         {metadata.image && (
           <div
             className={cn(
-              "size-18 bg-neutral-100 relative overflow-hidden flex-shrink-0",
+              "size-18 bg-neutral-100 dark:bg-neutral-800 relative overflow-hidden flex-shrink-0",
               isMacOSTheme && "hidden"
             )}
           >
@@ -64,7 +64,7 @@ export function LinkPreviewSideBySideContent({
         >
           {metadata.title && (
             <h3
-              className="font-semibold text-neutral-900 text-[10px]"
+              className="font-semibold text-neutral-900 dark:text-neutral-100 text-[10px]"
               style={{
                 display: "-webkit-box",
                 WebkitLineClamp: 1,
@@ -78,7 +78,7 @@ export function LinkPreviewSideBySideContent({
 
           {metadata.description && (
             <p
-              className={`text-[10px] text-neutral-600 ${
+              className={`text-[10px] text-neutral-600 dark:text-neutral-400 ${
                 metadata.image ? "" : "mb-2"
               }`}
               style={{
@@ -105,8 +105,8 @@ export function LinkPreviewSideBySideContent({
                   );
                 }}
               />
-              <div className="size-4 bg-neutral-300 rounded-full flex-shrink-0 hidden"></div>
-              <p className="text-[10px] text-neutral-500 truncate">
+              <div className="size-4 bg-neutral-300 dark:bg-neutral-600 rounded-full flex-shrink-0 hidden"></div>
+              <p className="text-[10px] text-neutral-500 dark:text-neutral-400 truncate">
                 {metadata.siteName || new URL(url).hostname}
               </p>
             </div>

--- a/src/index.css
+++ b/src/index.css
@@ -1062,6 +1062,18 @@ button.piano-key.piano-key[class*="bg-[#ff33ff]"] {
   animation: shimmer 2s infinite linear;
 }
 
+/* Tool-call / chat loading text — subdued sweep on dark surfaces (matches .dark on <html>) */
+.dark .shimmer {
+  background-image: linear-gradient(
+    90deg,
+    rgba(163, 163, 163, 0.32) 0%,
+    rgba(163, 163, 163, 0.32) 25%,
+    rgba(212, 212, 212, 0.62) 40%,
+    rgba(163, 163, 163, 0.32) 75%,
+    rgba(163, 163, 163, 0.32) 100%
+  );
+}
+
 .shimmer-gray {
   /* Use a gradient suitable for gray text */
   background-image: linear-gradient(
@@ -1077,6 +1089,17 @@ button.piano-key.piano-key[class*="bg-[#ff33ff]"] {
   background-clip: text;
   -webkit-text-fill-color: transparent;
   animation: shimmer 2s infinite linear;
+}
+
+.dark .shimmer-gray {
+  background-image: linear-gradient(
+    90deg,
+    rgba(115, 115, 115, 0.38) 0%,
+    rgba(115, 115, 115, 0.38) 25%,
+    rgba(212, 212, 212, 0.58) 40%,
+    rgba(115, 115, 115, 0.38) 75%,
+    rgba(115, 115, 115, 0.38) 100%
+  );
 }
 
 /* Cursor agent stream markdown — compact rhythm aligned with tool-call rows */

--- a/src/index.css
+++ b/src/index.css
@@ -1102,6 +1102,33 @@ button.piano-key.piano-key[class*="bg-[#ff33ff]"] {
   );
 }
 
+/* Link preview loading skeleton — surface + animated sweep (not text clip) */
+.link-preview-loading-skeleton {
+  background-color: rgba(245, 245, 245, 0.9);
+  background-image: linear-gradient(
+    90deg,
+    rgba(229, 229, 229, 0.9) 0%,
+    rgba(229, 229, 229, 0.9) 25%,
+    rgba(250, 250, 250, 1) 40%,
+    rgba(229, 229, 229, 0.9) 75%,
+    rgba(229, 229, 229, 0.9) 100%
+  );
+  background-size: 200% 100%;
+  animation: shimmer 2s infinite linear;
+}
+
+.dark .link-preview-loading-skeleton {
+  background-color: rgba(38, 38, 42, 0.95);
+  background-image: linear-gradient(
+    90deg,
+    rgba(63, 63, 70, 0.95) 0%,
+    rgba(63, 63, 70, 0.95) 25%,
+    rgba(82, 82, 91, 0.85) 40%,
+    rgba(63, 63, 70, 0.95) 75%,
+    rgba(63, 63, 70, 0.95) 100%
+  );
+}
+
 /* Cursor agent stream markdown — compact rhythm aligned with tool-call rows */
 .cursor-stream-md > *:first-child {
   margin-top: 0;

--- a/src/styles/themes.css
+++ b/src/styles/themes.css
@@ -2851,6 +2851,11 @@
   overflow: hidden;
 }
 
+/* Loading bubble: fill edge-to-edge so the skeleton sweep is visible (not just padding box) */
+:root[data-os-theme="macosx"] .link-preview-loading.macosx-link-preview.chat-bubble {
+  padding: 0 !important;
+}
+
 :root[data-os-theme="macosx"] .macosx-link-preview.chat-bubble:before {
   top: 2px; /* extend shine to very top when image flush */
   left: 8px;
@@ -2860,9 +2865,24 @@
   z-index: 10; /* above image */
 }
 
-:root[data-os-theme="macosx"] .macosx-link-preview .link-preview-loading-skeleton {
+:root[data-os-theme="macosx"] .link-preview-loading.link-preview-loading-skeleton {
   border-radius: 16px;
-  z-index: 2;
+}
+
+/* macOS Aqua dark — mirror .dark skeleton when only data-os-color-scheme is set */
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"]
+  .link-preview-loading.link-preview-loading-skeleton {
+  background-color: rgba(38, 38, 42, 0.95);
+  background-image: linear-gradient(
+    90deg,
+    rgba(63, 63, 70, 0.95) 0%,
+    rgba(63, 63, 70, 0.95) 25%,
+    rgba(82, 82, 91, 0.85) 40%,
+    rgba(63, 63, 70, 0.95) 75%,
+    rgba(63, 63, 70, 0.95) 100%
+  );
+  background-size: 200% 100%;
+  animation: shimmer 2s infinite linear;
 }
 
 /* Loading: shimmer must sit above the fill but below is wrong — gloss pseudo-elements

--- a/src/styles/themes.css
+++ b/src/styles/themes.css
@@ -2844,6 +2844,13 @@
   background-color: #e5e7eb !important; /* gray-200 */
 }
 
+/* Link preview cards (chat) — 16px outer radius matches chat-bubble + image top radii */
+:root[data-os-theme="macosx"] .macosx-link-preview.chat-bubble.link-preview-container,
+:root[data-os-theme="macosx"] .macosx-link-preview.chat-bubble.link-preview-loading {
+  border-radius: 16px !important;
+  overflow: hidden;
+}
+
 :root[data-os-theme="macosx"] .macosx-link-preview.chat-bubble:before {
   top: 2px; /* extend shine to very top when image flush */
   left: 8px;
@@ -2851,6 +2858,10 @@
   filter: blur(0.5px);
   border-radius: 14px 14px 4px 4px;
   z-index: 10; /* above image */
+}
+
+:root[data-os-theme="macosx"] .macosx-link-preview .link-preview-loading-skeleton {
+  border-radius: 16px;
 }
 
 /* Link preview loading: keep aqua chrome but avoid a bright gloss stripe on dark fills */

--- a/src/styles/themes.css
+++ b/src/styles/themes.css
@@ -2853,6 +2853,23 @@
   z-index: 10; /* above image */
 }
 
+/* Link preview loading: keep aqua chrome but avoid a bright gloss stripe on dark fills */
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"]
+  .link-preview-loading.macosx-link-preview.chat-bubble:before {
+  background: linear-gradient(
+    rgba(255, 255, 255, 0.1),
+    rgba(255, 255, 255, 0.02)
+  );
+}
+
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"]
+  .link-preview-loading.macosx-link-preview.chat-bubble:after {
+  background: linear-gradient(
+    rgba(255, 255, 255, 0),
+    rgba(255, 255, 255, 0.08)
+  );
+}
+
 /* macOS Memory/Progress bar styling */
 :root[data-os-theme="macosx"] .aqua-progress,
 .ipod-modern-screen .aqua-progress {

--- a/src/styles/themes.css
+++ b/src/styles/themes.css
@@ -2862,6 +2862,16 @@
 
 :root[data-os-theme="macosx"] .macosx-link-preview .link-preview-loading-skeleton {
   border-radius: 16px;
+  z-index: 2;
+}
+
+/* Loading: shimmer must sit above the fill but below is wrong — gloss pseudo-elements
+   default to z-index 10 on link previews and fully obscure the animated skeleton. */
+:root[data-os-theme="macosx"]
+  .link-preview-loading.macosx-link-preview.chat-bubble:before,
+:root[data-os-theme="macosx"]
+  .link-preview-loading.macosx-link-preview.chat-bubble:after {
+  display: none;
 }
 
 :root[data-os-theme="macosx"] .macosx-link-preview .link-preview-actions-divider {
@@ -2874,22 +2884,6 @@
   border-top-color: var(--os-color-separator);
 }
 
-/* Link preview loading: keep aqua chrome but avoid a bright gloss stripe on dark fills */
-:root[data-os-theme="macosx"][data-os-color-scheme="dark"]
-  .link-preview-loading.macosx-link-preview.chat-bubble:before {
-  background: linear-gradient(
-    rgba(255, 255, 255, 0.1),
-    rgba(255, 255, 255, 0.02)
-  );
-}
-
-:root[data-os-theme="macosx"][data-os-color-scheme="dark"]
-  .link-preview-loading.macosx-link-preview.chat-bubble:after {
-  background: linear-gradient(
-    rgba(255, 255, 255, 0),
-    rgba(255, 255, 255, 0.08)
-  );
-}
 
 /* macOS Memory/Progress bar styling */
 :root[data-os-theme="macosx"] .aqua-progress,

--- a/src/styles/themes.css
+++ b/src/styles/themes.css
@@ -4259,6 +4259,7 @@
   background-color: #423739 !important;
 }
 :root[data-os-theme="macosx"][data-os-color-scheme="dark"] .chat-bubble.bg-gray-100,
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"] .chat-bubble.bg-neutral-100,
 :root[data-os-theme="macosx"][data-os-color-scheme="dark"] .chat-bubble.bg-neutral-200 {
   background-color: #3a3a3f !important;
 }

--- a/src/styles/themes.css
+++ b/src/styles/themes.css
@@ -2864,6 +2864,16 @@
   border-radius: 16px;
 }
 
+:root[data-os-theme="macosx"] .macosx-link-preview .link-preview-actions-divider {
+  border-top-color: rgba(0, 0, 0, 0.1);
+}
+
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"]
+  .macosx-link-preview
+  .link-preview-actions-divider {
+  border-top-color: var(--os-color-separator);
+}
+
 /* Link preview loading: keep aqua chrome but avoid a bright gloss stripe on dark fills */
 :root[data-os-theme="macosx"][data-os-color-scheme="dark"]
   .link-preview-loading.macosx-link-preview.chat-bubble:before {

--- a/tests/test-link-preview-dark.test.ts
+++ b/tests/test-link-preview-dark.test.ts
@@ -70,9 +70,12 @@ describe("link preview dark mode styling", () => {
     expect(previewSource).toContain("dark:bg-neutral-800/90");
   });
 
-  test("macOS dark tones down link preview loading bubble gloss", () => {
-    expect(themesCss).toContain(".link-preview-loading.macosx-link-preview.chat-bubble:before");
-    expect(themesCss).toContain("rgba(255, 255, 255, 0.1)");
+  test("macOS loading hides bubble gloss pseudo-elements so skeleton shimmer shows", () => {
+    expect(themesCss).toContain(
+      ".link-preview-loading.macosx-link-preview.chat-bubble:before"
+    );
+    expect(themesCss).toContain("display: none");
+    expect(loadingSource).toContain("bg-transparent");
   });
 
   test("macOS themes enforce 16px radius on link preview cards and loading shells", () => {

--- a/tests/test-link-preview-dark.test.ts
+++ b/tests/test-link-preview-dark.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const loadingSource = readFileSync(
+  join(import.meta.dir, "../src/components/shared/link-preview/components/LinkPreviewLoading.tsx"),
+  "utf8"
+);
+const previewSource = readFileSync(
+  join(import.meta.dir, "../src/components/shared/link-preview/LinkPreview.tsx"),
+  "utf8"
+);
+
+describe("link preview dark mode styling", () => {
+  test("loading skeleton uses subdued dark gradient stops", () => {
+    expect(loadingSource).toContain("dark:before:from-neutral-800");
+    expect(loadingSource).toContain("dark:before:via-neutral-700");
+    expect(loadingSource).toContain("dark:border-neutral-700");
+    expect(loadingSource).toContain("dark:bg-neutral-900/80");
+  });
+
+  test("loaded card shell has dark surface tokens", () => {
+    expect(previewSource).toContain("dark:bg-neutral-950");
+    expect(previewSource).toContain("dark:border-neutral-700");
+    expect(previewSource).toContain("dark:bg-neutral-800/90");
+  });
+});

--- a/tests/test-link-preview-dark.test.ts
+++ b/tests/test-link-preview-dark.test.ts
@@ -36,7 +36,12 @@ describe("link preview dark mode styling", () => {
   test("loading component uses shared skeleton class and macOS bubble shell", () => {
     expect(loadingSource).toContain("link-preview-loading-skeleton");
     expect(loadingSource).toContain("macosx-link-preview");
+    expect(loadingSource).toContain("rounded-[16px]");
     expect(loadingSource).toContain("useThemeFlags");
+  });
+
+  test("loaded macOS link preview uses 16px radius to match chat image previews", () => {
+    expect(previewSource).toContain("rounded-[16px]");
   });
 
   test(".dark .link-preview-loading-skeleton avoids bright white sweep", () => {
@@ -61,5 +66,15 @@ describe("link preview dark mode styling", () => {
   test("macOS dark tones down link preview loading bubble gloss", () => {
     expect(themesCss).toContain(".link-preview-loading.macosx-link-preview.chat-bubble:before");
     expect(themesCss).toContain("rgba(255, 255, 255, 0.1)");
+  });
+
+  test("macOS themes enforce 16px radius on link preview cards and loading shells", () => {
+    expect(themesCss).toContain(
+      ".macosx-link-preview.chat-bubble.link-preview-container"
+    );
+    expect(themesCss).toContain(
+      ".macosx-link-preview.chat-bubble.link-preview-loading"
+    );
+    expect(themesCss).toContain("border-radius: 16px !important");
   });
 });

--- a/tests/test-link-preview-dark.test.ts
+++ b/tests/test-link-preview-dark.test.ts
@@ -11,6 +11,13 @@ const previewSource = readFileSync(
   join(import.meta.dir, "../src/components/shared/link-preview/LinkPreview.tsx"),
   "utf8"
 );
+const actionButtonsSource = readFileSync(
+  join(
+    import.meta.dir,
+    "../src/components/shared/link-preview/components/LinkPreviewActionButtons.tsx"
+  ),
+  "utf8"
+);
 const themesCss = readFileSync(
   join(import.meta.dir, "../src/styles/themes.css"),
   "utf8"
@@ -76,5 +83,12 @@ describe("link preview dark mode styling", () => {
       ".macosx-link-preview.chat-bubble.link-preview-loading"
     );
     expect(themesCss).toContain("border-radius: 16px !important");
+  });
+
+  test("action row divider uses OS separator tokens on macOS", () => {
+    expect(actionButtonsSource).toContain("link-preview-actions-divider");
+    expect(actionButtonsSource).toContain("var(--os-color-separator)");
+    expect(actionButtonsSource).toContain("useThemeFlags");
+    expect(themesCss).toContain(".macosx-link-preview .link-preview-actions-divider");
   });
 });

--- a/tests/test-link-preview-dark.test.ts
+++ b/tests/test-link-preview-dark.test.ts
@@ -45,6 +45,11 @@ describe("link preview dark mode styling", () => {
     expect(loadingSource).toContain("macosx-link-preview");
     expect(loadingSource).toContain("rounded-[16px]");
     expect(loadingSource).toContain("useThemeFlags");
+    // macOS: shimmer on the bubble root (chat-bubble > * breaks absolute children)
+    expect(loadingSource).toContain(
+      "chat-bubble macosx-link-preview rounded-[16px] border-none shadow-none link-preview-loading-skeleton"
+    );
+    expect(loadingSource).toContain("!isMacOSTheme");
   });
 
   test("loaded macOS link preview uses 16px radius to match chat image previews", () => {
@@ -75,7 +80,8 @@ describe("link preview dark mode styling", () => {
       ".link-preview-loading.macosx-link-preview.chat-bubble:before"
     );
     expect(themesCss).toContain("display: none");
-    expect(loadingSource).toContain("bg-transparent");
+    expect(themesCss).toContain(".link-preview-loading.macosx-link-preview.chat-bubble");
+    expect(themesCss).toContain("padding: 0 !important");
   });
 
   test("macOS themes enforce 16px radius on link preview cards and loading shells", () => {

--- a/tests/test-link-preview-dark.test.ts
+++ b/tests/test-link-preview-dark.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 
+const indexCss = readFileSync(join(import.meta.dir, "../src/index.css"), "utf8");
 const loadingSource = readFileSync(
   join(import.meta.dir, "../src/components/shared/link-preview/components/LinkPreviewLoading.tsx"),
   "utf8"
@@ -10,18 +11,55 @@ const previewSource = readFileSync(
   join(import.meta.dir, "../src/components/shared/link-preview/LinkPreview.tsx"),
   "utf8"
 );
+const themesCss = readFileSync(
+  join(import.meta.dir, "../src/styles/themes.css"),
+  "utf8"
+);
+
+function extractRuleBlock(css: string, selector: string): string {
+  const start = css.indexOf(selector);
+  if (start === -1) return "";
+  const braceStart = css.indexOf("{", start);
+  if (braceStart === -1) return "";
+  let depth = 0;
+  for (let i = braceStart; i < css.length; i++) {
+    if (css[i] === "{") depth++;
+    else if (css[i] === "}") {
+      depth--;
+      if (depth === 0) return css.slice(start, i + 1);
+    }
+  }
+  return "";
+}
 
 describe("link preview dark mode styling", () => {
-  test("loading skeleton uses subdued dark gradient stops", () => {
-    expect(loadingSource).toContain("dark:before:from-neutral-800");
-    expect(loadingSource).toContain("dark:before:via-neutral-700");
-    expect(loadingSource).toContain("dark:border-neutral-700");
-    expect(loadingSource).toContain("dark:bg-neutral-900/80");
+  test("loading component uses shared skeleton class and macOS bubble shell", () => {
+    expect(loadingSource).toContain("link-preview-loading-skeleton");
+    expect(loadingSource).toContain("macosx-link-preview");
+    expect(loadingSource).toContain("useThemeFlags");
+  });
+
+  test(".dark .link-preview-loading-skeleton avoids bright white sweep", () => {
+    const block = extractRuleBlock(indexCss, ".dark .link-preview-loading-skeleton");
+    expect(block.length).toBeGreaterThan(0);
+    expect(block).not.toMatch(/#fff\b/i);
+    expect(block).not.toMatch(/rgba\(\s*250\s*,\s*250\s*,\s*250/i);
+    expect(block).toContain("rgba(82, 82, 91");
+  });
+
+  test("light skeleton keeps a brighter highlight for light themes", () => {
+    const block = extractRuleBlock(indexCss, ".link-preview-loading-skeleton {");
+    expect(block).toContain("rgba(250, 250, 250");
   });
 
   test("loaded card shell has dark surface tokens", () => {
     expect(previewSource).toContain("dark:bg-neutral-950");
     expect(previewSource).toContain("dark:border-neutral-700");
     expect(previewSource).toContain("dark:bg-neutral-800/90");
+  });
+
+  test("macOS dark tones down link preview loading bubble gloss", () => {
+    expect(themesCss).toContain(".link-preview-loading.macosx-link-preview.chat-bubble:before");
+    expect(themesCss).toContain("rgba(255, 255, 255, 0.1)");
   });
 });

--- a/tests/test-tool-call-shimmer-dark.test.ts
+++ b/tests/test-tool-call-shimmer-dark.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const indexCss = readFileSync(join(import.meta.dir, "../src/index.css"), "utf8");
+
+function extractRuleBlock(css: string, selector: string): string {
+  const start = css.indexOf(selector);
+  if (start === -1) return "";
+  const braceStart = css.indexOf("{", start);
+  if (braceStart === -1) return "";
+  let depth = 0;
+  for (let i = braceStart; i < css.length; i++) {
+    if (css[i] === "{") depth++;
+    else if (css[i] === "}") {
+      depth--;
+      if (depth === 0) return css.slice(start, i + 1);
+    }
+  }
+  return "";
+}
+
+describe("tool call loading shimmer (dark mode)", () => {
+  test("light .shimmer keeps a bright highlight for light themes", () => {
+    const block = extractRuleBlock(indexCss, ".shimmer {");
+    expect(block).toContain("#fff");
+    expect(block).not.toContain(".dark");
+  });
+
+  test(".dark .shimmer uses subdued grays without pure white", () => {
+    const block = extractRuleBlock(indexCss, ".dark .shimmer");
+    expect(block.length).toBeGreaterThan(0);
+    expect(block).not.toMatch(/#fff\b/i);
+    expect(block).not.toMatch(/rgb\(\s*255\s*,\s*255\s*,\s*255/i);
+    expect(block).toContain("rgba(212, 212, 212");
+  });
+
+  test(".dark .shimmer-gray avoids black highlight peaks", () => {
+    const block = extractRuleBlock(indexCss, ".dark .shimmer-gray");
+    expect(block.length).toBeGreaterThan(0);
+    expect(block).not.toMatch(/rgba\(\s*0\s*,\s*0\s*,\s*0\s*,\s*1\s*\)/);
+    expect(block).toContain("rgba(212, 212, 212");
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Tool call cards and link previews used bright loading gradients in macOS Aqua dark mode.

## Changes

**Tool calls**
- `.dark .shimmer` / `.dark .shimmer-gray` in `src/index.css`
- `HtmlPreview` streaming overlay dark tweaks

**Link previews**
- Loaded cards: dark shells, text, borders, action rows, macOS `bg-neutral-100` bubble override
- **Loading**: dedicated `.link-preview-loading-skeleton` with `.dark` gradient (no white sweep); macOS uses `chat-bubble macosx-link-preview` shell; dark gloss toned down in `themes.css`

## Testing

- `bun test tests/test-tool-call-shimmer-dark.test.ts tests/test-link-preview-dark.test.ts` (8 pass)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0bada723-5890-4286-accb-031b4480e6e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0bada723-5890-4286-accb-031b4480e6e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

