### PR TITLE
refactor(vfs): unify file-content StoredContent type (Phase 4c / Wave 6)

### DIFF
--- a/src/apps/finder/hooks/useFileSystem.ts
+++ b/src/apps/finder/hooks/useFileSystem.ts
@@ -20,7 +20,7 @@ import {
 } from "@/stores/helpers";
 import { formatKugouImageUrl } from "@/utils/coverArt";
 import { abortableFetch } from "@/utils/abortableFetch";
-import { getStoreForFile } from "@/utils/indexedDBOperations";
+import { getStoreForFile, type StoredContent } from "@/utils/indexedDBOperations";
 import {
   emitCloudSyncDomainChange,
   emitCloudSyncDomainChanges,
@@ -32,10 +32,9 @@ import {
 import { useThemeFlags } from "@/hooks/useThemeFlags";
 import { FINDER_ANALYTICS, track } from "@/utils/analytics";
 
-// Interface for content stored in IndexedDB
-export interface DocumentContent {
-  name: string; // Used as the key in IndexedDB
-  content: string | Blob;
+// Interface for content stored in IndexedDB. The persisted shape is the shared
+// StoredContent ({ name, content }); contentUrl is a runtime-only Blob URL.
+export interface DocumentContent extends StoredContent {
   contentUrl?: string; // URL for Blob content (managed temporarily)
 }
 

--- a/src/stores/useFilesStore.ts
+++ b/src/stores/useFilesStore.ts
@@ -2,6 +2,7 @@ import { create } from "zustand";
 import { persist, createJSONStorage } from "zustand/middleware";
 import { v4 as uuidv4 } from "uuid";
 import { ensureIndexedDBInitialized, STORES } from "@/utils/indexedDB";
+import type { StoredContent } from "@/utils/indexedDBOperations";
 import type { OsThemeId } from "@/themes/types";
 import { getAppBasicInfoList } from "@/config/appRegistryData";
 import { abortableFetch } from "@/utils/abortableFetch";
@@ -46,11 +47,6 @@ interface FileSystemItemData extends Omit<FileSystemItem, "status"> {
   assetPath?: string; // For images
 }
 
-// Structure for content stored in IndexedDB
-interface StoredContent {
-  name: string;
-  content: string | Blob;
-}
 
 // Define the JSON structure
 interface FileSystemData {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Small, type-only consolidation toward the Wave 6 "one IndexedDB API" goal. The `StoredContent` record type (`{ name, content }`) was defined **identically** in two places — exported from `src/utils/indexedDBOperations.ts` and re-declared privately in `src/stores/useFilesStore.ts` — and `DocumentContent` in `useFileSystem.ts` re-stated the same two fields plus a runtime-only `contentUrl`.

- `useFilesStore.ts` now imports the shared `StoredContent` instead of its private duplicate.
- `DocumentContent` now `extends StoredContent` (adds the runtime-only `contentUrl`), so its exported shape is unchanged.
- `indexedDBOperations.ts` remains the single source for the persisted-record type.

No runtime behavior changes — this only removes a duplicate type definition.

I intentionally did **not** fold the `indexedDBOperations` content helpers into `dbOperations` in this PR: the batch helpers rely on a single transaction (atomicity) that the per-op `dbOperations` can't preserve, and `loadFileContent`/`contentExists` have different error semantics — so that step is deferred to avoid behavior changes.

## Testing

- ✅ `bun run build` (Vite + `tsc -b`, strict).
- ✅ `bun run test:unit` — 199 pass (1 pre-existing env failure, unrelated).
- ✅ **Playwright (clean Chromium):** TextEdit File ▸ Save → reload → the document persists in the `documents` IndexedDB store (`PERSISTED=true`), confirming the file-content path is unaffected.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ea255-d89a-7aee-a66a-5133bbe7db1f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ea255-d89a-7aee-a66a-5133bbe7db1f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

