### PR TITLE
fix(wallpaper): now-playing cover fills desktop fully

### DIFF
--- a/src/components/layout/desktop/DesktopDynamicWallpaper.tsx
+++ b/src/components/layout/desktop/DesktopDynamicWallpaper.tsx
@@ -48,23 +48,12 @@ function CoverWallpaperLayer() {
             exit={{ opacity: 0 }}
             transition={{ duration: 0.6 }}
           >
-            {/* Blurred, scaled fill so any aspect ratio covers the desktop. */}
+            {/* Full-bleed cover: fills the entire desktop, cropping as needed. */}
             <div
               className="absolute inset-0 w-full h-full"
               style={{
                 backgroundImage: `url("${coverUrl}")`,
                 backgroundSize: "cover",
-                backgroundPosition: "center",
-                filter: "blur(48px) saturate(1.2)",
-                transform: "scale(1.2)",
-              }}
-            />
-            {/* Sharp, centered cover floating on top of the blur. */}
-            <div
-              className="absolute inset-0 w-full h-full"
-              style={{
-                backgroundImage: `url("${coverUrl}")`,
-                backgroundSize: "contain",
                 backgroundPosition: "center",
                 backgroundRepeat: "no-repeat",
               }}


### PR DESCRIPTION
## Summary
- Simplifies `CoverWallpaperLayer` in `DesktopDynamicWallpaper.tsx` so the Now Playing cover fills the entire desktop.
- Removes the blurred/scaled backdrop layer and the letterboxed `contain` layer, leaving a single full-bleed `background-size: cover` layer (cropping as needed).
- Keeps the dark `bg-black/25` readability overlay, the empty-state fallback, and the `AnimatePresence` crossfade.

Follow-up to #1500.

## Test plan
- [x] `npx tsc --noEmit -p tsconfig.json`
- [x] `npx eslint src/components/layout/desktop/DesktopDynamicWallpaper.tsx`
- [ ] Visually confirm the Now Playing cover fills the desktop full-bleed.

Made with [Cursor](https://cursor.com)