### PR TITLE
Simplify audio ducking and volume handling

### DIFF
--- a/src/apps/ipod/components/ipod-app/useIpodAppController.tsx
+++ b/src/apps/ipod/components/ipod-app/useIpodAppController.tsx
@@ -1,6 +1,9 @@
 import { useCallback } from "react";
 import type { AppProps, IpodInitialData } from "@/apps/base/types";
-import { useAudioSettingsStore } from "@/stores/useAudioSettingsStore";
+import {
+  selectEffectiveIpodVolume,
+  useAudioSettingsStore,
+} from "@/stores/useAudioSettingsStore";
 import { useIpodStore } from "@/stores/useIpodStore";
 import { DisplayMode } from "@/types/lyrics";
 import {
@@ -25,7 +28,6 @@ export function useIpodAppController({
 
   const {
     t,
-    ipodVolume,
     displayMode,
     isAppleMusic,
     showStatus,
@@ -57,8 +59,7 @@ export function useIpodAppController({
   );
   const uiVariant = useIpodStore((s) => s.uiVariant);
   const isModernIpodUi = uiVariant === "modern";
-  const masterVolume = useAudioSettingsStore((s) => s.masterVolume);
-  const finalIpodVolume = ipodVolume * masterVolume;
+  const finalIpodVolume = useAudioSettingsStore(selectEffectiveIpodVolume);
 
   const handleClose = useCallback(() => {
     pauseBeforeWindowClose();

--- a/src/apps/ipod/components/ipod-screen/IpodScreen.tsx
+++ b/src/apps/ipod/components/ipod-screen/IpodScreen.tsx
@@ -8,7 +8,10 @@ import {
   useCallback,
 } from "react";
 import { cn } from "@/lib/utils";
-import { useAudioSettingsStore } from "@/stores/useAudioSettingsStore";
+import {
+  selectEffectiveIpodVolume,
+  useAudioSettingsStore,
+} from "@/stores/useAudioSettingsStore";
 import { useTranslation } from "react-i18next";
 import {
   getYouTubeVideoId,
@@ -67,7 +70,6 @@ export function IpodScreen({
   statusMessage,
   onToggleVideo,
   lcdFilterOn,
-  ipodVolume,
   showStatusCallback,
   showLyrics,
   lyricsAlignment,
@@ -132,8 +134,7 @@ export function IpodScreen({
     if (el) menuScrollRef.current = el;
   }, []);
 
-  const masterVolume = useAudioSettingsStore((s) => s.masterVolume);
-  const finalIpodVolume = ipodVolume * masterVolume;
+  const finalIpodVolume = useAudioSettingsStore(selectEffectiveIpodVolume);
   const isAppleMusicTrack = currentTrack?.source === "appleMusic";
   const isAppleMusicCollectionShell =
     isAppleMusicCollectionTrack(currentTrack);

--- a/src/apps/ipod/components/music-quiz/useMusicQuiz.ts
+++ b/src/apps/ipod/components/music-quiz/useMusicQuiz.ts
@@ -8,7 +8,10 @@ import {
 } from "react";
 import ReactPlayer from "react-player";
 import { useTranslation } from "react-i18next";
-import { useAudioSettingsStore } from "@/stores/useAudioSettingsStore";
+import {
+  selectEffectiveIpodVolume,
+  useAudioSettingsStore,
+} from "@/stores/useAudioSettingsStore";
 import { useIpodStore } from "@/stores/useIpodStore";
 import type { AppleMusicPlayerBridgeHandle } from "../AppleMusicPlayerBridge";
 import {
@@ -43,9 +46,7 @@ export function useMusicQuiz(
   const uiVariant = useIpodStore((s) => s.uiVariant ?? "modern");
   const isModernUi = uiVariant === "modern";
   const bodyTopOffsetPx = isModernUi ? 17 : 26;
-  const masterVolume = useAudioSettingsStore((s) => s.masterVolume);
-  const ipodVolume = useAudioSettingsStore((s) => s.ipodVolume);
-  const finalVolume = ipodVolume * masterVolume;
+  const finalVolume = useAudioSettingsStore(selectEffectiveIpodVolume);
 
   const [state, dispatch] = useReducer(quizUiReducer, initialQuizUiState);
   const {

--- a/src/apps/karaoke/components/karaoke-app/KaraokeFullscreenView.tsx
+++ b/src/apps/karaoke/components/karaoke-app/KaraokeFullscreenView.tsx
@@ -1,6 +1,9 @@
 import { FullScreenPortal } from "@/apps/ipod/components/FullScreenPortal";
 import { ReactionOverlay } from "@/components/listen/ReactionOverlay";
-import { useAudioSettingsStore } from "@/stores/useAudioSettingsStore";
+import {
+  selectEffectiveIpodVolume,
+  useAudioSettingsStore,
+} from "@/stores/useAudioSettingsStore";
 import { PLAYER_PROGRESS_INTERVAL_MS } from "@/apps/ipod/constants";
 import { YouTubePlayer } from "@/components/shared/YouTubePlayer";
 import { DisplayMode } from "@/types/lyrics";
@@ -17,6 +20,7 @@ import type { KaraokeAppController } from "./useKaraokeAppController";
 type KaraokeFullscreenViewProps = { c: KaraokeAppController; isForeground: boolean | undefined };
 
 export function KaraokeFullscreenView({ c, isForeground }: KaraokeFullscreenViewProps) {
+  const effectiveIpodVolume = useAudioSettingsStore(selectEffectiveIpodVolume);
   const {
     isFullScreen, toggleFullScreen, handlePlayPause, handleNext, handlePrevious,
     isListenSessionRemoteOnly, getCurrentKaraokeTrack, showStatus, showOfflineStatus,
@@ -27,7 +31,7 @@ export function KaraokeFullscreenView({ c, isForeground }: KaraokeFullscreenView
     toggleKaraokeKtvRoomFx, currentTrack, currentIndex, duration, setLyricOffset,
     adjustLyricOffset, fullScreenPlayerRef, playerRef, closeSyncMode, handleRefreshLyrics,
     t, seekTime, loopCurrent, handleTrackEnd, handleProgress, handlePlay, handlePause,
-    handleReady, ipodVolume, effectiveDisplayMode, visualBackgroundActive, coverUrl,
+    handleReady, effectiveDisplayMode, visualBackgroundActive, coverUrl,
     showEmptyLibrary, handleAddSong, listenSession, showLyrics, isOffline, seekToTime,
     koreanDisplay, japaneseFurigana, handleFullscreenLyricsSwipeUp, handleFullscreenLyricsSwipeDown,
     lyricsSourceOverride, isAddingSong, setIsLyricsSearchDialogOpen, auth, lyricsPlaybackSyncRef,
@@ -140,7 +144,7 @@ export function KaraokeFullscreenView({ c, isForeground }: KaraokeFullscreenView
                       controls
                       width="100%"
                       height="100%"
-                      volume={ipodVolume * useAudioSettingsStore.getState().masterVolume}
+                      volume={effectiveIpodVolume}
                       loop={loopCurrent}
                       onEnded={handleTrackEnd}
                       onProgress={handleProgress}

--- a/src/apps/karaoke/components/karaoke-app/KaraokeWindowContent.tsx
+++ b/src/apps/karaoke/components/karaoke-app/KaraokeWindowContent.tsx
@@ -5,7 +5,10 @@ import { ReactionOverlay } from "@/components/listen/ReactionOverlay";
 import { ListenSessionToolbar } from "@/components/listen/ListenSessionToolbar";
 import { FullscreenPlayerControls } from "@/components/shared/FullscreenPlayerControls";
 import { YouTubePlayer } from "@/components/shared/YouTubePlayer";
-import { useAudioSettingsStore } from "@/stores/useAudioSettingsStore";
+import {
+  selectEffectiveIpodVolume,
+  useAudioSettingsStore,
+} from "@/stores/useAudioSettingsStore";
 import { PLAYER_PROGRESS_INTERVAL_MS } from "@/apps/ipod/constants";
 import { DisplayMode } from "@/types/lyrics";
 import { KaraokeIosAutoplayWatchdog } from "../KaraokeIosAutoplayWatchdog";
@@ -22,6 +25,7 @@ import type { KaraokeAppController } from "./useKaraokeAppController";
 type KaraokeWindowContentProps = { c: KaraokeAppController };
 
 export function KaraokeWindowContent({ c }: KaraokeWindowContentProps) {
+  const effectiveIpodVolume = useAudioSettingsStore(selectEffectiveIpodVolume);
   const {
     t, tracks, currentIndex, loopCurrent, isPlaying, isFullScreen, showLyrics,
     lyricsAlignment, lyricsFont, koreanDisplay, japaneseFurigana, romanization,
@@ -30,7 +34,7 @@ export function KaraokeWindowContent({ c }: KaraokeWindowContentProps) {
     setIsLangMenuOpen, isPronunciationMenuOpen, setIsPronunciationMenuOpen, anyMenuOpen,
     isSyncModeOpen, isCoverFlowOpen, setIsCoverFlowOpen, coverFlowRef,
     screenLongPressTimerRef, screenLongPressFiredRef, longPressStartPos, LONG_PRESS_MOVE_THRESHOLD,
-    playerRef, lyricsPlaybackSyncRef, duration, statusMessage, showControls, ipodVolume,
+    playerRef, lyricsPlaybackSyncRef, duration, statusMessage, showControls,
     userHasInteractedRef, currentTrack, lyricsSourceOverride, coverUrl, translationLanguages,
     listenSession, listenSessionUsername, listenSessionClientInstanceId, listenListenerCount,
     isListenSessionHost, isListenSessionDj, isListenSessionAnonymous, showEmptyLibrary,
@@ -163,7 +167,7 @@ export function KaraokeWindowContent({ c }: KaraokeWindowContentProps) {
               playing={isPlaying && !isFullScreen && !isListenSessionRemoteOnly}
               width="100%"
               height="100%"
-              volume={ipodVolume * useAudioSettingsStore.getState().masterVolume}
+              volume={effectiveIpodVolume}
               loop={loopCurrent}
               onEnded={handleTrackEnd}
               onProgress={handleProgress}

--- a/src/hooks/useChatSynth.ts
+++ b/src/hooks/useChatSynth.ts
@@ -1,6 +1,9 @@
 import { useEffect, useRef, useState, useCallback } from "react";
 import * as Tone from "tone";
-import { useAudioSettingsStore } from "@/stores/useAudioSettingsStore";
+import {
+  selectEffectiveChatSynthVolume,
+  useAudioSettingsStore,
+} from "@/stores/useAudioSettingsStore";
 import { useVibration } from "./useVibration";
 import { resumeAudioContext } from "@/lib/audioContext";
 import { useEventListener } from "@/hooks/useEventListener";
@@ -50,9 +53,9 @@ function createSynthInstance(presetKey: string) {
   }).connect(tremolo);
 
   // Apply global chat synth volume (linear 0-1) as decibel offset
-  const masterVol = useAudioSettingsStore.getState().chatSynthVolume ?? 1;
-  const globalMasterVolume = useAudioSettingsStore.getState().masterVolume ?? 1;
-  const combinedVolume = masterVol * globalMasterVolume; // Combine volumes
+  const combinedVolume = selectEffectiveChatSynthVolume(
+    useAudioSettingsStore.getState()
+  );
   const volumeDb =
     presetKey === "off"
       ? -Infinity
@@ -391,22 +394,21 @@ export function useChatSynth() {
   }, [isAudioReady, vibrate, initializeAudio, currentPresetKey]); // Add initializeAudio dependency
 
   // ---------------------------------------------------------------
-  // Reactively update synth volume when the global chatSynthVolume
-  // slider changes, without requiring a re-creation of the synth.
+  // Reactively update synth volume when user volume or temporary ducking changes.
   // ---------------------------------------------------------------
-  const chatSynthVolume = useAudioSettingsStore((s) => s.chatSynthVolume);
-  const masterVolume = useAudioSettingsStore((s) => s.masterVolume);
+  const effectiveChatSynthVolume = useAudioSettingsStore(
+    selectEffectiveChatSynthVolume
+  );
 
   useEffect(() => {
     if (synthRef.current) {
-      const combinedVolume = chatSynthVolume * masterVolume; // Combine volumes
       const volDb =
-        combinedVolume === 0
+        effectiveChatSynthVolume === 0
           ? -Infinity
-          : DEFAULT_SYNTH_VOLUME + 20 * Math.log10(combinedVolume);
+          : DEFAULT_SYNTH_VOLUME + 20 * Math.log10(effectiveChatSynthVolume);
       synthRef.current.synth.volume.value = volDb;
     }
-  }, [chatSynthVolume, masterVolume]); // Add masterVolume to dependencies
+  }, [effectiveChatSynthVolume]);
 
   return {
     playNote,

--- a/src/hooks/useSoundboard.ts
+++ b/src/hooks/useSoundboard.ts
@@ -1,4 +1,5 @@
-import { useRef, useCallback } from "react";
+import { useEffect, useRef, useCallback } from "react";
+import { useAudioSettingsStore } from "@/stores/useAudioSettingsStore";
 import { useSoundboardStore } from "@/stores/useSoundboardStore";
 import { createAudioFromBase64 } from "@/utils/audio";
 // WaveSurfer import will be removed as it's moving to SoundGrid
@@ -22,8 +23,15 @@ export const useSoundboard = () => {
   const setSlotPlaybackStateAction = useSoundboardStore(
     (state) => state.setSlotPlaybackState
   );
+  const masterVolume = useAudioSettingsStore((state) => state.masterVolume);
 
   const audioRefs = useRef<(HTMLAudioElement | null)[]>(Array(9).fill(null));
+
+  useEffect(() => {
+    audioRefs.current.forEach((audio) => {
+      if (audio) audio.volume = masterVolume;
+    });
+  }, [masterVolume]);
 
   // Removed automatic initialization - now handled by the app component
 
@@ -92,6 +100,7 @@ export const useSoundboard = () => {
 
       // Pass the stored format for cross-browser compatibility
       const audio = createAudioFromBase64(slot.audioData, slot.audioFormat);
+      audio.volume = masterVolume;
       audioRefs.current[index] = audio;
       updateSlotState(index, true, false); // isPlaying: true, isRecording: false
 
@@ -105,7 +114,7 @@ export const useSoundboard = () => {
         audioRefs.current[index] = null;
       };
     },
-    [activeBoard, updateSlotState]
+    [activeBoard, masterVolume, updateSlotState]
   );
 
   const stopSound = useCallback(

--- a/src/hooks/useTtsQueue.ts
+++ b/src/hooks/useTtsQueue.ts
@@ -1,5 +1,11 @@
 import { useRef, useEffect, useCallback, useReducer } from "react";
 import { useLatestRef } from "@/hooks/useLatestRef";
+import {
+  startTtsDucking,
+  stopTtsDucking,
+  updateTtsDucking,
+  type TtsDuckingToken,
+} from "@/lib/audioDucking";
 import { getAudioContext, resumeAudioContext } from "@/lib/audioContext";
 import { useAudioSettingsStore } from "@/stores/useAudioSettingsStore";
 import { useIpodStore } from "@/stores/useIpodStore";
@@ -72,8 +78,6 @@ export function useTtsQueue(endpoint: string = "/api/speech") {
   const masterVolume = useAudioSettingsStore((s) => s.masterVolume);
   const speechVolumeRef = useLatestRef(speechVolume);
   const masterVolumeRef = useLatestRef(masterVolume);
-  const setIpodVolumeGlobal = useAudioSettingsStore((s) => s.setIpodVolume);
-  const setChatSynthVolumeGlobal = useAudioSettingsStore((s) => s.setChatSynthVolume);
 
   // Get TTS settings from audio settings store
   const ttsModel = useAudioSettingsStore((s) => s.ttsModel);
@@ -81,9 +85,7 @@ export function useTtsQueue(endpoint: string = "/api/speech") {
   const ttsModelRef = useLatestRef(ttsModel);
   const ttsVoiceRef = useLatestRef(ttsVoice);
 
-  // Keep track of iPod and chat synth volumes for duck/restore
-  const originalIpodVolumeRef = useRef<number | null>(null);
-  const originalChatSynthVolumeRef = useRef<number | null>(null);
+  const duckingTokenRef = useRef<TtsDuckingToken | null>(null);
 
   // Subscribe to iPod/Karaoke playing state so ducking reacts when playback starts/stops
   const ipodIsPlaying = useIpodStore((s) => s.isPlaying);
@@ -305,7 +307,7 @@ export function useTtsQueue(endpoint: string = "/api/speech") {
         }
       });
     },
-    [queuedFetch, ensureContext]
+    [queuedFetch, ensureContext, speechVolumeRef, masterVolumeRef]
   );
 
   /** Cancel all in-flight requests and reset the queue so the next call starts immediately. */
@@ -390,50 +392,31 @@ export function useTtsQueue(endpoint: string = "/api/speech") {
   }, [speechVolume, masterVolume]);
 
   /**
-   * Duck iPod and chat synth volumes while TTS is speaking.
-   * We only duck when audio is actively playing and we have not already
-   * done so for the current speech session. When speech ends, we restore the
-   * previous volumes.
+   * Duck music and chat synth output while TTS is speaking.
+   * Ducking is coordinated globally so overlapping TTS queues do not overwrite
+   * or restore the user's saved volume sliders.
    */
   useEffect(() => {
-    if (isSpeaking) {
-      // Activate ducking only once at the start of speech
-      if (originalIpodVolumeRef.current === null && musicIsPlaying && !isIOS) {
-        originalIpodVolumeRef.current = useAudioSettingsStore.getState().ipodVolume;
-        const duckedIpod = Math.max(0, originalIpodVolumeRef.current * 0.35);
-        setIpodVolumeGlobal(duckedIpod);
-      }
-
-      // Duck chat synth volume
-      if (originalChatSynthVolumeRef.current === null) {
-        originalChatSynthVolumeRef.current =
-          useAudioSettingsStore.getState().chatSynthVolume;
-        const duckedChatSynth = Math.max(
-          0,
-          originalChatSynthVolumeRef.current * 0.6
-        );
-        setChatSynthVolumeGlobal(duckedChatSynth);
-      }
-    } else {
-      // Restore iPod volume if it was ducked
-      if (originalIpodVolumeRef.current !== null) {
-        setIpodVolumeGlobal(originalIpodVolumeRef.current);
-        originalIpodVolumeRef.current = null;
-      }
-
-      // Restore chat synth volume if it was ducked
-      if (originalChatSynthVolumeRef.current !== null) {
-        setChatSynthVolumeGlobal(originalChatSynthVolumeRef.current);
-        originalChatSynthVolumeRef.current = null;
-      }
+    if (!isSpeaking) {
+      stopTtsDucking(duckingTokenRef.current);
+      duckingTokenRef.current = null;
+      return;
     }
-  }, [
-    isSpeaking,
-    musicIsPlaying,
-    setIpodVolumeGlobal,
-    setChatSynthVolumeGlobal,
-    isIOS,
-  ]);
+
+    const options = { duckMusic: musicIsPlaying && !isIOS };
+    if (duckingTokenRef.current) {
+      updateTtsDucking(duckingTokenRef.current, options);
+    } else {
+      duckingTokenRef.current = startTtsDucking(options);
+    }
+  }, [isSpeaking, musicIsPlaying, isIOS]);
+
+  useEffect(() => {
+    return () => {
+      stopTtsDucking(duckingTokenRef.current);
+      duckingTokenRef.current = null;
+    };
+  }, []);
 
   return { speak, stop, isSpeaking };
 }

--- a/src/lib/audioDucking.ts
+++ b/src/lib/audioDucking.ts
@@ -1,0 +1,64 @@
+import { useAudioSettingsStore } from "@/stores/useAudioSettingsStore";
+
+export type TtsDuckingToken = symbol;
+
+const TTS_MUSIC_DUCKING_FACTOR = 0.35;
+const TTS_CHAT_SYNTH_DUCKING_FACTOR = 0.6;
+
+type TtsDuckingOptions = {
+  duckMusic: boolean;
+  duckChatSynth?: boolean;
+};
+
+const activeDucking = new Map<
+  TtsDuckingToken,
+  Required<TtsDuckingOptions>
+>();
+
+function applyDuckingFactors() {
+  let shouldDuckMusic = false;
+  let shouldDuckChatSynth = false;
+
+  for (const options of activeDucking.values()) {
+    shouldDuckMusic ||= options.duckMusic;
+    shouldDuckChatSynth ||= options.duckChatSynth;
+  }
+
+  useAudioSettingsStore.getState().setTtsDuckingFactors({
+    music: shouldDuckMusic ? TTS_MUSIC_DUCKING_FACTOR : 1,
+    chatSynth: shouldDuckChatSynth ? TTS_CHAT_SYNTH_DUCKING_FACTOR : 1,
+  });
+}
+
+export function startTtsDucking(options: TtsDuckingOptions): TtsDuckingToken {
+  const token = Symbol("tts-ducking");
+  activeDucking.set(token, {
+    duckMusic: options.duckMusic,
+    duckChatSynth: options.duckChatSynth ?? true,
+  });
+  applyDuckingFactors();
+  return token;
+}
+
+export function updateTtsDucking(
+  token: TtsDuckingToken,
+  options: TtsDuckingOptions
+) {
+  if (!activeDucking.has(token)) return;
+
+  activeDucking.set(token, {
+    duckMusic: options.duckMusic,
+    duckChatSynth: options.duckChatSynth ?? true,
+  });
+  applyDuckingFactors();
+}
+
+export function stopTtsDucking(token: TtsDuckingToken | null) {
+  if (!token || !activeDucking.delete(token)) return;
+  applyDuckingFactors();
+}
+
+export function resetTtsDuckingForTests() {
+  activeDucking.clear();
+  applyDuckingFactors();
+}

--- a/src/stores/useAudioSettingsStore.ts
+++ b/src/stores/useAudioSettingsStore.ts
@@ -14,6 +14,8 @@ interface AudioSettingsState {
   chatSynthVolume: number;
   speechVolume: number;
   ipodVolume: number;
+  ttsMusicDuckingFactor: number;
+  ttsChatSynthDuckingFactor: number;
 
   // Audio feature toggles
   uiSoundsEnabled: boolean;
@@ -33,6 +35,10 @@ interface AudioSettingsState {
   setChatSynthVolume: (v: number) => void;
   setSpeechVolume: (v: number) => void;
   setIpodVolume: (v: number) => void;
+  setTtsDuckingFactors: (factors: {
+    music: number;
+    chatSynth: number;
+  }) => void;
   setUiSoundsEnabled: (v: boolean) => void;
   setTerminalSoundsEnabled: (v: boolean) => void;
   setTypingSynthEnabled: (v: boolean) => void;
@@ -54,6 +60,8 @@ export const useAudioSettingsStore = create<AudioSettingsState>()(
       chatSynthVolume: 2,
       speechVolume: 2,
       ipodVolume: 1,
+      ttsMusicDuckingFactor: 1,
+      ttsChatSynthDuckingFactor: 1,
 
       uiSoundsEnabled: true,
       terminalSoundsEnabled: true,
@@ -71,6 +79,11 @@ export const useAudioSettingsStore = create<AudioSettingsState>()(
       setChatSynthVolume: (v) => set({ chatSynthVolume: v }),
       setSpeechVolume: (v) => set({ speechVolume: v }),
       setIpodVolume: (v) => set({ ipodVolume: v }),
+      setTtsDuckingFactors: ({ music, chatSynth }) =>
+        set({
+          ttsMusicDuckingFactor: music,
+          ttsChatSynthDuckingFactor: chatSynth,
+        }),
       setUiSoundsEnabled: (v) => set({ uiSoundsEnabled: v }),
       setTerminalSoundsEnabled: (v) => set({ terminalSoundsEnabled: v }),
       setTypingSynthEnabled: (v) => set({ typingSynthEnabled: v }),
@@ -106,6 +119,10 @@ export const useAudioSettingsStore = create<AudioSettingsState>()(
 export const selectMasterVolume = (state: AudioSettingsState) => state.masterVolume;
 export const selectUiVolume = (state: AudioSettingsState) => state.uiVolume;
 export const selectUiSoundsEnabled = (state: AudioSettingsState) => state.uiSoundsEnabled;
+export const selectEffectiveIpodVolume = (state: AudioSettingsState) =>
+  state.ipodVolume * state.masterVolume * state.ttsMusicDuckingFactor;
+export const selectEffectiveChatSynthVolume = (state: AudioSettingsState) =>
+  state.chatSynthVolume * state.masterVolume * state.ttsChatSynthDuckingFactor;
 
 /**
  * Shallow-equality selector hook for this store. Co-located with the store

--- a/src/utils/audio.ts
+++ b/src/utils/audio.ts
@@ -2,6 +2,8 @@
 
 import { resumeAudioContext } from "@/lib/audioContext";
 
+const BASE64_CHUNK_SIZE = 0x8000;
+
 export const createWaveform = async (
   container: HTMLElement,
   base64Data: string,
@@ -81,9 +83,17 @@ export const getSupportedMimeType = (): string => {
 
 export const base64FromBlob = async (blob: Blob): Promise<string> => {
   const buffer = await blob.arrayBuffer();
-  return btoa(String.fromCharCode(...Array.from(new Uint8Array(buffer))));
+  return bufferToBase64(buffer);
 };
 
 export function bufferToBase64(buffer: ArrayBuffer): string {
-  return btoa(String.fromCharCode(...Array.from(new Uint8Array(buffer))));
+  const bytes = new Uint8Array(buffer);
+  let binary = "";
+
+  for (let offset = 0; offset < bytes.length; offset += BASE64_CHUNK_SIZE) {
+    const chunk = bytes.subarray(offset, offset + BASE64_CHUNK_SIZE);
+    binary += String.fromCharCode(...chunk);
+  }
+
+  return btoa(binary);
 }

--- a/tests/test-audio-system.test.ts
+++ b/tests/test-audio-system.test.ts
@@ -1,0 +1,84 @@
+import { Buffer } from "node:buffer";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import {
+  resetTtsDuckingForTests,
+  startTtsDucking,
+  stopTtsDucking,
+  updateTtsDucking,
+} from "../src/lib/audioDucking";
+import {
+  selectEffectiveChatSynthVolume,
+  selectEffectiveIpodVolume,
+  useAudioSettingsStore,
+} from "../src/stores/useAudioSettingsStore";
+import { base64FromBlob, bufferToBase64 } from "../src/utils/audio";
+
+const resetAudioState = () => {
+  resetTtsDuckingForTests();
+  useAudioSettingsStore.setState({
+    masterVolume: 1,
+    uiVolume: 1,
+    chatSynthVolume: 2,
+    speechVolume: 2,
+    ipodVolume: 1,
+    ttsMusicDuckingFactor: 1,
+    ttsChatSynthDuckingFactor: 1,
+  });
+};
+
+describe("TTS audio ducking", () => {
+  beforeEach(resetAudioState);
+  afterEach(resetAudioState);
+
+  test("uses temporary factors without mutating user volume sliders", () => {
+    useAudioSettingsStore.getState().setMasterVolume(0.5);
+    useAudioSettingsStore.getState().setIpodVolume(0.8);
+    useAudioSettingsStore.getState().setChatSynthVolume(1.5);
+
+    const first = startTtsDucking({ duckMusic: true });
+    const second = startTtsDucking({ duckMusic: false });
+    let state = useAudioSettingsStore.getState();
+
+    expect(state.masterVolume).toBe(0.5);
+    expect(state.ipodVolume).toBe(0.8);
+    expect(state.chatSynthVolume).toBe(1.5);
+    expect(selectEffectiveIpodVolume(state)).toBeCloseTo(0.8 * 0.5 * 0.35);
+    expect(selectEffectiveChatSynthVolume(state)).toBeCloseTo(1.5 * 0.5 * 0.6);
+
+    stopTtsDucking(first);
+    state = useAudioSettingsStore.getState();
+    expect(selectEffectiveIpodVolume(state)).toBeCloseTo(0.8 * 0.5);
+    expect(selectEffectiveChatSynthVolume(state)).toBeCloseTo(1.5 * 0.5 * 0.6);
+
+    stopTtsDucking(second);
+    state = useAudioSettingsStore.getState();
+    expect(selectEffectiveIpodVolume(state)).toBeCloseTo(0.8 * 0.5);
+    expect(selectEffectiveChatSynthVolume(state)).toBeCloseTo(1.5 * 0.5);
+  });
+
+  test("updates an active speech session when music starts later", () => {
+    const token = startTtsDucking({ duckMusic: false });
+    let state = useAudioSettingsStore.getState();
+
+    expect(state.ttsMusicDuckingFactor).toBe(1);
+    expect(state.ttsChatSynthDuckingFactor).toBe(0.6);
+
+    updateTtsDucking(token, { duckMusic: true });
+    state = useAudioSettingsStore.getState();
+    expect(state.ttsMusicDuckingFactor).toBe(0.35);
+    expect(state.ttsChatSynthDuckingFactor).toBe(0.6);
+  });
+});
+
+describe("audio base64 helpers", () => {
+  test("encode large buffers without spreading the whole clip", async () => {
+    const bytes = new Uint8Array(200_000);
+    for (let i = 0; i < bytes.length; i++) {
+      bytes[i] = i % 251;
+    }
+    const expected = Buffer.from(bytes).toString("base64");
+
+    expect(bufferToBase64(bytes.buffer)).toBe(expected);
+    await expect(base64FromBlob(new Blob([bytes]))).resolves.toBe(expected);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add a singleton TTS ducking coordinator with non-persisted effective volume factors so overlapping speech sessions do not mutate or incorrectly restore user volume sliders.
- Route iPod, Karaoke, Music Quiz, and chat synth playback through effective volume selectors.
- Make Soundboard playback honor master volume and make blob/base64 encoding chunked for larger recordings.
- Add focused audio-system tests for ducking behavior and large base64 encoding.

### Testing
- `bun test tests/test-audio-system.test.ts tests/test-playback-time-throttle.test.ts`
- `bun run build`
- `bun run lint`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ec32c-a2bd-7999-97ae-fa3beb2cdf18"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ec32c-a2bd-7999-97ae-fa3beb2cdf18"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

