### PR TITLE
perf(persist): debounced write-behind localStorage for Files/Chats/iPod stores

### DIFF
--- a/src/apps/control-panels/hooks/useControlPanelsLogic.ts
+++ b/src/apps/control-panels/hooks/useControlPanelsLogic.ts
@@ -6,6 +6,10 @@ import { helpItems } from "..";
 import { useFileSystem } from "@/apps/finder/hooks/useFileSystem";
 import { clearAllAppStates } from "@/stores/useAppStore";
 import { ensureIndexedDBInitialized } from "@/utils/indexedDB";
+import {
+  flushDebouncedPersistWrites,
+  haltDebouncedPersistWrites,
+} from "@/utils/debouncedPersistStorage";
 import { useAppStoreShallow } from "@/stores/useAppStore";
 import { useAudioSettingsStoreShallow } from "@/stores/useAudioSettingsStore";
 import { useDisplaySettingsStoreShallow } from "@/stores/useDisplaySettingsStore";
@@ -641,7 +645,9 @@ export function useControlPanelsLogic({
         version: 3,
       };
 
-      // Backup all localStorage data
+      // Backup all localStorage data (flush write-behind persist queues so
+      // the snapshot includes the latest store state)
+      flushDebouncedPersistWrites();
       for (let i = 0; i < localStorage.length; i++) {
         const key = localStorage.key(i);
         if (key) {
@@ -1045,7 +1051,11 @@ export function useControlPanelsLogic({
         throw new Error("Invalid backup format");
       }
 
-      // Clear current state
+      // Clear current state. Drain write-behind persist queues first so a
+      // pending debounced write can't fire mid-restore and clobber a
+      // freshly restored key before the reload.
+      flushDebouncedPersistWrites();
+      haltDebouncedPersistWrites();
       clearAllAppStates();
       clearPrefetchFlag();
 
@@ -1226,6 +1236,10 @@ export function useControlPanelsLogic({
   };
 
   const performReset = () => {
+    // Flush write-behind persist queues so the preserved keys are current,
+    // then halt further writes until the reload.
+    flushDebouncedPersistWrites();
+    haltDebouncedPersistWrites();
     // Preserve critical recovery keys while clearing everything else
     const fileMetadataStore = localStorage.getItem("ryos:files");
     const usernameRecovery = localStorage.getItem("_usr_recovery_key_");
@@ -1268,7 +1282,9 @@ export function useControlPanelsLogic({
       version: 3, // Version 3 includes applets support
     };
 
-    // Backup all localStorage data
+    // Backup all localStorage data (flush write-behind persist queues so
+    // the snapshot includes the latest store state)
+    flushDebouncedPersistWrites();
     for (let i = 0; i < localStorage.length; i++) {
       const key = localStorage.key(i);
       if (key) {
@@ -1433,7 +1449,11 @@ export function useControlPanelsLogic({
           compressed: file.name.endsWith(".gz"),
         });
 
-        // Clear current state
+        // Clear current state. Drain write-behind persist queues first so a
+        // pending debounced write can't fire mid-restore and clobber a
+        // freshly restored key before the reload.
+        flushDebouncedPersistWrites();
+        haltDebouncedPersistWrites();
         clearAllAppStates();
         clearPrefetchFlag(); // Force re-prefetch on next boot
 

--- a/src/stores/useChatsStore.ts
+++ b/src/stores/useChatsStore.ts
@@ -1,6 +1,7 @@
 import { create } from "zustand";
 import { useStoreShallow } from "./helpers";
-import { persist, createJSONStorage } from "zustand/middleware";
+import { persist } from "zustand/middleware";
+import { createDebouncedPersistStorage } from "@/utils/debouncedPersistStorage";
 import {
   type ChatRoom,
   type ChatMessage,
@@ -1215,7 +1216,10 @@ export const useChatsStore = create<ChatsStoreState>()(
     {
       name: STORE_NAME,
       version: STORE_VERSION,
-      storage: createJSONStorage(() => localStorage), // Use localStorage
+      // Write-behind storage: chat history (aiMessages + capped roomMessages)
+      // used to be JSON.stringify'd and written synchronously on every
+      // appended message. Serialization now happens once per quiet window.
+      storage: createDebouncedPersistStorage(),
       partialize: (state) => ({
         aiMessages: state.aiMessages,
         username: state.username,

--- a/src/stores/useFilesStore.ts
+++ b/src/stores/useFilesStore.ts
@@ -1,6 +1,7 @@
 import { create } from "zustand";
 import { useStoreShallow } from "./helpers";
-import { persist, createJSONStorage } from "zustand/middleware";
+import { persist } from "zustand/middleware";
+import { createDebouncedPersistStorage } from "@/utils/debouncedPersistStorage";
 import { v4 as uuidv4 } from "uuid";
 import { ensureIndexedDBInitialized, STORES } from "@/utils/indexedDB";
 import type { StoredContent } from "@/utils/indexedDBOperations";
@@ -1534,7 +1535,10 @@ export const useFilesStore = create<FilesStoreState>()(
     {
       name: STORE_NAME,
       version: STORE_VERSION,
-      storage: createJSONStorage(() => localStorage),
+      // Write-behind storage: the whole VFS used to be JSON.stringify'd and
+      // written synchronously on every metadata mutation (rename, move,
+      // trash). Serialization now happens once per quiet window.
+      storage: createDebouncedPersistStorage(),
       partialize: (state) => ({
         items: state.items, // Persist the entire file structure
         libraryState: state.libraryState,

--- a/src/stores/useIpodStore.ts
+++ b/src/stores/useIpodStore.ts
@@ -31,6 +31,7 @@ import { parseYouTubeVideoId } from "@/utils/youtubeUrl";
 import { emitCloudSyncDomainChange } from "@/utils/cloudSyncEvents";
 import { sortTracksLikeServerOrder } from "@/stores/ipodTrackOrder";
 import { shouldUpdatePlaybackTime } from "@/stores/playbackTime";
+import { createDebouncedPersistStorage } from "@/utils/debouncedPersistStorage";
 import {
   hasFetchedTrackMetadataChanges,
   hasLibraryTrackMetadataChanges,
@@ -2317,6 +2318,10 @@ export const useIpodStore = create<IpodState>()(
     {
       name: "ryos:ipod", // Unique name for localStorage persistence
       version: CURRENT_IPOD_STORE_VERSION, // Set the current version
+      // Write-behind storage: the YouTube track library used to be
+      // JSON.stringify'd and written synchronously on every persisted
+      // mutation. Serialization now happens once per quiet window.
+      storage: createDebouncedPersistStorage(),
       partialize: (state) => ({
         tracks: state.tracks,
         currentSongId: state.currentSongId,

--- a/src/utils/debouncedPersistStorage.ts
+++ b/src/utils/debouncedPersistStorage.ts
@@ -1,0 +1,141 @@
+import type { PersistStorage, StorageValue } from "zustand/middleware";
+
+/**
+ * Debounced write-behind localStorage adapter for zustand's persist
+ * middleware.
+ *
+ * `createJSONStorage(() => localStorage)` serializes the entire partialized
+ * slice and writes it synchronously on EVERY persisted mutation. For large
+ * slices (Files VFS, chat history, iPod library) that means multi-MB
+ * `JSON.stringify` + sync disk writes on hot paths like appending a chat
+ * message or renaming a file.
+ *
+ * This adapter keeps localStorage as the authoritative storage (backup,
+ * restore, and reset flows that read the raw keys keep working) but:
+ *   - `setItem` only records the latest snapshot and starts a debounce
+ *     timer; serialization happens once per quiet window instead of once
+ *     per mutation (zustand state is immutable, so the held reference is a
+ *     consistent snapshot).
+ *   - pending writes are flushed on `pagehide` / tab-hidden so quitting the
+ *     app never loses more than the current debounce window — the same
+ *     guarantee browsers give localStorage itself on crash.
+ *   - `getItem` serves a pending snapshot first (read-your-writes).
+ *
+ * Flows that read the raw localStorage keys directly (system reset, manual
+ * backup) must call `flushDebouncedPersistWrites()` first.
+ */
+
+type PendingFlush = () => void;
+
+// name -> flush, so a global flush can drain every adapter instance.
+const pendingFlushes = new Map<string, PendingFlush>();
+let lifecycleFlushRegistered = false;
+let halted = false;
+
+/** Synchronously write out every pending persist snapshot. */
+export function flushDebouncedPersistWrites(): void {
+  for (const flush of Array.from(pendingFlushes.values())) {
+    flush();
+  }
+}
+
+/**
+ * Stop all further persist writes until the page reloads. Used by
+ * restore/reset flows that rewrite localStorage directly and then reload:
+ * without this, an in-memory store mutation queued during the restore window
+ * would be flushed by the pagehide handler mid-reload and clobber freshly
+ * restored keys with pre-restore state.
+ */
+export function haltDebouncedPersistWrites(): void {
+  halted = true;
+  pendingFlushes.clear();
+}
+
+function ensureLifecycleFlush(): void {
+  if (lifecycleFlushRegistered || typeof window === "undefined") return;
+  lifecycleFlushRegistered = true;
+  window.addEventListener("pagehide", flushDebouncedPersistWrites);
+  document.addEventListener("visibilitychange", () => {
+    if (document.visibilityState === "hidden") {
+      flushDebouncedPersistWrites();
+    }
+  });
+}
+
+export function createDebouncedPersistStorage<S>(
+  options: { delayMs?: number } = {}
+): PersistStorage<S> {
+  const delayMs = options.delayMs ?? 500;
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  let pendingName: string | null = null;
+  let pendingValue: StorageValue<S> | null = null;
+
+  const writeNow = () => {
+    if (timer !== null) {
+      clearTimeout(timer);
+      timer = null;
+    }
+    if (halted) {
+      pendingName = null;
+      pendingValue = null;
+      return;
+    }
+    if (pendingName === null || pendingValue === null) return;
+    const name = pendingName;
+    const value = pendingValue;
+    pendingName = null;
+    pendingValue = null;
+    pendingFlushes.delete(name);
+    try {
+      localStorage.setItem(name, JSON.stringify(value));
+    } catch (error) {
+      console.error(
+        `[debouncedPersistStorage] Failed to write "${name}":`,
+        error
+      );
+    }
+  };
+
+  return {
+    getItem: (name) => {
+      // Read-your-writes: a queued snapshot is newer than localStorage.
+      if (pendingName === name && pendingValue !== null) {
+        return pendingValue;
+      }
+      const raw = localStorage.getItem(name);
+      if (!raw) return null;
+      try {
+        return JSON.parse(raw) as StorageValue<S>;
+      } catch (error) {
+        console.error(
+          `[debouncedPersistStorage] Failed to parse "${name}":`,
+          error
+        );
+        return null;
+      }
+    },
+
+    setItem: (name, value) => {
+      if (halted) return;
+      ensureLifecycleFlush();
+      pendingName = name;
+      pendingValue = value;
+      pendingFlushes.set(name, writeNow);
+      if (timer !== null) clearTimeout(timer);
+      timer = setTimeout(writeNow, delayMs);
+    },
+
+    removeItem: (name) => {
+      if (pendingName === name) {
+        pendingName = null;
+        pendingValue = null;
+        if (timer !== null) {
+          clearTimeout(timer);
+          timer = null;
+        }
+        pendingFlushes.delete(name);
+      }
+      localStorage.removeItem(name);
+    },
+  };
+}

--- a/tests/test-debounced-persist-storage.test.ts
+++ b/tests/test-debounced-persist-storage.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Tests for the write-behind localStorage persist adapter.
+ *
+ * Large persisted slices (Files VFS, chat history, iPod library) used to be
+ * JSON.stringify'd and written synchronously on every mutation. The adapter
+ * defers serialization to a debounce window while keeping read-your-writes
+ * semantics and explicit flush/halt hooks for backup/restore/reset flows.
+ */
+
+import { describe, test, expect, beforeEach } from "bun:test";
+
+// Minimal localStorage polyfill for the bun test environment.
+const backing = new Map<string, string>();
+(globalThis as Record<string, unknown>).localStorage = {
+  getItem: (key: string) => backing.get(key) ?? null,
+  setItem: (key: string, value: string) => {
+    backing.set(key, String(value));
+  },
+  removeItem: (key: string) => {
+    backing.delete(key);
+  },
+  clear: () => backing.clear(),
+  key: (i: number) => Array.from(backing.keys())[i] ?? null,
+  get length() {
+    return backing.size;
+  },
+};
+
+const {
+  createDebouncedPersistStorage,
+  flushDebouncedPersistWrites,
+} = await import("../src/utils/debouncedPersistStorage");
+
+const sleep = (ms: number) => new Promise((res) => setTimeout(res, ms));
+
+beforeEach(() => {
+  backing.clear();
+});
+
+describe("createDebouncedPersistStorage", () => {
+  test("setItem defers the localStorage write until the debounce window", async () => {
+    const storage = createDebouncedPersistStorage<{ a: number }>({ delayMs: 30 });
+    storage.setItem("k", { state: { a: 1 }, version: 1 });
+
+    expect(backing.has("k")).toBe(false);
+    await sleep(60);
+    expect(JSON.parse(backing.get("k")!)).toEqual({ state: { a: 1 }, version: 1 });
+  });
+
+  test("only the latest snapshot in a burst is serialized", async () => {
+    const storage = createDebouncedPersistStorage<{ a: number }>({ delayMs: 30 });
+    storage.setItem("k", { state: { a: 1 }, version: 1 });
+    storage.setItem("k", { state: { a: 2 }, version: 1 });
+    storage.setItem("k", { state: { a: 3 }, version: 1 });
+
+    await sleep(60);
+    expect(JSON.parse(backing.get("k")!).state.a).toBe(3);
+  });
+
+  test("getItem serves the pending snapshot before it is written (read-your-writes)", () => {
+    const storage = createDebouncedPersistStorage<{ a: number }>({ delayMs: 1000 });
+    storage.setItem("k", { state: { a: 7 }, version: 2 });
+
+    const value = storage.getItem("k");
+    expect(value && typeof value === "object" && "state" in value).toBe(true);
+    expect((value as { state: { a: number } }).state.a).toBe(7);
+  });
+
+  test("getItem falls back to localStorage and parses stored JSON", () => {
+    backing.set("k", JSON.stringify({ state: { a: 9 }, version: 3 }));
+    const storage = createDebouncedPersistStorage<{ a: number }>({ delayMs: 1000 });
+    expect((storage.getItem("k") as { state: { a: number } }).state.a).toBe(9);
+  });
+
+  test("flushDebouncedPersistWrites drains pending snapshots immediately", () => {
+    const storage = createDebouncedPersistStorage<{ a: number }>({ delayMs: 60_000 });
+    storage.setItem("k", { state: { a: 5 }, version: 1 });
+    expect(backing.has("k")).toBe(false);
+
+    flushDebouncedPersistWrites();
+    expect(JSON.parse(backing.get("k")!).state.a).toBe(5);
+
+    // Flush is one-shot: queue is drained.
+    backing.clear();
+    flushDebouncedPersistWrites();
+    expect(backing.has("k")).toBe(false);
+  });
+
+  test("removeItem cancels a pending write and clears storage", async () => {
+    const storage = createDebouncedPersistStorage<{ a: number }>({ delayMs: 20 });
+    backing.set("k", "old");
+    storage.setItem("k", { state: { a: 1 }, version: 1 });
+    storage.removeItem("k");
+
+    await sleep(50);
+    expect(backing.has("k")).toBe(false);
+  });
+});
+
+// NOTE: haltDebouncedPersistWrites is module-global and irreversible by
+// design (restore/reset flows reload the page right after), so it runs last.
+describe("haltDebouncedPersistWrites", () => {
+  test("halts pending and future writes until reload", async () => {
+    const { haltDebouncedPersistWrites } = await import(
+      "../src/utils/debouncedPersistStorage"
+    );
+    const storage = createDebouncedPersistStorage<{ a: number }>({ delayMs: 20 });
+    storage.setItem("k", { state: { a: 1 }, version: 1 });
+
+    haltDebouncedPersistWrites();
+    await sleep(50);
+    expect(backing.has("k")).toBe(false);
+
+    storage.setItem("k", { state: { a: 2 }, version: 1 });
+    flushDebouncedPersistWrites();
+    await sleep(50);
+    expect(backing.has("k")).toBe(false);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

`createJSONStorage(() => localStorage)` serializes the **entire partialized slice** and writes it synchronously on **every persisted mutation**:

- `useFilesStore` persists the whole VFS (`items`) — every rename/move/trash stringifies the full filesystem graph
- `useChatsStore` persists `aiMessages` + up to 500 messages/room — every appended message rewrites a multi-MB blob
- `useIpodStore` persists the full YouTube track library — every metadata edit re-serializes it

## Approach: write-behind, not IndexedDB (scope decision)

The original plan was an IndexedDB migration, but investigating the blast radius showed localStorage is load-bearing for these exact keys: the v3 backup format captures `localStorage` wholesale, `performReset` preserves `ryos:files` across resets, cloud restore rewrites raw keys, and `useKaraokeStore` reads `ryos:ipod` directly at init. Moving the data would silently break backup/restore/reset.

Instead, a new `createDebouncedPersistStorage` (zustand `PersistStorage`) keeps **localStorage authoritative** but eliminates the per-mutation cost:

- `setItem` only records the latest immutable snapshot and (re)arms a 500ms debounce — `JSON.stringify` + the sync disk write happen once per quiet window instead of once per mutation (a burst of N mutations = 1 serialization).
- `getItem` serves a pending snapshot first (read-your-writes), falling back to parsed localStorage; hydration stays fully synchronous, so boot behavior, `migrate`/version handling, and `onRehydrateStorage` ordering are unchanged.
- Pending writes flush on `pagehide` / tab-hidden, so quitting loses at most the current 500ms window.
- **Backup/reset/restore integration**: those flows read/rewrite raw keys, so they now call `flushDebouncedPersistWrites()` first; restore/reset additionally call `haltDebouncedPersistWrites()` so a pagehide flush during the post-restore reload can't clobber freshly restored values with pre-restore in-memory state.

Applied to the three heavy stores (`useFilesStore`, `useChatsStore`, `useIpodStore`); small settings stores keep the default storage.

## Testing

- ✅ `bun test tests/test-debounced-persist-storage.test.ts` — 7 pass (debounce deferral, burst coalescing, read-your-writes, localStorage fallback parse, flush drain, removeItem cancellation, halt semantics)
- ✅ `bun run test:unit` — 310 pass / 0 fail
- ✅ `bunx tsc -b --force`, `bun run build`, `bunx eslint` on changed files — all clean
- ✅ `bun run dev` smoke test — frontend serves HTTP 200
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-819f5fdd-4d5f-4944-83d4-bde8c75427ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-819f5fdd-4d5f-4944-83d4-bde8c75427ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

