### PR TITLE
fix(admin): polish dark mode styling with OS theme tokens

### DIFF
--- a/src/apps/admin/components/AdminSidebar.tsx
+++ b/src/apps/admin/components/AdminSidebar.tsx
@@ -6,6 +6,7 @@ import { useThemeFlags } from "@/hooks/useThemeFlags";
 import { SelectableListItem } from "@/components/ui/selectable-list-item";
 import { useTranslation } from "react-i18next";
 import type { AdminSection } from "../utils/navigationState";
+import { adminSidebarClass } from "../utils/adminStyles";
 
 interface Room {
   id: string;
@@ -57,7 +58,8 @@ export const AdminSidebar: React.FC<AdminSidebarProps> = ({
   return (
     <div
       className={cn(
-        "flex flex-col font-geneva-12 text-[12px] bg-neutral-100 w-56 border-r h-full overflow-hidden",
+        "flex flex-col font-geneva-12 text-[12px] w-56 border-r h-full overflow-hidden",
+        adminSidebarClass,
         isWindowsLegacyTheme
           ? "border-[#919b9c]"
           : isMacOSTheme
@@ -87,7 +89,7 @@ export const AdminSidebar: React.FC<AdminSidebarProps> = ({
           >
             <div className="flex items-center">
               <span>{t("apps.admin.sidebar.users")}</span>
-              <span className={cn("text-[10px] ml-1.5", activeSection === "users" && selectedRoomId === null ? "text-white/40" : "text-black/40")}>
+              <span className={cn("text-[10px] ml-1.5", activeSection === "users" && selectedRoomId === null ? "text-white/40" : "text-os-text-disabled")}>
                 {stats.totalUsers}
               </span>
             </div>
@@ -99,7 +101,7 @@ export const AdminSidebar: React.FC<AdminSidebarProps> = ({
           >
             <div className="flex items-center">
               <span>{t("apps.admin.sidebar.songs", "Songs")}</span>
-              <span className={cn("text-[10px] ml-1.5", activeSection === "songs" && selectedRoomId === null ? "text-white/40" : "text-black/40")}>
+              <span className={cn("text-[10px] ml-1.5", activeSection === "songs" && selectedRoomId === null ? "text-white/40" : "text-os-text-disabled")}>
                 {stats.totalSongs ?? 0}
               </span>
             </div>
@@ -116,7 +118,7 @@ export const AdminSidebar: React.FC<AdminSidebarProps> = ({
                   "ml-1.5 text-[10px]",
                   activeSection === "cursorAgents"
                     ? "text-white/40"
-                    : "text-black/40"
+                    : "text-os-text-disabled"
                 )}
               >
                 {stats.totalCursorAgents ?? 0}
@@ -128,7 +130,7 @@ export const AdminSidebar: React.FC<AdminSidebarProps> = ({
           <div
             className={cn(
               "mt-2 px-4 pt-2 pb-1 w-full flex items-center group cursor-pointer",
-              "!text-[11px] uppercase tracking-wide text-black/50"
+              "!text-[11px] uppercase tracking-wide text-os-text-secondary"
             )}
             onClick={() => {
               playButtonClick();
@@ -139,7 +141,7 @@ export const AdminSidebar: React.FC<AdminSidebarProps> = ({
             <span className="ml-2 opacity-0 group-hover:opacity-100 transition-opacity">
               <CaretRight
                 className={cn(
-                  "w-2.5 h-2.5 text-black/50 transition-transform",
+                  "w-2.5 h-2.5 text-os-text-secondary transition-transform",
                   isRoomsExpanded ? "rotate-90" : "rotate-0"
                 )}
               />
@@ -163,7 +165,7 @@ export const AdminSidebar: React.FC<AdminSidebarProps> = ({
                         <span
                           className={cn(
                             "text-[10px] ml-1.5 transition-opacity",
-                            selectedRoomId === room.id ? "text-white/40" : "text-black/40",
+                            selectedRoomId === room.id ? "text-white/40" : "text-os-text-disabled",
                             room.userCount > 0 ? "opacity-100" : selectedRoomId === room.id ? "opacity-100" : "opacity-0 group-hover:opacity-100"
                           )}
                         >

--- a/src/apps/admin/components/CursorAgentsPanel.tsx
+++ b/src/apps/admin/components/CursorAgentsPanel.tsx
@@ -14,6 +14,7 @@ import { Table, TableBody, TableCell, TableRow } from "@/components/ui/table";
 import { cn } from "@/lib/utils";
 import { useThemeFlags } from "@/hooks/useThemeFlags";
 import { CursorRepoAgentChatCard } from "@/components/shared/CursorRepoAgentChatCard";
+import { adminSurfaceClass, adminTableRowClass } from "../utils/adminStyles";
 
 export interface AdminCursorAgentRunRow {
   runId: string;
@@ -317,7 +318,7 @@ export function CursorAgentsPanel({
     <div className={panelShellClass}>
       {toolbar}
       {(truncated || scanIncomplete) && (
-        <p className="text-[10px] text-amber-700 bg-amber-50 px-3 py-1 border-b border-amber-100 shrink-0">
+        <p className="text-[10px] text-amber-700 bg-amber-50 px-3 py-1 border-b border-amber-100 shrink-0 os-mac-aqua-dark:text-amber-200 os-mac-aqua-dark:bg-amber-950/40 os-mac-aqua-dark:border-amber-900/50">
           {scanIncomplete && !truncated
             ? t(
                 "apps.admin.cursorAgents.scanIncompleteHint",
@@ -368,11 +369,11 @@ export function CursorAgentsPanel({
                   }
                 }}
                 className={cn(
-                  "border-none odd:bg-neutral-200/50 cursor-pointer",
+                  adminTableRowClass,
+                  "cursor-pointer",
                   run.status === "running" && "bg-amber-50/60 odd:bg-amber-50/70",
-                  selectedRunId === run.runId &&
-                    "bg-blue-100/80 odd:bg-blue-100/80"
                 )}
+                data-selected={selectedRunId === run.runId ? "true" : undefined}
               >
                 <TableCell className="w-0 align-top py-2 pl-2 pr-1">
                   <span
@@ -451,7 +452,7 @@ export function CursorAgentsPanel({
       </Table>
         </div>
         {selectedRunId ? (
-          <div className="flex h-full min-h-0 min-w-0 flex-col overflow-hidden border-l border-black/10 bg-white">
+          <div className={cn("flex h-full min-h-0 min-w-0 flex-col overflow-hidden border-l border-os-separator", adminSurfaceClass)}>
             <CursorRepoAgentChatCard
               key={selectedRunId}
               runId={selectedRunId}

--- a/src/apps/admin/components/DashboardServerCard.tsx
+++ b/src/apps/admin/components/DashboardServerCard.tsx
@@ -6,6 +6,12 @@ import { ActivityIndicator } from "@/components/ui/activity-indicator";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { abortableFetch } from "@/utils/abortableFetch";
+import {
+  adminCardClass,
+  adminCardHeaderClass,
+  adminListDividerClass,
+  adminSectionLabelClass,
+} from "../utils/adminStyles";
 
 interface VersionInfo {
   version?: string;
@@ -43,10 +49,10 @@ function InfoRow({
 }) {
   return (
     <div className="flex items-center justify-between gap-2 px-3 py-1.5">
-      <span className="text-[11px] text-neutral-500">{label}</span>
+      <span className="text-[11px] text-os-text-secondary">{label}</span>
       <div className="flex min-w-0 items-center gap-2">
         {typeof value === "string" ? (
-          <span className="truncate text-[11px] font-medium text-neutral-800 tabular-nums">
+          <span className="truncate text-[11px] font-medium text-os-text-primary tabular-nums">
             {value}
           </span>
         ) : (
@@ -131,9 +137,9 @@ export function DashboardServerCard({ reloadKey = 0 }: { reloadKey?: number }) {
   const commitUrl = ryosGitHubCommitUrl(versionInfo);
 
   return (
-    <div className="overflow-hidden rounded border border-neutral-200 bg-white">
-      <div className="border-b border-neutral-100 bg-neutral-50 px-3 py-2">
-        <span className="text-[10px] uppercase tracking-wide text-neutral-400">
+    <div className={adminCardClass}>
+      <div className={adminCardHeaderClass}>
+        <span className={adminSectionLabelClass}>
           {t("apps.admin.server.title", "Server")}
         </span>
       </div>
@@ -153,7 +159,7 @@ export function DashboardServerCard({ reloadKey = 0 }: { reloadKey?: number }) {
           </Button>
         </div>
       ) : (
-        <div className="divide-y divide-neutral-100">
+        <div className={adminListDividerClass}>
           <InfoRow
             label={t("apps.admin.server.version", "Version")}
             value={versionInfo?.version ?? "—"}

--- a/src/apps/admin/components/admin-app/AdminMainPane.tsx
+++ b/src/apps/admin/components/admin-app/AdminMainPane.tsx
@@ -3,6 +3,7 @@ import { AdminSidebar } from "../AdminSidebar";
 import { CursorAgentsPanel } from "../CursorAgentsPanel";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { cn } from "@/lib/utils";
+import { adminSurfaceClass } from "../../utils/adminStyles";
 import { AdminToolbar } from "./AdminToolbar";
 import { AdminImportStatusBar } from "./AdminImportStatusBar";
 import { AdminScrollContent } from "./AdminScrollContent";
@@ -188,7 +189,7 @@ export function AdminMainPane({
         isVisible={isSidebarVisible}
       />
 
-      <div className="flex min-w-0 flex-1 flex-col overflow-hidden bg-white">
+      <div className={cn("flex min-w-0 flex-1 flex-col overflow-hidden", adminSurfaceClass)}>
         {!selectedUserProfile &&
           !selectedSongId &&
           activeSection !== "dashboard" &&

--- a/src/apps/admin/components/admin-app/AdminRestrictedView.tsx
+++ b/src/apps/admin/components/admin-app/AdminRestrictedView.tsx
@@ -3,6 +3,8 @@ import { AppWindowShell } from "@/components/shared/AppWindowShell";
 import { Warning, WifiSlash } from "@phosphor-icons/react";
 import type { AppProps } from "../../../base/types";
 import type { TFunction } from "i18next";
+import { cn } from "@/lib/utils";
+import { adminSurfaceClass } from "../../utils/adminStyles";
 
 export type AdminRestrictedVariant = "accessDenied" | "offline";
 
@@ -55,7 +57,7 @@ export function AdminRestrictedView({
         onNavigatePrevious,
       }}
     >
-      <div className="flex flex-col items-center justify-center h-full gap-3 p-8 text-center bg-white">
+      <div className={cn("flex flex-col items-center justify-center h-full gap-3 p-8 text-center", adminSurfaceClass)}>
         {variant === "accessDenied" ? (
           <Warning className="size-10 text-neutral-400" weight="bold" />
         ) : (

--- a/src/apps/admin/components/admin-app/AdminRoomMessagesView.tsx
+++ b/src/apps/admin/components/admin-app/AdminRoomMessagesView.tsx
@@ -9,6 +9,13 @@ import {
 } from "@/components/ui/table";
 import { Trash } from "@phosphor-icons/react";
 import type { TFunction } from "i18next";
+import { cn } from "@/lib/utils";
+import {
+  adminAvatarWellClass,
+  adminGhostIconBtnClass,
+  adminTableHeadClass,
+  adminTableRowClass,
+} from "../../utils/adminStyles";
 
 interface MessageRow {
   id: string;
@@ -44,26 +51,26 @@ export function AdminRoomMessagesView({
         <Table>
           <TableHeader>
             <TableRow className="text-[10px] border-none font-normal">
-              <TableHead className="font-normal bg-neutral-100/50 h-[28px]">
+              <TableHead className={cn(adminTableHeadClass, "h-[28px]")}>
                 {t("apps.admin.tableHeaders.user")}
               </TableHead>
-              <TableHead className="font-normal bg-neutral-100/50 h-[28px]">
+              <TableHead className={cn(adminTableHeadClass, "h-[28px]")}>
                 {t("apps.admin.tableHeaders.message")}
               </TableHead>
-              <TableHead className="font-normal bg-neutral-100/50 h-[28px] whitespace-nowrap">
+              <TableHead className={cn(adminTableHeadClass, "h-[28px] whitespace-nowrap")}>
                 {t("apps.admin.tableHeaders.time")}
               </TableHead>
-              <TableHead className="font-normal bg-neutral-100/50 h-[28px] w-8"></TableHead>
+              <TableHead className={cn(adminTableHeadClass, "h-[28px] w-8")}></TableHead>
             </TableRow>
           </TableHeader>
           <TableBody className="text-[11px]">
             {roomMessages.map((message) => (
               <TableRow
                 key={message.id}
-                className="border-none hover:bg-neutral-100/50 transition-colors cursor-default odd:bg-neutral-200/50 group"
+                className={cn(adminTableRowClass, "cursor-default")}
               >
                 <TableCell className="flex items-center gap-2 whitespace-nowrap">
-                  <div className="size-4 rounded-full bg-neutral-200 flex items-center justify-center text-[9px] font-medium text-neutral-600">
+                  <div className={cn("size-4 rounded-full flex items-center justify-center text-[9px] font-medium", adminAvatarWellClass)}>
                     {message.username[0].toUpperCase()}
                   </div>
                   {message.username}
@@ -83,7 +90,7 @@ export function AdminRoomMessagesView({
                         deleteMessage(selectedRoomId, message.id);
                       }
                     }}
-                    className="size-5 p-0 md:opacity-0 md:group-hover:opacity-100 text-neutral-500 hover:text-neutral-700 hover:bg-neutral-100"
+                    className={cn("size-5 p-0 md:opacity-0 md:group-hover:opacity-100", adminGhostIconBtnClass)}
                   >
                     <Trash size={14} weight="bold" />
                   </Button>

--- a/src/apps/admin/components/admin-app/AdminSongsView.tsx
+++ b/src/apps/admin/components/admin-app/AdminSongsView.tsx
@@ -3,6 +3,14 @@ import { Button } from "@/components/ui/button";
 import { MusicNote, Trash, Funnel } from "@phosphor-icons/react";
 import type { TFunction } from "i18next";
 import type { CachedSongMetadata } from "@/utils/songMetadataCache";
+import { cn } from "@/lib/utils";
+import {
+  adminAvatarWellClass,
+  adminGhostIconBtnClass,
+  adminListDividerClass,
+  adminLoadMoreBtnClass,
+  adminRowHoverClass,
+} from "../../utils/adminStyles";
 
 export interface AdminSongsViewProps {
   t: TFunction;
@@ -57,14 +65,17 @@ export function AdminSongsView({
         </div>
       ) : (
         <>
-          <div className="w-full min-w-0 divide-y divide-neutral-200">
+          <div className={cn("w-full min-w-0", adminListDividerClass)}>
             {filteredSongs.slice(0, visibleSongsCount).map((song) => (
               <div
                 key={song.youtubeId}
-                className="flex w-full min-w-0 items-center gap-3 px-3 py-2 hover:bg-neutral-100/50 transition-colors cursor-pointer group"
+                className={cn(
+                  "flex w-full min-w-0 items-center gap-3 px-3 py-2 cursor-pointer group",
+                  adminRowHoverClass,
+                )}
                 onClick={() => setSelectedSongId(song.youtubeId)}
               >
-                <div className="size-10 flex-shrink-0 rounded overflow-hidden bg-neutral-200">
+                <div className={cn("size-10 flex-shrink-0 rounded overflow-hidden", adminAvatarWellClass)}>
                   <img
                     src={
                       formatKugouImageUrl(song.cover, 100) ||
@@ -101,7 +112,7 @@ export function AdminSongsView({
                     e.stopPropagation();
                     promptDelete("song", song.youtubeId, song.title);
                   }}
-                  className="size-6 p-0 flex-shrink-0 md:opacity-0 md:group-hover:opacity-100 text-neutral-500 hover:text-neutral-700 hover:bg-neutral-100"
+                  className={cn("size-6 p-0 flex-shrink-0 md:opacity-0 md:group-hover:opacity-100", adminGhostIconBtnClass)}
                 >
                   <Trash size={14} weight="bold" />
                 </Button>
@@ -116,7 +127,7 @@ export function AdminSongsView({
                 onClick={() =>
                   setVisibleSongsCount((prev) => prev + SONGS_PER_PAGE)
                 }
-                className="h-7 text-[11px] text-neutral-500 hover:text-neutral-700"
+                className={adminLoadMoreBtnClass}
               >
                 {t("apps.admin.loadMore", {
                   remaining: filteredSongs.length - visibleSongsCount,

--- a/src/apps/admin/components/admin-app/AdminStatusBar.tsx
+++ b/src/apps/admin/components/admin-app/AdminStatusBar.tsx
@@ -33,7 +33,7 @@ export function AdminStatusBar({
   username,
 }: AdminStatusBarProps) {
   return (
-    <div className="os-status-bar os-status-bar-text flex items-center justify-between px-2 py-1 text-[10px] font-geneva-12 bg-neutral-100 border-t border-neutral-300">
+    <div className="os-status-bar os-status-bar-text flex items-center justify-between px-2 py-1 text-[10px] font-geneva-12">
       <span>
         {activeSection === "dashboard"
           ? t("apps.admin.sidebar.dashboard", "Dashboard")

--- a/src/apps/admin/components/admin-app/AdminUsersView.tsx
+++ b/src/apps/admin/components/admin-app/AdminUsersView.tsx
@@ -10,6 +10,13 @@ import {
 } from "@/components/ui/table";
 import { MagnifyingGlass, Trash, Prohibit } from "@phosphor-icons/react";
 import { cn } from "@/lib/utils";
+import {
+  adminAvatarWellClass,
+  adminGhostIconBtnClass,
+  adminLoadMoreBtnClass,
+  adminTableHeadClass,
+  adminTableRowClass,
+} from "../../utils/adminStyles";
 import type { TFunction } from "i18next";
 
 interface UserRow {
@@ -57,16 +64,16 @@ export function AdminUsersView({
           <Table>
             <TableHeader>
               <TableRow className="text-[10px] border-none font-normal">
-                <TableHead className="font-normal bg-neutral-100/50 h-[28px]">
+                <TableHead className={cn(adminTableHeadClass, "h-[28px]")}>
                   {t("apps.admin.tableHeaders.username")}
                 </TableHead>
-                <TableHead className="font-normal bg-neutral-100/50 h-[28px]">
+                <TableHead className={cn(adminTableHeadClass, "h-[28px]")}>
                   {t("apps.admin.tableHeaders.status")}
                 </TableHead>
-                <TableHead className="font-normal bg-neutral-100/50 h-[28px] whitespace-nowrap">
+                <TableHead className={cn(adminTableHeadClass, "h-[28px] whitespace-nowrap")}>
                   {t("apps.admin.tableHeaders.lastActive")}
                 </TableHead>
-                <TableHead className="font-normal bg-neutral-100/50 h-[28px] w-8"></TableHead>
+                <TableHead className={cn(adminTableHeadClass, "h-[28px] w-8")}></TableHead>
               </TableRow>
             </TableHeader>
             <TableBody className="text-[11px]">
@@ -74,7 +81,8 @@ export function AdminUsersView({
                 <TableRow
                   key={user.username}
                   className={cn(
-                    "border-none hover:bg-neutral-100/50 transition-colors cursor-pointer odd:bg-neutral-200/50 group",
+                    adminTableRowClass,
+                    "cursor-pointer",
                     user.banned && "bg-red-50/50 odd:bg-red-50/70",
                   )}
                   onClick={() => setSelectedUserProfile(user.username)}
@@ -85,7 +93,7 @@ export function AdminUsersView({
                         "size-4 rounded-full flex items-center justify-center text-[9px] font-medium",
                         user.banned
                           ? "bg-red-200 text-red-700"
-                          : "bg-neutral-200 text-neutral-600",
+                          : adminAvatarWellClass,
                       )}
                     >
                       {user.username[0].toUpperCase()}
@@ -120,7 +128,7 @@ export function AdminUsersView({
                           e.stopPropagation();
                           promptDelete("user", user.username, user.username);
                         }}
-                        className="size-5 p-0 md:opacity-0 md:group-hover:opacity-100 text-neutral-500 hover:text-neutral-700 hover:bg-neutral-100"
+                        className={cn("size-5 p-0 md:opacity-0 md:group-hover:opacity-100", adminGhostIconBtnClass)}
                       >
                         <Trash size={14} weight="bold" />
                       </Button>
@@ -138,7 +146,7 @@ export function AdminUsersView({
                 onClick={() =>
                   setVisibleUsersCount((prev) => prev + USERS_PER_PAGE)
                 }
-                className="h-7 text-[11px] text-neutral-500 hover:text-neutral-700"
+                className={adminLoadMoreBtnClass}
               >
                 {t("apps.admin.loadMore", {
                   remaining: users.length - visibleUsersCount,

--- a/src/apps/admin/components/dashboard-panel/BreakdownList.tsx
+++ b/src/apps/admin/components/dashboard-panel/BreakdownList.tsx
@@ -3,6 +3,7 @@ import { EmptyState } from "@/components/ui/empty-state";
 import { cn } from "@/lib/utils";
 import type { ProductBreakdown } from "./types";
 import { formatNumber } from "./utils";
+import { adminListDividerClass, adminTrackBgClass } from "../../utils/adminStyles";
 
 export function BreakdownList({
   items,
@@ -22,25 +23,25 @@ export function BreakdownList({
   }
   const max = items[0]?.count || 1;
   return (
-    <div className="divide-y divide-neutral-100">
+    <div className={adminListDividerClass}>
       {items.slice(0, 10).map((item) => (
         <div key={item.name} className="flex items-center gap-2 px-3 py-1.5">
           <span
             className={cn(
-              "text-[11px] text-neutral-600 flex-1 truncate",
+              "text-[11px] text-os-text-secondary flex-1 truncate",
               nameClassName
             )}
           >
             {renderName ? renderName(item.name) : item.name}
           </span>
           <div className="w-24 flex items-center gap-1.5">
-            <div className="flex-1 h-1.5 bg-neutral-100 rounded-full overflow-hidden">
+            <div className={cn("flex-1 h-1.5 rounded-full overflow-hidden", adminTrackBgClass)}>
               <div
                 className={cn("h-full rounded-full", barClassName)}
                 style={{ width: `${(item.count / max) * 100}%` }}
               />
             </div>
-            <span className="text-[10px] text-neutral-500 w-8 text-right tabular-nums">
+            <span className="text-[10px] text-os-text-secondary w-8 text-right tabular-nums">
               {formatNumber(item.count)}
             </span>
           </div>

--- a/src/apps/admin/components/dashboard-panel/DashboardPanelView.tsx
+++ b/src/apps/admin/components/dashboard-panel/DashboardPanelView.tsx
@@ -12,6 +12,13 @@ import { StatCard } from "./StatCard";
 import type { DashboardPanelViewModel } from "./useDashboardPanel";
 import type { DailyMetrics, ProductBreakdownSection } from "./types";
 import { formatCountryDisplay, formatDateLabel } from "./utils";
+import {
+  adminCardClass,
+  adminCardHeaderClass,
+  adminListDividerClass,
+  adminSectionLabelClass,
+  adminTrackBgClass,
+} from "../../utils/adminStyles";
 
 export function DashboardPanelView(props: DashboardPanelViewModel) {
   const {
@@ -262,16 +269,16 @@ export function DashboardPanelView(props: DashboardPanelViewModel) {
         ) : null}
 
         <div className="px-3 pb-3">
-          <div className="border border-neutral-200 rounded bg-white overflow-hidden">
-            <div className="px-3 py-2 border-b border-neutral-100 bg-neutral-50">
-              <span className="text-[10px] uppercase tracking-wide text-neutral-400">
+          <div className={adminCardClass}>
+            <div className={adminCardHeaderClass}>
+              <span className={adminSectionLabelClass}>
                 {t("apps.admin.dashboard.sections.topEndpoints")} ({rangeLabel})
               </span>
             </div>
             {topEndpoints.length === 0 ? (
               <EmptyState message={t("apps.admin.dashboard.empty.noData")} />
             ) : (
-              <div className="divide-y divide-neutral-100">
+              <div className={adminListDividerClass}>
                 {topEndpoints.slice(0, 10).map((ep) => (
                   <div
                     key={ep.endpoint}
@@ -281,7 +288,7 @@ export function DashboardPanelView(props: DashboardPanelViewModel) {
                       {ep.endpoint}
                     </span>
                     <div className="w-24 flex items-center gap-1.5">
-                      <div className="flex-1 h-1.5 bg-neutral-100 rounded-full overflow-hidden">
+                      <div className={cn("flex-1 h-1.5 rounded-full overflow-hidden", adminTrackBgClass)}>
                         <div
                           className="h-full bg-indigo-400 rounded-full"
                           style={{
@@ -301,16 +308,16 @@ export function DashboardPanelView(props: DashboardPanelViewModel) {
         </div>
 
         <div className="grid grid-cols-1 md:grid-cols-2 gap-3 px-3 pb-3">
-          <div className="border border-neutral-200 rounded bg-white overflow-hidden">
-            <div className="px-3 py-2 border-b border-neutral-100 bg-neutral-50">
-              <span className="text-[10px] uppercase tracking-wide text-neutral-400">
+          <div className={adminCardClass}>
+            <div className={adminCardHeaderClass}>
+              <span className={adminSectionLabelClass}>
                 {t("apps.admin.dashboard.sections.statusCodes")}
               </span>
             </div>
             {statusCodes.length === 0 ? (
               <EmptyState message={t("apps.admin.dashboard.empty.noData")} />
             ) : (
-              <div className="divide-y divide-neutral-100">
+              <div className={adminListDividerClass}>
                 {statusCodes.map((sc) => (
                   <div
                     key={sc.status}
@@ -336,16 +343,16 @@ export function DashboardPanelView(props: DashboardPanelViewModel) {
             )}
           </div>
 
-          <div className="border border-neutral-200 rounded bg-white overflow-hidden">
-            <div className="px-3 py-2 border-b border-neutral-100 bg-neutral-50">
-              <span className="text-[10px] uppercase tracking-wide text-neutral-400">
+          <div className={adminCardClass}>
+            <div className={adminCardHeaderClass}>
+              <span className={adminSectionLabelClass}>
                 {t("apps.admin.dashboard.sections.aiUsageByUser")}
               </span>
             </div>
             {aiByUser.length === 0 ? (
               <EmptyState message={t("apps.admin.dashboard.empty.noAiUsage")} />
             ) : (
-              <div className="divide-y divide-neutral-100">
+              <div className={adminListDividerClass}>
                 {aiByUser.map((entry) => {
                   const rl = aiRateLimits.find(
                     (r) => r.identifier === entry.username
@@ -428,10 +435,10 @@ export function DashboardPanelView(props: DashboardPanelViewModel) {
                 {productSections.map((section) => (
                   <div
                     key={section.title}
-                    className="border border-neutral-200 rounded bg-white overflow-hidden"
+                    className={adminCardClass}
                   >
-                    <div className="px-3 py-2 border-b border-neutral-100 bg-neutral-50">
-                      <span className="text-[10px] uppercase tracking-wide text-neutral-400">
+                    <div className={adminCardHeaderClass}>
+                      <span className={adminSectionLabelClass}>
                         {section.title}
                       </span>
                     </div>
@@ -471,8 +478,8 @@ function TimeSeriesChartCard({
   height?: number;
 }) {
   return (
-    <div className="border border-neutral-200 rounded p-3 bg-white">
-      <div className="text-[10px] uppercase tracking-wide text-neutral-400 mb-2">
+    <div className={cn("rounded p-3", adminCardClass)}>
+      <div className={cn(adminSectionLabelClass, "mb-2")}>
         {title}
       </div>
       <MiniBarChart

--- a/src/apps/admin/components/dashboard-panel/StatCard.tsx
+++ b/src/apps/admin/components/dashboard-panel/StatCard.tsx
@@ -1,4 +1,5 @@
 import { cn } from "@/lib/utils";
+import { adminCardClass, adminSectionLabelClass } from "../../utils/adminStyles";
 import type { TrendInfo } from "./types";
 
 export function StatCard({
@@ -11,11 +12,11 @@ export function StatCard({
   trend?: TrendInfo;
 }) {
   return (
-    <div className="flex flex-col gap-1 p-3 bg-white rounded border border-neutral-200">
-      <span className="text-[10px] uppercase tracking-wide text-neutral-400">
+    <div className={cn("flex flex-col gap-1 p-3", adminCardClass)}>
+      <span className={adminSectionLabelClass}>
         {label}
       </span>
-      <div className="text-[18px] font-semibold leading-tight text-neutral-800">
+      <div className="text-[18px] font-semibold leading-tight text-os-text-primary">
         {value}
       </div>
       {trend && (
@@ -26,7 +27,7 @@ export function StatCard({
               ? "text-green-600"
               : trend.value < 0
                 ? "text-red-500"
-                : "text-neutral-400"
+                : "text-os-text-disabled"
           )}
         >
           {trend.value > 0 ? "+" : ""}

--- a/src/apps/admin/components/song-detail-panel/Skeleton.tsx
+++ b/src/apps/admin/components/song-detail-panel/Skeleton.tsx
@@ -1,5 +1,5 @@
 import { cn } from "@/lib/utils";
 
 export const Skeleton = ({ className }: { className?: string }) => (
-  <div className={cn("bg-neutral-200 animate-pulse rounded", className)} />
+  <div className={cn("bg-os-panel-bg animate-pulse rounded", className)} />
 );

--- a/src/apps/admin/components/song-detail-panel/SongDetailPanelHeader.tsx
+++ b/src/apps/admin/components/song-detail-panel/SongDetailPanelHeader.tsx
@@ -5,6 +5,7 @@ import { cn } from "@/lib/utils";
 import { formatKugouImageUrl } from "./utils";
 import { Skeleton } from "./Skeleton";
 import type { SongDetailPanelViewModel } from "./useSongDetailPanel";
+import { adminAvatarWellClass, adminDetailHeaderClass } from "../../utils/adminStyles";
 
 type Props = Pick<
   SongDetailPanelViewModel,
@@ -27,15 +28,16 @@ export function SongDetailPanelHeader({
   setIsDeleteDialogOpen,
 }: Props) {
   return (
-    <div className="flex items-center gap-2 px-3 py-2 border-b border-neutral-200 bg-neutral-50">
+    <div className={adminDetailHeaderClass}>
       <Button variant="ghost" size="sm" onClick={onBack} className="size-6 p-0">
         <ArrowLeft className="size-3.5" weight="bold" />
       </Button>
       <div className="flex items-center gap-2 flex-1 min-w-0">
         <div
           className={cn(
-            "size-10 rounded flex items-center justify-center text-sm font-medium text-neutral-600 flex-shrink-0 overflow-hidden",
-            isLoading ? "bg-neutral-200 animate-pulse" : "bg-neutral-200"
+            "size-10 rounded flex items-center justify-center text-sm font-medium flex-shrink-0 overflow-hidden",
+            adminAvatarWellClass,
+            isLoading && "animate-pulse"
           )}
         >
           {!isLoading && (

--- a/src/apps/admin/components/song-detail-panel/SongDetailPanelInfoSection.tsx
+++ b/src/apps/admin/components/song-detail-panel/SongDetailPanelInfoSection.tsx
@@ -15,7 +15,7 @@ export function SongDetailPanelInfoSection({
 
   return (
     <div className="space-y-2">
-      <div className="!text-[11px] uppercase tracking-wide text-black/50">
+      <div className="!text-[11px] uppercase tracking-wide text-os-text-secondary">
         {t("apps.admin.song.info", "Info")}
       </div>
       <div className="text-[11px] text-neutral-500 space-y-1">

--- a/src/apps/admin/components/song-detail-panel/SongDetailPanelLyricsSection.tsx
+++ b/src/apps/admin/components/song-detail-panel/SongDetailPanelLyricsSection.tsx
@@ -48,7 +48,7 @@ function SoramimiStatus({
 export function SongDetailPanelLyricsSection({ t, song, isLoading }: Props) {
   return (
     <div className="space-y-2">
-      <div className="!text-[11px] uppercase tracking-wide text-black/50">
+      <div className="!text-[11px] uppercase tracking-wide text-os-text-secondary">
         {t("apps.admin.song.lyricsContent", "Lyrics Content")}
       </div>
       <div className="space-y-2">

--- a/src/apps/admin/components/song-detail-panel/SongDetailPanelMetadataSection.tsx
+++ b/src/apps/admin/components/song-detail-panel/SongDetailPanelMetadataSection.tsx
@@ -53,7 +53,7 @@ export function SongDetailPanelMetadataSection({
 }: Props) {
   return (
     <div className="space-y-2">
-      <div className="!text-[11px] uppercase tracking-wide text-black/50">
+      <div className="!text-[11px] uppercase tracking-wide text-os-text-secondary">
         {t("apps.admin.song.metadata", "Metadata")}
       </div>
       <div className="space-y-2">

--- a/src/apps/admin/components/user-profile-panel/Skeleton.tsx
+++ b/src/apps/admin/components/user-profile-panel/Skeleton.tsx
@@ -1,5 +1,5 @@
 import { cn } from "@/lib/utils";
 
 export const Skeleton = ({ className }: { className?: string }) => (
-  <div className={cn("bg-neutral-200 animate-pulse rounded", className)} />
+  <div className={cn("bg-os-panel-bg animate-pulse rounded", className)} />
 );

--- a/src/apps/admin/components/user-profile-panel/UserProfilePanelHeader.tsx
+++ b/src/apps/admin/components/user-profile-panel/UserProfilePanelHeader.tsx
@@ -3,6 +3,7 @@ import { ArrowLeft } from "@phosphor-icons/react";
 import { cn } from "@/lib/utils";
 import { Skeleton } from "./Skeleton";
 import type { UserProfilePanelViewModel } from "./useUserProfilePanel";
+import { adminAvatarWellClass, adminDetailHeaderClass } from "../../utils/adminStyles";
 
 type Props = Pick<
   UserProfilePanelViewModel,
@@ -25,15 +26,16 @@ export function UserProfilePanelHeader({
   formatRelativeTime,
 }: Props) {
   return (
-    <div className="flex items-center gap-2 px-3 py-2 border-b border-neutral-200 bg-neutral-50">
+    <div className={adminDetailHeaderClass}>
       <Button variant="ghost" size="sm" onClick={onBack} className="size-6 p-0">
         <ArrowLeft className="size-3.5" weight="bold" />
       </Button>
       <div className="flex items-center gap-2">
         <div
           className={cn(
-            "size-8 rounded-full flex items-center justify-center text-sm font-medium text-neutral-600",
-            isLoading ? "bg-neutral-200 animate-pulse" : "bg-neutral-200"
+            "size-8 rounded-full flex items-center justify-center text-sm font-medium",
+            adminAvatarWellClass,
+            isLoading && "animate-pulse"
           )}
         >
           {!isLoading && username[0].toUpperCase()}

--- a/src/apps/admin/components/user-profile-panel/UserProfilePanelHeartbeatsSection.tsx
+++ b/src/apps/admin/components/user-profile-panel/UserProfilePanelHeartbeatsSection.tsx
@@ -11,6 +11,11 @@ import { CaretRight } from "@phosphor-icons/react";
 import { cn } from "@/lib/utils";
 import { SectionHeader } from "./SectionHeader";
 import { Skeleton } from "./Skeleton";
+import {
+  adminAltRowBgClass,
+  adminTableHeadClass,
+  adminTableRowClass,
+} from "../../utils/adminStyles";
 import type { UserProfilePanelViewModel } from "./useUserProfilePanel";
 
 type Props = Pick<
@@ -69,13 +74,13 @@ export function UserProfilePanelHeartbeatsSection({
                 <Table className="table-fixed">
                   <TableHeader>
                     <TableRow className="text-[10px] border-none font-normal">
-                      <TableHead className="font-normal bg-neutral-100/50 h-[24px] w-[22%]">
+                      <TableHead className={cn(adminTableHeadClass, "h-[24px] w-[22%]")}>
                         {t("apps.admin.tableHeaders.status")}
                       </TableHead>
-                      <TableHead className="font-normal bg-neutral-100/50 h-[24px]">
+                      <TableHead className={cn(adminTableHeadClass, "h-[24px]")}>
                         {t("apps.admin.tableHeaders.message")}
                       </TableHead>
-                      <TableHead className="font-normal bg-neutral-100/50 h-[24px] whitespace-nowrap w-[25%]">
+                      <TableHead className={cn(adminTableHeadClass, "h-[24px] whitespace-nowrap w-[25%]")}>
                         {t("apps.admin.tableHeaders.time")}
                       </TableHead>
                     </TableRow>
@@ -88,8 +93,9 @@ export function UserProfilePanelHeartbeatsSection({
                           <TableRow
                             onClick={() => toggleHeartbeat(hb.id)}
                             className={cn(
-                              "border-none hover:bg-neutral-100/50 transition-colors cursor-pointer",
-                              index % 2 === 1 && "bg-neutral-200/30"
+                              adminTableRowClass,
+                              "cursor-pointer",
+                              index % 2 === 1 && adminAltRowBgClass,
                             )}
                           >
                             <TableCell className="whitespace-nowrap">
@@ -124,7 +130,7 @@ export function UserProfilePanelHeartbeatsSection({
                             <TableRow
                               className={cn(
                                 "border-none",
-                                index % 2 === 1 ? "bg-neutral-200/30" : ""
+                                index % 2 === 1 ? adminAltRowBgClass : ""
                               )}
                             >
                               <TableCell colSpan={3} className="pt-0 pb-3">

--- a/src/apps/admin/components/user-profile-panel/UserProfilePanelMemoriesSection.tsx
+++ b/src/apps/admin/components/user-profile-panel/UserProfilePanelMemoriesSection.tsx
@@ -15,6 +15,12 @@ import {
 } from "@/lib/aquaIconButton";
 import { SectionHeader } from "./SectionHeader";
 import { Skeleton } from "./Skeleton";
+import {
+  adminAltRowBgClass,
+  adminRowHoverClass,
+  adminTableHeadClass,
+  adminTableRowClass,
+} from "../../utils/adminStyles";
 import type { UserProfilePanelViewModel } from "./useUserProfilePanel";
 
 type Props = Pick<
@@ -113,13 +119,13 @@ export function UserProfilePanelMemoriesSection(props: Props) {
                 <Table className="table-fixed">
                   <TableHeader>
                     <TableRow className="text-[10px] border-none font-normal">
-                  <TableHead className="font-normal bg-neutral-100/50 h-[24px] w-[30%]">
+                  <TableHead className={cn(adminTableHeadClass, "h-[24px] w-[30%]")}>
                     {t("apps.admin.profile.memoryKey")}
                   </TableHead>
-                  <TableHead className="font-normal bg-neutral-100/50 h-[24px]">
+                  <TableHead className={cn(adminTableHeadClass, "h-[24px]")}>
                     {t("apps.admin.profile.memorySummary")}
                   </TableHead>
-                  <TableHead className="font-normal bg-neutral-100/50 h-[24px] whitespace-nowrap w-[20%]">
+                  <TableHead className={cn(adminTableHeadClass, "h-[24px] whitespace-nowrap w-[20%]")}>
                     {t("apps.admin.tableHeaders.time")}
                   </TableHead>
                     </TableRow>
@@ -132,8 +138,9 @@ export function UserProfilePanelMemoriesSection(props: Props) {
                       <TableRow
                         onClick={() => toggleMemory(memory.key)}
                         className={cn(
-                          "border-none hover:bg-neutral-100/50 transition-colors cursor-pointer",
-                          index % 2 === 1 && "bg-neutral-200/30"
+                          adminTableRowClass,
+                          "cursor-pointer",
+                          index % 2 === 1 && adminAltRowBgClass,
                         )}
                       >
                         <TableCell>
@@ -157,7 +164,7 @@ export function UserProfilePanelMemoriesSection(props: Props) {
                         <TableRow
                           className={cn(
                         "border-none",
-                        index % 2 === 1 ? "bg-neutral-200/30" : ""
+                        index % 2 === 1 ? adminAltRowBgClass : ""
                           )}
                         >
                           <TableCell colSpan={3} className="pt-0 pb-3">
@@ -209,7 +216,10 @@ export function UserProfilePanelMemoriesSection(props: Props) {
                     <div key={note.date}>
                       <button
                         onClick={() => toggleDailyNote(note.date)}
-                        className="flex items-center gap-1.5 w-full text-left text-[11px] hover:bg-neutral-100/50 px-1 py-0.5 rounded transition-colors"
+                        className={cn(
+                          "flex items-center gap-1.5 w-full text-left text-[11px] px-1 py-0.5 rounded",
+                          adminRowHoverClass,
+                        )}
                       >
                         <CaretRight
                           className={cn(

--- a/src/apps/admin/components/user-profile-panel/UserProfilePanelMessagesSection.tsx
+++ b/src/apps/admin/components/user-profile-panel/UserProfilePanelMessagesSection.tsx
@@ -7,6 +7,8 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { SectionHeader } from "./SectionHeader";
+import { adminTableHeadClass, adminTableRowClass } from "../../utils/adminStyles";
+import { cn } from "@/lib/utils";
 import { Skeleton } from "./Skeleton";
 import type { UserProfilePanelViewModel } from "./useUserProfilePanel";
 
@@ -64,13 +66,13 @@ export function UserProfilePanelMessagesSection({
             <Table className="table-fixed">
               <TableHeader>
                 <TableRow className="text-[10px] border-none font-normal">
-                  <TableHead className="font-normal bg-neutral-100/50 h-[24px] w-[25%]">
+                  <TableHead className={cn(adminTableHeadClass, "h-[24px] w-[25%]")}>
                     {t("apps.admin.profile.room")}
                   </TableHead>
-                  <TableHead className="font-normal bg-neutral-100/50 h-[24px]">
+                  <TableHead className={cn(adminTableHeadClass, "h-[24px]")}>
                     {t("apps.admin.tableHeaders.message")}
                   </TableHead>
-                  <TableHead className="font-normal bg-neutral-100/50 h-[24px] whitespace-nowrap w-[20%]">
+                  <TableHead className={cn(adminTableHeadClass, "h-[24px] whitespace-nowrap w-[20%]")}>
                     {t("apps.admin.tableHeaders.time")}
                   </TableHead>
                 </TableRow>
@@ -79,7 +81,7 @@ export function UserProfilePanelMessagesSection({
                 {messages.map((message) => (
                   <TableRow
                     key={message.id}
-                    className="border-none hover:bg-neutral-100/50 transition-colors cursor-default odd:bg-neutral-200/30"
+                    className={cn(adminTableRowClass, "cursor-default")}
                   >
                     <TableCell>
                       <span className="text-neutral-500">#</span>

--- a/src/apps/admin/components/user-profile-panel/UserProfilePanelRoomsSection.tsx
+++ b/src/apps/admin/components/user-profile-panel/UserProfilePanelRoomsSection.tsx
@@ -49,7 +49,7 @@ export function UserProfilePanelRoomsSection({
       {isRoomsOpen && roomsCount > 0 && (
         <div className="flex flex-wrap gap-1">
           {profile?.rooms?.map((room) => (
-            <span key={room.id} className="px-2 py-1 text-[10px] bg-neutral-100 rounded">
+            <span key={room.id} className="px-2 py-1 text-[10px] bg-os-panel-bg rounded">
               #{room.name}
             </span>
           ))}

--- a/src/apps/admin/components/user-profile-panel/types.ts
+++ b/src/apps/admin/components/user-profile-panel/types.ts
@@ -2,7 +2,7 @@ export const RECENT_MESSAGES_LIMIT = 50;
 export const HEARTBEAT_LOOKBACK_DAYS = 7;
 
 export const SECTION_HEADER_CLASS =
-  "!text-[11px] uppercase tracking-wide text-black/50";
+  "!text-[11px] uppercase tracking-wide text-os-text-secondary";
 
 export interface UserProfile {
   username: string;

--- a/src/apps/admin/utils/adminStyles.ts
+++ b/src/apps/admin/utils/adminStyles.ts
@@ -1,0 +1,67 @@
+import { cn } from "@/lib/utils";
+
+/** Main content pane — tracks `--os-color-window-bg` in light and dark. */
+export const adminSurfaceClass = "bg-os-window-bg text-os-text-primary";
+
+/** Recessed sidebar / secondary panel surface. */
+export const adminSidebarClass = "bg-os-panel-bg text-os-text-primary";
+
+/** Card / panel shell with theme-aware border. */
+export const adminCardClass =
+  "overflow-hidden rounded border border-os-separator bg-os-window-bg";
+
+/** Card header band (dashboard sections, server card, etc.). */
+export const adminCardHeaderClass =
+  "border-b border-os-separator bg-os-panel-bg px-3 py-2";
+
+/** Detail panel header (user profile, song detail). */
+export const adminDetailHeaderClass =
+  "flex items-center gap-2 border-b border-os-separator bg-os-panel-bg px-3 py-2";
+
+/** Uppercase section labels in cards and profile panels. */
+export const adminSectionLabelClass =
+  "text-[10px] uppercase tracking-wide text-os-text-disabled";
+
+/** Collapsible section headers in profile / song panels. */
+export const adminSectionHeaderClass =
+  "!text-[11px] uppercase tracking-wide text-os-text-secondary";
+
+/** Theme-aware vertical list dividers. */
+export const adminListDividerClass =
+  "divide-y divide-[color:var(--os-color-separator)]";
+
+/** Table header cell background. */
+export const adminTableHeadClass =
+  "font-normal bg-os-panel-bg/80 text-os-text-secondary";
+
+/** Subtle row hover — remapped in dark `.window-body`, explicit for Aqua dark. */
+export const adminRowHoverClass =
+  "hover:bg-neutral-100/50 os-mac-aqua-dark:hover:bg-white/8 transition-colors";
+
+/** Alternating row tint (manual index-based striping). */
+export const adminAltRowBgClass =
+  "bg-[color:var(--os-color-list-row-alt-bg)]";
+
+/** Zebra-striped data table row. */
+export const adminTableRowClass = cn(
+  "border-none group",
+  "odd:bg-[color:var(--os-color-list-row-alt-bg)]",
+  adminRowHoverClass,
+);
+
+/** Ghost icon button in admin tables / lists. */
+export const adminGhostIconBtnClass = cn(
+  "text-os-text-secondary hover:text-os-text-primary",
+  "os-mac-aqua-dark:hover:bg-white/8",
+);
+
+/** Load-more / secondary action text button. */
+export const adminLoadMoreBtnClass =
+  "h-7 text-[11px] text-os-text-secondary hover:text-os-text-primary";
+
+/** Avatar / thumbnail placeholder well. */
+export const adminAvatarWellClass =
+  "bg-os-panel-bg text-os-text-secondary";
+
+/** Progress / chart track background. */
+export const adminTrackBgClass = "bg-os-panel-bg";

--- a/src/components/ui/selectable-list-item.tsx
+++ b/src/components/ui/selectable-list-item.tsx
@@ -22,7 +22,7 @@ export const SelectableListItem = (
   ref={ref}
   className={cn(
     "py-1 px-5 cursor-pointer",
-    !isSelected && "hover:bg-black/5",
+    !isSelected && "hover:bg-black/5 os-mac-aqua-dark:hover:bg-white/8",
     className
   )}
   data-selected={isSelected ? "true" : undefined}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes admin app dark mode styling by replacing hardcoded light neutrals with OS theme tokens (`--os-*` via Tailwind `bg-os-*`, `text-os-*`, `border-os-separator`).

- Adds shared `adminStyles.ts` helpers for surfaces, cards, dividers, tables, and hover states
- Updates admin lists/tables (Users, Songs, Room Messages, profile panels, Cursor Agents) to use theme-aware zebra rows and separators
- Fixes dashboard cards/panels (`StatCard`, `BreakdownList`, `DashboardPanelView`, `DashboardServerCard`)
- Removes `bg-neutral-100` override on `AdminStatusBar` so global dark `.os-status-bar` rules apply
- Updates `SelectableListItem` hover for Aqua dark (`os-mac-aqua-dark:hover:bg-white/8`)

## Testing

- `bun run test:unit` — 265 pass
- Manual: macOS Aqua dark mode walkthrough logged in as admin (`ryo`)

<a href="https://cursor.com/agents/bc-42afba2e-4a61-4cc9-a9e3-8a476f8a736e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fadmin_dark_mode_full_walkthrough.mp4"><img src="https://cursor.com/artifacts/c/art-4ba9f55c-0720-4aa6-895e-5ee333f3fb10" alt="admin_dark_mode_full_walkthrough.mp4" /></a>

Verified dashboard, users table, songs list, sidebar hover, dividers, and table contrast in dark mode.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-42afba2e-4a61-4cc9-a9e3-8a476f8a736e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-42afba2e-4a61-4cc9-a9e3-8a476f8a736e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

