### PR TITLE
fix(wallpaper): make shuffle rotate reliably after returning to the tab

### DIFF
--- a/src/hooks/useShuffleWallpaper.ts
+++ b/src/hooks/useShuffleWallpaper.ts
@@ -16,6 +16,13 @@ import {
  * to the store's runtime `wallpaperSource` so the desktop, menubar tint, and
  * accent sampling all see a real image while the persisted selection stays the
  * shuffle descriptor.
+ *
+ * Rotation is wall-clock based rather than relying solely on `setInterval`:
+ * browsers throttle (and during device sleep fully suspend) background-tab
+ * timers, so a plain interval would silently stall while the tab is hidden.
+ * We additionally rotate when the tab becomes visible/focused again if more
+ * than {@link SHUFFLE_INTERVAL_MS} has elapsed since the last swap — so coming
+ * back after being away always lands on a fresh wallpaper.
  */
 export function useShuffleWallpaper() {
   const currentWallpaper = useDisplaySettingsStore((s) => s.currentWallpaper);
@@ -36,33 +43,55 @@ export function useShuffleWallpaper() {
 
     let cancelled = false;
     let intervalId: ReturnType<typeof setInterval> | null = null;
+    let candidates: string[] = [];
+    // Wall-clock timestamp of the last swap, used to catch up after the tab
+    // (or the whole machine) was suspended and timers stopped firing.
+    let lastRotateAt = Date.now();
 
-    const rotate = (candidates: string[]) => {
+    const rotate = () => {
+      if (candidates.length === 0) return;
       const next = pickRandomCandidate(candidates, currentSourceRef.current);
       if (next) setRuntimeWallpaperSource(next);
+      lastRotateAt = Date.now();
+    };
+
+    // On regaining visibility/focus, rotate if we're overdue. Guards against
+    // background timers being throttled or suspended while the tab was hidden.
+    const rotateIfOverdue = () => {
+      if (document.visibilityState !== "visible") return;
+      if (Date.now() - lastRotateAt >= SHUFFLE_INTERVAL_MS) rotate();
     };
 
     loadWallpaperManifest()
       .then((manifest) => {
         if (cancelled) return;
-        const candidates = getShuffleCandidatePaths(manifest, target);
+        candidates = getShuffleCandidatePaths(manifest, target);
         if (candidates.length === 0) return;
 
         // Resolve immediately if the runtime source isn't already one of the
         // category's assets (e.g. fresh selection or stale descriptor).
         if (!candidates.includes(currentSourceRef.current)) {
-          rotate(candidates);
+          rotate();
+        } else {
+          // Already showing a category asset (e.g. restored from persistence):
+          // treat it as freshly shown so the next swap is a full interval away.
+          lastRotateAt = Date.now();
         }
 
-        intervalId = setInterval(() => rotate(candidates), SHUFFLE_INTERVAL_MS);
+        intervalId = setInterval(rotate, SHUFFLE_INTERVAL_MS);
       })
       .catch((err) =>
         console.error("Failed to load manifest for shuffle wallpaper", err)
       );
 
+    document.addEventListener("visibilitychange", rotateIfOverdue);
+    window.addEventListener("focus", rotateIfOverdue);
+
     return () => {
       cancelled = true;
       if (intervalId) clearInterval(intervalId);
+      document.removeEventListener("visibilitychange", rotateIfOverdue);
+      window.removeEventListener("focus", rotateIfOverdue);
     };
     // Re-run when the descriptor changes (category switch / disable).
   }, [currentWallpaper, setRuntimeWallpaperSource]);

--- a/src/utils/dynamicWallpaper.ts
+++ b/src/utils/dynamicWallpaper.ts
@@ -29,7 +29,7 @@ export const COVER_WALLPAPER = "dynamic://cover";
  * a fresh pick when the tab regains visibility/focus after being away longer
  * than this, since browsers throttle/suspend background-tab timers.
  */
-export const SHUFFLE_INTERVAL_MS = 60 * 1000;
+export const SHUFFLE_INTERVAL_MS = 5 * 60 * 1000;
 
 export function isDynamicWallpaper(wallpaper: string | undefined | null): boolean {
   return (

--- a/src/utils/dynamicWallpaper.ts
+++ b/src/utils/dynamicWallpaper.ts
@@ -23,8 +23,13 @@ export const SHUFFLE_PREFIX = "shuffle://";
 export const DAY_NIGHT_GRADIENT_WALLPAPER = "dynamic://gradient/day-night";
 export const COVER_WALLPAPER = "dynamic://cover";
 
-/** How often shuffle wallpapers swap to a new random pick. */
-export const SHUFFLE_INTERVAL_MS = 2 * 60 * 1000;
+/**
+ * How often shuffle wallpapers swap to a new random pick. Rotation is
+ * wall-clock based (see `useShuffleWallpaper`): the desktop also catches up to
+ * a fresh pick when the tab regains visibility/focus after being away longer
+ * than this, since browsers throttle/suspend background-tab timers.
+ */
+export const SHUFFLE_INTERVAL_MS = 60 * 1000;
 
 export function isDynamicWallpaper(wallpaper: string | undefined | null): boolean {
   return (


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Wallpaper **Shuffle** appeared not to work. The desktop changed once when you selected a shuffle category, but then often never rotated again.

Root cause: rotation relied solely on `setInterval`. Browsers heavily throttle background-tab timers and fully suspend them during device sleep, so the interval would silently stall while the tab was hidden — and on return it did **not** catch up. So if you left for a while and came back (the exact scenario raised in review), the wallpaper hadn't changed.

## Fix

`src/hooks/useShuffleWallpaper.ts`
- Track the last swap with a wall-clock timestamp (`lastRotateAt`).
- Add `visibilitychange` + `focus` listeners that rotate when overdue (elapsed ≥ `SHUFFLE_INTERVAL_MS`), so returning to the tab after being away always lands on a fresh wallpaper — robust to timer throttling/suspension.
- Restored assets (e.g. from persistence) are treated as freshly shown so the next swap is a full interval away.

`src/utils/dynamicWallpaper.ts`
- Interval set to **5 minutes**. The catch-up-on-return logic makes a long interval feel responsive: come back after 5+ minutes away and the wallpaper refreshes immediately.

Note: `<Desktop>` mounts once, so this runs a single interval (no stacking).

## Testing

Verified live in the browser (dev server) with temporary shortened intervals + console instrumentation that were reverted before commit:
- Immediate change on shuffle selection; steady automatic rotation through distinct category assets.
- **Catch-up on return verified in isolation** (interval disabled): the wallpaper stayed put while watching, then changed on return after being hidden, with `visibilitychange/focus` elapsed (15s, 97s) exceeding the threshold and triggering the catch-up rotation. This also proved there are no stray/stacked timers.
- ✅ `tsc -b` and ✅ `eslint` pass.

Shuffle selected (Aqua) with a resolved random asset:

![Shuffle tile selected in Aqua category with resolved aurora wallpaper](https://cursor.com/artifacts/c/art-f8b52ff7-8fa4-44da-991a-32bfa27dc755)

A different asset after rotation:

![Desktop showing a different Aqua asset after rotation](https://cursor.com/artifacts/c/art-a5361fca-691a-431a-bf5b-aec3251a3b8c)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ec5ca-2cdd-7468-9221-725ac3e8163c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ec5ca-2cdd-7468-9221-725ac3e8163c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

