### PR TITLE
Fix analytics visitor HLL migration

### DIFF
--- a/api/_utils/_analytics.ts
+++ b/api/_utils/_analytics.ts
@@ -593,15 +593,22 @@ function mergeHashCounts(
   }
 }
 
-function hasHashEntries(raw: Record<string, string> | null | undefined): raw is Record<string, string> {
-  return Boolean(raw && Object.keys(raw).length > 0);
-}
-
-function canonicalOrLegacyHash(
+function mergeNumericHashes(
   canonical: Record<string, string> | null,
   legacy: Record<string, string> | null
 ): Record<string, string> | null {
-  return hasHashEntries(canonical) ? canonical : legacy;
+  if (!canonical && !legacy) return null;
+  const merged = new Map<string, number>();
+  for (const raw of [legacy, canonical]) {
+    if (!raw) continue;
+    for (const [key, value] of Object.entries(raw)) {
+      const count = parseInt(String(value), 10) || 0;
+      merged.set(key, (merged.get(key) || 0) + count);
+    }
+  }
+  return Object.fromEntries(
+    [...merged.entries()].map(([key, value]) => [key, String(value)])
+  );
 }
 
 /**
@@ -636,7 +643,7 @@ export async function getAnalyticsSummary(
   const dailyMetrics: DailyMetrics[] = dates.map((date, i) => {
     const base = i * 3;
     const d = parseDailyHash(
-      canonicalOrLegacyHash(
+      mergeNumericHashes(
         (results[base] as Record<string, string> | null) || null,
         (results[base + 1] as Record<string, string> | null) || null
       )
@@ -726,7 +733,7 @@ export async function getAnalyticsDetail(
   const dailyMetrics: DailyMetrics[] = dates.map((date, i) => {
     const base = i * CMDS_PER_DAY;
     const d = parseDailyHash(
-      canonicalOrLegacyHash(
+      mergeNumericHashes(
         (results[base] as Record<string, string> | null) || null,
         (results[base + 1] as Record<string, string> | null) || null
       )
@@ -742,21 +749,21 @@ export async function getAnalyticsDetail(
 
     mergeHashCounts(
       epMap,
-      canonicalOrLegacyHash(
+      mergeNumericHashes(
         (results[base + 3] as Record<string, string> | null) || null,
         (results[base + 4] as Record<string, string> | null) || null
       )
     );
     mergeHashCounts(
       stMap,
-      canonicalOrLegacyHash(
+      mergeNumericHashes(
         (results[base + 5] as Record<string, string> | null) || null,
         (results[base + 6] as Record<string, string> | null) || null
       )
     );
     mergeHashCounts(
       aiuMap,
-      canonicalOrLegacyHash(
+      mergeNumericHashes(
         (results[base + 7] as Record<string, string> | null) || null,
         (results[base + 8] as Record<string, string> | null) || null
       )

--- a/api/_utils/redis-key-migration.ts
+++ b/api/_utils/redis-key-migration.ts
@@ -561,11 +561,22 @@ async function zrangeWithScores(
   }
 }
 
+function isAnalyticsVisitorHllKey(key: string): boolean {
+  return key.startsWith("analytics:uv:");
+}
+
 async function copyRedisValue(
   redis: Redis,
   sourceKey: string,
   targetKey: string
 ): Promise<string | null> {
+  if (isAnalyticsVisitorHllKey(sourceKey)) {
+    const ttl = await redis.ttl(sourceKey);
+    await redis.pfmerge(targetKey, targetKey, sourceKey);
+    if (ttl > 0) await redis.expire(targetKey, ttl);
+    return null;
+  }
+
   const type = await redis.type(sourceKey);
   const ttl = await redis.ttl(sourceKey);
   switch (type) {

--- a/api/_utils/redis-key-migration.ts
+++ b/api/_utils/redis-key-migration.ts
@@ -565,6 +565,11 @@ function isAnalyticsVisitorHllKey(key: string): boolean {
   return key.startsWith("analytics:uv:");
 }
 
+function isAnalyticsHashMetricKey(key: string): boolean {
+  const [metric, ...rest] = splitSuffix(key, "analytics:");
+  return ["aiu", "daily", "ep", "st"].includes(metric) && rest.length > 0;
+}
+
 async function copyRedisValue(
   redis: Redis,
   sourceKey: string,
@@ -573,6 +578,17 @@ async function copyRedisValue(
   if (isAnalyticsVisitorHllKey(sourceKey)) {
     const ttl = await redis.ttl(sourceKey);
     await redis.pfmerge(targetKey, targetKey, sourceKey);
+    if (ttl > 0) await redis.expire(targetKey, ttl);
+    return null;
+  }
+
+  if (isAnalyticsHashMetricKey(sourceKey)) {
+    const ttl = await redis.ttl(sourceKey);
+    const hash = (await redis.hgetall<Record<string, string>>(sourceKey)) ?? {};
+    for (const [field, value] of Object.entries(hash)) {
+      const increment = parseInt(String(value), 10) || 0;
+      if (increment !== 0) await redis.hincrby(targetKey, field, increment);
+    }
     if (ttl > 0) await redis.expire(targetKey, ttl);
     return null;
   }

--- a/api/_utils/redis.ts
+++ b/api/_utils/redis.ts
@@ -84,6 +84,7 @@ export interface RedisLike {
   rpush(key: string, ...values: string[]): Promise<number>;
   pfadd(key: string, ...elements: string[]): Promise<number>;
   pfcount(...keys: string[]): Promise<number>;
+  pfmerge(destinationKey: string, ...sourceKeys: string[]): Promise<"OK">;
   zadd(key: string, entry: RedisSortedSetEntry): Promise<number>;
   zrem(key: string, member: string): Promise<number>;
   zremrangebyscore(
@@ -447,6 +448,10 @@ class StandardRedisAdapter implements RedisLike {
   async pfcount(...keys: string[]): Promise<number> {
     if (keys.length === 0) return 0;
     return await this.client.pfcount(...keys);
+  }
+
+  async pfmerge(destinationKey: string, ...sourceKeys: string[]): Promise<"OK"> {
+    return await this.client.pfmerge(destinationKey, ...sourceKeys);
   }
 
   async zadd(key: string, entry: RedisSortedSetEntry): Promise<number> {

--- a/tests/fake-redis.ts
+++ b/tests/fake-redis.ts
@@ -78,6 +78,7 @@ export class FakeRedisPipeline {
 export class FakeRedis {
   readonly kv = new Map<string, string>();
   readonly sets = new Map<string, Set<string>>();
+  readonly hllKeys = new Set<string>();
   readonly hashes = new Map<string, Map<string, string>>();
   readonly lists = new Map<string, string[]>();
   /** Sorted sets: key → (member → score). */
@@ -131,6 +132,7 @@ export class FakeRedis {
     for (const key of keys) {
       if (this.kv.delete(key)) deleted += 1;
       if (this.sets.delete(key)) deleted += 1;
+      this.hllKeys.delete(key);
       if (this.hashes.delete(key)) deleted += 1;
       if (this.lists.delete(key)) deleted += 1;
       if (this.zsets.delete(key)) deleted += 1;
@@ -153,7 +155,9 @@ export class FakeRedis {
   }
 
   pfaddSync(key: string, ...elements: string[]): number {
-    return this.saddSync(key, ...elements);
+    const added = this.saddSync(key, ...elements);
+    this.hllKeys.add(key);
+    return added;
   }
 
   sremSync(key: string, ...members: string[]): number {
@@ -163,7 +167,10 @@ export class FakeRedis {
     for (const member of members) {
       if (set.delete(member)) removed += 1;
     }
-    if (set.size === 0) this.sets.delete(key);
+    if (set.size === 0) {
+      this.sets.delete(key);
+      this.hllKeys.delete(key);
+    }
     return removed;
   }
 
@@ -231,6 +238,7 @@ export class FakeRedis {
 
   async type(key: string): Promise<string> {
     if (this.kv.has(key)) return "string";
+    if (this.hllKeys.has(key)) return "string";
     if (this.sets.has(key)) return "set";
     if (this.hashes.has(key)) return "hash";
     if (this.lists.has(key)) return "list";
@@ -341,6 +349,18 @@ export class FakeRedis {
       }
     }
     return unique.size;
+  }
+
+  async pfmerge(destinationKey: string, ...sourceKeys: string[]): Promise<"OK"> {
+    const merged = new Set<string>();
+    for (const key of sourceKeys) {
+      for (const member of this.sets.get(key) || []) {
+        merged.add(member);
+      }
+    }
+    this.sets.set(destinationKey, merged);
+    this.hllKeys.add(destinationKey);
+    return "OK";
   }
 
   async rpush(key: string, ...values: string[]): Promise<number> {

--- a/tests/test-analytics-keys.test.ts
+++ b/tests/test-analytics-keys.test.ts
@@ -69,18 +69,19 @@ describe("analytics Redis keys", () => {
     expect(detail.aiByUser).toEqual([{ username: "ryo", count: 2 }]);
   });
 
-  test("prefers canonical analytics hashes over legacy hashes", async () => {
+  test("merges canonical and legacy analytics hashes during cutover", async () => {
     const fake = new FakeRedis();
     const redis = fake as unknown as Redis;
     const today = new Date().toISOString().slice(0, 10);
 
     await redis.hset(`analytics:daily:${today}`, {
-      calls: "100",
-      ai: "100",
-      errors: "100",
+      calls: "3",
+      ai: "2",
+      errors: "1",
       latsum: "100",
       latcnt: "1",
     });
+    await redis.pfadd(`analytics:uv:${today}`, "ip:203.0.113.10");
     await redis.hset(`analytics:api:daily:${today}`, {
       calls: "4",
       ai: "1",
@@ -88,13 +89,35 @@ describe("analytics Redis keys", () => {
       latsum: "80",
       latcnt: "4",
     });
+    await redis.pfadd(`analytics:api:uv:${today}`, "ip:203.0.113.11");
+    await redis.hset(`analytics:ep:${today}`, { "/api/chat": "2" });
+    await redis.hset(`analytics:api:ep:${today}`, { "/api/chat": "1", "/api/admin": "1" });
+    await redis.hset(`analytics:st:${today}`, { "200": "2" });
+    await redis.hset(`analytics:api:st:${today}`, { "200": "1", "500": "1" });
+    await redis.hset(`analytics:aiu:${today}`, { ryo: "2" });
+    await redis.hset(`analytics:api:aiu:${today}`, { ryo: "1", anonymous: "1" });
 
     const summary = await getAnalyticsSummary(redis, 1);
     expect(summary.totals).toMatchObject({
-      calls: 4,
-      ai: 1,
-      errors: 0,
-      avgLatencyMs: 20,
+      calls: 7,
+      ai: 3,
+      errors: 1,
+      uniqueVisitors: 2,
+      avgLatencyMs: 36,
     });
+
+    const detail = await getAnalyticsDetail(redis, 1);
+    expect(detail.topEndpoints).toEqual([
+      { endpoint: "/api/chat", count: 3 },
+      { endpoint: "/api/admin", count: 1 },
+    ]);
+    expect(detail.statusCodes).toEqual([
+      { status: "200", count: 3 },
+      { status: "500", count: 1 },
+    ]);
+    expect(detail.aiByUser).toEqual([
+      { username: "ryo", count: 3 },
+      { username: "anonymous", count: 1 },
+    ]);
   });
 });

--- a/tests/test-analytics-keys.test.ts
+++ b/tests/test-analytics-keys.test.ts
@@ -28,6 +28,8 @@ describe("analytics Redis keys", () => {
       latsum: "42",
       latcnt: "1",
     });
+    const summary = await getAnalyticsSummary(redis, 1);
+    expect(summary.totals.uniqueVisitors).toBe(1);
     expect(await redis.hgetall(`analytics:daily:${today}`)).toBeNull();
     expect(fake.allKeys().some((key) => key.startsWith("analytics:daily:"))).toBe(false);
   });

--- a/tests/test-redis-key-migration.test.ts
+++ b/tests/test-redis-key-migration.test.ts
@@ -64,6 +64,30 @@ describe("Redis key scheme migration helpers", () => {
     expect(fake.ttls.get(redisKeys.auth.userProfile("alice"))).toBe(3600);
   });
 
+  test("backfills analytics visitor HyperLogLogs with a readable canonical count", async () => {
+    const fake = new FakeRedis();
+    const redis = fake as unknown as Redis;
+    const today = new Date().toISOString().slice(0, 10);
+    const legacyKey = `analytics:uv:${today}`;
+    const canonicalKey = redisKeys.analytics.apiMetric("uv", today);
+
+    await redis.pfadd(legacyKey, "ip:203.0.113.10");
+    await redis.pfadd(canonicalKey, "ip:203.0.113.11");
+    await redis.expire(legacyKey, 3600);
+
+    const result = await backfillRedisKeyScheme(redis, {
+      pattern: "analytics:uv:*",
+      limit: 10,
+      dryRun: false,
+    });
+
+    expect(result.scanned).toBe(1);
+    expect(result.copied).toBe(1);
+    expect(await redis.pfcount(canonicalKey)).toBe(2);
+    expect(fake.ttls.get(canonicalKey)).toBe(3600);
+    expect(await redis.pfcount(legacyKey)).toBe(1);
+  });
+
   test("backfills auth sessions with hashed token keys and user session index", async () => {
     const fake = new FakeRedis();
     const redis = fake as unknown as Redis;

--- a/tests/test-redis-key-migration.test.ts
+++ b/tests/test-redis-key-migration.test.ts
@@ -88,6 +88,45 @@ describe("Redis key scheme migration helpers", () => {
     expect(await redis.pfcount(legacyKey)).toBe(1);
   });
 
+  test("backfills analytics hashes without replacing canonical counts", async () => {
+    const fake = new FakeRedis();
+    const redis = fake as unknown as Redis;
+    const today = new Date().toISOString().slice(0, 10);
+    const legacyKey = `analytics:daily:${today}`;
+    const canonicalKey = redisKeys.analytics.apiMetric("daily", today);
+
+    await redis.hset(legacyKey, {
+      calls: "3",
+      ai: "2",
+      latsum: "90",
+      latcnt: "3",
+    });
+    await redis.hset(canonicalKey, {
+      calls: "4",
+      errors: "1",
+      latsum: "80",
+      latcnt: "4",
+    });
+    await redis.expire(legacyKey, 3600);
+
+    const result = await backfillRedisKeyScheme(redis, {
+      pattern: "analytics:daily:*",
+      limit: 10,
+      dryRun: false,
+    });
+
+    expect(result.scanned).toBe(1);
+    expect(result.copied).toBe(1);
+    expect(await redis.hgetall(canonicalKey)).toMatchObject({
+      calls: "7",
+      ai: "2",
+      errors: "1",
+      latsum: "170",
+      latcnt: "7",
+    });
+    expect(fake.ttls.get(canonicalKey)).toBe(3600);
+  });
+
   test("backfills auth sessions with hashed token keys and user session index", async () => {
     const fake = new FakeRedis();
     const redis = fake as unknown as Redis;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Copy legacy analytics visitor HyperLogLog keys with Redis `PFMERGE` so canonical visitor counts remain readable.
- Merge canonical and legacy API analytics hashes on dashboard reads during cutover.
- Backfill legacy analytics hashes additively so post-cutover canonical counts are not replaced.
- Add regression coverage for canonical analytics visitor reads, HLL backfills, mixed hash reads, and additive hash backfills.

### Testing
- `bun test tests/test-redis-key-migration.test.ts tests/test-analytics-keys.test.ts` — 14 passing tests.
- `bun run build` — passed; existing CSS/Vite warnings remain non-blocking.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ed833-30a1-7275-b25c-c071d4506138"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ed833-30a1-7275-b25c-c071d4506138"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

