### PR TITLE
Fix high-impact client performance hotspots

### DIFF
--- a/src/apps/base/app-manager/AppManagerView.tsx
+++ b/src/apps/base/app-manager/AppManagerView.tsx
@@ -10,13 +10,14 @@ import { AppSwitcher } from "@/components/layout/AppSwitcher";
 import { AppErrorBoundary } from "@/components/errors/ErrorBoundaries";
 import { getTranslatedAppName } from "@/utils/i18n";
 import { isTextEditInitialData } from "@/types/appInitialData";
+import { useAppStore } from "@/stores/useAppStore";
 import { shouldMountInstance } from "../instanceMountPolicy";
 import { getZIndexForInstance, supportsMultiWindowApp } from "./instanceHelpers";
 import type { AppManagerViewModel } from "./useAppManager";
 
 export function AppManagerView({
   apps,
-  instances,
+  openInstanceIds,
   instanceOrder,
   exposeMode,
   showDesktopMenuBar,
@@ -37,120 +38,22 @@ export function AppManagerView({
     <>
       {showDesktopMenuBar && <MenuBar />}
       <Dock />
-      {Object.values(instances).map((instance) => {
-        if (!instance.isOpen) return null;
-        if (exposeMode && instance.appId === "stickies") return null;
-
-        const appId = instance.appId as AppId;
-        const zIndex = getZIndexForInstance(
-          instance.instanceId,
-          instanceOrder
-        );
-        const AppComponent = getAppComponent(appId);
-        const app = apps.find((registeredApp) => registeredApp.id === appId);
-        const translatedAppName = getTranslatedAppName(appId);
-        const crashDialogAppName =
-          translatedAppName !== appId
-            ? translatedAppName
-            : (app?.name ?? appId);
-
-        const shouldMount = shouldMountInstance(instance, exposeMode);
-        const hideWindow = !shouldMount || instance.isLoading;
-
-        return (
-          <div
-            key={instance.instanceId}
-            style={{
-              zIndex: exposeMode ? 9999 : zIndex,
-              visibility: hideWindow ? "hidden" : "visible",
-            }}
-            className="absolute inset-x-0 md:inset-x-auto w-full md:w-auto"
-            role="presentation"
-            onMouseDown={() => {
-              if (!instance.isForeground && !exposeMode) {
-                bringInstanceToForeground(instance.instanceId);
-              }
-            }}
-            onTouchStart={() => {
-              if (!instance.isForeground && !exposeMode) {
-                bringInstanceToForeground(instance.instanceId);
-              }
-            }}
-          >
-            <AppErrorBoundary
-              appId={appId}
-              appName={crashDialogAppName}
-              instanceId={instance.instanceId}
-              onCrash={() => {
-                setCrashedInstanceIds((prev) => {
-                  if (prev.has(instance.instanceId)) {
-                    return prev;
-                  }
-                  const next = new Set(prev);
-                  next.add(instance.instanceId);
-                  return next;
-                });
-                bringInstanceToForeground(instance.instanceId);
-              }}
-              onQuit={() => {
-                setCrashedInstanceIds((prev) => {
-                  if (!prev.has(instance.instanceId)) {
-                    return prev;
-                  }
-                  const next = new Set(prev);
-                  next.delete(instance.instanceId);
-                  return next;
-                });
-                closeAppInstance(instance.instanceId);
-              }}
-              onRelaunch={() => {
-                setCrashedInstanceIds((prev) => {
-                  if (!prev.has(instance.instanceId)) {
-                    return prev;
-                  }
-                  const next = new Set(prev);
-                  next.delete(instance.instanceId);
-                  return next;
-                });
-                const relaunchInitialData =
-                  appId === "textedit" &&
-                  isTextEditInitialData(instance.initialData)
-                    ? { path: instance.initialData.path }
-                    : instance.initialData;
-
-                closeAppInstance(instance.instanceId);
-                launchApp(
-                  appId,
-                  relaunchInitialData,
-                  instance.title,
-                  supportsMultiWindowApp(appId)
-                );
-              }}
-            >
-              {shouldMount ? (
-                <AppComponent
-                  isWindowOpen={instance.isOpen}
-                  isForeground={exposeMode ? false : instance.isForeground}
-                  onClose={() => requestCloseWindow(instance.instanceId)}
-                  className="pointer-events-auto"
-                  helpItems={app?.helpItems}
-                  skipInitialSound={isInitialMount}
-                  // @ts-expect-error - Dynamic component system with different initialData types per app
-                  initialData={instance.initialData}
-                  instanceId={instance.instanceId}
-                  title={instance.title}
-                  onNavigateNext={() =>
-                    navigateToNextInstance(instance.instanceId)
-                  }
-                  onNavigatePrevious={() =>
-                    navigateToPreviousInstance(instance.instanceId)
-                  }
-                />
-              ) : null}
-            </AppErrorBoundary>
-          </div>
-        );
-      })}
+      {openInstanceIds.map((instanceId) => (
+        <ManagedAppInstance
+          key={instanceId}
+          apps={apps}
+          instanceId={instanceId}
+          instanceOrder={instanceOrder}
+          exposeMode={exposeMode}
+          isInitialMount={isInitialMount}
+          setCrashedInstanceIds={setCrashedInstanceIds}
+          bringInstanceToForeground={bringInstanceToForeground}
+          closeAppInstance={closeAppInstance}
+          launchApp={launchApp}
+          navigateToNextInstance={navigateToNextInstance}
+          navigateToPreviousInstance={navigateToPreviousInstance}
+        />
+      ))}
 
       <Desktop
         apps={apps}
@@ -172,5 +75,138 @@ export function AppManagerView({
         selectedIndex={switcherIndex}
       />
     </>
+  );
+}
+
+function ManagedAppInstance({
+  apps,
+  instanceId,
+  instanceOrder,
+  exposeMode,
+  isInitialMount,
+  setCrashedInstanceIds,
+  bringInstanceToForeground,
+  closeAppInstance,
+  launchApp,
+  navigateToNextInstance,
+  navigateToPreviousInstance,
+}: Pick<
+  AppManagerViewModel,
+  | "apps"
+  | "instanceOrder"
+  | "exposeMode"
+  | "isInitialMount"
+  | "setCrashedInstanceIds"
+  | "bringInstanceToForeground"
+  | "closeAppInstance"
+  | "launchApp"
+  | "navigateToNextInstance"
+  | "navigateToPreviousInstance"
+> & {
+  instanceId: string;
+}) {
+  const instance = useAppStore((state) => state.instances[instanceId]);
+
+  if (!instance?.isOpen) return null;
+  if (exposeMode && instance.appId === "stickies") return null;
+
+  const appId = instance.appId as AppId;
+  const zIndex = getZIndexForInstance(instance.instanceId, instanceOrder);
+  const AppComponent = getAppComponent(appId);
+  const app = apps.find((registeredApp) => registeredApp.id === appId);
+  const translatedAppName = getTranslatedAppName(appId);
+  const crashDialogAppName =
+    translatedAppName !== appId ? translatedAppName : (app?.name ?? appId);
+
+  const shouldMount = shouldMountInstance(instance, exposeMode);
+
+  return (
+    <div
+      style={{
+        zIndex: exposeMode ? 9999 : zIndex,
+        visibility: shouldMount ? "visible" : "hidden",
+      }}
+      className="absolute inset-x-0 md:inset-x-auto w-full md:w-auto"
+      role="presentation"
+      onMouseDown={() => {
+        if (!instance.isForeground && !exposeMode) {
+          bringInstanceToForeground(instance.instanceId);
+        }
+      }}
+      onTouchStart={() => {
+        if (!instance.isForeground && !exposeMode) {
+          bringInstanceToForeground(instance.instanceId);
+        }
+      }}
+    >
+      <AppErrorBoundary
+        appId={appId}
+        appName={crashDialogAppName}
+        instanceId={instance.instanceId}
+        onCrash={() => {
+          setCrashedInstanceIds((prev) => {
+            if (prev.has(instance.instanceId)) {
+              return prev;
+            }
+            const next = new Set(prev);
+            next.add(instance.instanceId);
+            return next;
+          });
+          bringInstanceToForeground(instance.instanceId);
+        }}
+        onQuit={() => {
+          setCrashedInstanceIds((prev) => {
+            if (!prev.has(instance.instanceId)) {
+              return prev;
+            }
+            const next = new Set(prev);
+            next.delete(instance.instanceId);
+            return next;
+          });
+          closeAppInstance(instance.instanceId);
+        }}
+        onRelaunch={() => {
+          setCrashedInstanceIds((prev) => {
+            if (!prev.has(instance.instanceId)) {
+              return prev;
+            }
+            const next = new Set(prev);
+            next.delete(instance.instanceId);
+            return next;
+          });
+          const relaunchInitialData =
+            appId === "textedit" && isTextEditInitialData(instance.initialData)
+              ? { path: instance.initialData.path }
+              : instance.initialData;
+
+          closeAppInstance(instance.instanceId);
+          launchApp(
+            appId,
+            relaunchInitialData,
+            instance.title,
+            supportsMultiWindowApp(appId)
+          );
+        }}
+      >
+        {shouldMount ? (
+          <AppComponent
+            isWindowOpen={instance.isOpen}
+            isForeground={exposeMode ? false : instance.isForeground}
+            onClose={() => requestCloseWindow(instance.instanceId)}
+            className="pointer-events-auto"
+            helpItems={app?.helpItems}
+            skipInitialSound={isInitialMount}
+            // @ts-expect-error - Dynamic component system with different initialData types per app
+            initialData={instance.initialData}
+            instanceId={instance.instanceId}
+            title={instance.title}
+            onNavigateNext={() => navigateToNextInstance(instance.instanceId)}
+            onNavigatePrevious={() =>
+              navigateToPreviousInstance(instance.instanceId)
+            }
+          />
+        ) : null}
+      </AppErrorBoundary>
+    </div>
   );
 }

--- a/src/apps/base/app-manager/AppManagerView.tsx
+++ b/src/apps/base/app-manager/AppManagerView.tsx
@@ -119,12 +119,13 @@ function ManagedAppInstance({
     translatedAppName !== appId ? translatedAppName : (app?.name ?? appId);
 
   const shouldMount = shouldMountInstance(instance, exposeMode);
+  const hideWindow = !shouldMount || instance.isLoading;
 
   return (
     <div
       style={{
         zIndex: exposeMode ? 9999 : zIndex,
-        visibility: shouldMount ? "visible" : "hidden",
+        visibility: hideWindow ? "hidden" : "visible",
       }}
       className="absolute inset-x-0 md:inset-x-auto w-full md:w-auto"
       role="presentation"

--- a/src/apps/base/app-manager/useAppManager.ts
+++ b/src/apps/base/app-manager/useAppManager.ts
@@ -25,7 +25,7 @@ export function useAppManager({ apps }: AppManagerProps) {
   const { t } = useTranslation();
 
   const {
-    instances,
+    openInstanceIds,
     instanceOrder,
     launchApp,
     bringInstanceToForeground,
@@ -37,7 +37,9 @@ export function useAppManager({ apps }: AppManagerProps) {
     foregroundInstanceId,
     exposeMode,
   } = useAppStoreShallow((state) => ({
-    instances: state.instances,
+    openInstanceIds: Object.values(state.instances)
+      .filter((instance) => instance.isOpen)
+      .map((instance) => instance.instanceId),
     instanceOrder: state.instanceOrder,
     launchApp: state.launchApp,
     bringInstanceToForeground: state.bringInstanceToForeground,
@@ -76,7 +78,7 @@ export function useAppManager({ apps }: AppManagerProps) {
   const switcherApps = switcherState.apps;
   const switcherIndex = switcherState.index;
 
-  const instancesRef = useRef(instances);
+  const instancesRef = useRef(useAppStore.getState().instances);
   const instanceOrderRef = useRef(instanceOrder);
   const launchAppRef = useRef(launchApp);
   const foregroundInstanceIdRef = useRef(foregroundInstanceId);
@@ -90,8 +92,11 @@ export function useAppManager({ apps }: AppManagerProps) {
   const switcherIndexRef = useRef(0);
 
   useEffect(() => {
-    instancesRef.current = instances;
-  }, [instances]);
+    instancesRef.current = useAppStore.getState().instances;
+    return useAppStore.subscribe((state) => {
+      instancesRef.current = state.instances;
+    });
+  }, []);
 
   useEffect(() => {
     instanceOrderRef.current = instanceOrder;
@@ -133,8 +138,9 @@ export function useAppManager({ apps }: AppManagerProps) {
 
       let changed = false;
       const next = new Set<string>();
+      const openIds = new Set(openInstanceIds);
       prev.forEach((instanceId) => {
-        if (instances[instanceId]?.isOpen) {
+        if (openIds.has(instanceId)) {
           next.add(instanceId);
         } else {
           changed = true;
@@ -143,7 +149,7 @@ export function useAppManager({ apps }: AppManagerProps) {
 
       return changed ? next : prev;
     });
-  }, [instances]);
+  }, [openInstanceIds]);
 
   useEffect(() => {
     const timer = setTimeout(() => setIsInitialMount(false), 500);
@@ -318,7 +324,7 @@ export function useAppManager({ apps }: AppManagerProps) {
 
   return {
     apps,
-    instances,
+    openInstanceIds,
     instanceOrder,
     exposeMode,
     showDesktopMenuBar,

--- a/src/apps/base/app-manager/useAppManager.ts
+++ b/src/apps/base/app-manager/useAppManager.ts
@@ -1,4 +1,11 @@
-import { useCallback, useEffect, useMemo, useReducer, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useReducer,
+  useRef,
+  useState,
+} from "react";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 import type { AppId } from "@/config/appRegistry";
@@ -12,7 +19,10 @@ import {
   toggleSpotlightSearch,
 } from "@/utils/appEventBus";
 import { useDashboardShellTriggers } from "@/hooks/useDashboardShellTriggers";
-import { prefetchAppChunk, prefetchLikelyAppChunks } from "@/config/lazyAppComponent";
+import {
+  prefetchAppChunk,
+  prefetchLikelyAppChunks,
+} from "@/config/lazyAppComponent";
 import { useAppStore } from "@/stores/useAppStore";
 import { useGlobalUndoRedo } from "@/hooks/useGlobalUndoRedo";
 import { resolveInitialRoute } from "../appRouteRegistry";
@@ -25,7 +35,7 @@ export function useAppManager({ apps }: AppManagerProps) {
   const { t } = useTranslation();
 
   const {
-    instances,
+    openInstanceIdsKey,
     instanceOrder,
     launchApp,
     bringInstanceToForeground,
@@ -37,7 +47,10 @@ export function useAppManager({ apps }: AppManagerProps) {
     foregroundInstanceId,
     exposeMode,
   } = useAppStoreShallow((state) => ({
-    instances: state.instances,
+    openInstanceIdsKey: Object.values(state.instances)
+      .filter((instance) => instance.isOpen)
+      .map((instance) => instance.instanceId)
+      .join("\0"),
     instanceOrder: state.instanceOrder,
     launchApp: state.launchApp,
     bringInstanceToForeground: state.bringInstanceToForeground,
@@ -51,11 +64,8 @@ export function useAppManager({ apps }: AppManagerProps) {
   }));
 
   const openInstanceIds = useMemo(
-    () =>
-      Object.values(instances)
-        .filter((instance) => instance.isOpen)
-        .map((instance) => instance.instanceId),
-    [instances]
+    () => (openInstanceIdsKey ? openInstanceIdsKey.split("\0") : []),
+    [openInstanceIdsKey]
   );
 
   const { isWindowsTheme: isXpTheme } = useThemeFlags();

--- a/src/apps/base/app-manager/useAppManager.ts
+++ b/src/apps/base/app-manager/useAppManager.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useReducer, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useReducer, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 import type { AppId } from "@/config/appRegistry";
@@ -25,7 +25,7 @@ export function useAppManager({ apps }: AppManagerProps) {
   const { t } = useTranslation();
 
   const {
-    openInstanceIds,
+    instances,
     instanceOrder,
     launchApp,
     bringInstanceToForeground,
@@ -37,9 +37,7 @@ export function useAppManager({ apps }: AppManagerProps) {
     foregroundInstanceId,
     exposeMode,
   } = useAppStoreShallow((state) => ({
-    openInstanceIds: Object.values(state.instances)
-      .filter((instance) => instance.isOpen)
-      .map((instance) => instance.instanceId),
+    instances: state.instances,
     instanceOrder: state.instanceOrder,
     launchApp: state.launchApp,
     bringInstanceToForeground: state.bringInstanceToForeground,
@@ -51,6 +49,14 @@ export function useAppManager({ apps }: AppManagerProps) {
     foregroundInstanceId: state.foregroundInstanceId,
     exposeMode: state.exposeMode,
   }));
+
+  const openInstanceIds = useMemo(
+    () =>
+      Object.values(instances)
+        .filter((instance) => instance.isOpen)
+        .map((instance) => instance.instanceId),
+    [instances]
+  );
 
   const { isWindowsTheme: isXpTheme } = useThemeFlags();
 

--- a/src/apps/finder/components/FileIcon.tsx
+++ b/src/apps/finder/components/FileIcon.tsx
@@ -1,5 +1,5 @@
 import { useSound, Sounds } from "@/hooks/useSound";
-import { useEffect, useReducer, useRef } from "react";
+import { memo, useCallback, useEffect, useReducer, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { isTouchDevice } from "@/utils/device";
 import { useLongPress } from "@/hooks/useLongPress";
@@ -23,7 +23,33 @@ interface FileIconProps {
   context?: "desktop" | "finder";
 }
 
-export function FileIcon({
+type PreviewState = {
+  imgSrc: string | undefined;
+  fallbackToIcon: boolean;
+};
+
+type PreviewAction =
+  | { type: "reset"; imgSrc: string | undefined }
+  | { type: "setImage"; imgSrc: string | undefined }
+  | { type: "fallback" };
+
+const previewReducer = (
+  state: PreviewState,
+  action: PreviewAction
+): PreviewState => {
+  switch (action.type) {
+    case "reset":
+      return { imgSrc: action.imgSrc, fallbackToIcon: false };
+    case "setImage":
+      return { ...state, imgSrc: action.imgSrc };
+    case "fallback":
+      return { ...state, fallbackToIcon: true };
+    default:
+      return state;
+  }
+};
+
+export const FileIcon = memo(function FileIcon({
   name,
   isDirectory,
   icon,
@@ -44,31 +70,11 @@ export function FileIcon({
   const { isWinXp: isXpTheme, isWin98: isWin98Theme, isMacOSTheme: isMacOSXTheme } =
     useThemeFlags();
   const isFinderContext = context === "finder";
-  type PreviewState = {
-    imgSrc: string | undefined;
-    fallbackToIcon: boolean;
-  };
-  type PreviewAction =
-    | { type: "reset"; imgSrc: string | undefined }
-    | { type: "setImage"; imgSrc: string | undefined }
-    | { type: "fallback" };
   const initialState: PreviewState = {
     imgSrc: contentUrl,
     fallbackToIcon: false,
   };
-  const reducer = (state: PreviewState, action: PreviewAction): PreviewState => {
-    switch (action.type) {
-      case "reset":
-        return { imgSrc: action.imgSrc, fallbackToIcon: false };
-      case "setImage":
-        return { ...state, imgSrc: action.imgSrc };
-      case "fallback":
-        return { ...state, fallbackToIcon: true };
-      default:
-        return state;
-    }
-  };
-  const [previewState, dispatch] = useReducer(reducer, initialState);
+  const [previewState, dispatch] = useReducer(previewReducer, initialState);
   const { imgSrc, fallbackToIcon } = previewState;
   const attemptedUrlsRef = useRef<Set<string>>(new Set());
   const blobUrlRef = useRef<string | null>(null);
@@ -180,7 +186,7 @@ export function FileIcon({
 
   const sizes = sizeClasses[size];
 
-  const handleImageError = () => {
+  const handleImageError = useCallback(() => {
     console.error(
       `Error loading thumbnail for ${name}, fallback to icon. Current imgSrc: ${imgSrc?.substring(
         0,
@@ -220,7 +226,7 @@ export function FileIcon({
     // Otherwise fall back to icon
     console.log(`[FileIcon] Falling back to icon for ${name}`);
     dispatch({ type: "fallback" });
-  };
+  }, [fallbackToIcon, imgSrc, name]);
 
   const renderIcon = () => {
     // Show thumbnail for images or music files with cover art
@@ -277,7 +283,7 @@ export function FileIcon({
     );
   };
 
-  const handleClick = (e: React.MouseEvent<HTMLDivElement>) => {
+  const handleClick = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
     const now = Date.now();
     if (now - lastClickSoundRef.current >= CLICK_SOUND_COOLDOWN_MS) {
       lastClickSoundRef.current = now;
@@ -291,14 +297,14 @@ export function FileIcon({
       // On desktop, execute the regular onClick handler (selection)
       onClick?.(e);
     }
-  };
+  }, [onClick, onDoubleClick, playClick]);
 
-  const handleDoubleClick = (e: React.MouseEvent<HTMLDivElement>) => {
+  const handleDoubleClick = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
     // Only handle double-click on desktop (touch uses single tap)
     if (!isTouchDevice()) {
       onDoubleClick?.(e);
     }
-  };
+  }, [onDoubleClick]);
 
   // Add long-press support for context menu on mobile
   const longPressHandlers = useLongPress((touchEvent) => {
@@ -371,4 +377,4 @@ export function FileIcon({
       </div>
     </div>
   );
-}
+});

--- a/src/apps/finder/components/file-list/useFileList.ts
+++ b/src/apps/finder/components/file-list/useFileList.ts
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect, useCallback } from "react";
+import { useState, useRef, useEffect, useCallback, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { useThemeFlags } from "@/hooks/useThemeFlags";
 import { getFinderDisplayName } from "@/utils/finderDisplay";
@@ -63,17 +63,20 @@ export function useFileList({
     };
   }, []);
 
-  const handleFileOpen = (file: FileItem, launchOrigin?: LaunchOriginRect) => {
-    if (clickTimeoutRef.current) {
-      clearTimeout(clickTimeoutRef.current);
-      clickTimeoutRef.current = null;
-    }
+  const handleFileOpen = useCallback(
+    (file: FileItem, launchOrigin?: LaunchOriginRect) => {
+      if (clickTimeoutRef.current) {
+        clearTimeout(clickTimeoutRef.current);
+        clickTimeoutRef.current = null;
+      }
 
-    onFileOpen(file, launchOrigin);
-    onFileSelect(undefined, { selectedPaths: [], anchorPath: null });
-  };
+      onFileOpen(file, launchOrigin);
+      onFileSelect(undefined, { selectedPaths: [], anchorPath: null });
+    },
+    [onFileOpen, onFileSelect]
+  );
 
-  const orderedPaths = files.map((file) => file.path);
+  const orderedPaths = useMemo(() => files.map((file) => file.path), [files]);
 
   const applySelection = useCallback(
     (
@@ -179,61 +182,71 @@ export function useFileList({
     };
   }, [applySelection, selectionRect, updateSelectionFromMarquee]);
 
-  const handleFileSelect = (
-    file: FileItem,
-    event: React.MouseEvent<HTMLElement>,
-    options?: { allowRename?: boolean }
-  ) => {
-    const allowRename = options?.allowRename !== false;
-    const toggleKey = hasToggleModifier(event);
-    const shiftKey = event.shiftKey;
-    const isSinglePrimarySelection =
-      selectedFile?.path === file.path &&
-      selectedFiles.length === 1 &&
-      selectedFiles[0] === file.path;
+  const handleFileSelect = useCallback(
+    (
+      file: FileItem,
+      event: React.MouseEvent<HTMLElement>,
+      options?: { allowRename?: boolean }
+    ) => {
+      const allowRename = options?.allowRename !== false;
+      const toggleKey = hasToggleModifier(event);
+      const shiftKey = event.shiftKey;
+      const isSinglePrimarySelection =
+        selectedFile?.path === file.path &&
+        selectedFiles.length === 1 &&
+        selectedFiles[0] === file.path;
 
-    if (allowRename && !toggleKey && !shiftKey && isSinglePrimarySelection) {
-      if (clickTimeoutRef.current) {
+      if (allowRename && !toggleKey && !shiftKey && isSinglePrimarySelection) {
+        if (clickTimeoutRef.current) {
+          return;
+        }
+
+        lastClickedPathRef.current = file.path;
+        clickTimeoutRef.current = setTimeout(() => {
+          if (onRenameRequest && lastClickedPathRef.current === file.path) {
+            onRenameRequest(file);
+          }
+          clickTimeoutRef.current = null;
+        }, 600);
+
         return;
       }
 
-      lastClickedPathRef.current = file.path;
-      clickTimeoutRef.current = setTimeout(() => {
-        if (onRenameRequest && lastClickedPathRef.current === file.path) {
-          onRenameRequest(file);
-        }
+      if (clickTimeoutRef.current) {
+        clearTimeout(clickTimeoutRef.current);
         clickTimeoutRef.current = null;
-      }, 600);
+      }
 
-      return;
-    }
+      lastClickedPathRef.current = file.path;
+      const nextSelection = resolveMultiSelection({
+        orderedIds: orderedPaths,
+        currentSelectedIds: selectedFiles,
+        clickedId: file.path,
+        anchorId:
+          selectionAnchorPath || selectedFile?.path || selectedFiles[0] || null,
+        modifiers: {
+          shiftKey,
+          toggleKey,
+        },
+      });
 
-    if (clickTimeoutRef.current) {
-      clearTimeout(clickTimeoutRef.current);
-      clickTimeoutRef.current = null;
-    }
+      applySelection(
+        nextSelection.selectedIds,
+        nextSelection.primaryId,
+        nextSelection.anchorId
+      );
+    },
+    [
+      applySelection,
+      onRenameRequest,
+      orderedPaths,
+      selectedFile?.path,
+      selectedFiles,
+      selectionAnchorPath,
+    ]
+  );
 
-    lastClickedPathRef.current = file.path;
-    const nextSelection = resolveMultiSelection({
-      orderedIds: orderedPaths,
-      currentSelectedIds: selectedFiles,
-      clickedId: file.path,
-      anchorId:
-        selectionAnchorPath || selectedFile?.path || selectedFiles[0] || null,
-      modifiers: {
-        shiftKey,
-        toggleKey,
-      },
-    });
-
-    applySelection(
-      nextSelection.selectedIds,
-      nextSelection.primaryId,
-      nextSelection.anchorId
-    );
-  };
-
-  const handleDragStart = (e: React.DragEvent<HTMLElement>, file: FileItem) => {
+  const handleDragStart = useCallback((e: React.DragEvent<HTMLElement>, file: FileItem) => {
     if (file.isDirectory) {
       e.preventDefault();
       return;
@@ -348,9 +361,9 @@ export function useFileList({
         document.body.removeChild(dragImage);
       }
     }, 0);
-  };
+  }, [isMacOSXTheme, isXpTheme, viewType]);
 
-  const handleDragOver = (e: React.DragEvent<HTMLElement>, file: FileItem) => {
+  const handleDragOver = useCallback((e: React.DragEvent<HTMLElement>, file: FileItem) => {
     if (
       file.isDirectory &&
       canDropFiles &&
@@ -360,13 +373,13 @@ export function useFileList({
       e.preventDefault();
       setDropTargetPath(file.path);
     }
-  };
+  }, [canDropFiles]);
 
-  const handleDragLeave = () => {
+  const handleDragLeave = useCallback(() => {
     setDropTargetPath(null);
-  };
+  }, []);
 
-  const handleDrop = (
+  const handleDrop = useCallback((
     e: React.DragEvent<HTMLElement>,
     targetFolder: FileItem
   ) => {
@@ -389,14 +402,14 @@ export function useFileList({
 
     onFileDrop(draggedFileRef.current, targetFolder);
     draggedFileRef.current = null;
-  };
+  }, [onFileDrop]);
 
-  const handleDragEnd = () => {
+  const handleDragEnd = useCallback(() => {
     draggedFileRef.current = null;
     setDropTargetPath(null);
-  };
+  }, []);
 
-  const handleContainerDragOver = (e: React.DragEvent<HTMLElement>) => {
+  const handleContainerDragOver = useCallback((e: React.DragEvent<HTMLElement>) => {
     if (
       canDropFiles &&
       draggedFileRef.current &&
@@ -404,11 +417,11 @@ export function useFileList({
     ) {
       e.preventDefault();
     }
-  };
+  }, [canDropFiles, currentPath]);
 
-  const handleContainerDragLeave = () => {};
+  const handleContainerDragLeave = useCallback(() => {}, []);
 
-  const handleContainerDrop = (e: React.DragEvent<HTMLElement>) => {
+  const handleContainerDrop = useCallback((e: React.DragEvent<HTMLElement>) => {
     e.preventDefault();
 
     if (dropTargetPath) {
@@ -425,13 +438,19 @@ export function useFileList({
     }
 
     draggedFileRef.current = null;
-  };
+  }, [currentPath, dropTargetPath, onDropToCurrentDirectory]);
 
-  const getDisplayName = (file: FileItem): string => getFinderDisplayName(file);
-  const getListIconAlt = (file: FileItem): string =>
-    file.isDirectory
-      ? t("apps.finder.fileTypes.directory")
-      : t("apps.finder.fileTypes.file");
+  const getDisplayName = useCallback(
+    (file: FileItem): string => getFinderDisplayName(file),
+    []
+  );
+  const getListIconAlt = useCallback(
+    (file: FileItem): string =>
+      file.isDirectory
+        ? t("apps.finder.fileTypes.directory")
+        : t("apps.finder.fileTypes.file"),
+    [t]
+  );
 
   const renderedSelectionRect =
     selectionRect &&
@@ -450,20 +469,37 @@ export function useFileList({
         }
       : null;
 
-  const containerDragHandlers = {
-    onDragOver: handleContainerDragOver,
-    onDragLeave: handleContainerDragLeave,
-    onDrop: handleContainerDrop,
-    onMouseDown: handleBlankMouseDown,
-  };
+  const containerDragHandlers = useMemo(
+    () => ({
+      onDragOver: handleContainerDragOver,
+      onDragLeave: handleContainerDragLeave,
+      onDrop: handleContainerDrop,
+      onMouseDown: handleBlankMouseDown,
+    }),
+    [
+      handleBlankMouseDown,
+      handleContainerDragLeave,
+      handleContainerDragOver,
+      handleContainerDrop,
+    ]
+  );
 
-  const itemDragHandlers = {
-    onDragStart: handleDragStart,
-    onDragOver: handleDragOver,
-    onDragLeave: handleDragLeave,
-    onDrop: handleDrop,
-    onDragEnd: handleDragEnd,
-  };
+  const itemDragHandlers = useMemo(
+    () => ({
+      onDragStart: handleDragStart,
+      onDragOver: handleDragOver,
+      onDragLeave: handleDragLeave,
+      onDrop: handleDrop,
+      onDragEnd: handleDragEnd,
+    }),
+    [
+      handleDragEnd,
+      handleDragLeave,
+      handleDragOver,
+      handleDragStart,
+      handleDrop,
+    ]
+  );
 
   return {
     files,

--- a/src/components/layout/MenuBar.tsx
+++ b/src/components/layout/MenuBar.tsx
@@ -13,20 +13,8 @@ export type { MenuBarProps } from "./menu-bar/menuBarTypes";
 
 export function MenuBar({ children, inWindowFrame = false }: MenuBarProps) {
   const apps: AnyApp[] = useMemo(() => Object.values(appRegistry), []);
-  const {
-    instances,
-    bringInstanceToForeground,
-    restoreInstance,
-    foregroundInstanceId,
-  } = useAppStoreShallow((s) => ({
-    instances: s.instances,
-    bringInstanceToForeground: s.bringInstanceToForeground,
-    restoreInstance: s.restoreInstance,
-    foregroundInstanceId: s.foregroundInstanceId,
-  }));
 
   const { currentTheme, isWindowsTheme: isXpTheme } = useThemeFlags();
-  const getFileItem = useFilesStore((s) => s.getItem);
 
   if (inWindowFrame && isXpTheme) {
     return (
@@ -49,13 +37,8 @@ export function MenuBar({ children, inWindowFrame = false }: MenuBarProps) {
 
   if (isXpTheme && !inWindowFrame) {
     return (
-      <WindowsTaskbar
+      <WindowsTaskbarWithState
         apps={apps}
-        instances={instances}
-        foregroundInstanceId={foregroundInstanceId}
-        bringInstanceToForeground={bringInstanceToForeground}
-        restoreInstance={restoreInstance}
-        getFileItem={getFileItem}
         currentTheme={currentTheme}
         isXpTheme={isXpTheme}
       />
@@ -63,4 +46,40 @@ export function MenuBar({ children, inWindowFrame = false }: MenuBarProps) {
   }
 
   return <MacTopMenuBar>{children}</MacTopMenuBar>;
+}
+
+function WindowsTaskbarWithState({
+  apps,
+  currentTheme,
+  isXpTheme,
+}: {
+  apps: AnyApp[];
+  currentTheme: string;
+  isXpTheme: boolean;
+}) {
+  const {
+    instances,
+    bringInstanceToForeground,
+    restoreInstance,
+    foregroundInstanceId,
+  } = useAppStoreShallow((s) => ({
+    instances: s.instances,
+    bringInstanceToForeground: s.bringInstanceToForeground,
+    restoreInstance: s.restoreInstance,
+    foregroundInstanceId: s.foregroundInstanceId,
+  }));
+  const getFileItem = useFilesStore((s) => s.getItem);
+
+  return (
+    <WindowsTaskbar
+      apps={apps}
+      instances={instances}
+      foregroundInstanceId={foregroundInstanceId}
+      bringInstanceToForeground={bringInstanceToForeground}
+      restoreInstance={restoreInstance}
+      getFileItem={getFileItem}
+      currentTheme={currentTheme}
+      isXpTheme={isXpTheme}
+    />
+  );
 }

--- a/src/components/layout/menu-bar/ScrollableMenuWrapper.tsx
+++ b/src/components/layout/menu-bar/ScrollableMenuWrapper.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef, useCallback } from "react";
+import React, { useState, useEffect, useRef, useCallback, useMemo } from "react";
 import { useIsPhone } from "@/hooks/useIsPhone";
 
 const ScrollingContext = React.createContext<{
@@ -8,6 +8,11 @@ const ScrollingContext = React.createContext<{
   isScrolling: false,
   preventInteraction: () => false,
 });
+
+const NON_SCROLLING_CONTEXT_VALUE = {
+  isScrolling: false,
+  preventInteraction: () => false,
+};
 
 export function ScrollableMenuWrapper({ children }: { children: React.ReactNode }) {
   const isPhone = useIsPhone();
@@ -95,9 +100,7 @@ export function ScrollableMenuWrapper({ children }: { children: React.ReactNode 
   const canScrollLeft = scrollLeft > 0;
   const canScrollRight = scrollLeft < scrollWidth - clientWidth - 1;
 
-  // Calculate mask gradients based on scroll position
-  // In CSS masks: black = visible, transparent = hidden
-  const getMaskImage = () => {
+  const maskImage = useMemo(() => {
     if (!isPhone || scrollWidth <= clientWidth) {
       return undefined;
     }
@@ -115,7 +118,7 @@ export function ScrollableMenuWrapper({ children }: { children: React.ReactNode 
       return `linear-gradient(to right, black 0%, black calc(100% - ${fadeWidth}px), transparent 100%)`;
     }
     return undefined;
-  };
+  }, [canScrollLeft, canScrollRight, clientWidth, isPhone, scrollWidth]);
 
   const handleTouchStart = useCallback((e: React.TouchEvent) => {
     const touch = e.touches[0];
@@ -154,9 +157,17 @@ export function ScrollableMenuWrapper({ children }: { children: React.ReactNode 
     }
   }, []);
 
+  const scrollingContextValue = useMemo(
+    () => ({
+      isScrolling: hadRecentScrollRef.current,
+      preventInteraction,
+    }),
+    [preventInteraction, scrollLeft, scrollWidth, clientWidth]
+  );
+
   if (!isPhone) {
     return (
-      <ScrollingContext.Provider value={{ isScrolling: false, preventInteraction: () => false }}>
+      <ScrollingContext.Provider value={NON_SCROLLING_CONTEXT_VALUE}>
         <div className="flex items-stretch h-full">
           {children}
         </div>
@@ -165,7 +176,7 @@ export function ScrollableMenuWrapper({ children }: { children: React.ReactNode 
   }
 
   return (
-    <ScrollingContext.Provider value={{ isScrolling: hadRecentScrollRef.current, preventInteraction }}>
+    <ScrollingContext.Provider value={scrollingContextValue}>
       <div
         ref={scrollRef}
         onScroll={handleScroll}
@@ -175,8 +186,8 @@ export function ScrollableMenuWrapper({ children }: { children: React.ReactNode 
           overscrollBehaviorX: "contain",
           scrollbarWidth: "none",
           msOverflowStyle: "none",
-          maskImage: getMaskImage(),
-          WebkitMaskImage: getMaskImage(),
+          maskImage,
+          WebkitMaskImage: maskImage,
           touchAction: "pan-x",
         }}
         onTouchStart={handleTouchStart}

--- a/src/config/appRegistry.tsx
+++ b/src/config/appRegistry.tsx
@@ -2,6 +2,7 @@ import { resolveAppId, type AppId } from "./appRegistryData";
 import type {
   BaseApp,
   ControlPanelsInitialData,
+  FinderInitialData,
   InternetExplorerInitialData,
   IpodInitialData,
   PaintInitialData,
@@ -38,7 +39,7 @@ const defaultWindowConstraints: WindowConstraints = {
 
 // Lazy-loaded apps (loaded on-demand when opened)
 // Each uses a cache key to maintain stable references across HMR
-const LazyFinderApp = createLazyComponent<unknown>(
+const LazyFinderApp = createLazyComponent<FinderInitialData>(
   () => import("@/apps/finder/components/finder-app/FinderAppComponent").then(m => ({ default: m.FinderAppComponent })),
   "finder"
 );

--- a/src/config/appRegistry.tsx
+++ b/src/config/appRegistry.tsx
@@ -36,12 +36,13 @@ const defaultWindowConstraints: WindowConstraints = {
 // LAZY-LOADED APP COMPONENTS
 // ============================================================================
 
-// Critical apps (load immediately for perceived performance)
-// Finder is critical - users see it on desktop
-import { FinderAppComponent } from "@/apps/finder/components/finder-app/FinderAppComponent";
-
 // Lazy-loaded apps (loaded on-demand when opened)
 // Each uses a cache key to maintain stable references across HMR
+const LazyFinderApp = createLazyComponent<unknown>(
+  () => import("@/apps/finder/components/finder-app/FinderAppComponent").then(m => ({ default: m.FinderAppComponent })),
+  "finder"
+);
+
 const LazyTextEditApp = createLazyComponent<unknown>(
   () => import("@/apps/textedit/components/TextEditAppComponent").then(m => ({ default: m.TextEditAppComponent })),
   "textedit"
@@ -212,7 +213,7 @@ export const appRegistry = {
     name: "Finder",
     icon: { type: "image", src: "/icons/mac.png" },
     description: "Browse and manage files",
-    component: FinderAppComponent, // Critical - loaded eagerly
+    component: LazyFinderApp,
     helpItems: finderHelpItems,
     metadata: finderMetadata,
     windowConfig: {

--- a/src/config/lazyAppComponent.tsx
+++ b/src/config/lazyAppComponent.tsx
@@ -29,6 +29,18 @@ export function prefetchLikelyAppChunks(appIds: readonly string[]): void {
   }
 }
 
+function LazyAppFallback({ title }: { title?: string }) {
+  return (
+    <div
+      className="pointer-events-auto flex min-h-[180px] w-[320px] max-w-[calc(100vw-2rem)] items-center justify-center rounded-md border border-black/20 bg-white/90 p-4 text-sm text-neutral-700 shadow-xl backdrop-blur"
+      role="status"
+      aria-live="polite"
+    >
+      Loading {title || "app"}...
+    </div>
+  );
+}
+
 // Helper to create a lazy-loaded component with Suspense
 // Uses a cache to maintain stable component references across HMR
 export function createLazyComponent<T = unknown>(
@@ -47,7 +59,7 @@ export function createLazyComponent<T = unknown>(
 
   // Wrap with Suspense to handle loading state
   const WrappedComponent = (props: AppProps<T>) => (
-    <Suspense fallback={null}>
+    <Suspense fallback={<LazyAppFallback title={props.title} />}>
       <LazyComponent {...props} />
       <LazyLoadSignal instanceId={props.instanceId} />
     </Suspense>

--- a/src/config/lazyAppComponent.tsx
+++ b/src/config/lazyAppComponent.tsx
@@ -29,18 +29,6 @@ export function prefetchLikelyAppChunks(appIds: readonly string[]): void {
   }
 }
 
-function LazyAppFallback({ title }: { title?: string }) {
-  return (
-    <div
-      className="pointer-events-auto flex min-h-[180px] w-[320px] max-w-[calc(100vw-2rem)] items-center justify-center rounded-md border border-black/20 bg-white/90 p-4 text-sm text-neutral-700 shadow-xl backdrop-blur"
-      role="status"
-      aria-live="polite"
-    >
-      Loading {title || "app"}...
-    </div>
-  );
-}
-
 // Helper to create a lazy-loaded component with Suspense
 // Uses a cache to maintain stable component references across HMR
 export function createLazyComponent<T = unknown>(
@@ -59,7 +47,7 @@ export function createLazyComponent<T = unknown>(
 
   // Wrap with Suspense to handle loading state
   const WrappedComponent = (props: AppProps<T>) => (
-    <Suspense fallback={<LazyAppFallback title={props.title} />}>
+    <Suspense fallback={null}>
       <LazyComponent {...props} />
       <LazyLoadSignal instanceId={props.instanceId} />
     </Suspense>

--- a/src/hooks/useLaunchApp.ts
+++ b/src/hooks/useLaunchApp.ts
@@ -1,3 +1,4 @@
+import { useCallback } from "react";
 import { useAppStore, LaunchOriginRect } from "@/stores/useAppStore";
 import { AppId } from "@/config/appRegistry";
 
@@ -10,9 +11,7 @@ export interface LaunchAppOptions {
 }
 
 export const useLaunchApp = () => {
-  // Get the launch method and instances from the store
   const launchAppInstance = useAppStore((state) => state.launchApp);
-  const instances = useAppStore((state) => state.instances);
   const bringInstanceToForeground = useAppStore(
     (state) => state.bringInstanceToForeground
   );
@@ -21,166 +20,191 @@ export const useLaunchApp = () => {
     (state) => state.updateInstanceInitialData
   );
 
-  const launchApp = (appId: AppId, options?: LaunchAppOptions) => {
-    console.log(`[useLaunchApp] Launch event received for ${appId}`, options);
+  const launchApp = useCallback(
+    (appId: AppId, options?: LaunchAppOptions) => {
+      console.log(`[useLaunchApp] Launch event received for ${appId}`, options);
+      const { instances } = useAppStore.getState();
 
-    // Convert initialPath to proper initialData for Finder
-    let initialData = options?.initialData;
-    if (appId === "finder" && options?.initialPath && !initialData) {
-      initialData = { path: options.initialPath };
-    }
+      // Convert initialPath to proper initialData for Finder
+      let initialData = options?.initialData;
+      if (appId === "finder" && options?.initialPath && !initialData) {
+        initialData = { path: options.initialPath };
+      }
 
-    // Special handling for applet-viewer
-    if (appId === "applet-viewer") {
-      const appletInstances = Object.values(instances).filter(
-        (inst) => inst.appId === "applet-viewer" && inst.isOpen
+      // Special handling for applet-viewer
+      if (appId === "applet-viewer") {
+        const appletInstances = Object.values(instances).filter(
+          (inst) => inst.appId === "applet-viewer" && inst.isOpen
+        );
+
+        // If launching with content (initialData exists)
+        if (initialData) {
+          const data = initialData as {
+            path?: string;
+            content?: string;
+            shareCode?: string;
+            forceNewInstance?: boolean;
+          };
+
+          // Skip empty instance check if forceNewInstance is true
+          if (!data.forceNewInstance) {
+            // First, check if the same applet (by path or shareCode) is already open
+            if (data.path || data.shareCode) {
+              const existingInstance = appletInstances.find((inst) => {
+                const instData = inst.initialData as
+                  | { path?: string; content?: string; shareCode?: string }
+                  | undefined;
+
+                // Check by path if provided
+                if (data.path && instData?.path === data.path) {
+                  return true;
+                }
+
+                // Check by shareCode if provided
+                if (data.shareCode && instData?.shareCode === data.shareCode) {
+                  return true;
+                }
+
+                return false;
+              });
+
+              if (existingInstance) {
+                // Same applet already open, bring it to foreground
+                const identifier = data.path || data.shareCode;
+                console.log(
+                  `[useLaunchApp] Applet with ${data.path ? 'path' : 'shareCode'} ${identifier} already open in instance ${existingInstance.instanceId}, bringing to foreground`
+                );
+                bringInstanceToForeground(existingInstance.instanceId);
+                // Refresh initialData so persisted instances (whose content was
+                // stripped to "" for storage) pick up the freshly loaded content.
+                if (data.content) {
+                  updateInstanceInitialData(
+                    existingInstance.instanceId,
+                    initialData
+                  );
+                }
+                return existingInstance.instanceId;
+              }
+              // If opening a specific applet that's not already open, create a new instance
+              // (don't reuse empty instances for different applets)
+            } else {
+              // Opening applet store (no path, no shareCode) - can reuse empty instance
+              const emptyInstance = appletInstances.find((inst) => {
+                const instData = inst.initialData as
+                  | { path?: string; content?: string; shareCode?: string }
+                  | undefined;
+                // Empty instance is one without path, content, or shareCode
+                return (
+                  !instData?.path &&
+                  !instData?.content &&
+                  !instData?.shareCode
+                );
+              });
+
+              if (emptyInstance) {
+                // Reuse the empty applet store instance
+                console.log(
+                  `[useLaunchApp] Found empty applet store instance ${emptyInstance.instanceId}, reusing`
+                );
+                bringInstanceToForeground(emptyInstance.instanceId);
+                return emptyInstance.instanceId;
+              }
+            }
+          }
+        } else {
+          // Launching empty state - check if there's already an applet store window (empty instance)
+          const appletStoreInstance = appletInstances.find((inst) => {
+            const instData = inst.initialData as
+              | { path?: string; content?: string; shareCode?: string }
+              | undefined;
+            // An applet store window is one without path, content, or shareCode
+            return (
+              !instData?.path &&
+              !instData?.content &&
+              !instData?.shareCode
+            );
+          });
+
+          if (appletStoreInstance) {
+            // Bring the applet store window to foreground
+            console.log(
+              `[useLaunchApp] Found existing applet store window ${appletStoreInstance.instanceId}, bringing to foreground`
+            );
+            bringInstanceToForeground(appletStoreInstance.instanceId);
+            return appletStoreInstance.instanceId;
+          }
+
+          // If no applet store window exists, create a new one
+          // (fall through to the launchAppInstance call below)
+          console.log(
+            `[useLaunchApp] No applet store window found, creating new one`
+          );
+        }
+      }
+
+      // Check if all instances of this app are minimized
+      // If so, restore them instead of creating a new instance
+      const appInstances = Object.values(instances).filter(
+        (inst) => inst.appId === appId && inst.isOpen
       );
 
-      // If launching with content (initialData exists)
-      if (initialData) {
-        const data = initialData as { path?: string; content?: string; shareCode?: string; forceNewInstance?: boolean };
-        
-        // Skip empty instance check if forceNewInstance is true
-        if (!data.forceNewInstance) {
-          // First, check if the same applet (by path or shareCode) is already open
-          if (data.path || data.shareCode) {
-            const existingInstance = appletInstances.find((inst) => {
-              const instData = inst.initialData as
-                | { path?: string; content?: string; shareCode?: string }
-                | undefined;
-              
-              // Check by path if provided
-              if (data.path && instData?.path === data.path) {
-                return true;
-              }
-              
-              // Check by shareCode if provided
-              if (data.shareCode && instData?.shareCode === data.shareCode) {
-                return true;
-              }
-              
-              return false;
-            });
+      if (appInstances.length > 0) {
+        // Check if all instances are minimized
+        const allMinimized = appInstances.every((inst) => inst.isMinimized);
 
-            if (existingInstance) {
-              // Same applet already open, bring it to foreground
-              const identifier = data.path || data.shareCode;
-              console.log(
-                `[useLaunchApp] Applet with ${data.path ? 'path' : 'shareCode'} ${identifier} already open in instance ${existingInstance.instanceId}, bringing to foreground`
-              );
-              bringInstanceToForeground(existingInstance.instanceId);
-              // Refresh initialData so persisted instances (whose content was
-              // stripped to "" for storage) pick up the freshly loaded content.
-              if (data.content) {
-                updateInstanceInitialData(existingInstance.instanceId, initialData);
-              }
-              return existingInstance.instanceId;
+        if (allMinimized) {
+          // Restore all minimized instances
+          let lastRestoredId: string | null = null;
+          appInstances.forEach((inst) => {
+            if (inst.isMinimized) {
+              restoreInstance(inst.instanceId);
+              lastRestoredId = inst.instanceId;
             }
-            // If opening a specific applet that's not already open, create a new instance
-            // (don't reuse empty instances for different applets)
-          } else {
-            // Opening applet store (no path, no shareCode) - can reuse empty instance
-            const emptyInstance = appletInstances.find((inst) => {
-              const instData = inst.initialData as
-                | { path?: string; content?: string; shareCode?: string }
-                | undefined;
-              // Empty instance is one without path, content, or shareCode
-              return !instData?.path && !instData?.content && !instData?.shareCode;
-            });
+          });
 
-            if (emptyInstance) {
-              // Reuse the empty applet store instance
-              console.log(
-                `[useLaunchApp] Found empty applet store instance ${emptyInstance.instanceId}, reusing`
-              );
-              bringInstanceToForeground(emptyInstance.instanceId);
-              return emptyInstance.instanceId;
+          // Bring the most recently restored instance to foreground
+          if (lastRestoredId) {
+            console.log(
+              `[useLaunchApp] All instances of ${appId} were minimized, restored and bringing ${lastRestoredId} to foreground`
+            );
+            bringInstanceToForeground(lastRestoredId);
+            // Update initialData if provided (e.g. pre-fill commands from Spotlight)
+            if (initialData) {
+              updateInstanceInitialData(lastRestoredId, initialData);
             }
+            return lastRestoredId;
           }
-        }
-      } else {
-        // Launching empty state - check if there's already an applet store window (empty instance)
-        const appletStoreInstance = appletInstances.find((inst) => {
-          const instData = inst.initialData as
-            | { path?: string; content?: string; shareCode?: string }
-            | undefined;
-          // An applet store window is one without path, content, or shareCode
-          return !instData?.path && !instData?.content && !instData?.shareCode;
-        });
-        
-        if (appletStoreInstance) {
-          // Bring the applet store window to foreground
-          console.log(
-            `[useLaunchApp] Found existing applet store window ${appletStoreInstance.instanceId}, bringing to foreground`
-          );
-          bringInstanceToForeground(appletStoreInstance.instanceId);
-          return appletStoreInstance.instanceId;
-        }
-        
-        // If no applet store window exists, create a new one
-        // (fall through to the launchAppInstance call below)
-        console.log(
-          `[useLaunchApp] No applet store window found, creating new one`
-        );
-      }
-    }
-
-    // Check if all instances of this app are minimized
-    // If so, restore them instead of creating a new instance
-    const appInstances = Object.values(instances).filter(
-      (inst) => inst.appId === appId && inst.isOpen
-    );
-    
-    if (appInstances.length > 0) {
-      // Check if all instances are minimized
-      const allMinimized = appInstances.every((inst) => inst.isMinimized);
-      
-      if (allMinimized) {
-        // Restore all minimized instances
-        let lastRestoredId: string | null = null;
-        appInstances.forEach((inst) => {
-          if (inst.isMinimized) {
-            restoreInstance(inst.instanceId);
-            lastRestoredId = inst.instanceId;
-          }
-        });
-        
-        // Bring the most recently restored instance to foreground
-        if (lastRestoredId) {
-          console.log(
-            `[useLaunchApp] All instances of ${appId} were minimized, restored and bringing ${lastRestoredId} to foreground`
-          );
-          bringInstanceToForeground(lastRestoredId);
-          // Update initialData if provided (e.g. pre-fill commands from Spotlight)
-          if (initialData) {
-            updateInstanceInitialData(lastRestoredId, initialData);
-          }
-          return lastRestoredId;
         }
       }
-    }
 
-    // Always use multi-window for apps that support it
-    const multiWindow =
-      options?.multiWindow ||
-      appId === "finder" ||
-      appId === "textedit" ||
-      appId === "applet-viewer";
+      // Always use multi-window for apps that support it
+      const multiWindow =
+        options?.multiWindow ||
+        appId === "finder" ||
+        appId === "textedit" ||
+        appId === "applet-viewer";
 
-    // Use the new instance-based launch system
-    const instanceId = launchAppInstance(
-      appId,
-      initialData,
-      undefined,
-      multiWindow,
-      options?.launchOrigin
-    );
-    console.log(
-      `[useLaunchApp] Created instance ${instanceId} for app ${appId} with multiWindow: ${multiWindow}`
-    );
+      // Use the new instance-based launch system
+      const instanceId = launchAppInstance(
+        appId,
+        initialData,
+        undefined,
+        multiWindow,
+        options?.launchOrigin
+      );
+      console.log(
+        `[useLaunchApp] Created instance ${instanceId} for app ${appId} with multiWindow: ${multiWindow}`
+      );
 
-    return instanceId;
-  };
+      return instanceId;
+    },
+    [
+      bringInstanceToForeground,
+      launchAppInstance,
+      restoreInstance,
+      updateInstanceInitialData,
+    ]
+  );
 
   return launchApp;
 };

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -34,6 +34,8 @@ const localeLoaders: Partial<Record<SupportedLanguage, LocaleLoader>> = {
 const loadingLanguages = new Map<SupportedLanguage, Promise<void>>();
 
 let initializePromise: Promise<void> | null = null;
+let defaultInitPromise: Promise<void> | null = null;
+let initialLanguagePromise: Promise<void> | null = null;
 let hasBoundLanguageSync = false;
 let latestApplyRequestId = 0;
 
@@ -67,6 +69,47 @@ const setLanguageOnI18n = async (language: SupportedLanguage): Promise<void> => 
 
   await i18n.changeLanguage(language);
   syncDocumentLanguage(language);
+};
+
+const initializeDefaultI18n = async (): Promise<void> => {
+  if (defaultInitPromise) {
+    return defaultInitPromise;
+  }
+
+  defaultInitPromise = (async () => {
+    if (!i18n.isInitialized) {
+      await i18n.use(initReactI18next).init({
+        resources,
+        lng: DEFAULT_LANGUAGE,
+        fallbackLng: DEFAULT_LANGUAGE,
+        defaultNS: "translation",
+        ns: ["translation"],
+        initImmediate: false,
+        interpolation: {
+          escapeValue: false, // React already escapes values
+        },
+      });
+    }
+
+    bindLanguageSync();
+    syncDocumentLanguage(getCurrentLanguage());
+  })();
+
+  return defaultInitPromise;
+};
+
+const applyInitialLanguage = async (): Promise<void> => {
+  if (initialLanguagePromise) {
+    return initialLanguagePromise;
+  }
+
+  initialLanguagePromise = (async () => {
+    const initialLanguage = resolveInitialLanguage();
+    await ensureLanguageResources(initialLanguage);
+    await setLanguageOnI18n(initialLanguage);
+  })();
+
+  return initialLanguagePromise;
 };
 
 export async function ensureLanguageResources(
@@ -117,27 +160,18 @@ export async function initializeI18n(): Promise<void> {
   }
 
   initializePromise = (async () => {
-    if (!i18n.isInitialized) {
-      await i18n.use(initReactI18next).init({
-        resources,
-        lng: DEFAULT_LANGUAGE,
-        fallbackLng: DEFAULT_LANGUAGE,
-        defaultNS: "translation",
-        ns: ["translation"],
-        interpolation: {
-          escapeValue: false, // React already escapes values
-        },
-      });
-    }
-
-    bindLanguageSync();
-
-    const initialLanguage = resolveInitialLanguage();
-    await ensureLanguageResources(initialLanguage);
-    await setLanguageOnI18n(initialLanguage);
+    await initializeDefaultI18n();
+    await applyInitialLanguage();
   })();
 
   return initializePromise;
+}
+
+export async function initializeI18nForFirstPaint(): Promise<void> {
+  await initializeDefaultI18n();
+  void applyInitialLanguage().catch((error) => {
+    console.error("[ryOS] Failed to apply initial language:", error);
+  });
 }
 
 export async function applyLanguage(

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -7,7 +7,7 @@ import { useLanguageStore } from "./stores/useLanguageStore";
 import { preloadFileSystemData } from "./stores/useFilesStore";
 import { preloadIpodData } from "./stores/useIpodStore";
 import { initPrefetch } from "./utils/prefetch";
-import { initializeI18n } from "./lib/i18n";
+import { initializeI18nForFirstPaint } from "./lib/i18n";
 import { primeReactResources } from "./lib/reactResources";
 import { initializeAnalytics, track, SYSTEM_ANALYTICS } from "./utils/analytics";
 import {
@@ -144,7 +144,7 @@ const bootstrap = async () => {
   useThemeStore.getState().hydrate();
 
   try {
-    await initializeI18n();
+    await initializeI18nForFirstPaint();
   } catch (error) {
     console.error("[ryOS] Failed to initialize i18n during bootstrap:", error);
   }

--- a/src/stores/useAppStore.ts
+++ b/src/stores/useAppStore.ts
@@ -284,9 +284,8 @@ const createUseAppStore = () =>
             }
           }
 
-          // Check if app is lazy (most are, except Finder which is critical)
-          // We can assume non-Finder apps might need loading time
-          const isLazy = appId !== "finder";
+          // All app components are chunk-loaded so the shell can paint first.
+          const isLazy = true;
 
           const instances = {
             ...state.instances,
@@ -353,7 +352,7 @@ const createUseAppStore = () =>
               detail: {
                 instanceId: createdId,
                 isOpen: true,
-                isForeground: appId === "finder", // Only finder is foreground immediately
+                isForeground: false,
               },
             })
           );

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,10 +1,11 @@
-import { defineConfig } from "vite";
+import { defineConfig, type ViteDevServer } from "vite";
 import react from "@vitejs/plugin-react-swc";
 import tailwindcss from "@tailwindcss/vite";
 import { VitePWA } from "vite-plugin-pwa";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { readFileSync, existsSync } from "node:fs";
+import type { IncomingMessage, ServerResponse } from "node:http";
 
 // Polyfill __dirname in ESM context (Node >=16)
 const __filename = fileURLToPath(import.meta.url);
@@ -33,6 +34,24 @@ function readBuildNumber(): string {
 }
 
 const ryosBuildNumber = readBuildNumber();
+
+const devServiceWorkerResetScript = `
+self.addEventListener("install", (event) => {
+  self.skipWaiting();
+});
+
+self.addEventListener("activate", (event) => {
+  event.waitUntil((async () => {
+    if (self.caches) {
+      const keys = await self.caches.keys();
+      await Promise.all(keys.map((key) => self.caches.delete(key)));
+    }
+    await self.registration.unregister();
+    const clients = await self.clients.matchAll({ type: "window" });
+    await Promise.all(clients.map((client) => client.navigate(client.url)));
+  })());
+});
+`;
 
 // ---------------------------------------------------------------------------
 // Curated Workbox precache
@@ -224,6 +243,36 @@ export default defineConfig({
     ] : [],
   },
   plugins: [
+    // Replace any production service worker left on localhost with a tiny
+    // cleanup worker so Vite dev sessions cannot be controlled by stale bundles.
+    ...(isDev
+      ? [
+          {
+            name: "serve-dev-service-worker-reset",
+            configureServer(server: ViteDevServer) {
+              server.middlewares.use((
+                req: IncomingMessage,
+                res: ServerResponse,
+                next: () => void
+              ) => {
+                const pathPart = (req.url || "").split("?")[0];
+                if (pathPart !== "/sw.js") {
+                  next();
+                  return;
+                }
+
+                res.statusCode = 200;
+                res.setHeader(
+                  "Content-Type",
+                  "application/javascript; charset=utf-8"
+                );
+                res.setHeader("Cache-Control", "no-store, max-age=0");
+                res.end(devServiceWorkerResetScript);
+              });
+            },
+          },
+        ]
+      : []),
     // Serve static docs HTML files (before SPA fallback kicks in)
     {
       name: 'serve-static-docs',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Lazy-load Finder while preserving the old no-placeholder launch behavior for lazy app chunks.
- Narrow app shell subscriptions so desktop/menu launch paths avoid unnecessary re-renders without unstable store snapshots.
- Defer non-default i18n locale chunk loading until after the first React paint.
- Stabilize Finder file-list handlers, FileIcon rendering, and menu scrolling context values.
- Add a Vite dev cleanup `/sw.js` response so stale production service workers do not control local dev sessions.

### Testing
- `bun run build` — passes; Finder emits as a separate lazy chunk.
- `bun run test:unit` — 257 tests pass.
- Playwright smoke test delayed the Finder lazy component request and confirmed no `Loading Finder...` / `Loading app...` placeholder appears before Finder renders.

![Finder opened without lazy loading placeholder](https://cursor.com/artifacts/c/art-0bb394da-f0ca-4e60-b201-47e8ba3f8237)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019e8081-1c3a-7df7-892e-dc987d393b52"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019e8081-1c3a-7df7-892e-dc987d393b52"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

