### PR TITLE
Fix karaoke/iPod OG previews falling back to no metadata

### DIFF
--- a/api/_utils/og-share.ts
+++ b/api/_utils/og-share.ts
@@ -330,6 +330,38 @@ async function getYouTubeInfo(
   }
 }
 
+/**
+ * Resolve song metadata + cover image for iPod / Karaoke OG pages.
+ *
+ * Prefers the song stored in Redis (richest data: album cover, curated
+ * title/artist). When the song hasn't been persisted yet — e.g. it was shared
+ * by a logged-out user, the metadata save failed, or it simply isn't in the
+ * library — fall back to YouTube oEmbed (mirroring the `/videos/` path) so the
+ * preview still shows a real title and thumbnail instead of the generic app
+ * fallback.
+ */
+async function resolveSongShareInfo(
+  songId: string,
+  getSong: (songId: string) => Promise<SongShareMetadata | null>
+): Promise<{ songInfo: SongShareMetadata | null; imageUrl: string | null }> {
+  const stored = await getSong(songId);
+  if (stored) {
+    return { songInfo: stored, imageUrl: formatMusicCoverUrl(stored.cover, 400) };
+  }
+
+  if (YOUTUBE_VIDEO_ID_REGEX.test(songId)) {
+    const ytInfo = await getYouTubeInfo(songId);
+    if (ytInfo) {
+      return {
+        songInfo: { title: ytInfo.title, artist: ytInfo.artist, cover: null },
+        imageUrl: `https://i.ytimg.com/vi/${songId}/hqdefault.jpg`,
+      };
+    }
+  }
+
+  return { songInfo: null, imageUrl: null };
+}
+
 export async function createOgShareResponse(
   request: Request,
   options: {
@@ -384,9 +416,12 @@ export async function createOgShareResponse(
     const songId = resolveSongShareId(ipodMatch[1]);
     imageUrl = getAppIconUrl(publicOrigin, "ipod");
 
-    const songInfo = await (options.getSong || getSongFromRedis)(songId);
+    const { songInfo, imageUrl: songImageUrl } = await resolveSongShareInfo(
+      songId,
+      options.getSong || getSongFromRedis
+    );
     if (songInfo) {
-      imageUrl = formatMusicCoverUrl(songInfo.cover, 400) || imageUrl;
+      imageUrl = songImageUrl || imageUrl;
       if (songInfo.artist) {
         title = `${songInfo.title} - ${songInfo.artist}`;
         description = "Listen on ryOS iPod";
@@ -406,9 +441,12 @@ export async function createOgShareResponse(
     const songId = resolveSongShareId(karaokeMatch[1]);
     imageUrl = getAppIconUrl(publicOrigin, "karaoke");
 
-    const songInfo = await (options.getSong || getSongFromRedis)(songId);
+    const { songInfo, imageUrl: songImageUrl } = await resolveSongShareInfo(
+      songId,
+      options.getSong || getSongFromRedis
+    );
     if (songInfo) {
-      imageUrl = formatMusicCoverUrl(songInfo.cover, 400) || imageUrl;
+      imageUrl = songImageUrl || imageUrl;
       const songDisplay = songInfo.artist
         ? `${songInfo.title} - ${songInfo.artist}`
         : songInfo.title;

--- a/api/_utils/og-share.ts
+++ b/api/_utils/og-share.ts
@@ -340,13 +340,23 @@ async function getYouTubeInfo(
  * preview still shows a real title and thumbnail instead of the generic app
  * fallback.
  */
+type SongShareSource = "redis" | "youtube" | "none";
+
 async function resolveSongShareInfo(
   songId: string,
   getSong: (songId: string) => Promise<SongShareMetadata | null>
-): Promise<{ songInfo: SongShareMetadata | null; imageUrl: string | null }> {
+): Promise<{
+  songInfo: SongShareMetadata | null;
+  imageUrl: string | null;
+  source: SongShareSource;
+}> {
   const stored = await getSong(songId);
   if (stored) {
-    return { songInfo: stored, imageUrl: formatMusicCoverUrl(stored.cover, 400) };
+    return {
+      songInfo: stored,
+      imageUrl: formatMusicCoverUrl(stored.cover, 400),
+      source: "redis",
+    };
   }
 
   if (YOUTUBE_VIDEO_ID_REGEX.test(songId)) {
@@ -355,11 +365,12 @@ async function resolveSongShareInfo(
       return {
         songInfo: { title: ytInfo.title, artist: ytInfo.artist, cover: null },
         imageUrl: `https://i.ytimg.com/vi/${songId}/hqdefault.jpg`,
+        source: "youtube",
       };
     }
   }
 
-  return { songInfo: null, imageUrl: null };
+  return { songInfo: null, imageUrl: null, source: "none" };
 }
 
 export async function createOgShareResponse(
@@ -385,6 +396,15 @@ export async function createOgShareResponse(
   let title = "ryOS";
   let description = "An AI OS experience, made with Cursor";
   let matched = false;
+  // Crawlers cache aggressively, so OG pages are CDN-cached for an hour by
+  // default. Song shares persist their metadata to Redis asynchronously (and
+  // skip it entirely for logged-out users), so the first crawler hit can race
+  // ahead of the save and serve an incomplete preview. When we don't have rich
+  // metadata yet, cache only briefly so the CDN re-fetches and picks up the
+  // song once it lands in Redis instead of pinning a stale fallback.
+  const RICH_CACHE_SECONDS = 3600;
+  const FALLBACK_CACHE_SECONDS = 60;
+  let cacheMaxAge = RICH_CACHE_SECONDS;
 
   const appMatch = pathname.match(/^\/([a-z-]+)$/);
   if (appMatch && APP_NAMES[appMatch[1]]) {
@@ -416,10 +436,14 @@ export async function createOgShareResponse(
     const songId = resolveSongShareId(ipodMatch[1]);
     imageUrl = getAppIconUrl(publicOrigin, "ipod");
 
-    const { songInfo, imageUrl: songImageUrl } = await resolveSongShareInfo(
-      songId,
-      options.getSong || getSongFromRedis
-    );
+    const {
+      songInfo,
+      imageUrl: songImageUrl,
+      source,
+    } = await resolveSongShareInfo(songId, options.getSong || getSongFromRedis);
+    if (source !== "redis") {
+      cacheMaxAge = FALLBACK_CACHE_SECONDS;
+    }
     if (songInfo) {
       imageUrl = songImageUrl || imageUrl;
       if (songInfo.artist) {
@@ -441,10 +465,14 @@ export async function createOgShareResponse(
     const songId = resolveSongShareId(karaokeMatch[1]);
     imageUrl = getAppIconUrl(publicOrigin, "karaoke");
 
-    const { songInfo, imageUrl: songImageUrl } = await resolveSongShareInfo(
-      songId,
-      options.getSong || getSongFromRedis
-    );
+    const {
+      songInfo,
+      imageUrl: songImageUrl,
+      source,
+    } = await resolveSongShareInfo(songId, options.getSong || getSongFromRedis);
+    if (source !== "redis") {
+      cacheMaxAge = FALLBACK_CACHE_SECONDS;
+    }
     if (songInfo) {
       imageUrl = songImageUrl || imageUrl;
       const songDisplay = songInfo.artist
@@ -539,7 +567,7 @@ export async function createOgShareResponse(
       "Content-Type": "text/html; charset=utf-8",
       // no-store prevents service worker from caching this redirect page
       // s-maxage allows CDN to cache for crawlers (they don't have SW)
-      "Cache-Control": "no-store, s-maxage=3600",
+      "Cache-Control": `no-store, s-maxage=${cacheMaxAge}`,
     },
   });
 }

--- a/api/_utils/og-share.ts
+++ b/api/_utils/og-share.ts
@@ -1,4 +1,3 @@
-import { Redis } from "@upstash/redis";
 import { getAppPublicOrigin } from "./runtime-config.js";
 import { parseYouTubeTitleSimple } from "./parse-youtube-title.js";
 
@@ -256,22 +255,17 @@ export function getSongShareMetadataFromRaw(
 async function createSongRedisClient(): Promise<{
   get<T = unknown>(key: string): Promise<T | null>;
 } | null> {
-  if (
-    process.env.REDIS_KV_REST_API_URL?.trim() &&
-    process.env.REDIS_KV_REST_API_TOKEN?.trim()
-  ) {
-    return new Redis({
-      url: process.env.REDIS_KV_REST_API_URL,
-      token: process.env.REDIS_KV_REST_API_TOKEN,
-    });
-  }
-
-  if (process.env.REDIS_URL?.trim()) {
-    const { createRedis } = await import("./redis.js");
-    return createRedis();
-  }
-
-  return null;
+  // Delegate to the canonical Redis factory so the OG read path resolves the
+  // exact same backend (Upstash REST vs standard REDIS_URL) that the song API
+  // writes to. Picking a backend independently here used to silently diverge on
+  // non-Vercel deploys — e.g. when REDIS_URL (and/or REDIS_PROVIDER=redis-url)
+  // is set but stale Upstash vars also linger — causing reads to hit an empty
+  // store and previews to always fall back. The dynamic import keeps the
+  // standard-Redis (ioredis) dependency out of edge bundles that only use
+  // Upstash REST. `createRedis` throws when nothing is configured, which the
+  // caller treats as "no metadata".
+  const { createRedis } = await import("./redis.js");
+  return createRedis();
 }
 
 // Fetch song metadata from Redis song library

--- a/tests/test-og-share.test.ts
+++ b/tests/test-og-share.test.ts
@@ -155,6 +155,100 @@ describe("og share response", () => {
     );
   });
 
+  test("falls back to YouTube metadata for Karaoke OG when song is not in Redis", async () => {
+    process.env.APP_PUBLIC_ORIGIN = "https://os.example.com";
+    const fetchMock = mock(async (input: RequestInfo | URL) => {
+      const requestUrl = typeof input === "string" ? input : input.toString();
+      expect(requestUrl).toContain("youtube.com/oembed");
+      expect(requestUrl).toContain("abc123DEF45");
+      return new Response(
+        JSON.stringify({ title: "Queen - Bohemian Rhapsody (Official Video)" }),
+        { status: 200, headers: { "Content-Type": "application/json" } }
+      );
+    });
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    try {
+      const response = await createOgShareResponse(
+        new Request("https://os.example.com/karaoke/abc123DEF45"),
+        { getSong: async () => null }
+      );
+
+      expect(response).not.toBeNull();
+      const body = await response!.text();
+      expect(body).toContain(
+        '<meta property="og:title" content="Sing Bohemian Rhapsody - Queen on ryOS">'
+      );
+      expect(body).toContain(
+        '<meta property="og:image" content="https://i.ytimg.com/vi/abc123DEF45/hqdefault.jpg">'
+      );
+      expect(body).not.toContain("Sing on ryOS Karaoke");
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("falls back to YouTube metadata for iPod OG when song is not in Redis", async () => {
+    process.env.APP_PUBLIC_ORIGIN = "https://os.example.com";
+    const fetchMock = mock(async () => {
+      return new Response(
+        JSON.stringify({ title: "Queen - Bohemian Rhapsody" }),
+        { status: 200, headers: { "Content-Type": "application/json" } }
+      );
+    });
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    try {
+      const response = await createOgShareResponse(
+        new Request("https://os.example.com/ipod/abc123DEF45"),
+        { getSong: async () => null }
+      );
+
+      expect(response).not.toBeNull();
+      const body = await response!.text();
+      expect(body).toContain(
+        '<meta property="og:title" content="Bohemian Rhapsody - Queen">'
+      );
+      expect(body).toContain(
+        '<meta property="og:image" content="https://i.ytimg.com/vi/abc123DEF45/hqdefault.jpg">'
+      );
+      expect(body).not.toContain("Shared Song - ryOS");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("uses generic Karaoke fallback when song is missing and not a YouTube id", async () => {
+    process.env.APP_PUBLIC_ORIGIN = "https://os.example.com";
+    const fetchMock = mock(() => {
+      throw new Error("oEmbed should not be fetched for non-YouTube song ids");
+    });
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    try {
+      const response = await createOgShareResponse(
+        new Request("https://os.example.com/karaoke/am%3A1616228595"),
+        { getSong: async () => null }
+      );
+
+      expect(response).not.toBeNull();
+      const body = await response!.text();
+      expect(body).toContain(
+        '<meta property="og:title" content="Sing on ryOS Karaoke">'
+      );
+      expect(body).toContain(
+        '<meta property="og:image" content="https://os.example.com/icons/macosx/karaoke.png">'
+      );
+      expect(fetchMock).not.toHaveBeenCalled();
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
   test("normalizes supported song share route IDs", () => {
     expect(resolveSongShareId("abc123DEF45")).toBe("abc123DEF45");
     expect(resolveSongShareId("am%3A1616228595")).toBe("am:1616228595");

--- a/tests/test-og-share.test.ts
+++ b/tests/test-og-share.test.ts
@@ -92,6 +92,10 @@ describe("og share response", () => {
       );
       expect(body).not.toContain("i.ytimg.com");
       expect(fetchMock).not.toHaveBeenCalled();
+      // Rich Redis-backed metadata is stable, so it can be CDN-cached longer.
+      expect(response?.headers.get("cache-control")).toBe(
+        "no-store, s-maxage=3600"
+      );
     } finally {
       globalThis.fetch = originalFetch;
     }
@@ -185,6 +189,11 @@ describe("og share response", () => {
       );
       expect(body).not.toContain("Sing on ryOS Karaoke");
       expect(fetchMock).toHaveBeenCalledTimes(1);
+      // YouTube fallback metadata may be superseded by a Redis save that is
+      // still in flight, so the preview must not be pinned for an hour.
+      expect(response?.headers.get("cache-control")).toBe(
+        "no-store, s-maxage=60"
+      );
     } finally {
       globalThis.fetch = originalFetch;
     }
@@ -244,6 +253,9 @@ describe("og share response", () => {
         '<meta property="og:image" content="https://os.example.com/icons/macosx/karaoke.png">'
       );
       expect(fetchMock).not.toHaveBeenCalled();
+      expect(response?.headers.get("cache-control")).toBe(
+        "no-store, s-maxage=60"
+      );
     } finally {
       globalThis.fetch = originalFetch;
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Share previews for `/karaoke/{songId}` and `/ipod/{songId}` (title / artist / cover) frequently degraded to the generic **"Sing on ryOS Karaoke"** / **"Shared Song - ryOS"** title and the bare app icon — including for songs that were *already in Redis*.

Root causes:

1. **No fallback when Redis misses.** Unlike `/videos/{id}`, the karaoke/iPod branches of `createOgShareResponse` only consulted Redis. When the song wasn't persisted (logged-out sharer, failed save, not in the library), the lookup returned `null` and the preview silently used the generic fallback.

2. **Stale previews pinned at the CDN for an hour.** Share-time metadata persistence is fire-and-forget (`saveSongMetadataFromTrack(...).catch()`, not awaited) and skipped for logged-out users, so the first crawler hit often races ahead of the Redis write. The OG response was always `s-maxage=3600`, so a CDN pinned the incomplete fallback for an hour.

3. **OG Redis read diverged from the writer on non-Vercel deploys.** `og-share.ts` selected its own Redis backend (Upstash REST first, ignoring `REDIS_PROVIDER`), while the song API writes via the canonical `createRedis()` factory whose precedence is `REDIS_PROVIDER` → `REDIS_URL` → Upstash. On a self-hosted/non-Vercel deploy with `REDIS_URL` set (and/or lingering Upstash vars, or `REDIS_PROVIDER=redis-url`), writes landed in standard Redis while OG reads hit a different/empty Upstash store — so previews missed *even for songs already stored*. (Note: `middleware.ts` is Vercel-only Edge Middleware; off Vercel, OG generation runs in the standalone Bun server `bun run start`, which calls `createOgShareResponse` before static serving.)

## Fix (`api/_utils/og-share.ts`)

- Extracted `resolveSongShareInfo()` shared by karaoke + iPod. Prefers rich Redis metadata; when Redis misses and the resolved ID is a YouTube video ID, falls back to YouTube oEmbed (title/artist + `i.ytimg.com/.../hqdefault.jpg`). Non-YouTube IDs with no Redis entry keep the generic app fallback (no spurious fetch).
- Conditional CDN TTL: rich Redis-backed previews keep `s-maxage=3600`; oEmbed/generic fallbacks use `s-maxage=60` so a CDN re-fetches and picks up the song once the async save lands.
- Delegated the OG Redis read to the canonical `createRedis()` factory so reads and writes always resolve the same backend. Kept the dynamic `import("./redis.js")` so the standard-Redis (ioredis) dependency stays out of edge-only bundles.

## Testing

- `bun test tests/test-og-share.test.ts` — 12 pass (YouTube fallback for karaoke + iPod, non-YouTube generic fallback, cache-header assertions).
- `bun run test:unit` — 272 pass.
- `bunx eslint` on changed files — clean.
- Manual against the standalone Bun server (`bun run dev:api`, Upstash backend): `/ipod/dQw4w9WgXcQ` (in Redis) → real title + Kugou cover + `s-maxage=3600`; `/ipod/jNQXAC9IVRw` & `/karaoke/jNQXAC9IVRw` (not in Redis) → YouTube title + thumbnail + `s-maxage=60`; non-YouTube ID → generic + `s-maxage=60`; `/finder` → `s-maxage=3600`.
- Non-Vercel backend reproduction with a local standard Redis (`REDIS_PROVIDER=redis-url`, `REDIS_URL=...`, plus stale Upstash vars): wrote `song:meta` via the canonical writer; the old Upstash-first precedence would have read the (unreachable) stale store and fallen back, while the fixed read path resolved `Standard Redis Song - Self-Host Artist` with the correct cover.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019eb225-de06-7b86-b25e-e58cc82026ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019eb225-de06-7b86-b25e-e58cc82026ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

