### PR TITLE
iPod: brushed-metal window frame, drop custom transparent backdrop

### DIFF
--- a/src/apps/ipod/components/ipod-app/IpodAppComponent.tsx
+++ b/src/apps/ipod/components/ipod-app/IpodAppComponent.tsx
@@ -26,6 +26,7 @@ export function IpodAppComponent({
 
   const {
     isXpTheme,
+    isMacOSTheme,
     menuBar,
     handleClose,
     toggleFullScreen,
@@ -45,7 +46,7 @@ export function IpodAppComponent({
         isForeground,
         appId: "ipod",
         interceptClose: true,
-        material: "transparent",
+        material: isMacOSTheme ? "brushedmetal" : "default",
         skipInitialSound,
         instanceId,
         onNavigateNext,

--- a/src/apps/ipod/components/ipod-app/IpodDeviceBody.tsx
+++ b/src/apps/ipod/components/ipod-app/IpodDeviceBody.tsx
@@ -21,7 +21,7 @@ export function IpodDeviceBody({ c }: IpodDeviceBodyProps) {
   return (
     <div
       ref={containerRef}
-      className="ipod-device-surface ipod-force-font flex flex-col items-center justify-center w-full h-full bg-gradient-to-b from-neutral-100/20 to-neutral-300/20 backdrop-blur-lg p-4 select-none"
+      className="ipod-device-surface ipod-force-font flex flex-col items-center justify-center w-full h-full p-4 select-none"
       style={{ position: "relative", overflow: "hidden", contain: "layout style paint" }}
     >
       <div

--- a/src/apps/ipod/hooks/useIpodLogic.ts
+++ b/src/apps/ipod/hooks/useIpodLogic.ts
@@ -5179,7 +5179,7 @@ export function useIpodLogic({
     }
   );
 
-  const { isWindowsTheme: isXpTheme } = useThemeFlags();
+  const { isWindowsTheme: isXpTheme, isMacOSTheme } = useThemeFlags();
 
   return {
     // Translation
@@ -5233,6 +5233,7 @@ export function useIpodLogic({
     toggleFullScreen,
     isMinimized,
     isXpTheme,
+    isMacOSTheme,
     isOffline,
 
     // Refs

--- a/src/styles/themes.css
+++ b/src/styles/themes.css
@@ -5530,21 +5530,6 @@
   filter: saturate(0.9) brightness(0.98) !important;
 }
 
-/* iPod's blurred device backdrop gets the same frosted glass surface as the
-   metal windows (replacing its neutral translucent gradient). */
-:root[data-os-theme="macosx"][data-os-aqua-material="glass"] .ipod-device-surface {
-  background: var(--os-color-window-bg) !important;
-  background-image: none !important;
-  backdrop-filter: blur(26px) saturate(185%) !important;
-  -webkit-backdrop-filter: blur(26px) saturate(185%) !important;
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.4);
-}
-
-:root[data-os-theme="macosx"][data-os-aqua-material="glass"][data-os-color-scheme="dark"]
-  .ipod-device-surface {
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.12);
-}
-
 /* --- Frosted menu bar ----------------------------------------------------- */
 /* Beef up the menubar blur and swap the white pinstripe gloss for a soft
    specular top highlight. */


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Changes the iPod app's container window frame to brushed metal (macOS Aqua) and removes the app's custom transparent + blurred backdrop. The iPod device body itself (white/black casing, screen, click wheel) is unchanged.

### Changes
- `IpodAppComponent.tsx`: window `material` is now `brushedmetal` on macOS (and `default` on Windows/System 7 themes), replacing the previous `transparent` material.
- `IpodDeviceBody.tsx`: removed the custom translucent gradient (`bg-gradient-to-b from-neutral-100/20 to-neutral-300/20`) and `backdrop-blur-lg` from the `.ipod-device-surface` container so the window's own background shows through cleanly.
- `themes.css`: removed the `.ipod-device-surface` Aqua-glass override that re-applied a frosted backdrop blur.
- `useIpodLogic.ts`: expose `isMacOSTheme` so the component can pick the right material.

## Walkthrough

<a href="https://cursor.com/agents/bc-019eaa32-117a-7555-9580-7bab991e37e5/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fipod_metal_window.mp4"><img src="https://cursor.com/artifacts/c/art-ccc72d26-a404-45b4-af9a-a625f5d80e2f" alt="ipod_metal_window.mp4" /></a>

iPod window now renders with an opaque brushed-metal frame and no desktop transparency/blur behind the device.

## Testing
- `bun run build` (tsc + vite) passes.
- Manual verification in the macOS Aqua theme: window frame renders as opaque brushed metal with no transparency/blur of the desktop behind the iPod device.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019eaa32-117a-7555-9580-7bab991e37e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019eaa32-117a-7555-9580-7bab991e37e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

