### PR TITLE
Hide app launch loading status

### DIFF
--- a/src/apps/terminal/components/TerminalToolInvocation.tsx
+++ b/src/apps/terminal/components/TerminalToolInvocation.tsx
@@ -7,6 +7,7 @@ import {
   formatToolName,
   getWebSearchSummary,
 } from "@/lib/toolInvocationDisplay";
+import { shouldSuppressToolInvocationCallMessage } from "@/components/shared/tool-invocation-message/getToolInvocationCallMessage";
 
 // Helper to get app name
 function getAppName(id?: string): string {
@@ -34,6 +35,9 @@ export function TerminalToolInvocation({
 
   // Handle loading states (input-streaming or input-available, or any state that's not output-available/output-error)
   const isLoading = !state || state === "input-streaming" || state === "input-available";
+  if (isLoading && shouldSuppressToolInvocationCallMessage(toolName, input)) {
+    return null;
+  }
   
   if (isLoading) {
     switch (toolName) {

--- a/src/components/shared/tool-invocation-message/ToolInvocationMessage.tsx
+++ b/src/components/shared/tool-invocation-message/ToolInvocationMessage.tsx
@@ -1,5 +1,8 @@
 import { useTranslation } from "react-i18next";
-import { getToolInvocationCallMessage } from "./getToolInvocationCallMessage";
+import {
+  getToolInvocationCallMessage,
+  shouldSuppressToolInvocationCallMessage,
+} from "./getToolInvocationCallMessage";
 import { getToolInvocationResultMessage } from "./getToolInvocationResultMessage";
 import { tryRenderToolInvocationSpecialContent } from "./tryRenderToolInvocationSpecialContent";
 import { ToolInvocationMessageDefaultView } from "./ToolInvocationMessageDefaultView";
@@ -19,6 +22,15 @@ export function ToolInvocationMessage({
   const { t } = useTranslation();
   const toolName = getToolName(part);
   const { state, input, output } = part;
+  const isPendingToolCall =
+    state === "input-streaming" || (state === "input-available" && !output);
+
+  if (
+    isPendingToolCall &&
+    shouldSuppressToolInvocationCallMessage(toolName, input)
+  ) {
+    return null;
+  }
 
   const displayCallMessage = getToolInvocationCallMessage({
     toolName,

--- a/src/components/shared/tool-invocation-message/getToolInvocationCallMessage.ts
+++ b/src/components/shared/tool-invocation-message/getToolInvocationCallMessage.ts
@@ -2,6 +2,26 @@ import type { TFunction } from "i18next";
 import { getSongLibraryCallSummary } from "@/lib/toolInvocationDisplay";
 import type { ToolInvocationPart } from "./types";
 
+type ToolInvocationInput = { path?: unknown; [key: string]: unknown };
+
+export function shouldSuppressToolInvocationCallMessage(
+  toolName: string,
+  input?: ToolInvocationInput
+): boolean {
+  if (toolName === "launchApp") {
+    return true;
+  }
+
+  if (toolName === "open") {
+    return (
+      typeof input?.path === "string" &&
+      input.path.startsWith("/Applications/")
+    );
+  }
+
+  return false;
+}
+
 export function getToolInvocationCallMessage(
   params: {
     toolName: string;

--- a/tests/test-tool-invocation-display.test.ts
+++ b/tests/test-tool-invocation-display.test.ts
@@ -5,8 +5,23 @@ import {
   getSongLibraryResultSummary,
   getWebSearchSummary,
 } from "../src/lib/toolInvocationDisplay";
+import { shouldSuppressToolInvocationCallMessage } from "../src/components/shared/tool-invocation-message/getToolInvocationCallMessage";
 
 describe("tool invocation display helpers", () => {
+  test("suppresses transient app launch loading rows", () => {
+    expect(shouldSuppressToolInvocationCallMessage("launchApp")).toBe(true);
+    expect(
+      shouldSuppressToolInvocationCallMessage("open", {
+        path: "/Applications/TextEdit.app",
+      })
+    ).toBe(true);
+    expect(
+      shouldSuppressToolInvocationCallMessage("open", {
+        path: "/Documents/Notes.txt",
+      })
+    ).toBe(false);
+  });
+
   test("formats underscored and camelCase tool names for display", () => {
     expect(formatToolName("web_search")).toBe("Web search");
     expect(formatToolName("calendarControl")).toBe("Calendar Control");

--- a/tests/test-tool-invocation-message-render.test.tsx
+++ b/tests/test-tool-invocation-message-render.test.tsx
@@ -1,0 +1,49 @@
+import React from "react";
+import { describe, expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+import { ToolInvocationMessage } from "../src/components/shared/ToolInvocationMessage";
+
+const defaultProps = {
+  partKey: "part-1",
+  isLoading: true,
+  getAppName: (id?: string) => id || "app",
+  formatToolName: (name: string) => name,
+  setIsInteractingWithPreview: () => {},
+  playElevatorMusic: () => {},
+  stopElevatorMusic: () => {},
+  playDingSound: () => {},
+};
+
+describe("ToolInvocationMessage rendering", () => {
+  test("renders nothing for pending app launch tool calls", () => {
+    const markup = renderToStaticMarkup(
+      <ToolInvocationMessage
+        {...defaultProps}
+        part={{
+          type: "tool-launchApp",
+          toolCallId: "call-1",
+          state: "input-available",
+          input: { id: "textedit" },
+        }}
+      />
+    );
+
+    expect(markup).toBe("");
+  });
+
+  test("still renders non-app loading tool calls", () => {
+    const markup = renderToStaticMarkup(
+      <ToolInvocationMessage
+        {...defaultProps}
+        part={{
+          type: "tool-read",
+          toolCallId: "call-2",
+          state: "input-available",
+          input: { path: "/Documents/Notes.txt" },
+        }}
+      />
+    );
+
+    expect(markup).toContain("apps.chats.toolCalls.readingFile");
+  });
+});

--- a/tests/test-tool-invocation-message-render.test.tsx
+++ b/tests/test-tool-invocation-message-render.test.tsx
@@ -5,7 +5,7 @@ import { renderToStaticMarkup } from "react-dom/server";
 const storage = new Map<string, string>();
 
 Object.defineProperty(globalThis, "navigator", {
-  value: { hardwareConcurrency: 4 },
+  value: { hardwareConcurrency: 4, userAgent: "Bun" },
   configurable: true,
 });
 
@@ -53,20 +53,4 @@ describe("ToolInvocationMessage rendering", () => {
     expect(markup).toBe("");
   });
 
-  test("still renders non-app loading tool calls", async () => {
-    const ToolInvocationMessage = await loadToolInvocationMessage();
-    const markup = renderToStaticMarkup(
-      <ToolInvocationMessage
-        {...defaultProps}
-        part={{
-          type: "tool-read",
-          toolCallId: "call-2",
-          state: "input-available",
-          input: { path: "/Documents/Notes.txt" },
-        }}
-      />
-    );
-
-    expect(markup).toContain("apps.chats.toolCalls.readingFile");
-  });
 });

--- a/tests/test-tool-invocation-message-render.test.tsx
+++ b/tests/test-tool-invocation-message-render.test.tsx
@@ -1,23 +1,34 @@
 import React from "react";
-import { describe, expect, test } from "bun:test";
+import { describe, expect, mock, test } from "bun:test";
 import { renderToStaticMarkup } from "react-dom/server";
 
-const storage = new Map<string, string>();
+mock.module("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, values?: Record<string, unknown>) =>
+      values?.appName ? `${key}:${values.appName}` : key,
+  }),
+}));
 
-Object.defineProperty(globalThis, "navigator", {
-  value: { hardwareConcurrency: 4, userAgent: "Bun" },
-  configurable: true,
-});
+mock.module("@/components/shared/HtmlPreview", () => ({
+  default: () => null,
+}));
 
-Object.defineProperty(globalThis, "localStorage", {
-  value: {
-    getItem: (key: string) => storage.get(key) ?? null,
-    setItem: (key: string, value: string) => storage.set(key, value),
-    removeItem: (key: string) => storage.delete(key),
-    clear: () => storage.clear(),
-  },
-  configurable: true,
-});
+mock.module("@/components/shared/CursorCloudAgentRunsListCard", () => ({
+  CursorCloudAgentRunsListCard: () => null,
+}));
+
+mock.module("@/components/shared/CursorRepoAgentChatCard", () => ({
+  CursorRepoAgentChatCard: () => null,
+}));
+
+mock.module("@/components/shared/MapsSearchPlacesCard", () => ({
+  MapsSearchPlacesCard: () => null,
+}));
+
+mock.module("@/components/ui/activity-indicator", () => ({
+  ActivityIndicator: () =>
+    React.createElement("span", { "data-testid": "spinner" }),
+}));
 
 async function loadToolInvocationMessage() {
   const mod = await import("../src/components/shared/ToolInvocationMessage");
@@ -53,4 +64,20 @@ describe("ToolInvocationMessage rendering", () => {
     expect(markup).toBe("");
   });
 
+  test("still renders non-app loading tool calls", async () => {
+    const ToolInvocationMessage = await loadToolInvocationMessage();
+    const markup = renderToStaticMarkup(
+      <ToolInvocationMessage
+        {...defaultProps}
+        part={{
+          type: "tool-read",
+          toolCallId: "call-2",
+          state: "input-available",
+          input: { path: "/Documents/Notes.txt" },
+        }}
+      />
+    );
+
+    expect(markup).toContain("apps.chats.toolCalls.readingFile");
+  });
 });

--- a/tests/test-tool-invocation-message-render.test.tsx
+++ b/tests/test-tool-invocation-message-render.test.tsx
@@ -1,7 +1,28 @@
 import React from "react";
 import { describe, expect, test } from "bun:test";
 import { renderToStaticMarkup } from "react-dom/server";
-import { ToolInvocationMessage } from "../src/components/shared/ToolInvocationMessage";
+
+const storage = new Map<string, string>();
+
+Object.defineProperty(globalThis, "navigator", {
+  value: { hardwareConcurrency: 4 },
+  configurable: true,
+});
+
+Object.defineProperty(globalThis, "localStorage", {
+  value: {
+    getItem: (key: string) => storage.get(key) ?? null,
+    setItem: (key: string, value: string) => storage.set(key, value),
+    removeItem: (key: string) => storage.delete(key),
+    clear: () => storage.clear(),
+  },
+  configurable: true,
+});
+
+async function loadToolInvocationMessage() {
+  const mod = await import("../src/components/shared/ToolInvocationMessage");
+  return mod.ToolInvocationMessage;
+}
 
 const defaultProps = {
   partKey: "part-1",
@@ -15,7 +36,8 @@ const defaultProps = {
 };
 
 describe("ToolInvocationMessage rendering", () => {
-  test("renders nothing for pending app launch tool calls", () => {
+  test("renders nothing for pending app launch tool calls", async () => {
+    const ToolInvocationMessage = await loadToolInvocationMessage();
     const markup = renderToStaticMarkup(
       <ToolInvocationMessage
         {...defaultProps}
@@ -31,7 +53,8 @@ describe("ToolInvocationMessage rendering", () => {
     expect(markup).toBe("");
   });
 
-  test("still renders non-app loading tool calls", () => {
+  test("still renders non-app loading tool calls", async () => {
+    const ToolInvocationMessage = await loadToolInvocationMessage();
     const markup = renderToStaticMarkup(
       <ToolInvocationMessage
         {...defaultProps}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Suppress transient tool invocation loading rows for app launches in Chats and Terminal.
- Keep non-app tool progress messages and completed launch results visible.
- Add helper and render coverage for app-launch loading suppression.

### Testing
- `bun test tests/test-tool-invocation-display.test.ts`
- `bun test tests/test-tool-invocation-display.test.ts tests/test-tool-invocation-message-render.test.tsx`
- `bun run build`

### Notes
- GUI computer-use verification was unavailable in this VM due a computer-use executor error, so validation uses focused render coverage plus a full production build.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019e80a3-2d0c-7b00-94b5-bbc1832c7def"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019e80a3-2d0c-7b00-94b5-bbc1832c7def"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

