### PR TITLE
Make Admin window surface match Finder

### DIFF
--- a/src/apps/admin/utils/adminStyles.ts
+++ b/src/apps/admin/utils/adminStyles.ts
@@ -1,10 +1,10 @@
 import { cn } from "@/lib/utils";
 
-/** Main content pane — tracks `--os-color-window-bg` in light and dark. */
-export const adminSurfaceClass = "bg-os-window-bg text-os-text-primary";
+/** Main content pane — mirrors Finder's white pane surface and dark remap. */
+export const adminSurfaceClass = "bg-white/90 text-os-text-primary";
 
 /** Recessed sidebar / secondary panel surface. */
-export const adminSidebarClass = "bg-os-panel-bg text-os-text-primary";
+export const adminSidebarClass = "bg-white/90 text-os-text-primary";
 
 /** Card / panel shell with theme-aware border. */
 export const adminCardClass =

--- a/src/apps/admin/utils/adminStyles.ts
+++ b/src/apps/admin/utils/adminStyles.ts
@@ -27,8 +27,7 @@ export const adminSectionHeaderClass =
   "!text-[11px] uppercase tracking-wide text-os-text-secondary";
 
 /** Theme-aware vertical list dividers. */
-export const adminListDividerClass =
-  "divide-y divide-black/10 os-mac-aqua-dark:divide-white/10";
+export const adminListDividerClass = "admin-soft-list-dividers";
 
 /** Table header cell background. */
 export const adminTableHeadClass =

--- a/src/apps/admin/utils/adminStyles.ts
+++ b/src/apps/admin/utils/adminStyles.ts
@@ -8,15 +8,15 @@ export const adminSidebarClass = "bg-white/90 text-os-text-primary";
 
 /** Card / panel shell with theme-aware border. */
 export const adminCardClass =
-  "overflow-hidden rounded border border-os-separator bg-os-window-bg";
+  "overflow-hidden rounded border border-black/10 bg-white/90 os-mac-aqua-dark:border-white/10";
 
 /** Card header band (dashboard sections, server card, etc.). */
 export const adminCardHeaderClass =
-  "border-b border-os-separator bg-os-panel-bg px-3 py-2";
+  "border-b border-black/10 bg-white/90 px-3 py-2 os-mac-aqua-dark:border-white/10";
 
 /** Detail panel header (user profile, song detail). */
 export const adminDetailHeaderClass =
-  "flex items-center gap-2 border-b border-os-separator bg-os-panel-bg px-3 py-2";
+  "flex items-center gap-2 border-b border-black/10 bg-white/90 px-3 py-2 os-mac-aqua-dark:border-white/10";
 
 /** Uppercase section labels in cards and profile panels. */
 export const adminSectionLabelClass =
@@ -28,7 +28,7 @@ export const adminSectionHeaderClass =
 
 /** Theme-aware vertical list dividers. */
 export const adminListDividerClass =
-  "divide-y divide-[color:var(--os-color-separator)]";
+  "divide-y divide-black/10 os-mac-aqua-dark:divide-white/10";
 
 /** Table header cell background. */
 export const adminTableHeadClass =

--- a/src/styles/themes.css
+++ b/src/styles/themes.css
@@ -1278,6 +1278,17 @@
   line-height: 1 !important;
 }
 
+/* Admin list rows: softer separators than the default OS separator token. */
+.admin-soft-list-dividers > * + * {
+  border-top: 1px solid rgba(0, 0, 0, 0.1);
+}
+
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"]
+  .admin-soft-list-dividers
+  > * + * {
+  border-top-color: rgba(255, 255, 255, 0.1);
+}
+
 /* Chat meta (username/timestamp) override BEFORE generic Control Panels override anchor.
  * font-family override replaces the removed `:root[data-os-theme="macosx"] *` wildcard
  * so the meta row uses Lucida Grande instead of the inline `font-['Geneva-9']` class


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Change the Admin main content and sidebar surfaces to the same Finder-style white pane treatment.
- Match Admin dashboard cards and card headers to that pane surface.
- Use softer explicit Admin list row separators in light and Aqua dark mode.

## Walkthrough
<a href="https://cursor.com/agents/bc-019ea548-c2c1-7830-807b-862395974ac6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fadmin_dashboard_cards_borders_light_dark.mp4"><img src="https://cursor.com/artifacts/c/art-10798a78-9a1a-49a7-b55c-1be2e93d59e8" alt="admin_dashboard_cards_borders_light_dark.mp4" /></a>
![Admin dashboard cards light](https://cursor.com/artifacts/c/art-1127a87e-aa59-41b1-8c61-54ee866ebb76)
![Admin dashboard cards dark](https://cursor.com/artifacts/c/art-5905621e-898d-4682-86d0-5f60a6ef6dfd)

## Testing
- `bun run build`
- Headless Chrome verification confirmed Admin dashboard cards compute to the pane background in Aqua light/dark and list separators compute to 1px `rgba(..., 0.1)` borders.
- Browser walkthrough verified Admin dashboard cards and subtle list borders visually in Aqua light and dark modes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ea548-c2c1-7830-807b-862395974ac6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ea548-c2c1-7830-807b-862395974ac6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

