### PR TITLE
refactor: route stocks widget through api client

### DIFF
--- a/src/api/stocks.ts
+++ b/src/api/stocks.ts
@@ -1,0 +1,37 @@
+import { apiRequest } from "@/api/core";
+
+export interface StockApiQuote {
+  symbol: string;
+  price: number;
+  change: number;
+  changePercent: number;
+  name: string;
+}
+
+export interface StockApiChartPoint {
+  timestamp: number;
+  close: number;
+}
+
+export interface StocksApiResponse {
+  quotes: StockApiQuote[];
+  chart?: StockApiChartPoint[];
+}
+
+export async function getStocks(params: {
+  symbols: string[];
+  chart?: string;
+  range?: string;
+}): Promise<StocksApiResponse> {
+  return apiRequest<StocksApiResponse>({
+    path: "/api/stocks",
+    method: "GET",
+    query: {
+      symbols: params.symbols.join(","),
+      chart: params.chart,
+      range: params.range,
+    },
+    timeout: 15000,
+    retry: { maxAttempts: 1, initialDelayMs: 250 },
+  });
+}

--- a/src/components/layout/dashboard/stocks-widget/api.ts
+++ b/src/components/layout/dashboard/stocks-widget/api.ts
@@ -1,3 +1,4 @@
+import { getStocks } from "@/api/stocks";
 import { RANGE_TO_API, type TimeRange } from "./constants";
 import type { ApiChartPoint, ApiQuote, StockQuote } from "./types";
 
@@ -11,9 +12,7 @@ export async function fetchQuotes(symbols: string[]): Promise<StockQuote[]> {
   const cached = quotesCache.get(key);
   if (cached && Date.now() - cached.ts < CACHE_TTL_QUOTES) return cached.quotes;
 
-  const res = await fetch(`/api/stocks?symbols=${encodeURIComponent(key)}`);
-  if (!res.ok) throw new Error(`API ${res.status}`);
-  const data = await res.json();
+  const data = await getStocks({ symbols });
   const quotes: StockQuote[] = (data.quotes as ApiQuote[]).map((q) => ({
     symbol: q.symbol,
     price: q.price,
@@ -32,11 +31,11 @@ export async function fetchChart(
   if (cached && Date.now() - cached.ts < CACHE_TTL_CHART) return cached;
 
   const apiRange = RANGE_TO_API[range];
-  const res = await fetch(
-    `/api/stocks?symbols=${encodeURIComponent(symbol)}&chart=${encodeURIComponent(symbol)}&range=${apiRange}`
-  );
-  if (!res.ok) throw new Error(`API ${res.status}`);
-  const data = await res.json();
+  const data = await getStocks({
+    symbols: [symbol],
+    chart: symbol,
+    range: apiRange,
+  });
   const points = (data.chart ?? []) as ApiChartPoint[];
   const result = {
     history: points.map((p) => p.close),

--- a/tests/test-stocks-api-client-wiring.test.ts
+++ b/tests/test-stocks-api-client-wiring.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+
+describe("stocks API client wiring", () => {
+  test("dashboard stocks widget uses src/api/stocks", () => {
+    const source = readFileSync(
+      "src/components/layout/dashboard/stocks-widget/api.ts",
+      "utf8"
+    );
+
+    expect(source).toContain("@/api/stocks");
+    expect(source).toContain("getStocks");
+    expect(source).not.toContain("fetch(");
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Adds `src/api/stocks.ts` wrapper for the stocks endpoint.
- Routes the dashboard stocks widget helper through the shared stocks API client instead of raw internal `fetch` calls.
- Preserves widget-level quote/chart caches and mapping behavior.
- Adds a wiring test to keep the dashboard helper behind `src/api/stocks.ts`.

## Testing

- `API_URL=http://localhost:3001 bun test tests/test-stocks-api-client-wiring.test.ts`
- `bun run build`
- Browser smoke: opened ryOS at `localhost:5173`, launched Dashboard, and confirmed the dashboard renders without runtime errors.

<a href="https://cursor.com/agents/bc-019ea255-b456-75cf-9521-8a31af1d172d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fstocks_dashboard_ui_smoke.mp4"><img src="https://cursor.com/artifacts/c/art-e9b1683b-7380-4824-999b-462e8eb12bc2" alt="stocks_dashboard_ui_smoke.mp4" /></a>

## Notes

- The stocks widget was not visible in the current dashboard configuration during the smoke, but the dashboard surface rendered cleanly.

## Stack

- Base branch: `cursor/codebase-simplification-audit-172d`
- This is another Wave 7 follow-up phase PR for internal API client unification.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ea255-b456-75cf-9521-8a31af1d172d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ea255-b456-75cf-9521-8a31af1d172d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

