### PR TITLE
refactor: route airdrop calls through api client

### DIFF
--- a/src/api/airdrop.ts
+++ b/src/api/airdrop.ts
@@ -1,0 +1,65 @@
+import { apiRequest } from "@/api/core";
+
+export interface AirDropDiscoverResponse {
+  users: string[];
+}
+
+export interface AirDropSendRequest {
+  recipient: string;
+  fileName: string;
+  fileType?: string;
+  content: string;
+}
+
+export interface AirDropSendResponse {
+  success: boolean;
+  transferId: string;
+}
+
+export interface AirDropRespondRequest {
+  transferId: string;
+  accept: boolean;
+}
+
+export interface AirDropRespondResponse {
+  success: boolean;
+  declined?: boolean;
+  fileName?: string;
+  fileType?: string;
+  content?: string;
+  sender?: string;
+}
+
+export async function sendAirDropHeartbeat(): Promise<{ success: boolean }> {
+  return apiRequest<{ success: boolean }>({
+    path: "/api/airdrop/heartbeat",
+    method: "POST",
+  });
+}
+
+export async function discoverAirDropUsers(): Promise<AirDropDiscoverResponse> {
+  return apiRequest<AirDropDiscoverResponse>({
+    path: "/api/airdrop/discover",
+    method: "GET",
+  });
+}
+
+export async function sendAirDropFile(
+  body: AirDropSendRequest
+): Promise<AirDropSendResponse> {
+  return apiRequest<AirDropSendResponse, AirDropSendRequest>({
+    path: "/api/airdrop/send",
+    method: "POST",
+    body,
+  });
+}
+
+export async function respondToAirDropTransfer(
+  body: AirDropRespondRequest
+): Promise<AirDropRespondResponse> {
+  return apiRequest<AirDropRespondResponse, AirDropRespondRequest>({
+    path: "/api/airdrop/respond",
+    method: "POST",
+    body,
+  });
+}

--- a/src/stores/useAirDropStore.ts
+++ b/src/stores/useAirDropStore.ts
@@ -1,6 +1,11 @@
 import { create } from "zustand";
-import { getApiUrl } from "@/utils/platform";
-import { abortableFetch } from "@/utils/abortableFetch";
+import { ApiRequestError } from "@/api/core";
+import {
+  discoverAirDropUsers,
+  respondToAirDropTransfer,
+  sendAirDropFile,
+  sendAirDropHeartbeat,
+} from "@/api/airdrop";
 import {
   subscribePusherChannel,
   unsubscribePusherChannel,
@@ -56,19 +61,6 @@ interface AirDropState {
   unsubscribeFromChannel: () => void;
 }
 
-const makeApiRequest = async (
-  url: string,
-  options: RequestInit
-): Promise<Response> => {
-  return abortableFetch(url, {
-    ...options,
-    credentials: "include",
-    timeout: 15000,
-    throwOnHttpError: false,
-    retry: { maxAttempts: 1, initialDelayMs: 250 },
-  });
-};
-
 export const useAirDropStore = create<AirDropState>((set, get) => ({
   nearbyUsers: [],
   isDiscovering: false,
@@ -88,10 +80,7 @@ export const useAirDropStore = create<AirDropState>((set, get) => ({
 
     const heartbeat = async () => {
       try {
-        await makeApiRequest(getApiUrl("/api/airdrop/heartbeat"), {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-        });
+        await sendAirDropHeartbeat();
       } catch {
         // Silently fail heartbeat
       }
@@ -163,20 +152,15 @@ export const useAirDropStore = create<AirDropState>((set, get) => ({
   fetchNearbyUsers: async () => {
     try {
       set({ isDiscovering: true });
-      const res = await makeApiRequest(getApiUrl("/api/airdrop/discover"), {
-        method: "GET",
-      });
-      if (res.ok) {
-        const data = await res.json();
-        const users: string[] = data.users || [];
-        track(AIRDROP_ANALYTICS.DISCOVER, { nearbyCount: users.length });
-        const now = Date.now();
-        const map: Record<string, number> = {};
-        for (const u of users) {
-          map[u] = now;
-        }
-        set({ nearbyUsers: users, presenceMap: map });
+      const data = await discoverAirDropUsers();
+      const users: string[] = data.users || [];
+      track(AIRDROP_ANALYTICS.DISCOVER, { nearbyCount: users.length });
+      const now = Date.now();
+      const map: Record<string, number> = {};
+      for (const u of users) {
+        map[u] = now;
       }
+      set({ nearbyUsers: users, presenceMap: map });
     } catch {
       // Silently fail
     } finally {
@@ -187,24 +171,19 @@ export const useAirDropStore = create<AirDropState>((set, get) => ({
   sendFile: async (recipient, fileName, content, fileType) => {
     set({ isSending: true });
     try {
-      const res = await makeApiRequest(getApiUrl("/api/airdrop/send"), {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ recipient, fileName, fileType, content }),
+      await sendAirDropFile({ recipient, fileName, fileType, content });
+      track(AIRDROP_ANALYTICS.SEND, {
+        fileType: fileType || "unknown",
+        fileNameExtension: fileName.split(".").pop()?.slice(0, 12) || "",
       });
-      if (res.ok) {
-        track(AIRDROP_ANALYTICS.SEND, {
-          fileType: fileType || "unknown",
-          fileNameExtension: fileName.split(".").pop()?.slice(0, 12) || "",
-        });
-        toast.success(`Sent "${fileName}" to @${recipient}`);
-        return true;
-      }
-      const err = await res.json().catch(() => ({ error: "Send failed" }));
-      toast.error(err.error || "Failed to send file");
-      return false;
-    } catch {
-      toast.error("Failed to send file");
+      toast.success(`Sent "${fileName}" to @${recipient}`);
+      return true;
+    } catch (error) {
+      toast.error(
+        error instanceof ApiRequestError
+          ? error.message
+          : "Failed to send file"
+      );
       return false;
     } finally {
       set({ isSending: false });
@@ -213,18 +192,10 @@ export const useAirDropStore = create<AirDropState>((set, get) => ({
 
   respondToTransfer: async (transferId, accept) => {
     try {
-      const res = await makeApiRequest(getApiUrl("/api/airdrop/respond"), {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ transferId, accept }),
-      });
-      if (res.ok) {
-        const data = await res.json();
-        get().removeTransfer(transferId);
-        track(AIRDROP_ANALYTICS.RESPOND, { accepted: accept });
-        return { success: true, ...data };
-      }
-      return { success: false };
+      const data = await respondToAirDropTransfer({ transferId, accept });
+      get().removeTransfer(transferId);
+      track(AIRDROP_ANALYTICS.RESPOND, { accepted: accept });
+      return data;
     } catch {
       return { success: false };
     }

--- a/tests/test-airdrop-api-client-wiring.test.ts
+++ b/tests/test-airdrop-api-client-wiring.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+
+describe("AirDrop API client wiring", () => {
+  test("AirDrop store uses src/api/airdrop wrappers", () => {
+    const source = readFileSync("src/stores/useAirDropStore.ts", "utf8");
+
+    expect(source).toContain("@/api/airdrop");
+    expect(source).toContain("sendAirDropHeartbeat");
+    expect(source).toContain("discoverAirDropUsers");
+    expect(source).toContain("sendAirDropFile");
+    expect(source).toContain("respondToAirDropTransfer");
+    expect(source).not.toContain("/api/airdrop/");
+    expect(source).not.toContain("makeApiRequest");
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Adds `src/api/airdrop.ts` wrappers for heartbeat, discover, send, and respond endpoints.
- Routes `useAirDropStore` through the shared AirDrop API client instead of its local `makeApiRequest` helper.
- Preserves silent heartbeat/discover behavior and existing send/respond toast semantics.
- Adds a wiring test to keep AirDrop store calls behind `src/api/airdrop.ts`.

## Testing

- `API_URL=http://localhost:3001 bun test tests/test-airdrop-api-client-wiring.test.ts`
- `bun run build`

## Stack

- Base branch: `cursor/codebase-simplification-audit-172d`
- This is another Wave 7 follow-up phase PR for internal API client unification.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ea255-b456-75cf-9521-8a31af1d172d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ea255-b456-75cf-9521-8a31af1d172d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

