### PR TITLE
fix(chats): prevent duplicate React keys for greeting messages

### DIFF
--- a/src/apps/chats/components/chat-messages/utils.ts
+++ b/src/apps/chats/components/chat-messages/utils.ts
@@ -102,13 +102,41 @@ export const getMessageText = (message: {
   }, []).join("");
 };
 
+/** React list keys for synthetic greeting messages (not persisted server IDs). */
+export const SYNTHETIC_GREETING_KEY_PREFIX = "synthetic:greeting:";
+
+const isSyntheticGreetingId = (id: string): boolean =>
+  id === "1" || id.startsWith("proactive-");
+
+export const getSyntheticGreetingKey = (id: string): string =>
+  `${SYNTHETIC_GREETING_KEY_PREFIX}${id}`;
+
 export const getMessageKey = (message: {
   id?: string;
   role: string;
   parts?: Array<{ type: string; text?: string }>;
+  metadata?: { createdAt?: Date | number | string };
 }): string => {
+  if (message.id) {
+    if (isSyntheticGreetingId(message.id)) {
+      return getSyntheticGreetingKey(message.id);
+    }
+    return message.id;
+  }
+
   const messageText = getMessageText(message);
-  return message.id === "1" || message.id === "proactive-1"
-    ? "greeting"
-    : message.id || `${message.role}-${messageText.substring(0, 10)}`;
+  const createdAt = message.metadata?.createdAt;
+  let timestampSuffix = "";
+  if (createdAt instanceof Date) {
+    timestampSuffix = String(createdAt.getTime());
+  } else if (typeof createdAt === "number") {
+    timestampSuffix = String(createdAt);
+  } else if (typeof createdAt === "string") {
+    const parsed = new Date(createdAt).getTime();
+    if (Number.isFinite(parsed)) {
+      timestampSuffix = String(parsed);
+    }
+  }
+
+  return `${message.role}-${timestampSuffix}-${messageText.length}-${messageText.substring(0, 16)}`;
 };

--- a/src/apps/chats/components/chats-app/useChatsAppController.tsx
+++ b/src/apps/chats/components/chats-app/useChatsAppController.tsx
@@ -127,7 +127,8 @@ export function useChatsAppController({
 
   const globalOnlineUsers = useGlobalPresence();
 
-  const { isLoadingGreeting, triggerGreeting } = useProactiveGreeting();
+  const { isLoadingGreeting, triggerGreeting, cancelGreetingFetch } =
+    useProactiveGreeting();
   const [inputPrefillMessage, setInputPrefillMessage] = useState<string | null>(
     null
   );
@@ -268,6 +269,7 @@ export function useChatsAppController({
           return true;
         }
       } else {
+        cancelGreetingFetch();
         const didSubmit = await submitAiMessage(messageText, imageData);
         if (didSubmit) {
           setScrollToBottomTrigger((prev) => prev + 1);
@@ -280,6 +282,7 @@ export function useChatsAppController({
       username,
       sendRoomMessage,
       submitAiMessage,
+      cancelGreetingFetch,
       t,
       handleRyoMention,
       detectAndProcessMention,
@@ -291,10 +294,17 @@ export function useChatsAppController({
       if (currentRoomId && username) {
         sendRoomMessage(message);
       } else {
+        cancelGreetingFetch();
         handleDirectMessageSubmit(message);
       }
     },
-    [currentRoomId, username, sendRoomMessage, handleDirectMessageSubmit]
+    [
+      currentRoomId,
+      username,
+      sendRoomMessage,
+      handleDirectMessageSubmit,
+      cancelGreetingFetch,
+    ]
   );
 
   const handleNudgeClick = useCallback(() => {

--- a/src/apps/chats/components/chats-app/useChatsAppController.tsx
+++ b/src/apps/chats/components/chats-app/useChatsAppController.tsx
@@ -70,6 +70,8 @@ export function useChatsAppController({
     stopSpeech,
     rateLimitError,
     needsUsername,
+    getLiveMessages,
+    patchLiveMessages,
   } = useAiChat(promptSetUsername);
 
   const {
@@ -127,8 +129,10 @@ export function useChatsAppController({
 
   const globalOnlineUsers = useGlobalPresence();
 
-  const { isLoadingGreeting, triggerGreeting, cancelGreetingFetch } =
-    useProactiveGreeting();
+  const { isLoadingGreeting, triggerGreeting } = useProactiveGreeting({
+    getLiveMessages,
+    patchLiveMessages,
+  });
   const [inputPrefillMessage, setInputPrefillMessage] = useState<string | null>(
     null
   );
@@ -269,7 +273,6 @@ export function useChatsAppController({
           return true;
         }
       } else {
-        cancelGreetingFetch();
         const didSubmit = await submitAiMessage(messageText, imageData);
         if (didSubmit) {
           setScrollToBottomTrigger((prev) => prev + 1);
@@ -282,7 +285,6 @@ export function useChatsAppController({
       username,
       sendRoomMessage,
       submitAiMessage,
-      cancelGreetingFetch,
       t,
       handleRyoMention,
       detectAndProcessMention,
@@ -294,17 +296,10 @@ export function useChatsAppController({
       if (currentRoomId && username) {
         sendRoomMessage(message);
       } else {
-        cancelGreetingFetch();
         handleDirectMessageSubmit(message);
       }
     },
-    [
-      currentRoomId,
-      username,
-      sendRoomMessage,
-      handleDirectMessageSubmit,
-      cancelGreetingFetch,
-    ]
+    [currentRoomId, username, sendRoomMessage, handleDirectMessageSubmit]
   );
 
   const handleNudgeClick = useCallback(() => {

--- a/src/apps/chats/hooks/useAiChat.ts
+++ b/src/apps/chats/hooks/useAiChat.ts
@@ -2152,6 +2152,18 @@ export function useAiChat(onPromptSetUsername?: () => void) {
     stopSpeech();
   }, [sdkStop, stopSpeech]);
 
+  const getLiveMessages = useCallback(
+    () => currentSdkMessagesRef.current,
+    []
+  );
+
+  const patchLiveMessages = useCallback(
+    (messages: AIChatMessage[]) => {
+      setSdkMessages(messages);
+    },
+    [setSdkMessages]
+  );
+
   return {
     // AI Chat State & Actions
     messages: messagesWithTimestamps, // Return messages with timestamps
@@ -2187,5 +2199,8 @@ export function useAiChat(onPromptSetUsername?: () => void) {
     highlightSegment,
     speakAssistantMessageManually,
     stopSpeech,
+
+    getLiveMessages,
+    patchLiveMessages,
   };
 }

--- a/src/apps/chats/hooks/useProactiveGreeting.ts
+++ b/src/apps/chats/hooks/useProactiveGreeting.ts
@@ -3,6 +3,7 @@ import { useChatsStore } from "@/stores/useChatsStore";
 import type { AIChatMessage } from "@/types/chat";
 import { getApiUrl } from "@/utils/platform";
 import { abortableFetch } from "@/utils/abortableFetch";
+import { applyFreshProactiveGreeting } from "../utils/proactiveGreetingApply";
 
 /**
  * Minimum idle time (ms) since the last chat message before a proactive
@@ -57,6 +58,7 @@ export function useProactiveGreeting() {
   const hasTriggeredStaleRef = useRef(false);
   const abortRef = useRef<AbortController | null>(null);
   const fetchInFlightRef = useRef(false);
+  const suppressedRef = useRef(false);
 
   const username = useChatsStore((s) => s.username);
   const isAuthenticated = useChatsStore((s) => s.isAuthenticated);
@@ -82,6 +84,13 @@ export function useProactiveGreeting() {
     return Date.now() - lastTs > STALE_CHAT_THRESHOLD_MS;
   })();
 
+  const cancelGreetingFetch = useCallback(() => {
+    suppressedRef.current = true;
+    abortRef.current?.abort();
+    setIsLoadingGreeting(false);
+    fetchInFlightRef.current = false;
+  }, []);
+
   /**
    * Fetch a proactive greeting from the server and display it immediately.
    */
@@ -92,6 +101,7 @@ export function useProactiveGreeting() {
       // Prevent duplicate concurrent requests
       if (fetchInFlightRef.current) return;
       fetchInFlightRef.current = true;
+      suppressedRef.current = false;
 
       // Abort any previous in-flight request
       abortRef.current?.abort();
@@ -127,15 +137,18 @@ export function useProactiveGreeting() {
             metadata: { createdAt: new Date() },
           };
 
+          if (suppressedRef.current) return;
+
           const currentMessages = useChatsStore.getState().aiMessages;
 
           if (mode === "fresh") {
-            if (
-              currentMessages.length === 1 &&
-              currentMessages[0].id === "1" &&
-              currentMessages[0].role === "assistant"
-            ) {
-              setAiMessages([proactiveMessage]);
+            const updatedMessages = applyFreshProactiveGreeting(
+              currentMessages,
+              proactiveMessage,
+              { suppressed: suppressedRef.current }
+            );
+            if (updatedMessages) {
+              setAiMessages(updatedMessages);
             }
           } else {
             const lastMsg = currentMessages[currentMessages.length - 1];
@@ -219,5 +232,6 @@ export function useProactiveGreeting() {
   return {
     isLoadingGreeting,
     triggerGreeting,
+    cancelGreetingFetch,
   };
 }

--- a/src/apps/chats/hooks/useProactiveGreeting.ts
+++ b/src/apps/chats/hooks/useProactiveGreeting.ts
@@ -11,6 +11,13 @@ import { applyFreshProactiveGreeting } from "../utils/proactiveGreetingApply";
  */
 const STALE_CHAT_THRESHOLD_MS = 5 * 60 * 1000; // 5 minutes
 
+export interface UseProactiveGreetingOptions {
+  /** Latest AI SDK messages (may be ahead of the persisted store mid-stream). */
+  getLiveMessages?: () => AIChatMessage[];
+  /** Patch the AI SDK list in-place without resetting the conversation. */
+  patchLiveMessages?: (messages: AIChatMessage[]) => void;
+}
+
 /**
  * Get the timestamp (epoch ms) of the most recent message in the AI chat.
  * Falls back to 0 if no valid timestamp is found.
@@ -44,7 +51,10 @@ function getLastMessageTimestamp(messages: AIChatMessage[]): number {
  * The greeting is fetched as a complete JSON response from the server and
  * displayed in the chat as a single batch update.
  */
-export function useProactiveGreeting() {
+export function useProactiveGreeting({
+  getLiveMessages,
+  patchLiveMessages,
+}: UseProactiveGreetingOptions = {}) {
   const [isLoadingGreeting, setIsLoadingGreeting] = useState(() => {
     const state = useChatsStore.getState();
     const fresh =
@@ -58,7 +68,11 @@ export function useProactiveGreeting() {
   const hasTriggeredStaleRef = useRef(false);
   const abortRef = useRef<AbortController | null>(null);
   const fetchInFlightRef = useRef(false);
-  const suppressedRef = useRef(false);
+  const liveMessageAccessorsRef = useRef({
+    getLiveMessages,
+    patchLiveMessages,
+  });
+  liveMessageAccessorsRef.current = { getLiveMessages, patchLiveMessages };
 
   const username = useChatsStore((s) => s.username);
   const isAuthenticated = useChatsStore((s) => s.isAuthenticated);
@@ -84,13 +98,6 @@ export function useProactiveGreeting() {
     return Date.now() - lastTs > STALE_CHAT_THRESHOLD_MS;
   })();
 
-  const cancelGreetingFetch = useCallback(() => {
-    suppressedRef.current = true;
-    abortRef.current?.abort();
-    setIsLoadingGreeting(false);
-    fetchInFlightRef.current = false;
-  }, []);
-
   /**
    * Fetch a proactive greeting from the server and display it immediately.
    */
@@ -101,7 +108,6 @@ export function useProactiveGreeting() {
       // Prevent duplicate concurrent requests
       if (fetchInFlightRef.current) return;
       fetchInFlightRef.current = true;
-      suppressedRef.current = false;
 
       // Abort any previous in-flight request
       abortRef.current?.abort();
@@ -137,28 +143,31 @@ export function useProactiveGreeting() {
             metadata: { createdAt: new Date() },
           };
 
-          if (suppressedRef.current) return;
-
-          const currentMessages = useChatsStore.getState().aiMessages;
+          const storeMessages = useChatsStore.getState().aiMessages;
+          const { getLiveMessages: getLive, patchLiveMessages: patchLive } =
+            liveMessageAccessorsRef.current;
+          const liveMessages = getLive?.() ?? storeMessages;
 
           if (mode === "fresh") {
             const updatedMessages = applyFreshProactiveGreeting(
-              currentMessages,
-              proactiveMessage,
-              { suppressed: suppressedRef.current }
+              liveMessages,
+              proactiveMessage
             );
             if (updatedMessages) {
+              patchLive?.(updatedMessages);
               setAiMessages(updatedMessages);
             }
           } else {
-            const lastMsg = currentMessages[currentMessages.length - 1];
-            const lastTs = getLastMessageTimestamp(currentMessages);
+            const lastMsg = storeMessages[storeMessages.length - 1];
+            const lastTs = getLastMessageTimestamp(storeMessages);
             const stillStale =
               lastTs > 0 &&
               Date.now() - lastTs > STALE_CHAT_THRESHOLD_MS;
 
             if (stillStale && !lastMsg.id?.startsWith("proactive-")) {
-              setAiMessages([...currentMessages, proactiveMessage]);
+              const updatedMessages = [...liveMessages, proactiveMessage];
+              patchLive?.(updatedMessages);
+              setAiMessages(updatedMessages);
             }
           }
         }
@@ -232,6 +241,5 @@ export function useProactiveGreeting() {
   return {
     isLoadingGreeting,
     triggerGreeting,
-    cancelGreetingFetch,
   };
 }

--- a/src/apps/chats/hooks/useSyncedAiMessages.ts
+++ b/src/apps/chats/hooks/useSyncedAiMessages.ts
@@ -1,6 +1,10 @@
 import { useEffect, useRef } from "react";
 import type { UIMessage } from "@ai-sdk/react";
 import type { AIChatMessage } from "@/types/chat";
+import {
+  applyFreshProactiveGreeting,
+  isDefaultGreetingMessage,
+} from "../utils/proactiveGreetingApply";
 
 interface UseSyncedAiMessagesOptions {
   aiMessages: AIChatMessage[];
@@ -21,10 +25,30 @@ export function useSyncedAiMessages({
     const storeLast = aiMessages.at(-1);
     const sdkLast = sdkMessages.at(-1);
 
+    const sdkHasDefaultGreeting = sdkMessages.some((message) =>
+      isDefaultGreetingMessage(message as AIChatMessage)
+    );
+    const storeProactiveGreeting = aiMessages.find(
+      (message) =>
+        message.id === "proactive-1" || message.id?.startsWith("proactive-")
+    );
+
+    // Swap the loading placeholder greeting in the live SDK list when the store
+    // already received the proactive greeting but the stream is still running.
+    if (sdkHasDefaultGreeting && storeProactiveGreeting) {
+      const patchedMessages = applyFreshProactiveGreeting(
+        sdkMessages as AIChatMessage[],
+        storeProactiveGreeting
+      );
+      if (patchedMessages) {
+        setMessages(patchedMessages);
+      }
+      return;
+    }
+
     // While the user is mid-conversation the AI SDK list is ahead of the
     // persisted store until onFinish runs. Never overwrite a longer SDK list
-    // with a shorter store snapshot (e.g. proactive greeting replacing only the
-    // default greeting while a user message is already in flight).
+    // with a shorter store snapshot.
     if (sdkMessages.length > aiMessages.length) {
       return;
     }

--- a/src/apps/chats/hooks/useSyncedAiMessages.ts
+++ b/src/apps/chats/hooks/useSyncedAiMessages.ts
@@ -21,6 +21,14 @@ export function useSyncedAiMessages({
     const storeLast = aiMessages.at(-1);
     const sdkLast = sdkMessages.at(-1);
 
+    // While the user is mid-conversation the AI SDK list is ahead of the
+    // persisted store until onFinish runs. Never overwrite a longer SDK list
+    // with a shorter store snapshot (e.g. proactive greeting replacing only the
+    // default greeting while a user message is already in flight).
+    if (sdkMessages.length > aiMessages.length) {
+      return;
+    }
+
     if (aiMessages.length !== sdkMessages.length || storeLast?.id !== sdkLast?.id) {
       console.log("Syncing Zustand store messages to SDK.");
       setMessages(aiMessages);

--- a/src/apps/chats/utils/proactiveGreetingApply.ts
+++ b/src/apps/chats/utils/proactiveGreetingApply.ts
@@ -1,30 +1,27 @@
 import type { AIChatMessage } from "@/types/chat";
 
-const isDefaultGreeting = (message: AIChatMessage): boolean =>
+export const isDefaultGreetingMessage = (message: AIChatMessage): boolean =>
   message.id === "1" && message.role === "assistant";
 
 export function shouldApplyFreshProactiveGreeting(
-  currentMessages: AIChatMessage[],
-  options: { suppressed: boolean }
+  currentMessages: AIChatMessage[]
 ): boolean {
-  if (options.suppressed) return false;
-  return currentMessages.some(isDefaultGreeting);
+  return currentMessages.some(isDefaultGreetingMessage);
 }
 
 /**
- * Replace only the default greeting in-place so user/assistant messages are
- * preserved when a proactive greeting completes after the user has typed.
+ * Replace only the default greeting in-place so user/assistant messages and
+ * any in-flight assistant stream are preserved.
  */
 export function applyFreshProactiveGreeting(
   currentMessages: AIChatMessage[],
-  proactiveMessage: AIChatMessage,
-  options: { suppressed: boolean }
+  proactiveMessage: AIChatMessage
 ): AIChatMessage[] | null {
-  if (!shouldApplyFreshProactiveGreeting(currentMessages, options)) {
+  if (!shouldApplyFreshProactiveGreeting(currentMessages)) {
     return null;
   }
 
-  const greetingIndex = currentMessages.findIndex(isDefaultGreeting);
+  const greetingIndex = currentMessages.findIndex(isDefaultGreetingMessage);
   if (greetingIndex === -1) return null;
 
   const updated = [...currentMessages];

--- a/src/apps/chats/utils/proactiveGreetingApply.ts
+++ b/src/apps/chats/utils/proactiveGreetingApply.ts
@@ -1,0 +1,33 @@
+import type { AIChatMessage } from "@/types/chat";
+
+const isDefaultGreeting = (message: AIChatMessage): boolean =>
+  message.id === "1" && message.role === "assistant";
+
+export function shouldApplyFreshProactiveGreeting(
+  currentMessages: AIChatMessage[],
+  options: { suppressed: boolean }
+): boolean {
+  if (options.suppressed) return false;
+  return currentMessages.some(isDefaultGreeting);
+}
+
+/**
+ * Replace only the default greeting in-place so user/assistant messages are
+ * preserved when a proactive greeting completes after the user has typed.
+ */
+export function applyFreshProactiveGreeting(
+  currentMessages: AIChatMessage[],
+  proactiveMessage: AIChatMessage,
+  options: { suppressed: boolean }
+): AIChatMessage[] | null {
+  if (!shouldApplyFreshProactiveGreeting(currentMessages, options)) {
+    return null;
+  }
+
+  const greetingIndex = currentMessages.findIndex(isDefaultGreeting);
+  if (greetingIndex === -1) return null;
+
+  const updated = [...currentMessages];
+  updated[greetingIndex] = proactiveMessage;
+  return updated;
+}

--- a/tests/test-chat-message-keys.test.ts
+++ b/tests/test-chat-message-keys.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from "bun:test";
+import {
+  getMessageKey,
+  getSyntheticGreetingKey,
+  SYNTHETIC_GREETING_KEY_PREFIX,
+} from "../src/apps/chats/components/chat-messages/utils";
+
+describe("chat message keys", () => {
+  test("namespaces default and proactive fresh greetings with distinct keys", () => {
+    const defaultGreeting = {
+      id: "1",
+      role: "assistant",
+      parts: [{ type: "text", text: "👋 hey! i'm ryo. ask me anything!" }],
+    };
+    const proactiveGreeting = {
+      id: "proactive-1",
+      role: "assistant",
+      parts: [{ type: "text", text: "welcome back!" }],
+    };
+
+    const defaultKey = getMessageKey(defaultGreeting);
+    const proactiveKey = getMessageKey(proactiveGreeting);
+
+    expect(defaultKey).toBe(getSyntheticGreetingKey("1"));
+    expect(proactiveKey).toBe(getSyntheticGreetingKey("proactive-1"));
+    expect(defaultKey).not.toBe(proactiveKey);
+    expect(defaultKey.startsWith(SYNTHETIC_GREETING_KEY_PREFIX)).toBe(true);
+    expect(proactiveKey.startsWith(SYNTHETIC_GREETING_KEY_PREFIX)).toBe(true);
+  });
+
+  test("keeps persisted message ids as stable keys", () => {
+    const persisted = {
+      id: "msg-abc-123",
+      role: "user",
+      parts: [{ type: "text", text: "hello there" }],
+    };
+
+    expect(getMessageKey(persisted)).toBe("msg-abc-123");
+  });
+
+  test("namespaces stale proactive greetings without colliding with default greeting", () => {
+    const defaultGreeting = {
+      id: "1",
+      role: "assistant",
+      parts: [{ type: "text", text: "👋 hey! i'm ryo. ask me anything!" }],
+    };
+    const staleGreeting = {
+      id: "proactive-1712345678901",
+      role: "assistant",
+      parts: [{ type: "text", text: "long time no see" }],
+    };
+
+    const keys = [defaultGreeting, staleGreeting].map(getMessageKey);
+    expect(new Set(keys).size).toBe(keys.length);
+  });
+
+  test("produces unique keys for id-less messages with identical prefixes", () => {
+    const first = {
+      role: "human",
+      parts: [{ type: "text", text: "hello world" }],
+      metadata: { createdAt: new Date("2026-01-01T00:00:00.000Z") },
+    };
+    const second = {
+      role: "human",
+      parts: [{ type: "text", text: "hello world" }],
+      metadata: { createdAt: new Date("2026-01-02T00:00:00.000Z") },
+    };
+
+    expect(getMessageKey(first)).not.toBe(getMessageKey(second));
+  });
+});

--- a/tests/test-proactive-greeting-apply.test.ts
+++ b/tests/test-proactive-greeting-apply.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from "bun:test";
+import type { AIChatMessage } from "../src/types/chat";
+import {
+  applyFreshProactiveGreeting,
+  shouldApplyFreshProactiveGreeting,
+} from "../src/apps/chats/utils/proactiveGreetingApply";
+
+const defaultGreeting: AIChatMessage = {
+  id: "1",
+  role: "assistant",
+  parts: [{ type: "text", text: "👋 hey! i'm ryo. ask me anything!" }],
+};
+
+const proactiveGreeting: AIChatMessage = {
+  id: "proactive-1",
+  role: "assistant",
+  parts: [{ type: "text", text: "welcome back alice!" }],
+};
+
+const userMessage: AIChatMessage = {
+  id: "user-1",
+  role: "user",
+  parts: [{ type: "text", text: "what's new?" }],
+};
+
+describe("proactive greeting apply", () => {
+  test("replaces only the default greeting in a fresh chat", () => {
+    const result = applyFreshProactiveGreeting(
+      [defaultGreeting],
+      proactiveGreeting,
+      { suppressed: false }
+    );
+
+    expect(result).toEqual([proactiveGreeting]);
+  });
+
+  test("preserves user messages when replacing the default greeting", () => {
+    const result = applyFreshProactiveGreeting(
+      [defaultGreeting, userMessage],
+      proactiveGreeting,
+      { suppressed: false }
+    );
+
+    expect(result).toEqual([proactiveGreeting, userMessage]);
+  });
+
+  test("skips apply when greeting fetch was cancelled after user typed", () => {
+    expect(
+      shouldApplyFreshProactiveGreeting([defaultGreeting], { suppressed: true })
+    ).toBe(false);
+    expect(
+      applyFreshProactiveGreeting(
+        [defaultGreeting, userMessage],
+        proactiveGreeting,
+        { suppressed: true }
+      )
+    ).toBeNull();
+  });
+
+  test("skips apply when the default greeting is already gone", () => {
+    expect(
+      applyFreshProactiveGreeting([userMessage], proactiveGreeting, {
+        suppressed: false,
+      })
+    ).toBeNull();
+  });
+});

--- a/tests/test-proactive-greeting-apply.test.ts
+++ b/tests/test-proactive-greeting-apply.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import type { AIChatMessage } from "../src/types/chat";
 import {
   applyFreshProactiveGreeting,
+  isDefaultGreetingMessage,
   shouldApplyFreshProactiveGreeting,
 } from "../src/apps/chats/utils/proactiveGreetingApply";
 
@@ -23,45 +24,51 @@ const userMessage: AIChatMessage = {
   parts: [{ type: "text", text: "what's new?" }],
 };
 
+const assistantStream: AIChatMessage = {
+  id: "assistant-1",
+  role: "assistant",
+  parts: [{ type: "text", text: "streaming..." }],
+};
+
 describe("proactive greeting apply", () => {
+  test("detects the default loading greeting", () => {
+    expect(isDefaultGreetingMessage(defaultGreeting)).toBe(true);
+    expect(isDefaultGreetingMessage(proactiveGreeting)).toBe(false);
+  });
+
   test("replaces only the default greeting in a fresh chat", () => {
     const result = applyFreshProactiveGreeting(
       [defaultGreeting],
-      proactiveGreeting,
-      { suppressed: false }
+      proactiveGreeting
     );
 
     expect(result).toEqual([proactiveGreeting]);
   });
 
-  test("preserves user messages when replacing the default greeting", () => {
+  test("preserves user and streaming assistant messages", () => {
     const result = applyFreshProactiveGreeting(
-      [defaultGreeting, userMessage],
-      proactiveGreeting,
-      { suppressed: false }
+      [defaultGreeting, userMessage, assistantStream],
+      proactiveGreeting
     );
 
-    expect(result).toEqual([proactiveGreeting, userMessage]);
+    expect(result).toEqual([proactiveGreeting, userMessage, assistantStream]);
   });
 
-  test("skips apply when greeting fetch was cancelled after user typed", () => {
-    expect(
-      shouldApplyFreshProactiveGreeting([defaultGreeting], { suppressed: true })
-    ).toBe(false);
+  test("still applies while the user has already sent a message", () => {
+    expect(shouldApplyFreshProactiveGreeting([defaultGreeting, userMessage])).toBe(
+      true
+    );
     expect(
       applyFreshProactiveGreeting(
         [defaultGreeting, userMessage],
-        proactiveGreeting,
-        { suppressed: true }
+        proactiveGreeting
       )
-    ).toBeNull();
+    ).toEqual([proactiveGreeting, userMessage]);
   });
 
   test("skips apply when the default greeting is already gone", () => {
     expect(
-      applyFreshProactiveGreeting([userMessage], proactiveGreeting, {
-        suppressed: false,
-      })
+      applyFreshProactiveGreeting([userMessage], proactiveGreeting)
     ).toBeNull();
   });
 });

--- a/tests/test-synced-ai-messages.test.ts
+++ b/tests/test-synced-ai-messages.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "bun:test";
+
+/**
+ * Documents the store→SDK sync guard that prevents proactive greeting (or any
+ * shorter store snapshot) from clobbering an in-flight AI SDK conversation.
+ */
+describe("synced AI messages guard", () => {
+  test("does not overwrite SDK when it has more messages than the store", () => {
+    const aiMessages = [
+      {
+        id: "1",
+        role: "assistant" as const,
+        parts: [{ type: "text" as const, text: "hello" }],
+      },
+    ];
+    const sdkMessages = [
+      aiMessages[0],
+      {
+        id: "user-1",
+        role: "user" as const,
+        parts: [{ type: "text" as const, text: "what's new?" }],
+      },
+      {
+        id: "assistant-1",
+        role: "assistant" as const,
+        parts: [{ type: "text" as const, text: "streaming..." }],
+      },
+    ];
+
+    const shouldSyncStoreToSdk = sdkMessages.length <= aiMessages.length;
+    expect(shouldSyncStoreToSdk).toBe(false);
+  });
+});

--- a/tests/test-synced-ai-messages.test.ts
+++ b/tests/test-synced-ai-messages.test.ts
@@ -1,33 +1,40 @@
 import { describe, expect, test } from "bun:test";
+import type { AIChatMessage } from "../src/types/chat";
+import { applyFreshProactiveGreeting } from "../src/apps/chats/utils/proactiveGreetingApply";
 
-/**
- * Documents the store→SDK sync guard that prevents proactive greeting (or any
- * shorter store snapshot) from clobbering an in-flight AI SDK conversation.
- */
-describe("synced AI messages guard", () => {
-  test("does not overwrite SDK when it has more messages than the store", () => {
-    const aiMessages = [
-      {
-        id: "1",
-        role: "assistant" as const,
-        parts: [{ type: "text" as const, text: "hello" }],
-      },
-    ];
-    const sdkMessages = [
-      aiMessages[0],
+describe("synced AI messages greeting swap", () => {
+  test("patches only the default greeting in a longer live SDK list", () => {
+    const defaultGreeting: AIChatMessage = {
+      id: "1",
+      role: "assistant",
+      parts: [{ type: "text", text: "👋 hey! i'm ryo. ask me anything!" }],
+    };
+    const proactiveGreeting: AIChatMessage = {
+      id: "proactive-1",
+      role: "assistant",
+      parts: [{ type: "text", text: "welcome back alice!" }],
+    };
+    const sdkMessages: AIChatMessage[] = [
+      defaultGreeting,
       {
         id: "user-1",
-        role: "user" as const,
-        parts: [{ type: "text" as const, text: "what's new?" }],
+        role: "user",
+        parts: [{ type: "text", text: "what's new?" }],
       },
       {
         id: "assistant-1",
-        role: "assistant" as const,
-        parts: [{ type: "text" as const, text: "streaming..." }],
+        role: "assistant",
+        parts: [{ type: "text", text: "streaming..." }],
       },
     ];
 
-    const shouldSyncStoreToSdk = sdkMessages.length <= aiMessages.length;
-    expect(shouldSyncStoreToSdk).toBe(false);
+    const patched = applyFreshProactiveGreeting(sdkMessages, proactiveGreeting);
+
+    expect(patched).toEqual([
+      proactiveGreeting,
+      sdkMessages[1],
+      sdkMessages[2],
+    ]);
+    expect(patched?.length).toBe(sdkMessages.length);
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes duplicate React key warnings and a race where proactive greeting completion could clobber an in-flight chat. The greeting now swaps the loading placeholder in-place while the user continues chatting.

## Root causes

1. **Duplicate keys:** `getMessageKey` collapsed both `id: "1"` and `id: "proactive-1"` into `"greeting"`.
2. **Lost messages / canceled greeting:** Earlier fix aborted the greeting fetch on send. The correct behavior is to let the greeting finish and only replace the default loading message (`id: "1"`) without touching user/assistant stream messages.

## Changes

- Namespace synthetic greeting IDs under `synthetic:greeting:{id}` for unique React keys
- On proactive greeting completion, patch the **live AI SDK list** in-place (swap default greeting only)
- Persist the same patched list to the store so user/stream messages are preserved
- `useSyncedAiMessages` fallback: when store has proactive greeting but SDK still shows loading placeholder, swap greeting in SDK without resetting stream
- Removed greeting cancellation on user submit — chat stream continues uninterrupted

## Merge status

- Rebased/merged latest `main` including **#1388** (Ryo ToolLoopAgent chats refactor)
- **No merge conflicts** — `useAiChat.ts` auto-merged cleanly; `getLiveMessages` / `patchLiveMessages` hooks preserved

## Testing

- `bun test tests/test-chat-message-keys.test.ts` — 4 pass
- `bun test tests/test-proactive-greeting-apply.test.ts` — 5 pass
- `bun test tests/test-synced-ai-messages.test.ts` — 1 pass
- `bun run test:unit` — 265 pass (after main merge)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3017726d-8bc8-4b6d-842b-faabbf46166b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3017726d-8bc8-4b6d-842b-faabbf46166b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

