### PR TITLE
Audit: centralize text selection policy for OS chrome vs content

### DIFF
--- a/src/apps/chats/components/chat-messages/chat-message-item/ChatMessageItemMeta.tsx
+++ b/src/apps/chats/components/chat-messages/chat-message-item/ChatMessageItemMeta.tsx
@@ -45,7 +45,7 @@ export function ChatMessageItemMeta({ vm }: { vm: ChatMessageItemViewModel }) {
     <div
       className={`${
         isMacOSTheme ? "text-[10px]" : "text-[16px]"
-      } chat-messages-meta text-neutral-500 mb-0.5 font-['Geneva-9'] mb-[-2px] select-text flex items-center gap-2`}
+      } chat-messages-meta text-neutral-500 mb-0.5 font-['Geneva-9'] mb-[-2px] flex items-center gap-2`}
     >
       {message.role === "user" && (
         <>
@@ -59,7 +59,7 @@ export function ChatMessageItemMeta({ vm }: { vm: ChatMessageItemViewModel }) {
                       opacity: isHovered ? 1 : 0,
                       scale: 1,
                     }}
-                    className="size-3 text-neutral-400 hover:text-red-600 transition-colors"
+                    className="size-3 text-neutral-400 hover:text-red-600 transition-colors select-none"
                     onClick={() => onDeleteMessage(message)}
                     aria-label={t("apps.chats.ariaLabels.deleteMessage")}
                   >
@@ -78,7 +78,7 @@ export function ChatMessageItemMeta({ vm }: { vm: ChatMessageItemViewModel }) {
               opacity: isHovered ? 1 : 0,
               scale: 1,
             }}
-            className="size-3 text-neutral-400 hover:text-neutral-600 transition-colors"
+            className="size-3 text-neutral-400 hover:text-neutral-600 transition-colors select-none"
             onClick={() => onCopyMessage(message)}
             aria-label={t("apps.chats.ariaLabels.copyMessage")}
           >
@@ -91,7 +91,7 @@ export function ChatMessageItemMeta({ vm }: { vm: ChatMessageItemViewModel }) {
         </>
       )}
       <span
-        className="max-w-[120px] inline-block overflow-hidden text-ellipsis whitespace-nowrap"
+        className="max-w-[120px] inline-block overflow-hidden text-ellipsis whitespace-nowrap select-text"
         title={
           message.username ||
           (message.role === "user"
@@ -135,7 +135,7 @@ export function ChatMessageItemMeta({ vm }: { vm: ChatMessageItemViewModel }) {
               opacity: isHovered ? 1 : 0,
               scale: 1,
             }}
-            className="size-3 text-neutral-400 hover:text-neutral-600 transition-colors"
+            className="size-3 text-neutral-400 hover:text-neutral-600 transition-colors select-none"
             onClick={() => onCopyMessage(message)}
             aria-label={t("apps.chats.ariaLabels.copyMessage")}
           >
@@ -152,7 +152,7 @@ export function ChatMessageItemMeta({ vm }: { vm: ChatMessageItemViewModel }) {
                 opacity: isHovered ? 1 : 0,
                 scale: 1,
               }}
-              className="size-3 text-neutral-400 hover:text-neutral-600 transition-colors"
+              className="size-3 text-neutral-400 hover:text-neutral-600 transition-colors select-none"
               onClick={() => {
                 if (playingMessageId === messageKey) {
                   stopSpeech();
@@ -212,7 +212,7 @@ export function ChatMessageItemMeta({ vm }: { vm: ChatMessageItemViewModel }) {
                     opacity: isHovered ? 1 : 0,
                     scale: 1,
                   }}
-                  className="size-3 text-neutral-400 hover:text-os-link transition-colors"
+                  className="size-3 text-neutral-400 hover:text-os-link transition-colors select-none"
                   onClick={() => onSendMessage(message.username!)}
                   aria-label={t("apps.chats.ariaLabels.messageUser", {
                     username: message.username,
@@ -241,7 +241,7 @@ export function ChatMessageItemMeta({ vm }: { vm: ChatMessageItemViewModel }) {
                   opacity: isHovered ? 1 : 0,
                   scale: 1,
                 }}
-                className="size-3 text-neutral-400 hover:text-red-600 transition-colors"
+                className="size-3 text-neutral-400 hover:text-red-600 transition-colors select-none"
                 onClick={() => onDeleteMessage(message)}
                 aria-label={t("apps.chats.ariaLabels.deleteMessage")}
               >

--- a/src/index.css
+++ b/src/index.css
@@ -652,10 +652,48 @@ button.piano-key.piano-key[class*="bg-[#ff33ff]"] {
     font-smooth: always;
   }
 
+  /* ----------------------------------------------------------------------- */
+  /* Text selection policy (deny-by-default via @layer base `*` rule)        */
+  /* Opt back in: .select-text, .ryos-chat-streamdown, form controls,      */
+  /* TextEdit ProseMirror. Chrome reinforcement: .no-select-gesture,        */
+  /* .draggable-area, .no-select-all                                        */
+  /* ----------------------------------------------------------------------- */
+
+  .select-text,
+  .select-text * {
+    user-select: text;
+    -webkit-user-select: text;
+  }
+
   .ryos-chat-streamdown,
   .ryos-chat-streamdown * {
     user-select: text;
     -webkit-user-select: text;
+  }
+
+  /* Editable form controls and contenteditable surfaces */
+  input:not(
+      [type="checkbox"]
+    ):not([type="radio"]):not([type="button"]):not([type="submit"]):not(
+      [type="reset"]
+    ):not([type="range"]):not([type="file"]):not([type="image"]):not(
+      [type="hidden"]
+    ),
+  textarea,
+  select,
+  [contenteditable="true"],
+  [contenteditable="true"] *,
+  [role="textbox"] {
+    user-select: text;
+    -webkit-user-select: text;
+  }
+
+  /* TextEdit (TipTap / ProseMirror) — cross-browser; complements Firefox block */
+  .textedit-prosemirror-root.ProseMirror,
+  .textedit-prosemirror-root.ProseMirror * {
+    user-select: text !important;
+    -webkit-user-select: text !important;
+    cursor: text;
   }
 
   .ryos-chat-streamdown {
@@ -907,6 +945,11 @@ button.piano-key.piano-key[class*="bg-[#ff33ff]"] {
     touch-action: none !important;
     -ms-touch-action: none !important;
     -webkit-touch-callout: none !important;
+    -webkit-user-select: none !important;
+    -moz-user-select: none !important;
+    -ms-user-select: none !important;
+    user-select: none !important;
+    -webkit-tap-highlight-color: transparent !important;
   }
 
   /* Preview button reset - removes XP/98 theme button styling for image/canvas preview buttons */

--- a/tests/test-text-selection-policy.test.ts
+++ b/tests/test-text-selection-policy.test.ts
@@ -1,0 +1,67 @@
+#!/usr/bin/env bun
+
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const INDEX_CSS = readFileSync(join(import.meta.dir, "../src/index.css"), "utf8");
+const CHAT_META = readFileSync(
+  join(
+    import.meta.dir,
+    "../src/apps/chats/components/chat-messages/chat-message-item/ChatMessageItemMeta.tsx"
+  ),
+  "utf8"
+);
+
+describe("text selection policy (CSS)", () => {
+  test("denies selection globally in base layer", () => {
+    expect(INDEX_CSS).toMatch(/@layer base[\s\S]*\* \{[\s\S]*user-select: none/);
+  });
+
+  test("defines chat streamdown escape hatch", () => {
+    expect(INDEX_CSS).toMatch(
+      /\.ryos-chat-streamdown,\s*\n\s*\.ryos-chat-streamdown \* \{[\s\S]*user-select: text/
+    );
+  });
+
+  test("defines select-text utility escape hatch", () => {
+    expect(INDEX_CSS).toMatch(
+      /\.select-text,\s*\n\s*\.select-text \* \{[\s\S]*user-select: text/
+    );
+  });
+
+  test("enables selection for form controls and contenteditable", () => {
+    expect(INDEX_CSS).toContain('[contenteditable="true"]');
+    expect(INDEX_CSS).toMatch(/textarea,[\s\S]*user-select: text/);
+  });
+
+  test("enables cross-browser TextEdit ProseMirror selection", () => {
+    expect(INDEX_CSS).toMatch(
+      /\.textedit-prosemirror-root\.ProseMirror[\s\S]*user-select: text !important/
+    );
+    expect(INDEX_CSS).toMatch(
+      /\.textedit-prosemirror-root\.ProseMirror \*[\s\S]*-webkit-user-select: text !important/
+    );
+  });
+
+  test("hardens resize handles against text selection", () => {
+    expect(INDEX_CSS).toMatch(
+      /\.resize-handle \{[\s\S]*user-select: none !important/
+    );
+  });
+
+  test("documents chrome reinforcement helpers", () => {
+    expect(INDEX_CSS).toContain(".no-select-gesture");
+    expect(INDEX_CSS).toContain(".draggable-area");
+    expect(INDEX_CSS).toContain(".no-select-all");
+  });
+});
+
+describe("text selection policy (Chats meta row)", () => {
+  test("scopes select-text to username and timestamp, not action buttons", () => {
+    expect(CHAT_META).not.toMatch(/chat-messages-meta[\s\S]*select-text flex/);
+    expect(CHAT_META).toMatch(/whitespace-nowrap select-text/);
+    expect(CHAT_META).toMatch(/text-neutral-400 select-text/);
+    expect(CHAT_META).toMatch(/select-none/);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Report-first audit of ryOS text selection behavior, plus small safe centralization of escape hatches.

ryOS already uses a **deny-by-default** model (`* { user-select: none }` in `src/index.css`). This PR documents that policy and closes the highest-impact gaps without blanket `body` changes or per-app churn.

### Changes

- **`src/index.css`**
  - Document selection architecture (chrome deny-by-default + escape hatches)
  - Reinforce `.select-text` utility (including descendants)
  - Cross-browser `user-select: text` for TextEdit ProseMirror (was Firefox-only)
  - Form control / contenteditable opt-in (`input`, `textarea`, `select`, `[contenteditable]`, `[role="textbox"]`)
  - Align `.resize-handle` with `.draggable-area` selection prevention
- **`ChatMessageItemMeta.tsx`**
  - Remove `select-text` from meta row container; scope to username/timestamp spans
  - Add `select-none` to action buttons (copy/delete/TTS/DM)
- **`tests/test-text-selection-policy.test.ts`**
  - Smoke checks for CSS policy + Chats meta scoping

### Audit highlights (not changed — follow-ups)

| Area | Status |
|------|--------|
| Global chrome | Covered by `*` default; title bars use `draggable-area` |
| Dock / desktop / expose | Inherit global; lack explicit `no-select-gesture` for Safari drag |
| Shared `Button` / `Tabs` / toolbars | Inherit global; no per-primitive `select-none` |
| Chats bubbles | `.ryos-chat-streamdown` + `select-text` ✅ |
| Chats iOS long-press | `ChatMessageItem` `touchstart` `preventDefault` may block bubble selection |
| TextEdit body | Fixed cross-browser ProseMirror opt-in in this PR |
| Applets | iframe sandbox — parent `user-select` does not apply inside applet DOM |
| Finder/Contacts/Admin view text | Not copyable without future `select-text` on display fields |

### Proposed architecture (documented in CSS)

```
Default:     * { user-select: none }           // OS chrome
Reinforce:   .no-select-gesture, .draggable-area, .no-select-all
Escape:      .select-text, .ryos-chat-streamdown, form controls, ProseMirror
```

### Testing

```bash
bun test tests/test-text-selection-policy.test.ts
```

Manual smoke checklist (not run in this PR — GUI skipped per AGENTS.md unless requested):

- [ ] Drag window by title bar — no text highlight
- [ ] Click dock/menu buttons — no selection flash (esp. Safari)
- [ ] Select chat message markdown text
- [ ] Select text in chat input / TextEdit body
- [ ] iOS long-press on desktop icon → context menu (not native callout)

### Risk notes

- **TextEdit**: ProseMirror now has explicit WebKit `user-select: text !important`; monitor SlashCommands popup (should stay non-selectable).
- **Chats**: Meta row fix is low-risk; bubble selection on iOS still gated by `preventDefault` on `touchstart`.
- **Applets**: Generated HTML in `applet-viewer` iframe is isolated; only chrome outside iframe is affected.
- **contenteditable**: Global opt-in applies to any `[contenteditable="true"]` in the app tree.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3e081231-7642-4472-81bc-f6d4df03cf84"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3e081231-7642-4472-81bc-f6d4df03cf84"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

