### PR TITLE
Sort private chats by online status and recency

### DIFF
--- a/api/rooms/_helpers/_presence.ts
+++ b/api/rooms/_helpers/_presence.ts
@@ -4,9 +4,10 @@
  */
 
 import { createRedis } from "../../_utils/redis.js";
-import { parseRoomData, setRoom } from "./_redis.js";
+import { parseMessageData, parseRoomData, setRoom } from "./_redis.js";
 import {
   CHAT_ROOM_PREFIX,
+  CHAT_MESSAGES_PREFIX,
   CHAT_ROOM_PRESENCE_ZSET_PREFIX,
   CHAT_ROOMS_SET,
   ROOM_PRESENCE_TTL_SECONDS,
@@ -16,6 +17,46 @@ import type { Room, RoomWithUsers } from "./_types.js";
 // Create Redis client for presence operations
 function getRedis() {
   return createRedis();
+}
+
+function getMessageTimestamp(value: unknown): number | undefined {
+  const message = parseMessageData(value);
+  if (!message) return undefined;
+
+  const rawTimestamp = (message as { timestamp?: unknown }).timestamp;
+  const timestamp =
+    typeof rawTimestamp === "number"
+      ? rawTimestamp
+      : new Date(String(rawTimestamp)).getTime();
+
+  return Number.isFinite(timestamp) ? timestamp : undefined;
+}
+
+async function attachPrivateRoomLastMessageAt<T extends Room>(
+  rooms: T[]
+): Promise<T[]> {
+  const privateRooms = rooms.filter((room) => room.type === "private");
+  if (privateRooms.length === 0) return rooms;
+
+  const redis = getRedis();
+  const lastMessages = await Promise.all(
+    privateRooms.map((room) =>
+      redis.lindex(`${CHAT_MESSAGES_PREFIX}${room.id}`, 0)
+    )
+  );
+  const lastMessageAtByRoomId = new Map<string, number>();
+
+  privateRooms.forEach((room, index) => {
+    const lastMessageAt = getMessageTimestamp(lastMessages[index]);
+    if (lastMessageAt !== undefined) {
+      lastMessageAtByRoomId.set(room.id, lastMessageAt);
+    }
+  });
+
+  return rooms.map((room) => {
+    const lastMessageAt = lastMessageAtByRoomId.get(room.id);
+    return lastMessageAt === undefined ? room : { ...room, lastMessageAt };
+  });
 }
 
 // ============================================================================
@@ -161,7 +202,7 @@ export async function getDetailedRooms(): Promise<RoomWithUsers[]> {
       users: activeUsers,
     });
   }
-  return rooms;
+  return attachPrivateRoomLastMessageAt(rooms);
 }
 
 /**
@@ -222,5 +263,5 @@ export async function getRoomsWithCountsFast(): Promise<Room[]> {
     resIdx += 1;
     rooms.push({ ...roomObj, userCount });
   }
-  return rooms;
+  return attachPrivateRoomLastMessageAt(rooms);
 }

--- a/src/apps/chats/components/ChatRoomSidebar.tsx
+++ b/src/apps/chats/components/ChatRoomSidebar.tsx
@@ -9,6 +9,10 @@ import { useChatsStore } from "@/stores/useChatsStore";
 import { useThemeFlags } from "@/hooks/useThemeFlags";
 import { osAppSidebarSurfaceClassName } from "@/components/shared/osThemePrimitives";
 import {
+  isPrivateRoomOnline,
+  sortPrivateRoomsForSidebar,
+} from "../utils/privateRoomOrdering";
+import {
   Tooltip,
   TooltipContent,
   TooltipProvider,
@@ -151,6 +155,7 @@ export const ChatRoomSidebar = React.memo(function ChatRoomSidebar({
 }: ChatRoomSidebarProps) {
   const { t } = useTranslation();
   const { play: playButtonClick } = useSound(Sounds.BUTTON_CLICK);
+  const roomMessages = useChatsStore((s) => s.roomMessages);
   // NOTE: unread counts are deliberately NOT subscribed here — each
   // ChatRoomSidebarItem subscribes to its own room's count so a badge update
   // re-renders one row instead of the whole sidebar.
@@ -166,7 +171,6 @@ export const ChatRoomSidebar = React.memo(function ChatRoomSidebar({
   const toggleChannelsOpen = useChatsStore((s) => s.toggleChannelsOpen);
   const togglePrivateOpen = useChatsStore((s) => s.togglePrivateOpen);
 
-  const onlineUsersSet = useMemo(() => new Set(onlineUsers), [onlineUsers]);
   const { publicRooms, privateRooms } = useMemo(() => {
     const nextPublicRooms: ChatRoom[] = [];
     const nextPrivateRooms: ChatRoom[] = [];
@@ -181,9 +185,13 @@ export const ChatRoomSidebar = React.memo(function ChatRoomSidebar({
 
     return {
       publicRooms: nextPublicRooms,
-      privateRooms: nextPrivateRooms,
+      privateRooms: sortPrivateRoomsForSidebar(nextPrivateRooms, {
+        username,
+        onlineUsers,
+        roomMessages,
+      }),
     };
-  }, [rooms]);
+  }, [onlineUsers, roomMessages, rooms, username]);
 
   if (!isVisible) {
     return null;
@@ -193,9 +201,7 @@ export const ChatRoomSidebar = React.memo(function ChatRoomSidebar({
     // For private rooms, check if the other member(s) are online
     const isPrivateOnline = Boolean(
       room.type === "private" &&
-        room.members?.some(
-          (m) => m !== username?.toLowerCase() && onlineUsersSet.has(m)
-        )
+        isPrivateRoomOnline(room, username, onlineUsers)
     );
 
     return (

--- a/src/apps/chats/utils/privateRoomOrdering.ts
+++ b/src/apps/chats/utils/privateRoomOrdering.ts
@@ -1,0 +1,77 @@
+import type { ChatMessage, ChatRoom } from "@/types/chat";
+import { getPrivateRoomDisplayName } from "@/utils/chat";
+
+type RoomMessagesById = Record<string, ChatMessage[] | undefined>;
+
+interface SortPrivateRoomsForSidebarOptions {
+  username?: string | null;
+  onlineUsers?: string[];
+  roomMessages?: RoomMessagesById;
+}
+
+const normalizeUsername = (value?: string | null): string =>
+  value?.trim().toLowerCase() ?? "";
+
+export function isPrivateRoomOnline(
+  room: ChatRoom,
+  username?: string | null,
+  onlineUsers: Iterable<string> = []
+): boolean {
+  if (room.type !== "private" || !Array.isArray(room.members)) {
+    return false;
+  }
+
+  const self = normalizeUsername(username);
+  const onlineUsersSet = new Set(
+    Array.from(onlineUsers, (user) => normalizeUsername(user)).filter(Boolean)
+  );
+
+  return room.members.some((member) => {
+    const normalizedMember = normalizeUsername(member);
+    return normalizedMember !== self && onlineUsersSet.has(normalizedMember);
+  });
+}
+
+function getRoomRecentActivityAt(
+  room: ChatRoom,
+  roomMessages: RoomMessagesById
+): number {
+  const newestLocalMessageAt = (roomMessages[room.id] ?? []).reduce(
+    (newest, message) =>
+      Number.isFinite(message.timestamp)
+        ? Math.max(newest, message.timestamp)
+        : newest,
+    0
+  );
+
+  return Math.max(newestLocalMessageAt, room.lastMessageAt ?? 0, room.createdAt);
+}
+
+export function sortPrivateRoomsForSidebar(
+  rooms: ChatRoom[],
+  {
+    username = null,
+    onlineUsers = [],
+    roomMessages = {},
+  }: SortPrivateRoomsForSidebarOptions = {}
+): ChatRoom[] {
+  return [...rooms].sort((a, b) => {
+    const aOnline = isPrivateRoomOnline(a, username, onlineUsers);
+    const bOnline = isPrivateRoomOnline(b, username, onlineUsers);
+
+    if (aOnline !== bOnline) {
+      return aOnline ? -1 : 1;
+    }
+
+    const aRecentAt = getRoomRecentActivityAt(a, roomMessages);
+    const bRecentAt = getRoomRecentActivityAt(b, roomMessages);
+    if (aRecentAt !== bRecentAt) {
+      return bRecentAt - aRecentAt;
+    }
+
+    const aDisplayName = getPrivateRoomDisplayName(a, username);
+    const bDisplayName = getPrivateRoomDisplayName(b, username);
+    const displayNameComparison = aDisplayName.localeCompare(bDisplayName);
+    return displayNameComparison || a.id.localeCompare(b.id);
+  });
+}

--- a/src/shared/contracts/chat.ts
+++ b/src/shared/contracts/chat.ts
@@ -5,6 +5,7 @@ export interface ChatRoom {
   name: string;
   type?: RoomType;
   createdAt: number;
+  lastMessageAt?: number;
   userCount: number;
   users?: string[];
   members?: string[];

--- a/tests/test-chat-private-room-ordering.test.ts
+++ b/tests/test-chat-private-room-ordering.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from "bun:test";
+import {
+  isPrivateRoomOnline,
+  sortPrivateRoomsForSidebar,
+} from "../src/apps/chats/utils/privateRoomOrdering";
+import type { ChatMessage, ChatRoom } from "../src/types/chat";
+
+const privateRoom = (
+  id: string,
+  member: string,
+  lastMessageAt: number | undefined,
+  createdAt: number
+): ChatRoom => ({
+  id,
+  name: `@me, @${member}`,
+  type: "private",
+  members: ["me", member],
+  createdAt,
+  ...(lastMessageAt === undefined ? {} : { lastMessageAt }),
+  userCount: 2,
+});
+
+const message = (roomId: string, timestamp: number): ChatMessage => ({
+  id: `${roomId}-${timestamp}`,
+  roomId,
+  username: "me",
+  content: "hello",
+  timestamp,
+});
+
+describe("private chat sidebar ordering", () => {
+  test("sorts online private chats first, then by recent activity", () => {
+    const rooms = [
+      privateRoom("bob-room", "bob", 4_000, 1_000),
+      privateRoom("alice-room", "alice", 2_000, 1_000),
+      privateRoom("carol-room", "carol", 3_000, 1_000),
+      privateRoom("dave-room", "dave", 1_000, 1_000),
+    ];
+
+    expect(
+      sortPrivateRoomsForSidebar(rooms, {
+        username: "me",
+        onlineUsers: ["alice", "carol"],
+      }).map((room) => room.id)
+    ).toEqual(["carol-room", "alice-room", "bob-room", "dave-room"]);
+  });
+
+  test("uses live local messages ahead of stale room listing timestamps", () => {
+    const rooms = [
+      privateRoom("erin-room", "erin", 2_000, 1_000),
+      privateRoom("frank-room", "frank", 5_000, 1_000),
+    ];
+
+    expect(
+      sortPrivateRoomsForSidebar(rooms, {
+        username: "me",
+        roomMessages: {
+          "erin-room": [message("erin-room", 7_000)],
+        },
+      }).map((room) => room.id)
+    ).toEqual(["erin-room", "frank-room"]);
+  });
+
+  test("does not count the current user as the online private peer", () => {
+    expect(
+      isPrivateRoomOnline(privateRoom("self-room", "me", undefined, 1_000), "me", [
+        "me",
+      ])
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Sort private chat sidebar entries with online peers first, then newest chat activity within each group.
- Include `lastMessageAt` in private room listings so first-load ordering reflects existing conversations.
- Add focused coverage for private room ordering rules.

### Validation
- Passed: `bun test tests/test-chat-private-room-ordering.test.ts`
- Passed: `bun run build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ed7d2-e905-7b03-9e3a-2d2d0682513f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ed7d2-e905-7b03-9e3a-2d2d0682513f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

