### PR TITLE
refactor: route global presence through api client

### DIFF
--- a/src/api/presence.ts
+++ b/src/api/presence.ts
@@ -1,0 +1,27 @@
+import { apiRequest } from "@/api/core";
+
+export interface PresenceHeartbeatResponse {
+  success: boolean;
+}
+
+export interface PresenceUsersResponse {
+  users: string[];
+}
+
+export async function sendPresenceHeartbeat(): Promise<PresenceHeartbeatResponse> {
+  return apiRequest<PresenceHeartbeatResponse>({
+    path: "/api/presence/heartbeat",
+    method: "POST",
+    timeout: 10000,
+    retry: { maxAttempts: 1, initialDelayMs: 500 },
+  });
+}
+
+export async function fetchPresenceUsers(): Promise<PresenceUsersResponse> {
+  return apiRequest<PresenceUsersResponse>({
+    path: "/api/presence/heartbeat",
+    method: "GET",
+    timeout: 10000,
+    retry: { maxAttempts: 1, initialDelayMs: 500 },
+  });
+}

--- a/src/hooks/useGlobalPresence.ts
+++ b/src/hooks/useGlobalPresence.ts
@@ -3,8 +3,10 @@ import {
   subscribePusherChannel,
   unsubscribePusherChannel,
 } from "@/lib/pusherClient";
-import { getApiUrl } from "@/utils/platform";
-import { abortableFetch } from "@/utils/abortableFetch";
+import {
+  fetchPresenceUsers,
+  sendPresenceHeartbeat,
+} from "@/api/presence";
 import { useChatsStore } from "@/stores/useChatsStore";
 
 const GLOBAL_PRESENCE_CHANNEL = "presence-global";
@@ -48,35 +50,21 @@ export function useGlobalPresence(): string[] {
 
     // Send heartbeat
     const sendHeartbeat = () => {
-      abortableFetch(getApiUrl("/api/presence/heartbeat"), {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        timeout: 10000,
-        throwOnHttpError: false,
-        retry: { maxAttempts: 1, initialDelayMs: 500 },
-      }).catch(() => {});
+      sendPresenceHeartbeat().catch(() => {});
     };
 
     // Initial heartbeat + seed
     sendHeartbeat();
-    abortableFetch(getApiUrl("/api/presence/heartbeat"), {
-      method: "GET",
-      timeout: 10000,
-      throwOnHttpError: false,
-      retry: { maxAttempts: 1, initialDelayMs: 500 },
-    })
-      .then(async (res) => {
-        if (res.ok) {
-          const data = await res.json();
-          const users: string[] = data.users || [];
-          const now = Date.now();
-          const map: Record<string, PresenceEntry> = {};
-          for (const u of users) {
-            map[u] = { timestamp: now };
-          }
-          presenceMapRef.current = map;
-          deriveOnlineList();
+    fetchPresenceUsers()
+      .then((data) => {
+        const users: string[] = data.users || [];
+        const now = Date.now();
+        const map: Record<string, PresenceEntry> = {};
+        for (const u of users) {
+          map[u] = { timestamp: now };
         }
+        presenceMapRef.current = map;
+        deriveOnlineList();
       })
       .catch(() => {});
 

--- a/tests/test-presence-api-client-wiring.test.ts
+++ b/tests/test-presence-api-client-wiring.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+
+describe("presence API client wiring", () => {
+  test("global presence hook uses src/api/presence wrappers", () => {
+    const source = readFileSync("src/hooks/useGlobalPresence.ts", "utf8");
+
+    expect(source).toContain("@/api/presence");
+    expect(source).toContain("sendPresenceHeartbeat");
+    expect(source).toContain("fetchPresenceUsers");
+    expect(source).not.toContain("/api/presence/heartbeat");
+    expect(source).not.toContain("abortableFetch");
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Adds `src/api/presence.ts` wrappers for global presence heartbeat and online-user fetch.
- Routes `useGlobalPresence` through the shared presence API client instead of raw internal fetches.
- Preserves silent failure behavior for heartbeat and initial presence seeding.
- Adds a wiring test to keep global presence behind `src/api/presence.ts`.

## Testing

- `API_URL=http://localhost:3001 bun test tests/test-presence-api-client-wiring.test.ts tests/test-chat-notification-logic.test.ts tests/test-chat-notification-integration-wiring.test.ts tests/test-chat-hook-channel-lifecycle-wiring.test.ts`
- `bun run build`
- Browser smoke: opened ryOS at `localhost:5173`, launched Chats, and confirmed rooms/messages/input render without runtime errors.

<a href="https://cursor.com/agents/bc-019ea255-b456-75cf-9521-8a31af1d172d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpresence_chats_ui_smoke.mp4"><img src="https://cursor.com/artifacts/c/art-2c83ec3c-e828-460e-b6b0-90255b1d7ca9" alt="presence_chats_ui_smoke.mp4" /></a>

## Stack

- Base branch: `cursor/codebase-simplification-audit-172d`
- This is another Wave 7 follow-up phase PR for internal API client unification.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ea255-b456-75cf-9521-8a31af1d172d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ea255-b456-75cf-9521-8a31af1d172d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

