### PR TITLE
fix(wallpaper): center icon above label and match selection ring on dynamic tiles

### DIFF
--- a/src/apps/control-panels/components/WallpaperPicker.tsx
+++ b/src/apps/control-panels/components/WallpaperPicker.tsx
@@ -171,8 +171,8 @@ interface SpecialTileProps {
   /** Optional muted looping video rendered as the tile background. */
   backgroundVideoUrl?: string;
   /**
-   * Optional icon element centered in the space above the label. Rendered in
-   * its own flex-grow row so the bottom label never shifts it off-center.
+   * Optional icon element centered in the tile and nudged slightly upward so
+   * it reads as centered in the space above the label.
    */
   icon?: React.ReactNode;
   /**
@@ -204,7 +204,7 @@ function SpecialTile({
       type="button"
       className={`preview-button relative w-full ${
         isTile ? "aspect-square" : "aspect-video"
-      } cursor-pointer hover:opacity-90 flex flex-col overflow-hidden text-white`}
+      } cursor-pointer hover:opacity-90 flex items-center justify-center overflow-hidden text-white`}
       style={{
         backgroundColor: "#2a2a32",
         ...backgroundStyle,
@@ -248,26 +248,27 @@ function SpecialTile({
           />
         </>
       )}
-      {/* Icon occupies its own flex-grow row so it stays centered within the
-          space that remains above the label (rather than the full tile). The
-          row is always rendered — even when there's no icon — so the label
-          keeps its position. */}
-      <span
-        className="relative flex min-h-0 flex-1 items-center justify-center text-white opacity-[0.85]"
-        style={{
-          // Uniform element opacity (not color alpha) so the tile art shows
-          // through the glyph consistently. A simple drop-shadow keeps it
-          // legible on dark gradients, bright covers and busy patterns alike.
-          filter: "drop-shadow(0 1px 2px rgba(0,0,0,0.6))",
-        }}
-      >
-        {icon}
-      </span>
+      {/* Icon is centered in the tile, then nudged up by roughly half the
+          label height so it reads as centered in the space above the label
+          without floating too high. */}
+      {icon && (
+        <span
+          className="relative flex -translate-y-[5px] items-center justify-center text-white opacity-[0.85]"
+          style={{
+            // Uniform element opacity (not color alpha) so the tile art shows
+            // through the glyph consistently. A simple drop-shadow keeps it
+            // legible on dark gradients, bright covers and busy patterns alike.
+            filter: "drop-shadow(0 1px 2px rgba(0,0,0,0.6))",
+          }}
+        >
+          {icon}
+        </span>
+      )}
       {/* White label dimmed via element opacity (matching the icon) with a
           single soft dark text-shadow. Crisp and readable on dark gradients,
           bright covers and busy patterns without any blend modes. */}
       <span
-        className="relative w-full px-1 pt-1 pb-0.5 text-[10px] leading-tight text-center font-medium truncate text-white opacity-[0.85]"
+        className="absolute inset-x-0 bottom-0 px-1 pt-1 pb-0.5 text-[10px] leading-tight text-center font-medium truncate text-white opacity-[0.85]"
         style={{
           textShadow: "0 1px 2px rgba(0,0,0,0.6)",
         }}

--- a/src/apps/control-panels/components/WallpaperPicker.tsx
+++ b/src/apps/control-panels/components/WallpaperPicker.tsx
@@ -268,7 +268,7 @@ function SpecialTile({
           single soft dark text-shadow. Crisp and readable on dark gradients,
           bright covers and busy patterns without any blend modes. */}
       <span
-        className="absolute inset-x-0 bottom-0 px-1 pt-1 pb-0.5 text-[10px] leading-tight text-center font-medium truncate text-white opacity-[0.85]"
+        className="absolute inset-x-0 bottom-1 px-1 pt-1 pb-0.5 text-[10px] leading-tight text-center font-medium truncate text-white opacity-[0.85]"
         style={{
           textShadow: "0 1px 2px rgba(0,0,0,0.6)",
         }}

--- a/src/apps/control-panels/components/WallpaperPicker.tsx
+++ b/src/apps/control-panels/components/WallpaperPicker.tsx
@@ -170,7 +170,10 @@ interface SpecialTileProps {
   backgroundStyle?: React.CSSProperties;
   /** Optional muted looping video rendered as the tile background. */
   backgroundVideoUrl?: string;
-  /** Optional icon element rendered centered in the tile. */
+  /**
+   * Optional icon element centered in the space above the label. Rendered in
+   * its own flex-grow row so the bottom label never shifts it off-center.
+   */
   icon?: React.ReactNode;
   /**
    * Render a plain dark scrim (no blur) under the icon + label. Used for tiles
@@ -201,12 +204,12 @@ function SpecialTile({
       type="button"
       className={`preview-button relative w-full ${
         isTile ? "aspect-square" : "aspect-video"
-      } cursor-pointer hover:opacity-90 flex items-center justify-center overflow-hidden text-white`}
+      } cursor-pointer hover:opacity-90 flex flex-col overflow-hidden text-white`}
       style={{
         backgroundColor: "#2a2a32",
         ...backgroundStyle,
         boxShadow: isSelected
-          ? "0 0 0 1px transparent, 0 0 0 3px var(--os-color-selection-bg)"
+          ? "0 0 0 1px var(--os-color-selection-ring-gap), 0 0 0 3px var(--os-color-selection-bg)"
           : undefined,
       }}
       onClick={handleClick}
@@ -245,24 +248,26 @@ function SpecialTile({
           />
         </>
       )}
-      {icon && (
-        <span
-          className="relative flex items-center justify-center text-white opacity-[0.85]"
-          style={{
-            // Uniform element opacity (not color alpha) so the tile art shows
-            // through the glyph consistently. A simple drop-shadow keeps it
-            // legible on dark gradients, bright covers and busy patterns alike.
-            filter: "drop-shadow(0 1px 2px rgba(0,0,0,0.6))",
-          }}
-        >
-          {icon}
-        </span>
-      )}
+      {/* Icon occupies its own flex-grow row so it stays centered within the
+          space that remains above the label (rather than the full tile). The
+          row is always rendered — even when there's no icon — so the label
+          keeps its position. */}
+      <span
+        className="relative flex min-h-0 flex-1 items-center justify-center text-white opacity-[0.85]"
+        style={{
+          // Uniform element opacity (not color alpha) so the tile art shows
+          // through the glyph consistently. A simple drop-shadow keeps it
+          // legible on dark gradients, bright covers and busy patterns alike.
+          filter: "drop-shadow(0 1px 2px rgba(0,0,0,0.6))",
+        }}
+      >
+        {icon}
+      </span>
       {/* White label dimmed via element opacity (matching the icon) with a
           single soft dark text-shadow. Crisp and readable on dark gradients,
           bright covers and busy patterns without any blend modes. */}
       <span
-        className="absolute inset-x-0 bottom-0 px-1 pt-1 pb-0.5 text-[10px] leading-tight text-center font-medium truncate text-white opacity-[0.85]"
+        className="relative w-full px-1 pt-1 pb-0.5 text-[10px] leading-tight text-center font-medium truncate text-white opacity-[0.85]"
         style={{
           textShadow: "0 1px 2px rgba(0,0,0,0.6)",
         }}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Polishes the dynamic-wallpaper tiles (Day/Night, Now Playing) introduced in #1500. The shared `SpecialTile` (also used by the Shuffle tiles) now:

- **Nudges the icon slightly above the tile center** (≈5px) so it reads as centered in the space above the label without floating too high.
- **Lifts the text label off the bottom edge** (`bottom-1`) for a bit of breathing room, balancing the raised icon.
- **Uses the same selection ring as the other wallpapers** — the 1px gap now uses `var(--os-color-selection-ring-gap)` (white) to match `WallpaperItem`, instead of `transparent`.

## Walkthrough

Dynamic category — current result (icon nudged up, label lifted off the bottom, white-gap selection ring):

![Dynamic tiles](https://cursor.com/artifacts/c/art-2b7a6768-7e21-4005-937c-1afcd384f575)

## Testing
- `tsc -b` — passes
- `eslint` on the changed file — only pre-existing `exhaustive-deps` warnings
- Verified rendering with Playwright against the dev server.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ec5cc-f036-7a80-a02f-88f37fa8ffd4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ec5cc-f036-7a80-a02f-88f37fa8ffd4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

