### PR TITLE
Fix Aqua Glass menu open/close animations

### DIFF
--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -129,7 +129,7 @@ const DropdownMenuSubContent = (
     ref?: React.Ref<React.ElementRef<typeof DropdownMenuPrimitive.SubContent>>;
   }
 ) => {
-  const { isMacOSTheme } = useThemeFlags();
+  const { isMacOSTheme, isAquaGlass } = useThemeFlags();
   const isMobile = useMediaQuery("(max-width: 768px)");
 
   return (
@@ -146,11 +146,11 @@ const DropdownMenuSubContent = (
             border: "none",
             borderRadius: "0px",
             background: "var(--os-pinstripe-window)",
-            opacity: "0.92",
             boxShadow: "0 4px 16px rgba(0, 0, 0, 0.4)",
             padding: "4px 0px",
             ...(isMobile ? {} : { minWidth: "180px" }),
           }),
+          ...(isMacOSTheme && !isAquaGlass && { opacity: "0.92" }),
           ...(isMobile && { minWidth: "unset" }),
           ...style,
         }}
@@ -175,7 +175,7 @@ const DropdownMenuContent = (
     ref?: React.Ref<React.ElementRef<typeof DropdownMenuPrimitive.Content>>;
   }
 ) => {
-  const { isMacOSTheme } = useThemeFlags();
+  const { isMacOSTheme, isAquaGlass } = useThemeFlags();
   const isMobile = useMediaQuery("(max-width: 768px)");
 
   return (
@@ -195,11 +195,11 @@ const DropdownMenuContent = (
             border: "none",
             borderRadius: "0px",
             background: "var(--os-pinstripe-window)",
-            opacity: "0.92",
             boxShadow: "0 4px 16px rgba(0, 0, 0, 0.4)",
             padding: "4px 0px",
             ...(isMobile ? {} : { minWidth: style?.minWidth ?? "180px" }),
           }),
+          ...(isMacOSTheme && !isAquaGlass && { opacity: "0.92" }),
           ...(isMobile && { minWidth: "unset" }),
           ...style,
         }}

--- a/src/components/ui/menubar.tsx
+++ b/src/components/ui/menubar.tsx
@@ -182,7 +182,7 @@ const MenubarSubContent = (
     ref?: React.Ref<React.ElementRef<typeof MenubarPrimitive.SubContent>>;
   }
 ) => {
-  const { isMacOSTheme } = useThemeFlags()
+  const { isMacOSTheme, isAquaGlass } = useThemeFlags()
   const isMobile = useMediaQuery("(max-width: 768px)")
 
   return (
@@ -199,11 +199,11 @@ const MenubarSubContent = (
             border: "none",
             borderRadius: "0px",
             background: "var(--os-pinstripe-window)",
-            opacity: "0.92",
             boxShadow: "0 4px 16px rgba(0, 0, 0, 0.4)",
             padding: "4px 0px",
             ...(isMobile ? {} : { minWidth: "180px" }),
           }),
+          ...(isMacOSTheme && !isAquaGlass && { opacity: "0.92" }),
           ...(isMobile && { minWidth: "unset" }),
           ...style,
         }}
@@ -227,7 +227,7 @@ const MenubarContent = (
     ref?: React.Ref<React.ElementRef<typeof MenubarPrimitive.Content>>;
   }
 ) => {
-  const { isMacOSTheme } = useThemeFlags()
+  const { isMacOSTheme, isAquaGlass } = useThemeFlags()
   const isMobile = useMediaQuery("(max-width: 768px)")
   const isSwitching = React.use(MenubarSwitchingContext)
 
@@ -244,6 +244,9 @@ const MenubarContent = (
           "z-[10003] min-w-[12rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md",
           // Only animate when not switching between menus
           !isSwitching && "data-[state=open]:animate-in data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+          // Aqua Glass: also run the exit keyframe so the panel fades + scales
+          // back toward the trigger instead of cutting out abruptly (jitter).
+          !isSwitching && isAquaGlass && "data-[state=closed]:animate-out",
           className
         )}
         style={{
@@ -251,11 +254,13 @@ const MenubarContent = (
             border: "none",
             borderRadius: "0px",
             background: "var(--os-pinstripe-window)",
-            opacity: "0.92",
             boxShadow: "0 4px 16px rgba(0, 0, 0, 0.4)",
             padding: "4px 0px",
             ...(isMobile ? {} : { minWidth: style?.minWidth ?? "180px" }),
           }),
+          // Classic Aqua washes the panel to 0.92; glass stays fully opaque so
+          // the fade keyframe can drive opacity from 0 → 1 (and back) cleanly.
+          ...(isMacOSTheme && !isAquaGlass && { opacity: "0.92" }),
           ...(isMobile && { minWidth: "unset" }),
           ...style,
         }}

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -125,7 +125,7 @@ const SelectContent = (
     ref?: React.Ref<React.ElementRef<typeof SelectPrimitive.Content>>;
   }
 ) => {
-  const { isMacOSTheme } = useThemeFlags();
+  const { isMacOSTheme, isAquaGlass } = useThemeFlags();
 
   return (
     <SelectPrimitive.Portal>
@@ -142,10 +142,10 @@ const SelectContent = (
             border: "none",
             borderRadius: "0px",
             background: "var(--os-pinstripe-window)",
-            opacity: "0.92",
             boxShadow: "0 4px 16px rgba(0, 0, 0, 0.4)",
             padding: "4px 0px",
           }),
+          ...(isMacOSTheme && !isAquaGlass && { opacity: "0.92" }),
         }}
         position={position}
         {...props}

--- a/src/styles/themes.css
+++ b/src/styles/themes.css
@@ -5896,14 +5896,20 @@
   backdrop-filter: blur(36px) saturate(200%) !important;
   -webkit-backdrop-filter: blur(36px) saturate(200%) !important;
   /* Replace the inline pinstripe-window fill (0.74–0.8 alpha — opaque enough
-     to bury the blur) with a lighter wash so the backdrop blur reads through,
-     and kill the inline `opacity: 0.92` which washes out labels. */
+     to bury the blur) with a lighter wash so the backdrop blur reads through.
+     The inline `opacity: 0.92` (which washed out labels) is now skipped in
+     glass mode by the React components, so the element rests at full opacity
+     WITHOUT an `!important` override — that lets the open/close fade keyframes
+     actually animate opacity (an `!important` here would beat the animation). */
   background: color-mix(
     in srgb,
     var(--os-accent-color, #3a73d6) 6%,
     rgba(248, 250, 253, 0.62)
   ) !important;
-  opacity: 1 !important;
+  /* Grow/shrink the panel from the menubar/select trigger rather than the
+     panel centre. Radix publishes the anchor point on the popper wrapper as
+     `--radix-popper-transform-origin`, which this content inherits. */
+  transform-origin: var(--radix-popper-transform-origin) !important;
   /* Overrides the inline `0px` radius from the dropdown/select content. */
   border-radius: var(--os-glass-r-md) !important;
   border: var(--os-metrics-border-width) solid var(--os-color-window-border) !important;

--- a/src/styles/themes.css
+++ b/src/styles/themes.css
@@ -5910,6 +5910,11 @@
      panel centre. Radix publishes the anchor point on the popper wrapper as
      `--radix-popper-transform-origin`, which this content inherits. */
   transform-origin: var(--radix-popper-transform-origin) !important;
+  /* Slow the open/close keyframes down from tailwindcss-animate's snappy 150ms
+     default and ease them, so the frosted panel visibly fades + scales from the
+     trigger instead of snapping (the abrupt 150ms cut reads as exit jitter). */
+  animation-duration: 220ms !important;
+  animation-timing-function: cubic-bezier(0.22, 0.61, 0.36, 1) !important;
   /* Overrides the inline `0px` radius from the dropdown/select content. */
   border-radius: var(--os-glass-r-md) !important;
   border: var(--os-metrics-border-width) solid var(--os-color-window-border) !important;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the three reported problems with Aqua Glass menu animations (top menubar dropdowns, context dropdowns, submenus, and selects):

1. **Jitter when exiting** — `MenubarContent` (top-level menubar menus) was missing `data-[state=closed]:animate-out`, so glass menus had no exit keyframe and hard-cut on close. Added it (scoped to glass via `isAquaGlass`). Dropdowns/selects/submenus already had `animate-out` but the exit was effectively invisible (see #3).
2. **Origin should come from the toggle** — menu panels zoomed from their own center. They now use Radix's `--radix-popper-transform-origin`, so the panel scales out of / back toward the trigger.
3. **Lacking opacity transition** — the glass CSS forced `opacity: 1 !important` on the popover, and `!important` author rules beat CSS animations, so the fade keyframe never drove opacity. The React components now skip the inline `opacity: 0.92` in glass mode (classic Aqua keeps it), so the panel rests at full opacity *without* `!important` and the fade keyframe can animate `0 → 1` (and back).

Also slowed the glass open/close keyframes from tailwindcss-animate's snappy 150ms default to **220ms with an ease-out curve**, so the frosted fade + scale reads as a smooth transition rather than an abrupt snap.

## Changes

- `src/components/ui/menubar.tsx` — `MenubarContent` adds glass-only `data-[state=closed]:animate-out`; `MenubarContent`/`MenubarSubContent` only apply the `0.92` opacity wash for classic Aqua (not glass).
- `src/components/ui/dropdown-menu.tsx` — `DropdownMenuContent`/`DropdownMenuSubContent` opacity wash gated to classic Aqua only.
- `src/components/ui/select.tsx` — `SelectContent` opacity wash gated to classic Aqua only.
- `src/styles/themes.css` — glass frosted-popover rule drops `opacity: 1 !important`, adds `transform-origin: var(--radix-popper-transform-origin)`, and sets a 220ms eased `animation-duration`/`animation-timing-function`.

Non-glass themes (classic Aqua, System 7, Windows XP/98) are unchanged.

## Testing

- Verified the close animation numerically by sampling the menu content element's computed style each frame in a headless Chromium (Aqua Glass active): on close, `opacity` animates `1 → 0` and `scale` `1 → 0.95` over ~220ms with `transform-origin` resolving to the trigger anchor, and the element stays mounted for the full animation before removal.
- Confirmed the real browser runs the same keyframes (open fade `0 → 1` over ~165ms captured live).
- `bun run build` succeeds.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ebe50-8926-7f69-9108-ce55f981a1d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ebe50-8926-7f69-9108-ce55f981a1d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

