### PR TITLE
perf: remove derived-state effects (IE url bar, Videos shuffle, furigana batching) + dedupe chat merge pipeline

### DIFF
--- a/src/apps/internet-explorer/hooks/useInternetExplorerLogic.ts
+++ b/src/apps/internet-explorer/hooks/useInternetExplorerLogic.ts
@@ -221,7 +221,13 @@ export function useInternetExplorerLogic({
   const [hasMoreToScroll] = useState(false);
   const [urlBarUiState, dispatchUrlBarUi] = useReducer(
     urlBarUiReducer,
-    urlBarUiInitialState
+    urlBarUiInitialState,
+    // Initialize the address bar from the store's persisted url so no
+    // post-mount sync effect is needed.
+    (initialState) => ({
+      ...initialState,
+      localUrl: url.replace(/^(https?:\/\/|ftp:\/\/)/i, ""),
+    })
   );
   const {
     isUrlDropdownOpen,
@@ -307,6 +313,16 @@ export function useInternetExplorerLogic({
     if (!url) return "";
     return url.replace(/^(https?:\/\/|ftp:\/\/)/i, "");
   }, []);
+
+  // Sync localUrl when the store's url changes (navigation, history, share
+  // links, post-load normalization). Derived during render instead of via an
+  // effect so user typing is only reset when the url actually changed since
+  // the last render, never by unrelated re-renders.
+  const [prevStoreUrl, setPrevStoreUrl] = useState(url);
+  if (prevStoreUrl !== url) {
+    setPrevStoreUrl(url);
+    setLocalUrl(stripProtocol(url));
+  }
 
   // Helper to validate if a URL is well-formed enough to be saved
   const isValidUrl = useCallback(
@@ -1320,10 +1336,6 @@ export function useInternetExplorerLogic({
   const initialNavigationRef = useRef(false);
   // Track the last processed initialData to avoid duplicates
   const lastProcessedInitialDataRef = useRef<unknown>(null);
-  // Sync localUrl with store's url when the component loads or url changes from outside
-  useEffect(() => {
-    setLocalUrl(stripProtocol(url));
-  }, [url, stripProtocol]);
 
   useEffect(() => {
     // Only run initial navigation logic once when the window opens

--- a/src/apps/videos/hooks/useVideosLogic.ts
+++ b/src/apps/videos/hooks/useVideosLogic.ts
@@ -245,12 +245,7 @@ export function useVideosLogic({
   const hasAutoplayCheckedRef = useRef(false);
   const lastProcessedVideoIdRef = useRef<string | null>(null);
   const prevFullScreenRef = useRef(isFullScreen);
-  const videosRef = useRef(videos);
   const originalOrderRef = useRef(originalOrder);
-
-  useEffect(() => {
-    videosRef.current = videos;
-  }, [videos]);
 
   useEffect(() => {
     originalOrderRef.current = originalOrder;
@@ -595,13 +590,23 @@ export function useVideosLogic({
   }, [togglePlayStore, isPlaying, showStatus, t, playVideoTape]);
 
   const toggleShuffle = useCallback(() => {
-    setIsShuffled(!isShuffled);
+    const nextShuffled = !isShuffled;
+    if (nextShuffled) {
+      // Snapshot the current order so un-shuffling can restore it, then shuffle.
+      const currentVideos = useVideoStore.getState().videos;
+      setOriginalOrder(currentVideos);
+      originalOrderRef.current = currentVideos;
+      setVideos([...currentVideos].sort(() => Math.random() - 0.5));
+    } else {
+      setVideos([...originalOrderRef.current]);
+    }
+    setIsShuffled(nextShuffled);
     showStatus(
-      isShuffled
-        ? t("apps.videos.status.shuffleOff")
-        : t("apps.videos.status.shuffleOn")
+      nextShuffled
+        ? t("apps.videos.status.shuffleOn")
+        : t("apps.videos.status.shuffleOff")
     );
-  }, [isShuffled, setIsShuffled, showStatus, t]);
+  }, [isShuffled, setIsShuffled, setOriginalOrder, setVideos, showStatus, t]);
 
   const handleVideoEnd = useCallback(() => {
     if (loopCurrent) {
@@ -835,22 +840,17 @@ export function useVideosLogic({
     setElapsedTime(0);
   }, [currentVideoId]);
 
-  // Shuffle initialization
+  // Shuffle initialization: when shuffle was persisted as enabled, re-shuffle
+  // once on mount so each session gets a fresh order. Toggling shuffle on/off
+  // is handled directly in `toggleShuffle`, not reactively.
+  const hasInitializedShuffleRef = useRef(false);
   useEffect(() => {
-    if (isShuffled) {
-      const shuffled = [...videosRef.current].sort(() => Math.random() - 0.5);
-      setVideos(shuffled);
-    } else {
-      setVideos([...originalOrderRef.current]);
+    if (hasInitializedShuffleRef.current) return;
+    hasInitializedShuffleRef.current = true;
+    if (useVideoStore.getState().isShuffled) {
+      setVideos((prev) => [...prev].sort(() => Math.random() - 0.5));
     }
-  }, [isShuffled, setVideos]);
-
-  // Keep original order in sync with new additions
-  useEffect(() => {
-    if (!isShuffled) {
-      setOriginalOrder(videos);
-    }
-  }, [videos, isShuffled]);
+  }, [setVideos]);
 
   // Effect for initial data on mount
   useEffect(() => {

--- a/src/hooks/useFurigana.tsx
+++ b/src/hooks/useFurigana.tsx
@@ -68,6 +68,44 @@ function normalizeClientFuriganaSegments(segments: FuriganaSegment[]): FuriganaS
 }
 
 /**
+ * Batches snapshots of a progressively-built Map into React state at most once
+ * per animation frame. Streaming endpoints deliver one lyric line per SSE
+ * event; cloning the whole Map and re-rendering for every line is O(n²) in
+ * allocations. Callers must invoke `flushNow()` (or commit their own final
+ * state update) when the stream completes or errors, and `cancel()` on
+ * cleanup so a pending flush can't clobber a newer request's state.
+ */
+function createBatchedMapFlusher<K, V>(
+  source: Map<K, V>,
+  commit: (snapshot: Map<K, V>) => void,
+  shouldCommit: () => boolean
+) {
+  let rafId: number | null = null;
+  const cancel = () => {
+    if (rafId !== null) {
+      cancelAnimationFrame(rafId);
+      rafId = null;
+    }
+  };
+  return {
+    schedule() {
+      if (rafId !== null) return;
+      rafId = requestAnimationFrame(() => {
+        rafId = null;
+        if (!shouldCommit()) return;
+        commit(new Map(source));
+      });
+    },
+    flushNow() {
+      cancel();
+      if (!shouldCommit()) return;
+      commit(new Map(source));
+    },
+    cancel,
+  };
+}
+
+/**
  * Hook for fetching and managing Japanese furigana annotations and other romanization
  * 
  * Handles:
@@ -348,9 +386,16 @@ export function useFurigana({
     // Track this request so we can detect duplicates
     furiganaForceRequestRef.current = { controller, requestId };
 
-    // Use line-by-line streaming for furigana
+    // Use line-by-line streaming for furigana. State flushes are batched to
+    // one Map clone per animation frame instead of one per streamed line.
     const progressiveMap = new Map<string, FuriganaSegment[]>();
-    
+    const progressiveFlusher = createBatchedMapFlusher(
+      progressiveMap,
+      setFuriganaMap,
+      () =>
+        !controller.signal.aborted && effectSongId === currentSongIdRef.current
+    );
+
     processFuriganaSSE(effectSongId, {
       force: isFuriganaForceRequest,
       signal: controller.signal,
@@ -374,11 +419,14 @@ export function useFurigana({
             currentLines[lineIndex].startTimeMs,
             normalizeClientFuriganaSegments(segments)
           );
-          setFuriganaMap(new Map(progressiveMap));
+          progressiveFlusher.schedule();
         }
       },
     })
       .then((result: FuriganaResult) => {
+        // Cancel any pending progressive flush so it can't overwrite the
+        // complete map committed below.
+        progressiveFlusher.cancel();
         if (controller.signal.aborted) return;
         // Check for stale request
         if (effectSongId !== currentSongIdRef.current) return;
@@ -400,6 +448,9 @@ export function useFurigana({
         markFuriganaHandled();
       })
       .catch((err) => {
+        // Guarantee lines received before the error are committed (no-op when
+        // aborted or stale thanks to the flusher's internal guard).
+        progressiveFlusher.flushNow();
         if (controller.signal.aborted) return;
         // Check for stale request
         if (effectSongId !== currentSongIdRef.current) return;
@@ -427,6 +478,7 @@ export function useFurigana({
     return () => {
       // Always abort this request on cleanup - this controller is scoped to this effect run
       controller.abort();
+      progressiveFlusher.cancel();
       // Only clear the ref if this is still the current request
       const isThisRequest = furiganaForceRequestRef.current?.requestId === requestId;
       if (isThisRequest) {
@@ -548,8 +600,15 @@ export function useFurigana({
     // Track this request so we can detect duplicates
     soramimiForceRequestRef.current = { controller, requestId };
 
-    // Use line-by-line streaming for soramimi
+    // Use line-by-line streaming for soramimi. State flushes are batched to
+    // one Map clone per animation frame instead of one per streamed line.
     const progressiveMap = new Map<string, FuriganaSegment[]>();
+    const progressiveFlusher = createBatchedMapFlusher(
+      progressiveMap,
+      setSoramimiMap,
+      () =>
+        !controller.signal.aborted && effectSongId === currentSongIdRef.current
+    );
     
     // For Japanese songs, convert furigana map to array format for the API
     // Computed here (not in useMemo) to avoid re-running this effect during furigana streaming
@@ -593,11 +652,14 @@ export function useFurigana({
         if (lineIndex < currentLines.length && segments) {
           console.log(`[Soramimi] Line ${lineIndex} received:`, segments.length, 'segments');
           progressiveMap.set(currentLines[lineIndex].startTimeMs, segments);
-          setSoramimiMap(new Map(progressiveMap));
+          progressiveFlusher.schedule();
         }
       },
     })
       .then((result: SoramimiResult) => {
+        // Cancel any pending progressive flush so it can't overwrite the
+        // complete map committed below.
+        progressiveFlusher.cancel();
         if (controller.signal.aborted) return;
         // Check for stale request
         if (effectSongId !== currentSongIdRef.current) return;
@@ -616,6 +678,9 @@ export function useFurigana({
         markSoramimiHandled();
       })
       .catch((err) => {
+        // Guarantee lines received before the error are committed (no-op when
+        // aborted or stale thanks to the flusher's internal guard).
+        progressiveFlusher.flushNow();
         if (controller.signal.aborted) return;
         // Check for stale request
         if (effectSongId !== currentSongIdRef.current) return;
@@ -643,6 +708,7 @@ export function useFurigana({
     return () => {
       // Always abort this request on cleanup - this controller is scoped to this effect run
       controller.abort();
+      progressiveFlusher.cancel();
       // Only clear the ref if this is still the current request
       const isThisRequest = soramimiForceRequestRef.current?.requestId === requestId;
       if (isThisRequest) {

--- a/src/stores/useChatsStore.ts
+++ b/src/stores/useChatsStore.ts
@@ -53,6 +53,101 @@ interface ApiMessage {
   timestamp: string | number;
 }
 
+/**
+ * Merge messages fetched from the API into a room's existing message list.
+ *
+ * Decodes HTML entities, normalizes timestamps and sorts chronologically,
+ * then reconciles optimistic temp_ messages against the fetched server
+ * messages (by clientId, or by username + content within a time window) and
+ * caps the result to the history limit. Shared by fetchMessagesForRoom and
+ * fetchBulkMessages.
+ */
+const mergeFetchedRoomMessages = (
+  existing: ChatMessage[],
+  fetched: ApiMessage[]
+): ChatMessage[] => {
+  const fetchedMessages: ChatMessage[] = fetched
+    .map((msg) => ({
+      ...msg,
+      content: decodeHtmlEntities(String(msg.content || "")),
+      timestamp: normalizeChatTimestamp(msg.timestamp),
+    }))
+    .sort((a, b) => a.timestamp - b.timestamp);
+
+  const byId = new Map<string, ChatMessage>();
+
+  // Collect temp (optimistic) messages separately for deduplication
+  // Only messages with temp_ prefix IDs are considered optimistic
+  const tempMessages: ChatMessage[] = [];
+  for (const m of existing) {
+    if (m.id.startsWith("temp_")) {
+      tempMessages.push(m);
+    } else {
+      byId.set(m.id, m);
+    }
+  }
+
+  // Overlay fetched server messages
+  for (const m of fetchedMessages) {
+    const prev = byId.get(m.id);
+    if (prev && prev.clientId) {
+      byId.set(m.id, { ...m, clientId: prev.clientId });
+    } else {
+      byId.set(m.id, m);
+    }
+  }
+
+  // Auto-delete temp messages that match server messages by clientId, or by username + content + time window
+  const MATCH_WINDOW_MS = 10000; // 10 second window
+  const usedTempIds = new Set<string>();
+
+  for (const temp of tempMessages) {
+    const tempClientId = temp.clientId || temp.id;
+    let matched = false;
+
+    // Check if any server message matches this temp message
+    for (const serverMsg of fetchedMessages) {
+      // Match by clientId if the server echoes it back
+      const serverClientId = (serverMsg as ChatMessage & { clientId?: string })
+        .clientId;
+      if (serverClientId && serverClientId === tempClientId) {
+        // Server message has matching clientId - associate and skip temp
+        byId.set(serverMsg.id, {
+          ...byId.get(serverMsg.id)!,
+          clientId: tempClientId,
+        });
+        matched = true;
+        break;
+      }
+
+      // Match by username + content + time window
+      if (
+        serverMsg.username === temp.username &&
+        serverMsg.content === temp.content &&
+        Math.abs(serverMsg.timestamp - temp.timestamp) <= MATCH_WINDOW_MS
+      ) {
+        // Found matching server message - preserve clientId on it
+        byId.set(serverMsg.id, {
+          ...byId.get(serverMsg.id)!,
+          clientId: tempClientId,
+        });
+        matched = true;
+        break;
+      }
+    }
+
+    // If no match found, keep the temp message (might still be in flight)
+    if (!matched && !usedTempIds.has(temp.id)) {
+      byId.set(temp.id, temp);
+      usedTempIds.add(temp.id);
+    }
+  }
+
+  return capRoomMessages(
+    Array.from(byId.values()).sort((a, b) => a.timestamp - b.timestamp)
+  );
+};
+
 // Username recovery: plain-text localStorage (username is not secret)
 const saveUsernameToRecovery = (username: string | null) => {
   if (username) {
@@ -731,93 +826,16 @@ export const useChatsStore = create<ChatsStoreState>()(
             const data = await getRoomMessagesApi(roomId);
             if (data.messages) {
               clearApiUnavailable("room-messages");
-              const fetchedMessages: ChatMessage[] = (data.messages || [])
-                .map((msg: ApiMessage) => ({
-                  ...msg,
-                  content: decodeHtmlEntities(String(msg.content || "")),
-                  timestamp: normalizeChatTimestamp(msg.timestamp),
-                }))
-                .sort(
-                  (a: ChatMessage, b: ChatMessage) => a.timestamp - b.timestamp
-                );
-
               // Merge with any existing messages to avoid race conditions with realtime pushes
-              set((state) => {
-                const existing = state.roomMessages[roomId] || [];
-                const byId = new Map<string, ChatMessage>();
-                
-                // Collect temp (optimistic) messages separately for deduplication
-                // Only messages with temp_ prefix IDs are considered optimistic
-                const tempMessages: ChatMessage[] = [];
-                for (const m of existing) {
-                  if (m.id.startsWith("temp_")) {
-                    tempMessages.push(m);
-                  } else {
-                    byId.set(m.id, m);
-                  }
-                }
-                
-                // Overlay fetched server messages
-                for (const m of fetchedMessages) {
-                  const prev = byId.get(m.id);
-                  if (prev && prev.clientId) {
-                    byId.set(m.id, { ...m, clientId: prev.clientId });
-                  } else {
-                    byId.set(m.id, m);
-                  }
-                }
-                
-                // Auto-delete temp messages that match server messages by clientId, or by username + content + time window
-                const MATCH_WINDOW_MS = 10000; // 10 second window
-                const usedTempIds = new Set<string>();
-                
-                for (const temp of tempMessages) {
-                  const tempClientId = temp.clientId || temp.id;
-                  let matched = false;
-                  
-                  // Check if any server message matches this temp message
-                  for (const serverMsg of fetchedMessages) {
-                    // Match by clientId if the server echoes it back
-                    const serverClientId = (serverMsg as ChatMessage & { clientId?: string }).clientId;
-                    if (serverClientId && serverClientId === tempClientId) {
-                      // Server message has matching clientId - associate and skip temp
-                      byId.set(serverMsg.id, { ...byId.get(serverMsg.id)!, clientId: tempClientId });
-                      matched = true;
-                      break;
-                    }
-                    
-                    // Match by username + content + time window
-                    if (
-                      serverMsg.username === temp.username &&
-                      serverMsg.content === temp.content &&
-                      Math.abs(serverMsg.timestamp - temp.timestamp) <= MATCH_WINDOW_MS
-                    ) {
-                      // Found matching server message - preserve clientId on it
-                      byId.set(serverMsg.id, { ...byId.get(serverMsg.id)!, clientId: tempClientId });
-                      matched = true;
-                      break;
-                    }
-                  }
-                  
-                  // If no match found, keep the temp message (might still be in flight)
-                  if (!matched && !usedTempIds.has(temp.id)) {
-                    byId.set(temp.id, temp);
-                    usedTempIds.add(temp.id);
-                  }
-                }
-                
-                const merged = capRoomMessages(
-                  Array.from(byId.values()).sort(
-                    (a, b) => a.timestamp - b.timestamp
-                  )
-                );
-                return {
-                  roomMessages: {
-                    ...state.roomMessages,
-                    [roomId]: merged,
-                  },
-                };
-              });
+              set((state) => ({
+                roomMessages: {
+                  ...state.roomMessages,
+                  [roomId]: mergeFetchedRoomMessages(
+                    state.roomMessages[roomId] || [],
+                    data.messages || []
+                  ),
+                },
+              }));
 
               return { ok: true };
             }
@@ -858,80 +876,12 @@ export const useChatsStore = create<ChatsStoreState>()(
               set((state) => {
                 const nextRoomMessages = { ...state.roomMessages };
 
-                Object.entries(messagesMap).forEach(
-                  ([roomId, messages]) => {
-                    const processed: ChatMessage[] = (messages as ApiMessage[])
-                      .map((msg) => ({
-                        ...msg,
-                        content: decodeHtmlEntities(String(msg.content || "")),
-                        timestamp: normalizeChatTimestamp(msg.timestamp),
-                      }))
-                      .sort((a, b) => a.timestamp - b.timestamp);
-
-                    const existing = nextRoomMessages[roomId] || [];
-                    const byId = new Map<string, ChatMessage>();
-                    
-                    // Collect temp (optimistic) messages separately for deduplication
-                    // Only messages with temp_ prefix IDs are considered optimistic
-                    const tempMessages: ChatMessage[] = [];
-                    for (const m of existing) {
-                      if (m.id.startsWith("temp_")) {
-                        tempMessages.push(m);
-                      } else {
-                        byId.set(m.id, m);
-                      }
-                    }
-                    
-                    // Overlay fetched server messages
-                    for (const m of processed) {
-                      const prev = byId.get(m.id);
-                      if (prev && prev.clientId) {
-                        byId.set(m.id, { ...m, clientId: prev.clientId });
-                      } else {
-                        byId.set(m.id, m);
-                      }
-                    }
-                    
-                    // Auto-delete temp messages that match server messages
-                    const MATCH_WINDOW_MS = 10000;
-                    const usedTempIds = new Set<string>();
-                    
-                    for (const temp of tempMessages) {
-                      const tempClientId = temp.clientId || temp.id;
-                      let matched = false;
-                      
-                      for (const serverMsg of processed) {
-                        const serverClientId = (serverMsg as ChatMessage & { clientId?: string }).clientId;
-                        if (serverClientId && serverClientId === tempClientId) {
-                          byId.set(serverMsg.id, { ...byId.get(serverMsg.id)!, clientId: tempClientId });
-                          matched = true;
-                          break;
-                        }
-                        
-                        if (
-                          serverMsg.username === temp.username &&
-                          serverMsg.content === temp.content &&
-                          Math.abs(serverMsg.timestamp - temp.timestamp) <= MATCH_WINDOW_MS
-                        ) {
-                          byId.set(serverMsg.id, { ...byId.get(serverMsg.id)!, clientId: tempClientId });
-                          matched = true;
-                          break;
-                        }
-                      }
-                      
-                      if (!matched && !usedTempIds.has(temp.id)) {
-                        byId.set(temp.id, temp);
-                        usedTempIds.add(temp.id);
-                      }
-                    }
-                    
-                    nextRoomMessages[roomId] = capRoomMessages(
-                      Array.from(byId.values()).sort(
-                        (a, b) => a.timestamp - b.timestamp
-                      )
-                    );
-                  }
-                );
+                Object.entries(messagesMap).forEach(([roomId, messages]) => {
+                  nextRoomMessages[roomId] = mergeFetchedRoomMessages(
+                    nextRoomMessages[roomId] || [],
+                    messages as ApiMessage[]
+                  );
+                });
 
                 return { roomMessages: nextRoomMessages };
               });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Batch 2 of the parallelized fix round (derived-state effects & duplicate processing from the re-audit, rules `rerender-derived-state-no-effect` / `rerender-move-effect-to-event`).

## Changes

- **Internet Explorer**: removed the `setLocalUrl(stripProtocol(url))` sync effect — the url-bar reducer lazy-initializes from the persisted url and store-url changes are applied via a render-phase `prevStoreUrl` comparison, so typing is only reset when the url actually changes (never by unrelated re-renders).
- **Videos**: shuffle is computed in the `toggleShuffle` handler (snapshot order → shuffle/restore → flip flag); both reactive effects and the now-unused `videosRef` removed. A run-once mount effect preserves the existing "fresh shuffle per session when shuffle was persisted on" behavior.
- **Furigana/soramimi streaming**: each SSE lyric line did `setMap(new Map(progressiveMap))` — O(n²) allocations and a re-render per line. Both paths now batch through `createBatchedMapFlusher`: at most one Map commit per animation frame, with a guaranteed final flush on completion/error and cleanup-cancelled pending flushes.
- **Chats store**: the duplicated ~90-line decode → normalize → sort → temp-message reconcile → cap pipeline (two `MATCH_WINDOW_MS` blocks in `fetchMessagesForRoom` / `fetchBulkMessages`) is now one `mergeFetchedRoomMessages` helper, copied verbatim; existing guard-test patterns untouched.

## Testing

- ✅ `bunx tsc -b --force` — clean (verified in an isolated worktree of the pushed branch)
- ✅ `bun run test:unit` — 310 pass / 0 fail
- ✅ `bun test tests/test-chat-notification-logic.test.ts tests/test-chat-store-guards-wiring.test.ts tests/test-chat-broadcast-wiring.test.ts` — 27 pass / 0 fail
- ✅ `bunx eslint` on the 4 changed files — 0 errors; warnings reduced vs base (removed 2 pre-existing)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-819f5fdd-4d5f-4944-83d4-bde8c75427ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-819f5fdd-4d5f-4944-83d4-bde8c75427ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

