### PR TITLE
fix(ui): consistent accent-derived selection color for menus & selected items

### DIFF
--- a/src/apps/admin/components/admin-app/AdminRedisBrowserView.tsx
+++ b/src/apps/admin/components/admin-app/AdminRedisBrowserView.tsx
@@ -761,11 +761,11 @@ export function AdminRedisBrowserView({ t }: AdminRedisBrowserViewProps) {
                       className={cn(
                         adminTableRowClass,
                         "cursor-pointer",
-                        // Selected row uses the solid accent swatch
-                        // (`--os-accent-color`), falling back to the theme's
-                        // selection color when no accent is set ("System").
+                        // Selected row uses the shared selection fill
+                        // (`--os-color-selection-bg`) — the same accent-derived
+                        // color the chat sidebar and other selected items use.
                         selectedKey === item.key &&
-                          "bg-[var(--os-accent-color,var(--os-color-selection-bg))] text-os-selection-text hover:bg-[var(--os-accent-color,var(--os-color-selection-bg))]",
+                          "bg-os-selection-bg text-os-selection-text hover:bg-os-selection-bg",
                       )}
                       onClick={() => void loadKeyDocument(item.key)}
                       onKeyDown={(event) => {

--- a/src/apps/internet-explorer/components/internet-explorer-app/InternetExplorerFavoritesBar.tsx
+++ b/src/apps/internet-explorer/components/internet-explorer-app/InternetExplorerFavoritesBar.tsx
@@ -74,7 +74,7 @@ export function InternetExplorerFavoritesBar({
                               child.year
                             )
                           }
-                          className="text-md h-6 px-3 active:bg-neutral-900 active:text-white flex items-center gap-2"
+                          className="text-md h-6 px-3 active:bg-os-selection-bg active:text-os-selection-text flex items-center gap-2"
                         >
                           {child.favicon && !isOffline ? (
                             <img

--- a/src/apps/internet-explorer/components/internet-explorer-app/InternetExplorerToolbar.tsx
+++ b/src/apps/internet-explorer/components/internet-explorer-app/InternetExplorerToolbar.tsx
@@ -199,14 +199,14 @@ export function InternetExplorerToolbar({
                 <SelectItem
                   key={y}
                   value={y}
-                  className="text-md h-6 px-3 active:bg-neutral-900 active:text-white text-os-link"
+                  className="text-md h-6 px-3 active:bg-os-selection-bg active:text-os-selection-text text-os-link"
                 >
                   {y}
                 </SelectItem>
               ))}
               <SelectItem
                 value="current"
-                className="text-md h-6 px-3 active:bg-neutral-900 active:text-white"
+                className="text-md h-6 px-3 active:bg-os-selection-bg active:text-os-selection-text"
               >
                 {t("apps.internet-explorer.now")}
               </SelectItem>
@@ -214,7 +214,7 @@ export function InternetExplorerToolbar({
                 <SelectItem
                   key={y}
                   value={y}
-                  className={`text-md h-6 px-3 active:bg-neutral-900 active:text-white ${
+                  className={`text-md h-6 px-3 active:bg-os-selection-bg active:text-os-selection-text ${
                     parseInt(y) <= 1995 ? "text-os-link" : ""
                   }`}
                 >

--- a/src/apps/internet-explorer/components/time-machine-view/TimeMachineViewPortal.tsx
+++ b/src/apps/internet-explorer/components/time-machine-view/TimeMachineViewPortal.tsx
@@ -514,7 +514,7 @@ export function TimeMachineViewPortal({ vm, isOpen }: { vm: TimeMachineViewVm; i
                           key={type}
                           className={cn(
                             "font-geneva-12 text-[12px] flex items-center justify-between",
-                            isSelected && "bg-accent text-accent-foreground"
+                            isSelected && "bg-os-selection-bg text-os-selection-text"
                           )}
                           onClick={() => {
                             if (type === "off") {

--- a/src/apps/textedit/components/SlashCommandsList.tsx
+++ b/src/apps/textedit/components/SlashCommandsList.tsx
@@ -73,7 +73,7 @@ export const SlashCommandsList = (
         <button
           key={`${item.title}-${item.description}`}
           className={`flex w-full items-start gap-2 rounded-md px-2 py-1 text-left ${
-            index === selectedIndex ? "bg-accent text-accent-foreground" : ""
+            index === selectedIndex ? "bg-os-selection-bg text-os-selection-text" : ""
           }`}
           onClick={() => selectItem(index)}
         >

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -82,13 +82,22 @@ const DropdownMenuSubTrigger = (
     ref?: React.Ref<React.ElementRef<typeof DropdownMenuPrimitive.SubTrigger>>;
   }
 ) => {
-  const { isWindowsTheme, isMacOSTheme } = useThemeFlags();
+  const { isWindowsTheme, isMacOSTheme, isSystem7Theme } = useThemeFlags();
 
   return (
     <DropdownMenuPrimitive.SubTrigger
       ref={ref}
       className={cn(
-        "flex cursor-default gap-2 select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent data-[state=open]:bg-accent [&_svg]:pointer-events-none [&_svg]:shrink-0",
+        "flex cursor-default gap-2 select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none [&_svg]:pointer-events-none [&_svg]:shrink-0",
+        // Open/focused submenu trigger uses the accent-derived selection fill
+        // on classic chromes; `bg-accent` goes near-black in macOS dark mode.
+        isSystem7Theme &&
+          "focus:bg-[var(--os-color-selection-bg)] focus:text-[var(--os-color-selection-text)] data-[state=open]:bg-[var(--os-color-selection-bg)] data-[state=open]:text-[var(--os-color-selection-text)]",
+        isMacOSTheme &&
+          "focus:bg-[var(--os-color-selection-bg)] focus:text-[var(--os-color-selection-text)] data-[state=open]:bg-[var(--os-color-selection-bg)] data-[state=open]:text-[var(--os-color-selection-text)]",
+        !isSystem7Theme &&
+          !isMacOSTheme &&
+          "focus:bg-accent data-[state=open]:bg-accent",
         inset && "pl-8",
         className
       )}

--- a/src/components/ui/right-click-menu.tsx
+++ b/src/components/ui/right-click-menu.tsx
@@ -55,7 +55,7 @@ interface RightClickMenuProps {
 }
 
 export const menuItemClass =
-  "text-md h-6 px-3 active:bg-neutral-900 active:text-white min-w-[140px] flex items-center gap-2";
+  "text-md h-6 px-3 active:bg-os-selection-bg active:text-os-selection-text min-w-[140px] flex items-center gap-2";
 
 const menuItemKeyCache = new WeakMap<object, string>();
 let menuItemKeySeed = 0;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Selected/active items across ryOS should use the **accent-derived selection fill** (`--os-color-selection-bg` / `--os-color-selection-text`) — the same color the chat sidebar, Finder, and the global `[data-selected="true"]` rule use. A few spots diverged: one used the **solid accent swatch** (`--os-accent-color`), and several menus flashed **near-black** on their active/pressed/open state.

## Changes

### 1. Admin Redis browser — wrong selection color
`AdminRedisBrowserView.tsx` highlighted the selected key row with the solid accent swatch `--os-accent-color`, which looked different from every other selected item. Switched to the shared `--os-color-selection-bg` fill.

### 2. Menus showing black on active/selected
Audited the codebase for menu active/selected states rendering black instead of the selection color:

- **Right-click menus** (`right-click-menu.tsx` `menuItemClass`) and **Internet Explorer** year picker (`InternetExplorerToolbar.tsx`) + favorites (`InternetExplorerFavoritesBar.tsx`) used `active:bg-neutral-900` (near-black) on mouse-down across all themes → now `active:bg-os-selection-bg active:text-os-selection-text`.
- **`DropdownMenuSubTrigger`** used `bg-accent` for the open/focused state, which resolves to near-black in macOS dark mode. Now mirrors `MenubarSubTrigger`'s theme-aware selection tokens (System 7 / macOS use `--os-color-selection-bg`; Windows keeps `bg-accent`).
- **TextEdit slash-commands list** (`SlashCommandsList.tsx`) and **Time Machine shader picker** (`TimeMachineViewPortal.tsx`) used `bg-accent text-accent-foreground` for the selected row (near-black in dark mode) → now selection tokens.

### Audit result
No other selection/active **background** uses the solid `--os-accent-color`. Remaining `--os-accent-color` references are legitimate (text/icon `color`, glass `color-mix` tints, traffic-light buttons) and were left untouched.

## Testing

- `bun run build` — passes.
- Verified generated CSS: `.bg-os-selection-bg{background-color:var(--os-color-selection-bg)}`, `.active\:bg-os-selection-bg:active{background-color:var(--os-color-selection-bg)}`, `.active\:text-os-selection-text:active{color:var(--os-color-selection-text)}`.

Note: GUI/computer-use testing skipped per repo `AGENTS.md` guidance (skip unless explicitly requested). Changes are mechanical token swaps verified via build + compiled CSS.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019edd4a-d193-78b2-ac3d-077e59e01593"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019edd4a-d193-78b2-ac3d-077e59e01593"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

