### PR TITLE
refactor: route chat ai calls through api client

### DIFF
--- a/src/api/ai.ts
+++ b/src/api/ai.ts
@@ -1,0 +1,93 @@
+import { apiRequest } from "@/api/core";
+import type { AIChatMessage } from "@/types/chat";
+
+export interface RyoReplyRequest {
+  roomId: string;
+  prompt: string;
+  systemState?: {
+    chatRoomContext?: {
+      recentMessages?: string;
+      mentionedMessage?: string;
+    };
+  };
+}
+
+export interface RyoReplyResponse {
+  message: {
+    id: string;
+    roomId: string;
+    username: string;
+    content: string;
+    timestamp: string | number;
+  };
+}
+
+export async function requestRyoReply(
+  body: RyoReplyRequest,
+  options: { signal?: AbortSignal } = {}
+): Promise<RyoReplyResponse> {
+  return apiRequest<RyoReplyResponse, RyoReplyRequest>({
+    path: "/api/ai/ryo-reply",
+    method: "POST",
+    body,
+    signal: options.signal,
+    timeout: 20000,
+    retry: { maxAttempts: 1, initialDelayMs: 250 },
+  });
+}
+
+export interface ExtractMemoriesRequest {
+  timeZone: string;
+  messages: Array<{
+    role: AIChatMessage["role"];
+    parts: AIChatMessage["parts"];
+    metadata?: {
+      createdAt?: string | number | Date;
+    };
+  }>;
+}
+
+export interface ExtractMemoriesResponse {
+  extracted: number;
+  dailyNotes?: number;
+  analyzed?: number;
+  message?: string;
+}
+
+export async function extractMemoriesFromChat(
+  body: ExtractMemoriesRequest,
+  options: { timeZoneHeader?: string } = {}
+): Promise<ExtractMemoriesResponse> {
+  return apiRequest<ExtractMemoriesResponse, ExtractMemoriesRequest>({
+    path: "/api/ai/extract-memories",
+    method: "POST",
+    headers: options.timeZoneHeader
+      ? { "X-User-Timezone": options.timeZoneHeader }
+      : undefined,
+    body,
+    timeout: 15000,
+    retry: { maxAttempts: 1, initialDelayMs: 250 },
+  });
+}
+
+export interface ProactiveGreetingResponse {
+  greeting?: string;
+}
+
+export async function requestProactiveGreeting(
+  options: { signal?: AbortSignal } = {}
+): Promise<ProactiveGreetingResponse> {
+  return apiRequest<ProactiveGreetingResponse, {
+    messages: [];
+    proactiveGreeting: true;
+  }>({
+    path: "/api/chat",
+    method: "POST",
+    body: {
+      messages: [],
+      proactiveGreeting: true,
+    },
+    signal: options.signal,
+    timeout: 20000,
+  });
+}

--- a/src/apps/chats/hooks/useAiChat.ts
+++ b/src/apps/chats/hooks/useAiChat.ts
@@ -51,6 +51,7 @@ import { getAssistantVisibleText } from "../utils/aiMessageText";
 import { useChatSpeechSync } from "./useChatSpeechSync";
 import { useSyncedAiMessages } from "./useSyncedAiMessages";
 import { detectUserOS, getSystemState } from "../utils/systemState";
+import { extractMemoriesFromChat } from "@/api/ai";
 import {
   executeToolHandler,
   handleLaunchApp,
@@ -1812,13 +1813,8 @@ export function useAiChat(onPromptSetUsername?: () => void) {
     if (currentUsername && isAuthenticated && messagesToAnalyze.length > 2) {
       console.log("[clearChats] Triggering async memory extraction...");
 
-      abortableFetch(getApiUrl("/api/ai/extract-memories"), {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          "X-User-Timezone": currentTimeZone,
-        },
-        body: JSON.stringify({
+      extractMemoriesFromChat(
+        {
           timeZone: currentTimeZone,
           messages: messagesToAnalyze.map(msg => ({
             role: msg.role,
@@ -1832,11 +1828,9 @@ export function useAiChat(onPromptSetUsername?: () => void) {
                 }
               : undefined,
           })),
-        }),
-        timeout: 15000,
-        retry: { maxAttempts: 1, initialDelayMs: 250 },
-      })
-        .then(res => res.json())
+        },
+        { timeZoneHeader: currentTimeZone }
+      )
         .then(data => {
           if (data.extracted > 0) {
             console.log(`[clearChats] Extracted ${data.extracted} memories from conversation`);

--- a/src/apps/chats/hooks/useProactiveGreeting.ts
+++ b/src/apps/chats/hooks/useProactiveGreeting.ts
@@ -1,8 +1,7 @@
 import { useState, useEffect, useCallback, useRef } from "react";
 import { useChatsStore } from "@/stores/useChatsStore";
 import type { AIChatMessage } from "@/types/chat";
-import { getApiUrl } from "@/utils/platform";
-import { abortableFetch } from "@/utils/abortableFetch";
+import { requestProactiveGreeting } from "@/api/ai";
 import { applyFreshProactiveGreeting } from "../utils/proactiveGreetingApply";
 
 /**
@@ -117,20 +116,11 @@ export function useProactiveGreeting({
       setIsLoadingGreeting(true);
 
       try {
-        const response = await abortableFetch(getApiUrl("/api/chat"), {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            messages: [],
-            proactiveGreeting: true,
-          }),
-          timeout: 20000,
+        const data = await requestProactiveGreeting({
           signal: controller.signal,
         });
 
         if (controller.signal.aborted) return;
-
-        const data = await response.json();
 
         if (data.greeting && typeof data.greeting === "string") {
           const proactiveMessage: AIChatMessage = {

--- a/src/apps/chats/hooks/useRyoChat.ts
+++ b/src/apps/chats/hooks/useRyoChat.ts
@@ -1,7 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { getApiUrl } from "@/utils/platform";
-import { abortableFetch } from "@/utils/abortableFetch";
+import { requestRyoReply } from "@/api/ai";
 import { getSystemState } from "../utils/systemState";
 import { parseRyoMention } from "../utils/ryoMention";
 
@@ -60,18 +59,14 @@ export function useRyoChat({
       setIsRyoLoading(true);
 
       try {
-        await abortableFetch(getApiUrl("/api/ai/ryo-reply"), {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
+        await requestRyoReply(
+          {
             roomId: currentRoomId,
             prompt: messageContent,
             systemState: systemStateWithChat,
-          }),
-          signal: controller.signal,
-          timeout: 20000,
-          retry: { maxAttempts: 1, initialDelayMs: 250 },
-        });
+          },
+          { signal: controller.signal }
+        );
       } catch (error) {
         if (!(error instanceof DOMException && error.name === "AbortError")) {
           console.error("[RyoChat] Failed to request @ryo reply:", error);

--- a/tests/test-ai-client-wiring.test.ts
+++ b/tests/test-ai-client-wiring.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+
+describe("AI client wiring", () => {
+  test("Ryo room replies use the shared AI API client", () => {
+    const source = readFileSync("src/apps/chats/hooks/useRyoChat.ts", "utf8");
+
+    expect(source).toContain("requestRyoReply");
+    expect(source).not.toContain("/api/ai/ryo-reply");
+  });
+
+  test("clear-chat memory extraction uses the shared AI API client", () => {
+    const source = readFileSync("src/apps/chats/hooks/useAiChat.ts", "utf8");
+
+    expect(source).toContain("extractMemoriesFromChat");
+    expect(source).not.toContain("/api/ai/extract-memories");
+  });
+
+  test("proactive greeting uses the shared AI API client", () => {
+    const source = readFileSync(
+      "src/apps/chats/hooks/useProactiveGreeting.ts",
+      "utf8"
+    );
+
+    expect(source).toContain("requestProactiveGreeting");
+    expect(source).not.toContain("abortableFetch(getApiUrl(\"/api/chat\")");
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Adds `src/api/ai.ts` wrappers for Ryo room replies, clear-chat memory extraction, and proactive greetings.
- Routes `useRyoChat`, `useAiChat` memory extraction, and `useProactiveGreeting` through the shared AI API client instead of raw internal `abortableFetch` calls.
- Adds a wiring test to keep those discrete AI calls behind `src/api/ai.ts`.

## Testing

- `API_URL=http://localhost:3001 bun test tests/test-ai-client-wiring.test.ts tests/test-ai.test.ts tests/test-chat-input-composer-state.test.ts tests/test-synced-ai-messages.test.ts`
- `bun run build`
- Browser smoke: opened ryOS at `localhost:5173`, launched Chats, and confirmed the chat input accepts focus/text without runtime errors.

<a href="https://cursor.com/agents/bc-019ea255-b456-75cf-9521-8a31af1d172d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fai_client_chats_ui_smoke.mp4"><img src="https://cursor.com/artifacts/c/art-1d84112b-b3a2-4def-8ce1-2ed4cb75b45d" alt="ai_client_chats_ui_smoke.mp4" /></a>

## Stack

- Base branch: `cursor/codebase-simplification-audit-172d`
- This is another Wave 7 follow-up phase PR after auth client unification.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ea255-b456-75cf-9521-8a31af1d172d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ea255-b456-75cf-9521-8a31af1d172d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

