### PR TITLE
refactor(theme): source control-panels theme flags from useThemeFlags (Phase 7 / Wave 5)

### DIFF
--- a/src/apps/control-panels/hooks/useControlPanelsLogic.ts
+++ b/src/apps/control-panels/hooks/useControlPanelsLogic.ts
@@ -291,6 +291,9 @@ export function useControlPanelsLogic({
     supportsAccent,
     accent,
     macChrome,
+    isXpTheme,
+    isMacOSTheme: isMacOSXTheme,
+    isMacTheme: isClassicMacTheme,
   } = useThemeFlags();
   const setTheme = useThemeStore((state) => state.setTheme);
   const setDarkMode = useThemeStore((state) => state.setDarkMode);
@@ -1544,10 +1547,7 @@ export function useControlPanelsLogic({
     performFormat();
   };
 
-  const isXpTheme = currentTheme === "xp" || currentTheme === "win98";
-  const isMacOSXTheme = currentTheme === "macosx";
-  const isSystem7Theme = currentTheme === "system7";
-  const isClassicMacTheme = isMacOSXTheme || isSystem7Theme;
+  // Theme flags come from useThemeFlags() above (single source of truth).
   const isWindowsLegacyTheme = isXpTheme;
 
   const tabStyles = getTabStyles(currentTheme);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Continues the theme-flag consolidation (Wave 5 of `plans/simplification_execution_waves.md`). `useControlPanelsLogic` already calls `useThemeFlags()`, but then re-derived a second set of theme booleans manually from `currentTheme`:

```ts
const isXpTheme = currentTheme === "xp" || currentTheme === "win98";
const isMacOSXTheme = currentTheme === "macosx";
const isSystem7Theme = currentTheme === "system7";
const isClassicMacTheme = isMacOSXTheme || isSystem7Theme;
const isWindowsLegacyTheme = isXpTheme;
```

These are now sourced from the single `useThemeFlags()` source of truth:
- `isXpTheme` → `useThemeFlags().isXpTheme` (`metadata.isWindows`, true for `xp`/`win98`)
- `isMacOSXTheme` → `isMacOSTheme`
- `isClassicMacTheme` → `isMacTheme` (`metadata.isMac`, true for `macosx`/`system7`)
- `isWindowsLegacyTheme` → `isXpTheme`

The dead local `isSystem7Theme` (defined but unused) is removed. Equivalence was verified against the theme metadata definitions in `src/themes/*.ts`, so this is behavior-preserving.

## Testing

Tested locally against `bun run dev`.

- ✅ `bun run build` (Vite + `tsc -b`)
- ✅ `bun run test:unit` — 199 pass (1 pre-existing env failure in `test-ipod-apple-music`, unrelated)
- ✅ **Playwright (clean Chromium):** opened Control Panels and rendered it in all three flag-relevant themes; tabs/chrome render correctly in each, confirming the consolidated flags drive styling identically.

macOS Aqua (`isMacOSTheme`):
![Control Panels in macOS Aqua theme with aqua tabs](https://cursor.com/artifacts/c/art-86c97449-75d7-4fb1-8687-16034c3fd82e)

Windows XP (`isXpTheme` / `isWindowsLegacyTheme`):
![Control Panels in Windows XP theme with Luna tabs](https://cursor.com/artifacts/c/art-2a092def-4fec-4332-8b79-e942f7d0f5eb)

System 7 (`isClassicMacTheme`):
![Control Panels in System 7 theme with classic tabs and accent picker](https://cursor.com/artifacts/c/art-57335486-e098-4fc3-a4eb-0200aa075fc5)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ea255-d89a-7aee-a66a-5133bbe7db1f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ea255-d89a-7aee-a66a-5133bbe7db1f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

