### PR TITLE
perf: throttle shader backgrounds on mobile (desktop wallpaper + iPod/Karaoke)

### DIFF
--- a/src/components/shared/AmbientBackground.tsx
+++ b/src/components/shared/AmbientBackground.tsx
@@ -1,7 +1,7 @@
 import { useRef, useEffect, useCallback } from "react";
 import * as THREE from "three";
 import { useReducedGraphics } from "@/hooks/useReducedGraphics";
-import { useMediaQuery } from "@/hooks/useMediaQuery";
+import { useShaderAnimationDisabled } from "@/hooks/useShaderAnimationDisabled";
 
 /** Duration of crossfade between cover textures (seconds) */
 const CROSSFADE_SECONDS = 1.5;
@@ -195,7 +195,7 @@ export function AmbientBackground({
 }: AmbientBackgroundProps) {
   const mountRef = useRef<HTMLDivElement>(null);
   const reducedQuality = useReducedGraphics();
-  const prefersReducedMotion = useMediaQuery("(prefers-reduced-motion: reduce)");
+  const animationDisabled = useShaderAnimationDisabled();
 
   const currentUrlRef = useRef<string | null>(null);
   const showingBRef = useRef(false);
@@ -334,9 +334,9 @@ export function AmbientBackground({
         .catch(() => {});
     }
 
-    // Reduced motion: render a single static frame (crossfade snapped to its
-    // target) instead of animating. Exposed via a ref so cover-art changes and
-    // resizes can repaint without a continuous loop.
+    // Reduced motion / battery-saver: render a single static frame (crossfade
+    // snapped to its target) instead of animating. Exposed via a ref so
+    // cover-art changes and resizes can repaint without a continuous loop.
     const renderStatic = () => {
       const blend = blendRef.current;
       blend.current = blend.target;
@@ -350,13 +350,13 @@ export function AmbientBackground({
       if (w === 0 || h === 0) return;
       renderer.setSize(w, h, false);
       shaderMaterial.uniforms.resolution.value.set(w, h);
-      if (prefersReducedMotion) renderStatic();
+      if (animationDisabled) renderStatic();
     };
     const resizeObserver = new ResizeObserver(handleResize);
     resizeObserver.observe(el);
 
-    // ----- Reduced motion: no rAF loop, just a static frame on demand -----
-    if (prefersReducedMotion) {
+    // ----- Animation off: no rAF loop, just a static frame on demand -----
+    if (animationDisabled) {
       staticRenderRef.current = renderStatic;
       renderStatic();
       return () => {
@@ -440,7 +440,7 @@ export function AmbientBackground({
       materialsRef.current = { material: null, textureA: null, textureB: null };
       renderer.dispose();
     };
-  }, [isActive, variant, loadTexture, reducedQuality, prefersReducedMotion]);
+  }, [isActive, variant, loadTexture, reducedQuality, animationDisabled]);
 
   if (!isActive) return null;
 

--- a/src/components/shared/AmbientBackground.tsx
+++ b/src/components/shared/AmbientBackground.tsx
@@ -1,18 +1,21 @@
 import { useRef, useEffect, useCallback } from "react";
 import * as THREE from "three";
-import { useIsPhone } from "@/hooks/useIsPhone";
+import { useReducedGraphics } from "@/hooks/useReducedGraphics";
 import { useMediaQuery } from "@/hooks/useMediaQuery";
 
 /** Duration of crossfade between cover textures (seconds) */
 const CROSSFADE_SECONDS = 1.5;
 /** Render at a lower internal resolution to reduce shader cost. */
 const RENDER_SCALE = 0.4;
-/** Phones render the (texture-sampling, multi-tap) shader even smaller. */
-const PHONE_RENDER_SCALE = 0.3;
+/**
+ * Reduced tier (phones + low-power desktops) renders the (texture-sampling,
+ * multi-tap) shader even smaller.
+ */
+const LOW_RENDER_SCALE = 0.3;
 /** Cap the shader loop to reduce steady-state GPU usage. */
 const TARGET_FPS = 30;
-/** Lower cap on phones; the warp/liquid motion is slow enough to hide it. */
-const PHONE_TARGET_FPS = 20;
+/** Lower cap in the reduced tier; the warp/liquid motion hides it. */
+const LOW_TARGET_FPS = 20;
 
 export type AmbientVariant = "liquid" | "warp";
 
@@ -191,7 +194,7 @@ export function AmbientBackground({
   className = "",
 }: AmbientBackgroundProps) {
   const mountRef = useRef<HTMLDivElement>(null);
-  const isPhone = useIsPhone();
+  const reducedQuality = useReducedGraphics();
   const prefersReducedMotion = useMediaQuery("(prefers-reduced-motion: reduce)");
 
   const currentUrlRef = useRef<string | null>(null);
@@ -275,8 +278,9 @@ export function AmbientBackground({
       powerPreference: "high-performance",
     });
     renderer.setPixelRatio(1);
-    const scale = isPhone ? PHONE_RENDER_SCALE : RENDER_SCALE;
-    const frameIntervalMs = 1000 / (isPhone ? PHONE_TARGET_FPS : TARGET_FPS);
+    const scale = reducedQuality ? LOW_RENDER_SCALE : RENDER_SCALE;
+    const frameIntervalMs =
+      1000 / (reducedQuality ? LOW_TARGET_FPS : TARGET_FPS);
     renderer.setSize(
       Math.floor(el.clientWidth * scale),
       Math.floor(el.clientHeight * scale),
@@ -436,7 +440,7 @@ export function AmbientBackground({
       materialsRef.current = { material: null, textureA: null, textureB: null };
       renderer.dispose();
     };
-  }, [isActive, variant, loadTexture, isPhone, prefersReducedMotion]);
+  }, [isActive, variant, loadTexture, reducedQuality, prefersReducedMotion]);
 
   if (!isActive) return null;
 

--- a/src/components/shared/AmbientBackground.tsx
+++ b/src/components/shared/AmbientBackground.tsx
@@ -1,13 +1,18 @@
 import { useRef, useEffect, useCallback } from "react";
 import * as THREE from "three";
+import { useIsPhone } from "@/hooks/useIsPhone";
+import { useMediaQuery } from "@/hooks/useMediaQuery";
 
 /** Duration of crossfade between cover textures (seconds) */
 const CROSSFADE_SECONDS = 1.5;
 /** Render at a lower internal resolution to reduce shader cost. */
 const RENDER_SCALE = 0.4;
+/** Phones render the (texture-sampling, multi-tap) shader even smaller. */
+const PHONE_RENDER_SCALE = 0.3;
 /** Cap the shader loop to reduce steady-state GPU usage. */
 const TARGET_FPS = 30;
-const FRAME_INTERVAL_MS = 1000 / TARGET_FPS;
+/** Lower cap on phones; the warp/liquid motion is slow enough to hide it. */
+const PHONE_TARGET_FPS = 20;
 
 export type AmbientVariant = "liquid" | "warp";
 
@@ -186,6 +191,8 @@ export function AmbientBackground({
   className = "",
 }: AmbientBackgroundProps) {
   const mountRef = useRef<HTMLDivElement>(null);
+  const isPhone = useIsPhone();
+  const prefersReducedMotion = useMediaQuery("(prefers-reduced-motion: reduce)");
 
   const currentUrlRef = useRef<string | null>(null);
   const showingBRef = useRef(false);
@@ -195,6 +202,10 @@ export function AmbientBackground({
     textureA: THREE.Texture | null;
     textureB: THREE.Texture | null;
   }>({ material: null, textureA: null, textureB: null });
+  // Set by the animation effect when running in reduced-motion mode: snaps the
+  // crossfade to its target and renders a single static frame on demand (e.g.
+  // when the cover art changes) instead of running a continuous rAF loop.
+  const staticRenderRef = useRef<(() => void) | null>(null);
 
   // ---------- texture helpers ----------
 
@@ -243,6 +254,8 @@ export function AmbientBackground({
           blendRef.current.target = 1;
         }
         showingBRef.current = !showingBRef.current;
+        // Reduced motion runs no rAF loop, so paint the new cover once here.
+        staticRenderRef.current?.();
       })
       .catch(() => {});
   }, [coverUrl, isActive, loadTexture]);
@@ -262,7 +275,8 @@ export function AmbientBackground({
       powerPreference: "high-performance",
     });
     renderer.setPixelRatio(1);
-    const scale = RENDER_SCALE;
+    const scale = isPhone ? PHONE_RENDER_SCALE : RENDER_SCALE;
+    const frameIntervalMs = 1000 / (isPhone ? PHONE_TARGET_FPS : TARGET_FPS);
     renderer.setSize(
       Math.floor(el.clientWidth * scale),
       Math.floor(el.clientHeight * scale),
@@ -310,9 +324,21 @@ export function AmbientBackground({
         .then((tex) => {
           materialsRef.current.textureA = tex;
           shaderMaterial.uniforms.coverTextureA.value = tex;
+          // Reduced motion: no loop runs, so paint the initial cover once.
+          staticRenderRef.current?.();
         })
         .catch(() => {});
     }
+
+    // Reduced motion: render a single static frame (crossfade snapped to its
+    // target) instead of animating. Exposed via a ref so cover-art changes and
+    // resizes can repaint without a continuous loop.
+    const renderStatic = () => {
+      const blend = blendRef.current;
+      blend.current = blend.target;
+      shaderMaterial.uniforms.blendFactor.value = blend.current;
+      renderer.render(scene, camera);
+    };
 
     const handleResize = () => {
       const w = Math.floor(el.clientWidth * scale);
@@ -320,15 +346,41 @@ export function AmbientBackground({
       if (w === 0 || h === 0) return;
       renderer.setSize(w, h, false);
       shaderMaterial.uniforms.resolution.value.set(w, h);
+      if (prefersReducedMotion) renderStatic();
     };
     const resizeObserver = new ResizeObserver(handleResize);
     resizeObserver.observe(el);
 
-    let frameId: number;
+    // ----- Reduced motion: no rAF loop, just a static frame on demand -----
+    if (prefersReducedMotion) {
+      staticRenderRef.current = renderStatic;
+      renderStatic();
+      return () => {
+        staticRenderRef.current = null;
+        resizeObserver.disconnect();
+        if (el && renderer.domElement.parentNode === el) {
+          el.removeChild(renderer.domElement);
+        }
+        scene.remove(quad);
+        geometry.dispose();
+        shaderMaterial.dispose();
+        defaultTex.dispose();
+        materialsRef.current.textureA?.dispose();
+        materialsRef.current.textureB?.dispose();
+        materialsRef.current = {
+          material: null,
+          textureA: null,
+          textureB: null,
+        };
+        renderer.dispose();
+      };
+    }
+
+    let frameId = 0;
     let lastRenderAt = 0;
     const animate = (now: number) => {
       frameId = requestAnimationFrame(animate);
-      if (lastRenderAt !== 0 && now - lastRenderAt < FRAME_INTERVAL_MS) {
+      if (lastRenderAt !== 0 && now - lastRenderAt < frameIntervalMs) {
         return;
       }
 
@@ -347,10 +399,30 @@ export function AmbientBackground({
 
       renderer.render(scene, camera);
     };
-    frameId = requestAnimationFrame(animate);
+
+    // Pause the GPU loop while the tab/PWA is hidden (saves battery on mobile),
+    // and resume on return. Reset the frame clock so the first resumed frame
+    // renders immediately instead of being skipped by the interval gate.
+    const startLoop = () => {
+      if (frameId !== 0) return;
+      lastRenderAt = 0;
+      frameId = requestAnimationFrame(animate);
+    };
+    const stopLoop = () => {
+      if (frameId === 0) return;
+      cancelAnimationFrame(frameId);
+      frameId = 0;
+    };
+    const handleVisibility = () => {
+      if (document.hidden) stopLoop();
+      else startLoop();
+    };
+    document.addEventListener("visibilitychange", handleVisibility);
+    if (!document.hidden) startLoop();
 
     return () => {
-      cancelAnimationFrame(frameId);
+      document.removeEventListener("visibilitychange", handleVisibility);
+      stopLoop();
       resizeObserver.disconnect();
       if (el && renderer.domElement.parentNode === el) {
         el.removeChild(renderer.domElement);
@@ -364,7 +436,7 @@ export function AmbientBackground({
       materialsRef.current = { material: null, textureA: null, textureB: null };
       renderer.dispose();
     };
-  }, [isActive, variant, loadTexture]);
+  }, [isActive, variant, loadTexture, isPhone, prefersReducedMotion]);
 
   if (!isActive) return null;
 

--- a/src/components/shared/MeshGradientBackground.tsx
+++ b/src/components/shared/MeshGradientBackground.tsx
@@ -1,7 +1,7 @@
 import { MeshGradient } from "@paper-design/shaders-react";
 import { useCoverPalette } from "@/hooks/useCoverPalette";
 import { useReducedGraphics } from "@/hooks/useReducedGraphics";
-import { useMediaQuery } from "@/hooks/useMediaQuery";
+import { useShaderAnimationDisabled } from "@/hooks/useShaderAnimationDisabled";
 
 interface MeshGradientBackgroundProps {
   /** URL of the cover art to derive colors from; falls back to default palette when null */
@@ -47,12 +47,12 @@ export function MeshGradientBackground({
 }: MeshGradientBackgroundProps) {
   const colors = useCoverPalette(isActive ? coverUrl ?? null : null);
   const reducedQuality = useReducedGraphics();
-  const prefersReducedMotion = useMediaQuery("(prefers-reduced-motion: reduce)");
+  const animationDisabled = useShaderAnimationDisabled();
 
   if (!isActive) return null;
 
   // speed 0 => ShaderMount halts its rAF loop, leaving a static gradient.
-  const speed = prefersReducedMotion
+  const speed = animationDisabled
     ? 0
     : reducedQuality
       ? LOW_SPEED

--- a/src/components/shared/MeshGradientBackground.tsx
+++ b/src/components/shared/MeshGradientBackground.tsx
@@ -19,6 +19,12 @@ interface MeshGradientBackgroundProps {
  */
 const PHONE_MAX_PIXEL_COUNT = 1280 * 720;
 const PHONE_MIN_PIXEL_RATIO = 1;
+/**
+ * Cap the backing buffer on desktop too: the Paper default is ~8.3M px
+ * (1920×1080 × 2dpi per side), which is wasteful for a soft, blurry gradient
+ * on hi-dpi / 4K displays. QHD is plenty crisp here.
+ */
+const DESKTOP_MAX_PIXEL_COUNT = 2560 * 1440;
 /** Slightly calmer motion on phones; reduces steady-state GPU churn. */
 const PHONE_SPEED = 0.7;
 const DESKTOP_SPEED = 1;
@@ -61,12 +67,8 @@ export function MeshGradientBackground({
         speed={speed}
         scale={1.16}
         rotation={90}
-        {...(isPhone
-          ? {
-              maxPixelCount: PHONE_MAX_PIXEL_COUNT,
-              minPixelRatio: PHONE_MIN_PIXEL_RATIO,
-            }
-          : {})}
+        maxPixelCount={isPhone ? PHONE_MAX_PIXEL_COUNT : DESKTOP_MAX_PIXEL_COUNT}
+        {...(isPhone ? { minPixelRatio: PHONE_MIN_PIXEL_RATIO } : {})}
       />
     </div>
   );

--- a/src/components/shared/MeshGradientBackground.tsx
+++ b/src/components/shared/MeshGradientBackground.tsx
@@ -1,5 +1,7 @@
 import { MeshGradient } from "@paper-design/shaders-react";
 import { useCoverPalette } from "@/hooks/useCoverPalette";
+import { useIsPhone } from "@/hooks/useIsPhone";
+import { useMediaQuery } from "@/hooks/useMediaQuery";
 
 interface MeshGradientBackgroundProps {
   /** URL of the cover art to derive colors from; falls back to default palette when null */
@@ -10,10 +12,27 @@ interface MeshGradientBackgroundProps {
 }
 
 /**
+ * Cap the backing buffer on phones so the mesh-gradient fragment shader isn't
+ * paying for a full hi-dpi 4K-class surface (the library default is
+ * 1920×1080×2dpi ≈ 8.3M px). ~720p with a 1× floor is plenty for a soft,
+ * blurry gradient that mostly sits behind windows.
+ */
+const PHONE_MAX_PIXEL_COUNT = 1280 * 720;
+const PHONE_MIN_PIXEL_RATIO = 1;
+/** Slightly calmer motion on phones; reduces steady-state GPU churn. */
+const PHONE_SPEED = 0.7;
+const DESKTOP_SPEED = 1;
+
+/**
  * Mesh gradient shader background using Paper Design's MeshGradient.
  * StaticMeshGradient does not support animation (its shader has no u_time).
  * MeshGradient animates color blobs and distortion over time.
  * Colors are extracted from cover art when provided.
+ *
+ * Performance: the underlying ShaderMount already pauses its render loop while
+ * the tab is hidden, and stops the loop entirely when `speed` is 0. We exploit
+ * the latter for reduced-motion (static gradient) and cap the buffer
+ * resolution / animation speed on phones.
  */
 export function MeshGradientBackground({
   coverUrl = null,
@@ -21,8 +40,13 @@ export function MeshGradientBackground({
   className = "",
 }: MeshGradientBackgroundProps) {
   const colors = useCoverPalette(isActive ? coverUrl ?? null : null);
+  const isPhone = useIsPhone();
+  const prefersReducedMotion = useMediaQuery("(prefers-reduced-motion: reduce)");
 
   if (!isActive) return null;
+
+  // speed 0 => ShaderMount halts its rAF loop, leaving a static gradient.
+  const speed = prefersReducedMotion ? 0 : isPhone ? PHONE_SPEED : DESKTOP_SPEED;
 
   return (
     <div className={className} style={{ width: "100%", height: "100%" }}>
@@ -34,9 +58,15 @@ export function MeshGradientBackground({
         swirl={0.2}
         grainMixer={0.06}
         grainOverlay={0.1}
-        speed={1}
+        speed={speed}
         scale={1.16}
         rotation={90}
+        {...(isPhone
+          ? {
+              maxPixelCount: PHONE_MAX_PIXEL_COUNT,
+              minPixelRatio: PHONE_MIN_PIXEL_RATIO,
+            }
+          : {})}
       />
     </div>
   );

--- a/src/components/shared/MeshGradientBackground.tsx
+++ b/src/components/shared/MeshGradientBackground.tsx
@@ -1,6 +1,6 @@
 import { MeshGradient } from "@paper-design/shaders-react";
 import { useCoverPalette } from "@/hooks/useCoverPalette";
-import { useIsPhone } from "@/hooks/useIsPhone";
+import { useReducedGraphics } from "@/hooks/useReducedGraphics";
 import { useMediaQuery } from "@/hooks/useMediaQuery";
 
 interface MeshGradientBackgroundProps {
@@ -12,21 +12,21 @@ interface MeshGradientBackgroundProps {
 }
 
 /**
- * Cap the backing buffer on phones so the mesh-gradient fragment shader isn't
- * paying for a full hi-dpi 4K-class surface (the library default is
- * 1920×1080×2dpi ≈ 8.3M px). ~720p with a 1× floor is plenty for a soft,
- * blurry gradient that mostly sits behind windows.
+ * Cap the backing buffer in the reduced tier (phones + low-power desktops) so
+ * the mesh-gradient fragment shader isn't paying for a full hi-dpi 4K-class
+ * surface (the library default is 1920×1080×2dpi ≈ 8.3M px). ~720p with a 1×
+ * floor is plenty for a soft, blurry gradient that mostly sits behind windows.
  */
-const PHONE_MAX_PIXEL_COUNT = 1280 * 720;
-const PHONE_MIN_PIXEL_RATIO = 1;
+const LOW_MAX_PIXEL_COUNT = 1280 * 720;
+const LOW_MIN_PIXEL_RATIO = 1;
 /**
- * Cap the backing buffer on desktop too: the Paper default is ~8.3M px
+ * Cap the backing buffer on capable desktops too: the Paper default is ~8.3M px
  * (1920×1080 × 2dpi per side), which is wasteful for a soft, blurry gradient
  * on hi-dpi / 4K displays. QHD is plenty crisp here.
  */
 const DESKTOP_MAX_PIXEL_COUNT = 2560 * 1440;
-/** Slightly calmer motion on phones; reduces steady-state GPU churn. */
-const PHONE_SPEED = 0.7;
+/** Slightly calmer motion in the reduced tier; reduces steady-state GPU churn. */
+const LOW_SPEED = 0.7;
 const DESKTOP_SPEED = 1;
 
 /**
@@ -46,13 +46,17 @@ export function MeshGradientBackground({
   className = "",
 }: MeshGradientBackgroundProps) {
   const colors = useCoverPalette(isActive ? coverUrl ?? null : null);
-  const isPhone = useIsPhone();
+  const reducedQuality = useReducedGraphics();
   const prefersReducedMotion = useMediaQuery("(prefers-reduced-motion: reduce)");
 
   if (!isActive) return null;
 
   // speed 0 => ShaderMount halts its rAF loop, leaving a static gradient.
-  const speed = prefersReducedMotion ? 0 : isPhone ? PHONE_SPEED : DESKTOP_SPEED;
+  const speed = prefersReducedMotion
+    ? 0
+    : reducedQuality
+      ? LOW_SPEED
+      : DESKTOP_SPEED;
 
   return (
     <div className={className} style={{ width: "100%", height: "100%" }}>
@@ -67,8 +71,10 @@ export function MeshGradientBackground({
         speed={speed}
         scale={1.16}
         rotation={90}
-        maxPixelCount={isPhone ? PHONE_MAX_PIXEL_COUNT : DESKTOP_MAX_PIXEL_COUNT}
-        {...(isPhone ? { minPixelRatio: PHONE_MIN_PIXEL_RATIO } : {})}
+        maxPixelCount={
+          reducedQuality ? LOW_MAX_PIXEL_COUNT : DESKTOP_MAX_PIXEL_COUNT
+        }
+        {...(reducedQuality ? { minPixelRatio: LOW_MIN_PIXEL_RATIO } : {})}
       />
     </div>
   );

--- a/src/components/shared/WaterBackground.tsx
+++ b/src/components/shared/WaterBackground.tsx
@@ -1,6 +1,6 @@
 import { Water } from "@paper-design/shaders-react";
 import { useReducedGraphics } from "@/hooks/useReducedGraphics";
-import { useMediaQuery } from "@/hooks/useMediaQuery";
+import { useShaderAnimationDisabled } from "@/hooks/useShaderAnimationDisabled";
 
 interface WaterBackgroundProps {
   /** URL of the cover art to use as the base image */
@@ -43,12 +43,12 @@ export function WaterBackground({
   className = "",
 }: WaterBackgroundProps) {
   const reducedQuality = useReducedGraphics();
-  const prefersReducedMotion = useMediaQuery("(prefers-reduced-motion: reduce)");
+  const animationDisabled = useShaderAnimationDisabled();
 
   if (!isActive || !coverUrl) return null;
 
   // speed 0 => ShaderMount halts its rAF loop, leaving a static water image.
-  const speed = prefersReducedMotion
+  const speed = animationDisabled
     ? 0
     : reducedQuality
       ? LOW_SPEED

--- a/src/components/shared/WaterBackground.tsx
+++ b/src/components/shared/WaterBackground.tsx
@@ -17,6 +17,12 @@ interface WaterBackgroundProps {
  */
 const PHONE_MAX_PIXEL_COUNT = 1280 * 720;
 const PHONE_MIN_PIXEL_RATIO = 1;
+/**
+ * Cap the backing buffer on desktop too: the Paper default is ~8.3M px
+ * (1920×1080 × 2dpi per side), which is wasteful on hi-dpi / 4K displays. QHD
+ * keeps the caustics crisp at a fraction of the cost.
+ */
+const DESKTOP_MAX_PIXEL_COUNT = 2560 * 1440;
 /** Calmer caustics on phones; reduces steady-state GPU churn. */
 const PHONE_SPEED = 0.35;
 const DESKTOP_SPEED = 0.5;
@@ -60,12 +66,8 @@ export function WaterBackground({
         speed={speed}
         scale={1}
         fit="cover"
-        {...(isPhone
-          ? {
-              maxPixelCount: PHONE_MAX_PIXEL_COUNT,
-              minPixelRatio: PHONE_MIN_PIXEL_RATIO,
-            }
-          : {})}
+        maxPixelCount={isPhone ? PHONE_MAX_PIXEL_COUNT : DESKTOP_MAX_PIXEL_COUNT}
+        {...(isPhone ? { minPixelRatio: PHONE_MIN_PIXEL_RATIO } : {})}
       />
     </div>
   );

--- a/src/components/shared/WaterBackground.tsx
+++ b/src/components/shared/WaterBackground.tsx
@@ -1,5 +1,5 @@
 import { Water } from "@paper-design/shaders-react";
-import { useIsPhone } from "@/hooks/useIsPhone";
+import { useReducedGraphics } from "@/hooks/useReducedGraphics";
 import { useMediaQuery } from "@/hooks/useMediaQuery";
 
 interface WaterBackgroundProps {
@@ -11,20 +11,21 @@ interface WaterBackgroundProps {
 }
 
 /**
- * Cap the backing buffer on phones so the Water fragment shader isn't paying
- * for a full hi-dpi 4K-class surface (the library default is
- * 1920×1080×2dpi ≈ 8.3M px). ~720p with a 1× floor is plenty here.
+ * Cap the backing buffer in the reduced tier (phones + low-power desktops) so
+ * the Water fragment shader isn't paying for a full hi-dpi 4K-class surface
+ * (the library default is 1920×1080×2dpi ≈ 8.3M px). ~720p with a 1× floor is
+ * plenty here.
  */
-const PHONE_MAX_PIXEL_COUNT = 1280 * 720;
-const PHONE_MIN_PIXEL_RATIO = 1;
+const LOW_MAX_PIXEL_COUNT = 1280 * 720;
+const LOW_MIN_PIXEL_RATIO = 1;
 /**
- * Cap the backing buffer on desktop too: the Paper default is ~8.3M px
+ * Cap the backing buffer on capable desktops too: the Paper default is ~8.3M px
  * (1920×1080 × 2dpi per side), which is wasteful on hi-dpi / 4K displays. QHD
  * keeps the caustics crisp at a fraction of the cost.
  */
 const DESKTOP_MAX_PIXEL_COUNT = 2560 * 1440;
-/** Calmer caustics on phones; reduces steady-state GPU churn. */
-const PHONE_SPEED = 0.35;
+/** Calmer caustics in the reduced tier; reduces steady-state GPU churn. */
+const LOW_SPEED = 0.35;
 const DESKTOP_SPEED = 0.5;
 
 /**
@@ -41,13 +42,17 @@ export function WaterBackground({
   isActive = true,
   className = "",
 }: WaterBackgroundProps) {
-  const isPhone = useIsPhone();
+  const reducedQuality = useReducedGraphics();
   const prefersReducedMotion = useMediaQuery("(prefers-reduced-motion: reduce)");
 
   if (!isActive || !coverUrl) return null;
 
   // speed 0 => ShaderMount halts its rAF loop, leaving a static water image.
-  const speed = prefersReducedMotion ? 0 : isPhone ? PHONE_SPEED : DESKTOP_SPEED;
+  const speed = prefersReducedMotion
+    ? 0
+    : reducedQuality
+      ? LOW_SPEED
+      : DESKTOP_SPEED;
 
   return (
     <div className={className} style={{ width: "100%", height: "100%" }}>
@@ -66,8 +71,10 @@ export function WaterBackground({
         speed={speed}
         scale={1}
         fit="cover"
-        maxPixelCount={isPhone ? PHONE_MAX_PIXEL_COUNT : DESKTOP_MAX_PIXEL_COUNT}
-        {...(isPhone ? { minPixelRatio: PHONE_MIN_PIXEL_RATIO } : {})}
+        maxPixelCount={
+          reducedQuality ? LOW_MAX_PIXEL_COUNT : DESKTOP_MAX_PIXEL_COUNT
+        }
+        {...(reducedQuality ? { minPixelRatio: LOW_MIN_PIXEL_RATIO } : {})}
       />
     </div>
   );

--- a/src/components/shared/WaterBackground.tsx
+++ b/src/components/shared/WaterBackground.tsx
@@ -1,4 +1,6 @@
 import { Water } from "@paper-design/shaders-react";
+import { useIsPhone } from "@/hooks/useIsPhone";
+import { useMediaQuery } from "@/hooks/useMediaQuery";
 
 interface WaterBackgroundProps {
   /** URL of the cover art to use as the base image */
@@ -9,15 +11,37 @@ interface WaterBackgroundProps {
 }
 
 /**
+ * Cap the backing buffer on phones so the Water fragment shader isn't paying
+ * for a full hi-dpi 4K-class surface (the library default is
+ * 1920×1080×2dpi ≈ 8.3M px). ~720p with a 1× floor is plenty here.
+ */
+const PHONE_MAX_PIXEL_COUNT = 1280 * 720;
+const PHONE_MIN_PIXEL_RATIO = 1;
+/** Calmer caustics on phones; reduces steady-state GPU churn. */
+const PHONE_SPEED = 0.35;
+const DESKTOP_SPEED = 0.5;
+
+/**
  * Water shader background using Paper Design's Water.
  * Renders cover art with caustic/water effect overlay.
+ *
+ * Performance: the underlying ShaderMount already pauses its render loop while
+ * the tab is hidden, and stops the loop entirely when `speed` is 0. We exploit
+ * the latter for reduced-motion (static water image) and cap the buffer
+ * resolution / animation speed on phones.
  */
 export function WaterBackground({
   coverUrl = null,
   isActive = true,
   className = "",
 }: WaterBackgroundProps) {
+  const isPhone = useIsPhone();
+  const prefersReducedMotion = useMediaQuery("(prefers-reduced-motion: reduce)");
+
   if (!isActive || !coverUrl) return null;
+
+  // speed 0 => ShaderMount halts its rAF loop, leaving a static water image.
+  const speed = prefersReducedMotion ? 0 : isPhone ? PHONE_SPEED : DESKTOP_SPEED;
 
   return (
     <div className={className} style={{ width: "100%", height: "100%" }}>
@@ -33,9 +57,15 @@ export function WaterBackground({
         waves={0}
         caustic={0.2}
         size={0.7}
-        speed={0.5}
+        speed={speed}
         scale={1}
         fit="cover"
+        {...(isPhone
+          ? {
+              maxPixelCount: PHONE_MAX_PIXEL_COUNT,
+              minPixelRatio: PHONE_MIN_PIXEL_RATIO,
+            }
+          : {})}
       />
     </div>
   );

--- a/src/components/shared/WeatherShaderBackground.tsx
+++ b/src/components/shared/WeatherShaderBackground.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef } from "react";
 import * as THREE from "three";
 import type { WeatherFamily } from "@/utils/dynamicWallpaper";
-import { useIsPhone } from "@/hooks/useIsPhone";
+import { useReducedGraphics } from "@/hooks/useReducedGraphics";
 import { useMediaQuery } from "@/hooks/useMediaQuery";
 
 /**
@@ -11,20 +11,21 @@ import { useMediaQuery } from "@/hooks/useMediaQuery";
  */
 const RENDER_SCALE = 1.0;
 /**
- * Phones pay a much steeper per-pixel cost for this fragment shader (5-octave
- * FBM clouds + fog + 3 parallax precipitation layers) and the desktop is mostly
- * occluded by windows anyway, so render the backing buffer at a lower internal
- * resolution there. Mirrors the low-res approach in {@link AmbientBackground}.
+ * Reduced tier (phones + low-power desktops) pays a much steeper per-pixel cost
+ * for this fragment shader (5-octave FBM clouds + fog + 3 parallax precipitation
+ * layers) and the desktop is mostly occluded by windows anyway, so render the
+ * backing buffer at a lower internal resolution there. Mirrors the low-res
+ * approach in {@link AmbientBackground}.
  */
-const PHONE_RENDER_SCALE = 0.7;
+const LOW_RENDER_SCALE = 0.7;
 /** Upper bound on the device-pixel-ratio multiplier applied to the buffer. */
 const MAX_PIXEL_RATIO = 1.5;
-/** Don't multiply the (already heavy) buffer by hi-dpi on phones. */
-const PHONE_MAX_PIXEL_RATIO = 1.0;
+/** Don't multiply the (already heavy) buffer by hi-dpi in the reduced tier. */
+const LOW_MAX_PIXEL_RATIO = 1.0;
 /** Cap the shader loop to reduce steady-state GPU usage. */
 const TARGET_FPS = 30;
-/** Cloud/precip motion is slow, so a lower cap is imperceptible on phones. */
-const PHONE_TARGET_FPS = 20;
+/** Cloud/precip motion is slow, so a lower cap is imperceptible. */
+const LOW_TARGET_FPS = 20;
 
 type RGB = [number, number, number];
 
@@ -331,7 +332,7 @@ export function WeatherShaderBackground({
   className = "",
 }: WeatherShaderBackgroundProps) {
   const mountRef = useRef<HTMLDivElement>(null);
-  const isPhone = useIsPhone();
+  const reducedQuality = useReducedGraphics();
   const prefersReducedMotion = useMediaQuery("(prefers-reduced-motion: reduce)");
 
   // When the user prefers reduced motion we skip the animated shader entirely
@@ -348,9 +349,10 @@ export function WeatherShaderBackground({
   useEffect(() => {
     if (!shouldRender || !mountRef.current) return;
 
-    const renderScale = isPhone ? PHONE_RENDER_SCALE : RENDER_SCALE;
-    const maxPixelRatio = isPhone ? PHONE_MAX_PIXEL_RATIO : MAX_PIXEL_RATIO;
-    const frameIntervalMs = 1000 / (isPhone ? PHONE_TARGET_FPS : TARGET_FPS);
+    const renderScale = reducedQuality ? LOW_RENDER_SCALE : RENDER_SCALE;
+    const maxPixelRatio = reducedQuality ? LOW_MAX_PIXEL_RATIO : MAX_PIXEL_RATIO;
+    const frameIntervalMs =
+      1000 / (reducedQuality ? LOW_TARGET_FPS : TARGET_FPS);
 
     const el = mountRef.current;
     const scene = new THREE.Scene();
@@ -471,7 +473,7 @@ export function WeatherShaderBackground({
       shaderMaterial.dispose();
       renderer.dispose();
     };
-  }, [shouldRender, isPhone]);
+  }, [shouldRender, reducedQuality]);
 
   if (!shouldRender) return null;
 

--- a/src/components/shared/WeatherShaderBackground.tsx
+++ b/src/components/shared/WeatherShaderBackground.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef } from "react";
 import * as THREE from "three";
 import type { WeatherFamily } from "@/utils/dynamicWallpaper";
 import { useReducedGraphics } from "@/hooks/useReducedGraphics";
-import { useMediaQuery } from "@/hooks/useMediaQuery";
+import { useShaderAnimationDisabled } from "@/hooks/useShaderAnimationDisabled";
 
 /**
  * Render at full CSS-pixel resolution so the thin rain streaks stay crisp.
@@ -333,11 +333,11 @@ export function WeatherShaderBackground({
 }: WeatherShaderBackgroundProps) {
   const mountRef = useRef<HTMLDivElement>(null);
   const reducedQuality = useReducedGraphics();
-  const prefersReducedMotion = useMediaQuery("(prefers-reduced-motion: reduce)");
+  const animationDisabled = useShaderAnimationDisabled();
 
-  // When the user prefers reduced motion we skip the animated shader entirely
+  // Under reduced motion / battery-saver we skip the animated shader entirely
   // and let the caller's static CSS gradient show through.
-  const shouldRender = isActive && !prefersReducedMotion;
+  const shouldRender = isActive && !animationDisabled;
 
   // Latest weather props, read by the render loop each frame. Using a ref (not
   // an effect) means the shader always reflects the current props regardless of

--- a/src/components/shared/WeatherShaderBackground.tsx
+++ b/src/components/shared/WeatherShaderBackground.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useRef } from "react";
 import * as THREE from "three";
 import type { WeatherFamily } from "@/utils/dynamicWallpaper";
+import { useIsPhone } from "@/hooks/useIsPhone";
+import { useMediaQuery } from "@/hooks/useMediaQuery";
 
 /**
  * Render at full CSS-pixel resolution so the thin rain streaks stay crisp.
@@ -8,11 +10,21 @@ import type { WeatherFamily } from "@/utils/dynamicWallpaper";
  * precipitation sharp without paying for the native DPR on hi-dpi displays.
  */
 const RENDER_SCALE = 1.0;
+/**
+ * Phones pay a much steeper per-pixel cost for this fragment shader (5-octave
+ * FBM clouds + fog + 3 parallax precipitation layers) and the desktop is mostly
+ * occluded by windows anyway, so render the backing buffer at a lower internal
+ * resolution there. Mirrors the low-res approach in {@link AmbientBackground}.
+ */
+const PHONE_RENDER_SCALE = 0.7;
 /** Upper bound on the device-pixel-ratio multiplier applied to the buffer. */
 const MAX_PIXEL_RATIO = 1.5;
+/** Don't multiply the (already heavy) buffer by hi-dpi on phones. */
+const PHONE_MAX_PIXEL_RATIO = 1.0;
 /** Cap the shader loop to reduce steady-state GPU usage. */
 const TARGET_FPS = 30;
-const FRAME_INTERVAL_MS = 1000 / TARGET_FPS;
+/** Cloud/precip motion is slow, so a lower cap is imperceptible on phones. */
+const PHONE_TARGET_FPS = 20;
 
 type RGB = [number, number, number];
 
@@ -319,6 +331,12 @@ export function WeatherShaderBackground({
   className = "",
 }: WeatherShaderBackgroundProps) {
   const mountRef = useRef<HTMLDivElement>(null);
+  const isPhone = useIsPhone();
+  const prefersReducedMotion = useMediaQuery("(prefers-reduced-motion: reduce)");
+
+  // When the user prefers reduced motion we skip the animated shader entirely
+  // and let the caller's static CSS gradient show through.
+  const shouldRender = isActive && !prefersReducedMotion;
 
   // Latest weather props, read by the render loop each frame. Using a ref (not
   // an effect) means the shader always reflects the current props regardless of
@@ -328,7 +346,11 @@ export function WeatherShaderBackground({
   propsRef.current = { family, isDay, topColor, midColor, bottomColor };
 
   useEffect(() => {
-    if (!isActive || !mountRef.current) return;
+    if (!shouldRender || !mountRef.current) return;
+
+    const renderScale = isPhone ? PHONE_RENDER_SCALE : RENDER_SCALE;
+    const maxPixelRatio = isPhone ? PHONE_MAX_PIXEL_RATIO : MAX_PIXEL_RATIO;
+    const frameIntervalMs = 1000 / (isPhone ? PHONE_TARGET_FPS : TARGET_FPS);
 
     const el = mountRef.current;
     const scene = new THREE.Scene();
@@ -351,8 +373,8 @@ export function WeatherShaderBackground({
     // 0-size first paint can't leave the renderer stuck at a 1×1 buffer. The
     // effective scale folds in a capped DPR so streaks are crisp on hi-dpi.
     const measure = () => {
-      const dpr = Math.min(window.devicePixelRatio || 1, MAX_PIXEL_RATIO);
-      const eff = RENDER_SCALE * dpr;
+      const dpr = Math.min(window.devicePixelRatio || 1, maxPixelRatio);
+      const eff = renderScale * dpr;
       const w = el.clientWidth || window.innerWidth;
       const h = el.clientHeight || window.innerHeight;
       return {
@@ -400,7 +422,7 @@ export function WeatherShaderBackground({
     let lastRenderAt = 0;
     const animate = (now: number) => {
       frameId = requestAnimationFrame(animate);
-      if (lastRenderAt !== 0 && now - lastRenderAt < FRAME_INTERVAL_MS) return;
+      if (lastRenderAt !== 0 && now - lastRenderAt < frameIntervalMs) return;
       lastRenderAt = now;
       const p = propsRef.current;
       const u = shaderMaterial.uniforms;
@@ -416,10 +438,30 @@ export function WeatherShaderBackground({
       );
       renderer.render(scene, camera);
     };
-    frameId = requestAnimationFrame(animate);
+
+    // Pause the GPU loop while the tab/PWA is hidden (saves battery on mobile),
+    // and resume on return. Reset the frame clock so the first resumed frame
+    // renders immediately instead of being skipped by the interval gate.
+    const startLoop = () => {
+      if (frameId !== 0) return;
+      lastRenderAt = 0;
+      frameId = requestAnimationFrame(animate);
+    };
+    const stopLoop = () => {
+      if (frameId === 0) return;
+      cancelAnimationFrame(frameId);
+      frameId = 0;
+    };
+    const handleVisibility = () => {
+      if (document.hidden) stopLoop();
+      else startLoop();
+    };
+    document.addEventListener("visibilitychange", handleVisibility);
+    if (!document.hidden) startLoop();
 
     return () => {
-      cancelAnimationFrame(frameId);
+      document.removeEventListener("visibilitychange", handleVisibility);
+      stopLoop();
       resizeObserver.disconnect();
       if (renderer.domElement.parentNode === el) {
         el.removeChild(renderer.domElement);
@@ -429,9 +471,9 @@ export function WeatherShaderBackground({
       shaderMaterial.dispose();
       renderer.dispose();
     };
-  }, [isActive]);
+  }, [shouldRender, isPhone]);
 
-  if (!isActive) return null;
+  if (!shouldRender) return null;
 
   return (
     <div

--- a/src/hooks/useBatterySaver.ts
+++ b/src/hooks/useBatterySaver.ts
@@ -1,0 +1,68 @@
+import { useEffect, useState } from "react";
+
+/** Treat the device as power-saving below this battery level while discharging. */
+const LOW_BATTERY_THRESHOLD = 0.2;
+
+/**
+ * Minimal shape of the (non-standard, still widely shipped in Chromium/Android)
+ * BatteryManager returned by `navigator.getBattery()`. It was removed from
+ * `lib.dom.d.ts`, so we type just what we use.
+ */
+interface BatteryManagerLike extends EventTarget {
+  level: number;
+  charging: boolean;
+}
+
+type NavigatorWithBattery = Navigator & {
+  getBattery?: () => Promise<BatteryManagerLike>;
+};
+
+/**
+ * True when the device appears to be conserving power — currently approximated
+ * as "low battery and not charging" via the Battery Status API.
+ *
+ * There is no web API for the OS "Low Power Mode" toggle (iOS/macOS), and the
+ * Battery Status API is unavailable on Safari/Firefox, so this returns `false`
+ * there and is a best-effort signal rather than a guarantee. Reacts to battery
+ * level / charging changes.
+ */
+export function useBatterySaver(): boolean {
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    if (typeof navigator === "undefined") return;
+    const nav = navigator as NavigatorWithBattery;
+    if (typeof nav.getBattery !== "function") return;
+
+    let battery: BatteryManagerLike | null = null;
+    let cancelled = false;
+
+    const update = () => {
+      if (!battery) return;
+      setSaving(!battery.charging && battery.level <= LOW_BATTERY_THRESHOLD);
+    };
+
+    nav
+      .getBattery()
+      .then((b) => {
+        if (cancelled) return;
+        battery = b;
+        b.addEventListener("levelchange", update);
+        b.addEventListener("chargingchange", update);
+        update();
+      })
+      .catch(() => {
+        // Battery API unavailable / blocked — leave power-saving off.
+      });
+
+    return () => {
+      cancelled = true;
+      if (battery) {
+        battery.removeEventListener("levelchange", update);
+        battery.removeEventListener("chargingchange", update);
+      }
+    };
+  }, []);
+
+  return saving;
+}

--- a/src/hooks/useReducedGraphics.ts
+++ b/src/hooks/useReducedGraphics.ts
@@ -1,0 +1,16 @@
+import { useIsPhone } from "@/hooks/useIsPhone";
+import { isLowPowerHardware } from "@/utils/performanceCheck";
+
+/**
+ * True when animated shader backgrounds should run in their reduced-quality
+ * tier (lower internal resolution / frame rate / backing-buffer size).
+ *
+ * This covers phones AND low-power desktops (few CPU cores / little memory),
+ * reusing the same hardware signal we probe at boot via
+ * {@link isLowPowerHardware}. The phone check is reactive (it re-evaluates on
+ * resize); the hardware check is a stable, cached per-session value.
+ */
+export function useReducedGraphics(): boolean {
+  const isPhone = useIsPhone();
+  return isPhone || isLowPowerHardware();
+}

--- a/src/hooks/useShaderAnimationDisabled.ts
+++ b/src/hooks/useShaderAnimationDisabled.ts
@@ -1,0 +1,14 @@
+import { useMediaQuery } from "@/hooks/useMediaQuery";
+import { useBatterySaver } from "@/hooks/useBatterySaver";
+
+/**
+ * True when animated shader effects should be turned off entirely — either the
+ * user prefers reduced motion, or the device is in a battery-saving state (low
+ * battery and discharging, where detectable). Shader backgrounds fall back to a
+ * static frame / CSS gradient when this is true, stopping their render loops.
+ */
+export function useShaderAnimationDisabled(): boolean {
+  const prefersReducedMotion = useMediaQuery("(prefers-reduced-motion: reduce)");
+  const batterySaver = useBatterySaver();
+  return prefersReducedMotion || batterySaver;
+}

--- a/src/utils/performanceCheck.ts
+++ b/src/utils/performanceCheck.ts
@@ -1,3 +1,40 @@
+/** Desktops/laptops at or below this core count are treated as low-power. */
+const LOW_POWER_MAX_CORES = 4;
+/** Devices reporting at or below this much RAM (GB) are treated as low-power. */
+const LOW_POWER_MAX_MEMORY_GB = 4;
+
+let cachedLowPowerHardware: boolean | null = null;
+
+/**
+ * Lightweight, cached heuristic for weak hardware based on CPU core count and
+ * (where exposed) device memory — the same core-count signal probed by
+ * {@link checkShaderPerformance} at boot, but WITHOUT creating a WebGL context,
+ * so it's cheap enough to call from component render.
+ *
+ * Used to drop animated shader backgrounds into their reduced-quality tier
+ * (lower internal resolution / frame rate / buffer size) on weak machines —
+ * including low-core desktops, not just phones.
+ *
+ * @returns {boolean} True if the device looks low-power.
+ */
+export function isLowPowerHardware(): boolean {
+  if (cachedLowPowerHardware !== null) return cachedLowPowerHardware;
+  if (typeof navigator === "undefined") return false; // SSR: decide on client
+
+  const cores = navigator.hardwareConcurrency || 0;
+  const memory = (navigator as Navigator & { deviceMemory?: number })
+    .deviceMemory;
+
+  const lowCores = cores > 0 && cores <= LOW_POWER_MAX_CORES;
+  const lowMemory =
+    typeof memory === "number" &&
+    memory > 0 &&
+    memory <= LOW_POWER_MAX_MEMORY_GB;
+
+  cachedLowPowerHardware = lowCores || lowMemory;
+  return cachedLowPowerHardware;
+}
+
 /**
  * Checks for basic performance indicators to estimate if the device
  * is likely capable of handling intensive shader effects smoothly.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Reduces GPU/battery cost of shader-driven backgrounds, with no meaningful fidelity cost. Applies a consistent optimization set across every animated shader background: a **reduced-quality tier** (lower internal resolution / FPS / backing-buffer size / speed), pause-while-hidden, `prefers-reduced-motion` handling, and **turning animation off on low battery / power-saving**.

The reduced tier kicks in for **phones AND low-power desktops** (few CPU cores / little memory); animation is turned off entirely under reduced-motion or battery-saving.

### Hardware tiering
- `performanceCheck.ts`: new `isLowPowerHardware()` — cheap, cached heuristic (`hardwareConcurrency <= 4` or `deviceMemory <= 4GB`, no WebGL context) reusing the boot-time core-count signal.
- `useReducedGraphics()` = `useIsPhone() || isLowPowerHardware()`.

### Battery / power-saving
- `useBatterySaver()` — Battery Status API: returns true when **low battery (≤20%) and discharging**, reacting to level/charging changes. SSR- and Safari/Firefox-safe no-op (those don't expose the API). Note: the OS "Low Power Mode" toggle is not exposed to the web, so this approximates it via low battery.
- `useShaderAnimationDisabled()` = `prefers-reduced-motion || useBatterySaver()`. When true, shaders stop animating and fall back to a static frame / CSS gradient.

### Desktop wallpapers
**Weather — `WeatherShaderBackground.tsx` (three.js)**
- Reduced tier: `RENDER_SCALE 0.7` + DPR cap `1.0` (full: `1.0` / `1.5`), FPS cap `20` vs `30`.
- rAF loop pauses on `document.hidden`.
- Animation-disabled (reduced-motion / battery-saver) → skip the shader, show the static CSS gradient.

**Lyrics — `MeshGradientBackground.tsx` (Paper)**
- Reduced tier: `maxPixelCount` ~720p + `minPixelRatio 1` + calmer speed; capable desktops capped at QHD (vs Paper's ~8.3M px default).
- Animation-disabled → `speed = 0` (static). Tab-hidden pause handled by `ShaderMount`.

### iPod / Karaoke player shader backgrounds
**Shader mode — `AmbientBackground.tsx` (three.js)**
- Reduced-tier resolution (`0.3` vs `0.4`) and FPS (`20` vs `30`); rAF pauses on `document.hidden`.
- Animation-disabled → single static frame (no loop), repainting on cover change / resize.

**Water mode — `WaterBackground.tsx` (Paper)**
- Reduced tier: `maxPixelCount` ~720p + `minPixelRatio 1` + calmer speed; capable desktops capped at QHD.
- Animation-disabled → `speed = 0`. Tab-hidden pause handled by `ShaderMount`.

`MeshGradientBackground` (iPod/Karaoke Mesh mode) reuses the optimized component. New behavior is gated on existing tested hooks plus the new cached hardware/battery checks; `isActive` gating unchanged.

### Not changed (possible follow-ups)
- `LandscapeVideoBackground` (HTML5 video) only resumes on focus, doesn't pause on hide.
- iPod inline overlay gates on `showVideo && isPlaying` but not `isForeground` (fullscreen + Karaoke already do).
- `GalaxyBackground` (IE Time Machine) and `Waveform3D` (Synth) out of scope.

## Testing
- ✅ `bunx tsc -b` (typecheck)
- ✅ `bunx eslint` on all changed files
- ✅ `bun test` wallpaper suites (28 pass) + iPod suites (81 pass)

Manual GUI/visual testing skipped per repo `AGENTS.md` (skip computer-use testing unless explicitly requested). Battery-saver detection depends on the Battery Status API (Chromium/Android) and can't be exercised headlessly; logic is type-checked and lint-clean.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019edb99-e97f-7abc-ba87-aa7292bfa144"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019edb99-e97f-7abc-ba87-aa7292bfa144"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

