### PR TITLE
Default fullscreen lyrics to glow; sans-serif on small iPod LCD

### DIFF
--- a/src/apps/ipod/components/ipod-screen/IpodScreenMediaOverlay.tsx
+++ b/src/apps/ipod/components/ipod-screen/IpodScreenMediaOverlay.tsx
@@ -8,6 +8,7 @@ import { MeshGradientBackground } from "@/components/shared/MeshGradientBackgrou
 import { WaterBackground } from "@/components/shared/WaterBackground";
 import { DisplayMode } from "@/types/lyrics";
 import { LyricsDisplay } from "../lyrics-display/LyricsDisplay";
+import { getIpodSmallScreenLyricsFontClassName } from "../lyrics-display/useLyricsDisplaySettings";
 import {
   AppleMusicPlayerBridge,
 } from "../AppleMusicPlayerBridge";
@@ -332,6 +333,7 @@ export function IpodScreenMediaOverlay({
           error={lyricsControls.error}
           visible={shouldShowLyrics}
           videoVisible={showVideo}
+          fontClassName={getIpodSmallScreenLyricsFontClassName(uiVariant)}
           alignment={lyricsAlignment}
           koreanDisplay={koreanDisplay}
           japaneseFurigana={japaneseFurigana}

--- a/src/apps/ipod/components/lyrics-display/useLyricsDisplaySettings.ts
+++ b/src/apps/ipod/components/lyrics-display/useLyricsDisplaySettings.ts
@@ -10,6 +10,15 @@ import {
 import { useIpodStore } from "@/stores/useIpodStore";
 import type { LyricsDisplayProps } from "./types";
 
+/** Small iPod LCD lyrics always use sans-serif; ignore stored lyric style. */
+export function getIpodSmallScreenLyricsFontClassName(
+  uiVariant: "classic" | "modern"
+): string {
+  return uiVariant === "modern"
+    ? "font-ipod-modern-ui font-semibold"
+    : "font-geneva-12";
+}
+
 export function useLyricsDisplaySettings({
   alignment: alignmentOverride,
   koreanDisplay: koreanDisplayOverride,

--- a/src/apps/karaoke/components/karaoke-lyrics-playback/context.tsx
+++ b/src/apps/karaoke/components/karaoke-lyrics-playback/context.tsx
@@ -77,7 +77,7 @@ export function KaraokeLyricsPlaybackProvider({
   const appLanguage = i18n.resolvedLanguage ?? i18n.language;
   const elapsedTime = useKaraokeStore(useShallow((s) => s.elapsedTime));
 
-  const lyricsFontClassName = getLyricsFontClassName(lyricsFont ?? LyricsFontEnum.SansSerif);
+  const lyricsFontClassName = getLyricsFontClassName(lyricsFont ?? LyricsFontEnum.GoldGlow);
 
   const selectedMatchForLyrics = useMemo(() => {
     if (!lyricsSourceOverride) return undefined;

--- a/src/apps/karaoke/components/karaoke-menu-bar/useKaraokeMenuBar.ts
+++ b/src/apps/karaoke/components/karaoke-menu-bar/useKaraokeMenuBar.ts
@@ -79,7 +79,7 @@ export function useKaraokeMenuBar(props: KaraokeMenuBarProps) {
     exportLibrary,
   } = useIpodStoreShallow((s) => ({
     lyricsAlignment: s.lyricsAlignment ?? LyricsAlignment.FocusThree,
-    lyricsFont: s.lyricsFont ?? LyricsFont.SansSerif,
+    lyricsFont: s.lyricsFont ?? LyricsFont.GoldGlow,
     romanization: s.romanization,
     lyricsTranslationLanguage: s.lyricsTranslationLanguage,
     setLyricsAlignment: s.setLyricsAlignment,

--- a/src/stores/useIpodStore.ts
+++ b/src/stores/useIpodStore.ts
@@ -402,7 +402,7 @@ const initialIpodData: IpodData = {
   lcdFilterOn: true,
   showLyrics: true,
   lyricsAlignment: LyricsAlignment.Alternating,
-  lyricsFont: LyricsFont.SansSerif,
+  lyricsFont: LyricsFont.GoldGlow,
   koreanDisplay: KoreanDisplay.Original,
   japaneseFurigana: JapaneseFurigana.On,
   romanization: {
@@ -801,7 +801,7 @@ export function navigateActiveIpodTrack(
   }
 }
 
-const CURRENT_IPOD_STORE_VERSION = 39; // Add persisted iPod backlight timeout preference
+const CURRENT_IPOD_STORE_VERSION = 40; // Default fullscreen/Karaoke lyrics style is Gold Glow
 
 // Helper function to get unplayed track IDs from history
 function getUnplayedTrackIds(
@@ -2454,7 +2454,7 @@ export const useIpodStore = create<IpodState>()(
             lyricsAlignment: state.lyricsAlignment ?? LyricsAlignment.Alternating,
             lyricsFont: shouldUpgradeLegacyDefaultLyricsFont
               ? LyricsFont.SansSerif
-              : state.lyricsFont ?? LyricsFont.SansSerif,
+              : state.lyricsFont ?? LyricsFont.GoldGlow,
             displayMode: state.displayMode ?? DisplayMode.Video,
             koreanDisplay: state.koreanDisplay ?? KoreanDisplay.Original,
             japaneseFurigana: state.japaneseFurigana ?? JapaneseFurigana.On,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets **Gold Glow** (`LyricsFont.GoldGlow`) as the default lyrics style for Karaoke fullscreen and iPod fullscreen, while keeping any explicitly persisted `lyricsFont` value unchanged.

For the **small iPod device screen** only, lyrics always render with sans-serif typography (`font-ipod-modern-ui` on modern UI, `font-geneva-12` on classic), independent of the stored lyric style used in fullscreen/Karaoke.

## Changes

- `useIpodStore`: initial default `lyricsFont` → `GoldGlow`; store version **40**; migrate fallback `?? GoldGlow` for missing values only
- `IpodScreenMediaOverlay`: passes `getIpodSmallScreenLyricsFontClassName(uiVariant)` into `LyricsDisplay`
- `useLyricsDisplaySettings`: exports small-screen font helper
- Karaoke: `?? GoldGlow` fallbacks in lyrics playback context and menu bar VM

## Behavior

| Surface | Typography |
|---------|------------|
| iPod small LCD | Always sans (ignores lyric style setting) |
| iPod fullscreen | User `lyricsFont` (default **glow** for new users) |
| Karaoke fullscreen / window | User `lyricsFont` (default **glow** for new users) |

Existing users who already saved a lyric style (e.g. serif, rounded, sans) keep that preference.

## Testing

- `bun run test:unit` — 257 pass
- `bun test tests/test-cloud-sync-launch-and-store.test.ts` — 14 pass
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-908a14c2-136e-4a5d-9d1e-ac2a96451ba6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-908a14c2-136e-4a5d-9d1e-ac2a96451ba6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

