### PR TITLE
fix(chats): clear errors and greeting state on Clear Chat

### DIFF
--- a/src/apps/chats/hooks/useAiChat.ts
+++ b/src/apps/chats/hooks/useAiChat.ts
@@ -190,6 +190,7 @@ export function useAiChat(onPromptSetUsername?: () => void) {
     status,
     error,
     stop: sdkStop,
+    clearError,
     setMessages: setSdkMessages,
     sendMessage,
     regenerate,
@@ -1763,6 +1764,21 @@ export function useAiChat(onPromptSetUsername?: () => void) {
 
     }
 
+    // Stop any in-flight stream first. Otherwise the AI SDK keeps appending to
+    // its message list after we reset it below, and `useSyncedAiMessages`
+    // refuses to overwrite a longer SDK list with the cleared store snapshot —
+    // making the old conversation reappear right after "Clear Chat".
+    sdkStop();
+
+    // Clear the AI SDK error state (e.g. the inline red error / retry block).
+    // Without this, a previous failed turn's error stays visible after clearing.
+    clearError();
+
+    // Clear the non-SDK error channels surfaced below the input so the footer
+    // doesn't keep showing a stale rate-limit / login prompt after clearing.
+    setRateLimitError(null);
+    setNeedsUsername(false);
+
     // Reset speech and highlight state so the next reply starts clean.
     resetSpeechState();
 
@@ -1783,6 +1799,10 @@ export function useAiChat(onPromptSetUsername?: () => void) {
   }, [
     setAiMessages,
     setSdkMessages,
+    sdkStop,
+    clearError,
+    setRateLimitError,
+    setNeedsUsername,
     resetSpeechState,
     markAssistantMessageProcessed,
     aiMessages,

--- a/src/apps/chats/hooks/useSyncedAiMessages.ts
+++ b/src/apps/chats/hooks/useSyncedAiMessages.ts
@@ -1,10 +1,7 @@
 import { useEffect, useRef } from "react";
 import type { UIMessage } from "@ai-sdk/react";
 import type { AIChatMessage } from "@/types/chat";
-import {
-  applyFreshProactiveGreeting,
-  isDefaultGreetingMessage,
-} from "../utils/proactiveGreetingApply";
+import { resolveAiMessageSync } from "../utils/proactiveGreetingApply";
 
 interface UseSyncedAiMessagesOptions {
   aiMessages: AIChatMessage[];
@@ -21,41 +18,20 @@ export function useSyncedAiMessages({
   currentMessagesRef.current = currentMessages;
 
   useEffect(() => {
-    const sdkMessages = currentMessagesRef.current;
-    const storeLast = aiMessages.at(-1);
-    const sdkLast = sdkMessages.at(-1);
+    const sdkMessages = currentMessagesRef.current as AIChatMessage[];
+    const decision = resolveAiMessageSync(aiMessages, sdkMessages);
 
-    const sdkHasDefaultGreeting = sdkMessages.some((message) =>
-      isDefaultGreetingMessage(message as AIChatMessage)
-    );
-    const storeProactiveGreeting = aiMessages.find(
-      (message) =>
-        message.id === "proactive-1" || message.id?.startsWith("proactive-")
-    );
-
-    // Swap the loading placeholder greeting in the live SDK list when the store
-    // already received the proactive greeting but the stream is still running.
-    if (sdkHasDefaultGreeting && storeProactiveGreeting) {
-      const patchedMessages = applyFreshProactiveGreeting(
-        sdkMessages as AIChatMessage[],
-        storeProactiveGreeting
-      );
-      if (patchedMessages) {
-        setMessages(patchedMessages);
-      }
-      return;
-    }
-
-    // While the user is mid-conversation the AI SDK list is ahead of the
-    // persisted store until onFinish runs. Never overwrite a longer SDK list
-    // with a shorter store snapshot.
-    if (sdkMessages.length > aiMessages.length) {
-      return;
-    }
-
-    if (aiMessages.length !== sdkMessages.length || storeLast?.id !== sdkLast?.id) {
-      console.log("Syncing Zustand store messages to SDK.");
-      setMessages(aiMessages);
+    switch (decision.action) {
+      case "patch-greeting":
+        setMessages(decision.messages);
+        return;
+      case "sync":
+        console.log("Syncing Zustand store messages to SDK.");
+        setMessages(aiMessages);
+        return;
+      case "skip":
+      case "noop":
+        return;
     }
   }, [aiMessages, setMessages]);
 }

--- a/src/apps/chats/utils/proactiveGreetingApply.ts
+++ b/src/apps/chats/utils/proactiveGreetingApply.ts
@@ -3,6 +3,16 @@ import type { AIChatMessage } from "@/types/chat";
 export const isDefaultGreetingMessage = (message: AIChatMessage): boolean =>
   message.id === "1" && message.role === "assistant";
 
+/**
+ * True when the message list is exactly the single default greeting, i.e. the
+ * conversation has just been cleared / reset. Used to force the SDK message
+ * list back in sync even when it is momentarily longer (e.g. a stream that was
+ * still draining when the user pressed "Clear Chat").
+ */
+export const isClearedToDefaultGreeting = (
+  messages: AIChatMessage[]
+): boolean => messages.length === 1 && isDefaultGreetingMessage(messages[0]);
+
 export function shouldApplyFreshProactiveGreeting(
   currentMessages: AIChatMessage[]
 ): boolean {
@@ -27,4 +37,59 @@ export function applyFreshProactiveGreeting(
   const updated = [...currentMessages];
   updated[greetingIndex] = proactiveMessage;
   return updated;
+}
+
+const isProactiveGreetingMessage = (message: AIChatMessage): boolean =>
+  message.id === "proactive-1" || !!message.id?.startsWith("proactive-");
+
+export type AiMessageSyncDecision =
+  | { action: "patch-greeting"; messages: AIChatMessage[] }
+  | { action: "skip" }
+  | { action: "sync" }
+  | { action: "noop" };
+
+/**
+ * Pure decision for `useSyncedAiMessages`: given the persisted store list and
+ * the live AI SDK list, decide how (if at all) to reconcile them.
+ *
+ * - `patch-greeting`: the stream still shows the default loading greeting while
+ *   the store already has the proactive greeting; swap it in place.
+ * - `skip`: the SDK list is mid-stream (longer than the store) and the store is
+ *   NOT a fresh clear, so leave the live list alone.
+ * - `sync`: push the store list onto the SDK (length or last-id mismatch).
+ * - `noop`: already in sync.
+ */
+export function resolveAiMessageSync(
+  aiMessages: AIChatMessage[],
+  sdkMessages: AIChatMessage[]
+): AiMessageSyncDecision {
+  const storeLast = aiMessages.at(-1);
+  const sdkLast = sdkMessages.at(-1);
+
+  const sdkHasDefaultGreeting = sdkMessages.some(isDefaultGreetingMessage);
+  const storeProactiveGreeting = aiMessages.find(isProactiveGreetingMessage);
+
+  if (sdkHasDefaultGreeting && storeProactiveGreeting) {
+    const patched = applyFreshProactiveGreeting(
+      sdkMessages,
+      storeProactiveGreeting
+    );
+    return patched ? { action: "patch-greeting", messages: patched } : { action: "noop" };
+  }
+
+  // Mid-stream the SDK list runs ahead of the store. Don't clobber it with a
+  // shorter store snapshot — unless the store was just cleared to the single
+  // default greeting, in which case the clear must win.
+  if (
+    sdkMessages.length > aiMessages.length &&
+    !isClearedToDefaultGreeting(aiMessages)
+  ) {
+    return { action: "skip" };
+  }
+
+  if (aiMessages.length !== sdkMessages.length || storeLast?.id !== sdkLast?.id) {
+    return { action: "sync" };
+  }
+
+  return { action: "noop" };
 }

--- a/tests/test-proactive-greeting-apply.test.ts
+++ b/tests/test-proactive-greeting-apply.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, test } from "bun:test";
 import type { AIChatMessage } from "../src/types/chat";
 import {
   applyFreshProactiveGreeting,
+  isClearedToDefaultGreeting,
   isDefaultGreetingMessage,
+  resolveAiMessageSync,
   shouldApplyFreshProactiveGreeting,
 } from "../src/apps/chats/utils/proactiveGreetingApply";
 
@@ -70,5 +72,69 @@ describe("proactive greeting apply", () => {
     expect(
       applyFreshProactiveGreeting([userMessage], proactiveGreeting)
     ).toBeNull();
+  });
+});
+
+describe("cleared chat detection", () => {
+  test("recognizes a single default greeting as a cleared chat", () => {
+    expect(isClearedToDefaultGreeting([defaultGreeting])).toBe(true);
+  });
+
+  test("does not treat a proactive greeting as a cleared chat", () => {
+    expect(isClearedToDefaultGreeting([proactiveGreeting])).toBe(false);
+  });
+
+  test("does not treat a populated conversation as a cleared chat", () => {
+    expect(
+      isClearedToDefaultGreeting([defaultGreeting, userMessage, assistantStream])
+    ).toBe(false);
+  });
+});
+
+describe("resolveAiMessageSync", () => {
+  test("forces a clear to win even when the SDK stream is still longer", () => {
+    // User pressed "Clear Chat" while an assistant reply was still draining.
+    const decision = resolveAiMessageSync(
+      [defaultGreeting],
+      [defaultGreeting, userMessage, assistantStream]
+    );
+
+    expect(decision).toEqual({ action: "sync" });
+  });
+
+  test("skips overwriting a longer SDK list mid-conversation", () => {
+    const decision = resolveAiMessageSync(
+      [proactiveGreeting, userMessage],
+      [proactiveGreeting, userMessage, assistantStream]
+    );
+
+    expect(decision).toEqual({ action: "skip" });
+  });
+
+  test("patches the loading greeting once the proactive greeting arrives", () => {
+    const decision = resolveAiMessageSync(
+      [proactiveGreeting],
+      [defaultGreeting]
+    );
+
+    expect(decision).toEqual({
+      action: "patch-greeting",
+      messages: [proactiveGreeting],
+    });
+  });
+
+  test("syncs when same-length lists have a differing last message id", () => {
+    expect(resolveAiMessageSync([userMessage], [assistantStream])).toEqual({
+      action: "sync",
+    });
+  });
+
+  test("no-ops when store and SDK are already aligned", () => {
+    expect(
+      resolveAiMessageSync(
+        [proactiveGreeting, userMessage],
+        [proactiveGreeting, userMessage]
+      )
+    ).toEqual({ action: "noop" });
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

In the @ryo chat, **"Clear Chat" didn't fully reset state**:

- A previous failed turn's **error** stayed visible — both the inline red error/retry block (AI SDK `error`) and the rate-limit / "set a username" footer error (`rateLimitError` / `needsUsername`).
- Clearing while a reply was still **streaming** could **resurrect the old conversation/greeting**: `clearChats` reset the message lists but never stopped the stream, and `useSyncedAiMessages` refuses to overwrite a longer SDK list with the shorter cleared store snapshot.

## Fix

`clearChats` (`src/apps/chats/hooks/useAiChat.ts`) now:
- `sdkStop()` — stops any in-flight stream before resetting.
- `clearError()` — clears the AI SDK error state (newly destructured from `useChat`).
- `setRateLimitError(null)` + `setNeedsUsername(false)` — clears the footer error channels.

`useSyncedAiMessages` (`src/apps/chats/hooks/useSyncedAiMessages.ts`) now force-syncs the cleared store onto the SDK list when the store is exactly the single default greeting, so a draining stream can't bring the old conversation back. The reconciliation logic is extracted into a pure, tested `resolveAiMessageSync()` in `src/apps/chats/utils/proactiveGreetingApply.ts`.

## Testing

- ✅ `bun test tests/test-proactive-greeting-apply.test.ts` (added cleared-chat + sync decision tests)
- ✅ `bun run build` (`tsc -b && vite build`)
- ✅ `bunx eslint` on changed files

GUI testing was skipped per the repo's AGENTS.md guidance (skip computer-use unless explicitly requested); the behavior is covered by the new pure-function unit tests since no React/DOM test harness exists in the repo.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019eb22d-e7fa-7c2c-960d-39527860362a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019eb22d-e7fa-7c2c-960d-39527860362a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

