### PR TITLE
Add stored user timezone context

### DIFF
--- a/api/_utils/api-handler.ts
+++ b/api/_utils/api-handler.ts
@@ -6,6 +6,8 @@ import { createRedis } from "./redis.js";
 import { resolveRequestAuth, type AuthenticatedRequestUser } from "./request-auth.js";
 import { recordAnalyticsEvent } from "./_analytics.js";
 import { getClientIp } from "./_rate-limit.js";
+import { getHeader } from "./request-helpers.js";
+import { updateStoredUserTimeZone } from "./auth/_user-record.js";
 
 type AuthMode = "none" | "optional" | "required" | "admin";
 
@@ -123,6 +125,20 @@ export function apiHandler<TBody = unknown>(
         return;
       } else {
         user = authResult.user;
+      }
+
+      if (user) {
+        const timeZoneHeader = getHeader(req, "x-user-timezone");
+        if (timeZoneHeader) {
+          await updateStoredUserTimeZone(redis, user.username, timeZoneHeader).catch(
+            (error) => {
+              logger.warn("Failed to update user timezone from request header", {
+                username: user?.username,
+                error: error instanceof Error ? error.message : String(error),
+              });
+            }
+          );
+        }
       }
     }
 

--- a/api/_utils/auth/_user-record.ts
+++ b/api/_utils/auth/_user-record.ts
@@ -1,14 +1,19 @@
 /**
- * Helpers for reading the stored user record (`chat:users:{username}`).
+ * Helpers for reading and updating the stored user record (`chat:users:{username}`).
  *
  * The record is persisted as a JSON string (or, on some Redis backends, an
  * already-parsed object), so callers must tolerate both shapes.
  */
 
+import type { Redis } from "../redis.js";
+import { CHAT_USERS_PREFIX } from "./_constants.js";
+
 export interface StoredUserRecord {
   username?: string;
   createdAt?: number;
   lastActive?: number;
+  timeZone?: string;
+  timeZoneUpdatedAt?: number;
   banned?: boolean;
   banReason?: string;
   bannedAt?: number;
@@ -34,4 +39,75 @@ export function parseStoredUser(userData: unknown): StoredUserRecord | null {
  */
 export function isUserBanned(userData: unknown): boolean {
   return parseStoredUser(userData)?.banned === true;
+}
+
+/**
+ * Validate a browser-provided IANA timezone. Returns null for unknown/invalid
+ * values so we never persist misleading prompt context.
+ */
+export function normalizeUserTimeZone(timeZone?: string | null): string | null {
+  if (!timeZone || typeof timeZone !== "string") {
+    return null;
+  }
+
+  const trimmed = timeZone.trim();
+  if (!trimmed || trimmed === "Unknown") {
+    return null;
+  }
+
+  try {
+    new Intl.DateTimeFormat("en-US", { timeZone: trimmed });
+    return trimmed;
+  } catch {
+    return null;
+  }
+}
+
+export async function getStoredUserRecord(
+  redis: Redis,
+  username: string
+): Promise<StoredUserRecord | null> {
+  return parseStoredUser(await redis.get(`${CHAT_USERS_PREFIX}${username.toLowerCase()}`));
+}
+
+export async function getStoredUserTimeZone(
+  redis: Redis | undefined,
+  username?: string | null
+): Promise<string | null> {
+  if (!redis || !username) {
+    return null;
+  }
+
+  const record = await getStoredUserRecord(redis, username);
+  return normalizeUserTimeZone(record?.timeZone);
+}
+
+export async function updateStoredUserTimeZone(
+  redis: Redis,
+  username: string,
+  timeZone?: string | null,
+  now: number = Date.now()
+): Promise<StoredUserRecord | null> {
+  const normalizedTimeZone = normalizeUserTimeZone(timeZone);
+  if (!normalizedTimeZone) {
+    return null;
+  }
+
+  const key = `${CHAT_USERS_PREFIX}${username.toLowerCase()}`;
+  const existingRecord = parseStoredUser(await redis.get(key));
+  if (!existingRecord) {
+    return null;
+  }
+
+  if (existingRecord.timeZone === normalizedTimeZone) {
+    return existingRecord;
+  }
+
+  const updatedRecord: StoredUserRecord = {
+    ...existingRecord,
+    timeZone: normalizedTimeZone,
+    timeZoneUpdatedAt: now,
+  };
+  await redis.set(key, JSON.stringify(updatedRecord));
+  return updatedRecord;
 }

--- a/api/_utils/auth/index.ts
+++ b/api/_utils/auth/index.ts
@@ -78,7 +78,14 @@ export { extractAuth, extractAuthNormalized } from "./_extract.js";
 
 // Stored user-record helpers (ban status, etc.)
 export type { StoredUserRecord } from "./_user-record.js";
-export { parseStoredUser, isUserBanned } from "./_user-record.js";
+export {
+  parseStoredUser,
+  isUserBanned,
+  normalizeUserTimeZone,
+  getStoredUserRecord,
+  getStoredUserTimeZone,
+  updateStoredUserTimeZone,
+} from "./_user-record.js";
 
 // Per-username login lockout (shared by login + register)
 export {

--- a/api/_utils/ryo-conversation.ts
+++ b/api/_utils/ryo-conversation.ts
@@ -43,6 +43,7 @@ import {
   type CursorCloudAgentInput,
   type CursorRepoAgentTelegramNotify,
 } from "../chat/tools/cursor-repo-agent.js";
+import { getStoredUserLocalTimeContext } from "./user-time-context.js";
 
 export interface RyoConversationSystemState {
   username?: string | null;
@@ -725,7 +726,22 @@ export async function prepareRyoConversationModelInput(
     cursorRepoAgentNotifyTelegram,
   } = options;
 
-  const userTimeZone = systemState?.userLocalTime?.timeZone || timeZone;
+  const providedTimeZone = timeZone ?? preloadedMemoryContext?.userTimeZone;
+  const storedUserLocalTime = systemState?.userLocalTime
+    ? null
+    : await getStoredUserLocalTimeContext({
+        redis,
+        username,
+        fallbackTimeZone: providedTimeZone,
+      });
+  const effectiveSystemState = storedUserLocalTime
+    ? ({
+        ...(systemState ?? {}),
+        username: systemState?.username ?? username ?? undefined,
+        userLocalTime: storedUserLocalTime,
+      } as RyoConversationSystemState)
+    : systemState;
+  const userTimeZone = effectiveSystemState?.userLocalTime?.timeZone || providedTimeZone;
   const memoryContext =
     preloadedMemoryContext ||
     (await loadRyoMemoryContext({
@@ -759,7 +775,7 @@ export async function prepareRyoConversationModelInput(
 
   const volatileStatePrompt = buildVolatileStatePrompt({
     channel,
-    systemState,
+    systemState: effectiveSystemState,
     username,
   });
 
@@ -779,8 +795,8 @@ export async function prepareRyoConversationModelInput(
       username: username ?? null,
       redis,
       timeZone: userTimeZone,
-      ...(systemState?.requestGeo
-        ? { requestGeo: systemState.requestGeo }
+      ...(effectiveSystemState?.requestGeo
+        ? { requestGeo: effectiveSystemState.requestGeo }
         : {}),
       ...toolContextOverrides,
     },
@@ -839,7 +855,7 @@ export async function prepareRyoConversationModelInput(
     ...cursorRepoTools,
     ...(shouldEnableOpenAIWebSearch({ model, username })
       ? {
-          web_search: createOpenAIWebSearchTool(systemState),
+          web_search: createOpenAIWebSearchTool(effectiveSystemState),
         }
       : {}),
     ...(shouldEnableGoogleSearch({ model, username })

--- a/api/_utils/user-time-context.ts
+++ b/api/_utils/user-time-context.ts
@@ -1,0 +1,53 @@
+import type { Redis } from "./redis.js";
+import {
+  getStoredUserTimeZone,
+  normalizeUserTimeZone,
+} from "./auth/_user-record.js";
+
+export interface UserLocalTimeContext {
+  timeString: string;
+  dateString: string;
+  timeZone: string;
+}
+
+export function buildUserLocalTimeContext(
+  timeZone?: string | null,
+  date: Date = new Date()
+): UserLocalTimeContext | null {
+  const resolvedTimeZone = normalizeUserTimeZone(timeZone);
+  if (!resolvedTimeZone) {
+    return null;
+  }
+
+  return {
+    timeString: date.toLocaleTimeString("en-US", {
+      timeZone: resolvedTimeZone,
+      hour: "numeric",
+      minute: "2-digit",
+      hour12: true,
+    }),
+    dateString: date.toLocaleDateString("en-US", {
+      timeZone: resolvedTimeZone,
+      weekday: "long",
+      year: "numeric",
+      month: "long",
+      day: "numeric",
+    }),
+    timeZone: resolvedTimeZone,
+  };
+}
+
+export async function getStoredUserLocalTimeContext({
+  redis,
+  username,
+  fallbackTimeZone,
+  date,
+}: {
+  redis?: Redis;
+  username?: string | null;
+  fallbackTimeZone?: string | null;
+  date?: Date;
+}): Promise<UserLocalTimeContext | null> {
+  const storedTimeZone = await getStoredUserTimeZone(redis, username);
+  return buildUserLocalTimeContext(storedTimeZone || fallbackTimeZone, date);
+}

--- a/api/ai/extract-memories.ts
+++ b/api/ai/extract-memories.ts
@@ -27,6 +27,7 @@ import {
   markDailyNoteProcessed,
   MAX_MEMORIES_PER_USER,
 } from "../_utils/_memory.js";
+import { getStoredUserTimeZone } from "../_utils/auth/_user-record.js";
 
 export const runtime = "nodejs";
 export const maxDuration = 60;
@@ -480,7 +481,10 @@ export default apiHandler<{ messages?: ChatMessage[]; timeZone?: string }>(
     const headerTimeZone = Array.isArray(headerTimeZoneRaw)
       ? headerTimeZoneRaw[0]
       : headerTimeZoneRaw;
-    const userTimeZone = normalizeTimeZone(bodyTimeZone || headerTimeZone);
+    const storedTimeZone = await getStoredUserTimeZone(redis, username);
+    const userTimeZone = normalizeTimeZone(
+      bodyTimeZone || headerTimeZone || storedTimeZone
+    );
 
     if (!messages || !Array.isArray(messages) || messages.length === 0) {
       logger.warn("No messages provided");

--- a/api/ai/process-daily-notes.ts
+++ b/api/ai/process-daily-notes.ts
@@ -35,6 +35,7 @@ import {
   MAX_MEMORIES_PER_USER,
   CANONICAL_MEMORY_KEYS,
 } from "../_utils/_memory.js";
+import { getStoredUserTimeZone } from "../_utils/auth/_user-record.js";
 
 export const runtime = "nodejs";
 export const maxDuration = 60;
@@ -505,6 +506,7 @@ export default apiHandler<{ timeZone?: string }>(
     const headerTimeZone = Array.isArray(headerTimeZoneRaw)
       ? headerTimeZoneRaw[0]
       : headerTimeZoneRaw;
+    const storedTimeZone = await getStoredUserTimeZone(redis, username);
 
     try {
       const result = await processDailyNotesForUser(
@@ -512,7 +514,7 @@ export default apiHandler<{ timeZone?: string }>(
         username,
         (...args: unknown[]) => logger.info(String(args[0]), args[1]),
         (...args: unknown[]) => logger.error(String(args[0]), args[1]),
-        requestTimeZone || headerTimeZone,
+        requestTimeZone || headerTimeZone || storedTimeZone,
       );
 
       const totalExtracted = result.created + result.updated;

--- a/api/auth/login.ts
+++ b/api/auth/login.ts
@@ -28,6 +28,8 @@ import { verifyPassword, getUserPasswordHash } from "../_utils/auth/_password.js
 import { apiHandler } from "../_utils/api-handler.js";
 import { buildSetAuthCookie } from "../_utils/_cookie.js";
 import { getClientIp } from "../_utils/_rate-limit.js";
+import { getHeader } from "../_utils/request-helpers.js";
+import { updateStoredUserTimeZone } from "../_utils/auth/_user-record.js";
 
 export const runtime = "nodejs";
 export const maxDuration = 15;
@@ -120,6 +122,7 @@ export default apiHandler(
 
     // Successful login — reset the per-username failure counter.
     await resetLoginFailures(redis, username);
+    await updateStoredUserTimeZone(redis, username, getHeader(req, "x-user-timezone"));
 
     // Handle old token if provided (rotation)
     if (oldToken) {

--- a/api/auth/register.ts
+++ b/api/auth/register.ts
@@ -27,6 +27,11 @@ import { buildSetAuthCookie } from "../_utils/_cookie.js";
 // Use the shared trust-aware IP resolver so self-hosted deployments cannot
 // bypass per-IP rate limits via spoofed X-Forwarded-For headers.
 import { getClientIp } from "../_utils/_rate-limit.js";
+import { getHeader } from "../_utils/request-helpers.js";
+import {
+  normalizeUserTimeZone,
+  updateStoredUserTimeZone,
+} from "../_utils/auth/_user-record.js";
 
 export const runtime = "nodejs";
 export const maxDuration = 15;
@@ -138,6 +143,11 @@ export default apiHandler(
             }
             // Password matches - reset failures and log them in.
             await resetLoginFailures(redis, username);
+            await updateStoredUserTimeZone(
+              redis,
+              username,
+              getHeader(req, "x-user-timezone")
+            );
             const token = generateAuthToken();
             await storeToken(redis, username, token);
             res.setHeader("Set-Cookie", buildSetAuthCookie(username, token));
@@ -156,10 +166,15 @@ export default apiHandler(
     }
 
     // Create user
+    const now = Date.now();
+    const requestTimeZone = normalizeUserTimeZone(getHeader(req, "x-user-timezone"));
     const userData = {
       username,
-      createdAt: Date.now(),
-      lastActive: Date.now(),
+      createdAt: now,
+      lastActive: now,
+      ...(requestTimeZone
+        ? { timeZone: requestTimeZone, timeZoneUpdatedAt: now }
+        : {}),
     };
     await redis.set(userKey, JSON.stringify(userData));
 

--- a/api/auth/session.ts
+++ b/api/auth/session.ts
@@ -6,6 +6,7 @@
 
 import { buildSetAuthCookie } from "../_utils/_cookie.js";
 import { apiHandler } from "../_utils/api-handler.js";
+import { getStoredUserTimeZone } from "../_utils/auth/_user-record.js";
 
 export const runtime = "nodejs";
 export const maxDuration = 10;
@@ -16,7 +17,7 @@ export default apiHandler(
     auth: "optional",
     allowExpiredAuth: true,
   },
-  async ({ req: _req, res, logger, startTime, user }) => {
+  async ({ req: _req, res, logger, startTime, user, redis }) => {
     if (!user) {
       logger.response(200, Date.now() - startTime);
       res.status(200).json({ authenticated: false });
@@ -27,11 +28,13 @@ export default apiHandler(
     res.setHeader("Set-Cookie", buildSetAuthCookie(user.username, user.token));
 
     logger.info("Session restored", { username: user.username });
+    const timeZone = await getStoredUserTimeZone(redis, user.username);
     logger.response(200, Date.now() - startTime);
     res.status(200).json({
       authenticated: true,
       username: user.username,
       expired: user.expired,
+      ...(timeZone ? { timeZone } : {}),
     });
   }
 );

--- a/api/chat.ts
+++ b/api/chat.ts
@@ -24,6 +24,11 @@ import { apiHandler } from "./_utils/api-handler.js";
 import { getHeader } from "./_utils/request-helpers.js";
 import { resolveIpGeolocation } from "./_utils/_geolocation.js";
 import { createRyoToolLoopAgent } from "./_utils/ryo-agent.js";
+import {
+  getStoredUserTimeZone,
+  updateStoredUserTimeZone,
+} from "./_utils/auth/_user-record.js";
+import { buildUserLocalTimeContext } from "./_utils/user-time-context.js";
 type SystemState = RyoConversationSystemState;
 
 const CHAT_MODEL_ALIASES: Record<string, SupportedModel> = {
@@ -179,10 +184,20 @@ export default apiHandler<{
       ? { ...incomingSystemState, requestGeo: resolvedGeo }
       : ({ requestGeo: resolvedGeo } as SystemState);
     const userTimeZone = systemState?.userLocalTime?.timeZone;
+    if (isAuthenticated && username && userTimeZone) {
+      await updateStoredUserTimeZone(redis, username, userTimeZone).catch((error) => {
+        logError("Failed to update user timezone from chat system state", error);
+      });
+    }
+    const storedUserTimeZone =
+      !userTimeZone && isAuthenticated && username
+        ? await getStoredUserTimeZone(redis, username)
+        : null;
+    const effectiveUserTimeZone = userTimeZone || storedUserTimeZone || undefined;
     const loadedMemoryContext = await loadRyoMemoryContext({
       redis: isAuthenticated ? redis : undefined,
       username: isAuthenticated ? username : null,
-      timeZone: userTimeZone,
+      timeZone: effectiveUserTimeZone,
       log,
       logError,
     });
@@ -198,11 +213,11 @@ export default apiHandler<{
       // Only triggered on proactive greetings (once per session) to avoid
       // redundant checks on every chat message.
       try {
-        getUnprocessedDailyNotesExcludingToday(redis, username, 7, userTimeZone).then(async (unprocessedNotes) => {
+        getUnprocessedDailyNotesExcludingToday(redis, username, 7, effectiveUserTimeZone).then(async (unprocessedNotes) => {
           if (unprocessedNotes.length > 0) {
             log(`[DailyNotes] Found ${unprocessedNotes.length} unprocessed past daily notes for ${username}, triggering background processing`);
             const { processDailyNotesForUser } = await import("./ai/process-daily-notes.js");
-            processDailyNotesForUser(redis, username, log, logError, userTimeZone).catch((err: unknown) => {
+            processDailyNotesForUser(redis, username, log, logError, effectiveUserTimeZone).catch((err: unknown) => {
               logError("[DailyNotes] Background processing failed (non-blocking):", err);
             });
           }
@@ -231,21 +246,16 @@ export default apiHandler<{
         return;
       }
 
-      // Time context
       const now = new Date();
-      const sfTime = now.toLocaleTimeString("en-US", {
-        timeZone: "America/Los_Angeles",
-        hour: "numeric",
-        minute: "2-digit",
-        hour12: true,
-      });
-      const dayOfWeek = now.toLocaleDateString("en-US", {
-        timeZone: "America/Los_Angeles",
-        weekday: "long",
-      });
+      const localTimeContext =
+        buildUserLocalTimeContext(effectiveUserTimeZone, now) ||
+        buildUserLocalTimeContext("America/Los_Angeles", now);
+      const timeContext = localTimeContext
+        ? `${localTimeContext.dateString} ${localTimeContext.timeString} (${localTimeContext.timeZone})`
+        : now.toISOString();
 
       try {
-        const greetingDynamicContext = `It's ${dayOfWeek} ${sfTime}. The user's name is "${username}".
+        const greetingDynamicContext = `It's ${timeContext}. The user's name is "${username}".
 
 ${greetingMemoryContext}
 

--- a/api/cron/telegram-heartbeat.ts
+++ b/api/cron/telegram-heartbeat.ts
@@ -42,6 +42,7 @@ import {
 } from "../_utils/_aiModels.js";
 import { getHeader } from "../_utils/request-helpers.js";
 import { createRyoToolLoopAgent } from "../_utils/ryo-agent.js";
+import { getStoredUserTimeZone } from "../_utils/auth/_user-record.js";
 
 export const runtime = "nodejs";
 export const maxDuration = 80;
@@ -76,6 +77,7 @@ async function appendHeartbeatLog(
     message?: string | null;
     skipReason?: string | null;
     stateSummary: string;
+    timeZone: string;
   },
   logger: ReturnType<typeof initLogger>["logger"]
 ): Promise<void> {
@@ -86,7 +88,7 @@ async function appendHeartbeatLog(
       message: payload.message,
       skipReason: payload.skipReason,
       stateSummary: payload.stateSummary,
-      timeZone: TELEGRAM_HEARTBEAT_TIME_ZONE,
+      timeZone: payload.timeZone,
     });
   } catch (error) {
     logger.warn("Failed to append telegram heartbeat record", {
@@ -145,6 +147,8 @@ export default async function handler(
 
   const redis = createRedis();
   const username = TELEGRAM_HEARTBEAT_TARGET_USERNAME;
+  const userTimeZone =
+    (await getStoredUserTimeZone(redis, username)) || TELEGRAM_HEARTBEAT_TIME_ZONE;
   const linkedAccount = await getLinkedTelegramAccountByUsername(redis, username);
 
   if (!linkedAccount) {
@@ -155,6 +159,7 @@ export default async function handler(
         shouldSend: false,
         skipReason: "not-linked",
         stateSummary: "decision=not-linked; linked_account=false",
+        timeZone: userTimeZone,
       },
       logger
     );
@@ -173,6 +178,7 @@ export default async function handler(
         shouldSend: false,
         skipReason: "already-sent",
         stateSummary: `decision=already-sent; slot_key=${slotKey}`,
+        timeZone: userTimeZone,
       },
       logger
     );
@@ -196,7 +202,7 @@ export default async function handler(
       username,
       (...args: unknown[]) => logger.info("[TelegramHeartbeatDailyNotes]", args),
       (...args: unknown[]) => logger.error("[TelegramHeartbeatDailyNotes]", args),
-      TELEGRAM_HEARTBEAT_TIME_ZONE
+      userTimeZone
     );
     if (processedNotes.processed > 0 || processedNotes.skippedDates.length > 0) {
       logger.info("Telegram heartbeat processed past daily notes", {
@@ -220,7 +226,7 @@ export default async function handler(
     redis,
     username,
     TELEGRAM_HEARTBEAT_HISTORY_LOOKBACK_DAYS,
-    TELEGRAM_HEARTBEAT_TIME_ZONE,
+    userTimeZone,
     TELEGRAM_HEARTBEAT_TOPIC
   );
   const heartbeatHistoryContext = buildTelegramHeartbeatHistoryContext(
@@ -244,7 +250,7 @@ export default async function handler(
             createdAt: message.createdAt,
           },
         })),
-        timeZone: TELEGRAM_HEARTBEAT_TIME_ZONE,
+        timeZone: userTimeZone,
         storeLongTermMemories: false,
         markTodayProcessed: false,
         log: (...args: unknown[]) => logger.info("[TelegramHeartbeatChatDelta]", args),
@@ -267,7 +273,7 @@ export default async function handler(
     }
   }
 
-  const briefingType = getCurrentBriefingType(new Date(), TELEGRAM_HEARTBEAT_TIME_ZONE);
+  const briefingType = getCurrentBriefingType(new Date(), userTimeZone);
   if (briefingType) {
     logger.info("Telegram heartbeat detected scheduled briefing window", {
       username,
@@ -275,7 +281,7 @@ export default async function handler(
     });
   }
 
-  const today = getTodayDateString(TELEGRAM_HEARTBEAT_TIME_ZONE);
+  const today = getTodayDateString(userTimeZone);
   const todaysDailyNote = await getDailyNote(redis, username, today);
   const noteContext = buildTelegramHeartbeatNoteContext(todaysDailyNote);
   const conversationContext = buildTelegramHeartbeatConversationContext(history);
@@ -299,6 +305,7 @@ export default async function handler(
           conversationContext,
           decisionCode: gateDecision.code,
         }),
+        timeZone: userTimeZone,
       },
       logger
     );
@@ -364,14 +371,14 @@ export default async function handler(
     username,
     redis,
     model: telegramModel,
-    timeZone: TELEGRAM_HEARTBEAT_TIME_ZONE,
+    timeZone: userTimeZone,
     log: (...args: unknown[]) => logger.info(`[TelegramHeartbeat:${username}]`, args),
     logError: (...args: unknown[]) =>
       logger.error(`[TelegramHeartbeat:${username}]`, args),
     preloadedMemoryContext: {
       userMemories,
       dailyNotesText: null,
-      userTimeZone: TELEGRAM_HEARTBEAT_TIME_ZONE,
+      userTimeZone,
     },
   });
   const { enrichedMessages, loadedSections, staticSystemPrompt } =
@@ -417,6 +424,7 @@ export default async function handler(
           conversationContext,
           decisionCode: "model-no-heartbeat",
         }),
+        timeZone: userTimeZone,
       },
       logger
     );
@@ -485,6 +493,7 @@ export default async function handler(
         conversationContext,
         decisionCode: "sent",
       })}; reply_length=${replyText.length}`,
+      timeZone: userTimeZone,
     },
     logger
   );

--- a/src/api/core.ts
+++ b/src/api/core.ts
@@ -33,6 +33,24 @@ export interface ApiRequestOptions<TBody = unknown> {
   retry?: AbortableFetchOptions["retry"];
 }
 
+export function getBrowserTimeZone(): string | null {
+  if (typeof Intl === "undefined") {
+    return null;
+  }
+
+  try {
+    const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+    return timeZone && timeZone !== "Unknown" ? timeZone : null;
+  } catch {
+    return null;
+  }
+}
+
+export function getBrowserTimeZoneHeaders(): Record<string, string> {
+  const timeZone = getBrowserTimeZone();
+  return timeZone ? { "X-User-Timezone": timeZone } : {};
+}
+
 function buildUrl(
   path: string,
   query?: Record<string, string | number | boolean | null | undefined>
@@ -55,6 +73,10 @@ function buildHeaders(
   hasBody: boolean
 ): Headers {
   const merged = new Headers(headers);
+  const timeZone = getBrowserTimeZone();
+  if (timeZone && !merged.has("X-User-Timezone")) {
+    merged.set("X-User-Timezone", timeZone);
+  }
   if (hasBody && !merged.has("Content-Type")) {
     merged.set("Content-Type", "application/json");
   }

--- a/src/apps/chats/hooks/useAiChat.ts
+++ b/src/apps/chats/hooks/useAiChat.ts
@@ -9,6 +9,7 @@ import { useChatsStore } from "@/stores/useChatsStore";
 import type { AIChatMessage } from "@/types/chat";
 import { useAppStore } from "@/stores/useAppStore";
 import { useAudioSettingsStore } from "@/stores/useAudioSettingsStore";
+import { getBrowserTimeZoneHeaders } from "@/api/core";
 import { getApiUrl } from "@/utils/platform";
 import {
   getActiveIpodTracks,
@@ -193,6 +194,7 @@ function getSharedAiChat(): Chat<AIChatMessage> {
 
       transport: new DefaultChatTransport({
         api: getApiUrl("/api/chat"),
+        headers: getBrowserTimeZoneHeaders,
         body: async () => ({
           systemState: getSystemState(),
           model: useAppStore.getState().aiModel,

--- a/src/shared/contracts/auth.ts
+++ b/src/shared/contracts/auth.ts
@@ -23,6 +23,7 @@ export interface CheckPasswordResponse {
 
 export interface LoginResponse {
   username: string;
+  timeZone?: string;
 }
 
 export interface RegisterResponse {
@@ -30,6 +31,7 @@ export interface RegisterResponse {
     username: string;
     hasPassword?: boolean;
     createdAt?: number;
+    timeZone?: string;
   };
 }
 
@@ -37,4 +39,5 @@ export interface SessionResponse {
   authenticated: boolean;
   username?: string;
   expired?: boolean;
+  timeZone?: string;
 }

--- a/tests/test-auth-user-record.test.ts
+++ b/tests/test-auth-user-record.test.ts
@@ -1,8 +1,31 @@
 import { describe, expect, test } from "bun:test";
+import type { Redis } from "../api/_utils/redis";
 import {
+  getStoredUserTimeZone,
   isUserBanned,
+  normalizeUserTimeZone,
   parseStoredUser,
+  updateStoredUserTimeZone,
 } from "../api/_utils/auth/_user-record";
+import { CHAT_USERS_PREFIX } from "../api/_utils/auth/_constants";
+import { buildUserLocalTimeContext } from "../api/_utils/user-time-context";
+
+class FakeRedis {
+  private readonly store = new Map<string, unknown>();
+
+  async get<T = unknown>(key: string): Promise<T | null> {
+    return (this.store.has(key) ? this.store.get(key) : null) as T | null;
+  }
+
+  async set(key: string, value: unknown): Promise<"OK"> {
+    this.store.set(key, value);
+    return "OK";
+  }
+}
+
+function makeRedis(): Redis {
+  return new FakeRedis() as unknown as Redis;
+}
 
 describe("stored user record helpers", () => {
   test("parses JSON-string and object records", () => {
@@ -29,5 +52,43 @@ describe("stored user record helpers", () => {
     expect(isUserBanned({ username: "u" })).toBe(false);
     expect(isUserBanned(null)).toBe(false);
     expect(isUserBanned("garbage")).toBe(false);
+  });
+
+  test("validates and persists IANA timezones without accepting placeholders", async () => {
+    const redis = makeRedis();
+    const username = "timezone_user";
+    await redis.set(`${CHAT_USERS_PREFIX}${username}`, JSON.stringify({ username }));
+
+    expect(normalizeUserTimeZone("Asia/Tokyo")).toBe("Asia/Tokyo");
+    expect(normalizeUserTimeZone("Unknown")).toBeNull();
+    expect(normalizeUserTimeZone("not/a-zone")).toBeNull();
+
+    const updated = await updateStoredUserTimeZone(
+      redis,
+      username,
+      "Europe/Berlin",
+      123
+    );
+    expect(updated?.timeZone).toBe("Europe/Berlin");
+    expect(updated?.timeZoneUpdatedAt).toBe(123);
+    expect(await getStoredUserTimeZone(redis, username)).toBe("Europe/Berlin");
+
+    const ignored = await updateStoredUserTimeZone(redis, username, "not/a-zone", 456);
+    expect(ignored).toBeNull();
+    expect(await getStoredUserTimeZone(redis, username)).toBe("Europe/Berlin");
+  });
+
+  test("builds stable user-local prompt time context", () => {
+    const context = buildUserLocalTimeContext(
+      "Asia/Tokyo",
+      new Date("2026-01-15T06:30:00.000Z")
+    );
+
+    expect(context).toEqual({
+      timeString: "3:30 PM",
+      dateString: "Thursday, January 15, 2026",
+      timeZone: "Asia/Tokyo",
+    });
+    expect(buildUserLocalTimeContext("bad-zone")).toBeNull();
   });
 });

--- a/tests/test-telegram-heartbeat.test.ts
+++ b/tests/test-telegram-heartbeat.test.ts
@@ -35,6 +35,7 @@ import {
   getTelegramModel,
 } from "../api/_utils/_aiModels.js";
 import { prepareRyoConversationModelInput } from "../api/_utils/ryo-conversation";
+import { CHAT_USERS_PREFIX } from "../api/_utils/auth/_constants";
 
 class FakeRedis {
   private readonly store = new Map<string, unknown>();
@@ -459,6 +460,36 @@ describe("telegram heartbeat helpers", () => {
     expect("calendarControl" in prepared.tools).toBe(true);
     expect("stickiesControl" in prepared.tools).toBe(true);
     expect("web_search" in prepared.tools).toBe(true);
+  });
+
+  test("telegram prompts hydrate user local time from the stored user timezone", async () => {
+    const redis = makeRedis();
+    await redis.set(
+      `${CHAT_USERS_PREFIX}${TELEGRAM_HEARTBEAT_TARGET_USERNAME}`,
+      JSON.stringify({
+        username: TELEGRAM_HEARTBEAT_TARGET_USERNAME,
+        timeZone: "Asia/Tokyo",
+        timeZoneUpdatedAt: 123,
+      })
+    );
+
+    const prepared = await prepareRyoConversationModelInput({
+      channel: "telegram",
+      username: TELEGRAM_HEARTBEAT_TARGET_USERNAME,
+      redis,
+      model: "gpt-5.5",
+      messages: [
+        {
+          id: "telegram-timezone",
+          role: "user",
+          content: "what should i do now?",
+        },
+      ],
+    });
+
+    expect(prepared.userTimeZone).toBe("Asia/Tokyo");
+    expect(prepared.volatileStatePrompt).toContain("User Time:");
+    expect(prepared.volatileStatePrompt).toContain("(Asia/Tokyo)");
   });
 
   test("heartbeat conversations enable Google search grounding on gemini flash", async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Store a validated IANA timezone on user records from browser API/chat requests.
- Hydrate server-only Ryo conversations, Telegram heartbeat, and memory processing from the stored timezone.
- Add focused tests for timezone persistence and Telegram prompt hydration.

## Testing
- ✅ `bun test tests/test-auth-user-record.test.ts tests/test-telegram-heartbeat.test.ts`
- ✅ `bun run build` (passes with pre-existing CSS/chunking warnings)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ed6d8-51ea-77af-b514-e968007eef27"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ed6d8-51ea-77af-b514-e968007eef27"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

