### PR TITLE
Fix dashboard visitor analytics fallback

### DIFF
--- a/src/apps/admin/components/dashboard-panel/deriveDashboardAnalytics.ts
+++ b/src/apps/admin/components/dashboard-panel/deriveDashboardAnalytics.ts
@@ -1,0 +1,29 @@
+import type { AnalyticsDetail, AnalyticsSummary } from "./types";
+
+export function withDisplayVisitorMetrics(
+  data: AnalyticsDetail
+): AnalyticsSummary {
+  const productDaysByDate = new Map(
+    (data.product?.summary.days ?? []).map((day) => [day.date, day])
+  );
+
+  const days = data.summary.days.map((day) => {
+    const productVisitors =
+      productDaysByDate.get(day.date)?.uniqueVisitors ?? day.uniqueVisitors;
+    return {
+      ...day,
+      uniqueVisitors: Math.max(day.uniqueVisitors, productVisitors),
+    };
+  });
+
+  return {
+    days,
+    totals: {
+      ...data.summary.totals,
+      uniqueVisitors: Math.max(
+        data.summary.totals.uniqueVisitors,
+        data.product?.summary.totals.uniqueVisitors ?? 0
+      ),
+    },
+  };
+}

--- a/src/apps/admin/components/dashboard-panel/useDashboardPanel.ts
+++ b/src/apps/admin/components/dashboard-panel/useDashboardPanel.ts
@@ -8,6 +8,7 @@ import type {
   DashboardPanelProps,
   TrendInfo,
 } from "./types";
+import { withDisplayVisitorMetrics } from "./deriveDashboardAnalytics";
 import { RANGE_DAYS } from "./types";
 import { formatNumber } from "./utils";
 
@@ -82,8 +83,8 @@ export function useDashboardPanel({ onRefresh }: DashboardPanelProps) {
   const analytics = useMemo(() => {
     if (!data) return null;
 
-    const { summary, topEndpoints, statusCodes, aiByUser, aiRateLimits } =
-      data;
+    const { topEndpoints, statusCodes, aiByUser, aiRateLimits } = data;
+    const summary = withDisplayVisitorMetrics(data);
     const { totals, days } = summary;
 
     const latestDay = days.length > 0 ? days[days.length - 1] : null;

--- a/tests/test-dashboard-analytics-visitors.test.ts
+++ b/tests/test-dashboard-analytics-visitors.test.ts
@@ -1,0 +1,130 @@
+#!/usr/bin/env bun
+
+import { describe, expect, test } from "bun:test";
+import { withDisplayVisitorMetrics } from "../src/apps/admin/components/dashboard-panel/deriveDashboardAnalytics";
+import type { AnalyticsDetail } from "../src/apps/admin/components/dashboard-panel/types";
+
+const baseDetail = {
+  topEndpoints: [],
+  statusCodes: [],
+  aiByUser: [],
+  aiRateLimits: [],
+} satisfies Omit<AnalyticsDetail, "summary">;
+
+describe("dashboard analytics visitor metrics", () => {
+  test("uses product analytics visitors when API visitor keys are empty", () => {
+    const summary = withDisplayVisitorMetrics({
+      ...baseDetail,
+      summary: {
+        days: [
+          {
+            date: "2026-06-18",
+            calls: 0,
+            ai: 0,
+            errors: 0,
+            uniqueVisitors: 0,
+            avgLatencyMs: 0,
+          },
+        ],
+        totals: {
+          calls: 0,
+          ai: 0,
+          errors: 0,
+          uniqueVisitors: 0,
+          avgLatencyMs: 0,
+        },
+      },
+      product: {
+        summary: {
+          days: [
+            {
+              date: "2026-06-18",
+              events: 3,
+              pageViews: 1,
+              sessions: 1,
+              appLifecycle: 1,
+              auth: 0,
+              errors: 0,
+              uniqueVisitors: 2,
+            },
+          ],
+          totals: {
+            events: 3,
+            pageViews: 1,
+            sessions: 1,
+            appLifecycle: 1,
+            auth: 0,
+            errors: 0,
+            uniqueVisitors: 2,
+          },
+        },
+        topEvents: [],
+        topApps: [],
+        categories: [],
+        sources: [],
+        topPaths: [],
+      },
+    });
+
+    expect(summary.days[0].uniqueVisitors).toBe(2);
+    expect(summary.totals.uniqueVisitors).toBe(2);
+  });
+
+  test("keeps API visitors when product analytics has no visitor signal", () => {
+    const summary = withDisplayVisitorMetrics({
+      ...baseDetail,
+      summary: {
+        days: [
+          {
+            date: "2026-06-18",
+            calls: 5,
+            ai: 1,
+            errors: 0,
+            uniqueVisitors: 4,
+            avgLatencyMs: 25,
+          },
+        ],
+        totals: {
+          calls: 5,
+          ai: 1,
+          errors: 0,
+          uniqueVisitors: 4,
+          avgLatencyMs: 25,
+        },
+      },
+      product: {
+        summary: {
+          days: [
+            {
+              date: "2026-06-18",
+              events: 0,
+              pageViews: 0,
+              sessions: 0,
+              appLifecycle: 0,
+              auth: 0,
+              errors: 0,
+              uniqueVisitors: 0,
+            },
+          ],
+          totals: {
+            events: 0,
+            pageViews: 0,
+            sessions: 0,
+            appLifecycle: 0,
+            auth: 0,
+            errors: 0,
+            uniqueVisitors: 0,
+          },
+        },
+        topEvents: [],
+        topApps: [],
+        categories: [],
+        sources: [],
+        topPaths: [],
+      },
+    });
+
+    expect(summary.days[0].uniqueVisitors).toBe(4);
+    expect(summary.totals.uniqueVisitors).toBe(4);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Show dashboard visitor metrics from the strongest available analytics visitor signal so client/product analytics visitors are not hidden when API visitor counts are empty.
- Add a regression test for API visitor counts at zero while product analytics has visitors.

### Testing
- `bun test tests/test-dashboard-analytics-visitors.test.ts tests/test-analytics-keys.test.ts tests/test-analytics-aggregation.test.ts tests/test-redis-key-migration.test.ts`
- `bun -e 'import { createRedis } from "./api/_utils/redis.ts"; import { getAnalyticsDetail } from "./api/_utils/_analytics.ts"; import { withDisplayVisitorMetrics } from "./src/apps/admin/components/dashboard-panel/deriveDashboardAnalytics.ts"; const redis=createRedis(); const detail=await getAnalyticsDetail(redis,1); const display=withDisplayVisitorMetrics(detail); console.log(JSON.stringify({ apiVisitors: detail.summary.totals.uniqueVisitors, productVisitors: detail.product.summary.totals.uniqueVisitors, displayVisitors: display.totals.uniqueVisitors, displayToday: display.days.at(-1)?.uniqueVisitors }, null, 2));'`
- `bun run build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ed847-e702-7943-b775-cf887e397f20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ed847-e702-7943-b775-cf887e397f20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

