### PR TITLE
fix(admin): move Redis migration panel to bottom of view

### DIFF
--- a/src/apps/admin/components/admin-app/AdminRedisBrowserView.tsx
+++ b/src/apps/admin/components/admin-app/AdminRedisBrowserView.tsx
@@ -612,185 +612,6 @@ export function AdminRedisBrowserView({ t }: AdminRedisBrowserViewProps) {
       <div
         className={cn(
           adminToolbarClass,
-          "shrink-0 border-b border-os-separator text-[11px]",
-        )}
-      >
-        <button
-          type="button"
-          onClick={() => setIsMigrationExpanded((expanded) => !expanded)}
-          aria-expanded={isMigrationExpanded}
-          className={cn(
-            "flex w-full items-center gap-2 px-2 py-1.5 text-left transition-colors",
-            "hover:bg-black/5 os-mac-aqua-dark:hover:bg-white/8",
-          )}
-        >
-          <CaretRight
-            size={12}
-            weight="bold"
-            className={cn(
-              "shrink-0 opacity-60 transition-transform",
-              isMigrationExpanded && "rotate-90",
-            )}
-          />
-          <span className={cn(adminSectionHeaderClass, "shrink-0")}>
-            {t("apps.admin.redis.migration.label", "Migration")}
-          </span>
-          <span className="font-os-mono text-[10px] text-os-text-secondary">
-            {LEGACY_REDIS_SCAN_PATTERNS.length}{" "}
-            {t("apps.admin.redis.migration.legacyPatterns", "legacy patterns")}
-          </span>
-          {migrationStatus ? (
-            <span className="font-os-mono text-[10px] text-os-text-secondary">
-              · {migrationStatus.totalLegacyKeys}
-              {migrationStatus.truncated ? "+" : ""}{" "}
-              {t("apps.admin.redis.migration.keysSampled", "legacy sampled")}
-            </span>
-          ) : null}
-          {isMigrationRunning ? (
-            <span className="ml-auto flex items-center gap-1.5 text-[10px] text-os-text-secondary">
-              <ActivityIndicator size={12} />
-              {activeMigrationRun === "delete"
-                ? t("apps.admin.redis.migration.runningDelete", "Deleting…")
-                : activeMigrationRun === "backfill"
-                  ? t("apps.admin.redis.migration.runningBackfill", "Backfilling…")
-                  : t("apps.admin.redis.migration.runningDryRun", "Dry run…")}
-            </span>
-          ) : null}
-        </button>
-
-        {isMigrationExpanded ? (
-          <div className="space-y-2 border-t border-os-separator/60 px-2 py-2">
-            <div className="flex flex-wrap items-center gap-2">
-              <button
-                type="button"
-                onClick={() => void handleLoadMigrationStatus()}
-                disabled={isLoadingMigrationStatus || isMigrationRunning}
-                className={adminAquaIconButtonClass("secondary")}
-              >
-                {isLoadingMigrationStatus ? (
-                  <ActivityIndicator size={12} />
-                ) : (
-                  <MagnifyingGlass className={AQUA_ICON_BUTTON_ICON_CLASS} weight="bold" />
-                )}
-                <span>
-                  {isLoadingMigrationStatus
-                    ? t("apps.admin.redis.loading", "Loading...")
-                    : t("apps.admin.redis.migration.scan", "Scan legacy")}
-                </span>
-              </button>
-              <span
-                className="hidden h-5 w-px shrink-0 bg-os-separator sm:block"
-                aria-hidden
-              />
-              <button
-                type="button"
-                onClick={() => void runContinuousMigration("dry-run")}
-                disabled={isMigrationRunning}
-                className={adminAquaIconButtonClass("secondary")}
-              >
-                {activeMigrationRun === "dry-run" ? (
-                  <ActivityIndicator size={12} />
-                ) : (
-                  <Eye className={AQUA_ICON_BUTTON_ICON_CLASS} weight="bold" />
-                )}
-                <span>{t("apps.admin.redis.migration.dryRun", "Dry run")}</span>
-              </button>
-              <button
-                type="button"
-                onClick={() => void runContinuousMigration("backfill")}
-                disabled={isMigrationRunning}
-                className={adminAquaIconButtonClass("secondary")}
-              >
-                {activeMigrationRun === "backfill" ? (
-                  <ActivityIndicator size={12} />
-                ) : (
-                  <ArrowsLeftRight className={AQUA_ICON_BUTTON_ICON_CLASS} weight="bold" />
-                )}
-                <span>
-                  {activeMigrationRun === "backfill"
-                    ? t("apps.admin.redis.loading", "Loading...")
-                    : t("apps.admin.redis.migration.backfill", "Backfill all")}
-                </span>
-              </button>
-              <button
-                type="button"
-                onClick={() => setDeleteLegacyCandidate(true)}
-                disabled={isMigrationRunning}
-                className={adminAquaIconButtonClass("orange")}
-                style={DELETE_LEGACY_BUTTON_STYLE}
-              >
-                {activeMigrationRun === "delete" ? (
-                  <ActivityIndicator size={12} />
-                ) : (
-                  <Trash
-                    className={AQUA_ICON_BUTTON_ICON_CLASS}
-                    style={DELETE_LEGACY_BUTTON_STYLE}
-                    weight="bold"
-                  />
-                )}
-                <span style={DELETE_LEGACY_BUTTON_STYLE}>
-                  {activeMigrationRun === "delete"
-                    ? t("apps.admin.redis.loading", "Loading...")
-                    : t("apps.admin.redis.migration.deleteLegacy", "Delete all legacy")}
-                </span>
-              </button>
-              <button
-                type="button"
-                onClick={handleStopMigration}
-                disabled={!isMigrationRunning}
-                className={adminAquaIconButtonClass("secondary")}
-              >
-                <Stop className={AQUA_ICON_BUTTON_ICON_CLASS} weight="bold" />
-                <span>{t("apps.admin.redis.migration.stop", "Stop")}</span>
-              </button>
-            </div>
-
-            {migrationLog.length > 0 ? (
-              <StickToBottom
-                className="max-h-28 overflow-hidden rounded border border-os-separator bg-black/5 font-os-mono text-[10px] leading-relaxed os-mac-aqua-dark:bg-white/10"
-                resize="smooth"
-                initial="instant"
-              >
-                <StickToBottom.Content className="px-2 py-1.5">
-                  <div className="mb-1 flex items-center justify-between gap-2">
-                    <span className={adminSectionLabelClass}>
-                      {t("apps.admin.redis.migration.log", "Migration log")}
-                    </span>
-                    {!isMigrationRunning ? (
-                      <button
-                        type="button"
-                        onClick={() => setMigrationLog([])}
-                        className={adminAquaIconButtonClass("secondary", "sm")}
-                      >
-                        <span>{t("apps.admin.redis.migration.clearLog", "Clear")}</span>
-                      </button>
-                    ) : null}
-                  </div>
-                  {migrationLog.map((entry) => (
-                    <div
-                      key={entry.id}
-                      className={cn(
-                        entry.tone === "success" &&
-                          "text-green-700 os-mac-aqua-dark:text-green-300",
-                        entry.tone === "warning" &&
-                          "text-yellow-700 os-mac-aqua-dark:text-yellow-300",
-                        entry.tone === "error" &&
-                          "text-red-700 os-mac-aqua-dark:text-red-300",
-                      )}
-                    >
-                      {entry.message}
-                    </div>
-                  ))}
-                </StickToBottom.Content>
-              </StickToBottom>
-            ) : null}
-          </div>
-        ) : null}
-      </div>
-
-      <div
-        className={cn(
-          adminToolbarClass,
           "flex h-8 shrink-0 items-center gap-2 border-b border-os-separator px-2",
         )}
       >
@@ -1014,6 +835,185 @@ export function AdminRedisBrowserView({ t }: AdminRedisBrowserViewProps) {
               </div>
             )}
           </aside>
+        ) : null}
+      </div>
+
+      <div
+        className={cn(
+          adminToolbarClass,
+          "shrink-0 border-t border-os-separator text-[11px]",
+        )}
+      >
+        <button
+          type="button"
+          onClick={() => setIsMigrationExpanded((expanded) => !expanded)}
+          aria-expanded={isMigrationExpanded}
+          className={cn(
+            "flex w-full items-center gap-2 px-2 py-1.5 text-left transition-colors",
+            "hover:bg-black/5 os-mac-aqua-dark:hover:bg-white/8",
+          )}
+        >
+          <CaretRight
+            size={12}
+            weight="bold"
+            className={cn(
+              "shrink-0 opacity-60 transition-transform",
+              isMigrationExpanded && "rotate-90",
+            )}
+          />
+          <span className={cn(adminSectionHeaderClass, "shrink-0")}>
+            {t("apps.admin.redis.migration.label", "Migration")}
+          </span>
+          <span className="font-os-mono text-[10px] text-os-text-secondary">
+            {LEGACY_REDIS_SCAN_PATTERNS.length}{" "}
+            {t("apps.admin.redis.migration.legacyPatterns", "legacy patterns")}
+          </span>
+          {migrationStatus ? (
+            <span className="font-os-mono text-[10px] text-os-text-secondary">
+              · {migrationStatus.totalLegacyKeys}
+              {migrationStatus.truncated ? "+" : ""}{" "}
+              {t("apps.admin.redis.migration.keysSampled", "legacy sampled")}
+            </span>
+          ) : null}
+          {isMigrationRunning ? (
+            <span className="ml-auto flex items-center gap-1.5 text-[10px] text-os-text-secondary">
+              <ActivityIndicator size={12} />
+              {activeMigrationRun === "delete"
+                ? t("apps.admin.redis.migration.runningDelete", "Deleting…")
+                : activeMigrationRun === "backfill"
+                  ? t("apps.admin.redis.migration.runningBackfill", "Backfilling…")
+                  : t("apps.admin.redis.migration.runningDryRun", "Dry run…")}
+            </span>
+          ) : null}
+        </button>
+
+        {isMigrationExpanded ? (
+          <div className="space-y-2 border-t border-os-separator/60 px-2 py-2">
+            <div className="flex flex-wrap items-center gap-2">
+              <button
+                type="button"
+                onClick={() => void handleLoadMigrationStatus()}
+                disabled={isLoadingMigrationStatus || isMigrationRunning}
+                className={adminAquaIconButtonClass("secondary")}
+              >
+                {isLoadingMigrationStatus ? (
+                  <ActivityIndicator size={12} />
+                ) : (
+                  <MagnifyingGlass className={AQUA_ICON_BUTTON_ICON_CLASS} weight="bold" />
+                )}
+                <span>
+                  {isLoadingMigrationStatus
+                    ? t("apps.admin.redis.loading", "Loading...")
+                    : t("apps.admin.redis.migration.scan", "Scan legacy")}
+                </span>
+              </button>
+              <span
+                className="hidden h-5 w-px shrink-0 bg-os-separator sm:block"
+                aria-hidden
+              />
+              <button
+                type="button"
+                onClick={() => void runContinuousMigration("dry-run")}
+                disabled={isMigrationRunning}
+                className={adminAquaIconButtonClass("secondary")}
+              >
+                {activeMigrationRun === "dry-run" ? (
+                  <ActivityIndicator size={12} />
+                ) : (
+                  <Eye className={AQUA_ICON_BUTTON_ICON_CLASS} weight="bold" />
+                )}
+                <span>{t("apps.admin.redis.migration.dryRun", "Dry run")}</span>
+              </button>
+              <button
+                type="button"
+                onClick={() => void runContinuousMigration("backfill")}
+                disabled={isMigrationRunning}
+                className={adminAquaIconButtonClass("secondary")}
+              >
+                {activeMigrationRun === "backfill" ? (
+                  <ActivityIndicator size={12} />
+                ) : (
+                  <ArrowsLeftRight className={AQUA_ICON_BUTTON_ICON_CLASS} weight="bold" />
+                )}
+                <span>
+                  {activeMigrationRun === "backfill"
+                    ? t("apps.admin.redis.loading", "Loading...")
+                    : t("apps.admin.redis.migration.backfill", "Backfill all")}
+                </span>
+              </button>
+              <button
+                type="button"
+                onClick={() => setDeleteLegacyCandidate(true)}
+                disabled={isMigrationRunning}
+                className={adminAquaIconButtonClass("orange")}
+                style={DELETE_LEGACY_BUTTON_STYLE}
+              >
+                {activeMigrationRun === "delete" ? (
+                  <ActivityIndicator size={12} />
+                ) : (
+                  <Trash
+                    className={AQUA_ICON_BUTTON_ICON_CLASS}
+                    style={DELETE_LEGACY_BUTTON_STYLE}
+                    weight="bold"
+                  />
+                )}
+                <span style={DELETE_LEGACY_BUTTON_STYLE}>
+                  {activeMigrationRun === "delete"
+                    ? t("apps.admin.redis.loading", "Loading...")
+                    : t("apps.admin.redis.migration.deleteLegacy", "Delete all legacy")}
+                </span>
+              </button>
+              <button
+                type="button"
+                onClick={handleStopMigration}
+                disabled={!isMigrationRunning}
+                className={adminAquaIconButtonClass("secondary")}
+              >
+                <Stop className={AQUA_ICON_BUTTON_ICON_CLASS} weight="bold" />
+                <span>{t("apps.admin.redis.migration.stop", "Stop")}</span>
+              </button>
+            </div>
+
+            {migrationLog.length > 0 ? (
+              <StickToBottom
+                className="max-h-28 overflow-hidden rounded border border-os-separator bg-black/5 font-os-mono text-[10px] leading-relaxed os-mac-aqua-dark:bg-white/10"
+                resize="smooth"
+                initial="instant"
+              >
+                <StickToBottom.Content className="px-2 py-1.5">
+                  <div className="mb-1 flex items-center justify-between gap-2">
+                    <span className={adminSectionLabelClass}>
+                      {t("apps.admin.redis.migration.log", "Migration log")}
+                    </span>
+                    {!isMigrationRunning ? (
+                      <button
+                        type="button"
+                        onClick={() => setMigrationLog([])}
+                        className={adminAquaIconButtonClass("secondary", "sm")}
+                      >
+                        <span>{t("apps.admin.redis.migration.clearLog", "Clear")}</span>
+                      </button>
+                    ) : null}
+                  </div>
+                  {migrationLog.map((entry) => (
+                    <div
+                      key={entry.id}
+                      className={cn(
+                        entry.tone === "success" &&
+                          "text-green-700 os-mac-aqua-dark:text-green-300",
+                        entry.tone === "warning" &&
+                          "text-yellow-700 os-mac-aqua-dark:text-yellow-300",
+                        entry.tone === "error" &&
+                          "text-red-700 os-mac-aqua-dark:text-red-300",
+                      )}
+                    >
+                      {entry.message}
+                    </div>
+                  ))}
+                </StickToBottom.Content>
+              </StickToBottom>
+            ) : null}
+          </div>
         ) : null}
       </div>
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Moves the collapsible Redis migration panel from the top of the Admin Redis browser to the **bottom of the view**, directly above the Admin status bar.

Layout is now:
1. Search / backup / refresh toolbar
2. Breadcrumbs
3. Key browser grid (main content)
4. Migration panel (collapsed by default)
5. Admin status bar ("Redis Browser" / logged-in user)

## Screenshots

![Migration panel at bottom (collapsed)](https://cursor.com/artifacts/c/art-02368199-6ca9-48f3-8585-06ab040905cd)

![Migration panel expanded above status bar](https://cursor.com/artifacts/c/art-fcfaf5a9-7ce7-4496-a8d5-fa725632ac90)

## Testing

- `bun run build` — passes
- Manual Admin → Redis: migration header sits above status bar; key table has top priority
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ed85b-73b3-7d58-acdd-b920259c8144"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ed85b-73b3-7d58-acdd-b920259c8144"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

