### PR TITLE
Make title card white outline less opaque

### DIFF
--- a/src/apps/karaoke/components/karaoke-lyrics-playback/title-card-styles.ts
+++ b/src/apps/karaoke/components/karaoke-lyrics-playback/title-card-styles.ts
@@ -113,7 +113,7 @@ export const TITLE_CARD_TITLE_SHADOW_BLEED_STYLE = {
 
 export const TITLE_CARD_ROUNDED_OUTLINE_COLOR = "#0066FF";
 export const TITLE_CARD_SERIF_OUTLINE_COLOR = "#CC0000";
-export const TITLE_CARD_COLORED_OUTLINE_STROKE = "0.12em #fff";
+export const TITLE_CARD_COLORED_OUTLINE_STROKE = "0.12em rgba(255,255,255,0.6)";
 
 export function makeTitleCardColoredOutlineStyle(
   fillColor: string


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Softens the white outline stroke used by the karaoke title-card title (outline-blue / outline-red styles) so it reads less harshly. The lyrics display styles are left untouched.

## Changes

- `TITLE_CARD_COLORED_OUTLINE_STROKE` in `src/apps/karaoke/components/karaoke-lyrics-playback/title-card-styles.ts` changed from `0.12em #fff` to `0.12em rgba(255,255,255,0.6)`.

## Testing

- `bun test tests/test-karaoke-title-card.test.ts` — 13 pass

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019eaa33-ed28-783d-88a6-d9c43aa535e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019eaa33-ed28-783d-88a6-d9c43aa535e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

