### PR TITLE
Refactor Ryo tool loops to ToolLoopAgent

### DIFF
--- a/api/_utils/_aiModels.ts
+++ b/api/_utils/_aiModels.ts
@@ -76,3 +76,19 @@ export function getOpenAIProviderOptions(
     openai: openaiOptions,
   };
 }
+
+export function getTelegramModel(
+  log: (...args: unknown[]) => void,
+  env: NodeJS.ProcessEnv = process.env
+): SupportedModel {
+  const raw = env.TELEGRAM_BOT_MODEL as SupportedModel | undefined;
+  if (raw && SUPPORTED_AI_MODELS.includes(raw)) {
+    return raw;
+  }
+  if (raw) {
+    log(
+      `Unsupported TELEGRAM_BOT_MODEL "${raw}", falling back to ${TELEGRAM_DEFAULT_MODEL}`
+    );
+  }
+  return TELEGRAM_DEFAULT_MODEL;
+}

--- a/api/_utils/ryo-agent.ts
+++ b/api/_utils/ryo-agent.ts
@@ -4,40 +4,56 @@ import {
   type TextStreamPart,
   type ToolSet,
 } from "ai";
-import { getOpenAIProviderOptions, type SupportedModel } from "./_aiModels.js";
+import { getOpenAIProviderOptions } from "./_aiModels.js";
 import type { PreparedRyoConversation } from "./ryo-conversation.js";
 
+export const RYO_AGENT_PRESETS = {
+  chat: {
+    id: "ryo-chat",
+    stopAfterSteps: 10,
+    maxOutputTokens: 48000,
+  },
+  telegram: {
+    id: "ryo-telegram",
+    stopAfterSteps: 6,
+    maxOutputTokens: 4000,
+  },
+  telegramHeartbeat: {
+    id: "ryo-telegram-heartbeat",
+    stopAfterSteps: 6,
+    maxOutputTokens: 4000,
+  },
+} as const;
+
+type RyoAgentPresetName = keyof typeof RYO_AGENT_PRESETS;
+
 type RyoToolLoopAgentOptions = {
-  id: string;
-  prepared: Pick<PreparedRyoConversation, "selectedModel" | "tools">;
-  model: SupportedModel;
-  stopAfterSteps: number;
-  maxOutputTokens: number;
+  preset: RyoAgentPresetName;
+  prepared: Pick<PreparedRyoConversation, "selectedModel" | "modelId" | "tools">;
   temperature?: number;
-  headers?: Record<string, string> | undefined;
   tools?: ToolSet;
 };
 
 export function createRyoToolLoopAgent({
-  id,
+  preset,
   prepared,
-  model,
-  stopAfterSteps,
-  maxOutputTokens,
   temperature = 0.7,
-  headers,
   tools,
 }: RyoToolLoopAgentOptions): ToolLoopAgent<never, ToolSet> {
-  const providerOptions = getOpenAIProviderOptions(model);
+  const agentPreset = RYO_AGENT_PRESETS[preset];
+  const providerOptions = getOpenAIProviderOptions(prepared.modelId);
+  const headers = prepared.modelId.startsWith("sonnet")
+    ? { "anthropic-beta": "fine-grained-tool-streaming-2025-05-14" }
+    : undefined;
 
   return new ToolLoopAgent<never, ToolSet>({
-    id,
+    id: agentPreset.id,
     model: prepared.selectedModel,
     tools: tools ?? prepared.tools,
     allowSystemInMessages: true,
     temperature,
-    maxOutputTokens,
-    stopWhen: stepCountIs(stopAfterSteps),
+    maxOutputTokens: agentPreset.maxOutputTokens,
+    stopWhen: stepCountIs(agentPreset.stopAfterSteps),
     ...(headers ? { headers } : {}),
     ...(providerOptions ? { providerOptions } : {}),
   });

--- a/api/_utils/ryo-agent.ts
+++ b/api/_utils/ryo-agent.ts
@@ -1,0 +1,57 @@
+import {
+  ToolLoopAgent,
+  stepCountIs,
+  type TextStreamPart,
+  type ToolSet,
+} from "ai";
+import { getOpenAIProviderOptions, type SupportedModel } from "./_aiModels.js";
+import type { PreparedRyoConversation } from "./ryo-conversation.js";
+
+type RyoToolLoopAgentOptions = {
+  id: string;
+  prepared: Pick<PreparedRyoConversation, "selectedModel" | "tools">;
+  model: SupportedModel;
+  stopAfterSteps: number;
+  maxOutputTokens: number;
+  temperature?: number;
+  headers?: Record<string, string> | undefined;
+  tools?: ToolSet;
+};
+
+export function createRyoToolLoopAgent({
+  id,
+  prepared,
+  model,
+  stopAfterSteps,
+  maxOutputTokens,
+  temperature = 0.7,
+  headers,
+  tools,
+}: RyoToolLoopAgentOptions): ToolLoopAgent<never, ToolSet> {
+  const providerOptions = getOpenAIProviderOptions(model);
+
+  return new ToolLoopAgent<never, ToolSet>({
+    id,
+    model: prepared.selectedModel,
+    tools: tools ?? prepared.tools,
+    allowSystemInMessages: true,
+    temperature,
+    maxOutputTokens,
+    stopWhen: stepCountIs(stopAfterSteps),
+    ...(headers ? { headers } : {}),
+    ...(providerOptions ? { providerOptions } : {}),
+  });
+}
+
+export async function* textStreamFromFullStream<TOOLS extends ToolSet>(
+  fullStream: AsyncIterable<TextStreamPart<TOOLS>>,
+  onPart?: (part: TextStreamPart<TOOLS>) => Promise<void> | void
+): AsyncIterable<string> {
+  for await (const part of fullStream) {
+    await onPart?.(part);
+
+    if (part.type === "text-delta") {
+      yield part.text;
+    }
+  }
+}

--- a/api/_utils/ryo-conversation.ts
+++ b/api/_utils/ryo-conversation.ts
@@ -168,6 +168,7 @@ export interface PrepareRyoConversationOptions {
 
 export interface PreparedRyoConversation {
   selectedModel: LanguageModel;
+  modelId: SupportedModel;
   tools: ToolSet;
   enrichedMessages: ModelMessage[];
   loadedSections: string[];
@@ -880,6 +881,7 @@ export async function prepareRyoConversationModelInput(
 
   return {
     selectedModel: getModelInstance(model),
+    modelId: model,
     tools,
     enrichedMessages,
     loadedSections,

--- a/api/chat.ts
+++ b/api/chat.ts
@@ -23,6 +23,14 @@ import { resolveIpGeolocation } from "./_utils/_geolocation.js";
 import { createRyoToolLoopAgent } from "./_utils/ryo-agent.js";
 type SystemState = RyoConversationSystemState;
 
+const CHAT_MODEL_ALIASES: Record<string, SupportedModel> = {
+  "claude-sonnet": "sonnet-4.6",
+};
+
+function normalizeChatModel(model: string): string {
+  return CHAT_MODEL_ALIASES[model] ?? model;
+}
+
 
 // Node.js runtime configuration
 export const runtime = "nodejs";
@@ -62,7 +70,7 @@ export default apiHandler<{
     };
 
     // Use query parameter if available, otherwise use body parameter, otherwise use default
-    const model = queryModel || bodyModel || DEFAULT_MODEL;
+    const model = normalizeChatModel(queryModel || bodyModel || DEFAULT_MODEL);
 
     if (!messages || !Array.isArray(messages)) {
       logger.error("400 Error: Invalid messages format", { messages });

--- a/api/chat.ts
+++ b/api/chat.ts
@@ -340,23 +340,19 @@ Generate ONE short proactive greeting. Pick one interesting angle from the conte
       }),
     });
 
-    // Set CORS headers
     res.setHeader("Access-Control-Allow-Origin", validOrigin);
     
-    // Use pipeUIMessageStreamToResponse for Node.js streaming
     result.pipeUIMessageStreamToResponse(res, {
       status: 200,
     });
   } catch (error) {
     logger.error("Chat API error", error);
 
-    // Set CORS headers
     if (validOrigin) {
       res.setHeader("Access-Control-Allow-Origin", validOrigin);
     }
     res.setHeader("Content-Type", "application/json");
 
-    // Check if error is a SyntaxError (likely from parsing JSON)
     if (error instanceof SyntaxError) {
       logger.error(`Invalid JSON`, error.message);
       logger.response(400, Date.now() - startTime);

--- a/api/chat.ts
+++ b/api/chat.ts
@@ -1,15 +1,9 @@
-import {
-  streamText,
-  generateText,
-  smoothStream,
-  stepCountIs,
-} from "ai";
+import { generateText, smoothStream } from "ai";
 import { geolocation } from "@vercel/functions";
 import { google } from "@ai-sdk/google";
 import {
   DEFAULT_MODEL,
   SUPPORTED_AI_MODELS,
-  getOpenAIProviderOptions,
   type SupportedModel,
 } from "./_utils/_aiModels.js";
 import {
@@ -26,6 +20,7 @@ import { checkAndIncrementAIMessageCount } from "./_utils/_rate-limit.js";
 import { apiHandler } from "./_utils/api-handler.js";
 import { getHeader } from "./_utils/request-helpers.js";
 import { resolveIpGeolocation } from "./_utils/_geolocation.js";
+import { createRyoToolLoopAgent } from "./_utils/ryo-agent.js";
 type SystemState = RyoConversationSystemState;
 
 
@@ -329,23 +324,22 @@ Generate ONE short proactive greeting. Pick one interesting angle from the conte
       log(`Message ${index} [${msg.role}]: ${contentStr.substring(0, 100)}...`);
     });
 
-    const result = streamText({
-      model: selectedModel,
-      messages: enrichedMessages,
-      tools,
-      temperature: 0.7,
+    const agent = createRyoToolLoopAgent({
+      id: "ryo-chat",
+      prepared: { selectedModel, tools },
+      model: model as SupportedModel,
       maxOutputTokens: 48000, // Increased from 6000 to prevent code generation cutoff
-      stopWhen: stepCountIs(10), // Allow up to 10 steps for multi-tool workflows (agent loop)
+      stopAfterSteps: 10, // Allow up to 10 steps for multi-tool workflows (agent loop)
+      headers: model.startsWith("claude")
+        ? { "anthropic-beta": "fine-grained-tool-streaming-2025-05-14" }
+        : undefined,
+    });
+
+    const result = await agent.stream({
+      messages: enrichedMessages,
       experimental_transform: smoothStream({
         chunking: /[\u4E00-\u9FFF]|\S+\s+/,
       }),
-      headers: {
-        // Enable fine-grained tool streaming for Anthropic models
-        ...(model.startsWith("claude")
-          ? { "anthropic-beta": "fine-grained-tool-streaming-2025-05-14" }
-          : {}),
-      },
-      providerOptions: getOpenAIProviderOptions(model as SupportedModel),
     });
 
     // Set CORS headers

--- a/api/chat.ts
+++ b/api/chat.ts
@@ -297,13 +297,7 @@ Generate ONE short proactive greeting. Pick one interesting angle from the conte
       }
     }
 
-    const {
-      selectedModel,
-      tools,
-      enrichedMessages,
-      loadedSections,
-      staticSystemPrompt,
-    } = await prepareRyoConversationModelInput({
+    const preparedConversation = await prepareRyoConversationModelInput({
       channel: "chat",
       messages: messages as SimpleConversationMessage[],
       systemState,
@@ -314,6 +308,8 @@ Generate ONE short proactive greeting. Pick one interesting angle from the conte
       logError,
       preloadedMemoryContext: loadedMemoryContext,
     });
+    const { enrichedMessages, loadedSections, staticSystemPrompt } =
+      preparedConversation;
 
     log(
       `Context-aware prompts (${
@@ -333,14 +329,8 @@ Generate ONE short proactive greeting. Pick one interesting angle from the conte
     });
 
     const agent = createRyoToolLoopAgent({
-      id: "ryo-chat",
-      prepared: { selectedModel, tools },
-      model: model as SupportedModel,
-      maxOutputTokens: 48000, // Increased from 6000 to prevent code generation cutoff
-      stopAfterSteps: 10, // Allow up to 10 steps for multi-tool workflows (agent loop)
-      headers: model.startsWith("claude")
-        ? { "anthropic-beta": "fine-grained-tool-streaming-2025-05-14" }
-        : undefined,
+      preset: "chat",
+      prepared: preparedConversation,
     });
 
     const result = await agent.stream({

--- a/api/cron/telegram-heartbeat.ts
+++ b/api/cron/telegram-heartbeat.ts
@@ -1,5 +1,4 @@
 import type { VercelRequest, VercelResponse } from "@vercel/node";
-import { stepCountIs, streamText } from "ai";
 import { initLogger } from "../_utils/_logging.js";
 import createRedis from "../_utils/redis.js";
 import { getDailyNote, getMemoryIndex, getTodayDateString } from "../_utils/_memory.js";
@@ -41,10 +40,10 @@ import {
 import {
   TELEGRAM_DEFAULT_MODEL,
   SUPPORTED_AI_MODELS,
-  getOpenAIProviderOptions,
   type SupportedModel,
 } from "../_utils/_aiModels.js";
 import { getHeader } from "../_utils/request-helpers.js";
+import { createRyoToolLoopAgent } from "../_utils/ryo-agent.js";
 
 export const runtime = "nodejs";
 export const maxDuration = 80;
@@ -406,14 +405,16 @@ export default async function handler(
     approxTokens: Math.round(staticSystemPrompt.length / 4),
   });
 
-  const result = streamText({
-    model: selectedModel,
-    messages: enrichedMessages,
-    tools,
-    temperature: 0.7,
+  const agent = createRyoToolLoopAgent({
+    id: "ryo-telegram-heartbeat",
+    prepared: { selectedModel, tools },
+    model: telegramModel,
     maxOutputTokens: 4000,
-    stopWhen: stepCountIs(6),
-    providerOptions: getOpenAIProviderOptions(telegramModel),
+    stopAfterSteps: 6,
+  });
+
+  const result = await agent.generate({
+    messages: enrichedMessages,
     onStepFinish: async (stepResult) => {
       if (stepResult.toolResults.length > 0) {
         logger.info("Telegram heartbeat completed tool step", {
@@ -425,10 +426,7 @@ export default async function handler(
     },
   });
 
-  let rawReply = "";
-  for await (const chunk of result.textStream) {
-    rawReply += chunk;
-  }
+  const rawReply = result.text;
 
   const heartbeatResult = parseTelegramHeartbeatResult(rawReply);
   if (!heartbeatResult.shouldSend) {

--- a/api/cron/telegram-heartbeat.ts
+++ b/api/cron/telegram-heartbeat.ts
@@ -38,9 +38,7 @@ import {
   type SimpleConversationMessage,
 } from "../_utils/ryo-conversation.js";
 import {
-  TELEGRAM_DEFAULT_MODEL,
-  SUPPORTED_AI_MODELS,
-  type SupportedModel,
+  getTelegramModel,
 } from "../_utils/_aiModels.js";
 import { getHeader } from "../_utils/request-helpers.js";
 import { createRyoToolLoopAgent } from "../_utils/ryo-agent.js";
@@ -58,22 +56,6 @@ function sendJson(
   payload: Record<string, unknown>
 ): void {
   res.status(status).json(payload);
-}
-
-export function getTelegramModel(
-  log: (...args: unknown[]) => void,
-  env: NodeJS.ProcessEnv = process.env
-): SupportedModel {
-  const raw = env.TELEGRAM_BOT_MODEL as SupportedModel | undefined;
-  if (raw && SUPPORTED_AI_MODELS.includes(raw)) {
-    return raw;
-  }
-  if (raw) {
-    log(
-      `Unsupported TELEGRAM_BOT_MODEL "${raw}", falling back to ${TELEGRAM_DEFAULT_MODEL}`
-    );
-  }
-  return TELEGRAM_DEFAULT_MODEL;
 }
 
 async function markHeartbeatSlot(
@@ -376,13 +358,7 @@ export default async function handler(
   );
   const userMemories = await getMemoryIndex(redis, username);
 
-  const {
-    selectedModel,
-    tools,
-    enrichedMessages,
-    loadedSections,
-    staticSystemPrompt,
-  } = await prepareRyoConversationModelInput({
+  const preparedConversation = await prepareRyoConversationModelInput({
     channel: "telegram",
     messages: conversationMessages,
     username,
@@ -398,6 +374,8 @@ export default async function handler(
       userTimeZone: TELEGRAM_HEARTBEAT_TIME_ZONE,
     },
   });
+  const { enrichedMessages, loadedSections, staticSystemPrompt } =
+    preparedConversation;
 
   logger.info("Telegram heartbeat prompt sections loaded", {
     username,
@@ -406,11 +384,8 @@ export default async function handler(
   });
 
   const agent = createRyoToolLoopAgent({
-    id: "ryo-telegram-heartbeat",
-    prepared: { selectedModel, tools },
-    model: telegramModel,
-    maxOutputTokens: 4000,
-    stopAfterSteps: 6,
+    preset: "telegramHeartbeat",
+    prepared: preparedConversation,
   });
 
   const result = await agent.generate({

--- a/api/webhooks/telegram.ts
+++ b/api/webhooks/telegram.ts
@@ -34,11 +34,7 @@ import {
   prepareRyoConversationModelInput,
   type SimpleConversationMessage,
 } from "../_utils/ryo-conversation.js";
-import {
-  TELEGRAM_DEFAULT_MODEL,
-  SUPPORTED_AI_MODELS,
-  type SupportedModel,
-} from "../_utils/_aiModels.js";
+import { getTelegramModel } from "../_utils/_aiModels.js";
 import {
   createRyoToolLoopAgent,
   textStreamFromFullStream,
@@ -102,22 +98,6 @@ function getTelegramWebhookSecret(req: VercelRequest): string | null {
     return value[0] || null;
   }
   return typeof value === "string" ? value : null;
-}
-
-export function getTelegramModel(
-  log: (...args: unknown[]) => void,
-  env: NodeJS.ProcessEnv = process.env
-): SupportedModel {
-  const raw = env.TELEGRAM_BOT_MODEL as SupportedModel | undefined;
-  if (raw && SUPPORTED_AI_MODELS.includes(raw)) {
-    return raw;
-  }
-  if (raw) {
-    log(
-      `Unsupported TELEGRAM_BOT_MODEL "${raw}", falling back to ${TELEGRAM_DEFAULT_MODEL}`
-    );
-  }
-  return TELEGRAM_DEFAULT_MODEL;
 }
 
 async function sendTelegramInfoMessage(
@@ -629,13 +609,7 @@ export default async function handler(
   const telegramModel = getTelegramModel((message, ...rest) =>
     logger.info(String(message), rest.length > 0 ? rest : undefined)
   );
-  const {
-    selectedModel,
-    tools,
-    enrichedMessages,
-    loadedSections,
-    staticSystemPrompt,
-  } = await prepareRyoConversationModelInput({
+  const preparedConversation = await prepareRyoConversationModelInput({
     channel: "telegram",
     messages: conversationMessages,
     username: linkedAccount.username,
@@ -650,6 +624,8 @@ export default async function handler(
     logError: (...args: unknown[]) =>
       logger.error(`[Telegram:${linkedAccount.username}]`, args),
   });
+  const { tools, enrichedMessages, loadedSections, staticSystemPrompt } =
+    preparedConversation;
 
   logger.info("Telegram prompt sections loaded", {
     username: linkedAccount.username,
@@ -686,12 +662,9 @@ export default async function handler(
     );
 
     const agent = createRyoToolLoopAgent({
-      id: "ryo-telegram",
-      prepared: { selectedModel, tools },
+      preset: "telegram",
+      prepared: preparedConversation,
       tools: toolsWithStatus,
-      model: telegramModel,
-      maxOutputTokens: 4000,
-      stopAfterSteps: 6,
     });
 
     const result = await agent.stream({

--- a/api/webhooks/telegram.ts
+++ b/api/webhooks/telegram.ts
@@ -1,5 +1,5 @@
 import type { VercelRequest, VercelResponse } from "@vercel/node";
-import { stepCountIs, streamText, type ModelMessage, type ToolSet } from "ai";
+import { type ModelMessage, type ToolSet } from "ai";
 import { initLogger } from "../_utils/_logging.js";
 import createRedis from "../_utils/redis.js";
 import * as RateLimit from "../_utils/_rate-limit.js";
@@ -37,9 +37,12 @@ import {
 import {
   TELEGRAM_DEFAULT_MODEL,
   SUPPORTED_AI_MODELS,
-  getOpenAIProviderOptions,
   type SupportedModel,
 } from "../_utils/_aiModels.js";
+import {
+  createRyoToolLoopAgent,
+  textStreamFromFullStream,
+} from "../_utils/ryo-agent.js";
 import {
   generateElevenLabsSpeech,
   transcribeAudioBuffer,
@@ -682,15 +685,27 @@ export default async function handler(
       }
     );
 
-    const result = streamText({
-      model: selectedModel,
-      messages: finalMessages,
+    const agent = createRyoToolLoopAgent({
+      id: "ryo-telegram",
+      prepared: { selectedModel, tools },
       tools: toolsWithStatus,
-      temperature: 0.7,
+      model: telegramModel,
       maxOutputTokens: 4000,
-      stopWhen: stepCountIs(6),
-      providerOptions: getOpenAIProviderOptions(telegramModel),
-      onChunk: async ({ chunk }) => {
+      stopAfterSteps: 6,
+    });
+
+    const result = await agent.stream({
+      messages: finalMessages,
+      onStepFinish: async (stepResult) => {
+        if (stepResult.toolResults.length > 0) {
+          await statusReporter.markThinking();
+        }
+      },
+    });
+
+    const textStream = textStreamFromFullStream(
+      result.fullStream,
+      async (chunk) => {
         if (chunk.type !== "tool-input-start" && chunk.type !== "tool-call") {
           return;
         }
@@ -718,18 +733,13 @@ export default async function handler(
           providerToolCall.toolName,
           providerToolCall.input
         );
-      },
-      onStepFinish: async (stepResult) => {
-        if (stepResult.toolResults.length > 0) {
-          await statusReporter.markThinking();
-        }
-      },
-    });
+      }
+    );
 
     const { text: replyText, previewMode } = shouldSendVoiceOnlyReply
       ? {
           text: await collectTelegramReplyText({
-            textStream: result.textStream,
+            textStream,
             formatText: simplifyTelegramCitationDisplay,
           }),
           previewMode: "none" as const,
@@ -738,7 +748,7 @@ export default async function handler(
           botToken,
           chatId: parsedUpdate.chatId,
           draftId: parsedUpdate.updateId,
-          textStream: result.textStream,
+          textStream,
           replyToMessageId: parsedUpdate.messageId,
           formatText: simplifyTelegramCitationDisplay,
           onBeforePreview: async () => {

--- a/src/apps/chats/hooks/useAiChat.ts
+++ b/src/apps/chats/hooks/useAiChat.ts
@@ -73,24 +73,22 @@ import {
   type TvControlInput,
 } from "../tools";
 
-/**
- * NOTE: Future refactoring opportunity (tracked in codebase analysis)
- * 
- * Consider consolidating more state from ChatsAppComponent into this hook:
- * - AI chat state (currently using useChat hook here)
- * - Message processing (app control markup)
- * - System state generation
- * - Dialog states (clear, save)
- * 
- * This would make the component lighter and improve testability.
- * Priority: Low - current architecture works well for the use case.
- */
-
-// Track newly created TextEdit instances for fallback mechanism
 const recentlyCreatedTextEditInstances = new Map<
   string,
   { instanceId: string; path: string; timestamp: number }
 >();
+
+const SERVER_EXECUTED_TOOL_NAMES = new Set([
+  "generateHtml",
+  "searchSongs",
+  "memoryWrite",
+  "memoryRead",
+  "memoryDelete",
+  "webFetch",
+  "cursorCloudAgent",
+  "listCursorCloudAgentRuns",
+  "mapsSearchPlaces",
+]);
 
 // Helper to add a newly created instance to tracking
 const trackNewTextEditInstance = (instanceId: string, path: string) => {
@@ -386,8 +384,12 @@ export function useAiChat(onPromptSetUsername?: () => void) {
       };
 
       try {
-        // Default result message
         let result: string = "Tool executed successfully";
+
+        if (SERVER_EXECUTED_TOOL_NAMES.has(toolCall.toolName)) {
+          console.log(`[ToolCall] ${toolCall.toolName} (server-side):`, toolCall.input);
+          return;
+        }
 
         switch (toolCall.toolName) {
           case "aquarium": {
@@ -417,7 +419,7 @@ export function useAiChat(onPromptSetUsername?: () => void) {
               toolCall.toolCallId,
               toolContext
             );
-            result = ""; // Handler manages its own result
+            result = "";
             break;
           }
           case "karaokeControl": {
@@ -426,73 +428,9 @@ export function useAiChat(onPromptSetUsername?: () => void) {
               toolCall.toolCallId,
               toolContext
             );
-            result = ""; // Handler manages its own result
-            break;
-          }
-          // === Server-side tools (executed on the server via `execute` function) ===
-          // These tools have their results streamed from the server.
-          // We must NOT call addToolOutput here, as it would race with and
-          // potentially overwrite the real server result.
-          case "generateHtml": {
-            const { html } = toolCall.input as { html: string };
-            console.log("[ToolCall] generateHtml (server-side):", {
-              htmlLength: html?.length ?? 0,
-            });
-            // Result comes from server — do not call addToolOutput
             result = "";
             break;
           }
-          case "searchSongs": {
-            console.log("[ToolCall] searchSongs (server-side):", toolCall.input);
-            // Result comes from server — do not call addToolOutput
-            result = "";
-            break;
-          }
-          case "memoryWrite": {
-            console.log("[ToolCall] memoryWrite (server-side):", toolCall.input);
-            // Result comes from server — do not call addToolOutput
-            result = "";
-            break;
-          }
-          case "memoryRead": {
-            console.log("[ToolCall] memoryRead (server-side):", toolCall.input);
-            // Result comes from server — do not call addToolOutput
-            result = "";
-            break;
-          }
-          case "memoryDelete": {
-            console.log("[ToolCall] memoryDelete (server-side):", toolCall.input);
-            // Result comes from server — do not call addToolOutput
-            result = "";
-            break;
-          }
-          case "webFetch": {
-            console.log("[ToolCall] webFetch (server-side):", toolCall.input);
-            // Result comes from server — do not call addToolOutput
-            result = "";
-            break;
-          }
-          case "cursorCloudAgent": {
-            console.log("[ToolCall] cursorCloudAgent (server-side):", toolCall.input);
-            // Result comes from server — do not call addToolOutput
-            result = "";
-            break;
-          }
-          case "listCursorCloudAgentRuns": {
-            console.log(
-              "[ToolCall] listCursorCloudAgentRuns (server-side):",
-              toolCall.input
-            );
-            result = "";
-            break;
-          }
-          case "mapsSearchPlaces": {
-            console.log("[ToolCall] mapsSearchPlaces (server-side):", toolCall.input);
-            // Result comes from server — do not call addToolOutput
-            result = "";
-            break;
-          }
-          // === Unified VFS Tools ===
           case "list": {
             const { path, query, limit, librarySource } = toolCall.input as {
               path: string;
@@ -1442,7 +1380,7 @@ export function useAiChat(onPromptSetUsername?: () => void) {
               toolCall.toolCallId,
               toolContext
             );
-            result = ""; // Handler manages its own result
+            result = "";
             break;
           }
           case "stickiesControl": {
@@ -1451,7 +1389,7 @@ export function useAiChat(onPromptSetUsername?: () => void) {
               toolCall.toolCallId,
               toolContext
             );
-            result = ""; // Handler manages its own result
+            result = "";
             break;
           }
           case "infiniteMacControl": {
@@ -1460,7 +1398,7 @@ export function useAiChat(onPromptSetUsername?: () => void) {
               toolCall.toolCallId,
               toolContext
             );
-            result = ""; // Handler manages its own result
+            result = "";
             break;
           }
           case "calendarControl": {
@@ -1469,7 +1407,7 @@ export function useAiChat(onPromptSetUsername?: () => void) {
               toolCall.toolCallId,
               toolContext
             );
-            result = ""; // Handler manages its own result
+            result = "";
             break;
           }
           case "contactsControl": {
@@ -1478,7 +1416,7 @@ export function useAiChat(onPromptSetUsername?: () => void) {
               toolCall.toolCallId,
               toolContext
             );
-            result = ""; // Handler manages its own result
+            result = "";
             break;
           }
           case "tvControl": {
@@ -1487,7 +1425,7 @@ export function useAiChat(onPromptSetUsername?: () => void) {
               toolCall.toolCallId,
               toolContext
             );
-            result = ""; // Handler manages its own result
+            result = "";
             break;
           }
           default:
@@ -1504,7 +1442,6 @@ export function useAiChat(onPromptSetUsername?: () => void) {
             break;
         }
 
-        // Send the result back to the chat
         if (result) {
           console.log(
             `[onToolCall] Adding result for ${toolCall.toolName}:`,
@@ -1518,7 +1455,6 @@ export function useAiChat(onPromptSetUsername?: () => void) {
         }
       } catch (err) {
         console.error("Error executing tool call:", err);
-        // Send error result
         addToolOutput({
           tool: toolCall.toolName,
           toolCallId: toolCall.toolCallId,
@@ -1556,24 +1492,13 @@ export function useAiChat(onPromptSetUsername?: () => void) {
       // Only target server-side tools (client-side tools already called
       // addToolOutput from their handlers, so they don't need recovery).
       if (isError) {
-        const SERVER_SIDE_TOOL_SET = new Set([
-          "generateHtml",
-          "searchSongs",
-          "memoryWrite",
-          "memoryRead",
-          "memoryDelete",
-          "webFetch",
-          "cursorCloudAgent",
-          "listCursorCloudAgentRuns",
-          "mapsSearchPlaces",
-        ]);
         const toolParts = lastMsg.parts.filter(
           (part: { type?: string; state?: string }) =>
             typeof part.type === "string" &&
             part.type.startsWith("tool-") &&
             (part.state === "output-available" ||
               part.state === "output-error") &&
-            SERVER_SIDE_TOOL_SET.has((part.type as string).replace(/^tool-/, "")),
+            SERVER_EXECUTED_TOOL_NAMES.has((part.type as string).replace(/^tool-/, "")),
         );
         if (toolParts.length > 0) {
           console.log(

--- a/src/apps/chats/hooks/useAiChat.ts
+++ b/src/apps/chats/hooks/useAiChat.ts
@@ -347,7 +347,7 @@ export function useAiChat(onPromptSetUsername?: () => void) {
     ((message: UIMessage) => void) | null
   >(null);
 
-  // --- AI Chat Hook (Vercel AI SDK v5) ---
+  // --- AI Chat Hook (Vercel AI SDK v6) ---
   const {
     messages: currentSdkMessages,
     status,
@@ -356,20 +356,20 @@ export function useAiChat(onPromptSetUsername?: () => void) {
     setMessages: setSdkMessages,
     sendMessage,
     regenerate,
-    addToolResult,
+    addToolOutput,
   } = useChat({
     // Initialize from store
     messages: aiMessages,
 
     experimental_throttle: 50,
 
-    // Automatically submit when all tool results are available
+    // Automatically submit when all tool outputs are available
     sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithToolCalls,
 
     transport: chatTransport,
 
     async onToolCall({ toolCall }) {
-      // In AI SDK 5, client-side tool execution requires calling addToolResult
+      // Client-side tool execution requires returning output to the chat.
       // Short delay to allow the UI to render the "call" state
       await new Promise<void>((resolve) => setTimeout(resolve, 120));
 
@@ -381,7 +381,7 @@ export function useAiChat(onPromptSetUsername?: () => void) {
       // Create tool context for extracted handlers
       const toolContext: ToolContext = {
         launchApp: (appId, options) => launchApp(appId as AppId, options),
-        addToolResult,
+        addToolOutput,
         detectUserOS,
       };
 
@@ -431,50 +431,50 @@ export function useAiChat(onPromptSetUsername?: () => void) {
           }
           // === Server-side tools (executed on the server via `execute` function) ===
           // These tools have their results streamed from the server.
-          // We must NOT call addToolResult here, as it would race with and
+          // We must NOT call addToolOutput here, as it would race with and
           // potentially overwrite the real server result.
           case "generateHtml": {
             const { html } = toolCall.input as { html: string };
             console.log("[ToolCall] generateHtml (server-side):", {
               htmlLength: html?.length ?? 0,
             });
-            // Result comes from server — do not call addToolResult
+            // Result comes from server — do not call addToolOutput
             result = "";
             break;
           }
           case "searchSongs": {
             console.log("[ToolCall] searchSongs (server-side):", toolCall.input);
-            // Result comes from server — do not call addToolResult
+            // Result comes from server — do not call addToolOutput
             result = "";
             break;
           }
           case "memoryWrite": {
             console.log("[ToolCall] memoryWrite (server-side):", toolCall.input);
-            // Result comes from server — do not call addToolResult
+            // Result comes from server — do not call addToolOutput
             result = "";
             break;
           }
           case "memoryRead": {
             console.log("[ToolCall] memoryRead (server-side):", toolCall.input);
-            // Result comes from server — do not call addToolResult
+            // Result comes from server — do not call addToolOutput
             result = "";
             break;
           }
           case "memoryDelete": {
             console.log("[ToolCall] memoryDelete (server-side):", toolCall.input);
-            // Result comes from server — do not call addToolResult
+            // Result comes from server — do not call addToolOutput
             result = "";
             break;
           }
           case "webFetch": {
             console.log("[ToolCall] webFetch (server-side):", toolCall.input);
-            // Result comes from server — do not call addToolResult
+            // Result comes from server — do not call addToolOutput
             result = "";
             break;
           }
           case "cursorCloudAgent": {
             console.log("[ToolCall] cursorCloudAgent (server-side):", toolCall.input);
-            // Result comes from server — do not call addToolResult
+            // Result comes from server — do not call addToolOutput
             result = "";
             break;
           }
@@ -488,7 +488,7 @@ export function useAiChat(onPromptSetUsername?: () => void) {
           }
           case "mapsSearchPlaces": {
             console.log("[ToolCall] mapsSearchPlaces (server-side):", toolCall.input);
-            // Result comes from server — do not call addToolResult
+            // Result comes from server — do not call addToolOutput
             result = "";
             break;
           }
@@ -502,7 +502,7 @@ export function useAiChat(onPromptSetUsername?: () => void) {
             };
 
             if (!path) {
-              addToolResult({
+              addToolOutput({
                 tool: toolCall.toolName,
                 toolCallId: toolCall.toolCallId,
                 state: "output-error",
@@ -589,7 +589,7 @@ export function useAiChat(onPromptSetUsername?: () => void) {
                       ? `No songs matched "${query}" in ${libraryName}.`
                       : i18n.t("apps.chats.toolCalls.musicLibraryEmpty");
 
-                addToolResult({
+                addToolOutput({
                   tool: toolCall.toolName,
                   toolCallId: toolCall.toolCallId,
                   output: resultMessage,
@@ -671,7 +671,7 @@ export function useAiChat(onPromptSetUsername?: () => void) {
                     ? i18n.t("apps.chats.toolCalls.noSharedAppletsMatched", { query })
                     : i18n.t("apps.chats.toolCalls.noSharedAppletsAvailable");
 
-                addToolResult({
+                addToolOutput({
                   tool: toolCall.toolName,
                   toolCallId: toolCall.toolCallId,
                   output: resultMessage,
@@ -694,7 +694,7 @@ export function useAiChat(onPromptSetUsername?: () => void) {
                 const appsMessage = apps.length === 1
                   ? i18n.t("apps.chats.toolCalls.foundApplicationsList", { count: apps.length })
                   : i18n.t("apps.chats.toolCalls.foundApplicationsListPlural", { count: apps.length });
-                addToolResult({
+                addToolOutput({
                   tool: toolCall.toolName,
                   toolCallId: toolCall.toolCallId,
                   output: `${appsMessage}:\n${JSON.stringify(apps, null, 2)}`,
@@ -726,14 +726,14 @@ export function useAiChat(onPromptSetUsername?: () => void) {
                       : i18n.t("apps.chats.toolCalls.foundFileTypePlural", { count: fileList.length, fileType })}:\n${JSON.stringify(fileList, null, 2)}`
                   : i18n.t("apps.chats.toolCalls.noFileTypeFound", { fileType, path });
 
-                addToolResult({
+                addToolOutput({
                   tool: toolCall.toolName,
                   toolCallId: toolCall.toolCallId,
                   output: resultMessage,
                 });
                 result = "";
               } else {
-                addToolResult({
+                addToolOutput({
                   tool: toolCall.toolName,
                   toolCallId: toolCall.toolCallId,
                   state: "output-error",
@@ -743,7 +743,7 @@ export function useAiChat(onPromptSetUsername?: () => void) {
               }
             } catch (err) {
               console.error("list error:", err);
-              addToolResult({
+              addToolOutput({
                 tool: toolCall.toolName,
                 toolCallId: toolCall.toolCallId,
                 state: "output-error",
@@ -757,7 +757,7 @@ export function useAiChat(onPromptSetUsername?: () => void) {
             const { path } = toolCall.input as { path: string };
 
             if (!path) {
-              addToolResult({
+              addToolOutput({
                 tool: toolCall.toolName,
                 toolCallId: toolCall.toolCallId,
                 state: "output-error",
@@ -794,7 +794,7 @@ export function useAiChat(onPromptSetUsername?: () => void) {
                 const playingMessage = track.artist
                   ? i18n.t("apps.chats.toolCalls.playingTrackByArtist", { title: track.title, artist: track.artist })
                   : i18n.t("apps.chats.toolCalls.playingTrack", { title: track.title });
-                addToolResult({
+                addToolOutput({
                   tool: toolCall.toolName,
                   toolCallId: toolCall.toolCallId,
                   output: playingMessage,
@@ -824,7 +824,7 @@ export function useAiChat(onPromptSetUsername?: () => void) {
                   initialData: { path: "", content: "", shareCode: shareId },
                 });
 
-                addToolResult({
+                addToolOutput({
                   tool: toolCall.toolName,
                   toolCallId: toolCall.toolCallId,
                   output: i18n.t("apps.chats.toolCalls.openedApplet", { appletName }),
@@ -838,7 +838,7 @@ export function useAiChat(onPromptSetUsername?: () => void) {
                 }
 
                 launchApp(appId);
-                addToolResult({
+                addToolOutput({
                   tool: toolCall.toolName,
                   toolCallId: toolCall.toolCallId,
                   output: i18n.t("apps.chats.toolCalls.launchedApp", { appName: getTranslatedAppName(appId) }),
@@ -877,7 +877,7 @@ export function useAiChat(onPromptSetUsername?: () => void) {
                   initialData: { path, content },
                 });
 
-                addToolResult({
+                addToolOutput({
                   tool: toolCall.toolName,
                   toolCallId: toolCall.toolCallId,
                   output: i18n.t("apps.chats.toolCalls.openedFile", { fileName: fileItem.name }),
@@ -898,7 +898,7 @@ export function useAiChat(onPromptSetUsername?: () => void) {
                 if (existingInstanceId) {
                   if (appStore.instances[existingInstanceId]) {
                     appStore.bringInstanceToForeground(existingInstanceId);
-                    addToolResult({
+                    addToolOutput({
                       tool: toolCall.toolName,
                       toolCallId: toolCall.toolCallId,
                       output: i18n.t("apps.chats.toolCalls.openedDocument", {
@@ -918,7 +918,7 @@ export function useAiChat(onPromptSetUsername?: () => void) {
                 const recentInstanceId = getRecentTextEditInstanceForPath(path);
                 if (recentInstanceId) {
                   appStore.bringInstanceToForeground(recentInstanceId);
-                  addToolResult({
+                  addToolOutput({
                     tool: toolCall.toolName,
                     toolCallId: toolCall.toolCallId,
                     output: i18n.t("apps.chats.toolCalls.openedDocument", {
@@ -956,14 +956,14 @@ export function useAiChat(onPromptSetUsername?: () => void) {
                   initialData: { path, content },
                 });
 
-                addToolResult({
+                addToolOutput({
                   tool: toolCall.toolName,
                   toolCallId: toolCall.toolCallId,
                   output: i18n.t("apps.chats.toolCalls.openedDocument", { fileName: fileItem.name }),
                 });
                 result = "";
               } else {
-                addToolResult({
+                addToolOutput({
                   tool: toolCall.toolName,
                   toolCallId: toolCall.toolCallId,
                   state: "output-error",
@@ -973,7 +973,7 @@ export function useAiChat(onPromptSetUsername?: () => void) {
               }
             } catch (err) {
               console.error("open error:", err);
-              addToolResult({
+              addToolOutput({
                 tool: toolCall.toolName,
                 toolCallId: toolCall.toolCallId,
                 state: "output-error",
@@ -987,7 +987,7 @@ export function useAiChat(onPromptSetUsername?: () => void) {
             const { path } = toolCall.input as { path: string };
 
             if (!path) {
-              addToolResult({
+              addToolOutput({
                 tool: toolCall.toolName,
                 toolCallId: toolCall.toolCallId,
                 state: "output-error",
@@ -1030,7 +1030,7 @@ export function useAiChat(onPromptSetUsername?: () => void) {
                   content: typeof data?.content === "string" ? data.content : "",
                 };
 
-                addToolResult({
+                addToolOutput({
                   tool: toolCall.toolName,
                   toolCallId: toolCall.toolCallId,
                   output: JSON.stringify(payload, null, 2),
@@ -1067,14 +1067,14 @@ export function useAiChat(onPromptSetUsername?: () => void) {
                 }
 
                 const fileLabel = isApplet ? i18n.t("apps.chats.toolCalls.applet") : i18n.t("apps.chats.toolCalls.document");
-                addToolResult({
+                addToolOutput({
                   tool: toolCall.toolName,
                   toolCallId: toolCall.toolCallId,
                   output: i18n.t("apps.chats.toolCalls.fileContent", { fileLabel, fileName: fileItem.name, charCount: content.length }) + `\n\n${content}`,
                 });
                 result = "";
               } else {
-                addToolResult({
+                addToolOutput({
                   tool: toolCall.toolName,
                   toolCallId: toolCall.toolCallId,
                   state: "output-error",
@@ -1084,7 +1084,7 @@ export function useAiChat(onPromptSetUsername?: () => void) {
               }
             } catch (err) {
               console.error("read error:", err);
-              addToolResult({
+              addToolOutput({
                 tool: toolCall.toolName,
                 toolCallId: toolCall.toolCallId,
                 state: "output-error",
@@ -1102,7 +1102,7 @@ export function useAiChat(onPromptSetUsername?: () => void) {
             };
 
             if (!path) {
-              addToolResult({
+              addToolOutput({
                 tool: toolCall.toolName,
                 toolCallId: toolCall.toolCallId,
                 state: "output-error",
@@ -1114,7 +1114,7 @@ export function useAiChat(onPromptSetUsername?: () => void) {
 
             // Validate path format for documents
             if (!path.startsWith("/Documents/")) {
-              addToolResult({
+              addToolOutput({
                 tool: toolCall.toolName,
                 toolCallId: toolCall.toolCallId,
                 state: "output-error",
@@ -1127,7 +1127,7 @@ export function useAiChat(onPromptSetUsername?: () => void) {
             // Validate filename has .md extension
             const fileName = path.split("/").pop() || "";
             if (!fileName.endsWith(".md")) {
-              addToolResult({
+              addToolOutput({
                 tool: toolCall.toolName,
                 toolCallId: toolCall.toolCallId,
                 state: "output-error",
@@ -1138,7 +1138,7 @@ export function useAiChat(onPromptSetUsername?: () => void) {
             }
 
             if (!content && mode === "overwrite") {
-              addToolResult({
+              addToolOutput({
                 tool: toolCall.toolName,
                 toolCallId: toolCall.toolCallId,
                 state: "output-error",
@@ -1226,7 +1226,7 @@ export function useAiChat(onPromptSetUsername?: () => void) {
               }
 
               const outputKey = isNewFile ? "createdDocument" : "updatedDocument";
-              addToolResult({
+              addToolOutput({
                 tool: toolCall.toolName,
                 toolCallId: toolCall.toolCallId,
                 output: i18n.t(`apps.chats.toolCalls.${outputKey}`, { path }),
@@ -1234,7 +1234,7 @@ export function useAiChat(onPromptSetUsername?: () => void) {
               result = "";
             } catch (err) {
               console.error("write error:", err);
-              addToolResult({
+              addToolOutput({
                 tool: toolCall.toolName,
                 toolCallId: toolCall.toolCallId,
                 state: "output-error",
@@ -1252,7 +1252,7 @@ export function useAiChat(onPromptSetUsername?: () => void) {
             };
 
             if (!path || typeof old_string !== "string" || typeof new_string !== "string") {
-              addToolResult({
+              addToolOutput({
                 tool: toolCall.toolName,
                 toolCallId: toolCall.toolCallId,
                 state: "output-error",
@@ -1295,7 +1295,7 @@ export function useAiChat(onPromptSetUsername?: () => void) {
                 const occurrences = normalizedExisting.split(normalizedOldString).length - 1;
                 
                 if (occurrences === 0) {
-                  addToolResult({
+                  addToolOutput({
                     tool: toolCall.toolName,
                     toolCallId: toolCall.toolCallId,
                     state: "output-error",
@@ -1306,7 +1306,7 @@ export function useAiChat(onPromptSetUsername?: () => void) {
                 }
 
                 if (occurrences > 1) {
-                  addToolResult({
+                  addToolOutput({
                     tool: toolCall.toolName,
                     toolCallId: toolCall.toolCallId,
                     state: "output-error",
@@ -1342,7 +1342,7 @@ export function useAiChat(onPromptSetUsername?: () => void) {
                   }
                 }
 
-                addToolResult({
+                addToolOutput({
                   tool: toolCall.toolName,
                   toolCallId: toolCall.toolCallId,
                   output: i18n.t("apps.chats.toolCalls.editedDocument", { path }),
@@ -1373,7 +1373,7 @@ export function useAiChat(onPromptSetUsername?: () => void) {
                 const occurrences = normalizedExisting.split(normalizedOldString).length - 1;
                 
                 if (occurrences === 0) {
-                  addToolResult({
+                  addToolOutput({
                     tool: toolCall.toolName,
                     toolCallId: toolCall.toolCallId,
                     state: "output-error",
@@ -1384,7 +1384,7 @@ export function useAiChat(onPromptSetUsername?: () => void) {
                 }
 
                 if (occurrences > 1) {
-                  addToolResult({
+                  addToolOutput({
                     tool: toolCall.toolName,
                     toolCallId: toolCall.toolCallId,
                     state: "output-error",
@@ -1409,14 +1409,14 @@ export function useAiChat(onPromptSetUsername?: () => void) {
                   content: updatedContent,
                 });
 
-                addToolResult({
+                addToolOutput({
                   tool: toolCall.toolName,
                   toolCallId: toolCall.toolCallId,
                   output: i18n.t("apps.chats.toolCalls.editedApplet", { path }),
                 });
                 result = "";
               } else {
-                addToolResult({
+                addToolOutput({
                   tool: toolCall.toolName,
                   toolCallId: toolCall.toolCallId,
                   state: "output-error",
@@ -1426,7 +1426,7 @@ export function useAiChat(onPromptSetUsername?: () => void) {
               }
             } catch (err) {
               console.error("edit error:", err);
-              addToolResult({
+              addToolOutput({
                 tool: toolCall.toolName,
                 toolCallId: toolCall.toolCallId,
                 state: "output-error",
@@ -1494,7 +1494,7 @@ export function useAiChat(onPromptSetUsername?: () => void) {
             console.warn("Unhandled tool call:", toolCall.toolName);
             // Report as error rather than false success to avoid masking
             // missing handler wiring or new server-side tools
-            addToolResult({
+            addToolOutput({
               tool: toolCall.toolName,
               toolCallId: toolCall.toolCallId,
               state: "output-error",
@@ -1510,7 +1510,7 @@ export function useAiChat(onPromptSetUsername?: () => void) {
             `[onToolCall] Adding result for ${toolCall.toolName}:`,
             result,
           );
-          addToolResult({
+          addToolOutput({
             tool: toolCall.toolName,
             toolCallId: toolCall.toolCallId,
             output: result,
@@ -1519,7 +1519,7 @@ export function useAiChat(onPromptSetUsername?: () => void) {
       } catch (err) {
         console.error("Error executing tool call:", err);
         // Send error result
-        addToolResult({
+        addToolOutput({
           tool: toolCall.toolName,
           toolCallId: toolCall.toolCallId,
           state: "output-error",
@@ -1552,9 +1552,9 @@ export function useAiChat(onPromptSetUsername?: () => void) {
       // When stopWhen + tool calls trigger a TypeValidationError, the SDK
       // sets isError=true and skips the built-in sendAutomaticallyWhen check.
       // For server-side tools whose results arrived via the stream, we need
-      // to re-affirm them via addToolResult so sendAutomaticallyWhen fires.
+      // to re-affirm them via addToolOutput so sendAutomaticallyWhen fires.
       // Only target server-side tools (client-side tools already called
-      // addToolResult from their handlers, so they don't need recovery).
+      // addToolOutput from their handlers, so they don't need recovery).
       if (isError) {
         const SERVER_SIDE_TOOL_SET = new Set([
           "generateHtml",
@@ -1577,7 +1577,7 @@ export function useAiChat(onPromptSetUsername?: () => void) {
         );
         if (toolParts.length > 0) {
           console.log(
-            `[onFinish] isError recovery: re-affirming ${toolParts.length} server-side tool result(s) to trigger sendAutomaticallyWhen`,
+            `[onFinish] isError recovery: re-affirming ${toolParts.length} server-side tool output(s) to trigger sendAutomaticallyWhen`,
           );
           for (const part of toolParts) {
             const tp = part as {
@@ -1589,14 +1589,14 @@ export function useAiChat(onPromptSetUsername?: () => void) {
             };
             const toolName = tp.type.replace(/^tool-/, "");
             if (tp.state === "output-error") {
-              addToolResult({
+              addToolOutput({
                 tool: toolName,
                 toolCallId: tp.toolCallId,
                 state: "output-error",
                 errorText: tp.errorText || "Tool execution failed",
               });
             } else {
-              addToolResult({
+              addToolOutput({
                 tool: toolName,
                 toolCallId: tp.toolCallId,
                 output: tp.output,

--- a/src/apps/chats/tools/appHandlers.ts
+++ b/src/apps/chats/tools/appHandlers.ts
@@ -33,7 +33,7 @@ export const handleLaunchApp = (
   // Validate required parameter
   if (!id) {
     console.error("[ToolCall] launchApp: Missing required 'id' parameter");
-    context.addToolResult({
+    context.addToolOutput({
       tool: "launchApp",
       toolCallId,
       state: "output-error",
@@ -75,7 +75,7 @@ export const handleCloseApp = (
   // Validate required parameter
   if (!id) {
     console.error("[ToolCall] closeApp: Missing required 'id' parameter");
-    context.addToolResult({
+    context.addToolOutput({
       tool: "closeApp",
       toolCallId,
       state: "output-error",

--- a/src/apps/chats/tools/calendarHandler.ts
+++ b/src/apps/chats/tools/calendarHandler.ts
@@ -46,7 +46,7 @@ export const handleCalendarControl: ToolHandler<CalendarControlInput> = (
       const message = input.date
         ? tc(count === 1 ? "foundEventsForDate" : "foundEventsForDatePlural", { count, date: input.date })
         : tc(count === 1 ? "foundEventsTotal" : "foundEventsTotalPlural", { count });
-      context.addToolResult({
+      context.addToolOutput({
         tool: "calendarControl",
         toolCallId,
         output: {
@@ -60,7 +60,7 @@ export const handleCalendarControl: ToolHandler<CalendarControlInput> = (
 
     case "create": {
       if (!input.title || !input.date) {
-        context.addToolResult({
+        context.addToolOutput({
           state: "output-error",
           tool: "calendarControl",
           toolCallId,
@@ -81,7 +81,7 @@ export const handleCalendarControl: ToolHandler<CalendarControlInput> = (
       store.setSelectedDate(input.date);
       context.launchApp("calendar");
 
-      context.addToolResult({
+      context.addToolOutput({
         tool: "calendarControl",
         toolCallId,
         output: {
@@ -103,7 +103,7 @@ export const handleCalendarControl: ToolHandler<CalendarControlInput> = (
 
     case "update": {
       if (!input.id) {
-        context.addToolResult({
+        context.addToolOutput({
           state: "output-error",
           tool: "calendarControl",
           toolCallId,
@@ -114,7 +114,7 @@ export const handleCalendarControl: ToolHandler<CalendarControlInput> = (
 
       const existing = store.events.find((ev) => ev.id === input.id);
       if (!existing) {
-        context.addToolResult({
+        context.addToolOutput({
           state: "output-error",
           tool: "calendarControl",
           toolCallId,
@@ -133,7 +133,7 @@ export const handleCalendarControl: ToolHandler<CalendarControlInput> = (
 
       store.updateEvent(input.id, updates);
 
-      context.addToolResult({
+      context.addToolOutput({
         tool: "calendarControl",
         toolCallId,
         output: {
@@ -146,7 +146,7 @@ export const handleCalendarControl: ToolHandler<CalendarControlInput> = (
 
     case "delete": {
       if (!input.id) {
-        context.addToolResult({
+        context.addToolOutput({
           state: "output-error",
           tool: "calendarControl",
           toolCallId,
@@ -157,7 +157,7 @@ export const handleCalendarControl: ToolHandler<CalendarControlInput> = (
 
       const toDelete = store.events.find((ev) => ev.id === input.id);
       if (!toDelete) {
-        context.addToolResult({
+        context.addToolOutput({
           state: "output-error",
           tool: "calendarControl",
           toolCallId,
@@ -168,7 +168,7 @@ export const handleCalendarControl: ToolHandler<CalendarControlInput> = (
 
       store.deleteEvent(input.id);
 
-      context.addToolResult({
+      context.addToolOutput({
         tool: "calendarControl",
         toolCallId,
         output: {
@@ -192,7 +192,7 @@ export const handleCalendarControl: ToolHandler<CalendarControlInput> = (
         calendarId: t.calendarId,
       }));
       const count = formatted.length;
-      context.addToolResult({
+      context.addToolOutput({
         tool: "calendarControl",
         toolCallId,
         output: {
@@ -206,7 +206,7 @@ export const handleCalendarControl: ToolHandler<CalendarControlInput> = (
 
     case "createTodo": {
       if (!input.title) {
-        context.addToolResult({
+        context.addToolOutput({
           state: "output-error",
           tool: "calendarControl",
           toolCallId,
@@ -221,7 +221,7 @@ export const handleCalendarControl: ToolHandler<CalendarControlInput> = (
       store.setShowTodoSidebar(true);
       context.launchApp("calendar");
 
-      context.addToolResult({
+      context.addToolOutput({
         tool: "calendarControl",
         toolCallId,
         output: {
@@ -243,7 +243,7 @@ export const handleCalendarControl: ToolHandler<CalendarControlInput> = (
 
     case "toggleTodo": {
       if (!input.id) {
-        context.addToolResult({
+        context.addToolOutput({
           state: "output-error",
           tool: "calendarControl",
           toolCallId,
@@ -254,7 +254,7 @@ export const handleCalendarControl: ToolHandler<CalendarControlInput> = (
 
       const todoToToggle = store.todos.find((t) => t.id === input.id);
       if (!todoToToggle) {
-        context.addToolResult({
+        context.addToolOutput({
           state: "output-error",
           tool: "calendarControl",
           toolCallId,
@@ -265,7 +265,7 @@ export const handleCalendarControl: ToolHandler<CalendarControlInput> = (
 
       store.toggleTodo(input.id);
 
-      context.addToolResult({
+      context.addToolOutput({
         tool: "calendarControl",
         toolCallId,
         output: {
@@ -287,7 +287,7 @@ export const handleCalendarControl: ToolHandler<CalendarControlInput> = (
 
     case "deleteTodo": {
       if (!input.id) {
-        context.addToolResult({
+        context.addToolOutput({
           state: "output-error",
           tool: "calendarControl",
           toolCallId,
@@ -298,7 +298,7 @@ export const handleCalendarControl: ToolHandler<CalendarControlInput> = (
 
       const todoToDelete = store.todos.find((t) => t.id === input.id);
       if (!todoToDelete) {
-        context.addToolResult({
+        context.addToolOutput({
           state: "output-error",
           tool: "calendarControl",
           toolCallId,
@@ -309,7 +309,7 @@ export const handleCalendarControl: ToolHandler<CalendarControlInput> = (
 
       store.deleteTodo(input.id);
 
-      context.addToolResult({
+      context.addToolOutput({
         tool: "calendarControl",
         toolCallId,
         output: {
@@ -321,7 +321,7 @@ export const handleCalendarControl: ToolHandler<CalendarControlInput> = (
     }
 
     default:
-      context.addToolResult({
+      context.addToolOutput({
         state: "output-error",
         tool: "calendarControl",
         toolCallId,

--- a/src/apps/chats/tools/contactsHandler.ts
+++ b/src/apps/chats/tools/contactsHandler.ts
@@ -105,7 +105,7 @@ export const handleContactsControl = (
         "c"
       );
 
-      context.addToolResult({
+      context.addToolOutput({
         tool: "contactsControl",
         toolCallId,
         output: {
@@ -124,7 +124,7 @@ export const handleContactsControl = (
 
     case "get": {
       if (!input.id) {
-        context.addToolResult({
+        context.addToolOutput({
           tool: "contactsControl",
           toolCallId,
           state: "output-error",
@@ -137,7 +137,7 @@ export const handleContactsControl = (
       const contact = store.contacts.find((item) => item.id === id);
 
       if (!contact) {
-        context.addToolResult({
+        context.addToolOutput({
           tool: "contactsControl",
           toolCallId,
           state: "output-error",
@@ -148,7 +148,7 @@ export const handleContactsControl = (
         return;
       }
 
-      context.addToolResult({
+      context.addToolOutput({
         tool: "contactsControl",
         toolCallId,
         output: {
@@ -164,7 +164,7 @@ export const handleContactsControl = (
 
     case "create": {
       if (!hasMeaningfulDraft(input)) {
-        context.addToolResult({
+        context.addToolOutput({
           tool: "contactsControl",
           toolCallId,
           state: "output-error",
@@ -179,7 +179,7 @@ export const handleContactsControl = (
         .contacts.find((item) => item.id === id);
 
       context.launchApp("contacts");
-      context.addToolResult({
+      context.addToolOutput({
         tool: "contactsControl",
         toolCallId,
         output: {
@@ -195,7 +195,7 @@ export const handleContactsControl = (
 
     case "update": {
       if (!input.id) {
-        context.addToolResult({
+        context.addToolOutput({
           tool: "contactsControl",
           toolCallId,
           state: "output-error",
@@ -207,7 +207,7 @@ export const handleContactsControl = (
       const id = resolveId(input.id, contactsIdMap);
       const existing = store.contacts.find((item) => item.id === id);
       if (!existing) {
-        context.addToolResult({
+        context.addToolOutput({
           tool: "contactsControl",
           toolCallId,
           state: "output-error",
@@ -219,7 +219,7 @@ export const handleContactsControl = (
       }
 
       if (!hasMeaningfulDraft(input)) {
-        context.addToolResult({
+        context.addToolOutput({
           tool: "contactsControl",
           toolCallId,
           state: "output-error",
@@ -234,7 +234,7 @@ export const handleContactsControl = (
         .contacts.find((item) => item.id === id);
 
       context.launchApp("contacts");
-      context.addToolResult({
+      context.addToolOutput({
         tool: "contactsControl",
         toolCallId,
         output: {
@@ -250,7 +250,7 @@ export const handleContactsControl = (
 
     case "delete": {
       if (!input.id) {
-        context.addToolResult({
+        context.addToolOutput({
           tool: "contactsControl",
           toolCallId,
           state: "output-error",
@@ -262,7 +262,7 @@ export const handleContactsControl = (
       const id = resolveId(input.id, contactsIdMap);
       const existing = store.contacts.find((item) => item.id === id);
       if (!existing) {
-        context.addToolResult({
+        context.addToolOutput({
           tool: "contactsControl",
           toolCallId,
           state: "output-error",
@@ -274,7 +274,7 @@ export const handleContactsControl = (
       }
 
       store.deleteContact(id);
-      context.addToolResult({
+      context.addToolOutput({
         tool: "contactsControl",
         toolCallId,
         output: {

--- a/src/apps/chats/tools/index.ts
+++ b/src/apps/chats/tools/index.ts
@@ -1,60 +1,10 @@
-/**
- * Tool Handler Registry
- *
- * This module provides a registry pattern for tool handlers, enabling
- * the gradual extraction of tool handling logic from the monolithic
- * useAiChat hook into individual, testable modules.
- *
- * ## Architecture
- *
- * The tool handler system follows these principles:
- * 1. Each tool handler is a pure function that receives input and context
- * 2. Handlers call addToolOutput to return results to the chat
- * 3. Shared utilities are centralized in helpers.ts
- *
- * ## Migration Path
- *
- * To migrate a tool handler from useAiChat:
- * 1. Create a new file in src/apps/chats/tools/ (e.g., ipodHandler.ts)
- * 2. Export a handler function matching the ToolHandler type
- * 3. Register it in this file using registerToolHandler
- * 4. Remove the case from the switch statement in useAiChat
- *
- * ## Example Handler
- *
- * ```typescript
- * // src/apps/chats/tools/aquariumHandler.ts
- * import { ToolHandler } from './types';
- *
- * export const handleAquarium: ToolHandler = async (input, toolCallId, context) => {
- *   context.addToolOutput({
- *     tool: 'aquarium',
- *     toolCallId,
- *     output: 'Aquarium displayed',
- *   });
- * };
- * ```
- *
- * Then register it:
- * ```typescript
- * registerToolHandler('aquarium', handleAquarium);
- * ```
- */
-
 import type { ToolHandler, ToolHandlerEntry, ToolContext } from "./types";
 
-// Re-export types and helpers for convenience
 export * from "./types";
 export * from "./helpers";
 
-/**
- * Registry of tool handlers
- */
 const toolHandlerRegistry = new Map<string, ToolHandlerEntry>();
 
-/**
- * Register a tool handler
- */
 export const registerToolHandler = <T = unknown>(
   toolName: string,
   handler: ToolHandler<T>
@@ -65,24 +15,14 @@ export const registerToolHandler = <T = unknown>(
   });
 };
 
-/**
- * Get a registered tool handler
- */
 export const getToolHandler = (toolName: string): ToolHandler | undefined => {
   return toolHandlerRegistry.get(toolName)?.handler;
 };
 
-/**
- * Check if a tool handler is registered
- */
 export const hasToolHandler = (toolName: string): boolean => {
   return toolHandlerRegistry.has(toolName);
 };
 
-/**
- * Execute a tool handler if registered
- * Returns true if the handler was found and executed, false otherwise
- */
 export const executeToolHandler = async (
   toolName: string,
   input: unknown,
@@ -98,16 +38,9 @@ export const executeToolHandler = async (
   return true;
 };
 
-/**
- * Get list of all registered tool names
- */
 export const getRegisteredTools = (): string[] => {
   return Array.from(toolHandlerRegistry.keys());
 };
-
-// ============================================================================
-// Import and export individual handlers
-// ============================================================================
 
 export { handleLaunchApp, handleCloseApp } from "./appHandlers";
 export type { LaunchAppInput, CloseAppInput } from "./appHandlers";

--- a/src/apps/chats/tools/index.ts
+++ b/src/apps/chats/tools/index.ts
@@ -9,7 +9,7 @@
  *
  * The tool handler system follows these principles:
  * 1. Each tool handler is a pure function that receives input and context
- * 2. Handlers call addToolResult to return results to the chat
+ * 2. Handlers call addToolOutput to return results to the chat
  * 3. Shared utilities are centralized in helpers.ts
  *
  * ## Migration Path
@@ -27,7 +27,7 @@
  * import { ToolHandler } from './types';
  *
  * export const handleAquarium: ToolHandler = async (input, toolCallId, context) => {
- *   context.addToolResult({
+ *   context.addToolOutput({
  *     tool: 'aquarium',
  *     toolCallId,
  *     output: 'Aquarium displayed',

--- a/src/apps/chats/tools/infiniteMacHandler.ts
+++ b/src/apps/chats/tools/infiniteMacHandler.ts
@@ -123,7 +123,7 @@ export const handleInfiniteMacControl = async (
     switch (action) {
       case "launchSystem": {
         if (!system) {
-          context.addToolResult({
+          context.addToolOutput({
             tool: "infiniteMacControl",
             toolCallId,
             state: "output-error",
@@ -140,7 +140,7 @@ export const handleInfiniteMacControl = async (
             year: p.year,
             description: p.description,
           }));
-          context.addToolResult({
+          context.addToolOutput({
             tool: "infiniteMacControl",
             toolCallId,
             state: "output-error",
@@ -165,13 +165,13 @@ export const handleInfiniteMacControl = async (
         const loaded = await waitForEmulatorLoaded(45000);
 
         if (loaded) {
-          context.addToolResult({
+          context.addToolOutput({
             tool: "infiniteMacControl",
             toolCallId,
             output: `Successfully launched ${preset.name} (${preset.year}). ${preset.description}. Screen size: ${preset.screenSize.width}x${preset.screenSize.height}. Use 'readScreen' to see the current display.`,
           });
         } else {
-          context.addToolResult({
+          context.addToolOutput({
             tool: "infiniteMacControl",
             toolCallId,
             output: `Launched ${preset.name} - the emulator is loading. It may take a few moments to fully boot. Use 'getStatus' to check when it's ready, or 'readScreen' to see the current display.`,
@@ -202,13 +202,13 @@ export const handleInfiniteMacControl = async (
         };
 
         if (!selectedPreset) {
-          context.addToolResult({
+          context.addToolOutput({
             tool: "infiniteMacControl",
             toolCallId,
             output: `No system is currently running. Use 'launchSystem' to start a Mac OS. Available systems: ${MAC_PRESETS.map((p) => `${p.id} (${p.name}, ${p.year})`).join(", ")}`,
           });
         } else {
-          context.addToolResult({
+          context.addToolOutput({
             tool: "infiniteMacControl",
             toolCallId,
             output: `Emulator status: ${JSON.stringify(status, null, 2)}`,
@@ -221,7 +221,7 @@ export const handleInfiniteMacControl = async (
         const { isEmulatorLoaded, selectedPreset, getScreenAsBase64 } = store;
 
         if (!selectedPreset) {
-          context.addToolResult({
+          context.addToolOutput({
             tool: "infiniteMacControl",
             toolCallId,
             state: "output-error",
@@ -231,7 +231,7 @@ export const handleInfiniteMacControl = async (
         }
 
         if (!isEmulatorLoaded) {
-          context.addToolResult({
+          context.addToolOutput({
             tool: "infiniteMacControl",
             toolCallId,
             state: "output-error",
@@ -243,7 +243,7 @@ export const handleInfiniteMacControl = async (
         const screenBase64 = await getScreenAsBase64();
 
         if (!screenBase64) {
-          context.addToolResult({
+          context.addToolOutput({
             tool: "infiniteMacControl",
             toolCallId,
             state: "output-error",
@@ -268,7 +268,7 @@ export const handleInfiniteMacControl = async (
           ? `Coordinates are 1:1 with the screenshot - use pixel positions directly from the image.`
           : `This Mac OS X system uses relative coordinates only - mouse control may be limited.`;
 
-        context.addToolResult({
+        context.addToolOutput({
           tool: "infiniteMacControl",
           toolCallId,
           output: {
@@ -288,7 +288,7 @@ export const handleInfiniteMacControl = async (
 
       case "mouseMove": {
         if (x === undefined || y === undefined) {
-          context.addToolResult({
+          context.addToolOutput({
             tool: "infiniteMacControl",
             toolCallId,
             state: "output-error",
@@ -298,7 +298,7 @@ export const handleInfiniteMacControl = async (
         }
 
         if (!store.isEmulatorLoaded || !store.selectedPreset) {
-          context.addToolResult({
+          context.addToolOutput({
             tool: "infiniteMacControl",
             toolCallId,
             state: "output-error",
@@ -309,7 +309,7 @@ export const handleInfiniteMacControl = async (
 
         // Check if this system supports absolute coordinates
         if (!supportsAbsoluteCoordinates(store.selectedPreset.id)) {
-          context.addToolResult({
+          context.addToolOutput({
             tool: "infiniteMacControl",
             toolCallId,
             state: "output-error",
@@ -327,13 +327,13 @@ export const handleInfiniteMacControl = async (
         });
 
         if (moveSent) {
-          context.addToolResult({
+          context.addToolOutput({
             tool: "infiniteMacControl",
             toolCallId,
             output: `Mouse moved to (${x}, ${y})`,
           });
         } else {
-          context.addToolResult({
+          context.addToolOutput({
             tool: "infiniteMacControl",
             toolCallId,
             state: "output-error",
@@ -345,7 +345,7 @@ export const handleInfiniteMacControl = async (
 
       case "mouseClick": {
         if (x === undefined || y === undefined) {
-          context.addToolResult({
+          context.addToolOutput({
             tool: "infiniteMacControl",
             toolCallId,
             state: "output-error",
@@ -355,7 +355,7 @@ export const handleInfiniteMacControl = async (
         }
 
         if (!store.isEmulatorLoaded || !store.selectedPreset) {
-          context.addToolResult({
+          context.addToolOutput({
             tool: "infiniteMacControl",
             toolCallId,
             state: "output-error",
@@ -366,7 +366,7 @@ export const handleInfiniteMacControl = async (
 
         // Check if this system supports absolute coordinates
         if (!supportsAbsoluteCoordinates(store.selectedPreset.id)) {
-          context.addToolResult({
+          context.addToolOutput({
             tool: "infiniteMacControl",
             toolCallId,
             state: "output-error",
@@ -403,13 +403,13 @@ export const handleInfiniteMacControl = async (
         });
 
         if (upSent) {
-          context.addToolResult({
+          context.addToolOutput({
             tool: "infiniteMacControl",
             toolCallId,
             output: `${button === "right" ? "Right-" : ""}Clicked at (${x}, ${y})`,
           });
         } else {
-          context.addToolResult({
+          context.addToolOutput({
             tool: "infiniteMacControl",
             toolCallId,
             state: "output-error",
@@ -421,7 +421,7 @@ export const handleInfiniteMacControl = async (
 
       case "doubleClick": {
         if (x === undefined || y === undefined) {
-          context.addToolResult({
+          context.addToolOutput({
             tool: "infiniteMacControl",
             toolCallId,
             state: "output-error",
@@ -431,7 +431,7 @@ export const handleInfiniteMacControl = async (
         }
 
         if (!store.isEmulatorLoaded || !store.selectedPreset) {
-          context.addToolResult({
+          context.addToolOutput({
             tool: "infiniteMacControl",
             toolCallId,
             state: "output-error",
@@ -442,7 +442,7 @@ export const handleInfiniteMacControl = async (
 
         // Check if this system supports absolute coordinates
         if (!supportsAbsoluteCoordinates(store.selectedPreset.id)) {
-          context.addToolResult({
+          context.addToolOutput({
             tool: "infiniteMacControl",
             toolCallId,
             state: "output-error",
@@ -489,13 +489,13 @@ export const handleInfiniteMacControl = async (
         });
 
         if (dblUpSent) {
-          context.addToolResult({
+          context.addToolOutput({
             tool: "infiniteMacControl",
             toolCallId,
             output: `Double-clicked at (${x}, ${y})`,
           });
         } else {
-          context.addToolResult({
+          context.addToolOutput({
             tool: "infiniteMacControl",
             toolCallId,
             state: "output-error",
@@ -507,7 +507,7 @@ export const handleInfiniteMacControl = async (
 
       case "keyPress": {
         if (!key) {
-          context.addToolResult({
+          context.addToolOutput({
             tool: "infiniteMacControl",
             toolCallId,
             state: "output-error",
@@ -517,7 +517,7 @@ export const handleInfiniteMacControl = async (
         }
 
         if (!store.isEmulatorLoaded) {
-          context.addToolResult({
+          context.addToolOutput({
             tool: "infiniteMacControl",
             toolCallId,
             state: "output-error",
@@ -542,13 +542,13 @@ export const handleInfiniteMacControl = async (
         });
 
         if (keyUpSent) {
-          context.addToolResult({
+          context.addToolOutput({
             tool: "infiniteMacControl",
             toolCallId,
             output: `Key pressed: ${key}`,
           });
         } else {
-          context.addToolResult({
+          context.addToolOutput({
             tool: "infiniteMacControl",
             toolCallId,
             state: "output-error",
@@ -560,7 +560,7 @@ export const handleInfiniteMacControl = async (
 
       case "pause": {
         if (!store.isEmulatorLoaded) {
-          context.addToolResult({
+          context.addToolOutput({
             tool: "infiniteMacControl",
             toolCallId,
             state: "output-error",
@@ -573,13 +573,13 @@ export const handleInfiniteMacControl = async (
         store.setIsPaused(true);
 
         if (pauseSent) {
-          context.addToolResult({
+          context.addToolOutput({
             tool: "infiniteMacControl",
             toolCallId,
             output: "Emulator paused.",
           });
         } else {
-          context.addToolResult({
+          context.addToolOutput({
             tool: "infiniteMacControl",
             toolCallId,
             state: "output-error",
@@ -591,7 +591,7 @@ export const handleInfiniteMacControl = async (
 
       case "unpause": {
         if (!store.isEmulatorLoaded) {
-          context.addToolResult({
+          context.addToolOutput({
             tool: "infiniteMacControl",
             toolCallId,
             state: "output-error",
@@ -604,13 +604,13 @@ export const handleInfiniteMacControl = async (
         store.setIsPaused(false);
 
         if (unpauseSent) {
-          context.addToolResult({
+          context.addToolOutput({
             tool: "infiniteMacControl",
             toolCallId,
             output: "Emulator unpaused.",
           });
         } else {
-          context.addToolResult({
+          context.addToolOutput({
             tool: "infiniteMacControl",
             toolCallId,
             state: "output-error",
@@ -621,7 +621,7 @@ export const handleInfiniteMacControl = async (
       }
 
       default:
-        context.addToolResult({
+        context.addToolOutput({
           tool: "infiniteMacControl",
           toolCallId,
           state: "output-error",
@@ -630,7 +630,7 @@ export const handleInfiniteMacControl = async (
     }
   } catch (error) {
     console.error("[infiniteMacControl] Error:", error);
-    context.addToolResult({
+    context.addToolOutput({
       tool: "infiniteMacControl",
       toolCallId,
       state: "output-error",

--- a/src/apps/chats/tools/ipodHandler.ts
+++ b/src/apps/chats/tools/ipodHandler.ts
@@ -121,7 +121,7 @@ const handlePlaybackState = (
     if (stateChanges.length > 0) {
       resultParts.push(...stateChanges);
     }
-    context.addToolResult({
+    context.addToolOutput({
       tool: "ipodControl",
       toolCallId,
       output: buildResultMessage(resultParts),
@@ -164,7 +164,7 @@ const handlePlaybackState = (
   }
 
   const resultParts = [playbackState, ...stateChanges];
-  context.addToolResult({
+  context.addToolOutput({
     tool: "ipodControl",
     toolCallId,
     output: buildResultMessage(resultParts),
@@ -229,7 +229,7 @@ const handlePlayKnown = (
 
   if (finalCandidateIndices.length === 0) {
     const errorMsg = i18n.t("apps.chats.toolCalls.ipodSongNotFound");
-    context.addToolResult({
+    context.addToolOutput({
       tool: "ipodControl",
       toolCallId,
       output: errorMsg,
@@ -244,7 +244,7 @@ const handlePlayKnown = (
   const track = tracks[randomIndexFromArray];
   if (!track) {
     const errorMsg = i18n.t("apps.chats.toolCalls.ipodSongNotFound");
-    context.addToolResult({
+    context.addToolOutput({
       tool: "ipodControl",
       toolCallId,
       output: errorMsg,
@@ -269,7 +269,7 @@ const handlePlayKnown = (
     if (stateChanges.length > 0) {
       resultParts.push(...stateChanges);
     }
-    context.addToolResult({
+    context.addToolOutput({
       tool: "ipodControl",
       toolCallId,
       output: buildResultMessage(resultParts),
@@ -291,7 +291,7 @@ const handlePlayKnown = (
     : i18n.t("apps.chats.toolCalls.playing", { title: track.title });
 
   const resultParts = [trackDescForMsg, ...stateChanges];
-  context.addToolResult({
+  context.addToolOutput({
     tool: "ipodControl",
     toolCallId,
     output: buildResultMessage(resultParts),
@@ -314,7 +314,7 @@ const handleAddAndPlay = async (
   if (!id) {
     const errorMsg =
       "The 'addAndPlay' action requires the 'id' parameter (YouTube ID or URL).";
-    context.addToolResult({
+    context.addToolOutput({
       tool: "ipodControl",
       toolCallId,
       output: errorMsg,
@@ -326,7 +326,7 @@ const handleAddAndPlay = async (
   if (id.startsWith("am:")) {
     const errorMsg =
       "Apple Music tracks are already in the active library. Use playKnown with the Apple Music track ID instead of addAndPlay.";
-    context.addToolResult({
+    context.addToolOutput({
       tool: "ipodControl",
       toolCallId,
       output: errorMsg,
@@ -357,7 +357,7 @@ const handleAddAndPlay = async (
         resultParts.push(...stateChanges);
       }
 
-      context.addToolResult({
+      context.addToolOutput({
         tool: "ipodControl",
         toolCallId,
         output: buildResultMessage(resultParts),
@@ -370,7 +370,7 @@ const handleAddAndPlay = async (
       );
     } else {
       const errorMsg = i18n.t("apps.chats.toolCalls.ipodFailedToAdd", { id });
-      context.addToolResult({
+      context.addToolOutput({
         tool: "ipodControl",
         toolCallId,
         output: errorMsg,
@@ -391,7 +391,7 @@ const handleAddAndPlay = async (
       });
     }
 
-    context.addToolResult({
+    context.addToolOutput({
       tool: "ipodControl",
       toolCallId,
       output: errorMsg,
@@ -428,7 +428,7 @@ const handleNavigation = (
     if (stateChanges.length > 0) {
       resultParts.push(...stateChanges);
     }
-    context.addToolResult({
+    context.addToolOutput({
       tool: "ipodControl",
       toolCallId,
       output: buildResultMessage(resultParts),
@@ -447,7 +447,7 @@ const handleNavigation = (
   if (stateChanges.length > 0) {
     resultParts.push(...stateChanges);
   }
-  context.addToolResult({
+  context.addToolOutput({
     tool: "ipodControl",
     toolCallId,
     output: buildResultMessage(resultParts),
@@ -507,7 +507,7 @@ export const handleIpodControl = async (
   const stateChanges = applyIpodSettings(enableVideo, enableTranslation, enableFullscreen);
 
   if (stateChanges.length > 0) {
-    context.addToolResult({
+    context.addToolOutput({
       tool: "ipodControl",
       toolCallId,
       output: buildResultMessage(stateChanges),
@@ -517,7 +517,7 @@ export const handleIpodControl = async (
 
   // Always resolve the tool call to prevent hangs
   console.warn(`[ToolCall] ipodControl: Unhandled action "${normalizedAction}".`);
-  context.addToolResult({
+  context.addToolOutput({
     tool: "ipodControl",
     toolCallId,
     state: "output-error",

--- a/src/apps/chats/tools/karaokeHandler.ts
+++ b/src/apps/chats/tools/karaokeHandler.ts
@@ -221,7 +221,7 @@ const handlePlaybackState = (
     if (stateChanges.length > 0) {
       resultParts.push(...stateChanges);
     }
-    context.addToolResult({
+    context.addToolOutput({
       tool: "karaokeControl",
       toolCallId,
       output: buildResultMessage(resultParts),
@@ -269,7 +269,7 @@ const handlePlaybackState = (
   }
 
   const resultParts = [playbackState, ...stateChanges];
-  context.addToolResult({
+  context.addToolOutput({
     tool: "karaokeControl",
     toolCallId,
     output: buildResultMessage(resultParts),
@@ -345,7 +345,7 @@ const handlePlayKnown = (
     const errorMsg = i18n.t("apps.chats.toolCalls.karaokeSongNotFound", {
       defaultValue: "Could not find the requested song in the library",
     });
-    context.addToolResult({
+    context.addToolOutput({
       tool: "karaokeControl",
       toolCallId,
       output: errorMsg,
@@ -374,7 +374,7 @@ const handlePlayKnown = (
     if (stateChanges.length > 0) {
       resultParts.push(...stateChanges);
     }
-    context.addToolResult({
+    context.addToolOutput({
       tool: "karaokeControl",
       toolCallId,
       output: buildResultMessage(resultParts),
@@ -391,7 +391,7 @@ const handlePlayKnown = (
     : i18n.t("apps.chats.toolCalls.playing", { title: track.title });
 
   const resultParts = [trackDescForMsg, ...stateChanges];
-  context.addToolResult({
+  context.addToolOutput({
     tool: "karaokeControl",
     toolCallId,
     output: buildResultMessage(resultParts),
@@ -415,7 +415,7 @@ const handleAddAndPlay = async (
     const errorMsg = i18n.t("apps.chats.toolCalls.karaokeNoIdProvided", {
       defaultValue: "No YouTube ID or URL provided for addAndPlay",
     });
-    context.addToolResult({
+    context.addToolOutput({
       tool: "karaokeControl",
       toolCallId,
       output: errorMsg,
@@ -458,7 +458,7 @@ const handleAddAndPlay = async (
         resultParts.push(...stateChanges);
       }
 
-      context.addToolResult({
+      context.addToolOutput({
         tool: "karaokeControl",
         toolCallId,
         output: buildResultMessage(resultParts),
@@ -474,7 +474,7 @@ const handleAddAndPlay = async (
         id,
         defaultValue: `Failed to add ${id} to library`,
       });
-      context.addToolResult({
+      context.addToolOutput({
         tool: "karaokeControl",
         toolCallId,
         output: errorMsg,
@@ -499,7 +499,7 @@ const handleAddAndPlay = async (
       });
     }
 
-    context.addToolResult({
+    context.addToolOutput({
       tool: "karaokeControl",
       toolCallId,
       output: errorMsg,
@@ -543,7 +543,7 @@ const handleNavigation = (
     if (stateChanges.length > 0) {
       resultParts.push(...stateChanges);
     }
-    context.addToolResult({
+    context.addToolOutput({
       tool: "karaokeControl",
       toolCallId,
       output: buildResultMessage(resultParts),
@@ -561,7 +561,7 @@ const handleNavigation = (
   if (stateChanges.length > 0) {
     resultParts.push(...stateChanges);
   }
-  context.addToolResult({
+  context.addToolOutput({
     tool: "karaokeControl",
     toolCallId,
     output: buildResultMessage(resultParts),
@@ -616,7 +616,7 @@ export const handleKaraokeControl = async (
   const stateChanges = applyKaraokeSettings(enableTranslation, enableFullscreen);
 
   if (stateChanges.length > 0) {
-    context.addToolResult({
+    context.addToolOutput({
       tool: "karaokeControl",
       toolCallId,
       output: buildResultMessage(stateChanges),
@@ -626,7 +626,7 @@ export const handleKaraokeControl = async (
 
   // Always resolve the tool call to prevent hangs
   console.warn(`[ToolCall] karaokeControl: Unhandled action "${normalizedAction}".`);
-  context.addToolResult({
+  context.addToolOutput({
     tool: "karaokeControl",
     toolCallId,
     state: "output-error",

--- a/src/apps/chats/tools/settingsHandler.ts
+++ b/src/apps/chats/tools/settingsHandler.ts
@@ -120,13 +120,13 @@ export const handleSettings = (
   if (changes.length > 0) {
     const resultMessage =
       changes.length === 1 ? changes[0] : changes.join(". ") + ".";
-    context.addToolResult({
+    context.addToolOutput({
       tool: "settings",
       toolCallId,
       output: resultMessage,
     });
   } else {
-    context.addToolResult({
+    context.addToolOutput({
       tool: "settings",
       toolCallId,
       output: i18n.t("apps.chats.toolCalls.settingsNoChanges"),

--- a/src/apps/chats/tools/stickiesHandler.ts
+++ b/src/apps/chats/tools/stickiesHandler.ts
@@ -51,7 +51,7 @@ export const handleStickiesControl = (
         const notes = store.notes;
         if (notes.length === 0) {
           stickyIdMap = undefined;
-          context.addToolResult({ tool: "stickiesControl", toolCallId, output: i18n.t("apps.chats.toolCalls.stickies.noStickies") });
+          context.addToolOutput({ tool: "stickiesControl", toolCallId, output: i18n.t("apps.chats.toolCalls.stickies.noStickies") });
           return;
         }
         // Create short ID mapping for efficient AI communication
@@ -64,7 +64,7 @@ export const handleStickiesControl = (
           position: n.position,
           size: n.size,
         }));
-        context.addToolResult({ 
+        context.addToolOutput({ 
           tool: "stickiesControl", 
           toolCallId, 
           output: `${i18n.t("apps.chats.toolCalls.stickies.foundStickies", { count: notes.length })}:\n${JSON.stringify(notesData, null, 2)}` 
@@ -84,7 +84,7 @@ export const handleStickiesControl = (
         }
         const colorKey = color || "yellow";
         const translatedColor = i18n.t(`common.colors.${colorKey}`);
-        context.addToolResult({ 
+        context.addToolOutput({ 
           tool: "stickiesControl", 
           toolCallId, 
           output: i18n.t("apps.chats.toolCalls.stickies.createdWithColor", { color: translatedColor }) 
@@ -94,13 +94,13 @@ export const handleStickiesControl = (
 
       case "update": {
         if (!id) {
-          context.addToolResult({ tool: "stickiesControl", toolCallId, state: "output-error", errorText: i18n.t("apps.chats.toolCalls.stickies.missingId") });
+          context.addToolOutput({ tool: "stickiesControl", toolCallId, state: "output-error", errorText: i18n.t("apps.chats.toolCalls.stickies.missingId") });
           return;
         }
         // Resolve short ID to full UUID if mapping exists
         const resolvedId = resolveId(id, stickyIdMap);
         if (!store.notes.find((n) => n.id === resolvedId)) {
-          context.addToolResult({ tool: "stickiesControl", toolCallId, state: "output-error", errorText: i18n.t("apps.chats.toolCalls.stickies.notFound", { id }) });
+          context.addToolOutput({ tool: "stickiesControl", toolCallId, state: "output-error", errorText: i18n.t("apps.chats.toolCalls.stickies.notFound", { id }) });
           return;
         }
         const updates: Record<string, unknown> = {};
@@ -109,49 +109,49 @@ export const handleStickiesControl = (
         if (position !== undefined) updates.position = position;
         if (size !== undefined) updates.size = size;
         if (Object.keys(updates).length === 0) {
-          context.addToolResult({ tool: "stickiesControl", toolCallId, state: "output-error", errorText: i18n.t("apps.chats.toolCalls.stickies.noUpdates") });
+          context.addToolOutput({ tool: "stickiesControl", toolCallId, state: "output-error", errorText: i18n.t("apps.chats.toolCalls.stickies.noUpdates") });
           return;
         }
         store.updateNote(resolvedId, updates);
-        context.addToolResult({ tool: "stickiesControl", toolCallId, output: i18n.t("apps.chats.toolCalls.stickies.updated") });
+        context.addToolOutput({ tool: "stickiesControl", toolCallId, output: i18n.t("apps.chats.toolCalls.stickies.updated") });
         break;
       }
 
       case "delete": {
         if (!id) {
-          context.addToolResult({ tool: "stickiesControl", toolCallId, state: "output-error", errorText: i18n.t("apps.chats.toolCalls.stickies.missingId") });
+          context.addToolOutput({ tool: "stickiesControl", toolCallId, state: "output-error", errorText: i18n.t("apps.chats.toolCalls.stickies.missingId") });
           return;
         }
         // Resolve short ID to full UUID if mapping exists
         const resolvedId = resolveId(id, stickyIdMap);
         if (!store.notes.find((n) => n.id === resolvedId)) {
-          context.addToolResult({ tool: "stickiesControl", toolCallId, state: "output-error", errorText: i18n.t("apps.chats.toolCalls.stickies.notFound", { id }) });
+          context.addToolOutput({ tool: "stickiesControl", toolCallId, state: "output-error", errorText: i18n.t("apps.chats.toolCalls.stickies.notFound", { id }) });
           return;
         }
         store.deleteNote(resolvedId);
-        context.addToolResult({ tool: "stickiesControl", toolCallId, output: i18n.t("apps.chats.toolCalls.stickies.deleted") });
+        context.addToolOutput({ tool: "stickiesControl", toolCallId, output: i18n.t("apps.chats.toolCalls.stickies.deleted") });
         break;
       }
 
       case "clear": {
         const count = store.notes.length;
         if (count === 0) {
-          context.addToolResult({ tool: "stickiesControl", toolCallId, output: i18n.t("apps.chats.toolCalls.stickies.nothingToClear") });
+          context.addToolOutput({ tool: "stickiesControl", toolCallId, output: i18n.t("apps.chats.toolCalls.stickies.nothingToClear") });
           return;
         }
         store.clearAllNotes();
         // Clear the ID mapping since all notes are removed
         stickyIdMap = undefined;
-        context.addToolResult({ tool: "stickiesControl", toolCallId, output: i18n.t("apps.chats.toolCalls.stickies.cleared", { count }) });
+        context.addToolOutput({ tool: "stickiesControl", toolCallId, output: i18n.t("apps.chats.toolCalls.stickies.cleared", { count }) });
         break;
       }
 
       default:
-        context.addToolResult({ tool: "stickiesControl", toolCallId, state: "output-error", errorText: i18n.t("apps.chats.toolCalls.stickies.invalidAction", { action }) });
+        context.addToolOutput({ tool: "stickiesControl", toolCallId, state: "output-error", errorText: i18n.t("apps.chats.toolCalls.stickies.invalidAction", { action }) });
     }
   } catch (error) {
     console.error("[stickiesControl] Error:", error);
-    context.addToolResult({
+    context.addToolOutput({
       tool: "stickiesControl",
       toolCallId,
       state: "output-error",

--- a/src/apps/chats/tools/tvHandler.ts
+++ b/src/apps/chats/tools/tvHandler.ts
@@ -253,7 +253,7 @@ export const handleTvControl = async (
           count: channels.length,
         });
 
-        context.addToolResult({
+        context.addToolOutput({
           tool: "tvControl",
           toolCallId,
           output: { success: true, message, channels },
@@ -277,7 +277,7 @@ export const handleTvControl = async (
         }
 
         if (!target) {
-          context.addToolResult({
+          context.addToolOutput({
             tool: "tvControl",
             toolCallId,
             state: "output-error",
@@ -296,7 +296,7 @@ export const handleTvControl = async (
         const shortId =
           tvChannelIdMap?.fullToShort.get(target.id) ?? target.id;
 
-        context.addToolResult({
+        context.addToolOutput({
           tool: "tvControl",
           toolCallId,
           output: {
@@ -320,7 +320,7 @@ export const handleTvControl = async (
       case "createChannel": {
         const prompt = input.prompt?.trim();
         if (!prompt) {
-          context.addToolResult({
+          context.addToolOutput({
             tool: "tvControl",
             toolCallId,
             state: "output-error",
@@ -380,7 +380,7 @@ export const handleTvControl = async (
                 i18n.t("apps.chats.toolCalls.tv.createFailed", {
                   defaultValue: "Failed to plan channel",
                 });
-            context.addToolResult({
+            context.addToolOutput({
               tool: "tvControl",
               toolCallId,
               state: "output-error",
@@ -396,7 +396,7 @@ export const handleTvControl = async (
             videos?: Video[];
           };
           if (!raw?.videos?.length || !raw?.name) {
-            context.addToolResult({
+            context.addToolOutput({
               tool: "tvControl",
               toolCallId,
               state: "output-error",
@@ -415,7 +415,7 @@ export const handleTvControl = async (
           };
         } catch (err) {
           console.error("[tvControl] create-channel API failed:", err);
-          context.addToolResult({
+          context.addToolOutput({
             tool: "tvControl",
             toolCallId,
             state: "output-error",
@@ -433,7 +433,7 @@ export const handleTvControl = async (
         // only return YouTube videos but the user's data ends up in the store).
         const safeVideos = planned.videos.filter((v) => isYouTubeUrl(v.url));
         if (safeVideos.length === 0) {
-          context.addToolResult({
+          context.addToolOutput({
             tool: "tvControl",
             toolCallId,
             state: "output-error",
@@ -460,7 +460,7 @@ export const handleTvControl = async (
           useTvStore.getState().hiddenDefaultChannelIds
         ).find((c) => c.id === created.id);
         if (!createdListed) {
-          context.addToolResult({
+          context.addToolOutput({
             tool: "tvControl",
             toolCallId,
             state: "output-error",
@@ -478,7 +478,7 @@ export const handleTvControl = async (
           count: safeVideos.length,
         });
 
-        context.addToolResult({
+        context.addToolOutput({
           tool: "tvControl",
           toolCallId,
           output: {
@@ -498,7 +498,7 @@ export const handleTvControl = async (
 
       case "deleteChannel": {
         if (!input.channelId) {
-          context.addToolResult({
+          context.addToolOutput({
             tool: "tvControl",
             toolCallId,
             state: "output-error",
@@ -511,7 +511,7 @@ export const handleTvControl = async (
         const resolvedId = resolveChannelId(input.channelId);
         const targetListed = findChannel(resolvedId);
         if (!targetListed) {
-          context.addToolResult({
+          context.addToolOutput({
             tool: "tvControl",
             toolCallId,
             state: "output-error",
@@ -522,7 +522,7 @@ export const handleTvControl = async (
           return;
         }
         useTvStore.getState().removeChannel(resolvedId);
-        context.addToolResult({
+        context.addToolOutput({
           tool: "tvControl",
           toolCallId,
           output: {
@@ -538,7 +538,7 @@ export const handleTvControl = async (
 
       case "addVideo": {
         if (!input.channelId) {
-          context.addToolResult({
+          context.addToolOutput({
             tool: "tvControl",
             toolCallId,
             state: "output-error",
@@ -550,7 +550,7 @@ export const handleTvControl = async (
         }
         const resolvedId = resolveChannelId(input.channelId);
         if (DEFAULT_CHANNELS.some((c) => c.id === resolvedId)) {
-          context.addToolResult({
+          context.addToolOutput({
             tool: "tvControl",
             toolCallId,
             state: "output-error",
@@ -563,7 +563,7 @@ export const handleTvControl = async (
         }
         const target = findCustomChannel(resolvedId);
         if (!target) {
-          context.addToolResult({
+          context.addToolOutput({
             tool: "tvControl",
             toolCallId,
             state: "output-error",
@@ -581,7 +581,7 @@ export const handleTvControl = async (
           artist: input.artist,
         });
         if ("error" in resolvedVideo) {
-          context.addToolResult({
+          context.addToolOutput({
             tool: "tvControl",
             toolCallId,
             state: "output-error",
@@ -596,7 +596,7 @@ export const handleTvControl = async (
           .addVideoToCustomChannel(resolvedId, resolvedVideo.video);
 
         if (!result.added) {
-          context.addToolResult({
+          context.addToolOutput({
             tool: "tvControl",
             toolCallId,
             output: {
@@ -612,7 +612,7 @@ export const handleTvControl = async (
           return;
         }
 
-        context.addToolResult({
+        context.addToolOutput({
           tool: "tvControl",
           toolCallId,
           output: {
@@ -630,7 +630,7 @@ export const handleTvControl = async (
 
       case "removeVideo": {
         if (!input.channelId) {
-          context.addToolResult({
+          context.addToolOutput({
             tool: "tvControl",
             toolCallId,
             state: "output-error",
@@ -641,7 +641,7 @@ export const handleTvControl = async (
           return;
         }
         if (!input.removeVideoId) {
-          context.addToolResult({
+          context.addToolOutput({
             tool: "tvControl",
             toolCallId,
             state: "output-error",
@@ -653,7 +653,7 @@ export const handleTvControl = async (
         }
         const resolvedId = resolveChannelId(input.channelId);
         if (DEFAULT_CHANNELS.some((c) => c.id === resolvedId)) {
-          context.addToolResult({
+          context.addToolOutput({
             tool: "tvControl",
             toolCallId,
             state: "output-error",
@@ -666,7 +666,7 @@ export const handleTvControl = async (
         }
         const target = findCustomChannel(resolvedId);
         if (!target) {
-          context.addToolResult({
+          context.addToolOutput({
             tool: "tvControl",
             toolCallId,
             state: "output-error",
@@ -684,7 +684,7 @@ export const handleTvControl = async (
           .removeVideoFromCustomChannel(resolvedId, removeId);
 
         if (!result.removed) {
-          context.addToolResult({
+          context.addToolOutput({
             tool: "tvControl",
             toolCallId,
             state: "output-error",
@@ -695,7 +695,7 @@ export const handleTvControl = async (
           return;
         }
 
-        context.addToolResult({
+        context.addToolOutput({
           tool: "tvControl",
           toolCallId,
           output: {
@@ -712,7 +712,7 @@ export const handleTvControl = async (
       }
 
       default:
-        context.addToolResult({
+        context.addToolOutput({
           tool: "tvControl",
           toolCallId,
           state: "output-error",
@@ -724,7 +724,7 @@ export const handleTvControl = async (
     }
   } catch (error) {
     console.error("[tvControl] Error:", error);
-    context.addToolResult({
+    context.addToolOutput({
       tool: "tvControl",
       toolCallId,
       state: "output-error",

--- a/src/apps/chats/tools/types.ts
+++ b/src/apps/chats/tools/types.ts
@@ -1,27 +1,9 @@
-/**
- * Tool Handler Types
- *
- * This module defines the types used by the tool handler registry pattern.
- * The goal is to enable extracting tool handlers from the monolithic useAiChat hook
- * into individual, testable modules.
- */
-
-/**
- * Context provided to all tool handlers
- */
 export interface ToolContext {
-  /** Function to launch an app by ID */
   launchApp: (appId: string, options?: { initialData?: unknown; multiWindow?: boolean }) => string;
-  /** Function to add tool output back to the chat */
   addToolOutput: (result: ToolOutputPayload) => void;
-  /** Detect user's operating system */
   detectUserOS: () => string;
 }
 
-/**
- * Payload for tool outputs
- * Matches the AI SDK's addToolOutput signature
- */
 export type ToolOutputPayload =
   | {
       state?: "output-available";
@@ -38,21 +20,13 @@ export type ToolOutputPayload =
       errorText: string;
     };
 
-/**
- * Tool handler function signature
- */
 export type ToolHandler<T = unknown> = (
   input: T,
   toolCallId: string,
   context: ToolContext
 ) => Promise<void> | void;
 
-/**
- * Tool handler registry entry
- */
 export interface ToolHandlerEntry<T = unknown> {
-  /** Handler function */
   handler: ToolHandler<T>;
-  /** Tool name for matching */
   toolName: string;
 }

--- a/src/apps/chats/tools/types.ts
+++ b/src/apps/chats/tools/types.ts
@@ -12,17 +12,17 @@
 export interface ToolContext {
   /** Function to launch an app by ID */
   launchApp: (appId: string, options?: { initialData?: unknown; multiWindow?: boolean }) => string;
-  /** Function to add tool result back to the chat */
-  addToolResult: (result: ToolResultPayload) => void;
+  /** Function to add tool output back to the chat */
+  addToolOutput: (result: ToolOutputPayload) => void;
   /** Detect user's operating system */
   detectUserOS: () => string;
 }
 
 /**
- * Payload for tool results
- * Matches the AI SDK's addToolResult signature
+ * Payload for tool outputs
+ * Matches the AI SDK's addToolOutput signature
  */
-export type ToolResultPayload =
+export type ToolOutputPayload =
   | {
       state?: "output-available";
       tool: string;

--- a/tests/test-ipod-apple-music.test.ts
+++ b/tests/test-ipod-apple-music.test.ts
@@ -765,7 +765,7 @@ describe("useIpodStore Apple Music slice", () => {
       "call-1",
       {
         launchApp: () => "ipod-instance",
-        addToolResult: (result) => results.push(result),
+        addToolOutput: (result) => results.push(result),
         detectUserOS: () => "Linux",
       }
     );
@@ -797,7 +797,7 @@ describe("useIpodStore Apple Music slice", () => {
       "call-2",
       {
         launchApp: () => "ipod-instance",
-        addToolResult: () => {},
+        addToolOutput: () => {},
         detectUserOS: () => "Linux",
       }
     );
@@ -837,7 +837,7 @@ describe("useIpodStore Apple Music slice", () => {
       "call-karaoke-1",
       {
         launchApp: () => "karaoke-instance",
-        addToolResult: (result) => results.push(result),
+        addToolOutput: (result) => results.push(result),
         detectUserOS: () => "Linux",
       }
     );

--- a/tests/test-telegram-heartbeat.test.ts
+++ b/tests/test-telegram-heartbeat.test.ts
@@ -30,8 +30,10 @@ import {
   TELEGRAM_HEARTBEAT_TOPIC,
   TELEGRAM_HEARTBEAT_TARGET_USERNAME,
 } from "../api/_utils/telegram-heartbeat";
-import { TELEGRAM_DEFAULT_MODEL } from "../api/_utils/_aiModels.js";
-import { getTelegramModel } from "../api/cron/telegram-heartbeat.js";
+import {
+  TELEGRAM_DEFAULT_MODEL,
+  getTelegramModel,
+} from "../api/_utils/_aiModels.js";
 import { prepareRyoConversationModelInput } from "../api/_utils/ryo-conversation";
 
 class FakeRedis {

--- a/tests/test-telegram-webhook-model.test.ts
+++ b/tests/test-telegram-webhook-model.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from "bun:test";
-import { TELEGRAM_DEFAULT_MODEL } from "../api/_utils/_aiModels.js";
-import { getTelegramModel } from "../api/webhooks/telegram.js";
+import {
+  TELEGRAM_DEFAULT_MODEL,
+  getTelegramModel,
+} from "../api/_utils/_aiModels.js";
 
 describe("telegram webhook model selection", () => {
   test("defaults to gpt-5.5 when TELEGRAM_BOT_MODEL is unset", () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add a shared ryOS `ToolLoopAgent` factory for chat and Telegram agent loops.
- Migrate main chat, Telegram webhook, and Telegram heartbeat tool loops from direct `streamText` orchestration to `ToolLoopAgent`.
- Centralize agent presets (`chat`, `telegram`, `telegramHeartbeat`) plus provider options/Anthropic headers in the shared agent factory.
- Carry `modelId` in prepared conversations so agent callers pass one prepared object instead of parallel model/tool arguments.
- Move duplicate Telegram model selection into `_aiModels` and reuse it from webhook, heartbeat, and tests.
- Preserve the legacy `claude-sonnet` chat model query alias by normalizing it to `sonnet-4.6`.
- Align client-side tool continuation with current AI SDK docs by using `addToolOutput` instead of deprecated `addToolResult`.
- Trim verbose chat tool comments and replace repeated server-tool no-op switch cases with one shared server-executed tool set.

### Testing
- `bun test tests/test-telegram-webhook-model.test.ts tests/test-telegram-heartbeat.test.ts tests/test-telegram-status.test.ts tests/test-ryo-conversation-prompt-caching.test.ts tests/test-ryo-conversation-web-search.test.ts`
- `bun test tests/test-chat-notification-logic.test.ts tests/test-chat-notification-integration-wiring.test.ts tests/test-chat-broadcast-wiring.test.ts tests/test-chat-hook-channel-lifecycle-wiring.test.ts tests/test-chat-store-guards-wiring.test.ts tests/test-pusher-client-refcount.test.ts tests/test-pusher-client-constructor-wiring.test.ts tests/test-ipod-apple-music.test.ts`
- `bun run test:ai` (with `bun run dev:api` running)
- `bun run test:unit`
- `bun run build`

### Notes
- `bun run test:chat-wiring` currently does not match files in this environment, so the equivalent explicit chat/Pusher wiring test files were run directly.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019e9c71-1aa8-7de9-a5a7-28d8a65ae612"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019e9c71-1aa8-7de9-a5a7-28d8a65ae612"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

