### PR TITLE
fix(cloud-sync): propagate Aqua Glass → classic revert

### DIFF
--- a/src/utils/cloudSyncSettingsMerge.ts
+++ b/src/utils/cloudSyncSettingsMerge.ts
@@ -177,11 +177,13 @@ export function getSectionPayloadForSettingsPatch(
         data.themeDarkMode && Object.keys(data.themeDarkMode).length > 0;
       const hasAccent =
         data.themeAccent && Object.keys(data.themeAccent).length > 0;
-      // Only send the material when it deviates from the default so older
-      // clients keep receiving the plain-string payload they understand.
-      const hasAquaMaterial =
-        data.themeAquaMaterial !== undefined &&
-        data.themeAquaMaterial !== "classic";
+      // Always send the material when it's set (including the `"classic"`
+      // default) so reverting Aqua Glass → classic actually propagates. If we
+      // dropped the field for `"classic"`, `applySettingsRedisPatch` would
+      // never reset a remote that's still `"glass"`, and the stale glass value
+      // would keep syncing back to every device. (Mirrors `systemFont`, which
+      // also sends its default so it can be reverted.)
+      const hasAquaMaterial = data.themeAquaMaterial !== undefined;
       const hasSystemFont = data.themeSystemFont !== undefined;
       if (hasDarkMode || hasAccent || hasAquaMaterial || hasSystemFont) {
         return {

--- a/tests/test-cloud-sync-utils.test.ts
+++ b/tests/test-cloud-sync-utils.test.ts
@@ -836,6 +836,92 @@ describe("cloud sync shared helpers", () => {
     expect(out.language).toBe("en");
   });
 
+  test("reverting Aqua Glass → classic propagates through patch upload", () => {
+    const t1 = "2026-01-01T00:00:00.000Z";
+    const t2 = "2026-01-06T00:00:00.000Z";
+    const sectionUpdatedAt = {
+      theme: t1,
+      language: t1,
+      display: t1,
+      audio: t1,
+      aiModel: t1,
+      ipod: t1,
+      dock: t1,
+      dashboard: t1,
+    };
+    const base = {
+      theme: "macosx",
+      language: "en",
+      languageInitialized: true,
+      aiModel: null,
+      display: {
+        displayMode: "color",
+        shaderEffectEnabled: false,
+        selectedShaderType: "",
+        currentWallpaper: "",
+        screenSaverEnabled: false,
+        screenSaverType: "",
+        screenSaverIdleTime: 5,
+        debugMode: false,
+        htmlPreviewSplit: false,
+      },
+      audio: {
+        masterVolume: 0.5,
+        uiVolume: 0.4,
+        chatSynthVolume: 0.3,
+        speechVolume: 0.2,
+        ipodVolume: 0.1,
+        uiSoundsEnabled: true,
+        terminalSoundsEnabled: true,
+        typingSynthEnabled: false,
+        speechEnabled: false,
+        keepTalkingEnabled: false,
+        ttsModel: null,
+        ttsVoice: null,
+        synthPreset: "",
+      },
+      ipod: {
+        displayMode: "browser" as const,
+        showLyrics: true,
+        lyricsAlignment: "center" as const,
+        lyricsFont: "default" as const,
+        romanization: {},
+        lyricsTranslationLanguage: null,
+        theme: "classic" as const,
+        lcdFilterOn: false,
+      },
+      dock: { pinnedItems: [], scale: 1, hiding: false, magnification: false },
+      dashboard: { widgets: [] },
+    };
+    // Remote still has Aqua Glass enabled at the older timestamp.
+    const remote = {
+      ...base,
+      themeAquaMaterial: "glass" as const,
+      sectionUpdatedAt: { ...sectionUpdatedAt },
+    };
+    // Local has just reverted to classic Aqua (newer timestamp).
+    const local = {
+      ...base,
+      themeAquaMaterial: "classic" as const,
+      sectionUpdatedAt: { ...sectionUpdatedAt, theme: t2 },
+    };
+
+    // The revert must be detected as a dirty section to upload.
+    expect(getSettingsSectionsToPatchUpload(local, remote)).toEqual(["theme"]);
+
+    const patch = buildSettingsRedisPatch(local, ["theme"], t1);
+    expect(patch).not.toBeNull();
+    // The classic default must be carried in the patch payload.
+    expect((patch!.sections.theme as { aquaMaterial?: string }).aquaMaterial).toBe(
+      "classic"
+    );
+
+    // Applying the patch must reset the remote back to classic (no stale glass).
+    const out = applySettingsRedisPatch(remote, patch!);
+    expect(out.themeAquaMaterial).toBe("classic");
+    expect(out.sectionUpdatedAt?.theme).toBe(t2);
+  });
+
   test("merges settings per store so newer local and remote sections both survive", () => {
     const merged = mergeSettingsSnapshotData(
       {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

After switching the Mac OS X chrome to **Aqua Glass** and then switching back to classic Aqua in Control Panels, cloud sync would keep syncing the glass material as enabled. The revert never stuck across devices — glass would come back on the next sync.

## Root cause

`getSectionPayloadForSettingsPatch` (in `src/utils/cloudSyncSettingsMerge.ts`) encoded the `theme` section's `themeAquaMaterial` only when it **deviated** from the `"classic"` default:

```ts
const hasAquaMaterial =
  data.themeAquaMaterial !== undefined &&
  data.themeAquaMaterial !== "classic";
```

So reverting glass → classic dropped `aquaMaterial` from the patch payload entirely. `applySettingsRedisPatch` only resets the field when it's present, so a remote still set to `"glass"` was never reset, and that stale value kept re-syncing to every device.

This is the same asymmetry that `themeSystemFont` already avoids — it sends its default (`"theme-default"`) so it can be reverted.

## Fix

Always include `themeAquaMaterial` in the patch payload when it's set (including the `"classic"` default), mirroring `systemFont`. In practice the theme section is already always sent as an object (because `systemFont` is always present), so there is no payload/back-compat regression for older clients.

## Testing

- Added a regression test `reverting Aqua Glass → classic propagates through patch upload` that asserts the patch carries `aquaMaterial: "classic"` and that `applySettingsRedisPatch` resets a remote still on `"glass"`. Confirmed it fails before the fix (`Received: undefined`) and passes after.
- ✅ `bun test tests/test-cloud-sync-utils.test.ts` (41 pass)
- ✅ `bun run test:unit` (269 pass)
- ✅ `bunx tsc --noEmit`
- ✅ `bunx eslint` on changed files

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019eaea1-17b4-7b2a-b447-ff7546f2ff9d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019eaea1-17b4-7b2a-b447-ff7546f2ff9d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

