### PR TITLE
fix(chats): remove black bottom border on mobile sidebar overlay

### DIFF
--- a/src/components/shared/osThemePrimitives.ts
+++ b/src/components/shared/osThemePrimitives.ts
@@ -173,7 +173,7 @@ export function osAppSidebarSurfaceClassName(
   return cn(
     "os-app-sidebar flex flex-col font-geneva-12 text-[12px]",
     isMacOSTheme && isAquaGlass ? "bg-transparent" : surfaceClassName,
-    layout === "overlay" && "os-app-sidebar--overlay w-full border-b",
+    layout === "overlay" && "os-app-sidebar--overlay w-full",
     layout === "side" && "w-56 border-r h-full overflow-hidden",
     layout === "responsive" && "w-full border-b md:border-r md:border-b-0",
     borderColorClass,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The Chats app's **mobile sidebar dropdown overlay** (shown when the window is narrow and you tap the room title) rendered a dark horizontal border line along its bottom edge, which looked out of place against the dimmed backdrop below.

This was caused by the `overlay` layout branch in `osAppSidebarSurfaceClassName` always applying `border-b` together with the theme border color (e.g. `border-black/10` in classic Aqua). The `overlay` layout is used **only** by the Chats mobile sidebar, so dropping the bottom border is safe and does not affect the `side` / `responsive` sidebars used by Admin and Soundboard.

## Change
- `src/components/shared/osThemePrimitives.ts`: remove `border-b` from the `layout === "overlay"` class list.

## Before / After (classic macOS Aqua, narrow Chats window)

| Before | After |
| --- | --- |
| ![Before - dark border at bottom of mobile sidebar overlay](https://cursor.com/artifacts/c/art-9fdf2208-c070-4a50-9d8c-9a639f7d1d9c) | ![After - border removed](https://cursor.com/artifacts/c/art-fa4a76d0-c9ef-4f63-ac2b-3ef60e434b5c) |

## Testing
- `bun test tests/test-os-theme-primitives.test.ts` — 8 pass.
- `npx eslint src/components/shared/osThemePrimitives.ts` — clean.
- Reproduced in-browser via Playwright in both glass and classic Aqua themes; confirmed the overlay surface's computed `border-bottom-width` goes from `1px` to `0px` and the dark line is gone.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ed88f-5fec-7c2c-9283-b4eabd69f6de"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ed88f-5fec-7c2c-9283-b4eabd69f6de"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

