### PR TITLE
refactor(ie): extract url-bar reducer from useInternetExplorerLogic (Phase 5c)

### DIFF
--- a/src/apps/internet-explorer/hooks/useInternetExplorerLogic.ts
+++ b/src/apps/internet-explorer/hooks/useInternetExplorerLogic.ts
@@ -42,78 +42,16 @@ import {
   decodeData,
   normalizeUrlForHistory,
 } from "../utils/urlHelpers";
+import {
+  SuggestionItem,
+  urlBarUiReducer,
+  urlBarUiInitialState,
+} from "../utils/urlBarUiReducer";
 
 // Debug helper to identify direct passthrough URLs
 const logDirectPassthrough = (url: string) => {
   console.log(`[IE] Direct passthrough mode for: ${url}`);
 };
-
-// Define suggestion type to reuse
-type SuggestionItem = {
-  title: string;
-  url: string;
-  type: "favorite" | "history" | "search";
-  year?: string;
-  favicon?: string;
-  normalizedUrl?: string; // Optional prop for internal use
-};
-
-interface UrlBarUiState {
-  isUrlDropdownOpen: boolean;
-  filteredSuggestions: SuggestionItem[];
-  localUrl: string;
-  isSelectingText: boolean;
-  selectedSuggestionIndex: number;
-  dropdownStyle: CSSProperties;
-}
-
-const urlBarUiInitialState: UrlBarUiState = {
-  isUrlDropdownOpen: false,
-  filteredSuggestions: [],
-  localUrl: "",
-  isSelectingText: false,
-  selectedSuggestionIndex: 0,
-  dropdownStyle: {},
-};
-
-type UrlBarUiAction =
-  | { type: "setIsUrlDropdownOpen"; value: boolean }
-  | { type: "setFilteredSuggestions"; value: SuggestionItem[] }
-  | { type: "setLocalUrl"; value: string }
-  | { type: "setIsSelectingText"; value: boolean }
-  | { type: "setSelectedSuggestionIndex"; value: number }
-  | {
-      type: "setDropdownStyle";
-      value: CSSProperties | ((prev: CSSProperties) => CSSProperties);
-    };
-
-function urlBarUiReducer(
-  state: UrlBarUiState,
-  action: UrlBarUiAction
-): UrlBarUiState {
-  switch (action.type) {
-    case "setIsUrlDropdownOpen":
-      return { ...state, isUrlDropdownOpen: action.value };
-    case "setFilteredSuggestions":
-      return { ...state, filteredSuggestions: action.value };
-    case "setLocalUrl":
-      return { ...state, localUrl: action.value };
-    case "setIsSelectingText":
-      return { ...state, isSelectingText: action.value };
-    case "setSelectedSuggestionIndex":
-      return { ...state, selectedSuggestionIndex: action.value };
-    case "setDropdownStyle":
-      return {
-        ...state,
-        dropdownStyle:
-          typeof action.value === "function"
-            ? action.value(state.dropdownStyle)
-            : action.value,
-      };
-    default:
-      return state;
-  }
-}
 
 interface UseInternetExplorerLogicProps {
   isWindowOpen: boolean;

--- a/src/apps/internet-explorer/utils/urlBarUiReducer.ts
+++ b/src/apps/internet-explorer/utils/urlBarUiReducer.ts
@@ -1,0 +1,68 @@
+import { CSSProperties } from "react";
+
+// Define suggestion type to reuse
+export type SuggestionItem = {
+  title: string;
+  url: string;
+  type: "favorite" | "history" | "search";
+  year?: string;
+  favicon?: string;
+  normalizedUrl?: string; // Optional prop for internal use
+};
+
+export interface UrlBarUiState {
+  isUrlDropdownOpen: boolean;
+  filteredSuggestions: SuggestionItem[];
+  localUrl: string;
+  isSelectingText: boolean;
+  selectedSuggestionIndex: number;
+  dropdownStyle: CSSProperties;
+}
+
+export const urlBarUiInitialState: UrlBarUiState = {
+  isUrlDropdownOpen: false,
+  filteredSuggestions: [],
+  localUrl: "",
+  isSelectingText: false,
+  selectedSuggestionIndex: 0,
+  dropdownStyle: {},
+};
+
+export type UrlBarUiAction =
+  | { type: "setIsUrlDropdownOpen"; value: boolean }
+  | { type: "setFilteredSuggestions"; value: SuggestionItem[] }
+  | { type: "setLocalUrl"; value: string }
+  | { type: "setIsSelectingText"; value: boolean }
+  | { type: "setSelectedSuggestionIndex"; value: number }
+  | {
+      type: "setDropdownStyle";
+      value: CSSProperties | ((prev: CSSProperties) => CSSProperties);
+    };
+
+export function urlBarUiReducer(
+  state: UrlBarUiState,
+  action: UrlBarUiAction
+): UrlBarUiState {
+  switch (action.type) {
+    case "setIsUrlDropdownOpen":
+      return { ...state, isUrlDropdownOpen: action.value };
+    case "setFilteredSuggestions":
+      return { ...state, filteredSuggestions: action.value };
+    case "setLocalUrl":
+      return { ...state, localUrl: action.value };
+    case "setIsSelectingText":
+      return { ...state, isSelectingText: action.value };
+    case "setSelectedSuggestionIndex":
+      return { ...state, selectedSuggestionIndex: action.value };
+    case "setDropdownStyle":
+      return {
+        ...state,
+        dropdownStyle:
+          typeof action.value === "function"
+            ? action.value(state.dropdownStyle)
+            : action.value,
+      };
+    default:
+      return state;
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Continues the IE god-hook slimming (Phase 5). Moves the pure URL-bar UI reducer and its types out of `src/apps/internet-explorer/hooks/useInternetExplorerLogic.ts` into a new sibling module `src/apps/internet-explorer/utils/urlBarUiReducer.ts`:

- `SuggestionItem`, `UrlBarUiState`, `UrlBarUiAction` (types)
- `urlBarUiInitialState`, `urlBarUiReducer`

The hook keeps using `useReducer(urlBarUiReducer, urlBarUiInitialState)` — only the implementation moved and is re-imported. No public return-type changes, no behavior change. (No other files imported these symbols.)

## Testing

- ✅ `bun run build` (Vite + `tsc -b`, strict incl. `noUnusedLocals`).
- ✅ **Playwright (clean Chromium):** opened Internet Explorer, typed `appl` into the address bar → the reducer-driven **suggestion dropdown** rendered ("Apple (2001) — Favorite" + "Search …"), and typing a full URL + Enter navigated (`NAV_VALUE_OK`). This directly exercises `urlBarUiReducer` / `filteredSuggestions` state.

![IE address bar showing reducer-driven autocomplete suggestions for ](https://cursor.com/artifacts/c/art-70a29e24-3c49-4b59-a985-e736a355d706)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ea255-d89a-7aee-a66a-5133bbe7db1f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ea255-d89a-7aee-a66a-5133bbe7db1f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

