### PR TITLE
Hide desktop download prompt on mobile + release 1.0.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ryos",
   "private": true,
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "A web-based desktop operating system, reimagining classic Mac OS, Windows, and more.",
   "author": "Ryo Lu <me@ryo.lu> (https://ryo.lu)",
   "homepage": "https://os.ryo.lu",

--- a/src/components/dialogs/AboutFinderDialog.tsx
+++ b/src/components/dialogs/AboutFinderDialog.tsx
@@ -16,7 +16,10 @@ import { ThemedIcon } from "@/components/shared/ThemedIcon";
 import { getTranslatedAppName } from "@/utils/i18n";
 import type { AppId } from "@/config/appRegistry";
 import { abortableFetch } from "@/utils/abortableFetch";
-import { getDesktopDownloadUrl } from "@/utils/desktopDownload";
+import {
+  getDesktopDownloadUrl,
+  getSupportedDesktopDownloadTarget,
+} from "@/utils/desktopDownload";
 
 interface AboutFinderDialogProps {
   isOpen: boolean;
@@ -42,19 +45,21 @@ export function AboutFinderDialog({
   const buildTime = useAppStore((state) => state.ryOSBuildTime);
   const [versionDisplayMode, setVersionDisplayMode] = useState(0); // 0: version, 1: commit, 2: date
   const [desktopVersion, setDesktopVersion] = useState<string | null>(null);
-  const isMac = useMemo(() => 
-    typeof navigator !== 'undefined' && navigator.platform.toLowerCase().includes('mac'), 
+  // Only offer the Mac desktop download on actual Mac browsers. This relies on
+  // the shared detector so mobile devices (iPad/iPhone) are excluded too.
+  const isMac = useMemo(
+    () => getSupportedDesktopDownloadTarget()?.platform === "mac",
     []
   );
   const desktopDownloadUrl = useMemo(
     () =>
-      desktopVersion
+      desktopVersion && isMac
         ? getDesktopDownloadUrl(desktopVersion, {
             platform: "mac",
             arch: "aarch64",
           })
         : null,
-    [desktopVersion]
+    [desktopVersion, isMac]
   );
 
   // Fetch desktop version for download link

--- a/src/utils/desktopDownload.ts
+++ b/src/utils/desktopDownload.ts
@@ -13,6 +13,7 @@ export interface DesktopDownloadRuntimeInfo {
   platform?: string | null;
   userAgent?: string | null;
   desktopPlatform?: string | null;
+  maxTouchPoints?: number | null;
 }
 
 export interface SupportedDesktopDownloadTarget extends DesktopDownloadOptions {
@@ -31,6 +32,7 @@ function getDesktopDownloadRuntimeInfo(): DesktopDownloadRuntimeInfo {
       typeof window === "undefined"
         ? null
         : window.ryosDesktop?.platform ?? null,
+    maxTouchPoints: nav?.maxTouchPoints ?? null,
   };
 }
 
@@ -42,9 +44,44 @@ function hasMacSignal(values: Array<string | null | undefined>): boolean {
   return values.some((value) => /darwin|mac/i.test(value ?? ""));
 }
 
+// Phones/tablets can't run the Mac/Windows desktop build, yet their browsers
+// still trip the Mac signal (iPhone UA contains "like Mac OS X", iPadOS reports
+// as "Macintosh"). Treat those as mobile so we never offer a desktop download.
+function isMobileRuntime(runtimeInfo: DesktopDownloadRuntimeInfo): boolean {
+  // Running inside the native desktop shell is never mobile.
+  if (runtimeInfo.desktopPlatform) {
+    return false;
+  }
+
+  const values = [runtimeInfo.platform, runtimeInfo.userAgent];
+
+  if (
+    values.some((value) =>
+      /iphone|ipad|ipod|android|blackberry|iemobile|opera mini|mobile|windows phone|kindle|silk/i.test(
+        value ?? ""
+      )
+    )
+  ) {
+    return true;
+  }
+
+  // iPadOS 13+ presents a desktop ("Macintosh") UA but still exposes touch
+  // points, which a real Mac does not.
+  const maxTouchPoints = runtimeInfo.maxTouchPoints ?? 0;
+  if (maxTouchPoints > 1 && hasMacSignal(values)) {
+    return true;
+  }
+
+  return false;
+}
+
 export function getSupportedDesktopDownloadTarget(
   runtimeInfo: DesktopDownloadRuntimeInfo = getDesktopDownloadRuntimeInfo()
 ): SupportedDesktopDownloadTarget | null {
+  if (isMobileRuntime(runtimeInfo)) {
+    return null;
+  }
+
   const values = [
     runtimeInfo.desktopPlatform,
     runtimeInfo.platform,

--- a/tests/test-desktop-download.test.ts
+++ b/tests/test-desktop-download.test.ts
@@ -9,17 +9,17 @@ import {
 describe("desktop download URLs", () => {
   test("uses the desktop release tag for macOS Apple Silicon DMGs", () => {
     expect(
-      getDesktopDownloadUrl("1.0.4", { platform: "mac", arch: "aarch64" })
+      getDesktopDownloadUrl("1.0.5", { platform: "mac", arch: "aarch64" })
     ).toBe(
-      "https://github.com/ryokun6/ryos/releases/download/desktop/ryOS_1.0.4_aarch64.dmg"
+      "https://github.com/ryokun6/ryos/releases/download/desktop/ryOS_1.0.5_aarch64.dmg"
     );
   });
 
   test("uses the desktop release tag for Windows x64 installers", () => {
     expect(
-      getDesktopDownloadUrl("1.0.4", { platform: "windows", arch: "x64" })
+      getDesktopDownloadUrl("1.0.5", { platform: "windows", arch: "x64" })
     ).toBe(
-      "https://github.com/ryokun6/ryos/releases/download/desktop/ryOS_1.0.4_x64.exe"
+      "https://github.com/ryokun6/ryos/releases/download/desktop/ryOS_1.0.5_x64.exe"
     );
   });
 
@@ -31,8 +31,8 @@ describe("desktop download URLs", () => {
       arch: "aarch64",
       platformLabel: "Mac",
     });
-    expect(target && getDesktopDownloadUrl("1.0.4", target)).toBe(
-      "https://github.com/ryokun6/ryos/releases/download/desktop/ryOS_1.0.4_aarch64.dmg"
+    expect(target && getDesktopDownloadUrl("1.0.5", target)).toBe(
+      "https://github.com/ryokun6/ryos/releases/download/desktop/ryOS_1.0.5_aarch64.dmg"
     );
   });
 
@@ -50,10 +50,67 @@ describe("desktop download URLs", () => {
         arch: "x64",
         platformLabel: "Windows",
       });
-      expect(target && getDesktopDownloadUrl("1.0.4", target)).toBe(
-        "https://github.com/ryokun6/ryos/releases/download/desktop/ryOS_1.0.4_x64.exe"
+      expect(target && getDesktopDownloadUrl("1.0.5", target)).toBe(
+        "https://github.com/ryokun6/ryos/releases/download/desktop/ryOS_1.0.5_x64.exe"
       );
     }
+  });
+
+  test("does not offer a desktop download on mobile browsers", () => {
+    const mobileRuntimes: Array<{
+      label: string;
+      runtime: Parameters<typeof getSupportedDesktopDownloadTarget>[0];
+    }> = [
+      {
+        label: "iPhone Safari (UA contains 'like Mac OS X')",
+        runtime: {
+          platform: "iPhone",
+          userAgent:
+            "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1",
+          maxTouchPoints: 5,
+        },
+      },
+      {
+        label: "iPadOS Safari masquerading as Macintosh",
+        runtime: {
+          platform: "MacIntel",
+          userAgent:
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15",
+          maxTouchPoints: 5,
+        },
+      },
+      {
+        label: "Android Chrome",
+        runtime: {
+          platform: "Linux armv8l",
+          userAgent:
+            "Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Mobile Safari/537.36",
+          maxTouchPoints: 5,
+        },
+      },
+    ];
+
+    for (const { label, runtime } of mobileRuntimes) {
+      expect(getSupportedDesktopDownloadTarget(runtime), label).toBeNull();
+    }
+  });
+
+  test("still offers a desktop download for non-touch Mac and Windows browsers", () => {
+    expect(
+      getSupportedDesktopDownloadTarget({
+        platform: "MacIntel",
+        userAgent:
+          "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15",
+        maxTouchPoints: 0,
+      })?.platform
+    ).toBe("mac");
+    expect(
+      getSupportedDesktopDownloadTarget({
+        platform: "Win32",
+        userAgent: "Mozilla/5.0 (Windows NT 10.0; Win64; x64)",
+        maxTouchPoints: 0,
+      })?.platform
+    ).toBe("windows");
   });
 
   test("preserves package-derived versions without hardcoding a release", () => {
@@ -66,13 +123,13 @@ describe("desktop download URLs", () => {
 
   test("returns no asset for unsupported platforms or architectures", () => {
     expect(
-      getDesktopDownloadAssetName("1.0.4", { platform: "mac", arch: "x64" })
+      getDesktopDownloadAssetName("1.0.5", { platform: "mac", arch: "x64" })
     ).toBeNull();
     expect(
-      getDesktopDownloadUrl("1.0.4", { platform: "windows", arch: "arm64" })
+      getDesktopDownloadUrl("1.0.5", { platform: "windows", arch: "arm64" })
     ).toBeNull();
     expect(
-      getDesktopDownloadUrl("1.0.4", { platform: "linux", arch: "x64" })
+      getDesktopDownloadUrl("1.0.5", { platform: "linux", arch: "x64" })
     ).toBeNull();
     expect(getSupportedDesktopDownloadTarget({ platform: "Linux x86_64" })).toBeNull();
   });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What & why

The "ryOS is available as a Mac/Windows app" download prompt (and the About-dialog download link) was appearing on **mobile** devices, which can't run the desktop build.

**Root cause:** `getSupportedDesktopDownloadTarget()` keys off platform/UA signals, but mobile browsers trip the Mac signal:
- iPhone Safari's UA contains `like Mac OS X`
- iPadOS 13+ reports itself as `Macintosh`

So a Mac target was returned and the download toast fired on phones/tablets.

## Changes

- `src/utils/desktopDownload.ts`: add an `isMobileRuntime()` guard. It returns `null` (no desktop target) when:
  - the UA/platform matches common mobile patterns (`iphone|ipad|ipod|android|mobile|…`), or
  - the device reports `maxTouchPoints > 1` alongside a Mac signal (the iPadOS-masquerading-as-Mac case).
  - The native Electron shell (`window.ryosDesktop`) is always treated as non-mobile.
- `src/components/dialogs/AboutFinderDialog.tsx`: route the "Download Mac App" link through the same detector so it's also hidden on mobile (e.g. iPad).
- `package.json`: bump desktop version `1.0.4` → `1.0.5`.
- `tests/test-desktop-download.test.ts`: bump fixtures to `1.0.5` and add coverage for iPhone / iPadOS / Android (no target) and non-touch Mac/Windows (still offered).

## Release 1.0.5

`package.json` is the canonical desktop semver; `bun run build`/`prebuild` propagates it into the generated `public/version.json` (`desktopVersion: "1.0.5"`). Tagging `v1.0.5` triggers `.github/workflows/build-electron.yml` to publish the desktop artifacts.

## Testing

- `bun test tests/test-desktop-download.test.ts` — 8 pass (incl. new mobile cases)
- `bunx tsc -b` — clean
- Verified `bun run scripts/generate-build-version.ts` emits `desktopVersion: "1.0.5"`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ed9b3-9393-734f-9441-add60f4123ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ed9b3-9393-734f-9441-add60f4123ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

