### PR TITLE
feat(wallpaper): dynamic wallpaper options (day/night gradient, now-playing cover, shuffle)

### DIFF
--- a/src/apps/control-panels/components/WallpaperPicker.tsx
+++ b/src/apps/control-panels/components/WallpaperPicker.tsx
@@ -28,6 +28,7 @@ import {
   getDayNightGradientCss,
   isCoverWallpaper,
   isDayNightGradientWallpaper,
+  isShuffleWallpaper,
   parseShuffleDescriptor,
 } from "@/utils/dynamicWallpaper";
 import { useTranslation } from "react-i18next";
@@ -165,10 +166,18 @@ interface SpecialTileProps {
   isSelected: boolean;
   onClick: () => void;
   isTile?: boolean;
-  /** Inline style for the tile background (gradient / cover preview). */
+  /** Inline style for the tile background (gradient / cover / random art). */
   backgroundStyle?: React.CSSProperties;
+  /** Optional muted looping video rendered as the tile background. */
+  backgroundVideoUrl?: string;
   /** Optional icon element rendered centered in the tile. */
   icon?: React.ReactNode;
+  /**
+   * Render a plain dark scrim (no blur) under the icon + label. Used for tiles
+   * whose preview can be an arbitrary bright/busy photo (the Shuffle tiles) so
+   * the glassy glyphs always stay legible.
+   */
+  scrim?: boolean;
 }
 
 /** Tile used for dynamic & shuffle wallpaper options (carries a text label). */
@@ -178,7 +187,9 @@ function SpecialTile({
   onClick,
   isTile = false,
   backgroundStyle,
+  backgroundVideoUrl,
   icon,
+  scrim = false,
 }: SpecialTileProps) {
   const { play: playClick } = useSound(Sounds.BUTTON_CLICK, 0.3);
   const handleClick = () => {
@@ -206,12 +217,62 @@ function SpecialTile({
         }
       }}
     >
-      {icon}
+      {backgroundVideoUrl && (
+        <video
+          className="absolute inset-0 size-full object-cover"
+          src={backgroundVideoUrl}
+          autoPlay
+          loop
+          muted
+          playsInline
+        />
+      )}
+      {scrim && (
+        <>
+          {/* Flat dark wash so the centered icon stays readable over any art. */}
+          <span
+            aria-hidden
+            className="pointer-events-none absolute inset-0 bg-black/30"
+          />
+          {/* Stronger bottom-up gradient anchoring the label. No blur. */}
+          <span
+            aria-hidden
+            className="pointer-events-none absolute inset-x-0 bottom-0 h-2/3"
+            style={{
+              background:
+                "linear-gradient(to top, rgba(0,0,0,0.6), transparent)",
+            }}
+          />
+        </>
+      )}
+      {icon && (
+        <span
+          className="relative flex items-center justify-center"
+          style={{
+            // Glassy/knockout look: the white glyph tints with whatever is
+            // behind it (day/night gradient, random pattern, cover art) so it
+            // reads as semi-transparent. A tight drop-shadow plus a soft dark
+            // halo keep it legible on both dark and bright backgrounds.
+            mixBlendMode: "overlay",
+            filter:
+              "drop-shadow(0 1px 2px rgba(0,0,0,0.65)) drop-shadow(0 0 5px rgba(0,0,0,0.45))",
+          }}
+        >
+          {icon}
+        </span>
+      )}
+      {/* Glassy/transparent label: white text blended into the art with no
+          background panel. A tight multi-layer dark text-shadow acts as an
+          outline so it stays legible on dark gradients, bright covers and
+          busy patterns alike. */}
       <span
-        className="absolute inset-x-0 bottom-0 px-1 py-0.5 text-[10px] leading-tight text-center font-medium truncate"
+        className="absolute inset-x-0 bottom-0 px-1 pt-1 pb-0.5 text-[10px] leading-tight text-center font-medium truncate text-white"
         style={{
-          background: "linear-gradient(to top, rgba(0,0,0,0.55), transparent)",
-          textShadow: "0 1px 2px rgba(0,0,0,0.6)",
+          mixBlendMode: "overlay",
+          // Tight dark outline (rather than a soft blur) keeps the blended text
+          // crisp and readable even over bright cover photos / busy patterns.
+          textShadow:
+            "0 1px 1px rgba(0,0,0,0.95), 0 -1px 1px rgba(0,0,0,0.8), 1px 0 1px rgba(0,0,0,0.8), -1px 0 1px rgba(0,0,0,0.8), 0 0 4px rgba(0,0,0,0.5)",
         }}
       >
         {label}
@@ -230,6 +291,7 @@ interface WallpaperPickerProps {
 export function WallpaperPicker({ onSelect }: WallpaperPickerProps) {
   const {
     currentWallpaper,
+    wallpaperSource,
     setWallpaper,
     INDEXEDDB_PREFIX,
     loadCustomWallpapers,
@@ -346,6 +408,32 @@ export function WallpaperPicker({ onSelect }: WallpaperPickerProps) {
     }
     return r;
   }, [manifest]);
+
+  // Pick a stable random preview per category so the Shuffle tile hints at the
+  // art it will cycle through. Keyed on the source arrays so it only re-rolls
+  // when the manifest (or selected category) changes — not on every render.
+  const pickRandom = (arr: string[]): string | undefined =>
+    arr.length ? arr[Math.floor(Math.random() * arr.length)] : undefined;
+  const randomTileShuffleArt = useMemo(
+    () => pickRandom(tileWallpapers),
+    [tileWallpapers]
+  );
+  const randomVideoShuffleArt = useMemo(
+    () => pickRandom(videoWallpapers),
+    [videoWallpapers]
+  );
+  const randomPhotoShuffleArt = useMemo(
+    () => pickRandom(photoWallpapers[selectedCategory] ?? []),
+    [photoWallpapers, selectedCategory]
+  );
+
+  // When a category's shuffle is the *active* wallpaper, mirror the concrete
+  // asset the desktop currently shows (and rotates every 2 min) so the tile
+  // stays in sync. `wallpaperSource` is the live resolved asset; ignore it
+  // while it's still an unresolved shuffle:// descriptor.
+  const liveShuffleSource = isShuffleWallpaper(wallpaperSource)
+    ? undefined
+    : wallpaperSource;
 
   /** Leopard-era photo groups shown together, followed by Patterns and the remaining categories. */
   const MACOS9_PHOTO_ORDER = [
@@ -605,9 +693,7 @@ export function WallpaperPicker({ onSelect }: WallpaperPickerProps) {
                   handleWallpaperSelect(DAY_NIGHT_GRADIENT_WALLPAPER)
                 }
                 backgroundStyle={{ backgroundImage: dayNightPreview }}
-                icon={
-                  <Sun className="size-6 text-white/90" weight="fill" />
-                }
+                icon={<Sun className="size-6 text-white" weight="fill" />}
               />
               <SpecialTile
                 label={t("apps.control-panels.dynamicWallpapers.nowPlaying")}
@@ -624,10 +710,7 @@ export function WallpaperPicker({ onSelect }: WallpaperPickerProps) {
                 }
                 icon={
                   nowPlaying.coverUrl ? null : (
-                    <MusicNotes
-                      className="size-6 text-white/90"
-                      weight="fill"
-                    />
+                    <MusicNotes className="size-6 text-white" weight="fill" />
                   )
                 }
               />
@@ -641,9 +724,21 @@ export function WallpaperPicker({ onSelect }: WallpaperPickerProps) {
                   handleWallpaperSelect(buildShuffleDescriptor("tiles"))
                 }
                 isTile
-                icon={
-                  <Shuffle className="size-5 text-white/90" weight="bold" />
-                }
+                scrim
+                backgroundStyle={(() => {
+                  const active =
+                    currentWallpaper === buildShuffleDescriptor("tiles");
+                  const art =
+                    (active && liveShuffleSource) || randomTileShuffleArt;
+                  return art
+                    ? {
+                        backgroundImage: `url("${art}")`,
+                        backgroundSize: "64px 64px",
+                        backgroundRepeat: "repeat",
+                      }
+                    : undefined;
+                })()}
+                icon={<Shuffle className="size-5 text-white" weight="bold" />}
               />
               {tileWallpapers.map((path) => (
                 <WallpaperItem
@@ -665,9 +760,13 @@ export function WallpaperPicker({ onSelect }: WallpaperPickerProps) {
                 onClick={() =>
                   handleWallpaperSelect(buildShuffleDescriptor("videos"))
                 }
-                icon={
-                  <Shuffle className="size-6 text-white/90" weight="bold" />
+                scrim
+                backgroundVideoUrl={
+                  (currentWallpaper === buildShuffleDescriptor("videos") &&
+                    liveShuffleSource) ||
+                  randomVideoShuffleArt
                 }
+                icon={<Shuffle className="size-6 text-white" weight="bold" />}
               />
               {videoWallpapers.map((path) => (
                 <WallpaperItem
@@ -733,9 +832,22 @@ export function WallpaperPicker({ onSelect }: WallpaperPickerProps) {
                     buildShuffleDescriptor(selectedCategory)
                   )
                 }
-                icon={
-                  <Shuffle className="size-6 text-white/90" weight="bold" />
-                }
+                scrim
+                backgroundStyle={(() => {
+                  const active =
+                    currentWallpaper ===
+                    buildShuffleDescriptor(selectedCategory);
+                  const art =
+                    (active && liveShuffleSource) || randomPhotoShuffleArt;
+                  return art
+                    ? {
+                        backgroundImage: `url("${art}")`,
+                        backgroundSize: "cover",
+                        backgroundPosition: "center",
+                      }
+                    : undefined;
+                })()}
+                icon={<Shuffle className="size-6 text-white" weight="bold" />}
               />
               {photoWallpapers[selectedCategory].map((path) => (
                 <WallpaperItem

--- a/src/apps/control-panels/components/WallpaperPicker.tsx
+++ b/src/apps/control-panels/components/WallpaperPicker.tsx
@@ -175,7 +175,7 @@ interface SpecialTileProps {
   /**
    * Render a plain dark scrim (no blur) under the icon + label. Used for tiles
    * whose preview can be an arbitrary bright/busy photo (the Shuffle tiles) so
-   * the glassy glyphs always stay legible.
+   * the white glyphs always stay legible.
    */
   scrim?: boolean;
 }
@@ -247,32 +247,23 @@ function SpecialTile({
       )}
       {icon && (
         <span
-          className="relative flex items-center justify-center"
+          className="relative flex items-center justify-center text-white/85"
           style={{
-            // Glassy/knockout look: the white glyph tints with whatever is
-            // behind it (day/night gradient, random pattern, cover art) so it
-            // reads as semi-transparent. A tight drop-shadow plus a soft dark
-            // halo keep it legible on both dark and bright backgrounds.
-            mixBlendMode: "overlay",
-            filter:
-              "drop-shadow(0 1px 2px rgba(0,0,0,0.65)) drop-shadow(0 0 5px rgba(0,0,0,0.45))",
+            // Semi-transparent white glyph with a simple drop-shadow keeps it
+            // legible on dark gradients, bright covers and busy patterns alike.
+            filter: "drop-shadow(0 1px 2px rgba(0,0,0,0.6))",
           }}
         >
           {icon}
         </span>
       )}
-      {/* Glassy/transparent label: white text blended into the art with no
-          background panel. A tight multi-layer dark text-shadow acts as an
-          outline so it stays legible on dark gradients, bright covers and
-          busy patterns alike. */}
+      {/* Semi-transparent white label with a single soft dark text-shadow.
+          Crisp and readable on dark gradients, bright covers and busy patterns
+          without any blend modes. */}
       <span
-        className="absolute inset-x-0 bottom-0 px-1 pt-1 pb-0.5 text-[10px] leading-tight text-center font-medium truncate text-white"
+        className="absolute inset-x-0 bottom-0 px-1 pt-1 pb-0.5 text-[10px] leading-tight text-center font-medium truncate text-white/85"
         style={{
-          mixBlendMode: "overlay",
-          // Tight dark outline (rather than a soft blur) keeps the blended text
-          // crisp and readable even over bright cover photos / busy patterns.
-          textShadow:
-            "0 1px 1px rgba(0,0,0,0.95), 0 -1px 1px rgba(0,0,0,0.8), 1px 0 1px rgba(0,0,0,0.8), -1px 0 1px rgba(0,0,0,0.8), 0 0 4px rgba(0,0,0,0.5)",
+          textShadow: "0 1px 2px rgba(0,0,0,0.6)",
         }}
       >
         {label}
@@ -693,7 +684,7 @@ export function WallpaperPicker({ onSelect }: WallpaperPickerProps) {
                   handleWallpaperSelect(DAY_NIGHT_GRADIENT_WALLPAPER)
                 }
                 backgroundStyle={{ backgroundImage: dayNightPreview }}
-                icon={<Sun className="size-6 text-white" weight="fill" />}
+                icon={<Sun className="size-6 text-white/85" weight="fill" />}
               />
               <SpecialTile
                 label={t("apps.control-panels.dynamicWallpapers.nowPlaying")}
@@ -710,7 +701,7 @@ export function WallpaperPicker({ onSelect }: WallpaperPickerProps) {
                 }
                 icon={
                   nowPlaying.coverUrl ? null : (
-                    <MusicNotes className="size-6 text-white" weight="fill" />
+                    <MusicNotes className="size-6 text-white/85" weight="fill" />
                   )
                 }
               />
@@ -738,7 +729,7 @@ export function WallpaperPicker({ onSelect }: WallpaperPickerProps) {
                       }
                     : undefined;
                 })()}
-                icon={<Shuffle className="size-5 text-white" weight="bold" />}
+                icon={<Shuffle className="size-5 text-white/85" weight="bold" />}
               />
               {tileWallpapers.map((path) => (
                 <WallpaperItem
@@ -766,7 +757,7 @@ export function WallpaperPicker({ onSelect }: WallpaperPickerProps) {
                     liveShuffleSource) ||
                   randomVideoShuffleArt
                 }
-                icon={<Shuffle className="size-6 text-white" weight="bold" />}
+                icon={<Shuffle className="size-6 text-white/85" weight="bold" />}
               />
               {videoWallpapers.map((path) => (
                 <WallpaperItem
@@ -847,7 +838,7 @@ export function WallpaperPicker({ onSelect }: WallpaperPickerProps) {
                       }
                     : undefined;
                 })()}
-                icon={<Shuffle className="size-6 text-white" weight="bold" />}
+                icon={<Shuffle className="size-6 text-white/85" weight="bold" />}
               />
               {photoWallpapers[selectedCategory].map((path) => (
                 <WallpaperItem

--- a/src/apps/control-panels/components/WallpaperPicker.tsx
+++ b/src/apps/control-panels/components/WallpaperPicker.tsx
@@ -10,10 +10,26 @@ import {
 import { useWallpaper } from "@/hooks/useWallpaper";
 import { useSound, Sounds } from "@/hooks/useSound";
 import type { DisplayMode } from "@/utils/displayMode";
-import { Plus, Trash } from "@phosphor-icons/react";
+import {
+  Plus,
+  Trash,
+  Shuffle,
+  MusicNotes,
+  Sun,
+} from "@phosphor-icons/react";
 import { useDisplaySettingsStore } from "@/stores/useDisplaySettingsStore";
 import { loadWallpaperManifest } from "@/utils/wallpapers";
 import type { WallpaperManifest as WallpaperManifestType } from "@/utils/wallpapers";
+import { useNowPlayingCover } from "@/hooks/useNowPlayingCover";
+import {
+  COVER_WALLPAPER,
+  DAY_NIGHT_GRADIENT_WALLPAPER,
+  buildShuffleDescriptor,
+  getDayNightGradientCss,
+  isCoverWallpaper,
+  isDayNightGradientWallpaper,
+  parseShuffleDescriptor,
+} from "@/utils/dynamicWallpaper";
 import { useTranslation } from "react-i18next";
 
 // Remove unused constants
@@ -144,6 +160,66 @@ function WallpaperItem({
   );
 }
 
+interface SpecialTileProps {
+  label: string;
+  isSelected: boolean;
+  onClick: () => void;
+  isTile?: boolean;
+  /** Inline style for the tile background (gradient / cover preview). */
+  backgroundStyle?: React.CSSProperties;
+  /** Optional icon element rendered centered in the tile. */
+  icon?: React.ReactNode;
+}
+
+/** Tile used for dynamic & shuffle wallpaper options (carries a text label). */
+function SpecialTile({
+  label,
+  isSelected,
+  onClick,
+  isTile = false,
+  backgroundStyle,
+  icon,
+}: SpecialTileProps) {
+  const { play: playClick } = useSound(Sounds.BUTTON_CLICK, 0.3);
+  const handleClick = () => {
+    playClick();
+    onClick();
+  };
+  return (
+    <button
+      type="button"
+      className={`preview-button relative w-full ${
+        isTile ? "aspect-square" : "aspect-video"
+      } cursor-pointer hover:opacity-90 flex items-center justify-center overflow-hidden text-white`}
+      style={{
+        backgroundColor: "#2a2a32",
+        ...backgroundStyle,
+        boxShadow: isSelected
+          ? "0 0 0 1px var(--os-color-selection-ring-gap), 0 0 0 3px var(--os-color-selection-bg)"
+          : undefined,
+      }}
+      onClick={handleClick}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          handleClick();
+        }
+      }}
+    >
+      {icon}
+      <span
+        className="absolute inset-x-0 bottom-0 px-1 py-0.5 text-[10px] leading-tight text-center font-medium truncate"
+        style={{
+          background: "linear-gradient(to top, rgba(0,0,0,0.55), transparent)",
+          textShadow: "0 1px 2px rgba(0,0,0,0.6)",
+        }}
+      >
+        {label}
+      </span>
+    </button>
+  );
+}
+
 type PhotoCategory = string;
 
 // Wallpaper data will be loaded from the generated manifest at runtime.
@@ -170,9 +246,20 @@ export function WallpaperPicker({ onSelect }: WallpaperPickerProps) {
   const displayMode = useDisplaySettingsStore((s) => s.displayMode);
   const setDisplayMode = useDisplaySettingsStore((s) => s.setDisplayMode);
   const { t } = useTranslation();
+  const nowPlaying = useNowPlayingCover();
+  // Preview the gradient for the current time of day (static within a session).
+  const dayNightPreview = useMemo(() => getDayNightGradientCss(), []);
   const deriveCategoryFromWallpaper = (
     wallpaper: string
   ): "tiles" | PhotoCategory => {
+    if (isDayNightGradientWallpaper(wallpaper) || isCoverWallpaper(wallpaper))
+      return "dynamic";
+    const shuffleTarget = parseShuffleDescriptor(wallpaper);
+    if (shuffleTarget) {
+      if (shuffleTarget.kind === "tiles") return "tiles";
+      if (shuffleTarget.kind === "videos") return "videos";
+      return shuffleTarget.category;
+    }
     if (wallpaper.includes("/wallpapers/tiles/")) return "tiles";
     if (wallpaper.startsWith(INDEXEDDB_PREFIX)) return "custom";
     if (wallpaper.includes("/wallpapers/videos/")) return "videos";
@@ -436,6 +523,9 @@ export function WallpaperPicker({ onSelect }: WallpaperPickerProps) {
             </SelectTrigger>
             <SelectContent>
               <SelectItem value="custom">{t("apps.control-panels.custom")}</SelectItem>
+              <SelectItem value="dynamic">
+                {t("apps.control-panels.wallpaperCategories.dynamic")}
+              </SelectItem>
               <SelectSeparator
                 className="-mx-1 my-1 h-px"
                 style={{
@@ -506,26 +596,89 @@ export function WallpaperPicker({ onSelect }: WallpaperPickerProps) {
             selectedCategory === "tiles" ? "grid-cols-8" : "grid-cols-3"
           }`}
         >
-          {selectedCategory === "tiles" ? (
-            tileWallpapers.map((path) => (
-              <WallpaperItem
-                key={path}
-                path={path}
-                isSelected={currentWallpaper === path}
-                onClick={() => handleWallpaperSelect(path)}
+          {selectedCategory === "dynamic" ? (
+            <>
+              <SpecialTile
+                label={t("apps.control-panels.dynamicWallpapers.dayNight")}
+                isSelected={isDayNightGradientWallpaper(currentWallpaper)}
+                onClick={() =>
+                  handleWallpaperSelect(DAY_NIGHT_GRADIENT_WALLPAPER)
+                }
+                backgroundStyle={{ backgroundImage: dayNightPreview }}
+                icon={
+                  <Sun className="size-6 text-white/90" weight="fill" />
+                }
+              />
+              <SpecialTile
+                label={t("apps.control-panels.dynamicWallpapers.nowPlaying")}
+                isSelected={isCoverWallpaper(currentWallpaper)}
+                onClick={() => handleWallpaperSelect(COVER_WALLPAPER)}
+                backgroundStyle={
+                  nowPlaying.coverUrl
+                    ? {
+                        backgroundImage: `url("${nowPlaying.coverUrl}")`,
+                        backgroundSize: "cover",
+                        backgroundPosition: "center",
+                      }
+                    : undefined
+                }
+                icon={
+                  nowPlaying.coverUrl ? null : (
+                    <MusicNotes
+                      className="size-6 text-white/90"
+                      weight="fill"
+                    />
+                  )
+                }
+              />
+            </>
+          ) : selectedCategory === "tiles" ? (
+            <>
+              <SpecialTile
+                label={t("apps.control-panels.dynamicWallpapers.shuffle")}
+                isSelected={currentWallpaper === buildShuffleDescriptor("tiles")}
+                onClick={() =>
+                  handleWallpaperSelect(buildShuffleDescriptor("tiles"))
+                }
                 isTile
+                icon={
+                  <Shuffle className="size-5 text-white/90" weight="bold" />
+                }
               />
-            ))
+              {tileWallpapers.map((path) => (
+                <WallpaperItem
+                  key={path}
+                  path={path}
+                  isSelected={currentWallpaper === path}
+                  onClick={() => handleWallpaperSelect(path)}
+                  isTile
+                />
+              ))}
+            </>
           ) : selectedCategory === "videos" ? (
-            videoWallpapers.map((path) => (
-              <WallpaperItem
-                key={path}
-                path={path}
-                isSelected={currentWallpaper === path}
-                onClick={() => handleWallpaperSelect(path)}
-                isVideo
+            <>
+              <SpecialTile
+                label={t("apps.control-panels.dynamicWallpapers.shuffle")}
+                isSelected={
+                  currentWallpaper === buildShuffleDescriptor("videos")
+                }
+                onClick={() =>
+                  handleWallpaperSelect(buildShuffleDescriptor("videos"))
+                }
+                icon={
+                  <Shuffle className="size-6 text-white/90" weight="bold" />
+                }
               />
-            ))
+              {videoWallpapers.map((path) => (
+                <WallpaperItem
+                  key={path}
+                  path={path}
+                  isSelected={currentWallpaper === path}
+                  onClick={() => handleWallpaperSelect(path)}
+                  isVideo
+                />
+              ))}
+            </>
           )           : selectedCategory === "custom" ? (
             <>
               <button
@@ -568,14 +721,31 @@ export function WallpaperPicker({ onSelect }: WallpaperPickerProps) {
               )}
             </>
           ) : photoWallpapers[selectedCategory] ? (
-            photoWallpapers[selectedCategory].map((path) => (
-              <WallpaperItem
-                key={path}
-                path={path}
-                isSelected={currentWallpaper === path}
-                onClick={() => handleWallpaperSelect(path)}
+            <>
+              <SpecialTile
+                label={t("apps.control-panels.dynamicWallpapers.shuffle")}
+                isSelected={
+                  currentWallpaper ===
+                  buildShuffleDescriptor(selectedCategory)
+                }
+                onClick={() =>
+                  handleWallpaperSelect(
+                    buildShuffleDescriptor(selectedCategory)
+                  )
+                }
+                icon={
+                  <Shuffle className="size-6 text-white/90" weight="bold" />
+                }
               />
-            ))
+              {photoWallpapers[selectedCategory].map((path) => (
+                <WallpaperItem
+                  key={path}
+                  path={path}
+                  isSelected={currentWallpaper === path}
+                  onClick={() => handleWallpaperSelect(path)}
+                />
+              ))}
+            </>
           ) : (
             <div className="col-span-4 text-center py-8 text-neutral-500">
               {t("apps.control-panels.noWallpapers")}

--- a/src/apps/control-panels/components/WallpaperPicker.tsx
+++ b/src/apps/control-panels/components/WallpaperPicker.tsx
@@ -247,9 +247,10 @@ function SpecialTile({
       )}
       {icon && (
         <span
-          className="relative flex items-center justify-center text-white/85"
+          className="relative flex items-center justify-center text-white opacity-[0.85]"
           style={{
-            // Semi-transparent white glyph with a simple drop-shadow keeps it
+            // Uniform element opacity (not color alpha) so the tile art shows
+            // through the glyph consistently. A simple drop-shadow keeps it
             // legible on dark gradients, bright covers and busy patterns alike.
             filter: "drop-shadow(0 1px 2px rgba(0,0,0,0.6))",
           }}
@@ -257,11 +258,11 @@ function SpecialTile({
           {icon}
         </span>
       )}
-      {/* Semi-transparent white label with a single soft dark text-shadow.
-          Crisp and readable on dark gradients, bright covers and busy patterns
-          without any blend modes. */}
+      {/* White label dimmed via element opacity (matching the icon) with a
+          single soft dark text-shadow. Crisp and readable on dark gradients,
+          bright covers and busy patterns without any blend modes. */}
       <span
-        className="absolute inset-x-0 bottom-0 px-1 pt-1 pb-0.5 text-[10px] leading-tight text-center font-medium truncate text-white/85"
+        className="absolute inset-x-0 bottom-0 px-1 pt-1 pb-0.5 text-[10px] leading-tight text-center font-medium truncate text-white opacity-[0.85]"
         style={{
           textShadow: "0 1px 2px rgba(0,0,0,0.6)",
         }}
@@ -684,7 +685,7 @@ export function WallpaperPicker({ onSelect }: WallpaperPickerProps) {
                   handleWallpaperSelect(DAY_NIGHT_GRADIENT_WALLPAPER)
                 }
                 backgroundStyle={{ backgroundImage: dayNightPreview }}
-                icon={<Sun className="size-6 text-white/85" weight="fill" />}
+                icon={<Sun className="size-6 text-white" weight="fill" />}
               />
               <SpecialTile
                 label={t("apps.control-panels.dynamicWallpapers.nowPlaying")}
@@ -701,7 +702,7 @@ export function WallpaperPicker({ onSelect }: WallpaperPickerProps) {
                 }
                 icon={
                   nowPlaying.coverUrl ? null : (
-                    <MusicNotes className="size-6 text-white/85" weight="fill" />
+                    <MusicNotes className="size-6 text-white" weight="fill" />
                   )
                 }
               />
@@ -729,7 +730,7 @@ export function WallpaperPicker({ onSelect }: WallpaperPickerProps) {
                       }
                     : undefined;
                 })()}
-                icon={<Shuffle className="size-5 text-white/85" weight="bold" />}
+                icon={<Shuffle className="size-5 text-white" weight="bold" />}
               />
               {tileWallpapers.map((path) => (
                 <WallpaperItem
@@ -757,7 +758,7 @@ export function WallpaperPicker({ onSelect }: WallpaperPickerProps) {
                     liveShuffleSource) ||
                   randomVideoShuffleArt
                 }
-                icon={<Shuffle className="size-6 text-white/85" weight="bold" />}
+                icon={<Shuffle className="size-6 text-white" weight="bold" />}
               />
               {videoWallpapers.map((path) => (
                 <WallpaperItem
@@ -838,7 +839,7 @@ export function WallpaperPicker({ onSelect }: WallpaperPickerProps) {
                       }
                     : undefined;
                 })()}
-                icon={<Shuffle className="size-6 text-white/85" weight="bold" />}
+                icon={<Shuffle className="size-6 text-white" weight="bold" />}
               />
               {photoWallpapers[selectedCategory].map((path) => (
                 <WallpaperItem

--- a/src/apps/control-panels/components/WallpaperPicker.tsx
+++ b/src/apps/control-panels/components/WallpaperPicker.tsx
@@ -195,7 +195,7 @@ function SpecialTile({
         backgroundColor: "#2a2a32",
         ...backgroundStyle,
         boxShadow: isSelected
-          ? "0 0 0 1px var(--os-color-selection-ring-gap), 0 0 0 3px var(--os-color-selection-bg)"
+          ? "0 0 0 1px transparent, 0 0 0 3px var(--os-color-selection-bg)"
           : undefined,
       }}
       onClick={handleClick}

--- a/src/components/layout/desktop/Desktop.tsx
+++ b/src/components/layout/desktop/Desktop.tsx
@@ -4,6 +4,7 @@ import type { DesktopProps } from "./desktopTypes";
 import { useDesktop } from "./useDesktop";
 import { DesktopIconGrid } from "./DesktopIconGrid";
 import { DesktopDragRegion } from "./DesktopDragRegion";
+import { DesktopDynamicWallpaper } from "./DesktopDynamicWallpaper";
 
 export function Desktop(props: DesktopProps) {
   const d = useDesktop(props);
@@ -35,6 +36,7 @@ export function Desktop(props: DesktopProps) {
           display: d.isVideoWallpaper ? "block" : "none",
         }}
       />
+      <DesktopDynamicWallpaper />
       <DesktopDragRegion
         isDesktopApp={d.isDesktopApp}
         isXpTheme={d.isXpTheme}

--- a/src/components/layout/desktop/DesktopDynamicWallpaper.tsx
+++ b/src/components/layout/desktop/DesktopDynamicWallpaper.tsx
@@ -1,0 +1,110 @@
+import { useEffect, useState } from "react";
+import { AnimatePresence, motion } from "motion/react";
+import { useWallpaper } from "@/hooks/useWallpaper";
+import { useNowPlayingCover } from "@/hooks/useNowPlayingCover";
+import {
+  getDayNightGradientCss,
+  isCoverWallpaper,
+  isDayNightGradientWallpaper,
+} from "@/utils/dynamicWallpaper";
+
+/** Recompute the day/night gradient roughly once a minute. */
+const GRADIENT_REFRESH_MS = 60 * 1000;
+
+function DayNightGradientLayer() {
+  const [gradient, setGradient] = useState(() => getDayNightGradientCss());
+
+  useEffect(() => {
+    const update = () => setGradient(getDayNightGradientCss());
+    update();
+    const id = setInterval(update, GRADIENT_REFRESH_MS);
+    return () => clearInterval(id);
+  }, []);
+
+  return (
+    <div
+      className="absolute inset-0 w-full h-full z-[-10]"
+      style={{
+        backgroundImage: gradient,
+        // Slow cross-fade between successive gradients so shifts feel ambient.
+        transition: "background-image 3s linear",
+      }}
+    />
+  );
+}
+
+function CoverWallpaperLayer() {
+  const { coverUrl } = useNowPlayingCover();
+
+  return (
+    <div className="absolute inset-0 w-full h-full z-[-10] overflow-hidden bg-neutral-950">
+      <AnimatePresence mode="popLayout">
+        {coverUrl ? (
+          <motion.div
+            key={coverUrl}
+            className="absolute inset-0 w-full h-full"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.6 }}
+          >
+            {/* Blurred, scaled fill so any aspect ratio covers the desktop. */}
+            <div
+              className="absolute inset-0 w-full h-full"
+              style={{
+                backgroundImage: `url("${coverUrl}")`,
+                backgroundSize: "cover",
+                backgroundPosition: "center",
+                filter: "blur(48px) saturate(1.2)",
+                transform: "scale(1.2)",
+              }}
+            />
+            {/* Sharp, centered cover floating on top of the blur. */}
+            <div
+              className="absolute inset-0 w-full h-full"
+              style={{
+                backgroundImage: `url("${coverUrl}")`,
+                backgroundSize: "contain",
+                backgroundPosition: "center",
+                backgroundRepeat: "no-repeat",
+              }}
+            />
+            {/* Subtle darkening keeps desktop icons readable. */}
+            <div className="absolute inset-0 w-full h-full bg-black/25" />
+          </motion.div>
+        ) : (
+          <motion.div
+            key="cover-empty"
+            className="absolute inset-0 w-full h-full"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.6 }}
+            style={{
+              backgroundImage:
+                "linear-gradient(to bottom, #1a1a1f 0%, #0c0c10 100%)",
+            }}
+          />
+        )}
+      </AnimatePresence>
+    </div>
+  );
+}
+
+/**
+ * Renders dynamic desktop wallpapers (day/night gradient and now-playing cover)
+ * that can't be expressed as a single CSS background-image. Returns null for all
+ * other wallpaper kinds (static images, tiles, videos, shuffle — those render
+ * via the desktop background styles / video element).
+ */
+export function DesktopDynamicWallpaper() {
+  const { currentWallpaper } = useWallpaper();
+
+  if (isDayNightGradientWallpaper(currentWallpaper)) {
+    return <DayNightGradientLayer />;
+  }
+  if (isCoverWallpaper(currentWallpaper)) {
+    return <CoverWallpaperLayer />;
+  }
+  return null;
+}

--- a/src/components/layout/desktop/desktopWallpaperUtils.ts
+++ b/src/components/layout/desktop/desktopWallpaperUtils.ts
@@ -1,4 +1,5 @@
 import { INDEXEDDB_PREFIX } from "@/stores/useDisplaySettingsStore";
+import { isDynamicWallpaper } from "@/utils/dynamicWallpaper";
 import type { DesktopStyles } from "./desktopTypes";
 
 export function getWallpaperStyles(
@@ -8,6 +9,11 @@ export function getWallpaperStyles(
   if (!path || isVideoWallpaper) return {};
 
   if (path.startsWith(INDEXEDDB_PREFIX)) return {};
+
+  // Dynamic wallpapers (gradient / cover) paint via a dedicated React layer
+  // rather than a CSS background-image. Unresolved shuffle descriptors also
+  // land here briefly before the runtime source resolves to a concrete asset.
+  if (isDynamicWallpaper(path)) return {};
 
   const isTiled = path.includes("/wallpapers/tiles/");
   return {

--- a/src/components/layout/desktop/useDesktop.ts
+++ b/src/components/layout/desktop/useDesktop.ts
@@ -18,6 +18,7 @@ import type { LaunchOriginRect } from "@/stores/useAppStore";
 import { STORES, dbOperations } from "@/utils/indexedDB";
 import { useTranslation } from "react-i18next";
 import { useWallpaper } from "@/hooks/useWallpaper";
+import { useShuffleWallpaper } from "@/hooks/useShuffleWallpaper";
 import {
   createSelectionRect,
   getIntersectingSelectionIds,
@@ -59,6 +60,8 @@ export function useDesktop({
   const [selectionAnchorId, setSelectionAnchorId] =
     useState<DesktopItemId | null>(null);
   const { wallpaperSource, isVideoWallpaper } = useWallpaper();
+  // Resolve shuffle wallpapers into a concrete rotating asset source.
+  useShuffleWallpaper();
   const { videoRef } = useDesktopVideoWallpaper(isVideoWallpaper);
   const desktopRef = useRef<HTMLDivElement>(null);
   const marqueeStartRef = useRef<SelectionPoint | null>(null);

--- a/src/hooks/useNowPlayingCover.ts
+++ b/src/hooks/useNowPlayingCover.ts
@@ -1,0 +1,122 @@
+import { useMemo } from "react";
+import {
+  useIpodStore,
+  getActiveIpodCurrentTrack,
+  type Track,
+  type AppleMusicKitNowPlaying,
+} from "@/stores/useIpodStore";
+import { useKaraokeStore } from "@/stores/useKaraokeStore";
+import {
+  resolveAppleMusicArtworkUrl,
+  resolveMediaCoverUrl,
+} from "@/utils/coverArt";
+
+export interface NowPlayingCover {
+  coverUrl: string | null;
+  title: string | null;
+  /** Whichever player is currently driving the cover. */
+  source: "ipod" | "karaoke" | null;
+  isPlaying: boolean;
+}
+
+const EMPTY: NowPlayingCover = {
+  coverUrl: null,
+  title: null,
+  source: null,
+  isPlaying: false,
+};
+
+function resolveCover(
+  track: Track | null,
+  nowPlaying: AppleMusicKitNowPlaying | null
+): string | null {
+  if (track?.source === "appleMusic" || (!track && nowPlaying)) {
+    const cover = nowPlaying?.cover ?? track?.cover;
+    return resolveAppleMusicArtworkUrl(cover, 1000);
+  }
+  return resolveMediaCoverUrl(track, { kugouSize: 800 });
+}
+
+/**
+ * Resolves the cover art that should be shown for the "Now Playing" dynamic
+ * wallpaper. Prefers whichever of the iPod / Karaoke players is actively
+ * playing (iPod wins ties); otherwise falls back to whichever has a current
+ * track so the cover still shows while paused.
+ */
+export function useNowPlayingCover(): NowPlayingCover {
+  // iPod playback state.
+  const ipodIsPlaying = useIpodStore((s) => s.isPlaying);
+  const ipodLibrarySource = useIpodStore((s) => s.librarySource);
+  const ipodCurrentSongId = useIpodStore((s) => s.currentSongId);
+  const ipodAppleSongId = useIpodStore((s) => s.appleMusicCurrentSongId);
+  const ipodTracks = useIpodStore((s) => s.tracks);
+  const ipodAppleTracks = useIpodStore((s) => s.appleMusicTracks);
+  const ipodNowPlaying = useIpodStore((s) => s.appleMusicKitNowPlaying);
+
+  // Karaoke playback state (library is shared with the iPod's YouTube tracks).
+  const karaokeIsPlaying = useKaraokeStore((s) => s.isPlaying);
+  const karaokeSongId = useKaraokeStore((s) => s.currentSongId);
+
+  return useMemo<NowPlayingCover>(() => {
+    const ipodTrack = getActiveIpodCurrentTrack({
+      librarySource: ipodLibrarySource,
+      tracks: ipodTracks,
+      currentSongId: ipodCurrentSongId,
+      appleMusicTracks: ipodAppleTracks,
+      appleMusicCurrentSongId: ipodAppleSongId,
+    });
+
+    const karaokeTrack = karaokeSongId
+      ? ipodTracks.find((t) => t.id === karaokeSongId) ?? null
+      : null;
+
+    type Candidate = {
+      source: "ipod" | "karaoke";
+      track: Track | null;
+      nowPlaying: AppleMusicKitNowPlaying | null;
+      isPlaying: boolean;
+    };
+
+    const ipodCandidate: Candidate = {
+      source: "ipod",
+      track: ipodTrack,
+      nowPlaying: ipodLibrarySource === "appleMusic" ? ipodNowPlaying : null,
+      isPlaying: ipodIsPlaying,
+    };
+    const karaokeCandidate: Candidate = {
+      source: "karaoke",
+      track: karaokeTrack,
+      nowPlaying: null,
+      isPlaying: karaokeIsPlaying,
+    };
+
+    // Precedence: actively playing first (iPod wins ties), then whichever has
+    // a track so paused playback still shows its cover.
+    let chosen: Candidate | null = null;
+    if (ipodCandidate.isPlaying) chosen = ipodCandidate;
+    else if (karaokeCandidate.isPlaying) chosen = karaokeCandidate;
+    else if (ipodCandidate.track) chosen = ipodCandidate;
+    else if (karaokeCandidate.track) chosen = karaokeCandidate;
+
+    if (!chosen) return EMPTY;
+
+    const coverUrl = resolveCover(chosen.track, chosen.nowPlaying);
+    const title = chosen.nowPlaying?.title ?? chosen.track?.title ?? null;
+    return {
+      coverUrl,
+      title,
+      source: chosen.source,
+      isPlaying: chosen.isPlaying,
+    };
+  }, [
+    ipodIsPlaying,
+    ipodLibrarySource,
+    ipodCurrentSongId,
+    ipodAppleSongId,
+    ipodTracks,
+    ipodAppleTracks,
+    ipodNowPlaying,
+    karaokeIsPlaying,
+    karaokeSongId,
+  ]);
+}

--- a/src/hooks/useShuffleWallpaper.ts
+++ b/src/hooks/useShuffleWallpaper.ts
@@ -1,0 +1,69 @@
+import { useEffect, useRef } from "react";
+import { useDisplaySettingsStore } from "@/stores/useDisplaySettingsStore";
+import { loadWallpaperManifest } from "@/utils/wallpapers";
+import {
+  SHUFFLE_INTERVAL_MS,
+  getShuffleCandidatePaths,
+  isShuffleWallpaper,
+  parseShuffleDescriptor,
+  pickRandomCandidate,
+} from "@/utils/dynamicWallpaper";
+
+/**
+ * Drives shuffle wallpapers: when `currentWallpaper` is a `shuffle://…`
+ * descriptor, resolve a random asset from that category and rotate to a new
+ * random one every {@link SHUFFLE_INTERVAL_MS}. The concrete asset is written
+ * to the store's runtime `wallpaperSource` so the desktop, menubar tint, and
+ * accent sampling all see a real image while the persisted selection stays the
+ * shuffle descriptor.
+ */
+export function useShuffleWallpaper() {
+  const currentWallpaper = useDisplaySettingsStore((s) => s.currentWallpaper);
+  const wallpaperSource = useDisplaySettingsStore((s) => s.wallpaperSource);
+  const setRuntimeWallpaperSource = useDisplaySettingsStore(
+    (s) => s.setRuntimeWallpaperSource
+  );
+
+  // Keep the latest resolved source in a ref so the rotation can avoid
+  // immediately repeating the current pick without re-subscribing.
+  const currentSourceRef = useRef(wallpaperSource);
+  currentSourceRef.current = wallpaperSource;
+
+  useEffect(() => {
+    if (!isShuffleWallpaper(currentWallpaper)) return;
+    const target = parseShuffleDescriptor(currentWallpaper);
+    if (!target) return;
+
+    let cancelled = false;
+    let intervalId: ReturnType<typeof setInterval> | null = null;
+
+    const rotate = (candidates: string[]) => {
+      const next = pickRandomCandidate(candidates, currentSourceRef.current);
+      if (next) setRuntimeWallpaperSource(next);
+    };
+
+    loadWallpaperManifest()
+      .then((manifest) => {
+        if (cancelled) return;
+        const candidates = getShuffleCandidatePaths(manifest, target);
+        if (candidates.length === 0) return;
+
+        // Resolve immediately if the runtime source isn't already one of the
+        // category's assets (e.g. fresh selection or stale descriptor).
+        if (!candidates.includes(currentSourceRef.current)) {
+          rotate(candidates);
+        }
+
+        intervalId = setInterval(() => rotate(candidates), SHUFFLE_INTERVAL_MS);
+      })
+      .catch((err) =>
+        console.error("Failed to load manifest for shuffle wallpaper", err)
+      );
+
+    return () => {
+      cancelled = true;
+      if (intervalId) clearInterval(intervalId);
+    };
+    // Re-run when the descriptor changes (category switch / disable).
+  }, [currentWallpaper, setRuntimeWallpaperSource]);
+}

--- a/src/hooks/useWallpaperAccent.ts
+++ b/src/hooks/useWallpaperAccent.ts
@@ -2,18 +2,41 @@ import { useEffect } from "react";
 import { useThemeStore } from "@/stores/useThemeStore";
 import { useWallpaper } from "@/hooks/useWallpaper";
 import { useCoverPaletteResult } from "@/hooks/useCoverPalette";
+import { useNowPlayingCover } from "@/hooks/useNowPlayingCover";
 import { DEFAULT_ACCENT, getAccentChrome } from "@/themes/accents";
-import { resolveWallpaperAccentFromPalette } from "@/themes/wallpaperAccentColor";
+import {
+  normalizeWallpaperAccentColor,
+  resolveWallpaperAccentFromPalette,
+} from "@/themes/wallpaperAccentColor";
+import {
+  getDayNightGradientColors,
+  isCoverWallpaper,
+  isDayNightGradientWallpaper,
+} from "@/utils/dynamicWallpaper";
+
+// The gradient drifts with wall-clock time, so re-derive its accent on a slow
+// interval to keep it tracking the day → night shift.
+const GRADIENT_ACCENT_REFRESH_MS = 60 * 1000;
+
+const rgbToHex = ([r, g, b]: [number, number, number]): string =>
+  `#${[r, g, b]
+    .map((c) =>
+      Math.max(0, Math.min(255, Math.round(c)))
+        .toString(16)
+        .padStart(2, "0")
+    )
+    .join("")}`;
 
 /**
- * Drives the `"wallpaper"` accent: when the active theme uses it, sample a
- * representative color from the current wallpaper image (reusing the same
- * palette-extraction the iPod cover-art glow uses) and feed it to the theme
+ * Drives the `"wallpaper"` accent: when the active theme uses it, derive a
+ * representative color from the current wallpaper and feed it to the theme
  * store, which repaints the accent CSS vars.
  *
- * Only runs the (canvas-backed) extraction while the wallpaper accent is
- * actually selected and the wallpaper is a samplable image — video wallpapers
- * and load/CORS failures fall back to the theme's classic look.
+ * Image wallpapers (including shuffle photos) and the now-playing cover sample
+ * a color via the same canvas palette-extraction the iPod cover-art glow uses.
+ * The day/night gradient — which has no loadable image — derives its accent
+ * directly from the live gradient colors. Video wallpapers and load/CORS
+ * failures fall back to the theme's classic look.
  */
 export function useWallpaperAccent() {
   const current = useThemeStore((s) => s.current);
@@ -23,22 +46,58 @@ export function useWallpaperAccent() {
   const setWallpaperAccentColor = useThemeStore(
     (s) => s.setWallpaperAccentColor
   );
-  const { wallpaperSource, isVideoWallpaper } = useWallpaper();
+  const { currentWallpaper, wallpaperSource, isVideoWallpaper } =
+    useWallpaper();
 
   const isWallpaperAccent =
     getAccentChrome(current) !== null && accent === "wallpaper";
 
-  // Feed a URL to the extractor only when the wallpaper accent is active and the
-  // wallpaper is an image; otherwise pass null so no canvas work happens.
-  const sampleUrl =
-    isWallpaperAccent && !isVideoWallpaper ? wallpaperSource || null : null;
+  const isGradient = isDayNightGradientWallpaper(currentWallpaper);
+  const isCover = isCoverWallpaper(currentWallpaper);
+
+  const { coverUrl: nowPlayingCoverUrl } = useNowPlayingCover();
+
+  // Pick the image URL fed to the canvas palette extractor:
+  //  - cover wallpaper → the now-playing album art
+  //  - image wallpapers (incl. shuffle photos) → the resolved wallpaper source
+  //  - gradient / video / inactive → none (handled separately or skipped)
+  let sampleUrl: string | null = null;
+  if (isWallpaperAccent && !isGradient) {
+    if (isCover) {
+      sampleUrl = nowPlayingCoverUrl;
+    } else if (!isVideoWallpaper) {
+      sampleUrl = wallpaperSource || null;
+    }
+  }
 
   const { palette, source, coverUrl } = useCoverPaletteResult(sampleUrl);
 
   useEffect(() => {
-    if (!isWallpaperAccent) return;
-    // Only act on a palette actually extracted from the wallpaper image.
+    if (!isWallpaperAccent || isGradient) return;
+    // Only act on a palette actually extracted from an image.
     if (source !== "cover" || !coverUrl) return;
     setWallpaperAccentColor(resolveWallpaperAccentFromPalette(palette));
-  }, [isWallpaperAccent, source, coverUrl, palette, setWallpaperAccentColor]);
+  }, [
+    isWallpaperAccent,
+    isGradient,
+    source,
+    coverUrl,
+    palette,
+    setWallpaperAccentColor,
+  ]);
+
+  // Day/night gradient: derive the accent from the live gradient's mid color
+  // and refresh on an interval so it tracks the day → night transition.
+  useEffect(() => {
+    if (!isWallpaperAccent || !isGradient) return;
+
+    const apply = () => {
+      const [, mid] = getDayNightGradientColors(new Date());
+      setWallpaperAccentColor(normalizeWallpaperAccentColor(rgbToHex(mid)));
+    };
+
+    apply();
+    const id = window.setInterval(apply, GRADIENT_ACCENT_REFRESH_MS);
+    return () => window.clearInterval(id);
+  }, [isWallpaperAccent, isGradient, setWallpaperAccentColor]);
 }

--- a/src/hooks/useWallpaperMenubarText.ts
+++ b/src/hooks/useWallpaperMenubarText.ts
@@ -1,18 +1,29 @@
 import { useEffect, useState } from "react";
 import { useWallpaper } from "@/hooks/useWallpaper";
 import { useThemeFlags } from "@/hooks/useThemeFlags";
+import { useNowPlayingCover } from "@/hooks/useNowPlayingCover";
 import {
   menubarTextColorForLuminance,
   menubarTextForTone,
   menubarTextToneForLuminance,
   sampleWallpaperTopLuminance,
+  wallpaperLuminance,
   type MenubarTextTone,
 } from "@/themes/wallpaperMenubarText";
+import {
+  getDayNightGradientColors,
+  isCoverWallpaper,
+  isDayNightGradientWallpaper,
+} from "@/utils/dynamicWallpaper";
 
 export interface WallpaperMenubarText {
   textColor: string;
   tone: MenubarTextTone;
 }
+
+// The gradient drifts with wall-clock time, so re-derive its tone on a slow
+// interval to keep the menubar tracking the day → night shift.
+const GRADIENT_MENUBAR_REFRESH_MS = 60 * 1000;
 
 function fallbackMenubarText(isDarkMode: boolean): WallpaperMenubarText {
   const tone: MenubarTextTone = isDarkMode ? "light" : "dark";
@@ -74,28 +85,50 @@ function cacheLuminance(source: string, luminance: number) {
  * color. Only meaningful for Aqua Glass (transparent menubar); callers should
  * pass `enabled: isAquaGlass`.
  */
+function gradientMenubarText(): WallpaperMenubarText {
+  // The top gradient color is the strip directly behind the menubar.
+  const [top] = getDayNightGradientColors(new Date());
+  return menubarTextForLuminance(wallpaperLuminance(top[0], top[1], top[2]));
+}
+
 export function useWallpaperMenubarText(enabled: boolean): WallpaperMenubarText {
-  const { wallpaperSource, isVideoWallpaper } = useWallpaper();
+  const { currentWallpaper, wallpaperSource, isVideoWallpaper } =
+    useWallpaper();
   const { isDarkMode } = useThemeFlags();
+
+  const isGradient = isDayNightGradientWallpaper(currentWallpaper);
+  const isCover = isCoverWallpaper(currentWallpaper);
+  const { coverUrl: nowPlayingCoverUrl } = useNowPlayingCover();
+
+  // Image URL sampled for the menubar tone. The gradient has no loadable image
+  // (handled live below); the cover wallpaper samples its album art; videos and
+  // the inactive state sample nothing.
+  let sampleSource: string | null = null;
+  if (!isGradient) {
+    if (isCover) sampleSource = nowPlayingCoverUrl;
+    else if (!isVideoWallpaper) sampleSource = wallpaperSource || null;
+  }
+
   const [result, setResult] = useState<WallpaperMenubarText>(() => {
-    if (enabled && wallpaperSource && !isVideoWallpaper) {
+    if (enabled && isGradient) return gradientMenubarText();
+    if (enabled && sampleSource) {
       ensurePersistedLoaded();
-      const cached = luminanceCache.get(wallpaperSource);
+      const cached = luminanceCache.get(sampleSource);
       if (cached !== undefined) return menubarTextForLuminance(cached);
     }
     return fallbackMenubarText(isDarkMode);
   });
 
   useEffect(() => {
-    if (!enabled) return;
+    if (!enabled || isGradient) return;
 
-    if (isVideoWallpaper || !wallpaperSource) {
+    if (!sampleSource) {
       setResult(fallbackMenubarText(isDarkMode));
       return;
     }
 
     ensurePersistedLoaded();
-    const cached = luminanceCache.get(wallpaperSource);
+    const cached = luminanceCache.get(sampleSource);
     if (cached !== undefined) {
       setResult(menubarTextForLuminance(cached));
       return;
@@ -115,7 +148,7 @@ export function useWallpaperMenubarText(enabled: boolean): WallpaperMenubarText 
           setResult(fallbackMenubarText(isDarkMode));
           return;
         }
-        cacheLuminance(wallpaperSource, luminance);
+        cacheLuminance(sampleSource, luminance);
         setResult(menubarTextForLuminance(luminance));
       } catch {
         setResult(fallbackMenubarText(isDarkMode));
@@ -126,11 +159,23 @@ export function useWallpaperMenubarText(enabled: boolean): WallpaperMenubarText 
       if (!cancelled) setResult(fallbackMenubarText(isDarkMode));
     };
 
-    img.src = wallpaperSource;
+    img.src = sampleSource;
     return () => {
       cancelled = true;
     };
-  }, [enabled, wallpaperSource, isVideoWallpaper, isDarkMode]);
+  }, [enabled, isGradient, sampleSource, isDarkMode]);
+
+  // Day/night gradient: derive the tone from the live top gradient color and
+  // refresh on an interval so the menubar tracks the day → night transition.
+  useEffect(() => {
+    if (!enabled || !isGradient) return;
+
+    const apply = () => setResult(gradientMenubarText());
+
+    apply();
+    const id = window.setInterval(apply, GRADIENT_MENUBAR_REFRESH_MS);
+    return () => window.clearInterval(id);
+  }, [enabled, isGradient]);
 
   return result;
 }

--- a/src/lib/locales/de/translation.json
+++ b/src/lib/locales/de/translation.json
@@ -1386,6 +1386,11 @@
       "displayMode": "Anzeigemodus",
       "downloadMacApp": "Mac-App herunterladen",
       "dream": "Traum",
+      "dynamicWallpapers": {
+        "dayNight": "Tag & Nacht",
+        "nowPlaying": "Läuft gerade",
+        "shuffle": "Zufällig"
+      },
       "elevenlabs": "ElevenLabs",
       "elevenlabsVoiceId": "ElevenLabs Sprach-ID",
       "errorBoundaries": "Fehlergrenzen",
@@ -1551,6 +1556,7 @@
         "aqua": "Aqua",
         "black_and_white": "Schwarzweiß",
         "convergency": "Konvergenz",
+        "dynamic": "Dynamisch",
         "foliage": "Blattwerk",
         "graphics": "Grafiken",
         "landscapes": "Landschaften",

--- a/src/lib/locales/en/translation.json
+++ b/src/lib/locales/en/translation.json
@@ -3072,6 +3072,7 @@
       "noWallpapers": "No wallpapers",
       "iosVolumeHint": "On iOS, use hardware buttons to control media volume",
       "wallpaperCategories": {
+        "dynamic": "Dynamic",
         "landscapes": "Landscapes",
         "structures": "Structures",
         "objects": "Objects",
@@ -3083,6 +3084,11 @@
         "nature": "Nature",
         "plants": "Plants",
         "black_and_white": "Black & White"
+      },
+      "dynamicWallpapers": {
+        "dayNight": "Day & Night",
+        "nowPlaying": "Now Playing",
+        "shuffle": "Shuffle"
       },
       "alerts": {
         "selectImageFile": "Please select an image file. Videos are not supported.",

--- a/src/lib/locales/es/translation.json
+++ b/src/lib/locales/es/translation.json
@@ -1386,6 +1386,11 @@
       "displayMode": "Modo de visualización",
       "downloadMacApp": "Descargar app para Mac",
       "dream": "Sueño",
+      "dynamicWallpapers": {
+        "dayNight": "Día y noche",
+        "nowPlaying": "Reproduciendo ahora",
+        "shuffle": "Aleatorio"
+      },
       "elevenlabs": "ElevenLabs",
       "elevenlabsVoiceId": "ID de voz de ElevenLabs",
       "errorBoundaries": "Límites de error",
@@ -1551,6 +1556,7 @@
         "aqua": "Aqua",
         "black_and_white": "Blanco y negro",
         "convergency": "Convergencia",
+        "dynamic": "Dinámico",
         "foliage": "Follaje",
         "graphics": "Gráficos",
         "landscapes": "Paisajes",

--- a/src/lib/locales/fr/translation.json
+++ b/src/lib/locales/fr/translation.json
@@ -1386,6 +1386,11 @@
       "displayMode": "Mode d'affichage",
       "downloadMacApp": "Télécharger l'app Mac",
       "dream": "Rêve",
+      "dynamicWallpapers": {
+        "dayNight": "Jour et nuit",
+        "nowPlaying": "À l'écoute",
+        "shuffle": "Aléatoire"
+      },
       "elevenlabs": "ElevenLabs",
       "elevenlabsVoiceId": "Identifiant vocal ElevenLabs",
       "errorBoundaries": "Limites d'erreur",
@@ -1551,6 +1556,7 @@
         "aqua": "Aqua",
         "black_and_white": "Noir et blanc",
         "convergency": "Convergence",
+        "dynamic": "Dynamique",
         "foliage": "Feuillage",
         "graphics": "Graphiques",
         "landscapes": "Paysages",

--- a/src/lib/locales/it/translation.json
+++ b/src/lib/locales/it/translation.json
@@ -1386,6 +1386,11 @@
       "displayMode": "Modalità di visualizzazione",
       "downloadMacApp": "Scarica App Mac",
       "dream": "Sogno",
+      "dynamicWallpapers": {
+        "dayNight": "Giorno e notte",
+        "nowPlaying": "In riproduzione",
+        "shuffle": "Casuale"
+      },
       "elevenlabs": "ElevenLabs",
       "elevenlabsVoiceId": "ID Voce ElevenLabs",
       "errorBoundaries": "Limiti di errore",
@@ -1551,6 +1556,7 @@
         "aqua": "Aqua",
         "black_and_white": "Bianco e nero",
         "convergency": "Convergenza",
+        "dynamic": "Dinamico",
         "foliage": "Fogliame",
         "graphics": "Grafica",
         "landscapes": "Paesaggi",

--- a/src/lib/locales/ja/translation.json
+++ b/src/lib/locales/ja/translation.json
@@ -1386,6 +1386,11 @@
       "displayMode": "表示モード",
       "downloadMacApp": "Macアプリをダウンロード",
       "dream": "ドリーム",
+      "dynamicWallpapers": {
+        "dayNight": "デイ＆ナイト",
+        "nowPlaying": "再生中",
+        "shuffle": "シャッフル"
+      },
       "elevenlabs": "ElevenLabs",
       "elevenlabsVoiceId": "ElevenLabs 音声ID",
       "errorBoundaries": "エラー境界",
@@ -1551,6 +1556,7 @@
         "aqua": "アクア",
         "black_and_white": "白黒",
         "convergency": "コンバージェンス",
+        "dynamic": "ダイナミック",
         "foliage": "フォリッジ",
         "graphics": "グラフィックス",
         "landscapes": "風景",

--- a/src/lib/locales/ko/translation.json
+++ b/src/lib/locales/ko/translation.json
@@ -1386,6 +1386,11 @@
       "displayMode": "디스플레이 모드",
       "downloadMacApp": "Mac 앱 다운로드",
       "dream": "꿈",
+      "dynamicWallpapers": {
+        "dayNight": "주간 및 야간",
+        "nowPlaying": "지금 재생 중",
+        "shuffle": "임의 재생"
+      },
       "elevenlabs": "일레븐랩스",
       "elevenlabsVoiceId": "일레븐랩스 음성 ID",
       "errorBoundaries": "오류 경계",
@@ -1551,6 +1556,7 @@
         "aqua": "아쿠아",
         "black_and_white": "흑백",
         "convergency": "수렴",
+        "dynamic": "다이내믹",
         "foliage": "나뭇잎",
         "graphics": "그래픽",
         "landscapes": "풍경",

--- a/src/lib/locales/pt/translation.json
+++ b/src/lib/locales/pt/translation.json
@@ -1386,6 +1386,11 @@
       "displayMode": "Modo de Exibição",
       "downloadMacApp": "Baixar App para Mac",
       "dream": "Sonho",
+      "dynamicWallpapers": {
+        "dayNight": "Dia e Noite",
+        "nowPlaying": "Reproduzindo agora",
+        "shuffle": "Aleatório"
+      },
       "elevenlabs": "ElevenLabs",
       "elevenlabsVoiceId": "ID de Voz ElevenLabs",
       "errorBoundaries": "Limites de Erro",
@@ -1551,6 +1556,7 @@
         "aqua": "Aqua",
         "black_and_white": "Preto e branco",
         "convergency": "Convergência",
+        "dynamic": "Dinâmico",
         "foliage": "Folhagem",
         "graphics": "Gráficos",
         "landscapes": "Paisagens",

--- a/src/lib/locales/ru/translation.json
+++ b/src/lib/locales/ru/translation.json
@@ -1386,6 +1386,11 @@
       "displayMode": "Режим отображения",
       "downloadMacApp": "Скачать приложение Mac",
       "dream": "Мечта",
+      "dynamicWallpapers": {
+        "dayNight": "День и ночь",
+        "nowPlaying": "Сейчас играет",
+        "shuffle": "Перемешать"
+      },
       "elevenlabs": "ElevenLabs",
       "elevenlabsVoiceId": "ID голоса ElevenLabs",
       "errorBoundaries": "Границы ошибок",
@@ -1551,6 +1556,7 @@
         "aqua": "Аква",
         "black_and_white": "Чёрно-белое",
         "convergency": "Конвергенция",
+        "dynamic": "Динамический",
         "foliage": "Листва",
         "graphics": "Графика",
         "landscapes": "Пейзажи",

--- a/src/lib/locales/zh-TW/translation.json
+++ b/src/lib/locales/zh-TW/translation.json
@@ -1386,6 +1386,11 @@
       "displayMode": "顯示模式",
       "downloadMacApp": "下載 Mac 應用程式",
       "dream": "夢幻",
+      "dynamicWallpapers": {
+        "dayNight": "日與夜",
+        "nowPlaying": "播放中",
+        "shuffle": "隨機播放"
+      },
       "elevenlabs": "ElevenLabs",
       "elevenlabsVoiceId": "ElevenLabs 語音 ID",
       "errorBoundaries": "錯誤邊界",
@@ -1551,6 +1556,7 @@
         "aqua": "水藍",
         "black_and_white": "黑白",
         "convergency": "匯聚",
+        "dynamic": "動態",
         "foliage": "綠葉",
         "graphics": "圖形",
         "landscapes": "風景",

--- a/src/stores/useDisplaySettingsStore.ts
+++ b/src/stores/useDisplaySettingsStore.ts
@@ -93,6 +93,13 @@ interface DisplaySettingsState {
   wallpaperSource: string;
   setCurrentWallpaper: (p: string) => void;
   setWallpaper: (p: string | File) => Promise<void>;
+  /**
+   * Update only the *rendered* wallpaper source without changing the persisted
+   * `currentWallpaper` selection. Used by dynamic wallpapers (e.g. shuffle) that
+   * resolve a concrete asset to display while keeping the user's chosen
+   * descriptor intact.
+   */
+  setRuntimeWallpaperSource: (src: string) => void;
   loadCustomWallpapers: () => Promise<string[]>;
   deleteCustomWallpaper: (reference: string) => Promise<void>;
   getWallpaperData: (reference: string) => Promise<string | null>;
@@ -154,6 +161,11 @@ export const useDisplaySettingsStore = create<DisplaySettingsState>()(
         track(SETTINGS_ANALYTICS.WALLPAPER_CHANGE, {
           wallpaperKind: p.startsWith(INDEXEDDB_PREFIX) ? "custom" : "built-in",
         });
+      },
+
+      setRuntimeWallpaperSource: (src) => {
+        if (get().wallpaperSource === src) return;
+        set({ wallpaperSource: src });
       },
 
       setWallpaper: async (path) => {

--- a/src/utils/dynamicWallpaper.ts
+++ b/src/utils/dynamicWallpaper.ts
@@ -1,0 +1,200 @@
+// Dynamic wallpaper descriptors.
+//
+// The desktop wallpaper is stored as a plain string in
+// `useDisplaySettingsStore.currentWallpaper`. Most values are concrete asset
+// paths (e.g. `/wallpapers/photos/aqua/abstract-7.jpg`) or `indexeddb://…`
+// references. The schemes below describe *dynamic* wallpapers whose rendered
+// pixels change over time:
+//
+//   - `dynamic://gradient/day-night` — a gradient that shifts with wall-clock
+//     time of day.
+//   - `dynamic://cover`              — the now-playing cover art of the iPod or
+//     Karaoke (falls back to the paused cover).
+//   - `shuffle://photos/<category>`  — a random photo from a picker category,
+//     swapped every {@link SHUFFLE_INTERVAL_MS}.
+//   - `shuffle://tiles`              — a random tiled pattern, rotated likewise.
+//   - `shuffle://videos`             — a random video wallpaper, rotated likewise.
+
+import type { WallpaperManifest } from "@/utils/wallpapers";
+
+export const DYNAMIC_PREFIX = "dynamic://";
+export const SHUFFLE_PREFIX = "shuffle://";
+
+export const DAY_NIGHT_GRADIENT_WALLPAPER = "dynamic://gradient/day-night";
+export const COVER_WALLPAPER = "dynamic://cover";
+
+/** How often shuffle wallpapers swap to a new random pick. */
+export const SHUFFLE_INTERVAL_MS = 2 * 60 * 1000;
+
+export function isDynamicWallpaper(wallpaper: string | undefined | null): boolean {
+  return (
+    !!wallpaper &&
+    (wallpaper.startsWith(DYNAMIC_PREFIX) || wallpaper.startsWith(SHUFFLE_PREFIX))
+  );
+}
+
+export function isDayNightGradientWallpaper(
+  wallpaper: string | undefined | null
+): boolean {
+  return wallpaper === DAY_NIGHT_GRADIENT_WALLPAPER;
+}
+
+export function isCoverWallpaper(wallpaper: string | undefined | null): boolean {
+  return wallpaper === COVER_WALLPAPER;
+}
+
+export function isShuffleWallpaper(
+  wallpaper: string | undefined | null
+): boolean {
+  return !!wallpaper && wallpaper.startsWith(SHUFFLE_PREFIX);
+}
+
+export type ShuffleTarget =
+  | { kind: "tiles" }
+  | { kind: "videos" }
+  | { kind: "photos"; category: string };
+
+/** Build the descriptor stored for a "shuffle this category" selection. */
+export function buildShuffleDescriptor(
+  category: "tiles" | "videos" | string
+): string {
+  if (category === "tiles") return `${SHUFFLE_PREFIX}tiles`;
+  if (category === "videos") return `${SHUFFLE_PREFIX}videos`;
+  return `${SHUFFLE_PREFIX}photos/${category}`;
+}
+
+/** Parse a shuffle descriptor into its target category. */
+export function parseShuffleDescriptor(
+  wallpaper: string | undefined | null
+): ShuffleTarget | null {
+  if (!wallpaper || !wallpaper.startsWith(SHUFFLE_PREFIX)) return null;
+  const rest = wallpaper.slice(SHUFFLE_PREFIX.length);
+  if (rest === "tiles") return { kind: "tiles" };
+  if (rest === "videos") return { kind: "videos" };
+  if (rest.startsWith("photos/")) {
+    const category = rest.slice("photos/".length);
+    if (category) return { kind: "photos", category };
+  }
+  return null;
+}
+
+/** Resolve the full `/wallpapers/…` candidate paths for a shuffle descriptor. */
+export function getShuffleCandidatePaths(
+  manifest: WallpaperManifest,
+  target: ShuffleTarget
+): string[] {
+  let relative: string[] = [];
+  if (target.kind === "tiles") relative = manifest.tiles ?? [];
+  else if (target.kind === "videos") relative = manifest.videos ?? [];
+  else relative = manifest.photos?.[target.category] ?? [];
+  return relative.map((p) => `/wallpapers/${p}`);
+}
+
+/** Pick a random candidate, preferring one different from `exclude`. */
+export function pickRandomCandidate(
+  candidates: string[],
+  exclude?: string | null
+): string | null {
+  if (candidates.length === 0) return null;
+  if (candidates.length === 1) return candidates[0];
+  const pool = exclude
+    ? candidates.filter((c) => c !== exclude)
+    : candidates;
+  const list = pool.length > 0 ? pool : candidates;
+  return list[Math.floor(Math.random() * list.length)];
+}
+
+// ---------------------------------------------------------------------------
+// Day / night gradient
+// ---------------------------------------------------------------------------
+
+type RGB = [number, number, number];
+
+interface GradientKeyframe {
+  /** Hour of day in [0, 24). */
+  hour: number;
+  /** Top, middle, and bottom gradient colors (sky → horizon). */
+  colors: [RGB, RGB, RGB];
+}
+
+const hexToRgb = (hex: string): RGB => {
+  const n = parseInt(hex.replace("#", ""), 16);
+  return [(n >> 16) & 0xff, (n >> 8) & 0xff, n & 0xff];
+};
+
+const k = (
+  hour: number,
+  top: string,
+  mid: string,
+  bottom: string
+): GradientKeyframe => ({
+  hour,
+  colors: [hexToRgb(top), hexToRgb(mid), hexToRgb(bottom)],
+});
+
+// Keyframes across the day. Ordered by hour; the renderer wraps around so the
+// 21:00 dusk smoothly returns to the 0:00 deep night.
+const DAY_NIGHT_KEYFRAMES: GradientKeyframe[] = [
+  k(0, "#0a0f2c", "#11163a", "#1c2350"), // deep night
+  k(5, "#1a1f44", "#3a2f55", "#5a3a63"), // pre-dawn
+  k(6.5, "#5b6a9e", "#b98aa0", "#f0a878"), // dawn
+  k(8, "#3a7bd5", "#6fb1e3", "#cfe8f5"), // morning
+  k(12, "#2980d9", "#6dd5fa", "#d6f0ff"), // midday
+  k(16, "#2e8bd6", "#87cefa", "#eaf6ff"), // afternoon
+  k(18, "#5b6aa0", "#e8896f", "#f2b15a"), // golden hour
+  k(19.5, "#2a2350", "#7a3b6e", "#c75b54"), // sunset
+  k(21, "#14123a", "#2a2350", "#422a5a"), // dusk
+];
+
+const lerp = (a: number, b: number, t: number) => a + (b - a) * t;
+
+const lerpRgb = (a: RGB, b: RGB, t: number): RGB => [
+  Math.round(lerp(a[0], b[0], t)),
+  Math.round(lerp(a[1], b[1], t)),
+  Math.round(lerp(a[2], b[2], t)),
+];
+
+const rgbToCss = ([r, g, b]: RGB) => `rgb(${r}, ${g}, ${b})`;
+
+/** Compute the interpolated [top, mid, bottom] colors for a given time. */
+export function getDayNightGradientColors(date: Date = new Date()): [RGB, RGB, RGB] {
+  const hour = date.getHours() + date.getMinutes() / 60 + date.getSeconds() / 3600;
+
+  const frames = DAY_NIGHT_KEYFRAMES;
+  // Find the surrounding keyframes (with wraparound past the last one).
+  let start = frames[frames.length - 1];
+  let end = frames[0];
+  let startHour = start.hour - 24; // place the wrap-around frame before 0
+  let endHour = end.hour;
+
+  for (let i = 0; i < frames.length; i++) {
+    const cur = frames[i];
+    const next = frames[(i + 1) % frames.length];
+    const curHour = cur.hour;
+    const nextHour = i + 1 < frames.length ? next.hour : 24 + frames[0].hour;
+    if (hour >= curHour && hour < nextHour) {
+      start = cur;
+      end = next;
+      startHour = curHour;
+      endHour = nextHour;
+      break;
+    }
+  }
+
+  const span = endHour - startHour;
+  const t = span > 0 ? (hour - startHour) / span : 0;
+
+  return [
+    lerpRgb(start.colors[0], end.colors[0], t),
+    lerpRgb(start.colors[1], end.colors[1], t),
+    lerpRgb(start.colors[2], end.colors[2], t),
+  ];
+}
+
+/** Build a CSS `linear-gradient(...)` string for the current time of day. */
+export function getDayNightGradientCss(date: Date = new Date()): string {
+  const [top, mid, bottom] = getDayNightGradientColors(date);
+  return `linear-gradient(to bottom, ${rgbToCss(top)} 0%, ${rgbToCss(
+    mid
+  )} 55%, ${rgbToCss(bottom)} 100%)`;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a new set of **dynamic** wallpaper options to the Control Panels → Appearance wallpaper picker:

- **Day & Night gradient** — a desktop gradient whose colors shift continuously with the wall-clock time of day (deep night → dawn → midday → golden hour → dusk).
- **Now Playing cover** — uses the current cover art of the iPod or Karaoke player (falls back to the paused cover, or a neutral gradient when nothing is playing). Prefers whichever player is actively playing.
- **Per-category Shuffle** — every photo category (Aqua, Nature, …), Patterns, and Videos gets a Shuffle tile. When selected, the system picks a random wallpaper from that category and swaps to a new random one every 2 minutes.

## Implementation

- New descriptor schemes stored in `currentWallpaper`: `dynamic://gradient/day-night`, `dynamic://cover`, `shuffle://photos/<category>`, `shuffle://tiles`, `shuffle://videos`. Helpers + day/night gradient math live in `src/utils/dynamicWallpaper.ts`.
- `useShuffleWallpaper` resolves shuffle descriptors into a concrete rotating asset written to the store's runtime `wallpaperSource` (via new `setRuntimeWallpaperSource`), so the desktop, menubar tint, and accent sampling all see a real image while the persisted selection stays the shuffle descriptor.
- `useNowPlayingCover` resolves the active iPod/Karaoke cover art with player precedence.
- `DesktopDynamicWallpaper` renders the gradient / cover layers behind desktop icons; `getWallpaperStyles` suppresses the CSS background for dynamic descriptors.
- `WallpaperPicker` gains a **Dynamic** category plus per-category Shuffle tiles, and category derivation maps the new descriptors back to the right tab.
- English localization keys added under `wallpaperCategories.dynamic` and `dynamicWallpapers.*`.

## Testing

- `bun run build` ✅
- `eslint` on changed files ✅ (only pre-existing warnings)
- Manual verification in the browser (see walkthrough).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ec46d-162e-796b-8f44-dccb2d3faa97"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ec46d-162e-796b-8f44-dccb2d3faa97"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

