### PR TITLE
Skip cached cover color recalculation

### DIFF
--- a/src/apps/ipod/components/lyrics-display/colorUtils.ts
+++ b/src/apps/ipod/components/lyrics-display/colorUtils.ts
@@ -16,6 +16,17 @@ export function normalizeCoverColor(hex: string | null | undefined): string | un
   return trimmed.toLowerCase();
 }
 
+export function getNewCoverColorToSave(
+  resolvedCoverColor: string,
+  cachedCoverColor: string | null | undefined
+): string | undefined {
+  const normalized = normalizeCoverColor(resolvedCoverColor);
+  if (!normalized || normalizeCoverColor(cachedCoverColor)) {
+    return undefined;
+  }
+  return normalized;
+}
+
 function hexToRgb(hex: string): [number, number, number] {
   const m = /^#([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})$/i.exec(hex);
   if (!m) return [255, 215, 0];

--- a/src/apps/ipod/hooks/useLibraryUpdateChecker.ts
+++ b/src/apps/ipod/hooks/useLibraryUpdateChecker.ts
@@ -4,6 +4,7 @@ import { useDisplaySettingsStore } from "@/stores/useDisplaySettingsStore";
 import { toast } from "sonner";
 import { useTranslation } from "react-i18next";
 import { listAllCachedSongMetadata } from "@/utils/songMetadataCache";
+import { hasLibraryTrackMetadataChanges } from "@/stores/ipodTrackMetadataSync";
 
 const CHECK_INTERVAL = 5 * 60 * 1000; // Check every 5 minutes
 
@@ -71,23 +72,9 @@ export function useLibraryUpdateChecker(isActive: boolean) {
         currentTracks.forEach((currentTrack) => {
           const serverTrack = serverTrackMap.get(currentTrack.id);
           if (serverTrack) {
-            // Check if lyricsSource should be updated (new or different hash)
-            const shouldUpdateLyricsSource =
-              serverTrack.lyricsSource && (
-                !currentTrack.lyricsSource ||
-                currentTrack.lyricsSource.hash !== serverTrack.lyricsSource.hash
-              );
-
-            const hasChanges =
-              currentTrack.title !== serverTrack.title ||
-              currentTrack.artist !== serverTrack.artist ||
-              currentTrack.album !== serverTrack.album ||
-              currentTrack.cover !== serverTrack.cover ||
-              currentTrack.coverColor !== serverTrack.coverColor ||
-              currentTrack.url !== serverTrack.url ||
-              currentTrack.lyricOffset !== serverTrack.lyricOffset ||
-              shouldUpdateLyricsSource;
-            if (hasChanges) tracksUpdated++;
+            if (hasLibraryTrackMetadataChanges(currentTrack, serverTrack)) {
+              tracksUpdated++;
+            }
           }
         });
 

--- a/src/apps/ipod/hooks/useLibraryUpdateChecker.ts
+++ b/src/apps/ipod/hooks/useLibraryUpdateChecker.ts
@@ -91,6 +91,10 @@ export function useLibraryUpdateChecker(isActive: boolean) {
           // Auto-update: directly sync without asking user
           try {
             const result = await syncLibrary();
+            if (result.newTracksAdded === 0 && result.tracksUpdated === 0) {
+              console.log("[iPod] Auto update check resolved with no applied changes");
+              return;
+            }
             const message =
               wasEmpty && result.newTracksAdded > 0
                 ? t("apps.ipod.dialogs.addedSongsToTop", {

--- a/src/hooks/useCoverGlowColor.ts
+++ b/src/hooks/useCoverGlowColor.ts
@@ -12,6 +12,13 @@ interface CoverGlowColorOptions {
   onResolved?: (coverColor: string, coverUrl: string) => void;
 }
 
+export function shouldExtractCoverGlowColor(
+  enabled: boolean,
+  coverColor: string | null | undefined
+): boolean {
+  return enabled && !normalizeCoverColor(coverColor);
+}
+
 export function useCoverGlowColor({
   coverUrl,
   coverColor,
@@ -22,7 +29,7 @@ export function useCoverGlowColor({
     () => normalizeCoverColor(coverColor),
     [coverColor]
   );
-  const shouldExtract = enabled && !cachedCoverColor;
+  const shouldExtract = shouldExtractCoverGlowColor(enabled, coverColor);
   const paletteResult = useCoverPaletteResult(
     shouldExtract ? (coverUrl ?? null) : null
   );

--- a/src/hooks/useSaveSongCoverColor.ts
+++ b/src/hooks/useSaveSongCoverColor.ts
@@ -11,6 +11,17 @@ interface SongCoverColorTrack {
   coverColor?: string | null;
 }
 
+export function getNewCoverColorToSave(
+  resolvedCoverColor: string,
+  cachedCoverColor: string | null | undefined
+): string | undefined {
+  const normalized = normalizeCoverColor(resolvedCoverColor);
+  if (!normalized || normalizeCoverColor(cachedCoverColor)) {
+    return undefined;
+  }
+  return normalized;
+}
+
 export function useSaveSongCoverColor(track: SongCoverColorTrack | null) {
   const savedKeysRef = useRef<Set<string>>(new Set());
   const username = useChatsStore((state) => state.username);
@@ -19,8 +30,11 @@ export function useSaveSongCoverColor(track: SongCoverColorTrack | null) {
 
   return useCallback(
     async (coverColor: string, coverUrl: string) => {
-      const normalized = normalizeCoverColor(coverColor);
-      if (!track || !normalized || normalizeCoverColor(track.coverColor) === normalized) {
+      if (!track) {
+        return;
+      }
+      const normalized = getNewCoverColorToSave(coverColor, track.coverColor);
+      if (!normalized) {
         return;
       }
       setTrackCoverColor(track.id, normalized);

--- a/src/hooks/useSaveSongCoverColor.ts
+++ b/src/hooks/useSaveSongCoverColor.ts
@@ -1,6 +1,7 @@
 import { useCallback, useRef } from "react";
 import { updateSongById } from "@/api/songs";
 import {
+  getNewCoverColorToSave,
   normalizeCoverColor,
 } from "@/apps/ipod/components/lyrics-display/colorUtils";
 import { useChatsStore } from "@/stores/useChatsStore";
@@ -9,17 +10,6 @@ import { useIpodStore } from "@/stores/useIpodStore";
 interface SongCoverColorTrack {
   id: string;
   coverColor?: string | null;
-}
-
-export function getNewCoverColorToSave(
-  resolvedCoverColor: string,
-  cachedCoverColor: string | null | undefined
-): string | undefined {
-  const normalized = normalizeCoverColor(resolvedCoverColor);
-  if (!normalized || normalizeCoverColor(cachedCoverColor)) {
-    return undefined;
-  }
-  return normalized;
 }
 
 export function useSaveSongCoverColor(track: SongCoverColorTrack | null) {

--- a/src/hooks/useSaveSongCoverColor.ts
+++ b/src/hooks/useSaveSongCoverColor.ts
@@ -1,9 +1,6 @@
 import { useCallback, useRef } from "react";
 import { updateSongById } from "@/api/songs";
-import {
-  getNewCoverColorToSave,
-  normalizeCoverColor,
-} from "@/apps/ipod/components/lyrics-display/colorUtils";
+import { getNewCoverColorToSave } from "@/apps/ipod/components/lyrics-display/colorUtils";
 import { useChatsStore } from "@/stores/useChatsStore";
 import { useIpodStore } from "@/stores/useIpodStore";
 

--- a/src/stores/ipodTrackMetadataSync.ts
+++ b/src/stores/ipodTrackMetadataSync.ts
@@ -24,23 +24,12 @@ export function hasCoverColorMetadataChange(
   currentTrack: TrackMetadataFields,
   serverTrack: TrackMetadataFields
 ): boolean {
+  const serverCoverColor = normalizeCoverColorForSync(serverTrack.coverColor);
+  if (!serverCoverColor) return false;
   return (
     normalizeCoverColorForSync(currentTrack.coverColor) !==
-    normalizeCoverColorForSync(serverTrack.coverColor)
+    serverCoverColor
   );
-}
-
-export function getCoverColorToSyncToRemote(
-  currentTrack: TrackMetadataFields,
-  serverTrack: TrackMetadataFields
-): string | undefined {
-  const currentCoverColor = normalizeCoverColorForSync(currentTrack.coverColor);
-  const serverCoverColor = normalizeCoverColorForSync(serverTrack.coverColor);
-  if (!currentCoverColor || serverCoverColor) return undefined;
-  if (serverTrack.cover !== undefined && currentTrack.cover !== serverTrack.cover) {
-    return undefined;
-  }
-  return currentCoverColor;
 }
 
 export function shouldUpdateTrackLyricsSource(
@@ -54,7 +43,7 @@ export function shouldUpdateTrackLyricsSource(
   );
 }
 
-export function hasLibraryTrackMetadataChangesExcludingCoverColor(
+export function hasLibraryTrackMetadataChanges(
   currentTrack: TrackMetadataFields,
   serverTrack: TrackMetadataFields
 ): boolean {
@@ -63,37 +52,10 @@ export function hasLibraryTrackMetadataChangesExcludingCoverColor(
     currentTrack.artist !== serverTrack.artist ||
     currentTrack.album !== serverTrack.album ||
     currentTrack.cover !== serverTrack.cover ||
+    hasCoverColorMetadataChange(currentTrack, serverTrack) ||
     currentTrack.url !== serverTrack.url ||
     currentTrack.lyricOffset !== serverTrack.lyricOffset ||
     shouldUpdateTrackLyricsSource(currentTrack, serverTrack)
-  );
-}
-
-export function hasLibraryTrackMetadataChanges(
-  currentTrack: TrackMetadataFields,
-  serverTrack: TrackMetadataFields
-): boolean {
-  return (
-    hasLibraryTrackMetadataChangesExcludingCoverColor(
-      currentTrack,
-      serverTrack
-    ) ||
-    hasCoverColorMetadataChange(currentTrack, serverTrack)
-  );
-}
-
-export function hasFetchedTrackMetadataChangesExcludingCoverColor(
-  currentTrack: TrackMetadataFields,
-  fetchedTrack: TrackMetadataFields
-): boolean {
-  return Boolean(
-    (fetchedTrack.title && fetchedTrack.title !== currentTrack.title) ||
-      (fetchedTrack.artist && fetchedTrack.artist !== currentTrack.artist) ||
-      (fetchedTrack.album && fetchedTrack.album !== currentTrack.album) ||
-      (fetchedTrack.cover && fetchedTrack.cover !== currentTrack.cover) ||
-      (fetchedTrack.lyricOffset !== undefined &&
-        fetchedTrack.lyricOffset !== currentTrack.lyricOffset) ||
-      shouldUpdateTrackLyricsSource(currentTrack, fetchedTrack)
   );
 }
 
@@ -102,11 +64,14 @@ export function hasFetchedTrackMetadataChanges(
   fetchedTrack: TrackMetadataFields
 ): boolean {
   return Boolean(
-    hasFetchedTrackMetadataChangesExcludingCoverColor(
-      currentTrack,
-      fetchedTrack
-    ) ||
-      hasCoverColorMetadataChange(currentTrack, fetchedTrack)
+    (fetchedTrack.title && fetchedTrack.title !== currentTrack.title) ||
+      (fetchedTrack.artist && fetchedTrack.artist !== currentTrack.artist) ||
+      (fetchedTrack.album && fetchedTrack.album !== currentTrack.album) ||
+      (fetchedTrack.cover && fetchedTrack.cover !== currentTrack.cover) ||
+      hasCoverColorMetadataChange(currentTrack, fetchedTrack) ||
+      (fetchedTrack.lyricOffset !== undefined &&
+        fetchedTrack.lyricOffset !== currentTrack.lyricOffset) ||
+      shouldUpdateTrackLyricsSource(currentTrack, fetchedTrack)
   );
 }
 

--- a/src/stores/ipodTrackMetadataSync.ts
+++ b/src/stores/ipodTrackMetadataSync.ts
@@ -1,0 +1,65 @@
+interface TrackLyricsSourceFields {
+  hash?: string;
+}
+
+interface TrackMetadataFields {
+  title?: string;
+  artist?: string;
+  album?: string;
+  cover?: string;
+  coverColor?: string;
+  url?: string;
+  lyricOffset?: number;
+  lyricsSource?: TrackLyricsSourceFields | null;
+}
+
+export function shouldUpdateTrackLyricsSource(
+  currentTrack: TrackMetadataFields,
+  serverTrack: TrackMetadataFields
+): boolean {
+  return Boolean(
+    serverTrack.lyricsSource &&
+      (!currentTrack.lyricsSource ||
+        currentTrack.lyricsSource.hash !== serverTrack.lyricsSource.hash)
+  );
+}
+
+export function hasLibraryTrackMetadataChanges(
+  currentTrack: TrackMetadataFields,
+  serverTrack: TrackMetadataFields
+): boolean {
+  return (
+    currentTrack.title !== serverTrack.title ||
+    currentTrack.artist !== serverTrack.artist ||
+    currentTrack.album !== serverTrack.album ||
+    currentTrack.cover !== serverTrack.cover ||
+    currentTrack.url !== serverTrack.url ||
+    currentTrack.lyricOffset !== serverTrack.lyricOffset ||
+    shouldUpdateTrackLyricsSource(currentTrack, serverTrack)
+  );
+}
+
+export function hasFetchedTrackMetadataChanges(
+  currentTrack: TrackMetadataFields,
+  fetchedTrack: TrackMetadataFields
+): boolean {
+  return Boolean(
+    (fetchedTrack.title && fetchedTrack.title !== currentTrack.title) ||
+      (fetchedTrack.artist && fetchedTrack.artist !== currentTrack.artist) ||
+      (fetchedTrack.album && fetchedTrack.album !== currentTrack.album) ||
+      (fetchedTrack.cover && fetchedTrack.cover !== currentTrack.cover) ||
+      (fetchedTrack.lyricOffset !== undefined &&
+        fetchedTrack.lyricOffset !== currentTrack.lyricOffset) ||
+      shouldUpdateTrackLyricsSource(currentTrack, fetchedTrack)
+  );
+}
+
+export function resolveSyncedCoverColor(
+  currentTrack: TrackMetadataFields,
+  serverTrack: TrackMetadataFields
+): string | undefined {
+  return serverTrack.cover === undefined ||
+    currentTrack.cover === serverTrack.cover
+    ? currentTrack.coverColor
+    : serverTrack.coverColor;
+}

--- a/src/stores/ipodTrackMetadataSync.ts
+++ b/src/stores/ipodTrackMetadataSync.ts
@@ -30,6 +30,19 @@ export function hasCoverColorMetadataChange(
   );
 }
 
+export function getCoverColorToSyncToRemote(
+  currentTrack: TrackMetadataFields,
+  serverTrack: TrackMetadataFields
+): string | undefined {
+  const currentCoverColor = normalizeCoverColorForSync(currentTrack.coverColor);
+  const serverCoverColor = normalizeCoverColorForSync(serverTrack.coverColor);
+  if (!currentCoverColor || serverCoverColor) return undefined;
+  if (serverTrack.cover !== undefined && currentTrack.cover !== serverTrack.cover) {
+    return undefined;
+  }
+  return currentCoverColor;
+}
+
 export function shouldUpdateTrackLyricsSource(
   currentTrack: TrackMetadataFields,
   serverTrack: TrackMetadataFields
@@ -41,7 +54,7 @@ export function shouldUpdateTrackLyricsSource(
   );
 }
 
-export function hasLibraryTrackMetadataChanges(
+export function hasLibraryTrackMetadataChangesExcludingCoverColor(
   currentTrack: TrackMetadataFields,
   serverTrack: TrackMetadataFields
 ): boolean {
@@ -50,14 +63,26 @@ export function hasLibraryTrackMetadataChanges(
     currentTrack.artist !== serverTrack.artist ||
     currentTrack.album !== serverTrack.album ||
     currentTrack.cover !== serverTrack.cover ||
-    hasCoverColorMetadataChange(currentTrack, serverTrack) ||
     currentTrack.url !== serverTrack.url ||
     currentTrack.lyricOffset !== serverTrack.lyricOffset ||
     shouldUpdateTrackLyricsSource(currentTrack, serverTrack)
   );
 }
 
-export function hasFetchedTrackMetadataChanges(
+export function hasLibraryTrackMetadataChanges(
+  currentTrack: TrackMetadataFields,
+  serverTrack: TrackMetadataFields
+): boolean {
+  return (
+    hasLibraryTrackMetadataChangesExcludingCoverColor(
+      currentTrack,
+      serverTrack
+    ) ||
+    hasCoverColorMetadataChange(currentTrack, serverTrack)
+  );
+}
+
+export function hasFetchedTrackMetadataChangesExcludingCoverColor(
   currentTrack: TrackMetadataFields,
   fetchedTrack: TrackMetadataFields
 ): boolean {
@@ -66,10 +91,22 @@ export function hasFetchedTrackMetadataChanges(
       (fetchedTrack.artist && fetchedTrack.artist !== currentTrack.artist) ||
       (fetchedTrack.album && fetchedTrack.album !== currentTrack.album) ||
       (fetchedTrack.cover && fetchedTrack.cover !== currentTrack.cover) ||
-      hasCoverColorMetadataChange(currentTrack, fetchedTrack) ||
       (fetchedTrack.lyricOffset !== undefined &&
         fetchedTrack.lyricOffset !== currentTrack.lyricOffset) ||
       shouldUpdateTrackLyricsSource(currentTrack, fetchedTrack)
+  );
+}
+
+export function hasFetchedTrackMetadataChanges(
+  currentTrack: TrackMetadataFields,
+  fetchedTrack: TrackMetadataFields
+): boolean {
+  return Boolean(
+    hasFetchedTrackMetadataChangesExcludingCoverColor(
+      currentTrack,
+      fetchedTrack
+    ) ||
+      hasCoverColorMetadataChange(currentTrack, fetchedTrack)
   );
 }
 

--- a/src/stores/ipodTrackMetadataSync.ts
+++ b/src/stores/ipodTrackMetadataSync.ts
@@ -77,8 +77,10 @@ export function resolveSyncedCoverColor(
   currentTrack: TrackMetadataFields,
   serverTrack: TrackMetadataFields
 ): string | undefined {
+  const currentCoverColor = normalizeCoverColorForSync(currentTrack.coverColor);
+  const serverCoverColor = normalizeCoverColorForSync(serverTrack.coverColor);
   if (serverTrack.cover !== undefined && currentTrack.cover !== serverTrack.cover) {
-    return serverTrack.coverColor;
+    return serverCoverColor;
   }
-  return serverTrack.coverColor ?? currentTrack.coverColor;
+  return serverCoverColor ?? currentCoverColor;
 }

--- a/src/stores/ipodTrackMetadataSync.ts
+++ b/src/stores/ipodTrackMetadataSync.ts
@@ -13,6 +13,23 @@ interface TrackMetadataFields {
   lyricsSource?: TrackLyricsSourceFields | null;
 }
 
+function normalizeCoverColorForSync(
+  coverColor: string | null | undefined
+): string | undefined {
+  const trimmed = coverColor?.trim();
+  return trimmed ? trimmed.toLowerCase() : undefined;
+}
+
+export function hasCoverColorMetadataChange(
+  currentTrack: TrackMetadataFields,
+  serverTrack: TrackMetadataFields
+): boolean {
+  return (
+    normalizeCoverColorForSync(currentTrack.coverColor) !==
+    normalizeCoverColorForSync(serverTrack.coverColor)
+  );
+}
+
 export function shouldUpdateTrackLyricsSource(
   currentTrack: TrackMetadataFields,
   serverTrack: TrackMetadataFields
@@ -33,6 +50,7 @@ export function hasLibraryTrackMetadataChanges(
     currentTrack.artist !== serverTrack.artist ||
     currentTrack.album !== serverTrack.album ||
     currentTrack.cover !== serverTrack.cover ||
+    hasCoverColorMetadataChange(currentTrack, serverTrack) ||
     currentTrack.url !== serverTrack.url ||
     currentTrack.lyricOffset !== serverTrack.lyricOffset ||
     shouldUpdateTrackLyricsSource(currentTrack, serverTrack)
@@ -48,6 +66,7 @@ export function hasFetchedTrackMetadataChanges(
       (fetchedTrack.artist && fetchedTrack.artist !== currentTrack.artist) ||
       (fetchedTrack.album && fetchedTrack.album !== currentTrack.album) ||
       (fetchedTrack.cover && fetchedTrack.cover !== currentTrack.cover) ||
+      hasCoverColorMetadataChange(currentTrack, fetchedTrack) ||
       (fetchedTrack.lyricOffset !== undefined &&
         fetchedTrack.lyricOffset !== currentTrack.lyricOffset) ||
       shouldUpdateTrackLyricsSource(currentTrack, fetchedTrack)
@@ -58,8 +77,8 @@ export function resolveSyncedCoverColor(
   currentTrack: TrackMetadataFields,
   serverTrack: TrackMetadataFields
 ): string | undefined {
-  return serverTrack.cover === undefined ||
-    currentTrack.cover === serverTrack.cover
-    ? currentTrack.coverColor
-    : serverTrack.coverColor;
+  if (serverTrack.cover !== undefined && currentTrack.cover !== serverTrack.cover) {
+    return serverTrack.coverColor;
+  }
+  return serverTrack.coverColor ?? currentTrack.coverColor;
 }

--- a/src/stores/useIpodStore.ts
+++ b/src/stores/useIpodStore.ts
@@ -24,6 +24,12 @@ import {
 import { emitCloudSyncDomainChange } from "@/utils/cloudSyncEvents";
 import { sortTracksLikeServerOrder } from "@/stores/ipodTrackOrder";
 import {
+  hasFetchedTrackMetadataChanges,
+  hasLibraryTrackMetadataChanges,
+  resolveSyncedCoverColor,
+  shouldUpdateTrackLyricsSource,
+} from "@/stores/ipodTrackMetadataSync";
+import {
   saveAppleMusicLibrary,
   saveAppleMusicPlaylistTracks,
   saveAppleMusicTrackCollection,
@@ -1938,24 +1944,14 @@ export const useIpodStore = create<IpodState>()(
           const updatedTracks = current.tracks.map((currentTrack) => {
             const serverTrack = serverTrackMap.get(currentTrack.id);
             if (serverTrack) {
-              // Track exists on server, check if metadata needs updating
-              const hasMetadataChanges =
-                currentTrack.title !== serverTrack.title ||
-                currentTrack.artist !== serverTrack.artist ||
-                currentTrack.album !== serverTrack.album ||
-                currentTrack.cover !== serverTrack.cover ||
-                currentTrack.coverColor !== serverTrack.coverColor ||
-                currentTrack.url !== serverTrack.url ||
-                currentTrack.lyricOffset !== serverTrack.lyricOffset;
-
-              // Check if we should update lyricsSource:
-              // - Server has lyricsSource but user doesn't have one yet
-              // - Server has a different lyricsSource (compare by hash)
-              const shouldUpdateLyricsSource =
-                serverTrack.lyricsSource && (
-                  !currentTrack.lyricsSource ||
-                  currentTrack.lyricsSource.hash !== serverTrack.lyricsSource.hash
-                );
+              const hasMetadataChanges = hasLibraryTrackMetadataChanges(
+                currentTrack,
+                serverTrack
+              );
+              const shouldUpdateLyricsSource = shouldUpdateTrackLyricsSource(
+                currentTrack,
+                serverTrack
+              );
 
               const mergedCreatedAt = Math.max(
                 currentTrack.createdAt ?? 0,
@@ -1980,7 +1976,10 @@ export const useIpodStore = create<IpodState>()(
                   artist: serverTrack.artist,
                   album: serverTrack.album,
                   cover: serverTrack.cover,
-                  coverColor: serverTrack.coverColor,
+                  coverColor: resolveSyncedCoverColor(
+                    currentTrack,
+                    serverTrack
+                  ),
                   url: serverTrack.url,
                   lyricOffset: serverTrack.lyricOffset,
                   ...(shouldUpdateLyricsSource && {
@@ -2053,22 +2052,11 @@ export const useIpodStore = create<IpodState>()(
                 finalTracks = finalTracks.map((track) => {
                   const fetched = fetchedMap.get(track.id);
                   if (fetched) {
-                    // Check if lyricsSource should be updated (new or different hash)
-                    const shouldUpdateLyricsSource =
-                      fetched.lyricsSource && (
-                        !track.lyricsSource ||
-                        track.lyricsSource.hash !== fetched.lyricsSource.hash
-                      );
-
-                    // Check if any metadata has changed
-                    const hasChanges =
-                      (fetched.title && fetched.title !== track.title) ||
-                      (fetched.artist && fetched.artist !== track.artist) ||
-                      (fetched.album && fetched.album !== track.album) ||
-                      (fetched.cover && fetched.cover !== track.cover) ||
-                      (fetched.coverColor && fetched.coverColor !== track.coverColor) ||
-                      (fetched.lyricOffset !== undefined && fetched.lyricOffset !== track.lyricOffset) ||
-                      shouldUpdateLyricsSource;
+                    const shouldUpdateLyricsSource = shouldUpdateTrackLyricsSource(
+                      track,
+                      fetched
+                    );
+                    const hasChanges = hasFetchedTrackMetadataChanges(track, fetched);
 
                     if (hasChanges) {
                       tracksUpdated++;
@@ -2079,7 +2067,7 @@ export const useIpodStore = create<IpodState>()(
                         artist: fetched.artist ?? track.artist,
                         album: fetched.album ?? track.album,
                         cover: fetched.cover ?? track.cover,
-                        coverColor: fetched.coverColor ?? track.coverColor,
+                        coverColor: resolveSyncedCoverColor(track, fetched),
                         lyricOffset: fetched.lyricOffset ?? track.lyricOffset,
                         createdAt: Math.max(
                           track.createdAt ?? 0,

--- a/src/stores/useIpodStore.ts
+++ b/src/stores/useIpodStore.ts
@@ -11,7 +11,6 @@ import {
 } from "@/types/lyrics";
 import { LyricLine } from "@/types/lyrics";
 import type { FuriganaSegment } from "@/utils/romanization";
-import { updateSongById } from "@/api/songs";
 import { getApiUrl } from "@/utils/platform";
 import { getAppPublicOrigin } from "@/utils/runtimeConfig";
 import { getCachedSongMetadata, listAllCachedSongMetadata } from "@/utils/songMetadataCache";
@@ -25,11 +24,8 @@ import {
 import { emitCloudSyncDomainChange } from "@/utils/cloudSyncEvents";
 import { sortTracksLikeServerOrder } from "@/stores/ipodTrackOrder";
 import {
-  getCoverColorToSyncToRemote,
   hasFetchedTrackMetadataChanges,
-  hasFetchedTrackMetadataChangesExcludingCoverColor,
   hasLibraryTrackMetadataChanges,
-  hasLibraryTrackMetadataChangesExcludingCoverColor,
   resolveSyncedCoverColor,
   shouldUpdateTrackLyricsSource,
 } from "@/stores/ipodTrackMetadataSync";
@@ -131,44 +127,6 @@ function updateTrackCoverColorList(
     return { ...track, coverColor };
   });
   return { tracks: changed ? updatedTracks : tracks, changed };
-}
-
-interface RemoteCoverColorSync {
-  trackId: string;
-  coverColor: string;
-}
-
-async function syncRemoteCoverColors(
-  updates: RemoteCoverColorSync[]
-): Promise<number> {
-  if (updates.length === 0) return 0;
-  const { username, isAuthenticated } = useChatsStore.getState();
-  if (!username || !isAuthenticated) {
-    return 0;
-  }
-
-  const uniqueUpdates = [
-    ...new Map(
-      updates.map((update) => [
-        update.trackId,
-        update,
-      ])
-    ).values(),
-  ];
-  const results = await Promise.allSettled(
-    uniqueUpdates.map((update) =>
-      updateSongById(
-        update.trackId,
-        { coverColor: update.coverColor },
-        { username, isAuthenticated }
-      )
-    )
-  );
-
-  return results.filter(
-    (result) =>
-      result.status === "fulfilled" && result.value.success !== false
-  ).length;
 }
 
 /**
@@ -1981,29 +1939,15 @@ export const useIpodStore = create<IpodState>()(
 
           let newTracksAdded = 0;
           let tracksUpdated = 0;
-          const remoteCoverColorSyncs: RemoteCoverColorSync[] = [];
 
           // Process existing tracks: merge server timestamps + metadata when on server
           const updatedTracks = current.tracks.map((currentTrack) => {
             const serverTrack = serverTrackMap.get(currentTrack.id);
             if (serverTrack) {
-              const coverColorToSync = getCoverColorToSyncToRemote(
+              const hasMetadataChanges = hasLibraryTrackMetadataChanges(
                 currentTrack,
                 serverTrack
               );
-              if (coverColorToSync) {
-                remoteCoverColorSyncs.push({
-                  trackId: currentTrack.id,
-                  coverColor: coverColorToSync,
-                });
-              }
-              const hasMetadataChanges =
-                hasLibraryTrackMetadataChangesExcludingCoverColor(
-                  currentTrack,
-                  serverTrack
-                ) ||
-                (hasLibraryTrackMetadataChanges(currentTrack, serverTrack) &&
-                  !coverColorToSync);
               const shouldUpdateLyricsSource = shouldUpdateTrackLyricsSource(
                 currentTrack,
                 serverTrack
@@ -2108,27 +2052,11 @@ export const useIpodStore = create<IpodState>()(
                 finalTracks = finalTracks.map((track) => {
                   const fetched = fetchedMap.get(track.id);
                   if (fetched) {
-                    const coverColorToSync = getCoverColorToSyncToRemote(
-                      track,
-                      fetched
-                    );
-                    if (coverColorToSync) {
-                      remoteCoverColorSyncs.push({
-                        trackId: track.id,
-                        coverColor: coverColorToSync,
-                      });
-                    }
                     const shouldUpdateLyricsSource = shouldUpdateTrackLyricsSource(
                       track,
                       fetched
                     );
-                    const hasChanges =
-                      hasFetchedTrackMetadataChangesExcludingCoverColor(
-                        track,
-                        fetched
-                      ) ||
-                      (hasFetchedTrackMetadataChanges(track, fetched) &&
-                        !coverColorToSync);
+                    const hasChanges = hasFetchedTrackMetadataChanges(track, fetched);
 
                     if (hasChanges) {
                       tracksUpdated++;
@@ -2183,8 +2111,6 @@ export const useIpodStore = create<IpodState>()(
           const orderChanged =
             finalTracks.length !== current.tracks.length ||
             finalTracks.some((t, i) => t.id !== current.tracks[i]?.id);
-
-          tracksUpdated += await syncRemoteCoverColors(remoteCoverColorSyncs);
 
           // Update store if there were any changes
           if (newTracksAdded > 0 || tracksUpdated > 0 || orderChanged) {

--- a/src/stores/useIpodStore.ts
+++ b/src/stores/useIpodStore.ts
@@ -11,6 +11,7 @@ import {
 } from "@/types/lyrics";
 import { LyricLine } from "@/types/lyrics";
 import type { FuriganaSegment } from "@/utils/romanization";
+import { updateSongById } from "@/api/songs";
 import { getApiUrl } from "@/utils/platform";
 import { getAppPublicOrigin } from "@/utils/runtimeConfig";
 import { getCachedSongMetadata, listAllCachedSongMetadata } from "@/utils/songMetadataCache";
@@ -24,8 +25,11 @@ import {
 import { emitCloudSyncDomainChange } from "@/utils/cloudSyncEvents";
 import { sortTracksLikeServerOrder } from "@/stores/ipodTrackOrder";
 import {
+  getCoverColorToSyncToRemote,
   hasFetchedTrackMetadataChanges,
+  hasFetchedTrackMetadataChangesExcludingCoverColor,
   hasLibraryTrackMetadataChanges,
+  hasLibraryTrackMetadataChangesExcludingCoverColor,
   resolveSyncedCoverColor,
   shouldUpdateTrackLyricsSource,
 } from "@/stores/ipodTrackMetadataSync";
@@ -127,6 +131,44 @@ function updateTrackCoverColorList(
     return { ...track, coverColor };
   });
   return { tracks: changed ? updatedTracks : tracks, changed };
+}
+
+interface RemoteCoverColorSync {
+  trackId: string;
+  coverColor: string;
+}
+
+async function syncRemoteCoverColors(
+  updates: RemoteCoverColorSync[]
+): Promise<number> {
+  if (updates.length === 0) return 0;
+  const { username, isAuthenticated } = useChatsStore.getState();
+  if (!username || !isAuthenticated) {
+    return 0;
+  }
+
+  const uniqueUpdates = [
+    ...new Map(
+      updates.map((update) => [
+        update.trackId,
+        update,
+      ])
+    ).values(),
+  ];
+  const results = await Promise.allSettled(
+    uniqueUpdates.map((update) =>
+      updateSongById(
+        update.trackId,
+        { coverColor: update.coverColor },
+        { username, isAuthenticated }
+      )
+    )
+  );
+
+  return results.filter(
+    (result) =>
+      result.status === "fulfilled" && result.value.success !== false
+  ).length;
 }
 
 /**
@@ -1939,15 +1981,29 @@ export const useIpodStore = create<IpodState>()(
 
           let newTracksAdded = 0;
           let tracksUpdated = 0;
+          const remoteCoverColorSyncs: RemoteCoverColorSync[] = [];
 
           // Process existing tracks: merge server timestamps + metadata when on server
           const updatedTracks = current.tracks.map((currentTrack) => {
             const serverTrack = serverTrackMap.get(currentTrack.id);
             if (serverTrack) {
-              const hasMetadataChanges = hasLibraryTrackMetadataChanges(
+              const coverColorToSync = getCoverColorToSyncToRemote(
                 currentTrack,
                 serverTrack
               );
+              if (coverColorToSync) {
+                remoteCoverColorSyncs.push({
+                  trackId: currentTrack.id,
+                  coverColor: coverColorToSync,
+                });
+              }
+              const hasMetadataChanges =
+                hasLibraryTrackMetadataChangesExcludingCoverColor(
+                  currentTrack,
+                  serverTrack
+                ) ||
+                (hasLibraryTrackMetadataChanges(currentTrack, serverTrack) &&
+                  !coverColorToSync);
               const shouldUpdateLyricsSource = shouldUpdateTrackLyricsSource(
                 currentTrack,
                 serverTrack
@@ -2052,11 +2108,27 @@ export const useIpodStore = create<IpodState>()(
                 finalTracks = finalTracks.map((track) => {
                   const fetched = fetchedMap.get(track.id);
                   if (fetched) {
+                    const coverColorToSync = getCoverColorToSyncToRemote(
+                      track,
+                      fetched
+                    );
+                    if (coverColorToSync) {
+                      remoteCoverColorSyncs.push({
+                        trackId: track.id,
+                        coverColor: coverColorToSync,
+                      });
+                    }
                     const shouldUpdateLyricsSource = shouldUpdateTrackLyricsSource(
                       track,
                       fetched
                     );
-                    const hasChanges = hasFetchedTrackMetadataChanges(track, fetched);
+                    const hasChanges =
+                      hasFetchedTrackMetadataChangesExcludingCoverColor(
+                        track,
+                        fetched
+                      ) ||
+                      (hasFetchedTrackMetadataChanges(track, fetched) &&
+                        !coverColorToSync);
 
                     if (hasChanges) {
                       tracksUpdated++;
@@ -2111,6 +2183,8 @@ export const useIpodStore = create<IpodState>()(
           const orderChanged =
             finalTracks.length !== current.tracks.length ||
             finalTracks.some((t, i) => t.id !== current.tracks[i]?.id);
+
+          tracksUpdated += await syncRemoteCoverColors(remoteCoverColorSyncs);
 
           // Update store if there were any changes
           if (newTracksAdded > 0 || tracksUpdated > 0 || orderChanged) {

--- a/tests/test-ipod-track-metadata-sync.test.ts
+++ b/tests/test-ipod-track-metadata-sync.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, test } from "bun:test";
 import {
-  getCoverColorToSyncToRemote,
   hasCoverColorMetadataChange,
   hasFetchedTrackMetadataChanges,
   hasLibraryTrackMetadataChanges,
@@ -29,7 +28,7 @@ describe("iPod track metadata sync", () => {
     expect(resolveSyncedCoverColor(current, server)).toBe("#111111");
   });
 
-  test("treats missing remote coverColor as a metadata change to sync", () => {
+  test("does not treat missing remote coverColor as a library metadata change", () => {
     const current = {
       title: "Song",
       cover: "https://example.com/cover.jpg",
@@ -42,9 +41,8 @@ describe("iPod track metadata sync", () => {
       coverColor: undefined,
     };
 
-    expect(hasCoverColorMetadataChange(current, server)).toBe(true);
-    expect(hasLibraryTrackMetadataChanges(current, server)).toBe(true);
-    expect(getCoverColorToSyncToRemote(current, server)).toBe("#111111");
+    expect(hasCoverColorMetadataChange(current, server)).toBe(false);
+    expect(hasLibraryTrackMetadataChanges(current, server)).toBe(false);
     expect(resolveSyncedCoverColor(current, server)).toBe("#111111");
   });
 
@@ -79,7 +77,7 @@ describe("iPod track metadata sync", () => {
     };
 
     expect(hasCoverColorMetadataChange(current, server)).toBe(true);
-    expect(getCoverColorToSyncToRemote(current, server)).toBeUndefined();
+    expect(hasLibraryTrackMetadataChanges(current, server)).toBe(true);
     expect(resolveSyncedCoverColor(current, server)).toBe("#222222");
   });
 
@@ -93,7 +91,6 @@ describe("iPod track metadata sync", () => {
       coverColor: "#222222",
     };
 
-    expect(getCoverColorToSyncToRemote(current, server)).toBeUndefined();
     expect(resolveSyncedCoverColor(current, server)).toBe("#222222");
   });
 
@@ -108,11 +105,10 @@ describe("iPod track metadata sync", () => {
     };
 
     expect(hasFetchedTrackMetadataChanges(current, fetched)).toBe(true);
-    expect(getCoverColorToSyncToRemote(current, fetched)).toBeUndefined();
     expect(resolveSyncedCoverColor(current, fetched)).toBe("#222222");
   });
 
-  test("preserves local coverColor when fetched user track metadata has none", () => {
+  test("does not treat missing fetched coverColor as user track metadata change", () => {
     const current = {
       title: "User Song",
       cover: "https://example.com/cover.jpg",
@@ -122,8 +118,7 @@ describe("iPod track metadata sync", () => {
       title: "User Song",
     };
 
-    expect(hasFetchedTrackMetadataChanges(current, fetched)).toBe(true);
-    expect(getCoverColorToSyncToRemote(current, fetched)).toBe("#111111");
+    expect(hasFetchedTrackMetadataChanges(current, fetched)).toBe(false);
     expect(resolveSyncedCoverColor(current, fetched)).toBe("#111111");
   });
 });

--- a/tests/test-ipod-track-metadata-sync.test.ts
+++ b/tests/test-ipod-track-metadata-sync.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, test } from "bun:test";
+import {
+  hasFetchedTrackMetadataChanges,
+  hasLibraryTrackMetadataChanges,
+  resolveSyncedCoverColor,
+} from "../src/stores/ipodTrackMetadataSync";
+
+describe("iPod track metadata sync", () => {
+  test("ignores coverColor-only differences for library update checks", () => {
+    const current = {
+      id: "song-1",
+      title: "Song",
+      artist: "Artist",
+      album: "Album",
+      cover: "https://example.com/cover.jpg",
+      coverColor: "#111111",
+      url: "https://www.youtube.com/watch?v=song-1",
+      lyricOffset: 500,
+    };
+    const server = {
+      ...current,
+      coverColor: "#222222",
+    };
+
+    expect(hasLibraryTrackMetadataChanges(current, server)).toBe(false);
+    expect(resolveSyncedCoverColor(current, server)).toBe("#111111");
+  });
+
+  test("still detects real metadata changes while preserving same-cover cached color", () => {
+    const current = {
+      title: "Song",
+      artist: "Artist",
+      album: "Album",
+      cover: "https://example.com/cover.jpg",
+      coverColor: "#111111",
+      url: "https://www.youtube.com/watch?v=song-1",
+      lyricOffset: 500,
+    };
+    const server = {
+      ...current,
+      title: "Song (Remastered)",
+      coverColor: "#222222",
+    };
+
+    expect(hasLibraryTrackMetadataChanges(current, server)).toBe(true);
+    expect(resolveSyncedCoverColor(current, server)).toBe("#111111");
+  });
+
+  test("uses server coverColor only when cover art changes", () => {
+    const current = {
+      cover: "https://example.com/old-cover.jpg",
+      coverColor: "#111111",
+    };
+    const server = {
+      cover: "https://example.com/new-cover.jpg",
+      coverColor: "#222222",
+    };
+
+    expect(resolveSyncedCoverColor(current, server)).toBe("#222222");
+  });
+
+  test("ignores fetched coverColor-only differences for user track metadata", () => {
+    const current = {
+      title: "User Song",
+      cover: "https://example.com/cover.jpg",
+      coverColor: "#111111",
+    };
+    const fetched = {
+      coverColor: "#222222",
+    };
+
+    expect(hasFetchedTrackMetadataChanges(current, fetched)).toBe(false);
+    expect(resolveSyncedCoverColor(current, fetched)).toBe("#111111");
+  });
+});

--- a/tests/test-ipod-track-metadata-sync.test.ts
+++ b/tests/test-ipod-track-metadata-sync.test.ts
@@ -1,12 +1,13 @@
 import { describe, expect, test } from "bun:test";
 import {
+  hasCoverColorMetadataChange,
   hasFetchedTrackMetadataChanges,
   hasLibraryTrackMetadataChanges,
   resolveSyncedCoverColor,
 } from "../src/stores/ipodTrackMetadataSync";
 
 describe("iPod track metadata sync", () => {
-  test("ignores coverColor-only differences for library update checks", () => {
+  test("does not treat matching cover colors as library metadata changes", () => {
     const current = {
       id: "song-1",
       title: "Song",
@@ -19,10 +20,29 @@ describe("iPod track metadata sync", () => {
     };
     const server = {
       ...current,
-      coverColor: "#222222",
+      coverColor: "  #111111  ",
     };
 
+    expect(hasCoverColorMetadataChange(current, server)).toBe(false);
     expect(hasLibraryTrackMetadataChanges(current, server)).toBe(false);
+    expect(resolveSyncedCoverColor(current, server)).toBe("#111111");
+  });
+
+  test("treats missing remote coverColor as a metadata change to sync", () => {
+    const current = {
+      title: "Song",
+      cover: "https://example.com/cover.jpg",
+      coverColor: "#111111",
+      url: "https://www.youtube.com/watch?v=song-1",
+      lyricOffset: 500,
+    };
+    const server = {
+      ...current,
+      coverColor: undefined,
+    };
+
+    expect(hasCoverColorMetadataChange(current, server)).toBe(true);
+    expect(hasLibraryTrackMetadataChanges(current, server)).toBe(true);
     expect(resolveSyncedCoverColor(current, server)).toBe("#111111");
   });
 
@@ -39,11 +59,25 @@ describe("iPod track metadata sync", () => {
     const server = {
       ...current,
       title: "Song (Remastered)",
-      coverColor: "#222222",
+      coverColor: "#111111",
     };
 
     expect(hasLibraryTrackMetadataChanges(current, server)).toBe(true);
     expect(resolveSyncedCoverColor(current, server)).toBe("#111111");
+  });
+
+  test("uses remote coverColor when remote has a different synced value", () => {
+    const current = {
+      cover: "https://example.com/cover.jpg",
+      coverColor: "#111111",
+    };
+    const server = {
+      cover: "https://example.com/cover.jpg",
+      coverColor: "#222222",
+    };
+
+    expect(hasCoverColorMetadataChange(current, server)).toBe(true);
+    expect(resolveSyncedCoverColor(current, server)).toBe("#222222");
   });
 
   test("uses server coverColor only when cover art changes", () => {
@@ -59,7 +93,7 @@ describe("iPod track metadata sync", () => {
     expect(resolveSyncedCoverColor(current, server)).toBe("#222222");
   });
 
-  test("ignores fetched coverColor-only differences for user track metadata", () => {
+  test("uses fetched coverColor when user track metadata has a remote value", () => {
     const current = {
       title: "User Song",
       cover: "https://example.com/cover.jpg",
@@ -69,7 +103,21 @@ describe("iPod track metadata sync", () => {
       coverColor: "#222222",
     };
 
-    expect(hasFetchedTrackMetadataChanges(current, fetched)).toBe(false);
+    expect(hasFetchedTrackMetadataChanges(current, fetched)).toBe(true);
+    expect(resolveSyncedCoverColor(current, fetched)).toBe("#222222");
+  });
+
+  test("preserves local coverColor when fetched user track metadata has none", () => {
+    const current = {
+      title: "User Song",
+      cover: "https://example.com/cover.jpg",
+      coverColor: "#111111",
+    };
+    const fetched = {
+      title: "User Song",
+    };
+
+    expect(hasFetchedTrackMetadataChanges(current, fetched)).toBe(true);
     expect(resolveSyncedCoverColor(current, fetched)).toBe("#111111");
   });
 });

--- a/tests/test-ipod-track-metadata-sync.test.ts
+++ b/tests/test-ipod-track-metadata-sync.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import {
+  getCoverColorToSyncToRemote,
   hasCoverColorMetadataChange,
   hasFetchedTrackMetadataChanges,
   hasLibraryTrackMetadataChanges,
@@ -43,6 +44,7 @@ describe("iPod track metadata sync", () => {
 
     expect(hasCoverColorMetadataChange(current, server)).toBe(true);
     expect(hasLibraryTrackMetadataChanges(current, server)).toBe(true);
+    expect(getCoverColorToSyncToRemote(current, server)).toBe("#111111");
     expect(resolveSyncedCoverColor(current, server)).toBe("#111111");
   });
 
@@ -77,6 +79,7 @@ describe("iPod track metadata sync", () => {
     };
 
     expect(hasCoverColorMetadataChange(current, server)).toBe(true);
+    expect(getCoverColorToSyncToRemote(current, server)).toBeUndefined();
     expect(resolveSyncedCoverColor(current, server)).toBe("#222222");
   });
 
@@ -90,6 +93,7 @@ describe("iPod track metadata sync", () => {
       coverColor: "#222222",
     };
 
+    expect(getCoverColorToSyncToRemote(current, server)).toBeUndefined();
     expect(resolveSyncedCoverColor(current, server)).toBe("#222222");
   });
 
@@ -104,6 +108,7 @@ describe("iPod track metadata sync", () => {
     };
 
     expect(hasFetchedTrackMetadataChanges(current, fetched)).toBe(true);
+    expect(getCoverColorToSyncToRemote(current, fetched)).toBeUndefined();
     expect(resolveSyncedCoverColor(current, fetched)).toBe("#222222");
   });
 
@@ -118,6 +123,7 @@ describe("iPod track metadata sync", () => {
     };
 
     expect(hasFetchedTrackMetadataChanges(current, fetched)).toBe(true);
+    expect(getCoverColorToSyncToRemote(current, fetched)).toBe("#111111");
     expect(resolveSyncedCoverColor(current, fetched)).toBe("#111111");
   });
 });

--- a/tests/test-lyrics-color-extraction.test.ts
+++ b/tests/test-lyrics-color-extraction.test.ts
@@ -1,12 +1,12 @@
 import { describe, expect, test } from "bun:test";
 import {
   boostGlowColor,
+  getNewCoverColorToSave,
   normalizeCoverColor,
   pickPrimaryColor,
   resolveCoverGlowColor,
 } from "../src/apps/ipod/components/lyrics-display/colorUtils";
 import { shouldExtractCoverGlowColor } from "../src/hooks/useCoverGlowColor";
-import { getNewCoverColorToSave } from "../src/hooks/useSaveSongCoverColor";
 import { completeCoverPalette } from "../src/hooks/useCoverPalette";
 
 function hexToRgb(hex: string): [number, number, number] {

--- a/tests/test-lyrics-color-extraction.test.ts
+++ b/tests/test-lyrics-color-extraction.test.ts
@@ -5,6 +5,8 @@ import {
   pickPrimaryColor,
   resolveCoverGlowColor,
 } from "../src/apps/ipod/components/lyrics-display/colorUtils";
+import { shouldExtractCoverGlowColor } from "../src/hooks/useCoverGlowColor";
+import { getNewCoverColorToSave } from "../src/hooks/useSaveSongCoverColor";
 import { completeCoverPalette } from "../src/hooks/useCoverPalette";
 
 function hexToRgb(hex: string): [number, number, number] {
@@ -76,5 +78,18 @@ describe("lyrics color extraction", () => {
 
   test("resolves the boosted cover glow color from a palette", () => {
     expect(resolveCoverGlowColor(["#1a237e"])).toBe(boostGlowColor("#1a237e"));
+  });
+
+  test("does not extract a cover glow color when a cached color exists", () => {
+    expect(shouldExtractCoverGlowColor(true, "#123456")).toBe(false);
+    expect(shouldExtractCoverGlowColor(true, "  #ABCDEF  ")).toBe(false);
+    expect(shouldExtractCoverGlowColor(true, undefined)).toBe(true);
+    expect(shouldExtractCoverGlowColor(false, undefined)).toBe(false);
+  });
+
+  test("does not save a resolved cover color over a cached color", () => {
+    expect(getNewCoverColorToSave("#abcdef", "#123456")).toBeUndefined();
+    expect(getNewCoverColorToSave("#abcdef", "  #123456  ")).toBeUndefined();
+    expect(getNewCoverColorToSave("#ABCDEF", undefined)).toBe("#abcdef");
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Skip cover glow extraction when a cached cover color is already present.
- Prevent stale resolved cover-color callbacks from overwriting cached track metadata.
- Simplify cover-color library sync so remote-present colors hydrate local state, while remote-missing colors preserve local cache without triggering auto-update.
- Add unit coverage for cached extraction/save guards and cover-color metadata sync rules.

### Testing
- `bun test tests/test-lyrics-color-extraction.test.ts tests/test-ipod-track-metadata-sync.test.ts`
- `bun run build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019e8786-ed6d-7e56-9a2f-6955055aa473"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019e8786-ed6d-7e56-9a2f-6955055aa473"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

