### PR TITLE
fix(aqua-glass): less rounded select buttons without corner-shape

### DIFF
--- a/src/styles/themes.css
+++ b/src/styles/themes.css
@@ -6369,8 +6369,11 @@
   --os-metrics-radius: calc(0.45rem * var(--os-glass-radius-factor));
   --os-glass-r-xs: calc(5px * var(--os-glass-radius-factor));
   --os-glass-r-sm: calc(6px * var(--os-glass-radius-factor));
-  --os-glass-r-select: calc(8px * var(--os-glass-radius-factor));
-  --os-glass-r-select-gloss: calc(7px * var(--os-glass-radius-factor));
+  /* Select triggers: classic Aqua 6px / 5px gloss when squircle is unavailable —
+     circular arcs read pill-like if we scale these with --os-glass-radius-factor. */
+  --os-glass-r-select: 6px;
+  --os-glass-r-select-gloss: 5px;
+  --os-glass-r-select-group: 6px;
   --os-glass-r-inset: calc(6px * var(--os-glass-radius-factor));
   --os-glass-r-md: calc(10px * var(--os-glass-radius-factor));
   --os-glass-r-dialog: calc(7.2px * var(--os-glass-radius-factor));
@@ -6417,27 +6420,27 @@
 :root[data-os-theme="macosx"][data-os-aqua-material="glass"]
   .aqua-select-group
   .aqua-select-btn:first-child {
-  border-top-left-radius: var(--os-glass-r-sm) !important;
-  border-bottom-left-radius: var(--os-glass-r-sm) !important;
+  border-top-left-radius: var(--os-glass-r-select-group) !important;
+  border-bottom-left-radius: var(--os-glass-r-select-group) !important;
 }
 
 :root[data-os-theme="macosx"][data-os-aqua-material="glass"]
   .aqua-select-group
   .aqua-select-btn:last-child {
-  border-top-right-radius: var(--os-glass-r-sm) !important;
-  border-bottom-right-radius: var(--os-glass-r-sm) !important;
+  border-top-right-radius: var(--os-glass-r-select-group) !important;
+  border-bottom-right-radius: var(--os-glass-r-select-group) !important;
 }
 
 :root[data-os-theme="macosx"][data-os-aqua-material="glass"]
   .aqua-select-group
   .aqua-select-btn:first-child::before {
-  border-top-left-radius: var(--os-glass-r-sm) !important;
+  border-top-left-radius: var(--os-glass-r-select-group) !important;
 }
 
 :root[data-os-theme="macosx"][data-os-aqua-material="glass"]
   .aqua-select-group
   .aqua-select-btn:last-child::before {
-  border-top-right-radius: var(--os-glass-r-sm) !important;
+  border-top-right-radius: var(--os-glass-r-select-group) !important;
 }
 
 :root[data-os-theme="macosx"][data-os-aqua-material="glass"] .macosx-dialog {
@@ -6469,6 +6472,9 @@
   :root[data-os-theme="macosx"][data-os-aqua-material="glass"] {
     --os-corner-shape: squircle;
     --os-glass-radius-factor: 1.84;
+    --os-glass-r-select: calc(8px * var(--os-glass-radius-factor));
+    --os-glass-r-select-gloss: calc(7px * var(--os-glass-radius-factor));
+    --os-glass-r-select-group: calc(6px * var(--os-glass-radius-factor));
   }
 
   /* NOTE: pseudo-elements are invalid inside :is()/:where() and get silently


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Reduces Aqua Glass select trigger border radii in browsers that do not support `corner-shape: squircle`, so dropdown/segmented controls no longer look overly pill-like with plain circular arcs.

## Changes

In `src/styles/themes.css` (glass corner radii section):

- **Fallback (no squircle):** `--os-glass-r-select` / `--os-glass-r-select-gloss` / `--os-glass-r-select-group` now use the existing classic Aqua constants (`6px` / `5px` / `6px`) instead of scaling via `--os-glass-radius-factor` (which produced ~10px corners).
- **Squircle-capable browsers:** unchanged — `@supports (corner-shape: squircle)` still bumps the shared factor to `1.84×` and overrides select radii to the scaled `8px` / `7px` / `6px` bases with `corner-shape: squircle`.
- **Scope:** glass select triggers only (`.macos-select-trigger`, `.os-select-trigger-macos`, `.os-btn-aqua-select`, `.aqua-select-btn`); other glass radii (tabs, dialogs, dock, etc.) are untouched.

## Testing

- `bun run lint` — 0 errors (pre-existing warnings only)
- `bun run test:unit` — 342 pass, 0 fail
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4b0705a8-e5f0-4ecc-9d8f-ba0e457ffac8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4b0705a8-e5f0-4ecc-9d8f-ba0e457ffac8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

