### PR TITLE
Fix iPod cover color sync drift

### DIFF
--- a/src/hooks/useCoverGlowColor.ts
+++ b/src/hooks/useCoverGlowColor.ts
@@ -19,6 +19,19 @@ export function shouldExtractCoverGlowColor(
   return enabled && !normalizeCoverColor(coverColor);
 }
 
+export function shouldNotifyCoverGlowColorResolved(
+  shouldExtract: boolean,
+  requestedCoverUrl: string | null | undefined,
+  paletteResult: { source: string; coverUrl: string | null }
+): boolean {
+  return (
+    shouldExtract &&
+    paletteResult.source === "cover" &&
+    Boolean(paletteResult.coverUrl) &&
+    paletteResult.coverUrl === (requestedCoverUrl ?? null)
+  );
+}
+
 export function useCoverGlowColor({
   coverUrl,
   coverColor,
@@ -39,10 +52,16 @@ export function useCoverGlowColor({
   );
 
   useEffect(() => {
-    if (shouldExtract && paletteResult.source === "cover" && paletteResult.coverUrl) {
-      onResolved?.(resolvedColor, paletteResult.coverUrl);
+    if (
+      shouldNotifyCoverGlowColorResolved(shouldExtract, coverUrl, paletteResult)
+    ) {
+      const resolvedCoverUrl = paletteResult.coverUrl;
+      if (resolvedCoverUrl) {
+        onResolved?.(resolvedColor, resolvedCoverUrl);
+      }
     }
   }, [
+    coverUrl,
     onResolved,
     paletteResult.coverUrl,
     paletteResult.source,

--- a/src/stores/ipodTrackMetadataSync.ts
+++ b/src/stores/ipodTrackMetadataSync.ts
@@ -52,7 +52,6 @@ export function hasLibraryTrackMetadataChanges(
     currentTrack.artist !== serverTrack.artist ||
     currentTrack.album !== serverTrack.album ||
     currentTrack.cover !== serverTrack.cover ||
-    hasCoverColorMetadataChange(currentTrack, serverTrack) ||
     currentTrack.url !== serverTrack.url ||
     currentTrack.lyricOffset !== serverTrack.lyricOffset ||
     shouldUpdateTrackLyricsSource(currentTrack, serverTrack)
@@ -68,7 +67,6 @@ export function hasFetchedTrackMetadataChanges(
       (fetchedTrack.artist && fetchedTrack.artist !== currentTrack.artist) ||
       (fetchedTrack.album && fetchedTrack.album !== currentTrack.album) ||
       (fetchedTrack.cover && fetchedTrack.cover !== currentTrack.cover) ||
-      hasCoverColorMetadataChange(currentTrack, fetchedTrack) ||
       (fetchedTrack.lyricOffset !== undefined &&
         fetchedTrack.lyricOffset !== currentTrack.lyricOffset) ||
       shouldUpdateTrackLyricsSource(currentTrack, fetchedTrack)
@@ -84,5 +82,5 @@ export function resolveSyncedCoverColor(
   if (serverTrack.cover !== undefined && currentTrack.cover !== serverTrack.cover) {
     return serverCoverColor;
   }
-  return serverCoverColor ?? currentCoverColor;
+  return currentCoverColor ?? serverCoverColor;
 }

--- a/tests/test-ipod-track-metadata-sync.test.ts
+++ b/tests/test-ipod-track-metadata-sync.test.ts
@@ -5,6 +5,7 @@ import {
   hasLibraryTrackMetadataChanges,
   resolveSyncedCoverColor,
 } from "../src/stores/ipodTrackMetadataSync";
+import { shouldNotifyCoverGlowColorResolved } from "../src/hooks/useCoverGlowColor";
 
 describe("iPod track metadata sync", () => {
   test("does not treat matching cover colors as library metadata changes", () => {
@@ -66,19 +67,45 @@ describe("iPod track metadata sync", () => {
     expect(resolveSyncedCoverColor(current, server)).toBe("#111111");
   });
 
-  test("uses remote coverColor when remote has a different synced value", () => {
+  test("does not treat remote coverColor-only drift as a library metadata change", () => {
     const current = {
+      title: "Song",
+      artist: "Artist",
+      album: "Album",
       cover: "https://example.com/cover.jpg",
       coverColor: "#111111",
+      url: "https://www.youtube.com/watch?v=song-1",
+      lyricOffset: 500,
     };
     const server = {
+      ...current,
       cover: "https://example.com/cover.jpg",
       coverColor: "#222222",
     };
 
     expect(hasCoverColorMetadataChange(current, server)).toBe(true);
+    expect(hasLibraryTrackMetadataChanges(current, server)).toBe(false);
+    expect(resolveSyncedCoverColor(current, server)).toBe("#111111");
+  });
+
+  test("preserves local same-cover color when real metadata changes sync", () => {
+    const current = {
+      title: "Song",
+      artist: "Artist",
+      album: "Album",
+      cover: "https://example.com/cover.jpg",
+      coverColor: "#111111",
+      url: "https://www.youtube.com/watch?v=song-1",
+      lyricOffset: 500,
+    };
+    const server = {
+      ...current,
+      title: "Song (Remastered)",
+      coverColor: "#222222",
+    };
+
     expect(hasLibraryTrackMetadataChanges(current, server)).toBe(true);
-    expect(resolveSyncedCoverColor(current, server)).toBe("#222222");
+    expect(resolveSyncedCoverColor(current, server)).toBe("#111111");
   });
 
   test("uses server coverColor only when cover art changes", () => {
@@ -94,7 +121,19 @@ describe("iPod track metadata sync", () => {
     expect(resolveSyncedCoverColor(current, server)).toBe("#222222");
   });
 
-  test("uses fetched coverColor when user track metadata has a remote value", () => {
+  test("uses same-cover remote coverColor only when local color is missing", () => {
+    const current = {
+      cover: "https://example.com/cover.jpg",
+    };
+    const server = {
+      cover: "https://example.com/cover.jpg",
+      coverColor: "#222222",
+    };
+
+    expect(resolveSyncedCoverColor(current, server)).toBe("#222222");
+  });
+
+  test("does not treat fetched coverColor-only drift as user track metadata change", () => {
     const current = {
       title: "User Song",
       cover: "https://example.com/cover.jpg",
@@ -104,8 +143,8 @@ describe("iPod track metadata sync", () => {
       coverColor: "#222222",
     };
 
-    expect(hasFetchedTrackMetadataChanges(current, fetched)).toBe(true);
-    expect(resolveSyncedCoverColor(current, fetched)).toBe("#222222");
+    expect(hasFetchedTrackMetadataChanges(current, fetched)).toBe(false);
+    expect(resolveSyncedCoverColor(current, fetched)).toBe("#111111");
   });
 
   test("does not treat missing fetched coverColor as user track metadata change", () => {
@@ -120,5 +159,33 @@ describe("iPod track metadata sync", () => {
 
     expect(hasFetchedTrackMetadataChanges(current, fetched)).toBe(false);
     expect(resolveSyncedCoverColor(current, fetched)).toBe("#111111");
+  });
+});
+
+describe("cover glow color resolution", () => {
+  test("notifies when the extracted palette matches the requested cover URL", () => {
+    expect(
+      shouldNotifyCoverGlowColorResolved(
+        true,
+        "https://example.com/current-cover.jpg",
+        {
+          source: "cover",
+          coverUrl: "https://example.com/current-cover.jpg",
+        }
+      )
+    ).toBe(true);
+  });
+
+  test("does not notify with a stale palette result from a previous cover URL", () => {
+    expect(
+      shouldNotifyCoverGlowColorResolved(
+        true,
+        "https://example.com/current-cover.jpg",
+        {
+          source: "cover",
+          coverUrl: "https://example.com/previous-cover.jpg",
+        }
+      )
+    ).toBe(false);
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Stop treating coverColor-only drift as a library metadata update in iPod/Karaoke playback paths.
- Preserve local same-cover colors during library sync unless the cover art changes.
- Ignore stale cover-palette callbacks from previous cover URLs before saving colors.

## Testing
- Passed: `bun test tests/test-ipod-track-metadata-sync.test.ts tests/test-ipod-lyrics-track-metadata.test.ts`
- Passed: `bun run build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019e87bf-dae2-7fea-9bc2-f594a51a7a94"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019e87bf-dae2-7fea-9bc2-f594a51a7a94"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

