### PR TITLE
Fix Aqua Glass search icon color

### DIFF
--- a/src/apps/contacts/components/contacts-app/ContactsToolbar.tsx
+++ b/src/apps/contacts/components/contacts-app/ContactsToolbar.tsx
@@ -86,7 +86,7 @@ export function ContactsToolbar({ c }: ContactsToolbarProps) {
               <MagnifyingGlass
                 size={13}
                 weight="bold"
-                className="pointer-events-none absolute left-2 top-1/2 -translate-y-1/2 text-black/45"
+                className="pointer-events-none absolute left-2 top-1/2 -translate-y-1/2 text-black/45 os-search-icon"
               />
               <input
                 value={searchQuery}
@@ -161,7 +161,7 @@ export function ContactsToolbar({ c }: ContactsToolbarProps) {
               <MagnifyingGlass
                 size={13}
                 weight="bold"
-                className="pointer-events-none absolute left-2 top-1/2 -translate-y-1/2 text-black/35"
+                className="pointer-events-none absolute left-2 top-1/2 -translate-y-1/2 text-black/35 os-search-icon"
               />
               <input
                 value={searchQuery}

--- a/src/apps/contacts/components/contacts-app/ContactsToolbar.tsx
+++ b/src/apps/contacts/components/contacts-app/ContactsToolbar.tsx
@@ -86,7 +86,7 @@ export function ContactsToolbar({ c }: ContactsToolbarProps) {
               <MagnifyingGlass
                 size={13}
                 weight="bold"
-                className="pointer-events-none absolute left-2 top-1/2 -translate-y-1/2 text-black/45 os-search-icon"
+                className="pointer-events-none absolute left-2 top-1/2 z-10 -translate-y-1/2 text-black/45 os-search-icon"
               />
               <input
                 value={searchQuery}
@@ -161,7 +161,7 @@ export function ContactsToolbar({ c }: ContactsToolbarProps) {
               <MagnifyingGlass
                 size={13}
                 weight="bold"
-                className="pointer-events-none absolute left-2 top-1/2 -translate-y-1/2 text-black/35 os-search-icon"
+                className="pointer-events-none absolute left-2 top-1/2 z-10 -translate-y-1/2 text-black/35 os-search-icon"
               />
               <input
                 value={searchQuery}

--- a/src/components/layout/desktop/DesktopCornerMask.tsx
+++ b/src/components/layout/desktop/DesktopCornerMask.tsx
@@ -1,7 +1,7 @@
 import type { CSSProperties } from "react";
 import { useThemeFlags } from "@/hooks/useThemeFlags";
 
-const CORNER_SIZE = 14;
+const CORNER_SIZE = 12;
 const CORNER_MASK_Z_INDEX = 10004;
 
 const sharedCornerStyle: CSSProperties = {

--- a/src/components/ui/search-input.tsx
+++ b/src/components/ui/search-input.tsx
@@ -33,7 +33,7 @@ export function SearchInput({
         size={13}
         weight="bold"
         className={cn(
-          "pointer-events-none absolute left-2 top-1/2 -translate-y-1/2 os-search-icon",
+          "pointer-events-none absolute left-2 top-1/2 z-10 -translate-y-1/2 os-search-icon",
           isMacOSTheme ? "text-black/45" : "text-black/35"
         )}
       />

--- a/src/styles/themes.css
+++ b/src/styles/themes.css
@@ -5754,6 +5754,28 @@
     0 1px 0 rgba(255, 255, 255, 0.05) !important;
 }
 
+:root[data-os-theme="macosx"][data-os-aqua-material="glass"]:not(
+    [data-os-color-scheme="dark"]
+  )
+  .os-search-icon {
+  color: color-mix(
+    in srgb,
+    var(--os-accent-color, #2765ca) 88%,
+    #0b1e44
+  ) !important;
+  filter: drop-shadow(0 1px 0 rgba(255, 255, 255, 0.55));
+}
+
+:root[data-os-theme="macosx"][data-os-aqua-material="glass"][data-os-color-scheme="dark"]
+  .os-search-icon {
+  color: color-mix(
+    in srgb,
+    var(--os-accent-color, #5b9dff) 78%,
+    #ffffff
+  ) !important;
+  filter: drop-shadow(0 1px 0 rgba(0, 0, 0, 0.55));
+}
+
 /* --- Fully-rounded toolbar pills ----------------------------------------- */
 /* In glass the inset toggle group reads as a fully-rounded pill rather than the
    4px-radius brushed-metal slab. `overflow: hidden` on the group clips the

--- a/src/styles/themes.css
+++ b/src/styles/themes.css
@@ -5754,24 +5754,6 @@
     0 1px 0 rgba(255, 255, 255, 0.05) !important;
 }
 
-:root[data-os-theme="macosx"][data-os-aqua-material="glass"]:not(
-    [data-os-color-scheme="dark"]
-  )
-  .os-search-icon {
-  color: var(--os-color-link, #2765ca) !important;
-  filter: drop-shadow(0 1px 0 rgba(255, 255, 255, 0.55));
-}
-
-:root[data-os-theme="macosx"][data-os-aqua-material="glass"][data-os-color-scheme="dark"]
-  .os-search-icon {
-  color: color-mix(
-    in srgb,
-    var(--os-accent-color, #5b9dff) 88%,
-    #ffffff
-  ) !important;
-  filter: drop-shadow(0 1px 0 rgba(0, 0, 0, 0.55));
-}
-
 /* --- Fully-rounded toolbar pills ----------------------------------------- */
 /* In glass the inset toggle group reads as a fully-rounded pill rather than the
    4px-radius brushed-metal slab. `overflow: hidden` on the group clips the

--- a/src/styles/themes.css
+++ b/src/styles/themes.css
@@ -5488,7 +5488,7 @@
   background-color: var(--os-color-window-bg);
   backdrop-filter: blur(26px) saturate(185%);
   -webkit-backdrop-filter: blur(26px) saturate(185%);
-  border-radius: 14px !important;
+  border-radius: 12px !important;
   box-shadow: var(--os-window-shadow),
     inset 0 1px 0 rgba(255, 255, 255, 0.4);
 }
@@ -5517,7 +5517,7 @@
   .window-material-brushedmetal {
   backdrop-filter: blur(26px) saturate(185%);
   -webkit-backdrop-filter: blur(26px) saturate(185%);
-  border-radius: 14px !important;
+  border-radius: 12px !important;
 }
 
 :root[data-os-theme="macosx"][data-os-aqua-material="glass"]

--- a/src/styles/themes.css
+++ b/src/styles/themes.css
@@ -5488,6 +5488,7 @@
   background-color: var(--os-color-window-bg);
   backdrop-filter: blur(26px) saturate(185%);
   -webkit-backdrop-filter: blur(26px) saturate(185%);
+  border-radius: 14px !important;
   box-shadow: var(--os-window-shadow),
     inset 0 1px 0 rgba(255, 255, 255, 0.4);
 }
@@ -5516,6 +5517,7 @@
   .window-material-brushedmetal {
   backdrop-filter: blur(26px) saturate(185%);
   -webkit-backdrop-filter: blur(26px) saturate(185%);
+  border-radius: 14px !important;
 }
 
 :root[data-os-theme="macosx"][data-os-aqua-material="glass"]
@@ -5781,16 +5783,3 @@
   border-right: none;
 }
 
-/* --- Squircle corners ----------------------------------------------------- */
-/* Continuous (squircle) corners on the chrome that already carries a radius —
-   windows, the toolbar pills, and Aqua glossy buttons. `corner-shape` only
-   takes effect in browsers that support it (Chromium 139+); elsewhere the
-   existing border-radius is used unchanged, so this degrades gracefully. */
-:root[data-os-theme="macosx"][data-os-aqua-material="glass"] .window.window-material-glass,
-:root[data-os-theme="macosx"][data-os-aqua-material="glass"] .window-material-brushedmetal,
-:root[data-os-theme="macosx"][data-os-aqua-material="glass"] .metal-inset-btn-group,
-:root[data-os-theme="macosx"][data-os-aqua-material="glass"] .metal-inset-btn,
-:root[data-os-theme="macosx"][data-os-aqua-material="glass"] .aqua-button,
-:root[data-os-theme="macosx"][data-os-aqua-material="glass"] input[data-os-search-input="true"] {
-  corner-shape: squircle;
-}

--- a/src/styles/themes.css
+++ b/src/styles/themes.css
@@ -5758,11 +5758,7 @@
     [data-os-color-scheme="dark"]
   )
   .os-search-icon {
-  color: color-mix(
-    in srgb,
-    var(--os-accent-color, #2765ca) 88%,
-    #0b1e44
-  ) !important;
+  color: var(--os-accent-color, #2765ca) !important;
   filter: drop-shadow(0 1px 0 rgba(255, 255, 255, 0.55));
 }
 
@@ -5770,7 +5766,7 @@
   .os-search-icon {
   color: color-mix(
     in srgb,
-    var(--os-accent-color, #5b9dff) 78%,
+    var(--os-accent-color, #5b9dff) 88%,
     #ffffff
   ) !important;
   filter: drop-shadow(0 1px 0 rgba(0, 0, 0, 0.55));

--- a/src/styles/themes.css
+++ b/src/styles/themes.css
@@ -5758,7 +5758,7 @@
     [data-os-color-scheme="dark"]
   )
   .os-search-icon {
-  color: var(--os-accent-color, #2765ca) !important;
+  color: var(--os-color-link, #2765ca) !important;
   filter: drop-shadow(0 1px 0 rgba(255, 255, 255, 0.55));
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Keep Aqua Glass search fields frosted while letting their magnifying-glass icons inherit the same icon color as normal Aqua.
- Raise search icons above the input surface so Maps and other search fields do not visually lose the glyph.
- Remove Aqua Glass squircle styling entirely and use 12px window radii for regular Glass and brushed-metal Glass windows.
- Match the desktop screen corner masks to the 12px Glass corner radius.

### Walkthrough
![Aqua Glass 12px window and screen corner radius](https://cursor.com/artifacts/c/art-662b2939-b24a-4a3d-a0ed-fee2ff3b28bf)

### Testing
- `bun run build` passed; Vite emitted pre-existing CSS/dynamic-import warnings only.
- Headless Chrome verification opened Finder in normal Aqua and Aqua Glass and confirmed both search icons compute to `oklab(0 0 0 / 0.45)`.
- Headless Chrome verification opened Maps in Aqua Glass and confirmed the Maps search icon is displayed with `z-index: 10`, `display: block`, and color `oklab(0 0 0 / 0.45)`.
- `rg "corner-shape|cornerShape" /workspace` returned no matches, confirming no source-level corner-shape styling remains.
- Headless Chrome verification confirmed regular Glass and brushed-metal Glass windows compute to `border-radius: 12px`, and all four desktop corner masks render at `12px` by `12px` with 12px radial-gradient stops.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ead27-440f-7536-b916-154ca4b75428"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ead27-440f-7536-b916-154ca4b75428"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

