### PR TITLE
perf: profile ryOS and optimize client-side loading & rendering

### DIFF
--- a/src/apps/chats/components/chat-input/composerState.ts
+++ b/src/apps/chats/components/chat-input/composerState.ts
@@ -24,10 +24,17 @@ export function composerReducer(
 ): ComposerState {
   switch (action.type) {
     case "setInput":
+      if (state.input === action.value) return state;
       return { ...state, input: action.value };
     case "setHistoryIndex":
+      // Bail out if unchanged so useReducer can skip a re-render. The
+      // input-change effect re-asserts historyIndex: -1 on every keystroke,
+      // which would otherwise force a second wasted render of the composer
+      // because setInputAndResetHistory already reset it.
+      if (state.historyIndex === action.value) return state;
       return { ...state, historyIndex: action.value };
     case "setSelectedImage":
+      if (state.selectedImage === action.value) return state;
       return { ...state, selectedImage: action.value };
     case "setInputAndResetHistory":
       return { ...state, input: action.value, historyIndex: -1 };

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -1,4 +1,4 @@
-import WaveSurfer from "wavesurfer.js";
+import type WaveSurfer from "wavesurfer.js";
 
 export interface SoundSlot {
   audioData: string | null;

--- a/src/utils/performanceCheck.ts
+++ b/src/utils/performanceCheck.ts
@@ -1,61 +1,85 @@
-import * as THREE from 'three';
-
 /**
  * Checks for basic performance indicators to estimate if the device
  * is likely capable of handling intensive shader effects smoothly.
  * This is a heuristic and not foolproof.
  *
+ * Uses a raw WebGL context to probe GPU capabilities directly. Previously this
+ * pulled in the full `three` library (~225KB gzip) at module load time via the
+ * display-settings store, which is on the eager boot path — three.js is only
+ * needed by the Virtual PC app, so we avoid loading it on every page visit.
+ *
  * @returns {boolean} True if the device passes the checks, false otherwise.
  */
 export function checkShaderPerformance(): boolean {
-  console.log('[PerformanceCheck] Running checks...');
-
   // 1. Check CPU Cores
   const coreCount = navigator.hardwareConcurrency;
-  const hasEnoughCores = coreCount && coreCount >= 8;
-  console.log(`[PerformanceCheck] CPU Cores: ${coreCount} (Pass: ${hasEnoughCores})`);
+  const hasEnoughCores = !!coreCount && coreCount >= 8;
   if (!hasEnoughCores) {
-      return false; // Early exit if CPU core count is low
+    return false; // Early exit if CPU core count is low
   }
 
-  // 2. Check WebGL Capabilities (Requires creating a temporary renderer)
-  let renderer: THREE.WebGLRenderer | null = null;
+  // 2. Check WebGL Capabilities using a throwaway context.
   let maxAnisotropy = 0;
   let maxTextureSize = 0;
   let highpSupported = false;
 
+  let canvas: HTMLCanvasElement | null = null;
+  let gl: WebGLRenderingContext | WebGL2RenderingContext | null = null;
+
   try {
-    renderer = new THREE.WebGLRenderer({ powerPreference: 'high-performance' });
-    maxAnisotropy = renderer.capabilities.getMaxAnisotropy();
-    maxTextureSize = renderer.capabilities.maxTextureSize;
-    // Check if high precision floats are supported in fragment shaders
-    highpSupported = renderer.capabilities.precision === 'highp';
+    canvas = document.createElement("canvas");
+    gl =
+      (canvas.getContext("webgl2", {
+        powerPreference: "high-performance",
+      }) as WebGL2RenderingContext | null) ||
+      (canvas.getContext("webgl", {
+        powerPreference: "high-performance",
+      }) as WebGLRenderingContext | null) ||
+      (canvas.getContext(
+        "experimental-webgl"
+      ) as WebGLRenderingContext | null);
 
-    console.log(`[PerformanceCheck] Max Anisotropy: ${maxAnisotropy}`);
-    console.log(`[PerformanceCheck] Max Texture Size: ${maxTextureSize}`);
-    console.log(`[PerformanceCheck] High Precision Supported: ${highpSupported}`);
+    if (!gl) {
+      return false; // No WebGL available
+    }
 
+    maxTextureSize = gl.getParameter(gl.MAX_TEXTURE_SIZE) as number;
+
+    // Anisotropic filtering is an extension; mirrors three.js getMaxAnisotropy().
+    const anisoExt =
+      gl.getExtension("EXT_texture_filter_anisotropic") ||
+      gl.getExtension("MOZ_EXT_texture_filter_anisotropic") ||
+      gl.getExtension("WEBKIT_EXT_texture_filter_anisotropic");
+    if (anisoExt) {
+      maxAnisotropy = gl.getParameter(
+        anisoExt.MAX_TEXTURE_MAX_ANISOTROPY_EXT
+      ) as number;
+    }
+
+    // High precision float support in fragment shaders.
+    const highpFloat = gl.getShaderPrecisionFormat(
+      gl.FRAGMENT_SHADER,
+      gl.HIGH_FLOAT
+    );
+    highpSupported = !!highpFloat && highpFloat.precision > 0;
   } catch (error) {
-    console.error('[PerformanceCheck] Error creating WebGL context:', error);
+    console.error("[PerformanceCheck] Error creating WebGL context:", error);
     return false; // Cannot perform WebGL checks
   } finally {
-    // Ensure renderer is disposed if created
-    renderer?.dispose();
+    // Proactively release the context so the throwaway canvas can be GC'd.
+    const loseContext = gl?.getExtension("WEBGL_lose_context");
+    loseContext?.loseContext();
+    canvas = null;
   }
 
   // Define thresholds (these might need tuning)
   const anisotropyThreshold = 8;
   const textureSizeThreshold = 8192;
 
-  const passesGpuCheck = 
-    maxAnisotropy >= anisotropyThreshold && 
+  const passesGpuCheck =
+    maxAnisotropy >= anisotropyThreshold &&
     maxTextureSize >= textureSizeThreshold &&
     highpSupported;
 
-  console.log(`[PerformanceCheck] GPU Checks Pass: ${passesGpuCheck}`);
-
-  // Final decision: requires both CPU and GPU checks to pass
-  const finalResult = hasEnoughCores && passesGpuCheck;
-  console.log(`[PerformanceCheck] Final Result: ${finalResult}`);
-  return finalResult;
-} 
+  return hasEnoughCores && passesGpuCheck;
+}

--- a/tests/test-composer-reducer.test.ts
+++ b/tests/test-composer-reducer.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from "bun:test";
+import {
+  composerInitialState,
+  composerReducer,
+} from "../src/apps/chats/components/chat-input/composerState";
+
+describe("composerReducer — referential bail-out", () => {
+  test("setHistoryIndex with the same value returns the same state reference", () => {
+    // The chat input fires an input-change effect that re-asserts
+    // historyIndex: -1 on every keystroke. setInputAndResetHistory already
+    // reset it, so this dispatch must be a no-op to let useReducer skip a
+    // second wasted render of the composer.
+    const state = { ...composerInitialState, historyIndex: -1 };
+    const next = composerReducer(state, { type: "setHistoryIndex", value: -1 });
+    expect(next).toBe(state);
+  });
+
+  test("setHistoryIndex with a different value returns a new state", () => {
+    const state = { ...composerInitialState, historyIndex: -1 };
+    const next = composerReducer(state, { type: "setHistoryIndex", value: 2 });
+    expect(next).not.toBe(state);
+    expect(next.historyIndex).toBe(2);
+  });
+
+  test("setInput with the same value returns the same state reference", () => {
+    const state = { ...composerInitialState, input: "hello" };
+    const next = composerReducer(state, { type: "setInput", value: "hello" });
+    expect(next).toBe(state);
+  });
+
+  test("setSelectedImage with the same value returns the same state reference", () => {
+    const state = { ...composerInitialState, selectedImage: null };
+    const next = composerReducer(state, {
+      type: "setSelectedImage",
+      value: null,
+    });
+    expect(next).toBe(state);
+  });
+
+  test("setInputAndResetHistory updates input and resets history in one step", () => {
+    const state = { ...composerInitialState, input: "", historyIndex: 3 };
+    const next = composerReducer(state, {
+      type: "setInputAndResetHistory",
+      value: "h",
+    });
+    expect(next.input).toBe("h");
+    expect(next.historyIndex).toBe(-1);
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -532,68 +532,77 @@ export default defineConfig({
     target: 'es2022',
     rollupOptions: {
       output: {
-        manualChunks: {
-          // Core React - loaded immediately
-          react: ["react", "react-dom"],
-          
-          // UI primitives - loaded early
+        // Function-form manualChunks: only assigns vendor (node_modules) packages
+        // to named chunks. App code and Vite's internal helpers (e.g. the
+        // `vite/preload-helper`, which is NOT under node_modules) return
+        // `undefined` so Vite keeps them in the entry chunk. The previous
+        // object form caused the `__vitePreload` helper and react-dom to leak
+        // into vendor chunks, which forced heavy chunks (audio/media-player)
+        // to be eagerly `modulepreload`ed from index.html on every page load.
+        manualChunks(id) {
+          // Co-locate Vite's dynamic-import preload helper with the eagerly
+          // loaded react chunk. Otherwise Rollup merges this tiny virtual
+          // module into whichever vendor chunk it picks first (react-player /
+          // media-player), forcing that heavy chunk to be eagerly
+          // `modulepreload`ed from index.html even though it's only used by
+          // lazy apps.
+          if (id.includes("vite/preload-helper")) return "react";
+
+          if (!id.includes("node_modules")) return undefined;
+
+          // Core React + scheduler - loaded immediately, kept in a stable
+          // vendor chunk for long-term caching (so app changes don't bust it).
+          if (
+            /[\\/]node_modules[\\/](react|react-dom|scheduler)[\\/]/.test(id)
+          ) {
+            return "react";
+          }
+
+          // UI primitives - loaded early.
           // Note: ui-form was merged into ui-core to eliminate a circular chunk
           // dependency (ui-form -> ui-core -> ui-form) that caused a TDZ crash
           // in Vite 6.4.x: "can't access lexical declaration before initialization"
-          "ui-core": [
-            "@radix-ui/react-dialog",
-            "@radix-ui/react-dropdown-menu",
-            "@radix-ui/react-menubar",
-            "@radix-ui/react-scroll-area",
-            "@radix-ui/react-tooltip",
-            "@radix-ui/react-label",
-            "@radix-ui/react-select",
-            "@radix-ui/react-slider",
-            "@radix-ui/react-switch",
-            "@radix-ui/react-checkbox",
-            "@radix-ui/react-tabs",
-          ],
-          
+          if (id.includes("@radix-ui/")) return "ui-core";
+
           // Heavy audio libs - deferred until Soundboard/iPod/Synth opens
-          audio: ["tone", "wavesurfer.js", "audio-buffer-utils"],
-          
+          if (
+            /[\\/]node_modules[\\/](tone|wavesurfer\.js|audio-buffer-utils)[\\/]/.test(
+              id
+            )
+          ) {
+            return "audio";
+          }
+
           // Media player - shared by iPod and Videos apps
-          "media-player": ["react-player"],
+          if (id.includes("react-player")) return "media-player";
 
           // Korean romanization - only needed for lyrics
-          "hangul": ["hangul-romanization"],
-          
-          // AI SDK - deferred until Chats/IE opens  
-          "ai-sdk": ["ai", "@ai-sdk/anthropic", "@ai-sdk/google", "@ai-sdk/openai", "@ai-sdk/react"],
-          
+          if (id.includes("hangul-romanization")) return "hangul";
+
+          // AI SDK - deferred until Chats/IE opens
+          if (/[\\/]node_modules[\\/](ai|@ai-sdk)[\\/]/.test(id)) {
+            return "ai-sdk";
+          }
+
           // Rich text editor - deferred until TextEdit opens
-          // Note: @tiptap/pm is excluded because it only exports subpaths (e.g. @tiptap/pm/state)
-          // and has no main entry point, which causes Vite to fail
-          tiptap: [
-            "@tiptap/core",
-            "@tiptap/react",
-            "@tiptap/starter-kit",
-            "@tiptap/extension-task-item",
-            "@tiptap/extension-task-list",
-            "@tiptap/extension-text-align",
-            "@tiptap/extension-underline",
-            "@tiptap/suggestion",
-          ],
-          
+          if (id.includes("@tiptap/")) return "tiptap";
+
           // 3D rendering - deferred until PC app opens
-          three: ["three"],
-          
+          if (/[\\/]node_modules[\\/]three[\\/]/.test(id)) return "three";
+
           // Animation - used by multiple apps
-          motion: ["framer-motion"],
-          
+          if (id.includes("framer-motion")) return "motion";
+
           // State management
-          zustand: ["zustand"],
-          
+          if (/[\\/]node_modules[\\/]zustand[\\/]/.test(id)) return "zustand";
+
           // Realtime chat
-          pusher: ["pusher-js"],
+          if (id.includes("pusher-js")) return "pusher";
 
           // Winamp player - deferred until Winamp app opens
-          webamp: ["webamp"],
+          if (id.includes("webamp")) return "webamp";
+
+          return undefined;
         },
       },
     },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Overview

Profiled ryOS in the browser (production build + bundle import-graph analysis + react-scan) and fixed the concrete client-side performance issues found. The codebase is already well-optimized (lazy apps, shallow store selectors, rAF-batched window drag, prefetch), so this focuses on real, measured regressions rather than blanket churn.

<a href="https://cursor.com/agents/bc-019e7ef5-8be9-7442-b450-66a9911ac936/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fryos_production_build_apps_demo.mp4"><img src="https://cursor.com/artifacts/c/art-4e55d2d4-e152-4038-bf15-4fc562c46a4a" alt="ryos_production_build_apps_demo.mp4" /></a>

_Production build (this PR) booting and opening Chats, iPod, Synth, and Soundboard — the apps whose chunks changed — all render correctly._

## 1. Loading / network — ~226 KB gzip off the initial page load (~30%)

The entry `index.html` was eagerly `modulepreload`ing heavy chunks that belong only to lazy apps. Tracing the static import graph found three root causes:

| Chunk | gzip | Root cause | Fix |
|-------|------|------------|-----|
| `three` | ~116 KB | `checkShaderPerformance()` did `import * as THREE` at module-init of the eagerly-loaded display-settings store, only to probe GPU caps | Rewrote the probe with raw WebGL (`MAX_TEXTURE_SIZE`, `EXT_texture_filter_anisotropic`, `getShaderPrecisionFormat`) — no three.js |
| `audio` (tone/wavesurfer) | ~93 KB | `types/types.ts` value-imported `wavesurfer.js` but used it only as a type, dragging the audio chunk into the eager graph | Changed to `import type` |
| `media-player` (react-player) | ~13 KB | Vite's `__vitePreload` helper got merged into the `media-player` vendor chunk, forcing react-player to be preloaded | Switched `manualChunks` to function form and routed the preload helper into the eager `react` chunk |

Bonus: `react`/`react-dom` now live in a stable, cacheable `react` chunk instead of leaking into the entry (better repeat-visit caching), and `ui-core` is scoped more tightly (56→45 KB gz).

**Eager `modulepreload` total: 742.55 KB → 516.99 KB gzip.** Three/audio/media-player now load on demand with their apps. Full breakdown: `loading_bundle_comparison.txt`.

## 2. React rendering — removed a redundant composer render per keystroke

The Chats input fires an input-change effect that re-asserts `historyIndex: -1` on every keystroke, but `setInputAndResetHistory` already reset it. `composerReducer` always returned a fresh object, so `useReducer` couldn't bail out and each keystroke triggered a second wasted re-render of the composer subtree. Made the value setters return the same state reference when unchanged so React skips the redundant render (covered by a new unit test).

Browser react-scan profiling also confirmed the desktop is otherwise healthy at idle (only the menu-bar clock re-renders, once/second) and window drag is already rAF-batched with no global re-render storm.

## Testing

- ✅ `bun run build` (incl. `tsc -b`)
- ✅ `bun run test:unit` — 238 pass (incl. new `tests/test-composer-reducer.test.ts`)
- ✅ `eslint` clean on changed files
- ✅ Verified the **production build** (`vite preview`) boots and opens every app whose chunk changed (Synth, Soundboard, iPod, Videos, Chats, IE, TextEdit) with **no chunk-load / TDZ / React-crash errors** — important because the config previously warned about TDZ crashes from circular vendor chunks. Chats text input still works after the reducer change.

## Scope note

This is a targeted pass on the highest-impact, verifiable issues — not an exhaustive rewrite of all ~28 apps. A genuine remaining eager edge is `pusher-js` (~19 KB gz, statically imported by `pusherClient.ts`); deferring it safely requires reworking the synchronous realtime-client API and is left out of this PR since the realtime path can't be exercised here without backend credentials.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019e7ef5-8be9-7442-b450-66a9911ac936"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019e7ef5-8be9-7442-b450-66a9911ac936"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

