### PR TITLE
feat: keyboard shortcuts in menus (Cmd/Ctrl-aware)

### DIFF
--- a/src/apps/admin/components/AdminMenuBar.tsx
+++ b/src/apps/admin/components/AdminMenuBar.tsx
@@ -85,7 +85,12 @@ export function AdminMenuBar({
           onClick: onRefresh,
         },
         { type: "separator" },
-        { type: "action", label: t("common.menu.close"), onClick: onClose },
+        {
+          type: "action",
+          label: t("common.menu.close"),
+          onClick: onClose,
+          shortcutId: "close",
+        },
       ],
     },
     {

--- a/src/apps/applet-viewer/components/AppletViewerMenuBar.tsx
+++ b/src/apps/applet-viewer/components/AppletViewerMenuBar.tsx
@@ -10,6 +10,7 @@ import {
   MenubarSubContent,
 } from "@/components/ui/menubar";
 import { AppMenuBarShell } from "@/components/shared/menubar/AppMenuBarShell";
+import { ShortcutHint } from "@/components/shared/menubar/ShortcutHint";
 import {
   AppMenuBarMenus,
   type MenuDescriptor,
@@ -252,6 +253,7 @@ export function AppletViewerMenuBar({
             className="text-md h-6 px-3"
           >
             {t("common.menu.close")}
+            <ShortcutHint id="close" />
           </MenubarItem>
         </MenubarContent>
       </MenubarMenu>

--- a/src/apps/base/app-manager/useAppManagerKeyboardShortcuts.ts
+++ b/src/apps/base/app-manager/useAppManagerKeyboardShortcuts.ts
@@ -3,6 +3,8 @@ import type { AppId } from "@/config/appRegistry";
 import type { SwitcherApp } from "@/components/layout/AppSwitcher";
 import { requestCloseWindow } from "@/utils/windowUtils";
 import { toggleSpotlightSearch } from "@/utils/appEventBus";
+import { isDesktop } from "@/utils/platform";
+import { getShortcutPlatform } from "@/utils/shortcuts";
 import type { useAppStore } from "@/stores/useAppStore";
 import type { SwitcherAction } from "./types";
 
@@ -96,9 +98,35 @@ export function useAppManagerKeyboardShortcuts(
     };
 
     const handleKeyDown = (e: KeyboardEvent) => {
-      if (!e.altKey) return;
-
       const fgId = refs.foregroundInstanceIdRef.current;
+
+      // Desktop shell (Electron) supports the real command-modifier window
+      // shortcuts (⌘W / Ctrl+W to close, ⌘M / Ctrl+M to minimize). On the web
+      // these combos are reserved by the browser, so the Alt-based fallbacks
+      // below are used instead.
+      if (isDesktop() && !e.altKey && !e.shiftKey) {
+        const isMac = getShortcutPlatform() === "mac";
+        const cmdKey = isMac ? e.metaKey : e.ctrlKey;
+        const strayCmd = isMac ? e.ctrlKey : e.metaKey;
+        if (cmdKey && !strayCmd) {
+          if (e.code === "KeyW") {
+            if (fgId) {
+              e.preventDefault();
+              requestCloseWindow(fgId);
+            }
+            return;
+          }
+          if (e.code === "KeyM") {
+            if (fgId) {
+              e.preventDefault();
+              refs.minimizeInstanceRef.current(fgId);
+            }
+            return;
+          }
+        }
+      }
+
+      if (!e.altKey) return;
 
       if (e.code === "Space") {
         e.preventDefault();

--- a/src/apps/calendar/components/CalendarMenuBar.tsx
+++ b/src/apps/calendar/components/CalendarMenuBar.tsx
@@ -92,7 +92,12 @@ export function CalendarMenuBar({
           onClick: () => requestCloudSyncDomainCheck("calendar"),
         },
         { type: "separator" },
-        { type: "action", label: t("common.menu.close"), onClick: onClose },
+        {
+          type: "action",
+          label: t("common.menu.close"),
+          onClick: onClose,
+          shortcutId: "close",
+        },
       ],
     },
     {
@@ -104,6 +109,7 @@ export function CalendarMenuBar({
           onClick: undo,
           disabled: !canUndo,
           className: !canUndo ? "text-neutral-500" : "",
+          shortcutId: "undo",
         },
         {
           type: "action",
@@ -111,6 +117,7 @@ export function CalendarMenuBar({
           onClick: redo,
           disabled: !canRedo,
           className: !canRedo ? "text-neutral-500" : "",
+          shortcutId: "redo",
         },
         { type: "separator" },
         {

--- a/src/apps/chats/components/ChatsMenuBar.tsx
+++ b/src/apps/chats/components/ChatsMenuBar.tsx
@@ -13,6 +13,7 @@ import { SYNTH_PRESETS } from "@/hooks/chatSynthPresets";
 import { getPrivateRoomDisplayName } from "@/utils/chat";
 import { LoginDialog } from "@/components/dialogs/LoginDialog";
 import { AppMenuBarShell } from "@/components/shared/menubar/AppMenuBarShell";
+import { ShortcutHint } from "@/components/shared/menubar/ShortcutHint";
 import { MENUBAR_SEPARATOR_CLASS } from "@/components/shared/menubar/menubarStyles";
 import { useAppMenuBarChrome } from "@/hooks/useAppMenuBarChrome";
 import { useTranslation } from "react-i18next";
@@ -254,6 +255,7 @@ export const ChatsMenuBar = memo(function ChatsMenuBar({
               className="text-md h-6 px-3"
             >
               {t("common.menu.close")}
+              <ShortcutHint id="close" />
             </MenubarItem>
           </MenubarContent>
         </MenubarMenu>

--- a/src/apps/contacts/components/ContactsMenuBar.tsx
+++ b/src/apps/contacts/components/ContactsMenuBar.tsx
@@ -78,6 +78,7 @@ export function ContactsMenuBar({
                 type: "action",
                 label: t("common.menu.close"),
                 onClick: onClose,
+                shortcutId: "close",
               },
             ],
           },

--- a/src/apps/control-panels/components/ControlPanelsMenuBar.tsx
+++ b/src/apps/control-panels/components/ControlPanelsMenuBar.tsx
@@ -46,6 +46,7 @@ export function ControlPanelsMenuBar({
                 type: "action",
                 label: t("common.menu.close"),
                 onClick: onClose,
+                shortcutId: "close",
               },
             ],
           },

--- a/src/apps/dashboard/components/DashboardMenuBar.tsx
+++ b/src/apps/dashboard/components/DashboardMenuBar.tsx
@@ -130,7 +130,12 @@ export function DashboardMenuBar({
           onClick: onResetWidgets,
         },
         { type: "separator" },
-        { type: "action", label: t("common.menu.close"), onClick: onClose },
+        {
+          type: "action",
+          label: t("common.menu.close"),
+          onClick: onClose,
+          shortcutId: "close",
+        },
       ],
     },
   ];

--- a/src/apps/finder/components/FinderMenuBar.tsx
+++ b/src/apps/finder/components/FinderMenuBar.tsx
@@ -7,6 +7,7 @@ import {
   MenubarCheckboxItem,
 } from "@/components/ui/menubar";
 import { AppMenuBarShell } from "@/components/shared/menubar/AppMenuBarShell";
+import { ShortcutHint } from "@/components/shared/menubar/ShortcutHint";
 import { MENUBAR_SEPARATOR_CLASS } from "@/components/shared/menubar/menubarStyles";
 import { useAppMenuBarChrome } from "@/hooks/useAppMenuBarChrome";
 import { FileItem } from "./FileList";
@@ -128,6 +129,7 @@ export function FinderMenuBar({
             className="text-md h-6 px-3"
           >
             {t("apps.finder.menu.newFinderWindow")}
+            <ShortcutHint id="newWindow" />
           </MenubarItem>
           <MenubarItem
             onClick={onNewFolder}
@@ -135,6 +137,7 @@ export function FinderMenuBar({
             className="text-md h-6 px-3 disabled:opacity-50 disabled:cursor-not-allowed"
           >
             {t("apps.finder.menu.newFolder")}
+            <ShortcutHint id="newFolder" />
           </MenubarItem>
           <MenubarItem
             onClick={onImportFile}
@@ -187,6 +190,7 @@ export function FinderMenuBar({
             className="text-md h-6 px-3"
           >
             {t("common.menu.close")}
+            <ShortcutHint id="close" />
           </MenubarItem>
         </MenubarContent>
       </MenubarMenu>
@@ -203,6 +207,7 @@ export function FinderMenuBar({
             className={`text-md h-6 px-3 ${!canUndo ? "text-neutral-500" : ""}`}
           >
             {t("common.menu.undo")}
+            <ShortcutHint id="undo" />
           </MenubarItem>
           <MenubarItem
             onClick={redo}
@@ -210,6 +215,7 @@ export function FinderMenuBar({
             className={`text-md h-6 px-3 ${!canRedo ? "text-neutral-500" : ""}`}
           >
             {t("common.menu.redo")}
+            <ShortcutHint id="redo" />
           </MenubarItem>
           <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
           <MenubarItem className="text-md h-6 px-3">

--- a/src/apps/finder/components/finder-app/FinderAppComponent.tsx
+++ b/src/apps/finder/components/finder-app/FinderAppComponent.tsx
@@ -7,6 +7,7 @@ import {
   type FinderInitialData,
 } from "../../hooks/useFinderLogic";
 import { useRegisterUndoRedo } from "@/hooks/useUndoRedo";
+import { useMenuShortcuts } from "@/hooks/useMenuShortcuts";
 import { useAuth } from "@/hooks/useAuth";
 import { FinderHiddenFileInput } from "./FinderHiddenFileInput";
 import { FinderWindowBody } from "./FinderWindowBody";
@@ -132,6 +133,16 @@ export function FinderAppComponent({
     redo: redoFileOp,
     canUndo: canUndoFileOp,
     canRedo: canRedoFileOp,
+  });
+
+  // ⌘N New Window / ⇧⌘N New Folder fire in the Electron shell (browser reserves
+  // these on the web, where the menu hints are hidden). New Folder is gated to
+  // match the disabled menu item.
+  useMenuShortcuts(instanceId, {
+    newWindow: handleNewWindow,
+    newFolder: () => {
+      if (canCreateFolder) handleNewFolder();
+    },
   });
 
   const containerRef = useRef<HTMLDivElement>(null);

--- a/src/apps/infinite-mac/components/InfiniteMacMenuBar.tsx
+++ b/src/apps/infinite-mac/components/InfiniteMacMenuBar.tsx
@@ -67,7 +67,12 @@ export function InfiniteMacMenuBar({
       label: t("common.menu.file"),
       items: [
         ...backToPresetsItems,
-        { type: "action", label: t("common.menu.close"), onClick: onClose },
+        {
+          type: "action",
+          label: t("common.menu.close"),
+          onClick: onClose,
+          shortcutId: "close",
+        },
       ],
     },
     {

--- a/src/apps/infinite-pc/components/InfinitePcMenuBar.tsx
+++ b/src/apps/infinite-pc/components/InfinitePcMenuBar.tsx
@@ -108,7 +108,12 @@ export function InfinitePcMenuBar({
             onClick: onReset,
           },
           { type: "separator" },
-          { type: "action", label: t("common.menu.close"), onClick: onClose },
+          {
+            type: "action",
+            label: t("common.menu.close"),
+            onClick: onClose,
+            shortcutId: "close",
+          },
         ],
       },
       {
@@ -188,7 +193,12 @@ export function InfinitePcMenuBar({
       label: t("common.menu.file"),
       items: [
         ...backToBrowseItems,
-        { type: "action", label: t("common.menu.close"), onClick: onClose },
+        {
+          type: "action",
+          label: t("common.menu.close"),
+          onClick: onClose,
+          shortcutId: "close",
+        },
       ],
     },
     {

--- a/src/apps/internet-explorer/components/ie-menu-bar/IeMenuBarFileMenu.tsx
+++ b/src/apps/internet-explorer/components/ie-menu-bar/IeMenuBarFileMenu.tsx
@@ -5,6 +5,7 @@ import {
   MenubarItem,
   MenubarSeparator,
 } from "@/components/ui/menubar";
+import { ShortcutHint } from "@/components/shared/menubar/ShortcutHint";
 import type { InternetExplorerMenuBarViewModel } from "./useInternetExplorerMenuBar";
 
 export function IeMenuBarFileMenu({
@@ -33,6 +34,7 @@ export function IeMenuBarFileMenu({
         <MenubarSeparator className="h-[2px] bg-black my-1" />
         <MenubarItem onClick={onClose} className="text-md h-6 px-3">
           {t("common.menu.close")}
+          <ShortcutHint id="close" />
         </MenubarItem>
       </MenubarContent>
     </MenubarMenu>

--- a/src/apps/ipod/components/ipod-menu-bar/IpodMenuBarFileMenu.tsx
+++ b/src/apps/ipod/components/ipod-menu-bar/IpodMenuBarFileMenu.tsx
@@ -6,6 +6,7 @@ import {
   MenubarSeparator,
 } from "@/components/ui/menubar";
 import { MENUBAR_SEPARATOR_CLASS } from "@/components/shared/menubar/menubarStyles";
+import { ShortcutHint } from "@/components/shared/menubar/ShortcutHint";
 import { IpodMenuBarLibrarySourceActions } from "./IpodMenuBarLibrarySourceActions";
 import { IpodMenuBarLibrarySwitchItem } from "./IpodMenuBarLibrarySwitchItem";
 import type { IpodMenuBarViewModel } from "./useIpodMenuBar";
@@ -77,6 +78,7 @@ export function IpodMenuBarFileMenu({ vm }: { vm: IpodMenuBarViewModel }) {
             className="text-md h-6 px-3"
           >
             {t("common.menu.close")}
+            <ShortcutHint id="close" />
           </MenubarItem>
         </MenubarContent>
       </MenubarMenu>

--- a/src/apps/karaoke/components/karaoke-menu-bar/KaraokeMenuBarFileMenu.tsx
+++ b/src/apps/karaoke/components/karaoke-menu-bar/KaraokeMenuBarFileMenu.tsx
@@ -6,6 +6,7 @@ import {
   MenubarSeparator,
 } from "@/components/ui/menubar";
 import { MENUBAR_SEPARATOR_CLASS } from "@/components/shared/menubar/menubarStyles";
+import { ShortcutHint } from "@/components/shared/menubar/ShortcutHint";
 import type { KaraokeMenuBarViewModel } from "./useKaraokeMenuBar";
 
 export function KaraokeMenuBarFileMenu({ vm }: { vm: KaraokeMenuBarViewModel }) {
@@ -93,6 +94,7 @@ export function KaraokeMenuBarFileMenu({ vm }: { vm: KaraokeMenuBarViewModel }) 
         <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
         <MenubarItem onClick={onClose} className="text-md h-6 px-3">
           {t("common.menu.close")}
+          <ShortcutHint id="close" />
         </MenubarItem>
       </MenubarContent>
     </MenubarMenu>

--- a/src/apps/maps/components/MapsMenuBar.tsx
+++ b/src/apps/maps/components/MapsMenuBar.tsx
@@ -55,7 +55,12 @@ export function MapsMenuBar({
           className: !canUseMap ? "text-neutral-500" : undefined,
         },
         { type: "separator" },
-        { type: "action", label: t("common.menu.close"), onClick: onClose },
+        {
+          type: "action",
+          label: t("common.menu.close"),
+          onClick: onClose,
+          shortcutId: "close",
+        },
       ],
     },
     {

--- a/src/apps/minesweeper/components/MinesweeperMenuBar.tsx
+++ b/src/apps/minesweeper/components/MinesweeperMenuBar.tsx
@@ -54,6 +54,7 @@ export function MinesweeperMenuBar({
                 type: "action",
                 label: t("common.menu.close"),
                 onClick: onClose,
+                shortcutId: "close",
               },
             ],
           },

--- a/src/apps/paint/components/PaintAppComponent.tsx
+++ b/src/apps/paint/components/PaintAppComponent.tsx
@@ -12,6 +12,7 @@ import { InputDialog } from "@/components/dialogs/InputDialog";
 import { appMetadata } from "..";
 import { usePaintLogic } from "../hooks/usePaintLogic";
 import { useRegisterUndoRedo } from "@/hooks/useUndoRedo";
+import { useMenuShortcuts } from "@/hooks/useMenuShortcuts";
 import { OS_NATIVE_CHROME_SKIP_CLASS } from "@/lib/themeChrome";
 
 export const PaintAppComponent: React.FC<AppProps<PaintInitialData>> = ({
@@ -77,6 +78,14 @@ export const PaintAppComponent: React.FC<AppProps<PaintInitialData>> = ({
     redo: handleRedo,
     canUndo,
     canRedo,
+  });
+
+  // ⌘S/Ctrl+S Save (web + desktop). New/Open use browser-reserved combos so
+  // they fire in the Electron shell (Open is also intercepted on the web).
+  useMenuShortcuts(instanceId, {
+    save: handleSave,
+    newFile: handleNewFile,
+    open: handleImportFile,
   });
 
   const menuBar = (

--- a/src/apps/paint/components/paint-menu-bar/PaintMenuBarEditMenu.tsx
+++ b/src/apps/paint/components/paint-menu-bar/PaintMenuBarEditMenu.tsx
@@ -5,6 +5,7 @@ import {
   MenubarItem,
   MenubarSeparator,
 } from "@/components/ui/menubar";
+import { ShortcutHint } from "@/components/shared/menubar/ShortcutHint";
 import type { PaintMenuBarViewModel } from "./usePaintMenuBar";
 
 export function PaintMenuBarEditMenu({ vm }: { vm: PaintMenuBarViewModel }) {
@@ -32,6 +33,7 @@ export function PaintMenuBarEditMenu({ vm }: { vm: PaintMenuBarViewModel }) {
           className={`text-md h-6 px-3 ${!canUndo ? "text-neutral-500" : ""}`}
         >
           {t("common.menu.undo")}
+          <ShortcutHint id="undo" />
         </MenubarItem>
         <MenubarItem
           onClick={onRedo}
@@ -39,16 +41,20 @@ export function PaintMenuBarEditMenu({ vm }: { vm: PaintMenuBarViewModel }) {
           className={`text-md h-6 px-3 ${!canRedo ? "text-neutral-500" : ""}`}
         >
           {t("common.menu.redo")}
+          <ShortcutHint id="redo" />
         </MenubarItem>
         <MenubarSeparator className="h-[2px] bg-black my-1" />
         <MenubarItem onClick={onCut} className="text-md h-6 px-3">
           {t("common.menu.cut")}
+          <ShortcutHint id="cut" />
         </MenubarItem>
         <MenubarItem onClick={onCopy} className="text-md h-6 px-3">
           {t("common.menu.copy")}
+          <ShortcutHint id="copy" />
         </MenubarItem>
         <MenubarItem onClick={onPaste} className="text-md h-6 px-3">
           {t("common.menu.paste")}
+          <ShortcutHint id="paste" />
         </MenubarItem>
         <MenubarSeparator className="h-[2px] bg-black my-1" />
         <MenubarItem onClick={onClear} className="text-md h-6 px-3">

--- a/src/apps/paint/components/paint-menu-bar/PaintMenuBarFileMenu.tsx
+++ b/src/apps/paint/components/paint-menu-bar/PaintMenuBarFileMenu.tsx
@@ -5,6 +5,7 @@ import {
   MenubarItem,
   MenubarSeparator,
 } from "@/components/ui/menubar";
+import { ShortcutHint } from "@/components/shared/menubar/ShortcutHint";
 import type { PaintMenuBarViewModel } from "./usePaintMenuBar";
 
 export function PaintMenuBarFileMenu({ vm }: { vm: PaintMenuBarViewModel }) {
@@ -28,15 +29,18 @@ export function PaintMenuBarFileMenu({ vm }: { vm: PaintMenuBarViewModel }) {
       <MenubarContent align="start" sideOffset={1} className="px-0">
         <MenubarItem onClick={onNewFile} className="text-md h-6 px-3">
           {t("apps.paint.menu.newFile")}
+          <ShortcutHint id="newFile" />
         </MenubarItem>
         <MenubarSeparator className="h-[2px] bg-black my-1" />
         <MenubarItem onClick={onImportFile} className="text-md h-6 px-3">
           {t("apps.paint.menu.open")}
+          <ShortcutHint id="open" />
         </MenubarItem>
         <MenubarItem onClick={onSave} className="text-md h-6 px-3">
           {currentFilePath
             ? t("apps.paint.menu.save")
             : t("apps.paint.menu.saveEllipsis")}
+          <ShortcutHint id="save" />
         </MenubarItem>
         <MenubarSeparator className="h-[2px] bg-black my-1" />
         <input
@@ -58,6 +62,7 @@ export function PaintMenuBarFileMenu({ vm }: { vm: PaintMenuBarViewModel }) {
         <MenubarSeparator className="h-[2px] bg-black my-1" />
         <MenubarItem onClick={onClose} className="text-md h-6 px-3">
           {t("common.menu.close")}
+          <ShortcutHint id="close" />
         </MenubarItem>
       </MenubarContent>
     </MenubarMenu>

--- a/src/apps/photo-booth/components/PhotoBoothMenuBar.tsx
+++ b/src/apps/photo-booth/components/PhotoBoothMenuBar.tsx
@@ -65,7 +65,12 @@ export function PhotoBoothMenuBar({
           onClick: onClearPhotos,
         },
         { type: "separator" },
-        { type: "action", label: t("common.menu.close"), onClick: onClose },
+        {
+          type: "action",
+          label: t("common.menu.close"),
+          onClick: onClose,
+          shortcutId: "close",
+        },
       ],
     },
     {

--- a/src/apps/soundboard/components/SoundboardMenuBar.tsx
+++ b/src/apps/soundboard/components/SoundboardMenuBar.tsx
@@ -113,7 +113,12 @@ export function SoundboardMenuBar({
         },
         ...specialSoundboardsItems,
         { type: "separator" },
-        { type: "action", label: t("common.menu.close"), onClick: onClose },
+        {
+          type: "action",
+          label: t("common.menu.close"),
+          onClick: onClose,
+          shortcutId: "close",
+        },
       ],
     },
     {

--- a/src/apps/stickies/components/StickiesAppComponent.tsx
+++ b/src/apps/stickies/components/StickiesAppComponent.tsx
@@ -9,6 +9,7 @@ import { useStickiesLogic } from "../hooks/useStickiesLogic";
 import { AppHelpAboutDialogs } from "@/components/shared/AppHelpAboutDialogs";
 import { appMetadata } from "..";
 import { useAppStore } from "@/stores/useAppStore";
+import { useMenuShortcuts } from "@/hooks/useMenuShortcuts";
 import { requestCloudSyncDomainCheck } from "@/utils/cloudSyncEvents";
 
 export function StickiesAppComponent({
@@ -68,6 +69,11 @@ export function StickiesAppComponent({
       );
     };
   }, [instanceId, handleClose]);
+
+  // ⌘N New Note fires in the Electron shell (browser reserves ⌘N on the web).
+  useMenuShortcuts(instanceId, {
+    newFile: () => handleCreateNote(),
+  });
 
   // Create a new note when app is opened and no notes exist
   useEffect(() => {

--- a/src/apps/stickies/components/StickiesMenuBar.tsx
+++ b/src/apps/stickies/components/StickiesMenuBar.tsx
@@ -56,6 +56,7 @@ export function StickiesMenuBar({
           type: "action",
           label: t("apps.stickies.menu.newNote"),
           onClick: () => onNewNote(),
+          shortcutId: "newFile",
         },
         { type: "separator" },
         {
@@ -72,7 +73,12 @@ export function StickiesMenuBar({
           onClick: () => requestCloudSyncDomainCheck("stickies"),
         },
         { type: "separator" },
-        { type: "action", label: t("common.menu.close"), onClick: onClose },
+        {
+          type: "action",
+          label: t("common.menu.close"),
+          onClick: onClose,
+          shortcutId: "close",
+        },
       ],
     },
     {

--- a/src/apps/synth/components/SynthMenuBar.tsx
+++ b/src/apps/synth/components/SynthMenuBar.tsx
@@ -67,7 +67,12 @@ export function SynthMenuBar({
           onClick: onReset,
         },
         { type: "separator" },
-        { type: "action", label: t("common.menu.close"), onClick: onClose },
+        {
+          type: "action",
+          label: t("common.menu.close"),
+          onClick: onClose,
+          shortcutId: "close",
+        },
       ],
     },
     {

--- a/src/apps/terminal/components/TerminalMenuBar.tsx
+++ b/src/apps/terminal/components/TerminalMenuBar.tsx
@@ -64,7 +64,12 @@ export function TerminalMenuBar({
           onClick: onClear,
         },
         { type: "separator" },
-        { type: "action", label: t("common.menu.close"), onClick: onClose },
+        {
+          type: "action",
+          label: t("common.menu.close"),
+          onClick: onClose,
+          shortcutId: "close",
+        },
       ],
     },
     {

--- a/src/apps/textedit/components/TextEditAppComponent.tsx
+++ b/src/apps/textedit/components/TextEditAppComponent.tsx
@@ -31,6 +31,7 @@ import {
 import { persistedContentToEditorContent } from "../utils/documentContent";
 import { readDocumentTextContent } from "@/services/vfs/FileContentRepository";
 import { useRegisterUndoRedo } from "@/hooks/useUndoRedo";
+import { useMenuShortcuts } from "@/hooks/useMenuShortcuts";
 import { useThemeFlags } from "@/hooks/useThemeFlags";
 import { getTextAnalytics, TEXTEDIT_ANALYTICS, track } from "@/utils/analytics";
 import { openNativeFile } from "@/utils/nativeFileDialogs";
@@ -526,6 +527,15 @@ function TextEditContent({
       console.error("Save before close failed:", error);
     }
   };
+
+  // Menu-action keyboard shortcuts (foreground instance only). ⌘S/Ctrl+S Save
+  // works on web and desktop; ⌘N/⌘O are browser-reserved so they fire in the
+  // Electron shell (and ⌘O is intercepted on the web too).
+  useMenuShortcuts(instanceId, {
+    save: handleSaveClick,
+    newFile: handleNewFile,
+    open: handleImportFileClick,
+  });
 
   const showUnsavedIndicator =
     hasUnsavedChanges ||

--- a/src/apps/textedit/components/TextEditMenuBar.tsx
+++ b/src/apps/textedit/components/TextEditMenuBar.tsx
@@ -11,6 +11,7 @@ import {
   MenubarCheckboxItem,
 } from "@/components/ui/menubar";
 import { AppMenuBarShell } from "@/components/shared/menubar/AppMenuBarShell";
+import { ShortcutHint } from "@/components/shared/menubar/ShortcutHint";
 import { MENUBAR_SEPARATOR_CLASS } from "@/components/shared/menubar/menubarStyles";
 import { useAppMenuBarChrome } from "@/hooks/useAppMenuBarChrome";
 import { useTranslation } from "react-i18next";
@@ -79,6 +80,7 @@ export function TextEditMenuBar({
             className="text-md h-6 px-3"
           >
             {t("apps.textedit.menu.newFile")}
+            <ShortcutHint id="newFile" />
           </MenubarItem>
           <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
           <MenubarItem
@@ -86,12 +88,14 @@ export function TextEditMenuBar({
             className="text-md h-6 px-3"
           >
             {t("apps.textedit.menu.open")}
+            <ShortcutHint id="open" />
           </MenubarItem>
           <MenubarItem
             onClick={onSave}
             className="text-md h-6 px-3"
           >
             {currentFilePath ? t("apps.textedit.menu.save") : t("apps.textedit.menu.saveEllipsis")}
+            <ShortcutHint id="save" />
           </MenubarItem>
           <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
           <MenubarItem
@@ -131,6 +135,7 @@ export function TextEditMenuBar({
             className="text-md h-6 px-3"
           >
             {t("common.menu.close")}
+            <ShortcutHint id="close" />
           </MenubarItem>
         </MenubarContent>
       </MenubarMenu>
@@ -146,6 +151,7 @@ export function TextEditMenuBar({
             className="text-md h-6 px-3 disabled:text-os-text-disabled"
           >
             {t("common.menu.undo")}
+            <ShortcutHint id="undo" />
           </MenubarItem>
           <MenubarItem
             onClick={redo}
@@ -153,6 +159,7 @@ export function TextEditMenuBar({
             className="text-md h-6 px-3 disabled:text-os-text-disabled"
           >
             {t("common.menu.redo")}
+            <ShortcutHint id="redo" />
           </MenubarItem>
           <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
           <MenubarItem
@@ -164,6 +171,7 @@ export function TextEditMenuBar({
             className="text-md h-6 px-3"
           >
             {t("common.menu.copy")}
+            <ShortcutHint id="copy" />
           </MenubarItem>
           <MenubarItem
             onClick={() => {
@@ -174,12 +182,14 @@ export function TextEditMenuBar({
             className="text-md h-6 px-3"
           >
             {t("common.menu.cut")}
+            <ShortcutHint id="cut" />
           </MenubarItem>
           <MenubarItem
             onClick={() => document.execCommand("paste")}
             className="text-md h-6 px-3"
           >
             {t("common.menu.paste")}
+            <ShortcutHint id="paste" />
           </MenubarItem>
           <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
           <MenubarItem
@@ -187,6 +197,7 @@ export function TextEditMenuBar({
             className="text-md h-6 px-3"
           >
             {t("common.menu.selectAll")}
+            <ShortcutHint id="selectAll" />
           </MenubarItem>
         </MenubarContent>
       </MenubarMenu>
@@ -202,6 +213,7 @@ export function TextEditMenuBar({
             className="text-md h-6 px-3"
           >
             {t("apps.textedit.menu.bold")}
+            <ShortcutHint id="bold" />
           </MenubarCheckboxItem>
           <MenubarCheckboxItem
             checked={editor?.isActive("italic") ?? false}
@@ -209,6 +221,7 @@ export function TextEditMenuBar({
             className="text-md h-6 px-3"
           >
             {t("apps.textedit.menu.italic")}
+            <ShortcutHint id="italic" />
           </MenubarCheckboxItem>
           <MenubarCheckboxItem
             checked={editor?.isActive("underline") ?? false}
@@ -216,6 +229,7 @@ export function TextEditMenuBar({
             className="text-md h-6 px-3"
           >
             {t("apps.textedit.menu.underline")}
+            <ShortcutHint id="underline" />
           </MenubarCheckboxItem>
           <MenubarSeparator className={MENUBAR_SEPARATOR_CLASS} />
           <MenubarCheckboxItem

--- a/src/apps/tv/components/TvMenuBar.tsx
+++ b/src/apps/tv/components/TvMenuBar.tsx
@@ -96,7 +96,12 @@ export function TvMenuBar({
           onClick: onImportChannels,
         },
         { type: "separator" },
-        { type: "action", label: t("common.menu.close"), onClick: onClose },
+        {
+          type: "action",
+          label: t("common.menu.close"),
+          onClick: onClose,
+          shortcutId: "close",
+        },
       ],
     },
     {

--- a/src/apps/videos/components/VideosMenuBar.tsx
+++ b/src/apps/videos/components/VideosMenuBar.tsx
@@ -127,7 +127,12 @@ export function VideosMenuBar({
           disabled: videos.length === 0,
         },
         { type: "separator" },
-        { type: "action", label: t("common.menu.close"), onClick: onClose },
+        {
+          type: "action",
+          label: t("common.menu.close"),
+          onClick: onClose,
+          shortcutId: "close",
+        },
       ],
     },
   ];

--- a/src/apps/winamp/components/WinampMenuBar.tsx
+++ b/src/apps/winamp/components/WinampMenuBar.tsx
@@ -69,7 +69,12 @@ export function WinampMenuBar({
     {
       label: t("common.menu.file"),
       items: [
-        { type: "action", label: t("common.menu.close"), onClick: onClose },
+        {
+          type: "action",
+          label: t("common.menu.close"),
+          onClick: onClose,
+          shortcutId: "close",
+        },
       ],
     },
   ];

--- a/src/components/layout/AppMenu.tsx
+++ b/src/components/layout/AppMenu.tsx
@@ -7,6 +7,7 @@ import {
   MenubarItem,
   MenubarSeparator,
 } from "@/components/ui/menubar";
+import { ShortcutHint } from "@/components/shared/menubar/ShortcutHint";
 import { HelpDialog } from "@/components/dialogs/HelpDialog";
 import { AboutDialog } from "@/components/dialogs/AboutDialog";
 import { ShareItemDialog } from "@/components/dialogs/ShareItemDialog";
@@ -149,6 +150,7 @@ export function AppMenu({
             className="text-md h-6 px-3"
           >
             {t("common.appMenu.hideApp", { appName: translatedAppName })}
+            <ShortcutHint id="hide" />
           </MenubarItem>
 
           {/* Hide Others */}
@@ -157,6 +159,7 @@ export function AppMenu({
             className="text-md h-6 px-3"
           >
             {t("common.appMenu.hideOthers")}
+            <ShortcutHint id="hideOthers" />
           </MenubarItem>
 
           {/* Show All - only for multi-instance apps with minimized windows */}

--- a/src/components/layout/menu-bar/DefaultMenuItems.tsx
+++ b/src/components/layout/menu-bar/DefaultMenuItems.tsx
@@ -8,6 +8,7 @@ import {
   MenubarSeparator,
   MenubarCheckboxItem,
 } from "@/components/ui/menubar";
+import { ShortcutHint } from "@/components/shared/menubar/ShortcutHint";
 import { HelpDialog } from "@/components/dialogs/HelpDialog";
 import { AboutDialog } from "@/components/dialogs/AboutDialog";
 import { useLaunchApp } from "@/hooks/useLaunchApp";
@@ -72,6 +73,7 @@ export function DefaultMenuItems() {
             className="text-md h-6 px-3"
           >
             {t("common.menu.close")}
+            <ShortcutHint id="close" />
           </MenubarItem>
         </MenubarContent>
       </MenubarMenu>
@@ -88,6 +90,7 @@ export function DefaultMenuItems() {
             className={`text-md h-6 px-3 ${!undoRedoEntry?.canUndo ? "text-neutral-500" : ""}`}
           >
             {t("common.menu.undo")}
+            <ShortcutHint id="undo" />
           </MenubarItem>
           <MenubarItem
             onClick={() => undoRedoEntry?.redo()}
@@ -95,6 +98,7 @@ export function DefaultMenuItems() {
             className={`text-md h-6 px-3 ${!undoRedoEntry?.canRedo ? "text-neutral-500" : ""}`}
           >
             {t("common.menu.redo")}
+            <ShortcutHint id="redo" />
           </MenubarItem>
           <MenubarSeparator className="h-[2px] bg-black my-1" />
           <MenubarItem
@@ -102,18 +106,21 @@ export function DefaultMenuItems() {
             className="text-md h-6 px-3"
           >
             {t("common.menu.cut")}
+            <ShortcutHint id="cut" />
           </MenubarItem>
           <MenubarItem
             disabled
             className="text-md h-6 px-3"
           >
             {t("common.menu.copy")}
+            <ShortcutHint id="copy" />
           </MenubarItem>
           <MenubarItem
             disabled
             className="text-md h-6 px-3"
           >
             {t("common.menu.paste")}
+            <ShortcutHint id="paste" />
           </MenubarItem>
           <MenubarItem
             disabled
@@ -127,6 +134,7 @@ export function DefaultMenuItems() {
             className="text-md h-6 px-3"
           >
             {t("common.menu.selectAll")}
+            <ShortcutHint id="selectAll" />
           </MenubarItem>
         </MenubarContent>
       </MenubarMenu>

--- a/src/components/shared/menubar/AppMenuBarMenus.tsx
+++ b/src/components/shared/menubar/AppMenuBarMenus.tsx
@@ -14,6 +14,8 @@ import {
   MenubarRadioItem,
 } from "@/components/ui/menubar";
 import { cn } from "@/lib/utils";
+import { ShortcutHint } from "./ShortcutHint";
+import type { ShortcutId } from "@/utils/shortcuts";
 import {
   MENUBAR_ITEM_CLASS,
   MENUBAR_SEPARATOR_CLASS,
@@ -34,7 +36,10 @@ export type MenuItemDescriptor =
       label: ReactNode;
       onClick: () => void;
       disabled?: boolean;
+      /** Raw shortcut label (rendered as-is). */
       shortcut?: string;
+      /** Platform-aware shortcut id; formatted/hidden per host + environment. */
+      shortcutId?: ShortcutId;
       /** Extra classes merged onto the shared item class. */
       className?: string;
     }
@@ -82,9 +87,11 @@ function renderItems(items: MenuItemDescriptor[]) {
             className={cn(MENUBAR_ITEM_CLASS, item.className)}
           >
             {item.label}
-            {item.shortcut && (
+            {item.shortcutId ? (
+              <ShortcutHint id={item.shortcutId} />
+            ) : item.shortcut ? (
               <MenubarShortcut>{item.shortcut}</MenubarShortcut>
-            )}
+            ) : null}
           </MenubarItem>
         );
       case "checkbox":

--- a/src/components/shared/menubar/ShortcutHint.tsx
+++ b/src/components/shared/menubar/ShortcutHint.tsx
@@ -1,14 +1,17 @@
 import { MenubarShortcut } from "@/components/ui/menubar";
 import { formatShortcut, type ShortcutId } from "@/utils/shortcuts";
+import { useIsMobile } from "@/hooks/useIsMobile";
 
 /**
  * Renders a right-aligned keyboard-shortcut hint inside a `MenubarItem` /
  * `MenubarCheckboxItem`. Renders nothing when the shortcut isn't available in
- * the current environment (e.g. a browser-reserved combo on the web), so menus
+ * the current environment (e.g. a browser-reserved combo on the web), or on
+ * mobile/phone-sized screens where there's no hardware keyboard, so menus
  * never advertise a shortcut that can't fire.
  */
 export function ShortcutHint({ id }: { id: ShortcutId }) {
+  const isMobile = useIsMobile();
   const label = formatShortcut(id);
-  if (!label) return null;
+  if (isMobile || !label) return null;
   return <MenubarShortcut>{label}</MenubarShortcut>;
 }

--- a/src/components/shared/menubar/ShortcutHint.tsx
+++ b/src/components/shared/menubar/ShortcutHint.tsx
@@ -1,0 +1,14 @@
+import { MenubarShortcut } from "@/components/ui/menubar";
+import { formatShortcut, type ShortcutId } from "@/utils/shortcuts";
+
+/**
+ * Renders a right-aligned keyboard-shortcut hint inside a `MenubarItem` /
+ * `MenubarCheckboxItem`. Renders nothing when the shortcut isn't available in
+ * the current environment (e.g. a browser-reserved combo on the web), so menus
+ * never advertise a shortcut that can't fire.
+ */
+export function ShortcutHint({ id }: { id: ShortcutId }) {
+  const label = formatShortcut(id);
+  if (!label) return null;
+  return <MenubarShortcut>{label}</MenubarShortcut>;
+}

--- a/src/components/ui/menubar.tsx
+++ b/src/components/ui/menubar.tsx
@@ -323,7 +323,7 @@ const MenubarItem = (
         }),
         ...(isMacOSTheme && {
           borderRadius: "0px",
-          padding: isAquaGlass ? "4px 10px" : "6px 20px 6px 16px",
+          padding: isAquaGlass ? "4px 10px" : "6px 12px 6px 16px",
           margin: "1px 0",
           WebkitFontSmoothing: "antialiased",
           textShadow: "0 2px 3px rgba(0, 0, 0, 0.25)",
@@ -380,7 +380,7 @@ const MenubarCheckboxItem = (
         }),
         ...(isMacOSTheme && {
           borderRadius: "0px",
-          padding: "6px 20px 6px 32px",
+          padding: "6px 12px 6px 32px",
           margin: "1px 0",
           WebkitFontSmoothing: "antialiased",
           textShadow: "0 2px 3px rgba(0, 0, 0, 0.25)",
@@ -444,7 +444,7 @@ const MenubarRadioItem = (
         }),
         ...(isMacOSTheme && {
           borderRadius: "0px",
-          padding: "6px 20px 6px 32px",
+          padding: "6px 12px 6px 32px",
           margin: "1px 0",
           WebkitFontSmoothing: "antialiased",
           textShadow: "0 2px 3px rgba(0, 0, 0, 0.25)",
@@ -537,7 +537,9 @@ const MenubarShortcut = ({
   return (
     <span
       className={cn(
-        "ml-auto text-xs tracking-widest text-muted-foreground",
+        // Inherit the item's current text color (dimmed) so the hint flips
+        // along with the label on hover/focus instead of staying muted.
+        "ml-auto text-xs tracking-widest opacity-60",
         className
       )}
       {...props}

--- a/src/hooks/useGlobalUndoRedo.ts
+++ b/src/hooks/useGlobalUndoRedo.ts
@@ -1,6 +1,7 @@
 import { useEffect } from "react";
 import { useUndoRedoStore } from "@/stores/useUndoRedoStore";
 import { useAppStore } from "@/stores/useAppStore";
+import { getShortcutPlatform } from "@/utils/shortcuts";
 
 /**
  * Global keyboard listener that dispatches Cmd/Ctrl+Z and Cmd/Ctrl+Shift+Z
@@ -11,8 +12,10 @@ import { useAppStore } from "@/stores/useAppStore";
 export function useGlobalUndoRedo() {
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
-      const isMac = navigator.platform.toUpperCase().indexOf("MAC") >= 0;
-      const cmdKey = isMac ? e.metaKey : e.ctrlKey;
+      // Host-platform aware so the desktop shell on Windows uses Ctrl even when
+      // navigator.platform is ambiguous.
+      const cmdKey =
+        getShortcutPlatform() === "mac" ? e.metaKey : e.ctrlKey;
 
       if (!cmdKey || e.altKey) return;
       if (e.key.toLowerCase() !== "z" && e.key.toLowerCase() !== "y") return;

--- a/src/hooks/useMenuShortcuts.ts
+++ b/src/hooks/useMenuShortcuts.ts
@@ -1,0 +1,49 @@
+import { useEffect, useRef } from "react";
+import { useAppStore } from "@/stores/useAppStore";
+import { matchesShortcut, type ShortcutId } from "@/utils/shortcuts";
+
+export type MenuShortcutHandlers = Partial<Record<ShortcutId, () => void>>;
+
+/**
+ * Bind menu-action keyboard shortcuts (e.g. ⌘S / Ctrl+S to Save) for an app
+ * instance. Only the foreground instance reacts, so multiple open windows of
+ * the same app don't all fire.
+ *
+ * Handlers should be provided for actions that are NOT already handled by the
+ * global shells (undo/redo, cut/copy/paste, bold/italic/underline are native or
+ * global and should only be *displayed*, not wired here, to avoid double firing).
+ *
+ * Browser-reserved combos (e.g. ⌘N) only fire inside the Electron desktop shell;
+ * see {@link matchesShortcut}.
+ */
+export function useMenuShortcuts(
+  instanceId: string | undefined,
+  handlers: MenuShortcutHandlers
+): void {
+  const handlersRef = useRef(handlers);
+  handlersRef.current = handlers;
+
+  useEffect(() => {
+    if (!instanceId) return;
+
+    const onKeyDown = (e: KeyboardEvent) => {
+      // Foreground gating: ignore unless this instance owns focus.
+      if (useAppStore.getState().foregroundInstanceId !== instanceId) return;
+
+      const current = handlersRef.current;
+      for (const key of Object.keys(current) as ShortcutId[]) {
+        const handler = current[key];
+        if (!handler) continue;
+        if (matchesShortcut(e, key)) {
+          e.preventDefault();
+          e.stopPropagation();
+          handler();
+          return;
+        }
+      }
+    };
+
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [instanceId]);
+}

--- a/src/utils/shortcuts.ts
+++ b/src/utils/shortcuts.ts
@@ -69,7 +69,9 @@ export type ShortcutId =
   | "bold"
   | "italic"
   | "underline"
-  | "minimize";
+  | "minimize"
+  | "hide"
+  | "hideOthers";
 
 export const SHORTCUTS: Record<ShortcutId, ShortcutDef> = {
   newFile: { primary: { cmd: true, key: "n" }, browserReserved: true },
@@ -105,6 +107,11 @@ export const SHORTCUTS: Record<ShortcutId, ShortcutDef> = {
     browserReserved: true,
     webFallback: { alt: true, key: "m" },
   },
+  // Window/app management handled by the app-manager shell. These use Option/Alt
+  // universally (the ⌘ equivalents are reserved by the browser/OS), so model them
+  // as plain Alt combos that work on web and desktop alike.
+  hide: { primary: { alt: true, key: "h" } },
+  hideOthers: { primary: { alt: true, shift: true, key: "h" } },
 };
 
 /**

--- a/src/utils/shortcuts.ts
+++ b/src/utils/shortcuts.ts
@@ -1,0 +1,237 @@
+/**
+ * Keyboard-shortcut audit + single source of truth.
+ *
+ * This module centralizes the menu accelerators shown on the right side of
+ * menu items and the modifier mapping used to match keydown events. It is
+ * intentionally host-platform aware (not theme aware): a shortcut label and
+ * its matching combo follow the physical keyboard / runtime the user is on,
+ * so the macOS Aqua theme on a Windows machine still shows/uses Ctrl.
+ *
+ * The "command" modifier is ⌘ on macOS and Ctrl on Windows/Linux.
+ *
+ * Some combos are reserved by web browsers and cannot be intercepted from a
+ * web page (e.g. ⌘N opens a new window, ⌘W closes the tab). Those are flagged
+ * `browserReserved` so they only fire inside the Electron desktop shell, and
+ * an optional `webFallback` (an Alt/Option-based combo) is shown/handled on
+ * the web instead.
+ */
+
+import { isDesktop } from "./platform";
+
+export type ShortcutPlatform = "mac" | "other";
+
+export interface ShortcutEnv {
+  /** "mac" uses ⌘ symbols; "other" uses Ctrl/Alt/Shift text. */
+  platform?: ShortcutPlatform;
+  /** Whether we're running in the Electron desktop shell. */
+  electron?: boolean;
+}
+
+/**
+ * A modifier combo. `cmd` is the platform command modifier (⌘ on macOS, Ctrl
+ * elsewhere). `alt` and `shift` are literal. `key` is matched case-insensitively
+ * against `KeyboardEvent.key`.
+ */
+export interface Combo {
+  cmd?: boolean;
+  alt?: boolean;
+  shift?: boolean;
+  key: string;
+}
+
+interface ShortcutDef {
+  /** Primary combo using the platform command modifier. */
+  primary: Combo;
+  /** Optional override on Windows/Linux (e.g. redo => Ctrl+Y instead of ⇧⌘Z). */
+  otherPrimary?: Combo;
+  /** Primary combo is reserved by the browser; only usable in the Electron shell. */
+  browserReserved?: boolean;
+  /** Combo shown/handled on the web when `browserReserved` is set (Alt-based). */
+  webFallback?: Combo;
+}
+
+export type ShortcutId =
+  | "newFile"
+  | "newWindow"
+  | "newFolder"
+  | "open"
+  | "save"
+  | "saveAs"
+  | "print"
+  | "close"
+  | "find"
+  | "undo"
+  | "redo"
+  | "cut"
+  | "copy"
+  | "paste"
+  | "selectAll"
+  | "bold"
+  | "italic"
+  | "underline"
+  | "minimize";
+
+export const SHORTCUTS: Record<ShortcutId, ShortcutDef> = {
+  newFile: { primary: { cmd: true, key: "n" }, browserReserved: true },
+  newWindow: { primary: { cmd: true, key: "n" }, browserReserved: true },
+  newFolder: {
+    primary: { cmd: true, shift: true, key: "n" },
+    browserReserved: true,
+  },
+  open: { primary: { cmd: true, key: "o" } },
+  save: { primary: { cmd: true, key: "s" } },
+  saveAs: { primary: { cmd: true, shift: true, key: "s" } },
+  print: { primary: { cmd: true, key: "p" } },
+  close: {
+    primary: { cmd: true, key: "w" },
+    browserReserved: true,
+    webFallback: { alt: true, key: "w" },
+  },
+  find: { primary: { cmd: true, key: "f" } },
+  undo: { primary: { cmd: true, key: "z" } },
+  redo: {
+    primary: { cmd: true, shift: true, key: "z" },
+    otherPrimary: { cmd: true, key: "y" },
+  },
+  cut: { primary: { cmd: true, key: "x" } },
+  copy: { primary: { cmd: true, key: "c" } },
+  paste: { primary: { cmd: true, key: "v" } },
+  selectAll: { primary: { cmd: true, key: "a" } },
+  bold: { primary: { cmd: true, key: "b" } },
+  italic: { primary: { cmd: true, key: "i" } },
+  underline: { primary: { cmd: true, key: "u" } },
+  minimize: {
+    primary: { cmd: true, key: "m" },
+    browserReserved: true,
+    webFallback: { alt: true, key: "m" },
+  },
+};
+
+/**
+ * Resolve the host platform for shortcut purposes. Prefers the Electron-reported
+ * platform, then `navigator` hints. Defaults to "other" (Ctrl) when unknown.
+ */
+export function getShortcutPlatform(): ShortcutPlatform {
+  if (typeof window !== "undefined" && window.ryosDesktop?.platform) {
+    return window.ryosDesktop.platform === "darwin" ? "mac" : "other";
+  }
+  const nav =
+    typeof navigator !== "undefined"
+      ? (navigator as Navigator & {
+          userAgentData?: { platform?: string };
+        })
+      : undefined;
+  const hint =
+    nav?.userAgentData?.platform || nav?.platform || nav?.userAgent || "";
+  return /mac|iphone|ipad|ipod/i.test(hint) ? "mac" : "other";
+}
+
+function resolveEnv(env?: ShortcutEnv): Required<ShortcutEnv> {
+  return {
+    platform: env?.platform ?? getShortcutPlatform(),
+    electron: env?.electron ?? isDesktop(),
+  };
+}
+
+/** The combo that is actually active in the given environment, or null. */
+function activeCombo(
+  def: ShortcutDef,
+  { platform, electron }: Required<ShortcutEnv>
+): Combo | null {
+  if (def.browserReserved && !electron) {
+    return def.webFallback ?? null;
+  }
+  if (platform === "other" && def.otherPrimary) {
+    return def.otherPrimary;
+  }
+  return def.primary;
+}
+
+function formatKey(key: string): string {
+  if (key.length === 1) return key.toUpperCase();
+  // Friendly labels for a few common non-letter keys.
+  const map: Record<string, string> = {
+    arrowup: "↑",
+    arrowdown: "↓",
+    arrowleft: "←",
+    arrowright: "→",
+    enter: "↵",
+    escape: "Esc",
+    " ": "Space",
+    space: "Space",
+  };
+  return map[key.toLowerCase()] ?? key;
+}
+
+function formatCombo(combo: Combo, platform: ShortcutPlatform): string {
+  const keyLabel = formatKey(combo.key);
+  if (platform === "mac") {
+    // macOS convention order: ⌃ ⌥ ⇧ ⌘ then key, no separators.
+    let prefix = "";
+    if (combo.alt) prefix += "⌥";
+    if (combo.shift) prefix += "⇧";
+    if (combo.cmd) prefix += "⌘";
+    return `${prefix}${keyLabel}`;
+  }
+  // Windows/Linux convention: "Ctrl+Alt+Shift+Key".
+  const parts: string[] = [];
+  if (combo.cmd) parts.push("Ctrl");
+  if (combo.alt) parts.push("Alt");
+  if (combo.shift) parts.push("Shift");
+  parts.push(keyLabel);
+  return parts.join("+");
+}
+
+/**
+ * Format a shortcut for display on the right side of a menu item.
+ * Returns null when the shortcut is not available in the current environment
+ * (e.g. a browser-reserved combo with no web fallback while running on the web),
+ * so callers can omit the label entirely.
+ */
+export function formatShortcut(id: ShortcutId, env?: ShortcutEnv): string | null {
+  const resolved = resolveEnv(env);
+  const combo = activeCombo(SHORTCUTS[id], resolved);
+  if (!combo) return null;
+  return formatCombo(combo, resolved.platform);
+}
+
+/** Minimal shape we need from a keydown event (keeps this testable). */
+export interface KeyEventLike {
+  key: string;
+  metaKey: boolean;
+  ctrlKey: boolean;
+  altKey: boolean;
+  shiftKey: boolean;
+}
+
+function comboMatches(
+  e: KeyEventLike,
+  combo: Combo,
+  platform: ShortcutPlatform
+): boolean {
+  const cmdActive = platform === "mac" ? e.metaKey : e.ctrlKey;
+  // The modifier that is NOT the command modifier must never be held, otherwise
+  // ⌘S would also match Ctrl+⌘S etc.
+  const strayCmd = platform === "mac" ? e.ctrlKey : e.metaKey;
+  if (strayCmd) return false;
+  if (!!combo.cmd !== cmdActive) return false;
+  if (!!combo.alt !== e.altKey) return false;
+  if (!!combo.shift !== e.shiftKey) return false;
+  return e.key.toLowerCase() === combo.key.toLowerCase();
+}
+
+/**
+ * Whether a keydown event matches the given shortcut in the current
+ * environment. Browser-reserved combos only match inside Electron (or via
+ * their web fallback when present).
+ */
+export function matchesShortcut(
+  e: KeyEventLike,
+  id: ShortcutId,
+  env?: ShortcutEnv
+): boolean {
+  const resolved = resolveEnv(env);
+  const combo = activeCombo(SHORTCUTS[id], resolved);
+  if (!combo) return false;
+  return comboMatches(e, combo, resolved.platform);
+}

--- a/tests/test-shortcuts.test.ts
+++ b/tests/test-shortcuts.test.ts
@@ -1,0 +1,135 @@
+#!/usr/bin/env bun
+
+import { describe, expect, test } from "bun:test";
+import {
+  formatShortcut,
+  matchesShortcut,
+  type KeyEventLike,
+  type ShortcutEnv,
+} from "../src/utils/shortcuts";
+
+function ev(over: Partial<KeyEventLike>): KeyEventLike {
+  return {
+    key: over.key ?? "",
+    metaKey: over.metaKey ?? false,
+    ctrlKey: over.ctrlKey ?? false,
+    altKey: over.altKey ?? false,
+    shiftKey: over.shiftKey ?? false,
+  };
+}
+
+const mac: ShortcutEnv = { platform: "mac", electron: false };
+const macApp: ShortcutEnv = { platform: "mac", electron: true };
+const win: ShortcutEnv = { platform: "other", electron: false };
+const winApp: ShortcutEnv = { platform: "other", electron: true };
+
+describe("formatShortcut", () => {
+  test("mac uses ⌘ symbols, windows uses Ctrl text", () => {
+    expect(formatShortcut("save", mac)).toBe("⌘S");
+    expect(formatShortcut("save", win)).toBe("Ctrl+S");
+  });
+
+  test("multi-modifier ordering", () => {
+    expect(formatShortcut("saveAs", mac)).toBe("⇧⌘S");
+    expect(formatShortcut("saveAs", win)).toBe("Ctrl+Shift+S");
+  });
+
+  test("redo differs per platform (⇧⌘Z vs Ctrl+Y)", () => {
+    expect(formatShortcut("redo", mac)).toBe("⇧⌘Z");
+    expect(formatShortcut("redo", win)).toBe("Ctrl+Y");
+  });
+
+  test("browser-reserved combos are hidden on the web, shown in the shell", () => {
+    expect(formatShortcut("newFile", mac)).toBeNull();
+    expect(formatShortcut("newFile", win)).toBeNull();
+    expect(formatShortcut("newFile", macApp)).toBe("⌘N");
+    expect(formatShortcut("newFile", winApp)).toBe("Ctrl+N");
+  });
+
+  test("close falls back to Alt/Option on the web, real ⌘W in the shell", () => {
+    expect(formatShortcut("close", mac)).toBe("⌥W");
+    expect(formatShortcut("close", win)).toBe("Alt+W");
+    expect(formatShortcut("close", macApp)).toBe("⌘W");
+    expect(formatShortcut("close", winApp)).toBe("Ctrl+W");
+  });
+
+  test("newFolder uses ⇧⌘N in the shell", () => {
+    expect(formatShortcut("newFolder", macApp)).toBe("⇧⌘N");
+    expect(formatShortcut("newFolder", winApp)).toBe("Ctrl+Shift+N");
+  });
+});
+
+describe("matchesShortcut", () => {
+  test("save matches the command modifier for the platform", () => {
+    expect(matchesShortcut(ev({ key: "s", metaKey: true }), "save", mac)).toBe(
+      true
+    );
+    expect(matchesShortcut(ev({ key: "s", ctrlKey: true }), "save", win)).toBe(
+      true
+    );
+  });
+
+  test("save does not match the wrong modifier", () => {
+    // Ctrl+S on mac should not fire (mac command modifier is ⌘).
+    expect(matchesShortcut(ev({ key: "s", ctrlKey: true }), "save", mac)).toBe(
+      false
+    );
+    // ⌘S on windows should not fire (windows command modifier is Ctrl).
+    expect(matchesShortcut(ev({ key: "s", metaKey: true }), "save", win)).toBe(
+      false
+    );
+  });
+
+  test("save rejects stray extra command modifier", () => {
+    expect(
+      matchesShortcut(
+        ev({ key: "s", metaKey: true, ctrlKey: true }),
+        "save",
+        mac
+      )
+    ).toBe(false);
+  });
+
+  test("redo matches ⇧⌘Z on mac and Ctrl+Y on windows", () => {
+    expect(
+      matchesShortcut(ev({ key: "z", metaKey: true, shiftKey: true }), "redo", mac)
+    ).toBe(true);
+    expect(matchesShortcut(ev({ key: "y", ctrlKey: true }), "redo", win)).toBe(
+      true
+    );
+    // Plain ⌘Z is undo, not redo.
+    expect(matchesShortcut(ev({ key: "z", metaKey: true }), "redo", mac)).toBe(
+      false
+    );
+  });
+
+  test("browser-reserved combos only fire in the shell", () => {
+    expect(
+      matchesShortcut(ev({ key: "n", metaKey: true }), "newFile", mac)
+    ).toBe(false);
+    expect(
+      matchesShortcut(ev({ key: "n", metaKey: true }), "newFile", macApp)
+    ).toBe(true);
+    expect(
+      matchesShortcut(ev({ key: "n", ctrlKey: true }), "newFile", winApp)
+    ).toBe(true);
+  });
+
+  test("close uses Alt fallback on web and ⌘W in the shell", () => {
+    expect(matchesShortcut(ev({ key: "w", altKey: true }), "close", mac)).toBe(
+      true
+    );
+    expect(matchesShortcut(ev({ key: "w", metaKey: true }), "close", mac)).toBe(
+      false
+    );
+    expect(
+      matchesShortcut(ev({ key: "w", metaKey: true }), "close", macApp)
+    ).toBe(true);
+  });
+
+  test("case-insensitive key matching", () => {
+    expect(matchesShortcut(ev({ key: "S", metaKey: true }), "save", mac)).toBe(
+      true
+    );
+  });
+});

--- a/tests/test-shortcuts.test.ts
+++ b/tests/test-shortcuts.test.ts
@@ -57,6 +57,14 @@ describe("formatShortcut", () => {
     expect(formatShortcut("newFolder", macApp)).toBe("⇧⌘N");
     expect(formatShortcut("newFolder", winApp)).toBe("Ctrl+Shift+N");
   });
+
+  test("global hide/hideOthers use Option/Alt on every platform + env", () => {
+    expect(formatShortcut("hide", mac)).toBe("⌥H");
+    expect(formatShortcut("hide", win)).toBe("Alt+H");
+    expect(formatShortcut("hide", macApp)).toBe("⌥H");
+    expect(formatShortcut("hideOthers", mac)).toBe("⌥⇧H");
+    expect(formatShortcut("hideOthers", win)).toBe("Alt+Shift+H");
+  });
 });
 
 describe("matchesShortcut", () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Audits and surfaces keyboard shortcuts across ryOS menus, wires the common ones (Save, New, Open, Close), and shows global window/app shortcuts — all with correct cross-platform modifier mapping.

- **Shortcut system** (`src/utils/shortcuts.ts`): single source of truth (the "audit") with **host-platform aware** formatting/matching — `⌘` on macOS, `Ctrl`/`Alt` text on Windows/Linux. Host-aware, not theme-aware, so the macOS Aqua theme on Windows still shows/uses `Ctrl`.
- **Right-aligned shortcut labels** via `ShortcutHint`, plus a `shortcutId` field on the declarative menu descriptor (`AppMenuBarMenus`) so app menus opt in with one line.
- **Wired handlers** via foreground-gated `useMenuShortcuts`: `Cmd/Ctrl+S` Save works on web and desktop (TextEdit, Paint); `Cmd/Ctrl+N` New Note (Stickies, Electron); `Cmd/Ctrl+O` Open.
- **Global window/app shortcuts**: `Close` (`⌥W` web / `⌘W` desktop) now shown on **every app's** File menu and already works app-wide via the global handler; `Hide` (`⌥H`) and `Hide Others` (`⌥⇧H`) shown in the macOS app menu. The Electron shell also handles real `⌘W`/`⌘M`.
- **Browser-reserved combos** (`⌘N`, `⌘W`, …) only fire in the Electron shell; on the web they're hidden or use the Alt/Option fallback, so menus never advertise a shortcut that can't fire.

### Coverage
Wired/displayed in: TextEdit, Paint, Finder, Stickies, plus the shell app menu (Hide/Hide Others) and idle Finder menu. `Close` accelerator added across all apps: admin, applet-viewer, calendar, chats, contacts, control-panels, dashboard, infinite-mac, infinite-pc, internet-explorer, ipod, karaoke, maps, minesweeper, photo-booth, soundboard, stickies, synth, terminal, tv, videos, winamp.

### Shortcut catalog
Save `⌘S`, Save As `⇧⌘S`, New `⌘N`, New Folder `⇧⌘N`, Open `⌘O`, Close `⌘W`, Print `⌘P`, Find `⌘F`, Undo `⌘Z`, Redo `⇧⌘Z` (Win `Ctrl+Y`), Cut/Copy/Paste `⌘X/C/V`, Select All `⌘A`, Bold/Italic/Underline `⌘B/I/U`, Minimize `⌘M`, Hide `⌥H`, Hide Others `⌥⇧H`.

## Walkthrough

Global window/app shortcuts (demo on Linux → Windows/Linux `Alt+`/`Ctrl+` style):

<a href="https://cursor.com/agents/bc-372d0f5a-1235-4b27-92a4-7b180a7610c6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fglobal_shortcuts_demo.mp4"><img src="https://cursor.com/artifacts/c/art-e37b2ef7-f066-428c-87c6-37487f32d442" alt="global_shortcuts_demo.mp4" /></a>

macOS app menu shows `Hide ⌥H` / `Hide Others ⌥⇧H` (here `Alt+H` / `Alt+Shift+H` on Linux):

![App menu Hide shortcuts](https://cursor.com/artifacts/c/art-4a920a13-4b01-480f-8caf-7e006678ddc9)

Every app's File menu now shows `Close` with its accelerator, and `Alt+W` closes the window:

![File menu Close shortcut](https://cursor.com/artifacts/c/art-f2f3159b-f0d7-4266-a795-f2aa6f8b91c2)

Per-app Save (earlier pass) — TextEdit menus + `Ctrl+S` opening the ryOS Save dialog:

<a href="https://cursor.com/agents/bc-372d0f5a-1235-4b27-92a4-7b180a7610c6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fkeyboard_shortcuts_menu_demo.mp4"><img src="https://cursor.com/artifacts/c/art-29bf4996-854c-4471-8283-f5961dce0736" alt="keyboard_shortcuts_menu_demo.mp4" /></a>
![TextEdit File menu with shortcuts](https://cursor.com/artifacts/c/art-76f1341e-a3b7-4b02-a734-3f758ee7380d)
![ryOS Save dialog after Ctrl+S](https://cursor.com/artifacts/c/art-f6e4358c-5b28-45f0-86e9-d12acf406ebf)

## Testing
- `bun test tests/test-shortcuts.test.ts` — 14 unit tests (mac/windows formatting + matching, reserved/fallback, global hide/hideOthers).
- `bunx tsc -b` — typecheck passes.
- `bunx eslint` on changed files — clean.
- Manual in-browser: menu labels render correctly; `Ctrl+S` opens the ryOS Save dialog; `Alt+W` closes the focused window (see Walkthrough).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-372d0f5a-1235-4b27-92a4-7b180a7610c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-372d0f5a-1235-4b27-92a4-7b180a7610c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

