### PR TITLE
refactor(chats): share one AI SDK Chat instance between Chats and Terminal

### DIFF
--- a/src/apps/chats/hooks/useAiChat.ts
+++ b/src/apps/chats/hooks/useAiChat.ts
@@ -1,8 +1,9 @@
 import { useState, useEffect, useCallback, useRef, useMemo } from "react";
-import { useChat, type UIMessage } from "@ai-sdk/react";
+import { Chat, useChat, type UIMessage } from "@ai-sdk/react";
 import {
   DefaultChatTransport,
   lastAssistantMessageIsCompleteWithToolCalls,
+  type ChatInit,
 } from "ai";
 import { useChatsStore } from "@/stores/useChatsStore";
 import type { AIChatMessage } from "@/types/chat";
@@ -143,6 +144,78 @@ const showBackgroundedMessageNotification = (message: UIMessage) => {
   });
 };
 
+// ---------------------------------------------------------------------------
+// Shared AI chat instance
+//
+// Chats and Terminal both call useAiChat(). Each useChat() call used to spin
+// up its OWN SDK Chat (separate transport, separate message state, separate
+// tool execution) that fought over the single Zustand message store. All
+// callers now attach to ONE module-level Chat instance, so messages, status,
+// and in-flight streams are genuinely shared.
+//
+// Chat lifecycle callbacks (tool calls, finish, error) must be configured at
+// construction time, but their implementations need per-instance React scope
+// (launchApp, file saving, dialogs, toasts). The chat therefore delegates to
+// a handler registry: each mounted useAiChat registers its latest handlers,
+// and the chats app ("primary") wins over the terminal ("secondary") so
+// rate-limit / auth UI state lands in the app that renders it.
+// ---------------------------------------------------------------------------
+type SharedChatInit = ChatInit<AIChatMessage>;
+type SharedOnToolCall = NonNullable<SharedChatInit["onToolCall"]>;
+type SharedOnFinish = NonNullable<SharedChatInit["onFinish"]>;
+type SharedOnError = NonNullable<SharedChatInit["onError"]>;
+
+interface SharedAiChatHandlers {
+  onToolCall: SharedOnToolCall;
+  onFinish: SharedOnFinish;
+  onError: SharedOnError;
+}
+
+type SharedHandlerRole = "primary" | "secondary";
+
+const sharedHandlerRegistry = new Map<
+  SharedHandlerRole,
+  { readonly current: SharedAiChatHandlers }
+>();
+
+const resolveSharedHandlers = (): SharedAiChatHandlers | null =>
+  (sharedHandlerRegistry.get("primary") ?? sharedHandlerRegistry.get("secondary"))
+    ?.current ?? null;
+
+let sharedAiChat: Chat<AIChatMessage> | null = null;
+
+function getSharedAiChat(): Chat<AIChatMessage> {
+  if (!sharedAiChat) {
+    sharedAiChat = new Chat<AIChatMessage>({
+      // Initialize from the persisted store (hydrated synchronously before
+      // first mount); useSyncedAiMessages reconciles afterwards.
+      messages: useChatsStore.getState().aiMessages,
+
+      transport: new DefaultChatTransport({
+        api: getApiUrl("/api/chat"),
+        body: async () => ({
+          systemState: getSystemState(),
+          model: useAppStore.getState().aiModel,
+        }),
+      }),
+
+      // Automatically submit when all tool outputs are available
+      sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithToolCalls,
+
+      async onToolCall(options) {
+        await resolveSharedHandlers()?.onToolCall(options);
+      },
+      onFinish(options) {
+        resolveSharedHandlers()?.onFinish(options);
+      },
+      onError(error) {
+        resolveSharedHandlers()?.onError(error);
+      },
+    });
+  }
+  return sharedAiChat;
+}
+
 export function useAiChat(onPromptSetUsername?: () => void) {
   const { aiMessages, setAiMessages, username, isAuthenticated } =
     useChatsStoreShallow((state) => ({
@@ -170,16 +243,6 @@ export function useAiChat(onPromptSetUsername?: () => void) {
   } | null>(null);
   const [needsUsername, setNeedsUsername] = useState(false);
 
-  const chatTransport = useMemo(() => {
-    return new DefaultChatTransport({
-      api: getApiUrl("/api/chat"),
-      body: async () => ({
-        systemState: getSystemState(),
-        model: useAppStore.getState().aiModel,
-      }),
-    });
-  }, []);
-
   const speakFinalAssistantMessageRef = useRef<
     ((message: UIMessage) => void) | null
   >(null);
@@ -195,6 +258,7 @@ export function useAiChat(onPromptSetUsername?: () => void) {
   );
 
   // --- AI Chat Hook (Vercel AI SDK v6) ---
+  // Attach to the shared module-level Chat (see getSharedAiChat above).
   const {
     messages: currentSdkMessages,
     status,
@@ -205,18 +269,16 @@ export function useAiChat(onPromptSetUsername?: () => void) {
     sendMessage,
     regenerate,
     addToolOutput,
-  } = useChat({
-    // Initialize from store
-    messages: aiMessages,
-
+  } = useChat<AIChatMessage>({
+    chat: getSharedAiChat(),
     experimental_throttle: 50,
+  });
 
-    // Automatically submit when all tool outputs are available
-    sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithToolCalls,
-
-    transport: chatTransport,
-
-    async onToolCall({ toolCall }) {
+  // --- Shared chat lifecycle handlers -------------------------------------
+  // Defined as plain closures (not useCallback) and snapshotted into
+  // handlersRef on every render, so the shared chat always invokes the
+  // latest instance scope without giant dependency arrays.
+  const handleSharedToolCall: SharedOnToolCall = async ({ toolCall }) => {
       // Client-side tool execution requires returning output to the chat.
       // Short delay to allow the UI to render the "call" state
       await new Promise<void>((resolve) => setTimeout(resolve, 120));
@@ -1312,9 +1374,9 @@ export function useAiChat(onPromptSetUsername?: () => void) {
           errorText: err instanceof Error ? err.message : i18n.t("apps.chats.toolCalls.unknownError"),
         });
       }
-    },
+    };
 
-    onFinish: ({ messages, isError }) => {
+  const handleSharedFinish: SharedOnFinish = ({ messages, isError }) => {
       // Ensure all messages have metadata with createdAt. Prefer the
       // timestamp pinned while the message was streaming so it doesn't jump
       // to the finish time.
@@ -1391,9 +1453,9 @@ export function useAiChat(onPromptSetUsername?: () => void) {
       }
 
       speakFinalAssistantMessageRef.current?.(lastMsg);
-    },
+    };
 
-    onError: (err) => {
+  const handleSharedError: SharedOnError = (err) => {
       // Workaround for AI SDK v6 bug with stopWhen and tool calls (GitHub issue #10291)
       // The finish event emits {"type":"finish","finishReason":"tool-calls"} which fails validation
       // This is a known issue and the error can be safely ignored as the chat still works
@@ -1511,8 +1573,33 @@ export function useAiChat(onPromptSetUsername?: () => void) {
         description:
           err.message || i18n.t("apps.chats.toasts.failedToGetResponse"),
       });
-    },
+    };
+
+  // Register this instance's handlers with the shared chat. The chats app
+  // (identified by passing onPromptSetUsername) is "primary" and takes
+  // precedence over the terminal's "secondary" registration, so dialogs and
+  // rate-limit state land in the UI that displays them.
+  const sharedHandlersRef = useRef<SharedAiChatHandlers>({
+    onToolCall: handleSharedToolCall,
+    onFinish: handleSharedFinish,
+    onError: handleSharedError,
   });
+  sharedHandlersRef.current = {
+    onToolCall: handleSharedToolCall,
+    onFinish: handleSharedFinish,
+    onError: handleSharedError,
+  };
+  const sharedHandlerRole: SharedHandlerRole = onPromptSetUsername
+    ? "primary"
+    : "secondary";
+  useEffect(() => {
+    sharedHandlerRegistry.set(sharedHandlerRole, sharedHandlersRef);
+    return () => {
+      if (sharedHandlerRegistry.get(sharedHandlerRole) === sharedHandlersRef) {
+        sharedHandlerRegistry.delete(sharedHandlerRole);
+      }
+    };
+  }, [sharedHandlerRole]);
 
   // Ensure all messages have metadata with timestamps (runs synchronously during render).
   // The per-id cache keeps referential identity stable across streaming ticks:

--- a/tests/test-shared-ai-chat-wiring.test.ts
+++ b/tests/test-shared-ai-chat-wiring.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Guardrail tests for the shared AI chat instance.
+ *
+ * Chats and Terminal both call useAiChat(). Each useChat() call used to
+ * create its OWN SDK Chat (separate transport/message state/tool execution)
+ * that fought over the single Zustand message store. These tests pin the
+ * wiring that keeps all callers attached to ONE module-level Chat.
+ */
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, test, expect } from "bun:test";
+
+const readSource = (relativePath: string): string =>
+  readFileSync(resolve(process.cwd(), relativePath), "utf-8");
+
+describe("shared AI chat wiring", () => {
+  const source = readSource("src/apps/chats/hooks/useAiChat.ts");
+
+  test("exactly one Chat instance is constructed (module-level singleton)", () => {
+    const constructions = source.match(/new Chat</g) || [];
+    expect(constructions).toHaveLength(1);
+    expect(source).toContain("let sharedAiChat");
+    expect(source).toContain("function getSharedAiChat()");
+  });
+
+  test("useChat attaches to the shared chat instead of creating its own", () => {
+    expect(source).toMatch(/useChat<AIChatMessage>\(\{\s*chat: getSharedAiChat\(\)/);
+    // No per-hook chat config: transport/messages/sendAutomaticallyWhen live
+    // on the shared Chat, not in the useChat() options.
+    const useChatCall = source.slice(source.indexOf("useChat<AIChatMessage>("));
+    const optionsBlock = useChatCall.slice(0, useChatCall.indexOf("});"));
+    expect(optionsBlock).not.toContain("transport:");
+    expect(optionsBlock).not.toContain("sendAutomaticallyWhen");
+  });
+
+  test("lifecycle handlers delegate through the role registry (primary wins)", () => {
+    expect(source).toContain("resolveSharedHandlers()?.onToolCall");
+    expect(source).toContain("resolveSharedHandlers()?.onFinish");
+    expect(source).toContain("resolveSharedHandlers()?.onError");
+    expect(source).toMatch(
+      /sharedHandlerRegistry\.get\("primary"\) \?\? sharedHandlerRegistry\.get\("secondary"\)/
+    );
+    // Unmount cleanup must not clobber a newer registration.
+    expect(source).toMatch(
+      /if \(sharedHandlerRegistry\.get\(sharedHandlerRole\) === sharedHandlersRef\)/
+    );
+  });
+
+  test("chats registers as primary; terminal consumes without a username prompt", () => {
+    const chatsController = readSource(
+      "src/apps/chats/components/chats-app/useChatsAppController.tsx"
+    );
+    expect(chatsController).toMatch(/useAiChat\(promptSetUsername\)/);
+
+    const terminal = readSource("src/apps/terminal/hooks/useTerminalLogic.ts");
+    expect(terminal).toMatch(/useAiChat\(\)/);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Chats (`useChatsAppController`) and Terminal (`useTerminalLogic`) each call `useAiChat()`, and each call created its **own** AI SDK `Chat` — two transports, two independent message states, two `onToolCall` executors — both effect-syncing against the single `useChatsStore.aiMessages`. With both windows open this is a correctness hazard (competing `setMessages` syncs, ambiguous source of truth, tool calls executing in whichever instance received the stream).

## Approach

AI SDK v6's `useChat` accepts an existing `Chat` instance (`useChat({ chat })`) — that's the SDK-native sharing mechanism, so this PR uses it rather than inventing a provider layer:

- **One module-level `Chat`** created lazily in `useAiChat.ts` with the transport, `sendAutomaticallyWhen`, and messages seeded from the persisted store. Every `useAiChat()` caller attaches to it: messages, streaming status, and in-flight requests are genuinely shared (clearing the chat in Chats now also clears Terminal's view, and a response streamed while one window closes keeps flowing to the other).
- **Handler registry for lifecycle callbacks**: `onToolCall`/`onFinish`/`onError` must be configured at `Chat` construction but need per-instance React scope (app launching, file saving, dialogs, toasts, rate-limit state). The shared chat delegates to a registry; each mounted instance snapshots its latest closures into a ref every render (no giant dependency arrays), and the Chats app registers as **primary** (it passes `onPromptSetUsername`) over Terminal's **secondary**, so auth/rate-limit UI state lands in the surface that renders it. Unmount cleanup only deletes its own registration.
- The callback bodies (the ~1,000-line tool-call switch, finish/error handling) are unchanged — only re-bound from `useChat` options to registry handlers.

## Testing

- ✅ `bunx tsc -b --force` — clean
- ✅ `bun run test:unit` — 310 pass / 0 fail (includes the chat streaming-perf and chat wiring suites)
- ✅ `bun test tests/test-shared-ai-chat-wiring.test.ts` — 4 pass (new guardrails: single `new Chat`, `useChat({ chat })` attachment, registry precedence, caller roles)
- ✅ `bun run build` — clean
- ✅ `bunx eslint src/apps/chats/hooks/useAiChat.ts` — clean
- ✅ `bun run dev` smoke test — frontend serves HTTP 200
- ⚠️ Live end-to-end AI streaming with both windows open is browser-only behavior I could not exercise without GUI testing (skipped per AGENTS.md); the riskiest surface is covered by the SDK's first-class `{ chat }` API + wiring tests.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-819f5fdd-4d5f-4944-83d4-bde8c75427ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-819f5fdd-4d5f-4944-83d4-bde8c75427ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

