### PR TITLE
feat(control-panels): merge account actions into Account menu

### DIFF
--- a/src/apps/control-panels/components/control-panels-app/AccountActionsMenu.tsx
+++ b/src/apps/control-panels/components/control-panels-app/AccountActionsMenu.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
-import { CaretDown } from "@phosphor-icons/react";
+import { DotsThree } from "@phosphor-icons/react";
 import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -56,13 +57,13 @@ export function AccountActionsMenu({
       <DropdownMenuTrigger asChild>
         <Button
           variant="retro"
-          className="h-7 min-h-9 shrink-0 gap-1 px-2.5 sm:min-h-7"
+          className={cn(
+            "h-7 w-7 min-h-7 min-w-7 shrink-0 rounded-full p-0",
+            "inline-flex items-center justify-center"
+          )}
           aria-label={t("apps.control-panels.accountMenu")}
         >
-          <span className="font-geneva-12 text-[13px] leading-none">
-            {t("apps.control-panels.accountMenu")}
-          </span>
-          <CaretDown size={10} weight="bold" className="shrink-0" aria-hidden />
+          <DotsThree size={16} weight="bold" className="shrink-0" aria-hidden />
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end" side="bottom" sideOffset={4}>

--- a/src/apps/control-panels/components/control-panels-app/AccountActionsMenu.tsx
+++ b/src/apps/control-panels/components/control-panels-app/AccountActionsMenu.tsx
@@ -1,0 +1,121 @@
+import { useEffect, useState } from "react";
+import { CaretDown } from "@phosphor-icons/react";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+
+const menuItemClassName =
+  "text-md min-h-9 px-3 py-2 touch-manipulation cursor-pointer font-geneva-12";
+
+export type AccountActionsMenuProps = {
+  t: (key: string) => string;
+  hasPassword: boolean | null;
+  debugMode: boolean;
+  isLoggingOutAllDevices: boolean;
+  setPasswordInput: (value: string) => void;
+  setPasswordError: (error: string | null) => void;
+  setIsPasswordDialogOpen: (open: boolean) => void;
+  logout: () => void;
+  handleLogoutAllDevices: () => void;
+  promptVerifyToken: () => void;
+};
+
+export function AccountActionsMenu({
+  t,
+  hasPassword,
+  debugMode,
+  isLoggingOutAllDevices,
+  setPasswordInput,
+  setPasswordError,
+  setIsPasswordDialogOpen,
+  logout,
+  handleLogoutAllDevices,
+  promptVerifyToken,
+}: AccountActionsMenuProps) {
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    setOpen(false);
+  }, [hasPassword, isLoggingOutAllDevices]);
+
+  const openPasswordDialog = () => {
+    setPasswordInput("");
+    setPasswordError(null);
+    setIsPasswordDialogOpen(true);
+  };
+
+  const showChangePasswordActions = hasPassword !== false;
+
+  return (
+    <DropdownMenu open={open} onOpenChange={setOpen}>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="retro"
+          className="h-7 min-h-9 shrink-0 gap-1 px-2.5 sm:min-h-7"
+          aria-label={t("apps.control-panels.accountMenu")}
+        >
+          <span className="font-geneva-12 text-[13px] leading-none">
+            {t("apps.control-panels.accountMenu")}
+          </span>
+          <CaretDown size={10} weight="bold" className="shrink-0" aria-hidden />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" side="bottom" sideOffset={4}>
+        {debugMode ? (
+          <DropdownMenuItem
+            className={menuItemClassName}
+            onSelect={() => promptVerifyToken()}
+          >
+            {t("apps.control-panels.logIn")}
+          </DropdownMenuItem>
+        ) : null}
+        {showChangePasswordActions ? (
+          <>
+            <DropdownMenuItem
+              className={menuItemClassName}
+              onSelect={openPasswordDialog}
+            >
+              {t("apps.control-panels.changePassword")}
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              className={menuItemClassName}
+              onSelect={() => logout()}
+            >
+              {t("apps.control-panels.logOut")}
+            </DropdownMenuItem>
+          </>
+        ) : (
+          <DropdownMenuItem
+            className={menuItemClassName}
+            onSelect={openPasswordDialog}
+          >
+            {t("apps.control-panels.setPassword")}
+          </DropdownMenuItem>
+        )}
+        {debugMode ? (
+          <>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem
+              className={menuItemClassName}
+              disabled={isLoggingOutAllDevices}
+              onSelect={() => {
+                if (!isLoggingOutAllDevices) {
+                  handleLogoutAllDevices();
+                }
+              }}
+            >
+              {isLoggingOutAllDevices
+                ? t("apps.control-panels.loggingOut")
+                : t("apps.control-panels.logOutOfAllDevices")}
+            </DropdownMenuItem>
+          </>
+        ) : null}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/src/apps/control-panels/components/control-panels-app/SystemTabContent.tsx
+++ b/src/apps/control-panels/components/control-panels-app/SystemTabContent.tsx
@@ -22,6 +22,7 @@ import {
   controlPanelItemIconShell,
   userAvatarInitialsTextShadow,
 } from "./constants";
+import { AccountActionsMenu } from "./AccountActionsMenu";
 import { VersionDisplay } from "./VersionDisplay";
 
 export type SystemTabContentProps = {
@@ -170,58 +171,19 @@ export function SystemTabContent({
                   </span>
                 </div>
               </div>
-              <div className="flex gap-2">
-                {debugMode && (
-                  <Button variant="retro" onClick={promptVerifyToken} className="h-7">
-                    {t("apps.control-panels.logIn")}
-                  </Button>
-                )}
-                {hasPassword === false ? (
-                  <Button
-                    variant="retro"
-                    onClick={() => {
-                      setPasswordInput("");
-                      setPasswordError(null);
-                      setIsPasswordDialogOpen(true);
-                    }}
-                    className="h-7"
-                  >
-                    {t("apps.control-panels.setPassword")}
-                  </Button>
-                ) : (
-                  <>
-                    <Button
-                      variant="retro"
-                      onClick={() => {
-                        setPasswordInput("");
-                        setPasswordError(null);
-                        setIsPasswordDialogOpen(true);
-                      }}
-                      className="h-7"
-                    >
-                      {t("apps.control-panels.changePassword")}
-                    </Button>
-                    <Button variant="retro" onClick={logout} className="h-7">
-                      {t("apps.control-panels.logOut")}
-                    </Button>
-                  </>
-                )}
-              </div>
+              <AccountActionsMenu
+                t={t}
+                hasPassword={hasPassword}
+                debugMode={debugMode}
+                isLoggingOutAllDevices={isLoggingOutAllDevices}
+                setPasswordInput={setPasswordInput}
+                setPasswordError={setPasswordError}
+                setIsPasswordDialogOpen={setIsPasswordDialogOpen}
+                logout={logout}
+                handleLogoutAllDevices={handleLogoutAllDevices}
+                promptVerifyToken={promptVerifyToken}
+              />
             </div>
-            {debugMode && (
-              <div className="flex">
-                <Button
-                  variant="retro"
-                  onClick={handleLogoutAllDevices}
-                  disabled={isLoggingOutAllDevices}
-                  className="w-full"
-                >
-                  {isLoggingOutAllDevices
-                    ? t("apps.control-panels.loggingOut")
-                    : t("apps.control-panels.logOutOfAllDevices")}
-                </Button>
-              </div>
-            )}
           </div>
         ) : (
           <div className="space-y-2">

--- a/src/lib/locales/de/translation.json
+++ b/src/lib/locales/de/translation.json
@@ -992,6 +992,7 @@
         "listCursorCloudAgentRuns": {
           "listed": "Listed {{count}} recent run(s).",
           "loading": "Listing Cursor Cloud agent runs…",
+          "openDashboard": "Open agent in Cursor",
           "truncatedHint": "(list may be truncated)"
         },
         "listedItems": "Elemente aufgelistet",
@@ -1219,6 +1220,7 @@
       }
     },
     "control-panels": {
+      "accountMenu": "Account",
       "aiModel": "KI-Modell",
       "aiModelDescription": "Wird in Chats, IE und mehr verwendet",
       "alerts": {
@@ -1320,10 +1322,10 @@
       "crt": "CRT",
       "custom": "Benutzerdefiniert",
       "darkMode": "Dunkelmodus",
-      "darkModeDescription": "Dem System folgen oder die dunkle Variante erzwingen",
-      "darkModeSystem": "System",
-      "darkModeLight": "Hell",
       "darkModeDark": "Dunkel",
+      "darkModeDescription": "Dem System folgen oder die dunkle Variante erzwingen",
+      "darkModeLight": "Hell",
+      "darkModeSystem": "System",
       "debugMode": "Debug-Modus",
       "debugModeDescription": "Debugging-Einstellungen aktivieren",
       "default": "Standard",
@@ -3796,6 +3798,8 @@
       "appletStore": "Applet Store…",
       "controlPanels": "Systemsteuerung…",
       "createAccount": "Account erstellen…",
+      "enterFullScreen": "Vollbild aktivieren",
+      "exitFullScreen": "Vollbild beenden",
       "logOut": "{{username}} abmelden…",
       "login": "Anmelden…",
       "moreApps": "Mehr Apps…",
@@ -3804,9 +3808,7 @@
       "noRecentDocuments": "Keine kürzlich verwendeten Dokumente",
       "recentItems": "Benutzte Objekte",
       "softwareUpdate": "Softwareaktualisierung…",
-      "systemPreferences": "Systemeinstellungen…",
-      "enterFullScreen": "Vollbild aktivieren",
-      "exitFullScreen": "Vollbild beenden"
+      "systemPreferences": "Systemeinstellungen…"
     },
     "auth": {
       "changePassword": {

--- a/src/lib/locales/en/translation.json
+++ b/src/lib/locales/en/translation.json
@@ -2843,6 +2843,7 @@
         "disconnected": "Disconnected"
       },
       "logIn": "Log In",
+      "accountMenu": "Account",
       "setPassword": "Set Password",
       "changePassword": "Change Password",
       "logOut": "Log Out",

--- a/src/lib/locales/es/translation.json
+++ b/src/lib/locales/es/translation.json
@@ -992,6 +992,7 @@
         "listCursorCloudAgentRuns": {
           "listed": "Listed {{count}} recent run(s).",
           "loading": "Listing Cursor Cloud agent runs…",
+          "openDashboard": "Open agent in Cursor",
           "truncatedHint": "(list may be truncated)"
         },
         "listedItems": "Elementos listados",
@@ -1219,6 +1220,7 @@
       }
     },
     "control-panels": {
+      "accountMenu": "Account",
       "aiModel": "Modelo de IA",
       "aiModelDescription": "Usado en Chats, IE y más",
       "alerts": {
@@ -1320,10 +1322,10 @@
       "crt": "CRT",
       "custom": "Personalizado",
       "darkMode": "Modo oscuro",
-      "darkModeDescription": "Seguir al sistema o forzar la variante oscura",
-      "darkModeSystem": "Sistema",
-      "darkModeLight": "Claro",
       "darkModeDark": "Oscuro",
+      "darkModeDescription": "Seguir al sistema o forzar la variante oscura",
+      "darkModeLight": "Claro",
+      "darkModeSystem": "Sistema",
       "debugMode": "Modo de depuración",
       "debugModeDescription": "Habilitar ajustes de depuración",
       "default": "Predeterminado",
@@ -3796,6 +3798,8 @@
       "appletStore": "Applet Store…",
       "controlPanels": "Panel de Control…",
       "createAccount": "Crear Cuenta…",
+      "enterFullScreen": "Entrar en pantalla completa",
+      "exitFullScreen": "Salir de pantalla completa",
       "logOut": "Cerrar Sesión de {{username}}…",
       "login": "Iniciar Sesión…",
       "moreApps": "Más Apps…",
@@ -3804,9 +3808,7 @@
       "noRecentDocuments": "No hay documentos recientes",
       "recentItems": "Elementos Recientes",
       "softwareUpdate": "Actualización de Software…",
-      "systemPreferences": "Preferencias del Sistema…",
-      "enterFullScreen": "Entrar en pantalla completa",
-      "exitFullScreen": "Salir de pantalla completa"
+      "systemPreferences": "Preferencias del Sistema…"
     },
     "auth": {
       "changePassword": {

--- a/src/lib/locales/fr/translation.json
+++ b/src/lib/locales/fr/translation.json
@@ -992,6 +992,7 @@
         "listCursorCloudAgentRuns": {
           "listed": "Listed {{count}} recent run(s).",
           "loading": "Listing Cursor Cloud agent runs…",
+          "openDashboard": "Open agent in Cursor",
           "truncatedHint": "(list may be truncated)"
         },
         "listedItems": "Éléments listés",
@@ -1219,6 +1220,7 @@
       }
     },
     "control-panels": {
+      "accountMenu": "Account",
       "aiModel": "Modèle d'IA",
       "aiModelDescription": "Utilisé dans les discussions, IE, et plus encore",
       "alerts": {
@@ -1320,10 +1322,10 @@
       "crt": "CRT",
       "custom": "Personnalisé",
       "darkMode": "Mode sombre",
-      "darkModeDescription": "Suivre le système ou forcer la variante sombre",
-      "darkModeSystem": "Système",
-      "darkModeLight": "Clair",
       "darkModeDark": "Sombre",
+      "darkModeDescription": "Suivre le système ou forcer la variante sombre",
+      "darkModeLight": "Clair",
+      "darkModeSystem": "Système",
       "debugMode": "Mode débogage",
       "debugModeDescription": "Activer les réglages de débogage",
       "default": "Par défaut",
@@ -3796,6 +3798,8 @@
       "appletStore": "Applet Store…",
       "controlPanels": "Panneau de configuration…",
       "createAccount": "Créer un compte…",
+      "enterFullScreen": "Passer en plein écran",
+      "exitFullScreen": "Quitter le plein écran",
       "logOut": "Déconnecter {{username}}…",
       "login": "Connexion…",
       "moreApps": "Plus d'apps…",
@@ -3804,9 +3808,7 @@
       "noRecentDocuments": "Aucun document récent",
       "recentItems": "Éléments récents",
       "softwareUpdate": "Mise à jour de logiciels…",
-      "systemPreferences": "Préférences Système…",
-      "enterFullScreen": "Passer en plein écran",
-      "exitFullScreen": "Quitter le plein écran"
+      "systemPreferences": "Préférences Système…"
     },
     "auth": {
       "changePassword": {

--- a/src/lib/locales/it/translation.json
+++ b/src/lib/locales/it/translation.json
@@ -992,6 +992,7 @@
         "listCursorCloudAgentRuns": {
           "listed": "Listed {{count}} recent run(s).",
           "loading": "Listing Cursor Cloud agent runs…",
+          "openDashboard": "Open agent in Cursor",
           "truncatedHint": "(list may be truncated)"
         },
         "listedItems": "Elementi elencati",
@@ -1219,6 +1220,7 @@
       }
     },
     "control-panels": {
+      "accountMenu": "Account",
       "aiModel": "Modello AI",
       "aiModelDescription": "Utilizzato in Chat, IE e altro",
       "alerts": {
@@ -1320,10 +1322,10 @@
       "crt": "CRT",
       "custom": "Personalizzato",
       "darkMode": "Modalità scura",
-      "darkModeDescription": "Segui il sistema o forza la variante scura",
-      "darkModeSystem": "Sistema",
-      "darkModeLight": "Chiaro",
       "darkModeDark": "Scuro",
+      "darkModeDescription": "Segui il sistema o forza la variante scura",
+      "darkModeLight": "Chiaro",
+      "darkModeSystem": "Sistema",
       "debugMode": "Modalità Debug",
       "debugModeDescription": "Abilita impostazioni di debug",
       "default": "Predefinito",
@@ -3796,6 +3798,8 @@
       "appletStore": "Applet Store…",
       "controlPanels": "Pannello di Controllo…",
       "createAccount": "Crea Account…",
+      "enterFullScreen": "Attiva schermo intero",
+      "exitFullScreen": "Esci da schermo intero",
       "logOut": "Esci da {{username}}…",
       "login": "Accedi…",
       "moreApps": "Altre App…",
@@ -3804,9 +3808,7 @@
       "noRecentDocuments": "Nessun documento recente",
       "recentItems": "Elementi recenti",
       "softwareUpdate": "Aggiornamento Software…",
-      "systemPreferences": "Preferenze di Sistema…",
-      "enterFullScreen": "Attiva schermo intero",
-      "exitFullScreen": "Esci da schermo intero"
+      "systemPreferences": "Preferenze di Sistema…"
     },
     "auth": {
       "changePassword": {

--- a/src/lib/locales/ja/translation.json
+++ b/src/lib/locales/ja/translation.json
@@ -992,6 +992,7 @@
         "listCursorCloudAgentRuns": {
           "listed": "Listed {{count}} recent run(s).",
           "loading": "Listing Cursor Cloud agent runs…",
+          "openDashboard": "Open agent in Cursor",
           "truncatedHint": "(list may be truncated)"
         },
         "listedItems": "項目を一覧表示しました",
@@ -1219,6 +1220,7 @@
       }
     },
     "control-panels": {
+      "accountMenu": "Account",
       "aiModel": "AIモデル",
       "aiModelDescription": "チャット、IEなどで使用",
       "alerts": {
@@ -1320,10 +1322,10 @@
       "crt": "CRT",
       "custom": "カスタム",
       "darkMode": "ダークモード",
-      "darkModeDescription": "システムに合わせる、またはダークバリアントを強制する",
-      "darkModeSystem": "システム",
-      "darkModeLight": "ライト",
       "darkModeDark": "ダーク",
+      "darkModeDescription": "システムに合わせる、またはダークバリアントを強制する",
+      "darkModeLight": "ライト",
+      "darkModeSystem": "システム",
       "debugMode": "デバッグモード",
       "debugModeDescription": "デバッグ設定を有効にする",
       "default": "デフォルト",
@@ -3796,6 +3798,8 @@
       "appletStore": "アプレットストア…",
       "controlPanels": "コントロールパネル…",
       "createAccount": "アカウントを作成…",
+      "enterFullScreen": "フルスクリーンにする",
+      "exitFullScreen": "フルスクリーンを解除",
       "logOut": "{{username}}をログアウト…",
       "login": "ログイン…",
       "moreApps": "その他のアプリ…",
@@ -3804,9 +3808,7 @@
       "noRecentDocuments": "最近使った書類はありません",
       "recentItems": "最近使った項目",
       "softwareUpdate": "ソフトウェア・アップデート…",
-      "systemPreferences": "システム環境設定…",
-      "enterFullScreen": "フルスクリーンにする",
-      "exitFullScreen": "フルスクリーンを解除"
+      "systemPreferences": "システム環境設定…"
     },
     "auth": {
       "changePassword": {

--- a/src/lib/locales/ko/translation.json
+++ b/src/lib/locales/ko/translation.json
@@ -992,6 +992,7 @@
         "listCursorCloudAgentRuns": {
           "listed": "Listed {{count}} recent run(s).",
           "loading": "Listing Cursor Cloud agent runs…",
+          "openDashboard": "Open agent in Cursor",
           "truncatedHint": "(list may be truncated)"
         },
         "listedItems": "항목 목록 표시됨",
@@ -1219,6 +1220,7 @@
       }
     },
     "control-panels": {
+      "accountMenu": "Account",
       "aiModel": "AI 모델",
       "aiModelDescription": "채팅, IE 등에서 사용됨",
       "alerts": {
@@ -1320,10 +1322,10 @@
       "crt": "CRT",
       "custom": "사용자 설정",
       "darkMode": "다크 모드",
-      "darkModeDescription": "시스템 설정을 따르거나 어두운 버전을 강제로 사용합니다",
-      "darkModeSystem": "시스템",
-      "darkModeLight": "라이트",
       "darkModeDark": "다크",
+      "darkModeDescription": "시스템 설정을 따르거나 어두운 버전을 강제로 사용합니다",
+      "darkModeLight": "라이트",
+      "darkModeSystem": "시스템",
       "debugMode": "디버그 모드",
       "debugModeDescription": "디버깅 설정을 활성화합니다.",
       "default": "기본값",
@@ -3796,6 +3798,8 @@
       "appletStore": "애플릿 스토어…",
       "controlPanels": "제어판…",
       "createAccount": "계정 생성…",
+      "enterFullScreen": "전체 화면 사용",
+      "exitFullScreen": "전체 화면 종료",
       "logOut": "{{username}} 로그아웃…",
       "login": "로그인…",
       "moreApps": "더 많은 앱…",
@@ -3804,9 +3808,7 @@
       "noRecentDocuments": "최근 사용한 문서 없음",
       "recentItems": "최근 사용 항목",
       "softwareUpdate": "소프트웨어 업데이트…",
-      "systemPreferences": "시스템 환경설정…",
-      "enterFullScreen": "전체 화면 사용",
-      "exitFullScreen": "전체 화면 종료"
+      "systemPreferences": "시스템 환경설정…"
     },
     "auth": {
       "changePassword": {

--- a/src/lib/locales/pt/translation.json
+++ b/src/lib/locales/pt/translation.json
@@ -992,6 +992,7 @@
         "listCursorCloudAgentRuns": {
           "listed": "Listed {{count}} recent run(s).",
           "loading": "Listing Cursor Cloud agent runs…",
+          "openDashboard": "Open agent in Cursor",
           "truncatedHint": "(list may be truncated)"
         },
         "listedItems": "Itens listados",
@@ -1219,6 +1220,7 @@
       }
     },
     "control-panels": {
+      "accountMenu": "Account",
       "aiModel": "Modelo de IA",
       "aiModelDescription": "Usado em Chats, IE e mais",
       "alerts": {
@@ -1320,10 +1322,10 @@
       "crt": "CRT",
       "custom": "Personalizado",
       "darkMode": "Modo Escuro",
-      "darkModeDescription": "Seguir o sistema ou forçar a variante escura",
-      "darkModeSystem": "Sistema",
-      "darkModeLight": "Claro",
       "darkModeDark": "Escuro",
+      "darkModeDescription": "Seguir o sistema ou forçar a variante escura",
+      "darkModeLight": "Claro",
+      "darkModeSystem": "Sistema",
       "debugMode": "Modo Depuração",
       "debugModeDescription": "Ativar configurações de depuração",
       "default": "Padrão",
@@ -3796,6 +3798,8 @@
       "appletStore": "Applet Store…",
       "controlPanels": "Painel de Controlo…",
       "createAccount": "Criar Conta…",
+      "enterFullScreen": "Entrar em ecrã inteiro",
+      "exitFullScreen": "Sair de ecrã inteiro",
       "logOut": "Terminar Sessão de {{username}}…",
       "login": "Iniciar Sessão…",
       "moreApps": "Mais Apps…",
@@ -3804,9 +3808,7 @@
       "noRecentDocuments": "Nenhum documento recente",
       "recentItems": "Itens Recentes",
       "softwareUpdate": "Atualização de Software…",
-      "systemPreferences": "Preferências do Sistema…",
-      "enterFullScreen": "Entrar em ecrã inteiro",
-      "exitFullScreen": "Sair de ecrã inteiro"
+      "systemPreferences": "Preferências do Sistema…"
     },
     "auth": {
       "changePassword": {

--- a/src/lib/locales/ru/translation.json
+++ b/src/lib/locales/ru/translation.json
@@ -992,6 +992,7 @@
         "listCursorCloudAgentRuns": {
           "listed": "Listed {{count}} recent run(s).",
           "loading": "Listing Cursor Cloud agent runs…",
+          "openDashboard": "Open agent in Cursor",
           "truncatedHint": "(list may be truncated)"
         },
         "listedItems": "Перечисленные элементы",
@@ -1219,6 +1220,7 @@
       }
     },
     "control-panels": {
+      "accountMenu": "Account",
       "aiModel": "Модель ИИ",
       "aiModelDescription": "Используется в чатах, IE и других местах",
       "alerts": {
@@ -1320,10 +1322,10 @@
       "crt": "ЭЛТ",
       "custom": "Пользовательский",
       "darkMode": "Тёмный режим",
-      "darkModeDescription": "Следовать системе или принудительно использовать тёмный вариант",
-      "darkModeSystem": "Системный",
-      "darkModeLight": "Светлый",
       "darkModeDark": "Тёмный",
+      "darkModeDescription": "Следовать системе или принудительно использовать тёмный вариант",
+      "darkModeLight": "Светлый",
+      "darkModeSystem": "Системный",
       "debugMode": "Режим отладки",
       "debugModeDescription": "Включить параметры отладки",
       "default": "По умолчанию",
@@ -3796,6 +3798,8 @@
       "appletStore": "Applet Store…",
       "controlPanels": "Панель управления…",
       "createAccount": "Создать учётную запись…",
+      "enterFullScreen": "Перейти в полноэкранный режим",
+      "exitFullScreen": "Выйти из полноэкранного режима",
       "logOut": "Завершить сеанс {{username}}…",
       "login": "Войти…",
       "moreApps": "Другие программы…",
@@ -3804,9 +3808,7 @@
       "noRecentDocuments": "Нет недавних документов",
       "recentItems": "Недавние объекты",
       "softwareUpdate": "Обновление ПО…",
-      "systemPreferences": "Системные настройки…",
-      "enterFullScreen": "Перейти в полноэкранный режим",
-      "exitFullScreen": "Выйти из полноэкранного режима"
+      "systemPreferences": "Системные настройки…"
     },
     "auth": {
       "changePassword": {

--- a/src/lib/locales/zh-TW/translation.json
+++ b/src/lib/locales/zh-TW/translation.json
@@ -992,6 +992,7 @@
         "listCursorCloudAgentRuns": {
           "listed": "Listed {{count}} recent run(s).",
           "loading": "Listing Cursor Cloud agent runs…",
+          "openDashboard": "Open agent in Cursor",
           "truncatedHint": "(list may be truncated)"
         },
         "listedItems": "已列出項目",
@@ -1219,6 +1220,7 @@
       }
     },
     "control-panels": {
+      "accountMenu": "Account",
       "aiModel": "AI 模型",
       "aiModelDescription": "用於聊天、IE 等",
       "alerts": {
@@ -1320,10 +1322,10 @@
       "crt": "CRT",
       "custom": "自訂",
       "darkMode": "深色模式",
-      "darkModeDescription": "跟隨系統,或強制使用深色版本",
-      "darkModeSystem": "系統",
-      "darkModeLight": "淺色",
       "darkModeDark": "深色",
+      "darkModeDescription": "跟隨系統,或強制使用深色版本",
+      "darkModeLight": "淺色",
+      "darkModeSystem": "系統",
       "debugMode": "偵錯模式",
       "debugModeDescription": "啟用偵錯設定",
       "default": "預設",
@@ -3796,6 +3798,8 @@
       "appletStore": "小程式商店…",
       "controlPanels": "控制台…",
       "createAccount": "建立帳戶…",
+      "enterFullScreen": "進入全螢幕",
+      "exitFullScreen": "離開全螢幕",
       "logOut": "登出 {{username}}…",
       "login": "登入…",
       "moreApps": "更多 App…",
@@ -3804,9 +3808,7 @@
       "noRecentDocuments": "沒有最近使用的文件",
       "recentItems": "最近使用過的項目",
       "softwareUpdate": "軟體更新…",
-      "systemPreferences": "系統偏好設定…",
-      "enterFullScreen": "進入全螢幕",
-      "exitFullScreen": "離開全螢幕"
+      "systemPreferences": "系統偏好設定…"
     },
     "auth": {
       "changePassword": {

--- a/tests/test-control-panels-account-menu.test.ts
+++ b/tests/test-control-panels-account-menu.test.ts
@@ -1,0 +1,39 @@
+#!/usr/bin/env bun
+/**
+ * Wiring tests for Control Panels account actions menu.
+ */
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, test, expect } from "bun:test";
+
+const readSource = (relativePath: string): string =>
+  readFileSync(resolve(process.cwd(), relativePath), "utf-8");
+
+describe("Control Panels account actions menu", () => {
+  test("System tab uses AccountActionsMenu instead of separate account buttons", () => {
+    const systemTabSource = readSource(
+      "src/apps/control-panels/components/control-panels-app/SystemTabContent.tsx",
+    );
+    expect(systemTabSource.includes("<AccountActionsMenu")).toBe(true);
+    expect(systemTabSource.includes('t("apps.control-panels.changePassword")')).toBe(
+      false,
+    );
+    expect(systemTabSource.includes('t("apps.control-panels.logOut")')).toBe(false);
+  });
+
+  test("AccountActionsMenu exposes password, logout, and debug actions via dropdown", () => {
+    const menuSource = readSource(
+      "src/apps/control-panels/components/control-panels-app/AccountActionsMenu.tsx",
+    );
+    expect(menuSource.includes("DropdownMenu")).toBe(true);
+    expect(menuSource.includes('t("apps.control-panels.setPassword")')).toBe(true);
+    expect(menuSource.includes('t("apps.control-panels.changePassword")')).toBe(true);
+    expect(menuSource.includes('t("apps.control-panels.logOut")')).toBe(true);
+    expect(menuSource.includes('t("apps.control-panels.logOutOfAllDevices")')).toBe(
+      true,
+    );
+    expect(menuSource.includes("open={open}")).toBe(true);
+    expect(menuSource.includes("onOpenChange={setOpen}")).toBe(true);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Consolidates Control Panels System tab user/account actions into a compact **ellipsis** icon trigger (`h-7` × `w-7`, `rounded-full`) matching the height of adjacent link/manage buttons, with a dropdown for password, logout, and debug actions.

## Changes

- `AccountActionsMenu`: `DotsThree` icon button (same `h-7` as Telegram Link/Manage), circular via `w-7` + `rounded-full` + `p-0`.
- Dropdown behavior unchanged (theme-aware menu, dismiss rules, handlers preserved).

## Validation

| Check | Result |
|-------|--------|
| `bun test tests/test-control-panels-account-menu.test.ts` | pass |
| `bunx tsc -b` | pass |

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2db843d9-5fd7-41f0-a228-cca05b2cfbdf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2db843d9-5fd7-41f0-a228-cca05b2cfbdf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

