### PR TITLE
refactor: route cursor agent polling through api client

### DIFF
--- a/src/api/cursorAgent.ts
+++ b/src/api/cursorAgent.ts
@@ -1,0 +1,50 @@
+import { apiRequest } from "@/api/core";
+
+export interface CursorRunStatusResponse {
+  events?: unknown[];
+  done?: boolean;
+  meta?: {
+    agentId?: unknown;
+    agentTitle?: unknown;
+    prUrl?: unknown;
+    nextRunId?: unknown;
+    activeRunId?: unknown;
+    terminalStatus?: unknown;
+  };
+  terminal?: { prUrl?: unknown } | null;
+}
+
+export interface CursorRunFollowupResponse {
+  runId?: string;
+  agentId?: string;
+  previousRunId?: string;
+  message?: string;
+}
+
+export async function getCursorRunStatus(
+  runId: string
+): Promise<CursorRunStatusResponse> {
+  return apiRequest<CursorRunStatusResponse>({
+    path: "/api/ai/cursor-run-status",
+    method: "GET",
+    query: { runId },
+    timeout: 25000,
+    retry: { maxAttempts: 1, initialDelayMs: 250 },
+  });
+}
+
+export async function sendCursorRunFollowup(params: {
+  runId: string;
+  prompt: string;
+}): Promise<CursorRunFollowupResponse> {
+  return apiRequest<CursorRunFollowupResponse, {
+    runId: string;
+    prompt: string;
+  }>({
+    path: "/api/ai/cursor-run-followup",
+    method: "POST",
+    body: params,
+    timeout: 30000,
+    retry: { maxAttempts: 1, initialDelayMs: 250 },
+  });
+}

--- a/src/components/shared/useCursorAgentRunPoll.ts
+++ b/src/components/shared/useCursorAgentRunPoll.ts
@@ -1,6 +1,9 @@
 import { useCallback, useEffect, useReducer, useRef } from "react";
-import { abortableFetch } from "@/utils/abortableFetch";
-import { getApiUrl } from "@/utils/platform";
+import {
+  getCursorRunStatus,
+  sendCursorRunFollowup,
+  type CursorRunStatusResponse,
+} from "@/api/cursorAgent";
 
 export interface CursorAgentRunMeta {
   agentId?: string;
@@ -11,20 +14,6 @@ export interface CursorAgentRunMeta {
   /** When non-null, a run is in flight on this agent. */
   activeRunId?: string;
   terminalStatus?: string;
-}
-
-interface CursorRunStatusResponse {
-  events?: unknown[];
-  done?: boolean;
-  meta?: {
-    agentId?: unknown;
-    agentTitle?: unknown;
-    prUrl?: unknown;
-    nextRunId?: unknown;
-    activeRunId?: unknown;
-    terminalStatus?: unknown;
-  };
-  terminal?: { prUrl?: unknown } | null;
 }
 
 function pickMeta(raw: CursorRunStatusResponse | null): CursorAgentRunMeta {
@@ -76,7 +65,7 @@ export interface UseCursorAgentRunPollResult {
 }
 
 /**
- * Polls `/api/ai/cursor-run-status` until the run emits a terminal event.
+ * Polls Cursor agent run status until the run emits a terminal event.
  * Reads `meta.agentTitle` from Redis so the banner matches catalog even when
  * tool JSON omits it. When the meta references a follow-up run, the hook
  * automatically swaps to the new run id so the chat card keeps streaming.
@@ -163,15 +152,7 @@ export function useCursorAgentRunPoll(
 
     async function tick(force = false) {
       try {
-        const res = await abortableFetch(
-          `${getApiUrl("/api/ai/cursor-run-status")}?runId=${encodeURIComponent(activeRunId)}`,
-          {
-            credentials: "include",
-            timeout: 25000,
-            retry: { maxAttempts: 1, initialDelayMs: 250 },
-          }
-        );
-        const data = (await res.json()) as CursorRunStatusResponse;
+        const data = await getCursorRunStatus(activeRunId);
         if (cancelled) return;
 
         const newEvents = Array.isArray(data.events) ? data.events : [];
@@ -243,25 +224,10 @@ export function useCursorAgentRunPoll(
         payload: { isSendingFollowup: true, followupError: null },
       });
       try {
-        const res = await abortableFetch(
-          getApiUrl("/api/ai/cursor-run-followup"),
-          {
-            method: "POST",
-            credentials: "include",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ runId: activeRunId, prompt: trimmed }),
-            timeout: 30000,
-            throwOnHttpError: false,
-            retry: { maxAttempts: 1, initialDelayMs: 250 },
-          }
-        );
-        const data = (await res.json().catch(() => ({}))) as {
-          runId?: string;
-          error?: string;
-        };
-        if (!res.ok) {
-          throw new Error(data?.error || `Failed (${res.status})`);
-        }
+        const data = await sendCursorRunFollowup({
+          runId: activeRunId,
+          prompt: trimmed,
+        });
         if (typeof data.runId !== "string" || data.runId.length === 0) {
           throw new Error("Server did not return a new runId");
         }

--- a/tests/test-cursor-agent-api-client-wiring.test.ts
+++ b/tests/test-cursor-agent-api-client-wiring.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+
+describe("Cursor agent API client wiring", () => {
+  test("run polling hook uses src/api/cursorAgent wrappers", () => {
+    const source = readFileSync(
+      "src/components/shared/useCursorAgentRunPoll.ts",
+      "utf8"
+    );
+
+    expect(source).toContain("@/api/cursorAgent");
+    expect(source).toContain("getCursorRunStatus");
+    expect(source).toContain("sendCursorRunFollowup");
+    expect(source).not.toContain("/api/ai/cursor-run-status");
+    expect(source).not.toContain("/api/ai/cursor-run-followup");
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Adds `src/api/cursorAgent.ts` wrappers for Cursor agent run status polling and follow-up prompts.
- Routes `useCursorAgentRunPoll` through the shared Cursor agent API client instead of raw internal fetch calls.
- Adds a wiring test to prevent the polling hook from drifting back to direct endpoint usage.

## Testing

- `API_URL=http://localhost:3001 bun test tests/test-cursor-agent-api-client-wiring.test.ts tests/test-cursor-agent-tool-display.test.ts tests/test-cursor-repo-agent-tool.test.ts tests/test-cursor-sdk-run-coalesce.test.ts`
- `bun run build`
- Browser smoke: opened ryOS at `localhost:5173`, launched Chats, and confirmed the chat UI/input render without runtime errors.

<a href="https://cursor.com/agents/bc-019ea255-b456-75cf-9521-8a31af1d172d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcursor_agent_chat_ui_smoke.mp4"><img src="https://cursor.com/artifacts/c/art-cc14c30d-6acf-4f2e-a9d3-555b9b9e8622" alt="cursor_agent_chat_ui_smoke.mp4" /></a>

## Stack

- Base branch: `cursor/codebase-simplification-audit-172d`
- This is another Wave 7 follow-up phase PR for internal API client unification.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ea255-b456-75cf-9521-8a31af1d172d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ea255-b456-75cf-9521-8a31af1d172d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

