### PR TITLE
fix(chats): IRC sidebar label contrast in Aqua dark mode

### DIFF
--- a/src/apps/chats/components/ChatRoomSidebar.tsx
+++ b/src/apps/chats/components/ChatRoomSidebar.tsx
@@ -101,7 +101,7 @@ export const ChatRoomSidebar = React.memo(function ChatRoomSidebar({
           </span>
           {room.type === "irc" && (
             <span
-              className="ml-1 text-[9px] font-bold uppercase tracking-wider text-purple-700/70"
+              className="chat-room-irc-label ml-1 text-[9px] font-bold uppercase tracking-wider"
               title={`IRC ${room.ircHost || "irc.pieter.com"}`}
             >
               irc

--- a/src/styles/themes.css
+++ b/src/styles/themes.css
@@ -2822,6 +2822,26 @@
 :root[data-os-theme="macosx"] .chat-bubble.bg-purple-200 {
   background-color: #e9d5ff !important; /* purple-200 */
 }
+
+/* Chats sidebar — IRC room-type pill (purple tint; remapped in Aqua dark mode) */
+.chat-room-irc-label {
+  color: rgb(126 34 206 / 0.7);
+}
+
+[data-selected="true"] .chat-room-irc-label {
+  color: rgba(255, 255, 255, 0.75) !important;
+}
+
+:root[data-os-theme="macosx"] .chat-room-irc-label {
+  color: rgb(109 40 217 / 0.75);
+}
+
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"]
+  .window-body
+  .chat-room-irc-label {
+  color: #c4b5fd !important;
+}
+
 :root[data-os-theme="macosx"] .chat-bubble.bg-indigo-200 {
   background-color: #c7d2fe !important; /* indigo-200 */
 }

--- a/src/styles/themes.css
+++ b/src/styles/themes.css
@@ -2832,10 +2832,6 @@
   color: rgba(255, 255, 255, 0.75) !important;
 }
 
-:root[data-os-theme="macosx"] .chat-room-irc-label {
-  color: rgb(109 40 217 / 0.75);
-}
-
 :root[data-os-theme="macosx"][data-os-color-scheme="dark"]
   .window-body
   .chat-room-irc-label {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

IRC room-type pills in the Chats sidebar used hardcoded `text-purple-700/70`, which stays dark in Aqua dark mode while the sidebar is remapped to a graphite surface—poor contrast for labels like **irc**.

## What changed

- **`ChatRoomSidebar.tsx`**: Replaced `text-purple-700/70` with semantic class `chat-room-irc-label`.
- **`themes.css`**: Added theme rules for that class:
  - Light / legacy themes: same purple tint as before (`rgb(126 34 206 / 0.7)`).
  - Aqua dark mode (`.window-body`): lighter violet (`#c4b5fd`) for legibility on dark sidebars.
  - Selected rows (`[data-selected="true"]`): white at 75% opacity so the pill reads on the selection highlight (light and dark).

## Why

Colored Tailwind text utilities are intentionally not remapped in the dark coverage layer; this pill needed an explicit dark-mode color while keeping IRC’s purple accent in light mode.

## Testing

- `bun run build` — pass
- Manual: macOS Aqua dark + light, Chats sidebar — IRC label legible unselected/selected

![IRC label dark mode unselected](https://cursor.com/artifacts/c/art-9b05dbfa-b4c4-4b03-b26c-505ab0e43e6d)
![IRC label dark mode selected](https://cursor.com/artifacts/c/art-57a4b3cf-9396-41aa-b8f2-8628c3d8f584)
![IRC label light mode unselected](https://cursor.com/artifacts/c/art-824213d6-33ba-41a1-94cf-871f048bc8e6)
![IRC label light mode selected](https://cursor.com/artifacts/c/art-26b59adb-ac69-49a5-b56a-4701243d74e7)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f785241e-ea86-44ee-9aef-4ffcca6115bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f785241e-ea86-44ee-9aef-4ffcca6115bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

