### PR TITLE
Reduce focus change render invalidation

### DIFF
--- a/src/apps/applet-viewer/hooks/useAppletViewerLogic.ts
+++ b/src/apps/applet-viewer/hooks/useAppletViewerLogic.ts
@@ -371,7 +371,7 @@ export function useAppletViewerLogic({
 
     if (instanceId) {
       const inst = state.instances[instanceId];
-      if (!inst || !inst.isForeground) {
+      if (!inst || state.foregroundInstanceId !== instanceId) {
         state.bringInstanceToForeground(instanceId);
       }
     }

--- a/src/apps/base/app-manager/AppManagerView.tsx
+++ b/src/apps/base/app-manager/AppManagerView.tsx
@@ -1,3 +1,5 @@
+import { memo, useCallback } from "react";
+import type { ComponentType } from "react";
 import { MenuBar } from "@/components/layout/MenuBar";
 import { Desktop } from "@/components/layout/Desktop";
 import { DesktopCornerMask } from "@/components/layout/desktop/DesktopCornerMask";
@@ -11,15 +13,16 @@ import { AppSwitcher } from "@/components/layout/AppSwitcher";
 import { AppErrorBoundary } from "@/components/errors/ErrorBoundaries";
 import { getTranslatedAppName } from "@/utils/i18n";
 import { isTextEditInitialData } from "@/types/appInitialData";
-import { useAppStore } from "@/stores/useAppStore";
+import { selectIsInstanceForeground, useAppStore } from "@/stores/useAppStore";
+import { useAppStoreShallow } from "@/stores/helpers";
 import { shouldMountInstance } from "../instanceMountPolicy";
 import { getZIndexForInstance, supportsMultiWindowApp } from "./instanceHelpers";
+import type { AppProps } from "../types";
 import type { AppManagerViewModel } from "./useAppManager";
 
 export function AppManagerView({
   apps,
   openInstanceIds,
-  instanceOrder,
   exposeMode,
   showDesktopMenuBar,
   isInitialMount,
@@ -44,7 +47,6 @@ export function AppManagerView({
           key={instanceId}
           apps={apps}
           instanceId={instanceId}
-          instanceOrder={instanceOrder}
           exposeMode={exposeMode}
           isInitialMount={isInitialMount}
           setCrashedInstanceIds={setCrashedInstanceIds}
@@ -80,10 +82,9 @@ export function AppManagerView({
   );
 }
 
-function ManagedAppInstance({
+const ManagedAppInstance = memo(function ManagedAppInstance({
   apps,
   instanceId,
-  instanceOrder,
   exposeMode,
   isInitialMount,
   setCrashedInstanceIds,
@@ -95,7 +96,6 @@ function ManagedAppInstance({
 }: Pick<
   AppManagerViewModel,
   | "apps"
-  | "instanceOrder"
   | "exposeMode"
   | "isInitialMount"
   | "setCrashedInstanceIds"
@@ -107,14 +107,31 @@ function ManagedAppInstance({
 > & {
   instanceId: string;
 }) {
-  const instance = useAppStore((state) => state.instances[instanceId]);
+  const instance = useAppStoreShallow((state) => {
+    const inst = state.instances[instanceId];
+    if (!inst) return null;
+    return {
+      appId: inst.appId,
+      createdAt: inst.createdAt,
+      initialData: inst.initialData,
+      instanceId: inst.instanceId,
+      isLoading: inst.isLoading,
+      isOpen: inst.isOpen,
+      title: inst.title,
+    };
+  });
+  const isForeground = useAppStore((state) =>
+    selectIsInstanceForeground(state, instanceId)
+  );
+  const zIndex = useAppStore((state) =>
+    getZIndexForInstance(instanceId, state.instanceOrder)
+  );
 
   if (!instance?.isOpen) return null;
   if (exposeMode && instance.appId === "stickies") return null;
 
   const appId = instance.appId as AppId;
-  const zIndex = getZIndexForInstance(instance.instanceId, instanceOrder);
-  const AppComponent = getAppComponent(appId);
+  const AppComponent = getAppComponent(appId) as ComponentType<AppProps>;
   const app = apps.find((registeredApp) => registeredApp.id === appId);
   const translatedAppName = getTranslatedAppName(appId);
   const crashDialogAppName =
@@ -122,6 +139,19 @@ function ManagedAppInstance({
 
   const shouldMount = shouldMountInstance(instance, exposeMode);
   const hideWindow = !shouldMount || instance.isLoading;
+  const effectiveIsForeground = exposeMode ? false : isForeground;
+
+  const handleClose = useCallback(() => {
+    requestCloseWindow(instance.instanceId);
+  }, [instance.instanceId]);
+
+  const handleNavigateNext = useCallback(() => {
+    navigateToNextInstance(instance.instanceId);
+  }, [instance.instanceId, navigateToNextInstance]);
+
+  const handleNavigatePrevious = useCallback(() => {
+    navigateToPreviousInstance(instance.instanceId);
+  }, [instance.instanceId, navigateToPreviousInstance]);
 
   return (
     <div
@@ -132,12 +162,12 @@ function ManagedAppInstance({
       className="absolute inset-x-0 md:inset-x-auto w-full md:w-auto"
       role="presentation"
       onMouseDown={() => {
-        if (!instance.isForeground && !exposeMode) {
+        if (!isForeground && !exposeMode) {
           bringInstanceToForeground(instance.instanceId);
         }
       }}
       onTouchStart={() => {
-        if (!instance.isForeground && !exposeMode) {
+        if (!isForeground && !exposeMode) {
           bringInstanceToForeground(instance.instanceId);
         }
       }}
@@ -192,24 +222,33 @@ function ManagedAppInstance({
         }}
       >
         {shouldMount ? (
-          <AppComponent
+          <ManagedAppRoot
+            AppComponent={AppComponent}
             isWindowOpen={instance.isOpen}
-            isForeground={exposeMode ? false : instance.isForeground}
-            onClose={() => requestCloseWindow(instance.instanceId)}
+            isForeground={effectiveIsForeground}
+            onClose={handleClose}
             className="pointer-events-auto"
             helpItems={app?.helpItems}
             skipInitialSound={isInitialMount}
-            // @ts-expect-error - Dynamic component system with different initialData types per app
             initialData={instance.initialData}
             instanceId={instance.instanceId}
             title={instance.title}
-            onNavigateNext={() => navigateToNextInstance(instance.instanceId)}
-            onNavigatePrevious={() =>
-              navigateToPreviousInstance(instance.instanceId)
-            }
+            onNavigateNext={handleNavigateNext}
+            onNavigatePrevious={handleNavigatePrevious}
           />
         ) : null}
       </AppErrorBoundary>
     </div>
   );
-}
+});
+
+type ManagedAppRootProps = {
+  AppComponent: ComponentType<AppProps>;
+} & AppProps;
+
+const ManagedAppRoot = memo(function ManagedAppRoot({
+  AppComponent,
+  ...props
+}: ManagedAppRootProps) {
+  return <AppComponent {...props} />;
+});

--- a/src/apps/base/app-manager/useAppManager.ts
+++ b/src/apps/base/app-manager/useAppManager.ts
@@ -36,7 +36,6 @@ export function useAppManager({ apps }: AppManagerProps) {
 
   const {
     openInstanceIdsKey,
-    instanceOrder,
     launchApp,
     bringInstanceToForeground,
     closeAppInstance,
@@ -51,7 +50,6 @@ export function useAppManager({ apps }: AppManagerProps) {
       .filter((instance) => instance.isOpen)
       .map((instance) => instance.instanceId)
       .join("\0"),
-    instanceOrder: state.instanceOrder,
     launchApp: state.launchApp,
     bringInstanceToForeground: state.bringInstanceToForeground,
     closeAppInstance: state.closeAppInstance,
@@ -95,7 +93,7 @@ export function useAppManager({ apps }: AppManagerProps) {
   const switcherIndex = switcherState.index;
 
   const instancesRef = useRef(useAppStore.getState().instances);
-  const instanceOrderRef = useRef(instanceOrder);
+  const instanceOrderRef = useRef(useAppStore.getState().instanceOrder);
   const launchAppRef = useRef(launchApp);
   const foregroundInstanceIdRef = useRef(foregroundInstanceId);
   const minimizeInstanceRef = useRef(minimizeInstance);
@@ -115,8 +113,11 @@ export function useAppManager({ apps }: AppManagerProps) {
   }, []);
 
   useEffect(() => {
-    instanceOrderRef.current = instanceOrder;
-  }, [instanceOrder]);
+    instanceOrderRef.current = useAppStore.getState().instanceOrder;
+    return useAppStore.subscribe((state) => {
+      instanceOrderRef.current = state.instanceOrder;
+    });
+  }, []);
 
   useEffect(() => {
     launchAppRef.current = launchApp;
@@ -341,7 +342,6 @@ export function useAppManager({ apps }: AppManagerProps) {
   return {
     apps,
     openInstanceIds,
-    instanceOrder,
     exposeMode,
     showDesktopMenuBar,
     isInitialMount,

--- a/src/apps/chats/utils/systemState.ts
+++ b/src/apps/chats/utils/systemState.ts
@@ -114,7 +114,7 @@ export const getSystemState = () => {
     const base = {
       instanceId,
       appId: instance.appId,
-      isForeground: instance.isForeground || false,
+      isForeground: instanceId === appStore.foregroundInstanceId,
       title: instance.title,
     };
 

--- a/src/components/layout/Dock.tsx
+++ b/src/components/layout/Dock.tsx
@@ -1,8 +1,9 @@
+import { memo } from "react";
 import { useThemeFlags } from "@/hooks/useThemeFlags";
 import { MacDock } from "./dock/MacDock";
 
-export function Dock() {
+export const Dock = memo(function Dock() {
   const { isMacOSTheme } = useThemeFlags();
   if (!isMacOSTheme) return null;
   return <MacDock />;
-}
+});

--- a/src/components/layout/dock/MacDock.tsx
+++ b/src/components/layout/dock/MacDock.tsx
@@ -6,6 +6,7 @@ import React, {
   useEffect,
 } from "react";
 import { useTranslation } from "react-i18next";
+import { useAppStore } from "@/stores/useAppStore";
 import { useAppStoreShallow } from "@/stores/helpers";
 import { AppId, appRegistry } from "@/config/appRegistry";
 import { useLaunchApp } from "@/hooks/useLaunchApp";
@@ -40,20 +41,95 @@ import { DockDivider } from "./DockDivider";
 import { useDockIconHover } from "./useDockIconHover";
 import { useDockMagnification } from "./useDockMagnification";
 
+type DockInstanceSnapshot = Pick<
+  AppInstance,
+  | "appId"
+  | "createdAt"
+  | "displayTitle"
+  | "initialData"
+  | "instanceId"
+  | "isLoading"
+  | "isMinimized"
+  | "isOpen"
+  | "title"
+>;
+
+function getAppletInitialDataSignature(initialData: unknown): string {
+  if (!initialData || typeof initialData !== "object") return "";
+  const data = initialData as {
+    icon?: unknown;
+    name?: unknown;
+    path?: unknown;
+    shareCode?: unknown;
+  };
+  return [
+    data.path,
+    data.shareCode,
+    data.icon,
+    data.name,
+  ]
+    .map((value) => (typeof value === "string" ? value : ""))
+    .join("\u001f");
+}
+
+function getDockInstancesSignature(instances: Record<string, AppInstance>) {
+  return Object.values(instances)
+    .map((inst) =>
+      [
+        inst.instanceId,
+        inst.appId,
+        inst.isOpen ? "1" : "0",
+        inst.isLoading ? "1" : "0",
+        inst.isMinimized ? "1" : "0",
+        inst.createdAt,
+        inst.title ?? "",
+        inst.displayTitle ?? "",
+        inst.appId === "applet-viewer"
+          ? getAppletInitialDataSignature(inst.initialData)
+          : "",
+      ].join("\u001f")
+    )
+    .join("\u001e");
+}
+
+function getDockInstancesSnapshot(
+  instances: Record<string, AppInstance>
+): Record<string, AppInstance> {
+  return Object.fromEntries(
+    Object.entries(instances).map(([id, inst]) => {
+      const snapshot = {
+        appId: inst.appId,
+        createdAt: inst.createdAt,
+        displayTitle: inst.displayTitle,
+        initialData: inst.initialData,
+        instanceId: inst.instanceId,
+        isLoading: inst.isLoading,
+        isMinimized: inst.isMinimized,
+        isOpen: inst.isOpen,
+        title: inst.title,
+      } satisfies DockInstanceSnapshot;
+      return [id, snapshot as AppInstance];
+    })
+  );
+}
+
 export function MacDock() {
   const { t } = useTranslation();
   const isPhone = useIsPhone();
   // Match Dashboard shell guards: no bottom hover capture zone on touch-first viewports.
   const useSwipeToRevealDock = useDashboardShellInputDisabled();
-  const { instances, instanceOrder, bringInstanceToForeground, restoreInstance, minimizeInstance, closeAppInstance } =
+  const { dockInstancesSignature, bringInstanceToForeground, restoreInstance, minimizeInstance, closeAppInstance } =
     useAppStoreShallow((s) => ({
-      instances: s.instances,
-      instanceOrder: s.instanceOrder,
+      dockInstancesSignature: getDockInstancesSignature(s.instances),
       bringInstanceToForeground: s.bringInstanceToForeground,
       restoreInstance: s.restoreInstance,
       minimizeInstance: s.minimizeInstance,
       closeAppInstance: s.closeAppInstance,
     }));
+  const instances = useMemo(
+    () => getDockInstancesSnapshot(useAppStore.getState().instances),
+    [dockInstancesSignature]
+  );
   
   // Sound for hide/minimize action from dock context menu
   const { play: playZoomMinimize } = useSound(Sounds.WINDOW_ZOOM_MINIMIZE);
@@ -493,11 +569,13 @@ export function MacDock() {
     return set;
   }, [instances]);
 
-  const focusMostRecentInstanceOfApp = (appId: AppId) => {
+  const focusMostRecentInstanceOfApp = useCallback((appId: AppId) => {
+    const { instances: currentInstances, instanceOrder } =
+      useAppStore.getState();
     // First, restore all minimized instances of this app
     let hasMinimized = false;
     let lastRestoredId: string | null = null;
-    Object.values(instances).forEach((inst) => {
+    Object.values(currentInstances).forEach((inst) => {
       if (inst.appId === appId && inst.isOpen && inst.isMinimized) {
         restoreInstance(inst.instanceId);
         hasMinimized = true;
@@ -514,21 +592,23 @@ export function MacDock() {
     // Otherwise, walk instanceOrder from end to find most recent open instance for appId
     for (let i = instanceOrder.length - 1; i >= 0; i--) {
       const id = instanceOrder[i];
-      const inst = instances[id];
+      const inst = currentInstances[id];
       if (inst && inst.appId === appId && inst.isOpen) {
         bringInstanceToForeground(id);
         return;
       }
     }
     // No open instance found
-  };
+  }, [bringInstanceToForeground, restoreInstance]);
 
   const focusOrLaunchApp = useCallback(
     (appId: AppId, initialData?: unknown, launchOrigin?: LaunchOriginRect) => {
+      const { instances: currentInstances, instanceOrder } =
+        useAppStore.getState();
       // First, restore all minimized instances of this app
       let hasMinimized = false;
       let lastRestoredId: string | null = null;
-      Object.values(instances).forEach((inst) => {
+      Object.values(currentInstances).forEach((inst) => {
         if (inst.appId === appId && inst.isOpen && inst.isMinimized) {
           restoreInstance(inst.instanceId);
           hasMinimized = true;
@@ -545,7 +625,7 @@ export function MacDock() {
       // Try focusing existing instance of this app
       for (let i = instanceOrder.length - 1; i >= 0; i--) {
         const id = instanceOrder[i];
-        const inst = instances[id];
+        const inst = currentInstances[id];
         if (inst && inst.appId === appId && inst.isOpen) {
           bringInstanceToForeground(id);
           return;
@@ -554,16 +634,18 @@ export function MacDock() {
       // Launch new with launch origin for animation
       launchApp(appId, initialData !== undefined ? { initialData, launchOrigin } : { launchOrigin });
     },
-    [instanceOrder, instances, bringInstanceToForeground, restoreInstance, launchApp]
+    [bringInstanceToForeground, restoreInstance, launchApp]
   );
 
   // Finder-specific: bring existing to foreground, otherwise launch one
   const focusOrLaunchFinder = useCallback(
     (initialPath?: string, launchOrigin?: LaunchOriginRect) => {
+      const { instances: currentInstances, instanceOrder } =
+        useAppStore.getState();
       // First, restore all minimized Finder instances
       let hasMinimized = false;
       let lastRestoredId: string | null = null;
-      Object.values(instances).forEach((inst) => {
+      Object.values(currentInstances).forEach((inst) => {
         if (inst.appId === "finder" && inst.isOpen && inst.isMinimized) {
           restoreInstance(inst.instanceId);
           hasMinimized = true;
@@ -580,7 +662,7 @@ export function MacDock() {
       // Try focusing existing Finder instance
       for (let i = instanceOrder.length - 1; i >= 0; i--) {
         const id = instanceOrder[i];
-        const inst = instances[id];
+        const inst = currentInstances[id];
         if (inst && inst.appId === "finder" && inst.isOpen) {
           bringInstanceToForeground(id);
           return;
@@ -590,15 +672,17 @@ export function MacDock() {
       if (initialPath) launchApp("finder", { initialPath, launchOrigin });
       else launchApp("finder", { initialPath: "/", launchOrigin });
     },
-    [instances, instanceOrder, bringInstanceToForeground, restoreInstance, launchApp]
+    [bringInstanceToForeground, restoreInstance, launchApp]
   );
 
   // Focus a Finder window already at targetPath (or its subpath); otherwise launch new Finder at targetPath
   const focusFinderAtPathOrLaunch = useCallback(
     (targetPath: string, initialData?: unknown, launchOrigin?: LaunchOriginRect) => {
+      const { instances: currentInstances, instanceOrder } =
+        useAppStore.getState();
       for (let i = instanceOrder.length - 1; i >= 0; i--) {
         const id = instanceOrder[i];
-        const inst = instances[id];
+        const inst = currentInstances[id];
         if (inst && inst.appId === "finder" && inst.isOpen) {
           const fi = finderInstances[id];
           if (
@@ -623,8 +707,6 @@ export function MacDock() {
       });
     },
     [
-      instanceOrder,
-      instances,
       finderInstances,
       bringInstanceToForeground,
       restoreInstance,

--- a/src/components/layout/dock/MacDock.tsx
+++ b/src/components/layout/dock/MacDock.tsx
@@ -17,7 +17,7 @@ import { useIsPhone } from "@/hooks/useIsPhone";
 import { useIsRyoAdmin } from "@/hooks/useIsRyoAdmin";
 import { useLongPress } from "@/hooks/useLongPress";
 import { useSound, Sounds } from "@/hooks/useSound";
-import type { LaunchOriginRect } from "@/stores/useAppStore";
+import type { AppInstance, LaunchOriginRect } from "@/stores/useAppStore";
 import { RightClickMenu } from "@/components/ui/right-click-menu";
 import { ConfirmDialog } from "@/components/dialogs/ConfirmDialog";
 import { AnimatePresence, motion, LayoutGroup } from "motion/react";

--- a/src/components/layout/dock/dockContextMenus.ts
+++ b/src/components/layout/dock/dockContextMenus.ts
@@ -43,6 +43,7 @@ export function getAppContextMenuItems(
   deps: {
     t: TFunction;
     instances: Record<string, AppInstance>;
+    foregroundInstanceId: string | null;
     finderInstances: Record<string, FinderInstance>;
     pinnedItems: DockItem[];
     getFileItem: (path: string) => FileSystemItem | undefined;
@@ -61,6 +62,7 @@ export function getAppContextMenuItems(
   const {
     t,
     instances,
+    foregroundInstanceId,
     finderInstances,
     pinnedItems,
     getFileItem,
@@ -114,7 +116,8 @@ export function getAppContextMenuItems(
     const instance = instances[specificInstanceId];
     if (instance) {
       const { label } = getDockAppletInfo(instance, getFileItem, t);
-      const isForeground = !!(instance.isForeground && !instance.isMinimized);
+      const isForeground =
+        instance.instanceId === foregroundInstanceId && !instance.isMinimized;
       items.push({
         type: "checkbox",
         label: `${label}${instance.isMinimized ? ` ${t("common.dock.minimized")}` : ""}`,
@@ -185,7 +188,8 @@ export function getAppContextMenuItems(
         }
       }
 
-      const isForeground = !!(inst.isForeground && !inst.isMinimized);
+      const isForeground =
+        inst.instanceId === foregroundInstanceId && !inst.isMinimized;
       items.push({
         type: "checkbox",
         label: `${windowLabel}${inst.isMinimized ? ` ${t("common.dock.minimized")}` : ""}`,

--- a/src/components/layout/dock/useDockContextMenus.ts
+++ b/src/components/layout/dock/useDockContextMenus.ts
@@ -7,6 +7,7 @@ import type { FinderInstance } from "@/stores/useFinderStore";
 import type { DockItem } from "@/stores/useDockStore";
 import type { FileSystemItem } from "@/stores/useFilesStore";
 import type { LaunchAppOptions } from "@/hooks/useLaunchApp";
+import { useAppStore } from "@/stores/useAppStore";
 import {
   getAppContextMenuItems as buildAppContextMenuItems,
   getDividerContextMenuItems as buildDividerContextMenuItems,
@@ -96,6 +97,7 @@ export function useDockContextMenus(params: UseDockContextMenusParams) {
         {
           t,
           instances,
+          foregroundInstanceId: useAppStore.getState().foregroundInstanceId,
           finderInstances,
           pinnedItems,
           getFileItem,

--- a/src/stores/useAppStore.ts
+++ b/src/stores/useAppStore.ts
@@ -115,7 +115,45 @@ interface AppStoreState {
   clearRecentItems: () => void;
 }
 
-const CURRENT_APP_STORE_VERSION = 5; // remap legacy app ids (e.g. infinite-pc → pc)
+const CURRENT_APP_STORE_VERSION = 6; // store foreground as foregroundInstanceId, not per-instance flags
+
+function getDerivedForegroundInstanceId(state: Pick<AppStoreState, "foregroundInstanceId" | "instanceOrder" | "instances">): string | null {
+  if (
+    state.foregroundInstanceId &&
+    state.instances[state.foregroundInstanceId]?.isOpen
+  ) {
+    return state.foregroundInstanceId;
+  }
+
+  for (let i = state.instanceOrder.length - 1; i >= 0; i--) {
+    const id = state.instanceOrder[i];
+    if (state.instances[id]?.isOpen) {
+      return id;
+    }
+  }
+
+  return null;
+}
+
+function withDerivedForeground(
+  instance: AppInstance,
+  foregroundInstanceId: string | null
+): AppInstance {
+  return {
+    ...instance,
+    isForeground: instance.instanceId === foregroundInstanceId,
+  };
+}
+
+function stripInstanceForeground(instance: AppInstance): AppInstance {
+  const { isForeground: _isForeground, ...rest } = instance;
+  return rest as AppInstance;
+}
+
+export const selectIsInstanceForeground = (
+  state: { foregroundInstanceId: string | null },
+  instanceId: string
+) => state.foregroundInstanceId === instanceId;
 
 function remapLegacyAppIdsInAppStore(prev: {
   instances?: Record<string, AppInstance>;
@@ -293,7 +331,6 @@ const createUseAppStore = () =>
               instanceId: createdId,
               appId,
               isOpen: true,
-              isForeground: !isLazy, // Only foreground immediately if not lazy
               isLoading: isLazy,
               initialData,
               title,
@@ -303,13 +340,6 @@ const createUseAppStore = () =>
               launchOrigin, // Store the position of the icon that launched this instance
             },
           } as typeof state.instances;
-
-          if (!isLazy) {
-            Object.keys(instances).forEach((id) => {
-              if (id !== createdId && instances[id].isForeground)
-                instances[id] = { ...instances[id], isForeground: false };
-            });
-          }
 
           const instanceOrder = [
             ...state.instanceOrder.filter((id) => id !== createdId),
@@ -370,15 +400,10 @@ const createUseAppStore = () =>
           const inst = state.instances[instanceId];
           if (!inst || !inst.isLoading) return state;
 
-          const instances = { ...state.instances };
-          Object.keys(instances).forEach((id) => {
-            const shouldBeForeground = id === instanceId;
-            if (id === instanceId) {
-              instances[id] = { ...inst, isLoading: false, isForeground: true };
-            } else if (instances[id].isForeground !== shouldBeForeground) {
-              instances[id] = { ...instances[id], isForeground: false };
-            }
-          });
+          const instances = {
+            ...state.instances,
+            [instanceId]: { ...inst, isLoading: false },
+          };
 
           const order = [
             ...state.instanceOrder.filter((id) => id !== instanceId),
@@ -420,15 +445,6 @@ const createUseAppStore = () =>
           }
           if (!nextForeground && order.length)
             nextForeground = order[order.length - 1];
-          Object.keys(instances).forEach((id) => {
-            const shouldBeForeground = id === nextForeground;
-            if (instances[id].isForeground !== shouldBeForeground) {
-              instances[id] = {
-                ...instances[id],
-                isForeground: shouldBeForeground,
-              };
-            }
-          });
           if (nextForeground) {
             order = [
               ...order.filter((id) => id !== nextForeground),
@@ -461,25 +477,9 @@ const createUseAppStore = () =>
 
           if (instanceId === state.foregroundInstanceId) return state;
 
-          const instances = { ...state.instances };
           let order = state.instanceOrder;
           let foreground: string | null = null;
-          if (!instanceId) {
-            Object.keys(instances).forEach((id) => {
-              if (instances[id].isForeground) {
-                instances[id] = { ...instances[id], isForeground: false };
-              }
-            });
-          } else {
-            Object.keys(instances).forEach((id) => {
-              const shouldBeForeground = id === instanceId;
-              if (instances[id].isForeground !== shouldBeForeground) {
-                instances[id] = {
-                  ...instances[id],
-                  isForeground: shouldBeForeground,
-                };
-              }
-            });
+          if (instanceId) {
             order = [...order.filter((id) => id !== instanceId), instanceId];
             foreground = instanceId;
           }
@@ -487,19 +487,18 @@ const createUseAppStore = () =>
             new CustomEvent("instanceStateChange", {
               detail: {
                 instanceId,
-                isOpen: !!instances[instanceId]?.isOpen,
+                isOpen: !!state.instances[instanceId]?.isOpen,
                 isForeground: !!foreground && foreground === instanceId,
               },
             })
           );
-          if (foreground && instances[foreground]) {
+          if (foreground && state.instances[foreground]) {
             track(APP_ANALYTICS.APP_FOCUS, {
-              appId: instances[foreground].appId,
-              openWindowCount: Object.keys(instances).length,
+              appId: state.instances[foreground].appId,
+              openWindowCount: Object.keys(state.instances).length,
             });
           }
           return {
-            instances,
             instanceOrder: order,
             foregroundInstanceId: foreground,
           };
@@ -526,11 +525,18 @@ const createUseAppStore = () =>
           };
         }),
 
-      getInstancesByAppId: (appId) =>
-        Object.values(get().instances).filter((i) => i.appId === appId),
+      getInstancesByAppId: (appId) => {
+        const state = get();
+        return Object.values(state.instances)
+          .filter((i) => i.appId === appId)
+          .map((i) => withDerivedForeground(i, state.foregroundInstanceId));
+      },
       getForegroundInstance: () => {
         const id = get().foregroundInstanceId;
-        return id ? get().instances[id] || null : null;
+        const instance = id ? get().instances[id] : null;
+        return instance
+          ? withDerivedForeground(instance, get().foregroundInstanceId)
+          : null;
       },
       navigateToNextInstance: (currentId) => {
         const { instanceOrder } = get();
@@ -554,7 +560,7 @@ const createUseAppStore = () =>
           if (!inst || inst.isMinimized) return state;
 
           const instances = { ...state.instances };
-          instances[instanceId] = { ...inst, isMinimized: true, isForeground: false };
+          instances[instanceId] = { ...inst, isMinimized: true };
 
           // Find next foreground from non-minimized windows
           let nextForeground: string | null = null;
@@ -564,10 +570,6 @@ const createUseAppStore = () =>
               nextForeground = id;
               break;
             }
-          }
-
-          if (nextForeground) {
-            instances[nextForeground] = { ...instances[nextForeground], isForeground: true };
           }
 
           window.dispatchEvent(
@@ -591,14 +593,10 @@ const createUseAppStore = () =>
           const inst = state.instances[instanceId];
           if (!inst || !inst.isMinimized) return state;
 
-          const instances = { ...state.instances };
-          Object.keys(instances).forEach((id) => {
-            if (id === instanceId) {
-              instances[id] = { ...inst, isMinimized: false, isForeground: true };
-            } else if (instances[id].isForeground) {
-              instances[id] = { ...instances[id], isForeground: false };
-            }
-          });
+          const instances = {
+            ...state.instances,
+            [instanceId]: { ...inst, isMinimized: false },
+          };
 
           // Move to end of order
           const order = [
@@ -776,13 +774,17 @@ const createUseAppStore = () =>
               }
               // Exclude launchOrigin from persisted state - restored windows should
               // animate from window center, not from the original icon position
-              const { launchOrigin: _, ...instWithoutLaunchOrigin } = inst;
+              const {
+                launchOrigin: _launchOrigin,
+                isForeground: _isForeground,
+                ...instWithoutRuntimeState
+              } = inst;
               
               // For applet-viewer, exclude content from initialData to prevent localStorage storage
               if (inst.appId === "applet-viewer" && inst.initialData) {
                 const appletData = inst.initialData as { path?: string; content?: string; shareCode?: string; icon?: string; name?: string };
                 acc.push([id, {
-                  ...instWithoutLaunchOrigin,
+                  ...instWithoutRuntimeState,
                   initialData: {
                     ...appletData,
                     content: "", // Exclude content - it should be loaded from IndexedDB
@@ -790,7 +792,7 @@ const createUseAppStore = () =>
                 } as AppInstance]);
                 return acc;
               }
-              acc.push([id, instWithoutLaunchOrigin as AppInstance]);
+              acc.push([id, instWithoutRuntimeState as AppInstance]);
               return acc;
             }, [])
         ),
@@ -885,6 +887,18 @@ const createUseAppStore = () =>
           remapLegacyAppIdsInAppStore(prev);
         }
 
+        if (version < 6) {
+          let legacyForegroundId: string | null = null;
+          for (const [id, inst] of Object.entries(prev.instances)) {
+            if (inst.isForeground && inst.isOpen) {
+              legacyForegroundId = id;
+            }
+            prev.instances[id] = stripInstanceForeground(inst);
+          }
+          prev.foregroundInstanceId =
+            legacyForegroundId || getDerivedForegroundInstanceId(prev);
+        }
+
         prev.version = CURRENT_APP_STORE_VERSION;
         return prev;
         },
@@ -900,6 +914,7 @@ const createUseAppStore = () =>
             state as unknown as { instanceOrder?: string[] }
           ).instanceOrder!.filter((id: string) => state.instances[id]);
         }
+        state.foregroundInstanceId = getDerivedForegroundInstanceId(state);
         // Fix nextInstanceId
         if (state.instances && Object.keys(state.instances).length) {
           const max = Math.max(
@@ -910,7 +925,8 @@ const createUseAppStore = () =>
         }
         // Ensure positions & sizes
         Object.keys(state.instances || {}).forEach((id) => {
-          const inst = state.instances[id];
+          const inst = stripInstanceForeground(state.instances[id]);
+          state.instances[id] = inst;
           if (!inst.createdAt) {
             const numericId = parseInt(id, 10);
             inst.createdAt = !isNaN(numericId) ? numericId : Date.now();

--- a/tests/test-app-store-foreground-state.test.ts
+++ b/tests/test-app-store-foreground-state.test.ts
@@ -1,0 +1,103 @@
+#!/usr/bin/env bun
+
+import { beforeAll, beforeEach, describe, expect, test } from "bun:test";
+import type { useAppStore as UseAppStoreHook } from "../src/stores/useAppStore";
+
+let useAppStore: typeof UseAppStoreHook;
+
+function installBrowserStubs() {
+  const storage = new Map<string, string>();
+  const localStorageStub = {
+    clear: () => storage.clear(),
+    getItem: (key: string) => storage.get(key) ?? null,
+    removeItem: (key: string) => storage.delete(key),
+    setItem: (key: string, value: string) => {
+      storage.set(key, value);
+    },
+  };
+
+  Object.defineProperty(globalThis, "localStorage", {
+    configurable: true,
+    value: localStorageStub,
+  });
+
+  if (typeof globalThis.CustomEvent === "undefined") {
+    class TestCustomEvent<T = unknown> extends Event {
+      detail: T;
+
+      constructor(type: string, init?: CustomEventInit<T>) {
+        super(type);
+        this.detail = init?.detail as T;
+      }
+    }
+    Object.defineProperty(globalThis, "CustomEvent", {
+      configurable: true,
+      value: TestCustomEvent,
+    });
+  }
+
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: {
+      dispatchEvent: () => true,
+      innerWidth: 1024,
+    },
+  });
+}
+
+beforeAll(async () => {
+  installBrowserStubs();
+  ({ useAppStore } = await import("../src/stores/useAppStore"));
+});
+
+beforeEach(() => {
+  localStorage.clear();
+  useAppStore.setState({
+    instances: {},
+    instanceOrder: [],
+    foregroundInstanceId: null,
+    nextInstanceId: 0,
+    recentApps: [],
+    recentDocuments: [],
+  });
+});
+
+describe("useAppStore foreground state", () => {
+  test("focus changes preserve instance object identity", () => {
+    const store = useAppStore.getState();
+    const firstId = store.createAppInstance("textedit");
+    const secondId = useAppStore.getState().createAppInstance("finder");
+
+    useAppStore.getState().markInstanceAsLoaded(firstId);
+    useAppStore.getState().markInstanceAsLoaded(secondId);
+
+    const beforeFocusState = useAppStore.getState();
+    const beforeInstances = beforeFocusState.instances;
+    const beforeFirst = beforeInstances[firstId];
+    const beforeSecond = beforeInstances[secondId];
+
+    useAppStore.getState().bringInstanceToForeground(firstId);
+
+    const afterFocusState = useAppStore.getState();
+    expect(afterFocusState.foregroundInstanceId).toBe(firstId);
+    expect(afterFocusState.instanceOrder.at(-1)).toBe(firstId);
+    expect(afterFocusState.instances).toBe(beforeInstances);
+    expect(afterFocusState.instances[firstId]).toBe(beforeFirst);
+    expect(afterFocusState.instances[secondId]).toBe(beforeSecond);
+    expect("isForeground" in afterFocusState.instances[firstId]).toBe(false);
+    expect("isForeground" in afterFocusState.instances[secondId]).toBe(false);
+  });
+
+  test("foreground helpers derive isForeground from foregroundInstanceId", () => {
+    const id = useAppStore.getState().createAppInstance("textedit");
+    useAppStore.getState().markInstanceAsLoaded(id);
+
+    const foreground = useAppStore.getState().getForegroundInstance();
+    const instances = useAppStore.getState().getInstancesByAppId("textedit");
+
+    expect(foreground?.instanceId).toBe(id);
+    expect(foreground?.isForeground).toBe(true);
+    expect(instances).toHaveLength(1);
+    expect(instances[0].isForeground).toBe(true);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Store foreground focus as `foregroundInstanceId` instead of mutating per-instance `isForeground` flags.
- Memoize managed window rendering and isolate app roots from z-order container rerenders.
- Narrow Dock subscriptions to a compact open-instance signature and derive menu foreground state from the foreground id.
- Add regression coverage proving focus changes preserve instance object identity.

### Testing
- `bun test tests/test-app-store-foreground-state.test.ts tests/test-dock-open-items.test.ts`
- `bun run build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1f9728b6-b104-46a6-ba75-62d066d3aa34"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1f9728b6-b104-46a6-ba75-62d066d3aa34"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

