### PR TITLE
Adapt karaoke outline fills to cover colors

### DIFF
--- a/src/apps/ipod/components/lyrics-display/colorUtils.ts
+++ b/src/apps/ipod/components/lyrics-display/colorUtils.ts
@@ -9,8 +9,9 @@ const MAX_GLOW_LIGHTNESS = 0.72;
 const MIN_GLOW_LUMINANCE = 0.34;
 const MIN_NEUTRAL_LIGHTNESS = 0.88;
 const OUTLINE_FILL_LIGHTNESS = 0.42;
-const OUTLINE_FILL_MIN_LIGHTNESS = 0.32;
+const OUTLINE_FILL_MIN_LIGHTNESS = 0.26;
 const OUTLINE_FILL_MIN_SATURATION = 0.78;
+const OUTLINE_FILL_MAX_LUMINANCE = 0.22;
 const OUTLINE_NEUTRAL_FILL_LIGHTNESS = 0.56;
 const OUTLINE_NEUTRAL_MIN_LIGHTNESS = 0.38;
 const HEX_COLOR_RE = /^#([0-9a-f]{6})$/i;
@@ -118,6 +119,30 @@ function ensureMinimumLuminance([r, g, b]: Rgb): Rgb {
   return next;
 }
 
+function clampHslMaximumLuminance(
+  hsl: Hsl,
+  maxLuminance: number,
+  minLightness: number
+): Hsl {
+  if (relativeLuminance(...hslToRgb(hsl)) <= maxLuminance) {
+    return hsl;
+  }
+
+  let low = minLightness;
+  let high = hsl.l;
+  for (let i = 0; i < 16; i++) {
+    const mid = (low + high) / 2;
+    const luminance = relativeLuminance(...hslToRgb({ ...hsl, l: mid }));
+    if (luminance > maxLuminance) {
+      high = mid;
+    } else {
+      low = mid;
+    }
+  }
+
+  return { ...hsl, l: low };
+}
+
 /** Pick a readable glow source color from the extracted cover palette. */
 export function pickPrimaryColor(palette: string[]): string {
   const colors = palette.map((hex) => {
@@ -207,15 +232,23 @@ export function makeOutlineFillFromGlowColor(hex: string): string {
     );
   }
 
+  const fillHsl = {
+    h: hsl.h,
+    s: Math.max(hsl.s, OUTLINE_FILL_MIN_SATURATION),
+    l: Math.max(
+      Math.min(hsl.l - 0.14, OUTLINE_FILL_LIGHTNESS),
+      OUTLINE_FILL_MIN_LIGHTNESS
+    ),
+  };
+
   return rgbToHex(
-    hslToRgb({
-      h: hsl.h,
-      s: Math.max(hsl.s, OUTLINE_FILL_MIN_SATURATION),
-      l: Math.max(
-        Math.min(hsl.l - 0.14, OUTLINE_FILL_LIGHTNESS),
+    hslToRgb(
+      clampHslMaximumLuminance(
+        fillHsl,
+        OUTLINE_FILL_MAX_LUMINANCE,
         OUTLINE_FILL_MIN_LIGHTNESS
-      ),
-    })
+      )
+    )
   );
 }
 

--- a/src/apps/ipod/components/lyrics-display/colorUtils.ts
+++ b/src/apps/ipod/components/lyrics-display/colorUtils.ts
@@ -8,6 +8,11 @@ const MIN_GLOW_LIGHTNESS = 0.58;
 const MAX_GLOW_LIGHTNESS = 0.72;
 const MIN_GLOW_LUMINANCE = 0.34;
 const MIN_NEUTRAL_LIGHTNESS = 0.88;
+const OUTLINE_FILL_LIGHTNESS = 0.42;
+const OUTLINE_FILL_MIN_LIGHTNESS = 0.32;
+const OUTLINE_FILL_MIN_SATURATION = 0.78;
+const OUTLINE_NEUTRAL_FILL_LIGHTNESS = 0.56;
+const OUTLINE_NEUTRAL_MIN_LIGHTNESS = 0.38;
 const HEX_COLOR_RE = /^#([0-9a-f]{6})$/i;
 
 export function normalizeCoverColor(hex: string | null | undefined): string | undefined {
@@ -182,6 +187,36 @@ export function makeGlowFromColor(hex: string) {
     filter: `drop-shadow(0 0 8px rgba(${r},${g},${b},0.5))`,
     baseColor: `rgba(${r},${g},${b},0.6)`,
   };
+}
+
+/** Darken a boosted cover glow while preserving hue for outlined karaoke fills. */
+export function makeOutlineFillFromGlowColor(hex: string): string {
+  const [r, g, b] = hexToRgb(hex);
+  const hsl = rgbToHsl(r, g, b);
+
+  if (hsl.s <= NEUTRAL_SATURATION_MAX) {
+    return rgbToHex(
+      hslToRgb({
+        h: 0,
+        s: 0,
+        l: Math.max(
+          Math.min(hsl.l - 0.24, OUTLINE_NEUTRAL_FILL_LIGHTNESS),
+          OUTLINE_NEUTRAL_MIN_LIGHTNESS
+        ),
+      })
+    );
+  }
+
+  return rgbToHex(
+    hslToRgb({
+      h: hsl.h,
+      s: Math.max(hsl.s, OUTLINE_FILL_MIN_SATURATION),
+      l: Math.max(
+        Math.min(hsl.l - 0.14, OUTLINE_FILL_LIGHTNESS),
+        OUTLINE_FILL_MIN_LIGHTNESS
+      ),
+    })
+  );
 }
 
 export function resolveCoverGlowColor(palette: string[]): string {

--- a/src/apps/ipod/components/lyrics-display/useLyricsDisplayKaraokeStyle.ts
+++ b/src/apps/ipod/components/lyrics-display/useLyricsDisplayKaraokeStyle.ts
@@ -10,7 +10,11 @@ import {
   SERIF_RED_HIGHLIGHT_COLOR,
   getStyleCategory,
 } from "./constants";
-import { makeGlowFromColor } from "./colorUtils";
+import {
+  makeGlowFromColor,
+  makeOutlineFillFromGlowColor,
+  normalizeCoverColor,
+} from "./colorUtils";
 
 export function useLyricsDisplayKaraokeStyle(
   fontClassName: string,
@@ -24,15 +28,25 @@ export function useLyricsDisplayKaraokeStyle(
   );
   const isOldSchoolKaraoke =
     styleCategory === "outline-blue" || styleCategory === "outline-red";
+  const hasAdaptiveOutlineColor =
+    isOldSchoolKaraoke &&
+    (Boolean(coverUrl) || Boolean(normalizeCoverColor(coverColor)));
   const glowColor = useCoverGlowColor({
     coverUrl,
     coverColor,
-    enabled: styleCategory === "glow-gold",
+    enabled: styleCategory === "glow-gold" || hasAdaptiveOutlineColor,
     onResolved: onCoverColorResolved,
   });
   const primaryGlow = useMemo(() => {
     return makeGlowFromColor(glowColor);
   }, [glowColor]);
+  const outlineFillColor = useMemo(
+    () =>
+      hasAdaptiveOutlineColor
+        ? makeOutlineFillFromGlowColor(primaryGlow.color)
+        : undefined,
+    [hasAdaptiveOutlineColor, primaryGlow.color]
+  );
 
   const styleProps = useMemo(() => {
     const isOutline =
@@ -44,10 +58,10 @@ export function useLyricsDisplayKaraokeStyle(
     let highlight: string;
     switch (styleCategory) {
       case "outline-blue":
-        highlight = OLD_SCHOOL_HIGHLIGHT_COLOR;
+        highlight = outlineFillColor ?? OLD_SCHOOL_HIGHLIGHT_COLOR;
         break;
       case "outline-red":
-        highlight = SERIF_RED_HIGHLIGHT_COLOR;
+        highlight = outlineFillColor ?? SERIF_RED_HIGHLIGHT_COLOR;
         break;
       case "glow-gold":
         highlight = primaryGlow.color;
@@ -92,7 +106,7 @@ export function useLyricsDisplayKaraokeStyle(
       glowFilterStr: filter,
       baseColorResolved: base,
     };
-  }, [styleCategory, primaryGlow]);
+  }, [styleCategory, primaryGlow, outlineFillColor]);
 
   return {
     isOldSchoolKaraoke,

--- a/tests/test-lyrics-color-extraction.test.ts
+++ b/tests/test-lyrics-color-extraction.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import {
   boostGlowColor,
   getNewCoverColorToSave,
+  makeOutlineFillFromGlowColor,
   normalizeCoverColor,
   pickPrimaryColor,
   resolveCoverGlowColor,
@@ -29,6 +30,26 @@ function relativeLuminance(hex: string): number {
   };
 
   return 0.2126 * linear(r) + 0.7152 * linear(g) + 0.0722 * linear(b);
+}
+
+function hueOf(hex: string): number {
+  const [red, green, blue] = hexToRgb(hex);
+  const r = red / 255;
+  const g = green / 255;
+  const b = blue / 255;
+  const max = Math.max(r, g, b);
+  const min = Math.min(r, g, b);
+  const delta = max - min;
+
+  if (delta === 0) return 0;
+  if (max === r) return (((g - b) / delta + 6) % 6) / 6;
+  if (max === g) return ((b - r) / delta + 2) / 6;
+  return ((r - g) / delta + 4) / 6;
+}
+
+function hueDistance(a: number, b: number): number {
+  const distance = Math.abs(a - b);
+  return Math.min(distance, 1 - distance);
 }
 
 describe("lyrics color extraction", () => {
@@ -78,6 +99,24 @@ describe("lyrics color extraction", () => {
 
   test("resolves the boosted cover glow color from a palette", () => {
     expect(resolveCoverGlowColor(["#1a237e"])).toBe(boostGlowColor("#1a237e"));
+  });
+
+  test("derives outlined karaoke fills as a darker version of the cover glow hue", () => {
+    const glow = boostGlowColor("#1a237e");
+    const fill = makeOutlineFillFromGlowColor(glow);
+
+    expect(relativeLuminance(fill)).toBeLessThan(relativeLuminance(glow));
+    expect(hueDistance(hueOf(fill), hueOf(glow))).toBeLessThan(0.01);
+  });
+
+  test("keeps neutral outlined karaoke fills grayscale and darker than glow", () => {
+    const glow = boostGlowColor("#101010");
+    const fill = makeOutlineFillFromGlowColor(glow);
+    const [r, g, b] = hexToRgb(fill);
+
+    expect(r).toBe(g);
+    expect(g).toBe(b);
+    expect(relativeLuminance(fill)).toBeLessThan(relativeLuminance(glow));
   });
 
   test("does not extract a cover glow color when a cached color exists", () => {

--- a/tests/test-lyrics-color-extraction.test.ts
+++ b/tests/test-lyrics-color-extraction.test.ts
@@ -109,6 +109,16 @@ describe("lyrics color extraction", () => {
     expect(hueDistance(hueOf(fill), hueOf(glow))).toBeLessThan(0.01);
   });
 
+  test("clamps bright outlined karaoke fills below glow brightness", () => {
+    for (const glow of ["#00d5ff", "#ffd700", "#7cff00"]) {
+      const fill = makeOutlineFillFromGlowColor(glow);
+
+      expect(relativeLuminance(fill)).toBeLessThanOrEqual(0.225);
+      expect(relativeLuminance(fill)).toBeLessThan(relativeLuminance(glow));
+      expect(hueDistance(hueOf(fill), hueOf(glow))).toBeLessThan(0.01);
+    }
+  });
+
   test("keeps neutral outlined karaoke fills grayscale and darker than glow", () => {
     const glow = boostGlowColor("#101010");
     const fill = makeOutlineFillFromGlowColor(glow);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Make rounded and serif-red karaoke outline fills use a darker same-hue variant of the cover-derived glow color when cover color data is available.
- Preserve the existing blue/red fallback fills when there is no cover source.
- Add targeted tests for saturated and neutral outline fill derivation.

## Walkthrough
<a href="https://cursor.com/agents/bc-019e9fa4-90f3-7333-85c4-ddb6fb43fd61/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fkaraoke_cover_hue_outline_fill_demo.mp4"><img src="https://cursor.com/artifacts/c/art-ee89925e-1881-4b26-b215-b8d6ea8d80d3" alt="karaoke_cover_hue_outline_fill_demo.mp4" /></a>

## Testing
- `bun test tests/test-lyrics-color-extraction.test.ts`
- `bun test tests/test-karaoke-interlude-display.test.ts tests/test-karaoke-title-card.test.ts`
- `bun run build`
- Manual browser verification with a deterministic Karaoke demo route/mock: rounded outline fill used the cyan cover hue, then View > Lyrics > Serif Red changed the font while preserving the cyan cover-hued fill.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019e9fa4-90f3-7333-85c4-ddb6fb43fd61"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019e9fa4-90f3-7333-85c4-ddb6fb43fd61"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

