### PR TITLE
Fix desktop/context menu items not working on mobile

### DIFF
--- a/src/components/ui/right-click-menu.tsx
+++ b/src/components/ui/right-click-menu.tsx
@@ -57,6 +57,34 @@ interface RightClickMenuProps {
 export const menuItemClass =
   "text-md h-6 px-3 active:bg-neutral-900 active:text-white min-w-[140px] flex items-center gap-2";
 
+// On touch devices the browser does not synthesize a `click` from a tap on
+// these menu items (the app sets `touch-action: none` globally), and Radix
+// only manufactures one when the pointer-down happened *outside* the item.
+// So a normal tap fires `pointerup` but never `onSelect`, leaving the menu
+// inert on mobile. For non-mouse pointers we forward the tap to a synthetic
+// click (mirroring Radix's own keyboard-selection path), and dedupe so a
+// real click that does arrive afterwards never double-triggers an action.
+let lastTouchSelect: { item: object; at: number } | null = null;
+
+function selectOnce(item: object, run: () => void) {
+  const now = Date.now();
+  if (lastTouchSelect && lastTouchSelect.item === item && now - lastTouchSelect.at < 500) {
+    return;
+  }
+  lastTouchSelect = { item, at: now };
+  run();
+}
+
+function handleTouchPointerUp(
+  event: React.PointerEvent<HTMLDivElement>
+) {
+  if (event.pointerType !== "mouse") {
+    // Route the tap through a real click so Radix runs its normal
+    // select-and-close logic. `selectOnce` guards against duplicates.
+    event.currentTarget.click();
+  }
+}
+
 const menuItemKeyCache = new WeakMap<object, string>();
 let menuItemKeySeed = 0;
 
@@ -88,7 +116,8 @@ function renderItems(items: MenuItem[]): ReactNode {
         return (
           <DropdownMenuItem
             key={itemKey}
-            onSelect={item.onSelect}
+            onSelect={() => selectOnce(item, () => item.onSelect?.())}
+            onPointerUp={handleTouchPointerUp}
             disabled={item.disabled}
             className={menuItemClass}
           >
@@ -144,7 +173,8 @@ function renderItems(items: MenuItem[]): ReactNode {
           <DropdownMenuCheckboxItem
             key={itemKey}
             checked={item.checked}
-            onSelect={item.onSelect}
+            onSelect={() => selectOnce(item, () => item.onSelect?.())}
+            onPointerUp={handleTouchPointerUp}
             disabled={item.disabled}
             className="text-md h-6 min-w-[140px]"
           >
@@ -160,7 +190,8 @@ function renderItems(items: MenuItem[]): ReactNode {
                 <DropdownMenuCheckboxItem
                   key={ri.value}
                   checked={isActive}
-                  onSelect={() => item.onChange(ri.value)}
+                  onSelect={() => selectOnce(ri, () => item.onChange(ri.value))}
+                  onPointerUp={handleTouchPointerUp}
                   className="text-md h-6 min-w-[140px]"
                 >
                   {ri.label}
@@ -211,6 +242,13 @@ export function RightClickMenu({
         sideOffset={4}
         alignOffset={4}
         className="px-0"
+        // React portals propagate events through the React tree, so a touch on
+        // a menu item would otherwise reach the long-press handler on the
+        // surface that rendered this menu (desktop/Finder/dock) and reopen the
+        // menu right after it closes. Keep touch events from leaking out.
+        onTouchStart={(e) => e.stopPropagation()}
+        onTouchMove={(e) => e.stopPropagation()}
+        onTouchEnd={(e) => e.stopPropagation()}
       >
         {renderItems(items)}
       </DropdownMenuContent>

--- a/src/hooks/useLongPress.ts
+++ b/src/hooks/useLongPress.ts
@@ -6,38 +6,27 @@ import { useCallback, useRef } from "react";
  * onLongPress will be invoked after `delay` ms (default 500)
  * if the user is still pressing on the element.
  *
- * A small movement tolerance (`moveTolerance`, default 10px) is allowed so
- * that natural finger jitter while holding does not cancel the long press.
- * Only movement beyond the tolerance (i.e. an intentional scroll/drag) cancels
- * it. Without this, real touch devices almost always emit tiny `touchmove`
- * events during a hold, which previously aborted the gesture and made
- * context menus feel broken on mobile.
- *
  * Example:
  * const longPress = useLongPress((e) => console.log("long press", e));
  * <div {...longPress} />
  */
 export function useLongPress<T extends HTMLElement = HTMLElement>(
   onLongPress: (e: React.TouchEvent<T>) => void,
-  { delay = 500, moveTolerance = 10 }: { delay?: number; moveTolerance?: number } = {}
+  { delay = 500 }: { delay?: number } = {}
 ) {
   const timeoutRef = useRef<number | null>(null);
-  const startPosRef = useRef<{ x: number; y: number } | null>(null);
 
   const clear = useCallback(() => {
     if (timeoutRef.current !== null) {
       clearTimeout(timeoutRef.current);
       timeoutRef.current = null;
     }
-    startPosRef.current = null;
   }, []);
 
   const start = useCallback(
     (e: React.TouchEvent<T>) => {
       // Only handle single-finger touches
       if (e.touches && e.touches.length === 1) {
-        const touch = e.touches[0];
-        startPosRef.current = { x: touch.clientX, y: touch.clientY };
         timeoutRef.current = window.setTimeout(() => {
           onLongPress(e);
         }, delay);
@@ -46,32 +35,10 @@ export function useLongPress<T extends HTMLElement = HTMLElement>(
     [onLongPress, delay]
   );
 
-  const handleMove = useCallback(
-    (e: React.TouchEvent<T>) => {
-      const startPos = startPosRef.current;
-      if (!startPos || timeoutRef.current === null) return;
-
-      const touch = e.touches[0];
-      if (!touch) {
-        clear();
-        return;
-      }
-
-      const dx = touch.clientX - startPos.x;
-      const dy = touch.clientY - startPos.y;
-      // Cancel only when the finger has moved beyond the tolerance, treating
-      // it as an intentional scroll/drag rather than a stationary hold.
-      if (dx * dx + dy * dy > moveTolerance * moveTolerance) {
-        clear();
-      }
-    },
-    [clear, moveTolerance]
-  );
-
   return {
     onTouchStart: start,
     onTouchEnd: clear,
-    onTouchMove: handleMove,
+    onTouchMove: clear,
     onTouchCancel: clear,
   } as const;
 }

--- a/src/hooks/useLongPress.ts
+++ b/src/hooks/useLongPress.ts
@@ -6,27 +6,38 @@ import { useCallback, useRef } from "react";
  * onLongPress will be invoked after `delay` ms (default 500)
  * if the user is still pressing on the element.
  *
+ * A small movement tolerance (`moveTolerance`, default 10px) is allowed so
+ * that natural finger jitter while holding does not cancel the long press.
+ * Only movement beyond the tolerance (i.e. an intentional scroll/drag) cancels
+ * it. Without this, real touch devices almost always emit tiny `touchmove`
+ * events during a hold, which previously aborted the gesture and made
+ * context menus feel broken on mobile.
+ *
  * Example:
  * const longPress = useLongPress((e) => console.log("long press", e));
  * <div {...longPress} />
  */
 export function useLongPress<T extends HTMLElement = HTMLElement>(
   onLongPress: (e: React.TouchEvent<T>) => void,
-  { delay = 500 }: { delay?: number } = {}
+  { delay = 500, moveTolerance = 10 }: { delay?: number; moveTolerance?: number } = {}
 ) {
   const timeoutRef = useRef<number | null>(null);
+  const startPosRef = useRef<{ x: number; y: number } | null>(null);
 
   const clear = useCallback(() => {
     if (timeoutRef.current !== null) {
       clearTimeout(timeoutRef.current);
       timeoutRef.current = null;
     }
+    startPosRef.current = null;
   }, []);
 
   const start = useCallback(
     (e: React.TouchEvent<T>) => {
       // Only handle single-finger touches
       if (e.touches && e.touches.length === 1) {
+        const touch = e.touches[0];
+        startPosRef.current = { x: touch.clientX, y: touch.clientY };
         timeoutRef.current = window.setTimeout(() => {
           onLongPress(e);
         }, delay);
@@ -35,10 +46,32 @@ export function useLongPress<T extends HTMLElement = HTMLElement>(
     [onLongPress, delay]
   );
 
+  const handleMove = useCallback(
+    (e: React.TouchEvent<T>) => {
+      const startPos = startPosRef.current;
+      if (!startPos || timeoutRef.current === null) return;
+
+      const touch = e.touches[0];
+      if (!touch) {
+        clear();
+        return;
+      }
+
+      const dx = touch.clientX - startPos.x;
+      const dy = touch.clientY - startPos.y;
+      // Cancel only when the finger has moved beyond the tolerance, treating
+      // it as an intentional scroll/drag rather than a stationary hold.
+      if (dx * dx + dy * dy > moveTolerance * moveTolerance) {
+        clear();
+      }
+    },
+    [clear, moveTolerance]
+  );
+
   return {
     onTouchStart: start,
     onTouchEnd: clear,
-    onTouchMove: clear,
+    onTouchMove: handleMove,
     onTouchCancel: clear,
   } as const;
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

On touch devices, the desktop context menu opened on long-press, but **tapping a menu item (e.g. "Set Wallpaper…") did nothing** — the menu just sat there. Same issue affected the Finder and dock context menus, which all share `RightClickMenu`.

## Root cause

Two separate touch-only bugs, both in `RightClickMenu` (`src/components/ui/right-click-menu.tsx`):

1. **Selection never fired.** The app sets `touch-action: none` globally, so the browser does not synthesize a `click` from a tap. Radix's `MenuItem` only manufactures a click itself when the `pointerdown` happened *outside* the item (`if (!isPointerDownRef.current) event.currentTarget?.click()`). A normal tap puts pointerdown *on* the item, so Radix waits for a native click that never arrives — `pointerup` fires but `onSelect` never does.

2. **Menu reopened instantly (made it feel "stuck").** React portals propagate events through the React tree, not the DOM tree. The menu is rendered as a React child of the surface that owns it (desktop/Finder/dock), so a touch on a menu item bubbled to that surface's long-press handler and re-set the context-menu position ~500ms later — right after it closed.

## Fix

- Forward non-mouse `pointerup` on menu items to a synthetic `click` (mirroring Radix's own keyboard-selection path), with a small dedupe guard so any real click that does arrive can't double-trigger the action. Applied to item, checkbox, and radio entries.
- Stop touch events from propagating out of the menu content (`onTouchStart/Move/End`), so long-press handlers on the underlying surface no longer reopen the menu.

This is centralized in `RightClickMenu`, so it fixes the desktop, Finder, and dock context menus together.

## Testing

Verified in Chrome with iPhone 12 Pro touch emulation, driving precise CDP touch events and reading the live DOM/console:
- Tapping "Set Wallpaper…" now opens System Preferences (Control Panels) **and** the menu closes — confirmed via console (`onSelect` → `toggleApp` → `ControlPanel` mount) and DOM (popup menu removed).
- Tapping empty space still dismisses the menu.
- Mouse regression: right-click (DOM `contextmenu`) → click "Set Wallpaper…" still opens Control Panels and closes the menu; "Sort By" submenu still opens on hover.
- `bun run test:unit` → 257 pass / 0 fail.

Known pre-existing limitation (not changed here): the "Sort By" **submenu** does not open on a single touch tap (Radix submenus are hover-oriented), and selecting a sort radio with the mouse doesn't auto-close the menu. These predate this change and are independent of the reported bug.

Before — menu open on mobile:

![Desktop context menu open on mobile](https://cursor.com/artifacts/c/art-2c2abe3d-0ac7-43be-bf8c-3847863fa376)

After — tapping "Set Wallpaper…" opens System Preferences and dismisses the menu:

![System Preferences open after tapping Set Wallpaper, menu closed](https://cursor.com/artifacts/c/art-40719c8f-a81a-48da-8923-ec1c24b997d7)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019e7fc0-eb2b-72f9-8087-e6fa969b882a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019e7fc0-eb2b-72f9-8087-e6fa969b882a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

