### PR TITLE
Sort private Chats rooms by last activity (newest first)

### DIFF
--- a/src/stores/useChatsStore.ts
+++ b/src/stores/useChatsStore.ts
@@ -20,6 +20,7 @@ import {
   sendRoomMessage as sendRoomMessageApi,
   switchPresence as switchPresenceApi,
 } from "@/api/rooms";
+import { sortChatRooms } from "@/utils/chatRoomList";
 
 // Username recovery - plain text, username is public info
 const USERNAME_RECOVERY_KEY = "_usr_recovery_key_";
@@ -30,6 +31,14 @@ const MESSAGE_HISTORY_CAP = 500;
 
 const capRoomMessages = (messages: ChatMessage[]): ChatMessage[] =>
   messages.slice(-MESSAGE_HISTORY_CAP);
+
+const withSortedRoomList = (
+  state: { rooms: ChatRoom[]; roomMessages: Record<string, ChatMessage[]> },
+  roomMessages: Record<string, ChatMessage[]>
+) => ({
+  roomMessages,
+  rooms: sortChatRooms(state.rooms, roomMessages),
+});
 
 // API Response Types
 interface ApiMessage {
@@ -451,16 +460,7 @@ export const useChatsStore = create<ChatsStoreState>()(
 
           // Deep comparison to prevent unnecessary updates
           const currentRooms = get().rooms;
-          // Apply stable sort to keep UI order consistent (public first, then name, then id)
-          const sortedNewRooms = [...filtered].sort((a, b) => {
-            const ao = a.type === "private" ? 1 : 0;
-            const bo = b.type === "private" ? 1 : 0;
-            if (ao !== bo) return ao - bo;
-            const an = (a.name || "").toLowerCase();
-            const bn = (b.name || "").toLowerCase();
-            if (an !== bn) return an.localeCompare(bn);
-            return a.id.localeCompare(b.id);
-          });
+          const sortedNewRooms = sortChatRooms(filtered, get().roomMessages);
 
           if (JSON.stringify(currentRooms) === JSON.stringify(sortedNewRooms)) {
             console.log(
@@ -525,12 +525,10 @@ export const useChatsStore = create<ChatsStoreState>()(
                 } as ChatMessage;
                 const updated = [...existingMessages];
                 updated[idxByClientId] = replaced;
-                return {
-                  roomMessages: {
-                    ...state.roomMessages,
-                    [roomId]: sortAndCap(updated),
-                  },
-                };
+                return withSortedRoomList(state, {
+                  ...state.roomMessages,
+                  [roomId]: sortAndCap(updated),
+                });
               }
             }
 
@@ -550,12 +548,10 @@ export const useChatsStore = create<ChatsStoreState>()(
               } as ChatMessage;
               const updated = [...existingMessages];
               updated[tempIndex] = replaced; // replace in place to minimise list churn
-              return {
-                roomMessages: {
-                  ...state.roomMessages,
-                  [roomId]: sortAndCap(updated),
-                },
-              };
+              return withSortedRoomList(state, {
+                ...state.roomMessages,
+                [roomId]: sortAndCap(updated),
+              });
             }
 
             // Second fallback: replace the most recent temp message from same user within time window
@@ -598,21 +594,17 @@ export const useChatsStore = create<ChatsStoreState>()(
               } as ChatMessage;
               const updated = [...existingMessages];
               updated[bestIdx] = replaced;
-              return {
-                roomMessages: {
-                  ...state.roomMessages,
-                  [roomId]: sortAndCap(updated),
-                },
-              };
+              return withSortedRoomList(state, {
+                ...state.roomMessages,
+                [roomId]: sortAndCap(updated),
+              });
             }
 
             // No optimistic message to replace – append normally
-            return {
-              roomMessages: {
-                ...state.roomMessages,
-                [roomId]: sortAndCap([...existingMessages, incoming]),
-              },
-            };
+            return withSortedRoomList(state, {
+              ...state.roomMessages,
+              [roomId]: sortAndCap([...existingMessages, incoming]),
+            });
           });
         },
         removeMessageFromRoom: (roomId, messageId) => {
@@ -727,7 +719,6 @@ export const useChatsStore = create<ChatsStoreState>()(
             const data = await listRoomsApi();
             if (data.rooms && Array.isArray(data.rooms)) {
               clearApiUnavailable("rooms");
-              // Normalize ordering via setRooms to enforce alphabetical sections
               get().setRooms(data.rooms);
               return { ok: true };
             }
@@ -841,12 +832,10 @@ export const useChatsStore = create<ChatsStoreState>()(
                     (a, b) => a.timestamp - b.timestamp
                   )
                 );
-                return {
-                  roomMessages: {
-                    ...state.roomMessages,
-                    [roomId]: merged,
-                  },
-                };
+                return withSortedRoomList(state, {
+                  ...state.roomMessages,
+                  [roomId]: merged,
+                });
               });
 
               return { ok: true };
@@ -967,7 +956,7 @@ export const useChatsStore = create<ChatsStoreState>()(
                   }
                 );
 
-                return { roomMessages: nextRoomMessages };
+                return withSortedRoomList(state, nextRoomMessages);
               });
 
               return { ok: true };

--- a/src/utils/chatRoomList.ts
+++ b/src/utils/chatRoomList.ts
@@ -1,4 +1,71 @@
-import type { ChatRoom } from "@/types/chat";
+import type { ChatMessage, ChatRoom } from "@/types/chat";
+
+type RoomActivityFields = ChatRoom & {
+  updatedAt?: number;
+  lastMessageAt?: number;
+};
+
+export const getLastMessageTimestampForRoom = (
+  roomId: string,
+  roomMessages?: Record<string, ChatMessage[]>
+): number | undefined => {
+  const messages = roomMessages?.[roomId];
+  if (!messages?.length) return undefined;
+  const last = messages[messages.length - 1];
+  const timestamp = last?.timestamp;
+  return typeof timestamp === "number" && Number.isFinite(timestamp)
+    ? timestamp
+    : undefined;
+};
+
+export const getPrivateRoomActivityTimestamp = (
+  room: ChatRoom,
+  roomMessages?: Record<string, ChatMessage[]>
+): number => {
+  const fromMessages = getLastMessageTimestampForRoom(room.id, roomMessages);
+  if (fromMessages !== undefined) return fromMessages;
+
+  const extended = room as RoomActivityFields;
+  if (
+    typeof extended.lastMessageAt === "number" &&
+    Number.isFinite(extended.lastMessageAt)
+  ) {
+    return extended.lastMessageAt;
+  }
+  if (
+    typeof extended.updatedAt === "number" &&
+    Number.isFinite(extended.updatedAt)
+  ) {
+    return extended.updatedAt;
+  }
+  if (typeof room.createdAt === "number" && Number.isFinite(room.createdAt)) {
+    return room.createdAt;
+  }
+  return 0;
+};
+
+/** Public/IRC rooms: type group, then name, then id. Private rooms: newest activity first. */
+export const sortChatRooms = (
+  rooms: ChatRoom[],
+  roomMessages?: Record<string, ChatMessage[]>
+): ChatRoom[] =>
+  [...rooms].sort((a, b) => {
+    const ao = a.type === "private" ? 1 : 0;
+    const bo = b.type === "private" ? 1 : 0;
+    if (ao !== bo) return ao - bo;
+
+    if (a.type === "private" && b.type === "private") {
+      const at = getPrivateRoomActivityTimestamp(a, roomMessages);
+      const bt = getPrivateRoomActivityTimestamp(b, roomMessages);
+      if (at !== bt) return bt - at;
+      return a.id.localeCompare(b.id);
+    }
+
+    const an = (a.name || "").toLowerCase();
+    const bn = (b.name || "").toLowerCase();
+    if (an !== bn) return an.localeCompare(bn);
+    return a.id.localeCompare(b.id);
+  });
 
 export const upsertChatRoom = (
   rooms: ChatRoom[],

--- a/tests/test-chat-room-list-sort.test.ts
+++ b/tests/test-chat-room-list-sort.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, test } from "bun:test";
+import type { ChatMessage, ChatRoom } from "../src/types/chat";
+import {
+  getPrivateRoomActivityTimestamp,
+  sortChatRooms,
+} from "../src/utils/chatRoomList";
+
+const room = (
+  partial: Partial<ChatRoom> & Pick<ChatRoom, "id" | "name">
+): ChatRoom => ({
+  createdAt: 1000,
+  userCount: 0,
+  type: "public",
+  ...partial,
+});
+
+describe("chat room list sort", () => {
+  test("keeps public and IRC rooms before private rooms, sorted by name", () => {
+    const rooms: ChatRoom[] = [
+      room({ id: "p1", name: "DM", type: "private", createdAt: 5000 }),
+      room({ id: "a", name: "Zeta", type: "public" }),
+      room({ id: "b", name: "Alpha", type: "public" }),
+      room({ id: "i", name: "#irc", type: "irc" }),
+    ];
+
+    expect(sortChatRooms(rooms).map((r) => r.id)).toEqual([
+      "i",
+      "b",
+      "a",
+      "p1",
+    ]);
+  });
+
+  test("sorts private rooms by last message timestamp, newest first", () => {
+    const rooms: ChatRoom[] = [
+      room({
+        id: "old",
+        name: "@a, @b",
+        type: "private",
+        createdAt: 100,
+      }),
+      room({
+        id: "mid",
+        name: "@a, @c",
+        type: "private",
+        createdAt: 200,
+      }),
+      room({
+        id: "new",
+        name: "@a, @d",
+        type: "private",
+        createdAt: 50,
+      }),
+    ];
+    const roomMessages: Record<string, ChatMessage[]> = {
+      old: [
+        {
+          id: "m1",
+          roomId: "old",
+          username: "a",
+          content: "hi",
+          timestamp: 1000,
+        },
+      ],
+      mid: [
+        {
+          id: "m2",
+          roomId: "mid",
+          username: "a",
+          content: "hey",
+          timestamp: 5000,
+        },
+      ],
+      new: [
+        {
+          id: "m3",
+          roomId: "new",
+          username: "a",
+          content: "yo",
+          timestamp: 9000,
+        },
+      ],
+    };
+
+    expect(sortChatRooms(rooms, roomMessages).map((r) => r.id)).toEqual([
+      "new",
+      "mid",
+      "old",
+    ]);
+  });
+
+  test("falls back to updatedAt then createdAt for private rooms without messages", () => {
+    const rooms: ChatRoom[] = [
+      room({
+        id: "c",
+        name: "c",
+        type: "private",
+        createdAt: 300,
+      }),
+      room({
+        id: "u",
+        name: "u",
+        type: "private",
+        createdAt: 100,
+        updatedAt: 800,
+      } as ChatRoom & { updatedAt: number }),
+    ];
+
+    expect(sortChatRooms(rooms).map((r) => r.id)).toEqual(["u", "c"]);
+    expect(getPrivateRoomActivityTimestamp(rooms[1])).toBe(800);
+    expect(getPrivateRoomActivityTimestamp(rooms[0])).toBe(300);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Private/DM rooms in the Chats app are now ordered by recent activity (last message time when known), newest first. Public and IRC channels keep the existing ordering: non-private rooms first, then alphabetical by name and stable `id` tie-break.

## Changes

- Added `sortChatRooms`, `getPrivateRoomActivityTimestamp`, and `getLastMessageTimestampForRoom` in `src/utils/chatRoomList.ts`.
- `useChatsStore.setRooms` uses the shared sort with cached `roomMessages`.
- Re-sorts the room list after message append/replace and after per-room or bulk message fetches so DMs move up when new traffic arrives.
- Activity fallback order: last cached message timestamp → optional `lastMessageAt` / `updatedAt` on the room object → `createdAt` → `0`.
- Added `tests/test-chat-room-list-sort.test.ts`.

## Notes

- No pinned/archived room list semantics exist in the codebase; unread badges are unchanged.
- `ChatsMenuBar` still flattens private-before-public for the menubar picker (unchanged).

## Testing

- `bun test tests/test-chat-room-list-sort.test.ts` (3 passing)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d07a747b-4fff-4a69-a9d4-903d12757e68"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d07a747b-4fff-4a69-a9d4-903d12757e68"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

