### PR TITLE
Make inactive Aqua Glass windows more transparent

### DIFF
--- a/src/styles/themes.css
+++ b/src/styles/themes.css
@@ -5441,6 +5441,13 @@
     var(--os-accent-color, #3a73d6) 8%,
     rgba(243, 246, 251, 0.8)
   );
+  /* Inactive windows recede by letting more of the desktop bleed through the
+     frosted pane (lower fill alpha → more transparent). */
+  --os-color-window-bg-inactive: color-mix(
+    in srgb,
+    var(--os-accent-color, #3a73d6) 6%,
+    rgba(243, 246, 251, 0.48)
+  );
   --os-color-panel-bg: color-mix(
     in srgb,
     var(--os-accent-color, #3a73d6) 8%,
@@ -5513,6 +5520,13 @@
     in srgb,
     var(--os-accent-color, #3a73d6) 9%,
     rgba(38, 40, 46, 0.8)
+  );
+  /* Inactive windows recede by letting more of the desktop bleed through the
+     frosted pane (lower fill alpha → more transparent). */
+  --os-color-window-bg-inactive: color-mix(
+    in srgb,
+    var(--os-accent-color, #3a73d6) 7%,
+    rgba(38, 40, 46, 0.5)
   );
   --os-color-panel-bg: color-mix(
     in srgb,
@@ -5596,10 +5610,26 @@
     inset 0 1px 0 rgba(255, 255, 255, 0.4);
 }
 
+/* Inactive glass windows recede: more transparent fill + softer specular rim so
+   the focused window reads as the frontmost frosted pane. */
+:root[data-os-theme="macosx"][data-os-aqua-material="glass"]
+  .window.window-material-glass:not(.is-foreground) {
+  background-color: var(--os-color-window-bg-inactive);
+  box-shadow: var(--os-window-shadow),
+    inset 0 1px 0 rgba(255, 255, 255, 0.25);
+}
+
 :root[data-os-theme="macosx"][data-os-aqua-material="glass"][data-os-color-scheme="dark"]
   .window.window-material-glass {
   box-shadow: var(--os-window-shadow),
     inset 0 1px 0 rgba(255, 255, 255, 0.12);
+}
+
+:root[data-os-theme="macosx"][data-os-aqua-material="glass"][data-os-color-scheme="dark"]
+  .window.window-material-glass:not(.is-foreground) {
+  background-color: var(--os-color-window-bg-inactive);
+  box-shadow: var(--os-window-shadow),
+    inset 0 1px 0 rgba(255, 255, 255, 0.07);
 }
 
 /* Drop the hard titlebar divider — on a single frosted pane the seam reads as
@@ -5633,6 +5663,7 @@
 
 :root[data-os-theme="macosx"][data-os-aqua-material="glass"]
   .window-material-brushedmetal:not(.is-foreground)::before {
+  background: var(--os-color-window-bg-inactive) !important;
   filter: saturate(0.9) brightness(0.98) !important;
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

In the **Aqua Glass** material (Control Panels → Appearance → "Aqua Glass"), inactive (background) windows previously looked nearly identical to the focused window — they only differed by shadow strength and border tokens, with the same frosted-pane fill opacity. This made it hard to tell which window had focus.

This change makes inactive glass windows recede by letting more of the desktop bleed through their frosted pane:

- Adds a new `--os-color-window-bg-inactive` token for both **light** and **dark** glass, with a lower fill alpha (more transparent) and slightly reduced accent tint than the active `--os-color-window-bg`.
- Applies the token to `.window.window-material-glass:not(.is-foreground)` (light + dark), and softens the inner specular top-rim highlight for inactive windows.
- Applies the same inactive fill to brushed-metal windows in glass mode (`.window-material-brushedmetal:not(.is-foreground)::before`) for consistency.

Only affects the Aqua Glass variant; classic Aqua, System 7, XP, and Win98 are untouched.

## Testing

Visually verified active vs inactive windows in Aqua Glass (light + dark) in the browser.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019eba5a-9e29-717d-8eba-fabbb00e9bc4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019eba5a-9e29-717d-8eba-fabbb00e9bc4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

