### PR TITLE
refactor(menubars): memoized Videos grouping + shared LibraryTrackBrowser/MediaControlsMenu + declarative menu descriptors

### DIFF
--- a/src/apps/contacts/components/ContactsMenuBar.tsx
+++ b/src/apps/contacts/components/ContactsMenuBar.tsx
@@ -1,17 +1,5 @@
-import {
-  MenubarCheckboxItem,
-  MenubarContent,
-  MenubarItem,
-  MenubarMenu,
-  MenubarSeparator,
-  MenubarTrigger,
-} from "@/components/ui/menubar";
 import { AppMenuBarShell } from "@/components/shared/menubar/AppMenuBarShell";
-import {
-  MENUBAR_ITEM_CLASS,
-  MENUBAR_SEPARATOR_CLASS,
-  MENUBAR_TRIGGER_CLASS,
-} from "@/components/shared/menubar/menubarStyles";
+import { AppMenuBarMenus } from "@/components/shared/menubar/AppMenuBarMenus";
 import { useAppMenuBarChrome } from "@/hooks/useAppMenuBarChrome";
 import { requestCloudSyncDomainCheck } from "@/utils/cloudSyncEvents";
 import { useTranslation } from "react-i18next";
@@ -62,56 +50,60 @@ export function ContactsMenuBar({
       onShowHelp={onShowHelp}
       onShowAbout={onShowAbout}
     >
-      <MenubarMenu>
-        <MenubarTrigger className={MENUBAR_TRIGGER_CLASS}>
-          {t("common.menu.file")}
-        </MenubarTrigger>
-        <MenubarContent align="start" sideOffset={1} className="px-0">
-          <MenubarItem onClick={onNewContact} className={MENUBAR_ITEM_CLASS}>
-            {t("apps.contacts.menu.newContact")}
-          </MenubarItem>
-          <MenubarItem onClick={onImport} className={MENUBAR_ITEM_CLASS}>
-            {t("apps.contacts.menu.importVCard")}
-          </MenubarItem>
-          <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
-          <MenubarItem
-            onClick={() => requestCloudSyncDomainCheck("contacts")}
-            className={MENUBAR_ITEM_CLASS}
-          >
-            {t("apps.contacts.menu.syncContacts", {
-              defaultValue: "Sync Contacts",
-            })}
-          </MenubarItem>
-          <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
-          <MenubarItem onClick={onClose} className={MENUBAR_ITEM_CLASS}>
-            {t("common.menu.close")}
-          </MenubarItem>
-        </MenubarContent>
-      </MenubarMenu>
-
-      <MenubarMenu>
-        <MenubarTrigger className={MENUBAR_TRIGGER_CLASS}>
-          {t("common.menu.edit")}
-        </MenubarTrigger>
-        <MenubarContent align="start" sideOffset={1} className="px-0">
-          <MenubarCheckboxItem
-            checked={isSelectedMine}
-            onClick={onMarkAsMine}
-            disabled={!hasSelectedContact}
-            className={MENUBAR_ITEM_CLASS}
-          >
-            {t("apps.contacts.menu.markAsMine", { defaultValue: "Mark as Mine" })}
-          </MenubarCheckboxItem>
-          <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
-          <MenubarItem
-            onClick={onDeleteContact}
-            disabled={!hasSelectedContact}
-            className={MENUBAR_ITEM_CLASS}
-          >
-            {t("apps.contacts.menu.deleteContact")}
-          </MenubarItem>
-        </MenubarContent>
-      </MenubarMenu>
+      <AppMenuBarMenus
+        menus={[
+          {
+            label: t("common.menu.file"),
+            items: [
+              {
+                type: "action",
+                label: t("apps.contacts.menu.newContact"),
+                onClick: onNewContact,
+              },
+              {
+                type: "action",
+                label: t("apps.contacts.menu.importVCard"),
+                onClick: onImport,
+              },
+              { type: "separator" },
+              {
+                type: "action",
+                label: t("apps.contacts.menu.syncContacts", {
+                  defaultValue: "Sync Contacts",
+                }),
+                onClick: () => requestCloudSyncDomainCheck("contacts"),
+              },
+              { type: "separator" },
+              {
+                type: "action",
+                label: t("common.menu.close"),
+                onClick: onClose,
+              },
+            ],
+          },
+          {
+            label: t("common.menu.edit"),
+            items: [
+              {
+                type: "checkbox",
+                label: t("apps.contacts.menu.markAsMine", {
+                  defaultValue: "Mark as Mine",
+                }),
+                checked: isSelectedMine,
+                onChange: onMarkAsMine,
+                disabled: !hasSelectedContact,
+              },
+              { type: "separator" },
+              {
+                type: "action",
+                label: t("apps.contacts.menu.deleteContact"),
+                onClick: onDeleteContact,
+                disabled: !hasSelectedContact,
+              },
+            ],
+          },
+        ]}
+      />
     </AppMenuBarShell>
   );
 }

--- a/src/apps/control-panels/components/ControlPanelsMenuBar.tsx
+++ b/src/apps/control-panels/components/ControlPanelsMenuBar.tsx
@@ -1,10 +1,5 @@
-import {
-  MenubarMenu,
-  MenubarTrigger,
-  MenubarContent,
-  MenubarItem,
-} from "@/components/ui/menubar";
 import { AppMenuBarShell } from "@/components/shared/menubar/AppMenuBarShell";
+import { AppMenuBarMenus } from "@/components/shared/menubar/AppMenuBarMenus";
 import { useAppMenuBarChrome } from "@/hooks/useAppMenuBarChrome";
 import { useTranslation } from "react-i18next";
 
@@ -42,19 +37,20 @@ export function ControlPanelsMenuBar({
       onShowHelp={onShowHelp}
       onShowAbout={onShowAbout}
     >
-      <MenubarMenu>
-        <MenubarTrigger className="text-md px-2 py-1 border-none focus-visible:ring-0">
-          {t("common.menu.file")}
-        </MenubarTrigger>
-        <MenubarContent align="start" sideOffset={1} className="px-0">
-          <MenubarItem
-            onClick={onClose}
-            className="text-md h-6 px-3"
-          >
-            {t("common.menu.close")}
-          </MenubarItem>
-        </MenubarContent>
-      </MenubarMenu>
+      <AppMenuBarMenus
+        menus={[
+          {
+            label: t("common.menu.file"),
+            items: [
+              {
+                type: "action",
+                label: t("common.menu.close"),
+                onClick: onClose,
+              },
+            ],
+          },
+        ]}
+      />
     </AppMenuBarShell>
   );
 }

--- a/src/apps/minesweeper/components/MinesweeperMenuBar.tsx
+++ b/src/apps/minesweeper/components/MinesweeperMenuBar.tsx
@@ -1,12 +1,5 @@
-import {
-  MenubarMenu,
-  MenubarTrigger,
-  MenubarContent,
-  MenubarItem,
-  MenubarSeparator,
-} from "@/components/ui/menubar";
 import { AppMenuBarShell } from "@/components/shared/menubar/AppMenuBarShell";
-import { MENUBAR_SEPARATOR_CLASS } from "@/components/shared/menubar/menubarStyles";
+import { AppMenuBarMenus } from "@/components/shared/menubar/AppMenuBarMenus";
 import { useAppMenuBarChrome } from "@/hooks/useAppMenuBarChrome";
 import { useTranslation } from "react-i18next";
 
@@ -46,27 +39,26 @@ export function MinesweeperMenuBar({
       onShowHelp={onShowHelp}
       onShowAbout={onShowAbout}
     >
-      {/* Game Menu */}
-      <MenubarMenu>
-        <MenubarTrigger className="text-md px-2 py-1 border-none focus-visible:ring-0">
-          {t("common.menu.file")}
-        </MenubarTrigger>
-        <MenubarContent align="start" sideOffset={1} className="px-0">
-          <MenubarItem
-            onClick={onNewGame}
-            className="text-md h-6 px-3"
-          >
-            {t("apps.minesweeper.menu.newGame")}
-          </MenubarItem>
-          <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
-          <MenubarItem
-            onClick={onClose}
-            className="text-md h-6 px-3"
-          >
-            {t("common.menu.close")}
-          </MenubarItem>
-        </MenubarContent>
-      </MenubarMenu>
+      <AppMenuBarMenus
+        menus={[
+          {
+            label: t("common.menu.file"),
+            items: [
+              {
+                type: "action",
+                label: t("apps.minesweeper.menu.newGame"),
+                onClick: onNewGame,
+              },
+              { type: "separator" },
+              {
+                type: "action",
+                label: t("common.menu.close"),
+                onClick: onClose,
+              },
+            ],
+          },
+        ]}
+      />
     </AppMenuBarShell>
   );
 }

--- a/src/apps/videos/components/VideosMenuBar.tsx
+++ b/src/apps/videos/components/VideosMenuBar.tsx
@@ -1,18 +1,20 @@
+import { useMemo } from "react";
 import {
   MenubarMenu,
   MenubarTrigger,
   MenubarContent,
   MenubarItem,
   MenubarSeparator,
-  MenubarSub,
-  MenubarSubTrigger,
-  MenubarSubContent,
 } from "@/components/ui/menubar";
 import { AppMenuBarShell } from "@/components/shared/menubar/AppMenuBarShell";
 import { MediaControlsMenu } from "@/components/shared/menubar/MediaControlsMenu";
+import { LibraryTrackBrowser } from "@/components/shared/menubar/LibraryTrackBrowser";
 import { MENUBAR_SEPARATOR_CLASS } from "@/components/shared/menubar/menubarStyles";
 import { useAppMenuBarChrome } from "@/hooks/useAppMenuBarChrome";
-import { cn } from "@/lib/utils";
+import {
+  getSortedArtistNames,
+  groupTracksByArtist,
+} from "@/utils/groupTracksByArtist";
 import { useTranslation } from "react-i18next";
 
 interface Video {
@@ -81,21 +83,29 @@ export function VideosMenuBar({
     appName,
   } = useAppMenuBarChrome("videos");
 
-  // Group videos by artist
-  const videosByArtist = videos.reduce<Record<string, Video[]>>(
-    (acc, video) => {
-      const artist = video.artist || t("apps.videos.menu.unknownArtist");
-      if (!acc[artist]) {
-        acc[artist] = [];
-      }
-      acc[artist].push(video);
-      return acc;
-    },
-    {}
+  // Group videos by artist. Memoized because the menubar re-renders on
+  // every player tick and the reduce/sort is wasted work otherwise.
+  const unknownArtistLabel = t("apps.videos.menu.unknownArtist");
+  const videosByArtist = useMemo(
+    () => groupTracksByArtist(videos, unknownArtistLabel),
+    [videos, unknownArtistLabel]
+  );
+  const artists = useMemo(
+    () => getSortedArtistNames(videosByArtist),
+    [videosByArtist]
   );
 
-  // Get sorted list of artists
-  const artists = Object.keys(videosByArtist).sort();
+  const currentIndex = useMemo(
+    () => videos.findIndex((video) => video.id === currentVideoId),
+    [videos, currentVideoId]
+  );
+
+  const handlePlayVideo = (index: number) => {
+    const video = videos[index];
+    if (video) {
+      onPlayVideo(video.id);
+    }
+  };
 
   return (
     <AppMenuBarShell
@@ -187,75 +197,19 @@ export function VideosMenuBar({
           {videos.length > 0 && (
             <>
               <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
-              
-              {/* All Videos section */}
-              <MenubarSub>
-                <MenubarSubTrigger className="text-md h-6 px-3">
-                  <div className="flex justify-between w-full items-center overflow-hidden">
-                    <span className="truncate min-w-0">{t("apps.videos.menu.allVideos")}</span>
-                  </div>
-                </MenubarSubTrigger>
-                <MenubarSubContent className="px-0 max-w-[180px] sm:max-w-[220px]">
-                  {videos.map((video) => (
-                    <MenubarItem
-                      key={`all-${video.id}`}
-                      onClick={() => onPlayVideo(video.id)}
-                      className={cn(
-                        "text-md h-6 px-3 max-w-[220px] truncate",
-                        video.id === currentVideoId && "bg-neutral-200"
-                      )}
-                    >
-                      <div className="flex items-center w-full">
-                        <span
-                          className={cn(
-                            "flex-none whitespace-nowrap",
-                            video.id === currentVideoId ? "mr-1" : "pl-5"
-                          )}
-                        >
-                          {video.id === currentVideoId ? "♪ " : ""}
-                        </span>
-                        <span className="truncate min-w-0">{video.title}</span>
-                      </div>
-                    </MenubarItem>
-                  ))}
-                </MenubarSubContent>
-              </MenubarSub>
-              
-              {/* Individual Artist submenus */}
-              {artists.map((artist) => (
-                <MenubarSub key={artist}>
-                  <MenubarSubTrigger className="text-md h-6 px-3">
-                    <div className="flex justify-between w-full items-center overflow-hidden">
-                      <span className="truncate min-w-0">{artist}</span>
-                    </div>
-                  </MenubarSubTrigger>
-                  <MenubarSubContent className="px-0 max-w-[180px] sm:max-w-[220px]">
-                    {videosByArtist[artist].map((video) => (
-                      <MenubarItem
-                        key={`${artist}-${video.id}`}
-                        onClick={() => onPlayVideo(video.id)}
-                        className={cn(
-                          "text-md h-6 px-3 max-w-[160px] sm:max-w-[200px] truncate",
-                          video.id === currentVideoId && "bg-neutral-200"
-                        )}
-                      >
-                        <div className="flex items-center w-full">
-                          <span
-                            className={cn(
-                              "flex-none whitespace-nowrap",
-                              video.id === currentVideoId ? "mr-1" : "pl-5"
-                            )}
-                          >
-                            {video.id === currentVideoId ? "♪ " : ""}
-                          </span>
-                          <span className="truncate min-w-0">{video.title}</span>
-                        </div>
-                      </MenubarItem>
-                    ))}
-                  </MenubarSubContent>
-                </MenubarSub>
-              ))}
-              
+
+              <LibraryTrackBrowser
+                tracks={videos}
+                currentIndex={currentIndex}
+                tracksByArtist={videosByArtist}
+                artists={artists}
+                onPlayTrack={handlePlayVideo}
+                t={t}
+                allItemsLabel={t("apps.videos.menu.allVideos")}
+                itemVariant="nowPlaying"
+                limitLargeLibraries={false}
+              />
+
               <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
             </>
           )}

--- a/src/apps/winamp/components/WinampMenuBar.tsx
+++ b/src/apps/winamp/components/WinampMenuBar.tsx
@@ -4,11 +4,11 @@ import {
   MenubarContent,
   MenubarItem,
   MenubarSeparator,
-  MenubarCheckboxItem,
   MenubarRadioGroup,
   MenubarRadioItem,
 } from "@/components/ui/menubar";
 import { AppMenuBarShell } from "@/components/shared/menubar/AppMenuBarShell";
+import { MediaControlsMenu } from "@/components/shared/menubar/MediaControlsMenu";
 import {
   MENUBAR_ITEM_CLASS,
   MENUBAR_SEPARATOR_CLASS,
@@ -111,42 +111,29 @@ export function WinampMenuBar({
           </MenubarRadioGroup>
         </MenubarContent>
       </MenubarMenu>
-      <MenubarMenu>
-        <MenubarTrigger className={MENUBAR_TRIGGER_CLASS}>
-          {t("apps.winamp.menu.controls")}
-        </MenubarTrigger>
-        <MenubarContent align="start" sideOffset={1} className="px-0">
-          <MenubarItem onClick={onTogglePlay} className={MENUBAR_ITEM_CLASS}>
-            {isPlaying
-              ? t("apps.winamp.menu.pause")
-              : t("apps.winamp.menu.play")}
-          </MenubarItem>
+      <MediaControlsMenu
+        menuLabel={t("apps.winamp.menu.controls")}
+        triggerClassName={MENUBAR_TRIGGER_CLASS}
+        isPlaying={isPlaying}
+        onTogglePlay={onTogglePlay}
+        onPreviousTrack={onPreviousTrack}
+        onNextTrack={onNextTrack}
+        playLabel={t("apps.winamp.menu.play")}
+        pauseLabel={t("apps.winamp.menu.pause")}
+        previousLabel={t("apps.winamp.menu.previous")}
+        nextLabel={t("apps.winamp.menu.next")}
+        shuffleLabel={t("apps.winamp.menu.shuffle")}
+        repeatAllLabel={t("apps.winamp.menu.repeat")}
+        isShuffled={isShuffleEnabled}
+        onToggleShuffle={onToggleShuffle}
+        isLoopAll={isRepeatEnabled}
+        onToggleLoopAll={onToggleRepeat}
+        afterTogglePlayItems={
           <MenubarItem onClick={onStopPlayback} className={MENUBAR_ITEM_CLASS}>
             {t("apps.winamp.menu.stop")}
           </MenubarItem>
-          <MenubarItem onClick={onPreviousTrack} className={MENUBAR_ITEM_CLASS}>
-            {t("apps.winamp.menu.previous")}
-          </MenubarItem>
-          <MenubarItem onClick={onNextTrack} className={MENUBAR_ITEM_CLASS}>
-            {t("apps.winamp.menu.next")}
-          </MenubarItem>
-          <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
-          <MenubarCheckboxItem
-            checked={isShuffleEnabled}
-            onCheckedChange={() => onToggleShuffle()}
-            className={MENUBAR_ITEM_CLASS}
-          >
-            {t("apps.winamp.menu.shuffle")}
-          </MenubarCheckboxItem>
-          <MenubarCheckboxItem
-            checked={isRepeatEnabled}
-            onCheckedChange={() => onToggleRepeat()}
-            className={MENUBAR_ITEM_CLASS}
-          >
-            {t("apps.winamp.menu.repeat")}
-          </MenubarCheckboxItem>
-        </MenubarContent>
-      </MenubarMenu>
+        }
+      />
 
     </AppMenuBarShell>
   );

--- a/src/components/shared/menubar/AppMenuBarMenus.tsx
+++ b/src/components/shared/menubar/AppMenuBarMenus.tsx
@@ -1,0 +1,114 @@
+import {
+  MenubarMenu,
+  MenubarTrigger,
+  MenubarContent,
+  MenubarItem,
+  MenubarCheckboxItem,
+  MenubarSeparator,
+  MenubarShortcut,
+  MenubarSub,
+  MenubarSubTrigger,
+  MenubarSubContent,
+} from "@/components/ui/menubar";
+import {
+  MENUBAR_ITEM_CLASS,
+  MENUBAR_SEPARATOR_CLASS,
+  MENUBAR_TRIGGER_CLASS,
+} from "./menubarStyles";
+
+export type MenuItemDescriptor =
+  | {
+      type: "action";
+      label: string;
+      onClick: () => void;
+      disabled?: boolean;
+      shortcut?: string;
+    }
+  | { type: "separator" }
+  | {
+      type: "checkbox";
+      label: string;
+      checked: boolean;
+      onChange: (checked: boolean) => void;
+      disabled?: boolean;
+    }
+  | { type: "submenu"; label: string; items: MenuItemDescriptor[] };
+
+export type MenuDescriptor = {
+  label: string;
+  items: MenuItemDescriptor[];
+};
+
+function renderItems(items: MenuItemDescriptor[]) {
+  return items.map((item, index) => {
+    switch (item.type) {
+      case "separator":
+        return (
+          <MenubarSeparator key={index} className={MENUBAR_SEPARATOR_CLASS} />
+        );
+      case "action":
+        return (
+          <MenubarItem
+            key={index}
+            onClick={item.onClick}
+            disabled={item.disabled}
+            className={MENUBAR_ITEM_CLASS}
+          >
+            {item.label}
+            {item.shortcut && (
+              <MenubarShortcut>{item.shortcut}</MenubarShortcut>
+            )}
+          </MenubarItem>
+        );
+      case "checkbox":
+        return (
+          <MenubarCheckboxItem
+            key={index}
+            checked={item.checked}
+            onCheckedChange={item.onChange}
+            disabled={item.disabled}
+            className={MENUBAR_ITEM_CLASS}
+          >
+            {item.label}
+          </MenubarCheckboxItem>
+        );
+      case "submenu":
+        return (
+          <MenubarSub key={index}>
+            <MenubarSubTrigger className={MENUBAR_ITEM_CLASS}>
+              {item.label}
+            </MenubarSubTrigger>
+            <MenubarSubContent className="px-0">
+              {renderItems(item.items)}
+            </MenubarSubContent>
+          </MenubarSub>
+        );
+    }
+  });
+}
+
+/**
+ * Declarative renderer for simple app menubars. Each descriptor becomes a
+ * Radix MenubarMenu styled with the shared `menubarStyles` constants so all
+ * OS themes render identically to the hand-written JSX it replaces.
+ *
+ * Intended for small, mechanical menus (plain actions, separators,
+ * checkboxes, basic submenus). Menus that need radio groups, custom
+ * classNames, or bespoke item content should keep hand-written JSX.
+ */
+export function AppMenuBarMenus({ menus }: { menus: MenuDescriptor[] }) {
+  return (
+    <>
+      {menus.map((menu, index) => (
+        <MenubarMenu key={index}>
+          <MenubarTrigger className={MENUBAR_TRIGGER_CLASS}>
+            {menu.label}
+          </MenubarTrigger>
+          <MenubarContent align="start" sideOffset={1} className="px-0">
+            {renderItems(menu.items)}
+          </MenubarContent>
+        </MenubarMenu>
+      ))}
+    </>
+  );
+}

--- a/src/components/shared/menubar/LibraryTrackBrowser.tsx
+++ b/src/components/shared/menubar/LibraryTrackBrowser.tsx
@@ -11,49 +11,143 @@ import {
   MENUBAR_ARTIST_LIMIT,
 } from "@/components/shared/menubar/libraryMenuConstants";
 import type { TrackWithIndex } from "@/utils/groupTracksByArtist";
-import type { Track } from "@/stores/useIpodStore";
+import { cn } from "@/lib/utils";
 
-export function LibraryTrackBrowser({
+export type LibraryBrowserItem = {
+  id: string;
+  title: string;
+  artist?: string;
+};
+
+export function LibraryTrackBrowser<T extends LibraryBrowserItem>({
   tracks,
   currentIndex,
   tracksByArtist,
   artists,
   onPlayTrack,
   t,
+  allItemsLabel,
+  itemVariant = "checkbox",
+  limitLargeLibraries = true,
 }: {
-  tracks: Track[];
+  tracks: T[];
   currentIndex: number;
-  tracksByArtist: Record<string, TrackWithIndex<Track>[]>;
+  tracksByArtist: Record<string, TrackWithIndex<T>[]>;
   artists: string[];
   onPlayTrack: (index: number) => void;
   t: TFunction;
+  /** Label for the "all items" submenu. Defaults to the iPod "All Songs" label. */
+  allItemsLabel?: string;
+  /**
+   * How the current item is indicated: "checkbox" renders checkmark items
+   * (iPod/Karaoke), "nowPlaying" renders plain items with a ♪ prefix (Videos).
+   */
+  itemVariant?: "checkbox" | "nowPlaying";
+  /**
+   * Cap rendered tracks/artists and add scroll containers so huge libraries
+   * don't commit thousands of DOM nodes (iPod/Karaoke). Disable for small,
+   * unbounded libraries (Videos).
+   */
+  limitLargeLibraries?: boolean;
 }) {
   if (tracks.length === 0) {
     return null;
   }
+
+  const allLabel = allItemsLabel ?? t("apps.ipod.menu.allSongs");
+
+  const renderTrackItem = (
+    track: T,
+    index: number,
+    key: string,
+    maxWidthClass: string
+  ) =>
+    itemVariant === "checkbox" ? (
+      <MenubarCheckboxItem
+        key={key}
+        checked={index === currentIndex}
+        onCheckedChange={() => onPlayTrack(index)}
+        className={cn("text-md h-6 pr-3 truncate", maxWidthClass)}
+      >
+        <span className="truncate min-w-0">{track.title}</span>
+      </MenubarCheckboxItem>
+    ) : (
+      <MenubarItem
+        key={key}
+        onClick={() => onPlayTrack(index)}
+        className={cn(
+          "text-md h-6 px-3 truncate",
+          maxWidthClass,
+          index === currentIndex && "bg-neutral-200"
+        )}
+      >
+        <div className="flex items-center w-full">
+          <span
+            className={cn(
+              "flex-none whitespace-nowrap",
+              index === currentIndex ? "mr-1" : "pl-5"
+            )}
+          >
+            {index === currentIndex ? "♪ " : ""}
+          </span>
+          <span className="truncate min-w-0">{track.title}</span>
+        </div>
+      </MenubarItem>
+    );
+
+  const visibleTracks = limitLargeLibraries
+    ? tracks.slice(0, MENUBAR_TRACK_LIMIT)
+    : tracks;
+  const visibleArtists = limitLargeLibraries
+    ? artists.slice(0, MENUBAR_ARTIST_LIMIT)
+    : artists;
+
+  const artistSubmenus = visibleArtists.map((artist) => (
+    <MenubarSub key={artist}>
+      <MenubarSubTrigger className="text-md h-6 px-3">
+        <div className="flex justify-between w-full items-center overflow-hidden">
+          <span className="truncate min-w-0">{artist}</span>
+        </div>
+      </MenubarSubTrigger>
+      <MenubarSubContent
+        className={cn(
+          "px-0 max-w-[180px] sm:max-w-[220px]",
+          limitLargeLibraries && "max-h-[200px] overflow-y-auto"
+        )}
+      >
+        {(limitLargeLibraries
+          ? tracksByArtist[artist].slice(0, MENUBAR_TRACK_LIMIT)
+          : tracksByArtist[artist]
+        ).map(({ track, index }) =>
+          renderTrackItem(
+            track,
+            index,
+            `${artist}-${track.id}`,
+            "max-w-[160px] sm:max-w-[200px]"
+          )
+        )}
+      </MenubarSubContent>
+    </MenubarSub>
+  ));
 
   return (
     <>
       <MenubarSub>
         <MenubarSubTrigger className="text-md h-6 px-3">
           <div className="flex justify-between w-full items-center overflow-hidden">
-            <span className="truncate min-w-0">
-              {t("apps.ipod.menu.allSongs")}
-            </span>
+            <span className="truncate min-w-0">{allLabel}</span>
           </div>
         </MenubarSubTrigger>
-        <MenubarSubContent className="px-0 max-w-[180px] sm:max-w-[220px] max-h-[400px] overflow-y-auto">
-          {tracks.slice(0, MENUBAR_TRACK_LIMIT).map((track, index) => (
-            <MenubarCheckboxItem
-              key={`all-${track.id}`}
-              checked={index === currentIndex}
-              onCheckedChange={() => onPlayTrack(index)}
-              className="text-md h-6 pr-3 max-w-[220px] truncate"
-            >
-              <span className="truncate min-w-0">{track.title}</span>
-            </MenubarCheckboxItem>
-          ))}
-          {tracks.length > MENUBAR_TRACK_LIMIT && (
+        <MenubarSubContent
+          className={cn(
+            "px-0 max-w-[180px] sm:max-w-[220px]",
+            limitLargeLibraries && "max-h-[400px] overflow-y-auto"
+          )}
+        >
+          {visibleTracks.map((track, index) =>
+            renderTrackItem(track, index, `all-${track.id}`, "max-w-[220px]")
+          )}
+          {limitLargeLibraries && tracks.length > MENUBAR_TRACK_LIMIT && (
             <MenubarItem
               disabled
               className="text-md h-6 px-3 italic opacity-70"
@@ -70,48 +164,28 @@ export function LibraryTrackBrowser({
           )}
         </MenubarSubContent>
       </MenubarSub>
-      <div className="max-h-[300px] overflow-y-auto">
-        {artists.slice(0, MENUBAR_ARTIST_LIMIT).map((artist) => (
-          <MenubarSub key={artist}>
-            <MenubarSubTrigger className="text-md h-6 px-3">
-              <div className="flex justify-between w-full items-center overflow-hidden">
-                <span className="truncate min-w-0">{artist}</span>
-              </div>
-            </MenubarSubTrigger>
-            <MenubarSubContent className="px-0 max-w-[180px] sm:max-w-[220px] max-h-[200px] overflow-y-auto">
-              {tracksByArtist[artist]
-                .slice(0, MENUBAR_TRACK_LIMIT)
-                .map(({ track, index }) => (
-                  <MenubarCheckboxItem
-                    key={`${artist}-${track.id}`}
-                    checked={index === currentIndex}
-                    onCheckedChange={() => onPlayTrack(index)}
-                    className="text-md h-6 pr-3 max-w-[160px] sm:max-w-[200px] truncate"
-                  >
-                    <span className="truncate min-w-0">
-                      {track.title}
-                    </span>
-                  </MenubarCheckboxItem>
-                ))}
-            </MenubarSubContent>
-          </MenubarSub>
-        ))}
-        {artists.length > MENUBAR_ARTIST_LIMIT && (
-          <MenubarItem
-            disabled
-            className="text-md h-6 px-3 italic opacity-70"
-          >
-            {t(
-              "apps.ipod.menu.menubarArtistLimit",
-              `Showing ${MENUBAR_ARTIST_LIMIT} of ${artists.length} artists`,
-              {
-                limit: MENUBAR_ARTIST_LIMIT,
-                total: artists.length,
-              }
-            )}
-          </MenubarItem>
-        )}
-      </div>
+      {limitLargeLibraries ? (
+        <div className="max-h-[300px] overflow-y-auto">
+          {artistSubmenus}
+          {artists.length > MENUBAR_ARTIST_LIMIT && (
+            <MenubarItem
+              disabled
+              className="text-md h-6 px-3 italic opacity-70"
+            >
+              {t(
+                "apps.ipod.menu.menubarArtistLimit",
+                `Showing ${MENUBAR_ARTIST_LIMIT} of ${artists.length} artists`,
+                {
+                  limit: MENUBAR_ARTIST_LIMIT,
+                  total: artists.length,
+                }
+              )}
+            </MenubarItem>
+          )}
+        </div>
+      ) : (
+        artistSubmenus
+      )}
     </>
   );
 }

--- a/src/components/shared/menubar/MediaControlsMenu.tsx
+++ b/src/components/shared/menubar/MediaControlsMenu.tsx
@@ -12,7 +12,8 @@ import { MENUBAR_SEPARATOR_CLASS } from "./menubarStyles";
 export type MediaControlsMenuProps = {
   menuLabel: string;
   triggerClassName?: string;
-  tracksCount: number;
+  /** When provided, transport items are disabled while the library is empty. */
+  tracksCount?: number;
   isPlaying: boolean;
   onTogglePlay: () => void;
   onPreviousTrack: () => void;
@@ -23,13 +24,16 @@ export type MediaControlsMenuProps = {
   nextLabel: string;
   shuffleLabel: string;
   repeatAllLabel: string;
-  repeatOneLabel: string;
+  /** Omit (with isLoopCurrent/onToggleLoopCurrent) for apps with a single repeat toggle. */
+  repeatOneLabel?: string;
   isShuffled: boolean;
   onToggleShuffle: () => void;
   isLoopAll: boolean;
   onToggleLoopAll: () => void;
-  isLoopCurrent: boolean;
-  onToggleLoopCurrent: () => void;
+  isLoopCurrent?: boolean;
+  onToggleLoopCurrent?: () => void;
+  /** Extra items rendered between play/pause and previous (e.g. Winamp's Stop). */
+  afterTogglePlayItems?: ReactNode;
   /** Extra items rendered between the transport items and the shuffle/repeat block. */
   extraItems?: ReactNode;
 };
@@ -55,6 +59,7 @@ export function MediaControlsMenu({
   onToggleLoopAll,
   isLoopCurrent,
   onToggleLoopCurrent,
+  afterTogglePlayItems,
   extraItems,
 }: MediaControlsMenuProps) {
   const tracksDisabled = tracksCount === 0;
@@ -70,6 +75,7 @@ export function MediaControlsMenu({
         >
           {isPlaying ? pauseLabel : playLabel}
         </MenubarItem>
+        {afterTogglePlayItems}
         <MenubarItem
           onClick={onPreviousTrack}
           className="text-md h-6 px-3"
@@ -100,13 +106,15 @@ export function MediaControlsMenu({
         >
           {repeatAllLabel}
         </MenubarCheckboxItem>
-        <MenubarCheckboxItem
-          checked={isLoopCurrent}
-          onCheckedChange={onToggleLoopCurrent}
-          className="text-md h-6 px-3"
-        >
-          {repeatOneLabel}
-        </MenubarCheckboxItem>
+        {onToggleLoopCurrent && (
+          <MenubarCheckboxItem
+            checked={isLoopCurrent ?? false}
+            onCheckedChange={onToggleLoopCurrent}
+            className="text-md h-6 px-3"
+          >
+            {repeatOneLabel}
+          </MenubarCheckboxItem>
+        )}
       </MenubarContent>
     </MenubarMenu>
   );


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Batch 4 of the parallelized fix round (menubar consolidation from the re-audit).

## Changes

- **Videos**: `VideosMenuBar` ran an unmemoized `reduce`+`sort` over the whole library on every render (iPod/Karaoke already memoize the identical grouping) — now uses the shared `groupTracksByArtist`/`getSortedArtistNames` memoized, and reuses `LibraryTrackBrowser` instead of ~86 lines of hand-rolled artist/all-videos submenus. `LibraryTrackBrowser` generalized minimally: generic `{ id, title, artist? }` items, `allItemsLabel`, `itemVariant: "checkbox" | "nowPlaying"` (Videos' exact ♪-prefix styling), `limitLargeLibraries` opt-out; iPod/Karaoke call sites untouched and render byte-identical JSX.
- **Winamp**: transport menu items migrate to the shared `MediaControlsMenu` (new optional `afterTogglePlayItems` slot keeps Winamp's Stop item in its original position; repeat-one block made optional so Winamp's single Repeat toggle maps to loop-all). Labels/order/classes unchanged.
- **Declarative descriptors** (`src/components/shared/menubar/AppMenuBarMenus.tsx`): `MenuDescriptor` types (action/separator/checkbox/submenu) rendered with the existing `menubarStyles` constants. Proof-of-concept migration of the three most mechanical menubars: **Minesweeper**, **Control Panels**, **Contacts** (net −41 lines across them). TV (uses `MenubarRadioGroup`) and Maps (one-off conditional classes) were deliberately skipped rather than growing the descriptor vocabulary.

Net: 420 insertions / 303 deletions across 8 files, with the descriptor + generalized browser now available for migrating further apps incrementally.

## Testing

- ✅ `bunx tsc -b --force` — clean (verified in an isolated worktree of the pushed branch)
- ✅ `bun run test:unit` — 310 pass / 0 fail
- ✅ `bunx eslint` on the 8 changed files — 0 errors, 0 warnings
- ⚠️ No GUI verification (per repo testing guidelines); visual parity was enforced by keeping class strings, item order, labels, and DOM structure identical — worth a quick menubar click-through on Videos/Winamp/Contacts when reviewing
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-819f5fdd-4d5f-4944-83d4-bde8c75427ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-819f5fdd-4d5f-4944-83d4-bde8c75427ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

