### PR TITLE
Scope IRC channel updates to active chat rooms

### DIFF
--- a/api/_utils/irc/_bridge.ts
+++ b/api/_utils/irc/_bridge.ts
@@ -38,6 +38,7 @@ import {
   parseRoomData,
   setRoom,
 } from "../../rooms/_helpers/_redis.js";
+import { refreshRoomUserCount } from "../../rooms/_helpers/_presence.js";
 import { createRedis } from "../redis.js";
 import { broadcastNewMessage } from "../../rooms/_helpers/_pusher.js";
 import { CHAT_ROOM_PREFIX } from "../../rooms/_helpers/_constants.js";
@@ -138,8 +139,8 @@ export class IrcBridge extends EventEmitter {
   }
 
   /**
-   * Initialize the bridge by loading all Room records flagged as IRC rooms
-   * from Redis and connecting / joining them.
+   * Initialize the bridge by loading active IRC rooms from Redis. Rooms with no
+   * active presence stay unbound until a user enters them.
    */
   async initialize(): Promise<void> {
     if (this.initialized) return;
@@ -163,8 +164,11 @@ export class IrcBridge extends EventEmitter {
         if (room.type !== "irc") continue;
         if (!room.ircChannel) continue;
 
+        const userCount = await refreshRoomUserCount(room.id);
+        if (userCount <= 0) continue;
+
         try {
-          await this.bindRoom(room);
+          await this.bindRoom({ ...room, userCount });
         } catch (err) {
           console.error(
             `[IrcBridge] Failed to bind room ${room.id} during init:`,
@@ -197,11 +201,13 @@ export class IrcBridge extends EventEmitter {
       this.connectServer(server);
     }
 
-    const existing = server.channels.get(channel) || new Set<string>();
-    existing.add(room.id);
-    server.channels.set(channel, existing);
+    const existing = server.channels.get(channel);
+    const wasBound = Boolean(existing?.size);
+    const roomIds = existing || new Set<string>();
+    roomIds.add(room.id);
+    server.channels.set(channel, roomIds);
 
-    if (server.ready) {
+    if (server.ready && !wasBound) {
       if (!server.pendingJoins.has(channel)) {
         server.pendingJoins.add(channel);
         server.client?.join(channel);
@@ -713,6 +719,25 @@ export async function notifyRoomBindingChange(
     await bridge.bindRoom(room);
   } else {
     await bridge.unbindRoom(room);
+  }
+}
+
+/**
+ * Keep IRC bridge bindings aligned with active room presence.
+ */
+export async function syncRoomBindingForPresence(
+  room: Room,
+  userCount: number
+): Promise<void> {
+  if (room.type !== "irc") return;
+  const g = globalThis as GlobalWithBridge;
+  const bridge = g[GLOBAL_KEY];
+  if (!bridge) return;
+
+  if (userCount > 0) {
+    await bridge.bindRoom({ ...room, userCount });
+  } else {
+    await bridge.unbindRoom({ ...room, userCount });
   }
 }
 

--- a/api/presence/switch.ts
+++ b/api/presence/switch.ts
@@ -10,6 +10,10 @@ import { getRoomWriteAccessError } from "../rooms/_helpers/_access.js";
 import { setRoomPresence, removeRoomPresence, refreshRoomUserCount } from "../rooms/_helpers/_presence.js";
 import { broadcastRoomUpdated, broadcastPresenceUpdate } from "../rooms/_helpers/_pusher.js";
 import { ensureUserExists } from "../rooms/_helpers/_users.js";
+import {
+  isIrcBridgeEnabled,
+  syncRoomBindingForPresence,
+} from "../_utils/irc/_bridge.js";
 
 export const runtime = "nodejs";
 export const maxDuration = 15;
@@ -67,6 +71,13 @@ export default apiHandler(
         if (roomData && roomData.type !== "private") {
           await removeRoomPresence(previousRoomId, username);
           const prevCount = await refreshRoomUserCount(previousRoomId);
+          if (isIrcBridgeEnabled()) {
+            try {
+              await syncRoomBindingForPresence(roomData, prevCount);
+            } catch (err) {
+              logger.warn("IRC bridge presence unbind failed", err);
+            }
+          }
           await Promise.all([
             broadcastRoomUpdated(previousRoomId),
             broadcastPresenceUpdate(previousRoomId, { username, action: "left", userCount: prevCount }),
@@ -91,7 +102,15 @@ export default apiHandler(
 
         await setRoomPresence(nextRoomId, username);
         const userCount = await refreshRoomUserCount(nextRoomId);
-        await setRoom(nextRoomId, { ...roomData, userCount });
+        const updatedRoom = { ...roomData, userCount };
+        await setRoom(nextRoomId, updatedRoom);
+        if (isIrcBridgeEnabled()) {
+          try {
+            await syncRoomBindingForPresence(updatedRoom, userCount);
+          } catch (err) {
+            logger.warn("IRC bridge presence bind failed", err);
+          }
+        }
         await Promise.all([
           broadcastRoomUpdated(nextRoomId),
           broadcastPresenceUpdate(nextRoomId, { username, action: "joined", userCount }),

--- a/api/rooms/[id]/join.ts
+++ b/api/rooms/[id]/join.ts
@@ -10,6 +10,10 @@ import { getRoomWriteAccessError } from "../_helpers/_access.js";
 import { setRoomPresence, refreshRoomUserCount } from "../_helpers/_presence.js";
 import { broadcastRoomUpdated, broadcastPresenceUpdate } from "../_helpers/_pusher.js";
 import type { Room } from "../_helpers/_types.js";
+import {
+  isIrcBridgeEnabled,
+  syncRoomBindingForPresence,
+} from "../../_utils/irc/_bridge.js";
 
 export const runtime = "nodejs";
 export const maxDuration = 15;
@@ -83,6 +87,13 @@ export default apiHandler(
       const userCount = await refreshRoomUserCount(roomId);
       const updatedRoom: Room = { ...roomData, userCount };
       await setRoom(roomId, updatedRoom);
+      if (isIrcBridgeEnabled()) {
+        try {
+          await syncRoomBindingForPresence(updatedRoom, userCount);
+        } catch (err) {
+          logger.warn("IRC bridge presence bind failed", err);
+        }
+      }
       await Promise.all([
         broadcastRoomUpdated(roomId),
         broadcastPresenceUpdate(roomId, { username, action: "joined", userCount }),

--- a/api/rooms/[id]/leave.ts
+++ b/api/rooms/[id]/leave.ts
@@ -19,6 +19,10 @@ import {
 } from "../_helpers/_presence.js";
 import { broadcastRoomDeleted, broadcastRoomUpdated, broadcastPresenceUpdate } from "../_helpers/_pusher.js";
 import type { Room } from "../_helpers/_types.js";
+import {
+  isIrcBridgeEnabled,
+  syncRoomBindingForPresence,
+} from "../../_utils/irc/_bridge.js";
 
 export const runtime = "nodejs";
 export const maxDuration = 15;
@@ -82,6 +86,13 @@ export default apiHandler(
 
       if (removed) {
         const userCount = await refreshRoomUserCount(roomId);
+        if (isIrcBridgeEnabled() && roomData.type !== "private") {
+          try {
+            await syncRoomBindingForPresence(roomData, userCount);
+          } catch (err) {
+            logger.warn("IRC bridge presence unbind failed", err);
+          }
+        }
 
         if (roomData.type === "private") {
           const updatedMembers = roomData.members ? roomData.members.filter((m) => m !== username) : [];

--- a/api/rooms/index.ts
+++ b/api/rooms/index.ts
@@ -21,7 +21,6 @@ import {
 } from "../_utils/irc/_types.js";
 import { getIrcServer } from "../_utils/irc/_servers.js";
 import {
-  notifyRoomBindingChange,
   isIrcBridgeEnabled,
   getIrcBridge,
 } from "../_utils/irc/_bridge.js";
@@ -269,14 +268,6 @@ export default apiHandler(
 
       if (type === "private") {
         await Promise.all(normalizedMembers.map((member: string) => setRoomPresence(roomId, member)));
-      }
-
-      if (type === "irc" && isIrcBridgeEnabled()) {
-        try {
-          await notifyRoomBindingChange("bind", room);
-        } catch (err) {
-          logger.warn("IRC bridge bind failed", err);
-        }
       }
 
       await broadcastRoomCreated(room);

--- a/src/apps/chats/hooks/useChatRoom.ts
+++ b/src/apps/chats/hooks/useChatRoom.ts
@@ -23,6 +23,11 @@ const getGlobalChannelName = (username?: string | null): string =>
     ? `chats-${username.toLowerCase().replace(/[^a-zA-Z0-9_\-.]/g, "_")}`
     : "chats-public";
 
+const shouldSubscribeToRoomUpdates = (
+  room: Pick<ChatRoom, "id" | "type">,
+  currentRoomId: string | null
+): boolean => room.type !== "irc" || room.id === currentRoomId;
+
 interface GlobalHandlers {
   onRoomCreated: (data: { room: ChatRoom }) => void;
   onRoomDeleted: (data: { roomId: string }) => void;
@@ -452,17 +457,35 @@ export function useChatRoom(
       const { unreadCounts } = useChatsStore.getState();
       const hadUnreads = newRoomId ? (unreadCounts[newRoomId] || 0) > 0 : false;
 
-      // Simply switch room; we keep subscriptions so notifications still arrive.
+      const previousRoom = currentRoomId
+        ? rooms.find((room) => room.id === currentRoomId)
+        : null;
+
       await switchRoom(newRoomId);
 
-      // Ensure we're subscribed to the new room channel (no-op if already)
-      if (newRoomId) {
-        subscribeToRoomChannel(newRoomId);
+      if (previousRoom?.type === "irc" && currentRoomId) {
+        unsubscribeFromRoomChannel(currentRoomId);
+      }
+
+      const nextRoom = newRoomId
+        ? rooms.find((room) => room.id === newRoomId)
+        : null;
+      if (
+        nextRoom &&
+        shouldSubscribeToRoomUpdates(nextRoom, newRoomId)
+      ) {
+        subscribeToRoomChannel(nextRoom.id);
       }
 
       return { hadUnreads };
     },
-    [currentRoomId, switchRoom, subscribeToRoomChannel]
+    [
+      currentRoomId,
+      rooms,
+      switchRoom,
+      subscribeToRoomChannel,
+      unsubscribeFromRoomChannel,
+    ]
   );
 
   const sendRoomMessage = useCallback(
@@ -658,23 +681,31 @@ export function useChatRoom(
     subscribeToGlobalChannel();
   }, [isWindowOpen, username, subscribeToGlobalChannel]);
 
-  // Maintain subscriptions for ALL visible rooms
+  // Maintain subscriptions for visible rooms; IRC rooms are live only while open.
   useEffect(() => {
     if (!isWindowOpen) return;
 
-    // Subscribe to any room we can see
+    const visibleRoomsById = new Map(rooms.map((room) => [room.id, room]));
+
     rooms.forEach((room) => {
-      subscribeToRoomChannel(room.id);
+      if (shouldSubscribeToRoomUpdates(room, currentRoomId)) {
+        subscribeToRoomChannel(room.id);
+      }
     });
 
-    // Unsubscribe from rooms no longer visible
     Object.keys(roomChannelsRef.current).forEach((roomId) => {
-      const stillVisible = rooms.some((room) => room.id === roomId);
-      if (!stillVisible) {
+      const room = visibleRoomsById.get(roomId);
+      if (!room || !shouldSubscribeToRoomUpdates(room, currentRoomId)) {
         unsubscribeFromRoomChannel(roomId);
       }
     });
-  }, [isWindowOpen, rooms, subscribeToRoomChannel, unsubscribeFromRoomChannel]);
+  }, [
+    isWindowOpen,
+    rooms,
+    currentRoomId,
+    subscribeToRoomChannel,
+    unsubscribeFromRoomChannel,
+  ]);
 
   // Cleanup on unmount
   useEffect(() => {

--- a/src/apps/chats/hooks/useChatRoom.ts
+++ b/src/apps/chats/hooks/useChatRoom.ts
@@ -17,16 +17,12 @@ import { showRoomMessageNotification } from "@/utils/chatNotificationDisplay";
 import { decodeHtmlEntities } from "@/utils/decodeHtmlEntities";
 import { getApiUrl } from "@/utils/platform";
 import { abortableFetch } from "@/utils/abortableFetch";
+import { shouldSubscribeToForegroundRoomUpdates } from "@/utils/chatRoomSubscriptions";
 
 const getGlobalChannelName = (username?: string | null): string =>
   username
     ? `chats-${username.toLowerCase().replace(/[^a-zA-Z0-9_\-.]/g, "_")}`
     : "chats-public";
-
-const shouldSubscribeToRoomUpdates = (
-  room: Pick<ChatRoom, "id" | "type">,
-  currentRoomId: string | null
-): boolean => room.type !== "irc" || room.id === currentRoomId;
 
 interface GlobalHandlers {
   onRoomCreated: (data: { room: ChatRoom }) => void;
@@ -472,7 +468,7 @@ export function useChatRoom(
         : null;
       if (
         nextRoom &&
-        shouldSubscribeToRoomUpdates(nextRoom, newRoomId)
+        shouldSubscribeToForegroundRoomUpdates(nextRoom, newRoomId)
       ) {
         subscribeToRoomChannel(nextRoom.id);
       }
@@ -688,14 +684,17 @@ export function useChatRoom(
     const visibleRoomsById = new Map(rooms.map((room) => [room.id, room]));
 
     rooms.forEach((room) => {
-      if (shouldSubscribeToRoomUpdates(room, currentRoomId)) {
+      if (shouldSubscribeToForegroundRoomUpdates(room, currentRoomId)) {
         subscribeToRoomChannel(room.id);
       }
     });
 
     Object.keys(roomChannelsRef.current).forEach((roomId) => {
       const room = visibleRoomsById.get(roomId);
-      if (!room || !shouldSubscribeToRoomUpdates(room, currentRoomId)) {
+      if (
+        !room ||
+        !shouldSubscribeToForegroundRoomUpdates(room, currentRoomId)
+      ) {
         unsubscribeFromRoomChannel(roomId);
       }
     });

--- a/src/hooks/useBackgroundChatNotifications.ts
+++ b/src/hooks/useBackgroundChatNotifications.ts
@@ -19,6 +19,10 @@ const getGlobalChannelName = (username?: string | null): string =>
     ? `chats-${username.toLowerCase().replace(/[^a-zA-Z0-9_\-.]/g, "_")}`
     : "chats-public";
 
+const shouldSubscribeInBackground = (
+  room: Pick<ChatRoom, "type">
+): boolean => room.type !== "irc";
+
 const toTimestamp = (value: string | number): number =>
   (() => {
     if (typeof value !== "string" && typeof value !== "number") {
@@ -296,13 +300,18 @@ export function useBackgroundChatNotifications() {
       return;
     }
 
-    rooms.forEach((room) => {
+    const backgroundRoomsById = new Map(
+      rooms
+        .filter(shouldSubscribeInBackground)
+        .map((room) => [room.id, room])
+    );
+
+    backgroundRoomsById.forEach((room) => {
       subscribeToRoomChannel(room.id);
     });
 
     Object.keys(roomChannelsRef.current).forEach((roomId) => {
-      const stillVisible = rooms.some((room) => room.id === roomId);
-      if (!stillVisible) {
+      if (!backgroundRoomsById.has(roomId)) {
         unsubscribeFromRoomChannel(roomId);
       }
     });

--- a/src/hooks/useBackgroundChatNotifications.ts
+++ b/src/hooks/useBackgroundChatNotifications.ts
@@ -13,15 +13,12 @@ import { removeChatRoomById, upsertChatRoom } from "@/utils/chatRoomList";
 import { shouldNotifyForRoomMessage } from "@/utils/chatNotifications";
 import { showRoomMessageNotification } from "@/utils/chatNotificationDisplay";
 import { decodeHtmlEntities } from "@/utils/decodeHtmlEntities";
+import { shouldSubscribeToBackgroundRoomUpdates } from "@/utils/chatRoomSubscriptions";
 
 const getGlobalChannelName = (username?: string | null): string =>
   username
     ? `chats-${username.toLowerCase().replace(/[^a-zA-Z0-9_\-.]/g, "_")}`
     : "chats-public";
-
-const shouldSubscribeInBackground = (
-  room: Pick<ChatRoom, "type">
-): boolean => room.type !== "irc";
 
 const toTimestamp = (value: string | number): number =>
   (() => {
@@ -302,7 +299,7 @@ export function useBackgroundChatNotifications() {
 
     const backgroundRoomsById = new Map(
       rooms
-        .filter(shouldSubscribeInBackground)
+        .filter(shouldSubscribeToBackgroundRoomUpdates)
         .map((room) => [room.id, room])
     );
 

--- a/src/utils/chatRoomSubscriptions.ts
+++ b/src/utils/chatRoomSubscriptions.ts
@@ -1,0 +1,12 @@
+import type { ChatRoom } from "@/types/chat";
+
+type RoomSubscriptionSummary = Pick<ChatRoom, "id" | "type">;
+
+export const shouldSubscribeToForegroundRoomUpdates = (
+  room: RoomSubscriptionSummary,
+  currentRoomId: string | null
+): boolean => room.type !== "irc" || room.id === currentRoomId;
+
+export const shouldSubscribeToBackgroundRoomUpdates = (
+  room: Pick<ChatRoom, "type">
+): boolean => room.type !== "irc";

--- a/tests/test-chat-hook-channel-lifecycle-wiring.test.ts
+++ b/tests/test-chat-hook-channel-lifecycle-wiring.test.ts
@@ -31,23 +31,41 @@ const assertNoBroadUnbinds = (source: string): void => {
 describe("Chat Hook Channel Lifecycle Wiring", () => {
   describe("Background notifications hook", () => {
     test("background hook uses shared lifecycle helpers", async () => {
-    const source = readSource("src/hooks/useBackgroundChatNotifications.ts");
-    assertUsesSharedLifecycleHelpers(source);
-  });
+      const source = readSource("src/hooks/useBackgroundChatNotifications.ts");
+      assertUsesSharedLifecycleHelpers(source);
+    });
+
     test("background hook uses scoped unbind handlers", async () => {
-    const source = readSource("src/hooks/useBackgroundChatNotifications.ts");
-    assertNoBroadUnbinds(source);
-  });
+      const source = readSource("src/hooks/useBackgroundChatNotifications.ts");
+      assertNoBroadUnbinds(source);
+    });
+
+    test("background hook excludes IRC room channels", async () => {
+      const source = readSource("src/hooks/useBackgroundChatNotifications.ts");
+      expect(source).toContain("shouldSubscribeInBackground");
+      expect(source).toContain('room.type !== "irc"');
+      expect(source).toContain("backgroundRoomsById.has(roomId)");
+    });
   });
 
   describe("Foreground chat room hook", () => {
     test("chat room hook uses shared lifecycle helpers", async () => {
-    const source = readSource("src/apps/chats/hooks/useChatRoom.ts");
-    assertUsesSharedLifecycleHelpers(source);
-  });
+      const source = readSource("src/apps/chats/hooks/useChatRoom.ts");
+      assertUsesSharedLifecycleHelpers(source);
+    });
+
     test("chat room hook uses scoped unbind handlers", async () => {
-    const source = readSource("src/apps/chats/hooks/useChatRoom.ts");
-    assertNoBroadUnbinds(source);
-  });
+      const source = readSource("src/apps/chats/hooks/useChatRoom.ts");
+      assertNoBroadUnbinds(source);
+    });
+
+    test("chat room hook scopes IRC updates to the current room", async () => {
+      const source = readSource("src/apps/chats/hooks/useChatRoom.ts");
+      expect(source).toContain("shouldSubscribeToRoomUpdates");
+      expect(source).toContain('room.type !== "irc" || room.id === currentRoomId');
+      expect(source).toContain("unsubscribeFromRoomChannel(currentRoomId)");
+      expect(source).toContain("currentRoomId,");
+      expect(source).toContain("subscribeToRoomChannel,");
+    });
   });
 });

--- a/tests/test-chat-hook-channel-lifecycle-wiring.test.ts
+++ b/tests/test-chat-hook-channel-lifecycle-wiring.test.ts
@@ -1,4 +1,8 @@
 import { describe, test, expect } from "bun:test";
+import {
+  shouldSubscribeToBackgroundRoomUpdates,
+  shouldSubscribeToForegroundRoomUpdates,
+} from "../src/utils/chatRoomSubscriptions";
 
 /**
  * Guardrail tests for chat hook channel lifecycle wiring.
@@ -29,6 +33,42 @@ const assertNoBroadUnbinds = (source: string): void => {
 };
 
 describe("Chat Hook Channel Lifecycle Wiring", () => {
+  describe("Subscription decisions", () => {
+    test("foreground subscribes to IRC updates only for the active room", () => {
+      expect(
+        shouldSubscribeToForegroundRoomUpdates(
+          { id: "irc-active", type: "irc" },
+          "irc-active"
+        )
+      ).toBe(true);
+      expect(
+        shouldSubscribeToForegroundRoomUpdates(
+          { id: "irc-idle", type: "irc" },
+          "other-room"
+        )
+      ).toBe(false);
+      expect(
+        shouldSubscribeToForegroundRoomUpdates(
+          { id: "public-room", type: "public" },
+          "other-room"
+        )
+      ).toBe(true);
+      expect(
+        shouldSubscribeToForegroundRoomUpdates(
+          { id: "private-room", type: "private" },
+          null
+        )
+      ).toBe(true);
+    });
+
+    test("background skips IRC room update subscriptions", () => {
+      expect(shouldSubscribeToBackgroundRoomUpdates({ type: "irc" })).toBe(false);
+      expect(shouldSubscribeToBackgroundRoomUpdates({ type: "public" })).toBe(true);
+      expect(shouldSubscribeToBackgroundRoomUpdates({ type: "private" })).toBe(true);
+      expect(shouldSubscribeToBackgroundRoomUpdates({ type: undefined })).toBe(true);
+    });
+  });
+
   describe("Background notifications hook", () => {
     test("background hook uses shared lifecycle helpers", async () => {
       const source = readSource("src/hooks/useBackgroundChatNotifications.ts");
@@ -42,8 +82,7 @@ describe("Chat Hook Channel Lifecycle Wiring", () => {
 
     test("background hook excludes IRC room channels", async () => {
       const source = readSource("src/hooks/useBackgroundChatNotifications.ts");
-      expect(source).toContain("shouldSubscribeInBackground");
-      expect(source).toContain('room.type !== "irc"');
+      expect(source).toContain("shouldSubscribeToBackgroundRoomUpdates");
       expect(source).toContain("backgroundRoomsById.has(roomId)");
     });
   });
@@ -61,8 +100,7 @@ describe("Chat Hook Channel Lifecycle Wiring", () => {
 
     test("chat room hook scopes IRC updates to the current room", async () => {
       const source = readSource("src/apps/chats/hooks/useChatRoom.ts");
-      expect(source).toContain("shouldSubscribeToRoomUpdates");
-      expect(source).toContain('room.type !== "irc" || room.id === currentRoomId');
+      expect(source).toContain("shouldSubscribeToForegroundRoomUpdates");
       expect(source).toContain("unsubscribeFromRoomChannel(currentRoomId)");
       expect(source).toContain("currentRoomId,");
       expect(source).toContain("subscribeToRoomChannel,");

--- a/tests/test-irc-bridge.test.ts
+++ b/tests/test-irc-bridge.test.ts
@@ -263,6 +263,20 @@ describe("IRC Bridge", () => {
     expect(client.calls.some((c) => c.type === "part" && c.args[0] === "#pieter")).toBe(true);
   });
 
+  test("repeated bindRoom for same room does not rejoin channel", async () => {
+    const room = makeIrcRoom();
+    await bridge.bindRoom(room);
+    await new Promise((r) => setTimeout(r, 5));
+
+    await bridge.bindRoom(room);
+
+    const client = fakeClients[0];
+    const joinCalls = client.calls.filter(
+      (c) => c.type === "join" && c.args[0] === "#pieter"
+    );
+    expect(joinCalls.length).toBe(1);
+  });
+
   test("multiple rooms bound to the same channel share one connection", async () => {
     const roomA = makeIrcRoom({ id: "rA" });
     const roomB = makeIrcRoom({ id: "rB" });
@@ -423,13 +437,12 @@ describe("IRC Bridge", () => {
 });
 
 describe("IRC Bridge wiring", () => {
-  test("rooms/index.ts wires notifyRoomBindingChange on create", async () => {
+  test("rooms/index.ts does not bind IRC rooms on create", async () => {
     const fs = await import("node:fs/promises");
     const src = await fs.readFile("api/rooms/index.ts", "utf-8");
-    expect(src).toContain("notifyRoomBindingChange");
-    expect(/notifyRoomBindingChange\s*\(\s*"bind"/.test(src)).toBe(true);
+    expect(/notifyRoomBindingChange\s*\(\s*"bind"/.test(src)).toBe(false);
     // The create route must honour the opt-out flag so IRC_BRIDGE_DISABLED=1
-    // never accidentally opens a socket.
+    // never accidentally validates against a disabled bridge.
     expect(src).toContain("isIrcBridgeEnabled");
     expect(src).toContain("getIrcServer");
     expect(src).toContain("ircServerId");
@@ -449,6 +462,23 @@ describe("IRC Bridge wiring", () => {
     expect(src).toContain("getIrcBridge");
     expect(/roomData\.type === "irc"/.test(src)).toBe(true);
     expect(src).toContain("isIrcBridgeEnabled");
+  });
+
+  test("presence switch syncs IRC bridge bindings", async () => {
+    const fs = await import("node:fs/promises");
+    const src = await fs.readFile("api/presence/switch.ts", "utf-8");
+    expect(src).toContain("syncRoomBindingForPresence");
+    expect(src).toContain("isIrcBridgeEnabled");
+    expect(src).toContain("prevCount");
+    expect(src).toContain("userCount");
+  });
+
+  test("IRC bridge initializes only active IRC rooms", async () => {
+    const fs = await import("node:fs/promises");
+    const src = await fs.readFile("api/_utils/irc/_bridge.ts", "utf-8");
+    expect(src).toContain("refreshRoomUserCount");
+    expect(src).toContain("if (userCount <= 0) continue");
+    expect(src).toContain("syncRoomBindingForPresence");
   });
 
   test("standalone server initialises the IRC bridge on startup", async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Scope client IRC room update subscriptions to the selected channel only.
- Skip IRC room subscriptions in background chat notifications.
- Make the IRC bridge bind/unbind based on active room presence instead of room creation or inactive startup rooms.
- Add runtime tests for IRC subscription decisions and targeted bridge lifecycle coverage.

### Testing
- `bun test tests/test-chat-hook-channel-lifecycle-wiring.test.ts tests/test-irc-bridge.test.ts tests/test-pusher-client-refcount.test.ts`
- `bun run build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019e9ea8-eb0c-70a3-bb6d-7236bc49a2bb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019e9ea8-eb0c-70a3-bb6d-7236bc49a2bb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

