### PR TITLE
Fix window restore across mobile breakpoints

### DIFF
--- a/src/hooks/useWindowManager.ts
+++ b/src/hooks/useWindowManager.ts
@@ -11,6 +11,7 @@ import { useSound, Sounds } from "./useSound";
 import { getWindowConfig, getMobileWindowSize } from "@/config/appRegistry";
 import { useWindowInsets } from "./useWindowInsets";
 import { useEventListener } from "@/hooks/useEventListener";
+import { normalizeWindowFrame } from "./windowFrameGeometry";
 
 interface UseWindowManagerProps {
   appId: AppId;
@@ -55,23 +56,22 @@ export const useWindowManager = ({
   // Use instance state if available, otherwise fall back to app state
   const stateSource = instanceStateFromStore;
 
-  const initialState = {
+  const rawInitialState = {
     position: stateSource?.position ?? computeDefaultWindowState().position,
     size: stateSource?.size ?? computeDefaultWindowState().size,
   };
-
-  const adjustedPosition = { ...initialState.position };
-
-  // Ensure window is visible within viewport
-  if (adjustedPosition.x + initialState.size.width > window.innerWidth) {
-    adjustedPosition.x = Math.max(
-      0,
-      window.innerWidth - initialState.size.width
-    );
-  }
+  const initialInsets = computeInsets();
+  const initialState = normalizeWindowFrame({
+    ...rawInitialState,
+    viewport: { width: window.innerWidth, height: window.innerHeight },
+    topInset: initialInsets.topInset,
+    bottomInset: initialInsets.bottomInset,
+    isMobile: window.innerWidth < 768,
+    mobileSize: getMobileWindowSize(appId),
+  });
 
   const [windowPosition, setWindowPosition] =
-    useState<WindowPosition>(adjustedPosition);
+    useState<WindowPosition>(initialState.position);
   const [windowSize, setWindowSize] = useState<WindowSize>(initialState.size);
   const [isDragging, setIsDragging] = useState(false);
   const [dragOffset, setDragOffset] = useState({ x: 0, y: 0 });
@@ -96,6 +96,35 @@ export const useWindowManager = ({
   const moveRafRef = useRef<number | null>(null);
 
   const isMobile = window.innerWidth < 768;
+
+  const normalizeCurrentWindowFrame = useCallback(() => {
+    const { topInset, bottomInset } = computeInsets();
+    const normalized = normalizeWindowFrame({
+      position: latestWindowPositionRef.current,
+      size: latestWindowSizeRef.current,
+      viewport: { width: window.innerWidth, height: window.innerHeight },
+      topInset,
+      bottomInset,
+      isMobile: window.innerWidth < 768,
+      mobileSize: getMobileWindowSize(appId),
+    });
+
+    const positionChanged =
+      normalized.position.x !== latestWindowPositionRef.current.x ||
+      normalized.position.y !== latestWindowPositionRef.current.y;
+    const sizeChanged =
+      normalized.size.width !== latestWindowSizeRef.current.width ||
+      normalized.size.height !== latestWindowSizeRef.current.height;
+
+    if (positionChanged) {
+      latestWindowPositionRef.current = normalized.position;
+      setWindowPosition(normalized.position);
+    }
+    if (sizeChanged) {
+      latestWindowSizeRef.current = normalized.size;
+      setWindowSize(normalized.size);
+    }
+  }, [appId, computeInsets]);
 
   const flushPendingWindowFrame = useCallback(() => {
     if (moveRafRef.current !== null) {
@@ -160,10 +189,22 @@ export const useWindowManager = ({
       (storeSize.width !== latestWindowSizeRef.current.width ||
         storeSize.height !== latestWindowSizeRef.current.height)
     ) {
-      setWindowSize(storeSize);
-      latestWindowSizeRef.current = storeSize;
+      const { topInset, bottomInset } = computeInsets();
+      const normalized = normalizeWindowFrame({
+        position: latestWindowPositionRef.current,
+        size: storeSize,
+        viewport: { width: window.innerWidth, height: window.innerHeight },
+        topInset,
+        bottomInset,
+        isMobile: window.innerWidth < 768,
+        mobileSize: getMobileWindowSize(appId),
+      });
+      setWindowPosition(normalized.position);
+      setWindowSize(normalized.size);
+      latestWindowPositionRef.current = normalized.position;
+      latestWindowSizeRef.current = normalized.size;
     }
-  }, [instanceStateFromStore?.size, isDragging, resizeType]);
+  }, [appId, computeInsets, instanceStateFromStore?.size, isDragging, resizeType]);
 
   useEffect(() => {
     latestWindowSizeRef.current = windowSize;
@@ -178,10 +219,28 @@ export const useWindowManager = ({
       (storePosition.x !== latestWindowPositionRef.current.x ||
         storePosition.y !== latestWindowPositionRef.current.y)
     ) {
-      setWindowPosition(storePosition);
-      latestWindowPositionRef.current = storePosition;
+      const { topInset, bottomInset } = computeInsets();
+      const normalized = normalizeWindowFrame({
+        position: storePosition,
+        size: latestWindowSizeRef.current,
+        viewport: { width: window.innerWidth, height: window.innerHeight },
+        topInset,
+        bottomInset,
+        isMobile: window.innerWidth < 768,
+        mobileSize: getMobileWindowSize(appId),
+      });
+      setWindowPosition(normalized.position);
+      setWindowSize(normalized.size);
+      latestWindowPositionRef.current = normalized.position;
+      latestWindowSizeRef.current = normalized.size;
     }
-  }, [instanceStateFromStore?.position, isDragging, resizeType]);
+  }, [
+    appId,
+    computeInsets,
+    instanceStateFromStore?.position,
+    isDragging,
+    resizeType,
+  ]);
 
   useEffect(() => {
     latestWindowPositionRef.current = windowPosition;
@@ -194,6 +253,18 @@ export const useWindowManager = ({
       }
     };
   }, []);
+
+  useEffect(() => {
+    if (isDragging || resizeType) return;
+    normalizeCurrentWindowFrame();
+  }, [isDragging, normalizeCurrentWindowFrame, resizeType]);
+
+  const handleViewportResize = useCallback(() => {
+    if (isDragging || resizeType) return;
+    normalizeCurrentWindowFrame();
+  }, [isDragging, normalizeCurrentWindowFrame, resizeType]);
+
+  useEventListener("resize", handleViewportResize);
 
   const { play: playMoveSound, stop: stopMoveMoving } = useSound(Sounds.WINDOW_MOVE_MOVING);
   const { play: playMoveStop } = useSound(Sounds.WINDOW_MOVE_STOP);

--- a/src/hooks/windowFrameGeometry.ts
+++ b/src/hooks/windowFrameGeometry.ts
@@ -24,6 +24,31 @@ function clamp(value: number, min: number, max: number): number {
   return Math.min(Math.max(value, min), max);
 }
 
+function normalizeVerticalPosition(
+  y: number,
+  height: number,
+  viewport: ViewportSize,
+  topInset: number,
+  bottomInset: number
+): number {
+  const availableHeight = Math.max(
+    MIN_VISIBLE_EDGE,
+    viewport.height - topInset - bottomInset
+  );
+  const maxFullyVisibleY = Math.max(
+    topInset,
+    viewport.height - bottomInset - height
+  );
+
+  if (height > availableHeight) {
+    return topInset;
+  }
+  if (y < topInset || y > maxFullyVisibleY) {
+    return topInset;
+  }
+  return y;
+}
+
 export function normalizeWindowFrame({
   position,
   size,
@@ -34,14 +59,16 @@ export function normalizeWindowFrame({
   mobileSize,
 }: NormalizeWindowFrameInput): WindowFrameState {
   if (isMobile) {
-    const availableHeight = Math.max(
-      MIN_VISIBLE_EDGE,
-      viewport.height - bottomInset
-    );
     return {
       position: {
         x: 0,
-        y: clamp(position.y, topInset, availableHeight - MIN_VISIBLE_EDGE),
+        y: normalizeVerticalPosition(
+          position.y,
+          mobileSize.height,
+          viewport,
+          topInset,
+          bottomInset
+        ),
       },
       size: mobileSize,
     };
@@ -64,7 +91,13 @@ export function normalizeWindowFrame({
   return {
     position: {
       x: clamp(nextX, minX, maxX),
-      y: clamp(position.y, topInset, maxY),
+      y: normalizeVerticalPosition(
+        clamp(position.y, topInset, maxY),
+        nextSize.height,
+        viewport,
+        topInset,
+        bottomInset
+      ),
     },
     size: nextSize,
   };

--- a/src/hooks/windowFrameGeometry.ts
+++ b/src/hooks/windowFrameGeometry.ts
@@ -1,0 +1,71 @@
+import type { WindowPosition, WindowSize } from "@/types/types";
+
+const MIN_VISIBLE_EDGE = 80;
+
+export type ViewportSize = WindowSize;
+
+export interface NormalizeWindowFrameInput {
+  position: WindowPosition;
+  size: WindowSize;
+  viewport: ViewportSize;
+  topInset: number;
+  bottomInset: number;
+  isMobile: boolean;
+  mobileSize: WindowSize;
+}
+
+export interface WindowFrameState {
+  position: WindowPosition;
+  size: WindowSize;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  if (max < min) return min;
+  return Math.min(Math.max(value, min), max);
+}
+
+export function normalizeWindowFrame({
+  position,
+  size,
+  viewport,
+  topInset,
+  bottomInset,
+  isMobile,
+  mobileSize,
+}: NormalizeWindowFrameInput): WindowFrameState {
+  if (isMobile) {
+    const availableHeight = Math.max(
+      MIN_VISIBLE_EDGE,
+      viewport.height - bottomInset
+    );
+    return {
+      position: {
+        x: 0,
+        y: clamp(position.y, topInset, availableHeight - MIN_VISIBLE_EDGE),
+      },
+      size: mobileSize,
+    };
+  }
+
+  const nextSize = {
+    width: Math.min(size.width, viewport.width),
+    height: size.height,
+  };
+  const minX =
+    nextSize.width > MIN_VISIBLE_EDGE ? -(nextSize.width - MIN_VISIBLE_EDGE) : 0;
+  const maxX = Math.max(0, viewport.width - MIN_VISIBLE_EDGE);
+  const maxY = Math.max(topInset, viewport.height - MIN_VISIBLE_EDGE);
+
+  let nextX = position.x;
+  if (nextX + nextSize.width > viewport.width) {
+    nextX = Math.max(0, viewport.width - nextSize.width);
+  }
+
+  return {
+    position: {
+      x: clamp(nextX, minX, maxX),
+      y: clamp(position.y, topInset, maxY),
+    },
+    size: nextSize,
+  };
+}

--- a/tests/test-window-frame-geometry.test.ts
+++ b/tests/test-window-frame-geometry.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from "bun:test";
+import { normalizeWindowFrame } from "../src/hooks/windowFrameGeometry";
+
+describe("normalizeWindowFrame", () => {
+  test("pins a desktop window to the mobile viewport", () => {
+    const result = normalizeWindowFrame({
+      position: { x: 720, y: 900 },
+      size: { width: 680, height: 400 },
+      viewport: { width: 390, height: 844 },
+      topInset: 28,
+      bottomInset: 20,
+      isMobile: true,
+      mobileSize: { width: 390, height: 400 },
+    });
+
+    expect(result.position.x).toBe(0);
+    expect(result.position.y).toBeLessThanOrEqual(744);
+    expect(result.size).toEqual({ width: 390, height: 400 });
+  });
+
+  test("keeps a mobile window below the menu bar", () => {
+    const result = normalizeWindowFrame({
+      position: { x: 0, y: 0 },
+      size: { width: 390, height: 400 },
+      viewport: { width: 390, height: 844 },
+      topInset: 28,
+      bottomInset: 20,
+      isMobile: true,
+      mobileSize: { width: 390, height: 400 },
+    });
+
+    expect(result.position).toEqual({ x: 0, y: 28 });
+  });
+
+  test("clamps an off-screen desktop frame back into view", () => {
+    const result = normalizeWindowFrame({
+      position: { x: 1400, y: 900 },
+      size: { width: 680, height: 400 },
+      viewport: { width: 1024, height: 768 },
+      topInset: 24,
+      bottomInset: 0,
+      isMobile: false,
+      mobileSize: { width: 390, height: 400 },
+    });
+
+    expect(result.position).toEqual({ x: 344, y: 688 });
+    expect(result.size).toEqual({ width: 680, height: 400 });
+  });
+
+  test("shrinks a desktop frame wider than the viewport", () => {
+    const result = normalizeWindowFrame({
+      position: { x: 300, y: 40 },
+      size: { width: 1280, height: 500 },
+      viewport: { width: 1024, height: 768 },
+      topInset: 24,
+      bottomInset: 0,
+      isMobile: false,
+      mobileSize: { width: 390, height: 400 },
+    });
+
+    expect(result.position.x).toBe(0);
+    expect(result.size.width).toBe(1024);
+  });
+});

--- a/tests/test-window-frame-geometry.test.ts
+++ b/tests/test-window-frame-geometry.test.ts
@@ -14,7 +14,7 @@ describe("normalizeWindowFrame", () => {
     });
 
     expect(result.position.x).toBe(0);
-    expect(result.position.y).toBeLessThanOrEqual(744);
+    expect(result.position.y).toBe(28);
     expect(result.size).toEqual({ width: 390, height: 400 });
   });
 
@@ -43,7 +43,7 @@ describe("normalizeWindowFrame", () => {
       mobileSize: { width: 390, height: 400 },
     });
 
-    expect(result.position).toEqual({ x: 344, y: 688 });
+    expect(result.position).toEqual({ x: 344, y: 24 });
     expect(result.size).toEqual({ width: 680, height: 400 });
   });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Normalize restored window geometry against the current viewport so already-open apps remain visible after switching between mobile and desktop layouts.
- Add focused Bun coverage for off-screen mobile and desktop frame normalization.

## Verification
- `bun test tests/test-window-frame-geometry.test.ts`
- `bun run build`
- Headless Playwright smoke test: seeded an already-open Finder window at off-screen desktop coordinates, loaded the app on a mobile viewport, then resized to desktop and confirmed the window stayed visible.

![Restored Finder window visible on mobile viewport](https://cursor.com/artifacts/c/art-c63bc798-c9d4-4612-b36a-2942815d6373)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ea218-aa86-772b-b25c-71ae7326d771"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ea218-aa86-772b-b25c-71ae7326d771"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

