### PR TITLE
Use dark outline for karaoke title cards

### DIFF
--- a/src/apps/karaoke/components/karaoke-lyrics-playback/title-card-styles.ts
+++ b/src/apps/karaoke/components/karaoke-lyrics-playback/title-card-styles.ts
@@ -113,7 +113,7 @@ export const TITLE_CARD_TITLE_SHADOW_BLEED_STYLE = {
 
 export const TITLE_CARD_ROUNDED_OUTLINE_COLOR = "#0066FF";
 export const TITLE_CARD_SERIF_OUTLINE_COLOR = "#CC0000";
-export const TITLE_CARD_COLORED_OUTLINE_STROKE = "0.12em #fff";
+export const TITLE_CARD_COLORED_OUTLINE_STROKE = "0.12em rgba(0, 0, 0, 0.85)";
 
 export function makeTitleCardColoredOutlineStyle(
   fillColor: string

--- a/tests/test-karaoke-title-card.test.ts
+++ b/tests/test-karaoke-title-card.test.ts
@@ -152,6 +152,8 @@ describe("karaoke title card timing", () => {
     const rounded = makeTitleCardColoredOutlineStyle(TITLE_CARD_ROUNDED_OUTLINE_COLOR);
     const serif = makeTitleCardColoredOutlineStyle(TITLE_CARD_SERIF_OUTLINE_COLOR);
 
+    expect(TITLE_CARD_COLORED_OUTLINE_STROKE).toContain("rgba(0, 0, 0");
+    expect(TITLE_CARD_COLORED_OUTLINE_STROKE).not.toContain("#fff");
     expect(rounded.color).toBe("#0066FF");
     expect(serif.color).toBe("#CC0000");
     expect(rounded.WebkitTextStroke).toBe(TITLE_CARD_COLORED_OUTLINE_STROKE);

--- a/tests/test-karaoke-title-card.test.ts
+++ b/tests/test-karaoke-title-card.test.ts
@@ -13,6 +13,7 @@ import {
   TITLE_CARD_SERIF_OUTLINE_COLOR,
   TITLE_CARD_TITLE_SHADOW_BLEED_STYLE,
 } from "@/apps/karaoke/components/karaoke-lyrics-playback/title-card-styles";
+import { OLD_SCHOOL_HIGHLIGHT_STROKE } from "@/apps/ipod/components/lyrics-display/constants";
 
 const readSource = (relativePath: string): string =>
   readFileSync(resolve(process.cwd(), relativePath), "utf-8");
@@ -160,5 +161,9 @@ describe("karaoke title card timing", () => {
     expect(serif.WebkitTextStroke).toBe(TITLE_CARD_COLORED_OUTLINE_STROKE);
     expect(rounded.textShadow).toBe("none");
     expect(serif.textShadow).toBe("none");
+  });
+
+  test("does not change actual lyric outline styling", () => {
+    expect(OLD_SCHOOL_HIGHLIGHT_STROKE).toContain("#fff");
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Switch karaoke title-card outline stroke styles from white to dark while leaving normal lyric rendering untouched.
- Add focused regression coverage for the title-card dark outline and the actual lyric white outline.

### Walkthrough
<a href="https://cursor.com/agents/bc-019eaa85-9c33-7cd8-93b6-001f93a051c7/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fkaraoke_title_card_dark_outline_walkthrough.webm"><img src="https://cursor.com/artifacts/c/art-6979b710-1930-4214-ac6d-f5c18cfa4224" alt="karaoke_title_card_dark_outline_walkthrough.webm" /></a>
![Karaoke title card dark outline](https://cursor.com/artifacts/c/art-6ab433d9-1624-4ede-a02a-d89ece28e6b3)

### Testing
- `bun test tests/test-karaoke-title-card.test.ts`
- Browser visual assertion with system Chrome: title-card stroke computed as `rgba(0, 0, 0, 0.85)` and actual lyric stroke computed as `rgb(255, 255, 255)`.
- `bun run build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019eaa85-9c33-7cd8-93b6-001f93a051c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019eaa85-9c33-7cd8-93b6-001f93a051c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

