### PR TITLE
Lazy-load shader performance check

### DIFF
--- a/src/stores/useDisplaySettingsStore.ts
+++ b/src/stores/useDisplaySettingsStore.ts
@@ -83,9 +83,13 @@ interface DisplaySettingsState {
 
   // Shader settings
   shaderEffectEnabled: boolean;
+  shaderPerformanceCapable: boolean | null;
+  hasExplicitShaderEffectPreference: boolean;
   selectedShaderType: ShaderType;
   setShaderEffectEnabled: (v: boolean) => void;
   setSelectedShaderType: (t: ShaderType) => void;
+  ensureShaderPerformanceChecked: () => Promise<boolean>;
+  scheduleShaderPerformanceCheck: () => void;
 
   // Wallpaper
   currentWallpaper: string;
@@ -118,7 +122,32 @@ interface DisplaySettingsState {
 }
 
 const STORE_VERSION = 1;
-const initialShaderState = checkShaderPerformance();
+let shaderPerformanceCheckPromise: Promise<boolean> | null = null;
+let shaderPerformanceIdleHandle: number | ReturnType<typeof setTimeout> | null =
+  null;
+
+const hasOwn = (obj: unknown, key: PropertyKey) =>
+  Object.prototype.hasOwnProperty.call(obj, key);
+
+const scheduleIdleShaderPerformanceCheck = (callback: () => void) => {
+  if (typeof window === "undefined" || shaderPerformanceIdleHandle !== null) {
+    return;
+  }
+
+  const run = () => {
+    shaderPerformanceIdleHandle = null;
+    callback();
+  };
+
+  if ("requestIdleCallback" in window) {
+    shaderPerformanceIdleHandle = window.requestIdleCallback(() => run(), {
+      timeout: 5000,
+    });
+    return;
+  }
+
+  shaderPerformanceIdleHandle = globalThis.setTimeout(run, 1);
+};
 
 export const useDisplaySettingsStore = create<DisplaySettingsState>()(
   persist(
@@ -134,15 +163,52 @@ export const useDisplaySettingsStore = create<DisplaySettingsState>()(
       },
 
       // Shader settings
-      shaderEffectEnabled: initialShaderState,
+      shaderEffectEnabled: false,
+      shaderPerformanceCapable: null,
+      hasExplicitShaderEffectPreference: false,
       selectedShaderType: ShaderType.AURORA,
       setShaderEffectEnabled: (enabled) => {
-        set({ shaderEffectEnabled: enabled });
+        if (enabled && get().shaderPerformanceCapable === null) {
+          void get().ensureShaderPerformanceChecked();
+        }
+        set({
+          shaderEffectEnabled: enabled,
+          hasExplicitShaderEffectPreference: true,
+        });
         track(SETTINGS_ANALYTICS.SHADER_TOGGLE, { enabled });
       },
       setSelectedShaderType: (t) => {
         set({ selectedShaderType: t });
         track(SETTINGS_ANALYTICS.SHADER_TYPE_CHANGE, { shaderType: t });
+      },
+      ensureShaderPerformanceChecked: async () => {
+        const cachedResult = get().shaderPerformanceCapable;
+        if (cachedResult !== null) return cachedResult;
+
+        shaderPerformanceCheckPromise ??= checkShaderPerformance().catch(
+          (error) => {
+            console.error(
+              "[DisplaySettings] Shader performance check failed",
+              error
+            );
+            return false;
+          }
+        );
+
+        const capable = await shaderPerformanceCheckPromise;
+        set((state) => ({
+          shaderPerformanceCapable: capable,
+          shaderEffectEnabled: state.hasExplicitShaderEffectPreference
+            ? state.shaderEffectEnabled
+            : capable,
+        }));
+        return capable;
+      },
+      scheduleShaderPerformanceCheck: () => {
+        if (get().shaderPerformanceCapable !== null) return;
+        scheduleIdleShaderPerformanceCheck(() => {
+          void get().ensureShaderPerformanceChecked();
+        });
       },
 
       // Wallpaper
@@ -315,6 +381,7 @@ export const useDisplaySettingsStore = create<DisplaySettingsState>()(
       partialize: (state) => ({
         displayMode: state.displayMode,
         shaderEffectEnabled: state.shaderEffectEnabled,
+        shaderPerformanceCapable: state.shaderPerformanceCapable,
         selectedShaderType: state.selectedShaderType,
         currentWallpaper: state.currentWallpaper,
         wallpaperSource: state.wallpaperSource,
@@ -325,10 +392,21 @@ export const useDisplaySettingsStore = create<DisplaySettingsState>()(
         htmlPreviewSplit: state.htmlPreviewSplit,
       }),
       merge: (persistedState, currentState) => {
+        const persistedDisplayState =
+          (persistedState as Partial<DisplaySettingsState> | undefined) ?? {};
+        const hasExplicitShaderEffectPreference = hasOwn(
+          persistedDisplayState,
+          "shaderEffectEnabled"
+        );
         const merged = {
           ...currentState,
-          ...(persistedState as Partial<DisplaySettingsState> | undefined),
+          ...persistedDisplayState,
+          hasExplicitShaderEffectPreference,
         };
+        const shaderPerformanceCapable =
+          typeof merged.shaderPerformanceCapable === "boolean"
+            ? merged.shaderPerformanceCapable
+            : null;
         const cw = merged.currentWallpaper;
         const ws = merged.wallpaperSource;
         // Persisted blob: object URLs are invalid after reload; never hydrate them as the CSS/video src.
@@ -338,9 +416,12 @@ export const useDisplaySettingsStore = create<DisplaySettingsState>()(
           typeof ws === "string" &&
           (ws.startsWith("blob:") || ws === cw)
         ) {
-          return { ...merged, wallpaperSource: cw };
+          return { ...merged, shaderPerformanceCapable, wallpaperSource: cw };
         }
-        return merged;
+        return { ...merged, shaderPerformanceCapable };
+      },
+      onRehydrateStorage: () => (state) => {
+        state?.scheduleShaderPerformanceCheck();
       },
     }
   )

--- a/src/utils/performanceCheck.ts
+++ b/src/utils/performanceCheck.ts
@@ -1,5 +1,3 @@
-import * as THREE from 'three';
-
 /**
  * Checks for basic performance indicators to estimate if the device
  * is likely capable of handling intensive shader effects smoothly.
@@ -7,36 +5,43 @@ import * as THREE from 'three';
  *
  * @returns {boolean} True if the device passes the checks, false otherwise.
  */
-export function checkShaderPerformance(): boolean {
-  console.log('[PerformanceCheck] Running checks...');
+export async function checkShaderPerformance(): Promise<boolean> {
+  console.log("[PerformanceCheck] Running checks...");
+
+  if (typeof navigator === "undefined") {
+    return false;
+  }
 
   // 1. Check CPU Cores
   const coreCount = navigator.hardwareConcurrency;
   const hasEnoughCores = coreCount && coreCount >= 8;
-  console.log(`[PerformanceCheck] CPU Cores: ${coreCount} (Pass: ${hasEnoughCores})`);
+  console.log(
+    `[PerformanceCheck] CPU Cores: ${coreCount} (Pass: ${hasEnoughCores})`
+  );
   if (!hasEnoughCores) {
-      return false; // Early exit if CPU core count is low
+    return false; // Early exit if CPU core count is low
   }
 
+  const THREE = await import("three");
+
   // 2. Check WebGL Capabilities (Requires creating a temporary renderer)
-  let renderer: THREE.WebGLRenderer | null = null;
+  let renderer: InstanceType<typeof THREE.WebGLRenderer> | null = null;
   let maxAnisotropy = 0;
   let maxTextureSize = 0;
   let highpSupported = false;
 
   try {
-    renderer = new THREE.WebGLRenderer({ powerPreference: 'high-performance' });
+    renderer = new THREE.WebGLRenderer({ powerPreference: "high-performance" });
     maxAnisotropy = renderer.capabilities.getMaxAnisotropy();
     maxTextureSize = renderer.capabilities.maxTextureSize;
     // Check if high precision floats are supported in fragment shaders
-    highpSupported = renderer.capabilities.precision === 'highp';
+    highpSupported = renderer.capabilities.precision === "highp";
 
     console.log(`[PerformanceCheck] Max Anisotropy: ${maxAnisotropy}`);
     console.log(`[PerformanceCheck] Max Texture Size: ${maxTextureSize}`);
     console.log(`[PerformanceCheck] High Precision Supported: ${highpSupported}`);
-
   } catch (error) {
-    console.error('[PerformanceCheck] Error creating WebGL context:', error);
+    console.error("[PerformanceCheck] Error creating WebGL context:", error);
     return false; // Cannot perform WebGL checks
   } finally {
     // Ensure renderer is disposed if created
@@ -47,8 +52,8 @@ export function checkShaderPerformance(): boolean {
   const anisotropyThreshold = 8;
   const textureSizeThreshold = 8192;
 
-  const passesGpuCheck = 
-    maxAnisotropy >= anisotropyThreshold && 
+  const passesGpuCheck =
+    maxAnisotropy >= anisotropyThreshold &&
     maxTextureSize >= textureSizeThreshold &&
     highpSupported;
 
@@ -58,4 +63,4 @@ export function checkShaderPerformance(): boolean {
   const finalResult = hasEnoughCores && passesGpuCheck;
   console.log(`[PerformanceCheck] Final Result: ${finalResult}`);
   return finalResult;
-} 
+}

--- a/tests/test-shader-performance-check.test.ts
+++ b/tests/test-shader-performance-check.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from "bun:test";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { readFileSync } from "node:fs";
+import { checkShaderPerformance } from "../src/utils/performanceCheck";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+const readSource = (path: string) =>
+  readFileSync(resolve(repoRoot, path), "utf8");
+
+describe("shader performance check loading", () => {
+  test("keeps three out of the static performance-check import path", () => {
+    const source = readSource("src/utils/performanceCheck.ts");
+
+    expect(source).not.toMatch(/^import(?!\s+type).*from ["']three["'];?$/m);
+    expect(source).toContain('await import("three")');
+    expect(source.indexOf("navigator.hardwareConcurrency")).toBeLessThan(
+      source.indexOf('await import("three")')
+    );
+  });
+
+  test("does not run the shader check while the display store module initializes", () => {
+    const source = readSource("src/stores/useDisplaySettingsStore.ts");
+
+    expect(source).not.toMatch(
+      /const\s+initialShaderState\s*=\s*checkShaderPerformance\s*\(/
+    );
+    expect(source).toContain("requestIdleCallback");
+    expect(source).toContain(
+      "shaderPerformanceCapable: state.shaderPerformanceCapable"
+    );
+  });
+
+  test("returns false before importing three when CPU cores are below threshold", async () => {
+    const originalNavigator = Object.getOwnPropertyDescriptor(
+      globalThis,
+      "navigator"
+    );
+
+    Object.defineProperty(globalThis, "navigator", {
+      configurable: true,
+      value: { hardwareConcurrency: 2 },
+    });
+
+    try {
+      await expect(checkShaderPerformance()).resolves.toBe(false);
+    } finally {
+      if (originalNavigator) {
+        Object.defineProperty(globalThis, "navigator", originalNavigator);
+      } else {
+        delete (globalThis as { navigator?: Navigator }).navigator;
+      }
+    }
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Lazy-load `three` inside the async shader performance probe after cheap CPU/browser checks pass.
- Move the display settings shader probe to an idle scheduled, cached store action and persist `shaderPerformanceCapable`.
- Add regression coverage for static import avoidance, store module-init behavior, and CPU early exit.

## Testing
- `bun test tests/test-shader-performance-check.test.ts`
- `bun run build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5bd268e5-ea81-4467-b742-9990fc14aad2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5bd268e5-ea81-4467-b742-9990fc14aad2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

