### PR TITLE
fix(chats): keep scroll-to-bottom chevron dark in Aqua dark mode

### DIFF
--- a/src/apps/chats/components/chat-messages/ScrollToBottomButton.tsx
+++ b/src/apps/chats/components/chat-messages/ScrollToBottomButton.tsx
@@ -69,8 +69,8 @@ export function ScrollToBottomButton() {
             </>
           )}
           <CaretDown
-            className={`size-2.5 ${
-              isMacTheme ? "text-black/70 relative z-10" : "text-neutral-800"
+            className={`chat-scroll-to-bottom-glyph size-2.5 ${
+              isMacTheme ? "relative z-10" : ""
             }`}
             weight="bold"
           />

--- a/src/apps/chats/components/chat-messages/ScrollToBottomButton.tsx
+++ b/src/apps/chats/components/chat-messages/ScrollToBottomButton.tsx
@@ -6,7 +6,7 @@ import { useThemeFlags } from "@/hooks/useThemeFlags";
 
 export function ScrollToBottomButton() {
   const { t } = useTranslation();
-  const { isMacOSTheme: isMacTheme } = useThemeFlags();
+  const { isMacOSTheme: isMacTheme, isDarkMode } = useThemeFlags();
   const { isAtBottom, scrollToBottom } = useStickToBottomContext();
 
   return (
@@ -17,7 +17,7 @@ export function ScrollToBottomButton() {
           animate={{ opacity: 1, scale: 1, y: 0 }}
           exit={{ opacity: 0, scale: 0.8, y: 10 }}
           transition={{ type: "spring", duration: 0.2 }}
-          className={`absolute bottom-14 right-3 rounded-full z-20 flex items-center justify-center cursor-pointer select-none ${
+          className={`chat-scroll-to-bottom-btn absolute bottom-14 right-3 rounded-full z-20 flex items-center justify-center cursor-pointer select-none ${
             isMacTheme ? "relative overflow-hidden" : ""
           }`}
           style={{
@@ -41,7 +41,7 @@ export function ScrollToBottomButton() {
           {isMacTheme && (
             <>
               <div
-                className="pointer-events-none absolute left-1/2 -translate-x-1/2"
+                className="chat-scroll-to-bottom-gloss-top pointer-events-none absolute left-1/2 -translate-x-1/2"
                 style={{
                   top: "2px",
                   height: "30%",
@@ -54,7 +54,7 @@ export function ScrollToBottomButton() {
                 }}
               />
               <div
-                className="pointer-events-none absolute left-1/2 -translate-x-1/2"
+                className="chat-scroll-to-bottom-gloss-bottom pointer-events-none absolute left-1/2 -translate-x-1/2"
                 style={{
                   bottom: "1px",
                   height: "38%",
@@ -69,8 +69,14 @@ export function ScrollToBottomButton() {
             </>
           )}
           <CaretDown
-            className={`chat-scroll-to-bottom-glyph size-2.5 ${
+            className={`size-2.5 ${
               isMacTheme ? "relative z-10" : ""
+            } ${
+              isMacTheme && isDarkMode
+                ? "text-white"
+                : isMacTheme
+                  ? "text-black/70"
+                  : "text-neutral-800"
             }`}
             weight="bold"
           />

--- a/src/styles/themes.css
+++ b/src/styles/themes.css
@@ -3718,7 +3718,7 @@
     .text-black\/40,
     .text-black\/30,
     .text-black\/20
-  ):not(.chat-submit-glyph):not(.chat-stop-glyph):not(.chat-scroll-to-bottom-glyph):not(.ipod-force-font *):not(.karaoke-force-font *):not(.tv-cc-force-font *):not(.os-native-chrome-skip *):not(.dashboard-overlay *):not([class*="bg-pink-"]):not([class*="bg-blue-"]):not([class*="bg-yellow-"]):not([class*="bg-purple-"]):not([class*="bg-indigo-"]):not([class*="bg-teal-"]):not([class*="bg-lime-"]):not([class*="bg-amber-"]):not([class*="bg-cyan-"]):not([class*="bg-rose-"]):not([class*="bg-green-"]):not([class*="bg-orange-"]):not([class*="bg-red-"]) {
+  ):not(.chat-submit-glyph):not(.chat-stop-glyph):not(.ipod-force-font *):not(.karaoke-force-font *):not(.tv-cc-force-font *):not(.os-native-chrome-skip *):not(.dashboard-overlay *):not([class*="bg-pink-"]):not([class*="bg-blue-"]):not([class*="bg-yellow-"]):not([class*="bg-purple-"]):not([class*="bg-indigo-"]):not([class*="bg-teal-"]):not([class*="bg-lime-"]):not([class*="bg-amber-"]):not([class*="bg-cyan-"]):not([class*="bg-rose-"]):not([class*="bg-green-"]):not([class*="bg-orange-"]):not([class*="bg-red-"]) {
   color: var(--os-color-text-secondary) !important;
 }
 
@@ -3743,7 +3743,7 @@
     .text-slate-600,
     .text-slate-700,
     .text-slate-800
-  ):not(.chat-scroll-to-bottom-glyph):not(.ipod-force-font *):not(.karaoke-force-font *):not(.tv-cc-force-font *):not(.os-native-chrome-skip *):not(.dashboard-overlay *):not([class*="bg-pink-"]):not([class*="bg-blue-"]):not([class*="bg-yellow-"]):not([class*="bg-purple-"]):not([class*="bg-indigo-"]):not([class*="bg-teal-"]):not([class*="bg-lime-"]):not([class*="bg-amber-"]):not([class*="bg-cyan-"]):not([class*="bg-rose-"]):not([class*="bg-green-"]):not([class*="bg-orange-"]):not([class*="bg-red-"]):not([class*="bg-gray-1"]):not([class*="bg-neutral-1"]):not([class*="bg-zinc-1"]):not([class*="bg-slate-1"]) {
+  ):not(.ipod-force-font *):not(.karaoke-force-font *):not(.tv-cc-force-font *):not(.os-native-chrome-skip *):not(.dashboard-overlay *):not([class*="bg-pink-"]):not([class*="bg-blue-"]):not([class*="bg-yellow-"]):not([class*="bg-purple-"]):not([class*="bg-indigo-"]):not([class*="bg-teal-"]):not([class*="bg-lime-"]):not([class*="bg-amber-"]):not([class*="bg-cyan-"]):not([class*="bg-rose-"]):not([class*="bg-green-"]):not([class*="bg-orange-"]):not([class*="bg-red-"]):not([class*="bg-gray-1"]):not([class*="bg-neutral-1"]):not([class*="bg-zinc-1"]):not([class*="bg-slate-1"]) {
   color: var(--os-color-text-secondary) !important;
 }
 
@@ -4413,17 +4413,41 @@
    top. In dark mode the broader `.window-body` rules remap `text-black/70`
    to the secondary-text token (#c8c8cc), which would sink the arrow into
    the green pill. The dark `text-black/*` rule now explicitly excludes
-   `.chat-submit-glyph`, `.chat-stop-glyph`, and `.chat-scroll-to-bottom-glyph`),
-   so this lightweight pin wins across all themes / both color schemes. The
-   Phosphor glyph uses `fill="currentColor"`, so setting color is enough. */
+   `.chat-submit-glyph` (and `.chat-stop-glyph`), so this lightweight pin
+   wins across all themes / both color schemes. The Phosphor glyph uses
+   `fill="currentColor"`, so setting color is enough. */
 .chat-submit-glyph {
   color: rgba(0, 0, 0, 0.85) !important;
 }
 
-/* Scroll-to-bottom chevron sits on a light pill; keep the caret dark in Aqua dark
-   mode (window-body text remaps would otherwise lighten it). */
-.chat-scroll-to-bottom-glyph {
-  color: rgba(0, 0, 0, 0.7) !important;
+/* --- Chats scroll-to-bottom pill (macOS Aqua) -------------------------------- */
+/* Light mode keeps the inline silver/white gradient; dark mode uses a denser
+   graphite pill so the white chevron (authored in the component) stays legible. */
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"] .chat-scroll-to-bottom-btn {
+  background: linear-gradient(
+    rgba(88, 88, 90, 0.96),
+    rgba(48, 48, 50, 0.96)
+  ) !important;
+  box-shadow:
+    0 2px 3px rgba(0, 0, 0, 0.45),
+    0 1px 1px rgba(0, 0, 0, 0.35),
+    inset 0 0 0 0.5px rgba(0, 0, 0, 0.45),
+    inset 0 1px 2px rgba(0, 0, 0, 0.35),
+    inset 0 2px 3px 1px rgba(24, 24, 26, 0.85) !important;
+}
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"]
+  .chat-scroll-to-bottom-gloss-top {
+  background: linear-gradient(
+    rgba(255, 255, 255, 0.22),
+    rgba(255, 255, 255, 0.04)
+  ) !important;
+}
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"]
+  .chat-scroll-to-bottom-gloss-bottom {
+  background: linear-gradient(
+    rgba(255, 255, 255, 0.06),
+    rgba(255, 255, 255, 0.18)
+  ) !important;
 }
 
 /* --- Inline search/text inputs that don't use the shared SearchInput ----- */

--- a/src/styles/themes.css
+++ b/src/styles/themes.css
@@ -3718,7 +3718,7 @@
     .text-black\/40,
     .text-black\/30,
     .text-black\/20
-  ):not(.chat-submit-glyph):not(.chat-stop-glyph):not(.ipod-force-font *):not(.karaoke-force-font *):not(.tv-cc-force-font *):not(.os-native-chrome-skip *):not(.dashboard-overlay *):not([class*="bg-pink-"]):not([class*="bg-blue-"]):not([class*="bg-yellow-"]):not([class*="bg-purple-"]):not([class*="bg-indigo-"]):not([class*="bg-teal-"]):not([class*="bg-lime-"]):not([class*="bg-amber-"]):not([class*="bg-cyan-"]):not([class*="bg-rose-"]):not([class*="bg-green-"]):not([class*="bg-orange-"]):not([class*="bg-red-"]) {
+  ):not(.chat-submit-glyph):not(.chat-stop-glyph):not(.chat-scroll-to-bottom-glyph):not(.ipod-force-font *):not(.karaoke-force-font *):not(.tv-cc-force-font *):not(.os-native-chrome-skip *):not(.dashboard-overlay *):not([class*="bg-pink-"]):not([class*="bg-blue-"]):not([class*="bg-yellow-"]):not([class*="bg-purple-"]):not([class*="bg-indigo-"]):not([class*="bg-teal-"]):not([class*="bg-lime-"]):not([class*="bg-amber-"]):not([class*="bg-cyan-"]):not([class*="bg-rose-"]):not([class*="bg-green-"]):not([class*="bg-orange-"]):not([class*="bg-red-"]) {
   color: var(--os-color-text-secondary) !important;
 }
 
@@ -3743,7 +3743,7 @@
     .text-slate-600,
     .text-slate-700,
     .text-slate-800
-  ):not(.ipod-force-font *):not(.karaoke-force-font *):not(.tv-cc-force-font *):not(.os-native-chrome-skip *):not(.dashboard-overlay *):not([class*="bg-pink-"]):not([class*="bg-blue-"]):not([class*="bg-yellow-"]):not([class*="bg-purple-"]):not([class*="bg-indigo-"]):not([class*="bg-teal-"]):not([class*="bg-lime-"]):not([class*="bg-amber-"]):not([class*="bg-cyan-"]):not([class*="bg-rose-"]):not([class*="bg-green-"]):not([class*="bg-orange-"]):not([class*="bg-red-"]):not([class*="bg-gray-1"]):not([class*="bg-neutral-1"]):not([class*="bg-zinc-1"]):not([class*="bg-slate-1"]) {
+  ):not(.chat-scroll-to-bottom-glyph):not(.ipod-force-font *):not(.karaoke-force-font *):not(.tv-cc-force-font *):not(.os-native-chrome-skip *):not(.dashboard-overlay *):not([class*="bg-pink-"]):not([class*="bg-blue-"]):not([class*="bg-yellow-"]):not([class*="bg-purple-"]):not([class*="bg-indigo-"]):not([class*="bg-teal-"]):not([class*="bg-lime-"]):not([class*="bg-amber-"]):not([class*="bg-cyan-"]):not([class*="bg-rose-"]):not([class*="bg-green-"]):not([class*="bg-orange-"]):not([class*="bg-red-"]):not([class*="bg-gray-1"]):not([class*="bg-neutral-1"]):not([class*="bg-zinc-1"]):not([class*="bg-slate-1"]) {
   color: var(--os-color-text-secondary) !important;
 }
 
@@ -4413,11 +4413,17 @@
    top. In dark mode the broader `.window-body` rules remap `text-black/70`
    to the secondary-text token (#c8c8cc), which would sink the arrow into
    the green pill. The dark `text-black/*` rule now explicitly excludes
-   `.chat-submit-glyph` (and `.chat-stop-glyph`), so this lightweight pin
-   wins across all themes / both color schemes. The Phosphor glyph uses
-   `fill="currentColor"`, so setting color is enough. */
+   `.chat-submit-glyph`, `.chat-stop-glyph`, and `.chat-scroll-to-bottom-glyph`),
+   so this lightweight pin wins across all themes / both color schemes. The
+   Phosphor glyph uses `fill="currentColor"`, so setting color is enough. */
 .chat-submit-glyph {
   color: rgba(0, 0, 0, 0.85) !important;
+}
+
+/* Scroll-to-bottom chevron sits on a light pill; keep the caret dark in Aqua dark
+   mode (window-body text remaps would otherwise lighten it). */
+.chat-scroll-to-bottom-glyph {
+  color: rgba(0, 0, 0, 0.7) !important;
 }
 
 /* --- Inline search/text inputs that don't use the shared SearchInput ----- */

--- a/tests/test-chat-scroll-to-bottom-dark.test.ts
+++ b/tests/test-chat-scroll-to-bottom-dark.test.ts
@@ -14,23 +14,24 @@ const themesCss = readFileSync(
   "utf8"
 );
 
-describe("Chats scroll-to-bottom chevron in macOS Aqua dark mode", () => {
-  test("ScrollToBottomButton pins glyph color via shared class", () => {
-    expect(scrollButtonSource).toContain("chat-scroll-to-bottom-glyph");
-    expect(scrollButtonSource).not.toContain("text-neutral-800");
-    expect(scrollButtonSource).not.toContain("text-black/70");
+describe("Chats scroll-to-bottom in macOS Aqua dark mode", () => {
+  test("ScrollToBottomButton uses white chevron and dark pill hook class in dark mode", () => {
+    expect(scrollButtonSource).toContain("chat-scroll-to-bottom-btn");
+    expect(scrollButtonSource).toContain("isDarkMode");
+    expect(scrollButtonSource).toContain('"text-white"');
+    expect(scrollButtonSource).toContain("text-black/70");
+    expect(scrollButtonSource).not.toContain("chat-scroll-to-bottom-glyph");
   });
 
-  test("themes.css keeps scroll chevron dark and excludes it from dark remaps", () => {
-    expect(themesCss).toContain(".chat-scroll-to-bottom-glyph");
+  test("themes.css darkens scroll pill and tones gloss; no dark chevron pin", () => {
+    expect(themesCss).toContain(
+      ':root[data-os-theme="macosx"][data-os-color-scheme="dark"] .chat-scroll-to-bottom-btn'
+    );
     expect(themesCss).toMatch(
-      /\.chat-scroll-to-bottom-glyph\s*\{[^}]*color:\s*rgba\(0,\s*0,\s*0/i
+      /\.chat-scroll-to-bottom-btn\s*\{[^}]*rgba\(88,\s*88,\s*90/i
     );
-    expect(themesCss).toContain(
-      ":not(.chat-scroll-to-bottom-glyph):not(.ipod-force-font"
-    );
-    expect(themesCss).toContain(
-      ":not(.chat-submit-glyph):not(.chat-stop-glyph):not(.chat-scroll-to-bottom-glyph)"
-    );
+    expect(themesCss).toContain(".chat-scroll-to-bottom-gloss-top");
+    expect(themesCss).toContain(".chat-scroll-to-bottom-gloss-bottom");
+    expect(themesCss).not.toContain(".chat-scroll-to-bottom-glyph");
   });
 });

--- a/tests/test-chat-scroll-to-bottom-dark.test.ts
+++ b/tests/test-chat-scroll-to-bottom-dark.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const scrollButtonSource = readFileSync(
+  join(
+    import.meta.dir,
+    "../src/apps/chats/components/chat-messages/ScrollToBottomButton.tsx"
+  ),
+  "utf8"
+);
+const themesCss = readFileSync(
+  join(import.meta.dir, "../src/styles/themes.css"),
+  "utf8"
+);
+
+describe("Chats scroll-to-bottom chevron in macOS Aqua dark mode", () => {
+  test("ScrollToBottomButton pins glyph color via shared class", () => {
+    expect(scrollButtonSource).toContain("chat-scroll-to-bottom-glyph");
+    expect(scrollButtonSource).not.toContain("text-neutral-800");
+    expect(scrollButtonSource).not.toContain("text-black/70");
+  });
+
+  test("themes.css keeps scroll chevron dark and excludes it from dark remaps", () => {
+    expect(themesCss).toContain(".chat-scroll-to-bottom-glyph");
+    expect(themesCss).toMatch(
+      /\.chat-scroll-to-bottom-glyph\s*\{[^}]*color:\s*rgba\(0,\s*0,\s*0/i
+    );
+    expect(themesCss).toContain(
+      ":not(.chat-scroll-to-bottom-glyph):not(.ipod-force-font"
+    );
+    expect(themesCss).toContain(
+      ":not(.chat-submit-glyph):not(.chat-stop-glyph):not(.chat-scroll-to-bottom-glyph)"
+    );
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Reworked the Chats scroll-to-bottom control for macOS Aqua dark mode: instead of forcing a dark chevron on the light pill, the pill gradient is darkened and the chevron stays white for contrast.

## Changes

- `ScrollToBottomButton`: `chat-scroll-to-bottom-btn` hook class; `text-white` chevron when `isDarkMode` on Aqua, `text-black/70` in light mode.
- `themes.css`: dark graphite pill gradient, adjusted gloss layers; removed the `chat-scroll-to-bottom-glyph` dark-caret pin.
- Regression test updated in `tests/test-chat-scroll-to-bottom-dark.test.ts`.

## Testing

```bash
bun test tests/test-chat-scroll-to-bottom-dark.test.ts
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4eba5d4f-f9d6-4c1f-a1b7-392b435f097e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4eba5d4f-f9d6-4c1f-a1b7-392b435f097e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

