### PR TITLE
Add admin Redis browser

### DIFF
--- a/api/_utils/redis.ts
+++ b/api/_utils/redis.ts
@@ -57,6 +57,7 @@ export interface RedisLike {
   persist(key: string): Promise<number>;
   incr(key: string): Promise<number>;
   ttl(key: string): Promise<number>;
+  type(key: string): Promise<string>;
   scan(
     cursor: number | string,
     options?: RedisScanOptions
@@ -309,6 +310,10 @@ class StandardRedisAdapter implements RedisLike {
 
   async ttl(key: string): Promise<number> {
     return await this.client.ttl(key);
+  }
+
+  async type(key: string): Promise<string> {
+    return await this.client.type(key);
   }
 
   async scan(

--- a/api/admin.ts
+++ b/api/admin.ts
@@ -421,7 +421,7 @@ async function getRedisKeyType(redis: Redis, key: string): Promise<RedisKeyType>
     }
     return "unknown";
   } catch (error) {
-    console.error(`Error reading Redis type for ${key}:`, error);
+    console.error("Error reading Redis type", { key, error });
     return "unknown";
   }
 }
@@ -543,7 +543,7 @@ async function getRedisKeyDocument(
       }
     }
   } catch (error) {
-    console.error(`Error reading Redis key ${key}:`, error);
+    console.error("Error reading Redis key", { key, error });
     return {
       ...summary,
       value: null,

--- a/api/admin.ts
+++ b/api/admin.ts
@@ -32,6 +32,8 @@ interface AdminRequest {
   reason?: string;
   prompt?: string;
   modelId?: string;
+  key?: string;
+  confirmKey?: string;
 }
 
 interface UserProfile {
@@ -358,6 +360,261 @@ async function getStats(redis: Redis): Promise<{ totalUsers: number; totalRooms:
   }
 }
 
+type RedisKeyType = "string" | "list" | "set" | "hash" | "zset" | "none" | "stream" | "unknown";
+
+interface RedisKeySummary {
+  key: string;
+  type: RedisKeyType;
+  ttl: number | null;
+}
+
+interface RedisKeyDocument extends RedisKeySummary {
+  value: unknown;
+  length: number | null;
+  truncated: boolean;
+}
+
+const REDIS_BROWSER_SCAN_COUNT_DEFAULT = 100;
+const REDIS_BROWSER_SCAN_COUNT_MAX = 250;
+const REDIS_BROWSER_VALUE_PREVIEW_LIMIT = 200;
+const REDIS_BROWSER_BACKUP_KEY_LIMIT_DEFAULT = 500;
+const REDIS_BROWSER_BACKUP_KEY_LIMIT_MAX = 1000;
+
+function normalizeRedisPattern(pattern: unknown): string {
+  if (typeof pattern !== "string") return "*";
+  const trimmed = pattern.trim();
+  return trimmed.length > 0 ? trimmed : "*";
+}
+
+function clampInteger(value: unknown, fallback: number, min: number, max: number): number {
+  const parsed =
+    typeof value === "number"
+      ? value
+      : typeof value === "string"
+        ? Number.parseInt(value, 10)
+        : NaN;
+  if (!Number.isFinite(parsed)) return fallback;
+  return Math.min(Math.max(parsed, min), max);
+}
+
+function normalizeRedisCursor(cursor: unknown): string | number {
+  if (typeof cursor === "number") return cursor;
+  if (typeof cursor === "string" && cursor.trim()) return cursor.trim();
+  return 0;
+}
+
+async function getRedisKeyType(redis: Redis, key: string): Promise<RedisKeyType> {
+  try {
+    const typedRedis = redis as Redis & { type?: (key: string) => Promise<string> };
+    const rawType = await typedRedis.type?.(key);
+    if (!rawType) return "unknown";
+    if (
+      rawType === "string" ||
+      rawType === "list" ||
+      rawType === "set" ||
+      rawType === "hash" ||
+      rawType === "zset" ||
+      rawType === "none" ||
+      rawType === "stream"
+    ) {
+      return rawType;
+    }
+    return "unknown";
+  } catch (error) {
+    console.error(`Error reading Redis type for ${key}:`, error);
+    return "unknown";
+  }
+}
+
+async function getRedisTtl(redis: Redis, key: string): Promise<number | null> {
+  try {
+    return await redis.ttl(key);
+  } catch {
+    return null;
+  }
+}
+
+async function getRedisKeySummary(redis: Redis, key: string): Promise<RedisKeySummary> {
+  const [type, ttl] = await Promise.all([
+    getRedisKeyType(redis, key),
+    getRedisTtl(redis, key),
+  ]);
+  return { key, type, ttl };
+}
+
+function truncateObjectEntries(
+  value: Record<string, unknown>,
+  limit: number
+): { value: Record<string, unknown>; truncated: boolean; length: number } {
+  const entries = Object.entries(value);
+  if (entries.length <= limit) {
+    return { value, truncated: false, length: entries.length };
+  }
+  return {
+    value: Object.fromEntries(entries.slice(0, limit)),
+    truncated: true,
+    length: entries.length,
+  };
+}
+
+async function getRedisKeyDocument(
+  redis: Redis,
+  key: string,
+  options: { full?: boolean } = {}
+): Promise<RedisKeyDocument | null> {
+  const exists = await redis.exists(key);
+  if (exists === 0) return null;
+
+  const summary = await getRedisKeySummary(redis, key);
+  const previewLimit = options.full ? Number.POSITIVE_INFINITY : REDIS_BROWSER_VALUE_PREVIEW_LIMIT;
+
+  try {
+    switch (summary.type) {
+      case "string": {
+        const value = await redis.get(key);
+        const stringValue =
+          typeof value === "string" ? value : JSON.stringify(value ?? null);
+        return {
+          ...summary,
+          value,
+          length: stringValue.length,
+          truncated: false,
+        };
+      }
+      case "list": {
+        const length = await redis.llen(key);
+        const value = await redis.lrange(
+          key,
+          0,
+          options.full ? -1 : REDIS_BROWSER_VALUE_PREVIEW_LIMIT - 1
+        );
+        return {
+          ...summary,
+          value,
+          length,
+          truncated: !options.full && length > previewLimit,
+        };
+      }
+      case "set": {
+        const members = await redis.smembers<string[]>(key);
+        return {
+          ...summary,
+          value: options.full ? members : members.slice(0, REDIS_BROWSER_VALUE_PREVIEW_LIMIT),
+          length: members.length,
+          truncated: !options.full && members.length > previewLimit,
+        };
+      }
+      case "hash": {
+        const hash = (await redis.hgetall<Record<string, unknown>>(key)) ?? {};
+        const limited = options.full
+          ? { value: hash, truncated: false, length: Object.keys(hash).length }
+          : truncateObjectEntries(hash, REDIS_BROWSER_VALUE_PREVIEW_LIMIT);
+        return {
+          ...summary,
+          value: limited.value,
+          length: limited.length,
+          truncated: limited.truncated,
+        };
+      }
+      case "zset": {
+        const length = await redis.zcard(key);
+        const value = await redis.zrange(
+          key,
+          0,
+          options.full ? -1 : REDIS_BROWSER_VALUE_PREVIEW_LIMIT - 1
+        );
+        return {
+          ...summary,
+          value,
+          length,
+          truncated: !options.full && length > previewLimit,
+        };
+      }
+      case "none":
+        return null;
+      default: {
+        const value = await redis.get(key).catch(() => null);
+        return {
+          ...summary,
+          value,
+          length: null,
+          truncated: false,
+        };
+      }
+    }
+  } catch (error) {
+    console.error(`Error reading Redis key ${key}:`, error);
+    return {
+      ...summary,
+      value: null,
+      length: null,
+      truncated: false,
+    };
+  }
+}
+
+async function listRedisKeys(
+  redis: Redis,
+  input: { pattern: string; cursor: string | number; count: number }
+): Promise<{ keys: RedisKeySummary[]; cursor: string; pattern: string; count: number }> {
+  const [nextCursor, keys] = await redis.scan(input.cursor, {
+    match: input.pattern,
+    count: input.count,
+  });
+  const summaries = await Promise.all(keys.sort().map((key) => getRedisKeySummary(redis, key)));
+  return {
+    keys: summaries,
+    cursor: String(nextCursor),
+    pattern: input.pattern,
+    count: summaries.length,
+  };
+}
+
+async function backupRedisKeys(
+  redis: Redis,
+  input: { pattern: string; limit: number }
+): Promise<{
+  exportedAt: string;
+  pattern: string;
+  keyCount: number;
+  truncated: boolean;
+  keys: RedisKeyDocument[];
+}> {
+  const keys: string[] = [];
+  let cursor: string | number = 0;
+  let iterations = 0;
+
+  do {
+    const [nextCursor, batch] = await redis.scan(cursor, {
+      match: input.pattern,
+      count: REDIS_BROWSER_SCAN_COUNT_MAX,
+    });
+    cursor = nextCursor;
+    keys.push(...batch);
+    iterations++;
+  } while (
+    cursor !== 0 &&
+    cursor !== "0" &&
+    keys.length < input.limit &&
+    iterations < 200
+  );
+
+  const limitedKeys = Array.from(new Set(keys)).sort().slice(0, input.limit);
+  const documents = (
+    await Promise.all(
+      limitedKeys.map((key) => getRedisKeyDocument(redis, key, { full: true }))
+    )
+  ).filter((document): document is RedisKeyDocument => document !== null);
+
+  return {
+    exportedAt: new Date().toISOString(),
+    pattern: input.pattern,
+    keyCount: documents.length,
+    truncated: keys.length > input.limit || (cursor !== 0 && cursor !== "0"),
+    keys: documents,
+  };
+}
+
 interface UserMemory {
   key: string;
   summary: string;
@@ -548,6 +805,61 @@ export default apiHandler<AdminRequest>(
             truncated: sliceTruncated || scanIncomplete,
             scanIncomplete,
           });
+          return;
+        }
+        case "listRedisKeys": {
+          const pattern = normalizeRedisPattern(req.query.pattern);
+          const cursor = normalizeRedisCursor(req.query.cursor);
+          const count = clampInteger(
+            req.query.count,
+            REDIS_BROWSER_SCAN_COUNT_DEFAULT,
+            1,
+            REDIS_BROWSER_SCAN_COUNT_MAX
+          );
+          const data = await listRedisKeys(redis, { pattern, cursor, count });
+          logger.info("Redis keys listed", {
+            pattern,
+            cursor: data.cursor,
+            count: data.count,
+          });
+          logger.response(200, Date.now() - startTime);
+          res.status(200).json(data);
+          return;
+        }
+        case "getRedisKey": {
+          const key = typeof req.query.key === "string" ? req.query.key : "";
+          if (!key) {
+            logger.response(400, Date.now() - startTime);
+            res.status(400).json({ error: "Redis key is required" });
+            return;
+          }
+          const data = await getRedisKeyDocument(redis, key);
+          if (!data) {
+            logger.response(404, Date.now() - startTime);
+            res.status(404).json({ error: "Redis key not found" });
+            return;
+          }
+          logger.info("Redis key retrieved", { key, type: data.type });
+          logger.response(200, Date.now() - startTime);
+          res.status(200).json(data);
+          return;
+        }
+        case "backupRedisKeys": {
+          const pattern = normalizeRedisPattern(req.query.pattern);
+          const limit = clampInteger(
+            req.query.limit,
+            REDIS_BROWSER_BACKUP_KEY_LIMIT_DEFAULT,
+            1,
+            REDIS_BROWSER_BACKUP_KEY_LIMIT_MAX
+          );
+          const data = await backupRedisKeys(redis, { pattern, limit });
+          logger.info("Redis backup generated", {
+            pattern,
+            keyCount: data.keyCount,
+            truncated: data.truncated,
+          });
+          logger.response(200, Date.now() - startTime);
+          res.status(200).json(data);
           return;
         }
         default:
@@ -756,6 +1068,29 @@ export default apiHandler<AdminRequest>(
             res.status(500).json({ error: "Failed to process daily notes" });
             return;
           }
+        }
+        case "deleteRedisKey": {
+          const key = typeof body?.key === "string" ? body.key : "";
+          const confirmKey =
+            typeof body?.confirmKey === "string" ? body.confirmKey : "";
+          if (!key) {
+            logger.response(400, Date.now() - startTime);
+            res.status(400).json({ error: "Redis key is required" });
+            return;
+          }
+          if (confirmKey !== key) {
+            logger.response(400, Date.now() - startTime);
+            res.status(400).json({ error: "Confirmation does not match Redis key" });
+            return;
+          }
+          const deletedCount = await redis.del(key);
+          logger.info("Redis key delete requested", { key, deletedCount });
+          logger.response(200, Date.now() - startTime);
+          res.status(200).json({
+            success: deletedCount > 0,
+            deletedCount,
+          });
+          return;
         }
         default:
           logger.response(400, Date.now() - startTime);

--- a/src/api/admin.ts
+++ b/src/api/admin.ts
@@ -124,6 +124,37 @@ export async function getAdminCursorAgentRuns<TResponse>(
   return adminGet<TResponse>("getCursorAgentRuns", { limit });
 }
 
+export async function getAdminRedisKeys<TResponse>(input: {
+  pattern?: string;
+  cursor?: string;
+  count?: number;
+} = {}): Promise<TResponse> {
+  return adminGet<TResponse>("listRedisKeys", input);
+}
+
+export async function getAdminRedisKey<TResponse>(
+  key: string
+): Promise<TResponse> {
+  return adminGet<TResponse>("getRedisKey", { key });
+}
+
+export async function getAdminRedisBackup<TResponse>(input: {
+  pattern?: string;
+  limit?: number;
+} = {}): Promise<TResponse> {
+  return adminGet<TResponse>("backupRedisKeys", input);
+}
+
+export async function deleteAdminRedisKey<TResponse>(
+  key: string
+): Promise<TResponse> {
+  return adminPost<TResponse, { action: string; key: string; confirmKey: string }>({
+    action: "deleteRedisKey",
+    key,
+    confirmKey: key,
+  });
+}
+
 export async function postAdminStartCursorAgent<TResponse>(input: {
   prompt: string;
   modelId?: string;

--- a/src/apps/admin/components/AdminMenuBar.tsx
+++ b/src/apps/admin/components/AdminMenuBar.tsx
@@ -70,6 +70,7 @@ export function AdminMenuBar({
         ),
         sectionCheckbox("users", t("apps.admin.sidebar.users")),
         sectionCheckbox("songs", t("apps.admin.sidebar.songs")),
+        sectionCheckbox("redis", t("apps.admin.sidebar.redis", "Redis")),
         sectionCheckbox(
           "cursorAgents",
           t("apps.admin.sidebar.cursorAgents", "Cursor Agents")

--- a/src/apps/admin/components/AdminSidebar.tsx
+++ b/src/apps/admin/components/AdminSidebar.tsx
@@ -126,6 +126,13 @@ export const AdminSidebar: React.FC<AdminSidebarProps> = ({
             </div>
           </SelectableListItem>
 
+          <SelectableListItem
+            isSelected={activeSection === "redis"}
+            onClick={() => { playButtonClick(); onSectionChange("redis"); onRoomSelect(null); }}
+          >
+            {t("apps.admin.sidebar.redis", "Redis")}
+          </SelectableListItem>
+
           {/* Rooms Section Header */}
           <div
             className={cn(

--- a/src/apps/admin/components/admin-app/AdminMainPane.tsx
+++ b/src/apps/admin/components/admin-app/AdminMainPane.tsx
@@ -193,7 +193,8 @@ export function AdminMainPane({
         {!selectedUserProfile &&
           !selectedSongId &&
           activeSection !== "dashboard" &&
-          activeSection !== "cursorAgents" && (
+          activeSection !== "cursorAgents" &&
+          activeSection !== "redis" && (
             <AdminToolbar
               t={t}
               currentTheme={currentTheme}

--- a/src/apps/admin/components/admin-app/AdminMainPane.tsx
+++ b/src/apps/admin/components/admin-app/AdminMainPane.tsx
@@ -8,6 +8,7 @@ import { AdminToolbar } from "./AdminToolbar";
 import { AdminImportStatusBar } from "./AdminImportStatusBar";
 import { AdminScrollContent } from "./AdminScrollContent";
 import { AdminStatusBar } from "./AdminStatusBar";
+import { AdminRedisBrowserView } from "./AdminRedisBrowserView";
 import type { AdminSection } from "../../utils/navigationState";
 import type { TFunction } from "i18next";
 import type { CachedSongMetadata } from "@/utils/songMetadataCache";
@@ -175,6 +176,12 @@ export function AdminMainPane({
   deleteMessage,
   username,
 }: AdminMainPaneProps) {
+  const showRedisPanel =
+    activeSection === "redis" &&
+    !selectedRoomId &&
+    !selectedUserProfile &&
+    !selectedSongId;
+
   return (
     <div ref={containerRef} className="flex size-full admin-force-font">
       <AdminSidebar
@@ -241,11 +248,17 @@ export function AdminMainPane({
           </div>
         ) : null}
 
+        {showRedisPanel ? (
+          <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+            <AdminRedisBrowserView t={t} />
+          </div>
+        ) : null}
+
         <ScrollArea
           ref={scrollAreaRef}
           className={cn(
             "min-h-0 min-w-0 flex-1",
-            showCursorAgentsPanel && "hidden",
+            (showCursorAgentsPanel || showRedisPanel) && "hidden",
           )}
         >
           <AdminScrollContent

--- a/src/apps/admin/components/admin-app/AdminRedisBrowserView.tsx
+++ b/src/apps/admin/components/admin-app/AdminRedisBrowserView.tsx
@@ -28,13 +28,14 @@ import {
 } from "@/api/admin";
 import { cn } from "@/lib/utils";
 import {
-  adminCardClass,
-  adminCardHeaderClass,
   adminGhostIconBtnClass,
   adminLoadMoreBtnClass,
+  adminDetailHeaderClass,
   adminSectionLabelClass,
+  adminSurfaceClass,
   adminTableHeadClass,
   adminTableRowClass,
+  adminToolbarClass,
 } from "../../utils/adminStyles";
 
 interface RedisKeySummary {
@@ -225,10 +226,13 @@ export function AdminRedisBrowserView({ t }: AdminRedisBrowserViewProps) {
   };
 
   return (
-    <div className="flex min-h-[360px] flex-col gap-3 p-3 font-geneva-12">
+    <div className="flex h-full min-h-0 flex-col font-geneva-12">
       <form
         onSubmit={handlePatternSubmit}
-        className="flex flex-wrap items-center gap-2"
+        className={cn(
+          adminToolbarClass,
+          "flex shrink-0 flex-wrap items-center gap-2 border-b border-os-separator px-2 py-1.5",
+        )}
       >
         <SearchInput
           placeholder={t("apps.admin.redis.patternPlaceholder", "Redis pattern, e.g. chat:*")}
@@ -274,12 +278,15 @@ export function AdminRedisBrowserView({ t }: AdminRedisBrowserViewProps) {
         </Button>
       </form>
 
-      <div className="grid min-h-[300px] gap-3 md:grid-cols-[minmax(220px,0.42fr)_minmax(0,1fr)]">
-        <section className={cn(adminCardClass, "min-w-0")}>
-          <div className={cn(adminCardHeaderClass, "flex items-center justify-between")}>
-            <span>{t("apps.admin.redis.keys", "Keys")}</span>
-            <span className="text-os-text-disabled">{keys.length}</span>
-          </div>
+      <div
+        className={cn(
+          "grid min-h-0 flex-1 gap-0",
+          selectedKey
+            ? "md:grid-cols-[minmax(0,1fr)_minmax(280px,42%)]"
+            : "grid-cols-1",
+        )}
+      >
+        <div className="min-h-0 min-w-0 overflow-auto">
           {keys.length === 0 && !isLoadingKeys ? (
             <div className="flex flex-col items-center justify-center px-3 py-12 text-os-text-disabled">
               <Database className="mb-2 size-8 opacity-50" weight="bold" />
@@ -288,7 +295,7 @@ export function AdminRedisBrowserView({ t }: AdminRedisBrowserViewProps) {
               </span>
             </div>
           ) : (
-            <div className="max-h-[520px] overflow-auto">
+            <>
               <Table>
                 <TableHeader>
                   <TableRow className="border-none text-[10px] font-normal">
@@ -356,71 +363,70 @@ export function AdminRedisBrowserView({ t }: AdminRedisBrowserViewProps) {
                   </Button>
                 </div>
               )}
-            </div>
+            </>
           )}
-        </section>
+        </div>
 
-        <section className={cn(adminCardClass, "min-w-0")}>
-          <div className={cn(adminCardHeaderClass, "flex items-center justify-between gap-2")}>
-            <span>{t("apps.admin.redis.detail", "Key Detail")}</span>
-            {selectedDocument && (
-              <Button
-                variant="ghost"
-                size="sm"
-                onClick={() => setDeleteCandidate(selectedDocument.key)}
-                disabled={isDeleting}
-                className={cn("size-6 p-0", adminGhostIconBtnClass)}
-                title={t("apps.admin.redis.delete", "Delete Redis key")}
-              >
-                {isDeleting ? <ActivityIndicator size={13} /> : <Trash size={13} weight="bold" />}
-              </Button>
-            )}
-          </div>
-          {!selectedKey ? (
-            <div className="flex h-full min-h-[220px] items-center justify-center px-3 text-center text-[11px] text-os-text-disabled">
-              {t("apps.admin.redis.selectKey", "Select a Redis key to inspect its value")}
-            </div>
-          ) : isLoadingDocument ? (
-            <div className="flex h-full min-h-[220px] items-center justify-center">
-              <ActivityIndicator size={18} />
-            </div>
-          ) : selectedDocument ? (
-            <div className="space-y-3 p-3">
-              <div className="min-w-0 space-y-1">
-                <div className={adminSectionLabelClass}>
-                  {t("apps.admin.redis.key", "Key")}
-                </div>
-                <div className="break-all font-os-mono text-[12px]">{selectedDocument.key}</div>
-              </div>
-              <div className="grid grid-cols-3 gap-2 text-[11px]">
-                <div>
-                  <div className={adminSectionLabelClass}>{t("apps.admin.redis.type", "Type")}</div>
-                  <div className="font-os-mono">{selectedDocument.type}</div>
-                </div>
-                <div>
-                  <div className={adminSectionLabelClass}>{t("apps.admin.redis.ttl", "TTL")}</div>
-                  <div>{formatRedisTtl(selectedDocument.ttl)}</div>
-                </div>
-                <div>
-                  <div className={adminSectionLabelClass}>{t("apps.admin.redis.length", "Length")}</div>
-                  <div>{selectedDocument.length ?? "-"}</div>
-                </div>
-              </div>
-              {selectedDocument.truncated && (
-                <div className="rounded border border-yellow-500/30 bg-yellow-500/10 px-2 py-1 text-[11px] text-yellow-800 os-mac-aqua-dark:text-yellow-200">
-                  {t("apps.admin.redis.previewTruncated", "Preview is truncated; use Backup for the full value.")}
-                </div>
+        {selectedKey ? (
+          <aside className={cn("flex h-full min-h-0 min-w-0 flex-col overflow-hidden border-l border-os-separator", adminSurfaceClass)}>
+            <div className={cn(adminDetailHeaderClass, "justify-between gap-2")}>
+              <span>{t("apps.admin.redis.detail", "Key Detail")}</span>
+              {selectedDocument && (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => setDeleteCandidate(selectedDocument.key)}
+                  disabled={isDeleting}
+                  className={cn("size-6 p-0", adminGhostIconBtnClass)}
+                  title={t("apps.admin.redis.delete", "Delete Redis key")}
+                  aria-label={t("apps.admin.redis.delete", "Delete Redis key")}
+                >
+                  {isDeleting ? <ActivityIndicator size={13} /> : <Trash size={13} weight="bold" />}
+                </Button>
               )}
-              <pre className="max-h-[420px] overflow-auto rounded bg-black/5 p-2 font-os-mono text-[11px] leading-relaxed os-mac-aqua-dark:bg-white/10">
-                {formatRedisValue(selectedDocument.value)}
-              </pre>
             </div>
-          ) : (
-            <div className="flex h-full min-h-[220px] items-center justify-center px-3 text-center text-[11px] text-os-text-disabled">
-              {t("apps.admin.redis.keyUnavailable", "Redis key is unavailable")}
-            </div>
-          )}
-        </section>
+            {isLoadingDocument ? (
+              <div className="flex h-full min-h-[220px] items-center justify-center">
+                <ActivityIndicator size={18} />
+              </div>
+            ) : selectedDocument ? (
+              <div className="min-h-0 flex-1 space-y-3 overflow-auto p-3">
+                <div className="min-w-0 space-y-1">
+                  <div className={adminSectionLabelClass}>
+                    {t("apps.admin.redis.key", "Key")}
+                  </div>
+                  <div className="break-all font-os-mono text-[12px]">{selectedDocument.key}</div>
+                </div>
+                <div className="grid grid-cols-3 gap-2 text-[11px]">
+                  <div>
+                    <div className={adminSectionLabelClass}>{t("apps.admin.redis.type", "Type")}</div>
+                    <div className="font-os-mono">{selectedDocument.type}</div>
+                  </div>
+                  <div>
+                    <div className={adminSectionLabelClass}>{t("apps.admin.redis.ttl", "TTL")}</div>
+                    <div>{formatRedisTtl(selectedDocument.ttl)}</div>
+                  </div>
+                  <div>
+                    <div className={adminSectionLabelClass}>{t("apps.admin.redis.length", "Length")}</div>
+                    <div>{selectedDocument.length ?? "-"}</div>
+                  </div>
+                </div>
+                {selectedDocument.truncated && (
+                  <div className="rounded border border-yellow-500/30 bg-yellow-500/10 px-2 py-1 text-[11px] text-yellow-800 os-mac-aqua-dark:text-yellow-200">
+                    {t("apps.admin.redis.previewTruncated", "Preview is truncated; use Backup for the full value.")}
+                  </div>
+                )}
+                <pre className="max-h-[420px] overflow-auto rounded bg-black/5 p-2 font-os-mono text-[11px] leading-relaxed os-mac-aqua-dark:bg-white/10">
+                  {formatRedisValue(selectedDocument.value)}
+                </pre>
+              </div>
+            ) : (
+              <div className="flex h-full min-h-[220px] items-center justify-center px-3 text-center text-[11px] text-os-text-disabled">
+                {t("apps.admin.redis.keyUnavailable", "Redis key is unavailable")}
+              </div>
+            )}
+          </aside>
+        ) : null}
       </div>
 
       <ConfirmDialog

--- a/src/apps/admin/components/admin-app/AdminRedisBrowserView.tsx
+++ b/src/apps/admin/components/admin-app/AdminRedisBrowserView.tsx
@@ -1,0 +1,387 @@
+import { FormEvent, useCallback, useEffect, useState } from "react";
+import { ArrowsClockwise, Database, DownloadSimple, Trash } from "@phosphor-icons/react";
+import type { TFunction } from "i18next";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { SearchInput } from "@/components/ui/search-input";
+import { ActivityIndicator } from "@/components/ui/activity-indicator";
+import { ConfirmDialog } from "@/components/dialogs/ConfirmDialog";
+import {
+  deleteAdminRedisKey,
+  getAdminRedisBackup,
+  getAdminRedisKey,
+  getAdminRedisKeys,
+} from "@/api/admin";
+import { cn } from "@/lib/utils";
+import {
+  adminCardClass,
+  adminCardHeaderClass,
+  adminGhostIconBtnClass,
+  adminListDividerClass,
+  adminLoadMoreBtnClass,
+  adminRowHoverClass,
+  adminSectionLabelClass,
+} from "../../utils/adminStyles";
+
+interface RedisKeySummary {
+  key: string;
+  type: string;
+  ttl: number | null;
+}
+
+interface RedisKeysResponse {
+  keys: RedisKeySummary[];
+  cursor: string;
+  count: number;
+}
+
+interface RedisKeyDocument extends RedisKeySummary {
+  value: unknown;
+  length: number | null;
+  truncated: boolean;
+}
+
+interface RedisBackupDocument {
+  exportedAt: string;
+  pattern: string;
+  keyCount: number;
+  truncated: boolean;
+  keys: RedisKeyDocument[];
+}
+
+interface DeleteRedisKeyResponse {
+  success: boolean;
+  deletedCount: number;
+}
+
+export interface AdminRedisBrowserViewProps {
+  t: TFunction;
+}
+
+function formatRedisTtl(ttl: number | null): string {
+  if (ttl === null) return "TTL unknown";
+  if (ttl === -2) return "missing";
+  if (ttl === -1) return "no expiry";
+  if (ttl < 60) return `${ttl}s`;
+  if (ttl < 3600) return `${Math.round(ttl / 60)}m`;
+  if (ttl < 86400) return `${Math.round(ttl / 3600)}h`;
+  return `${Math.round(ttl / 86400)}d`;
+}
+
+function formatRedisValue(value: unknown): string {
+  if (typeof value === "string") {
+    try {
+      return JSON.stringify(JSON.parse(value), null, 2);
+    } catch {
+      return value;
+    }
+  }
+  return JSON.stringify(value, null, 2);
+}
+
+function downloadJson(filename: string, data: unknown): void {
+  const blob = new Blob([JSON.stringify(data, null, 2)], {
+    type: "application/json",
+  });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = filename;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+}
+
+export function AdminRedisBrowserView({ t }: AdminRedisBrowserViewProps) {
+  const [pattern, setPattern] = useState("*");
+  const [appliedPattern, setAppliedPattern] = useState("*");
+  const [keys, setKeys] = useState<RedisKeySummary[]>([]);
+  const [cursor, setCursor] = useState("0");
+  const [isLoadingKeys, setIsLoadingKeys] = useState(false);
+  const [isBackingUp, setIsBackingUp] = useState(false);
+  const [selectedKey, setSelectedKey] = useState<string | null>(null);
+  const [selectedDocument, setSelectedDocument] = useState<RedisKeyDocument | null>(null);
+  const [isLoadingDocument, setIsLoadingDocument] = useState(false);
+  const [deleteCandidate, setDeleteCandidate] = useState<string | null>(null);
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  const loadKeys = useCallback(
+    async (nextCursor: string = "0") => {
+      setIsLoadingKeys(true);
+      try {
+        const data = await getAdminRedisKeys<RedisKeysResponse>({
+          pattern: appliedPattern,
+          cursor: nextCursor,
+          count: 100,
+        });
+        setCursor(data.cursor);
+        setKeys((prev) => (nextCursor === "0" ? data.keys : [...prev, ...data.keys]));
+        if (nextCursor === "0") {
+          setSelectedKey(null);
+          setSelectedDocument(null);
+        }
+      } catch (error) {
+        console.error("Failed to load Redis keys:", error);
+        toast.error(t("apps.admin.redis.errors.loadKeys", "Failed to load Redis keys"));
+      } finally {
+        setIsLoadingKeys(false);
+      }
+    },
+    [appliedPattern, t]
+  );
+
+  const loadKeyDocument = useCallback(
+    async (key: string) => {
+      setSelectedKey(key);
+      setIsLoadingDocument(true);
+      try {
+        const data = await getAdminRedisKey<RedisKeyDocument>(key);
+        setSelectedDocument(data);
+      } catch (error) {
+        console.error("Failed to load Redis key:", error);
+        setSelectedDocument(null);
+        toast.error(t("apps.admin.redis.errors.loadKey", "Failed to load Redis key"));
+      } finally {
+        setIsLoadingDocument(false);
+      }
+    },
+    [t]
+  );
+
+  useEffect(() => {
+    void loadKeys("0");
+  }, [loadKeys]);
+
+  const handlePatternSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setAppliedPattern(pattern.trim() || "*");
+  };
+
+  const handleBackup = async () => {
+    setIsBackingUp(true);
+    try {
+      const backup = await getAdminRedisBackup<RedisBackupDocument>({
+        pattern: appliedPattern,
+      });
+      const date = new Date().toISOString().slice(0, 10);
+      downloadJson(`ryos-redis-backup-${date}.json`, backup);
+      toast.success(
+        t("apps.admin.redis.messages.backupReady", {
+          count: backup.keyCount,
+          defaultValue: `Backed up ${backup.keyCount} Redis keys`,
+        })
+      );
+      if (backup.truncated) {
+        toast.info(
+          t(
+            "apps.admin.redis.messages.backupTruncated",
+            "Backup reached the key limit; narrow the pattern for a full export",
+          )
+        );
+      }
+    } catch (error) {
+      console.error("Failed to back up Redis keys:", error);
+      toast.error(t("apps.admin.redis.errors.backup", "Failed to back up Redis keys"));
+    } finally {
+      setIsBackingUp(false);
+    }
+  };
+
+  const handleDeleteConfirm = async () => {
+    if (!deleteCandidate) return;
+    setIsDeleting(true);
+    try {
+      const result = await deleteAdminRedisKey<DeleteRedisKeyResponse>(deleteCandidate);
+      if (result.deletedCount > 0) {
+        toast.success(t("apps.admin.redis.messages.deleted", "Redis key deleted"));
+      } else {
+        toast.info(t("apps.admin.redis.messages.alreadyDeleted", "Redis key was already gone"));
+      }
+      setDeleteCandidate(null);
+      setSelectedKey(null);
+      setSelectedDocument(null);
+      await loadKeys("0");
+    } catch (error) {
+      console.error("Failed to delete Redis key:", error);
+      toast.error(t("apps.admin.redis.errors.delete", "Failed to delete Redis key"));
+    } finally {
+      setIsDeleting(false);
+    }
+  };
+
+  return (
+    <div className="flex min-h-[360px] flex-col gap-3 p-3 font-geneva-12">
+      <form
+        onSubmit={handlePatternSubmit}
+        className="flex flex-wrap items-center gap-2"
+      >
+        <SearchInput
+          placeholder={t("apps.admin.redis.patternPlaceholder", "Redis pattern, e.g. chat:*")}
+          value={pattern}
+          onChange={setPattern}
+          className="min-w-[220px] flex-1"
+          inputClassName="h-7 text-[12px] font-os-mono"
+          clearAriaLabel={t("apps.admin.search.clear", "Clear search")}
+        />
+        <Button type="submit" variant="ghost" size="sm" className="h-7 text-[11px]">
+          {t("apps.admin.redis.scan", "Scan")}
+        </Button>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          onClick={handleBackup}
+          disabled={isBackingUp || isLoadingKeys || keys.length === 0}
+          className="h-7 gap-1 text-[11px]"
+        >
+          {isBackingUp ? <ActivityIndicator size={13} /> : <DownloadSimple size={13} weight="bold" />}
+          {t("apps.admin.redis.backup", "Backup")}
+        </Button>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          onClick={() => void loadKeys("0")}
+          disabled={isLoadingKeys}
+          className="size-7 p-0"
+          title={t("apps.admin.redis.refresh", "Refresh Redis keys")}
+        >
+          {isLoadingKeys ? <ActivityIndicator size={14} /> : <ArrowsClockwise size={14} weight="bold" />}
+        </Button>
+      </form>
+
+      <div className="grid min-h-[300px] gap-3 md:grid-cols-[minmax(220px,0.42fr)_minmax(0,1fr)]">
+        <section className={cn(adminCardClass, "min-w-0")}>
+          <div className={cn(adminCardHeaderClass, "flex items-center justify-between")}>
+            <span>{t("apps.admin.redis.keys", "Keys")}</span>
+            <span className="text-os-text-disabled">{keys.length}</span>
+          </div>
+          {keys.length === 0 && !isLoadingKeys ? (
+            <div className="flex flex-col items-center justify-center px-3 py-12 text-os-text-disabled">
+              <Database className="mb-2 size-8 opacity-50" weight="bold" />
+              <span className="text-[11px]">
+                {t("apps.admin.redis.noKeys", "No Redis keys match this pattern")}
+              </span>
+            </div>
+          ) : (
+            <div className={cn("max-h-[520px] overflow-auto", adminListDividerClass)}>
+              {keys.map((item) => (
+                <button
+                  key={item.key}
+                  type="button"
+                  onClick={() => void loadKeyDocument(item.key)}
+                  className={cn(
+                    "flex w-full min-w-0 items-center gap-2 px-3 py-2 text-left",
+                    adminRowHoverClass,
+                    selectedKey === item.key && "bg-os-selection-bg text-os-selection-text hover:bg-os-selection-bg",
+                  )}
+                >
+                  <span className="rounded bg-black/10 px-1.5 py-0.5 font-os-mono text-[9px] uppercase os-mac-aqua-dark:bg-white/10">
+                    {item.type}
+                  </span>
+                  <span className="min-w-0 flex-1 truncate font-os-mono text-[11px]" title={item.key}>
+                    {item.key}
+                  </span>
+                  <span className="shrink-0 text-[10px] opacity-70">
+                    {formatRedisTtl(item.ttl)}
+                  </span>
+                </button>
+              ))}
+              {cursor !== "0" && (
+                <div className="flex justify-center py-2">
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => void loadKeys(cursor)}
+                    disabled={isLoadingKeys}
+                    className={adminLoadMoreBtnClass}
+                  >
+                    {isLoadingKeys
+                      ? t("apps.admin.redis.loading", "Loading...")
+                      : t("apps.admin.redis.loadMore", "Load more")}
+                  </Button>
+                </div>
+              )}
+            </div>
+          )}
+        </section>
+
+        <section className={cn(adminCardClass, "min-w-0")}>
+          <div className={cn(adminCardHeaderClass, "flex items-center justify-between gap-2")}>
+            <span>{t("apps.admin.redis.detail", "Key Detail")}</span>
+            {selectedDocument && (
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => setDeleteCandidate(selectedDocument.key)}
+                disabled={isDeleting}
+                className={cn("size-6 p-0", adminGhostIconBtnClass)}
+                title={t("apps.admin.redis.delete", "Delete Redis key")}
+              >
+                {isDeleting ? <ActivityIndicator size={13} /> : <Trash size={13} weight="bold" />}
+              </Button>
+            )}
+          </div>
+          {!selectedKey ? (
+            <div className="flex h-full min-h-[220px] items-center justify-center px-3 text-center text-[11px] text-os-text-disabled">
+              {t("apps.admin.redis.selectKey", "Select a Redis key to inspect its value")}
+            </div>
+          ) : isLoadingDocument ? (
+            <div className="flex h-full min-h-[220px] items-center justify-center">
+              <ActivityIndicator size={18} />
+            </div>
+          ) : selectedDocument ? (
+            <div className="space-y-3 p-3">
+              <div className="min-w-0 space-y-1">
+                <div className={adminSectionLabelClass}>
+                  {t("apps.admin.redis.key", "Key")}
+                </div>
+                <div className="break-all font-os-mono text-[12px]">{selectedDocument.key}</div>
+              </div>
+              <div className="grid grid-cols-3 gap-2 text-[11px]">
+                <div>
+                  <div className={adminSectionLabelClass}>{t("apps.admin.redis.type", "Type")}</div>
+                  <div className="font-os-mono">{selectedDocument.type}</div>
+                </div>
+                <div>
+                  <div className={adminSectionLabelClass}>{t("apps.admin.redis.ttl", "TTL")}</div>
+                  <div>{formatRedisTtl(selectedDocument.ttl)}</div>
+                </div>
+                <div>
+                  <div className={adminSectionLabelClass}>{t("apps.admin.redis.length", "Length")}</div>
+                  <div>{selectedDocument.length ?? "-"}</div>
+                </div>
+              </div>
+              {selectedDocument.truncated && (
+                <div className="rounded border border-yellow-500/30 bg-yellow-500/10 px-2 py-1 text-[11px] text-yellow-800 os-mac-aqua-dark:text-yellow-200">
+                  {t("apps.admin.redis.previewTruncated", "Preview is truncated; use Backup for the full value.")}
+                </div>
+              )}
+              <pre className="max-h-[420px] overflow-auto rounded bg-black/5 p-2 font-os-mono text-[11px] leading-relaxed os-mac-aqua-dark:bg-white/10">
+                {formatRedisValue(selectedDocument.value)}
+              </pre>
+            </div>
+          ) : (
+            <div className="flex h-full min-h-[220px] items-center justify-center px-3 text-center text-[11px] text-os-text-disabled">
+              {t("apps.admin.redis.keyUnavailable", "Redis key is unavailable")}
+            </div>
+          )}
+        </section>
+      </div>
+
+      <ConfirmDialog
+        isOpen={deleteCandidate !== null}
+        onOpenChange={(open) => {
+          if (!open) setDeleteCandidate(null);
+        }}
+        onConfirm={handleDeleteConfirm}
+        title={t("apps.admin.redis.deleteTitle", "Delete Redis key?")}
+        description={t("apps.admin.redis.deleteDescription", {
+          key: deleteCandidate,
+          defaultValue: `Delete Redis key "${deleteCandidate}"? This cannot be undone.`,
+        })}
+      />
+    </div>
+  );
+}

--- a/src/apps/admin/components/admin-app/AdminRedisBrowserView.tsx
+++ b/src/apps/admin/components/admin-app/AdminRedisBrowserView.tsx
@@ -1,11 +1,25 @@
 import { FormEvent, useCallback, useEffect, useState } from "react";
-import { ArrowsClockwise, Database, DownloadSimple, Trash } from "@phosphor-icons/react";
+import {
+  ArrowsClockwise,
+  Database,
+  DownloadSimple,
+  MagnifyingGlass,
+  Trash,
+} from "@phosphor-icons/react";
 import type { TFunction } from "i18next";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { SearchInput } from "@/components/ui/search-input";
 import { ActivityIndicator } from "@/components/ui/activity-indicator";
 import { ConfirmDialog } from "@/components/dialogs/ConfirmDialog";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
 import {
   deleteAdminRedisKey,
   getAdminRedisBackup,
@@ -17,10 +31,10 @@ import {
   adminCardClass,
   adminCardHeaderClass,
   adminGhostIconBtnClass,
-  adminListDividerClass,
   adminLoadMoreBtnClass,
-  adminRowHoverClass,
   adminSectionLabelClass,
+  adminTableHeadClass,
+  adminTableRowClass,
 } from "../../utils/adminStyles";
 
 interface RedisKeySummary {
@@ -224,8 +238,15 @@ export function AdminRedisBrowserView({ t }: AdminRedisBrowserViewProps) {
           inputClassName="h-7 text-[12px] font-os-mono"
           clearAriaLabel={t("apps.admin.search.clear", "Clear search")}
         />
-        <Button type="submit" variant="ghost" size="sm" className="h-7 text-[11px]">
-          {t("apps.admin.redis.scan", "Scan")}
+        <Button
+          type="submit"
+          variant="ghost"
+          size="sm"
+          className="size-7 p-0"
+          title={t("apps.admin.redis.scan", "Scan")}
+          aria-label={t("apps.admin.redis.scan", "Scan")}
+        >
+          <MagnifyingGlass size={14} weight="bold" />
         </Button>
         <Button
           type="button"
@@ -233,10 +254,11 @@ export function AdminRedisBrowserView({ t }: AdminRedisBrowserViewProps) {
           size="sm"
           onClick={handleBackup}
           disabled={isBackingUp || isLoadingKeys || keys.length === 0}
-          className="h-7 gap-1 text-[11px]"
+          className="size-7 p-0"
+          title={t("apps.admin.redis.backup", "Backup")}
+          aria-label={t("apps.admin.redis.backup", "Backup")}
         >
           {isBackingUp ? <ActivityIndicator size={13} /> : <DownloadSimple size={13} weight="bold" />}
-          {t("apps.admin.redis.backup", "Backup")}
         </Button>
         <Button
           type="button"
@@ -246,6 +268,7 @@ export function AdminRedisBrowserView({ t }: AdminRedisBrowserViewProps) {
           disabled={isLoadingKeys}
           className="size-7 p-0"
           title={t("apps.admin.redis.refresh", "Refresh Redis keys")}
+          aria-label={t("apps.admin.redis.refresh", "Refresh Redis keys")}
         >
           {isLoadingKeys ? <ActivityIndicator size={14} /> : <ArrowsClockwise size={14} weight="bold" />}
         </Button>
@@ -265,29 +288,59 @@ export function AdminRedisBrowserView({ t }: AdminRedisBrowserViewProps) {
               </span>
             </div>
           ) : (
-            <div className={cn("max-h-[520px] overflow-auto", adminListDividerClass)}>
-              {keys.map((item) => (
-                <button
-                  key={item.key}
-                  type="button"
-                  onClick={() => void loadKeyDocument(item.key)}
-                  className={cn(
-                    "flex w-full min-w-0 items-center gap-2 px-3 py-2 text-left",
-                    adminRowHoverClass,
-                    selectedKey === item.key && "bg-os-selection-bg text-os-selection-text hover:bg-os-selection-bg",
-                  )}
-                >
-                  <span className="rounded bg-black/10 px-1.5 py-0.5 font-os-mono text-[9px] uppercase os-mac-aqua-dark:bg-white/10">
-                    {item.type}
-                  </span>
-                  <span className="min-w-0 flex-1 truncate font-os-mono text-[11px]" title={item.key}>
-                    {item.key}
-                  </span>
-                  <span className="shrink-0 text-[10px] opacity-70">
-                    {formatRedisTtl(item.ttl)}
-                  </span>
-                </button>
-              ))}
+            <div className="max-h-[520px] overflow-auto">
+              <Table>
+                <TableHeader>
+                  <TableRow className="border-none text-[10px] font-normal">
+                    <TableHead className={cn(adminTableHeadClass, "h-[28px]")}>
+                      {t("apps.admin.redis.key", "Key")}
+                    </TableHead>
+                    <TableHead className={cn(adminTableHeadClass, "h-[28px] w-16")}>
+                      {t("apps.admin.redis.type", "Type")}
+                    </TableHead>
+                    <TableHead className={cn(adminTableHeadClass, "h-[28px] w-20")}>
+                      {t("apps.admin.redis.ttl", "TTL")}
+                    </TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody className="text-[11px]">
+                  {keys.map((item) => (
+                    <TableRow
+                      key={item.key}
+                      data-state={selectedKey === item.key ? "selected" : undefined}
+                      className={cn(
+                        adminTableRowClass,
+                        "cursor-pointer",
+                        selectedKey === item.key &&
+                          "bg-os-selection-bg text-os-selection-text hover:bg-os-selection-bg",
+                      )}
+                      onClick={() => void loadKeyDocument(item.key)}
+                      onKeyDown={(event) => {
+                        if (event.key === "Enter" || event.key === " ") {
+                          event.preventDefault();
+                          void loadKeyDocument(item.key);
+                        }
+                      }}
+                      role="button"
+                      tabIndex={0}
+                    >
+                      <TableCell className="max-w-0 py-2">
+                        <span className="block truncate font-os-mono" title={item.key}>
+                          {item.key}
+                        </span>
+                      </TableCell>
+                      <TableCell className="py-2">
+                        <span className="rounded bg-black/10 px-1.5 py-0.5 font-os-mono text-[9px] uppercase os-mac-aqua-dark:bg-white/10">
+                          {item.type}
+                        </span>
+                      </TableCell>
+                      <TableCell className="whitespace-nowrap py-2 text-[10px] opacity-75">
+                        {formatRedisTtl(item.ttl)}
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
               {cursor !== "0" && (
                 <div className="flex justify-center py-2">
                   <Button

--- a/src/apps/admin/components/admin-app/AdminScrollContent.tsx
+++ b/src/apps/admin/components/admin-app/AdminScrollContent.tsx
@@ -5,7 +5,6 @@ import { SongDetailPanel } from "../SongDetailPanel";
 import { AdminUsersView } from "./AdminUsersView";
 import { AdminSongsView } from "./AdminSongsView";
 import { AdminRoomMessagesView } from "./AdminRoomMessagesView";
-import { AdminRedisBrowserView } from "./AdminRedisBrowserView";
 import type { AdminSection } from "../../utils/navigationState";
 import type { TFunction } from "i18next";
 import type { CachedSongMetadata } from "@/utils/songMetadataCache";
@@ -153,11 +152,6 @@ export function AdminScrollContent({
             promptDelete={promptDelete}
           />
         )}
-
-      {activeSection === "redis" &&
-        !selectedRoomId &&
-        !selectedUserProfile &&
-        !selectedSongId && <AdminRedisBrowserView t={t} />}
 
       {selectedRoomId && !selectedUserProfile && (
         <AdminRoomMessagesView

--- a/src/apps/admin/components/admin-app/AdminScrollContent.tsx
+++ b/src/apps/admin/components/admin-app/AdminScrollContent.tsx
@@ -5,6 +5,7 @@ import { SongDetailPanel } from "../SongDetailPanel";
 import { AdminUsersView } from "./AdminUsersView";
 import { AdminSongsView } from "./AdminSongsView";
 import { AdminRoomMessagesView } from "./AdminRoomMessagesView";
+import { AdminRedisBrowserView } from "./AdminRedisBrowserView";
 import type { AdminSection } from "../../utils/navigationState";
 import type { TFunction } from "i18next";
 import type { CachedSongMetadata } from "@/utils/songMetadataCache";
@@ -152,6 +153,11 @@ export function AdminScrollContent({
             promptDelete={promptDelete}
           />
         )}
+
+      {activeSection === "redis" &&
+        !selectedRoomId &&
+        !selectedUserProfile &&
+        !selectedSongId && <AdminRedisBrowserView t={t} />}
 
       {selectedRoomId && !selectedUserProfile && (
         <AdminRoomMessagesView

--- a/src/apps/admin/components/admin-app/AdminStatusBar.tsx
+++ b/src/apps/admin/components/admin-app/AdminStatusBar.tsx
@@ -42,6 +42,8 @@ export function AdminStatusBar({
                 count: stats.totalCursorAgents ?? 0,
                 defaultValue: `${stats.totalCursorAgents ?? 0} Cursor agents`,
               })
+            : activeSection === "redis"
+              ? t("apps.admin.statusBar.redis", "Redis Browser")
             : activeSection === "users" && !selectedRoomId
               ? t("apps.admin.statusBar.usersCount", {
                   count: users.length,

--- a/src/apps/admin/utils/adminStyles.ts
+++ b/src/apps/admin/utils/adminStyles.ts
@@ -54,7 +54,7 @@ export const adminAltRowBgClass = "bg-black/5";
 
 /** Zebra-striped data table row — `odd:bg-black/5` matches Finder list view. */
 export const adminTableRowClass = cn(
-  "border-none group",
+  "admin-zebra-row border-none group",
   "odd:bg-black/5 hover:bg-black/5 transition-colors",
 );
 

--- a/src/apps/admin/utils/navigationState.ts
+++ b/src/apps/admin/utils/navigationState.ts
@@ -3,6 +3,7 @@ export type AdminSection =
   | "users"
   | "rooms"
   | "songs"
+  | "redis"
   | "cursorAgents";
 
 export interface AdminDetailSelectionState {

--- a/src/lib/locales/de/translation.json
+++ b/src/lib/locales/de/translation.json
@@ -242,6 +242,39 @@
         "today": "heute",
         "unban": "Nutzer entbannen"
       },
+      "redis": {
+        "backup": "[TODO] Backup",
+        "delete": "[TODO] Delete Redis key",
+        "deleteDescription": "[TODO] Delete Redis key \"{{key}}\"? This cannot be undone.",
+        "deleteTitle": "[TODO] Delete Redis key?",
+        "detail": "[TODO] Key Detail",
+        "errors": {
+          "backup": "[TODO] Failed to back up Redis keys",
+          "delete": "[TODO] Failed to delete Redis key",
+          "loadKey": "[TODO] Failed to load Redis key",
+          "loadKeys": "[TODO] Failed to load Redis keys"
+        },
+        "key": "[TODO] Key",
+        "keyUnavailable": "[TODO] Redis key is unavailable",
+        "keys": "[TODO] Keys",
+        "length": "[TODO] Length",
+        "loadMore": "[TODO] Load more",
+        "loading": "[TODO] Loading...",
+        "messages": {
+          "alreadyDeleted": "[TODO] Redis key was already gone",
+          "backupReady": "[TODO] Backed up {{count}} Redis keys",
+          "backupTruncated": "[TODO] Backup reached the key limit; narrow the pattern for a full export",
+          "deleted": "[TODO] Redis key deleted"
+        },
+        "noKeys": "[TODO] No Redis keys match this pattern",
+        "patternPlaceholder": "[TODO] Redis pattern, e.g. chat:*",
+        "previewTruncated": "[TODO] Preview is truncated; use Backup for the full value.",
+        "refresh": "[TODO] Refresh Redis keys",
+        "scan": "[TODO] Scan",
+        "selectKey": "[TODO] Select a Redis key to inspect its value",
+        "ttl": "[TODO] TTL",
+        "type": "[TODO] Type"
+      },
       "room": {
         "messagesCount": "{{count}} Nachrichten",
         "noMessages": "Keine Nachrichten"
@@ -282,6 +315,7 @@
         "messagesCount": "{{count}} Nachrichten",
         "online": "online",
         "private": "Privat",
+        "redis": "[TODO] Redis",
         "rooms": "Räume",
         "server": "Server",
         "songs": "Lieder",
@@ -333,6 +367,7 @@
         "loggedInAs": "Angemeldet als {{username}}",
         "messagesCount": "{{count}} Nachricht",
         "messagesCount_plural": "{{count}} Nachrichten",
+        "redis": "[TODO] Redis Browser",
         "roomsCount": "{{count}} Raum",
         "roomsCount_plural": "{{count}} Räume",
         "songsCount": "{{count}} Lieder",

--- a/src/lib/locales/en/translation.json
+++ b/src/lib/locales/en/translation.json
@@ -3695,6 +3695,7 @@
         "users": "Users",
         "rooms": "Rooms",
         "songs": "Songs",
+        "redis": "Redis",
         "server": "Server",
         "cursorAgents": "Cursor Agents",
         "private": "Private",
@@ -3749,6 +3750,39 @@
         "unhealthy": "Unhealthy",
         "configured": "Configured",
         "notConfigured": "Not configured"
+      },
+      "redis": {
+        "patternPlaceholder": "Redis pattern, e.g. chat:*",
+        "scan": "Scan",
+        "backup": "Backup",
+        "refresh": "Refresh Redis keys",
+        "keys": "Keys",
+        "noKeys": "No Redis keys match this pattern",
+        "loading": "Loading...",
+        "loadMore": "Load more",
+        "detail": "Key Detail",
+        "delete": "Delete Redis key",
+        "selectKey": "Select a Redis key to inspect its value",
+        "key": "Key",
+        "type": "Type",
+        "ttl": "TTL",
+        "length": "Length",
+        "previewTruncated": "Preview is truncated; use Backup for the full value.",
+        "keyUnavailable": "Redis key is unavailable",
+        "deleteTitle": "Delete Redis key?",
+        "deleteDescription": "Delete Redis key \"{{key}}\"? This cannot be undone.",
+        "messages": {
+          "backupReady": "Backed up {{count}} Redis keys",
+          "backupTruncated": "Backup reached the key limit; narrow the pattern for a full export",
+          "deleted": "Redis key deleted",
+          "alreadyDeleted": "Redis key was already gone"
+        },
+        "errors": {
+          "loadKeys": "Failed to load Redis keys",
+          "loadKey": "Failed to load Redis key",
+          "backup": "Failed to back up Redis keys",
+          "delete": "Failed to delete Redis key"
+        }
       },
       "search": {
         "placeholder": "Search users...",
@@ -3898,6 +3932,7 @@
         "songsCount": "{{count}} songs",
         "cursorAgentsCount": "{{count}} Cursor agent",
         "cursorAgentsCount_plural": "{{count}} Cursor agents",
+        "redis": "Redis Browser",
         "loggedInAs": "Logged in as {{username}}"
       },
       "accessDenied": {

--- a/src/lib/locales/es/translation.json
+++ b/src/lib/locales/es/translation.json
@@ -242,6 +242,39 @@
         "today": "hoy",
         "unban": "Desbloquear usuario"
       },
+      "redis": {
+        "backup": "[TODO] Backup",
+        "delete": "[TODO] Delete Redis key",
+        "deleteDescription": "[TODO] Delete Redis key \"{{key}}\"? This cannot be undone.",
+        "deleteTitle": "[TODO] Delete Redis key?",
+        "detail": "[TODO] Key Detail",
+        "errors": {
+          "backup": "[TODO] Failed to back up Redis keys",
+          "delete": "[TODO] Failed to delete Redis key",
+          "loadKey": "[TODO] Failed to load Redis key",
+          "loadKeys": "[TODO] Failed to load Redis keys"
+        },
+        "key": "[TODO] Key",
+        "keyUnavailable": "[TODO] Redis key is unavailable",
+        "keys": "[TODO] Keys",
+        "length": "[TODO] Length",
+        "loadMore": "[TODO] Load more",
+        "loading": "[TODO] Loading...",
+        "messages": {
+          "alreadyDeleted": "[TODO] Redis key was already gone",
+          "backupReady": "[TODO] Backed up {{count}} Redis keys",
+          "backupTruncated": "[TODO] Backup reached the key limit; narrow the pattern for a full export",
+          "deleted": "[TODO] Redis key deleted"
+        },
+        "noKeys": "[TODO] No Redis keys match this pattern",
+        "patternPlaceholder": "[TODO] Redis pattern, e.g. chat:*",
+        "previewTruncated": "[TODO] Preview is truncated; use Backup for the full value.",
+        "refresh": "[TODO] Refresh Redis keys",
+        "scan": "[TODO] Scan",
+        "selectKey": "[TODO] Select a Redis key to inspect its value",
+        "ttl": "[TODO] TTL",
+        "type": "[TODO] Type"
+      },
       "room": {
         "messagesCount": "{{count}} mensajes",
         "noMessages": "No hay mensajes"
@@ -282,6 +315,7 @@
         "messagesCount": "{{count}} mensajes",
         "online": "en línea",
         "private": "Privada",
+        "redis": "[TODO] Redis",
         "rooms": "Salas",
         "server": "Servidor",
         "songs": "Canciones",
@@ -333,6 +367,7 @@
         "loggedInAs": "Sesión iniciada como {{username}}",
         "messagesCount": "{{count}} mensaje",
         "messagesCount_plural": "{{count}} mensajes",
+        "redis": "[TODO] Redis Browser",
         "roomsCount": "{{count}} habitación",
         "roomsCount_plural": "{{count}} habitaciones",
         "songsCount": "{{count}} canciones",

--- a/src/lib/locales/fr/translation.json
+++ b/src/lib/locales/fr/translation.json
@@ -242,6 +242,39 @@
         "today": "aujourd'hui",
         "unban": "Débannir l'utilisateur"
       },
+      "redis": {
+        "backup": "[TODO] Backup",
+        "delete": "[TODO] Delete Redis key",
+        "deleteDescription": "[TODO] Delete Redis key \"{{key}}\"? This cannot be undone.",
+        "deleteTitle": "[TODO] Delete Redis key?",
+        "detail": "[TODO] Key Detail",
+        "errors": {
+          "backup": "[TODO] Failed to back up Redis keys",
+          "delete": "[TODO] Failed to delete Redis key",
+          "loadKey": "[TODO] Failed to load Redis key",
+          "loadKeys": "[TODO] Failed to load Redis keys"
+        },
+        "key": "[TODO] Key",
+        "keyUnavailable": "[TODO] Redis key is unavailable",
+        "keys": "[TODO] Keys",
+        "length": "[TODO] Length",
+        "loadMore": "[TODO] Load more",
+        "loading": "[TODO] Loading...",
+        "messages": {
+          "alreadyDeleted": "[TODO] Redis key was already gone",
+          "backupReady": "[TODO] Backed up {{count}} Redis keys",
+          "backupTruncated": "[TODO] Backup reached the key limit; narrow the pattern for a full export",
+          "deleted": "[TODO] Redis key deleted"
+        },
+        "noKeys": "[TODO] No Redis keys match this pattern",
+        "patternPlaceholder": "[TODO] Redis pattern, e.g. chat:*",
+        "previewTruncated": "[TODO] Preview is truncated; use Backup for the full value.",
+        "refresh": "[TODO] Refresh Redis keys",
+        "scan": "[TODO] Scan",
+        "selectKey": "[TODO] Select a Redis key to inspect its value",
+        "ttl": "[TODO] TTL",
+        "type": "[TODO] Type"
+      },
       "room": {
         "messagesCount": "{{count}} messages",
         "noMessages": "Aucun message"
@@ -282,6 +315,7 @@
         "messagesCount": "{{count}} messages",
         "online": "en ligne",
         "private": "Privé",
+        "redis": "[TODO] Redis",
         "rooms": "Salons",
         "server": "Serveur",
         "songs": "Morceaux",
@@ -333,6 +367,7 @@
         "loggedInAs": "Connecté en tant que {{username}}",
         "messagesCount": "{{count}} message",
         "messagesCount_plural": "{{count}} messages",
+        "redis": "[TODO] Redis Browser",
         "roomsCount": "{{count}} pièce",
         "roomsCount_plural": "{{count}} pièces",
         "songsCount": "{{count}} morceaux",

--- a/src/lib/locales/it/translation.json
+++ b/src/lib/locales/it/translation.json
@@ -242,6 +242,39 @@
         "today": "oggi",
         "unban": "Sblocca utente"
       },
+      "redis": {
+        "backup": "[TODO] Backup",
+        "delete": "[TODO] Delete Redis key",
+        "deleteDescription": "[TODO] Delete Redis key \"{{key}}\"? This cannot be undone.",
+        "deleteTitle": "[TODO] Delete Redis key?",
+        "detail": "[TODO] Key Detail",
+        "errors": {
+          "backup": "[TODO] Failed to back up Redis keys",
+          "delete": "[TODO] Failed to delete Redis key",
+          "loadKey": "[TODO] Failed to load Redis key",
+          "loadKeys": "[TODO] Failed to load Redis keys"
+        },
+        "key": "[TODO] Key",
+        "keyUnavailable": "[TODO] Redis key is unavailable",
+        "keys": "[TODO] Keys",
+        "length": "[TODO] Length",
+        "loadMore": "[TODO] Load more",
+        "loading": "[TODO] Loading...",
+        "messages": {
+          "alreadyDeleted": "[TODO] Redis key was already gone",
+          "backupReady": "[TODO] Backed up {{count}} Redis keys",
+          "backupTruncated": "[TODO] Backup reached the key limit; narrow the pattern for a full export",
+          "deleted": "[TODO] Redis key deleted"
+        },
+        "noKeys": "[TODO] No Redis keys match this pattern",
+        "patternPlaceholder": "[TODO] Redis pattern, e.g. chat:*",
+        "previewTruncated": "[TODO] Preview is truncated; use Backup for the full value.",
+        "refresh": "[TODO] Refresh Redis keys",
+        "scan": "[TODO] Scan",
+        "selectKey": "[TODO] Select a Redis key to inspect its value",
+        "ttl": "[TODO] TTL",
+        "type": "[TODO] Type"
+      },
       "room": {
         "messagesCount": "{{count}} messaggi",
         "noMessages": "Nessun messaggio"
@@ -282,6 +315,7 @@
         "messagesCount": "{{count}} messaggi",
         "online": "online",
         "private": "Privato",
+        "redis": "[TODO] Redis",
         "rooms": "Stanze",
         "server": "Server",
         "songs": "Brani",
@@ -333,6 +367,7 @@
         "loggedInAs": "Accesso effettuato come {{username}}",
         "messagesCount": "{{count}} messaggio",
         "messagesCount_plural": "{{count}} messaggi",
+        "redis": "[TODO] Redis Browser",
         "roomsCount": "{{count}} stanza",
         "roomsCount_plural": "{{count}} stanze",
         "songsCount": "{{count}} brani",

--- a/src/lib/locales/ja/translation.json
+++ b/src/lib/locales/ja/translation.json
@@ -242,6 +242,39 @@
         "today": "今日",
         "unban": "ユーザーのBANを解除"
       },
+      "redis": {
+        "backup": "[TODO] Backup",
+        "delete": "[TODO] Delete Redis key",
+        "deleteDescription": "[TODO] Delete Redis key \"{{key}}\"? This cannot be undone.",
+        "deleteTitle": "[TODO] Delete Redis key?",
+        "detail": "[TODO] Key Detail",
+        "errors": {
+          "backup": "[TODO] Failed to back up Redis keys",
+          "delete": "[TODO] Failed to delete Redis key",
+          "loadKey": "[TODO] Failed to load Redis key",
+          "loadKeys": "[TODO] Failed to load Redis keys"
+        },
+        "key": "[TODO] Key",
+        "keyUnavailable": "[TODO] Redis key is unavailable",
+        "keys": "[TODO] Keys",
+        "length": "[TODO] Length",
+        "loadMore": "[TODO] Load more",
+        "loading": "[TODO] Loading...",
+        "messages": {
+          "alreadyDeleted": "[TODO] Redis key was already gone",
+          "backupReady": "[TODO] Backed up {{count}} Redis keys",
+          "backupTruncated": "[TODO] Backup reached the key limit; narrow the pattern for a full export",
+          "deleted": "[TODO] Redis key deleted"
+        },
+        "noKeys": "[TODO] No Redis keys match this pattern",
+        "patternPlaceholder": "[TODO] Redis pattern, e.g. chat:*",
+        "previewTruncated": "[TODO] Preview is truncated; use Backup for the full value.",
+        "refresh": "[TODO] Refresh Redis keys",
+        "scan": "[TODO] Scan",
+        "selectKey": "[TODO] Select a Redis key to inspect its value",
+        "ttl": "[TODO] TTL",
+        "type": "[TODO] Type"
+      },
       "room": {
         "messagesCount": "メッセージ{{count}}件",
         "noMessages": "メッセージはありません"
@@ -282,6 +315,7 @@
         "messagesCount": "メッセージ{{count}}件",
         "online": "オンライン",
         "private": "プライベート",
+        "redis": "[TODO] Redis",
         "rooms": "ルーム",
         "server": "サーバー",
         "songs": "曲",
@@ -333,6 +367,7 @@
         "loggedInAs": "{{username}}としてログイン中",
         "messagesCount": "メッセージ{{count}}件",
         "messagesCount_plural": "メッセージ{{count}}件",
+        "redis": "[TODO] Redis Browser",
         "roomsCount": "{{count}}部屋",
         "roomsCount_plural": "{{count}}部屋",
         "songsCount": "{{count}} 曲",

--- a/src/lib/locales/ko/translation.json
+++ b/src/lib/locales/ko/translation.json
@@ -242,6 +242,39 @@
         "today": "오늘",
         "unban": "사용자 차단 해제"
       },
+      "redis": {
+        "backup": "[TODO] Backup",
+        "delete": "[TODO] Delete Redis key",
+        "deleteDescription": "[TODO] Delete Redis key \"{{key}}\"? This cannot be undone.",
+        "deleteTitle": "[TODO] Delete Redis key?",
+        "detail": "[TODO] Key Detail",
+        "errors": {
+          "backup": "[TODO] Failed to back up Redis keys",
+          "delete": "[TODO] Failed to delete Redis key",
+          "loadKey": "[TODO] Failed to load Redis key",
+          "loadKeys": "[TODO] Failed to load Redis keys"
+        },
+        "key": "[TODO] Key",
+        "keyUnavailable": "[TODO] Redis key is unavailable",
+        "keys": "[TODO] Keys",
+        "length": "[TODO] Length",
+        "loadMore": "[TODO] Load more",
+        "loading": "[TODO] Loading...",
+        "messages": {
+          "alreadyDeleted": "[TODO] Redis key was already gone",
+          "backupReady": "[TODO] Backed up {{count}} Redis keys",
+          "backupTruncated": "[TODO] Backup reached the key limit; narrow the pattern for a full export",
+          "deleted": "[TODO] Redis key deleted"
+        },
+        "noKeys": "[TODO] No Redis keys match this pattern",
+        "patternPlaceholder": "[TODO] Redis pattern, e.g. chat:*",
+        "previewTruncated": "[TODO] Preview is truncated; use Backup for the full value.",
+        "refresh": "[TODO] Refresh Redis keys",
+        "scan": "[TODO] Scan",
+        "selectKey": "[TODO] Select a Redis key to inspect its value",
+        "ttl": "[TODO] TTL",
+        "type": "[TODO] Type"
+      },
       "room": {
         "messagesCount": "{{count}}개 메시지",
         "noMessages": "메시지 없음"
@@ -282,6 +315,7 @@
         "messagesCount": "{{count}}개 메시지",
         "online": "온라인",
         "private": "비공개",
+        "redis": "[TODO] Redis",
         "rooms": "방",
         "server": "서버",
         "songs": "곡",
@@ -333,6 +367,7 @@
         "loggedInAs": "{{username}}님으로 로그인됨",
         "messagesCount": "{{count}}개 메시지",
         "messagesCount_plural": "{{count}}개 메시지",
+        "redis": "[TODO] Redis Browser",
         "roomsCount": "{{count}}개",
         "roomsCount_plural": "{{count}}개",
         "songsCount": "{{count}}곡",

--- a/src/lib/locales/pt/translation.json
+++ b/src/lib/locales/pt/translation.json
@@ -242,6 +242,39 @@
         "today": "hoje",
         "unban": "Desbanir Usuário"
       },
+      "redis": {
+        "backup": "[TODO] Backup",
+        "delete": "[TODO] Delete Redis key",
+        "deleteDescription": "[TODO] Delete Redis key \"{{key}}\"? This cannot be undone.",
+        "deleteTitle": "[TODO] Delete Redis key?",
+        "detail": "[TODO] Key Detail",
+        "errors": {
+          "backup": "[TODO] Failed to back up Redis keys",
+          "delete": "[TODO] Failed to delete Redis key",
+          "loadKey": "[TODO] Failed to load Redis key",
+          "loadKeys": "[TODO] Failed to load Redis keys"
+        },
+        "key": "[TODO] Key",
+        "keyUnavailable": "[TODO] Redis key is unavailable",
+        "keys": "[TODO] Keys",
+        "length": "[TODO] Length",
+        "loadMore": "[TODO] Load more",
+        "loading": "[TODO] Loading...",
+        "messages": {
+          "alreadyDeleted": "[TODO] Redis key was already gone",
+          "backupReady": "[TODO] Backed up {{count}} Redis keys",
+          "backupTruncated": "[TODO] Backup reached the key limit; narrow the pattern for a full export",
+          "deleted": "[TODO] Redis key deleted"
+        },
+        "noKeys": "[TODO] No Redis keys match this pattern",
+        "patternPlaceholder": "[TODO] Redis pattern, e.g. chat:*",
+        "previewTruncated": "[TODO] Preview is truncated; use Backup for the full value.",
+        "refresh": "[TODO] Refresh Redis keys",
+        "scan": "[TODO] Scan",
+        "selectKey": "[TODO] Select a Redis key to inspect its value",
+        "ttl": "[TODO] TTL",
+        "type": "[TODO] Type"
+      },
       "room": {
         "messagesCount": "{{count}} mensagens",
         "noMessages": "Nenhuma mensagem"
@@ -282,6 +315,7 @@
         "messagesCount": "{{count}} mensagens",
         "online": "online",
         "private": "Privado",
+        "redis": "[TODO] Redis",
         "rooms": "Salas",
         "server": "Servidor",
         "songs": "Músicas",
@@ -333,6 +367,7 @@
         "loggedInAs": "Sessão iniciada como {{username}}",
         "messagesCount": "{{count}} mensagem",
         "messagesCount_plural": "{{count}} mensagens",
+        "redis": "[TODO] Redis Browser",
         "roomsCount": "{{count}} sala",
         "roomsCount_plural": "{{count}} salas",
         "songsCount": "{{count}} músicas",

--- a/src/lib/locales/ru/translation.json
+++ b/src/lib/locales/ru/translation.json
@@ -242,6 +242,39 @@
         "today": "сегодня",
         "unban": "Разблокировать пользователя"
       },
+      "redis": {
+        "backup": "[TODO] Backup",
+        "delete": "[TODO] Delete Redis key",
+        "deleteDescription": "[TODO] Delete Redis key \"{{key}}\"? This cannot be undone.",
+        "deleteTitle": "[TODO] Delete Redis key?",
+        "detail": "[TODO] Key Detail",
+        "errors": {
+          "backup": "[TODO] Failed to back up Redis keys",
+          "delete": "[TODO] Failed to delete Redis key",
+          "loadKey": "[TODO] Failed to load Redis key",
+          "loadKeys": "[TODO] Failed to load Redis keys"
+        },
+        "key": "[TODO] Key",
+        "keyUnavailable": "[TODO] Redis key is unavailable",
+        "keys": "[TODO] Keys",
+        "length": "[TODO] Length",
+        "loadMore": "[TODO] Load more",
+        "loading": "[TODO] Loading...",
+        "messages": {
+          "alreadyDeleted": "[TODO] Redis key was already gone",
+          "backupReady": "[TODO] Backed up {{count}} Redis keys",
+          "backupTruncated": "[TODO] Backup reached the key limit; narrow the pattern for a full export",
+          "deleted": "[TODO] Redis key deleted"
+        },
+        "noKeys": "[TODO] No Redis keys match this pattern",
+        "patternPlaceholder": "[TODO] Redis pattern, e.g. chat:*",
+        "previewTruncated": "[TODO] Preview is truncated; use Backup for the full value.",
+        "refresh": "[TODO] Refresh Redis keys",
+        "scan": "[TODO] Scan",
+        "selectKey": "[TODO] Select a Redis key to inspect its value",
+        "ttl": "[TODO] TTL",
+        "type": "[TODO] Type"
+      },
       "room": {
         "messagesCount": "{{count}} сообщений",
         "noMessages": "Нет сообщений"
@@ -282,6 +315,7 @@
         "messagesCount": "{{count}} сообщений",
         "online": "онлайн",
         "private": "Приватный",
+        "redis": "[TODO] Redis",
         "rooms": "Комнаты",
         "server": "Сервер",
         "songs": "Песни",
@@ -333,6 +367,7 @@
         "loggedInAs": "Вы вошли как {{username}}",
         "messagesCount": "{{count}} сообщение",
         "messagesCount_plural": "{{count}} сообщений",
+        "redis": "[TODO] Redis Browser",
         "roomsCount": "{{count}} комната",
         "roomsCount_plural": "{{count}} комнат",
         "songsCount": "{{count}} песен",

--- a/src/lib/locales/zh-TW/translation.json
+++ b/src/lib/locales/zh-TW/translation.json
@@ -242,6 +242,39 @@
         "today": "今天",
         "unban": "解除使用者封鎖"
       },
+      "redis": {
+        "backup": "[TODO] Backup",
+        "delete": "[TODO] Delete Redis key",
+        "deleteDescription": "[TODO] Delete Redis key \"{{key}}\"? This cannot be undone.",
+        "deleteTitle": "[TODO] Delete Redis key?",
+        "detail": "[TODO] Key Detail",
+        "errors": {
+          "backup": "[TODO] Failed to back up Redis keys",
+          "delete": "[TODO] Failed to delete Redis key",
+          "loadKey": "[TODO] Failed to load Redis key",
+          "loadKeys": "[TODO] Failed to load Redis keys"
+        },
+        "key": "[TODO] Key",
+        "keyUnavailable": "[TODO] Redis key is unavailable",
+        "keys": "[TODO] Keys",
+        "length": "[TODO] Length",
+        "loadMore": "[TODO] Load more",
+        "loading": "[TODO] Loading...",
+        "messages": {
+          "alreadyDeleted": "[TODO] Redis key was already gone",
+          "backupReady": "[TODO] Backed up {{count}} Redis keys",
+          "backupTruncated": "[TODO] Backup reached the key limit; narrow the pattern for a full export",
+          "deleted": "[TODO] Redis key deleted"
+        },
+        "noKeys": "[TODO] No Redis keys match this pattern",
+        "patternPlaceholder": "[TODO] Redis pattern, e.g. chat:*",
+        "previewTruncated": "[TODO] Preview is truncated; use Backup for the full value.",
+        "refresh": "[TODO] Refresh Redis keys",
+        "scan": "[TODO] Scan",
+        "selectKey": "[TODO] Select a Redis key to inspect its value",
+        "ttl": "[TODO] TTL",
+        "type": "[TODO] Type"
+      },
       "room": {
         "messagesCount": "{{count}} 則訊息",
         "noMessages": "沒有訊息"
@@ -282,6 +315,7 @@
         "messagesCount": "{{count}} 則訊息",
         "online": "線上",
         "private": "私人",
+        "redis": "[TODO] Redis",
         "rooms": "聊天室",
         "server": "伺服器",
         "songs": "歌曲",
@@ -333,6 +367,7 @@
         "loggedInAs": "已登入為 {{username}}",
         "messagesCount": "{{count}} 則訊息",
         "messagesCount_plural": "{{count}} 則訊息",
+        "redis": "[TODO] Redis Browser",
         "roomsCount": "{{count}} 房間",
         "roomsCount_plural": "{{count}} 房間",
         "songsCount": "{{count}} 首歌曲",

--- a/src/styles/themes/aqua-glass.css
+++ b/src/styles/themes/aqua-glass.css
@@ -878,6 +878,30 @@
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04) !important;
 }
 
+:root[data-os-theme="macosx"][data-os-aqua-material="glass"]:not(
+    [data-os-color-scheme="dark"]
+  )
+  .admin-zebra-row:nth-child(odd):not([data-state="selected"]) {
+  background-color: rgba(0, 0, 0, 0.055) !important;
+}
+
+:root[data-os-theme="macosx"][data-os-aqua-material="glass"]:not(
+    [data-os-color-scheme="dark"]
+  )
+  .admin-zebra-row:hover:not([data-state="selected"]) {
+  background-color: rgba(0, 0, 0, 0.085) !important;
+}
+
+:root[data-os-theme="macosx"][data-os-aqua-material="glass"][data-os-color-scheme="dark"]
+  .admin-zebra-row:nth-child(odd):not([data-state="selected"]) {
+  background-color: rgba(255, 255, 255, 0.075) !important;
+}
+
+:root[data-os-theme="macosx"][data-os-aqua-material="glass"][data-os-color-scheme="dark"]
+  .admin-zebra-row:hover:not([data-state="selected"]) {
+  background-color: rgba(255, 255, 255, 0.11) !important;
+}
+
 :root[data-os-theme="macosx"] .admin-card-header {
   background-color: transparent !important;
 }

--- a/tests/fake-redis.ts
+++ b/tests/fake-redis.ts
@@ -195,6 +195,14 @@ export class FakeRedis {
     return this.ttls.get(key) ?? -1;
   }
 
+  async type(key: string): Promise<string> {
+    if (this.kv.has(key)) return "string";
+    if (this.sets.has(key)) return "set";
+    if (this.hashes.has(key)) return "hash";
+    if (this.lists.has(key)) return "list";
+    return "none";
+  }
+
   async scan(
     cursor: number | string,
     options?: { match?: string; count?: number }

--- a/tests/test-admin.test.ts
+++ b/tests/test-admin.test.ts
@@ -262,8 +262,9 @@ describe("admin", () => {
       const data = await res.json();
       expect(data.key).toBe(redisKey);
       expect(data.type).toBe("string");
-      expect(typeof data.value).toBe("string");
-      expect(data.value).toContain(ADMIN_USERNAME);
+      const valueText =
+        typeof data.value === "string" ? data.value : JSON.stringify(data.value);
+      expect(valueText).toContain(ADMIN_USERNAME);
     });
 
     test("GET backupRedisKeys - with admin token", async () => {

--- a/tests/test-admin.test.ts
+++ b/tests/test-admin.test.ts
@@ -222,6 +222,97 @@ describe("admin", () => {
       expect(typeof adminUser.lastActive).toBe("number");
     });
 
+    test("GET listRedisKeys - with admin token", async () => {
+      if (!adminToken) {
+        console.log("  ⚠️  Skipped (no admin token available)");
+        return;
+      }
+
+      const res = await fetchWithAuth(
+        `${BASE_URL}/api/admin?action=listRedisKeys&pattern=chat:users:${ADMIN_USERNAME}&count=10`,
+        ADMIN_USERNAME,
+        adminToken,
+        { method: "GET" }
+      );
+
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(Array.isArray(data.keys)).toBe(true);
+      expect(data.keys.some((key: { key: string }) => key.key === `chat:users:${ADMIN_USERNAME}`)).toBe(true);
+      const adminKey = data.keys.find((key: { key: string }) => key.key === `chat:users:${ADMIN_USERNAME}`);
+      expect(adminKey.type).toBe("string");
+      expect(typeof adminKey.ttl).toBe("number");
+    });
+
+    test("GET getRedisKey - with admin token", async () => {
+      if (!adminToken) {
+        console.log("  ⚠️  Skipped (no admin token available)");
+        return;
+      }
+
+      const redisKey = `chat:users:${ADMIN_USERNAME}`;
+      const res = await fetchWithAuth(
+        `${BASE_URL}/api/admin?action=getRedisKey&key=${encodeURIComponent(redisKey)}`,
+        ADMIN_USERNAME,
+        adminToken,
+        { method: "GET" }
+      );
+
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.key).toBe(redisKey);
+      expect(data.type).toBe("string");
+      expect(typeof data.value).toBe("string");
+      expect(data.value).toContain(ADMIN_USERNAME);
+    });
+
+    test("GET backupRedisKeys - with admin token", async () => {
+      if (!adminToken) {
+        console.log("  ⚠️  Skipped (no admin token available)");
+        return;
+      }
+
+      const res = await fetchWithAuth(
+        `${BASE_URL}/api/admin?action=backupRedisKeys&pattern=chat:users:${ADMIN_USERNAME}&limit=10`,
+        ADMIN_USERNAME,
+        adminToken,
+        { method: "GET" }
+      );
+
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.pattern).toBe(`chat:users:${ADMIN_USERNAME}`);
+      expect(data.keyCount).toBeGreaterThanOrEqual(1);
+      expect(Array.isArray(data.keys)).toBe(true);
+      expect(data.keys.some((key: { key: string }) => key.key === `chat:users:${ADMIN_USERNAME}`)).toBe(true);
+    });
+
+    test("POST deleteRedisKey - requires exact confirmation", async () => {
+      if (!adminToken) {
+        console.log("  ⚠️  Skipped (no admin token available)");
+        return;
+      }
+
+      const res = await fetchWithAuth(
+        `${BASE_URL}/api/admin`,
+        ADMIN_USERNAME,
+        adminToken,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            action: "deleteRedisKey",
+            key: `chat:users:${ADMIN_USERNAME}`,
+            confirmKey: "wrong-key",
+          }),
+        }
+      );
+
+      expect(res.status).toBe(400);
+      const data = await res.json();
+      expect(data.error).toContain("Confirmation");
+    });
+
     test("POST deleteUser - missing target username", async () => {
       if (!adminToken) {
         console.log("  ⚠️  Skipped (no admin token available)");


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add admin-only Redis key list/detail/backup/delete actions to `/api/admin`.
- Add a Redis section in the Admin app with pattern scanning, key previews, backup download, confirmed key deletion, glass-safe zebra table rows, icon-only toolbar actions, View menu navigation, and a Cursor Agents-style right detail panel.
- Address GitHub Advanced Security CodeQL feedback by using static Redis admin error log messages.

### Walkthrough
<a href="https://cursor.com/agents/bc-019ec160-9cc3-78fe-8c5a-a9c81f781b19/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fadmin_redis_browser_clean_walkthrough.mp4"><img src="https://cursor.com/artifacts/c/art-cea81e24-d287-47ab-9de5-2f7c46ae42b5" alt="admin_redis_browser_clean_walkthrough.mp4" /></a>

### Testing
- `API_URL=http://localhost:3001 bun test tests/test-admin.test.ts`
- `bun run build`
- Manual browser walkthrough on `http://localhost:3000` with standalone API proxy to port 3001.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ec160-9cc3-78fe-8c5a-a9c81f781b19"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ec160-9cc3-78fe-8c5a-a9c81f781b19"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

