### PR TITLE
Add Weather and Lyrics dynamic wallpapers

### DIFF
--- a/src/apps/control-panels/components/WallpaperPicker.tsx
+++ b/src/apps/control-panels/components/WallpaperPicker.tsx
@@ -16,6 +16,8 @@ import {
   Shuffle,
   MusicNotes,
   Sun,
+  CloudSun,
+  Microphone,
 } from "@phosphor-icons/react";
 import { useDisplaySettingsStore } from "@/stores/useDisplaySettingsStore";
 import { loadWallpaperManifest } from "@/utils/wallpapers";
@@ -24,13 +26,19 @@ import { useNowPlayingCover } from "@/hooks/useNowPlayingCover";
 import {
   COVER_WALLPAPER,
   DAY_NIGHT_GRADIENT_WALLPAPER,
+  LYRICS_WALLPAPER,
+  WEATHER_WALLPAPER,
   buildShuffleDescriptor,
   getDayNightGradientCss,
+  getWeatherGradientCss,
   isCoverWallpaper,
   isDayNightGradientWallpaper,
+  isLyricsWallpaper,
   isShuffleWallpaper,
+  isWeatherWallpaper,
   parseShuffleDescriptor,
 } from "@/utils/dynamicWallpaper";
+import { DEFAULT_COVER_PALETTE } from "@/hooks/useCoverPalette";
 import { useTranslation } from "react-i18next";
 
 // Remove unused constants
@@ -303,10 +311,24 @@ export function WallpaperPicker({ onSelect }: WallpaperPickerProps) {
   const nowPlaying = useNowPlayingCover();
   // Preview the gradient for the current time of day (static within a session).
   const dayNightPreview = useMemo(() => getDayNightGradientCss(), []);
+  // Weather preview uses an overcast/partly-cloudy treatment so it reads as a
+  // distinct "weather" tile while still tracking the current time of day.
+  const weatherPreview = useMemo(() => getWeatherGradientCss(3), []);
+  // Static fallback preview for the lyrics tile when nothing is playing.
+  const lyricsPreview = useMemo(
+    () =>
+      `linear-gradient(135deg, ${DEFAULT_COVER_PALETTE[0]} 0%, ${DEFAULT_COVER_PALETTE[2]} 50%, ${DEFAULT_COVER_PALETTE[4]} 100%)`,
+    []
+  );
   const deriveCategoryFromWallpaper = (
     wallpaper: string
   ): "tiles" | PhotoCategory => {
-    if (isDayNightGradientWallpaper(wallpaper) || isCoverWallpaper(wallpaper))
+    if (
+      isDayNightGradientWallpaper(wallpaper) ||
+      isWeatherWallpaper(wallpaper) ||
+      isCoverWallpaper(wallpaper) ||
+      isLyricsWallpaper(wallpaper)
+    )
       return "dynamic";
     const shuffleTarget = parseShuffleDescriptor(wallpaper);
     if (shuffleTarget) {
@@ -688,6 +710,13 @@ export function WallpaperPicker({ onSelect }: WallpaperPickerProps) {
                 icon={<Sun className="size-6 text-white" weight="fill" />}
               />
               <SpecialTile
+                label={t("apps.control-panels.dynamicWallpapers.weather")}
+                isSelected={isWeatherWallpaper(currentWallpaper)}
+                onClick={() => handleWallpaperSelect(WEATHER_WALLPAPER)}
+                backgroundStyle={{ backgroundImage: weatherPreview }}
+                icon={<CloudSun className="size-6 text-white" weight="fill" />}
+              />
+              <SpecialTile
                 label={t("apps.control-panels.dynamicWallpapers.nowPlaying")}
                 isSelected={isCoverWallpaper(currentWallpaper)}
                 onClick={() => handleWallpaperSelect(COVER_WALLPAPER)}
@@ -705,6 +734,22 @@ export function WallpaperPicker({ onSelect }: WallpaperPickerProps) {
                     <MusicNotes className="size-6 text-white" weight="fill" />
                   )
                 }
+              />
+              <SpecialTile
+                label={t("apps.control-panels.dynamicWallpapers.lyrics")}
+                isSelected={isLyricsWallpaper(currentWallpaper)}
+                onClick={() => handleWallpaperSelect(LYRICS_WALLPAPER)}
+                scrim={Boolean(nowPlaying.coverUrl)}
+                backgroundStyle={
+                  nowPlaying.coverUrl
+                    ? {
+                        backgroundImage: `url("${nowPlaying.coverUrl}")`,
+                        backgroundSize: "cover",
+                        backgroundPosition: "center",
+                      }
+                    : { backgroundImage: lyricsPreview }
+                }
+                icon={<Microphone className="size-6 text-white" weight="fill" />}
               />
             </>
           ) : selectedCategory === "tiles" ? (

--- a/src/apps/ipod/hooks/useIpodPipActive.ts
+++ b/src/apps/ipod/hooks/useIpodPipActive.ts
@@ -1,0 +1,26 @@
+import { useAppStore } from "@/stores/useAppStore";
+import { useIpodStore } from "@/stores/useIpodStore";
+import { useIpodActiveLibrary } from "@/apps/ipod/hooks/useIpodActiveLibrary";
+
+/**
+ * True when the iPod "pop player" (Picture-in-Picture mini player) is currently
+ * shown on screen. Mirrors the render condition in `IpodPipPlayer`: an open iPod
+ * window is minimized (and not full-screen) while a current track is loaded.
+ *
+ * Useful for desktop chrome (e.g. the lyrics wallpaper) that needs to reserve
+ * extra bottom clearance so it doesn't sit underneath the floating player.
+ */
+export function useIpodPipActive(): boolean {
+  const ipodMinimized = useAppStore((s) =>
+    Object.values(s.instances).some(
+      (instance) =>
+        instance.appId === "ipod" && instance.isOpen && instance.isMinimized
+    )
+  );
+  const isFullScreen = useIpodStore((s) => s.isFullScreen);
+  const { tracks, currentIndex } = useIpodActiveLibrary();
+
+  return (
+    ipodMinimized && !isFullScreen && tracks.length > 0 && currentIndex >= 0
+  );
+}

--- a/src/components/layout/desktop/DesktopDynamicWallpaper.tsx
+++ b/src/components/layout/desktop/DesktopDynamicWallpaper.tsx
@@ -2,10 +2,17 @@ import { useEffect, useState } from "react";
 import { AnimatePresence, motion } from "motion/react";
 import { useWallpaper } from "@/hooks/useWallpaper";
 import { useNowPlayingCover } from "@/hooks/useNowPlayingCover";
+import { useWeatherWallpaper } from "@/hooks/useWeatherWallpaper";
+import { useNowPlayingLyrics } from "@/hooks/useNowPlayingLyrics";
+import { MeshGradientBackground } from "@/components/shared/MeshGradientBackground";
+import { LyricsDisplay } from "@/apps/ipod/components/lyrics-display/LyricsDisplay";
 import {
   getDayNightGradientCss,
+  getWeatherGradientCss,
   isCoverWallpaper,
   isDayNightGradientWallpaper,
+  isLyricsWallpaper,
+  isWeatherWallpaper,
 } from "@/utils/dynamicWallpaper";
 
 /** Recompute the day/night gradient roughly once a minute. */
@@ -30,6 +37,67 @@ function DayNightGradientLayer() {
         transition: "background-image 3s linear",
       }}
     />
+  );
+}
+
+function WeatherGradientLayer() {
+  const { weatherCode } = useWeatherWallpaper();
+  const [gradient, setGradient] = useState(() =>
+    getWeatherGradientCss(weatherCode)
+  );
+
+  // Recompute on the minute timer (time-of-day) and whenever the live weather
+  // code changes. The gradient reads the wall clock internally.
+  useEffect(() => {
+    const update = () => setGradient(getWeatherGradientCss(weatherCode));
+    update();
+    const id = setInterval(update, GRADIENT_REFRESH_MS);
+    return () => clearInterval(id);
+  }, [weatherCode]);
+
+  return (
+    <div
+      className="absolute inset-0 w-full h-full z-[-10]"
+      style={{
+        backgroundImage: gradient,
+        transition: "background-image 3s linear",
+      }}
+    />
+  );
+}
+
+function LyricsWallpaperLayer() {
+  const np = useNowPlayingLyrics();
+
+  return (
+    <div className="absolute inset-0 w-full h-full z-[-10] overflow-hidden bg-neutral-950">
+      {/* "Gradient paper" — the same animated Paper mesh-gradient shader the
+          iPod / Karaoke use, tinted by the now-playing cover art. */}
+      <MeshGradientBackground
+        coverUrl={np.coverUrl}
+        isActive
+        className="absolute inset-0 w-full h-full"
+      />
+      {/* Soft darkening keeps the lyrics and desktop icons readable. */}
+      <div className="absolute inset-0 w-full h-full bg-black/30" />
+      {np.hasLyrics && (
+        <LyricsDisplay
+          lines={np.lyricsControls.lines}
+          originalLines={np.lyricsControls.originalLines}
+          currentLine={np.lyricsControls.currentLine}
+          isLoading={np.lyricsControls.isLoading}
+          error={np.lyricsControls.error}
+          visible
+          videoVisible
+          fontClassName={np.lyricsFontClassName}
+          isTranslating={np.lyricsControls.isTranslating}
+          furiganaMap={np.furiganaMap}
+          soramimiMap={np.soramimiMap}
+          currentTimeMs={np.currentTimeMs}
+          showInterludeEllipsis
+        />
+      )}
+    </div>
   );
 }
 
@@ -92,8 +160,14 @@ export function DesktopDynamicWallpaper() {
   if (isDayNightGradientWallpaper(currentWallpaper)) {
     return <DayNightGradientLayer />;
   }
+  if (isWeatherWallpaper(currentWallpaper)) {
+    return <WeatherGradientLayer />;
+  }
   if (isCoverWallpaper(currentWallpaper)) {
     return <CoverWallpaperLayer />;
+  }
+  if (isLyricsWallpaper(currentWallpaper)) {
+    return <LyricsWallpaperLayer />;
   }
   return null;
 }

--- a/src/components/layout/desktop/DesktopDynamicWallpaper.tsx
+++ b/src/components/layout/desktop/DesktopDynamicWallpaper.tsx
@@ -6,6 +6,7 @@ import { useWeatherWallpaper } from "@/hooks/useWeatherWallpaper";
 import { useNowPlayingLyrics } from "@/hooks/useNowPlayingLyrics";
 import { useThemeFlags } from "@/hooks/useThemeFlags";
 import { useIpodPipActive } from "@/apps/ipod/hooks/useIpodPipActive";
+import { useSaveSongCoverColor } from "@/hooks/useSaveSongCoverColor";
 import { MeshGradientBackground } from "@/components/shared/MeshGradientBackground";
 import { LyricsDisplay } from "@/apps/ipod/components/lyrics-display/LyricsDisplay";
 import {
@@ -90,6 +91,9 @@ function LyricsWallpaperLayer() {
   const np = useNowPlayingLyrics();
   const { isMacOSTheme, isAquaGlass, isWinXp, isWin98 } = useThemeFlags();
   const pipActive = useIpodPipActive();
+  // Persist the resolved cover color back to the song (and store) so the lyric
+  // highlight color matches the song palette — exactly like the Karaoke overlay.
+  const saveCoverColor = useSaveSongCoverColor(np.track);
 
   // Reserve enough bottom space for the lyrics to clear the dock / taskbar, plus
   // the iPod pop player (PiP) when it's active. The offset differs for Aqua vs
@@ -143,6 +147,9 @@ function LyricsWallpaperLayer() {
           textSizeClass="fullscreen-lyrics-text"
           gapClass="gap-0"
           containerStyle={containerStyle}
+          coverUrl={np.coverUrl}
+          coverColor={np.track?.coverColor}
+          onCoverColorResolved={saveCoverColor}
           showInterludeEllipsis
         />
       )}

--- a/src/components/layout/desktop/DesktopDynamicWallpaper.tsx
+++ b/src/components/layout/desktop/DesktopDynamicWallpaper.tsx
@@ -18,6 +18,16 @@ import {
 /** Recompute the day/night gradient roughly once a minute. */
 const GRADIENT_REFRESH_MS = 60 * 1000;
 
+// Mirror the Karaoke fullscreen lyric sizing so the wallpaper renders large,
+// viewport-relative lyrics (rather than the small in-app default). Hoisted to
+// module scope so LyricsDisplay doesn't get a freshly-allocated object prop on
+// every render.
+const LYRICS_WALLPAPER_CONTAINER_STYLE = {
+  gap: "clamp(0.2rem, calc(min(10vw, 10vh) * 0.08), 1rem)",
+  paddingLeft: "env(safe-area-inset-left, 0px)",
+  paddingRight: "env(safe-area-inset-right, 0px)",
+} as const;
+
 function DayNightGradientLayer() {
   const [gradient, setGradient] = useState(() => getDayNightGradientCss());
 
@@ -94,6 +104,10 @@ function LyricsWallpaperLayer() {
           furiganaMap={np.furiganaMap}
           soramimiMap={np.soramimiMap}
           currentTimeMs={np.currentTimeMs}
+          textSizeClass="fullscreen-lyrics-text"
+          gapClass="gap-0"
+          containerStyle={LYRICS_WALLPAPER_CONTAINER_STYLE}
+          bottomPaddingClass="pb-16"
           showInterludeEllipsis
         />
       )}

--- a/src/components/layout/desktop/DesktopDynamicWallpaper.tsx
+++ b/src/components/layout/desktop/DesktopDynamicWallpaper.tsx
@@ -31,6 +31,9 @@ const LYRICS_DOCK_CLEARANCE_GLASS = 82;
 const LYRICS_DOCK_CLEARANCE_AQUA = 72;
 const LYRICS_DOCK_CLEARANCE_WINDOWS = 42;
 const LYRICS_DOCK_CLEARANCE_DEFAULT = 16;
+// Lift the lyrics further off the dock so the bottom line has room to breathe
+// rather than hugging the dock/taskbar.
+const LYRICS_EXTRA_LIFT = 96;
 // Extra clearance (px) when the iPod "pop player" (PiP) is showing: the floating
 // player is ~64px tall and sits just above the dock, so lift the lyrics past it.
 const LYRICS_PIP_CLEARANCE = 76;
@@ -101,7 +104,9 @@ function LyricsWallpaperLayer() {
         ? LYRICS_DOCK_CLEARANCE_WINDOWS
         : LYRICS_DOCK_CLEARANCE_DEFAULT;
     const paddingBottomPx =
-      dockClearance + (pipActive ? LYRICS_PIP_CLEARANCE : 0);
+      dockClearance +
+      LYRICS_EXTRA_LIFT +
+      (pipActive ? LYRICS_PIP_CLEARANCE : 0);
     return {
       gap: LYRICS_WALLPAPER_GAP,
       paddingLeft: "env(safe-area-inset-left, 0px)",

--- a/src/components/layout/desktop/DesktopDynamicWallpaper.tsx
+++ b/src/components/layout/desktop/DesktopDynamicWallpaper.tsx
@@ -1,9 +1,11 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState, type CSSProperties } from "react";
 import { AnimatePresence, motion } from "motion/react";
 import { useWallpaper } from "@/hooks/useWallpaper";
 import { useNowPlayingCover } from "@/hooks/useNowPlayingCover";
 import { useWeatherWallpaper } from "@/hooks/useWeatherWallpaper";
 import { useNowPlayingLyrics } from "@/hooks/useNowPlayingLyrics";
+import { useThemeFlags } from "@/hooks/useThemeFlags";
+import { useIpodPipActive } from "@/apps/ipod/hooks/useIpodPipActive";
 import { MeshGradientBackground } from "@/components/shared/MeshGradientBackground";
 import { LyricsDisplay } from "@/apps/ipod/components/lyrics-display/LyricsDisplay";
 import {
@@ -19,14 +21,19 @@ import {
 const GRADIENT_REFRESH_MS = 60 * 1000;
 
 // Mirror the Karaoke fullscreen lyric sizing so the wallpaper renders large,
-// viewport-relative lyrics (rather than the small in-app default). Hoisted to
-// module scope so LyricsDisplay doesn't get a freshly-allocated object prop on
-// every render.
-const LYRICS_WALLPAPER_CONTAINER_STYLE = {
-  gap: "clamp(0.2rem, calc(min(10vw, 10vh) * 0.08), 1rem)",
-  paddingLeft: "env(safe-area-inset-left, 0px)",
-  paddingRight: "env(safe-area-inset-right, 0px)",
-} as const;
+// viewport-relative lyrics (rather than the small in-app default).
+const LYRICS_WALLPAPER_GAP = "clamp(0.2rem, calc(min(10vw, 10vh) * 0.08), 1rem)";
+
+// Bottom clearance (px) so the lyrics sit above the dock / taskbar. Matches the
+// PiP + toast bottom offsets used elsewhere so the lyrics line up with the rest
+// of the desktop chrome. Aqua glass sits a little higher than classic Aqua.
+const LYRICS_DOCK_CLEARANCE_GLASS = 82;
+const LYRICS_DOCK_CLEARANCE_AQUA = 72;
+const LYRICS_DOCK_CLEARANCE_WINDOWS = 42;
+const LYRICS_DOCK_CLEARANCE_DEFAULT = 16;
+// Extra clearance (px) when the iPod "pop player" (PiP) is showing: the floating
+// player is ~64px tall and sits just above the dock, so lift the lyrics past it.
+const LYRICS_PIP_CLEARANCE = 76;
 
 function DayNightGradientLayer() {
   const [gradient, setGradient] = useState(() => getDayNightGradientCss());
@@ -78,6 +85,30 @@ function WeatherGradientLayer() {
 
 function LyricsWallpaperLayer() {
   const np = useNowPlayingLyrics();
+  const { isMacOSTheme, isAquaGlass, isWinXp, isWin98 } = useThemeFlags();
+  const pipActive = useIpodPipActive();
+
+  // Reserve enough bottom space for the lyrics to clear the dock / taskbar, plus
+  // the iPod pop player (PiP) when it's active. The offset differs for Aqua vs
+  // Aqua Glass since the glass dock sits a touch higher.
+  const containerStyle = useMemo<CSSProperties>(() => {
+    const isWindowsTheme = isWinXp || isWin98;
+    const dockClearance = isMacOSTheme
+      ? isAquaGlass
+        ? LYRICS_DOCK_CLEARANCE_GLASS
+        : LYRICS_DOCK_CLEARANCE_AQUA
+      : isWindowsTheme
+        ? LYRICS_DOCK_CLEARANCE_WINDOWS
+        : LYRICS_DOCK_CLEARANCE_DEFAULT;
+    const paddingBottomPx =
+      dockClearance + (pipActive ? LYRICS_PIP_CLEARANCE : 0);
+    return {
+      gap: LYRICS_WALLPAPER_GAP,
+      paddingLeft: "env(safe-area-inset-left, 0px)",
+      paddingRight: "env(safe-area-inset-right, 0px)",
+      paddingBottom: `calc(env(safe-area-inset-bottom, 0px) + ${paddingBottomPx}px)`,
+    };
+  }, [isMacOSTheme, isAquaGlass, isWinXp, isWin98, pipActive]);
 
   return (
     <div className="absolute inset-0 w-full h-full z-[-10] overflow-hidden bg-neutral-950">
@@ -106,8 +137,7 @@ function LyricsWallpaperLayer() {
           currentTimeMs={np.currentTimeMs}
           textSizeClass="fullscreen-lyrics-text"
           gapClass="gap-0"
-          containerStyle={LYRICS_WALLPAPER_CONTAINER_STYLE}
-          bottomPaddingClass="pb-16"
+          containerStyle={containerStyle}
           showInterludeEllipsis
         />
       )}

--- a/src/hooks/useNowPlayingLyrics.ts
+++ b/src/hooks/useNowPlayingLyrics.ts
@@ -1,0 +1,178 @@
+import { useMemo } from "react";
+import {
+  useIpodStore,
+  getActiveIpodCurrentTrack,
+  getEffectiveTranslationLanguage,
+  type Track,
+} from "@/stores/useIpodStore";
+import { useKaraokeStore } from "@/stores/useKaraokeStore";
+import {
+  getLyricsFontClassName,
+  LyricsFont as LyricsFontEnum,
+} from "@/types/lyrics";
+import { useLyrics } from "@/hooks/useLyrics";
+import { useFurigana } from "@/hooks/useFurigana";
+import { useNowPlayingCover } from "@/hooks/useNowPlayingCover";
+
+export interface NowPlayingLyrics {
+  source: "ipod" | "karaoke" | null;
+  isPlaying: boolean;
+  track: Track | null;
+  coverUrl: string | null;
+  /** Live playback position used for word-level highlighting (ms). */
+  currentTimeMs: number;
+  lyricsControls: ReturnType<typeof useLyrics>;
+  furiganaMap: ReturnType<typeof useFurigana>["furiganaMap"];
+  soramimiMap: ReturnType<typeof useFurigana>["soramimiMap"];
+  lyricsFontClassName: string;
+  /** True when there are lyric lines to render for the active track. */
+  hasLyrics: boolean;
+}
+
+/**
+ * Resolves the now-playing track + synced lyrics for the `dynamic://lyrics`
+ * wallpaper. Mirrors {@link useNowPlayingCover}'s precedence (actively playing
+ * wins, iPod over Karaoke on ties; otherwise whichever has a current track) and
+ * independently loads lyrics so the wallpaper works whether or not the iPod /
+ * Karaoke windows are open.
+ */
+export function useNowPlayingLyrics(): NowPlayingLyrics {
+  // iPod playback state.
+  const ipodIsPlaying = useIpodStore((s) => s.isPlaying);
+  const ipodLibrarySource = useIpodStore((s) => s.librarySource);
+  const ipodCurrentSongId = useIpodStore((s) => s.currentSongId);
+  const ipodAppleSongId = useIpodStore((s) => s.appleMusicCurrentSongId);
+  const ipodTracks = useIpodStore((s) => s.tracks);
+  const ipodAppleTracks = useIpodStore((s) => s.appleMusicTracks);
+  const ipodElapsed = useIpodStore((s) => s.elapsedTime);
+
+  // Karaoke playback state (library shared with the iPod's YouTube tracks).
+  const karaokeIsPlaying = useKaraokeStore((s) => s.isPlaying);
+  const karaokeSongId = useKaraokeStore((s) => s.currentSongId);
+  const karaokeElapsed = useKaraokeStore((s) => s.elapsedTime);
+
+  // Shared lyrics preferences live on the iPod store.
+  const romanization = useIpodStore((s) => s.romanization);
+  const lyricsTranslationLanguage = useIpodStore(
+    (s) => s.lyricsTranslationLanguage
+  );
+  const lyricsFont = useIpodStore((s) => s.lyricsFont);
+
+  const cover = useNowPlayingCover();
+
+  const { source, track, elapsed, isPlaying } = useMemo(() => {
+    const ipodTrack = getActiveIpodCurrentTrack({
+      librarySource: ipodLibrarySource,
+      tracks: ipodTracks,
+      currentSongId: ipodCurrentSongId,
+      appleMusicTracks: ipodAppleTracks,
+      appleMusicCurrentSongId: ipodAppleSongId,
+    });
+    const karaokeTrack = karaokeSongId
+      ? ipodTracks.find((t) => t.id === karaokeSongId) ?? null
+      : null;
+
+    if (ipodIsPlaying)
+      return {
+        source: "ipod" as const,
+        track: ipodTrack,
+        elapsed: ipodElapsed,
+        isPlaying: true,
+      };
+    if (karaokeIsPlaying)
+      return {
+        source: "karaoke" as const,
+        track: karaokeTrack,
+        elapsed: karaokeElapsed,
+        isPlaying: true,
+      };
+    if (ipodTrack)
+      return {
+        source: "ipod" as const,
+        track: ipodTrack,
+        elapsed: ipodElapsed,
+        isPlaying: false,
+      };
+    if (karaokeTrack)
+      return {
+        source: "karaoke" as const,
+        track: karaokeTrack,
+        elapsed: karaokeElapsed,
+        isPlaying: false,
+      };
+    return {
+      source: null as "ipod" | "karaoke" | null,
+      track: null as Track | null,
+      elapsed: 0,
+      isPlaying: false,
+    };
+  }, [
+    ipodIsPlaying,
+    ipodLibrarySource,
+    ipodCurrentSongId,
+    ipodAppleSongId,
+    ipodTracks,
+    ipodAppleTracks,
+    ipodElapsed,
+    karaokeIsPlaying,
+    karaokeSongId,
+    karaokeElapsed,
+  ]);
+
+  const lyricOffsetMs = track?.lyricOffset ?? 0;
+  const currentTime = elapsed + lyricOffsetMs / 1000;
+
+  const effectiveTranslationLanguage = getEffectiveTranslationLanguage(
+    lyricsTranslationLanguage
+  );
+
+  const selectedMatchForLyrics = useMemo(() => {
+    const src = track?.lyricsSource;
+    if (!src) return undefined;
+    return {
+      hash: src.hash,
+      albumId: src.albumId,
+      title: src.title,
+      artist: src.artist,
+      album: src.album,
+    };
+  }, [track?.lyricsSource]);
+
+  const lyricsControls = useLyrics({
+    songId: track?.id ?? "",
+    title: track?.title ?? "",
+    artist: track?.artist ?? "",
+    currentTime,
+    translateTo: effectiveTranslationLanguage,
+    selectedMatch: selectedMatchForLyrics,
+    includeFurigana: true,
+    includeSoramimi: true,
+    soramimiTargetLanguage: romanization.soramamiTargetLanguage ?? "zh-TW",
+  });
+
+  const { furiganaMap, soramimiMap } = useFurigana({
+    songId: track?.id ?? "",
+    lines: lyricsControls.originalLines,
+    isShowingOriginal: true,
+    romanization,
+    prefetchedInfo: lyricsControls.furiganaInfo,
+    prefetchedSoramimiInfo: lyricsControls.soramimiInfo,
+  });
+
+  const lyricsFontClassName = getLyricsFontClassName(
+    lyricsFont ?? LyricsFontEnum.GoldGlow
+  );
+
+  return {
+    source,
+    isPlaying,
+    track,
+    coverUrl: cover.coverUrl,
+    currentTimeMs: currentTime * 1000,
+    lyricsControls,
+    furiganaMap,
+    soramimiMap,
+    lyricsFontClassName,
+    hasLyrics: lyricsControls.lines.length > 0,
+  };
+}

--- a/src/hooks/useWeatherWallpaper.ts
+++ b/src/hooks/useWeatherWallpaper.ts
@@ -1,0 +1,110 @@
+import { useEffect, useState } from "react";
+
+// Lightweight live-weather source for the `dynamic://weather` wallpaper. We only
+// need the current WMO weather code (the gradient derives time-of-day on its own
+// from the wall clock), so this is intentionally much smaller than the Dashboard
+// weather widget. Results are cached at module scope so toggling the wallpaper
+// on/off doesn't re-prompt for geolocation or re-hit the API.
+
+export interface WeatherWallpaperState {
+  weatherCode: number | null;
+  isDay: boolean;
+}
+
+interface WeatherWallpaperCacheEntry {
+  weatherCode: number;
+  isDay: boolean;
+  fetchedAt: number;
+}
+
+const WEATHER_REFRESH_MS = 15 * 60 * 1000;
+const SF_LAT = 37.7749;
+const SF_LON = -122.4194;
+
+let cache: WeatherWallpaperCacheEntry | null = null;
+let inFlight: Promise<WeatherWallpaperCacheEntry | null> | null = null;
+const listeners = new Set<() => void>();
+
+function notify() {
+  listeners.forEach((cb) => cb());
+}
+
+async function fetchWeather(
+  lat: number,
+  lon: number
+): Promise<WeatherWallpaperCacheEntry | null> {
+  try {
+    const res = await fetch(
+      `https://api.open-meteo.com/v1/forecast?latitude=${lat}&longitude=${lon}&current=weather_code,is_day&timezone=auto`
+    );
+    if (!res.ok) throw new Error("Weather fetch failed");
+    const data = await res.json();
+    const entry: WeatherWallpaperCacheEntry = {
+      weatherCode: Number(data?.current?.weather_code ?? 0),
+      isDay: data?.current?.is_day === 1,
+      fetchedAt: Date.now(),
+    };
+    cache = entry;
+    notify();
+    return entry;
+  } catch {
+    return null;
+  }
+}
+
+function resolveCoordsThenFetch(): Promise<WeatherWallpaperCacheEntry | null> {
+  return new Promise((resolve) => {
+    const done = (lat: number, lon: number) => resolve(fetchWeather(lat, lon));
+    if (typeof navigator === "undefined" || !navigator.geolocation) {
+      done(SF_LAT, SF_LON);
+      return;
+    }
+    navigator.geolocation.getCurrentPosition(
+      (pos) => done(pos.coords.latitude, pos.coords.longitude),
+      () => done(SF_LAT, SF_LON),
+      { timeout: 10000, maximumAge: WEATHER_REFRESH_MS }
+    );
+  });
+}
+
+function ensureFresh() {
+  const isStale = !cache || Date.now() - cache.fetchedAt > WEATHER_REFRESH_MS;
+  if (!isStale || inFlight) return;
+  inFlight = resolveCoordsThenFetch().finally(() => {
+    inFlight = null;
+  });
+}
+
+/**
+ * Provides the current local weather condition for the weather wallpaper.
+ * Returns `weatherCode: null` until the first fetch resolves (the gradient
+ * renderer treats this as a plain day/night sky).
+ */
+export function useWeatherWallpaper(): WeatherWallpaperState {
+  const [state, setState] = useState<WeatherWallpaperState>(() => ({
+    weatherCode: cache?.weatherCode ?? null,
+    isDay: cache?.isDay ?? true,
+  }));
+
+  useEffect(() => {
+    const sync = () =>
+      setState({
+        weatherCode: cache?.weatherCode ?? null,
+        isDay: cache?.isDay ?? true,
+      });
+    listeners.add(sync);
+    ensureFresh();
+    sync();
+
+    const id = setInterval(() => {
+      ensureFresh();
+    }, WEATHER_REFRESH_MS);
+
+    return () => {
+      listeners.delete(sync);
+      clearInterval(id);
+    };
+  }, []);
+
+  return state;
+}

--- a/src/lib/locales/de/translation.json
+++ b/src/lib/locales/de/translation.json
@@ -1390,8 +1390,10 @@
       "dream": "Traum",
       "dynamicWallpapers": {
         "dayNight": "Tag & Nacht",
+        "lyrics": "Songtext",
         "nowPlaying": "Läuft gerade",
-        "shuffle": "Zufällig"
+        "shuffle": "Zufällig",
+        "weather": "Wetter"
       },
       "elevenlabs": "ElevenLabs",
       "elevenlabsVoiceId": "ElevenLabs Sprach-ID",

--- a/src/lib/locales/en/translation.json
+++ b/src/lib/locales/en/translation.json
@@ -3087,7 +3087,9 @@
       },
       "dynamicWallpapers": {
         "dayNight": "Day & Night",
+        "weather": "Weather",
         "nowPlaying": "Now Playing",
+        "lyrics": "Lyrics",
         "shuffle": "Shuffle"
       },
       "alerts": {

--- a/src/lib/locales/es/translation.json
+++ b/src/lib/locales/es/translation.json
@@ -1390,8 +1390,10 @@
       "dream": "Sueño",
       "dynamicWallpapers": {
         "dayNight": "Día y noche",
+        "lyrics": "Letras",
         "nowPlaying": "Reproduciendo ahora",
-        "shuffle": "Aleatorio"
+        "shuffle": "Aleatorio",
+        "weather": "Clima"
       },
       "elevenlabs": "ElevenLabs",
       "elevenlabsVoiceId": "ID de voz de ElevenLabs",

--- a/src/lib/locales/fr/translation.json
+++ b/src/lib/locales/fr/translation.json
@@ -1390,8 +1390,10 @@
       "dream": "Rêve",
       "dynamicWallpapers": {
         "dayNight": "Jour et nuit",
+        "lyrics": "Paroles",
         "nowPlaying": "À l'écoute",
-        "shuffle": "Aléatoire"
+        "shuffle": "Aléatoire",
+        "weather": "Météo"
       },
       "elevenlabs": "ElevenLabs",
       "elevenlabsVoiceId": "Identifiant vocal ElevenLabs",

--- a/src/lib/locales/it/translation.json
+++ b/src/lib/locales/it/translation.json
@@ -1390,8 +1390,10 @@
       "dream": "Sogno",
       "dynamicWallpapers": {
         "dayNight": "Giorno e notte",
+        "lyrics": "Testo",
         "nowPlaying": "In riproduzione",
-        "shuffle": "Casuale"
+        "shuffle": "Casuale",
+        "weather": "Meteo"
       },
       "elevenlabs": "ElevenLabs",
       "elevenlabsVoiceId": "ID Voce ElevenLabs",

--- a/src/lib/locales/ja/translation.json
+++ b/src/lib/locales/ja/translation.json
@@ -1390,8 +1390,10 @@
       "dream": "ドリーム",
       "dynamicWallpapers": {
         "dayNight": "デイ＆ナイト",
+        "lyrics": "歌詞",
         "nowPlaying": "再生中",
-        "shuffle": "シャッフル"
+        "shuffle": "シャッフル",
+        "weather": "天気"
       },
       "elevenlabs": "ElevenLabs",
       "elevenlabsVoiceId": "ElevenLabs 音声ID",

--- a/src/lib/locales/ko/translation.json
+++ b/src/lib/locales/ko/translation.json
@@ -1390,8 +1390,10 @@
       "dream": "꿈",
       "dynamicWallpapers": {
         "dayNight": "주간 및 야간",
+        "lyrics": "가사",
         "nowPlaying": "지금 재생 중",
-        "shuffle": "임의 재생"
+        "shuffle": "임의 재생",
+        "weather": "날씨"
       },
       "elevenlabs": "일레븐랩스",
       "elevenlabsVoiceId": "일레븐랩스 음성 ID",

--- a/src/lib/locales/pt/translation.json
+++ b/src/lib/locales/pt/translation.json
@@ -1390,8 +1390,10 @@
       "dream": "Sonho",
       "dynamicWallpapers": {
         "dayNight": "Dia e Noite",
+        "lyrics": "Letras",
         "nowPlaying": "Reproduzindo agora",
-        "shuffle": "Aleatório"
+        "shuffle": "Aleatório",
+        "weather": "Clima"
       },
       "elevenlabs": "ElevenLabs",
       "elevenlabsVoiceId": "ID de Voz ElevenLabs",

--- a/src/lib/locales/ru/translation.json
+++ b/src/lib/locales/ru/translation.json
@@ -1390,8 +1390,10 @@
       "dream": "Мечта",
       "dynamicWallpapers": {
         "dayNight": "День и ночь",
+        "lyrics": "Текст",
         "nowPlaying": "Сейчас играет",
-        "shuffle": "Перемешать"
+        "shuffle": "Перемешать",
+        "weather": "Погода"
       },
       "elevenlabs": "ElevenLabs",
       "elevenlabsVoiceId": "ID голоса ElevenLabs",

--- a/src/lib/locales/zh-TW/translation.json
+++ b/src/lib/locales/zh-TW/translation.json
@@ -1390,8 +1390,10 @@
       "dream": "夢幻",
       "dynamicWallpapers": {
         "dayNight": "日與夜",
+        "lyrics": "歌詞",
         "nowPlaying": "播放中",
-        "shuffle": "隨機播放"
+        "shuffle": "隨機播放",
+        "weather": "天氣"
       },
       "elevenlabs": "ElevenLabs",
       "elevenlabsVoiceId": "ElevenLabs 語音 ID",

--- a/src/utils/dynamicWallpaper.ts
+++ b/src/utils/dynamicWallpaper.ts
@@ -8,8 +8,12 @@
 //
 //   - `dynamic://gradient/day-night` — a gradient that shifts with wall-clock
 //     time of day.
+//   - `dynamic://weather`            — the day/night gradient, re-tinted to match
+//     the live local weather condition (clear, cloudy, rain, snow, fog, storm).
 //   - `dynamic://cover`              — the now-playing cover art of the iPod or
 //     Karaoke (falls back to the paused cover).
+//   - `dynamic://lyrics`            — the now-playing synced lyrics over the same
+//     animated mesh-gradient ("gradient paper") shader used by the music apps.
 //   - `shuffle://photos/<category>`  — a random photo from a picker category,
 //     swapped every {@link SHUFFLE_INTERVAL_MS}.
 //   - `shuffle://tiles`              — a random tiled pattern, rotated likewise.
@@ -21,7 +25,9 @@ export const DYNAMIC_PREFIX = "dynamic://";
 export const SHUFFLE_PREFIX = "shuffle://";
 
 export const DAY_NIGHT_GRADIENT_WALLPAPER = "dynamic://gradient/day-night";
+export const WEATHER_WALLPAPER = "dynamic://weather";
 export const COVER_WALLPAPER = "dynamic://cover";
+export const LYRICS_WALLPAPER = "dynamic://lyrics";
 
 /** How often shuffle wallpapers swap to a new random pick. */
 export const SHUFFLE_INTERVAL_MS = 2 * 60 * 1000;
@@ -39,8 +45,20 @@ export function isDayNightGradientWallpaper(
   return wallpaper === DAY_NIGHT_GRADIENT_WALLPAPER;
 }
 
+export function isWeatherWallpaper(
+  wallpaper: string | undefined | null
+): boolean {
+  return wallpaper === WEATHER_WALLPAPER;
+}
+
 export function isCoverWallpaper(wallpaper: string | undefined | null): boolean {
   return wallpaper === COVER_WALLPAPER;
+}
+
+export function isLyricsWallpaper(
+  wallpaper: string | undefined | null
+): boolean {
+  return wallpaper === LYRICS_WALLPAPER;
 }
 
 export function isShuffleWallpaper(
@@ -194,6 +212,87 @@ export function getDayNightGradientColors(date: Date = new Date()): [RGB, RGB, R
 /** Build a CSS `linear-gradient(...)` string for the current time of day. */
 export function getDayNightGradientCss(date: Date = new Date()): string {
   const [top, mid, bottom] = getDayNightGradientColors(date);
+  return `linear-gradient(to bottom, ${rgbToCss(top)} 0%, ${rgbToCss(
+    mid
+  )} 55%, ${rgbToCss(bottom)} 100%)`;
+}
+
+// ---------------------------------------------------------------------------
+// Weather gradient
+//
+// The weather wallpaper reuses the time-of-day gradient as a base "sky" and
+// then re-tints it to match the current weather condition. This keeps the
+// gradient shifting through dawn/day/dusk/night while a storm reads darker, a
+// clear sky reads vivid, fog reads washed-out, snow reads bright & cool, etc.
+// ---------------------------------------------------------------------------
+
+const relativeLuminance = ([r, g, b]: RGB): number =>
+  0.299 * r + 0.587 * g + 0.114 * b;
+
+const desaturate = (rgb: RGB, amount: number): RGB => {
+  const l = relativeLuminance(rgb);
+  return lerpRgb(rgb, [l, l, l], amount);
+};
+
+const darken = (rgb: RGB, amount: number): RGB =>
+  rgb.map((c) => Math.round(c * (1 - amount))) as RGB;
+
+const lighten = (rgb: RGB, amount: number): RGB =>
+  lerpRgb(rgb, [255, 255, 255], amount);
+
+const tint = (rgb: RGB, color: RGB, amount: number): RGB =>
+  lerpRgb(rgb, color, amount);
+
+/** Weather treatments keyed by WMO weather-code "family". */
+type WeatherTreatment = (rgb: RGB) => RGB;
+
+const WEATHER_TREATMENTS: Record<string, WeatherTreatment> = {
+  clear: (rgb) => rgb,
+  partlyCloudy: (rgb) => lighten(desaturate(rgb, 0.28), 0.04),
+  fog: (rgb) => lighten(desaturate(rgb, 0.72), 0.16),
+  drizzle: (rgb) => tint(darken(desaturate(rgb, 0.42), 0.12), [92, 104, 120], 0.16),
+  rain: (rgb) => tint(darken(desaturate(rgb, 0.46), 0.2), [78, 92, 110], 0.24),
+  snow: (rgb) => tint(lighten(desaturate(rgb, 0.55), 0.2), [220, 228, 236], 0.12),
+  thunderstorm: (rgb) =>
+    tint(darken(desaturate(rgb, 0.5), 0.4), [58, 54, 80], 0.22),
+};
+
+/** Map a WMO weather code to a treatment family. */
+function weatherCodeToFamily(code: number | null | undefined): string {
+  if (code == null) return "clear";
+  if (code === 0) return "clear";
+  if (code <= 3) return "partlyCloudy";
+  if (code <= 48) return "fog";
+  if (code <= 57) return "drizzle";
+  if (code <= 67) return "rain";
+  if (code <= 77) return "snow";
+  if (code <= 82) return "rain"; // rain showers
+  if (code <= 86) return "snow"; // snow showers
+  if (code <= 99) return "thunderstorm";
+  return "clear";
+}
+
+/**
+ * Compute the [top, mid, bottom] gradient colors for the current time of day,
+ * re-tinted to match the supplied weather code. A `null`/`undefined` code (e.g.
+ * while the live weather is still loading) falls back to the plain day/night
+ * gradient.
+ */
+export function getWeatherGradientColors(
+  code: number | null | undefined,
+  date: Date = new Date()
+): [RGB, RGB, RGB] {
+  const base = getDayNightGradientColors(date);
+  const treat = WEATHER_TREATMENTS[weatherCodeToFamily(code)] ?? ((c: RGB) => c);
+  return [treat(base[0]), treat(base[1]), treat(base[2])];
+}
+
+/** Build a CSS `linear-gradient(...)` string for the current time + weather. */
+export function getWeatherGradientCss(
+  code: number | null | undefined,
+  date: Date = new Date()
+): string {
+  const [top, mid, bottom] = getWeatherGradientColors(code, date);
   return `linear-gradient(to bottom, ${rgbToCss(top)} 0%, ${rgbToCss(
     mid
   )} 55%, ${rgbToCss(bottom)} 100%)`;

--- a/src/utils/dynamicWallpaper.ts
+++ b/src/utils/dynamicWallpaper.ts
@@ -8,8 +8,8 @@
 //
 //   - `dynamic://gradient/day-night` — a gradient that shifts with wall-clock
 //     time of day.
-//   - `dynamic://weather`            — the day/night gradient, re-tinted to match
-//     the live local weather condition (clear, cloudy, rain, snow, fog, storm).
+//   - `dynamic://weather`            — a dedicated time-of-day gradient per live
+//     local weather condition (clear, cloudy, rain, snow, fog, storm).
 //   - `dynamic://cover`              — the now-playing cover art of the iPod or
 //     Karaoke (falls back to the paused cover).
 //   - `dynamic://lyrics`            — the now-playing synced lyrics over the same
@@ -174,11 +174,17 @@ const lerpRgb = (a: RGB, b: RGB, t: number): RGB => [
 
 const rgbToCss = ([r, g, b]: RGB) => `rgb(${r}, ${g}, ${b})`;
 
-/** Compute the interpolated [top, mid, bottom] colors for a given time. */
-export function getDayNightGradientColors(date: Date = new Date()): [RGB, RGB, RGB] {
+/**
+ * Interpolate a [top, mid, bottom] gradient from a set of time-of-day keyframes.
+ * Keyframes are ordered by hour; the renderer wraps around so the last frame
+ * (e.g. dusk) blends smoothly back into the first (deep night).
+ */
+function interpolateGradientKeyframes(
+  frames: GradientKeyframe[],
+  date: Date
+): [RGB, RGB, RGB] {
   const hour = date.getHours() + date.getMinutes() / 60 + date.getSeconds() / 3600;
 
-  const frames = DAY_NIGHT_KEYFRAMES;
   // Find the surrounding keyframes (with wraparound past the last one).
   let start = frames[frames.length - 1];
   let end = frames[0];
@@ -209,6 +215,11 @@ export function getDayNightGradientColors(date: Date = new Date()): [RGB, RGB, R
   ];
 }
 
+/** Compute the interpolated [top, mid, bottom] colors for a given time. */
+export function getDayNightGradientColors(date: Date = new Date()): [RGB, RGB, RGB] {
+  return interpolateGradientKeyframes(DAY_NIGHT_KEYFRAMES, date);
+}
+
 /** Build a CSS `linear-gradient(...)` string for the current time of day. */
 export function getDayNightGradientCss(date: Date = new Date()): string {
   const [top, mid, bottom] = getDayNightGradientColors(date);
@@ -220,45 +231,91 @@ export function getDayNightGradientCss(date: Date = new Date()): string {
 // ---------------------------------------------------------------------------
 // Weather gradient
 //
-// The weather wallpaper reuses the time-of-day gradient as a base "sky" and
-// then re-tints it to match the current weather condition. This keeps the
-// gradient shifting through dawn/day/dusk/night while a storm reads darker, a
-// clear sky reads vivid, fog reads washed-out, snow reads bright & cool, etc.
+// Each weather condition has its *own* set of time-of-day gradient keyframes
+// (not a tint applied over the day/night sky). Every family still shifts
+// through night → dawn → day → dusk, but with bespoke palettes: clear reads
+// vivid blue, an overcast sky reads soft & hazy, fog washes out to pale grey,
+// rain/drizzle go moody blue-grey, snow stays bright & cool, and storms turn
+// dark and ominous.
 // ---------------------------------------------------------------------------
 
-const relativeLuminance = ([r, g, b]: RGB): number =>
-  0.299 * r + 0.587 * g + 0.114 * b;
+type WeatherFamily =
+  | "clear"
+  | "partlyCloudy"
+  | "fog"
+  | "drizzle"
+  | "rain"
+  | "snow"
+  | "thunderstorm";
 
-const desaturate = (rgb: RGB, amount: number): RGB => {
-  const l = relativeLuminance(rgb);
-  return lerpRgb(rgb, [l, l, l], amount);
+const WEATHER_KEYFRAMES: Record<WeatherFamily, GradientKeyframe[]> = {
+  // Vivid clear sky: deep starry night → warm sunrise → bright blue → dusk.
+  clear: [
+    k(0, "#06091f", "#0d1336", "#18204c"),
+    k(6.5, "#4a5a92", "#d49a86", "#f6b46a"),
+    k(9, "#2a86dd", "#6cc3f3", "#d3efff"),
+    k(16, "#2f8ed8", "#79c6f7", "#e0f3ff"),
+    k(18.5, "#46518e", "#ef946b", "#ffc25d"),
+    k(21, "#11103a", "#281f4e", "#41305f"),
+  ],
+  // Soft, hazy partly-cloudy / overcast sky — muted blues and warm greys.
+  partlyCloudy: [
+    k(0, "#12162e", "#1d2340", "#2c3253"),
+    k(6.5, "#6b7390", "#c3a4a6", "#e6c29b"),
+    k(9, "#6191c0", "#a3c7dd", "#dde9f0"),
+    k(16, "#6a97c0", "#aacbe0", "#e3eef3"),
+    k(18.5, "#5e6489", "#d4a18d", "#eec196"),
+    k(21, "#1c1f3e", "#33304e", "#4a4560"),
+  ],
+  // Fog: low-contrast, washed-out pale grey.
+  fog: [
+    k(0, "#1f222a", "#2a2e37", "#393e47"),
+    k(6.5, "#888891", "#aaa6a4", "#c9c3bd"),
+    k(9, "#9ba4ac", "#c3c9cd", "#e4e7e9"),
+    k(16, "#a0a8af", "#c8cdd0", "#e8eaec"),
+    k(18.5, "#85848d", "#b1a49e", "#d3c7be"),
+    k(21, "#2d2e37", "#44444e", "#5a5862"),
+  ],
+  // Drizzle: cool, slightly subdued blue-grey.
+  drizzle: [
+    k(0, "#111720", "#1a222d", "#27313d"),
+    k(6.5, "#50616c", "#7b858e", "#9ca5aa"),
+    k(9, "#5d7282", "#8da2ae", "#c4cfd4"),
+    k(16, "#607585", "#91a4b0", "#cbd5d9"),
+    k(18.5, "#4b5661", "#707782", "#94979d"),
+    k(21, "#171e27", "#26303b", "#38424e"),
+  ],
+  // Rain: darker, moody deep blue-grey.
+  rain: [
+    k(0, "#0b1017", "#131a23", "#1e2731"),
+    k(6.5, "#3b4752", "#596775", "#75818b"),
+    k(9, "#45555f", "#6d7e89", "#98a5ac"),
+    k(16, "#485963", "#71828d", "#9ca9b0"),
+    k(18.5, "#394350", "#535d67", "#6f767e"),
+    k(21, "#10161e", "#1e262f", "#2b343f"),
+  ],
+  // Snow: bright, cool, pale blue-white.
+  snow: [
+    k(0, "#1d2634", "#2e3949", "#44505e"),
+    k(6.5, "#8b94a4", "#babfc9", "#dee1e7"),
+    k(9, "#a1b2c4", "#cfd9e3", "#eff4f8"),
+    k(16, "#a6b6c7", "#d3dce5", "#f2f6f9"),
+    k(18.5, "#828a9b", "#aeb4c2", "#d6dae1"),
+    k(21, "#222937", "#37404e", "#505a69"),
+  ],
+  // Thunderstorm: dark and ominous, purple-grey.
+  thunderstorm: [
+    k(0, "#07090f", "#0d0f17", "#161924"),
+    k(6.5, "#2a2b3a", "#3a394b", "#4c495d"),
+    k(9, "#313246", "#45424f", "#58535f"),
+    k(16, "#33344a", "#474450", "#5a5560"),
+    k(18.5, "#29283a", "#3b3548", "#4e4257"),
+    k(21, "#0b0c15", "#15141e", "#211e2b"),
+  ],
 };
 
-const darken = (rgb: RGB, amount: number): RGB =>
-  rgb.map((c) => Math.round(c * (1 - amount))) as RGB;
-
-const lighten = (rgb: RGB, amount: number): RGB =>
-  lerpRgb(rgb, [255, 255, 255], amount);
-
-const tint = (rgb: RGB, color: RGB, amount: number): RGB =>
-  lerpRgb(rgb, color, amount);
-
-/** Weather treatments keyed by WMO weather-code "family". */
-type WeatherTreatment = (rgb: RGB) => RGB;
-
-const WEATHER_TREATMENTS: Record<string, WeatherTreatment> = {
-  clear: (rgb) => rgb,
-  partlyCloudy: (rgb) => lighten(desaturate(rgb, 0.28), 0.04),
-  fog: (rgb) => lighten(desaturate(rgb, 0.72), 0.16),
-  drizzle: (rgb) => tint(darken(desaturate(rgb, 0.42), 0.12), [92, 104, 120], 0.16),
-  rain: (rgb) => tint(darken(desaturate(rgb, 0.46), 0.2), [78, 92, 110], 0.24),
-  snow: (rgb) => tint(lighten(desaturate(rgb, 0.55), 0.2), [220, 228, 236], 0.12),
-  thunderstorm: (rgb) =>
-    tint(darken(desaturate(rgb, 0.5), 0.4), [58, 54, 80], 0.22),
-};
-
-/** Map a WMO weather code to a treatment family. */
-function weatherCodeToFamily(code: number | null | undefined): string {
+/** Map a WMO weather code to a gradient family. */
+function weatherCodeToFamily(code: number | null | undefined): WeatherFamily {
   if (code == null) return "clear";
   if (code === 0) return "clear";
   if (code <= 3) return "partlyCloudy";
@@ -273,18 +330,17 @@ function weatherCodeToFamily(code: number | null | undefined): string {
 }
 
 /**
- * Compute the [top, mid, bottom] gradient colors for the current time of day,
- * re-tinted to match the supplied weather code. A `null`/`undefined` code (e.g.
- * while the live weather is still loading) falls back to the plain day/night
- * gradient.
+ * Compute the [top, mid, bottom] gradient colors for the supplied weather code
+ * at the given time of day, using that condition's dedicated palette. A
+ * `null`/`undefined` code (e.g. while the live weather is still loading) falls
+ * back to the clear-sky gradient.
  */
 export function getWeatherGradientColors(
   code: number | null | undefined,
   date: Date = new Date()
 ): [RGB, RGB, RGB] {
-  const base = getDayNightGradientColors(date);
-  const treat = WEATHER_TREATMENTS[weatherCodeToFamily(code)] ?? ((c: RGB) => c);
-  return [treat(base[0]), treat(base[1]), treat(base[2])];
+  const frames = WEATHER_KEYFRAMES[weatherCodeToFamily(code)];
+  return interpolateGradientKeyframes(frames, date);
 }
 
 /** Build a CSS `linear-gradient(...)` string for the current time + weather. */


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Walkthrough

<a href="https://cursor.com/agents/bc-019ec5d6-249c-7f2b-be3a-9941ef9096f3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdynamic_wallpapers_demo.mp4"><img src="https://cursor.com/artifacts/c/art-8cb8f158-feef-4d69-a657-a53d96364440" alt="dynamic_wallpapers_demo.mp4" /></a>

Selecting the new **Lyrics** wallpaper (now-playing synced lyrics over the animated mesh-gradient shader), then switching to the **Weather** wallpaper from the Dynamic picker category.

The lyric highlight color is derived from the now-playing cover palette, just like the Karaoke overlay — so it changes per song. Warm cover → warm highlight; cool cover → cool highlight:

![Lyrics highlight matches warm Ariana Grande cover (gold)](https://cursor.com/artifacts/c/art-a6b2a8c1-d4c4-4ed4-bb5a-11481328e11d)
![Lyrics highlight matches cool BIGBANG cover (cyan)](https://cursor.com/artifacts/c/art-ab3ed3f9-9c0b-49bb-a84a-048598c1ab09)

The lyrics reserve bottom space so they clear the dock/taskbar — plus the iPod pop player (PiP) when it's active — with a larger offset for Aqua Glass than classic Aqua, and an extra lift so the bottom line breathes instead of hugging the dock:

![Lyrics raised off the dock (classic Aqua)](https://cursor.com/artifacts/c/art-0237a00f-3206-4f09-aa35-16f1b2a89dbf)
![Lyrics clearing the pop player and dock (Aqua Glass)](https://cursor.com/artifacts/c/art-890ad477-67ef-4d81-9d87-588c3970e702)

Each weather condition has its **own** set of time-of-day gradients (no longer a tint over the day/night sky). Grid below shows every condition × time of day:

![Weather gradients per condition x time of day](https://cursor.com/artifacts/c/art-523701e6-8d0a-4cea-b3f1-5feca4023c3f)

## Summary

Adds two new dynamic desktop wallpapers, selectable from Control Panels → Appearance → Wallpaper picker → **Dynamic** category.

### `dynamic://weather` — Weather
A gradient driven by **weather condition + time of day**. Each WMO weather family has its **own dedicated set of time-of-day keyframes** (interpolated through night → dawn → day → dusk), independent of the day/night gradient. Live condition is fetched from Open-Meteo (via browser geolocation, San Francisco fallback):

- Clear → vivid blue sky
- Partly cloudy / overcast → soft, hazy blues and warm greys
- Fog → washed-out pale grey, low contrast
- Drizzle / Rain → cool, moody blue-grey (rain darker than drizzle)
- Snow → bright, cool pale blue-white
- Thunderstorm → dark, ominous purple-grey

### `dynamic://lyrics` — Lyrics
The now-playing **synced lyrics** rendered over the **same animated Paper mesh-gradient ("gradient paper") shader** used by the iPod / Karaoke "Gradient" display mode, tinted by the current cover-art palette. The lyric **highlight color is derived from the cover palette** (passing `coverUrl` / `coverColor` / `onCoverColorResolved` to `LyricsDisplay`), exactly like the Karaoke fullscreen overlay, so the text color matches the song. Lyrics are sized using the Karaoke fullscreen styling so they display large and prominent across the desktop, and reserve bottom clearance so they sit above the dock/taskbar (and the iPod pop player when it's showing) — with a larger offset for Aqua Glass than classic Aqua, plus an extra lift for breathing room. It mirrors `useNowPlayingCover` precedence (active player wins, iPod over Karaoke; otherwise whichever has a current track) and independently loads lyrics + furigana so it works whether or not the iPod / Karaoke windows are open.

## Changes
- `src/utils/dynamicWallpaper.ts` — new `WEATHER_WALLPAPER` / `LYRICS_WALLPAPER` descriptors, guards, a shared `interpolateGradientKeyframes` helper, and per-condition `WEATHER_KEYFRAMES` powering `getWeatherGradientColors` / `getWeatherGradientCss`.
- `src/hooks/useWeatherWallpaper.ts` — live weather fetch (Open-Meteo + geolocation, cached/refreshed).
- `src/hooks/useNowPlayingLyrics.ts` — consolidated now-playing track + cover + synced lyrics for the lyrics wallpaper.
- `src/apps/ipod/hooks/useIpodPipActive.ts` — detects when the iPod pop player (PiP) is visible (for lyrics bottom clearance).
- `src/components/layout/desktop/DesktopDynamicWallpaper.tsx` — weather + lyrics layers, theme/PiP-aware lyrics clearance, and cover-palette lyric coloring via `useSaveSongCoverColor`.
- `src/apps/control-panels/components/WallpaperPicker.tsx` — Weather / Lyrics tiles in the Dynamic category.
- Localized `weather` / `lyrics` labels across all 10 locales.

## Testing
- `npx tsc --noEmit` — passes
- `npx eslint` (changed files) — no errors
- Rendered every weather condition × time of day from the real `getWeatherGradientCss` into a preview grid (see walkthrough) — confirms each condition is a distinct palette that still shifts through the day, not a tint over day/night.
- Manual desktop testing: selected the Lyrics wallpaper and switched the now-playing song from a warm-cover track (Ariana Grande) to a cool-cover track (BIGBANG); confirmed the highlighted lyric line color tracks the cover palette (gold → cyan) and that lyrics clear the dock/PiP across themes. Note: lyric advancement was exercised with a temporary elapsed-clock nudge during capture because YouTube playback is blocked in the cloud test browser; that demo-only code is not part of the committed change.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ec5d6-249c-7f2b-be3a-9941ef9096f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ec5d6-249c-7f2b-be3a-9941ef9096f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

