### PR TITLE
Make Chats IRC badge gray

### DIFF
--- a/src/apps/chats/components/ChatRoomSidebar.tsx
+++ b/src/apps/chats/components/ChatRoomSidebar.tsx
@@ -118,7 +118,10 @@ export const ChatRoomSidebar = React.memo(function ChatRoomSidebar({
           </span>
           {room.type === "irc" && (
             <span
-              className="ml-1 text-[9px] font-bold uppercase tracking-wider text-purple-700/70"
+              className={cn(
+                "ml-1 text-[9px] font-bold uppercase tracking-wider",
+                isSelected ? "text-white/40" : "text-black/40"
+              )}
               title={`IRC ${room.ircHost || "irc.pieter.com"}`}
             >
               irc


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Make the Chats sidebar IRC badge use the same gray selected/unselected text treatment as the online count.

### Walkthrough
<a href="https://cursor.com/agents/bc-019e9dca-d995-771b-9b1e-733121efa8cc/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fchats_irc_badge_gray_demo.mp4"><img src="https://cursor.com/artifacts/c/art-78bd5107-286a-4dc7-872e-a8c71511b323" alt="chats_irc_badge_gray_demo.mp4" /></a>
![Chats IRC badge selected state](https://cursor.com/artifacts/c/art-da9c0b97-e69d-479b-9d4b-dbabf805f0c2)

### Testing
- `bun run build` passed.
- Manual Chrome walkthrough on `http://localhost:5173/` passed: created a local IRC room through the real API, opened Chats, and confirmed the badge matches the online text in selected and unselected states.
- Playwright screenshot capture passed and saved `/opt/cursor/artifacts/chats_irc_badge_gray_selected.png`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019e9dca-d995-771b-9b1e-733121efa8cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019e9dca-d995-771b-9b1e-733121efa8cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

