### PR TITLE
Fix TextEdit slash menu and editor state bugs

### DIFF
--- a/src/apps/textedit/components/TextEditAppComponent.tsx
+++ b/src/apps/textedit/components/TextEditAppComponent.tsx
@@ -220,7 +220,7 @@ function TextEditContent({
           const jsonContent = JSON.parse(e.detail.content);
           const { from, to } = editor.state.selection;
 
-          editor.commands.setContent(jsonContent);
+          editor.commands.setContent(jsonContent, false);
 
           if (from && to && from === to) {
             try {
@@ -244,7 +244,7 @@ function TextEditContent({
       if (editor && e.detail?.path === currentFilePath && e.detail?.content) {
         try {
           const jsonContent = JSON.parse(e.detail.content);
-          editor.commands.setContent(jsonContent);
+          editor.commands.setContent(jsonContent, false);
           setHasUnsavedChanges(false);
           console.log("Editor content updated after document updated event");
         } catch (error) {
@@ -316,7 +316,7 @@ function TextEditContent({
 
   const createNewFile = () => {
     if (editor) {
-      editor.commands.clearContent();
+      editor.commands.clearContent(false);
       setContentJson(null);
       setCurrentFilePath(null);
       setHasUnsavedChanges(false);
@@ -334,7 +334,7 @@ function TextEditContent({
             const processedContent = path.endsWith(".md")
               ? markdownToHtml(content)
               : content;
-            editor.commands.setContent(processedContent);
+            editor.commands.setContent(processedContent, false);
             setCurrentFilePath(path);
             setHasUnsavedChanges(false);
             setContentJson(editor.getJSON());

--- a/src/apps/textedit/extensions/SlashCommands.tsx
+++ b/src/apps/textedit/extensions/SlashCommands.tsx
@@ -4,16 +4,13 @@ import Suggestion, {
   SuggestionProps,
 } from "@tiptap/suggestion";
 import { Editor } from "@tiptap/react";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-} from "@/components/ui/dropdown-menu";
 import { createRoot } from "react-dom/client";
 import { Check } from "@phosphor-icons/react";
 import { useTranslation } from "react-i18next";
 import {
   executeSlashCommand,
   getNextSlashCommandIndex,
+  getSlashMenuPosition,
   getSlashCommandItems,
   type SlashCommandItem,
 } from "../utils/slashCommandUtils";
@@ -120,6 +117,7 @@ const suggestion: Partial<SuggestionOptions> = {
     const renderMenu = (props: SuggestionProps) => {
       const rect = props.clientRect?.();
       if (!rect || !root) return;
+      const position = getSlashMenuPosition(rect);
 
       const itemCount = props.items.length;
       if (itemCount === 0) {
@@ -129,31 +127,30 @@ const suggestion: Partial<SuggestionOptions> = {
       }
 
       root.render(
-        <DropdownMenu open modal={false}>
-          <DropdownMenuContent
-            onCloseAutoFocus={(event) => event.preventDefault()}
-            style={{
-              position: "fixed",
-              top: `${rect.top + rect.height}px`,
-              left: `${rect.left}px`,
+        <div
+          role="menu"
+          style={{
+            position: "fixed",
+            top: position.top,
+            left: position.left,
+            zIndex: 10003,
+          }}
+          className="w-72 max-h-[330px] overflow-y-auto rounded-md border bg-popover p-1 text-popover-foreground shadow-md"
+        >
+          <SlashMenuContent
+            items={props.items as SlashCommandItem[]}
+            selectedIndex={selectedIndex}
+            editor={props.editor}
+            onSelectIndex={(index) => {
+              selectedIndex = index;
+              renderMenu(props);
             }}
-            className="w-72"
-          >
-            <SlashMenuContent
-              items={props.items as SlashCommandItem[]}
-              selectedIndex={selectedIndex}
-              editor={props.editor}
-              onSelectIndex={(index) => {
-                selectedIndex = index;
-                renderMenu(props);
-              }}
-              onCommand={(command: SlashCommandItem) => {
-                props.command({ command });
-                cleanup();
-              }}
-            />
-          </DropdownMenuContent>
-        </DropdownMenu>
+            onCommand={(command: SlashCommandItem) => {
+              props.command({ command });
+              cleanup();
+            }}
+          />
+        </div>
       );
     };
 
@@ -165,8 +162,6 @@ const suggestion: Partial<SuggestionOptions> = {
         container = document.createElement("div");
         if (!container) return;
 
-        container.style.position = "absolute";
-        container.style.zIndex = "50";
         document.body.appendChild(container);
 
         root = createRoot(container);
@@ -180,8 +175,6 @@ const suggestion: Partial<SuggestionOptions> = {
 
         latestProps = props;
         selectedIndex = 0;
-        container.style.position = "absolute";
-        container.style.zIndex = "50";
 
         renderMenu(props);
       },

--- a/src/apps/textedit/extensions/SlashCommands.tsx
+++ b/src/apps/textedit/extensions/SlashCommands.tsx
@@ -9,35 +9,31 @@ import {
   DropdownMenuContent,
 } from "@/components/ui/dropdown-menu";
 import { createRoot } from "react-dom/client";
-import { useState, useEffect } from "react";
 import { Check } from "@phosphor-icons/react";
 import { useTranslation } from "react-i18next";
-
-interface CommandItem {
-  key: string;
-  title: string;
-  description: string;
-  command: (editor: Editor) => void;
-}
+import {
+  executeSlashCommand,
+  getNextSlashCommandIndex,
+  getSlashCommandItems,
+  type SlashCommandItem,
+} from "../utils/slashCommandUtils";
 
 const SlashMenuContent = ({
   items,
   onCommand,
   editor,
+  selectedIndex,
+  onSelectIndex,
 }: {
-  items: CommandItem[];
-  onCommand: (command: CommandItem) => void;
+  items: SlashCommandItem[];
+  onCommand: (command: SlashCommandItem) => void;
   editor: Editor;
+  selectedIndex: number;
+  onSelectIndex: (index: number) => void;
 }) => {
   const { t } = useTranslation();
-  const [selectedIndex, setSelectedIndex] = useState(0);
 
-  // Reset selection when items change (when filtering)
-  useEffect(() => {
-    setSelectedIndex(0);
-  }, [items]);
-
-  const isActive = (item: CommandItem) => {
+  const isActive = (item: SlashCommandItem) => {
     switch (item.key) {
       case "text":
         return editor.isActive("paragraph");
@@ -56,37 +52,9 @@ const SlashMenuContent = ({
     }
   };
 
-  const getTranslatedTitle = (item: CommandItem) => {
+  const getTranslatedTitle = (item: SlashCommandItem) => {
     return t(`apps.textedit.slashCommands.${item.key}.title`);
   };
-
-  useEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
-      // Only handle navigation keys
-      switch (e.key) {
-        case "ArrowDown":
-          e.preventDefault();
-          setSelectedIndex((prev) => (prev + 1) % items.length);
-          break;
-        case "ArrowUp":
-          e.preventDefault();
-          setSelectedIndex((prev) => (prev - 1 + items.length) % items.length);
-          break;
-        case "Enter":
-          e.preventDefault();
-          if (items.length > 0) {
-            onCommand(items[selectedIndex]);
-          }
-          break;
-        // Let other keys pass through to the editor
-        default:
-          return;
-      }
-    };
-
-    document.addEventListener("keydown", handleKeyDown);
-    return () => document.removeEventListener("keydown", handleKeyDown);
-  }, [items, selectedIndex, onCommand]);
 
   return (
     <div>
@@ -95,7 +63,8 @@ const SlashMenuContent = ({
           key={item.key}
           role="menuitem"
           onClick={() => onCommand(item)}
-          onMouseEnter={() => setSelectedIndex(index)}
+          onMouseDown={(event) => event.preventDefault()}
+          onMouseEnter={() => onSelectIndex(index)}
           className={`relative flex w-full items-center h-8 px-2 text-sm ${
             index === selectedIndex ? "bg-muted" : ""
           }`}
@@ -112,65 +81,6 @@ const SlashMenuContent = ({
   );
 };
 
-const commands: CommandItem[] = [
-  {
-    key: "text",
-    title: "Text",
-    description: "Just start typing with plain text",
-    command: (editor: Editor) => {
-      editor.chain().focus().setParagraph().run();
-    },
-  },
-  {
-    key: "heading1",
-    title: "Heading 1",
-    description: "Large section heading",
-    command: (editor: Editor) => {
-      editor.chain().focus().toggleHeading({ level: 1 }).run();
-    },
-  },
-  {
-    key: "heading2",
-    title: "Heading 2",
-    description: "Medium section heading",
-    command: (editor: Editor) => {
-      editor.chain().focus().toggleHeading({ level: 2 }).run();
-    },
-  },
-  {
-    key: "heading3",
-    title: "Heading 3",
-    description: "Small section heading",
-    command: (editor: Editor) => {
-      editor.chain().focus().toggleHeading({ level: 3 }).run();
-    },
-  },
-  {
-    key: "bulletList",
-    title: "Bullet List",
-    description: "Create a simple bullet list",
-    command: (editor: Editor) => {
-      editor.chain().focus().toggleBulletList().run();
-    },
-  },
-  {
-    key: "numberedList",
-    title: "Numbered List",
-    description: "Create a numbered list",
-    command: (editor: Editor) => {
-      editor.chain().focus().toggleOrderedList().run();
-    },
-  },
-  {
-    key: "taskList",
-    title: "Task List",
-    description: "Create a checklist with checkboxes",
-    command: (editor: Editor) => {
-      editor.chain().focus().toggleTaskList().run();
-    },
-  },
-];
-
 const suggestion: Partial<SuggestionOptions> = {
   char: "/",
   startOfLine: false,
@@ -181,20 +91,18 @@ const suggestion: Partial<SuggestionOptions> = {
   }: {
     editor: Editor;
     range: { from: number; to: number };
-    props: { command: CommandItem };
+    props: { command: SlashCommandItem };
   }) => {
-    props.command.command(editor);
-    editor.commands.deleteRange(range);
+    executeSlashCommand(editor, range, props.command);
   },
   items: ({ query }: { query: string }) => {
-    // Filter by English title for search, but display will be translated
-    return commands
-      .filter((item) => item.title.toLowerCase().includes(query.toLowerCase()))
-      .slice(0, 10);
+    return getSlashCommandItems(query);
   },
   render: () => {
     let root: ReturnType<typeof createRoot> | null = null;
     let container: HTMLElement | null = null;
+    let latestProps: SuggestionProps | null = null;
+    let selectedIndex = 0;
 
     const cleanup = () => {
       if (root) {
@@ -203,12 +111,57 @@ const suggestion: Partial<SuggestionOptions> = {
       if (container) {
         container.remove();
       }
+      root = null;
+      container = null;
+      latestProps = null;
+      selectedIndex = 0;
+    };
+
+    const renderMenu = (props: SuggestionProps) => {
+      const rect = props.clientRect?.();
+      if (!rect || !root) return;
+
+      const itemCount = props.items.length;
+      if (itemCount === 0) {
+        selectedIndex = 0;
+      } else if (selectedIndex >= itemCount) {
+        selectedIndex = itemCount - 1;
+      }
+
+      root.render(
+        <DropdownMenu open modal={false}>
+          <DropdownMenuContent
+            onOpenAutoFocus={(event) => event.preventDefault()}
+            onCloseAutoFocus={(event) => event.preventDefault()}
+            style={{
+              position: "fixed",
+              top: `${rect.top + rect.height}px`,
+              left: `${rect.left}px`,
+            }}
+            className="w-72"
+          >
+            <SlashMenuContent
+              items={props.items as SlashCommandItem[]}
+              selectedIndex={selectedIndex}
+              editor={props.editor}
+              onSelectIndex={(index) => {
+                selectedIndex = index;
+                renderMenu(props);
+              }}
+              onCommand={(command: SlashCommandItem) => {
+                props.command({ command });
+                cleanup();
+              }}
+            />
+          </DropdownMenuContent>
+        </DropdownMenu>
+      );
     };
 
     return {
       onStart: (props: SuggestionProps) => {
-        const rect = props.clientRect?.();
-        if (!rect) return;
+        latestProps = props;
+        selectedIndex = 0;
 
         container = document.createElement("div");
         if (!container) return;
@@ -220,57 +173,18 @@ const suggestion: Partial<SuggestionOptions> = {
         root = createRoot(container);
         if (!root) return;
 
-        root.render(
-          <DropdownMenu open>
-            <DropdownMenuContent
-              style={{
-                position: "fixed",
-                top: `${rect.top + rect.height}px`,
-                left: `${rect.left}px`,
-              }}
-              className="w-72"
-            >
-              <SlashMenuContent
-                items={props.items}
-                editor={props.editor}
-                onCommand={(command: CommandItem) => {
-                  props.command({ command });
-                  cleanup();
-                }}
-              />
-            </DropdownMenuContent>
-          </DropdownMenu>
-        );
+        renderMenu(props);
       },
 
       onUpdate: (props: SuggestionProps) => {
-        const rect = props.clientRect?.();
-        if (!rect || !root || !container) return;
+        if (!root || !container) return;
 
+        latestProps = props;
+        selectedIndex = 0;
         container.style.position = "absolute";
         container.style.zIndex = "50";
 
-        root.render(
-          <DropdownMenu open>
-            <DropdownMenuContent
-              style={{
-                position: "fixed",
-                top: `${rect.top + rect.height}px`,
-                left: `${rect.left}px`,
-              }}
-              className="w-72"
-            >
-              <SlashMenuContent
-                items={props.items}
-                editor={props.editor}
-                onCommand={(command: CommandItem) => {
-                  props.command({ command });
-                  cleanup();
-                }}
-              />
-            </DropdownMenuContent>
-          </DropdownMenu>
-        );
+        renderMenu(props);
       },
 
       onKeyDown: (props: { event: KeyboardEvent }) => {
@@ -280,6 +194,43 @@ const suggestion: Partial<SuggestionOptions> = {
           props.event.preventDefault();
           return true;
         }
+
+        if (!latestProps) return false;
+
+        if (props.event.key === "ArrowDown") {
+          props.event.preventDefault();
+          selectedIndex = getNextSlashCommandIndex(
+            selectedIndex,
+            latestProps.items.length,
+            1
+          );
+          renderMenu(latestProps);
+          return true;
+        }
+
+        if (props.event.key === "ArrowUp") {
+          props.event.preventDefault();
+          selectedIndex = getNextSlashCommandIndex(
+            selectedIndex,
+            latestProps.items.length,
+            -1
+          );
+          renderMenu(latestProps);
+          return true;
+        }
+
+        if (props.event.key === "Enter") {
+          props.event.preventDefault();
+          const item = latestProps.items[selectedIndex] as
+            | SlashCommandItem
+            | undefined;
+          if (item) {
+            latestProps.command({ command: item });
+            cleanup();
+          }
+          return true;
+        }
+
         return false;
       },
 

--- a/src/apps/textedit/extensions/SlashCommands.tsx
+++ b/src/apps/textedit/extensions/SlashCommands.tsx
@@ -4,6 +4,11 @@ import Suggestion, {
   SuggestionProps,
 } from "@tiptap/suggestion";
 import { Editor } from "@tiptap/react";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { createRoot } from "react-dom/client";
 import { Check } from "@phosphor-icons/react";
 import { useTranslation } from "react-i18next";
@@ -127,30 +132,43 @@ const suggestion: Partial<SuggestionOptions> = {
       }
 
       root.render(
-        <div
-          role="menu"
-          style={{
-            position: "fixed",
-            top: position.top,
-            left: position.left,
-            zIndex: 10003,
-          }}
-          className="w-72 max-h-[330px] overflow-y-auto rounded-md border bg-popover p-1 text-popover-foreground shadow-md"
-        >
-          <SlashMenuContent
-            items={props.items as SlashCommandItem[]}
-            selectedIndex={selectedIndex}
-            editor={props.editor}
-            onSelectIndex={(index) => {
-              selectedIndex = index;
-              renderMenu(props);
-            }}
-            onCommand={(command: SlashCommandItem) => {
-              props.command({ command });
-              cleanup();
-            }}
-          />
-        </div>
+        <DropdownMenu open modal={false}>
+          <DropdownMenuTrigger asChild>
+            <div
+              aria-hidden="true"
+              style={{
+                position: "fixed",
+                top: position.top,
+                left: position.left,
+                width: 0,
+                height: 0,
+                pointerEvents: "none",
+              }}
+            />
+          </DropdownMenuTrigger>
+          <DropdownMenuContent
+            align="start"
+            side="bottom"
+            sideOffset={0}
+            alignOffset={0}
+            onCloseAutoFocus={(event) => event.preventDefault()}
+            className="w-72 max-h-[330px] overflow-y-auto px-0"
+          >
+            <SlashMenuContent
+              items={props.items as SlashCommandItem[]}
+              selectedIndex={selectedIndex}
+              editor={props.editor}
+              onSelectIndex={(index) => {
+                selectedIndex = index;
+                renderMenu(props);
+              }}
+              onCommand={(command: SlashCommandItem) => {
+                props.command({ command });
+                cleanup();
+              }}
+            />
+          </DropdownMenuContent>
+        </DropdownMenu>
       );
     };
 

--- a/src/apps/textedit/extensions/SlashCommands.tsx
+++ b/src/apps/textedit/extensions/SlashCommands.tsx
@@ -131,7 +131,6 @@ const suggestion: Partial<SuggestionOptions> = {
       root.render(
         <DropdownMenu open modal={false}>
           <DropdownMenuContent
-            onOpenAutoFocus={(event) => event.preventDefault()}
             onCloseAutoFocus={(event) => event.preventDefault()}
             style={{
               position: "fixed",

--- a/src/apps/textedit/extensions/SlashCommands.tsx
+++ b/src/apps/textedit/extensions/SlashCommands.tsx
@@ -137,7 +137,7 @@ const suggestion: Partial<SuggestionOptions> = {
           modal={false}
           onOpenChange={(open) => {
             if (!open) {
-              cleanup();
+              window.setTimeout(cleanup, 0);
             }
           }}
         >

--- a/src/apps/textedit/extensions/SlashCommands.tsx
+++ b/src/apps/textedit/extensions/SlashCommands.tsx
@@ -132,7 +132,15 @@ const suggestion: Partial<SuggestionOptions> = {
       }
 
       root.render(
-        <DropdownMenu open modal={false}>
+        <DropdownMenu
+          open
+          modal={false}
+          onOpenChange={(open) => {
+            if (!open) {
+              cleanup();
+            }
+          }}
+        >
           <DropdownMenuTrigger asChild>
             <div
               aria-hidden="true"

--- a/src/apps/textedit/hooks/useFileOperations.ts
+++ b/src/apps/textedit/hooks/useFileOperations.ts
@@ -122,7 +122,7 @@ export function useFileOperations({
       }
 
       if (editorContent) {
-        editor.commands.setContent(editorContent);
+        editor.commands.setContent(editorContent, false);
       }
 
       // Always save in markdown format with rich metadata

--- a/src/apps/textedit/utils/slashCommandUtils.ts
+++ b/src/apps/textedit/utils/slashCommandUtils.ts
@@ -1,0 +1,115 @@
+import type { Editor } from "@tiptap/core";
+
+export interface SlashCommandItem {
+  key: string;
+  title: string;
+  description: string;
+  aliases: string[];
+  command: (editor: Editor) => void;
+}
+
+export interface SlashCommandRange {
+  from: number;
+  to: number;
+}
+
+export const slashCommands: SlashCommandItem[] = [
+  {
+    key: "text",
+    title: "Text",
+    description: "Just start typing with plain text",
+    aliases: ["paragraph", "plain"],
+    command: (editor) => {
+      editor.chain().focus().setParagraph().run();
+    },
+  },
+  {
+    key: "heading1",
+    title: "Heading 1",
+    description: "Large section heading",
+    aliases: ["h1", "heading"],
+    command: (editor) => {
+      editor.chain().focus().toggleHeading({ level: 1 }).run();
+    },
+  },
+  {
+    key: "heading2",
+    title: "Heading 2",
+    description: "Medium section heading",
+    aliases: ["h2", "subheading"],
+    command: (editor) => {
+      editor.chain().focus().toggleHeading({ level: 2 }).run();
+    },
+  },
+  {
+    key: "heading3",
+    title: "Heading 3",
+    description: "Small section heading",
+    aliases: ["h3"],
+    command: (editor) => {
+      editor.chain().focus().toggleHeading({ level: 3 }).run();
+    },
+  },
+  {
+    key: "bulletList",
+    title: "Bullet List",
+    description: "Create a simple bullet list",
+    aliases: ["bullet", "bullets", "ul", "unordered", "list"],
+    command: (editor) => {
+      editor.chain().focus().toggleBulletList().run();
+    },
+  },
+  {
+    key: "numberedList",
+    title: "Numbered List",
+    description: "Create a numbered list",
+    aliases: ["number", "numbers", "ordered", "ol", "list"],
+    command: (editor) => {
+      editor.chain().focus().toggleOrderedList().run();
+    },
+  },
+  {
+    key: "taskList",
+    title: "Task List",
+    description: "Create a checklist with checkboxes",
+    aliases: ["task", "todo", "checklist", "checkbox"],
+    command: (editor) => {
+      editor.chain().focus().toggleTaskList().run();
+    },
+  },
+];
+
+export const getSlashCommandItems = (query: string): SlashCommandItem[] => {
+  const normalizedQuery = query.trim().toLowerCase();
+
+  if (!normalizedQuery) {
+    return slashCommands.slice(0, 10);
+  }
+
+  return slashCommands
+    .filter((item) => {
+      const searchTargets = [item.title, item.description, ...item.aliases];
+      return searchTargets.some((target) =>
+        target.toLowerCase().includes(normalizedQuery)
+      );
+    })
+    .slice(0, 10);
+};
+
+export const getNextSlashCommandIndex = (
+  currentIndex: number,
+  itemCount: number,
+  direction: 1 | -1
+): number => {
+  if (itemCount <= 0) return 0;
+  return (currentIndex + direction + itemCount) % itemCount;
+};
+
+export const executeSlashCommand = (
+  editor: Editor,
+  range: SlashCommandRange,
+  item: SlashCommandItem
+): void => {
+  editor.chain().focus().deleteRange(range).run();
+  item.command(editor);
+};

--- a/src/apps/textedit/utils/slashCommandUtils.ts
+++ b/src/apps/textedit/utils/slashCommandUtils.ts
@@ -13,6 +13,19 @@ export interface SlashCommandRange {
   to: number;
 }
 
+export interface SlashMenuClientRect {
+  top: number;
+  left: number;
+  height: number;
+}
+
+export interface SlashMenuPositionOptions {
+  menuWidth?: number;
+  gap?: number;
+  viewportWidth?: number;
+  viewportPadding?: number;
+}
+
 export const slashCommands: SlashCommandItem[] = [
   {
     key: "text",
@@ -112,4 +125,27 @@ export const executeSlashCommand = (
 ): void => {
   editor.chain().focus().deleteRange(range).run();
   item.command(editor);
+};
+
+export const getSlashMenuPosition = (
+  rect: SlashMenuClientRect,
+  {
+    menuWidth = 288,
+    gap = 4,
+    viewportWidth =
+      typeof window === "undefined" ? Number.POSITIVE_INFINITY : window.innerWidth,
+    viewportPadding = 8,
+  }: SlashMenuPositionOptions = {}
+): { top: number; left: number } => {
+  const maxLeft = viewportWidth - menuWidth - viewportPadding;
+  const minLeft = viewportPadding;
+  const left =
+    maxLeft < minLeft
+      ? minLeft
+      : Math.min(Math.max(rect.left, minLeft), maxLeft);
+
+  return {
+    top: rect.top + rect.height + gap,
+    left,
+  };
 };

--- a/tests/test-textedit-programmatic-updates.test.ts
+++ b/tests/test-textedit-programmatic-updates.test.ts
@@ -46,10 +46,14 @@ describe("TextEdit programmatic editor updates", () => {
   });
 
   test("slash menu anchors DropdownMenu to the cursor instead of using triggerless popper", () => {
-    expect(SLASH_COMMANDS_EXTENSION).toContain("<DropdownMenu open modal={false}>");
+    expect(SLASH_COMMANDS_EXTENSION).toContain("<DropdownMenu");
+    expect(SLASH_COMMANDS_EXTENSION).toContain("open");
+    expect(SLASH_COMMANDS_EXTENSION).toContain("modal={false}");
     expect(SLASH_COMMANDS_EXTENSION).toContain("<DropdownMenuTrigger asChild>");
     expect(SLASH_COMMANDS_EXTENSION).toContain("<DropdownMenuContent");
     expect(SLASH_COMMANDS_EXTENSION).toContain("getSlashMenuPosition(rect)");
     expect(SLASH_COMMANDS_EXTENSION).toContain('position: "fixed"');
+    expect(SLASH_COMMANDS_EXTENSION).toContain("onOpenChange={(open)");
+    expect(SLASH_COMMANDS_EXTENSION).toContain("cleanup();");
   });
 });

--- a/tests/test-textedit-programmatic-updates.test.ts
+++ b/tests/test-textedit-programmatic-updates.test.ts
@@ -8,6 +8,10 @@ const TEXTEDIT_APP_COMPONENT = readFileSync(
   join(import.meta.dir, "../src/apps/textedit/components/TextEditAppComponent.tsx"),
   "utf8"
 );
+const SLASH_COMMANDS_EXTENSION = readFileSync(
+  join(import.meta.dir, "../src/apps/textedit/extensions/SlashCommands.tsx"),
+  "utf8"
+);
 const FILE_OPERATIONS = readFileSync(
   join(import.meta.dir, "../src/apps/textedit/hooks/useFileOperations.ts"),
   "utf8"
@@ -39,5 +43,11 @@ describe("TextEdit programmatic editor updates", () => {
     expect(FILE_OPERATIONS).toContain(
       "editor.commands.setContent(editorContent, false);"
     );
+  });
+
+  test("slash menu uses cursor fixed positioning instead of triggerless popper", () => {
+    expect(SLASH_COMMANDS_EXTENSION).not.toContain("DropdownMenu");
+    expect(SLASH_COMMANDS_EXTENSION).toContain("getSlashMenuPosition(rect)");
+    expect(SLASH_COMMANDS_EXTENSION).toContain('position: "fixed"');
   });
 });

--- a/tests/test-textedit-programmatic-updates.test.ts
+++ b/tests/test-textedit-programmatic-updates.test.ts
@@ -45,8 +45,10 @@ describe("TextEdit programmatic editor updates", () => {
     );
   });
 
-  test("slash menu uses cursor fixed positioning instead of triggerless popper", () => {
-    expect(SLASH_COMMANDS_EXTENSION).not.toContain("DropdownMenu");
+  test("slash menu anchors DropdownMenu to the cursor instead of using triggerless popper", () => {
+    expect(SLASH_COMMANDS_EXTENSION).toContain("<DropdownMenu open modal={false}>");
+    expect(SLASH_COMMANDS_EXTENSION).toContain("<DropdownMenuTrigger asChild>");
+    expect(SLASH_COMMANDS_EXTENSION).toContain("<DropdownMenuContent");
     expect(SLASH_COMMANDS_EXTENSION).toContain("getSlashMenuPosition(rect)");
     expect(SLASH_COMMANDS_EXTENSION).toContain('position: "fixed"');
   });

--- a/tests/test-textedit-programmatic-updates.test.ts
+++ b/tests/test-textedit-programmatic-updates.test.ts
@@ -54,6 +54,7 @@ describe("TextEdit programmatic editor updates", () => {
     expect(SLASH_COMMANDS_EXTENSION).toContain("getSlashMenuPosition(rect)");
     expect(SLASH_COMMANDS_EXTENSION).toContain('position: "fixed"');
     expect(SLASH_COMMANDS_EXTENSION).toContain("onOpenChange={(open)");
+    expect(SLASH_COMMANDS_EXTENSION).toContain("window.setTimeout(cleanup, 0);");
     expect(SLASH_COMMANDS_EXTENSION).toContain("cleanup();");
   });
 });

--- a/tests/test-textedit-programmatic-updates.test.ts
+++ b/tests/test-textedit-programmatic-updates.test.ts
@@ -1,0 +1,43 @@
+#!/usr/bin/env bun
+
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const TEXTEDIT_APP_COMPONENT = readFileSync(
+  join(import.meta.dir, "../src/apps/textedit/components/TextEditAppComponent.tsx"),
+  "utf8"
+);
+const FILE_OPERATIONS = readFileSync(
+  join(import.meta.dir, "../src/apps/textedit/hooks/useFileOperations.ts"),
+  "utf8"
+);
+
+describe("TextEdit programmatic editor updates", () => {
+  test("external document updates do not emit dirty-state editor updates", () => {
+    expect(TEXTEDIT_APP_COMPONENT).not.toContain(
+      "editor.commands.setContent(jsonContent);"
+    );
+    expect(TEXTEDIT_APP_COMPONENT).toContain(
+      "editor.commands.setContent(jsonContent, false);"
+    );
+  });
+
+  test("new-file and pending-file loads are silent editor updates", () => {
+    expect(TEXTEDIT_APP_COMPONENT).not.toContain("editor.commands.clearContent();");
+    expect(TEXTEDIT_APP_COMPONENT).not.toContain(
+      "editor.commands.setContent(processedContent);"
+    );
+    expect(TEXTEDIT_APP_COMPONENT).toContain("editor.commands.clearContent(false);");
+    expect(TEXTEDIT_APP_COMPONENT).toContain(
+      "editor.commands.setContent(processedContent, false);"
+    );
+  });
+
+  test("device imports load cleanly after saving", () => {
+    expect(FILE_OPERATIONS).not.toContain("editor.commands.setContent(editorContent);");
+    expect(FILE_OPERATIONS).toContain(
+      "editor.commands.setContent(editorContent, false);"
+    );
+  });
+});

--- a/tests/test-textedit-slash-commands.test.ts
+++ b/tests/test-textedit-slash-commands.test.ts
@@ -5,6 +5,7 @@ import type { Editor } from "@tiptap/core";
 import {
   executeSlashCommand,
   getNextSlashCommandIndex,
+  getSlashMenuPosition,
   getSlashCommandItems,
   type SlashCommandItem,
 } from "../src/apps/textedit/utils/slashCommandUtils";
@@ -26,6 +27,24 @@ describe("TextEdit slash commands", () => {
     expect(getSlashCommandItems("definitely-not-a-command")).toEqual([]);
     expect(getNextSlashCommandIndex(0, 0, 1)).toBe(0);
     expect(getNextSlashCommandIndex(0, 0, -1)).toBe(0);
+  });
+
+  test("positions the menu directly under the cursor rect", () => {
+    expect(
+      getSlashMenuPosition(
+        { top: 120, left: 240, height: 18 },
+        { viewportWidth: 1000 }
+      )
+    ).toEqual({ top: 142, left: 240 });
+  });
+
+  test("clamps menu position inside narrow viewports", () => {
+    expect(
+      getSlashMenuPosition(
+        { top: 20, left: 450, height: 16 },
+        { viewportWidth: 500, menuWidth: 288 }
+      )
+    ).toEqual({ top: 40, left: 204 });
   });
 
   test("deletes slash query before applying the selected command", () => {

--- a/tests/test-textedit-slash-commands.test.ts
+++ b/tests/test-textedit-slash-commands.test.ts
@@ -1,0 +1,63 @@
+#!/usr/bin/env bun
+
+import { describe, expect, test } from "bun:test";
+import type { Editor } from "@tiptap/core";
+import {
+  executeSlashCommand,
+  getNextSlashCommandIndex,
+  getSlashCommandItems,
+  type SlashCommandItem,
+} from "../src/apps/textedit/utils/slashCommandUtils";
+
+describe("TextEdit slash commands", () => {
+  test("matches commands by aliases used in the help text", () => {
+    expect(getSlashCommandItems("h1").map((item) => item.key)).toContain(
+      "heading1"
+    );
+    expect(getSlashCommandItems("todo").map((item) => item.key)).toContain(
+      "taskList"
+    );
+    expect(getSlashCommandItems("ol").map((item) => item.key)).toContain(
+      "numberedList"
+    );
+  });
+
+  test("keeps keyboard navigation index stable with no results", () => {
+    expect(getSlashCommandItems("definitely-not-a-command")).toEqual([]);
+    expect(getNextSlashCommandIndex(0, 0, 1)).toBe(0);
+    expect(getNextSlashCommandIndex(0, 0, -1)).toBe(0);
+  });
+
+  test("deletes slash query before applying the selected command", () => {
+    const calls: string[] = [];
+    const editor = {
+      chain: () => ({
+        focus() {
+          calls.push("focus");
+          return this;
+        },
+        deleteRange(range: { from: number; to: number }) {
+          calls.push(`delete:${range.from}-${range.to}`);
+          return this;
+        },
+        run() {
+          calls.push("run-delete");
+          return true;
+        },
+      }),
+    } as unknown as Editor;
+    const item: SlashCommandItem = {
+      key: "heading1",
+      title: "Heading 1",
+      description: "Large section heading",
+      aliases: ["h1"],
+      command: () => {
+        calls.push("apply-command");
+      },
+    };
+
+    executeSlashCommand(editor, { from: 1, to: 4 }, item);
+
+    expect(calls).toEqual(["focus", "delete:1-4", "run-delete", "apply-command"]);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Fix TextEdit slash command selection so arrow/enter handling stays inside TipTap suggestion lifecycle.
- Delete slash trigger text before applying the selected command and add alias matching for commands such as `/h1`, `/todo`, and `/ol`.
- Keep the slash menu on the shared `DropdownMenu` component while anchoring its trigger directly below TipTap's cursor `clientRect`.
- Dismiss the slash menu on outside interactions without blocking the clicked control's own dropdown.
- Suppress dirty-state editor updates for programmatic file loads, imports, external updates, and new-file resets.

### Walkthrough
<a href="https://cursor.com/agents/bc-019ec321-e63c-7486-94ff-6d1a835e8067/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftextedit_slash_menu_outside_dismiss_toolbar.mp4"><img src="https://cursor.com/artifacts/c/art-c1bd0f91-ed86-4777-b904-b35df93aa922" alt="textedit_slash_menu_outside_dismiss_toolbar.mp4" /></a>

### Testing
- `bun test tests/test-textedit-slash-commands.test.ts tests/test-textedit-programmatic-updates.test.ts`
- `bun run build`
- Manual browser smoke test in TextEdit confirming outside click dismisses the slash menu and the toolbar dropdown opens in the same click.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ec321-e63c-7486-94ff-6d1a835e8067"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ec321-e63c-7486-94ff-6d1a835e8067"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

