### PR TITLE
refactor: route wallpaper storage through indexeddb helpers

### DIFF
--- a/src/stores/useDisplaySettingsStore.ts
+++ b/src/stores/useDisplaySettingsStore.ts
@@ -3,7 +3,11 @@ import { persist } from "zustand/middleware";
 import { ShaderType } from "@/types/shader";
 import { DisplayMode } from "@/utils/displayMode";
 import { checkShaderPerformance } from "@/utils/performanceCheck";
-import { ensureIndexedDBInitialized } from "@/utils/indexedDB";
+import { STORES } from "@/utils/indexedDB";
+import {
+  dbOperations,
+  getIndexedDbStoreKeys,
+} from "@/utils/indexedDBOperations";
 import {
   emitCloudSyncDomainChange,
   requestCloudSyncDomainCheck,
@@ -23,7 +27,7 @@ export const DEFAULT_WALLPAPER_PATH =
 
 // IndexedDB helpers for custom wallpapers
 export const INDEXEDDB_PREFIX = "indexeddb://";
-const CUSTOM_WALLPAPERS_STORE = "custom_wallpapers";
+const CUSTOM_WALLPAPERS_STORE = STORES.CUSTOM_WALLPAPERS;
 const objectURLs: Record<string, string> = {};
 
 type StoredWallpaper = { blob?: Blob; content?: string; [k: string]: unknown };
@@ -49,9 +53,6 @@ const saveCustomWallpaper = async (file: File): Promise<string> => {
     throw new Error("Only image files allowed");
   try {
     const processedFile = await convertImageFileToWallpaperJpeg(file);
-    const db = await ensureIndexedDBInitialized();
-    const tx = db.transaction(CUSTOM_WALLPAPERS_STORE, "readwrite");
-    const store = tx.objectStore(CUSTOM_WALLPAPERS_STORE);
     const name = `custom_${Date.now()}_${processedFile.name.replace(
       /[^a-zA-Z0-9._-]/g,
       "_"
@@ -63,12 +64,7 @@ const saveCustomWallpaper = async (file: File): Promise<string> => {
       type: processedFile.type,
       dateAdded: new Date().toISOString(),
     };
-    await new Promise<void>((res, rej) => {
-      const r = store.put(rec, name);
-      r.onsuccess = () => res();
-      r.onerror = () => rej(r.error);
-    });
-    db.close();
+    await dbOperations.put(CUSTOM_WALLPAPERS_STORE, rec, name);
     return `${INDEXEDDB_PREFIX}${name}`;
   } catch (e) {
     console.error("saveCustomWallpaper", e);
@@ -196,15 +192,7 @@ export const useDisplaySettingsStore = create<DisplaySettingsState>()(
 
       loadCustomWallpapers: async () => {
         try {
-          const db = await ensureIndexedDBInitialized();
-          const tx = db.transaction(CUSTOM_WALLPAPERS_STORE, "readonly");
-          const store = tx.objectStore(CUSTOM_WALLPAPERS_STORE);
-          const keysReq = store.getAllKeys();
-          const keys: string[] = await new Promise((res, rej) => {
-            keysReq.onsuccess = () => res(keysReq.result as string[]);
-            keysReq.onerror = () => rej(keysReq.error);
-          });
-          db.close();
+          const keys = await getIndexedDbStoreKeys(CUSTOM_WALLPAPERS_STORE);
           return keys.map((k) => `${INDEXEDDB_PREFIX}${k}`);
         } catch (e) {
           console.error("loadCustomWallpapers", e);
@@ -218,15 +206,7 @@ export const useDisplaySettingsStore = create<DisplaySettingsState>()(
           : reference;
         useCloudSyncStore.getState().markDeletedKeys("customWallpaperKeys", [id]);
         try {
-          const db = await ensureIndexedDBInitialized();
-          const tx = db.transaction(CUSTOM_WALLPAPERS_STORE, "readwrite");
-          const store = tx.objectStore(CUSTOM_WALLPAPERS_STORE);
-          await new Promise<void>((res, rej) => {
-            const r = store.delete(id);
-            r.onsuccess = () => res();
-            r.onerror = () => rej(r.error);
-          });
-          db.close();
+          await dbOperations.delete(CUSTOM_WALLPAPERS_STORE, id);
           if (objectURLs[id]) {
             URL.revokeObjectURL(objectURLs[id]);
             delete objectURLs[id];
@@ -249,17 +229,10 @@ export const useDisplaySettingsStore = create<DisplaySettingsState>()(
         const id = reference.substring(INDEXEDDB_PREFIX.length);
         if (objectURLs[id]) return objectURLs[id];
         try {
-          const db = await ensureIndexedDBInitialized();
-          const tx = db.transaction(CUSTOM_WALLPAPERS_STORE, "readonly");
-          const store = tx.objectStore(CUSTOM_WALLPAPERS_STORE);
-          const req = store.get(id);
-          const result = await new Promise<StoredWallpaper | null>(
-            (res, rej) => {
-              req.onsuccess = () => res(req.result as StoredWallpaper);
-              req.onerror = () => rej(req.error);
-            }
+          const result = await dbOperations.get<StoredWallpaper>(
+            CUSTOM_WALLPAPERS_STORE,
+            id
           );
-          db.close();
           if (!result) return null;
           let objectURL: string | null = null;
           if (result.blob) objectURL = URL.createObjectURL(result.blob);

--- a/tests/test-display-settings-indexeddb-wiring.test.ts
+++ b/tests/test-display-settings-indexeddb-wiring.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+
+describe("display settings IndexedDB wiring", () => {
+  test("custom wallpapers use the shared IndexedDB operations boundary", () => {
+    const source = readFileSync(
+      "src/stores/useDisplaySettingsStore.ts",
+      "utf8"
+    );
+
+    expect(source).toContain("@/utils/indexedDBOperations");
+    expect(source).toContain("dbOperations.put");
+    expect(source).toContain("dbOperations.get");
+    expect(source).toContain("dbOperations.delete");
+    expect(source).toContain("getIndexedDbStoreKeys");
+    expect(source).not.toContain("ensureIndexedDBInitialized");
+    expect(source).not.toContain(".transaction(");
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Routes custom wallpaper IndexedDB reads/writes/deletes through `src/utils/indexedDBOperations.ts` instead of direct transactions in `useDisplaySettingsStore`.
- Reuses `STORES.CUSTOM_WALLPAPERS` and `getIndexedDbStoreKeys` for the custom wallpaper store.
- Adds a wiring test to prevent direct transaction usage from returning to display settings.

## Testing

- `bun test tests/test-display-settings-indexeddb-wiring.test.ts tests/test-wallpaper-cloud-sync-debug.test.ts tests/test-custom-wallpaper-processing.test.ts`
- `bun run build`
- Browser smoke: opened ryOS locally, opened System Preferences, and verified wallpaper/settings UI loads without visible runtime errors.

<a href="https://cursor.com/agents/bc-019ea255-b456-75cf-9521-8a31af1d172d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Findexeddb_wallpaper_settings_smoke.mp4"><img src="https://cursor.com/artifacts/c/art-8f9eb92b-c347-4fbd-ac45-0a0abd8b5d9b" alt="indexeddb_wallpaper_settings_smoke.mp4" /></a>

## Stack

- Base branch: `cursor/codebase-simplification-audit-172d`
- This is the first follow-up phase PR after resolving latest `main` conflicts.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ea255-b456-75cf-9521-8a31af1d172d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ea255-b456-75cf-9521-8a31af1d172d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

