### PR TITLE
Add desktop rounded corner mask

### DIFF
--- a/src/apps/base/app-manager/AppManagerView.tsx
+++ b/src/apps/base/app-manager/AppManagerView.tsx
@@ -1,5 +1,6 @@
 import { MenuBar } from "@/components/layout/MenuBar";
 import { Desktop } from "@/components/layout/Desktop";
+import { DesktopCornerMask } from "@/components/layout/desktop/DesktopCornerMask";
 import { Dock } from "@/components/layout/Dock";
 import { ExposeView } from "@/components/layout/ExposeView";
 import { getAppComponent } from "@/config/appRegistry";
@@ -74,6 +75,7 @@ export function AppManagerView({
         apps={switcherApps}
         selectedIndex={switcherIndex}
       />
+      <DesktopCornerMask />
     </>
   );
 }

--- a/src/components/layout/desktop/DesktopCornerMask.tsx
+++ b/src/components/layout/desktop/DesktopCornerMask.tsx
@@ -1,7 +1,7 @@
 import type { CSSProperties } from "react";
 import { useThemeFlags } from "@/hooks/useThemeFlags";
 
-const CORNER_SIZE = 18;
+const CORNER_SIZE = 14;
 const CORNER_MASK_Z_INDEX = 10004;
 
 const sharedCornerStyle: CSSProperties = {

--- a/src/components/layout/desktop/DesktopCornerMask.tsx
+++ b/src/components/layout/desktop/DesktopCornerMask.tsx
@@ -1,4 +1,5 @@
 import type { CSSProperties } from "react";
+import { useThemeFlags } from "@/hooks/useThemeFlags";
 
 const CORNER_SIZE = 18;
 const CORNER_MASK_Z_INDEX = 10004;
@@ -39,6 +40,10 @@ const corners: Array<{
 ];
 
 export function DesktopCornerMask() {
+  const { isMacOSTheme, isSystem7Theme } = useThemeFlags();
+
+  if (!isMacOSTheme && !isSystem7Theme) return null;
+
   return (
     <div
       aria-hidden="true"

--- a/src/components/layout/desktop/DesktopCornerMask.tsx
+++ b/src/components/layout/desktop/DesktopCornerMask.tsx
@@ -1,0 +1,57 @@
+import type { CSSProperties } from "react";
+
+const CORNER_SIZE = 18;
+const CORNER_MASK_Z_INDEX = 10004;
+
+const sharedCornerStyle: CSSProperties = {
+  width: CORNER_SIZE,
+  height: CORNER_SIZE,
+};
+
+const corners: Array<{
+  className: string;
+  style: CSSProperties;
+}> = [
+  {
+    className: "left-0 top-0",
+    style: {
+      background: `radial-gradient(circle at 100% 100%, transparent 0 ${CORNER_SIZE - 0.5}px, #000 ${CORNER_SIZE}px)`,
+    },
+  },
+  {
+    className: "right-0 top-0",
+    style: {
+      background: `radial-gradient(circle at 0 100%, transparent 0 ${CORNER_SIZE - 0.5}px, #000 ${CORNER_SIZE}px)`,
+    },
+  },
+  {
+    className: "bottom-0 left-0",
+    style: {
+      background: `radial-gradient(circle at 100% 0, transparent 0 ${CORNER_SIZE - 0.5}px, #000 ${CORNER_SIZE}px)`,
+    },
+  },
+  {
+    className: "bottom-0 right-0",
+    style: {
+      background: `radial-gradient(circle at 0 0, transparent 0 ${CORNER_SIZE - 0.5}px, #000 ${CORNER_SIZE}px)`,
+    },
+  },
+];
+
+export function DesktopCornerMask() {
+  return (
+    <div
+      aria-hidden="true"
+      className="pointer-events-none fixed inset-0"
+      style={{ zIndex: CORNER_MASK_Z_INDEX }}
+    >
+      {corners.map(({ className, style }) => (
+        <span
+          key={className}
+          className={`absolute block ${className}`}
+          style={{ ...sharedCornerStyle, ...style }}
+        />
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add a non-interactive black rounded corner mask above the ryOS desktop/menu bar chrome.
- Scope the mask to the Mac themes only: macOS Aqua (`macosx`) and System 7 (`system7`).
- Reduce the corner radius to 14px for a subtler mask.

## Walkthrough
<a href="https://cursor.com/agents/bc-019e9e91-7bcb-7568-a9c5-e0f74b6c0299/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdesktop_corner_mask_mac_themes.mp4"><img src="https://cursor.com/artifacts/c/art-2b130bf9-b3e7-459a-bb01-1dbed289da68" alt="desktop_corner_mask_mac_themes.mp4" /></a>

![macOS Aqua corner mask](https://cursor.com/artifacts/c/art-8cba4259-a051-4b60-bec9-ccd06b9d12ae)
![System 7 corner mask](https://cursor.com/artifacts/c/art-f35c647d-c638-4349-8935-ef8c716af824)
![Windows XP without corner mask](https://cursor.com/artifacts/c/art-a4a907b8-5764-44bc-9e7d-268568c58494)

## Testing
- `bun run build` passed.
- Browser DOM verification passed for `macosx`, `system7`, `xp`, and `win98`, confirming the 14px mask exists only on the Mac themes.
- Manual browser walkthrough passed for `macosx`, `system7`, and `xp`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019e9e91-7bcb-7568-a9c5-e0f74b6c0299"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019e9e91-7bcb-7568-a9c5-e0f74b6c0299"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

