### PR TITLE
Lighten wallpaper accent defaults

### DIFF
--- a/src/apps/control-panels/components/control-panels-app/AppearanceTabContent.tsx
+++ b/src/apps/control-panels/components/control-panels-app/AppearanceTabContent.tsx
@@ -11,6 +11,7 @@ import { ScreenSaverPicker } from "../ScreenSaverPicker";
 import type { LanguageCode } from "@/stores/useLanguageStore";
 import { themes } from "@/themes";
 import type { OsThemeId } from "@/themes/types";
+import { cn } from "@/lib/utils";
 import {
   getAccentOptions,
   type AccentChrome,
@@ -18,14 +19,31 @@ import {
 } from "@/themes/accents";
 import type { TabStyleConfig } from "@/utils/tabStyles";
 
-/** Small round color chip shown in the accent Select trigger + menu items. */
-function AccentSwatch({ color }: { color: string }) {
+/** Small color chip shown in the accent Select trigger + menu items. */
+function AccentSwatch({
+  chrome,
+  color,
+}: {
+  chrome: AccentChrome;
+  color: string;
+}) {
+  const isAqua = chrome === "aqua";
+
   return (
     <span
       aria-hidden="true"
-      className="h-3.5 w-3.5 flex-shrink-0 rounded-full border border-black/30 shadow-[inset_0_1px_1px_rgba(255,255,255,0.4)]"
+      className={cn(
+        "relative inline-block flex-shrink-0 overflow-hidden",
+        isAqua
+          ? "h-4 w-4 rounded-[5px] border border-black/25 shadow-[0_1px_1px_rgba(0,0,0,0.2),inset_0_0_0_1px_rgba(255,255,255,0.45)]"
+          : "h-3.5 w-3.5 rounded-none border border-black shadow-none"
+      )}
       style={{ background: color }}
-    />
+    >
+      {isAqua && (
+        <span className="absolute inset-x-[2px] top-[2px] h-[6px] rounded-[3px] bg-gradient-to-b from-white/85 to-white/15" />
+      )}
+    </span>
   );
 }
 
@@ -207,7 +225,7 @@ export function AppearanceTabContent({
                 <SelectTrigger className="w-[120px] flex-shrink-0">
                   <SelectValue placeholder={t("apps.control-panels.select")}>
                     <span className="flex items-center gap-2 min-w-0">
-                      <AccentSwatch color={selectedSwatch} />
+                      <AccentSwatch chrome={accentChrome} color={selectedSwatch} />
                       <span className="truncate">
                         {t(`apps.control-panels.accentColors.${accent}`)}
                       </span>
@@ -218,7 +236,7 @@ export function AppearanceTabContent({
                   {accentOptions.map((option) => (
                     <SelectItem key={option.id} value={option.id}>
                       <span className="flex items-center gap-2">
-                        <AccentSwatch color={option.swatch} />
+                        <AccentSwatch chrome={accentChrome} color={option.swatch} />
                         <span>
                           {t(`apps.control-panels.accentColors.${option.id}`)}
                         </span>

--- a/src/apps/control-panels/components/control-panels-app/AppearanceTabContent.tsx
+++ b/src/apps/control-panels/components/control-panels-app/AppearanceTabContent.tsx
@@ -35,13 +35,47 @@ function AccentSwatch({
       className={cn(
         "relative inline-block flex-shrink-0 overflow-hidden",
         isAqua
-          ? "h-4 w-4 rounded-[5px] border border-black/25 shadow-[0_1px_1px_rgba(0,0,0,0.2),inset_0_0_0_1px_rgba(255,255,255,0.45)]"
+          ? "h-4 w-4 rounded-full border-0"
           : "h-3.5 w-3.5 rounded-none border border-black shadow-none"
       )}
-      style={{ background: color }}
+      style={{
+        background: color,
+        ...(isAqua
+          ? {
+              boxShadow:
+                "0 2px 3px rgba(0,0,0,0.2), 0 1px 1px rgba(0,0,0,0.3), inset 0 0 0 0.5px rgba(0,0,0,0.3), inset 0 1px 2px rgba(0,0,0,0.4), inset 0 2px 3px 1px rgba(255,255,255,0.22)",
+              backdropFilter: "blur(2px)",
+            }
+          : {}),
+      }}
     >
       {isAqua && (
-        <span className="absolute inset-x-[2px] top-[2px] h-[6px] rounded-[3px] bg-gradient-to-b from-white/85 to-white/15" />
+        <>
+          <span
+            className="pointer-events-none absolute left-1/2 z-[2] -translate-x-1/2"
+            style={{
+              top: "2px",
+              height: "30%",
+              width: "calc(100% - 8px)",
+              borderRadius: "9999px 9999px 2px 2px",
+              background:
+                "linear-gradient(rgba(255,255,255,0.9), rgba(255,255,255,0.25))",
+              filter: "blur(0.2px)",
+            }}
+          />
+          <span
+            className="pointer-events-none absolute left-1/2 z-[1] -translate-x-1/2"
+            style={{
+              bottom: "1px",
+              height: "38%",
+              width: "calc(100% - 4px)",
+              borderRadius: "4px 4px 9999px 9999px",
+              background:
+                "linear-gradient(rgba(255,255,255,0.15), rgba(255,255,255,0.55))",
+              filter: "blur(0.3px)",
+            }}
+          />
+        </>
       )}
     </span>
   );

--- a/src/themes/wallpaperAccentColor.ts
+++ b/src/themes/wallpaperAccentColor.ts
@@ -4,11 +4,13 @@ import { pickPrimaryColor } from "@/apps/ipod/components/lyrics-display/colorUti
 type Rgb = { r: number; g: number; b: number };
 type Hsl = { h: number; s: number; l: number };
 
-// HSL lightness band aligned with stock manual accents (blue ~0.47).
+// HSL lightness band for sampled wallpaper accents. It sits a bit lighter than
+// the stock manual accents so the default wallpaper-driven accent reads clearly
+// in both Aqua light and dark mode chrome.
 export const WALLPAPER_ACCENT_LIGHTNESS = {
-  target: 0.48,
-  min: 0.4,
-  max: 0.52,
+  target: 0.56,
+  min: 0.5,
+  max: 0.6,
 } as const;
 
 export const WALLPAPER_ACCENT_SATURATION = {
@@ -113,7 +115,7 @@ export function normalizeWallpaperAccentColor(
       hslToRgb({
         h: hsl.h,
         s: hsl.s <= 0 ? 0 : Math.min(hsl.s, neutralTint),
-        l: Math.max(target, 0.54),
+        l: Math.max(target, 0.58),
       })
     );
   }

--- a/tests/test-wallpaper-accent-color.test.ts
+++ b/tests/test-wallpaper-accent-color.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { getAccentCssVars } from "../src/themes/accents";
 import {
   normalizeWallpaperAccentColor,
   resolveWallpaperAccentFromPalette,
@@ -41,6 +42,14 @@ function expectLightnessInBand(hex: string) {
   const { l } = hexToHsl(hex);
   expect(l).toBeGreaterThanOrEqual(WALLPAPER_ACCENT_LIGHTNESS.min);
   expect(l).toBeLessThanOrEqual(WALLPAPER_ACCENT_LIGHTNESS.max);
+}
+
+function hexToRgbTuple(hex: string): [number, number, number] {
+  return [
+    parseInt(hex.slice(1, 3), 16),
+    parseInt(hex.slice(3, 5), 16),
+    parseInt(hex.slice(5, 7), 16),
+  ];
 }
 
 describe("wallpaper accent color normalization", () => {
@@ -113,8 +122,8 @@ describe("wallpaper accent color normalization", () => {
     expect(s).toBeLessThanOrEqual(WALLPAPER_ACCENT_SATURATION.neutralTint);
   });
 
-  test("colorful wallpaper already in the band keeps its lightness", () => {
-    const source = "#2765ca";
+  test("colorful wallpaper already in the lighter band keeps its lightness", () => {
+    const source = "#4485d6";
     const accent = normalizeWallpaperAccentColor(source);
     const sourceHsl = hexToHsl(source);
     const accentHsl = hexToHsl(accent);
@@ -122,6 +131,18 @@ describe("wallpaper accent color normalization", () => {
     expectLightnessInBand(accent);
     expect(Math.abs(accentHsl.l - sourceHsl.l)).toBeLessThan(0.02);
     expect(hueDelta(sourceHsl.h, accentHsl.h)).toBeLessThanOrEqual(2);
+  });
+
+  test("light and dark Aqua wallpaper vars both use the lighter sampled base", () => {
+    const accent = normalizeWallpaperAccentColor("#1a237e");
+    const [r, g, b] = hexToRgbTuple(accent);
+    const expectedRgb = `rgba(${r}, ${g}, ${b},`;
+    const lightVars = getAccentCssVars("aqua", "wallpaper", false, accent);
+    const darkVars = getAccentCssVars("aqua", "wallpaper", true, accent);
+
+    expect(hexToHsl(accent).l).toBeGreaterThan(0.52);
+    expect(lightVars["--os-color-selection-bg"]).toStartWith(expectedRgb);
+    expect(darkVars["--os-color-selection-bg"]).toStartWith(expectedRgb);
   });
 
   test("resolveWallpaperAccentFromPalette normalizes the picked primary color", () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Lighten normalized wallpaper accent colors so the default wallpaper-derived accent is brighter in both Aqua light and dark mode.
- Style Control Panels accent chips by Mac chrome: circular glossy Aqua button-style chips for Aqua and flat square chips for System 7.
- Update focused wallpaper accent tests to cover the lighter lightness band and light/dark CSS variable output.

## Testing
- Earlier: `bun test tests/test-wallpaper-accent-color.test.ts`
- Earlier: `bun run tsc -b --pretty false`
- Skipped local testing for the latest chip refinement per request; pushed only.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019e9d97-e913-7796-8ed8-8164c67fc1e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019e9d97-e913-7796-8ed8-8164c67fc1e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

