### PR TITLE
Await analytics Redis writes

### DIFF
--- a/api/_utils/_analytics.ts
+++ b/api/_utils/_analytics.ts
@@ -74,10 +74,10 @@ export interface AnalyticsEvent {
   username?: string | null;
 }
 
-export function recordAnalyticsEvent(
+export async function recordAnalyticsEvent(
   redis: Redis,
   event: AnalyticsEvent
-): void {
+): Promise<void> {
   const date = todayUTC();
   const endpoint = normaliseEndpoint(event.path);
   const isAI = isAIEndpoint(event.path);
@@ -112,7 +112,7 @@ export function recordAnalyticsEvent(
     pipe.expire(k("aiu", date), ANALYTICS_TTL_SECONDS);
   }
 
-  pipe.exec().catch((err) => {
+  await pipe.exec().then(() => undefined).catch((err) => {
     console.warn("[analytics] pipeline error (non-fatal):", err);
   });
 }
@@ -421,11 +421,11 @@ function breakdownFromMap(map: Map<string, number>, limit: number): ProductEvent
     .slice(0, limit);
 }
 
-export function recordProductAnalyticsEvents(
+export async function recordProductAnalyticsEvents(
   redis: Redis,
   batch: ProductAnalyticsBatch,
   context: ProductAnalyticsRequestContext
-): void {
+): Promise<void> {
   const events = Array.isArray(batch?.events)
     ? batch.events.slice(0, MAX_PRODUCT_EVENTS_PER_BATCH)
     : [];
@@ -492,7 +492,7 @@ export function recordProductAnalyticsEvents(
     pipe.expire(pk("country", date), ANALYTICS_TTL_SECONDS);
   }
 
-  pipe.exec().catch((err) => {
+  await pipe.exec().then(() => undefined).catch((err) => {
     console.warn("[analytics] product pipeline error (non-fatal):", err);
   });
 }

--- a/api/_utils/api-handler.ts
+++ b/api/_utils/api-handler.ts
@@ -163,7 +163,7 @@ export function apiHandler<TBody = unknown>(
     }
 
     if (analytics) {
-      recordAnalyticsEvent(redis, {
+      await recordAnalyticsEvent(redis, {
         path: req.url || "/api/unknown",
         method,
         status: finalStatus,

--- a/api/analytics/events.ts
+++ b/api/analytics/events.ts
@@ -48,7 +48,7 @@ export default apiHandler<ProductAnalyticsBatch>(
       country = null;
     }
 
-    recordProductAnalyticsEvents(redis, body, {
+    await recordProductAnalyticsEvents(redis, body, {
       ip,
       username: user?.username,
       userAgent: getHeader(req, "user-agent"),

--- a/tests/test-analytics-aggregation.test.ts
+++ b/tests/test-analytics-aggregation.test.ts
@@ -109,7 +109,7 @@ describe("product analytics aggregation", () => {
 
   test("records product events into daily breakdowns", async () => {
     const redis = new FakeRedis();
-    recordProductAnalyticsEvents(
+    await recordProductAnalyticsEvents(
       redis as unknown as Redis,
       {
         events: [
@@ -121,8 +121,6 @@ describe("product analytics aggregation", () => {
       },
       { ip: "127.0.0.1" }
     );
-
-    await Promise.resolve();
 
     const detail = await getProductAnalyticsDetail(redis as unknown as Redis, 1);
     expect(detail.summary.totals.events).toBe(4);
@@ -139,7 +137,7 @@ describe("product analytics aggregation", () => {
 
   test("aggregates top songs, sites and countries", async () => {
     const redis = new FakeRedis();
-    recordProductAnalyticsEvents(
+    await recordProductAnalyticsEvents(
       redis as unknown as Redis,
       {
         events: [
@@ -178,8 +176,6 @@ describe("product analytics aggregation", () => {
       { ip: "8.8.8.8", country: "us" }
     );
 
-    await Promise.resolve();
-
     const detail = await getProductAnalyticsDetail(redis as unknown as Redis, 1);
     expect(detail.topSongs.find((e) => e.name === "The Beatles — Yesterday")?.count).toBe(2);
     expect(detail.topSongs.find((e) => e.name === "John Lennon — Imagine")?.count).toBe(1);
@@ -192,7 +188,7 @@ describe("product analytics aggregation", () => {
 
   test("ignores client-supplied country and skips when geo unresolved", async () => {
     const redis = new FakeRedis();
-    recordProductAnalyticsEvents(
+    await recordProductAnalyticsEvents(
       redis as unknown as Redis,
       {
         events: [
@@ -207,8 +203,6 @@ describe("product analytics aggregation", () => {
       },
       { ip: "8.8.8.8" }
     );
-
-    await Promise.resolve();
 
     const detail = await getProductAnalyticsDetail(redis as unknown as Redis, 1);
     expect(detail.topCountries).toEqual([]);

--- a/tests/test-analytics-keys.test.ts
+++ b/tests/test-analytics-keys.test.ts
@@ -13,7 +13,7 @@ describe("analytics Redis keys", () => {
     const redis = fake as unknown as Redis;
     const today = new Date().toISOString().slice(0, 10);
 
-    recordAnalyticsEvent(redis, {
+    await recordAnalyticsEvent(redis, {
       path: "/api/chat",
       method: "POST",
       status: 200,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Await API analytics Redis pipelines before API handlers return so serverless runtimes do not drop visitor HLL writes after the response.
- Await product analytics event pipelines before `/api/analytics/events` returns `204`.
- Updated analytics tests to await write helpers directly.

## Testing
- `bun test tests/test-analytics-keys.test.ts tests/test-analytics-aggregation.test.ts`
- `bun run test:unit`
- `bun run build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ed736-b03c-759c-a25d-b4cef94280c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ed736-b03c-759c-a25d-b4cef94280c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

