### PR TITLE
refactor(theme): rename isXpTheme → isWindowsTheme, isMacOsxTheme → isMacOSTheme

### DIFF
--- a/.cursor/skills/create-ryos-app/SKILL.md
+++ b/.cursor/skills/create-ryos-app/SKILL.md
@@ -78,7 +78,7 @@ export function [AppName]AppComponent({
     setIsHelpDialogOpen,
     isAboutDialogOpen,
     setIsAboutDialogOpen,
-    isXpTheme,
+    isWindowsTheme,
   } = use[AppName]Logic({ isWindowOpen, isForeground, instanceId });
 
   const menuBar = (
@@ -93,7 +93,7 @@ export function [AppName]AppComponent({
 
   return (
     <>
-      {!isXpTheme && isForeground && menuBar}
+      {!isWindowsTheme && isForeground && menuBar}
       <WindowFrame
         title={t("apps.[app-name].title")}
         onClose={onClose}
@@ -101,7 +101,7 @@ export function [AppName]AppComponent({
         appId="[app-name]"
         skipInitialSound={skipInitialSound}
         instanceId={instanceId}
-        menuBar={isXpTheme ? menuBar : undefined}
+        menuBar={isWindowsTheme ? menuBar : undefined}
       >
         <div className="flex flex-col h-full bg-os-window-bg font-os-ui">
           {/* App content */}
@@ -137,7 +137,7 @@ export function use[AppName]Logic({ instanceId }: { instanceId: string }) {
   const { t } = useTranslation();
   const translatedHelpItems = useTranslatedHelpItems("[app-name]", helpItems);
   const currentTheme = useThemeStore((state) => state.current);
-  const isXpTheme = currentTheme === "xp" || currentTheme === "win98";
+  const isWindowsTheme = currentTheme === "xp" || currentTheme === "win98";
 
   const [isHelpDialogOpen, setIsHelpDialogOpen] = useState(false);
   const [isAboutDialogOpen, setIsAboutDialogOpen] = useState(false);
@@ -145,7 +145,7 @@ export function use[AppName]Logic({ instanceId }: { instanceId: string }) {
   return {
     t,
     translatedHelpItems,
-    isXpTheme,
+    isWindowsTheme,
     isHelpDialogOpen,
     setIsHelpDialogOpen,
     isAboutDialogOpen,
@@ -158,7 +158,7 @@ export function use[AppName]Logic({ instanceId }: { instanceId: string }) {
 
 Match existing app menubars: structure, classes, and spacing.
 
-- **Wrapper**: `<MenuBar inWindowFrame={isXpTheme}>` — no extra gap between menus (layout uses `space-x-0`).
+- **Wrapper**: `<MenuBar inWindowFrame={isWindowsTheme}>` — no extra gap between menus (layout uses `space-x-0`).
 - **Trigger**: `MenubarTrigger className="text-md px-2 py-1 border-none focus-visible:ring-0"`.
 - **Content**: `MenubarContent align="start" sideOffset={1} className="px-0"`.
 - **Items**: `MenubarItem className="text-md h-6 px-3"`.
@@ -185,11 +185,11 @@ interface [AppName]MenuBarProps {
 export function [AppName]MenuBar({ onClose, onShowHelp, onShowAbout }: [AppName]MenuBarProps) {
   const { t } = useTranslation();
   const currentTheme = useThemeStore((state) => state.current);
-  const isXpTheme = currentTheme === "xp" || currentTheme === "win98";
-  const isMacOsxTheme = currentTheme === "macosx";
+  const isWindowsTheme = currentTheme === "xp" || currentTheme === "win98";
+  const isMacOSTheme = currentTheme === "macosx";
 
   return (
-    <MenuBar inWindowFrame={isXpTheme}>
+    <MenuBar inWindowFrame={isWindowsTheme}>
       <MenubarMenu>
         <MenubarTrigger className="text-md px-2 py-1 border-none focus-visible:ring-0">
           {t("common.menu.file")}
@@ -209,7 +209,7 @@ export function [AppName]MenuBar({ onClose, onShowHelp, onShowAbout }: [AppName]
           <MenubarItem onClick={onShowHelp} className="text-md h-6 px-3">
             {t("apps.[app-name].menu.help")}
           </MenubarItem>
-          {!isMacOsxTheme && (
+          {!isMacOSTheme && (
             <>
               <MenubarSeparator className="h-[2px] bg-black my-1" />
               <MenubarItem onClick={onShowAbout} className="text-md h-6 px-3">
@@ -270,11 +270,11 @@ const Lazy[AppName]App = createLazyComponent<unknown>(
 - **XP/Win98**: Pass via `menuBar` prop to WindowFrame
 
 ```tsx
-const isXpTheme = currentTheme === "xp" || currentTheme === "win98";
+const isWindowsTheme = currentTheme === "xp" || currentTheme === "win98";
 return (
   <>
-    {!isXpTheme && isForeground && menuBar}
-    <WindowFrame menuBar={isXpTheme ? menuBar : undefined}>
+    {!isWindowsTheme && isForeground && menuBar}
+    <WindowFrame menuBar={isWindowsTheme ? menuBar : undefined}>
 ```
 
 ## WindowFrame Options

--- a/docs/3.3-theme-system.md
+++ b/docs/3.3-theme-system.md
@@ -287,14 +287,14 @@ import { useThemeStore } from "@/stores/useThemeStore";
 
 function MyComponent() {
   const currentTheme = useThemeStore((state) => state.current);
-  const isXpTheme = currentTheme === "xp" || currentTheme === "win98";
+  const isWindowsTheme = currentTheme === "xp" || currentTheme === "win98";
   const isMacTheme = currentTheme === "macosx";
 
   if (isMacTheme) {
     return <AquaButton>Click me</AquaButton>;
   }
   
-  if (isXpTheme) {
+  if (isWindowsTheme) {
     return <button className="button">Click me</button>;
   }
   

--- a/docs/3.5-component-architecture.md
+++ b/docs/3.5-component-architecture.md
@@ -274,7 +274,7 @@ interface PlaybackBarsProps {
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
   ({ className, variant, ...props }, ref) => {
     const currentTheme = useThemeStore((state) => state.current);
-    const isXpTheme = currentTheme === "xp" || currentTheme === "win98";
+    const isWindowsTheme = currentTheme === "xp" || currentTheme === "win98";
     const isMacTheme = currentTheme === "macosx";
 
     // macOS Aqua styling
@@ -283,7 +283,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
     }
     
     // Windows styling
-    if (isXpTheme && variant === "default") {
+    if (isWindowsTheme && variant === "default") {
       return <Comp className={cn("button", className)} {...props} />;
     }
     
@@ -465,14 +465,14 @@ interface LinkPreviewProps {
 ```typescript
 function MyComponent() {
   const currentTheme = useThemeStore((state) => state.current);
-  const isXpTheme = currentTheme === "xp" || currentTheme === "win98";
+  const isWindowsTheme = currentTheme === "xp" || currentTheme === "win98";
   const isMacTheme = currentTheme === "macosx";
 
   return (
     <div className={cn(
       "base-styles",
       isMacTheme && "mac-specific-styles",
-      isXpTheme && "windows-specific-styles",
+      isWindowsTheme && "windows-specific-styles",
     )}>
       {/* content */}
     </div>
@@ -547,7 +547,7 @@ function InteractiveButton({ onClick, children }) {
     <DialogHeader>
       {title}
     </DialogHeader>
-    <div className={isXpTheme ? "window-body" : "p-6"}>
+    <div className={isWindowsTheme ? "window-body" : "p-6"}>
       {content}
     </div>
     <DialogFooter>

--- a/public/docs/component-architecture.html
+++ b/public/docs/component-architecture.html
@@ -486,7 +486,7 @@
 <pre><code>const Button = React.forwardRef&lt;HTMLButtonElement, ButtonProps&gt;(
   ({ className, variant, ...props }, ref) =&gt; {
     const currentTheme = useThemeStore((state) =&gt; state.current);
-    const isXpTheme = currentTheme === "xp" || currentTheme === "win98";
+    const isWindowsTheme = currentTheme === "xp" || currentTheme === "win98";
     const isMacTheme = currentTheme === "macosx";
 
     // macOS Aqua styling
@@ -495,7 +495,7 @@
     }
     
     // Windows styling
-    if (isXpTheme &amp;&amp; variant === "default") {
+    if (isWindowsTheme &amp;&amp; variant === "default") {
       return &lt;Comp className={cn("button", className)} {...props} /&gt;;
     }
     
@@ -606,14 +606,14 @@
 <h3>Standard Pattern</h3>
 <pre><code>function MyComponent() {
   const currentTheme = useThemeStore((state) =&gt; state.current);
-  const isXpTheme = currentTheme === "xp" || currentTheme === "win98";
+  const isWindowsTheme = currentTheme === "xp" || currentTheme === "win98";
   const isMacTheme = currentTheme === "macosx";
 
   return (
     &lt;div className={cn(
       "base-styles",
       isMacTheme &amp;&amp; "mac-specific-styles",
-      isXpTheme &amp;&amp; "windows-specific-styles",
+      isWindowsTheme &amp;&amp; "windows-specific-styles",
     )}&gt;
       {/* content */}
     &lt;/div&gt;
@@ -670,7 +670,7 @@ function InteractiveButton({ onClick, children }) {
     &lt;DialogHeader&gt;
       {title}
     &lt;/DialogHeader&gt;
-    &lt;div className={isXpTheme ? "window-body" : "p-6"}&gt;
+    &lt;div className={isWindowsTheme ? "window-body" : "p-6"}&gt;
       {content}
     &lt;/div&gt;
     &lt;DialogFooter&gt;

--- a/public/docs/theme-system.html
+++ b/public/docs/theme-system.html
@@ -501,14 +501,14 @@ export const useThemeStore = create&lt;ThemeState&gt;((set) =&gt; ({
 
 function MyComponent() {
   const currentTheme = useThemeStore((state) =&gt; state.current);
-  const isXpTheme = currentTheme === "xp" || currentTheme === "win98";
+  const isWindowsTheme = currentTheme === "xp" || currentTheme === "win98";
   const isMacTheme = currentTheme === "macosx";
 
   if (isMacTheme) {
     return &lt;AquaButton&gt;Click me&lt;/AquaButton&gt;;
   }
   
-  if (isXpTheme) {
+  if (isWindowsTheme) {
     return &lt;button className="button"&gt;Click me&lt;/button&gt;;
   }
   

--- a/src/apps/admin/components/AdminMenuBar.tsx
+++ b/src/apps/admin/components/AdminMenuBar.tsx
@@ -45,8 +45,8 @@ export function AdminMenuBar({
   const {
     isShareDialogOpen,
     setIsShareDialogOpen,
-    isXpTheme,
-    isMacOsxTheme,
+    isWindowsTheme,
+    isMacOSTheme,
     appId,
     appName,
   } = useAppMenuBarChrome("admin");
@@ -125,8 +125,8 @@ export function AdminMenuBar({
 
   return (
     <AppMenuBarShell
-      isXpTheme={isXpTheme}
-      isMacOsxTheme={isMacOsxTheme}
+      isWindowsTheme={isWindowsTheme}
+      isMacOSTheme={isMacOSTheme}
       appId={appId}
       appName={appName}
       isShareDialogOpen={isShareDialogOpen}

--- a/src/apps/admin/components/AdminPanelHeader.tsx
+++ b/src/apps/admin/components/AdminPanelHeader.tsx
@@ -10,7 +10,7 @@ export function AdminPanelHeader({
   title: string;
   actions?: ReactNode;
 }) {
-  const { isMacOSTheme: isMacOSXTheme, isWindowsTheme: isXpTheme } =
+  const { isMacOSTheme: isMacOSXTheme, isWindowsTheme } =
     useThemeFlags();
 
   return (
@@ -18,7 +18,7 @@ export function AdminPanelHeader({
       className={cn(
         adminToolbarClass,
         "flex flex-shrink-0 items-center gap-2 border-b px-2 py-1.5",
-        isXpTheme
+        isWindowsTheme
           ? "border-[#919b9c]"
           : isMacOSXTheme
             ? "border-black/10"

--- a/src/apps/admin/components/AdminSidebar.tsx
+++ b/src/apps/admin/components/AdminSidebar.tsx
@@ -60,7 +60,6 @@ export const AdminSidebar: React.FC<AdminSidebarProps> = ({
       className={osAppSidebarSurfaceClassName(
         {
           isMacOSTheme,
-          isXpTheme: isWindowsTheme,
           isWindowsTheme,
           isAquaGlass,
         },

--- a/src/apps/admin/components/CursorAgentsPanel.tsx
+++ b/src/apps/admin/components/CursorAgentsPanel.tsx
@@ -81,7 +81,7 @@ function CursorAgentsToolbar({
   refreshDisabled?: boolean;
 }) {
   const { t } = useTranslation();
-  const { isMacOSTheme: isMacOSXTheme, isWindowsTheme: isXpTheme } =
+  const { isMacOSTheme: isMacOSXTheme, isWindowsTheme } =
     useThemeFlags();
 
   const handleFormSubmit = (e: FormEvent) => {
@@ -96,7 +96,7 @@ function CursorAgentsToolbar({
         className={cn(
           adminToolbarClass,
           "flex items-center gap-2 border-b px-2 py-1.5",
-          isXpTheme
+          isWindowsTheme
             ? "border-[#919b9c]"
             : isMacOSXTheme
               ? "border-black/10"

--- a/src/apps/admin/components/admin-app/AdminAppComponent.tsx
+++ b/src/apps/admin/components/admin-app/AdminAppComponent.tsx
@@ -28,7 +28,7 @@ export function AdminAppComponent({
     isAdmin,
     isOffline,
     currentTheme,
-    isXpTheme,
+    isWindowsTheme,
     isHelpDialogOpen,
     setIsHelpDialogOpen,
     isAboutDialogOpen,
@@ -143,7 +143,7 @@ export function AdminAppComponent({
         t={t}
         username={username}
         isWindowOpen={isWindowOpen}
-        isXpTheme={isXpTheme}
+        isWindowsTheme={isWindowsTheme}
         menuBar={menuBar}
         onClose={onClose}
         isForeground={isForeground}
@@ -162,7 +162,7 @@ export function AdminAppComponent({
         t={t}
         username={username}
         isWindowOpen={isWindowOpen}
-        isXpTheme={isXpTheme}
+        isWindowsTheme={isWindowsTheme}
         menuBar={menuBar}
         onClose={onClose}
         isForeground={isForeground}
@@ -183,7 +183,7 @@ export function AdminAppComponent({
   return (
     <AppWindowShell
       isWindowOpen={isWindowOpen}
-      isXpTheme={isXpTheme}
+      isWindowsTheme={isWindowsTheme}
       isForeground={isForeground}
       menuBar={menuBar}
       windowFrameProps={{
@@ -212,7 +212,7 @@ export function AdminAppComponent({
           selectedUserProfile={selectedUserProfile}
           selectedSongId={selectedSongId}
           currentTheme={currentTheme}
-          isXpTheme={isXpTheme}
+          isWindowsTheme={isWindowsTheme}
           t={t}
           userSearch={userSearch}
           setUserSearch={setUserSearch}

--- a/src/apps/admin/components/admin-app/AdminMainPane.tsx
+++ b/src/apps/admin/components/admin-app/AdminMainPane.tsx
@@ -59,7 +59,7 @@ export interface AdminMainPaneProps {
   selectedUserProfile: string | null;
   selectedSongId: string | null;
   currentTheme: string;
-  isXpTheme: boolean;
+  isWindowsTheme: boolean;
   t: TFunction;
   userSearch: string;
   setUserSearch: (v: string) => void;
@@ -129,7 +129,7 @@ export function AdminMainPane({
   selectedUserProfile,
   selectedSongId,
   currentTheme,
-  isXpTheme,
+  isWindowsTheme,
   t,
   userSearch,
   setUserSearch,
@@ -205,7 +205,7 @@ export function AdminMainPane({
             <AdminToolbar
               t={t}
               currentTheme={currentTheme}
-              isXpTheme={isXpTheme}
+              isWindowsTheme={isWindowsTheme}
               activeSection={activeSection}
               selectedRoomId={selectedRoomId}
               selectedRoom={selectedRoom}

--- a/src/apps/admin/components/admin-app/AdminRestrictedView.tsx
+++ b/src/apps/admin/components/admin-app/AdminRestrictedView.tsx
@@ -22,7 +22,7 @@ export interface AdminRestrictedViewProps
   variant: AdminRestrictedVariant;
   t: TFunction;
   username: string | null | undefined;
-  isXpTheme: boolean;
+  isWindowsTheme: boolean;
   menuBar: ReactNode;
 }
 
@@ -31,7 +31,7 @@ export function AdminRestrictedView({
   t,
   username,
   isWindowOpen,
-  isXpTheme,
+  isWindowsTheme,
   menuBar,
   onClose,
   isForeground,
@@ -43,7 +43,7 @@ export function AdminRestrictedView({
   return (
     <AppWindowShell
       isWindowOpen={isWindowOpen}
-      isXpTheme={isXpTheme}
+      isWindowsTheme={isWindowsTheme}
       isForeground={isForeground}
       menuBar={menuBar}
       windowFrameProps={{

--- a/src/apps/admin/components/admin-app/AdminToolbar.tsx
+++ b/src/apps/admin/components/admin-app/AdminToolbar.tsx
@@ -24,7 +24,7 @@ interface RoomLite {
 interface AdminToolbarProps {
   t: TFunction;
   currentTheme: string;
-  isXpTheme: boolean;
+  isWindowsTheme: boolean;
   activeSection: AdminSection;
   selectedRoomId: string | null;
   selectedRoom: RoomLite | null;
@@ -56,7 +56,7 @@ interface AdminToolbarProps {
 export function AdminToolbar({
   t,
   currentTheme,
-  isXpTheme,
+  isWindowsTheme,
   activeSection,
   selectedRoomId,
   selectedRoom,
@@ -84,7 +84,7 @@ export function AdminToolbar({
     {
       isMacOSTheme: currentTheme === "macosx",
       isSystem7Theme: currentTheme === "system7",
-      isXpTheme,
+      isWindowsTheme,
       isWin98: currentTheme === "win98",
     },
     {

--- a/src/apps/admin/hooks/useAdminLogic.ts
+++ b/src/apps/admin/hooks/useAdminLogic.ts
@@ -199,7 +199,7 @@ export function useAdminLogic({ isWindowOpen }: UseAdminLogicProps) {
   const translatedHelpItems = useTranslatedHelpItems("admin", helpItems);
   const { username, isAuthenticated } = useAuth();
   const isOffline = useOffline();
-  const { currentTheme, isWindowsTheme: isXpTheme } = useThemeFlags();
+  const { currentTheme, isWindowsTheme } = useThemeFlags();
 
   const {
     isHelpDialogOpen,
@@ -1214,7 +1214,7 @@ export function useAdminLogic({ isWindowOpen }: UseAdminLogicProps) {
     isAdmin,
     isOffline,
     currentTheme,
-    isXpTheme,
+    isWindowsTheme,
     isHelpDialogOpen,
     setIsHelpDialogOpen,
     isAboutDialogOpen,

--- a/src/apps/applet-viewer/components/AppletViewerAppComponent.tsx
+++ b/src/apps/applet-viewer/components/AppletViewerAppComponent.tsx
@@ -30,7 +30,7 @@ export function AppletViewerAppComponent({
     setShareId,
     iframeRef,
     currentTheme,
-    isXpTheme,
+    isWindowsTheme,
     isMacTheme,
     hasAppletContent,
     htmlContent,
@@ -95,7 +95,7 @@ export function AppletViewerAppComponent({
   return (
     <AppWindowShell
       isWindowOpen={isWindowOpen}
-      isXpTheme={isXpTheme}
+      isWindowsTheme={isWindowsTheme}
       isForeground={isForeground}
       menuBar={menuBar}
       windowFrameProps={{

--- a/src/apps/applet-viewer/components/AppletViewerMenuBar.tsx
+++ b/src/apps/applet-viewer/components/AppletViewerMenuBar.tsx
@@ -62,8 +62,8 @@ export function AppletViewerMenuBar({
   const {
     isShareDialogOpen,
     setIsShareDialogOpen,
-    isXpTheme,
-    isMacOsxTheme,
+    isWindowsTheme,
+    isMacOSTheme,
     appId,
     appName,
   } = useAppMenuBarChrome("applet-viewer");
@@ -180,8 +180,8 @@ export function AppletViewerMenuBar({
 
   return (
     <AppMenuBarShell
-      isXpTheme={isXpTheme}
-      isMacOsxTheme={isMacOsxTheme}
+      isWindowsTheme={isWindowsTheme}
+      isMacOSTheme={isMacOSTheme}
       appId={appId}
       appName={appName}
       isShareDialogOpen={isShareDialogOpen}

--- a/src/apps/applet-viewer/components/app-store-feed/AppStoreFeed.tsx
+++ b/src/apps/applet-viewer/components/app-store-feed/AppStoreFeed.tsx
@@ -46,7 +46,7 @@ export function AppStoreFeed(props: UseAppStoreFeedControllerArgs) {
         cardProps={{
           isMacTheme: c.isMacTheme,
           isSystem7Theme: c.isSystem7Theme,
-          isXpTheme: c.isXpTheme,
+          isWindowsTheme: c.isWindowsTheme,
           actions: c.actions,
           t: c.t,
           scrollToIndex: c.scrollToIndex,

--- a/src/apps/applet-viewer/components/app-store-feed/AppStoreFeedCard.tsx
+++ b/src/apps/applet-viewer/components/app-store-feed/AppStoreFeedCard.tsx
@@ -17,7 +17,7 @@ export interface AppStoreFeedCardProps {
   appletsCount: number;
   isMacTheme: boolean;
   isSystem7Theme: boolean;
-  isXpTheme: boolean;
+  isWindowsTheme: boolean;
   actions: AppletActions;
   content: string | undefined;
   isLoadingContent: boolean;
@@ -35,7 +35,7 @@ export function AppStoreFeedCard({
   appletsCount,
   isMacTheme,
   isSystem7Theme,
-  isXpTheme,
+  isWindowsTheme,
   actions,
   content,
   isLoadingContent,
@@ -157,7 +157,7 @@ export function AppStoreFeedCard({
 
       <div
         className={`absolute top-0 left-0 right-0 z-10 flex items-center gap-3 px-3 py-2 ${
-          isXpTheme
+          isWindowsTheme
             ? "border-b border-[#919b9c]"
             : isMacTheme
               ? ""
@@ -167,7 +167,7 @@ export function AppStoreFeedCard({
         }`}
         style={{
           flexWrap: "nowrap",
-          background: isXpTheme ? "transparent" : undefined,
+          background: isWindowsTheme ? "transparent" : undefined,
           backgroundImage: isMacTheme
             ? "var(--os-pinstripe-window)"
             : undefined,

--- a/src/apps/applet-viewer/components/app-store-feed/useAppStoreFeedController.ts
+++ b/src/apps/applet-viewer/components/app-store-feed/useAppStoreFeedController.ts
@@ -59,7 +59,7 @@ export function useAppStoreFeedController({
 
   const isMacTheme = theme === "macosx" || osIsMac;
   const isSystem7Theme = theme === "system7" || osIsSystem7;
-  const isXpTheme = osIsXp;
+  const isWindowsTheme = osIsXp;
 
   const actions = useAppletActions();
 
@@ -281,7 +281,7 @@ export function useAppStoreFeedController({
     loadingContents,
     isMacTheme,
     isSystem7Theme,
-    isXpTheme,
+    isWindowsTheme,
     actions,
     scrollToIndex,
     handleInstall,

--- a/src/apps/applet-viewer/components/app-store/AppStoreDetailView.tsx
+++ b/src/apps/applet-viewer/components/app-store/AppStoreDetailView.tsx
@@ -18,7 +18,7 @@ export function AppStoreDetailView({ vm }: AppStoreDetailViewProps) {
     focusWindow,
     selectedApplet,
     selectedAppletContent,
-    isXpTheme,
+    isWindowsTheme,
     isMacChrome,
     isSystem7Chrome,
     isMacTheme,
@@ -43,7 +43,7 @@ export function AppStoreDetailView({ vm }: AppStoreDetailViewProps) {
       <div className="size-full flex flex-col">
         <div
           className={`flex items-center gap-3 px-3 py-2 ${
-            isXpTheme
+            isWindowsTheme
               ? "border-b border-[#919b9c]"
               : isMacChrome
                 ? ""
@@ -52,7 +52,7 @@ export function AppStoreDetailView({ vm }: AppStoreDetailViewProps) {
                   : "bg-neutral-100 border-b border-neutral-200"
           }`}
           style={{
-            background: isXpTheme ? "transparent" : undefined,
+            background: isWindowsTheme ? "transparent" : undefined,
             backgroundImage: isMacChrome ? "var(--os-pinstripe-window)" : undefined,
             borderBottom: isMacChrome
               ? `var(--os-metrics-titlebar-border-width, 1px) solid var(--os-color-titlebar-border-inactive, rgba(0, 0, 0, 0.2))`

--- a/src/apps/applet-viewer/components/app-store/AppStoreListView.tsx
+++ b/src/apps/applet-viewer/components/app-store/AppStoreListView.tsx
@@ -14,7 +14,7 @@ export function AppStoreListView({ vm }: AppStoreListViewProps) {
     searchQuery,
     setSearchQuery,
     setShowListView,
-    isXpTheme,
+    isWindowsTheme,
     isMacChrome,
     isSystem7Chrome,
     filteredApplets,
@@ -28,7 +28,7 @@ export function AppStoreListView({ vm }: AppStoreListViewProps) {
     <>
       <div
         className={`px-3 py-2 flex items-center gap-1 ${
-          isXpTheme
+          isWindowsTheme
             ? "border-b border-[#919b9c]"
             : isMacChrome
               ? ""
@@ -37,7 +37,7 @@ export function AppStoreListView({ vm }: AppStoreListViewProps) {
                 : "bg-neutral-100 border-b border-neutral-200"
         }`}
         style={{
-          background: isXpTheme ? "transparent" : undefined,
+          background: isWindowsTheme ? "transparent" : undefined,
           backgroundImage: isMacChrome ? "var(--os-pinstripe-window)" : undefined,
           borderBottom: isMacChrome
             ? `var(--os-metrics-titlebar-border-width, 1px) solid var(--os-color-titlebar-border-inactive, rgba(0, 0, 0, 0.2))`
@@ -50,7 +50,7 @@ export function AppStoreListView({ vm }: AppStoreListViewProps) {
           onChange={setSearchQuery}
           className="flex-1"
           inputClassName={
-            isXpTheme
+            isWindowsTheme
               ? "!text-[11px]"
               : isMacChrome
                 ? "!text-[12px] h-[26px] py-[2px]"

--- a/src/apps/applet-viewer/components/app-store/useAppStore.ts
+++ b/src/apps/applet-viewer/components/app-store/useAppStore.ts
@@ -50,7 +50,7 @@ export function useAppStore({ theme, sharedAppletId, focusWindow }: AppStoreProp
   const {
     isMacOSTheme: osIsMac,
     isSystem7Theme: osIsSystem7,
-    isWindowsTheme: isXpTheme,
+    isWindowsTheme,
   } = useThemeFlags();
   const isMacChrome = theme === "macosx" || osIsMac;
   const isSystem7Chrome = theme === "system7" || osIsSystem7;
@@ -456,7 +456,7 @@ export function useAppStore({ theme, sharedAppletId, focusWindow }: AppStoreProp
     setShowListView,
     isBulkUpdating,
     isAdmin,
-    isXpTheme,
+    isWindowsTheme,
     isMacChrome,
     isSystem7Chrome,
     isMacTheme,

--- a/src/apps/applet-viewer/hooks/useAppletViewerLogic.ts
+++ b/src/apps/applet-viewer/hooks/useAppletViewerLogic.ts
@@ -160,7 +160,7 @@ export function useAppletViewerLogic({
   const fileInputRef = useRef<HTMLInputElement>(null);
   const {
     currentTheme,
-    isWindowsTheme: isXpTheme,
+    isWindowsTheme,
     isMacOSTheme: isMacTheme,
   } = useThemeFlags();
   const username = useChatsStore((state) => state.username);
@@ -1579,7 +1579,7 @@ export function useAppletViewerLogic({
     setShareId,
     iframeRef,
     currentTheme,
-    isXpTheme,
+    isWindowsTheme,
     isMacTheme,
     hasAppletContent,
     htmlContent,

--- a/src/apps/base/app-manager/useAppManager.ts
+++ b/src/apps/base/app-manager/useAppManager.ts
@@ -66,7 +66,7 @@ export function useAppManager({ apps }: AppManagerProps) {
     [openInstanceIdsKey]
   );
 
-  const { isWindowsTheme: isXpTheme } = useThemeFlags();
+  const { isWindowsTheme } = useThemeFlags();
 
   const [crashedInstanceIds, setCrashedInstanceIds] = useState<Set<string>>(
     () => new Set()
@@ -77,7 +77,7 @@ export function useAppManager({ apps }: AppManagerProps) {
     ? crashedInstanceIds.has(foregroundInstanceId)
     : false;
   const showDesktopMenuBar =
-    isXpTheme || !hasForegroundApp || exposeMode || isForegroundAppCrashed;
+    isWindowsTheme || !hasForegroundApp || exposeMode || isForegroundAppCrashed;
 
   const [isInitialMount, setIsInitialMount] = useState(true);
   const [isExposeViewOpen, setIsExposeViewOpen] = useState(false);

--- a/src/apps/base/types.ts
+++ b/src/apps/base/types.ts
@@ -157,12 +157,12 @@ export type AnyInitialData =
 // For other themes, render the menu bar normally outside WindowFrame
 // Example:
 // const currentTheme = useThemeStore((state) => state.current);
-// const isXpTheme = currentTheme === "xp" || currentTheme === "win98";
+// const isWindowsTheme = currentTheme === "xp" || currentTheme === "win98";
 // const menuBar = <AppMenuBar ... />;
 // return (
 //   <>
-//     {!isXpTheme && menuBar}
-//     <WindowFrame menuBar={isXpTheme ? menuBar : undefined}>
+//     {!isWindowsTheme && menuBar}
+//     <WindowFrame menuBar={isWindowsTheme ? menuBar : undefined}>
 //       ...
 //     </WindowFrame>
 //   </>

--- a/src/apps/calendar/components/CalendarMenuBar.tsx
+++ b/src/apps/calendar/components/CalendarMenuBar.tsx
@@ -48,8 +48,8 @@ export function CalendarMenuBar({
   const {
     isShareDialogOpen,
     setIsShareDialogOpen,
-    isXpTheme,
-    isMacOsxTheme,
+    isWindowsTheme,
+    isMacOSTheme,
     appId,
     appName,
   } = useAppMenuBarChrome("calendar");
@@ -159,8 +159,8 @@ export function CalendarMenuBar({
 
   return (
     <AppMenuBarShell
-      isXpTheme={isXpTheme}
-      isMacOsxTheme={isMacOsxTheme}
+      isWindowsTheme={isWindowsTheme}
+      isMacOSTheme={isMacOSTheme}
       appId={appId}
       appName={appName}
       isShareDialogOpen={isShareDialogOpen}

--- a/src/apps/calendar/components/calendar-app/BottomToolbar.tsx
+++ b/src/apps/calendar/components/calendar-app/BottomToolbar.tsx
@@ -11,7 +11,7 @@ export function BottomToolbar({
   showTodoSidebar, onToggleTodoSidebar,
   searchQuery, onSearchQueryChange, showSearch,
   isNarrow,
-  isXpTheme, isMacOSTheme, isSystem7Theme, t,
+  isWindowsTheme, isMacOSTheme, isSystem7Theme, t,
 }: {
   view: string; onSetView: (v: "day" | "week" | "month") => void; onGoToToday: () => void; onNewEvent: () => void;
   onPrev: () => void; onNext: () => void;
@@ -20,7 +20,7 @@ export function BottomToolbar({
   showTodoSidebar: boolean; onToggleTodoSidebar: () => void;
   searchQuery: string; onSearchQueryChange: (value: string) => void; showSearch: boolean;
   isNarrow: boolean;
-  isXpTheme: boolean; isMacOSTheme: boolean; isSystem7Theme: boolean; t: (key: string) => string;
+  isWindowsTheme: boolean; isMacOSTheme: boolean; isSystem7Theme: boolean; t: (key: string) => string;
 }) {
   const views: { id: "day" | "week" | "month"; label: string }[] = [
     { id: "day", label: t("apps.calendar.views.day") },
@@ -49,7 +49,7 @@ export function BottomToolbar({
         // mb-[8px]); keep the roomier py-1.5 bottom on mobile.
         isMacOSTheme ? "px-1 md:pb-1" : "px-2",
         osToolbarSurfaceClassName(
-          { isMacOSTheme, isSystem7Theme, isXpTheme },
+          { isMacOSTheme, isSystem7Theme, isWindowsTheme },
           { border: "top" }
         )
       )}
@@ -139,7 +139,7 @@ export function BottomToolbar({
                   variant={isSystem7Theme ? "player" : "ghost"}
                   onClick={onToggleCalendarSidebar}
                   data-state={showCalendarSidebar ? "on" : "off"}
-                  className={cn("size-6", isXpTheme && "text-black")}
+                  className={cn("size-6", isWindowsTheme && "text-black")}
                   title={t("apps.calendar.sidebar.calendars")}
                 >
                   <SidebarSimple size={14} />
@@ -148,30 +148,30 @@ export function BottomToolbar({
                   variant={isSystem7Theme ? "player" : "ghost"}
                   onClick={onToggleMiniCalendar}
                   data-state={showMiniCalendar ? "on" : "off"}
-                  className={cn("size-6", isXpTheme && "text-black")}
+                  className={cn("size-6", isWindowsTheme && "text-black")}
                 >
                   <CalendarBlank size={14} />
                 </Button>
               </div>
             )}
             <Button variant={isSystem7Theme ? "player" : "ghost"} onClick={onGoToToday}
-              className={cn("h-6 w-[48px] text-[11px] px-0", isSystem7Theme && "font-geneva-12", isXpTheme && "text-black")}>
+              className={cn("h-6 w-[48px] text-[11px] px-0", isSystem7Theme && "font-geneva-12", isWindowsTheme && "text-black")}>
               {t("apps.calendar.today")}
             </Button>
             <div className="flex items-center gap-0">
               <Button variant={isSystem7Theme ? "player" : "default"} size="icon"
-                className={cn("h-[22px] w-6", isXpTheme && "text-black")} onClick={onPrev}>
+                className={cn("h-[22px] w-6", isWindowsTheme && "text-black")} onClick={onPrev}>
                 <CaretLeft size={12} weight="bold" />
               </Button>
               {views.map((v) => (
                 <Button key={v.id} variant={isSystem7Theme ? "player" : "default"}
                   data-state={view === v.id ? "on" : "off"} onClick={() => onSetView(v.id)}
-                  className={cn("h-[22px] w-[48px] px-0 text-[11px]", isSystem7Theme && "font-geneva-12", isXpTheme && "text-black")}>
+                  className={cn("h-[22px] w-[48px] px-0 text-[11px]", isSystem7Theme && "font-geneva-12", isWindowsTheme && "text-black")}>
                   {v.label}
                 </Button>
               ))}
               <Button variant={isSystem7Theme ? "player" : "default"} size="icon"
-                className={cn("h-[22px] w-6", isXpTheme && "text-black")} onClick={onNext}>
+                className={cn("h-[22px] w-6", isWindowsTheme && "text-black")} onClick={onNext}>
                 <CaretRight size={12} weight="bold" />
               </Button>
             </div>
@@ -185,12 +185,12 @@ export function BottomToolbar({
           )}
           <div className="flex items-center gap-0 shrink-0">
             <Button variant={isSystem7Theme ? "player" : "ghost"} onClick={onNewEvent}
-              className={cn("size-6", isXpTheme && "text-black")} title={t("apps.calendar.menu.newEvent")}>
+              className={cn("size-6", isWindowsTheme && "text-black")} title={t("apps.calendar.menu.newEvent")}>
               <Plus size={12} weight="bold" />
             </Button>
             <Button variant={isSystem7Theme ? "player" : "ghost"}
               onClick={onToggleTodoSidebar} data-state={showTodoSidebar ? "on" : "off"}
-              className={cn("size-6", isXpTheme && "text-black")} title={t("apps.calendar.sidebar.toDoItems")}>
+              className={cn("size-6", isWindowsTheme && "text-black")} title={t("apps.calendar.sidebar.toDoItems")}>
               <ListChecks size={12} weight="bold" />
             </Button>
           </div>

--- a/src/apps/calendar/components/calendar-app/CalendarAppComponent.tsx
+++ b/src/apps/calendar/components/calendar-app/CalendarAppComponent.tsx
@@ -46,7 +46,7 @@ export function CalendarAppComponent({
   const {
     t, translatedHelpItems,
     isHelpDialogOpen, setIsHelpDialogOpen, isAboutDialogOpen, setIsAboutDialogOpen,
-    isXpTheme, isMacOSTheme, isSystem7Theme,
+    isWindowsTheme, isMacOSTheme, isSystem7Theme,
     searchQuery, setSearchQuery,
     selectedDate, view, monthYearLabel, selectedDateLabel, calendarGrid, selectedDateEvents,
     narrowDayNames, hourLabels, weekDates, weekLabel,
@@ -243,7 +243,7 @@ export function CalendarAppComponent({
   return (
     <AppWindowShell
       isWindowOpen={isWindowOpen}
-      isXpTheme={isXpTheme}
+      isWindowsTheme={isWindowsTheme}
       isForeground={isForeground}
       menuBar={menuBar}
       windowFrameProps={{
@@ -265,7 +265,7 @@ export function CalendarAppComponent({
               calendars={calendars}
               isMacOSTheme={isMacOSTheme}
               isSystem7Theme={isSystem7Theme}
-              isXpTheme={isXpTheme}
+              isWindowsTheme={isWindowsTheme}
               onUpdateEvent={handleUpdateEvent}
               onDeleteEvent={handleDeleteEventFromTray}
               onUpdateTodo={updateTodo}
@@ -333,7 +333,7 @@ export function CalendarAppComponent({
                         selectedDate={selectedDate}
                         todayStr={logic.todayStr}
                         onDateClick={handleDateClick}
-                        isXpTheme={isXpTheme}
+                        isWindowsTheme={isWindowsTheme}
                         isMacOSTheme={isMacOSTheme}
                         isSystem7Theme={isSystem7Theme}
                         monthYearLabel={monthYearLabel}
@@ -362,7 +362,7 @@ export function CalendarAppComponent({
                       selectedDate={selectedDate}
                       todayStr={logic.todayStr}
                       onDateClick={handleDateClick}
-                      isXpTheme={isXpTheme}
+                      isWindowsTheme={isWindowsTheme}
                       isMacOSTheme={isMacOSTheme}
                       isSystem7Theme={isSystem7Theme}
                       monthYearLabel={monthYearLabel}
@@ -389,7 +389,7 @@ export function CalendarAppComponent({
                     onDateClick={handleDateClick} onTimeSlotClick={onNewEventAtTime}
                     onEventClick={(ev) => handleSelectEvent(ev.id)}
                     onEventDoubleClick={(ev) => handleSelectEvent(ev.id, { toggle: false })}
-                    isXpTheme={isXpTheme} isMacOSTheme={isMacOSTheme} isSystem7Theme={isSystem7Theme} searchQuery={normalizedSearchQuery} hourLabels={hourLabels}
+                    isWindowsTheme={isWindowsTheme} isMacOSTheme={isMacOSTheme} isSystem7Theme={isSystem7Theme} searchQuery={normalizedSearchQuery} hourLabels={hourLabels}
                     hourHeight={weekTimeGridHourHeight} setHourHeight={setWeekTimeGridHourHeight}
                     onUpdateEvent={handleUpdateEvent} />
                 )}
@@ -398,7 +398,7 @@ export function CalendarAppComponent({
                     onTimeSlotClick={onNewEventAtTime}
                     onEventClick={(ev) => handleSelectEvent(ev.id)}
                     onEventDoubleClick={(ev) => handleSelectEvent(ev.id, { toggle: false })}
-                    isXpTheme={isXpTheme} isMacOSTheme={isMacOSTheme} isSystem7Theme={isSystem7Theme} searchQuery={normalizedSearchQuery} hourLabels={hourLabels}
+                    isWindowsTheme={isWindowsTheme} isMacOSTheme={isMacOSTheme} isSystem7Theme={isSystem7Theme} searchQuery={normalizedSearchQuery} hourLabels={hourLabels}
                     hourHeight={dayTimeGridHourHeight} setHourHeight={setDayTimeGridHourHeight}
                     onUpdateEvent={handleUpdateEvent} />
                 )}
@@ -407,7 +407,7 @@ export function CalendarAppComponent({
                     onDateClick={handleDateClick} onDateDoubleClick={onDateDoubleClick}
                     onEventClick={(ev) => handleSelectEvent(ev.id)}
                     onEventDoubleClick={(ev) => handleSelectEvent(ev.id, { toggle: false })}
-                    isXpTheme={isXpTheme} searchQuery={normalizedSearchQuery} narrowDayNames={narrowDayNames} />
+                    isWindowsTheme={isWindowsTheme} searchQuery={normalizedSearchQuery} narrowDayNames={narrowDayNames} />
                 )}
               </div>
             )}
@@ -469,7 +469,7 @@ export function CalendarAppComponent({
             showTodoSidebar={showTodoSidebar} onToggleTodoSidebar={() => setShowTodoSidebar(!showTodoSidebar)}
             searchQuery={safeSearchQuery} onSearchQueryChange={setSearchQuery} showSearch={!isNarrow}
             isNarrow={isNarrow}
-            isXpTheme={isXpTheme} isMacOSTheme={isMacOSTheme} isSystem7Theme={isSystem7Theme} t={t}
+            isWindowsTheme={isWindowsTheme} isMacOSTheme={isMacOSTheme} isSystem7Theme={isSystem7Theme} t={t}
           />
         </div>
     </AppWindowShell>

--- a/src/apps/calendar/components/calendar-app/DayTimeGrid.tsx
+++ b/src/apps/calendar/components/calendar-app/DayTimeGrid.tsx
@@ -24,7 +24,7 @@ export function DayTimeGrid({
   onTimeSlotClick,
   onEventClick,
   onEventDoubleClick,
-  isXpTheme,
+  isWindowsTheme,
   isMacOSTheme,
   isSystem7Theme,
   searchQuery,
@@ -39,7 +39,7 @@ export function DayTimeGrid({
   onTimeSlotClick: (date: string, hour: number) => void;
   onEventClick: (event: CalendarEvent) => void;
   onEventDoubleClick: (event: CalendarEvent) => void;
-  isXpTheme: boolean;
+  isWindowsTheme: boolean;
   isMacOSTheme: boolean;
   isSystem7Theme: boolean;
   searchQuery: string;
@@ -159,7 +159,7 @@ export function DayTimeGrid({
                 style={{
                   top: (hour - HOUR_START) * hourHeight,
                   height: hourHeight,
-                  borderColor: isXpTheme ? "rgba(0,0,0,0.08)" : "rgba(0,0,0,0.06)",
+                  borderColor: isWindowsTheme ? "rgba(0,0,0,0.08)" : "rgba(0,0,0,0.06)",
                 }}
               />
             ))}
@@ -190,8 +190,8 @@ export function DayTimeGrid({
               return (
                 <div className="absolute left-0 right-0 pointer-events-none" style={{ top: topPos, zIndex: 5 }}>
                   <div className="flex items-center">
-                    <div className="size-2 rounded-full -ml-1 shrink-0" style={{ backgroundColor: isXpTheme ? TODAY_RED_XP : TODAY_RED }} />
-                    <div className="flex-1 h-px min-w-0" style={{ backgroundColor: isXpTheme ? TODAY_RED_XP : TODAY_RED }} />
+                    <div className="size-2 rounded-full -ml-1 shrink-0" style={{ backgroundColor: isWindowsTheme ? TODAY_RED_XP : TODAY_RED }} />
+                    <div className="flex-1 h-px min-w-0" style={{ backgroundColor: isWindowsTheme ? TODAY_RED_XP : TODAY_RED }} />
                   </div>
                 </div>
               );

--- a/src/apps/calendar/components/calendar-app/MiniCalendar.tsx
+++ b/src/apps/calendar/components/calendar-app/MiniCalendar.tsx
@@ -8,7 +8,7 @@ export function MiniCalendar({
   selectedDate,
   todayStr,
   onDateClick,
-  isXpTheme,
+  isWindowsTheme,
   isMacOSTheme,
   isSystem7Theme,
   monthYearLabel,
@@ -20,7 +20,7 @@ export function MiniCalendar({
   selectedDate: string;
   todayStr: string;
   onDateClick: (date: string) => void;
-  isXpTheme: boolean;
+  isWindowsTheme: boolean;
   isMacOSTheme: boolean;
   isSystem7Theme: boolean;
   monthYearLabel: string;
@@ -74,9 +74,9 @@ export function MiniCalendar({
                   borderRadius: "50%",
                   backgroundColor:
                     cell.date === todayStr
-                      ? isXpTheme ? TODAY_RED_XP : TODAY_RED
+                      ? isWindowsTheme ? TODAY_RED_XP : TODAY_RED
                       : cell.date === selectedDate
-                        ? isXpTheme ? "rgba(0,0,0,0.15)" : "rgba(0,0,0,0.08)"
+                        ? isWindowsTheme ? "rgba(0,0,0,0.15)" : "rgba(0,0,0,0.08)"
                         : "transparent",
                   color:
                     cell.date === todayStr

--- a/src/apps/calendar/components/calendar-app/MonthGrid.tsx
+++ b/src/apps/calendar/components/calendar-app/MonthGrid.tsx
@@ -12,10 +12,10 @@ import {
 } from "./calendarAppConstants";
 
 export function MonthGrid({
-  calendarGrid, selectedEventId, onDateClick, onDateDoubleClick, onEventClick, onEventDoubleClick, isXpTheme, searchQuery, narrowDayNames,
+  calendarGrid, selectedEventId, onDateClick, onDateDoubleClick, onEventClick, onEventDoubleClick, isWindowsTheme, searchQuery, narrowDayNames,
 }: {
   calendarGrid: CalendarDayCell[][]; selectedEventId: string | null; onDateClick: (date: string) => void; onDateDoubleClick: (date: string) => void;
-  onEventClick: (event: CalendarEvent) => void; onEventDoubleClick: (event: CalendarEvent) => void; isXpTheme: boolean; searchQuery: string; narrowDayNames: string[];
+  onEventClick: (event: CalendarEvent) => void; onEventDoubleClick: (event: CalendarEvent) => void; isWindowsTheme: boolean; searchQuery: string; narrowDayNames: string[];
 }) {
   const lastEventTapRef = useRef<{ id: string; time: number } | null>(null);
   const lastDateTapRef = useRef<{ id: string; time: number } | null>(null);
@@ -67,11 +67,11 @@ export function MonthGrid({
             {week.map((cell) => (
               <button key={cell.date} type="button" onClick={() => handleDateTap(cell.date)}
                 className="flex flex-col items-start p-0.5 min-h-[40px] relative transition-colors select-none overflow-hidden"
-                style={{ opacity: cell.isCurrentMonth ? 1 : 0.3, backgroundColor: cell.isSelected ? (isXpTheme ? "rgba(0,0,0,0.08)" : "rgba(0,0,0,0.06)") : "transparent" }}
+                style={{ opacity: cell.isCurrentMonth ? 1 : 0.3, backgroundColor: cell.isSelected ? (isWindowsTheme ? "rgba(0,0,0,0.08)" : "rgba(0,0,0,0.06)") : "transparent" }}
               >
                 <span className="text-[10px] font-medium self-end mr-0.5"
                   style={{ width: 18, height: 18, lineHeight: "18px", textAlign: "center", borderRadius: "50%", display: "inline-block",
-                    backgroundColor: cell.isToday ? (isXpTheme ? TODAY_RED_XP : TODAY_RED) : "transparent", color: cell.isToday ? "#FFF" : undefined }}
+                    backgroundColor: cell.isToday ? (isWindowsTheme ? TODAY_RED_XP : TODAY_RED) : "transparent", color: cell.isToday ? "#FFF" : undefined }}
                 >{cell.day}</span>
                 <div className="flex flex-col gap-px mt-px w-full">
                   {cell.events.slice(0, 2).map((ev) => (

--- a/src/apps/calendar/components/calendar-app/WeekTimeGrid.tsx
+++ b/src/apps/calendar/components/calendar-app/WeekTimeGrid.tsx
@@ -26,7 +26,7 @@ export function WeekTimeGrid({
   onTimeSlotClick,
   onEventClick,
   onEventDoubleClick,
-  isXpTheme,
+  isWindowsTheme,
   isMacOSTheme,
   isSystem7Theme,
   searchQuery,
@@ -41,7 +41,7 @@ export function WeekTimeGrid({
   onTimeSlotClick: (date: string, hour: number) => void;
   onEventClick: (event: CalendarEvent) => void;
   onEventDoubleClick: (event: CalendarEvent) => void;
-  isXpTheme: boolean;
+  isWindowsTheme: boolean;
   isMacOSTheme: boolean;
   isSystem7Theme: boolean;
   searchQuery: string;
@@ -135,7 +135,7 @@ export function WeekTimeGrid({
                 )}
                 style={{
                   width: 22, height: 22, lineHeight: "22px",
-                  ...(day.isToday ? { backgroundColor: isXpTheme ? TODAY_RED_XP : TODAY_RED } : {}),
+                  ...(day.isToday ? { backgroundColor: isWindowsTheme ? TODAY_RED_XP : TODAY_RED } : {}),
                 }}
               >
                 {day.dayOfMonth}
@@ -204,7 +204,7 @@ export function WeekTimeGrid({
                   dayColRefs.current[di] = el;
                 }}
                 className="flex-1 relative min-w-0"
-                style={{ borderLeft: isXpTheme ? "1px solid rgba(0,0,0,0.06)" : "1px solid rgba(0,0,0,0.04)" }}
+                style={{ borderLeft: isWindowsTheme ? "1px solid rgba(0,0,0,0.06)" : "1px solid rgba(0,0,0,0.04)" }}
               >
                 {Array.from({ length: totalHours }, (_, hourOffset) => HOUR_START + hourOffset).map((hour) => (
                   <button
@@ -215,7 +215,7 @@ export function WeekTimeGrid({
                     style={{
                       top: (hour - HOUR_START) * hourHeight,
                       height: hourHeight,
-                      borderColor: isXpTheme ? "rgba(0,0,0,0.08)" : "rgba(0,0,0,0.06)",
+                      borderColor: isWindowsTheme ? "rgba(0,0,0,0.08)" : "rgba(0,0,0,0.06)",
                     }}
                   />
                 ))}
@@ -247,8 +247,8 @@ export function WeekTimeGrid({
                   return (
                     <div className="absolute left-0 right-0 pointer-events-none" style={{ top: topPos, zIndex: 5 }}>
                       <div className="flex items-center">
-                        <div className="size-2 rounded-full -ml-1" style={{ backgroundColor: isXpTheme ? TODAY_RED_XP : TODAY_RED }} />
-                        <div className="flex-1 h-px" style={{ backgroundColor: isXpTheme ? TODAY_RED_XP : TODAY_RED }} />
+                        <div className="size-2 rounded-full -ml-1" style={{ backgroundColor: isWindowsTheme ? TODAY_RED_XP : TODAY_RED }} />
+                        <div className="flex-1 h-px" style={{ backgroundColor: isWindowsTheme ? TODAY_RED_XP : TODAY_RED }} />
                       </div>
                     </div>
                   );

--- a/src/apps/calendar/components/tray-details/EventTrayEditor.tsx
+++ b/src/apps/calendar/components/tray-details/EventTrayEditor.tsx
@@ -18,7 +18,7 @@ export function EventTrayEditor({
   useGeneva,
   isMacOSTheme,
   isSystem7Theme,
-  isXpTheme,
+  isWindowsTheme,
   locale,
   t,
   onUpdate,
@@ -123,7 +123,7 @@ export function EventTrayEditor({
   const fieldInputClass = cn(
     "w-full rounded-sm border bg-white px-1 py-0.5 text-[11px] outline-none",
     useGeneva ? "font-geneva-12 border-black/25" : "border-black/20",
-    isXpTheme && "text-black"
+    isWindowsTheme && "text-black"
   );
 
   const smallTimeClass = cn(

--- a/src/apps/calendar/components/tray-details/TodoDetails.tsx
+++ b/src/apps/calendar/components/tray-details/TodoDetails.tsx
@@ -19,7 +19,7 @@ export function TodoDetails({
   useGeneva,
   isMacOSTheme,
   isSystem7Theme,
-  isXpTheme,
+  isWindowsTheme,
   locale,
   t,
   onToggle,
@@ -73,7 +73,7 @@ export function TodoDetails({
   const fieldInputClass = cn(
     "w-full rounded-sm border bg-white px-1 py-0.5 text-[11px] outline-none",
     useGeneva ? "font-geneva-12 border-black/25" : "border-black/20",
-    isXpTheme && "text-black"
+    isWindowsTheme && "text-black"
   );
 
   // See note on EventTrayEditor.panelShell: keep scroller `pb-*` minimal and
@@ -188,7 +188,7 @@ export function TodoDetails({
               AQUA_ICON_BUTTON_PADDING_CLASS,
               "w-full min-w-0 justify-center text-[12px] leading-normal h-auto py-2",
               useGeneva && "font-geneva-12",
-              isXpTheme && "text-black"
+              isWindowsTheme && "text-black"
             )}
           >
             {todo.completed ? (

--- a/src/apps/calendar/components/tray-details/TrayDetails.tsx
+++ b/src/apps/calendar/components/tray-details/TrayDetails.tsx
@@ -10,7 +10,7 @@ export function TrayDetails({
   calendars,
   isMacOSTheme,
   isSystem7Theme,
-  isXpTheme,
+  isWindowsTheme,
   onUpdateEvent,
   onDeleteEvent,
   onUpdateTodo,
@@ -30,7 +30,7 @@ export function TrayDetails({
           useGeneva={useGeneva}
           isMacOSTheme={isMacOSTheme}
           isSystem7Theme={isSystem7Theme}
-          isXpTheme={isXpTheme}
+          isWindowsTheme={isWindowsTheme}
           locale={i18n.language}
           t={t}
           onUpdate={onUpdateEvent}
@@ -49,7 +49,7 @@ export function TrayDetails({
           useGeneva={useGeneva}
           isMacOSTheme={isMacOSTheme}
           isSystem7Theme={isSystem7Theme}
-          isXpTheme={isXpTheme}
+          isWindowsTheme={isWindowsTheme}
           locale={i18n.language}
           t={t}
           onToggle={onToggleTodo}

--- a/src/apps/calendar/components/tray-details/types.ts
+++ b/src/apps/calendar/components/tray-details/types.ts
@@ -10,7 +10,7 @@ export interface TrayDetailsProps {
   calendars: CalendarGroup[];
   isMacOSTheme: boolean;
   isSystem7Theme: boolean;
-  isXpTheme: boolean;
+  isWindowsTheme: boolean;
   onUpdateEvent: (id: string, updates: Partial<CalendarEvent>) => void;
   onDeleteEvent: (id: string) => void;
   onUpdateTodo: (
@@ -25,5 +25,5 @@ export interface TrayThemeProps {
   useGeneva: boolean;
   isMacOSTheme: boolean;
   isSystem7Theme: boolean;
-  isXpTheme: boolean;
+  isWindowsTheme: boolean;
 }

--- a/src/apps/calendar/hooks/useCalendarLogic.ts
+++ b/src/apps/calendar/hooks/useCalendarLogic.ts
@@ -52,7 +52,7 @@ export function useCalendarLogic() {
   // Theme
   const {
     currentTheme,
-    isXpTheme,
+    isWindowsTheme,
     isMacTheme,
     isMacOSTheme,
     isSystem7Theme,
@@ -589,7 +589,7 @@ export function useCalendarLogic() {
 
     // Theme
     currentTheme,
-    isXpTheme,
+    isWindowsTheme,
     isMacTheme,
     isMacOSTheme,
     isSystem7Theme,

--- a/src/apps/chats/components/ChatRoomSidebar.tsx
+++ b/src/apps/chats/components/ChatRoomSidebar.tsx
@@ -224,7 +224,6 @@ export const ChatRoomSidebar = React.memo(function ChatRoomSidebar({
       className={osAppSidebarSurfaceClassName(
         {
           isMacOSTheme,
-          isXpTheme: isWindowsTheme,
           isWindowsTheme,
           isAquaGlass,
         },

--- a/src/apps/chats/components/ChatsMenuBar.tsx
+++ b/src/apps/chats/components/ChatsMenuBar.tsx
@@ -118,8 +118,8 @@ export const ChatsMenuBar = memo(function ChatsMenuBar({
   const {
     isShareDialogOpen,
     setIsShareDialogOpen,
-    isXpTheme,
-    isMacOsxTheme,
+    isWindowsTheme,
+    isMacOSTheme,
     appId,
     appName,
   } = useAppMenuBarChrome("chats");
@@ -183,8 +183,8 @@ export const ChatsMenuBar = memo(function ChatsMenuBar({
   return (
     <>
       <AppMenuBarShell
-        isXpTheme={isXpTheme}
-        isMacOsxTheme={isMacOsxTheme}
+        isWindowsTheme={isWindowsTheme}
+        isMacOSTheme={isMacOSTheme}
         appId={appId}
         appName={appName}
         isShareDialogOpen={isShareDialogOpen}

--- a/src/apps/chats/components/chat-input/ChatInputActionButtons.tsx
+++ b/src/apps/chats/components/chat-input/ChatInputActionButtons.tsx
@@ -8,7 +8,7 @@ type Props = Pick<
   | "input"
   | "selectedImage"
   | "isMacTheme"
-  | "isXpTheme"
+  | "isWindowsTheme"
   | "isLoading"
   | "isOffline"
   | "isRecording"
@@ -18,9 +18,9 @@ type Props = Pick<
 
 export function ChatInputStopButton({
   isMacTheme,
-  isXpTheme,
+  isWindowsTheme,
   handleStopClick,
-}: Pick<Props, "isMacTheme" | "isXpTheme" | "handleStopClick">) {
+}: Pick<Props, "isMacTheme" | "isWindowsTheme" | "handleStopClick">) {
   return (
     <motion.div
       key="stop"
@@ -37,7 +37,7 @@ export function ChatInputStopButton({
         } ${
           isMacTheme
             ? "relative overflow-hidden transition-transform hover:scale-105"
-            : isXpTheme
+            : isWindowsTheme
               ? "text-black"
               : "bg-black hover:bg-black/80 text-white border-2 border-neutral-800"
         }`}
@@ -87,7 +87,7 @@ export function ChatInputStopButton({
           className={`chat-stop-glyph size-4 ${
             isMacTheme
               ? "text-black/70 relative z-10"
-              : isXpTheme
+              : isWindowsTheme
                 ? "text-black"
                 : ""
           }`}
@@ -100,10 +100,10 @@ export function ChatInputStopButton({
 
 export function ChatInputSendButton({
   isMacTheme,
-  isXpTheme,
+  isWindowsTheme,
   isLoading,
   isOffline,
-}: Pick<Props, "isMacTheme" | "isXpTheme" | "isLoading" | "isOffline">) {
+}: Pick<Props, "isMacTheme" | "isWindowsTheme" | "isLoading" | "isOffline">) {
   return (
     <motion.div
       key="send"
@@ -119,7 +119,7 @@ export function ChatInputSendButton({
         } ${
           isMacTheme
             ? "relative overflow-hidden transition-transform hover:scale-105"
-            : isXpTheme
+            : isWindowsTheme
               ? "text-black"
               : "bg-black hover:bg-black/80 text-white border-2 border-neutral-800"
         }`}
@@ -170,7 +170,7 @@ export function ChatInputSendButton({
           className={`chat-submit-glyph size-4 ${
             isMacTheme
               ? "text-black/70 relative z-10"
-              : isXpTheme
+              : isWindowsTheme
                 ? "text-black"
                 : ""
           }`}
@@ -190,7 +190,7 @@ export function ChatInputActionButtons(props: Props) {
     isRecording,
     isOffline,
     isMacTheme,
-    isXpTheme,
+    isWindowsTheme,
     handleStopClick,
   } = props;
 
@@ -198,7 +198,7 @@ export function ChatInputActionButtons(props: Props) {
     return (
       <ChatInputStopButton
         isMacTheme={isMacTheme}
-        isXpTheme={isXpTheme}
+        isWindowsTheme={isWindowsTheme}
         handleStopClick={handleStopClick}
       />
     );
@@ -208,7 +208,7 @@ export function ChatInputActionButtons(props: Props) {
     return (
       <ChatInputSendButton
         isMacTheme={isMacTheme}
-        isXpTheme={isXpTheme}
+        isWindowsTheme={isWindowsTheme}
         isLoading={isLoading}
         isOffline={isOffline}
       />

--- a/src/apps/chats/components/chat-input/ChatInputImagePreview.tsx
+++ b/src/apps/chats/components/chat-input/ChatInputImagePreview.tsx
@@ -4,7 +4,7 @@ import type { ChatInputViewModel } from "./useChatInput";
 
 type Props = Pick<
   ChatInputViewModel,
-  "t" | "selectedImage" | "isInChatRoom" | "isMacTheme" | "isXpTheme" | "handleImageClear"
+  "t" | "selectedImage" | "isInChatRoom" | "isMacTheme" | "isWindowsTheme" | "handleImageClear"
 >;
 
 export function ChatInputImagePreview({
@@ -12,7 +12,7 @@ export function ChatInputImagePreview({
   selectedImage,
   isInChatRoom,
   isMacTheme,
-  isXpTheme,
+  isWindowsTheme,
   handleImageClear,
 }: Props) {
   return (
@@ -31,7 +31,7 @@ export function ChatInputImagePreview({
               className={`relative overflow-hidden ${
                 isMacTheme
                   ? "chat-bubble macosx-link-preview rounded-[16px] bg-neutral-100"
-                  : isXpTheme
+                  : isWindowsTheme
                     ? "rounded-none border border-[#7f9db9] bg-white"
                     : "rounded-md border border-neutral-200 bg-white"
               }`}

--- a/src/apps/chats/components/chat-input/ChatInputRecordingUI.tsx
+++ b/src/apps/chats/components/chat-input/ChatInputRecordingUI.tsx
@@ -5,7 +5,7 @@ type Props = Pick<
   ChatInputViewModel,
   | "t"
   | "isMacTheme"
-  | "isXpTheme"
+  | "isWindowsTheme"
   | "waveformBars"
   | "waveformIsSilent"
 >;
@@ -13,7 +13,7 @@ type Props = Pick<
 export function ChatInputRecordingUI({
   t,
   isMacTheme,
-  isXpTheme,
+  isWindowsTheme,
   waveformBars,
   waveformIsSilent,
 }: Props) {
@@ -24,7 +24,7 @@ export function ChatInputRecordingUI({
       exit={{ opacity: 0, scale: 0.98 }}
       transition={{ duration: 0.15 }}
       className={`flex-1 relative h-9 flex items-center px-3 gap-2 ${
-        isMacTheme ? "rounded-full" : isXpTheme ? "rounded-none" : "rounded-md"
+        isMacTheme ? "rounded-full" : isWindowsTheme ? "rounded-none" : "rounded-md"
       }`}
       style={
         isMacTheme
@@ -33,7 +33,7 @@ export function ChatInputRecordingUI({
               backgroundColor: "rgba(255, 255, 255, 1)",
               boxShadow: "inset 0 1px 2px rgba(0, 0, 0, 0.1)",
             }
-          : isXpTheme
+          : isWindowsTheme
             ? {
                 border: "1px solid #7f9db9",
                 backgroundColor: "white",

--- a/src/apps/chats/components/chat-input/ChatInputView.tsx
+++ b/src/apps/chats/components/chat-input/ChatInputView.tsx
@@ -34,7 +34,7 @@ export function ChatInputView(vm: ChatInputViewModel) {
           selectedImage={vm.selectedImage}
           isInChatRoom={vm.isInChatRoom}
           isMacTheme={vm.isMacTheme}
-          isXpTheme={vm.isXpTheme}
+          isWindowsTheme={vm.isWindowsTheme}
           handleImageClear={vm.handleImageClear}
         />
 
@@ -81,7 +81,7 @@ export function ChatInputView(vm: ChatInputViewModel) {
                 key="recording-ui"
                 t={vm.t}
                 isMacTheme={vm.isMacTheme}
-                isXpTheme={vm.isXpTheme}
+                isWindowsTheme={vm.isWindowsTheme}
                 waveformBars={vm.waveformBars}
                 waveformIsSilent={vm.waveformIsSilent}
               />
@@ -116,7 +116,7 @@ export function ChatInputView(vm: ChatInputViewModel) {
               input={vm.input}
               selectedImage={vm.selectedImage}
               isMacTheme={vm.isMacTheme}
-              isXpTheme={vm.isXpTheme}
+              isWindowsTheme={vm.isWindowsTheme}
               isLoading={vm.isLoading}
               isOffline={vm.isOffline}
               isRecording={vm.isRecording}

--- a/src/apps/chats/components/chat-input/useChatInput.ts
+++ b/src/apps/chats/components/chat-input/useChatInput.ts
@@ -79,7 +79,7 @@ export function useChatInput({
   const aiModel = useAppStoreShallow((s) => s.aiModel);
   const {
     isMacOSTheme: isMacTheme,
-    isWindowsTheme: isXpTheme,
+    isWindowsTheme,
     isAquaGlass,
   } = useThemeFlags();
 
@@ -382,7 +382,7 @@ export function useChatInput({
     audioButtonRef,
     imageInputRef,
     isMacTheme,
-    isXpTheme,
+    isWindowsTheme,
     isAquaGlass,
     debugMode,
     modelDisplayName,

--- a/src/apps/chats/components/chats-app/ChatsAppComponent.tsx
+++ b/src/apps/chats/components/chats-app/ChatsAppComponent.tsx
@@ -28,7 +28,7 @@ export function ChatsAppComponent({
   });
 
   const {
-    isXpTheme,
+    isWindowsTheme,
     menuBar,
     windowTitle,
     isShaking,
@@ -38,7 +38,7 @@ export function ChatsAppComponent({
   return (
     <AppWindowShell
       isWindowOpen={isWindowOpen}
-      isXpTheme={isXpTheme}
+      isWindowsTheme={isWindowsTheme}
       isForeground={isForeground}
       menuBar={menuBar}
       windowFrameProps={{

--- a/src/apps/chats/components/chats-app/ChatsWindowContent.tsx
+++ b/src/apps/chats/components/chats-app/ChatsWindowContent.tsx
@@ -22,7 +22,7 @@ export function ChatsWindowContent({ c, isForeground }: ChatsWindowContentProps)
     isMacTheme,
     isAquaGlass,
     isDarkMode,
-    isXpTheme,
+    isWindowsTheme,
     containerRef,
     sidebarVisibleBool,
     isFrameNarrow,
@@ -353,7 +353,7 @@ export function ChatsWindowContent({ c, isForeground }: ChatsWindowContentProps)
                   <Button
                     onClick={promptSetUsername}
                     className={`w-full h-9 font-geneva-12 text-[12px] ${
-                      isXpTheme
+                      isWindowsTheme
                         ? "text-black"
                         : "bg-orange-600 text-white hover:bg-orange-700 transition-all duration-200"
                     }`}

--- a/src/apps/chats/components/chats-app/useChatsAppController.tsx
+++ b/src/apps/chats/components/chats-app/useChatsAppController.tsx
@@ -396,12 +396,12 @@ export function useChatsAppController({
   );
 
   const {
-    isWindowsTheme: isXpTheme,
+    isWindowsTheme,
     isMacOSTheme: isMacTheme,
     isAquaGlass,
     isDarkMode,
   } = useThemeFlags();
-  const isWindowsLegacyTheme = isXpTheme;
+  const isWindowsLegacyTheme = isWindowsTheme;
   const isOffline = useOffline();
   const {
     telegramLinkedAccount,
@@ -582,7 +582,7 @@ export function useChatsAppController({
 
   return {
     translatedHelpItems,
-    isXpTheme,
+    isWindowsTheme,
     isMacTheme,
     isAquaGlass,
     isDarkMode,

--- a/src/apps/chats/components/create-room-dialog/CreateRoomDialog.tsx
+++ b/src/apps/chats/components/create-room-dialog/CreateRoomDialog.tsx
@@ -14,18 +14,18 @@ export function CreateRoomDialog(props: CreateRoomDialogProps) {
   const { isOpen, onOpenChange, isAdmin } = props;
   const vm = useCreateRoomDialog(props);
   const { t, theme } = vm;
-  const { isXpTheme, isMacOSTheme } = theme;
+  const { isWindowsTheme, isMacOSTheme } = theme;
 
   return (
     <Dialog open={isOpen} onOpenChange={onOpenChange}>
       <DialogContent
         className={cn(
           "max-w-[400px] min-w-0 w-full",
-          isXpTheme && "p-0 overflow-hidden"
+          isWindowsTheme && "p-0 overflow-hidden"
         )}
-        style={isXpTheme ? { fontSize: "11px" } : undefined}
+        style={isWindowsTheme ? { fontSize: "11px" } : undefined}
       >
-        {isXpTheme ? (
+        {isWindowsTheme ? (
           <>
             <DialogHeader>
               {t("apps.chats.dialogs.newChatTitle")}

--- a/src/apps/chats/components/create-room-dialog/CreateRoomDialogContent.tsx
+++ b/src/apps/chats/components/create-room-dialog/CreateRoomDialogContent.tsx
@@ -33,7 +33,7 @@ export function CreateRoomDialogContent({ vm }: Props) {
   return (
 <div
       className={cn(
-        theme.isXpTheme ? "pt-2 pb-6 px-4" : "pt-3 pb-6 px-6",
+        theme.isWindowsTheme ? "pt-2 pb-6 px-4" : "pt-3 pb-6 px-6",
         "min-w-0 w-full max-w-full"
       )}
     >

--- a/src/apps/chats/components/create-room-dialog/CreateRoomDialogPrivateTab.tsx
+++ b/src/apps/chats/components/create-room-dialog/CreateRoomDialogPrivateTab.tsx
@@ -33,7 +33,7 @@ export function CreateRoomDialogPrivateTab(props: Props) {
     users,
     toggleUserSelection,
   } = props;
-  const { themeFont, themeFontStyle, isXpTheme } = theme;
+  const { themeFont, themeFontStyle, isWindowsTheme } = theme;
 
   return (
     <ThemedTabsContent value="private">
@@ -76,12 +76,12 @@ export function CreateRoomDialogPrivateTab(props: Props) {
                         variant="secondary"
                         className={cn(
                           "py-0.5 pl-2 pr-1 bg-neutral-100 hover:bg-neutral-200 border-neutral-300",
-                          isXpTheme
+                          isWindowsTheme
                             ? "font-['Pixelated_MS_Sans_Serif',Arial] text-[10px]"
                             : "font-geneva-12 text-[11px]"
                         )}
                         style={
-                          isXpTheme
+                          isWindowsTheme
                             ? {
                                 fontFamily:
                                   '"Pixelated MS Sans Serif", "ArkPixel", Arial',

--- a/src/apps/chats/components/create-room-dialog/types.ts
+++ b/src/apps/chats/components/create-room-dialog/types.ts
@@ -17,7 +17,6 @@ export interface CreateRoomDialogProps {
 
 export interface CreateRoomDialogTheme {
   isWindowsTheme: boolean;
-  isXpTheme: boolean;
   isMacOSTheme: boolean;
   themeFont: string;
   themeFontStyle: CSSProperties | undefined;

--- a/src/apps/chats/components/create-room-dialog/useCreateRoomDialogTheme.ts
+++ b/src/apps/chats/components/create-room-dialog/useCreateRoomDialogTheme.ts
@@ -17,8 +17,6 @@ export function useCreateRoomDialogTheme(): CreateRoomDialogTheme {
 
   return {
     isWindowsTheme,
-    // Legacy alias retained for existing dialog props.
-    isXpTheme: isWindowsTheme,
     isMacOSTheme,
     themeFont,
     themeFontStyle,

--- a/src/apps/contacts/components/ContactsMenuBar.tsx
+++ b/src/apps/contacts/components/ContactsMenuBar.tsx
@@ -31,16 +31,16 @@ export function ContactsMenuBar({
   const {
     isShareDialogOpen,
     setIsShareDialogOpen,
-    isXpTheme,
-    isMacOsxTheme,
+    isWindowsTheme,
+    isMacOSTheme,
     appId,
     appName,
   } = useAppMenuBarChrome("contacts");
 
   return (
     <AppMenuBarShell
-      isXpTheme={isXpTheme}
-      isMacOsxTheme={isMacOsxTheme}
+      isWindowsTheme={isWindowsTheme}
+      isMacOSTheme={isMacOSTheme}
       appId={appId}
       appName={appName}
       isShareDialogOpen={isShareDialogOpen}

--- a/src/apps/contacts/components/UserPicturePicker.tsx
+++ b/src/apps/contacts/components/UserPicturePicker.tsx
@@ -29,15 +29,15 @@ export function UserPicturePicker({
 }: UserPicturePickerProps) {
   const { t } = useTranslation();
   const {
-    isWindowsTheme: isXpTheme,
+    isWindowsTheme,
     isMacOSTheme: isMacTheme,
   } = useThemeFlags();
 
-  const fontClassName = isXpTheme
+  const fontClassName = isWindowsTheme
     ? "font-['Pixelated_MS_Sans_Serif',Arial] text-[11px]"
     : "font-geneva-12 text-[12px]";
 
-  const fontStyle = isXpTheme
+  const fontStyle = isWindowsTheme
     ? { fontFamily: '"Pixelated MS Sans Serif", "ArkPixel", Arial', fontSize: "11px" }
     : undefined;
 
@@ -69,7 +69,7 @@ export function UserPicturePicker({
   const title = t("apps.contacts.picturePicker.title");
 
   const dialogContent = (
-    <div className={isXpTheme ? "p-2 px-4" : "p-4 px-6"}>
+    <div className={isWindowsTheme ? "p-2 px-4" : "p-4 px-6"}>
       <div
         className="grid grid-cols-4 gap-2 overflow-y-auto pr-1"
         style={{ maxHeight: "320px" }}
@@ -142,11 +142,11 @@ export function UserPicturePicker({
   return (
     <Dialog open={isOpen} onOpenChange={onOpenChange}>
       <DialogContent
-        className={cn("max-w-[380px]", isXpTheme && "p-0 overflow-hidden")}
-        style={isXpTheme ? { fontSize: "11px" } : undefined}
+        className={cn("max-w-[380px]", isWindowsTheme && "p-0 overflow-hidden")}
+        style={isWindowsTheme ? { fontSize: "11px" } : undefined}
         onKeyDown={(e: React.KeyboardEvent) => e.stopPropagation()}
       >
-        {isXpTheme ? (
+        {isWindowsTheme ? (
           <>
             <DialogHeader>{title}</DialogHeader>
             <div className="window-body">{dialogContent}</div>

--- a/src/apps/contacts/components/contacts-app/ContactsAppComponent.tsx
+++ b/src/apps/contacts/components/contacts-app/ContactsAppComponent.tsx
@@ -19,12 +19,12 @@ export function ContactsAppComponent({
     instanceId,
   });
 
-  const { t, isXpTheme, isMacOsxTheme, menuBar } = c;
+  const { t, isWindowsTheme, isMacOSTheme, menuBar } = c;
 
   return (
     <AppWindowShell
       isWindowOpen={isWindowOpen}
-      isXpTheme={isXpTheme}
+      isWindowsTheme={isWindowsTheme}
       isForeground={isForeground}
       menuBar={menuBar}
       windowFrameProps={{
@@ -32,7 +32,7 @@ export function ContactsAppComponent({
         onClose,
         isForeground,
         appId: "contacts",
-        material: isMacOsxTheme ? "brushedmetal" : "default",
+        material: isMacOSTheme ? "brushedmetal" : "default",
         skipInitialSound,
         instanceId,
       }}

--- a/src/apps/contacts/components/contacts-app/ContactsCardPanel.tsx
+++ b/src/apps/contacts/components/contacts-app/ContactsCardPanel.tsx
@@ -15,7 +15,7 @@ type ContactsCardPanelProps = {
 export function ContactsCardPanel({ c }: ContactsCardPanelProps) {
   const {
     t,
-    isMacOsxTheme,
+    isMacOSTheme,
     selectedContact,
     contacts,
     isEditing,
@@ -31,7 +31,7 @@ export function ContactsCardPanel({ c }: ContactsCardPanelProps) {
 
   return (
     <Panel
-      bordered={isMacOsxTheme}
+      bordered={isMacOSTheme}
       className={cn(
         "flex-1 min-w-0 flex flex-col",
         isMobileLayout && "w-full max-w-none self-stretch basis-auto"

--- a/src/apps/contacts/components/contacts-app/ContactsGroupPanel.tsx
+++ b/src/apps/contacts/components/contacts-app/ContactsGroupPanel.tsx
@@ -13,7 +13,7 @@ type ContactsGroupPanelProps = {
 export function ContactsGroupPanel({ c }: ContactsGroupPanelProps) {
   const {
     t,
-    isMacOsxTheme,
+    isMacOSTheme,
     useGeneva,
     contactGroups,
     selectedGroupId,
@@ -22,16 +22,16 @@ export function ContactsGroupPanel({ c }: ContactsGroupPanelProps) {
 
   return (
     <Panel
-      bordered={isMacOsxTheme}
+      bordered={isMacOSTheme}
       className="w-[170px] shrink-0 flex flex-col min-h-0"
-      style={!isMacOsxTheme ? { borderRight: "1px solid rgba(0,0,0,0.08)" } : undefined}
+      style={!isMacOSTheme ? { borderRight: "1px solid rgba(0,0,0,0.08)" } : undefined}
     >
       <PanelHeader
         title={t("apps.contacts.groupHeaders.groups", {
           defaultValue: "Group",
         })}
         useGeneva={useGeneva}
-        bordered={isMacOsxTheme}
+        bordered={isMacOSTheme}
       />
       <div className={cn("flex-1 overflow-y-auto", useGeneva && "font-geneva-12")}>
         {contactGroups.map((group) => (

--- a/src/apps/contacts/components/contacts-app/ContactsListPanel.tsx
+++ b/src/apps/contacts/components/contacts-app/ContactsListPanel.tsx
@@ -13,7 +13,7 @@ type ContactsListPanelProps = {
 export function ContactsListPanel({ c }: ContactsListPanelProps) {
   const {
     t,
-    isMacOsxTheme,
+    isMacOSTheme,
     useGeneva,
     contacts,
     selectedContact,
@@ -26,7 +26,7 @@ export function ContactsListPanel({ c }: ContactsListPanelProps) {
 
   return (
     <Panel
-      bordered={isMacOsxTheme}
+      bordered={isMacOSTheme}
       className={cn(
         "flex flex-col min-h-0",
         isMobileLayout
@@ -38,7 +38,7 @@ export function ContactsListPanel({ c }: ContactsListPanelProps) {
             : "flex-1 min-w-0"
       )}
       style={
-        !isMacOsxTheme
+        !isMacOSTheme
           ? showCardPanel && isMobileLayout
             ? { borderBottom: "1px solid rgba(0,0,0,0.08)" }
             : showCardPanel
@@ -52,7 +52,7 @@ export function ContactsListPanel({ c }: ContactsListPanelProps) {
           defaultValue: "Name",
         })}
         useGeneva={useGeneva}
-        bordered={isMacOsxTheme}
+        bordered={isMacOSTheme}
       />
       <div className={cn("flex-1 overflow-y-auto", useGeneva && "font-geneva-12")}>
         {contacts.length === 0

--- a/src/apps/contacts/components/contacts-app/ContactsToolbar.tsx
+++ b/src/apps/contacts/components/contacts-app/ContactsToolbar.tsx
@@ -12,8 +12,8 @@ type ContactsToolbarProps = {
 export function ContactsToolbar({ c }: ContactsToolbarProps) {
   const {
     t,
-    isMacOsxTheme,
-    isXpTheme,
+    isMacOSTheme,
+    isWindowsTheme,
     isSystem7Theme,
     isMobileLayout,
     showGroupSidebar,
@@ -30,15 +30,15 @@ export function ContactsToolbar({ c }: ContactsToolbarProps) {
     <div
       className={cn(
         "flex items-center justify-between py-1.5 gap-2",
-        isMacOsxTheme ? "px-1" : "px-2",
+        isMacOSTheme ? "px-1" : "px-2",
         osToolbarSurfaceClassName({
-          isMacOSTheme: isMacOsxTheme,
+          isMacOSTheme,
           isSystem7Theme,
-          isXpTheme,
+          isWindowsTheme,
         })
       )}
     >
-      {isMacOsxTheme ? (
+      {isMacOSTheme ? (
         <>
           <div className="flex items-center gap-1.5">
             <div className="metal-inset-btn-group">
@@ -105,7 +105,7 @@ export function ContactsToolbar({ c }: ContactsToolbarProps) {
                 variant={isSystem7Theme ? "player" : "ghost"}
                 onClick={() => setShowGroupSidebar((current) => !current)}
                 data-state={showGroupSidebar && !isCardOnlyView ? "on" : "off"}
-                className={cn("size-6 px-0", isXpTheme && "text-black")}
+                className={cn("size-6 px-0", isWindowsTheme && "text-black")}
                 title={t("apps.contacts.views.toggleGroups", { defaultValue: "Toggle Groups" })}
               >
                 <SidebarSimple size={14} />
@@ -116,7 +116,7 @@ export function ContactsToolbar({ c }: ContactsToolbarProps) {
               variant={isSystem7Theme ? "player" : "ghost"}
               onClick={() => setIsCardOnlyView((current) => !current)}
               data-state={isCardOnlyView ? "on" : "off"}
-              className={cn("size-6 px-0", isXpTheme && "text-black")}
+              className={cn("size-6 px-0", isWindowsTheme && "text-black")}
               title={t("apps.contacts.views.cardOnly", { defaultValue: "Card Only" })}
             >
               <IdentificationCard size={14} />
@@ -125,7 +125,7 @@ export function ContactsToolbar({ c }: ContactsToolbarProps) {
               type="button"
               variant={isSystem7Theme ? "player" : "ghost"}
               onClick={handleCreateContactAndEdit}
-              className={cn("size-6 px-0", isXpTheme && "text-black")}
+              className={cn("size-6 px-0", isWindowsTheme && "text-black")}
               title={t("apps.contacts.menu.newContact")}
             >
               <Plus size={12} weight="bold" />
@@ -134,7 +134,7 @@ export function ContactsToolbar({ c }: ContactsToolbarProps) {
               type="button"
               variant={isSystem7Theme ? "player" : "ghost"}
               onClick={handleImport}
-              className={cn("size-6 px-0", isXpTheme && "text-black")}
+              className={cn("size-6 px-0", isWindowsTheme && "text-black")}
               title={t("apps.contacts.menu.importVCard")}
             >
               <DownloadSimple size={12} weight="bold" />

--- a/src/apps/contacts/components/contacts-app/ContactsWindowContent.tsx
+++ b/src/apps/contacts/components/contacts-app/ContactsWindowContent.tsx
@@ -10,7 +10,7 @@ type ContactsWindowContentProps = {
 };
 
 export function ContactsWindowContent({ c }: ContactsWindowContentProps) {
-  const { isMacOsxTheme, isSystem7Theme, containerRef, showGroupPanel, showListPanel, showCardPanel, isMobileLayout } =
+  const { isMacOSTheme, isSystem7Theme, containerRef, showGroupPanel, showListPanel, showCardPanel, isMobileLayout } =
     c;
 
   return (
@@ -18,7 +18,7 @@ export function ContactsWindowContent({ c }: ContactsWindowContentProps) {
       ref={containerRef}
       className={cn(
         "size-full flex flex-col font-os-ui overflow-hidden",
-        isMacOsxTheme ? "bg-transparent" : isSystem7Theme ? "bg-white" : "bg-[#efede4]"
+        isMacOSTheme ? "bg-transparent" : isSystem7Theme ? "bg-white" : "bg-[#efede4]"
       )}
     >
       <ContactsToolbar c={c} />
@@ -27,7 +27,7 @@ export function ContactsWindowContent({ c }: ContactsWindowContentProps) {
         className={cn(
           "flex-1 overflow-hidden",
           isMobileLayout ? "flex flex-col" : "flex",
-          !isMobileLayout && isMacOsxTheme && "gap-[5px]"
+          !isMobileLayout && isMacOSTheme && "gap-[5px]"
         )}
       >
         {showGroupPanel && <ContactsGroupPanel c={c} />}

--- a/src/apps/contacts/components/contacts-app/useContactsAppController.tsx
+++ b/src/apps/contacts/components/contacts-app/useContactsAppController.tsx
@@ -17,7 +17,7 @@ export function useContactsAppController({
   const logic = useContactsLogic();
   const {
     t,
-    isMacOsxTheme,
+    isMacOSTheme,
     isSystem7Theme,
     setIsHelpDialogOpen,
     setIsAboutDialogOpen,
@@ -30,7 +30,7 @@ export function useContactsAppController({
     handleImport,
   } = logic;
 
-  const useGeneva = isMacOsxTheme || isSystem7Theme;
+  const useGeneva = isMacOSTheme || isSystem7Theme;
   const mineLabel = t("apps.contacts.badges.mine", { defaultValue: "My Card" });
   const containerRef = useRef<HTMLDivElement>(null);
   const [containerWidth, setContainerWidth] = useState(820);

--- a/src/apps/contacts/hooks/useContactsLogic.ts
+++ b/src/apps/contacts/hooks/useContactsLogic.ts
@@ -24,7 +24,7 @@ interface ContactGroup {
 export function useContactsLogic() {
   const { t } = useTranslation();
   const translatedHelpItems = useTranslatedHelpItems("contacts", helpItems);
-  const { isXpTheme, isMacOSTheme, isSystem7Theme } = useThemeFlags();
+  const { isWindowsTheme, isMacOSTheme, isSystem7Theme } = useThemeFlags();
 
   const {
     isHelpDialogOpen,
@@ -244,8 +244,8 @@ export function useContactsLogic() {
   return {
     t,
     translatedHelpItems,
-    isXpTheme,
-      isMacOsxTheme: isMacOSTheme,
+    isWindowsTheme,
+      isMacOSTheme,
     isSystem7Theme,
     isHelpDialogOpen,
     setIsHelpDialogOpen,

--- a/src/apps/control-panels/components/ControlPanelsMenuBar.tsx
+++ b/src/apps/control-panels/components/ControlPanelsMenuBar.tsx
@@ -18,16 +18,16 @@ export function ControlPanelsMenuBar({
   const {
     isShareDialogOpen,
     setIsShareDialogOpen,
-    isXpTheme,
-    isMacOsxTheme,
+    isWindowsTheme,
+    isMacOSTheme,
     appId,
     appName,
   } = useAppMenuBarChrome("control-panels");
 
   return (
     <AppMenuBarShell
-      isXpTheme={isXpTheme}
-      isMacOsxTheme={isMacOsxTheme}
+      isWindowsTheme={isWindowsTheme}
+      isMacOSTheme={isMacOSTheme}
       appId={appId}
       appName={appName}
       isShareDialogOpen={isShareDialogOpen}

--- a/src/apps/control-panels/components/control-panels-app/ControlPanelsAppComponent.tsx
+++ b/src/apps/control-panels/components/control-panels-app/ControlPanelsAppComponent.tsx
@@ -87,7 +87,7 @@ export function ControlPanelsAppComponent({
     currentLanguage,
     setLanguage,
     tabStyles,
-    isXpTheme,
+    isWindowsTheme,
     isMacOSXTheme,
     isClassicMacTheme,
     isWindowsLegacyTheme,
@@ -249,7 +249,7 @@ export function ControlPanelsAppComponent({
   return (
     <AppWindowShell
       isWindowOpen={isWindowOpen}
-      isXpTheme={isXpTheme}
+      isWindowsTheme={isWindowsTheme}
       isForeground={isForeground}
       menuBar={menuBar}
       windowFrameProps={{

--- a/src/apps/control-panels/hooks/useControlPanelsLogic.ts
+++ b/src/apps/control-panels/hooks/useControlPanelsLogic.ts
@@ -290,7 +290,7 @@ export function useControlPanelsLogic({
     supportsAccent,
     accent,
     macChrome,
-    isXpTheme,
+    isWindowsTheme,
     isMacOSTheme: isMacOSXTheme,
     isMacTheme: isClassicMacTheme,
     aquaMaterial,
@@ -1415,7 +1415,7 @@ export function useControlPanelsLogic({
   };
 
   // Theme flags come from useThemeFlags() above (single source of truth).
-  const isWindowsLegacyTheme = isXpTheme;
+  const isWindowsLegacyTheme = isWindowsTheme;
 
   const tabStyles = getTabStyles(currentTheme);
   const defaultTab = initialData?.defaultTab || "appearance";
@@ -1501,7 +1501,7 @@ export function useControlPanelsLogic({
     currentLanguage,
     setLanguage,
     tabStyles,
-    isXpTheme,
+    isWindowsTheme,
     isMacOSXTheme,
     isClassicMacTheme,
     isWindowsLegacyTheme,

--- a/src/apps/dashboard/components/DashboardAppComponent.tsx
+++ b/src/apps/dashboard/components/DashboardAppComponent.tsx
@@ -256,11 +256,11 @@ const WIDGET_ICONS: Record<WidgetType, string> = {
 
 function WidgetStrip({
   onAdd,
-  isXpTheme,
+  isWindowsTheme,
   onHeightMeasured,
 }: {
   onAdd: (type: WidgetType) => void;
-  isXpTheme: boolean;
+  isWindowsTheme: boolean;
   onHeightMeasured?: (height: number) => void;
 }) {
   const { t } = useTranslation();
@@ -307,20 +307,20 @@ function WidgetStrip({
       <div
         ref={stripRef}
         style={{
-          background: isXpTheme
+          background: isWindowsTheme
             ? "linear-gradient(to bottom, rgba(200,200,200,0.95), rgba(180,180,180,0.98))"
             : "linear-gradient(180deg, #404040 0%, #353535 30%, #2a2a2a 100%)",
-          borderTop: isXpTheme
+          borderTop: isWindowsTheme
             ? "1px solid rgba(255,255,255,0.8)"
             : "1px solid rgba(255,255,255,0.15)",
-          borderBottom: isXpTheme ? undefined : "1px solid #000",
+          borderBottom: isWindowsTheme ? undefined : "1px solid #000",
           paddingBottom: "env(safe-area-inset-bottom, 0px)",
           position: "relative",
           overflow: "hidden",
         }}
       >
         {/* Perforated metal dot pattern */}
-        {!isXpTheme && (
+        {!isWindowsTheme && (
           <div
             style={{
               position: "absolute",
@@ -334,7 +334,7 @@ function WidgetStrip({
           />
         )}
         {/* Top inner highlight */}
-        {!isXpTheme && (
+        {!isWindowsTheme && (
           <div
             style={{
               position: "absolute",
@@ -378,8 +378,8 @@ function WidgetStrip({
               <span
                 className="text-[10px] font-bold text-center leading-tight max-w-[72px] truncate"
                 style={{
-                  color: isXpTheme ? "rgba(0,0,0,0.75)" : "rgba(255,255,255,0.7)",
-                  textShadow: isXpTheme ? "none" : "0 1px 3px rgba(0,0,0,0.5)",
+                  color: isWindowsTheme ? "rgba(0,0,0,0.75)" : "rgba(255,255,255,0.7)",
+                  textShadow: isWindowsTheme ? "none" : "0 1px 3px rgba(0,0,0,0.5)",
                 }}
               >
                 {w.label}
@@ -413,7 +413,7 @@ export function DashboardAppComponent({
     setIsHelpDialogOpen,
     isAboutDialogOpen,
     setIsAboutDialogOpen,
-    isXpTheme,
+    isWindowsTheme,
     widgets,
     handleAddWidget,
     removeWidget,
@@ -532,7 +532,7 @@ export function DashboardAppComponent({
       frameless
       alwaysRenderWhenClosed
       isWindowOpen={isWindowOpen}
-      isXpTheme={isXpTheme}
+      isWindowsTheme={isWindowsTheme}
       isForeground={isForeground}
       menuBar={menuBar}
       trailing={
@@ -580,7 +580,7 @@ export function DashboardAppComponent({
                 data-dashboard-scrim
                 className="absolute inset-0"
                 style={{
-                  background: isXpTheme
+                  background: isWindowsTheme
                     ? "rgba(0,0,0,0.6)"
                     : "rgba(0,0,0,0.55)",
                 }}
@@ -705,7 +705,7 @@ export function DashboardAppComponent({
                   <div data-dashboard-strip>
                     <WidgetStrip
                       onAdd={handleAddWidget}
-                      isXpTheme={isXpTheme}
+                      isWindowsTheme={isWindowsTheme}
                       onHeightMeasured={setStripHeight}
                     />
                   </div>
@@ -735,16 +735,16 @@ export function DashboardAppComponent({
                   width: 36,
                   height: 36,
                   borderRadius: "50%",
-                  background: isXpTheme
+                  background: isWindowsTheme
                     ? "rgba(255,255,255,0.85)"
                     : "linear-gradient(to bottom, rgba(60,60,60,0.7), rgba(30,30,30,0.6))",
-                  border: isXpTheme
+                  border: isWindowsTheme
                     ? "1px solid #ACA899"
                     : "1px solid rgba(255,255,255,0.12)",
-                  boxShadow: isXpTheme
+                  boxShadow: isWindowsTheme
                     ? "1px 1px 4px rgba(0,0,0,0.3)"
                     : "0 2px 8px rgba(0,0,0,0.4), inset 0 1px 0 rgba(255,255,255,0.1)",
-                  color: isXpTheme ? "#000" : "rgba(255,255,255,0.7)",
+                  color: isWindowsTheme ? "#000" : "rgba(255,255,255,0.7)",
                   zIndex: 12,
                   transition: "bottom 0.3s cubic-bezier(0.4, 0, 0.2, 1)",
                 }}

--- a/src/apps/dashboard/components/DashboardMenuBar.tsx
+++ b/src/apps/dashboard/components/DashboardMenuBar.tsx
@@ -49,8 +49,8 @@ export function DashboardMenuBar({
   const {
     isShareDialogOpen,
     setIsShareDialogOpen,
-    isXpTheme,
-    isMacOsxTheme,
+    isWindowsTheme,
+    isMacOSTheme,
     appId,
     appName,
   } = useAppMenuBarChrome("dashboard");
@@ -142,8 +142,8 @@ export function DashboardMenuBar({
 
   return (
     <AppMenuBarShell
-      isXpTheme={isXpTheme}
-      isMacOsxTheme={isMacOsxTheme}
+      isWindowsTheme={isWindowsTheme}
+      isMacOSTheme={isMacOSTheme}
       appId={appId}
       appName={appName}
       isShareDialogOpen={isShareDialogOpen}

--- a/src/apps/dashboard/hooks/useDashboardLogic.tsx
+++ b/src/apps/dashboard/hooks/useDashboardLogic.tsx
@@ -23,7 +23,7 @@ export function useDashboardLogic() {
     helpItemsWithEmojiIcons
   );
 
-  const { currentTheme, isXpTheme } = useThemeFlags();
+  const { currentTheme, isWindowsTheme } = useThemeFlags();
 
   const {
     isHelpDialogOpen,
@@ -124,7 +124,7 @@ export function useDashboardLogic() {
     t,
     translatedHelpItems,
     currentTheme,
-    isXpTheme,
+    isWindowsTheme,
     isHelpDialogOpen,
     setIsHelpDialogOpen,
     isAboutDialogOpen,

--- a/src/apps/finder/components/FileIcon.tsx
+++ b/src/apps/finder/components/FileIcon.tsx
@@ -67,7 +67,7 @@ export const FileIcon = memo(function FileIcon({
 }: FileIconProps) {
   const { t } = useTranslation();
   const { play: playClick } = useSound(Sounds.BUTTON_CLICK, 0.3);
-  const { isWinXp: isXpTheme, isWin98: isWin98Theme, isMacOSTheme: isMacOSXTheme } =
+  const { isWinXp: isWindowsTheme, isWin98: isWin98Theme, isMacOSTheme: isMacOSXTheme } =
     useThemeFlags();
   const isFinderContext = context === "finder";
   const initialState: PreviewState = {
@@ -350,7 +350,7 @@ export const FileIcon = memo(function FileIcon({
               ? ""
               : isWin98Theme
               ? "bg-white text-black"
-              : (isXpTheme || isMacOSXTheme) && !isFinderContext
+              : (isWindowsTheme || isMacOSXTheme) && !isFinderContext
               ? "bg-transparent text-white"
               : isMacOSXTheme && isFinderContext
               ? // Finder file labels (Mac OS X): transparent so the label
@@ -362,7 +362,7 @@ export const FileIcon = memo(function FileIcon({
           }`}
           data-selected={isSelected ? "true" : undefined}
           style={{
-            ...(!isSelected && (isXpTheme || isMacOSXTheme) && !isFinderContext
+            ...(!isSelected && (isWindowsTheme || isMacOSXTheme) && !isFinderContext
               ? isMacOSXTheme
                 ? {
                     textShadow:

--- a/src/apps/finder/components/FinderMenuBar.tsx
+++ b/src/apps/finder/components/FinderMenuBar.tsx
@@ -85,8 +85,8 @@ export function FinderMenuBar({
   const {
     isShareDialogOpen,
     setIsShareDialogOpen,
-    isXpTheme,
-    isMacOsxTheme,
+    isWindowsTheme,
+    isMacOSTheme,
     appId,
     appName,
   } = useAppMenuBarChrome("finder");
@@ -107,8 +107,8 @@ export function FinderMenuBar({
 
   return (
     <AppMenuBarShell
-      isXpTheme={isXpTheme}
-      isMacOsxTheme={isMacOsxTheme}
+      isWindowsTheme={isWindowsTheme}
+      isMacOSTheme={isMacOSTheme}
       appId={appId}
       appName={appName}
       isShareDialogOpen={isShareDialogOpen}
@@ -247,7 +247,7 @@ export function FinderMenuBar({
           {t("common.menu.view")}
         </MenubarTrigger>
         <MenubarContent align="start" sideOffset={1} className="px-0">
-          {isMacOsxTheme && onToggleSidebar && (
+          {isMacOSTheme && onToggleSidebar && (
             <>
               <MenubarCheckboxItem
                 checked={showSidebar}

--- a/src/apps/finder/components/file-list/useFileList.ts
+++ b/src/apps/finder/components/file-list/useFileList.ts
@@ -48,7 +48,7 @@ export function useFileList({
     end: SelectionPoint;
   } | null>(null);
   const {
-    isWindowsTheme: isXpTheme,
+    isWindowsTheme,
     isMacOSTheme: isMacOSXTheme,
   } = useThemeFlags();
 
@@ -279,12 +279,12 @@ export function useFileList({
         labelElement.style.background = "transparent";
         labelElement.style.backgroundColor = "transparent";
 
-        if (isMacOSXTheme || isXpTheme) {
+        if (isMacOSXTheme || isWindowsTheme) {
           labelElement.style.color = "white";
           if (isMacOSXTheme) {
             labelElement.style.textShadow =
               "rgba(0, 0, 0, 0.9) 0px 1px 0px, rgba(0, 0, 0, 0.85) 0px 1px 3px, rgba(0, 0, 0, 0.45) 0px 2px 3px";
-          } else if (isXpTheme) {
+          } else if (isWindowsTheme) {
             labelElement.style.textShadow = "1px 1px 2px rgba(0, 0, 0, 0.8)";
           }
         }
@@ -361,7 +361,7 @@ export function useFileList({
         document.body.removeChild(dragImage);
       }
     }, 0);
-  }, [isMacOSXTheme, isXpTheme, viewType]);
+  }, [isMacOSXTheme, isWindowsTheme, viewType]);
 
   const handleDragOver = useCallback((e: React.DragEvent<HTMLElement>, file: FileItem) => {
     if (

--- a/src/apps/finder/components/finder-app/FinderAppComponent.tsx
+++ b/src/apps/finder/components/finder-app/FinderAppComponent.tsx
@@ -103,7 +103,7 @@ export function FinderAppComponent({
     canCreateFolder,
     rootFolders,
     windowTitle,
-    isXpTheme,
+    isWindowsTheme,
     isMacOSXTheme,
     currentTheme,
     showSidebar,
@@ -208,7 +208,7 @@ export function FinderAppComponent({
   return (
     <AppWindowShell
       isWindowOpen={isWindowOpen}
-      isXpTheme={isXpTheme}
+      isWindowsTheme={isWindowsTheme}
       isForeground={isForeground}
       menuBar={menuBar}
       leading={
@@ -311,7 +311,7 @@ export function FinderAppComponent({
           }}
           legacyToolbarProps={{
             t,
-            isXpTheme,
+            isWindowsTheme,
             currentTheme,
             isAirDropView,
             currentPath,

--- a/src/apps/finder/components/finder-app/FinderLegacyToolbar.tsx
+++ b/src/apps/finder/components/finder-app/FinderLegacyToolbar.tsx
@@ -7,7 +7,7 @@ import type { TFunction } from "i18next";
 
 export interface FinderLegacyToolbarProps {
   t: TFunction;
-  isXpTheme: boolean;
+  isWindowsTheme: boolean;
   currentTheme: string;
   isAirDropView: boolean;
   currentPath: string;
@@ -28,7 +28,7 @@ export interface FinderLegacyToolbarProps {
 
 export function FinderLegacyToolbar({
   t,
-  isXpTheme,
+  isWindowsTheme,
   currentTheme,
   isAirDropView,
   currentPath,
@@ -50,14 +50,14 @@ export function FinderLegacyToolbar({
     <div
       className={cn(
         "flex flex-col gap-1 p-1",
-        isXpTheme
+        isWindowsTheme
           ? "border-b border-[#919b9c]"
           : currentTheme === "system7"
             ? "bg-neutral-100 border-b border-black"
             : "bg-neutral-100 border-b border-neutral-300"
       )}
       style={{
-        background: isXpTheme ? "transparent" : undefined,
+        background: isWindowsTheme ? "transparent" : undefined,
       }}
     >
       <div className="flex gap-2 items-center">
@@ -104,7 +104,7 @@ export function FinderLegacyToolbar({
           value={displayPath}
           onChange={handlePathInputChange}
           onKeyDown={handlePathInputKeyDown}
-          className={cn("flex-1 pl-2", isXpTheme ? "!text-[11px]" : "!text-[16px]")}
+          className={cn("flex-1 pl-2", isWindowsTheme ? "!text-[11px]" : "!text-[16px]")}
           placeholder={t("apps.finder.placeholders.enterPath")}
         />
       </div>

--- a/src/apps/finder/hooks/useFinderLogic.ts
+++ b/src/apps/finder/hooks/useFinderLogic.ts
@@ -145,7 +145,7 @@ export function useFinderLogic({
   const translatedHelpItems = useTranslatedHelpItems("finder", helpItems);
   const {
     currentTheme,
-    isWindowsTheme: isXpTheme,
+    isWindowsTheme,
     isMacOSTheme: isMacOSXTheme,
   } = useThemeFlags();
 
@@ -1619,7 +1619,7 @@ export function useFinderLogic({
     canCreateFolder,
     rootFolders,
     windowTitle,
-    isXpTheme,
+    isWindowsTheme,
     isMacOSXTheme,
     currentTheme,
 

--- a/src/apps/infinite-mac/components/InfiniteMacAppComponent.tsx
+++ b/src/apps/infinite-mac/components/InfiniteMacAppComponent.tsx
@@ -95,7 +95,7 @@ export function InfiniteMacAppComponent({
     t,
     translatedHelpItems,
     currentTheme,
-    isXpTheme,
+    isWindowsTheme,
     isHelpDialogOpen,
     setIsHelpDialogOpen,
     isAboutDialogOpen,
@@ -169,7 +169,7 @@ export function InfiniteMacAppComponent({
   return (
     <AppWindowShell
       isWindowOpen={isWindowOpen}
-      isXpTheme={isXpTheme}
+      isWindowsTheme={isWindowsTheme}
       isForeground={isForeground}
       menuBar={menuBar}
       windowFrameProps={{

--- a/src/apps/infinite-mac/components/InfiniteMacMenuBar.tsx
+++ b/src/apps/infinite-mac/components/InfiniteMacMenuBar.tsx
@@ -45,8 +45,8 @@ export function InfiniteMacMenuBar({
   const {
     isShareDialogOpen,
     setIsShareDialogOpen,
-    isXpTheme,
-    isMacOsxTheme,
+    isWindowsTheme,
+    isMacOSTheme,
     appId,
     appName,
   } = useAppMenuBarChrome("infinite-mac");
@@ -109,8 +109,8 @@ export function InfiniteMacMenuBar({
 
   return (
     <AppMenuBarShell
-      isXpTheme={isXpTheme}
-      isMacOsxTheme={isMacOsxTheme}
+      isWindowsTheme={isWindowsTheme}
+      isMacOSTheme={isMacOSTheme}
       appId={appId}
       appName={appName}
       isShareDialogOpen={isShareDialogOpen}

--- a/src/apps/infinite-mac/hooks/useInfiniteMacLogic.ts
+++ b/src/apps/infinite-mac/hooks/useInfiniteMacLogic.ts
@@ -140,7 +140,7 @@ export function useInfiniteMacLogic({
   }, [setIsPausedStore]);
 
   const { t } = useTranslation();
-  const { currentTheme, isWindowsTheme: isXpTheme } = useThemeFlags();
+  const { currentTheme, isWindowsTheme } = useThemeFlags();
   const translatedHelpItems = useTranslatedHelpItems("infinite-mac", helpItems);
   const embedUrl = selectedPreset ? buildWrapperUrl(selectedPreset, currentScale) : null;
 
@@ -393,7 +393,7 @@ export function useInfiniteMacLogic({
     t,
     translatedHelpItems,
     currentTheme,
-    isXpTheme,
+    isWindowsTheme,
     isHelpDialogOpen,
     setIsHelpDialogOpen,
     isAboutDialogOpen,

--- a/src/apps/infinite-pc/components/InfinitePcAppComponent.tsx
+++ b/src/apps/infinite-pc/components/InfinitePcAppComponent.tsx
@@ -171,7 +171,7 @@ export function InfinitePcAppComponent({
     t,
     translatedHelpItems,
     currentTheme,
-    isXpTheme,
+    isWindowsTheme,
     isHelpDialogOpen,
     setIsHelpDialogOpen,
     isAboutDialogOpen,
@@ -300,7 +300,7 @@ export function InfinitePcAppComponent({
   return (
     <AppWindowShell
       isWindowOpen={isWindowOpen}
-      isXpTheme={isXpTheme}
+      isWindowsTheme={isWindowsTheme}
       isForeground={isForeground}
       menuBar={menuBar}
       windowFrameProps={{

--- a/src/apps/infinite-pc/components/InfinitePcMenuBar.tsx
+++ b/src/apps/infinite-pc/components/InfinitePcMenuBar.tsx
@@ -61,8 +61,8 @@ export function InfinitePcMenuBar({
   const {
     isShareDialogOpen,
     setIsShareDialogOpen,
-    isXpTheme,
-    isMacOsxTheme,
+    isWindowsTheme,
+    isMacOSTheme,
     appId,
   } = useAppMenuBarChrome("pc", appName);
   const availableGames = loadGames();
@@ -161,8 +161,8 @@ export function InfinitePcMenuBar({
 
     return (
       <AppMenuBarShell
-        isXpTheme={isXpTheme}
-        isMacOsxTheme={isMacOsxTheme}
+        isWindowsTheme={isWindowsTheme}
+        isMacOSTheme={isMacOSTheme}
         appId={appId}
         appName={appName}
         isShareDialogOpen={isShareDialogOpen}
@@ -222,8 +222,8 @@ export function InfinitePcMenuBar({
 
   return (
     <AppMenuBarShell
-      isXpTheme={isXpTheme}
-      isMacOsxTheme={isMacOsxTheme}
+      isWindowsTheme={isWindowsTheme}
+      isMacOSTheme={isMacOSTheme}
       appId={appId}
       appName={appName}
       isShareDialogOpen={isShareDialogOpen}

--- a/src/apps/infinite-pc/hooks/useInfinitePcLogic.ts
+++ b/src/apps/infinite-pc/hooks/useInfinitePcLogic.ts
@@ -160,7 +160,7 @@ export function useInfinitePcLogic({
   );
 
   const { t } = useTranslation();
-  const { currentTheme, isWindowsTheme: isXpTheme } = useThemeFlags();
+  const { currentTheme, isWindowsTheme } = useThemeFlags();
   const translatedHelpItems = useTranslatedHelpItems("pc", helpItems);
   const embedUrl = selectedPreset ? buildWrapperUrl(selectedPreset) : null;
 
@@ -346,7 +346,7 @@ export function useInfinitePcLogic({
     t,
     translatedHelpItems,
     currentTheme,
-    isXpTheme,
+    isWindowsTheme,
     isHelpDialogOpen,
     setIsHelpDialogOpen,
     isAboutDialogOpen,

--- a/src/apps/internet-explorer/components/ie-menu-bar/InternetExplorerMenuBar.tsx
+++ b/src/apps/internet-explorer/components/ie-menu-bar/InternetExplorerMenuBar.tsx
@@ -11,8 +11,8 @@ export function InternetExplorerMenuBar(props: InternetExplorerMenuBarProps) {
 
   return (
     <AppMenuBarShell
-      isXpTheme={vm.isXpTheme}
-      isMacOsxTheme={vm.isMacOsxTheme}
+      isWindowsTheme={vm.isWindowsTheme}
+      isMacOSTheme={vm.isMacOSTheme}
       appId={vm.appId}
       appName={vm.appName}
       isShareDialogOpen={vm.isShareDialogOpen}

--- a/src/apps/internet-explorer/components/ie-menu-bar/useInternetExplorerMenuBar.ts
+++ b/src/apps/internet-explorer/components/ie-menu-bar/useInternetExplorerMenuBar.ts
@@ -44,8 +44,8 @@ export function useInternetExplorerMenuBar(props: InternetExplorerMenuBarProps) 
   const {
     isShareDialogOpen,
     setIsShareDialogOpen,
-    isXpTheme,
-    isMacOsxTheme,
+    isWindowsTheme,
+    isMacOSTheme,
     appId,
     appName,
   } = useAppMenuBarChrome("internet-explorer");
@@ -59,8 +59,8 @@ export function useInternetExplorerMenuBar(props: InternetExplorerMenuBarProps) 
     setIsShareDialogOpen,
     appId,
     appName,
-    isXpTheme,
-    isMacOsxTheme,
+    isWindowsTheme,
+    isMacOSTheme,
     futureYears,
     pastYears,
     onRefresh,

--- a/src/apps/internet-explorer/components/internet-explorer-app/InternetExplorerAppComponent.tsx
+++ b/src/apps/internet-explorer/components/internet-explorer-app/InternetExplorerAppComponent.tsx
@@ -74,7 +74,7 @@ export function InternetExplorerAppComponent({
     stopElevatorMusic,
     playDingSound,
     currentTheme,
-    isXpTheme,
+    isWindowsTheme,
     isOffline,
     pastYears,
     futureYears,
@@ -167,7 +167,7 @@ export function InternetExplorerAppComponent({
   return (
     <AppWindowShell
       isWindowOpen={isWindowOpen}
-      isXpTheme={isXpTheme}
+      isWindowsTheme={isWindowsTheme}
       isForeground={isForeground}
       menuBar={menuBar}
       windowFrameProps={{
@@ -195,7 +195,7 @@ export function InternetExplorerAppComponent({
       <TooltipProvider>
         <div className="flex flex-col size-full relative">
             <InternetExplorerToolbar
-              isXpTheme={isXpTheme}
+              isWindowsTheme={isWindowsTheme}
               currentTheme={currentTheme}
               isOffline={isOffline}
               historyIndex={historyIndex}

--- a/src/apps/internet-explorer/components/internet-explorer-app/InternetExplorerToolbar.tsx
+++ b/src/apps/internet-explorer/components/internet-explorer-app/InternetExplorerToolbar.tsx
@@ -19,7 +19,7 @@ import { InternetExplorerFavoritesBar } from "./InternetExplorerFavoritesBar";
 import type { InternetExplorerSuggestionItem } from "./types";
 
 export interface InternetExplorerToolbarProps {
-  isXpTheme: boolean;
+  isWindowsTheme: boolean;
   currentTheme: string;
   isOffline: boolean;
   historyIndex: number;
@@ -60,7 +60,7 @@ export interface InternetExplorerToolbarProps {
 }
 
 export function InternetExplorerToolbar({
-  isXpTheme,
+  isWindowsTheme,
   currentTheme,
   isOffline,
   historyIndex,
@@ -102,7 +102,7 @@ export function InternetExplorerToolbar({
   return (
     <div
       className={`flex flex-col gap-1 p-1 ${
-        isXpTheme
+        isWindowsTheme
           ? "bg-transparent border-b border-[#919b9c]"
           : currentTheme === "macosx"
             ? "bg-transparent"
@@ -159,7 +159,7 @@ export function InternetExplorerToolbar({
           localUrl={localUrl}
           url={url}
           isOffline={isOffline}
-          isXpTheme={isXpTheme}
+          isWindowsTheme={isWindowsTheme}
           currentTheme={currentTheme}
           isUrlDropdownOpen={isUrlDropdownOpen}
           filteredSuggestions={filteredSuggestions}
@@ -185,7 +185,7 @@ export function InternetExplorerToolbar({
           <Select value={year} onValueChange={(newYear) => handleNavigate(url, newYear)}>
             <SelectTrigger
               className={
-                isXpTheme
+                isWindowsTheme
                   ? "!text-[11px]"
                   : currentTheme === "macosx"
                     ? "!text-[12px]"

--- a/src/apps/internet-explorer/components/internet-explorer-app/InternetExplorerUrlBar.tsx
+++ b/src/apps/internet-explorer/components/internet-explorer-app/InternetExplorerUrlBar.tsx
@@ -16,7 +16,7 @@ export interface InternetExplorerUrlBarProps {
   localUrl: string;
   url: string;
   isOffline: boolean;
-  isXpTheme: boolean;
+  isWindowsTheme: boolean;
   currentTheme: string;
   isUrlDropdownOpen: boolean;
   filteredSuggestions: InternetExplorerSuggestionItem[];
@@ -44,7 +44,7 @@ export function InternetExplorerUrlBar({
   localUrl,
   url,
   isOffline,
-  isXpTheme,
+  isWindowsTheme,
   currentTheme,
   isUrlDropdownOpen,
   filteredSuggestions,
@@ -158,7 +158,7 @@ export function InternetExplorerUrlBar({
           setIsUrlDropdownOpen(true);
         }}
         className={`flex-1 pl-2 pr-8 ${
-          isXpTheme
+          isWindowsTheme
             ? "!text-[11px]"
             : currentTheme === "macosx"
               ? "!text-[12px] h-[26px]"

--- a/src/apps/internet-explorer/hooks/useInternetExplorerLogic.ts
+++ b/src/apps/internet-explorer/hooks/useInternetExplorerLogic.ts
@@ -367,7 +367,7 @@ export function useInternetExplorerLogic({
   const { playElevatorMusic, stopElevatorMusic, playDingSound } =
     useTerminalSounds();
 
-  const { currentTheme, isWindowsTheme: isXpTheme } = useThemeFlags();
+  const { currentTheme, isWindowsTheme } = useThemeFlags();
 
   const currentYear = new Date().getFullYear();
   const pastYears = [
@@ -1938,7 +1938,7 @@ export function useInternetExplorerLogic({
 
     // Theme and settings
     currentTheme,
-    isXpTheme,
+    isWindowsTheme,
     debugMode,
     terminalSoundsEnabled,
     isOffline,

--- a/src/apps/ipod/components/ipod-app/IpodAppComponent.tsx
+++ b/src/apps/ipod/components/ipod-app/IpodAppComponent.tsx
@@ -25,7 +25,7 @@ export function IpodAppComponent({
   });
 
   const {
-    isXpTheme,
+    isWindowsTheme,
     isMacOSTheme,
     menuBar,
     handleClose,
@@ -37,7 +37,7 @@ export function IpodAppComponent({
   return (
     <AppWindowShell
       isWindowOpen={isWindowOpen}
-      isXpTheme={isXpTheme}
+      isWindowsTheme={isWindowsTheme}
       isForeground={isForeground}
       menuBar={menuBar}
       windowFrameProps={{

--- a/src/apps/ipod/components/ipod-menu-bar/IpodMenuBar.tsx
+++ b/src/apps/ipod/components/ipod-menu-bar/IpodMenuBar.tsx
@@ -10,8 +10,8 @@ export function IpodMenuBar(props: IpodMenuBarProps) {
   const vm = useIpodMenuBar(props);
   return (
     <AppMenuBarShell
-      isXpTheme={vm.isXpTheme}
-      isMacOsxTheme={vm.isMacOsxTheme}
+      isWindowsTheme={vm.isWindowsTheme}
+      isMacOSTheme={vm.isMacOSTheme}
       appId={vm.appId}
       appName={vm.appName}
       isShareDialogOpen={vm.isShareDialogOpen}

--- a/src/apps/ipod/components/ipod-menu-bar/useIpodMenuBar.ts
+++ b/src/apps/ipod/components/ipod-menu-bar/useIpodMenuBar.ts
@@ -39,8 +39,8 @@ export function useIpodMenuBar(props: IpodMenuBarProps) {
   const {
     isShareDialogOpen,
     setIsShareDialogOpen,
-    isXpTheme,
-    isMacOsxTheme,
+    isWindowsTheme,
+    isMacOSTheme,
     appId,
     appName,
   } = useAppMenuBarChrome("ipod");
@@ -208,8 +208,8 @@ export function useIpodMenuBar(props: IpodMenuBarProps) {
     appId,
     appName,
     translationLanguages,
-    isXpTheme,
-    isMacOsxTheme,
+    isWindowsTheme,
+    isMacOSTheme,
     debugMode,
     isAdmin,
     isAppleMusic,

--- a/src/apps/ipod/hooks/useIpodLogic.ts
+++ b/src/apps/ipod/hooks/useIpodLogic.ts
@@ -5241,7 +5241,7 @@ export function useIpodLogic({
     }
   );
 
-  const { isWindowsTheme: isXpTheme, isMacOSTheme } = useThemeFlags();
+  const { isWindowsTheme, isMacOSTheme } = useThemeFlags();
 
   return {
     // Translation
@@ -5294,7 +5294,7 @@ export function useIpodLogic({
     isFullScreen,
     toggleFullScreen,
     isMinimized,
-    isXpTheme,
+    isWindowsTheme,
     isMacOSTheme,
     isOffline,
 

--- a/src/apps/karaoke/components/karaoke-app/KaraokeAppComponent.tsx
+++ b/src/apps/karaoke/components/karaoke-app/KaraokeAppComponent.tsx
@@ -25,7 +25,7 @@ export function KaraokeAppComponent({
   });
 
   const {
-    isXpTheme,
+    isWindowsTheme,
     menuBar,
     currentTrack,
     toggleFullScreen,
@@ -40,7 +40,7 @@ export function KaraokeAppComponent({
   return (
     <AppWindowShell
       isWindowOpen={isWindowOpen}
-      isXpTheme={isXpTheme}
+      isWindowsTheme={isWindowsTheme}
       isForeground={isForeground}
       menuBar={menuBar}
       windowFrameProps={{

--- a/src/apps/karaoke/components/karaoke-menu-bar/KaraokeMenuBar.tsx
+++ b/src/apps/karaoke/components/karaoke-menu-bar/KaraokeMenuBar.tsx
@@ -10,8 +10,8 @@ export function KaraokeMenuBar(props: KaraokeMenuBarProps) {
   const vm = useKaraokeMenuBar(props);
   return (
     <AppMenuBarShell
-      isXpTheme={vm.isXpTheme}
-      isMacOsxTheme={vm.isMacOsxTheme}
+      isWindowsTheme={vm.isWindowsTheme}
+      isMacOSTheme={vm.isMacOSTheme}
       appId={vm.appId}
       appName={vm.appName}
       isShareDialogOpen={vm.isShareDialogOpen}

--- a/src/apps/karaoke/components/karaoke-menu-bar/useKaraokeMenuBar.ts
+++ b/src/apps/karaoke/components/karaoke-menu-bar/useKaraokeMenuBar.ts
@@ -56,8 +56,8 @@ export function useKaraokeMenuBar(props: KaraokeMenuBarProps) {
   const {
     isShareDialogOpen,
     setIsShareDialogOpen,
-    isXpTheme,
-    isMacOsxTheme,
+    isWindowsTheme,
+    isMacOSTheme,
     appId,
     appName,
   } = useAppMenuBarChrome("karaoke", t("apps.karaoke.name"));
@@ -118,8 +118,8 @@ export function useKaraokeMenuBar(props: KaraokeMenuBarProps) {
     setIsShareDialogOpen,
     appId,
     appName,
-    isXpTheme,
-    isMacOsxTheme,
+    isWindowsTheme,
+    isMacOSTheme,
     debugMode,
     isAdmin,
     lyricsAlignment,

--- a/src/apps/karaoke/hooks/useKaraokeLogic.ts
+++ b/src/apps/karaoke/hooks/useKaraokeLogic.ts
@@ -1671,7 +1671,7 @@ export function useKaraokeLogic({
     return onAppUpdate(handleUpdateApp);
   }, [processVideoId, bringInstanceToForeground, joinListenSession, username, instanceId]);
 
-  const { isWindowsTheme: isXpTheme } = useThemeFlags();
+  const { isWindowsTheme } = useThemeFlags();
 
   const getCurrentKaraokeTrack = useCallback(() => {
     return useKaraokeStore.getState().getCurrentTrack();
@@ -1812,7 +1812,7 @@ export function useKaraokeLogic({
     setLyricOffset: (index: number, offsetMs: number) => {
       useMediaLibraryStore.getState().setLyricOffset(index, offsetMs, "youtube");
     },
-    isXpTheme,
+    isWindowsTheme,
     getCurrentKaraokeTrack,
     adjustLyricOffset: (index: number, delta: number) => {
       useMediaLibraryStore.getState().adjustLyricOffset(index, delta, "youtube");

--- a/src/apps/maps/components/MapsMenuBar.tsx
+++ b/src/apps/maps/components/MapsMenuBar.tsx
@@ -37,8 +37,8 @@ export function MapsMenuBar({
   const {
     isShareDialogOpen,
     setIsShareDialogOpen,
-    isXpTheme,
-    isMacOsxTheme,
+    isWindowsTheme,
+    isMacOSTheme,
     appId,
     appName,
   } = useAppMenuBarChrome("maps");
@@ -77,8 +77,8 @@ export function MapsMenuBar({
 
   return (
     <AppMenuBarShell
-      isXpTheme={isXpTheme}
-      isMacOsxTheme={isMacOsxTheme}
+      isWindowsTheme={isWindowsTheme}
+      isMacOSTheme={isMacOSTheme}
       appId={appId}
       appName={appName}
       isShareDialogOpen={isShareDialogOpen}

--- a/src/apps/maps/components/MapsPlaceCard.tsx
+++ b/src/apps/maps/components/MapsPlaceCard.tsx
@@ -101,7 +101,7 @@ export function MapsPlaceCard({
   onClose,
 }: MapsPlaceCardProps) {
   const { t } = useTranslation();
-  const { isMacOSTheme, isXpTheme, isSystem7Theme, isWin98 } = useThemeFlags();
+  const { isMacOSTheme, isWindowsTheme, isSystem7Theme, isWin98 } = useThemeFlags();
 
   return (
     <AnimatePresence>
@@ -121,11 +121,11 @@ export function MapsPlaceCard({
           <div
             className={cn(
               osCardClassName(
-                { isMacOSTheme, isSystem7Theme, isXpTheme, isWin98 },
+                { isMacOSTheme, isSystem7Theme, isWindowsTheme, isWin98 },
                 { embed: "panel" }
               ),
               "gap-2.5 p-3",
-              isXpTheme && "shadow-md"
+              isWindowsTheme && "shadow-md"
             )}
           >
             <PlaceCardHeader

--- a/src/apps/maps/components/maps-app/MapsAppComponent.tsx
+++ b/src/apps/maps/components/maps-app/MapsAppComponent.tsx
@@ -23,7 +23,7 @@ export function MapsAppComponent({
   const {
     t,
     translatedHelpItems,
-    isXpTheme,
+    isWindowsTheme,
     isMacOSTheme,
     isDarkMode,
     isHelpDialogOpen,
@@ -78,7 +78,7 @@ export function MapsAppComponent({
   return (
     <AppWindowShell
       isWindowOpen={isWindowOpen}
-      isXpTheme={isXpTheme}
+      isWindowsTheme={isWindowsTheme}
       isForeground={isForeground}
       menuBar={menuBar}
       windowFrameProps={{

--- a/src/apps/maps/components/maps-app/useMapsAppController.ts
+++ b/src/apps/maps/components/maps-app/useMapsAppController.ts
@@ -56,7 +56,7 @@ export function useMapsAppController({ isWindowOpen }: UseMapsAppControllerArgs)
   const {
     t,
     translatedHelpItems,
-    isXpTheme,
+    isWindowsTheme,
     isMacOSTheme,
     isDarkMode,
     isHelpDialogOpen,
@@ -1154,7 +1154,7 @@ export function useMapsAppController({ isWindowOpen }: UseMapsAppControllerArgs)
   return {
     t,
     translatedHelpItems,
-    isXpTheme,
+    isWindowsTheme,
     isMacOSTheme,
     isDarkMode,
     isHelpDialogOpen,

--- a/src/apps/maps/hooks/useMapsLogic.ts
+++ b/src/apps/maps/hooks/useMapsLogic.ts
@@ -27,7 +27,7 @@ export function useMapsLogic() {
   const translatedHelpItems = useTranslatedHelpItems("maps", helpItems);
   const {
     currentTheme,
-    isXpTheme,
+    isWindowsTheme,
     isMacOSTheme,
     isSystem7Theme,
     isClassicTheme,
@@ -48,7 +48,7 @@ export function useMapsLogic() {
     t,
     translatedHelpItems,
     currentTheme,
-    isXpTheme,
+    isWindowsTheme,
     isMacOSTheme,
     isSystem7Theme,
     isClassicTheme,

--- a/src/apps/minesweeper/components/MinesweeperAppComponent.tsx
+++ b/src/apps/minesweeper/components/MinesweeperAppComponent.tsx
@@ -180,7 +180,7 @@ export function MinesweeperAppComponent({
     remainingMines,
     totalMines,
     minesweeperStyles,
-    isXpTheme,
+    isWindowsTheme,
     isMacTheme,
     handleCellClick,
     handleCellRightClick,
@@ -207,7 +207,7 @@ export function MinesweeperAppComponent({
   return (
     <AppWindowShell
       isWindowOpen={isWindowOpen}
-      isXpTheme={isXpTheme}
+      isWindowsTheme={isWindowsTheme}
       isForeground={isForeground}
       menuBar={menuBar}
       leading={<style>{minesweeperStyles}</style>}

--- a/src/apps/minesweeper/components/MinesweeperMenuBar.tsx
+++ b/src/apps/minesweeper/components/MinesweeperMenuBar.tsx
@@ -20,16 +20,16 @@ export function MinesweeperMenuBar({
   const {
     isShareDialogOpen,
     setIsShareDialogOpen,
-    isXpTheme,
-    isMacOsxTheme,
+    isWindowsTheme,
+    isMacOSTheme,
     appId,
     appName,
   } = useAppMenuBarChrome("minesweeper");
 
   return (
     <AppMenuBarShell
-      isXpTheme={isXpTheme}
-      isMacOsxTheme={isMacOsxTheme}
+      isWindowsTheme={isWindowsTheme}
+      isMacOSTheme={isMacOSTheme}
       appId={appId}
       appName={appName}
       isShareDialogOpen={isShareDialogOpen}

--- a/src/apps/minesweeper/hooks/useMinesweeperLogic.ts
+++ b/src/apps/minesweeper/hooks/useMinesweeperLogic.ts
@@ -318,7 +318,7 @@ export function useMinesweeperLogic() {
     });
   }, [initializeBoard]);
 
-  const { isWindowsTheme: isXpTheme, isMacOSTheme: isMacTheme } =
+  const { isWindowsTheme, isMacOSTheme: isMacTheme } =
     useThemeFlags();
 
   return {
@@ -336,7 +336,7 @@ export function useMinesweeperLogic() {
     remainingMines,
     totalMines: MINES_COUNT,
     minesweeperStyles,
-    isXpTheme,
+    isWindowsTheme,
     isMacTheme,
     handleCellClick,
     handleCellRightClick,

--- a/src/apps/paint/components/PaintAppComponent.tsx
+++ b/src/apps/paint/components/PaintAppComponent.tsx
@@ -54,7 +54,7 @@ export const PaintAppComponent: React.FC<AppProps<PaintInitialData>> = ({
     canvasHeight,
     error,
     windowTitle,
-    isXpTheme,
+    isWindowsTheme,
     handleUndo,
     handleRedo,
     handleClear,
@@ -117,7 +117,7 @@ export const PaintAppComponent: React.FC<AppProps<PaintInitialData>> = ({
   return (
     <AppWindowShell
       isWindowOpen={isWindowOpen}
-      isXpTheme={isXpTheme}
+      isWindowsTheme={isWindowsTheme}
       isForeground={isForeground}
       menuBar={menuBar}
       windowFrameProps={{

--- a/src/apps/paint/components/paint-menu-bar/PaintMenuBar.tsx
+++ b/src/apps/paint/components/paint-menu-bar/PaintMenuBar.tsx
@@ -12,8 +12,8 @@ export function PaintMenuBar(props: PaintMenuBarProps) {
 
   return (
     <AppMenuBarShell
-      isXpTheme={vm.isXpTheme}
-      isMacOsxTheme={vm.isMacOsxTheme}
+      isWindowsTheme={vm.isWindowsTheme}
+      isMacOSTheme={vm.isMacOSTheme}
       appId={vm.appId}
       appName={vm.appName}
       isShareDialogOpen={vm.isShareDialogOpen}

--- a/src/apps/paint/components/paint-menu-bar/usePaintMenuBar.ts
+++ b/src/apps/paint/components/paint-menu-bar/usePaintMenuBar.ts
@@ -32,8 +32,8 @@ export function usePaintMenuBar(props: PaintMenuBarProps) {
   const {
     isShareDialogOpen,
     setIsShareDialogOpen,
-    isXpTheme,
-    isMacOsxTheme,
+    isWindowsTheme,
+    isMacOSTheme,
     appId,
     appName,
   } = useAppMenuBarChrome("paint");
@@ -44,8 +44,8 @@ export function usePaintMenuBar(props: PaintMenuBarProps) {
     isWindowOpen,
     isShareDialogOpen,
     setIsShareDialogOpen,
-    isXpTheme,
-    isMacOsxTheme,
+    isWindowsTheme,
+    isMacOSTheme,
     fileInputRef,
     appId,
     appName,

--- a/src/apps/paint/hooks/usePaintLogic.ts
+++ b/src/apps/paint/hooks/usePaintLogic.ts
@@ -434,7 +434,7 @@ export function usePaintLogic({ initialData, instanceId }: UsePaintLogicProps) {
     });
   }, []);
 
-  const { currentTheme, isWindowsTheme: isXpTheme } = useThemeFlags();
+  const { currentTheme, isWindowsTheme } = useThemeFlags();
 
   const windowTitle = currentFilePath
     ? currentFilePath.split("/").pop() || t("apps.paint.untitled")
@@ -470,7 +470,7 @@ export function usePaintLogic({ initialData, instanceId }: UsePaintLogicProps) {
     error,
     windowTitle,
     currentTheme,
-    isXpTheme,
+    isWindowsTheme,
     handleUndo,
     handleRedo,
     handleClear,

--- a/src/apps/pc/hooks/usePcLogic.ts
+++ b/src/apps/pc/hooks/usePcLogic.ts
@@ -34,7 +34,7 @@ export function usePcLogic({ isWindowOpen, instanceId }: UsePcLogicProps) {
   const dosPropsRef = useRef<DosProps | null>(null);
 
   const { t } = useTranslation();
-  const { currentTheme, isWindowsTheme: isXpTheme } = useThemeFlags();
+  const { currentTheme, isWindowsTheme } = useThemeFlags();
   const translatedHelpItems = useTranslatedHelpItems("pc", helpItems);
 
   const handleLoadGame = useCallback(
@@ -265,7 +265,7 @@ export function usePcLogic({ isWindowOpen, instanceId }: UsePcLogicProps) {
     t,
     translatedHelpItems,
     currentTheme,
-    isXpTheme,
+    isWindowsTheme,
     isHelpDialogOpen,
     setIsHelpDialogOpen,
     isAboutDialogOpen,

--- a/src/apps/photo-booth/components/PhotoBoothComponent.tsx
+++ b/src/apps/photo-booth/components/PhotoBoothComponent.tsx
@@ -69,7 +69,7 @@ export function PhotoBoothComponent({
     validPhotos,
     getPhotoPreviewSrc,
     isInitialLoad,
-    isXpTheme,
+    isWindowsTheme,
     isMacTheme,
     windowTitle,
     handleClearPhotos,
@@ -103,7 +103,7 @@ export function PhotoBoothComponent({
   return (
     <AppWindowShell
       isWindowOpen={isWindowOpen}
-      isXpTheme={isXpTheme}
+      isWindowsTheme={isWindowsTheme}
       isForeground={isForeground}
       menuBar={menuBar}
       windowFrameProps={{
@@ -413,19 +413,19 @@ export function PhotoBoothComponent({
                     validPhotos.length === 0 && "opacity-50 cursor-not-allowed"
                   )}
                   style={{
-                    background: isXpTheme
+                    background: isWindowsTheme
                       ? "rgba(255, 255, 255, 0.1)"
                       : undefined,
-                    border: isXpTheme ? "none" : undefined,
+                    border: isWindowsTheme ? "none" : undefined,
                   }}
                   onMouseEnter={(e) => {
-                    if (isXpTheme) {
+                    if (isWindowsTheme) {
                       e.currentTarget.style.background =
                         "rgba(255, 255, 255, 0.2)";
                     }
                   }}
                   onMouseLeave={(e) => {
-                    if (isXpTheme) {
+                    if (isWindowsTheme) {
                       e.currentTarget.style.background =
                         "rgba(255, 255, 255, 0.1)";
                     }
@@ -449,19 +449,19 @@ export function PhotoBoothComponent({
                     isMacTheme ? "z-10" : "bg-white/10 hover:bg-white/20"
                   )}
                   style={{
-                    background: isXpTheme
+                    background: isWindowsTheme
                       ? "rgba(255, 255, 255, 0.1)"
                       : undefined,
-                    border: isXpTheme ? "none" : undefined,
+                    border: isWindowsTheme ? "none" : undefined,
                   }}
                   onMouseEnter={(e) => {
-                    if (isXpTheme) {
+                    if (isWindowsTheme) {
                       e.currentTarget.style.background =
                         "rgba(255, 255, 255, 0.2)";
                     }
                   }}
                   onMouseLeave={(e) => {
-                    if (isXpTheme) {
+                    if (isWindowsTheme) {
                       e.currentTarget.style.background =
                         "rgba(255, 255, 255, 0.1)";
                     }
@@ -504,7 +504,7 @@ export function PhotoBoothComponent({
                         : "0 2px 3px rgba(0,0,0,0.2), 0 1px 1px rgba(0,0,0,0.3), inset 0 0 0 0.5px rgba(0,0,0,0.3), inset 0 1px 2px rgba(0,0,0,0.4), inset 0 2px 3px 1px rgba(254, 150, 150, 0.5)",
                       cursor: isMultiPhotoMode ? "not-allowed" : "pointer",
                     }
-                  : isXpTheme
+                  : isWindowsTheme
                   ? {
                       background: isMultiPhotoMode ? "#6b7280" : "#dc2626",
                       border: "none",
@@ -515,12 +515,12 @@ export function PhotoBoothComponent({
                     }
               }
               onMouseEnter={(e) => {
-                if (isXpTheme && !isMultiPhotoMode) {
+                if (isWindowsTheme && !isMultiPhotoMode) {
                   e.currentTarget.style.background = "#b91c1c";
                 }
               }}
               onMouseLeave={(e) => {
-                if (isXpTheme && !isMultiPhotoMode) {
+                if (isWindowsTheme && !isMultiPhotoMode) {
                   e.currentTarget.style.background = "#dc2626";
                 }
               }}
@@ -592,19 +592,19 @@ export function PhotoBoothComponent({
                     : "bg-white/10 hover:bg-white/20"
                 )}
                 style={{
-                  background: isXpTheme
+                  background: isWindowsTheme
                     ? "rgba(255, 255, 255, 0.1)"
                     : undefined,
-                  border: isXpTheme ? "none" : undefined,
+                  border: isWindowsTheme ? "none" : undefined,
                 }}
                 onMouseEnter={(e) => {
-                  if (isXpTheme) {
+                  if (isWindowsTheme) {
                     e.currentTarget.style.background =
                       "rgba(255, 255, 255, 0.2)";
                   }
                 }}
                 onMouseLeave={(e) => {
-                  if (isXpTheme) {
+                  if (isWindowsTheme) {
                     e.currentTarget.style.background =
                       "rgba(255, 255, 255, 0.1)";
                   }

--- a/src/apps/photo-booth/components/PhotoBoothMenuBar.tsx
+++ b/src/apps/photo-booth/components/PhotoBoothMenuBar.tsx
@@ -43,8 +43,8 @@ export function PhotoBoothMenuBar({
   const {
     isShareDialogOpen,
     setIsShareDialogOpen,
-    isXpTheme,
-    isMacOsxTheme,
+    isWindowsTheme,
+    isMacOSTheme,
     appId,
     appName,
   } = useAppMenuBarChrome("photo-booth");
@@ -104,8 +104,8 @@ export function PhotoBoothMenuBar({
 
   return (
     <AppMenuBarShell
-      isXpTheme={isXpTheme}
-      isMacOsxTheme={isMacOsxTheme}
+      isWindowsTheme={isWindowsTheme}
+      isMacOSTheme={isMacOSTheme}
       appId={appId}
       appName={appName}
       isShareDialogOpen={isShareDialogOpen}

--- a/src/apps/photo-booth/hooks/usePhotoBoothLogic.ts
+++ b/src/apps/photo-booth/hooks/usePhotoBoothLogic.ts
@@ -192,7 +192,7 @@ export function usePhotoBoothLogic({
   const recentPhotoPreviewsRef = useRef<Map<string, string>>(new Map());
 
   const {
-    isWindowsTheme: isXpTheme,
+    isWindowsTheme,
     isMacOSTheme: isMacTheme,
   } = useThemeFlags();
 
@@ -1067,7 +1067,7 @@ export function usePhotoBoothLogic({
     validPhotos,
     getPhotoPreviewSrc,
     isInitialLoad,
-    isXpTheme,
+    isWindowsTheme,
     isMacTheme,
     windowTitle,
     handleClearPhotos,

--- a/src/apps/soundboard/components/BoardList.tsx
+++ b/src/apps/soundboard/components/BoardList.tsx
@@ -47,7 +47,6 @@ export function BoardList({
       className={osAppSidebarSurfaceClassName(
         {
           isMacOSTheme,
-          isXpTheme: isWindowsTheme,
           isWindowsTheme,
           isAquaGlass,
         },

--- a/src/apps/soundboard/components/SoundboardAppComponent.tsx
+++ b/src/apps/soundboard/components/SoundboardAppComponent.tsx
@@ -32,7 +32,7 @@ export function SoundboardAppComponent({
     updateSlot,
     deleteSlot,
     hasInitialized,
-    isXpTheme,
+    isWindowsTheme,
     isEditingTitle,
     setIsEditingTitle,
     dialogState,
@@ -109,7 +109,7 @@ export function SoundboardAppComponent({
   return (
     <AppWindowShell
       isWindowOpen={isWindowOpen}
-      isXpTheme={isXpTheme}
+      isWindowsTheme={isWindowsTheme}
       isForeground={isForeground}
       menuBar={menuBar}
       windowFrameProps={windowFrameProps}
@@ -124,7 +124,7 @@ export function SoundboardAppComponent({
         <>
         <div
           className={`h-full w-full flex flex-col md:flex-row ${
-            isXpTheme ? "border-t border-[#919b9c]" : ""
+            isWindowsTheme ? "border-t border-[#919b9c]" : ""
           }`}
         >
           <input

--- a/src/apps/soundboard/components/SoundboardMenuBar.tsx
+++ b/src/apps/soundboard/components/SoundboardMenuBar.tsx
@@ -48,8 +48,8 @@ export function SoundboardMenuBar({
   const {
     isShareDialogOpen,
     setIsShareDialogOpen,
-    isXpTheme,
-    isMacOsxTheme,
+    isWindowsTheme,
+    isMacOSTheme,
     appId,
     appName,
   } = useAppMenuBarChrome("soundboard");
@@ -159,8 +159,8 @@ export function SoundboardMenuBar({
 
   return (
     <AppMenuBarShell
-      isXpTheme={isXpTheme}
-      isMacOsxTheme={isMacOsxTheme}
+      isWindowsTheme={isWindowsTheme}
+      isMacOSTheme={isMacOSTheme}
       appId={appId}
       appName={appName}
       isShareDialogOpen={isShareDialogOpen}

--- a/src/apps/soundboard/hooks/useSoundboardLogic.ts
+++ b/src/apps/soundboard/hooks/useSoundboardLogic.ts
@@ -55,7 +55,7 @@ export function useSoundboardLogic({
   const hasInitialized = useSoundboardStore((state) => state.hasInitialized);
 
   // Get current theme
-  const { currentTheme, isWindowsTheme: isXpTheme } = useThemeFlags();
+  const { currentTheme, isWindowsTheme } = useThemeFlags();
 
   useEffect(() => {
     if (!hasInitialized) {
@@ -390,7 +390,7 @@ export function useSoundboardLogic({
     stopSound,
     hasInitialized,
     currentTheme,
-    isXpTheme,
+    isWindowsTheme,
     isEditingTitle,
     setIsEditingTitle,
     dialogState,

--- a/src/apps/stickies/components/StickiesAppComponent.tsx
+++ b/src/apps/stickies/components/StickiesAppComponent.tsx
@@ -28,7 +28,7 @@ export function StickiesAppComponent({
     setIsHelpDialogOpen,
     isAboutDialogOpen,
     setIsAboutDialogOpen,
-    isXpTheme,
+    isWindowsTheme,
     notes,
     selectedNoteId,
     handleCreateNote,
@@ -117,7 +117,7 @@ export function StickiesAppComponent({
     <AppWindowShell
       frameless
       isWindowOpen={isWindowOpen}
-      isXpTheme={isXpTheme}
+      isWindowsTheme={isWindowsTheme}
       isForeground={isForeground}
       menuBar={menuBar}
       trailing={

--- a/src/apps/stickies/components/StickiesMenuBar.tsx
+++ b/src/apps/stickies/components/StickiesMenuBar.tsx
@@ -42,8 +42,8 @@ export function StickiesMenuBar({
   const {
     isShareDialogOpen,
     setIsShareDialogOpen,
-    isXpTheme,
-    isMacOsxTheme,
+    isWindowsTheme,
+    isMacOSTheme,
     appId,
     appName,
   } = useAppMenuBarChrome("stickies");
@@ -117,8 +117,8 @@ export function StickiesMenuBar({
 
   return (
     <AppMenuBarShell
-      isXpTheme={isXpTheme}
-      isMacOsxTheme={isMacOsxTheme}
+      isWindowsTheme={isWindowsTheme}
+      isMacOSTheme={isMacOSTheme}
       appId={appId}
       appName={appName}
       isShareDialogOpen={isShareDialogOpen}

--- a/src/apps/stickies/hooks/useStickiesLogic.ts
+++ b/src/apps/stickies/hooks/useStickiesLogic.ts
@@ -12,7 +12,7 @@ export function useStickiesLogic() {
   const translatedHelpItems = useTranslatedHelpItems("stickies", helpItems);
 
   // Theme state
-  const { currentTheme, isXpTheme } = useThemeFlags();
+  const { currentTheme, isWindowsTheme } = useThemeFlags();
 
   // Dialog state
   const {
@@ -72,7 +72,7 @@ export function useStickiesLogic() {
 
     // Theme
     currentTheme,
-    isXpTheme,
+    isWindowsTheme,
 
     // Dialogs
     isHelpDialogOpen,

--- a/src/apps/synth/components/SynthMenuBar.tsx
+++ b/src/apps/synth/components/SynthMenuBar.tsx
@@ -36,8 +36,8 @@ export function SynthMenuBar({
   const {
     isShareDialogOpen,
     setIsShareDialogOpen,
-    isXpTheme,
-    isMacOsxTheme,
+    isWindowsTheme,
+    isMacOSTheme,
     appId,
     appName,
   } = useAppMenuBarChrome("synth");
@@ -98,8 +98,8 @@ export function SynthMenuBar({
 
   return (
     <AppMenuBarShell
-      isXpTheme={isXpTheme}
-      isMacOsxTheme={isMacOsxTheme}
+      isWindowsTheme={isWindowsTheme}
+      isMacOSTheme={isMacOSTheme}
       appId={appId}
       appName={appName}
       isShareDialogOpen={isShareDialogOpen}

--- a/src/apps/synth/components/synth-app/SynthAppComponent.tsx
+++ b/src/apps/synth/components/synth-app/SynthAppComponent.tsx
@@ -20,12 +20,12 @@ export function SynthAppComponent({
     onClose,
   });
 
-  const { isXpTheme, isMacOSTheme, menuBar } = c;
+  const { isWindowsTheme, isMacOSTheme, menuBar } = c;
 
   return (
     <AppWindowShell
       isWindowOpen={isWindowOpen}
-      isXpTheme={isXpTheme}
+      isWindowsTheme={isWindowsTheme}
       isForeground={isForeground}
       menuBar={menuBar}
       windowFrameProps={{

--- a/src/apps/synth/components/synth-app/SynthControlsPanel.tsx
+++ b/src/apps/synth/components/synth-app/SynthControlsPanel.tsx
@@ -26,7 +26,7 @@ type SynthControlsPanelProps = Pick<
   | "isMacOSTheme"
   | "isSystem7Theme"
   | "isClassicTheme"
-  | "isXpTheme"
+  | "isWindowsTheme"
 >;
 
 export function SynthControlsPanel({
@@ -41,7 +41,7 @@ export function SynthControlsPanel({
   isMacOSTheme,
   isSystem7Theme,
   isClassicTheme,
-  isXpTheme,
+  isWindowsTheme,
 }: SynthControlsPanelProps) {
   return (
     <div className="relative w-full">
@@ -81,7 +81,7 @@ export function SynthControlsPanel({
                       onClick={addPreset}
                       className={cn(
                         "h-[22px] px-2 text-[9px] select-none",
-                        isXpTheme && "text-black"
+                        isWindowsTheme && "text-black"
                       )}
                     >
                       {t("apps.synth.addPreset")}

--- a/src/apps/synth/components/synth-app/SynthPresetsToolbar.tsx
+++ b/src/apps/synth/components/synth-app/SynthPresetsToolbar.tsx
@@ -23,7 +23,7 @@ type SynthPresetsToolbarProps = Pick<
   | "isMacOSTheme"
   | "isSystem7Theme"
   | "isClassicTheme"
-  | "isXpTheme"
+  | "isWindowsTheme"
 >;
 
 export function SynthPresetsToolbar({
@@ -38,7 +38,7 @@ export function SynthPresetsToolbar({
   isMacOSTheme,
   isSystem7Theme,
   isClassicTheme,
-  isXpTheme,
+  isWindowsTheme,
 }: SynthPresetsToolbarProps) {
   return (
     <div
@@ -119,7 +119,7 @@ export function SynthPresetsToolbar({
                     onClick={() => loadPreset(preset)}
                     className={cn(
                       "h-[22px] px-2 whitespace-nowrap uppercase select-none",
-                      isXpTheme && "text-black"
+                      isWindowsTheme && "text-black"
                     )}
                   >
                     {preset.name}
@@ -162,21 +162,21 @@ export function SynthPresetsToolbar({
             <Button
               variant={isSystem7Theme ? "player" : "default"}
               onClick={handleOctaveDown}
-              className={cn("h-[22px] px-2 select-none", isXpTheme && "text-black")}
+              className={cn("h-[22px] px-2 select-none", isWindowsTheme && "text-black")}
             >
               <CaretLeft weight="bold" className="size-3" />
             </Button>
             <Button
               variant={isSystem7Theme ? "player" : "default"}
               onClick={handleOctaveUp}
-              className={cn("h-[22px] px-2 select-none", isXpTheme && "text-black")}
+              className={cn("h-[22px] px-2 select-none", isWindowsTheme && "text-black")}
             >
               <CaretRight weight="bold" className="size-3" />
             </Button>
             <Button
               variant={isSystem7Theme ? "player" : "default"}
               onClick={toggleControls}
-              className={cn("h-[22px] px-2 select-none", isXpTheme && "text-black")}
+              className={cn("h-[22px] px-2 select-none", isWindowsTheme && "text-black")}
             >
               {t("apps.synth.controls")}
             </Button>

--- a/src/apps/synth/components/synth-app/SynthWindowContent.tsx
+++ b/src/apps/synth/components/synth-app/SynthWindowContent.tsx
@@ -37,7 +37,7 @@ export function SynthWindowContent({ c }: SynthWindowContentProps) {
           isMacOSTheme={c.isMacOSTheme}
           isSystem7Theme={c.isSystem7Theme}
           isClassicTheme={c.isClassicTheme}
-          isXpTheme={c.isXpTheme}
+          isWindowsTheme={c.isWindowsTheme}
         />
 
         <SynthControlsPanel
@@ -52,7 +52,7 @@ export function SynthWindowContent({ c }: SynthWindowContentProps) {
           isMacOSTheme={c.isMacOSTheme}
           isSystem7Theme={c.isSystem7Theme}
           isClassicTheme={c.isClassicTheme}
-          isXpTheme={c.isXpTheme}
+          isWindowsTheme={c.isWindowsTheme}
         />
 
         <SynthKeyboard

--- a/src/apps/synth/hooks/useSynthLogic.ts
+++ b/src/apps/synth/hooks/useSynthLogic.ts
@@ -196,11 +196,11 @@ export const useSynthLogic = ({
   const { t } = useTranslation();
   const translatedHelpItems = useTranslatedHelpItems("synth", helpItems);
   const {
-    isWindowsTheme: isXpTheme,
+    isWindowsTheme,
     isSystem7Theme,
     isMacOSTheme,
   } = useThemeFlags();
-  const isClassicTheme = isMacOSTheme || isXpTheme;
+  const isClassicTheme = isMacOSTheme || isWindowsTheme;
 
   // Define keyboard layout with extended range
   const allWhiteKeys = [
@@ -1242,7 +1242,7 @@ export const useSynthLogic = ({
     analyzerRef,
     appContainerRef,
     keyboardContainerRef,
-    isXpTheme,
+    isWindowsTheme,
     isSystem7Theme,
     isClassicTheme,
     isMacOSTheme,

--- a/src/apps/terminal/components/TerminalAppComponent.tsx
+++ b/src/apps/terminal/components/TerminalAppComponent.tsx
@@ -142,7 +142,7 @@ export function TerminalAppComponent({
     playDingSound,
     bringInstanceToForeground,
     handleClearTerminal,
-    isXpTheme,
+    isWindowsTheme,
     shouldApplyMarkdown,
   } = useTerminalLogic({ isForeground, initialData });
 
@@ -553,7 +553,7 @@ export function TerminalAppComponent({
   return (
     <AppWindowShell
       isWindowOpen={isWindowOpen}
-      isXpTheme={isXpTheme}
+      isWindowsTheme={isWindowsTheme}
       isForeground={isForeground}
       menuBar={menuBar}
       windowFrameProps={{

--- a/src/apps/terminal/components/TerminalMenuBar.tsx
+++ b/src/apps/terminal/components/TerminalMenuBar.tsx
@@ -34,8 +34,8 @@ export function TerminalMenuBar({
   const {
     isShareDialogOpen,
     setIsShareDialogOpen,
-    isXpTheme,
-    isMacOsxTheme,
+    isWindowsTheme,
+    isMacOSTheme,
     appId,
     appName,
   } = useAppMenuBarChrome("terminal");
@@ -111,8 +111,8 @@ export function TerminalMenuBar({
 
   return (
     <AppMenuBarShell
-      isXpTheme={isXpTheme}
-      isMacOsxTheme={isMacOsxTheme}
+      isWindowsTheme={isWindowsTheme}
+      isMacOSTheme={isMacOSTheme}
       appId={appId}
       appName={appName}
       isShareDialogOpen={isShareDialogOpen}

--- a/src/apps/terminal/hooks/useTerminalLogic.ts
+++ b/src/apps/terminal/hooks/useTerminalLogic.ts
@@ -166,7 +166,7 @@ export const useTerminalLogic = ({
   } = useTerminalSounds();
 
   const username = useChatsStore((state) => state.username);
-  const { isWindowsTheme: isXpTheme } = useThemeFlags();
+  const { isWindowsTheme } = useThemeFlags();
 
   // Load command history from store
   useEffect(() => {
@@ -1433,7 +1433,7 @@ export const useTerminalLogic = ({
     playDingSound,
     bringInstanceToForeground,
     handleClearTerminal,
-    isXpTheme,
+    isWindowsTheme,
     shouldApplyMarkdown,
   };
 };

--- a/src/apps/textedit/components/EditorToolbar.tsx
+++ b/src/apps/textedit/components/EditorToolbar.tsx
@@ -45,8 +45,8 @@ export function EditorToolbar({
 }: EditorToolbarProps) {
   const { t } = useTranslation();
   const { play: playButtonClick } = useSound(Sounds.BUTTON_CLICK);
-  const isXpTheme = currentTheme === "xp" || currentTheme === "win98";
-  const isLegacyToolbarTheme = isXpTheme || currentTheme === "system7";
+  const isWindowsTheme = currentTheme === "xp" || currentTheme === "win98";
+  const isLegacyToolbarTheme = isWindowsTheme || currentTheme === "system7";
   const isMacOSTheme = currentTheme === "macosx";
 
   const getCurrentHeading = () => {
@@ -303,7 +303,7 @@ export function EditorToolbar({
   return (
     <div
       className={`flex items-center gap-1 p-1 ${
-        isXpTheme
+        isWindowsTheme
           ? "border-b border-[#919b9c]"
           : isMacOSTheme
           ? "bg-transparent"

--- a/src/apps/textedit/components/TextEditAppComponent.tsx
+++ b/src/apps/textedit/components/TextEditAppComponent.tsx
@@ -57,7 +57,7 @@ function TextEditContent({
     (state) => state.clearInstanceInitialData
   );
   const launchAppInstance = useAppStore((state) => state.launchApp);
-  const { isWindowsTheme: isXpTheme, currentTheme } = useThemeFlags();
+  const { isWindowsTheme, currentTheme } = useThemeFlags();
   const speechEnabled = useAudioSettingsStore((state) => state.speechEnabled);
   // Local UI-only state for Save dialog filename
   const [saveFileName, setSaveFileName] = useState("");
@@ -566,7 +566,7 @@ function TextEditContent({
   return (
     <AppWindowShell
       isWindowOpen={isWindowOpen}
-      isXpTheme={isXpTheme}
+      isWindowsTheme={isWindowsTheme}
       isForeground={isForeground}
       menuBar={menuBar}
       leading={

--- a/src/apps/textedit/components/TextEditMenuBar.tsx
+++ b/src/apps/textedit/components/TextEditMenuBar.tsx
@@ -50,8 +50,8 @@ export function TextEditMenuBar({
   const {
     isShareDialogOpen,
     setIsShareDialogOpen,
-    isXpTheme,
-    isMacOsxTheme,
+    isWindowsTheme,
+    isMacOSTheme,
     appId,
     appName,
   } = useAppMenuBarChrome("textedit");
@@ -59,8 +59,8 @@ export function TextEditMenuBar({
 
   return (
     <AppMenuBarShell
-      isXpTheme={isXpTheme}
-      isMacOsxTheme={isMacOsxTheme}
+      isWindowsTheme={isWindowsTheme}
+      isMacOSTheme={isMacOSTheme}
       appId={appId}
       appName={appName}
       isShareDialogOpen={isShareDialogOpen}

--- a/src/apps/tv/components/CreateChannelDialog.tsx
+++ b/src/apps/tv/components/CreateChannelDialog.tsx
@@ -78,7 +78,7 @@ export function CreateChannelDialog({
 }: CreateChannelDialogProps) {
   const { t } = useTranslation();
   const {
-    isWindowsTheme: isXpTheme,
+    isWindowsTheme,
     isMacOSTheme: isMacTheme,
     isSystem7Theme,
   } = useThemeFlags();
@@ -150,17 +150,17 @@ export function CreateChannelDialog({
     }
   };
 
-  const fontStyle = isXpTheme
+  const fontStyle = isWindowsTheme
     ? { fontFamily: '"Pixelated MS Sans Serif", "ArkPixel", Arial' as const, fontSize: "11px" }
     : undefined;
-  const fontClass = isXpTheme
+  const fontClass = isWindowsTheme
     ? "font-['Pixelated_MS_Sans_Serif',Arial] text-[11px]"
     : isSystem7Theme
       ? "font-geneva-12 text-[12px]"
       : "font-os-ui text-[12px]";
 
   const dialogContent = (
-    <div className={cn(isXpTheme ? "p-2 px-4" : "p-4 px-6")}>
+    <div className={cn(isWindowsTheme ? "p-2 px-4" : "p-4 px-6")}>
       <p className={cn("text-neutral-500 mb-2", fontClass)} style={fontStyle}>
         {t("apps.tv.create.description")}
       </p>
@@ -242,11 +242,11 @@ export function CreateChannelDialog({
   return (
     <Dialog open={isOpen} onOpenChange={isLoading ? undefined : onOpenChange}>
       <DialogContent
-        className={cn("max-w-[500px]", isXpTheme && "p-0 overflow-hidden")}
-        style={isXpTheme ? { fontSize: "11px" } : undefined}
+        className={cn("max-w-[500px]", isWindowsTheme && "p-0 overflow-hidden")}
+        style={isWindowsTheme ? { fontSize: "11px" } : undefined}
         onKeyDown={(e) => e.stopPropagation()}
       >
-        {isXpTheme ? (
+        {isWindowsTheme ? (
           <>
             <DialogHeader>{t("apps.tv.create.title")}</DialogHeader>
             <div className="window-body">{dialogContent}</div>

--- a/src/apps/tv/components/TvMenuBar.tsx
+++ b/src/apps/tv/components/TvMenuBar.tsx
@@ -68,8 +68,8 @@ export function TvMenuBar({
   const {
     isShareDialogOpen,
     setIsShareDialogOpen,
-    isXpTheme,
-    isMacOsxTheme,
+    isWindowsTheme,
+    isMacOSTheme,
     appId,
     appName,
   } = useAppMenuBarChrome("tv");
@@ -193,8 +193,8 @@ export function TvMenuBar({
 
   return (
     <AppMenuBarShell
-      isXpTheme={isXpTheme}
-      isMacOsxTheme={isMacOsxTheme}
+      isWindowsTheme={isWindowsTheme}
+      isMacOSTheme={isMacOSTheme}
       appId={appId}
       appName={appName}
       isShareDialogOpen={isShareDialogOpen}

--- a/src/apps/tv/components/TvVideoDrawer.tsx
+++ b/src/apps/tv/components/TvVideoDrawer.tsx
@@ -35,7 +35,7 @@ interface TvChannelLogoStripProps {
   onSelectChannel: (channelId: string) => void;
   isMacOSTheme: boolean;
   isSystem7: boolean;
-  isXpTheme: boolean;
+  isWindowsTheme: boolean;
   isWin98: boolean;
 }
 
@@ -46,7 +46,7 @@ const TvChannelLogoStrip = memo(function TvChannelLogoStrip({
   onSelectChannel,
   isMacOSTheme,
   isSystem7,
-  isXpTheme,
+  isWindowsTheme,
   isWin98,
 }: TvChannelLogoStripProps) {
   const { t } = useTranslation();
@@ -65,7 +65,7 @@ const TvChannelLogoStrip = memo(function TvChannelLogoStrip({
       className={cn(
         "sticky top-0 z-10 shrink-0",
         osToolbarSurfaceClassName(
-          { isMacOSTheme, isSystem7Theme: isSystem7, isXpTheme, isWin98 },
+          { isMacOSTheme, isSystem7Theme: isSystem7, isWindowsTheme, isWin98 },
           { border: "bottom" }
         ),
         isMacOSTheme && "bg-[#f7f7f7]/95 border-black/15",
@@ -106,10 +106,10 @@ const TvChannelLogoStrip = memo(function TvChannelLogoStrip({
                 isSystem7 &&
                   "rounded-none border border-black bg-white hover:bg-black hover:text-white",
                 isSystem7 && isActive && "outline outline-2 outline-black outline-offset-[-4px]",
-                isXpTheme &&
+                isWindowsTheme &&
                   !isWin98 &&
                   "rounded-[4px] border border-[#7f9db9] bg-white shadow-[inset_0_1px_0_rgba(255,255,255,0.8)] hover:bg-[#f4f8ff]",
-                isXpTheme &&
+                isWindowsTheme &&
                   !isWin98 &&
                   isActive &&
                   "border-os-window bg-[#dce9ff] ring-2 ring-[color:var(--os-color-selection-bg)]/50",
@@ -133,7 +133,7 @@ const TvChannelLogoStrip = memo(function TvChannelLogoStrip({
                     "font-geneva-12 text-[10px] font-bold leading-none",
                     isMacOSTheme && "text-black/70",
                     isSystem7 && "font-chicago text-black",
-                    isXpTheme && "font-tahoma text-[#1f3f77]",
+                    isWindowsTheme && "font-tahoma text-[#1f3f77]",
                     isWin98 && "text-[#202020]"
                   )}
                 >
@@ -161,7 +161,7 @@ interface TvVideoDrawerItemProps {
   itemRef?: Ref<HTMLLIElement>;
   isMacOSTheme: boolean;
   isSystem7: boolean;
-  isXpTheme: boolean;
+  isWindowsTheme: boolean;
   isWin98: boolean;
 }
 
@@ -176,7 +176,7 @@ const TvVideoDrawerItem = memo(function TvVideoDrawerItem({
   itemRef,
   isMacOSTheme,
   isSystem7,
-  isXpTheme,
+  isWindowsTheme,
   isWin98,
 }: TvVideoDrawerItemProps) {
   return (
@@ -190,8 +190,8 @@ const TvVideoDrawerItem = memo(function TvVideoDrawerItem({
           isMacOSTheme && isActive && "tv-drawer-mac-row-active",
           isSystem7 && "font-chicago text-[12px] hover:bg-black hover:text-white",
           isSystem7 && isActive && "bg-black text-white hover:bg-black hover:text-white",
-          isXpTheme && "font-tahoma text-[11px] hover:bg-[#316AC5]/15",
-          isXpTheme && isActive && "bg-[#316AC5] text-white hover:bg-[#316AC5]"
+          isWindowsTheme && "font-tahoma text-[11px] hover:bg-[#316AC5]/15",
+          isWindowsTheme && isActive && "bg-[#316AC5] text-white hover:bg-[#316AC5]"
         )}
       >
         <span className={cn("shrink-0 w-5 text-right tabular-nums opacity-70", isActive && "opacity-100")}>
@@ -221,7 +221,7 @@ const TvVideoDrawerItem = memo(function TvVideoDrawerItem({
                 ? "text-white/75 hover:text-white hover:bg-white/15 hover:border-white/25 focus-visible:ring-white/60"
                 : "text-black/55 hover:text-red-700 hover:bg-black/[0.06] hover:border-black/15"
             ),
-            isXpTheme && !isWin98 && cn(
+            isWindowsTheme && !isWin98 && cn(
               "rounded-sm",
               isActive
                 ? "text-white/85 hover:text-white hover:bg-white/18 focus-visible:ring-white/70"
@@ -277,7 +277,7 @@ export const TvVideoDrawer = memo(function TvVideoDrawer({
   const {
     isMacOSTheme,
     isSystem7Theme: isSystem7,
-    isWindowsTheme: isXpTheme,
+    isWindowsTheme,
     isWin98,
   } = useThemeFlags();
 
@@ -318,7 +318,7 @@ export const TvVideoDrawer = memo(function TvVideoDrawer({
       onSelectChannel={onSelectChannel}
       isMacOSTheme={isMacOSTheme}
       isSystem7={isSystem7}
-      isXpTheme={isXpTheme}
+      isWindowsTheme={isWindowsTheme}
       isWin98={isWin98}
     />
   );
@@ -337,7 +337,7 @@ export const TvVideoDrawer = memo(function TvVideoDrawer({
               "px-3 py-2 text-[11px] opacity-60",
               isMacOSTheme && "font-lucida-grande",
               isSystem7 && "font-chicago",
-              isXpTheme && "font-tahoma"
+              isWindowsTheme && "font-tahoma"
             )}
           >
             {t("apps.tv.drawer.empty")}
@@ -358,7 +358,7 @@ export const TvVideoDrawer = memo(function TvVideoDrawer({
                 itemRef={isActive ? activeItemRef : undefined}
                 isMacOSTheme={isMacOSTheme}
                 isSystem7={isSystem7}
-                isXpTheme={isXpTheme}
+                isWindowsTheme={isWindowsTheme}
                 isWin98={isWin98}
               />
             );

--- a/src/apps/tv/components/tv-app/TvAppComponent.tsx
+++ b/src/apps/tv/components/tv-app/TvAppComponent.tsx
@@ -56,7 +56,7 @@ export function TvAppComponent(props: AppProps) {
   return (
     <AppWindowShell
       isWindowOpen={c.isWindowOpen}
-      isXpTheme={c.isXpTheme}
+      isWindowsTheme={c.isWindowsTheme}
       isForeground={c.isForeground}
       menuBar={c.menuBar}
       windowFrameProps={{

--- a/src/apps/tv/components/tv-app/useTvAppController.tsx
+++ b/src/apps/tv/components/tv-app/useTvAppController.tsx
@@ -27,7 +27,7 @@ export function useTvAppController({
   const {
     t,
     translatedHelpItems,
-    isXpTheme,
+    isWindowsTheme,
     isMacOSTheme,
     isHelpDialogOpen,
     setIsHelpDialogOpen,
@@ -261,7 +261,7 @@ export function useTvAppController({
     skipInitialSound,
     t,
     translatedHelpItems,
-    isXpTheme,
+    isWindowsTheme,
     isMacOSTheme,
     isHelpDialogOpen,
     setIsHelpDialogOpen,

--- a/src/apps/tv/hooks/useTvLogic.ts
+++ b/src/apps/tv/hooks/useTvLogic.ts
@@ -63,7 +63,7 @@ export function useTvLogic({ isWindowOpen, isForeground }: UseTvLogicOptions) {
     [customChannels, hiddenDefaultChannelIds]
   );
 
-  const { isWindowsTheme: isXpTheme, isMacOSTheme } = useThemeFlags();
+  const { isWindowsTheme, isMacOSTheme } = useThemeFlags();
   const masterVolume = useAudioSettingsStore((state) => state.masterVolume);
 
   const {
@@ -547,7 +547,7 @@ export function useTvLogic({ isWindowOpen, isForeground }: UseTvLogicOptions) {
   return {
     t,
     translatedHelpItems,
-    isXpTheme,
+    isWindowsTheme,
     isMacOSTheme,
     isHelpDialogOpen,
     setIsHelpDialogOpen,

--- a/src/apps/videos/components/VideosMenuBar.tsx
+++ b/src/apps/videos/components/VideosMenuBar.tsx
@@ -81,8 +81,8 @@ export function VideosMenuBar({
   const {
     isShareDialogOpen,
     setIsShareDialogOpen,
-    isXpTheme,
-    isMacOsxTheme,
+    isWindowsTheme,
+    isMacOSTheme,
     appId,
     appName,
   } = useAppMenuBarChrome("videos");
@@ -139,8 +139,8 @@ export function VideosMenuBar({
 
   return (
     <AppMenuBarShell
-      isXpTheme={isXpTheme}
-      isMacOsxTheme={isMacOsxTheme}
+      isWindowsTheme={isWindowsTheme}
+      isMacOSTheme={isMacOSTheme}
       appId={appId}
       appName={appName}
       isShareDialogOpen={isShareDialogOpen}

--- a/src/apps/videos/components/videos-app/VideosAppComponent.tsx
+++ b/src/apps/videos/components/videos-app/VideosAppComponent.tsx
@@ -29,7 +29,7 @@ export function VideosAppComponent({
   });
 
   const {
-    isXpTheme,
+    isWindowsTheme,
     isMacOSTheme,
     menuBar,
     shouldShowWhiteNoise,
@@ -60,7 +60,7 @@ export function VideosAppComponent({
   return (
     <AppWindowShell
       isWindowOpen={isWindowOpen}
-      isXpTheme={isXpTheme}
+      isWindowsTheme={isWindowsTheme}
       isForeground={isForeground}
       menuBar={menuBar}
       windowFrameProps={{

--- a/src/apps/videos/hooks/useVideosLogic.ts
+++ b/src/apps/videos/hooks/useVideosLogic.ts
@@ -69,7 +69,7 @@ export function useVideosLogic({
   // Theme and audio settings
   const {
     currentTheme,
-    isWindowsTheme: isXpTheme,
+    isWindowsTheme,
     isMacOSTheme,
   } = useThemeFlags();
   const masterVolume = useAudioSettingsStore((state) => state.masterVolume);
@@ -1097,7 +1097,7 @@ export function useVideosLogic({
 
     // Theme and audio
     currentTheme,
-    isXpTheme,
+    isWindowsTheme,
     isMacOSTheme,
     masterVolume,
 

--- a/src/apps/winamp/components/WinampAppComponent.tsx
+++ b/src/apps/winamp/components/WinampAppComponent.tsx
@@ -56,7 +56,7 @@ export function WinampAppComponent({
     setIsHelpDialogOpen,
     isAboutDialogOpen,
     setIsAboutDialogOpen,
-    isXpTheme,
+    isWindowsTheme,
   } = useWinampLogic();
 
   const handleSkinChange = useCallback((url: string | null) => {
@@ -325,7 +325,7 @@ export function WinampAppComponent({
     <AppWindowShell
       frameless
       isWindowOpen={isWindowOpen}
-      isXpTheme={isXpTheme}
+      isWindowsTheme={isWindowsTheme}
       isForeground={isForeground}
       menuBar={menuBar}
       trailing={

--- a/src/apps/winamp/components/WinampMenuBar.tsx
+++ b/src/apps/winamp/components/WinampMenuBar.tsx
@@ -59,8 +59,8 @@ export function WinampMenuBar({
   const {
     isShareDialogOpen,
     setIsShareDialogOpen,
-    isXpTheme,
-    isMacOsxTheme,
+    isWindowsTheme,
+    isMacOSTheme,
     appId,
     appName,
   } = useAppMenuBarChrome("winamp");
@@ -81,8 +81,8 @@ export function WinampMenuBar({
 
   return (
     <AppMenuBarShell
-      isXpTheme={isXpTheme}
-      isMacOsxTheme={isMacOsxTheme}
+      isWindowsTheme={isWindowsTheme}
+      isMacOSTheme={isMacOSTheme}
       appId={appId}
       appName={appName}
       isShareDialogOpen={isShareDialogOpen}

--- a/src/apps/winamp/hooks/useWinampLogic.ts
+++ b/src/apps/winamp/hooks/useWinampLogic.ts
@@ -7,7 +7,7 @@ import { useThemeFlags } from "@/hooks/useThemeFlags";
 export function useWinampLogic() {
   const { t } = useTranslation();
   const translatedHelpItems = useTranslatedHelpItems("winamp", helpItems);
-  const { isWindowsTheme: isXpTheme } = useThemeFlags();
+  const { isWindowsTheme } = useThemeFlags();
 
   const {
     isHelpDialogOpen,
@@ -19,7 +19,7 @@ export function useWinampLogic() {
   return {
     t,
     translatedHelpItems,
-    isXpTheme,
+    isWindowsTheme,
     isHelpDialogOpen,
     setIsHelpDialogOpen,
     isAboutDialogOpen,

--- a/src/components/dialogs/AboutDialog.tsx
+++ b/src/components/dialogs/AboutDialog.tsx
@@ -40,7 +40,7 @@ export function AboutDialog({
   appId,
 }: AboutDialogProps) {
   const { t } = useTranslation();
-  const { isWindowsTheme: isXpTheme, isMacOSTheme, isSystem7Theme } = useThemeFlags();
+  const { isWindowsTheme, isMacOSTheme, isSystem7Theme } = useThemeFlags();
   const launchApp = useAppStore((state) => state.launchApp);
   
   // Use translated app name if appId is provided, otherwise fall back to metadata.name
@@ -64,23 +64,23 @@ export function AboutDialog({
       <div
         className={cn(
           "space-y-0 text-center",
-          isXpTheme
+          isWindowsTheme
             ? "font-['Pixelated_MS_Sans_Serif',Arial] text-[11px]"
             : isSystem7Theme
             ? "font-geneva-12 text-[10px]"
             : "font-os-ui text-[12px]"
         )}
         style={{
-          fontFamily: isXpTheme
+          fontFamily: isWindowsTheme
             ? '"Pixelated MS Sans Serif", "ArkPixel", Arial'
             : undefined,
-          fontSize: isXpTheme ? "11px" : undefined,
+          fontSize: isWindowsTheme ? "11px" : undefined,
         }}
       >
         <div
           className={cn(
             "!text-3xl font-medium",
-            isXpTheme
+            isWindowsTheme
               ? "font-['Trebuchet MS'] !text-[17px]"
               : "font-apple-garamond"
           )}
@@ -128,13 +128,13 @@ export function AboutDialog({
   return (
     <Dialog open={isOpen} onOpenChange={onOpenChange}>
       <DialogContent
-        className={cn("w-fit min-w-[280px] max-w-[400px]", isXpTheme && "p-0 overflow-hidden")}
-        style={isXpTheme ? { fontSize: "11px" } : undefined}
+        className={cn("w-fit min-w-[280px] max-w-[400px]", isWindowsTheme && "p-0 overflow-hidden")}
+        style={isWindowsTheme ? { fontSize: "11px" } : undefined}
       >
-        {isXpTheme ? (
+        {isWindowsTheme ? (
           <>
             <DialogHeader>{t("common.dialog.aboutApp", { appName: displayName })}</DialogHeader>
-            <div className={`window-body ${isXpTheme ? "p-2 px-4" : "p-4"}`}>
+            <div className={`window-body ${isWindowsTheme ? "p-2 px-4" : "p-4"}`}>
               {dialogContent}
             </div>
           </>

--- a/src/components/dialogs/AboutFinderDialog.tsx
+++ b/src/components/dialogs/AboutFinderDialog.tsx
@@ -36,7 +36,7 @@ export function AboutFinderDialog({
   const { t } = useTranslation();
   const instances = useAppStore((state) => state.instances);
   const launchApp = useAppStore((state) => state.launchApp);
-  const { isWindowsTheme: isXpTheme, currentTheme } = useThemeFlags();
+  const { isWindowsTheme, currentTheme } = useThemeFlags();
   const version = useAppStore((state) => state.ryOSVersion);
   const buildNumber = useAppStore((state) => state.ryOSBuildNumber);
   const buildTime = useAppStore((state) => state.ryOSBuildTime);
@@ -140,7 +140,7 @@ export function AboutFinderDialog({
 
   const aboutFinderSmallClass = cn(
     "about-finder-small",
-    isXpTheme
+    isWindowsTheme
       ? "font-['Pixelated_MS_Sans_Serif',Arial] text-[10px]"
       : currentTheme === "macosx"
       ? "font-os-ui text-[13px]"
@@ -151,7 +151,7 @@ export function AboutFinderDialog({
     <div
       className={cn(
         "about-finder-dialog",
-        isXpTheme ? "p-2 px-4" : "p-4"
+        isWindowsTheme ? "p-2 px-4" : "p-4"
       )}
     >
       <div className="flex">
@@ -166,7 +166,7 @@ export function AboutFinderDialog({
               />
               <div
                 className={cn(
-                  isXpTheme
+                  isWindowsTheme
                     ? "font-['Pixelated_MS_Sans_Serif',Arial] text-[16px]"
                     : currentTheme === "macosx"
                     ? "font-apple-garamond text-2xl"
@@ -190,7 +190,7 @@ export function AboutFinderDialog({
                   "cursor-pointer select-none transition-opacity hover:opacity-70 text-neutral-500"
                 )}
                 style={
-                  isXpTheme
+                  isWindowsTheme
                     ? {
                         fontFamily:
                           '"Pixelated MS Sans Serif", "ArkPixel", Arial',
@@ -220,14 +220,14 @@ export function AboutFinderDialog({
               <div
                 className={cn(
                   "text-neutral-500",
-                  isXpTheme
+                  isWindowsTheme
                     ? "font-['Pixelated_MS_Sans_Serif',Arial] text-[10px]"
                     : currentTheme === "macosx"
                     ? "font-os-ui text-[11px]"
                     : "font-os-ui text-[10px]"
                 )}
                 style={
-                  isXpTheme
+                  isWindowsTheme
                     ? {
                         fontFamily:
                           '"Pixelated MS Sans Serif", "ArkPixel", Arial',
@@ -308,10 +308,10 @@ export function AboutFinderDialog({
   return (
     <Dialog open={isOpen} onOpenChange={onOpenChange}>
       <DialogContent
-        className={cn("max-w-[400px]", isXpTheme && "p-0 overflow-hidden")}
-        style={isXpTheme ? { fontSize: "11px" } : undefined}
+        className={cn("max-w-[400px]", isWindowsTheme && "p-0 overflow-hidden")}
+        style={isWindowsTheme ? { fontSize: "11px" } : undefined}
       >
-        {isXpTheme ? (
+        {isWindowsTheme ? (
           <>
             <DialogHeader>{t("common.aboutThisMac.title")}</DialogHeader>
             <div className="window-body">{dialogContent}</div>

--- a/src/components/dialogs/ChangePasswordDialog.tsx
+++ b/src/components/dialogs/ChangePasswordDialog.tsx
@@ -57,7 +57,7 @@ export function ChangePasswordDialog({
 }: ChangePasswordDialogProps) {
   const { t } = useTranslation();
   const {
-    isWindowsTheme: isXpTheme,
+    isWindowsTheme,
     isMacOSTheme: isMacTheme,
   } = useThemeFlags();
 
@@ -109,10 +109,10 @@ export function ChangePasswordDialog({
     }
   }, [isOpen]);
 
-  const themeFont = isXpTheme
+  const themeFont = isWindowsTheme
     ? "font-['Pixelated_MS_Sans_Serif',Arial] text-[11px]"
     : "font-geneva-12 text-[12px]";
-  const themeFontStyle: React.CSSProperties | undefined = isXpTheme
+  const themeFontStyle: React.CSSProperties | undefined = isWindowsTheme
     ? {
         fontFamily: '"Pixelated MS Sans Serif", "ArkPixel", Arial',
         fontSize: "11px",
@@ -294,7 +294,7 @@ export function ChangePasswordDialog({
   );
 
   const dialogBody = (
-    <div className={isXpTheme ? "p-2 px-4" : "p-4 px-6"}>
+    <div className={isWindowsTheme ? "p-2 px-4" : "p-4 px-6"}>
       <p
         className={cn("text-neutral-500 mb-3", themeFont)}
         style={themeFontStyle}
@@ -309,11 +309,11 @@ export function ChangePasswordDialog({
   return (
     <Dialog open={isOpen} onOpenChange={onOpenChange}>
       <DialogContent
-        className={cn("max-w-[420px]", isXpTheme && "p-0 overflow-hidden")}
-        style={isXpTheme ? { fontSize: "11px" } : undefined}
+        className={cn("max-w-[420px]", isWindowsTheme && "p-0 overflow-hidden")}
+        style={isWindowsTheme ? { fontSize: "11px" } : undefined}
         onKeyDown={(e: React.KeyboardEvent) => e.stopPropagation()}
       >
-        {isXpTheme ? (
+        {isWindowsTheme ? (
           <>
             <DialogHeader>{dialogTitle}</DialogHeader>
             <div className="window-body">{dialogBody}</div>

--- a/src/components/dialogs/ConfirmDialog.tsx
+++ b/src/components/dialogs/ConfirmDialog.tsx
@@ -33,7 +33,7 @@ export function ConfirmDialog({
   const confirmButtonRef = useRef<HTMLButtonElement>(null);
   const { play: playAlertSound } = useSound(Sounds.ALERT_SOSUMI);
   const {
-    isWindowsTheme: isXpTheme,
+    isWindowsTheme,
     isMacOSTheme: isMacTheme,
   } = useThemeFlags();
 
@@ -45,7 +45,7 @@ export function ConfirmDialog({
   }, [isOpen, playAlertSound]);
 
   const dialogContent = (
-    <div className={isXpTheme ? "p-2 px-4" : "p-6"}>
+    <div className={isWindowsTheme ? "p-2 px-4" : "p-6"}>
       <div className="flex gap-3 items-start">
         <ThemedIcon
           name="warn.png"
@@ -57,15 +57,15 @@ export function ConfirmDialog({
         <p
           className={cn(
             "text-neutral-900 mb-2 leading-tight",
-            isXpTheme
+            isWindowsTheme
               ? "font-['Pixelated_MS_Sans_Serif',Arial] text-[11px]"
               : "font-geneva-12 text-[12px]"
           )}
           style={{
-            fontFamily: isXpTheme
+            fontFamily: isWindowsTheme
               ? '"Pixelated MS Sans Serif", "ArkPixel", Arial'
               : undefined,
-            fontSize: isXpTheme ? "11px" : undefined,
+            fontSize: isWindowsTheme ? "11px" : undefined,
           }}
         >
           {description}
@@ -77,15 +77,15 @@ export function ConfirmDialog({
           onClick={() => onOpenChange(false)}
           className={cn(
             "h-7",
-            isXpTheme
+            isWindowsTheme
               ? "font-['Pixelated_MS_Sans_Serif',Arial] text-[11px]"
               : "font-geneva-12 text-[12px]"
           )}
           style={{
-            fontFamily: isXpTheme
+            fontFamily: isWindowsTheme
               ? '"Pixelated MS Sans Serif", "ArkPixel", Arial'
               : undefined,
-            fontSize: isXpTheme ? "11px" : undefined,
+            fontSize: isWindowsTheme ? "11px" : undefined,
           }}
         >
           {t("common.dialog.cancel")}
@@ -96,15 +96,15 @@ export function ConfirmDialog({
           ref={confirmButtonRef}
           className={cn(
             !isMacTheme && "h-7",
-            isXpTheme
+            isWindowsTheme
               ? "font-['Pixelated_MS_Sans_Serif',Arial] text-[11px]"
               : "font-geneva-12 text-[12px]"
           )}
           style={{
-            fontFamily: isXpTheme
+            fontFamily: isWindowsTheme
               ? '"Pixelated MS Sans Serif", "ArkPixel", Arial'
               : undefined,
-            fontSize: isXpTheme ? "11px" : undefined,
+            fontSize: isWindowsTheme ? "11px" : undefined,
           }}
         >
           {t("common.dialog.confirm")}
@@ -116,14 +116,14 @@ export function ConfirmDialog({
   return (
     <Dialog open={isOpen} onOpenChange={onOpenChange}>
       <DialogContent
-        className={cn("max-w-[400px]", isXpTheme && "p-0 overflow-hidden")}
-        style={isXpTheme ? { fontSize: "11px" } : undefined}
+        className={cn("max-w-[400px]", isWindowsTheme && "p-0 overflow-hidden")}
+        style={isWindowsTheme ? { fontSize: "11px" } : undefined}
         onOpenAutoFocus={(e) => {
           e.preventDefault();
           confirmButtonRef.current?.focus();
         }}
       >
-        {isXpTheme ? (
+        {isWindowsTheme ? (
           <>
             <DialogHeader>{title}</DialogHeader>
             <div className="window-body">{dialogContent}</div>

--- a/src/components/dialogs/EmojiDialog.tsx
+++ b/src/components/dialogs/EmojiDialog.tsx
@@ -233,23 +233,23 @@ export function EmojiDialog({
   onEmojiSelect,
 }: EmojiDialogProps) {
   const { t } = useTranslation();
-  const { isWindowsTheme: isXpTheme, isMacOSTheme } = useThemeFlags();
+  const { isWindowsTheme, isMacOSTheme } = useThemeFlags();
 
   const dialogContent = (
-    <div className={isXpTheme ? "p-2 px-4 pt-0" : "p-4 py-6"}>
+    <div className={isWindowsTheme ? "p-2 px-4 pt-0" : "p-4 py-6"}>
       <p
         id="dialog-description"
         className={cn(
           "mb-2 text-neutral-500",
-          isXpTheme
+          isWindowsTheme
             ? "font-['Pixelated_MS_Sans_Serif',Arial] text-[11px]"
             : "font-geneva-12 text-[12px]"
         )}
         style={{
-          fontFamily: isXpTheme
+          fontFamily: isWindowsTheme
             ? '"Pixelated MS Sans Serif", "ArkPixel", Arial'
             : undefined,
-          fontSize: isXpTheme ? "11px" : undefined,
+          fontSize: isWindowsTheme ? "11px" : undefined,
         }}
       >
         {t("common.dialog.emoji.chooseEmoji")}
@@ -274,10 +274,10 @@ export function EmojiDialog({
   return (
     <Dialog open={isOpen} onOpenChange={onOpenChange}>
       <DialogContent
-        className={cn("max-w-[500px]", isXpTheme && "p-0 overflow-hidden")}
-        style={isXpTheme ? { fontSize: "11px" } : undefined}
+        className={cn("max-w-[500px]", isWindowsTheme && "p-0 overflow-hidden")}
+        style={isWindowsTheme ? { fontSize: "11px" } : undefined}
       >
-        {isXpTheme ? (
+        {isWindowsTheme ? (
           <>
             <DialogHeader>{t("common.dialog.emoji.setEmoji")}</DialogHeader>
             <div className="window-body">{dialogContent}</div>

--- a/src/components/dialogs/FutureSettingsDialog.tsx
+++ b/src/components/dialogs/FutureSettingsDialog.tsx
@@ -34,7 +34,7 @@ const FutureSettingsDialog = ({
 }: FutureSettingsDialogProps) => {
   const { t } = useTranslation();
   const {
-    isWindowsTheme: isXpTheme,
+    isWindowsTheme,
     isMacOSTheme: isMacTheme,
   } = useThemeFlags();
   const [selectedYear, setSelectedYear] = useState<string>("2030");
@@ -99,21 +99,21 @@ const FutureSettingsDialog = ({
   };
 
   const dialogContent = (
-    <div className={isXpTheme ? "p-2 px-4" : "p-4 px-6"}>
+    <div className={isWindowsTheme ? "p-2 px-4" : "p-4 px-6"}>
       <div className="flex flex-col gap-4">
         <div className="flex items-center gap-2">
           <span
             className={cn(
               "text-neutral-900",
-              isXpTheme
+              isWindowsTheme
                 ? "font-['Pixelated_MS_Sans_Serif',Arial] text-[11px]"
                 : "font-geneva-12 text-[12px]"
             )}
             style={{
-              fontFamily: isXpTheme
+              fontFamily: isWindowsTheme
                 ? '"Pixelated MS Sans Serif", "ArkPixel", Arial'
                 : undefined,
-              fontSize: isXpTheme ? "11px" : undefined,
+              fontSize: isWindowsTheme ? "11px" : undefined,
             }}
           >
             {t("apps.internet-explorer.year")}:
@@ -148,15 +148,15 @@ const FutureSettingsDialog = ({
           placeholder={getDefaultTimelineText(selectedYear)}
           className={cn(
             "min-h-[200px]",
-            isXpTheme
+            isWindowsTheme
               ? "font-['Pixelated_MS_Sans_Serif',Arial] text-[11px]"
               : "font-geneva-12 text-[12px]"
           )}
           style={{
-            fontFamily: isXpTheme
+            fontFamily: isWindowsTheme
               ? '"Pixelated MS Sans Serif", "ArkPixel", Arial'
               : undefined,
-            fontSize: isXpTheme ? "11px" : undefined,
+            fontSize: isWindowsTheme ? "11px" : undefined,
           }}
         />
         <div className="flex justify-end gap-1">
@@ -165,15 +165,15 @@ const FutureSettingsDialog = ({
             onClick={handleReset}
             className={cn(
               "h-7",
-              isXpTheme
+              isWindowsTheme
                 ? "font-['Pixelated_MS_Sans_Serif',Arial] text-[11px]"
                 : "font-geneva-12 text-[12px]"
             )}
             style={{
-              fontFamily: isXpTheme
+              fontFamily: isWindowsTheme
                 ? '"Pixelated MS Sans Serif", "ArkPixel", Arial'
                 : undefined,
-              fontSize: isXpTheme ? "11px" : undefined,
+              fontSize: isWindowsTheme ? "11px" : undefined,
             }}
           >
             {t("apps.internet-explorer.futureTimeline.reset")}
@@ -184,15 +184,15 @@ const FutureSettingsDialog = ({
             ref={saveButtonRef}
             className={cn(
               !isMacTheme && "h-7",
-              isXpTheme
+              isWindowsTheme
                 ? "font-['Pixelated_MS_Sans_Serif',Arial] text-[11px]"
                 : "font-geneva-12 text-[12px]"
             )}
             style={{
-              fontFamily: isXpTheme
+              fontFamily: isWindowsTheme
                 ? '"Pixelated MS Sans Serif", "ArkPixel", Arial'
                 : undefined,
-              fontSize: isXpTheme ? "11px" : undefined,
+              fontSize: isWindowsTheme ? "11px" : undefined,
             }}
           >
             {t("common.dialog.close")}
@@ -207,15 +207,15 @@ const FutureSettingsDialog = ({
       <DialogContent
         className={cn(
           "bg-os-window-bg border-[length:var(--os-metrics-border-width)] border-os-window rounded-os shadow-os-window",
-          isXpTheme && "p-0 overflow-hidden"
+          isWindowsTheme && "p-0 overflow-hidden"
         )}
-        style={isXpTheme ? { fontSize: "11px" } : undefined}
+        style={isWindowsTheme ? { fontSize: "11px" } : undefined}
         onOpenAutoFocus={(e) => {
           e.preventDefault();
           saveButtonRef.current?.focus();
         }}
       >
-        {isXpTheme ? (
+        {isWindowsTheme ? (
           <>
             <DialogHeader>
               {t("apps.internet-explorer.futureTimeline.title")}

--- a/src/components/dialogs/HelpDialog.tsx
+++ b/src/components/dialogs/HelpDialog.tsx
@@ -33,7 +33,7 @@ interface HelpCardProps {
 }
 
 function HelpCard({ icon, title, description }: HelpCardProps) {
-  const { isWindowsTheme: isXpTheme, isMacOSTheme: isMacTheme } =
+  const { isWindowsTheme, isMacOSTheme: isMacTheme } =
     useThemeFlags();
 
   return (
@@ -48,14 +48,14 @@ function HelpCard({ icon, title, description }: HelpCardProps) {
         <h3
           className={cn(
             "font-medium leading-snug",
-            isXpTheme && "font-['Pixelated_MS_Sans_Serif',Arial] text-[11px]",
+            isWindowsTheme && "font-['Pixelated_MS_Sans_Serif',Arial] text-[11px]",
             isMacTheme && "font-bold"
           )}
           style={{
-            fontFamily: isXpTheme
+            fontFamily: isWindowsTheme
               ? '"Pixelated MS Sans Serif", "ArkPixel", Arial'
               : undefined,
-            fontSize: isXpTheme ? "11px" : undefined,
+            fontSize: isWindowsTheme ? "11px" : undefined,
           }}
         >
           {title}
@@ -63,15 +63,15 @@ function HelpCard({ icon, title, description }: HelpCardProps) {
         <p
           className={cn(
             "mt-0.5 text-neutral-700 leading-snug",
-            isXpTheme
+            isWindowsTheme
               ? "font-['Pixelated_MS_Sans_Serif',Arial] text-[10px]"
               : "font-geneva-12 text-[10px]"
           )}
           style={{
-            fontFamily: isXpTheme
+            fontFamily: isWindowsTheme
               ? '"Pixelated MS Sans Serif", "ArkPixel", Arial'
               : undefined,
-            fontSize: isXpTheme ? "10px" : undefined,
+            fontSize: isWindowsTheme ? "10px" : undefined,
           }}
         >
           {description}
@@ -155,7 +155,7 @@ export function HelpDialog({
   appId,
 }: HelpDialogProps) {
   const { t } = useTranslation();
-  const { isWindowsTheme: isXpTheme, isMacOSTheme: isMacTheme } =
+  const { isWindowsTheme, isMacOSTheme: isMacTheme } =
     useThemeFlags();
   const launchApp = useAppStore((state) => state.launchApp);
 
@@ -180,20 +180,20 @@ export function HelpDialog({
   };
 
   const dialogContent = (
-    <div className={isXpTheme ? "p-2 px-4" : "p-6 pt-4"}>
+    <div className={isWindowsTheme ? "p-2 px-4" : "p-6 pt-4"}>
       <div className="mb-4 flex items-center justify-between">
         <p
           className={cn(
             "text-2xl",
-            isXpTheme
+            isWindowsTheme
               ? "font-['Pixelated_MS_Sans_Serif',Arial]"
               : "font-apple-garamond"
           )}
           style={{
-            fontFamily: isXpTheme
+            fontFamily: isWindowsTheme
               ? '"Pixelated MS Sans Serif", "ArkPixel", Arial'
               : undefined,
-            fontSize: isXpTheme ? "18px" : undefined,
+            fontSize: isWindowsTheme ? "18px" : undefined,
           }}
         >
           {t("common.dialog.welcomeTo", { appName: displayAppName })}
@@ -205,7 +205,7 @@ export function HelpDialog({
           >
             {t("common.dialog.viewDocs")}
           </button>
-        ) : isXpTheme ? (
+        ) : isWindowsTheme ? (
           <button className="button" onClick={handleViewDocs}>
             {t("common.dialog.viewDocs")}
           </button>
@@ -241,11 +241,11 @@ export function HelpDialog({
       <DialogContent
         className={cn(
           "max-w-[min(600px,calc(100vw-1.5rem))] overflow-hidden",
-          isXpTheme && "p-0"
+          isWindowsTheme && "p-0"
         )}
-        style={isXpTheme ? { fontSize: "11px" } : undefined}
+        style={isWindowsTheme ? { fontSize: "11px" } : undefined}
       >
-        {isXpTheme ? (
+        {isWindowsTheme ? (
           <>
             <DialogHeader>{t("common.dialog.help")}</DialogHeader>
             <div className="window-body overflow-hidden">{dialogContent}</div>

--- a/src/components/dialogs/InputDialog.tsx
+++ b/src/components/dialogs/InputDialog.tsx
@@ -50,7 +50,7 @@ export function InputDialog({
 }: InputDialogProps) {
   const { t } = useTranslation();
   const {
-    isWindowsTheme: isXpTheme,
+    isWindowsTheme,
     isMacOSTheme: isMacTheme,
   } = useThemeFlags();
   const defaultSubmitLabel = submitLabel || t("common.dialog.save");
@@ -75,19 +75,19 @@ export function InputDialog({
   };
 
   const dialogContent = (
-    <div className={isXpTheme ? "p-2 px-4" : "p-4 px-6"}>
+    <div className={isWindowsTheme ? "p-2 px-4" : "p-4 px-6"}>
       <p
         className={cn(
           "text-neutral-500 mb-2",
-          isXpTheme
+          isWindowsTheme
             ? "font-['Pixelated_MS_Sans_Serif',Arial] text-[11px]"
             : "font-geneva-12 text-[12px]"
         )}
         style={{
-          fontFamily: isXpTheme
+          fontFamily: isWindowsTheme
             ? '"Pixelated MS Sans Serif", "ArkPixel", Arial'
             : undefined,
-          fontSize: isXpTheme ? "11px" : undefined,
+          fontSize: isWindowsTheme ? "11px" : undefined,
         }}
         id="dialog-description"
       >
@@ -105,15 +105,15 @@ export function InputDialog({
         }}
         className={cn(
           "shadow-none",
-          isXpTheme
+          isWindowsTheme
             ? "font-['Pixelated_MS_Sans_Serif',Arial] text-[11px]"
             : "font-geneva-12 text-[12px]"
         )}
         style={{
-          fontFamily: isXpTheme
+          fontFamily: isWindowsTheme
             ? '"Pixelated MS Sans Serif", "ArkPixel", Arial'
             : undefined,
-          fontSize: isXpTheme ? "11px" : undefined,
+          fontSize: isWindowsTheme ? "11px" : undefined,
         }}
         disabled={isLoading}
       />
@@ -130,15 +130,15 @@ export function InputDialog({
                 disabled={isLoading}
                 className={cn(
                   "w-full sm:w-auto h-7",
-                  isXpTheme
+                  isWindowsTheme
                     ? "font-['Pixelated_MS_Sans_Serif',Arial] text-[11px]"
                     : "font-geneva-12 text-[12px]"
                 )}
                 style={{
-                  fontFamily: isXpTheme
+                  fontFamily: isWindowsTheme
                     ? '"Pixelated MS Sans Serif", "ArkPixel", Arial'
                     : undefined,
-                  fontSize: isXpTheme ? "11px" : undefined,
+                  fontSize: isWindowsTheme ? "11px" : undefined,
                 }}
               >
                 {action.label}
@@ -154,15 +154,15 @@ export function InputDialog({
                 disabled={isLoading}
                 className={cn(
                   "w-full sm:w-auto h-7",
-                  isXpTheme
+                  isWindowsTheme
                     ? "font-['Pixelated_MS_Sans_Serif',Arial] text-[11px]"
                     : "font-geneva-12 text-[12px]"
                 )}
                 style={{
-                  fontFamily: isXpTheme
+                  fontFamily: isWindowsTheme
                     ? '"Pixelated MS Sans Serif", "ArkPixel", Arial'
                     : undefined,
-                  fontSize: isXpTheme ? "11px" : undefined,
+                  fontSize: isWindowsTheme ? "11px" : undefined,
                 }}
               >
                 {action.label}
@@ -176,15 +176,15 @@ export function InputDialog({
               className={cn(
                 "w-full sm:w-auto",
                 !isMacTheme && "h-7",
-                isXpTheme
+                isWindowsTheme
                   ? "font-['Pixelated_MS_Sans_Serif',Arial] text-[11px]"
                   : "font-geneva-12 text-[12px]"
               )}
               style={{
-                fontFamily: isXpTheme
+                fontFamily: isWindowsTheme
                   ? '"Pixelated MS Sans Serif", "ArkPixel", Arial'
                   : undefined,
-                fontSize: isXpTheme ? "11px" : undefined,
+                fontSize: isWindowsTheme ? "11px" : undefined,
               }}
             >
               {t("common.dialog.cancel")}
@@ -197,15 +197,15 @@ export function InputDialog({
             className={cn(
               "w-full sm:w-auto",
               !isMacTheme && "h-7",
-              isXpTheme
+              isWindowsTheme
                 ? "font-['Pixelated_MS_Sans_Serif',Arial] text-[11px]"
                 : "font-geneva-12 text-[12px]"
             )}
             style={{
-              fontFamily: isXpTheme
+              fontFamily: isWindowsTheme
                 ? '"Pixelated MS Sans Serif", "ArkPixel", Arial'
                 : undefined,
-              fontSize: isXpTheme ? "11px" : undefined,
+              fontSize: isWindowsTheme ? "11px" : undefined,
             }}
           >
             {isLoading ? t("common.dialog.adding") : defaultSubmitLabel}
@@ -218,11 +218,11 @@ export function InputDialog({
   return (
     <Dialog open={isOpen} onOpenChange={onOpenChange}>
       <DialogContent
-        className={cn("max-w-[500px]", isXpTheme && "p-0 overflow-hidden")}
-        style={isXpTheme ? { fontSize: "11px" } : undefined}
+        className={cn("max-w-[500px]", isWindowsTheme && "p-0 overflow-hidden")}
+        style={isWindowsTheme ? { fontSize: "11px" } : undefined}
         onKeyDown={(e: React.KeyboardEvent) => e.stopPropagation()}
       >
-        {isXpTheme ? (
+        {isWindowsTheme ? (
           <>
             <DialogHeader>{title}</DialogHeader>
             <div className="window-body">{dialogContent}</div>

--- a/src/components/dialogs/LoginDialog.tsx
+++ b/src/components/dialogs/LoginDialog.tsx
@@ -68,7 +68,7 @@ export function LoginDialog({
   signUpError,
 }: LoginDialogProps) {
   const [activeTab, setActiveTab] = useState<"login" | "signup">(initialTab);
-  const { isWindowsTheme: isXpTheme, isMacOSTheme } = useThemeFlags();
+  const { isWindowsTheme, isMacOSTheme } = useThemeFlags();
   const { t } = useTranslation();
   const dialogTitle = t("common.auth.dialogTitle");
 
@@ -93,11 +93,11 @@ export function LoginDialog({
     }
   };
 
-  const themeFont = isXpTheme
+  const themeFont = isWindowsTheme
     ? "font-['Pixelated_MS_Sans_Serif',Arial] text-[11px]"
     : "font-geneva-12 text-[12px]";
 
-  const themeFontStyle: React.CSSProperties | undefined = isXpTheme
+  const themeFontStyle: React.CSSProperties | undefined = isWindowsTheme
     ? {
         fontFamily: '"Pixelated MS Sans Serif", "ArkPixel", Arial',
         fontSize: "11px",
@@ -282,11 +282,11 @@ export function LoginDialog({
   return (
     <Dialog open={isOpen} onOpenChange={onOpenChange}>
       <DialogContent
-        className={cn("max-w-[400px]", isXpTheme && "p-0 overflow-hidden")}
-        style={isXpTheme ? { fontSize: "11px" } : undefined}
+        className={cn("max-w-[400px]", isWindowsTheme && "p-0 overflow-hidden")}
+        style={isWindowsTheme ? { fontSize: "11px" } : undefined}
         onKeyDown={(e: React.KeyboardEvent) => e.stopPropagation()}
       >
-        {isXpTheme ? (
+        {isWindowsTheme ? (
           <>
             <DialogHeader>{dialogTitle}</DialogHeader>
             <div className="window-body">{dialogContent}</div>

--- a/src/components/dialogs/LyricsSearchDialog.tsx
+++ b/src/components/dialogs/LyricsSearchDialog.tsx
@@ -90,7 +90,7 @@ export function LyricsSearchDialog({
 }: LyricsSearchDialogProps) {
   const { t } = useTranslation();
   const {
-    isWindowsTheme: isXpTheme,
+    isWindowsTheme,
     isMacOSTheme: isMacTheme,
   } = useThemeFlags();
 
@@ -235,19 +235,19 @@ export function LyricsSearchDialog({
   }, []);
 
   const dialogContent = (
-    <div className={isXpTheme ? "p-2 px-4" : "p-4 px-6"}>
+    <div className={isWindowsTheme ? "p-2 px-4" : "p-4 px-6"}>
       <p
         className={cn(
           "text-neutral-500 mb-2",
-          isXpTheme
+          isWindowsTheme
             ? "font-['Pixelated_MS_Sans_Serif',Arial] text-[11px]"
             : "font-geneva-12 text-[12px]"
         )}
         style={{
-          fontFamily: isXpTheme
+          fontFamily: isWindowsTheme
             ? '"Pixelated MS Sans Serif", "ArkPixel", Arial'
             : undefined,
-          fontSize: isXpTheme ? "11px" : undefined,
+          fontSize: isWindowsTheme ? "11px" : undefined,
         }}
         id="dialog-description"
       >
@@ -273,15 +273,15 @@ export function LyricsSearchDialog({
           placeholder={t("apps.ipod.dialogs.lyricsSearchPlaceholder")}
           className={cn(
             "shadow-none flex-1",
-            isXpTheme
+            isWindowsTheme
               ? "font-['Pixelated_MS_Sans_Serif',Arial] text-[11px]"
               : "font-geneva-12 text-[12px]"
           )}
           style={{
-            fontFamily: isXpTheme
+            fontFamily: isWindowsTheme
               ? '"Pixelated MS Sans Serif", "ArkPixel", Arial'
               : undefined,
-            fontSize: isXpTheme ? "11px" : undefined,
+            fontSize: isWindowsTheme ? "11px" : undefined,
           }}
           disabled={isSearching}
         />
@@ -292,15 +292,15 @@ export function LyricsSearchDialog({
           className={cn(
             "flex-shrink-0",
             !isMacTheme && "h-7",
-            isXpTheme
+            isWindowsTheme
               ? "font-['Pixelated_MS_Sans_Serif',Arial] text-[11px]"
               : "font-geneva-12 text-[12px]"
           )}
           style={{
-            fontFamily: isXpTheme
+            fontFamily: isWindowsTheme
               ? '"Pixelated MS Sans Serif", "ArkPixel", Arial'
               : undefined,
-            fontSize: isXpTheme ? "11px" : undefined,
+            fontSize: isWindowsTheme ? "11px" : undefined,
           }}
         >
           {isSearching
@@ -315,15 +315,15 @@ export function LyricsSearchDialog({
           <p
             className={cn(
               "text-neutral-500 mb-2",
-              isXpTheme
+              isWindowsTheme
                 ? "font-['Pixelated_MS_Sans_Serif',Arial] text-[11px]"
                 : "font-geneva-12 text-[12px]"
             )}
             style={{
-              fontFamily: isXpTheme
+              fontFamily: isWindowsTheme
                 ? '"Pixelated MS Sans Serif", "ArkPixel", Arial'
                 : undefined,
-              fontSize: isXpTheme ? "11px" : undefined,
+              fontSize: isWindowsTheme ? "11px" : undefined,
             }}
           >
             {t("apps.ipod.dialogs.lyricsSearchCurrentSelection")}
@@ -332,16 +332,16 @@ export function LyricsSearchDialog({
             <div
               className={cn(
                 "w-full",
-                isXpTheme
+                isWindowsTheme
                   ? "font-['Pixelated_MS_Sans_Serif',Arial] text-[11px]"
                   : "font-geneva-12 text-[12px]"
               )}
               data-selected="true"
               style={lyricsSearchRowStyle(0, true, {
-                fontFamily: isXpTheme
+                fontFamily: isWindowsTheme
                   ? '"Pixelated MS Sans Serif", "ArkPixel", Arial'
                   : undefined,
-                fontSize: isXpTheme ? "11px" : undefined,
+                fontSize: isWindowsTheme ? "11px" : undefined,
               })}
             >
               {(() => {
@@ -350,7 +350,7 @@ export function LyricsSearchDialog({
                   <div
                     className={cn(
                       "flex-shrink-0 w-9 h-9 overflow-hidden",
-                      isXpTheme ? "border border-neutral-400" : "rounded-sm"
+                      isWindowsTheme ? "border border-neutral-400" : "rounded-sm"
                     )}
                     style={{ backgroundColor: "var(--os-color-list-row-alt-bg)" }}
                     aria-hidden="true"
@@ -386,15 +386,15 @@ export function LyricsSearchDialog({
         <p
           className={cn(
             "text-red-600 mb-2",
-            isXpTheme
+            isWindowsTheme
               ? "font-['Pixelated_MS_Sans_Serif',Arial] text-[11px]"
               : "font-geneva-12 text-[12px]"
           )}
           style={{
-            fontFamily: isXpTheme
+            fontFamily: isWindowsTheme
               ? '"Pixelated MS Sans Serif", "ArkPixel", Arial'
               : undefined,
-            fontSize: isXpTheme ? "11px" : undefined,
+            fontSize: isWindowsTheme ? "11px" : undefined,
           }}
         >
           {error}
@@ -406,15 +406,15 @@ export function LyricsSearchDialog({
           <p
             className={cn(
               "text-neutral-500 mb-2",
-              isXpTheme
+              isWindowsTheme
                 ? "font-['Pixelated_MS_Sans_Serif',Arial] text-[11px]"
                 : "font-geneva-12 text-[12px]"
             )}
             style={{
-              fontFamily: isXpTheme
+              fontFamily: isWindowsTheme
                 ? '"Pixelated MS Sans Serif", "ArkPixel", Arial'
                 : undefined,
-              fontSize: isXpTheme ? "11px" : undefined,
+              fontSize: isWindowsTheme ? "11px" : undefined,
             }}
           >
             {t("apps.ipod.dialogs.lyricsSearchSelectResult")}
@@ -445,22 +445,22 @@ export function LyricsSearchDialog({
                     role="button"
                     className={cn(
                       "w-full",
-                      isXpTheme
+                      isWindowsTheme
                         ? "font-['Pixelated_MS_Sans_Serif',Arial] text-[11px]"
                         : "font-geneva-12 text-[12px]"
                     )}
                     data-selected={rowSelected ? "true" : undefined}
                     style={lyricsSearchRowStyle(index, rowSelected, {
-                      fontFamily: isXpTheme
+                      fontFamily: isWindowsTheme
                         ? '"Pixelated MS Sans Serif", "ArkPixel", Arial'
                         : undefined,
-                      fontSize: isXpTheme ? "11px" : undefined,
+                      fontSize: isWindowsTheme ? "11px" : undefined,
                     })}
                   >
                     <div
                       className={cn(
                         "flex-shrink-0 w-9 h-9 overflow-hidden",
-                        isXpTheme ? "border border-neutral-400" : "rounded-sm"
+                        isWindowsTheme ? "border border-neutral-400" : "rounded-sm"
                       )}
                       style={{ backgroundColor: "var(--os-color-list-row-alt-bg)" }}
                       aria-hidden="true"
@@ -509,15 +509,15 @@ export function LyricsSearchDialog({
               disabled={isSearching}
               className={cn(
                 "w-full sm:w-auto h-7",
-                isXpTheme
+                isWindowsTheme
                   ? "font-['Pixelated_MS_Sans_Serif',Arial] text-[11px]"
                   : "font-geneva-12 text-[12px]"
               )}
               style={{
-                fontFamily: isXpTheme
+                fontFamily: isWindowsTheme
                   ? '"Pixelated MS Sans Serif", "ArkPixel", Arial'
                   : undefined,
-                fontSize: isXpTheme ? "11px" : undefined,
+                fontSize: isWindowsTheme ? "11px" : undefined,
               }}
             >
               {t("apps.ipod.dialogs.lyricsSearchReset")}
@@ -534,15 +534,15 @@ export function LyricsSearchDialog({
               className={cn(
                 "w-full sm:w-auto",
                 !isMacTheme && "h-7",
-                isXpTheme
+                isWindowsTheme
                   ? "font-['Pixelated_MS_Sans_Serif',Arial] text-[11px]"
                   : "font-geneva-12 text-[12px]"
               )}
               style={{
-                fontFamily: isXpTheme
+                fontFamily: isWindowsTheme
                   ? '"Pixelated MS Sans Serif", "ArkPixel", Arial'
                   : undefined,
-                fontSize: isXpTheme ? "11px" : undefined,
+                fontSize: isWindowsTheme ? "11px" : undefined,
               }}
             >
               {t("common.dialog.cancel")}
@@ -554,15 +554,15 @@ export function LyricsSearchDialog({
               className={cn(
                 "w-full sm:w-auto",
                 !isMacTheme && "h-7",
-                isXpTheme
+                isWindowsTheme
                   ? "font-['Pixelated_MS_Sans_Serif',Arial] text-[11px]"
                   : "font-geneva-12 text-[12px]"
               )}
               style={{
-                fontFamily: isXpTheme
+                fontFamily: isWindowsTheme
                   ? '"Pixelated MS Sans Serif", "ArkPixel", Arial'
                   : undefined,
-                fontSize: isXpTheme ? "11px" : undefined,
+                fontSize: isWindowsTheme ? "11px" : undefined,
               }}
             >
               {t("apps.ipod.dialogs.lyricsSearchUseSelected")}
@@ -576,11 +576,11 @@ export function LyricsSearchDialog({
   return (
     <Dialog open={isOpen} onOpenChange={onOpenChange}>
       <DialogContent
-        className={cn("max-w-[600px]", isXpTheme && "p-0 overflow-hidden")}
-        style={isXpTheme ? { fontSize: "11px" } : undefined}
+        className={cn("max-w-[600px]", isWindowsTheme && "p-0 overflow-hidden")}
+        style={isWindowsTheme ? { fontSize: "11px" } : undefined}
         onKeyDown={handleDialogKeyDown}
       >
-        {isXpTheme ? (
+        {isWindowsTheme ? (
           <>
             <DialogHeader>
               {t("apps.ipod.dialogs.lyricsSearchTitle")}

--- a/src/components/dialogs/ShareItemDialog.tsx
+++ b/src/components/dialogs/ShareItemDialog.tsx
@@ -66,8 +66,8 @@ export function ShareItemDialog({
   const { isLoading, shareUrl } = state;
   const inputRef = useRef<HTMLInputElement>(null);
   const {
-    isWindowsTheme: isXpTheme,
-    isMacOSTheme: isMacOsxTheme,
+    isWindowsTheme,
+    isMacOSTheme,
     isWinXp,
   } = useThemeFlags();
 
@@ -158,15 +158,15 @@ export function ShareItemDialog({
             <p
               className={cn(
                 "text-neutral-500",
-                isXpTheme
+                isWindowsTheme
                   ? "font-['Pixelated_MS_Sans_Serif',Arial] text-[10px]"
                   : "font-geneva-12 text-[10px]"
               )}
               style={{
-                fontFamily: isXpTheme
+                fontFamily: isWindowsTheme
                   ? '"Pixelated MS Sans Serif", "ArkPixel", Arial'
                   : undefined,
-                fontSize: isXpTheme ? "10px" : undefined,
+                fontSize: isWindowsTheme ? "10px" : undefined,
               }}
             >
               {t("common.dialog.share.generating")}
@@ -189,15 +189,15 @@ export function ShareItemDialog({
             <p
               className={cn(
                 "text-neutral-500",
-                isXpTheme
+                isWindowsTheme
                   ? "font-['Pixelated_MS_Sans_Serif',Arial] text-[10px]"
                   : "font-geneva-12 text-[10px]"
               )}
               style={{
-                fontFamily: isXpTheme
+                fontFamily: isWindowsTheme
                   ? '"Pixelated MS Sans Serif", "ArkPixel", Arial'
                   : undefined,
-                fontSize: isXpTheme ? "10px" : undefined,
+                fontSize: isWindowsTheme ? "10px" : undefined,
               }}
             >
               {t("common.dialog.share.qrCode")}
@@ -208,15 +208,15 @@ export function ShareItemDialog({
         <p
           className={cn(
             "text-neutral-500 text-center mt-0 mb-4 break-words w-[80%]",
-            isXpTheme
+            isWindowsTheme
               ? "font-['Pixelated_MS_Sans_Serif',Arial] text-[10px]"
               : "font-geneva-12 text-xs"
           )}
           style={{
-            fontFamily: isXpTheme
+            fontFamily: isWindowsTheme
               ? '"Pixelated MS Sans Serif", "ArkPixel", Arial'
               : undefined,
-            fontSize: isXpTheme ? "10px" : undefined,
+            fontSize: isWindowsTheme ? "10px" : undefined,
           }}
         >
           {descriptionText()}
@@ -229,15 +229,15 @@ export function ShareItemDialog({
           readOnly
           className={cn(
             "shadow-none h-8 w-full",
-            isXpTheme
+            isWindowsTheme
               ? "font-['Pixelated_MS_Sans_Serif',Arial] text-[11px]"
               : "text-sm"
           )}
           style={{
-            fontFamily: isXpTheme
+            fontFamily: isWindowsTheme
               ? '"Pixelated MS Sans Serif", "ArkPixel", Arial'
               : undefined,
-            fontSize: isXpTheme ? "11px" : undefined,
+            fontSize: isWindowsTheme ? "11px" : undefined,
           }}
           placeholder={
             isLoading
@@ -254,15 +254,15 @@ export function ShareItemDialog({
           variant="retro"
           className={cn(
             "w-full h-7",
-            isXpTheme
+            isWindowsTheme
               ? "font-['Pixelated_MS_Sans_Serif',Arial] text-[11px]"
               : "font-geneva-12 text-[12px]"
           )}
           style={{
-            fontFamily: isXpTheme
+            fontFamily: isWindowsTheme
               ? '"Pixelated MS Sans Serif", "ArkPixel", Arial'
               : undefined,
-            fontSize: isXpTheme ? "11px" : undefined,
+            fontSize: isWindowsTheme ? "11px" : undefined,
           }}
         >
           {t("common.dialog.share.copyLink")}
@@ -271,7 +271,7 @@ export function ShareItemDialog({
     </div>
   );
 
-  if (isXpTheme) {
+  if (isWindowsTheme) {
     return (
       <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
         <DialogContent
@@ -311,7 +311,7 @@ export function ShareItemDialog({
         overlayClassName={overlayClassName}
         onKeyDown={(e: React.KeyboardEvent) => e.stopPropagation()}
       >
-        {isMacOsxTheme ? (
+        {isMacOSTheme ? (
           <>
             <DialogHeader>{t("common.dialog.share.shareItem", { itemType: translatedItemType })}</DialogHeader>
             <DialogDescription className="sr-only">

--- a/src/components/dialogs/TelegramLinkDialog.tsx
+++ b/src/components/dialogs/TelegramLinkDialog.tsx
@@ -47,8 +47,8 @@ export function TelegramLinkDialog({
 }: TelegramLinkDialogProps) {
   const { t } = useTranslation();
   const {
-    isWindowsTheme: isXpTheme,
-    isMacOSTheme: isMacOsxTheme,
+    isWindowsTheme,
+    isMacOSTheme,
     isWinXp,
   } = useThemeFlags();
 
@@ -90,15 +90,15 @@ export function TelegramLinkDialog({
       <p
         className={cn(
           "text-neutral-500",
-          isXpTheme
+          isWindowsTheme
             ? "font-['Pixelated_MS_Sans_Serif',Arial] text-[10px]"
             : "font-geneva-12 text-[10px]"
         )}
         style={{
-          fontFamily: isXpTheme
+          fontFamily: isWindowsTheme
             ? '"Pixelated MS Sans Serif", "ArkPixel", Arial'
             : undefined,
-          fontSize: isXpTheme ? "10px" : undefined,
+          fontSize: isWindowsTheme ? "10px" : undefined,
         }}
       >
         {t("common.dialog.share.generating")}
@@ -113,15 +113,15 @@ export function TelegramLinkDialog({
         <p
           className={cn(
             "mt-0 mb-2 w-[80%] break-words text-center text-neutral-500",
-            isXpTheme
+            isWindowsTheme
               ? "font-['Pixelated_MS_Sans_Serif',Arial] text-[10px]"
               : "font-geneva-12 text-xs"
           )}
           style={{
-            fontFamily: isXpTheme
+            fontFamily: isWindowsTheme
               ? '"Pixelated MS Sans Serif", "ArkPixel", Arial'
               : undefined,
-            fontSize: isXpTheme ? "10px" : undefined,
+            fontSize: isWindowsTheme ? "10px" : undefined,
           }}
         >
           {descriptionText}
@@ -136,15 +136,15 @@ export function TelegramLinkDialog({
             variant="retro"
             className={cn(
               "h-7 w-full",
-              isXpTheme
+              isWindowsTheme
                 ? "font-['Pixelated_MS_Sans_Serif',Arial] text-[11px]"
                 : "font-geneva-12 text-[12px]"
             )}
             style={{
-              fontFamily: isXpTheme
+              fontFamily: isWindowsTheme
                 ? '"Pixelated MS Sans Serif", "ArkPixel", Arial'
                 : undefined,
-              fontSize: isXpTheme ? "11px" : undefined,
+              fontSize: isWindowsTheme ? "11px" : undefined,
             }}
           >
             {isDisconnectingLink
@@ -159,15 +159,15 @@ export function TelegramLinkDialog({
                 variant="retro"
                 className={cn(
                   stackedActionButtonClass,
-                  isXpTheme
+                  isWindowsTheme
                     ? "font-['Pixelated_MS_Sans_Serif',Arial] text-[11px]"
                     : "font-geneva-12 text-[12px]"
                 )}
                 style={{
-                  fontFamily: isXpTheme
+                  fontFamily: isWindowsTheme
                     ? '"Pixelated MS Sans Serif", "ArkPixel", Arial'
                     : undefined,
-                  fontSize: isXpTheme ? "11px" : undefined,
+                  fontSize: isWindowsTheme ? "11px" : undefined,
                 }}
               >
                 {t("apps.control-panels.telegram.openTelegram")}
@@ -178,15 +178,15 @@ export function TelegramLinkDialog({
               variant="retro"
               className={cn(
                 hasDeepLink ? stackedActionButtonClass : "h-7 w-full",
-                isXpTheme
+                isWindowsTheme
                   ? "font-['Pixelated_MS_Sans_Serif',Arial] text-[11px]"
                   : "font-geneva-12 text-[12px]"
               )}
               style={{
-                fontFamily: isXpTheme
+                fontFamily: isWindowsTheme
                   ? '"Pixelated MS Sans Serif", "ArkPixel", Arial'
                   : undefined,
-                fontSize: isXpTheme ? "11px" : undefined,
+                fontSize: isWindowsTheme ? "11px" : undefined,
               }}
             >
               {t("apps.control-panels.telegram.copyCode")}
@@ -199,15 +199,15 @@ export function TelegramLinkDialog({
             variant="retro"
             className={cn(
               "h-7 w-full",
-              isXpTheme
+              isWindowsTheme
                 ? "font-['Pixelated_MS_Sans_Serif',Arial] text-[11px]"
                 : "font-geneva-12 text-[12px]"
             )}
             style={{
-              fontFamily: isXpTheme
+              fontFamily: isWindowsTheme
                 ? '"Pixelated MS Sans Serif", "ArkPixel", Arial'
                 : undefined,
-              fontSize: isXpTheme ? "11px" : undefined,
+              fontSize: isWindowsTheme ? "11px" : undefined,
             }}
           >
             {isCreatingLink
@@ -219,7 +219,7 @@ export function TelegramLinkDialog({
     </div>
   );
 
-  if (isXpTheme) {
+  if (isWindowsTheme) {
     return (
       <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
         <DialogContent
@@ -254,7 +254,7 @@ export function TelegramLinkDialog({
         className="max-w-xs rounded-os border-[length:var(--os-metrics-border-width)] border-os-window bg-os-window-bg shadow-os-window"
         onKeyDown={(e: React.KeyboardEvent) => e.stopPropagation()}
       >
-        {isMacOsxTheme ? (
+        {isMacOSTheme ? (
           <>
             <DialogHeader>{t("apps.control-panels.telegram.title")}</DialogHeader>
             <DialogDescription className="sr-only">

--- a/src/components/dialogs/song-search-dialog/SongSearchDialog.tsx
+++ b/src/components/dialogs/song-search-dialog/SongSearchDialog.tsx
@@ -12,7 +12,7 @@ import { SongSearchDialogBody } from "./components/SongSearchDialogBody";
 
 export function SongSearchDialog(props: SongSearchDialogProps) {
   const vm = useSongSearchDialog(props);
-  const { t, isXpTheme, isMacTheme } = vm;
+  const { t, isWindowsTheme, isMacTheme } = vm;
   const { isOpen, onOpenChange } = props;
 
   const dialogContent = <SongSearchDialogBody {...vm} />;
@@ -20,10 +20,10 @@ export function SongSearchDialog(props: SongSearchDialogProps) {
   return (
     <Dialog open={isOpen} onOpenChange={onOpenChange}>
       <DialogContent
-        className={cn(isXpTheme && "p-0")}
+        className={cn(isWindowsTheme && "p-0")}
         onKeyDown={(e) => e.stopPropagation()}
       >
-        {isXpTheme ? (
+        {isWindowsTheme ? (
           <>
             <DialogHeader>{t("apps.ipod.dialogs.addSongTitle")}</DialogHeader>
             <div className="window-body">{dialogContent}</div>

--- a/src/components/dialogs/song-search-dialog/components/SongSearchDialogBody.tsx
+++ b/src/components/dialogs/song-search-dialog/components/SongSearchDialogBody.tsx
@@ -10,7 +10,7 @@ type SongSearchDialogBodyProps = SongSearchDialogViewModel;
 export function SongSearchDialogBody(vm: SongSearchDialogBodyProps) {
   const {
     t,
-    isXpTheme,
+    isWindowsTheme,
     isMacTheme,
     dispatch,
     results,
@@ -32,7 +32,7 @@ export function SongSearchDialogBody(vm: SongSearchDialogBodyProps) {
   return (
     <div
       className={cn(
-        isXpTheme ? "p-2 px-4" : "p-4 px-6",
+        isWindowsTheme ? "p-2 px-4" : "p-4 px-6",
         "overflow-hidden w-full box-border"
       )}
     >

--- a/src/components/dialogs/song-search-dialog/hooks/useSongSearchDialog.ts
+++ b/src/components/dialogs/song-search-dialog/hooks/useSongSearchDialog.ts
@@ -23,7 +23,7 @@ export function useSongSearchDialog({
 }: SongSearchDialogProps) {
   const { t } = useTranslation();
   const {
-    isWindowsTheme: isXpTheme,
+    isWindowsTheme,
     isMacOSTheme: isMacTheme,
   } = useThemeFlags();
 
@@ -256,14 +256,14 @@ export function useSongSearchDialog({
     ]
   );
 
-  const fontStyle = isXpTheme
+  const fontStyle = isWindowsTheme
     ? {
         fontFamily: '"Pixelated MS Sans Serif", "ArkPixel", Arial',
         fontSize: "11px",
       }
     : undefined;
 
-  const fontClass = isXpTheme
+  const fontClass = isWindowsTheme
     ? "font-['Pixelated_MS_Sans_Serif',Arial] text-[11px]"
     : "font-geneva-12 text-[12px]";
 
@@ -272,7 +272,7 @@ export function useSongSearchDialog({
 
   return {
     t,
-    isXpTheme,
+    isWindowsTheme,
     isMacTheme,
     dispatch,
     query,

--- a/src/components/errors/ErrorBoundaries.tsx
+++ b/src/components/errors/ErrorBoundaries.tsx
@@ -148,7 +148,7 @@ function CrashDialog({
   error,
 }: CrashDialogProps) {
   const {
-    isWindowsTheme: isXpTheme,
+    isWindowsTheme,
     isMacOSTheme: isMacTheme,
   } = useThemeFlags();
   const { t } = useTranslation();
@@ -159,7 +159,7 @@ function CrashDialog({
 
   const bodyTextClasses = cn(
     "leading-[1.45] text-black",
-    isXpTheme
+    isWindowsTheme
       ? "font-['Pixelated_MS_Sans_Serif',Arial] text-[11px]"
       : isMacTheme
         ? "text-[13px]"
@@ -172,7 +172,7 @@ function CrashDialog({
 
   const dialogBody = (
     <div
-      className={cn(isXpTheme ? "p-2 px-4" : "p-5")}
+      className={cn(isWindowsTheme ? "p-2 px-4" : "p-5")}
     >
       <div className="flex items-start gap-3">
         <ThemedIcon
@@ -187,7 +187,7 @@ function CrashDialog({
             id={headingId}
             className={cn(
               "text-black",
-              isXpTheme
+              isWindowsTheme
                 ? "font-['Pixelated_MS_Sans_Serif',Arial] text-[11px] font-bold"
                 : isMacTheme
                   ? "text-[13px] font-semibold"
@@ -205,7 +205,7 @@ function CrashDialog({
             <div
               className={cn(
                 "rounded border border-black/15 bg-black/5 px-2 py-1.5 text-black/80",
-                isXpTheme
+                isWindowsTheme
                   ? "font-['Pixelated_MS_Sans_Serif',Arial] text-[10px]"
                   : "font-os-mono text-[10px]",
               )}
@@ -222,7 +222,7 @@ function CrashDialog({
                 onClick={onSecondaryAction}
                 className={cn(
                   !isMacTheme && "h-7",
-                  isXpTheme
+                  isWindowsTheme
                     ? "font-['Pixelated_MS_Sans_Serif',Arial] text-[11px]"
                     : isMacTheme
                       ? "text-[13px]"
@@ -238,7 +238,7 @@ function CrashDialog({
               onClick={onPrimaryAction}
               className={cn(
                 !isMacTheme && "h-7",
-                isXpTheme
+                isWindowsTheme
                   ? "font-['Pixelated_MS_Sans_Serif',Arial] text-[11px]"
                   : isMacTheme
                     ? "text-[13px]"
@@ -276,8 +276,8 @@ function CrashDialog({
             ? "bg-black/20 pointer-events-none"
             : "bg-black/25"
         }
-        className={cn("max-w-[420px]", isXpTheme && "p-0 overflow-hidden")}
-        style={isXpTheme ? { fontSize: "11px" } : undefined}
+        className={cn("max-w-[420px]", isWindowsTheme && "p-0 overflow-hidden")}
+        style={isWindowsTheme ? { fontSize: "11px" } : undefined}
         onOpenAutoFocus={(event) => {
           event.preventDefault();
           primaryActionButtonRef.current?.focus();
@@ -289,7 +289,7 @@ function CrashDialog({
           event.preventDefault();
         }}
       >
-        {isXpTheme ? (
+        {isWindowsTheme ? (
           <>
             <DialogHeader>{titleBarLabel}</DialogHeader>
             <div className="window-body">{dialogBody}</div>

--- a/src/components/layout/AppleMenu.tsx
+++ b/src/components/layout/AppleMenu.tsx
@@ -72,7 +72,7 @@ export function AppleMenu() {
   const { t } = useTranslation();
   const [aboutFinderOpen, setAboutFinderOpen] = useState(false);
   const launchApp = useLaunchApp();
-  const { isMacOSTheme: isMacOsxTheme } = useThemeFlags();
+  const { isMacOSTheme } = useThemeFlags();
   const { isFullscreen, supported: fullscreenSupported, toggle: toggleFullscreen } =
     useRyosFullscreen();
 
@@ -152,10 +152,10 @@ export function AppleMenu() {
         <MenubarTrigger
           className={cn(
             "border-none focus-visible:ring-0 flex items-center justify-center",
-            isMacOsxTheme ? "px-1" : "px-3"
+            isMacOSTheme ? "px-1" : "px-3"
           )}
         >
-          {isMacOsxTheme ? (
+          {isMacOSTheme ? (
             <ThemedIcon
               name="apple.png"
               alt="Apple Menu"
@@ -193,7 +193,7 @@ export function AppleMenu() {
             onClick={handleSystemPreferences}
             className="text-md h-6 px-3"
           >
-            {isMacOsxTheme ? t("common.appleMenu.systemPreferences") : t("common.appleMenu.controlPanels")}
+            {isMacOSTheme ? t("common.appleMenu.systemPreferences") : t("common.appleMenu.controlPanels")}
           </MenubarItem>
 
           {/* Applet Store */}

--- a/src/components/layout/MenuBar.tsx
+++ b/src/components/layout/MenuBar.tsx
@@ -18,14 +18,14 @@ export type { MenuBarProps } from "./menu-bar/menuBarTypes";
 export function MenuBar({ children, inWindowFrame = false }: MenuBarProps) {
   const apps: AnyApp[] = useMemo(() => Object.values(appRegistry), []);
 
-  const { currentTheme, isWindowsTheme: isXpTheme } = useThemeFlags();
+  const { currentTheme, isWindowsTheme } = useThemeFlags();
 
-  if (inWindowFrame && isXpTheme) {
+  if (inWindowFrame && isWindowsTheme) {
     return (
       <Menubar
         className="flex items-center border-none bg-transparent space-x-0 rounded-none"
         style={{
-          fontFamily: isXpTheme ? "var(--font-ms-sans)" : "var(--os-font-ui)",
+          fontFamily: isWindowsTheme ? "var(--font-ms-sans)" : "var(--os-font-ui)",
           fontSize: "11px",
           paddingLeft: "6px",
           paddingRight: "2px",
@@ -39,12 +39,12 @@ export function MenuBar({ children, inWindowFrame = false }: MenuBarProps) {
     );
   }
 
-  if (isXpTheme && !inWindowFrame) {
+  if (isWindowsTheme && !inWindowFrame) {
     return (
       <WindowsTaskbarWithState
         apps={apps}
         currentTheme={currentTheme}
-        isXpTheme={isXpTheme}
+        isWindowsTheme={isWindowsTheme}
       />
     );
   }
@@ -55,11 +55,11 @@ export function MenuBar({ children, inWindowFrame = false }: MenuBarProps) {
 function WindowsTaskbarWithState({
   apps,
   currentTheme,
-  isXpTheme,
+  isWindowsTheme,
 }: {
   apps: AnyApp[];
   currentTheme: string;
-  isXpTheme: boolean;
+  isWindowsTheme: boolean;
 }) {
   const {
     dockInstancesSignature,
@@ -91,7 +91,7 @@ function WindowsTaskbarWithState({
       restoreInstance={restoreInstance}
       getFileItem={getFileItem}
       currentTheme={currentTheme}
-      isXpTheme={isXpTheme}
+      isWindowsTheme={isWindowsTheme}
     />
   );
 }

--- a/src/components/layout/dashboard/CalendarWidget.tsx
+++ b/src/components/layout/dashboard/CalendarWidget.tsx
@@ -35,7 +35,7 @@ interface CalendarWidgetProps {
 export function CalendarWidget({ widgetId }: CalendarWidgetProps) {
   const { i18n } = useTranslation();
   const locale = i18n.language || "en";
-  const { isWindowsTheme: isXpTheme } = useThemeFlags();
+  const { isWindowsTheme } = useThemeFlags();
 
   const widget = useDashboardStore((s) => widgetId ? s.widgets.find((w) => w.id === widgetId) : undefined);
   const calConfig = widget?.config as CalendarWidgetConfig | undefined;
@@ -125,7 +125,7 @@ export function CalendarWidget({ widgetId }: CalendarWidgetProps) {
     requestAppLaunch({ appId: "calendar" });
   };
 
-  if (isXpTheme) {
+  if (isWindowsTheme) {
     // Simple XP-style calendar
     return (
       <div className="p-2 cursor-pointer" onClick={handleClick} style={{ color: "#000" }}>
@@ -285,7 +285,7 @@ const ALL_COLORS: { id: EventColor; hex: string }[] = [
 
 export function CalendarBackPanel({ widgetId }: { widgetId: string }) {
   const { t } = useTranslation();
-  const { isWindowsTheme: isXpTheme } = useThemeFlags();
+  const { isWindowsTheme } = useThemeFlags();
   const widget = useDashboardStore((s) => s.widgets.find((w) => w.id === widgetId));
   const updateWidgetConfig = useDashboardStore((s) => s.updateWidgetConfig);
   const calConfig = widget?.config as CalendarWidgetConfig | undefined;
@@ -301,7 +301,7 @@ export function CalendarBackPanel({ widgetId }: { widgetId: string }) {
     [hiddenColors, widgetId, updateWidgetConfig]
   );
 
-  const textColor = isXpTheme ? "#000" : "rgba(255,255,255,0.8)";
+  const textColor = isWindowsTheme ? "#000" : "rgba(255,255,255,0.8)";
 
   return (
     <div className="px-3 pb-3" onPointerDown={(e) => e.stopPropagation()}>
@@ -309,7 +309,7 @@ export function CalendarBackPanel({ widgetId }: { widgetId: string }) {
         className="font-bold mb-2"
         style={{
           fontSize: 11,
-          color: isXpTheme ? "#333" : "rgba(255,255,255,0.5)",
+          color: isWindowsTheme ? "#333" : "rgba(255,255,255,0.5)",
           fontFamily: "'Helvetica Neue', Helvetica, Arial, sans-serif",
         }}
       >
@@ -327,12 +327,12 @@ export function CalendarBackPanel({ widgetId }: { widgetId: string }) {
               style={{
                 opacity: visible ? 1 : 0.4,
                 background: visible
-                  ? isXpTheme ? "rgba(0,0,0,0.04)" : "rgba(255,255,255,0.06)"
+                  ? isWindowsTheme ? "rgba(0,0,0,0.04)" : "rgba(255,255,255,0.06)"
                   : "transparent",
               }}
-              onMouseEnter={(e) => (e.currentTarget.style.background = isXpTheme ? "rgba(0,0,0,0.08)" : "rgba(255,255,255,0.1)")}
+              onMouseEnter={(e) => (e.currentTarget.style.background = isWindowsTheme ? "rgba(0,0,0,0.08)" : "rgba(255,255,255,0.1)")}
               onMouseLeave={(e) => (e.currentTarget.style.background = visible
-                ? isXpTheme ? "rgba(0,0,0,0.04)" : "rgba(255,255,255,0.06)"
+                ? isWindowsTheme ? "rgba(0,0,0,0.04)" : "rgba(255,255,255,0.06)"
                 : "transparent"
               )}
             >
@@ -348,7 +348,7 @@ export function CalendarBackPanel({ widgetId }: { widgetId: string }) {
               <span className="text-[11px]" style={{ color: textColor, fontFamily: "'Helvetica Neue', Helvetica, Arial, sans-serif" }}>
                 {t(`apps.dashboard.calendar.colors.${c.id}`, c.id)}
               </span>
-              <span className="ml-auto text-[11px]" style={{ color: isXpTheme ? "#888" : "rgba(255,255,255,0.4)" }}>
+              <span className="ml-auto text-[11px]" style={{ color: isWindowsTheme ? "#888" : "rgba(255,255,255,0.4)" }}>
                 {visible ? "✓" : ""}
               </span>
             </button>

--- a/src/components/layout/dashboard/ClockWidget.tsx
+++ b/src/components/layout/dashboard/ClockWidget.tsx
@@ -72,7 +72,7 @@ interface ClockWidgetProps {
 export function ClockWidget({ widgetId, isFlipped }: ClockWidgetProps) {
   const { t } = useTranslation();
   const [time, setTime] = useState(() => new Date());
-  const { isWindowsTheme: isXpTheme } = useThemeFlags();
+  const { isWindowsTheme } = useThemeFlags();
   const widget = useDashboardStore((s) => widgetId ? s.widgets.find((w) => w.id === widgetId) : undefined);
   const config = widget?.config as ClockWidgetConfig | undefined;
   const gradId = useMemo(() => widgetId?.replace(/[^a-zA-Z0-9]/g, "") ?? "default", [widgetId]);
@@ -101,7 +101,7 @@ export function ClockWidget({ widgetId, isFlipped }: ClockWidgetProps) {
   }, [time, config?.timezone]);
 
   const hours = displayTime.getHours();
-  const isDark = !isXpTheme && (hours >= 19 || hours < 6);
+  const isDark = !isWindowsTheme && (hours >= 19 || hours < 6);
   const minutes = displayTime.getMinutes();
   const seconds = displayTime.getSeconds();
 
@@ -115,7 +115,7 @@ export function ClockWidget({ widgetId, isFlipped }: ClockWidgetProps) {
   const clockCenterY = svgSize / 2;
   const topLabelY = 15;
   const bottomLabelY = svgSize - 10;
-  const faceRadius = isXpTheme ? 52 : 55;
+  const faceRadius = isWindowsTheme ? 52 : 55;
 
   return (
     <svg
@@ -125,7 +125,7 @@ export function ClockWidget({ widgetId, isFlipped }: ClockWidgetProps) {
       style={{ display: "block" }}
     >
       <defs>
-        {!isXpTheme && (
+        {!isWindowsTheme && (
           <>
             <radialGradient id={`faceGrad-${gradId}`} cx="50%" cy="38%" r="58%">
               <stop offset="0%" stopColor={isDark ? "#3a3a3a" : "#f8f8f8"} />
@@ -144,7 +144,7 @@ export function ClockWidget({ widgetId, isFlipped }: ClockWidgetProps) {
         textAnchor="middle"
         fontSize={11}
         fontWeight="700"
-        fill={isXpTheme ? "#000" : "rgba(255,255,255,0.7)"}
+        fill={isWindowsTheme ? "#000" : "rgba(255,255,255,0.7)"}
         style={{ fontFamily: "Helvetica Neue, Helvetica, Arial, sans-serif" }}
       >
         {digitalTime}
@@ -154,10 +154,10 @@ export function ClockWidget({ widgetId, isFlipped }: ClockWidgetProps) {
         cx={clockCenterX}
         cy={clockCenterY}
         r={faceRadius}
-        fill={isXpTheme ? "#FFFFFF" : `url(#faceGrad-${gradId})`}
-        stroke={isXpTheme ? "#808080" : "none"}
-        strokeWidth={isXpTheme ? 1.5 : 0}
-        filter={isXpTheme ? undefined : `url(#clockShadow-${gradId})`}
+        fill={isWindowsTheme ? "#FFFFFF" : `url(#faceGrad-${gradId})`}
+        stroke={isWindowsTheme ? "#808080" : "none"}
+        strokeWidth={isWindowsTheme ? 1.5 : 0}
+        filter={isWindowsTheme ? undefined : `url(#clockShadow-${gradId})`}
       />
 
       {Array.from({ length: 12 }, (_, i) => {
@@ -173,7 +173,7 @@ export function ClockWidget({ widgetId, isFlipped }: ClockWidgetProps) {
             dominantBaseline="central"
             fontSize={14}
             fontWeight="700"
-            fill={!isXpTheme && isDark ? "rgba(255,255,255,0.9)" : "#333"}
+            fill={!isWindowsTheme && isDark ? "rgba(255,255,255,0.9)" : "#333"}
             style={{ fontFamily: "Helvetica Neue, Helvetica, Arial, sans-serif" }}
           >
             {num}
@@ -183,12 +183,12 @@ export function ClockWidget({ widgetId, isFlipped }: ClockWidgetProps) {
 
       <polygon
         points={handPolygon(clockCenterX, clockCenterY, hourAngle, 28, 3.5, 5)}
-        fill={!isXpTheme && isDark ? "#DDD" : "#222"}
+        fill={!isWindowsTheme && isDark ? "#DDD" : "#222"}
       />
 
       <polygon
         points={handPolygon(clockCenterX, clockCenterY, minuteAngle, 40, 2.5, 5)}
-        fill={!isXpTheme && isDark ? "#DDD" : "#222"}
+        fill={!isWindowsTheme && isDark ? "#DDD" : "#222"}
       />
 
       <line
@@ -201,7 +201,7 @@ export function ClockWidget({ widgetId, isFlipped }: ClockWidgetProps) {
         strokeLinecap="round"
       />
 
-      <circle cx={clockCenterX} cy={clockCenterY} r={6} fill={!isXpTheme && isDark ? "#DDD" : "#D95030"} />
+      <circle cx={clockCenterX} cy={clockCenterY} r={6} fill={!isWindowsTheme && isDark ? "#DDD" : "#D95030"} />
       <circle cx={clockCenterX} cy={clockCenterY} r={2.5} fill="#FFF" />
 
       <text
@@ -210,7 +210,7 @@ export function ClockWidget({ widgetId, isFlipped }: ClockWidgetProps) {
         textAnchor="middle"
         fontSize={12}
         fontWeight="700"
-        fill={isXpTheme ? "#000" : "rgba(255,255,255,0.8)"}
+        fill={isWindowsTheme ? "#000" : "rgba(255,255,255,0.8)"}
         style={{ fontFamily: "Helvetica Neue, Helvetica, Arial, sans-serif" }}
       >
         {cityName}
@@ -229,7 +229,7 @@ function formatCityLabel(city: CityResult): string {
 export function ClockBackPanel({ widgetId, onDone }: { widgetId: string; onDone?: () => void }) {
   const { t } = useTranslation();
   const popularCities = useMemo(() => getPopularCities(t), [t]);
-  const { isWindowsTheme: isXpTheme } = useThemeFlags();
+  const { isWindowsTheme } = useThemeFlags();
   const updateWidgetConfig = useDashboardStore((s) => s.updateWidgetConfig);
 
   type ClockSearchState = {
@@ -353,15 +353,15 @@ export function ClockBackPanel({ widgetId, onDone }: { widgetId: string; onDone?
   }, [widgetId, updateWidgetConfig, onDone]);
 
   const citiesToShow = searchQuery.length >= 2 ? searchResults : popularCities;
-  const textColor = isXpTheme ? "#000" : "rgba(255,255,255,0.8)";
+  const textColor = isWindowsTheme ? "#000" : "rgba(255,255,255,0.8)";
 
   return (
     <div onPointerDown={(e) => e.stopPropagation()}>
       <div
         className="flex items-center gap-1.5 px-3 py-1.5"
-        style={{ borderBottom: isXpTheme ? "1px solid #D5D2CA" : "1px solid rgba(255,255,255,0.08)" }}
+        style={{ borderBottom: isWindowsTheme ? "1px solid #D5D2CA" : "1px solid rgba(255,255,255,0.08)" }}
       >
-        <MagnifyingGlass size={12} weight="bold" style={{ color: isXpTheme ? "#888" : "rgba(255,255,255,0.35)", flexShrink: 0 }} />
+        <MagnifyingGlass size={12} weight="bold" style={{ color: isWindowsTheme ? "#888" : "rgba(255,255,255,0.35)", flexShrink: 0 }} />
         <input
           ref={searchInputRef}
           type="text"
@@ -369,7 +369,7 @@ export function ClockBackPanel({ widgetId, onDone }: { widgetId: string; onDone?
           onChange={(e) => handleSearchInput(e.target.value)}
           placeholder={t("apps.dashboard.weather.searchCity")}
           className="flex-1 bg-transparent outline-none text-[11px]"
-          style={{ color: textColor, caretColor: isXpTheme ? "#000" : "rgba(255,255,255,0.7)" }}
+          style={{ color: textColor, caretColor: isWindowsTheme ? "#000" : "rgba(255,255,255,0.7)" }}
         />
       </div>
 
@@ -379,10 +379,10 @@ export function ClockBackPanel({ widgetId, onDone }: { widgetId: string; onDone?
           onClick={useMyLocation}
           className="w-full flex items-center gap-1.5 px-3 py-1.5 text-left transition-colors"
           style={{
-            borderBottom: isXpTheme ? "1px solid #EAE8E1" : "1px solid rgba(255,255,255,0.05)",
-            color: isXpTheme ? "#0066CC" : "rgba(130,180,255,0.9)",
+            borderBottom: isWindowsTheme ? "1px solid #EAE8E1" : "1px solid rgba(255,255,255,0.05)",
+            color: isWindowsTheme ? "#0066CC" : "rgba(130,180,255,0.9)",
           }}
-          onMouseEnter={(e) => (e.currentTarget.style.background = isXpTheme ? "rgba(0,102,204,0.08)" : "rgba(255,255,255,0.06)")}
+          onMouseEnter={(e) => (e.currentTarget.style.background = isWindowsTheme ? "rgba(0,102,204,0.08)" : "rgba(255,255,255,0.06)")}
           onMouseLeave={(e) => (e.currentTarget.style.background = "transparent")}
         >
           <NavigationArrow size={11} weight="fill" style={{ flexShrink: 0 }} />
@@ -390,11 +390,11 @@ export function ClockBackPanel({ widgetId, onDone }: { widgetId: string; onDone?
         </button>
 
         {searching ? (
-          <div className="px-3 py-3 text-center text-[10px]" style={{ color: isXpTheme ? "#888" : "rgba(255,255,255,0.3)" }}>
+          <div className="px-3 py-3 text-center text-[10px]" style={{ color: isWindowsTheme ? "#888" : "rgba(255,255,255,0.3)" }}>
             {t("apps.dashboard.weather.searching")}
           </div>
         ) : searchQuery.length >= 2 && citiesToShow.length === 0 ? (
-          <div className="px-3 py-3 text-center text-[10px]" style={{ color: isXpTheme ? "#888" : "rgba(255,255,255,0.3)" }}>
+          <div className="px-3 py-3 text-center text-[10px]" style={{ color: isWindowsTheme ? "#888" : "rgba(255,255,255,0.3)" }}>
             {t("apps.dashboard.weather.noResults")}
           </div>
         ) : (
@@ -404,10 +404,10 @@ export function ClockBackPanel({ widgetId, onDone }: { widgetId: string; onDone?
               type="button"
               onClick={() => selectCity(city)}
               className="w-full flex items-center gap-1.5 px-3 py-1.5 text-left transition-colors"
-              onMouseEnter={(e) => (e.currentTarget.style.background = isXpTheme ? "rgba(0,102,204,0.08)" : "rgba(255,255,255,0.06)")}
+              onMouseEnter={(e) => (e.currentTarget.style.background = isWindowsTheme ? "rgba(0,102,204,0.08)" : "rgba(255,255,255,0.06)")}
               onMouseLeave={(e) => (e.currentTarget.style.background = "transparent")}
             >
-              <MapPin size={10} weight="fill" style={{ color: isXpTheme ? "#999" : "rgba(255,255,255,0.25)", flexShrink: 0 }} />
+              <MapPin size={10} weight="fill" style={{ color: isWindowsTheme ? "#999" : "rgba(255,255,255,0.25)", flexShrink: 0 }} />
               <span className="text-[11px] truncate" style={{ color: textColor }}>{formatCityLabel(city)}</span>
             </button>
           ))

--- a/src/components/layout/dashboard/DictionaryWidget.tsx
+++ b/src/components/layout/dashboard/DictionaryWidget.tsx
@@ -24,7 +24,7 @@ interface DictionaryWidgetProps {
 
 export function DictionaryWidget({ widgetId }: DictionaryWidgetProps) {
   const { t } = useTranslation();
-  const { isWindowsTheme: isXpTheme } = useThemeFlags();
+  const { isWindowsTheme } = useThemeFlags();
 
   const widget = useDashboardStore((s) =>
     s.widgets.find((w) => w.id === widgetId)
@@ -125,7 +125,7 @@ export function DictionaryWidget({ widgetId }: DictionaryWidgetProps) {
   const font = "'Helvetica Neue', Helvetica, Arial, sans-serif";
   const serifFont = "Georgia, 'Times New Roman', Times, serif";
 
-  if (isXpTheme) {
+  if (isWindowsTheme) {
     return (
       <div style={{ fontFamily: font, display: "flex", flexDirection: "column", minHeight: "inherit" }}>
         {/* XP header */}
@@ -423,9 +423,9 @@ export function DictionaryBackPanel({
   onDone?: () => void;
 }) {
   const { t } = useTranslation();
-  const { isWindowsTheme: isXpTheme } = useThemeFlags();
-  const textColor = isXpTheme ? "#000" : "rgba(255,255,255,0.8)";
-  const mutedColor = isXpTheme ? "#888" : "rgba(255,255,255,0.4)";
+  const { isWindowsTheme } = useThemeFlags();
+  const textColor = isWindowsTheme ? "#000" : "rgba(255,255,255,0.8)";
+  const mutedColor = isWindowsTheme ? "#888" : "rgba(255,255,255,0.4)";
 
   return (
     <div className="px-4 py-3" onPointerDown={(e) => e.stopPropagation()}>
@@ -443,7 +443,7 @@ export function DictionaryBackPanel({
           onClick={onDone}
           className="mt-3 text-[10px] font-medium hover:opacity-80 transition-opacity"
           style={{
-            color: isXpTheme ? "#0066CC" : "rgba(130,180,255,0.9)",
+            color: isWindowsTheme ? "#0066CC" : "rgba(130,180,255,0.9)",
             cursor: "pointer",
             border: "none",
             background: "none",

--- a/src/components/layout/dashboard/IpodWidget.tsx
+++ b/src/components/layout/dashboard/IpodWidget.tsx
@@ -241,7 +241,7 @@ function IpodWidgetTimeLabel({
 
 export function IpodWidget({ widgetId }: IpodWidgetProps) {
   const { t } = useTranslation();
-  const { isWindowsTheme: isXpTheme } = useThemeFlags();
+  const { isWindowsTheme } = useThemeFlags();
 
   const widget = useDashboardStore((s) => widgetId ? s.widgets.find((w) => w.id === widgetId) : undefined);
   const controlMode = (widget?.config as IpodWidgetConfig | undefined)?.controlMode ?? "ipod";
@@ -327,7 +327,7 @@ export function IpodWidget({ widgetId }: IpodWidgetProps) {
         width: "100%",
         height: "100%",
         minHeight: 125,
-        background: isXpTheme
+        background: isWindowsTheme
           ? "linear-gradient(180deg, #e4e4e4 0%, #d4d4d4 30%, #c8c8c8 60%, #d4d4d4 100%)"
           : "linear-gradient(180deg, #e2e2e2 0%, #d6d6d6 12%, #cccccc 28%, #c0c0c0 45%, #b8b8b8 55%, #c0c0c0 68%, #cccccc 82%, #d6d6d6 100%)",
         borderRadius: "inherit",
@@ -557,8 +557,8 @@ export function IpodBackPanel({
   onDone?: () => void;
 }) {
   const { t } = useTranslation();
-  const { isWindowsTheme: isXpTheme } = useThemeFlags();
-  const textColor = isXpTheme ? "#000" : "rgba(255,255,255,0.8)";
+  const { isWindowsTheme } = useThemeFlags();
+  const textColor = isWindowsTheme ? "#000" : "rgba(255,255,255,0.8)";
   const updateWidgetConfig = useDashboardStore((s) => s.updateWidgetConfig);
   const widget = useDashboardStore((s) => s.widgets.find((w) => w.id === widgetId));
   const config = widget?.config as IpodWidgetConfig | undefined;
@@ -577,7 +577,7 @@ export function IpodBackPanel({
     onDone?.();
   }, [onDone, controlMode]);
 
-  const linkColor = isXpTheme ? "#0066CC" : "rgba(130,180,255,0.9)";
+  const linkColor = isWindowsTheme ? "#0066CC" : "rgba(130,180,255,0.9)";
 
   return (
     <div
@@ -599,9 +599,9 @@ export function IpodBackPanel({
             fontWeight: 500,
             fontFamily: "'Helvetica Neue', Helvetica, Arial, sans-serif",
             padding: "2px 4px",
-            borderRadius: isXpTheme ? 2 : 6,
-            border: isXpTheme ? "1px solid #ACA899" : "1px solid rgba(255,255,255,0.2)",
-            background: isXpTheme ? "#fff" : "rgba(255,255,255,0.1)",
+            borderRadius: isWindowsTheme ? 2 : 6,
+            border: isWindowsTheme ? "1px solid #ACA899" : "1px solid rgba(255,255,255,0.2)",
+            background: isWindowsTheme ? "#fff" : "rgba(255,255,255,0.1)",
             color: textColor,
             cursor: "pointer",
             outline: "none",

--- a/src/components/layout/dashboard/StickyNoteWidget.tsx
+++ b/src/components/layout/dashboard/StickyNoteWidget.tsx
@@ -39,7 +39,7 @@ function textColorForBg(hex: string): string {
 
 export function StickyNoteWidget({ widgetId }: StickyNoteWidgetProps) {
   const { t } = useTranslation();
-  const { isWindowsTheme: isXpTheme } = useThemeFlags();
+  const { isWindowsTheme } = useThemeFlags();
 
   const widget = useDashboardStore((s) =>
     widgetId ? s.widgets.find((w) => w.id === widgetId) : undefined
@@ -85,7 +85,7 @@ export function StickyNoteWidget({ widgetId }: StickyNoteWidgetProps) {
   return (
     <div
       style={{
-        background: isXpTheme
+        background: isWindowsTheme
           ? noteColor
           : `linear-gradient(135deg, ${noteColor} 0%, ${gradientEnd} 100%)`,
         borderRadius: "inherit",
@@ -97,7 +97,7 @@ export function StickyNoteWidget({ widgetId }: StickyNoteWidgetProps) {
       }}
     >
       {/* Ruled lines (subtle, Mac theme only) */}
-      {!isXpTheme && (
+      {!isWindowsTheme && (
         <div
           style={{
             position: "absolute",
@@ -117,7 +117,7 @@ export function StickyNoteWidget({ widgetId }: StickyNoteWidgetProps) {
       )}
 
       {/* Paper texture grain (Mac only) */}
-      {!isXpTheme && (
+      {!isWindowsTheme && (
         <div
           style={{
             position: "absolute",
@@ -132,7 +132,7 @@ export function StickyNoteWidget({ widgetId }: StickyNoteWidgetProps) {
 
 
       {/* Drop shadow at bottom for floating effect (Mac only) */}
-      {!isXpTheme && (
+      {!isWindowsTheme && (
         <div
           style={{
             position: "absolute",
@@ -175,9 +175,9 @@ export function StickyNoteWidget({ widgetId }: StickyNoteWidgetProps) {
           border: "none",
           outline: "none",
           resize: "none",
-          fontFamily: isXpTheme ? "Tahoma, sans-serif" : FONT_STACK,
-          fontSize: isXpTheme ? 12 : 14,
-          lineHeight: isXpTheme ? "1.5" : "24px",
+          fontFamily: isWindowsTheme ? "Tahoma, sans-serif" : FONT_STACK,
+          fontSize: isWindowsTheme ? 12 : 14,
+          lineHeight: isWindowsTheme ? "1.5" : "24px",
           color: textColor,
           caretColor: textColor,
           position: "relative",
@@ -196,7 +196,7 @@ export function StickyNoteBackPanel({
   onDone?: () => void;
 }) {
   const { t } = useTranslation();
-  const { isWindowsTheme: isXpTheme } = useThemeFlags();
+  const { isWindowsTheme } = useThemeFlags();
 
   const widget = useDashboardStore((s) =>
     s.widgets.find((w) => w.id === widgetId)
@@ -216,7 +216,7 @@ export function StickyNoteBackPanel({
     [widgetId, updateWidgetConfig, config, onDone]
   );
 
-  const labelColor = isXpTheme ? "#444" : "rgba(255,255,255,0.5)";
+  const labelColor = isWindowsTheme ? "#444" : "rgba(255,255,255,0.5)";
 
   return (
     <div
@@ -244,10 +244,10 @@ export function StickyNoteBackPanel({
               background: c.value,
               border:
                 currentColor === c.value
-                  ? isXpTheme
+                  ? isWindowsTheme
                     ? "2px solid #333"
                     : "2px solid rgba(255,255,255,0.9)"
-                  : isXpTheme
+                  : isWindowsTheme
                     ? "2px solid #CCC"
                     : "2px solid rgba(255,255,255,0.2)",
               boxShadow:

--- a/src/components/layout/dashboard/TranslationWidget.tsx
+++ b/src/components/layout/dashboard/TranslationWidget.tsx
@@ -27,7 +27,7 @@ interface TranslationWidgetProps {
 export function TranslationWidget({ widgetId }: TranslationWidgetProps) {
   const { t, i18n } = useTranslation();
   const LANGUAGES = useLocalizedLanguages(i18n.language);
-  const { isWindowsTheme: isXpTheme } = useThemeFlags();
+  const { isWindowsTheme } = useThemeFlags();
 
   const widget = useDashboardStore((s) =>
     widgetId ? s.widgets.find((w) => w.id === widgetId) : undefined
@@ -158,7 +158,7 @@ export function TranslationWidget({ widgetId }: TranslationWidgetProps) {
 
   const font = "'Helvetica Neue', Helvetica, Arial, sans-serif";
 
-  if (isXpTheme) {
+  if (isWindowsTheme) {
     return (
       <div
       className="flex flex-col"
@@ -522,7 +522,7 @@ export function TranslationBackPanel({
 }) {
   const { t, i18n } = useTranslation();
   const LANGUAGES = useLocalizedLanguages(i18n.language);
-  const { isWindowsTheme: isXpTheme } = useThemeFlags();
+  const { isWindowsTheme } = useThemeFlags();
   const updateWidgetConfig = useDashboardStore((s) => s.updateWidgetConfig);
   const widget = useDashboardStore((s) => s.widgets.find((w) => w.id === widgetId));
   const config = widget?.config as TranslationWidgetConfig | undefined;
@@ -530,7 +530,7 @@ export function TranslationBackPanel({
   const [fromLang, setFromLang] = useState(config?.fromLang ?? "en");
   const [toLang, setToLang] = useState(config?.toLang ?? "fr");
 
-  const textColor = isXpTheme ? "#000" : "rgba(255,255,255,0.8)";
+  const textColor = isWindowsTheme ? "#000" : "rgba(255,255,255,0.8)";
   const font = "'Helvetica Neue', Helvetica, Arial, sans-serif";
 
   const handleSave = useCallback(() => {
@@ -546,7 +546,7 @@ export function TranslationBackPanel({
     >
       <div
         className="text-[10px] font-bold uppercase tracking-wider"
-        style={{ color: isXpTheme ? "#888" : "rgba(255,255,255,0.4)" }}
+        style={{ color: isWindowsTheme ? "#888" : "rgba(255,255,255,0.4)" }}
       >
         {t("apps.dashboard.translation.defaultLanguages", "Default Languages")}
       </div>
@@ -561,8 +561,8 @@ export function TranslationBackPanel({
             onChange={(e) => setFromLang(e.target.value)}
             className="flex-1 text-[11px] rounded px-1.5 py-0.5 outline-none"
             style={{
-              background: isXpTheme ? "#FFF" : "rgba(255,255,255,0.1)",
-              border: isXpTheme ? "1px solid #ACA899" : "1px solid rgba(255,255,255,0.15)",
+              background: isWindowsTheme ? "#FFF" : "rgba(255,255,255,0.1)",
+              border: isWindowsTheme ? "1px solid #ACA899" : "1px solid rgba(255,255,255,0.15)",
               color: textColor,
               cursor: "pointer",
             }}
@@ -583,8 +583,8 @@ export function TranslationBackPanel({
             onChange={(e) => setToLang(e.target.value)}
             className="flex-1 text-[11px] rounded px-1.5 py-0.5 outline-none"
             style={{
-              background: isXpTheme ? "#FFF" : "rgba(255,255,255,0.1)",
-              border: isXpTheme ? "1px solid #ACA899" : "1px solid rgba(255,255,255,0.15)",
+              background: isWindowsTheme ? "#FFF" : "rgba(255,255,255,0.1)",
+              border: isWindowsTheme ? "1px solid #ACA899" : "1px solid rgba(255,255,255,0.15)",
               color: textColor,
               cursor: "pointer",
             }}
@@ -603,7 +603,7 @@ export function TranslationBackPanel({
         onClick={handleSave}
         className="text-[11px] font-medium hover:opacity-80 transition-opacity self-end"
         style={{
-          color: isXpTheme ? "#0066CC" : "rgba(130,180,255,0.9)",
+          color: isWindowsTheme ? "#0066CC" : "rgba(130,180,255,0.9)",
           cursor: "pointer",
           border: "none",
           background: "none",

--- a/src/components/layout/dashboard/WeatherWidget.tsx
+++ b/src/components/layout/dashboard/WeatherWidget.tsx
@@ -79,7 +79,7 @@ interface WeatherWidgetProps {
 export function WeatherWidget({ widgetId }: WeatherWidgetProps) {
   const { t, i18n } = useTranslation();
   const locale = i18n.language || "en";
-  const { isWindowsTheme: isXpTheme } = useThemeFlags();
+  const { isWindowsTheme } = useThemeFlags();
 
   const widget = useDashboardStore((s) => s.widgets.find((w) => w.id === widgetId));
   const cityConfig = widget?.config as WeatherWidgetConfig | undefined;
@@ -132,7 +132,7 @@ export function WeatherWidget({ widgetId }: WeatherWidgetProps) {
         className="flex items-center justify-center p-4"
         style={{
           minHeight: 120,
-          color: isXpTheme ? "#666" : "rgba(255,255,255,0.45)",
+          color: isWindowsTheme ? "#666" : "rgba(255,255,255,0.45)",
           fontSize: 11,
           fontFamily: "'Helvetica Neue', Helvetica, Arial, sans-serif",
         }}
@@ -142,7 +142,7 @@ export function WeatherWidget({ widgetId }: WeatherWidgetProps) {
     );
   }
 
-  if (isXpTheme) {
+  if (isWindowsTheme) {
     if (loading)
       return (
         <div
@@ -324,7 +324,7 @@ export function WeatherEmojiOverflow({ widgetId }: { widgetId: string }) {
 export function WeatherBackPanel({ widgetId, onDone }: { widgetId: string; onDone?: () => void }) {
   const { t } = useTranslation();
   const popularCities = useMemo(() => getPopularCities(t), [t]);
-  const { isWindowsTheme: isXpTheme } = useThemeFlags();
+  const { isWindowsTheme } = useThemeFlags();
   const updateWidgetConfig = useDashboardStore((s) => s.updateWidgetConfig);
 
   type WeatherSearchState = {
@@ -419,15 +419,15 @@ export function WeatherBackPanel({ widgetId, onDone }: { widgetId: string; onDon
   }, [widgetId, updateWidgetConfig, onDone]);
 
   const citiesToShow = searchQuery.length >= 2 ? searchResults : popularCities;
-  const textColor = isXpTheme ? "#000" : "rgba(255,255,255,0.8)";
+  const textColor = isWindowsTheme ? "#000" : "rgba(255,255,255,0.8)";
 
   return (
     <div onPointerDown={(e) => e.stopPropagation()}>
       <div
         className="flex items-center gap-1.5 px-3 py-1.5"
-        style={{ borderBottom: isXpTheme ? "1px solid #D5D2CA" : "1px solid rgba(255,255,255,0.08)" }}
+        style={{ borderBottom: isWindowsTheme ? "1px solid #D5D2CA" : "1px solid rgba(255,255,255,0.08)" }}
       >
-        <MagnifyingGlass size={12} weight="bold" style={{ color: isXpTheme ? "#888" : "rgba(255,255,255,0.35)", flexShrink: 0 }} />
+        <MagnifyingGlass size={12} weight="bold" style={{ color: isWindowsTheme ? "#888" : "rgba(255,255,255,0.35)", flexShrink: 0 }} />
         <input
           ref={searchInputRef}
           type="text"
@@ -435,7 +435,7 @@ export function WeatherBackPanel({ widgetId, onDone }: { widgetId: string; onDon
           onChange={(e) => handleSearchInput(e.target.value)}
           placeholder={t("apps.dashboard.weather.searchCity")}
           className="flex-1 bg-transparent outline-none text-[11px]"
-          style={{ color: textColor, caretColor: isXpTheme ? "#000" : "rgba(255,255,255,0.7)" }}
+          style={{ color: textColor, caretColor: isWindowsTheme ? "#000" : "rgba(255,255,255,0.7)" }}
         />
       </div>
 
@@ -445,10 +445,10 @@ export function WeatherBackPanel({ widgetId, onDone }: { widgetId: string; onDon
           onClick={useMyLocation}
           className="w-full flex items-center gap-1.5 px-3 py-1.5 text-left transition-colors"
           style={{
-            borderBottom: isXpTheme ? "1px solid #EAE8E1" : "1px solid rgba(255,255,255,0.05)",
-            color: isXpTheme ? "#0066CC" : "rgba(130,180,255,0.9)",
+            borderBottom: isWindowsTheme ? "1px solid #EAE8E1" : "1px solid rgba(255,255,255,0.05)",
+            color: isWindowsTheme ? "#0066CC" : "rgba(130,180,255,0.9)",
           }}
-          onMouseEnter={(e) => (e.currentTarget.style.background = isXpTheme ? "rgba(0,102,204,0.08)" : "rgba(255,255,255,0.06)")}
+          onMouseEnter={(e) => (e.currentTarget.style.background = isWindowsTheme ? "rgba(0,102,204,0.08)" : "rgba(255,255,255,0.06)")}
           onMouseLeave={(e) => (e.currentTarget.style.background = "transparent")}
         >
           <NavigationArrow size={11} weight="fill" style={{ flexShrink: 0 }} />
@@ -456,11 +456,11 @@ export function WeatherBackPanel({ widgetId, onDone }: { widgetId: string; onDon
         </button>
 
         {searching ? (
-          <div className="px-3 py-3 text-center text-[10px]" style={{ color: isXpTheme ? "#888" : "rgba(255,255,255,0.3)" }}>
+          <div className="px-3 py-3 text-center text-[10px]" style={{ color: isWindowsTheme ? "#888" : "rgba(255,255,255,0.3)" }}>
             {t("apps.dashboard.weather.searching")}
           </div>
         ) : searchQuery.length >= 2 && citiesToShow.length === 0 ? (
-          <div className="px-3 py-3 text-center text-[10px]" style={{ color: isXpTheme ? "#888" : "rgba(255,255,255,0.3)" }}>
+          <div className="px-3 py-3 text-center text-[10px]" style={{ color: isWindowsTheme ? "#888" : "rgba(255,255,255,0.3)" }}>
             {t("apps.dashboard.weather.noResults")}
           </div>
         ) : (
@@ -470,10 +470,10 @@ export function WeatherBackPanel({ widgetId, onDone }: { widgetId: string; onDon
               type="button"
               onClick={() => selectCity(city)}
               className="w-full flex items-center gap-1.5 px-3 py-1.5 text-left transition-colors"
-              onMouseEnter={(e) => (e.currentTarget.style.background = isXpTheme ? "rgba(0,102,204,0.08)" : "rgba(255,255,255,0.06)")}
+              onMouseEnter={(e) => (e.currentTarget.style.background = isWindowsTheme ? "rgba(0,102,204,0.08)" : "rgba(255,255,255,0.06)")}
               onMouseLeave={(e) => (e.currentTarget.style.background = "transparent")}
             >
-              <MapPin size={10} weight="fill" style={{ color: isXpTheme ? "#999" : "rgba(255,255,255,0.25)", flexShrink: 0 }} />
+              <MapPin size={10} weight="fill" style={{ color: isWindowsTheme ? "#999" : "rgba(255,255,255,0.25)", flexShrink: 0 }} />
               <span className="text-[11px] truncate" style={{ color: textColor }}>{formatCityLabel(city)}</span>
             </button>
           ))

--- a/src/components/layout/dashboard/WidgetChrome.tsx
+++ b/src/components/layout/dashboard/WidgetChrome.tsx
@@ -44,7 +44,7 @@ export function WidgetChrome({
 }: WidgetChromeProps) {
   const isStacked = layout === "stacked";
   const { t } = useTranslation();
-  const { isWindowsTheme: isXpTheme } = useThemeFlags();
+  const { isWindowsTheme } = useThemeFlags();
   const [isHovered, setIsHovered] = useState(false);
   const [isTouchActive, setIsTouchActive] = useState(false);
   const [isDragging, setIsDragging] = useState(false);
@@ -154,19 +154,19 @@ export function WidgetChrome({
   const resolvedBackContent = typeof backContent === "function" ? backContent(flipBack) : backContent;
   const hasBack = !!backContent;
 
-  const borderRadius = borderRadiusProp ?? (isXpTheme ? "4px" : "20px");
+  const borderRadius = borderRadiusProp ?? (isWindowsTheme ? "4px" : "20px");
 
   const cardStyle = {
     width,
     minHeight: height,
     borderRadius,
-    background: isXpTheme
+    background: isWindowsTheme
       ? "rgba(255,255,255,0.92)"
       : "linear-gradient(to bottom, rgba(50,50,50,0.8), rgba(25,25,25,0.85))",
-    border: isXpTheme
+    border: isWindowsTheme
       ? "1px solid #ACA899"
       : "1px solid rgba(255,255,255,0.1)",
-    boxShadow: isXpTheme
+    boxShadow: isWindowsTheme
       ? "1px 1px 4px rgba(0,0,0,0.3)"
       : "0 8px 32px rgba(0,0,0,0.5), 0 2px 8px rgba(0,0,0,0.3), inset 0 1px 0 rgba(255,255,255,0.08)",
   };
@@ -216,9 +216,9 @@ export function WidgetChrome({
             top: -6, left: -6, width: 20, height: 20,
             borderRadius: "50%", zIndex: 20,
             pointerEvents: showControls ? "auto" : "none",
-            background: isXpTheme ? "#CC0000" : "linear-gradient(180deg, #5a5a5a 0%, #333333 100%)",
-            border: isXpTheme ? "1px solid #990000" : "1.5px solid rgba(255,255,255,0.3)",
-            boxShadow: isXpTheme ? "0 1px 3px rgba(0,0,0,0.4)" : "0 2px 6px rgba(0,0,0,0.5), inset 0 1px 0 rgba(255,255,255,0.2)",
+            background: isWindowsTheme ? "#CC0000" : "linear-gradient(180deg, #5a5a5a 0%, #333333 100%)",
+            border: isWindowsTheme ? "1px solid #990000" : "1.5px solid rgba(255,255,255,0.3)",
+            boxShadow: isWindowsTheme ? "0 1px 3px rgba(0,0,0,0.4)" : "0 2px 6px rgba(0,0,0,0.5), inset 0 1px 0 rgba(255,255,255,0.2)",
             color: "#FFF",
           }}
         >
@@ -287,7 +287,7 @@ export function WidgetChrome({
             <div className="flex flex-col" style={{ minHeight: "inherit" }}>
               {resolvedChildren}
             </div>
-            {!isXpTheme && (
+            {!isWindowsTheme && (
               <>
                 <div className="absolute pointer-events-none" style={{ top: 2, left: "50%", transform: "translateX(-50%)", width: "calc(100% - 6px)", height: "35%", maxHeight: 50, borderRadius: "18px 18px 50% 50%", background: "linear-gradient(rgba(255,255,255,0.3), rgba(255,255,255,0))", zIndex: 10 }} />
                 <div className="absolute pointer-events-none" style={{ bottom: 2, left: "50%", transform: "translateX(-50%)", width: "calc(100% - 10px)", height: "20%", maxHeight: 30, borderRadius: "50% 50% 16px 16px", background: "linear-gradient(rgba(255,255,255,0), rgba(255,255,255,0.08))", filter: "blur(1px)", zIndex: 10 }} />
@@ -319,7 +319,7 @@ export function WidgetChrome({
                       whileHover={{ opacity: 0.8 }}
                       style={{
                         fontSize: 12, padding: "4px 10px", cursor: "pointer",
-                        color: isXpTheme ? "#0066CC" : "rgba(130,180,255,0.9)",
+                        color: isWindowsTheme ? "#0066CC" : "rgba(130,180,255,0.9)",
                         fontFamily: "'Helvetica Neue', Helvetica, Arial, sans-serif",
                       }}
                     >

--- a/src/components/layout/dashboard/currency-widget/CurrencyBackPanel.tsx
+++ b/src/components/layout/dashboard/currency-widget/CurrencyBackPanel.tsx
@@ -7,7 +7,7 @@ import type { CurrencyBackPanelProps } from "./types";
 
 export function CurrencyBackPanel({ widgetId, onDone }: CurrencyBackPanelProps) {
   const { t } = useTranslation();
-  const { isWindowsTheme: isXpTheme } = useThemeFlags();
+  const { isWindowsTheme } = useThemeFlags();
   const updateWidgetConfig = useDashboardStore((s) => s.updateWidgetConfig);
   const widget = useDashboardStore((s) => s.widgets.find((w) => w.id === widgetId));
   const config = widget?.config as CurrencyWidgetConfig | undefined;
@@ -15,7 +15,7 @@ export function CurrencyBackPanel({ widgetId, onDone }: CurrencyBackPanelProps) 
   const [fromCurrency, setFromCurrency] = useState(config?.fromCurrency ?? "USD");
   const [toCurrency, setToCurrency] = useState(config?.toCurrency ?? "EUR");
 
-  const textColor = isXpTheme ? "#000" : "rgba(255,255,255,0.85)";
+  const textColor = isWindowsTheme ? "#000" : "rgba(255,255,255,0.85)";
 
   const handleSave = useCallback(() => {
     updateWidgetConfig(widgetId, {
@@ -30,7 +30,7 @@ export function CurrencyBackPanel({ widgetId, onDone }: CurrencyBackPanelProps) 
     <div className="p-3 flex flex-col gap-3" style={{ fontFamily: CURRENCY_WIDGET_FONT }} onPointerDown={(e) => e.stopPropagation()}>
       <div
         className="text-[10px] font-bold uppercase tracking-wider"
-        style={{ color: isXpTheme ? "#888" : "rgba(255,255,255,0.4)" }}
+        style={{ color: isWindowsTheme ? "#888" : "rgba(255,255,255,0.4)" }}
       >
         {t("apps.dashboard.currency.defaultPair", "Default currency pair")}
       </div>
@@ -44,8 +44,8 @@ export function CurrencyBackPanel({ widgetId, onDone }: CurrencyBackPanelProps) 
             onChange={(e) => setFromCurrency(e.target.value)}
             className="flex-1 text-[11px] rounded px-1.5 py-0.5 outline-none"
             style={{
-              background: isXpTheme ? "#FFF" : "rgba(255,255,255,0.1)",
-              border: isXpTheme ? "1px solid #ACA899" : "1px solid rgba(255,255,255,0.15)",
+              background: isWindowsTheme ? "#FFF" : "rgba(255,255,255,0.1)",
+              border: isWindowsTheme ? "1px solid #ACA899" : "1px solid rgba(255,255,255,0.15)",
               color: textColor,
               cursor: "pointer",
             }}
@@ -66,8 +66,8 @@ export function CurrencyBackPanel({ widgetId, onDone }: CurrencyBackPanelProps) 
             onChange={(e) => setToCurrency(e.target.value)}
             className="flex-1 text-[11px] rounded px-1.5 py-0.5 outline-none"
             style={{
-              background: isXpTheme ? "#FFF" : "rgba(255,255,255,0.1)",
-              border: isXpTheme ? "1px solid #ACA899" : "1px solid rgba(255,255,255,0.15)",
+              background: isWindowsTheme ? "#FFF" : "rgba(255,255,255,0.1)",
+              border: isWindowsTheme ? "1px solid #ACA899" : "1px solid rgba(255,255,255,0.15)",
               color: textColor,
               cursor: "pointer",
             }}
@@ -85,7 +85,7 @@ export function CurrencyBackPanel({ widgetId, onDone }: CurrencyBackPanelProps) 
         onClick={handleSave}
         className="text-[11px] font-medium hover:opacity-80 transition-opacity self-end"
         style={{
-          color: isXpTheme ? "#0066CC" : "rgba(210,215,245,0.95)",
+          color: isWindowsTheme ? "#0066CC" : "rgba(210,215,245,0.95)",
           cursor: "pointer",
           border: "none",
           background: "none",
@@ -94,7 +94,7 @@ export function CurrencyBackPanel({ widgetId, onDone }: CurrencyBackPanelProps) 
       >
         {t("apps.dashboard.translation.save", "Save")}
       </button>
-      <p className="text-[10px] leading-snug" style={{ color: isXpTheme ? "#666" : "rgba(255,255,255,0.55)" }}>
+      <p className="text-[10px] leading-snug" style={{ color: isWindowsTheme ? "#666" : "rgba(255,255,255,0.55)" }}>
         {t(
           "apps.dashboard.currency.about",
           "Rates from Frankfurter (ECB). For information only; not financial advice."

--- a/src/components/layout/dashboard/currency-widget/CurrencyWidget.tsx
+++ b/src/components/layout/dashboard/currency-widget/CurrencyWidget.tsx
@@ -5,10 +5,10 @@ import type { CurrencyWidgetProps } from "./types";
 import { useCurrencyWidget } from "./useCurrencyWidget";
 
 export function CurrencyWidget({ widgetId }: CurrencyWidgetProps) {
-  const { isWindowsTheme: isXpTheme } = useThemeFlags();
+  const { isWindowsTheme } = useThemeFlags();
   const viewProps = useCurrencyWidget(widgetId);
 
-  if (isXpTheme) {
+  if (isWindowsTheme) {
     return (
       <CurrencyWidgetXpView
         t={viewProps.t}

--- a/src/components/layout/dashboard/stocks-widget/MiniChart.tsx
+++ b/src/components/layout/dashboard/stocks-widget/MiniChart.tsx
@@ -4,12 +4,12 @@ import type { ChartPoint } from "./types";
 export function MiniChart({
   history,
   xLabels,
-  isXpTheme,
+  isWindowsTheme,
   widgetId,
 }: {
   history: number[];
   xLabels: string[];
-  isXpTheme: boolean;
+  isWindowsTheme: boolean;
   widgetId: string;
 }) {
   const width = 220;
@@ -62,20 +62,20 @@ export function MiniChart({
     <svg width={width} height={height} viewBox={`0 0 ${width} ${height}`} className="block">
       <defs>
         <linearGradient id={gradientId} x1="0" y1="0" x2="0" y2="1">
-          <stop offset="0%" stopColor={isXpTheme ? "#4A90D9" : "#FFFFFF"} stopOpacity={0.3} />
-          <stop offset="20%" stopColor={isXpTheme ? "#4A90D9" : "#FFFFFF"} stopOpacity={0.15} />
-          <stop offset="50%" stopColor={isXpTheme ? "#4A90D9" : "#FFFFFF"} stopOpacity={0.05} />
-          <stop offset="100%" stopColor={isXpTheme ? "#4A90D9" : "#FFFFFF"} stopOpacity={0} />
+          <stop offset="0%" stopColor={isWindowsTheme ? "#4A90D9" : "#FFFFFF"} stopOpacity={0.3} />
+          <stop offset="20%" stopColor={isWindowsTheme ? "#4A90D9" : "#FFFFFF"} stopOpacity={0.15} />
+          <stop offset="50%" stopColor={isWindowsTheme ? "#4A90D9" : "#FFFFFF"} stopOpacity={0.05} />
+          <stop offset="100%" stopColor={isWindowsTheme ? "#4A90D9" : "#FFFFFF"} stopOpacity={0} />
         </linearGradient>
       </defs>
       <path d={area} fill={`url(#${gradientId})`} />
-      <path d={linePath} fill="none" stroke={isXpTheme ? "#2060A0" : "#FFFFFF"} strokeWidth={1.5} />
+      <path d={linePath} fill="none" stroke={isWindowsTheme ? "#2060A0" : "#FFFFFF"} strokeWidth={1.5} />
       {yLabels.map((label) => (
         <text
           key={label.value}
           x={width - rightPad + 4}
           y={label.y + 3}
-          fill={isXpTheme ? "#666" : "rgba(255,255,255,0.4)"}
+          fill={isWindowsTheme ? "#666" : "rgba(255,255,255,0.4)"}
           fontSize={9}
           fontFamily="'Helvetica Neue', Helvetica, Arial, sans-serif"
         >
@@ -89,7 +89,7 @@ export function MiniChart({
             key={`${label}-${Math.round(xPos)}`}
             x={xPos}
             y={height - 2}
-            fill={isXpTheme ? "#666" : "rgba(255,255,255,0.4)"}
+            fill={isWindowsTheme ? "#666" : "rgba(255,255,255,0.4)"}
             fontSize={9}
             fontFamily="'Helvetica Neue', Helvetica, Arial, sans-serif"
             textAnchor="middle"

--- a/src/components/layout/dashboard/stocks-widget/StocksBackPanel.tsx
+++ b/src/components/layout/dashboard/stocks-widget/StocksBackPanel.tsx
@@ -9,7 +9,7 @@ import type { StocksBackPanelProps } from "./types";
 
 export function StocksBackPanel({ widgetId, onDone }: StocksBackPanelProps) {
   const { t } = useTranslation();
-  const { isWindowsTheme: isXpTheme } = useThemeFlags();
+  const { isWindowsTheme } = useThemeFlags();
   const updateWidgetConfig = useDashboardStore((s) => s.updateWidgetConfig);
 
   const widget = useDashboardStore((s) => s.widgets.find((w) => w.id === widgetId));
@@ -91,20 +91,20 @@ export function StocksBackPanel({ widgetId, onDone }: StocksBackPanelProps) {
   }, [widgetId, updateWidgetConfig, onDone]);
 
   const symbolsToShow = searchQuery ? searchResults.filter((s) => !currentSymbols.includes(s)) : availablePopular;
-  const textColor = isXpTheme ? "#000" : "rgba(255,255,255,0.8)";
+  const textColor = isWindowsTheme ? "#000" : "rgba(255,255,255,0.8)";
 
   return (
     <div onPointerDown={(e) => e.stopPropagation()}>
       <div
         className="flex items-center gap-1.5 px-3 py-1.5"
         style={{
-          borderBottom: isXpTheme ? "1px solid #D5D2CA" : "1px solid rgba(255,255,255,0.08)",
+          borderBottom: isWindowsTheme ? "1px solid #D5D2CA" : "1px solid rgba(255,255,255,0.08)",
         }}
       >
         <MagnifyingGlass
           size={12}
           weight="bold"
-          style={{ color: isXpTheme ? "#888" : "rgba(255,255,255,0.35)", flexShrink: 0 }}
+          style={{ color: isWindowsTheme ? "#888" : "rgba(255,255,255,0.35)", flexShrink: 0 }}
         />
         <input
           type="text"
@@ -112,19 +112,19 @@ export function StocksBackPanel({ widgetId, onDone }: StocksBackPanelProps) {
           onChange={(e) => handleSearchInput(e.target.value)}
           placeholder={t("apps.dashboard.stocks.searchSymbol")}
           className="flex-1 bg-transparent outline-none text-[11px]"
-          style={{ color: textColor, caretColor: isXpTheme ? "#000" : "rgba(255,255,255,0.7)" }}
+          style={{ color: textColor, caretColor: isWindowsTheme ? "#000" : "rgba(255,255,255,0.7)" }}
         />
       </div>
 
       <div
         className="px-3 py-1.5"
         style={{
-          borderBottom: isXpTheme ? "1px solid #D5D2CA" : "1px solid rgba(255,255,255,0.08)",
+          borderBottom: isWindowsTheme ? "1px solid #D5D2CA" : "1px solid rgba(255,255,255,0.08)",
         }}
       >
         <div
           className="text-[9px] font-bold uppercase tracking-wider mb-1"
-          style={{ color: isXpTheme ? "#888" : "rgba(255,255,255,0.35)" }}
+          style={{ color: isWindowsTheme ? "#888" : "rgba(255,255,255,0.35)" }}
         >
           {t("apps.dashboard.stocks.currentSymbols")}
         </div>
@@ -134,7 +134,7 @@ export function StocksBackPanel({ widgetId, onDone }: StocksBackPanelProps) {
               key={sym}
               className="inline-flex items-center gap-0.5 px-1.5 py-0.5 rounded text-[10px] font-medium"
               style={{
-                background: isXpTheme ? "rgba(0,0,0,0.06)" : "rgba(255,255,255,0.1)",
+                background: isWindowsTheme ? "rgba(0,0,0,0.06)" : "rgba(255,255,255,0.1)",
                 color: textColor,
               }}
             >
@@ -149,7 +149,7 @@ export function StocksBackPanel({ widgetId, onDone }: StocksBackPanelProps) {
                   <X
                     size={8}
                     weight="bold"
-                    style={{ color: isXpTheme ? "#888" : "rgba(255,255,255,0.4)" }}
+                    style={{ color: isWindowsTheme ? "#888" : "rgba(255,255,255,0.4)" }}
                   />
                 </button>
               )}
@@ -162,7 +162,7 @@ export function StocksBackPanel({ widgetId, onDone }: StocksBackPanelProps) {
         {searching ? (
           <div
             className="px-3 py-3 text-center text-[10px]"
-            style={{ color: isXpTheme ? "#888" : "rgba(255,255,255,0.3)" }}
+            style={{ color: isWindowsTheme ? "#888" : "rgba(255,255,255,0.3)" }}
           >
             {t("apps.dashboard.stocks.searching")}
           </div>
@@ -174,7 +174,7 @@ export function StocksBackPanel({ widgetId, onDone }: StocksBackPanelProps) {
               onClick={() => addSymbol(sym)}
               className="w-full flex items-center gap-1.5 px-3 py-1 text-left transition-colors"
               onMouseEnter={(e) =>
-                (e.currentTarget.style.background = isXpTheme
+                (e.currentTarget.style.background = isWindowsTheme
                   ? "rgba(0,102,204,0.08)"
                   : "rgba(255,255,255,0.06)")
               }
@@ -183,14 +183,14 @@ export function StocksBackPanel({ widgetId, onDone }: StocksBackPanelProps) {
               <Plus
                 size={10}
                 weight="bold"
-                style={{ color: isXpTheme ? "#0066CC" : "rgba(130,180,255,0.7)", flexShrink: 0 }}
+                style={{ color: isWindowsTheme ? "#0066CC" : "rgba(130,180,255,0.7)", flexShrink: 0 }}
               />
               <span className="text-[11px]" style={{ color: textColor }}>
                 {displaySymbol(sym)}
               </span>
               <span
                 className="text-[9px] ml-auto"
-                style={{ color: isXpTheme ? "#888" : "rgba(255,255,255,0.3)" }}
+                style={{ color: isWindowsTheme ? "#888" : "rgba(255,255,255,0.3)" }}
               >
                 {sym}
               </span>
@@ -200,7 +200,7 @@ export function StocksBackPanel({ widgetId, onDone }: StocksBackPanelProps) {
         {!searching && symbolsToShow.length === 0 && (
           <div
             className="px-3 py-2 text-center text-[10px]"
-            style={{ color: isXpTheme ? "#888" : "rgba(255,255,255,0.3)" }}
+            style={{ color: isWindowsTheme ? "#888" : "rgba(255,255,255,0.3)" }}
           >
             {searchQuery ? t("apps.dashboard.stocks.noResults") : t("apps.dashboard.stocks.allAdded")}
           </div>
@@ -210,7 +210,7 @@ export function StocksBackPanel({ widgetId, onDone }: StocksBackPanelProps) {
       <div
         className="px-3 py-1.5"
         style={{
-          borderTop: isXpTheme ? "1px solid #D5D2CA" : "1px solid rgba(255,255,255,0.08)",
+          borderTop: isWindowsTheme ? "1px solid #D5D2CA" : "1px solid rgba(255,255,255,0.08)",
         }}
       >
         <button
@@ -218,7 +218,7 @@ export function StocksBackPanel({ widgetId, onDone }: StocksBackPanelProps) {
           onClick={resetToDefault}
           className="text-[10px] font-medium hover:opacity-80 transition-opacity"
           style={{
-            color: isXpTheme ? "#0066CC" : "rgba(130,180,255,0.9)",
+            color: isWindowsTheme ? "#0066CC" : "rgba(130,180,255,0.9)",
             cursor: "pointer",
             border: "none",
             background: "none",

--- a/src/components/layout/dashboard/stocks-widget/StocksWidget.tsx
+++ b/src/components/layout/dashboard/stocks-widget/StocksWidget.tsx
@@ -9,7 +9,7 @@ import { StocksWidgetXpView } from "./StocksWidgetXpView";
 
 export function StocksWidget({ widgetId }: StocksWidgetProps) {
   const { t } = useTranslation();
-  const { isWindowsTheme: isXpTheme } = useThemeFlags();
+  const { isWindowsTheme } = useThemeFlags();
 
   const {
     stocks,
@@ -29,7 +29,7 @@ export function StocksWidget({ widgetId }: StocksWidgetProps) {
         className="flex items-center justify-center"
         style={{
           minHeight: 200,
-          color: isXpTheme ? "#888" : "rgba(255,255,255,0.4)",
+          color: isWindowsTheme ? "#888" : "rgba(255,255,255,0.4)",
           fontSize: 13,
           fontFamily: STOCKS_FONT,
         }}
@@ -45,7 +45,7 @@ export function StocksWidget({ widgetId }: StocksWidgetProps) {
         className="flex flex-col items-center justify-center gap-2 p-4"
         style={{
           minHeight: 200,
-          color: isXpTheme ? "#888" : "rgba(255,255,255,0.4)",
+          color: isWindowsTheme ? "#888" : "rgba(255,255,255,0.4)",
           fontSize: 13,
           fontFamily: STOCKS_FONT,
         }}
@@ -57,7 +57,7 @@ export function StocksWidget({ widgetId }: StocksWidgetProps) {
           onClick={loadQuotes}
           className="flex items-center gap-1 hover:opacity-80"
           style={{
-            color: isXpTheme ? "#0066CC" : "rgba(130,180,255,0.9)",
+            color: isWindowsTheme ? "#0066CC" : "rgba(130,180,255,0.9)",
             fontSize: 12,
             cursor: "pointer",
             border: "none",
@@ -82,7 +82,7 @@ export function StocksWidget({ widgetId }: StocksWidgetProps) {
     onSelectRange: setSelectedRange,
   };
 
-  if (isXpTheme) {
+  if (isWindowsTheme) {
     return <StocksWidgetXpView {...viewProps} />;
   }
 

--- a/src/components/layout/dashboard/stocks-widget/StocksWidgetMacView.tsx
+++ b/src/components/layout/dashboard/stocks-widget/StocksWidgetMacView.tsx
@@ -127,7 +127,7 @@ export function StocksWidgetMacView({
             <MiniChart
               history={chartHistory}
               xLabels={xLabels}
-              isXpTheme={false}
+              isWindowsTheme={false}
               widgetId={widgetId}
             />
           </div>

--- a/src/components/layout/dashboard/stocks-widget/StocksWidgetXpView.tsx
+++ b/src/components/layout/dashboard/stocks-widget/StocksWidgetXpView.tsx
@@ -92,7 +92,7 @@ export function StocksWidgetXpView({
           <MiniChart
             history={chartHistory}
             xLabels={xLabels}
-            isXpTheme
+            isWindowsTheme
             widgetId={widgetId}
           />
         </div>

--- a/src/components/layout/desktop/Desktop.tsx
+++ b/src/components/layout/desktop/Desktop.tsx
@@ -39,10 +39,10 @@ export function Desktop(props: DesktopProps) {
       <DesktopDynamicWallpaper />
       <DesktopDragRegion
         isDesktopApp={d.isDesktopApp}
-        isXpTheme={d.isXpTheme}
+        isWindowsTheme={d.isWindowsTheme}
       />
       <DesktopIconGrid
-        isXpTheme={d.isXpTheme}
+        isWindowsTheme={d.isWindowsTheme}
         isMacOSTheme={d.isMacOSTheme}
         isDesktopApp={d.isDesktopApp}
         currentTheme={d.currentTheme}

--- a/src/components/layout/desktop/DesktopDragRegion.tsx
+++ b/src/components/layout/desktop/DesktopDragRegion.tsx
@@ -2,14 +2,14 @@ import type { CSSProperties } from "react";
 
 interface DesktopDragRegionProps {
   isDesktopApp: boolean;
-  isXpTheme: boolean;
+  isWindowsTheme: boolean;
 }
 
 export function DesktopDragRegion({
   isDesktopApp,
-  isXpTheme,
+  isWindowsTheme,
 }: DesktopDragRegionProps) {
-  if (!isDesktopApp || !isXpTheme) {
+  if (!isDesktopApp || !isWindowsTheme) {
     return null;
   }
 

--- a/src/components/layout/desktop/DesktopIconGrid.tsx
+++ b/src/components/layout/desktop/DesktopIconGrid.tsx
@@ -15,7 +15,7 @@ import {
 import type { DesktopItemId } from "./desktopTypes";
 
 export interface DesktopIconGridProps {
-  isXpTheme: boolean;
+  isWindowsTheme: boolean;
   isMacOSTheme: boolean;
   isDesktopApp: boolean;
   currentTheme: string;
@@ -44,7 +44,7 @@ export interface DesktopIconGridProps {
 }
 
 export function DesktopIconGrid({
-  isXpTheme,
+  isWindowsTheme,
   isMacOSTheme,
   isDesktopApp,
   currentTheme,
@@ -70,12 +70,12 @@ export function DesktopIconGrid({
       className={cn(
         "flex flex-col relative z-[1]",
         isMacOSTheme && OS_SHELL_TEXT_SCALE_CLASS,
-        isXpTheme
+        isWindowsTheme
           ? "items-start pt-2" // Reserve space via height, not padding, to avoid clipping
           : "items-end pt-8" // Account for top menubar - keep right alignment for other themes
       )}
       style={
-        isXpTheme
+        isWindowsTheme
           ? {
               // Exclude menubar, safe area, and an extra visual buffer to prevent clipping
               // Add extra top padding for desktop traffic lights on Windows themes
@@ -98,7 +98,7 @@ export function DesktopIconGrid({
     >
       <div
         className={
-          isXpTheme
+          isWindowsTheme
             ? "flex flex-col flex-wrap justify-start content-start h-full gap-x-3 gap-y-3"
             : "flex flex-col flex-wrap-reverse justify-start content-start h-full gap-x-3 gap-y-3"
         }
@@ -108,7 +108,7 @@ export function DesktopIconGrid({
             name={macintoshHdName}
             isDirectory={true}
             icon={
-              isXpTheme ? "/icons/default/pc.png" : "/icons/default/disk.png"
+              isWindowsTheme ? "/icons/default/pc.png" : "/icons/default/disk.png"
             }
             onClick={(e) =>
               onDesktopItemClick(getDesktopAppItemId("macintosh-hd"), e)
@@ -189,7 +189,7 @@ export function DesktopIconGrid({
                 name={getTranslatedAppName(app.id as AppId)}
                 isDirectory={false}
                 icon={
-                  isXpTheme && app.id === "pc"
+                  isWindowsTheme && app.id === "pc"
                     ? `/icons/${currentTheme}/games.png`
                     : getAppIconPath(app.id)
                 }

--- a/src/components/layout/desktop/useDesktop.ts
+++ b/src/components/layout/desktop/useDesktop.ts
@@ -90,7 +90,7 @@ export function useDesktop({
 
   const {
     currentTheme,
-    isWindowsTheme: isXpTheme,
+    isWindowsTheme,
     isMacOSTheme,
     isSystem7Theme,
   } = useThemeFlags();
@@ -668,10 +668,10 @@ export function useDesktop({
 
   const macintoshHdName = useMemo(
     () =>
-      isXpTheme
+      isWindowsTheme
         ? t("common.desktop.myComputer")
         : t("apps.finder.window.macintoshHd"),
-    [isXpTheme, t]
+    [isWindowsTheme, t]
   );
 
   const handleShortcutDoubleClick = useCallback(
@@ -753,7 +753,7 @@ export function useDesktop({
       clearSelection();
     },
     isDesktopApp,
-    isXpTheme,
+    isWindowsTheme,
     isMacOSTheme,
     currentTheme,
     macintoshHdName,

--- a/src/components/layout/menu-bar/CloudSyncIndicator.tsx
+++ b/src/components/layout/menu-bar/CloudSyncIndicator.tsx
@@ -80,7 +80,7 @@ interface SyncCategoryActivity {
 export function CloudSyncIndicator() {
   const { t } = useTranslation();
   const {
-    isWindowsTheme: isXpTheme,
+    isWindowsTheme,
     isMacOSTheme,
     isSystem7Theme,
   } = useThemeFlags();
@@ -112,7 +112,7 @@ export function CloudSyncIndicator() {
 
   // Keep the indicator mounted while the menu is open so the menu does
   // not vanish mid-read when the last sync operation finishes.
-  if (isXpTheme || (!isCloudSyncActive && !isOpen)) return null;
+  if (isWindowsTheme || (!isCloudSyncActive && !isOpen)) return null;
 
   const lastCheckedRelative = formatRelativeTime(
     lastCheckedAt,

--- a/src/components/layout/menu-bar/ExposeButton.tsx
+++ b/src/components/layout/menu-bar/ExposeButton.tsx
@@ -5,10 +5,10 @@ import { toggleExposeView } from "@/utils/appEventBus";
 
 export function ExposeButton() {
   const { t } = useTranslation();
-  const { isWindowsTheme: isXpTheme } = useThemeFlags();
+  const { isWindowsTheme } = useThemeFlags();
 
   // Don't show on Windows themes (they have their own taskbar)
-  if (isXpTheme) return null;
+  if (isWindowsTheme) return null;
 
   const handleClick = () => {
     toggleExposeView();

--- a/src/components/layout/menu-bar/MenuBarClock.tsx
+++ b/src/components/layout/menu-bar/MenuBarClock.tsx
@@ -9,7 +9,7 @@ import type { ClockProps } from "./menuBarTypes";
 export function Clock({ enableExposeToggle = false, enableCalendarOpen = false }: ClockProps) {
   const [time, setTime] = useState(() => new Date());
   const [viewportWidth, setViewportWidth] = useState(() => window.innerWidth);
-  const { isWindowsTheme: isXpTheme, isMacOSTheme } = useThemeFlags();
+  const { isWindowsTheme, isMacOSTheme } = useThemeFlags();
   const { t, i18n: i18nInstance } = useTranslation();
   
   // Get current locale from i18n (reactive to language changes)
@@ -48,7 +48,7 @@ export function Clock({ enableExposeToggle = false, enableCalendarOpen = false }
   
   let displayTime: string;
 
-  if (isXpTheme) {
+  if (isWindowsTheme) {
     // For XP/98 themes: use 24h for locales that prefer it, otherwise 12h
     if (prefers24Hour) {
       displayTime = formatTime24h(time);
@@ -123,7 +123,7 @@ export function Clock({ enableExposeToggle = false, enableCalendarOpen = false }
     // biome-ignore lint/a11y/noStaticElementInteractions: Window drag handle for desktop shell
     <div
       role="presentation"
-      className={`${isXpTheme ? "" : "ml-auto mr-1 sm:mr-2"} whitespace-nowrap`}
+      className={`${isWindowsTheme ? "" : "ml-auto mr-1 sm:mr-2"} whitespace-nowrap`}
       style={{
         textShadow: isMacOSTheme
           ? "0 2px 3px rgba(0, 0, 0, 0.25)"

--- a/src/components/layout/menu-bar/OfflineIndicator.tsx
+++ b/src/components/layout/menu-bar/OfflineIndicator.tsx
@@ -6,7 +6,7 @@ import { useThemeFlags } from "@/hooks/useThemeFlags";
 export function OfflineIndicator() {
   const { t } = useTranslation();
   const isOffline = useOffline();
-  const { isWindowsTheme: isXpTheme, isWin98 } = useThemeFlags();
+  const { isWindowsTheme, isWin98 } = useThemeFlags();
 
   if (!isOffline) return null;
 
@@ -14,18 +14,18 @@ export function OfflineIndicator() {
     <div
       className="flex items-center"
       style={{
-        marginRight: isXpTheme ? "4px" : "8px",
+        marginRight: isWindowsTheme ? "4px" : "8px",
         color:
           isWin98
             ? "#000000"
-            : isXpTheme
+            : isWindowsTheme
             ? "#ffffff"
             : "var(--os-color-menubar-text)",
       }}
       title={t("common.menuBar.offline")}
     >
       <WifiSlash
-        className={isXpTheme ? "h-3 w-3" : "h-4 w-4"}
+        className={isWindowsTheme ? "h-3 w-3" : "h-4 w-4"}
         weight="bold"
         style={{
           opacity: 0.7,

--- a/src/components/layout/menu-bar/SpotlightMenuBarButton.tsx
+++ b/src/components/layout/menu-bar/SpotlightMenuBarButton.tsx
@@ -6,11 +6,11 @@ import { toggleSpotlightSearch } from "@/utils/appEventBus";
 
 export function SpotlightMenuBarButton() {
   const { t } = useTranslation();
-  const { isWindowsTheme: isXpTheme, isMacOSTheme } = useThemeFlags();
+  const { isWindowsTheme, isMacOSTheme } = useThemeFlags();
   const isSpotlightOpen = useSpotlightStore((state) => state.isOpen);
 
   // Only show on Mac themes — Windows themes use Start Menu "Run..."
-  if (isXpTheme) return null;
+  if (isWindowsTheme) return null;
 
   const handleClick = () => {
     toggleSpotlightSearch();

--- a/src/components/layout/menu-bar/VolumeControl.tsx
+++ b/src/components/layout/menu-bar/VolumeControl.tsx
@@ -30,7 +30,7 @@ export function VolumeControl() {
   const { play: playVolumeChangeSound } = useSound(Sounds.VOLUME_CHANGE);
   const launchApp = useLaunchApp();
   const [menuValue, setMenuValue] = useState("");
-  const { isWindowsTheme: isXpTheme, isWin98 } = useThemeFlags();
+  const { isWindowsTheme, isWin98 } = useThemeFlags();
 
   const volumeLabel = t("common.menuBar.volume", "Volume");
 
@@ -49,7 +49,7 @@ export function VolumeControl() {
       value={menuValue}
       onValueChange={setMenuValue}
       className={`hidden sm:flex items-stretch self-stretch border-none bg-transparent p-0 space-x-0 rounded-none h-full ${
-        isXpTheme ? "" : "mr-2"
+        isWindowsTheme ? "" : "mr-2"
       }`}
     >
       <MenubarMenu value={MENU_VALUE}>
@@ -57,14 +57,14 @@ export function VolumeControl() {
           className="flex items-center justify-center px-2 border-none focus-visible:ring-0"
           title={volumeLabel}
           aria-label={volumeLabel}
-          style={{ color: isXpTheme && isWin98 ? "#000000" : undefined }}
+          style={{ color: isWindowsTheme && isWin98 ? "#000000" : undefined }}
         >
           {getVolumeIcon()}
         </MenubarTrigger>
         <MenubarContent
           align="center"
-          side={isXpTheme ? "top" : "bottom"}
-          sideOffset={isXpTheme ? 8 : 1}
+          side={isWindowsTheme ? "top" : "bottom"}
+          sideOffset={isWindowsTheme ? 8 : 1}
           className="w-auto min-w-4 h-40 flex flex-col items-center justify-center"
           style={{ minWidth: "auto" }}
         >

--- a/src/components/layout/menu-bar/WindowsTaskbar.tsx
+++ b/src/components/layout/menu-bar/WindowsTaskbar.tsx
@@ -27,7 +27,7 @@ export interface WindowsTaskbarProps {
   restoreInstance: (instanceId: string) => void;
   getFileItem: (path: string) => FileSystemItem | undefined;
   currentTheme: string;
-  isXpTheme: boolean;
+  isWindowsTheme: boolean;
 }
 
 export function WindowsTaskbar({
@@ -38,7 +38,7 @@ export function WindowsTaskbar({
   restoreInstance,
   getFileItem,
   currentTheme,
-  isXpTheme,
+  isWindowsTheme,
 }: WindowsTaskbarProps) {
   const {
     runningAreaRef,
@@ -281,7 +281,7 @@ export function WindowsTaskbar({
                 </DropdownMenuTrigger>
                 <DropdownMenuContent
                   align="end"
-                  side={isXpTheme ? "top" : "bottom"}
+                  side={isWindowsTheme ? "top" : "bottom"}
                   sideOffset={4}
                   className="px-0"
                 >
@@ -369,14 +369,14 @@ export function WindowsTaskbar({
               <VolumeControl />
             </div>
             <div
-              className={`text-xs ${isXpTheme ? "font-bold" : "font-normal"} ${
-                isXpTheme ? "" : "px-2"
+              className={`text-xs ${isWindowsTheme ? "font-bold" : "font-normal"} ${
+                isWindowsTheme ? "" : "px-2"
               }`}
               style={{
                 color:
                   isWin98
                     ? "#000000"
-                    : isXpTheme
+                    : isWindowsTheme
                     ? "#ffffff"
                     : "#000000",
                 textShadow: isWinXp

--- a/src/components/layout/spotlight-search/useSpotlightSearchController.ts
+++ b/src/components/layout/spotlight-search/useSpotlightSearchController.ts
@@ -27,7 +27,7 @@ export function useSpotlightSearchController() {
   const inputRef = useRef<HTMLInputElement>(null);
   const listRef = useRef<HTMLDivElement>(null);
   const {
-    isWindowsTheme: isXpTheme,
+    isWindowsTheme,
     isMacTheme: isMac,
     isMacOSTheme,
     isSystem7Theme: isSystem7,
@@ -42,10 +42,10 @@ export function useSpotlightSearchController() {
       requestAnimationFrame(focusInput);
       return;
     }
-    const delay = isXpTheme ? 150 : 0;
+    const delay = isWindowsTheme ? 150 : 0;
     const id = setTimeout(() => {
       requestAnimationFrame(focusInput);
-      if (isXpTheme) {
+      if (isWindowsTheme) {
         reclaimId = setTimeout(() => requestAnimationFrame(focusInput), 100);
       }
     }, delay);
@@ -54,7 +54,7 @@ export function useSpotlightSearchController() {
       clearTimeout(id);
       if (reclaimId) clearTimeout(reclaimId);
     };
-  }, [isOpen, isXpTheme, isMobile]);
+  }, [isOpen, isWindowsTheme, isMobile]);
 
   // The global spotlight-toggle listener (and the mobile proxy input it
   // focuses) lives in SpotlightSearchHost, which is always mounted.
@@ -151,7 +151,7 @@ export function useSpotlightSearchController() {
     };
   }, [isMacOSTheme, isSystem7, isWinXp, isMobile]);
 
-  const fontFamily = isXpTheme
+  const fontFamily = isWindowsTheme
     ? "var(--font-ms-sans)"
     : isSystem7
       ? "'Geneva-12', 'ArkPixel', system-ui, sans-serif"
@@ -216,7 +216,7 @@ export function useSpotlightSearchController() {
     isSearching,
     inputRef,
     listRef,
-    isXpTheme,
+    isWindowsTheme,
     isMac,
     isMacOSTheme,
     isSystem7,

--- a/src/components/layout/window-frame/WindowFrame.tsx
+++ b/src/components/layout/window-frame/WindowFrame.tsx
@@ -109,7 +109,7 @@ export function WindowFrame({
   });
 
   const {
-    isWindowsTheme: isXpTheme,
+    isWindowsTheme,
     isMacOSTheme,
     isSystem7Theme,
     isWinXp,
@@ -178,7 +178,7 @@ export function WindowFrame({
     instanceId,
     isForeground,
     isMacOSTheme,
-    isXpTheme,
+    isWindowsTheme,
     bringInstanceToForeground,
   });
 
@@ -366,7 +366,7 @@ export function WindowFrame({
                   showResizers={showResizers}
                   resizeType={resizeType}
                   isMobile={isMobile}
-                  isXpTheme={isXpTheme}
+                  isWindowsTheme={isWindowsTheme}
                   isMacOSTheme={isMacOSTheme}
                   handleResizeStartWithForeground={
                     handleResizeStartWithForeground
@@ -376,15 +376,15 @@ export function WindowFrame({
 
                 <div
                   className={cn(
-                    isXpTheme
+                    isWindowsTheme
                       ? "window flex flex-col h-full"
                       : isNoTitlebar && isMacOSTheme
                         ? "window size-full flex flex-col rounded-os overflow-hidden relative"
                         : "window size-full flex flex-col border-[length:var(--os-metrics-border-width)] border-os-window rounded-os overflow-hidden relative",
                     !effectiveTransparentBackground &&
-                      !isXpTheme &&
+                      !isWindowsTheme &&
                       "bg-os-window-bg",
-                    !isXpTheme &&
+                    !isWindowsTheme &&
                       (!isSystem7Theme || isForeground)
                       ? "shadow-os-window"
                       : "",
@@ -395,7 +395,7 @@ export function WindowFrame({
                     isGlassRegular && "window-material-glass"
                   )}
                   style={{
-                    ...(!isXpTheme
+                    ...(!isWindowsTheme
                       ? getSwipeStyle(isPhone, isSwiping, swipeDirection)
                       : undefined),
                   }}
@@ -404,7 +404,7 @@ export function WindowFrame({
                   onMouseLeave={noTitlebarMouseHandlers.onMouseLeave}
                 >
                   <WindowFrameTitleBar
-                    isXpTheme={isXpTheme}
+                    isWindowsTheme={isWindowsTheme}
                     isMacOSTheme={isMacOSTheme}
                     isWinXp={isWinXp}
                     isForeground={isForeground}
@@ -438,7 +438,7 @@ export function WindowFrame({
                     showTitlebarWithAutoHide={showTitlebarWithAutoHide}
                   />
 
-                  {isXpTheme && menuBar && (
+                  {isWindowsTheme && menuBar && (
                     <div
                       className="menubar-container"
                       style={{
@@ -458,7 +458,7 @@ export function WindowFrame({
                         "ml-[8px] mr-[8px] mb-[8px] rounded-none overflow-hidden"
                     )}
                     style={
-                      isXpTheme
+                      isWindowsTheme
                         ? { margin: isWinXp ? "0px 3px" : "0" }
                         : isMacOSTheme
                           ? isTransparent || isBrushedMetal || isAquaGlass

--- a/src/components/layout/window-frame/WindowFrameResizeHandles.tsx
+++ b/src/components/layout/window-frame/WindowFrameResizeHandles.tsx
@@ -6,7 +6,7 @@ export interface WindowFrameResizeHandlesProps {
   resizerZIndexClass: string;
   showResizers: boolean;
   isMobile: boolean;
-  isXpTheme: boolean;
+  isWindowsTheme: boolean;
   isMacOSTheme: boolean;
   resizeType: ResizeType | null;
   handleResizeStartWithForeground: (
@@ -20,7 +20,7 @@ export function WindowFrameResizeHandles({
   resizerZIndexClass,
   showResizers,
   isMobile,
-  isXpTheme,
+  isWindowsTheme,
   isMacOSTheme,
   resizeType,
   handleResizeStartWithForeground,
@@ -42,7 +42,7 @@ export function WindowFrameResizeHandles({
           resizeType?.includes("n")
             ? "top-[-100px] h-[200px]"
             : isMobile
-            ? isXpTheme
+            ? isWindowsTheme
               ? "top-0 h-4" // Start from top but be shorter for XP/98 themes
               : isMacOSTheme
               ? "top-1 h-2" // Extend above window for macOS to avoid traffic lights

--- a/src/components/layout/window-frame/WindowFrameTitleBar.tsx
+++ b/src/components/layout/window-frame/WindowFrameTitleBar.tsx
@@ -9,7 +9,7 @@ import { isFromTitlebarControls } from "./windowFrameUtils";
 import { WindowFrameTrailingTitlebarControls } from "./WindowFrameTrailingTitlebarControls";
 
 export interface WindowFrameTitleBarProps {
-  isXpTheme: boolean;
+  isWindowsTheme: boolean;
   isWinXp: boolean;
   isMacOSTheme: boolean;
   isForeground: boolean;
@@ -42,7 +42,7 @@ export interface WindowFrameTitleBarProps {
 }
 
 export function WindowFrameTitleBar({
-  isXpTheme,
+  isWindowsTheme,
   isWinXp,
   isMacOSTheme,
   isForeground,
@@ -75,7 +75,7 @@ export function WindowFrameTitleBar({
   const coverFlowLabel = t("apps.ipod.menu.coverFlow");
 
   return (
-    isXpTheme ? (
+    isWindowsTheme ? (
         // XP/98 theme title bar structure
         <div
           className={cn(

--- a/src/components/layout/window-frame/hooks/useWindowFrameDragResize.ts
+++ b/src/components/layout/window-frame/hooks/useWindowFrameDragResize.ts
@@ -8,7 +8,7 @@ type DragResizeParams = {
   instanceId?: string;
   isForeground: boolean;
   isMacOSTheme: boolean;
-  isXpTheme: boolean;
+  isWindowsTheme: boolean;
   bringInstanceToForeground: (instanceId: string) => void;
 };
 
@@ -17,7 +17,7 @@ export function useWindowFrameDragResize({
   instanceId,
   isForeground,
   isMacOSTheme,
-  isXpTheme,
+  isWindowsTheme,
   bringInstanceToForeground,
 }: DragResizeParams) {
   const {
@@ -41,7 +41,7 @@ export function useWindowFrameDragResize({
 
   const resizerZIndexClass = isMacOSTheme
     ? "z-[60]"
-    : isXpTheme
+    : isWindowsTheme
       ? "z-40"
       : "z-50";
 

--- a/src/components/listen/JoinSessionDialog.tsx
+++ b/src/components/listen/JoinSessionDialog.tsx
@@ -100,7 +100,7 @@ export function JoinSessionDialog({
   const [state, dispatch] = useReducer(reducer, initialState);
   const { value, sessions, selectedIndex, isLoading, error } = state;
 
-  const { isWindowsTheme: isXpTheme, isMacOSTheme: isMacTheme } =
+  const { isWindowsTheme, isMacOSTheme: isMacTheme } =
     useThemeFlags();
   const fetchSessions = useListenSessionStore((state) => state.fetchSessions);
 
@@ -160,7 +160,7 @@ export function JoinSessionDialog({
   );
 
   const dialogContent = (
-    <div className={isXpTheme ? "p-2 px-4" : "p-4 px-6"}>
+    <div className={isWindowsTheme ? "p-2 px-4" : "p-4 px-6"}>
       {/* Session List - Primary view */}
       <div className="mb-3">
         <ScrollArea className="h-[160px] border border-neutral-300 rounded-md overflow-hidden bg-white">
@@ -169,15 +169,15 @@ export function JoinSessionDialog({
               <div
                 className={cn(
                   "flex items-center justify-center h-[140px] text-neutral-500",
-                  isXpTheme
+                  isWindowsTheme
                     ? "font-['Pixelated_MS_Sans_Serif',Arial] text-[11px]"
                     : "font-geneva-12 text-[12px]"
                 )}
                 style={{
-                  fontFamily: isXpTheme
+                  fontFamily: isWindowsTheme
                     ? '"Pixelated MS Sans Serif", "ArkPixel", Arial'
                     : undefined,
-                  fontSize: isXpTheme ? "11px" : undefined,
+                  fontSize: isWindowsTheme ? "11px" : undefined,
                 }}
               >
                 {t("apps.karaoke.liveListen.loadingSessions")}
@@ -186,15 +186,15 @@ export function JoinSessionDialog({
               <div
                 className={cn(
                   "flex items-center justify-center h-[140px] text-red-600",
-                  isXpTheme
+                  isWindowsTheme
                     ? "font-['Pixelated_MS_Sans_Serif',Arial] text-[11px]"
                     : "font-geneva-12 text-[12px]"
                 )}
                 style={{
-                  fontFamily: isXpTheme
+                  fontFamily: isWindowsTheme
                     ? '"Pixelated MS Sans Serif", "ArkPixel", Arial'
                     : undefined,
-                  fontSize: isXpTheme ? "11px" : undefined,
+                  fontSize: isWindowsTheme ? "11px" : undefined,
                 }}
               >
                 {error}
@@ -203,15 +203,15 @@ export function JoinSessionDialog({
               <div
                 className={cn(
                   "flex items-center justify-center h-[140px] text-neutral-500",
-                  isXpTheme
+                  isWindowsTheme
                     ? "font-['Pixelated_MS_Sans_Serif',Arial] text-[11px]"
                     : "font-geneva-12 text-[12px]"
                 )}
                 style={{
-                  fontFamily: isXpTheme
+                  fontFamily: isWindowsTheme
                     ? '"Pixelated MS Sans Serif", "ArkPixel", Arial'
                     : undefined,
-                  fontSize: isXpTheme ? "11px" : undefined,
+                  fontSize: isWindowsTheme ? "11px" : undefined,
                 }}
               >
                 {t("apps.karaoke.liveListen.noActiveSessions")}
@@ -237,16 +237,16 @@ export function JoinSessionDialog({
                       : index % 2 === 1
                         ? "bg-neutral-100"
                         : "bg-white",
-                    isXpTheme
+                    isWindowsTheme
                       ? "font-['Pixelated_MS_Sans_Serif',Arial] text-[11px]"
                       : "font-geneva-12 text-[12px]"
                   )}
                   data-selected={selectedIndex === index ? "true" : undefined}
                   style={{
-                    fontFamily: isXpTheme
+                    fontFamily: isWindowsTheme
                       ? '"Pixelated MS Sans Serif", "ArkPixel", Arial'
                       : undefined,
-                    fontSize: isXpTheme ? "11px" : undefined,
+                    fontSize: isWindowsTheme ? "11px" : undefined,
                   }}
                 >
                   <div className="font-semibold">
@@ -289,15 +289,15 @@ export function JoinSessionDialog({
       <p
         className={cn(
           "text-neutral-500 mb-2",
-          isXpTheme
+          isWindowsTheme
             ? "font-['Pixelated_MS_Sans_Serif',Arial] text-[11px]"
             : "font-geneva-12 text-[12px]"
         )}
         style={{
-          fontFamily: isXpTheme
+          fontFamily: isWindowsTheme
             ? '"Pixelated MS Sans Serif", "ArkPixel", Arial'
             : undefined,
-          fontSize: isXpTheme ? "11px" : undefined,
+          fontSize: isWindowsTheme ? "11px" : undefined,
         }}
       >
         {t("apps.karaoke.liveListen.orEnterSessionId")}
@@ -317,15 +317,15 @@ export function JoinSessionDialog({
           placeholder={t("apps.karaoke.liveListen.sessionLinkPlaceholder")}
           className={cn(
             "shadow-none flex-1",
-            isXpTheme
+            isWindowsTheme
               ? "font-['Pixelated_MS_Sans_Serif',Arial] text-[11px]"
               : "font-geneva-12 text-[12px]"
           )}
           style={{
-            fontFamily: isXpTheme
+            fontFamily: isWindowsTheme
               ? '"Pixelated MS Sans Serif", "ArkPixel", Arial'
               : undefined,
-            fontSize: isXpTheme ? "11px" : undefined,
+            fontSize: isWindowsTheme ? "11px" : undefined,
           }}
         />
         <Button
@@ -335,15 +335,15 @@ export function JoinSessionDialog({
           className={cn(
             "flex-shrink-0",
             !isMacTheme && "h-7",
-            isXpTheme
+            isWindowsTheme
               ? "font-['Pixelated_MS_Sans_Serif',Arial] text-[11px]"
               : "font-geneva-12 text-[12px]"
           )}
           style={{
-            fontFamily: isXpTheme
+            fontFamily: isWindowsTheme
               ? '"Pixelated MS Sans Serif", "ArkPixel", Arial'
               : undefined,
-            fontSize: isXpTheme ? "11px" : undefined,
+            fontSize: isWindowsTheme ? "11px" : undefined,
           }}
         >
           {t("apps.karaoke.liveListen.joinButton")}
@@ -360,15 +360,15 @@ export function JoinSessionDialog({
               className={cn(
                 "w-full sm:w-auto",
                 !isMacTheme && "h-7",
-                isXpTheme
+                isWindowsTheme
                   ? "font-['Pixelated_MS_Sans_Serif',Arial] text-[11px]"
                   : "font-geneva-12 text-[12px]"
               )}
               style={{
-                fontFamily: isXpTheme
+                fontFamily: isWindowsTheme
                   ? '"Pixelated MS Sans Serif", "ArkPixel", Arial'
                   : undefined,
-                fontSize: isXpTheme ? "11px" : undefined,
+                fontSize: isWindowsTheme ? "11px" : undefined,
               }}
             >
               {t("apps.karaoke.liveListen.cancel")}
@@ -380,15 +380,15 @@ export function JoinSessionDialog({
               className={cn(
                 "w-full sm:w-auto",
                 !isMacTheme && "h-7",
-                isXpTheme
+                isWindowsTheme
                   ? "font-['Pixelated_MS_Sans_Serif',Arial] text-[11px]"
                   : "font-geneva-12 text-[12px]"
               )}
               style={{
-                fontFamily: isXpTheme
+                fontFamily: isWindowsTheme
                   ? '"Pixelated MS Sans Serif", "ArkPixel", Arial'
                   : undefined,
-                fontSize: isXpTheme ? "11px" : undefined,
+                fontSize: isWindowsTheme ? "11px" : undefined,
               }}
             >
               {t("apps.karaoke.liveListen.joinButton")}
@@ -402,11 +402,11 @@ export function JoinSessionDialog({
   return (
     <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
       <DialogContent
-        className={cn("max-w-[420px]", isXpTheme && "p-0 overflow-hidden")}
-        style={isXpTheme ? { fontSize: "11px" } : undefined}
+        className={cn("max-w-[420px]", isWindowsTheme && "p-0 overflow-hidden")}
+        style={isWindowsTheme ? { fontSize: "11px" } : undefined}
         onKeyDown={handleDialogKeyDown}
       >
-        {isXpTheme ? (
+        {isWindowsTheme ? (
           <>
             <DialogHeader>
               {t("apps.karaoke.liveListen.joinSession")}

--- a/src/components/listen/ListenSessionBadge.tsx
+++ b/src/components/listen/ListenSessionBadge.tsx
@@ -23,16 +23,16 @@ export function ListenSessionBadge({
   className,
 }: ListenSessionBadgeProps) {
   const { t } = useTranslation();
-  const { isWindowsTheme: isXpTheme } = useThemeFlags();
+  const { isWindowsTheme } = useThemeFlags();
 
   const buttonClassName = cn(
     "h-6 px-2 text-[11px]",
-    isXpTheme
+    isWindowsTheme
       ? "font-['Pixelated_MS_Sans_Serif',Arial]"
       : "font-geneva-12"
   );
 
-  const buttonStyle = isXpTheme
+  const buttonStyle = isWindowsTheme
     ? { fontFamily: '"Pixelated MS Sans Serif", "ArkPixel", Arial' }
     : undefined;
 

--- a/src/components/listen/ListenSessionInvite.tsx
+++ b/src/components/listen/ListenSessionInvite.tsx
@@ -32,7 +32,7 @@ export function ListenSessionInvite({
   const { t } = useTranslation();
   const [shareUrl, setShareUrl] = useState("");
   const inputRef = useRef<HTMLInputElement>(null);
-  const { isWindowsTheme: isXpTheme, isMacOSTheme: isMacOsxTheme, isWinXp } =
+  const { isWindowsTheme, isMacOSTheme, isWinXp } =
     useThemeFlags();
 
   const baseUrl = useMemo(() => {
@@ -80,7 +80,7 @@ export function ListenSessionInvite({
   };
 
   const dialogContent = (
-    <div className={isXpTheme ? "p-2 px-4" : "p-3"}>
+    <div className={isWindowsTheme ? "p-2 px-4" : "p-3"}>
       <div className="flex flex-col items-center space-y-3 w-full">
         <div className="bg-white p-1.5 size-32 flex items-center justify-center">
           <QRCodeSVG
@@ -94,15 +94,15 @@ export function ListenSessionInvite({
         <p
           className={cn(
             "text-neutral-500 text-center",
-            isXpTheme
+            isWindowsTheme
               ? "font-['Pixelated_MS_Sans_Serif',Arial] text-[10px]"
               : "font-geneva-12 text-xs"
           )}
           style={{
-            fontFamily: isXpTheme
+            fontFamily: isWindowsTheme
               ? '"Pixelated MS Sans Serif", "ArkPixel", Arial'
               : undefined,
-            fontSize: isXpTheme ? "10px" : undefined,
+            fontSize: isWindowsTheme ? "10px" : undefined,
           }}
         >
           {t("apps.karaoke.liveListen.shareLinkInvite")}
@@ -114,15 +114,15 @@ export function ListenSessionInvite({
           readOnly
           className={cn(
             "shadow-none h-8 w-full",
-            isXpTheme
+            isWindowsTheme
               ? "font-['Pixelated_MS_Sans_Serif',Arial] text-[11px]"
               : "text-sm"
           )}
           style={{
-            fontFamily: isXpTheme
+            fontFamily: isWindowsTheme
               ? '"Pixelated MS Sans Serif", "ArkPixel", Arial'
               : undefined,
-            fontSize: isXpTheme ? "11px" : undefined,
+            fontSize: isWindowsTheme ? "11px" : undefined,
           }}
         />
       </div>
@@ -133,15 +133,15 @@ export function ListenSessionInvite({
           onClick={handleCopy}
           className={cn(
             "h-7 w-full",
-            isXpTheme
+            isWindowsTheme
               ? "font-['Pixelated_MS_Sans_Serif',Arial] text-[11px]"
               : "font-geneva-12 text-[12px]"
           )}
           style={{
-            fontFamily: isXpTheme
+            fontFamily: isWindowsTheme
               ? '"Pixelated MS Sans Serif", "ArkPixel", Arial'
               : undefined,
-            fontSize: isXpTheme ? "11px" : undefined,
+            fontSize: isWindowsTheme ? "11px" : undefined,
           }}
         >
           {t("apps.karaoke.liveListen.copyLink")}
@@ -150,7 +150,7 @@ export function ListenSessionInvite({
     </div>
   );
 
-  if (isXpTheme) {
+  if (isWindowsTheme) {
     return (
       <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
         <DialogContent
@@ -179,7 +179,7 @@ export function ListenSessionInvite({
         className="bg-os-window-bg border-[length:var(--os-metrics-border-width)] border-os-window rounded-os shadow-os-window max-w-xs"
         onKeyDown={(e: React.KeyboardEvent) => e.stopPropagation()}
       >
-        {isMacOsxTheme ? (
+        {isMacOSTheme ? (
           <>
             <DialogHeader>{t("apps.karaoke.liveListen.inviteToListen")}</DialogHeader>
             <DialogDescription className="sr-only">

--- a/src/components/shared/AppDrawer.tsx
+++ b/src/components/shared/AppDrawer.tsx
@@ -100,7 +100,7 @@ export function AppDrawer({
   const {
     isMacOSTheme,
     isSystem7Theme: isSystem7,
-    isWindowsTheme: isXpTheme,
+    isWindowsTheme,
     isWin98,
   } = useThemeFlags();
   const useGeneva = isMacOSTheme || isSystem7;
@@ -203,7 +203,7 @@ export function AppDrawer({
   // Side (desktop): rounded on the outward edge.
   // Compact (mobile): rounded on the edge that sticks out of the window.
   const panelOuterClass = osDrawerSurfaceClassName(
-    { isMacOSTheme, isSystem7Theme: isSystem7, isXpTheme, isWin98 },
+    { isMacOSTheme, isSystem7Theme: isSystem7, isWindowsTheme, isWin98 },
     placement
   );
 
@@ -223,7 +223,7 @@ export function AppDrawer({
     isMacOSTheme && "px-2 py-0.5 min-h-[20px]",
     !isMacOSTheme && "px-2 pt-1.5 pb-1",
     isSystem7 && "border-b border-black",
-    isXpTheme && !isWin98 && cn("border-b", osSeparatorBorderClassName()),
+    isWindowsTheme && !isWin98 && cn("border-b", osSeparatorBorderClassName()),
     isWin98 && cn("border-b", osSeparatorBorderClassName())
   );
 
@@ -231,7 +231,7 @@ export function AppDrawer({
     // Regular weight — not bold (matches OS label conventions)
     "text-[11px] font-normal truncate flex-1",
     useGeneva && "font-geneva-12",
-    isXpTheme && "font-tahoma",
+    isWindowsTheme && "font-tahoma",
     isMacOSTheme
       ? "text-[#222]"
       : "opacity-60 text-[9px] uppercase tracking-wide"
@@ -241,7 +241,7 @@ export function AppDrawer({
     "shrink-0 ml-1 flex items-center justify-center rounded p-0.5",
     "focus:outline-none focus-visible:ring-1",
     isMacOSTheme && "text-black/50 hover:bg-black/10 hover:text-black/80 focus-visible:ring-black/30",
-    (isSystem7 || isXpTheme || isWin98) && "text-black/50 hover:bg-black/10 hover:text-black/80"
+    (isSystem7 || isWindowsTheme || isWin98) && "text-black/50 hover:bg-black/10 hover:text-black/80"
   );
 
   // ── Inner content wrapper (handles macOS layering) ────────────────────────

--- a/src/components/shared/AppWindowShell.tsx
+++ b/src/components/shared/AppWindowShell.tsx
@@ -8,7 +8,7 @@ type WindowFramePassthrough = Omit<
 
 type AppWindowShellBaseProps = {
   isWindowOpen: boolean | undefined;
-  isXpTheme: boolean;
+  isWindowsTheme: boolean;
   isForeground: boolean | undefined;
   menuBar: ReactNode;
   children: ReactNode;
@@ -42,7 +42,7 @@ export type AppWindowShellProps = AppWindowShellBaseProps &
  */
 export function AppWindowShell({
   isWindowOpen,
-  isXpTheme,
+  isWindowsTheme,
   isForeground,
   menuBar,
   windowFrameProps,
@@ -55,7 +55,7 @@ export function AppWindowShell({
   if (!isWindowOpen && !alwaysRenderWhenClosed) return null;
 
   const showMacMenuBar =
-    !isXpTheme &&
+    !isWindowsTheme &&
     isForeground &&
     (alwaysRenderWhenClosed ? !!isWindowOpen : true);
 
@@ -76,7 +76,7 @@ export function AppWindowShell({
       {showMacMenuBar && menuBar}
       <WindowFrame
         {...windowFrameProps!}
-        menuBar={isXpTheme ? menuBar : undefined}
+        menuBar={isWindowsTheme ? menuBar : undefined}
       >
         {children}
       </WindowFrame>

--- a/src/components/shared/CursorCloudAgentRunsListCard.tsx
+++ b/src/components/shared/CursorCloudAgentRunsListCard.tsx
@@ -68,14 +68,14 @@ export function CursorCloudAgentRunsListCard({
   runs,
 }: CursorCloudAgentRunsListCardProps) {
   const { t } = useTranslation();
-  const { isMacOSTheme, isXpTheme, isSystem7Theme, isWin98 } = useThemeFlags();
+  const { isMacOSTheme, isWindowsTheme, isSystem7Theme, isWin98 } = useThemeFlags();
 
   if (!runs.length) return null;
 
   const shell = toolInlineCardShellClassName({
     isMacOSTheme,
     isSystem7Theme,
-    isXpTheme,
+    isWindowsTheme,
     isWin98,
   });
 

--- a/src/components/shared/CursorRepoAgentChatCard.tsx
+++ b/src/components/shared/CursorRepoAgentChatCard.tsx
@@ -50,7 +50,7 @@ export function CursorRepoAgentChatCard({
 }: CursorRepoAgentChatCardProps) {
   const isPanel = variant === "panel";
   const { t } = useTranslation();
-  const { isMacOSTheme, isXpTheme, isSystem7Theme, isWin98, isDarkMode } =
+  const { isMacOSTheme, isWindowsTheme, isSystem7Theme, isWin98, isDarkMode } =
     useThemeFlags();
   const {
     events,
@@ -126,7 +126,7 @@ export function CursorRepoAgentChatCard({
           toolInlineCardShellClassName({
             isMacOSTheme,
             isSystem7Theme,
-            isXpTheme,
+            isWindowsTheme,
             isWin98,
             embed: isPanel ? "panel" : "chat",
           }),
@@ -137,7 +137,7 @@ export function CursorRepoAgentChatCard({
           className={cursorAgentCardHeaderClassName({
             isMacOSTheme,
             isSystem7Theme,
-            isXpTheme,
+            isWindowsTheme,
             isDarkMode,
           })}
         >
@@ -146,7 +146,7 @@ export function CursorRepoAgentChatCard({
             <div
               className={cn(
                 "min-w-0 flex-1 truncate text-sm font-medium",
-                isXpTheme && !isMacOSTheme
+                isWindowsTheme && !isMacOSTheme
                   ? "text-white"
                   : "text-os-text-primary"
               )}
@@ -164,10 +164,10 @@ export function CursorRepoAgentChatCard({
                   isMacOSTheme &&
                     "border-black/20 bg-white/70 hover:bg-white/90 dark:border-white/15 dark:bg-white/10 dark:hover:bg-white/16",
                   !isMacOSTheme &&
-                    isXpTheme &&
+                    isWindowsTheme &&
                     "border-white/40 bg-white/20 text-white hover:bg-white/30",
                   !isMacOSTheme &&
-                    !isXpTheme &&
+                    !isWindowsTheme &&
                     "border-neutral-300 bg-white/85 text-neutral-700 hover:bg-neutral-100 dark:border-neutral-600 dark:bg-neutral-900/70 dark:text-neutral-200 dark:hover:bg-neutral-800"
                 )}
                 title={prUrl}
@@ -183,7 +183,7 @@ export function CursorRepoAgentChatCard({
               <span
                 className={cn(
                   "inline-flex shrink-0 items-center gap-1 text-[10px] font-medium",
-                  isXpTheme && !isMacOSTheme
+                  isWindowsTheme && !isMacOSTheme
                     ? "text-amber-100"
                     : "text-amber-900 dark:text-amber-200"
                 )}
@@ -195,7 +195,7 @@ export function CursorRepoAgentChatCard({
               <span
                 className={cn(
                   "inline-flex shrink-0 items-center gap-1 text-[10px] font-medium",
-                  isXpTheme && !isMacOSTheme
+                  isWindowsTheme && !isMacOSTheme
                     ? "text-emerald-100"
                     : "text-emerald-900 dark:text-emerald-200"
                 )}

--- a/src/components/shared/MapsSearchPlacesCard.tsx
+++ b/src/components/shared/MapsSearchPlacesCard.tsx
@@ -55,7 +55,7 @@ export function MapsSearchPlacesCard({
   results,
 }: MapsSearchPlacesCardProps) {
   const { t } = useTranslation();
-  const { isMacOSTheme, isXpTheme, isSystem7Theme, isWin98 } = useThemeFlags();
+  const { isMacOSTheme, isWindowsTheme, isSystem7Theme, isWin98 } = useThemeFlags();
   const launchApp = useLaunchApp();
 
   const handleOpenInMaps = useCallback(
@@ -81,7 +81,7 @@ export function MapsSearchPlacesCard({
     toolInlineCardShellClassName({
       isMacOSTheme,
       isSystem7Theme,
-      isXpTheme,
+      isWindowsTheme,
       isWin98,
     }),
     "px-2.5 py-2 text-[12px]",
@@ -106,7 +106,7 @@ export function MapsSearchPlacesCard({
       className={toolInlineCardShellClassName({
         isMacOSTheme,
         isSystem7Theme,
-        isXpTheme,
+        isWindowsTheme,
         isWin98,
       })}
     >

--- a/src/components/shared/ThemedTabs.tsx
+++ b/src/components/shared/ThemedTabs.tsx
@@ -14,10 +14,10 @@ interface ThemedTabsListProps {
 }
 
 export function ThemedTabsList({ children, className }: ThemedTabsListProps) {
-  const { currentTheme, isXpTheme } = useThemeFlags();
+  const { currentTheme, isWindowsTheme } = useThemeFlags();
   const tabStyles = getTabStyles(currentTheme);
 
-  if (isXpTheme) {
+  if (isWindowsTheme) {
     return (
       <TabsList asChild>
         <menu
@@ -55,10 +55,10 @@ export function ThemedTabsTrigger({
   children,
   className,
 }: ThemedTabsTriggerProps) {
-  const { currentTheme, isXpTheme } = useThemeFlags();
+  const { currentTheme, isWindowsTheme } = useThemeFlags();
   const tabStyles = getTabStyles(currentTheme);
 
-  if (isXpTheme) {
+  if (isWindowsTheme) {
     return (
       <TabsTrigger
         value={value}

--- a/src/components/shared/menubar/AppMenuBarHelpMenu.tsx
+++ b/src/components/shared/menubar/AppMenuBarHelpMenu.tsx
@@ -16,7 +16,7 @@ interface AppMenuBarHelpMenuProps {
   helpItemLabel: string;
   aboutItemLabel: string;
   shareItemLabel?: string;
-  isMacOsxTheme: boolean;
+  isMacOSTheme: boolean;
   onShowHelp?: () => void;
   onShowAbout?: () => void;
   onOpenShareDialog: () => void;
@@ -26,7 +26,7 @@ export function AppMenuBarHelpMenu({
   helpItemLabel,
   aboutItemLabel,
   shareItemLabel,
-  isMacOsxTheme,
+  isMacOSTheme,
   onShowHelp,
   onShowAbout,
   onOpenShareDialog,
@@ -46,7 +46,7 @@ export function AppMenuBarHelpMenu({
         >
           {helpItemLabel}
         </MenubarItem>
-        {!isMacOsxTheme && (
+        {!isMacOSTheme && (
           <>
             <MenubarItem
               onSelect={onOpenShareDialog}

--- a/src/components/shared/menubar/AppMenuBarShell.tsx
+++ b/src/components/shared/menubar/AppMenuBarShell.tsx
@@ -7,8 +7,8 @@ import type { AppId } from "@/config/appRegistry";
 interface AppMenuBarShellProps {
   /** App-specific menus (File, Controls, View, Library, ...). */
   children: ReactNode;
-  isXpTheme: boolean;
-  isMacOsxTheme: boolean;
+  isWindowsTheme: boolean;
+  isMacOSTheme: boolean;
   appId: AppId;
   appName: string;
   isShareDialogOpen: boolean;
@@ -28,8 +28,8 @@ interface AppMenuBarShellProps {
  */
 export function AppMenuBarShell({
   children,
-  isXpTheme,
-  isMacOsxTheme,
+  isWindowsTheme,
+  isMacOSTheme,
   appId,
   appName,
   isShareDialogOpen,
@@ -41,13 +41,13 @@ export function AppMenuBarShell({
   onShowAbout,
 }: AppMenuBarShellProps) {
   return (
-    <MenuBar inWindowFrame={isXpTheme}>
+    <MenuBar inWindowFrame={isWindowsTheme}>
       {children}
       <AppMenuBarHelpMenu
         helpItemLabel={helpItemLabel}
         aboutItemLabel={aboutItemLabel}
         shareItemLabel={shareItemLabel}
-        isMacOsxTheme={isMacOsxTheme}
+        isMacOSTheme={isMacOSTheme}
         onShowHelp={onShowHelp}
         onShowAbout={onShowAbout}
         onOpenShareDialog={() => setIsShareDialogOpen(true)}

--- a/src/components/shared/osThemePrimitives.ts
+++ b/src/components/shared/osThemePrimitives.ts
@@ -3,8 +3,7 @@ import { cn } from "@/lib/utils";
 type ThemeSurfaceFlags = {
   isMacOSTheme: boolean;
   isSystem7Theme: boolean;
-  isXpTheme: boolean;
-  isWindowsTheme?: boolean;
+  isWindowsTheme: boolean;
   isWin98?: boolean;
   isAquaGlass?: boolean;
 };
@@ -19,7 +18,7 @@ export function osCardClassName(
     className?: string;
   } = {}
 ): string {
-  const { isMacOSTheme, isSystem7Theme, isXpTheme, isWin98 = false } = flags;
+  const { isMacOSTheme, isSystem7Theme, isWindowsTheme, isWin98 = false } = flags;
   const { embed = "chat", className } = options;
 
   return cn(
@@ -35,7 +34,7 @@ export function osCardClassName(
       ),
     !isMacOSTheme &&
       !isSystem7Theme &&
-      isXpTheme &&
+      isWindowsTheme &&
       !isWin98 &&
       cn(
         embed === "chat" && "rounded-[0.4rem]",
@@ -51,7 +50,7 @@ export function osCardClassName(
       ),
     !isMacOSTheme &&
       !isSystem7Theme &&
-      !isXpTheme &&
+      !isWindowsTheme &&
       !isWin98 &&
       cn(
         embed === "chat" && "rounded",
@@ -65,7 +64,7 @@ export function osDrawerSurfaceClassName(
   flags: ThemeSurfaceFlags,
   placement: DrawerPlacement
 ): string {
-  const { isMacOSTheme, isSystem7Theme, isXpTheme, isWin98 = false } = flags;
+  const { isMacOSTheme, isSystem7Theme, isWindowsTheme, isWin98 = false } = flags;
 
   return cn(
     "flex flex-1 flex-col overflow-hidden min-h-0",
@@ -87,7 +86,7 @@ export function osDrawerSurfaceClassName(
             ? "bg-white border-2 border-black border-t-0 rounded-b shadow-[2px_4px_0_0_rgba(0,0,0,0.45)]"
             : "bg-white border-2 border-black border-b-0 rounded-t shadow-[2px_-4px_0_0_rgba(0,0,0,0.45)]"),
     !isMacOSTheme &&
-      isXpTheme &&
+      isWindowsTheme &&
       !isWin98 &&
       (placement === "right"
         ? "bg-os-window-bg border-[3px] border-l-0 border-os-window rounded-r-[0.5rem]"
@@ -111,14 +110,14 @@ export function osDrawerSurfaceClassName(
 export function osToolbarSurfaceClassName(
   flags: Pick<
     ThemeSurfaceFlags,
-    "isMacOSTheme" | "isSystem7Theme" | "isXpTheme"
+    "isMacOSTheme" | "isSystem7Theme" | "isWindowsTheme"
   > & { isWin98?: boolean },
   options: {
     border?: "none" | "top" | "bottom";
     className?: string;
   } = {}
 ): string {
-  const { isMacOSTheme, isSystem7Theme, isXpTheme, isWin98 = false } = flags;
+  const { isMacOSTheme, isSystem7Theme, isWindowsTheme, isWin98 = false } = flags;
   const { border = "none", className } = options;
 
   return cn(
@@ -129,7 +128,7 @@ export function osToolbarSurfaceClassName(
       isSystem7Theme &&
       "bg-[#e0e0e0] border-black/10 text-black",
     !isMacOSTheme &&
-      isXpTheme &&
+      isWindowsTheme &&
       !isWin98 &&
       "bg-os-window-bg border-os-separator text-os-text-primary",
     !isMacOSTheme &&
@@ -142,7 +141,7 @@ export function osToolbarSurfaceClassName(
 export function osAppSidebarSurfaceClassName(
   flags: Pick<
     ThemeSurfaceFlags,
-    "isMacOSTheme" | "isXpTheme" | "isWindowsTheme" | "isAquaGlass"
+    "isMacOSTheme" | "isWindowsTheme" | "isAquaGlass"
   >,
   options: {
     layout?: AppSidebarLayout;
@@ -152,8 +151,7 @@ export function osAppSidebarSurfaceClassName(
 ): string {
   const {
     isMacOSTheme,
-    isXpTheme,
-    isWindowsTheme = isXpTheme,
+    isWindowsTheme,
     isAquaGlass = false,
   } = flags;
   const {

--- a/src/components/shared/toolInlineCardShell.ts
+++ b/src/components/shared/toolInlineCardShell.ts
@@ -5,7 +5,7 @@ import { osCardClassName } from "./osThemePrimitives";
 export function toolInlineCardShellClassName(flags: {
   isMacOSTheme: boolean;
   isSystem7Theme: boolean;
-  isXpTheme: boolean;
+  isWindowsTheme: boolean;
   isWin98?: boolean;
   /** Chat embed; panel fills parent without outer margin/shadow. */
   embed?: "chat" | "panel";
@@ -18,10 +18,10 @@ export function toolInlineCardShellClassName(flags: {
 export function cursorAgentCardHeaderClassName(flags: {
   isMacOSTheme: boolean;
   isSystem7Theme: boolean;
-  isXpTheme: boolean;
+  isWindowsTheme: boolean;
   isDarkMode: boolean;
 }): string {
-  const { isMacOSTheme, isSystem7Theme, isXpTheme, isDarkMode } = flags;
+  const { isMacOSTheme, isSystem7Theme, isWindowsTheme, isDarkMode } = flags;
   return cn(
     "flex flex-shrink-0 items-center gap-3 border-b px-3 py-2",
     isMacOSTheme && "cursor-agent-card-header-aqua",
@@ -34,11 +34,11 @@ export function cursorAgentCardHeaderClassName(flags: {
       "border-black bg-[#DDDDDD]",
     !isMacOSTheme &&
       !isSystem7Theme &&
-      isXpTheme &&
+      isWindowsTheme &&
       "border-[#919b9c] bg-gradient-to-b from-[#3A6EA5] to-[#1E4A8C] text-white",
     !isMacOSTheme &&
       !isSystem7Theme &&
-      !isXpTheme &&
+      !isWindowsTheme &&
       "border-black/20 bg-neutral-100 dark:border-neutral-600 dark:bg-neutral-800/90"
   );
 }

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -62,7 +62,7 @@ const Button = (
 ) => {
   const { play: playButtonClick } = useSound(Sounds.BUTTON_CLICK);
   const Comp = asChild ? Slot : "button";
-  const { isXpTheme, isMacOSTheme } = useThemeFlags();
+  const { isWindowsTheme, isMacOSTheme } = useThemeFlags();
 
   const handleClick = (e: React.MouseEvent<HTMLButtonElement>) => {
     playButtonClick();
@@ -88,10 +88,10 @@ const Button = (
     }
 
     // XP/Win98: default/aqua_select → xp.css button class
-    if (isXpTheme && (variant === "default" || variant === "aqua_select")) return cn("button", className);
+    if (isWindowsTheme && (variant === "default" || variant === "aqua_select")) return cn("button", className);
 
     // XP/Win98 + macOS: ghost → transparent reset to fight global button styles
-    if ((isXpTheme || isMacOSTheme) && variant === "ghost") {
+    if ((isWindowsTheme || isMacOSTheme) && variant === "ghost") {
       return cn(buttonVariants({ variant, size }), "os-btn-ghost-reset", className);
     }
 

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -71,7 +71,7 @@ const DialogContent = (
     ref?: React.Ref<React.ElementRef<typeof DialogPrimitive.Content>>;
   }
 ) => {
-  const { isXpTheme, isMacOSTheme, isSystem7Theme } = useThemeFlags();
+  const { isWindowsTheme, isMacOSTheme, isSystem7Theme } = useThemeFlags();
 
   // Function to clean up pointer-events
   const cleanupPointerEvents = React.useCallback(() => {
@@ -87,7 +87,7 @@ const DialogContent = (
   }, [cleanupPointerEvents]);
 
   const getDialogContentClasses = () => {
-    if (isXpTheme) {
+    if (isWindowsTheme) {
       return cn(
         "fixed left-[50%] top-[50%] z-50 grid w-full min-w-0 max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 p-0 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 origin-center",
         "window", // Use xp.css window class
@@ -153,10 +153,10 @@ const DialogHeader = ({
   ...props
 }: React.HTMLAttributes<HTMLDivElement>) => {
   const { t } = useTranslation();
-  const { isWinXp, isXpTheme, isMacOSTheme } = useThemeFlags();
+  const { isWinXp, isWindowsTheme, isMacOSTheme } = useThemeFlags();
   const closeRef = React.useRef<HTMLButtonElement>(null);
 
-  if (isXpTheme) {
+  if (isWindowsTheme) {
     return (
       <div
         className={cn("title-bar", className)}

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -42,7 +42,7 @@ const SelectTrigger = (
   }
 ) => {
   const { play: playClick } = useSound(Sounds.BUTTON_CLICK, 0.3);
-  const { isMacOSTheme, isWindowsTheme: isXpTheme } = useThemeFlags();
+  const { isMacOSTheme, isWindowsTheme } = useThemeFlags();
 
   return (
     <SelectPrimitive.Trigger
@@ -55,9 +55,9 @@ const SelectTrigger = (
         className
       )}
       style={{
-        fontFamily: isXpTheme ? "var(--os-font-ui)" : undefined,
-        fontSize: isXpTheme ? "var(--os-menu-item-font-size)" : undefined,
-        ...(isXpTheme && { color: "black" }),
+        fontFamily: isWindowsTheme ? "var(--os-font-ui)" : undefined,
+        fontSize: isWindowsTheme ? "var(--os-menu-item-font-size)" : undefined,
+        ...(isWindowsTheme && { color: "black" }),
       }}
       onClick={() => playClick()}
       {...props}

--- a/src/hooks/useAppMenuBarChrome.ts
+++ b/src/hooks/useAppMenuBarChrome.ts
@@ -19,9 +19,6 @@ export function useAppMenuBarChrome(
     setIsShareDialogOpen,
     isWindowsTheme,
     isMacOSTheme,
-    // Legacy aliases retained for existing app menubar props.
-    isXpTheme: isWindowsTheme,
-    isMacOsxTheme: isMacOSTheme,
     appId,
     appName,
   };

--- a/src/hooks/useThemeFlags.ts
+++ b/src/hooks/useThemeFlags.ts
@@ -25,8 +25,7 @@ export function useThemeFlags() {
   const isSystem7Theme = currentTheme === "system7";
   const isWinXp = currentTheme === "xp";
   const isWin98 = currentTheme === "win98";
-  const isXpTheme = isWindowsTheme;
-  const isClassicTheme = isXpTheme || isSystem7Theme;
+  const isClassicTheme = isWindowsTheme || isSystem7Theme;
   /** Menu / menubar styling for Mac OS X Aqua only (not System 7). */
   const isAquaMenuChrome = isMacOSTheme;
   const supportsDarkMode = metadata.supportsDarkMode;
@@ -49,7 +48,6 @@ export function useThemeFlags() {
     isSystem7Theme,
     isWinXp,
     isWin98,
-    isXpTheme,
     isClassicTheme,
     isAquaMenuChrome,
     supportsDarkMode,

--- a/tests/test-os-theme-primitives.test.ts
+++ b/tests/test-os-theme-primitives.test.ts
@@ -14,7 +14,7 @@ describe("os theme primitives", () => {
     const className = osCardClassName({
       isMacOSTheme: false,
       isSystem7Theme: false,
-      isXpTheme: true,
+      isWindowsTheme: true,
     });
 
     expect(className).toContain("rounded-[0.4rem]");
@@ -27,7 +27,7 @@ describe("os theme primitives", () => {
     const className = osCardClassName({
       isMacOSTheme: false,
       isSystem7Theme: false,
-      isXpTheme: true,
+      isWindowsTheme: true,
       isWin98: true,
     });
 
@@ -42,7 +42,7 @@ describe("os theme primitives", () => {
       {
         isMacOSTheme: false,
         isSystem7Theme: false,
-        isXpTheme: true,
+        isWindowsTheme: true,
       },
       { embed: "panel" }
     );
@@ -57,7 +57,7 @@ describe("os theme primitives", () => {
       {
         isMacOSTheme: false,
         isSystem7Theme: false,
-        isXpTheme: true,
+        isWindowsTheme: true,
         isWin98: false,
       },
       "right"
@@ -66,7 +66,7 @@ describe("os theme primitives", () => {
       {
         isMacOSTheme: false,
         isSystem7Theme: false,
-        isXpTheme: true,
+        isWindowsTheme: true,
         isWin98: true,
       },
       "bottom"
@@ -83,7 +83,7 @@ describe("os theme primitives", () => {
       {
         isMacOSTheme: false,
         isSystem7Theme: false,
-        isXpTheme: true,
+        isWindowsTheme: true,
       },
       { border: "top" }
     );
@@ -97,7 +97,7 @@ describe("os theme primitives", () => {
     const glassSidebar = osAppSidebarSurfaceClassName(
       {
         isMacOSTheme: true,
-        isXpTheme: false,
+        isWindowsTheme: false,
         isAquaGlass: true,
       },
       { surfaceClassName: "bg-white/90", className: "custom-sidebar" }
@@ -105,7 +105,7 @@ describe("os theme primitives", () => {
     const responsiveWindowsSidebar = osAppSidebarSurfaceClassName(
       {
         isMacOSTheme: false,
-        isXpTheme: true,
+        isWindowsTheme: true,
       },
       { layout: "responsive" }
     );


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Renames the legacy theme flag aliases identified in the deprecated-code audit so callers use the canonical names from `useThemeFlags()`.

### Naming changes
| Legacy alias | Canonical name | Meaning |
|---|---|---|
| `isXpTheme` | `isWindowsTheme` | Any Windows theme (XP **or** Win98) |
| `isMacOsxTheme` | `isMacOSTheme` | macOS Aqua theme only |

`isWinXp` / `isWin98` are unchanged — they still mean the specific Windows sub-themes.

### What changed (2 commits)
1. **Core hooks + primitives** — removed `isXpTheme` from `useThemeFlags` return; removed legacy re-exports from `useAppMenuBarChrome`; consolidated `ThemeSurfaceFlags` in `osThemePrimitives.ts` to a single `isWindowsTheme` field.
2. **Bulk propagation** — renamed ~200 files across `src/`, `tests/`, `docs/`, `.cursor/skills/`, and `public/docs/` HTML. Fixed a handful of files that had both `isXpTheme` and `isWindowsTheme` (duplicate keys after rename).

### Intentionally unchanged
- Local/prop names like `isMacOSXTheme` (capital **OSX**) in Finder/Admin — these were never the deprecated `isMacOsxTheme` export and denote a distinct local variable/prop convention.
- `StocksWidgetXpView` filename — XP-specific widget view, not a theme flag alias.

### Testing
- `bun run build` (`tsc -b && vite build`) — passes
- `bun test tests/test-os-theme-primitives.test.ts` — 8 pass / 0 fail
- `bun run test:unit` — 370 pass / 0 fail
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ed9b8-b70a-7925-912f-a97050cee65a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ed9b8-b70a-7925-912f-a97050cee65a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

