### PR TITLE
perf(chats,finder): per-room store subscriptions + content-visibility for long lists

### DIFF
--- a/src/apps/chats/components/ChatRoomSidebar.tsx
+++ b/src/apps/chats/components/ChatRoomSidebar.tsx
@@ -29,6 +29,113 @@ interface ChatRoomSidebarProps {
   onlineUsers?: string[];
 }
 
+const ChatRoomSidebarItem = React.memo(function ChatRoomSidebarItem({
+  room,
+  isSelected,
+  isPrivateOnline,
+  isAdmin,
+  username,
+  onRoomSelect,
+  onDeleteRoom,
+  playButtonClick,
+}: {
+  room: ChatRoom;
+  isSelected: boolean;
+  isPrivateOnline: boolean;
+  isAdmin: boolean;
+  username?: string | null;
+  onRoomSelect: (room: ChatRoom | null) => void;
+  onDeleteRoom?: (room: ChatRoom) => void;
+  playButtonClick: () => void;
+}) {
+  const { t } = useTranslation();
+  // Per-room subscription: an unread-count bump re-renders only this row.
+  const unreadCount = useChatsStore((s) => s.unreadCounts[room.id] || 0);
+  const hasUnread = unreadCount > 0;
+
+  return (
+    <div
+      className={cn(
+        "group relative py-1 px-5",
+        isSelected ? "" : "hover:bg-black/5"
+      )}
+      data-selected={isSelected ? "true" : undefined}
+      onClick={() => {
+        playButtonClick();
+        onRoomSelect(room);
+      }}
+    >
+      <div className="flex items-center">
+        {isPrivateOnline && (
+          <span
+            className="inline-block size-1.5 rounded-full bg-green-500 mr-1.5 flex-shrink-0"
+            title="Online"
+          />
+        )}
+        <span>
+          {room.type === "private"
+            ? getPrivateRoomDisplayName(room, username ?? null)
+            : `#${room.name}`}
+        </span>
+        {room.type === "irc" && (
+          <span
+            className={cn(
+              "ml-1 text-[9px] font-bold uppercase tracking-wider",
+              isSelected ? "text-white/40" : "text-black/40"
+            )}
+            title={`IRC ${room.ircHost || "irc.pieter.com"}`}
+          >
+            irc
+          </span>
+        )}
+        {(hasUnread || room.type !== "private") && (
+          <span
+            className={cn(
+              "text-[10px] ml-1.5 transition-opacity",
+              hasUnread
+                ? "text-orange-600"
+                : isSelected
+                ? "text-white/40"
+                : "text-black/40",
+              hasUnread || room.userCount > 0
+                ? "opacity-100"
+                : isSelected
+                ? "opacity-100"
+                : "opacity-0 group-hover:opacity-100"
+            )}
+          >
+            {hasUnread
+              ? `${unreadCount >= 20 ? "20+" : unreadCount} ${t("apps.chats.sidebar.new")}`
+              : `${room.userCount} ${t("apps.chats.sidebar.online")}`}
+          </span>
+        )}
+      </div>
+      {((isAdmin && room.type !== "private") || room.type === "private") &&
+        onDeleteRoom && (
+          <button
+            className={cn(
+              "absolute right-1 top-1/2 transform -translate-y-1/2 transition-opacity text-neutral-500 hover:text-red-500 p-1 rounded hover:bg-black/5",
+              isSelected ? "opacity-100" : "opacity-0 group-hover:opacity-100"
+            )}
+            onClick={(e) => {
+              e.stopPropagation();
+              playButtonClick();
+              onDeleteRoom(room);
+            }}
+            aria-label={
+              room.type === "private" ? t("apps.chats.ariaLabels.leaveConversation") : t("apps.chats.ariaLabels.deleteRoom")
+            }
+            title={
+              room.type === "private" ? t("apps.chats.ariaLabels.leaveConversation") : t("apps.chats.ariaLabels.deleteRoom")
+            }
+          >
+            <Trash className="size-3 text-black/30" weight="bold" />
+          </button>
+        )}
+    </div>
+  );
+});
+
 export const ChatRoomSidebar = React.memo(function ChatRoomSidebar({
   rooms,
   currentRoom,
@@ -43,7 +150,9 @@ export const ChatRoomSidebar = React.memo(function ChatRoomSidebar({
 }: ChatRoomSidebarProps) {
   const { t } = useTranslation();
   const { play: playButtonClick } = useSound(Sounds.BUTTON_CLICK);
-  const unreadCounts = useChatsStore((state) => state.unreadCounts);
+  // NOTE: unread counts are deliberately NOT subscribed here — each
+  // ChatRoomSidebarItem subscribes to its own room's count so a badge update
+  // re-renders one row instead of the whole sidebar.
 
   // Theme detection for border styling
   const { isWindowsTheme: isXpTheme, isMacOSTheme, isAquaGlass } =
@@ -81,100 +190,26 @@ export const ChatRoomSidebar = React.memo(function ChatRoomSidebar({
   }
 
   const renderRoomItem = (room: ChatRoom) => {
-    const unreadCount = unreadCounts[room.id] || 0;
-    const hasUnread = unreadCount > 0;
-    const isSelected = currentRoom?.id === room.id;
-
     // For private rooms, check if the other member(s) are online
-    const isPrivateOnline =
+    const isPrivateOnline = Boolean(
       room.type === "private" &&
-      room.members?.some(
-        (m) => m !== username?.toLowerCase() && onlineUsersSet.has(m)
-      );
+        room.members?.some(
+          (m) => m !== username?.toLowerCase() && onlineUsersSet.has(m)
+        )
+    );
 
     return (
-      <div
+      <ChatRoomSidebarItem
         key={room.id}
-        className={cn(
-          "group relative py-1 px-5",
-          isSelected ? "" : "hover:bg-black/5"
-        )}
-        data-selected={isSelected ? "true" : undefined}
-        onClick={() => {
-          playButtonClick();
-          onRoomSelect(room);
-        }}
-      >
-        <div className="flex items-center">
-          {isPrivateOnline && (
-            <span
-              className="inline-block size-1.5 rounded-full bg-green-500 mr-1.5 flex-shrink-0"
-              title="Online"
-            />
-          )}
-          <span>
-            {room.type === "private"
-              ? getPrivateRoomDisplayName(room, username ?? null)
-              : `#${room.name}`}
-          </span>
-          {room.type === "irc" && (
-            <span
-              className={cn(
-                "ml-1 text-[9px] font-bold uppercase tracking-wider",
-                isSelected ? "text-white/40" : "text-black/40"
-              )}
-              title={`IRC ${room.ircHost || "irc.pieter.com"}`}
-            >
-              irc
-            </span>
-          )}
-          {(hasUnread || room.type !== "private") && (
-            <span
-              className={cn(
-                "text-[10px] ml-1.5 transition-opacity",
-                hasUnread
-                  ? "text-orange-600"
-                  : currentRoom?.id === room.id
-                  ? "text-white/40"
-                  : "text-black/40",
-                hasUnread || room.userCount > 0
-                  ? "opacity-100"
-                  : currentRoom?.id === room.id
-                  ? "opacity-100"
-                  : "opacity-0 group-hover:opacity-100"
-              )}
-            >
-              {hasUnread
-                ? `${unreadCount >= 20 ? "20+" : unreadCount} ${t("apps.chats.sidebar.new")}`
-                : `${room.userCount} ${t("apps.chats.sidebar.online")}`}
-            </span>
-          )}
-        </div>
-        {((isAdmin && room.type !== "private") || room.type === "private") &&
-          onDeleteRoom && (
-            <button
-              className={cn(
-                "absolute right-1 top-1/2 transform -translate-y-1/2 transition-opacity text-neutral-500 hover:text-red-500 p-1 rounded hover:bg-black/5",
-                currentRoom?.id === room.id
-                  ? "opacity-100"
-                  : "opacity-0 group-hover:opacity-100"
-              )}
-              onClick={(e) => {
-                e.stopPropagation();
-                playButtonClick();
-                onDeleteRoom(room);
-              }}
-              aria-label={
-                room.type === "private" ? t("apps.chats.ariaLabels.leaveConversation") : t("apps.chats.ariaLabels.deleteRoom")
-              }
-              title={
-                room.type === "private" ? t("apps.chats.ariaLabels.leaveConversation") : t("apps.chats.ariaLabels.deleteRoom")
-              }
-            >
-              <Trash className="size-3 text-black/30" weight="bold" />
-            </button>
-          )}
-      </div>
+        room={room}
+        isSelected={currentRoom?.id === room.id}
+        isPrivateOnline={isPrivateOnline}
+        isAdmin={isAdmin}
+        username={username}
+        onRoomSelect={onRoomSelect}
+        onDeleteRoom={onDeleteRoom}
+        playButtonClick={playButtonClick}
+      />
     );
   };
 

--- a/src/apps/chats/components/chat-messages/chat-message-item/ChatMessageItem.tsx
+++ b/src/apps/chats/components/chat-messages/chat-message-item/ChatMessageItem.tsx
@@ -39,6 +39,12 @@ export const ChatMessageItem = memo(function ChatMessageItem(
       style={{
         transformOrigin:
           message.role === "user" ? "bottom right" : "bottom left",
+        // Skip layout/paint for rows far outside the viewport so long
+        // threads stay cheap (especially while another message streams).
+        // `auto` intrinsic sizing remembers each row's rendered height, so
+        // scroll position and stick-to-bottom behavior are unaffected.
+        contentVisibility: "auto",
+        containIntrinsicSize: "auto 48px",
       }}
       onMouseEnter={() =>
         !isInteractingWithPreview &&

--- a/src/apps/chats/components/chat-messages/chat-message-item/ChatMessageItem.tsx
+++ b/src/apps/chats/components/chat-messages/chat-message-item/ChatMessageItem.tsx
@@ -45,6 +45,13 @@ export const ChatMessageItem = memo(function ChatMessageItem(
         // scroll position and stick-to-bottom behavior are unaffected.
         contentVisibility: "auto",
         containIntrinsicSize: "auto 48px",
+        // content-visibility implies contain:paint, which clips ink overflow
+        // (the Aqua bubble drop shadows) at the row box. Grow the containment
+        // box by the shadow extent and cancel it with negative margins +
+        // width so layout and bubble spacing are unchanged.
+        width: "calc(100% + 16px)",
+        padding: "4px 8px 10px",
+        margin: "-4px -8px -10px",
       }}
       onMouseEnter={() =>
         !isInteractingWithPreview &&

--- a/src/apps/chats/hooks/useChatRoom.ts
+++ b/src/apps/chats/hooks/useChatRoom.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useRef } from "react";
+import { useState, useEffect, useCallback, useMemo, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import type { PusherChannel } from "@/lib/pusherClient";
 import {
@@ -52,6 +52,8 @@ interface RoomHandlers {
   onUserTyping: (data: TypingPayload) => void;
 }
 
+const EMPTY_MESSAGES: ChatMessage[] = [];
+
 export function useChatRoom(
   isWindowOpen: boolean,
   onPromptSetUsername?: () => void
@@ -62,7 +64,6 @@ export function useChatRoom(
     isAuthenticated,
     rooms,
     currentRoomId,
-    roomMessages,
     isSidebarVisible,
     toggleSidebarVisibility,
     // Store methods
@@ -82,7 +83,6 @@ export function useChatRoom(
     isAuthenticated: state.isAuthenticated,
     rooms: state.rooms,
     currentRoomId: state.currentRoomId,
-    roomMessages: state.roomMessages,
     isSidebarVisible: state.isSidebarVisible,
     toggleSidebarVisibility: state.toggleSidebarVisibility,
     fetchRooms: state.fetchRooms,
@@ -118,15 +118,22 @@ export function useChatRoom(
   const [isDeleteRoomDialogOpen, setIsDeleteRoomDialogOpen] = useState(false);
   const [roomToDelete, setRoomToDelete] = useState<ChatRoom | null>(null);
 
-  // Get current room messages
-  const currentRoomMessages = currentRoomId
-    ? roomMessages[currentRoomId] || []
-    : [];
+  // Subscribe to the current room's message array only — subscribing to the
+  // whole `roomMessages` map re-rendered the open Chats window whenever a
+  // realtime message arrived in ANY room. Message arrays are replaced
+  // immutably in the store, so reference equality is the correct signal.
+  const currentRoomMessages = useChatsStore((state) =>
+    state.currentRoomId
+      ? state.roomMessages[state.currentRoomId] ?? EMPTY_MESSAGES
+      : EMPTY_MESSAGES
+  );
 
-  // Limit messages rendered initially for performance
-  const currentRoomMessagesLimited = currentRoomId
-    ? (roomMessages[currentRoomId] || []).slice(-messageRenderLimit)
-    : [];
+  // Limit messages rendered initially for performance. Memoized so downstream
+  // consumers get a stable array identity between unrelated re-renders.
+  const currentRoomMessagesLimited = useMemo(
+    () => currentRoomMessages.slice(-messageRenderLimit),
+    [currentRoomMessages, messageRenderLimit]
+  );
 
   // --- Pusher Setup ---
   const initializePusher = useCallback(() => {

--- a/src/apps/finder/components/file-list/GridItem.tsx
+++ b/src/apps/finder/components/file-list/GridItem.tsx
@@ -55,6 +55,11 @@ export const GridItem = memo(function GridItem({
       onDrop={(e) => onDrop(e, file)}
       onDragEnd={onDragEnd}
       className="transition-all duration-75"
+      style={{
+        // Skip layout/paint for icons scrolled out of view in large folders.
+        contentVisibility: "auto",
+        containIntrinsicSize: "auto 80px",
+      }}
       onContextMenu={(e: React.MouseEvent) => {
         if (onItemContextMenu) {
           onItemContextMenu(file, e);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Chat render-cost batch from the re-audit (top remaining render item after #1452/#1453/#1458).

## Changes

- **`useChatRoom`**: replaced the whole-map `roomMessages` subscription with a selector on the current room's array only. Previously a Pusher message in *any* room replaced the map and re-rendered the entire open Chats window; message arrays are replaced immutably in the store so reference equality on the current room's array is the precise signal. `currentRoomMessagesLimited` is now memoized (was a fresh `.slice()` identity every render).
- **`ChatRoomSidebar`**: the inline `renderRoomItem` closure is extracted into a memoized `ChatRoomSidebarItem` that subscribes to its own `unreadCounts[room.id]` — an unread badge bump re-renders one row instead of the full sidebar, and the sidebar itself no longer subscribes to `unreadCounts` at all.
- **`ChatMessageItem`** rows get `content-visibility: auto` + `contain-intrinsic-size: auto 48px`: offscreen rows in long threads skip layout/paint entirely — the biggest win while an AI response streams (~20 updates/sec) into a long conversation. `auto` intrinsic sizing remembers each row's real height so scroll position and stick-to-bottom are unaffected.
  - **Shadow-clipping fix**: `content-visibility` implies `contain: paint`, which clipped the Aqua bubbles' outer drop shadows at the row box (hard line under each bubble). The containment box is now grown by the shadow extent (`padding: 4px 8px 10px` + `width: calc(100% + 16px)`) and cancelled with matching negative margins, so layout/spacing are unchanged while ink overflow fits inside the box. Verified in-browser: bubble→row-edge clearance is 10px bottom / 8px sides vs a max shadow extent of ~6px, and a zoomed screen capture shows the full soft shadow fade.
- **Finder `GridItem`** icons get the same `content-visibility` treatment for large folders. The table-based list view was deliberately left alone (`content-visibility` containment on `<tr>` is unreliable across browsers).

This is the low-risk subset of the "virtualize the chat list" recommendation — no new dependency, no scroll-behavior changes. Full windowing remains a follow-up if profiling shows it's still needed.

## Verification

![Chat bubbles with intact drop shadows (zoomed)](https://cursor.com/artifacts/c/art-598b70cf-5649-478a-93f2-331c5a10187a)

Bubble shadows render with a full soft fade after the containment-box fix; computed measurements from the live page (via DevTools): each row has `content-visibility: auto`, `padding 4/8/10/8` with cancelling negative margins, and 10px bottom / 8px side clearance between bubble and containment edge.

## Testing

- ✅ `bunx tsc -b --force` — clean
- ✅ `bun run test:unit` — 310 pass / 0 fail
- ✅ `bun test tests/test-chat-*.test.ts tests/test-pusher-*.test.ts` — 76 pass / 0 fail (ran directly; the `test:chat-regression` script's `bun test --filter` is broken with bun 1.3.5 on `main` — pre-existing)
- ✅ `bun run build` — clean
- ✅ `bunx eslint` on changed files — 0 errors
- ✅ Manual browser verification of the bubble shadows (screenshot above + computed-style probe of the live DOM)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-819f5fdd-4d5f-4944-83d4-bde8c75427ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-819f5fdd-4d5f-4944-83d4-bde8c75427ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

