### PR TITLE
perf(shell): finish narrowing instance/clock subscriptions; SW precache + react-scan fixes

### DIFF
--- a/src/components/ReactScanDebug.tsx
+++ b/src/components/ReactScanDebug.tsx
@@ -10,13 +10,23 @@ export function ReactScanDebug() {
   const debugMode = useDisplaySettingsStore((s) => s.debugMode);
 
   useEffect(() => {
+    // Only download the react-scan chunk when debug mode is actually on —
+    // an unconditional import() fetched it on every session even though
+    // scanning was disabled.
+    if (!debugMode) return;
     import("react-scan").then(({ scan }) => {
       scan({
-        enabled: debugMode,
-        showToolbar: debugMode,
-        dangerouslyForceRunInProduction: debugMode,
+        enabled: true,
+        showToolbar: true,
+        dangerouslyForceRunInProduction: true,
       });
     });
+    return () => {
+      // Turn scanning off if debug mode is disabled after the module loaded.
+      import("react-scan").then(({ scan }) => {
+        scan({ enabled: false, showToolbar: false });
+      });
+    };
   }, [debugMode]);
 
   return null;

--- a/src/components/layout/AppMenu.tsx
+++ b/src/components/layout/AppMenu.tsx
@@ -11,7 +11,7 @@ import { HelpDialog } from "@/components/dialogs/HelpDialog";
 import { AboutDialog } from "@/components/dialogs/AboutDialog";
 import { ShareItemDialog } from "@/components/dialogs/ShareItemDialog";
 import { generateAppShareUrl } from "@/utils/sharedUrl";
-import { useAppStoreShallow } from "@/stores/useAppStore";
+import { useAppStore, useAppStoreShallow } from "@/stores/useAppStore";
 import { appRegistry, type AppId } from "@/config/appRegistry";
 import { getTranslatedAppName } from "@/utils/i18n";
 
@@ -40,16 +40,22 @@ export function AppMenu({
   const [isShareDialogOpen, setIsShareDialogOpen] = useState(false);
 
   const {
-    instances,
     minimizeInstance,
     restoreInstance,
     closeAppInstance,
   } = useAppStoreShallow((s) => ({
-    instances: s.instances,
     minimizeInstance: s.minimizeInstance,
     restoreInstance: s.restoreInstance,
     closeAppInstance: s.closeAppInstance,
   }));
+  // Boolean selector instead of subscribing to the whole `instances` map:
+  // the menu re-renders only when this flips, and the bulk handlers below
+  // read the map imperatively at click time.
+  const hasMinimizedInstances = useAppStore((s) =>
+    Object.values(s.instances).some(
+      (inst) => inst.appId === appId && inst.isOpen && inst.isMinimized
+    )
+  );
 
   // Get app metadata for help and about dialogs
   const app = appRegistry[appId];
@@ -65,14 +71,6 @@ export function AppMenu({
   // Check if this app supports fullscreen
   const supportsFullScreen = FULLSCREEN_APPS.includes(appId);
 
-  // Get all open instances of this app
-  const appInstances = Object.values(instances).filter(
-    (inst) => inst.appId === appId && inst.isOpen
-  );
-
-  // Check if there are any minimized instances of this app
-  const hasMinimizedInstances = appInstances.some((inst) => inst.isMinimized);
-
   // Hide this app (minimize the current instance)
   const handleHide = () => {
     minimizeInstance(instanceId);
@@ -80,7 +78,7 @@ export function AppMenu({
 
   // Hide others - minimize all other app instances
   const handleHideOthers = () => {
-    Object.values(instances).forEach((inst) => {
+    Object.values(useAppStore.getState().instances).forEach((inst) => {
       if (inst.isOpen && inst.instanceId !== instanceId && !inst.isMinimized) {
         minimizeInstance(inst.instanceId);
       }
@@ -89,8 +87,8 @@ export function AppMenu({
 
   // Show all - restore all minimized instances of this app
   const handleShowAll = () => {
-    appInstances.forEach((inst) => {
-      if (inst.isMinimized) {
+    Object.values(useAppStore.getState().instances).forEach((inst) => {
+      if (inst.appId === appId && inst.isOpen && inst.isMinimized) {
         restoreInstance(inst.instanceId);
       }
     });

--- a/src/components/layout/ExposeView.tsx
+++ b/src/components/layout/ExposeView.tsx
@@ -2,7 +2,7 @@ import { useEffect, useCallback, useMemo } from "react";
 import { useEventListener } from "@/hooks/useEventListener";
 import { usePrevious } from "@/hooks/useLatestRef";
 import { motion, AnimatePresence } from "motion/react";
-import { useAppStoreShallow } from "@/stores/useAppStore";
+import { useAppStore, useAppStoreShallow } from "@/stores/useAppStore";
 import { getAppIconPath } from "@/config/appRegistry";
 import { getTranslatedAppName } from "@/utils/i18n";
 import { ThemedIcon } from "@/components/shared/ThemedIcon";
@@ -25,19 +25,24 @@ interface ExposeViewProps {
   onClose: () => void;
 }
 
+const EMPTY_INSTANCES: Record<string, AppInstance> = {};
+
 export function ExposeView({ isOpen, onClose }: ExposeViewProps) {
   const { t } = useTranslation();
   const {
-    instances,
     setExposeMode,
     bringInstanceToForeground,
     restoreInstance,
   } = useAppStoreShallow((state) => ({
-    instances: state.instances,
     setExposeMode: state.setExposeMode,
     bringInstanceToForeground: state.bringInstanceToForeground,
     restoreInstance: state.restoreInstance,
   }));
+  // Only track the instances map while the overlay is visible; when closed
+  // the selector returns a constant so instance churn never re-renders us.
+  const instances = useAppStore((state) =>
+    isOpen ? state.instances : EMPTY_INSTANCES
+  );
 
   const getFileItem = useFilesStore((s) => s.getItem);
   const { isMacOSTheme: isMacOSXTheme } = useThemeFlags();

--- a/src/components/layout/MenuBar.tsx
+++ b/src/components/layout/MenuBar.tsx
@@ -2,7 +2,11 @@ import { useMemo } from "react";
 import { Menubar } from "@/components/ui/menubar";
 import { appRegistry } from "@/config/appRegistry";
 import type { AnyApp } from "@/apps/base/types";
-import { useAppStoreShallow } from "@/stores/useAppStore";
+import { useAppStore, useAppStoreShallow } from "@/stores/useAppStore";
+import {
+  getDockInstancesSignature,
+  getDockInstancesSnapshot,
+} from "./dock/dockInstancesSnapshot";
 import { useThemeFlags } from "@/hooks/useThemeFlags";
 import { useFilesStore } from "@/stores/useFilesStore";
 import type { MenuBarProps } from "./menu-bar/menuBarTypes";
@@ -58,16 +62,24 @@ function WindowsTaskbarWithState({
   isXpTheme: boolean;
 }) {
   const {
-    instances,
+    dockInstancesSignature,
     bringInstanceToForeground,
     restoreInstance,
     foregroundInstanceId,
   } = useAppStoreShallow((s) => ({
-    instances: s.instances,
+    dockInstancesSignature: getDockInstancesSignature(s.instances),
     bringInstanceToForeground: s.bringInstanceToForeground,
     restoreInstance: s.restoreInstance,
     foregroundInstanceId: s.foregroundInstanceId,
   }));
+  const instances = useMemo(
+    () => getDockInstancesSnapshot(useAppStore.getState().instances),
+    // The signature string is a deliberate cache key (same pattern as
+    // MacDock): the snapshot is rebuilt only when a taskbar-relevant field
+    // changes, not on every geometry/focus write to the instances map.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [dockInstancesSignature]
+  );
   const getFileItem = useFilesStore((s) => s.getItem);
 
   return (

--- a/src/components/layout/dashboard/IpodWidget.tsx
+++ b/src/components/layout/dashboard/IpodWidget.tsx
@@ -175,6 +175,70 @@ function ClickWheel({
   );
 }
 
+/**
+ * Subscribes to the active playback clock (~20Hz while playing) for the
+ * relevant store only. Kept in leaf components so clock ticks re-render just
+ * the progress fill / time label instead of the whole widget.
+ */
+function usePlaybackClock(isKaraoke: boolean, enabled: boolean) {
+  const ipodElapsed = useIpodStore((s) =>
+    enabled && !isKaraoke ? s.elapsedTime : 0
+  );
+  const ipodTotal = useIpodStore((s) =>
+    enabled && !isKaraoke ? s.totalTime : 0
+  );
+  const karaokeElapsed = useKaraokeStore((s) =>
+    enabled && isKaraoke ? s.elapsedTime : 0
+  );
+  const karaokeTotal = useKaraokeStore((s) =>
+    enabled && isKaraoke ? s.totalTime : 0
+  );
+  return {
+    elapsedTime: isKaraoke ? karaokeElapsed : ipodElapsed,
+    totalTime: isKaraoke ? karaokeTotal : ipodTotal,
+  };
+}
+
+function IpodWidgetProgressFill({ isKaraoke }: { isKaraoke: boolean }) {
+  const { elapsedTime, totalTime } = usePlaybackClock(isKaraoke, true);
+  return (
+    <div
+      style={{
+        height: "100%",
+        width: `${totalTime > 0 ? (elapsedTime / totalTime) * 100 : 0}%`,
+        background: "#2a4a00",
+        borderRadius: 2,
+        transition: "width 0.3s linear",
+      }}
+    />
+  );
+}
+
+function IpodWidgetTimeLabel({
+  isKaraoke,
+  hasTrack,
+}: {
+  isKaraoke: boolean;
+  hasTrack: boolean;
+}) {
+  const { elapsedTime } = usePlaybackClock(isKaraoke, hasTrack);
+  return (
+    <span
+      style={{
+        fontSize: 11,
+        fontWeight: 700,
+        fontFamily: "'Helvetica Neue', Helvetica, Arial, sans-serif",
+        color: "#2a4a00",
+        letterSpacing: "0.5px",
+      }}
+    >
+      {hasTrack
+        ? `${Math.floor(elapsedTime / 60)}:${String(Math.floor(elapsedTime % 60)).padStart(2, "0")}`
+        : "0:00"}
+    </span>
+  );
+}
+
 export function IpodWidget({ widgetId }: IpodWidgetProps) {
   const { t } = useTranslation();
   const { isWindowsTheme: isXpTheme } = useThemeFlags();
@@ -193,8 +257,6 @@ export function IpodWidget({ widgetId }: IpodWidgetProps) {
   const ipodLoopCurrent = useIpodStore((s) => s.loopCurrent);
   const ipodLoopAll = useIpodStore((s) => s.loopAll);
   const ipodToggleLoopCurrent = useIpodStore((s) => s.toggleLoopCurrent);
-  const ipodElapsedTime = useIpodStore((s) => s.elapsedTime);
-  const ipodTotalTime = useIpodStore((s) => s.totalTime);
 
   const karaokeGetCurrentTrack = useKaraokeStore((s) => s.getCurrentTrack);
   const karaokeIsPlaying = useKaraokeStore((s) => s.isPlaying);
@@ -206,8 +268,6 @@ export function IpodWidget({ widgetId }: IpodWidgetProps) {
   const karaokeLoopCurrent = useKaraokeStore((s) => s.loopCurrent);
   const karaokeLoopAll = useKaraokeStore((s) => s.loopAll);
   const karaokeToggleLoopCurrent = useKaraokeStore((s) => s.toggleLoopCurrent);
-  const karaokeElapsedTime = useKaraokeStore((s) => s.elapsedTime);
-  const karaokeTotalTime = useKaraokeStore((s) => s.totalTime);
 
   const getCurrentTrack = isKaraoke ? karaokeGetCurrentTrack : ipodGetCurrentTrack;
   const isPlaying = isKaraoke ? karaokeIsPlaying : ipodIsPlaying;
@@ -219,8 +279,6 @@ export function IpodWidget({ widgetId }: IpodWidgetProps) {
   const loopCurrent = isKaraoke ? karaokeLoopCurrent : ipodLoopCurrent;
   const loopAll = isKaraoke ? karaokeLoopAll : ipodLoopAll;
   const toggleLoopCurrent = isKaraoke ? karaokeToggleLoopCurrent : ipodToggleLoopCurrent;
-  const elapsedTime = isKaraoke ? karaokeElapsedTime : ipodElapsedTime;
-  const totalTime = isKaraoke ? karaokeTotalTime : ipodTotalTime;
 
   const targetAppId = isKaraoke ? "karaoke" : "ipod";
   const isTargetAppOpen = useAppStore(
@@ -414,15 +472,7 @@ export function IpodWidget({ widgetId }: IpodWidgetProps) {
               overflow: "hidden",
             }}
           >
-            <div
-              style={{
-                height: "100%",
-                width: `${totalTime > 0 ? (elapsedTime / totalTime) * 100 : 0}%`,
-                background: "#2a4a00",
-                borderRadius: 2,
-                transition: "width 0.3s linear",
-              }}
-            />
+            <IpodWidgetProgressFill isKaraoke={isKaraoke} />
           </div>
         )}
         {!hasTrack && (
@@ -464,19 +514,7 @@ export function IpodWidget({ widgetId }: IpodWidgetProps) {
             <Shuffle size={14} weight="bold" />
           </button>
 
-          <span
-            style={{
-              fontSize: 11,
-              fontWeight: 700,
-              fontFamily: "'Helvetica Neue', Helvetica, Arial, sans-serif",
-              color: "#2a4a00",
-              letterSpacing: "0.5px",
-            }}
-          >
-            {hasTrack
-              ? `${Math.floor(elapsedTime / 60)}:${String(Math.floor(elapsedTime % 60)).padStart(2, "0")}`
-              : "0:00"}
-          </span>
+          <IpodWidgetTimeLabel isKaraoke={isKaraoke} hasTrack={hasTrack} />
 
           <button
             type="button"

--- a/src/components/layout/dock/MacDock.tsx
+++ b/src/components/layout/dock/MacDock.tsx
@@ -16,7 +16,7 @@ import { useIsPhone } from "@/hooks/useIsPhone";
 import { useIsRyoAdmin } from "@/hooks/useIsRyoAdmin";
 import { useLongPress } from "@/hooks/useLongPress";
 import { useSound, Sounds } from "@/hooks/useSound";
-import type { AppInstance, LaunchOriginRect } from "@/stores/useAppStore";
+import type { LaunchOriginRect } from "@/stores/useAppStore";
 import { RightClickMenu } from "@/components/ui/right-click-menu";
 import { ConfirmDialog } from "@/components/dialogs/ConfirmDialog";
 import { AnimatePresence, motion, LayoutGroup, useMotionValue } from "motion/react";
@@ -39,78 +39,10 @@ import { createDockTrashHandlers } from "./dockTrashHandlers";
 import { DockDivider } from "./DockDivider";
 import { useDockIconHover } from "./useDockIconHover";
 import { useDockMagnification } from "./useDockMagnification";
-
-type DockInstanceSnapshot = Pick<
-  AppInstance,
-  | "appId"
-  | "createdAt"
-  | "displayTitle"
-  | "initialData"
-  | "instanceId"
-  | "isLoading"
-  | "isMinimized"
-  | "isOpen"
-  | "title"
->;
-
-function getAppletInitialDataSignature(initialData: unknown): string {
-  if (!initialData || typeof initialData !== "object") return "";
-  const data = initialData as {
-    icon?: unknown;
-    name?: unknown;
-    path?: unknown;
-    shareCode?: unknown;
-  };
-  return [
-    data.path,
-    data.shareCode,
-    data.icon,
-    data.name,
-  ]
-    .map((value) => (typeof value === "string" ? value : ""))
-    .join("\u001f");
-}
-
-function getDockInstancesSignature(instances: Record<string, AppInstance>) {
-  return Object.values(instances)
-    .map((inst) =>
-      [
-        inst.instanceId,
-        inst.appId,
-        inst.isOpen ? "1" : "0",
-        inst.isLoading ? "1" : "0",
-        inst.isMinimized ? "1" : "0",
-        inst.createdAt,
-        inst.title ?? "",
-        inst.displayTitle ?? "",
-        inst.appId === "applet-viewer"
-          ? getAppletInitialDataSignature(inst.initialData)
-          : "",
-      ].join("\u001f")
-    )
-    .join("\u001e");
-}
-
-function getDockInstancesSnapshot(
-  instances: Record<string, AppInstance>
-): Record<string, AppInstance> {
-  return Object.fromEntries(
-    Object.entries(instances).map(([id, inst]) => {
-      const snapshot = {
-        appId: inst.appId,
-        createdAt: inst.createdAt,
-        displayTitle: inst.displayTitle,
-        initialData: inst.initialData,
-        instanceId: inst.instanceId,
-        isLoading: inst.isLoading,
-        isMinimized: inst.isMinimized,
-        isOpen: inst.isOpen,
-        title: inst.title,
-      } satisfies DockInstanceSnapshot;
-      return [id, snapshot as AppInstance];
-    })
-  );
-}
+import {
+  getDockInstancesSignature,
+  getDockInstancesSnapshot,
+} from "./dockInstancesSnapshot";
 
 export function MacDock() {
   const { t } = useTranslation();

--- a/src/components/layout/dock/dockInstancesSnapshot.ts
+++ b/src/components/layout/dock/dockInstancesSnapshot.ts
@@ -1,0 +1,82 @@
+import type { AppInstance } from "@/stores/useAppStore";
+
+/**
+ * Signature-keyed snapshot of the instances map for shell chrome (Dock,
+ * Windows taskbar). Geometry/focus writes mutate the `instances` record
+ * identity without changing anything the chrome renders; selecting the
+ * signature string (cheap to compare) and rebuilding the snapshot only when
+ * it changes keeps these components out of high-frequency render paths.
+ */
+export type DockInstanceSnapshot = Pick<
+  AppInstance,
+  | "appId"
+  | "createdAt"
+  | "displayTitle"
+  | "initialData"
+  | "instanceId"
+  | "isLoading"
+  | "isMinimized"
+  | "isOpen"
+  | "title"
+>;
+
+function getAppletInitialDataSignature(initialData: unknown): string {
+  if (!initialData || typeof initialData !== "object") return "";
+  const data = initialData as {
+    icon?: unknown;
+    name?: unknown;
+    path?: unknown;
+    shareCode?: unknown;
+  };
+  return [
+    data.path,
+    data.shareCode,
+    data.icon,
+    data.name,
+  ]
+    .map((value) => (typeof value === "string" ? value : ""))
+    .join("\u001f");
+}
+
+export function getDockInstancesSignature(
+  instances: Record<string, AppInstance>
+) {
+  return Object.values(instances)
+    .map((inst) =>
+      [
+        inst.instanceId,
+        inst.appId,
+        inst.isOpen ? "1" : "0",
+        inst.isLoading ? "1" : "0",
+        inst.isMinimized ? "1" : "0",
+        inst.createdAt,
+        inst.title ?? "",
+        inst.displayTitle ?? "",
+        inst.appId === "applet-viewer"
+          ? getAppletInitialDataSignature(inst.initialData)
+          : "",
+      ].join("\u001f")
+    )
+    .join("\u001e");
+}
+
+export function getDockInstancesSnapshot(
+  instances: Record<string, AppInstance>
+): Record<string, AppInstance> {
+  return Object.fromEntries(
+    Object.entries(instances).map(([id, inst]) => {
+      const snapshot = {
+        appId: inst.appId,
+        createdAt: inst.createdAt,
+        displayTitle: inst.displayTitle,
+        initialData: inst.initialData,
+        instanceId: inst.instanceId,
+        isLoading: inst.isLoading,
+        isMinimized: inst.isMinimized,
+        isOpen: inst.isOpen,
+        title: inst.title,
+      } satisfies DockInstanceSnapshot;
+      return [id, snapshot as AppInstance];
+    })
+  );
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -68,6 +68,8 @@ self.addEventListener("activate", (event) => {
 //   - mermaid                         (chat diagrams)
 //   - webamp                          (Winamp app)
 //   - v86                             (Virtual PC emulator)
+//   - pusher-js                       (realtime chat; needs network anyway)
+//   - react-player                    (YouTube playback; needs network anyway)
 // `three` (3D wallpapers / Synth) and `audio` (Synth/Soundboard/iPod) are NOT
 // excluded so those keep working offline.
 //
@@ -76,7 +78,7 @@ self.addEventListener("activate", (event) => {
 // `manifestTransforms` hook below.
 // ---------------------------------------------------------------------------
 const HEAVY_PRECACHE_PACKAGES =
-  /[/\\]node_modules[/\\](?:\.pnpm[/\\][^/\\]+[/\\]node_modules[/\\])?(?:shiki|@shikijs|mermaid|webamp|v86)[/\\]/;
+  /[/\\]node_modules[/\\](?:\.pnpm[/\\][^/\\]+[/\\]node_modules[/\\])?(?:shiki|@shikijs|mermaid|webamp|v86|pusher-js|react-player)[/\\]/;
 const heavyPrecacheExclusions = new Set<string>();
 
 function collectHeavyChunksPlugin() {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Quick-wins batch from the post-#1452/#1453/#1458/#1459 re-audit — residual subscription hotspots plus two bundle/network fixes.

## Changes

- **`IpodWidget`**: the desktop widget still subscribed to both iPod and Karaoke `elapsedTime`/`totalTime`, re-rendering the whole widget ~20x/sec while music plays (apps were fixed in #1453, the widget wasn't). The clock now lives in leaf `IpodWidgetProgressFill` / `IpodWidgetTimeLabel` components with store-gated selectors, so ticks re-render only the 3px fill bar and the time text.
- **Windows taskbar** (`MenuBar.tsx`): subscribed to the full `instances` map; now uses the same signature-keyed snapshot pattern #1452 introduced for `MacDock` (helpers extracted to a shared `dock/dockInstancesSnapshot.ts`).
- **`AppMenu`**: replaced the full-map subscription with a boolean `hasMinimizedInstances` selector; "Hide Others"/"Show All" read `instances` imperatively via `getState()` at click time.
- **`ExposeView`**: `instances` subscription gated on `isOpen` — the closed overlay no longer re-renders on any instance churn.
- **Service worker**: `pusher-js` and `react-player` chunks excluded from precache (both are useless offline; they stay available via the runtime CacheFirst rule). Deliberately did **not** exclude `three`/`audio` — the existing config comment documents keeping wallpapers/Synth/Soundboard working offline.
- **`ReactScanDebug`**: the `react-scan` chunk was downloaded on every session even with debug off; now imported only when debug mode is enabled (with a disable path if toggled off after load).

## Testing

- ✅ `bunx tsc -b --force` — clean
- ✅ `bun run test:unit` — 310 pass / 0 fail
- ✅ `bun run build` — clean; SW precache dropped 11,816 → 11,757 KiB
- ✅ `bunx eslint` on changed files — 0 errors
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-819f5fdd-4d5f-4944-83d4-bde8c75427ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-819f5fdd-4d5f-4944-83d4-bde8c75427ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

