### PR TITLE
Lower Aqua glass dock raise and tighten PiP/toast/window clearances

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -76,14 +76,16 @@ export function App() {
 
   // Determine toast position and offset based on theme and device
   const toastConfig = useMemo(() => {
-    // The Aqua glass dock sits ~20px higher than the classic dock (12px lift +
-    // 8px taller bar), so add extra clearance to keep the same gap above it.
-    const dockHeight = isMacOSTheme ? (isAquaGlass ? 76 : 56) : 0;
+    // The Aqua glass dock sits a bit higher than the classic dock (6px lift +
+    // 8px taller bar = 70px tall), so add a little extra clearance to clear it.
+    const dockHeight = isMacOSTheme ? (isAquaGlass ? 70 : 56) : 0;
     const taskbarHeight = isWindowsTheme ? 30 : 0;
 
     // Mobile: always show at bottom-center with dock/taskbar and safe area clearance
     if (isMobile) {
-      const bottomOffset = dockHeight + taskbarHeight + 16;
+      // Tighten the gap above the (taller) glass dock so toasts don't float too high.
+      const gap = isAquaGlass ? 12 : 16;
+      const bottomOffset = dockHeight + taskbarHeight + gap;
       return {
         position: "bottom-center" as const,
         offset: `calc(env(safe-area-inset-bottom, 0px) + ${bottomOffset}px)`,

--- a/src/apps/ipod/components/PipPlayer.tsx
+++ b/src/apps/ipod/components/PipPlayer.tsx
@@ -28,9 +28,9 @@ export function PipPlayer({
   const isPhone = useIsPhone();
 
   // Calculate bottom offset based on theme (similar to Sonner positioning).
-  // The Aqua glass dock sits ~20px higher than the classic dock (12px lift +
-  // 8px taller bar), so add extra clearance to keep the same gap above it.
-  const macOSBottom = isAquaGlass ? "92px" : "72px";
+  // The Aqua glass dock sits a bit higher than the classic dock (6px lift +
+  // 8px taller bar), so add a little extra clearance to clear it.
+  const macOSBottom = isAquaGlass ? "82px" : "72px";
   const bottomOffset = isWinFamily
     ? "calc(env(safe-area-inset-bottom, 0px) + 42px)"
     : isMacOSX

--- a/src/hooks/useWindowInsets.ts
+++ b/src/hooks/useWindowInsets.ts
@@ -66,11 +66,11 @@ export function useWindowInsets() {
         : 0;
 
     // The Aqua glass dock is taller than the classic dock (8px vertical padding
-    // per side vs 4px, see MacDock.tsx) and is lifted 12px off the screen edge
+    // per side vs 4px, see MacDock.tsx) and is lifted 6px off the screen edge
     // (margin-bottom in aqua-glass.css). Reserve that extra space so maximized
     // / resized windows don't overlap the glass dock.
     if (dockHeight > 0 && isAquaGlass) {
-      const GLASS_DOCK_LIFT = 12;
+      const GLASS_DOCK_LIFT = 6;
       const glassExtraBarHeight =
         (Math.round(8 * dockScale) - Math.round(4 * dockScale)) * 2;
       dockHeight += glassExtraBarHeight + GLASS_DOCK_LIFT;

--- a/src/index.css
+++ b/src/index.css
@@ -1961,9 +1961,9 @@ button.piano-key.piano-key[class*="bg-[#ff33ff]"] {
     bottom: calc(env(safe-area-inset-bottom, 0px) + 72px) !important;
   }
 
-  /* macOS X Aqua glass: dock sits ~20px higher (12px lift + 8px taller bar) */
+  /* macOS X Aqua glass: dock sits a bit higher (6px lift + 8px taller bar) */
   :root[data-os-theme="macosx"][data-os-aqua-material="glass"] [data-sonner-toaster][data-y-position="bottom"] {
-    bottom: calc(env(safe-area-inset-bottom, 0px) + 92px) !important;
+    bottom: calc(env(safe-area-inset-bottom, 0px) + 82px) !important;
   }
   
   /* Windows XP theme: add taskbar height (30px) */

--- a/src/styles/themes/aqua-glass.css
+++ b/src/styles/themes/aqua-glass.css
@@ -524,8 +524,8 @@
   backdrop-filter: blur(26px) saturate(185%);
   border-radius: var(--os-glass-r-dock) !important;
   border: var(--os-metrics-border-width) solid var(--os-color-window-border) !important;
-  /* Lift the glass pill off the screen edge — classic dock sits flush. */
-  margin-bottom: 12px;
+  /* Lift the glass pill slightly off the screen edge — classic dock sits flush. */
+  margin-bottom: 6px;
   box-shadow: var(--os-color-dock-shadow),
     inset 0 1px 0 rgba(255, 255, 255, 0.4) !important;
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up to #1496 and #1498. The Aqua **glass** dock was raised too much — it floated too high and the gaps under maximized windows and around the iPod PiP / Sonner toast were too big.

This lowers the dock so it's only slightly raised and tightens the clearances to match:
- **Lowers the glass dock**: `margin-bottom` `12px` → `6px` in `aqua-glass.css` (still raised, just less).
- **Tightens PiP / toast**: bottom offset `92px` → `82px`.
- **Tightens maximized/resized windows**: glass dock lift reserved in `useWindowInsets` `12px` → `6px`.

Geometry (scale 1): glass dock bar is `64px` (vs `56px` classic) + `6px` lift = `70px` tall. PiP/toast sit at `82px`; maximized windows reserve `70px` at the bottom.

Classic Aqua and all other themes are unchanged.

## Changes

- `src/styles/themes/aqua-glass.css`: glass dock `margin-bottom` `12px` → `6px`.
- `src/apps/ipod/components/PipPlayer.tsx`: glass PiP bottom offset `92px` → `82px`.
- `src/App.tsx`: glass toast mobile `dockHeight` `76` → `70` and gap `16` → `12` (→ `82px`).
- `src/index.css`: glass mobile bottom toast `92px` → `82px`.
- `src/hooks/useWindowInsets.ts`: glass dock lift `12px` → `6px`.

## Testing

- `bunx tsc -b` passes.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ec3cf-b59d-79d8-9907-0ca0a72cc978"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ec3cf-b59d-79d8-9907-0ca0a72cc978"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

