### PR TITLE
refactor: route auth flows through api client

### DIFF
--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -1,4 +1,4 @@
-import { apiRequest } from "@/api/core";
+import { apiRequest, apiRequestRaw } from "@/api/core";
 
 export interface LoginResponse {
   username: string;
@@ -67,6 +67,26 @@ export async function logoutUser(): Promise<{ success: boolean }> {
   });
 }
 
+export async function logoutAllDevices(): Promise<{
+  success: boolean;
+  message?: string;
+}> {
+  return apiRequest<{ success: boolean; message?: string }>({
+    path: "/api/auth/logout-all",
+    method: "POST",
+  });
+}
+
+export async function checkUserPassword(): Promise<{
+  hasPassword: boolean;
+  username: string;
+}> {
+  return apiRequest<{ hasPassword: boolean; username: string }>({
+    path: "/api/auth/password/check",
+    method: "GET",
+  });
+}
+
 export interface SetPasswordRequest {
   /** New password to store. */
   password: string;
@@ -84,5 +104,24 @@ export async function setUserPassword(
     path: "/api/auth/password/set",
     method: "POST",
     body: params,
+  });
+}
+
+export async function restoreAuthSession(params: {
+  username: string;
+  legacyToken?: string | null;
+}): Promise<Response> {
+  const headers: Record<string, string> = {};
+  if (params.legacyToken) {
+    headers.Authorization = `Bearer ${params.legacyToken}`;
+    headers["X-Username"] = params.username;
+  }
+
+  return apiRequestRaw({
+    path: "/api/auth/session",
+    method: "GET",
+    headers,
+    timeout: 10000,
+    retry: { maxAttempts: 2, initialDelayMs: 500 },
   });
 }

--- a/src/apps/control-panels/hooks/useControlPanelsLogic.ts
+++ b/src/apps/control-panels/hooks/useControlPanelsLogic.ts
@@ -40,6 +40,7 @@ import {
 } from "@/utils/cloudSyncShared";
 import { useShallow } from "zustand/react/shallow";
 import { useTelegramLink } from "@/hooks/useTelegramLink";
+import { logoutAllDevices } from "@/api/auth";
 import {
   downloadAndApplyLogicalCloudSyncDomain,
   uploadLogicalCloudSyncDomain,
@@ -486,19 +487,8 @@ export function useControlPanelsLogic({
         return;
       }
 
-      const response = await abortableFetch(getApiUrl("/api/auth/logout-all"), {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        timeout: 15000,
-        throwOnHttpError: false,
-        retry: { maxAttempts: 1, initialDelayMs: 250 },
-      });
-
-      const data = await response.json();
-
-      if (response.ok) {
+      try {
+        const data = await logoutAllDevices();
         toast.success("Logged Out", {
           description: data.message || "Logged out from all devices",
         });
@@ -507,9 +497,12 @@ export function useControlPanelsLogic({
         confirmLogout();
 
         // No full page reload needed – UI will update via store reset
-      } else {
+      } catch (error) {
         toast.error("Logout Failed", {
-          description: data.error || "Failed to logout from all devices",
+          description:
+            error instanceof Error
+              ? error.message
+              : "Failed to logout from all devices",
         });
       }
     } catch (error) {

--- a/src/apps/terminal/hooks/useTerminalLogic.ts
+++ b/src/apps/terminal/hooks/useTerminalLogic.ts
@@ -21,7 +21,7 @@ import { useFilesStore } from "@/stores/useFilesStore";
 import { TERMINAL_ANALYTICS } from "@/utils/analytics";
 import i18n from "@/lib/i18n";
 import { CommandHistory, CommandContext, ToolInvocationData } from "../types";
-import { abortableFetch } from "@/utils/abortableFetch";
+import { loginWithPassword } from "@/api/auth";
 
 // Maximum number of rendered command entries to keep in memory
 const MAX_RENDERED_HISTORY = 200;
@@ -865,27 +865,19 @@ export const useTerminalLogic = ({
 
               // If password provided, attempt authentication first
               if (passwordArg) {
-                const authResp = await abortableFetch("/api/auth/login", {
-                  method: "POST",
-                  headers: { "Content-Type": "application/json" },
-                  body: JSON.stringify({
+                try {
+                  const data = await loginWithPassword({
                     username: targetUsername,
                     password: passwordArg,
-                  }),
-                  timeout: 15000,
-                  throwOnHttpError: false,
-                  retry: { maxAttempts: 1, initialDelayMs: 250 },
-                });
-
-                if (authResp.ok) {
-                  const data = await authResp.json();
+                  });
                   const uname = data.username || targetUsername;
                   store.setUsername(uname);
                   store.setAuthenticated(true);
                   this.updateOutput(`logged in as ${uname}`);
                   return;
+                } catch {
+                  // fallthrough if auth failed -> will attempt create
                 }
-                // fallthrough if auth failed -> will attempt create
               }
 
               // Attempt to create user; password is required by server

--- a/src/stores/useChatsStore.ts
+++ b/src/stores/useChatsStore.ts
@@ -8,10 +8,15 @@ import {
 import { APP_ANALYTICS, CHAT_ANALYTICS, getTextAnalytics, track } from "@/utils/analytics";
 import { decodeHtmlEntities } from "@/utils/decodeHtmlEntities";
 import i18n from "@/lib/i18n";
-import { getApiUrl } from "@/utils/platform";
-import { abortableFetch } from "@/utils/abortableFetch";
 import { ApiRequestError } from "@/api/core";
 import { USERNAME_REGEX, PASSWORD_MIN_LENGTH } from "@/shared/validation";
+import {
+  checkUserPassword,
+  logoutUser,
+  registerUser,
+  restoreAuthSession,
+  setUserPassword,
+} from "@/api/auth";
 import {
   type CreateRoomPayload,
   createRoom as createRoomApi,
@@ -344,24 +349,9 @@ export const useChatsStore = create<ChatsStoreState>()(
           }
 
           try {
-            const response = await abortableFetch(
-              "/api/auth/password/check",
-              {
-                method: "GET",
-                timeout: 15000,
-                throwOnHttpError: false,
-                retry: { maxAttempts: 1, initialDelayMs: 250 },
-              }
-            );
-
-            if (response.ok) {
-              const data = await response.json();
-              set({ hasPassword: data.hasPassword });
-              return { ok: true };
-            } else {
-              set({ hasPassword: null });
-              return { ok: false, error: "Failed to check password status" };
-            }
+            const data = await checkUserPassword();
+            set({ hasPassword: data.hasPassword });
+            return { ok: true };
           } catch (error) {
             console.error(
               "[ChatsStore] Error checking password status:",
@@ -389,34 +379,20 @@ export const useChatsStore = create<ChatsStoreState>()(
               payload.currentPassword = currentPassword;
             }
 
-            const response = await abortableFetch(
-              getApiUrl("/api/auth/password/set"),
-              {
-                method: "POST",
-                headers: {
-                  "Content-Type": "application/json",
-                },
-                body: JSON.stringify(payload),
-                timeout: 15000,
-                throwOnHttpError: false,
-                retry: { maxAttempts: 1, initialDelayMs: 250 },
-              }
-            );
-
-            if (!response.ok) {
-              const data = await response.json();
-              return {
-                ok: false,
-                error: data.error || "Failed to set password",
-              };
-            }
+            await setUserPassword(payload);
 
             // Update local state to reflect password has been set
             set({ hasPassword: true });
             return { ok: true };
           } catch (error) {
             console.error("[ChatsStore] Error setting password:", error);
-            return { ok: false, error: "Network error while setting password" };
+            return {
+              ok: false,
+              error:
+                error instanceof ApiRequestError
+                  ? error.message
+                  : "Network error while setting password",
+            };
           }
         },
         setRooms: (newRooms) => {
@@ -663,13 +639,7 @@ export const useChatsStore = create<ChatsStoreState>()(
 
           if (currentUsername) {
             try {
-              await abortableFetch(getApiUrl("/api/auth/logout"), {
-                method: "POST",
-                headers: { "Content-Type": "application/json" },
-                timeout: 15000,
-                throwOnHttpError: false,
-                retry: { maxAttempts: 1, initialDelayMs: 250 },
-              });
+              await logoutUser();
             } catch (err) {
               console.warn(
                 "[ChatsStore] Failed to notify server during logout:",
@@ -1191,29 +1161,10 @@ export const useChatsStore = create<ChatsStoreState>()(
           }
 
           try {
-            const response = await abortableFetch(
-              getApiUrl("/api/auth/register"),
-              {
-                method: "POST",
-                headers: { "Content-Type": "application/json" },
-                body: JSON.stringify({ username: trimmedUsername, password }),
-                timeout: 15000,
-                throwOnHttpError: false,
-                retry: { maxAttempts: 1, initialDelayMs: 250 },
-              }
-            );
-
-            if (!response.ok) {
-              const errorData = await response.json().catch(() => ({
-                error: `HTTP error! status: ${response.status}`,
-              }));
-              return {
-                ok: false,
-                error: errorData.error || "Failed to create user",
-              };
-            }
-
-            const data = await response.json();
+            const data = await registerUser({
+              username: trimmedUsername,
+              password,
+            });
             if (data.user) {
               set({ username: data.user.username, isAuthenticated: true });
 
@@ -1229,7 +1180,13 @@ export const useChatsStore = create<ChatsStoreState>()(
             return { ok: false, error: "Invalid response format" };
           } catch (error) {
             console.error("[ChatsStore] Error creating user:", error);
-            return { ok: false, error: "Network error. Please try again." };
+            return {
+              ok: false,
+              error:
+                error instanceof ApiRequestError
+                  ? error.message
+                  : "Network error. Please try again.",
+            };
           }
         },
         incrementUnread: (roomId) => {
@@ -1499,22 +1456,16 @@ async function restoreSessionFromCookie(
   legacyToken?: string | null
 ) {
   try {
-    const headers: Record<string, string> = {};
     if (legacyToken) {
       console.log(
         "[ChatsStore] Migrating legacy token to httpOnly cookie for",
         expectedUsername
       );
-      headers["Authorization"] = `Bearer ${legacyToken}`;
-      headers["X-Username"] = expectedUsername;
     }
 
-    const response = await abortableFetch("/api/auth/session", {
-      method: "GET",
-      headers,
-      timeout: 10000,
-      throwOnHttpError: false,
-      retry: { maxAttempts: 2, initialDelayMs: 500 },
+    const response = await restoreAuthSession({
+      username: expectedUsername,
+      legacyToken,
     });
 
     if (!response.ok) {

--- a/tests/test-auth-client-wiring.test.ts
+++ b/tests/test-auth-client-wiring.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+
+describe("auth client wiring", () => {
+  test("chat store auth flows use src/api/auth wrappers", () => {
+    const source = readFileSync("src/stores/useChatsStore.ts", "utf8");
+
+    expect(source).toContain("@/api/auth");
+    expect(source).toContain("checkUserPassword()");
+    expect(source).toContain("setUserPassword(");
+    expect(source).toContain("logoutUser()");
+    expect(source).toContain("registerUser(");
+    expect(source).toContain("restoreAuthSession(");
+    expect(source).not.toContain("/api/auth/password/check");
+    expect(source).not.toContain("/api/auth/password/set");
+    expect(source).not.toContain("/api/auth/register");
+    expect(source).not.toContain("/api/auth/session");
+  });
+
+  test("terminal su password login uses the auth client wrapper", () => {
+    const source = readFileSync(
+      "src/apps/terminal/hooks/useTerminalLogic.ts",
+      "utf8"
+    );
+
+    expect(source).toContain("loginWithPassword");
+    expect(source).not.toContain("/api/auth/login");
+  });
+
+  test("control panels logout-all uses the auth client wrapper", () => {
+    const source = readFileSync(
+      "src/apps/control-panels/hooks/useControlPanelsLogic.ts",
+      "utf8"
+    );
+
+    expect(source).toContain("logoutAllDevices");
+    expect(source).not.toContain("/api/auth/logout-all");
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Adds missing auth client wrappers for password check, logout-all, and session restore.
- Routes `useChatsStore` auth flows through `src/api/auth.ts` instead of raw `/api/auth/*` fetches.
- Routes Terminal `su` password login and Control Panels logout-all through the auth client.
- Adds a wiring test to keep migrated auth flows behind the shared API client.

## Testing

- `API_URL=http://localhost:3001 bun test tests/test-auth-client-wiring.test.ts tests/test-auth-extra.test.ts`
- `bun run build`
- Browser smoke on API-backed local UI: opened ryOS at `localhost:5173`, checked System Preferences auth modal, and ran Terminal `su ryo testtest` with a structured non-404 auth response.

<a href="https://cursor.com/agents/bc-019ea255-b456-75cf-9521-8a31af1d172d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fauth_client_5173_smoke.mp4"><img src="https://cursor.com/artifacts/c/art-81f0eb81-e2d0-4a5b-b469-ee89fbd59cf8" alt="auth_client_5173_smoke.mp4" /></a>

## Warnings

- `tests/test-new-api.test.ts` still has the pre-existing register/login state issue noted on the parent branch; `test-auth-extra` passed against the API server on port 3001.

## Stack

- Base branch: `cursor/codebase-simplification-audit-172d`
- This is the second follow-up phase PR after resolving latest `main` conflicts.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ea255-b456-75cf-9521-8a31af1d172d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ea255-b456-75cf-9521-8a31af1d172d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

