### PR TITLE
refactor(finder): extract pure helpers from useFileSystem (Phase 5b)

### DIFF
--- a/src/apps/finder/hooks/useFileSystem.ts
+++ b/src/apps/finder/hooks/useFileSystem.ts
@@ -1,5 +1,4 @@
 import { useState, useEffect, useCallback, useRef } from "react";
-import { FileItem as DisplayFileItem } from "../components/FileList";
 import { ensureIndexedDBInitialized, STORES, dbOperations } from "@/utils/indexedDB";
 import { getNonFinderApps, AppId, getAppIconPath } from "@/config/appRegistry";
 import { useIsRyoAdmin } from "@/hooks/useIsRyoAdmin";
@@ -25,55 +24,28 @@ import {
   emitCloudSyncDomainChange,
   emitCloudSyncDomainChanges,
 } from "@/utils/cloudSyncEvents";
-import {
-  useCloudSyncStore,
-  type CloudSyncDeletionBucket,
-} from "@/stores/useCloudSyncStore";
+import { useCloudSyncStore } from "@/stores/useCloudSyncStore";
 import { useThemeFlags } from "@/hooks/useThemeFlags";
 import { FINDER_ANALYTICS, track } from "@/utils/analytics";
+import {
+  ExtendedDisplayFileItem,
+  getParentPath,
+  getFinderAnalyticsPathInfo,
+  getFinderSizeBucket,
+  arePathArraysEqual,
+  DEFAULT_FILE_PATHS,
+  getCloudSyncDomainForContentStore,
+  getCloudSyncDeletionBucketForContentStore,
+  getFileTypeFromExtension,
+  UUID_MIGRATION_KEY,
+  isUUIDMigrationDone,
+} from "../utils/fileSystemHelpers";
 
 // Interface for content stored in IndexedDB. The persisted shape is the shared
 // StoredContent ({ name, content }); contentUrl is a runtime-only Blob URL.
 export interface DocumentContent extends StoredContent {
   contentUrl?: string; // URL for Blob content (managed temporarily)
 }
-
-// Type for items displayed in the UI (might include contentUrl)
-interface ExtendedDisplayFileItem extends Omit<DisplayFileItem, "content"> {
-  content?: string | Blob; // Keep content for passing to apps
-  contentUrl?: string;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  data?: any; // Add optional data field for virtual files
-  originalPath?: string; // For trash items
-  deletedAt?: number; // For trash items
-  status?: "active" | "trashed"; // Include status for potential UI differences
-}
-
-const getParentPath = (path: string): string => {
-  if (path === "/") return "/";
-  const parts = path.split("/").filter(Boolean);
-  if (parts.length <= 1) return "/";
-  return `/${parts.slice(0, -1).join("/")}`;
-};
-
-const getFinderAnalyticsPathInfo = (path: string, type?: string) => {
-  const parts = path.split("/").filter(Boolean);
-  const fileName = parts[parts.length - 1] || "";
-  const extMatch = fileName.match(/\.([a-z0-9]+)$/i);
-  return {
-    topLevel: parts[0] || "root",
-    fileType: type || extMatch?.[1]?.toLowerCase() || "unknown",
-    isRoot: parts.length === 0,
-  };
-};
-
-const getFinderSizeBucket = (sizeBytes: number): string => {
-  if (sizeBytes <= 0) return "empty";
-  if (sizeBytes < 10 * 1024) return "<10kb";
-  if (sizeBytes < 100 * 1024) return "10-100kb";
-  if (sizeBytes < 1024 * 1024) return "100kb-1mb";
-  return "1mb+";
-};
 
 const trackFinderFileOperation = (
   eventName: string,
@@ -86,48 +58,6 @@ const trackFinderFileOperation = (
     ...getFinderAnalyticsPathInfo(path, type),
     ...extra,
   });
-};
-
-const arePathArraysEqual = (first: readonly string[], second: readonly string[]) =>
-  first.length === second.length &&
-  first.every((path, index) => path === second[index]);
-const DEFAULT_FILE_PATHS = new Set([
-  "/Documents/README.md",
-  "/Documents/Quick Tips.md",
-  "/Images/steve-jobs.png",
-  "/Images/susan-kare.png",
-]);
-
-const getCloudSyncDomainForContentStore = (
-  storeName: string
-): "files-metadata" | "files-images" | "files-trash" | "files-applets" | null => {
-  switch (storeName) {
-    case STORES.DOCUMENTS:
-      return "files-metadata";
-    case STORES.IMAGES:
-      return "files-images";
-    case STORES.TRASH:
-      return "files-trash";
-    case STORES.APPLETS:
-      return "files-applets";
-    default:
-      return null;
-  }
-};
-
-const getCloudSyncDeletionBucketForContentStore = (
-  storeName: string
-): CloudSyncDeletionBucket | null => {
-  switch (storeName) {
-    case STORES.IMAGES:
-      return "fileImageKeys";
-    case STORES.TRASH:
-      return "fileTrashKeys";
-    case STORES.APPLETS:
-      return "fileAppletKeys";
-    default:
-      return null;
-  }
 };
 
 const getIndexedDbStoreKeys = async (storeName: string): Promise<string[]> => {
@@ -146,35 +76,6 @@ const getIndexedDbStoreKeys = async (storeName: string): Promise<string[]> => {
 };
 
 // --- Helper Functions --- //
-
-// Get specific type from extension
-function getFileTypeFromExtension(fileName: string): string {
-  const ext = fileName.split(".").pop()?.toLowerCase() || "unknown";
-  switch (ext) {
-    case "app":
-      return "application";
-    case "md":
-      return "markdown";
-    case "txt":
-      return "text";
-    case "png":
-      return ext;
-    case "jpg":
-    case "jpeg":
-      return "jpg"; // Standardize to jpg for jpeg/jpg files
-    case "gif":
-      return ext;
-    case "webp":
-      return ext;
-    case "bmp":
-      return ext;
-    case "html":
-    case "htm":
-      return "html";
-    default:
-      return "unknown";
-  }
-}
 
 // Get icon based on FileSystemItem metadata
 function getFileIcon(item: FileSystemItem): string {
@@ -241,14 +142,6 @@ function getFileIcon(item: FileSystemItem): string {
       return "/icons/file.png";
   }
 }
-
-// --- Global flags for cross-instance coordination --- //
-// Use localStorage to persist initialization state across page refreshes
-const UUID_MIGRATION_KEY = "ryos:indexeddb-uuid-migration-v1";
-
-// Check localStorage for completion status
-const isUUIDMigrationDone = () =>
-  localStorage.getItem(UUID_MIGRATION_KEY) === "completed";
 
 const loggedInitializationPaths = new Set<string>();
 

--- a/src/apps/finder/utils/fileSystemHelpers.ts
+++ b/src/apps/finder/utils/fileSystemHelpers.ts
@@ -1,0 +1,126 @@
+import { FileItem as DisplayFileItem } from "../components/FileList";
+import { STORES } from "@/utils/indexedDB";
+import { type CloudSyncDeletionBucket } from "@/stores/useCloudSyncStore";
+
+// Type for items displayed in the UI (might include contentUrl)
+export interface ExtendedDisplayFileItem
+  extends Omit<DisplayFileItem, "content"> {
+  content?: string | Blob; // Keep content for passing to apps
+  contentUrl?: string;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  data?: any; // Add optional data field for virtual files
+  originalPath?: string; // For trash items
+  deletedAt?: number; // For trash items
+  status?: "active" | "trashed"; // Include status for potential UI differences
+}
+
+export const getParentPath = (path: string): string => {
+  if (path === "/") return "/";
+  const parts = path.split("/").filter(Boolean);
+  if (parts.length <= 1) return "/";
+  return `/${parts.slice(0, -1).join("/")}`;
+};
+
+export const getFinderAnalyticsPathInfo = (path: string, type?: string) => {
+  const parts = path.split("/").filter(Boolean);
+  const fileName = parts[parts.length - 1] || "";
+  const extMatch = fileName.match(/\.([a-z0-9]+)$/i);
+  return {
+    topLevel: parts[0] || "root",
+    fileType: type || extMatch?.[1]?.toLowerCase() || "unknown",
+    isRoot: parts.length === 0,
+  };
+};
+
+export const getFinderSizeBucket = (sizeBytes: number): string => {
+  if (sizeBytes <= 0) return "empty";
+  if (sizeBytes < 10 * 1024) return "<10kb";
+  if (sizeBytes < 100 * 1024) return "10-100kb";
+  if (sizeBytes < 1024 * 1024) return "100kb-1mb";
+  return "1mb+";
+};
+
+export const arePathArraysEqual = (
+  first: readonly string[],
+  second: readonly string[]
+) =>
+  first.length === second.length &&
+  first.every((path, index) => path === second[index]);
+
+export const DEFAULT_FILE_PATHS = new Set([
+  "/Documents/README.md",
+  "/Documents/Quick Tips.md",
+  "/Images/steve-jobs.png",
+  "/Images/susan-kare.png",
+]);
+
+export const getCloudSyncDomainForContentStore = (
+  storeName: string
+): "files-metadata" | "files-images" | "files-trash" | "files-applets" | null => {
+  switch (storeName) {
+    case STORES.DOCUMENTS:
+      return "files-metadata";
+    case STORES.IMAGES:
+      return "files-images";
+    case STORES.TRASH:
+      return "files-trash";
+    case STORES.APPLETS:
+      return "files-applets";
+    default:
+      return null;
+  }
+};
+
+export const getCloudSyncDeletionBucketForContentStore = (
+  storeName: string
+): CloudSyncDeletionBucket | null => {
+  switch (storeName) {
+    case STORES.IMAGES:
+      return "fileImageKeys";
+    case STORES.TRASH:
+      return "fileTrashKeys";
+    case STORES.APPLETS:
+      return "fileAppletKeys";
+    default:
+      return null;
+  }
+};
+
+// --- Helper Functions --- //
+
+// Get specific type from extension
+export function getFileTypeFromExtension(fileName: string): string {
+  const ext = fileName.split(".").pop()?.toLowerCase() || "unknown";
+  switch (ext) {
+    case "app":
+      return "application";
+    case "md":
+      return "markdown";
+    case "txt":
+      return "text";
+    case "png":
+      return ext;
+    case "jpg":
+    case "jpeg":
+      return "jpg"; // Standardize to jpg for jpeg/jpg files
+    case "gif":
+      return ext;
+    case "webp":
+      return ext;
+    case "bmp":
+      return ext;
+    case "html":
+    case "htm":
+      return "html";
+    default:
+      return "unknown";
+  }
+}
+
+// --- Global flags for cross-instance coordination --- //
+// Use localStorage to persist initialization state across page refreshes
+export const UUID_MIGRATION_KEY = "ryos:indexeddb-uuid-migration-v1";
+
+// Check localStorage for completion status
+export const isUUIDMigrationDone = () =>
+  localStorage.getItem(UUID_MIGRATION_KEY) === "completed";


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Continues the Finder god-hook slimming (Phase 5). Moves pure, module-level helpers out of `src/apps/finder/hooks/useFileSystem.ts` into a new sibling module `src/apps/finder/utils/fileSystemHelpers.ts` and re-imports them. No public hook return-type changes, no behavior change — only pure code relocated.

Moved (and exported): `getParentPath`, `getFinderAnalyticsPathInfo`, `getFinderSizeBucket`, `arePathArraysEqual`, `DEFAULT_FILE_PATHS`, `getCloudSyncDomainForContentStore`, `getCloudSyncDeletionBucketForContentStore`, `getFileTypeFromExtension`, `UUID_MIGRATION_KEY`, `isUUIDMigrationDone`, and the `ExtendedDisplayFileItem` interface.

Left in the hook (not pure): `getFileIcon` (reads the files store), `getIndexedDbStoreKeys` (async IndexedDB), `trackFinderFileOperation` (analytics — now imports `getFinderAnalyticsPathInfo` from the new module). Removed the now-unused `DisplayFileItem`/`CloudSyncDeletionBucket` imports from the hook to satisfy `noUnusedLocals`. `useFinderLogic.ts` needed no changes.

`useFileSystem.ts` shrinks by ~120 lines.

## Testing

- ✅ `bun run build` (Vite + `tsc -b`, strict).
- ✅ **Playwright (clean Chromium):** opened Finder → Documents lists `README.md` / `Quick Tips.md` with correct **Type** ("Document", from the moved `getFileTypeFromExtension`) and **Size** columns; and a TextEdit File ▸ Save → reload persisted the document (exercises `saveFile`'s moved `getCloudSyncDomainForContentStore`). No page errors.

![Finder Documents list rendering file Type/Size from extracted helpers](https://cursor.com/artifacts/c/art-c2d5dacb-12ab-4d60-9c44-df1159f81b2b)

This PR and #1427 (IE url-bar reducer) were implemented in parallel on independent files; both are behavior-neutral pure-helper extractions.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ea255-d89a-7aee-a66a-5133bbe7db1f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ea255-d89a-7aee-a66a-5133bbe7db1f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

