### PR TITLE
Improve admin analytics dashboard

### DIFF
--- a/src/apps/admin/components/dashboard-panel/DashboardPanelView.tsx
+++ b/src/apps/admin/components/dashboard-panel/DashboardPanelView.tsx
@@ -157,6 +157,35 @@ export function DashboardPanelView(props: DashboardPanelViewModel) {
       ]
     : null;
 
+  const selectedCalls = isToday ? (latestDay?.calls ?? 0) : totals.calls;
+  const selectedErrors = isToday ? (latestDay?.errors ?? 0) : totals.errors;
+  const selectedAvgLatency = isToday
+    ? (latestDay?.avgLatencyMs ?? 0)
+    : totals.avgLatencyMs;
+  const successRate =
+    selectedCalls > 0
+      ? Math.max(0, 100 - (selectedErrors / selectedCalls) * 100)
+      : 100;
+  const aiShare = selectedCalls > 0 ? (kpiAI / selectedCalls) * 100 : 0;
+  const productTotals = data.product?.summary.totals;
+  const eventsPerSession =
+    productTotals && productTotals.sessions > 0
+      ? productTotals.events / productTotals.sessions
+      : 0;
+  const serverErrorCount = statusCodes
+    .filter((sc) => sc.status.startsWith("5"))
+    .reduce((sum, sc) => sum + sc.count, 0);
+  const clientErrorCount = statusCodes
+    .filter((sc) => sc.status.startsWith("4"))
+    .reduce((sum, sc) => sum + sc.count, 0);
+  const pressuredAiUsers = aiRateLimits.filter(
+    (rl) => rl.limit > 0 && rl.currentCount >= rl.limit * 0.8
+  ).length;
+  const topApp = data.product?.topApps?.[0]?.name ?? "none";
+  const topEvent = data.product?.topEvents?.[0]?.name ?? "none";
+  const topSong = data.product?.topSongs?.[0]?.name ?? "none";
+  const topSite = data.product?.topSites?.[0]?.name ?? "none";
+
   return (
     <div className="flex flex-col h-full font-geneva-12">
       <AdminPanelHeader
@@ -215,27 +244,111 @@ export function DashboardPanelView(props: DashboardPanelViewModel) {
           />
         </div>
 
-        <div className="flex items-center gap-4 px-4 pb-2 text-[10px] text-neutral-400">
-          <span>
-            {rangeLabel}
-            {!isToday ? ` ${t("apps.admin.dashboard.totals.totals")}` : ""}:{" "}
-            {formatNumber(isToday ? (latestDay?.calls ?? 0) : totals.calls)}{" "}
-            {t("apps.admin.dashboard.totals.calls")}
-          </span>
-          <span>
-            {formatNumber(
-              isToday ? (latestDay?.uniqueVisitors ?? 0) : totals.uniqueVisitors
-            )}{" "}
-            {t("apps.admin.dashboard.totals.visitors")}
-          </span>
-          <span>
-            {formatNumber(isToday ? (latestDay?.ai ?? 0) : totals.ai)}{" "}
-            {t("apps.admin.dashboard.totals.ai")}
-          </span>
-          <span>
-            {isToday ? (latestDay?.avgLatencyMs ?? 0) : totals.avgLatencyMs}
-            {t("apps.admin.dashboard.totals.msAvg")}
-          </span>
+        <div className="px-3 pb-3">
+          <OperationsBrief
+            title={t("apps.admin.dashboard.sections.operationsBrief", {
+              defaultValue: "Operations brief",
+            })}
+            caption={`${rangeLabel}${
+              !isToday ? ` ${t("apps.admin.dashboard.totals.totals")}` : ""
+            }`}
+            metrics={[
+              {
+                label: t("apps.admin.dashboard.brief.successRate", {
+                  defaultValue: "Success rate",
+                }),
+                value: `${successRate.toFixed(1)}%`,
+                accentClassName:
+                  successRate >= 99
+                    ? "bg-green-500"
+                    : successRate >= 95
+                      ? "bg-yellow-500"
+                      : "bg-red-500",
+                progress: successRate,
+              },
+              {
+                label: t("apps.admin.dashboard.brief.avgLatency", {
+                  defaultValue: "Avg latency",
+                }),
+                value: `${selectedAvgLatency}ms`,
+                accentClassName:
+                  selectedAvgLatency <= 1000
+                    ? "bg-green-500"
+                    : selectedAvgLatency <= 2500
+                      ? "bg-yellow-500"
+                      : "bg-red-500",
+                detail: `${formatNumber(selectedCalls)} ${t(
+                  "apps.admin.dashboard.totals.calls"
+                )}`,
+              },
+              {
+                label: t("apps.admin.dashboard.brief.aiShare", {
+                  defaultValue: "AI share",
+                }),
+                value: `${aiShare.toFixed(1)}%`,
+                accentClassName: "bg-yellow-400",
+                progress: aiShare,
+                detail: `${formatNumber(kpiAI)} ${t(
+                  "apps.admin.dashboard.totals.ai"
+                )}`,
+              },
+              {
+                label: t("apps.admin.dashboard.brief.productDepth", {
+                  defaultValue: "Product depth",
+                }),
+                value:
+                  eventsPerSession > 0
+                    ? `${eventsPerSession.toFixed(1)}x`
+                    : formatNumber(productTotals?.events ?? 0),
+                accentClassName: "bg-purple-400",
+                detail: `${formatNumber(productTotals?.sessions ?? 0)} ${t(
+                  "apps.admin.dashboard.kpi.sessions"
+                )}`,
+              },
+            ]}
+          />
+        </div>
+
+        <div className="grid grid-cols-1 lg:grid-cols-3 gap-3 px-3 pb-3">
+          <ReportCadenceCard
+            cadence={t("apps.admin.dashboard.reports.daily", {
+              defaultValue: "Daily",
+            })}
+            title={t("apps.admin.dashboard.reports.dailyTitle", {
+              defaultValue: "Health and abuse watch",
+            })}
+            items={[
+              `${formatNumber(selectedErrors)} ${t("apps.admin.dashboard.charts.errors")} / ${formatNumber(selectedCalls)} ${t("apps.admin.dashboard.totals.calls")}`,
+              `${formatNumber(serverErrorCount)} 5xx, ${formatNumber(clientErrorCount)} 4xx`,
+              `${formatNumber(pressuredAiUsers)} ${t("apps.admin.dashboard.reports.aiPressure", { defaultValue: "AI users near limit" })}`,
+            ]}
+          />
+          <ReportCadenceCard
+            cadence={t("apps.admin.dashboard.reports.weekly", {
+              defaultValue: "Weekly",
+            })}
+            title={t("apps.admin.dashboard.reports.weeklyTitle", {
+              defaultValue: "Adoption and content",
+            })}
+            items={[
+              `${t("apps.admin.dashboard.sections.topApps")}: ${topApp}`,
+              `${t("apps.admin.dashboard.sections.topProductEvents")}: ${topEvent}`,
+              `${t("apps.admin.dashboard.sections.topSongs")}: ${topSong}`,
+            ]}
+          />
+          <ReportCadenceCard
+            cadence={t("apps.admin.dashboard.reports.monthly", {
+              defaultValue: "Monthly",
+            })}
+            title={t("apps.admin.dashboard.reports.monthlyTitle", {
+              defaultValue: "Rollup and retention",
+            })}
+            items={[
+              `${formatNumber(productTotals?.events ?? 0)} ${t("apps.admin.dashboard.kpi.productEvents")}`,
+              `${formatNumber(data.product?.topApps.length ?? 0)} ${t("apps.admin.dashboard.reports.activeApps", { defaultValue: "active apps" })}`,
+              `${t("apps.admin.dashboard.sections.topSites")}: ${topSite}`,
+            ]}
+          />
         </div>
 
         {showTimeSeriesCharts ? (
@@ -494,6 +607,99 @@ function TimeSeriesChartCard({
             ? formatDateLabel(days[days.length - 1].date)
             : ""}
         </span>
+      </div>
+    </div>
+  );
+}
+
+function OperationsBrief({
+  title,
+  caption,
+  metrics,
+}: {
+  title: string;
+  caption: string;
+  metrics: Array<{
+    label: string;
+    value: string;
+    detail?: string;
+    progress?: number;
+    accentClassName: string;
+  }>;
+}) {
+  return (
+    <div className={adminCardClass}>
+      <div className={cn(adminCardHeaderClass, "flex items-center justify-between gap-2")}>
+        <span className={adminSectionLabelClass}>{title}</span>
+        <span className="text-[10px] text-os-text-disabled">{caption}</span>
+      </div>
+      <div className="grid grid-cols-2 lg:grid-cols-4">
+        {metrics.map((metric) => (
+          <div
+            key={metric.label}
+            className="border-b border-r border-black/10 px-3 py-2 last:border-r-0 os-mac-aqua-dark:border-white/10 lg:border-b-0"
+          >
+            <div className="flex items-center justify-between gap-2">
+              <span className="text-[10px] uppercase tracking-wide text-os-text-disabled">
+                {metric.label}
+              </span>
+              <span className={cn("h-2 w-2 rounded-full", metric.accentClassName)} />
+            </div>
+            <div className="mt-1 text-[17px] font-semibold leading-tight text-os-text-primary">
+              {metric.value}
+            </div>
+            {metric.progress !== undefined ? (
+              <div className={cn("mt-2 h-1.5 overflow-hidden rounded-full", adminTrackBgClass)}>
+                <div
+                  className={cn("h-full rounded-full", metric.accentClassName)}
+                  style={{ width: `${Math.max(0, Math.min(100, metric.progress))}%` }}
+                />
+              </div>
+            ) : null}
+            {metric.detail ? (
+              <div className="mt-1 text-[10px] text-os-text-secondary">
+                {metric.detail}
+              </div>
+            ) : null}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function ReportCadenceCard({
+  cadence,
+  title,
+  items,
+}: {
+  cadence: string;
+  title: string;
+  items: string[];
+}) {
+  return (
+    <div className={cn("p-3", adminCardClass)}>
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <div className={adminSectionLabelClass}>{cadence}</div>
+          <div className="mt-0.5 text-[13px] font-semibold text-os-text-primary">
+            {title}
+          </div>
+        </div>
+        <div className="rounded-full border border-black/10 px-2 py-0.5 text-[9px] uppercase tracking-wide text-os-text-disabled os-mac-aqua-dark:border-white/10">
+          Report
+        </div>
+      </div>
+      <div className="mt-2 space-y-1">
+        {items.map((item) => (
+          <div
+            key={item}
+            className="flex items-center gap-2 text-[11px] text-os-text-secondary"
+          >
+            <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-os-text-disabled/60" />
+            <span className="min-w-0 truncate">{item}</span>
+          </div>
+        ))}
       </div>
     </div>
   );


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Adds an operations brief to the Admin dashboard with success rate, latency, AI share, and product depth derived from existing analytics.
- Adds daily, weekly, and monthly report cards that surface health, adoption, content, and retention signals.
- Keeps the existing analytics endpoint and Redis aggregation model unchanged.

### Walkthrough
<a href="https://cursor.com/agents/bc-019ec393-6ee5-7c65-b5b1-505809829e73/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fadmin_dashboard_reports_walkthrough.mp4"><img src="https://cursor.com/artifacts/c/art-4c2458f4-8cec-40a0-af2c-b415d48699c3" alt="admin_dashboard_reports_walkthrough.mp4" /></a>

### Testing
- `bun test tests/test-client-analytics-wiring.test.ts tests/test-analytics-aggregation.test.ts`
- `bun run build`
- `bun run lint -- src/apps/admin/components/dashboard-panel/DashboardPanelView.tsx` (repository warning baseline only; no warnings from the changed dashboard file)
- Manual browser walkthrough against `bun run dev` with seeded local analytics
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ec393-6ee5-7c65-b5b1-505809829e73"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ec393-6ee5-7c65-b5b1-505809829e73"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

