### PR TITLE
Fix mobile Chats sidebar scrolling

### DIFF
--- a/src/apps/chats/components/ChatRoomSidebar.tsx
+++ b/src/apps/chats/components/ChatRoomSidebar.tsx
@@ -222,13 +222,18 @@ export const ChatRoomSidebar = React.memo(function ChatRoomSidebar({
           isWindowsTheme,
           isAquaGlass,
         },
-        { layout: isOverlay ? "overlay" : "side" }
+        {
+          layout: isOverlay ? "overlay" : "side",
+          className: isOverlay ? "min-h-0 overflow-hidden" : undefined,
+        }
       )}
     >
       <div
         className={cn(
           "pt-3 flex flex-col",
-          isOverlay ? "pb-3" : "flex-1 overflow-hidden"
+          isOverlay
+            ? "min-h-0 flex-1 overflow-hidden pb-3"
+            : "flex-1 overflow-hidden"
         )}
       >
         <div className="os-app-sidebar-header flex justify-between items-center mb-2 flex-shrink-0 px-3">

--- a/src/apps/chats/components/chats-app/ChatsWindowContent.tsx
+++ b/src/apps/chats/components/chats-app/ChatsWindowContent.tsx
@@ -154,7 +154,7 @@ export function ChatsWindowContent({ c, isForeground }: ChatsWindowContentProps)
                 transformPerspective: "2000px",
                 backfaceVisibility: "hidden",
                 willChange: "transform",
-                maxHeight: "70%",
+                maxHeight: "calc(100% - 44px)",
               }}
             >
               <ChatRoomSidebar

--- a/src/apps/chats/components/chats-app/ChatsWindowContent.tsx
+++ b/src/apps/chats/components/chats-app/ChatsWindowContent.tsx
@@ -149,7 +149,7 @@ export function ChatsWindowContent({ c, isForeground }: ChatsWindowContentProps)
                 stiffness: 300,
                 mass: 1,
               }}
-              className="relative w-full bg-neutral-100 z-10"
+              className="relative z-10 flex w-full flex-col overflow-hidden bg-neutral-100"
               style={{
                 transformPerspective: "2000px",
                 backfaceVisibility: "hidden",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Constrain the mobile Chats sidebar overlay as an overflow-hidden flex panel.
- Ensure the overlay sidebar content can shrink so the room list scrolls internally.
- Set the mobile overlay max height to `calc(100% - 44px)` so it can be taller while preserving a bottom tap-out area.

### Testing
- `bun run build` completed successfully.
- `bun /tmp/chats_sidebar_scroll_check.mjs` mocked `/api/rooms` to force overflow and verified the overlay panel is height constrained, `.os-app-sidebar-list` scrolls internally, and the bottom tap-out gap is 44px.
- Manual browser walkthrough recorded for the narrow Chats overlay and tap-out dismissal.

<a href="https://cursor.com/agents/bc-019ed7b1-b9ca-7e9a-9a0c-af83465e3afe/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fchats_mobile_sidebar_44px_tapout.mp4"><img src="https://cursor.com/artifacts/c/art-fc529e95-beb7-4173-890f-81cae32e4214" alt="chats_mobile_sidebar_44px_tapout.mp4" /></a>
![Chats sidebar 44px tap-out gap](https://cursor.com/artifacts/c/art-a75215ba-739d-4df5-897b-6cd5f0fc176f)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ed7b1-b9ca-7e9a-9a0c-af83465e3afe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ed7b1-b9ca-7e9a-9a0c-af83465e3afe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

