### PR TITLE
Spotlight: Aqua Glass backdrop blur + dark-mode input fix

### DIFF
--- a/src/components/layout/spotlight-search/SpotlightSearchInput.tsx
+++ b/src/components/layout/spotlight-search/SpotlightSearchInput.tsx
@@ -62,7 +62,7 @@ export function SpotlightSearchInput({
           </span>
         )}
         <div
-          className="flex items-center flex-1"
+          className="flex items-center flex-1 spotlight-input-well"
           style={{
             background: "#FFFFFF",
             borderRadius: isMobile ? "24px" : "12px",

--- a/src/styles/themes.css
+++ b/src/styles/themes.css
@@ -3701,14 +3701,27 @@
 
 /* The Spotlight search field pill is hardcoded white inline (the light-mode
    Aqua look). In dark mode that bright pill clashes with the dark panel and
-   buries the light input text — swap it for a dark translucent well. Covers
-   both classic dark Aqua and dark Aqua Glass (both set the dark scheme attr). */
-:root[data-os-theme="macosx"][data-os-color-scheme="dark"]
+   buries the light input text — swap it for a dark well. Classic dark Aqua gets
+   the opaque input token; dark Aqua Glass gets a dark translucent frosted well
+   (a near-transparent fill would let the bright wallpaper read as a light pill). */
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"]:not(
+    [data-os-aqua-material="glass"]
+  )
   .spotlight-panel
   .spotlight-input-well {
   background: var(--os-color-input-bg) !important;
   box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.4),
     0 0 0 1px rgba(255, 255, 255, 0.12) !important;
+}
+
+:root[data-os-theme="macosx"][data-os-aqua-material="glass"][data-os-color-scheme="dark"]
+  .spotlight-panel
+  .spotlight-input-well {
+  background: rgba(28, 30, 36, 0.5) !important;
+  backdrop-filter: blur(12px) saturate(180%);
+  -webkit-backdrop-filter: blur(12px) saturate(180%);
+  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.45),
+    0 0 0 1px rgba(255, 255, 255, 0.14) !important;
 }
 
 /* Aqua select triggers, the Radix `.os-select-trigger-macos` / `.os-btn-aqua-select`

--- a/src/styles/themes.css
+++ b/src/styles/themes.css
@@ -5904,6 +5904,37 @@
     inset 0 1px 0 rgba(255, 255, 255, 0.1) !important;
 }
 
+/* --- Frosted Spotlight panel --------------------------------------------- */
+/* Spotlight is not a Radix popper, so it misses the popover rules above. It
+   paints `var(--os-pinstripe-window)` inline (0.74–0.8 alpha — opaque enough
+   to bury the blur); swap in a lighter wash + add the same backdrop blur,
+   rounded glass radius and hairline rim the dropdowns/menus use. */
+:root[data-os-theme="macosx"][data-os-aqua-material="glass"] .spotlight-panel {
+  backdrop-filter: blur(36px) saturate(200%) !important;
+  -webkit-backdrop-filter: blur(36px) saturate(200%) !important;
+  background: color-mix(
+    in srgb,
+    var(--os-accent-color, #3a73d6) 6%,
+    rgba(248, 250, 253, 0.62)
+  ) !important;
+  background-attachment: scroll !important;
+  border-radius: var(--os-glass-r-md) !important;
+  border: var(--os-metrics-border-width) solid var(--os-color-window-border) !important;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.25),
+    inset 0 1px 0 rgba(255, 255, 255, 0.4) !important;
+}
+
+:root[data-os-theme="macosx"][data-os-aqua-material="glass"][data-os-color-scheme="dark"]
+  .spotlight-panel {
+  background: color-mix(
+    in srgb,
+    var(--os-accent-color, #3a73d6) 7%,
+    rgba(36, 38, 44, 0.62)
+  ) !important;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.55),
+    inset 0 1px 0 rgba(255, 255, 255, 0.1) !important;
+}
+
 /* Modern macOS menu layout: the panel gets a uniform inner gutter and each
    item carries a rounded highlight inset from the panel edge (the classic
    edge-to-edge selection bar is a non-glass Aqua trait). The `!important`s

--- a/src/styles/themes.css
+++ b/src/styles/themes.css
@@ -3699,6 +3699,18 @@
   caret-color: var(--os-color-text-primary);
 }
 
+/* The Spotlight search field pill is hardcoded white inline (the light-mode
+   Aqua look). In dark mode that bright pill clashes with the dark panel and
+   buries the light input text — swap it for a dark translucent well. Covers
+   both classic dark Aqua and dark Aqua Glass (both set the dark scheme attr). */
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"]
+  .spotlight-panel
+  .spotlight-input-well {
+  background: var(--os-color-input-bg) !important;
+  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.4),
+    0 0 0 1px rgba(255, 255, 255, 0.12) !important;
+}
+
 /* Aqua select triggers, the Radix `.os-select-trigger-macos` / `.os-btn-aqua-select`
    variants, and `.aqua-button.secondary` all bake light gradients
    (`rgba(160,160,160) → rgba(255,255,255)`) into CSS. In dark mode those


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Two Spotlight fixes for the Mac OS X theme:

**1. Aqua Glass backdrop blur.** The Spotlight panel rendered as a flat, fairly-opaque pane in the Aqua Glass material — it was missing the frosted backdrop blur the rest of the glass chrome uses. Spotlight isn't a Radix popper, so it was not covered by the existing frosted-popover rules and paints an opaque `var(--os-pinstripe-window)` inline. Added a glass-material `.spotlight-panel` rule mirroring the frosted dropdown/menu treatment: `backdrop-filter: blur(36px) saturate(200%)`, lighter translucent wash, rounded glass radius, hairline rim, soft shadow, plus a dark-glass variant.

**2. Dark-mode input pill.** The Spotlight search field pill is hardcoded white inline (the light-mode Aqua look). In dark mode that bright pill clashed with the dark panel and buried the (light) input text. Tagged the pill with `.spotlight-input-well` and added dark-mode overrides:
- Classic dark Aqua → opaque dark well (`--os-color-input-bg`).
- Dark Aqua Glass → dark translucent frosted well + backdrop blur (a near-transparent fill would let the bright wallpaper read as a light pill).

All rules are scoped to `[data-os-theme="macosx"]` (+ material/scheme attrs); System 7, Windows XP/98 and light Aqua are unaffected.

## Testing

Verified visually in the browser.

Aqua Glass spotlight backdrop blur:
<a href="https://cursor.com/agents/bc-019eba98-6d87-7bb3-a5b1-1f1cbe54dc1b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fspotlight_aqua_glass_backdrop_blur_demo.mp4"><img src="https://cursor.com/artifacts/c/art-e7d6dd15-d861-463c-91cd-db1d60e59917" alt="spotlight_aqua_glass_backdrop_blur_demo.mp4" /></a>

Dark-mode input pill is dark (not white) in both dark Aqua Glass and classic dark Aqua:
<a href="https://cursor.com/agents/bc-019eba98-6d87-7bb3-a5b1-1f1cbe54dc1b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fspotlight_dark_mode_input_not_white.mp4"><img src="https://cursor.com/artifacts/c/art-27dd78ab-9240-48f8-9006-c615f4c136b6" alt="spotlight_dark_mode_input_not_white.mp4" /></a>

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019eba98-6d87-7bb3-a5b1-1f1cbe54dc1b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019eba98-6d87-7bb3-a5b1-1f1cbe54dc1b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

