### PR TITLE
Fix Applet Store crash loop

### DIFF
--- a/src/apps/applet-viewer/utils/appletActions.ts
+++ b/src/apps/applet-viewer/utils/appletActions.ts
@@ -1,8 +1,13 @@
 import { useCallback, useRef } from "react";
 import { toast } from "sonner";
-import { useFileSystem } from "@/apps/finder/hooks/useFileSystem";
 import { useLaunchApp } from "@/hooks/useLaunchApp";
-import { useFilesStore } from "@/stores/useFilesStore";
+import {
+  updateFileMetadata,
+  useFileMetadataInPath,
+} from "@/services/vfs/FileMetadataService";
+import { readAppletTextContent } from "@/services/vfs/FileContentRepository";
+import { useVfsFileOperations } from "@/services/vfs/useVfsFileOperations";
+import { useFilesStore, type FileSystemItem } from "@/stores/useFilesStore";
 import { APPLET_ANALYTICS, track } from "@/utils/analytics";
 import { getApiUrl } from "@/utils/platform";
 import { abortableFetch } from "@/utils/abortableFetch";
@@ -40,12 +45,11 @@ export const extractEmojiIcon = (
 };
 
 export const useAppletActions = () => {
-  const { saveFile, files, handleFileOpen } = useFileSystem("/Applets");
+  const { saveFile } = useVfsFileOperations("/Applets");
+  const files = useFileMetadataInPath("/Applets");
   const launchApp = useLaunchApp();
   const getFileItem = useFilesStore((state) => state.getItem);
-  const updateFileItemMetadata = useFilesStore(
-    (state) => state.updateItemMetadata
-  );
+  const updateFileItemMetadata = updateFileMetadata;
 
   // Check if an applet is installed
   const isAppletInstalled = useCallback((appletId: string): boolean => {
@@ -118,6 +122,19 @@ export const useAppletActions = () => {
     [getFileItem, getInstalledApplet, isAppletInstalled, scheduleStoreCreatedAtUpdate]
   );
 
+  const openInstalledApplet = useCallback(
+    async (file: FileSystemItem) => {
+      const content = await readAppletTextContent(file.path);
+      launchApp("applet-viewer", {
+        initialData: {
+          path: file.path,
+          content: content ?? "",
+        },
+      });
+    },
+    [launchApp]
+  );
+
   // Handle clicking on an applet
   const handleAppletClick = async (applet: Applet) => {
     const installed = isAppletInstalled(applet.id);
@@ -130,7 +147,7 @@ export const useAppletActions = () => {
 
       if (installedApplet) {
         try {
-          await handleFileOpen(installedApplet);
+          await openInstalledApplet(installedApplet);
         } catch (error) {
           console.error("Error launching applet from disk:", error);
           toast.error("Failed to launch applet");

--- a/src/services/vfs/useVfsFileOperations.ts
+++ b/src/services/vfs/useVfsFileOperations.ts
@@ -1,6 +1,6 @@
 import { useFileSystem } from "@/apps/finder/hooks/useFileSystem";
 
 export function useVfsFileOperations(basePath: string) {
-  const { saveFile } = useFileSystem(basePath);
+  const { saveFile } = useFileSystem(basePath, { skipLoad: true });
   return { saveFile };
 }

--- a/tests/test-vfs-service-wiring.test.ts
+++ b/tests/test-vfs-service-wiring.test.ts
@@ -13,8 +13,16 @@ const appletSource = readFileSync(
   "src/apps/applet-viewer/hooks/useAppletViewerLogic.ts",
   "utf8"
 );
+const appletActionsSource = readFileSync(
+  "src/apps/applet-viewer/utils/appletActions.ts",
+  "utf8"
+);
 const fileMetadataServiceSource = readFileSync(
   "src/services/vfs/FileMetadataService.ts",
+  "utf8"
+);
+const vfsFileOperationsSource = readFileSync(
+  "src/services/vfs/useVfsFileOperations.ts",
   "utf8"
 );
 
@@ -50,6 +58,16 @@ describe("VFS service wiring", () => {
     );
     expect(fileMetadataServiceSource).not.toContain(
       "useFilesStore((state) => state.getItemsInPath(path))"
+    );
+  });
+
+  test("Applet Store actions avoid Finder file-loading effects", () => {
+    expect(appletActionsSource).toContain("@/services/vfs/useVfsFileOperations");
+    expect(appletActionsSource).toContain("@/services/vfs/FileMetadataService");
+    expect(appletActionsSource).toContain("@/services/vfs/FileContentRepository");
+    expect(appletActionsSource).not.toContain("@/apps/finder/hooks/useFileSystem");
+    expect(vfsFileOperationsSource).toContain(
+      "useFileSystem(basePath, { skipLoad: true })"
     );
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Prevents Applet Store actions from mounting Finder's full file-loading hook by routing saves through VFS operations with `skipLoad`.
- Uses cached `/Applets` metadata and direct applet launch for installed applets, avoiding the render/update loop that showed `Applet Store quit unexpectedly`.
- Adds VFS wiring coverage to keep Applet Store off Finder file-loading effects.

## Browser smoke
<a href="https://cursor.com/agents/bc-019ea3ed-3ace-7360-b79b-86cc7b1f7fec/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fapplet_store_weather_final_smoke.mp4"><img src="https://cursor.com/artifacts/c/art-3fe78575-14e7-4abe-ac89-94bc115c123a" alt="applet_store_weather_final_smoke.mp4" /></a>

## Testing
- `bun test tests/test-vfs-service-wiring.test.ts tests/test-applet-trust.test.ts`
- `bun run build`
- API-backed browser smoke on `localhost:5173`: Applet Store loads Weather and opens it without a crash dialog or failed-open toast.

## Notes
- `API_URL=http://localhost:3100 bun test tests/test-share-applet.test.ts` passed 17/18 locally; the remaining list assertion did not find the just-created applet in shared external API state, while direct applet fetch and browser open smoke passed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ea3ed-3ace-7360-b79b-86cc7b1f7fec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ea3ed-3ace-7360-b79b-86cc7b1f7fec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

