### PR TITLE
Set dandelion seeds as default wallpaper

### DIFF
--- a/src/stores/useDisplaySettingsStore.ts
+++ b/src/stores/useDisplaySettingsStore.ts
@@ -12,9 +12,9 @@ import { convertImageFileToWallpaperJpeg } from "@/utils/customWallpaperProcessi
 import { useCloudSyncStore } from "@/stores/useCloudSyncStore";
 import { SETTINGS_ANALYTICS, track } from "@/utils/analytics";
 
-/** Default desktop wallpaper (nature photo). */
+/** Default desktop wallpaper (plants photo). */
 export const DEFAULT_WALLPAPER_PATH =
-  "/wallpapers/photos/nature/earth_horizon.jpg";
+  "/wallpapers/photos/plants/dandelion_seeds.jpg";
 
 /**
  * Display settings store - manages wallpaper, shaders, and screen saver settings.

--- a/tests/test-wallpaper-cloud-sync-debug.test.ts
+++ b/tests/test-wallpaper-cloud-sync-debug.test.ts
@@ -98,12 +98,22 @@ describe("wallpaper cloud sync debug reproduction", () => {
     const { useDisplaySettingsStore, DEFAULT_WALLPAPER_PATH } = await import(
       "../src/stores/useDisplaySettingsStore"
     );
+    const wallpaperManifest = await Bun.file(
+      "public/wallpapers/manifest.json"
+    ).json();
     const syncDomainChecks: string[] = [];
     const unsubscribe = subscribeToCloudSyncDomainCheckRequests((domain) => {
       syncDomainChecks.push(domain);
     });
 
     try {
+      expect(DEFAULT_WALLPAPER_PATH).toBe(
+        "/wallpapers/photos/plants/dandelion_seeds.jpg"
+      );
+      expect(wallpaperManifest.photos.plants).toContain(
+        "photos/plants/dandelion_seeds.jpg"
+      );
+
       useDisplaySettingsStore.setState({
         currentWallpaper: DEFAULT_WALLPAPER_PATH,
         wallpaperSource: DEFAULT_WALLPAPER_PATH,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Set the built-in default wallpaper to `dandelion_seeds.jpg`.
- Added a focused regression assertion that the default path is present in the wallpaper manifest.

### Walkthrough
![Default dandelion wallpaper](https://cursor.com/artifacts/c/art-947b2ea6-9ca1-4bdf-bbd3-b9860906607d)

<a href="https://cursor.com/agents/bc-019e9eab-5964-776c-b9a3-7d376f92333a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdefault_dandelion_wallpaper_static_demo.mp4"><img src="https://cursor.com/artifacts/c/art-6a7f590b-4c01-47cc-8025-3e4bf530e955" alt="default_dandelion_wallpaper_static_demo.mp4" /></a>

### Testing
- `bun test tests/test-wallpaper-cloud-sync-debug.test.ts`
- `bun run build`
- Browser DOM assertion confirmed the computed desktop background URL is `http://localhost:5173/wallpapers/photos/plants/dandelion_seeds.jpg`.
- Manual browser verification confirmed the desktop displays the requested dandelion seeds wallpaper.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019e9eab-5964-776c-b9a3-7d376f92333a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019e9eab-5964-776c-b9a3-7d376f92333a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

