### PR TITLE
Cut Redis runtime paths over to canonical keys

### DIFF
--- a/api/_utils/_analytics.ts
+++ b/api/_utils/_analytics.ts
@@ -33,8 +33,12 @@ function k(suffix: string, date: string): string {
   return redisKeys.analytics.apiMetric(suffix, date);
 }
 
+function legacyK(suffix: string, date: string): string {
+  return `analytics:${suffix}:${date}`;
+}
+
 function pk(suffix: string, date: string): string {
-  return `analytics:product:${suffix}:${date}`;
+  return redisKeys.analytics.productMetric(suffix, date);
 }
 
 const AI_PATH_PREFIXES = [
@@ -589,6 +593,17 @@ function mergeHashCounts(
   }
 }
 
+function hasHashEntries(raw: Record<string, string> | null | undefined): raw is Record<string, string> {
+  return Boolean(raw && Object.keys(raw).length > 0);
+}
+
+function canonicalOrLegacyHash(
+  canonical: Record<string, string> | null,
+  legacy: Record<string, string> | null
+): Record<string, string> | null {
+  return hasHashEntries(canonical) ? canonical : legacy;
+}
+
 /**
  * Summary-only view.
  * 1 pipeline: 2 commands per day + 1 PFCOUNT across all UV keys for
@@ -600,14 +615,16 @@ export async function getAnalyticsSummary(
 ): Promise<AnalyticsSummary> {
   const dates = dateRange(days);
   const uvKeys = dates.map((d) => k("uv", d));
+  const legacyUvKeys = dates.map((d) => legacyK("uv", d));
 
   const pipe = redis.pipeline();
   for (const date of dates) {
     pipe.hgetall(k("daily", date));
-    pipe.pfcount(k("uv", date));
+    pipe.hgetall(legacyK("daily", date));
+    pipe.pfcount(k("uv", date), legacyK("uv", date));
   }
   // Cross-day unique visitors via HLL union (single PFCOUNT with N keys)
-  if (uvKeys.length > 0) pipe.pfcount(...uvKeys);
+  if (uvKeys.length > 0) pipe.pfcount(...uvKeys, ...legacyUvKeys);
   const results = await pipe.exec();
 
   let totalCalls = 0;
@@ -617,10 +634,14 @@ export async function getAnalyticsSummary(
   let totalLatCnt = 0;
 
   const dailyMetrics: DailyMetrics[] = dates.map((date, i) => {
+    const base = i * 3;
     const d = parseDailyHash(
-      (results[i * 2] as Record<string, string> | null) || null
+      canonicalOrLegacyHash(
+        (results[base] as Record<string, string> | null) || null,
+        (results[base + 1] as Record<string, string> | null) || null
+      )
     );
-    const uv = (results[i * 2 + 1] as number) || 0;
+    const uv = (results[base + 2] as number) || 0;
     const avgLatencyMs = d.latcnt > 0 ? Math.round(d.latsum / d.latcnt) : 0;
 
     totalCalls += d.calls;
@@ -642,7 +663,7 @@ export async function getAnalyticsSummary(
   // Last result in the pipeline is the cross-day PFCOUNT union
   const totalUV =
     uvKeys.length > 0
-      ? ((results[dates.length * 2] as number) || 0)
+      ? ((results[dates.length * 3] as number) || 0)
       : 0;
 
   return {
@@ -663,8 +684,10 @@ export async function getAnalyticsSummary(
  * plus 1 optional small pipeline for AI rate-limit lookups.
  *
  * Per-day slot layout in the single pipeline:
- *   [hgetall(daily), pfcount(uv), hgetall(ep), hgetall(st), hgetall(aiu)]
- *   = 5 commands per day, + 1 cross-day PFCOUNT at the end.
+ *   [hgetall(daily), hgetall(legacyDaily), pfcount(uv, legacyUv),
+ *    hgetall(ep), hgetall(legacyEp), hgetall(st), hgetall(legacySt),
+ *    hgetall(aiu), hgetall(legacyAiu)]
+ *   = 9 commands per day, + 1 cross-day PFCOUNT at the end.
  */
 export async function getAnalyticsDetail(
   redis: Redis,
@@ -672,17 +695,22 @@ export async function getAnalyticsDetail(
 ): Promise<AnalyticsDetail> {
   const dates = dateRange(days);
   const uvKeys = dates.map((d) => k("uv", d));
-  const CMDS_PER_DAY = 5;
+  const legacyUvKeys = dates.map((d) => legacyK("uv", d));
+  const CMDS_PER_DAY = 9;
 
   const pipe = redis.pipeline();
   for (const date of dates) {
     pipe.hgetall(k("daily", date));
-    pipe.pfcount(k("uv", date));
+    pipe.hgetall(legacyK("daily", date));
+    pipe.pfcount(k("uv", date), legacyK("uv", date));
     pipe.hgetall(k("ep", date));
+    pipe.hgetall(legacyK("ep", date));
     pipe.hgetall(k("st", date));
+    pipe.hgetall(legacyK("st", date));
     pipe.hgetall(k("aiu", date));
+    pipe.hgetall(legacyK("aiu", date));
   }
-  if (uvKeys.length > 0) pipe.pfcount(...uvKeys);
+  if (uvKeys.length > 0) pipe.pfcount(...uvKeys, ...legacyUvKeys);
   const results = await pipe.exec();
 
   let totalCalls = 0;
@@ -698,9 +726,12 @@ export async function getAnalyticsDetail(
   const dailyMetrics: DailyMetrics[] = dates.map((date, i) => {
     const base = i * CMDS_PER_DAY;
     const d = parseDailyHash(
-      (results[base] as Record<string, string> | null) || null
+      canonicalOrLegacyHash(
+        (results[base] as Record<string, string> | null) || null,
+        (results[base + 1] as Record<string, string> | null) || null
+      )
     );
-    const uv = (results[base + 1] as number) || 0;
+    const uv = (results[base + 2] as number) || 0;
     const avgLatencyMs = d.latcnt > 0 ? Math.round(d.latsum / d.latcnt) : 0;
 
     totalCalls += d.calls;
@@ -709,9 +740,27 @@ export async function getAnalyticsDetail(
     totalLatSum += d.latsum;
     totalLatCnt += d.latcnt;
 
-    mergeHashCounts(epMap, (results[base + 2] as Record<string, string> | null) || null);
-    mergeHashCounts(stMap, (results[base + 3] as Record<string, string> | null) || null);
-    mergeHashCounts(aiuMap, (results[base + 4] as Record<string, string> | null) || null);
+    mergeHashCounts(
+      epMap,
+      canonicalOrLegacyHash(
+        (results[base + 3] as Record<string, string> | null) || null,
+        (results[base + 4] as Record<string, string> | null) || null
+      )
+    );
+    mergeHashCounts(
+      stMap,
+      canonicalOrLegacyHash(
+        (results[base + 5] as Record<string, string> | null) || null,
+        (results[base + 6] as Record<string, string> | null) || null
+      )
+    );
+    mergeHashCounts(
+      aiuMap,
+      canonicalOrLegacyHash(
+        (results[base + 7] as Record<string, string> | null) || null,
+        (results[base + 8] as Record<string, string> | null) || null
+      )
+    );
 
     return {
       date,

--- a/api/_utils/_analytics.ts
+++ b/api/_utils/_analytics.ts
@@ -5,11 +5,11 @@
  * All writes are fire-and-forget to avoid impacting request latency.
  *
  * Redis key schema:
- *   analytics:daily:{YYYY-MM-DD}    hash  { calls, ai, errors, latsum, latcnt }
- *   analytics:uv:{YYYY-MM-DD}       HyperLogLog  (unique visitor IPs)
- *   analytics:ep:{YYYY-MM-DD}       hash  { endpoint: count }
- *   analytics:st:{YYYY-MM-DD}       hash  { statusCode: count }
- *   analytics:aiu:{YYYY-MM-DD}      hash  { username|"anon": count }
+ *   analytics:api:daily:{YYYY-MM-DD}    hash  { calls, ai, errors, latsum, latcnt }
+ *   analytics:api:uv:{YYYY-MM-DD}       HyperLogLog  (unique visitor IPs)
+ *   analytics:api:ep:{YYYY-MM-DD}       hash  { endpoint: count }
+ *   analytics:api:st:{YYYY-MM-DD}       hash  { statusCode: count }
+ *   analytics:api:aiu:{YYYY-MM-DD}      hash  { username|"anon": count }
  *
  * Performance:
  *   Write path: 5–8 Redis commands per request in 1 pipeline (fire-and-forget).
@@ -18,6 +18,7 @@
  */
 
 import type { Redis } from "./redis.js";
+import { redisKeys } from "../../src/shared/redisKeys.js";
 
 const ANALYTICS_TTL_SECONDS = 90 * 24 * 60 * 60; // 90 days
 
@@ -29,7 +30,7 @@ function todayUTC(): string {
 }
 
 function k(suffix: string, date: string): string {
-  return `analytics:${suffix}:${date}`;
+  return redisKeys.analytics.apiMetric(suffix, date);
 }
 
 function pk(suffix: string, date: string): string {

--- a/api/_utils/_geolocation.ts
+++ b/api/_utils/_geolocation.ts
@@ -154,9 +154,6 @@ async function writeCache(
     await redis.set(redisKeys.cache.geoip(await sha256RedisIdentifier(ip)), JSON.stringify(entry), {
       ex: ttlSeconds,
     });
-    await redis.set(`${REDIS_KEY_PREFIX}${ip}`, JSON.stringify(entry), {
-      ex: ttlSeconds,
-    });
   } catch {
     // Caching is best-effort.
   }

--- a/api/_utils/_geolocation.ts
+++ b/api/_utils/_geolocation.ts
@@ -1,5 +1,6 @@
 import type { Redis } from "./redis.js";
 import { isPrivateOrReservedIp } from "./_ip.js";
+import { redisKeys, sha256RedisIdentifier } from "../../src/shared/redisKeys.js";
 
 /**
  * IP-based geolocation fallback for non-Vercel deployments (Coolify, Docker,
@@ -129,9 +130,11 @@ async function readCache(
 ): Promise<CachedGeoEntry | null> {
   if (!redis) return null;
   try {
-    const raw = await redis.get<string | CachedGeoEntry>(
-      `${REDIS_KEY_PREFIX}${ip}`
-    );
+    const raw =
+      (await redis.get<string | CachedGeoEntry>(
+        redisKeys.cache.geoip(await sha256RedisIdentifier(ip))
+      )) ??
+      (await redis.get<string | CachedGeoEntry>(`${REDIS_KEY_PREFIX}${ip}`));
     if (!raw) return null;
     if (typeof raw === "string") return JSON.parse(raw) as CachedGeoEntry;
     return raw as CachedGeoEntry;
@@ -148,6 +151,9 @@ async function writeCache(
 ): Promise<void> {
   if (!redis) return;
   try {
+    await redis.set(redisKeys.cache.geoip(await sha256RedisIdentifier(ip)), JSON.stringify(entry), {
+      ex: ttlSeconds,
+    });
     await redis.set(`${REDIS_KEY_PREFIX}${ip}`, JSON.stringify(entry), {
       ex: ttlSeconds,
     });

--- a/api/_utils/_rate-limit.ts
+++ b/api/_utils/_rate-limit.ts
@@ -1,4 +1,5 @@
 import { createRedis } from "./redis.js";
+import { validateAuth } from "./auth/index.js";
 
 // Set up Redis client
 const redis = createRedis();
@@ -46,9 +47,8 @@ export async function checkAndIncrementAIMessageCount(
   // If authenticated, validate the token
   if (isAuthenticated && authToken) {
     const lower = identifier.toLowerCase();
-    const userScopedKey = `chat:token:user:${lower}:${authToken}`;
-    const exists = await redis.exists(userScopedKey);
-    if (!exists) {
+    const validation = await validateAuth(redis, lower, authToken);
+    if (!validation.valid) {
       // Invalid token for this user – treat as unauthenticated (use anon limit)
       return {
         allowed: false,

--- a/api/_utils/_song-service.ts
+++ b/api/_utils/_song-service.ts
@@ -367,19 +367,16 @@ export async function saveSong(
 
   // Save metadata to Redis
   await redis.set(getSongMetaKey(song.id), JSON.stringify(meta));
-  await redis.set(getLegacySongMetaKey(song.id), JSON.stringify(meta));
 
   // Save content to Redis (only if there's any content)
   const hasContent = content.lyrics || content.translations || content.furigana || 
                      content.soramimi || content.soramimiByLang;
   if (hasContent) {
     await redis.set(getSongContentKey(song.id), JSON.stringify(content));
-    await redis.set(getLegacySongContentKey(song.id), JSON.stringify(content));
   }
 
   // Add to the set of all song IDs
   await redis.sadd(redisKeys.media.songIds(), song.id);
-  await redis.sadd(SONG_SET_KEY, song.id);
 
   // Return combined document
   return { ...meta, ...content };
@@ -610,8 +607,6 @@ export async function saveLyrics(
 ): Promise<SongDocument> {
   const metaKey = getSongMetaKey(id);
   const contentKey = getSongContentKey(id);
-  const legacyMetaKey = getLegacySongMetaKey(id);
-  const legacyContentKey = getLegacySongContentKey(id);
   const now = Date.now();
 
   // Get existing metadata
@@ -657,13 +652,10 @@ export async function saveLyrics(
     soramimiByLang: shouldClearAnnotations ? undefined : existingContent?.soramimiByLang,
   };
 
-  // Save both keys
+  // Save canonical keys
   await redis.set(metaKey, JSON.stringify(meta));
-  await redis.set(legacyMetaKey, JSON.stringify(meta));
   await redis.set(contentKey, JSON.stringify(content));
-  await redis.set(legacyContentKey, JSON.stringify(content));
   await redis.sadd(redisKeys.media.songIds(), id);
-  await redis.sadd(SONG_SET_KEY, id);
 
   return { ...meta, ...content };
 }
@@ -679,7 +671,6 @@ export async function saveTranslation(
   translatedLrc: string
 ): Promise<SongDocument | null> {
   const contentKey = getSongContentKey(id);
-  const legacyContentKey = getLegacySongContentKey(id);
 
   // Verify song exists
   const existingMeta = parseJson<SongMetadata>(await getSongMetaRaw(redis, id));
@@ -696,7 +687,6 @@ export async function saveTranslation(
 
   // Save content key only
   await redis.set(contentKey, JSON.stringify(content));
-  await redis.set(legacyContentKey, JSON.stringify(content));
 
   return { ...existingMeta, ...content };
 }
@@ -711,7 +701,6 @@ export async function saveFurigana(
   furigana: FuriganaSegment[][]
 ): Promise<SongDocument | null> {
   const contentKey = getSongContentKey(id);
-  const legacyContentKey = getLegacySongContentKey(id);
 
   // Verify song exists
   const existingMeta = parseJson<SongMetadata>(await getSongMetaRaw(redis, id));
@@ -728,7 +717,6 @@ export async function saveFurigana(
 
   // Save content key only
   await redis.set(contentKey, JSON.stringify(content));
-  await redis.set(legacyContentKey, JSON.stringify(content));
 
   return { ...existingMeta, ...content };
 }
@@ -745,7 +733,6 @@ export async function saveSoramimi(
   language?: "zh-TW" | "en"
 ): Promise<SongDocument | null> {
   const contentKey = getSongContentKey(id);
-  const legacyContentKey = getLegacySongContentKey(id);
 
   // Verify song exists
   const existingMeta = parseJson<SongMetadata>(await getSongMetaRaw(redis, id));
@@ -764,7 +751,6 @@ export async function saveSoramimi(
 
   // Save content key only
   await redis.set(contentKey, JSON.stringify(content));
-  await redis.set(legacyContentKey, JSON.stringify(content));
 
   return { ...existingMeta, ...content };
 }

--- a/api/_utils/_song-service.ts
+++ b/api/_utils/_song-service.ts
@@ -9,6 +9,7 @@
  */
 
 import type { Redis } from "./redis.js";
+import { redisKeys } from "../../src/shared/redisKeys.js";
 
 // =============================================================================
 // Types
@@ -152,6 +153,10 @@ export const SONG_SET_KEY = "song:all";
  * Get the Redis key for song metadata
  */
 export function getSongMetaKey(id: string): string {
+  return redisKeys.media.songMeta(id);
+}
+
+export function getLegacySongMetaKey(id: string): string {
   return `${SONG_META_PREFIX}${id}`;
 }
 
@@ -159,7 +164,28 @@ export function getSongMetaKey(id: string): string {
  * Get the Redis key for song content
  */
 export function getSongContentKey(id: string): string {
+  return redisKeys.media.songContent(id);
+}
+
+export function getLegacySongContentKey(id: string): string {
   return `${SONG_CONTENT_PREFIX}${id}`;
+}
+
+async function getSongIds(redis: Redis): Promise<string[]> {
+  return [
+    ...new Set([
+      ...((await redis.smembers<string[]>(redisKeys.media.songIds())) || []),
+      ...((await redis.smembers<string[]>(SONG_SET_KEY)) || []),
+    ]),
+  ];
+}
+
+async function getSongMetaRaw(redis: Redis, id: string): Promise<unknown> {
+  return (await redis.get(getSongMetaKey(id))) ?? (await redis.get(getLegacySongMetaKey(id)));
+}
+
+async function getSongContentRaw(redis: Redis, id: string): Promise<unknown> {
+  return (await redis.get(getSongContentKey(id))) ?? (await redis.get(getLegacySongContentKey(id)));
 }
 
 /**
@@ -199,8 +225,7 @@ export async function getSong(
   const needsContent = includeLyrics || includeTranslations || includeFurigana || includeSoramimi;
 
   // Fetch metadata (always needed)
-  const metaKey = getSongMetaKey(id);
-  const metaRaw = await redis.get(metaKey);
+  const metaRaw = await getSongMetaRaw(redis, id);
   const meta = parseJson<SongMetadata>(metaRaw);
 
   if (!meta) return null;
@@ -226,8 +251,7 @@ export async function getSong(
 
   // Fetch content if needed
   if (needsContent) {
-    const contentKey = getSongContentKey(id);
-    const contentRaw = await redis.get(contentKey);
+    const contentRaw = await getSongContentRaw(redis, id);
     const content = parseJson<SongContent>(contentRaw);
 
     if (content) {
@@ -343,15 +367,18 @@ export async function saveSong(
 
   // Save metadata to Redis
   await redis.set(getSongMetaKey(song.id), JSON.stringify(meta));
+  await redis.set(getLegacySongMetaKey(song.id), JSON.stringify(meta));
 
   // Save content to Redis (only if there's any content)
   const hasContent = content.lyrics || content.translations || content.furigana || 
                      content.soramimi || content.soramimiByLang;
   if (hasContent) {
     await redis.set(getSongContentKey(song.id), JSON.stringify(content));
+    await redis.set(getLegacySongContentKey(song.id), JSON.stringify(content));
   }
 
   // Add to the set of all song IDs
+  await redis.sadd(redisKeys.media.songIds(), song.id);
   await redis.sadd(SONG_SET_KEY, song.id);
 
   // Return combined document
@@ -363,15 +390,22 @@ export async function saveSong(
  */
 export async function deleteSong(redis: Redis, id: string): Promise<boolean> {
   const metaKey = getSongMetaKey(id);
+  const legacyMetaKey = getLegacySongMetaKey(id);
 
   // Check if exists
-  const exists = await redis.exists(metaKey);
+  const exists = await redis.exists(metaKey, legacyMetaKey);
   if (!exists) return false;
 
   // Delete both metadata and content keys
-  await redis.del(metaKey, getSongContentKey(id));
+  await redis.del(
+    metaKey,
+    legacyMetaKey,
+    getSongContentKey(id),
+    getLegacySongContentKey(id)
+  );
 
   // Remove from the set
+  await redis.srem(redisKeys.media.songIds(), id);
   await redis.srem(SONG_SET_KEY, id);
 
   return true;
@@ -383,18 +417,19 @@ export async function deleteSong(redis: Redis, id: string): Promise<boolean> {
  */
 export async function deleteAllSongs(redis: Redis): Promise<number> {
   // Get all song IDs
-  const songIds = await redis.smembers(SONG_SET_KEY);
+  const songIds = await getSongIds(redis);
   
   if (!songIds || songIds.length === 0) {
     return 0;
   }
 
   // Delete all metadata and content keys
-  const metaKeys = songIds.map((id) => getSongMetaKey(id));
-  const contentKeys = songIds.map((id) => getSongContentKey(id));
+  const metaKeys = songIds.flatMap((id) => [getSongMetaKey(id), getLegacySongMetaKey(id)]);
+  const contentKeys = songIds.flatMap((id) => [getSongContentKey(id), getLegacySongContentKey(id)]);
   await redis.del(...metaKeys, ...contentKeys);
 
   // Clear the set
+  await redis.del(redisKeys.media.songIds());
   await redis.del(SONG_SET_KEY);
 
   return songIds.length;
@@ -417,17 +452,15 @@ export async function getSongsVersionInfo(
   options: { createdBy?: string } = {}
 ): Promise<SongsVersionInfo> {
   const { createdBy } = options;
-  const songIds = await redis.smembers(SONG_SET_KEY);
+  const songIds = await getSongIds(redis);
   if (!songIds || songIds.length === 0) {
     return { version: 0, count: 0 };
   }
 
-  const metaKeys = songIds.map((id) => getSongMetaKey(id));
-  const rawMetas = await redis.mget(...metaKeys);
-
   let version = 0;
   let count = 0;
-  for (const rawMeta of rawMetas) {
+  for (const songId of songIds) {
+    const rawMeta = await getSongMetaRaw(redis, songId);
     if (!rawMeta) continue;
     const meta = parseJson<SongMetadata>(rawMeta);
     if (!meta) continue;
@@ -459,7 +492,7 @@ export async function listSongs(
   if (ids && ids.length > 0) {
     songIds = ids;
   } else {
-    songIds = await redis.smembers(SONG_SET_KEY);
+    songIds = await getSongIds(redis);
   }
 
   if (!songIds || songIds.length === 0) {
@@ -470,20 +503,9 @@ export async function listSongs(
   const needsContent = getOptions.includeLyrics || getOptions.includeTranslations || 
                        getOptions.includeFurigana || getOptions.includeSoramimi;
 
-  // Fetch all metadata (lightweight, ~300 bytes per song)
-  const metaKeys = songIds.map((id) => getSongMetaKey(id));
-  const rawMetas = await redis.mget(...metaKeys);
-
-  // Fetch content only if needed (heavy data)
-  let rawContents: (string | null)[] | null = null;
-  if (needsContent) {
-    const contentKeys = songIds.map((id) => getSongContentKey(id));
-    rawContents = await redis.mget(...contentKeys) as (string | null)[];
-  }
-
   const songs: SongDocument[] = [];
-  for (let i = 0; i < rawMetas.length; i++) {
-    const rawMeta = rawMetas[i];
+  for (const songId of songIds) {
+    const rawMeta = await getSongMetaRaw(redis, songId);
     if (!rawMeta) continue;
 
     const meta = parseJson<SongMetadata>(rawMeta);
@@ -513,8 +535,8 @@ export async function listSongs(
     }
 
     // Add content if fetched
-    if (needsContent && rawContents) {
-      const rawContent = rawContents[i];
+    if (needsContent) {
+      const rawContent = await getSongContentRaw(redis, songId);
       if (rawContent) {
         const content = parseJson<SongContent>(rawContent);
         if (content) {
@@ -588,13 +610,15 @@ export async function saveLyrics(
 ): Promise<SongDocument> {
   const metaKey = getSongMetaKey(id);
   const contentKey = getSongContentKey(id);
+  const legacyMetaKey = getLegacySongMetaKey(id);
+  const legacyContentKey = getLegacySongContentKey(id);
   const now = Date.now();
 
   // Get existing metadata
-  const existingMeta = parseJson<SongMetadata>(await redis.get(metaKey));
+  const existingMeta = parseJson<SongMetadata>(await getSongMetaRaw(redis, id));
   
   // Get existing content to preserve other fields
-  const existingContent = parseJson<SongContent>(await redis.get(contentKey));
+  const existingContent = parseJson<SongContent>(await getSongContentRaw(redis, id));
 
   // Check if lyrics source changed (compare by hash)
   // If changed, we need to clear cached annotations since they're tied to the old lyrics
@@ -635,7 +659,10 @@ export async function saveLyrics(
 
   // Save both keys
   await redis.set(metaKey, JSON.stringify(meta));
+  await redis.set(legacyMetaKey, JSON.stringify(meta));
   await redis.set(contentKey, JSON.stringify(content));
+  await redis.set(legacyContentKey, JSON.stringify(content));
+  await redis.sadd(redisKeys.media.songIds(), id);
   await redis.sadd(SONG_SET_KEY, id);
 
   return { ...meta, ...content };
@@ -651,15 +678,15 @@ export async function saveTranslation(
   language: string,
   translatedLrc: string
 ): Promise<SongDocument | null> {
-  const metaKey = getSongMetaKey(id);
   const contentKey = getSongContentKey(id);
+  const legacyContentKey = getLegacySongContentKey(id);
 
   // Verify song exists
-  const existingMeta = parseJson<SongMetadata>(await redis.get(metaKey));
+  const existingMeta = parseJson<SongMetadata>(await getSongMetaRaw(redis, id));
   if (!existingMeta) return null;
 
   // Get existing content
-  const existingContent = parseJson<SongContent>(await redis.get(contentKey)) ?? {};
+  const existingContent = parseJson<SongContent>(await getSongContentRaw(redis, id)) ?? {};
 
   // Update translations
   const content: SongContent = {
@@ -669,6 +696,7 @@ export async function saveTranslation(
 
   // Save content key only
   await redis.set(contentKey, JSON.stringify(content));
+  await redis.set(legacyContentKey, JSON.stringify(content));
 
   return { ...existingMeta, ...content };
 }
@@ -682,15 +710,15 @@ export async function saveFurigana(
   id: string,
   furigana: FuriganaSegment[][]
 ): Promise<SongDocument | null> {
-  const metaKey = getSongMetaKey(id);
   const contentKey = getSongContentKey(id);
+  const legacyContentKey = getLegacySongContentKey(id);
 
   // Verify song exists
-  const existingMeta = parseJson<SongMetadata>(await redis.get(metaKey));
+  const existingMeta = parseJson<SongMetadata>(await getSongMetaRaw(redis, id));
   if (!existingMeta) return null;
 
   // Get existing content
-  const existingContent = parseJson<SongContent>(await redis.get(contentKey)) ?? {};
+  const existingContent = parseJson<SongContent>(await getSongContentRaw(redis, id)) ?? {};
 
   // Update furigana
   const content: SongContent = {
@@ -700,6 +728,7 @@ export async function saveFurigana(
 
   // Save content key only
   await redis.set(contentKey, JSON.stringify(content));
+  await redis.set(legacyContentKey, JSON.stringify(content));
 
   return { ...existingMeta, ...content };
 }
@@ -715,15 +744,15 @@ export async function saveSoramimi(
   soramimi: FuriganaSegment[][],
   language?: "zh-TW" | "en"
 ): Promise<SongDocument | null> {
-  const metaKey = getSongMetaKey(id);
   const contentKey = getSongContentKey(id);
+  const legacyContentKey = getLegacySongContentKey(id);
 
   // Verify song exists
-  const existingMeta = parseJson<SongMetadata>(await redis.get(metaKey));
+  const existingMeta = parseJson<SongMetadata>(await getSongMetaRaw(redis, id));
   if (!existingMeta) return null;
 
   // Get existing content
-  const existingContent = parseJson<SongContent>(await redis.get(contentKey)) ?? {};
+  const existingContent = parseJson<SongContent>(await getSongContentRaw(redis, id)) ?? {};
 
   // Update soramimi (use language-specific field if language provided)
   const content: SongContent = {
@@ -735,6 +764,7 @@ export async function saveSoramimi(
 
   // Save content key only
   await redis.set(contentKey, JSON.stringify(content));
+  await redis.set(legacyContentKey, JSON.stringify(content));
 
   return { ...existingMeta, ...content };
 }

--- a/api/_utils/auth/_password-storage.ts
+++ b/api/_utils/auth/_password-storage.ts
@@ -7,6 +7,7 @@
 
 import type { Redis } from "../redis.js";
 import { PASSWORD_HASH_PREFIX } from "./_constants.js";
+import { redisKeys } from "../../../src/shared/redisKeys.js";
 
 // Re-export constants for convenience
 export {
@@ -21,6 +22,10 @@ function getPasswordKey(username: string): string {
   return `${PASSWORD_HASH_PREFIX}${username.toLowerCase()}`;
 }
 
+function getCanonicalPasswordKey(username: string): string {
+  return redisKeys.auth.userPassword(username);
+}
+
 /**
  * Set or update a user's password hash
  */
@@ -29,7 +34,7 @@ export async function setUserPasswordHash(
   username: string,
   passwordHash: string
 ): Promise<void> {
-  const key = getPasswordKey(username);
+  const key = getCanonicalPasswordKey(username);
   await redis.set(key, passwordHash);
 }
 
@@ -40,8 +45,10 @@ export async function getUserPasswordHash(
   redis: Redis,
   username: string
 ): Promise<string | null> {
-  const key = getPasswordKey(username);
-  return await redis.get(key);
+  return (
+    (await redis.get<string>(getCanonicalPasswordKey(username))) ??
+    (await redis.get<string>(getPasswordKey(username)))
+  );
 }
 
 /**
@@ -51,8 +58,7 @@ export async function deleteUserPasswordHash(
   redis: Redis,
   username: string
 ): Promise<void> {
-  const key = getPasswordKey(username);
-  await redis.del(key);
+  await redis.del(getCanonicalPasswordKey(username), getPasswordKey(username));
 }
 
 /**

--- a/api/_utils/auth/_tokens.ts
+++ b/api/_utils/auth/_tokens.ts
@@ -248,5 +248,4 @@ export async function refreshTokenTTL(
   const tokenHash = await sha256RedisIdentifier(token);
   await redis.expire(redisKeys.auth.session(tokenHash), USER_TTL_SECONDS);
   await redis.expire(redisKeys.auth.userSessions(normalizedUsername), USER_TTL_SECONDS);
-  await redis.expire(getUserTokenKey(normalizedUsername, token), USER_TTL_SECONDS);
 }

--- a/api/_utils/auth/_tokens.ts
+++ b/api/_utils/auth/_tokens.ts
@@ -13,6 +13,7 @@ import {
   USER_EXPIRATION_TIME,
   TOKEN_GRACE_PERIOD,
 } from "./_constants.js";
+import { redisKeys, sha256RedisIdentifier } from "../../../src/shared/redisKeys.js";
 
 // ============================================================================
 // Key Helpers
@@ -26,6 +27,14 @@ export function getUserTokenKey(username: string, token: string): string {
   return `${AUTH_TOKEN_PREFIX}user:${username.toLowerCase()}:${token}`;
 }
 
+export async function getCanonicalSessionKey(token: string): Promise<string> {
+  return redisKeys.auth.session(await sha256RedisIdentifier(token));
+}
+
+export async function getCanonicalUserSessionsKey(username: string): Promise<string> {
+  return redisKeys.auth.userSessions(username);
+}
+
 /**
  * Get pattern for scanning all tokens for a user
  */
@@ -37,6 +46,10 @@ export function getUserTokenPattern(username: string): string {
  * Build the Redis key for grace-period token storage
  */
 export function getLastTokenKey(username: string): string {
+  return redisKeys.auth.lastSession(username);
+}
+
+export function getLegacyLastTokenKey(username: string): string {
   return `${AUTH_TOKEN_PREFIX}last:${username.toLowerCase()}`;
 }
 
@@ -71,9 +84,12 @@ export async function storeToken(
   if (!token) return;
   
   const normalizedUsername = username.toLowerCase();
-  const key = getUserTokenKey(normalizedUsername, token);
+  const tokenHash = await sha256RedisIdentifier(token);
+  const key = redisKeys.auth.session(tokenHash);
   
   await redis.set(key, Date.now(), { ex: USER_EXPIRATION_TIME });
+  await redis.sadd(redisKeys.auth.userSessions(normalizedUsername), tokenHash);
+  await redis.expire(redisKeys.auth.userSessions(normalizedUsername), USER_EXPIRATION_TIME);
 }
 
 /**
@@ -84,6 +100,20 @@ export async function deleteToken(
   token: string
 ): Promise<void> {
   if (!token) return;
+  const tokenHash = await sha256RedisIdentifier(token);
+  await redis.del(redisKeys.auth.session(tokenHash));
+
+  let canonicalCursor = 0;
+  do {
+    const [newCursor, foundKeys] = await redis.scan(canonicalCursor, {
+      match: "auth:user:*:sessions",
+      count: 100,
+    });
+    canonicalCursor = parseInt(String(newCursor));
+    for (const key of foundKeys) {
+      await redis.srem(key, tokenHash);
+    }
+  } while (canonicalCursor !== 0);
 
   // Find and delete the token key by scanning
   const pattern = `${AUTH_TOKEN_PREFIX}user:*:${token}`;
@@ -119,6 +149,15 @@ export async function deleteAllUserTokens(
   const userTokenKeys: string[] = [];
   let cursor = 0;
 
+  const canonicalSessionSetKey = redisKeys.auth.userSessions(normalizedUsername);
+  const tokenHashes = await redis.smembers<string[]>(canonicalSessionSetKey);
+  if (tokenHashes.length > 0) {
+    deletedCount += await redis.del(
+      ...tokenHashes.map((tokenHash) => redisKeys.auth.session(tokenHash))
+    );
+  }
+  deletedCount += await redis.del(canonicalSessionSetKey);
+
   do {
     const [newCursor, foundKeys] = await redis.scan(cursor, {
       match: pattern,
@@ -137,6 +176,7 @@ export async function deleteAllUserTokens(
   const lastTokenKey = getLastTokenKey(normalizedUsername);
   const lastDeleted = await redis.del(lastTokenKey);
   deletedCount += lastDeleted;
+  deletedCount += await redis.del(getLegacyLastTokenKey(normalizedUsername));
 
   return deletedCount;
 }
@@ -148,7 +188,15 @@ export async function getUserTokens(
   redis: Redis,
   username: string
 ): Promise<TokenInfo[]> {
-  const pattern = getUserTokenPattern(username);
+  const normalizedUsername = username.toLowerCase();
+  const tokenHashes = await redis.smembers<string[]>(redisKeys.auth.userSessions(normalizedUsername));
+  const canonicalTokens = await Promise.all(
+    tokenHashes.map(async (tokenHash) => ({
+      token: tokenHash,
+      createdAt: await redis.get<number | string>(redisKeys.auth.session(tokenHash)),
+    }))
+  );
+  const pattern = getUserTokenPattern(normalizedUsername);
   const tokens: TokenInfo[] = [];
   let cursor = 0;
 
@@ -167,7 +215,7 @@ export async function getUserTokens(
     }
   } while (cursor !== 0);
 
-  return tokens;
+  return [...canonicalTokens, ...tokens];
 }
 
 /**
@@ -196,6 +244,9 @@ export async function refreshTokenTTL(
   username: string,
   token: string
 ): Promise<void> {
-  const key = getUserTokenKey(username.toLowerCase(), token);
-  await redis.expire(key, USER_TTL_SECONDS);
+  const normalizedUsername = username.toLowerCase();
+  const tokenHash = await sha256RedisIdentifier(token);
+  await redis.expire(redisKeys.auth.session(tokenHash), USER_TTL_SECONDS);
+  await redis.expire(redisKeys.auth.userSessions(normalizedUsername), USER_TTL_SECONDS);
+  await redis.expire(getUserTokenKey(normalizedUsername, token), USER_TTL_SECONDS);
 }

--- a/api/_utils/auth/_user-record.ts
+++ b/api/_utils/auth/_user-record.ts
@@ -1,5 +1,5 @@
 /**
- * Helpers for reading and updating the stored user record (`chat:users:{username}`).
+ * Helpers for reading and updating the stored user record.
  *
  * The record is persisted as a JSON string (or, on some Redis backends, an
  * already-parsed object), so callers must tolerate both shapes.
@@ -7,6 +7,7 @@
 
 import type { Redis } from "../redis.js";
 import { CHAT_USERS_PREFIX } from "./_constants.js";
+import { redisKeys } from "../../../src/shared/redisKeys.js";
 
 export interface StoredUserRecord {
   username?: string;
@@ -41,6 +42,10 @@ export function isUserBanned(userData: unknown): boolean {
   return parseStoredUser(userData)?.banned === true;
 }
 
+export function getLegacyStoredUserKey(username: string): string {
+  return `${CHAT_USERS_PREFIX}${username.toLowerCase()}`;
+}
+
 /**
  * Validate a browser-provided IANA timezone. Returns null for unknown/invalid
  * values so we never persist misleading prompt context.
@@ -67,7 +72,22 @@ export async function getStoredUserRecord(
   redis: Redis,
   username: string
 ): Promise<StoredUserRecord | null> {
-  return parseStoredUser(await redis.get(`${CHAT_USERS_PREFIX}${username.toLowerCase()}`));
+  const normalizedUsername = username.toLowerCase();
+  return parseStoredUser(
+    (await redis.get(redisKeys.auth.userProfile(normalizedUsername))) ??
+      (await redis.get(getLegacyStoredUserKey(normalizedUsername)))
+  );
+}
+
+export async function setStoredUserRecord(
+  redis: Redis,
+  username: string,
+  record: StoredUserRecord
+): Promise<void> {
+  await redis.set(
+    redisKeys.auth.userProfile(username.toLowerCase()),
+    JSON.stringify(record)
+  );
 }
 
 export async function getStoredUserTimeZone(
@@ -93,8 +113,8 @@ export async function updateStoredUserTimeZone(
     return null;
   }
 
-  const key = `${CHAT_USERS_PREFIX}${username.toLowerCase()}`;
-  const existingRecord = parseStoredUser(await redis.get(key));
+  const key = redisKeys.auth.userProfile(username.toLowerCase());
+  const existingRecord = await getStoredUserRecord(redis, username);
   if (!existingRecord) {
     return null;
   }

--- a/api/_utils/auth/_validate.ts
+++ b/api/_utils/auth/_validate.ts
@@ -79,8 +79,9 @@ export async function validateAuth(
   const exists = await redis.exists(userScopedKey);
   
   if (exists) {
-    // Refresh TTL on successful validation
-    await redis.expire(userScopedKey, USER_TTL_SECONDS);
+    await redis.set(canonicalSessionKey, Date.now(), { ex: USER_TTL_SECONDS });
+    await redis.sadd(redisKeys.auth.userSessions(normalizedUsername), tokenHash);
+    await redis.expire(redisKeys.auth.userSessions(normalizedUsername), USER_TTL_SECONDS);
     return { valid: true, expired: false };
   }
 

--- a/api/_utils/auth/_validate.ts
+++ b/api/_utils/auth/_validate.ts
@@ -11,7 +11,13 @@ import {
   USER_TTL_SECONDS,
   TOKEN_GRACE_PERIOD,
 } from "./_constants.js";
-import { getUserTokenKey, getLastTokenKey } from "./_tokens.js";
+import {
+  getCanonicalSessionKey,
+  getLegacyLastTokenKey,
+  getUserTokenKey,
+  getLastTokenKey,
+} from "./_tokens.js";
+import { redisKeys, sha256RedisIdentifier } from "../../../src/shared/redisKeys.js";
 
 // ============================================================================
 // Validation Options
@@ -52,7 +58,23 @@ export async function validateAuth(
 
   const normalizedUsername = username.toLowerCase();
 
-  // 1. Check active token: chat:token:user:{username}:{token}
+  // 1. Check canonical active token:
+  // auth:session:{sha256(token)} + auth:user:{username}:sessions membership.
+  const tokenHash = await sha256RedisIdentifier(token);
+  const canonicalSessionKey = await getCanonicalSessionKey(token);
+  const canonicalSessionExists = await redis.exists(canonicalSessionKey);
+  if (canonicalSessionExists) {
+    const sessionHashes = await redis.smembers<string[]>(
+      redisKeys.auth.userSessions(normalizedUsername)
+    );
+    if (sessionHashes.includes(tokenHash)) {
+      await redis.expire(canonicalSessionKey, USER_TTL_SECONDS);
+      await redis.expire(redisKeys.auth.userSessions(normalizedUsername), USER_TTL_SECONDS);
+      return { valid: true, expired: false };
+    }
+  }
+
+  // 2. Check legacy active token: chat:token:user:{username}:{token}
   const userScopedKey = getUserTokenKey(normalizedUsername, token);
   const exists = await redis.exists(userScopedKey);
   
@@ -62,10 +84,12 @@ export async function validateAuth(
     return { valid: true, expired: false };
   }
 
-  // 2. Check grace period for recently expired tokens (if allowed)
+  // 3. Check grace period for recently expired tokens (if allowed)
   if (allowExpired) {
     const lastTokenKey = getLastTokenKey(normalizedUsername);
-    const lastTokenData = await redis.get<string>(lastTokenKey);
+    const lastTokenData =
+      (await redis.get<string>(lastTokenKey)) ??
+      (await redis.get<string>(getLegacyLastTokenKey(normalizedUsername)));
 
     if (lastTokenData) {
       try {
@@ -98,6 +122,13 @@ export async function tokenExists(
   username: string,
   token: string
 ): Promise<boolean> {
+  const tokenHash = await sha256RedisIdentifier(token);
+  if (await redis.exists(redisKeys.auth.session(tokenHash))) {
+    const sessionHashes = await redis.smembers<string[]>(
+      redisKeys.auth.userSessions(username.toLowerCase())
+    );
+    if (sessionHashes.includes(tokenHash)) return true;
+  }
   const key = getUserTokenKey(username.toLowerCase(), token);
   const exists = await redis.exists(key);
   return exists > 0;

--- a/api/_utils/irc/_bridge.ts
+++ b/api/_utils/irc/_bridge.ts
@@ -36,13 +36,11 @@ import {
   getAllRoomIds,
   getCurrentTimestamp,
   getRoom,
-  parseRoomData,
   setRoom,
 } from "../../rooms/_helpers/_redis.js";
 import { refreshRoomUserCount } from "../../rooms/_helpers/_presence.js";
 import { createRedis } from "../redis.js";
 import { broadcastNewMessage } from "../../rooms/_helpers/_pusher.js";
-import { CHAT_ROOM_PREFIX } from "../../rooms/_helpers/_constants.js";
 import { escapeHTML, filterProfanityPreservingUrls } from "../_validation.js";
 
 // Use createRequire so we can load the CommonJS-only `irc-framework` module
@@ -145,16 +143,8 @@ export class IrcBridge extends EventEmitter {
       const roomIds = await getAllRoomIds();
       if (roomIds.length === 0) return;
 
-      const redis = createRedis();
-      const keys = roomIds.map((id) => `${CHAT_ROOM_PREFIX}${id}`);
-      const raws = await redis.mget<(Room | string | null)[]>(
-        ...(keys as [string, ...string[]])
-      );
-
-      for (let i = 0; i < raws.length; i++) {
-        const raw = raws[i];
-        if (!raw) continue;
-        const room = parseRoomData(raw);
+      for (const roomId of roomIds) {
+        const room = await getRoom(roomId);
         if (!room) continue;
         if (room.type !== "irc") continue;
         if (!room.ircChannel) continue;

--- a/api/_utils/irc/_servers.ts
+++ b/api/_utils/irc/_servers.ts
@@ -18,6 +18,7 @@ import {
   DEFAULT_IRC_TLS,
 } from "./_types.js";
 import type { IrcServer } from "../../../src/shared/contracts/irc.js";
+import { redisKeys } from "../../../src/shared/redisKeys.js";
 export type { IrcServer } from "../../../src/shared/contracts/irc.js";
 
 export const IRC_SERVER_PREFIX = "chat:irc:server:";
@@ -65,19 +66,25 @@ function parseServerData(raw: unknown): IrcServer | null {
  */
 export async function setIrcServer(server: IrcServer): Promise<void> {
   const redis = getRedis();
+  await redis.set(redisKeys.integration.ircServer(server.id), JSON.stringify(server));
   await redis.set(`${IRC_SERVER_PREFIX}${server.id}`, JSON.stringify(server));
+  await redis.sadd(redisKeys.integration.ircServerIds(), server.id);
   await redis.sadd(IRC_SERVERS_SET, server.id);
 }
 
 export async function getIrcServer(id: string): Promise<IrcServer | null> {
   const redis = getRedis();
-  const raw = await redis.get(`${IRC_SERVER_PREFIX}${id}`);
+  const raw =
+    (await redis.get(redisKeys.integration.ircServer(id))) ??
+    (await redis.get(`${IRC_SERVER_PREFIX}${id}`));
   return parseServerData(raw);
 }
 
 export async function deleteIrcServer(id: string): Promise<void> {
   const redis = getRedis();
+  await redis.del(redisKeys.integration.ircServer(id));
   await redis.del(`${IRC_SERVER_PREFIX}${id}`);
+  await redis.srem(redisKeys.integration.ircServerIds(), id);
   await redis.srem(IRC_SERVERS_SET, id);
 }
 
@@ -87,24 +94,29 @@ export async function deleteIrcServer(id: string): Promise<void> {
  */
 export async function listIrcServers(): Promise<IrcServer[]> {
   const redis = getRedis();
-  let ids = (await redis.smembers<string[]>(IRC_SERVERS_SET)) || [];
+  let ids = [
+    ...new Set([
+      ...((await redis.smembers<string[]>(redisKeys.integration.ircServerIds())) || []),
+      ...((await redis.smembers<string[]>(IRC_SERVERS_SET)) || []),
+    ]),
+  ];
 
   if (!ids.includes(DEFAULT_SERVER_ID)) {
     const seed: IrcServer = { ...DEFAULT_SERVER, createdAt: Date.now() };
     await setIrcServer(seed);
-    ids = await redis.smembers<string[]>(IRC_SERVERS_SET);
+    ids = [
+      ...new Set([
+        ...((await redis.smembers<string[]>(redisKeys.integration.ircServerIds())) || []),
+        ...((await redis.smembers<string[]>(IRC_SERVERS_SET)) || []),
+      ]),
+    ];
   }
 
   if (ids.length === 0) return [];
 
-  const keys = ids.map((id) => `${IRC_SERVER_PREFIX}${id}`);
-  const raws = await redis.mget<(IrcServer | string | null)[]>(
-    ...(keys as [string, ...string[]])
-  );
-
   const servers: IrcServer[] = [];
-  for (let i = 0; i < raws.length; i++) {
-    const parsed = parseServerData(raws[i]);
+  for (const id of ids) {
+    const parsed = await getIrcServer(id);
     if (parsed) servers.push(parsed);
   }
 

--- a/api/_utils/irc/_servers.ts
+++ b/api/_utils/irc/_servers.ts
@@ -67,9 +67,7 @@ function parseServerData(raw: unknown): IrcServer | null {
 export async function setIrcServer(server: IrcServer): Promise<void> {
   const redis = getRedis();
   await redis.set(redisKeys.integration.ircServer(server.id), JSON.stringify(server));
-  await redis.set(`${IRC_SERVER_PREFIX}${server.id}`, JSON.stringify(server));
   await redis.sadd(redisKeys.integration.ircServerIds(), server.id);
-  await redis.sadd(IRC_SERVERS_SET, server.id);
 }
 
 export async function getIrcServer(id: string): Promise<IrcServer | null> {

--- a/api/_utils/realtime-auth.ts
+++ b/api/_utils/realtime-auth.ts
@@ -91,9 +91,6 @@ export async function issueRealtimeTicket(
   await redis.set(redisKeys.realtime.ticket(await sha256RedisIdentifier(ticket)), username.toLowerCase(), {
     ex: REALTIME_TICKET_TTL_SECONDS,
   });
-  await redis.set(`${REALTIME_TICKET_PREFIX}${ticket}`, username.toLowerCase(), {
-    ex: REALTIME_TICKET_TTL_SECONDS,
-  });
   return ticket;
 }
 

--- a/api/_utils/realtime-auth.ts
+++ b/api/_utils/realtime-auth.ts
@@ -15,6 +15,7 @@ import {
   classifyRealtimeChannel,
   sanitizeUsernameForRealtimeChannel,
 } from "../../src/shared/constants/realtime.js";
+import { redisKeys, sha256RedisIdentifier } from "../../src/shared/redisKeys.js";
 import { getRoom } from "../rooms/_helpers/_redis.js";
 import { isPrivateRoom, isRoomMember } from "../rooms/_helpers/_access.js";
 
@@ -87,6 +88,9 @@ export async function issueRealtimeTicket(
   username: string
 ): Promise<string> {
   const ticket = generateTicket();
+  await redis.set(redisKeys.realtime.ticket(await sha256RedisIdentifier(ticket)), username.toLowerCase(), {
+    ex: REALTIME_TICKET_TTL_SECONDS,
+  });
   await redis.set(`${REALTIME_TICKET_PREFIX}${ticket}`, username.toLowerCase(), {
     ex: REALTIME_TICKET_TTL_SECONDS,
   });
@@ -102,9 +106,10 @@ export async function consumeRealtimeTicket(
   ticket: string | null | undefined
 ): Promise<string | null> {
   if (!ticket) return null;
-  const key = `${REALTIME_TICKET_PREFIX}${ticket}`;
-  const username = await redis.get<string>(key);
+  const key = redisKeys.realtime.ticket(await sha256RedisIdentifier(ticket));
+  const legacyKey = `${REALTIME_TICKET_PREFIX}${ticket}`;
+  const username = (await redis.get<string>(key)) ?? (await redis.get<string>(legacyKey));
   if (!username) return null;
-  await redis.del(key);
+  await redis.del(key, legacyKey);
   return typeof username === "string" ? username : String(username);
 }

--- a/api/_utils/redis-key-migration.ts
+++ b/api/_utils/redis-key-migration.ts
@@ -1,4 +1,4 @@
-import type { Redis } from "./redis.js";
+import type { Redis, RedisSortedSetEntry } from "./redis.js";
 import { ensureSync2Initialized } from "../sync/v2/_core.js";
 import {
   LEGACY_REDIS_SCAN_PATTERNS,
@@ -359,6 +359,14 @@ export async function planRedisKeyMigration(
     if (builder && username) {
       return { legacyKey, targetKey: builder(username), action: "copy" };
     }
+    if (family === "log" && username) {
+      return {
+        legacyKey,
+        targetKey: null,
+        action: "skip",
+        reason: undefined,
+      };
+    }
     if (legacyKey === "sync2:maint:cursor") {
       return { legacyKey, targetKey: redisKeys.sync.maintenanceCursor(), action: "copy" };
     }
@@ -465,6 +473,91 @@ export async function planRedisKeyMigration(
   };
 }
 
+function parseZrangeWithScores(
+  raw: unknown,
+  expectedCount: number
+): RedisSortedSetEntry[] | null {
+  if (!Array.isArray(raw)) return null;
+  if (raw.length === 0) return expectedCount === 0 ? [] : null;
+
+  if (raw.every((entry) => Array.isArray(entry) && entry.length >= 2)) {
+    const parsed = raw
+      .map((entry) => {
+        const [member, score] = entry as [unknown, unknown];
+        return {
+          member: typeof member === "string" ? member : String(member),
+          score: Number(score),
+        };
+      })
+      .filter((entry) => Number.isFinite(entry.score));
+    return parsed.length === expectedCount ? parsed : null;
+  }
+
+  if (
+    raw.every(
+      (entry) =>
+        entry &&
+        typeof entry === "object" &&
+        "member" in entry &&
+        "score" in entry
+    )
+  ) {
+    const parsed = raw
+      .map((entry) => {
+        const candidate = entry as { member: unknown; score: unknown };
+        return {
+          member:
+            typeof candidate.member === "string"
+              ? candidate.member
+              : String(candidate.member),
+          score: Number(candidate.score),
+        };
+      })
+      .filter((entry) => Number.isFinite(entry.score));
+    return parsed.length === expectedCount ? parsed : null;
+  }
+
+  if (raw.length !== expectedCount * 2) return null;
+  const parsed: RedisSortedSetEntry[] = [];
+  for (let index = 0; index < raw.length; index += 2) {
+    const member = raw[index];
+    const score = Number(raw[index + 1]);
+    if (!Number.isFinite(score)) return null;
+    parsed.push({
+      member: typeof member === "string" ? member : String(member),
+      score,
+    });
+  }
+  return parsed.length === expectedCount ? parsed : null;
+}
+
+async function zrangeWithScores(
+  redis: Redis,
+  key: string
+): Promise<RedisSortedSetEntry[] | null> {
+  const redisWithScores = redis as Redis & {
+    zrangeWithScores?: (
+      key: string,
+      start: number,
+      stop: number
+    ) => Promise<RedisSortedSetEntry[]>;
+  };
+  if (typeof redisWithScores.zrangeWithScores === "function") {
+    return await redisWithScores.zrangeWithScores(key, 0, -1);
+  }
+
+  const redisWithExtendedZrange = redis as Redis & {
+    zrange: (key: string, start: number, stop: number, options: unknown) => Promise<unknown>;
+  };
+  try {
+    const expectedCount = await redis.zcard(key);
+    const raw = await redisWithExtendedZrange.zrange(key, 0, -1, { withScores: true });
+    return parseZrangeWithScores(raw, expectedCount);
+  } catch {
+    return null;
+  }
+}
+
 async function copyRedisValue(
   redis: Redis,
   sourceKey: string,
@@ -500,7 +593,18 @@ async function copyRedisValue(
       return null;
     }
     case "zset":
-      return `Skipped ${sourceKey}: score-preserving zset copy is not supported by RedisLike`;
+      {
+        const entries = await zrangeWithScores(redis, sourceKey);
+        if (!entries) {
+          return `Skipped ${sourceKey}: score-preserving zset copy is not supported by this Redis client`;
+        }
+        await redis.del(targetKey);
+        for (const entry of entries) {
+          await redis.zadd(targetKey, entry);
+        }
+        if (ttl > 0) await redis.expire(targetKey, ttl);
+        return null;
+      }
     case "none":
       return `Skipped ${sourceKey}: key no longer exists`;
     default:

--- a/api/_utils/redis-key-migration.ts
+++ b/api/_utils/redis-key-migration.ts
@@ -1,0 +1,559 @@
+import type { Redis } from "./redis.js";
+import {
+  LEGACY_REDIS_SCAN_PATTERNS,
+  redisKeys,
+  sha256RedisIdentifier,
+  type LegacyRedisScanPattern,
+} from "../../src/shared/redisKeys.js";
+
+export interface RedisLegacyPatternStatus {
+  pattern: LegacyRedisScanPattern;
+  count: number;
+  sampleKeys: string[];
+  truncated: boolean;
+}
+
+export interface RedisMigrationStatus {
+  checkedAt: string;
+  perPatternLimit: number;
+  totalLegacyKeys: number;
+  truncated: boolean;
+  patterns: RedisLegacyPatternStatus[];
+}
+
+export interface RedisKeyMigrationPlan {
+  legacyKey: string;
+  targetKey: string | null;
+  additionalKeys?: string[];
+  action: "copy" | "skip";
+  reason?: string;
+}
+
+export interface RedisBackfillResult {
+  pattern: string;
+  dryRun: boolean;
+  scanned: number;
+  planned: number;
+  copied: number;
+  skipped: number;
+  warnings: string[];
+  truncated: boolean;
+  keys: RedisKeyMigrationPlan[];
+}
+
+export interface RedisDeleteLegacyResult {
+  pattern: string;
+  dryRun: boolean;
+  scanned: number;
+  deleted: number;
+  truncated: boolean;
+  keys: string[];
+}
+
+const LEGACY_PATTERN_SET = new Set<string>(LEGACY_REDIS_SCAN_PATTERNS);
+const STATUS_SCAN_COUNT = 1000;
+
+function isKnownLegacyPattern(pattern: string): pattern is LegacyRedisScanPattern {
+  return LEGACY_PATTERN_SET.has(pattern);
+}
+
+export function assertKnownLegacyRedisPattern(pattern: string): void {
+  if (!isKnownLegacyPattern(pattern)) {
+    throw new Error("Pattern must be one of the registered legacy Redis patterns");
+  }
+}
+
+function suffixAfter(key: string, prefix: string): string {
+  return key.slice(prefix.length);
+}
+
+function splitSuffix(key: string, prefix: string): string[] {
+  const suffix = suffixAfter(key, prefix);
+  return suffix ? suffix.split(":") : [];
+}
+
+function safeDecode(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}
+
+async function scanKeys(
+  redis: Redis,
+  pattern: string,
+  limit: number
+): Promise<{ keys: string[]; truncated: boolean }> {
+  const keys: string[] = [];
+  const seen = new Set<string>();
+  let cursor: string | number = 0;
+  let iterations = 0;
+
+  do {
+    const [nextCursor, batch] = await redis.scan(cursor, {
+      match: pattern,
+      count: STATUS_SCAN_COUNT,
+    });
+    cursor = nextCursor;
+    iterations += 1;
+    for (const key of batch) {
+      if (!seen.has(key)) {
+        seen.add(key);
+        keys.push(key);
+        if (keys.length >= limit) break;
+      }
+    }
+  } while (
+    cursor !== 0 &&
+    cursor !== "0" &&
+    keys.length < limit &&
+    iterations < 250
+  );
+
+  return {
+    keys: keys.sort(),
+    truncated: keys.length >= limit || (cursor !== 0 && cursor !== "0"),
+  };
+}
+
+export async function getRedisMigrationStatus(
+  redis: Redis,
+  perPatternLimit: number
+): Promise<RedisMigrationStatus> {
+  const patterns: RedisLegacyPatternStatus[] = [];
+  for (const pattern of LEGACY_REDIS_SCAN_PATTERNS) {
+    const { keys, truncated } = await scanKeys(redis, pattern, perPatternLimit);
+    patterns.push({
+      pattern,
+      count: keys.length,
+      sampleKeys: keys.slice(0, 10),
+      truncated,
+    });
+  }
+
+  return {
+    checkedAt: new Date().toISOString(),
+    perPatternLimit,
+    totalLegacyKeys: patterns.reduce((sum, item) => sum + item.count, 0),
+    truncated: patterns.some((item) => item.truncated),
+    patterns,
+  };
+}
+
+export async function planRedisKeyMigration(
+  legacyKey: string
+): Promise<RedisKeyMigrationPlan> {
+  if (legacyKey === "airdrop:presence") {
+    return { legacyKey, targetKey: redisKeys.presence.airdropLobby(), action: "copy" };
+  }
+  if (legacyKey.startsWith("airdrop:transfer:")) {
+    return {
+      legacyKey,
+      targetKey: redisKeys.session.airdropTransfer(suffixAfter(legacyKey, "airdrop:transfer:")),
+      action: "copy",
+    };
+  }
+  if (legacyKey.startsWith("analytics:")) {
+    const [metric, ...rest] = splitSuffix(legacyKey, "analytics:");
+    if (["aiu", "daily", "ep", "st", "uv"].includes(metric) && rest.length > 0) {
+      return {
+        legacyKey,
+        targetKey: redisKeys.analytics.apiMetric(metric, rest.join(":")),
+        action: "copy",
+      };
+    }
+  }
+  if (legacyKey.startsWith("apple:artwork:")) {
+    return {
+      legacyKey,
+      targetKey: redisKeys.cache.appleArtwork(suffixAfter(legacyKey, "apple:artwork:")),
+      action: "copy",
+    };
+  }
+  if (legacyKey.startsWith("applet:share:")) {
+    return {
+      legacyKey,
+      targetKey: redisKeys.media.appletShare(suffixAfter(legacyKey, "applet:share:")),
+      action: "copy",
+    };
+  }
+  if (legacyKey === "chat:irc:servers") {
+    return { legacyKey, targetKey: redisKeys.integration.ircServerIds(), action: "copy" };
+  }
+  if (legacyKey.startsWith("chat:irc:server:")) {
+    return {
+      legacyKey,
+      targetKey: redisKeys.integration.ircServer(suffixAfter(legacyKey, "chat:irc:server:")),
+      action: "copy",
+    };
+  }
+  if (legacyKey.startsWith("chat:messages:")) {
+    return {
+      legacyKey,
+      targetKey: redisKeys.chat.roomMessages(suffixAfter(legacyKey, "chat:messages:")),
+      action: "copy",
+    };
+  }
+  if (legacyKey.startsWith("chat:password:")) {
+    return {
+      legacyKey,
+      targetKey: redisKeys.auth.userPassword(suffixAfter(legacyKey, "chat:password:")),
+      action: "copy",
+    };
+  }
+  if (legacyKey.startsWith("chat:presencez:") || legacyKey.startsWith("chat:presence:")) {
+    const roomId = legacyKey.startsWith("chat:presencez:")
+      ? suffixAfter(legacyKey, "chat:presencez:")
+      : suffixAfter(legacyKey, "chat:presence:");
+    return { legacyKey, targetKey: redisKeys.chat.roomPresence(roomId), action: "copy" };
+  }
+  if (legacyKey.startsWith("chat:room:users:")) {
+    return {
+      legacyKey,
+      targetKey: redisKeys.chat.roomPresence(suffixAfter(legacyKey, "chat:room:users:")),
+      action: "skip",
+      reason: "Delete-only legacy room user index has no current writer",
+    };
+  }
+  if (legacyKey.startsWith("chat:room:")) {
+    return {
+      legacyKey,
+      targetKey: redisKeys.chat.roomMeta(suffixAfter(legacyKey, "chat:room:")),
+      action: "copy",
+    };
+  }
+  if (legacyKey === "chat:rooms") {
+    return { legacyKey, targetKey: redisKeys.chat.roomIds(), action: "copy" };
+  }
+  if (legacyKey.startsWith("chat:token:user:")) {
+    const [username, ...tokenParts] = splitSuffix(legacyKey, "chat:token:user:");
+    const token = tokenParts.join(":");
+    if (!username || !token) {
+      return { legacyKey, targetKey: null, action: "skip", reason: "Malformed auth token key" };
+    }
+    const tokenHash = await sha256RedisIdentifier(token);
+    return {
+      legacyKey,
+      targetKey: redisKeys.auth.session(tokenHash),
+      additionalKeys: [redisKeys.auth.userSessions(username)],
+      action: "copy",
+    };
+  }
+  if (legacyKey.startsWith("chat:token:last:")) {
+    return {
+      legacyKey,
+      targetKey: redisKeys.auth.lastSession(suffixAfter(legacyKey, "chat:token:last:")),
+      action: "copy",
+    };
+  }
+  if (legacyKey.startsWith("chat:users:")) {
+    return {
+      legacyKey,
+      targetKey: redisKeys.auth.userProfile(suffixAfter(legacyKey, "chat:users:")),
+      action: "copy",
+    };
+  }
+  if (legacyKey.startsWith("cursor-sdk-agent:") && legacyKey.endsWith(":latestRun")) {
+    const agentId = legacyKey.slice("cursor-sdk-agent:".length, -":latestRun".length);
+    return { legacyKey, targetKey: redisKeys.agent.cursorLatestRun(agentId), action: "copy" };
+  }
+  if (legacyKey.startsWith("cursor-sdk-run:")) {
+    const parts = splitSuffix(legacyKey, "cursor-sdk-run:");
+    const facet = parts.at(-1);
+    const runId = parts.slice(0, -1).join(":");
+    if (runId && facet === "events") {
+      return { legacyKey, targetKey: redisKeys.agent.cursorRunEvents(runId), action: "copy" };
+    }
+    if (runId && facet === "meta") {
+      return { legacyKey, targetKey: redisKeys.agent.cursorRunMeta(runId), action: "copy" };
+    }
+  }
+  if (legacyKey.startsWith("geoip:v1:")) {
+    const ipHash = await sha256RedisIdentifier(suffixAfter(legacyKey, "geoip:v1:"));
+    return { legacyKey, targetKey: redisKeys.cache.geoip(ipHash), action: "copy" };
+  }
+  if (legacyKey.startsWith("ie:cache:")) {
+    const parts = splitSuffix(legacyKey, "ie:cache:");
+    const year = parts.at(-1);
+    const encodedUrl = parts.slice(0, -1).join(":");
+    if (year && encodedUrl) {
+      const urlHash = await sha256RedisIdentifier(safeDecode(encodedUrl));
+      return { legacyKey, targetKey: redisKeys.cache.ieVersions(urlHash, year), action: "copy" };
+    }
+  }
+  if (legacyKey === "listen:sessions") {
+    return { legacyKey, targetKey: redisKeys.session.listenIds(), action: "copy" };
+  }
+  if (legacyKey.startsWith("listen:session:")) {
+    return {
+      legacyKey,
+      targetKey: redisKeys.session.listen(suffixAfter(legacyKey, "listen:session:")),
+      action: "copy",
+    };
+  }
+  if (legacyKey.endsWith(":processing_lock") && legacyKey.startsWith("memory:user:")) {
+    const username = legacyKey.slice("memory:user:".length, -":processing_lock".length);
+    return { legacyKey, targetKey: redisKeys.memory.processingLock(username), action: "copy" };
+  }
+  if (legacyKey.startsWith("rl:")) {
+    return { legacyKey, targetKey: null, action: "skip", reason: "Ephemeral rate-limit key" };
+  }
+  if (legacyKey.startsWith("rt:ticket:")) {
+    const ticketHash = await sha256RedisIdentifier(suffixAfter(legacyKey, "rt:ticket:"));
+    return { legacyKey, targetKey: redisKeys.realtime.ticket(ticketHash), action: "copy" };
+  }
+  if (legacyKey === "song:all") {
+    return { legacyKey, targetKey: redisKeys.media.songIds(), action: "copy" };
+  }
+  if (legacyKey.startsWith("song:meta:")) {
+    return {
+      legacyKey,
+      targetKey: redisKeys.media.songMeta(suffixAfter(legacyKey, "song:meta:")),
+      action: "copy",
+    };
+  }
+  if (legacyKey.startsWith("song:content:")) {
+    return {
+      legacyKey,
+      targetKey: redisKeys.media.songContent(suffixAfter(legacyKey, "song:content:")),
+      action: "copy",
+    };
+  }
+  if (legacyKey.startsWith("sync2:")) {
+    const parts = splitSuffix(legacyKey, "sync2:");
+    const family = parts[0];
+    const username = parts.slice(1).join(":");
+    const byFamily: Record<string, ((username: string) => string) | undefined> = {
+      blobs: redisKeys.sync.v2Blobs,
+      jrnl: redisKeys.sync.v2Journal,
+      kv: redisKeys.sync.v2Kv,
+      lock: redisKeys.sync.v2Lock,
+      seq: redisKeys.sync.v2Seq,
+      "ttl-touched": redisKeys.sync.v2TtlTouched,
+    };
+    const builder = byFamily[family];
+    if (builder && username) {
+      return { legacyKey, targetKey: builder(username), action: "copy" };
+    }
+    if (legacyKey === "sync2:maint:cursor") {
+      return { legacyKey, targetKey: redisKeys.sync.maintenanceCursor(), action: "copy" };
+    }
+  }
+  if (legacyKey.startsWith("sync:meta:")) {
+    return {
+      legacyKey,
+      targetKey: redisKeys.sync.backupMeta(suffixAfter(legacyKey, "sync:meta:")),
+      action: "copy",
+    };
+  }
+  if (legacyKey.startsWith("sync:pref:autoSync:")) {
+    return {
+      legacyKey,
+      targetKey: redisKeys.sync.autoSyncPreference(suffixAfter(legacyKey, "sync:pref:autoSync:")),
+      action: "copy",
+    };
+  }
+  if (
+    legacyKey.startsWith("sync:state:") ||
+    legacyKey.startsWith("sync:auto:") ||
+    legacyKey.startsWith("sync:songs:")
+  ) {
+    return {
+      legacyKey,
+      targetKey: null,
+      action: "skip",
+      reason: "Legacy sync v1 data must be imported into sync v2 before deletion",
+    };
+  }
+  if (legacyKey.startsWith("telegram:link:code:")) {
+    return {
+      legacyKey,
+      targetKey: redisKeys.integration.telegramLinkCode(suffixAfter(legacyKey, "telegram:link:code:")),
+      action: "copy",
+    };
+  }
+  if (legacyKey.startsWith("telegram:link:username:")) {
+    return {
+      legacyKey,
+      targetKey: redisKeys.integration.telegramPendingLink(suffixAfter(legacyKey, "telegram:link:username:")),
+      action: "copy",
+    };
+  }
+  if (legacyKey.startsWith("telegram:user:")) {
+    return {
+      legacyKey,
+      targetKey: redisKeys.integration.telegramAccountByTelegramUser(suffixAfter(legacyKey, "telegram:user:")),
+      action: "copy",
+    };
+  }
+  if (legacyKey.startsWith("telegram:username:")) {
+    return {
+      legacyKey,
+      targetKey: redisKeys.integration.telegramAccountByUsername(suffixAfter(legacyKey, "telegram:username:")),
+      action: "copy",
+    };
+  }
+  if (legacyKey.startsWith("telegram:history:")) {
+    return {
+      legacyKey,
+      targetKey: redisKeys.integration.telegramHistory(suffixAfter(legacyKey, "telegram:history:")),
+      action: "copy",
+    };
+  }
+  if (legacyKey.startsWith("telegram:update:")) {
+    return {
+      legacyKey,
+      targetKey: redisKeys.integration.telegramUpdate(suffixAfter(legacyKey, "telegram:update:")),
+      action: "copy",
+    };
+  }
+  if (legacyKey.startsWith("telegram:heartbeat:")) {
+    const parts = splitSuffix(legacyKey, "telegram:heartbeat:");
+    const slot = parts.at(-1);
+    const username = parts.slice(0, -1).join(":");
+    if (username && slot) {
+      return {
+        legacyKey,
+        targetKey: redisKeys.integration.telegramHeartbeat(username, slot),
+        action: "copy",
+      };
+    }
+  }
+  if (legacyKey.startsWith("wayback:cache:")) {
+    const parts = splitSuffix(legacyKey, "wayback:cache:");
+    const year = parts.at(-1);
+    const encodedUrl = parts.slice(0, -1).join(":");
+    if (year && encodedUrl) {
+      const urlHash = await sha256RedisIdentifier(safeDecode(encodedUrl));
+      return { legacyKey, targetKey: redisKeys.cache.wayback(urlHash, year), action: "copy" };
+    }
+  }
+
+  return {
+    legacyKey,
+    targetKey: null,
+    action: "skip",
+    reason: "No canonical mapping registered for this legacy key",
+  };
+}
+
+async function copyRedisValue(
+  redis: Redis,
+  sourceKey: string,
+  targetKey: string
+): Promise<string | null> {
+  const type = await redis.type(sourceKey);
+  const ttl = await redis.ttl(sourceKey);
+  switch (type) {
+    case "string": {
+      const value = await redis.get(sourceKey);
+      await redis.set(targetKey, value, ttl > 0 ? { ex: ttl } : undefined);
+      return null;
+    }
+    case "list": {
+      const values = await redis.lrange<string>(sourceKey, 0, -1);
+      await redis.del(targetKey);
+      if (values.length > 0) await redis.rpush(targetKey, ...values);
+      if (ttl > 0) await redis.expire(targetKey, ttl);
+      return null;
+    }
+    case "set": {
+      const members = await redis.smembers<string[]>(sourceKey);
+      await redis.del(targetKey);
+      if (members.length > 0) await redis.sadd(targetKey, ...members);
+      if (ttl > 0) await redis.expire(targetKey, ttl);
+      return null;
+    }
+    case "hash": {
+      const hash = (await redis.hgetall<Record<string, unknown>>(sourceKey)) ?? {};
+      await redis.del(targetKey);
+      if (Object.keys(hash).length > 0) await redis.hset(targetKey, hash);
+      if (ttl > 0) await redis.expire(targetKey, ttl);
+      return null;
+    }
+    case "zset":
+      return `Skipped ${sourceKey}: score-preserving zset copy is not supported by RedisLike`;
+    case "none":
+      return `Skipped ${sourceKey}: key no longer exists`;
+    default:
+      return `Skipped ${sourceKey}: unsupported Redis type ${type}`;
+  }
+}
+
+async function applyAdditionalMigrationSideEffects(
+  redis: Redis,
+  plan: RedisKeyMigrationPlan
+): Promise<void> {
+  if (
+    plan.legacyKey.startsWith("chat:token:user:") &&
+    plan.targetKey &&
+    plan.additionalKeys?.length
+  ) {
+    const sessionSetKey = plan.additionalKeys[0];
+    const tokenHash = suffixAfter(plan.targetKey, "auth:session:");
+    await redis.sadd(sessionSetKey, tokenHash);
+    const ttl = await redis.ttl(plan.legacyKey);
+    if (ttl > 0) await redis.expire(sessionSetKey, ttl);
+  }
+}
+
+export async function backfillRedisKeyScheme(
+  redis: Redis,
+  input: { pattern: string; limit: number; dryRun: boolean }
+): Promise<RedisBackfillResult> {
+  assertKnownLegacyRedisPattern(input.pattern);
+  const { keys, truncated } = await scanKeys(redis, input.pattern, input.limit);
+  const plans = await Promise.all(keys.map((key) => planRedisKeyMigration(key)));
+  const warnings: string[] = [];
+  let copied = 0;
+  let skipped = 0;
+
+  for (const plan of plans) {
+    if (plan.action === "skip" || !plan.targetKey) {
+      skipped += 1;
+      if (plan.reason) warnings.push(`${plan.legacyKey}: ${plan.reason}`);
+      continue;
+    }
+    if (input.dryRun) {
+      continue;
+    }
+    const warning = await copyRedisValue(redis, plan.legacyKey, plan.targetKey);
+    if (warning) {
+      skipped += 1;
+      warnings.push(warning);
+      continue;
+    }
+    await applyAdditionalMigrationSideEffects(redis, plan);
+    copied += 1;
+  }
+
+  return {
+    pattern: input.pattern,
+    dryRun: input.dryRun,
+    scanned: keys.length,
+    planned: plans.filter((plan) => plan.action === "copy" && plan.targetKey).length,
+    copied,
+    skipped,
+    warnings,
+    truncated,
+    keys: plans,
+  };
+}
+
+export async function deleteLegacyRedisKeys(
+  redis: Redis,
+  input: { pattern: string; limit: number; dryRun: boolean }
+): Promise<RedisDeleteLegacyResult> {
+  assertKnownLegacyRedisPattern(input.pattern);
+  const { keys, truncated } = await scanKeys(redis, input.pattern, input.limit);
+  const deleted = input.dryRun || keys.length === 0 ? 0 : await redis.del(...keys);
+  return {
+    pattern: input.pattern,
+    dryRun: input.dryRun,
+    scanned: keys.length,
+    deleted,
+    truncated,
+    keys,
+  };
+}

--- a/api/_utils/redis-key-migration.ts
+++ b/api/_utils/redis-key-migration.ts
@@ -31,6 +31,7 @@ export interface RedisKeyMigrationPlan {
 
 export interface RedisBackfillResult {
   pattern: string;
+  cursor: string;
   dryRun: boolean;
   scanned: number;
   planned: number;
@@ -43,6 +44,7 @@ export interface RedisBackfillResult {
 
 export interface RedisDeleteLegacyResult {
   pattern: string;
+  cursor: string;
   dryRun: boolean;
   scanned: number;
   deleted: number;
@@ -83,17 +85,18 @@ function safeDecode(value: string): string {
 async function scanKeys(
   redis: Redis,
   pattern: string,
-  limit: number
-): Promise<{ keys: string[]; truncated: boolean }> {
+  limit: number,
+  startCursor: string | number = 0
+): Promise<{ keys: string[]; cursor: string; truncated: boolean }> {
   const keys: string[] = [];
   const seen = new Set<string>();
-  let cursor: string | number = 0;
+  let cursor: string | number = startCursor;
   let iterations = 0;
 
   do {
     const [nextCursor, batch] = await redis.scan(cursor, {
       match: pattern,
-      count: STATUS_SCAN_COUNT,
+      count: Math.max(1, Math.min(limit, STATUS_SCAN_COUNT)),
     });
     cursor = nextCursor;
     iterations += 1;
@@ -101,7 +104,6 @@ async function scanKeys(
       if (!seen.has(key)) {
         seen.add(key);
         keys.push(key);
-        if (keys.length >= limit) break;
       }
     }
   } while (
@@ -113,7 +115,8 @@ async function scanKeys(
 
   return {
     keys: keys.sort(),
-    truncated: keys.length >= limit || (cursor !== 0 && cursor !== "0"),
+    cursor: String(cursor),
+    truncated: cursor !== 0 && cursor !== "0",
   };
 }
 
@@ -500,10 +503,15 @@ async function applyAdditionalMigrationSideEffects(
 
 export async function backfillRedisKeyScheme(
   redis: Redis,
-  input: { pattern: string; limit: number; dryRun: boolean }
+  input: { pattern: string; limit: number; dryRun: boolean; cursor?: string | number }
 ): Promise<RedisBackfillResult> {
   assertKnownLegacyRedisPattern(input.pattern);
-  const { keys, truncated } = await scanKeys(redis, input.pattern, input.limit);
+  const { keys, cursor, truncated } = await scanKeys(
+    redis,
+    input.pattern,
+    input.limit,
+    input.cursor ?? 0
+  );
   const plans = await Promise.all(keys.map((key) => planRedisKeyMigration(key)));
   const warnings: string[] = [];
   let copied = 0;
@@ -530,6 +538,7 @@ export async function backfillRedisKeyScheme(
 
   return {
     pattern: input.pattern,
+    cursor,
     dryRun: input.dryRun,
     scanned: keys.length,
     planned: plans.filter((plan) => plan.action === "copy" && plan.targetKey).length,
@@ -543,13 +552,19 @@ export async function backfillRedisKeyScheme(
 
 export async function deleteLegacyRedisKeys(
   redis: Redis,
-  input: { pattern: string; limit: number; dryRun: boolean }
+  input: { pattern: string; limit: number; dryRun: boolean; cursor?: string | number }
 ): Promise<RedisDeleteLegacyResult> {
   assertKnownLegacyRedisPattern(input.pattern);
-  const { keys, truncated } = await scanKeys(redis, input.pattern, input.limit);
+  const { keys, cursor, truncated } = await scanKeys(
+    redis,
+    input.pattern,
+    input.limit,
+    input.cursor ?? 0
+  );
   const deleted = input.dryRun || keys.length === 0 ? 0 : await redis.del(...keys);
   return {
     pattern: input.pattern,
+    cursor,
     dryRun: input.dryRun,
     scanned: keys.length,
     deleted,

--- a/api/_utils/redis-key-migration.ts
+++ b/api/_utils/redis-key-migration.ts
@@ -1,4 +1,5 @@
 import type { Redis } from "./redis.js";
+import { ensureSync2Initialized } from "../sync/v2/_core.js";
 import {
   LEGACY_REDIS_SCAN_PATTERNS,
   redisKeys,
@@ -25,7 +26,8 @@ export interface RedisKeyMigrationPlan {
   legacyKey: string;
   targetKey: string | null;
   additionalKeys?: string[];
-  action: "copy" | "skip";
+  action: "copy" | "import-v1-sync" | "skip";
+  username?: string;
   reason?: string;
 }
 
@@ -80,6 +82,24 @@ function safeDecode(value: string): string {
   } catch {
     return value;
   }
+}
+
+function syncV1Username(legacyKey: string): string | null {
+  if (legacyKey.startsWith("sync:state:meta:")) {
+    return suffixAfter(legacyKey, "sync:state:meta:");
+  }
+  if (legacyKey.startsWith("sync:state:")) {
+    const parts = splitSuffix(legacyKey, "sync:state:");
+    return parts.length >= 2 ? parts[0] : null;
+  }
+  if (legacyKey.startsWith("sync:auto:meta:")) {
+    return suffixAfter(legacyKey, "sync:auto:meta:");
+  }
+  if (legacyKey.startsWith("sync:songs:")) {
+    const parts = splitSuffix(legacyKey, "sync:songs:");
+    return parts.length >= 2 ? parts[0] : null;
+  }
+  return null;
 }
 
 async function scanKeys(
@@ -362,11 +382,15 @@ export async function planRedisKeyMigration(
     legacyKey.startsWith("sync:auto:") ||
     legacyKey.startsWith("sync:songs:")
   ) {
+    const username = syncV1Username(legacyKey);
     return {
       legacyKey,
-      targetKey: null,
-      action: "skip",
-      reason: "Legacy sync v1 data must be imported into sync v2 before deletion",
+      targetKey: username ? redisKeys.sync.v2Kv(username) : null,
+      action: username ? "import-v1-sync" : "skip",
+      username: username ?? undefined,
+      reason: username
+        ? "Will initialize sync v2 from legacy v1 data"
+        : "Malformed legacy sync v1 key",
     };
   }
   if (legacyKey.startsWith("telegram:link:code:")) {
@@ -514,6 +538,7 @@ export async function backfillRedisKeyScheme(
   );
   const plans = await Promise.all(keys.map((key) => planRedisKeyMigration(key)));
   const warnings: string[] = [];
+  const importedSyncUsers = new Set<string>();
   let copied = 0;
   let skipped = 0;
 
@@ -521,6 +546,14 @@ export async function backfillRedisKeyScheme(
     if (plan.action === "skip" || !plan.targetKey) {
       skipped += 1;
       if (plan.reason) warnings.push(`${plan.legacyKey}: ${plan.reason}`);
+      continue;
+    }
+    if (plan.action === "import-v1-sync") {
+      if (!input.dryRun && plan.username && !importedSyncUsers.has(plan.username)) {
+        await ensureSync2Initialized(redis, plan.username);
+        importedSyncUsers.add(plan.username);
+      }
+      copied += input.dryRun ? 0 : 1;
       continue;
     }
     if (input.dryRun) {
@@ -541,7 +574,11 @@ export async function backfillRedisKeyScheme(
     cursor,
     dryRun: input.dryRun,
     scanned: keys.length,
-    planned: plans.filter((plan) => plan.action === "copy" && plan.targetKey).length,
+    planned: plans.filter(
+      (plan) =>
+        (plan.action === "copy" || plan.action === "import-v1-sync") &&
+        plan.targetKey
+    ).length,
     copied,
     skipped,
     warnings,

--- a/api/_utils/redis-key-migration.ts
+++ b/api/_utils/redis-key-migration.ts
@@ -170,6 +170,9 @@ export async function planRedisKeyMigration(
   if (legacyKey === "airdrop:presence") {
     return { legacyKey, targetKey: redisKeys.presence.airdropLobby(), action: "copy" };
   }
+  if (legacyKey === "ryos:presence:online") {
+    return { legacyKey, targetKey: redisKeys.presence.globalOnline(), action: "copy" };
+  }
   if (legacyKey.startsWith("airdrop:transfer:")) {
     return {
       legacyKey,

--- a/api/_utils/redis.ts
+++ b/api/_utils/redis.ts
@@ -92,6 +92,11 @@ export interface RedisLike {
     max: number | string
   ): Promise<number>;
   zrange(key: string, start: number, stop: number): Promise<string[]>;
+  zrangeWithScores(
+    key: string,
+    start: number,
+    stop: number
+  ): Promise<RedisSortedSetEntry[]>;
   zcard(key: string): Promise<number>;
 }
 
@@ -462,6 +467,23 @@ class StandardRedisAdapter implements RedisLike {
 
   async zrange(key: string, start: number, stop: number): Promise<string[]> {
     return await this.client.zrange(key, start, stop);
+  }
+
+  async zrangeWithScores(
+    key: string,
+    start: number,
+    stop: number
+  ): Promise<RedisSortedSetEntry[]> {
+    const raw = await this.client.zrange(key, start, stop, "WITHSCORES");
+    const entries: RedisSortedSetEntry[] = [];
+    for (let index = 0; index < raw.length; index += 2) {
+      const member = raw[index];
+      const score = Number(raw[index + 1]);
+      if (member !== undefined && Number.isFinite(score)) {
+        entries.push({ member, score });
+      }
+    }
+    return entries;
   }
 
   async zcard(key: string): Promise<number> {

--- a/api/_utils/telegram-heartbeat.ts
+++ b/api/_utils/telegram-heartbeat.ts
@@ -1,6 +1,7 @@
 import type { DailyNote, DailyNoteEntry } from "./_memory.js";
 import type { HeartbeatRecord } from "./heartbeats.js";
 import type { TelegramConversationMessage } from "./telegram-link.js";
+import { redisKeys } from "../../src/shared/redisKeys.js";
 
 export const TELEGRAM_HEARTBEAT_TARGET_USERNAME = "ryo";
 export const TELEGRAM_HEARTBEAT_INTERVAL_MINUTES = 30;
@@ -56,6 +57,16 @@ export function getTelegramHeartbeatSlot(date: Date = new Date()): number {
 }
 
 export function buildTelegramHeartbeatRedisKey(
+  username: string,
+  date: Date = new Date()
+): string {
+  return redisKeys.integration.telegramHeartbeat(
+    username,
+    String(getTelegramHeartbeatSlot(date))
+  );
+}
+
+export function buildLegacyTelegramHeartbeatRedisKey(
   username: string,
   date: Date = new Date()
 ): string {

--- a/api/_utils/telegram-link.ts
+++ b/api/_utils/telegram-link.ts
@@ -225,24 +225,7 @@ export async function createTelegramLinkCode(
     { ex: ttlSeconds }
   );
   await redis.set(
-    buildLegacyTelegramLinkCodeKey(code),
-    JSON.stringify({
-      username: normalizedUsername,
-      createdAt,
-    } satisfies TelegramLinkCodeRecord),
-    { ex: ttlSeconds }
-  );
-  await redis.set(
     buildTelegramPendingLinkKey(normalizedUsername),
-    JSON.stringify({
-      username: normalizedUsername,
-      code,
-      createdAt,
-    } satisfies TelegramPendingLinkSessionRecord),
-    { ex: ttlSeconds }
-  );
-  await redis.set(
-    buildLegacyTelegramPendingLinkKey(normalizedUsername),
     JSON.stringify({
       username: normalizedUsername,
       code,
@@ -368,9 +351,7 @@ export async function linkTelegramAccount(
 
   const serialized = JSON.stringify(linkRecord);
   await redis.set(buildTelegramUsernameKey(username), serialized);
-  await redis.set(buildLegacyTelegramUsernameKey(username), serialized);
   await redis.set(buildTelegramUserKey(options.telegramUserId), serialized);
-  await redis.set(buildLegacyTelegramUserKey(options.telegramUserId), serialized);
 
   return linkRecord;
 }
@@ -394,9 +375,6 @@ export async function markTelegramUpdateProcessed(
   await redis.set(buildTelegramProcessedUpdateKey(updateId), "1", {
     ex: ttlSeconds,
   });
-  await redis.set(buildLegacyTelegramProcessedUpdateKey(updateId), "1", {
-    ex: ttlSeconds,
-  });
 }
 
 /**
@@ -418,9 +396,6 @@ export async function claimTelegramUpdate(
     nx: true,
     ex: ttlSeconds,
   });
-  if (result === "OK" || result === true) {
-    await redis.set(legacyKey, "1", { ex: ttlSeconds });
-  }
   return result === "OK" || result === true;
 }
 
@@ -429,10 +404,15 @@ export async function loadTelegramConversationHistory(
   chatId: string,
   limit: number = TELEGRAM_HISTORY_LIMIT
 ): Promise<TelegramConversationMessage[]> {
+  const seen = new Set<string>();
   const values = [
     ...((await redis.lrange<string>(buildTelegramHistoryKey(chatId), 0, limit - 1)) || []),
     ...((await redis.lrange<string>(buildLegacyTelegramHistoryKey(chatId), 0, limit - 1)) || []),
-  ].slice(0, limit);
+  ].filter((value) => {
+    if (seen.has(value)) return false;
+    seen.add(value);
+    return true;
+  }).slice(0, limit);
   const parsedMessages = (values || []).reduce<TelegramConversationMessage[]>(
     (acc, value) => {
       const parsed = parseTelegramConversationMessage(value);
@@ -458,14 +438,10 @@ export async function appendTelegramConversationMessage(
   const limit = options.limit ?? TELEGRAM_HISTORY_LIMIT;
   const ttlSeconds = options.ttlSeconds ?? TELEGRAM_HISTORY_TTL_SECONDS;
   const key = buildTelegramHistoryKey(chatId);
-  const legacyKey = buildLegacyTelegramHistoryKey(chatId);
 
   await redis.lpush(key, JSON.stringify(message));
   await redis.ltrim(key, 0, limit - 1);
   await redis.expire(key, ttlSeconds);
-  await redis.lpush(legacyKey, JSON.stringify(message));
-  await redis.ltrim(legacyKey, 0, limit - 1);
-  await redis.expire(legacyKey, ttlSeconds);
 }
 
 export async function clearTelegramConversationHistory(

--- a/api/_utils/telegram-link.ts
+++ b/api/_utils/telegram-link.ts
@@ -1,5 +1,6 @@
 import { generateAuthToken } from "./auth/index.js";
 import type { RedisLike } from "./redis.js";
+import { redisKeys } from "../../src/shared/redisKeys.js";
 
 export const TELEGRAM_LINK_CODE_TTL_SECONDS = 10 * 60;
 export const TELEGRAM_HISTORY_LIMIT = 16;
@@ -34,26 +35,50 @@ export interface TelegramConversationMessage {
 }
 
 export function buildTelegramLinkCodeKey(code: string): string {
+  return redisKeys.integration.telegramLinkCode(code);
+}
+
+function buildLegacyTelegramLinkCodeKey(code: string): string {
   return `telegram:link:code:${code}`;
 }
 
 export function buildTelegramPendingLinkKey(username: string): string {
+  return redisKeys.integration.telegramPendingLink(username);
+}
+
+function buildLegacyTelegramPendingLinkKey(username: string): string {
   return `telegram:link:username:${username.toLowerCase()}`;
 }
 
 export function buildTelegramUserKey(telegramUserId: string): string {
+  return redisKeys.integration.telegramAccountByTelegramUser(telegramUserId);
+}
+
+function buildLegacyTelegramUserKey(telegramUserId: string): string {
   return `telegram:user:${telegramUserId}`;
 }
 
 export function buildTelegramUsernameKey(username: string): string {
+  return redisKeys.integration.telegramAccountByUsername(username);
+}
+
+function buildLegacyTelegramUsernameKey(username: string): string {
   return `telegram:username:${username.toLowerCase()}`;
 }
 
 export function buildTelegramHistoryKey(chatId: string): string {
+  return redisKeys.integration.telegramHistory(chatId);
+}
+
+function buildLegacyTelegramHistoryKey(chatId: string): string {
   return `telegram:history:${chatId}`;
 }
 
 export function buildTelegramProcessedUpdateKey(updateId: number): string {
+  return redisKeys.integration.telegramUpdate(updateId);
+}
+
+function buildLegacyTelegramProcessedUpdateKey(updateId: number): string {
   return `telegram:update:${updateId}`;
 }
 
@@ -150,16 +175,22 @@ export async function getTelegramPendingLinkSession(
   username: string
 ): Promise<{ code: string; expiresIn: number } | null> {
   const pendingKey = buildTelegramPendingLinkKey(username);
-  const raw = await redis.get<string>(pendingKey);
+  const legacyPendingKey = buildLegacyTelegramPendingLinkKey(username);
+  const raw =
+    (await redis.get<string>(pendingKey)) ??
+    (await redis.get<string>(legacyPendingKey));
   const pending = parseTelegramPendingLinkSessionRecord(raw);
 
   if (!pending) {
     return null;
   }
 
-  const expiresIn = await redis.ttl(buildTelegramLinkCodeKey(pending.code));
+  const expiresIn = Math.max(
+    await redis.ttl(buildTelegramLinkCodeKey(pending.code)),
+    await redis.ttl(buildLegacyTelegramLinkCodeKey(pending.code))
+  );
   if (expiresIn <= 0) {
-    await redis.del(pendingKey);
+    await redis.del(pendingKey, legacyPendingKey);
     return null;
   }
 
@@ -194,7 +225,24 @@ export async function createTelegramLinkCode(
     { ex: ttlSeconds }
   );
   await redis.set(
+    buildLegacyTelegramLinkCodeKey(code),
+    JSON.stringify({
+      username: normalizedUsername,
+      createdAt,
+    } satisfies TelegramLinkCodeRecord),
+    { ex: ttlSeconds }
+  );
+  await redis.set(
     buildTelegramPendingLinkKey(normalizedUsername),
+    JSON.stringify({
+      username: normalizedUsername,
+      code,
+      createdAt,
+    } satisfies TelegramPendingLinkSessionRecord),
+    { ex: ttlSeconds }
+  );
+  await redis.set(
+    buildLegacyTelegramPendingLinkKey(normalizedUsername),
     JSON.stringify({
       username: normalizedUsername,
       code,
@@ -211,14 +259,20 @@ export async function consumeTelegramLinkCode(
   code: string
 ): Promise<TelegramLinkCodeRecord | null> {
   const key = buildTelegramLinkCodeKey(code);
-  const raw = await redis.get<string>(key);
+  const legacyKey = buildLegacyTelegramLinkCodeKey(code);
+  const raw = (await redis.get<string>(key)) ?? (await redis.get<string>(legacyKey));
   const parsed = parseTelegramLinkCodeRecord(raw);
 
   if (!parsed) {
     return null;
   }
 
-  await redis.del(key, buildTelegramPendingLinkKey(parsed.username));
+  await redis.del(
+    key,
+    legacyKey,
+    buildTelegramPendingLinkKey(parsed.username),
+    buildLegacyTelegramPendingLinkKey(parsed.username)
+  );
   return parsed;
 }
 
@@ -226,7 +280,9 @@ export async function getLinkedTelegramAccountByUsername(
   redis: RedisLike,
   username: string
 ): Promise<LinkedTelegramAccount | null> {
-  const raw = await redis.get<string>(buildTelegramUsernameKey(username));
+  const raw =
+    (await redis.get<string>(buildTelegramUsernameKey(username))) ??
+    (await redis.get<string>(buildLegacyTelegramUsernameKey(username)));
   return parseLinkedTelegramAccount(raw);
 }
 
@@ -234,7 +290,9 @@ export async function getLinkedTelegramAccountByTelegramUserId(
   redis: RedisLike,
   telegramUserId: string
 ): Promise<LinkedTelegramAccount | null> {
-  const raw = await redis.get<string>(buildTelegramUserKey(telegramUserId));
+  const raw =
+    (await redis.get<string>(buildTelegramUserKey(telegramUserId))) ??
+    (await redis.get<string>(buildLegacyTelegramUserKey(telegramUserId)));
   return parseLinkedTelegramAccount(raw);
 }
 
@@ -249,7 +307,9 @@ export async function unlinkTelegramAccountByUsername(
 
   await redis.del(
     buildTelegramUsernameKey(existing.username),
-    buildTelegramUserKey(existing.telegramUserId)
+    buildLegacyTelegramUsernameKey(existing.username),
+    buildTelegramUserKey(existing.telegramUserId),
+    buildLegacyTelegramUserKey(existing.telegramUserId)
   );
 }
 
@@ -283,11 +343,17 @@ export async function linkTelegramAccount(
     existingByUsername &&
     existingByUsername.telegramUserId !== options.telegramUserId
   ) {
-    await redis.del(buildTelegramUserKey(existingByUsername.telegramUserId));
+    await redis.del(
+      buildTelegramUserKey(existingByUsername.telegramUserId),
+      buildLegacyTelegramUserKey(existingByUsername.telegramUserId)
+    );
   }
 
   if (existingByTelegram && existingByTelegram.username !== username) {
-    await redis.del(buildTelegramUsernameKey(existingByTelegram.username));
+    await redis.del(
+      buildTelegramUsernameKey(existingByTelegram.username),
+      buildLegacyTelegramUsernameKey(existingByTelegram.username)
+    );
   }
 
   const linkRecord: LinkedTelegramAccount = {
@@ -302,7 +368,9 @@ export async function linkTelegramAccount(
 
   const serialized = JSON.stringify(linkRecord);
   await redis.set(buildTelegramUsernameKey(username), serialized);
+  await redis.set(buildLegacyTelegramUsernameKey(username), serialized);
   await redis.set(buildTelegramUserKey(options.telegramUserId), serialized);
+  await redis.set(buildLegacyTelegramUserKey(options.telegramUserId), serialized);
 
   return linkRecord;
 }
@@ -311,7 +379,10 @@ export async function hasProcessedTelegramUpdate(
   redis: RedisLike,
   updateId: number
 ): Promise<boolean> {
-  const count = await redis.exists(buildTelegramProcessedUpdateKey(updateId));
+  const count = await redis.exists(
+    buildTelegramProcessedUpdateKey(updateId),
+    buildLegacyTelegramProcessedUpdateKey(updateId)
+  );
   return count > 0;
 }
 
@@ -321,6 +392,9 @@ export async function markTelegramUpdateProcessed(
   ttlSeconds: number = TELEGRAM_UPDATE_TTL_SECONDS
 ): Promise<void> {
   await redis.set(buildTelegramProcessedUpdateKey(updateId), "1", {
+    ex: ttlSeconds,
+  });
+  await redis.set(buildLegacyTelegramProcessedUpdateKey(updateId), "1", {
     ex: ttlSeconds,
   });
 }
@@ -337,10 +411,16 @@ export async function claimTelegramUpdate(
   updateId: number,
   ttlSeconds: number = TELEGRAM_UPDATE_TTL_SECONDS
 ): Promise<boolean> {
-  const result = await redis.set(buildTelegramProcessedUpdateKey(updateId), "1", {
+  const canonicalKey = buildTelegramProcessedUpdateKey(updateId);
+  const legacyKey = buildLegacyTelegramProcessedUpdateKey(updateId);
+  if ((await redis.exists(canonicalKey, legacyKey)) > 0) return false;
+  const result = await redis.set(canonicalKey, "1", {
     nx: true,
     ex: ttlSeconds,
   });
+  if (result === "OK" || result === true) {
+    await redis.set(legacyKey, "1", { ex: ttlSeconds });
+  }
   return result === "OK" || result === true;
 }
 
@@ -349,7 +429,10 @@ export async function loadTelegramConversationHistory(
   chatId: string,
   limit: number = TELEGRAM_HISTORY_LIMIT
 ): Promise<TelegramConversationMessage[]> {
-  const values = await redis.lrange<string>(buildTelegramHistoryKey(chatId), 0, limit - 1);
+  const values = [
+    ...((await redis.lrange<string>(buildTelegramHistoryKey(chatId), 0, limit - 1)) || []),
+    ...((await redis.lrange<string>(buildLegacyTelegramHistoryKey(chatId), 0, limit - 1)) || []),
+  ].slice(0, limit);
   const parsedMessages = (values || []).reduce<TelegramConversationMessage[]>(
     (acc, value) => {
       const parsed = parseTelegramConversationMessage(value);
@@ -375,15 +458,19 @@ export async function appendTelegramConversationMessage(
   const limit = options.limit ?? TELEGRAM_HISTORY_LIMIT;
   const ttlSeconds = options.ttlSeconds ?? TELEGRAM_HISTORY_TTL_SECONDS;
   const key = buildTelegramHistoryKey(chatId);
+  const legacyKey = buildLegacyTelegramHistoryKey(chatId);
 
   await redis.lpush(key, JSON.stringify(message));
   await redis.ltrim(key, 0, limit - 1);
   await redis.expire(key, ttlSeconds);
+  await redis.lpush(legacyKey, JSON.stringify(message));
+  await redis.ltrim(legacyKey, 0, limit - 1);
+  await redis.expire(legacyKey, ttlSeconds);
 }
 
 export async function clearTelegramConversationHistory(
   redis: RedisLike,
   chatId: string
 ): Promise<void> {
-  await redis.del(buildTelegramHistoryKey(chatId));
+  await redis.del(buildTelegramHistoryKey(chatId), buildLegacyTelegramHistoryKey(chatId));
 }

--- a/api/admin.ts
+++ b/api/admin.ts
@@ -9,7 +9,6 @@ import type { Redis } from "./_utils/redis.js";
 import { CHAT_USERS_PREFIX } from "./rooms/_helpers/_constants.js";
 import { deleteAllUserTokens, PASSWORD_HASH_PREFIX } from "./_utils/auth/index.js";
 import {
-  getLegacyStoredUserKey,
   getStoredUserRecord,
   setStoredUserRecord,
 } from "./_utils/auth/_user-record.js";
@@ -251,7 +250,6 @@ async function banUser(redis: Redis, targetUsername: string, reason?: string): P
 
     const updatedUser = { ...userData, banned: true, banReason: reason || "No reason provided", bannedAt: Date.now() };
     await setStoredUserRecord(redis, normalizedUsername, updatedUser);
-    await redis.set(getLegacyStoredUserKey(normalizedUsername), JSON.stringify(updatedUser));
     await deleteAllUserTokens(redis, normalizedUsername);
     return { success: true };
   } catch (error) {
@@ -269,7 +267,6 @@ async function unbanUser(redis: Redis, targetUsername: string): Promise<{ succes
 
     const updatedUser = { ...userData, banned: false, banReason: undefined, bannedAt: undefined };
     await setStoredUserRecord(redis, normalizedUsername, updatedUser);
-    await redis.set(getLegacyStoredUserKey(normalizedUsername), JSON.stringify(updatedUser));
     return { success: true };
   } catch (error) {
     console.error(`Error unbanning user ${normalizedUsername}:`, error);

--- a/api/admin.ts
+++ b/api/admin.ts
@@ -8,6 +8,11 @@
 import type { Redis } from "./_utils/redis.js";
 import { CHAT_USERS_PREFIX } from "./rooms/_helpers/_constants.js";
 import { deleteAllUserTokens, PASSWORD_HASH_PREFIX } from "./_utils/auth/index.js";
+import {
+  getLegacyStoredUserKey,
+  getStoredUserRecord,
+  setStoredUserRecord,
+} from "./_utils/auth/_user-record.js";
 import { apiHandler } from "./_utils/api-handler.js";
 import { getMemoryIndex, getMemoryDetail, getRecentDailyNotes, clearAllMemories, resetDailyNotesProcessedFlag, type MemoryEntry, type DailyNote } from "./_utils/_memory.js";
 import { getRecentHeartbeatRecords, type HeartbeatRecord } from "./_utils/heartbeats.js";
@@ -28,6 +33,7 @@ import {
   getRedisMigrationStatus,
   assertKnownLegacyRedisPattern,
 } from "./_utils/redis-key-migration.js";
+import { redisKeys } from "../src/shared/redisKeys.js";
 
 export const runtime = "nodejs";
 export const maxDuration = 30;
@@ -62,8 +68,12 @@ async function deleteUser(redis: Redis, targetUsername: string): Promise<{ succe
   if (normalizedUsername === "ryo") return { success: false, error: "Cannot delete admin user" };
 
   try {
-    await redis.del(`${CHAT_USERS_PREFIX}${normalizedUsername}`);
-    await redis.del(`${PASSWORD_HASH_PREFIX}${normalizedUsername}`);
+    await redis.del(
+      redisKeys.auth.userProfile(normalizedUsername),
+      `${CHAT_USERS_PREFIX}${normalizedUsername}`,
+      redisKeys.auth.userPassword(normalizedUsername),
+      `${PASSWORD_HASH_PREFIX}${normalizedUsername}`
+    );
     await deleteAllUserTokens(redis, normalizedUsername);
     return { success: true };
   } catch (error) {
@@ -72,30 +82,61 @@ async function deleteUser(redis: Redis, targetUsername: string): Promise<{ succe
   }
 }
 
-async function getAllUsers(redis: Redis): Promise<{ username: string; lastActive: number; banned?: boolean }[]> {
-  const users: { username: string; lastActive: number; banned?: boolean }[] = [];
+async function scanRedisKeys(redis: Redis, pattern: string): Promise<string[]> {
+  const keys: string[] = [];
   let cursor: string | number = 0;
   let iterations = 0;
+  do {
+    const [newCursor, foundKeys] = await redis.scan(cursor, { match: pattern, count: 1000 });
+    cursor = newCursor;
+    iterations++;
+    keys.push(...foundKeys);
+  } while (cursor !== 0 && cursor !== "0" && iterations < 100);
+  return keys;
+}
 
+async function getAdminRoomIds(redis: Redis): Promise<string[]> {
+  const canonicalIds = await redis.smembers<string[]>(redisKeys.chat.roomIds());
+  const legacyIds = await redis.smembers<string[]>("chat:rooms");
+  return [...new Set([...(canonicalIds || []), ...(legacyIds || [])])];
+}
+
+async function getAdminRoomData(redis: Redis, roomId: string): Promise<{ name?: string } | null> {
+  const roomData =
+    (await redis.get<{ name: string } | string>(redisKeys.chat.roomMeta(roomId))) ??
+    (await redis.get<{ name: string } | string>(`chat:room:${roomId}`));
+  if (!roomData) return null;
+  return typeof roomData === "string" ? JSON.parse(roomData) : roomData;
+}
+
+async function getAdminRoomMessages(redis: Redis, roomId: string): Promise<unknown[]> {
+  const canonicalMessages = await redis.lrange<unknown>(redisKeys.chat.roomMessages(roomId), 0, -1);
+  const legacyMessages = await redis.lrange<unknown>(`chat:messages:${roomId}`, 0, -1);
+  return canonicalMessages.length > 0 ? canonicalMessages : legacyMessages;
+}
+
+async function getAllUsers(redis: Redis): Promise<{ username: string; lastActive: number; banned?: boolean }[]> {
   try {
-    do {
-      const [newCursor, keys] = await redis.scan(cursor, { match: `${CHAT_USERS_PREFIX}*`, count: 1000 });
-      cursor = newCursor;
-      iterations++;
-
-      if (keys.length > 0) {
-        const userData = await redis.mget<(string | { username: string; lastActive: number; banned?: boolean } | null)[]>(...keys);
-        for (const data of userData) {
-          if (!data) continue;
-          const parsed = typeof data === "string" ? JSON.parse(data) : data;
-          if (parsed?.username) {
-            users.push({ username: parsed.username, lastActive: parsed.lastActive || 0, banned: parsed.banned || false });
-          }
+    const canonicalKeys = await scanRedisKeys(redis, "auth:user:*:profile");
+    const legacyKeys = await scanRedisKeys(redis, `${CHAT_USERS_PREFIX}*`);
+    const keys = [...new Set([...canonicalKeys, ...legacyKeys])];
+    const byUsername = new Map<string, { username: string; lastActive: number; banned?: boolean }>();
+    if (keys.length > 0) {
+      const userData = await redis.mget<(string | { username: string; lastActive: number; banned?: boolean } | null)[]>(...keys);
+      for (const data of userData) {
+        if (!data) continue;
+        const parsed = typeof data === "string" ? JSON.parse(data) : data;
+        if (parsed?.username) {
+          byUsername.set(parsed.username.toLowerCase(), {
+            username: parsed.username,
+            lastActive: parsed.lastActive || 0,
+            banned: parsed.banned || false,
+          });
         }
       }
-    } while (cursor !== 0 && cursor !== "0" && iterations < 100);
+    }
 
-    return users;
+    return [...byUsername.values()];
   } catch (error) {
     console.error("Error fetching all users:", error);
     return [];
@@ -106,22 +147,21 @@ async function getUserProfile(redis: Redis, targetUsername: string): Promise<Use
   const normalizedUsername = targetUsername.toLowerCase();
 
   try {
-    const userData = await redis.get<{ username: string; lastActive: number; banned?: boolean; banReason?: string; bannedAt?: number } | string>(`${CHAT_USERS_PREFIX}${normalizedUsername}`);
+    const userData = await getStoredUserRecord(redis, normalizedUsername);
     if (!userData) return null;
 
-    const parsed = typeof userData === "string" ? JSON.parse(userData) : userData;
+    const parsed = userData;
     let messageCount = 0;
     const userRooms: { id: string; name: string }[] = [];
     
-    const roomIds = await redis.smembers("chat:rooms");
+    const roomIds = await getAdminRoomIds(redis);
     const roomNameMap: Record<string, string> = {};
     
     for (const roomId of roomIds || []) {
       try {
-        const roomData = await redis.get<{ name: string } | string>(`chat:room:${roomId}`);
+        const roomData = await getAdminRoomData(redis, roomId);
         if (roomData) {
-          const p = typeof roomData === "string" ? JSON.parse(roomData) : roomData;
-          roomNameMap[roomId] = p.name || roomId;
+          roomNameMap[roomId] = roomData.name || roomId;
         } else {
           roomNameMap[roomId] = roomId;
         }
@@ -131,7 +171,7 @@ async function getUserProfile(redis: Redis, targetUsername: string): Promise<Use
     }
     
     for (const roomId of roomIds || []) {
-      const messages = await redis.lrange(`chat:messages:${roomId}`, 0, -1);
+      const messages = await getAdminRoomMessages(redis, roomId);
       let roomMessageCount = 0;
       
       for (const msg of messages || []) {
@@ -167,15 +207,14 @@ async function getUserMessages(redis: Redis, targetUsername: string, limit = 50)
   const messages: { id: string; roomId: string; roomName: string; content: string; timestamp: number }[] = [];
 
   try {
-    const roomIds = await redis.smembers("chat:rooms");
+    const roomIds = await getAdminRoomIds(redis);
     const roomNameMap: Record<string, string> = {};
     
     for (const roomId of roomIds || []) {
       try {
-        const roomData = await redis.get<{ name: string } | string>(`chat:room:${roomId}`);
+        const roomData = await getAdminRoomData(redis, roomId);
         if (roomData) {
-          const p = typeof roomData === "string" ? JSON.parse(roomData) : roomData;
-          roomNameMap[roomId] = p.name || roomId;
+          roomNameMap[roomId] = roomData.name || roomId;
         } else {
           roomNameMap[roomId] = roomId;
         }
@@ -185,7 +224,7 @@ async function getUserMessages(redis: Redis, targetUsername: string, limit = 50)
     }
     
     for (const roomId of roomIds || []) {
-      const roomMessages = await redis.lrange(`chat:messages:${roomId}`, 0, -1);
+      const roomMessages = await getAdminRoomMessages(redis, roomId);
       for (const msg of roomMessages || []) {
         const msgData = typeof msg === "string" ? JSON.parse(msg) : msg;
         if (msgData?.username?.toLowerCase() === normalizedUsername) {
@@ -207,13 +246,12 @@ async function banUser(redis: Redis, targetUsername: string, reason?: string): P
   if (normalizedUsername === "ryo") return { success: false, error: "Cannot ban admin user" };
 
   try {
-    const userKey = `${CHAT_USERS_PREFIX}${normalizedUsername}`;
-    const userData = await redis.get<{ username: string; lastActive: number; banned?: boolean } | string>(userKey);
+    const userData = await getStoredUserRecord(redis, normalizedUsername);
     if (!userData) return { success: false, error: "User not found" };
 
-    const parsed = typeof userData === "string" ? JSON.parse(userData) : userData;
-    const updatedUser = { ...parsed, banned: true, banReason: reason || "No reason provided", bannedAt: Date.now() };
-    await redis.set(userKey, JSON.stringify(updatedUser));
+    const updatedUser = { ...userData, banned: true, banReason: reason || "No reason provided", bannedAt: Date.now() };
+    await setStoredUserRecord(redis, normalizedUsername, updatedUser);
+    await redis.set(getLegacyStoredUserKey(normalizedUsername), JSON.stringify(updatedUser));
     await deleteAllUserTokens(redis, normalizedUsername);
     return { success: true };
   } catch (error) {
@@ -226,13 +264,12 @@ async function unbanUser(redis: Redis, targetUsername: string): Promise<{ succes
   const normalizedUsername = targetUsername.toLowerCase();
 
   try {
-    const userKey = `${CHAT_USERS_PREFIX}${normalizedUsername}`;
-    const userData = await redis.get<{ username: string; lastActive: number; banned?: boolean } | string>(userKey);
+    const userData = await getStoredUserRecord(redis, normalizedUsername);
     if (!userData) return { success: false, error: "User not found" };
 
-    const parsed = typeof userData === "string" ? JSON.parse(userData) : userData;
-    const updatedUser = { ...parsed, banned: false, banReason: undefined, bannedAt: undefined };
-    await redis.set(userKey, JSON.stringify(updatedUser));
+    const updatedUser = { ...userData, banned: false, banReason: undefined, bannedAt: undefined };
+    await setStoredUserRecord(redis, normalizedUsername, updatedUser);
+    await redis.set(getLegacyStoredUserKey(normalizedUsername), JSON.stringify(updatedUser));
     return { success: true };
   } catch (error) {
     console.error(`Error unbanning user ${normalizedUsername}:`, error);
@@ -337,32 +374,14 @@ async function listCursorSdkRunsForAdmin(
 
 async function getStats(redis: Redis): Promise<{ totalUsers: number; totalRooms: number; totalMessages: number }> {
   try {
-    let userCount = 0;
-    let cursor: string | number = 0;
-    let iterations = 0;
-    
-    do {
-      const [newCursor, keys] = await redis.scan(cursor, { match: `${CHAT_USERS_PREFIX}*`, count: 1000 });
-      cursor = newCursor;
-      userCount += keys.length;
-      iterations++;
-    } while (cursor !== 0 && cursor !== "0" && iterations < 100);
-
-    const roomIds = await redis.smembers("chat:rooms");
+    const userCount = (await getAllUsers(redis)).length;
+    const roomIds = await getAdminRoomIds(redis);
     const roomCount = roomIds?.length || 0;
 
     let messageCount = 0;
-    cursor = 0;
-    iterations = 0;
-    do {
-      const [newCursor, keys] = await redis.scan(cursor, { match: "chat:messages:*", count: 1000 });
-      cursor = newCursor;
-      iterations++;
-      for (const key of keys) {
-        const len = await redis.llen(key);
-        messageCount += len;
-      }
-    } while (cursor !== 0 && cursor !== "0" && iterations < 100);
+    for (const roomId of roomIds) {
+      messageCount += (await getAdminRoomMessages(redis, roomId)).length;
+    }
 
     return { totalUsers: userCount, totalRooms: roomCount, totalMessages: messageCount };
   } catch (error) {

--- a/api/admin.ts
+++ b/api/admin.ts
@@ -44,6 +44,7 @@ interface AdminRequest {
   confirmPattern?: string;
   limit?: number;
   dryRun?: boolean;
+  cursor?: string;
 }
 
 interface UserProfile {
@@ -1210,9 +1211,11 @@ export default apiHandler<AdminRequest>(
           }
           const limit = clampInteger(body?.limit, 100, 1, 500);
           const dryRun = body?.dryRun !== false;
-          const data = await backfillRedisKeyScheme(redis, { pattern, limit, dryRun });
+          const cursor = normalizeRedisCursor(body?.cursor);
+          const data = await backfillRedisKeyScheme(redis, { pattern, limit, dryRun, cursor });
           logger.info("Redis key scheme backfill requested", {
             pattern,
+            cursor: data.cursor,
             dryRun,
             scanned: data.scanned,
             copied: data.copied,
@@ -1241,9 +1244,11 @@ export default apiHandler<AdminRequest>(
           }
           const limit = clampInteger(body?.limit, 100, 1, 500);
           const dryRun = body?.dryRun !== false;
-          const data = await deleteLegacyRedisKeys(redis, { pattern, limit, dryRun });
+          const cursor = normalizeRedisCursor(body?.cursor);
+          const data = await deleteLegacyRedisKeys(redis, { pattern, limit, dryRun, cursor });
           logger.info("Legacy Redis key delete requested", {
             pattern,
+            cursor: data.cursor,
             dryRun,
             scanned: data.scanned,
             deleted: data.deleted,

--- a/api/admin.ts
+++ b/api/admin.ts
@@ -22,6 +22,12 @@ import {
   executeCursorCloudAgent,
   listCursorSdkRunsFromRedis,
 } from "./chat/tools/cursor-repo-agent.js";
+import {
+  backfillRedisKeyScheme,
+  deleteLegacyRedisKeys,
+  getRedisMigrationStatus,
+  assertKnownLegacyRedisPattern,
+} from "./_utils/redis-key-migration.js";
 
 export const runtime = "nodejs";
 export const maxDuration = 30;
@@ -34,6 +40,10 @@ interface AdminRequest {
   modelId?: string;
   key?: string;
   confirmKey?: string;
+  pattern?: string;
+  confirmPattern?: string;
+  limit?: number;
+  dryRun?: boolean;
 }
 
 interface UserProfile {
@@ -941,6 +951,17 @@ export default apiHandler<AdminRequest>(
           res.status(200).json(data);
           return;
         }
+        case "getRedisKeyMigrationStatus": {
+          const limit = clampInteger(req.query.limit, 50, 1, 500);
+          const data = await getRedisMigrationStatus(redis, limit);
+          logger.info("Redis key migration status retrieved", {
+            totalLegacyKeys: data.totalLegacyKeys,
+            truncated: data.truncated,
+          });
+          logger.response(200, Date.now() - startTime);
+          res.status(200).json(data);
+          return;
+        }
         default:
           logger.response(400, Date.now() - startTime);
           res.status(400).json({ error: "Invalid action" });
@@ -1169,6 +1190,67 @@ export default apiHandler<AdminRequest>(
             success: deletedCount > 0,
             deletedCount,
           });
+          return;
+        }
+        case "backfillRedisKeyScheme": {
+          const pattern = normalizeRedisPattern(body?.pattern);
+          const confirmPattern =
+            typeof body?.confirmPattern === "string" ? body.confirmPattern : "";
+          if (confirmPattern !== pattern) {
+            logger.response(400, Date.now() - startTime);
+            res.status(400).json({ error: "Confirmation does not match Redis pattern" });
+            return;
+          }
+          try {
+            assertKnownLegacyRedisPattern(pattern);
+          } catch (error) {
+            logger.response(400, Date.now() - startTime);
+            res.status(400).json({ error: error instanceof Error ? error.message : "Invalid pattern" });
+            return;
+          }
+          const limit = clampInteger(body?.limit, 100, 1, 500);
+          const dryRun = body?.dryRun !== false;
+          const data = await backfillRedisKeyScheme(redis, { pattern, limit, dryRun });
+          logger.info("Redis key scheme backfill requested", {
+            pattern,
+            dryRun,
+            scanned: data.scanned,
+            copied: data.copied,
+            skipped: data.skipped,
+            truncated: data.truncated,
+          });
+          logger.response(200, Date.now() - startTime);
+          res.status(200).json(data);
+          return;
+        }
+        case "deleteLegacyRedisKeys": {
+          const pattern = normalizeRedisPattern(body?.pattern);
+          const confirmPattern =
+            typeof body?.confirmPattern === "string" ? body.confirmPattern : "";
+          if (confirmPattern !== pattern) {
+            logger.response(400, Date.now() - startTime);
+            res.status(400).json({ error: "Confirmation does not match Redis pattern" });
+            return;
+          }
+          try {
+            assertKnownLegacyRedisPattern(pattern);
+          } catch (error) {
+            logger.response(400, Date.now() - startTime);
+            res.status(400).json({ error: error instanceof Error ? error.message : "Invalid pattern" });
+            return;
+          }
+          const limit = clampInteger(body?.limit, 100, 1, 500);
+          const dryRun = body?.dryRun !== false;
+          const data = await deleteLegacyRedisKeys(redis, { pattern, limit, dryRun });
+          logger.info("Legacy Redis key delete requested", {
+            pattern,
+            dryRun,
+            scanned: data.scanned,
+            deleted: data.deleted,
+            truncated: data.truncated,
+          });
+          logger.response(200, Date.now() - startTime);
+          res.status(200).json(data);
           return;
         }
         default:

--- a/api/ai/cursor-run-status.ts
+++ b/api/ai/cursor-run-status.ts
@@ -7,6 +7,8 @@ import {
   CURSOR_REPO_AGENT_OWNER,
   cursorSdkEventsKey,
   cursorSdkMetaKey,
+  legacyCursorSdkEventsKey,
+  legacyCursorSdkMetaKey,
 } from "../chat/tools/cursor-repo-agent.js";
 import { apiHandler } from "../_utils/api-handler.js";
 
@@ -77,7 +79,9 @@ export default apiHandler(
     }
 
     const metaKey = cursorSdkMetaKey(runId);
-    const rawMeta = await redis.get(metaKey);
+    const rawMeta =
+      (await redis.get(metaKey)) ??
+      (await redis.get(legacyCursorSdkMetaKey(runId)));
     const meta = parseStoredJson<{ username?: string }>(rawMeta);
     if (!meta) {
       logger.response(404, Date.now() - startTime);
@@ -92,7 +96,11 @@ export default apiHandler(
     }
 
     const eventsKey = cursorSdkEventsKey(runId);
-    const rawLinesUnknown = await redis.lrange(eventsKey, 0, -1);
+    const canonicalLines = await redis.lrange(eventsKey, 0, -1);
+    const rawLinesUnknown =
+      canonicalLines.length > 0
+        ? canonicalLines
+        : await redis.lrange(legacyCursorSdkEventsKey(runId), 0, -1);
     const rawLines = Array.isArray(rawLinesUnknown)
       ? rawLinesUnknown
       : [];

--- a/api/ai/process-daily-notes.ts
+++ b/api/ai/process-daily-notes.ts
@@ -138,7 +138,6 @@ export async function processDailyNotesForUser(
     log("[processDailyNotes] Skipping — another run already in progress", { username });
     return EMPTY;
   }
-  await redis.set(legacyLockKey, "1", { ex: 120 });
 
   try {
     return await _processDailyNotesForUserInner(redis, username, log, logError, timeZone);

--- a/api/ai/process-daily-notes.ts
+++ b/api/ai/process-daily-notes.ts
@@ -36,6 +36,7 @@ import {
   CANONICAL_MEMORY_KEYS,
 } from "../_utils/_memory.js";
 import { getStoredUserTimeZone } from "../_utils/auth/_user-record.js";
+import { redisKeys } from "../../src/shared/redisKeys.js";
 
 export const runtime = "nodejs";
 export const maxDuration = 60;
@@ -126,18 +127,24 @@ export async function processDailyNotesForUser(
 
   // Acquire a short-lived lock to prevent concurrent processing for the same user.
   // If another request is already processing, we skip (the other run will handle it).
-  const lockKey = `memory:user:${username}:processing_lock`;
+  const lockKey = redisKeys.memory.processingLock(username);
+  const legacyLockKey = `memory:user:${username}:processing_lock`;
+  if ((await redis.exists(legacyLockKey)) > 0) {
+    log("[processDailyNotes] Skipping — another run already in progress", { username });
+    return EMPTY;
+  }
   const acquired = await redis.set(lockKey, "1", { nx: true, ex: 120 }); // 2-min TTL
   if (!acquired) {
     log("[processDailyNotes] Skipping — another run already in progress", { username });
     return EMPTY;
   }
+  await redis.set(legacyLockKey, "1", { ex: 120 });
 
   try {
     return await _processDailyNotesForUserInner(redis, username, log, logError, timeZone);
   } finally {
     // Release lock when done (or on error)
-    await redis.del(lockKey).catch(() => {});
+    await redis.del(lockKey, legacyLockKey).catch(() => {});
   }
 }
 

--- a/api/airdrop/discover.ts
+++ b/api/airdrop/discover.ts
@@ -4,6 +4,7 @@ import {
   AIRDROP_PRESENCE_KEY,
   AIRDROP_PRESENCE_TTL_SECONDS,
 } from "./heartbeat.js";
+import { redisKeys } from "../../src/shared/redisKeys.js";
 
 export const runtime = "nodejs";
 export const maxDuration = 10;
@@ -15,13 +16,16 @@ export default apiHandler(
     const redis = createRedis();
 
     const cutoff = Date.now() - AIRDROP_PRESENCE_TTL_SECONDS * 1000;
+    const canonicalPresenceKey = redisKeys.presence.airdropLobby();
+    await redis.zremrangebyscore(canonicalPresenceKey, 0, cutoff);
     await redis.zremrangebyscore(AIRDROP_PRESENCE_KEY, 0, cutoff);
 
-    const onlineUsers: string[] = await redis.zrange(
-      AIRDROP_PRESENCE_KEY,
-      0,
-      -1
-    );
+    const onlineUsers: string[] = [
+      ...new Set([
+        ...(await redis.zrange(canonicalPresenceKey, 0, -1)),
+        ...(await redis.zrange(AIRDROP_PRESENCE_KEY, 0, -1)),
+      ]),
+    ];
 
     const nearbyUsers = onlineUsers.filter((u) => u !== username);
 

--- a/api/airdrop/heartbeat.ts
+++ b/api/airdrop/heartbeat.ts
@@ -21,7 +21,6 @@ export default apiHandler(
       member: username,
     };
     await redis.zadd(redisKeys.presence.airdropLobby(), entry);
-    await redis.zadd(AIRDROP_PRESENCE_KEY, entry);
 
     // Broadcast presence to the shared lobby so other clients update instantly
     await triggerRealtimeEvent(AIRDROP_LOBBY_CHANNEL, "airdrop-presence", {

--- a/api/airdrop/heartbeat.ts
+++ b/api/airdrop/heartbeat.ts
@@ -1,6 +1,7 @@
 import { apiHandler } from "../_utils/api-handler.js";
 import { createRedis } from "../_utils/redis.js";
 import { triggerRealtimeEvent } from "../_utils/realtime.js";
+import { redisKeys } from "../../src/shared/redisKeys.js";
 
 export const runtime = "nodejs";
 export const maxDuration = 10;
@@ -15,10 +16,12 @@ export default apiHandler(
     const username = user!.username;
     const redis = createRedis();
 
-    await redis.zadd(AIRDROP_PRESENCE_KEY, {
+    const entry = {
       score: Date.now(),
       member: username,
-    });
+    };
+    await redis.zadd(redisKeys.presence.airdropLobby(), entry);
+    await redis.zadd(AIRDROP_PRESENCE_KEY, entry);
 
     // Broadcast presence to the shared lobby so other clients update instantly
     await triggerRealtimeEvent(AIRDROP_LOBBY_CHANNEL, "airdrop-presence", {

--- a/api/airdrop/respond.ts
+++ b/api/airdrop/respond.ts
@@ -1,6 +1,7 @@
 import { apiHandler } from "../_utils/api-handler.js";
 import { createRedis } from "../_utils/redis.js";
 import { triggerRealtimeEvent } from "../_utils/realtime.js";
+import { redisKeys } from "../../src/shared/redisKeys.js";
 
 export const runtime = "nodejs";
 export const maxDuration = 15;
@@ -24,9 +25,12 @@ export default apiHandler<RespondBody>(
 
     const { transferId, accept } = body;
     const redis = createRedis();
-    const transferKey = `airdrop:transfer:${transferId}`;
+    const transferKey = redisKeys.session.airdropTransfer(transferId);
+    const legacyTransferKey = `airdrop:transfer:${transferId}`;
 
-    const raw = await redis.get<string>(transferKey);
+    const raw =
+      (await redis.get<string>(transferKey)) ??
+      (await redis.get<string>(legacyTransferKey));
     if (!raw) {
       res.status(404).json({ error: "Transfer expired or not found" });
       return;
@@ -53,7 +57,7 @@ export default apiHandler<RespondBody>(
     }
 
     if (accept) {
-      await redis.del(transferKey);
+      await redis.del(transferKey, legacyTransferKey);
 
       await triggerRealtimeEvent(
         `airdrop-${transfer.sender}`,
@@ -73,7 +77,7 @@ export default apiHandler<RespondBody>(
         sender: transfer.sender,
       });
     } else {
-      await redis.del(transferKey);
+      await redis.del(transferKey, legacyTransferKey);
 
       await triggerRealtimeEvent(
         `airdrop-${transfer.sender}`,

--- a/api/airdrop/send.ts
+++ b/api/airdrop/send.ts
@@ -57,7 +57,6 @@ export default apiHandler<SendBody>(
 
     const transferId = crypto.randomUUID();
     const transferKey = redisKeys.session.airdropTransfer(transferId);
-    const legacyTransferKey = `airdrop:transfer:${transferId}`;
     const transferData = {
       id: transferId,
       sender: senderUsername,
@@ -69,9 +68,6 @@ export default apiHandler<SendBody>(
     };
 
     await redis.set(transferKey, JSON.stringify(transferData), {
-      ex: TRANSFER_TTL_SECONDS,
-    });
-    await redis.set(legacyTransferKey, JSON.stringify(transferData), {
       ex: TRANSFER_TTL_SECONDS,
     });
 

--- a/api/airdrop/send.ts
+++ b/api/airdrop/send.ts
@@ -5,6 +5,7 @@ import {
   AIRDROP_PRESENCE_KEY,
   AIRDROP_PRESENCE_TTL_SECONDS,
 } from "./heartbeat.js";
+import { redisKeys } from "../../src/shared/redisKeys.js";
 
 export const runtime = "nodejs";
 export const maxDuration = 15;
@@ -39,8 +40,15 @@ export default apiHandler<SendBody>(
     const redis = createRedis();
 
     const cutoff = Date.now() - AIRDROP_PRESENCE_TTL_SECONDS * 1000;
+    const canonicalPresenceKey = redisKeys.presence.airdropLobby();
+    await redis.zremrangebyscore(canonicalPresenceKey, 0, cutoff);
     await redis.zremrangebyscore(AIRDROP_PRESENCE_KEY, 0, cutoff);
-    const onlineUsers: string[] = await redis.zrange(AIRDROP_PRESENCE_KEY, 0, -1);
+    const onlineUsers: string[] = [
+      ...new Set([
+        ...(await redis.zrange(canonicalPresenceKey, 0, -1)),
+        ...(await redis.zrange(AIRDROP_PRESENCE_KEY, 0, -1)),
+      ]),
+    ];
 
     if (!onlineUsers.includes(recipient)) {
       res.status(404).json({ error: "Recipient is not available" });
@@ -48,7 +56,8 @@ export default apiHandler<SendBody>(
     }
 
     const transferId = crypto.randomUUID();
-    const transferKey = `airdrop:transfer:${transferId}`;
+    const transferKey = redisKeys.session.airdropTransfer(transferId);
+    const legacyTransferKey = `airdrop:transfer:${transferId}`;
     const transferData = {
       id: transferId,
       sender: senderUsername,
@@ -60,6 +69,9 @@ export default apiHandler<SendBody>(
     };
 
     await redis.set(transferKey, JSON.stringify(transferData), {
+      ex: TRANSFER_TTL_SECONDS,
+    });
+    await redis.set(legacyTransferKey, JSON.stringify(transferData), {
       ex: TRANSFER_TTL_SECONDS,
     });
 

--- a/api/apple-music-artwork.ts
+++ b/api/apple-music-artwork.ts
@@ -1,6 +1,7 @@
 import { apiHandler } from "./_utils/api-handler.js";
 import * as RateLimit from "./_utils/_rate-limit.js";
 import { getClientIp } from "./_utils/_rate-limit.js";
+import { redisKeys } from "../src/shared/redisKeys.js";
 
 export const runtime = "nodejs";
 export const maxDuration = 15;
@@ -88,11 +89,12 @@ export default apiHandler(
       logger.error("Rate limit check failed", e);
     }
 
-    const cacheKey = `${CACHE_PREFIX}${catalogId}`;
+    const cacheKey = redisKeys.cache.appleArtwork(catalogId);
+    const legacyCacheKey = `${CACHE_PREFIX}${catalogId}`;
 
     // Serve from cache when available.
     try {
-      const cached = await redis.get(cacheKey);
+      const cached = (await redis.get(cacheKey)) ?? (await redis.get(legacyCacheKey));
       if (cached) {
         const parsed: ArtworkResult =
           typeof cached === "string" ? JSON.parse(cached) : (cached as ArtworkResult);
@@ -140,6 +142,9 @@ export default apiHandler(
     // Cache the result (positive longer than negative).
     try {
       await redis.set(cacheKey, JSON.stringify(result), {
+        ex: result.cover ? CACHE_TTL_SECONDS : NEGATIVE_TTL_SECONDS,
+      });
+      await redis.set(legacyCacheKey, JSON.stringify(result), {
         ex: result.cover ? CACHE_TTL_SECONDS : NEGATIVE_TTL_SECONDS,
       });
     } catch (e) {

--- a/api/apple-music-artwork.ts
+++ b/api/apple-music-artwork.ts
@@ -144,9 +144,6 @@ export default apiHandler(
       await redis.set(cacheKey, JSON.stringify(result), {
         ex: result.cover ? CACHE_TTL_SECONDS : NEGATIVE_TTL_SECONDS,
       });
-      await redis.set(legacyCacheKey, JSON.stringify(result), {
-        ex: result.cover ? CACHE_TTL_SECONDS : NEGATIVE_TTL_SECONDS,
-      });
     } catch (e) {
       logger.warn("Artwork cache write failed", e);
     }

--- a/api/auth/login.ts
+++ b/api/auth/login.ts
@@ -21,7 +21,6 @@ import {
   isLoginLocked,
   recordLoginFailure,
   resetLoginFailures,
-  CHAT_USERS_PREFIX,
   TOKEN_GRACE_PERIOD,
 } from "../_utils/auth/index.js";
 import { verifyPassword, getUserPasswordHash } from "../_utils/auth/_password.js";
@@ -29,7 +28,10 @@ import { apiHandler } from "../_utils/api-handler.js";
 import { buildSetAuthCookie } from "../_utils/_cookie.js";
 import { getClientIp } from "../_utils/_rate-limit.js";
 import { getHeader } from "../_utils/request-helpers.js";
-import { updateStoredUserTimeZone } from "../_utils/auth/_user-record.js";
+import {
+  getStoredUserRecord,
+  updateStoredUserTimeZone,
+} from "../_utils/auth/_user-record.js";
 
 export const runtime = "nodejs";
 export const maxDuration = 15;
@@ -85,10 +87,8 @@ export default apiHandler(
       return;
     }
 
-    const userKey = `${CHAT_USERS_PREFIX}${username}`;
-
     // Check if user exists
-    const userData = await redis.get(userKey);
+    const userData = await getStoredUserRecord(redis, username);
     if (!userData) {
       // Same generic error as wrong-password to avoid username enumeration.
       // We DO NOT increment the per-user fail counter because this username

--- a/api/auth/register.ts
+++ b/api/auth/register.ts
@@ -11,7 +11,6 @@ import {
   isLoginLocked,
   recordLoginFailure,
   resetLoginFailures,
-  CHAT_USERS_PREFIX,
   PASSWORD_MIN_LENGTH,
   PASSWORD_MAX_LENGTH,
 } from "../_utils/auth/index.js";
@@ -29,7 +28,9 @@ import { buildSetAuthCookie } from "../_utils/_cookie.js";
 import { getClientIp } from "../_utils/_rate-limit.js";
 import { getHeader } from "../_utils/request-helpers.js";
 import {
+  getStoredUserRecord,
   normalizeUserTimeZone,
+  setStoredUserRecord,
   updateStoredUserTimeZone,
 } from "../_utils/auth/_user-record.js";
 
@@ -115,10 +116,9 @@ export default apiHandler(
     }
 
     const username = rawUsername.toLowerCase();
-    const userKey = `${CHAT_USERS_PREFIX}${username}`;
 
     // Check if user already exists
-    const existingUser = await redis.get(userKey);
+    const existingUser = await getStoredUserRecord(redis, username);
     if (existingUser) {
       // User exists - try to log them in with provided password. This path is
       // subject to the SAME per-username lockout as /api/auth/login so it
@@ -176,7 +176,7 @@ export default apiHandler(
         ? { timeZone: requestTimeZone, timeZoneUpdatedAt: now }
         : {}),
     };
-    await redis.set(userKey, JSON.stringify(userData));
+    await setStoredUserRecord(redis, username, userData);
 
     // Hash and store password
     const passwordHash = await hashPassword(password);

--- a/api/auth/token/refresh.ts
+++ b/api/auth/token/refresh.ts
@@ -11,13 +11,13 @@ import {
   storeLastValidToken,
   validateAuth,
   isUserBanned,
-  CHAT_USERS_PREFIX,
   TOKEN_GRACE_PERIOD,
 } from "../../_utils/auth/index.js";
 import * as RateLimit from "../../_utils/_rate-limit.js";
 import { getClientIp } from "../../_utils/_rate-limit.js";
 import { apiHandler } from "../../_utils/api-handler.js";
 import { buildSetAuthCookie, parseAuthCookie } from "../../_utils/_cookie.js";
+import { getStoredUserRecord } from "../../_utils/auth/_user-record.js";
 
 export const runtime = "nodejs";
 
@@ -79,8 +79,7 @@ export default apiHandler<RefreshRequest>(
     const username = rawUsername.toLowerCase();
 
     // Check if user exists
-    const userKey = `${CHAT_USERS_PREFIX}${username}`;
-    const userData = await redis.get(userKey);
+    const userData = await getStoredUserRecord(redis, username);
     if (!userData) {
       logger.warn("User not found", { username });
       logger.response(404, Date.now() - startTime);

--- a/api/chat/tools/cursor-repo-agent.ts
+++ b/api/chat/tools/cursor-repo-agent.ts
@@ -542,7 +542,6 @@ export async function executeListCursorCloudAgentRuns(
 async function safePushEvent(
   redis: Redis,
   eventsKey: string,
-  legacyEventsKey: string | null,
   payload: unknown
 ): Promise<void> {
   let line: string;
@@ -557,10 +556,6 @@ async function safePushEvent(
   }
   await redis.lpush(eventsKey, line);
   await redis.expire(eventsKey, CURSOR_SDK_RUN_TTL_SEC);
-  if (legacyEventsKey) {
-    await redis.lpush(legacyEventsKey, line);
-    await redis.expire(legacyEventsKey, CURSOR_SDK_RUN_TTL_SEC);
-  }
 }
 
 async function executeBlockingPrompt(
@@ -603,7 +598,6 @@ interface BackgroundCursorRunInput {
   username: string;
   eventsKey: string;
   metaKey: string;
-  legacyEventsKey?: string;
   legacyMetaKey?: string;
   repoUrl?: string;
   startingRef?: string;
@@ -654,9 +648,6 @@ async function writeMergedMeta(
   const existing = await readRunMeta(redis, metaKey, legacyMetaKey);
   const merged: Record<string, unknown> = { ...(existing ?? {}), ...patch };
   await redis.set(metaKey, JSON.stringify(merged), { ex: CURSOR_SDK_RUN_TTL_SEC });
-  if (legacyMetaKey) {
-    await redis.set(legacyMetaKey, JSON.stringify(merged), { ex: CURSOR_SDK_RUN_TTL_SEC });
-  }
   log("[cursorCloudAgent] meta updated", {
     metaKey,
     keys: Object.keys(merged),
@@ -668,7 +659,6 @@ function spawnBackgroundCursorRun(input: BackgroundCursorRunInput): void {
     redis,
     eventsKey,
     metaKey,
-    legacyEventsKey,
     legacyMetaKey,
     runId,
     agentId,
@@ -691,7 +681,7 @@ function spawnBackgroundCursorRun(input: BackgroundCursorRunInput): void {
     let prUrlMaybe: string | undefined = inheritedPrUrl;
     try {
       for await (const ev of run.stream()) {
-        await safePushEvent(redis, eventsKey, legacyEventsKey ?? null, { ts: Date.now(), ev });
+        await safePushEvent(redis, eventsKey, { ts: Date.now(), ev });
       }
 
       let summary = "";
@@ -707,7 +697,7 @@ function spawnBackgroundCursorRun(input: BackgroundCursorRunInput): void {
       prUrlMaybe = pickPrUrlFromRunGit(run.git) ?? inheritedPrUrl;
       const prUrl = prUrlMaybe;
 
-      await safePushEvent(redis, eventsKey, legacyEventsKey ?? null, {
+      await safePushEvent(redis, eventsKey, {
         ts: Date.now(),
         type: "terminal",
         status,
@@ -754,7 +744,7 @@ function spawnBackgroundCursorRun(input: BackgroundCursorRunInput): void {
     } catch (e) {
       logError("[cursorCloudAgent] background run failed", e);
       const errorText = e instanceof Error ? e.message : String(e);
-      await safePushEvent(redis, eventsKey, legacyEventsKey ?? null, {
+      await safePushEvent(redis, eventsKey, {
         ts: Date.now(),
         type: "terminal",
         status: "error",
@@ -892,8 +882,6 @@ export async function executeCursorCloudAgent(
 
     const eventsKey = cursorSdkEventsKey(runId);
     const metaKey = cursorSdkMetaKey(runId);
-    const legacyEventsKey = legacyCursorSdkEventsKey(runId);
-    const legacyMetaKey = legacyCursorSdkMetaKey(runId);
     const initialMeta = JSON.stringify({
       username: context.username,
       runId,
@@ -914,11 +902,6 @@ export async function executeCursorCloudAgent(
       initialMeta,
       { ex: CURSOR_SDK_RUN_TTL_SEC }
     );
-    await context.redis.set(
-      legacyMetaKey,
-      initialMeta,
-      { ex: CURSOR_SDK_RUN_TTL_SEC }
-    );
 
     const latestRunPayload = JSON.stringify({
       username: context.username,
@@ -927,11 +910,6 @@ export async function executeCursorCloudAgent(
     });
     await context.redis.set(
       cursorSdkAgentLatestRunKey(agentId),
-      latestRunPayload,
-      { ex: CURSOR_SDK_RUN_TTL_SEC }
-    );
-    await context.redis.set(
-      legacyCursorSdkAgentLatestRunKey(agentId),
       latestRunPayload,
       { ex: CURSOR_SDK_RUN_TTL_SEC }
     );
@@ -948,8 +926,6 @@ export async function executeCursorCloudAgent(
       username: context.username!,
       eventsKey,
       metaKey,
-      legacyEventsKey,
-      legacyMetaKey,
       log: context.log,
       logError: context.logError,
       agent,
@@ -1131,8 +1107,6 @@ export async function sendCursorAgentFollowup(input: {
   const newRunId = run.id;
   const newEventsKey = cursorSdkEventsKey(newRunId);
   const newMetaKey = cursorSdkMetaKey(newRunId);
-  const legacyNewEventsKey = legacyCursorSdkEventsKey(newRunId);
-  const legacyNewMetaKey = legacyCursorSdkMetaKey(newRunId);
   const followupMeta = JSON.stringify({
     username,
     runId: newRunId,
@@ -1158,11 +1132,6 @@ export async function sendCursorAgentFollowup(input: {
     followupMeta,
     { ex: CURSOR_SDK_RUN_TTL_SEC }
   );
-  await redis.set(
-    legacyNewMetaKey,
-    followupMeta,
-    { ex: CURSOR_SDK_RUN_TTL_SEC }
-  );
 
   await writeMergedMeta(
     redis,
@@ -1182,11 +1151,6 @@ export async function sendCursorAgentFollowup(input: {
     latestRunPayload,
     { ex: CURSOR_SDK_RUN_TTL_SEC }
   );
-  await redis.set(
-    legacyCursorSdkAgentLatestRunKey(agentId),
-    latestRunPayload,
-    { ex: CURSOR_SDK_RUN_TTL_SEC }
-  );
 
   spawnBackgroundCursorRun({
     redis,
@@ -1196,8 +1160,6 @@ export async function sendCursorAgentFollowup(input: {
     username,
     eventsKey: newEventsKey,
     metaKey: newMetaKey,
-    legacyEventsKey: legacyNewEventsKey,
-    legacyMetaKey: legacyNewMetaKey,
     ...(repoUrl ? { repoUrl } : {}),
     ...(startingRef ? { startingRef } : {}),
     ...(modelId ? { modelId } : {}),

--- a/api/chat/tools/cursor-repo-agent.ts
+++ b/api/chat/tools/cursor-repo-agent.ts
@@ -9,6 +9,7 @@ import { z } from "zod";
 import type { MemoryToolContext } from "./executors.js";
 import { simplifyTelegramCitationDisplay } from "../../_utils/telegram-format.js";
 import { sendTelegramMessage } from "../../_utils/telegram.js";
+import { redisKeys } from "../../../src/shared/redisKeys.js";
 
 export const CURSOR_REPO_AGENT_OWNER = "ryo";
 
@@ -16,22 +17,36 @@ export const CURSOR_SDK_RUN_TTL_SEC = 90 * 86_400;
 
 /** Redis key prefixes — keep in sync with api/ai/cursor-run-status.ts */
 export function cursorSdkEventsKey(runId: string): string {
+  return redisKeys.agent.cursorRunEvents(runId);
+}
+
+export function legacyCursorSdkEventsKey(runId: string): string {
   return `cursor-sdk-run:${runId}:events`;
 }
 
 export function cursorSdkMetaKey(runId: string): string {
+  return redisKeys.agent.cursorRunMeta(runId);
+}
+
+export function legacyCursorSdkMetaKey(runId: string): string {
   return `cursor-sdk-run:${runId}:meta`;
 }
 
 /** Tracks the latest run for a given Cursor agent so follow-ups can resume it. */
 export function cursorSdkAgentLatestRunKey(agentId: string): string {
+  return redisKeys.agent.cursorLatestRun(agentId);
+}
+
+export function legacyCursorSdkAgentLatestRunKey(agentId: string): string {
   return `cursor-sdk-agent:${agentId}:latestRun`;
 }
 
 /** Redis SCAN pattern for run metadata keys — keep in sync with api/admin.ts */
-export const CURSOR_SDK_META_KEY_PATTERN = "cursor-sdk-run:*:meta";
+export const CURSOR_SDK_META_KEY_PATTERN = "agent:cursor:run:*:meta";
+export const LEGACY_CURSOR_SDK_META_KEY_PATTERN = "cursor-sdk-run:*:meta";
 
-const META_RUN_ID_REGEX = /^cursor-sdk-run:([^:]+):meta$/;
+const META_RUN_ID_REGEX = /^agent:cursor:run:([^:]+):meta$/;
+const LEGACY_META_RUN_ID_REGEX = /^cursor-sdk-run:([^:]+):meta$/;
 
 const TOOL_LOG_PREFIX = "[cursorCloudAgent]";
 
@@ -357,17 +372,20 @@ export async function listCursorSdkRunsFromRedis(
   const maxIterations = 200;
 
   try {
-    do {
-      const [nextCursor, keys] = await redis.scan(cursor, {
-        match: CURSOR_SDK_META_KEY_PATTERN,
-        count: 500,
-      });
-      cursor = nextCursor;
-      iterations++;
-      for (const k of keys) {
-        if (typeof k === "string") metaKeys.add(k);
-      }
-    } while (cursor !== 0 && cursor !== "0" && iterations < maxIterations);
+    for (const pattern of [CURSOR_SDK_META_KEY_PATTERN, LEGACY_CURSOR_SDK_META_KEY_PATTERN]) {
+      cursor = 0;
+      do {
+        const [nextCursor, keys] = await redis.scan(cursor, {
+          match: pattern,
+          count: 500,
+        });
+        cursor = nextCursor;
+        iterations++;
+        for (const k of keys) {
+          if (typeof k === "string") metaKeys.add(k);
+        }
+      } while (cursor !== 0 && cursor !== "0" && iterations < maxIterations);
+    }
   } catch (e) {
     console.error(`${TOOL_LOG_PREFIX} listCursorSdkRunsFromRedis scan failed`, e);
     return { runs: [], totalCount: 0, scanIncomplete: false };
@@ -395,7 +413,9 @@ export async function listCursorSdkRunsFromRedis(
       const rec = parseStoredRecordForRunList(values[j]);
       if (!rec) continue;
 
-      const fromKey = META_RUN_ID_REGEX.exec(key)?.[1];
+      const fromKey =
+        META_RUN_ID_REGEX.exec(key)?.[1] ??
+        LEGACY_META_RUN_ID_REGEX.exec(key)?.[1];
       const runId = strFieldRunList(rec, "runId") ?? fromKey;
       if (!runId) continue;
 
@@ -522,6 +542,7 @@ export async function executeListCursorCloudAgentRuns(
 async function safePushEvent(
   redis: Redis,
   eventsKey: string,
+  legacyEventsKey: string | null,
   payload: unknown
 ): Promise<void> {
   let line: string;
@@ -536,6 +557,10 @@ async function safePushEvent(
   }
   await redis.lpush(eventsKey, line);
   await redis.expire(eventsKey, CURSOR_SDK_RUN_TTL_SEC);
+  if (legacyEventsKey) {
+    await redis.lpush(legacyEventsKey, line);
+    await redis.expire(legacyEventsKey, CURSOR_SDK_RUN_TTL_SEC);
+  }
 }
 
 async function executeBlockingPrompt(
@@ -578,6 +603,8 @@ interface BackgroundCursorRunInput {
   username: string;
   eventsKey: string;
   metaKey: string;
+  legacyEventsKey?: string;
+  legacyMetaKey?: string;
   repoUrl?: string;
   startingRef?: string;
   modelId?: string;
@@ -596,9 +623,12 @@ interface BackgroundCursorRunInput {
 /** Read the run's existing meta (if any) so background updates merge instead of overwriting. */
 async function readRunMeta(
   redis: Redis,
-  metaKey: string
+  metaKey: string,
+  legacyMetaKey?: string
 ): Promise<Record<string, unknown> | null> {
-  const raw = await redis.get(metaKey);
+  const raw =
+    (await redis.get(metaKey)) ??
+    (legacyMetaKey ? await redis.get(legacyMetaKey) : null);
   if (raw === null || raw === undefined) return null;
   if (typeof raw === "object") return raw as Record<string, unknown>;
   if (typeof raw === "string") {
@@ -617,12 +647,16 @@ async function readRunMeta(
 async function writeMergedMeta(
   redis: Redis,
   metaKey: string,
+  legacyMetaKey: string | undefined,
   patch: Record<string, unknown>,
   log: (...args: unknown[]) => void
 ): Promise<void> {
-  const existing = await readRunMeta(redis, metaKey);
+  const existing = await readRunMeta(redis, metaKey, legacyMetaKey);
   const merged: Record<string, unknown> = { ...(existing ?? {}), ...patch };
   await redis.set(metaKey, JSON.stringify(merged), { ex: CURSOR_SDK_RUN_TTL_SEC });
+  if (legacyMetaKey) {
+    await redis.set(legacyMetaKey, JSON.stringify(merged), { ex: CURSOR_SDK_RUN_TTL_SEC });
+  }
   log("[cursorCloudAgent] meta updated", {
     metaKey,
     keys: Object.keys(merged),
@@ -634,6 +668,8 @@ function spawnBackgroundCursorRun(input: BackgroundCursorRunInput): void {
     redis,
     eventsKey,
     metaKey,
+    legacyEventsKey,
+    legacyMetaKey,
     runId,
     agentId,
     agentTitle,
@@ -655,7 +691,7 @@ function spawnBackgroundCursorRun(input: BackgroundCursorRunInput): void {
     let prUrlMaybe: string | undefined = inheritedPrUrl;
     try {
       for await (const ev of run.stream()) {
-        await safePushEvent(redis, eventsKey, { ts: Date.now(), ev });
+        await safePushEvent(redis, eventsKey, legacyEventsKey ?? null, { ts: Date.now(), ev });
       }
 
       let summary = "";
@@ -671,7 +707,7 @@ function spawnBackgroundCursorRun(input: BackgroundCursorRunInput): void {
       prUrlMaybe = pickPrUrlFromRunGit(run.git) ?? inheritedPrUrl;
       const prUrl = prUrlMaybe;
 
-      await safePushEvent(redis, eventsKey, {
+      await safePushEvent(redis, eventsKey, legacyEventsKey ?? null, {
         ts: Date.now(),
         type: "terminal",
         status,
@@ -684,6 +720,7 @@ function spawnBackgroundCursorRun(input: BackgroundCursorRunInput): void {
       await writeMergedMeta(
         redis,
         metaKey,
+        legacyMetaKey,
         {
           username,
           runId,
@@ -717,7 +754,7 @@ function spawnBackgroundCursorRun(input: BackgroundCursorRunInput): void {
     } catch (e) {
       logError("[cursorCloudAgent] background run failed", e);
       const errorText = e instanceof Error ? e.message : String(e);
-      await safePushEvent(redis, eventsKey, {
+      await safePushEvent(redis, eventsKey, legacyEventsKey ?? null, {
         ts: Date.now(),
         type: "terminal",
         status: "error",
@@ -726,6 +763,7 @@ function spawnBackgroundCursorRun(input: BackgroundCursorRunInput): void {
       await writeMergedMeta(
         redis,
         metaKey,
+        legacyMetaKey,
         {
           username,
           runId,
@@ -854,33 +892,47 @@ export async function executeCursorCloudAgent(
 
     const eventsKey = cursorSdkEventsKey(runId);
     const metaKey = cursorSdkMetaKey(runId);
+    const legacyEventsKey = legacyCursorSdkEventsKey(runId);
+    const legacyMetaKey = legacyCursorSdkMetaKey(runId);
+    const initialMeta = JSON.stringify({
+      username: context.username,
+      runId,
+      agentId,
+      ...(agentTitle ? { agentTitle } : {}),
+      repoUrl,
+      startingRef,
+      modelId,
+      ...(model.params?.length ? { modelParams: model.params } : {}),
+      autoCreatePR,
+      createdAt: Date.now(),
+      promptPreview: input.prompt.slice(0, 280),
+      activeRunId: runId,
+    });
 
     await context.redis.set(
       metaKey,
-      JSON.stringify({
-        username: context.username,
-        runId,
-        agentId,
-        ...(agentTitle ? { agentTitle } : {}),
-        repoUrl,
-        startingRef,
-        modelId,
-        ...(model.params?.length ? { modelParams: model.params } : {}),
-        autoCreatePR,
-        createdAt: Date.now(),
-        promptPreview: input.prompt.slice(0, 280),
-        activeRunId: runId,
-      }),
+      initialMeta,
+      { ex: CURSOR_SDK_RUN_TTL_SEC }
+    );
+    await context.redis.set(
+      legacyMetaKey,
+      initialMeta,
       { ex: CURSOR_SDK_RUN_TTL_SEC }
     );
 
+    const latestRunPayload = JSON.stringify({
+      username: context.username,
+      runId,
+      ...(agentTitle ? { agentTitle } : {}),
+    });
     await context.redis.set(
       cursorSdkAgentLatestRunKey(agentId),
-      JSON.stringify({
-        username: context.username,
-        runId,
-        ...(agentTitle ? { agentTitle } : {}),
-      }),
+      latestRunPayload,
+      { ex: CURSOR_SDK_RUN_TTL_SEC }
+    );
+    await context.redis.set(
+      legacyCursorSdkAgentLatestRunKey(agentId),
+      latestRunPayload,
       { ex: CURSOR_SDK_RUN_TTL_SEC }
     );
 
@@ -896,6 +948,8 @@ export async function executeCursorCloudAgent(
       username: context.username!,
       eventsKey,
       metaKey,
+      legacyEventsKey,
+      legacyMetaKey,
       log: context.log,
       logError: context.logError,
       agent,
@@ -972,7 +1026,8 @@ export async function sendCursorAgentFollowup(input: {
   }
 
   const prevMetaKey = cursorSdkMetaKey(previousRunId);
-  const prevMeta = await readRunMeta(redis, prevMetaKey);
+  const legacyPrevMetaKey = legacyCursorSdkMetaKey(previousRunId);
+  const prevMeta = await readRunMeta(redis, prevMetaKey, legacyPrevMetaKey);
   if (!prevMeta) {
     return { ok: false, status: 404, error: "Run not found" };
   }
@@ -1076,45 +1131,60 @@ export async function sendCursorAgentFollowup(input: {
   const newRunId = run.id;
   const newEventsKey = cursorSdkEventsKey(newRunId);
   const newMetaKey = cursorSdkMetaKey(newRunId);
+  const legacyNewEventsKey = legacyCursorSdkEventsKey(newRunId);
+  const legacyNewMetaKey = legacyCursorSdkMetaKey(newRunId);
+  const followupMeta = JSON.stringify({
+    username,
+    runId: newRunId,
+    agentId,
+    ...(agentTitle ? { agentTitle } : {}),
+    ...(repoUrl ? { repoUrl } : {}),
+    ...(startingRef ? { startingRef } : {}),
+    ...(modelId ? { modelId } : {}),
+    ...(modelFromMeta?.params?.length
+      ? { modelParams: modelFromMeta.params }
+      : {}),
+    ...(typeof autoCreatePR === "boolean" ? { autoCreatePR } : {}),
+    ...(inheritedPrUrl ? { prUrl: inheritedPrUrl } : {}),
+    createdAt: Date.now(),
+    promptPreview: prompt.slice(0, 280),
+    activeRunId: newRunId,
+    previousRunId,
+    isFollowup: true,
+  });
 
   await redis.set(
     newMetaKey,
-    JSON.stringify({
-      username,
-      runId: newRunId,
-      agentId,
-      ...(agentTitle ? { agentTitle } : {}),
-      ...(repoUrl ? { repoUrl } : {}),
-      ...(startingRef ? { startingRef } : {}),
-      ...(modelId ? { modelId } : {}),
-      ...(modelFromMeta?.params?.length
-        ? { modelParams: modelFromMeta.params }
-        : {}),
-      ...(typeof autoCreatePR === "boolean" ? { autoCreatePR } : {}),
-      ...(inheritedPrUrl ? { prUrl: inheritedPrUrl } : {}),
-      createdAt: Date.now(),
-      promptPreview: prompt.slice(0, 280),
-      activeRunId: newRunId,
-      previousRunId,
-      isFollowup: true,
-    }),
+    followupMeta,
+    { ex: CURSOR_SDK_RUN_TTL_SEC }
+  );
+  await redis.set(
+    legacyNewMetaKey,
+    followupMeta,
     { ex: CURSOR_SDK_RUN_TTL_SEC }
   );
 
   await writeMergedMeta(
     redis,
     prevMetaKey,
+    legacyPrevMetaKey,
     { nextRunId: newRunId },
     log
   );
 
+  const latestRunPayload = JSON.stringify({
+    username,
+    runId: newRunId,
+    ...(agentTitle ? { agentTitle } : {}),
+  });
   await redis.set(
     cursorSdkAgentLatestRunKey(agentId),
-    JSON.stringify({
-      username,
-      runId: newRunId,
-      ...(agentTitle ? { agentTitle } : {}),
-    }),
+    latestRunPayload,
+    { ex: CURSOR_SDK_RUN_TTL_SEC }
+  );
+  await redis.set(
+    legacyCursorSdkAgentLatestRunKey(agentId),
+    latestRunPayload,
     { ex: CURSOR_SDK_RUN_TTL_SEC }
   );
 
@@ -1126,6 +1196,8 @@ export async function sendCursorAgentFollowup(input: {
     username,
     eventsKey: newEventsKey,
     metaKey: newMetaKey,
+    legacyEventsKey: legacyNewEventsKey,
+    legacyMetaKey: legacyNewMetaKey,
     ...(repoUrl ? { repoUrl } : {}),
     ...(startingRef ? { startingRef } : {}),
     ...(modelId ? { modelId } : {}),

--- a/api/cron/telegram-heartbeat.ts
+++ b/api/cron/telegram-heartbeat.ts
@@ -63,13 +63,9 @@ function sendJson(
 async function markHeartbeatSlot(
   redis: ReturnType<typeof createRedis>,
   slotKey: string,
-  legacySlotKey: string,
   payload: Record<string, unknown>
 ): Promise<void> {
   await redis.set(slotKey, JSON.stringify(payload), {
-    ex: TELEGRAM_HEARTBEAT_SLOT_TTL_SECONDS,
-  });
-  await redis.set(legacySlotKey, JSON.stringify(payload), {
     ex: TELEGRAM_HEARTBEAT_SLOT_TTL_SECONDS,
   });
 }
@@ -315,7 +311,7 @@ export default async function handler(
       },
       logger
     );
-    await markHeartbeatSlot(redis, slotKey, legacySlotKey, {
+    await markHeartbeatSlot(redis, slotKey, {
       username,
       chatId: linkedAccount.chatId,
       sent: false,
@@ -434,7 +430,7 @@ export default async function handler(
       },
       logger
     );
-    await markHeartbeatSlot(redis, slotKey, legacySlotKey, {
+    await markHeartbeatSlot(redis, slotKey, {
       username,
       chatId: linkedAccount.chatId,
       sent: false,
@@ -474,7 +470,6 @@ export default async function handler(
   await markHeartbeatSlot(
     redis,
     slotKey,
-    legacySlotKey,
     {
       username,
       chatId: linkedAccount.chatId,

--- a/api/cron/telegram-heartbeat.ts
+++ b/api/cron/telegram-heartbeat.ts
@@ -17,6 +17,7 @@ import {
   buildTelegramHeartbeatNoteContext,
   buildTelegramHeartbeatConversationContext,
   buildTelegramHeartbeatPrompt,
+  buildLegacyTelegramHeartbeatRedisKey,
   buildTelegramHeartbeatRedisKey,
   buildTelegramHeartbeatStateSummary,
   formatTelegramConversationEntries,
@@ -62,9 +63,13 @@ function sendJson(
 async function markHeartbeatSlot(
   redis: ReturnType<typeof createRedis>,
   slotKey: string,
+  legacySlotKey: string,
   payload: Record<string, unknown>
 ): Promise<void> {
   await redis.set(slotKey, JSON.stringify(payload), {
+    ex: TELEGRAM_HEARTBEAT_SLOT_TTL_SECONDS,
+  });
+  await redis.set(legacySlotKey, JSON.stringify(payload), {
     ex: TELEGRAM_HEARTBEAT_SLOT_TTL_SECONDS,
   });
 }
@@ -170,7 +175,8 @@ export default async function handler(
   }
 
   const slotKey = buildTelegramHeartbeatRedisKey(username);
-  if ((await redis.exists(slotKey)) > 0) {
+  const legacySlotKey = buildLegacyTelegramHeartbeatRedisKey(username);
+  if ((await redis.exists(slotKey, legacySlotKey)) > 0) {
     await appendHeartbeatLog(
       redis,
       username,
@@ -309,7 +315,7 @@ export default async function handler(
       },
       logger
     );
-    await markHeartbeatSlot(redis, slotKey, {
+    await markHeartbeatSlot(redis, slotKey, legacySlotKey, {
       username,
       chatId: linkedAccount.chatId,
       sent: false,
@@ -428,7 +434,7 @@ export default async function handler(
       },
       logger
     );
-    await markHeartbeatSlot(redis, slotKey, {
+    await markHeartbeatSlot(redis, slotKey, legacySlotKey, {
       username,
       chatId: linkedAccount.chatId,
       sent: false,
@@ -468,6 +474,7 @@ export default async function handler(
   await markHeartbeatSlot(
     redis,
     slotKey,
+    legacySlotKey,
     {
       username,
       chatId: linkedAccount.chatId,

--- a/api/ie-generate.ts
+++ b/api/ie-generate.ts
@@ -30,8 +30,6 @@ export const maxDuration = 80;
 // Constants and Types
 // ============================================================================
 
-const IE_CACHE_PREFIX = "ie:cache:"; // Key prefix for stored generated pages
-
 type IncomingUIMessage = Omit<UIMessage, "id">;
 type SimpleMessage = {
   id?: string;
@@ -253,12 +251,6 @@ export default apiHandler<IEGenerateRequestBody>(
             effectiveYearStr
           )
         : null;
-    const legacyCacheKey =
-      normalizedUrlForKey && effectiveYearStr
-        ? `${IE_CACHE_PREFIX}${encodeURIComponent(
-            normalizedUrlForKey
-          )}:${effectiveYearStr}`
-        : null;
 
     // Removed cache read to avoid duplicate generation; cache handled through iframe-check AI mode
 
@@ -349,10 +341,6 @@ export default apiHandler<IEGenerateRequestBody>(
           }
           await redis.lpush(cacheKey, cleaned);
           await redis.ltrim(cacheKey, 0, 4);
-          if (legacyCacheKey) {
-            await redis.lpush(legacyCacheKey, cleaned);
-            await redis.ltrim(legacyCacheKey, 0, 4);
-          }
           const duration = Date.now() - startTime;
           logger.info(`Cached result for ${cacheKey} (length=${cleaned.length}, duration=${duration.toFixed(2)}ms)`);
         } catch (cacheErr) {

--- a/api/ie-generate.ts
+++ b/api/ie-generate.ts
@@ -14,6 +14,7 @@ import {
   getOpenAIProviderOptions,
 } from "./_utils/_aiModels.js";
 import { normalizeUrlForCacheKey } from "./_utils/_url.js";
+import { redisKeys, sha256RedisIdentifier } from "../src/shared/redisKeys.js";
 import {
   CORE_PRIORITY_INSTRUCTIONS,
   RYO_PERSONA_INSTRUCTIONS,
@@ -247,6 +248,13 @@ export default apiHandler<IEGenerateRequestBody>(
     // Use normalized URL for the cache key
     const cacheKey =
       normalizedUrlForKey && effectiveYearStr
+        ? redisKeys.cache.ieVersions(
+            await sha256RedisIdentifier(normalizedUrlForKey),
+            effectiveYearStr
+          )
+        : null;
+    const legacyCacheKey =
+      normalizedUrlForKey && effectiveYearStr
         ? `${IE_CACHE_PREFIX}${encodeURIComponent(
             normalizedUrlForKey
           )}:${effectiveYearStr}`
@@ -341,6 +349,10 @@ export default apiHandler<IEGenerateRequestBody>(
           }
           await redis.lpush(cacheKey, cleaned);
           await redis.ltrim(cacheKey, 0, 4);
+          if (legacyCacheKey) {
+            await redis.lpush(legacyCacheKey, cleaned);
+            await redis.ltrim(legacyCacheKey, 0, 4);
+          }
           const duration = Date.now() - startTime;
           logger.info(`Cached result for ${cacheKey} (length=${cleaned.length}, duration=${duration.toFixed(2)}ms)`);
         } catch (cacheErr) {

--- a/api/iframe-check.ts
+++ b/api/iframe-check.ts
@@ -413,8 +413,8 @@ export default apiHandler(
         for (const key of keys) {
           const parts = key.split(":");
           const yearPart = parts[3] ? decodeURIComponent(parts[3]) : "";
-          if (yearPart && /^(\d{1,4}( BC)?|\d+ CE)$/.test(yearPart)) {
-            uniqueYears.add(yearPart);
+          if (yearPart && /^(\d{1,4}( BC)?|\d+ CE)$/i.test(yearPart)) {
+            uniqueYears.add(yearPart.replace(/\b(bc|ce)\b/gi, (era) => era.toUpperCase()));
           }
         }
       } while (canonicalAiCursor !== 0);
@@ -1117,14 +1117,13 @@ export default apiHandler(
             logger.info(`Attempting to cache Wayback content for ${normalizedUrl} (${waybackYear}/${waybackMonth})`);
             const normalizedUrlForKey = normalizeUrlForCacheKey(normalizedUrl);
             if (normalizedUrlForKey) {
-              const { canonical: cacheKey, legacy: legacyCacheKey } = await getWaybackCacheKeys(
+              const { canonical: cacheKey } = await getWaybackCacheKeys(
                 normalizedUrlForKey,
                 `${waybackYear}${waybackMonth}`
               );
               logger.info(`Writing to Wayback cache key: ${cacheKey} (content length: ${html.length})`);
               // Use SET with expiration for Wayback cache (e.g., 30 days)
               await redis.set(cacheKey, html, { ex: 60 * 60 * 24 * 30 });
-              await redis.set(legacyCacheKey, html, { ex: 60 * 60 * 24 * 30 });
               logger.info(`Successfully cached Wayback content for ${cacheKey}`);
             } else {
               logger.info(`Skipped Wayback caching - URL normalization failed: ${normalizedUrl}`);

--- a/api/iframe-check.ts
+++ b/api/iframe-check.ts
@@ -5,6 +5,7 @@ import { normalizeUrlForCacheKey } from "./_utils/_url.js";
 import { safeFetchWithRedirects, validatePublicUrl, SsrfBlockedError } from "./_utils/_ssrf.js";
 import { getAppPublicOrigin } from "./_utils/runtime-config.js";
 import { decodeHtmlEntitiesOnce } from "./_utils/html-entities.js";
+import { redisKeys, sha256RedisIdentifier } from "../src/shared/redisKeys.js";
 
 export const runtime = "nodejs";
 
@@ -135,6 +136,32 @@ const generateRandomBrowserHeaders = (): Record<string, string> => {
 const IE_CACHE_PREFIX = "ie:cache:";
 const WAYBACK_CACHE_PREFIX = "wayback:cache:";
 // --- End Constants ---
+
+async function getIeCacheKeys(normalizedUrlForKey: string, year: string): Promise<{
+  canonical: string;
+  legacy: string;
+}> {
+  return {
+    canonical: redisKeys.cache.ieVersions(
+      await sha256RedisIdentifier(normalizedUrlForKey),
+      year
+    ),
+    legacy: `${IE_CACHE_PREFIX}${encodeURIComponent(normalizedUrlForKey)}:${year}`,
+  };
+}
+
+async function getWaybackCacheKeys(normalizedUrlForKey: string, yearMonth: string): Promise<{
+  canonical: string;
+  legacy: string;
+}> {
+  return {
+    canonical: redisKeys.cache.wayback(
+      await sha256RedisIdentifier(normalizedUrlForKey),
+      yearMonth
+    ),
+    legacy: `${WAYBACK_CACHE_PREFIX}${encodeURIComponent(normalizedUrlForKey)}:${yearMonth}`,
+  };
+}
 
 /**
  * Edge function that checks if a remote website allows itself to be embedded in an iframe.
@@ -322,11 +349,14 @@ export default apiHandler(
     }
 
     try {
-      const key = `${IE_CACHE_PREFIX}${encodeURIComponent(
-        normalizedUrlForKey
-      )}:${year}`;
+      const { canonical: key, legacy: legacyKey } = await getIeCacheKeys(
+        normalizedUrlForKey,
+        year
+      );
       logger.info(`Checking AI cache with key: ${key}`);
-      const html = (await redis.lindex(key, 0)) as string | null;
+      const html =
+        ((await redis.lindex(key, 0)) as string | null) ??
+        ((await redis.lindex(legacyKey, 0)) as string | null);
       if (html) {
         logger.info(`AI Cache HIT for key: ${key}`);
         res.setHeader("Content-Type", "text/html; charset=utf-8");
@@ -362,8 +392,10 @@ export default apiHandler(
 
     try {
       const uniqueYears = new Set<string>();
+      const urlHash = await sha256RedisIdentifier(normalizedUrlForKey);
 
       // Scan for AI Cache keys (ie:cache:...)
+      const canonicalAiPattern = `cache:ie:${urlHash}:*:versions`;
       const aiPattern = `${IE_CACHE_PREFIX}${encodeURIComponent(
         normalizedUrlForKey
       )}:*`;
@@ -371,6 +403,21 @@ export default apiHandler(
         normalizedUrlForKey
       )}:`.length;
       logger.info(`Scanning Redis for AI cache with pattern: ${aiPattern}`);
+      let canonicalAiCursor = 0;
+      do {
+        const [nextCursor, keys] = await redis.scan(canonicalAiCursor, {
+          match: canonicalAiPattern,
+          count: 100,
+        });
+        canonicalAiCursor = parseInt(nextCursor as unknown as string, 10);
+        for (const key of keys) {
+          const parts = key.split(":");
+          const yearPart = parts[3] ? decodeURIComponent(parts[3]) : "";
+          if (yearPart && /^(\d{1,4}( BC)?|\d+ CE)$/.test(yearPart)) {
+            uniqueYears.add(yearPart);
+          }
+        }
+      } while (canonicalAiCursor !== 0);
       let aiCursor = 0;
       do {
         const [nextCursor, keys] = await redis.scan(aiCursor, {
@@ -390,6 +437,7 @@ export default apiHandler(
       } while (aiCursor !== 0);
 
       // Scan for Wayback Cache keys (wayback:cache:...)
+      const canonicalWaybackPattern = `cache:wayback:${urlHash}:*`;
       const waybackPattern = `${WAYBACK_CACHE_PREFIX}${encodeURIComponent(
         normalizedUrlForKey
       )}:*`;
@@ -397,6 +445,20 @@ export default apiHandler(
         `${WAYBACK_CACHE_PREFIX}${encodeURIComponent(normalizedUrlForKey)}:`
           .length;
       logger.info(`Scanning Redis for Wayback cache with pattern: ${waybackPattern}`);
+      let canonicalWaybackCursor = 0;
+      do {
+        const [nextCursor, keys] = await redis.scan(canonicalWaybackCursor, {
+          match: canonicalWaybackPattern,
+          count: 100,
+        });
+        canonicalWaybackCursor = parseInt(nextCursor as unknown as string, 10);
+        for (const key of keys) {
+          const yearMonthPart = key.split(":")[3];
+          if (yearMonthPart && /^\d{6}$/.test(yearMonthPart)) {
+            uniqueYears.add(yearMonthPart.substring(0, 4));
+          }
+        }
+      } while (canonicalWaybackCursor !== 0);
       let waybackCursor = 0;
       do {
         const [nextCursor, keys] = await redis.scan(waybackCursor, {
@@ -502,11 +564,14 @@ export default apiHandler(
       logger.info(`Initializing Wayback cache check for ${normalizedUrl} (${waybackYear}/${waybackMonth})`);
       const normalizedUrlForKey = normalizeUrlForCacheKey(normalizedUrl);
       if (normalizedUrlForKey) {
-        const cacheKey = `${WAYBACK_CACHE_PREFIX}${encodeURIComponent(
-          normalizedUrlForKey
-        )}:${waybackYear}${waybackMonth}`;
+        const { canonical: cacheKey, legacy: legacyCacheKey } = await getWaybackCacheKeys(
+          normalizedUrlForKey,
+          `${waybackYear}${waybackMonth}`
+        );
         logger.info(`Generated Wayback cache key: ${cacheKey}`);
-        const cachedContent = (await redis.get(cacheKey)) as string | null;
+        const cachedContent =
+          ((await redis.get(cacheKey)) as string | null) ??
+          ((await redis.get(legacyCacheKey)) as string | null);
         if (cachedContent) {
           logger.info(`Wayback Cache HIT for ${cacheKey} (content length: ${cachedContent.length})`);
           res.setHeader("Content-Type", "text/html; charset=utf-8");
@@ -1052,12 +1117,14 @@ export default apiHandler(
             logger.info(`Attempting to cache Wayback content for ${normalizedUrl} (${waybackYear}/${waybackMonth})`);
             const normalizedUrlForKey = normalizeUrlForCacheKey(normalizedUrl);
             if (normalizedUrlForKey) {
-              const cacheKey = `${WAYBACK_CACHE_PREFIX}${encodeURIComponent(
-                normalizedUrlForKey
-              )}:${waybackYear}${waybackMonth}`;
+              const { canonical: cacheKey, legacy: legacyCacheKey } = await getWaybackCacheKeys(
+                normalizedUrlForKey,
+                `${waybackYear}${waybackMonth}`
+              );
               logger.info(`Writing to Wayback cache key: ${cacheKey} (content length: ${html.length})`);
               // Use SET with expiration for Wayback cache (e.g., 30 days)
               await redis.set(cacheKey, html, { ex: 60 * 60 * 24 * 30 });
+              await redis.set(legacyCacheKey, html, { ex: 60 * 60 * 24 * 30 });
               logger.info(`Successfully cached Wayback content for ${cacheKey}`);
             } else {
               logger.info(`Skipped Wayback caching - URL normalization failed: ${normalizedUrl}`);

--- a/api/listen/_helpers/_redis.ts
+++ b/api/listen/_helpers/_redis.ts
@@ -14,6 +14,7 @@ import {
   LISTEN_SESSIONS_SET,
   LISTEN_SESSION_TTL_SECONDS,
 } from "./_constants.js";
+import { redisKeys } from "../../../src/shared/redisKeys.js";
 
 // ============================================================================
 // Redis Client Factory
@@ -39,7 +40,9 @@ export function parseSessionData(data: unknown): ListenSession | null {
 
 export async function getSession(sessionId: string): Promise<ListenSession | null> {
   const client = createRedisClient();
-  const data = await client.get(`${LISTEN_SESSION_PREFIX}${sessionId}`);
+  const data =
+    (await client.get(redisKeys.session.listen(sessionId))) ??
+    (await client.get(`${LISTEN_SESSION_PREFIX}${sessionId}`));
   return parseSessionData(data);
 }
 
@@ -48,22 +51,32 @@ export async function setSession(
   session: ListenSession
 ): Promise<void> {
   const client = createRedisClient();
+  await client.set(redisKeys.session.listen(sessionId), JSON.stringify(session), {
+    ex: LISTEN_SESSION_TTL_SECONDS,
+  });
   await client.set(`${LISTEN_SESSION_PREFIX}${sessionId}`, JSON.stringify(session), {
     ex: LISTEN_SESSION_TTL_SECONDS,
   });
+  await client.sadd(redisKeys.session.listenIds(), sessionId);
   await client.sadd(LISTEN_SESSIONS_SET, sessionId);
 }
 
 export async function deleteSession(sessionId: string): Promise<void> {
   const client = createRedisClient();
   const pipeline = client.pipeline();
+  pipeline.del(redisKeys.session.listen(sessionId));
   pipeline.del(`${LISTEN_SESSION_PREFIX}${sessionId}`);
+  pipeline.srem(redisKeys.session.listenIds(), sessionId);
   pipeline.srem(LISTEN_SESSIONS_SET, sessionId);
   await pipeline.exec();
 }
 
 export async function touchSession(sessionId: string): Promise<void> {
   const client = createRedisClient();
+  await client.expire(
+    redisKeys.session.listen(sessionId),
+    LISTEN_SESSION_TTL_SECONDS
+  );
   await client.expire(
     `${LISTEN_SESSION_PREFIX}${sessionId}`,
     LISTEN_SESSION_TTL_SECONDS
@@ -72,6 +85,10 @@ export async function touchSession(sessionId: string): Promise<void> {
 
 export async function getActiveSessionIds(): Promise<string[]> {
   const client = createRedisClient();
-  const sessionIds = await client.smembers<string[]>(LISTEN_SESSIONS_SET);
-  return sessionIds || [];
+  return [
+    ...new Set([
+      ...((await client.smembers<string[]>(redisKeys.session.listenIds())) || []),
+      ...((await client.smembers<string[]>(LISTEN_SESSIONS_SET)) || []),
+    ]),
+  ];
 }

--- a/api/listen/_helpers/_redis.ts
+++ b/api/listen/_helpers/_redis.ts
@@ -54,11 +54,7 @@ export async function setSession(
   await client.set(redisKeys.session.listen(sessionId), JSON.stringify(session), {
     ex: LISTEN_SESSION_TTL_SECONDS,
   });
-  await client.set(`${LISTEN_SESSION_PREFIX}${sessionId}`, JSON.stringify(session), {
-    ex: LISTEN_SESSION_TTL_SECONDS,
-  });
   await client.sadd(redisKeys.session.listenIds(), sessionId);
-  await client.sadd(LISTEN_SESSIONS_SET, sessionId);
 }
 
 export async function deleteSession(sessionId: string): Promise<void> {
@@ -75,10 +71,6 @@ export async function touchSession(sessionId: string): Promise<void> {
   const client = createRedisClient();
   await client.expire(
     redisKeys.session.listen(sessionId),
-    LISTEN_SESSION_TTL_SECONDS
-  );
-  await client.expire(
-    `${LISTEN_SESSION_PREFIX}${sessionId}`,
     LISTEN_SESSION_TTL_SECONDS
   );
 }

--- a/api/listen/sessions/[id]/join.ts
+++ b/api/listen/sessions/[id]/join.ts
@@ -13,7 +13,7 @@ import {
   isProfaneUsername,
 } from "../../../_utils/_validation.js";
 import { resolveRequestAuth } from "../../../_utils/request-auth.js";
-import { CHAT_USERS_PREFIX } from "../../../_utils/auth/_constants.js";
+import { getStoredUserRecord } from "../../../_utils/auth/_user-record.js";
 import {
   getCurrentTimestamp,
   getSession,
@@ -104,7 +104,7 @@ export default apiHandler(
       if (username) {
         const [session, userData] = await Promise.all([
           getSession(sessionId),
-          redis.get(`${CHAT_USERS_PREFIX}${username}`),
+          getStoredUserRecord(redis, username),
         ]);
 
         if (!session) {

--- a/api/listen/sessions/index.ts
+++ b/api/listen/sessions/index.ts
@@ -9,7 +9,7 @@ import {
   assertValidUsername,
 } from "../../_utils/_validation.js";
 import { resolveRequestAuth } from "../../_utils/request-auth.js";
-import { CHAT_USERS_PREFIX } from "../../_utils/auth/_constants.js";
+import { getStoredUserRecord } from "../../_utils/auth/_user-record.js";
 import {
   generateSessionId,
   getCurrentTimestamp,
@@ -132,7 +132,7 @@ export default apiHandler(
       return;
     }
 
-    const userData = await redis.get(`${CHAT_USERS_PREFIX}${username}`);
+    const userData = await getStoredUserRecord(redis, username);
     if (!userData) {
       logger.response(404, Date.now() - startTime);
       res.status(404).json({ error: "User not found" });

--- a/api/presence/heartbeat.ts
+++ b/api/presence/heartbeat.ts
@@ -10,6 +10,7 @@
 import { apiHandler } from "../_utils/api-handler.js";
 import { triggerRealtimeEvent } from "../_utils/realtime.js";
 import { GLOBAL_PRESENCE_CHANNEL } from "../../src/shared/constants/realtime.js";
+import { redisKeys } from "../../src/shared/redisKeys.js";
 
 export const runtime = "nodejs";
 export const maxDuration = 10;
@@ -24,7 +25,10 @@ export default apiHandler(
       const username = user!.username;
       const now = Date.now();
 
-      await redis.zadd(GLOBAL_PRESENCE_KEY, { score: now, member: username });
+      await redis.zadd(redisKeys.presence.globalOnline(), {
+        score: now,
+        member: username,
+      });
 
       // Broadcast to the global presence channel
       await triggerRealtimeEvent(GLOBAL_PRESENCE_CHANNEL, "user-heartbeat", {
@@ -38,8 +42,15 @@ export default apiHandler(
 
     // GET: return online users (authenticated)
     const cutoff = Date.now() - GLOBAL_PRESENCE_TTL_SECONDS * 1000;
+    const canonicalPresenceKey = redisKeys.presence.globalOnline();
+    await redis.zremrangebyscore(canonicalPresenceKey, 0, cutoff);
     await redis.zremrangebyscore(GLOBAL_PRESENCE_KEY, 0, cutoff);
-    const onlineUsers: string[] = await redis.zrange(GLOBAL_PRESENCE_KEY, 0, -1);
+    const onlineUsers: string[] = [
+      ...new Set([
+        ...(await redis.zrange(canonicalPresenceKey, 0, -1)),
+        ...(await redis.zrange(GLOBAL_PRESENCE_KEY, 0, -1)),
+      ]),
+    ];
 
     res.status(200).json({ users: onlineUsers });
   }

--- a/api/rooms/[id].ts
+++ b/api/rooms/[id].ts
@@ -7,9 +7,15 @@
 
 import { apiHandler } from "../_utils/api-handler.js";
 import { assertValidRoomId } from "../_utils/_validation.js";
-import { getRoom, setRoom } from "./_helpers/_redis.js";
+import {
+  deleteAllMessages,
+  deleteRoom,
+  getRoom,
+  setRoom,
+  unregisterRoom,
+} from "./_helpers/_redis.js";
 import { getRoomReadAccessError } from "./_helpers/_access.js";
-import { CHAT_ROOM_PREFIX, CHAT_ROOM_USERS_PREFIX, CHAT_ROOMS_SET } from "./_helpers/_constants.js";
+import { CHAT_ROOM_USERS_PREFIX } from "./_helpers/_constants.js";
 import { refreshRoomUserCount, deleteRoomPresence } from "./_helpers/_presence.js";
 import { broadcastRoomDeleted, broadcastRoomUpdated } from "./_helpers/_pusher.js";
 import type { Room } from "./_helpers/_types.js";
@@ -110,12 +116,10 @@ export default apiHandler(
       if (roomData.type === "private") {
         const updatedMembers = roomData.members!.filter((m) => m !== username);
         if (updatedMembers.length <= 1) {
-          const pipeline = redis.pipeline();
-          pipeline.del(`${CHAT_ROOM_PREFIX}${roomId}`);
-          pipeline.del(`chat:messages:${roomId}`);
-          pipeline.del(`${CHAT_ROOM_USERS_PREFIX}${roomId}`);
-          pipeline.srem(CHAT_ROOMS_SET, roomId);
-          await pipeline.exec();
+          await deleteRoom(roomId);
+          await deleteAllMessages(roomId);
+          await unregisterRoom(roomId);
+          await redis.del(`${CHAT_ROOM_USERS_PREFIX}${roomId}`);
           await deleteRoomPresence(roomId);
 
           await broadcastRoomDeleted(roomId, roomData.type, roomData.members || []);
@@ -136,12 +140,10 @@ export default apiHandler(
           });
         }
       } else {
-        const pipeline = redis.pipeline();
-        pipeline.del(`${CHAT_ROOM_PREFIX}${roomId}`);
-        pipeline.del(`chat:messages:${roomId}`);
-        pipeline.del(`${CHAT_ROOM_USERS_PREFIX}${roomId}`);
-        pipeline.srem(CHAT_ROOMS_SET, roomId);
-        await pipeline.exec();
+        await deleteRoom(roomId);
+        await deleteAllMessages(roomId);
+        await unregisterRoom(roomId);
+        await redis.del(`${CHAT_ROOM_USERS_PREFIX}${roomId}`);
         await deleteRoomPresence(roomId);
 
         await broadcastRoomDeleted(roomId, roomData.type, roomData.members || []);

--- a/api/rooms/[id]/join.ts
+++ b/api/rooms/[id]/join.ts
@@ -6,7 +6,6 @@
 import { apiHandler } from "../../_utils/api-handler.js";
 import { isProfaneUsername, assertValidRoomId, assertValidUsername } from "../../_utils/_validation.js";
 import { getRoom, setRoom } from "../_helpers/_redis.js";
-import { CHAT_USERS_PREFIX } from "../_helpers/_constants.js";
 import { getRoomWriteAccessError } from "../_helpers/_access.js";
 import { setRoomPresence, refreshRoomUserCount } from "../_helpers/_presence.js";
 import { broadcastRoomUpdated, broadcastPresenceUpdate } from "../_helpers/_pusher.js";
@@ -15,6 +14,7 @@ import {
   isIrcBridgeEnabled,
   syncRoomBindingForPresence,
 } from "../../_utils/irc/_bridge.js";
+import { getStoredUserRecord } from "../../_utils/auth/_user-record.js";
 
 export const runtime = "nodejs";
 export const maxDuration = 15;
@@ -62,7 +62,7 @@ export default apiHandler(
     try {
       const [roomData, userData] = await Promise.all([
         getRoom(roomId),
-        redis.get(`${CHAT_USERS_PREFIX}${username}`),
+        getStoredUserRecord(redis, username),
       ]);
 
       if (!roomData) {

--- a/api/rooms/[id]/leave.ts
+++ b/api/rooms/[id]/leave.ts
@@ -5,13 +5,15 @@
 
 import { apiHandler } from "../../_utils/api-handler.js";
 import { isProfaneUsername, assertValidRoomId, assertValidUsername } from "../../_utils/_validation.js";
-import { getRoom, setRoom } from "../_helpers/_redis.js";
-import { getRoomWriteAccessError } from "../_helpers/_access.js";
 import {
-  CHAT_ROOM_PREFIX,
-  CHAT_ROOM_USERS_PREFIX,
-  CHAT_ROOMS_SET,
-} from "../_helpers/_constants.js";
+  deleteAllMessages,
+  deleteRoom,
+  getRoom,
+  setRoom,
+  unregisterRoom,
+} from "../_helpers/_redis.js";
+import { getRoomWriteAccessError } from "../_helpers/_access.js";
+import { CHAT_ROOM_USERS_PREFIX } from "../_helpers/_constants.js";
 import {
   deleteRoomPresence,
   removeRoomPresence,
@@ -98,12 +100,10 @@ export default apiHandler(
           const updatedMembers = roomData.members ? roomData.members.filter((m) => m !== username) : [];
 
           if (updatedMembers.length <= 1) {
-            const pipeline = redis.pipeline();
-            pipeline.del(`${CHAT_ROOM_PREFIX}${roomId}`);
-            pipeline.del(`chat:messages:${roomId}`);
-            pipeline.del(`${CHAT_ROOM_USERS_PREFIX}${roomId}`);
-            pipeline.srem(CHAT_ROOMS_SET, roomId);
-            await pipeline.exec();
+            await deleteRoom(roomId);
+            await deleteAllMessages(roomId);
+            await unregisterRoom(roomId);
+            await redis.del(`${CHAT_ROOM_USERS_PREFIX}${roomId}`);
             await deleteRoomPresence(roomId);
 
             await broadcastRoomDeleted(roomId, roomData.type, roomData.members || []);

--- a/api/rooms/_helpers/_presence.ts
+++ b/api/rooms/_helpers/_presence.ts
@@ -12,6 +12,7 @@ import {
   ROOM_PRESENCE_TTL_SECONDS,
 } from "./_constants.js";
 import type { Room, RoomWithUsers } from "./_types.js";
+import { redisKeys } from "../../../src/shared/redisKeys.js";
 
 // Create Redis client for presence operations
 function getRedis() {
@@ -30,8 +31,9 @@ export async function setRoomPresence(
   username: string
 ): Promise<void> {
   const redis = getRedis();
-  const zkey = `${CHAT_ROOM_PRESENCE_ZSET_PREFIX}${roomId}`;
-  await redis.zadd(zkey, { score: Date.now(), member: username });
+  const entry = { score: Date.now(), member: username };
+  await redis.zadd(redisKeys.chat.roomPresence(roomId), entry);
+  await redis.zadd(`${CHAT_ROOM_PRESENCE_ZSET_PREFIX}${roomId}`, entry);
 }
 
 /**
@@ -42,8 +44,9 @@ export async function removeRoomPresence(
   username: string
 ): Promise<number> {
   const redis = getRedis();
-  const zkey = `${CHAT_ROOM_PRESENCE_ZSET_PREFIX}${roomId}`;
-  return await redis.zrem(zkey, username);
+  const canonicalRemoved = await redis.zrem(redisKeys.chat.roomPresence(roomId), username);
+  const legacyRemoved = await redis.zrem(`${CHAT_ROOM_PRESENCE_ZSET_PREFIX}${roomId}`, username);
+  return canonicalRemoved + legacyRemoved;
 }
 
 /**
@@ -51,10 +54,17 @@ export async function removeRoomPresence(
  */
 export async function getActiveUsersInRoom(roomId: string): Promise<string[]> {
   const redis = getRedis();
-  const zkey = `${CHAT_ROOM_PRESENCE_ZSET_PREFIX}${roomId}`;
+  const zkey = redisKeys.chat.roomPresence(roomId);
+  const legacyZkey = `${CHAT_ROOM_PRESENCE_ZSET_PREFIX}${roomId}`;
   const cutoff = Date.now() - ROOM_PRESENCE_TTL_SECONDS * 1000;
   await redis.zremrangebyscore(zkey, 0, cutoff);
-  return await redis.zrange(zkey, 0, -1);
+  await redis.zremrangebyscore(legacyZkey, 0, cutoff);
+  return [
+    ...new Set([
+      ...(await redis.zrange(zkey, 0, -1)),
+      ...(await redis.zrange(legacyZkey, 0, -1)),
+    ]),
+  ];
 }
 
 /**
@@ -63,12 +73,19 @@ export async function getActiveUsersInRoom(roomId: string): Promise<string[]> {
  */
 export async function refreshRoomUserCount(roomId: string): Promise<number> {
   const redis = getRedis();
-  const zkey = `${CHAT_ROOM_PRESENCE_ZSET_PREFIX}${roomId}`;
+  const zkey = redisKeys.chat.roomPresence(roomId);
+  const legacyZkey = `${CHAT_ROOM_PRESENCE_ZSET_PREFIX}${roomId}`;
   const cutoff = Date.now() - ROOM_PRESENCE_TTL_SECONDS * 1000;
   await redis.zremrangebyscore(zkey, 0, cutoff);
-  const userCount = await redis.zcard(zkey);
+  await redis.zremrangebyscore(legacyZkey, 0, cutoff);
+  const userCount = new Set([
+    ...(await redis.zrange(zkey, 0, -1)),
+    ...(await redis.zrange(legacyZkey, 0, -1)),
+  ]).size;
 
-  const roomRaw = await redis.get(`${CHAT_ROOM_PREFIX}${roomId}`);
+  const roomRaw =
+    (await redis.get(redisKeys.chat.roomMeta(roomId))) ??
+    (await redis.get(`${CHAT_ROOM_PREFIX}${roomId}`));
   const roomData = parseRoomData(roomRaw);
   if (roomData) {
     const updatedRoom: Room = { ...roomData, userCount };
@@ -88,7 +105,12 @@ export async function cleanupExpiredPresence(): Promise<{
 }> {
   try {
     const redis = getRedis();
-    const roomIds = await redis.smembers(CHAT_ROOMS_SET);
+    const roomIds = [
+      ...new Set([
+        ...(await redis.smembers<string[]>(redisKeys.chat.roomIds())),
+        ...(await redis.smembers<string[]>(CHAT_ROOMS_SET)),
+      ]),
+    ];
     for (const roomId of roomIds) {
       const newCount = await refreshRoomUserCount(roomId);
       console.log(
@@ -110,7 +132,7 @@ export async function cleanupExpiredPresence(): Promise<{
  */
 export async function deleteRoomPresence(roomId: string): Promise<void> {
   const redis = getRedis();
-  await redis.del(`${CHAT_ROOM_PRESENCE_ZSET_PREFIX}${roomId}`);
+  await redis.del(redisKeys.chat.roomPresence(roomId), `${CHAT_ROOM_PRESENCE_ZSET_PREFIX}${roomId}`);
 }
 
 // ============================================================================
@@ -122,7 +144,12 @@ export async function deleteRoomPresence(roomId: string): Promise<void> {
  */
 export async function getDetailedRooms(): Promise<RoomWithUsers[]> {
   const redis = getRedis();
-  let roomIds = await redis.smembers(CHAT_ROOMS_SET);
+  let roomIds = [
+    ...new Set([
+      ...(await redis.smembers<string[]>(redisKeys.chat.roomIds())),
+      ...(await redis.smembers<string[]>(CHAT_ROOMS_SET)),
+    ]),
+  ];
 
   if (!roomIds || roomIds.length === 0) {
     // Fallback: discover rooms and repopulate registry
@@ -138,6 +165,7 @@ export async function getDetailedRooms(): Promise<RoomWithUsers[]> {
       discovered.push(...ids);
     } while (cursor !== 0);
     if (discovered.length) {
+      await redis.sadd(redisKeys.chat.roomIds(), ...(discovered as [string, ...string[]]));
       await redis.sadd(CHAT_ROOMS_SET, ...(discovered as [string, ...string[]]));
       roomIds = discovered;
     } else {
@@ -145,12 +173,11 @@ export async function getDetailedRooms(): Promise<RoomWithUsers[]> {
     }
   }
 
-  const roomKeys = roomIds.map((id) => `${CHAT_ROOM_PREFIX}${id}`);
-  const roomsData = await redis.mget<(Room | string | null)[]>(...(roomKeys as [string, ...string[]]));
-
   const rooms: RoomWithUsers[] = [];
-  for (let i = 0; i < roomsData.length; i++) {
-    const raw = roomsData[i];
+  for (const roomId of roomIds) {
+    const raw =
+      (await redis.get(redisKeys.chat.roomMeta(roomId))) ??
+      (await redis.get(`${CHAT_ROOM_PREFIX}${roomId}`));
     if (!raw) continue;
     const roomObj = parseRoomData(raw);
     if (!roomObj) continue;
@@ -169,7 +196,12 @@ export async function getDetailedRooms(): Promise<RoomWithUsers[]> {
  */
 export async function getRoomsWithCountsFast(): Promise<Room[]> {
   const redis = getRedis();
-  let roomIds = await redis.smembers(CHAT_ROOMS_SET);
+  let roomIds = [
+    ...new Set([
+      ...(await redis.smembers<string[]>(redisKeys.chat.roomIds())),
+      ...(await redis.smembers<string[]>(CHAT_ROOMS_SET)),
+    ]),
+  ];
 
   if (!roomIds || roomIds.length === 0) {
     const discovered: string[] = [];
@@ -184,6 +216,7 @@ export async function getRoomsWithCountsFast(): Promise<Room[]> {
       discovered.push(...ids);
     } while (cursor !== 0);
     if (discovered.length) {
+      await redis.sadd(redisKeys.chat.roomIds(), ...(discovered as [string, ...string[]]));
       await redis.sadd(CHAT_ROOMS_SET, ...(discovered as [string, ...string[]]));
       roomIds = discovered;
     } else {
@@ -191,35 +224,21 @@ export async function getRoomsWithCountsFast(): Promise<Room[]> {
     }
   }
 
-  const roomKeys = roomIds.map((id) => `${CHAT_ROOM_PREFIX}${id}`);
-  const roomsData = await redis.mget<(Room | string | null)[]>(...(roomKeys as [string, ...string[]]));
-
-  // Batch prune + count ZSET presence for all rooms
-  const pipeline = redis.pipeline();
-  const zkeys = roomIds.map((id) => `${CHAT_ROOM_PRESENCE_ZSET_PREFIX}${id}`);
   const cutoff = Date.now() - ROOM_PRESENCE_TTL_SECONDS * 1000;
-  for (const z of zkeys) {
-    pipeline.zremrangebyscore(z, 0, cutoff);
-    pipeline.zcard(z);
-  }
-  const results = await pipeline.exec();
-
   const rooms: Room[] = [];
-  let resIdx = 0;
-  for (let i = 0; i < roomsData.length; i++) {
-    const raw = roomsData[i];
-    if (!raw) {
-      resIdx += 2;
-      continue;
-    }
+  for (const roomId of roomIds) {
+    await redis.zremrangebyscore(redisKeys.chat.roomPresence(roomId), 0, cutoff);
+    await redis.zremrangebyscore(`${CHAT_ROOM_PRESENCE_ZSET_PREFIX}${roomId}`, 0, cutoff);
+    const raw =
+      (await redis.get(redisKeys.chat.roomMeta(roomId))) ??
+      (await redis.get(`${CHAT_ROOM_PREFIX}${roomId}`));
+    if (!raw) continue;
     const roomObj = parseRoomData(raw);
-    if (!roomObj) {
-      resIdx += 2;
-      continue;
-    }
-    resIdx += 1; // Skip pruned result
-    const userCount = Number(results[resIdx]);
-    resIdx += 1;
+    if (!roomObj) continue;
+    const userCount = new Set([
+      ...(await redis.zrange(redisKeys.chat.roomPresence(roomObj.id), 0, -1)),
+      ...(await redis.zrange(`${CHAT_ROOM_PRESENCE_ZSET_PREFIX}${roomObj.id}`, 0, -1)),
+    ]).size;
     rooms.push({ ...roomObj, userCount });
   }
   return rooms;

--- a/api/rooms/_helpers/_presence.ts
+++ b/api/rooms/_helpers/_presence.ts
@@ -33,7 +33,6 @@ export async function setRoomPresence(
   const redis = getRedis();
   const entry = { score: Date.now(), member: username };
   await redis.zadd(redisKeys.chat.roomPresence(roomId), entry);
-  await redis.zadd(`${CHAT_ROOM_PRESENCE_ZSET_PREFIX}${roomId}`, entry);
 }
 
 /**
@@ -166,7 +165,6 @@ export async function getDetailedRooms(): Promise<RoomWithUsers[]> {
     } while (cursor !== 0);
     if (discovered.length) {
       await redis.sadd(redisKeys.chat.roomIds(), ...(discovered as [string, ...string[]]));
-      await redis.sadd(CHAT_ROOMS_SET, ...(discovered as [string, ...string[]]));
       roomIds = discovered;
     } else {
       return [];
@@ -217,7 +215,6 @@ export async function getRoomsWithCountsFast(): Promise<Room[]> {
     } while (cursor !== 0);
     if (discovered.length) {
       await redis.sadd(redisKeys.chat.roomIds(), ...(discovered as [string, ...string[]]));
-      await redis.sadd(CHAT_ROOMS_SET, ...(discovered as [string, ...string[]]));
       roomIds = discovered;
     } else {
       return [];

--- a/api/rooms/_helpers/_pusher.ts
+++ b/api/rooms/_helpers/_pusher.ts
@@ -7,14 +7,11 @@
  * - Caches room data to avoid repeated Redis lookups
  */
 
-import { createRedis } from "../../_utils/redis.js";
 import {
   triggerRealtimeBatch,
   triggerRealtimeEvent,
 } from "../../_utils/realtime.js";
-import { parseRoomData } from "./_redis.js";
 import { refreshRoomUserCount } from "./_presence.js";
-import { CHAT_ROOM_PREFIX } from "./_constants.js";
 import type { Room, Message } from "./_types.js";
 import {
   CHATS_PUBLIC_CHANNEL,
@@ -23,11 +20,6 @@ import {
   sanitizeRealtimeChannelSegment,
 } from "../../../src/shared/constants/realtime.js";
 import { getRoom } from "./_redis.js";
-
-// Create Redis client
-function getRedis() {
-  return createRedis();
-}
 
 interface BatchEvent {
   channel: string;
@@ -81,10 +73,7 @@ export function filterRoomsForUser(
  */
 export async function broadcastRoomUpdated(roomId: string): Promise<void> {
   try {
-    const roomRaw = await getRedis().get(`${CHAT_ROOM_PREFIX}${roomId}`);
-    if (!roomRaw) return;
-
-    const roomObj = parseRoomData(roomRaw);
+    const roomObj = await getRoom(roomId);
     if (!roomObj) return;
 
     const count = await refreshRoomUserCount(roomId);
@@ -230,10 +219,7 @@ export async function fanOutToPrivateMembers(
   payload: unknown
 ): Promise<void> {
   try {
-    const roomRaw = await getRedis().get(`${CHAT_ROOM_PREFIX}${roomId}`);
-    if (!roomRaw) return;
-
-    const roomObj = parseRoomData(roomRaw);
+    const roomObj = await getRoom(roomId);
     if (!roomObj) return;
     if (roomObj.type !== "private" || !Array.isArray(roomObj.members)) return;
 

--- a/api/rooms/_helpers/_redis.ts
+++ b/api/rooms/_helpers/_redis.ts
@@ -79,7 +79,6 @@ export async function getRoom(roomId: string): Promise<Room | null> {
 export async function setRoom(roomId: string, room: Room): Promise<void> {
   const client = createRedisClient();
   await client.set(redisKeys.chat.roomMeta(roomId), room);
-  await client.set(`${CHAT_ROOM_PREFIX}${roomId}`, room);
 }
 
 /**
@@ -126,7 +125,6 @@ export async function getAllRoomIds(): Promise<string[]> {
 
     if (discovered.length) {
       await client.sadd(redisKeys.chat.roomIds(), ...(discovered as [string, ...string[]]));
-      await client.sadd(CHAT_ROOMS_SET, ...(discovered as [string, ...string[]]));
       roomIds = discovered;
     }
   }
@@ -140,7 +138,6 @@ export async function getAllRoomIds(): Promise<string[]> {
 export async function registerRoom(roomId: string): Promise<void> {
   const client = createRedisClient();
   await client.sadd(redisKeys.chat.roomIds(), roomId);
-  await client.sadd(CHAT_ROOMS_SET, roomId);
 }
 
 /**
@@ -171,7 +168,6 @@ export async function getUser(username: string): Promise<User | null> {
 export async function setUser(username: string, user: User): Promise<void> {
   const client = createRedisClient();
   await setStoredUserRecord(client, username, user);
-  await client.set(`${CHAT_USERS_PREFIX}${username}`, JSON.stringify(user));
 }
 
 /**
@@ -186,11 +182,7 @@ export async function createUserIfNotExists(
   const existing = await getStoredUserRecord(client, username);
   if (existing) return false;
   await setStoredUserRecord(client, username, user);
-  const created = await client.setnx(
-    `${CHAT_USERS_PREFIX}${username}`,
-    JSON.stringify(user)
-  );
-  return created === 1;
+  return true;
 }
 
 /**
@@ -220,14 +212,17 @@ export async function getMessages(
   const messagesKey = redisKeys.chat.roomMessages(roomId);
   const legacyMessagesKey = `${CHAT_MESSAGES_PREFIX}${roomId}`;
   const rawMessages = await client.lrange<(Message | string)[]>(messagesKey, 0, limit - 1);
-  const sourceMessages =
-    rawMessages.length > 0
-      ? rawMessages
-      : await client.lrange<(Message | string)[]>(legacyMessagesKey, 0, limit - 1);
+  const remaining = Math.max(0, limit - rawMessages.length);
+  const legacyRawMessages =
+    remaining > 0
+      ? await client.lrange<(Message | string)[]>(legacyMessagesKey, 0, remaining - 1)
+      : [];
 
-  return (sourceMessages || []).reduce<Message[]>((acc, item) => {
+  const seenIds = new Set<string>();
+  return [...(rawMessages || []), ...(legacyRawMessages || [])].reduce<Message[]>((acc, item) => {
     const message = parseMessageData(item);
-    if (message !== null) {
+    if (message !== null && !seenIds.has(message.id) && acc.length < limit) {
+      seenIds.add(message.id);
       acc.push(message);
     }
     return acc;
@@ -244,11 +239,8 @@ export async function addMessage(
   const client = createRedisClient();
   const serialized = JSON.stringify(message);
   const messagesKey = redisKeys.chat.roomMessages(roomId);
-  const legacyMessagesKey = `${CHAT_MESSAGES_PREFIX}${roomId}`;
   await client.lpush(messagesKey, serialized);
   await client.ltrim(messagesKey, 0, 99);
-  await client.lpush(legacyMessagesKey, serialized);
-  await client.ltrim(legacyMessagesKey, 0, 99);
 }
 
 /**
@@ -261,12 +253,10 @@ export async function deleteMessage(
   const client = createRedisClient();
   const listKey = redisKeys.chat.roomMessages(roomId);
   const legacyListKey = `${CHAT_MESSAGES_PREFIX}${roomId}`;
-  let messagesRaw = await client.lrange<(Message | string)[]>(listKey, 0, -1);
-  let sourceKey = listKey;
-  if (messagesRaw.length === 0) {
-    messagesRaw = await client.lrange<(Message | string)[]>(legacyListKey, 0, -1);
-    sourceKey = legacyListKey;
-  }
+  const messagesRaw = [
+    ...(await client.lrange<(Message | string)[]>(listKey, 0, -1)),
+    ...(await client.lrange<(Message | string)[]>(legacyListKey, 0, -1)),
+  ];
 
   let targetRaw: string | null = null;
   for (const raw of messagesRaw || []) {
@@ -279,8 +269,8 @@ export async function deleteMessage(
 
   if (!targetRaw) return false;
 
-  await client.lrem(sourceKey, 1, targetRaw);
-  await client.lrem(sourceKey === listKey ? legacyListKey : listKey, 1, targetRaw);
+  await client.lrem(listKey, 1, targetRaw);
+  await client.lrem(legacyListKey, 1, targetRaw);
   return true;
 }
 
@@ -297,8 +287,11 @@ export async function deleteAllMessages(roomId: string): Promise<void> {
  */
 export async function getLastMessage(roomId: string): Promise<Message | null> {
   const client = createRedisClient();
-  const messagesKey = `${CHAT_MESSAGES_PREFIX}${roomId}`;
+  const messagesKey = redisKeys.chat.roomMessages(roomId);
+  const legacyMessagesKey = `${CHAT_MESSAGES_PREFIX}${roomId}`;
   const lastMessages = await client.lrange<(Message | string)[]>(messagesKey, 0, 0);
-  if (!lastMessages || lastMessages.length === 0) return null;
-  return parseMessageData(lastMessages[0]);
+  if (lastMessages && lastMessages.length > 0) return parseMessageData(lastMessages[0]);
+  const legacyLastMessages = await client.lrange<(Message | string)[]>(legacyMessagesKey, 0, 0);
+  if (!legacyLastMessages || legacyLastMessages.length === 0) return null;
+  return parseMessageData(legacyLastMessages[0]);
 }

--- a/api/rooms/_helpers/_redis.ts
+++ b/api/rooms/_helpers/_redis.ts
@@ -16,6 +16,11 @@ import {
   CHAT_USERS_PREFIX,
   CHAT_ROOMS_SET,
 } from "./_constants.js";
+import { redisKeys } from "../../../src/shared/redisKeys.js";
+import {
+  getStoredUserRecord,
+  setStoredUserRecord,
+} from "../../_utils/auth/_user-record.js";
 
 // Export for direct usage in endpoints and feature helpers.
 export { createRedisClient, getCurrentTimestamp, parseJSON };
@@ -62,7 +67,9 @@ export function parseMessageData(data: unknown): Message | null {
  */
 export async function getRoom(roomId: string): Promise<Room | null> {
   const client = createRedisClient();
-  const data = await client.get(`${CHAT_ROOM_PREFIX}${roomId}`);
+  const data =
+    (await client.get(redisKeys.chat.roomMeta(roomId))) ??
+    (await client.get(`${CHAT_ROOM_PREFIX}${roomId}`));
   return parseRoomData(data);
 }
 
@@ -71,6 +78,7 @@ export async function getRoom(roomId: string): Promise<Room | null> {
  */
 export async function setRoom(roomId: string, room: Room): Promise<void> {
   const client = createRedisClient();
+  await client.set(redisKeys.chat.roomMeta(roomId), room);
   await client.set(`${CHAT_ROOM_PREFIX}${roomId}`, room);
 }
 
@@ -79,7 +87,7 @@ export async function setRoom(roomId: string, room: Room): Promise<void> {
  */
 export async function deleteRoom(roomId: string): Promise<void> {
   const client = createRedisClient();
-  await client.del(`${CHAT_ROOM_PREFIX}${roomId}`);
+  await client.del(redisKeys.chat.roomMeta(roomId), `${CHAT_ROOM_PREFIX}${roomId}`);
 }
 
 /**
@@ -87,8 +95,11 @@ export async function deleteRoom(roomId: string): Promise<void> {
  */
 export async function roomExists(roomId: string): Promise<boolean> {
   const client = createRedisClient();
-  const exists = await client.exists(`${CHAT_ROOM_PREFIX}${roomId}`);
-  return exists === 1;
+  const exists = await client.exists(
+    redisKeys.chat.roomMeta(roomId),
+    `${CHAT_ROOM_PREFIX}${roomId}`
+  );
+  return exists > 0;
 }
 
 /**
@@ -96,7 +107,9 @@ export async function roomExists(roomId: string): Promise<boolean> {
  */
 export async function getAllRoomIds(): Promise<string[]> {
   const client = createRedisClient();
-  let roomIds = await client.smembers<string[]>(CHAT_ROOMS_SET);
+  const canonicalRoomIds = await client.smembers<string[]>(redisKeys.chat.roomIds());
+  const legacyRoomIds = await client.smembers<string[]>(CHAT_ROOMS_SET);
+  let roomIds = [...new Set([...(canonicalRoomIds || []), ...(legacyRoomIds || [])])];
 
   if (!roomIds || roomIds.length === 0) {
     const discovered: string[] = [];
@@ -112,6 +125,7 @@ export async function getAllRoomIds(): Promise<string[]> {
     } while (cursor !== 0);
 
     if (discovered.length) {
+      await client.sadd(redisKeys.chat.roomIds(), ...(discovered as [string, ...string[]]));
       await client.sadd(CHAT_ROOMS_SET, ...(discovered as [string, ...string[]]));
       roomIds = discovered;
     }
@@ -125,6 +139,7 @@ export async function getAllRoomIds(): Promise<string[]> {
  */
 export async function registerRoom(roomId: string): Promise<void> {
   const client = createRedisClient();
+  await client.sadd(redisKeys.chat.roomIds(), roomId);
   await client.sadd(CHAT_ROOMS_SET, roomId);
 }
 
@@ -133,6 +148,7 @@ export async function registerRoom(roomId: string): Promise<void> {
  */
 export async function unregisterRoom(roomId: string): Promise<void> {
   const client = createRedisClient();
+  await client.srem(redisKeys.chat.roomIds(), roomId);
   await client.srem(CHAT_ROOMS_SET, roomId);
 }
 
@@ -145,8 +161,8 @@ export async function unregisterRoom(roomId: string): Promise<void> {
  */
 export async function getUser(username: string): Promise<User | null> {
   const client = createRedisClient();
-  const data = await client.get(`${CHAT_USERS_PREFIX}${username}`);
-  return parseUserData(data);
+  const record = await getStoredUserRecord(client, username);
+  return parseUserData(record);
 }
 
 /**
@@ -154,6 +170,7 @@ export async function getUser(username: string): Promise<User | null> {
  */
 export async function setUser(username: string, user: User): Promise<void> {
   const client = createRedisClient();
+  await setStoredUserRecord(client, username, user);
   await client.set(`${CHAT_USERS_PREFIX}${username}`, JSON.stringify(user));
 }
 
@@ -166,6 +183,9 @@ export async function createUserIfNotExists(
   user: User
 ): Promise<boolean> {
   const client = createRedisClient();
+  const existing = await getStoredUserRecord(client, username);
+  if (existing) return false;
+  await setStoredUserRecord(client, username, user);
   const created = await client.setnx(
     `${CHAT_USERS_PREFIX}${username}`,
     JSON.stringify(user)
@@ -178,8 +198,11 @@ export async function createUserIfNotExists(
  */
 export async function userExists(username: string): Promise<boolean> {
   const client = createRedisClient();
-  const exists = await client.exists(`${CHAT_USERS_PREFIX}${username}`);
-  return exists === 1;
+  const exists = await client.exists(
+    redisKeys.auth.userProfile(username),
+    `${CHAT_USERS_PREFIX}${username}`
+  );
+  return exists > 0;
 }
 
 // ============================================================================
@@ -194,10 +217,15 @@ export async function getMessages(
   limit: number = 20
 ): Promise<Message[]> {
   const client = createRedisClient();
-  const messagesKey = `${CHAT_MESSAGES_PREFIX}${roomId}`;
+  const messagesKey = redisKeys.chat.roomMessages(roomId);
+  const legacyMessagesKey = `${CHAT_MESSAGES_PREFIX}${roomId}`;
   const rawMessages = await client.lrange<(Message | string)[]>(messagesKey, 0, limit - 1);
+  const sourceMessages =
+    rawMessages.length > 0
+      ? rawMessages
+      : await client.lrange<(Message | string)[]>(legacyMessagesKey, 0, limit - 1);
 
-  return (rawMessages || []).reduce<Message[]>((acc, item) => {
+  return (sourceMessages || []).reduce<Message[]>((acc, item) => {
     const message = parseMessageData(item);
     if (message !== null) {
       acc.push(message);
@@ -214,9 +242,13 @@ export async function addMessage(
   message: Message
 ): Promise<void> {
   const client = createRedisClient();
-  const messagesKey = `${CHAT_MESSAGES_PREFIX}${roomId}`;
-  await client.lpush(messagesKey, JSON.stringify(message));
+  const serialized = JSON.stringify(message);
+  const messagesKey = redisKeys.chat.roomMessages(roomId);
+  const legacyMessagesKey = `${CHAT_MESSAGES_PREFIX}${roomId}`;
+  await client.lpush(messagesKey, serialized);
   await client.ltrim(messagesKey, 0, 99);
+  await client.lpush(legacyMessagesKey, serialized);
+  await client.ltrim(legacyMessagesKey, 0, 99);
 }
 
 /**
@@ -227,8 +259,14 @@ export async function deleteMessage(
   messageId: string
 ): Promise<boolean> {
   const client = createRedisClient();
-  const listKey = `${CHAT_MESSAGES_PREFIX}${roomId}`;
-  const messagesRaw = await client.lrange<(Message | string)[]>(listKey, 0, -1);
+  const listKey = redisKeys.chat.roomMessages(roomId);
+  const legacyListKey = `${CHAT_MESSAGES_PREFIX}${roomId}`;
+  let messagesRaw = await client.lrange<(Message | string)[]>(listKey, 0, -1);
+  let sourceKey = listKey;
+  if (messagesRaw.length === 0) {
+    messagesRaw = await client.lrange<(Message | string)[]>(legacyListKey, 0, -1);
+    sourceKey = legacyListKey;
+  }
 
   let targetRaw: string | null = null;
   for (const raw of messagesRaw || []) {
@@ -241,7 +279,8 @@ export async function deleteMessage(
 
   if (!targetRaw) return false;
 
-  await client.lrem(listKey, 1, targetRaw);
+  await client.lrem(sourceKey, 1, targetRaw);
+  await client.lrem(sourceKey === listKey ? legacyListKey : listKey, 1, targetRaw);
   return true;
 }
 
@@ -250,7 +289,7 @@ export async function deleteMessage(
  */
 export async function deleteAllMessages(roomId: string): Promise<void> {
   const client = createRedisClient();
-  await client.del(`${CHAT_MESSAGES_PREFIX}${roomId}`);
+  await client.del(redisKeys.chat.roomMessages(roomId), `${CHAT_MESSAGES_PREFIX}${roomId}`);
 }
 
 /**

--- a/api/rooms/_helpers/_users.ts
+++ b/api/rooms/_helpers/_users.ts
@@ -136,41 +136,46 @@ export async function handleGetUsers(
       });
     }
 
-    const users: User[] = [];
+    const users = new Map<string, User>();
     let cursor = 0;
     const maxResults = 20;
-    const pattern = `${CHAT_USERS_PREFIX}*${searchQuery.toLowerCase()}*`;
+    const patterns = [
+      `auth:user:*${searchQuery.toLowerCase()}*:profile`,
+      `${CHAT_USERS_PREFIX}*${searchQuery.toLowerCase()}*`,
+    ];
 
-    do {
-      const [newCursor, keys] = await redis.scan(cursor, {
-        match: pattern,
-        count: 100,
-      });
+    for (const pattern of patterns) {
+      cursor = 0;
+      do {
+        const [newCursor, keys] = await redis.scan(cursor, {
+          match: pattern,
+          count: 100,
+        });
 
-      cursor = parseInt(String(newCursor));
+        cursor = parseInt(String(newCursor));
 
-      if (keys.length > 0) {
-        const usersData = await redis.mget<(User | string | null)[]>(...keys);
-        const foundUsers = usersData.reduce<User[]>((acc, user) => {
-          try {
-            if (!user) return acc;
-            const parsedUser = typeof user === "string" ? JSON.parse(user) : user;
-            acc.push(parsedUser);
-          } catch {
-            return acc;
+        if (keys.length > 0) {
+          const usersData = await redis.mget<(User | string | null)[]>(...keys);
+          for (const user of usersData) {
+            try {
+              if (!user) continue;
+              const parsedUser = typeof user === "string" ? JSON.parse(user) : user;
+              if (parsedUser?.username) {
+                users.set(parsedUser.username.toLowerCase(), parsedUser);
+              }
+            } catch {
+              continue;
+            }
           }
-          return acc;
-        }, []);
 
-        users.push(...foundUsers);
-
-        if (users.length >= maxResults) {
-          break;
+          if (users.size >= maxResults) {
+            break;
+          }
         }
-      }
-    } while (cursor !== 0 && users.length < maxResults);
+      } while (cursor !== 0 && users.size < maxResults);
+    }
 
-    const limitedUsers = users.slice(0, maxResults);
+    const limitedUsers = [...users.values()].slice(0, maxResults);
 
     logInfo(
       requestId,

--- a/api/share-applet.ts
+++ b/api/share-applet.ts
@@ -228,7 +228,6 @@ export default apiHandler<Record<string, unknown>>(
       }
 
       const key = appletShareKey(id);
-      const legacyKey = legacyAppletShareKey(id);
       const appletData = {
         content,
         title: title || undefined,
@@ -242,7 +241,6 @@ export default apiHandler<Record<string, unknown>>(
       };
 
       await redis.set(key, JSON.stringify(appletData));
-      await redis.set(legacyKey, JSON.stringify(appletData));
       const shareUrl = `${getAppPublicOrigin(origin)}/applet-viewer/${id}`;
 
       logger.info("Saved applet", { id, isUpdate });
@@ -349,7 +347,6 @@ export default apiHandler<Record<string, unknown>>(
       const parsed = typeof appletData === "string" ? JSON.parse(appletData) : appletData;
       parsed.featured = featured;
       await redis.set(key, JSON.stringify(parsed));
-      await redis.set(legacyKey, JSON.stringify(parsed));
 
       logger.info("Updated applet", { id, featured });
       logger.response(200, Date.now() - startTime);

--- a/api/share-applet.ts
+++ b/api/share-applet.ts
@@ -5,6 +5,7 @@ import { getClientIp } from "./_utils/_rate-limit.js";
 import { apiHandler } from "./_utils/api-handler.js";
 import { resolveRequestAuth } from "./_utils/request-auth.js";
 import { getAppPublicOrigin } from "./_utils/runtime-config.js";
+import { redisKeys } from "../src/shared/redisKeys.js";
 
 export const runtime = "nodejs";
 export const maxDuration = 30;
@@ -20,6 +21,9 @@ const RATE_LIMITS = {
 
 // Applet sharing key prefix
 const APPLET_SHARE_PREFIX = "applet:share:";
+
+const appletShareKey = (id: string): string => redisKeys.media.appletShare(id);
+const legacyAppletShareKey = (id: string): string => `${APPLET_SHARE_PREFIX}${id}`;
 
 // Generate unique ID for applets
 const generateId = (): string => generateAuthToken().substring(0, 32);
@@ -79,20 +83,30 @@ export default apiHandler<Record<string, unknown>>(
             if (id) appletIds.push(id);
           }
         } while (cursor !== 0);
+        cursor = 0;
+        do {
+          const [newCursor, keys] = await redis.scan(cursor, { match: "media:applet:share:*", count: 100 });
+          cursor = parseInt(newCursor as unknown as string, 10);
+          for (const key of keys) {
+            const id = key.slice("media:applet:share:".length);
+            if (id) appletIds.push(decodeURIComponent(id));
+          }
+        } while (cursor !== 0);
         
         const applets: { id: string; title?: string; name?: string; icon?: string; createdAt: number; featured: boolean; createdBy?: string }[] = [];
         
         if (appletIds.length > 0) {
-          const appletKeys = appletIds.map((id) => `${APPLET_SHARE_PREFIX}${id}`);
-          const appletsData = await redis.mget(...appletKeys);
+          const uniqueAppletIds = [...new Set(appletIds)];
           
-          for (let i = 0; i < appletsData.length; i++) {
-            const appletData = appletsData[i];
+          for (const appletId of uniqueAppletIds) {
+            const appletData =
+              (await redis.get(appletShareKey(appletId))) ??
+              (await redis.get(legacyAppletShareKey(appletId)));
             if (!appletData) continue;
             try {
               const parsed = typeof appletData === "string" ? JSON.parse(appletData) : appletData;
               applets.push({
-                id: appletIds[i],
+                id: appletId,
                 title: parsed.title,
                 name: parsed.name,
                 icon: parsed.icon,
@@ -125,8 +139,9 @@ export default apiHandler<Record<string, unknown>>(
         return;
       }
 
-      const key = `${APPLET_SHARE_PREFIX}${id}`;
-      const appletData = await redis.get(key);
+      const key = appletShareKey(id);
+      const legacyKey = legacyAppletShareKey(id);
+      const appletData = (await redis.get(key)) ?? (await redis.get(legacyKey));
 
       if (!appletData) {
         logger.response(404, Date.now() - startTime);
@@ -188,8 +203,9 @@ export default apiHandler<Record<string, unknown>>(
       let existingAppletData: { createdAt?: number; createdBy?: string; featured?: boolean } | null = null;
 
       if (shareId) {
-        const existingKey = `${APPLET_SHARE_PREFIX}${shareId}`;
-        const existingData = await redis.get(existingKey);
+        const existingData =
+          (await redis.get(appletShareKey(shareId))) ??
+          (await redis.get(legacyAppletShareKey(shareId)));
 
         if (existingData) {
           try {
@@ -211,7 +227,8 @@ export default apiHandler<Record<string, unknown>>(
         id = generateId();
       }
 
-      const key = `${APPLET_SHARE_PREFIX}${id}`;
+      const key = appletShareKey(id);
+      const legacyKey = legacyAppletShareKey(id);
       const appletData = {
         content,
         title: title || undefined,
@@ -225,6 +242,7 @@ export default apiHandler<Record<string, unknown>>(
       };
 
       await redis.set(key, JSON.stringify(appletData));
+      await redis.set(legacyKey, JSON.stringify(appletData));
       const shareUrl = `${getAppPublicOrigin(origin)}/applet-viewer/${id}`;
 
       logger.info("Saved applet", { id, isUpdate });
@@ -264,8 +282,9 @@ export default apiHandler<Record<string, unknown>>(
         return;
       }
 
-      const key = `${APPLET_SHARE_PREFIX}${id}`;
-      const deleted = await redis.del(key);
+      const key = appletShareKey(id);
+      const legacyKey = legacyAppletShareKey(id);
+      const deleted = await redis.del(key, legacyKey);
 
       if (deleted === 0) {
         logger.response(404, Date.now() - startTime);
@@ -317,8 +336,9 @@ export default apiHandler<Record<string, unknown>>(
         return;
       }
 
-      const key = `${APPLET_SHARE_PREFIX}${id}`;
-      const appletData = await redis.get(key);
+      const key = appletShareKey(id);
+      const legacyKey = legacyAppletShareKey(id);
+      const appletData = (await redis.get(key)) ?? (await redis.get(legacyKey));
 
       if (!appletData) {
         logger.response(404, Date.now() - startTime);
@@ -329,6 +349,7 @@ export default apiHandler<Record<string, unknown>>(
       const parsed = typeof appletData === "string" ? JSON.parse(appletData) : appletData;
       parsed.featured = featured;
       await redis.set(key, JSON.stringify(parsed));
+      await redis.set(legacyKey, JSON.stringify(parsed));
 
       logger.info("Updated applet", { id, featured });
       logger.response(200, Date.now() - startTime);

--- a/api/songs/index.ts
+++ b/api/songs/index.ts
@@ -30,9 +30,6 @@ import {
   deleteAllSongs,
   getSongMetaKey,
   getSongContentKey,
-  getLegacySongMetaKey,
-  getLegacySongContentKey,
-  SONG_SET_KEY,
   type SongMetadata,
   type SongContent,
   type GetSongOptions,
@@ -456,13 +453,10 @@ export default apiHandler<Record<string, unknown>>(
         const pipeline = redis.pipeline();
         for (const { meta, content } of songDocs) {
           pipeline.set(getSongMetaKey(meta.id), JSON.stringify(meta));
-          pipeline.set(getLegacySongMetaKey(meta.id), JSON.stringify(meta));
           pipeline.sadd(redisKeys.media.songIds(), meta.id);
-          pipeline.sadd(SONG_SET_KEY, meta.id);
           // Save content if present
           if (content) {
             pipeline.set(getSongContentKey(meta.id), JSON.stringify(content));
-            pipeline.set(getLegacySongContentKey(meta.id), JSON.stringify(content));
           }
         }
         await pipeline.exec();

--- a/api/songs/index.ts
+++ b/api/songs/index.ts
@@ -30,6 +30,8 @@ import {
   deleteAllSongs,
   getSongMetaKey,
   getSongContentKey,
+  getLegacySongMetaKey,
+  getLegacySongContentKey,
   SONG_SET_KEY,
   type SongMetadata,
   type SongContent,
@@ -38,6 +40,7 @@ import {
 } from "../_utils/_song-service.js";
 import { fetchCoverUrl } from "./_kugou.js";
 import { apiHandler } from "../_utils/api-handler.js";
+import { redisKeys } from "../../src/shared/redisKeys.js";
 
 export const runtime = "nodejs";
 
@@ -453,10 +456,13 @@ export default apiHandler<Record<string, unknown>>(
         const pipeline = redis.pipeline();
         for (const { meta, content } of songDocs) {
           pipeline.set(getSongMetaKey(meta.id), JSON.stringify(meta));
+          pipeline.set(getLegacySongMetaKey(meta.id), JSON.stringify(meta));
+          pipeline.sadd(redisKeys.media.songIds(), meta.id);
           pipeline.sadd(SONG_SET_KEY, meta.id);
           // Save content if present
           if (content) {
             pipeline.set(getSongContentKey(meta.id), JSON.stringify(content));
+            pipeline.set(getLegacySongContentKey(meta.id), JSON.stringify(content));
           }
         }
         await pipeline.exec();

--- a/api/sync/_keys.ts
+++ b/api/sync/_keys.ts
@@ -1,7 +1,17 @@
+import { redisKeys } from "../../src/shared/redisKeys.js";
+
 export function backupMetaKey(username: string): string {
+  return redisKeys.sync.backupMeta(username);
+}
+
+export function legacyBackupMetaKey(username: string): string {
   return `sync:meta:${username}`;
 }
 
 export function autoSyncPreferenceKey(username: string): string {
+  return redisKeys.sync.autoSyncPreference(username);
+}
+
+export function legacyAutoSyncPreferenceKey(username: string): string {
   return `sync:pref:autoSync:${username.toLowerCase()}`;
 }

--- a/api/sync/auto-sync-preference.ts
+++ b/api/sync/auto-sync-preference.ts
@@ -47,7 +47,6 @@ export default apiHandler<PrefBody>(
       updatedAt: new Date().toISOString(),
     });
     await redis.set(key, serialized);
-    await redis.set(legacyKey, serialized);
     res.status(200).json({ ok: true, enabled });
   }
 );

--- a/api/sync/auto-sync-preference.ts
+++ b/api/sync/auto-sync-preference.ts
@@ -2,7 +2,7 @@
  * GET/PUT /api/sync/auto-sync-preference — cross-device Auto Sync toggle
  */
 import { apiHandler } from "../_utils/api-handler.js";
-import { autoSyncPreferenceKey } from "./_keys.js";
+import { autoSyncPreferenceKey, legacyAutoSyncPreferenceKey } from "./_keys.js";
 
 export const runtime = "nodejs";
 export const maxDuration = 10;
@@ -20,9 +20,12 @@ export default apiHandler<PrefBody>(
   async ({ req, res, redis, user, body }): Promise<void> => {
     const username = user?.username || "";
     const key = autoSyncPreferenceKey(username);
+    const legacyKey = legacyAutoSyncPreferenceKey(username);
 
     if ((req.method || "GET").toUpperCase() === "GET") {
-      const raw = await redis.get<string | { enabled?: boolean }>(key);
+      const raw =
+        (await redis.get<string | { enabled?: boolean }>(key)) ??
+        (await redis.get<string | { enabled?: boolean }>(legacyKey));
       if (!raw) {
         res.status(200).json({ hasPreference: false, enabled: false });
         return;
@@ -39,13 +42,12 @@ export default apiHandler<PrefBody>(
     }
 
     const enabled = body?.enabled === true;
-    await redis.set(
-      key,
-      JSON.stringify({
-        enabled,
-        updatedAt: new Date().toISOString(),
-      })
-    );
+    const serialized = JSON.stringify({
+      enabled,
+      updatedAt: new Date().toISOString(),
+    });
+    await redis.set(key, serialized);
+    await redis.set(legacyKey, serialized);
     res.status(200).json({ ok: true, enabled });
   }
 );

--- a/api/sync/backup.ts
+++ b/api/sync/backup.ts
@@ -125,9 +125,6 @@ async function handleSaveMetadata(
     await redis.set(backupMetaKey(username), JSON.stringify(meta), {
       ex: META_TTL,
     });
-    await redis.set(legacyBackupMetaKey(username), JSON.stringify(meta), {
-      ex: META_TTL,
-    });
 
     res.status(200).json({
       ok: true,

--- a/api/sync/backup.ts
+++ b/api/sync/backup.ts
@@ -17,7 +17,7 @@ import {
   downloadStoredObject,
   headStoredObject,
 } from "../_utils/storage.js";
-import { backupMetaKey } from "./_keys.js";
+import { backupMetaKey, legacyBackupMetaKey } from "./_keys.js";
 import { getStoredLocation } from "./_storage-location.js";
 
 export const runtime = "nodejs";
@@ -94,9 +94,9 @@ async function handleSaveMetadata(
 
   try {
     // Delete old blob if it exists and differs from the new one
-    const existingMeta = await redis.get<string | BackupMeta>(
-      backupMetaKey(username)
-    );
+    const existingMeta =
+      (await redis.get<string | BackupMeta>(backupMetaKey(username))) ??
+      (await redis.get<string | BackupMeta>(legacyBackupMetaKey(username)));
     if (existingMeta) {
       const parsed: BackupMeta =
         typeof existingMeta === "string"
@@ -125,6 +125,9 @@ async function handleSaveMetadata(
     await redis.set(backupMetaKey(username), JSON.stringify(meta), {
       ex: META_TTL,
     });
+    await redis.set(legacyBackupMetaKey(username), JSON.stringify(meta), {
+      ex: META_TTL,
+    });
 
     res.status(200).json({
       ok: true,
@@ -150,7 +153,9 @@ async function handleDownload(
 ): Promise<void> {
   try {
     // Get metadata from Redis
-    const rawMeta = await redis.get<string | BackupMeta>(backupMetaKey(username));
+    const rawMeta =
+      (await redis.get<string | BackupMeta>(backupMetaKey(username))) ??
+      (await redis.get<string | BackupMeta>(legacyBackupMetaKey(username)));
     if (!rawMeta) {
       res.status(404).json({ error: "No backup found" });
       return;
@@ -167,7 +172,7 @@ async function handleDownload(
 
     const objectInfo = await headStoredObject(storageUrl).catch(() => null);
     if (!objectInfo) {
-      await redis.del(backupMetaKey(username));
+      await redis.del(backupMetaKey(username), legacyBackupMetaKey(username));
       res.status(404).json({ error: "Backup data not found. It may have expired." });
       return;
     }
@@ -197,7 +202,9 @@ async function handleDelete(
   username: string
 ): Promise<void> {
   try {
-    const rawMeta = await redis.get<string | BackupMeta>(backupMetaKey(username));
+    const rawMeta =
+      (await redis.get<string | BackupMeta>(backupMetaKey(username))) ??
+      (await redis.get<string | BackupMeta>(legacyBackupMetaKey(username)));
     if (!rawMeta) {
       res.status(404).json({ error: "No backup found" });
       return;
@@ -216,7 +223,7 @@ async function handleDelete(
     }
 
     // Delete metadata
-    await redis.del(backupMetaKey(username));
+    await redis.del(backupMetaKey(username), legacyBackupMetaKey(username));
 
     res.status(200).json({ ok: true });
   } catch (error) {

--- a/api/sync/status.ts
+++ b/api/sync/status.ts
@@ -6,7 +6,7 @@
  */
 
 import { apiHandler } from "../_utils/api-handler.js";
-import { backupMetaKey } from "./_keys.js";
+import { backupMetaKey, legacyBackupMetaKey } from "./_keys.js";
 
 export const runtime = "nodejs";
 export const maxDuration = 10;
@@ -27,7 +27,9 @@ export default apiHandler(
   async ({ res, redis, user }): Promise<void> => {
     try {
       const username = user?.username || "";
-      const rawMeta = await redis.get<string | BackupMeta>(backupMetaKey(username));
+      const rawMeta =
+        (await redis.get<string | BackupMeta>(backupMetaKey(username))) ??
+        (await redis.get<string | BackupMeta>(legacyBackupMetaKey(username)));
 
       if (!rawMeta) {
         res.status(200).json({

--- a/api/sync/v2/_core.ts
+++ b/api/sync/v2/_core.ts
@@ -157,7 +157,6 @@ async function acquireUserLock(redis: Redis, username: string): Promise<boolean>
       ex: LOCK_TTL_SECONDS,
     });
     if (result === "OK" || result === 1) {
-      await redis.set(legacyKey, token, { ex: LOCK_TTL_SECONDS });
       return true;
     }
     if (attempt < LOCK_RETRY_DELAYS_MS.length) {
@@ -187,13 +186,9 @@ async function readSeq(redis: Redis, username: string): Promise<number | null> {
 async function touchTtls(redis: Redis, username: string): Promise<void> {
   const pipeline = redis.pipeline();
   pipeline.expire(sync2SeqKey(username), USER_TTL_SECONDS);
-  pipeline.expire(legacySync2SeqKey(username), USER_TTL_SECONDS);
   pipeline.expire(sync2KvKey(username), USER_TTL_SECONDS);
-  pipeline.expire(legacySync2KvKey(username), USER_TTL_SECONDS);
   pipeline.expire(sync2JournalKey(username), USER_TTL_SECONDS);
-  pipeline.expire(legacySync2JournalKey(username), USER_TTL_SECONDS);
   pipeline.expire(sync2BlobsKey(username), USER_TTL_SECONDS);
-  pipeline.expire(legacySync2BlobsKey(username), USER_TTL_SECONDS);
   await pipeline.exec();
 }
 
@@ -212,9 +207,6 @@ async function touchTtlsThrottled(redis: Redis, username: string): Promise<void>
       { nx: true, ex: TTL_TOUCH_THROTTLE_SECONDS }
     );
     if (marker === "OK" || marker === 1) {
-      await redis.set(`sync2:ttl-touched:${username.toLowerCase()}`, "1", {
-        ex: TTL_TOUCH_THROTTLE_SECONDS,
-      });
       await touchTtls(redis, username);
     }
   } catch (error) {
@@ -262,16 +254,13 @@ export async function ensureSync2Initialized(
 
     if (Object.keys(kvFields).length > 0) {
       await redis.hset(sync2KvKey(username), kvFields);
-      await redis.hset(legacySync2KvKey(username), kvFields);
     }
     if (Object.keys(blobRegistry).length > 0) {
       await redis.hset(sync2BlobsKey(username), blobRegistry);
-      await redis.hset(legacySync2BlobsKey(username), blobRegistry);
     }
     // The import is a baseline snapshot, not journal history: clients that
     // have never synced v2 bootstrap from the snapshot anyway.
     await redis.set(sync2SeqKey(username), "0", { ex: USER_TTL_SECONDS });
-    await redis.set(legacySync2SeqKey(username), "0", { ex: USER_TTL_SECONDS });
     await touchTtls(redis, username);
     console.log(
       `[sync2] Initialized ${username} (${Object.keys(kvFields).length} keys imported from v1)`
@@ -421,18 +410,12 @@ export async function applySyncOps(
 
     if (accepted.length > 0) {
       await redis.hset(sync2KvKey(username), kvWrites);
-      await redis.hset(legacySync2KvKey(username), kvWrites);
       const journalKey = sync2JournalKey(username);
-      const legacyJournalKey = legacySync2JournalKey(username);
       for (const { seq, member } of journalEntries) {
         await redis.zadd(journalKey, { score: seq, member });
-        await redis.zadd(legacyJournalKey, { score: seq, member });
       }
       const pipeline = redis.pipeline();
       pipeline.set(sync2SeqKey(username), String(nextSeq), {
-        ex: USER_TTL_SECONDS,
-      });
-      pipeline.set(legacySync2SeqKey(username), String(nextSeq), {
         ex: USER_TTL_SECONDS,
       });
       await pipeline.exec();
@@ -442,14 +425,8 @@ export async function applySyncOps(
         "-inf",
         nextSeq - JOURNAL_MAX_LENGTH
       );
-      await redis.zremrangebyscore(
-        legacyJournalKey,
-        "-inf",
-        nextSeq - JOURNAL_MAX_LENGTH
-      );
       if (Object.keys(blobRegistry).length > 0) {
         await redis.hset(sync2BlobsKey(username), blobRegistry);
-        await redis.hset(legacySync2BlobsKey(username), blobRegistry);
       }
       await touchTtls(redis, username);
     }

--- a/api/sync/v2/_core.ts
+++ b/api/sync/v2/_core.ts
@@ -38,6 +38,7 @@ import {
   type SyncOpResult,
   type SyncOpsRealtimeEvent,
 } from "../../../src/shared/sync2/types.js";
+import { redisKeys } from "../../../src/shared/redisKeys.js";
 import { importV1SyncState } from "./_import.js";
 
 export const MAX_OPS_PER_REQUEST = 1000;
@@ -49,22 +50,42 @@ const LOCK_RETRY_DELAYS_MS = [150, 300, 600, 1200, 2400];
 const REALTIME_INLINE_LIMIT_BYTES = 8 * 1024;
 
 export function sync2SeqKey(username: string): string {
+  return redisKeys.sync.v2Seq(username);
+}
+
+export function legacySync2SeqKey(username: string): string {
   return `sync2:seq:${username.toLowerCase()}`;
 }
 
 export function sync2KvKey(username: string): string {
+  return redisKeys.sync.v2Kv(username);
+}
+
+export function legacySync2KvKey(username: string): string {
   return `sync2:kv:${username.toLowerCase()}`;
 }
 
 export function sync2JournalKey(username: string): string {
+  return redisKeys.sync.v2Journal(username);
+}
+
+export function legacySync2JournalKey(username: string): string {
   return `sync2:jrnl:${username.toLowerCase()}`;
 }
 
 export function sync2BlobsKey(username: string): string {
+  return redisKeys.sync.v2Blobs(username);
+}
+
+export function legacySync2BlobsKey(username: string): string {
   return `sync2:blobs:${username.toLowerCase()}`;
 }
 
 function sync2LockKey(username: string): string {
+  return redisKeys.sync.v2Lock(username);
+}
+
+function legacySync2LockKey(username: string): string {
   return `sync2:lock:${username.toLowerCase()}`;
 }
 
@@ -103,19 +124,40 @@ async function hmgetValues<T>(
   return fields.map(() => null);
 }
 
+async function hmgetValuesWithFallback<T>(
+  redis: Redis,
+  key: string,
+  legacyKey: string,
+  fields: string[]
+): Promise<(T | null)[]> {
+  const primary = await hmgetValues<T>(redis, key, fields);
+  if (primary.every((value) => value !== null)) return primary;
+  const fallback = await hmgetValues<T>(redis, legacyKey, fields);
+  return primary.map((value, index) => value ?? fallback[index] ?? null);
+}
+
 async function sleep(ms: number): Promise<void> {
   await new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 async function acquireUserLock(redis: Redis, username: string): Promise<boolean> {
   const key = sync2LockKey(username);
+  const legacyKey = legacySync2LockKey(username);
   const token = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
   for (let attempt = 0; attempt <= LOCK_RETRY_DELAYS_MS.length; attempt += 1) {
+    if ((await redis.exists(legacyKey)) > 0) {
+      if (attempt < LOCK_RETRY_DELAYS_MS.length) {
+        await sleep(LOCK_RETRY_DELAYS_MS[attempt]);
+        continue;
+      }
+      return false;
+    }
     const result = await redis.set(key, token, {
       nx: true,
       ex: LOCK_TTL_SECONDS,
     });
     if (result === "OK" || result === 1) {
+      await redis.set(legacyKey, token, { ex: LOCK_TTL_SECONDS });
       return true;
     }
     if (attempt < LOCK_RETRY_DELAYS_MS.length) {
@@ -127,14 +169,16 @@ async function acquireUserLock(redis: Redis, username: string): Promise<boolean>
 
 async function releaseUserLock(redis: Redis, username: string): Promise<void> {
   try {
-    await redis.del(sync2LockKey(username));
+    await redis.del(sync2LockKey(username), legacySync2LockKey(username));
   } catch (error) {
     console.warn("[sync2] Failed to release user lock:", error);
   }
 }
 
 async function readSeq(redis: Redis, username: string): Promise<number | null> {
-  const raw = await redis.get<string | number>(sync2SeqKey(username));
+  const raw =
+    (await redis.get<string | number>(sync2SeqKey(username))) ??
+    (await redis.get<string | number>(legacySync2SeqKey(username)));
   if (raw === null || raw === undefined) return null;
   const parsed = typeof raw === "number" ? raw : Number.parseInt(raw, 10);
   return Number.isFinite(parsed) ? parsed : null;
@@ -143,9 +187,13 @@ async function readSeq(redis: Redis, username: string): Promise<number | null> {
 async function touchTtls(redis: Redis, username: string): Promise<void> {
   const pipeline = redis.pipeline();
   pipeline.expire(sync2SeqKey(username), USER_TTL_SECONDS);
+  pipeline.expire(legacySync2SeqKey(username), USER_TTL_SECONDS);
   pipeline.expire(sync2KvKey(username), USER_TTL_SECONDS);
+  pipeline.expire(legacySync2KvKey(username), USER_TTL_SECONDS);
   pipeline.expire(sync2JournalKey(username), USER_TTL_SECONDS);
+  pipeline.expire(legacySync2JournalKey(username), USER_TTL_SECONDS);
   pipeline.expire(sync2BlobsKey(username), USER_TTL_SECONDS);
+  pipeline.expire(legacySync2BlobsKey(username), USER_TTL_SECONDS);
   await pipeline.exec();
 }
 
@@ -159,11 +207,14 @@ const TTL_TOUCH_THROTTLE_SECONDS = 24 * 60 * 60;
 async function touchTtlsThrottled(redis: Redis, username: string): Promise<void> {
   try {
     const marker = await redis.set(
-      `sync2:ttl-touched:${username.toLowerCase()}`,
+      redisKeys.sync.v2TtlTouched(username),
       "1",
       { nx: true, ex: TTL_TOUCH_THROTTLE_SECONDS }
     );
     if (marker === "OK" || marker === 1) {
+      await redis.set(`sync2:ttl-touched:${username.toLowerCase()}`, "1", {
+        ex: TTL_TOUCH_THROTTLE_SECONDS,
+      });
       await touchTtls(redis, username);
     }
   } catch (error) {
@@ -211,13 +262,16 @@ export async function ensureSync2Initialized(
 
     if (Object.keys(kvFields).length > 0) {
       await redis.hset(sync2KvKey(username), kvFields);
+      await redis.hset(legacySync2KvKey(username), kvFields);
     }
     if (Object.keys(blobRegistry).length > 0) {
       await redis.hset(sync2BlobsKey(username), blobRegistry);
+      await redis.hset(legacySync2BlobsKey(username), blobRegistry);
     }
     // The import is a baseline snapshot, not journal history: clients that
     // have never synced v2 bootstrap from the snapshot anyway.
     await redis.set(sync2SeqKey(username), "0", { ex: USER_TTL_SECONDS });
+    await redis.set(legacySync2SeqKey(username), "0", { ex: USER_TTL_SECONDS });
     await touchTtls(redis, username);
     console.log(
       `[sync2] Initialized ${username} (${Object.keys(kvFields).length} keys imported from v1)`
@@ -305,9 +359,10 @@ export async function applySyncOps(
     }
 
     const keys = Array.from(opsByKey.keys());
-    const existingEntries = await hmgetValues<SyncKvEntry>(
+    const existingEntries = await hmgetValuesWithFallback<SyncKvEntry>(
       redis,
       sync2KvKey(username),
+      legacySync2KvKey(username),
       keys
     );
 
@@ -366,12 +421,18 @@ export async function applySyncOps(
 
     if (accepted.length > 0) {
       await redis.hset(sync2KvKey(username), kvWrites);
+      await redis.hset(legacySync2KvKey(username), kvWrites);
       const journalKey = sync2JournalKey(username);
+      const legacyJournalKey = legacySync2JournalKey(username);
       for (const { seq, member } of journalEntries) {
         await redis.zadd(journalKey, { score: seq, member });
+        await redis.zadd(legacyJournalKey, { score: seq, member });
       }
       const pipeline = redis.pipeline();
       pipeline.set(sync2SeqKey(username), String(nextSeq), {
+        ex: USER_TTL_SECONDS,
+      });
+      pipeline.set(legacySync2SeqKey(username), String(nextSeq), {
         ex: USER_TTL_SECONDS,
       });
       await pipeline.exec();
@@ -381,8 +442,14 @@ export async function applySyncOps(
         "-inf",
         nextSeq - JOURNAL_MAX_LENGTH
       );
+      await redis.zremrangebyscore(
+        legacyJournalKey,
+        "-inf",
+        nextSeq - JOURNAL_MAX_LENGTH
+      );
       if (Object.keys(blobRegistry).length > 0) {
         await redis.hset(sync2BlobsKey(username), blobRegistry);
+        await redis.hset(legacySync2BlobsKey(username), blobRegistry);
       }
       await touchTtls(redis, username);
     }
@@ -451,8 +518,12 @@ export async function readSyncChanges(
     return { seq, ops: [] };
   }
 
-  const journalKey = sync2JournalKey(username);
-  const count = await redis.zcard(journalKey);
+  const canonicalJournalKey = sync2JournalKey(username);
+  const legacyJournalKey = legacySync2JournalKey(username);
+  const canonicalCount = await redis.zcard(canonicalJournalKey);
+  const legacyCount = await redis.zcard(legacyJournalKey);
+  const journalKey = canonicalCount > 0 ? canonicalJournalKey : legacyJournalKey;
+  const count = canonicalCount > 0 ? canonicalCount : legacyCount;
   const missing = seq - since;
   if (missing > count) {
     return { seq, snapshotRequired: true };
@@ -497,7 +568,12 @@ export async function readSyncSnapshot(
 
   // Read seq AFTER the KV hash so the cursor can only undercount (clients
   // re-fetch ops they already have, which LWW makes harmless), never skip.
-  const raw = await redis.hgetall<Record<string, unknown>>(sync2KvKey(username));
+  const legacyRaw = await redis.hgetall<Record<string, unknown>>(legacySync2KvKey(username));
+  const canonicalRaw = await redis.hgetall<Record<string, unknown>>(sync2KvKey(username));
+  const raw = {
+    ...(legacyRaw || {}),
+    ...(canonicalRaw || {}),
+  };
   const seq = (await readSeq(redis, username)) ?? 0;
 
   const entries: Record<string, SyncKvEntry> = {};
@@ -562,9 +638,10 @@ export async function lookupSyncBlobs(
   digests: string[]
 ): Promise<(SyncBlobRegistryEntry | null)[]> {
   if (digests.length === 0) return [];
-  const values = await hmgetValues<SyncBlobRegistryEntry>(
+  const values = await hmgetValuesWithFallback<SyncBlobRegistryEntry>(
     redis,
     sync2BlobsKey(username),
+    legacySync2BlobsKey(username),
     digests
   );
   return values.map((value) =>

--- a/api/sync/v2/_maintenance.ts
+++ b/api/sync/v2/_maintenance.ts
@@ -24,10 +24,13 @@ import type { Redis } from "../../_utils/redis.js";
 import { deleteStoredObject } from "../../_utils/storage.js";
 import { getSyncBlobRef } from "../../../src/shared/sync2/types.js";
 import {
+  legacySync2BlobsKey,
+  legacySync2KvKey,
   parseRedisJson,
   sync2BlobsKey,
   sync2KvKey,
 } from "./_core.js";
+import { redisKeys } from "../../../src/shared/redisKeys.js";
 
 /**
  * Retirement TTL for frozen v1 keys. These are dead copies of data already
@@ -38,7 +41,7 @@ export const V1_RETIREMENT_TTL_SECONDS = 90 * 24 * 60 * 60;
 /** Unreferenced blobs must stay marked this long before deletion. */
 export const BLOB_GC_GRACE_MS = 24 * 60 * 60 * 1000;
 
-const MAINTENANCE_CURSOR_KEY = "sync2:maint:cursor";
+const LEGACY_MAINTENANCE_CURSOR_KEY = "sync2:maint:cursor";
 
 const V1_REDIS_DOMAINS = [
   "settings",
@@ -101,9 +104,11 @@ interface V1ManifestEntry {
 
 function getUsernameFromKvKey(key: string): string | null {
   const prefix = "sync2:kv:";
-  return key.startsWith(prefix) && key.length > prefix.length
-    ? key.slice(prefix.length)
-    : null;
+  if (key.startsWith(prefix) && key.length > prefix.length) {
+    return key.slice(prefix.length);
+  }
+  const canonicalMatch = /^sync:v2:user:([^:]+):kv$/.exec(key);
+  return canonicalMatch?.[1] ? decodeURIComponent(canonicalMatch[1]) : null;
 }
 
 /**
@@ -118,37 +123,46 @@ async function scanUserBatch(
   scanCount: number
 ): Promise<{ usernames: string[]; scanComplete: boolean }> {
   const startCursor =
-    (await redis.get<string | number>(MAINTENANCE_CURSOR_KEY)) ?? "0";
+    (await redis.get<string | number>(redisKeys.sync.maintenanceCursor())) ??
+    (await redis.get<string | number>(LEGACY_MAINTENANCE_CURSOR_KEY)) ??
+    "0";
   let cursor: string | number = String(startCursor);
   const usernames: string[] = [];
   let scanComplete = false;
 
   // SCAN counts are hints; loop until the batch is full or the scan wraps.
-  for (let iterations = 0; iterations < 50; iterations += 1) {
-    const [nextCursor, keys] = await redis.scan(cursor, {
-      match: "sync2:kv:*",
-      count: scanCount,
-    });
-    for (const key of keys) {
-      const username = getUsernameFromKvKey(key);
-      if (username && !usernames.includes(username)) {
-        usernames.push(username);
+  for (const pattern of ["sync:v2:user:*:kv", "sync2:kv:*"]) {
+    for (let iterations = 0; iterations < 50; iterations += 1) {
+      const [nextCursor, keys] = await redis.scan(cursor, {
+        match: pattern,
+        count: scanCount,
+      });
+      for (const key of keys) {
+        const username = getUsernameFromKvKey(key);
+        if (username && !usernames.includes(username)) {
+          usernames.push(username);
+        }
+      }
+      cursor = String(nextCursor);
+      if (cursor === "0") {
+        scanComplete = true;
+        break;
+      }
+      if (usernames.length >= maxUsers) {
+        break;
       }
     }
-    cursor = String(nextCursor);
-    if (cursor === "0") {
-      scanComplete = true;
-      break;
-    }
-    if (usernames.length >= maxUsers) {
-      break;
-    }
+    if (usernames.length >= maxUsers) break;
+    cursor = "0";
   }
 
   if (scanComplete) {
-    await redis.del(MAINTENANCE_CURSOR_KEY);
+    await redis.del(redisKeys.sync.maintenanceCursor(), LEGACY_MAINTENANCE_CURSOR_KEY);
   } else {
-    await redis.set(MAINTENANCE_CURSOR_KEY, String(cursor), {
+    await redis.set(redisKeys.sync.maintenanceCursor(), String(cursor), {
+      ex: 7 * 24 * 60 * 60,
+    });
+    await redis.set(LEGACY_MAINTENANCE_CURSOR_KEY, String(cursor), {
       ex: 7 * 24 * 60 * 60,
     });
   }
@@ -163,7 +177,9 @@ async function collectReferencedBlobs(
 ): Promise<{ hashes: Set<string>; urls: Set<string> }> {
   const hashes = new Set<string>();
   const urls = new Set<string>();
-  const raw = await redis.hgetall<Record<string, unknown>>(sync2KvKey(username));
+  const legacyRaw = await redis.hgetall<Record<string, unknown>>(legacySync2KvKey(username));
+  const canonicalRaw = await redis.hgetall<Record<string, unknown>>(sync2KvKey(username));
+  const raw = { ...(legacyRaw || {}), ...(canonicalRaw || {}) };
   if (!raw) return { hashes, urls };
 
   for (const value of Object.values(raw)) {
@@ -225,15 +241,17 @@ async function healUserRecord(
   username: string,
   stats: SyncMaintenanceStats
 ): Promise<void> {
-  const key = `chat:users:${username}`;
-  try {
-    if ((await redis.ttl(key)) > 0) {
-      await redis.persist(key);
-      stats.userRecordsPersisted += 1;
+  const keys = [redisKeys.auth.userProfile(username), `chat:users:${username}`];
+  for (const key of keys) {
+    try {
+      if ((await redis.ttl(key)) > 0) {
+        await redis.persist(key);
+        stats.userRecordsPersisted += 1;
+      }
+    } catch (error) {
+      stats.errors += 1;
+      console.warn(`[sync2:maint] Failed to persist user record ${key}:`, error);
     }
-  } catch (error) {
-    stats.errors += 1;
-    console.warn(`[sync2:maint] Failed to persist user record ${key}:`, error);
   }
 }
 
@@ -250,7 +268,10 @@ async function sweepBlobRegistry(
   options: Required<Pick<SyncMaintenanceOptions, "graceMs" | "now" | "deleteObject">>
 ): Promise<void> {
   const registryKey = sync2BlobsKey(username);
-  const raw = await redis.hgetall<Record<string, unknown>>(registryKey);
+  const legacyRegistryKey = legacySync2BlobsKey(username);
+  const legacyRaw = await redis.hgetall<Record<string, unknown>>(legacyRegistryKey);
+  const canonicalRaw = await redis.hgetall<Record<string, unknown>>(registryKey);
+  const raw = { ...(legacyRaw || {}), ...(canonicalRaw || {}) };
   if (!raw) return;
 
   for (const [digest, value] of Object.entries(raw)) {
@@ -265,6 +286,7 @@ async function sweepBlobRegistry(
         // Re-referenced while marked: clear the mark.
         const { gc: _gc, ...unmarked } = entry;
         await redis.hset(registryKey, { [digest]: JSON.stringify(unmarked) });
+        await redis.hset(legacyRegistryKey, { [digest]: JSON.stringify(unmarked) });
         stats.blobsUnmarked += 1;
       }
       continue;
@@ -272,6 +294,9 @@ async function sweepBlobRegistry(
 
     if (!entry.gc) {
       await redis.hset(registryKey, {
+        [digest]: JSON.stringify({ ...entry, gc: options.now }),
+      });
+      await redis.hset(legacyRegistryKey, {
         [digest]: JSON.stringify({ ...entry, gc: options.now }),
       });
       stats.blobsMarked += 1;
@@ -285,6 +310,7 @@ async function sweepBlobRegistry(
       budget.remaining -= 1;
       await options.deleteObject(entry.url);
       await redis.hdel(registryKey, digest);
+      await redis.hdel(legacyRegistryKey, digest);
       stats.blobsDeleted += 1;
     } catch (error) {
       stats.errors += 1;

--- a/api/sync/v2/_maintenance.ts
+++ b/api/sync/v2/_maintenance.ts
@@ -131,6 +131,25 @@ function getUsernameFromKvKey(key: string): string | null {
   return canonicalMatch?.[1] ? decodeURIComponent(canonicalMatch[1]) : null;
 }
 
+function parseMaintenanceCursor(raw: string | number): {
+  patternIndex: number;
+  cursor: string;
+} {
+  if (typeof raw === "string" && raw.trim().startsWith("{")) {
+    const parsed = parseRedisJson<{ patternIndex?: unknown; cursor?: unknown }>(raw);
+    const patternIndex =
+      typeof parsed?.patternIndex === "number" && parsed.patternIndex >= 0
+        ? Math.floor(parsed.patternIndex)
+        : 0;
+    const cursor =
+      typeof parsed?.cursor === "number" || typeof parsed?.cursor === "string"
+        ? String(parsed.cursor)
+        : "0";
+    return { patternIndex, cursor };
+  }
+  return { patternIndex: 0, cursor: String(raw) };
+}
+
 /**
  * Discover the next batch of v2 users by scanning their KV hash keys.
  * Every user returned by a consumed scan iteration is processed (never
@@ -146,12 +165,16 @@ async function scanUserBatch(
     (await redis.get<string | number>(redisKeys.sync.maintenanceCursor())) ??
     (await redis.get<string | number>(LEGACY_MAINTENANCE_CURSOR_KEY)) ??
     "0";
-  let cursor: string | number = String(startCursor);
+  const patterns = ["sync:v2:user:*:kv", "sync2:kv:*"];
+  const startState = parseMaintenanceCursor(startCursor);
+  let cursor: string | number = startState.cursor;
+  let patternIndex = Math.min(startState.patternIndex, patterns.length - 1);
   const usernames: string[] = [];
   let scanComplete = false;
 
   // SCAN counts are hints; loop until the batch is full or the scan wraps.
-  for (const pattern of ["sync:v2:user:*:kv", "sync2:kv:*"]) {
+  for (; patternIndex < patterns.length; patternIndex += 1) {
+    const pattern = patterns[patternIndex];
     for (let iterations = 0; iterations < 50; iterations += 1) {
       const [nextCursor, keys] = await redis.scan(cursor, {
         match: pattern,
@@ -165,24 +188,25 @@ async function scanUserBatch(
       }
       cursor = String(nextCursor);
       if (cursor === "0") {
-        scanComplete = true;
         break;
       }
       if (usernames.length >= maxUsers) {
         break;
       }
     }
-    if (usernames.length >= maxUsers) break;
+    if (cursor !== "0") break;
+    if (usernames.length >= maxUsers) {
+      patternIndex += 1;
+      break;
+    }
     cursor = "0";
   }
+  scanComplete = patternIndex >= patterns.length && cursor === "0";
 
   if (scanComplete) {
     await redis.del(redisKeys.sync.maintenanceCursor(), LEGACY_MAINTENANCE_CURSOR_KEY);
   } else {
-    await redis.set(redisKeys.sync.maintenanceCursor(), String(cursor), {
-      ex: 7 * 24 * 60 * 60,
-    });
-    await redis.set(LEGACY_MAINTENANCE_CURSOR_KEY, String(cursor), {
+    await redis.set(redisKeys.sync.maintenanceCursor(), JSON.stringify({ patternIndex, cursor }), {
       ex: 7 * 24 * 60 * 60,
     });
   }
@@ -261,7 +285,7 @@ async function healUserRecord(
   username: string,
   stats: SyncMaintenanceStats
 ): Promise<void> {
-  const keys = [redisKeys.auth.userProfile(username), `chat:users:${username}`];
+  const keys = [redisKeys.auth.userProfile(username)];
   for (const key of keys) {
     try {
       if ((await redis.ttl(key)) > 0) {
@@ -306,7 +330,7 @@ async function sweepBlobRegistry(
         // Re-referenced while marked: clear the mark.
         const { gc: _gc, ...unmarked } = entry;
         await redis.hset(registryKey, { [digest]: JSON.stringify(unmarked) });
-        await redis.hset(legacyRegistryKey, { [digest]: JSON.stringify(unmarked) });
+        await redis.hdel(legacyRegistryKey, digest);
         stats.blobsUnmarked += 1;
       }
       continue;
@@ -316,9 +340,7 @@ async function sweepBlobRegistry(
       await redis.hset(registryKey, {
         [digest]: JSON.stringify({ ...entry, gc: options.now }),
       });
-      await redis.hset(legacyRegistryKey, {
-        [digest]: JSON.stringify({ ...entry, gc: options.now }),
-      });
+      await redis.hdel(legacyRegistryKey, digest);
       stats.blobsMarked += 1;
       continue;
     }

--- a/api/sync/v2/_maintenance.ts
+++ b/api/sync/v2/_maintenance.ts
@@ -102,6 +102,26 @@ interface V1ManifestEntry {
   [key: string]: unknown;
 }
 
+function mergeBlobRegistries(
+  legacyRaw: Record<string, unknown> | null,
+  canonicalRaw: Record<string, unknown> | null
+): Record<string, string> {
+  const merged: Record<string, string> = {};
+  const digests = new Set([
+    ...Object.keys(legacyRaw || {}),
+    ...Object.keys(canonicalRaw || {}),
+  ]);
+  for (const digest of digests) {
+    const legacyEntry = parseRedisJson<BlobRegistryEntry>(legacyRaw?.[digest]);
+    const canonicalEntry = parseRedisJson<BlobRegistryEntry>(canonicalRaw?.[digest]);
+    const entry = canonicalEntry || legacyEntry;
+    if (!entry) continue;
+    const gc = canonicalEntry?.gc ?? legacyEntry?.gc;
+    merged[digest] = JSON.stringify(gc ? { ...entry, gc } : entry);
+  }
+  return merged;
+}
+
 function getUsernameFromKvKey(key: string): string | null {
   const prefix = "sync2:kv:";
   if (key.startsWith(prefix) && key.length > prefix.length) {
@@ -271,8 +291,8 @@ async function sweepBlobRegistry(
   const legacyRegistryKey = legacySync2BlobsKey(username);
   const legacyRaw = await redis.hgetall<Record<string, unknown>>(legacyRegistryKey);
   const canonicalRaw = await redis.hgetall<Record<string, unknown>>(registryKey);
-  const raw = { ...(legacyRaw || {}), ...(canonicalRaw || {}) };
-  if (!raw) return;
+  const raw = mergeBlobRegistries(legacyRaw, canonicalRaw);
+  if (Object.keys(raw).length === 0) return;
 
   for (const [digest, value] of Object.entries(raw)) {
     const entry = parseRedisJson<BlobRegistryEntry>(value);

--- a/src/api/admin.ts
+++ b/src/api/admin.ts
@@ -155,6 +155,58 @@ export async function deleteAdminRedisKey<TResponse>(
   });
 }
 
+export async function getAdminRedisKeyMigrationStatus<TResponse>(input: {
+  limit?: number;
+} = {}): Promise<TResponse> {
+  return adminGet<TResponse>("getRedisKeyMigrationStatus", input);
+}
+
+export async function backfillAdminRedisKeyScheme<TResponse>(input: {
+  pattern: string;
+  limit?: number;
+  dryRun?: boolean;
+}): Promise<TResponse> {
+  return adminPost<
+    TResponse,
+    {
+      action: string;
+      pattern: string;
+      confirmPattern: string;
+      limit?: number;
+      dryRun?: boolean;
+    }
+  >({
+    action: "backfillRedisKeyScheme",
+    pattern: input.pattern,
+    confirmPattern: input.pattern,
+    ...(input.limit ? { limit: input.limit } : {}),
+    ...(input.dryRun !== undefined ? { dryRun: input.dryRun } : {}),
+  });
+}
+
+export async function deleteAdminLegacyRedisKeys<TResponse>(input: {
+  pattern: string;
+  limit?: number;
+  dryRun?: boolean;
+}): Promise<TResponse> {
+  return adminPost<
+    TResponse,
+    {
+      action: string;
+      pattern: string;
+      confirmPattern: string;
+      limit?: number;
+      dryRun?: boolean;
+    }
+  >({
+    action: "deleteLegacyRedisKeys",
+    pattern: input.pattern,
+    confirmPattern: input.pattern,
+    ...(input.limit ? { limit: input.limit } : {}),
+    ...(input.dryRun !== undefined ? { dryRun: input.dryRun } : {}),
+  });
+}
+
 export async function postAdminStartCursorAgent<TResponse>(input: {
   prompt: string;
   modelId?: string;

--- a/src/api/admin.ts
+++ b/src/api/admin.ts
@@ -165,6 +165,7 @@ export async function backfillAdminRedisKeyScheme<TResponse>(input: {
   pattern: string;
   limit?: number;
   dryRun?: boolean;
+  cursor?: string;
 }): Promise<TResponse> {
   return adminPost<
     TResponse,
@@ -174,6 +175,7 @@ export async function backfillAdminRedisKeyScheme<TResponse>(input: {
       confirmPattern: string;
       limit?: number;
       dryRun?: boolean;
+      cursor?: string;
     }
   >({
     action: "backfillRedisKeyScheme",
@@ -181,6 +183,7 @@ export async function backfillAdminRedisKeyScheme<TResponse>(input: {
     confirmPattern: input.pattern,
     ...(input.limit ? { limit: input.limit } : {}),
     ...(input.dryRun !== undefined ? { dryRun: input.dryRun } : {}),
+    ...(input.cursor ? { cursor: input.cursor } : {}),
   });
 }
 
@@ -188,6 +191,7 @@ export async function deleteAdminLegacyRedisKeys<TResponse>(input: {
   pattern: string;
   limit?: number;
   dryRun?: boolean;
+  cursor?: string;
 }): Promise<TResponse> {
   return adminPost<
     TResponse,
@@ -197,6 +201,7 @@ export async function deleteAdminLegacyRedisKeys<TResponse>(input: {
       confirmPattern: string;
       limit?: number;
       dryRun?: boolean;
+      cursor?: string;
     }
   >({
     action: "deleteLegacyRedisKeys",
@@ -204,6 +209,7 @@ export async function deleteAdminLegacyRedisKeys<TResponse>(input: {
     confirmPattern: input.pattern,
     ...(input.limit ? { limit: input.limit } : {}),
     ...(input.dryRun !== undefined ? { dryRun: input.dryRun } : {}),
+    ...(input.cursor ? { cursor: input.cursor } : {}),
   });
 }
 

--- a/src/apps/admin/components/admin-app/AdminRedisBrowserView.tsx
+++ b/src/apps/admin/components/admin-app/AdminRedisBrowserView.tsx
@@ -23,12 +23,16 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import {
+  backfillAdminRedisKeyScheme,
   deleteAdminRedisKey,
+  deleteAdminLegacyRedisKeys,
   getAdminRedisBackup,
   getAdminRedisKey,
+  getAdminRedisKeyMigrationStatus,
   getAdminRedisKeys,
 } from "@/api/admin";
 import { cn } from "@/lib/utils";
+import { LEGACY_REDIS_SCAN_PATTERNS } from "@/shared/redisKeys";
 import {
   adminGhostIconBtnClass,
   adminLoadMoreBtnClass,
@@ -75,6 +79,38 @@ interface RedisBackupDocument {
 interface DeleteRedisKeyResponse {
   success: boolean;
   deletedCount: number;
+}
+
+interface RedisMigrationPatternStatus {
+  pattern: string;
+  count: number;
+  sampleKeys: string[];
+  truncated: boolean;
+}
+
+interface RedisMigrationStatusResponse {
+  totalLegacyKeys: number;
+  truncated: boolean;
+  patterns: RedisMigrationPatternStatus[];
+}
+
+interface RedisBackfillResponse {
+  pattern: string;
+  dryRun: boolean;
+  scanned: number;
+  planned: number;
+  copied: number;
+  skipped: number;
+  truncated: boolean;
+  warnings: string[];
+}
+
+interface DeleteLegacyRedisKeysResponse {
+  pattern: string;
+  dryRun: boolean;
+  scanned: number;
+  deleted: number;
+  truncated: boolean;
 }
 
 export interface AdminRedisBrowserViewProps {
@@ -132,6 +168,14 @@ export function AdminRedisBrowserView({ t }: AdminRedisBrowserViewProps) {
   const [isLoadingDocument, setIsLoadingDocument] = useState(false);
   const [deleteCandidate, setDeleteCandidate] = useState<string | null>(null);
   const [isDeleting, setIsDeleting] = useState(false);
+  const [migrationPattern, setMigrationPattern] = useState<string>(
+    LEGACY_REDIS_SCAN_PATTERNS[0]
+  );
+  const [migrationStatus, setMigrationStatus] = useState<RedisMigrationStatusResponse | null>(null);
+  const [isLoadingMigrationStatus, setIsLoadingMigrationStatus] = useState(false);
+  const [isBackfillingMigration, setIsBackfillingMigration] = useState(false);
+  const [deleteLegacyCandidate, setDeleteLegacyCandidate] = useState<string | null>(null);
+  const [isDeletingLegacy, setIsDeletingLegacy] = useState(false);
   // Cache fetched key documents so reopening a key (or returning to it after
   // navigating) does not re-hit Redis. Cleared on fresh scans / refresh.
   const documentCacheRef = useRef<Map<string, RedisKeyDocument>>(new Map());
@@ -242,6 +286,9 @@ export function AdminRedisBrowserView({ t }: AdminRedisBrowserViewProps) {
   const visibleLeaves = treeLevel.leaves;
   const visibleFolders = isRoot ? rootFolders : treeLevel.folders;
   const hasVisibleRows = visibleFolders.length > 0 || visibleLeaves.length > 0;
+  const selectedMigrationStatus = migrationStatus?.patterns.find(
+    (item) => item.pattern === migrationPattern
+  );
 
   const handlePatternSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -278,6 +325,80 @@ export function AdminRedisBrowserView({ t }: AdminRedisBrowserViewProps) {
     }
   };
 
+  const handleLoadMigrationStatus = async () => {
+    setIsLoadingMigrationStatus(true);
+    try {
+      const status =
+        await getAdminRedisKeyMigrationStatus<RedisMigrationStatusResponse>({ limit: 100 });
+      setMigrationStatus(status);
+      toast.success(
+        t("apps.admin.redis.migration.statusReady", {
+          count: status.totalLegacyKeys,
+          defaultValue: `Found ${status.totalLegacyKeys} sampled legacy Redis keys`,
+        })
+      );
+      if (status.truncated) {
+        toast.info(
+          t(
+            "apps.admin.redis.migration.statusTruncated",
+            "Some legacy patterns hit the preview limit; run batches until clear.",
+          )
+        );
+      }
+    } catch (error) {
+      console.error("Failed to load Redis migration status:", error);
+      toast.error(
+        t("apps.admin.redis.migration.errors.status", "Failed to load migration status")
+      );
+    } finally {
+      setIsLoadingMigrationStatus(false);
+    }
+  };
+
+  const handleBackfillMigration = async (dryRun: boolean) => {
+    setIsBackfillingMigration(true);
+    try {
+      const result = await backfillAdminRedisKeyScheme<RedisBackfillResponse>({
+        pattern: migrationPattern,
+        limit: 100,
+        dryRun,
+      });
+      toast.success(
+        dryRun
+          ? t("apps.admin.redis.migration.dryRunComplete", {
+              scanned: result.scanned,
+              planned: result.planned,
+              defaultValue: `Dry run scanned ${result.scanned}; ${result.planned} keys can be copied`,
+            })
+          : t("apps.admin.redis.migration.backfillComplete", {
+              copied: result.copied,
+              skipped: result.skipped,
+              defaultValue: `Backfilled ${result.copied}; skipped ${result.skipped}`,
+            })
+      );
+      if (result.warnings.length > 0) {
+        toast.info(result.warnings.slice(0, 2).join("\n"));
+      }
+      if (result.truncated) {
+        toast.info(
+          t(
+            "apps.admin.redis.migration.batchTruncated",
+            "Batch limit reached; run the action again for the next batch.",
+          )
+        );
+      }
+      await handleLoadMigrationStatus();
+      refreshScope();
+    } catch (error) {
+      console.error("Failed to backfill Redis key scheme:", error);
+      toast.error(
+        t("apps.admin.redis.migration.errors.backfill", "Failed to backfill Redis keys")
+      );
+    } finally {
+      setIsBackfillingMigration(false);
+    }
+  };
+
   const handleDeleteConfirm = async () => {
     if (!deleteCandidate) return;
     setIsDeleting(true);
@@ -301,6 +422,42 @@ export function AdminRedisBrowserView({ t }: AdminRedisBrowserViewProps) {
       toast.error(t("apps.admin.redis.errors.delete", "Failed to delete Redis key"));
     } finally {
       setIsDeleting(false);
+    }
+  };
+
+  const handleDeleteLegacyConfirm = async () => {
+    if (!deleteLegacyCandidate) return;
+    setIsDeletingLegacy(true);
+    try {
+      const result = await deleteAdminLegacyRedisKeys<DeleteLegacyRedisKeysResponse>({
+        pattern: deleteLegacyCandidate,
+        limit: 100,
+        dryRun: false,
+      });
+      toast.success(
+        t("apps.admin.redis.migration.deleteComplete", {
+          deleted: result.deleted,
+          defaultValue: `Deleted ${result.deleted} legacy Redis keys`,
+        })
+      );
+      if (result.truncated) {
+        toast.info(
+          t(
+            "apps.admin.redis.migration.deleteTruncated",
+            "Batch limit reached; run delete again after reviewing the next batch.",
+          )
+        );
+      }
+      setDeleteLegacyCandidate(null);
+      await handleLoadMigrationStatus();
+      refreshScope();
+    } catch (error) {
+      console.error("Failed to delete legacy Redis keys:", error);
+      toast.error(
+        t("apps.admin.redis.migration.errors.delete", "Failed to delete legacy Redis keys")
+      );
+    } finally {
+      setIsDeletingLegacy(false);
     }
   };
 
@@ -346,6 +503,82 @@ export function AdminRedisBrowserView({ t }: AdminRedisBrowserViewProps) {
           {isLoadingKeys ? <ActivityIndicator size={14} /> : <ArrowsClockwise size={14} weight="bold" />}
         </Button>
       </form>
+
+      <div
+        className={cn(
+          adminToolbarClass,
+          "flex shrink-0 flex-wrap items-center gap-2 border-b border-os-separator px-2 py-1.5 text-[11px]",
+        )}
+      >
+        <span className={cn(adminSectionLabelClass, "mr-1")}>
+          {t("apps.admin.redis.migration.label", "Migration")}
+        </span>
+        <select
+          value={migrationPattern}
+          onChange={(event) => setMigrationPattern(event.target.value)}
+          className="h-7 min-w-[190px] rounded border border-os-separator bg-os-window px-2 font-os-mono text-[11px] text-os-text-primary"
+          aria-label={t("apps.admin.redis.migration.pattern", "Legacy Redis pattern")}
+        >
+          {LEGACY_REDIS_SCAN_PATTERNS.map((legacyPattern) => (
+            <option key={legacyPattern} value={legacyPattern}>
+              {legacyPattern}
+            </option>
+          ))}
+        </select>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          onClick={() => void handleLoadMigrationStatus()}
+          disabled={isLoadingMigrationStatus}
+          className="h-7 px-2 text-[11px]"
+        >
+          {isLoadingMigrationStatus
+            ? t("apps.admin.redis.loading", "Loading...")
+            : t("apps.admin.redis.migration.scan", "Scan legacy")}
+        </Button>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          onClick={() => void handleBackfillMigration(true)}
+          disabled={isBackfillingMigration}
+          className="h-7 px-2 text-[11px]"
+        >
+          {t("apps.admin.redis.migration.dryRun", "Dry run")}
+        </Button>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          onClick={() => void handleBackfillMigration(false)}
+          disabled={isBackfillingMigration}
+          className="h-7 px-2 text-[11px]"
+        >
+          {isBackfillingMigration
+            ? t("apps.admin.redis.loading", "Loading...")
+            : t("apps.admin.redis.migration.backfill", "Backfill batch")}
+        </Button>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          onClick={() => setDeleteLegacyCandidate(migrationPattern)}
+          disabled={isDeletingLegacy}
+          className="h-7 px-2 text-[11px] text-red-600 hover:text-red-700 os-mac-aqua-dark:text-red-300"
+        >
+          {isDeletingLegacy
+            ? t("apps.admin.redis.loading", "Loading...")
+            : t("apps.admin.redis.migration.deleteLegacy", "Delete legacy batch")}
+        </Button>
+        {selectedMigrationStatus ? (
+          <span className="font-os-mono text-[10px] text-os-text-secondary">
+            {selectedMigrationStatus.count}
+            {selectedMigrationStatus.truncated ? "+" : ""}{" "}
+            {t("apps.admin.redis.migration.keysSampled", "sampled")}
+          </span>
+        ) : null}
+      </div>
 
       <div
         className={cn(
@@ -586,6 +819,18 @@ export function AdminRedisBrowserView({ t }: AdminRedisBrowserViewProps) {
         description={t("apps.admin.redis.deleteDescription", {
           key: deleteCandidate,
           defaultValue: `Delete Redis key "${deleteCandidate}"? This cannot be undone.`,
+        })}
+      />
+      <ConfirmDialog
+        isOpen={deleteLegacyCandidate !== null}
+        onOpenChange={(open) => {
+          if (!open) setDeleteLegacyCandidate(null);
+        }}
+        onConfirm={handleDeleteLegacyConfirm}
+        title={t("apps.admin.redis.migration.deleteTitle", "Delete legacy Redis keys?")}
+        description={t("apps.admin.redis.migration.deleteDescription", {
+          pattern: deleteLegacyCandidate,
+          defaultValue: `Delete up to 100 Redis keys matching "${deleteLegacyCandidate}"? Backfill first and repeat until the scan is clear.`,
         })}
       />
     </div>

--- a/src/apps/admin/components/admin-app/AdminRedisBrowserView.tsx
+++ b/src/apps/admin/components/admin-app/AdminRedisBrowserView.tsx
@@ -1,4 +1,5 @@
 import { FormEvent, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { StickToBottom } from "use-stick-to-bottom";
 import {
   ArrowsClockwise,
   CaretRight,
@@ -617,34 +618,40 @@ export function AdminRedisBrowserView({ t }: AdminRedisBrowserViewProps) {
       </div>
 
       {migrationLog.length > 0 ? (
-        <div className="max-h-28 shrink-0 overflow-auto border-b border-os-separator bg-black/5 px-2 py-1 font-os-mono text-[10px] leading-relaxed os-mac-aqua-dark:bg-white/10">
-          <div className="mb-1 flex items-center justify-between gap-2">
-            <span className={adminSectionLabelClass}>
-              {t("apps.admin.redis.migration.log", "Migration log")}
-            </span>
-            {!isMigrationRunning ? (
-              <button
-                type="button"
-                onClick={() => setMigrationLog([])}
-                className="text-os-text-secondary hover:text-os-text-primary hover:underline"
-              >
-                {t("apps.admin.redis.migration.clearLog", "Clear")}
-              </button>
-            ) : null}
-          </div>
-          {migrationLog.map((entry) => (
-            <div
-              key={entry.id}
-              className={cn(
-                entry.tone === "success" && "text-green-700 os-mac-aqua-dark:text-green-300",
-                entry.tone === "warning" && "text-yellow-700 os-mac-aqua-dark:text-yellow-300",
-                entry.tone === "error" && "text-red-700 os-mac-aqua-dark:text-red-300",
-              )}
-            >
-              {entry.message}
+        <StickToBottom
+          className="max-h-28 shrink-0 overflow-hidden border-b border-os-separator bg-black/5 font-os-mono text-[10px] leading-relaxed os-mac-aqua-dark:bg-white/10"
+          resize="smooth"
+          initial="instant"
+        >
+          <StickToBottom.Content className="px-2 py-1">
+            <div className="mb-1 flex items-center justify-between gap-2">
+              <span className={adminSectionLabelClass}>
+                {t("apps.admin.redis.migration.log", "Migration log")}
+              </span>
+              {!isMigrationRunning ? (
+                <button
+                  type="button"
+                  onClick={() => setMigrationLog([])}
+                  className="text-os-text-secondary hover:text-os-text-primary hover:underline"
+                >
+                  {t("apps.admin.redis.migration.clearLog", "Clear")}
+                </button>
+              ) : null}
             </div>
-          ))}
-        </div>
+            {migrationLog.map((entry) => (
+              <div
+                key={entry.id}
+                className={cn(
+                  entry.tone === "success" && "text-green-700 os-mac-aqua-dark:text-green-300",
+                  entry.tone === "warning" && "text-yellow-700 os-mac-aqua-dark:text-yellow-300",
+                  entry.tone === "error" && "text-red-700 os-mac-aqua-dark:text-red-300",
+                )}
+              >
+                {entry.message}
+              </div>
+            ))}
+          </StickToBottom.Content>
+        </StickToBottom>
       ) : null}
 
       <div

--- a/src/apps/admin/components/admin-app/AdminRedisBrowserView.tsx
+++ b/src/apps/admin/components/admin-app/AdminRedisBrowserView.tsx
@@ -96,6 +96,7 @@ interface RedisMigrationStatusResponse {
 
 interface RedisBackfillResponse {
   pattern: string;
+  cursor: string;
   dryRun: boolean;
   scanned: number;
   planned: number;
@@ -107,10 +108,19 @@ interface RedisBackfillResponse {
 
 interface DeleteLegacyRedisKeysResponse {
   pattern: string;
+  cursor: string;
   dryRun: boolean;
   scanned: number;
   deleted: number;
   truncated: boolean;
+}
+
+type RedisMigrationRunKind = "dry-run" | "backfill" | "delete";
+
+interface RedisMigrationLogEntry {
+  id: number;
+  message: string;
+  tone: "info" | "success" | "warning" | "error";
 }
 
 export interface AdminRedisBrowserViewProps {
@@ -168,14 +178,13 @@ export function AdminRedisBrowserView({ t }: AdminRedisBrowserViewProps) {
   const [isLoadingDocument, setIsLoadingDocument] = useState(false);
   const [deleteCandidate, setDeleteCandidate] = useState<string | null>(null);
   const [isDeleting, setIsDeleting] = useState(false);
-  const [migrationPattern, setMigrationPattern] = useState<string>(
-    LEGACY_REDIS_SCAN_PATTERNS[0]
-  );
   const [migrationStatus, setMigrationStatus] = useState<RedisMigrationStatusResponse | null>(null);
   const [isLoadingMigrationStatus, setIsLoadingMigrationStatus] = useState(false);
-  const [isBackfillingMigration, setIsBackfillingMigration] = useState(false);
-  const [deleteLegacyCandidate, setDeleteLegacyCandidate] = useState<string | null>(null);
-  const [isDeletingLegacy, setIsDeletingLegacy] = useState(false);
+  const [activeMigrationRun, setActiveMigrationRun] = useState<RedisMigrationRunKind | null>(null);
+  const [deleteLegacyCandidate, setDeleteLegacyCandidate] = useState(false);
+  const [migrationLog, setMigrationLog] = useState<RedisMigrationLogEntry[]>([]);
+  const migrationStopRequestedRef = useRef(false);
+  const migrationLogIdRef = useRef(0);
   // Cache fetched key documents so reopening a key (or returning to it after
   // navigating) does not re-hit Redis. Cleared on fresh scans / refresh.
   const documentCacheRef = useRef<Map<string, RedisKeyDocument>>(new Map());
@@ -286,8 +295,22 @@ export function AdminRedisBrowserView({ t }: AdminRedisBrowserViewProps) {
   const visibleLeaves = treeLevel.leaves;
   const visibleFolders = isRoot ? rootFolders : treeLevel.folders;
   const hasVisibleRows = visibleFolders.length > 0 || visibleLeaves.length > 0;
-  const selectedMigrationStatus = migrationStatus?.patterns.find(
-    (item) => item.pattern === migrationPattern
+  const isMigrationRunning = activeMigrationRun !== null;
+
+  const appendMigrationLog = useCallback(
+    (message: string, tone: RedisMigrationLogEntry["tone"] = "info") => {
+      migrationLogIdRef.current += 1;
+      const timestamp = new Date().toLocaleTimeString();
+      setMigrationLog((entries) => [
+        ...entries.slice(-199),
+        {
+          id: migrationLogIdRef.current,
+          message: `[${timestamp}] ${message}`,
+          tone,
+        },
+      ]);
+    },
+    []
   );
 
   const handlePatternSubmit = (event: FormEvent<HTMLFormElement>) => {
@@ -325,18 +348,24 @@ export function AdminRedisBrowserView({ t }: AdminRedisBrowserViewProps) {
     }
   };
 
-  const handleLoadMigrationStatus = async () => {
+  const handleLoadMigrationStatus = async (showToast: boolean = true) => {
     setIsLoadingMigrationStatus(true);
     try {
       const status =
         await getAdminRedisKeyMigrationStatus<RedisMigrationStatusResponse>({ limit: 100 });
       setMigrationStatus(status);
-      toast.success(
-        t("apps.admin.redis.migration.statusReady", {
-          count: status.totalLegacyKeys,
-          defaultValue: `Found ${status.totalLegacyKeys} sampled legacy Redis keys`,
-        })
+      appendMigrationLog(
+        `Status scan found ${status.totalLegacyKeys}${status.truncated ? "+" : ""} sampled legacy keys across ${status.patterns.length} patterns`,
+        status.totalLegacyKeys > 0 ? "info" : "success"
       );
+      if (showToast) {
+        toast.success(
+          t("apps.admin.redis.migration.statusReady", {
+            count: status.totalLegacyKeys,
+            defaultValue: `Found ${status.totalLegacyKeys} sampled legacy Redis keys`,
+          })
+        );
+      }
       if (status.truncated) {
         toast.info(
           t(
@@ -355,48 +384,84 @@ export function AdminRedisBrowserView({ t }: AdminRedisBrowserViewProps) {
     }
   };
 
-  const handleBackfillMigration = async (dryRun: boolean) => {
-    setIsBackfillingMigration(true);
+  const runContinuousMigration = async (kind: RedisMigrationRunKind) => {
+    if (activeMigrationRun) return;
+    migrationStopRequestedRef.current = false;
+    setActiveMigrationRun(kind);
+    appendMigrationLog(
+      `${kind === "delete" ? "Delete" : kind === "backfill" ? "Backfill" : "Dry run"} started for all legacy patterns`,
+      "info"
+    );
     try {
-      const result = await backfillAdminRedisKeyScheme<RedisBackfillResponse>({
-        pattern: migrationPattern,
-        limit: 100,
-        dryRun,
-      });
-      toast.success(
-        dryRun
-          ? t("apps.admin.redis.migration.dryRunComplete", {
-              scanned: result.scanned,
-              planned: result.planned,
-              defaultValue: `Dry run scanned ${result.scanned}; ${result.planned} keys can be copied`,
-            })
-          : t("apps.admin.redis.migration.backfillComplete", {
-              copied: result.copied,
-              skipped: result.skipped,
-              defaultValue: `Backfilled ${result.copied}; skipped ${result.skipped}`,
-            })
-      );
-      if (result.warnings.length > 0) {
-        toast.info(result.warnings.slice(0, 2).join("\n"));
+      for (const legacyPattern of LEGACY_REDIS_SCAN_PATTERNS) {
+        if (migrationStopRequestedRef.current) break;
+        let cursor = "0";
+        let batchNumber = 0;
+        let continuePattern = true;
+        while (continuePattern && !migrationStopRequestedRef.current) {
+          batchNumber += 1;
+          if (kind === "delete") {
+            const result = await deleteAdminLegacyRedisKeys<DeleteLegacyRedisKeysResponse>({
+              pattern: legacyPattern,
+              limit: 100,
+              dryRun: false,
+              cursor: "0",
+            });
+            appendMigrationLog(
+              `${legacyPattern} delete batch ${batchNumber}: scanned ${result.scanned}, deleted ${result.deleted}${result.truncated ? ", more pending" : ""}`,
+              result.deleted > 0 ? "success" : "info"
+            );
+            if (result.scanned === 0 || result.deleted === 0) {
+              continuePattern = false;
+            }
+            continue;
+          }
+
+          const result = await backfillAdminRedisKeyScheme<RedisBackfillResponse>({
+            pattern: legacyPattern,
+            limit: 100,
+            dryRun: kind === "dry-run",
+            cursor,
+          });
+          appendMigrationLog(
+            `${legacyPattern} ${kind === "dry-run" ? "dry-run" : "backfill"} batch ${batchNumber}: scanned ${result.scanned}, planned ${result.planned}, copied ${result.copied}, skipped ${result.skipped}, cursor ${result.cursor}`,
+            result.warnings.length > 0 ? "warning" : result.copied > 0 ? "success" : "info"
+          );
+          for (const warning of result.warnings.slice(0, 3)) {
+            appendMigrationLog(`${legacyPattern}: ${warning}`, "warning");
+          }
+          cursor = result.cursor;
+          continuePattern = cursor !== "0";
+        }
       }
-      if (result.truncated) {
-        toast.info(
-          t(
-            "apps.admin.redis.migration.batchTruncated",
-            "Batch limit reached; run the action again for the next batch.",
-          )
+      if (migrationStopRequestedRef.current) {
+        appendMigrationLog("Stopped by user request", "warning");
+      } else {
+        appendMigrationLog(
+          `${kind === "delete" ? "Delete" : kind === "backfill" ? "Backfill" : "Dry run"} completed for all legacy patterns`,
+          "success"
         );
       }
-      await handleLoadMigrationStatus();
+      await handleLoadMigrationStatus(false);
       refreshScope();
     } catch (error) {
-      console.error("Failed to backfill Redis key scheme:", error);
+      console.error("Redis migration run failed:", error);
+      appendMigrationLog(
+        error instanceof Error ? error.message : "Redis migration run failed",
+        "error"
+      );
       toast.error(
-        t("apps.admin.redis.migration.errors.backfill", "Failed to backfill Redis keys")
+        t("apps.admin.redis.migration.errors.run", "Redis migration run failed")
       );
     } finally {
-      setIsBackfillingMigration(false);
+      setActiveMigrationRun(null);
+      migrationStopRequestedRef.current = false;
     }
+  };
+
+  const handleStopMigration = () => {
+    migrationStopRequestedRef.current = true;
+    appendMigrationLog("Stop requested; waiting for current batch to finish", "warning");
   };
 
   const handleDeleteConfirm = async () => {
@@ -427,38 +492,8 @@ export function AdminRedisBrowserView({ t }: AdminRedisBrowserViewProps) {
 
   const handleDeleteLegacyConfirm = async () => {
     if (!deleteLegacyCandidate) return;
-    setIsDeletingLegacy(true);
-    try {
-      const result = await deleteAdminLegacyRedisKeys<DeleteLegacyRedisKeysResponse>({
-        pattern: deleteLegacyCandidate,
-        limit: 100,
-        dryRun: false,
-      });
-      toast.success(
-        t("apps.admin.redis.migration.deleteComplete", {
-          deleted: result.deleted,
-          defaultValue: `Deleted ${result.deleted} legacy Redis keys`,
-        })
-      );
-      if (result.truncated) {
-        toast.info(
-          t(
-            "apps.admin.redis.migration.deleteTruncated",
-            "Batch limit reached; run delete again after reviewing the next batch.",
-          )
-        );
-      }
-      setDeleteLegacyCandidate(null);
-      await handleLoadMigrationStatus();
-      refreshScope();
-    } catch (error) {
-      console.error("Failed to delete legacy Redis keys:", error);
-      toast.error(
-        t("apps.admin.redis.migration.errors.delete", "Failed to delete legacy Redis keys")
-      );
-    } finally {
-      setIsDeletingLegacy(false);
-    }
+    setDeleteLegacyCandidate(false);
+    await runContinuousMigration("delete");
   };
 
   return (
@@ -513,24 +548,15 @@ export function AdminRedisBrowserView({ t }: AdminRedisBrowserViewProps) {
         <span className={cn(adminSectionLabelClass, "mr-1")}>
           {t("apps.admin.redis.migration.label", "Migration")}
         </span>
-        <select
-          value={migrationPattern}
-          onChange={(event) => setMigrationPattern(event.target.value)}
-          className="h-7 min-w-[190px] rounded border border-os-separator bg-os-window px-2 font-os-mono text-[11px] text-os-text-primary"
-          aria-label={t("apps.admin.redis.migration.pattern", "Legacy Redis pattern")}
-        >
-          {LEGACY_REDIS_SCAN_PATTERNS.map((legacyPattern) => (
-            <option key={legacyPattern} value={legacyPattern}>
-              {legacyPattern}
-            </option>
-          ))}
-        </select>
+        <span className="font-os-mono text-[10px] text-os-text-secondary">
+          {LEGACY_REDIS_SCAN_PATTERNS.length} legacy patterns
+        </span>
         <Button
           type="button"
           variant="ghost"
           size="sm"
           onClick={() => void handleLoadMigrationStatus()}
-          disabled={isLoadingMigrationStatus}
+          disabled={isLoadingMigrationStatus || isMigrationRunning}
           className="h-7 px-2 text-[11px]"
         >
           {isLoadingMigrationStatus
@@ -541,8 +567,8 @@ export function AdminRedisBrowserView({ t }: AdminRedisBrowserViewProps) {
           type="button"
           variant="ghost"
           size="sm"
-          onClick={() => void handleBackfillMigration(true)}
-          disabled={isBackfillingMigration}
+          onClick={() => void runContinuousMigration("dry-run")}
+          disabled={isMigrationRunning}
           className="h-7 px-2 text-[11px]"
         >
           {t("apps.admin.redis.migration.dryRun", "Dry run")}
@@ -551,34 +577,76 @@ export function AdminRedisBrowserView({ t }: AdminRedisBrowserViewProps) {
           type="button"
           variant="ghost"
           size="sm"
-          onClick={() => void handleBackfillMigration(false)}
-          disabled={isBackfillingMigration}
+          onClick={() => void runContinuousMigration("backfill")}
+          disabled={isMigrationRunning}
           className="h-7 px-2 text-[11px]"
         >
-          {isBackfillingMigration
+          {activeMigrationRun === "backfill"
             ? t("apps.admin.redis.loading", "Loading...")
-            : t("apps.admin.redis.migration.backfill", "Backfill batch")}
+            : t("apps.admin.redis.migration.backfill", "Backfill all")}
         </Button>
         <Button
           type="button"
           variant="ghost"
           size="sm"
-          onClick={() => setDeleteLegacyCandidate(migrationPattern)}
-          disabled={isDeletingLegacy}
+          onClick={() => setDeleteLegacyCandidate(true)}
+          disabled={isMigrationRunning}
           className="h-7 px-2 text-[11px] text-red-600 hover:text-red-700 os-mac-aqua-dark:text-red-300"
         >
-          {isDeletingLegacy
+          {activeMigrationRun === "delete"
             ? t("apps.admin.redis.loading", "Loading...")
-            : t("apps.admin.redis.migration.deleteLegacy", "Delete legacy batch")}
+            : t("apps.admin.redis.migration.deleteLegacy", "Delete all legacy")}
         </Button>
-        {selectedMigrationStatus ? (
+        {isMigrationRunning ? (
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={handleStopMigration}
+            className="h-7 px-2 text-[11px]"
+          >
+            {t("apps.admin.redis.migration.stop", "Stop")}
+          </Button>
+        ) : null}
+        {migrationStatus ? (
           <span className="font-os-mono text-[10px] text-os-text-secondary">
-            {selectedMigrationStatus.count}
-            {selectedMigrationStatus.truncated ? "+" : ""}{" "}
-            {t("apps.admin.redis.migration.keysSampled", "sampled")}
+            {migrationStatus.totalLegacyKeys}
+            {migrationStatus.truncated ? "+" : ""}{" "}
+            {t("apps.admin.redis.migration.keysSampled", "legacy sampled")}
           </span>
         ) : null}
       </div>
+
+      {migrationLog.length > 0 ? (
+        <div className="max-h-28 shrink-0 overflow-auto border-b border-os-separator bg-black/5 px-2 py-1 font-os-mono text-[10px] leading-relaxed os-mac-aqua-dark:bg-white/10">
+          <div className="mb-1 flex items-center justify-between gap-2">
+            <span className={adminSectionLabelClass}>
+              {t("apps.admin.redis.migration.log", "Migration log")}
+            </span>
+            {!isMigrationRunning ? (
+              <button
+                type="button"
+                onClick={() => setMigrationLog([])}
+                className="text-os-text-secondary hover:text-os-text-primary hover:underline"
+              >
+                {t("apps.admin.redis.migration.clearLog", "Clear")}
+              </button>
+            ) : null}
+          </div>
+          {migrationLog.map((entry) => (
+            <div
+              key={entry.id}
+              className={cn(
+                entry.tone === "success" && "text-green-700 os-mac-aqua-dark:text-green-300",
+                entry.tone === "warning" && "text-yellow-700 os-mac-aqua-dark:text-yellow-300",
+                entry.tone === "error" && "text-red-700 os-mac-aqua-dark:text-red-300",
+              )}
+            >
+              {entry.message}
+            </div>
+          ))}
+        </div>
+      ) : null}
 
       <div
         className={cn(
@@ -822,15 +890,15 @@ export function AdminRedisBrowserView({ t }: AdminRedisBrowserViewProps) {
         })}
       />
       <ConfirmDialog
-        isOpen={deleteLegacyCandidate !== null}
+        isOpen={deleteLegacyCandidate}
         onOpenChange={(open) => {
-          if (!open) setDeleteLegacyCandidate(null);
+          if (!open) setDeleteLegacyCandidate(false);
         }}
         onConfirm={handleDeleteLegacyConfirm}
         title={t("apps.admin.redis.migration.deleteTitle", "Delete legacy Redis keys?")}
         description={t("apps.admin.redis.migration.deleteDescription", {
-          pattern: deleteLegacyCandidate,
-          defaultValue: `Delete up to 100 Redis keys matching "${deleteLegacyCandidate}"? Backfill first and repeat until the scan is clear.`,
+          defaultValue:
+            "Delete all registered legacy Redis keys in continuous batches? Backfill first; this keeps going until every legacy pattern is clear or Stop is clicked.",
         })}
       />
     </div>

--- a/src/apps/admin/components/admin-app/AdminRedisBrowserView.tsx
+++ b/src/apps/admin/components/admin-app/AdminRedisBrowserView.tsx
@@ -114,6 +114,7 @@ interface DeleteLegacyRedisKeysResponse {
   scanned: number;
   deleted: number;
   truncated: boolean;
+  keys: string[];
 }
 
 type RedisMigrationRunKind = "dry-run" | "backfill" | "delete";
@@ -127,6 +128,9 @@ interface RedisMigrationLogEntry {
 export interface AdminRedisBrowserViewProps {
   t: TFunction;
 }
+
+const MIGRATION_BATCH_LIMIT = 100;
+const DELETE_LEGACY_BATCH_LIMIT = 1000;
 
 function formatRedisTtl(ttl: number | null): string {
   if (ttl === null) return "TTL unknown";
@@ -161,6 +165,12 @@ function downloadJson(filename: string, data: unknown): void {
   link.click();
   document.body.removeChild(link);
   URL.revokeObjectURL(url);
+}
+
+function formatDeletedKeySample(keys: string[]): string {
+  if (keys.length === 0) return "no keys";
+  if (keys.length === 1) return `key ${keys[0]}`;
+  return `keys ${keys[0]} ... ${keys[keys.length - 1]}`;
 }
 
 // How many keys each SCAN page requests. SCAN COUNT is a hint, so the actual
@@ -415,7 +425,7 @@ export function AdminRedisBrowserView({ t }: AdminRedisBrowserViewProps) {
           if (kind === "delete") {
             const result = await deleteAdminLegacyRedisKeys<DeleteLegacyRedisKeysResponse>({
               pattern: legacyPattern,
-              limit: 100,
+              limit: DELETE_LEGACY_BATCH_LIMIT,
               dryRun: false,
               cursor: "0",
             });
@@ -423,7 +433,7 @@ export function AdminRedisBrowserView({ t }: AdminRedisBrowserViewProps) {
             totals.scanned += result.scanned;
             totals.deleted += result.deleted;
             appendMigrationLog(
-              `${legacyPattern} delete batch ${batchNumber}: scanned ${result.scanned}, deleted ${result.deleted}${result.truncated ? ", more pending" : ""}`,
+              `pattern ${legacyPattern} delete batch ${batchNumber}: scanned ${result.scanned}, deleted ${result.deleted} (${formatDeletedKeySample(result.keys)})${result.truncated ? ", more pending" : ""}`,
               result.deleted > 0 ? "success" : "info"
             );
             if (result.scanned === 0 || result.deleted === 0) {
@@ -434,7 +444,7 @@ export function AdminRedisBrowserView({ t }: AdminRedisBrowserViewProps) {
 
           const result = await backfillAdminRedisKeyScheme<RedisBackfillResponse>({
             pattern: legacyPattern,
-            limit: 100,
+            limit: MIGRATION_BATCH_LIMIT,
             dryRun: kind === "dry-run",
             cursor,
           });

--- a/src/apps/admin/components/admin-app/AdminRedisBrowserView.tsx
+++ b/src/apps/admin/components/admin-app/AdminRedisBrowserView.tsx
@@ -597,17 +597,16 @@ export function AdminRedisBrowserView({ t }: AdminRedisBrowserViewProps) {
             ? t("apps.admin.redis.loading", "Loading...")
             : t("apps.admin.redis.migration.deleteLegacy", "Delete all legacy")}
         </Button>
-        {isMigrationRunning ? (
-          <Button
-            type="button"
-            variant="ghost"
-            size="sm"
-            onClick={handleStopMigration}
-            className="h-7 px-2 text-[11px]"
-          >
-            {t("apps.admin.redis.migration.stop", "Stop")}
-          </Button>
-        ) : null}
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          onClick={handleStopMigration}
+          disabled={!isMigrationRunning}
+          className="h-7 px-2 text-[11px]"
+        >
+          {t("apps.admin.redis.migration.stop", "Stop")}
+        </Button>
         {migrationStatus ? (
           <span className="font-os-mono text-[10px] text-os-text-secondary">
             {migrationStatus.totalLegacyKeys}

--- a/src/apps/admin/components/admin-app/AdminRedisBrowserView.tsx
+++ b/src/apps/admin/components/admin-app/AdminRedisBrowserView.tsx
@@ -389,8 +389,19 @@ export function AdminRedisBrowserView({ t }: AdminRedisBrowserViewProps) {
     if (activeMigrationRun) return;
     migrationStopRequestedRef.current = false;
     setActiveMigrationRun(kind);
+    const totals = {
+      batches: 0,
+      copied: 0,
+      deleted: 0,
+      planned: 0,
+      scanned: 0,
+      skipped: 0,
+      warnings: 0,
+    };
+    const runLabel =
+      kind === "delete" ? "Delete" : kind === "backfill" ? "Backfill" : "Dry run";
     appendMigrationLog(
-      `${kind === "delete" ? "Delete" : kind === "backfill" ? "Backfill" : "Dry run"} started for all legacy patterns`,
+      `${runLabel} started for all legacy patterns`,
       "info"
     );
     try {
@@ -408,6 +419,9 @@ export function AdminRedisBrowserView({ t }: AdminRedisBrowserViewProps) {
               dryRun: false,
               cursor: "0",
             });
+            totals.batches += 1;
+            totals.scanned += result.scanned;
+            totals.deleted += result.deleted;
             appendMigrationLog(
               `${legacyPattern} delete batch ${batchNumber}: scanned ${result.scanned}, deleted ${result.deleted}${result.truncated ? ", more pending" : ""}`,
               result.deleted > 0 ? "success" : "info"
@@ -424,6 +438,12 @@ export function AdminRedisBrowserView({ t }: AdminRedisBrowserViewProps) {
             dryRun: kind === "dry-run",
             cursor,
           });
+          totals.batches += 1;
+          totals.scanned += result.scanned;
+          totals.planned += result.planned;
+          totals.copied += result.copied;
+          totals.skipped += result.skipped;
+          totals.warnings += result.warnings.length;
           appendMigrationLog(
             `${legacyPattern} ${kind === "dry-run" ? "dry-run" : "backfill"} batch ${batchNumber}: scanned ${result.scanned}, planned ${result.planned}, copied ${result.copied}, skipped ${result.skipped}, cursor ${result.cursor}`,
             result.warnings.length > 0 ? "warning" : result.copied > 0 ? "success" : "info"
@@ -438,11 +458,14 @@ export function AdminRedisBrowserView({ t }: AdminRedisBrowserViewProps) {
       if (migrationStopRequestedRef.current) {
         appendMigrationLog("Stopped by user request", "warning");
       } else {
-        appendMigrationLog(
-          `${kind === "delete" ? "Delete" : kind === "backfill" ? "Backfill" : "Dry run"} completed for all legacy patterns`,
-          "success"
-        );
+        appendMigrationLog(`${runLabel} completed for all legacy patterns`, "success");
       }
+      appendMigrationLog(
+        kind === "delete"
+          ? `${runLabel} totals: ${totals.batches} batches, ${totals.scanned} scanned, ${totals.deleted} deleted`
+          : `${runLabel} totals: ${totals.batches} batches, ${totals.scanned} scanned, ${totals.planned} planned, ${totals.copied} copied, ${totals.skipped} skipped, ${totals.warnings} warnings`,
+        migrationStopRequestedRef.current ? "warning" : "success"
+      );
       await handleLoadMigrationStatus(false);
       refreshScope();
     } catch (error) {

--- a/src/apps/admin/components/admin-app/AdminRedisBrowserView.tsx
+++ b/src/apps/admin/components/admin-app/AdminRedisBrowserView.tsx
@@ -420,6 +420,8 @@ export function AdminRedisBrowserView({ t }: AdminRedisBrowserViewProps) {
         let cursor = "0";
         let batchNumber = 0;
         let continuePattern = true;
+        let lastDeleteSignature: string | null = null;
+        let repeatedDeleteSignatureCount = 0;
         while (continuePattern && !migrationStopRequestedRef.current) {
           batchNumber += 1;
           if (kind === "delete") {
@@ -436,6 +438,22 @@ export function AdminRedisBrowserView({ t }: AdminRedisBrowserViewProps) {
               `pattern ${legacyPattern} delete batch ${batchNumber}: scanned ${result.scanned}, deleted ${result.deleted} (${formatDeletedKeySample(result.keys)})${result.truncated ? ", more pending" : ""}`,
               result.deleted > 0 ? "success" : "info"
             );
+            const deleteSignature = result.keys.join("\u001f");
+            if (result.deleted > 0 && deleteSignature) {
+              if (deleteSignature === lastDeleteSignature) {
+                repeatedDeleteSignatureCount += 1;
+              } else {
+                lastDeleteSignature = deleteSignature;
+                repeatedDeleteSignatureCount = 1;
+              }
+              if (repeatedDeleteSignatureCount >= 2) {
+                appendMigrationLog(
+                  `pattern ${legacyPattern} stopped after the same deleted batch reappeared (${formatDeletedKeySample(result.keys)}); a running service may be recreating it`,
+                  "warning"
+                );
+                continuePattern = false;
+              }
+            }
             if (result.scanned === 0 || result.deleted === 0) {
               continuePattern = false;
             }

--- a/src/apps/admin/utils/redisKeyTree.ts
+++ b/src/apps/admin/utils/redisKeyTree.ts
@@ -7,6 +7,8 @@
  * group keys by that separator and let the UI drill into one level at a time.
  */
 
+import { CANONICAL_REDIS_PREFIXES } from "../../../shared/redisKeys";
+
 export const REDIS_KEY_SEPARATOR = ":";
 
 /**
@@ -15,25 +17,7 @@ export const REDIS_KEY_SEPARATOR = ":";
  * scoped SCAN without first paging through a global `*` scan. Kept in sync with
  * the key builders across `api/` (chat/sync/analytics/memory/etc.).
  */
-export const KNOWN_REDIS_PREFIXES: string[] = [
-  "chat",
-  "sync",
-  "sync2",
-  "analytics",
-  "memory",
-  "system",
-  "airdrop",
-  "song",
-  "listen",
-  "applet",
-  "apple",
-  "ie",
-  "wayback",
-  "cursor-sdk-run",
-  "cursor-sdk-agent",
-  "ryos",
-  "rl",
-];
+export const KNOWN_REDIS_PREFIXES: string[] = [...CANONICAL_REDIS_PREFIXES];
 
 export interface RedisKeyNode {
   key: string;

--- a/src/shared/redisKeys.ts
+++ b/src/shared/redisKeys.ts
@@ -34,6 +34,11 @@ export type CanonicalRedisPrefix = (typeof CANONICAL_REDIS_PREFIXES)[number];
  */
 export const LEGACY_REDIS_SCAN_PATTERNS = [
   "airdrop:*",
+  "analytics:aiu:*",
+  "analytics:daily:*",
+  "analytics:ep:*",
+  "analytics:st:*",
+  "analytics:uv:*",
   "apple:*",
   "applet:*",
   "chat:irc:*",
@@ -50,6 +55,7 @@ export const LEGACY_REDIS_SCAN_PATTERNS = [
   "geoip:*",
   "ie:*",
   "listen:*",
+  "memory:user:*:processing_lock",
   "rl:*",
   "rt:*",
   "song:*",
@@ -159,6 +165,8 @@ export const redisKeys = {
       redisKey("rate", "block", feature, scope, identifierHash),
   },
   media: {
+    appletShare: (shareId: string) =>
+      redisKeyCaseSensitive("media", "applet", "share", shareId),
     songIds: () => redisKey("media", "song", "ids"),
     songMeta: (songId: string) =>
       redisKeyCaseSensitive("media", "song", songId, "meta"),

--- a/src/shared/redisKeys.ts
+++ b/src/shared/redisKeys.ts
@@ -1,0 +1,200 @@
+/**
+ * Canonical Redis key registry for the next key-scheme migration.
+ *
+ * This file intentionally does not change runtime storage behavior by itself.
+ * Stage-one migration work can import these builders for new code, tests, admin
+ * discovery, and backfill jobs before individual feature modules cut over.
+ */
+
+export const REDIS_KEY_SEPARATOR = ":";
+
+export const CANONICAL_REDIS_PREFIXES = [
+  "agent",
+  "analytics",
+  "auth",
+  "cache",
+  "chat",
+  "integration",
+  "media",
+  "memory",
+  "presence",
+  "rate",
+  "realtime",
+  "session",
+  "sync",
+  "system",
+] as const;
+
+export type CanonicalRedisPrefix = (typeof CANONICAL_REDIS_PREFIXES)[number];
+
+/**
+ * Legacy key patterns that must be empty before the final no-compatibility
+ * cutover. Patterns stay precise where a top-level prefix remains canonical
+ * (for example, `chat:*` becomes only selected legacy subtrees).
+ */
+export const LEGACY_REDIS_SCAN_PATTERNS = [
+  "airdrop:*",
+  "apple:*",
+  "applet:*",
+  "chat:irc:*",
+  "chat:messages:*",
+  "chat:password:*",
+  "chat:presence:*",
+  "chat:presencez:*",
+  "chat:room:*",
+  "chat:rooms",
+  "chat:token:*",
+  "chat:users:*",
+  "cursor-sdk-agent:*",
+  "cursor-sdk-run:*",
+  "geoip:*",
+  "ie:*",
+  "listen:*",
+  "rl:*",
+  "rt:*",
+  "song:*",
+  "sync:auto:*",
+  "sync:meta:*",
+  "sync:pref:*",
+  "sync:songs:*",
+  "sync:state:*",
+  "sync2:*",
+  "telegram:*",
+  "wayback:*",
+] as const;
+
+export type LegacyRedisScanPattern = (typeof LEGACY_REDIS_SCAN_PATTERNS)[number];
+
+export function normalizeRedisSegment(segment: string | number): string {
+  return encodeURIComponent(String(segment).trim().toLowerCase());
+}
+
+export function normalizeCaseSensitiveRedisSegment(segment: string | number): string {
+  return encodeURIComponent(String(segment).trim());
+}
+
+export function redisKey(
+  ...segments: Array<string | number | null | undefined>
+): string {
+  return segments
+    .filter((segment): segment is string | number => segment !== null && segment !== undefined && String(segment) !== "")
+    .map(normalizeRedisSegment)
+    .join(REDIS_KEY_SEPARATOR);
+}
+
+export function redisKeyCaseSensitive(
+  ...segments: Array<string | number | null | undefined>
+): string {
+  return segments
+    .filter((segment): segment is string | number => segment !== null && segment !== undefined && String(segment) !== "")
+    .map(normalizeCaseSensitiveRedisSegment)
+    .join(REDIS_KEY_SEPARATOR);
+}
+
+export async function sha256RedisIdentifier(value: string): Promise<string> {
+  const digest = await globalThis.crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(value)
+  );
+  return Array.from(new Uint8Array(digest), (byte) =>
+    byte.toString(16).padStart(2, "0")
+  ).join("");
+}
+
+export function redisKeysForHashedIdentifiers() {
+  return {
+    token: sha256RedisIdentifier,
+    ip: sha256RedisIdentifier,
+    url: sha256RedisIdentifier,
+  };
+}
+
+export const redisKeys = {
+  auth: {
+    userProfile: (username: string) => redisKey("auth", "user", username, "profile"),
+    userPassword: (username: string) => redisKey("auth", "user", username, "password"),
+    userSessions: (username: string) => redisKey("auth", "user", username, "sessions"),
+    session: (tokenHash: string) => redisKey("auth", "session", tokenHash),
+    lastSession: (username: string) => redisKey("auth", "user", username, "last-session"),
+  },
+  chat: {
+    roomIds: () => redisKey("chat", "rooms"),
+    roomMeta: (roomId: string) => redisKeyCaseSensitive("chat", "room", roomId, "meta"),
+    roomMessages: (roomId: string) => redisKeyCaseSensitive("chat", "room", roomId, "messages"),
+    roomPresence: (roomId: string) => redisKeyCaseSensitive("chat", "room", roomId, "presence"),
+    ircServer: (serverId: string) => redisKeyCaseSensitive("chat", "irc", "server", serverId),
+    ircServerIds: () => redisKey("chat", "irc", "servers"),
+  },
+  sync: {
+    v2Seq: (username: string) => redisKey("sync", "v2", "user", username, "seq"),
+    v2Kv: (username: string) => redisKey("sync", "v2", "user", username, "kv"),
+    v2Journal: (username: string) => redisKey("sync", "v2", "user", username, "journal"),
+    v2Blobs: (username: string) => redisKey("sync", "v2", "user", username, "blobs"),
+    v2Lock: (username: string) => redisKey("sync", "v2", "user", username, "lock"),
+    v2TtlTouched: (username: string) => redisKey("sync", "v2", "user", username, "ttl-touched"),
+    maintenanceCursor: () => redisKey("sync", "maintenance", "cursor"),
+    backupMeta: (username: string) => redisKey("sync", "backup", "user", username, "meta"),
+    autoSyncPreference: (username: string) => redisKey("sync", "preference", "user", username, "auto-sync"),
+  },
+  rate: {
+    counter: (feature: string, window: string, scope: string, identifierHash: string) =>
+      redisKey("rate", feature, window, scope, identifierHash),
+    block: (feature: string, scope: string, identifierHash: string) =>
+      redisKey("rate", "block", feature, scope, identifierHash),
+  },
+  media: {
+    songIds: () => redisKey("media", "song", "ids"),
+    songMeta: (songId: string) => redisKeyCaseSensitive("media", "song", songId, "meta"),
+    songContent: (songId: string) => redisKeyCaseSensitive("media", "song", songId, "content"),
+  },
+  cache: {
+    appleArtwork: (catalogId: string) => redisKey("cache", "apple-music", "artwork", catalogId),
+    geoip: (ipHash: string) => redisKey("cache", "geoip", ipHash),
+    ieVersions: (urlHash: string, year: string | number) => redisKey("cache", "ie", urlHash, year, "versions"),
+    wayback: (urlHash: string, year: string | number) => redisKey("cache", "wayback", urlHash, year),
+  },
+  analytics: {
+    apiMetric: (metric: string, date: string) => redisKey("analytics", "api", metric, date),
+    productMetric: (metric: string, date: string) => redisKey("analytics", "product", metric, date),
+  },
+  memory: {
+    index: (username: string) => redisKey("memory", "user", username, "index"),
+    detail: (username: string, key: string) => redisKey("memory", "user", username, "detail", key),
+    daily: (username: string, date: string) => redisKey("memory", "user", username, "daily", date),
+    processingLock: (username: string) => redisKey("memory", "user", username, "processing-lock"),
+  },
+  integration: {
+    telegramLinkCode: (code: string) => redisKeyCaseSensitive("integration", "telegram", "link", "code", code),
+    telegramPendingLink: (username: string) => redisKey("integration", "telegram", "link", "user", username),
+    telegramAccountByTelegramUser: (telegramUserId: string) =>
+      redisKey("integration", "telegram", "account", "telegram-user", telegramUserId),
+    telegramAccountByUsername: (username: string) =>
+      redisKey("integration", "telegram", "account", "user", username),
+    telegramHistory: (chatId: string) => redisKey("integration", "telegram", "history", chatId),
+    telegramUpdate: (updateId: string | number) => redisKey("integration", "telegram", "update", updateId),
+    telegramHeartbeat: (username: string, slot: string) =>
+      redisKey("integration", "telegram", "heartbeat", username, slot),
+  },
+  realtime: {
+    ticket: (ticketHash: string) => redisKey("realtime", "ticket", ticketHash),
+    pubsubChannel: () => redisKey("realtime", "pubsub"),
+  },
+  presence: {
+    globalOnline: () => redisKey("presence", "global", "online"),
+    airdropLobby: () => redisKey("presence", "airdrop", "lobby"),
+  },
+  session: {
+    listenIds: () => redisKey("session", "listen", "ids"),
+    listen: (sessionId: string) => redisKeyCaseSensitive("session", "listen", sessionId),
+    airdropTransfer: (transferId: string) => redisKeyCaseSensitive("session", "airdrop", "transfer", transferId),
+  },
+  agent: {
+    cursorRunEvents: (runId: string) => redisKeyCaseSensitive("agent", "cursor", "run", runId, "events"),
+    cursorRunMeta: (runId: string) => redisKeyCaseSensitive("agent", "cursor", "run", runId, "meta"),
+    cursorLatestRun: (agentId: string) => redisKeyCaseSensitive("agent", "cursor", "agent", agentId, "latest-run"),
+  },
+  system: {
+    userHeartbeats: (username: string, date: string) => redisKey("system", "user", username, "heartbeats", date),
+    migrationRun: (runId: string) => redisKeyCaseSensitive("system", "migration", "redis-key-scheme", runId),
+  },
+} as const;

--- a/src/shared/redisKeys.ts
+++ b/src/shared/redisKeys.ts
@@ -77,7 +77,10 @@ export function redisKey(
   ...segments: Array<string | number | null | undefined>
 ): string {
   return segments
-    .filter((segment): segment is string | number => segment !== null && segment !== undefined && String(segment) !== "")
+    .filter(
+      (segment): segment is string | number =>
+        segment !== null && segment !== undefined && String(segment).trim() !== ""
+    )
     .map(normalizeRedisSegment)
     .join(REDIS_KEY_SEPARATOR);
 }
@@ -86,7 +89,10 @@ export function redisKeyCaseSensitive(
   ...segments: Array<string | number | null | undefined>
 ): string {
   return segments
-    .filter((segment): segment is string | number => segment !== null && segment !== undefined && String(segment) !== "")
+    .filter(
+      (segment): segment is string | number =>
+        segment !== null && segment !== undefined && String(segment).trim() !== ""
+    )
     .map(normalizeCaseSensitiveRedisSegment)
     .join(REDIS_KEY_SEPARATOR);
 }
@@ -111,30 +117,40 @@ export function redisKeysForHashedIdentifiers() {
 
 export const redisKeys = {
   auth: {
-    userProfile: (username: string) => redisKey("auth", "user", username, "profile"),
-    userPassword: (username: string) => redisKey("auth", "user", username, "password"),
-    userSessions: (username: string) => redisKey("auth", "user", username, "sessions"),
+    userProfile: (username: string) =>
+      redisKey("auth", "user", username, "profile"),
+    userPassword: (username: string) =>
+      redisKey("auth", "user", username, "password"),
+    userSessions: (username: string) =>
+      redisKey("auth", "user", username, "sessions"),
     session: (tokenHash: string) => redisKey("auth", "session", tokenHash),
-    lastSession: (username: string) => redisKey("auth", "user", username, "last-session"),
+    lastSession: (username: string) =>
+      redisKey("auth", "user", username, "last-session"),
   },
   chat: {
-    roomIds: () => redisKey("chat", "rooms"),
-    roomMeta: (roomId: string) => redisKeyCaseSensitive("chat", "room", roomId, "meta"),
-    roomMessages: (roomId: string) => redisKeyCaseSensitive("chat", "room", roomId, "messages"),
-    roomPresence: (roomId: string) => redisKeyCaseSensitive("chat", "room", roomId, "presence"),
-    ircServer: (serverId: string) => redisKeyCaseSensitive("chat", "irc", "server", serverId),
-    ircServerIds: () => redisKey("chat", "irc", "servers"),
+    roomIds: () => redisKey("chat", "rooms", "ids"),
+    roomMeta: (roomId: string) =>
+      redisKeyCaseSensitive("chat", "rooms", roomId, "meta"),
+    roomMessages: (roomId: string) =>
+      redisKeyCaseSensitive("chat", "rooms", roomId, "messages"),
+    roomPresence: (roomId: string) =>
+      redisKeyCaseSensitive("chat", "rooms", roomId, "presence"),
   },
   sync: {
     v2Seq: (username: string) => redisKey("sync", "v2", "user", username, "seq"),
     v2Kv: (username: string) => redisKey("sync", "v2", "user", username, "kv"),
-    v2Journal: (username: string) => redisKey("sync", "v2", "user", username, "journal"),
-    v2Blobs: (username: string) => redisKey("sync", "v2", "user", username, "blobs"),
+    v2Journal: (username: string) =>
+      redisKey("sync", "v2", "user", username, "journal"),
+    v2Blobs: (username: string) =>
+      redisKey("sync", "v2", "user", username, "blobs"),
     v2Lock: (username: string) => redisKey("sync", "v2", "user", username, "lock"),
-    v2TtlTouched: (username: string) => redisKey("sync", "v2", "user", username, "ttl-touched"),
+    v2TtlTouched: (username: string) =>
+      redisKey("sync", "v2", "user", username, "ttl-touched"),
     maintenanceCursor: () => redisKey("sync", "maintenance", "cursor"),
-    backupMeta: (username: string) => redisKey("sync", "backup", "user", username, "meta"),
-    autoSyncPreference: (username: string) => redisKey("sync", "preference", "user", username, "auto-sync"),
+    backupMeta: (username: string) =>
+      redisKey("sync", "backup", "user", username, "meta"),
+    autoSyncPreference: (username: string) =>
+      redisKey("sync", "preference", "user", username, "auto-sync"),
   },
   rate: {
     counter: (feature: string, window: string, scope: string, identifierHash: string) =>
@@ -144,34 +160,51 @@ export const redisKeys = {
   },
   media: {
     songIds: () => redisKey("media", "song", "ids"),
-    songMeta: (songId: string) => redisKeyCaseSensitive("media", "song", songId, "meta"),
-    songContent: (songId: string) => redisKeyCaseSensitive("media", "song", songId, "content"),
+    songMeta: (songId: string) =>
+      redisKeyCaseSensitive("media", "song", songId, "meta"),
+    songContent: (songId: string) =>
+      redisKeyCaseSensitive("media", "song", songId, "content"),
   },
   cache: {
-    appleArtwork: (catalogId: string) => redisKey("cache", "apple-music", "artwork", catalogId),
+    appleArtwork: (catalogId: string) =>
+      redisKey("cache", "apple-music", "artwork", catalogId),
     geoip: (ipHash: string) => redisKey("cache", "geoip", ipHash),
-    ieVersions: (urlHash: string, year: string | number) => redisKey("cache", "ie", urlHash, year, "versions"),
-    wayback: (urlHash: string, year: string | number) => redisKey("cache", "wayback", urlHash, year),
+    ieVersions: (urlHash: string, year: string | number) =>
+      redisKey("cache", "ie", urlHash, year, "versions"),
+    wayback: (urlHash: string, year: string | number) =>
+      redisKey("cache", "wayback", urlHash, year),
   },
   analytics: {
-    apiMetric: (metric: string, date: string) => redisKey("analytics", "api", metric, date),
-    productMetric: (metric: string, date: string) => redisKey("analytics", "product", metric, date),
+    apiMetric: (metric: string, date: string) =>
+      redisKey("analytics", "api", metric, date),
+    productMetric: (metric: string, date: string) =>
+      redisKey("analytics", "product", metric, date),
   },
   memory: {
     index: (username: string) => redisKey("memory", "user", username, "index"),
-    detail: (username: string, key: string) => redisKey("memory", "user", username, "detail", key),
-    daily: (username: string, date: string) => redisKey("memory", "user", username, "daily", date),
-    processingLock: (username: string) => redisKey("memory", "user", username, "processing-lock"),
+    detail: (username: string, key: string) =>
+      redisKey("memory", "user", username, "detail", key),
+    daily: (username: string, date: string) =>
+      redisKey("memory", "user", username, "daily", date),
+    processingLock: (username: string) =>
+      redisKey("memory", "user", username, "processing-lock"),
   },
   integration: {
-    telegramLinkCode: (code: string) => redisKeyCaseSensitive("integration", "telegram", "link", "code", code),
-    telegramPendingLink: (username: string) => redisKey("integration", "telegram", "link", "user", username),
+    ircServer: (serverId: string) =>
+      redisKeyCaseSensitive("integration", "irc", "server", serverId),
+    ircServerIds: () => redisKey("integration", "irc", "servers"),
+    telegramLinkCode: (code: string) =>
+      redisKeyCaseSensitive("integration", "telegram", "link", "code", code),
+    telegramPendingLink: (username: string) =>
+      redisKey("integration", "telegram", "link", "user", username),
     telegramAccountByTelegramUser: (telegramUserId: string) =>
       redisKey("integration", "telegram", "account", "telegram-user", telegramUserId),
     telegramAccountByUsername: (username: string) =>
       redisKey("integration", "telegram", "account", "user", username),
-    telegramHistory: (chatId: string) => redisKey("integration", "telegram", "history", chatId),
-    telegramUpdate: (updateId: string | number) => redisKey("integration", "telegram", "update", updateId),
+    telegramHistory: (chatId: string) =>
+      redisKey("integration", "telegram", "history", chatId),
+    telegramUpdate: (updateId: string | number) =>
+      redisKey("integration", "telegram", "update", updateId),
     telegramHeartbeat: (username: string, slot: string) =>
       redisKey("integration", "telegram", "heartbeat", username, slot),
   },
@@ -185,16 +218,23 @@ export const redisKeys = {
   },
   session: {
     listenIds: () => redisKey("session", "listen", "ids"),
-    listen: (sessionId: string) => redisKeyCaseSensitive("session", "listen", sessionId),
-    airdropTransfer: (transferId: string) => redisKeyCaseSensitive("session", "airdrop", "transfer", transferId),
+    listen: (sessionId: string) =>
+      redisKeyCaseSensitive("session", "listen", sessionId),
+    airdropTransfer: (transferId: string) =>
+      redisKeyCaseSensitive("session", "airdrop", "transfer", transferId),
   },
   agent: {
-    cursorRunEvents: (runId: string) => redisKeyCaseSensitive("agent", "cursor", "run", runId, "events"),
-    cursorRunMeta: (runId: string) => redisKeyCaseSensitive("agent", "cursor", "run", runId, "meta"),
-    cursorLatestRun: (agentId: string) => redisKeyCaseSensitive("agent", "cursor", "agent", agentId, "latest-run"),
+    cursorRunEvents: (runId: string) =>
+      redisKeyCaseSensitive("agent", "cursor", "run", runId, "events"),
+    cursorRunMeta: (runId: string) =>
+      redisKeyCaseSensitive("agent", "cursor", "run", runId, "meta"),
+    cursorLatestRun: (agentId: string) =>
+      redisKeyCaseSensitive("agent", "cursor", "agent", agentId, "latest-run"),
   },
   system: {
-    userHeartbeats: (username: string, date: string) => redisKey("system", "user", username, "heartbeats", date),
-    migrationRun: (runId: string) => redisKeyCaseSensitive("system", "migration", "redis-key-scheme", runId),
+    userHeartbeats: (username: string, date: string) =>
+      redisKey("system", "user", username, "heartbeats", date),
+    migrationRun: (runId: string) =>
+      redisKeyCaseSensitive("system", "migration", "redis-key-scheme", runId),
   },
 } as const;

--- a/src/shared/redisKeys.ts
+++ b/src/shared/redisKeys.ts
@@ -58,6 +58,7 @@ export const LEGACY_REDIS_SCAN_PATTERNS = [
   "memory:user:*:processing_lock",
   "rl:*",
   "rt:*",
+  "ryos:presence:*",
   "song:*",
   "sync:auto:*",
   "sync:meta:*",

--- a/src/shared/redisKeys.ts
+++ b/src/shared/redisKeys.ts
@@ -103,6 +103,13 @@ export function redisKeyCaseSensitive(
     .join(REDIS_KEY_SEPARATOR);
 }
 
+function songKey(songId: string, facet: "meta" | "content"): string {
+  if (songId.startsWith("am:")) {
+    return redisKeyCaseSensitive("media", "song", "am", songId.slice(3), facet);
+  }
+  return redisKeyCaseSensitive("media", "song", songId, facet);
+}
+
 export async function sha256RedisIdentifier(value: string): Promise<string> {
   const digest = await globalThis.crypto.subtle.digest(
     "SHA-256",
@@ -168,10 +175,8 @@ export const redisKeys = {
     appletShare: (shareId: string) =>
       redisKeyCaseSensitive("media", "applet", "share", shareId),
     songIds: () => redisKey("media", "song", "ids"),
-    songMeta: (songId: string) =>
-      redisKeyCaseSensitive("media", "song", songId, "meta"),
-    songContent: (songId: string) =>
-      redisKeyCaseSensitive("media", "song", songId, "content"),
+    songMeta: (songId: string) => songKey(songId, "meta"),
+    songContent: (songId: string) => songKey(songId, "content"),
   },
   cache: {
     appleArtwork: (catalogId: string) =>

--- a/tests/fake-redis.ts
+++ b/tests/fake-redis.ts
@@ -25,6 +25,11 @@ export class FakeRedisPipeline {
     return this;
   }
 
+  get(key: string): this {
+    this.operations.push(() => this.redis.getSync(key));
+    return this;
+  }
+
   del(...keys: string[]): this {
     this.operations.push(() => this.redis.delSync(...keys));
     return this;
@@ -42,6 +47,11 @@ export class FakeRedisPipeline {
 
   pfadd(key: string, ...elements: string[]): this {
     this.operations.push(() => this.redis.pfaddSync(key, ...elements));
+    return this;
+  }
+
+  pfcount(...keys: string[]): this {
+    this.operations.push(() => this.redis.pfcountSync(...keys));
     return this;
   }
 
@@ -112,6 +122,10 @@ export class FakeRedis {
     return "OK";
   }
 
+  getSync<T = unknown>(key: string): T | null {
+    return (this.kv.get(key) as T | undefined) ?? null;
+  }
+
   delSync(...keys: string[]): number {
     let deleted = 0;
     for (const key of keys) {
@@ -162,7 +176,7 @@ export class FakeRedis {
   // --- async API ------------------------------------------------------------
 
   async get<T = unknown>(key: string): Promise<T | null> {
-    return (this.kv.get(key) as T | undefined) ?? null;
+    return this.getSync<T>(key);
   }
 
   async set(
@@ -316,6 +330,10 @@ export class FakeRedis {
   }
 
   async pfcount(...keys: string[]): Promise<number> {
+    return this.pfcountSync(...keys);
+  }
+
+  pfcountSync(...keys: string[]): number {
     const unique = new Set<string>();
     for (const key of keys) {
       for (const member of this.sets.get(key) || []) {

--- a/tests/fake-redis.ts
+++ b/tests/fake-redis.ts
@@ -40,8 +40,18 @@ export class FakeRedisPipeline {
     return this;
   }
 
+  pfadd(key: string, ...elements: string[]): this {
+    this.operations.push(() => this.redis.pfaddSync(key, ...elements));
+    return this;
+  }
+
   srem(key: string, ...members: string[]): this {
     this.operations.push(() => this.redis.sremSync(key, ...members));
+    return this;
+  }
+
+  hincrby(key: string, field: string, increment: number): this {
+    this.operations.push(() => this.redis.hincrbySync(key, field, increment));
     return this;
   }
 
@@ -126,6 +136,10 @@ export class FakeRedis {
     }
     this.sets.set(key, set);
     return added;
+  }
+
+  pfaddSync(key: string, ...elements: string[]): number {
+    return this.saddSync(key, ...elements);
   }
 
   sremSync(key: string, ...members: string[]): number {
@@ -285,11 +299,29 @@ export class FakeRedis {
   }
 
   async hincrby(key: string, field: string, increment: number): Promise<number> {
+    return this.hincrbySync(key, field, increment);
+  }
+
+  hincrbySync(key: string, field: string, increment: number): number {
     const hash = this.hashes.get(key) || new Map<string, string>();
     const next = (Number.parseInt(hash.get(field) || "0", 10) || 0) + increment;
     hash.set(field, String(next));
     this.hashes.set(key, hash);
     return next;
+  }
+
+  async pfadd(key: string, ...elements: string[]): Promise<number> {
+    return this.pfaddSync(key, ...elements);
+  }
+
+  async pfcount(...keys: string[]): Promise<number> {
+    const unique = new Set<string>();
+    for (const key of keys) {
+      for (const member of this.sets.get(key) || []) {
+        unique.add(member);
+      }
+    }
+    return unique.size;
   }
 
   async rpush(key: string, ...values: string[]): Promise<number> {

--- a/tests/fake-redis.ts
+++ b/tests/fake-redis.ts
@@ -187,7 +187,8 @@ export class FakeRedis {
         this.kv.has(key) ||
         this.sets.has(key) ||
         this.hashes.has(key) ||
-        this.lists.has(key)
+        this.lists.has(key) ||
+        this.zsets.has(key)
     )
       ? 1
       : 0;

--- a/tests/fake-redis.ts
+++ b/tests/fake-redis.ts
@@ -366,6 +366,21 @@ export class FakeRedis {
     return ordered.slice(normalizedStart, normalizedStop + 1);
   }
 
+  async zrangeWithScores(
+    key: string,
+    start: number,
+    stop: number
+  ): Promise<Array<{ member: string; score: number }>> {
+    const ordered = this.zsorted(key);
+    const normalizedStart = start < 0 ? Math.max(0, ordered.length + start) : start;
+    const normalizedStop = stop < 0 ? ordered.length + stop : stop;
+    const scores = this.zsets.get(key) || new Map<string, number>();
+    return ordered.slice(normalizedStart, normalizedStop + 1).map((member) => ({
+      member,
+      score: scores.get(member) ?? 0,
+    }));
+  }
+
   async zremrangebyscore(
     key: string,
     min: number | string,

--- a/tests/fake-redis.ts
+++ b/tests/fake-redis.ts
@@ -358,6 +358,35 @@ export class FakeRedis {
     return (this.lists.get(key) || []).length;
   }
 
+  async lrem(key: string, count: number, value: string): Promise<number> {
+    const list = this.lists.get(key) || [];
+    if (list.length === 0 || count === 0) return 0;
+    let removed = 0;
+    const shouldRemove = (item: string) => item === value;
+    if (count > 0) {
+      const next: string[] = [];
+      for (const item of list) {
+        if (removed < count && shouldRemove(item)) {
+          removed += 1;
+          continue;
+        }
+        next.push(item);
+      }
+      this.lists.set(key, next);
+      return removed;
+    }
+
+    const next = [...list];
+    for (let index = next.length - 1; index >= 0 && removed < Math.abs(count); index -= 1) {
+      if (shouldRemove(next[index])) {
+        next.splice(index, 1);
+        removed += 1;
+      }
+    }
+    this.lists.set(key, next);
+    return removed;
+  }
+
   // --- sorted sets ----------------------------------------------------------
 
   /** Members ordered by score ascending, ties broken lexicographically. */

--- a/tests/test-admin.test.ts
+++ b/tests/test-admin.test.ts
@@ -314,6 +314,80 @@ describe("admin", () => {
       expect(data.error).toContain("Confirmation");
     });
 
+    test("GET getRedisKeyMigrationStatus - with admin token", async () => {
+      if (!adminToken) {
+        console.log("  ⚠️  Skipped (no admin token available)");
+        return;
+      }
+
+      const res = await fetchWithAuth(
+        `${BASE_URL}/api/admin?action=getRedisKeyMigrationStatus&limit=5`,
+        ADMIN_USERNAME,
+        adminToken,
+        { method: "GET" }
+      );
+
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(typeof data.totalLegacyKeys).toBe("number");
+      expect(Array.isArray(data.patterns)).toBe(true);
+      expect(data.patterns.some((item: { pattern: string }) => item.pattern === "chat:users:*")).toBe(true);
+    });
+
+    test("POST backfillRedisKeyScheme - requires exact pattern confirmation", async () => {
+      if (!adminToken) {
+        console.log("  ⚠️  Skipped (no admin token available)");
+        return;
+      }
+
+      const res = await fetchWithAuth(
+        `${BASE_URL}/api/admin`,
+        ADMIN_USERNAME,
+        adminToken,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            action: "backfillRedisKeyScheme",
+            pattern: "chat:users:*",
+            confirmPattern: "wrong-pattern",
+            dryRun: true,
+          }),
+        }
+      );
+
+      expect(res.status).toBe(400);
+      const data = await res.json();
+      expect(data.error).toContain("Confirmation");
+    });
+
+    test("POST deleteLegacyRedisKeys - requires exact pattern confirmation", async () => {
+      if (!adminToken) {
+        console.log("  ⚠️  Skipped (no admin token available)");
+        return;
+      }
+
+      const res = await fetchWithAuth(
+        `${BASE_URL}/api/admin`,
+        ADMIN_USERNAME,
+        adminToken,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            action: "deleteLegacyRedisKeys",
+            pattern: "chat:users:*",
+            confirmPattern: "wrong-pattern",
+            dryRun: true,
+          }),
+        }
+      );
+
+      expect(res.status).toBe(400);
+      const data = await res.json();
+      expect(data.error).toContain("Confirmation");
+    });
+
     test("POST deleteUser - missing target username", async () => {
       if (!adminToken) {
         console.log("  ⚠️  Skipped (no admin token available)");

--- a/tests/test-analytics-keys.test.ts
+++ b/tests/test-analytics-keys.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test } from "bun:test";
 import type { Redis } from "../api/_utils/redis";
-import { recordAnalyticsEvent } from "../api/_utils/_analytics";
+import {
+  getAnalyticsDetail,
+  getAnalyticsSummary,
+  recordAnalyticsEvent,
+} from "../api/_utils/_analytics";
 import { FakeRedis } from "./fake-redis";
 
 describe("analytics Redis keys", () => {
@@ -26,5 +30,69 @@ describe("analytics Redis keys", () => {
     });
     expect(await redis.hgetall(`analytics:daily:${today}`)).toBeNull();
     expect(fake.allKeys().some((key) => key.startsWith("analytics:daily:"))).toBe(false);
+  });
+
+  test("reads legacy API analytics when canonical counters are absent", async () => {
+    const fake = new FakeRedis();
+    const redis = fake as unknown as Redis;
+    const today = new Date().toISOString().slice(0, 10);
+
+    await redis.hset(`analytics:daily:${today}`, {
+      calls: "3",
+      ai: "2",
+      errors: "1",
+      latsum: "90",
+      latcnt: "3",
+    });
+    await redis.pfadd(`analytics:uv:${today}`, "ip:203.0.113.10");
+    await redis.hset(`analytics:ep:${today}`, { "/api/chat": "2" });
+    await redis.hset(`analytics:st:${today}`, { "200": "2", "500": "1" });
+    await redis.hset(`analytics:aiu:${today}`, { ryo: "2" });
+
+    const summary = await getAnalyticsSummary(redis, 1);
+    expect(summary.totals).toMatchObject({
+      calls: 3,
+      ai: 2,
+      errors: 1,
+      uniqueVisitors: 1,
+      avgLatencyMs: 30,
+    });
+
+    const detail = await getAnalyticsDetail(redis, 1);
+    expect(detail.topEndpoints).toEqual([{ endpoint: "/api/chat", count: 2 }]);
+    expect(detail.statusCodes).toEqual([
+      { status: "200", count: 2 },
+      { status: "500", count: 1 },
+    ]);
+    expect(detail.aiByUser).toEqual([{ username: "ryo", count: 2 }]);
+  });
+
+  test("prefers canonical analytics hashes over legacy hashes", async () => {
+    const fake = new FakeRedis();
+    const redis = fake as unknown as Redis;
+    const today = new Date().toISOString().slice(0, 10);
+
+    await redis.hset(`analytics:daily:${today}`, {
+      calls: "100",
+      ai: "100",
+      errors: "100",
+      latsum: "100",
+      latcnt: "1",
+    });
+    await redis.hset(`analytics:api:daily:${today}`, {
+      calls: "4",
+      ai: "1",
+      errors: "0",
+      latsum: "80",
+      latcnt: "4",
+    });
+
+    const summary = await getAnalyticsSummary(redis, 1);
+    expect(summary.totals).toMatchObject({
+      calls: 4,
+      ai: 1,
+      errors: 0,
+      avgLatencyMs: 20,
+    });
   });
 });

--- a/tests/test-analytics-keys.test.ts
+++ b/tests/test-analytics-keys.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "bun:test";
+import type { Redis } from "../api/_utils/redis";
+import { recordAnalyticsEvent } from "../api/_utils/_analytics";
+import { FakeRedis } from "./fake-redis";
+
+describe("analytics Redis keys", () => {
+  test("records API analytics into canonical keys only", async () => {
+    const fake = new FakeRedis();
+    const redis = fake as unknown as Redis;
+    const today = new Date().toISOString().slice(0, 10);
+
+    recordAnalyticsEvent(redis, {
+      path: "/api/chat",
+      method: "POST",
+      status: 200,
+      latencyMs: 42,
+      ip: "203.0.113.10",
+      username: "ryo",
+    });
+
+    expect(await redis.hgetall(`analytics:api:daily:${today}`)).toMatchObject({
+      calls: "1",
+      ai: "1",
+      latsum: "42",
+      latcnt: "1",
+    });
+    expect(await redis.hgetall(`analytics:daily:${today}`)).toBeNull();
+    expect(fake.allKeys().some((key) => key.startsWith("analytics:daily:"))).toBe(false);
+  });
+});

--- a/tests/test-auth-canonical-session.test.ts
+++ b/tests/test-auth-canonical-session.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from "bun:test";
+import type { Redis } from "../api/_utils/redis";
+import { validateAuth } from "../api/_utils/auth/_validate";
+import {
+  getUserPasswordHash,
+  setUserPasswordHash,
+} from "../api/_utils/auth/_password-storage";
+import { getUserTokenKey, storeToken } from "../api/_utils/auth/_tokens";
+import {
+  getLegacyStoredUserKey,
+  getStoredUserRecord,
+  setStoredUserRecord,
+} from "../api/_utils/auth/_user-record";
+import { redisKeys, sha256RedisIdentifier } from "../src/shared/redisKeys";
+import { FakeRedis } from "./fake-redis";
+
+describe("canonical auth sessions", () => {
+  test("validates after legacy chat token key is gone", async () => {
+    const fake = new FakeRedis();
+    const redis = fake as unknown as Redis;
+    const username = "ryo";
+    const token = "secret-token";
+
+    await storeToken(redis, username, token);
+    await redis.del(getUserTokenKey(username, token));
+
+    const tokenHash = await sha256RedisIdentifier(token);
+    expect(await redis.exists(redisKeys.auth.session(tokenHash))).toBe(1);
+    expect(await validateAuth(redis, username, token)).toEqual({
+      valid: true,
+      expired: false,
+    });
+  });
+
+  test("reads canonical user profile and password after legacy auth keys are gone", async () => {
+    const fake = new FakeRedis();
+    const redis = fake as unknown as Redis;
+
+    await setStoredUserRecord(redis, "ryo", {
+      username: "ryo",
+      createdAt: 1,
+      lastActive: 2,
+    });
+    await setUserPasswordHash(redis, "ryo", "hashed-password");
+    await redis.del(getLegacyStoredUserKey("ryo"), "chat:password:ryo");
+
+    expect(await getStoredUserRecord(redis, "ryo")).toMatchObject({
+      username: "ryo",
+      lastActive: 2,
+    });
+    expect(await getUserPasswordHash(redis, "ryo")).toBe("hashed-password");
+    expect(await redis.get(redisKeys.auth.userProfile("ryo"))).not.toBeNull();
+    expect(await redis.get(redisKeys.auth.userPassword("ryo"))).toBe("hashed-password");
+  });
+});

--- a/tests/test-chat-broadcast-wiring.test.ts
+++ b/tests/test-chat-broadcast-wiring.test.ts
@@ -67,8 +67,7 @@ describe("Chat Broadcast Wiring Tests", () => {
 
     test("room delete route removes room from registry and presence", async () => {
       const source = readRoute("api/rooms/[id].ts");
-      expect(source.includes("CHAT_ROOMS_SET")).toBe(true);
-      expect(/srem\s*\(\s*CHAT_ROOMS_SET/.test(source)).toBe(true);
+      assertHasCall(source, "unregisterRoom");
       assertHasCall(source, "deleteRoomPresence");
     });
 
@@ -80,8 +79,7 @@ describe("Chat Broadcast Wiring Tests", () => {
 
     test("leave route removes deleted private room from registry", async () => {
       const source = readRoute("api/rooms/[id]/leave.ts");
-      expect(source.includes("CHAT_ROOMS_SET")).toBe(true);
-      expect(/srem\s*\(\s*CHAT_ROOMS_SET/.test(source)).toBe(true);
+      assertHasCall(source, "unregisterRoom");
     });
 
     test("leave route clears room presence for deleted private room", async () => {

--- a/tests/test-chat-message-canonical-cutover.test.ts
+++ b/tests/test-chat-message-canonical-cutover.test.ts
@@ -1,0 +1,56 @@
+import { beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import { redisKeys } from "../src/shared/redisKeys";
+import { FakeRedis } from "./fake-redis";
+
+let fake: FakeRedis;
+
+mock.module("../api/_utils/redis.js", () => ({
+  createRedis: () => fake,
+}));
+
+let chatRedis: typeof import("../api/rooms/_helpers/_redis");
+
+beforeAll(async () => {
+  chatRedis = await import("../api/rooms/_helpers/_redis");
+});
+
+beforeEach(() => {
+  fake = new FakeRedis();
+});
+
+describe("chat message canonical cutover", () => {
+  test("writes canonical messages only while reading and deleting legacy backlog", async () => {
+    const roomId = "room-1";
+    const canonicalKey = redisKeys.chat.roomMessages(roomId);
+    const legacyKey = `chat:messages:${roomId}`;
+    const legacyMessage = {
+      id: "legacy-message",
+      roomId,
+      username: "ryo",
+      content: "old",
+      timestamp: 1,
+    };
+    const canonicalMessage = {
+      id: "canonical-message",
+      roomId,
+      username: "ryo",
+      content: "new",
+      timestamp: 2,
+    };
+
+    await fake.lpush(legacyKey, JSON.stringify(legacyMessage));
+    await chatRedis.addMessage(roomId, canonicalMessage);
+
+    expect(await fake.llen(canonicalKey)).toBe(1);
+    expect(await fake.llen(legacyKey)).toBe(1);
+    expect((await chatRedis.getMessages(roomId, 10)).map((message) => message.id)).toEqual([
+      "canonical-message",
+      "legacy-message",
+    ]);
+    expect((await chatRedis.getLastMessage(roomId))?.id).toBe("canonical-message");
+
+    expect(await chatRedis.deleteMessage(roomId, "legacy-message")).toBe(true);
+    expect(await fake.llen(legacyKey)).toBe(0);
+    expect(await fake.llen(canonicalKey)).toBe(1);
+  });
+});

--- a/tests/test-chat-message-canonical-cutover.test.ts
+++ b/tests/test-chat-message-canonical-cutover.test.ts
@@ -4,8 +4,22 @@ import { FakeRedis } from "./fake-redis";
 
 let fake: FakeRedis;
 
-mock.module("../api/_utils/redis.js", () => ({
-  createRedis: () => fake,
+mock.module("../api/_utils/redis-helpers.js", () => ({
+  createRedisClient: () => fake,
+  generateRandomHexId: (byteLength: number) => "a".repeat(byteLength * 2),
+  getCurrentTimestamp: () => 1_718_180_000_000,
+  parseJSON: <T>(data: unknown): T | null => {
+    if (!data) return null;
+    if (typeof data === "object") return data as T;
+    if (typeof data === "string") {
+      try {
+        return JSON.parse(data) as T;
+      } catch {
+        return null;
+      }
+    }
+    return null;
+  },
 }));
 
 let chatRedis: typeof import("../api/rooms/_helpers/_redis");

--- a/tests/test-redis-key-migration.test.ts
+++ b/tests/test-redis-key-migration.test.ts
@@ -23,6 +23,14 @@ describe("Redis key scheme migration helpers", () => {
       targetKey: "media:song:am:123:meta",
       action: "copy",
     });
+    await expect(planRedisKeyMigration("airdrop:presence")).resolves.toMatchObject({
+      targetKey: "presence:airdrop:lobby",
+      action: "copy",
+    });
+    await expect(planRedisKeyMigration("ryos:presence:online")).resolves.toMatchObject({
+      targetKey: "presence:global:online",
+      action: "copy",
+    });
     await expect(planRedisKeyMigration("rl:ai:anon:127.0.0.1")).resolves.toMatchObject({
       targetKey: null,
       action: "skip",

--- a/tests/test-redis-key-migration.test.ts
+++ b/tests/test-redis-key-migration.test.ts
@@ -87,6 +87,39 @@ describe("Redis key scheme migration helpers", () => {
     expect(await redis.get(redisKeys.media.songMeta("abc"))).toBeNull();
   });
 
+  test("backfill returns cursors so the UI can continue through all batches", async () => {
+    const fake = new FakeRedis();
+    const redis = fake as unknown as Redis;
+    fake.setSync("chat:users:alice", JSON.stringify({ username: "alice" }));
+    fake.setSync("chat:users:bob", JSON.stringify({ username: "bob" }));
+
+    const first = await backfillRedisKeyScheme(redis, {
+      pattern: "chat:users:*",
+      limit: 1,
+      dryRun: false,
+      cursor: "0",
+    });
+    expect(first.scanned).toBe(1);
+    expect(first.cursor).not.toBe("0");
+
+    let cursor = first.cursor;
+    let scanned = first.scanned;
+    for (let i = 0; i < 10 && cursor !== "0"; i += 1) {
+      const next = await backfillRedisKeyScheme(redis, {
+        pattern: "chat:users:*",
+        limit: 1,
+        dryRun: false,
+        cursor,
+      });
+      scanned += next.scanned;
+      cursor = next.cursor;
+    }
+    expect(cursor).toBe("0");
+    expect(scanned).toBeGreaterThanOrEqual(2);
+    expect(await redis.get(redisKeys.auth.userProfile("alice"))).not.toBeNull();
+    expect(await redis.get(redisKeys.auth.userProfile("bob"))).not.toBeNull();
+  });
+
   test("reports legacy status and deletes legacy batches only when not dry-run", async () => {
     const fake = new FakeRedis();
     const redis = fake as unknown as Redis;

--- a/tests/test-redis-key-migration.test.ts
+++ b/tests/test-redis-key-migration.test.ts
@@ -153,6 +153,49 @@ describe("Redis key scheme migration helpers", () => {
     expect(Object.keys(kv || {})).toContain("settings/display");
   });
 
+  test("backfills sync2 journals as zsets while preserving scores", async () => {
+    const fake = new FakeRedis();
+    const redis = fake as unknown as Redis;
+    await fake.zadd("sync2:jrnl:ryo", { score: 2, member: JSON.stringify({ seq: 2 }) });
+    await fake.zadd("sync2:jrnl:ryo", { score: 1, member: JSON.stringify({ seq: 1 }) });
+
+    const result = await backfillRedisKeyScheme(redis, {
+      pattern: "sync2:*",
+      limit: 10,
+      dryRun: false,
+    });
+
+    expect(result.scanned).toBe(1);
+    expect(result.copied).toBe(1);
+    expect(result.warnings).toEqual([]);
+    expect(await fake.zrangeWithScores(redisKeys.sync.v2Journal("ryo"), 0, -1)).toEqual([
+      { score: 1, member: JSON.stringify({ seq: 1 }) },
+      { score: 2, member: JSON.stringify({ seq: 2 }) },
+    ]);
+  });
+
+  test("treats abandoned sync2 log keys as a silent backfill skip", async () => {
+    const fake = new FakeRedis();
+    const redis = fake as unknown as Redis;
+    await fake.rpush("sync2:log:ryo", JSON.stringify({ seq: 1 }));
+
+    await expect(planRedisKeyMigration("sync2:log:ryo")).resolves.toMatchObject({
+      targetKey: null,
+      action: "skip",
+    });
+
+    const result = await backfillRedisKeyScheme(redis, {
+      pattern: "sync2:*",
+      limit: 10,
+      dryRun: false,
+    });
+
+    expect(result.scanned).toBe(1);
+    expect(result.copied).toBe(0);
+    expect(result.skipped).toBe(1);
+    expect(result.warnings).toEqual([]);
+  });
+
   test("reports legacy status and deletes legacy batches only when not dry-run", async () => {
     const fake = new FakeRedis();
     const redis = fake as unknown as Redis;

--- a/tests/test-redis-key-migration.test.ts
+++ b/tests/test-redis-key-migration.test.ts
@@ -148,8 +148,8 @@ describe("Redis key scheme migration helpers", () => {
     expect(result.planned).toBe(1);
     expect(result.copied).toBe(1);
     expect(result.warnings).toEqual([]);
-    expect(await redis.get("sync2:seq:alice")).toBe("0");
-    const kv = await redis.hgetall("sync2:kv:alice");
+    expect(await redis.get(redisKeys.sync.v2Seq("alice"))).toBe("0");
+    const kv = await redis.hgetall(redisKeys.sync.v2Kv("alice"));
     expect(Object.keys(kv || {})).toContain("settings/display");
   });
 

--- a/tests/test-redis-key-migration.test.ts
+++ b/tests/test-redis-key-migration.test.ts
@@ -20,7 +20,7 @@ describe("Redis key scheme migration helpers", () => {
       action: "copy",
     });
     await expect(planRedisKeyMigration("song:meta:am:123")).resolves.toMatchObject({
-      targetKey: "media:song:am%3A123:meta",
+      targetKey: "media:song:am:123:meta",
       action: "copy",
     });
     await expect(planRedisKeyMigration("rl:ai:anon:127.0.0.1")).resolves.toMatchObject({

--- a/tests/test-redis-key-migration.test.ts
+++ b/tests/test-redis-key-migration.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, test } from "bun:test";
+import type { Redis } from "../api/_utils/redis";
+import {
+  backfillRedisKeyScheme,
+  deleteLegacyRedisKeys,
+  getRedisMigrationStatus,
+  planRedisKeyMigration,
+} from "../api/_utils/redis-key-migration";
+import { redisKeys, sha256RedisIdentifier } from "../src/shared/redisKeys";
+import { FakeRedis } from "./fake-redis";
+
+describe("Redis key scheme migration helpers", () => {
+  test("maps representative legacy keys to canonical targets", async () => {
+    await expect(planRedisKeyMigration("chat:users:Alice")).resolves.toMatchObject({
+      targetKey: "auth:user:alice:profile",
+      action: "copy",
+    });
+    await expect(planRedisKeyMigration("chat:messages:RoomABC")).resolves.toMatchObject({
+      targetKey: "chat:rooms:RoomABC:messages",
+      action: "copy",
+    });
+    await expect(planRedisKeyMigration("song:meta:am:123")).resolves.toMatchObject({
+      targetKey: "media:song:am%3A123:meta",
+      action: "copy",
+    });
+    await expect(planRedisKeyMigration("rl:ai:anon:127.0.0.1")).resolves.toMatchObject({
+      targetKey: null,
+      action: "skip",
+    });
+  });
+
+  test("backfills strings and preserves TTLs without deleting legacy keys", async () => {
+    const fake = new FakeRedis();
+    const redis = fake as unknown as Redis;
+    fake.setSync("chat:users:alice", JSON.stringify({ username: "alice" }), {
+      ex: 3600,
+    });
+
+    const result = await backfillRedisKeyScheme(redis, {
+      pattern: "chat:users:*",
+      limit: 10,
+      dryRun: false,
+    });
+
+    expect(result.scanned).toBe(1);
+    expect(result.copied).toBe(1);
+    expect(await redis.get(redisKeys.auth.userProfile("alice"))).toBe(
+      JSON.stringify({ username: "alice" })
+    );
+    expect(await redis.get("chat:users:alice")).toBe(JSON.stringify({ username: "alice" }));
+    expect(fake.ttls.get(redisKeys.auth.userProfile("alice"))).toBe(3600);
+  });
+
+  test("backfills auth sessions with hashed token keys and user session index", async () => {
+    const fake = new FakeRedis();
+    const redis = fake as unknown as Redis;
+    fake.setSync("chat:token:user:alice:secret-token", "123", { ex: 120 });
+    const tokenHash = await sha256RedisIdentifier("secret-token");
+
+    const result = await backfillRedisKeyScheme(redis, {
+      pattern: "chat:token:*",
+      limit: 10,
+      dryRun: false,
+    });
+
+    expect(result.copied).toBe(1);
+    expect(await redis.get(redisKeys.auth.session(tokenHash))).toBe("123");
+    expect(await redis.smembers(redisKeys.auth.userSessions("alice"))).toEqual([tokenHash]);
+    expect(fake.ttls.get(redisKeys.auth.session(tokenHash))).toBe(120);
+    expect(fake.ttls.get(redisKeys.auth.userSessions("alice"))).toBe(120);
+  });
+
+  test("dry-run backfill plans without writing target keys", async () => {
+    const fake = new FakeRedis();
+    const redis = fake as unknown as Redis;
+    fake.setSync("song:meta:abc", JSON.stringify({ id: "abc" }));
+
+    const result = await backfillRedisKeyScheme(redis, {
+      pattern: "song:*",
+      limit: 10,
+      dryRun: true,
+    });
+
+    expect(result.scanned).toBe(1);
+    expect(result.planned).toBe(1);
+    expect(result.copied).toBe(0);
+    expect(await redis.get(redisKeys.media.songMeta("abc"))).toBeNull();
+  });
+
+  test("reports legacy status and deletes legacy batches only when not dry-run", async () => {
+    const fake = new FakeRedis();
+    const redis = fake as unknown as Redis;
+    fake.setSync("applet:share:a1", JSON.stringify({ id: "a1" }));
+    fake.setSync("applet:share:a2", JSON.stringify({ id: "a2" }));
+
+    const status = await getRedisMigrationStatus(redis, 10);
+    const appletStatus = status.patterns.find((item) => item.pattern === "applet:*");
+    expect(appletStatus?.count).toBe(2);
+
+    const dryRun = await deleteLegacyRedisKeys(redis, {
+      pattern: "applet:*",
+      limit: 10,
+      dryRun: true,
+    });
+    expect(dryRun.deleted).toBe(0);
+    expect(await redis.get("applet:share:a1")).not.toBeNull();
+
+    const deleted = await deleteLegacyRedisKeys(redis, {
+      pattern: "applet:*",
+      limit: 10,
+      dryRun: false,
+    });
+    expect(deleted.deleted).toBe(2);
+    expect(await redis.get("applet:share:a1")).toBeNull();
+    expect(await redis.get("applet:share:a2")).toBeNull();
+  });
+});

--- a/tests/test-redis-key-migration.test.ts
+++ b/tests/test-redis-key-migration.test.ts
@@ -27,6 +27,11 @@ describe("Redis key scheme migration helpers", () => {
       targetKey: null,
       action: "skip",
     });
+    await expect(planRedisKeyMigration("sync:state:alice:settings")).resolves.toMatchObject({
+      targetKey: "sync:v2:user:alice:kv",
+      action: "import-v1-sync",
+      username: "alice",
+    });
   });
 
   test("backfills strings and preserves TTLs without deleting legacy keys", async () => {
@@ -118,6 +123,34 @@ describe("Redis key scheme migration helpers", () => {
     expect(scanned).toBeGreaterThanOrEqual(2);
     expect(await redis.get(redisKeys.auth.userProfile("alice"))).not.toBeNull();
     expect(await redis.get(redisKeys.auth.userProfile("bob"))).not.toBeNull();
+  });
+
+  test("imports legacy sync v1 keys into sync2 instead of warning", async () => {
+    const fake = new FakeRedis();
+    const redis = fake as unknown as Redis;
+    fake.setSync(
+      "sync:state:alice:settings",
+      JSON.stringify({
+        data: {
+          display: { desktopScale: 1 },
+        },
+        updatedAt: "2026-01-01T00:00:00.000Z",
+      })
+    );
+
+    const result = await backfillRedisKeyScheme(redis, {
+      pattern: "sync:state:*",
+      limit: 10,
+      dryRun: false,
+    });
+
+    expect(result.scanned).toBe(1);
+    expect(result.planned).toBe(1);
+    expect(result.copied).toBe(1);
+    expect(result.warnings).toEqual([]);
+    expect(await redis.get("sync2:seq:alice")).toBe("0");
+    const kv = await redis.hgetall("sync2:kv:alice");
+    expect(Object.keys(kv || {})).toContain("settings/display");
   });
 
   test("reports legacy status and deletes legacy batches only when not dry-run", async () => {

--- a/tests/test-redis-keys.test.ts
+++ b/tests/test-redis-keys.test.ts
@@ -65,7 +65,10 @@ describe("canonical Redis key registry", () => {
 
   test("preserves case-sensitive IDs where existing IDs may be mixed-case", () => {
     expect(redisKeys.chat.roomMeta("RoomABC")).toBe("chat:rooms:RoomABC:meta");
-    expect(redisKeys.media.songMeta("am:12345")).toBe("media:song:am%3A12345:meta");
+    expect(redisKeys.media.songMeta("am:12345")).toBe("media:song:am:12345:meta");
+    expect(redisKeys.media.songContent("am:12345")).toBe(
+      "media:song:am:12345:content"
+    );
     expect(redisKeys.agent.cursorRunMeta("bc_AbC")).toBe(
       "agent:cursor:run:bc_AbC:meta"
     );

--- a/tests/test-redis-keys.test.ts
+++ b/tests/test-redis-keys.test.ts
@@ -44,6 +44,10 @@ describe("canonical Redis key registry", () => {
     expect(LEGACY_REDIS_SCAN_PATTERNS).toContain("cursor-sdk-run:*");
     expect(LEGACY_REDIS_SCAN_PATTERNS).not.toContain("chat:*");
     expect(LEGACY_REDIS_SCAN_PATTERNS).not.toContain("sync:*");
+    expect(redisKeys.chat.roomMeta("abc").startsWith("chat:room:")).toBe(false);
+    expect(redisKeys.integration.ircServer("libera").startsWith("chat:irc:")).toBe(
+      false
+    );
   });
 
   test("normalizes dynamic segments consistently", () => {
@@ -58,7 +62,7 @@ describe("canonical Redis key registry", () => {
   });
 
   test("preserves case-sensitive IDs where existing IDs may be mixed-case", () => {
-    expect(redisKeys.chat.roomMeta("RoomABC")).toBe("chat:room:RoomABC:meta");
+    expect(redisKeys.chat.roomMeta("RoomABC")).toBe("chat:rooms:RoomABC:meta");
     expect(redisKeys.media.songMeta("am:12345")).toBe("media:song:am%3A12345:meta");
     expect(redisKeys.agent.cursorRunMeta("bc_AbC")).toBe(
       "agent:cursor:run:bc_AbC:meta"
@@ -73,6 +77,9 @@ describe("canonical Redis key registry", () => {
     );
     expect(redisKeys.integration.telegramPendingLink("Ryo")).toBe(
       "integration:telegram:link:user:ryo"
+    );
+    expect(redisKeys.integration.ircServer("libera")).toBe(
+      "integration:irc:server:libera"
     );
     expect(redisKeys.realtime.ticket("tickethash")).toBe("realtime:ticket:tickethash");
     expect(redisKeys.presence.globalOnline()).toBe("presence:global:online");

--- a/tests/test-redis-keys.test.ts
+++ b/tests/test-redis-keys.test.ts
@@ -1,0 +1,93 @@
+#!/usr/bin/env bun
+/**
+ * Unit tests for the canonical Redis key registry. These tests do not touch a
+ * Redis server; they lock down key shapes for the staged migration.
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  CANONICAL_REDIS_PREFIXES,
+  LEGACY_REDIS_SCAN_PATTERNS,
+  redisKey,
+  redisKeys,
+  redisKeysForHashedIdentifiers,
+  sha256RedisIdentifier,
+} from "../src/shared/redisKeys";
+
+describe("canonical Redis key registry", () => {
+  test("uses the approved top-level prefixes without an app or env wrapper", () => {
+    expect(CANONICAL_REDIS_PREFIXES).toEqual([
+      "agent",
+      "analytics",
+      "auth",
+      "cache",
+      "chat",
+      "integration",
+      "media",
+      "memory",
+      "presence",
+      "rate",
+      "realtime",
+      "session",
+      "sync",
+      "system",
+    ]);
+    expect(CANONICAL_REDIS_PREFIXES).not.toContain("ryos");
+    expect(CANONICAL_REDIS_PREFIXES).not.toContain("prod");
+  });
+
+  test("keeps precise legacy scan patterns for final cleanup", () => {
+    expect(LEGACY_REDIS_SCAN_PATTERNS).toContain("chat:users:*");
+    expect(LEGACY_REDIS_SCAN_PATTERNS).toContain("chat:token:*");
+    expect(LEGACY_REDIS_SCAN_PATTERNS).toContain("sync2:*");
+    expect(LEGACY_REDIS_SCAN_PATTERNS).toContain("rl:*");
+    expect(LEGACY_REDIS_SCAN_PATTERNS).toContain("cursor-sdk-run:*");
+    expect(LEGACY_REDIS_SCAN_PATTERNS).not.toContain("chat:*");
+    expect(LEGACY_REDIS_SCAN_PATTERNS).not.toContain("sync:*");
+  });
+
+  test("normalizes dynamic segments consistently", () => {
+    expect(redisKey("Auth", "User", "Ryo Lu", "Profile")).toBe(
+      "auth:user:ryo%20lu:profile"
+    );
+    expect(redisKeys.auth.userProfile("Alice")).toBe("auth:user:alice:profile");
+    expect(redisKeys.auth.userSessions("Alice")).toBe("auth:user:alice:sessions");
+    expect(redisKeys.rate.counter("AI Chat", "5h", "user", "Alice")).toBe(
+      "rate:ai%20chat:5h:user:alice"
+    );
+  });
+
+  test("preserves case-sensitive IDs where existing IDs may be mixed-case", () => {
+    expect(redisKeys.chat.roomMeta("RoomABC")).toBe("chat:room:RoomABC:meta");
+    expect(redisKeys.media.songMeta("am:12345")).toBe("media:song:am%3A12345:meta");
+    expect(redisKeys.agent.cursorRunMeta("bc_AbC")).toBe(
+      "agent:cursor:run:bc_AbC:meta"
+    );
+  });
+
+  test("builds representative migration target keys", () => {
+    expect(redisKeys.sync.v2Kv("Ryo")).toBe("sync:v2:user:ryo:kv");
+    expect(redisKeys.sync.v2Journal("Ryo")).toBe("sync:v2:user:ryo:journal");
+    expect(redisKeys.cache.ieVersions("urlhash", 1999)).toBe(
+      "cache:ie:urlhash:1999:versions"
+    );
+    expect(redisKeys.integration.telegramPendingLink("Ryo")).toBe(
+      "integration:telegram:link:user:ryo"
+    );
+    expect(redisKeys.realtime.ticket("tickethash")).toBe("realtime:ticket:tickethash");
+    expect(redisKeys.presence.globalOnline()).toBe("presence:global:online");
+  });
+
+  test("hashes sensitive identifiers before they become key segments", async () => {
+    const hash = await sha256RedisIdentifier("secret-token");
+    expect(hash).toHaveLength(64);
+    expect(hash).toMatch(/^[a-f0-9]{64}$/);
+    expect(hash).not.toContain("secret-token");
+    expect(redisKeys.auth.session(hash)).toBe(`auth:session:${hash}`);
+
+    const helpers = redisKeysForHashedIdentifiers();
+    await expect(helpers.token("secret-token")).resolves.toBe(hash);
+    await expect(helpers.ip("203.0.113.10")).resolves.toHaveLength(64);
+    await expect(helpers.url("https://example.com/path")).resolves.toHaveLength(64);
+  });
+});

--- a/tests/test-redis-keys.test.ts
+++ b/tests/test-redis-keys.test.ts
@@ -39,6 +39,8 @@ describe("canonical Redis key registry", () => {
   test("keeps precise legacy scan patterns for final cleanup", () => {
     expect(LEGACY_REDIS_SCAN_PATTERNS).toContain("chat:users:*");
     expect(LEGACY_REDIS_SCAN_PATTERNS).toContain("chat:token:*");
+    expect(LEGACY_REDIS_SCAN_PATTERNS).toContain("analytics:daily:*");
+    expect(LEGACY_REDIS_SCAN_PATTERNS).toContain("memory:user:*:processing_lock");
     expect(LEGACY_REDIS_SCAN_PATTERNS).toContain("sync2:*");
     expect(LEGACY_REDIS_SCAN_PATTERNS).toContain("rl:*");
     expect(LEGACY_REDIS_SCAN_PATTERNS).toContain("cursor-sdk-run:*");

--- a/tests/test-redis-runtime-cutover.test.ts
+++ b/tests/test-redis-runtime-cutover.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, test } from "bun:test";
+import type { Redis } from "../api/_utils/redis";
+import {
+  consumeRealtimeTicket,
+  issueRealtimeTicket,
+} from "../api/_utils/realtime-auth";
+import {
+  clearTelegramConversationHistory,
+  consumeTelegramLinkCode,
+  createTelegramLinkCode,
+  loadTelegramConversationHistory,
+} from "../api/_utils/telegram-link";
+import {
+  deleteSong,
+  getLegacySongContentKey,
+  getLegacySongMetaKey,
+  getSong,
+  getSongContentKey,
+  getSongMetaKey,
+  listSongs,
+  saveSong,
+  SONG_SET_KEY,
+} from "../api/_utils/_song-service";
+import {
+  applySyncOps,
+  legacySync2JournalKey,
+  legacySync2KvKey,
+  legacySync2SeqKey,
+  readSyncChanges,
+  readSyncSnapshot,
+  sync2JournalKey,
+  sync2KvKey,
+  sync2SeqKey,
+} from "../api/sync/v2/_core";
+import { redisKeys, sha256RedisIdentifier } from "../src/shared/redisKeys";
+import { formatHlc } from "../src/shared/sync2/hlc";
+import { FakeRedis } from "./fake-redis";
+
+const hlc = (offsetMs: number, clientId = "client-a") =>
+  formatHlc(1_718_180_000_000 + offsetMs, 0, clientId);
+
+describe("runtime Redis canonical cutover", () => {
+  test("songs write canonical and legacy keys and read after legacy keys are gone", async () => {
+    const fake = new FakeRedis();
+    const redis = fake as unknown as Redis;
+
+    await saveSong(redis, {
+      id: "am:1441633005",
+      title: "Canonical Song",
+      lyrics: { lrc: "[00:00.00]hello" },
+    });
+
+    expect(await redis.get(getSongMetaKey("am:1441633005"))).not.toBeNull();
+    expect(await redis.get(getLegacySongMetaKey("am:1441633005"))).not.toBeNull();
+    expect(await redis.smembers(redisKeys.media.songIds())).toEqual(["am:1441633005"]);
+    expect(await redis.smembers(SONG_SET_KEY)).toEqual(["am:1441633005"]);
+
+    await redis.del(
+      getLegacySongMetaKey("am:1441633005"),
+      getLegacySongContentKey("am:1441633005"),
+      SONG_SET_KEY
+    );
+
+    const song = await getSong(redis, "am:1441633005", { includeLyrics: true });
+    expect(song?.title).toBe("Canonical Song");
+    expect(song?.lyrics?.lrc).toBe("[00:00.00]hello");
+    expect((await listSongs(redis)).map((item) => item.id)).toEqual(["am:1441633005"]);
+
+    expect(await deleteSong(redis, "am:1441633005")).toBe(true);
+    expect(await redis.get(getSongMetaKey("am:1441633005"))).toBeNull();
+    expect(await redis.get(getSongContentKey("am:1441633005"))).toBeNull();
+  });
+
+  test("sync2 writes canonical and legacy state and reads legacy-only users", async () => {
+    const fake = new FakeRedis();
+    const redis = fake as unknown as Redis;
+
+    const result = await applySyncOps(
+      redis,
+      "ryo",
+      [{ k: "settings/display", v: { desktopScale: 1 }, t: hlc(0) }],
+      "client-a",
+      { trusted: true }
+    );
+
+    expect(result.seq).toBe(1);
+    expect(await redis.get(sync2SeqKey("ryo"))).toBe("1");
+    expect(await redis.get(legacySync2SeqKey("ryo"))).toBe("1");
+    expect(await redis.hget(sync2KvKey("ryo"), "settings/display")).not.toBeNull();
+    expect(await redis.hget(legacySync2KvKey("ryo"), "settings/display")).not.toBeNull();
+    expect(await redis.zcard(sync2JournalKey("ryo"))).toBe(1);
+    expect(await redis.zcard(legacySync2JournalKey("ryo"))).toBe(1);
+
+    await redis.del(legacySync2SeqKey("ryo"), legacySync2KvKey("ryo"), legacySync2JournalKey("ryo"));
+    const canonicalSnapshot = await readSyncSnapshot(redis, "ryo");
+    expect(canonicalSnapshot.entries["settings/display"]?.v).toEqual({ desktopScale: 1 });
+
+    fake.setSync(legacySync2SeqKey("legacy"), "2");
+    await redis.hset(legacySync2KvKey("legacy"), {
+      "settings/theme": JSON.stringify({
+        v: { theme: "aqua" },
+        t: hlc(1, "legacy"),
+        seq: 2,
+      }),
+    });
+    await redis.zadd(legacySync2JournalKey("legacy"), {
+      score: 2,
+      member: JSON.stringify({
+        k: "settings/theme",
+        v: { theme: "aqua" },
+        t: hlc(1, "legacy"),
+        seq: 2,
+        c: "legacy-client",
+      }),
+    });
+
+    const legacySnapshot = await readSyncSnapshot(redis, "legacy");
+    expect(legacySnapshot.seq).toBe(2);
+    expect(legacySnapshot.entries["settings/theme"]?.v).toEqual({ theme: "aqua" });
+    const changes = await readSyncChanges(redis, "legacy", 1);
+    expect(changes.ops?.[0]?.k).toBe("settings/theme");
+  });
+
+  test("realtime tickets consume canonical keys after legacy ticket deletion", async () => {
+    const fake = new FakeRedis();
+    const redis = fake as unknown as Redis;
+
+    const ticket = await issueRealtimeTicket(redis, "Ryo");
+    const ticketHash = await sha256RedisIdentifier(ticket);
+    expect(await redis.get(redisKeys.realtime.ticket(ticketHash))).toBe("ryo");
+
+    await redis.del(`rt:ticket:${ticket}`);
+    expect(await consumeRealtimeTicket(redis, ticket)).toBe("ryo");
+    expect(await redis.get(redisKeys.realtime.ticket(ticketHash))).toBeNull();
+  });
+
+  test("telegram link codes and history use canonical keys with legacy fallback", async () => {
+    const fake = new FakeRedis();
+    const redis = fake as unknown as Redis;
+
+    const { code } = await createTelegramLinkCode(redis, "Ryo", 60);
+    await redis.del(`telegram:link:code:${code}`, "telegram:link:username:ryo");
+    expect(await consumeTelegramLinkCode(redis, code)).toEqual({
+      username: "ryo",
+      createdAt: expect.any(Number),
+    });
+
+    await redis.lpush(
+      "telegram:history:chat-1",
+      JSON.stringify({ role: "user", content: "hello", createdAt: 1 })
+    );
+    expect(await loadTelegramConversationHistory(redis, "chat-1")).toEqual([
+      { role: "user", content: "hello", createdAt: 1 },
+    ]);
+
+    await clearTelegramConversationHistory(redis, "chat-1");
+    expect(await redis.lrange("telegram:history:chat-1", 0, -1)).toEqual([]);
+    expect(await redis.lrange(redisKeys.integration.telegramHistory("chat-1"), 0, -1)).toEqual([]);
+  });
+});

--- a/tests/test-redis-runtime-cutover.test.ts
+++ b/tests/test-redis-runtime-cutover.test.ts
@@ -40,7 +40,7 @@ const hlc = (offsetMs: number, clientId = "client-a") =>
   formatHlc(1_718_180_000_000 + offsetMs, 0, clientId);
 
 describe("runtime Redis canonical cutover", () => {
-  test("songs write canonical and legacy keys and read after legacy keys are gone", async () => {
+  test("songs write canonical keys only and still read legacy-only songs", async () => {
     const fake = new FakeRedis();
     const redis = fake as unknown as Redis;
 
@@ -51,27 +51,34 @@ describe("runtime Redis canonical cutover", () => {
     });
 
     expect(await redis.get(getSongMetaKey("am:1441633005"))).not.toBeNull();
-    expect(await redis.get(getLegacySongMetaKey("am:1441633005"))).not.toBeNull();
+    expect(await redis.get(getLegacySongMetaKey("am:1441633005"))).toBeNull();
     expect(await redis.smembers(redisKeys.media.songIds())).toEqual(["am:1441633005"]);
-    expect(await redis.smembers(SONG_SET_KEY)).toEqual(["am:1441633005"]);
-
-    await redis.del(
-      getLegacySongMetaKey("am:1441633005"),
-      getLegacySongContentKey("am:1441633005"),
-      SONG_SET_KEY
-    );
+    expect(await redis.smembers(SONG_SET_KEY)).toEqual([]);
 
     const song = await getSong(redis, "am:1441633005", { includeLyrics: true });
     expect(song?.title).toBe("Canonical Song");
     expect(song?.lyrics?.lrc).toBe("[00:00.00]hello");
     expect((await listSongs(redis)).map((item) => item.id)).toEqual(["am:1441633005"]);
 
+    await redis.set(
+      getLegacySongMetaKey("legacy-song"),
+      JSON.stringify({ id: "legacy-song", title: "Legacy Song" })
+    );
+    await redis.set(
+      getLegacySongContentKey("legacy-song"),
+      JSON.stringify({ lyrics: { lrc: "[00:01.00]legacy" } })
+    );
+    await redis.sadd(SONG_SET_KEY, "legacy-song");
+    const legacySong = await getSong(redis, "legacy-song", { includeLyrics: true });
+    expect(legacySong?.title).toBe("Legacy Song");
+    expect(legacySong?.lyrics?.lrc).toBe("[00:01.00]legacy");
+
     expect(await deleteSong(redis, "am:1441633005")).toBe(true);
     expect(await redis.get(getSongMetaKey("am:1441633005"))).toBeNull();
     expect(await redis.get(getSongContentKey("am:1441633005"))).toBeNull();
   });
 
-  test("sync2 writes canonical and legacy state and reads legacy-only users", async () => {
+  test("sync2 writes canonical state only and reads legacy-only users", async () => {
     const fake = new FakeRedis();
     const redis = fake as unknown as Redis;
 
@@ -85,13 +92,12 @@ describe("runtime Redis canonical cutover", () => {
 
     expect(result.seq).toBe(1);
     expect(await redis.get(sync2SeqKey("ryo"))).toBe("1");
-    expect(await redis.get(legacySync2SeqKey("ryo"))).toBe("1");
+    expect(await redis.get(legacySync2SeqKey("ryo"))).toBeNull();
     expect(await redis.hget(sync2KvKey("ryo"), "settings/display")).not.toBeNull();
-    expect(await redis.hget(legacySync2KvKey("ryo"), "settings/display")).not.toBeNull();
+    expect(await redis.hget(legacySync2KvKey("ryo"), "settings/display")).toBeNull();
     expect(await redis.zcard(sync2JournalKey("ryo"))).toBe(1);
-    expect(await redis.zcard(legacySync2JournalKey("ryo"))).toBe(1);
+    expect(await redis.zcard(legacySync2JournalKey("ryo"))).toBe(0);
 
-    await redis.del(legacySync2SeqKey("ryo"), legacySync2KvKey("ryo"), legacySync2JournalKey("ryo"));
     const canonicalSnapshot = await readSyncSnapshot(redis, "ryo");
     expect(canonicalSnapshot.entries["settings/display"]?.v).toEqual({ desktopScale: 1 });
 
@@ -121,25 +127,30 @@ describe("runtime Redis canonical cutover", () => {
     expect(changes.ops?.[0]?.k).toBe("settings/theme");
   });
 
-  test("realtime tickets consume canonical keys after legacy ticket deletion", async () => {
+  test("realtime tickets write canonical keys only and consume legacy fallback", async () => {
     const fake = new FakeRedis();
     const redis = fake as unknown as Redis;
 
     const ticket = await issueRealtimeTicket(redis, "Ryo");
     const ticketHash = await sha256RedisIdentifier(ticket);
     expect(await redis.get(redisKeys.realtime.ticket(ticketHash))).toBe("ryo");
+    expect(await redis.get(`rt:ticket:${ticket}`)).toBeNull();
 
-    await redis.del(`rt:ticket:${ticket}`);
     expect(await consumeRealtimeTicket(redis, ticket)).toBe("ryo");
     expect(await redis.get(redisKeys.realtime.ticket(ticketHash))).toBeNull();
+
+    await redis.set("rt:ticket:legacy-ticket", "legacy-user");
+    expect(await consumeRealtimeTicket(redis, "legacy-ticket")).toBe("legacy-user");
+    expect(await redis.get("rt:ticket:legacy-ticket")).toBeNull();
   });
 
-  test("telegram link codes and history use canonical keys with legacy fallback", async () => {
+  test("telegram link codes and history write canonical only with legacy fallback", async () => {
     const fake = new FakeRedis();
     const redis = fake as unknown as Redis;
 
     const { code } = await createTelegramLinkCode(redis, "Ryo", 60);
-    await redis.del(`telegram:link:code:${code}`, "telegram:link:username:ryo");
+    expect(await redis.get(`telegram:link:code:${code}`)).toBeNull();
+    expect(await redis.get("telegram:link:username:ryo")).toBeNull();
     expect(await consumeTelegramLinkCode(redis, code)).toEqual({
       username: "ryo",
       createdAt: expect.any(Number),
@@ -147,6 +158,10 @@ describe("runtime Redis canonical cutover", () => {
 
     await redis.lpush(
       "telegram:history:chat-1",
+      JSON.stringify({ role: "user", content: "hello", createdAt: 1 })
+    );
+    await redis.lpush(
+      redisKeys.integration.telegramHistory("chat-1"),
       JSON.stringify({ role: "user", content: "hello", createdAt: 1 })
     );
     expect(await loadTelegramConversationHistory(redis, "chat-1")).toEqual([

--- a/tests/test-sync-maintenance.test.ts
+++ b/tests/test-sync-maintenance.test.ts
@@ -1,10 +1,11 @@
 import { describe, expect, test } from "bun:test";
 import type { Redis } from "../api/_utils/redis";
-import { applySyncOps, ensureSync2Initialized } from "../api/sync/v2/_core";
+import { applySyncOps, ensureSync2Initialized, sync2BlobsKey } from "../api/sync/v2/_core";
 import {
   runSyncMaintenance,
   V1_RETIREMENT_TTL_SECONDS,
 } from "../api/sync/v2/_maintenance";
+import { redisKeys } from "../src/shared/redisKeys";
 import { formatHlc } from "../src/shared/sync2/hlc";
 import { FakeRedis } from "./fake-redis";
 
@@ -72,7 +73,10 @@ describe("sync maintenance: v1 key retirement", () => {
     const fake = new FakeRedis();
     const redis = fake as unknown as Redis;
 
-    // Legacy expire-on-room-message left a TTL on the user record.
+    const canonicalUserKey = redisKeys.auth.userProfile("alice");
+    fake.setSync(canonicalUserKey, JSON.stringify({ username: "alice" }), {
+      ex: 90 * 24 * 60 * 60,
+    });
     fake.setSync("chat:users:alice", JSON.stringify({ username: "alice" }), {
       ex: 90 * 24 * 60 * 60,
     });
@@ -82,7 +86,8 @@ describe("sync maintenance: v1 key retirement", () => {
     const stats = await runSyncMaintenance(redis, { deleteObject, now: NOW });
 
     expect(stats.userRecordsPersisted).toBe(1);
-    expect(fake.ttls.has("chat:users:alice")).toBe(false);
+    expect(fake.ttls.has(canonicalUserKey)).toBe(false);
+    expect(fake.ttls.has("chat:users:alice")).toBe(true);
 
     // Already-persistent records are untouched on subsequent runs.
     const again = await runSyncMaintenance(redis, { deleteObject, now: NOW + 1 });
@@ -170,7 +175,7 @@ describe("sync maintenance: blob GC mark-and-sweep", () => {
     expect(spy.deleted).toEqual([`s3://bucket/sync/alice/blobs/${sha("b")}.gz`]);
 
     // Referenced blobs are untouched.
-    const registry = await fake.hgetall("sync2:blobs:alice");
+    const registry = await fake.hgetall(sync2BlobsKey("alice"));
     expect(Object.keys(registry || {})).toContain(sha("a"));
     expect(Object.keys(registry || {})).toContain(sha("c"));
     expect(Object.keys(registry || {})).not.toContain(sha("b"));
@@ -199,7 +204,7 @@ describe("sync maintenance: blob GC mark-and-sweep", () => {
     });
     expect(sweep.blobsDeleted).toBe(0);
     expect(spy.deleted).toEqual([]);
-    const registry = await fake.hgetall("sync2:blobs:alice");
+    const registry = await fake.hgetall(sync2BlobsKey("alice"));
     expect(Object.keys(registry || {})).toContain(sha("b"));
   });
 
@@ -209,7 +214,7 @@ describe("sync maintenance: blob GC mark-and-sweep", () => {
     await seedBlobUser(redis);
 
     // Simulate a leftover mark on a referenced blob (e.g. interrupted run).
-    const registryKey = "sync2:blobs:alice";
+    const registryKey = sync2BlobsKey("alice");
     const marked = JSON.parse(
       (await fake.hget<string>(registryKey, sha("a")))!
     );

--- a/tests/test-sync-v2-core.test.ts
+++ b/tests/test-sync-v2-core.test.ts
@@ -10,6 +10,7 @@ import {
   lookupSyncBlobs,
   validateSyncOps,
   sync2KvKey,
+  sync2JournalKey,
 } from "../api/sync/v2/_core";
 import {
   clampHlc,
@@ -423,17 +424,17 @@ describe("sync v2 v1-import", () => {
     );
 
     // Simulate TTLs decaying (e.g. an idle device only ever reads).
-    fake.ttls.delete("sync2:kv:user1");
-    fake.ttls.delete("sync2:jrnl:user1");
+    fake.ttls.delete(sync2KvKey("user1"));
+    fake.ttls.delete(sync2JournalKey("user1"));
 
     await readSyncChanges(r, "user1", 0);
-    expect(fake.ttls.get("sync2:kv:user1")).toBeGreaterThan(0);
-    expect(fake.ttls.get("sync2:jrnl:user1")).toBeGreaterThan(0);
+    expect(fake.ttls.get(sync2KvKey("user1"))).toBeGreaterThan(0);
+    expect(fake.ttls.get(sync2JournalKey("user1"))).toBeGreaterThan(0);
 
     // Throttle marker prevents refreshing again within the same day.
-    fake.ttls.delete("sync2:kv:user1");
+    fake.ttls.delete(sync2KvKey("user1"));
     await readSyncChanges(r, "user1", 0);
-    expect(fake.ttls.get("sync2:kv:user1")).toBeUndefined();
+    expect(fake.ttls.get(sync2KvKey("user1"))).toBeUndefined();
   });
 
   test("import is skipped once initialized and writes proceed normally", async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Cut runtime writes over to canonical Redis keys only while preserving canonical-first reads with legacy fallback.
- Kept destructive cleanup paths deleting both canonical and legacy keys.
- Fixed mixed list reads for chat messages and Telegram history, sync maintenance cursor progress, canonical IE cache year parsing, Airdrop/global presence fallback reads, and analytics legacy read fallback.
- Added `ryos:presence:*` to legacy migration discovery and mapped `ryos:presence:online` to `presence:global:online`.
- Updated focused coverage for canonical-only writes, legacy fallback reads, mixed-list behavior, analytics fallback, and presence migration mapping.

## Testing
- `bun test tests/test-analytics-keys.test.ts tests/test-redis-key-migration.test.ts tests/test-redis-runtime-cutover.test.ts tests/test-chat-message-canonical-cutover.test.ts`
- `bun test tests/test-auth-canonical-session.test.ts tests/test-redis-key-migration.test.ts tests/test-sync-v2-core.test.ts tests/test-sync-maintenance.test.ts tests/test-chat-broadcast-wiring.test.ts`
- `bun run test:unit`
- `bun run build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ed736-b03c-759c-a25d-b4cef94280c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ed736-b03c-759c-a25d-b4cef94280c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

