### PR TITLE
Convert cloud sync indicator dropdown to a menubar menu

### DIFF
--- a/src/components/layout/menu-bar/CloudSyncIndicator.tsx
+++ b/src/components/layout/menu-bar/CloudSyncIndicator.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { ArrowsClockwise } from "@phosphor-icons/react";
 import { motion, AnimatePresence } from "motion/react";
@@ -16,7 +16,6 @@ import { getAppIconPath } from "@/config/appRegistry";
 import type { AppId } from "@/config/appRegistryData";
 import { useThemeFlags } from "@/hooks/useThemeFlags";
 import { useLaunchApp } from "@/hooks/useLaunchApp";
-import { useSound, Sounds } from "@/hooks/useSound";
 import { useCloudSyncStore } from "@/stores/useCloudSyncStore";
 import {
   getCloudSyncCategory,
@@ -74,8 +73,6 @@ const SYNC_CATEGORY_ORDER: CloudSyncCategory[] = [
   "stickies",
 ];
 
-const HOVER_CLOSE_DELAY_MS = 200;
-
 const MENU_VALUE = "cloud-sync";
 
 interface SyncCategoryActivity {
@@ -92,11 +89,8 @@ export function CloudSyncIndicator() {
     isSystem7Theme,
   } = useThemeFlags();
   const launchApp = useLaunchApp();
-  const { play: playMenuOpen } = useSound(Sounds.MENU_OPEN);
-  const { play: playMenuClose } = useSound(Sounds.MENU_CLOSE);
   const [menuValue, setMenuValue] = useState("");
   const isOpen = menuValue === MENU_VALUE;
-  const closeTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const { isCheckingRemote, lastCheckedAt, lastError, domainStatus } =
     useCloudSyncStore(
@@ -127,50 +121,6 @@ export function CloudSyncIndicator() {
 
   const syncLabel = t("apps.control-panels.autoSync.title");
 
-  const cancelScheduledClose = useCallback(() => {
-    if (closeTimeoutRef.current) {
-      clearTimeout(closeTimeoutRef.current);
-      closeTimeoutRef.current = null;
-    }
-  }, []);
-
-  useEffect(() => cancelScheduledClose, [cancelScheduledClose]);
-
-  const openMenu = useCallback(() => {
-    cancelScheduledClose();
-    setMenuValue((wasValue) => {
-      if (wasValue !== MENU_VALUE) playMenuOpen();
-      return MENU_VALUE;
-    });
-  }, [cancelScheduledClose, playMenuOpen]);
-
-  const scheduleClose = useCallback(() => {
-    cancelScheduledClose();
-    closeTimeoutRef.current = setTimeout(() => {
-      closeTimeoutRef.current = null;
-      setMenuValue((wasValue) => {
-        if (wasValue === MENU_VALUE) playMenuClose();
-        return "";
-      });
-    }, HOVER_CLOSE_DELAY_MS);
-  }, [cancelScheduledClose, playMenuClose]);
-
-  const handlePointerEnter = useCallback(
-    (event: React.PointerEvent) => {
-      if (event.pointerType !== "mouse") return;
-      openMenu();
-    },
-    [openMenu]
-  );
-
-  const handlePointerLeave = useCallback(
-    (event: React.PointerEvent) => {
-      if (event.pointerType !== "mouse") return;
-      scheduleClose();
-    },
-    [scheduleClose]
-  );
-
   // Keep the indicator mounted while the menu is open so the menu does
   // not vanish mid-read when the last sync operation finishes.
   if (isXpTheme || (!isCloudSyncActive && !isOpen)) return null;
@@ -181,34 +131,17 @@ export function CloudSyncIndicator() {
     AUTO_SYNC_TIME_KEYS
   );
 
-  const itemRowClass = "flex items-center gap-2 px-2 py-1 text-sm";
-  const itemRowStyle: React.CSSProperties = {
-    fontFamily: isMacOSTheme ? "var(--os-font-ui)" : undefined,
-    fontSize: isMacOSTheme ? "var(--os-menu-item-font-size)" : undefined,
-    ...(isMacOSTheme && {
-      padding: "4px 16px",
-      WebkitFontSmoothing: "antialiased" as const,
-      textShadow: "0 2px 3px rgba(0, 0, 0, 0.25)",
-    }),
-  };
-
   return (
     <Menubar
       value={menuValue}
-      onValueChange={(value) => {
-        cancelScheduledClose();
-        setMenuValue(value);
-      }}
-      className="flex items-center border-none bg-transparent p-0 space-x-0 rounded-none h-full"
+      onValueChange={setMenuValue}
+      className="flex items-stretch self-stretch border-none bg-transparent p-0 space-x-0 rounded-none h-full"
     >
       <MenubarMenu value={MENU_VALUE}>
         <MenubarTrigger
-          className="flex items-center justify-center px-1 border-none focus-visible:ring-0"
-          style={{ marginRight: "2px" }}
+          className="flex items-center justify-center px-2 border-none focus-visible:ring-0"
           title={syncLabel}
           aria-label={syncLabel}
-          onPointerEnter={handlePointerEnter}
-          onPointerLeave={handlePointerLeave}
         >
           <motion.span
             initial={{ opacity: 0, scale: 0.85 }}
@@ -233,9 +166,6 @@ export function CloudSyncIndicator() {
           align="end"
           sideOffset={1}
           className="min-w-[200px]"
-          onCloseAutoFocus={(event) => event.preventDefault()}
-          onPointerEnter={cancelScheduledClose}
-          onPointerLeave={handlePointerLeave}
         >
           <AnimatePresence initial={false}>
             {activeCategories.map(({ category, isUploading }) => {
@@ -249,7 +179,10 @@ export function CloudSyncIndicator() {
                   transition={{ duration: 0.15, ease: "easeOut" }}
                   className="overflow-hidden"
                 >
-                  <div className={itemRowClass} style={itemRowStyle}>
+                  <MenubarItem
+                    className="text-md h-6 px-3 flex items-center gap-2"
+                    onSelect={(event) => event.preventDefault()}
+                  >
                     <ThemedIcon
                       name={getAppIconPath(meta.appId)}
                       alt=""
@@ -261,31 +194,31 @@ export function CloudSyncIndicator() {
                         ? t("apps.control-panels.autoSync.uploading")
                         : t("apps.control-panels.autoSync.fetching")}
                     </span>
-                  </div>
+                  </MenubarItem>
                 </motion.div>
               );
             })}
           </AnimatePresence>
           {activeCategories.length === 0 && (
-            <div className={itemRowClass} style={itemRowStyle}>
-              <span className="opacity-70">
-                {lastCheckedRelative
-                  ? t("apps.control-panels.autoSync.lastChecked", {
-                      date: lastCheckedRelative,
-                    })
-                  : t("apps.control-panels.autoSync.waiting")}
-              </span>
-            </div>
+            <MenubarItem disabled className="text-md h-6 px-3 opacity-70">
+              {lastCheckedRelative
+                ? t("apps.control-panels.autoSync.lastChecked", {
+                    date: lastCheckedRelative,
+                  })
+                : t("apps.control-panels.autoSync.waiting")}
+            </MenubarItem>
           )}
           {lastError && (
-            <div className={itemRowClass} style={itemRowStyle}>
-              <span className="text-red-600 break-words">
-                {t("apps.control-panels.autoSync.error", { error: lastError })}
-              </span>
-            </div>
+            <MenubarItem
+              disabled
+              className="text-md min-h-6 px-3 text-red-600 break-words whitespace-normal"
+            >
+              {t("apps.control-panels.autoSync.error", { error: lastError })}
+            </MenubarItem>
           )}
           <MenubarSeparator />
           <MenubarItem
+            className="text-md h-6 px-3"
             onSelect={() => {
               setMenuValue("");
               launchApp("control-panels", {

--- a/src/components/layout/menu-bar/CloudSyncIndicator.tsx
+++ b/src/components/layout/menu-bar/CloudSyncIndicator.tsx
@@ -4,12 +4,13 @@ import { ArrowsClockwise } from "@phosphor-icons/react";
 import { motion, AnimatePresence } from "motion/react";
 import { useShallow } from "zustand/react/shallow";
 import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
+  Menubar,
+  MenubarMenu,
+  MenubarTrigger,
+  MenubarContent,
+  MenubarItem,
+  MenubarSeparator,
+} from "@/components/ui/menubar";
 import { ThemedIcon } from "@/components/shared/ThemedIcon";
 import { getAppIconPath } from "@/config/appRegistry";
 import type { AppId } from "@/config/appRegistryData";
@@ -75,6 +76,8 @@ const SYNC_CATEGORY_ORDER: CloudSyncCategory[] = [
 
 const HOVER_CLOSE_DELAY_MS = 200;
 
+const MENU_VALUE = "cloud-sync";
+
 interface SyncCategoryActivity {
   category: CloudSyncCategory;
   isUploading: boolean;
@@ -91,7 +94,8 @@ export function CloudSyncIndicator() {
   const launchApp = useLaunchApp();
   const { play: playMenuOpen } = useSound(Sounds.MENU_OPEN);
   const { play: playMenuClose } = useSound(Sounds.MENU_CLOSE);
-  const [isOpen, setIsOpen] = useState(false);
+  const [menuValue, setMenuValue] = useState("");
+  const isOpen = menuValue === MENU_VALUE;
   const closeTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const { isCheckingRemote, lastCheckedAt, lastError, domainStatus } =
@@ -134,9 +138,9 @@ export function CloudSyncIndicator() {
 
   const openMenu = useCallback(() => {
     cancelScheduledClose();
-    setIsOpen((wasOpen) => {
-      if (!wasOpen) playMenuOpen();
-      return true;
+    setMenuValue((wasValue) => {
+      if (wasValue !== MENU_VALUE) playMenuOpen();
+      return MENU_VALUE;
     });
   }, [cancelScheduledClose, playMenuOpen]);
 
@@ -144,9 +148,9 @@ export function CloudSyncIndicator() {
     cancelScheduledClose();
     closeTimeoutRef.current = setTimeout(() => {
       closeTimeoutRef.current = null;
-      setIsOpen((wasOpen) => {
-        if (wasOpen) playMenuClose();
-        return false;
+      setMenuValue((wasValue) => {
+        if (wasValue === MENU_VALUE) playMenuClose();
+        return "";
       });
     }, HOVER_CLOSE_DELAY_MS);
   }, [cancelScheduledClose, playMenuClose]);
@@ -167,7 +171,7 @@ export function CloudSyncIndicator() {
     [scheduleClose]
   );
 
-  // Keep the indicator mounted while the menu is open so the dropdown does
+  // Keep the indicator mounted while the menu is open so the menu does
   // not vanish mid-read when the last sync operation finishes.
   if (isXpTheme || (!isCloudSyncActive && !isOpen)) return null;
 
@@ -189,108 +193,110 @@ export function CloudSyncIndicator() {
   };
 
   return (
-    <DropdownMenu
-      open={isOpen}
-      onOpenChange={(open) => {
+    <Menubar
+      value={menuValue}
+      onValueChange={(value) => {
         cancelScheduledClose();
-        setIsOpen(open);
+        setMenuValue(value);
       }}
-      modal={false}
+      className="flex items-center border-none bg-transparent p-0 space-x-0 rounded-none h-full"
     >
-      <DropdownMenuTrigger asChild>
-        <motion.button
-          type="button"
-          initial={{ opacity: 0, scale: 0.85 }}
-          animate={{ opacity: 1, scale: 1 }}
-          exit={{ opacity: 0, scale: 0.85 }}
-          transition={{ duration: 0.15, ease: "easeOut" }}
-          className="relative flex items-center justify-center px-1 py-0.5 rounded-sm hover:bg-black/10 active:bg-black/20 border-none focus-visible:ring-0 outline-none"
+      <MenubarMenu value={MENU_VALUE}>
+        <MenubarTrigger
+          className="flex items-center justify-center px-1 border-none focus-visible:ring-0"
           style={{ marginRight: "2px" }}
           title={syncLabel}
           aria-label={syncLabel}
           onPointerEnter={handlePointerEnter}
           onPointerLeave={handlePointerLeave}
         >
-          <ArrowsClockwise
-            aria-hidden="true"
-            className={`h-3.5 w-3.5 ${isCloudSyncActive ? "animate-spin" : ""}`}
-            weight="bold"
-            style={{
-              opacity: isSystem7Theme ? 1 : 0.82,
-              textShadow: isMacOSTheme
-                ? "0 2px 3px rgba(0, 0, 0, 0.25)"
-                : undefined,
-            }}
-          />
-        </motion.button>
-      </DropdownMenuTrigger>
-      <DropdownMenuContent
-        align="end"
-        sideOffset={1}
-        className="min-w-[200px]"
-        onCloseAutoFocus={(event) => event.preventDefault()}
-        onPointerEnter={cancelScheduledClose}
-        onPointerLeave={handlePointerLeave}
-      >
-        <AnimatePresence initial={false}>
-          {activeCategories.map(({ category, isUploading }) => {
-            const meta = SYNC_CATEGORY_META[category];
-            return (
-              <motion.div
-                key={category}
-                initial={{ opacity: 0, height: 0 }}
-                animate={{ opacity: 1, height: "auto" }}
-                exit={{ opacity: 0, height: 0 }}
-                transition={{ duration: 0.15, ease: "easeOut" }}
-                className="overflow-hidden"
-              >
-                <div className={itemRowClass} style={itemRowStyle}>
-                  <ThemedIcon
-                    name={getAppIconPath(meta.appId)}
-                    alt=""
-                    className="size-4 shrink-0 object-contain"
-                  />
-                  <span>{t(meta.labelKey)}</span>
-                  <span className="ml-auto pl-3 text-xs opacity-60">
-                    {isUploading
-                      ? t("apps.control-panels.autoSync.uploading")
-                      : t("apps.control-panels.autoSync.fetching")}
-                  </span>
-                </div>
-              </motion.div>
-            );
-          })}
-        </AnimatePresence>
-        {activeCategories.length === 0 && (
-          <div className={itemRowClass} style={itemRowStyle}>
-            <span className="opacity-70">
-              {lastCheckedRelative
-                ? t("apps.control-panels.autoSync.lastChecked", {
-                    date: lastCheckedRelative,
-                  })
-                : t("apps.control-panels.autoSync.waiting")}
-            </span>
-          </div>
-        )}
-        {lastError && (
-          <div className={itemRowClass} style={itemRowStyle}>
-            <span className="text-red-600 break-words">
-              {t("apps.control-panels.autoSync.error", { error: lastError })}
-            </span>
-          </div>
-        )}
-        <DropdownMenuSeparator />
-        <DropdownMenuItem
-          onSelect={() => {
-            setIsOpen(false);
-            launchApp("control-panels", {
-              initialData: { defaultTab: "sync" },
-            });
-          }}
+          <motion.span
+            initial={{ opacity: 0, scale: 0.85 }}
+            animate={{ opacity: 1, scale: 1 }}
+            transition={{ duration: 0.15, ease: "easeOut" }}
+            className="flex items-center justify-center"
+          >
+            <ArrowsClockwise
+              aria-hidden="true"
+              className={`h-3.5 w-3.5 ${isCloudSyncActive ? "animate-spin" : ""}`}
+              weight="bold"
+              style={{
+                opacity: isSystem7Theme ? 1 : 0.82,
+                textShadow: isMacOSTheme
+                  ? "0 2px 3px rgba(0, 0, 0, 0.25)"
+                  : undefined,
+              }}
+            />
+          </motion.span>
+        </MenubarTrigger>
+        <MenubarContent
+          align="end"
+          sideOffset={1}
+          className="min-w-[200px]"
+          onCloseAutoFocus={(event) => event.preventDefault()}
+          onPointerEnter={cancelScheduledClose}
+          onPointerLeave={handlePointerLeave}
         >
-          {t("apps.control-panels.autoSync.openSettings")}
-        </DropdownMenuItem>
-      </DropdownMenuContent>
-    </DropdownMenu>
+          <AnimatePresence initial={false}>
+            {activeCategories.map(({ category, isUploading }) => {
+              const meta = SYNC_CATEGORY_META[category];
+              return (
+                <motion.div
+                  key={category}
+                  initial={{ opacity: 0, height: 0 }}
+                  animate={{ opacity: 1, height: "auto" }}
+                  exit={{ opacity: 0, height: 0 }}
+                  transition={{ duration: 0.15, ease: "easeOut" }}
+                  className="overflow-hidden"
+                >
+                  <div className={itemRowClass} style={itemRowStyle}>
+                    <ThemedIcon
+                      name={getAppIconPath(meta.appId)}
+                      alt=""
+                      className="size-4 shrink-0 object-contain"
+                    />
+                    <span>{t(meta.labelKey)}</span>
+                    <span className="ml-auto pl-3 text-xs opacity-60">
+                      {isUploading
+                        ? t("apps.control-panels.autoSync.uploading")
+                        : t("apps.control-panels.autoSync.fetching")}
+                    </span>
+                  </div>
+                </motion.div>
+              );
+            })}
+          </AnimatePresence>
+          {activeCategories.length === 0 && (
+            <div className={itemRowClass} style={itemRowStyle}>
+              <span className="opacity-70">
+                {lastCheckedRelative
+                  ? t("apps.control-panels.autoSync.lastChecked", {
+                      date: lastCheckedRelative,
+                    })
+                  : t("apps.control-panels.autoSync.waiting")}
+              </span>
+            </div>
+          )}
+          {lastError && (
+            <div className={itemRowClass} style={itemRowStyle}>
+              <span className="text-red-600 break-words">
+                {t("apps.control-panels.autoSync.error", { error: lastError })}
+              </span>
+            </div>
+          )}
+          <MenubarSeparator />
+          <MenubarItem
+            onSelect={() => {
+              setMenuValue("");
+              launchApp("control-panels", {
+                initialData: { defaultTab: "sync" },
+              });
+            }}
+          >
+            {t("apps.control-panels.autoSync.openSettings")}
+          </MenubarItem>
+        </MenubarContent>
+      </MenubarMenu>
+    </Menubar>
   );
 }

--- a/src/components/layout/menu-bar/MacTopMenuBar.tsx
+++ b/src/components/layout/menu-bar/MacTopMenuBar.tsx
@@ -117,7 +117,7 @@ export function MacTopMenuBar({ children }: MacTopMenuBarProps) {
           }}
         />
       )}
-      <div className={`${isPhone ? "flex-shrink-0 pl-1 pr-0.5" : "ml-auto"} flex items-center`}>
+      <div className={`${isPhone ? "flex-shrink-0 pl-1 pr-0.5" : "ml-auto"} flex items-center h-full`}>
         <OfflineIndicator />
         <CloudSyncIndicator />
         <ExposeButton />


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The cloud sync indicator in the top menu bar previously used a Radix `DropdownMenu` with custom hover-to-open behavior and custom-height status rows, making it inconsistent with the other menu bar items (Apple, File, Edit, View, etc.) that use the shared `Menubar` primitives. This PR makes it behave and look like a real menu bar menu.

## Changes

- Convert `CloudSyncIndicator` from `DropdownMenu*` to the `Menubar`/`MenubarMenu`/`MenubarTrigger`/`MenubarContent`/`MenubarItem`/`MenubarSeparator` primitives.
- Replace the custom `<div>` status rows with actual `MenubarItem`s using the standard `text-md h-6 px-3` height other menus use; informational rows (last-checked/waiting and error) are `disabled` items, matching the `AppleMenu` "No recent apps" pattern.
- Make the sync icon a real click-to-toggle menu trigger like the Apple menu (removed the custom hover-open / delayed-close logic and manual sounds; the `Menubar` root now drives open/close sounds), with the standard open-state highlight.
- Give the trigger a full menu-bar-height highlight: the `Menubar`/trigger now stretch full height, and the right-side cluster in `MacTopMenuBar` is given `h-full` (siblings remain vertically centered via `items-center`).

## Testing

- `bun run build` (tsc + vite) — passes
- `eslint` + `tsc --noEmit` on changed files — pass
- Headless (Playwright, port 3000, service worker bypassed) measurement confirms parity with the Apple menu trigger:
  - Menu bar height: 25px (1px border)
  - Apple trigger box: `y=0, height=24`
  - Sync trigger box: `y=0, height=24` (closed and open) — full bar height, identical to Apple menu
  - Dropdown menu item heights: all 24px (matching standard menubar items)

![Cloud sync menu open showing full-height trigger highlight and standard menu items](https://cursor.com/artifacts/c/art-1c9fc768-4f37-496b-920c-ec68b50a4fba)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019eb9e5-f140-7c16-85eb-765eae5dc3ee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019eb9e5-f140-7c16-85eb-765eae5dc3ee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

