### PR TITLE
Frost toolbar buttons and search input in Aqua Glass theme

### DIFF
--- a/src/styles/themes.css
+++ b/src/styles/themes.css
@@ -5602,3 +5602,115 @@
   box-shadow: 0 10px 30px rgba(0, 0, 0, 0.55),
     inset 0 1px 0 rgba(255, 255, 255, 0.1) !important;
 }
+
+/* --- Frosted toolbar inset buttons --------------------------------------- */
+/* The brushed-metal toggle pills (`metal-inset-btn`) carry a hard two-tone
+   aluminum gradient with a sharp 49%/50% midline. In glass we swap that for a
+   single smooth, translucent gradient so the desktop blur reads through the
+   pill, matching the rest of the glass chrome. The blur lives on the group
+   (which clips its children) so the whole control shares one frosted backdrop. */
+:root[data-os-theme="macosx"][data-os-aqua-material="glass"]:not(
+    [data-os-color-scheme="dark"]
+  )
+  .metal-inset-btn-group {
+  background: rgba(255, 255, 255, 0.14);
+  backdrop-filter: blur(12px) saturate(180%);
+  -webkit-backdrop-filter: blur(12px) saturate(180%);
+  border: 1px solid rgba(255, 255, 255, 0.45);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.55),
+    inset 0 -1px 0 rgba(0, 0, 0, 0.06), 0 1px 2px rgba(0, 0, 0, 0.12);
+}
+
+:root[data-os-theme="macosx"][data-os-aqua-material="glass"]:not(
+    [data-os-color-scheme="dark"]
+  )
+  .metal-inset-btn {
+  color: #1c2330;
+  background: linear-gradient(
+    to bottom,
+    rgba(255, 255, 255, 0.55) 0%,
+    rgba(255, 255, 255, 0.26) 100%
+  );
+  border-right-color: rgba(255, 255, 255, 0.3);
+  text-shadow: 0 1px 0 rgba(255, 255, 255, 0.6);
+}
+
+:root[data-os-theme="macosx"][data-os-aqua-material="glass"]:not(
+    [data-os-color-scheme="dark"]
+  )
+  .metal-inset-btn:active,
+:root[data-os-theme="macosx"][data-os-aqua-material="glass"]:not(
+    [data-os-color-scheme="dark"]
+  )
+  .metal-inset-btn[data-state="on"] {
+  color: #0f2a52;
+  background: linear-gradient(
+    to bottom,
+    rgba(120, 168, 226, 0.6) 0%,
+    rgba(86, 138, 212, 0.45) 100%
+  );
+  text-shadow: 0 1px 0 rgba(255, 255, 255, 0.35);
+  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.12);
+}
+
+/* Dark glass: translucent graphite stack instead of the white frosted pill. */
+:root[data-os-theme="macosx"][data-os-aqua-material="glass"][data-os-color-scheme="dark"]
+  .metal-inset-btn-group {
+  background: rgba(255, 255, 255, 0.06);
+  backdrop-filter: blur(12px) saturate(180%);
+  -webkit-backdrop-filter: blur(12px) saturate(180%);
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.12),
+    0 1px 2px rgba(0, 0, 0, 0.4);
+}
+
+:root[data-os-theme="macosx"][data-os-aqua-material="glass"][data-os-color-scheme="dark"]
+  .metal-inset-btn {
+  color: rgba(255, 255, 255, 0.9);
+  background: linear-gradient(
+    to bottom,
+    rgba(255, 255, 255, 0.16) 0%,
+    rgba(255, 255, 255, 0.05) 100%
+  );
+  border-right-color: rgba(255, 255, 255, 0.1);
+  text-shadow: 0 1px 0 rgba(0, 0, 0, 0.5);
+}
+
+:root[data-os-theme="macosx"][data-os-aqua-material="glass"][data-os-color-scheme="dark"]
+  .metal-inset-btn:active,
+:root[data-os-theme="macosx"][data-os-aqua-material="glass"][data-os-color-scheme="dark"]
+  .metal-inset-btn[data-state="on"] {
+  color: #fff;
+  background: linear-gradient(
+    to bottom,
+    rgba(90, 140, 210, 0.55) 0%,
+    rgba(60, 108, 184, 0.42) 100%
+  );
+  text-shadow: 0 1px 0 rgba(0, 0, 0, 0.4);
+  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.35);
+}
+
+/* --- Frosted search field ------------------------------------------------- */
+/* `SearchInput` pins an opaque `bg-white` pill; in glass make it a semi-opaque
+   frosted well so the desktop blur shows through, like the other glass inputs. */
+:root[data-os-theme="macosx"][data-os-aqua-material="glass"]:not(
+    [data-os-color-scheme="dark"]
+  )
+  input[data-os-search-input="true"] {
+  background-color: rgba(255, 255, 255, 0.42) !important;
+  backdrop-filter: blur(12px) saturate(180%);
+  -webkit-backdrop-filter: blur(12px) saturate(180%);
+  border-color: rgba(255, 255, 255, 0.5) !important;
+  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.1),
+    0 1px 0 rgba(255, 255, 255, 0.4) !important;
+}
+
+:root[data-os-theme="macosx"][data-os-aqua-material="glass"][data-os-color-scheme="dark"]
+  input[data-os-search-input="true"] {
+  background-color: rgba(255, 255, 255, 0.1) !important;
+  backdrop-filter: blur(12px) saturate(180%);
+  -webkit-backdrop-filter: blur(12px) saturate(180%);
+  border-color: rgba(255, 255, 255, 0.16) !important;
+  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.4),
+    0 1px 0 rgba(255, 255, 255, 0.05) !important;
+}

--- a/src/styles/themes.css
+++ b/src/styles/themes.css
@@ -5714,3 +5714,40 @@
   box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.4),
     0 1px 0 rgba(255, 255, 255, 0.05) !important;
 }
+
+/* --- Fully-rounded toolbar pills ----------------------------------------- */
+/* In glass the inset toggle group reads as a fully-rounded pill rather than the
+   4px-radius brushed-metal slab. `overflow: hidden` on the group clips the
+   child buttons to the pill, so only the group needs the radius; the first/last
+   buttons get matching ends for browsers that honor per-button rounding. */
+:root[data-os-theme="macosx"][data-os-aqua-material="glass"] .metal-inset-btn-group {
+  border-radius: 999px;
+}
+
+:root[data-os-theme="macosx"][data-os-aqua-material="glass"]
+  .metal-inset-btn-group
+  .metal-inset-btn:first-child {
+  border-top-left-radius: 999px;
+  border-bottom-left-radius: 999px;
+}
+
+:root[data-os-theme="macosx"][data-os-aqua-material="glass"]
+  .metal-inset-btn-group
+  .metal-inset-btn:last-child {
+  border-top-right-radius: 999px;
+  border-bottom-right-radius: 999px;
+}
+
+/* --- Squircle corners ----------------------------------------------------- */
+/* Continuous (squircle) corners on the chrome that already carries a radius —
+   windows, the toolbar pills, and Aqua glossy buttons. `corner-shape` only
+   takes effect in browsers that support it (Chromium 139+); elsewhere the
+   existing border-radius is used unchanged, so this degrades gracefully. */
+:root[data-os-theme="macosx"][data-os-aqua-material="glass"] .window.window-material-glass,
+:root[data-os-theme="macosx"][data-os-aqua-material="glass"] .window-material-brushedmetal,
+:root[data-os-theme="macosx"][data-os-aqua-material="glass"] .metal-inset-btn-group,
+:root[data-os-theme="macosx"][data-os-aqua-material="glass"] .metal-inset-btn,
+:root[data-os-theme="macosx"][data-os-aqua-material="glass"] .aqua-button,
+:root[data-os-theme="macosx"][data-os-aqua-material="glass"] input[data-os-search-input="true"] {
+  corner-shape: squircle;
+}

--- a/src/styles/themes.css
+++ b/src/styles/themes.css
@@ -5668,8 +5668,7 @@
     )
   );
   text-shadow: 0 1px 1px rgba(0, 0, 0, 0.35);
-  box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.3),
-    inset 0 2px 3px 1px var(--os-accent-button-inner, rgba(0, 78, 187, 0.6));
+  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.18);
 }
 
 /* Dark glass: graphite translucent stack, same as the dark dropdown toggle. */
@@ -5716,8 +5715,7 @@
     )
   );
   text-shadow: 0 1px 1px rgba(0, 0, 0, 0.45);
-  box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.45),
-    inset 0 2px 3px 1px var(--os-accent-button-inner, rgba(0, 78, 187, 0.6));
+  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.28);
 }
 
 /* --- Frosted search field ------------------------------------------------- */

--- a/src/styles/themes.css
+++ b/src/styles/themes.css
@@ -5651,24 +5651,23 @@
     [data-os-color-scheme="dark"]
   )
   .metal-inset-btn[data-state="on"] {
-  /* Selected/pressed segment tints to the active accent (semi-transparent so
-     it stays glassy), with a white top gloss and accent-aware label color. */
+  /* Selected/pressed segment follows the active accent using the same recipe
+     as `.aqua-button.primary`: the ready-made semi-transparent accent gloss
+     gradient (`--os-accent-button-bg`, already glassy at 0.625 alpha) plus an
+     accent-tinted inner glow. Label color comes from the accent-aware
+     selection-text token so it stays legible on light or dark accents. */
   color: var(--os-color-selection-text, #fff);
-  background: linear-gradient(
-        to bottom,
-        rgba(255, 255, 255, 0.4) 0%,
-        rgba(255, 255, 255, 0.12) 55%,
-        rgba(255, 255, 255, 0) 100%
-      )
-      top / 100% 50% no-repeat,
+  background: var(
+    --os-accent-button-bg,
     linear-gradient(
-      to bottom,
-      color-mix(in srgb, var(--os-accent-color, #3a73d6) 82%, transparent),
-      color-mix(in srgb, var(--os-accent-color, #3a73d6) 58%, transparent)
-    );
-  text-shadow: 0 1px 1px rgba(0, 0, 0, 0.3);
-  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.2),
-    inset 0 1px 1px rgba(0, 0, 0, 0.12);
+      rgba(0, 65, 184, 0.625),
+      rgba(45, 115, 199, 0.625),
+      rgba(33, 160, 196, 0.625)
+    )
+  );
+  text-shadow: 0 1px 1px rgba(0, 0, 0, 0.35);
+  box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.3),
+    inset 0 2px 3px 1px var(--os-accent-button-inner, rgba(0, 78, 187, 0.6));
 }
 
 /* Dark glass: graphite translucent stack, same as the dark dropdown toggle. */
@@ -5706,20 +5705,17 @@
 :root[data-os-theme="macosx"][data-os-aqua-material="glass"][data-os-color-scheme="dark"]
   .metal-inset-btn[data-state="on"] {
   color: var(--os-color-selection-text, #fff);
-  background: linear-gradient(
-        to bottom,
-        rgba(255, 255, 255, 0.16) 0%,
-        rgba(255, 255, 255, 0.04) 55%,
-        rgba(255, 255, 255, 0) 100%
-      )
-      top / 100% 50% no-repeat,
+  background: var(
+    --os-accent-button-bg,
     linear-gradient(
-      to bottom,
-      color-mix(in srgb, var(--os-accent-color, #3a73d6) 80%, transparent),
-      color-mix(in srgb, var(--os-accent-color, #3a73d6) 55%, transparent)
-    );
-  text-shadow: 0 1px 1px rgba(0, 0, 0, 0.5);
-  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.45);
+      rgba(0, 65, 184, 0.625),
+      rgba(45, 115, 199, 0.625),
+      rgba(33, 160, 196, 0.625)
+    )
+  );
+  text-shadow: 0 1px 1px rgba(0, 0, 0, 0.45);
+  box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.45),
+    inset 0 2px 3px 1px var(--os-accent-button-inner, rgba(0, 78, 187, 0.6));
 }
 
 /* --- Frosted search field ------------------------------------------------- */
@@ -5768,6 +5764,10 @@
   .metal-inset-btn:last-child {
   border-top-right-radius: 999px;
   border-bottom-right-radius: 999px;
+  /* The glass `.metal-inset-btn` rule re-adds `border-right` (it beats the base
+     `:last-child` reset on specificity), leaving a 1px line between the last
+     segment's fill and the group's outer ring. Strip it back off. */
+  border-right: none;
 }
 
 /* --- Squircle corners ----------------------------------------------------- */

--- a/src/styles/themes.css
+++ b/src/styles/themes.css
@@ -5605,34 +5605,42 @@
 
 /* --- Frosted toolbar inset buttons --------------------------------------- */
 /* The brushed-metal toggle pills (`metal-inset-btn`) carry a hard two-tone
-   aluminum gradient with a sharp 49%/50% midline. In glass we swap that for a
-   single smooth, translucent gradient so the desktop blur reads through the
-   pill, matching the rest of the glass chrome. The blur lives on the group
-   (which clips its children) so the whole control shares one frosted backdrop. */
+   aluminum gradient with a sharp 49%/50% midline and a recessed dark well. In
+   glass we instead borrow the Aqua dropdown-toggle vocabulary
+   (`.os-select-trigger-macos` / `.aqua-select-btn`): a single smooth, semi-
+   transparent gray→white gradient capped with a top gloss, and a raised dark
+   hairline ring (`0 0 0 1px rgba(0,0,0,0.3)`) instead of a white border. The
+   0.625 alpha lets the desktop read through; the blur on the group keeps it
+   frosted. */
 :root[data-os-theme="macosx"][data-os-aqua-material="glass"]:not(
     [data-os-color-scheme="dark"]
   )
   .metal-inset-btn-group {
-  background: rgba(255, 255, 255, 0.14);
+  background: transparent;
   backdrop-filter: blur(12px) saturate(180%);
   -webkit-backdrop-filter: blur(12px) saturate(180%);
-  border: 1px solid rgba(255, 255, 255, 0.45);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.55),
-    inset 0 -1px 0 rgba(0, 0, 0, 0.06), 0 1px 2px rgba(0, 0, 0, 0.12);
+  border: none;
+  box-shadow: 0 2px 3px rgba(0, 0, 0, 0.2), 0 1px 1px rgba(0, 0, 0, 0.3),
+    0 0 0 1px rgba(0, 0, 0, 0.3);
 }
 
 :root[data-os-theme="macosx"][data-os-aqua-material="glass"]:not(
     [data-os-color-scheme="dark"]
   )
   .metal-inset-btn {
-  color: #1c2330;
+  color: #000;
+  /* Top gloss layered over a gray→white base, matching the Aqua select
+     trigger. Both layers are backgrounds so button icons paint above them. */
   background: linear-gradient(
-    to bottom,
-    rgba(255, 255, 255, 0.55) 0%,
-    rgba(255, 255, 255, 0.26) 100%
-  );
-  border-right-color: rgba(255, 255, 255, 0.3);
-  text-shadow: 0 1px 0 rgba(255, 255, 255, 0.6);
+        to bottom,
+        rgba(255, 255, 255, 0.85) 0%,
+        rgba(255, 255, 255, 0.35) 60%,
+        rgba(255, 255, 255, 0) 100%
+      )
+      top / 100% 50% no-repeat,
+    linear-gradient(rgba(160, 160, 160, 0.625), rgba(255, 255, 255, 0.625));
+  border-right: 1px solid rgba(0, 0, 0, 0.18);
+  text-shadow: 0 1px 0 rgba(255, 255, 255, 0.5);
 }
 
 :root[data-os-theme="macosx"][data-os-aqua-material="glass"]:not(
@@ -5643,37 +5651,44 @@
     [data-os-color-scheme="dark"]
   )
   .metal-inset-btn[data-state="on"] {
-  color: #0f2a52;
+  color: #000;
   background: linear-gradient(
-    to bottom,
-    rgba(120, 168, 226, 0.6) 0%,
-    rgba(86, 138, 212, 0.45) 100%
+    rgb(145 153 156 / 91%),
+    rgb(184 188 192 / 80%)
   );
-  text-shadow: 0 1px 0 rgba(255, 255, 255, 0.35);
-  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.12);
+  text-shadow: 0 1px 0 rgba(255, 255, 255, 0.4);
+  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.3),
+    inset 0 1px 1px rgba(0, 0, 0, 0.2);
 }
 
-/* Dark glass: translucent graphite stack instead of the white frosted pill. */
+/* Dark glass: graphite translucent stack, same as the dark dropdown toggle. */
 :root[data-os-theme="macosx"][data-os-aqua-material="glass"][data-os-color-scheme="dark"]
   .metal-inset-btn-group {
-  background: rgba(255, 255, 255, 0.06);
+  background: transparent;
   backdrop-filter: blur(12px) saturate(180%);
   -webkit-backdrop-filter: blur(12px) saturate(180%);
-  border: 1px solid rgba(255, 255, 255, 0.16);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.12),
-    0 1px 2px rgba(0, 0, 0, 0.4);
+  border: none;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.35), 0 1px 1px rgba(0, 0, 0, 0.35),
+    inset 0 0 0 0.5px rgba(255, 255, 255, 0.08),
+    inset 0 1px 0 rgba(255, 255, 255, 0.14);
 }
 
 :root[data-os-theme="macosx"][data-os-aqua-material="glass"][data-os-color-scheme="dark"]
   .metal-inset-btn {
-  color: rgba(255, 255, 255, 0.9);
+  color: rgba(255, 255, 255, 0.92);
   background: linear-gradient(
-    to bottom,
-    rgba(255, 255, 255, 0.16) 0%,
-    rgba(255, 255, 255, 0.05) 100%
-  );
-  border-right-color: rgba(255, 255, 255, 0.1);
-  text-shadow: 0 1px 0 rgba(0, 0, 0, 0.5);
+        to bottom,
+        rgba(255, 255, 255, 0.14),
+        rgba(255, 255, 255, 0.04)
+      )
+      top / 100% 50% no-repeat,
+    linear-gradient(
+      to bottom,
+      rgba(72, 72, 78, 0.78),
+      rgba(34, 34, 38, 0.78)
+    );
+  border-right: 1px solid rgba(0, 0, 0, 0.4);
+  text-shadow: 0 1px 0 rgba(0, 0, 0, 0.55);
 }
 
 :root[data-os-theme="macosx"][data-os-aqua-material="glass"][data-os-color-scheme="dark"]
@@ -5683,11 +5698,11 @@
   color: #fff;
   background: linear-gradient(
     to bottom,
-    rgba(90, 140, 210, 0.55) 0%,
-    rgba(60, 108, 184, 0.42) 100%
+    rgba(48, 48, 52, 0.9),
+    rgba(22, 22, 26, 0.9)
   );
-  text-shadow: 0 1px 0 rgba(0, 0, 0, 0.4);
-  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.35);
+  text-shadow: 0 1px 0 rgba(0, 0, 0, 0.55);
+  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.6);
 }
 
 /* --- Frosted search field ------------------------------------------------- */
@@ -5700,9 +5715,9 @@
   background-color: rgba(255, 255, 255, 0.42) !important;
   backdrop-filter: blur(12px) saturate(180%);
   -webkit-backdrop-filter: blur(12px) saturate(180%);
-  border-color: rgba(255, 255, 255, 0.5) !important;
-  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.1),
-    0 1px 0 rgba(255, 255, 255, 0.4) !important;
+  border-color: rgba(0, 0, 0, 0.28) !important;
+  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.12),
+    0 1px 0 rgba(255, 255, 255, 0.45) !important;
 }
 
 :root[data-os-theme="macosx"][data-os-aqua-material="glass"][data-os-color-scheme="dark"]

--- a/src/styles/themes.css
+++ b/src/styles/themes.css
@@ -5651,14 +5651,24 @@
     [data-os-color-scheme="dark"]
   )
   .metal-inset-btn[data-state="on"] {
-  color: #000;
+  /* Selected/pressed segment tints to the active accent (semi-transparent so
+     it stays glassy), with a white top gloss and accent-aware label color. */
+  color: var(--os-color-selection-text, #fff);
   background: linear-gradient(
-    rgb(145 153 156 / 91%),
-    rgb(184 188 192 / 80%)
-  );
-  text-shadow: 0 1px 0 rgba(255, 255, 255, 0.4);
-  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.3),
-    inset 0 1px 1px rgba(0, 0, 0, 0.2);
+        to bottom,
+        rgba(255, 255, 255, 0.4) 0%,
+        rgba(255, 255, 255, 0.12) 55%,
+        rgba(255, 255, 255, 0) 100%
+      )
+      top / 100% 50% no-repeat,
+    linear-gradient(
+      to bottom,
+      color-mix(in srgb, var(--os-accent-color, #3a73d6) 82%, transparent),
+      color-mix(in srgb, var(--os-accent-color, #3a73d6) 58%, transparent)
+    );
+  text-shadow: 0 1px 1px rgba(0, 0, 0, 0.3);
+  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.2),
+    inset 0 1px 1px rgba(0, 0, 0, 0.12);
 }
 
 /* Dark glass: graphite translucent stack, same as the dark dropdown toggle. */
@@ -5695,14 +5705,21 @@
   .metal-inset-btn:active,
 :root[data-os-theme="macosx"][data-os-aqua-material="glass"][data-os-color-scheme="dark"]
   .metal-inset-btn[data-state="on"] {
-  color: #fff;
+  color: var(--os-color-selection-text, #fff);
   background: linear-gradient(
-    to bottom,
-    rgba(48, 48, 52, 0.9),
-    rgba(22, 22, 26, 0.9)
-  );
-  text-shadow: 0 1px 0 rgba(0, 0, 0, 0.55);
-  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.6);
+        to bottom,
+        rgba(255, 255, 255, 0.16) 0%,
+        rgba(255, 255, 255, 0.04) 55%,
+        rgba(255, 255, 255, 0) 100%
+      )
+      top / 100% 50% no-repeat,
+    linear-gradient(
+      to bottom,
+      color-mix(in srgb, var(--os-accent-color, #3a73d6) 80%, transparent),
+      color-mix(in srgb, var(--os-accent-color, #3a73d6) 55%, transparent)
+    );
+  text-shadow: 0 1px 1px rgba(0, 0, 0, 0.5);
+  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.45);
 }
 
 /* --- Frosted search field ------------------------------------------------- */

--- a/src/styles/themes.css
+++ b/src/styles/themes.css
@@ -5653,22 +5653,25 @@
     [data-os-color-scheme="dark"]
   )
   .metal-inset-btn[data-state="on"] {
-  /* Selected/pressed segment follows the active accent using the same recipe
-     as `.aqua-button.primary`: the ready-made semi-transparent accent gloss
-     gradient (`--os-accent-button-bg`, already glassy at 0.625 alpha) plus an
-     accent-tinted inner glow. Label color comes from the accent-aware
-     selection-text token so it stays legible on light or dark accents. */
-  color: var(--os-color-selection-text, #fff);
-  background: var(
-    --os-accent-button-bg,
+  /* Selected segment keeps the glassy gloss/base but gets a light accent wash
+     layered between the top gloss and the gray base — a gentle tint rather
+     than a pressed/inset look. */
+  color: #000;
+  background: linear-gradient(
+        to bottom,
+        rgba(255, 255, 255, 0.55) 0%,
+        rgba(255, 255, 255, 0.18) 60%,
+        rgba(255, 255, 255, 0) 100%
+      )
+      top / 100% 50% no-repeat,
     linear-gradient(
-      rgba(0, 65, 184, 0.625),
-      rgba(45, 115, 199, 0.625),
-      rgba(33, 160, 196, 0.625)
-    )
-  );
-  text-shadow: 0 1px 1px rgba(0, 0, 0, 0.35);
-  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.18);
+      to bottom,
+      color-mix(in srgb, var(--os-accent-color, #3a73d6) 42%, transparent),
+      color-mix(in srgb, var(--os-accent-color, #3a73d6) 32%, transparent)
+    ),
+    linear-gradient(rgba(188, 188, 188, 0.34), rgba(255, 255, 255, 0.3));
+  text-shadow: 0 1px 0 rgba(255, 255, 255, 0.5);
+  box-shadow: none;
 }
 
 /* Dark glass: graphite translucent stack, same as the dark dropdown toggle. */
@@ -5705,17 +5708,26 @@
   .metal-inset-btn:active,
 :root[data-os-theme="macosx"][data-os-aqua-material="glass"][data-os-color-scheme="dark"]
   .metal-inset-btn[data-state="on"] {
-  color: var(--os-color-selection-text, #fff);
-  background: var(
-    --os-accent-button-bg,
+  color: rgba(255, 255, 255, 0.95);
+  background: linear-gradient(
+        to bottom,
+        rgba(255, 255, 255, 0.12) 0%,
+        rgba(255, 255, 255, 0.03) 60%,
+        rgba(255, 255, 255, 0) 100%
+      )
+      top / 100% 50% no-repeat,
     linear-gradient(
-      rgba(0, 65, 184, 0.625),
-      rgba(45, 115, 199, 0.625),
-      rgba(33, 160, 196, 0.625)
-    )
-  );
-  text-shadow: 0 1px 1px rgba(0, 0, 0, 0.45);
-  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.28);
+      to bottom,
+      color-mix(in srgb, var(--os-accent-color, #3a73d6) 55%, transparent),
+      color-mix(in srgb, var(--os-accent-color, #3a73d6) 42%, transparent)
+    ),
+    linear-gradient(
+      to bottom,
+      rgba(72, 72, 78, 0.42),
+      rgba(34, 34, 38, 0.42)
+    );
+  text-shadow: 0 1px 0 rgba(0, 0, 0, 0.5);
+  box-shadow: none;
 }
 
 /* --- Frosted search field ------------------------------------------------- */

--- a/src/styles/themes.css
+++ b/src/styles/themes.css
@@ -5630,15 +5630,17 @@
   .metal-inset-btn {
   color: #000;
   /* Top gloss layered over a gray→white base, matching the Aqua select
-     trigger. Both layers are backgrounds so button icons paint above them. */
+     trigger. Both layers are backgrounds so button icons paint above them.
+     Kept at a low alpha so the frosted desktop reads through the pill — the
+     group's blur does the rest. */
   background: linear-gradient(
         to bottom,
-        rgba(255, 255, 255, 0.85) 0%,
-        rgba(255, 255, 255, 0.35) 60%,
+        rgba(255, 255, 255, 0.55) 0%,
+        rgba(255, 255, 255, 0.18) 60%,
         rgba(255, 255, 255, 0) 100%
       )
       top / 100% 50% no-repeat,
-    linear-gradient(rgba(160, 160, 160, 0.625), rgba(255, 255, 255, 0.625));
+    linear-gradient(rgba(188, 188, 188, 0.34), rgba(255, 255, 255, 0.3));
   border-right: 1px solid rgba(0, 0, 0, 0.18);
   text-shadow: 0 1px 0 rgba(255, 255, 255, 0.5);
 }
@@ -5687,14 +5689,14 @@
   color: rgba(255, 255, 255, 0.92);
   background: linear-gradient(
         to bottom,
-        rgba(255, 255, 255, 0.14),
-        rgba(255, 255, 255, 0.04)
+        rgba(255, 255, 255, 0.12),
+        rgba(255, 255, 255, 0.03)
       )
       top / 100% 50% no-repeat,
     linear-gradient(
       to bottom,
-      rgba(72, 72, 78, 0.78),
-      rgba(34, 34, 38, 0.78)
+      rgba(72, 72, 78, 0.42),
+      rgba(34, 34, 38, 0.42)
     );
   border-right: 1px solid rgba(0, 0, 0, 0.4);
   text-shadow: 0 1px 0 rgba(0, 0, 0, 0.55);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Reworks the brushed-metal toolbar toggle pills (`.metal-inset-btn` / `.metal-inset-btn-group`) and the shared `SearchInput` in the **Aqua Glass** appearance (`data-os-aqua-material="glass"`) so they match the rest of the glass chrome. All changes are scoped to `[data-os-aqua-material="glass"]` in `src/styles/themes.css`; classic Aqua and the other themes are untouched.

- **Toolbar buttons** borrow the Aqua dropdown-toggle vocabulary: a smooth gray→white gloss gradient (no hard 49%/50% midline) capped with a top sheen, a raised **dark hairline ring** (`0 0 0 1px rgba(0,0,0,0.3)`) instead of a white border, and a frosted `backdrop-filter` blur on the group.
- **Translucent fill**: the gloss/base gradient alpha is kept low so the frosted desktop reads through the pills instead of looking like a solid chip.
- **Fully-rounded pills**: `border-radius: 999px`.
- **Squircle corners**: `corner-shape: squircle` on glass windows, toolbar pills, and Aqua buttons (graceful no-op where unsupported).
- **Search input** is a semi-opaque frosted well with `backdrop-filter` blur and a thin dark border instead of solid white.
- **Accent-aware selected state**: the toggled segment keeps its glassy gloss/base and gets a **light accent wash** layered between the gloss and base (a gentle tint, no pressed/inset look), driven by `--os-accent-color`.
- **Fixes** a 1px line on the last segment's right edge (the glass `border-right` was overriding the base `:last-child` reset).
- Both light and dark glass variants are covered.

## Testing

Captured with Playwright + Chrome against the dev server (`bun run dev:vite`, glass theme seeded via `localStorage`), verifying `data-os-aqua-material="glass"` applied and `--os-accent-color` resolved per accent.

Light (green accent) — lightly-tinted selected toggle:
![Glass toolbar (light)](https://cursor.com/artifacts/c/art-e25c3919-3ac5-4445-939d-8b1176a50ed4)

Dark (blue accent):
![Glass toolbar (dark)](https://cursor.com/artifacts/c/art-72287c4e-bedb-41d7-a5c2-081940f3a131)

Full desktop (light, green):
![Glass desktop (light, green)](https://cursor.com/artifacts/c/art-80b6d4b9-4844-4848-9ecc-880f846825df)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019eaa4e-2691-7ef1-b602-c8aa15ccf127"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019eaa4e-2691-7ef1-b602-c8aa15ccf127"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

