### PR TITLE
Fix karaoke highlight timing with glow shadows

### DIFF
--- a/src/apps/ipod/components/lyrics-display/WordTimingHighlight.tsx
+++ b/src/apps/ipod/components/lyrics-display/WordTimingHighlight.tsx
@@ -376,10 +376,13 @@ export function WordTimingHighlight({
                 marginTop: isOldSchoolKaraoke ? `-${OLD_SCHOOL_PADDING_TOP}` : `calc(-1 * ${LYRICS_SHADOW_BLEED_TOP})`,
                 paddingBottom: isOldSchoolKaraoke ? OLD_SCHOOL_PADDING_BOTTOM : LYRICS_SHADOW_BLEED_BOTTOM,
                 marginBottom: isOldSchoolKaraoke ? `-${OLD_SCHOOL_PADDING_BOTTOM}` : `calc(-1 * ${LYRICS_SHADOW_BLEED_BOTTOM})`,
-                paddingLeft: isOldSchoolKaraoke ? OLD_SCHOOL_PADDING : LYRICS_SHADOW_BLEED_X,
-                paddingRight: isOldSchoolKaraoke ? OLD_SCHOOL_PADDING : LYRICS_SHADOW_BLEED_X,
-                marginLeft: isOldSchoolKaraoke ? `-${OLD_SCHOOL_PADDING}` : `calc(-1 * ${LYRICS_SHADOW_BLEED_X})`,
-                marginRight: isOldSchoolKaraoke ? `-${OLD_SCHOOL_PADDING}` : `calc(-1 * ${LYRICS_SHADOW_BLEED_X})`,
+                // Glow styles get horizontal shadow room from the filtered outer layer.
+                // Repeating that bleed here makes mask percentages resolve against an
+                // invisible wider box, delaying the visible word fill.
+                paddingLeft: isOldSchoolKaraoke ? OLD_SCHOOL_PADDING : undefined,
+                paddingRight: isOldSchoolKaraoke ? OLD_SCHOOL_PADDING : undefined,
+                marginLeft: isOldSchoolKaraoke ? `-${OLD_SCHOOL_PADDING}` : undefined,
+                marginRight: isOldSchoolKaraoke ? `-${OLD_SCHOOL_PADDING}` : undefined,
                 // Keep GPU-composited to prevent pixel rounding
                 backfaceVisibility: "hidden",
                 willChange: "mask-image",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Fixes glow-style karaoke highlight timing by ensuring mask progress resolves against the visible word width instead of horizontal shadow bleed padding.
- Keeps existing glow/shadow styling values unchanged; old-school outline padding remains unchanged.

## Validation
- `bun test tests/test-karaoke-interlude-display.test.ts tests/test-karaoke-title-card.test.ts tests/test-lyrics-parsing.test.ts` — 25 passed.
- `bun run build` — passed; existing Vite CSS `::highlight` warning and dynamic import chunk notice remain.
- Chrome rendered-width probe with system Chrome: old duplicated-bleed structure measured `397.17px` mask vs `253.17px` text (`+144px` invisible width); fixed structure measured `253.17px` mask vs `253.17px` text (`0px` delta).
- Manual browser check: app and iPod UI load locally, but the local Songs library is empty, so the real karaoke screen is not reachable from normal UI state in this environment.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019e983c-c0ef-763d-9603-f7ee9ea9a7b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019e983c-c0ef-763d-9603-f7ee9ea9a7b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

