### PR TITLE
Fix read-only-legacy Redis key reads after canonical cutover

### DIFF
--- a/api/_utils/_analytics.ts
+++ b/api/_utils/_analytics.ts
@@ -19,6 +19,7 @@
 
 import type { Redis } from "./redis.js";
 import { redisKeys } from "../../src/shared/redisKeys.js";
+import { getAIRateLimitKey } from "./_rate-limit.js";
 
 const ANALYTICS_TTL_SECONDS = 90 * 24 * 60 * 60; // 90 days
 
@@ -816,7 +817,7 @@ export async function getAnalyticsDetail(
   if (nonAnonUsers.length > 0) {
     const rlPipe = redis.pipeline();
     for (const { username } of nonAnonUsers) {
-      rlPipe.get(`rl:ai:${username}`);
+      rlPipe.get(getAIRateLimitKey(username));
     }
     const rlResults = await rlPipe.exec();
     for (let i = 0; i < nonAnonUsers.length; i++) {

--- a/api/_utils/_rate-limit.ts
+++ b/api/_utils/_rate-limit.ts
@@ -47,7 +47,7 @@ function makeCanonicalRateKey(parts: string[]): string {
 }
 
 // Helper function to get rate limit key for a user
-const getAIRateLimitKey = (identifier: string): string => {
+export const getAIRateLimitKey = (identifier: string): string => {
   const scope = identifier.startsWith("anon:") ? "anon" : "user";
   return makeCanonicalRateKey(["ai", scope, identifier]);
 };

--- a/api/_utils/og-share.ts
+++ b/api/_utils/og-share.ts
@@ -1,5 +1,6 @@
 import { getAppPublicOrigin } from "./runtime-config.js";
 import { parseYouTubeTitleSimple } from "./parse-youtube-title.js";
+import { redisKeys } from "../../src/shared/redisKeys.js";
 
 // App display names for OG titles
 const APP_NAMES: Record<string, string> = {
@@ -276,9 +277,12 @@ async function getSongFromRedis(
     const redis = await createSongRedisClient();
     if (!redis) return null;
 
-    // Fetch from song:meta:{id} (split storage format)
-    const metaKey = `song:meta:${songId}`;
-    const raw = await redis.get(metaKey);
+    // Fetch song metadata (split storage format). Read the canonical
+    // `media:song:…:meta` key first, falling back to the legacy `song:meta:{id}`
+    // key for songs persisted before the canonical Redis-key cutover.
+    const raw =
+      (await redis.get(redisKeys.media.songMeta(songId))) ??
+      (await redis.get(`song:meta:${songId}`));
     return getSongShareMetadataFromRaw(raw);
   } catch {
     return null;

--- a/api/rooms/_helpers/_presence.ts
+++ b/api/rooms/_helpers/_presence.ts
@@ -41,9 +41,17 @@ async function attachPrivateRoomLastMessageAt<T extends Room>(
 
   const redis = getRedis();
   const lastMessages = await Promise.all(
-    privateRooms.map((room) =>
-      redis.lindex(`${CHAT_MESSAGES_PREFIX}${room.id}`, 0)
-    )
+    privateRooms.map(async (room) => {
+      // Newest message is at index 0 (messages are LPUSH-ed). Read the
+      // canonical key first, falling back to the legacy key for rooms whose
+      // messages were written before the canonical cutover.
+      const canonical = await redis.lindex(
+        redisKeys.chat.roomMessages(room.id),
+        0
+      );
+      if (canonical !== null && canonical !== undefined) return canonical;
+      return redis.lindex(`${CHAT_MESSAGES_PREFIX}${room.id}`, 0);
+    })
   );
   const lastMessageAtByRoomId = new Map<string, number>();
 

--- a/tests/fake-redis.ts
+++ b/tests/fake-redis.ts
@@ -396,6 +396,13 @@ export class FakeRedis {
     return (this.lists.get(key) || []).length;
   }
 
+  async lindex<T = unknown>(key: string, index: number): Promise<T | null> {
+    const list = this.lists.get(key) || [];
+    const normalizedIndex = index < 0 ? list.length + index : index;
+    if (normalizedIndex < 0 || normalizedIndex >= list.length) return null;
+    return list[normalizedIndex] as T;
+  }
+
   async lrem(key: string, count: number, value: string): Promise<number> {
     const list = this.lists.get(key) || [];
     if (list.length === 0 || count === 0) return 0;

--- a/tests/test-analytics-keys.test.ts
+++ b/tests/test-analytics-keys.test.ts
@@ -5,6 +5,7 @@ import {
   getAnalyticsSummary,
   recordAnalyticsEvent,
 } from "../api/_utils/_analytics";
+import { getAIRateLimitKey } from "../api/_utils/_rate-limit";
 import { FakeRedis } from "./fake-redis";
 
 describe("analytics Redis keys", () => {
@@ -119,5 +120,24 @@ describe("analytics Redis keys", () => {
       { username: "ryo", count: 3 },
       { username: "anonymous", count: 1 },
     ]);
+  });
+
+  test("reads AI rate-limit counts from the canonical key the writer uses", async () => {
+    const fake = new FakeRedis();
+    const redis = fake as unknown as Redis;
+    const today = new Date().toISOString().slice(0, 10);
+
+    // Activity attributed to "alice" in the AI-by-user breakdown.
+    await redis.hset(`analytics:api:aiu:${today}`, { alice: "4" });
+    // The runtime counter lives under the canonical `rate:` key, NOT `rl:ai:*`.
+    const counterKey = getAIRateLimitKey("alice");
+    expect(counterKey.startsWith("rate:")).toBe(true);
+    await redis.set(counterKey, "9");
+    // A stale legacy key must NOT be what the reader picks up.
+    await redis.set("rl:ai:alice", "999");
+
+    const detail = await getAnalyticsDetail(redis, 1);
+    const alice = detail.aiRateLimits.find((r) => r.identifier === "alice");
+    expect(alice).toMatchObject({ currentCount: 9, limit: 15, windowLabel: "5h" });
   });
 });

--- a/tests/test-og-share-song-key-cutover.test.ts
+++ b/tests/test-og-share-song-key-cutover.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { redisKeys } from "../src/shared/redisKeys";
+import { FakeRedis } from "./fake-redis";
+
+let fake: FakeRedis;
+
+// og-share resolves song metadata through `createRedis()` from this module
+// (dynamically imported inside createSongRedisClient). Point it at a fake so we
+// exercise the real getSongFromRedis key-reading logic.
+mock.module("../api/_utils/redis.js", () => ({
+  createRedis: () => fake,
+}));
+
+let ogShare: typeof import("../api/_utils/og-share");
+
+const ORIGINAL_ENV = { ...process.env };
+
+beforeEach(async () => {
+  fake = new FakeRedis();
+  process.env.APP_PUBLIC_ORIGIN = "https://os.example.com";
+  ogShare = await import("../api/_utils/og-share");
+});
+
+afterEach(() => {
+  for (const key of Object.keys(process.env)) {
+    if (!(key in ORIGINAL_ENV)) delete process.env[key];
+  }
+  for (const [key, value] of Object.entries(ORIGINAL_ENV)) {
+    process.env[key] = value;
+  }
+});
+
+describe("og share song-key canonical cutover", () => {
+  test("reads song metadata from the canonical media:song key", async () => {
+    const songId = "abc123DEF45";
+    await fake.set(
+      redisKeys.media.songMeta(songId),
+      JSON.stringify({
+        title: "Canonical Song",
+        artist: "Canonical Artist",
+        cover: "https://example.com/canonical.jpg",
+      })
+    );
+    // A YouTube oEmbed fetch would indicate the canonical read missed.
+    const fetchMock = mock(() => {
+      throw new Error("should not fall back to YouTube when canonical exists");
+    });
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+    try {
+      const response = await ogShare.createOgShareResponse(
+        new Request(`https://os.example.com/ipod/${songId}`)
+      );
+      const body = await response!.text();
+      expect(body).toContain(
+        '<meta property="og:title" content="Canonical Song - Canonical Artist">'
+      );
+      expect(body).toContain(
+        '<meta property="og:image" content="https://example.com/canonical.jpg">'
+      );
+      expect(fetchMock).not.toHaveBeenCalled();
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("falls back to the legacy song:meta key for pre-cutover songs", async () => {
+    const songId = "am:1616228595";
+    await fake.set(
+      `song:meta:${songId}`,
+      JSON.stringify({
+        title: "Legacy Song",
+        artist: "Legacy Artist",
+        cover: "https://example.com/legacy.jpg",
+      })
+    );
+
+    const response = await ogShare.createOgShareResponse(
+      new Request("https://os.example.com/karaoke/am%3A1616228595")
+    );
+    const body = await response!.text();
+    expect(body).toContain(
+      '<meta property="og:title" content="Sing Legacy Song - Legacy Artist on ryOS">'
+    );
+    expect(body).toContain(
+      '<meta property="og:image" content="https://example.com/legacy.jpg">'
+    );
+  });
+});

--- a/tests/test-private-room-last-message-cutover.test.ts
+++ b/tests/test-private-room-last-message-cutover.test.ts
@@ -1,0 +1,75 @@
+import { beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import { redisKeys } from "../src/shared/redisKeys";
+import { FakeRedis } from "./fake-redis";
+
+let fake: FakeRedis;
+
+// Presence helpers resolve their client through createRedis() in this module.
+mock.module("../api/_utils/redis.js", () => ({
+  createRedis: () => fake,
+}));
+
+let presence: typeof import("../api/rooms/_helpers/_presence");
+
+beforeAll(async () => {
+  presence = await import("../api/rooms/_helpers/_presence");
+});
+
+beforeEach(() => {
+  fake = new FakeRedis();
+});
+
+async function seedPrivateRoom(roomId: string): Promise<void> {
+  await fake.sadd(redisKeys.chat.roomIds(), roomId);
+  await fake.set(
+    redisKeys.chat.roomMeta(roomId),
+    JSON.stringify({
+      id: roomId,
+      name: "@me, @bob",
+      type: "private",
+      members: ["me", "bob"],
+      createdAt: 1_000,
+    })
+  );
+}
+
+describe("private room lastMessageAt canonical cutover", () => {
+  test("derives lastMessageAt from the canonical messages list", async () => {
+    const roomId = "me-bob";
+    await seedPrivateRoom(roomId);
+    // Newest message lives at index 0 of the canonical list (LPUSH order).
+    await fake.lpush(
+      redisKeys.chat.roomMessages(roomId),
+      JSON.stringify({
+        id: "m1",
+        roomId,
+        username: "bob",
+        content: "hi",
+        timestamp: 7_000,
+      })
+    );
+
+    const rooms = await presence.getDetailedRooms();
+    const room = rooms.find((r) => r.id === roomId);
+    expect(room?.lastMessageAt).toBe(7_000);
+  });
+
+  test("falls back to the legacy messages list for pre-cutover rooms", async () => {
+    const roomId = "me-carol";
+    await seedPrivateRoom(roomId);
+    await fake.lpush(
+      `chat:messages:${roomId}`,
+      JSON.stringify({
+        id: "m2",
+        roomId,
+        username: "carol",
+        content: "yo",
+        timestamp: 4_200,
+      })
+    );
+
+    const rooms = await presence.getDetailedRooms();
+    const room = rooms.find((r) => r.id === roomId);
+    expect(room?.lastMessageAt).toBe(4_200);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What & why

During the canonical Redis-key migration, runtime **writes** were cut over to the canonical `redisKeys.*` scheme and legacy writes were stopped. Correct readers should read the **canonical** key first and fall back to the legacy key. This PR fixes three readers that still queried **only** the legacy key, so they returned stale/empty data for anything written after the cutover.

### 1. Admin AI rate-limit panel (the original report)
- The AI rate-limit counter writer emits canonical keys (`rate:ai:user:global:<sha256>` / `rate:ai:anon:global:<sha256>`); it no longer writes `rl:ai:*`.
- `getAnalyticsDetail` in `api/_utils/_analytics.ts` still read the legacy `rl:ai:<username>` key → dashboard AI counts were stale/zero.
- Fix: export `getAIRateLimitKey()` and reuse it in the reader so read and write keys match.

### 2. Song share OG previews
- `getSongFromRedis` in `api/_utils/og-share.ts` read only the legacy `song:meta:<id>` key, but the song service now writes canonical `media:song:<id>:meta` (and stopped writing legacy). Songs saved after the cutover produced no OG title/cover (Apple Music `am:` shares fell through to the generic fallback).
- Fix: read `redisKeys.media.songMeta(id)` first, fall back to `song:meta:<id>`.

### 3. Private room `lastMessageAt`
- `attachPrivateRoomLastMessageAt` in `api/rooms/_helpers/_presence.ts` read only the legacy `chat:messages:<room>` list, but messages are now written to canonical `chat:rooms:<room>:messages`. Private room listings lost `lastMessageAt` ordering for post-cutover messages.
- Fix: read the canonical list (index 0) first, fall back to the legacy list — mirroring `getLastMessage` in `_redis.ts`.

## Audit
I audited all runtime Redis reads under `api/` and `src/` against the legacy patterns in `LEGACY_REDIS_SCAN_PATTERNS`. Everything else either dual-reads correctly (auth, rooms/messages, sync v2, song service, telegram, irc, realtime, geoip, apple artwork, applet share, cursor-agent, airdrop, presence, analytics daily/uv/ep/st/aiu) or reads legacy-only intentionally (sync v1 → v2 import/maintenance). The three above were the only read-only-legacy bugs found.

## Testing
- ✅ `bun test tests/test-analytics-keys.test.ts tests/test-rate-limit-keys.test.ts`
- ✅ `bun test tests/test-og-share-song-key-cutover.test.ts tests/test-private-room-last-message-cutover.test.ts tests/test-og-share.test.ts tests/test-chat-message-canonical-cutover.test.ts`
- ✅ `bun run test:unit` (370 pass)
- ✅ Combined run incl. `test-self-host-redis-config` after the `mock.module` files to confirm no mock leakage (48 pass)
- ✅ `bunx tsc --noEmit` (clean for touched files)

New regression tests seed the canonical key plus a decoy legacy value and assert the canonical value wins, and also assert the legacy fallback still works for pre-cutover data. Added `FakeRedis.lindex` to support the presence test.

Note: `docs/1.2-api-architecture.md` still lists `rl:ai:` as the AI prefix (now outdated) — left out of scope to keep this fix focused.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ed863-2f4d-75a6-94a7-48dceebbdc3f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ed863-2f4d-75a6-94a7-48dceebbdc3f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

