### PR TITLE
perf(ipod,karaoke): isolate ~20Hz playback clock from root logic hooks

### DIFF
--- a/src/apps/ipod/components/ipod-app/IpodAppDialogs.tsx
+++ b/src/apps/ipod/components/ipod-app/IpodAppDialogs.tsx
@@ -6,6 +6,7 @@ import { SongSearchDialog } from "@/components/dialogs/SongSearchDialog";
 import { LyricsSyncMode } from "@/components/shared/LyricsSyncMode";
 import { appMetadata } from "../..";
 import type { IpodAppController } from "./useIpodAppController";
+import { useIpodElapsedTime } from "../../hooks/useIpodElapsedTime";
 
 type IpodAppDialogsProps = {
   c: IpodAppController;
@@ -48,7 +49,6 @@ export function IpodAppDialogs({ c }: IpodAppDialogsProps) {
     isFullScreen,
     isSyncModeOpen,
     fullScreenLyricsControls,
-    elapsedTime,
     totalTime,
     lyricOffset,
     romanization,
@@ -58,6 +58,9 @@ export function IpodAppDialogs({ c }: IpodAppDialogsProps) {
     playerRef,
     closeSyncMode,
   } = c;
+  // The ~20Hz playback clock is only needed while the lyrics sync-mode
+  // overlay is visible; otherwise opt out of tick re-renders entirely.
+  const elapsedTime = useIpodElapsedTime(!isFullScreen && isSyncModeOpen);
 
   return (
     <>

--- a/src/apps/ipod/components/ipod-app/IpodFullScreenView.tsx
+++ b/src/apps/ipod/components/ipod-app/IpodFullScreenView.tsx
@@ -10,6 +10,7 @@ import { FullScreenPortal } from "../FullScreenPortal";
 import { LyricsDisplay } from "../lyrics-display/LyricsDisplay";
 import { useSaveSongCoverColor } from "@/hooks/useSaveSongCoverColor";
 import type { IpodAppController } from "./useIpodAppController";
+import { useIpodElapsedTime } from "../../hooks/useIpodElapsedTime";
 import {
   AmbientBackground,
   LandscapeVideoBackground,
@@ -55,7 +56,6 @@ export function IpodFullScreenView({ c }: IpodFullScreenViewProps) {
     handleDisplayModeSelect,
     displayModeOptions,
     fullScreenLyricsControls,
-    elapsedTime,
     totalTime,
     lyricOffset,
     furiganaMap,
@@ -84,6 +84,8 @@ export function IpodFullScreenView({ c }: IpodFullScreenViewProps) {
     seekTime,
   } = c;
   const saveCoverColor = useSaveSongCoverColor(currentTrack);
+  // Only subscribe to the ~20Hz playback clock while fullscreen is visible.
+  const elapsedTime = useIpodElapsedTime(isFullScreen);
 
   if (!isFullScreen) return null;
 

--- a/src/apps/ipod/components/ipod-app/IpodScreenArea.tsx
+++ b/src/apps/ipod/components/ipod-app/IpodScreenArea.tsx
@@ -54,7 +54,6 @@ export function IpodScreenArea({ c }: IpodScreenAreaProps) {
     setSelectedMenuItem,
     menuDirection,
     handleMenuItemAction,
-    elapsedTime,
     totalTime,
     nowPlayingScope,
     statusMessage,
@@ -112,7 +111,6 @@ export function IpodScreenArea({ c }: IpodScreenAreaProps) {
       <IpodScreen
         currentTrack={tracks[currentIndex] || null}
         isPlaying={isPlaying && !isFullScreen}
-        elapsedTime={elapsedTime}
         totalTime={totalTime}
         menuMode={menuMode}
         menuHistory={menuHistory}

--- a/src/apps/ipod/components/ipod-screen/IpodScreen.tsx
+++ b/src/apps/ipod/components/ipod-screen/IpodScreen.tsx
@@ -20,6 +20,7 @@ import {
 import { youtubeThumbnailUrl } from "@/utils/youtubeUrl";
 import { DisplayMode } from "@/types/lyrics";
 import type { IpodScreenProps } from "../../types";
+import { useIpodElapsedTime } from "../../hooks/useIpodElapsedTime";
 import { useIpodStore, isAppleMusicCollectionTrack } from "@/stores/useIpodStore";
 import {
   MENU_ITEM_HEIGHT_CLASSIC,
@@ -41,7 +42,6 @@ import { IpodScreenSplitArtPanel } from "./IpodScreenSplitArtPanel";
 export function IpodScreen({
   currentTrack,
   isPlaying,
-  elapsedTime,
   totalTime,
   menuMode,
   menuHistory,
@@ -89,6 +89,9 @@ export function IpodScreen({
   fastScrollLetter = null,
 }: IpodScreenProps) {
   const { t } = useTranslation();
+  // Subscribed here (the screen actually displays time) rather than in
+  // useIpodLogic, so ~20Hz playback ticks only re-render the screen subtree.
+  const elapsedTime = useIpodElapsedTime();
   
   const isAnyActivityActive = Boolean(
     activityState?.isLoadingLyrics ||

--- a/src/apps/ipod/hooks/useIpodElapsedTime.ts
+++ b/src/apps/ipod/hooks/useIpodElapsedTime.ts
@@ -1,0 +1,17 @@
+import { useIpodStore } from "@/stores/useIpodStore";
+
+/**
+ * Narrow subscription to the iPod playback clock.
+ *
+ * `elapsedTime` updates ~20x/sec while a track plays. Subscribing to it from
+ * `useIpodLogic` (or any other large hook) re-renders the entire iPod tree on
+ * every tick, so only leaf components that actually display time should call
+ * this hook.
+ *
+ * Pass `enabled: false` while the consuming UI is hidden (e.g. a closed
+ * dialog) to opt out of tick re-renders entirely — the selector then returns
+ * a constant `0`.
+ */
+export function useIpodElapsedTime(enabled: boolean = true): number {
+  return useIpodStore((s) => (enabled ? s.elapsedTime : 0));
+}

--- a/src/apps/ipod/hooks/useIpodLogic.ts
+++ b/src/apps/ipod/hooks/useIpodLogic.ts
@@ -304,20 +304,11 @@ export function useIpodLogic({
   );
 
 
-  const lyricOffset = useIpodStore(
-    (s) => {
-      const sourceTracks =
-        s.librarySource === "appleMusic" ? s.appleMusicTracks : s.tracks;
-      const sourceCurrentId =
-        s.librarySource === "appleMusic"
-          ? s.appleMusicCurrentSongId
-          : s.currentSongId;
-      const track = sourceCurrentId
-        ? sourceTracks.find((t) => t.id === sourceCurrentId)
-        : sourceTracks[0];
-      return track?.lyricOffset ?? 0;
-    }
-  );
+  // Derived from the active-library subscription instead of a store selector:
+  // a selector would run its O(n) track lookup on every store mutation
+  // (including each playback tick), while `tracks`/`currentIndex` only change
+  // on library or track-selection updates.
+  const lyricOffset = tracks[currentIndex]?.lyricOffset ?? 0;
 
   const prevIsForeground = useRef(isForeground);
   const {
@@ -422,7 +413,6 @@ export function useIpodLogic({
   const wasPlayingBeforeBrickGameRef = useRef(false);
 
   const {
-    elapsedTime,
     totalTime,
     setTotalTime,
     playerRef,
@@ -3965,9 +3955,9 @@ export function useIpodLogic({
   }, [loopCurrent, nextTrack, setIsPlaying, isFullScreen, startTrackSwitch]);
 
   const handleProgress = useCallback((state: { playedSeconds: number }) => {
-    // Single source of truth — zustand. The selector at the top of
-    // this hook re-subscribes us to the new value, so any code path
-    // that needs reactivity still gets it.
+    // Single source of truth — zustand. This hook intentionally does NOT
+    // subscribe to `elapsedTime` (that would re-run all of useIpodLogic on
+    // every tick); leaf components subscribe via `useIpodElapsedTime()`.
     useIpodStore.getState().setElapsedTime(state.playedSeconds);
   }, []);
 
@@ -3987,6 +3977,7 @@ export function useIpodLogic({
 
     const currentTrack = tracks[currentIndex];
     if (currentTrack) {
+      const elapsedTime = useIpodStore.getState().elapsedTime;
       const lastTracked = lastTrackedSongRef.current;
       const isNewTrack = !lastTracked || lastTracked.trackId !== currentTrack.id;
       const isStartingFromBeginning = elapsedTime < 1;
@@ -4000,7 +3991,7 @@ export function useIpodLogic({
         lastTrackedSongRef.current = { trackId: currentTrack.id, elapsedTime };
       }
     }
-  }, [setIsPlaying, showStatus, tracks, currentIndex, elapsedTime]);
+  }, [setIsPlaying, showStatus, tracks, currentIndex]);
 
   const handlePause = useCallback(() => {
     // Don't update state if we're in the middle of a track switch
@@ -4013,20 +4004,25 @@ export function useIpodLogic({
 
   const handleReady = useCallback(() => {}, []);
 
-  // Watchdog for blocked autoplay
+  // Watchdog for blocked autoplay: if the clock hasn't advanced 1.2s after
+  // entering the playing state, autoplay was likely blocked — flip back to
+  // paused. Reads the clock via getState() so this effect doesn't subscribe
+  // the whole hook to per-tick updates.
   useEffect(() => {
     if (!isPlaying || !isIOSSafari || userHasInteractedRef.current) return;
 
-    const startElapsed = elapsedTime;
+    const startElapsed = useIpodStore.getState().elapsedTime;
     const timer = setTimeout(() => {
-      if (useIpodStore.getState().isPlaying && elapsedTime === startElapsed) {
+      const { isPlaying: stillPlaying, elapsedTime: nowElapsed } =
+        useIpodStore.getState();
+      if (stillPlaying && nowElapsed === startElapsed) {
         setIsPlaying(false);
         showStatus("⏸");
       }
     }, 1200);
 
     return () => clearTimeout(timer);
-  }, [isPlaying, elapsedTime, setIsPlaying, showStatus, isIOSSafari]);
+  }, [isPlaying, setIsPlaying, showStatus, isIOSSafari]);
 
   // Menu button handler
   const handleMenuButton = useCallback(() => {
@@ -4870,7 +4866,10 @@ export function useIpodLogic({
     songId: lyricsSongId,
     title: lyricsTitle,
     artist: lyricsArtist,
-    currentTime: elapsedTime + lyricsTimingOffsetMs / 1000,
+    // Static value: passing the live clock here would re-render this entire
+    // hook ~20x/sec. Current-line tracking is driven by the store
+    // subscription effect below via `updateCurrentTimeManually`.
+    currentTime: 0,
     translateTo: effectiveTranslationLanguage,
     selectedMatch: selectedMatchForLyrics,
     includeFurigana: true, // Fetch furigana info with lyrics to reduce API calls
@@ -4883,6 +4882,34 @@ export function useIpodLogic({
     // Auth for force refresh / changing lyrics source
     auth,
   });
+
+  // Drive lyrics current-line tracking from the playback clock without
+  // subscribing this (very large) hook to `elapsedTime`. The store
+  // subscription runs outside React; `updateCurrentTimeManually` only
+  // triggers a re-render when the current lyric line index changes.
+  const updateLyricsTimeRef = useRef(
+    fullScreenLyricsControls.updateCurrentTimeManually
+  );
+  updateLyricsTimeRef.current =
+    fullScreenLyricsControls.updateCurrentTimeManually;
+  const lyricsTimingOffsetMsRef = useRef(lyricsTimingOffsetMs);
+  lyricsTimingOffsetMsRef.current = lyricsTimingOffsetMs;
+
+  useEffect(() => {
+    const syncLyricsTime = (elapsedSeconds: number) => {
+      updateLyricsTimeRef.current(
+        elapsedSeconds + lyricsTimingOffsetMsRef.current / 1000
+      );
+    };
+    // Re-sync immediately when lyrics load or the timing offset changes
+    // (deps below), then follow the clock.
+    syncLyricsTime(useIpodStore.getState().elapsedTime);
+    return useIpodStore.subscribe((state, prevState) => {
+      if (state.elapsedTime !== prevState.elapsedTime) {
+        syncLyricsTime(state.elapsedTime);
+      }
+    });
+  }, [fullScreenLyricsControls.lines, lyricsTimingOffsetMs]);
 
   // Show toast with Search button when lyrics fetch fails
   useLyricsErrorToast({
@@ -4980,7 +5007,9 @@ export function useIpodLogic({
       }
 
       if (isFullScreen) {
-        const currentTime = playerRef.current?.getCurrentTime() || elapsedTime;
+        const currentTime =
+          playerRef.current?.getCurrentTime() ||
+          useIpodStore.getState().elapsedTime;
         const wasPlaying = isPlaying;
 
         // Wait for fullscreen player to be ready before seeking
@@ -5009,7 +5038,9 @@ export function useIpodLogic({
         };
         scheduleTimeout(checkAndSync, 100);
       } else {
-        const currentTime = fullScreenPlayerRef.current?.getCurrentTime() || elapsedTime;
+        const currentTime =
+          fullScreenPlayerRef.current?.getCurrentTime() ||
+          useIpodStore.getState().elapsedTime;
         const wasPlaying = isPlaying;
 
         scheduleTimeout(() => {
@@ -5031,7 +5062,7 @@ export function useIpodLogic({
       timeoutIds.forEach((timeoutId) => clearTimeout(timeoutId));
       timeoutIds.clear();
     };
-  }, [isAppleMusic, isFullScreen, elapsedTime, isPlaying, setIsPlaying, isIOSSafari]);
+  }, [isAppleMusic, isFullScreen, isPlaying, setIsPlaying, isIOSSafari]);
 
   // Seek time for fullscreen (delta)
   const seekTime = useCallback(
@@ -5249,7 +5280,9 @@ export function useIpodLogic({
 
     // State
     statusMessage,
-    elapsedTime,
+    // NOTE: `elapsedTime` is intentionally NOT exposed here. Subscribing to
+    // the ~20Hz playback clock from this hook would re-render the whole iPod
+    // tree per tick — leaf components use `useIpodElapsedTime()` instead.
     totalTime,
     scale,
     menuMode,

--- a/src/apps/ipod/hooks/useIpodPlayback.ts
+++ b/src/apps/ipod/hooks/useIpodPlayback.ts
@@ -13,7 +13,10 @@ export function useIpodPlayback(options: {
   musicKitInstanceRef: React.MutableRefObject<MusicKitLike>;
 }) {
   const { isWindowOpen, isFullScreen, musicKitInstanceRef } = options;
-  const elapsedTime = useIpodStore((state) => state.elapsedTime);
+  // NOTE: deliberately no `elapsedTime` subscription here. The playback clock
+  // updates ~20x/sec; subscribing would re-run the entire iPod logic hook on
+  // every tick. Leaf components use `useIpodElapsedTime()` instead, and logic
+  // callbacks read `useIpodStore.getState().elapsedTime` on demand.
   const [totalTime, setTotalTime] = useState(0);
   const playerRef = useRef<ReactPlayer | null>(null);
   const fullScreenPlayerRef = useRef<ReactPlayer | null>(null);
@@ -74,7 +77,6 @@ export function useIpodPlayback(options: {
   }, [isWindowOpen, pauseBeforeWindowClose]);
 
   return {
-    elapsedTime,
     totalTime,
     setTotalTime,
     playerRef,

--- a/src/apps/ipod/types.ts
+++ b/src/apps/ipod/types.ts
@@ -155,7 +155,6 @@ export interface FullScreenPortalProps {
 export interface IpodScreenProps {
   currentTrack: Track | null;
   isPlaying: boolean;
-  elapsedTime: number;
   totalTime: number;
   menuMode: boolean;
   menuHistory: MenuHistoryEntry[];

--- a/src/stores/playbackTime.ts
+++ b/src/stores/playbackTime.ts
@@ -1,0 +1,16 @@
+/**
+ * Shared guard for high-frequency playback clock writes (iPod, Karaoke).
+ *
+ * Media players report progress many times per second; persisting every tick
+ * to a Zustand store re-renders every subscriber at that rate. Skipping
+ * updates smaller than this epsilon caps the store update frequency while
+ * keeping lyric/progress display accuracy well below perceptible thresholds.
+ */
+export const PLAYBACK_TIME_UPDATE_EPSILON_SECONDS = 0.05;
+
+export function shouldUpdatePlaybackTime(
+  previous: number,
+  next: number
+): boolean {
+  return Math.abs(previous - next) >= PLAYBACK_TIME_UPDATE_EPSILON_SECONDS;
+}

--- a/src/stores/useIpodStore.ts
+++ b/src/stores/useIpodStore.ts
@@ -29,6 +29,7 @@ import {
 import { parseYouTubeVideoId } from "@/utils/youtubeUrl";
 import { emitCloudSyncDomainChange } from "@/utils/cloudSyncEvents";
 import { sortTracksLikeServerOrder } from "@/stores/ipodTrackOrder";
+import { shouldUpdatePlaybackTime } from "@/stores/playbackTime";
 import {
   hasFetchedTrackMetadataChanges,
   hasLibraryTrackMetadataChanges,
@@ -181,11 +182,6 @@ export function appleMusicKitIdToLyricsSongId(
 }
 
 type LibraryState = "uninitialized" | "loaded" | "cleared";
-const PLAYBACK_TIME_UPDATE_EPSILON_SECONDS = 0.05;
-
-function shouldUpdatePlaybackTime(previous: number, next: number): boolean {
-  return Math.abs(previous - next) >= PLAYBACK_TIME_UPDATE_EPSILON_SECONDS;
-}
 
 interface IpodData {
   tracks: Track[];

--- a/src/stores/useKaraokeStore.ts
+++ b/src/stores/useKaraokeStore.ts
@@ -3,6 +3,7 @@ import { persist } from "zustand/middleware";
 import type { SetStateAction } from "react";
 import { DisplayMode } from "@/types/lyrics";
 import { useIpodStore, Track } from "./useIpodStore";
+import { shouldUpdatePlaybackTime } from "./playbackTime";
 
 /** Helper to get current index from song ID */
 function getIndexFromSongId(tracks: Track[], songId: string | null): number {
@@ -242,10 +243,17 @@ export const useKaraokeStore = create<KaraokeState>()(
       setKaraokeKtvRoomFx: (karaokeKtvRoomFx) => set({ karaokeKtvRoomFx }),
 
       setElapsedTime: (time) =>
-        set((state) => ({
-          elapsedTime:
-            typeof time === "function" ? (time as (prev: number) => number)(state.elapsedTime) : time,
-        })),
+        set((state) => {
+          const next =
+            typeof time === "function"
+              ? (time as (prev: number) => number)(state.elapsedTime)
+              : time;
+          // Throttle high-frequency player progress ticks (same epsilon as
+          // iPod) so subscribers don't re-render on every sub-frame update.
+          return shouldUpdatePlaybackTime(state.elapsedTime, next)
+            ? { elapsedTime: next }
+            : state;
+        }),
       setTotalTime: (time) => set({ totalTime: time }),
 
       setDisplayMode: (mode) => set({ displayMode: mode }),

--- a/tests/test-playback-time-throttle.test.ts
+++ b/tests/test-playback-time-throttle.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Guardrail tests for the playback clock throttle + subscription wiring.
+ *
+ * `elapsedTime` updates ~20x/sec during playback. Two invariants keep that
+ * cheap:
+ *   1. Both media stores (iPod, Karaoke) gate `setElapsedTime` behind the
+ *      shared `shouldUpdatePlaybackTime` epsilon so redundant ticks never
+ *      notify subscribers.
+ *   2. The big iPod logic hook never subscribes to `elapsedTime` — only leaf
+ *      components do (via `useIpodElapsedTime`), so a tick re-renders the
+ *      screen subtree instead of the whole app.
+ */
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, test, expect } from "bun:test";
+
+import {
+  PLAYBACK_TIME_UPDATE_EPSILON_SECONDS,
+  shouldUpdatePlaybackTime,
+} from "../src/stores/playbackTime";
+
+const readSource = (relativePath: string): string =>
+  readFileSync(resolve(process.cwd(), relativePath), "utf-8");
+
+describe("shouldUpdatePlaybackTime", () => {
+  test("skips sub-epsilon updates and accepts larger ones", () => {
+    expect(shouldUpdatePlaybackTime(10, 10)).toBe(false);
+    expect(
+      shouldUpdatePlaybackTime(10, 10 + PLAYBACK_TIME_UPDATE_EPSILON_SECONDS / 2)
+    ).toBe(false);
+    expect(
+      shouldUpdatePlaybackTime(10, 10 + PLAYBACK_TIME_UPDATE_EPSILON_SECONDS)
+    ).toBe(true);
+    expect(shouldUpdatePlaybackTime(10, 11)).toBe(true);
+  });
+
+  test("is symmetric (seeks backwards also update)", () => {
+    expect(shouldUpdatePlaybackTime(120, 0)).toBe(true);
+    expect(
+      shouldUpdatePlaybackTime(10, 10 - PLAYBACK_TIME_UPDATE_EPSILON_SECONDS / 2)
+    ).toBe(false);
+  });
+});
+
+describe("store wiring", () => {
+  test("iPod store gates setElapsedTime/setTotalTime behind the shared epsilon", () => {
+    const source = readSource("src/stores/useIpodStore.ts");
+    expect(source).toContain('from "@/stores/playbackTime"');
+    expect(source).toMatch(
+      /setElapsedTime: \(time\) =>\s*set\(\(state\) =>\s*shouldUpdatePlaybackTime\(state\.elapsedTime, time\)/
+    );
+    expect(source).toMatch(
+      /setTotalTime: \(time\) =>\s*set\(\(state\) =>\s*shouldUpdatePlaybackTime\(state\.totalTime, time\)/
+    );
+  });
+
+  test("Karaoke store gates setElapsedTime behind the shared epsilon", () => {
+    const source = readSource("src/stores/useKaraokeStore.ts");
+    expect(source).toContain('from "./playbackTime"');
+    expect(source).toMatch(
+      /shouldUpdatePlaybackTime\(state\.elapsedTime, next\)/
+    );
+  });
+});
+
+describe("iPod elapsedTime subscription wiring", () => {
+  test("useIpodPlayback does not subscribe to the playback clock", () => {
+    const source = readSource("src/apps/ipod/hooks/useIpodPlayback.ts");
+    expect(source).not.toMatch(/useIpodStore\(\s*\(\s*state\s*\)\s*=>\s*state\.elapsedTime\s*\)/);
+  });
+
+  test("useIpodLogic reads the clock via getState() and drives lyrics via store subscription", () => {
+    const source = readSource("src/apps/ipod/hooks/useIpodLogic.ts");
+    // No reactive selector on elapsedTime anywhere in the logic hook.
+    expect(source).not.toMatch(/useIpodStore\(\s*\([^)]*\)\s*=>[^)]*\.elapsedTime/);
+    // Lyrics current-line tracking runs off a vanilla store subscription.
+    expect(source).toMatch(/useIpodStore\.subscribe\(\(state, prevState\) =>/);
+    // The logic hook must not re-expose elapsedTime to the controller bag.
+    expect(source).not.toMatch(/^\s{4}elapsedTime,\s*$/m);
+  });
+
+  test("leaf components subscribe via useIpodElapsedTime", () => {
+    for (const file of [
+      "src/apps/ipod/components/ipod-screen/IpodScreen.tsx",
+      "src/apps/ipod/components/ipod-app/IpodFullScreenView.tsx",
+      "src/apps/ipod/components/ipod-app/IpodAppDialogs.tsx",
+    ]) {
+      expect(readSource(file)).toContain("useIpodElapsedTime(");
+    }
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

`useIpodPlayback` subscribed to `useIpodStore.elapsedTime`, which updates ~20x/sec during playback. That re-ran the entire 5,388-line `useIpodLogic` hook on every tick, rebuilt its ~150-key controller bag, and re-rendered every iPod subtree (device body, fullscreen view, PiP player, dialogs). A `lyricOffset` store selector additionally ran an O(n) `tracks.find()` on every store mutation. Karaoke was worse: `useKaraokeStore.setElapsedTime` had no throttle at all, so every raw ReactPlayer progress event re-rendered the karaoke lyrics tree and `IpodWidget`.

## Changes

- **`useIpodLogic` no longer subscribes to the playback clock.** Callbacks (`handlePlay`, autoplay watchdog, fullscreen player sync) read `useIpodStore.getState().elapsedTime` on demand; `elapsedTime` is removed from the controller bag.
- **Lyrics current-line tracking** is driven by a vanilla `useIpodStore.subscribe` bridge calling `updateCurrentTimeManually` — the hook re-renders only when the current lyric line index changes (every few seconds), not per tick. `useLyrics`'s public API is unchanged.
- **New `useIpodElapsedTime()` leaf hook** — `IpodScreen` (time labels, progress, lyrics overlay), `IpodFullScreenView` (gated on fullscreen), and `IpodAppDialogs` (gated on sync-mode being open) subscribe directly, so ticks re-render only the subtrees that display time.
- **`lyricOffset`** is now derived from the already-subscribed `tracks`/`currentIndex` instead of an O(n) selector that ran on every store mutation (including each tick).
- **Karaoke `setElapsedTime` is throttled** with the same 0.05s epsilon as iPod via a new shared `src/stores/playbackTime.ts` helper (deduplicates the logic between both stores).
- **Guardrail tests** (`tests/test-playback-time-throttle.test.ts`) cover the epsilon behavior and the subscription wiring so the clock can't silently leak back into the root hooks.

## Result

During playback, a clock tick now re-renders only `IpodScreen` + its chrome (and the fullscreen overlay when open) instead of the entire iPod app; Karaoke store updates are capped at the same rate as iPod instead of firing per progress event.

## Testing

- ✅ `bunx tsc -b --force` — clean
- ✅ `bun run test:unit` — 306 pass / 0 fail
- ✅ `bun test tests/test-playback-time-throttle.test.ts` — 7 pass (new guardrails)
- ✅ `bun run build` — builds successfully
- ✅ `bunx eslint` on changed files — 0 errors, warnings identical to `main` (pre-existing)
- ✅ `bun run dev` smoke test — frontend serves HTTP 200
- ⚠️ `tests/test-ipod-library-index.test.ts` fails on `main` too (pre-existing `localStorage` env issue, unrelated)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-819f5fdd-4d5f-4944-83d4-bde8c75427ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-819f5fdd-4d5f-4944-83d4-bde8c75427ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

