### PR TITLE
Optimize chat room initialization fetches

### DIFF
--- a/src/apps/chats/hooks/useChatRoom.ts
+++ b/src/apps/chats/hooks/useChatRoom.ts
@@ -625,35 +625,48 @@ export function useChatRoom(
 
     initializePusher();
     (async () => {
-      const result = await fetchRooms();
-      if (result.ok) {
-        // Get fresh rooms list to fetch messages for all visible rooms
-        const { rooms: freshRooms } = useChatsStore.getState();
-        if (freshRooms.length > 0) {
-          // Limit initial fetch to first 5 rooms to reduce load; others lazy-load via channel
-          const limitedIds = freshRooms.slice(0, 5).map((room) => room.id);
+      const getInitialRoomIds = () =>
+        useChatsStore
+          .getState()
+          .rooms.slice(0, 5)
+          .map((room) => room.id);
+
+      const fetchInitialMessages = async (roomIds: string[]) => {
+        if (roomIds.length === 0) return null;
+
+        console.log(
+          `[useChatRoom] Initial bulk fetch of messages for ${roomIds.length} rooms`
+        );
+        return fetchBulkMessages(roomIds);
+      };
+
+      const cachedRoomIds = getInitialRoomIds();
+      const roomsPromise = fetchRooms();
+      const cachedMessagesPromise = fetchInitialMessages(cachedRoomIds);
+      const [roomsResult, cachedBulkResult] = await Promise.all([
+        roomsPromise,
+        cachedMessagesPromise,
+      ]);
+
+      const bulkResult =
+        cachedBulkResult ??
+        (roomsResult.ok ? await fetchInitialMessages(getInitialRoomIds()) : null);
+
+      // For experienced users, don't recalculate unreads on reload - only track new messages going forward
+      if (bulkResult?.ok) {
+        const { hasEverUsedChats, setHasEverUsedChats } =
+          useChatsStore.getState();
+
+        if (!hasEverUsedChats) {
+          // First time user - mark all as read from this point forward
           console.log(
-            `[useChatRoom] Initial bulk fetch of messages for ${limitedIds.length} rooms`
+            `[useChatRoom] First-time user detected - skipping unread calculation and marking as experienced user`
           );
-          const bulkResult = await fetchBulkMessages(limitedIds);
-
-          // For experienced users, don't recalculate unreads on reload - only track new messages going forward
-          if (bulkResult.ok) {
-            const { hasEverUsedChats, setHasEverUsedChats } =
-              useChatsStore.getState();
-
-            if (!hasEverUsedChats) {
-              // First time user - mark all as read from this point forward
-              console.log(
-                `[useChatRoom] First-time user detected - skipping unread calculation and marking as experienced user`
-              );
-              setHasEverUsedChats(true);
-            } else {
-              console.log(
-                `[useChatRoom] Experienced user - skipping unread recalculation on reload, will track new messages only`
-              );
-            }
-          }
+          setHasEverUsedChats(true);
+        } else {
+          console.log(
+            `[useChatRoom] Experienced user - skipping unread recalculation on reload, will track new messages only`
+          );
         }
       }
     })();

--- a/src/stores/useChatsStore.ts
+++ b/src/stores/useChatsStore.ts
@@ -73,6 +73,18 @@ const getUsernameFromRecovery = (): string | null => {
 
 const API_UNAVAILABLE_COOLDOWN_MS = 10_000;
 const apiUnavailableUntil: Record<string, number> = {};
+const ROOMS_FETCH_TTL_MS = 1_500;
+
+type FetchResult = { ok: boolean; error?: string };
+type FetchRoomsOptions = { force?: boolean };
+
+let roomsFetchPromise: Promise<FetchResult> | null = null;
+let roomsFetchFreshUntil = 0;
+
+const resetRoomsFetchCache = (): void => {
+  roomsFetchPromise = null;
+  roomsFetchFreshUntil = 0;
+};
 
 const isApiTemporarilyUnavailable = (key: string): boolean =>
   Date.now() < (apiUnavailableUntil[key] || 0);
@@ -162,7 +174,7 @@ export interface ChatsStoreState {
   setFontSize: (size: number | ((prevSize: number) => number)) => void; // Add font size action
   setMessageRenderLimit: (limit: number) => void; // Set render limit
   // Room Management Actions
-  fetchRooms: () => Promise<{ ok: boolean; error?: string }>;
+  fetchRooms: (options?: FetchRoomsOptions) => Promise<FetchResult>;
   fetchMessagesForRoom: (
     roomId: string
   ) => Promise<{ ok: boolean; error?: string }>;
@@ -281,6 +293,9 @@ export const useChatsStore = create<ChatsStoreState>()(
         // --- Actions ---
         setAiMessages: (messages) => set({ aiMessages: messages }),
         setUsername: (username) => {
+          if (get().username !== username) {
+            resetRoomsFetchCache();
+          }
           saveUsernameToRecovery(username);
           set({ username });
 
@@ -309,6 +324,9 @@ export const useChatsStore = create<ChatsStoreState>()(
           }
         },
         setAuthenticated: (authenticated) => {
+          if (get().isAuthenticated !== authenticated) {
+            resetRoomsFetchCache();
+          }
           set({ isAuthenticated: authenticated });
         },
         setHasPassword: (hasPassword) => {
@@ -604,6 +622,7 @@ export const useChatsStore = create<ChatsStoreState>()(
           if (currentUsername) {
             saveUsernameToRecovery(currentUsername);
           }
+          resetRoomsFetchCache();
           set(getInitialState());
         },
         logout: async () => {
@@ -628,6 +647,7 @@ export const useChatsStore = create<ChatsStoreState>()(
 
           localStorage.removeItem(USERNAME_RECOVERY_KEY);
           clearLegacyTokenRecovery();
+          resetRoomsFetchCache();
 
           set((state) => ({
             ...state,
@@ -642,7 +662,7 @@ export const useChatsStore = create<ChatsStoreState>()(
           }));
 
           try {
-            await get().fetchRooms();
+            await get().fetchRooms({ force: true });
           } catch (error) {
             console.error(
               "[ChatsStore] Error refreshing rooms after logout:",
@@ -652,33 +672,50 @@ export const useChatsStore = create<ChatsStoreState>()(
 
           console.log("[ChatsStore] User logged out successfully");
         },
-        fetchRooms: async () => {
+        fetchRooms: async (options = {}) => {
+          if (roomsFetchPromise) {
+            console.log("[ChatsStore] Reusing in-flight rooms fetch...");
+            return roomsFetchPromise;
+          }
+
+          if (!options.force && Date.now() < roomsFetchFreshUntil) {
+            console.log("[ChatsStore] Skipping rooms fetch; cache is fresh.");
+            return { ok: true };
+          }
+
           console.log("[ChatsStore] Fetching rooms...");
           if (isApiTemporarilyUnavailable("rooms")) {
             return { ok: false, error: "Rooms API temporarily unavailable" };
           }
 
-          try {
-            const data = await listRoomsApi();
-            if (data.rooms && Array.isArray(data.rooms)) {
-              clearApiUnavailable("rooms");
-              // Normalize ordering via setRooms to enforce alphabetical sections
-              get().setRooms(data.rooms);
-              return { ok: true };
-            }
+          roomsFetchPromise = (async (): Promise<FetchResult> => {
+            try {
+              const data = await listRoomsApi();
+              if (data.rooms && Array.isArray(data.rooms)) {
+                clearApiUnavailable("rooms");
+                // Normalize ordering via setRooms to enforce alphabetical sections
+                get().setRooms(data.rooms);
+                roomsFetchFreshUntil = Date.now() + ROOMS_FETCH_TTL_MS;
+                return { ok: true };
+              }
 
-            return { ok: false, error: "Invalid response format" };
-          } catch (error) {
-            console.error("[ChatsStore] Error fetching rooms:", error);
-            markApiTemporarilyUnavailable("rooms");
-            return {
-              ok: false,
-              error:
-                error instanceof Error
-                  ? error.message
-                  : "Network error. Please try again.",
-            };
-          }
+              return { ok: false, error: "Invalid response format" };
+            } catch (error) {
+              console.error("[ChatsStore] Error fetching rooms:", error);
+              markApiTemporarilyUnavailable("rooms");
+              return {
+                ok: false,
+                error:
+                  error instanceof Error
+                    ? error.message
+                    : "Network error. Please try again.",
+              };
+            } finally {
+              roomsFetchPromise = null;
+            }
+          })();
+
+          return roomsFetchPromise;
         },
         fetchMessagesForRoom: async (roomId: string) => {
           if (!roomId) return { ok: false, error: "Room ID required" };

--- a/tests/test-chat-store-guards-wiring.test.ts
+++ b/tests/test-chat-store-guards-wiring.test.ts
@@ -7,7 +7,8 @@
 
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
-import { describe, test, expect } from "bun:test";
+import { describe, test, expect, mock } from "bun:test";
+import type { ChatRoom } from "../src/types/chat";
 
 const readStoreSource = (): string =>
   readFileSync(resolve(process.cwd(), "src/stores/useChatsStore.ts"), "utf-8");
@@ -16,7 +17,132 @@ const countMatches = (source: string, pattern: RegExp): number =>
   source.match(new RegExp(pattern.source, pattern.flags.includes("g") ? pattern.flags : `${pattern.flags}g`))
     ?.length || 0;
 
+class MemoryStorage implements Storage {
+  private readonly map = new Map<string, string>();
+  get length(): number {
+    return this.map.size;
+  }
+  clear(): void {
+    this.map.clear();
+  }
+  getItem(key: string): string | null {
+    return this.map.get(key) ?? null;
+  }
+  key(index: number): string | null {
+    return Array.from(this.map.keys())[index] ?? null;
+  }
+  removeItem(key: string): void {
+    this.map.delete(key);
+  }
+  setItem(key: string, value: string): void {
+    this.map.set(key, value);
+  }
+}
+
+const globals = globalThis as typeof globalThis & { localStorage?: Storage };
+if (!globals.localStorage) {
+  globals.localStorage = new MemoryStorage();
+}
+
+let listRoomsImpl: () => Promise<{ rooms: ChatRoom[] }> = async () => ({
+  rooms: [],
+});
+const listRoomsMock = mock(() => listRoomsImpl());
+const successMock = mock(async () => ({ success: true }));
+
+mock.module("@/api/rooms", () => ({
+  listRooms: listRoomsMock,
+  getRoomMessages: mock(async () => ({ messages: [] })),
+  getBulkMessages: mock(async () => ({
+    messagesMap: {},
+    validRoomIds: [],
+    invalidRoomIds: [],
+  })),
+  switchPresence: successMock,
+  deleteRoom: successMock,
+  createRoom: mock(async () => ({
+    room: { id: "created", name: "Created", type: "public", createdAt: 1, userCount: 0 },
+  })),
+  sendRoomMessage: mock(async () => ({
+    message: {
+      id: "message",
+      roomId: "general",
+      username: "ryo",
+      content: "hi",
+      timestamp: Date.now(),
+    },
+  })),
+}));
+
+const { useChatsStore } = await import("../src/stores/useChatsStore");
+
 describe("Chat Store Guard Wiring Tests", () => {
+  describe("Rooms fetch deduplication", () => {
+    test("coalesces concurrent fetchRooms calls and reuses a fresh result", async () => {
+      useChatsStore.getState().reset();
+
+      const rooms: ChatRoom[] = [
+        {
+          id: "general",
+          name: "General",
+          type: "public",
+          createdAt: 1,
+          userCount: 0,
+        },
+      ];
+      let resolveRooms: ((value: { rooms: ChatRoom[] }) => void) | null = null;
+      listRoomsImpl = () =>
+        new Promise((resolve) => {
+          resolveRooms = resolve;
+        });
+
+      const first = useChatsStore.getState().fetchRooms({ force: true });
+      const second = useChatsStore.getState().fetchRooms();
+
+      expect(listRoomsMock).toHaveBeenCalledTimes(1);
+
+      resolveRooms?.({ rooms });
+      await expect(Promise.all([first, second])).resolves.toEqual([
+        { ok: true },
+        { ok: true },
+      ]);
+      expect(useChatsStore.getState().rooms.map((room) => room.id)).toEqual([
+        "general",
+      ]);
+
+      await expect(useChatsStore.getState().fetchRooms()).resolves.toEqual({
+        ok: true,
+      });
+      expect(listRoomsMock).toHaveBeenCalledTimes(1);
+    });
+
+    test("shares fetchRooms failures across concurrent callers", async () => {
+      useChatsStore.getState().reset();
+
+      const startCallCount = listRoomsMock.mock.calls.length;
+      listRoomsImpl = async () => {
+        throw new Error("rooms unavailable");
+      };
+
+      const originalConsoleError = console.error;
+      console.error = mock(() => {});
+      try {
+        await expect(
+          Promise.all([
+            useChatsStore.getState().fetchRooms({ force: true }),
+            useChatsStore.getState().fetchRooms({ force: true }),
+          ])
+        ).resolves.toEqual([
+          { ok: false, error: "rooms unavailable" },
+          { ok: false, error: "rooms unavailable" },
+        ]);
+      } finally {
+        console.error = originalConsoleError;
+      }
+      expect(listRoomsMock.mock.calls.length - startCallCount).toBe(1);
+    });
+  });
+
   describe("Cooldown availability checks", () => {
     test("checks cooldown gate for each chat fetch endpoint", async () => {
       const source = readStoreSource();
@@ -48,6 +174,23 @@ describe("Chat Store Guard Wiring Tests", () => {
       expect(countMatches(source, /clearApiUnavailable\("rooms"\)/)).toBe(1);
       expect(countMatches(source, /clearApiUnavailable\("room-messages"\)/)).toBe(1);
       expect(countMatches(source, /clearApiUnavailable\("bulk-messages"\)/)).toBe(1);
+    });
+  });
+
+  describe("Initial chat hydration", () => {
+    test("starts rooms and initial bulk messages in parallel", async () => {
+      const source = readFileSync(
+        resolve(process.cwd(), "src/apps/chats/hooks/useChatRoom.ts"),
+        "utf-8"
+      );
+
+      expect(source).toContain("const roomsPromise = fetchRooms()");
+      expect(source).toContain(
+        "const cachedMessagesPromise = fetchInitialMessages(cachedRoomIds)"
+      );
+      expect(source).toContain("Promise.all([");
+      expect(source).toContain("roomsPromise,");
+      expect(source).toContain("cachedMessagesPromise,");
     });
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add in-flight deduplication and a short freshness TTL for `fetchRooms`, with cache invalidation on auth/user reset transitions.
- Start chat room list refresh and initial bulk message hydration in parallel when persisted room IDs are available.
- Add focused Bun coverage for concurrent room fetch success/failure and an init parallelization guard.

## Testing
- `bun test tests/test-chat-store-guards-wiring.test.ts`
- `bun test tests/test-chat-streaming-perf.test.ts tests/test-chat-notification-logic.test.ts tests/test-chat-notification-integration-wiring.test.ts tests/test-chat-broadcast-wiring.test.ts tests/test-chat-hook-channel-lifecycle-wiring.test.ts tests/test-chat-store-guards-wiring.test.ts tests/test-pusher-client-refcount.test.ts tests/test-pusher-client-constructor-wiring.test.ts`
- `bun run build`

## Notes
- `bun run test:chat-regression` was attempted but Bun reported that the filter did not match test files, so the same chat/Pusher suites were run by explicit path.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0949c6c9-c856-40f2-af70-412de2c52f80"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0949c6c9-c856-40f2-af70-412de2c52f80"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

