### PR TITLE
perf: transient drag/resize, dock scale, and marquee without per-frame renders

### DIFF
--- a/src/components/layout/desktop/Desktop.tsx
+++ b/src/components/layout/desktop/Desktop.tsx
@@ -61,14 +61,17 @@ export function Desktop(props: DesktopProps) {
         onAppDoubleClick={d.handleAppDoubleClick}
         onTrashDoubleClick={d.handleTrashDoubleClick}
       />
-      {d.renderedSelectionRect && d.desktopBounds ? (
+      {d.isMarqueeSelecting ? (
+        // Geometry is painted directly onto this element per pointer move
+        // (see useDesktop) so the marquee never re-renders the desktop tree.
         <div
+          ref={d.marqueeElementRef}
           className="pointer-events-none absolute z-[2] border"
           style={{
-            left: d.renderedSelectionRect.left - d.desktopBounds.left,
-            top: d.renderedSelectionRect.top - d.desktopBounds.top,
-            width: d.renderedSelectionRect.right - d.renderedSelectionRect.left,
-            height: d.renderedSelectionRect.bottom - d.renderedSelectionRect.top,
+            left: 0,
+            top: 0,
+            width: 0,
+            height: 0,
             borderColor: "rgba(128, 128, 128, 0.6)",
             backgroundColor: "rgba(128, 128, 128, 0.15)",
           }}

--- a/src/components/layout/desktop/useDesktop.ts
+++ b/src/components/layout/desktop/useDesktop.ts
@@ -24,6 +24,7 @@ import {
   hasToggleModifier,
   mergeSelectionIds,
   resolveMultiSelection,
+  type SelectableRect,
   type SelectionPoint,
 } from "@/utils/selection";
 import type { MenuItem } from "@/components/ui/right-click-menu";
@@ -63,10 +64,15 @@ export function useDesktop({
   const marqueeBaseSelectionRef = useRef<DesktopItemId[]>([]);
   const marqueeAdditiveRef = useRef(false);
   const suppressClickAfterMarqueeRef = useRef(false);
-  const [selectionRect, setSelectionRect] = useState<{
-    start: SelectionPoint;
-    end: SelectionPoint;
-  } | null>(null);
+  // Marquee internals are ref-driven so pointer moves don't re-render the
+  // desktop: the rect element is painted directly, item rects are captured
+  // once on mousedown, and selection state only updates when the intersecting
+  // set actually changes.
+  const marqueeElementRef = useRef<HTMLDivElement | null>(null);
+  const marqueeOriginRef = useRef<{ left: number; top: number } | null>(null);
+  const marqueeItemRectsRef = useRef<SelectableRect<DesktopItemId>[]>([]);
+  const lastMarqueeSelectionSigRef = useRef<string | null>(null);
+  const [isMarqueeSelecting, setIsMarqueeSelecting] = useState(false);
   const [sortType, setSortType] = useState<SortType>("name");
   const [contextMenuPos, setContextMenuPos] = useState<{
     x: number;
@@ -405,25 +411,28 @@ export function useDesktop({
     return items;
   }, [isMacOSTheme, desktopShortcuts, displayedApps]);
 
+  // Paint the marquee rect element directly (no React state per pointer move).
+  const paintMarqueeRect = useCallback(
+    (start: SelectionPoint, end: SelectionPoint) => {
+      const element = marqueeElementRef.current;
+      const origin = marqueeOriginRef.current;
+      if (!element || !origin) return;
+
+      const rect = createSelectionRect(start, end);
+      element.style.left = `${rect.left - origin.left}px`;
+      element.style.top = `${rect.top - origin.top}px`;
+      element.style.width = `${rect.right - rect.left}px`;
+      element.style.height = `${rect.bottom - rect.top}px`;
+    },
+    []
+  );
+
   const updateSelectionFromMarquee = useCallback(
     (start: SelectionPoint, end: SelectionPoint) => {
-      const desktop = desktopRef.current;
-      if (!desktop) return;
-
       const intersectingIds = getIntersectingSelectionIds(
         createSelectionRect(start, end),
-        Array.from(
-          desktop.querySelectorAll<HTMLElement>("[data-desktop-item-id]")
-        ).map((element) => ({
-          id: element.dataset.desktopItemId || "",
-          rect: {
-            left: element.getBoundingClientRect().left,
-            top: element.getBoundingClientRect().top,
-            right: element.getBoundingClientRect().right,
-            bottom: element.getBoundingClientRect().bottom,
-          },
-        }))
-      ).filter(Boolean);
+        marqueeItemRectsRef.current
+      );
 
       const nextSelectedIds = marqueeAdditiveRef.current
         ? mergeSelectionIds(
@@ -432,6 +441,12 @@ export function useDesktop({
             intersectingIds
           )
         : intersectingIds;
+
+      // Only touch React state when the intersecting set actually changes.
+      const signature = nextSelectedIds.join("\u0000");
+      if (signature === lastMarqueeSelectionSigRef.current) return;
+      lastMarqueeSelectionSigRef.current = signature;
+
       const nextAnchorId = nextSelectedIds[nextSelectedIds.length - 1] ?? null;
       applySelection(nextSelectedIds, nextAnchorId);
     },
@@ -439,14 +454,17 @@ export function useDesktop({
   );
 
   useEffect(() => {
-    if (!selectionRect || !marqueeStartRef.current) return;
+    if (!isMarqueeSelecting || !marqueeStartRef.current) return;
+
+    // Position the freshly-mounted marquee element at its zero-size origin.
+    paintMarqueeRect(marqueeStartRef.current, marqueeStartRef.current);
 
     const handleMouseMove = (event: MouseEvent) => {
       const start = marqueeStartRef.current;
       if (!start) return;
 
       const end = { x: event.clientX, y: event.clientY };
-      setSelectionRect({ start, end });
+      paintMarqueeRect(start, end);
       updateSelectionFromMarquee(start, end);
     };
 
@@ -466,7 +484,7 @@ export function useDesktop({
 
       suppressClickAfterMarqueeRef.current = movedEnough;
       marqueeStartRef.current = null;
-      setSelectionRect(null);
+      setIsMarqueeSelecting(false);
     };
 
     window.addEventListener("mousemove", handleMouseMove);
@@ -476,7 +494,12 @@ export function useDesktop({
       window.removeEventListener("mousemove", handleMouseMove);
       window.removeEventListener("mouseup", handleMouseUp);
     };
-  }, [clearSelection, selectionRect, updateSelectionFromMarquee]);
+  }, [
+    clearSelection,
+    isMarqueeSelecting,
+    paintMarqueeRect,
+    updateSelectionFromMarquee,
+  ]);
 
   const handleDesktopItemClick = (
     itemId: DesktopItemId,
@@ -507,7 +530,36 @@ export function useDesktop({
     marqueeStartRef.current = start;
     marqueeBaseSelectionRef.current = selectedItemIds;
     marqueeAdditiveRef.current = event.shiftKey || hasToggleModifier(event);
-    setSelectionRect({ start, end: start });
+    lastMarqueeSelectionSigRef.current = null;
+
+    // Capture desktop origin + item rects once; the desktop doesn't scroll,
+    // so per-move getBoundingClientRect calls are unnecessary.
+    const desktop = desktopRef.current;
+    const bounds = desktop?.getBoundingClientRect();
+    marqueeOriginRef.current = bounds
+      ? { left: bounds.left, top: bounds.top }
+      : { left: 0, top: 0 };
+    marqueeItemRectsRef.current = desktop
+      ? Array.from(
+          desktop.querySelectorAll<HTMLElement>("[data-desktop-item-id]")
+        ).reduce<SelectableRect<DesktopItemId>[]>((acc, element) => {
+          const id = element.dataset.desktopItemId;
+          if (!id) return acc;
+          const rect = element.getBoundingClientRect();
+          acc.push({
+            id: id as DesktopItemId,
+            rect: {
+              left: rect.left,
+              top: rect.top,
+              right: rect.right,
+              bottom: rect.bottom,
+            },
+          });
+          return acc;
+        }, [])
+      : [];
+
+    setIsMarqueeSelecting(true);
   };
 
   const handleDesktopClick = () => {
@@ -610,12 +662,6 @@ export function useDesktop({
     (itemId: DesktopItemId) => selectedItemIds.includes(itemId),
     [selectedItemIds]
   );
-
-  const renderedSelectionRect =
-    selectionRect && desktopRef.current
-      ? createSelectionRect(selectionRect.start, selectionRect.end)
-      : null;
-  const desktopBounds = desktopRef.current?.getBoundingClientRect();
 
   const macintoshHdName = useMemo(
     () =>
@@ -726,8 +772,8 @@ export function useDesktop({
     contextMenuPos,
     closeContextMenu,
     getContextMenuItems,
-    renderedSelectionRect,
-    desktopBounds,
+    isMarqueeSelecting,
+    marqueeElementRef,
     isEmptyTrashDialogOpen,
     setIsEmptyTrashDialogOpen,
     confirmEmptyTrash,

--- a/src/components/layout/dock/MacDock.tsx
+++ b/src/components/layout/dock/MacDock.tsx
@@ -19,7 +19,7 @@ import { useSound, Sounds } from "@/hooks/useSound";
 import type { LaunchOriginRect } from "@/stores/useAppStore";
 import { RightClickMenu } from "@/components/ui/right-click-menu";
 import { ConfirmDialog } from "@/components/dialogs/ConfirmDialog";
-import { AnimatePresence, motion, LayoutGroup } from "motion/react";
+import { AnimatePresence, motion, LayoutGroup, useMotionValue } from "motion/react";
 import { useShallow } from "zustand/react/shallow";
 import {
   isClientYInBottomZone,
@@ -128,9 +128,12 @@ export function MacDock() {
   const { hoveredId, isSwapping, handleIconHover, handleIconLeave } =
     useDockIconHover();
 
-  // Resize dragging state
+  // Resize dragging state. While dragging, the dock is scaled with a CSS
+  // transform (motion value) instead of re-rendering every icon per frame;
+  // the real scale is committed to the store on mouseup.
   const [isResizing, setIsResizing] = useState(false);
-  const [liveDockScale, setLiveDockScale] = useState<number | null>(null);
+  const dockResizePreviewScale = useMotionValue(1);
+  const liveDockScaleRef = useRef<number | null>(null);
   const resizeStartY = useRef<number>(0);
   const resizeStartScale = useRef<number>(1);
   
@@ -147,12 +150,10 @@ export function MacDock() {
   const lastAutoHideTimeRef = useRef<number>(0); // Track when dock was last auto-hidden
   const lastTimerRestartRef = useRef<number>(0); // Throttle timer restarts
 
-  const effectiveDockScale = liveDockScale ?? dockScale;
-
-  // Computed scaled sizes
-  const scaledButtonSize = Math.round(DOCK_BASE_BUTTON_SIZE * effectiveDockScale);
-  const scaledDockHeight = Math.round(56 * effectiveDockScale); // Base dock height is 56px
-  const scaledPadding = Math.round(4 * effectiveDockScale); // Base padding is 4px (py-1, px-1)
+  // Computed scaled sizes (from the committed scale; drag preview is a transform)
+  const scaledButtonSize = Math.round(DOCK_BASE_BUTTON_SIZE * dockScale);
+  const scaledDockHeight = Math.round(56 * dockScale); // Base dock height is 56px
+  const scaledPadding = Math.round(4 * dockScale); // Base padding is 4px (py-1, px-1)
 
 
   const {
@@ -174,7 +175,7 @@ export function MacDock() {
     handleDividerDrop,
   } = useDockDragDrop({
     pinnedItems,
-    effectiveDockScale,
+    effectiveDockScale: dockScale,
     scaledPadding,
     getFileItem,
     addDockItem,
@@ -191,9 +192,9 @@ export function MacDock() {
     e.stopPropagation();
     setIsResizing(true);
     resizeStartY.current = e.clientY;
-    resizeStartScale.current = effectiveDockScale;
-    setLiveDockScale(effectiveDockScale);
-  }, [isPhone, effectiveDockScale]);
+    resizeStartScale.current = dockScale;
+    liveDockScaleRef.current = dockScale;
+  }, [isPhone, dockScale]);
 
   useEffect(() => {
     if (!isResizing) return;
@@ -204,16 +205,21 @@ export function MacDock() {
       const deltaY = resizeStartY.current - e.clientY;
       const scaleDelta = deltaY / 100; // 100px drag = 1.0 scale change
       const newScale = resizeStartScale.current + scaleDelta;
-      // Keep drag updates local and transient; persist only on mouseup.
+      // Keep drag updates transient: preview with a CSS transform (no React
+      // re-render per move); persist the real scale only on mouseup.
       const clampedScale = Math.max(0.5, Math.min(1.5, newScale));
-      setLiveDockScale(clampedScale);
+      liveDockScaleRef.current = clampedScale;
+      dockResizePreviewScale.set(clampedScale / resizeStartScale.current);
     };
 
     const handleMouseUp = () => {
       setIsResizing(false);
-      const finalScale = liveDockScale ?? resizeStartScale.current;
+      const finalScale = liveDockScaleRef.current ?? resizeStartScale.current;
+      liveDockScaleRef.current = null;
+      // Commit the real scale (re-lays-out the dock) and drop the transform
+      // preview in the same frame.
       setDockScale(finalScale);
-      setLiveDockScale(null);
+      dockResizePreviewScale.set(1);
     };
 
     document.addEventListener("mousemove", handleMouseMove);
@@ -223,13 +229,7 @@ export function MacDock() {
       document.removeEventListener("mousemove", handleMouseMove);
       document.removeEventListener("mouseup", handleMouseUp);
     };
-  }, [isResizing, setDockScale, liveDockScale]);
-
-  useEffect(() => {
-    if (!isResizing) {
-      setLiveDockScale(null);
-    }
-  }, [isResizing]);
+  }, [isResizing, setDockScale, dockResizePreviewScale]);
 
   // Sync visibility state when hiding setting changes
   useEffect(() => {
@@ -748,6 +748,8 @@ export function MacDock() {
           }}
           style={{
             pointerEvents: isDockVisible ? "auto" : "none",
+            // Transient divider-drag resize preview (committed on mouseup).
+            scale: dockResizePreviewScale,
             // Same tint variable as the menubar so light/dark switch in lockstep.
             background:
               "var(--os-color-dock-surface, rgba(248, 248, 248, 0.75))",

--- a/src/components/layout/window-frame/WindowFrame.tsx
+++ b/src/components/layout/window-frame/WindowFrame.tsx
@@ -154,6 +154,10 @@ export function WindowFrame({
   const {
     windowPosition,
     windowSize,
+    windowLeftMotionValue,
+    windowTopMotionValue,
+    windowWidthMotionValue,
+    windowHeightMotionValue,
     isDragging,
     resizeType,
     setWindowSize,
@@ -270,6 +274,13 @@ export function WindowFrame({
                     }
             }
             style={{
+              // Drag / resize writes window geometry straight into these
+              // motion values (no per-frame React render); the `animate` prop
+              // above animates the same values for programmatic transitions.
+              left: windowLeftMotionValue,
+              top: windowTopMotionValue,
+              width: windowWidthMotionValue,
+              height: windowHeightMotionValue,
               minWidth:
                 window.innerWidth >= 768 ? mergedConstraints.minWidth : "100%",
               minHeight: mergedConstraints.minHeight,

--- a/src/components/layout/window-frame/hooks/useWindowFrameDragResize.ts
+++ b/src/components/layout/window-frame/hooks/useWindowFrameDragResize.ts
@@ -23,6 +23,10 @@ export function useWindowFrameDragResize({
   const {
     windowPosition,
     windowSize,
+    windowLeftMotionValue,
+    windowTopMotionValue,
+    windowWidthMotionValue,
+    windowHeightMotionValue,
     isDragging,
     resizeType,
     handleMouseDown,
@@ -66,6 +70,10 @@ export function useWindowFrameDragResize({
   return {
     windowPosition,
     windowSize,
+    windowLeftMotionValue,
+    windowTopMotionValue,
+    windowWidthMotionValue,
+    windowHeightMotionValue,
     isDragging,
     resizeType,
     setWindowSize,

--- a/src/hooks/useWindowManager.ts
+++ b/src/hooks/useWindowManager.ts
@@ -1,4 +1,5 @@
 import { useState, useCallback, useRef, useEffect } from "react";
+import { useMotionValue } from "motion/react";
 import {
   WindowPosition,
   WindowSize,
@@ -85,69 +86,63 @@ export const useWindowManager = ({
     top: 0,
   });
   
-  // Snap to edge state
+  // Snap to edge state. The ref mirrors the state so per-move detection can
+  // bail without scheduling a render; state only changes on zone transitions.
   const [snapZone, setSnapZone] = useState<"left" | "right" | null>(null);
+  const snapZoneRef = useRef<"left" | "right" | null>(null);
   // Store pre-snap size/position for potential restore
   const preSnapStateRef = useRef<{ position: WindowPosition; size: WindowSize } | null>(null);
   const latestWindowPositionRef = useRef(windowPosition);
   const latestWindowSizeRef = useRef(windowSize);
-  const pendingWindowPositionRef = useRef<WindowPosition | null>(null);
-  const pendingWindowSizeRef = useRef<WindowSize | null>(null);
-  const moveRafRef = useRef<number | null>(null);
 
   const isMobile = window.innerWidth < 768;
 
-  const flushPendingWindowFrame = useCallback(() => {
-    if (moveRafRef.current !== null) {
-      cancelAnimationFrame(moveRafRef.current);
-      moveRafRef.current = null;
-    }
+  // Transient geometry written directly during drag / resize. WindowFrame
+  // binds these motion values to the frame's style, so pointer moves update
+  // the DOM without re-rendering the React subtree. The committed React state
+  // (and the store) is only updated on pointer-up. Programmatic moves (snap,
+  // maximize, store sync) flow through the `animate` prop, which animates
+  // these same motion values.
+  const windowLeftMotionValue = useMotionValue<number | string>(
+    adjustedPosition.x
+  );
+  const windowTopMotionValue = useMotionValue<number | string>(
+    Math.max(0, adjustedPosition.y)
+  );
+  const windowWidthMotionValue = useMotionValue<number | string>(
+    isMobile ? "100%" : initialState.size.width
+  );
+  const windowHeightMotionValue = useMotionValue<number | string>(
+    initialState.size.height
+  );
 
-    if (pendingWindowPositionRef.current) {
-      setWindowPosition(pendingWindowPositionRef.current);
-      pendingWindowPositionRef.current = null;
-    }
-
-    if (pendingWindowSizeRef.current) {
-      setWindowSize(pendingWindowSizeRef.current);
-      pendingWindowSizeRef.current = null;
-    }
-  }, []);
-
-  const scheduleWindowFrame = useCallback(() => {
-    if (moveRafRef.current !== null) return;
-    moveRafRef.current = requestAnimationFrame(() => {
-      moveRafRef.current = null;
-
-      if (pendingWindowPositionRef.current) {
-        setWindowPosition(pendingWindowPositionRef.current);
-        pendingWindowPositionRef.current = null;
-      }
-
-      if (pendingWindowSizeRef.current) {
-        setWindowSize(pendingWindowSizeRef.current);
-        pendingWindowSizeRef.current = null;
-      }
-    });
-  }, []);
-
-  const queueWindowPosition = useCallback(
+  const applyLiveWindowPosition = useCallback(
     (nextPosition: WindowPosition) => {
       latestWindowPositionRef.current = nextPosition;
-      pendingWindowPositionRef.current = nextPosition;
-      scheduleWindowFrame();
+      windowLeftMotionValue.set(nextPosition.x);
+      windowTopMotionValue.set(Math.max(0, nextPosition.y));
     },
-    [scheduleWindowFrame]
+    [windowLeftMotionValue, windowTopMotionValue]
   );
 
-  const queueWindowSize = useCallback(
+  const applyLiveWindowSize = useCallback(
     (nextSize: WindowSize) => {
       latestWindowSizeRef.current = nextSize;
-      pendingWindowSizeRef.current = nextSize;
-      scheduleWindowFrame();
+      // Below the md breakpoint the frame is rendered at "100%" width; leave
+      // the motion value alone so it stays correct across viewport resizes.
+      if (window.innerWidth >= 768) {
+        windowWidthMotionValue.set(nextSize.width);
+      }
+      windowHeightMotionValue.set(nextSize.height);
     },
-    [scheduleWindowFrame]
+    [windowWidthMotionValue, windowHeightMotionValue]
   );
+
+  const updateSnapZone = useCallback((zone: "left" | "right" | null) => {
+    if (snapZoneRef.current === zone) return;
+    snapZoneRef.current = zone;
+    setSnapZone(zone);
+  }, []);
 
   // Sync local state with store when store changes (for programmatic updates).
   // Use refs for comparison to avoid re-running on every local state change during drag.
@@ -186,14 +181,6 @@ export const useWindowManager = ({
   useEffect(() => {
     latestWindowPositionRef.current = windowPosition;
   }, [windowPosition]);
-
-  useEffect(() => {
-    return () => {
-      if (moveRafRef.current !== null) {
-        cancelAnimationFrame(moveRafRef.current);
-      }
-    };
-  }, []);
 
   const { play: playMoveSound, stop: stopMoveMoving } = useSound(Sounds.WINDOW_MOVE_MOVING);
   const { play: playMoveStop } = useSound(Sounds.WINDOW_MOVE_STOP);
@@ -310,8 +297,8 @@ export const useWindowManager = ({
 
         if (isMobile) {
           // On mobile, only allow vertical dragging and keep window full width
-          queueWindowPosition({ x: 0, y: Math.max(menuBarHeight, newY) });
-          setSnapZone(null);
+          applyLiveWindowPosition({ x: 0, y: Math.max(menuBarHeight, newY) });
+          updateSnapZone(null);
         } else {
           // Allow dragging past edges, but keep at least 80px of window visible
           const minX = -(windowSize.width - 80); // Can drag left, keeping 80px visible on right
@@ -319,16 +306,16 @@ export const useWindowManager = ({
           const maxY = window.innerHeight - 80; // Can drag down, keeping 80px visible at top
           const x = Math.min(Math.max(minX, newX), maxX);
           const y = Math.min(Math.max(menuBarHeight, newY), Math.max(0, maxY));
-          queueWindowPosition({ x, y });
+          applyLiveWindowPosition({ x, y });
 
           // Detect snap zones - trigger when cursor is within 20px of screen edge
           const SNAP_THRESHOLD = 20;
           if (clientX <= SNAP_THRESHOLD) {
-            setSnapZone("left");
+            updateSnapZone("left");
           } else if (clientX >= window.innerWidth - SNAP_THRESHOLD) {
-            setSnapZone("right");
+            updateSnapZone("right");
           } else {
-            setSnapZone(null);
+            updateSnapZone(null);
           }
         }
       }
@@ -408,8 +395,11 @@ export const useWindowManager = ({
           newLeft = 0;
         }
 
-        queueWindowSize({ width: newWidth, height: newHeight });
-        queueWindowPosition({ x: newLeft, y: Math.max(menuBarHeight, newTop) });
+        applyLiveWindowSize({ width: newWidth, height: newHeight });
+        applyLiveWindowPosition({
+          x: newLeft,
+          y: Math.max(menuBarHeight, newTop),
+        });
 
         // Play resize sound once when movement begins
         if (
@@ -432,14 +422,15 @@ export const useWindowManager = ({
       playResizeSound,
       config,
       computeInsets,
-      queueWindowPosition,
-      queueWindowSize,
-      setSnapZone,
+      applyLiveWindowPosition,
+      applyLiveWindowSize,
+      updateSnapZone,
     ]
   );
 
   const handleEnd = useCallback(() => {
-    flushPendingWindowFrame();
+    // Commit the transient (motion-value-driven) geometry to React state and
+    // the store in a single update now that the interaction ended.
     const currentPosition = latestWindowPositionRef.current;
     const currentSize = latestWindowSizeRef.current;
 
@@ -447,7 +438,7 @@ export const useWindowManager = ({
       setIsDragging(false);
 
       // Handle snap to edge
-      if (snapZone && !isMobile) {
+      if (snapZoneRef.current && !isMobile) {
         const { topInset, bottomInset } = computeInsets();
         const snapHeight = window.innerHeight - topInset - bottomInset;
         const snapWidth = Math.floor(window.innerWidth / 2);
@@ -460,7 +451,7 @@ export const useWindowManager = ({
 
         const newSize = { width: snapWidth, height: snapHeight };
         const newPosition = {
-          x: snapZone === "left" ? 0 : snapWidth,
+          x: snapZoneRef.current === "left" ? 0 : snapWidth,
           y: topInset,
         };
 
@@ -473,8 +464,9 @@ export const useWindowManager = ({
           updateInstanceWindowState(instanceId, newPosition, newSize);
         }
 
-        setSnapZone(null);
+        updateSnapZone(null);
       } else {
+        setWindowPosition(currentPosition);
         if (instanceId) {
           updateInstanceWindowState(instanceId, currentPosition, currentSize);
         }
@@ -489,6 +481,8 @@ export const useWindowManager = ({
     }
     if (resizeType) {
       setResizeType("");
+      setWindowPosition(currentPosition);
+      setWindowSize(currentSize);
       if (instanceId) {
         updateInstanceWindowState(instanceId, currentPosition, currentSize);
       }
@@ -500,13 +494,12 @@ export const useWindowManager = ({
       }
     }
   }, [
-    flushPendingWindowFrame,
     isDragging,
-    snapZone,
     isMobile,
     computeInsets,
     instanceId,
     updateInstanceWindowState,
+    updateSnapZone,
     stopMoveMoving,
     playMoveStop,
     resizeType,
@@ -536,6 +529,10 @@ export const useWindowManager = ({
   return {
     windowPosition,
     windowSize,
+    windowLeftMotionValue,
+    windowTopMotionValue,
+    windowWidthMotionValue,
+    windowHeightMotionValue,
     isDragging,
     resizeType,
     handleMouseDown,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Several pointer-driven interactions re-rendered large React subtrees on every mousemove (rule: rerender-use-ref-transient-values):

- `useWindowManager` RAF-batched drag/resize geometry into local React state, and `WindowFrame` animated `left/top/width/height` via the `animate` prop — re-rendering the whole window subtree each frame.
- `setSnapZone` added a second state update per move, and the drawer context value (`useWindowFrameDrawerSlot`) churned per frame as a result.
- The dock-scale divider drag (`MacDock`) re-rendered the entire dock (all icons) per mousemove via `setLiveDockScale`.
- The desktop marquee (`useDesktop`) updated `selectionRect` state per move and called `getBoundingClientRect` 4× per icon per move (plus a per-render desktop `getBoundingClientRect`).

## Fix

- **Window drag/resize** — `useWindowManager` now writes transient geometry into `left/top/width/height` motion values that `WindowFrame` binds in `style`; pointer moves update the DOM via motion without any React render, and the committed state + store write happen once on pointer-up. Programmatic transitions (snap, maximize, store sync) still flow through the `animate` prop, which animates the same motion values. The drawer context now only changes on commit, removing its per-frame churn.
- **Snap zone** — detection goes through a ref; state (and the indicator render) only updates on actual `left/right/null` transitions.
- **Dock scale drag** — the divider drag previews the new size with a CSS `scale` transform (motion value, `transform-origin: center bottom`) and commits the real scale to the dock store on mouseup, where the dock re-lays-out once.
- **Desktop marquee** — icon rects and the desktop origin are captured once on mousedown; the marquee rect element is painted directly via a ref per move; selection state only updates when the intersecting id set changes (signature compare).

## Testing

- ✅ `bunx tsc -b --noEmit`
- ✅ `bunx eslint` on changed files
- ✅ `bun run test:unit` (306 pass)
- ✅ `bun run build`
- ✅ Manual browser verification of window drag, resize, edge snap, marquee selection, and dock-scale drag (see screenshots)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-db31f888-f9da-42bf-8924-64165421e644"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-db31f888-f9da-42bf-8924-64165421e644"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

