### PR TITLE
Aqua Glass: restyle Chats toolbar platter to match frosted metal buttons

### DIFF
--- a/src/apps/chats/components/chats-app/ChatsWindowContent.tsx
+++ b/src/apps/chats/components/chats-app/ChatsWindowContent.tsx
@@ -76,15 +76,19 @@ export function ChatsWindowContent({ c, isForeground }: ChatsWindowContentProps)
   // (left = room title, right = actions). The right island is only rendered
   // when there are actions to show, so it never appears as an empty pill.
   const hasRightActions = !currentRoom || currentRoom.type === "private";
+  // Glossy translucent "platter" that echoes the .aqua-button lozenge: a bright
+  // glassy shine across the top half, a near-clear body (so the desktop shows
+  // through), and a faint bottom glow. The layered gradient lives in the
+  // background so it always paints behind the button labels (no z-index fuss).
   const aquaGlassIslandStyle: CSSProperties = {
     background:
-      "linear-gradient(to bottom, rgba(255, 255, 255, 0.24), rgba(255, 255, 255, 0.34))",
+      "linear-gradient(to bottom, rgba(255, 255, 255, 0.5) 0%, rgba(255, 255, 255, 0.16) 45%, rgba(255, 255, 255, 0.05) 55%, rgba(255, 255, 255, 0.18) 100%)",
     backdropFilter: "blur(20px) saturate(180%)",
     WebkitBackdropFilter: "blur(20px) saturate(180%)",
     border: "0.5px solid rgba(255, 255, 255, 0.5)",
-    boxShadow: `0 1px 3px rgba(0, 0, 0, 0.12), inset 0 1px 0 rgba(255, 255, 255, ${
-      isDarkMode ? 0.25 : 0.6
-    })`,
+    boxShadow: `0 2px 4px rgba(0, 0, 0, 0.15), 0 1px 1px rgba(0, 0, 0, 0.18), inset 0 1px 1px rgba(255, 255, 255, ${
+      isDarkMode ? 0.4 : 0.85
+    }), inset 0 -1px 2px rgba(0, 0, 0, 0.07)`,
   };
 
   return (

--- a/src/apps/chats/components/chats-app/ChatsWindowContent.tsx
+++ b/src/apps/chats/components/chats-app/ChatsWindowContent.tsx
@@ -76,19 +76,24 @@ export function ChatsWindowContent({ c, isForeground }: ChatsWindowContentProps)
   // (left = room title, right = actions). The right island is only rendered
   // when there are actions to show, so it never appears as an empty pill.
   const hasRightActions = !currentRoom || currentRoom.type === "private";
-  // Glossy translucent "platter" that echoes the .aqua-button lozenge: a bright
-  // glassy shine across the top half, a near-clear body (so the desktop shows
-  // through), and a faint bottom glow. The layered gradient lives in the
-  // background so it always paints behind the button labels (no z-index fuss).
+  // The "platter" islands borrow the Aqua Glass frosted metal-button vocabulary
+  // (`.metal-inset-btn` group + button): a top gloss layered over a smooth
+  // gray→white base, low alpha so the frosted desktop reads through, capped by a
+  // raised dark hairline ring (light) / soft inner highlight (dark) instead of a
+  // white border. Both fills live in the background so labels paint above them.
   const aquaGlassIslandStyle: CSSProperties = {
-    background:
-      "linear-gradient(to bottom, rgba(255, 255, 255, 0.5) 0%, rgba(255, 255, 255, 0.16) 45%, rgba(255, 255, 255, 0.05) 55%, rgba(255, 255, 255, 0.18) 100%)",
-    backdropFilter: "blur(20px) saturate(180%)",
-    WebkitBackdropFilter: "blur(20px) saturate(180%)",
-    border: "0.5px solid rgba(255, 255, 255, 0.5)",
-    boxShadow: `0 2px 4px rgba(0, 0, 0, 0.15), 0 1px 1px rgba(0, 0, 0, 0.18), inset 0 1px 1px rgba(255, 255, 255, ${
-      isDarkMode ? 0.4 : 0.85
-    }), inset 0 -1px 2px rgba(0, 0, 0, 0.07)`,
+    background: isDarkMode
+      ? "linear-gradient(to bottom, rgba(255, 255, 255, 0.12), rgba(255, 255, 255, 0.03) 60%, rgba(255, 255, 255, 0) 100%) top / 100% 50% no-repeat, linear-gradient(to bottom, rgba(72, 72, 78, 0.42), rgba(34, 34, 38, 0.42))"
+      : "linear-gradient(to bottom, rgba(255, 255, 255, 0.55) 0%, rgba(255, 255, 255, 0.18) 60%, rgba(255, 255, 255, 0) 100%) top / 100% 50% no-repeat, linear-gradient(rgba(188, 188, 188, 0.34), rgba(255, 255, 255, 0.3))",
+    backdropFilter: "blur(12px) saturate(180%)",
+    WebkitBackdropFilter: "blur(12px) saturate(180%)",
+    border: "none",
+    textShadow: isDarkMode
+      ? "0 1px 0 rgba(0, 0, 0, 0.55)"
+      : "0 1px 0 rgba(255, 255, 255, 0.5)",
+    boxShadow: isDarkMode
+      ? "0 2px 4px rgba(0, 0, 0, 0.35), 0 1px 1px rgba(0, 0, 0, 0.35), inset 0 0 0 0.5px rgba(255, 255, 255, 0.08), inset 0 1px 0 rgba(255, 255, 255, 0.14)"
+      : "0 2px 3px rgba(0, 0, 0, 0.2), 0 1px 1px rgba(0, 0, 0, 0.3), 0 0 0 1px rgba(0, 0, 0, 0.3)",
   };
 
   return (


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Restyles the Aqua Glass Chats toolbar "platter" (the floating glass islands holding the room title and actions) so it matches the existing frosted **metal-button-in-glass** vocabulary (`.metal-inset-btn` group + button) rather than the classic glossy `.aqua-button` lozenge.

The platter (`aquaGlassIslandStyle` in `ChatsWindowContent.tsx`) now uses:
- A two-layer background: a top gloss (white, top half) over a smooth gray→white base, at low alpha so the frosted desktop reads through (the `blur(12px) saturate(180%)` group blur does the rest).
- A raised dark hairline ring (`0 0 0 1px rgba(0,0,0,0.3)`) in light mode and a soft inner highlight in dark mode, instead of a white border.
- A subtle label text-shadow matching the metal buttons.

Both fills live in the `background` so the button labels always paint above them.

## Walkthrough

Light mode — the `@ryo` pill renders as a frosted gray→white metal button with a thin dark outline ring; text stays legible:

![Aqua Glass chat platter, light mode (zoom)](https://cursor.com/artifacts/c/art-e4e28839-08d1-4a8b-8df7-5c921488b019)

Dark mode — graphite translucent pill with a soft top highlight:

![Aqua Glass chat platter, dark mode (zoom)](https://cursor.com/artifacts/c/art-142cd6a6-ebad-44ad-b7b9-bf10f3cc2107)

Full window context (Aqua Glass, purple accent):

![Chats app in Aqua Glass showing the toolbar platters](https://cursor.com/artifacts/c/art-71efc547-6241-4298-a023-14f7eeee4981)

## Testing

- `bun run build` passes.
- Verified in the running app (Aqua Glass enabled) in light and dark mode — see Walkthrough.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019eaf58-2946-7e4f-8a56-8378109fa4c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019eaf58-2946-7e4f-8a56-8378109fa4c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

