### PR TITLE
refactor: route media api calls through client wrappers

### DIFF
--- a/src/api/media.ts
+++ b/src/api/media.ts
@@ -1,0 +1,76 @@
+import {
+  apiRequest,
+  apiRequestRaw,
+  ApiRequestError,
+  type ApiErrorPayload,
+} from "@/api/core";
+import type { Video } from "@/stores/useVideoStore";
+
+export interface ParsedTitleResponse {
+  title?: string;
+  artist?: string;
+  album?: string;
+}
+
+export async function parseVideoTitle(params: {
+  title: string;
+  authorName?: string;
+  timeout?: number;
+}): Promise<ParsedTitleResponse> {
+  return apiRequest<ParsedTitleResponse, {
+    title: string;
+    author_name?: string;
+  }>({
+    path: "/api/parse-title",
+    method: "POST",
+    body: {
+      title: params.title,
+      author_name: params.authorName,
+    },
+    timeout: params.timeout ?? 15000,
+    retry: { maxAttempts: 1, initialDelayMs: 250 },
+  });
+}
+
+export interface CreateTvChannelPlanRequest {
+  description: string;
+}
+
+export interface CreateTvChannelPlanResponse {
+  name: string;
+  description: string;
+  queries: string[];
+  videos: Video[];
+}
+
+export class MediaApiRequestError extends ApiRequestError {
+  constructor(status: number, message: string, payload?: ApiErrorPayload) {
+    super(status, message, payload);
+    this.name = "MediaApiRequestError";
+  }
+}
+
+export async function createTvChannelPlan(
+  body: CreateTvChannelPlanRequest,
+  options: { timeout?: number } = {}
+): Promise<CreateTvChannelPlanResponse> {
+  const response = await apiRequestRaw<CreateTvChannelPlanRequest>({
+    path: "/api/tv/create-channel",
+    method: "POST",
+    body,
+    timeout: options.timeout ?? 45000,
+    retry: { maxAttempts: 1, initialDelayMs: 250 },
+  });
+
+  const data = await response.json().catch(() => ({}));
+  if (!response.ok) {
+    const payload = data as ApiErrorPayload;
+    throw new MediaApiRequestError(
+      response.status,
+      payload.error || payload.message || `Request failed with status ${response.status}`,
+      payload
+    );
+  }
+
+  return data as CreateTvChannelPlanResponse;
+}

--- a/src/apps/chats/tools/tvHandler.ts
+++ b/src/apps/chats/tools/tvHandler.ts
@@ -19,9 +19,11 @@ import {
 } from "@/apps/tv/data/channels";
 import type { Video } from "@/stores/useVideoStore";
 import { isYouTubeUrl, parseYouTubeId } from "@/apps/tv/utils";
-import { abortableFetch } from "@/utils/abortableFetch";
-import { fetchYouTubeOembed } from "@/utils/youtubeMetadata";
-import { getApiUrl } from "@/utils/platform";
+import {
+  createTvChannelPlan,
+  MediaApiRequestError,
+} from "@/api/media";
+import { fetchYouTubeOembed, parseYouTubeTitle } from "@/utils/youtubeMetadata";
 import { createShortIdMap, resolveId, type ShortIdMap } from "./helpers";
 
 export interface TvControlInput {
@@ -87,32 +89,11 @@ const fetchVideoMetadata = async (
       const rawTitle = oembed.rawTitle || `Video ID: ${videoId}`;
       const authorName = oembed.authorName;
 
-      // Best-effort AI title parse for cleaner title/artist split — if it
-      // fails, we just keep the oEmbed values (still better than nothing).
-      try {
-        const parseRes = await abortableFetch(getApiUrl("/api/parse-title"), {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ title: rawTitle, author_name: authorName }),
-          timeout: 10000,
-          throwOnHttpError: false,
-          retry: { maxAttempts: 1, initialDelayMs: 250 },
-        });
-        if (parseRes.ok) {
-          const parsed = (await parseRes.json()) as {
-            title?: string;
-            artist?: string;
-          };
-          return {
-            title: parsed.title || rawTitle,
-            artist: parsed.artist || authorName,
-          };
-        }
-      } catch {
-        // Ignore parse errors and keep oEmbed values.
-      }
-
-      return { title: rawTitle, artist: authorName };
+      const parsed = await parseYouTubeTitle(rawTitle, authorName);
+      return {
+        title: parsed.title || rawTitle,
+        artist: parsed.artist || authorName,
+      };
     }
   } catch {
     // Network failure — fall through to default title.
@@ -332,7 +313,7 @@ export const handleTvControl = async (
           return;
         }
 
-        // Server fanout: /api/tv/create-channel runs the same AI plan +
+        // Server fanout runs the same AI plan +
         // YouTube fanout the manual TV "Create Channel" dialog uses, so
         // the AI doesn't need to call searchSongs first or ask the user
         // for a video list.
@@ -343,58 +324,10 @@ export const handleTvControl = async (
           videos: Video[];
         };
         try {
-          const response = await abortableFetch(
-            getApiUrl("/api/tv/create-channel"),
-            {
-              method: "POST",
-              headers: { "Content-Type": "application/json" },
-              body: JSON.stringify({ description: prompt }),
-              timeout: 60000,
-              throwOnHttpError: false,
-            }
+          const raw = await createTvChannelPlan(
+            { description: prompt },
+            { timeout: 60000 }
           );
-
-          if (!response.ok) {
-            const data = (await response.json().catch(() => ({}))) as {
-              error?: string;
-              scope?: string;
-            };
-            const isAuthRequired =
-              response.status === 401 || response.status === 403;
-            const isRateLimit = response.status === 429;
-            // Surface auth errors with a distinct, actionable message so
-            // the chat AI can suggest the user log in (and so the chat
-            // UI's tool-error renderer can flag it differently from a
-            // generic failure). Falls back to the generic failure text
-            // for unknown statuses.
-            const errorText = isAuthRequired
-              ? i18n.t("apps.tv.create.signInRequired", {
-                  defaultValue: "Sign in to create channels",
-                })
-              : isRateLimit
-              ? i18n.t("apps.chats.toolCalls.tv.createRateLimited", {
-                  defaultValue:
-                    "Channel creation is rate-limited right now. Try again in a bit.",
-                })
-              : data?.error ||
-                i18n.t("apps.chats.toolCalls.tv.createFailed", {
-                  defaultValue: "Failed to plan channel",
-                });
-            context.addToolOutput({
-              tool: "tvControl",
-              toolCallId,
-              state: "output-error",
-              errorText,
-            });
-            return;
-          }
-
-          const raw = (await response.json()) as {
-            name?: string;
-            description?: string;
-            queries?: string[];
-            videos?: Video[];
-          };
           if (!raw?.videos?.length || !raw?.name) {
             context.addToolOutput({
               tool: "tvControl",
@@ -414,6 +347,31 @@ export const handleTvControl = async (
             videos: raw.videos,
           };
         } catch (err) {
+          if (err instanceof MediaApiRequestError) {
+            const isAuthRequired = err.status === 401 || err.status === 403;
+            const isRateLimit = err.status === 429;
+            const errorText = isAuthRequired
+              ? i18n.t("apps.tv.create.signInRequired", {
+                  defaultValue: "Sign in to create channels",
+                })
+              : isRateLimit
+              ? i18n.t("apps.chats.toolCalls.tv.createRateLimited", {
+                  defaultValue:
+                    "Channel creation is rate-limited right now. Try again in a bit.",
+                })
+              : err.message ||
+                i18n.t("apps.chats.toolCalls.tv.createFailed", {
+                  defaultValue: "Failed to plan channel",
+                });
+            context.addToolOutput({
+              tool: "tvControl",
+              toolCallId,
+              state: "output-error",
+              errorText,
+            });
+            return;
+          }
+
           console.error("[tvControl] create-channel API failed:", err);
           context.addToolOutput({
             tool: "tvControl",

--- a/src/apps/tv/hooks/useCreateTvChannel.ts
+++ b/src/apps/tv/hooks/useCreateTvChannel.ts
@@ -1,17 +1,11 @@
 import { useCallback, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { abortableFetch } from "@/utils/abortableFetch";
-import { getApiUrl } from "@/utils/platform";
+import {
+  createTvChannelPlan,
+  MediaApiRequestError,
+} from "@/api/media";
 import { useTvStore, type CustomChannel } from "@/stores/useTvStore";
-import type { Video } from "@/stores/useVideoStore";
 import { getTextAnalytics, MEDIA_ANALYTICS, track } from "@/utils/analytics";
-
-interface CreateChannelResponse {
-  name: string;
-  description: string;
-  queries: string[];
-  videos: Video[];
-}
 
 export interface CreateTvChannelResult {
   /** Created and persisted channel, ready to tune in. */
@@ -22,7 +16,7 @@ export interface CreateTvChannelResult {
 
 /**
  * Sentinel error thrown when the API returns 401 (or 403) on
- * /api/tv/create-channel. Callers should catch this and surface a
+ * the channel creation API. Callers should catch this and surface a
  * "log in to continue" prompt instead of treating it as a generic
  * failure. Subclassing Error keeps `instanceof` checks reliable
  * across the bundle without depending on string-matching message
@@ -58,36 +52,10 @@ export function useCreateTvChannel() {
 
       setIsCreating(true);
       try {
-        const response = await abortableFetch(
-          getApiUrl("/api/tv/create-channel"),
-          {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ description: trimmed }),
-            timeout: 45000,
-            throwOnHttpError: false,
-          }
-        );
-
-        if (!response.ok) {
-          const data = await response.json().catch(() => ({}));
-          if (response.status === 401 || response.status === 403) {
-            throw new TvChannelAuthRequiredError(
-              t("apps.tv.create.signInRequired")
-            );
-          }
-          const msg =
-            response.status === 429
-              ? t("apps.tv.create.errorRateLimit")
-              : data?.error || t("apps.tv.create.errorGeneric");
-          throw new Error(msg);
-        }
-
-        const data = (await response.json()) as CreateChannelResponse;
+        const data = await createTvChannelPlan({ description: trimmed });
         if (!data?.videos?.length) {
           throw new Error(t("apps.tv.create.errorNoVideos"));
         }
-
         const channel = addCustomChannel({
           name: data.name,
           description: data.description,
@@ -104,17 +72,27 @@ export function useCreateTvChannel() {
 
         return { channel, queries: data.queries ?? [] };
       } catch (error) {
+        const normalizedError =
+          error instanceof MediaApiRequestError
+            ? error.status === 401 || error.status === 403
+              ? new TvChannelAuthRequiredError(t("apps.tv.create.signInRequired"))
+              : new Error(
+                  error.status === 429
+                    ? t("apps.tv.create.errorRateLimit")
+                    : error.message || t("apps.tv.create.errorGeneric")
+                )
+            : error;
         track(MEDIA_ANALYTICS.TV_CHANNEL_CREATE, {
           ...getTextAnalytics(trimmed),
           success: false,
           errorType:
-            error instanceof TvChannelAuthRequiredError
+            normalizedError instanceof TvChannelAuthRequiredError
               ? "auth"
-              : error instanceof Error
-                ? error.name
+              : normalizedError instanceof Error
+                ? normalizedError.name
                 : "unknown",
         });
-        throw error;
+        throw normalizedError;
       } finally {
         setIsCreating(false);
       }

--- a/src/utils/youtubeMetadata.ts
+++ b/src/utils/youtubeMetadata.ts
@@ -1,5 +1,5 @@
 import { abortableFetch } from "@/utils/abortableFetch";
-import { getApiUrl } from "@/utils/platform";
+import { parseVideoTitle } from "@/api/media";
 
 const FETCH_OPTS = {
   timeout: 15000,
@@ -47,7 +47,7 @@ export interface ParsedYouTubeTitle {
 }
 
 /**
- * Resolve a cleaned title/artist via `/api/parse-title`. Never throws: on any
+ * Resolve a cleaned title/artist via the internal title parser. Never throws: on any
  * HTTP/network failure it falls back to `{ title: rawTitle }`.
  */
 export async function parseYouTubeTitle(
@@ -55,24 +55,16 @@ export async function parseYouTubeTitle(
   authorName?: string
 ): Promise<ParsedYouTubeTitle> {
   try {
-    const res = await abortableFetch(getApiUrl("/api/parse-title"), {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ title: rawTitle, author_name: authorName }),
-      ...FETCH_OPTS,
+    const data = await parseVideoTitle({
+      title: rawTitle,
+      authorName,
+      timeout: FETCH_OPTS.timeout,
     });
-    if (res.ok) {
-      const data = (await res.json()) as {
-        title?: string;
-        artist?: string;
-        album?: string;
-      };
-      return {
-        title: data.title || rawTitle,
-        artist: data.artist,
-        album: data.album,
-      };
-    }
+    return {
+      title: data.title || rawTitle,
+      artist: data.artist,
+      album: data.album,
+    };
   } catch {
     // ignore — fall back to the raw oEmbed title
   }

--- a/tests/test-media-api-client-wiring.test.ts
+++ b/tests/test-media-api-client-wiring.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+
+describe("media API client wiring", () => {
+  test("YouTube title parsing uses the media API client", () => {
+    const source = readFileSync("src/utils/youtubeMetadata.ts", "utf8");
+
+    expect(source).toContain("parseVideoTitle");
+    expect(source).not.toContain("/api/parse-title");
+  });
+
+  test("TV create hook uses the media API client", () => {
+    const source = readFileSync("src/apps/tv/hooks/useCreateTvChannel.ts", "utf8");
+
+    expect(source).toContain("createTvChannelPlan");
+    expect(source).not.toContain("/api/tv/create-channel");
+  });
+
+  test("chat tv control uses the media API client for parse and create calls", () => {
+    const source = readFileSync("src/apps/chats/tools/tvHandler.ts", "utf8");
+
+    expect(source).toContain("parseYouTubeTitle");
+    expect(source).toContain("createTvChannelPlan");
+    expect(source).not.toContain("/api/parse-title");
+    expect(source).not.toContain("/api/tv/create-channel");
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Adds `src/api/media.ts` wrappers for parse-title and TV channel creation.
- Routes YouTube title parsing, TV channel creation hook, and chat `tvControl` media calls through the shared media API client.
- Preserves existing fallback behavior for title parsing and existing auth/rate-limit messaging for TV channel creation.
- Adds a wiring test to prevent these paths from drifting back to raw internal fetches.

## Testing

- `API_URL=http://localhost:3001 bun test tests/test-media-api-client-wiring.test.ts tests/test-media.test.ts tests/test-tv-utils.test.ts tests/test-tv-control-schema.test.ts tests/test-tv-channels.test.ts`
- `bun run build`
- Browser smoke: opened ryOS at `localhost:5173`, launched TV, focused the create-channel prompt, and typed text without submitting or triggering quota-consuming API calls.

<a href="https://cursor.com/agents/bc-019ea255-b456-75cf-9521-8a31af1d172d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmedia_api_tv_prompt_smoke.mp4"><img src="https://cursor.com/artifacts/c/art-27cda36d-d8a2-45ae-9fd1-a14c4be0f698" alt="media_api_tv_prompt_smoke.mp4" /></a>

## Notes

- The smoke video shows an unrelated embedded YouTube availability message for the currently tuned channel; no app runtime error overlay appears and the prompt input remains usable.

## Stack

- Base branch: `cursor/codebase-simplification-audit-172d`
- This is another Wave 7 follow-up phase PR after auth/AI client unification.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ea255-b456-75cf-9521-8a31af1d172d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ea255-b456-75cf-9521-8a31af1d172d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

