### PR TITLE
feat(macosx): accent-theme Aqua boot screen overlay and logo

### DIFF
--- a/src/components/dialogs/BootScreen.tsx
+++ b/src/components/dialogs/BootScreen.tsx
@@ -190,7 +190,7 @@ export function BootScreen({
               left: 0, 
               right: 0, 
               bottom: 0,
-              backgroundColor: "#4566a0"
+              backgroundColor: "var(--os-accent-boot-bg, #4566a0)"
             }}
           />
           <DialogContent
@@ -215,8 +215,8 @@ export function BootScreen({
               <img
                 src="/icons/macosx/apple.png"
                 alt="Apple"
-                className="size-[120px] object-contain"
-                style={{ marginBottom: "-30px", filter: "grayscale(50%) brightness(1.25)" }}
+                className="boot-screen-apple-logo size-[120px] object-contain"
+                style={{ marginBottom: "-30px" }}
               />
               {/* ryOS X text */}
               <h1 

--- a/src/styles/themes.css
+++ b/src/styles/themes.css
@@ -4162,6 +4162,15 @@
   filter: var(--os-accent-apple-filter, none);
 }
 
+/* Boot screen Apple logo — classic washed look; accent hue follows the menu logo
+   recipe via `--os-accent-boot-apple-filter` (falls back to the stock filter). */
+:root[data-os-theme="macosx"] img.boot-screen-apple-logo {
+  filter: var(
+    --os-accent-boot-apple-filter,
+    grayscale(50%) brightness(1.25)
+  );
+}
+
 /* --- Title bar text-shadow ------------------------------------------------ */
 /* Regular (non-brushed-metal) windows keep the light-mode dark-colored
    text-shadow on titlebar / menubar labels so dark mode looks visually

--- a/src/themes/accents.ts
+++ b/src/themes/accents.ts
@@ -351,6 +351,24 @@ function appleFilter(base: RGB): string {
   return `hue-rotate(${Math.round(delta)}deg) saturate(1.05)`;
 }
 
+/** Stock macOS X boot-screen backdrop (`BootScreen` overlay). */
+const BOOT_BG_REF = "#4566a0";
+
+/** Boot overlay fill — same hue as the accent, stock saturation/lightness profile. */
+function bootScreenBg(base: RGB): string {
+  const ref = rgbToHsl(parseHex(BOOT_BG_REF));
+  const { hue, sat: accentSat } = hueSat(base);
+  const sat = accentSat < 0.12 ? Math.min(ref.s, 0.08) : ref.s;
+  return rgb(hslToRgb(hue, sat, ref.l));
+}
+
+/** Boot Apple logo — keeps the classic washed look, then applies accent hue. */
+function bootAppleFilter(base: RGB): string {
+  const bootBase = "grayscale(50%) brightness(1.25)";
+  const accentPart = appleFilter(base);
+  return `${bootBase} ${accentPart}`;
+}
+
 // ---------------------------------------------------------------------------
 // CSS variable generation
 // ---------------------------------------------------------------------------
@@ -499,6 +517,9 @@ export function getAccentCssVars(
     "--os-accent-tab-border": rgb(tabBorder),
     // Apple-logo hue (consumed via `var(--os-accent-apple-filter, none)`).
     "--os-accent-apple-filter": appleFilter(base),
+    // Boot screen overlay + logo (consumed via `var(--os-accent-boot-*, …)`).
+    "--os-accent-boot-bg": bootScreenBg(base),
+    "--os-accent-boot-apple-filter": bootAppleFilter(base),
     // Chats assistant / Ryo AI bubble hue (`.chat-bubble.bg-blue-100`).
     "--os-accent-assistant-bubble-bg": assistantBubbleBgColor,
     "--os-color-link": link,
@@ -529,6 +550,8 @@ export const ACCENT_CSS_VAR_NAMES = [
   "--os-accent-tab-text-shadow",
   "--os-accent-tab-border",
   "--os-accent-apple-filter",
+  "--os-accent-boot-bg",
+  "--os-accent-boot-apple-filter",
   "--os-accent-assistant-bubble-bg",
   "--os-color-link",
   "--os-accent-selection-text-shadow",

--- a/tests/test-boot-screen-accent.test.ts
+++ b/tests/test-boot-screen-accent.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { getAccentCssVars } from "../src/themes/accents";
+
+const themesCss = readFileSync(
+  join(import.meta.dir, "../src/styles/themes.css"),
+  "utf8"
+);
+const bootScreenSource = readFileSync(
+  join(import.meta.dir, "../src/components/dialogs/BootScreen.tsx"),
+  "utf8"
+);
+
+function hexToHsl(hex: string): { h: number; s: number; l: number } {
+  const m = /^#([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})$/i.exec(hex);
+  if (!m) throw new Error(`Invalid hex: ${hex}`);
+  const [r, g, b] = [
+    parseInt(m[1]!, 16),
+    parseInt(m[2]!, 16),
+    parseInt(m[3]!, 16),
+  ];
+  const rn = r / 255;
+  const gn = g / 255;
+  const bn = b / 255;
+  const max = Math.max(rn, gn, bn);
+  const min = Math.min(rn, gn, bn);
+  const delta = max - min;
+  const l = (max + min) / 2;
+  let h = 0;
+  if (delta !== 0) {
+    if (max === rn) h = ((gn - bn) / delta) % 6;
+    else if (max === gn) h = (bn - rn) / delta + 2;
+    else h = (rn - gn) / delta + 4;
+    h = (h * 60 + 360) % 360;
+  }
+  const s = delta === 0 ? 0 : delta / (1 - Math.abs(2 * l - 1));
+  return { h, s, l };
+}
+
+function hueDelta(a: number, b: number): number {
+  const delta = Math.abs(a - b) % 360;
+  return delta > 180 ? 360 - delta : delta;
+}
+
+function rgbToHex(value: string): string {
+  const match = /^rgb\((\d+), (\d+), (\d+)\)$/.exec(value);
+  expect(match).not.toBeNull();
+  const [, r, g, b] = match!;
+  return `#${[r, g, b]
+    .map((n) => parseInt(n, 10).toString(16).padStart(2, "0"))
+    .join("")}`;
+}
+
+describe("macOS boot screen accent tokens", () => {
+  test("default accent emits no boot overrides", () => {
+    expect(getAccentCssVars("aqua", "default", false)).toEqual({});
+  });
+
+  test("named accent shifts boot backdrop hue while keeping stock lightness", () => {
+    const purple = getAccentCssVars("aqua", "purple", false);
+    const refHsl = hexToHsl("#4566a0");
+    const purpleHex = rgbToHex(purple["--os-accent-boot-bg"]!);
+    const purpleHsl = hexToHsl(purpleHex);
+
+    expect(hueDelta(hexToHsl("#8344c4").h, purpleHsl.h)).toBeLessThanOrEqual(12);
+    expect(Math.abs(purpleHsl.l - refHsl.l)).toBeLessThan(0.03);
+    expect(Math.abs(purpleHsl.s - refHsl.s)).toBeLessThan(0.05);
+  });
+
+  test("boot apple filter keeps the washed base and applies accent hue", () => {
+    const purple = getAccentCssVars("aqua", "purple", false);
+    const filter = purple["--os-accent-boot-apple-filter"]!;
+
+    expect(filter).toStartWith("grayscale(50%) brightness(1.25)");
+    expect(filter).toContain("hue-rotate(");
+    expect(purple["--os-accent-apple-filter"]).toContain("hue-rotate(");
+  });
+
+  test("BootScreen overlay and logo consume boot accent CSS variables", () => {
+    expect(bootScreenSource).toContain("var(--os-accent-boot-bg, #4566a0)");
+    expect(bootScreenSource).toContain("boot-screen-apple-logo");
+    expect(bootScreenSource).not.toContain('filter: "grayscale(50%) brightness(1.25)"');
+  });
+
+  test("themes.css wires boot apple logo filter with stock fallback", () => {
+    expect(themesCss).toContain("img.boot-screen-apple-logo");
+    expect(themesCss).toContain("--os-accent-boot-apple-filter");
+    expect(themesCss).toContain("grayscale(50%) brightness(1.25)");
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Hooks the macOS X (Aqua) boot screen into the existing accent CSS variable pipeline so the backdrop and Apple logo follow the same hue logic as the menu-bar Apple logo.

- Adds `--os-accent-boot-bg` and `--os-accent-boot-apple-filter` in `src/themes/accents.ts` (Aqua chrome only)
- Boot overlay reads `var(--os-accent-boot-bg, #4566a0)` — default/System accent keeps the stock blue
- Boot Apple logo uses `.boot-screen-apple-logo` with the washed grayscale base plus accent hue filter
- Progress bar and pinstripe dialog already consumed accent tokens; unchanged

## Testing

- `bun test tests/test-boot-screen-accent.test.ts tests/test-wallpaper-accent-color.test.ts` — 19 pass
- Manual: set Accent to Purple, trigger debug boot screen — purple backdrop + logo confirmed

![Purple-accent macOS boot screen](https://cursor.com/artifacts/c/art-14436708-467d-48a2-b08e-b3034a3c4c6a)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-36c87699-904e-4c01-9994-a977b1b050c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-36c87699-904e-4c01-9994-a977b1b050c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

