### PR TITLE
Move backup/restore controls from System tab to Sync tab

### DIFF
--- a/src/apps/control-panels/components/control-panels-app/ControlPanelsAppComponent.tsx
+++ b/src/apps/control-panels/components/control-panels-app/ControlPanelsAppComponent.tsx
@@ -455,6 +455,9 @@ export function ControlPanelsAppComponent({
                 cloudProgress={cloudProgress}
                 isCloudStatusLoading={isCloudStatusLoading}
                 CLOUD_BACKUP_MAX_SIZE={CLOUD_BACKUP_MAX_SIZE}
+                handleBackup={handleBackup}
+                fileInputRef={fileInputRef}
+                handleRestore={handleRestore}
               />
             </ThemedTabsContent>
 
@@ -482,9 +485,6 @@ export function ControlPanelsAppComponent({
                 openTelegramDialog={openTelegramDialog}
                 isTelegramStatusLoading={isTelegramStatusLoading}
                 handleCheckForUpdates={handleCheckForUpdates}
-                handleBackup={handleBackup}
-                fileInputRef={fileInputRef}
-                handleRestore={handleRestore}
                 handleResetAll={handleResetAll}
                 setIsConfirmFormatOpen={setIsConfirmFormatOpen}
                 setDebugMode={setDebugMode}

--- a/src/apps/control-panels/components/control-panels-app/SyncTabContent.tsx
+++ b/src/apps/control-panels/components/control-panels-app/SyncTabContent.tsx
@@ -1,3 +1,4 @@
+import type { RefObject } from "react";
 import { Button } from "@/components/ui/button";
 import { Switch } from "@/components/ui/switch";
 import { cn } from "@/lib/utils";
@@ -59,6 +60,9 @@ export type SyncTabContentProps = {
   cloudProgress: { phase: string; percent: number } | null;
   isCloudStatusLoading: boolean;
   CLOUD_BACKUP_MAX_SIZE: number;
+  handleBackup: () => void;
+  fileInputRef: RefObject<HTMLInputElement | null>;
+  handleRestore: (event: React.ChangeEvent<HTMLInputElement>) => void;
 };
 
 export function SyncTabContent({
@@ -104,6 +108,9 @@ export function SyncTabContent({
   cloudProgress,
   isCloudStatusLoading,
   CLOUD_BACKUP_MAX_SIZE,
+  handleBackup,
+  fileInputRef,
+  handleRestore,
 }: SyncTabContentProps) {
   return (
     <div className="space-y-4 h-full overflow-y-auto p-4">
@@ -350,6 +357,33 @@ export function SyncTabContent({
                     })}
           </p>
         )}
+      </div>
+
+      <hr className="my-4 border-t" style={tabStyles.separatorStyle} />
+
+      <div className="space-y-2">
+        <div className="flex gap-2">
+          <Button variant="retro" onClick={handleBackup} className="flex-1">
+            {t("apps.control-panels.backup")}
+          </Button>
+          <Button
+            variant="retro"
+            onClick={() => fileInputRef.current?.click()}
+            className="flex-1"
+          >
+            {t("apps.control-panels.restore")}
+          </Button>
+          <input
+            type="file"
+            ref={fileInputRef}
+            onChange={handleRestore}
+            accept=".json,.gz"
+            className="hidden"
+          />
+        </div>
+        <p className="text-[11px] text-neutral-600 font-geneva-12">
+          {t("apps.control-panels.backupRestoreDescription")}
+        </p>
       </div>
     </div>
   );

--- a/src/apps/control-panels/components/control-panels-app/SystemTabContent.tsx
+++ b/src/apps/control-panels/components/control-panels-app/SystemTabContent.tsx
@@ -1,4 +1,3 @@
-import type { RefObject } from "react";
 import { PaperPlaneRight } from "@phosphor-icons/react";
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
@@ -53,9 +52,6 @@ export type SystemTabContentProps = {
   openTelegramDialog: () => void;
   isTelegramStatusLoading: boolean;
   handleCheckForUpdates: () => void;
-  handleBackup: () => void;
-  fileInputRef: RefObject<HTMLInputElement | null>;
-  handleRestore: (event: React.ChangeEvent<HTMLInputElement>) => void;
   handleResetAll: () => void;
   setIsConfirmFormatOpen: (open: boolean) => void;
   setDebugMode: (enabled: boolean) => void;
@@ -98,9 +94,6 @@ export function SystemTabContent({
   openTelegramDialog,
   isTelegramStatusLoading,
   handleCheckForUpdates,
-  handleBackup,
-  fileInputRef,
-  handleRestore,
   handleResetAll,
   setIsConfirmFormatOpen,
   setDebugMode,
@@ -287,31 +280,6 @@ export function SystemTabContent({
           {t("apps.control-panels.checkForUpdates")}
         </Button>
         <VersionDisplay />
-      </div>
-
-      <div className="space-y-2">
-        <div className="flex gap-2">
-          <Button variant="retro" onClick={handleBackup} className="flex-1">
-            {t("apps.control-panels.backup")}
-          </Button>
-          <Button
-            variant="retro"
-            onClick={() => fileInputRef.current?.click()}
-            className="flex-1"
-          >
-            {t("apps.control-panels.restore")}
-          </Button>
-          <input
-            type="file"
-            ref={fileInputRef}
-            onChange={handleRestore}
-            accept=".json,.gz"
-            className="hidden"
-          />
-        </div>
-        <p className="text-[11px] text-neutral-600 font-geneva-12">
-          {t("apps.control-panels.backupRestoreDescription")}
-        </p>
       </div>
 
       <div className="space-y-2">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Moves the local **Back Up** and **Restore** controls from the System tab to the bottom of the Sync tab in Control Panels.

## Changes

- Removed backup/restore UI and related props from `SystemTabContent.tsx`
- Added backup/restore section at the bottom of `SyncTabContent.tsx` (below cloud sync controls)
- Updated prop wiring in `ControlPanelsAppComponent.tsx` to pass `handleBackup`, `fileInputRef`, and `handleRestore` to the Sync tab

## Behavior

- Existing backup/restore handlers are unchanged
- Same translation keys and file input (`accept=".json,.gz"`) preserved

## Testing

- `bunx tsc -b` — passes
- `bun test tests/test-control-panels-account-menu.test.ts tests/test-error-boundary-wiring.test.ts` — 9/9 pass
- Verified `apps.control-panels.backup` is only referenced in `SyncTabContent.tsx`, not `SystemTabContent.tsx`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-070a0199-7b8b-40b3-b9bc-a73c194525f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-070a0199-7b8b-40b3-b9bc-a73c194525f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

