### PR TITLE
feat(sync2): coalesce /changes, per-field settings keys, sorted-set journal

### DIFF
--- a/api/sync/v2/_core.ts
+++ b/api/sync/v2/_core.ts
@@ -4,9 +4,15 @@
  * Per-user state in Redis:
  * - `sync2:seq:{user}`   STRING  monotonically increasing op counter
  * - `sync2:kv:{user}`    HASH    key → JSON SyncKvEntry (latest doc per key)
- * - `sync2:log:{user}`   LIST    accepted ops (ascending seq), bounded
+ * - `sync2:jrnl:{user}`  ZSET    score = seq, member = JSON op (ascending), bounded
  * - `sync2:blobs:{user}` HASH    sha256 → JSON { url, size } dedupe registry
  * - `sync2:lock:{user}`  STRING  short-TTL write lock
+ *
+ * The journal is a sorted set keyed by `seq` so catch-up reads an exact
+ * range by rank and trimming drops the lowest scores — no list-tail
+ * heuristics. (Pre-v2.1 deployments kept it as a `sync2:log:{user}` LIST;
+ * that key is abandoned and expires via its TTL. Clients mid-catch-up fall
+ * back to a snapshot once, then resume on the sorted-set journal.)
  *
  * Writes are ops resolved per key with last-writer-wins on the HLC
  * timestamp. There are no conflicts surfaced to clients: losing ops return
@@ -50,8 +56,8 @@ export function sync2KvKey(username: string): string {
   return `sync2:kv:${username.toLowerCase()}`;
 }
 
-export function sync2LogKey(username: string): string {
-  return `sync2:log:${username.toLowerCase()}`;
+export function sync2JournalKey(username: string): string {
+  return `sync2:jrnl:${username.toLowerCase()}`;
 }
 
 export function sync2BlobsKey(username: string): string {
@@ -138,7 +144,7 @@ async function touchTtls(redis: Redis, username: string): Promise<void> {
   const pipeline = redis.pipeline();
   pipeline.expire(sync2SeqKey(username), USER_TTL_SECONDS);
   pipeline.expire(sync2KvKey(username), USER_TTL_SECONDS);
-  pipeline.expire(sync2LogKey(username), USER_TTL_SECONDS);
+  pipeline.expire(sync2JournalKey(username), USER_TTL_SECONDS);
   pipeline.expire(sync2BlobsKey(username), USER_TTL_SECONDS);
   await pipeline.exec();
 }
@@ -310,7 +316,7 @@ export async function applySyncOps(
     const results: SyncOpResult[] = [];
     const accepted: SyncOp[] = [];
     const kvWrites: Record<string, string> = {};
-    const logEntries: string[] = [];
+    const journalEntries: Array<{ seq: number; member: string }> = [];
     const blobRegistry: Record<string, string> = {};
     const nowMs = Date.now();
 
@@ -345,7 +351,7 @@ export async function applySyncOps(
       };
 
       kvWrites[key] = JSON.stringify(entry);
-      logEntries.push(JSON.stringify(acceptedOp));
+      journalEntries.push({ seq: nextSeq, member: JSON.stringify(acceptedOp) });
       accepted.push(acceptedOp);
       results.push({ k: key, accepted: true, seq: nextSeq });
 
@@ -360,13 +366,21 @@ export async function applySyncOps(
 
     if (accepted.length > 0) {
       await redis.hset(sync2KvKey(username), kvWrites);
-      await redis.rpush(sync2LogKey(username), ...logEntries);
+      const journalKey = sync2JournalKey(username);
+      for (const { seq, member } of journalEntries) {
+        await redis.zadd(journalKey, { score: seq, member });
+      }
       const pipeline = redis.pipeline();
       pipeline.set(sync2SeqKey(username), String(nextSeq), {
         ex: USER_TTL_SECONDS,
       });
       await pipeline.exec();
-      await redis.ltrim(sync2LogKey(username), -JOURNAL_MAX_LENGTH, -1);
+      // Trim to the last JOURNAL_MAX_LENGTH ops by dropping the lowest seqs.
+      await redis.zremrangebyscore(
+        journalKey,
+        "-inf",
+        nextSeq - JOURNAL_MAX_LENGTH
+      );
       if (Object.keys(blobRegistry).length > 0) {
         await redis.hset(sync2BlobsKey(username), blobRegistry);
       }
@@ -408,6 +422,22 @@ export interface SyncChangesResult {
   snapshotRequired?: boolean;
 }
 
+/**
+ * Collapse a seq-ordered op list to the newest op per key. Catch-up only
+ * needs each key's latest value to converge under LWW, so replaying a key's
+ * intermediate states is wasted bandwidth — and on bootstrap they're already
+ * compacted in the KV state. Input must be ascending by seq; the returned
+ * list preserves that order. The cursor still advances to the server seq, so
+ * dropping superseded ops never desyncs the client.
+ */
+function coalesceSyncOpsByKey(ops: SyncOp[]): SyncOp[] {
+  const latest = new Map<string, SyncOp>();
+  for (const op of ops) {
+    latest.set(op.k, op); // ascending seq → last write per key wins
+  }
+  return Array.from(latest.values()).sort((a, b) => (a.seq ?? 0) - (b.seq ?? 0));
+}
+
 export async function readSyncChanges(
   redis: Redis,
   username: string,
@@ -421,17 +451,19 @@ export async function readSyncChanges(
     return { seq, ops: [] };
   }
 
-  const logKey = sync2LogKey(username);
-  const length = await redis.llen(logKey);
+  const journalKey = sync2JournalKey(username);
+  const count = await redis.zcard(journalKey);
   const missing = seq - since;
-  if (missing > length) {
+  if (missing > count) {
     return { seq, snapshotRequired: true };
   }
 
-  // Fetch a small safety margin to absorb writes between the seq and llen
-  // reads, then filter precisely by each op's embedded seq.
-  const fetchCount = Math.min(length, missing + 16);
-  const raw = await redis.lrange<string | SyncOp>(logKey, -fetchCount, -1);
+  // The journal is contiguous in seq (each accept increments by one; trimming
+  // only removes a low-seq prefix), so the op with seq = since+1 sits at rank
+  // `count - missing`. Read from a small margin before it to absorb writes
+  // racing between the zcard and zrange, then filter precisely by seq.
+  const startIndex = Math.max(0, count - missing - 16);
+  const raw = await redis.zrange(journalKey, startIndex, -1);
   const ops: SyncOp[] = [];
   for (const value of raw) {
     const op = parseRedisJson<SyncOp>(value);
@@ -446,7 +478,8 @@ export async function readSyncChanges(
     return { seq, snapshotRequired: true };
   }
 
-  return { seq: Math.max(seq, ops[ops.length - 1].seq ?? seq), ops };
+  const maxSeq = Math.max(seq, ops[ops.length - 1].seq ?? seq);
+  return { seq: maxSeq, ops: coalesceSyncOpsByKey(ops) };
 }
 
 export interface SyncSnapshotResult {

--- a/docs/1.2-api-architecture.md
+++ b/docs/1.2-api-architecture.md
@@ -708,7 +708,7 @@ Cloud Sync v2 publishes `sync-ops` events on per-user sync channels; small remot
 | `sync:meta:` | Backup metadata | `sync:meta:alice` |
 | `sync2:seq:{username}` | Sync v2 journal cursor (op counter) | `sync2:seq:alice` |
 | `sync2:kv:{username}` | Sync v2 key-value state (hash: key → entry) | `sync2:kv:alice` |
-| `sync2:log:{username}` | Sync v2 op journal (bounded list) | `sync2:log:alice` |
+| `sync2:jrnl:{username}` | Sync v2 op journal (bounded sorted set, score = seq) | `sync2:jrnl:alice` |
 | `sync2:blobs:{username}` | Sync v2 content-hash blob registry | `sync2:blobs:alice` |
 | `sync2:maint:cursor` | Sync maintenance cron scan cursor | `sync2:maint:cursor` |
 | `sync:state:{username}:{domain}` | Legacy v1 sync snapshots (imported on first v2 access) | `sync:state:alice:contacts` |

--- a/docs/8.9-utility-apis.md
+++ b/docs/8.9-utility-apis.md
@@ -546,7 +546,10 @@ timestamps are clamped to `serverNow + 5min`.
 
 Returns `{ ok, seq, ops: [...] }` with the ops after `since`, `{ ops: [] }`
 when up to date, or `{ seq, snapshotRequired: true }` when the journal no
-longer covers the cursor (bounded retention; fall back to the snapshot).
+longer covers the cursor (bounded retention; fall back to the snapshot). The
+`ops` are coalesced per key — only the newest op for each key in the window
+is returned (under LWW the client only needs each key's latest value to
+converge), while `seq` still reflects the server cursor.
 
 ### GET /api/sync/v2/snapshot
 

--- a/docs/proposals/cloud-sync-v2.md
+++ b/docs/proposals/cloud-sync-v2.md
@@ -209,9 +209,10 @@ Every syncable piece of state becomes a **key → document** pair, where keys
 are namespaced strings and documents are small JSON values:
 
 ```
-settings/theme                 → { current: "macosx", wallpaper: {...} }
-settings/audio                 → { uiSoundsEnabled: true, ... }
-settings/dock                  → { pinned: [...], magnify: ... }
+settings/theme/current         → "macosx"
+settings/theme/accent          → { macosx: "blue", ... }
+settings/audio/uiSoundsEnabled → true
+settings/dock/pinnedItems      → [...]
 files/doc:/Documents/notes.md  → { name, type, size, contentRef? , ... }
 files/trash:uuid               → { originalPath, deletedAt, contentRef }
 songs/track:dQw4w9WgXcQ        → { title, artist, url, ... }
@@ -227,9 +228,15 @@ wallpapers/item:uuid           → { name, contentRef: { sha256, size } }
 ```
 
 The granularity rule: **a key is the unit of conflict resolution**. v1
-already merges at exactly these granularities (settings sections, file
+already merges at roughly these granularities (settings sections, file
 paths, track ids, per-item signatures) — v2 makes that granularity the
-protocol's native unit instead of reconstructing it from snapshots.
+protocol's native unit instead of reconstructing it from snapshots, and goes
+one finer for settings: each settings *field* is its own key
+(`settings/<section>/<field>`), so two devices editing different fields of
+the same section no longer clobber each other. Legacy bundled
+`settings/<section>` docs (pre-per-field clients, v1 import) are still read
+on apply — their fields are fanned out to the per-field keys, and the
+migrating client retires the bundled key.
 
 Binary content never lives in a document. Documents reference blobs by
 content hash (`contentRef`, §6).
@@ -286,7 +293,7 @@ bootstrap/gap: GET full KV state + current seq  (1 request)
 ```
 sync2:seq:{user}       STRING   monotonically increasing op counter (INCR)
 sync2:kv:{user}        HASH     field = key, value = JSON { v, t, del?, seq }
-sync2:log:{user}       ZSET     score = seq, member = JSON-encoded op
+sync2:jrnl:{user}      ZSET     score = seq, member = JSON-encoded op
 sync2:lock:{user}      STRING   short-TTL write lock (SET NX PX 2000)
 ```
 
@@ -297,7 +304,10 @@ lightweight lock (sync writes for one user are low-frequency — the v1
 debouncer already spaces them seconds apart), and within the lock a single
 pipeline applies KV updates, journal appends, and the seq bump.
 
-Journal trimming: after append, `ZREMRANGEBYSCORE sync2:log:{user} -inf (seq - 4096)`.
+Journal trimming: after append, `ZREMRANGEBYSCORE sync2:jrnl:{user} -inf (seq - 4096)`.
+(Pre-v2.1 deployments stored this as a `sync2:log:{user}` LIST; that key is
+abandoned on upgrade and expires via its TTL — clients mid-catch-up take one
+snapshot, then resume on the sorted-set journal.)
 TTLs use `USER_TTL_SECONDS` (1 year), refreshed on writes and — throttled
 daily — on reads, so any device check-in retains the user's cloud data.
 
@@ -358,13 +368,19 @@ After the write, the server publishes to Pusher on the existing
 
 ```jsonc
 // response (since is within journal retention)
-{ "ok": true, "seq": 1042, "ops": [ /* ops with seq > since, ordered */ ] }
+{ "ok": true, "seq": 1042, "ops": [ /* latest op per key with seq > since */ ] }
 
 // response (since too old / never synced)
 { "ok": true, "seq": 1042, "snapshotRequired": true }
 ```
 
-One `ZRANGEBYSCORE`. No metadata aggregation, no per-domain anything.
+One ranged read of the sorted set. No metadata aggregation, no per-domain
+anything. The returned ops are **coalesced per key**: only the newest op for
+each key in the `(since, seq]` window is sent, since LWW means a catching-up
+client only needs each key's latest value to converge (the journal's
+intermediate states are redundant — the KV state already compacts them). The
+cursor still advances to the server `seq`, so dropping superseded ops never
+desyncs the client.
 
 #### `GET /api/sync/v2/snapshot`
 
@@ -531,7 +547,7 @@ v1 — it is what v1 already converges to, expressed directly:
 
 | State | v1 mechanism | v2 equivalent |
 |---|---|---|
-| Settings | per-section `sectionUpdatedAt`, newer section wins | key per section, LWW |
+| Settings | per-section `sectionUpdatedAt`, newer section wins | key per field (`settings/<section>/<field>`), LWW |
 | Files metadata | per-path merge by timestamp | key per path, LWW |
 | Songs / videos / contacts / calendar / stickies / maps | client-side merge of snapshots by item timestamp + deletion markers | key per item, LWW |
 | Blob items | per-item signature comparison | key per item, LWW + content hash |

--- a/src/sync/codecs.ts
+++ b/src/sync/codecs.ts
@@ -184,198 +184,368 @@ function asRecord(value: unknown): Record<string, unknown> | null {
 
 // ---------------------------------------------------------------------------
 // Settings codec
+//
+// Each settings field is its own sync key (`settings/<section>/<field>`) so
+// concurrent edits to different fields of the same section merge under
+// per-key LWW instead of one section-level write clobbering the other.
+//
+// Legacy bundled section docs (`settings/<section>`, written by pre-per-field
+// clients and the v1 import) are still understood on apply: their fields are
+// fanned out to the per-field writers. A migrating client re-uploads the
+// fields as per-field keys and tombstones the now-redundant bundled key, so
+// the old shape self-retires.
 // ---------------------------------------------------------------------------
+
+interface SettingsField {
+  /** Field name; also the property key inside a legacy bundled section doc. */
+  field: string;
+  /** Current value from the store (always defined; absent → null). */
+  read(): unknown;
+  /**
+   * Apply a remote value onto the backing store. The return value is always
+   * discarded (callers `await` it), so it is typed loosely to accommodate the
+   * varied `setState`/setter return types across stores.
+   */
+  write(value: unknown): unknown;
+}
+
+interface SettingsSection {
+  section: string;
+  fields: SettingsField[];
+}
+
+const SETTINGS_KEY_PREFIX = "settings/";
+
+const SETTINGS_SCHEMA: SettingsSection[] = [
+  {
+    section: "theme",
+    fields: [
+      {
+        field: "current",
+        read: () => useThemeStore.getState().current,
+        write: (v) => {
+          if (typeof v === "string") useThemeStore.getState().setTheme(v as never);
+        },
+      },
+      {
+        field: "darkMode",
+        read: () => useThemeStore.getState().darkModeByTheme,
+        write: (v) => {
+          const map = asRecord(v);
+          if (!map) return;
+          for (const [themeId, value] of Object.entries(map)) {
+            useThemeStore.getState().setDarkMode(value as never, themeId as never);
+          }
+        },
+      },
+      {
+        field: "accent",
+        read: () => useThemeStore.getState().accentByTheme,
+        write: (v) => {
+          const map = asRecord(v);
+          if (!map) return;
+          for (const [themeId, value] of Object.entries(map)) {
+            useThemeStore.getState().setAccent(value as never, themeId as never);
+          }
+        },
+      },
+      {
+        field: "aquaMaterial",
+        read: () => useThemeStore.getState().aquaMaterial,
+        write: (v) => {
+          if (v === "classic" || v === "glass") {
+            useThemeStore.getState().setAquaMaterial(v);
+          }
+        },
+      },
+      {
+        field: "systemFont",
+        read: () => useThemeStore.getState().systemFont,
+        write: (v) => {
+          if (typeof v === "string" && v) {
+            useThemeStore.getState().setSystemFont(v as never);
+          }
+        },
+      },
+    ],
+  },
+  {
+    section: "language",
+    fields: [
+      {
+        field: "current",
+        read: () => useLanguageStore.getState().current,
+        write: async (v) => {
+          if (typeof v === "string") {
+            await useLanguageStore.getState().setLanguage(v as never);
+          }
+        },
+      },
+      {
+        field: "initialized",
+        read: () =>
+          typeof localStorage !== "undefined" &&
+          localStorage.getItem("ryos:language-initialized") === "true",
+        write: (v) => {
+          if (typeof localStorage !== "undefined") {
+            localStorage.setItem(
+              "ryos:language-initialized",
+              v === true ? "true" : "false"
+            );
+          }
+        },
+      },
+    ],
+  },
+  {
+    section: "display",
+    fields: [
+      {
+        field: "displayMode",
+        read: () => useDisplaySettingsStore.getState().displayMode,
+        write: (v) => useDisplaySettingsStore.setState({ displayMode: v as never }),
+      },
+      {
+        field: "shaderEffectEnabled",
+        read: () => useDisplaySettingsStore.getState().shaderEffectEnabled,
+        write: (v) =>
+          useDisplaySettingsStore.setState({ shaderEffectEnabled: Boolean(v) }),
+      },
+      {
+        field: "selectedShaderType",
+        read: () => useDisplaySettingsStore.getState().selectedShaderType,
+        write: (v) =>
+          useDisplaySettingsStore.setState({ selectedShaderType: v as never }),
+      },
+      {
+        field: "currentWallpaper",
+        read: () => useDisplaySettingsStore.getState().currentWallpaper,
+        write: async (v) => {
+          if (typeof v === "string" && v) {
+            await useDisplaySettingsStore.getState().setWallpaper(v);
+          }
+        },
+      },
+      {
+        field: "screenSaverEnabled",
+        read: () => useDisplaySettingsStore.getState().screenSaverEnabled,
+        write: (v) =>
+          useDisplaySettingsStore.setState({ screenSaverEnabled: Boolean(v) }),
+      },
+      {
+        field: "screenSaverType",
+        read: () => useDisplaySettingsStore.getState().screenSaverType,
+        write: (v) =>
+          useDisplaySettingsStore.setState({ screenSaverType: v as never }),
+      },
+      {
+        field: "screenSaverIdleTime",
+        read: () => useDisplaySettingsStore.getState().screenSaverIdleTime,
+        write: (v) =>
+          useDisplaySettingsStore.setState({ screenSaverIdleTime: v as never }),
+      },
+      {
+        field: "debugMode",
+        read: () => useDisplaySettingsStore.getState().debugMode,
+        write: (v) => useDisplaySettingsStore.setState({ debugMode: Boolean(v) }),
+      },
+      {
+        field: "htmlPreviewSplit",
+        read: () => useDisplaySettingsStore.getState().htmlPreviewSplit,
+        write: (v) =>
+          useDisplaySettingsStore.setState({ htmlPreviewSplit: Boolean(v) }),
+      },
+    ],
+  },
+  {
+    section: "audio",
+    fields: [
+      ...(
+        [
+          "masterVolume",
+          "uiVolume",
+          "chatSynthVolume",
+          "speechVolume",
+          "ipodVolume",
+          "ttsModel",
+          "ttsVoice",
+          "synthPreset",
+        ] as const
+      ).map((field) => ({
+        field,
+        read: () => useAudioSettingsStore.getState()[field],
+        write: (v: unknown) =>
+          useAudioSettingsStore.setState({ [field]: v } as never),
+      })),
+      ...(
+        [
+          "uiSoundsEnabled",
+          "terminalSoundsEnabled",
+          "typingSynthEnabled",
+          "speechEnabled",
+          "keepTalkingEnabled",
+        ] as const
+      ).map((field) => ({
+        field,
+        read: () => useAudioSettingsStore.getState()[field],
+        write: (v: unknown) =>
+          useAudioSettingsStore.setState({ [field]: Boolean(v) } as never),
+      })),
+    ],
+  },
+  {
+    section: "ai",
+    fields: [
+      {
+        field: "model",
+        read: () => useAppStore.getState().aiModel ?? null,
+        write: (v) => useAppStore.getState().setAiModel(v as never),
+      },
+    ],
+  },
+  {
+    section: "ipod",
+    fields: [
+      {
+        field: "displayMode",
+        read: () => useIpodStore.getState().displayMode,
+        write: (v) => useIpodStore.setState({ displayMode: v as never }),
+      },
+      {
+        field: "showLyrics",
+        read: () => useIpodStore.getState().showLyrics,
+        write: (v) => useIpodStore.setState({ showLyrics: Boolean(v) }),
+      },
+      {
+        field: "lyricsAlignment",
+        read: () => useIpodStore.getState().lyricsAlignment,
+        write: (v) => useIpodStore.setState({ lyricsAlignment: v as never }),
+      },
+      {
+        field: "lyricsFont",
+        read: () => useIpodStore.getState().lyricsFont,
+        write: (v) => useIpodStore.setState({ lyricsFont: v as never }),
+      },
+      {
+        field: "romanization",
+        read: () => useIpodStore.getState().romanization,
+        write: (v) => useIpodStore.setState({ romanization: v as never }),
+      },
+      {
+        field: "lyricsTranslationLanguage",
+        read: () => useIpodStore.getState().lyricsTranslationLanguage ?? null,
+        write: (v) =>
+          useIpodStore.setState({
+            lyricsTranslationLanguage: (v ?? null) as never,
+          }),
+      },
+      {
+        field: "theme",
+        read: () => useIpodStore.getState().theme,
+        write: (v) => useIpodStore.setState({ theme: v as never }),
+      },
+      {
+        field: "lcdFilterOn",
+        read: () => useIpodStore.getState().lcdFilterOn,
+        write: (v) => useIpodStore.setState({ lcdFilterOn: Boolean(v) }),
+      },
+    ],
+  },
+  {
+    section: "dock",
+    fields: (["pinnedItems", "scale", "hiding", "magnification"] as const).map(
+      (field) => ({
+        field,
+        read: () => useDockStore.getState()[field],
+        write: (v: unknown) => useDockStore.setState({ [field]: v } as never),
+      })
+    ),
+  },
+  {
+    section: "dashboard",
+    fields: [
+      {
+        field: "widgets",
+        read: () => useDashboardStore.getState().widgets,
+        write: (v) => {
+          if (Array.isArray(v)) useDashboardStore.setState({ widgets: v as never });
+        },
+      },
+    ],
+  },
+];
+
+const SETTINGS_SECTIONS_BY_NAME = new Map(
+  SETTINGS_SCHEMA.map((section) => [
+    section.section,
+    {
+      section,
+      fieldsByName: new Map(section.fields.map((f) => [f.field, f])),
+    },
+  ])
+);
+
+function settingsFieldKey(section: string, field: string): string {
+  return `${SETTINGS_KEY_PREFIX}${section}/${field}`;
+}
+
+function parseSettingsKey(
+  key: string
+): { section: string; field?: string } | null {
+  if (!key.startsWith(SETTINGS_KEY_PREFIX)) return null;
+  const rest = key.slice(SETTINGS_KEY_PREFIX.length);
+  if (!rest) return null;
+  const slash = rest.indexOf("/");
+  if (slash === -1) return { section: rest }; // legacy bundled section doc
+  return { section: rest.slice(0, slash), field: rest.slice(slash + 1) };
+}
 
 function collectSettings(): Map<string, unknown> {
   const docs = new Map<string, unknown>();
-  const themeState = useThemeStore.getState();
-  const displayState = useDisplaySettingsStore.getState();
-  const audioState = useAudioSettingsStore.getState();
-  const ipodState = useIpodStore.getState();
-  const dockState = useDockStore.getState();
-  const dashboardState = useDashboardStore.getState();
-
-  docs.set("settings/theme", {
-    current: themeState.current,
-    darkMode: themeState.darkModeByTheme,
-    accent: themeState.accentByTheme,
-    aquaMaterial: themeState.aquaMaterial,
-    systemFont: themeState.systemFont,
-  });
-  docs.set("settings/language", {
-    current: useLanguageStore.getState().current,
-    initialized:
-      typeof localStorage !== "undefined" &&
-      localStorage.getItem("ryos:language-initialized") === "true",
-  });
-  docs.set("settings/display", {
-    displayMode: displayState.displayMode,
-    shaderEffectEnabled: displayState.shaderEffectEnabled,
-    selectedShaderType: displayState.selectedShaderType,
-    currentWallpaper: displayState.currentWallpaper,
-    screenSaverEnabled: displayState.screenSaverEnabled,
-    screenSaverType: displayState.screenSaverType,
-    screenSaverIdleTime: displayState.screenSaverIdleTime,
-    debugMode: displayState.debugMode,
-    htmlPreviewSplit: displayState.htmlPreviewSplit,
-  });
-  docs.set("settings/audio", {
-    masterVolume: audioState.masterVolume,
-    uiVolume: audioState.uiVolume,
-    chatSynthVolume: audioState.chatSynthVolume,
-    speechVolume: audioState.speechVolume,
-    ipodVolume: audioState.ipodVolume,
-    uiSoundsEnabled: audioState.uiSoundsEnabled,
-    terminalSoundsEnabled: audioState.terminalSoundsEnabled,
-    typingSynthEnabled: audioState.typingSynthEnabled,
-    speechEnabled: audioState.speechEnabled,
-    keepTalkingEnabled: audioState.keepTalkingEnabled,
-    ttsModel: audioState.ttsModel,
-    ttsVoice: audioState.ttsVoice,
-    synthPreset: audioState.synthPreset,
-  });
-  docs.set("settings/ai", { model: useAppStore.getState().aiModel ?? null });
-  docs.set("settings/ipod", {
-    displayMode: ipodState.displayMode,
-    showLyrics: ipodState.showLyrics,
-    lyricsAlignment: ipodState.lyricsAlignment,
-    lyricsFont: ipodState.lyricsFont,
-    romanization: ipodState.romanization,
-    lyricsTranslationLanguage: ipodState.lyricsTranslationLanguage ?? null,
-    theme: ipodState.theme,
-    lcdFilterOn: ipodState.lcdFilterOn,
-  });
-  docs.set("settings/dock", {
-    pinnedItems: dockState.pinnedItems,
-    scale: dockState.scale,
-    hiding: dockState.hiding,
-    magnification: dockState.magnification,
-  });
-  docs.set("settings/dashboard", {
-    widgets: dashboardState.widgets,
-  });
+  for (const section of SETTINGS_SCHEMA) {
+    for (const f of section.fields) {
+      docs.set(settingsFieldKey(section.section, f.field), f.read());
+    }
+  }
   return docs;
 }
 
 async function applySettingsOp(op: AppliedSyncOp): Promise<void> {
-  if (op.del) return; // settings sections are never deleted
-  const doc = asRecord(op.v);
-  if (!doc) return;
+  const parsed = parseSettingsKey(op.k);
+  if (!parsed) return;
+  const entry = SETTINGS_SECTIONS_BY_NAME.get(parsed.section);
+  if (!entry) return;
 
-  switch (op.k) {
-    case "settings/theme": {
-      const themeStore = useThemeStore.getState();
-      if (typeof doc.current === "string") {
-        themeStore.setTheme(doc.current as never);
+  if (parsed.field === undefined) {
+    // Legacy bundled section doc: fan its fields out to the per-field writers.
+    // A bundled tombstone is ignored — the data now lives in per-field keys.
+    if (op.del) return;
+    const doc = asRecord(op.v);
+    if (!doc) return;
+    for (const f of entry.section.fields) {
+      if (f.field in doc && doc[f.field] !== undefined) {
+        await f.write(doc[f.field]);
       }
-      const darkMap = asRecord(doc.darkMode);
-      if (darkMap) {
-        for (const [themeId, value] of Object.entries(darkMap)) {
-          useThemeStore.getState().setDarkMode(value as never, themeId as never);
-        }
-      }
-      const accentMap = asRecord(doc.accent);
-      if (accentMap) {
-        for (const [themeId, value] of Object.entries(accentMap)) {
-          useThemeStore.getState().setAccent(value as never, themeId as never);
-        }
-      }
-      if (doc.aquaMaterial === "classic" || doc.aquaMaterial === "glass") {
-        useThemeStore.getState().setAquaMaterial(doc.aquaMaterial);
-      }
-      if (typeof doc.systemFont === "string" && doc.systemFont) {
-        useThemeStore.getState().setSystemFont(doc.systemFont as never);
-      }
-      return;
     }
-    case "settings/language": {
-      if (typeof doc.current === "string") {
-        if (typeof localStorage !== "undefined") {
-          localStorage.setItem(
-            "ryos:language-initialized",
-            doc.initialized === true ? "true" : "false"
-          );
-        }
-        await useLanguageStore.getState().setLanguage(doc.current as never);
-      }
-      return;
-    }
-    case "settings/display": {
-      useDisplaySettingsStore.setState({
-        displayMode: doc.displayMode as never,
-        shaderEffectEnabled: Boolean(doc.shaderEffectEnabled),
-        selectedShaderType: doc.selectedShaderType as never,
-        screenSaverEnabled: Boolean(doc.screenSaverEnabled),
-        screenSaverType: doc.screenSaverType as never,
-        screenSaverIdleTime: doc.screenSaverIdleTime as never,
-        debugMode: Boolean(doc.debugMode),
-        htmlPreviewSplit: Boolean(doc.htmlPreviewSplit),
-      });
-      if (typeof doc.currentWallpaper === "string" && doc.currentWallpaper) {
-        await useDisplaySettingsStore
-          .getState()
-          .setWallpaper(doc.currentWallpaper);
-      }
-      return;
-    }
-    case "settings/audio": {
-      useAudioSettingsStore.setState({
-        masterVolume: doc.masterVolume as never,
-        uiVolume: doc.uiVolume as never,
-        chatSynthVolume: doc.chatSynthVolume as never,
-        speechVolume: doc.speechVolume as never,
-        ipodVolume: doc.ipodVolume as never,
-        uiSoundsEnabled: Boolean(doc.uiSoundsEnabled),
-        terminalSoundsEnabled: Boolean(doc.terminalSoundsEnabled),
-        typingSynthEnabled: Boolean(doc.typingSynthEnabled),
-        speechEnabled: Boolean(doc.speechEnabled),
-        keepTalkingEnabled: Boolean(doc.keepTalkingEnabled),
-        ttsModel: doc.ttsModel as never,
-        ttsVoice: doc.ttsVoice as never,
-        synthPreset: doc.synthPreset as never,
-      });
-      return;
-    }
-    case "settings/ai": {
-      useAppStore.getState().setAiModel(doc.model as never);
-      return;
-    }
-    case "settings/ipod": {
-      useIpodStore.setState({
-        displayMode: doc.displayMode as never,
-        showLyrics: Boolean(doc.showLyrics),
-        lyricsAlignment: doc.lyricsAlignment as never,
-        lyricsFont: doc.lyricsFont as never,
-        romanization: doc.romanization as never,
-        lyricsTranslationLanguage: (doc.lyricsTranslationLanguage ?? null) as never,
-        theme: doc.theme as never,
-        lcdFilterOn: Boolean(doc.lcdFilterOn),
-      });
-      return;
-    }
-    case "settings/dock": {
-      useDockStore.setState({
-        pinnedItems: doc.pinnedItems as never,
-        scale: doc.scale as never,
-        hiding: doc.hiding as never,
-        magnification: doc.magnification as never,
-      });
-      return;
-    }
-    case "settings/dashboard": {
-      if (Array.isArray(doc.widgets)) {
-        useDashboardStore.setState({ widgets: doc.widgets as never });
-      }
-      return;
-    }
+    return;
   }
+
+  if (op.del) return; // settings fields are never deleted
+  const field = entry.fieldsByName.get(parsed.field);
+  if (!field) return;
+  await field.write(op.v);
 }
 
 const settingsCodec: SyncCodec = {
   namespace: "settings",
   collect: collectSettings,
   async apply(ops) {
-    for (const op of ops) {
+    // Apply oldest-first so a legacy bundled doc and a newer per-field op in
+    // the same batch converge to the newer value regardless of input order.
+    const sorted = [...ops].sort((a, b) =>
+      a.t < b.t ? -1 : a.t > b.t ? 1 : 0
+    );
+    for (const op of sorted) {
       try {
         await applySettingsOp(op);
       } catch (error) {

--- a/tests/fake-redis.ts
+++ b/tests/fake-redis.ts
@@ -60,6 +60,8 @@ export class FakeRedis {
   readonly sets = new Map<string, Set<string>>();
   readonly hashes = new Map<string, Map<string, string>>();
   readonly lists = new Map<string, string[]>();
+  /** Sorted sets: key → (member → score). */
+  readonly zsets = new Map<string, Map<string, number>>();
   /** Recorded TTLs (seconds); FakeRedis never actually expires keys. */
   readonly ttls = new Map<string, number>();
 
@@ -70,6 +72,7 @@ export class FakeRedis {
         ...this.sets.keys(),
         ...this.hashes.keys(),
         ...this.lists.keys(),
+        ...this.zsets.keys(),
       ]),
     ];
   }
@@ -79,7 +82,8 @@ export class FakeRedis {
       this.kv.has(key) ||
       this.sets.has(key) ||
       this.hashes.has(key) ||
-      this.lists.has(key)
+      this.lists.has(key) ||
+      this.zsets.has(key)
     );
   }
 
@@ -105,6 +109,7 @@ export class FakeRedis {
       if (this.sets.delete(key)) deleted += 1;
       if (this.hashes.delete(key)) deleted += 1;
       if (this.lists.delete(key)) deleted += 1;
+      if (this.zsets.delete(key)) deleted += 1;
       this.ttls.delete(key);
     }
     return deleted;
@@ -200,6 +205,7 @@ export class FakeRedis {
     if (this.sets.has(key)) return "set";
     if (this.hashes.has(key)) return "hash";
     if (this.lists.has(key)) return "list";
+    if (this.zsets.has(key)) return "zset";
     return "none";
   }
 
@@ -317,6 +323,67 @@ export class FakeRedis {
 
   async llen(key: string): Promise<number> {
     return (this.lists.get(key) || []).length;
+  }
+
+  // --- sorted sets ----------------------------------------------------------
+
+  /** Members ordered by score ascending, ties broken lexicographically. */
+  private zsorted(key: string): string[] {
+    const zset = this.zsets.get(key);
+    if (!zset) return [];
+    return [...zset.entries()]
+      .sort((a, b) => (a[1] - b[1]) || (a[0] < b[0] ? -1 : a[0] > b[0] ? 1 : 0))
+      .map(([member]) => member);
+  }
+
+  async zadd(
+    key: string,
+    entry: { score: number; member: string }
+  ): Promise<number> {
+    const zset = this.zsets.get(key) || new Map<string, number>();
+    const isNew = !zset.has(entry.member);
+    zset.set(entry.member, entry.score);
+    this.zsets.set(key, zset);
+    return isNew ? 1 : 0;
+  }
+
+  async zrem(key: string, member: string): Promise<number> {
+    const zset = this.zsets.get(key);
+    if (!zset) return 0;
+    const removed = zset.delete(member) ? 1 : 0;
+    if (zset.size === 0) this.zsets.delete(key);
+    return removed;
+  }
+
+  async zcard(key: string): Promise<number> {
+    return this.zsets.get(key)?.size ?? 0;
+  }
+
+  async zrange(key: string, start: number, stop: number): Promise<string[]> {
+    const ordered = this.zsorted(key);
+    const normalizedStart = start < 0 ? Math.max(0, ordered.length + start) : start;
+    const normalizedStop = stop < 0 ? ordered.length + stop : stop;
+    return ordered.slice(normalizedStart, normalizedStop + 1);
+  }
+
+  async zremrangebyscore(
+    key: string,
+    min: number | string,
+    max: number | string
+  ): Promise<number> {
+    const zset = this.zsets.get(key);
+    if (!zset) return 0;
+    const lo = min === "-inf" ? -Infinity : Number(min);
+    const hi = max === "+inf" ? Infinity : Number(max);
+    let removed = 0;
+    for (const [member, score] of [...zset.entries()]) {
+      if (score >= lo && score <= hi) {
+        zset.delete(member);
+        removed += 1;
+      }
+    }
+    if (zset.size === 0) this.zsets.delete(key);
+    return removed;
   }
 
   pipeline(): FakeRedisPipeline {

--- a/tests/test-sync-v2-codecs.test.ts
+++ b/tests/test-sync-v2-codecs.test.ts
@@ -7,6 +7,7 @@ import { useVideoStore } from "../src/stores/useVideoStore";
 import { useTvStore } from "../src/stores/useTvStore";
 import { useIpodStore } from "../src/stores/useIpodStore";
 import { useMapsStore } from "../src/stores/useMapsStore";
+import { useAudioSettingsStore } from "../src/stores/useAudioSettingsStore";
 import {
   mergePersistedCloudSyncCategoryStatus,
   useCloudSyncStore,
@@ -213,6 +214,67 @@ describe("maps codec", () => {
     const state = useMapsStore.getState();
     expect(state.home).toMatchObject({ name: "Home" });
     expect(state.favorites.map((favorite) => favorite.id)).toEqual(["f1"]);
+  });
+});
+
+describe("settings codec", () => {
+  test("collect emits one key per settings field (no bundled sections)", () => {
+    const docs = SYNC_CODECS.settings.collect(ctx) as Map<string, unknown>;
+    const keys = [...docs.keys()];
+    expect(keys).toContain("settings/audio/masterVolume");
+    expect(keys).toContain("settings/theme/current");
+    expect(keys).toContain("settings/dashboard/widgets");
+    expect(
+      keys.some((k) => k === "settings/audio" || k === "settings/theme")
+    ).toBe(false);
+  });
+
+  test("apply writes a per-field op onto the store", async () => {
+    useAudioSettingsStore.setState({ masterVolume: 1 } as never);
+    await SYNC_CODECS.settings.apply(
+      [{ k: "settings/audio/masterVolume", v: 0.25, t }],
+      ctx
+    );
+    expect(useAudioSettingsStore.getState().masterVolume).toBe(0.25);
+  });
+
+  test("apply fans a legacy bundled section doc out to its fields", async () => {
+    useAudioSettingsStore.setState({ masterVolume: 1, uiVolume: 1 } as never);
+    await SYNC_CODECS.settings.apply(
+      [{ k: "settings/audio", v: { masterVolume: 0.5, uiVolume: 0.1 }, t }],
+      ctx
+    );
+    const state = useAudioSettingsStore.getState();
+    expect(state.masterVolume).toBe(0.5);
+    expect(state.uiVolume).toBe(0.1);
+  });
+
+  test("a newer per-field op wins over an older bundled doc in one batch", async () => {
+    useAudioSettingsStore.setState({ masterVolume: 1 } as never);
+    const older = "01718180000000-0000-test";
+    const newer = "01718190000000-0000-test";
+    await SYNC_CODECS.settings.apply(
+      [
+        { k: "settings/audio/masterVolume", v: 0.9, t: newer },
+        { k: "settings/audio", v: { masterVolume: 0.1 }, t: older },
+      ],
+      ctx
+    );
+    expect(useAudioSettingsStore.getState().masterVolume).toBe(0.9);
+  });
+
+  test("concurrent edits to different fields both survive", async () => {
+    useAudioSettingsStore.setState({ masterVolume: 1, uiVolume: 1 } as never);
+    await SYNC_CODECS.settings.apply(
+      [
+        { k: "settings/audio/masterVolume", v: 0.3, t },
+        { k: "settings/audio/uiVolume", v: 0.7, t },
+      ],
+      ctx
+    );
+    const state = useAudioSettingsStore.getState();
+    expect(state.masterVolume).toBe(0.3);
+    expect(state.uiVolume).toBe(0.7);
   });
 });
 

--- a/tests/test-sync-v2-core.test.ts
+++ b/tests/test-sync-v2-core.test.ts
@@ -228,10 +228,77 @@ describe("sync v2 changes feed", () => {
       [{ k: "settings/theme", v: { current: "macosx" }, t: t(0) }],
       "client-a"
     );
-    // Simulate journal trimming by clearing the log list.
-    (r as unknown as FakeRedis).lists.clear();
+    // Simulate journal trimming by clearing the sorted-set journal.
+    (r as unknown as FakeRedis).zsets.clear();
     const result = await readSyncChanges(r, "user1", 0);
     expect(result.snapshotRequired).toBe(true);
+  });
+
+  test("coalesces repeated writes to the same key to the latest op", async () => {
+    const r = redis();
+    // Three writes to one key + one write to another, ascending seq.
+    await applySyncOps(
+      r,
+      "user1",
+      [{ k: "settings/theme/current", v: { value: "system7" }, t: t(0) }],
+      "client-a"
+    );
+    await applySyncOps(
+      r,
+      "user1",
+      [{ k: "settings/theme/current", v: { value: "macosx" }, t: t(1000) }],
+      "client-a"
+    );
+    await applySyncOps(
+      r,
+      "user1",
+      [{ k: "settings/theme/current", v: { value: "win98" }, t: t(2000) }],
+      "client-a"
+    );
+    await applySyncOps(
+      r,
+      "user1",
+      [{ k: "settings/audio/masterVolume", v: 1, t: t(3000) }],
+      "client-a"
+    );
+
+    const changes = await readSyncChanges(r, "user1", 0);
+    // Four accepted ops, but catch-up collapses the theme key to its latest.
+    expect(changes.seq).toBe(4);
+    expect(changes.ops).toHaveLength(2);
+    const theme = changes.ops?.find((op) => op.k === "settings/theme/current");
+    expect(theme?.v).toEqual({ value: "win98" });
+    expect(theme?.seq).toBe(3);
+    // Ops remain ordered ascending by seq after coalescing.
+    expect(changes.ops?.map((op) => op.seq)).toEqual([3, 4]);
+  });
+
+  test("coalescing from a mid-journal cursor keeps only newer per-key ops", async () => {
+    const r = redis();
+    await applySyncOps(
+      r,
+      "user1",
+      [{ k: "settings/theme/current", v: { value: "a" }, t: t(0) }],
+      "client-a"
+    );
+    const afterFirst = (await readSyncChanges(r, "user1", 0)).seq; // 1
+    await applySyncOps(
+      r,
+      "user1",
+      [{ k: "settings/theme/current", v: { value: "b" }, t: t(1000) }],
+      "client-a"
+    );
+    await applySyncOps(
+      r,
+      "user1",
+      [{ k: "settings/theme/current", v: { value: "c" }, t: t(2000) }],
+      "client-a"
+    );
+
+    const changes = await readSyncChanges(r, "user1", afterFirst);
+    expect(changes.seq).toBe(3);
+    expect(changes.ops).toHaveLength(1);
+    expect(changes.ops?.[0].v).toEqual({ value: "c" });
   });
 });
 
@@ -357,11 +424,11 @@ describe("sync v2 v1-import", () => {
 
     // Simulate TTLs decaying (e.g. an idle device only ever reads).
     fake.ttls.delete("sync2:kv:user1");
-    fake.ttls.delete("sync2:log:user1");
+    fake.ttls.delete("sync2:jrnl:user1");
 
     await readSyncChanges(r, "user1", 0);
     expect(fake.ttls.get("sync2:kv:user1")).toBeGreaterThan(0);
-    expect(fake.ttls.get("sync2:log:user1")).toBeGreaterThan(0);
+    expect(fake.ttls.get("sync2:jrnl:user1")).toBeGreaterThan(0);
 
     // Throttle marker prevents refreshing again within the same day.
     fake.ttls.delete("sync2:kv:user1");


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Follow-up to a discussion on why Cloud Sync v2 "replays history" of settings during catch-up. This implements the three improvements identified:

1. **Coalesce `/changes` per key** — stop replaying a key's intermediate states.
2. **Per-field settings keys** — fix section-level clobbering of concurrent edits.
3. **Sorted-set journal** — match the original design spec and drop the list-tail heuristic.

## What changed

### 1. `/changes` coalesces per key (`api/sync/v2/_core.ts`)
`readSyncChanges` now returns only the newest op per key in the `(since, seq]` window. Under per-key LWW a catching-up client only needs each key's latest value to converge, so the journal's intermediate states were wasted bandwidth (the KV state already compacts them). The cursor still advances to the server `seq`, so dropping superseded ops never desyncs the client.

### 2. Per-field settings keys (`src/sync/codecs.ts`)
Settings now sync as `settings/<section>/<field>` (one key per field) instead of one bundled doc per section. Two devices editing different fields of the same section now merge under per-key LWW instead of the later whole-section write clobbering the other. A declarative field schema drives both `collect` and `apply`.

**Migration:** legacy bundled `settings/<section>` docs (pre-per-field clients and the v1 import) are still understood on apply — their fields fan out to the per-field writers, applied oldest-first by HLC so a newer per-field op wins over an older bundled doc in the same batch. A migrating client re-uploads the fields as per-field keys and tombstones the redundant bundled key, so the old shape self-retires. No server-side data migration required.

### 3. Sorted-set journal (`api/sync/v2/_core.ts`)
The journal moves from a Redis LIST (`sync2:log`) to a sorted set keyed by `seq` (`sync2:jrnl`). Catch-up reads an exact range by rank and trimming drops the lowest scores via `ZREMRANGEBYSCORE` — no list-tail fetch heuristic. Pre-v2.1 LIST keys are abandoned on upgrade and expire via their TTL; clients mid-catch-up take one snapshot, then resume on the sorted set.

Also: `FakeRedis` gains `zadd`/`zrem`/`zcard`/`zrange`/`zremrangebyscore`; docs updated.

## Testing
All sync v2 suites pass (unit + API integration + client engine e2e against a live `bun run dev:api`).

- ✅ `bun test tests/test-sync-v2-core.test.ts tests/test-sync-v2-codecs.test.ts tests/test-sync-maintenance.test.ts tests/test-songs-tombstone-sync.test.ts tests/test-sync-v2-api.test.ts tests/test-sync-v2-engine-e2e.test.ts` — 65 pass / 0 fail
- ✅ `bunx tsc -b` — clean
- ✅ `bunx eslint` on changed files — clean

New coverage: per-key coalescing (full-journal + mid-cursor), per-field settings round-trip, legacy bundled fan-out, and oldest-first apply ordering.

> Note: the e2e run logs two caught errors (`settings/language/current`, `settings/display/currentWallpaper`) — these are pre-existing bun-environment quirks (no `window`/`locale`), caught per-field, and the writers succeed in the browser. Tests pass.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ec3e6-e230-7b70-aa53-cb37ba7eb5dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ec3e6-e230-7b70-aa53-cb37ba7eb5dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

