### PR TITLE
fix(telegram): stop document tool-call retry loop with idempotent updates

### DIFF
--- a/api/_utils/telegram-link.ts
+++ b/api/_utils/telegram-link.ts
@@ -325,6 +325,25 @@ export async function markTelegramUpdateProcessed(
   });
 }
 
+/**
+ * Atomically claim an update for processing. Returns true only for the caller
+ * that wins the claim; concurrent or retried deliveries of the same update_id
+ * get false so they can be skipped. This guards the expensive AI/tool pipeline
+ * against Telegram's automatic webhook retries (which fire whenever a slow turn
+ * exceeds Telegram's delivery timeout) re-running the same message in parallel.
+ */
+export async function claimTelegramUpdate(
+  redis: RedisLike,
+  updateId: number,
+  ttlSeconds: number = TELEGRAM_UPDATE_TTL_SECONDS
+): Promise<boolean> {
+  const result = await redis.set(buildTelegramProcessedUpdateKey(updateId), "1", {
+    nx: true,
+    ex: ttlSeconds,
+  });
+  return result === "OK" || result === true;
+}
+
 export async function loadTelegramConversationHistory(
   redis: RedisLike,
   chatId: string,

--- a/api/webhooks/telegram.ts
+++ b/api/webhooks/telegram.ts
@@ -5,6 +5,7 @@ import createRedis from "../_utils/redis.js";
 import * as RateLimit from "../_utils/_rate-limit.js";
 import {
   appendTelegramConversationMessage,
+  claimTelegramUpdate,
   clearTelegramConversationHistory,
   getLinkedTelegramAccountByTelegramUserId,
   hasProcessedTelegramUpdate,
@@ -262,6 +263,26 @@ type TelegramStatusStreamChunk =
       providerExecuted?: boolean;
     };
 
+export function extractTelegramToolResultMessage(
+  output: unknown
+): { message: string; success: boolean } | null {
+  if (!output || typeof output !== "object" || !("message" in output)) {
+    return null;
+  }
+
+  const message = (output as { message?: unknown }).message;
+  if (typeof message !== "string" || message.trim().length === 0) {
+    return null;
+  }
+
+  const success = (output as { success?: unknown }).success;
+  return {
+    message: message.trim(),
+    // Treat missing success as truthy so tools that don't report it still count.
+    success: success !== false,
+  };
+}
+
 export function getTelegramProviderStatusToolCall(
   chunk: TelegramStatusStreamChunk
 ): { toolCallId: string; toolName: string; input: unknown } | null {
@@ -462,6 +483,21 @@ export default async function handler(
     return;
   }
 
+  // Claim the update before any rate-limit accounting or the expensive AI/tool
+  // pipeline. Telegram re-delivers any update it doesn't get a timely 2xx for,
+  // and a multi-step tool turn (e.g. creating a document) can easily outlast that
+  // window. Without an atomic claim, each retry re-enters processing in parallel,
+  // which the user sees as the bot looping on the same status (e.g. "Reading
+  // document...") and can even double-apply tool side effects.
+  if (!(await claimTelegramUpdate(redis, parsedUpdate.updateId))) {
+    logger.info("Skipping in-flight or already-processed Telegram update", {
+      updateId: parsedUpdate.updateId,
+    });
+    logger.response(202, Date.now() - startTime);
+    sendJson(res, 202, { ignored: true, reason: "duplicate-update" });
+    return;
+  }
+
   const isExemptUser = linkedAccount.username === "ryo";
 
   if (!isExemptUser) {
@@ -644,6 +680,11 @@ export default async function handler(
   });
   const reportedProviderToolCalls = new Set<string>();
   const shouldSendVoiceOnlyReply = Boolean(parsedUpdate.voiceFileId);
+  // Track the latest tool result messages so we can still reply with something
+  // useful (e.g. "Created document 'todo.md'.") when the model ends a turn on a
+  // tool call without emitting any assistant text.
+  let lastToolSuccessMessage = "";
+  let lastToolMessage = "";
 
   try {
     await statusReporter.start();
@@ -679,6 +720,19 @@ export default async function handler(
     const textStream = textStreamFromFullStream(
       result.fullStream,
       async (chunk) => {
+        if (chunk.type === "tool-result") {
+          const toolMessage = extractTelegramToolResultMessage(
+            (chunk as { output?: unknown }).output
+          );
+          if (toolMessage) {
+            lastToolMessage = toolMessage.message;
+            if (toolMessage.success) {
+              lastToolSuccessMessage = toolMessage.message;
+            }
+          }
+          return;
+        }
+
         if (chunk.type !== "tool-input-start" && chunk.type !== "tool-call") {
           return;
         }
@@ -730,14 +784,42 @@ export default async function handler(
           logWarn: (message, details) => logger.warn(message, details),
         });
 
-    if (!replyText) {
-      logger.warn("Generated empty Telegram reply", {
-        username: linkedAccount.username,
-        updateId: parsedUpdate.updateId,
-      });
-      logger.response(500, Date.now() - startTime);
-      sendJson(res, 500, { error: "Generated empty reply" });
-      return;
+    // When the model finishes a turn on a tool call without emitting assistant
+    // text (common after a successful documentsControl write), fall back to the
+    // tool's own confirmation message so the user still gets a reply and Telegram
+    // does not keep retrying the update.
+    let outboundText = replyText;
+    if (!outboundText) {
+      const fallback = lastToolSuccessMessage || lastToolMessage;
+      outboundText = fallback
+        ? normalizeTelegramReplyText(fallback, {
+            formatText: simplifyTelegramCitationDisplay,
+          })
+        : "";
+      if (outboundText) {
+        logger.info("Falling back to tool result message for empty reply", {
+          username: linkedAccount.username,
+          updateId: parsedUpdate.updateId,
+        });
+      } else {
+        logger.warn("Generated empty Telegram reply", {
+          username: linkedAccount.username,
+          updateId: parsedUpdate.updateId,
+        });
+        outboundText = "done.";
+      }
+
+      // The streaming helper sent nothing because the model produced no text, so
+      // deliver the fallback ourselves (voice path handles its own send below).
+      if (!shouldSendVoiceOnlyReply) {
+        await statusReporter.dispose();
+        await sendTelegramMessage({
+          botToken,
+          chatId: parsedUpdate.chatId,
+          text: outboundText,
+          replyToMessageId: parsedUpdate.messageId,
+        });
+      }
     }
 
     let voiceReplyMessageId: number | null = null;
@@ -750,7 +832,7 @@ export default async function handler(
           action: "upload_voice",
         });
         const voiceReplyAudio = await generateElevenLabsSpeech({
-          text: replyText,
+          text: outboundText,
         });
         voiceReplyMessageId = await sendTelegramVoice({
           botToken,
@@ -783,7 +865,7 @@ export default async function handler(
     });
     await appendTelegramConversationMessage(redis, parsedUpdate.chatId, {
       role: "assistant",
-      content: replyText,
+      content: outboundText,
       createdAt: timestamp,
     });
     await markTelegramUpdateProcessed(redis, parsedUpdate.updateId);
@@ -794,16 +876,45 @@ export default async function handler(
       updateId: parsedUpdate.updateId,
       hasImage: !!imageData,
       hasVoiceInput: !!parsedUpdate.voiceFileId,
-      replyLength: replyText.length,
+      replyLength: outboundText.length,
       previewMode,
       voiceReplyMessageId,
     });
     logger.response(200, Date.now() - startTime);
     sendJson(res, 200, {
       success: true,
-      reply: replyText,
+      reply: outboundText,
       voiceReplySent: voiceReplyMessageId !== null,
     });
+  } catch (error) {
+    // The update is already claimed, so retries would be skipped anyway. Ack the
+    // webhook (200) instead of letting a 500 trigger Telegram's retry storm, and
+    // let the user know something went wrong so the chat isn't left silent.
+    logger.error("Failed to handle Telegram message", {
+      username: linkedAccount.username,
+      updateId: parsedUpdate.updateId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    if (!res.headersSent) {
+      try {
+        await statusReporter.dispose();
+        await sendTelegramInfoMessage(
+          botToken,
+          parsedUpdate.chatId,
+          "something went wrong on my end. try again in a moment.",
+          parsedUpdate.messageId
+        );
+      } catch (notifyError) {
+        logger.warn("Failed to notify Telegram user about processing error", {
+          error:
+            notifyError instanceof Error
+              ? notifyError.message
+              : String(notifyError),
+        });
+      }
+      logger.response(200, Date.now() - startTime);
+      sendJson(res, 200, { success: false, reason: "processing-error" });
+    }
   } finally {
     await statusReporter.dispose();
   }

--- a/tests/test-telegram-update-claim.test.ts
+++ b/tests/test-telegram-update-claim.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, test } from "bun:test";
+import type { RedisLike } from "../api/_utils/redis";
+import {
+  claimTelegramUpdate,
+  hasProcessedTelegramUpdate,
+  markTelegramUpdateProcessed,
+} from "../api/_utils/telegram-link";
+import { extractTelegramToolResultMessage } from "../api/webhooks/telegram";
+import { FakeRedis } from "./fake-redis";
+
+function makeRedis(): RedisLike {
+  return new FakeRedis() as unknown as RedisLike;
+}
+
+describe("claimTelegramUpdate", () => {
+  test("only the first claim for an update wins", async () => {
+    const redis = makeRedis();
+    const updateId = 12345;
+
+    expect(await claimTelegramUpdate(redis, updateId)).toBe(true);
+    // A concurrent Telegram retry of the same update must be skipped so the AI
+    // pipeline does not run twice in parallel (the source of the loop bug).
+    expect(await claimTelegramUpdate(redis, updateId)).toBe(false);
+    expect(await claimTelegramUpdate(redis, updateId)).toBe(false);
+  });
+
+  test("claiming marks the update as processed for the dedup check", async () => {
+    const redis = makeRedis();
+    const updateId = 67890;
+
+    expect(await hasProcessedTelegramUpdate(redis, updateId)).toBe(false);
+    expect(await claimTelegramUpdate(redis, updateId)).toBe(true);
+    expect(await hasProcessedTelegramUpdate(redis, updateId)).toBe(true);
+  });
+
+  test("a previously processed update cannot be claimed", async () => {
+    const redis = makeRedis();
+    const updateId = 11111;
+
+    await markTelegramUpdateProcessed(redis, updateId);
+    expect(await claimTelegramUpdate(redis, updateId)).toBe(false);
+  });
+
+  test("different updates are claimed independently", async () => {
+    const redis = makeRedis();
+
+    expect(await claimTelegramUpdate(redis, 1)).toBe(true);
+    expect(await claimTelegramUpdate(redis, 2)).toBe(true);
+    expect(await claimTelegramUpdate(redis, 1)).toBe(false);
+  });
+});
+
+describe("extractTelegramToolResultMessage", () => {
+  test("returns a successful document confirmation message", () => {
+    const result = extractTelegramToolResultMessage({
+      success: true,
+      message: "Created document 'todo.md'.",
+      document: { path: "/Documents/todo.md", name: "todo.md", content: "x" },
+    });
+    expect(result).toEqual({
+      message: "Created document 'todo.md'.",
+      success: true,
+    });
+  });
+
+  test("flags failed tool results so they don't override successes", () => {
+    const result = extractTelegramToolResultMessage({
+      success: false,
+      message: "Document '/Documents/missing.md' not found.",
+    });
+    expect(result).toEqual({
+      message: "Document '/Documents/missing.md' not found.",
+      success: false,
+    });
+  });
+
+  test("treats a missing success flag as truthy", () => {
+    const result = extractTelegramToolResultMessage({ message: "Done." });
+    expect(result).toEqual({ message: "Done.", success: true });
+  });
+
+  test("returns null when there is no usable message", () => {
+    expect(extractTelegramToolResultMessage(null)).toBeNull();
+    expect(extractTelegramToolResultMessage(undefined)).toBeNull();
+    expect(extractTelegramToolResultMessage("just a string")).toBeNull();
+    expect(extractTelegramToolResultMessage({ success: true })).toBeNull();
+    expect(
+      extractTelegramToolResultMessage({ success: true, message: "   " })
+    ).toBeNull();
+  });
+});

--- a/tests/test-telegram-webhook.test.ts
+++ b/tests/test-telegram-webhook.test.ts
@@ -4,6 +4,7 @@ import { parseAuthCookie } from "../api/_utils/_cookie";
 import { createRedis } from "../api/_utils/redis";
 import {
   appendTelegramConversationMessage,
+  claimTelegramUpdate,
   createTelegramLinkCode,
   linkTelegramAccount,
   loadTelegramConversationHistory,
@@ -536,6 +537,60 @@ describe("telegram webhook", () => {
     );
 
     expect(await loadTelegramConversationHistory(redis, chatId, 10)).toEqual([]);
+  });
+
+  test("skips the AI pipeline for an already-claimed (retried) update", async () => {
+    const redis = createRedis();
+    const claimUsername = `tg_claim_${Date.now()}`;
+    const telegramUserId = String(RUN_ID + 7007);
+    const chatId = telegramUserId;
+    const updateId = UPDATE_ID_BASE + 7;
+
+    const linkSession = await createTelegramLinkCode(redis, claimUsername, 60);
+    const linkedAccount = await linkTelegramAccount(redis, {
+      code: linkSession.code,
+      telegramUserId,
+      chatId,
+      firstName: "Claim",
+    });
+    expect(linkedAccount?.username).toBe(claimUsername);
+
+    // Simulate Telegram re-delivering an update whose first delivery is already
+    // being processed (the slow document/tool turn that caused the loop). The
+    // update is claimed, so this retry must short-circuit before any AI work or
+    // Telegram API calls happen.
+    expect(await claimTelegramUpdate(redis, updateId)).toBe(true);
+
+    mockRequests.length = 0;
+
+    const retryRes = await fetch(`${TEST_BASE_URL}/api/webhooks/telegram`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Telegram-Bot-Api-Secret-Token": WEBHOOK_SECRET,
+      },
+      body: JSON.stringify({
+        update_id: updateId,
+        message: {
+          message_id: 17,
+          from: {
+            id: Number(telegramUserId),
+            first_name: "Claim",
+          },
+          chat: {
+            id: Number(chatId),
+            type: "private",
+          },
+          text: "create a document called notes",
+        },
+      }),
+    });
+
+    expect(retryRes.status).toBe(202);
+    const retryData = await retryRes.json();
+    expect(retryData.reason).toBe("duplicate-update");
+    // No AI work ran, so the bot made no Telegram API calls for this retry.
+    expect(mockRequests).toHaveLength(0);
   });
 
   test("sends a Telegram rate limit message when the burst limit is reached", async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Asking the Telegram bot to **create a new document** could get the bot stuck looping on a status like "Reading document..." and never finish.

Root cause is in the Telegram webhook handler (`api/webhooks/telegram.ts`), not the document executor itself:

1. **No idempotency before slow work.** A document turn runs several slow tool steps (`documentsControl` list/read/write). The handler only marked an update processed *after* a fully successful reply. Telegram automatically re-delivers any update it doesn't get a timely `2xx` for, so when a turn outlasted that window the same `update_id` re-entered the AI pipeline **in parallel** — the user saw the bot repeat the same tool status, and tool side effects could be double-applied.
2. **Empty reply returned `500`.** When the model ended a turn on a tool call without emitting any assistant text (common right after a successful write), the handler returned HTTP `500`. Telegram treats that as a failed delivery and retries the update — since it was never marked processed, this looped indefinitely.

## Fix

- **Atomic claim per update** (`claimTelegramUpdate`, `SET NX EX`) taken before rate-limit accounting and the AI/tool pipeline. Concurrent or retried deliveries short-circuit with `202 duplicate-update` instead of re-running.
- **Empty-reply fallback**: capture the latest tool-result `message` from the stream and reply with the tool's own confirmation (e.g. `Created document 'todo.md'.`) when the model produces no text, instead of `500`.
- **Catch + ack**: unexpected errors now ack the webhook (`200`) and notify the user, so a failure can't trigger Telegram's retry storm.

## Testing

- `bun test tests/test-telegram-update-claim.test.ts` — unit tests for the atomic claim and tool-result message extraction.
- `bun test tests/test-telegram-webhook.test.ts` — existing webhook suite + a new test proving a claimed/retried update skips the AI pipeline (no Telegram API calls).
- End-to-end against a standalone API server with a mock Telegram API:
  - Single create message → `200`, document created once, reply `created /Documents/groceries.md with milk, eggs, bread.`
  - **Two concurrent identical deliveries** (simulating Telegram retrying a slow turn) → one `200`, one `202 duplicate-update`, document created **exactly once**.
- `bunx tsc -b` and `bunx eslint` on changed files both clean.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ec83e-2e64-7632-9a44-fe0fc375018c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ec83e-2e64-7632-9a44-fe0fc375018c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

