### PR TITLE
Improve lyrics glow color extraction

### DIFF
--- a/src/apps/ipod/components/lyrics-display/colorUtils.ts
+++ b/src/apps/ipod/components/lyrics-display/colorUtils.ts
@@ -1,31 +1,128 @@
 import { GOLD_GLOW_COLOR_FALLBACK } from "./constants";
 
+type Rgb = [number, number, number];
+type Hsl = { h: number; s: number; l: number };
+
+const NEUTRAL_SATURATION_MAX = 0.12;
+const MIN_GLOW_LIGHTNESS = 0.58;
+const MAX_GLOW_LIGHTNESS = 0.72;
+const MIN_GLOW_LUMINANCE = 0.34;
+const MIN_NEUTRAL_LIGHTNESS = 0.88;
+
 function hexToRgb(hex: string): [number, number, number] {
   const m = /^#([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})$/i.exec(hex);
   if (!m) return [255, 215, 0];
   return [parseInt(m[1]!, 16), parseInt(m[2]!, 16), parseInt(m[3]!, 16)];
 }
 
-/** RGB → HSL saturation (0-1) */
-function rgbSaturation(r: number, g: number, b: number): number {
-  const rn = r / 255, gn = g / 255, bn = b / 255;
-  const max = Math.max(rn, gn, bn), min = Math.min(rn, gn, bn);
-  if (max === min) return 0;
-  const l = (max + min) / 2;
-  return l > 0.5 ? (max - min) / (2 - max - min) : (max - min) / (max + min);
+function rgbToHex([r, g, b]: Rgb): string {
+  return `#${r.toString(16).padStart(2, "0")}${g
+    .toString(16)
+    .padStart(2, "0")}${b.toString(16).padStart(2, "0")}`;
 }
 
-/** Pick the most vibrant (highest saturation, moderate lightness) color from a palette */
+function rgbToHsl(r: number, g: number, b: number): Hsl {
+  const rn = r / 255;
+  const gn = g / 255;
+  const bn = b / 255;
+  const max = Math.max(rn, gn, bn);
+  const min = Math.min(rn, gn, bn);
+  let h = 0;
+  const l = (max + min) / 2;
+  const d = max - min;
+  const s = d === 0 ? 0 : d / (1 - Math.abs(2 * l - 1));
+
+  if (d !== 0) {
+    if (max === rn) h = ((gn - bn) / d + 6) % 6;
+    else if (max === gn) h = (bn - rn) / d + 2;
+    else h = (rn - gn) / d + 4;
+    h /= 6;
+  }
+
+  return { h, s, l };
+}
+
+function hslToRgb({ h, s, l }: Hsl): Rgb {
+  if (s === 0) {
+    const value = Math.round(l * 255);
+    return [value, value, value];
+  }
+
+  const hsl2rgb = (p: number, q: number, t: number) => {
+    if (t < 0) t += 1;
+    if (t > 1) t -= 1;
+    if (t < 1 / 6) return p + (q - p) * 6 * t;
+    if (t < 1 / 2) return q;
+    if (t < 2 / 3) return p + (q - p) * (2 / 3 - t) * 6;
+    return p;
+  };
+  const q = l < 0.5 ? l * (1 + s) : l + s - l * s;
+  const p = 2 * l - q;
+
+  return [
+    Math.round(hsl2rgb(p, q, h + 1 / 3) * 255),
+    Math.round(hsl2rgb(p, q, h) * 255),
+    Math.round(hsl2rgb(p, q, h - 1 / 3) * 255),
+  ];
+}
+
+function relativeLuminance(r: number, g: number, b: number): number {
+  const linear = (channel: number) => {
+    const normalized = channel / 255;
+    return normalized <= 0.03928
+      ? normalized / 12.92
+      : ((normalized + 0.055) / 1.055) ** 2.4;
+  };
+
+  return 0.2126 * linear(r) + 0.7152 * linear(g) + 0.0722 * linear(b);
+}
+
+function ensureMinimumLuminance([r, g, b]: Rgb): Rgb {
+  let next: Rgb = [r, g, b];
+  let luminance = relativeLuminance(...next);
+
+  while (luminance < MIN_GLOW_LUMINANCE) {
+    next = [
+      Math.round(next[0] + (255 - next[0]) * 0.12),
+      Math.round(next[1] + (255 - next[1]) * 0.12),
+      Math.round(next[2] + (255 - next[2]) * 0.12),
+    ];
+    const updatedLuminance = relativeLuminance(...next);
+    if (updatedLuminance <= luminance) break;
+    luminance = updatedLuminance;
+  }
+
+  return next;
+}
+
+/** Pick a readable glow source color from the extracted cover palette. */
 export function pickPrimaryColor(palette: string[]): string {
-  let best = palette[0] ?? GOLD_GLOW_COLOR_FALLBACK;
-  let bestScore = -1;
-  for (const hex of palette) {
+  const colors = palette.map((hex) => {
     const [r, g, b] = hexToRgb(hex);
-    const sat = rgbSaturation(r, g, b);
-    const lightness = (r + g + b) / (3 * 255);
-    // Prefer saturated colors with moderate lightness (not too dark/light)
-    const lightnessBoost = 1 - Math.abs(lightness - 0.5) * 2;
-    const score = sat * 0.7 + lightnessBoost * 0.3;
+    const hsl = rgbToHsl(r, g, b);
+    return {
+      hex,
+      hsl,
+      luminance: relativeLuminance(r, g, b),
+    };
+  });
+
+  if (colors.length === 0) return GOLD_GLOW_COLOR_FALLBACK;
+
+  const colorful = colors.filter(({ hsl }) => hsl.s > NEUTRAL_SATURATION_MAX);
+  if (colorful.length === 0) {
+    return colors.reduce((best, color) =>
+      color.luminance > best.luminance ? color : best
+    ).hex;
+  }
+
+  let best = colorful[0]!.hex;
+  let bestScore = -1;
+
+  for (const { hex, hsl, luminance } of colorful) {
+    const luminanceBoost = Math.min(luminance / MIN_GLOW_LUMINANCE, 1);
+    const lightnessBoost = 1 - Math.min(Math.abs(hsl.l - 0.62) / 0.62, 1);
+    const score = hsl.s * 0.55 + luminanceBoost * 0.3 + lightnessBoost * 0.15;
     if (score > bestScore) {
       bestScore = score;
       best = hex;
@@ -37,35 +134,25 @@ export function pickPrimaryColor(palette: string[]): string {
 /** Boost saturation and brightness of a hex color so it pops as a glow */
 export function boostGlowColor(hex: string): string {
   const [r, g, b] = hexToRgb(hex);
-  const rn = r / 255, gn = g / 255, bn = b / 255;
-  const max = Math.max(rn, gn, bn), min = Math.min(rn, gn, bn);
-  let h = 0;
-  const l = (max + min) / 2;
-  const d = max - min;
-  const s = d === 0 ? 0 : d / (1 - Math.abs(2 * l - 1));
-  if (d !== 0) {
-    if (max === rn) h = ((gn - bn) / d + 6) % 6;
-    else if (max === gn) h = (bn - rn) / d + 2;
-    else h = (rn - gn) / d + 4;
-    h /= 6;
+  const hsl = rgbToHsl(r, g, b);
+
+  if (hsl.s <= NEUTRAL_SATURATION_MAX) {
+    return rgbToHex(
+      hslToRgb({
+        h: 0,
+        s: 0,
+        l: Math.max(hsl.l, MIN_NEUTRAL_LIGHTNESS),
+      })
+    );
   }
-  // Boost saturation to at least 0.85, lightness to at least 0.55
-  const boostedS = Math.max(s, 0.85);
-  const boostedL = Math.max(Math.min(l, 0.65), 0.55);
-  const hsl2rgb = (p: number, q: number, t: number) => {
-    if (t < 0) t += 1;
-    if (t > 1) t -= 1;
-    if (t < 1 / 6) return p + (q - p) * 6 * t;
-    if (t < 1 / 2) return q;
-    if (t < 2 / 3) return p + (q - p) * (2 / 3 - t) * 6;
-    return p;
-  };
-  const q = boostedL < 0.5 ? boostedL * (1 + boostedS) : boostedL + boostedS - boostedL * boostedS;
-  const p = 2 * boostedL - q;
-  const ro = Math.round(hsl2rgb(p, q, h + 1 / 3) * 255);
-  const go = Math.round(hsl2rgb(p, q, h) * 255);
-  const bo = Math.round(hsl2rgb(p, q, h - 1 / 3) * 255);
-  return `#${ro.toString(16).padStart(2, "0")}${go.toString(16).padStart(2, "0")}${bo.toString(16).padStart(2, "0")}`;
+
+  const boosted = hslToRgb({
+    h: hsl.h,
+    s: Math.max(hsl.s, 0.85),
+    l: Math.max(Math.min(hsl.l, MAX_GLOW_LIGHTNESS), MIN_GLOW_LIGHTNESS),
+  });
+
+  return rgbToHex(ensureMinimumLuminance(boosted));
 }
 
 /** Generate glow CSS values from a hex color */

--- a/src/apps/karaoke/components/karaoke-lyrics-playback/title-card-styles.ts
+++ b/src/apps/karaoke/components/karaoke-lyrics-playback/title-card-styles.ts
@@ -1,7 +1,11 @@
 import type { CSSProperties } from "react";
+import {
+  boostGlowColor,
+  makeGlowFromColor,
+  pickPrimaryColor,
+} from "@/apps/ipod/components/lyrics-display/colorUtils";
 
 export const TITLE_CARD_BASE_SHADOW = "0 0 6px rgba(0,0,0,0.5), 0 0 6px rgba(0,0,0,0.5)";
-export const TITLE_CARD_GOLD_GLOW_COLOR_FALLBACK = "#FFD700";
 export const TITLE_CARD_MOVEMENT_TRANSITION = {
   type: "spring" as const,
   stiffness: 200,
@@ -30,101 +34,12 @@ export function getTitleCardStyleCategory(className: string): TitleCardStyleCate
   return "glow-white";
 }
 
-function titleCardHexToRgb(hex: string): [number, number, number] {
-  const match = /^#([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})$/i.exec(hex);
-  if (!match) return [255, 215, 0];
-  return [
-    Number.parseInt(match[1]!, 16),
-    Number.parseInt(match[2]!, 16),
-    Number.parseInt(match[3]!, 16),
-  ];
-}
-
-function titleCardRgbSaturation(r: number, g: number, b: number): number {
-  const rn = r / 255;
-  const gn = g / 255;
-  const bn = b / 255;
-  const max = Math.max(rn, gn, bn);
-  const min = Math.min(rn, gn, bn);
-  if (max === min) return 0;
-  const lightness = (max + min) / 2;
-  return lightness > 0.5
-    ? (max - min) / (2 - max - min)
-    : (max - min) / (max + min);
-}
-
-function pickTitleCardPrimaryColor(palette: string[]): string {
-  let best = palette[0] ?? TITLE_CARD_GOLD_GLOW_COLOR_FALLBACK;
-  let bestScore = -1;
-
-  for (const hex of palette) {
-    const [r, g, b] = titleCardHexToRgb(hex);
-    const saturation = titleCardRgbSaturation(r, g, b);
-    const lightness = (r + g + b) / (3 * 255);
-    const lightnessBoost = 1 - Math.abs(lightness - 0.5) * 2;
-    const score = saturation * 0.7 + lightnessBoost * 0.3;
-    if (score > bestScore) {
-      bestScore = score;
-      best = hex;
-    }
-  }
-
-  return best;
-}
-
-function boostTitleCardGlowColor(hex: string): string {
-  const [r, g, b] = titleCardHexToRgb(hex);
-  const rn = r / 255;
-  const gn = g / 255;
-  const bn = b / 255;
-  const max = Math.max(rn, gn, bn);
-  const min = Math.min(rn, gn, bn);
-  let hue = 0;
-  const lightness = (max + min) / 2;
-  const delta = max - min;
-  const saturation = delta === 0 ? 0 : delta / (1 - Math.abs(2 * lightness - 1));
-
-  if (delta !== 0) {
-    if (max === rn) hue = ((gn - bn) / delta + 6) % 6;
-    else if (max === gn) hue = (bn - rn) / delta + 2;
-    else hue = (rn - gn) / delta + 4;
-    hue /= 6;
-  }
-
-  const boostedSaturation = Math.max(saturation, 0.85);
-  const boostedLightness = Math.max(Math.min(lightness, 0.65), 0.55);
-  const hslToRgb = (p: number, q: number, t: number) => {
-    let nextT = t;
-    if (nextT < 0) nextT += 1;
-    if (nextT > 1) nextT -= 1;
-    if (nextT < 1 / 6) return p + (q - p) * 6 * nextT;
-    if (nextT < 1 / 2) return q;
-    if (nextT < 2 / 3) return p + (q - p) * (2 / 3 - nextT) * 6;
-    return p;
-  };
-  const q =
-    boostedLightness < 0.5
-      ? boostedLightness * (1 + boostedSaturation)
-      : boostedLightness + boostedSaturation - boostedLightness * boostedSaturation;
-  const p = 2 * boostedLightness - q;
-  const ro = Math.round(hslToRgb(p, q, hue + 1 / 3) * 255);
-  const go = Math.round(hslToRgb(p, q, hue) * 255);
-  const bo = Math.round(hslToRgb(p, q, hue - 1 / 3) * 255);
-  return `#${ro.toString(16).padStart(2, "0")}${go.toString(16).padStart(2, "0")}${bo.toString(16).padStart(2, "0")}`;
-}
-
 export function makeTitleCardGlow(hex: string) {
-  const [r, g, b] = titleCardHexToRgb(hex);
-  return {
-    color: hex,
-    shadow: `0 0 8px rgba(${r},${g},${b},0.8), 0 0 16px rgba(${r},${g},${b},0.4), 0 0 6px rgba(0,0,0,0.5)`,
-    filter: `drop-shadow(0 0 8px rgba(${r},${g},${b},0.5))`,
-    baseColor: `rgba(${r},${g},${b},0.6)`,
-  };
+  return makeGlowFromColor(hex);
 }
 
 export function pickBoostedTitleCardGlow(palette: string[]) {
-  return makeTitleCardGlow(boostTitleCardGlowColor(pickTitleCardPrimaryColor(palette)));
+  return makeTitleCardGlow(boostGlowColor(pickPrimaryColor(palette)));
 }
 
 export const TITLE_CARD_SECONDARY_TEXT_STYLE: CSSProperties = {

--- a/src/hooks/useCoverPalette.ts
+++ b/src/hooks/useCoverPalette.ts
@@ -42,6 +42,61 @@ const MIN_DISTINCT_SQ = 70 * 70;
 
 const COLOR_COUNT = 7;
 
+function hexToRgb(hex: string): [number, number, number] | null {
+  const m = /^#([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})$/i.exec(hex);
+  if (!m) return null;
+  return [parseInt(m[1]!, 16), parseInt(m[2]!, 16), parseInt(m[3]!, 16)];
+}
+
+function mixHexColors(fromHex: string, toHex: string, amount: number): string | null {
+  const from = hexToRgb(fromHex);
+  const to = hexToRgb(toHex);
+  if (!from || !to) return null;
+
+  return rgbToHex(
+    from[0] + (to[0] - from[0]) * amount,
+    from[1] + (to[1] - from[1]) * amount,
+    from[2] + (to[2] - from[2]) * amount
+  );
+}
+
+export function completeCoverPalette(colors: string[]): string[] {
+  if (colors.length === 0) return DEFAULT_PALETTE;
+
+  const result = [...colors];
+  const selectedHexes = new Set(result.map((hex) => hex.toLowerCase()));
+  const addColor = (hex: string | null) => {
+    if (!hex || result.length >= COLOR_COUNT) return;
+    const key = hex.toLowerCase();
+    if (selectedHexes.has(key)) return;
+    result.push(hex);
+    selectedHexes.add(key);
+  };
+
+  for (let i = 0; i < colors.length && result.length < COLOR_COUNT; i++) {
+    const current = colors[i]!;
+    const next = colors[(i + 1) % colors.length] ?? current;
+    if (current === next) continue;
+    for (const amount of [0.25, 0.5, 0.75]) {
+      addColor(mixHexColors(current, next, amount));
+    }
+  }
+
+  for (const color of colors) {
+    for (const amount of [0.16, 0.32, 0.48, 0.64, 0.8, 1]) {
+      addColor(mixHexColors(color, "#ffffff", amount));
+    }
+    addColor(mixHexColors(color, "#000000", 0.2));
+    addColor(mixHexColors(color, "#000000", 0.4));
+  }
+
+  for (const color of DEFAULT_PALETTE) {
+    addColor(color);
+  }
+
+  return result.slice(0, COLOR_COUNT);
+}
+
 /**
  * Extracts 7 distinct main colors from cover art.
  * Samples a grid, quantizes to reduce noise, counts frequency, then greedily
@@ -131,7 +186,7 @@ function extractPaletteFromImage(img: HTMLImageElement): string[] {
     }
   }
 
-  return result.length >= COLOR_COUNT ? result : DEFAULT_PALETTE;
+  return completeCoverPalette(result);
 }
 
 /**

--- a/tests/test-lyrics-color-extraction.test.ts
+++ b/tests/test-lyrics-color-extraction.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from "bun:test";
+import {
+  boostGlowColor,
+  pickPrimaryColor,
+} from "../src/apps/ipod/components/lyrics-display/colorUtils";
+import { completeCoverPalette } from "../src/hooks/useCoverPalette";
+
+function hexToRgb(hex: string): [number, number, number] {
+  const match = /^#([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})$/i.exec(hex);
+  if (!match) throw new Error(`Invalid hex color: ${hex}`);
+  return [
+    Number.parseInt(match[1]!, 16),
+    Number.parseInt(match[2]!, 16),
+    Number.parseInt(match[3]!, 16),
+  ];
+}
+
+function relativeLuminance(hex: string): number {
+  const [r, g, b] = hexToRgb(hex);
+  const linear = (channel: number) => {
+    const normalized = channel / 255;
+    return normalized <= 0.03928
+      ? normalized / 12.92
+      : ((normalized + 0.055) / 1.055) ** 2.4;
+  };
+
+  return 0.2126 * linear(r) + 0.7152 * linear(g) + 0.0722 * linear(b);
+}
+
+describe("lyrics color extraction", () => {
+  test("keeps black and white cover palettes neutral instead of falling back warm", () => {
+    const palette = completeCoverPalette(["#000000", "#ffffff"]);
+
+    expect(palette).toHaveLength(7);
+    expect(palette).toContain("#ffffff");
+    expect(palette).not.toContain("#9c2b2b");
+    expect(pickPrimaryColor(palette)).toBe("#ffffff");
+  });
+
+  test("pads single-color neutral covers without introducing warm defaults", () => {
+    const palette = completeCoverPalette(["#000000"]);
+
+    expect(palette).toHaveLength(7);
+    expect(palette).toContain("#ffffff");
+    expect(palette).not.toContain("#9c2b2b");
+    expect(pickPrimaryColor(palette)).toBe("#ffffff");
+  });
+
+  test("chooses white for purely black and white lyrics glow palettes", () => {
+    expect(pickPrimaryColor(["#000000", "#ffffff"])).toBe("#ffffff");
+    expect(boostGlowColor("#ffffff")).toBe("#ffffff");
+  });
+
+  test("does not turn grayscale colors red when boosting glow", () => {
+    const boosted = boostGlowColor("#101010");
+    const [r, g, b] = hexToRgb(boosted);
+
+    expect(r).toBe(g);
+    expect(g).toBe(b);
+    expect(r).toBeGreaterThanOrEqual(224);
+  });
+
+  test("lifts dark saturated colors to a readable glow luminance", () => {
+    const boosted = boostGlowColor("#1a237e");
+
+    expect(relativeLuminance(boosted)).toBeGreaterThanOrEqual(0.34);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Keep small real cover palettes instead of replacing them with the warm default palette.
- Preserve neutral black/white artwork as neutral lyrics glow colors.
- Lift dark saturated glow colors using perceived luminance and reuse the same logic for karaoke title cards.

## Testing
- `bun test tests/test-lyrics-color-extraction.test.ts`
- `bun run build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019e813d-5c04-7c24-962f-936df3672907"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019e813d-5c04-7c24-962f-936df3672907"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

