### PR TITLE
Allow iPod window smaller minimum height

### DIFF
--- a/src/apps/ipod/components/ipod-app/IpodDeviceBody.tsx
+++ b/src/apps/ipod/components/ipod-app/IpodDeviceBody.tsx
@@ -1,4 +1,8 @@
 import { cn } from "@/lib/utils";
+import {
+  IPOD_DEVICE_BASE_HEIGHT_PX,
+  IPOD_DEVICE_BASE_WIDTH_PX,
+} from "../../constants";
 import { IpodWheel } from "../IpodWheel";
 import { IpodScreenArea } from "./IpodScreenArea";
 import type { IpodAppController } from "./useIpodAppController";
@@ -25,31 +29,37 @@ export function IpodDeviceBody({ c }: IpodDeviceBodyProps) {
       style={{ position: "relative", overflow: "hidden", contain: "layout style paint" }}
     >
       <div
-        className={cn(
-          "ipod-force-font w-[250px] h-[400px] rounded-2xl shadow-xl border border-black/40 flex flex-col items-center p-4 pb-8",
-          theme === "classic" ? "bg-white/85" : "bg-black/85"
-        )}
+        className="relative shrink-0"
         style={{
-          transform: `scale(${scale})`,
-          transformOrigin: "center",
-          transition: "transform 0.2s ease",
-          minWidth: "250px",
-          minHeight: "400px",
-          maxWidth: "250px",
-          maxHeight: "400px",
-          contain: "layout style paint",
-          willChange: "transform",
-          backfaceVisibility: "hidden",
+          width: IPOD_DEVICE_BASE_WIDTH_PX * scale,
+          height: IPOD_DEVICE_BASE_HEIGHT_PX * scale,
         }}
       >
-        <IpodScreenArea c={c} />
-        <IpodWheel
-          theme={theme}
-          onWheelClick={handleWheelClick}
-          onWheelRotation={handleWheelRotation}
-          onMenuButton={handleMenuButton}
-          onCenterLongPress={handleCenterLongPress}
-        />
+        <div
+          className={cn(
+            "ipod-force-font absolute top-0 left-0 rounded-2xl shadow-xl border border-black/40 flex flex-col items-center p-4 pb-8",
+            theme === "classic" ? "bg-white/85" : "bg-black/85"
+          )}
+          style={{
+            width: IPOD_DEVICE_BASE_WIDTH_PX,
+            height: IPOD_DEVICE_BASE_HEIGHT_PX,
+            transform: `scale(${scale})`,
+            transformOrigin: "top left",
+            transition: "transform 0.2s ease",
+            contain: "layout style paint",
+            willChange: "transform",
+            backfaceVisibility: "hidden",
+          }}
+        >
+          <IpodScreenArea c={c} />
+          <IpodWheel
+            theme={theme}
+            onWheelClick={handleWheelClick}
+            onWheelRotation={handleWheelRotation}
+            onMenuButton={handleMenuButton}
+            onCenterLongPress={handleCenterLongPress}
+          />
+        </div>
       </div>
     </div>
   );

--- a/src/apps/ipod/constants.ts
+++ b/src/apps/ipod/constants.ts
@@ -15,6 +15,19 @@ export {
   getTranslationBadge,
 } from "@/utils/lyricsTranslation";
 
+/** Fixed physical iPod chassis size (px) before responsive window scaling. */
+export const IPOD_DEVICE_BASE_WIDTH_PX = 250;
+export const IPOD_DEVICE_BASE_HEIGHT_PX = 400;
+
+/**
+ * Lowest scale applied when the window is shorter than the default size.
+ * Keeps the click wheel and LCD usable while allowing a shorter min height.
+ */
+export const IPOD_MIN_DEVICE_SCALE = 0.65;
+
+/** Minimum window height (px); must fit scaled chassis plus layout padding. */
+export const IPOD_MIN_WINDOW_HEIGHT_PX = 340;
+
 /** Fixed modern iPod LCD outer height (px), including `border-2` on the screen element. */
 export const IPOD_MODERN_SCREEN_HEIGHT_PX = 152;
 

--- a/src/apps/ipod/hooks/useIpodLogic.ts
+++ b/src/apps/ipod/hooks/useIpodLogic.ts
@@ -59,6 +59,9 @@ import {
 import { onAppUpdate } from "@/utils/appEventBus";
 import {
   SEEK_AMOUNT_SECONDS,
+  IPOD_DEVICE_BASE_WIDTH_PX,
+  IPOD_DEVICE_BASE_HEIGHT_PX,
+  IPOD_MIN_DEVICE_SCALE,
   IPOD_NOW_PLAYING_SONG_MENU_KEY as NOW_PLAYING_SONG_MENU_KEY,
   getYouTubeVideoId,
   formatKugouImageUrl,
@@ -4715,14 +4718,14 @@ export function useIpodLogic({
         if (!containerRef.current) return;
         const containerWidth = containerRef.current.clientWidth;
         const containerHeight = containerRef.current.clientHeight;
-        const baseWidth = 250;
-        const baseHeight = 400;
+        const baseWidth = IPOD_DEVICE_BASE_WIDTH_PX;
+        const baseHeight = IPOD_DEVICE_BASE_HEIGHT_PX;
         const availableWidth = containerWidth - 50;
         const availableHeight = containerHeight - 50;
         const widthScale = availableWidth / baseWidth;
         const heightScale = availableHeight / baseHeight;
         const newScale = Math.min(widthScale, heightScale, 2);
-        const finalScale = Math.max(1, newScale);
+        const finalScale = Math.max(IPOD_MIN_DEVICE_SCALE, newScale);
 
         setScale((prevScale) => {
           if (Math.abs(prevScale - finalScale) > 0.01) return finalScale;

--- a/src/config/appRegistry.tsx
+++ b/src/config/appRegistry.tsx
@@ -10,6 +10,7 @@ import type {
 } from "@/apps/base/types";
 import type { AppletViewerInitialData } from "@/apps/applet-viewer";
 import { createLazyComponent } from "./lazyAppComponent";
+import { IPOD_MIN_WINDOW_HEIGHT_PX } from "@/apps/ipod/constants";
 
 export type { AppId };
 
@@ -352,7 +353,7 @@ export const appRegistry = {
     metadata: ipodMetadata,
     windowConfig: {
       defaultSize: { width: 300, height: 480 },
-      minSize: { width: 300, height: 480 },
+      minSize: { width: 300, height: IPOD_MIN_WINDOW_HEIGHT_PX },
     } as WindowConstraints,
   } as BaseApp<IpodInitialData> & { windowConfig: WindowConstraints },
   ["karaoke"]: {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Lowers the iPod app window minimum height from 480px to 340px and allows the device chassis to scale down (to 65%) when the window is shorter, so playback controls and the LCD stay usable without clipping.

## Changes

- **`src/apps/ipod/constants.ts`**: Added `IPOD_DEVICE_BASE_*`, `IPOD_MIN_DEVICE_SCALE` (0.65), and `IPOD_MIN_WINDOW_HEIGHT_PX` (340).
- **`src/config/appRegistry.tsx`**: iPod `minSize.height` now uses `IPOD_MIN_WINDOW_HEIGHT_PX` (default size unchanged at 480).
- **`src/apps/ipod/hooks/useIpodLogic.ts`**: Resize logic permits scale below 1.0 down to `IPOD_MIN_DEVICE_SCALE`.
- **`src/apps/ipod/components/ipod-app/IpodDeviceBody.tsx`**: Layout wrapper sized to scaled dimensions with `transformOrigin: top left` so the chassis compresses cleanly instead of overflowing.

## Verification

- `bun run build` — passed
- `bun run lint` — passed (pre-existing warnings only)
- iPod unit tests — 33/34 passed; `test-ipod-library-index.test.ts` fails on pre-existing `localStorage` setup (unrelated)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e07ae037-da67-4329-bbf3-d2a8ef5cd68a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e07ae037-da67-4329-bbf3-d2a8ef5cd68a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

