### PR TITLE
Add Redis key scheme registry

### DIFF
--- a/api/_utils/_analytics.ts
+++ b/api/_utils/_analytics.ts
@@ -5,11 +5,11 @@
  * All writes are fire-and-forget to avoid impacting request latency.
  *
  * Redis key schema:
- *   analytics:daily:{YYYY-MM-DD}    hash  { calls, ai, errors, latsum, latcnt }
- *   analytics:uv:{YYYY-MM-DD}       HyperLogLog  (unique visitor IPs)
- *   analytics:ep:{YYYY-MM-DD}       hash  { endpoint: count }
- *   analytics:st:{YYYY-MM-DD}       hash  { statusCode: count }
- *   analytics:aiu:{YYYY-MM-DD}      hash  { username|"anon": count }
+ *   analytics:api:daily:{YYYY-MM-DD}    hash  { calls, ai, errors, latsum, latcnt }
+ *   analytics:api:uv:{YYYY-MM-DD}       HyperLogLog  (unique visitor IPs)
+ *   analytics:api:ep:{YYYY-MM-DD}       hash  { endpoint: count }
+ *   analytics:api:st:{YYYY-MM-DD}       hash  { statusCode: count }
+ *   analytics:api:aiu:{YYYY-MM-DD}      hash  { username|"anon": count }
  *
  * Performance:
  *   Write path: 5–8 Redis commands per request in 1 pipeline (fire-and-forget).
@@ -18,6 +18,7 @@
  */
 
 import type { Redis } from "./redis.js";
+import { redisKeys } from "../../src/shared/redisKeys.js";
 
 const ANALYTICS_TTL_SECONDS = 90 * 24 * 60 * 60; // 90 days
 
@@ -29,7 +30,7 @@ function todayUTC(): string {
 }
 
 function k(suffix: string, date: string): string {
-  return `analytics:${suffix}:${date}`;
+  return redisKeys.analytics.apiMetric(suffix, date);
 }
 
 function pk(suffix: string, date: string): string {

--- a/api/_utils/auth/_password-storage.ts
+++ b/api/_utils/auth/_password-storage.ts
@@ -7,6 +7,7 @@
 
 import type { Redis } from "../redis.js";
 import { PASSWORD_HASH_PREFIX } from "./_constants.js";
+import { redisKeys } from "../../../src/shared/redisKeys.js";
 
 // Re-export constants for convenience
 export {
@@ -21,6 +22,10 @@ function getPasswordKey(username: string): string {
   return `${PASSWORD_HASH_PREFIX}${username.toLowerCase()}`;
 }
 
+function getCanonicalPasswordKey(username: string): string {
+  return redisKeys.auth.userPassword(username);
+}
+
 /**
  * Set or update a user's password hash
  */
@@ -29,7 +34,7 @@ export async function setUserPasswordHash(
   username: string,
   passwordHash: string
 ): Promise<void> {
-  const key = getPasswordKey(username);
+  const key = getCanonicalPasswordKey(username);
   await redis.set(key, passwordHash);
 }
 
@@ -40,8 +45,10 @@ export async function getUserPasswordHash(
   redis: Redis,
   username: string
 ): Promise<string | null> {
-  const key = getPasswordKey(username);
-  return await redis.get(key);
+  return (
+    (await redis.get<string>(getCanonicalPasswordKey(username))) ??
+    (await redis.get<string>(getPasswordKey(username)))
+  );
 }
 
 /**
@@ -51,8 +58,7 @@ export async function deleteUserPasswordHash(
   redis: Redis,
   username: string
 ): Promise<void> {
-  const key = getPasswordKey(username);
-  await redis.del(key);
+  await redis.del(getCanonicalPasswordKey(username), getPasswordKey(username));
 }
 
 /**

--- a/api/_utils/auth/_tokens.ts
+++ b/api/_utils/auth/_tokens.ts
@@ -13,6 +13,7 @@ import {
   USER_EXPIRATION_TIME,
   TOKEN_GRACE_PERIOD,
 } from "./_constants.js";
+import { redisKeys, sha256RedisIdentifier } from "../../../src/shared/redisKeys.js";
 
 // ============================================================================
 // Key Helpers
@@ -26,6 +27,14 @@ export function getUserTokenKey(username: string, token: string): string {
   return `${AUTH_TOKEN_PREFIX}user:${username.toLowerCase()}:${token}`;
 }
 
+export async function getCanonicalSessionKey(token: string): Promise<string> {
+  return redisKeys.auth.session(await sha256RedisIdentifier(token));
+}
+
+export async function getCanonicalUserSessionsKey(username: string): Promise<string> {
+  return redisKeys.auth.userSessions(username);
+}
+
 /**
  * Get pattern for scanning all tokens for a user
  */
@@ -37,6 +46,10 @@ export function getUserTokenPattern(username: string): string {
  * Build the Redis key for grace-period token storage
  */
 export function getLastTokenKey(username: string): string {
+  return redisKeys.auth.lastSession(username);
+}
+
+export function getLegacyLastTokenKey(username: string): string {
   return `${AUTH_TOKEN_PREFIX}last:${username.toLowerCase()}`;
 }
 
@@ -71,9 +84,12 @@ export async function storeToken(
   if (!token) return;
   
   const normalizedUsername = username.toLowerCase();
-  const key = getUserTokenKey(normalizedUsername, token);
+  const tokenHash = await sha256RedisIdentifier(token);
+  const key = redisKeys.auth.session(tokenHash);
   
   await redis.set(key, Date.now(), { ex: USER_EXPIRATION_TIME });
+  await redis.sadd(redisKeys.auth.userSessions(normalizedUsername), tokenHash);
+  await redis.expire(redisKeys.auth.userSessions(normalizedUsername), USER_EXPIRATION_TIME);
 }
 
 /**
@@ -84,6 +100,20 @@ export async function deleteToken(
   token: string
 ): Promise<void> {
   if (!token) return;
+  const tokenHash = await sha256RedisIdentifier(token);
+  await redis.del(redisKeys.auth.session(tokenHash));
+
+  let canonicalCursor = 0;
+  do {
+    const [newCursor, foundKeys] = await redis.scan(canonicalCursor, {
+      match: "auth:user:*:sessions",
+      count: 100,
+    });
+    canonicalCursor = parseInt(String(newCursor));
+    for (const key of foundKeys) {
+      await redis.srem(key, tokenHash);
+    }
+  } while (canonicalCursor !== 0);
 
   // Find and delete the token key by scanning
   const pattern = `${AUTH_TOKEN_PREFIX}user:*:${token}`;
@@ -119,6 +149,15 @@ export async function deleteAllUserTokens(
   const userTokenKeys: string[] = [];
   let cursor = 0;
 
+  const canonicalSessionSetKey = redisKeys.auth.userSessions(normalizedUsername);
+  const tokenHashes = await redis.smembers<string[]>(canonicalSessionSetKey);
+  if (tokenHashes.length > 0) {
+    deletedCount += await redis.del(
+      ...tokenHashes.map((tokenHash) => redisKeys.auth.session(tokenHash))
+    );
+  }
+  deletedCount += await redis.del(canonicalSessionSetKey);
+
   do {
     const [newCursor, foundKeys] = await redis.scan(cursor, {
       match: pattern,
@@ -137,6 +176,7 @@ export async function deleteAllUserTokens(
   const lastTokenKey = getLastTokenKey(normalizedUsername);
   const lastDeleted = await redis.del(lastTokenKey);
   deletedCount += lastDeleted;
+  deletedCount += await redis.del(getLegacyLastTokenKey(normalizedUsername));
 
   return deletedCount;
 }
@@ -148,7 +188,15 @@ export async function getUserTokens(
   redis: Redis,
   username: string
 ): Promise<TokenInfo[]> {
-  const pattern = getUserTokenPattern(username);
+  const normalizedUsername = username.toLowerCase();
+  const tokenHashes = await redis.smembers<string[]>(redisKeys.auth.userSessions(normalizedUsername));
+  const canonicalTokens = await Promise.all(
+    tokenHashes.map(async (tokenHash) => ({
+      token: tokenHash,
+      createdAt: await redis.get<number | string>(redisKeys.auth.session(tokenHash)),
+    }))
+  );
+  const pattern = getUserTokenPattern(normalizedUsername);
   const tokens: TokenInfo[] = [];
   let cursor = 0;
 
@@ -167,7 +215,7 @@ export async function getUserTokens(
     }
   } while (cursor !== 0);
 
-  return tokens;
+  return [...canonicalTokens, ...tokens];
 }
 
 /**
@@ -196,6 +244,9 @@ export async function refreshTokenTTL(
   username: string,
   token: string
 ): Promise<void> {
-  const key = getUserTokenKey(username.toLowerCase(), token);
-  await redis.expire(key, USER_TTL_SECONDS);
+  const normalizedUsername = username.toLowerCase();
+  const tokenHash = await sha256RedisIdentifier(token);
+  await redis.expire(redisKeys.auth.session(tokenHash), USER_TTL_SECONDS);
+  await redis.expire(redisKeys.auth.userSessions(normalizedUsername), USER_TTL_SECONDS);
+  await redis.expire(getUserTokenKey(normalizedUsername, token), USER_TTL_SECONDS);
 }

--- a/api/_utils/auth/_user-record.ts
+++ b/api/_utils/auth/_user-record.ts
@@ -1,5 +1,5 @@
 /**
- * Helpers for reading and updating the stored user record (`chat:users:{username}`).
+ * Helpers for reading and updating the stored user record.
  *
  * The record is persisted as a JSON string (or, on some Redis backends, an
  * already-parsed object), so callers must tolerate both shapes.
@@ -7,6 +7,7 @@
 
 import type { Redis } from "../redis.js";
 import { CHAT_USERS_PREFIX } from "./_constants.js";
+import { redisKeys } from "../../../src/shared/redisKeys.js";
 
 export interface StoredUserRecord {
   username?: string;
@@ -41,6 +42,10 @@ export function isUserBanned(userData: unknown): boolean {
   return parseStoredUser(userData)?.banned === true;
 }
 
+export function getLegacyStoredUserKey(username: string): string {
+  return `${CHAT_USERS_PREFIX}${username.toLowerCase()}`;
+}
+
 /**
  * Validate a browser-provided IANA timezone. Returns null for unknown/invalid
  * values so we never persist misleading prompt context.
@@ -67,7 +72,22 @@ export async function getStoredUserRecord(
   redis: Redis,
   username: string
 ): Promise<StoredUserRecord | null> {
-  return parseStoredUser(await redis.get(`${CHAT_USERS_PREFIX}${username.toLowerCase()}`));
+  const normalizedUsername = username.toLowerCase();
+  return parseStoredUser(
+    (await redis.get(redisKeys.auth.userProfile(normalizedUsername))) ??
+      (await redis.get(getLegacyStoredUserKey(normalizedUsername)))
+  );
+}
+
+export async function setStoredUserRecord(
+  redis: Redis,
+  username: string,
+  record: StoredUserRecord
+): Promise<void> {
+  await redis.set(
+    redisKeys.auth.userProfile(username.toLowerCase()),
+    JSON.stringify(record)
+  );
 }
 
 export async function getStoredUserTimeZone(
@@ -93,8 +113,8 @@ export async function updateStoredUserTimeZone(
     return null;
   }
 
-  const key = `${CHAT_USERS_PREFIX}${username.toLowerCase()}`;
-  const existingRecord = parseStoredUser(await redis.get(key));
+  const key = redisKeys.auth.userProfile(username.toLowerCase());
+  const existingRecord = await getStoredUserRecord(redis, username);
   if (!existingRecord) {
     return null;
   }

--- a/api/_utils/auth/_validate.ts
+++ b/api/_utils/auth/_validate.ts
@@ -11,7 +11,13 @@ import {
   USER_TTL_SECONDS,
   TOKEN_GRACE_PERIOD,
 } from "./_constants.js";
-import { getUserTokenKey, getLastTokenKey } from "./_tokens.js";
+import {
+  getCanonicalSessionKey,
+  getLegacyLastTokenKey,
+  getUserTokenKey,
+  getLastTokenKey,
+} from "./_tokens.js";
+import { redisKeys, sha256RedisIdentifier } from "../../../src/shared/redisKeys.js";
 
 // ============================================================================
 // Validation Options
@@ -52,7 +58,23 @@ export async function validateAuth(
 
   const normalizedUsername = username.toLowerCase();
 
-  // 1. Check active token: chat:token:user:{username}:{token}
+  // 1. Check canonical active token:
+  // auth:session:{sha256(token)} + auth:user:{username}:sessions membership.
+  const tokenHash = await sha256RedisIdentifier(token);
+  const canonicalSessionKey = await getCanonicalSessionKey(token);
+  const canonicalSessionExists = await redis.exists(canonicalSessionKey);
+  if (canonicalSessionExists) {
+    const sessionHashes = await redis.smembers<string[]>(
+      redisKeys.auth.userSessions(normalizedUsername)
+    );
+    if (sessionHashes.includes(tokenHash)) {
+      await redis.expire(canonicalSessionKey, USER_TTL_SECONDS);
+      await redis.expire(redisKeys.auth.userSessions(normalizedUsername), USER_TTL_SECONDS);
+      return { valid: true, expired: false };
+    }
+  }
+
+  // 2. Check legacy active token: chat:token:user:{username}:{token}
   const userScopedKey = getUserTokenKey(normalizedUsername, token);
   const exists = await redis.exists(userScopedKey);
   
@@ -62,10 +84,12 @@ export async function validateAuth(
     return { valid: true, expired: false };
   }
 
-  // 2. Check grace period for recently expired tokens (if allowed)
+  // 3. Check grace period for recently expired tokens (if allowed)
   if (allowExpired) {
     const lastTokenKey = getLastTokenKey(normalizedUsername);
-    const lastTokenData = await redis.get<string>(lastTokenKey);
+    const lastTokenData =
+      (await redis.get<string>(lastTokenKey)) ??
+      (await redis.get<string>(getLegacyLastTokenKey(normalizedUsername)));
 
     if (lastTokenData) {
       try {
@@ -98,6 +122,13 @@ export async function tokenExists(
   username: string,
   token: string
 ): Promise<boolean> {
+  const tokenHash = await sha256RedisIdentifier(token);
+  if (await redis.exists(redisKeys.auth.session(tokenHash))) {
+    const sessionHashes = await redis.smembers<string[]>(
+      redisKeys.auth.userSessions(username.toLowerCase())
+    );
+    if (sessionHashes.includes(tokenHash)) return true;
+  }
   const key = getUserTokenKey(username.toLowerCase(), token);
   const exists = await redis.exists(key);
   return exists > 0;

--- a/api/_utils/redis-key-migration.ts
+++ b/api/_utils/redis-key-migration.ts
@@ -1,4 +1,4 @@
-import type { Redis } from "./redis.js";
+import type { Redis, RedisSortedSetEntry } from "./redis.js";
 import { ensureSync2Initialized } from "../sync/v2/_core.js";
 import {
   LEGACY_REDIS_SCAN_PATTERNS,
@@ -359,6 +359,14 @@ export async function planRedisKeyMigration(
     if (builder && username) {
       return { legacyKey, targetKey: builder(username), action: "copy" };
     }
+    if (family === "log" && username) {
+      return {
+        legacyKey,
+        targetKey: null,
+        action: "skip",
+        reason: undefined,
+      };
+    }
     if (legacyKey === "sync2:maint:cursor") {
       return { legacyKey, targetKey: redisKeys.sync.maintenanceCursor(), action: "copy" };
     }
@@ -465,6 +473,91 @@ export async function planRedisKeyMigration(
   };
 }
 
+function parseZrangeWithScores(
+  raw: unknown,
+  expectedCount: number
+): RedisSortedSetEntry[] | null {
+  if (!Array.isArray(raw)) return null;
+  if (raw.length === 0) return expectedCount === 0 ? [] : null;
+
+  if (raw.every((entry) => Array.isArray(entry) && entry.length >= 2)) {
+    const parsed = raw
+      .map((entry) => {
+        const [member, score] = entry as [unknown, unknown];
+        return {
+          member: typeof member === "string" ? member : String(member),
+          score: Number(score),
+        };
+      })
+      .filter((entry) => Number.isFinite(entry.score));
+    return parsed.length === expectedCount ? parsed : null;
+  }
+
+  if (
+    raw.every(
+      (entry) =>
+        entry &&
+        typeof entry === "object" &&
+        "member" in entry &&
+        "score" in entry
+    )
+  ) {
+    const parsed = raw
+      .map((entry) => {
+        const candidate = entry as { member: unknown; score: unknown };
+        return {
+          member:
+            typeof candidate.member === "string"
+              ? candidate.member
+              : String(candidate.member),
+          score: Number(candidate.score),
+        };
+      })
+      .filter((entry) => Number.isFinite(entry.score));
+    return parsed.length === expectedCount ? parsed : null;
+  }
+
+  if (raw.length !== expectedCount * 2) return null;
+  const parsed: RedisSortedSetEntry[] = [];
+  for (let index = 0; index < raw.length; index += 2) {
+    const member = raw[index];
+    const score = Number(raw[index + 1]);
+    if (!Number.isFinite(score)) return null;
+    parsed.push({
+      member: typeof member === "string" ? member : String(member),
+      score,
+    });
+  }
+  return parsed.length === expectedCount ? parsed : null;
+}
+
+async function zrangeWithScores(
+  redis: Redis,
+  key: string
+): Promise<RedisSortedSetEntry[] | null> {
+  const redisWithScores = redis as Redis & {
+    zrangeWithScores?: (
+      key: string,
+      start: number,
+      stop: number
+    ) => Promise<RedisSortedSetEntry[]>;
+  };
+  if (typeof redisWithScores.zrangeWithScores === "function") {
+    return await redisWithScores.zrangeWithScores(key, 0, -1);
+  }
+
+  const redisWithExtendedZrange = redis as Redis & {
+    zrange: (key: string, start: number, stop: number, options: unknown) => Promise<unknown>;
+  };
+  try {
+    const expectedCount = await redis.zcard(key);
+    const raw = await redisWithExtendedZrange.zrange(key, 0, -1, { withScores: true });
+    return parseZrangeWithScores(raw, expectedCount);
+  } catch {
+    return null;
+  }
+}
+
 async function copyRedisValue(
   redis: Redis,
   sourceKey: string,
@@ -500,7 +593,18 @@ async function copyRedisValue(
       return null;
     }
     case "zset":
-      return `Skipped ${sourceKey}: score-preserving zset copy is not supported by RedisLike`;
+      {
+        const entries = await zrangeWithScores(redis, sourceKey);
+        if (!entries) {
+          return `Skipped ${sourceKey}: score-preserving zset copy is not supported by this Redis client`;
+        }
+        await redis.del(targetKey);
+        for (const entry of entries) {
+          await redis.zadd(targetKey, entry);
+        }
+        if (ttl > 0) await redis.expire(targetKey, ttl);
+        return null;
+      }
     case "none":
       return `Skipped ${sourceKey}: key no longer exists`;
     default:

--- a/api/_utils/redis-key-migration.ts
+++ b/api/_utils/redis-key-migration.ts
@@ -1,0 +1,559 @@
+import type { Redis } from "./redis.js";
+import {
+  LEGACY_REDIS_SCAN_PATTERNS,
+  redisKeys,
+  sha256RedisIdentifier,
+  type LegacyRedisScanPattern,
+} from "../../src/shared/redisKeys.js";
+
+export interface RedisLegacyPatternStatus {
+  pattern: LegacyRedisScanPattern;
+  count: number;
+  sampleKeys: string[];
+  truncated: boolean;
+}
+
+export interface RedisMigrationStatus {
+  checkedAt: string;
+  perPatternLimit: number;
+  totalLegacyKeys: number;
+  truncated: boolean;
+  patterns: RedisLegacyPatternStatus[];
+}
+
+export interface RedisKeyMigrationPlan {
+  legacyKey: string;
+  targetKey: string | null;
+  additionalKeys?: string[];
+  action: "copy" | "skip";
+  reason?: string;
+}
+
+export interface RedisBackfillResult {
+  pattern: string;
+  dryRun: boolean;
+  scanned: number;
+  planned: number;
+  copied: number;
+  skipped: number;
+  warnings: string[];
+  truncated: boolean;
+  keys: RedisKeyMigrationPlan[];
+}
+
+export interface RedisDeleteLegacyResult {
+  pattern: string;
+  dryRun: boolean;
+  scanned: number;
+  deleted: number;
+  truncated: boolean;
+  keys: string[];
+}
+
+const LEGACY_PATTERN_SET = new Set<string>(LEGACY_REDIS_SCAN_PATTERNS);
+const STATUS_SCAN_COUNT = 1000;
+
+function isKnownLegacyPattern(pattern: string): pattern is LegacyRedisScanPattern {
+  return LEGACY_PATTERN_SET.has(pattern);
+}
+
+export function assertKnownLegacyRedisPattern(pattern: string): void {
+  if (!isKnownLegacyPattern(pattern)) {
+    throw new Error("Pattern must be one of the registered legacy Redis patterns");
+  }
+}
+
+function suffixAfter(key: string, prefix: string): string {
+  return key.slice(prefix.length);
+}
+
+function splitSuffix(key: string, prefix: string): string[] {
+  const suffix = suffixAfter(key, prefix);
+  return suffix ? suffix.split(":") : [];
+}
+
+function safeDecode(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}
+
+async function scanKeys(
+  redis: Redis,
+  pattern: string,
+  limit: number
+): Promise<{ keys: string[]; truncated: boolean }> {
+  const keys: string[] = [];
+  const seen = new Set<string>();
+  let cursor: string | number = 0;
+  let iterations = 0;
+
+  do {
+    const [nextCursor, batch] = await redis.scan(cursor, {
+      match: pattern,
+      count: STATUS_SCAN_COUNT,
+    });
+    cursor = nextCursor;
+    iterations += 1;
+    for (const key of batch) {
+      if (!seen.has(key)) {
+        seen.add(key);
+        keys.push(key);
+        if (keys.length >= limit) break;
+      }
+    }
+  } while (
+    cursor !== 0 &&
+    cursor !== "0" &&
+    keys.length < limit &&
+    iterations < 250
+  );
+
+  return {
+    keys: keys.sort(),
+    truncated: keys.length >= limit || (cursor !== 0 && cursor !== "0"),
+  };
+}
+
+export async function getRedisMigrationStatus(
+  redis: Redis,
+  perPatternLimit: number
+): Promise<RedisMigrationStatus> {
+  const patterns: RedisLegacyPatternStatus[] = [];
+  for (const pattern of LEGACY_REDIS_SCAN_PATTERNS) {
+    const { keys, truncated } = await scanKeys(redis, pattern, perPatternLimit);
+    patterns.push({
+      pattern,
+      count: keys.length,
+      sampleKeys: keys.slice(0, 10),
+      truncated,
+    });
+  }
+
+  return {
+    checkedAt: new Date().toISOString(),
+    perPatternLimit,
+    totalLegacyKeys: patterns.reduce((sum, item) => sum + item.count, 0),
+    truncated: patterns.some((item) => item.truncated),
+    patterns,
+  };
+}
+
+export async function planRedisKeyMigration(
+  legacyKey: string
+): Promise<RedisKeyMigrationPlan> {
+  if (legacyKey === "airdrop:presence") {
+    return { legacyKey, targetKey: redisKeys.presence.airdropLobby(), action: "copy" };
+  }
+  if (legacyKey.startsWith("airdrop:transfer:")) {
+    return {
+      legacyKey,
+      targetKey: redisKeys.session.airdropTransfer(suffixAfter(legacyKey, "airdrop:transfer:")),
+      action: "copy",
+    };
+  }
+  if (legacyKey.startsWith("analytics:")) {
+    const [metric, ...rest] = splitSuffix(legacyKey, "analytics:");
+    if (["aiu", "daily", "ep", "st", "uv"].includes(metric) && rest.length > 0) {
+      return {
+        legacyKey,
+        targetKey: redisKeys.analytics.apiMetric(metric, rest.join(":")),
+        action: "copy",
+      };
+    }
+  }
+  if (legacyKey.startsWith("apple:artwork:")) {
+    return {
+      legacyKey,
+      targetKey: redisKeys.cache.appleArtwork(suffixAfter(legacyKey, "apple:artwork:")),
+      action: "copy",
+    };
+  }
+  if (legacyKey.startsWith("applet:share:")) {
+    return {
+      legacyKey,
+      targetKey: redisKeys.media.appletShare(suffixAfter(legacyKey, "applet:share:")),
+      action: "copy",
+    };
+  }
+  if (legacyKey === "chat:irc:servers") {
+    return { legacyKey, targetKey: redisKeys.integration.ircServerIds(), action: "copy" };
+  }
+  if (legacyKey.startsWith("chat:irc:server:")) {
+    return {
+      legacyKey,
+      targetKey: redisKeys.integration.ircServer(suffixAfter(legacyKey, "chat:irc:server:")),
+      action: "copy",
+    };
+  }
+  if (legacyKey.startsWith("chat:messages:")) {
+    return {
+      legacyKey,
+      targetKey: redisKeys.chat.roomMessages(suffixAfter(legacyKey, "chat:messages:")),
+      action: "copy",
+    };
+  }
+  if (legacyKey.startsWith("chat:password:")) {
+    return {
+      legacyKey,
+      targetKey: redisKeys.auth.userPassword(suffixAfter(legacyKey, "chat:password:")),
+      action: "copy",
+    };
+  }
+  if (legacyKey.startsWith("chat:presencez:") || legacyKey.startsWith("chat:presence:")) {
+    const roomId = legacyKey.startsWith("chat:presencez:")
+      ? suffixAfter(legacyKey, "chat:presencez:")
+      : suffixAfter(legacyKey, "chat:presence:");
+    return { legacyKey, targetKey: redisKeys.chat.roomPresence(roomId), action: "copy" };
+  }
+  if (legacyKey.startsWith("chat:room:users:")) {
+    return {
+      legacyKey,
+      targetKey: redisKeys.chat.roomPresence(suffixAfter(legacyKey, "chat:room:users:")),
+      action: "skip",
+      reason: "Delete-only legacy room user index has no current writer",
+    };
+  }
+  if (legacyKey.startsWith("chat:room:")) {
+    return {
+      legacyKey,
+      targetKey: redisKeys.chat.roomMeta(suffixAfter(legacyKey, "chat:room:")),
+      action: "copy",
+    };
+  }
+  if (legacyKey === "chat:rooms") {
+    return { legacyKey, targetKey: redisKeys.chat.roomIds(), action: "copy" };
+  }
+  if (legacyKey.startsWith("chat:token:user:")) {
+    const [username, ...tokenParts] = splitSuffix(legacyKey, "chat:token:user:");
+    const token = tokenParts.join(":");
+    if (!username || !token) {
+      return { legacyKey, targetKey: null, action: "skip", reason: "Malformed auth token key" };
+    }
+    const tokenHash = await sha256RedisIdentifier(token);
+    return {
+      legacyKey,
+      targetKey: redisKeys.auth.session(tokenHash),
+      additionalKeys: [redisKeys.auth.userSessions(username)],
+      action: "copy",
+    };
+  }
+  if (legacyKey.startsWith("chat:token:last:")) {
+    return {
+      legacyKey,
+      targetKey: redisKeys.auth.lastSession(suffixAfter(legacyKey, "chat:token:last:")),
+      action: "copy",
+    };
+  }
+  if (legacyKey.startsWith("chat:users:")) {
+    return {
+      legacyKey,
+      targetKey: redisKeys.auth.userProfile(suffixAfter(legacyKey, "chat:users:")),
+      action: "copy",
+    };
+  }
+  if (legacyKey.startsWith("cursor-sdk-agent:") && legacyKey.endsWith(":latestRun")) {
+    const agentId = legacyKey.slice("cursor-sdk-agent:".length, -":latestRun".length);
+    return { legacyKey, targetKey: redisKeys.agent.cursorLatestRun(agentId), action: "copy" };
+  }
+  if (legacyKey.startsWith("cursor-sdk-run:")) {
+    const parts = splitSuffix(legacyKey, "cursor-sdk-run:");
+    const facet = parts.at(-1);
+    const runId = parts.slice(0, -1).join(":");
+    if (runId && facet === "events") {
+      return { legacyKey, targetKey: redisKeys.agent.cursorRunEvents(runId), action: "copy" };
+    }
+    if (runId && facet === "meta") {
+      return { legacyKey, targetKey: redisKeys.agent.cursorRunMeta(runId), action: "copy" };
+    }
+  }
+  if (legacyKey.startsWith("geoip:v1:")) {
+    const ipHash = await sha256RedisIdentifier(suffixAfter(legacyKey, "geoip:v1:"));
+    return { legacyKey, targetKey: redisKeys.cache.geoip(ipHash), action: "copy" };
+  }
+  if (legacyKey.startsWith("ie:cache:")) {
+    const parts = splitSuffix(legacyKey, "ie:cache:");
+    const year = parts.at(-1);
+    const encodedUrl = parts.slice(0, -1).join(":");
+    if (year && encodedUrl) {
+      const urlHash = await sha256RedisIdentifier(safeDecode(encodedUrl));
+      return { legacyKey, targetKey: redisKeys.cache.ieVersions(urlHash, year), action: "copy" };
+    }
+  }
+  if (legacyKey === "listen:sessions") {
+    return { legacyKey, targetKey: redisKeys.session.listenIds(), action: "copy" };
+  }
+  if (legacyKey.startsWith("listen:session:")) {
+    return {
+      legacyKey,
+      targetKey: redisKeys.session.listen(suffixAfter(legacyKey, "listen:session:")),
+      action: "copy",
+    };
+  }
+  if (legacyKey.endsWith(":processing_lock") && legacyKey.startsWith("memory:user:")) {
+    const username = legacyKey.slice("memory:user:".length, -":processing_lock".length);
+    return { legacyKey, targetKey: redisKeys.memory.processingLock(username), action: "copy" };
+  }
+  if (legacyKey.startsWith("rl:")) {
+    return { legacyKey, targetKey: null, action: "skip", reason: "Ephemeral rate-limit key" };
+  }
+  if (legacyKey.startsWith("rt:ticket:")) {
+    const ticketHash = await sha256RedisIdentifier(suffixAfter(legacyKey, "rt:ticket:"));
+    return { legacyKey, targetKey: redisKeys.realtime.ticket(ticketHash), action: "copy" };
+  }
+  if (legacyKey === "song:all") {
+    return { legacyKey, targetKey: redisKeys.media.songIds(), action: "copy" };
+  }
+  if (legacyKey.startsWith("song:meta:")) {
+    return {
+      legacyKey,
+      targetKey: redisKeys.media.songMeta(suffixAfter(legacyKey, "song:meta:")),
+      action: "copy",
+    };
+  }
+  if (legacyKey.startsWith("song:content:")) {
+    return {
+      legacyKey,
+      targetKey: redisKeys.media.songContent(suffixAfter(legacyKey, "song:content:")),
+      action: "copy",
+    };
+  }
+  if (legacyKey.startsWith("sync2:")) {
+    const parts = splitSuffix(legacyKey, "sync2:");
+    const family = parts[0];
+    const username = parts.slice(1).join(":");
+    const byFamily: Record<string, ((username: string) => string) | undefined> = {
+      blobs: redisKeys.sync.v2Blobs,
+      jrnl: redisKeys.sync.v2Journal,
+      kv: redisKeys.sync.v2Kv,
+      lock: redisKeys.sync.v2Lock,
+      seq: redisKeys.sync.v2Seq,
+      "ttl-touched": redisKeys.sync.v2TtlTouched,
+    };
+    const builder = byFamily[family];
+    if (builder && username) {
+      return { legacyKey, targetKey: builder(username), action: "copy" };
+    }
+    if (legacyKey === "sync2:maint:cursor") {
+      return { legacyKey, targetKey: redisKeys.sync.maintenanceCursor(), action: "copy" };
+    }
+  }
+  if (legacyKey.startsWith("sync:meta:")) {
+    return {
+      legacyKey,
+      targetKey: redisKeys.sync.backupMeta(suffixAfter(legacyKey, "sync:meta:")),
+      action: "copy",
+    };
+  }
+  if (legacyKey.startsWith("sync:pref:autoSync:")) {
+    return {
+      legacyKey,
+      targetKey: redisKeys.sync.autoSyncPreference(suffixAfter(legacyKey, "sync:pref:autoSync:")),
+      action: "copy",
+    };
+  }
+  if (
+    legacyKey.startsWith("sync:state:") ||
+    legacyKey.startsWith("sync:auto:") ||
+    legacyKey.startsWith("sync:songs:")
+  ) {
+    return {
+      legacyKey,
+      targetKey: null,
+      action: "skip",
+      reason: "Legacy sync v1 data must be imported into sync v2 before deletion",
+    };
+  }
+  if (legacyKey.startsWith("telegram:link:code:")) {
+    return {
+      legacyKey,
+      targetKey: redisKeys.integration.telegramLinkCode(suffixAfter(legacyKey, "telegram:link:code:")),
+      action: "copy",
+    };
+  }
+  if (legacyKey.startsWith("telegram:link:username:")) {
+    return {
+      legacyKey,
+      targetKey: redisKeys.integration.telegramPendingLink(suffixAfter(legacyKey, "telegram:link:username:")),
+      action: "copy",
+    };
+  }
+  if (legacyKey.startsWith("telegram:user:")) {
+    return {
+      legacyKey,
+      targetKey: redisKeys.integration.telegramAccountByTelegramUser(suffixAfter(legacyKey, "telegram:user:")),
+      action: "copy",
+    };
+  }
+  if (legacyKey.startsWith("telegram:username:")) {
+    return {
+      legacyKey,
+      targetKey: redisKeys.integration.telegramAccountByUsername(suffixAfter(legacyKey, "telegram:username:")),
+      action: "copy",
+    };
+  }
+  if (legacyKey.startsWith("telegram:history:")) {
+    return {
+      legacyKey,
+      targetKey: redisKeys.integration.telegramHistory(suffixAfter(legacyKey, "telegram:history:")),
+      action: "copy",
+    };
+  }
+  if (legacyKey.startsWith("telegram:update:")) {
+    return {
+      legacyKey,
+      targetKey: redisKeys.integration.telegramUpdate(suffixAfter(legacyKey, "telegram:update:")),
+      action: "copy",
+    };
+  }
+  if (legacyKey.startsWith("telegram:heartbeat:")) {
+    const parts = splitSuffix(legacyKey, "telegram:heartbeat:");
+    const slot = parts.at(-1);
+    const username = parts.slice(0, -1).join(":");
+    if (username && slot) {
+      return {
+        legacyKey,
+        targetKey: redisKeys.integration.telegramHeartbeat(username, slot),
+        action: "copy",
+      };
+    }
+  }
+  if (legacyKey.startsWith("wayback:cache:")) {
+    const parts = splitSuffix(legacyKey, "wayback:cache:");
+    const year = parts.at(-1);
+    const encodedUrl = parts.slice(0, -1).join(":");
+    if (year && encodedUrl) {
+      const urlHash = await sha256RedisIdentifier(safeDecode(encodedUrl));
+      return { legacyKey, targetKey: redisKeys.cache.wayback(urlHash, year), action: "copy" };
+    }
+  }
+
+  return {
+    legacyKey,
+    targetKey: null,
+    action: "skip",
+    reason: "No canonical mapping registered for this legacy key",
+  };
+}
+
+async function copyRedisValue(
+  redis: Redis,
+  sourceKey: string,
+  targetKey: string
+): Promise<string | null> {
+  const type = await redis.type(sourceKey);
+  const ttl = await redis.ttl(sourceKey);
+  switch (type) {
+    case "string": {
+      const value = await redis.get(sourceKey);
+      await redis.set(targetKey, value, ttl > 0 ? { ex: ttl } : undefined);
+      return null;
+    }
+    case "list": {
+      const values = await redis.lrange<string>(sourceKey, 0, -1);
+      await redis.del(targetKey);
+      if (values.length > 0) await redis.rpush(targetKey, ...values);
+      if (ttl > 0) await redis.expire(targetKey, ttl);
+      return null;
+    }
+    case "set": {
+      const members = await redis.smembers<string[]>(sourceKey);
+      await redis.del(targetKey);
+      if (members.length > 0) await redis.sadd(targetKey, ...members);
+      if (ttl > 0) await redis.expire(targetKey, ttl);
+      return null;
+    }
+    case "hash": {
+      const hash = (await redis.hgetall<Record<string, unknown>>(sourceKey)) ?? {};
+      await redis.del(targetKey);
+      if (Object.keys(hash).length > 0) await redis.hset(targetKey, hash);
+      if (ttl > 0) await redis.expire(targetKey, ttl);
+      return null;
+    }
+    case "zset":
+      return `Skipped ${sourceKey}: score-preserving zset copy is not supported by RedisLike`;
+    case "none":
+      return `Skipped ${sourceKey}: key no longer exists`;
+    default:
+      return `Skipped ${sourceKey}: unsupported Redis type ${type}`;
+  }
+}
+
+async function applyAdditionalMigrationSideEffects(
+  redis: Redis,
+  plan: RedisKeyMigrationPlan
+): Promise<void> {
+  if (
+    plan.legacyKey.startsWith("chat:token:user:") &&
+    plan.targetKey &&
+    plan.additionalKeys?.length
+  ) {
+    const sessionSetKey = plan.additionalKeys[0];
+    const tokenHash = suffixAfter(plan.targetKey, "auth:session:");
+    await redis.sadd(sessionSetKey, tokenHash);
+    const ttl = await redis.ttl(plan.legacyKey);
+    if (ttl > 0) await redis.expire(sessionSetKey, ttl);
+  }
+}
+
+export async function backfillRedisKeyScheme(
+  redis: Redis,
+  input: { pattern: string; limit: number; dryRun: boolean }
+): Promise<RedisBackfillResult> {
+  assertKnownLegacyRedisPattern(input.pattern);
+  const { keys, truncated } = await scanKeys(redis, input.pattern, input.limit);
+  const plans = await Promise.all(keys.map((key) => planRedisKeyMigration(key)));
+  const warnings: string[] = [];
+  let copied = 0;
+  let skipped = 0;
+
+  for (const plan of plans) {
+    if (plan.action === "skip" || !plan.targetKey) {
+      skipped += 1;
+      if (plan.reason) warnings.push(`${plan.legacyKey}: ${plan.reason}`);
+      continue;
+    }
+    if (input.dryRun) {
+      continue;
+    }
+    const warning = await copyRedisValue(redis, plan.legacyKey, plan.targetKey);
+    if (warning) {
+      skipped += 1;
+      warnings.push(warning);
+      continue;
+    }
+    await applyAdditionalMigrationSideEffects(redis, plan);
+    copied += 1;
+  }
+
+  return {
+    pattern: input.pattern,
+    dryRun: input.dryRun,
+    scanned: keys.length,
+    planned: plans.filter((plan) => plan.action === "copy" && plan.targetKey).length,
+    copied,
+    skipped,
+    warnings,
+    truncated,
+    keys: plans,
+  };
+}
+
+export async function deleteLegacyRedisKeys(
+  redis: Redis,
+  input: { pattern: string; limit: number; dryRun: boolean }
+): Promise<RedisDeleteLegacyResult> {
+  assertKnownLegacyRedisPattern(input.pattern);
+  const { keys, truncated } = await scanKeys(redis, input.pattern, input.limit);
+  const deleted = input.dryRun || keys.length === 0 ? 0 : await redis.del(...keys);
+  return {
+    pattern: input.pattern,
+    dryRun: input.dryRun,
+    scanned: keys.length,
+    deleted,
+    truncated,
+    keys,
+  };
+}

--- a/api/_utils/redis-key-migration.ts
+++ b/api/_utils/redis-key-migration.ts
@@ -31,6 +31,7 @@ export interface RedisKeyMigrationPlan {
 
 export interface RedisBackfillResult {
   pattern: string;
+  cursor: string;
   dryRun: boolean;
   scanned: number;
   planned: number;
@@ -43,6 +44,7 @@ export interface RedisBackfillResult {
 
 export interface RedisDeleteLegacyResult {
   pattern: string;
+  cursor: string;
   dryRun: boolean;
   scanned: number;
   deleted: number;
@@ -83,17 +85,18 @@ function safeDecode(value: string): string {
 async function scanKeys(
   redis: Redis,
   pattern: string,
-  limit: number
-): Promise<{ keys: string[]; truncated: boolean }> {
+  limit: number,
+  startCursor: string | number = 0
+): Promise<{ keys: string[]; cursor: string; truncated: boolean }> {
   const keys: string[] = [];
   const seen = new Set<string>();
-  let cursor: string | number = 0;
+  let cursor: string | number = startCursor;
   let iterations = 0;
 
   do {
     const [nextCursor, batch] = await redis.scan(cursor, {
       match: pattern,
-      count: STATUS_SCAN_COUNT,
+      count: Math.max(1, Math.min(limit, STATUS_SCAN_COUNT)),
     });
     cursor = nextCursor;
     iterations += 1;
@@ -101,7 +104,6 @@ async function scanKeys(
       if (!seen.has(key)) {
         seen.add(key);
         keys.push(key);
-        if (keys.length >= limit) break;
       }
     }
   } while (
@@ -113,7 +115,8 @@ async function scanKeys(
 
   return {
     keys: keys.sort(),
-    truncated: keys.length >= limit || (cursor !== 0 && cursor !== "0"),
+    cursor: String(cursor),
+    truncated: cursor !== 0 && cursor !== "0",
   };
 }
 
@@ -500,10 +503,15 @@ async function applyAdditionalMigrationSideEffects(
 
 export async function backfillRedisKeyScheme(
   redis: Redis,
-  input: { pattern: string; limit: number; dryRun: boolean }
+  input: { pattern: string; limit: number; dryRun: boolean; cursor?: string | number }
 ): Promise<RedisBackfillResult> {
   assertKnownLegacyRedisPattern(input.pattern);
-  const { keys, truncated } = await scanKeys(redis, input.pattern, input.limit);
+  const { keys, cursor, truncated } = await scanKeys(
+    redis,
+    input.pattern,
+    input.limit,
+    input.cursor ?? 0
+  );
   const plans = await Promise.all(keys.map((key) => planRedisKeyMigration(key)));
   const warnings: string[] = [];
   let copied = 0;
@@ -530,6 +538,7 @@ export async function backfillRedisKeyScheme(
 
   return {
     pattern: input.pattern,
+    cursor,
     dryRun: input.dryRun,
     scanned: keys.length,
     planned: plans.filter((plan) => plan.action === "copy" && plan.targetKey).length,
@@ -543,13 +552,19 @@ export async function backfillRedisKeyScheme(
 
 export async function deleteLegacyRedisKeys(
   redis: Redis,
-  input: { pattern: string; limit: number; dryRun: boolean }
+  input: { pattern: string; limit: number; dryRun: boolean; cursor?: string | number }
 ): Promise<RedisDeleteLegacyResult> {
   assertKnownLegacyRedisPattern(input.pattern);
-  const { keys, truncated } = await scanKeys(redis, input.pattern, input.limit);
+  const { keys, cursor, truncated } = await scanKeys(
+    redis,
+    input.pattern,
+    input.limit,
+    input.cursor ?? 0
+  );
   const deleted = input.dryRun || keys.length === 0 ? 0 : await redis.del(...keys);
   return {
     pattern: input.pattern,
+    cursor,
     dryRun: input.dryRun,
     scanned: keys.length,
     deleted,

--- a/api/_utils/redis-key-migration.ts
+++ b/api/_utils/redis-key-migration.ts
@@ -1,4 +1,5 @@
 import type { Redis } from "./redis.js";
+import { ensureSync2Initialized } from "../sync/v2/_core.js";
 import {
   LEGACY_REDIS_SCAN_PATTERNS,
   redisKeys,
@@ -25,7 +26,8 @@ export interface RedisKeyMigrationPlan {
   legacyKey: string;
   targetKey: string | null;
   additionalKeys?: string[];
-  action: "copy" | "skip";
+  action: "copy" | "import-v1-sync" | "skip";
+  username?: string;
   reason?: string;
 }
 
@@ -80,6 +82,24 @@ function safeDecode(value: string): string {
   } catch {
     return value;
   }
+}
+
+function syncV1Username(legacyKey: string): string | null {
+  if (legacyKey.startsWith("sync:state:meta:")) {
+    return suffixAfter(legacyKey, "sync:state:meta:");
+  }
+  if (legacyKey.startsWith("sync:state:")) {
+    const parts = splitSuffix(legacyKey, "sync:state:");
+    return parts.length >= 2 ? parts[0] : null;
+  }
+  if (legacyKey.startsWith("sync:auto:meta:")) {
+    return suffixAfter(legacyKey, "sync:auto:meta:");
+  }
+  if (legacyKey.startsWith("sync:songs:")) {
+    const parts = splitSuffix(legacyKey, "sync:songs:");
+    return parts.length >= 2 ? parts[0] : null;
+  }
+  return null;
 }
 
 async function scanKeys(
@@ -362,11 +382,15 @@ export async function planRedisKeyMigration(
     legacyKey.startsWith("sync:auto:") ||
     legacyKey.startsWith("sync:songs:")
   ) {
+    const username = syncV1Username(legacyKey);
     return {
       legacyKey,
-      targetKey: null,
-      action: "skip",
-      reason: "Legacy sync v1 data must be imported into sync v2 before deletion",
+      targetKey: username ? redisKeys.sync.v2Kv(username) : null,
+      action: username ? "import-v1-sync" : "skip",
+      username: username ?? undefined,
+      reason: username
+        ? "Will initialize sync v2 from legacy v1 data"
+        : "Malformed legacy sync v1 key",
     };
   }
   if (legacyKey.startsWith("telegram:link:code:")) {
@@ -514,6 +538,7 @@ export async function backfillRedisKeyScheme(
   );
   const plans = await Promise.all(keys.map((key) => planRedisKeyMigration(key)));
   const warnings: string[] = [];
+  const importedSyncUsers = new Set<string>();
   let copied = 0;
   let skipped = 0;
 
@@ -521,6 +546,14 @@ export async function backfillRedisKeyScheme(
     if (plan.action === "skip" || !plan.targetKey) {
       skipped += 1;
       if (plan.reason) warnings.push(`${plan.legacyKey}: ${plan.reason}`);
+      continue;
+    }
+    if (plan.action === "import-v1-sync") {
+      if (!input.dryRun && plan.username && !importedSyncUsers.has(plan.username)) {
+        await ensureSync2Initialized(redis, plan.username);
+        importedSyncUsers.add(plan.username);
+      }
+      copied += input.dryRun ? 0 : 1;
       continue;
     }
     if (input.dryRun) {
@@ -541,7 +574,11 @@ export async function backfillRedisKeyScheme(
     cursor,
     dryRun: input.dryRun,
     scanned: keys.length,
-    planned: plans.filter((plan) => plan.action === "copy" && plan.targetKey).length,
+    planned: plans.filter(
+      (plan) =>
+        (plan.action === "copy" || plan.action === "import-v1-sync") &&
+        plan.targetKey
+    ).length,
     copied,
     skipped,
     warnings,

--- a/api/_utils/redis.ts
+++ b/api/_utils/redis.ts
@@ -92,6 +92,11 @@ export interface RedisLike {
     max: number | string
   ): Promise<number>;
   zrange(key: string, start: number, stop: number): Promise<string[]>;
+  zrangeWithScores(
+    key: string,
+    start: number,
+    stop: number
+  ): Promise<RedisSortedSetEntry[]>;
   zcard(key: string): Promise<number>;
 }
 
@@ -462,6 +467,23 @@ class StandardRedisAdapter implements RedisLike {
 
   async zrange(key: string, start: number, stop: number): Promise<string[]> {
     return await this.client.zrange(key, start, stop);
+  }
+
+  async zrangeWithScores(
+    key: string,
+    start: number,
+    stop: number
+  ): Promise<RedisSortedSetEntry[]> {
+    const raw = await this.client.zrange(key, start, stop, "WITHSCORES");
+    const entries: RedisSortedSetEntry[] = [];
+    for (let index = 0; index < raw.length; index += 2) {
+      const member = raw[index];
+      const score = Number(raw[index + 1]);
+      if (member !== undefined && Number.isFinite(score)) {
+        entries.push({ member, score });
+      }
+    }
+    return entries;
   }
 
   async zcard(key: string): Promise<number> {

--- a/api/admin.ts
+++ b/api/admin.ts
@@ -44,6 +44,7 @@ interface AdminRequest {
   confirmPattern?: string;
   limit?: number;
   dryRun?: boolean;
+  cursor?: string;
 }
 
 interface UserProfile {
@@ -1210,9 +1211,11 @@ export default apiHandler<AdminRequest>(
           }
           const limit = clampInteger(body?.limit, 100, 1, 500);
           const dryRun = body?.dryRun !== false;
-          const data = await backfillRedisKeyScheme(redis, { pattern, limit, dryRun });
+          const cursor = normalizeRedisCursor(body?.cursor);
+          const data = await backfillRedisKeyScheme(redis, { pattern, limit, dryRun, cursor });
           logger.info("Redis key scheme backfill requested", {
             pattern,
+            cursor: data.cursor,
             dryRun,
             scanned: data.scanned,
             copied: data.copied,
@@ -1241,9 +1244,11 @@ export default apiHandler<AdminRequest>(
           }
           const limit = clampInteger(body?.limit, 100, 1, 500);
           const dryRun = body?.dryRun !== false;
-          const data = await deleteLegacyRedisKeys(redis, { pattern, limit, dryRun });
+          const cursor = normalizeRedisCursor(body?.cursor);
+          const data = await deleteLegacyRedisKeys(redis, { pattern, limit, dryRun, cursor });
           logger.info("Legacy Redis key delete requested", {
             pattern,
+            cursor: data.cursor,
             dryRun,
             scanned: data.scanned,
             deleted: data.deleted,

--- a/api/admin.ts
+++ b/api/admin.ts
@@ -22,6 +22,12 @@ import {
   executeCursorCloudAgent,
   listCursorSdkRunsFromRedis,
 } from "./chat/tools/cursor-repo-agent.js";
+import {
+  backfillRedisKeyScheme,
+  deleteLegacyRedisKeys,
+  getRedisMigrationStatus,
+  assertKnownLegacyRedisPattern,
+} from "./_utils/redis-key-migration.js";
 
 export const runtime = "nodejs";
 export const maxDuration = 30;
@@ -34,6 +40,10 @@ interface AdminRequest {
   modelId?: string;
   key?: string;
   confirmKey?: string;
+  pattern?: string;
+  confirmPattern?: string;
+  limit?: number;
+  dryRun?: boolean;
 }
 
 interface UserProfile {
@@ -941,6 +951,17 @@ export default apiHandler<AdminRequest>(
           res.status(200).json(data);
           return;
         }
+        case "getRedisKeyMigrationStatus": {
+          const limit = clampInteger(req.query.limit, 50, 1, 500);
+          const data = await getRedisMigrationStatus(redis, limit);
+          logger.info("Redis key migration status retrieved", {
+            totalLegacyKeys: data.totalLegacyKeys,
+            truncated: data.truncated,
+          });
+          logger.response(200, Date.now() - startTime);
+          res.status(200).json(data);
+          return;
+        }
         default:
           logger.response(400, Date.now() - startTime);
           res.status(400).json({ error: "Invalid action" });
@@ -1169,6 +1190,67 @@ export default apiHandler<AdminRequest>(
             success: deletedCount > 0,
             deletedCount,
           });
+          return;
+        }
+        case "backfillRedisKeyScheme": {
+          const pattern = normalizeRedisPattern(body?.pattern);
+          const confirmPattern =
+            typeof body?.confirmPattern === "string" ? body.confirmPattern : "";
+          if (confirmPattern !== pattern) {
+            logger.response(400, Date.now() - startTime);
+            res.status(400).json({ error: "Confirmation does not match Redis pattern" });
+            return;
+          }
+          try {
+            assertKnownLegacyRedisPattern(pattern);
+          } catch (error) {
+            logger.response(400, Date.now() - startTime);
+            res.status(400).json({ error: error instanceof Error ? error.message : "Invalid pattern" });
+            return;
+          }
+          const limit = clampInteger(body?.limit, 100, 1, 500);
+          const dryRun = body?.dryRun !== false;
+          const data = await backfillRedisKeyScheme(redis, { pattern, limit, dryRun });
+          logger.info("Redis key scheme backfill requested", {
+            pattern,
+            dryRun,
+            scanned: data.scanned,
+            copied: data.copied,
+            skipped: data.skipped,
+            truncated: data.truncated,
+          });
+          logger.response(200, Date.now() - startTime);
+          res.status(200).json(data);
+          return;
+        }
+        case "deleteLegacyRedisKeys": {
+          const pattern = normalizeRedisPattern(body?.pattern);
+          const confirmPattern =
+            typeof body?.confirmPattern === "string" ? body.confirmPattern : "";
+          if (confirmPattern !== pattern) {
+            logger.response(400, Date.now() - startTime);
+            res.status(400).json({ error: "Confirmation does not match Redis pattern" });
+            return;
+          }
+          try {
+            assertKnownLegacyRedisPattern(pattern);
+          } catch (error) {
+            logger.response(400, Date.now() - startTime);
+            res.status(400).json({ error: error instanceof Error ? error.message : "Invalid pattern" });
+            return;
+          }
+          const limit = clampInteger(body?.limit, 100, 1, 500);
+          const dryRun = body?.dryRun !== false;
+          const data = await deleteLegacyRedisKeys(redis, { pattern, limit, dryRun });
+          logger.info("Legacy Redis key delete requested", {
+            pattern,
+            dryRun,
+            scanned: data.scanned,
+            deleted: data.deleted,
+            truncated: data.truncated,
+          });
+          logger.response(200, Date.now() - startTime);
+          res.status(200).json(data);
           return;
         }
         default:

--- a/api/auth/login.ts
+++ b/api/auth/login.ts
@@ -21,7 +21,6 @@ import {
   isLoginLocked,
   recordLoginFailure,
   resetLoginFailures,
-  CHAT_USERS_PREFIX,
   TOKEN_GRACE_PERIOD,
 } from "../_utils/auth/index.js";
 import { verifyPassword, getUserPasswordHash } from "../_utils/auth/_password.js";
@@ -29,7 +28,10 @@ import { apiHandler } from "../_utils/api-handler.js";
 import { buildSetAuthCookie } from "../_utils/_cookie.js";
 import { getClientIp } from "../_utils/_rate-limit.js";
 import { getHeader } from "../_utils/request-helpers.js";
-import { updateStoredUserTimeZone } from "../_utils/auth/_user-record.js";
+import {
+  getStoredUserRecord,
+  updateStoredUserTimeZone,
+} from "../_utils/auth/_user-record.js";
 
 export const runtime = "nodejs";
 export const maxDuration = 15;
@@ -85,10 +87,8 @@ export default apiHandler(
       return;
     }
 
-    const userKey = `${CHAT_USERS_PREFIX}${username}`;
-
     // Check if user exists
-    const userData = await redis.get(userKey);
+    const userData = await getStoredUserRecord(redis, username);
     if (!userData) {
       // Same generic error as wrong-password to avoid username enumeration.
       // We DO NOT increment the per-user fail counter because this username

--- a/api/auth/register.ts
+++ b/api/auth/register.ts
@@ -11,7 +11,6 @@ import {
   isLoginLocked,
   recordLoginFailure,
   resetLoginFailures,
-  CHAT_USERS_PREFIX,
   PASSWORD_MIN_LENGTH,
   PASSWORD_MAX_LENGTH,
 } from "../_utils/auth/index.js";
@@ -29,7 +28,9 @@ import { buildSetAuthCookie } from "../_utils/_cookie.js";
 import { getClientIp } from "../_utils/_rate-limit.js";
 import { getHeader } from "../_utils/request-helpers.js";
 import {
+  getStoredUserRecord,
   normalizeUserTimeZone,
+  setStoredUserRecord,
   updateStoredUserTimeZone,
 } from "../_utils/auth/_user-record.js";
 
@@ -115,10 +116,9 @@ export default apiHandler(
     }
 
     const username = rawUsername.toLowerCase();
-    const userKey = `${CHAT_USERS_PREFIX}${username}`;
 
     // Check if user already exists
-    const existingUser = await redis.get(userKey);
+    const existingUser = await getStoredUserRecord(redis, username);
     if (existingUser) {
       // User exists - try to log them in with provided password. This path is
       // subject to the SAME per-username lockout as /api/auth/login so it
@@ -176,7 +176,7 @@ export default apiHandler(
         ? { timeZone: requestTimeZone, timeZoneUpdatedAt: now }
         : {}),
     };
-    await redis.set(userKey, JSON.stringify(userData));
+    await setStoredUserRecord(redis, username, userData);
 
     // Hash and store password
     const passwordHash = await hashPassword(password);

--- a/api/auth/token/refresh.ts
+++ b/api/auth/token/refresh.ts
@@ -11,13 +11,13 @@ import {
   storeLastValidToken,
   validateAuth,
   isUserBanned,
-  CHAT_USERS_PREFIX,
   TOKEN_GRACE_PERIOD,
 } from "../../_utils/auth/index.js";
 import * as RateLimit from "../../_utils/_rate-limit.js";
 import { getClientIp } from "../../_utils/_rate-limit.js";
 import { apiHandler } from "../../_utils/api-handler.js";
 import { buildSetAuthCookie, parseAuthCookie } from "../../_utils/_cookie.js";
+import { getStoredUserRecord } from "../../_utils/auth/_user-record.js";
 
 export const runtime = "nodejs";
 
@@ -79,8 +79,7 @@ export default apiHandler<RefreshRequest>(
     const username = rawUsername.toLowerCase();
 
     // Check if user exists
-    const userKey = `${CHAT_USERS_PREFIX}${username}`;
-    const userData = await redis.get(userKey);
+    const userData = await getStoredUserRecord(redis, username);
     if (!userData) {
       logger.warn("User not found", { username });
       logger.response(404, Date.now() - startTime);

--- a/src/api/admin.ts
+++ b/src/api/admin.ts
@@ -155,6 +155,58 @@ export async function deleteAdminRedisKey<TResponse>(
   });
 }
 
+export async function getAdminRedisKeyMigrationStatus<TResponse>(input: {
+  limit?: number;
+} = {}): Promise<TResponse> {
+  return adminGet<TResponse>("getRedisKeyMigrationStatus", input);
+}
+
+export async function backfillAdminRedisKeyScheme<TResponse>(input: {
+  pattern: string;
+  limit?: number;
+  dryRun?: boolean;
+}): Promise<TResponse> {
+  return adminPost<
+    TResponse,
+    {
+      action: string;
+      pattern: string;
+      confirmPattern: string;
+      limit?: number;
+      dryRun?: boolean;
+    }
+  >({
+    action: "backfillRedisKeyScheme",
+    pattern: input.pattern,
+    confirmPattern: input.pattern,
+    ...(input.limit ? { limit: input.limit } : {}),
+    ...(input.dryRun !== undefined ? { dryRun: input.dryRun } : {}),
+  });
+}
+
+export async function deleteAdminLegacyRedisKeys<TResponse>(input: {
+  pattern: string;
+  limit?: number;
+  dryRun?: boolean;
+}): Promise<TResponse> {
+  return adminPost<
+    TResponse,
+    {
+      action: string;
+      pattern: string;
+      confirmPattern: string;
+      limit?: number;
+      dryRun?: boolean;
+    }
+  >({
+    action: "deleteLegacyRedisKeys",
+    pattern: input.pattern,
+    confirmPattern: input.pattern,
+    ...(input.limit ? { limit: input.limit } : {}),
+    ...(input.dryRun !== undefined ? { dryRun: input.dryRun } : {}),
+  });
+}
+
 export async function postAdminStartCursorAgent<TResponse>(input: {
   prompt: string;
   modelId?: string;

--- a/src/api/admin.ts
+++ b/src/api/admin.ts
@@ -165,6 +165,7 @@ export async function backfillAdminRedisKeyScheme<TResponse>(input: {
   pattern: string;
   limit?: number;
   dryRun?: boolean;
+  cursor?: string;
 }): Promise<TResponse> {
   return adminPost<
     TResponse,
@@ -174,6 +175,7 @@ export async function backfillAdminRedisKeyScheme<TResponse>(input: {
       confirmPattern: string;
       limit?: number;
       dryRun?: boolean;
+      cursor?: string;
     }
   >({
     action: "backfillRedisKeyScheme",
@@ -181,6 +183,7 @@ export async function backfillAdminRedisKeyScheme<TResponse>(input: {
     confirmPattern: input.pattern,
     ...(input.limit ? { limit: input.limit } : {}),
     ...(input.dryRun !== undefined ? { dryRun: input.dryRun } : {}),
+    ...(input.cursor ? { cursor: input.cursor } : {}),
   });
 }
 
@@ -188,6 +191,7 @@ export async function deleteAdminLegacyRedisKeys<TResponse>(input: {
   pattern: string;
   limit?: number;
   dryRun?: boolean;
+  cursor?: string;
 }): Promise<TResponse> {
   return adminPost<
     TResponse,
@@ -197,6 +201,7 @@ export async function deleteAdminLegacyRedisKeys<TResponse>(input: {
       confirmPattern: string;
       limit?: number;
       dryRun?: boolean;
+      cursor?: string;
     }
   >({
     action: "deleteLegacyRedisKeys",
@@ -204,6 +209,7 @@ export async function deleteAdminLegacyRedisKeys<TResponse>(input: {
     confirmPattern: input.pattern,
     ...(input.limit ? { limit: input.limit } : {}),
     ...(input.dryRun !== undefined ? { dryRun: input.dryRun } : {}),
+    ...(input.cursor ? { cursor: input.cursor } : {}),
   });
 }
 

--- a/src/apps/admin/components/admin-app/AdminRedisBrowserView.tsx
+++ b/src/apps/admin/components/admin-app/AdminRedisBrowserView.tsx
@@ -23,12 +23,16 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import {
+  backfillAdminRedisKeyScheme,
   deleteAdminRedisKey,
+  deleteAdminLegacyRedisKeys,
   getAdminRedisBackup,
   getAdminRedisKey,
+  getAdminRedisKeyMigrationStatus,
   getAdminRedisKeys,
 } from "@/api/admin";
 import { cn } from "@/lib/utils";
+import { LEGACY_REDIS_SCAN_PATTERNS } from "@/shared/redisKeys";
 import {
   adminGhostIconBtnClass,
   adminLoadMoreBtnClass,
@@ -75,6 +79,38 @@ interface RedisBackupDocument {
 interface DeleteRedisKeyResponse {
   success: boolean;
   deletedCount: number;
+}
+
+interface RedisMigrationPatternStatus {
+  pattern: string;
+  count: number;
+  sampleKeys: string[];
+  truncated: boolean;
+}
+
+interface RedisMigrationStatusResponse {
+  totalLegacyKeys: number;
+  truncated: boolean;
+  patterns: RedisMigrationPatternStatus[];
+}
+
+interface RedisBackfillResponse {
+  pattern: string;
+  dryRun: boolean;
+  scanned: number;
+  planned: number;
+  copied: number;
+  skipped: number;
+  truncated: boolean;
+  warnings: string[];
+}
+
+interface DeleteLegacyRedisKeysResponse {
+  pattern: string;
+  dryRun: boolean;
+  scanned: number;
+  deleted: number;
+  truncated: boolean;
 }
 
 export interface AdminRedisBrowserViewProps {
@@ -132,6 +168,14 @@ export function AdminRedisBrowserView({ t }: AdminRedisBrowserViewProps) {
   const [isLoadingDocument, setIsLoadingDocument] = useState(false);
   const [deleteCandidate, setDeleteCandidate] = useState<string | null>(null);
   const [isDeleting, setIsDeleting] = useState(false);
+  const [migrationPattern, setMigrationPattern] = useState<string>(
+    LEGACY_REDIS_SCAN_PATTERNS[0]
+  );
+  const [migrationStatus, setMigrationStatus] = useState<RedisMigrationStatusResponse | null>(null);
+  const [isLoadingMigrationStatus, setIsLoadingMigrationStatus] = useState(false);
+  const [isBackfillingMigration, setIsBackfillingMigration] = useState(false);
+  const [deleteLegacyCandidate, setDeleteLegacyCandidate] = useState<string | null>(null);
+  const [isDeletingLegacy, setIsDeletingLegacy] = useState(false);
   // Cache fetched key documents so reopening a key (or returning to it after
   // navigating) does not re-hit Redis. Cleared on fresh scans / refresh.
   const documentCacheRef = useRef<Map<string, RedisKeyDocument>>(new Map());
@@ -242,6 +286,9 @@ export function AdminRedisBrowserView({ t }: AdminRedisBrowserViewProps) {
   const visibleLeaves = treeLevel.leaves;
   const visibleFolders = isRoot ? rootFolders : treeLevel.folders;
   const hasVisibleRows = visibleFolders.length > 0 || visibleLeaves.length > 0;
+  const selectedMigrationStatus = migrationStatus?.patterns.find(
+    (item) => item.pattern === migrationPattern
+  );
 
   const handlePatternSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -278,6 +325,80 @@ export function AdminRedisBrowserView({ t }: AdminRedisBrowserViewProps) {
     }
   };
 
+  const handleLoadMigrationStatus = async () => {
+    setIsLoadingMigrationStatus(true);
+    try {
+      const status =
+        await getAdminRedisKeyMigrationStatus<RedisMigrationStatusResponse>({ limit: 100 });
+      setMigrationStatus(status);
+      toast.success(
+        t("apps.admin.redis.migration.statusReady", {
+          count: status.totalLegacyKeys,
+          defaultValue: `Found ${status.totalLegacyKeys} sampled legacy Redis keys`,
+        })
+      );
+      if (status.truncated) {
+        toast.info(
+          t(
+            "apps.admin.redis.migration.statusTruncated",
+            "Some legacy patterns hit the preview limit; run batches until clear.",
+          )
+        );
+      }
+    } catch (error) {
+      console.error("Failed to load Redis migration status:", error);
+      toast.error(
+        t("apps.admin.redis.migration.errors.status", "Failed to load migration status")
+      );
+    } finally {
+      setIsLoadingMigrationStatus(false);
+    }
+  };
+
+  const handleBackfillMigration = async (dryRun: boolean) => {
+    setIsBackfillingMigration(true);
+    try {
+      const result = await backfillAdminRedisKeyScheme<RedisBackfillResponse>({
+        pattern: migrationPattern,
+        limit: 100,
+        dryRun,
+      });
+      toast.success(
+        dryRun
+          ? t("apps.admin.redis.migration.dryRunComplete", {
+              scanned: result.scanned,
+              planned: result.planned,
+              defaultValue: `Dry run scanned ${result.scanned}; ${result.planned} keys can be copied`,
+            })
+          : t("apps.admin.redis.migration.backfillComplete", {
+              copied: result.copied,
+              skipped: result.skipped,
+              defaultValue: `Backfilled ${result.copied}; skipped ${result.skipped}`,
+            })
+      );
+      if (result.warnings.length > 0) {
+        toast.info(result.warnings.slice(0, 2).join("\n"));
+      }
+      if (result.truncated) {
+        toast.info(
+          t(
+            "apps.admin.redis.migration.batchTruncated",
+            "Batch limit reached; run the action again for the next batch.",
+          )
+        );
+      }
+      await handleLoadMigrationStatus();
+      refreshScope();
+    } catch (error) {
+      console.error("Failed to backfill Redis key scheme:", error);
+      toast.error(
+        t("apps.admin.redis.migration.errors.backfill", "Failed to backfill Redis keys")
+      );
+    } finally {
+      setIsBackfillingMigration(false);
+    }
+  };
+
   const handleDeleteConfirm = async () => {
     if (!deleteCandidate) return;
     setIsDeleting(true);
@@ -301,6 +422,42 @@ export function AdminRedisBrowserView({ t }: AdminRedisBrowserViewProps) {
       toast.error(t("apps.admin.redis.errors.delete", "Failed to delete Redis key"));
     } finally {
       setIsDeleting(false);
+    }
+  };
+
+  const handleDeleteLegacyConfirm = async () => {
+    if (!deleteLegacyCandidate) return;
+    setIsDeletingLegacy(true);
+    try {
+      const result = await deleteAdminLegacyRedisKeys<DeleteLegacyRedisKeysResponse>({
+        pattern: deleteLegacyCandidate,
+        limit: 100,
+        dryRun: false,
+      });
+      toast.success(
+        t("apps.admin.redis.migration.deleteComplete", {
+          deleted: result.deleted,
+          defaultValue: `Deleted ${result.deleted} legacy Redis keys`,
+        })
+      );
+      if (result.truncated) {
+        toast.info(
+          t(
+            "apps.admin.redis.migration.deleteTruncated",
+            "Batch limit reached; run delete again after reviewing the next batch.",
+          )
+        );
+      }
+      setDeleteLegacyCandidate(null);
+      await handleLoadMigrationStatus();
+      refreshScope();
+    } catch (error) {
+      console.error("Failed to delete legacy Redis keys:", error);
+      toast.error(
+        t("apps.admin.redis.migration.errors.delete", "Failed to delete legacy Redis keys")
+      );
+    } finally {
+      setIsDeletingLegacy(false);
     }
   };
 
@@ -346,6 +503,82 @@ export function AdminRedisBrowserView({ t }: AdminRedisBrowserViewProps) {
           {isLoadingKeys ? <ActivityIndicator size={14} /> : <ArrowsClockwise size={14} weight="bold" />}
         </Button>
       </form>
+
+      <div
+        className={cn(
+          adminToolbarClass,
+          "flex shrink-0 flex-wrap items-center gap-2 border-b border-os-separator px-2 py-1.5 text-[11px]",
+        )}
+      >
+        <span className={cn(adminSectionLabelClass, "mr-1")}>
+          {t("apps.admin.redis.migration.label", "Migration")}
+        </span>
+        <select
+          value={migrationPattern}
+          onChange={(event) => setMigrationPattern(event.target.value)}
+          className="h-7 min-w-[190px] rounded border border-os-separator bg-os-window px-2 font-os-mono text-[11px] text-os-text-primary"
+          aria-label={t("apps.admin.redis.migration.pattern", "Legacy Redis pattern")}
+        >
+          {LEGACY_REDIS_SCAN_PATTERNS.map((legacyPattern) => (
+            <option key={legacyPattern} value={legacyPattern}>
+              {legacyPattern}
+            </option>
+          ))}
+        </select>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          onClick={() => void handleLoadMigrationStatus()}
+          disabled={isLoadingMigrationStatus}
+          className="h-7 px-2 text-[11px]"
+        >
+          {isLoadingMigrationStatus
+            ? t("apps.admin.redis.loading", "Loading...")
+            : t("apps.admin.redis.migration.scan", "Scan legacy")}
+        </Button>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          onClick={() => void handleBackfillMigration(true)}
+          disabled={isBackfillingMigration}
+          className="h-7 px-2 text-[11px]"
+        >
+          {t("apps.admin.redis.migration.dryRun", "Dry run")}
+        </Button>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          onClick={() => void handleBackfillMigration(false)}
+          disabled={isBackfillingMigration}
+          className="h-7 px-2 text-[11px]"
+        >
+          {isBackfillingMigration
+            ? t("apps.admin.redis.loading", "Loading...")
+            : t("apps.admin.redis.migration.backfill", "Backfill batch")}
+        </Button>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          onClick={() => setDeleteLegacyCandidate(migrationPattern)}
+          disabled={isDeletingLegacy}
+          className="h-7 px-2 text-[11px] text-red-600 hover:text-red-700 os-mac-aqua-dark:text-red-300"
+        >
+          {isDeletingLegacy
+            ? t("apps.admin.redis.loading", "Loading...")
+            : t("apps.admin.redis.migration.deleteLegacy", "Delete legacy batch")}
+        </Button>
+        {selectedMigrationStatus ? (
+          <span className="font-os-mono text-[10px] text-os-text-secondary">
+            {selectedMigrationStatus.count}
+            {selectedMigrationStatus.truncated ? "+" : ""}{" "}
+            {t("apps.admin.redis.migration.keysSampled", "sampled")}
+          </span>
+        ) : null}
+      </div>
 
       <div
         className={cn(
@@ -586,6 +819,18 @@ export function AdminRedisBrowserView({ t }: AdminRedisBrowserViewProps) {
         description={t("apps.admin.redis.deleteDescription", {
           key: deleteCandidate,
           defaultValue: `Delete Redis key "${deleteCandidate}"? This cannot be undone.`,
+        })}
+      />
+      <ConfirmDialog
+        isOpen={deleteLegacyCandidate !== null}
+        onOpenChange={(open) => {
+          if (!open) setDeleteLegacyCandidate(null);
+        }}
+        onConfirm={handleDeleteLegacyConfirm}
+        title={t("apps.admin.redis.migration.deleteTitle", "Delete legacy Redis keys?")}
+        description={t("apps.admin.redis.migration.deleteDescription", {
+          pattern: deleteLegacyCandidate,
+          defaultValue: `Delete up to 100 Redis keys matching "${deleteLegacyCandidate}"? Backfill first and repeat until the scan is clear.`,
         })}
       />
     </div>

--- a/src/apps/admin/components/admin-app/AdminRedisBrowserView.tsx
+++ b/src/apps/admin/components/admin-app/AdminRedisBrowserView.tsx
@@ -1,4 +1,5 @@
 import { FormEvent, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { StickToBottom } from "use-stick-to-bottom";
 import {
   ArrowsClockwise,
   CaretRight,
@@ -617,34 +618,40 @@ export function AdminRedisBrowserView({ t }: AdminRedisBrowserViewProps) {
       </div>
 
       {migrationLog.length > 0 ? (
-        <div className="max-h-28 shrink-0 overflow-auto border-b border-os-separator bg-black/5 px-2 py-1 font-os-mono text-[10px] leading-relaxed os-mac-aqua-dark:bg-white/10">
-          <div className="mb-1 flex items-center justify-between gap-2">
-            <span className={adminSectionLabelClass}>
-              {t("apps.admin.redis.migration.log", "Migration log")}
-            </span>
-            {!isMigrationRunning ? (
-              <button
-                type="button"
-                onClick={() => setMigrationLog([])}
-                className="text-os-text-secondary hover:text-os-text-primary hover:underline"
-              >
-                {t("apps.admin.redis.migration.clearLog", "Clear")}
-              </button>
-            ) : null}
-          </div>
-          {migrationLog.map((entry) => (
-            <div
-              key={entry.id}
-              className={cn(
-                entry.tone === "success" && "text-green-700 os-mac-aqua-dark:text-green-300",
-                entry.tone === "warning" && "text-yellow-700 os-mac-aqua-dark:text-yellow-300",
-                entry.tone === "error" && "text-red-700 os-mac-aqua-dark:text-red-300",
-              )}
-            >
-              {entry.message}
+        <StickToBottom
+          className="max-h-28 shrink-0 overflow-hidden border-b border-os-separator bg-black/5 font-os-mono text-[10px] leading-relaxed os-mac-aqua-dark:bg-white/10"
+          resize="smooth"
+          initial="instant"
+        >
+          <StickToBottom.Content className="px-2 py-1">
+            <div className="mb-1 flex items-center justify-between gap-2">
+              <span className={adminSectionLabelClass}>
+                {t("apps.admin.redis.migration.log", "Migration log")}
+              </span>
+              {!isMigrationRunning ? (
+                <button
+                  type="button"
+                  onClick={() => setMigrationLog([])}
+                  className="text-os-text-secondary hover:text-os-text-primary hover:underline"
+                >
+                  {t("apps.admin.redis.migration.clearLog", "Clear")}
+                </button>
+              ) : null}
             </div>
-          ))}
-        </div>
+            {migrationLog.map((entry) => (
+              <div
+                key={entry.id}
+                className={cn(
+                  entry.tone === "success" && "text-green-700 os-mac-aqua-dark:text-green-300",
+                  entry.tone === "warning" && "text-yellow-700 os-mac-aqua-dark:text-yellow-300",
+                  entry.tone === "error" && "text-red-700 os-mac-aqua-dark:text-red-300",
+                )}
+              >
+                {entry.message}
+              </div>
+            ))}
+          </StickToBottom.Content>
+        </StickToBottom>
       ) : null}
 
       <div

--- a/src/apps/admin/components/admin-app/AdminRedisBrowserView.tsx
+++ b/src/apps/admin/components/admin-app/AdminRedisBrowserView.tsx
@@ -96,6 +96,7 @@ interface RedisMigrationStatusResponse {
 
 interface RedisBackfillResponse {
   pattern: string;
+  cursor: string;
   dryRun: boolean;
   scanned: number;
   planned: number;
@@ -107,10 +108,19 @@ interface RedisBackfillResponse {
 
 interface DeleteLegacyRedisKeysResponse {
   pattern: string;
+  cursor: string;
   dryRun: boolean;
   scanned: number;
   deleted: number;
   truncated: boolean;
+}
+
+type RedisMigrationRunKind = "dry-run" | "backfill" | "delete";
+
+interface RedisMigrationLogEntry {
+  id: number;
+  message: string;
+  tone: "info" | "success" | "warning" | "error";
 }
 
 export interface AdminRedisBrowserViewProps {
@@ -168,14 +178,13 @@ export function AdminRedisBrowserView({ t }: AdminRedisBrowserViewProps) {
   const [isLoadingDocument, setIsLoadingDocument] = useState(false);
   const [deleteCandidate, setDeleteCandidate] = useState<string | null>(null);
   const [isDeleting, setIsDeleting] = useState(false);
-  const [migrationPattern, setMigrationPattern] = useState<string>(
-    LEGACY_REDIS_SCAN_PATTERNS[0]
-  );
   const [migrationStatus, setMigrationStatus] = useState<RedisMigrationStatusResponse | null>(null);
   const [isLoadingMigrationStatus, setIsLoadingMigrationStatus] = useState(false);
-  const [isBackfillingMigration, setIsBackfillingMigration] = useState(false);
-  const [deleteLegacyCandidate, setDeleteLegacyCandidate] = useState<string | null>(null);
-  const [isDeletingLegacy, setIsDeletingLegacy] = useState(false);
+  const [activeMigrationRun, setActiveMigrationRun] = useState<RedisMigrationRunKind | null>(null);
+  const [deleteLegacyCandidate, setDeleteLegacyCandidate] = useState(false);
+  const [migrationLog, setMigrationLog] = useState<RedisMigrationLogEntry[]>([]);
+  const migrationStopRequestedRef = useRef(false);
+  const migrationLogIdRef = useRef(0);
   // Cache fetched key documents so reopening a key (or returning to it after
   // navigating) does not re-hit Redis. Cleared on fresh scans / refresh.
   const documentCacheRef = useRef<Map<string, RedisKeyDocument>>(new Map());
@@ -286,8 +295,22 @@ export function AdminRedisBrowserView({ t }: AdminRedisBrowserViewProps) {
   const visibleLeaves = treeLevel.leaves;
   const visibleFolders = isRoot ? rootFolders : treeLevel.folders;
   const hasVisibleRows = visibleFolders.length > 0 || visibleLeaves.length > 0;
-  const selectedMigrationStatus = migrationStatus?.patterns.find(
-    (item) => item.pattern === migrationPattern
+  const isMigrationRunning = activeMigrationRun !== null;
+
+  const appendMigrationLog = useCallback(
+    (message: string, tone: RedisMigrationLogEntry["tone"] = "info") => {
+      migrationLogIdRef.current += 1;
+      const timestamp = new Date().toLocaleTimeString();
+      setMigrationLog((entries) => [
+        ...entries.slice(-199),
+        {
+          id: migrationLogIdRef.current,
+          message: `[${timestamp}] ${message}`,
+          tone,
+        },
+      ]);
+    },
+    []
   );
 
   const handlePatternSubmit = (event: FormEvent<HTMLFormElement>) => {
@@ -325,18 +348,24 @@ export function AdminRedisBrowserView({ t }: AdminRedisBrowserViewProps) {
     }
   };
 
-  const handleLoadMigrationStatus = async () => {
+  const handleLoadMigrationStatus = async (showToast: boolean = true) => {
     setIsLoadingMigrationStatus(true);
     try {
       const status =
         await getAdminRedisKeyMigrationStatus<RedisMigrationStatusResponse>({ limit: 100 });
       setMigrationStatus(status);
-      toast.success(
-        t("apps.admin.redis.migration.statusReady", {
-          count: status.totalLegacyKeys,
-          defaultValue: `Found ${status.totalLegacyKeys} sampled legacy Redis keys`,
-        })
+      appendMigrationLog(
+        `Status scan found ${status.totalLegacyKeys}${status.truncated ? "+" : ""} sampled legacy keys across ${status.patterns.length} patterns`,
+        status.totalLegacyKeys > 0 ? "info" : "success"
       );
+      if (showToast) {
+        toast.success(
+          t("apps.admin.redis.migration.statusReady", {
+            count: status.totalLegacyKeys,
+            defaultValue: `Found ${status.totalLegacyKeys} sampled legacy Redis keys`,
+          })
+        );
+      }
       if (status.truncated) {
         toast.info(
           t(
@@ -355,48 +384,84 @@ export function AdminRedisBrowserView({ t }: AdminRedisBrowserViewProps) {
     }
   };
 
-  const handleBackfillMigration = async (dryRun: boolean) => {
-    setIsBackfillingMigration(true);
+  const runContinuousMigration = async (kind: RedisMigrationRunKind) => {
+    if (activeMigrationRun) return;
+    migrationStopRequestedRef.current = false;
+    setActiveMigrationRun(kind);
+    appendMigrationLog(
+      `${kind === "delete" ? "Delete" : kind === "backfill" ? "Backfill" : "Dry run"} started for all legacy patterns`,
+      "info"
+    );
     try {
-      const result = await backfillAdminRedisKeyScheme<RedisBackfillResponse>({
-        pattern: migrationPattern,
-        limit: 100,
-        dryRun,
-      });
-      toast.success(
-        dryRun
-          ? t("apps.admin.redis.migration.dryRunComplete", {
-              scanned: result.scanned,
-              planned: result.planned,
-              defaultValue: `Dry run scanned ${result.scanned}; ${result.planned} keys can be copied`,
-            })
-          : t("apps.admin.redis.migration.backfillComplete", {
-              copied: result.copied,
-              skipped: result.skipped,
-              defaultValue: `Backfilled ${result.copied}; skipped ${result.skipped}`,
-            })
-      );
-      if (result.warnings.length > 0) {
-        toast.info(result.warnings.slice(0, 2).join("\n"));
+      for (const legacyPattern of LEGACY_REDIS_SCAN_PATTERNS) {
+        if (migrationStopRequestedRef.current) break;
+        let cursor = "0";
+        let batchNumber = 0;
+        let continuePattern = true;
+        while (continuePattern && !migrationStopRequestedRef.current) {
+          batchNumber += 1;
+          if (kind === "delete") {
+            const result = await deleteAdminLegacyRedisKeys<DeleteLegacyRedisKeysResponse>({
+              pattern: legacyPattern,
+              limit: 100,
+              dryRun: false,
+              cursor: "0",
+            });
+            appendMigrationLog(
+              `${legacyPattern} delete batch ${batchNumber}: scanned ${result.scanned}, deleted ${result.deleted}${result.truncated ? ", more pending" : ""}`,
+              result.deleted > 0 ? "success" : "info"
+            );
+            if (result.scanned === 0 || result.deleted === 0) {
+              continuePattern = false;
+            }
+            continue;
+          }
+
+          const result = await backfillAdminRedisKeyScheme<RedisBackfillResponse>({
+            pattern: legacyPattern,
+            limit: 100,
+            dryRun: kind === "dry-run",
+            cursor,
+          });
+          appendMigrationLog(
+            `${legacyPattern} ${kind === "dry-run" ? "dry-run" : "backfill"} batch ${batchNumber}: scanned ${result.scanned}, planned ${result.planned}, copied ${result.copied}, skipped ${result.skipped}, cursor ${result.cursor}`,
+            result.warnings.length > 0 ? "warning" : result.copied > 0 ? "success" : "info"
+          );
+          for (const warning of result.warnings.slice(0, 3)) {
+            appendMigrationLog(`${legacyPattern}: ${warning}`, "warning");
+          }
+          cursor = result.cursor;
+          continuePattern = cursor !== "0";
+        }
       }
-      if (result.truncated) {
-        toast.info(
-          t(
-            "apps.admin.redis.migration.batchTruncated",
-            "Batch limit reached; run the action again for the next batch.",
-          )
+      if (migrationStopRequestedRef.current) {
+        appendMigrationLog("Stopped by user request", "warning");
+      } else {
+        appendMigrationLog(
+          `${kind === "delete" ? "Delete" : kind === "backfill" ? "Backfill" : "Dry run"} completed for all legacy patterns`,
+          "success"
         );
       }
-      await handleLoadMigrationStatus();
+      await handleLoadMigrationStatus(false);
       refreshScope();
     } catch (error) {
-      console.error("Failed to backfill Redis key scheme:", error);
+      console.error("Redis migration run failed:", error);
+      appendMigrationLog(
+        error instanceof Error ? error.message : "Redis migration run failed",
+        "error"
+      );
       toast.error(
-        t("apps.admin.redis.migration.errors.backfill", "Failed to backfill Redis keys")
+        t("apps.admin.redis.migration.errors.run", "Redis migration run failed")
       );
     } finally {
-      setIsBackfillingMigration(false);
+      setActiveMigrationRun(null);
+      migrationStopRequestedRef.current = false;
     }
+  };
+
+  const handleStopMigration = () => {
+    migrationStopRequestedRef.current = true;
+    appendMigrationLog("Stop requested; waiting for current batch to finish", "warning");
   };
 
   const handleDeleteConfirm = async () => {
@@ -427,38 +492,8 @@ export function AdminRedisBrowserView({ t }: AdminRedisBrowserViewProps) {
 
   const handleDeleteLegacyConfirm = async () => {
     if (!deleteLegacyCandidate) return;
-    setIsDeletingLegacy(true);
-    try {
-      const result = await deleteAdminLegacyRedisKeys<DeleteLegacyRedisKeysResponse>({
-        pattern: deleteLegacyCandidate,
-        limit: 100,
-        dryRun: false,
-      });
-      toast.success(
-        t("apps.admin.redis.migration.deleteComplete", {
-          deleted: result.deleted,
-          defaultValue: `Deleted ${result.deleted} legacy Redis keys`,
-        })
-      );
-      if (result.truncated) {
-        toast.info(
-          t(
-            "apps.admin.redis.migration.deleteTruncated",
-            "Batch limit reached; run delete again after reviewing the next batch.",
-          )
-        );
-      }
-      setDeleteLegacyCandidate(null);
-      await handleLoadMigrationStatus();
-      refreshScope();
-    } catch (error) {
-      console.error("Failed to delete legacy Redis keys:", error);
-      toast.error(
-        t("apps.admin.redis.migration.errors.delete", "Failed to delete legacy Redis keys")
-      );
-    } finally {
-      setIsDeletingLegacy(false);
-    }
+    setDeleteLegacyCandidate(false);
+    await runContinuousMigration("delete");
   };
 
   return (
@@ -513,24 +548,15 @@ export function AdminRedisBrowserView({ t }: AdminRedisBrowserViewProps) {
         <span className={cn(adminSectionLabelClass, "mr-1")}>
           {t("apps.admin.redis.migration.label", "Migration")}
         </span>
-        <select
-          value={migrationPattern}
-          onChange={(event) => setMigrationPattern(event.target.value)}
-          className="h-7 min-w-[190px] rounded border border-os-separator bg-os-window px-2 font-os-mono text-[11px] text-os-text-primary"
-          aria-label={t("apps.admin.redis.migration.pattern", "Legacy Redis pattern")}
-        >
-          {LEGACY_REDIS_SCAN_PATTERNS.map((legacyPattern) => (
-            <option key={legacyPattern} value={legacyPattern}>
-              {legacyPattern}
-            </option>
-          ))}
-        </select>
+        <span className="font-os-mono text-[10px] text-os-text-secondary">
+          {LEGACY_REDIS_SCAN_PATTERNS.length} legacy patterns
+        </span>
         <Button
           type="button"
           variant="ghost"
           size="sm"
           onClick={() => void handleLoadMigrationStatus()}
-          disabled={isLoadingMigrationStatus}
+          disabled={isLoadingMigrationStatus || isMigrationRunning}
           className="h-7 px-2 text-[11px]"
         >
           {isLoadingMigrationStatus
@@ -541,8 +567,8 @@ export function AdminRedisBrowserView({ t }: AdminRedisBrowserViewProps) {
           type="button"
           variant="ghost"
           size="sm"
-          onClick={() => void handleBackfillMigration(true)}
-          disabled={isBackfillingMigration}
+          onClick={() => void runContinuousMigration("dry-run")}
+          disabled={isMigrationRunning}
           className="h-7 px-2 text-[11px]"
         >
           {t("apps.admin.redis.migration.dryRun", "Dry run")}
@@ -551,34 +577,76 @@ export function AdminRedisBrowserView({ t }: AdminRedisBrowserViewProps) {
           type="button"
           variant="ghost"
           size="sm"
-          onClick={() => void handleBackfillMigration(false)}
-          disabled={isBackfillingMigration}
+          onClick={() => void runContinuousMigration("backfill")}
+          disabled={isMigrationRunning}
           className="h-7 px-2 text-[11px]"
         >
-          {isBackfillingMigration
+          {activeMigrationRun === "backfill"
             ? t("apps.admin.redis.loading", "Loading...")
-            : t("apps.admin.redis.migration.backfill", "Backfill batch")}
+            : t("apps.admin.redis.migration.backfill", "Backfill all")}
         </Button>
         <Button
           type="button"
           variant="ghost"
           size="sm"
-          onClick={() => setDeleteLegacyCandidate(migrationPattern)}
-          disabled={isDeletingLegacy}
+          onClick={() => setDeleteLegacyCandidate(true)}
+          disabled={isMigrationRunning}
           className="h-7 px-2 text-[11px] text-red-600 hover:text-red-700 os-mac-aqua-dark:text-red-300"
         >
-          {isDeletingLegacy
+          {activeMigrationRun === "delete"
             ? t("apps.admin.redis.loading", "Loading...")
-            : t("apps.admin.redis.migration.deleteLegacy", "Delete legacy batch")}
+            : t("apps.admin.redis.migration.deleteLegacy", "Delete all legacy")}
         </Button>
-        {selectedMigrationStatus ? (
+        {isMigrationRunning ? (
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={handleStopMigration}
+            className="h-7 px-2 text-[11px]"
+          >
+            {t("apps.admin.redis.migration.stop", "Stop")}
+          </Button>
+        ) : null}
+        {migrationStatus ? (
           <span className="font-os-mono text-[10px] text-os-text-secondary">
-            {selectedMigrationStatus.count}
-            {selectedMigrationStatus.truncated ? "+" : ""}{" "}
-            {t("apps.admin.redis.migration.keysSampled", "sampled")}
+            {migrationStatus.totalLegacyKeys}
+            {migrationStatus.truncated ? "+" : ""}{" "}
+            {t("apps.admin.redis.migration.keysSampled", "legacy sampled")}
           </span>
         ) : null}
       </div>
+
+      {migrationLog.length > 0 ? (
+        <div className="max-h-28 shrink-0 overflow-auto border-b border-os-separator bg-black/5 px-2 py-1 font-os-mono text-[10px] leading-relaxed os-mac-aqua-dark:bg-white/10">
+          <div className="mb-1 flex items-center justify-between gap-2">
+            <span className={adminSectionLabelClass}>
+              {t("apps.admin.redis.migration.log", "Migration log")}
+            </span>
+            {!isMigrationRunning ? (
+              <button
+                type="button"
+                onClick={() => setMigrationLog([])}
+                className="text-os-text-secondary hover:text-os-text-primary hover:underline"
+              >
+                {t("apps.admin.redis.migration.clearLog", "Clear")}
+              </button>
+            ) : null}
+          </div>
+          {migrationLog.map((entry) => (
+            <div
+              key={entry.id}
+              className={cn(
+                entry.tone === "success" && "text-green-700 os-mac-aqua-dark:text-green-300",
+                entry.tone === "warning" && "text-yellow-700 os-mac-aqua-dark:text-yellow-300",
+                entry.tone === "error" && "text-red-700 os-mac-aqua-dark:text-red-300",
+              )}
+            >
+              {entry.message}
+            </div>
+          ))}
+        </div>
+      ) : null}
 
       <div
         className={cn(
@@ -822,15 +890,15 @@ export function AdminRedisBrowserView({ t }: AdminRedisBrowserViewProps) {
         })}
       />
       <ConfirmDialog
-        isOpen={deleteLegacyCandidate !== null}
+        isOpen={deleteLegacyCandidate}
         onOpenChange={(open) => {
-          if (!open) setDeleteLegacyCandidate(null);
+          if (!open) setDeleteLegacyCandidate(false);
         }}
         onConfirm={handleDeleteLegacyConfirm}
         title={t("apps.admin.redis.migration.deleteTitle", "Delete legacy Redis keys?")}
         description={t("apps.admin.redis.migration.deleteDescription", {
-          pattern: deleteLegacyCandidate,
-          defaultValue: `Delete up to 100 Redis keys matching "${deleteLegacyCandidate}"? Backfill first and repeat until the scan is clear.`,
+          defaultValue:
+            "Delete all registered legacy Redis keys in continuous batches? Backfill first; this keeps going until every legacy pattern is clear or Stop is clicked.",
         })}
       />
     </div>

--- a/src/apps/admin/components/admin-app/AdminRedisBrowserView.tsx
+++ b/src/apps/admin/components/admin-app/AdminRedisBrowserView.tsx
@@ -114,6 +114,7 @@ interface DeleteLegacyRedisKeysResponse {
   scanned: number;
   deleted: number;
   truncated: boolean;
+  keys: string[];
 }
 
 type RedisMigrationRunKind = "dry-run" | "backfill" | "delete";
@@ -127,6 +128,9 @@ interface RedisMigrationLogEntry {
 export interface AdminRedisBrowserViewProps {
   t: TFunction;
 }
+
+const MIGRATION_BATCH_LIMIT = 100;
+const DELETE_LEGACY_BATCH_LIMIT = 1000;
 
 function formatRedisTtl(ttl: number | null): string {
   if (ttl === null) return "TTL unknown";
@@ -161,6 +165,12 @@ function downloadJson(filename: string, data: unknown): void {
   link.click();
   document.body.removeChild(link);
   URL.revokeObjectURL(url);
+}
+
+function formatDeletedKeySample(keys: string[]): string {
+  if (keys.length === 0) return "no keys";
+  if (keys.length === 1) return `key ${keys[0]}`;
+  return `keys ${keys[0]} ... ${keys[keys.length - 1]}`;
 }
 
 // How many keys each SCAN page requests. SCAN COUNT is a hint, so the actual
@@ -415,7 +425,7 @@ export function AdminRedisBrowserView({ t }: AdminRedisBrowserViewProps) {
           if (kind === "delete") {
             const result = await deleteAdminLegacyRedisKeys<DeleteLegacyRedisKeysResponse>({
               pattern: legacyPattern,
-              limit: 100,
+              limit: DELETE_LEGACY_BATCH_LIMIT,
               dryRun: false,
               cursor: "0",
             });
@@ -423,7 +433,7 @@ export function AdminRedisBrowserView({ t }: AdminRedisBrowserViewProps) {
             totals.scanned += result.scanned;
             totals.deleted += result.deleted;
             appendMigrationLog(
-              `${legacyPattern} delete batch ${batchNumber}: scanned ${result.scanned}, deleted ${result.deleted}${result.truncated ? ", more pending" : ""}`,
+              `pattern ${legacyPattern} delete batch ${batchNumber}: scanned ${result.scanned}, deleted ${result.deleted} (${formatDeletedKeySample(result.keys)})${result.truncated ? ", more pending" : ""}`,
               result.deleted > 0 ? "success" : "info"
             );
             if (result.scanned === 0 || result.deleted === 0) {
@@ -434,7 +444,7 @@ export function AdminRedisBrowserView({ t }: AdminRedisBrowserViewProps) {
 
           const result = await backfillAdminRedisKeyScheme<RedisBackfillResponse>({
             pattern: legacyPattern,
-            limit: 100,
+            limit: MIGRATION_BATCH_LIMIT,
             dryRun: kind === "dry-run",
             cursor,
           });

--- a/src/apps/admin/components/admin-app/AdminRedisBrowserView.tsx
+++ b/src/apps/admin/components/admin-app/AdminRedisBrowserView.tsx
@@ -597,17 +597,16 @@ export function AdminRedisBrowserView({ t }: AdminRedisBrowserViewProps) {
             ? t("apps.admin.redis.loading", "Loading...")
             : t("apps.admin.redis.migration.deleteLegacy", "Delete all legacy")}
         </Button>
-        {isMigrationRunning ? (
-          <Button
-            type="button"
-            variant="ghost"
-            size="sm"
-            onClick={handleStopMigration}
-            className="h-7 px-2 text-[11px]"
-          >
-            {t("apps.admin.redis.migration.stop", "Stop")}
-          </Button>
-        ) : null}
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          onClick={handleStopMigration}
+          disabled={!isMigrationRunning}
+          className="h-7 px-2 text-[11px]"
+        >
+          {t("apps.admin.redis.migration.stop", "Stop")}
+        </Button>
         {migrationStatus ? (
           <span className="font-os-mono text-[10px] text-os-text-secondary">
             {migrationStatus.totalLegacyKeys}

--- a/src/apps/admin/components/admin-app/AdminRedisBrowserView.tsx
+++ b/src/apps/admin/components/admin-app/AdminRedisBrowserView.tsx
@@ -389,8 +389,19 @@ export function AdminRedisBrowserView({ t }: AdminRedisBrowserViewProps) {
     if (activeMigrationRun) return;
     migrationStopRequestedRef.current = false;
     setActiveMigrationRun(kind);
+    const totals = {
+      batches: 0,
+      copied: 0,
+      deleted: 0,
+      planned: 0,
+      scanned: 0,
+      skipped: 0,
+      warnings: 0,
+    };
+    const runLabel =
+      kind === "delete" ? "Delete" : kind === "backfill" ? "Backfill" : "Dry run";
     appendMigrationLog(
-      `${kind === "delete" ? "Delete" : kind === "backfill" ? "Backfill" : "Dry run"} started for all legacy patterns`,
+      `${runLabel} started for all legacy patterns`,
       "info"
     );
     try {
@@ -408,6 +419,9 @@ export function AdminRedisBrowserView({ t }: AdminRedisBrowserViewProps) {
               dryRun: false,
               cursor: "0",
             });
+            totals.batches += 1;
+            totals.scanned += result.scanned;
+            totals.deleted += result.deleted;
             appendMigrationLog(
               `${legacyPattern} delete batch ${batchNumber}: scanned ${result.scanned}, deleted ${result.deleted}${result.truncated ? ", more pending" : ""}`,
               result.deleted > 0 ? "success" : "info"
@@ -424,6 +438,12 @@ export function AdminRedisBrowserView({ t }: AdminRedisBrowserViewProps) {
             dryRun: kind === "dry-run",
             cursor,
           });
+          totals.batches += 1;
+          totals.scanned += result.scanned;
+          totals.planned += result.planned;
+          totals.copied += result.copied;
+          totals.skipped += result.skipped;
+          totals.warnings += result.warnings.length;
           appendMigrationLog(
             `${legacyPattern} ${kind === "dry-run" ? "dry-run" : "backfill"} batch ${batchNumber}: scanned ${result.scanned}, planned ${result.planned}, copied ${result.copied}, skipped ${result.skipped}, cursor ${result.cursor}`,
             result.warnings.length > 0 ? "warning" : result.copied > 0 ? "success" : "info"
@@ -438,11 +458,14 @@ export function AdminRedisBrowserView({ t }: AdminRedisBrowserViewProps) {
       if (migrationStopRequestedRef.current) {
         appendMigrationLog("Stopped by user request", "warning");
       } else {
-        appendMigrationLog(
-          `${kind === "delete" ? "Delete" : kind === "backfill" ? "Backfill" : "Dry run"} completed for all legacy patterns`,
-          "success"
-        );
+        appendMigrationLog(`${runLabel} completed for all legacy patterns`, "success");
       }
+      appendMigrationLog(
+        kind === "delete"
+          ? `${runLabel} totals: ${totals.batches} batches, ${totals.scanned} scanned, ${totals.deleted} deleted`
+          : `${runLabel} totals: ${totals.batches} batches, ${totals.scanned} scanned, ${totals.planned} planned, ${totals.copied} copied, ${totals.skipped} skipped, ${totals.warnings} warnings`,
+        migrationStopRequestedRef.current ? "warning" : "success"
+      );
       await handleLoadMigrationStatus(false);
       refreshScope();
     } catch (error) {

--- a/src/apps/admin/components/admin-app/AdminRedisBrowserView.tsx
+++ b/src/apps/admin/components/admin-app/AdminRedisBrowserView.tsx
@@ -420,6 +420,8 @@ export function AdminRedisBrowserView({ t }: AdminRedisBrowserViewProps) {
         let cursor = "0";
         let batchNumber = 0;
         let continuePattern = true;
+        let lastDeleteSignature: string | null = null;
+        let repeatedDeleteSignatureCount = 0;
         while (continuePattern && !migrationStopRequestedRef.current) {
           batchNumber += 1;
           if (kind === "delete") {
@@ -436,6 +438,22 @@ export function AdminRedisBrowserView({ t }: AdminRedisBrowserViewProps) {
               `pattern ${legacyPattern} delete batch ${batchNumber}: scanned ${result.scanned}, deleted ${result.deleted} (${formatDeletedKeySample(result.keys)})${result.truncated ? ", more pending" : ""}`,
               result.deleted > 0 ? "success" : "info"
             );
+            const deleteSignature = result.keys.join("\u001f");
+            if (result.deleted > 0 && deleteSignature) {
+              if (deleteSignature === lastDeleteSignature) {
+                repeatedDeleteSignatureCount += 1;
+              } else {
+                lastDeleteSignature = deleteSignature;
+                repeatedDeleteSignatureCount = 1;
+              }
+              if (repeatedDeleteSignatureCount >= 2) {
+                appendMigrationLog(
+                  `pattern ${legacyPattern} stopped after the same deleted batch reappeared (${formatDeletedKeySample(result.keys)}); a running service may be recreating it`,
+                  "warning"
+                );
+                continuePattern = false;
+              }
+            }
             if (result.scanned === 0 || result.deleted === 0) {
               continuePattern = false;
             }

--- a/src/apps/admin/utils/redisKeyTree.ts
+++ b/src/apps/admin/utils/redisKeyTree.ts
@@ -7,6 +7,8 @@
  * group keys by that separator and let the UI drill into one level at a time.
  */
 
+import { CANONICAL_REDIS_PREFIXES } from "../../../shared/redisKeys";
+
 export const REDIS_KEY_SEPARATOR = ":";
 
 /**
@@ -15,25 +17,7 @@ export const REDIS_KEY_SEPARATOR = ":";
  * scoped SCAN without first paging through a global `*` scan. Kept in sync with
  * the key builders across `api/` (chat/sync/analytics/memory/etc.).
  */
-export const KNOWN_REDIS_PREFIXES: string[] = [
-  "chat",
-  "sync",
-  "sync2",
-  "analytics",
-  "memory",
-  "system",
-  "airdrop",
-  "song",
-  "listen",
-  "applet",
-  "apple",
-  "ie",
-  "wayback",
-  "cursor-sdk-run",
-  "cursor-sdk-agent",
-  "ryos",
-  "rl",
-];
+export const KNOWN_REDIS_PREFIXES: string[] = [...CANONICAL_REDIS_PREFIXES];
 
 export interface RedisKeyNode {
   key: string;

--- a/src/shared/redisKeys.ts
+++ b/src/shared/redisKeys.ts
@@ -34,6 +34,11 @@ export type CanonicalRedisPrefix = (typeof CANONICAL_REDIS_PREFIXES)[number];
  */
 export const LEGACY_REDIS_SCAN_PATTERNS = [
   "airdrop:*",
+  "analytics:aiu:*",
+  "analytics:daily:*",
+  "analytics:ep:*",
+  "analytics:st:*",
+  "analytics:uv:*",
   "apple:*",
   "applet:*",
   "chat:irc:*",
@@ -50,6 +55,7 @@ export const LEGACY_REDIS_SCAN_PATTERNS = [
   "geoip:*",
   "ie:*",
   "listen:*",
+  "memory:user:*:processing_lock",
   "rl:*",
   "rt:*",
   "song:*",
@@ -159,6 +165,8 @@ export const redisKeys = {
       redisKey("rate", "block", feature, scope, identifierHash),
   },
   media: {
+    appletShare: (shareId: string) =>
+      redisKeyCaseSensitive("media", "applet", "share", shareId),
     songIds: () => redisKey("media", "song", "ids"),
     songMeta: (songId: string) =>
       redisKeyCaseSensitive("media", "song", songId, "meta"),

--- a/src/shared/redisKeys.ts
+++ b/src/shared/redisKeys.ts
@@ -1,0 +1,200 @@
+/**
+ * Canonical Redis key registry for the next key-scheme migration.
+ *
+ * This file intentionally does not change runtime storage behavior by itself.
+ * Stage-one migration work can import these builders for new code, tests, admin
+ * discovery, and backfill jobs before individual feature modules cut over.
+ */
+
+export const REDIS_KEY_SEPARATOR = ":";
+
+export const CANONICAL_REDIS_PREFIXES = [
+  "agent",
+  "analytics",
+  "auth",
+  "cache",
+  "chat",
+  "integration",
+  "media",
+  "memory",
+  "presence",
+  "rate",
+  "realtime",
+  "session",
+  "sync",
+  "system",
+] as const;
+
+export type CanonicalRedisPrefix = (typeof CANONICAL_REDIS_PREFIXES)[number];
+
+/**
+ * Legacy key patterns that must be empty before the final no-compatibility
+ * cutover. Patterns stay precise where a top-level prefix remains canonical
+ * (for example, `chat:*` becomes only selected legacy subtrees).
+ */
+export const LEGACY_REDIS_SCAN_PATTERNS = [
+  "airdrop:*",
+  "apple:*",
+  "applet:*",
+  "chat:irc:*",
+  "chat:messages:*",
+  "chat:password:*",
+  "chat:presence:*",
+  "chat:presencez:*",
+  "chat:room:*",
+  "chat:rooms",
+  "chat:token:*",
+  "chat:users:*",
+  "cursor-sdk-agent:*",
+  "cursor-sdk-run:*",
+  "geoip:*",
+  "ie:*",
+  "listen:*",
+  "rl:*",
+  "rt:*",
+  "song:*",
+  "sync:auto:*",
+  "sync:meta:*",
+  "sync:pref:*",
+  "sync:songs:*",
+  "sync:state:*",
+  "sync2:*",
+  "telegram:*",
+  "wayback:*",
+] as const;
+
+export type LegacyRedisScanPattern = (typeof LEGACY_REDIS_SCAN_PATTERNS)[number];
+
+export function normalizeRedisSegment(segment: string | number): string {
+  return encodeURIComponent(String(segment).trim().toLowerCase());
+}
+
+export function normalizeCaseSensitiveRedisSegment(segment: string | number): string {
+  return encodeURIComponent(String(segment).trim());
+}
+
+export function redisKey(
+  ...segments: Array<string | number | null | undefined>
+): string {
+  return segments
+    .filter((segment): segment is string | number => segment !== null && segment !== undefined && String(segment) !== "")
+    .map(normalizeRedisSegment)
+    .join(REDIS_KEY_SEPARATOR);
+}
+
+export function redisKeyCaseSensitive(
+  ...segments: Array<string | number | null | undefined>
+): string {
+  return segments
+    .filter((segment): segment is string | number => segment !== null && segment !== undefined && String(segment) !== "")
+    .map(normalizeCaseSensitiveRedisSegment)
+    .join(REDIS_KEY_SEPARATOR);
+}
+
+export async function sha256RedisIdentifier(value: string): Promise<string> {
+  const digest = await globalThis.crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(value)
+  );
+  return Array.from(new Uint8Array(digest), (byte) =>
+    byte.toString(16).padStart(2, "0")
+  ).join("");
+}
+
+export function redisKeysForHashedIdentifiers() {
+  return {
+    token: sha256RedisIdentifier,
+    ip: sha256RedisIdentifier,
+    url: sha256RedisIdentifier,
+  };
+}
+
+export const redisKeys = {
+  auth: {
+    userProfile: (username: string) => redisKey("auth", "user", username, "profile"),
+    userPassword: (username: string) => redisKey("auth", "user", username, "password"),
+    userSessions: (username: string) => redisKey("auth", "user", username, "sessions"),
+    session: (tokenHash: string) => redisKey("auth", "session", tokenHash),
+    lastSession: (username: string) => redisKey("auth", "user", username, "last-session"),
+  },
+  chat: {
+    roomIds: () => redisKey("chat", "rooms"),
+    roomMeta: (roomId: string) => redisKeyCaseSensitive("chat", "room", roomId, "meta"),
+    roomMessages: (roomId: string) => redisKeyCaseSensitive("chat", "room", roomId, "messages"),
+    roomPresence: (roomId: string) => redisKeyCaseSensitive("chat", "room", roomId, "presence"),
+    ircServer: (serverId: string) => redisKeyCaseSensitive("chat", "irc", "server", serverId),
+    ircServerIds: () => redisKey("chat", "irc", "servers"),
+  },
+  sync: {
+    v2Seq: (username: string) => redisKey("sync", "v2", "user", username, "seq"),
+    v2Kv: (username: string) => redisKey("sync", "v2", "user", username, "kv"),
+    v2Journal: (username: string) => redisKey("sync", "v2", "user", username, "journal"),
+    v2Blobs: (username: string) => redisKey("sync", "v2", "user", username, "blobs"),
+    v2Lock: (username: string) => redisKey("sync", "v2", "user", username, "lock"),
+    v2TtlTouched: (username: string) => redisKey("sync", "v2", "user", username, "ttl-touched"),
+    maintenanceCursor: () => redisKey("sync", "maintenance", "cursor"),
+    backupMeta: (username: string) => redisKey("sync", "backup", "user", username, "meta"),
+    autoSyncPreference: (username: string) => redisKey("sync", "preference", "user", username, "auto-sync"),
+  },
+  rate: {
+    counter: (feature: string, window: string, scope: string, identifierHash: string) =>
+      redisKey("rate", feature, window, scope, identifierHash),
+    block: (feature: string, scope: string, identifierHash: string) =>
+      redisKey("rate", "block", feature, scope, identifierHash),
+  },
+  media: {
+    songIds: () => redisKey("media", "song", "ids"),
+    songMeta: (songId: string) => redisKeyCaseSensitive("media", "song", songId, "meta"),
+    songContent: (songId: string) => redisKeyCaseSensitive("media", "song", songId, "content"),
+  },
+  cache: {
+    appleArtwork: (catalogId: string) => redisKey("cache", "apple-music", "artwork", catalogId),
+    geoip: (ipHash: string) => redisKey("cache", "geoip", ipHash),
+    ieVersions: (urlHash: string, year: string | number) => redisKey("cache", "ie", urlHash, year, "versions"),
+    wayback: (urlHash: string, year: string | number) => redisKey("cache", "wayback", urlHash, year),
+  },
+  analytics: {
+    apiMetric: (metric: string, date: string) => redisKey("analytics", "api", metric, date),
+    productMetric: (metric: string, date: string) => redisKey("analytics", "product", metric, date),
+  },
+  memory: {
+    index: (username: string) => redisKey("memory", "user", username, "index"),
+    detail: (username: string, key: string) => redisKey("memory", "user", username, "detail", key),
+    daily: (username: string, date: string) => redisKey("memory", "user", username, "daily", date),
+    processingLock: (username: string) => redisKey("memory", "user", username, "processing-lock"),
+  },
+  integration: {
+    telegramLinkCode: (code: string) => redisKeyCaseSensitive("integration", "telegram", "link", "code", code),
+    telegramPendingLink: (username: string) => redisKey("integration", "telegram", "link", "user", username),
+    telegramAccountByTelegramUser: (telegramUserId: string) =>
+      redisKey("integration", "telegram", "account", "telegram-user", telegramUserId),
+    telegramAccountByUsername: (username: string) =>
+      redisKey("integration", "telegram", "account", "user", username),
+    telegramHistory: (chatId: string) => redisKey("integration", "telegram", "history", chatId),
+    telegramUpdate: (updateId: string | number) => redisKey("integration", "telegram", "update", updateId),
+    telegramHeartbeat: (username: string, slot: string) =>
+      redisKey("integration", "telegram", "heartbeat", username, slot),
+  },
+  realtime: {
+    ticket: (ticketHash: string) => redisKey("realtime", "ticket", ticketHash),
+    pubsubChannel: () => redisKey("realtime", "pubsub"),
+  },
+  presence: {
+    globalOnline: () => redisKey("presence", "global", "online"),
+    airdropLobby: () => redisKey("presence", "airdrop", "lobby"),
+  },
+  session: {
+    listenIds: () => redisKey("session", "listen", "ids"),
+    listen: (sessionId: string) => redisKeyCaseSensitive("session", "listen", sessionId),
+    airdropTransfer: (transferId: string) => redisKeyCaseSensitive("session", "airdrop", "transfer", transferId),
+  },
+  agent: {
+    cursorRunEvents: (runId: string) => redisKeyCaseSensitive("agent", "cursor", "run", runId, "events"),
+    cursorRunMeta: (runId: string) => redisKeyCaseSensitive("agent", "cursor", "run", runId, "meta"),
+    cursorLatestRun: (agentId: string) => redisKeyCaseSensitive("agent", "cursor", "agent", agentId, "latest-run"),
+  },
+  system: {
+    userHeartbeats: (username: string, date: string) => redisKey("system", "user", username, "heartbeats", date),
+    migrationRun: (runId: string) => redisKeyCaseSensitive("system", "migration", "redis-key-scheme", runId),
+  },
+} as const;

--- a/src/shared/redisKeys.ts
+++ b/src/shared/redisKeys.ts
@@ -77,7 +77,10 @@ export function redisKey(
   ...segments: Array<string | number | null | undefined>
 ): string {
   return segments
-    .filter((segment): segment is string | number => segment !== null && segment !== undefined && String(segment) !== "")
+    .filter(
+      (segment): segment is string | number =>
+        segment !== null && segment !== undefined && String(segment).trim() !== ""
+    )
     .map(normalizeRedisSegment)
     .join(REDIS_KEY_SEPARATOR);
 }
@@ -86,7 +89,10 @@ export function redisKeyCaseSensitive(
   ...segments: Array<string | number | null | undefined>
 ): string {
   return segments
-    .filter((segment): segment is string | number => segment !== null && segment !== undefined && String(segment) !== "")
+    .filter(
+      (segment): segment is string | number =>
+        segment !== null && segment !== undefined && String(segment).trim() !== ""
+    )
     .map(normalizeCaseSensitiveRedisSegment)
     .join(REDIS_KEY_SEPARATOR);
 }
@@ -111,30 +117,40 @@ export function redisKeysForHashedIdentifiers() {
 
 export const redisKeys = {
   auth: {
-    userProfile: (username: string) => redisKey("auth", "user", username, "profile"),
-    userPassword: (username: string) => redisKey("auth", "user", username, "password"),
-    userSessions: (username: string) => redisKey("auth", "user", username, "sessions"),
+    userProfile: (username: string) =>
+      redisKey("auth", "user", username, "profile"),
+    userPassword: (username: string) =>
+      redisKey("auth", "user", username, "password"),
+    userSessions: (username: string) =>
+      redisKey("auth", "user", username, "sessions"),
     session: (tokenHash: string) => redisKey("auth", "session", tokenHash),
-    lastSession: (username: string) => redisKey("auth", "user", username, "last-session"),
+    lastSession: (username: string) =>
+      redisKey("auth", "user", username, "last-session"),
   },
   chat: {
-    roomIds: () => redisKey("chat", "rooms"),
-    roomMeta: (roomId: string) => redisKeyCaseSensitive("chat", "room", roomId, "meta"),
-    roomMessages: (roomId: string) => redisKeyCaseSensitive("chat", "room", roomId, "messages"),
-    roomPresence: (roomId: string) => redisKeyCaseSensitive("chat", "room", roomId, "presence"),
-    ircServer: (serverId: string) => redisKeyCaseSensitive("chat", "irc", "server", serverId),
-    ircServerIds: () => redisKey("chat", "irc", "servers"),
+    roomIds: () => redisKey("chat", "rooms", "ids"),
+    roomMeta: (roomId: string) =>
+      redisKeyCaseSensitive("chat", "rooms", roomId, "meta"),
+    roomMessages: (roomId: string) =>
+      redisKeyCaseSensitive("chat", "rooms", roomId, "messages"),
+    roomPresence: (roomId: string) =>
+      redisKeyCaseSensitive("chat", "rooms", roomId, "presence"),
   },
   sync: {
     v2Seq: (username: string) => redisKey("sync", "v2", "user", username, "seq"),
     v2Kv: (username: string) => redisKey("sync", "v2", "user", username, "kv"),
-    v2Journal: (username: string) => redisKey("sync", "v2", "user", username, "journal"),
-    v2Blobs: (username: string) => redisKey("sync", "v2", "user", username, "blobs"),
+    v2Journal: (username: string) =>
+      redisKey("sync", "v2", "user", username, "journal"),
+    v2Blobs: (username: string) =>
+      redisKey("sync", "v2", "user", username, "blobs"),
     v2Lock: (username: string) => redisKey("sync", "v2", "user", username, "lock"),
-    v2TtlTouched: (username: string) => redisKey("sync", "v2", "user", username, "ttl-touched"),
+    v2TtlTouched: (username: string) =>
+      redisKey("sync", "v2", "user", username, "ttl-touched"),
     maintenanceCursor: () => redisKey("sync", "maintenance", "cursor"),
-    backupMeta: (username: string) => redisKey("sync", "backup", "user", username, "meta"),
-    autoSyncPreference: (username: string) => redisKey("sync", "preference", "user", username, "auto-sync"),
+    backupMeta: (username: string) =>
+      redisKey("sync", "backup", "user", username, "meta"),
+    autoSyncPreference: (username: string) =>
+      redisKey("sync", "preference", "user", username, "auto-sync"),
   },
   rate: {
     counter: (feature: string, window: string, scope: string, identifierHash: string) =>
@@ -144,34 +160,51 @@ export const redisKeys = {
   },
   media: {
     songIds: () => redisKey("media", "song", "ids"),
-    songMeta: (songId: string) => redisKeyCaseSensitive("media", "song", songId, "meta"),
-    songContent: (songId: string) => redisKeyCaseSensitive("media", "song", songId, "content"),
+    songMeta: (songId: string) =>
+      redisKeyCaseSensitive("media", "song", songId, "meta"),
+    songContent: (songId: string) =>
+      redisKeyCaseSensitive("media", "song", songId, "content"),
   },
   cache: {
-    appleArtwork: (catalogId: string) => redisKey("cache", "apple-music", "artwork", catalogId),
+    appleArtwork: (catalogId: string) =>
+      redisKey("cache", "apple-music", "artwork", catalogId),
     geoip: (ipHash: string) => redisKey("cache", "geoip", ipHash),
-    ieVersions: (urlHash: string, year: string | number) => redisKey("cache", "ie", urlHash, year, "versions"),
-    wayback: (urlHash: string, year: string | number) => redisKey("cache", "wayback", urlHash, year),
+    ieVersions: (urlHash: string, year: string | number) =>
+      redisKey("cache", "ie", urlHash, year, "versions"),
+    wayback: (urlHash: string, year: string | number) =>
+      redisKey("cache", "wayback", urlHash, year),
   },
   analytics: {
-    apiMetric: (metric: string, date: string) => redisKey("analytics", "api", metric, date),
-    productMetric: (metric: string, date: string) => redisKey("analytics", "product", metric, date),
+    apiMetric: (metric: string, date: string) =>
+      redisKey("analytics", "api", metric, date),
+    productMetric: (metric: string, date: string) =>
+      redisKey("analytics", "product", metric, date),
   },
   memory: {
     index: (username: string) => redisKey("memory", "user", username, "index"),
-    detail: (username: string, key: string) => redisKey("memory", "user", username, "detail", key),
-    daily: (username: string, date: string) => redisKey("memory", "user", username, "daily", date),
-    processingLock: (username: string) => redisKey("memory", "user", username, "processing-lock"),
+    detail: (username: string, key: string) =>
+      redisKey("memory", "user", username, "detail", key),
+    daily: (username: string, date: string) =>
+      redisKey("memory", "user", username, "daily", date),
+    processingLock: (username: string) =>
+      redisKey("memory", "user", username, "processing-lock"),
   },
   integration: {
-    telegramLinkCode: (code: string) => redisKeyCaseSensitive("integration", "telegram", "link", "code", code),
-    telegramPendingLink: (username: string) => redisKey("integration", "telegram", "link", "user", username),
+    ircServer: (serverId: string) =>
+      redisKeyCaseSensitive("integration", "irc", "server", serverId),
+    ircServerIds: () => redisKey("integration", "irc", "servers"),
+    telegramLinkCode: (code: string) =>
+      redisKeyCaseSensitive("integration", "telegram", "link", "code", code),
+    telegramPendingLink: (username: string) =>
+      redisKey("integration", "telegram", "link", "user", username),
     telegramAccountByTelegramUser: (telegramUserId: string) =>
       redisKey("integration", "telegram", "account", "telegram-user", telegramUserId),
     telegramAccountByUsername: (username: string) =>
       redisKey("integration", "telegram", "account", "user", username),
-    telegramHistory: (chatId: string) => redisKey("integration", "telegram", "history", chatId),
-    telegramUpdate: (updateId: string | number) => redisKey("integration", "telegram", "update", updateId),
+    telegramHistory: (chatId: string) =>
+      redisKey("integration", "telegram", "history", chatId),
+    telegramUpdate: (updateId: string | number) =>
+      redisKey("integration", "telegram", "update", updateId),
     telegramHeartbeat: (username: string, slot: string) =>
       redisKey("integration", "telegram", "heartbeat", username, slot),
   },
@@ -185,16 +218,23 @@ export const redisKeys = {
   },
   session: {
     listenIds: () => redisKey("session", "listen", "ids"),
-    listen: (sessionId: string) => redisKeyCaseSensitive("session", "listen", sessionId),
-    airdropTransfer: (transferId: string) => redisKeyCaseSensitive("session", "airdrop", "transfer", transferId),
+    listen: (sessionId: string) =>
+      redisKeyCaseSensitive("session", "listen", sessionId),
+    airdropTransfer: (transferId: string) =>
+      redisKeyCaseSensitive("session", "airdrop", "transfer", transferId),
   },
   agent: {
-    cursorRunEvents: (runId: string) => redisKeyCaseSensitive("agent", "cursor", "run", runId, "events"),
-    cursorRunMeta: (runId: string) => redisKeyCaseSensitive("agent", "cursor", "run", runId, "meta"),
-    cursorLatestRun: (agentId: string) => redisKeyCaseSensitive("agent", "cursor", "agent", agentId, "latest-run"),
+    cursorRunEvents: (runId: string) =>
+      redisKeyCaseSensitive("agent", "cursor", "run", runId, "events"),
+    cursorRunMeta: (runId: string) =>
+      redisKeyCaseSensitive("agent", "cursor", "run", runId, "meta"),
+    cursorLatestRun: (agentId: string) =>
+      redisKeyCaseSensitive("agent", "cursor", "agent", agentId, "latest-run"),
   },
   system: {
-    userHeartbeats: (username: string, date: string) => redisKey("system", "user", username, "heartbeats", date),
-    migrationRun: (runId: string) => redisKeyCaseSensitive("system", "migration", "redis-key-scheme", runId),
+    userHeartbeats: (username: string, date: string) =>
+      redisKey("system", "user", username, "heartbeats", date),
+    migrationRun: (runId: string) =>
+      redisKeyCaseSensitive("system", "migration", "redis-key-scheme", runId),
   },
 } as const;

--- a/src/shared/redisKeys.ts
+++ b/src/shared/redisKeys.ts
@@ -103,6 +103,13 @@ export function redisKeyCaseSensitive(
     .join(REDIS_KEY_SEPARATOR);
 }
 
+function songKey(songId: string, facet: "meta" | "content"): string {
+  if (songId.startsWith("am:")) {
+    return redisKeyCaseSensitive("media", "song", "am", songId.slice(3), facet);
+  }
+  return redisKeyCaseSensitive("media", "song", songId, facet);
+}
+
 export async function sha256RedisIdentifier(value: string): Promise<string> {
   const digest = await globalThis.crypto.subtle.digest(
     "SHA-256",
@@ -168,10 +175,8 @@ export const redisKeys = {
     appletShare: (shareId: string) =>
       redisKeyCaseSensitive("media", "applet", "share", shareId),
     songIds: () => redisKey("media", "song", "ids"),
-    songMeta: (songId: string) =>
-      redisKeyCaseSensitive("media", "song", songId, "meta"),
-    songContent: (songId: string) =>
-      redisKeyCaseSensitive("media", "song", songId, "content"),
+    songMeta: (songId: string) => songKey(songId, "meta"),
+    songContent: (songId: string) => songKey(songId, "content"),
   },
   cache: {
     appleArtwork: (catalogId: string) =>

--- a/tests/fake-redis.ts
+++ b/tests/fake-redis.ts
@@ -40,8 +40,18 @@ export class FakeRedisPipeline {
     return this;
   }
 
+  pfadd(key: string, ...elements: string[]): this {
+    this.operations.push(() => this.redis.pfaddSync(key, ...elements));
+    return this;
+  }
+
   srem(key: string, ...members: string[]): this {
     this.operations.push(() => this.redis.sremSync(key, ...members));
+    return this;
+  }
+
+  hincrby(key: string, field: string, increment: number): this {
+    this.operations.push(() => this.redis.hincrbySync(key, field, increment));
     return this;
   }
 
@@ -126,6 +136,10 @@ export class FakeRedis {
     }
     this.sets.set(key, set);
     return added;
+  }
+
+  pfaddSync(key: string, ...elements: string[]): number {
+    return this.saddSync(key, ...elements);
   }
 
   sremSync(key: string, ...members: string[]): number {
@@ -285,11 +299,29 @@ export class FakeRedis {
   }
 
   async hincrby(key: string, field: string, increment: number): Promise<number> {
+    return this.hincrbySync(key, field, increment);
+  }
+
+  hincrbySync(key: string, field: string, increment: number): number {
     const hash = this.hashes.get(key) || new Map<string, string>();
     const next = (Number.parseInt(hash.get(field) || "0", 10) || 0) + increment;
     hash.set(field, String(next));
     this.hashes.set(key, hash);
     return next;
+  }
+
+  async pfadd(key: string, ...elements: string[]): Promise<number> {
+    return this.pfaddSync(key, ...elements);
+  }
+
+  async pfcount(...keys: string[]): Promise<number> {
+    const unique = new Set<string>();
+    for (const key of keys) {
+      for (const member of this.sets.get(key) || []) {
+        unique.add(member);
+      }
+    }
+    return unique.size;
   }
 
   async rpush(key: string, ...values: string[]): Promise<number> {

--- a/tests/fake-redis.ts
+++ b/tests/fake-redis.ts
@@ -366,6 +366,21 @@ export class FakeRedis {
     return ordered.slice(normalizedStart, normalizedStop + 1);
   }
 
+  async zrangeWithScores(
+    key: string,
+    start: number,
+    stop: number
+  ): Promise<Array<{ member: string; score: number }>> {
+    const ordered = this.zsorted(key);
+    const normalizedStart = start < 0 ? Math.max(0, ordered.length + start) : start;
+    const normalizedStop = stop < 0 ? ordered.length + stop : stop;
+    const scores = this.zsets.get(key) || new Map<string, number>();
+    return ordered.slice(normalizedStart, normalizedStop + 1).map((member) => ({
+      member,
+      score: scores.get(member) ?? 0,
+    }));
+  }
+
   async zremrangebyscore(
     key: string,
     min: number | string,

--- a/tests/test-admin.test.ts
+++ b/tests/test-admin.test.ts
@@ -314,6 +314,80 @@ describe("admin", () => {
       expect(data.error).toContain("Confirmation");
     });
 
+    test("GET getRedisKeyMigrationStatus - with admin token", async () => {
+      if (!adminToken) {
+        console.log("  ⚠️  Skipped (no admin token available)");
+        return;
+      }
+
+      const res = await fetchWithAuth(
+        `${BASE_URL}/api/admin?action=getRedisKeyMigrationStatus&limit=5`,
+        ADMIN_USERNAME,
+        adminToken,
+        { method: "GET" }
+      );
+
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(typeof data.totalLegacyKeys).toBe("number");
+      expect(Array.isArray(data.patterns)).toBe(true);
+      expect(data.patterns.some((item: { pattern: string }) => item.pattern === "chat:users:*")).toBe(true);
+    });
+
+    test("POST backfillRedisKeyScheme - requires exact pattern confirmation", async () => {
+      if (!adminToken) {
+        console.log("  ⚠️  Skipped (no admin token available)");
+        return;
+      }
+
+      const res = await fetchWithAuth(
+        `${BASE_URL}/api/admin`,
+        ADMIN_USERNAME,
+        adminToken,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            action: "backfillRedisKeyScheme",
+            pattern: "chat:users:*",
+            confirmPattern: "wrong-pattern",
+            dryRun: true,
+          }),
+        }
+      );
+
+      expect(res.status).toBe(400);
+      const data = await res.json();
+      expect(data.error).toContain("Confirmation");
+    });
+
+    test("POST deleteLegacyRedisKeys - requires exact pattern confirmation", async () => {
+      if (!adminToken) {
+        console.log("  ⚠️  Skipped (no admin token available)");
+        return;
+      }
+
+      const res = await fetchWithAuth(
+        `${BASE_URL}/api/admin`,
+        ADMIN_USERNAME,
+        adminToken,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            action: "deleteLegacyRedisKeys",
+            pattern: "chat:users:*",
+            confirmPattern: "wrong-pattern",
+            dryRun: true,
+          }),
+        }
+      );
+
+      expect(res.status).toBe(400);
+      const data = await res.json();
+      expect(data.error).toContain("Confirmation");
+    });
+
     test("POST deleteUser - missing target username", async () => {
       if (!adminToken) {
         console.log("  ⚠️  Skipped (no admin token available)");

--- a/tests/test-analytics-keys.test.ts
+++ b/tests/test-analytics-keys.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "bun:test";
+import type { Redis } from "../api/_utils/redis";
+import { recordAnalyticsEvent } from "../api/_utils/_analytics";
+import { FakeRedis } from "./fake-redis";
+
+describe("analytics Redis keys", () => {
+  test("records API analytics into canonical keys only", async () => {
+    const fake = new FakeRedis();
+    const redis = fake as unknown as Redis;
+    const today = new Date().toISOString().slice(0, 10);
+
+    recordAnalyticsEvent(redis, {
+      path: "/api/chat",
+      method: "POST",
+      status: 200,
+      latencyMs: 42,
+      ip: "203.0.113.10",
+      username: "ryo",
+    });
+
+    expect(await redis.hgetall(`analytics:api:daily:${today}`)).toMatchObject({
+      calls: "1",
+      ai: "1",
+      latsum: "42",
+      latcnt: "1",
+    });
+    expect(await redis.hgetall(`analytics:daily:${today}`)).toBeNull();
+    expect(fake.allKeys().some((key) => key.startsWith("analytics:daily:"))).toBe(false);
+  });
+});

--- a/tests/test-auth-canonical-session.test.ts
+++ b/tests/test-auth-canonical-session.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from "bun:test";
+import type { Redis } from "../api/_utils/redis";
+import { validateAuth } from "../api/_utils/auth/_validate";
+import {
+  getUserPasswordHash,
+  setUserPasswordHash,
+} from "../api/_utils/auth/_password-storage";
+import { getUserTokenKey, storeToken } from "../api/_utils/auth/_tokens";
+import {
+  getLegacyStoredUserKey,
+  getStoredUserRecord,
+  setStoredUserRecord,
+} from "../api/_utils/auth/_user-record";
+import { redisKeys, sha256RedisIdentifier } from "../src/shared/redisKeys";
+import { FakeRedis } from "./fake-redis";
+
+describe("canonical auth sessions", () => {
+  test("validates after legacy chat token key is gone", async () => {
+    const fake = new FakeRedis();
+    const redis = fake as unknown as Redis;
+    const username = "ryo";
+    const token = "secret-token";
+
+    await storeToken(redis, username, token);
+    await redis.del(getUserTokenKey(username, token));
+
+    const tokenHash = await sha256RedisIdentifier(token);
+    expect(await redis.exists(redisKeys.auth.session(tokenHash))).toBe(1);
+    expect(await validateAuth(redis, username, token)).toEqual({
+      valid: true,
+      expired: false,
+    });
+  });
+
+  test("reads canonical user profile and password after legacy auth keys are gone", async () => {
+    const fake = new FakeRedis();
+    const redis = fake as unknown as Redis;
+
+    await setStoredUserRecord(redis, "ryo", {
+      username: "ryo",
+      createdAt: 1,
+      lastActive: 2,
+    });
+    await setUserPasswordHash(redis, "ryo", "hashed-password");
+    await redis.del(getLegacyStoredUserKey("ryo"), "chat:password:ryo");
+
+    expect(await getStoredUserRecord(redis, "ryo")).toMatchObject({
+      username: "ryo",
+      lastActive: 2,
+    });
+    expect(await getUserPasswordHash(redis, "ryo")).toBe("hashed-password");
+    expect(await redis.get(redisKeys.auth.userProfile("ryo"))).not.toBeNull();
+    expect(await redis.get(redisKeys.auth.userPassword("ryo"))).toBe("hashed-password");
+  });
+});

--- a/tests/test-redis-key-migration.test.ts
+++ b/tests/test-redis-key-migration.test.ts
@@ -87,6 +87,39 @@ describe("Redis key scheme migration helpers", () => {
     expect(await redis.get(redisKeys.media.songMeta("abc"))).toBeNull();
   });
 
+  test("backfill returns cursors so the UI can continue through all batches", async () => {
+    const fake = new FakeRedis();
+    const redis = fake as unknown as Redis;
+    fake.setSync("chat:users:alice", JSON.stringify({ username: "alice" }));
+    fake.setSync("chat:users:bob", JSON.stringify({ username: "bob" }));
+
+    const first = await backfillRedisKeyScheme(redis, {
+      pattern: "chat:users:*",
+      limit: 1,
+      dryRun: false,
+      cursor: "0",
+    });
+    expect(first.scanned).toBe(1);
+    expect(first.cursor).not.toBe("0");
+
+    let cursor = first.cursor;
+    let scanned = first.scanned;
+    for (let i = 0; i < 10 && cursor !== "0"; i += 1) {
+      const next = await backfillRedisKeyScheme(redis, {
+        pattern: "chat:users:*",
+        limit: 1,
+        dryRun: false,
+        cursor,
+      });
+      scanned += next.scanned;
+      cursor = next.cursor;
+    }
+    expect(cursor).toBe("0");
+    expect(scanned).toBeGreaterThanOrEqual(2);
+    expect(await redis.get(redisKeys.auth.userProfile("alice"))).not.toBeNull();
+    expect(await redis.get(redisKeys.auth.userProfile("bob"))).not.toBeNull();
+  });
+
   test("reports legacy status and deletes legacy batches only when not dry-run", async () => {
     const fake = new FakeRedis();
     const redis = fake as unknown as Redis;

--- a/tests/test-redis-key-migration.test.ts
+++ b/tests/test-redis-key-migration.test.ts
@@ -153,6 +153,49 @@ describe("Redis key scheme migration helpers", () => {
     expect(Object.keys(kv || {})).toContain("settings/display");
   });
 
+  test("backfills sync2 journals as zsets while preserving scores", async () => {
+    const fake = new FakeRedis();
+    const redis = fake as unknown as Redis;
+    await fake.zadd("sync2:jrnl:ryo", { score: 2, member: JSON.stringify({ seq: 2 }) });
+    await fake.zadd("sync2:jrnl:ryo", { score: 1, member: JSON.stringify({ seq: 1 }) });
+
+    const result = await backfillRedisKeyScheme(redis, {
+      pattern: "sync2:*",
+      limit: 10,
+      dryRun: false,
+    });
+
+    expect(result.scanned).toBe(1);
+    expect(result.copied).toBe(1);
+    expect(result.warnings).toEqual([]);
+    expect(await fake.zrangeWithScores(redisKeys.sync.v2Journal("ryo"), 0, -1)).toEqual([
+      { score: 1, member: JSON.stringify({ seq: 1 }) },
+      { score: 2, member: JSON.stringify({ seq: 2 }) },
+    ]);
+  });
+
+  test("treats abandoned sync2 log keys as a silent backfill skip", async () => {
+    const fake = new FakeRedis();
+    const redis = fake as unknown as Redis;
+    await fake.rpush("sync2:log:ryo", JSON.stringify({ seq: 1 }));
+
+    await expect(planRedisKeyMigration("sync2:log:ryo")).resolves.toMatchObject({
+      targetKey: null,
+      action: "skip",
+    });
+
+    const result = await backfillRedisKeyScheme(redis, {
+      pattern: "sync2:*",
+      limit: 10,
+      dryRun: false,
+    });
+
+    expect(result.scanned).toBe(1);
+    expect(result.copied).toBe(0);
+    expect(result.skipped).toBe(1);
+    expect(result.warnings).toEqual([]);
+  });
+
   test("reports legacy status and deletes legacy batches only when not dry-run", async () => {
     const fake = new FakeRedis();
     const redis = fake as unknown as Redis;

--- a/tests/test-redis-key-migration.test.ts
+++ b/tests/test-redis-key-migration.test.ts
@@ -20,7 +20,7 @@ describe("Redis key scheme migration helpers", () => {
       action: "copy",
     });
     await expect(planRedisKeyMigration("song:meta:am:123")).resolves.toMatchObject({
-      targetKey: "media:song:am%3A123:meta",
+      targetKey: "media:song:am:123:meta",
       action: "copy",
     });
     await expect(planRedisKeyMigration("rl:ai:anon:127.0.0.1")).resolves.toMatchObject({

--- a/tests/test-redis-key-migration.test.ts
+++ b/tests/test-redis-key-migration.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, test } from "bun:test";
+import type { Redis } from "../api/_utils/redis";
+import {
+  backfillRedisKeyScheme,
+  deleteLegacyRedisKeys,
+  getRedisMigrationStatus,
+  planRedisKeyMigration,
+} from "../api/_utils/redis-key-migration";
+import { redisKeys, sha256RedisIdentifier } from "../src/shared/redisKeys";
+import { FakeRedis } from "./fake-redis";
+
+describe("Redis key scheme migration helpers", () => {
+  test("maps representative legacy keys to canonical targets", async () => {
+    await expect(planRedisKeyMigration("chat:users:Alice")).resolves.toMatchObject({
+      targetKey: "auth:user:alice:profile",
+      action: "copy",
+    });
+    await expect(planRedisKeyMigration("chat:messages:RoomABC")).resolves.toMatchObject({
+      targetKey: "chat:rooms:RoomABC:messages",
+      action: "copy",
+    });
+    await expect(planRedisKeyMigration("song:meta:am:123")).resolves.toMatchObject({
+      targetKey: "media:song:am%3A123:meta",
+      action: "copy",
+    });
+    await expect(planRedisKeyMigration("rl:ai:anon:127.0.0.1")).resolves.toMatchObject({
+      targetKey: null,
+      action: "skip",
+    });
+  });
+
+  test("backfills strings and preserves TTLs without deleting legacy keys", async () => {
+    const fake = new FakeRedis();
+    const redis = fake as unknown as Redis;
+    fake.setSync("chat:users:alice", JSON.stringify({ username: "alice" }), {
+      ex: 3600,
+    });
+
+    const result = await backfillRedisKeyScheme(redis, {
+      pattern: "chat:users:*",
+      limit: 10,
+      dryRun: false,
+    });
+
+    expect(result.scanned).toBe(1);
+    expect(result.copied).toBe(1);
+    expect(await redis.get(redisKeys.auth.userProfile("alice"))).toBe(
+      JSON.stringify({ username: "alice" })
+    );
+    expect(await redis.get("chat:users:alice")).toBe(JSON.stringify({ username: "alice" }));
+    expect(fake.ttls.get(redisKeys.auth.userProfile("alice"))).toBe(3600);
+  });
+
+  test("backfills auth sessions with hashed token keys and user session index", async () => {
+    const fake = new FakeRedis();
+    const redis = fake as unknown as Redis;
+    fake.setSync("chat:token:user:alice:secret-token", "123", { ex: 120 });
+    const tokenHash = await sha256RedisIdentifier("secret-token");
+
+    const result = await backfillRedisKeyScheme(redis, {
+      pattern: "chat:token:*",
+      limit: 10,
+      dryRun: false,
+    });
+
+    expect(result.copied).toBe(1);
+    expect(await redis.get(redisKeys.auth.session(tokenHash))).toBe("123");
+    expect(await redis.smembers(redisKeys.auth.userSessions("alice"))).toEqual([tokenHash]);
+    expect(fake.ttls.get(redisKeys.auth.session(tokenHash))).toBe(120);
+    expect(fake.ttls.get(redisKeys.auth.userSessions("alice"))).toBe(120);
+  });
+
+  test("dry-run backfill plans without writing target keys", async () => {
+    const fake = new FakeRedis();
+    const redis = fake as unknown as Redis;
+    fake.setSync("song:meta:abc", JSON.stringify({ id: "abc" }));
+
+    const result = await backfillRedisKeyScheme(redis, {
+      pattern: "song:*",
+      limit: 10,
+      dryRun: true,
+    });
+
+    expect(result.scanned).toBe(1);
+    expect(result.planned).toBe(1);
+    expect(result.copied).toBe(0);
+    expect(await redis.get(redisKeys.media.songMeta("abc"))).toBeNull();
+  });
+
+  test("reports legacy status and deletes legacy batches only when not dry-run", async () => {
+    const fake = new FakeRedis();
+    const redis = fake as unknown as Redis;
+    fake.setSync("applet:share:a1", JSON.stringify({ id: "a1" }));
+    fake.setSync("applet:share:a2", JSON.stringify({ id: "a2" }));
+
+    const status = await getRedisMigrationStatus(redis, 10);
+    const appletStatus = status.patterns.find((item) => item.pattern === "applet:*");
+    expect(appletStatus?.count).toBe(2);
+
+    const dryRun = await deleteLegacyRedisKeys(redis, {
+      pattern: "applet:*",
+      limit: 10,
+      dryRun: true,
+    });
+    expect(dryRun.deleted).toBe(0);
+    expect(await redis.get("applet:share:a1")).not.toBeNull();
+
+    const deleted = await deleteLegacyRedisKeys(redis, {
+      pattern: "applet:*",
+      limit: 10,
+      dryRun: false,
+    });
+    expect(deleted.deleted).toBe(2);
+    expect(await redis.get("applet:share:a1")).toBeNull();
+    expect(await redis.get("applet:share:a2")).toBeNull();
+  });
+});

--- a/tests/test-redis-key-migration.test.ts
+++ b/tests/test-redis-key-migration.test.ts
@@ -27,6 +27,11 @@ describe("Redis key scheme migration helpers", () => {
       targetKey: null,
       action: "skip",
     });
+    await expect(planRedisKeyMigration("sync:state:alice:settings")).resolves.toMatchObject({
+      targetKey: "sync:v2:user:alice:kv",
+      action: "import-v1-sync",
+      username: "alice",
+    });
   });
 
   test("backfills strings and preserves TTLs without deleting legacy keys", async () => {
@@ -118,6 +123,34 @@ describe("Redis key scheme migration helpers", () => {
     expect(scanned).toBeGreaterThanOrEqual(2);
     expect(await redis.get(redisKeys.auth.userProfile("alice"))).not.toBeNull();
     expect(await redis.get(redisKeys.auth.userProfile("bob"))).not.toBeNull();
+  });
+
+  test("imports legacy sync v1 keys into sync2 instead of warning", async () => {
+    const fake = new FakeRedis();
+    const redis = fake as unknown as Redis;
+    fake.setSync(
+      "sync:state:alice:settings",
+      JSON.stringify({
+        data: {
+          display: { desktopScale: 1 },
+        },
+        updatedAt: "2026-01-01T00:00:00.000Z",
+      })
+    );
+
+    const result = await backfillRedisKeyScheme(redis, {
+      pattern: "sync:state:*",
+      limit: 10,
+      dryRun: false,
+    });
+
+    expect(result.scanned).toBe(1);
+    expect(result.planned).toBe(1);
+    expect(result.copied).toBe(1);
+    expect(result.warnings).toEqual([]);
+    expect(await redis.get("sync2:seq:alice")).toBe("0");
+    const kv = await redis.hgetall("sync2:kv:alice");
+    expect(Object.keys(kv || {})).toContain("settings/display");
   });
 
   test("reports legacy status and deletes legacy batches only when not dry-run", async () => {

--- a/tests/test-redis-keys.test.ts
+++ b/tests/test-redis-keys.test.ts
@@ -65,7 +65,10 @@ describe("canonical Redis key registry", () => {
 
   test("preserves case-sensitive IDs where existing IDs may be mixed-case", () => {
     expect(redisKeys.chat.roomMeta("RoomABC")).toBe("chat:rooms:RoomABC:meta");
-    expect(redisKeys.media.songMeta("am:12345")).toBe("media:song:am%3A12345:meta");
+    expect(redisKeys.media.songMeta("am:12345")).toBe("media:song:am:12345:meta");
+    expect(redisKeys.media.songContent("am:12345")).toBe(
+      "media:song:am:12345:content"
+    );
     expect(redisKeys.agent.cursorRunMeta("bc_AbC")).toBe(
       "agent:cursor:run:bc_AbC:meta"
     );

--- a/tests/test-redis-keys.test.ts
+++ b/tests/test-redis-keys.test.ts
@@ -44,6 +44,10 @@ describe("canonical Redis key registry", () => {
     expect(LEGACY_REDIS_SCAN_PATTERNS).toContain("cursor-sdk-run:*");
     expect(LEGACY_REDIS_SCAN_PATTERNS).not.toContain("chat:*");
     expect(LEGACY_REDIS_SCAN_PATTERNS).not.toContain("sync:*");
+    expect(redisKeys.chat.roomMeta("abc").startsWith("chat:room:")).toBe(false);
+    expect(redisKeys.integration.ircServer("libera").startsWith("chat:irc:")).toBe(
+      false
+    );
   });
 
   test("normalizes dynamic segments consistently", () => {
@@ -58,7 +62,7 @@ describe("canonical Redis key registry", () => {
   });
 
   test("preserves case-sensitive IDs where existing IDs may be mixed-case", () => {
-    expect(redisKeys.chat.roomMeta("RoomABC")).toBe("chat:room:RoomABC:meta");
+    expect(redisKeys.chat.roomMeta("RoomABC")).toBe("chat:rooms:RoomABC:meta");
     expect(redisKeys.media.songMeta("am:12345")).toBe("media:song:am%3A12345:meta");
     expect(redisKeys.agent.cursorRunMeta("bc_AbC")).toBe(
       "agent:cursor:run:bc_AbC:meta"
@@ -73,6 +77,9 @@ describe("canonical Redis key registry", () => {
     );
     expect(redisKeys.integration.telegramPendingLink("Ryo")).toBe(
       "integration:telegram:link:user:ryo"
+    );
+    expect(redisKeys.integration.ircServer("libera")).toBe(
+      "integration:irc:server:libera"
     );
     expect(redisKeys.realtime.ticket("tickethash")).toBe("realtime:ticket:tickethash");
     expect(redisKeys.presence.globalOnline()).toBe("presence:global:online");

--- a/tests/test-redis-keys.test.ts
+++ b/tests/test-redis-keys.test.ts
@@ -1,0 +1,93 @@
+#!/usr/bin/env bun
+/**
+ * Unit tests for the canonical Redis key registry. These tests do not touch a
+ * Redis server; they lock down key shapes for the staged migration.
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  CANONICAL_REDIS_PREFIXES,
+  LEGACY_REDIS_SCAN_PATTERNS,
+  redisKey,
+  redisKeys,
+  redisKeysForHashedIdentifiers,
+  sha256RedisIdentifier,
+} from "../src/shared/redisKeys";
+
+describe("canonical Redis key registry", () => {
+  test("uses the approved top-level prefixes without an app or env wrapper", () => {
+    expect(CANONICAL_REDIS_PREFIXES).toEqual([
+      "agent",
+      "analytics",
+      "auth",
+      "cache",
+      "chat",
+      "integration",
+      "media",
+      "memory",
+      "presence",
+      "rate",
+      "realtime",
+      "session",
+      "sync",
+      "system",
+    ]);
+    expect(CANONICAL_REDIS_PREFIXES).not.toContain("ryos");
+    expect(CANONICAL_REDIS_PREFIXES).not.toContain("prod");
+  });
+
+  test("keeps precise legacy scan patterns for final cleanup", () => {
+    expect(LEGACY_REDIS_SCAN_PATTERNS).toContain("chat:users:*");
+    expect(LEGACY_REDIS_SCAN_PATTERNS).toContain("chat:token:*");
+    expect(LEGACY_REDIS_SCAN_PATTERNS).toContain("sync2:*");
+    expect(LEGACY_REDIS_SCAN_PATTERNS).toContain("rl:*");
+    expect(LEGACY_REDIS_SCAN_PATTERNS).toContain("cursor-sdk-run:*");
+    expect(LEGACY_REDIS_SCAN_PATTERNS).not.toContain("chat:*");
+    expect(LEGACY_REDIS_SCAN_PATTERNS).not.toContain("sync:*");
+  });
+
+  test("normalizes dynamic segments consistently", () => {
+    expect(redisKey("Auth", "User", "Ryo Lu", "Profile")).toBe(
+      "auth:user:ryo%20lu:profile"
+    );
+    expect(redisKeys.auth.userProfile("Alice")).toBe("auth:user:alice:profile");
+    expect(redisKeys.auth.userSessions("Alice")).toBe("auth:user:alice:sessions");
+    expect(redisKeys.rate.counter("AI Chat", "5h", "user", "Alice")).toBe(
+      "rate:ai%20chat:5h:user:alice"
+    );
+  });
+
+  test("preserves case-sensitive IDs where existing IDs may be mixed-case", () => {
+    expect(redisKeys.chat.roomMeta("RoomABC")).toBe("chat:room:RoomABC:meta");
+    expect(redisKeys.media.songMeta("am:12345")).toBe("media:song:am%3A12345:meta");
+    expect(redisKeys.agent.cursorRunMeta("bc_AbC")).toBe(
+      "agent:cursor:run:bc_AbC:meta"
+    );
+  });
+
+  test("builds representative migration target keys", () => {
+    expect(redisKeys.sync.v2Kv("Ryo")).toBe("sync:v2:user:ryo:kv");
+    expect(redisKeys.sync.v2Journal("Ryo")).toBe("sync:v2:user:ryo:journal");
+    expect(redisKeys.cache.ieVersions("urlhash", 1999)).toBe(
+      "cache:ie:urlhash:1999:versions"
+    );
+    expect(redisKeys.integration.telegramPendingLink("Ryo")).toBe(
+      "integration:telegram:link:user:ryo"
+    );
+    expect(redisKeys.realtime.ticket("tickethash")).toBe("realtime:ticket:tickethash");
+    expect(redisKeys.presence.globalOnline()).toBe("presence:global:online");
+  });
+
+  test("hashes sensitive identifiers before they become key segments", async () => {
+    const hash = await sha256RedisIdentifier("secret-token");
+    expect(hash).toHaveLength(64);
+    expect(hash).toMatch(/^[a-f0-9]{64}$/);
+    expect(hash).not.toContain("secret-token");
+    expect(redisKeys.auth.session(hash)).toBe(`auth:session:${hash}`);
+
+    const helpers = redisKeysForHashedIdentifiers();
+    await expect(helpers.token("secret-token")).resolves.toBe(hash);
+    await expect(helpers.ip("203.0.113.10")).resolves.toHaveLength(64);
+    await expect(helpers.url("https://example.com/path")).resolves.toHaveLength(64);
+  });
+});

--- a/tests/test-redis-keys.test.ts
+++ b/tests/test-redis-keys.test.ts
@@ -39,6 +39,8 @@ describe("canonical Redis key registry", () => {
   test("keeps precise legacy scan patterns for final cleanup", () => {
     expect(LEGACY_REDIS_SCAN_PATTERNS).toContain("chat:users:*");
     expect(LEGACY_REDIS_SCAN_PATTERNS).toContain("chat:token:*");
+    expect(LEGACY_REDIS_SCAN_PATTERNS).toContain("analytics:daily:*");
+    expect(LEGACY_REDIS_SCAN_PATTERNS).toContain("memory:user:*:processing_lock");
     expect(LEGACY_REDIS_SCAN_PATTERNS).toContain("sync2:*");
     expect(LEGACY_REDIS_SCAN_PATTERNS).toContain("rl:*");
     expect(LEGACY_REDIS_SCAN_PATTERNS).toContain("cursor-sdk-run:*");


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add a shared canonical Redis key registry for the proposed no-env-prefix scheme.
- Add precise legacy scan patterns for migration cleanup gates, including same-prefix legacy analytics and memory lock shapes.
- Add admin Redis migration helpers for status sampling, dry-run/backfill batches, and confirmed legacy delete batches.
- Preserve Apple Music song IDs as readable `media:song:am:<catalogId>:meta/content` keys instead of `am%3A...`.
- Import legacy sync v1 data through the existing sync2 initializer during backfill instead of logging it as a skipped error.
- Add `/api/admin` actions and client wrappers for migration status, cursor-based backfill, and legacy deletion.
- Add Redis browser controls that run all legacy patterns continuously, append per-batch progress logs, auto-scroll logs unless the user scrolls up, and support Stop after the current batch.
- Add focused unit and integration coverage for key builders, migration mapping/backfill/delete behavior, v1 sync import, cursor continuation, and admin action guardrails.

## Notes
- Backfill is bounded and non-destructive; legacy deletion is a separate confirmed action.
- ZSET legacy keys are reported as skipped during backfill because the current Redis abstraction cannot read scores portably; delete remains available after review.

## Testing
- Passed: `bun test tests/test-redis-keys.test.ts tests/test-redis-key-tree.test.ts tests/test-redis-key-migration.test.ts`
- Passed: `bun run test:admin`
- Passed: `bun run build` (build completed with existing CSS/chunking warnings unrelated to this change)
- Manual UI smoke: verified Admin Redis migration toolbar has no migration pattern selector, runs Scan/Dry run across all patterns, and shows a progress log.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ed736-b03c-759c-a25d-b4cef94280c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ed736-b03c-759c-a25d-b4cef94280c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

