### PR TITLE
Refactor song metadata sync helpers

### DIFF
--- a/src/api/songs.ts
+++ b/src/api/songs.ts
@@ -1,4 +1,4 @@
-import { apiRequest, apiRequestRaw } from "@/api/core";
+import { apiRequest, apiRequestRaw, type ApiRequestOptions } from "@/api/core";
 
 /** Auth context for cookie-based auth (credentials sent automatically via credentials: "include") */
 export interface SongsAuthContext {
@@ -33,6 +33,74 @@ export interface SongImportBatchResult {
   data?: Record<string, unknown>;
 }
 
+export interface SongLyricsSource {
+  hash: string;
+  albumId: string | number;
+  title: string;
+  artist: string;
+  album?: string;
+}
+
+export interface SongMetadataPatch {
+  title?: string;
+  artist?: string;
+  album?: string;
+  cover?: string;
+  coverColor?: string;
+  lyricOffset?: number;
+  lyricsSource?: SongLyricsSource;
+  clearTranslations?: boolean;
+  clearFurigana?: boolean;
+  clearSoramimi?: boolean;
+  clearLyrics?: boolean;
+  isShare?: boolean;
+}
+
+export interface SongParsedLyricLine {
+  startTimeMs: string;
+  words: string;
+  wordTimings?: Array<{
+    text: string;
+    startTimeMs: number;
+    durationMs: number;
+  }>;
+}
+
+export interface FetchSongLyricsParams {
+  force?: boolean;
+  title?: string;
+  artist?: string;
+  translateTo?: string;
+  includeFurigana?: boolean;
+  includeSoramimi?: boolean;
+  soramimiTargetLanguage?: "zh-TW" | "en";
+  lyricsSource?: SongLyricsSource;
+  returnMetadata?: boolean;
+  signal?: AbortSignal;
+  timeout?: number;
+  retry?: ApiRequestOptions["retry"];
+}
+
+export interface FetchSongLyricsResponse {
+  lyrics?: {
+    lrc: string;
+    krc?: string;
+    parsedLines?: SongParsedLyricLine[];
+  };
+  cached?: boolean;
+  translation?: unknown;
+  furigana?: unknown;
+  soramimi?: unknown;
+  metadata?: {
+    title?: string;
+    artist?: string;
+    album?: string;
+    cover?: string;
+    coverColor?: string;
+    lyricsSource?: SongLyricsSource;
+  };
+}
+
 export async function listSongs<TSong = Record<string, unknown>>(
   query: SongListQuery = {}
 ): Promise<{ songs: TSong[] }> {
@@ -63,12 +131,64 @@ export async function getSongById<TSong = Record<string, unknown>>(
 export async function updateSongById<TPayload extends Record<string, unknown>>(
   songId: string,
   payload: TPayload,
-  _auth: SongsAuthContext
+  _auth?: SongsAuthContext
 ): Promise<SongSaveResponse> {
   return apiRequest<SongSaveResponse, TPayload>({
     path: `/api/songs/${encodeURIComponent(songId)}`,
     method: "POST",
     body: payload,
+  });
+}
+
+export async function patchSongMetadata(
+  songId: string,
+  payload: SongMetadataPatch,
+  auth?: SongsAuthContext
+): Promise<SongSaveResponse> {
+  return updateSongById(songId, payload, auth);
+}
+
+export async function fetchSongLyrics(
+  songId: string,
+  params: FetchSongLyricsParams = {}
+): Promise<FetchSongLyricsResponse> {
+  const {
+    signal,
+    timeout = 15000,
+    retry = { maxAttempts: 3, initialDelayMs: 1000, backoffMultiplier: 2 },
+    ...body
+  } = params;
+
+  return apiRequest<FetchSongLyricsResponse>({
+    path: `/api/songs/${encodeURIComponent(songId)}`,
+    method: "POST",
+    body: {
+      action: "fetch-lyrics",
+      ...body,
+    },
+    signal,
+    timeout,
+    retry,
+  });
+}
+
+export async function clearSongCachedData(
+  songId: string,
+  options: {
+    clearTranslations?: boolean;
+    clearFurigana?: boolean;
+    clearSoramimi?: boolean;
+  } = {}
+): Promise<Record<string, unknown>> {
+  return apiRequest<Record<string, unknown>>({
+    path: `/api/songs/${encodeURIComponent(songId)}`,
+    method: "POST",
+    body: {
+      action: "clear-cached-data",
+      clearTranslations: options.clearTranslations ?? true,
+      clearFurigana: options.clearFurigana ?? true,
+      clearSoramimi: options.clearSoramimi ?? true,
+    },
   });
 }
 

--- a/src/api/songs.ts
+++ b/src/api/songs.ts
@@ -128,7 +128,7 @@ export async function getSongById<TSong = Record<string, unknown>>(
   });
 }
 
-export async function updateSongById<TPayload extends Record<string, unknown>>(
+export async function updateSongById<TPayload extends object>(
   songId: string,
   payload: TPayload,
   _auth?: SongsAuthContext

--- a/src/apps/ipod/hooks/useLibraryUpdateChecker.ts
+++ b/src/apps/ipod/hooks/useLibraryUpdateChecker.ts
@@ -1,10 +1,11 @@
 import { useEffect, useRef } from "react";
-import { useIpodStore, type Track } from "@/stores/useIpodStore";
+import { useIpodStore } from "@/stores/useIpodStore";
 import { useDisplaySettingsStore } from "@/stores/useDisplaySettingsStore";
 import { toast } from "sonner";
 import { useTranslation } from "react-i18next";
 import { listAllCachedSongMetadata } from "@/utils/songMetadataCache";
 import { hasLibraryTrackMetadataChanges } from "@/stores/ipodTrackMetadataSync";
+import { mapCatalogSongToTrack } from "@/stores/ipodCatalogTrackMapping";
 
 const CHECK_INTERVAL = 5 * 60 * 1000; // Check every 5 minutes
 
@@ -45,17 +46,7 @@ export function useLibraryUpdateChecker(isActive: boolean) {
           return;
         }
         
-        const serverTracks: Track[] = cachedSongs.map((song) => ({
-          id: song.youtubeId,
-          url: `https://www.youtube.com/watch?v=${song.youtubeId}`,
-          title: song.title,
-          artist: song.artist,
-          album: song.album ?? "",
-          cover: song.cover,
-          coverColor: song.coverColor,
-          lyricOffset: song.lyricOffset,
-          lyricsSource: song.lyricsSource,
-        }));
+        const serverTracks = cachedSongs.map(mapCatalogSongToTrack);
         const serverVersion = Math.max(...cachedSongs.map((s) => s.createdAt || 1));
 
         // Check for new tracks (same logic as syncLibrary)

--- a/src/hooks/useLyrics.ts
+++ b/src/hooks/useLyrics.ts
@@ -3,8 +3,8 @@ import type { LyricLine } from "@/types/lyrics";
 import { useIpodStore } from "@/stores/useIpodStore";
 import { useCacheBustTrigger, useRefetchTrigger } from "@/hooks/useCacheBustTrigger";
 import { isOffline } from "@/utils/offline";
-import { getApiUrl } from "@/utils/platform";
-import { abortableFetch } from "@/utils/abortableFetch";
+import { ApiRequestError } from "@/api/core";
+import { fetchSongLyrics } from "@/api/songs";
 import {
   processTranslationSSE,
   parseLrcToTranslations,
@@ -379,24 +379,27 @@ export function useLyrics({
       };
     }
 
-    const headers: Record<string, string> = { "Content-Type": "application/json" };
-
-    abortableFetch(getApiUrl(`/api/songs/${effectSongId}`), {
-      method: "POST",
-      headers,
-      body: JSON.stringify(requestBody),
+    fetchSongLyrics(effectSongId, {
+      force: Boolean(requestBody.force),
+      title: typeof requestBody.title === "string" ? requestBody.title : undefined,
+      artist: typeof requestBody.artist === "string" ? requestBody.artist : undefined,
+      translateTo:
+        typeof requestBody.translateTo === "string"
+          ? requestBody.translateTo
+          : undefined,
+      includeFurigana: Boolean(requestBody.includeFurigana),
+      includeSoramimi: Boolean(requestBody.includeSoramimi),
+      soramimiTargetLanguage:
+        requestBody.soramimiTargetLanguage === "en" ? "en" : undefined,
+      lyricsSource: requestBody.lyricsSource as
+        | NonNullable<Parameters<typeof fetchSongLyrics>[1]>["lyricsSource"]
+        | undefined,
       signal: controller.signal,
-      timeout: 15000,
-      retry: { maxAttempts: 3, initialDelayMs: 1000, backoffMultiplier: 2 },
     })
-      .then(async (res) => {
+      .then(async (json) => {
         if (controller.signal.aborted) return null;
         if (effectSongId !== currentSongIdRef.current) return null;
-        if (!res.ok) {
-          if (res.status === 404) return null;
-          throw new Error(`Failed to fetch lyrics (status ${res.status})`);
-        }
-        return res.json() as Promise<UnifiedLyricsResponse>;
+        return json as UnifiedLyricsResponse;
       })
       .then((json) => {
         if (controller.signal.aborted) return;
@@ -438,6 +441,11 @@ export function useLyrics({
       .catch((err: unknown) => {
         if (controller.signal.aborted) return;
         if (effectSongId !== currentSongIdRef.current) return;
+        if (err instanceof ApiRequestError && err.status === 404) {
+          err = new Error("No lyrics found");
+        } else if (err instanceof ApiRequestError) {
+          err = new Error(`Failed to fetch lyrics (status ${err.status})`);
+        }
         handleLyricsError(err, setError, setOriginalLines, setCurrentLine);
         dispatch({
           type: "patch",

--- a/src/stores/ipodCatalogTrackMapping.ts
+++ b/src/stores/ipodCatalogTrackMapping.ts
@@ -1,0 +1,19 @@
+import type { Track } from "@/stores/useIpodStore";
+import type { CachedSongMetadata } from "@/utils/songMetadataCache";
+
+export function mapCatalogSongToTrack(song: CachedSongMetadata): Track {
+  return {
+    id: song.youtubeId,
+    url: `https://www.youtube.com/watch?v=${song.youtubeId}`,
+    title: song.title,
+    artist: song.artist,
+    album: song.album ?? "",
+    cover: song.cover,
+    coverColor: song.coverColor,
+    lyricOffset: song.lyricOffset,
+    lyricsSource: song.lyricsSource,
+    createdAt: song.createdAt,
+    importOrder: song.importOrder,
+    updatedAt: song.updatedAt,
+  };
+}

--- a/src/stores/useIpodStore.ts
+++ b/src/stores/useIpodStore.ts
@@ -11,7 +11,6 @@ import {
 } from "@/types/lyrics";
 import { LyricLine } from "@/types/lyrics";
 import type { FuriganaSegment } from "@/utils/romanization";
-import { getApiUrl } from "@/utils/platform";
 import { getAppPublicOrigin } from "@/utils/runtimeConfig";
 import { getCachedSongMetadata, listAllCachedSongMetadata } from "@/utils/songMetadataCache";
 import { ApiRequestError } from "@/api/core";
@@ -23,7 +22,6 @@ import {
 } from "@/api/songs";
 import i18n from "@/lib/i18n";
 import { useChatsStore } from "./useChatsStore";
-import { abortableFetch } from "@/utils/abortableFetch";
 import {
   fetchYouTubeOembed,
   parseYouTubeTitle,

--- a/src/stores/useIpodStore.ts
+++ b/src/stores/useIpodStore.ts
@@ -14,6 +14,13 @@ import type { FuriganaSegment } from "@/utils/romanization";
 import { getApiUrl } from "@/utils/platform";
 import { getAppPublicOrigin } from "@/utils/runtimeConfig";
 import { getCachedSongMetadata, listAllCachedSongMetadata } from "@/utils/songMetadataCache";
+import { ApiRequestError } from "@/api/core";
+import {
+  clearSongCachedData,
+  fetchSongLyrics,
+  listSongs,
+  patchSongMetadata,
+} from "@/api/songs";
 import i18n from "@/lib/i18n";
 import { useChatsStore } from "./useChatsStore";
 import { abortableFetch } from "@/utils/abortableFetch";
@@ -29,6 +36,7 @@ import {
   resolveSyncedCoverColor,
   shouldUpdateTrackLyricsSource,
 } from "@/stores/ipodTrackMetadataSync";
+import { mapCatalogSongToTrack } from "@/stores/ipodCatalogTrackMapping";
 import {
   saveAppleMusicLibrary,
   saveAppleMusicPlaylistTracks,
@@ -373,20 +381,7 @@ async function loadDefaultTracks(forceRefresh = false): Promise<{
       
       console.log(`[iPod Store] Loaded ${cachedSongs.length} tracks from Redis cache (by ryo)`);
       // Songs are already sorted by createdAt (newest first) from the API
-      const tracks: Track[] = cachedSongs.map((song) => ({
-        id: song.youtubeId,
-        url: `https://www.youtube.com/watch?v=${song.youtubeId}`,
-        title: song.title,
-        artist: song.artist,
-        album: song.album ?? "",
-        cover: song.cover,
-        coverColor: song.coverColor,
-        lyricOffset: song.lyricOffset,
-        lyricsSource: song.lyricsSource,
-        createdAt: song.createdAt,
-        importOrder: song.importOrder,
-        updatedAt: song.updatedAt,
-      }));
+      const tracks: Track[] = cachedSongs.map(mapCatalogSongToTrack);
       // Use the latest createdAt timestamp as version (or 1 if empty)
       const version = cachedSongs.length > 0 
         ? Math.max(...cachedSongs.map((s) => s.createdAt || 1))
@@ -945,48 +940,30 @@ async function saveLyricOffsetToServer(
   console.log(`[iPod Store] Saving lyric offset for ${trackId}: ${lyricOffset}ms...`);
   
   try {
-    const response = await abortableFetch(
-      getApiUrl(`/api/songs/${encodeURIComponent(trackId)}`),
-      {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          lyricOffset,
-        }),
-        timeout: 15000,
-        throwOnHttpError: false,
-        retry: { maxAttempts: 1, initialDelayMs: 250 },
-      }
+    const data = await patchSongMetadata(
+      trackId,
+      { lyricOffset },
+      { username, isAuthenticated }
     );
-
-    if (response.status === 401) {
-      console.warn(`[iPod Store] Unauthorized - user must be logged in to save lyric offset`);
-      return false;
-    }
-
-    if (response.status === 403) {
-      // Permission denied - song is owned by another user
-      console.log(`[iPod Store] Cannot save lyric offset for ${trackId} - song owned by another user`);
-      return false;
-    }
-
-    if (!response.ok) {
-      const errorText = await response.text();
-      console.warn(`[iPod Store] Failed to save lyric offset for ${trackId}: ${response.status} - ${errorText}`);
-      return false;
-    }
-
-    const data = await response.json();
     if (data.success) {
       console.log(`[iPod Store] ✓ Saved lyric offset for ${trackId}: ${lyricOffset}ms (by ${data.createdBy || username})`);
       return true;
-    } else {
-      console.warn(`[iPod Store] Server returned failure for ${trackId}:`, data);
+    }
+    console.warn(`[iPod Store] Server returned failure for ${trackId}:`, data);
+    return false;
+  } catch (error) {
+    if (error instanceof ApiRequestError) {
+      if (error.status === 401) {
+        console.warn(`[iPod Store] Unauthorized - user must be logged in to save lyric offset`);
+        return false;
+      }
+      if (error.status === 403) {
+        console.log(`[iPod Store] Cannot save lyric offset for ${trackId} - song owned by another user`);
+        return false;
+      }
+      console.warn(`[iPod Store] Failed to save lyric offset for ${trackId}: ${error.status} - ${error.message}`);
       return false;
     }
-  } catch (error) {
     console.error(`[iPod Store] Error saving lyric offset for ${trackId}:`, error);
     return false;
   }
@@ -1059,52 +1036,38 @@ async function saveLyricsSourceToServer(
   }
 
   try {
-    const response = await abortableFetch(
-      getApiUrl(`/api/songs/${encodeURIComponent(trackId)}`),
+    const data = await patchSongMetadata(
+      trackId,
       {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          lyricsSource: lyricsSource || undefined,
+        ...(lyricsSource && {
+          lyricsSource,
           // Update song metadata from lyricsSource (KuGou has more accurate metadata)
-          ...(lyricsSource && {
-            title: lyricsSource.title,
-            artist: lyricsSource.artist,
-            album: lyricsSource.album,
-          }),
-          // Clear translations, furigana, and soramimi since lyrics changed
-          clearTranslations: true,
-          clearFurigana: true,
-          clearSoramimi: true,
-          clearLyrics: true,
+          title: lyricsSource.title,
+          artist: lyricsSource.artist,
+          album: lyricsSource.album,
         }),
-        timeout: 15000,
-        throwOnHttpError: false,
-        retry: { maxAttempts: 1, initialDelayMs: 250 },
-      }
+        // Clear translations, furigana, and soramimi since lyrics changed
+        clearTranslations: true,
+        clearFurigana: true,
+        clearSoramimi: true,
+        clearLyrics: true,
+      },
+      { username, isAuthenticated }
     );
-
-    if (response.status === 401) {
-      console.warn(`[iPod Store] Unauthorized - user must be logged in to save lyrics source`);
-      return;
-    }
-
-    if (response.status === 403) {
-      // Permission denied - song is owned by another user
-      console.log(`[iPod Store] Cannot save lyrics source for ${trackId} - song owned by another user`);
-      return;
-    }
-
-    if (!response.ok) {
-      console.warn(`[iPod Store] Failed to save lyrics source for ${trackId}: ${response.status}`);
-      return;
-    }
-
-    const data = await response.json();
     console.log(`[iPod Store] Saved lyrics source for ${trackId}, cleared translations/furigana (by ${data.createdBy || username})`);
   } catch (error) {
+    if (error instanceof ApiRequestError) {
+      if (error.status === 401) {
+        console.warn(`[iPod Store] Unauthorized - user must be logged in to save lyrics source`);
+        return;
+      }
+      if (error.status === 403) {
+        console.log(`[iPod Store] Cannot save lyrics source for ${trackId} - song owned by another user`);
+        return;
+      }
+      console.warn(`[iPod Store] Failed to save lyrics source for ${trackId}: ${error.status}`);
+      return;
+    }
     console.error(`[iPod Store] Error saving lyrics source for ${trackId}:`, error);
   }
 }
@@ -1522,19 +1485,7 @@ export const useIpodStore = create<IpodState>()(
         
         // Clear server-side cache for translations, furigana, and soramimi
         if (currentTrack?.id) {
-          abortableFetch(getApiUrl(`/api/songs/${currentTrack.id}`), {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({
-              action: "clear-cached-data",
-              clearTranslations: true,
-              clearFurigana: true,
-              clearSoramimi: true,
-            }),
-            timeout: 15000,
-            throwOnHttpError: false,
-            retry: { maxAttempts: 1, initialDelayMs: 250 },
-          }).catch((err) => {
+          clearSongCachedData(currentTrack.id).catch((err) => {
             console.error("[iPod Store] Failed to clear server cache:", err);
           });
         }
@@ -1850,41 +1801,27 @@ export const useIpodStore = create<IpodState>()(
         // Single call to fetch-lyrics with returnMetadata: searches Kugou, fetches lyrics+cover, returns metadata
         // This consolidates search + fetch into one call
         try {
-          const fetchResponse = await abortableFetch(
-            getApiUrl(`/api/songs/${videoId}`),
-            {
-              method: "POST",
-              headers: { "Content-Type": "application/json" },
-              body: JSON.stringify({
-                action: "fetch-lyrics",
-                title: rawTitle,
-                returnMetadata: true,
-              }),
-              timeout: 15000,
-              throwOnHttpError: false,
-              retry: { maxAttempts: 1, initialDelayMs: 250 },
-            }
-          );
+          const fetchData = await fetchSongLyrics(videoId, {
+            title: rawTitle,
+            returnMetadata: true,
+            retry: { maxAttempts: 1, initialDelayMs: 250 },
+          });
 
-          if (fetchResponse.ok) {
-            const fetchData = await fetchResponse.json();
+          // Use metadata from server (Kugou source) if available
+          if (fetchData.metadata?.lyricsSource) {
+            const meta = fetchData.metadata;
+            console.log(`[iPod Store] Got metadata from Kugou for ${videoId}:`, {
+              title: meta.title,
+              artist: meta.artist,
+              cover: meta.cover,
+            });
             
-            // Use metadata from server (Kugou source) if available
-            if (fetchData.metadata?.lyricsSource) {
-              const meta = fetchData.metadata;
-              console.log(`[iPod Store] Got metadata from Kugou for ${videoId}:`, {
-                title: meta.title,
-                artist: meta.artist,
-                cover: meta.cover,
-              });
-              
-              trackInfo.title = meta.title || trackInfo.title;
-              trackInfo.artist = meta.artist;
-              trackInfo.album = meta.album;
-              trackInfo.cover = meta.cover;
-              trackInfo.coverColor = meta.coverColor;
-              trackInfo.lyricsSource = meta.lyricsSource;
-            }
+            trackInfo.title = meta.title || trackInfo.title;
+            trackInfo.artist = meta.artist;
+            trackInfo.album = meta.album;
+            trackInfo.cover = meta.cover;
+            trackInfo.coverColor = meta.coverColor;
+            trackInfo.lyricsSource = meta.lyricsSource;
           }
         } catch (error) {
           console.warn(`[iPod Store] Failed to fetch lyrics for ${videoId}:`, error);
@@ -2016,91 +1953,80 @@ export const useIpodStore = create<IpodState>()(
             
             try {
               // Batch fetch metadata for tracks not in default library
-              const idsToFetch = tracksNotInDefaultLibrary.map((t) => t.id).join(",");
-              const response = await abortableFetch(
-                getApiUrl(`/api/songs?ids=${encodeURIComponent(idsToFetch)}&include=metadata`),
-                {
-                  method: "GET",
-                  headers: { "Content-Type": "application/json" },
-                  timeout: 15000,
-                  throwOnHttpError: false,
-                  retry: { maxAttempts: 1, initialDelayMs: 250 },
-                }
+              type FetchedSongMetadata = {
+                id: string;
+                title?: string;
+                artist?: string;
+                album?: string;
+                cover?: string;
+                coverColor?: string;
+                lyricOffset?: number;
+                lyricsSource?: LyricsSource;
+                createdAt?: number;
+                importOrder?: number;
+                updatedAt?: number;
+              };
+              const data = await listSongs<FetchedSongMetadata>({
+                include: "metadata",
+                ids: tracksNotInDefaultLibrary.map((t) => t.id),
+              });
+              const fetchedSongs = data.songs || [];
+              const fetchedMap = new Map<string, FetchedSongMetadata>(
+                fetchedSongs.map((s: FetchedSongMetadata) => [s.id, s])
               );
 
-              if (response.ok) {
-                const data = await response.json();
-                const fetchedSongs = data.songs || [];
-                type FetchedSongMetadata = {
-                  id: string;
-                  title?: string;
-                  artist?: string;
-                  album?: string;
-                  cover?: string;
-                  coverColor?: string;
-                  lyricOffset?: number;
-                  lyricsSource?: LyricsSource;
-                  createdAt?: number;
-                  importOrder?: number;
-                  updatedAt?: number;
-                };
-                const fetchedMap = new Map<string, FetchedSongMetadata>(
-                  fetchedSongs.map((s: FetchedSongMetadata) => [s.id, s])
-                );
+              // Update tracks with fetched metadata
+              finalTracks = finalTracks.map((track) => {
+                const fetched = fetchedMap.get(track.id);
+                if (fetched) {
+                  const shouldUpdateLyricsSource = shouldUpdateTrackLyricsSource(
+                    track,
+                    fetched
+                  );
+                  const hasChanges = hasFetchedTrackMetadataChanges(track, fetched);
 
-                // Update tracks with fetched metadata
-                finalTracks = finalTracks.map((track) => {
-                  const fetched = fetchedMap.get(track.id);
-                  if (fetched) {
-                    const shouldUpdateLyricsSource = shouldUpdateTrackLyricsSource(
-                      track,
-                      fetched
-                    );
-                    const hasChanges = hasFetchedTrackMetadataChanges(track, fetched);
-
-                    if (hasChanges) {
-                      tracksUpdated++;
-                      return {
-                        ...track,
-                        // Update with server metadata, preserving existing values if server doesn't have them
-                        title: fetched.title || track.title,
-                        artist: fetched.artist ?? track.artist,
-                        album: fetched.album ?? track.album,
-                        cover: fetched.cover ?? track.cover,
-                        coverColor: resolveSyncedCoverColor(track, fetched),
-                        lyricOffset: fetched.lyricOffset ?? track.lyricOffset,
-                        createdAt: Math.max(
-                          track.createdAt ?? 0,
-                          fetched.createdAt ?? 0
-                        ) || undefined,
-                        importOrder: fetched.importOrder ?? track.importOrder,
-                        updatedAt: Math.max(
-                          track.updatedAt ?? 0,
-                          fetched.updatedAt ?? 0
-                        ) || undefined,
-                        // Update lyricsSource from server if it's new or different
-                        ...(shouldUpdateLyricsSource && {
-                          lyricsSource: fetched.lyricsSource,
-                        }),
-                      };
-                    }
+                  if (hasChanges) {
+                    tracksUpdated++;
+                    return {
+                      ...track,
+                      // Update with server metadata, preserving existing values if server doesn't have them
+                      title: fetched.title || track.title,
+                      artist: fetched.artist ?? track.artist,
+                      album: fetched.album ?? track.album,
+                      cover: fetched.cover ?? track.cover,
+                      coverColor: resolveSyncedCoverColor(track, fetched),
+                      lyricOffset: fetched.lyricOffset ?? track.lyricOffset,
+                      createdAt: Math.max(
+                        track.createdAt ?? 0,
+                        fetched.createdAt ?? 0
+                      ) || undefined,
+                      importOrder: fetched.importOrder ?? track.importOrder,
+                      updatedAt: Math.max(
+                        track.updatedAt ?? 0,
+                        fetched.updatedAt ?? 0
+                      ) || undefined,
+                      // Update lyricsSource from server if it's new or different
+                      ...(shouldUpdateLyricsSource && {
+                        lyricsSource: fetched.lyricsSource,
+                      }),
+                    };
                   }
-                  const mergedCreated = Math.max(
-                    track.createdAt ?? 0,
-                    fetched?.createdAt ?? 0
-                  );
-                  const mergedUpdated = Math.max(
-                    track.updatedAt ?? 0,
-                    fetched?.updatedAt ?? 0
-                  );
-                  return {
-                    ...track,
-                    createdAt: mergedCreated || undefined,
-                    importOrder: fetched?.importOrder ?? track.importOrder,
-                    updatedAt: mergedUpdated || undefined,
-                  };
-                });
-              }
+                }
+                const mergedCreated = Math.max(
+                  track.createdAt ?? 0,
+                  fetched?.createdAt ?? 0
+                );
+                const mergedUpdated = Math.max(
+                  track.updatedAt ?? 0,
+                  fetched?.updatedAt ?? 0
+                );
+                return {
+                  ...track,
+                  createdAt: mergedCreated || undefined,
+                  importOrder: fetched?.importOrder ?? track.importOrder,
+                  updatedAt: mergedUpdated || undefined,
+                };
+              });
             } catch (error) {
               console.warn(`[iPod Store] Failed to fetch metadata for user tracks:`, error);
             }

--- a/tests/test-cloud-sync-song-order.test.ts
+++ b/tests/test-cloud-sync-song-order.test.ts
@@ -78,7 +78,11 @@ class MockAudioContext {
 }
 
 function createBrowserTestEnvironment(): void {
-  browserGlobals.localStorage = new MemoryStorage();
+  if (browserGlobals.localStorage instanceof MemoryStorage) {
+    browserGlobals.localStorage.clear();
+  } else {
+    browserGlobals.localStorage = new MemoryStorage();
+  }
   browserGlobals.document = {
     documentElement: {
       dataset: {},

--- a/tests/test-cloud-sync-song-order.test.ts
+++ b/tests/test-cloud-sync-song-order.test.ts
@@ -78,7 +78,7 @@ class MockAudioContext {
 }
 
 function createBrowserTestEnvironment(): void {
-  if (browserGlobals.localStorage instanceof MemoryStorage) {
+  if (browserGlobals.localStorage) {
     browserGlobals.localStorage.clear();
   } else {
     browserGlobals.localStorage = new MemoryStorage();

--- a/tests/test-ipod-lyrics-track-metadata.test.ts
+++ b/tests/test-ipod-lyrics-track-metadata.test.ts
@@ -44,6 +44,22 @@ const {
 const { useIpodStore } = await import("../src/stores/useIpodStore");
 type Track = import("../src/stores/useIpodStore").Track;
 
+function readPersistedIpodState(): unknown {
+  const storeWithPersist = useIpodStore as typeof useIpodStore & {
+    persist?: {
+      getOptions?: () => {
+        storage?: {
+          getItem: (name: string) => unknown;
+        };
+      };
+    };
+  };
+  const raw =
+    storeWithPersist.persist?.getOptions?.().storage?.getItem("ryos:ipod") ??
+    localStorage.getItem("ryos:ipod");
+  return typeof raw === "string" ? JSON.parse(raw) : raw;
+}
+
 const youtubeTrack: Track = {
   id: "dQw4w9WgXcQ",
   url: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
@@ -238,7 +254,9 @@ describe("setTrackCoverColor", () => {
       updated.appleMusicPlaylistTracks["pl.favorites-mix"]?.[0]?.coverColor
     ).toBe("#abcdef");
 
-    const persisted = JSON.parse(localStorage.getItem("ryos:ipod") ?? "{}");
+    const persisted = readPersistedIpodState() as {
+      state?: { tracks?: Track[] };
+    };
     expect(persisted.state?.tracks?.[0]?.coverColor).toBe("#123456");
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add shared song API helpers for metadata patches, lyrics fetches, and cache clearing.
- Replace duplicated iPod catalog-to-track mapping with a shared mapper.
- Move iPod store and lyrics hook song reads/writes onto the shared API helpers.
- Tighten focused test storage setup so persisted iPod state assertions survive grouped Bun test execution.

### Testing
- `bun run build`
- `bun test tests/test-ipod-track-metadata-sync.test.ts tests/test-ipod-lyrics-track-metadata.test.ts tests/test-cloud-sync-song-order.test.ts`
- `bun test tests/test-song.test.ts` with `bun run dev:api` running
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019e88be-060d-7826-8802-28401028b0ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019e88be-060d-7826-8802-28401028b0ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

