### PR TITLE
refactor(media): extract shared lyrics, playback, deep-link & queue hooks

### DIFF
--- a/src/apps/ipod/hooks/useIpodLogic.ts
+++ b/src/apps/ipod/hooks/useIpodLogic.ts
@@ -6,10 +6,7 @@ import { useSound, Sounds } from "@/hooks/useSound";
 import { useVibration } from "@/hooks/useVibration";
 import { useOffline } from "@/hooks/useOffline";
 import { useTranslatedHelpItems } from "@/hooks/useTranslatedHelpItems";
-import { useLyrics } from "@/hooks/useLyrics";
-import { useFurigana } from "@/hooks/useFurigana";
-import { useActivityState } from "@/hooks/useActivityState";
-import { useLyricsErrorToast } from "@/hooks/useLyricsErrorToast";
+import { useMediaLyricsPlayback } from "@/shared/media/useMediaLyricsPlayback";
 import { useMediaAppDialogs } from "@/hooks/useMediaAppDialogs";
 import { useCustomEventListener, useEventListener } from "@/hooks/useEventListener";
 import { useLibraryUpdateChecker } from "./useLibraryUpdateChecker";
@@ -32,7 +29,6 @@ import {
   useIpodStore,
   Track,
   IpodBacklightTimeout,
-  getEffectiveTranslationLanguage,
   flushPendingLyricOffsetSave,
   isAppleMusicCollectionTrack,
 } from "@/stores/useIpodStore";
@@ -4830,24 +4826,10 @@ export function useIpodLogic({
   // Volume from audio settings store
   const { ipodVolume } = useAudioSettingsStoreShallow((state) => ({ ipodVolume: state.ipodVolume }));
 
-  // Lyrics hook
-  const selectedMatchForLyrics = useMemo(() => {
-    if (!lyricsSourceOverride) return undefined;
-    return {
-      hash: lyricsSourceOverride.hash,
-      albumId: lyricsSourceOverride.albumId,
-      title: lyricsSourceOverride.title,
-      artist: lyricsSourceOverride.artist,
-      album: lyricsSourceOverride.album,
-    };
-  }, [lyricsSourceOverride]);
-
-  // Resolve "auto" translation language to actual ryOS locale (must track i18n so UI updates when system language changes)
-  const appLanguage = i18n.resolvedLanguage ?? i18n.language;
-  const effectiveTranslationLanguage = useMemo(
-    () => getEffectiveTranslationLanguage(lyricsTranslationLanguage),
-    [lyricsTranslationLanguage, appLanguage]
-  );
+  // Lyrics hook. The shared `selectedMatch` / effective-translation-language
+  // composition lives in `useMediaLyricsPlayback` (shared with Karaoke); the
+  // Apple Music metadata resolution + out-of-React clock sync below stay
+  // iPod-specific.
   // For Apple Music stations / playlists the iPod's `currentTrack` is
   // a *shell* — its title / artist describe the station or playlist
   // itself ("Today's Hits" / "Apple Music"), NOT the song that's
@@ -4871,7 +4853,13 @@ export function useIpodLogic({
     return currentTrack?.lyricOffset ?? 0;
   }, [currentTrack, appleMusicKitNowPlaying?.id]);
 
-  const fullScreenLyricsControls = useLyrics({
+  const {
+    lyricsControls: fullScreenLyricsControls,
+    furiganaMap,
+    soramimiMap,
+    activityState,
+    effectiveTranslationLanguage,
+  } = useMediaLyricsPlayback({
     songId: lyricsSongId,
     title: lyricsTitle,
     artist: lyricsArtist,
@@ -4879,17 +4867,14 @@ export function useIpodLogic({
     // hook ~20x/sec. Current-line tracking is driven by the store
     // subscription effect below via `updateCurrentTimeManually`.
     currentTime: 0,
-    translateTo: effectiveTranslationLanguage,
-    selectedMatch: selectedMatchForLyrics,
-    includeFurigana: true, // Fetch furigana info with lyrics to reduce API calls
-    // Always include soramimi in request to avoid hydration timing issues
-    // (default setting is false, but user's saved setting might be true after hydration)
-    // The server only returns cached soramimi data, doesn't generate anything here
-    includeSoramimi: true,
-    // Pass target language so server returns correct cached soramimi data
-    soramimiTargetLanguage: romanization.soramamiTargetLanguage ?? "zh-TW",
-    // Auth for force refresh / changing lyrics source
+    lyricsTranslationLanguage,
+    romanization,
+    lyricsSourceOverride,
+    isAddingSong,
+    onSearchLyrics: () => setIsLyricsSearchDialogOpen(true),
+    appId: "ipod",
     auth,
+    t,
   });
 
   // Drive lyrics current-line tracking from the playback clock without
@@ -4919,51 +4904,6 @@ export function useIpodLogic({
       }
     });
   }, [fullScreenLyricsControls.lines, lyricsTimingOffsetMs]);
-
-  // Show toast with Search button when lyrics fetch fails
-  useLyricsErrorToast({
-    error: fullScreenLyricsControls.error,
-    songId: lyricsSongId || undefined,
-    onSearchClick: () => setIsLyricsSearchDialogOpen(true),
-    t,
-    appId: "ipod",
-  });
-
-  // Fetch furigana for lyrics and store in shared state
-  // Use pre-fetched info from lyrics request to skip extra API call
-  const { 
-    furiganaMap, 
-    soramimiMap, 
-    isFetchingFurigana,
-    isFetchingSoramimi,
-    furiganaProgress,
-    soramimiProgress,
-  } = useFurigana({
-    songId: lyricsSongId,
-    lines: fullScreenLyricsControls.originalLines,
-    isShowingOriginal: true,
-    romanization,
-    prefetchedInfo: fullScreenLyricsControls.furiganaInfo,
-    prefetchedSoramimiInfo: fullScreenLyricsControls.soramimiInfo,
-    auth,
-  });
-
-  // Consolidated activity state for loading indicators
-  const activityState = useActivityState({
-    lyricsState: {
-      isLoading: fullScreenLyricsControls.isLoading,
-      isTranslating: fullScreenLyricsControls.isTranslating,
-      translationProgress: fullScreenLyricsControls.translationProgress,
-    },
-    furiganaState: {
-      isFetchingFurigana,
-      furiganaProgress,
-      isFetchingSoramimi,
-      soramimiProgress,
-    },
-    translationLanguage: effectiveTranslationLanguage,
-    isAddingSong,
-  });
 
   // Convert furiganaMap to Record for storage - only when content actually changes
   const furiganaRecord = useMemo(() => {

--- a/src/apps/ipod/hooks/useIpodLogic.ts
+++ b/src/apps/ipod/hooks/useIpodLogic.ts
@@ -7,6 +7,10 @@ import { useVibration } from "@/hooks/useVibration";
 import { useOffline } from "@/hooks/useOffline";
 import { useTranslatedHelpItems } from "@/hooks/useTranslatedHelpItems";
 import { useMediaLyricsPlayback } from "@/shared/media/useMediaLyricsPlayback";
+import {
+  useMediaTrackChangeReset,
+  useMediaFullscreenSync,
+} from "@/shared/media/useMediaPlayback";
 import { useMediaAppDialogs } from "@/hooks/useMediaAppDialogs";
 import { useCustomEventListener, useEventListener } from "@/hooks/useEventListener";
 import { useLibraryUpdateChecker } from "./useLibraryUpdateChecker";
@@ -427,6 +431,7 @@ export function useIpodLogic({
     userHasInteractedRef,
     isTrackSwitchingRef,
     trackSwitchTimeoutRef,
+    startTrackSwitch,
     pauseBeforeWindowClose,
   } = useIpodPlayback({
     isWindowOpen,
@@ -1401,62 +1406,27 @@ export function useIpodLogic({
     prevIsForeground.current = isForeground;
   }, [isForeground, toggleBacklight, registerActivity]);
 
-  // Reset elapsed time on track change and set track switching guard
-  // This catches track changes from any source (AI tools, shared URLs, menu selections, etc.)
-  // Using null as initial value ensures first render triggers the auto-skip check
-  const prevCurrentIndexRef = useRef<number | null>(null);
-  useEffect(() => {
-    let timeoutId: ReturnType<typeof setTimeout> | null = null;
-
-    // Check if track changed or this is initial render (prevCurrentIndexRef.current is null)
-    if (prevCurrentIndexRef.current !== currentIndex) {
-      isTrackSwitchingRef.current = true;
-      if (trackSwitchTimeoutRef.current) {
-        clearTimeout(trackSwitchTimeoutRef.current);
-      }
-      
-      // Get the new track's offset
-      const newTrack = tracks[currentIndex];
-      const newLyricOffset = newTrack?.lyricOffset ?? 0;
-      
-      // For negative offset, auto-skip to where lyrics time = 0
-      // Formula: lyricsTime = playerTime + (lyricOffset / 1000)
-      // When lyricsTime = 0: playerTime = -lyricOffset / 1000
-      // Only seek if offset is negative (produces positive seek target)
-      // and the seek target is reasonable (less than track duration, at least 1 second)
-      const seekTarget = -newLyricOffset / 1000;
-      
-      if (newLyricOffset < 0 && seekTarget >= 1) {
-        useIpodStore.getState().setElapsedTime(seekTarget);
-        
-        timeoutId = setTimeout(() => {
-          isTrackSwitchingRef.current = false;
-          const activePlayer = isFullScreen ? fullScreenPlayerRef.current : playerRef.current;
-          if (activePlayer) {
-            activePlayer.seekTo(seekTarget);
-            showStatus(`▶ ${formatSecondsAsMinutesSeconds(seekTarget)}`);
-          }
-        }, 2000);
-        trackSwitchTimeoutRef.current = timeoutId;
-      } else {
-        // Start from beginning for positive/zero offset or small negative offset
-        useIpodStore.getState().setElapsedTime(0);
-        timeoutId = setTimeout(() => {
-          isTrackSwitchingRef.current = false;
-        }, 2000);
-        trackSwitchTimeoutRef.current = timeoutId;
-      }
-    }
-    prevCurrentIndexRef.current = currentIndex;
-    return () => {
-      if (timeoutId !== null) {
-        clearTimeout(timeoutId);
-        if (trackSwitchTimeoutRef.current === timeoutId) {
-          trackSwitchTimeoutRef.current = null;
-        }
-      }
-    };
-  }, [currentIndex, tracks, isFullScreen, showStatus]);
+  // Reset elapsed time on track change + arm the track-switch guard (shared).
+  const setElapsedTimeOnReset = useCallback(
+    (time: number) => useIpodStore.getState().setElapsedTime(time),
+    []
+  );
+  const handleResetSeekStatus = useCallback(
+    (seconds: number) =>
+      showStatus(`▶ ${formatSecondsAsMinutesSeconds(seconds)}`),
+    [showStatus]
+  );
+  useMediaTrackChangeReset({
+    currentIndex,
+    tracks,
+    isFullScreen,
+    playerRef,
+    fullScreenPlayerRef,
+    isTrackSwitchingRef,
+    trackSwitchTimeoutRef,
+    setElapsedTime: setElapsedTimeOnReset,
+    onSeekStatus: handleResetSeekStatus,
+  });
 
   // Cleanup status timeout
   useEffect(() => {
@@ -3658,18 +3628,6 @@ export function useIpodLogic({
     }
   }, [menuMode]);
 
-  // Helper to mark track switch start and schedule end
-  const startTrackSwitch = useCallback(() => {
-    isTrackSwitchingRef.current = true;
-    if (trackSwitchTimeoutRef.current) {
-      clearTimeout(trackSwitchTimeoutRef.current);
-    }
-    // Allow 2 seconds for YouTube to load before accepting play/pause events
-    trackSwitchTimeoutRef.current = setTimeout(() => {
-      isTrackSwitchingRef.current = false;
-    }, 2000);
-  }, []);
-
   const getCurrentAppleMusicCollectionShellTrack = useCallback(() => {
     const state = useIpodStore.getState();
     if (state.librarySource !== "appleMusic" || !state.appleMusicCurrentSongId) {
@@ -4926,92 +4884,35 @@ export function useIpodLogic({
     setCurrentFuriganaMap(furiganaRecord);
   }, [furiganaRecord, setCurrentFuriganaMap]);
 
-  // Fullscreen sync
-  const prevFullScreenRef = useRef(isFullScreen);
-
-  useEffect(() => {
-    const timeoutIds = new Set<ReturnType<typeof setTimeout>>();
-    const scheduleTimeout = (callback: () => void, delay: number) => {
-      const timeoutId = setTimeout(() => {
-        timeoutIds.delete(timeoutId);
-        callback();
-      }, delay);
-      timeoutIds.add(timeoutId);
-      return timeoutId;
-    };
-
-    if (isFullScreen !== prevFullScreenRef.current) {
-      // Apple Music plays through a single shared MusicKit instance, so
-      // toggling fullscreen never needs the YouTube-style seek-and-resume
-      // dance between two iframes. Skip the sync entirely.
-      if (isAppleMusic) {
-        prevFullScreenRef.current = isFullScreen;
-        return;
-      }
-
-      // Mark as track switching to prevent spurious play/pause events during sync
-      isTrackSwitchingRef.current = true;
-      if (trackSwitchTimeoutRef.current) {
-        clearTimeout(trackSwitchTimeoutRef.current);
-      }
-
-      if (isFullScreen) {
-        const currentTime =
-          playerRef.current?.getCurrentTime() ||
-          useIpodStore.getState().elapsedTime;
-        const wasPlaying = isPlaying;
-
-        // Wait for fullscreen player to be ready before seeking
-        const checkAndSync = () => {
-          const internalPlayer = fullScreenPlayerRef.current?.getInternalPlayer?.();
-          if (internalPlayer && typeof internalPlayer.getPlayerState === "function") {
-            const playerState = internalPlayer.getPlayerState();
-            // -1 = unstarted, wait for player to be ready
-            if (playerState !== -1) {
-              fullScreenPlayerRef.current?.seekTo(currentTime);
-              if (wasPlaying && typeof internalPlayer.playVideo === "function") {
-                // On iOS Safari, only play if user has interacted
-                if (!isIOSSafari || userHasInteractedRef.current) {
-                  internalPlayer.playVideo();
-                }
-              }
-              // End track switch after sync complete
-              trackSwitchTimeoutRef.current = scheduleTimeout(() => {
-                isTrackSwitchingRef.current = false;
-              }, 500);
-              return;
-            }
-          }
-          // Player not ready, retry
-          scheduleTimeout(checkAndSync, 100);
-        };
-        scheduleTimeout(checkAndSync, 100);
-      } else {
-        const currentTime =
-          fullScreenPlayerRef.current?.getCurrentTime() ||
-          useIpodStore.getState().elapsedTime;
-        const wasPlaying = isPlaying;
-
-        scheduleTimeout(() => {
-          if (playerRef.current) {
-            playerRef.current.seekTo(currentTime);
-            if (wasPlaying && !useIpodStore.getState().isPlaying) {
-              setIsPlaying(true);
-            }
-          }
-          // End track switch after sync complete
-          trackSwitchTimeoutRef.current = scheduleTimeout(() => {
-            isTrackSwitchingRef.current = false;
-          }, 500);
-        }, 200);
-      }
-      prevFullScreenRef.current = isFullScreen;
-    }
-    return () => {
-      timeoutIds.forEach((timeoutId) => clearTimeout(timeoutId));
-      timeoutIds.clear();
-    };
-  }, [isAppleMusic, isFullScreen, isPlaying, setIsPlaying, isIOSSafari]);
+  // Fullscreen position sync (shared). Apple Music plays through a single
+  // shared MusicKit instance, so toggling fullscreen never needs the
+  // YouTube-style seek-and-resume dance between two iframes — skip it. On iOS
+  // Safari, only autoplay after a user interaction.
+  const getElapsedForFullscreenSync = useCallback(
+    () => useIpodStore.getState().elapsedTime,
+    []
+  );
+  const canAutoplayInFullscreen = useCallback(
+    () => !isIOSSafari || userHasInteractedRef.current,
+    [isIOSSafari, userHasInteractedRef]
+  );
+  const isStorePlayingNow = useCallback(
+    () => useIpodStore.getState().isPlaying,
+    []
+  );
+  useMediaFullscreenSync({
+    isFullScreen,
+    isPlaying,
+    setIsPlaying,
+    playerRef,
+    fullScreenPlayerRef,
+    isTrackSwitchingRef,
+    trackSwitchTimeoutRef,
+    getElapsedTime: getElapsedForFullscreenSync,
+    skip: isAppleMusic,
+    canAutoplay: canAutoplayInFullscreen,
+    guardRedundantResumeOnExit: isStorePlayingNow,
+  });
 
   // Seek time for fullscreen (delta)
   const seekTime = useCallback(

--- a/src/apps/ipod/hooks/useIpodLogic.ts
+++ b/src/apps/ipod/hooks/useIpodLogic.ts
@@ -11,6 +11,7 @@ import {
   useMediaTrackChangeReset,
   useMediaFullscreenSync,
 } from "@/shared/media/useMediaPlayback";
+import { useMediaDeepLinks } from "@/shared/media/useMediaDeepLinks";
 import { useMediaAppDialogs } from "@/hooks/useMediaAppDialogs";
 import { useCustomEventListener, useEventListener } from "@/hooks/useEventListener";
 import { useLibraryUpdateChecker } from "./useLibraryUpdateChecker";
@@ -56,7 +57,6 @@ import {
   generateIpodSongShareUrl,
   shouldCacheSongMetadataForShare,
 } from "@/utils/sharedUrl";
-import { onAppUpdate } from "@/utils/appEventBus";
 import {
   SEEK_AMOUNT_SECONDS,
   IPOD_NOW_PLAYING_SONG_MENU_KEY as NOW_PLAYING_SONG_MENU_KEY,
@@ -325,8 +325,6 @@ export function useIpodLogic({
   const isMinimized = instanceId
     ? instances[instanceId]?.isMinimized ?? false
     : false;
-  const lastProcessedInitialDataRef = useRef<unknown>(null);
-  const lastProcessedListenSessionRef = useRef<string | null>(null);
 
   const joinListenSession = useListenSessionStore((s) => s.joinSession);
 
@@ -3773,127 +3771,36 @@ export function useIpodLogic({
     [setLibrarySource, setYoutubeCurrentSongId, setIsPlaying, handleAddTrack, isOffline, showOfflineStatus, t, isIOS, isSafari, startTrackSwitch]
   );
 
-  // Initial data handling
-  useEffect(() => {
-    let timeoutId: ReturnType<typeof setTimeout> | null = null;
-
-    if (isWindowOpen && initialData?.videoId && typeof initialData.videoId === "string") {
-      if (lastProcessedInitialDataRef.current === initialData) return;
-
-      const videoIdToProcess = initialData.videoId;
-      timeoutId = setTimeout(() => {
-        processVideoId(videoIdToProcess)
-          .then(() => {
-            if (instanceId) clearIpodInitialData(instanceId);
-          })
-          .catch((error) => {
-            console.error(`Error processing initial videoId ${videoIdToProcess}:`, error);
-          });
-      }, 100);
-      lastProcessedInitialDataRef.current = initialData;
-    }
-    return () => {
-      if (timeoutId !== null) {
-        clearTimeout(timeoutId);
-      }
-    };
-  }, [isWindowOpen, initialData, processVideoId, clearIpodInitialData, instanceId]);
-
-  useEffect(() => {
-    let timeoutId: ReturnType<typeof setTimeout> | null = null;
-
-    if (
-      isWindowOpen &&
-      initialData?.listenSessionId &&
-      typeof initialData.listenSessionId === "string"
-    ) {
-      if (lastProcessedListenSessionRef.current === initialData.listenSessionId) return;
-
-      const sessionIdToProcess = initialData.listenSessionId;
-      timeoutId = setTimeout(() => {
-        joinListenSession(sessionIdToProcess, username || undefined)
-          .then((result) => {
-            if (!result.ok) {
-              toast.error(t("apps.ipod.dialogs.listenSessionJoinFailed"), {
-                description:
-                  result.error || t("apps.ipod.dialogs.pleaseTryAgain"),
-              });
-            }
-            if (instanceId) clearIpodInitialData(instanceId);
-          })
-          .catch((error) => {
-            console.error(`[iPod] Error joining listen session ${sessionIdToProcess}:`, error);
-          });
-      }, 100);
-      lastProcessedListenSessionRef.current = initialData.listenSessionId;
-    }
-    return () => {
-      if (timeoutId !== null) {
-        clearTimeout(timeoutId);
-      }
-    };
-  }, [
+  // Initial data / shared-URL / onAppUpdate handling (shared scaffolding).
+  const handleListenJoinError = useCallback(
+    (result: { ok: boolean; error?: string }) => {
+      toast.error(t("apps.ipod.dialogs.listenSessionJoinFailed"), {
+        description: result.error || t("apps.ipod.dialogs.pleaseTryAgain"),
+      });
+    },
+    [t]
+  );
+  const handleSharedVideoError = useCallback(
+    (videoId: string) => {
+      toast.error(t("apps.ipod.dialogs.failedToLoadSharedTrack"), {
+        description: t("apps.ipod.dialogs.sharedTrackVideoId", { videoId }),
+      });
+    },
+    [t]
+  );
+  useMediaDeepLinks({
+    appId: "ipod",
     isWindowOpen,
     initialData,
-    joinListenSession,
-    username,
-    clearIpodInitialData,
     instanceId,
-  ]);
-
-  // Update app event handling
-  useEffect(() => {
-    return onAppUpdate((event) => {
-      const updateInitialData = event.detail.initialData as
-        | { videoId?: string; listenSessionId?: string }
-        | undefined;
-
-      if (
-        event.detail.appId === "ipod" &&
-        updateInitialData?.videoId &&
-        (!event.detail.instanceId || event.detail.instanceId === instanceId)
-      ) {
-        if (lastProcessedInitialDataRef.current === updateInitialData) return;
-
-        const videoId = updateInitialData.videoId;
-        if (instanceId) {
-          bringInstanceToForeground(instanceId);
-        }
-        processVideoId(videoId).catch((error) => {
-          console.error(`Error processing videoId ${videoId}:`, error);
-          toast.error(t("apps.ipod.dialogs.failedToLoadSharedTrack"), {
-            description: t("apps.ipod.dialogs.sharedTrackVideoId", { videoId }),
-          });
-        });
-        lastProcessedInitialDataRef.current = updateInitialData;
-      }
-
-      if (
-        event.detail.appId === "ipod" &&
-        updateInitialData?.listenSessionId &&
-        (!event.detail.instanceId || event.detail.instanceId === instanceId)
-      ) {
-        const sessionId = updateInitialData.listenSessionId;
-        if (lastProcessedListenSessionRef.current === sessionId) return;
-        if (instanceId) {
-          bringInstanceToForeground(instanceId);
-        }
-        joinListenSession(sessionId, username || undefined)
-          .then((result) => {
-            if (!result.ok) {
-              toast.error(t("apps.ipod.dialogs.listenSessionJoinFailed"), {
-                description:
-                  result.error || t("apps.ipod.dialogs.pleaseTryAgain"),
-              });
-            }
-          })
-          .catch((error) => {
-            console.error(`[iPod] Error joining listen session ${sessionId}:`, error);
-          });
-        lastProcessedListenSessionRef.current = sessionId;
-      }
-    });
-  }, [bringInstanceToForeground, instanceId, joinListenSession, processVideoId, username]);
+    username,
+    clearInitialData: clearIpodInitialData,
+    bringInstanceToForeground,
+    processVideoId,
+    joinListenSession,
+    onJoinError: handleListenJoinError,
+    onVideoIdUpdateError: handleSharedVideoError,
+  });
 
   // Handle closing sync mode - flush pending offset saves
   const closeSyncMode = useCallback(async () => {

--- a/src/apps/ipod/hooks/useIpodPlayback.ts
+++ b/src/apps/ipod/hooks/useIpodPlayback.ts
@@ -1,6 +1,6 @@
 import { useCallback, useLayoutEffect, useRef, useState } from "react";
-import type ReactPlayer from "react-player";
 import { useIpodStore } from "@/stores/useIpodStore";
+import { useMediaPlayerRefs } from "@/shared/media/useMediaPlayback";
 
 type MusicKitLike = {
   currentPlaybackTime?: number;
@@ -18,13 +18,18 @@ export function useIpodPlayback(options: {
   // every tick. Leaf components use `useIpodElapsedTime()` instead, and logic
   // callbacks read `useIpodStore.getState().elapsedTime` on demand.
   const [totalTime, setTotalTime] = useState(0);
-  const playerRef = useRef<ReactPlayer | null>(null);
-  const fullScreenPlayerRef = useRef<ReactPlayer | null>(null);
+  // Shared player refs + track-switch guard (also used by Karaoke).
+  const {
+    playerRef,
+    fullScreenPlayerRef,
+    isTrackSwitchingRef,
+    trackSwitchTimeoutRef,
+    userHasInteractedRef,
+    startTrackSwitch,
+  } = useMediaPlayerRefs();
+  // iPod-only refs for analytics dedupe + skip-driven status suppression.
   const lastTrackedSongRef = useRef<{ trackId: string; elapsedTime: number } | null>(null);
   const skipOperationRef = useRef(false);
-  const userHasInteractedRef = useRef(false);
-  const isTrackSwitchingRef = useRef(false);
-  const trackSwitchTimeoutRef = useRef<NodeJS.Timeout | null>(null);
 
   const pauseBeforeWindowClose = useCallback(() => {
     const store = useIpodStore.getState();
@@ -86,6 +91,7 @@ export function useIpodPlayback(options: {
     userHasInteractedRef,
     isTrackSwitchingRef,
     trackSwitchTimeoutRef,
+    startTrackSwitch,
     pauseBeforeWindowClose,
   };
 }

--- a/src/apps/karaoke/components/karaoke-lyrics-playback/context.tsx
+++ b/src/apps/karaoke/components/karaoke-lyrics-playback/context.tsx
@@ -7,14 +7,13 @@ import {
   type ReactNode,
 } from "react";
 import type { TFunction } from "i18next";
-import { useTranslation } from "react-i18next";
 import { useShallow } from "zustand/react/shallow";
-import { useLyrics } from "@/hooks/useLyrics";
-import { useFurigana } from "@/hooks/useFurigana";
-import { useActivityState, isAnyActivityActive } from "@/hooks/useActivityState";
-import { useLyricsErrorToast } from "@/hooks/useLyricsErrorToast";
 import { useKaraokeStore } from "@/stores/useKaraokeStore";
-import { getEffectiveTranslationLanguage, type Track } from "@/stores/useIpodStore";
+import { type Track } from "@/stores/useIpodStore";
+import {
+  useMediaLyricsPlayback,
+  type UseMediaLyricsPlaybackResult,
+} from "@/shared/media/useMediaLyricsPlayback";
 import {
   getLyricsFontClassName,
   LyricsFont as LyricsFontEnum,
@@ -23,10 +22,10 @@ import {
 } from "@/types/lyrics";
 
 export interface KaraokeLyricsPlaybackContextValue {
-  lyricsControls: ReturnType<typeof useLyrics>;
-  furiganaMap: ReturnType<typeof useFurigana>["furiganaMap"];
-  soramimiMap: ReturnType<typeof useFurigana>["soramimiMap"];
-  activityState: ReturnType<typeof useActivityState>;
+  lyricsControls: UseMediaLyricsPlaybackResult["lyricsControls"];
+  furiganaMap: UseMediaLyricsPlaybackResult["furiganaMap"];
+  soramimiMap: UseMediaLyricsPlaybackResult["soramimiMap"];
+  activityState: UseMediaLyricsPlaybackResult["activityState"];
   hasActiveActivity: boolean;
   elapsedTime: number;
   lyricsFontClassName: string;
@@ -73,83 +72,32 @@ export function KaraokeLyricsPlaybackProvider({
   auth,
   lyricsPlaybackSyncRef,
 }: ProviderProps) {
-  const { i18n } = useTranslation();
-  const appLanguage = i18n.resolvedLanguage ?? i18n.language;
   const elapsedTime = useKaraokeStore(useShallow((s) => s.elapsedTime));
 
   const lyricsFontClassName = getLyricsFontClassName(lyricsFont ?? LyricsFontEnum.GoldGlow);
 
-  const selectedMatchForLyrics = useMemo(() => {
-    if (!lyricsSourceOverride) return undefined;
-    return {
-      hash: lyricsSourceOverride.hash,
-      albumId: lyricsSourceOverride.albumId,
-      title: lyricsSourceOverride.title,
-      artist: lyricsSourceOverride.artist,
-      album: lyricsSourceOverride.album,
-    };
-  }, [lyricsSourceOverride]);
-
-  const effectiveTranslationLanguage = useMemo(
-    () => getEffectiveTranslationLanguage(lyricsTranslationLanguage),
-    [lyricsTranslationLanguage, appLanguage]
-  );
-
-  const lyricsControls = useLyrics({
+  const {
+    lyricsControls,
+    furiganaMap,
+    soramimiMap,
+    activityState,
+    hasActiveActivity,
+  } = useMediaLyricsPlayback({
     songId: currentTrack?.id ?? "",
     title: currentTrack?.title ?? "",
     artist: currentTrack?.artist ?? "",
+    // Karaoke drives line tracking reactively from the playback clock; this
+    // small provider re-rendering each tick is acceptable.
     currentTime: elapsedTime + (currentTrack?.lyricOffset ?? 0) / 1000,
-    translateTo: effectiveTranslationLanguage,
-    selectedMatch: selectedMatchForLyrics,
-    includeFurigana: true,
-    includeSoramimi: true,
-    soramimiTargetLanguage: romanization.soramamiTargetLanguage ?? "zh-TW",
-    auth,
-  });
-
-  useLyricsErrorToast({
-    error: lyricsControls.error,
-    songId: currentTrack?.id,
-    onSearchClick: () => setIsLyricsSearchDialogOpen(true),
-    t,
-    appId: "karaoke",
-  });
-
-  const {
-    furiganaMap,
-    soramimiMap,
-    isFetchingFurigana: isFetchingFuriganaFromHook,
-    isFetchingSoramimi,
-    furiganaProgress,
-    soramimiProgress,
-  } = useFurigana({
-    songId: currentTrack?.id ?? "",
-    lines: lyricsControls.originalLines,
-    isShowingOriginal: true,
+    lyricsTranslationLanguage,
     romanization,
-    prefetchedInfo: lyricsControls.furiganaInfo,
-    prefetchedSoramimiInfo: lyricsControls.soramimiInfo,
-    auth,
-  });
-
-  const activityState = useActivityState({
-    lyricsState: {
-      isLoading: lyricsControls.isLoading,
-      isTranslating: lyricsControls.isTranslating,
-      translationProgress: lyricsControls.translationProgress,
-    },
-    furiganaState: {
-      isFetchingFurigana: isFetchingFuriganaFromHook,
-      furiganaProgress,
-      isFetchingSoramimi,
-      soramimiProgress,
-    },
-    translationLanguage: effectiveTranslationLanguage,
+    lyricsSourceOverride,
     isAddingSong,
+    onSearchLyrics: () => setIsLyricsSearchDialogOpen(true),
+    appId: "karaoke",
+    auth,
+    t,
   });
-
-  const hasActiveActivity = isAnyActivityActive(activityState);
 
   useEffect(() => {
     lyricsPlaybackSyncRef.current = (timeInLyricsSeconds: number) => {

--- a/src/apps/karaoke/hooks/useKaraokeLogic.ts
+++ b/src/apps/karaoke/hooks/useKaraokeLogic.ts
@@ -36,7 +36,7 @@ import type { KaraokeInitialData } from "../../base/types";
 import type { CoverFlowRef } from "@/apps/ipod/components/cover-flow/types";
 import type { SongSearchResult } from "@/components/dialogs/SongSearchDialog";
 import { helpItems } from "..";
-import { onAppUpdate } from "@/utils/appEventBus";
+import { useMediaDeepLinks } from "@/shared/media/useMediaDeepLinks";
 import { MEDIA_ANALYTICS, track as trackAnalytics } from "@/utils/analytics";
 import { formatSecondsAsMinutesSeconds } from "@/utils/timeFormat";
 
@@ -125,9 +125,8 @@ export function useKaraokeLogic({
       bringInstanceToForeground: state.bringInstanceToForeground,
     }));
 
-  // Ref to track processed initial data
-  const lastProcessedInitialDataRef = useRef<typeof initialData | null>(null);
-  const lastProcessedListenSessionRef = useRef<string | null>(null);
+  // Ref to track pending remote-track hydration (deep-link dedupe refs now
+  // live inside useMediaDeepLinks).
   const pendingRemoteTrackHydrationRef = useRef<string | null>(null);
 
   // Independent playback + display state from Karaoke store (not shared with iPod)
@@ -1409,137 +1408,46 @@ export function useKaraokeLogic({
     t,
   ]);
 
-  // Handle initial data (shared track) - process video ID to add/play
-  useEffect(() => {
-    let timeoutId: ReturnType<typeof setTimeout> | null = null;
-
-    if (isWindowOpen && initialData?.videoId && typeof initialData.videoId === "string") {
-      if (lastProcessedInitialDataRef.current === initialData) return;
-
-      const videoIdToProcess = initialData.videoId;
-      timeoutId = setTimeout(() => {
-        processVideoId(videoIdToProcess)
-          .then(() => {
-            if (instanceId) clearInstanceInitialData(instanceId);
-          })
-          .catch((error) => {
-            console.error(`[Karaoke] Error processing initial videoId ${videoIdToProcess}:`, error);
-          });
-      }, 100);
-      lastProcessedInitialDataRef.current = initialData;
-    } else if (
-      isWindowOpen &&
+  // Initial data / shared-URL / onAppUpdate handling (shared scaffolding).
+  const handleListenJoinError = useCallback(
+    (result: { ok: boolean; error?: string }) => {
+      toast.error("Failed to join session", {
+        description: result.error || "Please try again.",
+      });
+    },
+    []
+  );
+  const handleSharedVideoError = useCallback((videoId: string) => {
+    toast.error("Failed to load shared track", {
+      description: `Video ID: ${videoId}`,
+    });
+  }, []);
+  // Reset to the first track when there's no shared track and the current song
+  // no longer exists in the library (Karaoke-only).
+  const handleNoInitialVideoId = useCallback(() => {
+    if (
       !listenRemoteOnly &&
       tracks.length > 0 &&
       currentSongId &&
       !tracks.some((t) => t.id === currentSongId)
     ) {
-      // Reset to first track if current song no longer exists in library
       setCurrentSongId(tracks[0]?.id ?? null);
     }
-    return () => {
-      if (timeoutId !== null) {
-        clearTimeout(timeoutId);
-      }
-    };
-  }, [
+  }, [listenRemoteOnly, tracks, currentSongId, setCurrentSongId]);
+  useMediaDeepLinks({
+    appId: "karaoke",
     isWindowOpen,
     initialData,
-    listenRemoteOnly,
-    processVideoId,
-    clearInstanceInitialData,
     instanceId,
-    tracks,
-    currentSongId,
-    setCurrentSongId,
-  ]);
-
-  useEffect(() => {
-    let timeoutId: ReturnType<typeof setTimeout> | null = null;
-
-    if (
-      isWindowOpen &&
-      initialData?.listenSessionId &&
-      typeof initialData.listenSessionId === "string"
-    ) {
-      if (lastProcessedListenSessionRef.current === initialData.listenSessionId) return;
-
-      const sessionIdToProcess = initialData.listenSessionId;
-      timeoutId = setTimeout(() => {
-        joinListenSession(sessionIdToProcess, username || undefined)
-          .then((result) => {
-            if (!result.ok) {
-              toast.error("Failed to join session", {
-                description: result.error || "Please try again.",
-              });
-            }
-            if (instanceId) clearInstanceInitialData(instanceId);
-          })
-          .catch((error) => {
-            console.error(`[Karaoke] Error joining listen session ${sessionIdToProcess}:`, error);
-          });
-      }, 100);
-      lastProcessedListenSessionRef.current = initialData.listenSessionId;
-    }
-    return () => {
-      if (timeoutId !== null) {
-        clearTimeout(timeoutId);
-      }
-    };
-  }, [isWindowOpen, initialData, joinListenSession, username, clearInstanceInitialData, instanceId]);
-
-  // Handle updateApp event for when app is already open and receives new video
-  useEffect(() => {
-    const handleUpdateApp = (event: CustomEvent<{ appId: string; instanceId?: string; initialData?: unknown }>) => {
-      const updateInitialData = event.detail.initialData as
-        | { videoId?: string; listenSessionId?: string }
-        | undefined;
-
-      if (
-        event.detail.appId === "karaoke" &&
-        updateInitialData?.videoId &&
-        (!event.detail.instanceId || event.detail.instanceId === instanceId)
-      ) {
-        if (lastProcessedInitialDataRef.current === updateInitialData) return;
-
-        const videoId = updateInitialData.videoId;
-        if (instanceId) {
-          bringInstanceToForeground(instanceId);
-        }
-        processVideoId(videoId).catch((error) => {
-          console.error(`[Karaoke] Error processing videoId ${videoId}:`, error);
-          toast.error("Failed to load shared track", { description: `Video ID: ${videoId}` });
-        });
-        lastProcessedInitialDataRef.current = updateInitialData;
-      }
-
-      if (
-        event.detail.appId === "karaoke" &&
-        updateInitialData?.listenSessionId &&
-        (!event.detail.instanceId || event.detail.instanceId === instanceId)
-      ) {
-        const sessionId = updateInitialData.listenSessionId;
-        if (lastProcessedListenSessionRef.current === sessionId) return;
-        if (instanceId) {
-          bringInstanceToForeground(instanceId);
-        }
-        joinListenSession(sessionId, username || undefined)
-          .then((result) => {
-            if (!result.ok) {
-              toast.error("Failed to join session", {
-                description: result.error || "Please try again.",
-              });
-            }
-          })
-          .catch((error) => {
-            console.error(`[Karaoke] Error joining listen session ${sessionId}:`, error);
-          });
-        lastProcessedListenSessionRef.current = sessionId;
-      }
-    };
-
-    return onAppUpdate(handleUpdateApp);
-  }, [processVideoId, bringInstanceToForeground, joinListenSession, username, instanceId]);
+    username,
+    clearInitialData: clearInstanceInitialData,
+    bringInstanceToForeground,
+    processVideoId,
+    joinListenSession,
+    onJoinError: handleListenJoinError,
+    onVideoIdUpdateError: handleSharedVideoError,
+    onNoInitialVideoId: handleNoInitialVideoId,
+  });
 
   const { isWindowsTheme: isXpTheme } = useThemeFlags();
 

--- a/src/apps/karaoke/hooks/useKaraokeLogic.ts
+++ b/src/apps/karaoke/hooks/useKaraokeLogic.ts
@@ -1,6 +1,5 @@
 import { useState, useRef, useEffect, useCallback, useMemo } from "react";
 import { useMediaAppDialogs } from "@/hooks/useMediaAppDialogs";
-import ReactPlayer from "react-player";
 import { toast } from "sonner";
 import { useTranslation } from "react-i18next";
 import { useTranslatedHelpItems } from "@/hooks/useTranslatedHelpItems";
@@ -21,6 +20,11 @@ import {
   broadcastListenState,
   usePlaybackListenSync,
 } from "@/shared/media/playbackListenSync";
+import {
+  useMediaPlayerRefs,
+  useMediaTrackChangeReset,
+  useMediaFullscreenSync,
+} from "@/shared/media/useMediaPlayback";
 import { parseYouTubeVideoId } from "@/utils/youtubeUrl";
 import { resolveMediaCoverUrl } from "@/utils/coverArt";
 import { TRANSLATION_LANGUAGES } from "@/utils/lyricsTranslation";
@@ -279,8 +283,15 @@ export function useKaraokeLogic({
   const longPressStartPos = useRef<{ x: number; y: number } | null>(null);
   const LONG_PRESS_MOVE_THRESHOLD = 10; // pixels - cancel if moved more than this
 
-  // Full screen additional state
-  const fullScreenPlayerRef = useRef<ReactPlayer | null>(null);
+  // Shared player refs + track-switch guard (also used by iPod).
+  const {
+    playerRef,
+    fullScreenPlayerRef,
+    isTrackSwitchingRef,
+    trackSwitchTimeoutRef,
+    userHasInteractedRef,
+    startTrackSwitch,
+  } = useMediaPlayerRefs();
 
   // Playback position lives in karaoke store (high-frequency updates) so the main hook does not re-render every tick
   const [duration, setDurationLocal] = useState(0);
@@ -288,15 +299,10 @@ export function useKaraokeLogic({
     setDurationLocal(d);
     setStoreTotalTime(d);
   }, [setStoreTotalTime]);
-  const playerRef = useRef<ReactPlayer | null>(null);
   const [statusMessage, setStatusMessage] = useState<string | null>(null);
   const statusTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const [showControls, setShowControls] = useState(true);
   const hideControlsTimeoutRef = useRef<number | null>(null);
-
-  // Track switching state to prevent race conditions
-  const isTrackSwitchingRef = useRef(false);
-  const trackSwitchTimeoutRef = useRef<NodeJS.Timeout | null>(null);
 
   // Volume from audio settings store
   const { ipodVolume } = useAudioSettingsStoreShallow((state) => ({ ipodVolume: state.ipodVolume }));
@@ -304,8 +310,6 @@ export function useKaraokeLogic({
   // iOS/Safari detection for autoplay restrictions (cached at module scope).
   const isIOS = IS_IOS;
   const isSafari = IS_SAFARI;
-  // Track user interaction for autoplay guard (iOS Safari blocks autoplay until user interacts)
-  const userHasInteractedRef = useRef(false);
 
   // Current track
   const currentTrack = useMemo<Track | null>(() => {
@@ -491,18 +495,6 @@ export function useKaraokeLogic({
     userHasInteractedRef.current = true;
   }, [restartAutoHideTimer]);
 
-  // Helper to mark track switch start and schedule end
-  const startTrackSwitch = useCallback(() => {
-    isTrackSwitchingRef.current = true;
-    if (trackSwitchTimeoutRef.current) {
-      clearTimeout(trackSwitchTimeoutRef.current);
-    }
-    // Allow 2 seconds for YouTube to load before accepting play/pause events
-    trackSwitchTimeoutRef.current = setTimeout(() => {
-      isTrackSwitchingRef.current = false;
-    }, 2000);
-  }, []);
-
   // Wrapped handlers for fullscreen controls (with offline check)
   const handlePrevious = useCallback(() => {
     if (isOffline) {
@@ -593,62 +585,23 @@ export function useKaraokeLogic({
     };
   }, [isPlaying, anyMenuOpen, isSyncModeOpen, restartAutoHideTimer]);
 
-  // Reset elapsed time on track change and set track switching guard
-  // This catches track changes from any source (AI tools, shared URLs, menu selections, etc.)
-  // Using null as initial value ensures first render triggers the auto-skip check
-  const prevCurrentIndexRef = useRef<number | null>(null);
-  useEffect(() => {
-    let timeoutId: ReturnType<typeof setTimeout> | null = null;
-
-    // Check if track changed or this is initial render (prevCurrentIndexRef.current is null)
-    if (prevCurrentIndexRef.current !== currentIndex) {
-      isTrackSwitchingRef.current = true;
-      if (trackSwitchTimeoutRef.current) {
-        clearTimeout(trackSwitchTimeoutRef.current);
-      }
-      
-      // Get the new track's offset
-      const newTrack = tracks[currentIndex];
-      const newLyricOffset = newTrack?.lyricOffset ?? 0;
-      
-      // For negative offset, auto-skip to where lyrics time = 0
-      // Formula: lyricsTime = playerTime + (lyricOffset / 1000)
-      // When lyricsTime = 0: playerTime = -lyricOffset / 1000
-      // Only seek if offset is negative (produces positive seek target)
-      // and the seek target is reasonable (at least 1 second)
-      const seekTarget = -newLyricOffset / 1000;
-      
-      if (newLyricOffset < 0 && seekTarget >= 1) {
-        setStoreElapsedTime(seekTarget);
-        
-        timeoutId = setTimeout(() => {
-          isTrackSwitchingRef.current = false;
-          const activePlayer = isFullScreen ? fullScreenPlayerRef.current : playerRef.current;
-          if (activePlayer) {
-            activePlayer.seekTo(seekTarget);
-            showStatus(`▶ ${formatSecondsAsMinutesSeconds(seekTarget)}`);
-          }
-        }, 2000);
-        trackSwitchTimeoutRef.current = timeoutId;
-      } else {
-        // Start from beginning for positive/zero offset or small negative offset
-        setStoreElapsedTime(0);
-        timeoutId = setTimeout(() => {
-          isTrackSwitchingRef.current = false;
-        }, 2000);
-        trackSwitchTimeoutRef.current = timeoutId;
-      }
-    }
-    prevCurrentIndexRef.current = currentIndex;
-    return () => {
-      if (timeoutId !== null) {
-        clearTimeout(timeoutId);
-        if (trackSwitchTimeoutRef.current === timeoutId) {
-          trackSwitchTimeoutRef.current = null;
-        }
-      }
-    };
-  }, [currentIndex, tracks, isFullScreen, showStatus, setStoreElapsedTime]);
+  // Reset elapsed time on track change + arm the track-switch guard (shared).
+  const handleResetSeekStatus = useCallback(
+    (seconds: number) =>
+      showStatus(`▶ ${formatSecondsAsMinutesSeconds(seconds)}`),
+    [showStatus]
+  );
+  useMediaTrackChangeReset({
+    currentIndex,
+    tracks,
+    isFullScreen,
+    playerRef,
+    fullScreenPlayerRef,
+    isTrackSwitchingRef,
+    trackSwitchTimeoutRef,
+    setElapsedTime: setStoreElapsedTime,
+    onSeekStatus: handleResetSeekStatus,
+  });
 
   // Cleanup
   useEffect(() => {
@@ -689,81 +642,25 @@ export function useKaraokeLogic({
     return () => window.removeEventListener("toggleAppFullScreen", handleAppMenuFullScreen as EventListener);
   }, [instanceId, toggleFullScreen]);
 
-  // Sync playback position between main and fullscreen player
-  const prevFullScreenRef = useRef(isFullScreen);
-
-  useEffect(() => {
-    const timeoutIds = new Set<ReturnType<typeof setTimeout>>();
-    const scheduleTimeout = (callback: () => void, delay: number) => {
-      const timeoutId = setTimeout(() => {
-        timeoutIds.delete(timeoutId);
-        callback();
-      }, delay);
-      timeoutIds.add(timeoutId);
-      return timeoutId;
-    };
-
-    if (isFullScreen !== prevFullScreenRef.current) {
-      // Mark as track switching to prevent spurious play/pause events during sync
-      isTrackSwitchingRef.current = true;
-      if (trackSwitchTimeoutRef.current) {
-        clearTimeout(trackSwitchTimeoutRef.current);
-      }
-      
-      if (isFullScreen) {
-        trackAnalytics(MEDIA_ANALYTICS.FULLSCREEN, { appId: "karaoke", isOpen: true });
-        // Entering fullscreen - sync position from main player to fullscreen player
-        const currentTime = playerRef.current?.getCurrentTime() ?? useKaraokeStore.getState().elapsedTime;
-        const wasPlaying = isPlaying;
-
-        // Wait for fullscreen player to be ready before seeking
-        const checkAndSync = () => {
-          const internalPlayer = fullScreenPlayerRef.current?.getInternalPlayer?.();
-          if (internalPlayer && typeof internalPlayer.getPlayerState === "function") {
-            const playerState = internalPlayer.getPlayerState();
-            // -1 = unstarted, 3 = buffering, 5 = cued are "not ready" states
-            if (playerState !== -1) {
-              fullScreenPlayerRef.current?.seekTo(currentTime);
-              if (wasPlaying && typeof internalPlayer.playVideo === "function") {
-                internalPlayer.playVideo();
-              }
-              // End track switch after sync complete
-              trackSwitchTimeoutRef.current = scheduleTimeout(() => {
-                isTrackSwitchingRef.current = false;
-              }, 500);
-              return;
-            }
-          }
-          // Player not ready, retry
-          scheduleTimeout(checkAndSync, 100);
-        };
-        scheduleTimeout(checkAndSync, 100);
-      } else {
-        trackAnalytics(MEDIA_ANALYTICS.FULLSCREEN, { appId: "karaoke", isOpen: false });
-        // Exiting fullscreen - sync position from fullscreen player to main player
-        const currentTime = fullScreenPlayerRef.current?.getCurrentTime() ?? useKaraokeStore.getState().elapsedTime;
-        const wasPlaying = isPlaying;
-
-        scheduleTimeout(() => {
-          if (playerRef.current) {
-            playerRef.current.seekTo(currentTime);
-            if (wasPlaying) {
-              setIsPlaying(true);
-            }
-          }
-          // End track switch after sync complete
-          trackSwitchTimeoutRef.current = scheduleTimeout(() => {
-            isTrackSwitchingRef.current = false;
-          }, 500);
-        }, 200);
-      }
-      prevFullScreenRef.current = isFullScreen;
-    }
-    return () => {
-      timeoutIds.forEach((timeoutId) => clearTimeout(timeoutId));
-      timeoutIds.clear();
-    };
-  }, [isFullScreen, isPlaying, setIsPlaying]);
+  // Sync playback position between main and fullscreen player (shared).
+  const getElapsedForFullscreenSync = useCallback(
+    () => useKaraokeStore.getState().elapsedTime,
+    []
+  );
+  const handleFullscreenToggleAnalytics = useCallback((isOpen: boolean) => {
+    trackAnalytics(MEDIA_ANALYTICS.FULLSCREEN, { appId: "karaoke", isOpen });
+  }, []);
+  useMediaFullscreenSync({
+    isFullScreen,
+    isPlaying,
+    setIsPlaying,
+    playerRef,
+    fullScreenPlayerRef,
+    isTrackSwitchingRef,
+    trackSwitchTimeoutRef,
+    getElapsedTime: getElapsedForFullscreenSync,
+    onToggle: handleFullscreenToggleAnalytics,
+  });
 
   // Handle closing sync mode - flush pending offset saves
   const closeSyncMode = useCallback(async () => {

--- a/src/shared/media/mediaQueue.ts
+++ b/src/shared/media/mediaQueue.ts
@@ -1,0 +1,15 @@
+/**
+ * Pure, store-agnostic helpers for media playback queues shared by the iPod and
+ * Karaoke stores. Kept free of any store/React imports so they can be unit
+ * tested and reused without pulling in persistence machinery.
+ */
+
+/** Resolve the index of an item by id, returning -1 when absent/empty. */
+export function getIndexFromSongId<T extends { id: string }>(
+  items: T[],
+  id: string | null
+): number {
+  if (!id || items.length === 0) return -1;
+  const index = items.findIndex((item) => item.id === id);
+  return index >= 0 ? index : -1;
+}

--- a/src/shared/media/useMediaDeepLinks.ts
+++ b/src/shared/media/useMediaDeepLinks.ts
@@ -1,0 +1,214 @@
+import { useEffect, useRef } from "react";
+import { onAppUpdate } from "@/utils/appEventBus";
+
+/**
+ * Shared deep-link / shared-URL plumbing for media apps (iPod + Karaoke).
+ *
+ * Both apps handle the same three flows identically except for app-specific
+ * bodies (which library/setter a shared track lands in, toast copy, etc.):
+ * 1. Initial `initialData.videoId` — add/play a shared track on open.
+ * 2. Initial `initialData.listenSessionId` — join a listen session on open.
+ * 3. `onAppUpdate` — same two flows when the app is already open.
+ *
+ * The app-specific work is passed in as callbacks; only the effect scaffolding
+ * (dedupe guards, the 100ms defer on open, instance matching, foregrounding,
+ * and clearing initial data) lives here.
+ */
+
+export interface MediaDeepLinkInitialData {
+  videoId?: string;
+  listenSessionId?: string;
+}
+
+export interface ListenSessionJoinResult {
+  ok: boolean;
+  error?: string;
+}
+
+export interface UseMediaDeepLinksParams {
+  appId: string;
+  isWindowOpen: boolean;
+  initialData: MediaDeepLinkInitialData | undefined;
+  instanceId: string | undefined;
+  username: string | null | undefined;
+  clearInitialData: (instanceId: string) => void;
+  bringInstanceToForeground: (instanceId: string) => void;
+  /** Add/select + (maybe) play the shared video. App owns library routing. */
+  processVideoId: (videoId: string) => Promise<void>;
+  joinListenSession: (
+    sessionId: string,
+    username?: string
+  ) => Promise<ListenSessionJoinResult>;
+  /** Toast on a failed join (copy differs per app). */
+  onJoinError: (result: ListenSessionJoinResult) => void;
+  /** Toast on a failed `onAppUpdate` video load (copy differs per app). */
+  onVideoIdUpdateError: (videoId: string, error: unknown) => void;
+  /**
+   * Runs (only while the window is open) when there is no initial `videoId`.
+   * Karaoke uses this to reset to the first track when the current song no
+   * longer exists; iPod omits it.
+   */
+  onNoInitialVideoId?: () => void;
+}
+
+export function useMediaDeepLinks({
+  appId,
+  isWindowOpen,
+  initialData,
+  instanceId,
+  username,
+  clearInitialData,
+  bringInstanceToForeground,
+  processVideoId,
+  joinListenSession,
+  onJoinError,
+  onVideoIdUpdateError,
+  onNoInitialVideoId,
+}: UseMediaDeepLinksParams): void {
+  const lastProcessedInitialDataRef = useRef<unknown>(null);
+  const lastProcessedListenSessionRef = useRef<string | null>(null);
+
+  // 1. Initial shared track (videoId) on open.
+  useEffect(() => {
+    let timeoutId: ReturnType<typeof setTimeout> | null = null;
+
+    if (
+      isWindowOpen &&
+      initialData?.videoId &&
+      typeof initialData.videoId === "string"
+    ) {
+      if (lastProcessedInitialDataRef.current === initialData) return;
+
+      const videoIdToProcess = initialData.videoId;
+      timeoutId = setTimeout(() => {
+        processVideoId(videoIdToProcess)
+          .then(() => {
+            if (instanceId) clearInitialData(instanceId);
+          })
+          .catch((error) => {
+            console.error(
+              `[${appId}] Error processing initial videoId ${videoIdToProcess}:`,
+              error
+            );
+          });
+      }, 100);
+      lastProcessedInitialDataRef.current = initialData;
+    } else if (isWindowOpen) {
+      onNoInitialVideoId?.();
+    }
+    return () => {
+      if (timeoutId !== null) {
+        clearTimeout(timeoutId);
+      }
+    };
+  }, [
+    appId,
+    isWindowOpen,
+    initialData,
+    instanceId,
+    processVideoId,
+    clearInitialData,
+    onNoInitialVideoId,
+  ]);
+
+  // 2. Initial listen-session join on open.
+  useEffect(() => {
+    let timeoutId: ReturnType<typeof setTimeout> | null = null;
+
+    if (
+      isWindowOpen &&
+      initialData?.listenSessionId &&
+      typeof initialData.listenSessionId === "string"
+    ) {
+      if (lastProcessedListenSessionRef.current === initialData.listenSessionId)
+        return;
+
+      const sessionIdToProcess = initialData.listenSessionId;
+      timeoutId = setTimeout(() => {
+        joinListenSession(sessionIdToProcess, username || undefined)
+          .then((result) => {
+            if (!result.ok) onJoinError(result);
+            if (instanceId) clearInitialData(instanceId);
+          })
+          .catch((error) => {
+            console.error(
+              `[${appId}] Error joining listen session ${sessionIdToProcess}:`,
+              error
+            );
+          });
+      }, 100);
+      lastProcessedListenSessionRef.current = initialData.listenSessionId;
+    }
+    return () => {
+      if (timeoutId !== null) {
+        clearTimeout(timeoutId);
+      }
+    };
+  }, [
+    appId,
+    isWindowOpen,
+    initialData,
+    instanceId,
+    username,
+    joinListenSession,
+    clearInitialData,
+    onJoinError,
+  ]);
+
+  // 3. `onAppUpdate` — same two flows when the app is already open.
+  useEffect(() => {
+    return onAppUpdate((event) => {
+      const updateInitialData = event.detail.initialData as
+        | MediaDeepLinkInitialData
+        | undefined;
+      const matchesInstance =
+        !event.detail.instanceId || event.detail.instanceId === instanceId;
+
+      if (
+        event.detail.appId === appId &&
+        updateInitialData?.videoId &&
+        matchesInstance
+      ) {
+        if (lastProcessedInitialDataRef.current === updateInitialData) return;
+
+        const videoId = updateInitialData.videoId;
+        if (instanceId) bringInstanceToForeground(instanceId);
+        processVideoId(videoId).catch((error) => {
+          console.error(`[${appId}] Error processing videoId ${videoId}:`, error);
+          onVideoIdUpdateError(videoId, error);
+        });
+        lastProcessedInitialDataRef.current = updateInitialData;
+      }
+
+      if (
+        event.detail.appId === appId &&
+        updateInitialData?.listenSessionId &&
+        matchesInstance
+      ) {
+        const sessionId = updateInitialData.listenSessionId;
+        if (lastProcessedListenSessionRef.current === sessionId) return;
+        if (instanceId) bringInstanceToForeground(instanceId);
+        joinListenSession(sessionId, username || undefined)
+          .then((result) => {
+            if (!result.ok) onJoinError(result);
+          })
+          .catch((error) => {
+            console.error(
+              `[${appId}] Error joining listen session ${sessionId}:`,
+              error
+            );
+          });
+        lastProcessedListenSessionRef.current = sessionId;
+      }
+    });
+  }, [
+    appId,
+    instanceId,
+    username,
+    processVideoId,
+    joinListenSession,
+    bringInstanceToForeground,
+    onJoinError,
+    onVideoIdUpdateError,
+  ]);
+}

--- a/src/shared/media/useMediaLyricsPlayback.ts
+++ b/src/shared/media/useMediaLyricsPlayback.ts
@@ -1,0 +1,177 @@
+import { useMemo } from "react";
+import type { TFunction } from "i18next";
+import { useTranslation } from "react-i18next";
+import { useLyrics } from "@/hooks/useLyrics";
+import { useFurigana } from "@/hooks/useFurigana";
+import {
+  useActivityState,
+  isAnyActivityActive,
+} from "@/hooks/useActivityState";
+import { useLyricsErrorToast } from "@/hooks/useLyricsErrorToast";
+import {
+  getEffectiveTranslationLanguage,
+  type LyricsSource,
+} from "@/stores/useIpodStore";
+import type { RomanizationSettings } from "@/types/lyrics";
+
+/**
+ * Shared lyrics-playback composition for media apps (iPod + Karaoke).
+ *
+ * Wraps the four hooks both apps wire identically — `useLyrics`,
+ * `useLyricsErrorToast`, `useFurigana`, `useActivityState` — together with the
+ * `selectedMatch` / effective-translation-language memos that were previously
+ * copy-pasted into `useIpodLogic` and `KaraokeLyricsPlaybackProvider`.
+ *
+ * App-specific concerns intentionally stay with the caller:
+ * - The playback clock. iPod drives lyric-line tracking out-of-React via a
+ *   store subscription (passing `currentTime: 0` here to avoid re-rendering the
+ *   huge iPod logic hook ~20x/sec); Karaoke passes a reactive `currentTime`.
+ *   Both use the returned `lyricsControls.updateCurrentTimeManually`.
+ * - Writing the furigana map into a store (iPod only).
+ * - Apple Music shell metadata resolution (iPod resolves title/artist/songId
+ *   before calling this hook).
+ */
+export interface UseMediaLyricsPlaybackParams {
+  /** Resolved lyrics song id (Apple Music callers resolve the live song id). */
+  songId: string;
+  /** Resolved title (may differ from the track title for AM shells). */
+  title: string;
+  /** Resolved artist. */
+  artist: string;
+  /**
+   * Current playback time in seconds, already including any lyric offset.
+   * Pass `0` (static) when driving line tracking imperatively via
+   * `lyricsControls.updateCurrentTimeManually` to avoid per-tick re-renders.
+   */
+  currentTime: number;
+  /** Raw translation-language preference; resolved to a locale internally. */
+  lyricsTranslationLanguage: string | null;
+  romanization: RomanizationSettings;
+  /** Manual per-track lyrics-source override, if any. */
+  lyricsSourceOverride: LyricsSource | undefined;
+  /** Whether a song is currently being added (feeds the activity indicator). */
+  isAddingSong: boolean;
+  /** Opens the manual lyrics-search dialog from the error toast action. */
+  onSearchLyrics: () => void;
+  /** Owning app — selects the i18n namespace for the error toast. */
+  appId: "ipod" | "karaoke";
+  auth?: { username: string; isAuthenticated: boolean };
+  t: TFunction;
+}
+
+export interface UseMediaLyricsPlaybackResult {
+  lyricsControls: ReturnType<typeof useLyrics>;
+  furiganaMap: ReturnType<typeof useFurigana>["furiganaMap"];
+  soramimiMap: ReturnType<typeof useFurigana>["soramimiMap"];
+  activityState: ReturnType<typeof useActivityState>;
+  hasActiveActivity: boolean;
+  /** "auto" resolved to the active ryOS locale. */
+  effectiveTranslationLanguage: string | null;
+}
+
+export function useMediaLyricsPlayback({
+  songId,
+  title,
+  artist,
+  currentTime,
+  lyricsTranslationLanguage,
+  romanization,
+  lyricsSourceOverride,
+  isAddingSong,
+  onSearchLyrics,
+  appId,
+  auth,
+  t,
+}: UseMediaLyricsPlaybackParams): UseMediaLyricsPlaybackResult {
+  const { i18n } = useTranslation();
+  // Track the resolved language so "auto" updates when the system language changes.
+  const appLanguage = i18n.resolvedLanguage ?? i18n.language;
+
+  const selectedMatchForLyrics = useMemo(() => {
+    if (!lyricsSourceOverride) return undefined;
+    return {
+      hash: lyricsSourceOverride.hash,
+      albumId: lyricsSourceOverride.albumId,
+      title: lyricsSourceOverride.title,
+      artist: lyricsSourceOverride.artist,
+      album: lyricsSourceOverride.album,
+    };
+  }, [lyricsSourceOverride]);
+
+  const effectiveTranslationLanguage = useMemo(
+    () => getEffectiveTranslationLanguage(lyricsTranslationLanguage),
+    // appLanguage intentionally a dep so "auto" re-resolves on locale change.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [lyricsTranslationLanguage, appLanguage]
+  );
+
+  const lyricsControls = useLyrics({
+    songId,
+    title,
+    artist,
+    currentTime,
+    translateTo: effectiveTranslationLanguage,
+    selectedMatch: selectedMatchForLyrics,
+    // Fetch furigana info with lyrics to reduce API calls.
+    includeFurigana: true,
+    // Always include soramimi in request to avoid hydration timing issues
+    // (default setting is false, but the user's saved setting might be true
+    // after hydration). The server only returns cached soramimi data here.
+    includeSoramimi: true,
+    soramimiTargetLanguage: romanization.soramamiTargetLanguage ?? "zh-TW",
+    auth,
+  });
+
+  // Show a toast with a Search button when lyrics fetch fails.
+  useLyricsErrorToast({
+    error: lyricsControls.error,
+    songId: songId || undefined,
+    onSearchClick: onSearchLyrics,
+    t,
+    appId,
+  });
+
+  const {
+    furiganaMap,
+    soramimiMap,
+    isFetchingFurigana,
+    isFetchingSoramimi,
+    furiganaProgress,
+    soramimiProgress,
+  } = useFurigana({
+    songId,
+    lines: lyricsControls.originalLines,
+    isShowingOriginal: true,
+    romanization,
+    prefetchedInfo: lyricsControls.furiganaInfo,
+    prefetchedSoramimiInfo: lyricsControls.soramimiInfo,
+    auth,
+  });
+
+  const activityState = useActivityState({
+    lyricsState: {
+      isLoading: lyricsControls.isLoading,
+      isTranslating: lyricsControls.isTranslating,
+      translationProgress: lyricsControls.translationProgress,
+    },
+    furiganaState: {
+      isFetchingFurigana,
+      furiganaProgress,
+      isFetchingSoramimi,
+      soramimiProgress,
+    },
+    translationLanguage: effectiveTranslationLanguage,
+    isAddingSong,
+  });
+
+  const hasActiveActivity = isAnyActivityActive(activityState);
+
+  return {
+    lyricsControls,
+    furiganaMap,
+    soramimiMap,
+    activityState,
+    hasActiveActivity,
+    effectiveTranslationLanguage,
+  };
+}

--- a/src/shared/media/useMediaPlayback.ts
+++ b/src/shared/media/useMediaPlayback.ts
@@ -1,0 +1,283 @@
+import { useCallback, useEffect, useRef } from "react";
+import type ReactPlayer from "react-player";
+import type { Track } from "@/stores/useIpodStore";
+
+/**
+ * Shared YouTube/ReactPlayer playback machinery for media apps (iPod + Karaoke).
+ *
+ * Only the *mechanical* pieces that were duplicated near-verbatim live here:
+ * - the dual player refs (window + fullscreen) and the track-switch guard,
+ * - the negative-lyric-offset auto-seek on track change,
+ * - the position sync when toggling between the window and fullscreen players.
+ *
+ * App-specific handlers (`handlePlay` / `handlePause` / `handleProgress` /
+ * `handleTrackEnd` / seek) intentionally stay in each app: they differ in
+ * analytics namespace, status glyphs, Apple Music, and Karaoke's listen-session
+ * remote-control paths, so unifying them would be a leaky abstraction.
+ */
+
+export interface MediaPlayerRefs {
+  playerRef: React.MutableRefObject<ReactPlayer | null>;
+  fullScreenPlayerRef: React.MutableRefObject<ReactPlayer | null>;
+  isTrackSwitchingRef: React.MutableRefObject<boolean>;
+  trackSwitchTimeoutRef: React.MutableRefObject<NodeJS.Timeout | null>;
+  userHasInteractedRef: React.MutableRefObject<boolean>;
+  /**
+   * Mark a track switch as in-progress and auto-clear it after 2s so the
+   * window/fullscreen players' transient play/pause events are ignored while
+   * the new video loads.
+   */
+  startTrackSwitch: () => void;
+}
+
+/**
+ * Owns the two ReactPlayer refs + the track-switch guard shared by both apps.
+ * iPod composes this inside `useIpodPlayback` (which adds MusicKit-specific
+ * refs + `pauseBeforeWindowClose`); Karaoke uses it directly.
+ */
+export function useMediaPlayerRefs(): MediaPlayerRefs {
+  const playerRef = useRef<ReactPlayer | null>(null);
+  const fullScreenPlayerRef = useRef<ReactPlayer | null>(null);
+  const isTrackSwitchingRef = useRef(false);
+  const trackSwitchTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const userHasInteractedRef = useRef(false);
+
+  const startTrackSwitch = useCallback(() => {
+    isTrackSwitchingRef.current = true;
+    if (trackSwitchTimeoutRef.current) {
+      clearTimeout(trackSwitchTimeoutRef.current);
+    }
+    // Allow 2 seconds for YouTube to load before accepting play/pause events.
+    trackSwitchTimeoutRef.current = setTimeout(() => {
+      isTrackSwitchingRef.current = false;
+    }, 2000);
+  }, []);
+
+  return {
+    playerRef,
+    fullScreenPlayerRef,
+    isTrackSwitchingRef,
+    trackSwitchTimeoutRef,
+    userHasInteractedRef,
+    startTrackSwitch,
+  };
+}
+
+export interface UseMediaTrackChangeResetParams {
+  currentIndex: number;
+  tracks: Track[];
+  isFullScreen: boolean;
+  playerRef: React.MutableRefObject<ReactPlayer | null>;
+  fullScreenPlayerRef: React.MutableRefObject<ReactPlayer | null>;
+  isTrackSwitchingRef: React.MutableRefObject<boolean>;
+  trackSwitchTimeoutRef: React.MutableRefObject<NodeJS.Timeout | null>;
+  /** Sink for the playback clock (iPod / Karaoke store `setElapsedTime`). */
+  setElapsedTime: (time: number) => void;
+  /** Called with the seek target (seconds) after a negative-offset auto-seek. */
+  onSeekStatus?: (seconds: number) => void;
+}
+
+/**
+ * Reset the playback clock on track change and arm the track-switch guard.
+ * Catches track changes from any source (AI tools, shared URLs, menu
+ * selections). For tracks with a negative lyric offset, auto-seeks to where
+ * lyrics time = 0 once the player is ready.
+ */
+export function useMediaTrackChangeReset({
+  currentIndex,
+  tracks,
+  isFullScreen,
+  playerRef,
+  fullScreenPlayerRef,
+  isTrackSwitchingRef,
+  trackSwitchTimeoutRef,
+  setElapsedTime,
+  onSeekStatus,
+}: UseMediaTrackChangeResetParams): void {
+  // null initial value ensures the first render triggers the auto-skip check.
+  const prevCurrentIndexRef = useRef<number | null>(null);
+  useEffect(() => {
+    let timeoutId: ReturnType<typeof setTimeout> | null = null;
+
+    if (prevCurrentIndexRef.current !== currentIndex) {
+      isTrackSwitchingRef.current = true;
+      if (trackSwitchTimeoutRef.current) {
+        clearTimeout(trackSwitchTimeoutRef.current);
+      }
+
+      const newTrack = tracks[currentIndex];
+      const newLyricOffset = newTrack?.lyricOffset ?? 0;
+
+      // For negative offset, auto-skip to where lyrics time = 0.
+      // lyricsTime = playerTime + (lyricOffset / 1000); solve for lyricsTime = 0.
+      // Only seek for a negative offset producing a target of at least 1s.
+      const seekTarget = -newLyricOffset / 1000;
+
+      if (newLyricOffset < 0 && seekTarget >= 1) {
+        setElapsedTime(seekTarget);
+
+        timeoutId = setTimeout(() => {
+          isTrackSwitchingRef.current = false;
+          const activePlayer = isFullScreen
+            ? fullScreenPlayerRef.current
+            : playerRef.current;
+          if (activePlayer) {
+            activePlayer.seekTo(seekTarget);
+            onSeekStatus?.(seekTarget);
+          }
+        }, 2000);
+        trackSwitchTimeoutRef.current = timeoutId;
+      } else {
+        // Start from the beginning for positive/zero/small-negative offsets.
+        setElapsedTime(0);
+        timeoutId = setTimeout(() => {
+          isTrackSwitchingRef.current = false;
+        }, 2000);
+        trackSwitchTimeoutRef.current = timeoutId;
+      }
+    }
+    prevCurrentIndexRef.current = currentIndex;
+    return () => {
+      if (timeoutId !== null) {
+        clearTimeout(timeoutId);
+        if (trackSwitchTimeoutRef.current === timeoutId) {
+          trackSwitchTimeoutRef.current = null;
+        }
+      }
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [currentIndex, tracks, isFullScreen, onSeekStatus, setElapsedTime]);
+}
+
+export interface UseMediaFullscreenSyncParams {
+  isFullScreen: boolean;
+  isPlaying: boolean;
+  setIsPlaying: (playing: boolean) => void;
+  playerRef: React.MutableRefObject<ReactPlayer | null>;
+  fullScreenPlayerRef: React.MutableRefObject<ReactPlayer | null>;
+  isTrackSwitchingRef: React.MutableRefObject<boolean>;
+  trackSwitchTimeoutRef: React.MutableRefObject<NodeJS.Timeout | null>;
+  /** Reads the current playback clock as a fallback when the player can't. */
+  getElapsedTime: () => number;
+  /**
+   * Skip the seek-and-resume dance entirely (iPod Apple Music plays through a
+   * single shared MusicKit instance, so there are never two iframes to sync).
+   */
+  skip?: boolean;
+  /** Gate autoplay on entering fullscreen (iOS Safari blocks autoplay). */
+  canAutoplay?: () => boolean;
+  /**
+   * When true, only resume on exit if the store isn't already playing
+   * (avoids a redundant `setIsPlaying(true)` notification). iPod opts in.
+   */
+  guardRedundantResumeOnExit?: () => boolean;
+  /** Side effect when fullscreen toggles (e.g. analytics). */
+  onToggle?: (isOpen: boolean) => void;
+}
+
+/**
+ * Sync playback position (and resume state) when toggling between the window
+ * player and the fullscreen player.
+ */
+export function useMediaFullscreenSync({
+  isFullScreen,
+  isPlaying,
+  setIsPlaying,
+  playerRef,
+  fullScreenPlayerRef,
+  isTrackSwitchingRef,
+  trackSwitchTimeoutRef,
+  getElapsedTime,
+  skip,
+  canAutoplay,
+  guardRedundantResumeOnExit,
+  onToggle,
+}: UseMediaFullscreenSyncParams): void {
+  const prevFullScreenRef = useRef(isFullScreen);
+
+  useEffect(() => {
+    const timeoutIds = new Set<ReturnType<typeof setTimeout>>();
+    const scheduleTimeout = (callback: () => void, delay: number) => {
+      const timeoutId = setTimeout(() => {
+        timeoutIds.delete(timeoutId);
+        callback();
+      }, delay);
+      timeoutIds.add(timeoutId);
+      return timeoutId;
+    };
+
+    if (isFullScreen !== prevFullScreenRef.current) {
+      if (skip) {
+        prevFullScreenRef.current = isFullScreen;
+        return;
+      }
+
+      onToggle?.(isFullScreen);
+
+      // Mark as track switching to prevent spurious play/pause events during sync.
+      isTrackSwitchingRef.current = true;
+      if (trackSwitchTimeoutRef.current) {
+        clearTimeout(trackSwitchTimeoutRef.current);
+      }
+
+      if (isFullScreen) {
+        // Entering fullscreen — sync position from window to fullscreen player.
+        const currentTime =
+          playerRef.current?.getCurrentTime() || getElapsedTime();
+        const wasPlaying = isPlaying;
+
+        // Wait for the fullscreen player to be ready before seeking.
+        const checkAndSync = () => {
+          const internalPlayer = fullScreenPlayerRef.current?.getInternalPlayer?.();
+          if (
+            internalPlayer &&
+            typeof internalPlayer.getPlayerState === "function"
+          ) {
+            const playerState = internalPlayer.getPlayerState();
+            // -1 = unstarted; wait for the player to be ready.
+            if (playerState !== -1) {
+              fullScreenPlayerRef.current?.seekTo(currentTime);
+              if (wasPlaying && typeof internalPlayer.playVideo === "function") {
+                if (!canAutoplay || canAutoplay()) {
+                  internalPlayer.playVideo();
+                }
+              }
+              trackSwitchTimeoutRef.current = scheduleTimeout(() => {
+                isTrackSwitchingRef.current = false;
+              }, 500);
+              return;
+            }
+          }
+          scheduleTimeout(checkAndSync, 100);
+        };
+        scheduleTimeout(checkAndSync, 100);
+      } else {
+        // Exiting fullscreen — sync position from fullscreen to window player.
+        const currentTime =
+          fullScreenPlayerRef.current?.getCurrentTime() || getElapsedTime();
+        const wasPlaying = isPlaying;
+
+        scheduleTimeout(() => {
+          if (playerRef.current) {
+            playerRef.current.seekTo(currentTime);
+            const shouldResume =
+              wasPlaying &&
+              (!guardRedundantResumeOnExit || !guardRedundantResumeOnExit());
+            if (shouldResume) {
+              setIsPlaying(true);
+            }
+          }
+          trackSwitchTimeoutRef.current = scheduleTimeout(() => {
+            isTrackSwitchingRef.current = false;
+          }, 500);
+        }, 200);
+      }
+      prevFullScreenRef.current = isFullScreen;
+    }
+    return () => {
+      timeoutIds.forEach((timeoutId) => clearTimeout(timeoutId));
+      timeoutIds.clear();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [skip, isFullScreen, isPlaying, setIsPlaying]);
+}

--- a/src/stores/useIpodStore.ts
+++ b/src/stores/useIpodStore.ts
@@ -13,6 +13,7 @@ import {
 import { LyricLine } from "@/types/lyrics";
 import type { FuriganaSegment } from "@/utils/romanization";
 import { getAppPublicOrigin } from "@/utils/runtimeConfig";
+import { getIndexFromSongId } from "@/shared/media/mediaQueue";
 import { getCachedSongMetadata } from "@/utils/songMetadataCache";
 import { ApiRequestError } from "@/api/core";
 import {
@@ -457,13 +458,6 @@ export function isAppleMusicCollectionTrack(
     track?.appleMusicPlayParams?.stationId ||
       track?.appleMusicPlayParams?.playlistId
   );
-}
-
-/** Helper to get current index from song ID */
-function getIndexFromSongId(tracks: Track[], songId: string | null): number {
-  if (!songId || tracks.length === 0) return -1;
-  const index = tracks.findIndex((t) => t.id === songId);
-  return index >= 0 ? index : -1;
 }
 
 export interface IpodState extends IpodData {

--- a/src/stores/useKaraokeStore.ts
+++ b/src/stores/useKaraokeStore.ts
@@ -4,13 +4,7 @@ import type { SetStateAction } from "react";
 import { DisplayMode } from "@/types/lyrics";
 import { useIpodStore, Track } from "./useIpodStore";
 import { shouldUpdatePlaybackTime } from "./playbackTime";
-
-/** Helper to get current index from song ID */
-function getIndexFromSongId(tracks: Track[], songId: string | null): number {
-  if (!songId || tracks.length === 0) return -1;
-  const index = tracks.findIndex((t) => t.id === songId);
-  return index >= 0 ? index : -1;
-}
+import { getIndexFromSongId } from "@/shared/media/mediaQueue";
 
 /** Get a random song ID avoiding the current song */
 function getRandomSongId(tracks: Track[], currentSongId: string | null): string | null {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Decomposes the iPod logic/store monoliths by extracting the media logic genuinely shared between the **iPod** (`useIpodLogic.ts`, 5,430 lines) and **Karaoke** apps into `src/shared/media/`. Four behavior-preserving extractions:

### 1. `useMediaLyricsPlayback` (lyrics composition)
Both apps wired up an identical 5-hook lyrics stack. Extracted into `src/shared/media/useMediaLyricsPlayback.ts`:
- `useLyrics` + `useLyricsErrorToast` + `useFurigana` + `useActivityState`
- the `selectedMatch` memo and the `effectiveTranslationLanguage` ("auto" → locale) memo

App-specific concerns stay with callers: iPod keeps Apple Music shell metadata resolution, the static `currentTime: 0` + out-of-React `useIpodStore` clock subscription, and the furigana→store write; Karaoke keeps its reactive `elapsedTime` clock and `lyricsPlaybackSyncRef`.

### 2. `useMediaPlayback` (playback engine)
The mechanical, near-duplicated YouTube/ReactPlayer machinery, extracted into `src/shared/media/useMediaPlayback.ts` as three composable hooks:
- `useMediaPlayerRefs` — dual player refs (window + fullscreen) + the `startTrackSwitch` guard. iPod composes it inside `useIpodPlayback` (which keeps MusicKit refs + `pauseBeforeWindowClose`); Karaoke uses it directly.
- `useMediaTrackChangeReset` — negative-lyric-offset auto-seek on track change, parameterized by the elapsed-time sink + seek-status callback.
- `useMediaFullscreenSync` — window↔fullscreen position sync, parameterized for Apple Music skip (iPod), iOS autoplay gating (iPod), the redundant-resume guard (iPod), and an analytics `onToggle` hook (Karaoke).

The per-app **handlers** (`handlePlay` / `handlePause` / `handleProgress` / `handleTrackEnd` / seek) intentionally stay in each app — they differ in analytics namespace, status glyphs, Apple Music, and Karaoke's listen-session remote-control paths, so unifying them would be a leaky abstraction.

### 3. `useMediaDeepLinks` (shared-URL / deep-link scaffolding)
Both apps duplicated three effects for shared-link handling. Extracted into `src/shared/media/useMediaDeepLinks.ts`:
- initial `initialData.videoId` (add/play a shared track on open)
- initial `initialData.listenSessionId` (join a listen session on open)
- `onAppUpdate` (same two flows when the app is already open)

The hook owns the dedupe guards, the 100ms defer, instance matching, foregrounding, and `clearInitialData`. App-specific bodies stay as callbacks: iPod routes shared tracks into the YouTube library + closes the menu, toast copy differs (i18n vs literals), and Karaoke's "reset to first track when the current song no longer exists" branch is passed via `onNoInitialVideoId`. The two `lastProcessed*` dedupe refs now live inside the hook.

### 4. `mediaQueue.getIndexFromSongId` (queue helper)
The byte-identical `getIndexFromSongId` copies in `useIpodStore` and `useKaraokeStore` are replaced by a single generic, store-agnostic helper in `src/shared/media/mediaQueue.ts`.

Net effect: lyrics, playback-engine, deep-link, and queue-index duplication removed from the two apps and consolidated into shared, documented modules.

## Testing
- `npx tsc --noEmit` — passes
- `npx eslint` on all changed files — 0 errors (only pre-existing `exhaustive-deps` warnings)
- `bun run test:unit` — 351 pass / 0 fail
- `bun run build` — succeeds

GUI testing was not performed (per `AGENTS.md`: skip computer-use/GUI testing unless explicitly requested). This is a behavior-preserving refactor; the highest-value areas for a manual smoke test are **iPod/Karaoke fullscreen toggling + track skipping** (`useMediaFullscreenSync` / `useMediaTrackChangeReset`) and **opening a shared track / listen-session deep link** (`useMediaDeepLinks`).

## Notes / deliberately out of scope
- `src/shared/media/lyricsPlaybackInput.ts` (`buildLyricsPlaybackInput`) looked like dead code but is covered by `tests/test-lyrics-playback-input.test.ts`, so it was left untouched.
- A **unified queue-navigation slice** (`nextTrack`/`previousTrack`/shuffle) was assessed but not unified: iPod uses history-aware random (`getRandomTrackIdAvoidingRecent` + `playbackHistory`) while Karaoke uses a simpler random, so merging would change Karaoke's behavior and needs runtime testing. Only the truly identical `getIndexFromSongId` was deduped.
- **Carving the iPod-only Apple Music / chrome / menu-navigation slices out of `useIpodStore`** was deferred: it's an internal modularization (no cross-app reuse) and the parts that matter touch the persisted store (version 40, IndexedDB + cloud sync + migrations, ~20 consumers), which can't be safely verified with build/unit tests alone — it warrants a separate, runtime/hydration-tested PR.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ec3a1-6047-707a-b640-8fa51185dc75"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ec3a1-6047-707a-b640-8fa51185dc75"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

