### PR TITLE
feat(textedit): reactively merge external/sync/cloud updates without losing the caret

### DIFF
--- a/src/apps/textedit/components/TextEditAppComponent.tsx
+++ b/src/apps/textedit/components/TextEditAppComponent.tsx
@@ -20,7 +20,16 @@ import { useAudioSettingsStore } from "@/stores/useAudioSettingsStore";
 import { useLaunchApp } from "@/hooks/useLaunchApp";
 import { markdownToHtml } from "@/utils/markdown";
 import { useTranslation } from "react-i18next";
-import { onDocumentUpdated } from "@/utils/appEventBus";
+import {
+  onDocumentUpdated,
+  onDocumentContentSynced,
+} from "@/utils/appEventBus";
+import {
+  mergeEditorContent,
+  type MergeableContent,
+} from "../utils/mergeEditorContent";
+import { persistedContentToEditorContent } from "../utils/documentContent";
+import { readDocumentTextContent } from "@/services/vfs/FileContentRepository";
 import { useRegisterUndoRedo } from "@/hooks/useUndoRedo";
 import { useThemeFlags } from "@/hooks/useThemeFlags";
 import { getTextAnalytics, TEXTEDIT_ANALYTICS, track } from "@/utils/analytics";
@@ -121,7 +130,15 @@ function TextEditContent({
   useEffect(() => {
     if (!editor) return;
 
-    const handleUpdate = () => {
+    const handleUpdate = ({
+      transaction,
+    }: {
+      transaction?: { getMeta: (key: string) => unknown };
+    } = {}) => {
+      // Reactive external updates are applied as transactions tagged with the
+      // "external" meta. Ignore them here so merging cloud/sync/AI updates does
+      // not mark the document dirty or fight the user's edits.
+      if (transaction?.getMeta("external")) return;
       // Only mark changes and store latest content/JSON in onUpdate
       const currentJson = editor.getJSON();
       setContentJson(currentJson); // Update store JSON for recovery
@@ -213,28 +230,30 @@ function TextEditContent({
     handleLoadFromDatabase,
   ]);
 
+  // Reactively merge externally-sourced content (cloud sync, file sync, or AI
+  // edits) into the editor while preserving the user's caret, selection, focus
+  // and scroll position. Returns true if the document changed.
+  const applyExternalUpdate = useCallback(
+    (content: MergeableContent): boolean => {
+      if (!editor) return false;
+      const changed = mergeEditorContent(editor, content);
+      // Keep the per-instance store mirror in sync and treat external updates as
+      // a clean baseline so they don't surface as unsaved changes.
+      setContentJson(editor.getJSON());
+      setHasUnsavedChanges(false);
+      return changed;
+    },
+    [editor, setContentJson, setHasUnsavedChanges]
+  );
+
   // Add listeners for external document updates
   useEffect(() => {
     const handleUpdateEditorContent = (e: CustomEvent) => {
       if (editor && e.detail?.path === currentFilePath && e.detail?.content) {
         try {
           const jsonContent = JSON.parse(e.detail.content);
-          const { from, to } = editor.state.selection;
-
-          editor.commands.setContent(jsonContent, false);
-
-          if (from && to && from === to) {
-            try {
-              editor.commands.setTextSelection(
-                Math.min(from, editor.state.doc.content.size)
-              );
-            } catch (e) {
-              console.log("Could not restore cursor position", e);
-            }
-          }
-
-          setHasUnsavedChanges(false);
-          console.log("Editor content updated from external source");
+          applyExternalUpdate(jsonContent);
+          console.log("Editor content merged from external source");
         } catch (error) {
           console.error("Failed to update editor content:", error);
         }
@@ -245,9 +264,8 @@ function TextEditContent({
       if (editor && e.detail?.path === currentFilePath && e.detail?.content) {
         try {
           const jsonContent = JSON.parse(e.detail.content);
-          editor.commands.setContent(jsonContent, false);
-          setHasUnsavedChanges(false);
-          console.log("Editor content updated after document updated event");
+          applyExternalUpdate(jsonContent);
+          console.log("Editor content merged after document updated event");
         } catch (error) {
           console.error(
             t("apps.textedit.failedToUpdateEditorWithDocumentUpdatedEvent"),
@@ -257,11 +275,45 @@ function TextEditContent({
       }
     };
 
+    // Cloud / multi-device sync writes document content straight to storage.
+    // Re-read the source of truth and merge it so open documents stay live.
+    const handleDocumentContentSynced = (e: CustomEvent) => {
+      if (!editor || !currentFilePath) return;
+      const paths = e.detail?.paths;
+      if (!Array.isArray(paths) || !paths.includes(currentFilePath)) return;
+
+      void (async () => {
+        try {
+          const contentStr = await readDocumentTextContent(currentFilePath);
+          if (contentStr == null) return;
+          const editorContent = persistedContentToEditorContent(
+            currentFilePath,
+            contentStr
+          );
+          const changed = applyExternalUpdate(editorContent);
+          if (changed) {
+            console.log(
+              "[TextEdit] Editor content merged from cloud/file sync:",
+              currentFilePath
+            );
+          }
+        } catch (error) {
+          console.error(
+            "[TextEdit] Failed to merge synced document content:",
+            error
+          );
+        }
+      })();
+    };
+
     window.addEventListener(
       "updateEditorContent",
       handleUpdateEditorContent as EventListener
     );
     const unsubscribeDocumentUpdated = onDocumentUpdated(handleDocumentUpdated);
+    const unsubscribeDocumentContentSynced = onDocumentContentSynced(
+      handleDocumentContentSynced
+    );
 
     return () => {
       window.removeEventListener(
@@ -269,10 +321,11 @@ function TextEditContent({
         handleUpdateEditorContent as EventListener
       );
       unsubscribeDocumentUpdated();
+      unsubscribeDocumentContentSynced();
     };
-  }, [editor, currentFilePath, setHasUnsavedChanges, t]);
+  }, [editor, currentFilePath, applyExternalUpdate, t]);
 
-  // Sync editor when contentJson is externally updated
+  // Sync editor when contentJson is externally updated (e.g. AI edit tool)
   useEffect(() => {
     if (!editor || !contentJson) return;
 
@@ -280,9 +333,9 @@ function TextEditContent({
     if (JSON.stringify(currentJson) === JSON.stringify(contentJson)) return;
 
     try {
-      editor.commands.setContent(contentJson, false);
+      mergeEditorContent(editor, contentJson);
       setHasUnsavedChanges(false);
-      console.log("[TextEdit] Editor content synced from store change");
+      console.log("[TextEdit] Editor content merged from store change");
     } catch (err) {
       console.error("[TextEdit] Failed to sync editor content:", err);
     }

--- a/src/apps/textedit/utils/documentContent.ts
+++ b/src/apps/textedit/utils/documentContent.ts
@@ -1,0 +1,30 @@
+import type { JSONContent } from "@tiptap/core";
+import { markdownToHtml } from "@/utils/markdown";
+import { parseRichMarkdown } from "./richMarkdown";
+
+/**
+ * Convert a persisted document string (as stored in IndexedDB) into content the
+ * TipTap editor can ingest. Returns either TipTap/ProseMirror JSON (preferred,
+ * when the rich-markdown metadata header is present) or an HTML string.
+ *
+ * This mirrors the conversion used when first loading a file so that reactive
+ * updates produce the same document shape as an initial open.
+ */
+export function persistedContentToEditorContent(
+  path: string,
+  contentStr: string
+): JSONContent | string {
+  if (path.endsWith(".md")) {
+    const parsed = parseRichMarkdown(contentStr);
+    if (parsed.editorJson) {
+      return parsed.editorJson as JSONContent;
+    }
+    return markdownToHtml(parsed.markdown);
+  }
+
+  try {
+    return JSON.parse(contentStr) as JSONContent;
+  } catch {
+    return `<p>${contentStr}</p>`;
+  }
+}

--- a/src/apps/textedit/utils/mergeEditorContent.ts
+++ b/src/apps/textedit/utils/mergeEditorContent.ts
@@ -1,0 +1,234 @@
+import type { Editor, JSONContent } from "@tiptap/core";
+import type { Node as ProseMirrorNode } from "@tiptap/pm/model";
+import { DOMParser as ProseMirrorDOMParser } from "@tiptap/pm/model";
+import type { EditorState, Transaction } from "@tiptap/pm/state";
+import { TextSelection } from "@tiptap/pm/state";
+
+/**
+ * Content that can be merged into a TextEdit editor. Either a TipTap/ProseMirror
+ * document JSON object, or an HTML string (parsed with the editor's own schema).
+ */
+export type MergeableContent = JSONContent | string;
+
+interface MergeOptions {
+  /**
+   * When true (default) the user's selection, focus and scroll position are
+   * preserved across the merge. Set to false to behave like a plain replace.
+   */
+  preserveSelection?: boolean;
+}
+
+/**
+ * Minimal contiguous range that differs between two documents.
+ *  - `start`  position where the documents start to differ
+ *  - `endA`   end of the changed range in the *old* document
+ *  - `endB`   end of the changed range in the *new* document
+ */
+export interface MergeRange {
+  start: number;
+  endA: number;
+  endB: number;
+}
+
+function clampPos(pos: number, doc: ProseMirrorNode): number {
+  return Math.max(0, Math.min(pos, doc.content.size));
+}
+
+/**
+ * Compute the minimal contiguous range that differs between two ProseMirror
+ * documents using `findDiffStart` / `findDiffEnd`. Returns `null` when the
+ * document contents are identical (nothing to merge).
+ *
+ * This is the core of the cursor-preserving merge: by replacing only the
+ * changed range (instead of the whole document) we can map the user's caret
+ * through the resulting transaction so it follows its surrounding text.
+ */
+export function computeMergeRange(
+  oldDoc: ProseMirrorNode,
+  newDoc: ProseMirrorNode
+): MergeRange | null {
+  const start = oldDoc.content.findDiffStart(newDoc.content);
+  if (start == null) {
+    return null;
+  }
+
+  const diffEnd = oldDoc.content.findDiffEnd(newDoc.content);
+  let endA = diffEnd ? diffEnd.a : oldDoc.content.size;
+  let endB = diffEnd ? diffEnd.b : newDoc.content.size;
+
+  // findDiffStart / findDiffEnd can yield overlapping ranges (e.g. when the
+  // same text is inserted next to identical text); widen the end bounds so the
+  // replaced range stays valid.
+  const overlap = start - Math.min(endA, endB);
+  if (overlap > 0) {
+    endA += overlap;
+    endB += overlap;
+  }
+
+  return { start, endA, endB };
+}
+
+/**
+ * Build a transaction that incrementally replaces only the changed range of the
+ * document with the corresponding content from `newDoc`, mapping the current
+ * selection through the change so the caret is preserved.
+ *
+ * Returns `null` when the documents already have identical content.
+ */
+export function buildMergeTransaction(
+  state: EditorState,
+  newDoc: ProseMirrorNode,
+  options: MergeOptions = {}
+): Transaction | null {
+  const { preserveSelection = true } = options;
+  const range = computeMergeRange(state.doc, newDoc);
+  if (!range) {
+    return null;
+  }
+
+  const { start, endA, endB } = range;
+  const slice = newDoc.slice(start, endB);
+  const tr = state.tr.replace(start, endA, slice);
+
+  if (preserveSelection) {
+    const { from, to } = state.selection;
+    const mappedFrom = clampPos(tr.mapping.map(from, 1), tr.doc);
+    const mappedTo = clampPos(tr.mapping.map(to, 1), tr.doc);
+    try {
+      tr.setSelection(TextSelection.create(tr.doc, mappedFrom, mappedTo));
+    } catch {
+      /* selection mapping is best-effort */
+    }
+  }
+
+  // Keep external updates out of the user's undo history and let listeners
+  // recognise them as programmatic (non-dirtying) updates.
+  tr.setMeta("addToHistory", false);
+  tr.setMeta("external", true);
+  return tr;
+}
+
+function findScrollParent(el: HTMLElement | null): HTMLElement | null {
+  let node: HTMLElement | null = el?.parentElement ?? null;
+  while (node) {
+    const style = window.getComputedStyle(node);
+    const overflowY = style.overflowY;
+    if (
+      (overflowY === "auto" || overflowY === "scroll") &&
+      node.scrollHeight > node.clientHeight
+    ) {
+      return node;
+    }
+    node = node.parentElement;
+  }
+  return null;
+}
+
+/**
+ * Build a ProseMirror document node from arbitrary mergeable content using the
+ * editor's live schema (so it matches the installed extensions exactly).
+ */
+function buildDocNode(
+  editor: Editor,
+  content: MergeableContent
+): ProseMirrorNode | null {
+  const { schema } = editor.state;
+  try {
+    if (typeof content === "string") {
+      const template = document.createElement("div");
+      template.innerHTML = content;
+      return ProseMirrorDOMParser.fromSchema(schema).parse(template);
+    }
+    return schema.nodeFromJSON(content);
+  } catch (error) {
+    console.warn("[TextEdit] mergeEditorContent: failed to build doc node", error);
+    return null;
+  }
+}
+
+function restoreFocusAndScroll(
+  editor: Editor,
+  scrollParent: HTMLElement | null,
+  previousScrollTop: number
+): void {
+  // Re-focusing can scroll the caret into view; restore the prior scroll
+  // position afterwards so the viewport doesn't jump around the user.
+  editor.view.focus();
+  if (scrollParent) {
+    scrollParent.scrollTop = previousScrollTop;
+  }
+}
+
+/**
+ * Reactively merge externally-sourced content into a live TipTap editor while
+ * preserving the user's caret, selection, focus and scroll position.
+ *
+ * Instead of rebuilding the whole document (which would reset the caret to the
+ * top and lose the user's place), this computes the minimal changed range
+ * between the current document and the incoming one and replaces only that
+ * range in a single transaction. The user's selection is then mapped through
+ * that transaction so the caret follows its surrounding text when edits happen
+ * before it, and stays put when edits happen after it.
+ *
+ * @returns `true` if the document was changed, `false` if it was already
+ * up to date (or the content could not be parsed).
+ */
+export function mergeEditorContent(
+  editor: Editor,
+  content: MergeableContent,
+  options: MergeOptions = {}
+): boolean {
+  const { preserveSelection = true } = options;
+  const { state, view } = editor;
+  const oldDoc = state.doc;
+
+  const newDoc = buildDocNode(editor, content);
+  if (!newDoc) return false;
+
+  // Nothing to do if the documents are already identical.
+  if (oldDoc.eq(newDoc)) return false;
+
+  const wasFocused = view.hasFocus();
+  const scrollParent = findScrollParent(view.dom as HTMLElement);
+  const previousScrollTop = scrollParent?.scrollTop ?? 0;
+
+  const dispatchFullReplace = () => {
+    // Fallback: rebuild the document but keep the caret near its old offset.
+    const { from, to } = state.selection;
+    editor.commands.setContent(content, false);
+    if (preserveSelection) {
+      try {
+        const nextDoc = editor.state.doc;
+        editor.commands.setTextSelection({
+          from: clampPos(from, nextDoc),
+          to: clampPos(to, nextDoc),
+        });
+      } catch {
+        /* selection restore is best-effort */
+      }
+    }
+  };
+
+  try {
+    const tr = buildMergeTransaction(state, newDoc, { preserveSelection });
+    if (tr) {
+      view.dispatch(tr);
+    } else {
+      // Content fragments are identical but the documents differ (e.g. doc-level
+      // attrs); fall back to a full replace.
+      dispatchFullReplace();
+    }
+  } catch (error) {
+    console.warn(
+      "[TextEdit] mergeEditorContent: incremental merge failed, replacing",
+      error
+    );
+    dispatchFullReplace();
+  }
+
+  if (wasFocused) {
+    restoreFocusAndScroll(editor, scrollParent, previousScrollTop);
+  }
+
+  return true;
+}

--- a/src/sync/codecs.ts
+++ b/src/sync/codecs.ts
@@ -43,6 +43,7 @@ import {
   type IndexedDBStoreItemWithKey as StoreItemWithKey,
 } from "@/utils/indexedDBBackup";
 import type { SyncNamespace } from "@/shared/sync2/namespaces";
+import { emitDocumentContentSynced } from "@/utils/appEventBus";
 
 export interface AppliedSyncOp {
   k: string;
@@ -727,6 +728,29 @@ const filesCodec: SyncCodec = {
       const db = requireDb(ctx, "files");
       await deleteStoreItemsByKey(db, STORES.DOCUMENTS, docDeletes);
       await upsertStoreItems(db, STORES.DOCUMENTS, docUpserts);
+
+      // Notify open editors (e.g. TextEdit) that document content changed in
+      // storage so they can reactively merge the update without losing the
+      // user's caret. Map the upserted content keys (file UUIDs) back to paths.
+      if (docUpserts.length > 0) {
+        const items = useFilesStore.getState().items;
+        const uuidToPath = new Map<string, string>();
+        for (const [path, item] of Object.entries(items)) {
+          if (item?.uuid) {
+            uuidToPath.set(item.uuid, path);
+          }
+        }
+        const changedPaths: string[] = [];
+        for (const doc of docUpserts) {
+          const path = doc.key ? uuidToPath.get(doc.key) : undefined;
+          if (path) {
+            changedPaths.push(path);
+          }
+        }
+        if (changedPaths.length > 0) {
+          emitDocumentContentSynced({ paths: changedPaths });
+        }
+      }
     }
   },
   subscribe(onChange) {

--- a/src/utils/appEventBus.ts
+++ b/src/utils/appEventBus.ts
@@ -45,6 +45,15 @@ export interface DocumentUpdatedEventDetail {
   content: string;
 }
 
+export interface DocumentContentSyncedEventDetail {
+  /**
+   * Document paths whose persisted content changed in storage (e.g. via cloud
+   * sync or another writer). Listeners should re-read the content from the
+   * source of truth (IndexedDB) rather than trusting an inline payload.
+   */
+  paths: string[];
+}
+
 export interface AppletUpdatedEventDetail {
   path?: string;
   content?: string;
@@ -61,6 +70,7 @@ const APP_EVENT_NAMES = {
   fileUpdated: "fileUpdated",
   fileRenamed: "fileRenamed",
   documentUpdated: "documentUpdated",
+  documentContentSynced: "documentContentSynced",
   appletUpdated: "appletUpdated",
 } as const;
 
@@ -77,6 +87,7 @@ type AppEventDetailMap = {
   fileUpdated: FileUpdatedEventDetail;
   fileRenamed: FileRenamedEventDetail;
   documentUpdated: DocumentUpdatedEventDetail;
+  documentContentSynced: DocumentContentSyncedEventDetail;
   appletUpdated: AppletUpdatedEventDetail;
 };
 
@@ -254,6 +265,23 @@ export function onDocumentUpdated(
   target?: AppEventTarget | null,
 ): () => void {
   return subscribeToEvent("documentUpdated", handler, target);
+}
+
+export function emitDocumentContentSynced(
+  detail: DocumentContentSyncedEventDetail,
+  target?: AppEventTarget | null,
+): void {
+  if (!detail.paths || detail.paths.length === 0) {
+    return;
+  }
+  emitEvent("documentContentSynced", detail, target);
+}
+
+export function onDocumentContentSynced(
+  handler: (event: CustomEvent<DocumentContentSyncedEventDetail>) => void,
+  target?: AppEventTarget | null,
+): () => void {
+  return subscribeToEvent("documentContentSynced", handler, target);
 }
 
 export function emitAppletUpdated(

--- a/tests/test-textedit-merge-content.test.ts
+++ b/tests/test-textedit-merge-content.test.ts
@@ -1,0 +1,101 @@
+#!/usr/bin/env bun
+
+import { describe, expect, test } from "bun:test";
+import { Schema, type Node as PMNode } from "@tiptap/pm/model";
+import { EditorState, TextSelection } from "@tiptap/pm/state";
+import {
+  buildMergeTransaction,
+  computeMergeRange,
+} from "../src/apps/textedit/utils/mergeEditorContent";
+
+// Minimal schema (doc > paragraph > text) — enough to exercise the diff/merge
+// math without needing a DOM or a full TipTap editor.
+const schema = new Schema({
+  nodes: {
+    doc: { content: "block+" },
+    paragraph: {
+      group: "block",
+      content: "inline*",
+      parseDOM: [{ tag: "p" }],
+      toDOM: () => ["p", 0],
+    },
+    text: { group: "inline" },
+  },
+  marks: {},
+});
+
+function makeDoc(text: string): PMNode {
+  return schema.node("doc", null, [
+    schema.node("paragraph", null, text ? [schema.text(text)] : []),
+  ]);
+}
+
+function makeStateWithCaret(text: string, caret: number): EditorState {
+  const doc = makeDoc(text);
+  const state = EditorState.create({ schema, doc });
+  return state.apply(
+    state.tr.setSelection(TextSelection.create(state.doc, caret))
+  );
+}
+
+describe("TextEdit cursor-preserving merge", () => {
+  test("identical documents produce no merge transaction", () => {
+    const state = makeStateWithCaret("Hello world", 7);
+    const tr = buildMergeTransaction(state, makeDoc("Hello world"));
+    expect(tr).toBeNull();
+    expect(computeMergeRange(state.doc, makeDoc("Hello world"))).toBeNull();
+  });
+
+  test("insertion before the caret moves the caret with its text", () => {
+    // Caret sits just before "world" (position 7) in "Hello world".
+    const state = makeStateWithCaret("Hello world", 7);
+    const tr = buildMergeTransaction(state, makeDoc("Say Hello world"));
+
+    expect(tr).not.toBeNull();
+    // "Say " (4 chars) inserted before the caret -> caret shifts 7 -> 11.
+    expect(tr!.selection.from).toBe(11);
+    expect(tr!.doc.textContent).toBe("Say Hello world");
+  });
+
+  test("insertion after the caret leaves the caret put", () => {
+    const state = makeStateWithCaret("Hello world", 7);
+    const tr = buildMergeTransaction(state, makeDoc("Hello world!!!"));
+
+    expect(tr).not.toBeNull();
+    // Appended text is after the caret -> caret unchanged at 7.
+    expect(tr!.selection.from).toBe(7);
+    expect(tr!.doc.textContent).toBe("Hello world!!!");
+  });
+
+  test("merge only replaces the minimal changed range", () => {
+    const oldDoc = makeDoc("The quick brown fox");
+    const newDoc = makeDoc("The slow brown fox");
+    const range = computeMergeRange(oldDoc, newDoc);
+
+    expect(range).not.toBeNull();
+    // Only "quick" -> "slow" changes; the shared prefix/suffix stay untouched.
+    expect(oldDoc.textBetween(range!.start, range!.endA)).toBe("quick");
+    expect(newDoc.textBetween(range!.start, range!.endB)).toBe("slow");
+  });
+
+  test("merge transaction is flagged external and non-undoable", () => {
+    const state = makeStateWithCaret("Hello world", 7);
+    const tr = buildMergeTransaction(state, makeDoc("Hello brave world"));
+
+    expect(tr).not.toBeNull();
+    expect(tr!.getMeta("external")).toBe(true);
+    expect(tr!.getMeta("addToHistory")).toBe(false);
+  });
+
+  test("selection preservation can be disabled", () => {
+    const state = makeStateWithCaret("Hello world", 7);
+    const tr = buildMergeTransaction(state, makeDoc("Say Hello world"), {
+      preserveSelection: false,
+    });
+
+    expect(tr).not.toBeNull();
+    // Without preservation the selection is not explicitly remapped; the caret
+    // stays at the raw mapped default rather than being re-anchored by us.
+    expect(tr!.doc.textContent).toBe("Say Hello world");
+  });
+});

--- a/tests/test-textedit-programmatic-updates.test.ts
+++ b/tests/test-textedit-programmatic-updates.test.ts
@@ -16,15 +16,34 @@ const FILE_OPERATIONS = readFileSync(
   join(import.meta.dir, "../src/apps/textedit/hooks/useFileOperations.ts"),
   "utf8"
 );
+const MERGE_EDITOR_CONTENT = readFileSync(
+  join(import.meta.dir, "../src/apps/textedit/utils/mergeEditorContent.ts"),
+  "utf8"
+);
 
 describe("TextEdit programmatic editor updates", () => {
-  test("external document updates do not emit dirty-state editor updates", () => {
+  test("external document updates merge through the cursor-preserving helper", () => {
+    // External updates must not directly replace content (which would reset the
+    // caret); they go through mergeEditorContent instead.
     expect(TEXTEDIT_APP_COMPONENT).not.toContain(
       "editor.commands.setContent(jsonContent);"
     );
-    expect(TEXTEDIT_APP_COMPONENT).toContain(
+    expect(TEXTEDIT_APP_COMPONENT).not.toContain(
       "editor.commands.setContent(jsonContent, false);"
     );
+    expect(TEXTEDIT_APP_COMPONENT).toContain("mergeEditorContent(editor");
+    expect(TEXTEDIT_APP_COMPONENT).toContain("applyExternalUpdate(jsonContent)");
+  });
+
+  test("external merge transactions are ignored by the dirty-state tracker", () => {
+    expect(TEXTEDIT_APP_COMPONENT).toContain('transaction?.getMeta("external")');
+  });
+
+  test("merge helper tags external, non-undoable transactions", () => {
+    expect(MERGE_EDITOR_CONTENT).toContain('tr.setMeta("external", true)');
+    expect(MERGE_EDITOR_CONTENT).toContain('tr.setMeta("addToHistory", false)');
+    expect(MERGE_EDITOR_CONTENT).toContain("findDiffStart");
+    expect(MERGE_EDITOR_CONTENT).toContain("findDiffEnd");
   });
 
   test("new-file and pending-file loads are silent editor updates", () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Makes TextEdit react live to external content changes — cloud/multi-device sync, file sync, and AI (Chats) edits — and merges them into the open document **without losing the user's caret, selection, focus, or scroll position** while they are editing.

Previously, external updates either never reached an open TextEdit window (cloud sync wrote straight to IndexedDB with no notification) or replaced the whole document via `setContent(...)`, which reset the caret to the top of the document.

## What changed

- **New cursor-preserving merge** (`src/apps/textedit/utils/mergeEditorContent.ts`): instead of rebuilding the document, it computes the minimal changed range between the current and incoming docs (ProseMirror `findDiffStart` / `findDiffEnd`) and replaces only that range in a single transaction. The selection is mapped through that transaction, so the caret follows its surrounding text when edits land before it and stays put when they land after it. The transaction is tagged `addToHistory: false` (keeps external updates out of the undo stack) and `external: true`.
- **Cloud-sync notification**: `filesCodec.apply` now emits a `documentContentSynced` event (mapping the upserted content UUIDs back to file paths) after writing remote document content to IndexedDB.
- **New app-event** `documentContentSynced` in `appEventBus.ts`.
- **TextEdit wiring** (`TextEditAppComponent.tsx`):
  - The dirty-state tracker now ignores transactions tagged `external`, so merges don't mark the doc unsaved or fight the user.
  - The `documentUpdated` and legacy `updateEditorContent` handlers, plus the `contentJson` store-sync effect (AI edit tool), now route through the cursor-preserving merge.
  - A new listener re-reads the file from IndexedDB and merges it when `documentContentSynced` fires for the open file.
- **Shared converter** (`documentContent.ts`) turns a persisted document string (rich-markdown header → TipTap JSON, else markdown→HTML / JSON) into editor-ingestable content.

## Testing

- `bun test tests/test-textedit-merge-content.test.ts` — new behavioral tests proving caret math: insertion before the caret shifts it with its text, insertion after leaves it put, identical docs are a no-op, minimal range is replaced, transactions are flagged external/non-undoable.
- `bun test tests/test-textedit-programmatic-updates.test.ts` — updated wiring assertions.
- `bun run test:unit` — full unit suite green (368 passed).
- `bunx tsc -b` and `eslint` — clean.

GUI/computer-use testing was skipped per the repo's `AGENTS.md` guidance ("Skip computer use / GUI-driven testing unless the user explicitly requests it"); the cursor-preservation logic is covered by the pure ProseMirror unit tests above.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ec868-ded4-72ad-9a84-a2553f8edf48"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ec868-ded4-72ad-9a84-a2553f8edf48"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

