### PR TITLE
Fix Workbox stale app shell caching

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,7 +24,7 @@
     <meta name="msapplication-tap-highlight" content="no" />
 
     <!-- Cache control -->
-    <meta http-equiv="Cache-Control" content="max-age=86400" />
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
 
     <!-- Preconnect to external domains for faster resource loading -->
     <link rel="preconnect" href="https://www.youtube.com" />

--- a/vercel.json
+++ b/vercel.json
@@ -212,6 +212,24 @@
       ]
     },
     {
+      "source": "/",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "no-cache, no-store, must-revalidate"
+        }
+      ]
+    },
+    {
+      "source": "/:path(index.html|sw.js|registerSW.js)",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "no-cache, no-store, must-revalidate"
+        }
+      ]
+    },
+    {
       "source": "/version.json",
       "headers": [
         {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -382,52 +382,56 @@ export default defineConfig({
         ],
       },
       workbox: {
-        // Exclude API routes, iframe content, and app deep links from navigation fallback
-        // This prevents the SW from returning index.html for API/iframe requests
-        // and allows the middleware to handle OG meta tags for shared links
-        // IMPORTANT: Safari has issues with service worker responses that contain redirections.
-        // The middleware returns HTML with location.replace() which Safari treats as a redirect.
-        // By denying these routes, the request goes directly to the server/middleware.
-        navigateFallbackDenylist: [
-          /^\/api\//,  // API routes
-          /^\/embed\//,  // embed wrapper pages (e.g. infinite-mac with COEP)
-          /^\/iframe-check/,  // iframe proxy endpoint
-          /^\/404/,  // Don't intercept 404 redirects
-          /^\/docs(\/|$)/,  // Documentation pages - serve static HTML files directly (including /docs root redirect)
-          // App routes handled by middleware for OG preview links
-          // These need to reach the middleware first, then redirect to ?_ryo=1
-          /^\/finder$/,
-          /^\/soundboard$/,
-          /^\/internet-explorer(\/|$)/,
-          /^\/chats$/,
-          /^\/textedit$/,
-          /^\/paint$/,
-          /^\/photo-booth$/,
-          /^\/minesweeper$/,
-          /^\/videos(\/|$)/,
-          /^\/tv$/,
-          /^\/ipod(\/|$)/,
-          /^\/karaoke(\/|$)/,
-          /^\/listen(\/|$)/,
-          /^\/synth$/,
-          /^\/pc$/,
-          /^\/terminal$/,
-          /^\/applet-viewer(\/|$)/,
-          /^\/control-panels$/,
-          /^\/dashboard$/,
-        ],
-        // Enable navigation fallback to precached index.html for offline support
-        // This ensures the app can start when offline by serving the cached shell
-        navigateFallback: 'index.html',
+        // Do not let Workbox auto-register a precached navigation fallback.
+        // GenerateSW emits that route before runtimeCaching, which means it can
+        // serve an old precached index.html before our NetworkFirst navigation
+        // route below gets a chance to fetch the latest shell.
+        navigateFallback: null,
+        // Prevent precacheAndRoute from mapping "/" directly to cached
+        // index.html; navigations should flow through the NetworkFirst route.
+        directoryIndex: null,
         // Cache strategy for different asset types
         runtimeCaching: [
           {
-            // Navigation requests (/, /foo, etc.) - network first to avoid stale index.html
-            // Critical for Safari which can error on missing chunks after updates
-            urlPattern: ({ request }) => request.mode === 'navigate',
+            // Navigation requests (/, /foo, etc.) - network first to avoid stale index.html.
+            // If the network is unavailable, fall back to the precached shell for offline use.
+            // Denied routes still go to the server/middleware for APIs, embeds,
+            // docs, redirects, and OG preview links.
+            urlPattern: ({ request, url }: { request: Request; url: URL }) => {
+              if (request.mode !== 'navigate') return false;
+              return ![
+                /^\/api\//,
+                /^\/embed\//,
+                /^\/iframe-check/,
+                /^\/404/,
+                /^\/docs(\/|$)/,
+                /^\/finder$/,
+                /^\/soundboard$/,
+                /^\/internet-explorer(\/|$)/,
+                /^\/chats$/,
+                /^\/textedit$/,
+                /^\/paint$/,
+                /^\/photo-booth$/,
+                /^\/minesweeper$/,
+                /^\/videos(\/|$)/,
+                /^\/tv$/,
+                /^\/ipod(\/|$)/,
+                /^\/karaoke(\/|$)/,
+                /^\/listen(\/|$)/,
+                /^\/synth$/,
+                /^\/pc$/,
+                /^\/terminal$/,
+                /^\/applet-viewer(\/|$)/,
+                /^\/control-panels$/,
+                /^\/dashboard$/,
+              ].some((pattern) => pattern.test(url.pathname));
+            },
             handler: "NetworkFirst",
             options: {
               cacheName: "html-pages",
+              precacheFallback: {
+                fallbackURL: "/index.html",
+              },
               expiration: {
                 maxEntries: 10,
                 maxAgeSeconds: 60 * 60 * 24, // 1 day


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Disable Workbox's generated precached navigation fallback so it cannot serve an old `index.html` before the NetworkFirst navigation route runs.
- Route app-shell navigations through NetworkFirst with a precached offline fallback.
- Add no-store cache headers for the root shell and service-worker registration files.

## Testing
- `bun run build`
- inspected generated `dist/sw.js` to confirm `precacheAndRoute(..., { directoryIndex: null })` and NetworkFirst + PrecacheFallbackPlugin route order
- `bun test tests/test-reload-guard.test.ts`
- `bun -e "JSON.parse(await Bun.file('vercel.json').text()); console.log('vercel.json ok')"`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019e86ac-2fd1-7874-b8fd-79687c73c56c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019e86ac-2fd1-7874-b8fd-79687c73c56c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

