### PR TITLE
Restrict IRC room creation to admin only

### DIFF
--- a/api/rooms/index.ts
+++ b/api/rooms/index.ts
@@ -20,10 +20,6 @@ import {
   normalizeIrcChannel,
 } from "../_utils/irc/_types.js";
 import { getIrcServer } from "../_utils/irc/_servers.js";
-import {
-  isIrcBridgeEnabled,
-  getIrcBridge,
-} from "../_utils/irc/_bridge.js";
 
 export const runtime = "nodejs";
 export const maxDuration = 30;
@@ -103,6 +99,13 @@ export default apiHandler(
     }
 
     if (type === "irc") {
+      if (username !== "ryo") {
+        logger.response(403, Date.now() - startTime);
+        res
+          .status(403)
+          .json({ error: "Forbidden - Only admin can create IRC rooms" });
+        return;
+      }
       if (isProfaneUsername(originalName || "")) {
         logger.response(400, Date.now() - startTime);
         res.status(400).json({ error: "Room name contains inappropriate language" });
@@ -151,88 +154,32 @@ export default apiHandler(
       const serverIdRaw =
         typeof ircServerIdBody === "string" ? ircServerIdBody.trim() : "";
 
-      if (username === "ryo") {
-        const serverFromRegistry = serverIdRaw
-          ? await getIrcServer(serverIdRaw)
-          : null;
-        if (serverIdRaw && !serverFromRegistry) {
-          logger.response(400, Date.now() - startTime);
-          res.status(400).json({ error: "Unknown IRC server id" });
-          return;
-        }
-        if (serverFromRegistry) {
-          ircResolved = {
-            host: serverFromRegistry.host,
-            port: serverFromRegistry.port,
-            tls: serverFromRegistry.tls,
-            channel: derivedChannel,
-            ircServerLabel: serverFromRegistry.label,
-          };
-        } else {
-          ircResolved = {
-            host: (ircHostBody || DEFAULT_IRC_HOST).toString().toLowerCase(),
-            port: Number(ircPortBody) || DEFAULT_IRC_PORT,
-            tls: typeof ircTlsBody === "boolean" ? ircTlsBody : DEFAULT_IRC_TLS,
-            channel: derivedChannel,
-            ircServerLabel:
-              typeof ircServerLabelBody === "string" &&
-              ircServerLabelBody.trim()
-                ? ircServerLabelBody.trim()
-                : undefined,
-          };
-        }
-      } else {
-        if (!serverIdRaw) {
-          logger.response(403, Date.now() - startTime);
-          res.status(403).json({
-            error:
-              "Forbidden — pick a registered IRC server to create a bridged room",
-          });
-          return;
-        }
-        const serverFromRegistry = await getIrcServer(serverIdRaw);
-        if (!serverFromRegistry) {
-          logger.response(400, Date.now() - startTime);
-          res.status(400).json({ error: "Unknown IRC server id" });
-          return;
-        }
-        if (!isIrcBridgeEnabled()) {
-          logger.response(503, Date.now() - startTime);
-          res.status(503).json({
-            error: "IRC bridge is disabled in this environment",
-          });
-          return;
-        }
-        try {
-          const advertised = await getIrcBridge().listChannels(
-            serverFromRegistry.host,
-            serverFromRegistry.port,
-            serverFromRegistry.tls,
-            { maxChannels: 2000, timeoutMs: 15000 }
-          );
-          const channelOk = advertised.some(
-            (c) => c.channel.toLowerCase() === derivedChannel.toLowerCase()
-          );
-          if (!channelOk) {
-            logger.response(403, Date.now() - startTime);
-            res.status(403).json({
-              error:
-                "Channel must appear in that server’s public channel list (refresh the list and pick a channel)",
-            });
-            return;
-          }
-        } catch (err) {
-          logger.error("IRC channel validation failed", err);
-          logger.response(503, Date.now() - startTime);
-          res.status(503).json({ error: "Failed to validate IRC channel" });
-          return;
-        }
+      const serverFromRegistry = serverIdRaw
+        ? await getIrcServer(serverIdRaw)
+        : null;
+      if (serverIdRaw && !serverFromRegistry) {
+        logger.response(400, Date.now() - startTime);
+        res.status(400).json({ error: "Unknown IRC server id" });
+        return;
+      }
+      if (serverFromRegistry) {
         ircResolved = {
           host: serverFromRegistry.host,
           port: serverFromRegistry.port,
           tls: serverFromRegistry.tls,
           channel: derivedChannel,
           ircServerLabel: serverFromRegistry.label,
+        };
+      } else {
+        ircResolved = {
+          host: (ircHostBody || DEFAULT_IRC_HOST).toString().toLowerCase(),
+          port: Number(ircPortBody) || DEFAULT_IRC_PORT,
+          tls: typeof ircTlsBody === "boolean" ? ircTlsBody : DEFAULT_IRC_TLS,
+          channel: derivedChannel,
+          ircServerLabel:
+            typeof ircServerLabelBody === "string" && ircServerLabelBody.trim()
+              ? ircServerLabelBody.trim()
+              : undefined,
         };
       }
 

--- a/src/apps/chats/components/create-room-dialog/CreateRoomDialogContent.tsx
+++ b/src/apps/chats/components/create-room-dialog/CreateRoomDialogContent.tsx
@@ -45,7 +45,7 @@ export function CreateRoomDialogContent({ vm }: Props) {
         <ThemedTabsList
           className={cn(
             "grid w-full",
-            isAdmin ? "grid-cols-3" : "grid-cols-2"
+            isAdmin ? "grid-cols-3" : "grid-cols-1"
           )}
         >
           <ThemedTabsTrigger value="private">
@@ -56,7 +56,7 @@ export function CreateRoomDialogContent({ vm }: Props) {
               {t("apps.chats.dialogs.public")}
             </ThemedTabsTrigger>
           )}
-          <ThemedTabsTrigger value="irc">IRC</ThemedTabsTrigger>
+          {isAdmin && <ThemedTabsTrigger value="irc">IRC</ThemedTabsTrigger>}
         </ThemedTabsList>
         {isAdmin && (
           <CreateRoomDialogPublicTab
@@ -67,7 +67,7 @@ export function CreateRoomDialogContent({ vm }: Props) {
             isLoading={vm.isLoading}
           />
         )}
-        <CreateRoomDialogIrcTab {...vm} />
+        {isAdmin && <CreateRoomDialogIrcTab {...vm} />}
         <CreateRoomDialogPrivateTab
           t={vm.t}
           theme={vm.theme}

--- a/tests/test-irc-bridge.test.ts
+++ b/tests/test-irc-bridge.test.ts
@@ -441,9 +441,9 @@ describe("IRC Bridge wiring", () => {
     const fs = await import("node:fs/promises");
     const src = await fs.readFile("api/rooms/index.ts", "utf-8");
     expect(/notifyRoomBindingChange\s*\(\s*"bind"/.test(src)).toBe(false);
-    // The create route must honour the opt-out flag so IRC_BRIDGE_DISABLED=1
-    // never accidentally validates against a disabled bridge.
-    expect(src).toContain("isIrcBridgeEnabled");
+    // IRC room creation is admin-only; the registry is trusted without
+    // re-validating channels against the live bridge at create time.
+    expect(src).toContain("Only admin can create IRC rooms");
     expect(src).toContain("getIrcServer");
     expect(src).toContain("ircServerId");
   });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Previously any authenticated user could create an IRC-bridged room as long as they picked a registered server and a channel from the advertised list. This change makes IRC room creation **admin-only** (`ryo`), consistent with public-room creation and IRC-server management which are already admin-gated.

## Changes

- **`api/rooms/index.ts`**: Reject non-admin users with `403 Forbidden - Only admin can create IRC rooms` for `type === "irc"`. Removed the now-dead non-admin branch that validated channels against the live bridge, so the IRC server registry is trusted directly. Dropped the now-unused `isIrcBridgeEnabled` / `getIrcBridge` imports.
- **`src/apps/chats/components/create-room-dialog/CreateRoomDialogContent.tsx`**: Only render the IRC tab/trigger for admins; non-admins now see just the Private tab.
- **`tests/test-irc-bridge.test.ts`**: Updated the create-route wiring assertion to reflect that IRC creation is admin-gated and no longer re-validates against the bridge at create time.

## Testing

- `bun test tests/test-irc-bridge.test.ts tests/test-realtime-channels.test.ts` — all pass.
- Manual API verification against `bun run dev:api`:
  - Non-admin `POST /api/rooms` with `type: "irc"` → `403 {"error":"Forbidden - Only admin can create IRC rooms"}`.
  - Admin (`ryo`) `POST /api/rooms` with `type: "irc"` → `201` (room created), cleanup delete `200`.
- `bunx tsc -b` and `eslint` on changed files pass.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ebea5-918a-75eb-949c-50df898e226b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ebea5-918a-75eb-949c-50df898e226b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

