### PR TITLE
Aqua Glass: more opaque, subtly accent-tinted glass surfaces

### DIFF
--- a/src/styles/themes.css
+++ b/src/styles/themes.css
@@ -5382,28 +5382,28 @@
      the continuous frosted pane — keep it opaque enough to stay legible. */
   --os-color-window-bg: color-mix(
     in srgb,
-    var(--os-accent-color, #3a73d6) 5%,
-    rgba(243, 246, 251, 0.7)
+    var(--os-accent-color, #3a73d6) 8%,
+    rgba(243, 246, 251, 0.8)
   );
   --os-color-panel-bg: color-mix(
     in srgb,
-    var(--os-accent-color, #3a73d6) 5%,
-    rgba(243, 246, 251, 0.7)
+    var(--os-accent-color, #3a73d6) 8%,
+    rgba(243, 246, 251, 0.8)
   );
   --os-color-menubar-bg: color-mix(
     in srgb,
-    var(--os-accent-color, #3a73d6) 5%,
-    rgba(250, 251, 253, 0.64)
+    var(--os-accent-color, #3a73d6) 8%,
+    rgba(250, 251, 253, 0.74)
   );
   --os-color-menubar-surface: color-mix(
     in srgb,
-    var(--os-accent-color, #3a73d6) 5%,
-    rgba(250, 251, 253, 0.64)
+    var(--os-accent-color, #3a73d6) 8%,
+    rgba(250, 251, 253, 0.74)
   );
   --os-color-dock-surface: color-mix(
     in srgb,
-    var(--os-accent-color, #3a73d6) 5%,
-    rgba(250, 251, 253, 0.58)
+    var(--os-accent-color, #3a73d6) 8%,
+    rgba(250, 251, 253, 0.68)
   );
   --os-color-dock-shadow: 0 8px 30px rgba(0, 0, 0, 0.22);
 
@@ -5438,8 +5438,8 @@
      rather than `none`. The menubar pattern goes flat. */
   --os-pinstripe-window: linear-gradient(
     to bottom,
-    color-mix(in srgb, var(--os-accent-color, #3a73d6) 5%, rgba(252, 253, 255, 0.7)),
-    color-mix(in srgb, var(--os-accent-color, #3a73d6) 5%, rgba(244, 247, 251, 0.64))
+    color-mix(in srgb, var(--os-accent-color, #3a73d6) 8%, rgba(252, 253, 255, 0.8)),
+    color-mix(in srgb, var(--os-accent-color, #3a73d6) 8%, rgba(244, 247, 251, 0.74))
   );
   --os-pinstripe-menubar: none;
   /* Specular top sheen on the titlebar instead of the pinstripe gloss. */
@@ -5455,28 +5455,28 @@
 :root[data-os-theme="macosx"][data-os-aqua-material="glass"][data-os-color-scheme="dark"] {
   --os-color-window-bg: color-mix(
     in srgb,
-    var(--os-accent-color, #3a73d6) 6%,
-    rgba(38, 40, 46, 0.7)
+    var(--os-accent-color, #3a73d6) 9%,
+    rgba(38, 40, 46, 0.8)
   );
   --os-color-panel-bg: color-mix(
     in srgb,
-    var(--os-accent-color, #3a73d6) 6%,
-    rgba(38, 40, 46, 0.7)
+    var(--os-accent-color, #3a73d6) 9%,
+    rgba(38, 40, 46, 0.8)
   );
   --os-color-menubar-bg: color-mix(
     in srgb,
-    var(--os-accent-color, #3a73d6) 6%,
-    rgba(26, 27, 31, 0.66)
+    var(--os-accent-color, #3a73d6) 9%,
+    rgba(26, 27, 31, 0.76)
   );
   --os-color-menubar-surface: color-mix(
     in srgb,
-    var(--os-accent-color, #3a73d6) 6%,
-    rgba(26, 27, 31, 0.66)
+    var(--os-accent-color, #3a73d6) 9%,
+    rgba(26, 27, 31, 0.76)
   );
   --os-color-dock-surface: color-mix(
     in srgb,
-    var(--os-accent-color, #3a73d6) 6%,
-    rgba(26, 27, 31, 0.58)
+    var(--os-accent-color, #3a73d6) 9%,
+    rgba(26, 27, 31, 0.68)
   );
   --os-color-dock-shadow: 0 8px 30px rgba(0, 0, 0, 0.55);
 
@@ -5505,8 +5505,8 @@
 
   --os-pinstripe-window: linear-gradient(
     to bottom,
-    color-mix(in srgb, var(--os-accent-color, #3a73d6) 6%, rgba(52, 54, 60, 0.7)),
-    color-mix(in srgb, var(--os-accent-color, #3a73d6) 6%, rgba(40, 42, 48, 0.64))
+    color-mix(in srgb, var(--os-accent-color, #3a73d6) 9%, rgba(52, 54, 60, 0.8)),
+    color-mix(in srgb, var(--os-accent-color, #3a73d6) 9%, rgba(40, 42, 48, 0.74))
   );
   --os-pinstripe-menubar: none;
   --os-pinstripe-titlebar: linear-gradient(

--- a/src/styles/themes.css
+++ b/src/styles/themes.css
@@ -5380,11 +5380,31 @@
   /* Translucent surfaces (the blur lives on the chrome elements below). The
      titlebar + body are transparent in glass, so this single `.window` fill is
      the continuous frosted pane — keep it opaque enough to stay legible. */
-  --os-color-window-bg: rgba(243, 246, 251, 0.62);
-  --os-color-panel-bg: rgba(243, 246, 251, 0.62);
-  --os-color-menubar-bg: rgba(250, 251, 253, 0.55);
-  --os-color-menubar-surface: rgba(250, 251, 253, 0.55);
-  --os-color-dock-surface: rgba(250, 251, 253, 0.5);
+  --os-color-window-bg: color-mix(
+    in srgb,
+    var(--os-accent-color, #3a73d6) 5%,
+    rgba(243, 246, 251, 0.7)
+  );
+  --os-color-panel-bg: color-mix(
+    in srgb,
+    var(--os-accent-color, #3a73d6) 5%,
+    rgba(243, 246, 251, 0.7)
+  );
+  --os-color-menubar-bg: color-mix(
+    in srgb,
+    var(--os-accent-color, #3a73d6) 5%,
+    rgba(250, 251, 253, 0.64)
+  );
+  --os-color-menubar-surface: color-mix(
+    in srgb,
+    var(--os-accent-color, #3a73d6) 5%,
+    rgba(250, 251, 253, 0.64)
+  );
+  --os-color-dock-surface: color-mix(
+    in srgb,
+    var(--os-accent-color, #3a73d6) 5%,
+    rgba(250, 251, 253, 0.58)
+  );
   --os-color-dock-shadow: 0 8px 30px rgba(0, 0, 0, 0.22);
 
   /* Soft glassy edges + diffuse shadow. */
@@ -5418,8 +5438,8 @@
      rather than `none`. The menubar pattern goes flat. */
   --os-pinstripe-window: linear-gradient(
     to bottom,
-    rgba(252, 253, 255, 0.62),
-    rgba(244, 247, 251, 0.55)
+    color-mix(in srgb, var(--os-accent-color, #3a73d6) 5%, rgba(252, 253, 255, 0.7)),
+    color-mix(in srgb, var(--os-accent-color, #3a73d6) 5%, rgba(244, 247, 251, 0.64))
   );
   --os-pinstripe-menubar: none;
   /* Specular top sheen on the titlebar instead of the pinstripe gloss. */
@@ -5433,11 +5453,31 @@
 
 /* --- Dark glass tokens ---------------------------------------------------- */
 :root[data-os-theme="macosx"][data-os-aqua-material="glass"][data-os-color-scheme="dark"] {
-  --os-color-window-bg: rgba(38, 40, 46, 0.62);
-  --os-color-panel-bg: rgba(38, 40, 46, 0.62);
-  --os-color-menubar-bg: rgba(26, 27, 31, 0.58);
-  --os-color-menubar-surface: rgba(26, 27, 31, 0.58);
-  --os-color-dock-surface: rgba(26, 27, 31, 0.5);
+  --os-color-window-bg: color-mix(
+    in srgb,
+    var(--os-accent-color, #3a73d6) 6%,
+    rgba(38, 40, 46, 0.7)
+  );
+  --os-color-panel-bg: color-mix(
+    in srgb,
+    var(--os-accent-color, #3a73d6) 6%,
+    rgba(38, 40, 46, 0.7)
+  );
+  --os-color-menubar-bg: color-mix(
+    in srgb,
+    var(--os-accent-color, #3a73d6) 6%,
+    rgba(26, 27, 31, 0.66)
+  );
+  --os-color-menubar-surface: color-mix(
+    in srgb,
+    var(--os-accent-color, #3a73d6) 6%,
+    rgba(26, 27, 31, 0.66)
+  );
+  --os-color-dock-surface: color-mix(
+    in srgb,
+    var(--os-accent-color, #3a73d6) 6%,
+    rgba(26, 27, 31, 0.58)
+  );
   --os-color-dock-shadow: 0 8px 30px rgba(0, 0, 0, 0.55);
 
   --os-color-window-border: rgba(255, 255, 255, 0.16);
@@ -5465,8 +5505,8 @@
 
   --os-pinstripe-window: linear-gradient(
     to bottom,
-    rgba(52, 54, 60, 0.62),
-    rgba(40, 42, 48, 0.55)
+    color-mix(in srgb, var(--os-accent-color, #3a73d6) 6%, rgba(52, 54, 60, 0.7)),
+    color-mix(in srgb, var(--os-accent-color, #3a73d6) 6%, rgba(40, 42, 48, 0.64))
   );
   --os-pinstripe-menubar: none;
   --os-pinstripe-titlebar: linear-gradient(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

In the **Aqua Glass** Mac OS X material, makes the glassy surfaces more opaque and adds a subtle tint of the active accent color.

Implemented at the token level in `themes.css` (light + dark glass token blocks), so every glass surface that reads these tokens inherits the change: window/panel panes, the menu bar, the dock, and frosted popovers/menus (`--os-pinstripe-window`).

- **Opacity:** bumped the base fill alphas (window `0.62 → 0.80`, menu bar `0.55 → 0.74`/`0.76`, dock `0.50 → 0.68`).
- **Accent tint:** wrapped each fill in `color-mix(in srgb, var(--os-accent-color, #3a73d6) 8–9%, <base rgba>)` — an established pattern already used elsewhere in the glass section. Falls back to the classic Aqua blue when the accent is "default".

## Walkthrough

Before (main, neutral + more transparent) vs after (more opaque, subtle lavender accent tint); purple accent shown so the tint is visible:

![Glass window/menubar before](https://cursor.com/artifacts/c/art-ac6c926a-5ddb-4c30-a61c-b2b4df92dd60)
![Glass window/menubar after (more opaque, more tinted)](https://cursor.com/artifacts/c/art-1573d0c5-6f33-4ff9-9edd-9e11fc6725a7)

Full window + dark mode (after):

![Glass surfaces after, full window](https://cursor.com/artifacts/c/art-4cb02567-7810-4b79-895d-2e6308e74ab5)
![Glass surfaces after, dark mode](https://cursor.com/artifacts/c/art-449502f3-e666-452b-a4a1-87f9fa3e3ee7)

## Testing

- `bun run build` passes.
- Verified before/after in the running app with Aqua Glass enabled and a purple accent — see Walkthrough.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019eaf58-2946-7e4f-8a56-8378109fa4c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019eaf58-2946-7e4f-8a56-8378109fa4c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

