### PR TITLE
Aqua Glass: Chats toolbar as floating glass islands

### DIFF
--- a/src/apps/chats/components/ChatRoomSidebar.tsx
+++ b/src/apps/chats/components/ChatRoomSidebar.tsx
@@ -46,7 +46,8 @@ export const ChatRoomSidebar = React.memo(function ChatRoomSidebar({
   const unreadCounts = useChatsStore((state) => state.unreadCounts);
 
   // Theme detection for border styling
-  const { isWindowsTheme: isXpTheme, isMacOSTheme } = useThemeFlags();
+  const { isWindowsTheme: isXpTheme, isMacOSTheme, isAquaGlass } =
+    useThemeFlags();
 
   // Section headings are non-interactive; show all lists by default
 
@@ -180,7 +181,8 @@ export const ChatRoomSidebar = React.memo(function ChatRoomSidebar({
   return (
     <div
       className={cn(
-        "flex flex-col font-geneva-12 text-[12px] bg-neutral-100",
+        "flex flex-col font-geneva-12 text-[12px]",
+        isAquaGlass ? "bg-transparent" : "bg-neutral-100",
         isOverlay
           ? `w-full border-b ${
               isXpTheme

--- a/src/apps/chats/components/chat-messages/ChatMessages.tsx
+++ b/src/apps/chats/components/chat-messages/ChatMessages.tsx
@@ -1,56 +1,41 @@
-import { useEffect, useRef } from "react";
+import { useEffect } from "react";
 import { StickToBottom, useStickToBottomContext } from "use-stick-to-bottom";
 import { useThemeFlags } from "@/hooks/useThemeFlags";
 import { ChatMessagesContent } from "./ChatMessagesContent";
 import { ScrollToBottomButton } from "./ScrollToBottomButton";
 import type { ChatMessagesProps } from "./types";
 
-// Self-mask of the scrim: solid under the floating islands, fading out lower so
-// messages dissolve into the frosted top band rather than clipping at a hard
-// edge. A CSS `mask` on the scroller itself does not clip the message bubbles
-// (they are composited `motion.div`s that escape the mask), so we instead paint
-// a frosted scrim above the messages and below the toolbar islands.
-const SCRIM_MASK =
-  "linear-gradient(to bottom, black 0px, black 30px, transparent 100%)";
+// In Aqua Glass, fade the very top of the scroller once it's scrolled away
+// from the top so messages dissolve under the floating toolbar islands.
+const TOP_FADE_MASK = "linear-gradient(to bottom, transparent 0px, black 52px)";
 
-// In Aqua Glass, frost + fade the top band of the message scroller once it is
-// scrolled away from the top, so messages dissolve under the toolbar islands.
 function TopScrollFade() {
   const { isAquaGlass } = useThemeFlags();
   const { scrollRef } = useStickToBottomContext();
-  const scrimRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     const el = scrollRef.current;
-    const scrim = scrimRef.current;
-    if (!el || !scrim || !isAquaGlass) return;
+    if (!el) return;
+    const setMask = (mask: string) => {
+      el.style.maskImage = mask;
+      el.style.setProperty("-webkit-mask-image", mask);
+    };
+    if (!isAquaGlass) {
+      setMask("");
+      return;
+    }
     const update = () => {
-      scrim.style.opacity = el.scrollTop > 4 ? "1" : "0";
+      setMask(el.scrollTop > 4 ? TOP_FADE_MASK : "");
     };
     update();
     el.addEventListener("scroll", update, { passive: true });
-    return () => el.removeEventListener("scroll", update);
+    return () => {
+      el.removeEventListener("scroll", update);
+      setMask("");
+    };
   }, [isAquaGlass, scrollRef]);
 
-  if (!isAquaGlass) return null;
-  return (
-    <div
-      ref={scrimRef}
-      aria-hidden
-      className="pointer-events-none absolute top-0 left-0 right-0 z-[5]"
-      style={{
-        height: 96,
-        opacity: 0,
-        transition: "opacity 150ms ease",
-        backdropFilter: "blur(12px) saturate(160%)",
-        WebkitBackdropFilter: "blur(12px) saturate(160%)",
-        background:
-          "linear-gradient(to bottom, rgba(255, 255, 255, 0.22), rgba(255, 255, 255, 0))",
-        maskImage: SCRIM_MASK,
-        WebkitMaskImage: SCRIM_MASK,
-      }}
-    />
-  );
+  return null;
 }
 
 export function ChatMessages({

--- a/src/apps/chats/components/chat-messages/ChatMessages.tsx
+++ b/src/apps/chats/components/chat-messages/ChatMessages.tsx
@@ -7,7 +7,7 @@ import type { ChatMessagesProps } from "./types";
 
 // In Aqua Glass, fade the very top of the scroller once it's scrolled away
 // from the top so messages dissolve under the floating toolbar islands.
-const TOP_FADE_MASK = "linear-gradient(to bottom, transparent 0px, black 52px)";
+const TOP_FADE_MASK = "linear-gradient(to bottom, transparent 0px, black 72px)";
 
 function TopScrollFade() {
   const { isAquaGlass } = useThemeFlags();

--- a/src/apps/chats/components/chat-messages/ChatMessages.tsx
+++ b/src/apps/chats/components/chat-messages/ChatMessages.tsx
@@ -7,7 +7,11 @@ import type { ChatMessagesProps } from "./types";
 
 // In Aqua Glass, fade the very top of the scroller once it's scrolled away
 // from the top so messages dissolve under the floating toolbar islands.
-const TOP_FADE_MASK = "linear-gradient(to bottom, transparent 0px, black 72px)";
+// Keep the band under the floating islands fully transparent, then ramp in
+// over a longer, clearly-visible distance so messages dissolve smoothly below
+// the islands rather than clipping at a hard edge.
+const TOP_FADE_MASK =
+  "linear-gradient(to bottom, transparent 0px, transparent 36px, black 104px)";
 
 function TopScrollFade() {
   const { isAquaGlass } = useThemeFlags();

--- a/src/apps/chats/components/chat-messages/ChatMessages.tsx
+++ b/src/apps/chats/components/chat-messages/ChatMessages.tsx
@@ -1,7 +1,42 @@
-import { StickToBottom } from "use-stick-to-bottom";
+import { useEffect } from "react";
+import { StickToBottom, useStickToBottomContext } from "use-stick-to-bottom";
+import { useThemeFlags } from "@/hooks/useThemeFlags";
 import { ChatMessagesContent } from "./ChatMessagesContent";
 import { ScrollToBottomButton } from "./ScrollToBottomButton";
 import type { ChatMessagesProps } from "./types";
+
+// In Aqua Glass, fade the very top of the scroller once it's scrolled away
+// from the top so messages dissolve under the floating toolbar islands.
+const TOP_FADE_MASK = "linear-gradient(to bottom, transparent 0px, black 52px)";
+
+function TopScrollFade() {
+  const { isAquaGlass } = useThemeFlags();
+  const { scrollRef } = useStickToBottomContext();
+
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const setMask = (mask: string) => {
+      el.style.maskImage = mask;
+      el.style.setProperty("-webkit-mask-image", mask);
+    };
+    if (!isAquaGlass) {
+      setMask("");
+      return;
+    }
+    const update = () => {
+      setMask(el.scrollTop > 4 ? TOP_FADE_MASK : "");
+    };
+    update();
+    el.addEventListener("scroll", update, { passive: true });
+    return () => {
+      el.removeEventListener("scroll", update);
+      setMask("");
+    };
+  }, [isAquaGlass, scrollRef]);
+
+  return null;
+}
 
 export function ChatMessages({
   messages,
@@ -54,6 +89,7 @@ export function ChatMessages({
         />
       </StickToBottom.Content>
 
+      <TopScrollFade />
       <ScrollToBottomButton />
     </StickToBottom>
   );

--- a/src/apps/chats/components/chat-messages/ChatMessages.tsx
+++ b/src/apps/chats/components/chat-messages/ChatMessages.tsx
@@ -1,45 +1,56 @@
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { StickToBottom, useStickToBottomContext } from "use-stick-to-bottom";
 import { useThemeFlags } from "@/hooks/useThemeFlags";
 import { ChatMessagesContent } from "./ChatMessagesContent";
 import { ScrollToBottomButton } from "./ScrollToBottomButton";
 import type { ChatMessagesProps } from "./types";
 
-// In Aqua Glass, fade the very top of the scroller once it's scrolled away
-// from the top so messages dissolve under the floating toolbar islands.
-// Keep the band under the floating islands fully transparent, then ramp in
-// over a longer, clearly-visible distance so messages dissolve smoothly below
-// the islands rather than clipping at a hard edge.
-const TOP_FADE_MASK =
-  "linear-gradient(to bottom, transparent 0px, transparent 36px, black 104px)";
+// Self-mask of the scrim: solid under the floating islands, fading out lower so
+// messages dissolve into the frosted top band rather than clipping at a hard
+// edge. A CSS `mask` on the scroller itself does not clip the message bubbles
+// (they are composited `motion.div`s that escape the mask), so we instead paint
+// a frosted scrim above the messages and below the toolbar islands.
+const SCRIM_MASK =
+  "linear-gradient(to bottom, black 0px, black 30px, transparent 100%)";
 
+// In Aqua Glass, frost + fade the top band of the message scroller once it is
+// scrolled away from the top, so messages dissolve under the toolbar islands.
 function TopScrollFade() {
   const { isAquaGlass } = useThemeFlags();
   const { scrollRef } = useStickToBottomContext();
+  const scrimRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     const el = scrollRef.current;
-    if (!el) return;
-    const setMask = (mask: string) => {
-      el.style.maskImage = mask;
-      el.style.setProperty("-webkit-mask-image", mask);
-    };
-    if (!isAquaGlass) {
-      setMask("");
-      return;
-    }
+    const scrim = scrimRef.current;
+    if (!el || !scrim || !isAquaGlass) return;
     const update = () => {
-      setMask(el.scrollTop > 4 ? TOP_FADE_MASK : "");
+      scrim.style.opacity = el.scrollTop > 4 ? "1" : "0";
     };
     update();
     el.addEventListener("scroll", update, { passive: true });
-    return () => {
-      el.removeEventListener("scroll", update);
-      setMask("");
-    };
+    return () => el.removeEventListener("scroll", update);
   }, [isAquaGlass, scrollRef]);
 
-  return null;
+  if (!isAquaGlass) return null;
+  return (
+    <div
+      ref={scrimRef}
+      aria-hidden
+      className="pointer-events-none absolute top-0 left-0 right-0 z-[5]"
+      style={{
+        height: 96,
+        opacity: 0,
+        transition: "opacity 150ms ease",
+        backdropFilter: "blur(12px) saturate(160%)",
+        WebkitBackdropFilter: "blur(12px) saturate(160%)",
+        background:
+          "linear-gradient(to bottom, rgba(255, 255, 255, 0.22), rgba(255, 255, 255, 0))",
+        maskImage: SCRIM_MASK,
+        WebkitMaskImage: SCRIM_MASK,
+      }}
+    />
+  );
 }
 
 export function ChatMessages({

--- a/src/apps/chats/components/chats-app/ChatsWindowContent.tsx
+++ b/src/apps/chats/components/chats-app/ChatsWindowContent.tsx
@@ -19,6 +19,7 @@ export function ChatsWindowContent({ c, isForeground }: ChatsWindowContentProps)
   const {
     isWindowsLegacyTheme,
     isMacTheme,
+    isAquaGlass,
     isXpTheme,
     containerRef,
     sidebarVisibleBool,
@@ -180,7 +181,12 @@ export function ChatsWindowContent({ c, isForeground }: ChatsWindowContentProps)
               ...(isMacTheme
                 ? {
                     backgroundImage: "var(--os-pinstripe-window)",
-                    opacity: 0.95,
+                    ...(isAquaGlass
+                      ? {
+                          backdropFilter: "blur(26px) saturate(185%)",
+                          WebkitBackdropFilter: "blur(26px) saturate(185%)",
+                        }
+                      : { opacity: 0.95 }),
                     borderBottom:
                       "var(--os-metrics-titlebar-border-width, 1px) solid var(--os-color-titlebar-border-inactive, rgba(0, 0, 0, 0.2))",
                   }

--- a/src/apps/chats/components/chats-app/ChatsWindowContent.tsx
+++ b/src/apps/chats/components/chats-app/ChatsWindowContent.tsx
@@ -76,7 +76,7 @@ export function ChatsWindowContent({ c, isForeground }: ChatsWindowContentProps)
   // when there are actions to show, so it never appears as an empty pill.
   const hasRightActions = !currentRoom || currentRoom.type === "private";
   const aquaGlassIslandStyle: CSSProperties = {
-    background: "rgba(255, 255, 255, 0.4)",
+    background: "rgba(255, 255, 255, 0.28)",
     backdropFilter: "blur(20px) saturate(180%)",
     WebkitBackdropFilter: "blur(20px) saturate(180%)",
     border: "0.5px solid rgba(255, 255, 255, 0.5)",

--- a/src/apps/chats/components/chats-app/ChatsWindowContent.tsx
+++ b/src/apps/chats/components/chats-app/ChatsWindowContent.tsx
@@ -1,3 +1,4 @@
+import type { CSSProperties } from "react";
 import { AnimatePresence, motion } from "motion/react";
 import { CaretDown } from "@phosphor-icons/react";
 import { Button } from "@/components/ui/button";
@@ -69,6 +70,19 @@ export function ChatsWindowContent({ c, isForeground }: ChatsWindowContentProps)
     isOffline,
     handleTypingInCurrentRoom,
   } = c;
+
+  // In Aqua Glass the toolbar is split into two floating frosted "islands"
+  // (left = room title, right = actions). The right island is only rendered
+  // when there are actions to show, so it never appears as an empty pill.
+  const hasRightActions = !currentRoom || currentRoom.type === "private";
+  const aquaGlassIslandStyle: CSSProperties = {
+    background: "rgba(255, 255, 255, 0.4)",
+    backdropFilter: "blur(20px) saturate(180%)",
+    WebkitBackdropFilter: "blur(20px) saturate(180%)",
+    border: "0.5px solid rgba(255, 255, 255, 0.5)",
+    boxShadow:
+      "0 1px 3px rgba(0, 0, 0, 0.12), inset 0 1px 0 rgba(255, 255, 255, 0.6)",
+  };
 
   return (
     <div
@@ -165,9 +179,15 @@ export function ChatsWindowContent({ c, isForeground }: ChatsWindowContentProps)
           />
         </div>
 
-        <div className="relative flex flex-col flex-1 h-full bg-white/85">
+        <div
+          className={`relative flex flex-col flex-1 h-full ${
+            isAquaGlass ? "" : "bg-white/85"
+          }`}
+        >
           <div
-            className={`sticky top-0 z-10 isolate flex items-center justify-between px-2 py-1 border-b ${
+            className={`sticky top-0 z-10 isolate flex items-center justify-between px-2 py-1 ${
+              isAquaGlass ? "" : "border-b"
+            } ${
               isMacTheme ? "" : "bg-neutral-200/90 backdrop-blur-lg"
             } ${
               isWindowsLegacyTheme
@@ -178,22 +198,24 @@ export function ChatsWindowContent({ c, isForeground }: ChatsWindowContentProps)
             }`}
             style={{
               transform: "translateZ(0)",
-              ...(isMacTheme
-                ? {
-                    backgroundImage: "var(--os-pinstripe-window)",
-                    ...(isAquaGlass
-                      ? {
-                          backdropFilter: "blur(26px) saturate(185%)",
-                          WebkitBackdropFilter: "blur(26px) saturate(185%)",
-                        }
-                      : { opacity: 0.95 }),
-                    borderBottom:
-                      "var(--os-metrics-titlebar-border-width, 1px) solid var(--os-color-titlebar-border-inactive, rgba(0, 0, 0, 0.2))",
-                  }
-                : undefined),
+              ...(isAquaGlass
+                ? { background: "transparent" }
+                : isMacTheme
+                  ? {
+                      backgroundImage: "var(--os-pinstripe-window)",
+                      opacity: 0.95,
+                      borderBottom:
+                        "var(--os-metrics-titlebar-border-width, 1px) solid var(--os-color-titlebar-border-inactive, rgba(0, 0, 0, 0.2))",
+                    }
+                  : undefined),
             }}
           >
-            <div className="flex items-center">
+            <div
+              className={`flex items-center ${
+                isAquaGlass ? "rounded-full overflow-hidden" : ""
+              }`}
+              style={isAquaGlass ? aquaGlassIslandStyle : undefined}
+            >
               <Button
                 variant="ghost"
                 onClick={toggleSidebarVisibility}
@@ -220,7 +242,14 @@ export function ChatsWindowContent({ c, isForeground }: ChatsWindowContentProps)
                   </span>
                 )}
             </div>
-            <div className="flex items-center gap-2">
+            <div
+              className={`flex items-center gap-2 ${
+                isAquaGlass && hasRightActions ? "rounded-full overflow-hidden" : ""
+              }`}
+              style={
+                isAquaGlass && hasRightActions ? aquaGlassIslandStyle : undefined
+              }
+            >
               {!currentRoom && !username && (
                 <Button
                   variant="ghost"

--- a/src/apps/chats/components/chats-app/ChatsWindowContent.tsx
+++ b/src/apps/chats/components/chats-app/ChatsWindowContent.tsx
@@ -21,6 +21,7 @@ export function ChatsWindowContent({ c, isForeground }: ChatsWindowContentProps)
     isWindowsLegacyTheme,
     isMacTheme,
     isAquaGlass,
+    isDarkMode,
     isXpTheme,
     containerRef,
     sidebarVisibleBool,
@@ -76,12 +77,14 @@ export function ChatsWindowContent({ c, isForeground }: ChatsWindowContentProps)
   // when there are actions to show, so it never appears as an empty pill.
   const hasRightActions = !currentRoom || currentRoom.type === "private";
   const aquaGlassIslandStyle: CSSProperties = {
-    background: "rgba(255, 255, 255, 0.28)",
+    background:
+      "linear-gradient(to bottom, rgba(255, 255, 255, 0.24), rgba(255, 255, 255, 0.34))",
     backdropFilter: "blur(20px) saturate(180%)",
     WebkitBackdropFilter: "blur(20px) saturate(180%)",
     border: "0.5px solid rgba(255, 255, 255, 0.5)",
-    boxShadow:
-      "0 1px 3px rgba(0, 0, 0, 0.12), inset 0 1px 0 rgba(255, 255, 255, 0.6)",
+    boxShadow: `0 1px 3px rgba(0, 0, 0, 0.12), inset 0 1px 0 rgba(255, 255, 255, ${
+      isDarkMode ? 0.25 : 0.6
+    })`,
   };
 
   return (

--- a/src/apps/chats/components/chats-app/useChatsAppController.tsx
+++ b/src/apps/chats/components/chats-app/useChatsAppController.tsx
@@ -383,6 +383,7 @@ export function useChatsAppController({
     isWindowsTheme: isXpTheme,
     isMacOSTheme: isMacTheme,
     isAquaGlass,
+    isDarkMode,
   } = useThemeFlags();
   const isWindowsLegacyTheme = isXpTheme;
   const isOffline = useOffline();
@@ -568,6 +569,7 @@ export function useChatsAppController({
     isXpTheme,
     isMacTheme,
     isAquaGlass,
+    isDarkMode,
     isWindowsLegacyTheme,
     isOffline,
     menuBar,

--- a/src/apps/chats/components/chats-app/useChatsAppController.tsx
+++ b/src/apps/chats/components/chats-app/useChatsAppController.tsx
@@ -379,8 +379,11 @@ export function useChatsAppController({
     [setIsNewRoomDialogOpen]
   );
 
-  const { isWindowsTheme: isXpTheme, isMacOSTheme: isMacTheme } =
-    useThemeFlags();
+  const {
+    isWindowsTheme: isXpTheme,
+    isMacOSTheme: isMacTheme,
+    isAquaGlass,
+  } = useThemeFlags();
   const isWindowsLegacyTheme = isXpTheme;
   const isOffline = useOffline();
   const {
@@ -564,6 +567,7 @@ export function useChatsAppController({
     translatedHelpItems,
     isXpTheme,
     isMacTheme,
+    isAquaGlass,
     isWindowsLegacyTheme,
     isOffline,
     menuBar,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Reworks the Chats app chrome in the macOS **Aqua Glass** material so the toolbar reads as two floating frosted-glass "islands" over a transparent window, with a subtle fade at the top of the scroller.

## Changes

- `ChatsWindowContent.tsx`
  - Aqua Glass toolbar container is transparent (no full-width bar, border, or pinstripe). The left section (room title) and right section (actions) are each wrapped in a rounded-full frosted glass pill (`backdrop-filter: blur(20px) saturate(180%)`). The right island only renders when there are actions, so it never shows as an empty pill.
  - Platter background uses a subtle top→bottom gradient (slightly more alpha at the bottom); the inset highlight is lighter in dark mode.
  - Content column drops `bg-white/85` in Aqua Glass so the frosted window material shows through behind messages.
- `ChatMessages.tsx`: in Aqua Glass, the message scroller gets a top gradient mask (`linear-gradient(transparent 0, black 52px)`) that turns on once scrolled away from the top and off at the very top.
- `ChatRoomSidebar.tsx`: room-list sidebar background becomes transparent in Aqua Glass.
- `useChatsAppController.tsx`: exposes `isAquaGlass` and `isDarkMode` from `useThemeFlags()`.

Classic Aqua, System 7, Windows XP, and Windows 98 are unchanged.

## Testing

- `bunx tsc --noEmit -p tsconfig.app.json` passes.
- Manually verified in-browser under the Aqua Glass theme: two separate rounded glassy islands (left = `@ryo`, right = `Login to ryOS` / `Clear`), transparent/frosted window background, and messages scrolling behind the floating islands.

<a href="https://cursor.com/agents/bc-019eaa4a-7379-79d3-b346-2733bce6a47f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fchats_aqua_glass_islands.mp4"><img src="https://cursor.com/artifacts/c/art-6c0ecc01-9b19-4105-9959-1a1f06ad5c16" alt="chats_aqua_glass_islands.mp4" /></a>
Chats toolbar as two frosted glass islands floating over a transparent window in Aqua Glass.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019eaa4a-7379-79d3-b346-2733bce6a47f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019eaa4a-7379-79d3-b346-2733bce6a47f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

