### PR TITLE
fix(ipod): dark-theme lyrics search dialog to match Search Songs

### DIFF
--- a/src/components/dialogs/LyricsSearchDialog.tsx
+++ b/src/components/dialogs/LyricsSearchDialog.tsx
@@ -1,4 +1,4 @@
-import React, { useReducer, useEffect, useCallback } from "react";
+import React, { useReducer, useEffect, useCallback, type CSSProperties } from "react";
 import {
   Dialog,
   DialogContent,
@@ -13,9 +13,36 @@ import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { useTranslation } from "react-i18next";
 import { getApiUrl } from "@/utils/platform";
-import { ScrollArea } from "@/components/ui/scroll-area";
 import { abortableFetch } from "@/utils/abortableFetch";
 import { formatKugouImageUrl } from "@/utils/coverArt";
+
+const lyricsSearchListStyle: CSSProperties = {
+  border: "1px solid var(--os-color-input-border)",
+  borderRadius: "6px",
+  backgroundColor: "var(--os-color-input-bg)",
+  overflowX: "hidden",
+};
+
+function lyricsSearchRowStyle(
+  index: number,
+  selected: boolean,
+  fontStyle?: CSSProperties
+): CSSProperties {
+  return {
+    ...fontStyle,
+    padding: "6px 8px",
+    cursor: "pointer",
+    display: "flex",
+    alignItems: "center",
+    gap: "8px",
+    boxSizing: "border-box",
+    background: selected
+      ? undefined
+      : index % 2 === 1
+        ? "var(--os-color-list-row-alt-bg)"
+        : "var(--os-color-input-bg)",
+  };
+}
 
 export interface LyricsSearchResult {
   title: string;
@@ -301,30 +328,31 @@ export function LyricsSearchDialog({
           >
             {t("apps.ipod.dialogs.lyricsSearchCurrentSelection")}
           </p>
-          <div className="border border-neutral-300 rounded-md overflow-hidden bg-white">
+          <div style={lyricsSearchListStyle}>
             <div
               className={cn(
-                "flex items-center gap-2 px-2 py-1.5",
+                "w-full",
                 isXpTheme
                   ? "font-['Pixelated_MS_Sans_Serif',Arial] text-[11px]"
                   : "font-geneva-12 text-[12px]"
               )}
               data-selected="true"
-              style={{
+              style={lyricsSearchRowStyle(0, true, {
                 fontFamily: isXpTheme
                   ? '"Pixelated MS Sans Serif", "ArkPixel", Arial'
                   : undefined,
                 fontSize: isXpTheme ? "11px" : undefined,
-              }}
+              })}
             >
               {(() => {
                 const coverUrl = formatKugouImageUrl(currentSelection.cover, 100);
                 return (
                   <div
                     className={cn(
-                      "flex-shrink-0 w-9 h-9 overflow-hidden bg-neutral-200",
+                      "flex-shrink-0 w-9 h-9 overflow-hidden",
                       isXpTheme ? "border border-neutral-400" : "rounded-sm"
                     )}
+                    style={{ backgroundColor: "var(--os-color-list-row-alt-bg)" }}
                     aria-hidden="true"
                   >
                     {coverUrl ? (
@@ -391,10 +419,16 @@ export function LyricsSearchDialog({
           >
             {t("apps.ipod.dialogs.lyricsSearchSelectResult")}
           </p>
-          <ScrollArea className="h-[200px] border border-neutral-300 rounded-md overflow-hidden bg-white">
-            <div>
-              {results.map((result, index) => {
+          <div
+            style={{
+              ...lyricsSearchListStyle,
+              height: "200px",
+              overflowY: "auto",
+            }}
+          >
+            {results.map((result, index) => {
                 const coverUrl = formatKugouImageUrl(result.cover, 100);
+                const rowSelected = selectedIndex === index;
                 return (
                   <div
                     key={result.hash}
@@ -410,29 +444,25 @@ export function LyricsSearchDialog({
                     tabIndex={0}
                     role="button"
                     className={cn(
-                      "flex items-center gap-2 px-2 py-1.5 cursor-pointer",
-                      selectedIndex === index
-                        ? "" // Selection styling handled by inline style
-                        : index % 2 === 1
-                          ? "bg-neutral-100"
-                          : "bg-white",
+                      "w-full",
                       isXpTheme
                         ? "font-['Pixelated_MS_Sans_Serif',Arial] text-[11px]"
                         : "font-geneva-12 text-[12px]"
                     )}
-                    data-selected={selectedIndex === index ? "true" : undefined}
-                    style={{
+                    data-selected={rowSelected ? "true" : undefined}
+                    style={lyricsSearchRowStyle(index, rowSelected, {
                       fontFamily: isXpTheme
                         ? '"Pixelated MS Sans Serif", "ArkPixel", Arial'
                         : undefined,
                       fontSize: isXpTheme ? "11px" : undefined,
-                    }}
+                    })}
                   >
                     <div
                       className={cn(
-                        "flex-shrink-0 w-9 h-9 overflow-hidden bg-neutral-200",
+                        "flex-shrink-0 w-9 h-9 overflow-hidden",
                         isXpTheme ? "border border-neutral-400" : "rounded-sm"
                       )}
+                      style={{ backgroundColor: "var(--os-color-list-row-alt-bg)" }}
                       aria-hidden="true"
                     >
                       {coverUrl ? (
@@ -451,10 +481,13 @@ export function LyricsSearchDialog({
                     <div className="min-w-0 flex-1">
                       <div className="font-semibold truncate">{result.title}</div>
                       <div
-                        className={cn(
-                          "truncate",
-                          selectedIndex === index ? "opacity-80" : "text-neutral-600"
-                        )}
+                        className="truncate"
+                        style={{
+                          opacity: rowSelected ? 0.8 : 1,
+                          color: rowSelected
+                            ? undefined
+                            : "var(--os-color-text-secondary)",
+                        }}
                       >
                         {result.artist}
                         {result.album && ` • ${result.album}`}
@@ -463,8 +496,7 @@ export function LyricsSearchDialog({
                   </div>
                 );
               })}
-            </div>
-          </ScrollArea>
+          </div>
         </div>
       )}
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The lyrics search dialog used hardcoded light surfaces (`bg-white`, `border-neutral-300`, `bg-neutral-100`) that did not follow OS theme tokens in dark mode. Search Songs already uses `--os-color-input-*`, `--os-color-list-row-alt-bg`, and `[data-selected]` selection styling.

This change aligns **Search Lyrics** with **Search Songs**:

- List containers use `var(--os-color-input-border)` and `var(--os-color-input-bg)`
- Result rows use alternating `var(--os-color-list-row-alt-bg)` / input background, with selection via `[data-selected="true"]`
- Secondary line text uses `var(--os-color-text-secondary)`
- Replaced `ScrollArea` wrapper with the same scrollable div pattern as song search

## Testing

- `bun run build` — pass
- Manual: macOS Aqua dark mode — Lyrics Search and Search Songs dialogs reviewed for matching list surfaces, borders, and text (computer-use session)

## Scope

- `src/components/dialogs/LyricsSearchDialog.tsx` only
- No UI test suite exists for these dialogs; no new tests added
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-999c8df0-df2a-4f4f-830c-2b763a8c6d88"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-999c8df0-df2a-4f4f-830c-2b763a8c6d88"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

