### PR TITLE
Lazy load Pusher client runtime

### DIFF
--- a/src/lib/pusherClient.ts
+++ b/src/lib/pusherClient.ts
@@ -1,6 +1,5 @@
 import type PusherType from "pusher-js";
 import type { Channel } from "pusher-js";
-import * as PusherNamespace from "pusher-js";
 import {
   getPusherRuntimeConfig,
   getRealtimeProvider,
@@ -106,7 +105,7 @@ const PUSHER_APP_KEY = pusherRuntimeConfig.key;
 const PUSHER_CLUSTER = pusherRuntimeConfig.cluster;
 const PUSHER_FORCE_TLS = pusherRuntimeConfig.forceTLS;
 
-const getPusherConstructor = (): PusherConstructor => {
+const getPusherConstructor = (PusherNamespace: unknown): PusherConstructor => {
   const constructorFromModule = (
     PusherNamespace as unknown as { default?: PusherConstructor }
   ).default;
@@ -200,6 +199,190 @@ class LocalRealtimeChannel implements RealtimeChannel {
     const listeners = this.listeners.get(eventName);
     if (!listeners) return;
     listeners.forEach((listener) => listener(payload));
+  }
+}
+
+class DeferredRealtimeConnection implements RealtimeConnection {
+  private delegate: RealtimeConnection | null = null;
+  private pendingBinds: Array<{
+    eventName: string;
+    handler: ConnectionEventHandler;
+  }> = [];
+
+  state: RealtimeConnectionState = "connecting";
+
+  bind(eventName: string, handler: ConnectionEventHandler): void {
+    if (this.delegate) {
+      this.delegate.bind(eventName, handler);
+      return;
+    }
+    this.pendingBinds.push({ eventName, handler });
+  }
+
+  unbind(eventName?: string, handler?: ConnectionEventHandler): void {
+    if (this.delegate) {
+      this.delegate.unbind(eventName, handler);
+    }
+
+    if (!eventName) {
+      this.pendingBinds = [];
+      return;
+    }
+
+    if (!handler) {
+      this.pendingBinds = this.pendingBinds.filter(
+        (binding) => binding.eventName !== eventName
+      );
+      return;
+    }
+
+    this.pendingBinds = this.pendingBinds.filter(
+      (binding) =>
+        binding.eventName !== eventName || binding.handler !== handler
+    );
+  }
+
+  emit(eventName: string, payload?: unknown): void {
+    this.pendingBinds
+      .filter((binding) => binding.eventName === eventName)
+      .forEach((binding) => binding.handler(payload));
+  }
+
+  attach(connection: RealtimeConnection): void {
+    this.delegate = connection;
+
+    const updateState = (state: RealtimeConnectionState) => {
+      this.state = state;
+    };
+    connection.bind("connected", () => updateState("connected"));
+    connection.bind("connecting", () => updateState("connecting"));
+    connection.bind("disconnected", () => updateState("disconnected"));
+
+    if ("state" in connection && typeof connection.state === "string") {
+      const currentState = connection.state;
+      if (currentState === "connected") {
+        this.state = "connected";
+      } else if (
+        currentState === "connecting" ||
+        currentState === "initialized" ||
+        currentState === "unavailable"
+      ) {
+        this.state = "connecting";
+      } else {
+        this.state = "disconnected";
+      }
+    }
+
+    const pendingBinds = this.pendingBinds;
+    this.pendingBinds = [];
+    pendingBinds.forEach(({ eventName, handler }) => {
+      connection.bind(eventName, handler);
+    });
+  }
+}
+
+class DeferredRealtimeChannel implements RealtimeChannel {
+  readonly name: string;
+
+  private delegate: RealtimeChannel | null = null;
+  private pendingBinds: Array<{
+    eventName: string;
+    handler: ChannelEventHandler;
+  }> = [];
+
+  constructor(name: string) {
+    this.name = name;
+  }
+
+  bind(eventName: string, handler: ChannelEventHandler): void {
+    if (this.delegate) {
+      this.delegate.bind(eventName, handler);
+      return;
+    }
+    this.pendingBinds.push({ eventName, handler });
+  }
+
+  unbind(eventName?: string, handler?: ChannelEventHandler): void {
+    if (this.delegate) {
+      this.delegate.unbind(eventName, handler);
+    }
+
+    if (!eventName) {
+      this.pendingBinds = [];
+      return;
+    }
+
+    if (!handler) {
+      this.pendingBinds = this.pendingBinds.filter(
+        (binding) => binding.eventName !== eventName
+      );
+      return;
+    }
+
+    this.pendingBinds = this.pendingBinds.filter(
+      (binding) =>
+        binding.eventName !== eventName || binding.handler !== handler
+    );
+  }
+
+  attach(channel: RealtimeChannel): void {
+    this.delegate = channel;
+    const pendingBinds = this.pendingBinds;
+    this.pendingBinds = [];
+    pendingBinds.forEach(({ eventName, handler }) => {
+      channel.bind(eventName, handler);
+    });
+  }
+}
+
+class DeferredPusherRealtimeClient implements RealtimeClient {
+  readonly connection = new DeferredRealtimeConnection();
+
+  private delegate: RealtimeClient | null = null;
+  private channels = new Map<string, DeferredRealtimeChannel>();
+
+  constructor(clientPromise: Promise<RealtimeClient>) {
+    void clientPromise.then(
+      (client) => {
+        this.delegate = client;
+        this.connection.attach(client.connection);
+        for (const channel of this.channels.values()) {
+          channel.attach(client.subscribe(channel.name));
+        }
+      },
+      (error) => {
+        this.connection.state = "disconnected";
+        this.connection.emit(
+          "error",
+          error instanceof Error
+            ? error
+            : new Error("[pusherClient] Failed to load Pusher client")
+        );
+      }
+    );
+  }
+
+  subscribe(channelName: string): RealtimeChannel {
+    const existing = this.channels.get(channelName);
+    if (existing) {
+      return existing;
+    }
+
+    const channel = new DeferredRealtimeChannel(channelName);
+    this.channels.set(channelName, channel);
+    if (this.delegate) {
+      channel.attach(this.delegate.subscribe(channelName));
+    }
+    return channel;
+  }
+
+  unsubscribe(channelName: string): void {
+    this.channels.delete(channelName);
+    this.delegate?.unsubscribe(channelName);
+  }
+
+  channel(channelName: string): RealtimeChannel | undefined {
+    return this.channels.get(channelName);
   }
 }
 
@@ -559,12 +742,17 @@ export function getPusherClient(): RealtimeClient {
         fetchLocalRealtimeTicket
       );
     } else {
-      const Pusher = getPusherConstructor();
-      globalWithPusher.__pusherClient = new Pusher(PUSHER_APP_KEY, {
-        cluster: PUSHER_CLUSTER,
-        forceTLS: PUSHER_FORCE_TLS,
-        authorizer: createChannelAuthorizer(),
-      }) as unknown as RealtimeClient;
+      const pusherClientPromise = import("pusher-js").then((PusherNamespace) => {
+        const Pusher = getPusherConstructor(PusherNamespace);
+        return new Pusher(PUSHER_APP_KEY, {
+          cluster: PUSHER_CLUSTER,
+          forceTLS: PUSHER_FORCE_TLS,
+          authorizer: createChannelAuthorizer(),
+        }) as unknown as RealtimeClient;
+      });
+      globalWithPusher.__pusherClient = new DeferredPusherRealtimeClient(
+        pusherClientPromise
+      );
     }
   }
   return globalWithPusher.__pusherClient;

--- a/tests/test-pusher-client-constructor-wiring.test.ts
+++ b/tests/test-pusher-client-constructor-wiring.test.ts
@@ -36,8 +36,19 @@ describe("Pusher Constructor Wiring Tests", () => {
 
     test("getPusherClient instantiates via constructor resolver", async () => {
       const source = readPusherClientSource();
-      expect(/const Pusher = getPusherConstructor\(\);/.test(source)).toBe(true);
+      expect(/const Pusher = getPusherConstructor\(PusherNamespace\);/.test(source)).toBe(true);
       expect(/new Pusher\(PUSHER_APP_KEY/.test(source)).toBe(true);
+    });
+
+    test("loads pusher-js only through a provider-branch dynamic import", async () => {
+      const source = readPusherClientSource();
+      expect(/import\s+(?!type)[^;]*["']pusher-js["']/.test(source)).toBe(false);
+      expect(source.includes('import("pusher-js")')).toBe(true);
+      expect(
+        /if \(getRealtimeProvider\(\) === "local"\)[\s\S]*\} else \{[\s\S]*import\("pusher-js"\)/.test(
+          source
+        )
+      ).toBe(true);
     });
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Move the `pusher-js` runtime import behind the Pusher provider branch in `getPusherClient()`.
- Preserve the existing synchronous realtime client API with deferred connection/channel wrappers while the Pusher chunk loads.
- Add a guardrail test to prevent static value imports of `pusher-js` from returning.

## Testing
- `bun test tests/test-pusher-client-constructor-wiring.test.ts tests/test-pusher-client-refcount.test.ts`
- `bun run build`
- Build asset inspection confirmed Pusher runtime strings are absent from generated `index-*.js` startup chunks and emitted in separate `pusher-*` assets.
- `bun run test:pusher-regression` with `bun run dev:api` running for the API-backed auth suite.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-92eea355-45a8-4809-960f-15c9dacdbc43"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-92eea355-45a8-4809-960f-15c9dacdbc43"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

