### PR TITLE
Style Cursor agent chat cards like Maps with pinstripes

### DIFF
--- a/src/components/shared/CursorBrandMark.tsx
+++ b/src/components/shared/CursorBrandMark.tsx
@@ -1,0 +1,43 @@
+import { cn } from "@/lib/utils";
+
+export interface CursorBrandMarkProps {
+  /** Outer circle diameter (Tailwind size class number, e.g. 9 → size-9). */
+  size?: 9 | 6;
+  className?: string;
+}
+
+/**
+ * Cursor cube logo in a fully round badge (light/dark assets).
+ */
+export function CursorBrandMark({ size = 9, className }: CursorBrandMarkProps) {
+  const outer = size === 9 ? "size-9" : "size-6";
+  const inner = size === 9 ? "size-5" : "size-4";
+
+  return (
+    <span
+      className={cn(
+        "inline-flex shrink-0 items-center justify-center rounded-full",
+        outer,
+        className
+      )}
+      aria-hidden
+    >
+      <img
+        src="/brands/cursor-cube-2d-light.svg"
+        alt=""
+        width={size === 9 ? 20 : 16}
+        height={size === 9 ? 20 : 16}
+        className={cn(inner, "dark:hidden")}
+        draggable={false}
+      />
+      <img
+        src="/brands/cursor-cube-2d-dark.svg"
+        alt=""
+        width={size === 9 ? 20 : 16}
+        height={size === 9 ? 20 : 16}
+        className={cn(inner, "hidden dark:block")}
+        draggable={false}
+      />
+    </span>
+  );
+}

--- a/src/components/shared/CursorCloudAgentRunsListCard.tsx
+++ b/src/components/shared/CursorCloudAgentRunsListCard.tsx
@@ -1,6 +1,7 @@
-import { ArrowSquareOut, Robot } from "@phosphor-icons/react";
+import { ArrowSquareOut } from "@phosphor-icons/react";
 import { useTranslation } from "react-i18next";
 import { useThemeFlags } from "@/hooks/useThemeFlags";
+import { CursorBrandMark } from "@/components/shared/CursorBrandMark";
 import { cn } from "@/lib/utils";
 import {
   toolInlineCardListClassName,
@@ -22,6 +23,15 @@ export interface CursorCloudAgentRunListRow {
 
 export interface CursorCloudAgentRunsListCardProps {
   runs: CursorCloudAgentRunListRow[];
+}
+
+function formatRunStatusLabel(status: string): string {
+  const normalized = status.trim().replace(/_/g, " ");
+  if (!normalized) return normalized;
+  return normalized
+    .split(/\s+/)
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
+    .join(" ");
 }
 
 function statusDotClass(status: string): string {
@@ -88,24 +98,25 @@ export function CursorCloudAgentRunsListCard({
                   isDarkMode,
                 })}
               >
-                <div
+                <CursorBrandMark
                   className={cn(
-                    "flex size-9 shrink-0 items-center justify-center rounded-[0.35rem]",
                     isMacOSTheme && isDarkMode
                       ? "bg-white/10"
                       : isMacOSTheme
                         ? "bg-black/[0.06]"
                         : "bg-neutral-200 dark:bg-neutral-800"
                   )}
-                  aria-hidden
-                >
-                  <Robot
-                    className="size-5 text-os-text-secondary"
-                    weight="duotone"
-                  />
-                </div>
+                />
                 <div className="min-w-0 flex-1">
-                  <div className="flex items-center gap-1.5">
+                  <div className="min-w-0 truncate text-[13px] font-semibold leading-tight text-os-text-primary">
+                    {primary}
+                  </div>
+                  {secondary ? (
+                    <div className="line-clamp-2 text-[11px] leading-snug text-os-text-secondary">
+                      {secondary}
+                    </div>
+                  ) : null}
+                  <div className="mt-0.5 flex items-center gap-1.5 text-[10px] text-os-text-secondary">
                     <span
                       className={cn(
                         "size-1.5 shrink-0 rounded-full",
@@ -113,17 +124,7 @@ export function CursorCloudAgentRunsListCard({
                       )}
                       aria-hidden
                     />
-                    <div className="min-w-0 flex-1 truncate text-[13px] font-semibold leading-tight text-os-text-primary">
-                      {primary}
-                    </div>
-                  </div>
-                  {secondary ? (
-                    <div className="line-clamp-2 text-[11px] leading-snug text-os-text-secondary">
-                      {secondary}
-                    </div>
-                  ) : null}
-                  <div className="mt-0.5 text-[10px] text-os-text-secondary">
-                    {run.status}
+                    <span>{formatRunStatusLabel(run.status)}</span>
                   </div>
                 </div>
                 {dash ? (

--- a/src/components/shared/CursorCloudAgentRunsListCard.tsx
+++ b/src/components/shared/CursorCloudAgentRunsListCard.tsx
@@ -1,0 +1,160 @@
+import { ArrowSquareOut, Robot } from "@phosphor-icons/react";
+import { useTranslation } from "react-i18next";
+import { useThemeFlags } from "@/hooks/useThemeFlags";
+import { cn } from "@/lib/utils";
+import {
+  toolInlineCardListClassName,
+  toolInlineCardListRowClassName,
+  toolInlineCardShellClassName,
+} from "@/components/shared/toolInlineCardShell";
+
+export interface CursorCloudAgentRunListRow {
+  runId: string;
+  agentId: string;
+  status: string;
+  agentTitle?: string;
+  promptPreview?: string;
+  summaryPreview?: string;
+  errorPreview?: string;
+  prUrl?: string;
+  agentDashboardUrl?: string;
+}
+
+export interface CursorCloudAgentRunsListCardProps {
+  runs: CursorCloudAgentRunListRow[];
+}
+
+function statusDotClass(status: string): string {
+  const s = status.toLowerCase();
+  if (s === "running") return "bg-amber-500";
+  if (s === "finished") return "bg-emerald-500";
+  if (s === "error" || s === "failed" || s === "cancelled" || s === "canceled") {
+    return "bg-red-500";
+  }
+  return "bg-neutral-400";
+}
+
+function rowPrimarySecondary(run: CursorCloudAgentRunListRow): {
+  primary: string;
+  secondary: string | null;
+} {
+  const summaryLine =
+    run.summaryPreview || run.errorPreview || run.promptPreview || "—";
+  const taskTitle = run.agentTitle?.trim();
+  const primary = taskTitle || summaryLine;
+  const secondary =
+    taskTitle && summaryLine !== "—" && summaryLine !== taskTitle
+      ? summaryLine
+      : null;
+  return { primary, secondary };
+}
+
+/**
+ * Inline chat list for `listCursorCloudAgentRuns` — layout parallels
+ * `MapsSearchPlacesCard` (pinstripe aqua shell, divided rows).
+ */
+export function CursorCloudAgentRunsListCard({
+  runs,
+}: CursorCloudAgentRunsListCardProps) {
+  const { t } = useTranslation();
+  const { isMacOSTheme, isXpTheme, isSystem7Theme, isDarkMode } = useThemeFlags();
+
+  if (!runs.length) return null;
+
+  const shell = toolInlineCardShellClassName({
+    isMacOSTheme,
+    isSystem7Theme,
+    isXpTheme,
+  });
+
+  return (
+    <div className={shell}>
+      <ul
+        className={toolInlineCardListClassName({ isMacOSTheme, isDarkMode })}
+      >
+        {runs.map((run) => {
+          const { primary, secondary } = rowPrimarySecondary(run);
+          const dash =
+            run.agentDashboardUrl?.trim() ||
+            (run.agentId
+              ? `https://cursor.com/agents/${encodeURIComponent(run.agentId)}`
+              : null);
+
+          return (
+            <li key={run.runId}>
+              <div
+                className={toolInlineCardListRowClassName({
+                  isMacOSTheme,
+                  isDarkMode,
+                })}
+              >
+                <div
+                  className={cn(
+                    "flex size-9 shrink-0 items-center justify-center rounded-[0.35rem]",
+                    isMacOSTheme && isDarkMode
+                      ? "bg-white/10"
+                      : isMacOSTheme
+                        ? "bg-black/[0.06]"
+                        : "bg-neutral-200 dark:bg-neutral-800"
+                  )}
+                  aria-hidden
+                >
+                  <Robot
+                    className="size-5 text-os-text-secondary"
+                    weight="duotone"
+                  />
+                </div>
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-center gap-1.5">
+                    <span
+                      className={cn(
+                        "size-1.5 shrink-0 rounded-full",
+                        statusDotClass(run.status)
+                      )}
+                      aria-hidden
+                    />
+                    <div className="min-w-0 flex-1 truncate text-[13px] font-semibold leading-tight text-os-text-primary">
+                      {primary}
+                    </div>
+                  </div>
+                  {secondary ? (
+                    <div className="line-clamp-2 text-[11px] leading-snug text-os-text-secondary">
+                      {secondary}
+                    </div>
+                  ) : null}
+                  <div className="mt-0.5 text-[10px] text-os-text-secondary">
+                    {run.status}
+                  </div>
+                </div>
+                {dash ? (
+                  <a
+                    href={dash}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className={cn(
+                      "shrink-0 -mr-0.5 flex size-7 items-center justify-center rounded-full",
+                      "focus:outline-none focus-visible:ring-1",
+                      isMacOSTheme && isDarkMode
+                        ? "text-os-text-secondary hover:bg-white/12 hover:text-os-text-primary focus-visible:ring-white/35"
+                        : "text-os-text-secondary hover:bg-black/10 hover:text-os-text-primary focus-visible:ring-black/30"
+                    )}
+                    aria-label={t(
+                      "apps.chats.toolCalls.listCursorCloudAgentRuns.openDashboard",
+                      { defaultValue: "Open agent in Cursor" }
+                    )}
+                    title={t(
+                      "apps.chats.toolCalls.listCursorCloudAgentRuns.openDashboard",
+                      { defaultValue: "Open agent in Cursor" }
+                    )}
+                  >
+                    <ArrowSquareOut size={14} weight="bold" />
+                  </a>
+                ) : null}
+              </div>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}

--- a/src/components/shared/CursorRepoAgentChatCard.tsx
+++ b/src/components/shared/CursorRepoAgentChatCard.tsx
@@ -16,7 +16,13 @@ import {
   MergedToolCallStreamBlock,
   MergedUserStreamBlock,
 } from "@/components/shared/CursorRunEventView";
+import { useThemeFlags } from "@/hooks/useThemeFlags";
 import { coalesceCursorRunRows } from "@/lib/cursorSdkRunCoalesce";
+import { cn } from "@/lib/utils";
+import {
+  cursorAgentCardHeaderClassName,
+  toolInlineCardShellClassName,
+} from "@/components/shared/toolInlineCardShell";
 import { useCursorAgentRunPoll } from "@/components/shared/useCursorAgentRunPoll";
 
 interface CursorRepoAgentChatCardProps {
@@ -43,6 +49,7 @@ export function CursorRepoAgentChatCard({
 }: CursorRepoAgentChatCardProps) {
   const isPanel = variant === "panel";
   const { t } = useTranslation();
+  const { isMacOSTheme, isXpTheme, isSystem7Theme, isDarkMode } = useThemeFlags();
   const {
     events,
     done,
@@ -109,14 +116,24 @@ export function CursorRepoAgentChatCard({
       ) : null}
 
       <div
-        className={
-          isPanel
-            ? "flex h-full min-h-0 flex-col overflow-hidden bg-white font-geneva-12 dark:bg-neutral-950"
-            : "my-1 flex flex-col overflow-hidden rounded bg-white font-geneva-12 dark:bg-neutral-950"
-        }
-        style={isPanel ? undefined : { boxShadow: "0 0 0 1px rgba(0, 0, 0, 0.3)" }}
+        className={cn(
+          toolInlineCardShellClassName({
+            isMacOSTheme,
+            isSystem7Theme,
+            isXpTheme,
+            embed: isPanel ? "panel" : "chat",
+          }),
+          isPanel && "h-full min-h-0"
+        )}
       >
-        <div className="flex flex-shrink-0 items-center gap-3 border-b border-neutral-300 bg-neutral-100 px-3 py-2 dark:border-neutral-600 dark:bg-neutral-800/90">
+        <div
+          className={cursorAgentCardHeaderClassName({
+            isMacOSTheme,
+            isSystem7Theme,
+            isXpTheme,
+            isDarkMode,
+          })}
+        >
           <span className="relative inline-flex size-6 shrink-0 items-center justify-center" aria-hidden>
             <img
               src="/brands/cursor-cube-2d-light.svg"
@@ -136,7 +153,15 @@ export function CursorRepoAgentChatCard({
             />
           </span>
           <div className="flex min-w-0 flex-1 items-center gap-2">
-            <div className="min-w-0 flex-1 truncate text-sm font-medium text-neutral-900 dark:text-neutral-100" title={displayTitle}>
+            <div
+              className={cn(
+                "min-w-0 flex-1 truncate text-sm font-medium",
+                isXpTheme && !isMacOSTheme
+                  ? "text-white"
+                  : "text-os-text-primary"
+              )}
+              title={displayTitle}
+            >
               {displayTitle}
             </div>
             {prUrl ? (
@@ -144,7 +169,17 @@ export function CursorRepoAgentChatCard({
                 href={prUrl}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="inline-flex shrink-0 items-center gap-1 rounded border border-neutral-300 bg-white/85 px-1.5 py-0.5 text-[10px] font-medium text-neutral-700 transition-colors hover:bg-neutral-100 dark:border-neutral-600 dark:bg-neutral-900/70 dark:text-neutral-200 dark:hover:bg-neutral-800"
+                className={cn(
+                  "inline-flex shrink-0 items-center gap-1 rounded border px-1.5 py-0.5 text-[10px] font-medium transition-colors",
+                  isMacOSTheme &&
+                    "border-black/20 bg-white/70 hover:bg-white/90 dark:border-white/15 dark:bg-white/10 dark:hover:bg-white/16",
+                  !isMacOSTheme &&
+                    isXpTheme &&
+                    "border-white/40 bg-white/20 text-white hover:bg-white/30",
+                  !isMacOSTheme &&
+                    !isXpTheme &&
+                    "border-neutral-300 bg-white/85 text-neutral-700 hover:bg-neutral-100 dark:border-neutral-600 dark:bg-neutral-900/70 dark:text-neutral-200 dark:hover:bg-neutral-800"
+                )}
                 title={prUrl}
                 aria-label={t("apps.chats.toolCalls.cursorCloudAgent.openPr")}
               >
@@ -155,12 +190,26 @@ export function CursorRepoAgentChatCard({
               </a>
             ) : null}
             {!done ? (
-              <span className="inline-flex shrink-0 items-center gap-1 text-[10px] font-medium text-amber-900 dark:text-amber-200">
+              <span
+                className={cn(
+                  "inline-flex shrink-0 items-center gap-1 text-[10px] font-medium",
+                  isXpTheme && !isMacOSTheme
+                    ? "text-amber-100"
+                    : "text-amber-900 dark:text-amber-200"
+                )}
+              >
                 <span className="size-1.5 rounded-full bg-amber-500" aria-hidden />
                 {t("apps.chats.toolCalls.cursorCloudAgent.running")}
               </span>
             ) : (
-              <span className="inline-flex shrink-0 items-center gap-1 text-[10px] font-medium text-emerald-900 dark:text-emerald-200">
+              <span
+                className={cn(
+                  "inline-flex shrink-0 items-center gap-1 text-[10px] font-medium",
+                  isXpTheme && !isMacOSTheme
+                    ? "text-emerald-100"
+                    : "text-emerald-900 dark:text-emerald-200"
+                )}
+              >
                 <span className="size-1.5 rounded-full bg-emerald-500" aria-hidden />
                 {t("apps.chats.toolCalls.cursorCloudAgent.finished")}
               </span>
@@ -169,11 +218,15 @@ export function CursorRepoAgentChatCard({
         </div>
 
         <div
-          className={
-            isPanel
-              ? "flex min-h-0 flex-1 flex-col border-t border-neutral-200 bg-neutral-50/50 dark:border-neutral-600 dark:bg-neutral-900/40"
-              : "border-t border-neutral-200 bg-neutral-50/50 dark:border-neutral-600 dark:bg-neutral-900/40"
-          }
+          className={cn(
+            "flex flex-col",
+            isPanel && "min-h-0 flex-1",
+            isMacOSTheme
+              ? isDarkMode
+                ? "border-t border-[color:var(--os-color-separator)] bg-black/15"
+                : "border-t border-black/10 bg-white/45"
+              : "border-t border-black/10 bg-neutral-50/80 dark:border-neutral-600 dark:bg-neutral-900/40"
+          )}
         >
           {error ? (
             <div className="border-b border-red-200/80 bg-red-50/90 px-3 py-1.5 text-[11px] text-red-700 dark:border-red-900/50 dark:bg-red-950/30 dark:text-red-200">
@@ -256,11 +309,14 @@ export function CursorRepoAgentChatCard({
           </div>
 
           <div
-            className={
-              isPanel
-                ? "shrink-0 border-t border-neutral-200 bg-white/80 px-2 py-1.5 dark:border-neutral-700 dark:bg-neutral-900/60"
-                : "border-t border-neutral-200 bg-white/80 px-2 py-1.5 dark:border-neutral-700 dark:bg-neutral-900/60"
-            }
+            className={cn(
+              "shrink-0 border-t px-2 py-1.5",
+              isMacOSTheme
+                ? isDarkMode
+                  ? "border-[color:var(--os-color-separator)] bg-black/20"
+                  : "border-black/10 bg-white/55"
+                : "border-neutral-200 bg-white/80 dark:border-neutral-700 dark:bg-neutral-900/60"
+            )}
           >
             {followupError ? (
               <div className="mb-1 text-[10px] text-red-700 dark:text-red-300">

--- a/src/components/shared/CursorRepoAgentChatCard.tsx
+++ b/src/components/shared/CursorRepoAgentChatCard.tsx
@@ -23,6 +23,7 @@ import {
   cursorAgentCardHeaderClassName,
   toolInlineCardShellClassName,
 } from "@/components/shared/toolInlineCardShell";
+import { CursorBrandMark } from "@/components/shared/CursorBrandMark";
 import { useCursorAgentRunPoll } from "@/components/shared/useCursorAgentRunPoll";
 
 interface CursorRepoAgentChatCardProps {
@@ -134,24 +135,7 @@ export function CursorRepoAgentChatCard({
             isDarkMode,
           })}
         >
-          <span className="relative inline-flex size-6 shrink-0 items-center justify-center" aria-hidden>
-            <img
-              src="/brands/cursor-cube-2d-light.svg"
-              alt=""
-              width={24}
-              height={24}
-              className="size-6 dark:hidden"
-              draggable={false}
-            />
-            <img
-              src="/brands/cursor-cube-2d-dark.svg"
-              alt=""
-              width={24}
-              height={24}
-              className="hidden size-6 dark:block"
-              draggable={false}
-            />
-          </span>
+          <CursorBrandMark size={6} />
           <div className="flex min-w-0 flex-1 items-center gap-2">
             <div
               className={cn(

--- a/src/components/shared/MapsSearchPlacesCard.tsx
+++ b/src/components/shared/MapsSearchPlacesCard.tsx
@@ -10,6 +10,11 @@ import {
 } from "@/apps/maps/utils/poiVisuals";
 import type { SavedPlace } from "@/apps/maps/utils/types";
 import { cn } from "@/lib/utils";
+import {
+  toolInlineCardListClassName,
+  toolInlineCardListRowClassName,
+  toolInlineCardShellClassName,
+} from "@/components/shared/toolInlineCardShell";
 
 /**
  * Result returned by the `mapsSearchPlaces` server tool. Mirrors
@@ -71,24 +76,19 @@ export function MapsSearchPlacesCard({
     [launchApp]
   );
 
+  const emptyShell = cn(
+    toolInlineCardShellClassName({
+      isMacOSTheme,
+      isSystem7Theme,
+      isXpTheme,
+    }),
+    "px-2.5 py-2 text-[12px]",
+    isMacOSTheme && "text-os-text-secondary"
+  );
+
   if (!results || results.length === 0) {
     return (
-      <div
-        className={cn(
-          "my-1 px-2.5 py-2 text-[12px]",
-          isMacOSTheme &&
-            "maps-place-card-aqua rounded-[0.5rem] text-os-text-secondary shadow-md",
-          !isMacOSTheme &&
-            isSystem7Theme &&
-            "rounded border-2 border-black bg-white text-black shadow-[2px_2px_0_0_rgba(0,0,0,0.5)]",
-          !isMacOSTheme &&
-            !isSystem7Theme &&
-            isXpTheme &&
-            "rounded-[0.4rem] border-2 border-[#0054E3] bg-[#ECE9D8] text-black",
-          !isMacOSTheme && !isSystem7Theme && !isXpTheme &&
-            "rounded border border-black/30 bg-white text-black"
-        )}
-      >
+      <div className={emptyShell}>
         <p className="text-os-text-secondary">
           {t("apps.chats.toolCalls.maps.noResults", {
             defaultValue: 'No places found for "{{query}}".',
@@ -101,30 +101,14 @@ export function MapsSearchPlacesCard({
 
   return (
     <div
-      className={cn(
-        "my-1 overflow-hidden",
-        // Theme shells mirror the in-app place card so the chat surface
-        // looks like a sibling of the real Maps UI.
-        isMacOSTheme &&
-          "maps-place-card-aqua rounded-[0.5rem] border-transparent text-os-text-primary",
-        !isMacOSTheme &&
-          isSystem7Theme &&
-          "rounded border-2 border-black bg-white text-black shadow-[2px_2px_0_0_rgba(0,0,0,0.5)]",
-        !isMacOSTheme &&
-          !isSystem7Theme &&
-          isXpTheme &&
-          "rounded-[0.4rem] border-2 border-[#0054E3] bg-[#ECE9D8] text-black",
-        !isMacOSTheme && !isSystem7Theme && !isXpTheme &&
-          "rounded border border-black/30 bg-white text-black shadow-md"
-      )}
+      className={toolInlineCardShellClassName({
+        isMacOSTheme,
+        isSystem7Theme,
+        isXpTheme,
+      })}
     >
       <ul
-        className={cn(
-          "divide-y",
-          isMacOSTheme && isDarkMode
-            ? "divide-[color:var(--os-color-separator)]"
-            : "divide-black/10"
-        )}
+        className={toolInlineCardListClassName({ isMacOSTheme, isDarkMode })}
       >
         {results.map((place) => {
           const visual = getPoiVisual(place.category);
@@ -134,16 +118,10 @@ export function MapsSearchPlacesCard({
               <button
                 type="button"
                 onClick={() => handleOpenInMaps(place)}
-                className={cn(
-                  "flex w-full items-center gap-2.5 px-2.5 py-2 text-left",
-                  isMacOSTheme && isDarkMode
-                    ? "hover:bg-white/10 active:bg-white/14"
-                    : "hover:bg-black/5 active:bg-black/10",
-                  "focus:outline-none focus-visible:ring-1",
-                  isMacOSTheme && isDarkMode
-                    ? "focus-visible:ring-white/35"
-                    : "focus-visible:ring-black/30"
-                )}
+                className={toolInlineCardListRowClassName({
+                  isMacOSTheme,
+                  isDarkMode,
+                })}
                 aria-label={t("apps.chats.toolCalls.maps.openInMaps", {
                   defaultValue: "Open {{name}} in Maps",
                   name: place.name,

--- a/src/components/shared/tool-invocation-message/tryRenderToolInvocationSpecialContent.tsx
+++ b/src/components/shared/tool-invocation-message/tryRenderToolInvocationSpecialContent.tsx
@@ -2,6 +2,10 @@ import { Check } from "@phosphor-icons/react";
 import type { ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 import HtmlPreview from "@/components/shared/HtmlPreview";
+import {
+  CursorCloudAgentRunsListCard,
+  type CursorCloudAgentRunListRow,
+} from "@/components/shared/CursorCloudAgentRunsListCard";
 import { CursorRepoAgentChatCard } from "@/components/shared/CursorRepoAgentChatCard";
 import {
   MapsSearchPlacesCard,
@@ -74,6 +78,46 @@ export function tryRenderToolInvocationSpecialContent(
         introMessage={out.message}
       />
     );
+  }
+
+  if (state === "output-available" && toolName === "listCursorCloudAgentRuns") {
+    const out = output as
+      | {
+          success?: boolean;
+          runs?: CursorCloudAgentRunListRow[];
+          truncated?: boolean;
+          error?: string;
+        }
+      | undefined;
+    if (out && out.success === true && Array.isArray(out.runs)) {
+      const runs = out.runs;
+      const more = out.truncated
+        ? ` ${t("apps.chats.toolCalls.listCursorCloudAgentRuns.truncatedHint")}`
+        : "";
+      return (
+        <div key={partKey} className="mb-0 px-1 py-0.5 text-[12px]">
+          <ToolInvocationStatusRow
+            icon={
+              <Check
+                className="size-3 text-blue-600 dark:text-blue-400"
+                weight="bold"
+              />
+            }
+            className="text-neutral-700 dark:text-neutral-200"
+            align="start"
+          >
+            <span>
+              {`${t("apps.chats.toolCalls.listCursorCloudAgentRuns.listed", {
+                count: runs.length,
+              })}${more}`}
+            </span>
+          </ToolInvocationStatusRow>
+          {runs.length > 0 ? (
+            <CursorCloudAgentRunsListCard runs={runs} />
+          ) : null}
+        </div>
+      );
+    }
   }
 
   // Special handling for mapsSearchPlaces — render a rich place-card list

--- a/src/components/shared/toolInlineCardShell.ts
+++ b/src/components/shared/toolInlineCardShell.ts
@@ -1,0 +1,97 @@
+import { cn } from "@/lib/utils";
+
+/** Outer shell for inline chat tool cards (Maps places, Cursor agents, …). */
+export function toolInlineCardShellClassName(flags: {
+  isMacOSTheme: boolean;
+  isSystem7Theme: boolean;
+  isXpTheme: boolean;
+  /** Chat embed; panel fills parent without outer margin/shadow. */
+  embed?: "chat" | "panel";
+}): string {
+  const { isMacOSTheme, isSystem7Theme, isXpTheme, embed = "chat" } = flags;
+  return cn(
+    "flex flex-col overflow-hidden font-geneva-12",
+    embed === "chat" && "my-1",
+    isMacOSTheme &&
+      "maps-place-card-aqua rounded-[0.5rem] border-transparent text-os-text-primary",
+    !isMacOSTheme &&
+      isSystem7Theme &&
+      cn(
+        embed === "chat" && "rounded",
+        "border-2 border-black bg-white text-black shadow-[2px_2px_0_0_rgba(0,0,0,0.5)]"
+      ),
+    !isMacOSTheme &&
+      !isSystem7Theme &&
+      isXpTheme &&
+      cn(
+        embed === "chat" && "rounded-[0.4rem]",
+        "border-2 border-[#0054E3] bg-[#ECE9D8] text-black"
+      ),
+    !isMacOSTheme &&
+      !isSystem7Theme &&
+      !isXpTheme &&
+      cn(
+        embed === "chat" && "rounded",
+        "border border-black/30 bg-white text-black shadow-md"
+      )
+  );
+}
+
+/** Header band for Cursor agent stream card (pinstripe on macOS via CSS). */
+export function cursorAgentCardHeaderClassName(flags: {
+  isMacOSTheme: boolean;
+  isSystem7Theme: boolean;
+  isXpTheme: boolean;
+  isDarkMode: boolean;
+}): string {
+  const { isMacOSTheme, isSystem7Theme, isXpTheme, isDarkMode } = flags;
+  return cn(
+    "flex flex-shrink-0 items-center gap-3 border-b px-3 py-2",
+    isMacOSTheme && "cursor-agent-card-header-aqua",
+    isMacOSTheme &&
+      (isDarkMode
+        ? "border-[color:var(--os-color-separator)]"
+        : "border-black/10"),
+    !isMacOSTheme &&
+      isSystem7Theme &&
+      "border-black bg-[#DDDDDD]",
+    !isMacOSTheme &&
+      !isSystem7Theme &&
+      isXpTheme &&
+      "border-[#919b9c] bg-gradient-to-b from-[#3A6EA5] to-[#1E4A8C] text-white",
+    !isMacOSTheme &&
+      !isSystem7Theme &&
+      !isXpTheme &&
+      "border-black/20 bg-neutral-100 dark:border-neutral-600 dark:bg-neutral-800/90"
+  );
+}
+
+export function toolInlineCardListClassName(flags: {
+  isMacOSTheme: boolean;
+  isDarkMode: boolean;
+}): string {
+  const { isMacOSTheme, isDarkMode } = flags;
+  return cn(
+    "divide-y",
+    isMacOSTheme && isDarkMode
+      ? "divide-[color:var(--os-color-separator)]"
+      : "divide-black/10"
+  );
+}
+
+export function toolInlineCardListRowClassName(flags: {
+  isMacOSTheme: boolean;
+  isDarkMode: boolean;
+}): string {
+  const { isMacOSTheme, isDarkMode } = flags;
+  return cn(
+    "flex w-full items-center gap-2.5 px-2.5 py-2 text-left",
+    isMacOSTheme && isDarkMode
+      ? "hover:bg-white/10 active:bg-white/14"
+      : "hover:bg-black/5 active:bg-black/10",
+    "focus:outline-none focus-visible:ring-1",
+    isMacOSTheme && isDarkMode
+      ? "focus-visible:ring-white/35"
+      : "focus-visible:ring-black/30"
+  );
+}

--- a/src/lib/locales/en/translation.json
+++ b/src/lib/locales/en/translation.json
@@ -1041,7 +1041,8 @@
         "listCursorCloudAgentRuns": {
           "loading": "Listing Cursor Cloud agent runs…",
           "listed": "Listed {{count}} recent run(s).",
-          "truncatedHint": "(list may be truncated)"
+          "truncatedHint": "(list may be truncated)",
+          "openDashboard": "Open agent in Cursor"
         },
         "searchedWebFor": "Searched the web for {{query}}",
         "foundVideos": "Found {{count}} videos",

--- a/src/styles/themes.css
+++ b/src/styles/themes.css
@@ -3052,15 +3052,15 @@
   background-color: rgb(255 255 255 / 0.08);
 }
 
-/* macOS: Cursor agent chat card header — titlebar pinstripe band on the glass card */
+/* macOS: Cursor agent chat card header — pinstripes only (no titlebar gray gloss) */
 :root[data-os-theme="macosx"] .cursor-agent-card-header-aqua {
   background-color: rgba(248, 248, 248, 0.88);
-  background-image: var(--os-pinstripe-titlebar), var(--os-pinstripe-menubar);
+  background-image: var(--os-pinstripe-menubar);
 }
 :root[data-os-theme="macosx"][data-os-color-scheme="dark"]
   .cursor-agent-card-header-aqua {
   background-color: color-mix(in srgb, var(--os-color-panel-bg) 90%, transparent);
-  background-image: var(--os-pinstripe-titlebar);
+  background-image: var(--os-pinstripe-menubar);
   color: var(--os-color-text-primary);
 }
 

--- a/src/styles/themes.css
+++ b/src/styles/themes.css
@@ -3052,6 +3052,18 @@
   background-color: rgb(255 255 255 / 0.08);
 }
 
+/* macOS: Cursor agent chat card header — titlebar pinstripe band on the glass card */
+:root[data-os-theme="macosx"] .cursor-agent-card-header-aqua {
+  background-color: rgba(248, 248, 248, 0.88);
+  background-image: var(--os-pinstripe-titlebar), var(--os-pinstripe-menubar);
+}
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"]
+  .cursor-agent-card-header-aqua {
+  background-color: color-mix(in srgb, var(--os-color-panel-bg) 90%, transparent);
+  background-image: var(--os-pinstripe-titlebar);
+  color: var(--os-color-text-primary);
+}
+
 /* macOS: Style toast containers with semi-transparent pinstripes like dock */
 :root[data-os-theme="macosx"] .toaster [data-sonner-toast] {
   background: rgba(248, 248, 248, 0.75) !important;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Cursor Cloud agent tool UI now mirrors the Maps inline tool cards: shared maps-place-card-aqua glass shell on macOS Aqua, theme-aware borders on System 7 / XP / fallback, and a titlebar pinstripe header band on the streaming agent card.

listCursorCloudAgentRuns also renders a divided list card (status dot, title, preview, open-dashboard link) instead of text-only output.

## Changes

- toolInlineCardShell.ts — shared shell, list row, and Cursor header class helpers
- CursorRepoAgentChatCard — themed shell + cursor-agent-card-header-aqua CSS
- CursorCloudAgentRunsListCard + special renderer in tryRenderToolInvocationSpecialContent
- MapsSearchPlacesCard refactored to use the same shell helpers
- themes.css — macOS header pinstripe rules

## Testing

bun run build succeeds.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bf5fb67c-c97a-40c0-a399-e6710690e5e7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bf5fb67c-c97a-40c0-a399-e6710690e5e7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

