### PR TITLE
Admin View menu lists rooms in a submenu

### DIFF
--- a/src/apps/admin/components/AdminMenuBar.tsx
+++ b/src/apps/admin/components/AdminMenuBar.tsx
@@ -63,43 +63,17 @@ export function AdminMenuBar({
 
   const publicRooms = rooms.filter((r) => r.type !== "private");
 
-  const roomsSubmenuItems: MenuDescriptor["items"] = [
-    {
-      type: "checkbox",
-      label: t("apps.admin.menu.allRooms", "All Rooms"),
-      checked: activeSection === "rooms" && selectedRoomId === null,
-      onChange: (checked) => {
-        if (checked) {
-          onSectionChange("rooms");
-          onRoomSelect(null);
-        }
-      },
+  const roomsSubmenuItems: MenuDescriptor["items"] = publicRooms.map((room) => ({
+    type: "checkbox",
+    label: `#${room.name}`,
+    checked: activeSection === "rooms" && selectedRoomId === room.id,
+    onChange: (checked) => {
+      if (checked) {
+        onSectionChange("rooms");
+        onRoomSelect(room.id);
+      }
     },
-  ];
-
-  if (publicRooms.length > 0) {
-    roomsSubmenuItems.push({ type: "separator" });
-    for (const room of publicRooms) {
-      roomsSubmenuItems.push({
-        type: "checkbox",
-        label: `#${room.name}`,
-        checked: activeSection === "rooms" && selectedRoomId === room.id,
-        onChange: (checked) => {
-          if (checked) {
-            onSectionChange("rooms");
-            onRoomSelect(room.id);
-          }
-        },
-      });
-    }
-  } else {
-    roomsSubmenuItems.push({
-      type: "action",
-      label: t("apps.admin.menu.noRooms", "No rooms"),
-      onClick: () => {},
-      disabled: true,
-    });
-  }
+  }));
 
   const menus: MenuDescriptor[] = [
     {
@@ -133,6 +107,7 @@ export function AdminMenuBar({
           type: "submenu",
           label: t("apps.admin.sidebar.rooms"),
           items: roomsSubmenuItems,
+          disabled: roomsSubmenuItems.length === 0,
         },
         { type: "separator" },
         {

--- a/src/apps/admin/components/AdminMenuBar.tsx
+++ b/src/apps/admin/components/AdminMenuBar.tsx
@@ -7,6 +7,13 @@ import { useAppMenuBarChrome } from "@/hooks/useAppMenuBarChrome";
 import { useTranslation } from "react-i18next";
 import type { AdminSection } from "../utils/navigationState";
 
+interface AdminMenuBarRoom {
+  id: string;
+  name: string;
+  type: "public" | "private" | "irc";
+  userCount: number;
+}
+
 interface AdminMenuBarProps {
   onClose: () => void;
   onShowHelp: () => void;
@@ -16,6 +23,9 @@ interface AdminMenuBarProps {
   isSidebarVisible: boolean;
   activeSection: AdminSection;
   onSectionChange: (section: AdminSection) => void;
+  rooms: AdminMenuBarRoom[];
+  selectedRoomId: string | null;
+  onRoomSelect: (roomId: string | null) => void;
 }
 
 export function AdminMenuBar({
@@ -27,6 +37,9 @@ export function AdminMenuBar({
   isSidebarVisible,
   activeSection,
   onSectionChange,
+  rooms,
+  selectedRoomId,
+  onRoomSelect,
 }: AdminMenuBarProps) {
   const { t } = useTranslation();
   const {
@@ -47,6 +60,46 @@ export function AdminMenuBar({
         if (checked) onSectionChange(section);
       },
     } as const);
+
+  const publicRooms = rooms.filter((r) => r.type !== "private");
+
+  const roomsSubmenuItems: MenuDescriptor["items"] = [
+    {
+      type: "checkbox",
+      label: t("apps.admin.menu.allRooms", "All Rooms"),
+      checked: activeSection === "rooms" && selectedRoomId === null,
+      onChange: (checked) => {
+        if (checked) {
+          onSectionChange("rooms");
+          onRoomSelect(null);
+        }
+      },
+    },
+  ];
+
+  if (publicRooms.length > 0) {
+    roomsSubmenuItems.push({ type: "separator" });
+    for (const room of publicRooms) {
+      roomsSubmenuItems.push({
+        type: "checkbox",
+        label: `#${room.name}`,
+        checked: activeSection === "rooms" && selectedRoomId === room.id,
+        onChange: (checked) => {
+          if (checked) {
+            onSectionChange("rooms");
+            onRoomSelect(room.id);
+          }
+        },
+      });
+    }
+  } else {
+    roomsSubmenuItems.push({
+      type: "action",
+      label: t("apps.admin.menu.noRooms", "No rooms"),
+      onClick: () => {},
+      disabled: true,
+    });
+  }
 
   const menus: MenuDescriptor[] = [
     {
@@ -76,7 +129,11 @@ export function AdminMenuBar({
           t("apps.admin.sidebar.cursorAgents", "Cursor Agents")
         ),
         { type: "separator" },
-        sectionCheckbox("rooms", t("apps.admin.sidebar.rooms")),
+        {
+          type: "submenu",
+          label: t("apps.admin.sidebar.rooms"),
+          items: roomsSubmenuItems,
+        },
         { type: "separator" },
         {
           type: "checkbox",

--- a/src/apps/admin/components/AdminMenuBar.tsx
+++ b/src/apps/admin/components/AdminMenuBar.tsx
@@ -63,7 +63,7 @@ export function AdminMenuBar({
 
   const publicRooms = rooms.filter((r) => r.type !== "private");
 
-  const roomsSubmenuItems: MenuDescriptor["items"] = publicRooms.map((room) => ({
+  const roomItems: MenuDescriptor["items"] = publicRooms.map((room) => ({
     type: "checkbox",
     label: `#${room.name}`,
     checked: activeSection === "rooms" && selectedRoomId === room.id,
@@ -102,13 +102,9 @@ export function AdminMenuBar({
           "cursorAgents",
           t("apps.admin.sidebar.cursorAgents", "Cursor Agents")
         ),
-        { type: "separator" },
-        {
-          type: "submenu",
-          label: t("apps.admin.sidebar.rooms"),
-          items: roomsSubmenuItems,
-          disabled: roomsSubmenuItems.length === 0,
-        },
+        ...(roomItems.length > 0
+          ? ([{ type: "separator" }, ...roomItems] as MenuDescriptor["items"])
+          : []),
         { type: "separator" },
         {
           type: "checkbox",

--- a/src/apps/admin/components/admin-app/AdminAppComponent.tsx
+++ b/src/apps/admin/components/admin-app/AdminAppComponent.tsx
@@ -100,6 +100,9 @@ export function AdminAppComponent({
       isSidebarVisible={isSidebarVisible}
       activeSection={activeSection}
       onSectionChange={setActiveSection}
+      rooms={rooms}
+      selectedRoomId={selectedRoomId}
+      onRoomSelect={setSelectedRoomId}
     />
   );
 

--- a/src/lib/locales/en/translation.json
+++ b/src/lib/locales/en/translation.json
@@ -3689,7 +3689,9 @@
         "refreshData": "Refresh Data",
         "showSidebar": "Show Sidebar",
         "adminHelp": "Admin Help",
-        "aboutAdmin": "About Admin"
+        "aboutAdmin": "About Admin",
+        "allRooms": "All Rooms",
+        "noRooms": "No rooms"
       },
       "sidebar": {
         "dashboard": "Dashboard",

--- a/src/lib/locales/en/translation.json
+++ b/src/lib/locales/en/translation.json
@@ -3689,9 +3689,7 @@
         "refreshData": "Refresh Data",
         "showSidebar": "Show Sidebar",
         "adminHelp": "Admin Help",
-        "aboutAdmin": "About Admin",
-        "allRooms": "All Rooms",
-        "noRooms": "No rooms"
+        "aboutAdmin": "About Admin"
       },
       "sidebar": {
         "dashboard": "Dashboard",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

In the Admin app's menu bar, the **View** menu previously had a single "Rooms" checkbox. The rooms are now listed flat as a section directly in the View menu (separated by a divider), rather than nested in a submenu.

Each room shows as `#room-name` and navigates to / selects that room when clicked (checkmark reflects the active selection). When there are no rooms, the section is omitted entirely.

## Changes
- `AdminMenuBar.tsx`: accept `rooms`, `selectedRoomId`, `onRoomSelect`; render room checkboxes inline in the View menu as a separated section.
- `AdminAppComponent.tsx`: pass `rooms`, `selectedRoomId`, and `setSelectedRoomId` to the menu bar.

## Testing
- `tsc -b` passes.
- `eslint` passes on changed files.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ec477-179e-78bd-8f97-3585699d4666"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ec477-179e-78bd-8f97-3585699d4666"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

