### PR TITLE
Fix rate-limit key scheme after Redis key swap

### DIFF
--- a/api/_utils/_rate-limit.ts
+++ b/api/_utils/_rate-limit.ts
@@ -1,6 +1,7 @@
 import { createHash } from "node:crypto";
 import { createRedis } from "./redis.js";
 import { validateAuth } from "./auth/index.js";
+import { redisKeys } from "../../src/shared/redisKeys.js";
 
 // Set up Redis client
 const redis = createRedis();
@@ -21,15 +22,28 @@ function hashRateLimitIdentifier(identifier: string): string {
   return createHash("sha256").update(identifier).digest("hex");
 }
 
+const RATE_LIMIT_SCOPE_LABELS = new Set(["anon", "host", "ip", "user"]);
+
+function deriveRateLimitScope(parts: string[]): string {
+  const labels = parts
+    .map((part) => part.trim().toLowerCase())
+    .filter((part) => RATE_LIMIT_SCOPE_LABELS.has(part));
+  return labels.length > 0 ? labels.join("-") : "global";
+}
+
 function makeCanonicalRateKey(parts: string[]): string {
   if (parts.length === 0) return RATE_LIMIT_PREFIX;
-  const identifier = parts[parts.length - 1] || "global";
-  const prefixParts = parts.slice(0, -1).map(normalizeRateKeyPart);
-  return [
-    RATE_LIMIT_PREFIX,
-    ...prefixParts,
-    hashRateLimitIdentifier(identifier),
-  ].join(":");
+  const [feature = "global", window = "counter", ...identityParts] = parts;
+  const normalizedFeature = normalizeRateKeyPart(feature);
+  const normalizedWindow = normalizeRateKeyPart(window);
+  const scope = deriveRateLimitScope(identityParts);
+  const identifier = parts.join("\0");
+  return redisKeys.rate.counter(
+    normalizedFeature,
+    normalizedWindow,
+    scope,
+    hashRateLimitIdentifier(identifier)
+  );
 }
 
 // Helper function to get rate limit key for a user


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Align rate-limit Redis counters with the canonical `rate:*` registry key shape.
- Keep readable non-sensitive scope labels while hashing the full rate-limit identity tuple.
- Preserve the regression coverage that proves `rl:*` legacy cleanup no longer deletes active counters.

### Testing
- `bun test tests/test-rate-limit-keys.test.ts tests/test-rate-limit-client-ip.test.ts`
- `bun test tests/test-redis-key-migration.test.ts tests/test-redis-keys.test.ts tests/test-redis-runtime-cutover.test.ts`
- `bun run test:parse-title && bun run test:link-preview && bun run test:media`
- `bun --eval 'const ip = `10.77.${Date.now() % 200}.42`; const statuses = []; let lastBody = null; for (let i = 1; i <= 11; i += 1) { const res = await fetch("http://localhost:3000/api/link-preview", { headers: { Origin: "http://localhost:3000", "X-Forwarded-For": ip } }); statuses.push(res.status); if (i === 11) lastBody = await res.json().catch(() => null); else await res.text(); } console.log(JSON.stringify({ ip, statuses, lastBody }, null, 2));'`
- `bun run build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ed850-3eb6-73fa-8103-d31e0c6070b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ed850-3eb6-73fa-8103-d31e0c6070b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

