### PR TITLE
Normalize wallpaper accent lightness to a consistent middle band

### DIFF
--- a/src/hooks/useWallpaperAccent.ts
+++ b/src/hooks/useWallpaperAccent.ts
@@ -2,8 +2,8 @@ import { useEffect } from "react";
 import { useThemeStore } from "@/stores/useThemeStore";
 import { useWallpaper } from "@/hooks/useWallpaper";
 import { useCoverPaletteResult } from "@/hooks/useCoverPalette";
-import { pickPrimaryColor } from "@/apps/ipod/components/lyrics-display/colorUtils";
 import { DEFAULT_ACCENT, getAccentChrome } from "@/themes/accents";
+import { resolveWallpaperAccentFromPalette } from "@/themes/wallpaperAccentColor";
 
 /**
  * Drives the `"wallpaper"` accent: when the active theme uses it, sample a
@@ -39,6 +39,6 @@ export function useWallpaperAccent() {
     if (!isWallpaperAccent) return;
     // Only act on a palette actually extracted from the wallpaper image.
     if (source !== "cover" || !coverUrl) return;
-    setWallpaperAccentColor(pickPrimaryColor(palette));
+    setWallpaperAccentColor(resolveWallpaperAccentFromPalette(palette));
   }, [isWallpaperAccent, source, coverUrl, palette, setWallpaperAccentColor]);
 }

--- a/src/themes/wallpaperAccentColor.ts
+++ b/src/themes/wallpaperAccentColor.ts
@@ -4,39 +4,21 @@ import { pickPrimaryColor } from "@/apps/ipod/components/lyrics-display/colorUti
 type Rgb = { r: number; g: number; b: number };
 type Hsl = { h: number; s: number; l: number };
 
-/**
- * Tunable targets for wallpaper-derived accent colors.
- *
- * Stock manual accents (blue #2765ca, purple #8344c4, red #d23b30, etc.) sit
- * around HSL lightness 0.45–0.52. We normalize extracted wallpaper colors into
- * that band so selections stay readable on both light and dark Aqua/System 7
- * chrome without washing out or sinking into near-black.
- */
+// HSL lightness band aligned with stock manual accents (blue ~0.47).
 export const WALLPAPER_ACCENT_LIGHTNESS = {
-  /** Ideal lightness — aligned with the default Aqua blue accent. */
   target: 0.48,
-  /** Inclusive band; colors already inside are kept (hue/chroma preserved). */
   min: 0.4,
   max: 0.52,
 } as const;
 
-/**
- * Saturation guards for colorful vs neutral wallpaper samples.
- *
- * Below `neutralMax` we treat the sample as achromatic and emit a graphite-like
- * neutral. Colorful samples are lifted to at least `colorfulMin` so a vivid
- * wallpaper does not collapse into a muddy gray accent.
- */
 export const WALLPAPER_ACCENT_SATURATION = {
   neutralMax: 0.12,
-  /** Faint tint retained on neutral wallpapers (graphite is ~6% sat). */
   neutralTint: 0.06,
   colorfulMin: 0.38,
   colorfulMax: 0.72,
 } as const;
 
-/** Fallback when palette extraction yields nothing usable. */
-export const WALLPAPER_ACCENT_FALLBACK = "#2765ca";
+const FALLBACK = "#2765ca";
 
 function parseHex(hex: string): Rgb {
   const clean = hex.replace("#", "");
@@ -115,70 +97,37 @@ function hslToRgb({ h, s, l }: Hsl): Rgb {
   };
 }
 
-function normalizeLightness(lightness: number): number {
-  const { min, max, target } = WALLPAPER_ACCENT_LIGHTNESS;
-  if (lightness >= min && lightness <= max) return lightness;
-  return target;
-}
-
-function normalizeNeutralAccent(hsl: Hsl): string {
-  const { neutralTint } = WALLPAPER_ACCENT_SATURATION;
-  const { target } = WALLPAPER_ACCENT_LIGHTNESS;
-  // Graphite-like neutral: mid lightness; only keep a tint when the source had one.
-  const tint =
-    hsl.s <= 0 ? 0 : Math.min(hsl.s, neutralTint);
-  const tinted = hslToRgb({
-    h: hsl.h,
-    s: tint,
-    l: Math.max(target, 0.54),
-  });
-  return rgbToHex(tinted);
-}
-
-/**
- * Normalize a sampled wallpaper hex for use as a UI accent.
- *
- * Preserves hue (and chroma where present) while pulling lightness into
- * {@link WALLPAPER_ACCENT_LIGHTNESS}. Neutral / near-black / near-white inputs
- * are handled without inventing false chroma.
- */
 export function normalizeWallpaperAccentColor(
   hex: string | null | undefined
 ): string {
   const normalized = normalizeAccentHex(hex);
-  if (!normalized) return WALLPAPER_ACCENT_FALLBACK;
+  if (!normalized) return FALLBACK;
 
   const hsl = rgbToHsl(parseHex(normalized));
-  const { neutralMax, colorfulMin, colorfulMax } = WALLPAPER_ACCENT_SATURATION;
+  const { neutralMax, neutralTint, colorfulMin, colorfulMax } =
+    WALLPAPER_ACCENT_SATURATION;
+  const { min, max, target } = WALLPAPER_ACCENT_LIGHTNESS;
 
   if (hsl.s <= neutralMax) {
-    return normalizeNeutralAccent(hsl);
+    return rgbToHex(
+      hslToRgb({
+        h: hsl.h,
+        s: hsl.s <= 0 ? 0 : Math.min(hsl.s, neutralTint),
+        l: Math.max(target, 0.54),
+      })
+    );
   }
-
-  const saturation = Math.min(
-    Math.max(hsl.s, colorfulMin),
-    colorfulMax
-  );
-  const lightness = normalizeLightness(hsl.l);
 
   return rgbToHex(
     hslToRgb({
       h: hsl.h,
-      s: saturation,
-      l: lightness,
+      s: Math.min(Math.max(hsl.s, colorfulMin), colorfulMax),
+      l: hsl.l >= min && hsl.l <= max ? hsl.l : target,
     })
   );
 }
 
-/** Pick + normalize the accent color from an extracted wallpaper palette. */
 export function resolveWallpaperAccentFromPalette(palette: string[]): string {
-  if (palette.length === 0) return WALLPAPER_ACCENT_FALLBACK;
+  if (palette.length === 0) return FALLBACK;
   return normalizeWallpaperAccentColor(pickPrimaryColor(palette));
-}
-
-/** @internal Exported for unit tests. */
-export function wallpaperAccentHsl(hex: string): Hsl {
-  const normalized = normalizeAccentHex(hex);
-  if (!normalized) throw new Error(`Invalid hex: ${hex}`);
-  return rgbToHsl(parseHex(normalized));
 }

--- a/src/themes/wallpaperAccentColor.ts
+++ b/src/themes/wallpaperAccentColor.ts
@@ -1,0 +1,184 @@
+import { normalizeAccentHex } from "@/themes/accents";
+import { pickPrimaryColor } from "@/apps/ipod/components/lyrics-display/colorUtils";
+
+type Rgb = { r: number; g: number; b: number };
+type Hsl = { h: number; s: number; l: number };
+
+/**
+ * Tunable targets for wallpaper-derived accent colors.
+ *
+ * Stock manual accents (blue #2765ca, purple #8344c4, red #d23b30, etc.) sit
+ * around HSL lightness 0.45–0.52. We normalize extracted wallpaper colors into
+ * that band so selections stay readable on both light and dark Aqua/System 7
+ * chrome without washing out or sinking into near-black.
+ */
+export const WALLPAPER_ACCENT_LIGHTNESS = {
+  /** Ideal lightness — aligned with the default Aqua blue accent. */
+  target: 0.48,
+  /** Inclusive band; colors already inside are kept (hue/chroma preserved). */
+  min: 0.4,
+  max: 0.52,
+} as const;
+
+/**
+ * Saturation guards for colorful vs neutral wallpaper samples.
+ *
+ * Below `neutralMax` we treat the sample as achromatic and emit a graphite-like
+ * neutral. Colorful samples are lifted to at least `colorfulMin` so a vivid
+ * wallpaper does not collapse into a muddy gray accent.
+ */
+export const WALLPAPER_ACCENT_SATURATION = {
+  neutralMax: 0.12,
+  /** Faint tint retained on neutral wallpapers (graphite is ~6% sat). */
+  neutralTint: 0.06,
+  colorfulMin: 0.38,
+  colorfulMax: 0.72,
+} as const;
+
+/** Fallback when palette extraction yields nothing usable. */
+export const WALLPAPER_ACCENT_FALLBACK = "#2765ca";
+
+function parseHex(hex: string): Rgb {
+  const clean = hex.replace("#", "");
+  const value =
+    clean.length === 3
+      ? clean
+          .split("")
+          .map((c) => c + c)
+          .join("")
+      : clean;
+  return {
+    r: parseInt(value.slice(0, 2), 16),
+    g: parseInt(value.slice(2, 4), 16),
+    b: parseInt(value.slice(4, 6), 16),
+  };
+}
+
+function clampByte(n: number): number {
+  return Math.max(0, Math.min(255, Math.round(n)));
+}
+
+function rgbToHex({ r, g, b }: Rgb): string {
+  return `#${clampByte(r).toString(16).padStart(2, "0")}${clampByte(g)
+    .toString(16)
+    .padStart(2, "0")}${clampByte(b).toString(16).padStart(2, "0")}`;
+}
+
+function rgbToHsl({ r, g, b }: Rgb): Hsl {
+  const rn = r / 255;
+  const gn = g / 255;
+  const bn = b / 255;
+  const max = Math.max(rn, gn, bn);
+  const min = Math.min(rn, gn, bn);
+  const delta = max - min;
+  const lightness = (max + min) / 2;
+  let hue = 0;
+
+  if (delta !== 0) {
+    if (max === rn) hue = ((gn - bn) / delta) % 6;
+    else if (max === gn) hue = (bn - rn) / delta + 2;
+    else hue = (rn - gn) / delta + 4;
+    hue *= 60;
+    if (hue < 0) hue += 360;
+  }
+
+  const saturation =
+    delta === 0 ? 0 : delta / (1 - Math.abs(2 * lightness - 1));
+
+  return { h: hue, s: saturation, l: lightness };
+}
+
+function hslToRgb({ h, s, l }: Hsl): Rgb {
+  if (s === 0) {
+    const value = clampByte(l * 255);
+    return { r: value, g: value, b: value };
+  }
+
+  const hue2rgb = (p: number, q: number, t: number) => {
+    let tt = t;
+    if (tt < 0) tt += 1;
+    if (tt > 1) tt -= 1;
+    if (tt < 1 / 6) return p + (q - p) * 6 * tt;
+    if (tt < 1 / 2) return q;
+    if (tt < 2 / 3) return p + (q - p) * (2 / 3 - tt) * 6;
+    return p;
+  };
+
+  const hn = h / 360;
+  const q = l < 0.5 ? l * (1 + s) : l + s - l * s;
+  const p = 2 * l - q;
+
+  return {
+    r: clampByte(hue2rgb(p, q, hn + 1 / 3) * 255),
+    g: clampByte(hue2rgb(p, q, hn) * 255),
+    b: clampByte(hue2rgb(p, q, hn - 1 / 3) * 255),
+  };
+}
+
+function normalizeLightness(lightness: number): number {
+  const { min, max, target } = WALLPAPER_ACCENT_LIGHTNESS;
+  if (lightness >= min && lightness <= max) return lightness;
+  return target;
+}
+
+function normalizeNeutralAccent(hsl: Hsl): string {
+  const { neutralTint } = WALLPAPER_ACCENT_SATURATION;
+  const { target } = WALLPAPER_ACCENT_LIGHTNESS;
+  // Graphite-like neutral: mid lightness; only keep a tint when the source had one.
+  const tint =
+    hsl.s <= 0 ? 0 : Math.min(hsl.s, neutralTint);
+  const tinted = hslToRgb({
+    h: hsl.h,
+    s: tint,
+    l: Math.max(target, 0.54),
+  });
+  return rgbToHex(tinted);
+}
+
+/**
+ * Normalize a sampled wallpaper hex for use as a UI accent.
+ *
+ * Preserves hue (and chroma where present) while pulling lightness into
+ * {@link WALLPAPER_ACCENT_LIGHTNESS}. Neutral / near-black / near-white inputs
+ * are handled without inventing false chroma.
+ */
+export function normalizeWallpaperAccentColor(
+  hex: string | null | undefined
+): string {
+  const normalized = normalizeAccentHex(hex);
+  if (!normalized) return WALLPAPER_ACCENT_FALLBACK;
+
+  const hsl = rgbToHsl(parseHex(normalized));
+  const { neutralMax, colorfulMin, colorfulMax } = WALLPAPER_ACCENT_SATURATION;
+
+  if (hsl.s <= neutralMax) {
+    return normalizeNeutralAccent(hsl);
+  }
+
+  const saturation = Math.min(
+    Math.max(hsl.s, colorfulMin),
+    colorfulMax
+  );
+  const lightness = normalizeLightness(hsl.l);
+
+  return rgbToHex(
+    hslToRgb({
+      h: hsl.h,
+      s: saturation,
+      l: lightness,
+    })
+  );
+}
+
+/** Pick + normalize the accent color from an extracted wallpaper palette. */
+export function resolveWallpaperAccentFromPalette(palette: string[]): string {
+  if (palette.length === 0) return WALLPAPER_ACCENT_FALLBACK;
+  return normalizeWallpaperAccentColor(pickPrimaryColor(palette));
+}
+
+/** @internal Exported for unit tests. */
+export function wallpaperAccentHsl(hex: string): Hsl {
+  const normalized = normalizeAccentHex(hex);
+  if (!normalized) throw new Error(`Invalid hex: ${hex}`);
+  return rgbToHsl(parseHex(normalized));
+}

--- a/tests/test-wallpaper-accent-color.test.ts
+++ b/tests/test-wallpaper-accent-color.test.ts
@@ -4,8 +4,33 @@ import {
   resolveWallpaperAccentFromPalette,
   WALLPAPER_ACCENT_LIGHTNESS,
   WALLPAPER_ACCENT_SATURATION,
-  wallpaperAccentHsl,
 } from "../src/themes/wallpaperAccentColor";
+
+function hexToHsl(hex: string): { h: number; s: number; l: number } {
+  const m = /^#([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})$/i.exec(hex);
+  if (!m) throw new Error(`Invalid hex: ${hex}`);
+  const [r, g, b] = [
+    parseInt(m[1]!, 16),
+    parseInt(m[2]!, 16),
+    parseInt(m[3]!, 16),
+  ];
+  const rn = r / 255;
+  const gn = g / 255;
+  const bn = b / 255;
+  const max = Math.max(rn, gn, bn);
+  const min = Math.min(rn, gn, bn);
+  const delta = max - min;
+  const l = (max + min) / 2;
+  let h = 0;
+  if (delta !== 0) {
+    if (max === rn) h = ((gn - bn) / delta) % 6;
+    else if (max === gn) h = (bn - rn) / delta + 2;
+    else h = (rn - gn) / delta + 4;
+    h = (h * 60 + 360) % 360;
+  }
+  const s = delta === 0 ? 0 : delta / (1 - Math.abs(2 * l - 1));
+  return { h, s, l };
+}
 
 function hueDelta(a: number, b: number): number {
   const delta = Math.abs(a - b) % 360;
@@ -13,7 +38,7 @@ function hueDelta(a: number, b: number): number {
 }
 
 function expectLightnessInBand(hex: string) {
-  const { l } = wallpaperAccentHsl(hex);
+  const { l } = hexToHsl(hex);
   expect(l).toBeGreaterThanOrEqual(WALLPAPER_ACCENT_LIGHTNESS.min);
   expect(l).toBeLessThanOrEqual(WALLPAPER_ACCENT_LIGHTNESS.max);
 }
@@ -22,8 +47,8 @@ describe("wallpaper accent color normalization", () => {
   test("dark wallpaper lifts lightness into the middle band while keeping hue", () => {
     const source = "#1a237e";
     const accent = normalizeWallpaperAccentColor(source);
-    const sourceHsl = wallpaperAccentHsl(source);
-    const accentHsl = wallpaperAccentHsl(accent);
+    const sourceHsl = hexToHsl(source);
+    const accentHsl = hexToHsl(accent);
 
     expectLightnessInBand(accent);
     expect(hueDelta(sourceHsl.h, accentHsl.h)).toBeLessThanOrEqual(5);
@@ -35,8 +60,8 @@ describe("wallpaper accent color normalization", () => {
   test("light wallpaper lowers lightness into the middle band while keeping hue", () => {
     const source = "#ffd6e8";
     const accent = normalizeWallpaperAccentColor(source);
-    const sourceHsl = wallpaperAccentHsl(source);
-    const accentHsl = wallpaperAccentHsl(accent);
+    const sourceHsl = hexToHsl(source);
+    const accentHsl = hexToHsl(accent);
 
     expectLightnessInBand(accent);
     expect(hueDelta(sourceHsl.h, accentHsl.h)).toBeLessThanOrEqual(5);
@@ -48,8 +73,8 @@ describe("wallpaper accent color normalization", () => {
   test("saturated wallpaper preserves hue and lands in the lightness band", () => {
     const source = "#e60026";
     const accent = normalizeWallpaperAccentColor(source);
-    const sourceHsl = wallpaperAccentHsl(source);
-    const accentHsl = wallpaperAccentHsl(accent);
+    const sourceHsl = hexToHsl(source);
+    const accentHsl = hexToHsl(accent);
 
     expectLightnessInBand(accent);
     expect(hueDelta(sourceHsl.h, accentHsl.h)).toBeLessThanOrEqual(5);
@@ -60,11 +85,10 @@ describe("wallpaper accent color normalization", () => {
 
   test("low-chroma wallpaper becomes a graphite-like neutral without false color", () => {
     const accent = normalizeWallpaperAccentColor("#808080");
-    const { s, l } = wallpaperAccentHsl(accent);
+    const { s, l } = hexToHsl(accent);
 
     expect(s).toBeLessThanOrEqual(WALLPAPER_ACCENT_SATURATION.neutralTint);
     expect(l).toBeGreaterThanOrEqual(WALLPAPER_ACCENT_LIGHTNESS.target);
-    // Faint tint only — channels stay close (not a false full-chroma accent).
     const [r, g, b] = [
       parseInt(accent.slice(1, 3), 16),
       parseInt(accent.slice(3, 5), 16),
@@ -75,7 +99,7 @@ describe("wallpaper accent color normalization", () => {
 
   test("near-black neutral wallpaper does not collapse to pure black", () => {
     const accent = normalizeWallpaperAccentColor("#101010");
-    const { s, l } = wallpaperAccentHsl(accent);
+    const { s, l } = hexToHsl(accent);
 
     expect(l).toBeGreaterThanOrEqual(WALLPAPER_ACCENT_LIGHTNESS.target);
     expect(s).toBeLessThanOrEqual(WALLPAPER_ACCENT_SATURATION.neutralTint);
@@ -83,7 +107,7 @@ describe("wallpaper accent color normalization", () => {
 
   test("near-white neutral wallpaper does not stay washed out", () => {
     const accent = normalizeWallpaperAccentColor("#f5f5f5");
-    const { s, l } = wallpaperAccentHsl(accent);
+    const { s, l } = hexToHsl(accent);
 
     expect(l).toBeGreaterThanOrEqual(WALLPAPER_ACCENT_LIGHTNESS.target);
     expect(s).toBeLessThanOrEqual(WALLPAPER_ACCENT_SATURATION.neutralTint);
@@ -92,8 +116,8 @@ describe("wallpaper accent color normalization", () => {
   test("colorful wallpaper already in the band keeps its lightness", () => {
     const source = "#2765ca";
     const accent = normalizeWallpaperAccentColor(source);
-    const sourceHsl = wallpaperAccentHsl(source);
-    const accentHsl = wallpaperAccentHsl(accent);
+    const sourceHsl = hexToHsl(source);
+    const accentHsl = hexToHsl(accent);
 
     expectLightnessInBand(accent);
     expect(Math.abs(accentHsl.l - sourceHsl.l)).toBeLessThan(0.02);
@@ -107,8 +131,7 @@ describe("wallpaper accent color normalization", () => {
       "#3949ab",
     ]);
     expectLightnessInBand(accent);
-    const accentHsl = wallpaperAccentHsl(accent);
-    expect(hueDelta(wallpaperAccentHsl("#1a237e").h, accentHsl.h)).toBeLessThanOrEqual(
+    expect(hueDelta(hexToHsl("#1a237e").h, hexToHsl(accent).h)).toBeLessThanOrEqual(
       15
     );
   });

--- a/tests/test-wallpaper-accent-color.test.ts
+++ b/tests/test-wallpaper-accent-color.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, test } from "bun:test";
+import {
+  normalizeWallpaperAccentColor,
+  resolveWallpaperAccentFromPalette,
+  WALLPAPER_ACCENT_LIGHTNESS,
+  WALLPAPER_ACCENT_SATURATION,
+  wallpaperAccentHsl,
+} from "../src/themes/wallpaperAccentColor";
+
+function hueDelta(a: number, b: number): number {
+  const delta = Math.abs(a - b) % 360;
+  return delta > 180 ? 360 - delta : delta;
+}
+
+function expectLightnessInBand(hex: string) {
+  const { l } = wallpaperAccentHsl(hex);
+  expect(l).toBeGreaterThanOrEqual(WALLPAPER_ACCENT_LIGHTNESS.min);
+  expect(l).toBeLessThanOrEqual(WALLPAPER_ACCENT_LIGHTNESS.max);
+}
+
+describe("wallpaper accent color normalization", () => {
+  test("dark wallpaper lifts lightness into the middle band while keeping hue", () => {
+    const source = "#1a237e";
+    const accent = normalizeWallpaperAccentColor(source);
+    const sourceHsl = wallpaperAccentHsl(source);
+    const accentHsl = wallpaperAccentHsl(accent);
+
+    expectLightnessInBand(accent);
+    expect(hueDelta(sourceHsl.h, accentHsl.h)).toBeLessThanOrEqual(5);
+    expect(accentHsl.s).toBeGreaterThanOrEqual(
+      WALLPAPER_ACCENT_SATURATION.colorfulMin
+    );
+  });
+
+  test("light wallpaper lowers lightness into the middle band while keeping hue", () => {
+    const source = "#ffd6e8";
+    const accent = normalizeWallpaperAccentColor(source);
+    const sourceHsl = wallpaperAccentHsl(source);
+    const accentHsl = wallpaperAccentHsl(accent);
+
+    expectLightnessInBand(accent);
+    expect(hueDelta(sourceHsl.h, accentHsl.h)).toBeLessThanOrEqual(5);
+    expect(accentHsl.s).toBeGreaterThanOrEqual(
+      WALLPAPER_ACCENT_SATURATION.colorfulMin
+    );
+  });
+
+  test("saturated wallpaper preserves hue and lands in the lightness band", () => {
+    const source = "#e60026";
+    const accent = normalizeWallpaperAccentColor(source);
+    const sourceHsl = wallpaperAccentHsl(source);
+    const accentHsl = wallpaperAccentHsl(accent);
+
+    expectLightnessInBand(accent);
+    expect(hueDelta(sourceHsl.h, accentHsl.h)).toBeLessThanOrEqual(5);
+    expect(accentHsl.s).toBeGreaterThanOrEqual(
+      WALLPAPER_ACCENT_SATURATION.colorfulMin
+    );
+  });
+
+  test("low-chroma wallpaper becomes a graphite-like neutral without false color", () => {
+    const accent = normalizeWallpaperAccentColor("#808080");
+    const { s, l } = wallpaperAccentHsl(accent);
+
+    expect(s).toBeLessThanOrEqual(WALLPAPER_ACCENT_SATURATION.neutralTint);
+    expect(l).toBeGreaterThanOrEqual(WALLPAPER_ACCENT_LIGHTNESS.target);
+    // Faint tint only — channels stay close (not a false full-chroma accent).
+    const [r, g, b] = [
+      parseInt(accent.slice(1, 3), 16),
+      parseInt(accent.slice(3, 5), 16),
+      parseInt(accent.slice(5, 7), 16),
+    ];
+    expect(Math.max(r, g, b) - Math.min(r, g, b)).toBeLessThanOrEqual(12);
+  });
+
+  test("near-black neutral wallpaper does not collapse to pure black", () => {
+    const accent = normalizeWallpaperAccentColor("#101010");
+    const { s, l } = wallpaperAccentHsl(accent);
+
+    expect(l).toBeGreaterThanOrEqual(WALLPAPER_ACCENT_LIGHTNESS.target);
+    expect(s).toBeLessThanOrEqual(WALLPAPER_ACCENT_SATURATION.neutralTint);
+  });
+
+  test("near-white neutral wallpaper does not stay washed out", () => {
+    const accent = normalizeWallpaperAccentColor("#f5f5f5");
+    const { s, l } = wallpaperAccentHsl(accent);
+
+    expect(l).toBeGreaterThanOrEqual(WALLPAPER_ACCENT_LIGHTNESS.target);
+    expect(s).toBeLessThanOrEqual(WALLPAPER_ACCENT_SATURATION.neutralTint);
+  });
+
+  test("colorful wallpaper already in the band keeps its lightness", () => {
+    const source = "#2765ca";
+    const accent = normalizeWallpaperAccentColor(source);
+    const sourceHsl = wallpaperAccentHsl(source);
+    const accentHsl = wallpaperAccentHsl(accent);
+
+    expectLightnessInBand(accent);
+    expect(Math.abs(accentHsl.l - sourceHsl.l)).toBeLessThan(0.02);
+    expect(hueDelta(sourceHsl.h, accentHsl.h)).toBeLessThanOrEqual(2);
+  });
+
+  test("resolveWallpaperAccentFromPalette normalizes the picked primary color", () => {
+    const accent = resolveWallpaperAccentFromPalette([
+      "#050a30",
+      "#1a237e",
+      "#3949ab",
+    ]);
+    expectLightnessInBand(accent);
+    const accentHsl = wallpaperAccentHsl(accent);
+    expect(hueDelta(wallpaperAccentHsl("#1a237e").h, accentHsl.h)).toBeLessThanOrEqual(
+      15
+    );
+  });
+
+  test("invalid input falls back to the stock blue accent", () => {
+    expect(normalizeWallpaperAccentColor("not-a-color")).toBe("#2765ca");
+    expect(resolveWallpaperAccentFromPalette([])).toBe("#2765ca");
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Wallpaper-derived accent colors were passed through unchanged after palette extraction (`pickPrimaryColor`), so very dark or very light wallpapers produced accents that were too dark or washed out for Aqua/System 7 selection chrome.

This change adds a centralized normalization step that preserves hue (and guarded chroma) while pulling lightness into a consistent middle band aligned with stock manual accents.

## Changes

- **`src/themes/wallpaperAccentColor.ts`** — New module with documented tunables:
  - Lightness target `0.48`, band `0.40–0.52` (matches default blue `#2765ca` and other stock accents)
  - Saturation guards: neutral → graphite-like mid tone; colorful → minimum saturation so vivid wallpapers don't collapse to gray
- **`src/hooks/useWallpaperAccent.ts`** — Uses `resolveWallpaperAccentFromPalette()` instead of raw `pickPrimaryColor()`
- **`tests/test-wallpaper-accent-color.test.ts`** — Coverage for dark, light, saturated, low-chroma, in-band, and palette resolution cases

## Behavior

| Wallpaper type | Before | After |
|----------------|--------|-------|
| Dark saturated (e.g. `#1a237e`) | Near-black accent | Hue preserved, lightness ~0.48 |
| Light pastel (e.g. `#ffd6e8`) | Washed-out accent | Hue preserved, lightness ~0.48 |
| Neutral gray / near-black / near-white | Too extreme | Graphite-like mid tone |
| Already in band (e.g. `#2765ca`) | Unchanged | Unchanged |

Manual accent colors and theme switching are unaffected — normalization only runs on the wallpaper accent pipeline.

## Testing

```
bun test tests/test-wallpaper-accent-color.test.ts
bun run test:unit
```

All unit tests pass (including existing lyrics color extraction tests — iPod glow path unchanged).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d5c3c0e4-994c-4a50-8e8e-b13db7888215"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d5c3c0e4-994c-4a50-8e8e-b13db7888215"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

