### PR TITLE
Show matching wallpaper on the shuffle tile

### DIFF
--- a/src/apps/control-panels/components/WallpaperPicker.tsx
+++ b/src/apps/control-panels/components/WallpaperPicker.tsx
@@ -214,6 +214,7 @@ function SpecialTile({
   return (
     <button
       type="button"
+      aria-label={label}
       className={`preview-button relative w-full ${
         isTile ? "aspect-square" : "aspect-video"
       } cursor-pointer hover:opacity-90 flex items-center justify-center overflow-hidden text-white`}
@@ -249,23 +250,28 @@ function SpecialTile({
             aria-hidden
             className="pointer-events-none absolute inset-0 bg-black/30"
           />
-          {/* Stronger bottom-up gradient anchoring the label. No blur. */}
-          <span
-            aria-hidden
-            className="pointer-events-none absolute inset-x-0 bottom-0 h-2/3"
-            style={{
-              background:
-                "linear-gradient(to top, rgba(0,0,0,0.6), transparent)",
-            }}
-          />
+          {/* Stronger bottom-up gradient anchoring the label. No blur. Skipped
+              on small tiles where the label is hidden. */}
+          {!isTile && (
+            <span
+              aria-hidden
+              className="pointer-events-none absolute inset-x-0 bottom-0 h-2/3"
+              style={{
+                background:
+                  "linear-gradient(to top, rgba(0,0,0,0.6), transparent)",
+              }}
+            />
+          )}
         </>
       )}
-      {/* Icon is centered in the tile, then nudged up by roughly half the
-          label height so it reads as centered in the space above the label
-          without floating too high. */}
+      {/* Icon is centered in the tile. When a label is shown it is nudged up by
+          roughly half the label height so it reads as centered in the space
+          above the label; on small tiles (no label) it stays truly centered. */}
       {icon && (
         <span
-          className="relative flex -translate-y-[5px] items-center justify-center text-white opacity-[0.85]"
+          className={`relative flex items-center justify-center text-white opacity-[0.85] ${
+            isTile ? "" : "-translate-y-[5px]"
+          }`}
           style={{
             // Uniform element opacity (not color alpha) so the tile art shows
             // through the glyph consistently. A simple drop-shadow keeps it
@@ -277,16 +283,18 @@ function SpecialTile({
         </span>
       )}
       {/* White label dimmed via element opacity (matching the icon) with a
-          single soft dark text-shadow. Crisp and readable on dark gradients,
-          bright covers and busy patterns without any blend modes. */}
-      <span
-        className="absolute inset-x-0 bottom-1 px-1 pt-1 pb-0.5 text-[10px] leading-tight text-center font-medium truncate text-white opacity-[0.85]"
-        style={{
-          textShadow: "0 1px 2px rgba(0,0,0,0.6)",
-        }}
-      >
-        {label}
-      </span>
+          single soft dark text-shadow. Hidden on small tiles (e.g. Patterns)
+          where there isn't room for legible text. */}
+      {!isTile && (
+        <span
+          className="absolute inset-x-0 bottom-1 px-1 pt-1 pb-0.5 text-[10px] leading-tight text-center font-medium truncate text-white opacity-[0.85]"
+          style={{
+            textShadow: "0 1px 2px rgba(0,0,0,0.6)",
+          }}
+        >
+          {label}
+        </span>
+      )}
     </button>
   );
 }

--- a/src/apps/control-panels/components/WallpaperPicker.tsx
+++ b/src/apps/control-panels/components/WallpaperPicker.tsx
@@ -37,8 +37,12 @@ import {
   isShuffleWallpaper,
   isWeatherWallpaper,
   parseShuffleDescriptor,
+  pickDeterministicCandidate,
+  shuffleBucket,
+  SHUFFLE_INTERVAL_MS,
 } from "@/utils/dynamicWallpaper";
 import { DEFAULT_COVER_PALETTE } from "@/hooks/useCoverPalette";
+import { useChatsStore } from "@/stores/useChatsStore";
 import { useTranslation } from "react-i18next";
 
 // Remove unused constants
@@ -313,6 +317,28 @@ export function WallpaperPicker({ onSelect }: WallpaperPickerProps) {
   const { play: playClick } = useSound(Sounds.BUTTON_CLICK, 0.3);
   const displayMode = useDisplaySettingsStore((s) => s.displayMode);
   const setDisplayMode = useDisplaySettingsStore((s) => s.setDisplayMode);
+  // Same per-user seed component used by `useShuffleWallpaper`, so the preview
+  // resolves to the exact asset the desktop would (and other devices do) show.
+  const username = useChatsStore((s) => s.username);
+  // Advance a tick at each wall-clock bucket boundary so inactive shuffle tile
+  // previews rotate in lockstep with what shuffle would actually display.
+  const [shuffleTick, setShuffleTick] = useState(() => shuffleBucket());
+  useEffect(() => {
+    let intervalId: ReturnType<typeof setInterval> | null = null;
+    const msToNextBoundary =
+      SHUFFLE_INTERVAL_MS - (Date.now() % SHUFFLE_INTERVAL_MS);
+    const timeoutId = setTimeout(() => {
+      setShuffleTick(shuffleBucket());
+      intervalId = setInterval(
+        () => setShuffleTick(shuffleBucket()),
+        SHUFFLE_INTERVAL_MS
+      );
+    }, msToNextBoundary);
+    return () => {
+      clearTimeout(timeoutId);
+      if (intervalId) clearInterval(intervalId);
+    };
+  }, []);
   const { t } = useTranslation();
   const nowPlaying = useNowPlayingCover();
   // Preview the gradient for the current time of day (static within a session).
@@ -429,22 +455,32 @@ export function WallpaperPicker({ onSelect }: WallpaperPickerProps) {
     return r;
   }, [manifest]);
 
-  // Pick a stable random preview per category so the Shuffle tile hints at the
-  // art it will cycle through. Keyed on the source arrays so it only re-rolls
-  // when the manifest (or selected category) changes — not on every render.
-  const pickRandom = (arr: string[]): string | undefined =>
-    arr.length ? arr[Math.floor(Math.random() * arr.length)] : undefined;
-  const randomTileShuffleArt = useMemo(
-    () => pickRandom(tileWallpapers),
-    [tileWallpapers]
+  // Shuffle picks are deterministic per (user, descriptor, wall-clock bucket),
+  // so the Shuffle tile can preview the *exact* asset shuffle would resolve to
+  // right now — matching the desktop and the user's other devices — instead of
+  // an arbitrary random hint. `shuffleTick` keeps it rotating in lockstep.
+  const pickShuffleArt = (
+    arr: string[],
+    category: "tiles" | "videos" | string
+  ): string | undefined =>
+    pickDeterministicCandidate(
+      arr,
+      `${username ?? "anon"}|${buildShuffleDescriptor(category)}`
+    ) ?? undefined;
+  const tileShuffleArt = useMemo(
+    () => pickShuffleArt(tileWallpapers, "tiles"),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [tileWallpapers, username, shuffleTick]
   );
-  const randomVideoShuffleArt = useMemo(
-    () => pickRandom(videoWallpapers),
-    [videoWallpapers]
+  const videoShuffleArt = useMemo(
+    () => pickShuffleArt(videoWallpapers, "videos"),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [videoWallpapers, username, shuffleTick]
   );
-  const randomPhotoShuffleArt = useMemo(
-    () => pickRandom(photoWallpapers[selectedCategory] ?? []),
-    [photoWallpapers, selectedCategory]
+  const photoShuffleArt = useMemo(
+    () => pickShuffleArt(photoWallpapers[selectedCategory] ?? [], selectedCategory),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [photoWallpapers, selectedCategory, username, shuffleTick]
   );
 
   // When a category's shuffle is the *active* wallpaper, mirror the concrete
@@ -772,7 +808,7 @@ export function WallpaperPicker({ onSelect }: WallpaperPickerProps) {
                   const active =
                     currentWallpaper === buildShuffleDescriptor("tiles");
                   const art =
-                    (active && liveShuffleSource) || randomTileShuffleArt;
+                    (active && liveShuffleSource) || tileShuffleArt;
                   return art
                     ? {
                         backgroundImage: `url("${art}")`,
@@ -807,7 +843,7 @@ export function WallpaperPicker({ onSelect }: WallpaperPickerProps) {
                 backgroundVideoUrl={
                   (currentWallpaper === buildShuffleDescriptor("videos") &&
                     liveShuffleSource) ||
-                  randomVideoShuffleArt
+                  videoShuffleArt
                 }
                 icon={<Shuffle className="size-6 text-white" weight="bold" />}
               />
@@ -881,7 +917,7 @@ export function WallpaperPicker({ onSelect }: WallpaperPickerProps) {
                     currentWallpaper ===
                     buildShuffleDescriptor(selectedCategory);
                   const art =
-                    (active && liveShuffleSource) || randomPhotoShuffleArt;
+                    (active && liveShuffleSource) || photoShuffleArt;
                   return art
                     ? {
                         backgroundImage: `url("${art}")`,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Dynamic shuffle wallpapers are now deterministic per `(user, descriptor, wall-clock bucket)` (see `pickDeterministicCandidate` / `useShuffleWallpaper`). This makes the Wallpaper picker's Shuffle tile show the **exact** asset shuffle would resolve to right now, rather than an arbitrary `Math.random()` hint.

### Changes
- `WallpaperPicker.tsx`: replace the random per-category preview pick (`pickRandom`) with `pickDeterministicCandidate`, seeded with the same `${username}|${descriptor}` scheme used by `useShuffleWallpaper`. The Patterns, Videos, and per-photo-category Shuffle tiles now preview the wallpaper the desktop (and the user's other devices) would currently display.
- Added a wall-clock bucket `shuffleTick` so inactive Shuffle tile previews rotate in lockstep with shuffle's 5-minute rotation while the picker is open.
- `SpecialTile`: on small (square `isTile`) tiles such as Patterns, hide the text label and center the icon (drop the upward nudge and the label gradient). The label is preserved as an `aria-label` for accessibility.

When a category's shuffle is the active wallpaper, the tile continues to mirror the live resolved `wallpaperSource` (which now equals the same deterministic pick).

## Testing
- `bunx tsc -b` — passes
- `bunx eslint src/apps/control-panels/components/WallpaperPicker.tsx` — only pre-existing warnings, no new errors
- `bun test tests/test-shuffle-wallpaper-deterministic.test.ts` — 6 pass

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ec82c-7c49-7fab-9134-57381e611e51"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ec82c-7c49-7fab-9134-57381e611e51"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

