### PR TITLE
refactor: route sync preference through api client

### DIFF
--- a/src/api/sync.ts
+++ b/src/api/sync.ts
@@ -1,0 +1,32 @@
+import { apiRequest } from "@/api/core";
+
+export interface AutoSyncPreferenceResponse {
+  hasPreference: boolean;
+  enabled: boolean;
+}
+
+export interface SaveAutoSyncPreferenceResponse {
+  ok: boolean;
+  enabled: boolean;
+}
+
+export async function getAutoSyncPreference(): Promise<AutoSyncPreferenceResponse> {
+  return apiRequest<AutoSyncPreferenceResponse>({
+    path: "/api/sync/auto-sync-preference",
+    method: "GET",
+    timeout: 12000,
+    retry: { maxAttempts: 1, initialDelayMs: 200 },
+  });
+}
+
+export async function saveAutoSyncPreference(
+  enabled: boolean
+): Promise<SaveAutoSyncPreferenceResponse> {
+  return apiRequest<SaveAutoSyncPreferenceResponse, { enabled: boolean }>({
+    path: "/api/sync/auto-sync-preference",
+    method: "PUT",
+    body: { enabled },
+    timeout: 12000,
+    retry: { maxAttempts: 2, initialDelayMs: 400 },
+  });
+}

--- a/src/utils/autoSyncPreference.ts
+++ b/src/utils/autoSyncPreference.ts
@@ -1,5 +1,7 @@
-import { abortableFetch } from "@/utils/abortableFetch";
-import { getApiUrl } from "@/utils/platform";
+import {
+  getAutoSyncPreference,
+  saveAutoSyncPreference,
+} from "@/api/sync";
 
 export type AutoSyncPreferenceFetch =
   | { ok: true; apply: false }
@@ -9,23 +11,7 @@ export type AutoSyncPreferenceFetch =
 /** Load server preference. Only `apply: true` when user has saved a choice (new devices follow it). */
 export async function fetchAutoSyncPreferenceFromServer(): Promise<AutoSyncPreferenceFetch> {
   try {
-    const res = await abortableFetch(
-      getApiUrl("/api/sync/auto-sync-preference"),
-      {
-        method: "GET",
-        credentials: "include",
-        throwOnHttpError: false,
-        timeout: 12000,
-        retry: { maxAttempts: 1, initialDelayMs: 200 },
-      }
-    );
-    if (!res.ok) {
-      return { ok: false };
-    }
-    const data = (await res.json()) as {
-      hasPreference?: unknown;
-      enabled?: unknown;
-    };
+    const data = await getAutoSyncPreference();
     if (data.hasPreference !== true) {
       return { ok: true, apply: false };
     }
@@ -43,15 +29,7 @@ export async function persistAutoSyncPreferenceToServer(
   enabled: boolean
 ): Promise<void> {
   try {
-    await abortableFetch(getApiUrl("/api/sync/auto-sync-preference"), {
-      method: "PUT",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ enabled }),
-      credentials: "include",
-      throwOnHttpError: false,
-      timeout: 12000,
-      retry: { maxAttempts: 2, initialDelayMs: 400 },
-    });
+    await saveAutoSyncPreference(enabled);
   } catch (e) {
     console.warn("[CloudSync] Failed to persist auto-sync preference:", e);
   }

--- a/tests/test-sync-api-client-wiring.test.ts
+++ b/tests/test-sync-api-client-wiring.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+
+describe("sync API client wiring", () => {
+  test("auto-sync preference helper uses src/api/sync wrappers", () => {
+    const source = readFileSync("src/utils/autoSyncPreference.ts", "utf8");
+
+    expect(source).toContain("@/api/sync");
+    expect(source).toContain("getAutoSyncPreference");
+    expect(source).toContain("saveAutoSyncPreference");
+    expect(source).not.toContain("/api/sync/auto-sync-preference");
+    expect(source).not.toContain("abortableFetch");
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Adds `src/api/sync.ts` wrappers for auto-sync preference GET/PUT.
- Routes `src/utils/autoSyncPreference.ts` through the shared sync API client instead of raw internal fetches.
- Preserves tolerant failure behavior for login/new-device preference reads and writes.
- Adds a wiring test to keep this helper behind `src/api/sync.ts`.

## Testing

- `API_URL=http://localhost:3001 bun test tests/test-sync-api-client-wiring.test.ts tests/test-cloud-sync-launch-and-store.test.ts tests/test-cloud-sync-persist-domain-status.test.ts tests/test-sync-logical-domains.test.ts`
- `bun run build`

## Stack

- Base branch: `cursor/codebase-simplification-audit-172d`
- This is another Wave 7 follow-up phase PR for internal API client unification.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ea255-b456-75cf-9521-8a31af1d172d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ea255-b456-75cf-9521-8a31af1d172d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

