### PR TITLE
Use colored title card outline styles

### DIFF
--- a/src/apps/karaoke/components/karaoke-lyrics-playback/KaraokeTitleCard.tsx
+++ b/src/apps/karaoke/components/karaoke-lyrics-playback/KaraokeTitleCard.tsx
@@ -1,11 +1,16 @@
 import { memo, useMemo } from "react";
 import { motion } from "motion/react";
 import { useCoverGlowColor } from "@/hooks/useCoverGlowColor";
+import { normalizeCoverColor } from "@/apps/ipod/components/lyrics-display/colorUtils";
 import { ScrollingText } from "@/apps/ipod/components/screen";
 import {
   getTitleCardStyleCategory,
+  makeTitleCardColoredOutlineStyle,
   makeTitleCardGlow,
+  makeTitleCardOutlineFillFromGlowColor,
   TITLE_CARD_BASE_SHADOW,
+  TITLE_CARD_ROUNDED_OUTLINE_COLOR,
+  TITLE_CARD_SERIF_OUTLINE_COLOR,
   TITLE_CARD_CONTENT_STYLE_FULLSCREEN,
   TITLE_CARD_CONTENT_STYLE_WINDOW,
   TITLE_CARD_COVER_IMAGE_STYLE_FULLSCREEN,
@@ -17,7 +22,6 @@ import {
   TITLE_CARD_OUTER_STYLE_FULLSCREEN,
   TITLE_CARD_OUTER_STYLE_WINDOW,
   TITLE_CARD_REGULAR_GRADIENT_STYLE,
-  TITLE_CARD_REGULAR_OUTLINE_STYLE,
   TITLE_CARD_SECONDARY_TEXT_STYLE,
   TITLE_CARD_TITLE_LINE_HEIGHT,
   TITLE_CARD_TITLE_SHADOW_BLEED_STYLE,
@@ -57,13 +61,25 @@ export const KaraokeTitleCard = memo(function KaraokeTitleCard({
   isPlaying: boolean;
 }) {
   const styleCategory = getTitleCardStyleCategory(fontClassName);
+  const isOutlineTitleStyle =
+    styleCategory === "outline-blue" || styleCategory === "outline-red";
+  const hasAdaptiveOutlineColor =
+    isOutlineTitleStyle &&
+    (Boolean(coverUrl) || Boolean(normalizeCoverColor(coverColor)));
   const glowColor = useCoverGlowColor({
     coverUrl,
     coverColor,
-    enabled: styleCategory === "glow-gold",
+    enabled: styleCategory === "glow-gold" || hasAdaptiveOutlineColor,
     onResolved: onCoverColorResolved,
   });
   const primaryGlow = makeTitleCardGlow(glowColor);
+  const outlineFillColor = useMemo(
+    () =>
+      hasAdaptiveOutlineColor
+        ? makeTitleCardOutlineFillFromGlowColor(primaryGlow.color)
+        : undefined,
+    [hasAdaptiveOutlineColor, primaryGlow.color]
+  );
 
   const titleTextSizeClass =
     variant === "fullscreen"
@@ -86,8 +102,13 @@ export const KaraokeTitleCard = memo(function KaraokeTitleCard({
   const regularTextStyle = useMemo((): TitleCardLineStyle => {
     switch (styleCategory) {
       case "outline-blue":
+        return makeTitleCardColoredOutlineStyle(
+          outlineFillColor ?? TITLE_CARD_ROUNDED_OUTLINE_COLOR
+        );
       case "outline-red":
-        return TITLE_CARD_REGULAR_OUTLINE_STYLE;
+        return makeTitleCardColoredOutlineStyle(
+          outlineFillColor ?? TITLE_CARD_SERIF_OUTLINE_COLOR
+        );
       case "glow-gold":
         return {
           ...TITLE_CARD_TITLE_SHADOW_BLEED_STYLE,
@@ -100,7 +121,7 @@ export const KaraokeTitleCard = memo(function KaraokeTitleCard({
       default:
         return TITLE_CARD_REGULAR_GRADIENT_STYLE;
     }
-  }, [primaryGlow, styleCategory]);
+  }, [outlineFillColor, primaryGlow, styleCategory]);
   const metadataLines = useMemo(() => {
     const values: string[] = [];
     for (const value of [artist, album]) {

--- a/src/apps/karaoke/components/karaoke-lyrics-playback/title-card-styles.ts
+++ b/src/apps/karaoke/components/karaoke-lyrics-playback/title-card-styles.ts
@@ -2,6 +2,7 @@ import type { CSSProperties } from "react";
 import {
   boostGlowColor,
   makeGlowFromColor,
+  makeOutlineFillFromGlowColor,
   pickPrimaryColor,
 } from "@/apps/ipod/components/lyrics-display/colorUtils";
 
@@ -110,14 +111,27 @@ export const TITLE_CARD_TITLE_SHADOW_BLEED_STYLE = {
   maxWidth: `calc(100% + ${TITLE_CARD_TITLE_LEFT_BLEED})`,
 } satisfies TitleCardLineStyle;
 
-export const TITLE_CARD_REGULAR_OUTLINE_STYLE: TitleCardLineStyle = {
-  ...TITLE_CARD_TITLE_SHADOW_BLEED_STYLE,
-  color: "#fff",
-  lineHeight: TITLE_CARD_TITLE_LINE_HEIGHT,
-  WebkitTextStroke: "0.12em rgba(0,0,0,0.7)",
-  paintOrder: "stroke fill",
-  textShadow: "none",
-};
+export const TITLE_CARD_ROUNDED_OUTLINE_COLOR = "#0066FF";
+export const TITLE_CARD_SERIF_OUTLINE_COLOR = "#CC0000";
+export const TITLE_CARD_COLORED_OUTLINE_STROKE = "0.12em #fff";
+
+export function makeTitleCardColoredOutlineStyle(
+  fillColor: string
+): TitleCardLineStyle {
+  return {
+    ...TITLE_CARD_TITLE_SHADOW_BLEED_STYLE,
+    color: fillColor,
+    lineHeight: TITLE_CARD_TITLE_LINE_HEIGHT,
+    WebkitTextStroke: TITLE_CARD_COLORED_OUTLINE_STROKE,
+    paintOrder: "stroke fill",
+    textShadow: "none",
+  };
+}
+
+export function makeTitleCardOutlineFillFromGlowColor(hex: string): string {
+  return makeOutlineFillFromGlowColor(hex);
+}
+
 export const TITLE_CARD_REGULAR_GRADIENT_STYLE: TitleCardLineStyle = {
   ...TITLE_CARD_TITLE_SHADOW_BLEED_STYLE,
   color: "rgba(255, 255, 255, 0.78)",

--- a/tests/test-karaoke-title-card.test.ts
+++ b/tests/test-karaoke-title-card.test.ts
@@ -6,7 +6,13 @@ import {
   getFirstLyricStartMs,
   shouldShowKaraokeTitleCard,
 } from "@/apps/karaoke/utils/titleCard";
-import { TITLE_CARD_TITLE_SHADOW_BLEED_STYLE } from "@/apps/karaoke/components/karaoke-lyrics-playback/title-card-styles";
+import {
+  makeTitleCardColoredOutlineStyle,
+  TITLE_CARD_COLORED_OUTLINE_STROKE,
+  TITLE_CARD_ROUNDED_OUTLINE_COLOR,
+  TITLE_CARD_SERIF_OUTLINE_COLOR,
+  TITLE_CARD_TITLE_SHADOW_BLEED_STYLE,
+} from "@/apps/karaoke/components/karaoke-lyrics-playback/title-card-styles";
 
 const readSource = (relativePath: string): string =>
   readFileSync(resolve(process.cwd(), relativePath), "utf-8");
@@ -140,5 +146,17 @@ describe("karaoke title card timing", () => {
     expect(TITLE_CARD_TITLE_SHADOW_BLEED_STYLE.marginLeft).toBe("-0.35em");
     expect(TITLE_CARD_TITLE_SHADOW_BLEED_STYLE.width).toBe("calc(100% + 0.35em)");
     expect(TITLE_CARD_TITLE_SHADOW_BLEED_STYLE.maxWidth).toBe("calc(100% + 0.35em)");
+  });
+
+  test("uses colored fills for outline title-card title styles", () => {
+    const rounded = makeTitleCardColoredOutlineStyle(TITLE_CARD_ROUNDED_OUTLINE_COLOR);
+    const serif = makeTitleCardColoredOutlineStyle(TITLE_CARD_SERIF_OUTLINE_COLOR);
+
+    expect(rounded.color).toBe("#0066FF");
+    expect(serif.color).toBe("#CC0000");
+    expect(rounded.WebkitTextStroke).toBe(TITLE_CARD_COLORED_OUTLINE_STROKE);
+    expect(serif.WebkitTextStroke).toBe(TITLE_CARD_COLORED_OUTLINE_STROKE);
+    expect(rounded.textShadow).toBe("none");
+    expect(serif.textShadow).toBe("none");
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Switch karaoke title card outline title styles to colored fills with white outlines for rounded and serif outline fonts.
- Reuse the existing album-art-derived outline fill when cover color data is available.
- Add regression coverage for the colored outline title-card style helper.

### Testing
- `bun test tests/test-karaoke-title-card.test.ts` — passed (13 tests)
- `bun run build` — passed (Vite emitted existing CSS/chunking warnings)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ea594-30b4-73c7-939b-015509018ca3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ea594-30b4-73c7-939b-015509018ca3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

