### PR TITLE
Make tool success checkmarks follow accent color

### DIFF
--- a/src/apps/terminal/components/TerminalToolInvocation.tsx
+++ b/src/apps/terminal/components/TerminalToolInvocation.tsx
@@ -335,7 +335,7 @@ export function TerminalToolInvocation({
         <>
           <Check
             className="size-3 flex-shrink-0"
-            style={{ color: "var(--os-color-selection-bg)" }}
+            style={{ color: "var(--os-accent-color, var(--os-color-selection-bg))" }}
             weight="bold"
           />
           <span className="italic">{displayResultMessage}</span>

--- a/src/apps/terminal/components/TerminalToolInvocation.tsx
+++ b/src/apps/terminal/components/TerminalToolInvocation.tsx
@@ -333,7 +333,11 @@ export function TerminalToolInvocation({
     >
       {state === "output-available" && displayResultMessage ? (
         <>
-          <Check className="size-3 text-green-400 flex-shrink-0" weight="bold" />
+          <Check
+            className="size-3 flex-shrink-0"
+            style={{ color: "var(--os-color-selection-bg)" }}
+            weight="bold"
+          />
           <span className="italic">{displayResultMessage}</span>
         </>
       ) : state === "output-error" ? (

--- a/src/components/shared/CursorRepoAgentChatCard.tsx
+++ b/src/components/shared/CursorRepoAgentChatCard.tsx
@@ -111,7 +111,7 @@ export function CursorRepoAgentChatCard({
             <span className="inline-flex size-3 shrink-0 items-center justify-center pt-0.5">
               <Check
                 className="size-3"
-                style={{ color: "var(--os-color-selection-bg)" }}
+                style={{ color: "var(--os-accent-color, var(--os-color-selection-bg))" }}
                 weight="bold"
               />
             </span>

--- a/src/components/shared/CursorRepoAgentChatCard.tsx
+++ b/src/components/shared/CursorRepoAgentChatCard.tsx
@@ -109,7 +109,11 @@ export function CursorRepoAgentChatCard({
         <div className="mb-2 px-0.5">
           <div className="flex items-start gap-1 text-[12px] text-neutral-800 dark:text-neutral-200">
             <span className="inline-flex size-3 shrink-0 items-center justify-center pt-0.5">
-              <Check className="size-3 text-blue-600 dark:text-blue-400" weight="bold" />
+              <Check
+                className="size-3"
+                style={{ color: "var(--os-color-selection-bg)" }}
+                weight="bold"
+              />
             </span>
             <span className="italic leading-snug">{introMessage}</span>
           </div>

--- a/src/components/shared/tool-invocation-message/ToolInvocationMessageDefaultView.tsx
+++ b/src/components/shared/tool-invocation-message/ToolInvocationMessageDefaultView.tsx
@@ -53,7 +53,7 @@ export function ToolInvocationMessageDefaultView({
           icon={
             <Check
               className="size-3"
-              style={{ color: "var(--os-color-selection-bg)" }}
+              style={{ color: "var(--os-accent-color, var(--os-color-selection-bg))" }}
               weight="bold"
             />
           }

--- a/src/components/shared/tool-invocation-message/ToolInvocationMessageDefaultView.tsx
+++ b/src/components/shared/tool-invocation-message/ToolInvocationMessageDefaultView.tsx
@@ -50,7 +50,13 @@ export function ToolInvocationMessageDefaultView({
         )}
       {state === "output-available" && (
         <ToolInvocationStatusRow
-          icon={<Check className="size-3 text-blue-600 dark:text-blue-400" weight="bold" />}
+          icon={
+            <Check
+              className="size-3"
+              style={{ color: "var(--os-color-selection-bg)" }}
+              weight="bold"
+            />
+          }
           className="text-neutral-700 dark:text-neutral-200"
           align="start"
         >

--- a/src/components/shared/tool-invocation-message/tryRenderToolInvocationSpecialContent.tsx
+++ b/src/components/shared/tool-invocation-message/tryRenderToolInvocationSpecialContent.tsx
@@ -99,7 +99,8 @@ export function tryRenderToolInvocationSpecialContent(
           <ToolInvocationStatusRow
             icon={
               <Check
-                className="size-3 text-blue-600 dark:text-blue-400"
+                className="size-3"
+                style={{ color: "var(--os-color-selection-bg)" }}
                 weight="bold"
               />
             }
@@ -141,7 +142,13 @@ export function tryRenderToolInvocationSpecialContent(
       return (
         <div key={partKey} className="mb-0 px-1 py-0.5 text-[12px]">
           <ToolInvocationStatusRow
-            icon={<Check className="size-3 text-blue-600 dark:text-blue-400" weight="bold" />}
+            icon={
+              <Check
+                className="size-3"
+                style={{ color: "var(--os-color-selection-bg)" }}
+                weight="bold"
+              />
+            }
             className="text-neutral-700 dark:text-neutral-200"
             align="start"
           >

--- a/src/components/shared/tool-invocation-message/tryRenderToolInvocationSpecialContent.tsx
+++ b/src/components/shared/tool-invocation-message/tryRenderToolInvocationSpecialContent.tsx
@@ -100,7 +100,7 @@ export function tryRenderToolInvocationSpecialContent(
             icon={
               <Check
                 className="size-3"
-                style={{ color: "var(--os-color-selection-bg)" }}
+                style={{ color: "var(--os-accent-color, var(--os-color-selection-bg))" }}
                 weight="bold"
               />
             }
@@ -145,7 +145,7 @@ export function tryRenderToolInvocationSpecialContent(
             icon={
               <Check
                 className="size-3"
-                style={{ color: "var(--os-color-selection-bg)" }}
+                style={{ color: "var(--os-accent-color, var(--os-color-selection-bg))" }}
                 weight="bold"
               />
             }

--- a/src/themes/accents.ts
+++ b/src/themes/accents.ts
@@ -359,6 +359,7 @@ export function getAccentCssVars(
   if (chrome === "system7") {
     // System 7 selections are flat fills — no gradients.
     return {
+      "--os-accent-color": rgb(base),
       "--os-color-selection-bg": rgb(base),
       "--os-color-selection-text": text,
       "--os-color-input-focus-border": rgb(base),
@@ -431,6 +432,7 @@ export function getAccentCssVars(
       )} 100%)`;
 
   return {
+    "--os-accent-color": rgb(base),
     "--os-color-selection-bg": rgba(base, selectionAlpha),
     "--os-color-selection-text": text,
     "--os-color-selection-text-shadow": "none",
@@ -471,6 +473,7 @@ export function getAccentCssVars(
 
 /** CSS custom properties that this module may set, so callers can clear them. */
 export const ACCENT_CSS_VAR_NAMES = [
+  "--os-accent-color",
   "--os-color-selection-bg",
   "--os-color-selection-text",
   "--os-color-selection-text-shadow",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Make tool-call success checkmarks use the active OS accent color via a solid accent CSS token, with selection color as the fallback for default theme behavior.

### Testing
- `bun run lint` passed.
- `bun run build` passed.
- `rg "text-blue-600 dark:text-blue-400|text-green-400 flex-shrink-0|style=\{\{ color: \"var\(--os-color-selection-bg\)\"" src --glob "*.tsx"` returned no matches for the old tool-call success color patterns.

Note: visual testing was stopped per request.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019e9e2c-530d-73e5-8035-3168fc9d27d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019e9e2c-530d-73e5-8035-3168fc9d27d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

