### PR TITLE
Set ryOS root document background to black

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" data-os-theme="macosx" data-os-platform="mac" data-os-mac-chrome="aqua">
+<html lang="en" data-os-theme="macosx" data-os-platform="mac" data-os-mac-chrome="aqua" style="background-color: #000">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/x-icon" href="/favicon.ico" />

--- a/src/index.css
+++ b/src/index.css
@@ -106,6 +106,7 @@
     -webkit-touch-callout: none;
   }
   html {
+    background-color: #000;
     overscroll-behavior: none;
     overscroll-behavior-x: none;
     overscroll-behavior-y: none;
@@ -123,7 +124,8 @@
   }
 
   body {
-    @apply bg-background text-foreground;
+    @apply text-foreground;
+    background-color: #000;
     user-select: none;
     -webkit-user-select: none;
     font-family: "ChicagoKare", "ArkPixel", "SerenityOS-Emoji", system-ui,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Set the root HTML element and global body background to black so initial and post-CSS document paint do not flash white regardless of theme.

### Walkthrough
<a href="https://cursor.com/agents/bc-019e84e1-bec1-701e-9df3-d1be5b63dff7/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fryos_black_startup_xp_reload.mp4"><img src="https://cursor.com/artifacts/c/art-9b9830ee-4d7e-4baa-ac89-3110993fdabd" alt="ryos_black_startup_xp_reload.mp4" /></a>

### Testing
- Passed: `bun run build`
- Passed: generated `dist/index.html` inspection confirms inline black `html` and `body` startup backgrounds
- Passed: generated CSS inspection confirms black `html` and `body` backgrounds are emitted
- Passed: Playwright + system Chrome computed `html` and `body` as `rgb(0, 0, 0)` for `macosx`, `system7`, `xp`, and `win98`
- Passed: manual Chrome reload walkthrough showed no white flash and successful XP theme reload
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019e84e1-bec1-701e-9df3-d1be5b63dff7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019e84e1-bec1-701e-9df3-d1be5b63dff7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

