### PR TITLE
Fix themed icon React cleanup warning

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -143,7 +143,13 @@ export function App() {
     if (isFirstBoot) {
       setHasBooted();
     }
-  }, [isFirstBoot, setHasBooted]);
+  }, [
+    isFirstBoot,
+    setBootDebugMode,
+    setBootScreenMessage,
+    setHasBooted,
+    setShowBootScreen,
+  ]);
 
   // Show download toast for macOS users when new desktop version is available
   // For web: show on first visit and updates

--- a/src/apps/admin/components/admin-app/AdminAppComponent.tsx
+++ b/src/apps/admin/components/admin-app/AdminAppComponent.tsx
@@ -104,20 +104,22 @@ export function AdminAppComponent({
   );
 
   const filteredSongs = useMemo(() => {
-    let list = songs;
-    if (songsFilterByRyoOnly) {
-      list = list.filter((s) => s.createdBy?.toLowerCase() === "ryo");
-    }
-    if (songSearch.length > 0) {
-      list = list.filter(
-        (song) =>
-          song.title.toLowerCase().includes(songSearch.toLowerCase()) ||
-          (song.artist
-            ?.toLowerCase()
-            .includes(songSearch.toLowerCase()) ?? false),
+    const normalizedSearch = songSearch.toLowerCase();
+
+    return songs.filter((song) => {
+      if (songsFilterByRyoOnly && song.createdBy?.toLowerCase() !== "ryo") {
+        return false;
+      }
+
+      if (normalizedSearch.length === 0) {
+        return true;
+      }
+
+      return (
+        song.title.toLowerCase().includes(normalizedSearch) ||
+        (song.artist?.toLowerCase().includes(normalizedSearch) ?? false)
       );
-    }
-    return list;
+    });
   }, [songs, songsFilterByRyoOnly, songSearch]);
 
   const shouldShowImportStatus = getShouldShowAdminImportStatus(

--- a/src/apps/admin/hooks/useAdminLogic.ts
+++ b/src/apps/admin/hooks/useAdminLogic.ts
@@ -106,6 +106,22 @@ function chunkArray<T>(items: T[], chunkSize: number): T[][] {
   return chunks;
 }
 
+function sortAdminUsers(users: User[]): User[] {
+  return [...users].sort((a: User, b: User) => {
+    if (a.banned && !b.banned) return -1;
+    if (!a.banned && b.banned) return 1;
+    return b.lastActive - a.lastActive;
+  });
+}
+
+function filterAdminUsers(users: User[], search: string): User[] {
+  if (search.length === 0) return users;
+  const lowerSearch = search.toLowerCase();
+  return users.filter((user) =>
+    user.username.toLowerCase().includes(lowerSearch)
+  );
+}
+
 interface ExportSongDocument {
   id: string;
   title: string;
@@ -188,10 +204,12 @@ export function useAdminLogic({ isWindowOpen }: UseAdminLogicProps) {
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
   const [deleteTarget, setDeleteTarget] = useState<DeleteTarget | null>(null);
 
+  const [allUsers, setAllUsers] = useState<User[]>([]);
   const [users, setUsers] = useState<User[]>([]);
   const [rooms, setRooms] = useState<Room[]>([]);
   const [roomMessages, setRoomMessages] = useState<Message[]>([]);
   const [userSearch, setUserSearch] = useState("");
+  const userSearchRef = useRef(userSearch);
   const [isLoading, setIsLoading] = useState(false);
   const [visibleUsersCount, setVisibleUsersCount] = useState(USERS_PER_PAGE);
   const [stats, setStats] = useState<Stats>({
@@ -283,9 +301,25 @@ export function useAdminLogic({ isWindowOpen }: UseAdminLogicProps) {
   const [isDeletingAll, setIsDeletingAll] = useState(false);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const importStatusResetTimeoutRef = useRef<number | null>(null);
+  const loadingRequestCountRef = useRef(0);
 
   const isAdmin = useIsRyoAdmin();
   const selectedRoom = rooms.find((r) => r.id === selectedRoomId) || null;
+
+  const beginLoading = useCallback(() => {
+    loadingRequestCountRef.current += 1;
+    setIsLoading(true);
+  }, []);
+
+  const endLoading = useCallback(() => {
+    loadingRequestCountRef.current = Math.max(
+      loadingRequestCountRef.current - 1,
+      0
+    );
+    if (loadingRequestCountRef.current === 0) {
+      setIsLoading(false);
+    }
+  }, []);
 
   const clearImportStatusResetTimer = useCallback(() => {
     if (importStatusResetTimeoutRef.current !== null) {
@@ -347,34 +381,21 @@ export function useAdminLogic({ isWindowOpen }: UseAdminLogicProps) {
       if (!username || !isAuthenticated) return;
       if (isOffline) return; // Skip API calls when offline
 
-      setIsLoading(true);
+      beginLoading();
       try {
         const data = await getAdminUsers<{ users?: User[] }>();
-        // Sort users: banned first, then by most recently active
-        let sortedUsers = (data.users || []).sort((a: User, b: User) => {
-          // Banned users first
-          if (a.banned && !b.banned) return -1;
-          if (!a.banned && b.banned) return 1;
-          // Then by last active (most recent first)
-          return b.lastActive - a.lastActive;
-        });
-        // Filter by search query client-side
-        if (search.length > 0) {
-          const lowerSearch = search.toLowerCase();
-          sortedUsers = sortedUsers.filter((u: User) =>
-            u.username.toLowerCase().includes(lowerSearch)
-          );
-        }
-        setUsers(sortedUsers);
+        const sortedUsers = sortAdminUsers(data.users || []);
+        setAllUsers(sortedUsers);
+        setUsers(filterAdminUsers(sortedUsers, search));
         setVisibleUsersCount(USERS_PER_PAGE); // Reset pagination when fetching
       } catch (error) {
         console.error("Failed to fetch users:", error);
         toast.error(t("apps.admin.errors.failedToFetchUsers"));
       } finally {
-        setIsLoading(false);
+        endLoading();
       }
     },
-    [username, isAuthenticated, t, isOffline]
+    [username, isAuthenticated, t, isOffline, beginLoading, endLoading]
   );
 
   // Fetch rooms
@@ -382,7 +403,7 @@ export function useAdminLogic({ isWindowOpen }: UseAdminLogicProps) {
     if (!username || !isAuthenticated) return;
     if (isOffline) return; // Skip API calls when offline
 
-    setIsLoading(true);
+    beginLoading();
     try {
       const data = await listRoomsApi();
       const normalizedRooms = data.rooms.map((room) => ({
@@ -394,9 +415,9 @@ export function useAdminLogic({ isWindowOpen }: UseAdminLogicProps) {
       console.error("Failed to fetch rooms:", error);
       toast.error(t("apps.admin.errors.failedToFetchRooms"));
     } finally {
-      setIsLoading(false);
+      endLoading();
     }
-  }, [username, isAuthenticated, t, isOffline]);
+  }, [username, isAuthenticated, t, isOffline, beginLoading, endLoading]);
 
   // Fetch messages for a room
   const fetchRoomMessages = useCallback(
@@ -404,7 +425,7 @@ export function useAdminLogic({ isWindowOpen }: UseAdminLogicProps) {
       if (!username || !isAuthenticated) return;
       if (isOffline) return; // Skip API calls when offline
 
-      setIsLoading(true);
+      beginLoading();
       try {
         const data = await getRoomMessagesApi(roomId);
         setRoomMessages(data.messages || []);
@@ -412,17 +433,17 @@ export function useAdminLogic({ isWindowOpen }: UseAdminLogicProps) {
         console.error("Failed to fetch messages:", error);
         toast.error(t("apps.admin.errors.failedToFetchMessages"));
       } finally {
-        setIsLoading(false);
+        endLoading();
       }
     },
-    [username, isAuthenticated, t, isOffline]
+    [username, isAuthenticated, t, isOffline, beginLoading, endLoading]
   );
 
   // Fetch songs from Redis cache
   const fetchSongs = useCallback(async () => {
     if (isOffline) return; // Skip API calls when offline
 
-    setIsLoading(true);
+    beginLoading();
     try {
       const allSongs = await listAllCachedSongMetadata();
       setSongs(allSongs);
@@ -434,9 +455,18 @@ export function useAdminLogic({ isWindowOpen }: UseAdminLogicProps) {
         t("apps.admin.errors.failedToFetchSongs", "Failed to fetch songs")
       );
     } finally {
-      setIsLoading(false);
+      endLoading();
     }
-  }, [t, isOffline]);
+  }, [t, isOffline, beginLoading, endLoading]);
+
+  const loadIndependentAdminDatasets = useCallback(async () => {
+    await Promise.all([
+      fetchRooms(),
+      fetchStats(),
+      fetchSongs(),
+      fetchCursorAgentCount(),
+    ]);
+  }, [fetchRooms, fetchStats, fetchSongs, fetchCursorAgentCount]);
 
   // Delete user
   const deleteUser = useCallback(
@@ -483,7 +513,7 @@ export function useAdminLogic({ isWindowOpen }: UseAdminLogicProps) {
         toast.error(t("apps.admin.errors.failedToDeleteRoom"));
       }
     },
-    [username, isAuthenticated, fetchRooms, fetchStats, t]
+    [username, isAuthenticated, fetchRooms, fetchStats, setSelectedRoomId, t]
   );
 
   // Delete message
@@ -1036,24 +1066,15 @@ export function useAdminLogic({ isWindowOpen }: UseAdminLogicProps) {
   // Load data on mount
   useEffect(() => {
     if (isAdmin && isWindowOpen) {
-      fetchRooms();
-      fetchStats();
-      fetchSongs();
-      fetchCursorAgentCount();
+      void loadIndependentAdminDatasets();
+      void fetchUsers(userSearchRef.current);
     }
   }, [
     isAdmin,
     isWindowOpen,
-    fetchRooms,
-    fetchStats,
-    fetchSongs,
-    fetchCursorAgentCount,
+    loadIndependentAdminDatasets,
+    fetchUsers,
   ]);
-
-  useEffect(() => {
-    if (!isAdmin || !isWindowOpen) return;
-    fetchCursorAgentCount();
-  }, [cursorAgentsRefreshSignal, isAdmin, isWindowOpen, fetchCursorAgentCount]);
 
   useEffect(() => {
     return () => {
@@ -1063,11 +1084,13 @@ export function useAdminLogic({ isWindowOpen }: UseAdminLogicProps) {
 
   // Handle user search
   useEffect(() => {
+    userSearchRef.current = userSearch;
     const timer = setTimeout(() => {
-      fetchUsers(userSearch);
+      setUsers(filterAdminUsers(allUsers, userSearch));
+      setVisibleUsersCount(USERS_PER_PAGE);
     }, 300);
     return () => clearTimeout(timer);
-  }, [userSearch, fetchUsers]);
+  }, [allUsers, userSearch]);
 
   // Fetch room messages when room is selected
   useEffect(() => {
@@ -1098,21 +1121,15 @@ export function useAdminLogic({ isWindowOpen }: UseAdminLogicProps) {
       toast.error(t("common.offline", "You are offline"));
       return;
     }
-    fetchRooms();
-    fetchStats();
-    fetchCursorAgentCount();
-    fetchSongs();
+    void loadIndependentAdminDatasets();
     if (selectedRoomId) {
-      fetchRoomMessages(selectedRoomId);
+      void fetchRoomMessages(selectedRoomId);
     }
-    fetchUsers(userSearch);
+    void fetchUsers(userSearch);
     setCursorAgentsRefreshSignal((n) => n + 1);
     toast.success(t("apps.admin.messages.dataRefreshed"));
   }, [
-    fetchRooms,
-    fetchStats,
-    fetchCursorAgentCount,
-    fetchSongs,
+    loadIndependentAdminDatasets,
     fetchRoomMessages,
     fetchUsers,
     selectedRoomId,

--- a/src/apps/calendar/components/calendar-app/DayTimeGrid.tsx
+++ b/src/apps/calendar/components/calendar-app/DayTimeGrid.tsx
@@ -1,4 +1,4 @@
-import { useRef, useLayoutEffect, useEffect, useState, useMemo, useCallback } from "react";
+import { useRef, useLayoutEffect, useEffect, useState, useCallback } from "react";
 import { cn } from "@/lib/utils";
 import type { CalendarEvent } from "@/stores/useCalendarStore";
 import {
@@ -73,10 +73,8 @@ export function DayTimeGrid({
   const allDayEvents = events.filter((ev) => !ev.startTime);
   const timedEvents = events.filter((ev) => !!ev.startTime).sort((a, b) => (a.startTime || "").localeCompare(b.startTime || ""));
 
-  const todayStr = useMemo(() => {
-    const d = new Date();
-    return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
-  }, [currentMinute]);
+  const d = new Date();
+  const todayStr = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
   const isToday = date === todayStr;
 
   useLayoutEffect(() => {

--- a/src/apps/calendar/components/calendar-app/DayTimeGrid.tsx
+++ b/src/apps/calendar/components/calendar-app/DayTimeGrid.tsx
@@ -1,4 +1,4 @@
-import { useRef, useLayoutEffect, useEffect, useState, useCallback } from "react";
+import { useRef, useLayoutEffect, useEffect, useState, useCallback, useMemo } from "react";
 import { cn } from "@/lib/utils";
 import type { CalendarEvent } from "@/stores/useCalendarStore";
 import {
@@ -70,8 +70,27 @@ export function DayTimeGrid({
     return now.getHours() * 60 + now.getMinutes();
   });
 
-  const allDayEvents = events.filter((ev) => !ev.startTime);
-  const timedEvents = events.filter((ev) => !!ev.startTime).sort((a, b) => (a.startTime || "").localeCompare(b.startTime || ""));
+  const { allDayEvents, timedEvents } = useMemo(() => {
+    const nextAllDayEvents: CalendarEvent[] = [];
+    const nextTimedEvents: CalendarEvent[] = [];
+
+    for (const ev of events) {
+      if (ev.startTime) {
+        nextTimedEvents.push(ev);
+      } else {
+        nextAllDayEvents.push(ev);
+      }
+    }
+
+    nextTimedEvents.sort((a, b) =>
+      (a.startTime || "").localeCompare(b.startTime || "")
+    );
+
+    return {
+      allDayEvents: nextAllDayEvents,
+      timedEvents: nextTimedEvents,
+    };
+  }, [events]);
 
   const d = new Date();
   const todayStr = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;

--- a/src/apps/calendar/components/calendar-app/TodoSidebar.tsx
+++ b/src/apps/calendar/components/calendar-app/TodoSidebar.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from "react";
+import { useState, useCallback, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { Trash } from "@phosphor-icons/react";
 import { cn } from "@/lib/utils";
@@ -42,6 +42,10 @@ export function TodoSidebar({
   const [editingTodoId, setEditingTodoId] = useState<string | null>(null);
   const [editingTitle, setEditingTitle] = useState("");
   const defaultCalId = calendars[0]?.id || "home";
+  const calendarById = useMemo(
+    () => new Map(calendars.map((calendar) => [calendar.id, calendar])),
+    [calendars]
+  );
 
   const handleAdd = () => {
     if (!newTitle.trim()) return;
@@ -102,7 +106,7 @@ export function TodoSidebar({
           <div className={cn("text-[10px] opacity-30 px-2 py-2", useGeneva && "font-geneva-12")}>{t("apps.calendar.sidebar.noTodoItems")}</div>
         )}
         {todos.map((todo) => {
-          const cal = calendars.find((c) => c.id === todo.calendarId);
+          const cal = calendarById.get(todo.calendarId);
           const isEditing = editingTodoId === todo.id;
           const isSelected = selectedTodoId === todo.id;
           return (

--- a/src/apps/chats/components/ChatRoomSidebar.tsx
+++ b/src/apps/chats/components/ChatRoomSidebar.tsx
@@ -57,6 +57,23 @@ export const ChatRoomSidebar = React.memo(function ChatRoomSidebar({
   const togglePrivateOpen = useChatsStore((s) => s.togglePrivateOpen);
 
   const onlineUsersSet = useMemo(() => new Set(onlineUsers), [onlineUsers]);
+  const { publicRooms, privateRooms } = useMemo(() => {
+    const nextPublicRooms: ChatRoom[] = [];
+    const nextPrivateRooms: ChatRoom[] = [];
+
+    for (const room of Array.isArray(rooms) ? rooms : []) {
+      if (room.type === "private") {
+        nextPrivateRooms.push(room);
+      } else {
+        nextPublicRooms.push(room);
+      }
+    }
+
+    return {
+      publicRooms: nextPublicRooms,
+      privateRooms: nextPrivateRooms,
+    };
+  }, [rooms]);
 
   if (!isVisible) {
     return null;
@@ -235,12 +252,6 @@ export const ChatRoomSidebar = React.memo(function ChatRoomSidebar({
           {Array.isArray(rooms) && (
             <>
               {(() => {
-                const publicRooms = rooms.filter(
-                  (room) => room.type !== "private"
-                );
-                const privateRooms = rooms.filter(
-                  (room) => room.type === "private"
-                );
                 const hasBoth =
                   publicRooms.length > 0 && privateRooms.length > 0;
                 const hasPrivate = privateRooms.length > 0;

--- a/src/apps/chats/components/chat-input/composerState.ts
+++ b/src/apps/chats/components/chat-input/composerState.ts
@@ -11,8 +11,6 @@ export const composerInitialState: ComposerState = {
 };
 
 export type ComposerAction =
-  | { type: "setInput"; value: string }
-  | { type: "setHistoryIndex"; value: number }
   | { type: "setSelectedImage"; value: string | null }
   | { type: "setInputAndResetHistory"; value: string }
   | { type: "setHistoryNavigation"; value: { index: number; input: string } }
@@ -23,10 +21,6 @@ export function composerReducer(
   action: ComposerAction
 ): ComposerState {
   switch (action.type) {
-    case "setInput":
-      return { ...state, input: action.value };
-    case "setHistoryIndex":
-      return { ...state, historyIndex: action.value };
     case "setSelectedImage":
       return { ...state, selectedImage: action.value };
     case "setInputAndResetHistory":
@@ -38,7 +32,7 @@ export function composerReducer(
         input: action.value.input,
       };
     case "clearComposer":
-      return { ...state, input: "", selectedImage: null };
+      return { ...state, input: "", historyIndex: -1, selectedImage: null };
     default:
       return state;
   }

--- a/src/apps/chats/components/chat-input/useChatInput.ts
+++ b/src/apps/chats/components/chat-input/useChatInput.ts
@@ -44,11 +44,8 @@ export function useChatInput({
     composerInitialState
   );
   const { input, historyIndex, selectedImage } = composerState;
-  const setInput = useCallback((value: string) => {
-    dispatchComposer({ type: "setInput", value });
-  }, []);
-  const setHistoryIndex = useCallback((value: number) => {
-    dispatchComposer({ type: "setHistoryIndex", value });
+  const setInputAndResetHistory = useCallback((value: string) => {
+    dispatchComposer({ type: "setInputAndResetHistory", value });
   }, []);
   const setSelectedImage = useCallback((value: string | null) => {
     dispatchComposer({ type: "setSelectedImage", value });
@@ -124,14 +121,10 @@ export function useChatInput({
   }, [isForeground, historyIndex, previousMessages]);
 
   useEffect(() => {
-    setHistoryIndex(-1);
-  }, [input, setHistoryIndex]);
-
-  useEffect(() => {
     if (prefillMessage) {
-      setInput(prefillMessage);
+      setInputAndResetHistory(prefillMessage);
     }
-  }, [prefillMessage, setInput]);
+  }, [prefillMessage, setInputAndResetHistory]);
 
   useEffect(() => {
     if (!didMountRef.current) {
@@ -205,7 +198,7 @@ export function useChatInput({
     } else {
       void Promise.resolve(onSubmitMessage(text.trim(), null)).then(
         (didSubmit) => {
-          if (didSubmit) setInput("");
+          if (didSubmit) setInputAndResetHistory("");
         }
       );
     }
@@ -257,7 +250,7 @@ export function useChatInput({
       newValue = `@ryo ${input}`.trim() + (input.endsWith(" ") ? "" : " ");
     }
 
-    setInput(newValue);
+    setInputAndResetHistory(newValue);
     inputRef.current?.focus();
 
     setTimeout(() => {

--- a/src/apps/dashboard/components/DashboardAppComponent.tsx
+++ b/src/apps/dashboard/components/DashboardAppComponent.tsx
@@ -1,4 +1,13 @@
-import { useEffect, useCallback, useState, useRef } from "react";
+import {
+  lazy,
+  Suspense,
+  useEffect,
+  useCallback,
+  useState,
+  useRef,
+  type ComponentType,
+  type LazyExoticComponent,
+} from "react";
 import { createPortal } from "react-dom";
 import { motion, AnimatePresence } from "framer-motion";
 import { AppProps } from "@/apps/base/types";
@@ -7,17 +16,6 @@ import { AppHelpAboutDialogs } from "@/components/shared/AppHelpAboutDialogs";
 import { appMetadata } from "../metadata";
 import { useDashboardLogic } from "../hooks/useDashboardLogic";
 import { WidgetChrome } from "@/components/layout/dashboard/WidgetChrome";
-import { ClockWidget, ClockBackPanel } from "@/components/layout/dashboard/ClockWidget";
-import { CalendarWidget, CalendarBackPanel } from "@/components/layout/dashboard/CalendarWidget";
-import { WeatherWidget, WeatherEmojiOverflow, WeatherBackPanel } from "@/components/layout/dashboard/WeatherWidget";
-import { StocksWidget, StocksBackPanel } from "@/components/layout/dashboard/StocksWidget";
-import { IpodWidget, IpodBackPanel } from "@/components/layout/dashboard/IpodWidget";
-import { TranslationWidget, TranslationBackPanel } from "@/components/layout/dashboard/TranslationWidget";
-import { CurrencyWidget, CurrencyBackPanel } from "@/components/layout/dashboard/CurrencyWidget";
-import { StickyNoteWidget, StickyNoteBackPanel } from "@/components/layout/dashboard/StickyNoteWidget";
-import { DictionaryWidget, DictionaryBackPanel } from "@/components/layout/dashboard/DictionaryWidget";
-import { AquariumWidget, AquariumBubbleOverflow } from "@/components/layout/dashboard/AquariumWidget";
-import { TerrariumWidget, TerrariumFireflyOverflow } from "@/components/layout/dashboard/TerrariumWidget";
 import { DashboardMenuBar } from "./DashboardMenuBar";
 import { useAppStore } from "@/stores/useAppStore";
 import { useTranslation } from "react-i18next";
@@ -26,65 +24,220 @@ import { useDashboardStore, type WidgetType } from "@/stores/useDashboardStore";
 import { useMediaQuery } from "@/hooks/useMediaQuery";
 import { Emoji } from "@/components/shared/Emoji";
 
-function WidgetContent({ type, widgetId, isFlipped }: { type: string; widgetId: string; isFlipped?: boolean }) {
-  switch (type) {
-    case "clock":
-      return <ClockWidget widgetId={widgetId} isFlipped={isFlipped} />;
-    case "calendar":
-      return <CalendarWidget widgetId={widgetId} />;
-    case "weather":
-      return <WeatherWidget widgetId={widgetId} />;
-    case "stocks":
-      return <StocksWidget widgetId={widgetId} />;
-    case "ipod":
-      return <IpodWidget widgetId={widgetId} />;
-    case "translation":
-      return <TranslationWidget widgetId={widgetId} />;
-    case "currency":
-      return <CurrencyWidget widgetId={widgetId} />;
-    case "stickynote":
-      return <StickyNoteWidget widgetId={widgetId} />;
-    case "dictionary":
-      return <DictionaryWidget widgetId={widgetId} />;
-    case "aquarium":
-      return <AquariumWidget widgetId={widgetId} />;
-    case "terrarium":
-      return <TerrariumWidget widgetId={widgetId} />;
-    default:
-      return null;
-  }
+type WidgetFrontProps = {
+  widgetId: string;
+  isFlipped?: boolean;
+};
+
+type WidgetBackProps = {
+  widgetId: string;
+  onDone?: () => void;
+};
+
+type WidgetOverflowProps = {
+  widgetId: string;
+};
+
+type LazyWidgetComponent<Props> = LazyExoticComponent<ComponentType<Props>>;
+
+type WidgetRegistryEntry = {
+  front: LazyWidgetComponent<WidgetFrontProps>;
+  back?: LazyWidgetComponent<WidgetBackProps>;
+  overflow?: LazyWidgetComponent<WidgetOverflowProps>;
+};
+
+function lazyWidget<Props>(
+  loader: () => Promise<{ default: ComponentType<Props> }>
+): LazyWidgetComponent<Props> {
+  return lazy(loader);
 }
 
-function WidgetBackContent({ type, widgetId, onDone }: { type: string; widgetId: string; onDone: () => void }) {
-  switch (type) {
-    case "clock":
-      return <ClockBackPanel widgetId={widgetId} onDone={onDone} />;
-    case "calendar":
-      return <CalendarBackPanel widgetId={widgetId} />;
-    case "weather":
-      return <WeatherBackPanel widgetId={widgetId} onDone={onDone} />;
-    case "stocks":
-      return <StocksBackPanel widgetId={widgetId} onDone={onDone} />;
-    case "ipod":
-      return <IpodBackPanel widgetId={widgetId} onDone={onDone} />;
-    case "translation":
-      return <TranslationBackPanel widgetId={widgetId} onDone={onDone} />;
-    case "currency":
-      return <CurrencyBackPanel widgetId={widgetId} onDone={onDone} />;
-    case "stickynote":
-      return <StickyNoteBackPanel widgetId={widgetId} onDone={onDone} />;
-    case "dictionary":
-      return <DictionaryBackPanel widgetId={widgetId} onDone={onDone} />;
-    default:
-      return null;
-  }
+const WIDGET_REGISTRY: Record<WidgetType, WidgetRegistryEntry> = {
+  clock: {
+    front: lazyWidget<WidgetFrontProps>(() =>
+      import("@/components/layout/dashboard/ClockWidget").then((module) => ({
+        default: module.ClockWidget,
+      }))
+    ),
+    back: lazyWidget<WidgetBackProps>(() =>
+      import("@/components/layout/dashboard/ClockWidget").then((module) => ({
+        default: module.ClockBackPanel,
+      }))
+    ),
+  },
+  calendar: {
+    front: lazyWidget<WidgetFrontProps>(() =>
+      import("@/components/layout/dashboard/CalendarWidget").then((module) => ({
+        default: module.CalendarWidget,
+      }))
+    ),
+    back: lazyWidget<WidgetBackProps>(() =>
+      import("@/components/layout/dashboard/CalendarWidget").then((module) => ({
+        default: module.CalendarBackPanel,
+      }))
+    ),
+  },
+  weather: {
+    front: lazyWidget<WidgetFrontProps>(() =>
+      import("@/components/layout/dashboard/WeatherWidget").then((module) => ({
+        default: module.WeatherWidget,
+      }))
+    ),
+    back: lazyWidget<WidgetBackProps>(() =>
+      import("@/components/layout/dashboard/WeatherWidget").then((module) => ({
+        default: module.WeatherBackPanel,
+      }))
+    ),
+    overflow: lazyWidget<WidgetOverflowProps>(() =>
+      import("@/components/layout/dashboard/WeatherWidget").then((module) => ({
+        default: module.WeatherEmojiOverflow,
+      }))
+    ),
+  },
+  stocks: {
+    front: lazyWidget<WidgetFrontProps>(() =>
+      import("@/components/layout/dashboard/StocksWidget").then((module) => ({
+        default: module.StocksWidget,
+      }))
+    ),
+    back: lazyWidget<WidgetBackProps>(() =>
+      import("@/components/layout/dashboard/StocksWidget").then((module) => ({
+        default: module.StocksBackPanel,
+      }))
+    ),
+  },
+  ipod: {
+    front: lazyWidget<WidgetFrontProps>(() =>
+      import("@/components/layout/dashboard/IpodWidget").then((module) => ({
+        default: module.IpodWidget,
+      }))
+    ),
+    back: lazyWidget<WidgetBackProps>(() =>
+      import("@/components/layout/dashboard/IpodWidget").then((module) => ({
+        default: module.IpodBackPanel,
+      }))
+    ),
+  },
+  translation: {
+    front: lazyWidget<WidgetFrontProps>(() =>
+      import("@/components/layout/dashboard/TranslationWidget").then((module) => ({
+        default: module.TranslationWidget,
+      }))
+    ),
+    back: lazyWidget<WidgetBackProps>(() =>
+      import("@/components/layout/dashboard/TranslationWidget").then((module) => ({
+        default: module.TranslationBackPanel,
+      }))
+    ),
+  },
+  currency: {
+    front: lazyWidget<WidgetFrontProps>(() =>
+      import("@/components/layout/dashboard/CurrencyWidget").then((module) => ({
+        default: module.CurrencyWidget,
+      }))
+    ),
+    back: lazyWidget<WidgetBackProps>(() =>
+      import("@/components/layout/dashboard/CurrencyWidget").then((module) => ({
+        default: module.CurrencyBackPanel,
+      }))
+    ),
+  },
+  stickynote: {
+    front: lazyWidget<WidgetFrontProps>(() =>
+      import("@/components/layout/dashboard/StickyNoteWidget").then((module) => ({
+        default: module.StickyNoteWidget,
+      }))
+    ),
+    back: lazyWidget<WidgetBackProps>(() =>
+      import("@/components/layout/dashboard/StickyNoteWidget").then((module) => ({
+        default: module.StickyNoteBackPanel,
+      }))
+    ),
+  },
+  dictionary: {
+    front: lazyWidget<WidgetFrontProps>(() =>
+      import("@/components/layout/dashboard/DictionaryWidget").then((module) => ({
+        default: module.DictionaryWidget,
+      }))
+    ),
+    back: lazyWidget<WidgetBackProps>(() =>
+      import("@/components/layout/dashboard/DictionaryWidget").then((module) => ({
+        default: module.DictionaryBackPanel,
+      }))
+    ),
+  },
+  aquarium: {
+    front: lazyWidget<WidgetFrontProps>(() =>
+      import("@/components/layout/dashboard/AquariumWidget").then((module) => ({
+        default: module.AquariumWidget,
+      }))
+    ),
+    overflow: lazyWidget<WidgetOverflowProps>(() =>
+      import("@/components/layout/dashboard/AquariumWidget").then((module) => ({
+        default: module.AquariumBubbleOverflow,
+      }))
+    ),
+  },
+  terrarium: {
+    front: lazyWidget<WidgetFrontProps>(() =>
+      import("@/components/layout/dashboard/TerrariumWidget").then((module) => ({
+        default: module.TerrariumWidget,
+      }))
+    ),
+    overflow: lazyWidget<WidgetOverflowProps>(() =>
+      import("@/components/layout/dashboard/TerrariumWidget").then((module) => ({
+        default: module.TerrariumFireflyOverflow,
+      }))
+    ),
+  },
+};
+
+function WidgetContent({
+  type,
+  widgetId,
+  isFlipped,
+}: {
+  type: WidgetType;
+  widgetId: string;
+  isFlipped?: boolean;
+}) {
+  const Front = WIDGET_REGISTRY[type].front;
+
+  return (
+    <Suspense fallback={null}>
+      <Front widgetId={widgetId} isFlipped={isFlipped} />
+    </Suspense>
+  );
 }
 
-function WidgetOverflow({ type, widgetId }: { type: string; widgetId: string }) {
-  if (type === "weather") return <WeatherEmojiOverflow widgetId={widgetId} />;
-  if (type === "aquarium") return <AquariumBubbleOverflow widgetId={widgetId} />;
-  if (type === "terrarium") return <TerrariumFireflyOverflow widgetId={widgetId} />;
-  return null;
+function WidgetBackContent({
+  type,
+  widgetId,
+  onDone,
+}: {
+  type: WidgetType;
+  widgetId: string;
+  onDone: () => void;
+}) {
+  const Back = WIDGET_REGISTRY[type].back;
+  if (!Back) return null;
+
+  return (
+    <Suspense fallback={null}>
+      <Back widgetId={widgetId} onDone={onDone} />
+    </Suspense>
+  );
+}
+
+function WidgetOverflow({ type, widgetId }: { type: WidgetType; widgetId: string }) {
+  const Overflow = WIDGET_REGISTRY[type].overflow;
+  if (!Overflow) return null;
+
+  return (
+    <Suspense fallback={null}>
+      <Overflow widgetId={widgetId} />
+    </Suspense>
+  );
 }
 
 const WIDGET_ICONS: Record<WidgetType, string> = {

--- a/src/apps/ipod/components/PipPlayer.tsx
+++ b/src/apps/ipod/components/PipPlayer.tsx
@@ -1,4 +1,3 @@
-import { useMemo } from "react";
 import { motion } from "framer-motion";
 import { createPortal } from "react-dom";
 import { cn } from "@/lib/utils";
@@ -28,18 +27,11 @@ export function PipPlayer({
   const isPhone = useIsPhone();
 
   // Calculate bottom offset based on theme (similar to Sonner positioning)
-  const bottomOffset = useMemo(() => {
-    if (isWinFamily) {
-      // Windows themes: taskbar height (30px) + padding
-      return "calc(env(safe-area-inset-bottom, 0px) + 42px)";
-    } else if (isMacOSX) {
-      // macOS X: dock height (56px) + padding
-      return "calc(env(safe-area-inset-bottom, 0px) + 72px)";
-    } else {
-      // System 7 and others: just safe area + small padding
-      return "calc(env(safe-area-inset-bottom, 0px) + 16px)";
-    }
-  }, [isWinFamily, isMacOSX]);
+  const bottomOffset = isWinFamily
+    ? "calc(env(safe-area-inset-bottom, 0px) + 42px)"
+    : isMacOSX
+      ? "calc(env(safe-area-inset-bottom, 0px) + 72px)"
+      : "calc(env(safe-area-inset-bottom, 0px) + 16px)";
 
   // Use track's cover (from Kugou, fetched during library sync), fallback to YouTube thumbnail
   const youtubeVideoId = currentTrack?.url

--- a/src/apps/karaoke/components/karaoke-lyrics-playback/KaraokeTitleCard.tsx
+++ b/src/apps/karaoke/components/karaoke-lyrics-playback/KaraokeTitleCard.tsx
@@ -63,9 +63,7 @@ export const KaraokeTitleCard = memo(function KaraokeTitleCard({
     enabled: styleCategory === "glow-gold",
     onResolved: onCoverColorResolved,
   });
-  const primaryGlow = useMemo(() => {
-    return makeTitleCardGlow(glowColor);
-  }, [glowColor]);
+  const primaryGlow = makeTitleCardGlow(glowColor);
 
   const titleTextSizeClass =
     variant === "fullscreen"

--- a/src/apps/tv/components/MtvLyricsOverlay.tsx
+++ b/src/apps/tv/components/MtvLyricsOverlay.tsx
@@ -6,6 +6,8 @@ import { useIpodStore } from "@/stores/useIpodStore";
 import { cn } from "@/lib/utils";
 import type { LyricLine } from "@/types/lyrics";
 
+const WORD_WITH_TRAILING_SPACE_RE = /\S+\s*/g;
+
 interface MtvLyricsOverlayProps {
   /** The id of the currently playing video. For the MTV channel this maps
    *  1:1 to an iPod track id (see `trackToVideo` in `useTvLogic`). */
@@ -186,9 +188,9 @@ export function MtvLyricsOverlay({
     const trimmed = original.trim();
     if (!trimmed) return [];
     const parts: string[] = [];
-    const re = /\S+\s*/g;
+    WORD_WITH_TRAILING_SPACE_RE.lastIndex = 0;
     let m: RegExpExecArray | null;
-    while ((m = re.exec(trimmed)) !== null) {
+    while ((m = WORD_WITH_TRAILING_SPACE_RE.exec(trimmed)) !== null) {
       parts.push(m[0]);
     }
     const total = lineDurationMs;
@@ -198,7 +200,7 @@ export function MtvLyricsOverlay({
     }));
   }, [activeLine, lineDurationMs]);
 
-  const fullText = useMemo(() => tokens.map((t) => t.text).join(""), [tokens]);
+  const fullText = tokens.map((t) => t.text).join("");
 
   // Track the latest prop time + when we received it so we can
   // extrapolate per-frame for smooth reveal between coarse progress

--- a/src/apps/tv/components/tv-app/useTvCrtPlaybackEffects.ts
+++ b/src/apps/tv/components/tv-app/useTvCrtPlaybackEffects.ts
@@ -60,7 +60,7 @@ export function useTvCrtPlaybackEffects({
 }) {
   useEffect(() => {
     setLcdSlot("now");
-  }, [currentChannelId, currentVideoId]);
+  }, [currentChannelId, currentVideoId, setLcdSlot]);
 
   const wasOpenRef = useRef(false);
   useEffect(() => {
@@ -75,7 +75,15 @@ export function useTvCrtPlaybackEffects({
       setPoweringOff(false);
       stopStatic();
     }
-  }, [isWindowOpen, skipInitialSound, playPowerOn, stopStatic, isMobileSafariDevice]);
+  }, [
+    isWindowOpen,
+    skipInitialSound,
+    playPowerOn,
+    setPowerOnKey,
+    setPoweringOff,
+    stopStatic,
+    isMobileSafariDevice,
+  ]);
 
   const channelMountedRef = useRef(false);
   useEffect(() => {
@@ -86,11 +94,11 @@ export function useTvCrtPlaybackEffects({
     if (isFullScreen) return;
     setChannelSwitchKey((k) => k + 1);
     void playChannelSwitch();
-  }, [currentChannelId, playChannelSwitch, isFullScreen]);
+  }, [currentChannelId, playChannelSwitch, setChannelSwitchKey, isFullScreen]);
 
   useEffect(() => {
     setIsBuffering(false);
-  }, [currentVideoId]);
+  }, [currentVideoId, setIsBuffering]);
 
   const ccTransitionMountedRef = useRef(false);
   useEffect(() => {
@@ -101,7 +109,7 @@ export function useTvCrtPlaybackEffects({
     setIsTransitioningCc(true);
     const id = window.setTimeout(() => setIsTransitioningCc(false), 700);
     return () => window.clearTimeout(id);
-  }, [currentChannelId, currentVideoId]);
+  }, [currentChannelId, currentVideoId, setIsTransitioningCc]);
 
   const prevPlayingRef = useRef(isPlaying);
   const prevVideoIdRef = useRef(currentVideoId);
@@ -155,6 +163,8 @@ export function useTvCrtPlaybackEffects({
     currentVideoId,
     playPowerOff,
     playPowerOn,
+    setPowerOnKey,
+    setScreenOff,
     stopStatic,
   ]);
 
@@ -163,7 +173,7 @@ export function useTvCrtPlaybackEffects({
       setScreenOff(isMobileSafariDevice);
       hasPausedRef.current = false;
     }
-  }, [isWindowOpen, isMobileSafariDevice]);
+  }, [isWindowOpen, isMobileSafariDevice, setScreenOff]);
 
   useEffect(() => {
     if (staticBedActive) {

--- a/src/apps/videos/components/SeekBar.tsx
+++ b/src/apps/videos/components/SeekBar.tsx
@@ -21,21 +21,15 @@ export function SeekBar({
   autoDismissTimeout = 3000, // Default 3 seconds
 }: SeekBarProps) {
   const [isLocalHovered, setIsLocalHovered] = useState(false);
-  const [isDragging, setIsDragging] = useState(false);
-  const [seekPosition, setSeekPosition] = useState(0);
+  const [dragPosition, setDragPosition] = useState<number | null>(null);
   const [isVisible, setIsVisible] = useState(false);
   const seekBarRef = useRef<HTMLDivElement>(null);
   const autoDismissTimerRef = useRef<NodeJS.Timeout | null>(null);
 
   // Calculate progress percentage
   const progress = (currentTime / duration) * 100;
-
-  // Update seek position when current time changes
-  useEffect(() => {
-    if (!isDragging) {
-      setSeekPosition(progress);
-    }
-  }, [currentTime, duration, isDragging, progress]);
+  const isDragging = dragPosition !== null;
+  const displayedProgress = dragPosition ?? progress;
 
   // Auto-dismiss functionality
   const startAutoDismissTimer = useCallback(() => {
@@ -74,6 +68,7 @@ export function SeekBar({
       }
     } else if (!isPlaying) {
       setIsVisible(false);
+      setDragPosition(null);
       clearAutoDismissTimer();
     }
   }, [
@@ -119,16 +114,15 @@ export function SeekBar({
   const handleMouseMove = (e: React.MouseEvent) => {
     if (!isDragging) return;
     const position = calculatePosition(e.clientX);
-    setSeekPosition(position);
+    setDragPosition(position);
   };
 
   // Handle mouse down on seek bar
   const handleMouseDown = (e: React.MouseEvent) => {
     e.stopPropagation(); // Prevent click from reaching the play/pause overlay
-    setIsDragging(true);
     showSeekBar();
     const position = calculatePosition(e.clientX);
-    setSeekPosition(position);
+    setDragPosition(position);
     if (onDragChange) {
       const seekTime = (position / 100) * duration;
       onDragChange(true, seekTime);
@@ -137,18 +131,17 @@ export function SeekBar({
 
   // Handle mouse up - seek to position
   const handleMouseUp = useCallback(() => {
-    if (isDragging) {
-      onSeek((seekPosition / 100) * duration);
-      setIsDragging(false);
+    if (dragPosition !== null) {
+      onSeek((dragPosition / 100) * duration);
+      setDragPosition(null);
       if (onDragChange) {
         onDragChange(false);
       }
       startAutoDismissTimer();
     }
   }, [
-    isDragging,
+    dragPosition,
     onSeek,
-    seekPosition,
     duration,
     onDragChange,
     startAutoDismissTimer,
@@ -158,11 +151,10 @@ export function SeekBar({
   const handleTouchStart = (e: React.TouchEvent) => {
     e.preventDefault(); // Prevent default touch behavior
     e.stopPropagation();
-    setIsDragging(true);
     showSeekBar();
     const touch = e.touches[0];
     const position = calculatePosition(touch.clientX);
-    setSeekPosition(position);
+    setDragPosition(position);
     if (onDragChange) {
       const seekTime = (position / 100) * duration;
       onDragChange(true, seekTime);
@@ -174,7 +166,7 @@ export function SeekBar({
     e.preventDefault(); // Prevent scrolling while dragging
     const touch = e.touches[0];
     const position = calculatePosition(touch.clientX);
-    setSeekPosition(position);
+    setDragPosition(position);
     if (onDragChange) {
       const seekTime = (position / 100) * duration;
       onDragChange(true, seekTime);
@@ -182,9 +174,9 @@ export function SeekBar({
   };
 
   const handleTouchEnd = () => {
-    if (isDragging) {
-      onSeek((seekPosition / 100) * duration);
-      setIsDragging(false);
+    if (dragPosition !== null) {
+      onSeek((dragPosition / 100) * duration);
+      setDragPosition(null);
       if (onDragChange) {
         onDragChange(false);
       }
@@ -202,7 +194,7 @@ export function SeekBar({
       const handleGlobalMouseMove = (e: MouseEvent) => {
         if (!isDragging) return;
         const position = calculatePosition(e.clientX);
-        setSeekPosition(position);
+        setDragPosition(position);
         if (onDragChange) {
           const seekTime = (position / 100) * duration;
           onDragChange(true, seekTime);
@@ -276,7 +268,7 @@ export function SeekBar({
             className={`absolute left-0 top-0 h-full transition-colors duration-150 ${
               isDragging ? "bg-white/80" : "bg-white/50"
             }`}
-            style={{ width: `${isDragging ? seekPosition : progress}%` }}
+            style={{ width: `${displayedProgress}%` }}
           />
         </div>
       </div>

--- a/src/components/layout/dashboard/ClockWidget.tsx
+++ b/src/components/layout/dashboard/ClockWidget.tsx
@@ -71,7 +71,7 @@ interface ClockWidgetProps {
 
 export function ClockWidget({ widgetId, isFlipped }: ClockWidgetProps) {
   const { t } = useTranslation();
-  const [time, setTime] = useState(new Date());
+  const [time, setTime] = useState(() => new Date());
   const { isWindowsTheme: isXpTheme } = useThemeFlags();
   const widget = useDashboardStore((s) => widgetId ? s.widgets.find((w) => w.id === widgetId) : undefined);
   const config = widget?.config as ClockWidgetConfig | undefined;

--- a/src/components/layout/menu-bar/MenuBarClock.tsx
+++ b/src/components/layout/menu-bar/MenuBarClock.tsx
@@ -7,8 +7,8 @@ import { requestAppLaunch, toggleExposeView } from "@/utils/appEventBus";
 import type { ClockProps } from "./menuBarTypes";
 
 export function Clock({ enableExposeToggle = false, enableCalendarOpen = false }: ClockProps) {
-  const [time, setTime] = useState(new Date());
-  const [viewportWidth, setViewportWidth] = useState(window.innerWidth);
+  const [time, setTime] = useState(() => new Date());
+  const [viewportWidth, setViewportWidth] = useState(() => window.innerWidth);
   const { isWindowsTheme: isXpTheme, isMacOSTheme } = useThemeFlags();
   const { t, i18n: i18nInstance } = useTranslation();
   

--- a/src/components/shared/ThemedIcon.tsx
+++ b/src/components/shared/ThemedIcon.tsx
@@ -116,16 +116,18 @@ export const ThemedIcon: React.FC<ThemedIconProps> = ({
   const themedPath = useIconPath(logical, themeOverride ?? currentTheme);
 
   React.useEffect(() => {
+    const objectUrls = objectUrlsRef.current;
+
     recoveryAttemptsRef.current.clear();
     setRecoveredSrc(null);
 
     return () => {
-      for (const objectUrl of objectUrlsRef.current) {
+      for (const objectUrl of objectUrls) {
         if (typeof URL.revokeObjectURL === "function") {
           URL.revokeObjectURL(objectUrl);
         }
       }
-      objectUrlsRef.current.clear();
+      objectUrls.clear();
     };
   }, [resolved, themedPath]);
 

--- a/src/components/shared/html-preview/HtmlPreview.tsx
+++ b/src/components/shared/html-preview/HtmlPreview.tsx
@@ -8,6 +8,7 @@ import {
 } from "@/stores/useDisplaySettingsStore";
 import { useAudioSettingsStore } from "@/stores/useAudioSettingsStore";
 import { useThemeFlags } from "@/hooks/useThemeFlags";
+import { useMediaQuery } from "@/hooks/useMediaQuery";
 import { InputDialog } from "@/components/dialogs/InputDialog";
 import { getAppletSandboxAttribute } from "@/utils/appletAuthBridge";
 import { useTranslation } from "react-i18next";
@@ -49,7 +50,7 @@ export default function HtmlPreview({
   const [showCode, setShowCode] = useState(false);
   const [isSplitView, setIsSplitView] = useState(loadHtmlPreviewSplit());
   const [originalHeight, setOriginalHeight] = useState<string | null>(null);
-  const [isMobile, setIsMobile] = useState(false);
+  const isMobile = useMediaQuery("(max-width: 767px)");
   const [isDragging, setIsDragging] = useState(false);
   const [isToolbarCollapsed, setIsToolbarCollapsed] = useState(false);
   const wasDragging = useRef(false);
@@ -125,16 +126,6 @@ export default function HtmlPreview({
       setOriginalHeight(height);
     }
   }, [isFullScreen, originalHeight]);
-
-  const checkMobile = useCallback(() => {
-    setIsMobile(window.innerWidth < 768);
-  }, []);
-
-  useEffect(() => {
-    checkMobile();
-  }, [checkMobile]);
-
-  useEventListener("resize", checkMobile);
 
   // Listen for ESC key to exit fullscreen
   useEventListener(

--- a/src/hooks/useChatSynth.ts
+++ b/src/hooks/useChatSynth.ts
@@ -14,6 +14,7 @@ let globalSynthRef: {
 } | null = null;
 let lastUsedPreset = "classic"; // Default to classic, "off" will be handled
 const DEFAULT_SYNTH_VOLUME = -12;
+const ONCE_LISTENER_OPTIONS = { once: true } as const;
 
 export type SynthPreset = {
   name: string;
@@ -367,9 +368,9 @@ export function useChatSynth() {
   }, [initializeAudio]);
 
   const interactionTarget = isAudioReady ? null : window;
-  useEventListener("click", handleInteraction, interactionTarget, { once: true });
-  useEventListener("keydown", handleInteraction, interactionTarget, { once: true });
-  useEventListener("touchstart", handleInteraction, interactionTarget, { once: true });
+  useEventListener("click", handleInteraction, interactionTarget, ONCE_LISTENER_OPTIONS);
+  useEventListener("keydown", handleInteraction, interactionTarget, ONCE_LISTENER_OPTIONS);
+  useEventListener("touchstart", handleInteraction, interactionTarget, ONCE_LISTENER_OPTIONS);
 
   // NOTE: Visibility/focus handlers are handled centrally by @/lib/audioContext
   // to prevent race conditions. Do not add duplicate listeners here.

--- a/src/hooks/useCoverPalette.ts
+++ b/src/hooks/useCoverPalette.ts
@@ -49,9 +49,10 @@ function colorDistSq(
 const MIN_DISTINCT_SQ = 70 * 70;
 
 const COLOR_COUNT = 7;
+const HEX_COLOR_RE = /^#([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})$/i;
 
 function hexToRgb(hex: string): [number, number, number] | null {
-  const m = /^#([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})$/i.exec(hex);
+  const m = HEX_COLOR_RE.exec(hex);
   if (!m) return null;
   return [parseInt(m[1]!, 16), parseInt(m[2]!, 16), parseInt(m[3]!, 16)];
 }
@@ -170,11 +171,9 @@ function extractPaletteFromImage(img: HTMLImageElement): string[] {
   for (const c of sorted) {
     if (result.length >= COLOR_COUNT) break;
     const tooClose = result.some((hex) => {
-      const m = /^#([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})$/i.exec(hex);
-      if (!m) return false;
-      const r2 = parseInt(m[1]!, 16);
-      const g2 = parseInt(m[2]!, 16);
-      const b2 = parseInt(m[3]!, 16);
+      const rgb = hexToRgb(hex);
+      if (!rgb) return false;
+      const [r2, g2, b2] = rgb;
       return colorDistSq(c.r, c.g, c.b, r2, g2, b2) < MIN_DISTINCT_SQ;
     });
     if (!tooClose) {

--- a/src/hooks/useTerminalSounds.ts
+++ b/src/hooks/useTerminalSounds.ts
@@ -6,6 +6,8 @@ import { useEventListener } from "@/hooks/useEventListener";
 type SoundType = "command" | "error" | "aiResponse";
 type TimeMode = "past" | "future" | "now";
 
+const ONCE_LISTENER_OPTIONS = { once: true } as const;
+
 const TERMINAL_SOUND_PRESETS = {
   command: {
     oscillator: {
@@ -820,7 +822,7 @@ export function useTerminalSounds() {
   }, [initializeToneOnce]);
 
   // Initialize Tone.js on first user interaction
-  useEventListener("click", handleFirstInteraction, window, { once: true });
+  useEventListener("click", handleFirstInteraction, window, ONCE_LISTENER_OPTIONS);
 
   const playSound = useCallback(
     async (type: SoundType) => {

--- a/tests/test-chat-input-composer-state.test.ts
+++ b/tests/test-chat-input-composer-state.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from "bun:test";
+import {
+  composerInitialState,
+  composerReducer,
+} from "../src/apps/chats/components/chat-input/composerState";
+
+describe("chat input composer reducer", () => {
+  test("keeps history index while navigating message history", () => {
+    const state = composerReducer(composerInitialState, {
+      type: "setHistoryNavigation",
+      value: { index: 1, input: "previous message" },
+    });
+
+    expect(state).toEqual({
+      input: "previous message",
+      historyIndex: 1,
+      selectedImage: null,
+    });
+  });
+
+  test("resets history index when input is replaced outside history navigation", () => {
+    const state = composerReducer(
+      { input: "previous message", historyIndex: 1, selectedImage: null },
+      { type: "setInputAndResetHistory", value: "new message" }
+    );
+
+    expect(state).toEqual({
+      input: "new message",
+      historyIndex: -1,
+      selectedImage: null,
+    });
+  });
+
+  test("resets history index when composer is cleared", () => {
+    const state = composerReducer(
+      {
+        input: "previous message",
+        historyIndex: 1,
+        selectedImage: "data:image/png;base64,image",
+      },
+      { type: "clearComposer" }
+    );
+
+    expect(state).toEqual({
+      input: "",
+      historyIndex: -1,
+      selectedImage: null,
+    });
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Ran the online Vercel Labs `vercel-react-best-practices` skill across the codebase with parallel subagent audits for shared infrastructure, media apps, communication/admin apps, and desktop/productivity apps.
- Applied a low-risk cross-section of rule-backed fixes: hook dependency cleanup, lazy state initialization, stable listener options, hoisted regex/parser work, combined array passes, memoized lookup maps, and removal of trivial `useMemo` calls.
- Used parallel implementation agents for larger/riskier cleanup work:
  - Dashboard widget registry with `React.lazy` widget modules.
  - HtmlPreview responsive state and Videos SeekBar derived-state cleanup.
  - Chats composer reducer/history cleanup with focused reducer tests.
  - Admin data-loading orchestration with parallel dataset refreshes.
- Kept the earlier `ThemedIcon` cleanup and `DayTimeGrid` simple-memo cleanup.

## Online skill used
- https://raw.githubusercontent.com/vercel-labs/agent-skills/main/skills/react-best-practices/SKILL.md
- Full guide: https://raw.githubusercontent.com/vercel-labs/agent-skills/main/skills/react-best-practices/AGENTS.md

## Areas audited with subagents
- Shared React infrastructure: `src/components`, `src/hooks`, `src/contexts`, React-facing stores
- Media apps: iPod, Karaoke, Videos, TV, Synth
- Communication/admin apps: Chats, Internet Explorer, TextEdit, Terminal, Admin
- Desktop/productivity apps: Finder, Calendar, Control Panels, Contacts, Dashboard, Paint, `App.tsx`

## Testing
- `./node_modules/.bin/eslint` over all larger-refactor files
- `bun test tests/test-chat-input-composer-state.test.ts tests/test-chat-notification-logic.test.ts tests/test-chat-notification-integration-wiring.test.ts tests/test-chat-broadcast-wiring.test.ts tests/test-chat-hook-channel-lifecycle-wiring.test.ts tests/test-chat-store-guards-wiring.test.ts tests/test-pusher-client-refcount.test.ts tests/test-pusher-client-constructor-wiring.test.ts` (52 pass)
- `bun run test:admin` (11 pass)
- `bun run test:unit` (265 pass)
- `bun run lint` (passes with 134 existing warnings remaining)
- `bun run build` (passes; Vite reports existing CSS pseudo-element/chunking warnings)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019e9c91-46d9-713e-a7ee-867ebc573eab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019e9c91-46d9-713e-a7ee-867ebc573eab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

