### PR TITLE
Update fullscreen karaoke controls and title cards

### DIFF
--- a/src/apps/ipod/components/FullScreenPortal.tsx
+++ b/src/apps/ipod/components/FullScreenPortal.tsx
@@ -50,8 +50,7 @@ export function FullScreenPortal({
   onDisplayModeSelect,
   displayModeOptions,
   fullScreenPlayerRef,
-  karaokeKtvRoomFxEnabled,
-  onToggleKaraokeKtvRoomFx,
+  trailingControls,
   activityState,
   onSurfaceLongPress,
   surfaceLongPressEnabled = true,
@@ -426,6 +425,11 @@ export function FullScreenPortal({
 
   useEventListener("keydown", handleKeyDown);
 
+  const renderedTrailingControls =
+    typeof trailingControls === "function"
+      ? trailingControls({ portalContainer: containerRef.current })
+      : trailingControls;
+
   return createPortal(
     <div
       ref={containerRef}
@@ -598,8 +602,6 @@ export function FullScreenPortal({
           onFontCycle={onCycleLyricsFont}
           romanization={romanization}
           onRomanizationChange={onRomanizationChange}
-          karaokeKtvRoomFxEnabled={karaokeKtvRoomFxEnabled}
-          onToggleKaraokeKtvRoomFx={onToggleKaraokeKtvRoomFx}
           isPronunciationMenuOpen={isPronunciationMenuOpen}
           setIsPronunciationMenuOpen={setIsPronunciationMenuOpen}
           currentTranslationCode={currentTranslationCode}
@@ -612,6 +614,7 @@ export function FullScreenPortal({
           bgOpacity="35"
           onInteraction={registerActivity}
           portalContainer={containerRef.current}
+          trailingControls={renderedTrailingControls}
         />
       </div>
 

--- a/src/apps/ipod/components/FullScreenPortal.tsx
+++ b/src/apps/ipod/components/FullScreenPortal.tsx
@@ -50,7 +50,8 @@ export function FullScreenPortal({
   onDisplayModeSelect,
   displayModeOptions,
   fullScreenPlayerRef,
-  trailingControls,
+  mobileCloseLeadingControls,
+  desktopTopRightControls,
   activityState,
   onSurfaceLongPress,
   surfaceLongPressEnabled = true,
@@ -425,10 +426,14 @@ export function FullScreenPortal({
 
   useEventListener("keydown", handleKeyDown);
 
-  const renderedTrailingControls =
-    typeof trailingControls === "function"
-      ? trailingControls({ portalContainer: containerRef.current })
-      : trailingControls;
+  const renderedMobileCloseLeadingControls =
+    typeof mobileCloseLeadingControls === "function"
+      ? mobileCloseLeadingControls({ portalContainer: containerRef.current })
+      : mobileCloseLeadingControls;
+  const renderedDesktopTopRightControls =
+    typeof desktopTopRightControls === "function"
+      ? desktopTopRightControls({ portalContainer: containerRef.current })
+      : desktopTopRightControls;
 
   return createPortal(
     <div
@@ -530,8 +535,32 @@ export function FullScreenPortal({
           forceVisible={anyMenuOpen}
           onDismiss={onClose}
           onInteraction={registerActivity}
-          leadingControls={renderedTrailingControls}
+          leadingControls={renderedMobileCloseLeadingControls}
         />
+      )}
+
+      {renderedDesktopTopRightControls && (
+        <div
+          data-toolbar
+          className={cn(
+            "fixed z-[10001] hidden md:flex transition-opacity duration-200",
+            !suppressToolbar &&
+            (showControls || anyMenuOpen || !getActualPlayerState())
+              ? "opacity-100 pointer-events-auto"
+              : "opacity-0 pointer-events-none"
+          )}
+          style={{
+            top: "calc(max(env(safe-area-inset-top), 0.75rem) + 1.5rem)",
+            right:
+              "calc(max(env(safe-area-inset-right), 0.75rem) + 1.5rem)",
+          }}
+          onClick={(e) => {
+            e.stopPropagation();
+            restartAutoHideTimer();
+          }}
+        >
+          {renderedDesktopTopRightControls}
+        </div>
       )}
 
       <div
@@ -615,7 +644,6 @@ export function FullScreenPortal({
           bgOpacity="35"
           onInteraction={registerActivity}
           portalContainer={containerRef.current}
-          trailingControls={renderedTrailingControls}
         />
       </div>
 

--- a/src/apps/ipod/components/FullScreenPortal.tsx
+++ b/src/apps/ipod/components/FullScreenPortal.tsx
@@ -530,6 +530,7 @@ export function FullScreenPortal({
           forceVisible={anyMenuOpen}
           onDismiss={onClose}
           onInteraction={registerActivity}
+          leadingControls={renderedTrailingControls}
         />
       )}
 

--- a/src/apps/ipod/components/ipod-app/IpodFullScreenView.tsx
+++ b/src/apps/ipod/components/ipod-app/IpodFullScreenView.tsx
@@ -3,6 +3,8 @@ import ReactPlayer from "react-player";
 import { Suspense } from "react";
 import type React from "react";
 import { DisplayMode } from "@/types/lyrics";
+import { shouldShowKaraokeTitleCard } from "@/apps/karaoke/utils/titleCard";
+import { KaraokeTitleCard } from "@/apps/karaoke/components/karaoke-lyrics-playback/KaraokeTitleCard";
 import { LyricsSyncMode } from "@/components/shared/LyricsSyncMode";
 import { PLAYER_PROGRESS_INTERVAL_MS } from "../../constants";
 import { AppleMusicPlayerBridge } from "../AppleMusicPlayerBridge";
@@ -45,6 +47,7 @@ export function IpodFullScreenView({ c }: IpodFullScreenViewProps) {
     lyricsAlignment,
     cycleAlignment,
     lyricsFont,
+    lyricsFontClassName,
     cycleLyricsFont,
     romanization,
     setRomanization,
@@ -84,6 +87,14 @@ export function IpodFullScreenView({ c }: IpodFullScreenViewProps) {
   } = c;
 
   if (!isFullScreen) return null;
+
+  const currentTimeMs =
+    (elapsedTime + (currentTrack?.lyricOffset ?? 0) / 1000) * 1000;
+  const showTitleCard = showLyrics && Boolean(currentTrack) && shouldShowKaraokeTitleCard({
+    lines: fullScreenLyricsControls.originalLines,
+    currentTimeMs,
+    lyricOffsetMs: currentTrack?.lyricOffset ?? 0,
+  });
 
   return (
     <FullScreenPortal
@@ -324,74 +335,89 @@ export function IpodFullScreenView({ c }: IpodFullScreenViewProps) {
 
             {showLyrics && tracks[currentIndex] && (
               <div className="absolute inset-0 z-20 pointer-events-none" data-lyrics>
-                <LyricsDisplay
-                  lines={fullScreenLyricsControls.lines}
-                  originalLines={fullScreenLyricsControls.originalLines}
-                  currentLine={fullScreenLyricsControls.currentLine}
-                  isLoading={fullScreenLyricsControls.isLoading}
-                  error={fullScreenLyricsControls.error}
-                  visible={true}
-                  videoVisible={true}
-                  alignment={lyricsAlignment}
-                  koreanDisplay={koreanDisplay}
-                  japaneseFurigana={japaneseFurigana}
-                  onAdjustOffset={(delta) => {
-                    adjustLyricOffset(currentIndex, delta);
-                    const newOffset = (tracks[currentIndex]?.lyricOffset ?? 0) + delta;
-                    const sign = newOffset > 0 ? "+" : newOffset < 0 ? "" : "";
-                    showStatus(
-                      `${t("apps.ipod.status.offset")} ${sign}${(newOffset / 1000).toFixed(2)}s`
-                    );
-                    fullScreenLyricsControls.updateCurrentTimeManually(
-                      elapsedTime + newOffset / 1000
-                    );
-                  }}
-                  onSwipeUp={() => {
-                    if (isOffline) {
-                      showOfflineStatus();
-                    } else {
-                      skipOperationRef.current = true;
-                      startTrackSwitch();
-                      nextTrack();
-                      const newTrack = getCurrentStoreTrack();
-                      if (newTrack) {
-                        const artistInfo = newTrack.artist ? ` - ${newTrack.artist}` : "";
-                        showStatus(`⏭ ${newTrack.title}${artistInfo}`);
+                <AnimatePresence>
+                  {showTitleCard && currentTrack && (
+                    <KaraokeTitleCard
+                      title={currentTrack.title}
+                      artist={currentTrack.artist}
+                      album={currentTrack.album}
+                      fontClassName={lyricsFontClassName}
+                      variant="fullscreen"
+                      coverUrl={fullscreenCoverUrl}
+                      bottomPaddingClass={controlsVisible ? "pb-28" : "pb-16"}
+                      isPlaying={isPlaying}
+                    />
+                  )}
+                </AnimatePresence>
+                {!showTitleCard && (
+                  <LyricsDisplay
+                    lines={fullScreenLyricsControls.lines}
+                    originalLines={fullScreenLyricsControls.originalLines}
+                    currentLine={fullScreenLyricsControls.currentLine}
+                    isLoading={fullScreenLyricsControls.isLoading}
+                    error={fullScreenLyricsControls.error}
+                    visible={true}
+                    videoVisible={true}
+                    alignment={lyricsAlignment}
+                    koreanDisplay={koreanDisplay}
+                    japaneseFurigana={japaneseFurigana}
+                    fontClassName={lyricsFontClassName}
+                    onAdjustOffset={(delta) => {
+                      adjustLyricOffset(currentIndex, delta);
+                      const newOffset = (tracks[currentIndex]?.lyricOffset ?? 0) + delta;
+                      const sign = newOffset > 0 ? "+" : newOffset < 0 ? "" : "";
+                      showStatus(
+                        `${t("apps.ipod.status.offset")} ${sign}${(newOffset / 1000).toFixed(2)}s`
+                      );
+                      fullScreenLyricsControls.updateCurrentTimeManually(
+                        elapsedTime + newOffset / 1000
+                      );
+                    }}
+                    onSwipeUp={() => {
+                      if (isOffline) {
+                        showOfflineStatus();
+                      } else {
+                        skipOperationRef.current = true;
+                        startTrackSwitch();
+                        nextTrack();
+                        const newTrack = getCurrentStoreTrack();
+                        if (newTrack) {
+                          const artistInfo = newTrack.artist ? ` - ${newTrack.artist}` : "";
+                          showStatus(`⏭ ${newTrack.title}${artistInfo}`);
+                        }
                       }
-                    }
-                  }}
-                  onSwipeDown={() => {
-                    if (isOffline) {
-                      showOfflineStatus();
-                    } else {
-                      skipOperationRef.current = true;
-                      startTrackSwitch();
-                      previousTrack();
-                      const newTrack = getCurrentStoreTrack();
-                      if (newTrack) {
-                        const artistInfo = newTrack.artist ? ` - ${newTrack.artist}` : "";
-                        showStatus(`⏮ ${newTrack.title}${artistInfo}`);
+                    }}
+                    onSwipeDown={() => {
+                      if (isOffline) {
+                        showOfflineStatus();
+                      } else {
+                        skipOperationRef.current = true;
+                        startTrackSwitch();
+                        previousTrack();
+                        const newTrack = getCurrentStoreTrack();
+                        if (newTrack) {
+                          const artistInfo = newTrack.artist ? ` - ${newTrack.artist}` : "";
+                          showStatus(`⏮ ${newTrack.title}${artistInfo}`);
+                        }
                       }
-                    }
-                  }}
-                  isTranslating={fullScreenLyricsControls.isTranslating}
-                  textSizeClass="fullscreen-lyrics-text"
-                  gapClass="gap-0"
-                  containerStyle={{
-                    gap: "clamp(0.2rem, calc(min(10vw,10vh) * 0.08), 1rem)",
-                    paddingLeft: "env(safe-area-inset-left, 0px)",
-                    paddingRight: "env(safe-area-inset-right, 0px)",
-                  }}
-                  interactive={true}
-                  bottomPaddingClass={controlsVisible ? "pb-28" : "pb-16"}
-                  furiganaMap={furiganaMap}
-                  soramimiMap={soramimiMap}
-                  currentTimeMs={
-                    (elapsedTime + (currentTrack?.lyricOffset ?? 0) / 1000) * 1000
-                  }
-                  onSeekToTime={seekToTime}
-                  coverUrl={fullscreenCoverUrl}
-                />
+                    }}
+                    isTranslating={fullScreenLyricsControls.isTranslating}
+                    textSizeClass="fullscreen-lyrics-text"
+                    gapClass="gap-0"
+                    containerStyle={{
+                      gap: "clamp(0.2rem, calc(min(10vw,10vh) * 0.08), 1rem)",
+                      paddingLeft: "env(safe-area-inset-left, 0px)",
+                      paddingRight: "env(safe-area-inset-right, 0px)",
+                    }}
+                    interactive={true}
+                    bottomPaddingClass={controlsVisible ? "pb-28" : "pb-16"}
+                    furiganaMap={furiganaMap}
+                    soramimiMap={soramimiMap}
+                    currentTimeMs={currentTimeMs}
+                    onSeekToTime={seekToTime}
+                    coverUrl={fullscreenCoverUrl}
+                  />
+                )}
               </div>
             )}
           </div>

--- a/src/apps/ipod/types.ts
+++ b/src/apps/ipod/types.ts
@@ -133,8 +133,12 @@ export interface FullScreenPortalProps {
   displayMode?: DisplayMode;
   onDisplayModeSelect?: (mode: DisplayMode) => void;
   displayModeOptions?: { value: DisplayMode; label: string }[];
-  /** Additional controls rendered immediately before the desktop close button. */
-  trailingControls?:
+  /** Additional controls rendered before the mobile top-right close button. */
+  mobileCloseLeadingControls?:
+    | React.ReactNode
+    | ((ctx: { portalContainer: HTMLElement | null }) => React.ReactNode);
+  /** Additional controls rendered in a desktop top-right fullscreen toolbar. */
+  desktopTopRightControls?:
     | React.ReactNode
     | ((ctx: { portalContainer: HTMLElement | null }) => React.ReactNode);
   // Player ref for mobile Safari handling

--- a/src/apps/ipod/types.ts
+++ b/src/apps/ipod/types.ts
@@ -133,9 +133,10 @@ export interface FullScreenPortalProps {
   displayMode?: DisplayMode;
   onDisplayModeSelect?: (mode: DisplayMode) => void;
   displayModeOptions?: { value: DisplayMode; label: string }[];
-  /** Karaoke fullscreen: audience-style reaction ambience toggle */
-  karaokeKtvRoomFxEnabled?: boolean;
-  onToggleKaraokeKtvRoomFx?: () => void;
+  /** Additional controls rendered immediately before the desktop close button. */
+  trailingControls?:
+    | React.ReactNode
+    | ((ctx: { portalContainer: HTMLElement | null }) => React.ReactNode);
   // Player ref for mobile Safari handling
   fullScreenPlayerRef: React.RefObject<ReactPlayer | null>;
   /** Activity state for loading indicators (optional — karaoke supplies from lyrics subtree) */

--- a/src/apps/karaoke/components/karaoke-app/KaraokeFullscreenRoomControls.tsx
+++ b/src/apps/karaoke/components/karaoke-app/KaraokeFullscreenRoomControls.tsx
@@ -1,0 +1,302 @@
+import type { MouseEvent, ReactElement } from "react";
+import { useTranslation } from "react-i18next";
+import { cn } from "@/lib/utils";
+import { useSound, Sounds } from "@/hooks/useSound";
+import { useThemeFlags } from "@/hooks/useThemeFlags";
+import type { ListenSession } from "@/stores/useListenSessionStore";
+import {
+  connectionLabel,
+  makeConnectionKey,
+} from "@/lib/listenClientInstance";
+import { REACTION_MAP } from "@/components/listen/reactionFloaterConstants";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import {
+  Headphones,
+  Smiley,
+} from "@phosphor-icons/react";
+
+const REACTIONS = Object.entries(REACTION_MAP).map(([id, reaction]) => ({
+  id,
+  ...reaction,
+}));
+
+interface KaraokeFullscreenRoomControlsProps {
+  session: ListenSession | null;
+  isRemoteOnly: boolean;
+  isHost: boolean;
+  isDj: boolean;
+  isAnonymous: boolean;
+  listenerCount: number;
+  currentUsername: string | null;
+  currentClientInstanceId: string | null;
+  onJoinRoom: () => void;
+  onLeave: () => void;
+  onAssignPlaybackDevice: (username: string, clientInstanceId: string) => void;
+  onPassDj: (username: string, clientInstanceId: string) => void;
+  onTransferHost: (username: string, clientInstanceId: string) => void;
+  onSendReaction: (emoji: string) => void;
+  onInteraction?: () => void;
+  portalContainer?: HTMLElement | null;
+}
+
+export function KaraokeFullscreenRoomControls({
+  session,
+  isRemoteOnly,
+  isHost,
+  isDj,
+  isAnonymous,
+  listenerCount,
+  currentUsername,
+  currentClientInstanceId,
+  onJoinRoom,
+  onLeave,
+  onAssignPlaybackDevice,
+  onPassDj,
+  onTransferHost,
+  onSendReaction,
+  onInteraction,
+  portalContainer,
+}: KaraokeFullscreenRoomControlsProps) {
+  const { t } = useTranslation();
+  const { isMacOSTheme: isMacTheme } = useThemeFlags();
+  const { play: playClick } = useSound(Sounds.BUTTON_CLICK, 0.3);
+  const iconClasses = isMacTheme
+    ? "text-white/70 drop-shadow-[0_1px_2px_rgba(0,0,0,0.5)]"
+    : "";
+  const buttonClasses = cn(
+    "w-9 h-9 md:w-12 md:h-12 flex items-center justify-center rounded-full transition-colors focus:outline-none relative z-10",
+    !isMacTheme && "text-white/70 hover:text-white hover:bg-white/10"
+  );
+  const svgClasses = cn(
+    "w-[18px] h-[18px] md:w-[22px] md:h-[22px]",
+    iconClasses
+  );
+  const playbackValue = session
+    ? makeConnectionKey(
+        session.djUsername,
+        session.djClientInstanceId ?? `legacy:${session.djUsername.toLowerCase()}`
+      )
+    : "";
+  const isSelfConnection = (u: ListenSession["users"][number]) =>
+    u.username === currentUsername && u.clientInstanceId === currentClientInstanceId;
+
+  const handleClick =
+    (handler: () => void) => (e: MouseEvent) => {
+      e.stopPropagation();
+      playClick();
+      onInteraction?.();
+      handler();
+    };
+
+  const roomButton = (
+    <button
+      type="button"
+      onClick={session ? (e) => e.stopPropagation() : handleClick(onJoinRoom)}
+      className={cn(buttonClasses, "gap-1 px-2 w-auto")}
+      title={
+        session
+          ? t("apps.karaoke.liveListen.listening", { count: listenerCount })
+          : t("apps.karaoke.liveListen.joinSession")
+      }
+    >
+      {session && isDj && (
+        <span
+          className={cn(
+            "px-1.5 py-0.5 rounded-full text-[10px] font-semibold uppercase tracking-wide bg-white/20",
+            iconClasses
+          )}
+        >
+          {t("apps.karaoke.liveListen.playbackBadge")}
+        </span>
+      )}
+      {session && isRemoteOnly && !isDj && (
+        <span
+          className={cn(
+            "px-1.5 py-0.5 rounded-full text-[10px] font-semibold uppercase tracking-wide bg-amber-500/35",
+            iconClasses
+          )}
+        >
+          {t("apps.karaoke.liveListen.remoteBadge")}
+        </span>
+      )}
+      <Headphones weight="fill" className={svgClasses} />
+      <span className={cn("text-sm tabular-nums", iconClasses)}>
+        {session ? listenerCount : 0}
+      </span>
+    </button>
+  );
+
+  const reactionButton = (
+    <button
+      type="button"
+      disabled={!session || isAnonymous}
+      onClick={(e) => e.stopPropagation()}
+      className={cn(
+        buttonClasses,
+        (!session || isAnonymous) && "opacity-[0.42] cursor-default"
+      )}
+      title={t("apps.karaoke.liveListen.sendReaction")}
+    >
+      <Smiley weight="fill" className={svgClasses} />
+    </button>
+  );
+
+  return (
+    <>
+      {session ? (
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>{roomButton}</DropdownMenuTrigger>
+          <DropdownMenuContent
+            container={portalContainer}
+            side="top"
+            align="center"
+            sideOffset={8}
+            className="px-0 w-56"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="px-2 py-1 text-xs text-muted-foreground">
+              {t("apps.karaoke.liveListen.listening", { count: listenerCount })}
+              {listenerCount - session.users.length > 0 &&
+                ` (${t("apps.karaoke.liveListen.anonymous", {
+                  count: listenerCount - session.users.length,
+                })})`}
+            </div>
+            {session.users.length > 1 && (isHost || isDj) && (
+              <>
+                <div className="px-2 py-1 text-[11px] text-muted-foreground">
+                  {isHost
+                    ? t("apps.karaoke.liveListen.playbackOnDevice")
+                    : t("apps.karaoke.liveListen.passPlayback")}
+                </div>
+                <DropdownMenuRadioGroup
+                  value={playbackValue}
+                  onValueChange={(key) => {
+                    onInteraction?.();
+                    if (key === playbackValue) return;
+                    playClick();
+                    const pipe = key.indexOf("|");
+                    const uname = pipe === -1 ? key : key.slice(0, pipe);
+                    const cid =
+                      pipe === -1
+                        ? `legacy:${uname.toLowerCase()}`
+                        : key.slice(pipe + 1);
+                    if (isHost) onAssignPlaybackDevice(uname, cid);
+                    else onPassDj(uname, cid);
+                  }}
+                >
+                  {session.users.map((user) => {
+                    const cid =
+                      user.clientInstanceId ??
+                      `legacy:${user.username.toLowerCase()}`;
+                    const key = makeConnectionKey(user.username, cid);
+                    return (
+                      <DropdownMenuRadioItem
+                        key={key}
+                        value={key}
+                        className="text-md h-6 pr-3"
+                      >
+                        {connectionLabel(user.username, cid)}
+                        {key === playbackValue
+                          ? ` (${t("apps.karaoke.liveListen.playbackBadge")})`
+                          : ""}
+                      </DropdownMenuRadioItem>
+                    );
+                  })}
+                </DropdownMenuRadioGroup>
+              </>
+            )}
+            {isHost && session.users.length > 1 && (
+              <>
+                <DropdownMenuSeparator />
+                <div className="px-2 py-1 text-[11px] text-muted-foreground">
+                  {t("apps.karaoke.liveListen.makeHost")}
+                </div>
+                {session.users.reduce<ReactElement[]>((acc, user) => {
+                  if (isSelfConnection(user)) return acc;
+                  const cid =
+                    user.clientInstanceId ??
+                    `legacy:${user.username.toLowerCase()}`;
+                  acc.push(
+                    <DropdownMenuItem
+                      key={`host-${makeConnectionKey(user.username, cid)}`}
+                      onClick={() => {
+                        onInteraction?.();
+                        playClick();
+                        onTransferHost(user.username, cid);
+                      }}
+                      className="text-md h-6"
+                    >
+                      {connectionLabel(user.username, cid)}
+                    </DropdownMenuItem>
+                  );
+                  return acc;
+                }, [])}
+              </>
+            )}
+            <DropdownMenuSeparator />
+            <DropdownMenuItem
+              onClick={() => {
+                onInteraction?.();
+                playClick();
+                onLeave();
+              }}
+              className="text-md h-6"
+            >
+              {isHost
+                ? t("apps.karaoke.liveListen.endSession")
+                : t("apps.karaoke.liveListen.leaveSession")}
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      ) : (
+        roomButton
+      )}
+
+      {session && !isAnonymous ? (
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>{reactionButton}</DropdownMenuTrigger>
+          <DropdownMenuContent
+            container={portalContainer}
+            side="top"
+            align="center"
+            sideOffset={8}
+            className="px-1 py-1 flex gap-1 min-w-0 w-auto"
+            onClick={(e) => e.stopPropagation()}
+          >
+            {REACTIONS.map((reaction) => (
+              <button
+                key={reaction.id}
+                type="button"
+                onClick={() => {
+                  playClick();
+                  onSendReaction(reaction.id);
+                  onInteraction?.();
+                }}
+                className={cn(
+                  "w-8 h-8 flex items-center justify-center rounded hover:bg-accent transition-colors",
+                  reaction.color
+                )}
+              >
+                <reaction.icon
+                  weight="fill"
+                  size={18}
+                  className={cn("shrink-0", reaction.color)}
+                />
+              </button>
+            ))}
+          </DropdownMenuContent>
+        </DropdownMenu>
+      ) : (
+        reactionButton
+      )}
+    </>
+  );
+}

--- a/src/apps/karaoke/components/karaoke-app/KaraokeFullscreenRoomControls.tsx
+++ b/src/apps/karaoke/components/karaoke-app/KaraokeFullscreenRoomControls.tsx
@@ -1,4 +1,4 @@
-import type { MouseEvent, ReactElement } from "react";
+import type { CSSProperties, MouseEvent, ReactElement } from "react";
 import { useTranslation } from "react-i18next";
 import { cn } from "@/lib/utils";
 import { useSound, Sounds } from "@/hooks/useSound";
@@ -45,6 +45,9 @@ interface KaraokeFullscreenRoomControlsProps {
   onSendReaction: (emoji: string) => void;
   onInteraction?: () => void;
   portalContainer?: HTMLElement | null;
+  dropdownSide?: "top" | "bottom";
+  inline?: boolean;
+  className?: string;
 }
 
 export function KaraokeFullscreenRoomControls({
@@ -64,19 +67,33 @@ export function KaraokeFullscreenRoomControls({
   onSendReaction,
   onInteraction,
   portalContainer,
+  dropdownSide = "bottom",
+  inline = false,
+  className,
 }: KaraokeFullscreenRoomControlsProps) {
   const { t } = useTranslation();
   const { isMacOSTheme: isMacTheme } = useThemeFlags();
   const { play: playClick } = useSound(Sounds.BUTTON_CLICK, 0.3);
+  const segmentClasses = isMacTheme
+    ? "relative overflow-hidden rounded-full shadow-lg flex items-center gap-1 px-1 py-1"
+    : "border border-white/10 backdrop-blur-sm rounded-full shadow-lg flex items-center gap-1 px-1 py-1 bg-neutral-800/60";
+  const aquaSegmentStyle: CSSProperties = isMacTheme
+    ? {
+        background:
+          "linear-gradient(to bottom, rgba(60, 60, 60, 0.6), rgba(30, 30, 30, 0.5))",
+        boxShadow:
+          "0 2px 4px rgba(0, 0, 0, 0.2), inset 0 0 0 0.5px rgba(255, 255, 255, 0.1), inset 0 1px 0 rgba(255, 255, 255, 0.15)",
+      }
+    : {};
   const iconClasses = isMacTheme
     ? "text-white/70 drop-shadow-[0_1px_2px_rgba(0,0,0,0.5)]"
     : "";
   const buttonClasses = cn(
-    "w-9 h-9 md:w-12 md:h-12 flex items-center justify-center rounded-full transition-colors focus:outline-none relative z-10",
+    "w-8 h-8 flex items-center justify-center rounded-full transition-colors focus:outline-none relative z-10",
     !isMacTheme && "text-white/70 hover:text-white hover:bg-white/10"
   );
   const svgClasses = cn(
-    "w-[18px] h-[18px] md:w-[22px] md:h-[22px]",
+    "w-[14px] h-[14px]",
     iconClasses
   );
   const playbackValue = session
@@ -149,14 +166,14 @@ export function KaraokeFullscreenRoomControls({
     </button>
   );
 
-  return (
+  const controls = (
     <>
       {session ? (
         <DropdownMenu>
           <DropdownMenuTrigger asChild>{roomButton}</DropdownMenuTrigger>
           <DropdownMenuContent
             container={portalContainer}
-            side="top"
+            side={dropdownSide}
             align="center"
             sideOffset={8}
             className="px-0 w-56"
@@ -265,7 +282,7 @@ export function KaraokeFullscreenRoomControls({
           <DropdownMenuTrigger asChild>{reactionButton}</DropdownMenuTrigger>
           <DropdownMenuContent
             container={portalContainer}
-            side="top"
+            side={dropdownSide}
             align="center"
             sideOffset={8}
             className="px-1 py-1 flex gap-1 min-w-0 w-auto"
@@ -298,5 +315,13 @@ export function KaraokeFullscreenRoomControls({
         reactionButton
       )}
     </>
+  );
+
+  if (inline) return controls;
+
+  return (
+    <div className={cn(segmentClasses, className)} style={aquaSegmentStyle}>
+      {controls}
+    </div>
   );
 }

--- a/src/apps/karaoke/components/karaoke-app/KaraokeFullscreenView.tsx
+++ b/src/apps/karaoke/components/karaoke-app/KaraokeFullscreenView.tsx
@@ -40,6 +40,32 @@ export function KaraokeFullscreenView({ c, isForeground }: KaraokeFullscreenView
 
   if (!isFullScreen) return null;
 
+  const renderRoomControls = (
+    portalContainer: HTMLElement | null,
+    inline = false
+  ) => (
+    <KaraokeFullscreenRoomControls
+      session={listenSession}
+      isRemoteOnly={isListenSessionRemoteOnly}
+      isHost={isListenSessionHost}
+      isDj={isListenSessionDj}
+      isAnonymous={isListenSessionAnonymous}
+      listenerCount={listenListenerCount}
+      currentUsername={listenSessionUsername}
+      currentClientInstanceId={listenSessionClientInstanceId}
+      onJoinRoom={() => setIsJoinListenDialogOpen(true)}
+      onLeave={handleLeaveListenSession}
+      onAssignPlaybackDevice={handleAssignPlaybackDevice}
+      onPassDj={handlePassDj}
+      onTransferHost={handleTransferSessionHost}
+      onSendReaction={handleSendReaction}
+      onInteraction={registerActivity}
+      portalContainer={portalContainer}
+      dropdownSide="bottom"
+      inline={inline}
+    />
+  );
+
   return (
     <KaraokeLyricsPlaybackProvider
       currentTrack={currentTrack}
@@ -96,26 +122,12 @@ export function KaraokeFullscreenView({ c, isForeground }: KaraokeFullscreenView
       displayMode={displayMode}
       onDisplayModeSelect={handleDisplayModeSelect}
       displayModeOptions={displayModeOptions}
-      trailingControls={({ portalContainer }) => (
-        <KaraokeFullscreenRoomControls
-          session={listenSession}
-          isRemoteOnly={isListenSessionRemoteOnly}
-          isHost={isListenSessionHost}
-          isDj={isListenSessionDj}
-          isAnonymous={isListenSessionAnonymous}
-          listenerCount={listenListenerCount}
-          currentUsername={listenSessionUsername}
-          currentClientInstanceId={listenSessionClientInstanceId}
-          onJoinRoom={() => setIsJoinListenDialogOpen(true)}
-          onLeave={handleLeaveListenSession}
-          onAssignPlaybackDevice={handleAssignPlaybackDevice}
-          onPassDj={handlePassDj}
-          onTransferHost={handleTransferSessionHost}
-          onSendReaction={handleSendReaction}
-          onInteraction={registerActivity}
-          portalContainer={portalContainer}
-        />
-      )}
+      mobileCloseLeadingControls={({ portalContainer }) =>
+        renderRoomControls(portalContainer, true)
+      }
+      desktopTopRightControls={({ portalContainer }) =>
+        renderRoomControls(portalContainer)
+      }
       syncModeContent={
         <KaraokeSyncModeFullscreenPanel
           isSyncModeOpen={isSyncModeOpen}

--- a/src/apps/karaoke/components/karaoke-app/KaraokeFullscreenView.tsx
+++ b/src/apps/karaoke/components/karaoke-app/KaraokeFullscreenView.tsx
@@ -1,7 +1,6 @@
 import ReactPlayer from "react-player";
 import { FullScreenPortal } from "@/apps/ipod/components/FullScreenPortal";
 import { ReactionOverlay } from "@/components/listen/ReactionOverlay";
-import { ListenSessionToolbar } from "@/components/listen/ListenSessionToolbar";
 import { useAudioSettingsStore } from "@/stores/useAudioSettingsStore";
 import { PLAYER_PROGRESS_INTERVAL_MS } from "@/apps/ipod/constants";
 import { DisplayMode } from "@/types/lyrics";
@@ -12,6 +11,7 @@ import {
   KaraokeFullscreenLyricsOverlay,
   KaraokeSyncModeFullscreenPanel,
 } from "../karaoke-lyrics-playback";
+import { KaraokeFullscreenRoomControls } from "./KaraokeFullscreenRoomControls";
 import { KaraokeVisualLayers } from "./KaraokeVisualLayers";
 import type { KaraokeAppController } from "./useKaraokeAppController";
 
@@ -33,7 +33,7 @@ export function KaraokeFullscreenView({ c, isForeground }: KaraokeFullscreenView
     koreanDisplay, japaneseFurigana, handleFullscreenLyricsSwipeUp, handleFullscreenLyricsSwipeDown,
     lyricsSourceOverride, isAddingSong, setIsLyricsSearchDialogOpen, auth, lyricsPlaybackSyncRef,
     listenSessionUsername, listenSessionClientInstanceId, listenListenerCount,
-    isListenSessionHost, isListenSessionDj, isListenSessionAnonymous, setIsListenInviteOpen,
+    isListenSessionHost, isListenSessionDj, isListenSessionAnonymous, setIsJoinListenDialogOpen,
     handleLeaveListenSession, handleAssignPlaybackDevice, handlePassDj, handleTransferSessionHost,
     handleSendReaction,
   } = c;
@@ -96,31 +96,26 @@ export function KaraokeFullscreenView({ c, isForeground }: KaraokeFullscreenView
       displayMode={displayMode}
       onDisplayModeSelect={handleDisplayModeSelect}
       displayModeOptions={displayModeOptions}
-      trailingControls={({ portalContainer }) =>
-        listenSession && !isSyncModeOpen ? (
-          <ListenSessionToolbar
-            session={listenSession}
-            isRemoteOnly={isListenSessionRemoteOnly}
-            isHost={isListenSessionHost}
-            isDj={isListenSessionDj}
-            isAnonymous={isListenSessionAnonymous}
-            listenerCount={listenListenerCount}
-            currentUsername={listenSessionUsername}
-            currentClientInstanceId={listenSessionClientInstanceId}
-            onShare={() => setIsListenInviteOpen(true)}
-            onLeave={handleLeaveListenSession}
-            onAssignPlaybackDevice={handleAssignPlaybackDevice}
-            onPassDj={handlePassDj}
-            onTransferHost={handleTransferSessionHost}
-            onSendReaction={handleSendReaction}
-            onInteraction={registerActivity}
-            portalContainer={portalContainer}
-            dropdownSide="top"
-            showShare={false}
-            className="hidden md:flex"
-          />
-        ) : null
-      }
+      trailingControls={({ portalContainer }) => (
+        <KaraokeFullscreenRoomControls
+          session={listenSession}
+          isRemoteOnly={isListenSessionRemoteOnly}
+          isHost={isListenSessionHost}
+          isDj={isListenSessionDj}
+          isAnonymous={isListenSessionAnonymous}
+          listenerCount={listenListenerCount}
+          currentUsername={listenSessionUsername}
+          currentClientInstanceId={listenSessionClientInstanceId}
+          onJoinRoom={() => setIsJoinListenDialogOpen(true)}
+          onLeave={handleLeaveListenSession}
+          onAssignPlaybackDevice={handleAssignPlaybackDevice}
+          onPassDj={handlePassDj}
+          onTransferHost={handleTransferSessionHost}
+          onSendReaction={handleSendReaction}
+          onInteraction={registerActivity}
+          portalContainer={portalContainer}
+        />
+      )}
       syncModeContent={
         <KaraokeSyncModeFullscreenPanel
           isSyncModeOpen={isSyncModeOpen}

--- a/src/apps/karaoke/components/karaoke-app/KaraokeFullscreenView.tsx
+++ b/src/apps/karaoke/components/karaoke-app/KaraokeFullscreenView.tsx
@@ -1,6 +1,7 @@
 import ReactPlayer from "react-player";
 import { FullScreenPortal } from "@/apps/ipod/components/FullScreenPortal";
 import { ReactionOverlay } from "@/components/listen/ReactionOverlay";
+import { ListenSessionToolbar } from "@/components/listen/ListenSessionToolbar";
 import { useAudioSettingsStore } from "@/stores/useAudioSettingsStore";
 import { PLAYER_PROGRESS_INTERVAL_MS } from "@/apps/ipod/constants";
 import { DisplayMode } from "@/types/lyrics";
@@ -24,13 +25,17 @@ export function KaraokeFullscreenView({ c, isForeground }: KaraokeFullscreenView
     setLyricsTranslationLanguage, lyricsAlignment, cycleAlignment, lyricsFont,
     cycleLyricsFont, romanization, setRomanization, setIsSyncModeOpen, isSyncModeOpen,
     displayMode, handleDisplayModeSelect, displayModeOptions, karaokeKtvRoomFx,
-    toggleKaraokeKtvRoomFx, currentTrack, currentIndex, duration, setLyricOffset,
+    currentTrack, currentIndex, duration, setLyricOffset,
     adjustLyricOffset, fullScreenPlayerRef, playerRef, closeSyncMode, handleRefreshLyrics,
     t, seekTime, loopCurrent, handleTrackEnd, handleProgress, handlePlay, handlePause,
     handleReady, ipodVolume, effectiveDisplayMode, visualBackgroundActive, coverUrl,
     showEmptyLibrary, handleAddSong, listenSession, showLyrics, isOffline, seekToTime,
     koreanDisplay, japaneseFurigana, handleFullscreenLyricsSwipeUp, handleFullscreenLyricsSwipeDown,
     lyricsSourceOverride, isAddingSong, setIsLyricsSearchDialogOpen, auth, lyricsPlaybackSyncRef,
+    listenSessionUsername, listenSessionClientInstanceId, listenListenerCount,
+    isListenSessionHost, isListenSessionDj, isListenSessionAnonymous, setIsListenInviteOpen,
+    handleLeaveListenSession, handleAssignPlaybackDevice, handlePassDj, handleTransferSessionHost,
+    handleSendReaction,
   } = c;
 
   if (!isFullScreen) return null;
@@ -91,8 +96,31 @@ export function KaraokeFullscreenView({ c, isForeground }: KaraokeFullscreenView
       displayMode={displayMode}
       onDisplayModeSelect={handleDisplayModeSelect}
       displayModeOptions={displayModeOptions}
-      karaokeKtvRoomFxEnabled={karaokeKtvRoomFx}
-      onToggleKaraokeKtvRoomFx={toggleKaraokeKtvRoomFx}
+      trailingControls={({ portalContainer }) =>
+        listenSession && !isSyncModeOpen ? (
+          <ListenSessionToolbar
+            session={listenSession}
+            isRemoteOnly={isListenSessionRemoteOnly}
+            isHost={isListenSessionHost}
+            isDj={isListenSessionDj}
+            isAnonymous={isListenSessionAnonymous}
+            listenerCount={listenListenerCount}
+            currentUsername={listenSessionUsername}
+            currentClientInstanceId={listenSessionClientInstanceId}
+            onShare={() => setIsListenInviteOpen(true)}
+            onLeave={handleLeaveListenSession}
+            onAssignPlaybackDevice={handleAssignPlaybackDevice}
+            onPassDj={handlePassDj}
+            onTransferHost={handleTransferSessionHost}
+            onSendReaction={handleSendReaction}
+            onInteraction={registerActivity}
+            portalContainer={portalContainer}
+            dropdownSide="top"
+            showShare={false}
+            className="hidden md:flex"
+          />
+        ) : null
+      }
       syncModeContent={
         <KaraokeSyncModeFullscreenPanel
           isSyncModeOpen={isSyncModeOpen}

--- a/src/components/listen/ListenSessionToolbar.tsx
+++ b/src/components/listen/ListenSessionToolbar.tsx
@@ -76,6 +76,8 @@ interface ListenSessionToolbarProps {
   onSendReaction: (emoji: string) => void;
   onInteraction?: () => void;
   portalContainer?: HTMLElement | null;
+  dropdownSide?: "top" | "bottom";
+  showShare?: boolean;
   className?: string;
 }
 
@@ -96,6 +98,8 @@ export function ListenSessionToolbar({
   onSendReaction,
   onInteraction,
   portalContainer,
+  dropdownSide = "bottom",
+  showShare = true,
   className,
 }: ListenSessionToolbarProps) {
   const { t } = useTranslation();
@@ -182,7 +186,7 @@ export function ListenSessionToolbar({
           </DropdownMenuTrigger>
           <DropdownMenuContent
             container={portalContainer}
-            side="bottom"
+            side={dropdownSide}
             align="center"
             sideOffset={8}
             className="px-0 w-56"
@@ -303,7 +307,7 @@ export function ListenSessionToolbar({
             </DropdownMenuTrigger>
             <DropdownMenuContent
               container={portalContainer}
-              side="bottom"
+              side={dropdownSide}
               align="center"
               sideOffset={8}
               className="px-1 py-1 flex gap-1 min-w-0 w-auto"
@@ -336,17 +340,19 @@ export function ListenSessionToolbar({
       )}
 
       {/* Share/Invite Island */}
-      <div className={segmentClasses} style={aquaSegmentStyle}>
-        {isMacTheme && <AquaShineOverlays />}
-        <button
-          type="button"
-          onClick={handleClick(onShare)}
-          className={buttonClasses}
-          title={t("apps.karaoke.liveListen.inviteTitle")}
-        >
-          <Export weight="regular" size={svgSize} className={iconClasses} />
-        </button>
-      </div>
+      {showShare && (
+        <div className={segmentClasses} style={aquaSegmentStyle}>
+          {isMacTheme && <AquaShineOverlays />}
+          <button
+            type="button"
+            onClick={handleClick(onShare)}
+            className={buttonClasses}
+            title={t("apps.karaoke.liveListen.inviteTitle")}
+          >
+            <Export weight="regular" size={svgSize} className={iconClasses} />
+          </button>
+        </div>
+      )}
 
     </div>
   );

--- a/src/components/shared/FullscreenMobileDismiss.tsx
+++ b/src/components/shared/FullscreenMobileDismiss.tsx
@@ -3,6 +3,7 @@ import { useThemeFlags } from "@/hooks/useThemeFlags";
 import { useSound, Sounds } from "@/hooks/useSound";
 import { useTranslation } from "react-i18next";
 import { X } from "@phosphor-icons/react";
+import type { ReactNode } from "react";
 
 export interface FullscreenMobileDismissProps {
   visible: boolean;
@@ -10,6 +11,7 @@ export interface FullscreenMobileDismissProps {
   onInteraction?: () => void;
   /** Extra condition to keep the control interactive (e.g. menus open) */
   forceVisible?: boolean;
+  leadingControls?: ReactNode;
 }
 
 /**
@@ -20,6 +22,7 @@ export function FullscreenMobileDismiss({
   onDismiss,
   onInteraction,
   forceVisible = false,
+  leadingControls,
 }: FullscreenMobileDismissProps) {
   const { t } = useTranslation();
   const { isMacOSTheme: isMacTheme } = useThemeFlags();
@@ -56,6 +59,7 @@ export function FullscreenMobileDismiss({
             : {}
         }
       >
+        {leadingControls}
         <button
           type="button"
           onClick={(e) => {

--- a/src/components/shared/fullscreen-player-controls/CloseIsland.tsx
+++ b/src/components/shared/fullscreen-player-controls/CloseIsland.tsx
@@ -1,4 +1,5 @@
 import { useTranslation } from "react-i18next";
+import type { ReactNode } from "react";
 import { cn } from "@/lib/utils";
 import { X } from "@phosphor-icons/react";
 import { AquaShineOverlays } from "./AquaShineOverlays";
@@ -11,12 +12,14 @@ interface CloseIslandProps {
   onClose: () => void;
   styles: FullscreenControlStyles;
   handleClick: FullscreenControlClickHandler;
+  leadingControls?: ReactNode;
 }
 
 export function CloseIsland({
   onClose,
   styles,
   handleClick,
+  leadingControls,
 }: CloseIslandProps) {
   const { t } = useTranslation();
   const {
@@ -41,6 +44,7 @@ export function CloseIsland({
       style={aquaSegmentStyle}
     >
       {isMacTheme && <AquaShineOverlays variant={variant} />}
+      {leadingControls}
       <button
         type="button"
         onClick={handleClick(onClose)}

--- a/src/components/shared/fullscreen-player-controls/CloseIsland.tsx
+++ b/src/components/shared/fullscreen-player-controls/CloseIsland.tsx
@@ -1,5 +1,4 @@
 import { useTranslation } from "react-i18next";
-import type { ReactNode } from "react";
 import { cn } from "@/lib/utils";
 import { X } from "@phosphor-icons/react";
 import { AquaShineOverlays } from "./AquaShineOverlays";
@@ -12,14 +11,12 @@ interface CloseIslandProps {
   onClose: () => void;
   styles: FullscreenControlStyles;
   handleClick: FullscreenControlClickHandler;
-  leadingControls?: ReactNode;
 }
 
 export function CloseIsland({
   onClose,
   styles,
   handleClick,
-  leadingControls,
 }: CloseIslandProps) {
   const { t } = useTranslation();
   const {
@@ -44,7 +41,6 @@ export function CloseIsland({
       style={aquaSegmentStyle}
     >
       {isMacTheme && <AquaShineOverlays variant={variant} />}
-      {leadingControls}
       <button
         type="button"
         onClick={handleClick(onClose)}

--- a/src/components/shared/fullscreen-player-controls/FullscreenPlayerControls.tsx
+++ b/src/components/shared/fullscreen-player-controls/FullscreenPlayerControls.tsx
@@ -119,13 +119,12 @@ export function FullscreenPlayerControls({
         />
       )}
 
-      {trailingControls}
-
       {onClose && (
         <CloseIsland
           onClose={onClose}
           styles={styles}
           handleClick={handleClick}
+          leadingControls={trailingControls}
         />
       )}
     </div>

--- a/src/components/shared/fullscreen-player-controls/FullscreenPlayerControls.tsx
+++ b/src/components/shared/fullscreen-player-controls/FullscreenPlayerControls.tsx
@@ -42,7 +42,6 @@ export function FullscreenPlayerControls({
   bgOpacity = "35",
   onInteraction,
   portalContainer,
-  trailingControls,
   hideLyricsControls = false,
 }: FullscreenPlayerControlsProps) {
   const { play: playClick } = useSound(Sounds.BUTTON_CLICK, 0.3);
@@ -124,7 +123,6 @@ export function FullscreenPlayerControls({
           onClose={onClose}
           styles={styles}
           handleClick={handleClick}
-          leadingControls={trailingControls}
         />
       )}
     </div>

--- a/src/components/shared/fullscreen-player-controls/FullscreenPlayerControls.tsx
+++ b/src/components/shared/fullscreen-player-controls/FullscreenPlayerControls.tsx
@@ -42,8 +42,7 @@ export function FullscreenPlayerControls({
   bgOpacity = "35",
   onInteraction,
   portalContainer,
-  karaokeKtvRoomFxEnabled,
-  onToggleKaraokeKtvRoomFx,
+  trailingControls,
   hideLyricsControls = false,
 }: FullscreenPlayerControlsProps) {
   const { play: playClick } = useSound(Sounds.BUTTON_CLICK, 0.3);
@@ -114,13 +113,13 @@ export function FullscreenPlayerControls({
           isLangMenuOpen={isLangMenuOpen}
           setIsLangMenuOpen={setIsLangMenuOpen}
           portalContainer={portalContainer}
-          karaokeKtvRoomFxEnabled={karaokeKtvRoomFxEnabled}
-          onToggleKaraokeKtvRoomFx={onToggleKaraokeKtvRoomFx}
           onInteraction={onInteraction}
           styles={styles}
           handleClick={handleClick}
         />
       )}
+
+      {trailingControls}
 
       {onClose && (
         <CloseIsland

--- a/src/components/shared/fullscreen-player-controls/LyricsControlsIsland.tsx
+++ b/src/components/shared/fullscreen-player-controls/LyricsControlsIsland.tsx
@@ -5,7 +5,6 @@ import type { LyricsAlignment, RomanizationSettings } from "@/types/lyrics";
 import { getLyricsFontClassName, LyricsFont } from "@/types/lyrics";
 import {
   ClockClockwise,
-  HandsClapping,
   Translate,
 } from "@phosphor-icons/react";
 import {
@@ -42,8 +41,6 @@ interface LyricsControlsIslandProps {
   isLangMenuOpen: boolean;
   setIsLangMenuOpen: (open: boolean) => void;
   portalContainer?: HTMLElement | null;
-  karaokeKtvRoomFxEnabled?: boolean;
-  onToggleKaraokeKtvRoomFx?: () => void;
   onInteraction?: () => void;
   styles: FullscreenControlStyles;
   handleClick: FullscreenControlClickHandler;
@@ -65,8 +62,6 @@ export function LyricsControlsIsland({
   isLangMenuOpen,
   setIsLangMenuOpen,
   portalContainer,
-  karaokeKtvRoomFxEnabled,
-  onToggleKaraokeKtvRoomFx,
   onInteraction,
   styles,
   handleClick,
@@ -104,28 +99,6 @@ export function LyricsControlsIsland({
         >
           <ClockClockwise
             weight="fill"
-            className={cn(
-              variant === "compact" ? "w-3.5 h-3.5" : "w-4 h-4",
-              svgClasses()
-            )}
-          />
-        </button>
-      )}
-
-      {karaokeKtvRoomFxEnabled !== undefined && onToggleKaraokeKtvRoomFx && (
-        <button
-          type="button"
-          onClick={handleClick(onToggleKaraokeKtvRoomFx)}
-          aria-pressed={karaokeKtvRoomFxEnabled}
-          aria-label={t("apps.karaoke.ktvRoomFx")}
-          className={cn(
-            buttonClasses,
-            !karaokeKtvRoomFxEnabled && "opacity-[0.42]"
-          )}
-          title={t("apps.karaoke.ktvRoomFxHint")}
-        >
-          <HandsClapping
-            weight={karaokeKtvRoomFxEnabled ? "fill" : "regular"}
             className={cn(
               variant === "compact" ? "w-3.5 h-3.5" : "w-4 h-4",
               svgClasses()

--- a/src/components/shared/fullscreen-player-controls/types.ts
+++ b/src/components/shared/fullscreen-player-controls/types.ts
@@ -69,9 +69,8 @@ export interface FullscreenPlayerControlsProps {
   // Portal container for fullscreen mode (dropdown menus need to render inside the fullscreen element)
   portalContainer?: HTMLElement | null;
 
-  /** Karaoke fullscreen: solo “room reactions” bursts */
-  karaokeKtvRoomFxEnabled?: boolean;
-  onToggleKaraokeKtvRoomFx?: () => void;
+  /** Extra controls rendered immediately before the close island. */
+  trailingControls?: React.ReactNode;
 
   // Hide lyrics controls island (for video players without lyrics)
   hideLyricsControls?: boolean;

--- a/src/components/shared/fullscreen-player-controls/types.ts
+++ b/src/components/shared/fullscreen-player-controls/types.ts
@@ -69,9 +69,6 @@ export interface FullscreenPlayerControlsProps {
   // Portal container for fullscreen mode (dropdown menus need to render inside the fullscreen element)
   portalContainer?: HTMLElement | null;
 
-  /** Extra controls rendered immediately before the close island. */
-  trailingControls?: React.ReactNode;
-
   // Hide lyrics controls island (for video players without lyrics)
   hideLyricsControls?: boolean;
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Remove the karaoke fullscreen room FX toggle from the lyrics controls.
- Keep bottom fullscreen controls unchanged while rendering room-status and reaction-face controls in desktop top-right fullscreen chrome and beside the top-right mobile X pill.
- Reuse the title card in iPod fullscreen mode alongside karaoke fullscreen.

### Walkthrough
<a href="https://cursor.com/agents/bc-019e84d2-240a-70af-8384-10c9a32501d4/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fkaraoke_fullscreen_top_room_controls.mp4"><img src="https://cursor.com/artifacts/c/art-74d76cd1-2786-4c00-9e3f-8b05a5929ca5" alt="karaoke_fullscreen_top_room_controls.mp4" /></a>
<a href="https://cursor.com/agents/bc-019e84d2-240a-70af-8384-10c9a32501d4/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fkaraoke_mobile_top_room_controls.mp4"><img src="https://cursor.com/artifacts/c/art-e44bffd0-31ba-4810-bf82-de69a837ae26" alt="karaoke_mobile_top_room_controls.mp4" /></a>
<a href="https://cursor.com/agents/bc-019e84d2-240a-70af-8384-10c9a32501d4/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffullscreen_karaoke_ipod_controls_title_cards.mp4"><img src="https://cursor.com/artifacts/c/art-3147d5fb-5b4c-4682-851f-a7449979a422" alt="fullscreen_karaoke_ipod_controls_title_cards.mp4" /></a>

### Testing
- `bun run tsc --noEmit` passed.
- `bun test tests/test-karaoke-title-card.test.ts` passed.
- `bun run build` passed.
- Desktop browser walkthrough verified the bottom fullscreen controls are unchanged and the headphones/smiley controls render in a separate top-right listen-style toolbar.
- Mobile/narrow browser walkthrough verified the headphones/smiley controls render next to the top-right mobile X pill and remain absent from the bottom controls.
- Browser walkthrough also verified title cards appear in both karaoke and iPod fullscreen modes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019e84d2-240a-70af-8384-10c9a32501d4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019e84d2-240a-70af-8384-10c9a32501d4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

