### PR TITLE
fix(ipod): keep modern progress bar on neutral Aqua fill, not accent

### DIFF
--- a/src/styles/themes.css
+++ b/src/styles/themes.css
@@ -3144,8 +3144,7 @@
   border-radius: 0 !important;
 }
 
-:root[data-os-theme="macosx"] .aqua-progress-fill,
-.ipod-modern-screen .aqua-progress-fill {
+:root[data-os-theme="macosx"] .aqua-progress-fill:not(.ipod-modern-screen *) {
   position: relative;
   height: 100%;
   border-radius: 9999px; /* fully rounded */
@@ -3173,6 +3172,35 @@
         #9dcfff 80%,
         #74deff 100%
       )
+    );
+  box-shadow: inset 0 0 0 0.5px rgba(0, 0, 0, 0.4),
+    inset 0 1px 0 rgba(0, 0, 0, 0.3), inset 0 -1px 0 rgba(0, 0, 0, 0.3);
+}
+
+/* iPod modern UI: fixed neutral Aqua fill (not accent-tinted). Same rationale
+   as the dark-mode exclusions on `.aqua-progress` above. */
+.ipod-modern-screen .aqua-progress-fill {
+  position: relative;
+  height: 100%;
+  border-radius: 9999px; /* fully rounded */
+  background:
+    repeating-linear-gradient(
+      to right,
+      transparent 0px,
+      rgba(255, 255, 255, 0.15) 10px,
+      rgba(255, 255, 255, 0.2) 15px,
+      rgba(255, 255, 255, 0.15) 20px,
+      transparent 30px
+    ),
+    linear-gradient(
+      to bottom,
+      #2260a4 0%,
+      #e2fbfd 8%,
+      #aecef3 25%,
+      #7aafee 40%,
+      #98ceff 60%,
+      #9dcfff 80%,
+      #74deff 100%
     );
   box-shadow: inset 0 0 0 0.5px rgba(0, 0, 0, 0.4),
     inset 0 1px 0 rgba(0, 0, 0, 0.3), inset 0 -1px 0 rgba(0, 0, 0, 0.3);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The modern iPod Now Playing and Music Quiz progress bars were picking up `--os-accent-tab-bar-line` after accent theming was added to `.aqua-progress-fill` in `themes.css`.

This scopes macOS accent-tinted progress fills away from `.ipod-modern-screen` descendants (matching the existing dark-mode exclusion pattern) and restores the hardcoded classic Aqua blue gradient for the iPod modern UI only.

## Changes

- `src/styles/themes.css`
  - macOS `.aqua-progress-fill` accent rule now uses `:not(.ipod-modern-screen *)`
  - `.ipod-modern-screen .aqua-progress-fill` uses the original neutral Aqua gradient (no accent CSS variables)

## Verification

- Static check: iPod fill block contains no `--os-accent*` references; macOS fill outside iPod still uses `--os-accent-tab-bar-line`
- Playwright fixture with a red accent override: OS bar follows accent; iPod bar stays classic blue

![iPod progress bar accent isolation](https://cursor.com/artifacts/c/art-7f280abf-204e-47d1-b34b-fd6065595832)

## Acceptance criteria

- [x] Modern iPod progress bar no longer uses accent hue/color variables
- [x] Other controls and app theming remain unchanged
- [x] Classic iPod UI unaffected (uses separate hardcoded `#0a3667` bar)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-613284b6-bdf1-45fa-8689-9d783bb1cb1e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-613284b6-bdf1-45fa-8689-9d783bb1cb1e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

