### PR TITLE
style(admin): semi-transparent amber in Cursor agents view

### DIFF
--- a/src/apps/admin/components/CursorAgentsPanel.tsx
+++ b/src/apps/admin/components/CursorAgentsPanel.tsx
@@ -15,7 +15,14 @@ import { Table, TableBody, TableCell, TableRow } from "@/components/ui/table";
 import { cn } from "@/lib/utils";
 import { useThemeFlags } from "@/hooks/useThemeFlags";
 import { CursorRepoAgentChatCard } from "@/components/shared/CursorRepoAgentChatCard";
-import { adminSurfaceClass, adminTableRowClass, adminToolbarClass } from "../utils/adminStyles";
+import {
+  adminCursorAgentBannerClass,
+  adminCursorAgentRunningRowClass,
+  adminCursorAgentsPanelClass,
+  adminSurfaceClass,
+  adminTableRowClass,
+  adminToolbarClass,
+} from "../utils/adminStyles";
 
 export interface AdminCursorAgentRunRow {
   runId: string;
@@ -256,8 +263,10 @@ export function CursorAgentsPanel({
     />
   );
 
-  const panelShellClass =
-    "font-geneva-12 flex h-full min-h-0 flex-1 flex-col overflow-hidden";
+  const panelShellClass = cn(
+    adminCursorAgentsPanelClass,
+    "font-geneva-12 flex h-full min-h-0 flex-1 flex-col overflow-hidden"
+  );
 
   if (isLoading) {
     return (
@@ -311,7 +320,7 @@ export function CursorAgentsPanel({
     <div className={panelShellClass}>
       {toolbar}
       {(truncated || scanIncomplete) && (
-        <p className="text-[10px] text-amber-700 bg-amber-50 px-3 py-1 border-b border-amber-100 shrink-0 os-mac-aqua-dark:text-amber-200 os-mac-aqua-dark:bg-amber-950/40 os-mac-aqua-dark:border-amber-900/50">
+        <p className={adminCursorAgentBannerClass}>
           {scanIncomplete && !truncated
             ? t(
                 "apps.admin.cursorAgents.scanIncompleteHint",
@@ -364,7 +373,7 @@ export function CursorAgentsPanel({
                 className={cn(
                   adminTableRowClass,
                   "cursor-pointer",
-                  run.status === "running" && "bg-amber-50/60 odd:bg-amber-50/70",
+                  run.status === "running" && adminCursorAgentRunningRowClass,
                 )}
                 data-selected={selectedRunId === run.runId ? "true" : undefined}
               >

--- a/src/apps/admin/utils/adminStyles.ts
+++ b/src/apps/admin/utils/adminStyles.ts
@@ -71,3 +71,14 @@ export const adminAvatarWellClass =
 
 /** Progress / chart track background. */
 export const adminTrackBgClass = "bg-os-panel-bg";
+
+/** Root shell for Admin → Cursor Agents (scopes semi-transparent amber overrides). */
+export const adminCursorAgentsPanelClass = "admin-cursor-agents-panel";
+
+/** Truncation / scan-cap hint banner in the Cursor Agents panel. */
+export const adminCursorAgentBannerClass =
+  "admin-cursor-agent-banner shrink-0 border-b border-amber-400/20 bg-amber-400/12 px-3 py-1 text-[10px] text-amber-800 os-mac-aqua-dark:border-amber-400/15 os-mac-aqua-dark:bg-amber-400/10 os-mac-aqua-dark:text-amber-200";
+
+/** Running agent row — amber wash; glass theme overrides in aqua-glass.css. */
+export const adminCursorAgentRunningRowClass =
+  "admin-cursor-agent-running-row !bg-amber-400/12 odd:!bg-amber-400/18 hover:!bg-amber-400/22 os-mac-aqua-dark:!bg-amber-400/10 os-mac-aqua-dark:odd:!bg-amber-400/14 os-mac-aqua-dark:hover:!bg-amber-400/18";

--- a/src/styles/themes/aqua-glass.css
+++ b/src/styles/themes/aqua-glass.css
@@ -1153,6 +1153,43 @@
   background-color: rgba(255, 255, 255, 0.11) !important;
 }
 
+/* Admin → Cursor Agents: semi-transparent amber for running rows (overrides zebra) */
+:root[data-os-theme="macosx"][data-os-aqua-material="glass"]
+  .admin-cursor-agents-panel
+  .admin-cursor-agent-running-row {
+  background-color: rgba(251, 191, 36, 0.12) !important;
+}
+
+:root[data-os-theme="macosx"][data-os-aqua-material="glass"]
+  .admin-cursor-agents-panel
+  .admin-cursor-agent-running-row:nth-child(odd) {
+  background-color: rgba(251, 191, 36, 0.18) !important;
+}
+
+:root[data-os-theme="macosx"][data-os-aqua-material="glass"]
+  .admin-cursor-agents-panel
+  .admin-cursor-agent-running-row:hover {
+  background-color: rgba(251, 191, 36, 0.22) !important;
+}
+
+:root[data-os-theme="macosx"][data-os-aqua-material="glass"][data-os-color-scheme="dark"]
+  .admin-cursor-agents-panel
+  .admin-cursor-agent-running-row {
+  background-color: rgba(251, 191, 36, 0.1) !important;
+}
+
+:root[data-os-theme="macosx"][data-os-aqua-material="glass"][data-os-color-scheme="dark"]
+  .admin-cursor-agents-panel
+  .admin-cursor-agent-running-row:nth-child(odd) {
+  background-color: rgba(251, 191, 36, 0.14) !important;
+}
+
+:root[data-os-theme="macosx"][data-os-aqua-material="glass"][data-os-color-scheme="dark"]
+  .admin-cursor-agents-panel
+  .admin-cursor-agent-running-row:hover {
+  background-color: rgba(251, 191, 36, 0.18) !important;
+}
+
 :root[data-os-theme="macosx"] .admin-card-header {
   background-color: transparent !important;
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Makes the yellow/amber backgrounds in the Admin **Cursor Agents** view semi-transparent instead of fully opaque, while keeping text readable and the retro ryOS aesthetic.

## Changes

- **`CursorAgentsPanel.tsx`**: Scoped panel shell class; truncation/scan banner and running-agent rows use new admin style tokens.
- **`adminStyles.ts`**: Added `adminCursorAgentsPanelClass`, `adminCursorAgentBannerClass`, and `adminCursorAgentRunningRowClass` with low-alpha amber washes (`bg-amber-400/12`–`/22`, with dark-mode variants).
- **`aqua-glass.css`**: Glass-theme overrides so `admin-zebra-row` `!important` rules do not flatten the running-row highlight.

## Scope

Changes are limited to the Admin Cursor agents panel only — no global yellow/amber styling changes.

## Testing

- `bun run test:unit` — 370 pass, 0 fail
- Lint on touched TS/TSX files — no new issues
- Visual verification not run (no GUI session requested)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7559b03a-54f0-48c6-a936-814e5fca8057"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7559b03a-54f0-48c6-a936-814e5fca8057"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

