### PR TITLE
Add Aqua Glass theme variant

### DIFF
--- a/src/apps/control-panels/components/control-panels-app/AppearanceTabContent.tsx
+++ b/src/apps/control-panels/components/control-panels-app/AppearanceTabContent.tsx
@@ -84,6 +84,8 @@ export type AppearanceTabContentProps = {
   t: (key: string, opts?: Record<string, unknown>) => string;
   currentTheme: OsThemeId;
   setTheme: (theme: OsThemeId) => void;
+  aquaMaterial: "classic" | "glass";
+  setAquaMaterial: (material: "classic" | "glass") => void;
   supportsDarkMode: boolean;
   darkModePreference: "system" | "light" | "dark";
   setDarkMode: (mode: "system" | "light" | "dark") => void;
@@ -102,6 +104,8 @@ export function AppearanceTabContent({
   t,
   currentTheme,
   setTheme,
+  aquaMaterial,
+  setAquaMaterial,
   supportsDarkMode,
   darkModePreference,
   setDarkMode,
@@ -114,6 +118,33 @@ export function AppearanceTabContent({
   setLanguage,
   tabStyles,
 }: AppearanceTabContentProps) {
+  // "Aqua Glass" is a surface material variant of the macosx (Aqua) chrome, not
+  // a separate OsThemeId. Surface it as its own picker entry using a synthetic
+  // value so it sits right below classic "Aqua".
+  const GLASS_VALUE = "macosx:glass";
+  const themeOptions: { value: string; label: string }[] = [];
+  for (const [id, theme] of Object.entries(themes)) {
+    themeOptions.push({ value: id, label: theme.name });
+    if (id === "macosx") {
+      themeOptions.push({ value: GLASS_VALUE, label: `${theme.name} Glass` });
+    }
+  }
+  const selectedThemeValue =
+    currentTheme === "macosx" && aquaMaterial === "glass"
+      ? GLASS_VALUE
+      : currentTheme;
+  const selectedThemeLabel =
+    themeOptions.find((option) => option.value === selectedThemeValue)?.label ??
+    themes[currentTheme]?.name;
+  const handleThemeChange = (value: string) => {
+    if (value === GLASS_VALUE) {
+      setTheme("macosx");
+      setAquaMaterial("glass");
+    } else {
+      setTheme(value as OsThemeId);
+      setAquaMaterial("classic");
+    }
+  };
   return (
     <div className="space-y-4 h-full overflow-y-auto p-4 pt-6">
       <div className="flex items-center justify-between gap-2">
@@ -176,19 +207,16 @@ export function AppearanceTabContent({
             {t("apps.control-panels.themeDescription")}
           </Label>
         </div>
-        <Select
-          value={currentTheme}
-          onValueChange={(value) => setTheme(value as OsThemeId)}
-        >
+        <Select value={selectedThemeValue} onValueChange={handleThemeChange}>
           <SelectTrigger className="w-[120px] flex-shrink-0">
             <SelectValue placeholder={t("apps.control-panels.select")}>
-              {themes[currentTheme]?.name || t("apps.control-panels.select")}
+              {selectedThemeLabel || t("apps.control-panels.select")}
             </SelectValue>
           </SelectTrigger>
           <SelectContent>
-            {Object.entries(themes).map(([id, theme]) => (
-              <SelectItem key={id} value={id}>
-                {theme.name}
+            {themeOptions.map((option) => (
+              <SelectItem key={option.value} value={option.value}>
+                {option.label}
               </SelectItem>
             ))}
           </SelectContent>

--- a/src/apps/control-panels/components/control-panels-app/ControlPanelsAppComponent.tsx
+++ b/src/apps/control-panels/components/control-panels-app/ControlPanelsAppComponent.tsx
@@ -70,6 +70,8 @@ export function ControlPanelsAppComponent({
     setShaderEffectEnabled,
     currentTheme,
     setTheme,
+    aquaMaterial,
+    setAquaMaterial,
     supportsDarkMode,
     darkModePreference,
     setDarkMode,
@@ -355,6 +357,8 @@ export function ControlPanelsAppComponent({
                 t={t}
                 currentTheme={currentTheme}
                 setTheme={setTheme}
+                aquaMaterial={aquaMaterial}
+                setAquaMaterial={setAquaMaterial}
                 supportsDarkMode={supportsDarkMode}
                 darkModePreference={darkModePreference}
                 setDarkMode={setDarkMode}

--- a/src/apps/control-panels/hooks/useControlPanelsLogic.ts
+++ b/src/apps/control-panels/hooks/useControlPanelsLogic.ts
@@ -294,10 +294,12 @@ export function useControlPanelsLogic({
     isXpTheme,
     isMacOSTheme: isMacOSXTheme,
     isMacTheme: isClassicMacTheme,
+    aquaMaterial,
   } = useThemeFlags();
   const setTheme = useThemeStore((state) => state.setTheme);
   const setDarkMode = useThemeStore((state) => state.setDarkMode);
   const setAccent = useThemeStore((state) => state.setAccent);
+  const setAquaMaterial = useThemeStore((state) => state.setAquaMaterial);
   const wallpaperAccentColor = useThemeStore(
     (state) => state.wallpaperAccentColor
   );
@@ -1616,6 +1618,8 @@ export function useControlPanelsLogic({
     setShaderEffectEnabled,
     currentTheme,
     setTheme,
+    aquaMaterial,
+    setAquaMaterial,
     supportsDarkMode,
     isDarkMode,
     darkModePreference,

--- a/src/apps/ipod/components/ipod-app/IpodDeviceBody.tsx
+++ b/src/apps/ipod/components/ipod-app/IpodDeviceBody.tsx
@@ -21,7 +21,7 @@ export function IpodDeviceBody({ c }: IpodDeviceBodyProps) {
   return (
     <div
       ref={containerRef}
-      className="ipod-force-font flex flex-col items-center justify-center w-full h-full bg-gradient-to-b from-neutral-100/20 to-neutral-300/20 backdrop-blur-lg p-4 select-none"
+      className="ipod-device-surface ipod-force-font flex flex-col items-center justify-center w-full h-full bg-gradient-to-b from-neutral-100/20 to-neutral-300/20 backdrop-blur-lg p-4 select-none"
       style={{ position: "relative", overflow: "hidden", contain: "layout style paint" }}
     >
       <div

--- a/src/components/layout/dock/MacDock.tsx
+++ b/src/components/layout/dock/MacDock.tsx
@@ -740,7 +740,7 @@ export function MacDock() {
           ref={dockBarRef}
           layout
           layoutRoot
-          className="inline-flex items-end"
+          className="mac-dock-surface inline-flex items-end"
           initial={false}
           animate={{
             y: isDockVisible ? 0 : scaledDockHeight + 10,

--- a/src/components/layout/window-frame/WindowFrame.tsx
+++ b/src/components/layout/window-frame/WindowFrame.tsx
@@ -114,10 +114,14 @@ export function WindowFrame({
   const isTransparent = material === "transparent" || material === "notitlebar";
   const isNoTitlebar = material === "notitlebar";
   const isBrushedMetal = material === "brushedmetal";
-  // Regular (opaque-material) windows under Aqua Glass: the `.window` element
-  // becomes the single frosted pane. Transparent / brushed-metal materials keep
-  // their own treatment, so they're excluded here.
-  const isGlassRegular = isAquaGlass && !isTransparent && !isBrushedMetal;
+  // Aqua Glass window-material mapping: every opaque material (default AND
+  // brushedmetal — glass is "the new metal") maps to the single frosted glass
+  // pane. Only the genuinely see-through materials (transparent / notitlebar,
+  // e.g. iPod, Photo Booth, Videos) opt out and keep their own treatment.
+  const isGlassSurface = isAquaGlass && !isTransparent;
+  // In the glass theme the brushed-metal texture is replaced by the glass
+  // surface, so don't apply the metal chrome class.
+  const useBrushedMetalChrome = isBrushedMetal && isMacOSTheme && !isAquaGlass;
   const effectiveTransparentBackground =
     isMacOSTheme ? true : isTransparent;
 
@@ -370,10 +374,8 @@ export function WindowFrame({
                       ? "shadow-os-window"
                       : "",
                     isForeground ? "is-foreground" : "",
-                    isBrushedMetal &&
-                      isMacOSTheme &&
-                      "window-material-brushedmetal",
-                    isGlassRegular && "window-material-glass"
+                    useBrushedMetalChrome && "window-material-brushedmetal",
+                    isGlassSurface && "window-material-glass"
                   )}
                   style={{
                     ...(!isXpTheme
@@ -396,7 +398,7 @@ export function WindowFrame({
                       effectiveTransparentBackground
                     }
                     isBrushedMetal={isBrushedMetal}
-                    isGlassSurface={isGlassRegular}
+                    isGlassSurface={isGlassSurface}
                     isTransparent={isTransparent}
                     debugMode={debugMode}
                     appId={appId}
@@ -434,8 +436,7 @@ export function WindowFrame({
                   <div
                     className={cn(
                       "window-body flex flex-1 min-h-0 flex-col md:flex-row relative",
-                      isBrushedMetal &&
-                        isMacOSTheme &&
+                      useBrushedMetalChrome &&
                         "ml-[8px] mr-[8px] mb-[8px] rounded-none overflow-hidden"
                     )}
                     style={

--- a/src/components/layout/window-frame/WindowFrame.tsx
+++ b/src/components/layout/window-frame/WindowFrame.tsx
@@ -114,14 +114,13 @@ export function WindowFrame({
   const isTransparent = material === "transparent" || material === "notitlebar";
   const isNoTitlebar = material === "notitlebar";
   const isBrushedMetal = material === "brushedmetal";
-  // Aqua Glass window-material mapping: every opaque material (default AND
-  // brushedmetal — glass is "the new metal") maps to the single frosted glass
-  // pane. Only the genuinely see-through materials (transparent / notitlebar,
-  // e.g. iPod, Photo Booth, Videos) opt out and keep their own treatment.
-  const isGlassSurface = isAquaGlass && !isTransparent;
-  // In the glass theme the brushed-metal texture is replaced by the glass
-  // surface, so don't apply the metal chrome class.
-  const useBrushedMetalChrome = isBrushedMetal && isMacOSTheme && !isAquaGlass;
+  // Regular (default-material) windows under Aqua Glass use the single frosted
+  // glass pane. Brushed-metal windows keep their `window-material-brushedmetal`
+  // class and are converted to glass purely via CSS overrides (so apps can
+  // still opt into the metal material). Transparent / notitlebar materials keep
+  // their own treatment.
+  const isGlassRegular =
+    isAquaGlass && !isTransparent && !isBrushedMetal;
   const effectiveTransparentBackground =
     isMacOSTheme ? true : isTransparent;
 
@@ -374,8 +373,10 @@ export function WindowFrame({
                       ? "shadow-os-window"
                       : "",
                     isForeground ? "is-foreground" : "",
-                    useBrushedMetalChrome && "window-material-brushedmetal",
-                    isGlassSurface && "window-material-glass"
+                    isBrushedMetal &&
+                      isMacOSTheme &&
+                      "window-material-brushedmetal",
+                    isGlassRegular && "window-material-glass"
                   )}
                   style={{
                     ...(!isXpTheme
@@ -398,7 +399,7 @@ export function WindowFrame({
                       effectiveTransparentBackground
                     }
                     isBrushedMetal={isBrushedMetal}
-                    isGlassSurface={isGlassSurface}
+                    isGlassSurface={isGlassRegular}
                     isTransparent={isTransparent}
                     debugMode={debugMode}
                     appId={appId}
@@ -436,7 +437,8 @@ export function WindowFrame({
                   <div
                     className={cn(
                       "window-body flex flex-1 min-h-0 flex-col md:flex-row relative",
-                      useBrushedMetalChrome &&
+                      isBrushedMetal &&
+                        isMacOSTheme &&
                         "ml-[8px] mr-[8px] mb-[8px] rounded-none overflow-hidden"
                     )}
                     style={

--- a/src/components/layout/window-frame/WindowFrame.tsx
+++ b/src/components/layout/window-frame/WindowFrame.tsx
@@ -114,6 +114,10 @@ export function WindowFrame({
   const isTransparent = material === "transparent" || material === "notitlebar";
   const isNoTitlebar = material === "notitlebar";
   const isBrushedMetal = material === "brushedmetal";
+  // Regular (opaque-material) windows under Aqua Glass: the `.window` element
+  // becomes the single frosted pane. Transparent / brushed-metal materials keep
+  // their own treatment, so they're excluded here.
+  const isGlassRegular = isAquaGlass && !isTransparent && !isBrushedMetal;
   const effectiveTransparentBackground =
     isMacOSTheme ? true : isTransparent;
 
@@ -368,7 +372,8 @@ export function WindowFrame({
                     isForeground ? "is-foreground" : "",
                     isBrushedMetal &&
                       isMacOSTheme &&
-                      "window-material-brushedmetal"
+                      "window-material-brushedmetal",
+                    isGlassRegular && "window-material-glass"
                   )}
                   style={{
                     ...(!isXpTheme
@@ -391,7 +396,7 @@ export function WindowFrame({
                       effectiveTransparentBackground
                     }
                     isBrushedMetal={isBrushedMetal}
-                    isAquaGlass={isAquaGlass}
+                    isGlassSurface={isGlassRegular}
                     isTransparent={isTransparent}
                     debugMode={debugMode}
                     appId={appId}

--- a/src/components/layout/window-frame/WindowFrame.tsx
+++ b/src/components/layout/window-frame/WindowFrame.tsx
@@ -2,6 +2,7 @@ import { useAppStoreShallow } from "@/stores/helpers";
 import { useAppStore } from "@/stores/useAppStore";
 import { useDisplaySettingsStore } from "@/stores/useDisplaySettingsStore";
 import { useWindowInsets } from "@/hooks/useWindowInsets";
+import { useThemeFlags } from "@/hooks/useThemeFlags";
 import { useIsMobile } from "@/hooks/useIsMobile";
 import { useIsPhone } from "@/hooks/useIsPhone";
 import { cn } from "@/lib/utils";
@@ -108,6 +109,7 @@ export function WindowFrame({
   });
 
   const { isXpTheme, isMacOSTheme, isSystem7Theme, isWinXp } = useWindowInsets();
+  const { isAquaGlass } = useThemeFlags();
 
   const isTransparent = material === "transparent" || material === "notitlebar";
   const isNoTitlebar = material === "notitlebar";
@@ -389,6 +391,7 @@ export function WindowFrame({
                       effectiveTransparentBackground
                     }
                     isBrushedMetal={isBrushedMetal}
+                    isAquaGlass={isAquaGlass}
                     isTransparent={isTransparent}
                     debugMode={debugMode}
                     appId={appId}
@@ -434,11 +437,12 @@ export function WindowFrame({
                       isXpTheme
                         ? { margin: isWinXp ? "0px 3px" : "0" }
                         : isMacOSTheme
-                          ? isTransparent
-                            ? undefined
-                            : isBrushedMetal
-                              ? undefined
-                              : isForeground
+                          ? isTransparent || isBrushedMetal || isAquaGlass
+                            ? // Aqua Glass: let the single frosted `.window`
+                              // surface show through so the titlebar + body read
+                              // as one continuous pane (like brushed metal).
+                              undefined
+                            : isForeground
                                 ? {
                                     backgroundColor: "var(--os-color-window-bg)",
                                     backgroundImage:

--- a/src/components/layout/window-frame/WindowFrameTitleBar.tsx
+++ b/src/components/layout/window-frame/WindowFrameTitleBar.tsx
@@ -17,7 +17,7 @@ export interface WindowFrameTitleBarProps {
   disableTitlebarAutoHide: boolean;
   effectiveTransparentBackground: boolean;
   isBrushedMetal: boolean;
-  isAquaGlass: boolean;
+  isGlassSurface: boolean;
   isTransparent: boolean;
   isTitlebarHovered: boolean;
   showTitlebarWithAutoHide: () => void;
@@ -50,7 +50,7 @@ export function WindowFrameTitleBar({
   disableTitlebarAutoHide,
   effectiveTransparentBackground,
   isBrushedMetal,
-  isAquaGlass,
+  isGlassSurface,
   isTransparent,
   isTitlebarHovered,
   showTitlebarWithAutoHide,
@@ -230,7 +230,7 @@ export function WindowFrameTitleBar({
                   borderBottom: "none",
                   opacity: isTitlebarHovered ? 1 : 0,
                 }
-              : isBrushedMetal || isAquaGlass
+              : isBrushedMetal || isGlassSurface
               ? // Aqua Glass shares the frosted `.window` surface, so the
                 // titlebar stays transparent and reads continuous with the body.
                 {
@@ -248,7 +248,7 @@ export function WindowFrameTitleBar({
                   opacity: "0.85",
                 }),
             // No border for notitlebar, brushed metal, or Aqua Glass
-            ...(!isNoTitlebar && !isBrushedMetal && !isAquaGlass && {
+            ...(!isNoTitlebar && !isBrushedMetal && !isGlassSurface && {
               borderBottom: `1px solid ${
                 isForeground
                   ? "var(--os-color-titlebar-border, rgba(0, 0, 0, 0.1))"

--- a/src/components/layout/window-frame/WindowFrameTitleBar.tsx
+++ b/src/components/layout/window-frame/WindowFrameTitleBar.tsx
@@ -17,6 +17,7 @@ export interface WindowFrameTitleBarProps {
   disableTitlebarAutoHide: boolean;
   effectiveTransparentBackground: boolean;
   isBrushedMetal: boolean;
+  isAquaGlass: boolean;
   isTransparent: boolean;
   isTitlebarHovered: boolean;
   showTitlebarWithAutoHide: () => void;
@@ -49,6 +50,7 @@ export function WindowFrameTitleBar({
   disableTitlebarAutoHide,
   effectiveTransparentBackground,
   isBrushedMetal,
+  isAquaGlass,
   isTransparent,
   isTitlebarHovered,
   showTitlebarWithAutoHide,
@@ -228,8 +230,10 @@ export function WindowFrameTitleBar({
                   borderBottom: "none",
                   opacity: isTitlebarHovered ? 1 : 0,
                 }
-              : isBrushedMetal
-              ? {
+              : isBrushedMetal || isAquaGlass
+              ? // Aqua Glass shares the frosted `.window` surface, so the
+                // titlebar stays transparent and reads continuous with the body.
+                {
                   background: "transparent",
                 }
               : isForeground
@@ -243,8 +247,8 @@ export function WindowFrameTitleBar({
                   backgroundImage: "var(--os-pinstripe-window)",
                   opacity: "0.85",
                 }),
-            // No border for notitlebar or brushed metal
-            ...(!isNoTitlebar && !isBrushedMetal && {
+            // No border for notitlebar, brushed metal, or Aqua Glass
+            ...(!isNoTitlebar && !isBrushedMetal && !isAquaGlass && {
               borderBottom: `1px solid ${
                 isForeground
                   ? "var(--os-color-titlebar-border, rgba(0, 0, 0, 0.1))"

--- a/src/components/shared/TrafficLightButton.tsx
+++ b/src/components/shared/TrafficLightButton.tsx
@@ -64,6 +64,20 @@ const graphiteStyles = {
 };
 
 /**
+ * Aqua Glass: the three lights drop their red/yellow/green identity and become
+ * translucent orbs tinted with the active accent color (falling back to the
+ * classic Aqua blue when the accent is "System"/default). `color-mix` keeps the
+ * fill see-through so the frosted titlebar shows through, and the white shine /
+ * glow overlays below still read as glass. Mode-independent.
+ */
+const ACCENT_VAR = "var(--os-accent-color, #2765ca)";
+const glassStyles = {
+  gradient: `linear-gradient(color-mix(in srgb, ${ACCENT_VAR} 66%, transparent), color-mix(in srgb, ${ACCENT_VAR} 42%, transparent))`,
+  iconColor: "rgba(255, 255, 255, 0.92)",
+  shadow: `0 1px 2px rgba(0, 0, 0, 0.22), 0 0 0 0.5px rgba(255, 255, 255, 0.35) inset, 0 1px 1px rgba(255, 255, 255, 0.5) inset, 0 -2px 3px 1px color-mix(in srgb, ${ACCENT_VAR} 45%, transparent) inset`,
+};
+
+/**
  * macOS-style traffic light window control button (close, minimize, maximize).
  * Extracted to reduce duplication in WindowFrame.tsx
  */
@@ -74,8 +88,12 @@ export function TrafficLightButton({
   debugMode = false,
   ariaLabel,
 }: TrafficLightButtonProps) {
-  const { accent } = useThemeFlags();
-  const activeStyles = accent === "graphite" ? graphiteStyles : colorStyles[color];
+  const { accent, isAquaGlass } = useThemeFlags();
+  const activeStyles = isAquaGlass
+    ? glassStyles
+    : accent === "graphite"
+      ? graphiteStyles
+      : colorStyles[color];
   const styles = isForeground ? activeStyles : inactiveStyles;
 
   return (

--- a/src/components/shared/TrafficLightButton.tsx
+++ b/src/components/shared/TrafficLightButton.tsx
@@ -72,9 +72,14 @@ const graphiteStyles = {
  */
 const ACCENT_VAR = "var(--os-accent-color, #2765ca)";
 const glassStyles = {
-  gradient: `linear-gradient(color-mix(in srgb, ${ACCENT_VAR} 66%, transparent), color-mix(in srgb, ${ACCENT_VAR} 42%, transparent))`,
+  // Slightly semi-opaque accent fill (close to the inactive light's 0.625
+  // alpha) so the orb reads as tinted glass without washing out.
+  gradient: `linear-gradient(color-mix(in srgb, ${ACCENT_VAR} 80%, transparent), color-mix(in srgb, ${ACCENT_VAR} 58%, transparent))`,
   iconColor: "rgba(255, 255, 255, 0.92)",
-  shadow: `0 1px 2px rgba(0, 0, 0, 0.22), 0 0 0 0.5px rgba(255, 255, 255, 0.35) inset, 0 1px 1px rgba(255, 255, 255, 0.5) inset, 0 -2px 3px 1px color-mix(in srgb, ${ACCENT_VAR} 45%, transparent) inset`,
+  // Mirror the inactive light's shadow stack — outer drop + a crisp 0.5px dark
+  // inset stroke for definition, tight (non-blurry) inset highlights, and an
+  // accent-tinted inner glow instead of the inactive gray.
+  shadow: `0 2px 3px rgba(0, 0, 0, 0.2), 0 1px 1px rgba(0, 0, 0, 0.3), inset 0 0 0 0.5px rgba(0, 0, 0, 0.45), inset 0 1px 1px rgba(255, 255, 255, 0.45), inset 0 2px 3px 1px color-mix(in srgb, ${ACCENT_VAR} 60%, transparent)`,
 };
 
 /**

--- a/src/hooks/useThemeFlags.ts
+++ b/src/hooks/useThemeFlags.ts
@@ -14,6 +14,7 @@ export function useThemeFlags() {
   const accent: AccentId = useThemeStore(
     (state) => state.accentByTheme[state.current] ?? DEFAULT_ACCENT
   );
+  const aquaMaterial = useThemeStore((state) => state.aquaMaterial);
   const metadata = useMemo(() => getThemeMetadata(currentTheme), [currentTheme]);
   const osPlatform: OsPlatform = getOsPlatform(currentTheme);
   const macChrome: OsMacChrome | null = getOsMacChrome(currentTheme);
@@ -33,6 +34,8 @@ export function useThemeFlags() {
   const isDarkMode = supportsDarkMode && isDark;
   /** Only the classic Mac chromes (Aqua + System 7) expose an accent picker. */
   const supportsAccent = macChrome !== null;
+  /** True when the Aqua "glass" material is active (only meaningful for macosx). */
+  const isAquaGlass = isMacOSTheme && aquaMaterial === "glass";
 
   return {
     currentTheme,
@@ -54,5 +57,7 @@ export function useThemeFlags() {
     darkModePreference,
     supportsAccent,
     accent,
+    aquaMaterial,
+    isAquaGlass,
   };
 }

--- a/src/shared/domains/settings.ts
+++ b/src/shared/domains/settings.ts
@@ -17,6 +17,8 @@ export interface SettingsSnapshotData {
   theme: string;
   themeDarkMode?: Record<string, "system" | "light" | "dark" | boolean>;
   themeAccent?: Record<string, string>;
+  /** Mac OS X Aqua surface material ("classic" pinstripe vs "glass" frosted). */
+  themeAquaMaterial?: "classic" | "glass";
   language: LanguageCode;
   languageInitialized: boolean;
   aiModel: AIModel | null;

--- a/src/stores/useThemeStore.ts
+++ b/src/stores/useThemeStore.ts
@@ -106,6 +106,40 @@ function writeAccentMap(map: AccentMap) {
   }
 }
 
+/**
+ * Surface material for the Mac OS X Aqua chrome:
+ * - `"classic"` (default): the pinstriped / brushed-metal Tiger-era Aqua look.
+ * - `"glass"`: the "Aqua Glass" re-imagining — frosted translucent surfaces with
+ *   specular shine and blurred highlights (inspired by the karaoke controls).
+ *
+ * Stored as a flat string (not per-theme) because it only modifies the `macosx`
+ * chrome; other themes ignore it. Applied to `<html>` as `data-os-aqua-material`
+ * only when the active theme is `macosx` and the material is `"glass"`, so it
+ * layers on top of the existing Aqua rules via higher-specificity selectors.
+ */
+export type AquaMaterial = "classic" | "glass";
+
+function isAquaMaterial(value: unknown): value is AquaMaterial {
+  return value === "classic" || value === "glass";
+}
+
+function safeReadAquaMaterial(): AquaMaterial {
+  try {
+    const raw = localStorage.getItem(AQUA_MATERIAL_KEY);
+    return isAquaMaterial(raw) ? raw : "classic";
+  } catch {
+    return "classic";
+  }
+}
+
+function writeAquaMaterial(material: AquaMaterial) {
+  try {
+    localStorage.setItem(AQUA_MATERIAL_KEY, material);
+  } catch {
+    // ignore quota / private-mode errors
+  }
+}
+
 interface ThemeState {
   current: OsThemeId;
   /** Effective dark-mode flag for the active theme (false if the theme has no dark tokens). */
@@ -114,6 +148,8 @@ interface ThemeState {
   darkModeByTheme: DarkModeMap;
   /** Per-theme accent-color preferences (Aqua + System 7); persisted per theme. */
   accentByTheme: AccentMap;
+  /** Mac OS X Aqua surface material ("classic" pinstripe vs "glass" frosted). */
+  aquaMaterial: AquaMaterial;
   /**
    * Color sampled from the active wallpaper, driving the `"wallpaper"` accent.
    * `null` until sampled (or when the wallpaper can't be sampled).
@@ -138,6 +174,11 @@ interface ThemeState {
    * Aqua + System 7 support accents; calls for other themes are ignored.
    */
   setAccent: (accent: AccentId, theme?: OsThemeId) => void;
+  /**
+   * Switch the Aqua surface material. Only meaningful for the `macosx` theme,
+   * but the preference is persisted regardless so it sticks when toggling back.
+   */
+  setAquaMaterial: (material: AquaMaterial) => void;
   /**
    * Record the latest color sampled from the wallpaper. Re-applies the root
    * accent immediately when the current theme is using the `"wallpaper"` accent.
@@ -204,6 +245,12 @@ const DARK_MODE_KEY = "ryos:theme:dark";
  * settings-sync localStorage snapshot without a dedicated section.
  */
 const ACCENT_KEY = "ryos:theme:accent";
+/**
+ * Aqua surface material ("classic" vs "glass"). Single flat value (only the
+ * `macosx` chrome reads it). Stored as a plain string so it round-trips through
+ * the settings-sync localStorage snapshot alongside the other theme keys.
+ */
+const AQUA_MATERIAL_KEY = "ryos:theme:aqua-material";
 /**
  * Last color sampled from the active wallpaper for the `"wallpaper"` accent.
  * Cached so a non-default-accent reload paints the right color immediately
@@ -278,7 +325,8 @@ function applyRootThemeAttributes(
   theme: OsThemeId,
   isDark: boolean,
   accentMap: AccentMap,
-  wallpaperColor: string | null
+  wallpaperColor: string | null,
+  aquaMaterial: AquaMaterial
 ) {
   const root = document.documentElement;
   root.dataset.osTheme = theme;
@@ -286,6 +334,14 @@ function applyRootThemeAttributes(
   const macChrome = getOsMacChrome(theme);
   if (macChrome) root.dataset.osMacChrome = macChrome;
   else delete root.dataset.osMacChrome;
+  // Aqua "glass" material only applies to the macosx chrome. The attribute is
+  // omitted for classic Aqua (and every other theme) so the glass overrides —
+  // which key on `[data-os-aqua-material="glass"]` — stay dormant.
+  if (theme === "macosx" && aquaMaterial === "glass") {
+    root.dataset.osAquaMaterial = "glass";
+  } else {
+    delete root.dataset.osAquaMaterial;
+  }
   // Color-scheme attribute is only applied when the theme supports dark mode AND it's enabled.
   // This keeps the existing light-mode CSS the single source of truth for unsupported themes.
   // Mirror the same predicate on Tailwind's `dark` class so `dark:*` utilities match Aqua dark mode
@@ -335,7 +391,8 @@ function ensureSystemDarkListener() {
       state.current,
       nextDark,
       state.accentByTheme,
-      state.wallpaperAccentColor
+      state.wallpaperAccentColor,
+      state.aquaMaterial
     );
   };
   if (typeof systemDarkQuery.addEventListener === "function") {
@@ -351,6 +408,7 @@ const createThemeStore = () => create<ThemeState>((set) => ({
   isDark: false,
   darkModeByTheme: {},
   accentByTheme: {},
+  aquaMaterial: "classic",
   wallpaperAccentColor: null,
   setTheme: (theme) => {
     const safe = sanitizeStoredTheme(theme);
@@ -366,7 +424,8 @@ const createThemeStore = () => create<ThemeState>((set) => ({
       safe,
       nextDark,
       state.accentByTheme,
-      state.wallpaperAccentColor
+      state.wallpaperAccentColor,
+      state.aquaMaterial
     );
     ensureLegacyCss(safe);
     // Note: No need to invalidate icon cache on theme switch.
@@ -408,7 +467,8 @@ const createThemeStore = () => create<ThemeState>((set) => ({
         state.current,
         nextDark,
         state.accentByTheme,
-        state.wallpaperAccentColor
+        state.wallpaperAccentColor,
+        state.aquaMaterial
       );
       track(SETTINGS_ANALYTICS.THEME_CHANGE, {
         theme: state.current,
@@ -450,6 +510,24 @@ const createThemeStore = () => create<ThemeState>((set) => ({
         accent,
       });
     }
+  },
+  setAquaMaterial: (material) => {
+    if (!isAquaMaterial(material)) return;
+    const state = useThemeStore.getState();
+    if (material === state.aquaMaterial) return;
+    writeAquaMaterial(material);
+    set({ aquaMaterial: material });
+    applyRootThemeAttributes(
+      state.current,
+      state.isDark,
+      state.accentByTheme,
+      state.wallpaperAccentColor,
+      material
+    );
+    track(SETTINGS_ANALYTICS.THEME_CHANGE, {
+      theme: state.current,
+      aquaMaterial: material,
+    });
   },
   setWallpaperAccentColor: (hex) => {
     const normalized = normalizeAccentHex(hex);
@@ -497,15 +575,23 @@ const createThemeStore = () => create<ThemeState>((set) => ({
     }
     const accentMap = safeReadAccentMap();
     const wallpaperAccentColor = safeReadWallpaperAccentColor();
+    const aquaMaterial = safeReadAquaMaterial();
     const isDark = effectiveDarkFor(theme, map);
     set({
       current: theme,
       isDark,
       darkModeByTheme: map,
       accentByTheme: accentMap,
+      aquaMaterial,
       wallpaperAccentColor,
     });
-    applyRootThemeAttributes(theme, isDark, accentMap, wallpaperAccentColor);
+    applyRootThemeAttributes(
+      theme,
+      isDark,
+      accentMap,
+      wallpaperAccentColor,
+      aquaMaterial
+    );
     ensureLegacyCss(theme);
     ensureSystemDarkListener();
   },

--- a/src/styles/themes.css
+++ b/src/styles/themes.css
@@ -5378,8 +5378,10 @@
 :root[data-os-theme="macosx"][data-os-aqua-material="glass"]:not(
     [data-os-color-scheme="dark"]
   ) {
-  /* Translucent surfaces (the blur lives on the chrome elements below). */
-  --os-color-window-bg: rgba(243, 246, 251, 0.55);
+  /* Translucent surfaces (the blur lives on the chrome elements below). The
+     titlebar + body are transparent in glass, so this single `.window` fill is
+     the continuous frosted pane — keep it opaque enough to stay legible. */
+  --os-color-window-bg: rgba(243, 246, 251, 0.62);
   --os-color-panel-bg: rgba(243, 246, 251, 0.62);
   --os-color-menubar-bg: rgba(250, 251, 253, 0.55);
   --os-color-menubar-surface: rgba(250, 251, 253, 0.55);
@@ -5432,7 +5434,7 @@
 
 /* --- Dark glass tokens ---------------------------------------------------- */
 :root[data-os-theme="macosx"][data-os-aqua-material="glass"][data-os-color-scheme="dark"] {
-  --os-color-window-bg: rgba(38, 40, 46, 0.55);
+  --os-color-window-bg: rgba(38, 40, 46, 0.62);
   --os-color-panel-bg: rgba(38, 40, 46, 0.62);
   --os-color-menubar-bg: rgba(26, 27, 31, 0.58);
   --os-color-menubar-surface: rgba(26, 27, 31, 0.58);

--- a/src/styles/themes.css
+++ b/src/styles/themes.css
@@ -5568,7 +5568,7 @@
 :root[data-os-theme="macosx"][data-os-aqua-material="glass"] .mac-dock-surface {
   backdrop-filter: blur(26px) saturate(185%);
   -webkit-backdrop-filter: blur(26px) saturate(185%);
-  border-radius: 20px !important;
+  border-radius: 13px !important;
   box-shadow: var(--os-color-dock-shadow),
     inset 0 1px 0 rgba(255, 255, 255, 0.4) !important;
 }
@@ -5588,7 +5588,7 @@
   backdrop-filter: blur(22px) saturate(185%);
   -webkit-backdrop-filter: blur(22px) saturate(185%);
   /* Overrides the inline `0px` radius from the dropdown/select content. */
-  border-radius: 12px !important;
+  border-radius: 7px !important;
   box-shadow: 0 10px 30px rgba(0, 0, 0, 0.25),
     inset 0 1px 0 rgba(255, 255, 255, 0.4) !important;
 }

--- a/src/styles/themes.css
+++ b/src/styles/themes.css
@@ -5564,9 +5564,12 @@
 }
 
 /* --- Frosted dock --------------------------------------------------------- */
+/* `border-radius` overrides the inline `0px` from MacDock so the pill reads as
+   a modern rounded glass tray. */
 :root[data-os-theme="macosx"][data-os-aqua-material="glass"] .mac-dock-surface {
   backdrop-filter: blur(26px) saturate(185%);
   -webkit-backdrop-filter: blur(26px) saturate(185%);
+  border-radius: 20px !important;
   box-shadow: var(--os-color-dock-shadow),
     inset 0 1px 0 rgba(255, 255, 255, 0.4) !important;
 }
@@ -5585,6 +5588,8 @@
 :root[data-os-theme="macosx"][data-os-aqua-material="glass"] [role="listbox"] {
   backdrop-filter: blur(22px) saturate(185%);
   -webkit-backdrop-filter: blur(22px) saturate(185%);
+  /* Overrides the inline `0px` radius from the dropdown/select content. */
+  border-radius: 12px !important;
   box-shadow: 0 10px 30px rgba(0, 0, 0, 0.25),
     inset 0 1px 0 rgba(255, 255, 255, 0.4) !important;
 }

--- a/src/styles/themes.css
+++ b/src/styles/themes.css
@@ -5350,3 +5350,225 @@
   td[style*="rgba(0,0,0,0.04)"] {
   background-color: rgba(255, 255, 255, 0.03) !important;
 }
+
+/* ============================================================================
+ * Aqua Glass — Mac OS X surface material variant
+ *
+ * Selected via Control Panels → Appearance ("Aqua Glass"). The theme id stays
+ * `macosx`, so all Aqua chrome + component behavior is reused; the difference is
+ * `data-os-aqua-material="glass"` on <html>, which this section keys off of.
+ *
+ * Goal: re-imagine Aqua with NO pinstripes and NO brushed metal. Instead, every
+ * surface becomes a blurred translucent glass pane with a specular top shine and
+ * soft, blurred highlights — the same vocabulary used by the karaoke playback
+ * controls. Supports both light and dark modes.
+ *
+ * Specificity notes (so these layer cleanly without touching the 500+ base
+ * macosx rules):
+ *   - Light tokens use `[data-os-aqua-material="glass"]:not([data-os-color-scheme="dark"])`
+ *     (3 attribute selectors) so they never leak into dark mode regardless of
+ *     source order.
+ *   - Dark tokens use `[data-os-aqua-material="glass"][data-os-color-scheme="dark"]`
+ *     (3 attribute selectors) which beats the 2-attribute base dark token block.
+ *   - Structural rules add `[data-os-aqua-material="glass"]` (2 attributes) on top
+ *     of a class/descendant, beating the 1-attribute base macosx rules.
+ * ============================================================================ */
+
+/* --- Light glass tokens --------------------------------------------------- */
+:root[data-os-theme="macosx"][data-os-aqua-material="glass"]:not(
+    [data-os-color-scheme="dark"]
+  ) {
+  /* Translucent surfaces (the blur lives on the chrome elements below). */
+  --os-color-window-bg: rgba(243, 246, 251, 0.55);
+  --os-color-panel-bg: rgba(243, 246, 251, 0.62);
+  --os-color-menubar-bg: rgba(250, 251, 253, 0.55);
+  --os-color-menubar-surface: rgba(250, 251, 253, 0.55);
+  --os-color-dock-surface: rgba(250, 251, 253, 0.5);
+  --os-color-dock-shadow: 0 8px 30px rgba(0, 0, 0, 0.22);
+
+  /* Soft glassy edges + diffuse shadow. */
+  --os-color-window-border: rgba(255, 255, 255, 0.55);
+  --os-color-window-border-inactive: rgba(255, 255, 255, 0.35);
+  --os-color-menubar-border: rgba(255, 255, 255, 0.4);
+  --os-color-titlebar-border: rgba(255, 255, 255, 0.45);
+  --os-color-titlebar-border-inactive: rgba(255, 255, 255, 0.25);
+  --os-window-shadow: 0 18px 50px rgba(0, 0, 0, 0.28),
+    0 2px 10px rgba(0, 0, 0, 0.12);
+  --os-color-separator: rgba(60, 70, 90, 0.14);
+
+  /* Titlebar gradient becomes a glass pane (translucent, no pinstripe). */
+  --os-color-titlebar-active-bg: linear-gradient(
+    to bottom,
+    rgba(255, 255, 255, 0.5) 0%,
+    rgba(244, 247, 251, 0.35) 100%
+  );
+  --os-color-titlebar-inactive-bg: linear-gradient(
+    to bottom,
+    rgba(248, 250, 252, 0.42) 0%,
+    rgba(240, 243, 247, 0.3) 100%
+  );
+
+  /* Inputs read as frosted glass wells. */
+  --os-color-input-bg: rgba(255, 255, 255, 0.55);
+  --os-color-input-border: rgba(60, 70, 90, 0.22);
+
+  /* Kill the pinstripes. `--os-pinstripe-window` doubles as the popover /
+     window-body fill, so it becomes a self-contained translucent glass pane
+     rather than `none`. The menubar pattern goes flat. */
+  --os-pinstripe-window: linear-gradient(
+    to bottom,
+    rgba(252, 253, 255, 0.62),
+    rgba(244, 247, 251, 0.55)
+  );
+  --os-pinstripe-menubar: none;
+  /* Specular top sheen on the titlebar instead of the pinstripe gloss. */
+  --os-pinstripe-titlebar: linear-gradient(
+    to bottom,
+    rgba(255, 255, 255, 0.65) 0%,
+    rgba(255, 255, 255, 0.18) 45%,
+    rgba(255, 255, 255, 0) 100%
+  );
+}
+
+/* --- Dark glass tokens ---------------------------------------------------- */
+:root[data-os-theme="macosx"][data-os-aqua-material="glass"][data-os-color-scheme="dark"] {
+  --os-color-window-bg: rgba(38, 40, 46, 0.55);
+  --os-color-panel-bg: rgba(38, 40, 46, 0.62);
+  --os-color-menubar-bg: rgba(26, 27, 31, 0.58);
+  --os-color-menubar-surface: rgba(26, 27, 31, 0.58);
+  --os-color-dock-surface: rgba(26, 27, 31, 0.5);
+  --os-color-dock-shadow: 0 8px 30px rgba(0, 0, 0, 0.55);
+
+  --os-color-window-border: rgba(255, 255, 255, 0.16);
+  --os-color-window-border-inactive: rgba(255, 255, 255, 0.08);
+  --os-color-menubar-border: rgba(255, 255, 255, 0.1);
+  --os-color-titlebar-border: rgba(255, 255, 255, 0.14);
+  --os-color-titlebar-border-inactive: rgba(255, 255, 255, 0.08);
+  --os-window-shadow: 0 18px 55px rgba(0, 0, 0, 0.6),
+    0 2px 12px rgba(0, 0, 0, 0.4);
+  --os-color-separator: rgba(255, 255, 255, 0.12);
+
+  --os-color-titlebar-active-bg: linear-gradient(
+    to bottom,
+    rgba(72, 74, 82, 0.5) 0%,
+    rgba(44, 46, 52, 0.4) 100%
+  );
+  --os-color-titlebar-inactive-bg: linear-gradient(
+    to bottom,
+    rgba(56, 58, 64, 0.42) 0%,
+    rgba(40, 42, 47, 0.34) 100%
+  );
+
+  --os-color-input-bg: rgba(255, 255, 255, 0.08);
+  --os-color-input-border: rgba(255, 255, 255, 0.16);
+
+  --os-pinstripe-window: linear-gradient(
+    to bottom,
+    rgba(52, 54, 60, 0.62),
+    rgba(40, 42, 48, 0.55)
+  );
+  --os-pinstripe-menubar: none;
+  --os-pinstripe-titlebar: linear-gradient(
+    to bottom,
+    rgba(255, 255, 255, 0.16) 0%,
+    rgba(255, 255, 255, 0.05) 45%,
+    rgba(255, 255, 255, 0) 100%
+  );
+}
+
+/* --- Frosted window panes ------------------------------------------------- */
+/* Blur the desktop behind every window and add a specular inner rim so the
+   edge catches light like glass. */
+:root[data-os-theme="macosx"][data-os-aqua-material="glass"] .window {
+  backdrop-filter: blur(26px) saturate(185%);
+  -webkit-backdrop-filter: blur(26px) saturate(185%);
+  box-shadow: var(--os-window-shadow),
+    inset 0 1px 0 rgba(255, 255, 255, 0.35);
+}
+
+:root[data-os-theme="macosx"][data-os-aqua-material="glass"][data-os-color-scheme="dark"]
+  .window {
+  box-shadow: var(--os-window-shadow),
+    inset 0 1px 0 rgba(255, 255, 255, 0.1);
+}
+
+/* The classic brushed-metal material drops its aluminum JPG and becomes the
+   same frosted glass pane (used by iPod / iTunes-style windows). */
+:root[data-os-theme="macosx"][data-os-aqua-material="glass"]
+  .window-material-brushedmetal::before {
+  background: var(--os-pinstripe-window) !important;
+  filter: none !important;
+}
+
+:root[data-os-theme="macosx"][data-os-aqua-material="glass"]
+  .window-material-brushedmetal:not(.is-foreground)::before {
+  filter: saturate(0.9) brightness(0.98) !important;
+}
+
+/* --- Frosted menu bar ----------------------------------------------------- */
+/* Beef up the menubar blur and swap the white pinstripe gloss for a soft
+   specular top highlight. */
+:root[data-os-theme="macosx"][data-os-aqua-material="glass"] .menubar {
+  backdrop-filter: blur(26px) saturate(185%) !important;
+  -webkit-backdrop-filter: blur(26px) saturate(185%) !important;
+  box-shadow: 0 1px 0 rgba(255, 255, 255, 0.4) inset,
+    0 -1px 0 rgba(0, 0, 0, 0.08) inset;
+}
+
+:root[data-os-theme="macosx"][data-os-aqua-material="glass"] .menubar::before {
+  height: 60%;
+  background: linear-gradient(
+    to bottom,
+    rgba(255, 255, 255, 0.35),
+    rgba(255, 255, 255, 0)
+  );
+}
+
+:root[data-os-theme="macosx"][data-os-aqua-material="glass"][data-os-color-scheme="dark"]
+  .menubar {
+  box-shadow: 0 1px 0 rgba(255, 255, 255, 0.08) inset,
+    0 -1px 0 rgba(0, 0, 0, 0.4) inset;
+}
+
+:root[data-os-theme="macosx"][data-os-aqua-material="glass"][data-os-color-scheme="dark"]
+  .menubar::before {
+  background: linear-gradient(
+    to bottom,
+    rgba(255, 255, 255, 0.1),
+    rgba(255, 255, 255, 0)
+  );
+}
+
+/* --- Frosted dock --------------------------------------------------------- */
+:root[data-os-theme="macosx"][data-os-aqua-material="glass"] .mac-dock-surface {
+  backdrop-filter: blur(26px) saturate(185%);
+  -webkit-backdrop-filter: blur(26px) saturate(185%);
+  box-shadow: var(--os-color-dock-shadow),
+    inset 0 1px 0 rgba(255, 255, 255, 0.4) !important;
+}
+
+:root[data-os-theme="macosx"][data-os-aqua-material="glass"][data-os-color-scheme="dark"]
+  .mac-dock-surface {
+  box-shadow: var(--os-color-dock-shadow),
+    inset 0 1px 0 rgba(255, 255, 255, 0.12) !important;
+}
+
+/* --- Frosted popovers (dropdowns, menubar menus, selects) ----------------- */
+/* These portal to <body> but remain under <html>, so the root attribute still
+   scopes them. They paint `var(--os-pinstripe-window)` inline, so they pick up
+   the glass fill from the tokens above; here we add the blur + specular rim. */
+:root[data-os-theme="macosx"][data-os-aqua-material="glass"] [role="menu"],
+:root[data-os-theme="macosx"][data-os-aqua-material="glass"] [role="listbox"] {
+  backdrop-filter: blur(22px) saturate(185%);
+  -webkit-backdrop-filter: blur(22px) saturate(185%);
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.25),
+    inset 0 1px 0 rgba(255, 255, 255, 0.4) !important;
+}
+
+:root[data-os-theme="macosx"][data-os-aqua-material="glass"][data-os-color-scheme="dark"]
+  [role="menu"],
+:root[data-os-theme="macosx"][data-os-aqua-material="glass"][data-os-color-scheme="dark"]
+  [role="listbox"] {
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.55),
+    inset 0 1px 0 rgba(255, 255, 255, 0.1) !important;
+}

--- a/src/styles/themes.css
+++ b/src/styles/themes.css
@@ -5510,8 +5510,25 @@
   border-bottom: none !important;
 }
 
-/* The brushed-metal material is mapped to `window-material-glass` in the glass
-   theme (see WindowFrame), so it needs no aluminum-texture overrides here. */
+/* Brushed-metal windows keep their material/class, but in the glass theme the
+   aluminum JPG is overridden so the surface renders as the same frosted glass
+   pane (used by iPod / iTunes-style windows that opt into the metal material). */
+:root[data-os-theme="macosx"][data-os-aqua-material="glass"]
+  .window-material-brushedmetal {
+  backdrop-filter: blur(26px) saturate(185%);
+  -webkit-backdrop-filter: blur(26px) saturate(185%);
+}
+
+:root[data-os-theme="macosx"][data-os-aqua-material="glass"]
+  .window-material-brushedmetal::before {
+  background: var(--os-color-window-bg) !important;
+  filter: none !important;
+}
+
+:root[data-os-theme="macosx"][data-os-aqua-material="glass"]
+  .window-material-brushedmetal:not(.is-foreground)::before {
+  filter: saturate(0.9) brightness(0.98) !important;
+}
 
 /* iPod's blurred device backdrop gets the same frosted glass surface as the
    metal windows (replacing its neutral translucent gradient). */

--- a/src/styles/themes.css
+++ b/src/styles/themes.css
@@ -5479,19 +5479,24 @@
 }
 
 /* --- Frosted window panes ------------------------------------------------- */
-/* Blur the desktop behind every window and add a specular inner rim so the
-   edge catches light like glass. */
-:root[data-os-theme="macosx"][data-os-aqua-material="glass"] .window {
+/* Regular windows: the titlebar + body render transparent (see WindowFrame), so
+   this single `.window` surface is the continuous frosted pane. It carries the
+   translucent tint, the desktop blur, and a specular inner rim at the top edge.
+   `effectiveTransparentBackground` keeps macOS `.window` elements free of the
+   `bg-os-window-bg` class, so the fill is applied here instead. */
+:root[data-os-theme="macosx"][data-os-aqua-material="glass"]
+  .window.window-material-glass {
+  background-color: var(--os-color-window-bg);
   backdrop-filter: blur(26px) saturate(185%);
   -webkit-backdrop-filter: blur(26px) saturate(185%);
   box-shadow: var(--os-window-shadow),
-    inset 0 1px 0 rgba(255, 255, 255, 0.35);
+    inset 0 1px 0 rgba(255, 255, 255, 0.4);
 }
 
 :root[data-os-theme="macosx"][data-os-aqua-material="glass"][data-os-color-scheme="dark"]
-  .window {
+  .window.window-material-glass {
   box-shadow: var(--os-window-shadow),
-    inset 0 1px 0 rgba(255, 255, 255, 0.1);
+    inset 0 1px 0 rgba(255, 255, 255, 0.12);
 }
 
 /* Drop the hard titlebar divider — on a single frosted pane the seam reads as
@@ -5507,6 +5512,12 @@
 
 /* The classic brushed-metal material drops its aluminum JPG and becomes the
    same frosted glass pane (used by iPod / iTunes-style windows). */
+:root[data-os-theme="macosx"][data-os-aqua-material="glass"]
+  .window-material-brushedmetal {
+  backdrop-filter: blur(26px) saturate(185%);
+  -webkit-backdrop-filter: blur(26px) saturate(185%);
+}
+
 :root[data-os-theme="macosx"][data-os-aqua-material="glass"]
   .window-material-brushedmetal::before {
   background: var(--os-pinstripe-window) !important;

--- a/src/styles/themes.css
+++ b/src/styles/themes.css
@@ -5510,23 +5510,22 @@
   border-bottom: none !important;
 }
 
-/* The classic brushed-metal material drops its aluminum JPG and becomes the
-   same frosted glass pane (used by iPod / iTunes-style windows). */
-:root[data-os-theme="macosx"][data-os-aqua-material="glass"]
-  .window-material-brushedmetal {
-  backdrop-filter: blur(26px) saturate(185%);
-  -webkit-backdrop-filter: blur(26px) saturate(185%);
+/* The brushed-metal material is mapped to `window-material-glass` in the glass
+   theme (see WindowFrame), so it needs no aluminum-texture overrides here. */
+
+/* iPod's blurred device backdrop gets the same frosted glass surface as the
+   metal windows (replacing its neutral translucent gradient). */
+:root[data-os-theme="macosx"][data-os-aqua-material="glass"] .ipod-device-surface {
+  background: var(--os-color-window-bg) !important;
+  background-image: none !important;
+  backdrop-filter: blur(26px) saturate(185%) !important;
+  -webkit-backdrop-filter: blur(26px) saturate(185%) !important;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.4);
 }
 
-:root[data-os-theme="macosx"][data-os-aqua-material="glass"]
-  .window-material-brushedmetal::before {
-  background: var(--os-pinstripe-window) !important;
-  filter: none !important;
-}
-
-:root[data-os-theme="macosx"][data-os-aqua-material="glass"]
-  .window-material-brushedmetal:not(.is-foreground)::before {
-  filter: saturate(0.9) brightness(0.98) !important;
+:root[data-os-theme="macosx"][data-os-aqua-material="glass"][data-os-color-scheme="dark"]
+  .ipod-device-surface {
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.12);
 }
 
 /* --- Frosted menu bar ----------------------------------------------------- */

--- a/src/styles/themes.css
+++ b/src/styles/themes.css
@@ -5492,6 +5492,17 @@
     inset 0 1px 0 rgba(255, 255, 255, 0.1);
 }
 
+/* Drop the hard titlebar divider — on a single frosted pane the seam reads as
+   an ugly line, so the titlebar blends straight into the window body. */
+:root[data-os-theme="macosx"][data-os-aqua-material="glass"]
+  .window.is-foreground
+  .title-bar:not(.absolute),
+:root[data-os-theme="macosx"][data-os-aqua-material="glass"]
+  .window:not(.is-foreground)
+  .title-bar:not(.absolute) {
+  border-bottom: none !important;
+}
+
 /* The classic brushed-metal material drops its aluminum JPG and becomes the
    same frosted glass pane (used by iPod / iTunes-style windows). */
 :root[data-os-theme="macosx"][data-os-aqua-material="glass"]

--- a/src/sync/domains.ts
+++ b/src/sync/domains.ts
@@ -472,6 +472,7 @@ function serializeSettingsSnapshot(): SettingsSnapshotData {
       string,
       string
     >,
+    themeAquaMaterial: useThemeStore.getState().aquaMaterial,
     language: useLanguageStore.getState().current,
     languageInitialized:
       localStorage.getItem("ryos:language-initialized") === "true",
@@ -954,6 +955,15 @@ async function applySettingsSnapshot(
               .getState()
               .setAccent(value as never, themeId as never);
           }
+        }
+        // Apply the Aqua surface material. The setter is a no-op for invalid
+        // values and only repaints when the macosx chrome is active.
+        const remoteAquaMaterial = normalizedData.themeAquaMaterial;
+        if (
+          remoteAquaMaterial === "classic" ||
+          remoteAquaMaterial === "glass"
+        ) {
+          useThemeStore.getState().setAquaMaterial(remoteAquaMaterial);
         }
         appliedSections.push("theme");
       } catch (e) {

--- a/src/utils/cloudSyncSettingsMerge.ts
+++ b/src/utils/cloudSyncSettingsMerge.ts
@@ -76,6 +76,9 @@ export function mergeSettingsSnapshotData(
         ...normalizedRemote.themeAccent,
       };
     }
+    if (normalizedRemote.themeAquaMaterial !== undefined) {
+      merged.themeAquaMaterial = normalizedRemote.themeAquaMaterial;
+    }
     merged.sectionUpdatedAt!.theme = remoteSectionUpdatedAt.theme;
   }
 
@@ -170,11 +173,17 @@ export function getSectionPayloadForSettingsPatch(
         data.themeDarkMode && Object.keys(data.themeDarkMode).length > 0;
       const hasAccent =
         data.themeAccent && Object.keys(data.themeAccent).length > 0;
-      if (hasDarkMode || hasAccent) {
+      // Only send the material when it deviates from the default so older
+      // clients keep receiving the plain-string payload they understand.
+      const hasAquaMaterial =
+        data.themeAquaMaterial !== undefined &&
+        data.themeAquaMaterial !== "classic";
+      if (hasDarkMode || hasAccent || hasAquaMaterial) {
         return {
           theme: data.theme,
           ...(hasDarkMode ? { darkMode: data.themeDarkMode } : {}),
           ...(hasAccent ? { accent: data.themeAccent } : {}),
+          ...(hasAquaMaterial ? { aquaMaterial: data.themeAquaMaterial } : {}),
         };
       }
       return data.theme;
@@ -308,6 +317,7 @@ export function applySettingsRedisPatch(
             theme?: string;
             darkMode?: Record<string, "system" | "light" | "dark" | boolean>;
             accent?: Record<string, string>;
+            aquaMaterial?: "classic" | "glass";
           };
           if (typeof v.theme === "string") next.theme = v.theme;
           // Deep-merge the per-theme maps over the remote base so the patching
@@ -318,6 +328,9 @@ export function applySettingsRedisPatch(
           }
           if (v.accent && typeof v.accent === "object") {
             next.themeAccent = { ...next.themeAccent, ...v.accent };
+          }
+          if (v.aquaMaterial === "classic" || v.aquaMaterial === "glass") {
+            next.themeAquaMaterial = v.aquaMaterial;
           }
         }
         break;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds **Aqua Glass**, a re-imagining of the macOS Aqua theme that drops pinstripes and brushed metal in favor of blurred, translucent glass surfaces with specular shine and soft blurred highlights (the same visual vocabulary used by the karaoke playback controls). Supports both light and dark modes.

Aqua Glass is implemented as a **surface material variant** of the existing `macosx` theme rather than a brand-new `OsThemeId`. This keeps `current === "macosx"`, so all existing Aqua chrome, component behavior, icons, accents, and dark mode are reused unchanged. The variant is applied via a new `data-os-aqua-material="glass"` attribute on `<html>` and layered on top of the Aqua rules using higher-specificity CSS selectors.

## Changes

- `useThemeStore`: new `aquaMaterial` state (`"classic" | "glass"`), persisted to `ryos:theme:aqua-material`, `setAquaMaterial` action, and `data-os-aqua-material` root attribute applied when the Aqua chrome is active.
- `useThemeFlags`: exposes `aquaMaterial` and `isAquaGlass`.
- Control Panels → Appearance: theme picker surfaces "Aqua Glass" as its own entry (maps to `macosx` + glass material).
- Settings sync: `themeAquaMaterial` round-trips through the existing `theme` section (snapshot, merge, patch, apply); older clients keep getting the plain-string payload.
- `themes.css`: new Aqua Glass section — frosted token overrides (light + dark) plus `backdrop-filter` blur/saturate and specular highlights on windows, the menu bar, the dock, and popovers.
- `MacDock`: adds a `mac-dock-surface` hook class for the dock blur.

## Testing

- `tsc -b` and `eslint` pass.
- Manual verification of light + dark Aqua Glass in the browser (see walkthrough on the PR / agent summary).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ea9ea-2ad5-7389-86f9-106fe5124bc9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ea9ea-2ad5-7389-86f9-106fe5124bc9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

