### PR TITLE
refactor(menubars): migrate remaining app menus to descriptors; add radio + submenu-disabled support

### DIFF
--- a/src/apps/admin/components/AdminMenuBar.tsx
+++ b/src/apps/admin/components/AdminMenuBar.tsx
@@ -1,17 +1,8 @@
-import {
-  MenubarCheckboxItem,
-  MenubarContent,
-  MenubarItem,
-  MenubarMenu,
-  MenubarSeparator,
-  MenubarTrigger,
-} from "@/components/ui/menubar";
 import { AppMenuBarShell } from "@/components/shared/menubar/AppMenuBarShell";
 import {
-  MENUBAR_ITEM_CLASS,
-  MENUBAR_SEPARATOR_CLASS,
-  MENUBAR_TRIGGER_CLASS,
-} from "@/components/shared/menubar/menubarStyles";
+  AppMenuBarMenus,
+  type MenuDescriptor,
+} from "@/components/shared/menubar/AppMenuBarMenus";
 import { useAppMenuBarChrome } from "@/hooks/useAppMenuBarChrome";
 import { useTranslation } from "react-i18next";
 import type { AdminSection } from "../utils/navigationState";
@@ -47,6 +38,57 @@ export function AdminMenuBar({
     appName,
   } = useAppMenuBarChrome("admin");
 
+  const sectionCheckbox = (section: AdminSection, label: string) =>
+    ({
+      type: "checkbox",
+      label,
+      checked: activeSection === section,
+      onChange: (checked: boolean) => {
+        if (checked) onSectionChange(section);
+      },
+    } as const);
+
+  const menus: MenuDescriptor[] = [
+    {
+      label: t("common.menu.file"),
+      items: [
+        {
+          type: "action",
+          label: t("apps.admin.menu.refreshData"),
+          onClick: onRefresh,
+        },
+        { type: "separator" },
+        { type: "action", label: t("common.menu.close"), onClick: onClose },
+      ],
+    },
+    {
+      label: t("common.menu.view"),
+      items: [
+        sectionCheckbox(
+          "dashboard",
+          t("apps.admin.sidebar.dashboard", "Dashboard")
+        ),
+        sectionCheckbox("users", t("apps.admin.sidebar.users")),
+        sectionCheckbox("songs", t("apps.admin.sidebar.songs")),
+        sectionCheckbox(
+          "cursorAgents",
+          t("apps.admin.sidebar.cursorAgents", "Cursor Agents")
+        ),
+        { type: "separator" },
+        sectionCheckbox("rooms", t("apps.admin.sidebar.rooms")),
+        { type: "separator" },
+        {
+          type: "checkbox",
+          label: t("apps.admin.menu.showSidebar"),
+          checked: isSidebarVisible,
+          onChange: (checked) => {
+            if (checked !== isSidebarVisible) onToggleSidebar();
+          },
+        },
+      ],
+    },
+  ];
+
   return (
     <AppMenuBarShell
       isXpTheme={isXpTheme}
@@ -60,88 +102,7 @@ export function AdminMenuBar({
       onShowHelp={onShowHelp}
       onShowAbout={onShowAbout}
     >
-      {/* File Menu */}
-      <MenubarMenu>
-        <MenubarTrigger className={MENUBAR_TRIGGER_CLASS}>
-          {t("common.menu.file")}
-        </MenubarTrigger>
-        <MenubarContent align="start" sideOffset={1} className="px-0">
-          <MenubarItem onClick={onRefresh} className={MENUBAR_ITEM_CLASS}>
-            {t("apps.admin.menu.refreshData")}
-          </MenubarItem>
-          <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
-          <MenubarItem onClick={onClose} className={MENUBAR_ITEM_CLASS}>
-            {t("common.menu.close")}
-          </MenubarItem>
-        </MenubarContent>
-      </MenubarMenu>
-
-      {/* View Menu */}
-      <MenubarMenu>
-        <MenubarTrigger className={MENUBAR_TRIGGER_CLASS}>
-          {t("common.menu.view")}
-        </MenubarTrigger>
-        <MenubarContent align="start" sideOffset={1} className="px-0">
-          {/* Section Selection */}
-          <MenubarCheckboxItem
-            checked={activeSection === "dashboard"}
-            onCheckedChange={(checked) => {
-              if (checked) onSectionChange("dashboard");
-            }}
-            className={MENUBAR_ITEM_CLASS}
-          >
-            {t("apps.admin.sidebar.dashboard", "Dashboard")}
-          </MenubarCheckboxItem>
-          <MenubarCheckboxItem
-            checked={activeSection === "users"}
-            onCheckedChange={(checked) => {
-              if (checked) onSectionChange("users");
-            }}
-            className={MENUBAR_ITEM_CLASS}
-          >
-            {t("apps.admin.sidebar.users")}
-          </MenubarCheckboxItem>
-          <MenubarCheckboxItem
-            checked={activeSection === "songs"}
-            onCheckedChange={(checked) => {
-              if (checked) onSectionChange("songs");
-            }}
-            className={MENUBAR_ITEM_CLASS}
-          >
-            {t("apps.admin.sidebar.songs")}
-          </MenubarCheckboxItem>
-          <MenubarCheckboxItem
-            checked={activeSection === "cursorAgents"}
-            onCheckedChange={(checked) => {
-              if (checked) onSectionChange("cursorAgents");
-            }}
-            className={MENUBAR_ITEM_CLASS}
-          >
-            {t("apps.admin.sidebar.cursorAgents", "Cursor Agents")}
-          </MenubarCheckboxItem>
-          <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
-          <MenubarCheckboxItem
-            checked={activeSection === "rooms"}
-            onCheckedChange={(checked) => {
-              if (checked) onSectionChange("rooms");
-            }}
-            className={MENUBAR_ITEM_CLASS}
-          >
-            {t("apps.admin.sidebar.rooms")}
-          </MenubarCheckboxItem>
-          <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
-          {/* Sidebar Toggle */}
-          <MenubarCheckboxItem
-            checked={isSidebarVisible}
-            onCheckedChange={(checked) => {
-              if (checked !== isSidebarVisible) onToggleSidebar();
-            }}
-            className={MENUBAR_ITEM_CLASS}
-          >
-            {t("apps.admin.menu.showSidebar")}
-          </MenubarCheckboxItem>
-        </MenubarContent>
-      </MenubarMenu>
+      <AppMenuBarMenus menus={menus} />
     </AppMenuBarShell>
   );
 }

--- a/src/apps/applet-viewer/components/AppletViewerMenuBar.tsx
+++ b/src/apps/applet-viewer/components/AppletViewerMenuBar.tsx
@@ -8,9 +8,12 @@ import {
   MenubarSub,
   MenubarSubTrigger,
   MenubarSubContent,
-  MenubarCheckboxItem,
 } from "@/components/ui/menubar";
 import { AppMenuBarShell } from "@/components/shared/menubar/AppMenuBarShell";
+import {
+  AppMenuBarMenus,
+  type MenuDescriptor,
+} from "@/components/shared/menubar/AppMenuBarMenus";
 import { MENUBAR_SEPARATOR_CLASS } from "@/components/shared/menubar/menubarStyles";
 import { useAppMenuBarChrome } from "@/hooks/useAppMenuBarChrome";
 import { useLaunchApp } from "@/hooks/useLaunchApp";
@@ -80,6 +83,100 @@ export function AppletViewerMenuBar({
   const isAuthenticated = useChatsStore((s) => s.isAuthenticated);
   const isLoggedIn = !!(username && isAuthenticated);
 
+  const menus: MenuDescriptor[] = [
+    {
+      label: t("apps.applet-viewer.menu.store"),
+      items: [
+        {
+          type: "action",
+          label: t("apps.applet-viewer.menu.openAppletStore"),
+          onClick: () =>
+            launchApp("applet-viewer", {
+              initialData: { path: "", content: "" },
+            }),
+        },
+        {
+          type: "action",
+          label:
+            updateCount > 0
+              ? updateCount === 1
+                ? t("apps.applet-viewer.menu.updateApplets", {
+                    count: updateCount,
+                  })
+                : t("apps.applet-viewer.menu.updateAppletsPlural", {
+                    count: updateCount,
+                  })
+              : t("apps.applet-viewer.menu.checkForUpdates"),
+          onClick: async () => {
+            if (updateCount > 0 && onUpdateAll) {
+              await onUpdateAll();
+            } else if (onCheckForUpdates) {
+              await onCheckForUpdates();
+            }
+          },
+        },
+        { type: "separator" },
+        ...(username && isAuthenticated
+          ? ([
+              {
+                type: "action",
+                label: t("apps.applet-viewer.menu.logOut"),
+                onClick: () => onLogout?.(),
+              },
+            ] as const)
+          : ([
+              {
+                type: "action",
+                label: t("apps.applet-viewer.menu.createAccount"),
+                onClick: () => onSetUsername?.(),
+              },
+              {
+                type: "action",
+                label: t("apps.applet-viewer.menu.login"),
+                onClick: () => onVerifyToken?.(),
+              },
+            ] as const)),
+      ],
+    },
+    {
+      label: t("apps.applet-viewer.menu.window"),
+      items:
+        appletInstances.length > 0
+          ? appletInstances.map((inst) => {
+              const initialData = inst.initialData as
+                | { path?: string; content?: string }
+                | undefined;
+              const path = initialData?.path || "";
+              const fileName = path
+                ? path
+                    .split("/")
+                    .pop()
+                    ?.replace(/\.(html|app)$/i, "") ||
+                  t("apps.applet-viewer.menu.untitled")
+                : t("apps.applet-viewer.menu.appletStore");
+              const isActive = inst.instanceId === instanceId;
+
+              return {
+                type: "checkbox" as const,
+                label: fileName,
+                checked: isActive,
+                onChange: (checked: boolean) => {
+                  if (checked) bringInstanceToForeground(inst.instanceId);
+                },
+              };
+            })
+          : [
+              {
+                type: "action" as const,
+                label: t("apps.applet-viewer.menu.noAppletsOpen"),
+                onClick: () => {},
+                disabled: true,
+                className: "opacity-50",
+              },
+            ],
+    },
+  ];
+
   return (
     <AppMenuBarShell
       isXpTheme={isXpTheme}
@@ -100,7 +197,8 @@ export function AppletViewerMenuBar({
         accept=".html,.htm,.app,.gz"
         className="hidden"
       />
-      {/* File Menu */}
+      {/* File menu stays hand-written: the Export As sub-content renders
+          without the px-0 class that the descriptor renderer always adds. */}
       <MenubarMenu>
         <MenubarTrigger className="text-md px-2 py-1 border-none focus-visible:ring-0">
           {t("common.menu.file")}
@@ -158,101 +256,7 @@ export function AppletViewerMenuBar({
         </MenubarContent>
       </MenubarMenu>
 
-      {/* Store Menu */}
-      <MenubarMenu>
-        <MenubarTrigger className="text-md px-2 py-1 border-none focus-visible:ring-0">
-          {t("apps.applet-viewer.menu.store")}
-        </MenubarTrigger>
-        <MenubarContent align="start" sideOffset={1} className="px-0">
-          <MenubarItem
-            onClick={() => launchApp("applet-viewer", { 
-              initialData: { path: "", content: "" } 
-            })}
-            className="text-md h-6 px-3"
-          >
-            {t("apps.applet-viewer.menu.openAppletStore")}
-          </MenubarItem>
-          <MenubarItem
-            onClick={async () => {
-              if (updateCount > 0 && onUpdateAll) {
-                await onUpdateAll();
-              } else if (onCheckForUpdates) {
-                await onCheckForUpdates();
-              }
-            }}
-            className="text-md h-6 px-3"
-          >
-            {updateCount > 0
-              ? updateCount === 1
-                ? t("apps.applet-viewer.menu.updateApplets", { count: updateCount })
-                : t("apps.applet-viewer.menu.updateAppletsPlural", { count: updateCount })
-              : t("apps.applet-viewer.menu.checkForUpdates")}
-          </MenubarItem>
-          <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
-          {username && isAuthenticated ? (
-            <MenubarItem
-              onClick={() => onLogout?.()}
-              className="text-md h-6 px-3"
-            >
-              {t("apps.applet-viewer.menu.logOut")}
-            </MenubarItem>
-          ) : (
-            <>
-              <MenubarItem
-                onClick={onSetUsername}
-                className="text-md h-6 px-3"
-              >
-                {t("apps.applet-viewer.menu.createAccount")}
-              </MenubarItem>
-              <MenubarItem
-                onClick={onVerifyToken}
-                className="text-md h-6 px-3"
-              >
-                {t("apps.applet-viewer.menu.login")}
-              </MenubarItem>
-            </>
-          )}
-        </MenubarContent>
-      </MenubarMenu>
-
-      {/* Window Menu */}
-      <MenubarMenu>
-        <MenubarTrigger className="px-2 py-1 text-md focus-visible:ring-0">
-          {t("apps.applet-viewer.menu.window")}
-        </MenubarTrigger>
-        <MenubarContent align="start" sideOffset={1} className="px-0">
-          {appletInstances.length > 0 ? (
-            appletInstances.map((inst) => {
-              const initialData = inst.initialData as { path?: string; content?: string } | undefined;
-              const path = initialData?.path || "";
-              const fileName = path
-                ? path
-                    .split("/")
-                    .pop()
-                    ?.replace(/\.(html|app)$/i, "") || t("apps.applet-viewer.menu.untitled")
-                : t("apps.applet-viewer.menu.appletStore");
-              const isActive = inst.instanceId === instanceId;
-
-              return (
-                <MenubarCheckboxItem
-                  key={inst.instanceId}
-                  checked={isActive}
-                  onCheckedChange={(checked) => {
-                    if (checked) bringInstanceToForeground(inst.instanceId);
-                  }}
-                  className="text-md h-6 px-3"
-                >
-                  {fileName}
-                </MenubarCheckboxItem>
-              );
-            })
-          ) : (
-            <MenubarItem disabled className="text-md h-6 px-3 opacity-50">
-              {t("apps.applet-viewer.menu.noAppletsOpen")}
-            </MenubarItem>
-          )}
-        </MenubarContent>
-      </MenubarMenu>
+      <AppMenuBarMenus menus={menus} />
     </AppMenuBarShell>
   );
 }

--- a/src/apps/calendar/components/CalendarMenuBar.tsx
+++ b/src/apps/calendar/components/CalendarMenuBar.tsx
@@ -1,19 +1,9 @@
-import {
-  MenubarMenu,
-  MenubarTrigger,
-  MenubarContent,
-  MenubarItem,
-  MenubarSeparator,
-  MenubarCheckboxItem,
-} from "@/components/ui/menubar";
 import { AppMenuBarShell } from "@/components/shared/menubar/AppMenuBarShell";
 import {
-  MENUBAR_ITEM_CLASS,
-  MENUBAR_SEPARATOR_CLASS,
-  MENUBAR_TRIGGER_CLASS,
-} from "@/components/shared/menubar/menubarStyles";
+  AppMenuBarMenus,
+  type MenuDescriptor,
+} from "@/components/shared/menubar/AppMenuBarMenus";
 import { useAppMenuBarChrome } from "@/hooks/useAppMenuBarChrome";
-import { cn } from "@/lib/utils";
 import { requestCloudSyncDomainCheck } from "@/utils/cloudSyncEvents";
 import { useTranslation } from "react-i18next";
 import type { CalendarView } from "@/stores/useCalendarStore";
@@ -65,6 +55,101 @@ export function CalendarMenuBar({
   } = useAppMenuBarChrome("calendar");
   const { canUndo, canRedo, undo, redo } = useInstanceUndoRedo(instanceId || "");
 
+  const viewCheckbox = (viewValue: CalendarView, label: string) =>
+    ({
+      type: "checkbox",
+      label,
+      checked: view === viewValue,
+      onChange: () => onSetView(viewValue),
+    } as const);
+
+  const menus: MenuDescriptor[] = [
+    {
+      label: t("common.menu.file"),
+      items: [
+        {
+          type: "action",
+          label: t("apps.calendar.menu.newEvent"),
+          onClick: onNewEvent,
+        },
+        { type: "separator" },
+        {
+          type: "action",
+          label: t("apps.calendar.menu.importFromDevice"),
+          onClick: onImport,
+        },
+        {
+          type: "action",
+          label: t("apps.calendar.menu.exportToIcs"),
+          onClick: onExport,
+        },
+        { type: "separator" },
+        {
+          type: "action",
+          label: t("apps.calendar.menu.syncCalendar", {
+            defaultValue: "Sync Calendar",
+          }),
+          onClick: () => requestCloudSyncDomainCheck("calendar"),
+        },
+        { type: "separator" },
+        { type: "action", label: t("common.menu.close"), onClick: onClose },
+      ],
+    },
+    {
+      label: t("common.menu.edit"),
+      items: [
+        {
+          type: "action",
+          label: t("common.menu.undo"),
+          onClick: undo,
+          disabled: !canUndo,
+          className: !canUndo ? "text-neutral-500" : "",
+        },
+        {
+          type: "action",
+          label: t("common.menu.redo"),
+          onClick: redo,
+          disabled: !canRedo,
+          className: !canRedo ? "text-neutral-500" : "",
+        },
+        { type: "separator" },
+        {
+          type: "action",
+          label: t("apps.calendar.menu.editEvent"),
+          onClick: onEditEvent,
+          disabled: !hasSelectedEvent,
+        },
+        {
+          type: "action",
+          label: t("apps.calendar.menu.deleteEvent"),
+          onClick: onDeleteEvent,
+          disabled: !hasSelectedEvent,
+        },
+      ],
+    },
+    {
+      label: t("common.menu.view"),
+      items: [
+        viewCheckbox("day", t("apps.calendar.menu.dayView")),
+        viewCheckbox("week", t("apps.calendar.menu.weekView")),
+        viewCheckbox("month", t("apps.calendar.menu.monthView")),
+        { type: "separator" },
+        {
+          type: "checkbox",
+          label: t("apps.calendar.menu.showToDoItems"),
+          checked: showTodoSidebar,
+          onChange: () => onToggleTodoSidebar(),
+        },
+        { type: "separator" },
+        {
+          type: "action",
+          label: t("apps.calendar.menu.goToToday"),
+          onClick: onGoToToday,
+        },
+      ],
+    },
+  ];
+
   return (
     <AppMenuBarShell
       isXpTheme={isXpTheme}
@@ -78,120 +163,7 @@ export function CalendarMenuBar({
       onShowHelp={onShowHelp}
       onShowAbout={onShowAbout}
     >
-      <MenubarMenu>
-        <MenubarTrigger className={MENUBAR_TRIGGER_CLASS}>
-          {t("common.menu.file")}
-        </MenubarTrigger>
-        <MenubarContent align="start" sideOffset={1} className="px-0">
-          <MenubarItem onClick={onNewEvent} className={MENUBAR_ITEM_CLASS}>
-            {t("apps.calendar.menu.newEvent")}
-          </MenubarItem>
-          <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
-          <MenubarItem onClick={onImport} className={MENUBAR_ITEM_CLASS}>
-            {t("apps.calendar.menu.importFromDevice")}
-          </MenubarItem>
-          <MenubarItem onClick={onExport} className={MENUBAR_ITEM_CLASS}>
-            {t("apps.calendar.menu.exportToIcs")}
-          </MenubarItem>
-          <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
-          <MenubarItem
-            onClick={() => requestCloudSyncDomainCheck("calendar")}
-            className={MENUBAR_ITEM_CLASS}
-          >
-            {t("apps.calendar.menu.syncCalendar", {
-              defaultValue: "Sync Calendar",
-            })}
-          </MenubarItem>
-          <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
-          <MenubarItem onClick={onClose} className={MENUBAR_ITEM_CLASS}>
-            {t("common.menu.close")}
-          </MenubarItem>
-        </MenubarContent>
-      </MenubarMenu>
-
-      <MenubarMenu>
-        <MenubarTrigger className={MENUBAR_TRIGGER_CLASS}>
-          {t("common.menu.edit")}
-        </MenubarTrigger>
-        <MenubarContent align="start" sideOffset={1} className="px-0">
-          <MenubarItem
-            onClick={undo}
-            disabled={!canUndo}
-            className={cn(
-              MENUBAR_ITEM_CLASS,
-              !canUndo ? "text-neutral-500" : "",
-            )}
-          >
-            {t("common.menu.undo")}
-          </MenubarItem>
-          <MenubarItem
-            onClick={redo}
-            disabled={!canRedo}
-            className={cn(
-              MENUBAR_ITEM_CLASS,
-              !canRedo ? "text-neutral-500" : "",
-            )}
-          >
-            {t("common.menu.redo")}
-          </MenubarItem>
-          <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
-          <MenubarItem
-            disabled={!hasSelectedEvent}
-            onClick={onEditEvent}
-            className={MENUBAR_ITEM_CLASS}
-          >
-            {t("apps.calendar.menu.editEvent")}
-          </MenubarItem>
-          <MenubarItem
-            disabled={!hasSelectedEvent}
-            onClick={onDeleteEvent}
-            className={MENUBAR_ITEM_CLASS}
-          >
-            {t("apps.calendar.menu.deleteEvent")}
-          </MenubarItem>
-        </MenubarContent>
-      </MenubarMenu>
-
-      <MenubarMenu>
-        <MenubarTrigger className={MENUBAR_TRIGGER_CLASS}>
-          {t("common.menu.view")}
-        </MenubarTrigger>
-        <MenubarContent align="start" sideOffset={1} className="px-0">
-          <MenubarCheckboxItem
-            checked={view === "day"}
-            onClick={() => onSetView("day")}
-            className={MENUBAR_ITEM_CLASS}
-          >
-            {t("apps.calendar.menu.dayView")}
-          </MenubarCheckboxItem>
-          <MenubarCheckboxItem
-            checked={view === "week"}
-            onClick={() => onSetView("week")}
-            className={MENUBAR_ITEM_CLASS}
-          >
-            {t("apps.calendar.menu.weekView")}
-          </MenubarCheckboxItem>
-          <MenubarCheckboxItem
-            checked={view === "month"}
-            onClick={() => onSetView("month")}
-            className={MENUBAR_ITEM_CLASS}
-          >
-            {t("apps.calendar.menu.monthView")}
-          </MenubarCheckboxItem>
-          <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
-          <MenubarCheckboxItem
-            checked={showTodoSidebar}
-            onClick={onToggleTodoSidebar}
-            className={MENUBAR_ITEM_CLASS}
-          >
-            {t("apps.calendar.menu.showToDoItems")}
-          </MenubarCheckboxItem>
-          <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
-          <MenubarItem onClick={onGoToToday} className={MENUBAR_ITEM_CLASS}>
-            {t("apps.calendar.menu.goToToday")}
-          </MenubarItem>
-        </MenubarContent>
-      </MenubarMenu>
+      <AppMenuBarMenus menus={menus} />
     </AppMenuBarShell>
   );
 }

--- a/src/apps/dashboard/components/DashboardMenuBar.tsx
+++ b/src/apps/dashboard/components/DashboardMenuBar.tsx
@@ -1,21 +1,10 @@
-import {
-  MenubarMenu,
-  MenubarTrigger,
-  MenubarContent,
-  MenubarItem,
-  MenubarSeparator,
-  MenubarSub,
-  MenubarSubTrigger,
-  MenubarSubContent,
-} from "@/components/ui/menubar";
 import { AppMenuBarShell } from "@/components/shared/menubar/AppMenuBarShell";
 import {
-  MENUBAR_ITEM_CLASS,
-  MENUBAR_SEPARATOR_CLASS,
-  MENUBAR_TRIGGER_CLASS,
-} from "@/components/shared/menubar/menubarStyles";
+  AppMenuBarMenus,
+  type MenuDescriptor,
+  type MenuItemDescriptor,
+} from "@/components/shared/menubar/AppMenuBarMenus";
 import { useAppMenuBarChrome } from "@/hooks/useAppMenuBarChrome";
-import { cn } from "@/lib/utils";
 import { useTranslation } from "react-i18next";
 import { Emoji } from "@/components/shared/Emoji";
 
@@ -37,7 +26,7 @@ interface DashboardMenuBarProps {
   onResetWidgets: () => void;
 }
 
-const WIDGET_MENU_ITEM_CLASS = cn(MENUBAR_ITEM_CLASS, "gap-1.5");
+const WIDGET_MENU_ITEM_CLASS = "gap-1.5";
 
 export function DashboardMenuBar({
   onClose,
@@ -66,6 +55,86 @@ export function DashboardMenuBar({
     appName,
   } = useAppMenuBarChrome("dashboard");
 
+  const widgetItem = (
+    emoji: string,
+    label: string,
+    onClick: () => void
+  ): MenuItemDescriptor => ({
+    type: "action",
+    label: (
+      <>
+        <Emoji emoji={emoji} size={14} />
+        {label}
+      </>
+    ),
+    onClick,
+    className: WIDGET_MENU_ITEM_CLASS,
+  });
+
+  const menus: MenuDescriptor[] = [
+    {
+      label: t("common.menu.file"),
+      items: [
+        {
+          type: "submenu",
+          label: t("apps.dashboard.menu.addWidget"),
+          items: [
+            widgetItem("🕐", t("apps.dashboard.widgets.clock"), onAddClock),
+            widgetItem(
+              "📅",
+              t("apps.dashboard.widgets.calendar"),
+              onAddCalendar
+            ),
+            widgetItem("🌤️", t("apps.dashboard.widgets.weather"), onAddWeather),
+            widgetItem("📈", t("apps.dashboard.widgets.stocks"), onAddStocks),
+            widgetItem("🎵", t("apps.dashboard.widgets.ipod", "iPod"), onAddIpod),
+            widgetItem(
+              "🌐",
+              t("apps.dashboard.widgets.translation", "Translation"),
+              onAddTranslation
+            ),
+            widgetItem(
+              "💱",
+              t(
+                "apps.dashboard.widgets.currencyConverter",
+                "Currency Converter"
+              ),
+              onAddCurrency
+            ),
+            widgetItem(
+              "📝",
+              t("apps.dashboard.widgets.stickyNote", "Sticky Note"),
+              onAddStickyNote
+            ),
+            widgetItem(
+              "📖",
+              t("apps.dashboard.widgets.dictionary", "Dictionary"),
+              onAddDictionary
+            ),
+            widgetItem(
+              "🐠",
+              t("apps.dashboard.widgets.aquarium", "Aquarium"),
+              onAddAquarium
+            ),
+            widgetItem(
+              "🌿",
+              t("apps.dashboard.widgets.terrarium", "Terrarium"),
+              onAddTerrarium
+            ),
+          ],
+        },
+        { type: "separator" },
+        {
+          type: "action",
+          label: t("apps.dashboard.menu.resetWidgets"),
+          onClick: onResetWidgets,
+        },
+        { type: "separator" },
+        { type: "action", label: t("common.menu.close"), onClick: onClose },
+      ],
+    },
+  ];
+
   return (
     <AppMenuBarShell
       isXpTheme={isXpTheme}
@@ -79,84 +148,7 @@ export function DashboardMenuBar({
       onShowHelp={onShowHelp}
       onShowAbout={onShowAbout}
     >
-      <MenubarMenu>
-        <MenubarTrigger className={MENUBAR_TRIGGER_CLASS}>
-          {t("common.menu.file")}
-        </MenubarTrigger>
-        <MenubarContent align="start" sideOffset={1} className="px-0">
-          <MenubarSub>
-            <MenubarSubTrigger className={MENUBAR_ITEM_CLASS}>
-              {t("apps.dashboard.menu.addWidget")}
-            </MenubarSubTrigger>
-            <MenubarSubContent className="px-0">
-              <MenubarItem onClick={onAddClock} className={WIDGET_MENU_ITEM_CLASS}>
-                <Emoji emoji="🕐" size={14} />
-                {t("apps.dashboard.widgets.clock")}
-              </MenubarItem>
-              <MenubarItem onClick={onAddCalendar} className={WIDGET_MENU_ITEM_CLASS}>
-                <Emoji emoji="📅" size={14} />
-                {t("apps.dashboard.widgets.calendar")}
-              </MenubarItem>
-              <MenubarItem onClick={onAddWeather} className={WIDGET_MENU_ITEM_CLASS}>
-                <Emoji emoji="🌤️" size={14} />
-                {t("apps.dashboard.widgets.weather")}
-              </MenubarItem>
-              <MenubarItem onClick={onAddStocks} className={WIDGET_MENU_ITEM_CLASS}>
-                <Emoji emoji="📈" size={14} />
-                {t("apps.dashboard.widgets.stocks")}
-              </MenubarItem>
-              <MenubarItem onClick={onAddIpod} className={WIDGET_MENU_ITEM_CLASS}>
-                <Emoji emoji="🎵" size={14} />
-                {t("apps.dashboard.widgets.ipod", "iPod")}
-              </MenubarItem>
-              <MenubarItem
-                onClick={onAddTranslation}
-                className={WIDGET_MENU_ITEM_CLASS}
-              >
-                <Emoji emoji="🌐" size={14} />
-                {t("apps.dashboard.widgets.translation", "Translation")}
-              </MenubarItem>
-              <MenubarItem onClick={onAddCurrency} className={WIDGET_MENU_ITEM_CLASS}>
-                <Emoji emoji="💱" size={14} />
-                {t("apps.dashboard.widgets.currencyConverter", "Currency Converter")}
-              </MenubarItem>
-              <MenubarItem
-                onClick={onAddStickyNote}
-                className={WIDGET_MENU_ITEM_CLASS}
-              >
-                <Emoji emoji="📝" size={14} />
-                {t("apps.dashboard.widgets.stickyNote", "Sticky Note")}
-              </MenubarItem>
-              <MenubarItem
-                onClick={onAddDictionary}
-                className={WIDGET_MENU_ITEM_CLASS}
-              >
-                <Emoji emoji="📖" size={14} />
-                {t("apps.dashboard.widgets.dictionary", "Dictionary")}
-              </MenubarItem>
-              <MenubarItem onClick={onAddAquarium} className={WIDGET_MENU_ITEM_CLASS}>
-                <Emoji emoji="🐠" size={14} />
-                {t("apps.dashboard.widgets.aquarium", "Aquarium")}
-              </MenubarItem>
-              <MenubarItem
-                onClick={onAddTerrarium}
-                className={WIDGET_MENU_ITEM_CLASS}
-              >
-                <Emoji emoji="🌿" size={14} />
-                {t("apps.dashboard.widgets.terrarium", "Terrarium")}
-              </MenubarItem>
-            </MenubarSubContent>
-          </MenubarSub>
-          <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
-          <MenubarItem onClick={onResetWidgets} className={MENUBAR_ITEM_CLASS}>
-            {t("apps.dashboard.menu.resetWidgets")}
-          </MenubarItem>
-          <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
-          <MenubarItem onClick={onClose} className={MENUBAR_ITEM_CLASS}>
-            {t("common.menu.close")}
-          </MenubarItem>
-        </MenubarContent>
-      </MenubarMenu>
+      <AppMenuBarMenus menus={menus} />
     </AppMenuBarShell>
   );
 }

--- a/src/apps/infinite-mac/components/InfiniteMacMenuBar.tsx
+++ b/src/apps/infinite-mac/components/InfiniteMacMenuBar.tsx
@@ -1,20 +1,9 @@
-import {
-  MenubarMenu,
-  MenubarTrigger,
-  MenubarContent,
-  MenubarItem,
-  MenubarSeparator,
-  MenubarSub,
-  MenubarSubTrigger,
-  MenubarSubContent,
-  MenubarCheckboxItem,
-} from "@/components/ui/menubar";
 import { AppMenuBarShell } from "@/components/shared/menubar/AppMenuBarShell";
 import {
-  MENUBAR_ITEM_CLASS,
-  MENUBAR_SEPARATOR_CLASS,
-  MENUBAR_TRIGGER_CLASS,
-} from "@/components/shared/menubar/menubarStyles";
+  AppMenuBarMenus,
+  type MenuDescriptor,
+  type MenuItemDescriptor,
+} from "@/components/shared/menubar/AppMenuBarMenus";
 import { useAppMenuBarChrome } from "@/hooks/useAppMenuBarChrome";
 import { useTranslation } from "react-i18next";
 import type { ScaleOption } from "../hooks/useInfiniteMacLogic";
@@ -32,6 +21,12 @@ interface InfiniteMacMenuBarProps {
   isPaused: boolean;
   currentScale: ScaleOption;
 }
+
+const SCALE_OPTIONS: { scale: ScaleOption; label: string }[] = [
+  { scale: 1, label: "1x" },
+  { scale: 1.5, label: "1.5x" },
+  { scale: 2, label: "2x" },
+];
 
 export function InfiniteMacMenuBar({
   onClose,
@@ -56,6 +51,57 @@ export function InfiniteMacMenuBar({
     appName,
   } = useAppMenuBarChrome("infinite-mac");
 
+  const backToPresetsItems: MenuItemDescriptor[] = hasEmulator
+    ? [
+        {
+          type: "action",
+          label: t("apps.infinite-mac.menu.backToPresets"),
+          onClick: onBackToPresets,
+        },
+        { type: "separator" },
+      ]
+    : [];
+
+  const menus: MenuDescriptor[] = [
+    {
+      label: t("common.menu.file"),
+      items: [
+        ...backToPresetsItems,
+        { type: "action", label: t("common.menu.close"), onClick: onClose },
+      ],
+    },
+    {
+      label: t("common.menu.view"),
+      items: [
+        {
+          type: "submenu",
+          label: t("apps.infinite-mac.menu.scaling"),
+          items: SCALE_OPTIONS.map(({ scale, label }) => ({
+            type: "checkbox" as const,
+            label,
+            checked: currentScale === scale,
+            onChange: () => onSetScale(scale),
+          })),
+        },
+        { type: "separator" },
+        {
+          type: "action",
+          label: isPaused
+            ? t("apps.infinite-mac.menu.resume")
+            : t("apps.infinite-mac.menu.pause"),
+          onClick: isPaused ? onUnpause : onPause,
+          disabled: !hasEmulator,
+        },
+        {
+          type: "action",
+          label: t("apps.infinite-mac.menu.captureScreenshot"),
+          onClick: onCaptureScreenshot,
+          disabled: !hasEmulator,
+        },
+      ],
+    },
+  ];
+
   return (
     <AppMenuBarShell
       isXpTheme={isXpTheme}
@@ -69,77 +115,7 @@ export function InfiniteMacMenuBar({
       onShowHelp={onShowHelp}
       onShowAbout={onShowAbout}
     >
-      <MenubarMenu>
-        <MenubarTrigger className={MENUBAR_TRIGGER_CLASS}>
-          {t("common.menu.file")}
-        </MenubarTrigger>
-        <MenubarContent align="start" sideOffset={1} className="px-0">
-          {hasEmulator && (
-            <>
-              <MenubarItem onClick={onBackToPresets} className={MENUBAR_ITEM_CLASS}>
-                {t("apps.infinite-mac.menu.backToPresets")}
-              </MenubarItem>
-              <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
-            </>
-          )}
-          <MenubarItem onClick={onClose} className={MENUBAR_ITEM_CLASS}>
-            {t("common.menu.close")}
-          </MenubarItem>
-        </MenubarContent>
-      </MenubarMenu>
-
-      <MenubarMenu>
-        <MenubarTrigger className={MENUBAR_TRIGGER_CLASS}>
-          {t("common.menu.view")}
-        </MenubarTrigger>
-        <MenubarContent align="start" sideOffset={1} className="px-0">
-          <MenubarSub>
-            <MenubarSubTrigger className={MENUBAR_ITEM_CLASS}>
-              {t("apps.infinite-mac.menu.scaling")}
-            </MenubarSubTrigger>
-            <MenubarSubContent className="px-0">
-              <MenubarCheckboxItem
-                checked={currentScale === 1}
-                onCheckedChange={() => onSetScale(1)}
-                className={MENUBAR_ITEM_CLASS}
-              >
-                1x
-              </MenubarCheckboxItem>
-              <MenubarCheckboxItem
-                checked={currentScale === 1.5}
-                onCheckedChange={() => onSetScale(1.5)}
-                className={MENUBAR_ITEM_CLASS}
-              >
-                1.5x
-              </MenubarCheckboxItem>
-              <MenubarCheckboxItem
-                checked={currentScale === 2}
-                onCheckedChange={() => onSetScale(2)}
-                className={MENUBAR_ITEM_CLASS}
-              >
-                2x
-              </MenubarCheckboxItem>
-            </MenubarSubContent>
-          </MenubarSub>
-          <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
-          <MenubarItem
-            onClick={isPaused ? onUnpause : onPause}
-            className={MENUBAR_ITEM_CLASS}
-            disabled={!hasEmulator}
-          >
-            {isPaused
-              ? t("apps.infinite-mac.menu.resume")
-              : t("apps.infinite-mac.menu.pause")}
-          </MenubarItem>
-          <MenubarItem
-            onClick={onCaptureScreenshot}
-            className={MENUBAR_ITEM_CLASS}
-            disabled={!hasEmulator}
-          >
-            {t("apps.infinite-mac.menu.captureScreenshot")}
-          </MenubarItem>
-        </MenubarContent>
-      </MenubarMenu>
+      <AppMenuBarMenus menus={menus} />
     </AppMenuBarShell>
   );
 }

--- a/src/apps/infinite-pc/components/InfinitePcMenuBar.tsx
+++ b/src/apps/infinite-pc/components/InfinitePcMenuBar.tsx
@@ -1,15 +1,9 @@
-import {
-  MenubarMenu,
-  MenubarTrigger,
-  MenubarContent,
-  MenubarItem,
-  MenubarSeparator,
-  MenubarSub,
-  MenubarSubTrigger,
-  MenubarSubContent,
-} from "@/components/ui/menubar";
 import { AppMenuBarShell } from "@/components/shared/menubar/AppMenuBarShell";
-import { MENUBAR_SEPARATOR_CLASS } from "@/components/shared/menubar/menubarStyles";
+import {
+  AppMenuBarMenus,
+  type MenuDescriptor,
+  type MenuItemDescriptor,
+} from "@/components/shared/menubar/AppMenuBarMenus";
 import { useAppMenuBarChrome } from "@/hooks/useAppMenuBarChrome";
 import { useTranslation } from "react-i18next";
 import { Game, loadGames } from "@/stores/usePcStore";
@@ -76,6 +70,90 @@ export function InfinitePcMenuBar({
   const sensitivityOptions = [0.25, 0.5, 0.75, 1.0, 1.25, 1.5, 2.0];
 
   if (isGameRunning && selectedGame && onLoadGame && onReset) {
+    const gameMenus: MenuDescriptor[] = [
+      {
+        label: t("common.menu.file"),
+        items: [
+          {
+            type: "action",
+            label: t("apps.pc.menu.backToBrowse"),
+            onClick: onBackToBrowse,
+          },
+          { type: "separator" },
+          {
+            type: "submenu",
+            label: t("apps.pc.menu.loadGame"),
+            items: availableGames.map((game) => ({
+              type: "action" as const,
+              label: game.name,
+              onClick: () => onLoadGame(game),
+              className: selectedGame.id === game.id ? "bg-neutral-100" : "",
+            })),
+          },
+          { type: "separator" },
+          {
+            type: "action",
+            label: t("apps.pc.menu.saveState"),
+            onClick: () => onSaveState?.(),
+          },
+          {
+            type: "action",
+            label: t("apps.pc.menu.loadState"),
+            onClick: () => onLoadState?.(),
+          },
+          { type: "separator" },
+          {
+            type: "action",
+            label: t("apps.pc.menu.reset"),
+            onClick: onReset,
+          },
+          { type: "separator" },
+          { type: "action", label: t("common.menu.close"), onClick: onClose },
+        ],
+      },
+      {
+        label: t("apps.pc.menu.controls"),
+        items: [
+          {
+            type: "action",
+            label: t("apps.pc.menu.fullScreen"),
+            onClick: () => onSetDosFullScreen?.(!isDosFullScreen),
+          },
+          { type: "separator" },
+          {
+            type: "action",
+            label: t("apps.pc.menu.toggleMouseCapture"),
+            onClick: () => onSetMouseCapture?.(!isMouseCaptured),
+          },
+          {
+            type: "submenu",
+            label: t("apps.pc.menu.mouseSensitivity"),
+            items: sensitivityOptions.map((sensitivity) => ({
+              type: "action" as const,
+              label: `${sensitivity}x`,
+              onClick: () => onSetMouseSensitivity?.(sensitivity),
+              className:
+                mouseSensitivity === sensitivity ? "bg-neutral-100" : "",
+            })),
+          },
+          { type: "separator" },
+          {
+            type: "submenu",
+            label: t("apps.pc.menu.aspectRatio"),
+            items: renderAspects.map((aspect) => ({
+              type: "action" as const,
+              label: t(`apps.pc.aspectRatios.${aspect}`, {
+                defaultValue: aspect,
+              }),
+              onClick: () => onSetRenderAspect?.(aspect),
+              className:
+                currentRenderAspect === aspect ? "bg-neutral-100" : "",
+            })),
+          },
+        ],
+      },
+    ];
+
     return (
       <AppMenuBarShell
         isXpTheme={isXpTheme}
@@ -89,114 +167,48 @@ export function InfinitePcMenuBar({
         onShowHelp={onShowHelp}
         onShowAbout={onShowAbout}
       >
-        <MenubarMenu>
-          <MenubarTrigger className="text-md px-2 py-1 border-none focus-visible:ring-0">
-            {t("common.menu.file")}
-          </MenubarTrigger>
-          <MenubarContent align="start" sideOffset={1} className="px-0">
-            <MenubarItem
-              onClick={onBackToBrowse}
-              className="text-md h-6 px-3"
-            >
-              {t("apps.pc.menu.backToBrowse")}
-            </MenubarItem>
-            <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
-            <MenubarSub>
-              <MenubarSubTrigger className="text-md h-6 px-3">
-                {t("apps.pc.menu.loadGame")}
-              </MenubarSubTrigger>
-              <MenubarSubContent className="px-0">
-                {availableGames.map((game) => (
-                  <MenubarItem
-                    key={game.id}
-                    onClick={() => onLoadGame(game)}
-                    className={`text-md h-6 px-3 ${
-                      selectedGame.id === game.id ? "bg-neutral-100" : ""
-                    }`}
-                  >
-                    {game.name}
-                  </MenubarItem>
-                ))}
-              </MenubarSubContent>
-            </MenubarSub>
-            <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
-            <MenubarItem onClick={onSaveState} className="text-md h-6 px-3">
-              {t("apps.pc.menu.saveState")}
-            </MenubarItem>
-            <MenubarItem onClick={onLoadState} className="text-md h-6 px-3">
-              {t("apps.pc.menu.loadState")}
-            </MenubarItem>
-            <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
-            <MenubarItem onClick={onReset} className="text-md h-6 px-3">
-              {t("apps.pc.menu.reset")}
-            </MenubarItem>
-            <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
-            <MenubarItem onClick={onClose} className="text-md h-6 px-3">
-              {t("common.menu.close")}
-            </MenubarItem>
-          </MenubarContent>
-        </MenubarMenu>
-
-        <MenubarMenu>
-          <MenubarTrigger className="px-2 py-1 text-md focus-visible:ring-0">
-            {t("apps.pc.menu.controls")}
-          </MenubarTrigger>
-          <MenubarContent align="start" sideOffset={1} className="px-0">
-            <MenubarItem
-              onClick={() => onSetDosFullScreen?.(!isDosFullScreen)}
-              className="text-md h-6 px-3"
-            >
-              {t("apps.pc.menu.fullScreen")}
-            </MenubarItem>
-            <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
-            <MenubarItem
-              onClick={() => onSetMouseCapture?.(!isMouseCaptured)}
-              className="text-md h-6 px-3"
-            >
-              {t("apps.pc.menu.toggleMouseCapture")}
-            </MenubarItem>
-            <MenubarSub>
-              <MenubarSubTrigger className="text-md h-6 px-3">
-                {t("apps.pc.menu.mouseSensitivity")}
-              </MenubarSubTrigger>
-              <MenubarSubContent className="px-0">
-                {sensitivityOptions.map((sensitivity) => (
-                  <MenubarItem
-                    key={sensitivity}
-                    onClick={() => onSetMouseSensitivity?.(sensitivity)}
-                    className={`text-md h-6 px-3 ${
-                      mouseSensitivity === sensitivity ? "bg-neutral-100" : ""
-                    }`}
-                  >
-                    {sensitivity}x
-                  </MenubarItem>
-                ))}
-              </MenubarSubContent>
-            </MenubarSub>
-            <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
-            <MenubarSub>
-              <MenubarSubTrigger className="text-md h-6 px-3">
-                {t("apps.pc.menu.aspectRatio")}
-              </MenubarSubTrigger>
-              <MenubarSubContent className="px-0">
-                {renderAspects.map((aspect) => (
-                  <MenubarItem
-                    key={aspect}
-                    onClick={() => onSetRenderAspect?.(aspect)}
-                    className={`text-md h-6 px-3 ${
-                      currentRenderAspect === aspect ? "bg-neutral-100" : ""
-                    }`}
-                  >
-                    {t(`apps.pc.aspectRatios.${aspect}`, { defaultValue: aspect })}
-                  </MenubarItem>
-                ))}
-              </MenubarSubContent>
-            </MenubarSub>
-          </MenubarContent>
-        </MenubarMenu>
+        <AppMenuBarMenus menus={gameMenus} />
       </AppMenuBarShell>
     );
   }
+
+  const backToBrowseItems: MenuItemDescriptor[] = hasV86Session
+    ? [
+        {
+          type: "action",
+          label: t("apps.pc.menu.backToBrowse"),
+          onClick: onBackToBrowse,
+        },
+        { type: "separator" },
+      ]
+    : [];
+
+  const menus: MenuDescriptor[] = [
+    {
+      label: t("common.menu.file"),
+      items: [
+        ...backToBrowseItems,
+        { type: "action", label: t("common.menu.close"), onClick: onClose },
+      ],
+    },
+    {
+      label: t("common.menu.view"),
+      items: [
+        {
+          type: "action",
+          label: t("apps.pc.menu.fullScreen"),
+          onClick: onFullScreen,
+          disabled: !hasV86Session,
+        },
+        {
+          type: "action",
+          label: t("apps.pc.menu.captureScreenshot"),
+          onClick: onCaptureScreenshot,
+          disabled: !hasV86Session,
+        },
+      ],
+    },
+  ];
 
   return (
     <AppMenuBarShell
@@ -211,49 +223,7 @@ export function InfinitePcMenuBar({
       onShowHelp={onShowHelp}
       onShowAbout={onShowAbout}
     >
-      <MenubarMenu>
-        <MenubarTrigger className="text-md px-2 py-1 border-none focus-visible:ring-0">
-          {t("common.menu.file")}
-        </MenubarTrigger>
-        <MenubarContent align="start" sideOffset={1} className="px-0">
-          {hasV86Session && (
-            <>
-              <MenubarItem
-                onClick={onBackToBrowse}
-                className="text-md h-6 px-3"
-              >
-                {t("apps.pc.menu.backToBrowse")}
-              </MenubarItem>
-              <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
-            </>
-          )}
-          <MenubarItem onClick={onClose} className="text-md h-6 px-3">
-            {t("common.menu.close")}
-          </MenubarItem>
-        </MenubarContent>
-      </MenubarMenu>
-
-      <MenubarMenu>
-        <MenubarTrigger className="px-2 py-1 text-md focus-visible:ring-0">
-          {t("common.menu.view")}
-        </MenubarTrigger>
-        <MenubarContent align="start" sideOffset={1} className="px-0">
-          <MenubarItem
-            onClick={onFullScreen}
-            className="text-md h-6 px-3"
-            disabled={!hasV86Session}
-          >
-            {t("apps.pc.menu.fullScreen")}
-          </MenubarItem>
-          <MenubarItem
-            onClick={onCaptureScreenshot}
-            className="text-md h-6 px-3"
-            disabled={!hasV86Session}
-          >
-            {t("apps.pc.menu.captureScreenshot")}
-          </MenubarItem>
-        </MenubarContent>
-      </MenubarMenu>
+      <AppMenuBarMenus menus={menus} />
     </AppMenuBarShell>
   );
 }

--- a/src/apps/maps/components/MapsMenuBar.tsx
+++ b/src/apps/maps/components/MapsMenuBar.tsx
@@ -1,19 +1,9 @@
-import {
-  MenubarMenu,
-  MenubarTrigger,
-  MenubarContent,
-  MenubarItem,
-  MenubarSeparator,
-  MenubarCheckboxItem,
-} from "@/components/ui/menubar";
 import { AppMenuBarShell } from "@/components/shared/menubar/AppMenuBarShell";
 import {
-  MENUBAR_ITEM_CLASS,
-  MENUBAR_SEPARATOR_CLASS,
-  MENUBAR_TRIGGER_CLASS,
-} from "@/components/shared/menubar/menubarStyles";
+  AppMenuBarMenus,
+  type MenuDescriptor,
+} from "@/components/shared/menubar/AppMenuBarMenus";
 import { useAppMenuBarChrome } from "@/hooks/useAppMenuBarChrome";
-import { cn } from "@/lib/utils";
 import { useTranslation } from "react-i18next";
 import type { MapsMapType } from "../hooks/useMapsLogic";
 
@@ -26,6 +16,13 @@ interface MapsMenuBarProps {
   onSetMapType: (type: MapsMapType) => void;
   canUseMap: boolean;
 }
+
+const MAP_TYPES: Array<{ type: MapsMapType; labelKey: string }> = [
+  { type: "standard", labelKey: "apps.maps.menu.standard" },
+  { type: "hybrid", labelKey: "apps.maps.menu.hybrid" },
+  { type: "satellite", labelKey: "apps.maps.menu.satellite" },
+  { type: "mutedStandard", labelKey: "apps.maps.menu.mutedStandard" },
+];
 
 export function MapsMenuBar({
   onClose,
@@ -46,6 +43,33 @@ export function MapsMenuBar({
     appName,
   } = useAppMenuBarChrome("maps");
 
+  const menus: MenuDescriptor[] = [
+    {
+      label: t("common.menu.file"),
+      items: [
+        {
+          type: "action",
+          label: t("apps.maps.menu.locateMe"),
+          onClick: onLocateMe,
+          disabled: !canUseMap,
+          className: !canUseMap ? "text-neutral-500" : undefined,
+        },
+        { type: "separator" },
+        { type: "action", label: t("common.menu.close"), onClick: onClose },
+      ],
+    },
+    {
+      label: t("common.menu.view"),
+      // Checkbox items (not a radio group) to match the original rendering.
+      items: MAP_TYPES.map(({ type, labelKey }) => ({
+        type: "checkbox" as const,
+        label: t(labelKey),
+        checked: mapType === type,
+        onChange: () => onSetMapType(type),
+      })),
+    },
+  ];
+
   return (
     <AppMenuBarShell
       isXpTheme={isXpTheme}
@@ -59,63 +83,7 @@ export function MapsMenuBar({
       onShowHelp={onShowHelp}
       onShowAbout={onShowAbout}
     >
-      <MenubarMenu>
-        <MenubarTrigger className={MENUBAR_TRIGGER_CLASS}>
-          {t("common.menu.file")}
-        </MenubarTrigger>
-        <MenubarContent align="start" sideOffset={1} className="px-0">
-          <MenubarItem
-            onClick={onLocateMe}
-            disabled={!canUseMap}
-            className={cn(
-              MENUBAR_ITEM_CLASS,
-              !canUseMap ? "text-neutral-500" : "",
-            )}
-          >
-            {t("apps.maps.menu.locateMe")}
-          </MenubarItem>
-          <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
-          <MenubarItem onClick={onClose} className={MENUBAR_ITEM_CLASS}>
-            {t("common.menu.close")}
-          </MenubarItem>
-        </MenubarContent>
-      </MenubarMenu>
-
-      <MenubarMenu>
-        <MenubarTrigger className={MENUBAR_TRIGGER_CLASS}>
-          {t("common.menu.view")}
-        </MenubarTrigger>
-        <MenubarContent align="start" sideOffset={1} className="px-0">
-          <MenubarCheckboxItem
-            checked={mapType === "standard"}
-            onClick={() => onSetMapType("standard")}
-            className={MENUBAR_ITEM_CLASS}
-          >
-            {t("apps.maps.menu.standard")}
-          </MenubarCheckboxItem>
-          <MenubarCheckboxItem
-            checked={mapType === "hybrid"}
-            onClick={() => onSetMapType("hybrid")}
-            className={MENUBAR_ITEM_CLASS}
-          >
-            {t("apps.maps.menu.hybrid")}
-          </MenubarCheckboxItem>
-          <MenubarCheckboxItem
-            checked={mapType === "satellite"}
-            onClick={() => onSetMapType("satellite")}
-            className={MENUBAR_ITEM_CLASS}
-          >
-            {t("apps.maps.menu.satellite")}
-          </MenubarCheckboxItem>
-          <MenubarCheckboxItem
-            checked={mapType === "mutedStandard"}
-            onClick={() => onSetMapType("mutedStandard")}
-            className={MENUBAR_ITEM_CLASS}
-          >
-            {t("apps.maps.menu.mutedStandard")}
-          </MenubarCheckboxItem>
-        </MenubarContent>
-      </MenubarMenu>
+      <AppMenuBarMenus menus={menus} />
     </AppMenuBarShell>
   );
 }

--- a/src/apps/photo-booth/components/PhotoBoothMenuBar.tsx
+++ b/src/apps/photo-booth/components/PhotoBoothMenuBar.tsx
@@ -1,13 +1,8 @@
-import {
-  MenubarMenu,
-  MenubarTrigger,
-  MenubarContent,
-  MenubarItem,
-  MenubarSeparator,
-  MenubarCheckboxItem,
-} from "@/components/ui/menubar";
 import { AppMenuBarShell } from "@/components/shared/menubar/AppMenuBarShell";
-import { MENUBAR_SEPARATOR_CLASS } from "@/components/shared/menubar/menubarStyles";
+import {
+  AppMenuBarMenus,
+  type MenuDescriptor,
+} from "@/components/shared/menubar/AppMenuBarMenus";
 import { useAppMenuBarChrome } from "@/hooks/useAppMenuBarChrome";
 import { useTranslation } from "react-i18next";
 
@@ -54,6 +49,54 @@ export function PhotoBoothMenuBar({
     appName,
   } = useAppMenuBarChrome("photo-booth");
 
+  const menus: MenuDescriptor[] = [
+    {
+      label: t("common.menu.file"),
+      items: [
+        {
+          type: "action",
+          label: t("apps.photo-booth.menu.exportPhotos"),
+          onClick: onExportPhotos,
+        },
+        { type: "separator" },
+        {
+          type: "action",
+          label: t("apps.photo-booth.menu.clearAllPhotos"),
+          onClick: onClearPhotos,
+        },
+        { type: "separator" },
+        { type: "action", label: t("common.menu.close"), onClick: onClose },
+      ],
+    },
+    {
+      label: t("apps.photo-booth.menu.camera"),
+      items: availableCameras.map((camera) => ({
+        type: "checkbox" as const,
+        label:
+          camera.label ||
+          `${t("apps.photo-booth.menu.camera")} ${camera.deviceId.slice(
+            0,
+            4
+          )}`,
+        checked: selectedCameraId === camera.deviceId,
+        onChange: (checked: boolean) => {
+          if (checked) onCameraSelect(camera.deviceId);
+        },
+      })),
+    },
+    {
+      label: t("apps.photo-booth.menu.effects"),
+      items: effects.map((effect) => ({
+        type: "checkbox" as const,
+        label: t(`apps.photo-booth.effects.${effect.translationKey}`),
+        checked: selectedEffect.name === effect.name,
+        onChange: (checked: boolean) => {
+          if (checked) onEffectSelect(effect);
+        },
+      })),
+    },
+  ];
+
   return (
     <AppMenuBarShell
       isXpTheme={isXpTheme}
@@ -67,74 +110,7 @@ export function PhotoBoothMenuBar({
       onShowHelp={onShowHelp}
       onShowAbout={onShowAbout}
     >
-      {/* File Menu */}
-      <MenubarMenu>
-        <MenubarTrigger className="text-md px-2 py-1 border-none focus-visible:ring-0">
-          {t("common.menu.file")}
-        </MenubarTrigger>
-        <MenubarContent align="start" sideOffset={1} className="px-0">
-          <MenubarItem
-            onClick={onExportPhotos}
-            className="text-md h-6 px-3"
-          >
-            {t("apps.photo-booth.menu.exportPhotos")}
-          </MenubarItem>
-          <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
-          <MenubarItem
-            onClick={onClearPhotos}
-            className="text-md h-6 px-3"
-          >
-            {t("apps.photo-booth.menu.clearAllPhotos")}
-          </MenubarItem>
-          <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
-          <MenubarItem
-            onClick={onClose}
-            className="text-md h-6 px-3"
-          >
-            {t("common.menu.close")}
-          </MenubarItem>
-        </MenubarContent>
-      </MenubarMenu>
-
-      <MenubarMenu>
-        <MenubarTrigger className="text-md px-2 py-1 border-none focus-visible:ring-0">
-          {t("apps.photo-booth.menu.camera")}
-        </MenubarTrigger>
-        <MenubarContent align="start" sideOffset={1} className="px-0">
-          {availableCameras.map((camera) => (
-            <MenubarCheckboxItem
-              key={camera.deviceId}
-              checked={selectedCameraId === camera.deviceId}
-              onCheckedChange={(checked) => {
-                if (checked) onCameraSelect(camera.deviceId);
-              }}
-              className="text-md h-6 px-3"
-            >
-              {camera.label || `${t("apps.photo-booth.menu.camera")} ${camera.deviceId.slice(0, 4)}`}
-            </MenubarCheckboxItem>
-          ))}
-        </MenubarContent>
-      </MenubarMenu>
-
-      <MenubarMenu>
-        <MenubarTrigger className="text-md px-2 py-1 border-none focus-visible:ring-0">
-          {t("apps.photo-booth.menu.effects")}
-        </MenubarTrigger>
-        <MenubarContent align="start" sideOffset={1} className="px-0">
-          {effects.map((effect) => (
-            <MenubarCheckboxItem
-              key={effect.name}
-              checked={selectedEffect.name === effect.name}
-              onCheckedChange={(checked) => {
-                if (checked) onEffectSelect(effect);
-              }}
-              className="text-md h-6 px-3"
-            >
-              {t(`apps.photo-booth.effects.${effect.translationKey}`)}
-            </MenubarCheckboxItem>
-          ))}
-        </MenubarContent>
-      </MenubarMenu>
+      <AppMenuBarMenus menus={menus} />
     </AppMenuBarShell>
   );
 }

--- a/src/apps/soundboard/components/SoundboardMenuBar.tsx
+++ b/src/apps/soundboard/components/SoundboardMenuBar.tsx
@@ -1,15 +1,11 @@
-import {
-  MenubarMenu,
-  MenubarTrigger,
-  MenubarContent,
-  MenubarItem,
-  MenubarSeparator,
-  MenubarCheckboxItem,
-} from "@/components/ui/menubar";
 import { AppProps } from "../../base/types";
 import { useState, useEffect } from "react";
 import { AppMenuBarShell } from "@/components/shared/menubar/AppMenuBarShell";
-import { MENUBAR_SEPARATOR_CLASS } from "@/components/shared/menubar/menubarStyles";
+import {
+  AppMenuBarMenus,
+  type MenuDescriptor,
+  type MenuItemDescriptor,
+} from "@/components/shared/menubar/AppMenuBarMenus";
 import { useAppMenuBarChrome } from "@/hooks/useAppMenuBarChrome";
 import { useTranslation } from "react-i18next";
 
@@ -80,6 +76,82 @@ export function SoundboardMenuBar({
     };
   }, []);
 
+  const specialSoundboardsItems: MenuItemDescriptor[] = isOptionPressed
+    ? [
+        {
+          type: "action",
+          label: t("apps.soundboard.menu.loadSpecialSoundboards"),
+          onClick: () => onReloadAllSounds?.(),
+        },
+      ]
+    : [];
+
+  const menus: MenuDescriptor[] = [
+    {
+      label: t("common.menu.file"),
+      items: [
+        {
+          type: "action",
+          label: t("apps.soundboard.menu.newSoundboard"),
+          onClick: () => onNewBoard?.(),
+        },
+        { type: "separator" },
+        {
+          type: "action",
+          label: t("apps.soundboard.menu.importSoundboards"),
+          onClick: () => onImportBoard?.(),
+        },
+        {
+          type: "action",
+          label: t("apps.soundboard.menu.exportSoundboards"),
+          onClick: () => onExportBoard?.(),
+        },
+        {
+          type: "action",
+          label: t("apps.soundboard.menu.resetSoundboards"),
+          onClick: () => onReloadBoard?.(),
+        },
+        ...specialSoundboardsItems,
+        { type: "separator" },
+        { type: "action", label: t("common.menu.close"), onClick: onClose },
+      ],
+    },
+    {
+      label: t("common.menu.edit"),
+      items: [
+        {
+          type: "action",
+          label: t("apps.soundboard.menu.renameSoundboard"),
+          onClick: () => onRenameBoard?.(),
+        },
+        {
+          type: "action",
+          label: t("apps.soundboard.menu.deleteSoundboard"),
+          onClick: () => onDeleteBoard?.(),
+          disabled: !canDeleteBoard,
+          className: !canDeleteBoard ? "text-neutral-400" : undefined,
+        },
+      ],
+    },
+    {
+      label: t("common.menu.view"),
+      items: [
+        {
+          type: "checkbox",
+          label: t("apps.soundboard.menu.waveforms"),
+          checked: showWaveforms ?? false,
+          onChange: (checked) => onToggleWaveforms?.(checked),
+        },
+        {
+          type: "checkbox",
+          label: t("apps.soundboard.menu.emojis"),
+          checked: showEmojis ?? false,
+          onChange: (checked) => onToggleEmojis?.(checked),
+        },
+      ],
+    },
+  ];
+
   return (
     <AppMenuBarShell
       isXpTheme={isXpTheme}
@@ -93,103 +165,7 @@ export function SoundboardMenuBar({
       onShowHelp={onShowHelp}
       onShowAbout={onShowAbout}
     >
-      {/* File Menu */}
-      <MenubarMenu>
-        <MenubarTrigger className="text-md px-2 py-1 border-none focus-visible:ring-0">
-          {t("common.menu.file")}
-        </MenubarTrigger>
-        <MenubarContent align="start" sideOffset={1} className="px-0">
-          <MenubarItem
-            onClick={onNewBoard}
-            className="text-md h-6 px-3"
-          >
-            {t("apps.soundboard.menu.newSoundboard")}
-          </MenubarItem>
-          <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
-          <MenubarItem
-            onClick={onImportBoard}
-            className="text-md h-6 px-3"
-          >
-            {t("apps.soundboard.menu.importSoundboards")}
-          </MenubarItem>
-          <MenubarItem
-            onClick={onExportBoard}
-            className="text-md h-6 px-3"
-          >
-            {t("apps.soundboard.menu.exportSoundboards")}
-          </MenubarItem>
-          <MenubarItem
-            onClick={onReloadBoard}
-            className="text-md h-6 px-3"
-          >
-            {t("apps.soundboard.menu.resetSoundboards")}
-          </MenubarItem>
-          {isOptionPressed && (
-            <MenubarItem
-              onClick={onReloadAllSounds}
-              className="text-md h-6 px-3"
-            >
-              {t("apps.soundboard.menu.loadSpecialSoundboards")}
-            </MenubarItem>
-          )}
-          <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
-          <MenubarItem
-            onClick={onClose}
-            className="text-md h-6 px-3"
-          >
-            {t("common.menu.close")}
-          </MenubarItem>
-        </MenubarContent>
-      </MenubarMenu>
-
-      {/* Edit Menu */}
-      <MenubarMenu>
-        <MenubarTrigger className="px-2 py-1 text-md focus-visible:ring-0">
-          {t("common.menu.edit")}
-        </MenubarTrigger>
-        <MenubarContent align="start" sideOffset={1} className="px-0">
-          <MenubarItem
-            onClick={onRenameBoard}
-            className="text-md h-6 px-3"
-          >
-            {t("apps.soundboard.menu.renameSoundboard")}
-          </MenubarItem>
-          <MenubarItem
-            onClick={onDeleteBoard}
-            disabled={!canDeleteBoard}
-            className={
-              !canDeleteBoard
-                ? "text-neutral-400 text-md h-6 px-3"
-                : "text-md h-6 px-3"
-            }
-          >
-            {t("apps.soundboard.menu.deleteSoundboard")}
-          </MenubarItem>
-        </MenubarContent>
-      </MenubarMenu>
-
-      {/* View Menu */}
-      <MenubarMenu>
-        <MenubarTrigger className="px-2 py-1 text-md focus-visible:ring-0">
-          {t("common.menu.view")}
-        </MenubarTrigger>
-        <MenubarContent align="start" sideOffset={1} className="px-0">
-          <MenubarCheckboxItem
-            checked={showWaveforms ?? false}
-            onCheckedChange={(checked) => onToggleWaveforms?.(checked)}
-            className="text-md h-6 px-3"
-          >
-            {t("apps.soundboard.menu.waveforms")}
-          </MenubarCheckboxItem>
-          <MenubarCheckboxItem
-            checked={showEmojis ?? false}
-            onCheckedChange={(checked) => onToggleEmojis?.(checked)}
-            className="text-md h-6 px-3"
-          >
-            {t("apps.soundboard.menu.emojis")}
-          </MenubarCheckboxItem>
-        </MenubarContent>
-      </MenubarMenu>
+      <AppMenuBarMenus menus={menus} />
     </AppMenuBarShell>
   );
 }

--- a/src/apps/stickies/components/StickiesMenuBar.tsx
+++ b/src/apps/stickies/components/StickiesMenuBar.tsx
@@ -1,19 +1,8 @@
-import {
-  MenubarMenu,
-  MenubarTrigger,
-  MenubarContent,
-  MenubarItem,
-  MenubarSeparator,
-  MenubarSub,
-  MenubarSubTrigger,
-  MenubarSubContent,
-} from "@/components/ui/menubar";
 import { AppMenuBarShell } from "@/components/shared/menubar/AppMenuBarShell";
 import {
-  MENUBAR_ITEM_CLASS,
-  MENUBAR_SEPARATOR_CLASS,
-  MENUBAR_TRIGGER_CLASS,
-} from "@/components/shared/menubar/menubarStyles";
+  AppMenuBarMenus,
+  type MenuDescriptor,
+} from "@/components/shared/menubar/AppMenuBarMenus";
 import { useAppMenuBarChrome } from "@/hooks/useAppMenuBarChrome";
 import { requestCloudSyncDomainCheck } from "@/utils/cloudSyncEvents";
 import { useTranslation } from "react-i18next";
@@ -59,6 +48,67 @@ export function StickiesMenuBar({
     appName,
   } = useAppMenuBarChrome("stickies");
 
+  const menus: MenuDescriptor[] = [
+    {
+      label: t("common.menu.file"),
+      items: [
+        {
+          type: "action",
+          label: t("apps.stickies.menu.newNote"),
+          onClick: () => onNewNote(),
+        },
+        { type: "separator" },
+        {
+          type: "action",
+          label: t("apps.stickies.menu.clearAll"),
+          onClick: onClearAll,
+        },
+        { type: "separator" },
+        {
+          type: "action",
+          label: t("apps.stickies.menu.syncStickies", {
+            defaultValue: "Sync Stickies",
+          }),
+          onClick: () => requestCloudSyncDomainCheck("stickies"),
+        },
+        { type: "separator" },
+        { type: "action", label: t("common.menu.close"), onClick: onClose },
+      ],
+    },
+    {
+      label: t("apps.stickies.menu.note"),
+      items: [
+        {
+          type: "submenu",
+          label: t("apps.stickies.menu.color"),
+          disabled: !selectedNoteId,
+          items: COLORS.map((color) => ({
+            type: "action" as const,
+            label: (
+              <>
+                <span
+                  className="w-4 h-3 border border-black/30 inline-block"
+                  style={{ backgroundColor: color.hex }}
+                />
+                {t(color.labelKey)}
+              </>
+            ),
+            onClick: () =>
+              selectedNoteId && onChangeColor(selectedNoteId, color.value),
+            className: "flex items-center gap-2",
+          })),
+        },
+        { type: "separator" },
+        {
+          type: "action",
+          label: t("apps.stickies.menu.deleteNote"),
+          onClick: () => selectedNoteId && onDeleteNote(selectedNoteId),
+          disabled: !selectedNoteId,
+        },
+      ],
+    },
+  ];
+
   return (
     <AppMenuBarShell
       isXpTheme={isXpTheme}
@@ -72,74 +122,7 @@ export function StickiesMenuBar({
       onShowHelp={onShowHelp}
       onShowAbout={onShowAbout}
     >
-      <MenubarMenu>
-        <MenubarTrigger className={MENUBAR_TRIGGER_CLASS}>
-          {t("common.menu.file")}
-        </MenubarTrigger>
-        <MenubarContent align="start" sideOffset={1} className="px-0">
-          <MenubarItem onClick={() => onNewNote()} className={MENUBAR_ITEM_CLASS}>
-            {t("apps.stickies.menu.newNote")}
-          </MenubarItem>
-          <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
-          <MenubarItem onClick={onClearAll} className={MENUBAR_ITEM_CLASS}>
-            {t("apps.stickies.menu.clearAll")}
-          </MenubarItem>
-          <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
-          <MenubarItem
-            onClick={() => requestCloudSyncDomainCheck("stickies")}
-            className={MENUBAR_ITEM_CLASS}
-          >
-            {t("apps.stickies.menu.syncStickies", {
-              defaultValue: "Sync Stickies",
-            })}
-          </MenubarItem>
-          <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
-          <MenubarItem onClick={onClose} className={MENUBAR_ITEM_CLASS}>
-            {t("common.menu.close")}
-          </MenubarItem>
-        </MenubarContent>
-      </MenubarMenu>
-
-      <MenubarMenu>
-        <MenubarTrigger className={MENUBAR_TRIGGER_CLASS}>
-          {t("apps.stickies.menu.note")}
-        </MenubarTrigger>
-        <MenubarContent align="start" sideOffset={1} className="px-0">
-          <MenubarSub>
-            <MenubarSubTrigger
-              disabled={!selectedNoteId}
-              className={MENUBAR_ITEM_CLASS}
-            >
-              {t("apps.stickies.menu.color")}
-            </MenubarSubTrigger>
-            <MenubarSubContent className="px-0">
-              {COLORS.map((color) => (
-                <MenubarItem
-                  key={color.value}
-                  onClick={() =>
-                    selectedNoteId && onChangeColor(selectedNoteId, color.value)
-                  }
-                  className={`${MENUBAR_ITEM_CLASS} flex items-center gap-2`}
-                >
-                  <span
-                    className="w-4 h-3 border border-black/30 inline-block"
-                    style={{ backgroundColor: color.hex }}
-                  />
-                  {t(color.labelKey)}
-                </MenubarItem>
-              ))}
-            </MenubarSubContent>
-          </MenubarSub>
-          <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
-          <MenubarItem
-            disabled={!selectedNoteId}
-            onClick={() => selectedNoteId && onDeleteNote(selectedNoteId)}
-            className={MENUBAR_ITEM_CLASS}
-          >
-            {t("apps.stickies.menu.deleteNote")}
-          </MenubarItem>
-        </MenubarContent>
-      </MenubarMenu>
+      <AppMenuBarMenus menus={menus} />
     </AppMenuBarShell>
   );
 }

--- a/src/apps/synth/components/SynthMenuBar.tsx
+++ b/src/apps/synth/components/SynthMenuBar.tsx
@@ -1,13 +1,8 @@
-import {
-  MenubarMenu,
-  MenubarTrigger,
-  MenubarContent,
-  MenubarItem,
-  MenubarSeparator,
-  MenubarCheckboxItem,
-} from "@/components/ui/menubar";
 import { AppMenuBarShell } from "@/components/shared/menubar/AppMenuBarShell";
-import { MENUBAR_SEPARATOR_CLASS } from "@/components/shared/menubar/menubarStyles";
+import {
+  AppMenuBarMenus,
+  type MenuDescriptor,
+} from "@/components/shared/menubar/AppMenuBarMenus";
 import { useAppMenuBarChrome } from "@/hooks/useAppMenuBarChrome";
 import type { NoteLabelType } from "@/stores/useSynthStore";
 import { useTranslation } from "react-i18next";
@@ -47,6 +42,55 @@ export function SynthMenuBar({
     appName,
   } = useAppMenuBarChrome("synth");
 
+  const labelCheckbox = (type: NoteLabelType, label: string) =>
+    ({
+      type: "checkbox",
+      label,
+      checked: labelType === type,
+      onChange: (checked: boolean) => {
+        if (checked) onLabelTypeChange(type);
+      },
+    } as const);
+
+  const menus: MenuDescriptor[] = [
+    {
+      label: t("common.menu.file"),
+      items: [
+        {
+          type: "action",
+          label: t("apps.synth.menu.newPreset"),
+          onClick: onAddPreset,
+        },
+        {
+          type: "action",
+          label: t("apps.synth.menu.resetSynth"),
+          onClick: onReset,
+        },
+        { type: "separator" },
+        { type: "action", label: t("common.menu.close"), onClick: onClose },
+      ],
+    },
+    {
+      label: t("apps.synth.menu.presets"),
+      items: presets.map((preset) => ({
+        type: "checkbox" as const,
+        label: preset.name,
+        checked: currentPresetId === preset.id,
+        onChange: (checked: boolean) => {
+          if (checked) onLoadPresetById(preset.id);
+        },
+      })),
+    },
+    {
+      label: t("common.menu.view"),
+      items: [
+        labelCheckbox("note", t("apps.synth.menu.noteLabels")),
+        labelCheckbox("key", t("apps.synth.menu.keyLabels")),
+        labelCheckbox("off", t("apps.synth.menu.noLabels")),
+      ],
+    },
+  ];
+
   return (
     <AppMenuBarShell
       isXpTheme={isXpTheme}
@@ -60,91 +104,7 @@ export function SynthMenuBar({
       onShowHelp={onShowHelp}
       onShowAbout={onShowAbout}
     >
-      {/* File Menu */}
-      <MenubarMenu>
-        <MenubarTrigger className="text-md px-2 py-1 border-none focus-visible:ring-0">
-          {t("common.menu.file")}
-        </MenubarTrigger>
-        <MenubarContent align="start" sideOffset={1} className="px-0">
-          <MenubarItem
-            onClick={onAddPreset}
-            className="text-md h-6 px-3"
-          >
-            {t("apps.synth.menu.newPreset")}
-          </MenubarItem>
-          <MenubarItem
-            onClick={onReset}
-            className="text-md h-6 px-3"
-          >
-            {t("apps.synth.menu.resetSynth")}
-          </MenubarItem>
-          <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
-          <MenubarItem
-            onClick={onClose}
-            className="text-md h-6 px-3"
-          >
-            {t("common.menu.close")}
-          </MenubarItem>
-        </MenubarContent>
-      </MenubarMenu>
-
-      {/* Presets Menu */}
-      <MenubarMenu>
-        <MenubarTrigger className="text-md px-2 py-1 border-none focus-visible:ring-0">
-          {t("apps.synth.menu.presets")}
-        </MenubarTrigger>
-        <MenubarContent align="start" sideOffset={1} className="px-0">
-          {presets.map((preset) => (
-            <MenubarCheckboxItem
-              key={preset.id}
-              checked={currentPresetId === preset.id}
-              onCheckedChange={(checked) => {
-                if (checked) onLoadPresetById(preset.id);
-              }}
-              className="text-md h-6 px-3"
-            >
-              {preset.name}
-            </MenubarCheckboxItem>
-          ))}
-        </MenubarContent>
-      </MenubarMenu>
-
-      {/* View Menu */}
-      <MenubarMenu>
-        <MenubarTrigger className="text-md px-2 py-1 border-none focus-visible:ring-0">
-          {t("common.menu.view")}
-        </MenubarTrigger>
-        <MenubarContent align="start" sideOffset={1} className="px-0">
-          <MenubarCheckboxItem
-            checked={labelType === "note"}
-            onCheckedChange={(checked) => {
-              if (checked) onLabelTypeChange("note");
-            }}
-            className="text-md h-6 px-3"
-          >
-            {t("apps.synth.menu.noteLabels")}
-          </MenubarCheckboxItem>
-          <MenubarCheckboxItem
-            checked={labelType === "key"}
-            onCheckedChange={(checked) => {
-              if (checked) onLabelTypeChange("key");
-            }}
-            className="text-md h-6 px-3"
-          >
-            {t("apps.synth.menu.keyLabels")}
-          </MenubarCheckboxItem>
-          <MenubarCheckboxItem
-            checked={labelType === "off"}
-            onCheckedChange={(checked) => {
-              if (checked) onLabelTypeChange("off");
-            }}
-            className="text-md h-6 px-3"
-          >
-            {t("apps.synth.menu.noLabels")}
-          </MenubarCheckboxItem>
-        </MenubarContent>
-      </MenubarMenu>
-
+      <AppMenuBarMenus menus={menus} />
     </AppMenuBarShell>
   );
 }

--- a/src/apps/terminal/components/TerminalMenuBar.tsx
+++ b/src/apps/terminal/components/TerminalMenuBar.tsx
@@ -1,13 +1,9 @@
-import {
-  MenubarMenu,
-  MenubarTrigger,
-  MenubarContent,
-  MenubarItem,
-  MenubarSeparator,
-  MenubarCheckboxItem,
-} from "@/components/ui/menubar";
 import { AppMenuBarShell } from "@/components/shared/menubar/AppMenuBarShell";
-import { MENUBAR_SEPARATOR_CLASS } from "@/components/shared/menubar/menubarStyles";
+import {
+  AppMenuBarMenus,
+  type MenuDescriptor,
+  type MenuItemDescriptor,
+} from "@/components/shared/menubar/AppMenuBarMenus";
 import { useAppMenuBarChrome } from "@/hooks/useAppMenuBarChrome";
 import { useTranslation } from "react-i18next";
 
@@ -44,6 +40,70 @@ export function TerminalMenuBar({
     appName,
   } = useAppMenuBarChrome("terminal");
 
+  const muteItems: MenuItemDescriptor[] = onToggleMute
+    ? [
+        { type: "separator" },
+        {
+          type: "checkbox",
+          label: t("apps.terminal.menu.muteSounds"),
+          checked: isMuted,
+          onChange: (checked) => {
+            if (checked !== isMuted) onToggleMute();
+          },
+        },
+      ]
+    : [];
+
+  const menus: MenuDescriptor[] = [
+    {
+      label: t("common.menu.file"),
+      items: [
+        {
+          type: "action",
+          label: t("apps.terminal.menu.clearTerminal"),
+          onClick: onClear,
+        },
+        { type: "separator" },
+        { type: "action", label: t("common.menu.close"), onClick: onClose },
+      ],
+    },
+    {
+      label: t("common.menu.edit"),
+      items: [
+        { type: "action", label: t("common.menu.copy"), onClick: () => {} },
+        { type: "action", label: t("common.menu.paste"), onClick: () => {} },
+        { type: "separator" },
+        {
+          type: "action",
+          label: t("common.menu.selectAll"),
+          onClick: () => {},
+        },
+      ],
+    },
+    {
+      label: t("common.menu.view"),
+      items: [
+        {
+          type: "action",
+          label: t("apps.terminal.menu.increaseFontSize"),
+          onClick: onIncreaseFontSize,
+        },
+        {
+          type: "action",
+          label: t("apps.terminal.menu.decreaseFontSize"),
+          onClick: onDecreaseFontSize,
+        },
+        { type: "separator" },
+        {
+          type: "action",
+          label: t("apps.terminal.menu.resetFontSize"),
+          onClick: onResetFontSize,
+        },
+        ...muteItems,
+      ],
+    },
+  ];
+
   return (
     <AppMenuBarShell
       isXpTheme={isXpTheme}
@@ -57,89 +117,7 @@ export function TerminalMenuBar({
       onShowHelp={onShowHelp}
       onShowAbout={onShowAbout}
     >
-      {/* File Menu */}
-      <MenubarMenu>
-        <MenubarTrigger className="text-md px-2 py-1 border-none focus-visible:ring-0">
-          {t("common.menu.file")}
-        </MenubarTrigger>
-        <MenubarContent align="start" sideOffset={1} className="px-0">
-          <MenubarItem
-            onClick={onClear}
-            className="text-md h-6 px-3"
-          >
-            {t("apps.terminal.menu.clearTerminal")}
-          </MenubarItem>
-          <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
-          <MenubarItem
-            onClick={onClose}
-            className="text-md h-6 px-3"
-          >
-            {t("common.menu.close")}
-          </MenubarItem>
-        </MenubarContent>
-      </MenubarMenu>
-
-      {/* Edit Menu */}
-      <MenubarMenu>
-        <MenubarTrigger className="text-md px-2 py-1 border-none focus-visible:ring-0">
-          {t("common.menu.edit")}
-        </MenubarTrigger>
-        <MenubarContent align="start" sideOffset={1} className="px-0">
-          <MenubarItem className="text-md h-6 px-3">
-            {t("common.menu.copy")}
-          </MenubarItem>
-          <MenubarItem className="text-md h-6 px-3">
-            {t("common.menu.paste")}
-          </MenubarItem>
-          <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
-          <MenubarItem className="text-md h-6 px-3">
-            {t("common.menu.selectAll")}
-          </MenubarItem>
-        </MenubarContent>
-      </MenubarMenu>
-
-      {/* View Menu */}
-      <MenubarMenu>
-        <MenubarTrigger className="text-md px-2 py-1 border-none focus-visible:ring-0">
-          {t("common.menu.view")}
-        </MenubarTrigger>
-        <MenubarContent align="start" sideOffset={1} className="px-0">
-          <MenubarItem
-            onClick={onIncreaseFontSize}
-            className="text-md h-6 px-3"
-          >
-            {t("apps.terminal.menu.increaseFontSize")}
-          </MenubarItem>
-          <MenubarItem
-            onClick={onDecreaseFontSize}
-            className="text-md h-6 px-3"
-          >
-            {t("apps.terminal.menu.decreaseFontSize")}
-          </MenubarItem>
-          <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
-          <MenubarItem
-            onClick={onResetFontSize}
-            className="text-md h-6 px-3"
-          >
-            {t("apps.terminal.menu.resetFontSize")}
-          </MenubarItem>
-          {onToggleMute && (
-            <>
-              <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
-              <MenubarCheckboxItem
-                checked={isMuted}
-                onCheckedChange={(checked) => {
-                  if (checked !== isMuted) onToggleMute();
-                }}
-                className="text-md h-6 px-3"
-              >
-                {t("apps.terminal.menu.muteSounds")}
-              </MenubarCheckboxItem>
-            </>
-          )}
-        </MenubarContent>
-      </MenubarMenu>
-
+      <AppMenuBarMenus menus={menus} />
     </AppMenuBarShell>
   );
 }

--- a/src/apps/tv/components/TvMenuBar.tsx
+++ b/src/apps/tv/components/TvMenuBar.tsx
@@ -1,19 +1,8 @@
-import {
-  MenubarMenu,
-  MenubarTrigger,
-  MenubarContent,
-  MenubarItem,
-  MenubarCheckboxItem,
-  MenubarSeparator,
-  MenubarRadioGroup,
-  MenubarRadioItem,
-} from "@/components/ui/menubar";
 import { AppMenuBarShell } from "@/components/shared/menubar/AppMenuBarShell";
 import {
-  MENUBAR_ITEM_CLASS,
-  MENUBAR_SEPARATOR_CLASS,
-  MENUBAR_TRIGGER_CLASS,
-} from "@/components/shared/menubar/menubarStyles";
+  AppMenuBarMenus,
+  type MenuDescriptor,
+} from "@/components/shared/menubar/AppMenuBarMenus";
 import { useAppMenuBarChrome } from "@/hooks/useAppMenuBarChrome";
 import { useTranslation } from "react-i18next";
 import type { Channel } from "@/apps/tv/data/channels";
@@ -85,6 +74,118 @@ export function TvMenuBar({
     appName,
   } = useAppMenuBarChrome("tv");
 
+  const menus: MenuDescriptor[] = [
+    {
+      label: t("common.menu.file"),
+      items: [
+        {
+          type: "action",
+          label: t("apps.tv.menu.newChannel"),
+          onClick: onCreateChannel,
+        },
+        { type: "separator" },
+        {
+          type: "action",
+          label: t("apps.tv.menu.exportChannels"),
+          onClick: onExportChannels,
+          disabled: !hasCustomChannels,
+        },
+        {
+          type: "action",
+          label: t("apps.tv.menu.importChannels"),
+          onClick: onImportChannels,
+        },
+        { type: "separator" },
+        { type: "action", label: t("common.menu.close"), onClick: onClose },
+      ],
+    },
+    {
+      label: t("apps.tv.menu.controls"),
+      items: [
+        {
+          type: "action",
+          label: isPlaying ? t("apps.tv.menu.pause") : t("apps.tv.menu.play"),
+          onClick: onTogglePlay,
+        },
+        {
+          type: "action",
+          label: t("apps.tv.menu.previous"),
+          onClick: onPrevVideo,
+        },
+        { type: "action", label: t("apps.tv.menu.next"), onClick: onNextVideo },
+        { type: "separator" },
+        {
+          type: "action",
+          label: t("apps.tv.menu.channelDown"),
+          onClick: onPrevChannel,
+        },
+        {
+          type: "action",
+          label: t("apps.tv.menu.channelUp"),
+          onClick: onNextChannel,
+        },
+        { type: "separator" },
+        {
+          type: "checkbox",
+          label: t("apps.tv.menu.showVideos"),
+          checked: isDrawerOpen,
+          onChange: onToggleDrawer,
+        },
+        {
+          type: "checkbox",
+          label: t("apps.tv.menu.lcdFilter"),
+          checked: isLcdFilterOn,
+          onChange: onToggleLcdFilter,
+        },
+        {
+          type: "checkbox",
+          label: t("apps.tv.menu.closedCaptions"),
+          checked: closedCaptionsOn,
+          onChange: onToggleClosedCaptions,
+        },
+        { type: "separator" },
+        {
+          type: "action",
+          label: t("apps.tv.menu.fullScreen"),
+          onClick: onFullScreen,
+        },
+      ],
+    },
+    {
+      label: t("apps.tv.menu.channels"),
+      items: [
+        {
+          type: "radioGroup",
+          value: currentChannelId,
+          onValueChange: onSelectChannel,
+          options: channels.map((ch) => ({
+            value: ch.id,
+            label: `${String(ch.number).padStart(2, "0")} ${ch.name}`,
+          })),
+        },
+        { type: "separator" },
+        {
+          type: "action",
+          label: t("apps.tv.menu.newChannel"),
+          onClick: onCreateChannel,
+        },
+        {
+          type: "action",
+          label: t("apps.tv.menu.deleteChannel"),
+          onClick: () => onDeleteChannel(currentChannelId),
+          disabled: channels.length <= 1,
+        },
+        { type: "separator" },
+        {
+          type: "action",
+          label: t("apps.tv.menu.resetChannels"),
+          onClick: onResetChannels,
+          disabled: !canResetChannels,
+        },
+      ],
+    },
+  ];
+
   return (
     <AppMenuBarShell
       isXpTheme={isXpTheme}
@@ -98,121 +199,7 @@ export function TvMenuBar({
       onShowHelp={onShowHelp}
       onShowAbout={onShowAbout}
     >
-      <MenubarMenu>
-        <MenubarTrigger className={MENUBAR_TRIGGER_CLASS}>
-          {t("common.menu.file")}
-        </MenubarTrigger>
-        <MenubarContent align="start" sideOffset={1} className="px-0">
-          <MenubarItem onClick={onCreateChannel} className={MENUBAR_ITEM_CLASS}>
-            {t("apps.tv.menu.newChannel")}
-          </MenubarItem>
-          <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
-          <MenubarItem
-            onClick={onExportChannels}
-            disabled={!hasCustomChannels}
-            className={MENUBAR_ITEM_CLASS}
-          >
-            {t("apps.tv.menu.exportChannels")}
-          </MenubarItem>
-          <MenubarItem onClick={onImportChannels} className={MENUBAR_ITEM_CLASS}>
-            {t("apps.tv.menu.importChannels")}
-          </MenubarItem>
-          <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
-          <MenubarItem onClick={onClose} className={MENUBAR_ITEM_CLASS}>
-            {t("common.menu.close")}
-          </MenubarItem>
-        </MenubarContent>
-      </MenubarMenu>
-      <MenubarMenu>
-        <MenubarTrigger className={MENUBAR_TRIGGER_CLASS}>
-          {t("apps.tv.menu.controls")}
-        </MenubarTrigger>
-        <MenubarContent align="start" sideOffset={1} className="px-0">
-          <MenubarItem onClick={onTogglePlay} className={MENUBAR_ITEM_CLASS}>
-            {isPlaying ? t("apps.tv.menu.pause") : t("apps.tv.menu.play")}
-          </MenubarItem>
-          <MenubarItem onClick={onPrevVideo} className={MENUBAR_ITEM_CLASS}>
-            {t("apps.tv.menu.previous")}
-          </MenubarItem>
-          <MenubarItem onClick={onNextVideo} className={MENUBAR_ITEM_CLASS}>
-            {t("apps.tv.menu.next")}
-          </MenubarItem>
-          <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
-          <MenubarItem onClick={onPrevChannel} className={MENUBAR_ITEM_CLASS}>
-            {t("apps.tv.menu.channelDown")}
-          </MenubarItem>
-          <MenubarItem onClick={onNextChannel} className={MENUBAR_ITEM_CLASS}>
-            {t("apps.tv.menu.channelUp")}
-          </MenubarItem>
-          <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
-          <MenubarCheckboxItem
-            checked={isDrawerOpen}
-            onCheckedChange={onToggleDrawer}
-            className={MENUBAR_ITEM_CLASS}
-          >
-            {t("apps.tv.menu.showVideos")}
-          </MenubarCheckboxItem>
-          <MenubarCheckboxItem
-            checked={isLcdFilterOn}
-            onCheckedChange={onToggleLcdFilter}
-            className={MENUBAR_ITEM_CLASS}
-          >
-            {t("apps.tv.menu.lcdFilter")}
-          </MenubarCheckboxItem>
-          <MenubarCheckboxItem
-            checked={closedCaptionsOn}
-            onCheckedChange={onToggleClosedCaptions}
-            className={MENUBAR_ITEM_CLASS}
-          >
-            {t("apps.tv.menu.closedCaptions")}
-          </MenubarCheckboxItem>
-          <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
-          <MenubarItem onClick={onFullScreen} className={MENUBAR_ITEM_CLASS}>
-            {t("apps.tv.menu.fullScreen")}
-          </MenubarItem>
-        </MenubarContent>
-      </MenubarMenu>
-      <MenubarMenu>
-        <MenubarTrigger className={MENUBAR_TRIGGER_CLASS}>
-          {t("apps.tv.menu.channels")}
-        </MenubarTrigger>
-        <MenubarContent align="start" sideOffset={1} className="px-0">
-          <MenubarRadioGroup
-            value={currentChannelId}
-            onValueChange={onSelectChannel}
-          >
-            {channels.map((ch) => (
-              <MenubarRadioItem
-                key={ch.id}
-                value={ch.id}
-                className={MENUBAR_ITEM_CLASS}
-              >
-                {String(ch.number).padStart(2, "0")} {ch.name}
-              </MenubarRadioItem>
-            ))}
-          </MenubarRadioGroup>
-          <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
-          <MenubarItem onClick={onCreateChannel} className={MENUBAR_ITEM_CLASS}>
-            {t("apps.tv.menu.newChannel")}
-          </MenubarItem>
-          <MenubarItem
-            onClick={() => onDeleteChannel(currentChannelId)}
-            disabled={channels.length <= 1}
-            className={MENUBAR_ITEM_CLASS}
-          >
-            {t("apps.tv.menu.deleteChannel")}
-          </MenubarItem>
-          <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
-          <MenubarItem
-            onClick={onResetChannels}
-            disabled={!canResetChannels}
-            className={MENUBAR_ITEM_CLASS}
-          >
-            {t("apps.tv.menu.resetChannels")}
-          </MenubarItem>
-        </MenubarContent>
-      </MenubarMenu>
-
+      <AppMenuBarMenus menus={menus} />
     </AppMenuBarShell>
   );
 }

--- a/src/apps/videos/components/VideosMenuBar.tsx
+++ b/src/apps/videos/components/VideosMenuBar.tsx
@@ -7,6 +7,10 @@ import {
   MenubarSeparator,
 } from "@/components/ui/menubar";
 import { AppMenuBarShell } from "@/components/shared/menubar/AppMenuBarShell";
+import {
+  AppMenuBarMenus,
+  type MenuDescriptor,
+} from "@/components/shared/menubar/AppMenuBarMenus";
 import { MediaControlsMenu } from "@/components/shared/menubar/MediaControlsMenu";
 import { LibraryTrackBrowser } from "@/components/shared/menubar/LibraryTrackBrowser";
 import { MENUBAR_SEPARATOR_CLASS } from "@/components/shared/menubar/menubarStyles";
@@ -107,6 +111,27 @@ export function VideosMenuBar({
     }
   };
 
+  const menus: MenuDescriptor[] = [
+    {
+      label: t("common.menu.file"),
+      items: [
+        {
+          type: "action",
+          label: t("apps.videos.menu.openVideo"),
+          onClick: onOpenVideo,
+        },
+        {
+          type: "action",
+          label: t("apps.videos.menu.shareVideo"),
+          onClick: onShareVideo,
+          disabled: videos.length === 0,
+        },
+        { type: "separator" },
+        { type: "action", label: t("common.menu.close"), onClick: onClose },
+      ],
+    },
+  ];
+
   return (
     <AppMenuBarShell
       isXpTheme={isXpTheme}
@@ -121,33 +146,7 @@ export function VideosMenuBar({
       onShowAbout={onShowAbout}
     >
       {/* File Menu */}
-      <MenubarMenu>
-        <MenubarTrigger className="text-md px-2 py-1 border-none focus-visible:ring-0">
-          {t("common.menu.file")}
-        </MenubarTrigger>
-        <MenubarContent align="start" sideOffset={1} className="px-0">
-          <MenubarItem
-            onClick={onOpenVideo}
-            className="text-md h-6 px-3"
-          >
-            {t("apps.videos.menu.openVideo")}
-          </MenubarItem>
-          <MenubarItem
-            onClick={onShareVideo}
-            className="text-md h-6 px-3"
-            disabled={videos.length === 0}
-          >
-            {t("apps.videos.menu.shareVideo")}
-          </MenubarItem>
-          <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
-          <MenubarItem
-            onClick={onClose}
-            className="text-md h-6 px-3"
-          >
-            {t("common.menu.close")}
-          </MenubarItem>
-        </MenubarContent>
-      </MenubarMenu>
+      <AppMenuBarMenus menus={menus} />
 
       {/* Controls Menu */}
       <MediaControlsMenu

--- a/src/apps/winamp/components/WinampMenuBar.tsx
+++ b/src/apps/winamp/components/WinampMenuBar.tsx
@@ -8,6 +8,10 @@ import {
   MenubarRadioItem,
 } from "@/components/ui/menubar";
 import { AppMenuBarShell } from "@/components/shared/menubar/AppMenuBarShell";
+import {
+  AppMenuBarMenus,
+  type MenuDescriptor,
+} from "@/components/shared/menubar/AppMenuBarMenus";
 import { MediaControlsMenu } from "@/components/shared/menubar/MediaControlsMenu";
 import {
   MENUBAR_ITEM_CLASS,
@@ -61,6 +65,15 @@ export function WinampMenuBar({
     appName,
   } = useAppMenuBarChrome("winamp");
 
+  const menus: MenuDescriptor[] = [
+    {
+      label: t("common.menu.file"),
+      items: [
+        { type: "action", label: t("common.menu.close"), onClick: onClose },
+      ],
+    },
+  ];
+
   return (
     <AppMenuBarShell
       isXpTheme={isXpTheme}
@@ -74,16 +87,10 @@ export function WinampMenuBar({
       onShowHelp={onShowHelp}
       onShowAbout={onShowAbout}
     >
-      <MenubarMenu>
-        <MenubarTrigger className={MENUBAR_TRIGGER_CLASS}>
-          {t("common.menu.file")}
-        </MenubarTrigger>
-        <MenubarContent align="start" sideOffset={1} className="px-0">
-          <MenubarItem onClick={onClose} className={MENUBAR_ITEM_CLASS}>
-            {t("common.menu.close")}
-          </MenubarItem>
-        </MenubarContent>
-      </MenubarMenu>
+      <AppMenuBarMenus menus={menus} />
+      {/* Skins menu stays hand-written: its radio items use a bare pr-3
+          class (no px-3) and the radio group embeds a separator, neither of
+          which the descriptor radioGroup can express. */}
       <MenubarMenu>
         <MenubarTrigger className={MENUBAR_TRIGGER_CLASS}>
           {t("apps.winamp.menu.skins")}

--- a/src/components/shared/menubar/AppMenuBarMenus.tsx
+++ b/src/components/shared/menubar/AppMenuBarMenus.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from "react";
 import {
   MenubarMenu,
   MenubarTrigger,
@@ -9,33 +10,59 @@ import {
   MenubarSub,
   MenubarSubTrigger,
   MenubarSubContent,
+  MenubarRadioGroup,
+  MenubarRadioItem,
 } from "@/components/ui/menubar";
+import { cn } from "@/lib/utils";
 import {
   MENUBAR_ITEM_CLASS,
   MENUBAR_SEPARATOR_CLASS,
   MENUBAR_TRIGGER_CLASS,
 } from "./menubarStyles";
 
+export interface MenuRadioOptionDescriptor {
+  label: ReactNode;
+  value: string;
+  disabled?: boolean;
+  /** Extra classes merged onto the shared item class. */
+  className?: string;
+}
+
 export type MenuItemDescriptor =
   | {
       type: "action";
-      label: string;
+      label: ReactNode;
       onClick: () => void;
       disabled?: boolean;
       shortcut?: string;
+      /** Extra classes merged onto the shared item class. */
+      className?: string;
     }
   | { type: "separator" }
   | {
       type: "checkbox";
-      label: string;
+      label: ReactNode;
       checked: boolean;
       onChange: (checked: boolean) => void;
       disabled?: boolean;
+      /** Extra classes merged onto the shared item class. */
+      className?: string;
     }
-  | { type: "submenu"; label: string; items: MenuItemDescriptor[] };
+  | {
+      type: "radioGroup";
+      value: string;
+      onValueChange: (value: string) => void;
+      options: MenuRadioOptionDescriptor[];
+    }
+  | {
+      type: "submenu";
+      label: ReactNode;
+      items: MenuItemDescriptor[];
+      disabled?: boolean;
+    };
 
 export type MenuDescriptor = {
-  label: string;
+  label: ReactNode;
   items: MenuItemDescriptor[];
 };
 
@@ -52,7 +79,7 @@ function renderItems(items: MenuItemDescriptor[]) {
             key={index}
             onClick={item.onClick}
             disabled={item.disabled}
-            className={MENUBAR_ITEM_CLASS}
+            className={cn(MENUBAR_ITEM_CLASS, item.className)}
           >
             {item.label}
             {item.shortcut && (
@@ -67,15 +94,37 @@ function renderItems(items: MenuItemDescriptor[]) {
             checked={item.checked}
             onCheckedChange={item.onChange}
             disabled={item.disabled}
-            className={MENUBAR_ITEM_CLASS}
+            className={cn(MENUBAR_ITEM_CLASS, item.className)}
           >
             {item.label}
           </MenubarCheckboxItem>
         );
+      case "radioGroup":
+        return (
+          <MenubarRadioGroup
+            key={index}
+            value={item.value}
+            onValueChange={item.onValueChange}
+          >
+            {item.options.map((option) => (
+              <MenubarRadioItem
+                key={option.value}
+                value={option.value}
+                disabled={option.disabled}
+                className={cn(MENUBAR_ITEM_CLASS, option.className)}
+              >
+                {option.label}
+              </MenubarRadioItem>
+            ))}
+          </MenubarRadioGroup>
+        );
       case "submenu":
         return (
           <MenubarSub key={index}>
-            <MenubarSubTrigger className={MENUBAR_ITEM_CLASS}>
+            <MenubarSubTrigger
+              disabled={item.disabled}
+              className={MENUBAR_ITEM_CLASS}
+            >
               {item.label}
             </MenubarSubTrigger>
             <MenubarSubContent className="px-0">
@@ -88,13 +137,14 @@ function renderItems(items: MenuItemDescriptor[]) {
 }
 
 /**
- * Declarative renderer for simple app menubars. Each descriptor becomes a
- * Radix MenubarMenu styled with the shared `menubarStyles` constants so all
- * OS themes render identically to the hand-written JSX it replaces.
+ * Declarative renderer for app menubars. Each descriptor becomes a Radix
+ * MenubarMenu styled with the shared `menubarStyles` constants so all OS
+ * themes render identically to the hand-written JSX it replaces.
  *
- * Intended for small, mechanical menus (plain actions, separators,
- * checkboxes, basic submenus). Menus that need radio groups, custom
- * classNames, or bespoke item content should keep hand-written JSX.
+ * Supports actions (with shortcuts), separators, checkboxes, radio groups,
+ * and nested submenus; labels accept ReactNode and items accept extra
+ * classes. Menus with truly bespoke content (embedded components, custom
+ * triggers) should keep hand-written JSX.
  */
 export function AppMenuBarMenus({ menus }: { menus: MenuDescriptor[] }) {
   return (


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Follow-up to #1468: extends the declarative `AppMenuBarMenus` renderer and migrates the rest of the mechanical app menubars onto it.

## Renderer extensions

- **`radioGroup` item type** — `{ value, onValueChange, options: [{ label, value, disabled?, className? }] }` rendering `MenubarRadioGroup`/`MenubarRadioItem` with the shared item class (this is what blocked TV in #1468)
- **`ReactNode` labels** (emoji/icon/swatch labels), **per-item `className`** merged onto the shared class, and **`disabled` submenu triggers**

## Migrations (15 menubars)

Fully migrated: **TV** (radio channel picker), **Maps** (kept checkbox semantics for map type to match the original rendering), **Terminal** (inert Edit items stay inert), **Stickies** (color-swatch submenu with disabled trigger), **Infinite Mac**, **Infinite PC**, **Photo Booth**, **Admin**, **Synth**, **Dashboard**, **Soundboard**, **Calendar**.

Partially migrated (plain menus only; bespoke menus stay hand-written): **Applet Viewer** (File menu keeps its custom sub-content class + hidden file input), **Winamp** (Skins radio menu keeps non-standard classes + in-group separator; `MediaControlsMenu` untouched), **Videos** (Controls/Library keep `MediaControlsMenu`/`LibraryTrackBrowser`).

Deliberately not migrated: Chats, Finder, TextEdit, iPod, Karaoke (genuinely bespoke menus/modular structures).

Parity rules followed throughout: identical item order, labels, separators, disabled conditions, shortcuts, and extra classes; literal legacy class strings verified equal to the `menubarStyles` constants before consolidation. Net: **−241 lines** (1,116 insertions / 1,357 deletions across 16 files).

## Verification

![TV Channels menu rendered by the descriptor radio group](https://cursor.com/artifacts/c/art-4bdacf55-3fc6-4e83-9f61-9b30cf230da9)

TV's Channels menu rendered by the new `radioGroup` descriptor — verified in-browser: exactly one radio indicator, clicking another channel switches the TV (title + content), the indicator follows the selection, and the disabled "Reset Channels…" renders greyed.

## Testing

- ✅ `bunx tsc -b --force` — clean (run after every migrated file)
- ✅ `bun run test:unit` — 322 pass / 0 fail
- ✅ `bunx eslint` on all 16 changed files — 0 errors, 0 warnings
- ✅ Manual browser verification of the new radio path (TV Channels menu, screenshot above)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-819f5fdd-4d5f-4944-83d4-bde8c75427ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-819f5fdd-4d5f-4944-83d4-bde8c75427ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

