### PR TITLE
Add stored user GeoIP context

### DIFF
--- a/api/_utils/api-handler.ts
+++ b/api/_utils/api-handler.ts
@@ -1,4 +1,5 @@
 import type { VercelRequest, VercelResponse } from "@vercel/node";
+import { geolocation } from "@vercel/functions";
 import type { Redis } from "./redis.js";
 import { initLogger } from "./_logging.js";
 import { getEffectiveOrigin, isAllowedOrigin, setCorsHeaders } from "./_cors.js";
@@ -7,7 +8,10 @@ import { resolveRequestAuth, type AuthenticatedRequestUser } from "./request-aut
 import { recordAnalyticsEvent } from "./_analytics.js";
 import { getClientIp } from "./_rate-limit.js";
 import { getHeader } from "./request-helpers.js";
-import { updateStoredUserTimeZone } from "./auth/_user-record.js";
+import {
+  updateStoredUserGeo,
+  updateStoredUserTimeZone,
+} from "./auth/_user-record.js";
 
 type AuthMode = "none" | "optional" | "required" | "admin";
 
@@ -138,6 +142,15 @@ export function apiHandler<TBody = unknown>(
               });
             }
           );
+        }
+        try {
+          await updateStoredUserGeo(
+            redis,
+            user.username,
+            geolocation(req as unknown as Request)
+          );
+        } catch {
+          // Vercel geolocation is unavailable in some local/self-hosted runtimes.
         }
       }
     }

--- a/api/_utils/auth/_user-record.ts
+++ b/api/_utils/auth/_user-record.ts
@@ -6,7 +6,10 @@
  */
 
 import type { Redis } from "../redis.js";
+import type { IpGeolocation } from "../_geolocation.js";
 import { CHAT_USERS_PREFIX } from "./_constants.js";
+
+export type StoredUserGeo = IpGeolocation;
 
 export interface StoredUserRecord {
   username?: string;
@@ -14,6 +17,8 @@ export interface StoredUserRecord {
   lastActive?: number;
   timeZone?: string;
   timeZoneUpdatedAt?: number;
+  geo?: StoredUserGeo;
+  geoUpdatedAt?: number;
   banned?: boolean;
   banReason?: string;
   bannedAt?: number;
@@ -63,11 +68,75 @@ export function normalizeUserTimeZone(timeZone?: string | null): string | null {
   }
 }
 
+function normalizeGeoString(value: unknown, maxLength: number): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  if (!trimmed) return undefined;
+  return trimmed.slice(0, maxLength);
+}
+
+function normalizeGeoCoordinate(
+  value: unknown,
+  min: number,
+  max: number
+): string | undefined {
+  const raw =
+    typeof value === "number"
+      ? String(value)
+      : typeof value === "string"
+        ? value.trim()
+        : "";
+  if (!raw) return undefined;
+
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed < min || parsed > max) {
+    return undefined;
+  }
+
+  return raw;
+}
+
+export function normalizeUserGeo(geo?: unknown): StoredUserGeo | null {
+  if (!geo || typeof geo !== "object") {
+    return null;
+  }
+
+  const raw = geo as Record<string, unknown>;
+  const normalized: StoredUserGeo = {};
+  const city = normalizeGeoString(raw.city, 100);
+  const region = normalizeGeoString(raw.region, 100);
+  const country = normalizeGeoString(raw.country, 100);
+  const latitude = normalizeGeoCoordinate(raw.latitude, -90, 90);
+  const longitude = normalizeGeoCoordinate(raw.longitude, -180, 180);
+
+  if (city) normalized.city = city;
+  if (region) normalized.region = region;
+  if (country) normalized.country = country;
+  if (latitude) normalized.latitude = latitude;
+  if (longitude) normalized.longitude = longitude;
+
+  if (
+    !normalized.city &&
+    !normalized.country &&
+    !(normalized.latitude && normalized.longitude)
+  ) {
+    return null;
+  }
+
+  return normalized;
+}
+
+function geoMatches(a: StoredUserGeo | null, b: StoredUserGeo | null): boolean {
+  return JSON.stringify(a ?? null) === JSON.stringify(b ?? null);
+}
+
 export async function getStoredUserRecord(
   redis: Redis,
   username: string
 ): Promise<StoredUserRecord | null> {
-  return parseStoredUser(await redis.get(`${CHAT_USERS_PREFIX}${username.toLowerCase()}`));
+  return parseStoredUser(
+    await redis.get(`${CHAT_USERS_PREFIX}${username.toLowerCase()}`)
+  );
 }
 
 export async function getStoredUserTimeZone(
@@ -80,6 +149,18 @@ export async function getStoredUserTimeZone(
 
   const record = await getStoredUserRecord(redis, username);
   return normalizeUserTimeZone(record?.timeZone);
+}
+
+export async function getStoredUserGeo(
+  redis: Redis | undefined,
+  username?: string | null
+): Promise<StoredUserGeo | null> {
+  if (!redis || !username) {
+    return null;
+  }
+
+  const record = await getStoredUserRecord(redis, username);
+  return normalizeUserGeo(record?.geo);
 }
 
 export async function updateStoredUserTimeZone(
@@ -107,6 +188,37 @@ export async function updateStoredUserTimeZone(
     ...existingRecord,
     timeZone: normalizedTimeZone,
     timeZoneUpdatedAt: now,
+  };
+  await redis.set(key, JSON.stringify(updatedRecord));
+  return updatedRecord;
+}
+
+export async function updateStoredUserGeo(
+  redis: Redis,
+  username: string,
+  geo?: unknown,
+  now: number = Date.now()
+): Promise<StoredUserRecord | null> {
+  const normalizedGeo = normalizeUserGeo(geo);
+  if (!normalizedGeo) {
+    return null;
+  }
+
+  const key = `${CHAT_USERS_PREFIX}${username.toLowerCase()}`;
+  const existingRecord = parseStoredUser(await redis.get(key));
+  if (!existingRecord) {
+    return null;
+  }
+
+  const existingGeo = normalizeUserGeo(existingRecord.geo);
+  if (geoMatches(existingGeo, normalizedGeo)) {
+    return existingRecord;
+  }
+
+  const updatedRecord: StoredUserRecord = {
+    ...existingRecord,
+    geo: normalizedGeo,
+    geoUpdatedAt: now,
   };
   await redis.set(key, JSON.stringify(updatedRecord));
   return updatedRecord;

--- a/api/_utils/auth/index.ts
+++ b/api/_utils/auth/index.ts
@@ -82,9 +82,12 @@ export {
   parseStoredUser,
   isUserBanned,
   normalizeUserTimeZone,
+  normalizeUserGeo,
   getStoredUserRecord,
   getStoredUserTimeZone,
+  getStoredUserGeo,
   updateStoredUserTimeZone,
+  updateStoredUserGeo,
 } from "./_user-record.js";
 
 // Per-username login lockout (shared by login + register)

--- a/api/_utils/ryo-conversation.ts
+++ b/api/_utils/ryo-conversation.ts
@@ -44,6 +44,10 @@ import {
   type CursorRepoAgentTelegramNotify,
 } from "../chat/tools/cursor-repo-agent.js";
 import { getStoredUserLocalTimeContext } from "./user-time-context.js";
+import {
+  getStoredUserGeo,
+  normalizeUserGeo,
+} from "./auth/_user-record.js";
 
 export interface RyoConversationSystemState {
   username?: string | null;
@@ -279,6 +283,10 @@ function createOpenAIWebSearchTool(
   );
 }
 
+function hasUsefulGeo(geo?: RyoConversationSystemState["requestGeo"]): boolean {
+  return !!normalizeUserGeo(geo);
+}
+
 function createGoogleSearchTool(): ReturnType<typeof google.tools.googleSearch> {
   return google.tools.googleSearch({});
 }
@@ -484,13 +492,19 @@ User Locale: ${effectiveState.locale}`;
   if (effectiveState.requestGeo) {
     const location = [
       effectiveState.requestGeo.city,
+      effectiveState.requestGeo.region,
       effectiveState.requestGeo.country,
     ]
       .filter(Boolean)
       .join(", ");
-    if (location) {
+    const coordinates =
+      effectiveState.requestGeo.latitude && effectiveState.requestGeo.longitude
+        ? `${effectiveState.requestGeo.latitude}, ${effectiveState.requestGeo.longitude}`
+        : "";
+    const locationText = location || coordinates;
+    if (locationText) {
       prompt += `
-User Location: ${location} (inferred from IP, may be inaccurate)`;
+User Location: ${locationText} (inferred from IP, may be inaccurate)`;
     }
   }
 
@@ -734,11 +748,15 @@ export async function prepareRyoConversationModelInput(
         username,
         fallbackTimeZone: providedTimeZone,
       });
-  const effectiveSystemState = storedUserLocalTime
+  const storedUserGeo = hasUsefulGeo(systemState?.requestGeo)
+    ? null
+    : await getStoredUserGeo(redis, username);
+  const effectiveSystemState = storedUserLocalTime || storedUserGeo
     ? ({
         ...(systemState ?? {}),
         username: systemState?.username ?? username ?? undefined,
-        userLocalTime: storedUserLocalTime,
+        ...(storedUserLocalTime ? { userLocalTime: storedUserLocalTime } : {}),
+        ...(storedUserGeo ? { requestGeo: storedUserGeo } : {}),
       } as RyoConversationSystemState)
     : systemState;
   const userTimeZone = effectiveSystemState?.userLocalTime?.timeZone || providedTimeZone;

--- a/api/auth/login.ts
+++ b/api/auth/login.ts
@@ -12,6 +12,7 @@
  *   attacker rotates IPs or uses a botnet.
  */
 
+import { geolocation } from "@vercel/functions";
 import {
   generateAuthToken,
   storeToken,
@@ -29,7 +30,10 @@ import { apiHandler } from "../_utils/api-handler.js";
 import { buildSetAuthCookie } from "../_utils/_cookie.js";
 import { getClientIp } from "../_utils/_rate-limit.js";
 import { getHeader } from "../_utils/request-helpers.js";
-import { updateStoredUserTimeZone } from "../_utils/auth/_user-record.js";
+import {
+  updateStoredUserGeo,
+  updateStoredUserTimeZone,
+} from "../_utils/auth/_user-record.js";
 
 export const runtime = "nodejs";
 export const maxDuration = 15;
@@ -123,6 +127,11 @@ export default apiHandler(
     // Successful login — reset the per-username failure counter.
     await resetLoginFailures(redis, username);
     await updateStoredUserTimeZone(redis, username, getHeader(req, "x-user-timezone"));
+    try {
+      await updateStoredUserGeo(redis, username, geolocation(req as unknown as Request));
+    } catch {
+      // Vercel geolocation is unavailable in local/self-hosted runtimes.
+    }
 
     // Handle old token if provided (rotation)
     if (oldToken) {

--- a/api/auth/register.ts
+++ b/api/auth/register.ts
@@ -4,6 +4,7 @@
  * Create a new user account with password (Node.js runtime for bcrypt)
  */
 
+import { geolocation } from "@vercel/functions";
 import {
   generateAuthToken,
   storeToken,
@@ -29,7 +30,9 @@ import { buildSetAuthCookie } from "../_utils/_cookie.js";
 import { getClientIp } from "../_utils/_rate-limit.js";
 import { getHeader } from "../_utils/request-helpers.js";
 import {
+  normalizeUserGeo,
   normalizeUserTimeZone,
+  updateStoredUserGeo,
   updateStoredUserTimeZone,
 } from "../_utils/auth/_user-record.js";
 
@@ -148,6 +151,15 @@ export default apiHandler(
               username,
               getHeader(req, "x-user-timezone")
             );
+            try {
+              await updateStoredUserGeo(
+                redis,
+                username,
+                geolocation(req as unknown as Request)
+              );
+            } catch {
+              // Vercel geolocation is unavailable in local/self-hosted runtimes.
+            }
             const token = generateAuthToken();
             await storeToken(redis, username, token);
             res.setHeader("Set-Cookie", buildSetAuthCookie(username, token));
@@ -168,6 +180,12 @@ export default apiHandler(
     // Create user
     const now = Date.now();
     const requestTimeZone = normalizeUserTimeZone(getHeader(req, "x-user-timezone"));
+    let requestGeo: ReturnType<typeof normalizeUserGeo> = null;
+    try {
+      requestGeo = normalizeUserGeo(geolocation(req as unknown as Request));
+    } catch {
+      requestGeo = null;
+    }
     const userData = {
       username,
       createdAt: now,
@@ -175,6 +193,7 @@ export default apiHandler(
       ...(requestTimeZone
         ? { timeZone: requestTimeZone, timeZoneUpdatedAt: now }
         : {}),
+      ...(requestGeo ? { geo: requestGeo, geoUpdatedAt: now } : {}),
     };
     await redis.set(userKey, JSON.stringify(userData));
 

--- a/api/auth/session.ts
+++ b/api/auth/session.ts
@@ -6,7 +6,10 @@
 
 import { buildSetAuthCookie } from "../_utils/_cookie.js";
 import { apiHandler } from "../_utils/api-handler.js";
-import { getStoredUserTimeZone } from "../_utils/auth/_user-record.js";
+import {
+  getStoredUserGeo,
+  getStoredUserTimeZone,
+} from "../_utils/auth/_user-record.js";
 
 export const runtime = "nodejs";
 export const maxDuration = 10;
@@ -28,13 +31,17 @@ export default apiHandler(
     res.setHeader("Set-Cookie", buildSetAuthCookie(user.username, user.token));
 
     logger.info("Session restored", { username: user.username });
-    const timeZone = await getStoredUserTimeZone(redis, user.username);
+    const [timeZone, geo] = await Promise.all([
+      getStoredUserTimeZone(redis, user.username),
+      getStoredUserGeo(redis, user.username),
+    ]);
     logger.response(200, Date.now() - startTime);
     res.status(200).json({
       authenticated: true,
       username: user.username,
       expired: user.expired,
       ...(timeZone ? { timeZone } : {}),
+      ...(geo ? { geo } : {}),
     });
   }
 );

--- a/api/chat.ts
+++ b/api/chat.ts
@@ -25,7 +25,9 @@ import { getHeader } from "./_utils/request-helpers.js";
 import { resolveIpGeolocation } from "./_utils/_geolocation.js";
 import { createRyoToolLoopAgent } from "./_utils/ryo-agent.js";
 import {
+  getStoredUserGeo,
   getStoredUserTimeZone,
+  updateStoredUserGeo,
   updateStoredUserTimeZone,
 } from "./_utils/auth/_user-record.js";
 import { buildUserLocalTimeContext } from "./_utils/user-time-context.js";
@@ -39,6 +41,9 @@ function normalizeChatModel(model: string): string {
   return CHAT_MODEL_ALIASES[model] ?? model;
 }
 
+function hasUsefulGeo(geo?: SystemState["requestGeo"] | null): boolean {
+  return Boolean(geo && (geo.city || geo.country || (geo.latitude && geo.longitude)));
+}
 
 // Node.js runtime configuration
 export const runtime = "nodejs";
@@ -178,11 +183,26 @@ export default apiHandler<{
         log,
         logError,
       })) ?? geo;
+    if (isAuthenticated && username && hasUsefulGeo(resolvedGeo)) {
+      await updateStoredUserGeo(redis, username, resolvedGeo).catch((error) => {
+        logError("Failed to update user geo from chat request", error);
+      });
+    }
+    const storedUserGeo =
+      !hasUsefulGeo(resolvedGeo) && isAuthenticated && username
+        ? await getStoredUserGeo(redis, username)
+        : null;
+    const effectiveGeo = hasUsefulGeo(resolvedGeo) ? resolvedGeo : storedUserGeo;
 
     // Attach geolocation info to system state that will be sent to the prompt
     const systemState: SystemState | undefined = incomingSystemState
-      ? { ...incomingSystemState, requestGeo: resolvedGeo }
-      : ({ requestGeo: resolvedGeo } as SystemState);
+      ? {
+          ...incomingSystemState,
+          ...(effectiveGeo ? { requestGeo: effectiveGeo } : {}),
+        }
+      : effectiveGeo
+        ? ({ requestGeo: effectiveGeo } as SystemState)
+        : undefined;
     const userTimeZone = systemState?.userLocalTime?.timeZone;
     if (isAuthenticated && username && userTimeZone) {
       await updateStoredUserTimeZone(redis, username, userTimeZone).catch((error) => {

--- a/src/shared/contracts/auth.ts
+++ b/src/shared/contracts/auth.ts
@@ -21,9 +21,18 @@ export interface CheckPasswordResponse {
   username: string;
 }
 
+export interface AuthGeoResponse {
+  city?: string;
+  region?: string;
+  country?: string;
+  latitude?: string;
+  longitude?: string;
+}
+
 export interface LoginResponse {
   username: string;
   timeZone?: string;
+  geo?: AuthGeoResponse;
 }
 
 export interface RegisterResponse {
@@ -32,6 +41,7 @@ export interface RegisterResponse {
     hasPassword?: boolean;
     createdAt?: number;
     timeZone?: string;
+    geo?: AuthGeoResponse;
   };
 }
 
@@ -40,4 +50,5 @@ export interface SessionResponse {
   username?: string;
   expired?: boolean;
   timeZone?: string;
+  geo?: AuthGeoResponse;
 }

--- a/tests/test-auth-user-record.test.ts
+++ b/tests/test-auth-user-record.test.ts
@@ -1,10 +1,13 @@
 import { describe, expect, test } from "bun:test";
 import type { Redis } from "../api/_utils/redis";
 import {
+  getStoredUserGeo,
   getStoredUserTimeZone,
   isUserBanned,
+  normalizeUserGeo,
   normalizeUserTimeZone,
   parseStoredUser,
+  updateStoredUserGeo,
   updateStoredUserTimeZone,
 } from "../api/_utils/auth/_user-record";
 import { CHAT_USERS_PREFIX } from "../api/_utils/auth/_constants";
@@ -76,6 +79,55 @@ describe("stored user record helpers", () => {
     const ignored = await updateStoredUserTimeZone(redis, username, "not/a-zone", 456);
     expect(ignored).toBeNull();
     expect(await getStoredUserTimeZone(redis, username)).toBe("Europe/Berlin");
+  });
+
+  test("validates and persists useful approximate GeoIP context", async () => {
+    const redis = makeRedis();
+    const username = "geo_user";
+    await redis.set(`${CHAT_USERS_PREFIX}${username}`, JSON.stringify({ username }));
+
+    expect(
+      normalizeUserGeo({
+        city: "  San Francisco  ",
+        region: "California",
+        country: "US",
+        latitude: "37.7749",
+        longitude: -122.4194,
+      })
+    ).toEqual({
+      city: "San Francisco",
+      region: "California",
+      country: "US",
+      latitude: "37.7749",
+      longitude: "-122.4194",
+    });
+    expect(normalizeUserGeo({ region: "California" })).toBeNull();
+    expect(normalizeUserGeo({ latitude: "999", longitude: "0" })).toBeNull();
+
+    const updated = await updateStoredUserGeo(
+      redis,
+      username,
+      {
+        city: "Berlin",
+        country: "DE",
+        latitude: "52.52",
+        longitude: "13.405",
+      },
+      456
+    );
+
+    expect(updated?.geo).toEqual({
+      city: "Berlin",
+      country: "DE",
+      latitude: "52.52",
+      longitude: "13.405",
+    });
+    expect(updated?.geoUpdatedAt).toBe(456);
+    expect(await getStoredUserGeo(redis, username)).toEqual(updated?.geo);
+
+    const ignored = await updateStoredUserGeo(redis, username, { region: "Only" }, 789);
+    expect(ignored).toBeNull();
+    expect(await getStoredUserGeo(redis, username)).toEqual(updated?.geo);
   });
 
   test("builds stable user-local prompt time context", () => {

--- a/tests/test-telegram-heartbeat.test.ts
+++ b/tests/test-telegram-heartbeat.test.ts
@@ -462,7 +462,7 @@ describe("telegram heartbeat helpers", () => {
     expect("web_search" in prepared.tools).toBe(true);
   });
 
-  test("telegram prompts hydrate user local time from the stored user timezone", async () => {
+  test("telegram prompts hydrate local time and location from the stored user record", async () => {
     const redis = makeRedis();
     await redis.set(
       `${CHAT_USERS_PREFIX}${TELEGRAM_HEARTBEAT_TARGET_USERNAME}`,
@@ -470,6 +470,14 @@ describe("telegram heartbeat helpers", () => {
         username: TELEGRAM_HEARTBEAT_TARGET_USERNAME,
         timeZone: "Asia/Tokyo",
         timeZoneUpdatedAt: 123,
+        geo: {
+          city: "Tokyo",
+          region: "Tokyo",
+          country: "JP",
+          latitude: "35.6762",
+          longitude: "139.6503",
+        },
+        geoUpdatedAt: 456,
       })
     );
 
@@ -490,6 +498,7 @@ describe("telegram heartbeat helpers", () => {
     expect(prepared.userTimeZone).toBe("Asia/Tokyo");
     expect(prepared.volatileStatePrompt).toContain("User Time:");
     expect(prepared.volatileStatePrompt).toContain("(Asia/Tokyo)");
+    expect(prepared.volatileStatePrompt).toContain("User Location: Tokyo, Tokyo, JP");
   });
 
   test("heartbeat conversations enable Google search grounding on gemini flash", async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Store a validated approximate GeoIP location on user records from platform/chat geolocation.
- Hydrate server-only Ryo conversations and Telegram prompts from stored GeoIP when request/client geo is absent.
- Add focused tests for GeoIP persistence and prompt hydration.

## Testing
- ✅ `bun test tests/test-auth-user-record.test.ts tests/test-telegram-heartbeat.test.ts`
- ✅ `bun run build` (passes with pre-existing CSS/chunking warnings)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ed6d8-51ea-77af-b514-e968007eef27"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ed6d8-51ea-77af-b514-e968007eef27"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

