### PR TITLE
fix(sync): persist songs deletion tombstones server-side (Phase 6a)

### DIFF
--- a/api/_utils/song-library-state.ts
+++ b/api/_utils/song-library-state.ts
@@ -5,12 +5,20 @@ import {
   normalizeCloudSyncVersionState,
   type CloudSyncVersionState,
 } from "../../src/utils/cloudSyncVersion.js";
+import {
+  normalizeDeletionMarkerMap,
+  type DeletionMarkerMap,
+} from "../../src/utils/cloudSyncDeletionMarkers.js";
 import { redisStateMetaKey } from "../sync/_keys.js";
 
 export interface SongsSnapshotData {
   tracks: Track[];
   libraryState: "uninitialized" | "loaded" | "cleared";
   lastKnownVersion: number;
+  // Deletion tombstones (trackId -> ISO timestamp). Persisted so multi-client
+  // conflict merges don't resurrect deleted tracks — matches how every other
+  // Redis-backed sync domain stores its deleted* markers.
+  deletedTrackIds?: DeletionMarkerMap;
 }
 
 export interface SongsStateMetadata {
@@ -24,6 +32,7 @@ interface PersistedSongsLibraryMeta extends SongsStateMetadata {
   trackOrder: string[];
   libraryState: SongsSnapshotData["libraryState"];
   lastKnownVersion: number;
+  deletedTrackIds?: DeletionMarkerMap;
 }
 
 interface PersistedSongsLegacyState extends SongsStateMetadata {
@@ -161,6 +170,8 @@ function normalizeSongsSnapshotData(value: unknown): SongsSnapshotData | null {
     return true;
   });
 
+  const deletedTrackIds = normalizeDeletionMarkerMap(candidate.deletedTrackIds);
+
   return {
     tracks: dedupedTracks,
     libraryState: isLibraryState(candidate.libraryState)
@@ -173,6 +184,7 @@ function normalizeSongsSnapshotData(value: unknown): SongsSnapshotData | null {
       Number.isFinite(candidate.lastKnownVersion)
         ? candidate.lastKnownVersion
         : 0,
+    ...(Object.keys(deletedTrackIds).length > 0 ? { deletedTrackIds } : {}),
   };
 }
 
@@ -246,6 +258,8 @@ async function readStoredSongsState(
     }
   }
 
+  const deletedTrackIds = normalizeDeletionMarkerMap(meta.deletedTrackIds);
+
   return {
     data: {
       tracks: trackOrder.reduce<Track[]>((acc, id) => {
@@ -260,6 +274,7 @@ async function readStoredSongsState(
         typeof meta.lastKnownVersion === "number" && Number.isFinite(meta.lastKnownVersion)
           ? meta.lastKnownVersion
           : 0,
+      ...(Object.keys(deletedTrackIds).length > 0 ? { deletedTrackIds } : {}),
     },
     metadata: normalizeSongsStateMetadata(meta, new Date().toISOString()),
   };
@@ -340,6 +355,30 @@ export async function writeSongsState(
     return acc;
   }, []);
 
+  // Tombstone resolution. Deletion markers (trackId -> ISO timestamp) must
+  // survive the server round-trip so multi-client conflict merges don't
+  // resurrect deleted tracks.
+  // - Full sync snapshots from the client carry `deletedTrackIds` and are
+  //   authoritative (replace) — the client owns the lifecycle and clears a
+  //   marker when a track is re-added.
+  // - Partial server-side writers (e.g. AI tools that add a song) omit the
+  //   field; preserve the existing stored markers so they aren't wiped.
+  // In both cases, a track that is present is by definition not deleted, so
+  // strip its marker (mirrors the client's clear-on-add behavior).
+  const callerProvidedTombstones =
+    data != null &&
+    typeof data === "object" &&
+    (data as SongsSnapshotData).deletedTrackIds != null;
+  const baseDeletedTrackIds = callerProvidedTombstones
+    ? normalizeDeletionMarkerMap((data as SongsSnapshotData).deletedTrackIds)
+    : normalizeDeletionMarkerMap(existingState?.data.deletedTrackIds);
+  const resolvedDeletedTrackIds: DeletionMarkerMap = {};
+  for (const [id, marker] of Object.entries(baseDeletedTrackIds)) {
+    if (!nextTrackIds.has(id)) {
+      resolvedDeletedTrackIds[id] = marker;
+    }
+  }
+
   const pipeline = redis.pipeline();
   for (const track of normalized.tracks) {
     pipeline.set(getSongLibraryTrackKey(username, track.id), JSON.stringify(track));
@@ -353,6 +392,9 @@ export async function writeSongsState(
       trackOrder,
       libraryState: normalized.libraryState,
       lastKnownVersion: normalized.lastKnownVersion,
+      ...(Object.keys(resolvedDeletedTrackIds).length > 0
+        ? { deletedTrackIds: resolvedDeletedTrackIds }
+        : {}),
       ...metadata,
     } satisfies PersistedSongsLibraryMeta)
   );

--- a/tests/test-cloud-sync-domains.test.ts
+++ b/tests/test-cloud-sync-domains.test.ts
@@ -314,6 +314,95 @@ describe("logical cloud sync domain API", () => {
     expect((json.error || "").toLowerCase()).toContain("maps");
   });
 
+  test("PUT/GET /api/sync/domains/songs round-trips deletion tombstones", async () => {
+    const authToken = await getAuthToken();
+
+    const songTrack = (id: string) => ({
+      id,
+      url: `https://www.youtube.com/watch?v=${id}`,
+      title: `Song ${id}`,
+    });
+
+    // Initial upload: A + B, no tombstones.
+    const firstPut = await fetchWithAuth(
+      `${BASE_URL}/api/sync/domains/songs`,
+      TEST_USERNAME,
+      authToken,
+      {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          writes: {
+            songs: {
+              domain: "songs",
+              updatedAt: "2026-05-01T10:00:00.000Z",
+              version: 1,
+              syncVersion: makeSyncVersion("songs-client", 1),
+              data: {
+                tracks: [songTrack("A"), songTrack("B")],
+                libraryState: "loaded",
+                lastKnownVersion: 1,
+                deletedTrackIds: {},
+              },
+            },
+          },
+        }),
+      }
+    );
+    expect(firstPut.status).toBe(200);
+    const firstPutJson = await firstPut.json();
+    const baseServerVersion: number =
+      firstPutJson.writes?.songs?.metadata?.syncVersion?.serverVersion ??
+      firstPutJson.metadata?.syncVersion?.serverVersion ??
+      null;
+
+    // Delete B: upload tracks=[A] with a tombstone for B, chained off the
+    // server version returned by the first write so it fast-forwards.
+    const deletedAt = "2026-05-01T10:05:00.000Z";
+    const secondPut = await fetchWithAuth(
+      `${BASE_URL}/api/sync/domains/songs`,
+      TEST_USERNAME,
+      authToken,
+      {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          writes: {
+            songs: {
+              domain: "songs",
+              updatedAt: deletedAt,
+              version: 1,
+              syncVersion: makeSyncVersion("songs-client", 2, baseServerVersion),
+              data: {
+                tracks: [songTrack("A")],
+                libraryState: "loaded",
+                lastKnownVersion: 2,
+                deletedTrackIds: { B: deletedAt },
+              },
+            },
+          },
+        }),
+      }
+    );
+    expect(secondPut.status).toBe(200);
+
+    // A fresh client download must see the tombstone for B so it cannot
+    // resurrect the deleted track during a conflict merge.
+    const getRes = await fetchWithAuth(
+      `${BASE_URL}/api/sync/domains/songs`,
+      TEST_USERNAME,
+      authToken
+    );
+    expect(getRes.status).toBe(200);
+    const getJson = await getRes.json();
+    expect(getJson.ok).toBe(true);
+    expect(getJson.domain).toBe("songs");
+    expect(getJson.parts.songs.data.tracks.map((t: { id: string }) => t.id)).toEqual([
+      "A",
+    ]);
+    expect(getJson.parts.songs.data.deletedTrackIds?.B).toBe(deletedAt);
+  });
+
   test("POST /api/sync/domains/files/attachments/prepare accepts custom wallpapers only under files", async () => {
     const authToken = await getAuthToken();
 

--- a/tests/test-songs-tombstone-sync.test.ts
+++ b/tests/test-songs-tombstone-sync.test.ts
@@ -1,0 +1,120 @@
+import { afterAll, describe, expect, test } from "bun:test";
+import { createRedis } from "../api/_utils/redis";
+import {
+  writeSongsState,
+  readSongsState,
+  getSongLibraryMetaKey,
+  getSongLibraryTrackKey,
+  type SongsSnapshotData,
+} from "../api/_utils/song-library-state";
+
+/**
+ * Server-side round-trip tests for songs sync deletion tombstones.
+ *
+ * Regression: writeSongsState used to drop `deletedTrackIds`, so a deleted
+ * track could resurrect during a multi-client conflict merge (the client
+ * downloaded a snapshot with no tombstones and re-added the track).
+ *
+ * Requires a live Redis (REDIS_KV_REST_API_URL / _TOKEN in env).
+ */
+
+const redis = createRedis();
+const username = `tombstone-test-${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+
+function track(id: string) {
+  return {
+    id,
+    url: `https://www.youtube.com/watch?v=${id}`,
+    title: `Song ${id}`,
+  };
+}
+
+async function cleanup() {
+  const keys = [
+    getSongLibraryMetaKey(username),
+    getSongLibraryTrackKey(username, "A"),
+    getSongLibraryTrackKey(username, "B"),
+    getSongLibraryTrackKey(username, "C"),
+  ];
+  await redis.del(...(keys as [string, ...string[]]));
+}
+
+afterAll(async () => {
+  await cleanup();
+});
+
+describe("songs sync deletion tombstones (server round-trip)", () => {
+  test("a deleted track's tombstone survives the server round-trip", async () => {
+    // Initial library: A + B, no tombstones.
+    await writeSongsState(redis, username, {
+      tracks: [track("A"), track("B")],
+      libraryState: "loaded",
+      lastKnownVersion: 1,
+      deletedTrackIds: {},
+    });
+
+    // Client deletes B: uploads tracks=[A] with a tombstone for B.
+    const ts = new Date().toISOString();
+    await writeSongsState(redis, username, {
+      tracks: [track("A")],
+      libraryState: "loaded",
+      lastKnownVersion: 2,
+      deletedTrackIds: { B: ts },
+    });
+
+    const read = await readSongsState(redis, username);
+    expect(read).not.toBeNull();
+    const data = read!.data as SongsSnapshotData;
+    expect(data.tracks.map((t) => t.id)).toEqual(["A"]);
+    // The fix: the tombstone is echoed back so a stale client cannot resurrect B.
+    expect(data.deletedTrackIds?.B).toBe(ts);
+  });
+
+  test("partial server-side writers (AI tools) preserve existing tombstones", async () => {
+    // Continue from previous state (tombstone for B exists). Simulate the AI
+    // "add song" tool, which calls writeSongsState WITHOUT deletedTrackIds.
+    await writeSongsState(redis, username, {
+      tracks: [track("A"), track("C")],
+      libraryState: "loaded",
+      lastKnownVersion: 3,
+    } as SongsSnapshotData);
+
+    const read = await readSongsState(redis, username);
+    const data = read!.data as SongsSnapshotData;
+    expect(data.tracks.map((t) => t.id).sort()).toEqual(["A", "C"]);
+    // B's tombstone must NOT be wiped by a partial write.
+    expect(data.deletedTrackIds?.B).toBeTruthy();
+  });
+
+  test("re-adding a track clears its tombstone (present track is not deleted)", async () => {
+    // Client re-adds B and (per useAutoCloudSync) clears its tombstone:
+    // uploads tracks=[A,B,C] with an explicit deletedTrackIds that omits B.
+    await writeSongsState(redis, username, {
+      tracks: [track("A"), track("B"), track("C")],
+      libraryState: "loaded",
+      lastKnownVersion: 4,
+      deletedTrackIds: {},
+    });
+
+    const read = await readSongsState(redis, username);
+    const data = read!.data as SongsSnapshotData;
+    expect(data.tracks.map((t) => t.id).sort()).toEqual(["A", "B", "C"]);
+    expect(data.deletedTrackIds?.B).toBeUndefined();
+  });
+
+  test("a present track in the snapshot strips a stale tombstone for the same id", async () => {
+    // Defensive: even if a snapshot lists B as both present AND tombstoned,
+    // the present track wins (mirrors the client's clear-on-add).
+    await writeSongsState(redis, username, {
+      tracks: [track("A"), track("B")],
+      libraryState: "loaded",
+      lastKnownVersion: 5,
+      deletedTrackIds: { B: new Date().toISOString() },
+    });
+
+    const read = await readSongsState(redis, username);
+    const data = read!.data as SongsSnapshotData;
+    expect(data.tracks.map((t) => t.id).sort()).toEqual(["A", "B"]);
+    expect(data.deletedTrackIds?.B).toBeUndefined();
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes a **data-loss-class bug** flagged in the duplication/complexity audit: deleted songs could **resurrect** after a multi-client sync.

`api/_utils/song-library-state.ts` `writeSongsState` dropped the client's `deletedTrackIds`, and `readSongsState` never returned them. Every other Redis-backed sync domain (tv/stickies/calendar/contacts/maps/files) persists its `deleted*` markers via the generic blob path — songs was the lone exception because it uses a special per-track Redis storage. As a result, in the conflict-merge path a stale client would download a songs snapshot **without tombstones**, and its client-side merge (`mergeSongsSnapshots`) would re-add the deleted track and re-upload it.

### Fix
- `SongsSnapshotData` and the persisted songs meta now carry `deletedTrackIds` (`Record<trackId, ISO timestamp>`).
- `readSongsState` echoes `deletedTrackIds` back to clients.
- `writeSongsState` resolves tombstones robustly across all callers:
  - **Full client snapshots** (sync path) are authoritative → replace. This is correct because the client owns the lifecycle and clears a marker when a track is re-added (`useAutoCloudSync` → `clearDeletedKeys("songTrackIds", addedIds)`).
  - **Partial server-side writers** (AI tools that omit the field) → preserve existing markers so they aren't wiped.
  - A track that is **present** in the snapshot always strips its own marker (mirrors the client's clear-on-add), so re-adding a song un-deletes it.

This brings songs in line with how all other sync domains already behave.

## Testing

Server-side data correctness, so the appropriate evidence is integration tests against **live Redis** and the **real HTTP endpoint** (tombstone state is internal and wouldn't show in a browser screenshot).

- ✅ New `tests/test-songs-tombstone-sync.test.ts` — direct `writeSongsState`/`readSongsState` round-trip against live Redis: tombstone survives, partial writers preserve it, re-add clears it, present-track strips a stale marker (4 cases).
- ✅ Extended `tests/test-cloud-sync-domains.test.ts` — end-to-end `PUT`→`PUT (delete)`→`GET /api/sync/domains/songs` with proper version chaining; the GET returns `tracks: ["A"]` **and** `deletedTrackIds.B`. (8/8 pass.)
- ✅ Related suites unaffected: `test-cloud-sync-song-order`, `test-chat-tools-songs` (AI add path), `test-song`, `test-song-import-batching` (47/47).
- ✅ `bun run build`; `bun run test:unit` 199 pass (1 pre-existing env failure in `test-ipod-apple-music`, unrelated).

The new test would fail on `main` (pre-fix, `deletedTrackIds` is never returned), so it guards the regression.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ea255-d89a-7aee-a66a-5133bbe7db1f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ea255-d89a-7aee-a66a-5133bbe7db1f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

