### PR TITLE
perf(songs): dedup metadata/lyrics fetches; version-probe gating for library polling

### DIFF
--- a/api/_utils/_song-service.ts
+++ b/api/_utils/_song-service.ts
@@ -400,6 +400,46 @@ export async function deleteAllSongs(redis: Redis): Promise<number> {
   return songIds.length;
 }
 
+export interface SongsVersionInfo {
+  /** Highest updatedAt (falling back to createdAt) across matching songs. */
+  version: number;
+  /** Number of matching songs. */
+  count: number;
+}
+
+/**
+ * Lightweight version summary of the song catalog, so clients can poll for
+ * changes (~50 byte response) instead of downloading the full metadata list
+ * every interval.
+ */
+export async function getSongsVersionInfo(
+  redis: Redis,
+  options: { createdBy?: string } = {}
+): Promise<SongsVersionInfo> {
+  const { createdBy } = options;
+  const songIds = await redis.smembers(SONG_SET_KEY);
+  if (!songIds || songIds.length === 0) {
+    return { version: 0, count: 0 };
+  }
+
+  const metaKeys = songIds.map((id) => getSongMetaKey(id));
+  const rawMetas = await redis.mget(...metaKeys);
+
+  let version = 0;
+  let count = 0;
+  for (const rawMeta of rawMetas) {
+    if (!rawMeta) continue;
+    const meta = parseJson<SongMetadata>(rawMeta);
+    if (!meta) continue;
+    if (createdBy && meta.createdBy !== createdBy) continue;
+    count++;
+    const stamp = meta.updatedAt || meta.createdAt || 0;
+    if (stamp > version) version = stamp;
+  }
+
+  return { version, count };
+}
+
 /**
  * List songs with optional filtering
  * Only fetches metadata by default (lightweight), fetches content only when requested

--- a/api/songs/index.ts
+++ b/api/songs/index.ts
@@ -23,6 +23,7 @@ import * as RateLimit from "../_utils/_rate-limit.js";
 import { getClientIp } from "../_utils/_rate-limit.js";
 import {
   listSongs,
+  getSongsVersionInfo,
   saveSong,
   canModifySong,
   getSong,
@@ -232,6 +233,18 @@ export default apiHandler<Record<string, unknown>>(
       const ids = idsParam ? idsParam.split(",").map((s) => s.trim()).filter(Boolean) : undefined;
       const includeParam = (req.query.include as string) || "metadata";
       const includes = includeParam.split(",").map((s) => s.trim());
+
+      // Lightweight version probe: lets clients poll for catalog changes
+      // without downloading the full metadata list every interval.
+      if (includes.includes("version")) {
+        const versionInfo = await getSongsVersionInfo(redis, { createdBy });
+        logger.info("Returning songs version", {
+          ...versionInfo,
+          createdBy,
+          duration: `${Date.now() - startTime}ms`,
+        });
+        return jsonResponse(versionInfo);
+      }
 
       logger.info("Listing songs", { createdBy, idsCount: ids?.length, includes });
 

--- a/src/api/songs.ts
+++ b/src/api/songs.ts
@@ -116,6 +116,28 @@ export async function listSongs<TSong = Record<string, unknown>>(
   });
 }
 
+export interface SongsVersionInfo {
+  /** Highest updatedAt/createdAt across matching songs. */
+  version: number;
+  /** Number of matching songs. */
+  count: number;
+}
+
+/**
+ * Lightweight catalog version probe (`include=version`) — ~50 bytes instead
+ * of the full metadata list. Used by pollers to decide whether a full fetch
+ * is needed.
+ */
+export async function fetchSongsVersion(
+  createdBy?: string
+): Promise<SongsVersionInfo> {
+  return apiRequest<SongsVersionInfo>({
+    path: "/api/songs",
+    method: "GET",
+    query: { include: "version", createdBy },
+  });
+}
+
 export async function getSongById<TSong = Record<string, unknown>>(
   songId: string,
   options: { include?: string; signal?: AbortSignal } = {}
@@ -133,6 +155,8 @@ export async function updateSongById<TPayload extends object>(
   payload: TPayload,
   _auth?: SongsAuthContext
 ): Promise<SongSaveResponse> {
+  // Any song mutation may change lyrics/timings — drop cached responses.
+  invalidateLyricsCacheForSong(songId);
   return apiRequest<SongSaveResponse, TPayload>({
     path: `/api/songs/${encodeURIComponent(songId)}`,
     method: "POST",
@@ -148,6 +172,62 @@ export async function patchSongMetadata(
   return updateSongById(songId, payload, auth);
 }
 
+// ---------------------------------------------------------------------------
+// fetch-lyrics dedup cache
+//
+// The same song's lyrics are requested from several places (track import,
+// playback, fullscreen, StrictMode double-effects). Identical requests within
+// a short window share one in-flight promise and a small TTL response cache.
+// `force: true` bypasses and invalidates all entries for that song.
+// ---------------------------------------------------------------------------
+const LYRICS_CACHE_TTL_MS = 5 * 60 * 1000;
+const LYRICS_CACHE_MAX_ENTRIES = 12;
+
+const lyricsResponseCache = new Map<
+  string,
+  { at: number; data: FetchSongLyricsResponse }
+>();
+const lyricsInFlight = new Map<string, Promise<FetchSongLyricsResponse>>();
+
+function lyricsCacheKey(songId: string, body: Record<string, unknown>): string {
+  // Sort keys so logically-identical param objects produce the same key.
+  const stable = Object.keys(body)
+    .sort()
+    .map((k) => `${k}:${JSON.stringify(body[k])}`)
+    .join("|");
+  return `${songId}\u001f${stable}`;
+}
+
+function invalidateLyricsCacheForSong(songId: string): void {
+  const prefix = `${songId}\u001f`;
+  for (const key of lyricsResponseCache.keys()) {
+    if (key.startsWith(prefix)) lyricsResponseCache.delete(key);
+  }
+}
+
+/** Wait for `promise` but reject early if the caller's signal aborts. */
+function raceWithSignal<T>(promise: Promise<T>, signal?: AbortSignal): Promise<T> {
+  if (!signal) return promise;
+  if (signal.aborted) {
+    return Promise.reject(new DOMException("Aborted", "AbortError"));
+  }
+  return new Promise<T>((resolve, reject) => {
+    const onAbort = () =>
+      reject(new DOMException("Aborted", "AbortError"));
+    signal.addEventListener("abort", onAbort, { once: true });
+    promise.then(
+      (value) => {
+        signal.removeEventListener("abort", onAbort);
+        resolve(value);
+      },
+      (error) => {
+        signal.removeEventListener("abort", onAbort);
+        reject(error);
+      }
+    );
+  });
+}
+
 export async function fetchSongLyrics(
   songId: string,
   params: FetchSongLyricsParams = {}
@@ -159,17 +239,63 @@ export async function fetchSongLyrics(
     ...body
   } = params;
 
-  return apiRequest<FetchSongLyricsResponse>({
+  const key = lyricsCacheKey(songId, body);
+
+  if (body.force) {
+    // Forced refetch (e.g. changing lyrics source): drop every cached
+    // variant for this song so subsequent reads see the new content.
+    invalidateLyricsCacheForSong(songId);
+  } else {
+    const cached = lyricsResponseCache.get(key);
+    if (cached && Date.now() - cached.at < LYRICS_CACHE_TTL_MS) {
+      return cached.data;
+    }
+    const inFlight = lyricsInFlight.get(key);
+    if (inFlight) {
+      // Share the request, but honor this caller's own abort signal without
+      // cancelling the request for other awaiters.
+      return raceWithSignal(inFlight, signal);
+    }
+  }
+
+  // The shared request deliberately runs without the caller's signal —
+  // aborting one awaiter must not cancel it for the others. Callers race
+  // against their own signal instead.
+  const requestPromise = apiRequest<FetchSongLyricsResponse>({
     path: `/api/songs/${encodeURIComponent(songId)}`,
     method: "POST",
     body: {
       action: "fetch-lyrics",
       ...body,
     },
-    signal,
     timeout,
     retry,
-  });
+  })
+    .then((data) => {
+      lyricsResponseCache.set(key, { at: Date.now(), data });
+      // Simple LRU-ish cap: drop the oldest insertion order entries.
+      while (lyricsResponseCache.size > LYRICS_CACHE_MAX_ENTRIES) {
+        const oldest = lyricsResponseCache.keys().next().value;
+        if (oldest === undefined) break;
+        lyricsResponseCache.delete(oldest);
+      }
+      return data;
+    })
+    .finally(() => {
+      lyricsInFlight.delete(key);
+    });
+
+  if (!body.force) {
+    lyricsInFlight.set(key, requestPromise);
+  }
+
+  return raceWithSignal(requestPromise, signal);
+}
+
+/** Test-only helper: reset the fetch-lyrics dedup caches. */
+export function __clearLyricsCachesForTests(): void {
+  lyricsResponseCache.clear();
+  lyricsInFlight.clear();
 }
 
 export async function clearSongCachedData(
@@ -180,6 +306,7 @@ export async function clearSongCachedData(
     clearSoramimi?: boolean;
   } = {}
 ): Promise<Record<string, unknown>> {
+  invalidateLyricsCacheForSong(songId);
   return apiRequest<Record<string, unknown>>({
     path: `/api/songs/${encodeURIComponent(songId)}`,
     method: "POST",

--- a/src/apps/ipod/hooks/useLibraryUpdateChecker.ts
+++ b/src/apps/ipod/hooks/useLibraryUpdateChecker.ts
@@ -6,6 +6,7 @@ import { useTranslation } from "react-i18next";
 import { listAllCachedSongMetadata } from "@/utils/songMetadataCache";
 import { hasLibraryTrackMetadataChanges } from "@/stores/ipodTrackMetadataSync";
 import { mapCatalogSongToTrack } from "@/stores/ipodCatalogTrackMapping";
+import { fetchSongsVersion, type SongsVersionInfo } from "@/api/songs";
 
 const CHECK_INTERVAL = 5 * 60 * 1000; // Check every 5 minutes
 
@@ -15,6 +16,14 @@ export function useLibraryUpdateChecker(isActive: boolean) {
   const debugMode = useDisplaySettingsStore((state) => state.debugMode);
   const intervalRef = useRef<NodeJS.Timeout | null>(null);
   const lastCheckedRef = useRef<number>(0);
+  /**
+   * Server version observed by the last full check that ended in-sync.
+   * While the server still reports this version+count, the poller skips the
+   * full catalog download (which used to run every 5 minutes regardless).
+   * Only set after a check confirms there is nothing to apply, so a failed
+   * or partial sync never suppresses the next full comparison.
+   */
+  const lastInSyncVersionRef = useRef<SongsVersionInfo | null>(null);
 
   useEffect(() => {
     // Skip all auto-update logic when debug mode is enabled
@@ -33,11 +42,34 @@ export function useLibraryUpdateChecker(isActive: boolean) {
 
     const checkForUpdates = async () => {
       try {
-        // Do track-based comparison like manual sync, not version-based
-        // This avoids timing issues where version might already be updated
         const currentTracks = useIpodStore.getState().tracks;
         const wasEmpty = currentTracks.length === 0;
 
+        // Cheap version probe first: skip the full catalog download when the
+        // server reports the same version+count we already confirmed as
+        // in-sync. Probe failures fall through to the full check.
+        let versionInfo: SongsVersionInfo | null = null;
+        try {
+          versionInfo = await fetchSongsVersion("ryo");
+        } catch (error) {
+          console.warn(
+            "[iPod] Songs version probe failed; falling back to full check",
+            error
+          );
+        }
+        const lastInSync = lastInSyncVersionRef.current;
+        if (
+          versionInfo &&
+          lastInSync &&
+          versionInfo.version === lastInSync.version &&
+          versionInfo.count === lastInSync.count
+        ) {
+          console.log("[iPod] Catalog version unchanged, skipping full check", versionInfo);
+          return;
+        }
+
+        // Do track-based comparison like manual sync, not version-based
+        // This avoids timing issues where version might already be updated
         // Get server tracks from Redis cache (only songs by ryo)
         const cachedSongs = await listAllCachedSongMetadata("ryo");
         
@@ -78,10 +110,23 @@ export function useLibraryUpdateChecker(isActive: boolean) {
           currentLastKnownVersion: useIpodStore.getState().lastKnownVersion,
         });
 
+        if (newTracksCount === 0 && tracksUpdated === 0) {
+          // Fully in sync — remember the server version so the next polls
+          // can stop at the cheap probe.
+          if (versionInfo) {
+            lastInSyncVersionRef.current = versionInfo;
+          }
+        }
+
         if (newTracksCount > 0 || tracksUpdated > 0) {
           // Auto-update: directly sync without asking user
           try {
             const result = await syncLibrary();
+            if (versionInfo) {
+              // Sync applied (or confirmed no-op) — record the version we
+              // just reconciled against.
+              lastInSyncVersionRef.current = versionInfo;
+            }
             if (result.newTracksAdded === 0 && result.tracksUpdated === 0) {
               console.log("[iPod] Auto update check resolved with no applied changes");
               return;

--- a/src/utils/songMetadataCache.ts
+++ b/src/utils/songMetadataCache.ts
@@ -202,6 +202,22 @@ function unifiedToMetadata(doc: UnifiedSongDocument): CachedSongMetadata {
   };
 }
 
+// In-memory layer in front of the HTTP "cache": dedupes concurrent lookups
+// for the same id and remembers hits for a short window so repeated
+// add-track / navigation flows don't refetch identical metadata.
+const METADATA_MEMO_TTL_MS = 5 * 60 * 1000;
+const metadataMemo = new Map<string, { at: number; data: CachedSongMetadata }>();
+const metadataInFlight = new Map<string, Promise<CachedSongMetadata | null>>();
+
+/** Drop the in-memory copy for one id (or all when omitted). */
+export function invalidateCachedSongMetadata(youtubeId?: string): void {
+  if (youtubeId === undefined) {
+    metadataMemo.clear();
+    return;
+  }
+  metadataMemo.delete(youtubeId);
+}
+
 /**
  * Retrieve cached song metadata from Redis
  * 
@@ -211,20 +227,41 @@ function unifiedToMetadata(doc: UnifiedSongDocument): CachedSongMetadata {
 export async function getCachedSongMetadata(
   youtubeId: string
 ): Promise<CachedSongMetadata | null> {
-  try {
-    const data = await getSongById<UnifiedSongDocument>(youtubeId, {
-      include: "metadata",
-    });
-    console.log(`[SongMetadataCache] Cache HIT for ${youtubeId}`);
-    return unifiedToMetadata(data);
-  } catch (error) {
-    if (error instanceof ApiRequestError && error.status === 404) {
-      console.log(`[SongMetadataCache] Cache MISS for ${youtubeId}`);
-      return null;
-    }
-    console.error(`[SongMetadataCache] Error fetching metadata for ${youtubeId}:`, error);
-    return null;
+  const memo = metadataMemo.get(youtubeId);
+  if (memo && Date.now() - memo.at < METADATA_MEMO_TTL_MS) {
+    return memo.data;
   }
+
+  const inFlight = metadataInFlight.get(youtubeId);
+  if (inFlight) {
+    return inFlight;
+  }
+
+  const requestPromise = (async (): Promise<CachedSongMetadata | null> => {
+    try {
+      const data = await getSongById<UnifiedSongDocument>(youtubeId, {
+        include: "metadata",
+      });
+      console.log(`[SongMetadataCache] Cache HIT for ${youtubeId}`);
+      const metadata = unifiedToMetadata(data);
+      // Only memoize hits — a miss (song not imported yet) should be
+      // re-checked next time, e.g. right after an import completes.
+      metadataMemo.set(youtubeId, { at: Date.now(), data: metadata });
+      return metadata;
+    } catch (error) {
+      if (error instanceof ApiRequestError && error.status === 404) {
+        console.log(`[SongMetadataCache] Cache MISS for ${youtubeId}`);
+        return null;
+      }
+      console.error(`[SongMetadataCache] Error fetching metadata for ${youtubeId}:`, error);
+      return null;
+    } finally {
+      metadataInFlight.delete(youtubeId);
+    }
+  })();
+
+  metadataInFlight.set(youtubeId, requestPromise);
+  return requestPromise;
 }
 
 /**
@@ -260,6 +297,7 @@ export async function deleteSongMetadata(
   youtubeId: string,
   auth: SongMetadataAuthCredentials
 ): Promise<boolean> {
+  invalidateCachedSongMetadata(youtubeId);
   try {
     await deleteSongById(youtubeId, {
       username: auth.username,
@@ -346,6 +384,7 @@ export async function saveSongMetadata(
   auth: SongMetadataAuthCredentials,
   options?: { isShare?: boolean }
 ): Promise<boolean> {
+  invalidateCachedSongMetadata(metadata.youtubeId);
   try {
     const data = await updateSongById(
       metadata.youtubeId,

--- a/tests/test-song-fetch-dedup.test.ts
+++ b/tests/test-song-fetch-dedup.test.ts
@@ -1,0 +1,197 @@
+/**
+ * Tests for the song fetch dedup layer.
+ *
+ * - `fetchSongLyrics` shares in-flight requests and caches responses per
+ *   (songId, params) with TTL; `force` bypasses + invalidates.
+ * - A caller aborting its own signal must not cancel the shared request for
+ *   other awaiters.
+ * - `getCachedSongMetadata` dedupes concurrent lookups and memoizes hits.
+ * - The iPod library poller probes the lightweight `include=version` endpoint
+ *   before downloading the full catalog.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import {
+  fetchSongLyrics,
+  __clearLyricsCachesForTests,
+} from "../src/api/songs";
+import {
+  getCachedSongMetadata,
+  invalidateCachedSongMetadata,
+} from "../src/utils/songMetadataCache";
+
+const originalFetch = globalThis.fetch;
+
+type FetchStub = {
+  calls: Array<{ url: string; body: unknown }>;
+  restore: () => void;
+};
+
+function stubFetch(makeResponse: (url: string, body: unknown) => unknown): FetchStub {
+  const calls: FetchStub["calls"] = [];
+  globalThis.fetch = (async (
+    input: RequestInfo | URL,
+    init?: RequestInit
+  ) => {
+    const url = String(input);
+    const body =
+      typeof init?.body === "string" ? JSON.parse(init.body) : undefined;
+    calls.push({ url, body });
+    return new Response(JSON.stringify(makeResponse(url, body)), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  }) as typeof fetch;
+  return {
+    calls,
+    restore: () => {
+      globalThis.fetch = originalFetch;
+    },
+  };
+}
+
+let activeStub: FetchStub | null = null;
+
+beforeEach(() => {
+  __clearLyricsCachesForTests();
+  invalidateCachedSongMetadata();
+});
+
+afterEach(() => {
+  activeStub?.restore();
+  activeStub = null;
+});
+
+describe("fetchSongLyrics dedup", () => {
+  test("concurrent identical requests share one HTTP call", async () => {
+    activeStub = stubFetch(() => ({ lyrics: { lrc: "[00:00.00]hi" } }));
+
+    const [a, b] = await Promise.all([
+      fetchSongLyrics("vid-1", { title: "Song" }),
+      fetchSongLyrics("vid-1", { title: "Song" }),
+    ]);
+
+    expect(activeStub.calls).toHaveLength(1);
+    expect(a.lyrics?.lrc).toBe("[00:00.00]hi");
+    expect(b.lyrics?.lrc).toBe("[00:00.00]hi");
+  });
+
+  test("a repeat request within the TTL is served from cache", async () => {
+    activeStub = stubFetch(() => ({ lyrics: { lrc: "x" } }));
+
+    await fetchSongLyrics("vid-1", { title: "Song" });
+    await fetchSongLyrics("vid-1", { title: "Song" });
+
+    expect(activeStub.calls).toHaveLength(1);
+  });
+
+  test("different params do not share cache entries", async () => {
+    activeStub = stubFetch(() => ({ lyrics: { lrc: "x" } }));
+
+    await fetchSongLyrics("vid-1", { title: "Song" });
+    await fetchSongLyrics("vid-1", { title: "Song", translateTo: "ja" });
+
+    expect(activeStub.calls).toHaveLength(2);
+  });
+
+  test("force bypasses and invalidates the cache for the song", async () => {
+    activeStub = stubFetch(() => ({ lyrics: { lrc: "x" } }));
+
+    await fetchSongLyrics("vid-1", { title: "Song" });
+    await fetchSongLyrics("vid-1", { title: "Song", force: true });
+    // Cached non-force entry was invalidated by the force request.
+    await fetchSongLyrics("vid-1", { title: "Song" });
+
+    expect(activeStub.calls).toHaveLength(3);
+  });
+
+  test("one caller aborting does not cancel the shared request", async () => {
+    let release: (() => void) | null = null;
+    const gate = new Promise<void>((res) => {
+      release = res;
+    });
+    const calls: unknown[] = [];
+    globalThis.fetch = (async () => {
+      calls.push(1);
+      await gate;
+      return new Response(JSON.stringify({ lyrics: { lrc: "shared" } }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }) as typeof fetch;
+    activeStub = { calls: [], restore: () => (globalThis.fetch = originalFetch) };
+
+    const controller = new AbortController();
+    const aborting = fetchSongLyrics("vid-1", {
+      title: "Song",
+      signal: controller.signal,
+    });
+    const surviving = fetchSongLyrics("vid-1", { title: "Song" });
+
+    controller.abort();
+    await expect(aborting).rejects.toMatchObject({ name: "AbortError" });
+
+    release!();
+    const result = await surviving;
+    expect(result.lyrics?.lrc).toBe("shared");
+    expect(calls).toHaveLength(1);
+  });
+});
+
+describe("getCachedSongMetadata dedup", () => {
+  const metadataDoc = {
+    id: "vid-9",
+    title: "Title",
+    artist: "Artist",
+    createdAt: 100,
+    updatedAt: 200,
+  };
+
+  test("concurrent lookups for the same id share one HTTP call", async () => {
+    activeStub = stubFetch(() => metadataDoc);
+
+    const [a, b] = await Promise.all([
+      getCachedSongMetadata("vid-9"),
+      getCachedSongMetadata("vid-9"),
+    ]);
+
+    expect(activeStub.calls).toHaveLength(1);
+    expect(a?.youtubeId).toBe("vid-9");
+    expect(b?.title).toBe("Title");
+  });
+
+  test("hits are memoized; invalidation forces a refetch", async () => {
+    activeStub = stubFetch(() => metadataDoc);
+
+    await getCachedSongMetadata("vid-9");
+    await getCachedSongMetadata("vid-9");
+    expect(activeStub.calls).toHaveLength(1);
+
+    invalidateCachedSongMetadata("vid-9");
+    await getCachedSongMetadata("vid-9");
+    expect(activeStub.calls).toHaveLength(2);
+  });
+});
+
+describe("source wiring", () => {
+  test("library poller probes the version endpoint before a full fetch", () => {
+    const source = readFileSync(
+      resolve(process.cwd(), "src/apps/ipod/hooks/useLibraryUpdateChecker.ts"),
+      "utf-8"
+    );
+    expect(source).toContain("fetchSongsVersion");
+    expect(source).toContain("lastInSyncVersionRef");
+  });
+
+  test("songs API exposes the lightweight version probe", () => {
+    const source = readFileSync(
+      resolve(process.cwd(), "api/songs/index.ts"),
+      "utf-8"
+    );
+    expect(source).toContain('includes.includes("version")');
+    expect(source).toContain("getSongsVersionInfo");
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Song fetch-layer batch from the re-audit: the client previously had no request dedup anywhere in the song pipeline, and the iPod auto-update checker downloaded the full catalog every 5 minutes to diff client-side.

## Changes

- **`fetchSongLyrics` dedup** (`src/api/songs.ts`): identical concurrent requests share one in-flight promise; successful responses are cached for 5 min (max 12 entries) keyed by `songId` + stable-sorted params. `force: true` bypasses and invalidates every cached variant for that song; song mutations (`updateSongById`, `clearSongCachedData`) also invalidate. The shared request runs without any caller's `AbortSignal` — each awaiter races its own signal instead, so one component unmounting can't cancel the fetch for another.
- **`getCachedSongMetadata`** (`src/utils/songMetadataCache.ts`): despite the name this was network-only. Concurrent lookups for the same id now share one HTTP call, hits are memoized for 5 min (misses are deliberately not memoized so a just-imported song is found on the next check), and `saveSongMetadata`/`deleteSongMetadata` invalidate.
- **Lightweight catalog version probe**: new `GET /api/songs?include=version` returns `{ version: maxUpdatedAt, count }` (~40 bytes; same Redis cost server-side, no document assembly). `useLibraryUpdateChecker` polls the probe and only downloads the full 100+ song metadata list when version/count differ from the last state it confirmed as in-sync — the in-sync marker is only recorded after a full check finds nothing to apply (or a sync completes), so a failed sync can never suppress the next full comparison.

## Testing

- ✅ `bun test tests/test-song-fetch-dedup.test.ts` — 9 pass (in-flight sharing, TTL, param isolation, force invalidation, abort isolation, metadata memoization, wiring guards)
- ✅ Live probe against the dev API server (real Redis): `curl '/api/songs?include=version&createdBy=ryo'` → `{"version":1780775315563,"count":105}`
- ✅ `bun run test:song` — 23 pass / 0 fail (integration suite against running server)
- ✅ `bun run test:unit` — 310 pass / 0 fail
- ✅ `bunx tsc -b --force`, `bun run build`, `bunx eslint` on changed files — all clean
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-819f5fdd-4d5f-4944-83d4-bde8c75427ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-819f5fdd-4d5f-4944-83d4-bde8c75427ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

