### PR TITLE
test: fix always-pass, mislabeled, and weak-assertion tests from audit

### DIFF
--- a/api/chat/tools/executors.ts
+++ b/api/chat/tools/executors.ts
@@ -36,7 +36,7 @@ import {
   writeFilesMetadataToolState,
 } from "../../sync/v2/_tool-state.js";
 import { getAppPublicOrigin } from "../../_utils/runtime-config.js";
-import { decodeHtmlEntitiesOnce } from "../../_utils/html-entities.js";
+import { extractMetadata, stripHtmlToText } from "./htmlExtract.js";
 import {
   getYouTubeApiKeys,
   toSearchSongsResult,
@@ -187,143 +187,8 @@ const WEB_FETCH_BROWSER_HEADERS: Record<string, string> = {
   "Upgrade-Insecure-Requests": "1",
 };
 
-const DANGEROUS_URL_SCHEMES = /^(?:javascript|data|vbscript|blob):/i;
-
-/**
- * Repeatedly strip tag patterns until no more matches remain,
- * preventing nested-tag bypass (e.g. `<scr<script>ipt>`).
- */
-function stripTagsLoop(html: string, pattern: RegExp, maxPasses = 10): string {
-  let result = html;
-  for (let i = 0; i < maxPasses; i++) {
-    const next = result.replace(pattern, "");
-    if (next === result) break;
-    result = next;
-  }
-  return result;
-}
-function stripHtmlToText(html: string, selector?: string): string {
-  let working = html;
-
-  if (selector) {
-    const selectorPatterns = buildSelectorPatterns(selector);
-    const extracted = extractByPatterns(working, selectorPatterns);
-    if (extracted) {
-      working = extracted;
-    }
-  } else {
-    working = extractMainContent(working);
-  }
-
-  // Strip dangerous/non-content tags in a loop to handle nested obfuscation.
-  // Closing-tag regex uses `[^>]*>` to match malformed variants like
-  // `</script \t\n bar>` where extra chars appear before `>`.
-  working = stripTagsLoop(working, /<script\b[\s\S]*?<\/script[^>]*>/gi);
-  working = stripTagsLoop(working, /<style\b[\s\S]*?<\/style[^>]*>/gi);
-  working = stripTagsLoop(working, /<noscript\b[\s\S]*?<\/noscript[^>]*>/gi);
-  working = stripTagsLoop(working, /<nav\b[\s\S]*?<\/nav[^>]*>/gi);
-  working = stripTagsLoop(working, /<footer\b[\s\S]*?<\/footer[^>]*>/gi);
-  working = stripTagsLoop(working, /<header\b[\s\S]*?<\/header[^>]*>/gi);
-  working = stripTagsLoop(working, /<!--[\s\S]*?-->/g);
-  working = stripTagsLoop(working, /<svg\b[\s\S]*?<\/svg[^>]*>/gi);
-
-  working = working.replace(/<(h[1-6])[^>]*>([\s\S]*?)<\/\1>/gi, (_m, tag, inner) => {
-    const level = parseInt(tag.charAt(1), 10);
-    return "\n" + "#".repeat(level) + " " + inner.trim() + "\n";
-  });
-
-  working = working.replace(/<li[^>]*>/gi, "\n- ");
-  working = working.replace(/<\/li>/gi, "");
-  working = working.replace(/<br\s*\/?>/gi, "\n");
-  working = working.replace(/<\/p>/gi, "\n\n");
-  working = working.replace(/<\/div>/gi, "\n");
-  working = working.replace(/<\/tr>/gi, "\n");
-  working = working.replace(/<td[^>]*>/gi, "\t");
-
-  working = working.replace(/<a[^>]*href=["']([^"']+)["'][^>]*>([\s\S]*?)<\/a>/gi, (_m, href, text) => {
-    const linkText = stripTagsLoop(text, /<[^>]+>/g).trim();
-    if (!linkText) return "";
-    if (href.startsWith("#") || DANGEROUS_URL_SCHEMES.test(href)) return linkText;
-    return `${linkText} (${href})`;
-  });
-
-  // Loop-strip remaining tags to handle any nested fragments
-  working = stripTagsLoop(working, /<[^>]+>/g);
-
-  working = decodeHtmlEntitiesOnce(working);
-
-  working = working.replace(/[ \t]+/g, " ");
-  working = working.replace(/\n[ \t]+/g, "\n");
-  working = working.replace(/\n{3,}/g, "\n\n");
-  working = working.trim();
-
-  return working;
-}
-
-function buildSelectorPatterns(selector: string): RegExp[] {
-  const patterns: RegExp[] = [];
-
-  if (selector.startsWith("#")) {
-    const id = selector.slice(1).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-    patterns.push(new RegExp(`<[a-z][a-z0-9]*[^>]*\\bid=["']${id}["'][^>]*>[\\s\\S]*?(?=<\\/[a-z])`, "i"));
-  } else if (selector.startsWith(".")) {
-    const cls = selector.slice(1).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-    patterns.push(new RegExp(`<[a-z][a-z0-9]*[^>]*\\bclass=["'][^"']*\\b${cls}\\b[^"']*["'][^>]*>[\\s\\S]*?(?=<\\/[a-z])`, "i"));
-  } else {
-    const tag = selector.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-    patterns.push(new RegExp(`<${tag}[^>]*>[\\s\\S]*?<\\/${tag}>`, "gi"));
-  }
-
-  return patterns;
-}
-
-function extractByPatterns(html: string, patterns: RegExp[]): string | null {
-  for (const pattern of patterns) {
-    const match = html.match(pattern);
-    if (match) return match[0];
-  }
-  return null;
-}
-
-function extractMainContent(html: string): string {
-  const mainPatterns = [
-    /<main[^>]*>([\s\S]*?)<\/main>/i,
-    /<article[^>]*>([\s\S]*?)<\/article>/i,
-    /<div[^>]*(?:id|class)=["'][^"']*(?:content|article|post|entry|main-body|main_content|page-content|post-content)[^"']*["'][^>]*>([\s\S]*?)<\/div>/i,
-    /<div[^>]*role=["']main["'][^>]*>([\s\S]*?)<\/div>/i,
-  ];
-
-  for (const pattern of mainPatterns) {
-    const match = html.match(pattern);
-    if (match) {
-      const content = match[1] || match[0];
-      if (content.length > 200) return content;
-    }
-  }
-
-  return html;
-}
-
-function extractMetadata(html: string): {
-  title?: string;
-  description?: string;
-  siteName?: string;
-} {
-  const result: { title?: string; description?: string; siteName?: string } = {};
-
-  const ogTitle = html.match(/<meta[^>]*property=["']og:title["'][^>]*content=["']([^"']+)["'][^>]*>/i);
-  const titleTag = html.match(/<title[^>]*>([\s\S]*?)<\/title>/i);
-  result.title = ogTitle?.[1]?.trim() || titleTag?.[1]?.trim().replace(/\s+/g, " ");
-
-  const ogDesc = html.match(/<meta[^>]*property=["']og:description["'][^>]*content=["']([^"']+)["'][^>]*>/i);
-  const metaDesc = html.match(/<meta[^>]*name=["']description["'][^>]*content=["']([^"']+)["'][^>]*>/i);
-  result.description = ogDesc?.[1]?.trim() || metaDesc?.[1]?.trim();
-
-  const ogSite = html.match(/<meta[^>]*property=["']og:site_name["'][^>]*content=["']([^"']+)["'][^>]*>/i);
-  result.siteName = ogSite?.[1]?.trim();
-
-  return result;
-}
+// Pure HTML→text + metadata helpers live in ./htmlExtract.js so they can be
+// unit-tested without pulling this module's server-only imports.
 
 export async function executeWebFetch(
   input: WebFetchInput,

--- a/api/chat/tools/htmlExtract.ts
+++ b/api/chat/tools/htmlExtract.ts
@@ -1,0 +1,183 @@
+/**
+ * Pure HTML→text and metadata extraction helpers for the webFetch tool.
+ *
+ * These were previously private functions inside executors.ts. They are split
+ * into this dependency-free module so they can be unit-tested directly (without
+ * pulling executors.ts's heavy server-only imports) and reused without
+ * duplicating the logic.
+ */
+
+import { decodeHtmlEntitiesOnce } from "../../_utils/html-entities.js";
+
+export const DANGEROUS_URL_SCHEMES = /^(?:javascript|data|vbscript|blob):/i;
+
+/**
+ * Repeatedly strip tag patterns until no more matches remain,
+ * preventing nested-tag bypass (e.g. `<scr<script>ipt>`).
+ */
+export function stripTagsLoop(
+  html: string,
+  pattern: RegExp,
+  maxPasses = 10
+): string {
+  let result = html;
+  for (let i = 0; i < maxPasses; i++) {
+    const next = result.replace(pattern, "");
+    if (next === result) break;
+    result = next;
+  }
+  return result;
+}
+
+export function buildSelectorPatterns(selector: string): RegExp[] {
+  const patterns: RegExp[] = [];
+
+  if (selector.startsWith("#")) {
+    const id = selector.slice(1).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    patterns.push(
+      new RegExp(
+        `<[a-z][a-z0-9]*[^>]*\\bid=["']${id}["'][^>]*>[\\s\\S]*?(?=<\\/[a-z])`,
+        "i"
+      )
+    );
+  } else if (selector.startsWith(".")) {
+    const cls = selector.slice(1).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    patterns.push(
+      new RegExp(
+        `<[a-z][a-z0-9]*[^>]*\\bclass=["'][^"']*\\b${cls}\\b[^"']*["'][^>]*>[\\s\\S]*?(?=<\\/[a-z])`,
+        "i"
+      )
+    );
+  } else {
+    const tag = selector.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    patterns.push(new RegExp(`<${tag}[^>]*>[\\s\\S]*?<\\/${tag}>`, "gi"));
+  }
+
+  return patterns;
+}
+
+export function extractByPatterns(
+  html: string,
+  patterns: RegExp[]
+): string | null {
+  for (const pattern of patterns) {
+    const match = html.match(pattern);
+    if (match) return match[0];
+  }
+  return null;
+}
+
+export function extractMainContent(html: string): string {
+  const mainPatterns = [
+    /<main[^>]*>([\s\S]*?)<\/main>/i,
+    /<article[^>]*>([\s\S]*?)<\/article>/i,
+    /<div[^>]*(?:id|class)=["'][^"']*(?:content|article|post|entry|main-body|main_content|page-content|post-content)[^"']*["'][^>]*>([\s\S]*?)<\/div>/i,
+    /<div[^>]*role=["']main["'][^>]*>([\s\S]*?)<\/div>/i,
+  ];
+
+  for (const pattern of mainPatterns) {
+    const match = html.match(pattern);
+    if (match) {
+      const content = match[1] || match[0];
+      if (content.length > 200) return content;
+    }
+  }
+
+  return html;
+}
+
+export function stripHtmlToText(html: string, selector?: string): string {
+  let working = html;
+
+  if (selector) {
+    const selectorPatterns = buildSelectorPatterns(selector);
+    const extracted = extractByPatterns(working, selectorPatterns);
+    if (extracted) {
+      working = extracted;
+    }
+  } else {
+    working = extractMainContent(working);
+  }
+
+  // Strip dangerous/non-content tags in a loop to handle nested obfuscation.
+  // Closing-tag regex uses `[^>]*>` to match malformed variants like
+  // `</script \t\n bar>` where extra chars appear before `>`.
+  working = stripTagsLoop(working, /<script\b[\s\S]*?<\/script[^>]*>/gi);
+  working = stripTagsLoop(working, /<style\b[\s\S]*?<\/style[^>]*>/gi);
+  working = stripTagsLoop(working, /<noscript\b[\s\S]*?<\/noscript[^>]*>/gi);
+  working = stripTagsLoop(working, /<nav\b[\s\S]*?<\/nav[^>]*>/gi);
+  working = stripTagsLoop(working, /<footer\b[\s\S]*?<\/footer[^>]*>/gi);
+  working = stripTagsLoop(working, /<header\b[\s\S]*?<\/header[^>]*>/gi);
+  working = stripTagsLoop(working, /<!--[\s\S]*?-->/g);
+  working = stripTagsLoop(working, /<svg\b[\s\S]*?<\/svg[^>]*>/gi);
+
+  working = working.replace(
+    /<(h[1-6])[^>]*>([\s\S]*?)<\/\1>/gi,
+    (_m, tag, inner) => {
+      const level = parseInt(tag.charAt(1), 10);
+      return "\n" + "#".repeat(level) + " " + inner.trim() + "\n";
+    }
+  );
+
+  working = working.replace(/<li[^>]*>/gi, "\n- ");
+  working = working.replace(/<\/li>/gi, "");
+  working = working.replace(/<br\s*\/?>/gi, "\n");
+  working = working.replace(/<\/p>/gi, "\n\n");
+  working = working.replace(/<\/div>/gi, "\n");
+  working = working.replace(/<\/tr>/gi, "\n");
+  working = working.replace(/<td[^>]*>/gi, "\t");
+
+  working = working.replace(
+    /<a[^>]*href=["']([^"']+)["'][^>]*>([\s\S]*?)<\/a>/gi,
+    (_m, href, text) => {
+      const linkText = stripTagsLoop(text, /<[^>]+>/g).trim();
+      if (!linkText) return "";
+      if (href.startsWith("#") || DANGEROUS_URL_SCHEMES.test(href))
+        return linkText;
+      return `${linkText} (${href})`;
+    }
+  );
+
+  // Loop-strip remaining tags to handle any nested fragments
+  working = stripTagsLoop(working, /<[^>]+>/g);
+
+  working = decodeHtmlEntitiesOnce(working);
+
+  working = working.replace(/[ \t]+/g, " ");
+  working = working.replace(/\n[ \t]+/g, "\n");
+  working = working.replace(/\n{3,}/g, "\n\n");
+  working = working.trim();
+
+  return working;
+}
+
+export function extractMetadata(html: string): {
+  title?: string;
+  description?: string;
+  siteName?: string;
+} {
+  const result: { title?: string; description?: string; siteName?: string } =
+    {};
+
+  const ogTitle = html.match(
+    /<meta[^>]*property=["']og:title["'][^>]*content=["']([^"']+)["'][^>]*>/i
+  );
+  const titleTag = html.match(/<title[^>]*>([\s\S]*?)<\/title>/i);
+  result.title =
+    ogTitle?.[1]?.trim() || titleTag?.[1]?.trim().replace(/\s+/g, " ");
+
+  const ogDesc = html.match(
+    /<meta[^>]*property=["']og:description["'][^>]*content=["']([^"']+)["'][^>]*>/i
+  );
+  const metaDesc = html.match(
+    /<meta[^>]*name=["']description["'][^>]*content=["']([^"']+)["'][^>]*>/i
+  );
+  result.description = ogDesc?.[1]?.trim() || metaDesc?.[1]?.trim();
+
+  const ogSite = html.match(
+    /<meta[^>]*property=["']og:site_name["'][^>]*content=["']([^"']+)["'][^>]*>/i
+  );
+  result.siteName = ogSite?.[1]?.trim();
+
+  return result;
+}

--- a/api/sync/v2/_maintenance.ts
+++ b/api/sync/v2/_maintenance.ts
@@ -131,23 +131,38 @@ function getUsernameFromKvKey(key: string): string | null {
   return canonicalMatch?.[1] ? decodeURIComponent(canonicalMatch[1]) : null;
 }
 
-function parseMaintenanceCursor(raw: string | number): {
+function parseMaintenanceCursor(raw: unknown): {
   patternIndex: number;
   cursor: string;
 } {
-  if (typeof raw === "string" && raw.trim().startsWith("{")) {
-    const parsed = parseRedisJson<{ patternIndex?: unknown; cursor?: unknown }>(raw);
+  // The cursor is persisted as `JSON.stringify({ patternIndex, cursor })`.
+  // Upstash's REST client auto-deserializes stored JSON, so on read this can
+  // come back as an OBJECT rather than a string. Handle both shapes — passing
+  // the object straight through would yield `String(obj)` === "[object Object]"
+  // and Redis would reject it as an invalid SCAN cursor.
+  let parsed: { patternIndex?: unknown; cursor?: unknown } | null = null;
+  if (raw && typeof raw === "object") {
+    parsed = raw as { patternIndex?: unknown; cursor?: unknown };
+  } else if (typeof raw === "string" && raw.trim().startsWith("{")) {
+    parsed = parseRedisJson<{ patternIndex?: unknown; cursor?: unknown }>(raw);
+  }
+
+  if (parsed) {
     const patternIndex =
-      typeof parsed?.patternIndex === "number" && parsed.patternIndex >= 0
+      typeof parsed.patternIndex === "number" && parsed.patternIndex >= 0
         ? Math.floor(parsed.patternIndex)
         : 0;
     const cursor =
-      typeof parsed?.cursor === "number" || typeof parsed?.cursor === "string"
+      typeof parsed.cursor === "number" || typeof parsed.cursor === "string"
         ? String(parsed.cursor)
         : "0";
     return { patternIndex, cursor };
   }
-  return { patternIndex: 0, cursor: String(raw) };
+
+  if (typeof raw === "number" || typeof raw === "string") {
+    return { patternIndex: 0, cursor: String(raw) };
+  }
+  return { patternIndex: 0, cursor: "0" };
 }
 
 /**
@@ -161,9 +176,11 @@ async function scanUserBatch(
   maxUsers: number,
   scanCount: number
 ): Promise<{ usernames: string[]; scanComplete: boolean }> {
+  // `get` may return a string, number, or — when Upstash auto-deserializes the
+  // persisted JSON cursor — an object. parseMaintenanceCursor handles all three.
   const startCursor =
-    (await redis.get<string | number>(redisKeys.sync.maintenanceCursor())) ??
-    (await redis.get<string | number>(LEGACY_MAINTENANCE_CURSOR_KEY)) ??
+    (await redis.get<unknown>(redisKeys.sync.maintenanceCursor())) ??
+    (await redis.get<unknown>(LEGACY_MAINTENANCE_CURSOR_KEY)) ??
     "0";
   const patterns = ["sync:v2:user:*:kv", "sync2:kv:*"];
   const startState = parseMaintenanceCursor(startCursor);

--- a/bun.lock
+++ b/bun.lock
@@ -93,6 +93,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.39.2",
+        "@happy-dom/global-registrator": "^20.10.6",
         "@tailwindcss/typography": "^0.5.19",
         "@types/formidable": "^3.4.6",
         "@types/node": "^22",
@@ -109,6 +110,7 @@
         "eslint-plugin-react-hooks": "^5.2.0",
         "eslint-plugin-react-refresh": "^0.4.26",
         "globals": "^15.15.0",
+        "happy-dom": "^20.10.6",
         "playwright": "^1.58.0",
         "tailwindcss": "^4.1.18",
         "typescript": "~5.6.3",
@@ -556,6 +558,8 @@
     "@floating-ui/utils": ["@floating-ui/utils@0.2.9", "", {}, "sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg=="],
 
     "@gar/promisify": ["@gar/promisify@1.1.3", "", {}, "sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw=="],
+
+    "@happy-dom/global-registrator": ["@happy-dom/global-registrator@20.10.6", "", { "dependencies": { "@types/node": ">=20.0.0", "happy-dom": "^20.10.6" } }, "sha512-Nu/IjRkkNxmeG2ywWsyJSO4d1BrWTqVzxCPL+gXj0b97klhmjd6wLzt6Bx/laNpkZ3WLW7zNCqmtMIbIlahqug=="],
 
     "@humanfs/core": ["@humanfs/core@0.19.1", "", {}, "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA=="],
 
@@ -1255,6 +1259,10 @@
 
     "@types/webxr": ["@types/webxr@0.5.21", "", {}, "sha512-geZIAtLzjGmgY2JUi6VxXdCrTb99A7yP49lxLr2Nm/uIK0PkkxcEi4OGhoGDO4pxCf3JwGz2GiJL2Ej4K2bKaA=="],
 
+    "@types/whatwg-mimetype": ["@types/whatwg-mimetype@3.0.2", "", {}, "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA=="],
+
+    "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
+
     "@types/yauzl": ["@types/yauzl@2.10.3", "", { "dependencies": { "@types/node": "*" } }, "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q=="],
 
     "@types/youtube": ["@types/youtube@0.1.2", "", {}, "sha512-n1/KqusanheyQRWHamNZv8K3kydlRqyEsZEKxMTeNWXQTC15lZprITCUt+WgL1vAIvKHCjPBIWz/gf/KQLsB3g=="],
@@ -1512,6 +1520,8 @@
     "buffer-crc32": ["buffer-crc32@0.2.13", "", {}, "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ=="],
 
     "buffer-from": ["buffer-from@1.1.2", "", {}, "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="],
+
+    "buffer-image-size": ["buffer-image-size@0.6.4", "", { "dependencies": { "@types/node": "*" } }, "sha512-nEh+kZOPY1w+gcCMobZ6ETUp9WfibndnosbpwB1iJk/8Gt5ZF2bhS6+B6bPYz424KtwsR6Rflc3tCz1/ghX2dQ=="],
 
     "builder-util": ["builder-util@25.1.7", "", { "dependencies": { "7zip-bin": "~5.2.0", "@types/debug": "^4.1.6", "app-builder-bin": "5.0.0-alpha.10", "bluebird-lst": "^1.0.9", "builder-util-runtime": "9.2.10", "chalk": "^4.1.2", "cross-spawn": "^7.0.3", "debug": "^4.3.4", "fs-extra": "^10.1.0", "http-proxy-agent": "^7.0.0", "https-proxy-agent": "^7.0.0", "is-ci": "^3.0.0", "js-yaml": "^4.1.0", "source-map-support": "^0.5.19", "stat-mode": "^1.0.0", "temp-file": "^3.4.0" } }, "sha512-7jPjzBwEGRbwNcep0gGNpLXG9P94VA3CPAZQCzxkFXiV2GMQKlziMbY//rXPI7WKfhsvGgFXjTcXdBEwgXw9ww=="],
 
@@ -1825,7 +1835,7 @@
 
     "enhanced-resolve": ["enhanced-resolve@5.18.4", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.2.0" } }, "sha512-LgQMM4WXU3QI+SYgEc2liRgznaD5ojbmY3sb8LxyguVkIg5FxdpTkvk72te2R38/TGKxH634oLxXRGY6d7AP+Q=="],
 
-    "entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
+    "entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
 
     "env-paths": ["env-paths@3.0.0", "", {}, "sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A=="],
 
@@ -2038,6 +2048,8 @@
     "hachure-fill": ["hachure-fill@0.5.2", "", {}, "sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg=="],
 
     "hangul-romanization": ["hangul-romanization@1.0.1", "", {}, "sha512-Nh67VGRK0Zet2JRDWII4/RW004XSZyWVySSurM9PEAR1p+7/5Kr8OrrcSYQcQhyGCcBEKyQm98xd+rRnyO0uXg=="],
+
+    "happy-dom": ["happy-dom@20.10.6", "", { "dependencies": { "@types/node": ">=20.0.0", "@types/whatwg-mimetype": "^3.0.2", "@types/ws": "^8.18.1", "buffer-image-size": "^0.6.4", "entities": "^7.0.1", "whatwg-mimetype": "^3.0.0", "ws": "^8.21.0" } }, "sha512-6QD0ilzDDt93tX44y8tbmZdAcdTRYDhUP+Asgi6pC8Pp5IA3cvaZGyoVN/EGtlq9ziT65iPuBBn3ASLr6hCgVw=="],
 
     "has-bigints": ["has-bigints@1.1.0", "", {}, "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg=="],
 
@@ -3315,6 +3327,8 @@
 
     "webidl-conversions": ["webidl-conversions@3.0.1", "", {}, "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="],
 
+    "whatwg-mimetype": ["whatwg-mimetype@3.0.0", "", {}, "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q=="],
+
     "whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
 
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
@@ -3374,6 +3388,8 @@
     "wrap-ansi-cjs": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
 
     "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
+
+    "ws": ["ws@8.21.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g=="],
 
     "xdg-app-paths": ["xdg-app-paths@5.1.0", "", { "dependencies": { "xdg-portable": "^7.0.0" } }, "sha512-RAQ3WkPf4KTU1A8RtFx3gWywzVKe00tfOPFfl2NDGqbIFENQO4kqAJp7mhQjNj/33W5x5hiWWUdyfPq/5SU3QA=="],
 
@@ -3643,6 +3659,8 @@
 
     "@eslint/eslintrc/js-yaml": ["js-yaml@4.1.0", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA=="],
 
+    "@happy-dom/global-registrator/@types/node": ["@types/node@24.13.2", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA=="],
+
     "@humanfs/node/@humanwhocodes/retry": ["@humanwhocodes/retry@0.3.1", "", {}, "sha512-JBxkERygn7Bv/GbN5Rv8Ul6LVknS+5Bp6RgDC/O8gEBU/yeH5Ui5C/OlWrTb6qct7LjjfT6Re2NxB0ln0yYybA=="],
 
     "@isaacs/cliui/string-width": ["string-width@5.1.2", "", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
@@ -3750,6 +3768,8 @@
     "@types/node-fetch/@types/node": ["@types/node@22.13.10", "", { "dependencies": { "undici-types": "~6.20.0" } }, "sha512-I6LPUvlRH+O6VRUqYOcMudhaIdUVWfsjnZavnsraHvpBwaEyMN29ry+0UVJhImYL16xsscu0aske3yA+uPOWfw=="],
 
     "@types/node-fetch/form-data": ["form-data@4.0.2", "", { "dependencies": { "asynckit": "^0.4.0", "combined-stream": "^1.0.8", "es-set-tostringtag": "^2.1.0", "mime-types": "^2.1.12" } }, "sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w=="],
+
+    "@types/ws/@types/node": ["@types/node@24.13.2", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA=="],
 
     "@types/yauzl/@types/node": ["@types/node@24.13.2", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA=="],
 
@@ -3865,6 +3885,8 @@
 
     "browserslist/caniuse-lite": ["caniuse-lite@1.0.30001705", "", {}, "sha512-S0uyMMiYvA7CxNgomYBwwwPUnWzFD83f3B1ce5jHUfHTH//QL6hHsreI8RVC5606R4ssqravelYO5TU6t8sEyg=="],
 
+    "buffer-image-size/@types/node": ["@types/node@24.13.2", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA=="],
+
     "builder-util/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
     "builder-util-runtime/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
@@ -3925,6 +3947,8 @@
 
     "glob/minipass": ["minipass@7.1.2", "", {}, "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw=="],
 
+    "happy-dom/@types/node": ["@types/node@24.13.2", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA=="],
+
     "hosted-git-info/lru-cache": ["lru-cache@6.0.0", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA=="],
 
     "http-proxy-agent/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
@@ -3954,6 +3978,8 @@
     "make-fetch-happen/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
 
     "make-fetch-happen/socks-proxy-agent": ["socks-proxy-agent@6.2.1", "", { "dependencies": { "agent-base": "^6.0.2", "debug": "^4.3.3", "socks": "^2.6.2" } }, "sha512-a6KW9G+6B3nWZ1yB8G7pJwL3ggLy1uTzKAgCb7ttblwqdz9fMGJUuTy3uFzEP48FAs9FLILlmzDlE2JJhVQaXQ=="],
+
+    "markdown-it/entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
 
     "mdast-util-find-and-replace/escape-string-regexp": ["escape-string-regexp@5.0.0", "", {}, "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="],
 
@@ -4423,6 +4449,8 @@
 
     "@electron/universal/minimatch/brace-expansion": ["brace-expansion@2.0.1", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA=="],
 
+    "@happy-dom/global-registrator/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
+
     "@isaacs/cliui/strip-ansi/ansi-regex": ["ansi-regex@6.1.0", "", {}, "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA=="],
 
     "@isaacs/cliui/wrap-ansi/ansi-styles": ["ansi-styles@6.2.1", "", {}, "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug=="],
@@ -4472,6 +4500,8 @@
     "@types/babel__traverse/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.25.9", "", {}, "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ=="],
 
     "@types/node-fetch/@types/node/undici-types": ["undici-types@6.20.0", "", {}, "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg=="],
+
+    "@types/ws/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 
     "@types/yauzl/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 
@@ -4623,6 +4653,8 @@
 
     "assert/util/inherits": ["inherits@2.0.3", "", {}, "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw=="],
 
+    "buffer-image-size/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
+
     "config-file-ts/glob/jackspeak": ["jackspeak@3.4.3", "", { "dependencies": { "@isaacs/cliui": "^8.0.2" }, "optionalDependencies": { "@pkgjs/parseargs": "^0.11.0" } }, "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw=="],
 
     "config-file-ts/glob/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
@@ -4642,6 +4674,8 @@
     "electron/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 
     "filelist/minimatch/brace-expansion": ["brace-expansion@2.0.1", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA=="],
+
+    "happy-dom/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 
     "make-fetch-happen/http-proxy-agent/@tootallnate/once": ["@tootallnate/once@1.1.2", "", {}, "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw=="],
 

--- a/package.json
+++ b/package.json
@@ -162,6 +162,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.39.2",
+    "@happy-dom/global-registrator": "^20.10.6",
     "@tailwindcss/typography": "^0.5.19",
     "@types/formidable": "^3.4.6",
     "@types/node": "^22",
@@ -178,6 +179,7 @@
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.26",
     "globals": "^15.15.0",
+    "happy-dom": "^20.10.6",
     "playwright": "^1.58.0",
     "tailwindcss": "^4.1.18",
     "typescript": "~5.6.3",

--- a/src/lib/pusherClient.ts
+++ b/src/lib/pusherClient.ts
@@ -106,7 +106,15 @@ const PUSHER_APP_KEY = pusherRuntimeConfig.key;
 const PUSHER_CLUSTER = pusherRuntimeConfig.cluster;
 const PUSHER_FORCE_TLS = pusherRuntimeConfig.forceTLS;
 
-const getPusherConstructor = (PusherNamespace: unknown): PusherConstructor => {
+/**
+ * Resolves the Pusher constructor, preferring the module default export and
+ * falling back to a global `Pusher` (set by some script-tag builds). Throws
+ * when neither is available. Exported for unit tests (see
+ * tests/test-pusher-client-constructor-wiring.test.ts).
+ */
+export const getPusherConstructor = (
+  PusherNamespace: unknown
+): PusherConstructor => {
   const constructorFromModule = (
     PusherNamespace as unknown as { default?: PusherConstructor }
   ).default;

--- a/tests/test-admin.test.ts
+++ b/tests/test-admin.test.ts
@@ -1,9 +1,15 @@
 #!/usr/bin/env bun
 /**
  * Tests for /api/admin endpoint
+ *
+ * Admin auth + a throwaway test user are set up once at module load. When the
+ * environment legitimately cannot provide them (admin user pre-exists with a
+ * different password, or setup is rate-limited) the dependent tests are
+ * SKIPPED via `test.skipIf` — reported as skipped rather than silently passing,
+ * so a real auth regression still surfaces (unexpected statuses throw).
  */
 
-import { describe, test, expect, beforeAll } from "bun:test";
+import { describe, test, expect } from "bun:test";
 import {
   BASE_URL,
   fetchWithOrigin,
@@ -17,102 +23,102 @@ const ADMIN_USERNAME = "ryo";
 // Canonical Redis key where the admin user's profile is stored post-cutover.
 const ADMIN_PROFILE_KEY = redisKeys.auth.userProfile(ADMIN_USERNAME);
 const ADMIN_PASSWORD = "testtest";
-let adminToken: string | null = null;
 
-// Test user for deletion tests
-let testUserToken: string | null = null;
-let testUsername: string | null = null;
+async function setupAdminToken(): Promise<string | null> {
+  const res = await fetchWithOrigin(`${BASE_URL}/api/auth/login`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ username: ADMIN_USERNAME, password: ADMIN_PASSWORD }),
+  });
+
+  if (res.status === 200) {
+    const token = getTokenFromAuthCookie(res);
+    if (!token) {
+      throw new Error("admin login succeeded but no auth cookie was returned");
+    }
+    return token;
+  }
+
+  const createRes = await fetchWithOrigin(`${BASE_URL}/api/auth/register`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ username: ADMIN_USERNAME, password: ADMIN_PASSWORD }),
+  });
+
+  if (createRes.status === 201) {
+    const token = getTokenFromAuthCookie(createRes);
+    if (!token) {
+      throw new Error("admin register succeeded but no auth cookie was returned");
+    }
+    return token;
+  }
+
+  // Legit environment limitations -> skip (not fail). Anything else is a real
+  // problem and should blow up the suite.
+  if (createRes.status === 409 || createRes.status === 429) {
+    return null;
+  }
+
+  throw new Error(`Failed to setup admin auth: ${createRes.status}`);
+}
+
+async function setupTestUser(): Promise<{
+  username: string;
+  token: string;
+} | null> {
+  const username = `testuser_${Date.now()}`;
+  const res = await fetchWithOrigin(`${BASE_URL}/api/auth/register`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-Forwarded-For": `10.0.${Date.now() % 255}.${Math.floor(
+        Math.random() * 255
+      )}`,
+    },
+    body: JSON.stringify({ username, password: "testpassword123" }),
+  });
+
+  if (res.status === 201) {
+    const token = getTokenFromAuthCookie(res);
+    if (!token) {
+      throw new Error("test user register succeeded but no auth cookie was returned");
+    }
+    return { username, token };
+  }
+
+  if (res.status === 409) {
+    const loginRes = await fetchWithOrigin(`${BASE_URL}/api/auth/login`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ username, password: "testpassword123" }),
+    });
+    if (loginRes.status === 200) {
+      const token = getTokenFromAuthCookie(loginRes);
+      if (!token) {
+        throw new Error("test user login succeeded but no auth cookie was returned");
+      }
+      return { username, token };
+    }
+  }
+
+  if (res.status === 429) {
+    return null;
+  }
+
+  throw new Error(`Expected 201 when creating test user, got ${res.status}`);
+}
+
+// Top-level setup so the skip conditions are known when tests are defined
+// (`test.skipIf` is evaluated at collection time, not after `beforeAll`).
+const adminToken = await setupAdminToken();
+const testUser = await setupTestUser();
+const testUsername = testUser?.username ?? null;
+const testUserToken = testUser?.token ?? null;
+
+const skipWithoutAdmin = !adminToken;
+const skipWithoutTestUser = !testUserToken || !testUsername;
 
 describe("admin", () => {
-  beforeAll(async () => {
-    // Setup - Admin authentication
-    const res = await fetchWithOrigin(`${BASE_URL}/api/auth/login`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        username: ADMIN_USERNAME,
-        password: ADMIN_PASSWORD,
-      }),
-    });
-
-    if (res.status === 200) {
-      adminToken = getTokenFromAuthCookie(res);
-      expect(adminToken).toBeTruthy();
-      return;
-    }
-
-    const createRes = await fetchWithOrigin(`${BASE_URL}/api/auth/register`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        username: ADMIN_USERNAME,
-        password: ADMIN_PASSWORD,
-      }),
-    });
-
-    if (createRes.status === 201) {
-      adminToken = getTokenFromAuthCookie(createRes);
-      return;
-    }
-
-    if (createRes.status === 409) {
-      console.log("  ⚠️  Admin user exists with a different password; skipping admin-auth tests");
-      return;
-    }
-
-    if (createRes.status === 429) {
-      console.log("  ⚠️  Admin user setup rate-limited; skipping admin-auth tests");
-      return;
-    }
-
-    throw new Error(`Failed to setup admin auth: ${createRes.status}`);
-  });
-
-  beforeAll(async () => {
-    // Setup - Test user
-    testUsername = `testuser_${Date.now()}`;
-    const res = await fetchWithOrigin(`${BASE_URL}/api/auth/register`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        "X-Forwarded-For": `10.0.${Date.now() % 255}.${Math.floor(Math.random() * 255)}`,
-      },
-      body: JSON.stringify({
-        username: testUsername,
-        password: "testpassword123",
-      }),
-    });
-
-    if (res.status === 201) {
-      testUserToken = getTokenFromAuthCookie(res);
-      expect(testUserToken).toBeTruthy();
-      return;
-    }
-
-    if (res.status === 409) {
-      const loginRes = await fetchWithOrigin(`${BASE_URL}/api/auth/login`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          username: testUsername,
-          password: "testpassword123",
-        }),
-      });
-
-      if (loginRes.status === 200) {
-        testUserToken = getTokenFromAuthCookie(loginRes);
-        return;
-      }
-    }
-
-    if (res.status === 429) {
-      console.log("  ⚠️  Test user setup rate-limited; skipping non-admin user tests");
-      return;
-    }
-
-    throw new Error(`Expected 201 when creating test user, got ${res.status}`);
-  });
-
   describe("Admin Access", () => {
     test("GET getStats - without auth (forbidden)", async () => {
       const res = await fetchWithOrigin(`${BASE_URL}/api/admin?action=getStats`, {
@@ -137,272 +143,260 @@ describe("admin", () => {
       expect(data.error).toContain("Forbidden");
     });
 
-    test("GET getStats - with non-admin user (forbidden)", async () => {
-      if (!testUserToken || !testUsername) {
-        console.log("  ⚠️  Skipped (no test user available)");
-        return;
+    test.skipIf(skipWithoutTestUser)(
+      "GET getStats - with non-admin user (forbidden)",
+      async () => {
+        const res = await fetchWithAuth(
+          `${BASE_URL}/api/admin?action=getStats`,
+          testUsername!,
+          testUserToken!,
+          { method: "GET" }
+        );
+
+        expect(res.status).toBe(403);
+        const data = await res.json();
+        expect(data.error).toContain("Forbidden");
       }
+    );
 
-      const res = await fetchWithAuth(
-        `${BASE_URL}/api/admin?action=getStats`,
-        testUsername,
-        testUserToken,
-        { method: "GET" }
-      );
+    test.skipIf(skipWithoutAdmin)(
+      "GET getStats - with admin token",
+      async () => {
+        const res = await fetchWithAuth(
+          `${BASE_URL}/api/admin?action=getStats`,
+          ADMIN_USERNAME,
+          adminToken!,
+          { method: "GET" }
+        );
 
-      expect(res.status).toBe(403);
-      const data = await res.json();
-      expect(data.error).toContain("Forbidden");
-    });
-
-    test("GET getStats - with admin token", async () => {
-      if (!adminToken) {
-        console.log("  ⚠️  Skipped (no admin token available)");
-        return;
+        expect(res.status).toBe(200);
+        const data = await res.json();
+        expect(typeof data.totalUsers).toBe("number");
+        expect(typeof data.totalRooms).toBe("number");
+        expect(typeof data.totalMessages).toBe("number");
+        expect(data.totalUsers).toBeGreaterThanOrEqual(0);
+        expect(data.totalRooms).toBeGreaterThanOrEqual(0);
+        expect(data.totalMessages).toBeGreaterThanOrEqual(0);
       }
+    );
 
-      const res = await fetchWithAuth(
-        `${BASE_URL}/api/admin?action=getStats`,
-        ADMIN_USERNAME,
-        adminToken,
-        { method: "GET" }
-      );
+    test.skipIf(skipWithoutAdmin)(
+      "GET getCursorAgentRuns - with admin token",
+      async () => {
+        const res = await fetchWithAuth(
+          `${BASE_URL}/api/admin?action=getCursorAgentRuns&limit=10`,
+          ADMIN_USERNAME,
+          adminToken!,
+          { method: "GET" }
+        );
 
-      expect(res.status).toBe(200);
-      const data = await res.json();
-      expect(typeof data.totalUsers).toBe("number");
-      expect(typeof data.totalRooms).toBe("number");
-      expect(typeof data.totalMessages).toBe("number");
-      expect(data.totalUsers).toBeGreaterThanOrEqual(0);
-      expect(data.totalRooms).toBeGreaterThanOrEqual(0);
-      expect(data.totalMessages).toBeGreaterThanOrEqual(0);
-    });
-
-    test("GET getCursorAgentRuns - with admin token", async () => {
-      if (!adminToken) {
-        console.log("  ⚠️  Skipped (no admin token available)");
-        return;
+        expect(res.status).toBe(200);
+        const data = await res.json();
+        expect(Array.isArray(data.runs)).toBe(true);
+        expect(typeof data.truncated).toBe("boolean");
+        expect(typeof data.totalCount).toBe("number");
       }
-
-      const res = await fetchWithAuth(
-        `${BASE_URL}/api/admin?action=getCursorAgentRuns&limit=10`,
-        ADMIN_USERNAME,
-        adminToken,
-        { method: "GET" }
-      );
-
-      expect(res.status).toBe(200);
-      const data = await res.json();
-      expect(Array.isArray(data.runs)).toBe(true);
-      expect(typeof data.truncated).toBe("boolean");
-      expect(typeof data.totalCount).toBe("number");
-    });
+    );
   });
 
   describe("Admin Operations", () => {
-    test("GET getAllUsers - with admin token", async () => {
-      if (!adminToken) {
-        console.log("  ⚠️  Skipped (no admin token available)");
-        return;
+    test.skipIf(skipWithoutAdmin)(
+      "GET getAllUsers - with admin token",
+      async () => {
+        const res = await fetchWithAuth(
+          `${BASE_URL}/api/admin?action=getAllUsers`,
+          ADMIN_USERNAME,
+          adminToken!,
+          { method: "GET" }
+        );
+
+        expect(res.status).toBe(200);
+        const data = await res.json();
+        expect(Array.isArray(data.users)).toBe(true);
+        expect(data.users.length).toBeGreaterThan(0);
+
+        const adminUser = data.users.find(
+          (u: { username: string }) =>
+            u.username.toLowerCase() === ADMIN_USERNAME.toLowerCase()
+        );
+        expect(adminUser).toBeTruthy();
+        expect(typeof adminUser.lastActive).toBe("number");
       }
+    );
 
-      const res = await fetchWithAuth(
-        `${BASE_URL}/api/admin?action=getAllUsers`,
-        ADMIN_USERNAME,
-        adminToken,
-        { method: "GET" }
-      );
+    test.skipIf(skipWithoutAdmin)(
+      "GET listRedisKeys - with admin token",
+      async () => {
+        const res = await fetchWithAuth(
+          `${BASE_URL}/api/admin?action=listRedisKeys&pattern=${encodeURIComponent(
+            ADMIN_PROFILE_KEY
+          )}&count=10`,
+          ADMIN_USERNAME,
+          adminToken!,
+          { method: "GET" }
+        );
 
-      expect(res.status).toBe(200);
-      const data = await res.json();
-      expect(Array.isArray(data.users)).toBe(true);
-      expect(data.users.length).toBeGreaterThan(0);
-
-      const adminUser = data.users.find(
-        (u: { username: string }) => u.username.toLowerCase() === ADMIN_USERNAME.toLowerCase()
-      );
-      expect(adminUser).toBeTruthy();
-      expect(typeof adminUser.lastActive).toBe("number");
-    });
-
-    test("GET listRedisKeys - with admin token", async () => {
-      if (!adminToken) {
-        console.log("  ⚠️  Skipped (no admin token available)");
-        return;
+        expect(res.status).toBe(200);
+        const data = await res.json();
+        expect(Array.isArray(data.keys)).toBe(true);
+        expect(
+          data.keys.some((key: { key: string }) => key.key === ADMIN_PROFILE_KEY)
+        ).toBe(true);
+        const adminKey = data.keys.find(
+          (key: { key: string }) => key.key === ADMIN_PROFILE_KEY
+        );
+        expect(adminKey.type).toBe("string");
+        expect(typeof adminKey.ttl).toBe("number");
       }
+    );
 
-      const res = await fetchWithAuth(
-        `${BASE_URL}/api/admin?action=listRedisKeys&pattern=${encodeURIComponent(ADMIN_PROFILE_KEY)}&count=10`,
-        ADMIN_USERNAME,
-        adminToken,
-        { method: "GET" }
-      );
+    test.skipIf(skipWithoutAdmin)(
+      "GET getRedisKey - with admin token",
+      async () => {
+        const redisKey = ADMIN_PROFILE_KEY;
+        const res = await fetchWithAuth(
+          `${BASE_URL}/api/admin?action=getRedisKey&key=${encodeURIComponent(
+            redisKey
+          )}`,
+          ADMIN_USERNAME,
+          adminToken!,
+          { method: "GET" }
+        );
 
-      expect(res.status).toBe(200);
-      const data = await res.json();
-      expect(Array.isArray(data.keys)).toBe(true);
-      expect(data.keys.some((key: { key: string }) => key.key === ADMIN_PROFILE_KEY)).toBe(true);
-      const adminKey = data.keys.find((key: { key: string }) => key.key === ADMIN_PROFILE_KEY);
-      expect(adminKey.type).toBe("string");
-      expect(typeof adminKey.ttl).toBe("number");
-    });
-
-    test("GET getRedisKey - with admin token", async () => {
-      if (!adminToken) {
-        console.log("  ⚠️  Skipped (no admin token available)");
-        return;
+        expect(res.status).toBe(200);
+        const data = await res.json();
+        expect(data.key).toBe(redisKey);
+        expect(data.type).toBe("string");
+        const valueText =
+          typeof data.value === "string"
+            ? data.value
+            : JSON.stringify(data.value);
+        expect(valueText).toContain(ADMIN_USERNAME);
       }
+    );
 
-      const redisKey = ADMIN_PROFILE_KEY;
-      const res = await fetchWithAuth(
-        `${BASE_URL}/api/admin?action=getRedisKey&key=${encodeURIComponent(redisKey)}`,
-        ADMIN_USERNAME,
-        adminToken,
-        { method: "GET" }
-      );
+    test.skipIf(skipWithoutAdmin)(
+      "GET backupRedisKeys - with admin token",
+      async () => {
+        const res = await fetchWithAuth(
+          `${BASE_URL}/api/admin?action=backupRedisKeys&pattern=${encodeURIComponent(
+            ADMIN_PROFILE_KEY
+          )}&limit=10`,
+          ADMIN_USERNAME,
+          adminToken!,
+          { method: "GET" }
+        );
 
-      expect(res.status).toBe(200);
-      const data = await res.json();
-      expect(data.key).toBe(redisKey);
-      expect(data.type).toBe("string");
-      const valueText =
-        typeof data.value === "string" ? data.value : JSON.stringify(data.value);
-      expect(valueText).toContain(ADMIN_USERNAME);
-    });
-
-    test("GET backupRedisKeys - with admin token", async () => {
-      if (!adminToken) {
-        console.log("  ⚠️  Skipped (no admin token available)");
-        return;
+        expect(res.status).toBe(200);
+        const data = await res.json();
+        expect(data.pattern).toBe(ADMIN_PROFILE_KEY);
+        expect(data.keyCount).toBeGreaterThanOrEqual(1);
+        expect(Array.isArray(data.keys)).toBe(true);
+        expect(
+          data.keys.some((key: { key: string }) => key.key === ADMIN_PROFILE_KEY)
+        ).toBe(true);
       }
+    );
 
-      const res = await fetchWithAuth(
-        `${BASE_URL}/api/admin?action=backupRedisKeys&pattern=${encodeURIComponent(ADMIN_PROFILE_KEY)}&limit=10`,
-        ADMIN_USERNAME,
-        adminToken,
-        { method: "GET" }
-      );
+    test.skipIf(skipWithoutAdmin)(
+      "POST deleteRedisKey - requires exact confirmation",
+      async () => {
+        const res = await fetchWithAuth(
+          `${BASE_URL}/api/admin`,
+          ADMIN_USERNAME,
+          adminToken!,
+          {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              action: "deleteRedisKey",
+              key: ADMIN_PROFILE_KEY,
+              confirmKey: "wrong-key",
+            }),
+          }
+        );
 
-      expect(res.status).toBe(200);
-      const data = await res.json();
-      expect(data.pattern).toBe(ADMIN_PROFILE_KEY);
-      expect(data.keyCount).toBeGreaterThanOrEqual(1);
-      expect(Array.isArray(data.keys)).toBe(true);
-      expect(data.keys.some((key: { key: string }) => key.key === ADMIN_PROFILE_KEY)).toBe(true);
-    });
-
-    test("POST deleteRedisKey - requires exact confirmation", async () => {
-      if (!adminToken) {
-        console.log("  ⚠️  Skipped (no admin token available)");
-        return;
+        expect(res.status).toBe(400);
+        const data = await res.json();
+        expect(data.error).toContain("Confirmation");
       }
+    );
 
-      const res = await fetchWithAuth(
-        `${BASE_URL}/api/admin`,
-        ADMIN_USERNAME,
-        adminToken,
-        {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            action: "deleteRedisKey",
-            key: ADMIN_PROFILE_KEY,
-            confirmKey: "wrong-key",
-          }),
-        }
-      );
+    test.skipIf(skipWithoutAdmin)(
+      "POST deleteUser - missing target username",
+      async () => {
+        const res = await fetchWithAuth(
+          `${BASE_URL}/api/admin`,
+          ADMIN_USERNAME,
+          adminToken!,
+          {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              action: "deleteUser",
+            }),
+          }
+        );
 
-      expect(res.status).toBe(400);
-      const data = await res.json();
-      expect(data.error).toContain("Confirmation");
-    });
-
-    test("POST deleteUser - missing target username", async () => {
-      if (!adminToken) {
-        console.log("  ⚠️  Skipped (no admin token available)");
-        return;
+        expect(res.status).toBe(400);
+        const data = await res.json();
+        expect(data.error).toContain("Target username");
       }
+    );
 
-      const res = await fetchWithAuth(
-        `${BASE_URL}/api/admin`,
-        ADMIN_USERNAME,
-        adminToken,
-        {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            action: "deleteUser",
-          }),
-        }
-      );
+    test.skipIf(skipWithoutAdmin)(
+      "POST deleteUser - try to delete admin (forbidden)",
+      async () => {
+        const res = await fetchWithAuth(
+          `${BASE_URL}/api/admin`,
+          ADMIN_USERNAME,
+          adminToken!,
+          {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              action: "deleteUser",
+              targetUsername: ADMIN_USERNAME,
+            }),
+          }
+        );
 
-      expect(res.status).toBe(400);
-      const data = await res.json();
-      expect(data.error).toContain("Target username");
-    });
-
-    test("POST deleteUser - try to delete admin (forbidden)", async () => {
-      if (!adminToken) {
-        console.log("  ⚠️  Skipped (no admin token available)");
-        return;
+        expect(res.status).toBe(400);
+        const data = await res.json();
+        expect(data.error).toContain("admin");
       }
+    );
 
-      const res = await fetchWithAuth(
-        `${BASE_URL}/api/admin`,
-        ADMIN_USERNAME,
-        adminToken,
-        {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            action: "deleteUser",
-            targetUsername: ADMIN_USERNAME,
-          }),
-        }
-      );
+    test.skipIf(skipWithoutAdmin || skipWithoutTestUser)(
+      "POST deleteUser - delete test user",
+      async () => {
+        const res = await fetchWithAuth(
+          `${BASE_URL}/api/admin`,
+          ADMIN_USERNAME,
+          adminToken!,
+          {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              action: "deleteUser",
+              targetUsername: testUsername!,
+            }),
+          }
+        );
 
-      expect(res.status).toBe(400);
-      const data = await res.json();
-      expect(data.error).toContain("admin");
-    });
-
-    test("POST deleteUser - delete test user", async () => {
-      if (!adminToken || !testUsername) {
-        console.log("  ⚠️  Skipped (no admin token or test user available)");
-        return;
+        expect(res.status).toBe(200);
+        const data = await res.json();
+        expect(data.success).toBe(true);
       }
-
-      const res = await fetchWithAuth(
-        `${BASE_URL}/api/admin`,
-        ADMIN_USERNAME,
-        adminToken,
-        {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            action: "deleteUser",
-            targetUsername: testUsername,
-          }),
-        }
-      );
-
-      expect(res.status).toBe(200);
-      const data = await res.json();
-      expect(data.success).toBe(true);
-    });
+    );
   });
 
   describe("Error Cases", () => {
-    test("GET invalid action", async () => {
-      if (!adminToken) {
-        console.log("  ⚠️  Skipped (no admin token available)");
-        return;
-      }
-
+    test.skipIf(skipWithoutAdmin)("GET invalid action", async () => {
       const res = await fetchWithAuth(
         `${BASE_URL}/api/admin?action=invalidAction`,
         ADMIN_USERNAME,
-        adminToken,
+        adminToken!,
         { method: "GET" }
       );
 
@@ -411,16 +405,11 @@ describe("admin", () => {
       expect(data.error).toContain("Invalid action");
     });
 
-    test("PUT invalid method", async () => {
-      if (!adminToken) {
-        console.log("  ⚠️  Skipped (no admin token available)");
-        return;
-      }
-
+    test.skipIf(skipWithoutAdmin)("PUT invalid method", async () => {
       const res = await fetchWithAuth(
         `${BASE_URL}/api/admin?action=getStats`,
         ADMIN_USERNAME,
-        adminToken,
+        adminToken!,
         { method: "PUT" }
       );
 

--- a/tests/test-ai.test.ts
+++ b/tests/test-ai.test.ts
@@ -1,10 +1,18 @@
-import { describe, test, expect } from "bun:test";
+import { describe, test, expect, beforeAll } from "bun:test";
 
 import {
   BASE_URL,
   fetchWithOrigin,
   fetchWithAuth,
+  ensureUserAuth,
 } from "./test-utils";
+
+// A real authenticated user so the ryo-reply input-validation tests actually
+// reach the validation branches (with an invalid token they only ever got
+// 401, so the 400 paths were never exercised). Created fresh per run to avoid
+// the per-user 5/min rate limit accumulating across re-runs.
+const ryoReplyUsername = `tuser${Date.now()}`;
+let ryoReplyToken: string | null = null;
 /**
  * Tests for AI-related API endpoints
  * Tests: /api/chat, /api/applet-ai, /api/ie-generate, /api/ai/ryo-reply
@@ -25,7 +33,7 @@ async function testChatOptionsRequest(): Promise<void> {
   const res = await fetchWithOrigin(`${BASE_URL}/api/chat`, {
     method: "OPTIONS",
   });
-  expect(res.status === 200 || res.status === 204).toBeTruthy();
+  expect([200, 204]).toContain(res.status);
 }
 
 async function testChatMissingMessages(): Promise<void> {
@@ -34,7 +42,7 @@ async function testChatMissingMessages(): Promise<void> {
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({}),
   });
-  expect(res.status === 400 || res.status === 429).toBeTruthy();
+  expect([400, 429]).toContain(res.status);
 }
 
 async function testChatInvalidMessagesFormat(): Promise<void> {
@@ -43,7 +51,7 @@ async function testChatInvalidMessagesFormat(): Promise<void> {
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ messages: "not an array" }),
   });
-  expect(res.status === 400 || res.status === 429).toBeTruthy();
+  expect([400, 429]).toContain(res.status);
 }
 
 async function testChatInvalidModel(): Promise<void> {
@@ -57,7 +65,7 @@ async function testChatInvalidModel(): Promise<void> {
   });
   // Rate limiting is checked before model validation, so may get 429 first
   // Otherwise expect 400 for invalid model
-  expect(res.status === 400 || res.status === 429).toBeTruthy();
+  expect([400, 429]).toContain(res.status);
 }
 
 async function testChatInvalidJson(): Promise<void> {
@@ -66,7 +74,7 @@ async function testChatInvalidJson(): Promise<void> {
     headers: { "Content-Type": "application/json" },
     body: "not valid json{",
   });
-  expect(res.status >= 400).toBeTruthy();
+  expect(res.status).toBeGreaterThanOrEqual(400);
 }
 
 async function testChatInvalidAuthToken(): Promise<void> {
@@ -95,10 +103,10 @@ async function testChatBasicRequest(): Promise<void> {
   });
   if (res.status === 200) {
     const contentType = res.headers.get("content-type") || "";
-    expect(contentType.includes("text/") || contentType.includes("stream")).toBeTruthy();
+    expect(contentType).toMatch(/text\/|stream/);
   } else if (res.status === 429) {
     const data = await res.json();
-    expect(data.error === "rate_limit_exceeded").toBeTruthy();
+    expect(data.error).toBe("rate_limit_exceeded");
   } else {
     throw new Error(`Unexpected status: ${res.status}`);
   }
@@ -112,7 +120,7 @@ async function testChatWithModelQuery(): Promise<void> {
       messages: [{ role: "user", content: "Say hi" }],
     }),
   });
-  expect(res.status === 200 || res.status === 429).toBeTruthy();
+  expect([200, 429]).toContain(res.status);
 }
 
 // ============================================================================
@@ -130,7 +138,7 @@ async function testAppletAiOptionsRequest(): Promise<void> {
   const res = await fetchWithOrigin(`${BASE_URL}/api/applet-ai`, {
     method: "OPTIONS",
   });
-  expect(res.status === 200 || res.status === 204).toBeTruthy();
+  expect([200, 204]).toContain(res.status);
 }
 
 async function testAppletAiMissingPromptAndMessages(): Promise<void> {
@@ -188,7 +196,7 @@ async function testAppletAiInvalidJson(): Promise<void> {
     headers: { "Content-Type": "application/json" },
     body: "not valid json{",
   });
-  expect(res.status >= 400).toBeTruthy();
+  expect(res.status).toBeGreaterThanOrEqual(400);
 }
 
 async function testAppletAiInvalidAuthToken(): Promise<void> {
@@ -213,11 +221,11 @@ async function testAppletAiBasicTextRequest(): Promise<void> {
   });
   if (res.status === 200) {
     const data = await res.json();
-    expect(typeof data.reply === "string").toBeTruthy();
-    expect(data.reply.length > 0).toBeTruthy();
+    expect(typeof data.reply).toBe("string");
+    expect(data.reply.length).toBeGreaterThan(0);
   } else if (res.status === 429) {
     const data = await res.json();
-    expect(data.error === "rate_limit_exceeded").toBeTruthy();
+    expect(data.error).toBe("rate_limit_exceeded");
   } else {
     throw new Error(`Unexpected status: ${res.status}`);
   }
@@ -232,7 +240,7 @@ async function testAppletAiWithContext(): Promise<void> {
       context: "You are a calculator assistant.",
     }),
   });
-  expect(res.status === 200 || res.status === 429).toBeTruthy();
+  expect([200, 429]).toContain(res.status);
 }
 
 async function testAppletAiWithMessagesArray(): Promise<void> {
@@ -247,7 +255,7 @@ async function testAppletAiWithMessagesArray(): Promise<void> {
       ],
     }),
   });
-  expect(res.status === 200 || res.status === 429).toBeTruthy();
+  expect([200, 429]).toContain(res.status);
 }
 
 async function testAppletAiInvalidImageModeWithoutPrompt(): Promise<void> {
@@ -279,13 +287,13 @@ async function testAppletAiRateLimitHeaders(): Promise<void> {
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ prompt: "Rate limit test" }),
   });
+  expect([200, 400, 429]).toContain(res.status);
   if (res.status === 429) {
     const retryAfter = res.headers.get("Retry-After");
-    expect(retryAfter !== null).toBeTruthy();
+    expect(retryAfter).not.toBeNull();
     const limitHeader = res.headers.get("X-RateLimit-Limit");
-    expect(limitHeader !== null).toBeTruthy();
+    expect(limitHeader).not.toBeNull();
   }
-  expect(true).toBeTruthy();
 }
 
 // ============================================================================
@@ -303,7 +311,7 @@ async function testIeGenerateOptionsRequest(): Promise<void> {
   const res = await fetchWithOrigin(`${BASE_URL}/api/ie-generate`, {
     method: "OPTIONS",
   });
-  expect(res.status === 200 || res.status === 204).toBeTruthy();
+  expect([200, 204]).toContain(res.status);
 }
 
 async function testIeGenerateInvalidMessagesFormat(): Promise<void> {
@@ -313,7 +321,7 @@ async function testIeGenerateInvalidMessagesFormat(): Promise<void> {
     body: JSON.stringify({ messages: "not an array" }),
   });
   // Rate limiting may be checked before input validation, so 429 is also acceptable
-  expect(res.status === 400 || res.status === 429).toBeTruthy();
+  expect([400, 429]).toContain(res.status);
 }
 
 async function testIeGenerateInvalidModel(): Promise<void> {
@@ -328,7 +336,7 @@ async function testIeGenerateInvalidModel(): Promise<void> {
     }),
   });
   // Rate limiting may be checked before model validation, so 429 is also acceptable
-  expect(res.status === 400 || res.status === 429).toBeTruthy();
+  expect([400, 429]).toContain(res.status);
 }
 
 async function testIeGenerateInvalidJson(): Promise<void> {
@@ -337,7 +345,7 @@ async function testIeGenerateInvalidJson(): Promise<void> {
     headers: { "Content-Type": "application/json" },
     body: "not valid json{",
   });
-  expect(res.status >= 400).toBeTruthy();
+  expect(res.status).toBeGreaterThanOrEqual(400);
 }
 
 async function testIeGenerateBasicRequest(): Promise<void> {
@@ -350,10 +358,10 @@ async function testIeGenerateBasicRequest(): Promise<void> {
   });
   if (res.status === 200) {
     const contentType = res.headers.get("content-type") || "";
-    expect(contentType.includes("text/") || contentType.includes("stream")).toBeTruthy();
+    expect(contentType).toMatch(/text\/|stream/);
   } else if (res.status === 429) {
     const data = await res.json();
-    expect(data.error === "rate_limit_exceeded").toBeTruthy();
+    expect(data.error).toBe("rate_limit_exceeded");
   } else {
     throw new Error(`Unexpected status: ${res.status}`);
   }
@@ -369,7 +377,7 @@ async function testIeGenerateWithBodyParams(): Promise<void> {
       messages: [{ role: "user", content: "Generate a futuristic page" }],
     }),
   });
-  expect(res.status === 200 || res.status === 429).toBeTruthy();
+  expect([200, 429]).toContain(res.status);
 }
 
 async function testIeGenerateRateLimitBurst(): Promise<void> {
@@ -383,13 +391,13 @@ async function testIeGenerateRateLimitBurst(): Promise<void> {
       messages: [{ role: "user", content: "Test" }],
     }),
   });
+  expect([200, 400, 429]).toContain(res.status);
   if (res.status === 429) {
     const data = await res.json();
-    expect(data.error === "rate_limit_exceeded").toBeTruthy();
-    expect(typeof data.scope === "string").toBeTruthy();
-    expect(typeof data.limit === "number").toBeTruthy();
+    expect(data.error).toBe("rate_limit_exceeded");
+    expect(typeof data.scope).toBe("string");
+    expect(typeof data.limit).toBe("number");
   }
-  expect(true).toBeTruthy();
 }
 
 // ============================================================================
@@ -407,7 +415,7 @@ async function testRyoReplyOptionsRequest(): Promise<void> {
   const res = await fetchWithOrigin(`${BASE_URL}/api/ai/ryo-reply`, {
     method: "OPTIONS",
   });
-  expect(res.status === 200 || res.status === 204).toBeTruthy();
+  expect([200, 204]).toContain(res.status);
 }
 
 async function testRyoReplyMissingAuth(): Promise<void> {
@@ -433,63 +441,61 @@ async function testRyoReplyInvalidAuthToken(): Promise<void> {
   expect(res.status).toBe(401);
 }
 
-async function testRyoReplyMissingRoomId(): Promise<void> {
+async function testRyoReplyBlankRoomId(): Promise<void> {
+  // A blank roomId fails ROOM_ID_REGEX validation -> 400.
   const res = await fetchWithAuth(
     `${BASE_URL}/api/ai/ryo-reply`,
-    "testuser",
-    "some-token",
+    ryoReplyUsername,
+    ryoReplyToken ?? "",
     {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ prompt: "Hello" }),
+      body: JSON.stringify({ roomId: "", prompt: "Hello" }),
     }
   );
-  // Will fail auth first (401) since token is invalid, which is expected
-  expect(res.status === 400 || res.status === 401).toBeTruthy();
+  expect(res.status).toBe(400);
 }
 
 async function testRyoReplyMissingPrompt(): Promise<void> {
   const res = await fetchWithAuth(
     `${BASE_URL}/api/ai/ryo-reply`,
-    "testuser",
-    "some-token",
+    ryoReplyUsername,
+    ryoReplyToken ?? "",
     {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ roomId: "test-room" }),
+      body: JSON.stringify({ roomId: "testroom123" }),
     }
   );
-  // Will fail auth first (401) since token is invalid, which is expected
-  expect(res.status === 400 || res.status === 401).toBeTruthy();
+  expect(res.status).toBe(400);
 }
 
 async function testRyoReplyInvalidRoomId(): Promise<void> {
   const res = await fetchWithAuth(
     `${BASE_URL}/api/ai/ryo-reply`,
-    "testuser",
-    "some-token",
+    ryoReplyUsername,
+    ryoReplyToken ?? "",
     {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ roomId: "invalid/room/id!", prompt: "Hello" }),
     }
   );
-  // Will fail auth first (401) or validation (400)
-  expect(res.status === 400 || res.status === 401).toBeTruthy();
+  expect(res.status).toBe(400);
 }
 
 async function testRyoReplyInvalidJson(): Promise<void> {
   const res = await fetchWithAuth(
     `${BASE_URL}/api/ai/ryo-reply`,
-    "testuser",
-    "some-token",
+    ryoReplyUsername,
+    ryoReplyToken ?? "",
     {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: "not valid json{",
     }
   );
-  expect(res.status >= 400).toBeTruthy();
+  expect(res.status).toBe(400);
 }
 
 // ============================================================================
@@ -651,8 +657,12 @@ describe("Ai", () => {
   });
 
   describe("AI Endpoints - /api/ai/ryo-reply - Input Validation", () => {
-    test("Missing roomId", async () => {
-      await testRyoReplyMissingRoomId();
+    beforeAll(async () => {
+      ryoReplyToken = await ensureUserAuth(ryoReplyUsername, "passw0rd123");
+    });
+
+    test("Blank roomId", async () => {
+      await testRyoReplyBlankRoomId();
     });
     test("Missing prompt", async () => {
       await testRyoReplyMissingPrompt();

--- a/tests/test-auth-ban-lockout.test.ts
+++ b/tests/test-auth-ban-lockout.test.ts
@@ -125,8 +125,10 @@ describe("register login lockout (shared with /api/auth/login)", () => {
       const res = await register(user, "definitely-wrong-password");
       last = res.status;
     }
-    // After crossing the threshold, register returns 429 (locked), not 409.
-    expect(last === 429 || last === 409).toBe(true);
+    // The final loop attempt is either the last wrong-password 409 or the
+    // first locked 429 (depends on exactly when the threshold trips); the
+    // assertion below pins that the account is definitively locked afterwards.
+    expect([409, 429]).toContain(last);
 
     const lockedRegister = await register(user, "definitely-wrong-password");
     expect(lockedRegister.status).toBe(429);

--- a/tests/test-background-task.test.ts
+++ b/tests/test-background-task.test.ts
@@ -3,16 +3,24 @@
  * (src/utils/backgroundTask.ts).
  *
  * The pure scheduling logic is exercised by injecting a fake visibility
- * source (getter + change-event emitter) and using small real delays.
- * Without injected options the helper must degrade to a plain setInterval
- * (bun:test has no `document`), which keeps it SSR/test safe.
+ * source (getter + change-event emitter) and Bun's fake timers, so we can
+ * advance time by exact amounts and assert exact tick counts instead of
+ * sleeping past the interval and using `>=` fuzz. Without injected options the
+ * helper must degrade to a plain setInterval (bun:test has no `document`),
+ * which keeps it SSR/test safe.
  */
 
-import { describe, test, expect } from "bun:test";
+import { describe, test, expect, beforeEach, afterEach, jest } from "bun:test";
 
 import { createVisibilityGatedInterval } from "../src/utils/backgroundTask";
 
-const sleep = (ms: number) => new Promise<void>((res) => setTimeout(res, ms));
+beforeEach(() => {
+  jest.useFakeTimers();
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+});
 
 /** Fake visibility source: a getter plus a manual change-event emitter. */
 const createFakeVisibility = (initiallyVisible: boolean) => {
@@ -35,55 +43,56 @@ const createFakeVisibility = (initiallyVisible: boolean) => {
 };
 
 describe("createVisibilityGatedInterval", () => {
-  test("runs the callback on the interval cadence while visible", async () => {
+  test("runs the callback on the interval cadence while visible", () => {
     const visibility = createFakeVisibility(true);
     let calls = 0;
     const dispose = createVisibilityGatedInterval(() => calls++, 40, visibility);
 
-    await sleep(150);
+    // Ticks fire at 40/80/120ms.
+    jest.advanceTimersByTime(150);
     dispose();
 
-    expect(calls).toBeGreaterThanOrEqual(2);
+    expect(calls).toBe(3);
   });
 
-  test("does not run while hidden", async () => {
+  test("does not run while hidden", () => {
     const visibility = createFakeVisibility(false);
     let calls = 0;
     const dispose = createVisibilityGatedInterval(() => calls++, 30, visibility);
 
-    await sleep(120);
+    jest.advanceTimersByTime(120);
     dispose();
 
     expect(calls).toBe(0);
   });
 
-  test("pauses when the document becomes hidden", async () => {
+  test("pauses when the document becomes hidden", () => {
     const visibility = createFakeVisibility(true);
     let calls = 0;
     const dispose = createVisibilityGatedInterval(() => calls++, 40, visibility);
 
-    await sleep(60); // at least one tick
+    jest.advanceTimersByTime(60); // one tick at 40ms
     visibility.setVisible(false);
     const callsWhenHidden = calls;
 
-    await sleep(120);
+    jest.advanceTimersByTime(120);
     dispose();
 
-    expect(callsWhenHidden).toBeGreaterThanOrEqual(1);
+    expect(callsWhenHidden).toBe(1);
     expect(calls).toBe(callsWhenHidden);
   });
 
-  test("runs immediately on becoming visible when the last run is overdue", async () => {
+  test("runs immediately on becoming visible when the last run is overdue", () => {
     const visibility = createFakeVisibility(true);
     let calls = 0;
     const dispose = createVisibilityGatedInterval(() => calls++, 50, visibility);
 
-    await sleep(70); // first tick fires (~50ms)
+    jest.advanceTimersByTime(70); // first tick fires at 50ms
     visibility.setVisible(false);
     const callsBeforeHide = calls;
-    expect(callsBeforeHide).toBeGreaterThanOrEqual(1);
+    expect(callsBeforeHide).toBe(1);
 
-    await sleep(80); // hidden for longer than the interval
+    jest.advanceTimersByTime(80); // hidden for longer than the interval
     visibility.setVisible(true);
 
     // Catch-up run happens synchronously inside the visibility handler.
@@ -91,12 +100,12 @@ describe("createVisibilityGatedInterval", () => {
     dispose();
   });
 
-  test("does not run immediately on becoming visible when the last run is fresh", async () => {
+  test("does not run immediately on becoming visible when the last run is fresh", () => {
     const visibility = createFakeVisibility(true);
     let calls = 0;
     const dispose = createVisibilityGatedInterval(() => calls++, 200, visibility);
 
-    await sleep(20); // well within the interval; no tick yet
+    jest.advanceTimersByTime(20); // well within the interval; no tick yet
     visibility.setVisible(false);
     visibility.setVisible(true);
 
@@ -104,7 +113,7 @@ describe("createVisibilityGatedInterval", () => {
     dispose();
   });
 
-  test("dispose stops the interval and unsubscribes from visibility changes", async () => {
+  test("dispose stops the interval and unsubscribes from visibility changes", () => {
     const visibility = createFakeVisibility(true);
     let calls = 0;
     const dispose = createVisibilityGatedInterval(() => calls++, 30, visibility);
@@ -113,26 +122,27 @@ describe("createVisibilityGatedInterval", () => {
     dispose();
     expect(visibility.handlerCount()).toBe(0);
 
-    await sleep(100);
+    jest.advanceTimersByTime(100);
     expect(calls).toBe(0);
 
     // Visibility flapping after dispose must not restart anything.
     visibility.setVisible(false);
     visibility.setVisible(true);
-    await sleep(80);
+    jest.advanceTimersByTime(80);
     expect(calls).toBe(0);
   });
 
-  test("falls back to a plain interval when document is undefined", async () => {
+  test("falls back to a plain interval when document is undefined", () => {
     // bun:test has no DOM, so the default options exercise the SSR path.
     expect(typeof document).toBe("undefined");
 
     let calls = 0;
     const dispose = createVisibilityGatedInterval(() => calls++, 40, {});
 
-    await sleep(150);
+    // Ticks fire at 40/80/120ms.
+    jest.advanceTimersByTime(150);
     dispose();
 
-    expect(calls).toBeGreaterThanOrEqual(2);
+    expect(calls).toBe(3);
   });
 });

--- a/tests/test-chat-auth-api-wiring.test.ts
+++ b/tests/test-chat-auth-api-wiring.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 
+import * as authApi from "../src/api/auth";
+
 const storeSource = readFileSync("src/stores/useChatsStore.ts", "utf8");
-const authApiSource = readFileSync("src/api/auth.ts", "utf8");
 
 describe("chat auth API wiring", () => {
   test("routes auth HTTP calls through src/api/auth", () => {
@@ -31,8 +32,12 @@ describe("chat auth API wiring", () => {
   });
 
   test("auth API exports session and password helpers", () => {
-    for (const symbol of ["checkUserPassword", "getAuthSession", "logoutUserSafe"]) {
-      expect(authApiSource).toContain(`function ${symbol}`);
+    for (const symbol of [
+      "checkUserPassword",
+      "getAuthSession",
+      "logoutUserSafe",
+    ] as const) {
+      expect(typeof authApi[symbol]).toBe("function");
     }
   });
 });

--- a/tests/test-chat-broadcast-wiring.test.ts
+++ b/tests/test-chat-broadcast-wiring.test.ts
@@ -19,7 +19,7 @@ const assertHasCall = (
   fnName: string
 ): void => {
   const callPattern = new RegExp(`\\b${fnName}\\s*\\(`);
-  expect(callPattern.test(source)).toBe(true);
+  expect(source).toMatch(callPattern);
 };
 
 const countCalls = (source: string, fnName: string): number => {
@@ -49,9 +49,9 @@ describe("Chat Broadcast Wiring Tests", () => {
     test("presence switch route emits room-updated", async () => {
       const source = readRoute("api/presence/switch.ts");
       assertHasCall(source, "broadcastRoomUpdated");
-      expect(countCalls(source, "broadcastRoomUpdated") >= 2).toBe(true);
-      expect(/broadcastRoomUpdated\s*\(\s*previousRoomId\s*\)/.test(source)).toBe(true);
-      expect(/broadcastRoomUpdated\s*\(\s*nextRoomId\s*\)/.test(source)).toBe(true);
+      expect(countCalls(source, "broadcastRoomUpdated")).toBeGreaterThanOrEqual(2);
+      expect(source).toMatch(/broadcastRoomUpdated\s*\(\s*previousRoomId\s*\)/);
+      expect(source).toMatch(/broadcastRoomUpdated\s*\(\s*nextRoomId\s*\)/);
     });
 
     test("join route emits room-updated", async () => {

--- a/tests/test-chat-hook-channel-lifecycle-wiring.test.ts
+++ b/tests/test-chat-hook-channel-lifecycle-wiring.test.ts
@@ -21,15 +21,14 @@ const readSource = (relativePath: string): string =>
 const assertUsesSharedLifecycleHelpers = (
   source: string
 ): void => {
-  expect(/subscribePusherChannel\s*\(/.test(source)).toBeTruthy();
-  expect(/unsubscribePusherChannel\s*\(/.test(source)).toBeTruthy();
-  expect(!/pusherRef\.current\?\.(subscribe|unsubscribe)\s*\(/.test(source)).toBeTruthy();
+  expect(source).toMatch(/subscribePusherChannel\s*\(/);
+  expect(source).toMatch(/unsubscribePusherChannel\s*\(/);
+  expect(source).not.toMatch(/pusherRef\.current\?\.(subscribe|unsubscribe)\s*\(/);
 };
 
 const assertNoBroadUnbinds = (source: string): void => {
   // Broad unbind looks like: channel.unbind("event")
-  const broadUnbindPattern = /\.unbind\(\s*"[^"]+"\s*\)/g;
-  expect(!broadUnbindPattern.test(source)).toBeTruthy();
+  expect(source).not.toMatch(/\.unbind\(\s*"[^"]+"\s*\)/);
 };
 
 describe("Chat Hook Channel Lifecycle Wiring", () => {
@@ -70,7 +69,7 @@ describe("Chat Hook Channel Lifecycle Wiring", () => {
   });
 
   describe("Background notifications hook", () => {
-    test("background hook uses shared lifecycle helpers", async () => {
+    test("background hook delegates to ChatRealtimeService, which uses shared lifecycle helpers", async () => {
       const source = readSource("src/hooks/useBackgroundChatNotifications.ts");
       expect(source).toContain("ChatRealtimeService");
       const serviceSource = readSource("src/services/chat/ChatRealtimeService.ts");

--- a/tests/test-chat-message-canonical-cutover.test.ts
+++ b/tests/test-chat-message-canonical-cutover.test.ts
@@ -1,10 +1,22 @@
-import { beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
 import { redisKeys } from "../src/shared/redisKeys";
 import { FakeRedis } from "./fake-redis";
+import * as actualRedisHelpers from "../api/_utils/redis-helpers";
 
 let fake: FakeRedis;
 
+// Spread the real module so its other exports survive — Bun module mocks are
+// global and persist across files in the same run.
 mock.module("../api/_utils/redis-helpers.js", () => ({
+  ...actualRedisHelpers,
   createRedisClient: () => fake,
   generateRandomHexId: (byteLength: number) => "a".repeat(byteLength * 2),
   getCurrentTimestamp: () => 1_718_180_000_000,
@@ -21,6 +33,10 @@ mock.module("../api/_utils/redis-helpers.js", () => ({
     return null;
   },
 }));
+
+afterAll(() => {
+  mock.module("../api/_utils/redis-helpers.js", () => actualRedisHelpers);
+});
 
 let chatRedis: typeof import("../api/rooms/_helpers/_redis");
 

--- a/tests/test-chat-notification-integration-wiring.test.ts
+++ b/tests/test-chat-notification-integration-wiring.test.ts
@@ -16,9 +16,9 @@ const readSource = (relativePath: string): string =>
 const assertUsesSharedNotificationGate = (
   source: string
 ): void => {
-  expect(/from\s+["']@\/utils\/chatNotifications["']/.test(source)).toBe(true);
-  expect(/shouldNotifyForRoomMessage/.test(source)).toBe(true);
-  expect(/shouldNotifyForRoomMessage\s*\(\s*\{/.test(source)).toBe(true);
+  expect(source).toMatch(/from\s+["']@\/utils\/chatNotifications["']/);
+  expect(source).toMatch(/shouldNotifyForRoomMessage/);
+  expect(source).toMatch(/shouldNotifyForRoomMessage\s*\(\s*\{/);
 };
 
 describe("Chat Notification Integration Wiring", () => {

--- a/tests/test-chat-store-guards-wiring.test.ts
+++ b/tests/test-chat-store-guards-wiring.test.ts
@@ -157,7 +157,7 @@ describe("Chat Store Guard Wiring Tests", () => {
       const match = source.match(/API_UNAVAILABLE_COOLDOWN_MS\s*=\s*([0-9_]+)/);
       expect(match?.[1]).toBeTruthy();
       const parsedMs = Number((match?.[1] || "").replaceAll("_", ""));
-      expect(parsedMs > 0).toBe(true);
+      expect(parsedMs).toBeGreaterThan(0);
     });
 
     test("marks cooldown on fetch failures", async () => {

--- a/tests/test-chat-streaming-perf.test.ts
+++ b/tests/test-chat-streaming-perf.test.ts
@@ -15,7 +15,8 @@
 
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
-import { describe, expect, test } from "bun:test";
+import { describe, expect, test, beforeAll, afterAll } from "bun:test";
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
 import type { AIChatMessage, ChatMessage } from "../src/types/chat";
 import { buildDisplayMessages } from "../src/apps/chats/utils/messages";
 import { getStreamPreviewThrottleMs } from "../src/components/shared/html-preview/hooks/useStreamPreview";
@@ -162,11 +163,24 @@ describe("decodeHtmlEntities streaming fast path", () => {
     expect(decodeHtmlEntities("&lt;hello&gt;")).toBe("<hello>");
   });
 
-  test("does not take the fast path when tags are present", () => {
-    // The full parse path also strips tags; the fast path must not change
-    // that behavior, so tagged input must not be returned verbatim.
-    const source = readSource("src/utils/decodeHtmlEntities.ts");
-    expect(source).toMatch(/!text\.includes\("&"\) && !text\.includes\("<"\)/);
+  describe("with a DOM available (DOMParser path)", () => {
+    beforeAll(() => {
+      if (typeof window === "undefined") {
+        GlobalRegistrator.register();
+      }
+    });
+    afterAll(() => {
+      if (GlobalRegistrator.isRegistered) {
+        GlobalRegistrator.unregister();
+      }
+    });
+
+    test("does not take the fast path when tags are present", () => {
+      // The full parse path strips tags; the fast path (reference return) must
+      // only trigger for plain text. Tagged input must not be returned verbatim.
+      expect(decodeHtmlEntities("<b>bold</b> text")).toBe("bold text");
+      expect(decodeHtmlEntities("a <span>b</span> &amp; c")).toBe("a b & c");
+    });
   });
 });
 

--- a/tests/test-client-analytics-wiring.test.ts
+++ b/tests/test-client-analytics-wiring.test.ts
@@ -4,6 +4,8 @@ import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { describe, expect, test } from "bun:test";
 
+import * as analytics from "../src/utils/analytics";
+
 const readSource = (relativePath: string): string =>
   readFileSync(resolve(process.cwd(), relativePath), "utf-8");
 
@@ -31,12 +33,15 @@ describe("client analytics wiring", () => {
   });
 
   test("exports first-party analytics SDK functions", () => {
-    const source = readSource("src/utils/analytics.ts");
-    expect(source.includes("export function track")).toBe(true);
-    expect(source.includes("export function initializeAnalytics")).toBe(true);
-    expect(source.includes("export async function flushAnalytics")).toBe(true);
-    expect(source.includes("export function getTextAnalytics")).toBe(true);
-    expect(source.includes("export function normalizeUrlForAnalytics")).toBe(true);
+    for (const name of [
+      "track",
+      "initializeAnalytics",
+      "flushAnalytics",
+      "getTextAnalytics",
+      "normalizeUrlForAnalytics",
+    ] as const) {
+      expect(typeof analytics[name]).toBe("function");
+    }
   });
 
   test("does not send raw chat messages or terminal prompts", () => {

--- a/tests/test-debounced-persist-storage.test.ts
+++ b/tests/test-debounced-persist-storage.test.ts
@@ -7,7 +7,7 @@
  * semantics and explicit flush/halt hooks for backup/restore/reset flows.
  */
 
-import { describe, test, expect, beforeEach } from "bun:test";
+import { describe, test, expect, beforeEach, afterEach, jest } from "bun:test";
 
 // Minimal localStorage polyfill for the bun test environment.
 const backing = new Map<string, string>();
@@ -31,29 +31,37 @@ const {
   flushDebouncedPersistWrites,
 } = await import("../src/utils/debouncedPersistStorage");
 
-const sleep = (ms: number) => new Promise((res) => setTimeout(res, ms));
-
+// Fake timers make the debounce window deterministic: we advance time by an
+// exact amount instead of sleeping past it and hoping the real timer fired.
 beforeEach(() => {
+  jest.useFakeTimers();
   backing.clear();
 });
 
+afterEach(() => {
+  jest.useRealTimers();
+});
+
 describe("createDebouncedPersistStorage", () => {
-  test("setItem defers the localStorage write until the debounce window", async () => {
+  test("setItem defers the localStorage write until the debounce window", () => {
     const storage = createDebouncedPersistStorage<{ a: number }>({ delayMs: 30 });
     storage.setItem("k", { state: { a: 1 }, version: 1 });
 
+    // Just before the window closes nothing is written yet...
+    jest.advanceTimersByTime(29);
     expect(backing.has("k")).toBe(false);
-    await sleep(60);
+    // ...and exactly at the window the snapshot is serialized.
+    jest.advanceTimersByTime(1);
     expect(JSON.parse(backing.get("k")!)).toEqual({ state: { a: 1 }, version: 1 });
   });
 
-  test("only the latest snapshot in a burst is serialized", async () => {
+  test("only the latest snapshot in a burst is serialized", () => {
     const storage = createDebouncedPersistStorage<{ a: number }>({ delayMs: 30 });
     storage.setItem("k", { state: { a: 1 }, version: 1 });
     storage.setItem("k", { state: { a: 2 }, version: 1 });
     storage.setItem("k", { state: { a: 3 }, version: 1 });
 
-    await sleep(60);
+    jest.advanceTimersByTime(30);
     expect(JSON.parse(backing.get("k")!).state.a).toBe(3);
   });
 
@@ -86,13 +94,13 @@ describe("createDebouncedPersistStorage", () => {
     expect(backing.has("k")).toBe(false);
   });
 
-  test("removeItem cancels a pending write and clears storage", async () => {
+  test("removeItem cancels a pending write and clears storage", () => {
     const storage = createDebouncedPersistStorage<{ a: number }>({ delayMs: 20 });
     backing.set("k", "old");
     storage.setItem("k", { state: { a: 1 }, version: 1 });
     storage.removeItem("k");
 
-    await sleep(50);
+    jest.advanceTimersByTime(50);
     expect(backing.has("k")).toBe(false);
   });
 });
@@ -108,12 +116,12 @@ describe("haltDebouncedPersistWrites", () => {
     storage.setItem("k", { state: { a: 1 }, version: 1 });
 
     haltDebouncedPersistWrites();
-    await sleep(50);
+    jest.advanceTimersByTime(50);
     expect(backing.has("k")).toBe(false);
 
     storage.setItem("k", { state: { a: 2 }, version: 1 });
     flushDebouncedPersistWrites();
-    await sleep(50);
+    jest.advanceTimersByTime(50);
     expect(backing.has("k")).toBe(false);
   });
 });

--- a/tests/test-error-boundary-wiring.test.ts
+++ b/tests/test-error-boundary-wiring.test.ts
@@ -22,50 +22,46 @@ describe("Error Boundary Wiring Tests", () => {
       const source = readSource(
         "src/apps/base/app-manager/AppManagerView.tsx",
       );
-      expect(source.includes("<AppErrorBoundary")).toBe(true);
-      expect(/<AppErrorBoundary[\s\S]*<AppComponent/.test(source)).toBe(true);
+      expect(source).toContain("<AppErrorBoundary");
+      expect(source).toMatch(/<AppErrorBoundary[\s\S]*<AppComponent/);
     });
 
     test("relaunches crashed instances via close-and-launch flow", async () => {
       const source = readSource(
         "src/apps/base/app-manager/AppManagerView.tsx",
       );
-      expect(source.includes("closeAppInstance(instance.instanceId);")).toBe(true);
-      expect(
-        /launchApp\(\s*appId,\s*(?:instance\.initialData|relaunchInitialData),\s*instance\.title,\s*supportsMultiWindowApp\(appId\)/.test(
-          source,
-        )
-      ).toBe(true);
+      expect(source).toContain("closeAppInstance(instance.instanceId);");
+      expect(source).toMatch(
+        /launchApp\(\s*appId,\s*(?:instance\.initialData|relaunchInitialData),\s*instance\.title,\s*supportsMultiWindowApp\(appId\)/,
+      );
     });
   });
 
   describe("Desktop shell fallback", () => {
     test("wraps AppManager in DesktopErrorBoundary", async () => {
       const source = readSource("src/App.tsx");
-      expect(source.includes("<DesktopErrorBoundary>")).toBe(true);
-      expect(
-        /<DesktopErrorBoundary>\s*<AppManager apps=\{apps\} \/>\s*<\/DesktopErrorBoundary>/.test(
-          source,
-        )
-      ).toBe(true);
+      expect(source).toContain("<DesktopErrorBoundary>");
+      expect(source).toMatch(
+        /<DesktopErrorBoundary>\s*<AppManager apps=\{apps\} \/>\s*<\/DesktopErrorBoundary>/,
+      );
     });
   });
 
   describe("Boundary implementation + reporting", () => {
     test("implements catch/reporting flow in ErrorBoundaries", async () => {
       const source = readSource("src/components/errors/ErrorBoundaries.tsx");
-      expect(source.includes("componentDidCatch")).toBe(true);
-      expect(source.includes("reportRuntimeCrash")).toBe(true);
-      expect(source.includes("RYOS_ERROR_BOUNDARY_TEST_EVENT")).toBe(true);
+      expect(source).toContain("componentDidCatch");
+      expect(source).toContain("reportRuntimeCrash");
+      expect(source).toContain("RYOS_ERROR_BOUNDARY_TEST_EVENT");
     });
 
     test("supports optional external error reporter registration", async () => {
       const source = readSource("src/utils/errorReporting.ts");
-      expect(source.includes("setRuntimeErrorReporter")).toBe(true);
-      expect(source.includes("__RYOS_ERROR_REPORTER__")).toBe(true);
-      expect(source.includes("window.reportError")).toBe(true);
-      expect(source.includes("triggerRuntimeCrashTest")).toBe(true);
-      expect(source.includes("RYOS_ERROR_BOUNDARY_TEST_EVENT")).toBe(true);
+      expect(source).toContain("setRuntimeErrorReporter");
+      expect(source).toContain("__RYOS_ERROR_REPORTER__");
+      expect(source).toContain("window.reportError");
+      expect(source).toContain("triggerRuntimeCrashTest");
+      expect(source).toContain("RYOS_ERROR_BOUNDARY_TEST_EVENT");
     });
   });
 
@@ -77,20 +73,20 @@ describe("Error Boundary Wiring Tests", () => {
       const systemTabSource = readSource(
         "src/apps/control-panels/components/control-panels-app/SystemTabContent.tsx",
       );
-      expect(
-        systemTabSource.includes('t("apps.control-panels.errorBoundaries")'),
-      ).toBe(true);
-      expect(shellSource.includes("handleTriggerAppCrashTest")).toBe(true);
-      expect(shellSource.includes("handleTriggerDesktopCrashTest")).toBe(true);
+      expect(systemTabSource).toContain(
+        't("apps.control-panels.errorBoundaries")',
+      );
+      expect(shellSource).toContain("handleTriggerAppCrashTest");
+      expect(shellSource).toContain("handleTriggerDesktopCrashTest");
     });
 
     test("dispatches shared crash events from Control Panels logic", async () => {
       const source = readSource(
         "src/apps/control-panels/hooks/useControlPanelsLogic.ts",
       );
-      expect(source.includes("triggerRuntimeCrashTest")).toBe(true);
-      expect(/scope:\s*"app"[\s\S]*appId:\s*"control-panels"/.test(source)).toBe(true);
-      expect(/scope:\s*"desktop"/.test(source)).toBe(true);
+      expect(source).toContain("triggerRuntimeCrashTest");
+      expect(source).toMatch(/scope:\s*"app"[\s\S]*appId:\s*"control-panels"/);
+      expect(source).toMatch(/scope:\s*"desktop"/);
     });
   });
 });

--- a/tests/test-furigana-word-spacing.test.ts
+++ b/tests/test-furigana-word-spacing.test.ts
@@ -1,46 +1,82 @@
 import { describe, expect, test } from "bun:test";
 import { getFuriganaSegmentsPronunciationOnly } from "../src/utils/romanization";
+import type { FuriganaSegment } from "../src/utils/romanization";
+import {
+  getTrailingWhitespace,
+  mapWordTimingsToFurigana,
+} from "../src/apps/ipod/components/lyrics-display/furiganaWordMapping";
+import type { LyricWord } from "../src/types/lyrics";
 
-function stripTrailingWhitespace(text: string): string {
-  return text.replace(/\s+$/u, "");
+// Build LyricWord timings from plain strings; timing values are irrelevant to
+// the text-combining behavior under test.
+function mkWords(texts: string[]): LyricWord[] {
+  return texts.map((text, i) => ({
+    text,
+    startTimeMs: i * 100,
+    durationMs: 100,
+  }));
 }
 
-/** Mirror of LyricsDisplay.tsx timed-word combine logic for regression testing */
-function combineTimedWordParts(parts: string[]): string {
-  return stripTrailingWhitespace(parts.join(""));
+function seg(text: string, reading?: string): FuriganaSegment {
+  return reading ? { text, reading } : { text };
 }
 
-function shouldCombineAcrossWordTimings(segmentText: string): boolean {
-  return !/\s/u.test(segmentText);
-}
-
-describe("furigana timed-word spacing", () => {
-  test("preserves authored English spaces", () => {
-    expect(combineTimedWordParts(["Oh ", "no ", "loving ", "you"])).toBe("Oh no loving you");
+// These tests drive the real production combiner (mapWordTimingsToFurigana)
+// instead of re-implementing its logic, so they fail if the source changes.
+describe("furigana timed-word combine (mapWordTimingsToFurigana)", () => {
+  test("combines consecutive no-space Japanese words sharing a reading", () => {
+    const { renderItems, skipIndices } = mapWordTimingsToFurigana(
+      mkWords(["走", "る"]),
+      [seg("走る", "はしる")]
+    );
+    expect(renderItems).toHaveLength(1);
+    expect(renderItems[0].text).toBe("走る");
+    expect(renderItems[0].reading).toBe("はしる");
+    expect(renderItems[0].combinedWordIndices).toEqual([0, 1]);
+    expect([...skipIndices]).toEqual([1]);
   });
 
-  test("preserves authored Korean spaces", () => {
-    expect(combineTimedWordParts(["안녕 ", "하세요"])).toBe("안녕 하세요");
+  test("strips trailing whitespace from a combined unit", () => {
+    const { renderItems } = mapWordTimingsToFurigana(
+      mkWords(["走", "る "]),
+      [seg("走る", "はしる")]
+    );
+    expect(renderItems).toHaveLength(1);
+    expect(renderItems[0].text).toBe("走る");
   });
 
-  test("keeps Japanese chunks concatenated when source has no spaces", () => {
-    expect(combineTimedWordParts(["走", "る"])).toBe("走る");
+  test("combines a mixed Latin+kanji no-space segment", () => {
+    const { renderItems } = mapWordTimingsToFurigana(
+      mkWords(["Hello", "世界"]),
+      [seg("Hello世界", "ハローせかい")]
+    );
+    expect(renderItems).toHaveLength(1);
+    expect(renderItems[0].text).toBe("Hello世界");
   });
 
-  test("keeps mixed Latin and kanji boundary unchanged when source has no spaces", () => {
-    expect(combineTimedWordParts(["Hello", "世界"])).toBe("Hello世界");
+  test("does NOT combine grouped English phrases when the segment has spaces", () => {
+    const { renderItems, skipIndices } = mapWordTimingsToFurigana(
+      mkWords(["to ", "the"]),
+      [seg("to the", "トゥザ")]
+    );
+    expect(renderItems).toHaveLength(2);
+    expect(renderItems.map((r) => r.text)).toEqual(["to", "the"]);
+    expect(skipIndices.size).toBe(0);
   });
 
-  test("does not combine grouped English furigana phrases across multiple timings", () => {
-    expect(shouldCombineAcrossWordTimings("to the")).toBe(false);
+  test("does NOT combine grouped Korean phrases when the segment has spaces", () => {
+    const { renderItems, skipIndices } = mapWordTimingsToFurigana(
+      mkWords(["아주 ", "길게"]),
+      [seg("아주 길게", "ajoo gilge")]
+    );
+    expect(renderItems).toHaveLength(2);
+    expect(skipIndices.size).toBe(0);
   });
 
-  test("does not combine grouped Korean furigana phrases across multiple timings", () => {
-    expect(shouldCombineAcrossWordTimings("아주 길게")).toBe(false);
-  });
-
-  test("still combines Japanese no-space furigana across multiple timings", () => {
-    expect(shouldCombineAcrossWordTimings("走る")).toBe(true);
+  test("exposes authored trailing whitespace per word for spaced rendering", () => {
+    expect(getTrailingWhitespace("no ")).toBe(" ");
+    expect(getTrailingWhitespace("you")).toBe("");
+    expect(getTrailingWhitespace("안녕 ")).toBe(" ");
   });
 });
 

--- a/tests/test-iframe-check.test.ts
+++ b/tests/test-iframe-check.test.ts
@@ -22,7 +22,7 @@ describe("iframe-check", () => {
       );
       expect(res.status).toBe(200);
       const data = await res.json();
-      expect(typeof data.allowed).toBe("boolean");
+      expect(data.allowed).toBe(true);
     });
   });
 
@@ -33,16 +33,16 @@ describe("iframe-check", () => {
       );
       expect(res.status).toBe(200);
       const data = await res.json();
-      expect(typeof data.allowed).toBe("boolean");
+      expect(data.allowed).toBe(true);
     });
 
-    test("Check mode - blocked site", async () => {
+    test("Check mode - auto-proxied site", async () => {
       const res = await fetchWithOrigin(
         `${BASE_URL}/api/iframe-check?url=https://youtube.com&mode=check`
       );
       expect(res.status).toBe(200);
       const data = await res.json();
-      expect(typeof data.allowed).toBe("boolean");
+      expect(data.allowed).toBe(false);
     });
 
     test("Check mode - auto-proxy domain", async () => {
@@ -74,7 +74,8 @@ describe("iframe-check", () => {
       );
       expect(res.status).toBe(200);
       const title = res.headers.get("X-Proxied-Page-Title");
-      expect(title !== null || true).toBe(true);
+      expect(title).not.toBeNull();
+      expect(decodeURIComponent(title ?? "")).toContain("Example");
     });
 
     test("Proxy mode - theme parameter", async () => {
@@ -83,7 +84,9 @@ describe("iframe-check", () => {
       );
       expect(res.status).toBe(200);
       const html = await res.text();
-      expect(!html.includes("Geneva-12") || html.includes("Geneva-12")).toBe(true);
+      // The macosx theme suppresses the pixel-font override that other themes
+      // inject (shouldInjectFontOverrides = theme !== "macosx").
+      expect(html).not.toContain("Geneva-12");
     });
 
     test("Proxy mode - invalid URL", async () => {
@@ -99,9 +102,8 @@ describe("iframe-check", () => {
       );
       expect(res.status).toBe(200);
       const contentType = res.headers.get("content-type") || "";
-      expect(
-        contentType.includes("text/html") || contentType.includes("application/json")
-      ).toBe(true);
+      // Default mode is proxy, which streams the rewritten HTML document.
+      expect(contentType).toContain("text/html");
     });
   });
 

--- a/tests/test-irc-bridge.test.ts
+++ b/tests/test-irc-bridge.test.ts
@@ -479,7 +479,7 @@ describe("IRC Bridge wiring", () => {
     const fs = await import("node:fs/promises");
     const src = await fs.readFile("api/rooms/[id].ts", "utf-8");
     expect(src).toContain("notifyRoomBindingChange");
-    expect(/notifyRoomBindingChange\s*\(\s*"unbind"/.test(src)).toBe(true);
+    expect(src).toMatch(/notifyRoomBindingChange\s*\(\s*"unbind"/);
     expect(src).toContain("isIrcBridgeEnabled");
   });
 
@@ -487,7 +487,7 @@ describe("IRC Bridge wiring", () => {
     const fs = await import("node:fs/promises");
     const src = await fs.readFile("api/rooms/[id]/messages.ts", "utf-8");
     expect(src).toContain("getIrcBridge");
-    expect(/roomData\.type === "irc"/.test(src)).toBe(true);
+    expect(src).toMatch(/roomData\.type === "irc"/);
     expect(src).toContain("isIrcBridgeEnabled");
   });
 
@@ -512,7 +512,7 @@ describe("IRC Bridge wiring", () => {
     const fs = await import("node:fs/promises");
     const src = await fs.readFile("scripts/api-standalone-server.ts", "utf-8");
     expect(src).toContain("getIrcBridge");
-    expect(/getIrcBridge\(\)\.initialize\(\)/.test(src)).toBe(true);
+    expect(src).toMatch(/getIrcBridge\(\)\.initialize\(\)/);
     expect(src).toContain("isIrcBridgeEnabled");
   });
 

--- a/tests/test-irc-bridge.test.ts
+++ b/tests/test-irc-bridge.test.ts
@@ -91,6 +91,29 @@ class FakeIrcClient extends EventEmitter implements IrcClientLike {
   nick: string = "";
 }
 
+/** Resolve as soon as `predicate` is true, instead of sleeping a fixed amount. */
+async function waitFor(
+  predicate: () => boolean,
+  { timeoutMs = 1000, intervalMs = 2 }: { timeoutMs?: number; intervalMs?: number } = {}
+): Promise<void> {
+  const start = Date.now();
+  while (!predicate()) {
+    if (Date.now() - start > timeoutMs) {
+      throw new Error(`waitFor: condition not met within ${timeoutMs}ms`);
+    }
+    await new Promise((r) => setTimeout(r, intervalMs));
+  }
+}
+
+/** Drain the microtask queue so synchronous early-returns settle deterministically. */
+async function flushMicrotasks(): Promise<void> {
+  for (let i = 0; i < 5; i++) await Promise.resolve();
+}
+
+/** The bridge issues JOIN only after the `registered` handler ran (server ready). */
+const hasJoined = (client?: FakeIrcClient): boolean =>
+  Boolean(client?.calls.some((c) => c.type === "join"));
+
 function makeIrcRoom(overrides: Partial<Room> = {}): Room {
   return {
     id: "testroom1",
@@ -163,8 +186,8 @@ describe("IRC Bridge", () => {
     const room = makeIrcRoom();
     await bridge.bindRoom(room);
 
-    // Let the fake client register so server.ready becomes true.
-    await new Promise((r) => setTimeout(r, 5));
+    // Wait until the fake client registers + joins so server.ready is true.
+    await waitFor(() => hasJoined(fakeClients[0]));
 
     await bridge.sendMessage(room, "alice", "hello world");
 
@@ -178,7 +201,7 @@ describe("IRC Bridge", () => {
   test("incoming IRC messages are persisted via the callback", async () => {
     const room = makeIrcRoom();
     await bridge.bindRoom(room);
-    await new Promise((r) => setTimeout(r, 5));
+    await waitFor(() => hasJoined(fakeClients[0]));
 
     const client = fakeClients[0];
     client.emit("message", {
@@ -188,8 +211,8 @@ describe("IRC Bridge", () => {
       message: "hi there",
     });
 
-    // Allow the async handler (which also calls getRoom) to settle.
-    await new Promise((r) => setTimeout(r, 200));
+    // The async handler calls getRoom then persists; wait for the result.
+    await waitFor(() => persisted.length === 1);
 
     expect(persisted.length).toBe(1);
     const persistedItem = persisted[0];
@@ -201,7 +224,7 @@ describe("IRC Bridge", () => {
   test("incoming IRC 'action' events are prefixed with '*'", async () => {
     const room = makeIrcRoom();
     await bridge.bindRoom(room);
-    await new Promise((r) => setTimeout(r, 5));
+    await waitFor(() => hasJoined(fakeClients[0]));
 
     const client = fakeClients[0];
     client.emit("message", {
@@ -211,7 +234,7 @@ describe("IRC Bridge", () => {
       message: "waves",
     });
 
-    await new Promise((r) => setTimeout(r, 200));
+    await waitFor(() => persisted.length === 1);
 
     expect(persisted.length).toBe(1);
     expect(persisted[0].message.content).toBe("* waves");
@@ -220,7 +243,7 @@ describe("IRC Bridge", () => {
   test("incoming messages from unbound channels are ignored", async () => {
     const room = makeIrcRoom();
     await bridge.bindRoom(room);
-    await new Promise((r) => setTimeout(r, 5));
+    await waitFor(() => hasJoined(fakeClients[0]));
 
     const client = fakeClients[0];
     client.emit("message", {
@@ -230,14 +253,16 @@ describe("IRC Bridge", () => {
       message: "hi",
     });
 
-    await new Promise((r) => setTimeout(r, 5));
+    // The handler returns synchronously for unbound channels; drain microtasks
+    // and confirm nothing was persisted.
+    await flushMicrotasks();
     expect(persisted.length).toBe(0);
   });
 
   test("bot's own messages (by nick match) are not persisted back", async () => {
     const room = makeIrcRoom();
     await bridge.bindRoom(room);
-    await new Promise((r) => setTimeout(r, 5));
+    await waitFor(() => hasJoined(fakeClients[0]));
 
     const client = fakeClients[0];
     client.emit("message", {
@@ -247,14 +272,16 @@ describe("IRC Bridge", () => {
       message: "<alice> hello",
     });
 
-    await new Promise((r) => setTimeout(r, 5));
+    // The handler returns synchronously for the bot's own nick; drain
+    // microtasks and confirm nothing was persisted back.
+    await flushMicrotasks();
     expect(persisted.length).toBe(0);
   });
 
   test("unbindRoom parts channel and drops the binding", async () => {
     const room = makeIrcRoom();
     await bridge.bindRoom(room);
-    await new Promise((r) => setTimeout(r, 5));
+    await waitFor(() => hasJoined(fakeClients[0]));
 
     await bridge.unbindRoom(room);
 
@@ -266,7 +293,7 @@ describe("IRC Bridge", () => {
   test("repeated bindRoom for same room does not rejoin channel", async () => {
     const room = makeIrcRoom();
     await bridge.bindRoom(room);
-    await new Promise((r) => setTimeout(r, 5));
+    await waitFor(() => hasJoined(fakeClients[0]));
 
     await bridge.bindRoom(room);
 
@@ -283,7 +310,7 @@ describe("IRC Bridge", () => {
 
     await bridge.bindRoom(roomA);
     await bridge.bindRoom(roomB);
-    await new Promise((r) => setTimeout(r, 5));
+    await waitFor(() => hasJoined(fakeClients[0]));
 
     // Still only a single IRC connection.
     expect(fakeClients.length).toBe(1);
@@ -295,7 +322,7 @@ describe("IRC Bridge", () => {
   test("different servers get separate connections", async () => {
     await bridge.bindRoom(makeIrcRoom({ id: "rA", ircHost: "irc.example.com" }));
     await bridge.bindRoom(makeIrcRoom({ id: "rB", ircHost: "irc.pieter.com" }));
-    await new Promise((r) => setTimeout(r, 5));
+    await waitFor(() => fakeClients.length === 2 && fakeClients.every(hasJoined));
 
     expect(fakeClients.length).toBe(2);
     const bindings = bridge.getBindings().map((b) => b.host).sort();
@@ -306,7 +333,7 @@ describe("IRC Bridge", () => {
     // Simulate a race: sendMessage called before any bind.
     const room = makeIrcRoom({ id: "rLazy" });
     await bridge.sendMessage(room, "alice", "hi");
-    await new Promise((r) => setTimeout(r, 5));
+    await waitFor(() => fakeClients.length === 1);
 
     // A client should now exist because sendMessage triggered bindRoom.
     expect(fakeClients.length).toBe(1);
@@ -318,7 +345,7 @@ describe("IRC Bridge", () => {
   test("listChannels reuses an existing connection when available", async () => {
     const room = makeIrcRoom();
     await bridge.bindRoom(room);
-    await new Promise((r) => setTimeout(r, 10));
+    await waitFor(() => hasJoined(fakeClients[0]));
 
     // Bridge should now have a single ready client; queue a synthetic LIST
     // response on it before invoking listChannels.

--- a/tests/test-irc-server-registry-cutover.test.ts
+++ b/tests/test-irc-server-registry-cutover.test.ts
@@ -1,14 +1,22 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 import { redisKeys } from "../src/shared/redisKeys";
 import { FakeRedis } from "./fake-redis";
+import * as actualRedis from "../api/_utils/redis";
 
 let fake: FakeRedis;
 
 // The IRC server registry resolves its client through createRedis() from this
-// module, so point it at a fake to exercise the real key-reading logic.
+// module, so point it at a fake to exercise the real key-reading logic. Spread
+// the real module so other exports (e.g. supportsRedisPubSub) survive — Bun
+// module mocks are global and persist across files in the same run.
 mock.module("../api/_utils/redis.js", () => ({
+  ...actualRedis,
   createRedis: () => fake,
 }));
+
+afterAll(() => {
+  mock.module("../api/_utils/redis.js", () => actualRedis);
+});
 
 let servers: typeof import("../api/_utils/irc/_servers");
 

--- a/tests/test-link-preview.test.ts
+++ b/tests/test-link-preview.test.ts
@@ -73,10 +73,10 @@ describe("link-preview", () => {
       const res = await fetchWithOrigin(
         `${BASE_URL}/api/link-preview?url=https://example.com`
       );
-      if (res.status === 200) {
-        const cacheControl = res.headers.get("Cache-Control");
-        expect(cacheControl !== null || true).toBe(true);
-      }
+      expect(res.status).toBe(200);
+      const cacheControl = res.headers.get("Cache-Control");
+      expect(cacheControl).not.toBeNull();
+      expect(cacheControl).toContain("max-age");
     });
   });
 
@@ -89,7 +89,7 @@ describe("link-preview", () => {
         const data = await res.json();
         expect(data.siteName?.toLowerCase().includes("youtube") || data.title).toBe(true);
       } else {
-        expect(res.status >= 400).toBe(true);
+        expect(res.status).toBeGreaterThanOrEqual(400);
       }
     });
 
@@ -101,7 +101,7 @@ describe("link-preview", () => {
         const data = await res.json();
         expect(data.siteName).toBe("YouTube");
       } else {
-        expect(res.status >= 400).toBe(true);
+        expect(res.status).toBeGreaterThanOrEqual(400);
       }
     });
   });
@@ -111,7 +111,7 @@ describe("link-preview", () => {
       const res = await fetchWithOrigin(
         `${BASE_URL}/api/link-preview?url=https://httpstat.us/404`
       );
-      expect(res.status >= 400).toBe(true);
+      expect(res.status).toBeGreaterThanOrEqual(400);
     });
   });
 });

--- a/tests/test-link-preview.test.ts
+++ b/tests/test-link-preview.test.ts
@@ -4,12 +4,18 @@
  */
 
 import { describe, test, expect } from "bun:test";
-import { BASE_URL, fetchWithOrigin } from "./test-utils";
+import {
+  BASE_URL,
+  fetchWithOrigin,
+  makeRateLimitBypassHeaders,
+} from "./test-utils";
 
 describe("link-preview", () => {
   describe("Input Validation", () => {
     test("Missing URL parameter", async () => {
-      const res = await fetchWithOrigin(`${BASE_URL}/api/link-preview`);
+      const res = await fetchWithOrigin(`${BASE_URL}/api/link-preview`, {
+        headers: makeRateLimitBypassHeaders(),
+      });
       expect(res.status).toBe(400);
       const data = await res.json();
       expect(data.error?.includes("URL") || data.error?.includes("url")).toBe(true);
@@ -17,7 +23,8 @@ describe("link-preview", () => {
 
     test("Invalid URL format", async () => {
       const res = await fetchWithOrigin(
-        `${BASE_URL}/api/link-preview?url=not-a-valid-url`
+        `${BASE_URL}/api/link-preview?url=not-a-valid-url`,
+        { headers: makeRateLimitBypassHeaders() }
       );
       expect(res.status).toBe(400);
       const data = await res.json();
@@ -26,7 +33,8 @@ describe("link-preview", () => {
 
     test("Non-HTTP protocol", async () => {
       const res = await fetchWithOrigin(
-        `${BASE_URL}/api/link-preview?url=ftp://example.com`
+        `${BASE_URL}/api/link-preview?url=ftp://example.com`,
+        { headers: makeRateLimitBypassHeaders() }
       );
       expect(res.status).toBe(400);
       const data = await res.json();
@@ -36,6 +44,7 @@ describe("link-preview", () => {
     test("Method not allowed (POST)", async () => {
       const res = await fetchWithOrigin(`${BASE_URL}/api/link-preview`, {
         method: "POST",
+        headers: makeRateLimitBypassHeaders(),
       });
       expect(res.status).toBe(405);
     });
@@ -43,15 +52,17 @@ describe("link-preview", () => {
     test("OPTIONS request (CORS preflight)", async () => {
       const res = await fetchWithOrigin(`${BASE_URL}/api/link-preview`, {
         method: "OPTIONS",
+        headers: makeRateLimitBypassHeaders(),
       });
-      expect(res.status === 200 || res.status === 204).toBe(true);
+      expect([200, 204]).toContain(res.status);
     });
   });
 
   describe("Metadata Extraction", () => {
     test("Basic metadata extraction", async () => {
       const res = await fetchWithOrigin(
-        `${BASE_URL}/api/link-preview?url=https://example.com`
+        `${BASE_URL}/api/link-preview?url=https://example.com`,
+        { headers: makeRateLimitBypassHeaders() }
       );
       expect(res.status).toBe(200);
       const data = await res.json();
@@ -61,7 +72,8 @@ describe("link-preview", () => {
 
     test("Open Graph extraction", async () => {
       const res = await fetchWithOrigin(
-        `${BASE_URL}/api/link-preview?url=https://github.com`
+        `${BASE_URL}/api/link-preview?url=https://github.com`,
+        { headers: makeRateLimitBypassHeaders() }
       );
       expect(res.status).toBe(200);
       const data = await res.json();
@@ -71,7 +83,8 @@ describe("link-preview", () => {
 
     test("Cache headers", async () => {
       const res = await fetchWithOrigin(
-        `${BASE_URL}/api/link-preview?url=https://example.com`
+        `${BASE_URL}/api/link-preview?url=https://example.com`,
+        { headers: makeRateLimitBypassHeaders() }
       );
       expect(res.status).toBe(200);
       const cacheControl = res.headers.get("Cache-Control");
@@ -83,11 +96,15 @@ describe("link-preview", () => {
   describe("YouTube Handling", () => {
     test("YouTube URL (watch)", async () => {
       const res = await fetchWithOrigin(
-        `${BASE_URL}/api/link-preview?url=https://www.youtube.com/watch?v=dQw4w9WgXcQ`
+        `${BASE_URL}/api/link-preview?url=https://www.youtube.com/watch?v=dQw4w9WgXcQ`,
+        { headers: makeRateLimitBypassHeaders() }
       );
       if (res.status === 200) {
         const data = await res.json();
-        expect(data.siteName?.toLowerCase().includes("youtube") || data.title).toBe(true);
+        const looksLikeYouTube =
+          data.siteName?.toLowerCase().includes("youtube") ||
+          Boolean(data.title);
+        expect(looksLikeYouTube).toBe(true);
       } else {
         expect(res.status).toBeGreaterThanOrEqual(400);
       }
@@ -95,7 +112,8 @@ describe("link-preview", () => {
 
     test("YouTube short URL (youtu.be)", async () => {
       const res = await fetchWithOrigin(
-        `${BASE_URL}/api/link-preview?url=https://youtu.be/dQw4w9WgXcQ`
+        `${BASE_URL}/api/link-preview?url=https://youtu.be/dQw4w9WgXcQ`,
+        { headers: makeRateLimitBypassHeaders() }
       );
       if (res.status === 200) {
         const data = await res.json();
@@ -107,11 +125,31 @@ describe("link-preview", () => {
   });
 
   describe("Error Cases", () => {
-    test("URL returning 404", async () => {
+    // Previously this fetched https://httpstat.us/404 to exercise upstream HTTP
+    // errors, but that host is unreachable from CI and made the test time out.
+    // SSRF validation runs before any outbound fetch, so a private/reserved
+    // target deterministically exercises the endpoint's rejection path with no
+    // external dependency.
+    test("rejects private/reserved IP targets (SSRF guard)", async () => {
       const res = await fetchWithOrigin(
-        `${BASE_URL}/api/link-preview?url=https://httpstat.us/404`
+        `${BASE_URL}/api/link-preview?url=http://127.0.0.1/`,
+        { headers: makeRateLimitBypassHeaders() }
       );
-      expect(res.status).toBeGreaterThanOrEqual(400);
+      expect(res.status).toBe(400);
+      const data = await res.json();
+      expect(typeof data.error).toBe("string");
+      expect(data.error).toContain("Private or reserved IPs");
+    });
+
+    test("rejects blocked hostnames (SSRF guard)", async () => {
+      const res = await fetchWithOrigin(
+        `${BASE_URL}/api/link-preview?url=http://169.254.169.254/latest/meta-data/`,
+        { headers: makeRateLimitBypassHeaders() }
+      );
+      expect(res.status).toBe(400);
+      const data = await res.json();
+      expect(typeof data.error).toBe("string");
+      expect(data.error).toContain("Blocked hostname");
     });
   });
 });

--- a/tests/test-media.test.ts
+++ b/tests/test-media.test.ts
@@ -23,7 +23,7 @@ describe("audio-transcribe", () => {
       const res = await fetchWithOrigin(`${BASE_URL}/api/audio-transcribe`, {
         method: "OPTIONS",
       });
-      expect(res.status === 200 || res.status === 204).toBe(true);
+      expect([200, 204]).toContain(res.status);
     });
   });
 
@@ -86,17 +86,14 @@ describe("audio-transcribe", () => {
         body: formData,
       });
 
+      // 400/500 are acceptable: OpenAI may reject the minimal synthetic WAV.
+      expect([200, 400, 429, 500]).toContain(res.status);
       if (res.status === 200) {
         const data = await res.json();
         expect("text" in data).toBe(true);
       } else if (res.status === 429) {
         const data = await res.json();
         expect(data.error).toBe("rate_limit_exceeded");
-      } else if (res.status === 400 || res.status === 500) {
-        // OpenAI may reject the minimal WAV - that's acceptable
-        expect(true).toBe(true);
-      } else {
-        throw new Error(`Unexpected status: ${res.status}`);
       }
     });
   });
@@ -107,7 +104,7 @@ describe("audio-transcribe", () => {
         method: "OPTIONS",
       });
       const allowOrigin = res.headers.get("Access-Control-Allow-Origin");
-      expect(allowOrigin !== null || res.status >= 400).toBe(true);
+      expect(allowOrigin).toBe("http://localhost:3000");
     });
 
     test("Rate limit headers", async () => {
@@ -120,13 +117,13 @@ describe("audio-transcribe", () => {
         body: formData,
       });
 
+      expect([200, 400, 429, 500]).toContain(res.status);
       if (res.status === 429) {
         const retryAfter = res.headers.get("Retry-After");
-        expect(retryAfter !== null).toBe(true);
+        expect(retryAfter).not.toBeNull();
         const data = await res.json();
-        expect(data.scope === "burst" || data.scope === "daily").toBe(true);
+        expect(["burst", "daily"]).toContain(data.scope);
       }
-      expect(true).toBe(true);
     });
   });
 });
@@ -148,7 +145,7 @@ describe("youtube-search", () => {
       const res = await fetchWithOrigin(`${BASE_URL}/api/youtube-search`, {
         method: "OPTIONS",
       });
-      expect(res.status === 200 || res.status === 204).toBe(true);
+      expect([200, 204]).toContain(res.status);
     });
   });
 
@@ -207,6 +204,8 @@ describe("youtube-search", () => {
         body: JSON.stringify({ query: "lofi music" }),
       });
 
+      // 403/500 are acceptable: YouTube quota exceeded or API key not configured.
+      expect([200, 403, 429, 500]).toContain(res.status);
       if (res.status === 200) {
         const data = await res.json();
         expect(Array.isArray(data.results)).toBe(true);
@@ -220,14 +219,6 @@ describe("youtube-search", () => {
       } else if (res.status === 429) {
         const data = await res.json();
         expect(data.error).toBe("rate_limit_exceeded");
-      } else if (res.status === 403) {
-        // YouTube API quota exceeded or not configured
-        expect(true).toBe(true);
-      } else if (res.status === 500) {
-        // API not configured
-        expect(true).toBe(true);
-      } else {
-        throw new Error(`Unexpected status: ${res.status}`);
       }
     });
 
@@ -238,14 +229,11 @@ describe("youtube-search", () => {
         body: JSON.stringify({ query: "jazz music", maxResults: 5 }),
       });
 
+      expect([200, 403, 429, 500]).toContain(res.status);
       if (res.status === 200) {
         const data = await res.json();
         expect(Array.isArray(data.results)).toBe(true);
         expect(data.results.length).toBeLessThanOrEqual(5);
-      } else if (res.status === 429 || res.status === 403 || res.status === 500) {
-        expect(true).toBe(true);
-      } else {
-        throw new Error(`Unexpected status: ${res.status}`);
       }
     });
   });
@@ -256,7 +244,7 @@ describe("youtube-search", () => {
         method: "OPTIONS",
       });
       const allowOrigin = res.headers.get("Access-Control-Allow-Origin");
-      expect(allowOrigin !== null || res.status >= 400).toBe(true);
+      expect(allowOrigin).toBe("http://localhost:3000");
     });
 
     test("Rate limit headers", async () => {
@@ -266,13 +254,13 @@ describe("youtube-search", () => {
         body: JSON.stringify({ query: "rate limit test" }),
       });
 
+      expect([200, 403, 429, 500]).toContain(res.status);
       if (res.status === 429) {
         const retryAfter = res.headers.get("Retry-After");
-        expect(retryAfter !== null).toBe(true);
+        expect(retryAfter).not.toBeNull();
         const data = await res.json();
-        expect(data.scope === "burst" || data.scope === "daily").toBe(true);
+        expect(["burst", "daily"]).toContain(data.scope);
       }
-      expect(true).toBe(true);
     });
   });
 });

--- a/tests/test-media.test.ts
+++ b/tests/test-media.test.ts
@@ -192,7 +192,7 @@ describe("youtube-search", () => {
         headers: { "Content-Type": "application/json" },
         body: "not valid json{",
       });
-      expect(res.status >= 400).toBe(true);
+      expect(res.status).toBeGreaterThanOrEqual(400);
     });
   });
 

--- a/tests/test-memory-system.test.ts
+++ b/tests/test-memory-system.test.ts
@@ -86,8 +86,10 @@ describe("Memory System Timestamp Tests", () => {
       const [entry] = note?.entries || [];
       expect(entry.timeZone).toBe(tz);
       expect(entry.localDate).toBe(todayInTz);
-      expect(typeof entry.localTime === "string" && entry.localTime.length > 0).toBe(true);
-      expect(typeof entry.isoTimestamp === "string" && entry.isoTimestamp.endsWith("Z")).toBe(true);
+      expect(typeof entry.localTime).toBe("string");
+      expect(entry.localTime.length).toBeGreaterThan(0);
+      expect(typeof entry.isoTimestamp).toBe("string");
+      expect(entry.isoTimestamp.endsWith("Z")).toBe(true);
     });
 
     test("appendDailyNote can bucket by a source event timestamp", async () => {

--- a/tests/test-og-share-song-key-cutover.test.ts
+++ b/tests/test-og-share-song-key-cutover.test.ts
@@ -1,15 +1,33 @@
-import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
 import { redisKeys } from "../src/shared/redisKeys";
 import { FakeRedis } from "./fake-redis";
+import * as actualRedis from "../api/_utils/redis";
 
 let fake: FakeRedis;
 
 // og-share resolves song metadata through `createRedis()` from this module
 // (dynamically imported inside createSongRedisClient). Point it at a fake so we
-// exercise the real getSongFromRedis key-reading logic.
+// exercise the real getSongFromRedis key-reading logic. Spread the real module
+// so other exports (e.g. supportsRedisPubSub, used by realtime.ts) survive —
+// Bun module mocks are global and persist across files in the same run.
 mock.module("../api/_utils/redis.js", () => ({
+  ...actualRedis,
   createRedis: () => fake,
 }));
+
+// Restore the real module after this file so the createRedis override does not
+// leak into later test files.
+afterAll(() => {
+  mock.module("../api/_utils/redis.js", () => actualRedis);
+});
 
 let ogShare: typeof import("../api/_utils/og-share");
 

--- a/tests/test-private-room-last-message-cutover.test.ts
+++ b/tests/test-private-room-last-message-cutover.test.ts
@@ -1,16 +1,30 @@
-import { beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
 import { redisKeys } from "../src/shared/redisKeys";
 import { FakeRedis } from "./fake-redis";
+import * as actualRedis from "../api/_utils/redis";
+import * as actualRedisHelpers from "../api/_utils/redis-helpers";
 
 let fake: FakeRedis;
 
 // Presence helpers resolve their client through createRedis() in this module.
+// Spread the real module so other exports (e.g. supportsRedisPubSub) survive —
+// Bun module mocks are global and persist across files in the same run.
 mock.module("../api/_utils/redis.js", () => ({
+  ...actualRedis,
   createRedis: () => fake,
 }));
 
 // Room discovery (getAllRoomIds) resolves its client through redis-helpers.
 mock.module("../api/_utils/redis-helpers.js", () => ({
+  ...actualRedisHelpers,
   createRedisClient: () => fake,
   generateRandomHexId: (byteLength: number) => "a".repeat(byteLength * 2),
   getCurrentTimestamp: () => 1_718_180_000_000,
@@ -27,6 +41,12 @@ mock.module("../api/_utils/redis-helpers.js", () => ({
     return null;
   },
 }));
+
+// Restore the real modules after this file so the overrides do not leak.
+afterAll(() => {
+  mock.module("../api/_utils/redis.js", () => actualRedis);
+  mock.module("../api/_utils/redis-helpers.js", () => actualRedisHelpers);
+});
 
 let presence: typeof import("../api/rooms/_helpers/_presence");
 

--- a/tests/test-pusher-client-constructor-wiring.test.ts
+++ b/tests/test-pusher-client-constructor-wiring.test.ts
@@ -1,54 +1,98 @@
 #!/usr/bin/env bun
 /**
- * Guardrail tests for pusher client constructor resolution wiring.
+ * Tests for pusher client constructor resolution.
  *
  * Why:
  * A prior regression relied on globalThis.Pusher only, which broke under Vite
- * module builds. These checks ensure module-default + global fallback logic
- * stays in place.
+ * module builds. The resolver now prefers the dynamically-imported module
+ * default and falls back to a global constructor. These tests exercise that
+ * resolution behaviorally; the remaining two checks are structural guards that
+ * keep pusher-js out of the static import graph (no runtime equivalent).
  */
 
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
-import { describe, test, expect } from "bun:test";
+import { afterEach, describe, test, expect } from "bun:test";
+
+import { getPusherConstructor } from "../src/lib/pusherClient";
 
 const readPusherClientSource = (): string =>
   readFileSync(resolve(process.cwd(), "src/lib/pusherClient.ts"), "utf-8");
 
-describe("Pusher Constructor Wiring Tests", () => {
-  describe("Constructor resolution fallback", () => {
-    test("checks module default constructor first", async () => {
-      const source = readPusherClientSource();
-      expect(source.includes("constructorFromModule")).toBe(true);
-      expect(/PusherNamespace[\s\S]*default\?/.test(source)).toBe(true);
-    });
+const globalWithPusher = globalThis as typeof globalThis & {
+  Pusher?: unknown;
+};
 
-    test("falls back to global constructor when needed", async () => {
-      const source = readPusherClientSource();
-      expect(source.includes("constructorFromGlobal")).toBe(true);
-      expect(source.includes("globalWithPusher.Pusher")).toBe(true);
-    });
+class FakePusher {
+  constructor(
+    public key: string,
+    public options: Record<string, unknown>
+  ) {}
+}
 
-    test("throws explicit error when no constructor is available", async () => {
-      const source = readPusherClientSource();
-      expect(source.includes("[pusherClient] Pusher constructor not available")).toBe(true);
-    });
+describe("Pusher constructor resolution", () => {
+  afterEach(() => {
+    delete globalWithPusher.Pusher;
+  });
 
-    test("getPusherClient instantiates via constructor resolver", async () => {
-      const source = readPusherClientSource();
-      expect(/const Pusher = getPusherConstructor\(PusherNamespace\);/.test(source)).toBe(true);
-      expect(/new Pusher\(PUSHER_APP_KEY/.test(source)).toBe(true);
-    });
+  test("prefers the module default export", () => {
+    delete globalWithPusher.Pusher;
+    const resolved = getPusherConstructor({ default: FakePusher });
+    expect(resolved).toBe(FakePusher as never);
+  });
 
-    test("loads pusher-js only through a provider-branch dynamic import", async () => {
-      const source = readPusherClientSource();
-      expect(/import\s+(?!type)[^;]*["']pusher-js["']/.test(source)).toBe(false);
-      expect(source.includes('import("pusher-js")')).toBe(true);
-      expect(
-        /if \(getRealtimeProvider\(\) === "local"\)[\s\S]*\} else \{[\s\S]*import\("pusher-js"\)/.test(
-          source
-        )
-      ).toBe(true);
+  test("module default wins even when a global constructor exists", () => {
+    class GlobalPusher {}
+    globalWithPusher.Pusher = GlobalPusher;
+    const resolved = getPusherConstructor({ default: FakePusher });
+    expect(resolved).toBe(FakePusher as never);
+  });
+
+  test("falls back to the global constructor when no module default", () => {
+    class GlobalPusher {}
+    globalWithPusher.Pusher = GlobalPusher;
+    expect(getPusherConstructor({})).toBe(GlobalPusher as never);
+    // A namespace with an undefined default still falls through to the global.
+    expect(getPusherConstructor({ default: undefined })).toBe(
+      GlobalPusher as never
+    );
+  });
+
+  test("throws an explicit error when no constructor is available", () => {
+    delete globalWithPusher.Pusher;
+    expect(() => getPusherConstructor({})).toThrow(
+      "[pusherClient] Pusher constructor not available"
+    );
+  });
+
+  test("the resolved constructor is what getPusherClient instantiates with", () => {
+    delete globalWithPusher.Pusher;
+    const Resolved = getPusherConstructor({ default: FakePusher });
+    const instance = new Resolved("app-key", {
+      cluster: "us2",
+      forceTLS: true,
     });
+    expect(instance).toBeInstanceOf(FakePusher);
+    expect((instance as unknown as FakePusher).key).toBe("app-key");
+  });
+});
+
+describe("Pusher static-import guards (structural)", () => {
+  test("instantiates pusher via the constructor resolver", () => {
+    const source = readPusherClientSource();
+    expect(source).toMatch(
+      /const Pusher = getPusherConstructor\(PusherNamespace\);/
+    );
+    expect(source).toMatch(/new Pusher\(PUSHER_APP_KEY/);
+  });
+
+  test("loads pusher-js only through a provider-branch dynamic import", () => {
+    const source = readPusherClientSource();
+    // No static `import ... "pusher-js"` (type-only imports are allowed).
+    expect(source).not.toMatch(/import\s+(?!type)[^;]*["']pusher-js["']/);
+    expect(source).toContain('import("pusher-js")');
+    expect(source).toMatch(
+      /if \(getRealtimeProvider\(\) === "local"\)[\s\S]*\} else \{[\s\S]*import\("pusher-js"\)/
+    );
   });
 });

--- a/tests/test-ryo-conversation-prompt-caching.test.ts
+++ b/tests/test-ryo-conversation-prompt-caching.test.ts
@@ -190,7 +190,7 @@ describe("prompt caching structure", () => {
     expect(result.volatileStatePrompt).toContain("system_state");
   });
 
-  test("prepareRyoConversationModelInput emits two system messages without memories", async () => {
+  test("prepareRyoConversationModelInput emits three system messages without memories", async () => {
     const result = await prepareRyoConversationModelInput({
       channel: "chat",
       messages: [{ id: "1", role: "user", content: "hello" }],

--- a/tests/test-ryos-fullscreen.test.ts
+++ b/tests/test-ryos-fullscreen.test.ts
@@ -1,6 +1,24 @@
 #!/usr/bin/env bun
 
-import { describe, expect, test, beforeEach, afterEach } from "bun:test";
+import { describe, expect, test, beforeAll, afterAll, beforeEach, afterEach } from "bun:test";
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+
+// These helpers operate on the real DOM (document.getElementById,
+// document.documentElement, document.fullscreenElement). Bun has no DOM by
+// default, so register happy-dom for this suite — otherwise every test would
+// silently no-op. See the previous `typeof document === "undefined"` guards.
+beforeAll(() => {
+  if (typeof document === "undefined") {
+    GlobalRegistrator.register();
+  }
+});
+
+afterAll(() => {
+  if (GlobalRegistrator.isRegistered) {
+    GlobalRegistrator.unregister();
+  }
+});
+
 import {
   RYOS_FULLSCREEN_ROOT_ID,
   getRyosFullscreenElement,
@@ -13,20 +31,16 @@ describe("ryosFullscreen", () => {
   let root: HTMLDivElement | null = null;
 
   beforeEach(() => {
-    if (typeof document === "undefined") {
-      return;
-    }
     root = document.createElement("div");
     root.id = RYOS_FULLSCREEN_ROOT_ID;
     document.body.appendChild(root);
   });
 
   afterEach(() => {
-    if (typeof document === "undefined" || !root) {
-      return;
+    if (root) {
+      root.remove();
+      root = null;
     }
-    root.remove();
-    root = null;
     Object.defineProperty(document, "fullscreenElement", {
       configurable: true,
       get: () => null,
@@ -34,26 +48,14 @@ describe("ryosFullscreen", () => {
   });
 
   test("getRyosFullscreenRoot returns the React shell root", () => {
-    if (typeof document === "undefined") {
-      expect(true).toBe(true);
-      return;
-    }
     expect(getRyosFullscreenRoot()).toBe(root);
   });
 
   test("getRyosFullscreenElement returns documentElement", () => {
-    if (typeof document === "undefined") {
-      expect(true).toBe(true);
-      return;
-    }
     expect(getRyosFullscreenElement()).toBe(document.documentElement);
   });
 
   test("isRyosFullscreenActive is false when another element is fullscreen", () => {
-    if (typeof document === "undefined" || !root) {
-      expect(true).toBe(true);
-      return;
-    }
     const other = document.createElement("div");
     document.body.appendChild(other);
     Object.defineProperty(document, "fullscreenElement", {
@@ -65,10 +67,6 @@ describe("ryosFullscreen", () => {
   });
 
   test("isRyosFullscreenActive is true when documentElement is fullscreen", () => {
-    if (typeof document === "undefined") {
-      expect(true).toBe(true);
-      return;
-    }
     Object.defineProperty(document, "fullscreenElement", {
       configurable: true,
       get: () => document.documentElement,
@@ -77,10 +75,6 @@ describe("ryosFullscreen", () => {
   });
 
   test("isRyosFullscreenSupported requires fullscreenEnabled and requestFullscreen on html", () => {
-    if (typeof document === "undefined" || !root) {
-      expect(true).toBe(true);
-      return;
-    }
     const originalEnabled = document.fullscreenEnabled;
     Object.defineProperty(document, "fullscreenEnabled", {
       configurable: true,

--- a/tests/test-share-applet.test.ts
+++ b/tests/test-share-applet.test.ts
@@ -8,13 +8,22 @@ import { describe, test, expect, beforeAll } from "bun:test";
 import { BASE_URL, fetchWithOrigin, fetchWithAuth, ensureUserAuth } from "./test-utils";
 
 let testAppletId: string | null = null;
-let testToken: string | null = null;
-let testUsername: string | null = null;
+let testToken: string;
+let testUsername: string;
 
 describe("share-applet", () => {
   beforeAll(async () => {
     testUsername = `shareuser${Math.floor(Math.random() * 100000)}`;
-    testToken = await ensureUserAuth(testUsername, "testpassword123");
+    const token = await ensureUserAuth(testUsername, "testpassword123");
+    // Fail loudly instead of silently skipping every authed test: a missing
+    // token means auth/registration is broken, which is exactly what these
+    // tests should catch.
+    if (!token) {
+      throw new Error(
+        "share-applet test setup failed: could not obtain an auth token"
+      );
+    }
+    testToken = token;
   });
 
   describe("HTTP Methods", () => {
@@ -29,7 +38,7 @@ describe("share-applet", () => {
       const res = await fetchWithOrigin(`${BASE_URL}/api/share-applet`, {
         method: "OPTIONS",
       });
-      expect(res.status === 200 || res.status === 204).toBe(true);
+      expect([200, 204]).toContain(res.status);
     });
   });
 
@@ -82,10 +91,6 @@ describe("share-applet", () => {
     });
 
     test("POST - missing content", async () => {
-      if (!testToken || !testUsername) {
-        console.log("  ⚠️  Skipped (test user not set up)");
-        return;
-      }
       const res = await fetchWithAuth(
         `${BASE_URL}/api/share-applet`,
         testUsername,
@@ -102,10 +107,6 @@ describe("share-applet", () => {
     });
 
     test("POST - success (create)", async () => {
-      if (!testToken || !testUsername) {
-        console.log("  ⚠️  Skipped (test user not set up)");
-        return;
-      }
       const res = await fetchWithAuth(
         `${BASE_URL}/api/share-applet`,
         testUsername,
@@ -131,10 +132,8 @@ describe("share-applet", () => {
     });
 
     test("GET - created applet", async () => {
-      if (!testAppletId) {
-        console.log("  ⚠️  Skipped (test applet not created)");
-        return;
-      }
+      // Hard-fail (not silent skip) if the create step did not produce an id.
+      expect(testAppletId).toBeTruthy();
       const res = await fetchWithOrigin(
         `${BASE_URL}/api/share-applet?id=${testAppletId}`
       );
@@ -147,10 +146,7 @@ describe("share-applet", () => {
     });
 
     test("GET - list applets", async () => {
-      if (!testAppletId) {
-        console.log("  ⚠️  Skipped (test applet not created)");
-        return;
-      }
+      expect(testAppletId).toBeTruthy();
       const res = await fetchWithOrigin(
         `${BASE_URL}/api/share-applet?list=true`
       );
@@ -164,10 +160,7 @@ describe("share-applet", () => {
     });
 
     test("POST - update applet (by owner)", async () => {
-      if (!testToken || !testUsername || !testAppletId) {
-        console.log("  ⚠️  Skipped (test data not set up)");
-        return;
-      }
+      expect(testAppletId).toBeTruthy();
       const res = await fetchWithAuth(
         `${BASE_URL}/api/share-applet`,
         testUsername,
@@ -189,15 +182,15 @@ describe("share-applet", () => {
     });
 
     test("POST - update by non-owner (should create new)", async () => {
-      if (!testAppletId) return;
+      expect(testAppletId).toBeTruthy();
       const otherUsername = `otheruser${Math.floor(Math.random() * 100000)}`;
       const otherToken = await ensureUserAuth(otherUsername, "testpassword123");
-      if (!otherToken) return;
+      expect(otherToken).toBeTruthy();
 
       const res = await fetchWithAuth(
         `${BASE_URL}/api/share-applet`,
         otherUsername,
-        otherToken,
+        otherToken!,
         {
           method: "POST",
           headers: { "Content-Type": "application/json" },
@@ -209,7 +202,7 @@ describe("share-applet", () => {
       );
       expect(res.status).toBe(200);
       const data = await res.json();
-      expect(data.id !== testAppletId).toBe(true);
+      expect(data.id).not.toBe(testAppletId);
     });
   });
 
@@ -223,10 +216,7 @@ describe("share-applet", () => {
     });
 
     test("DELETE - by non-admin", async () => {
-      if (!testToken || !testUsername || !testAppletId) {
-        console.log("  ⚠️  Skipped (test data not set up)");
-        return;
-      }
+      expect(testAppletId).toBeTruthy();
       const res = await fetchWithAuth(
         `${BASE_URL}/api/share-applet?id=${testAppletId}`,
         testUsername,
@@ -237,10 +227,7 @@ describe("share-applet", () => {
     });
 
     test("DELETE - with invalid token (forbidden)", async () => {
-      if (!testAppletId) {
-        console.log("  ⚠️  Skipped (test applet ID not set up)");
-        return;
-      }
+      expect(testAppletId).toBeTruthy();
       const res = await fetchWithAuth(
         `${BASE_URL}/api/share-applet?id=${testAppletId}`,
         "ryo",
@@ -265,10 +252,7 @@ describe("share-applet", () => {
     });
 
     test("PATCH - by non-admin", async () => {
-      if (!testToken || !testUsername || !testAppletId) {
-        console.log("  ⚠️  Skipped (test data not set up)");
-        return;
-      }
+      expect(testAppletId).toBeTruthy();
       const res = await fetchWithAuth(
         `${BASE_URL}/api/share-applet?id=${testAppletId}`,
         testUsername,
@@ -283,10 +267,7 @@ describe("share-applet", () => {
     });
 
     test("PATCH - with invalid token (forbidden)", async () => {
-      if (!testAppletId) {
-        console.log("  ⚠️  Skipped (test applet ID not set up)");
-        return;
-      }
+      expect(testAppletId).toBeTruthy();
       const res = await fetchWithAuth(
         `${BASE_URL}/api/share-applet?id=${testAppletId}`,
         "ryo",

--- a/tests/test-speech.test.ts
+++ b/tests/test-speech.test.ts
@@ -75,7 +75,7 @@ describe("speech", () => {
         const contentType = res.headers.get("content-type") || "";
         expect(contentType).toContain("audio");
         const buffer = await res.arrayBuffer();
-        expect(buffer.byteLength > 0).toBe(true);
+        expect(buffer.byteLength).toBeGreaterThan(0);
       } else if (res.status === 429) {
         const data = await res.json();
         expect(data.error).toBe("rate_limit_exceeded");

--- a/tests/test-speech.test.ts
+++ b/tests/test-speech.test.ts
@@ -20,7 +20,7 @@ describe("speech", () => {
       const res = await fetchWithOrigin(`${BASE_URL}/api/speech`, {
         method: "OPTIONS",
       });
-      expect(res.status === 200 || res.status === 204).toBe(true);
+      expect([200, 204]).toContain(res.status);
     });
   });
 
@@ -31,7 +31,7 @@ describe("speech", () => {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({}),
       });
-      expect(res.status === 400 || res.status === 429).toBe(true);
+      expect([400, 429]).toContain(res.status);
     });
 
     test("Empty text", async () => {
@@ -40,7 +40,7 @@ describe("speech", () => {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ text: "" }),
       });
-      expect(res.status === 400 || res.status === 429).toBe(true);
+      expect([400, 429]).toContain(res.status);
     });
 
     test("Whitespace only text", async () => {
@@ -49,7 +49,7 @@ describe("speech", () => {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ text: "   " }),
       });
-      expect(res.status === 400 || res.status === 429).toBe(true);
+      expect([400, 429]).toContain(res.status);
     });
 
     test("Invalid JSON", async () => {
@@ -94,13 +94,10 @@ describe("speech", () => {
           voice: "alloy",
         }),
       });
+      expect([200, 429]).toContain(res.status);
       if (res.status === 200) {
         const contentType = res.headers.get("content-type") || "";
         expect(contentType).toContain("audio");
-      } else if (res.status === 429) {
-        expect(true).toBe(true);
-      } else {
-        throw new Error(`Unexpected status: ${res.status}`);
       }
     });
 
@@ -113,18 +110,14 @@ describe("speech", () => {
           model: "elevenlabs",
         }),
       });
+      expect([200, 429, 503]).toContain(res.status);
       if (res.status === 200) {
         const contentType = res.headers.get("content-type") || "";
         expect(contentType).toContain("audio");
-      } else if (res.status === 429) {
-        expect(true).toBe(true);
       } else if (res.status === 503) {
         const data = await res.json();
-        expect(
-          typeof data.error === "string" && data.error.includes("ElevenLabs")
-        ).toBe(true);
-      } else {
-        throw new Error(`Unexpected status: ${res.status}`);
+        expect(typeof data.error).toBe("string");
+        expect(data.error).toContain("ElevenLabs");
       }
     });
 
@@ -142,13 +135,10 @@ describe("speech", () => {
           speed: 1.2,
         }),
       });
+      expect([200, 429]).toContain(res.status);
       if (res.status === 200) {
         const contentType = res.headers.get("content-type") || "";
         expect(contentType).toContain("audio");
-      } else if (res.status === 429) {
-        expect(true).toBe(true);
-      } else {
-        throw new Error(`Unexpected status: ${res.status}`);
       }
     });
 
@@ -160,9 +150,7 @@ describe("speech", () => {
           text: "Testing default model.",
         }),
       });
-      expect(
-        res.status === 200 || res.status === 429 || res.status === 503
-      ).toBe(true);
+      expect([200, 429, 503]).toContain(res.status);
     });
   });
 
@@ -175,13 +163,13 @@ describe("speech", () => {
           text: "Rate limit test.",
         }),
       });
+      expect([200, 429, 503]).toContain(res.status);
       if (res.status === 429) {
         const retryAfter = res.headers.get("Retry-After");
-        expect(retryAfter !== null).toBe(true);
+        expect(retryAfter).not.toBeNull();
         const limitHeader = res.headers.get("X-RateLimit-Limit");
-        expect(limitHeader !== null).toBe(true);
+        expect(limitHeader).not.toBeNull();
       }
-      expect(true).toBe(true);
     });
 
     test("CORS headers", async () => {
@@ -193,9 +181,7 @@ describe("speech", () => {
         }),
       });
       const allowOrigin = res.headers.get("Access-Control-Allow-Origin");
-      expect(
-        allowOrigin !== null || res.status >= 400
-      ).toBe(true);
+      expect(allowOrigin).toBe("http://localhost:3000");
     });
   });
 });

--- a/tests/test-sync-v2-api.test.ts
+++ b/tests/test-sync-v2-api.test.ts
@@ -200,16 +200,11 @@ describe("sync v2 API", () => {
     expect([401, 503]).toContain(badAuth.status);
   });
 
-  test(
+  // Visibly skipped (not a silent pass) when CRON_SECRET is not configured.
+  test.skipIf(!process.env.CRON_SECRET?.trim())(
     "sync maintenance cron runs with a valid secret",
     async () => {
-      const secret = process.env.CRON_SECRET?.trim();
-      if (!secret) {
-        console.warn(
-          "[sync-v2-api] CRON_SECRET not set; skipping authorized cron test"
-        );
-        return;
-      }
+      const secret = process.env.CRON_SECRET!.trim();
       const response = await fetchWithOrigin(
         `${BASE_URL}/api/cron/sync-maintenance?maxUsers=2`,
         { headers: { Authorization: `Bearer ${secret}` } }
@@ -224,7 +219,9 @@ describe("sync v2 API", () => {
       expect(typeof body.usersProcessed).toBe("number");
       expect(typeof body.scanComplete).toBe("boolean");
     },
-    30000
+    // The cron walks the keyspace via many bounded SCAN round-trips; against a
+    // large/shared Redis a single run can take ~30s, so allow generous margin.
+    90000
   );
 
   test("ops referencing a blob register it for dedupe", async () => {

--- a/tests/test-sync-v2-engine-e2e.test.ts
+++ b/tests/test-sync-v2-engine-e2e.test.ts
@@ -18,6 +18,20 @@ import { useCloudSyncStore } from "../src/stores/useCloudSyncStore";
 const USERNAME = `sync2eng${Date.now().toString(36)}`;
 const PASSWORD = "test-password-123";
 
+/** Resolve as soon as `predicate` is true, instead of sleeping a fixed amount. */
+async function waitFor(
+  predicate: () => boolean,
+  { timeoutMs = 2000, intervalMs = 10 }: { timeoutMs?: number; intervalMs?: number } = {}
+): Promise<void> {
+  const start = Date.now();
+  while (!predicate()) {
+    if (Date.now() - start > timeoutMs) {
+      throw new Error(`waitFor: condition not met within ${timeoutMs}ms`);
+    }
+    await new Promise((r) => setTimeout(r, intervalMs));
+  }
+}
+
 let token: string;
 let engine: CloudSyncEngine;
 const originalFetch = globalThis.fetch;
@@ -163,8 +177,13 @@ describe("sync v2 engine end-to-end", () => {
       c: "foreign-client",
       ops: [{ k: "stickies/note:e2e-rt", v: { id: "e2e-rt", content: "realtime" }, t, seq: body.seq, c: "foreign-client" }],
     });
-    // handleRealtimeEvent applies asynchronously.
-    await new Promise((resolve) => setTimeout(resolve, 300));
+    // handleRealtimeEvent applies asynchronously; wait until it lands instead
+    // of sleeping a fixed amount.
+    await waitFor(
+      () =>
+        useStickiesStore.getState().notes.some((note) => note.id === "e2e-rt") &&
+        engine.cursor === body.seq
+    );
 
     expect(
       useStickiesStore.getState().notes.some((note) => note.id === "e2e-rt")

--- a/tests/test-telegram-status.test.ts
+++ b/tests/test-telegram-status.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, test, jest } from "bun:test";
 import {
   deleteTelegramMessage,
   editTelegramMessageText,
@@ -52,36 +52,45 @@ describe("telegram status helpers", () => {
   test("keeps the latest tool status visible while typing continues", async () => {
     const calls: Array<{ type: string; text?: string; messageId?: number }> = [];
 
-    const reporter = createTelegramStatusReporter({
-      botToken: "bot-token",
-      chatId: "chat-123",
-      typingRefreshMs: 10,
-      deps: {
-        sendMessage: async ({ text }) => {
-          calls.push({ type: "send", text });
-          return 9001;
+    // Fake timers make the typing-refresh interval deterministic: start() emits
+    // one immediate typing action, then we advance past exactly two refresh
+    // windows (10ms each) instead of sleeping 25ms and hoping the interval ran.
+    jest.useFakeTimers();
+    try {
+      const reporter = createTelegramStatusReporter({
+        botToken: "bot-token",
+        chatId: "chat-123",
+        typingRefreshMs: 10,
+        deps: {
+          sendMessage: async ({ text }) => {
+            calls.push({ type: "send", text });
+            return 9001;
+          },
+          editMessage: async ({ text, messageId }) => {
+            calls.push({ type: "edit", text, messageId });
+          },
+          deleteMessage: async ({ messageId }) => {
+            calls.push({ type: "delete", messageId });
+          },
+          sendChatAction: async () => {
+            calls.push({ type: "typing" });
+          },
         },
-        editMessage: async ({ text, messageId }) => {
-          calls.push({ type: "edit", text, messageId });
-        },
-        deleteMessage: async ({ messageId }) => {
-          calls.push({ type: "delete", messageId });
-        },
-        sendChatAction: async () => {
-          calls.push({ type: "typing" });
-        },
-      },
-    });
+      });
 
-    await reporter.start();
-    await Bun.sleep(25);
-    await reporter.markTool("memoryRead", {});
-    await reporter.markTool("memoryRead", {});
-    await reporter.markThinking();
-    await reporter.markTool("calendarControl", { action: "create" });
-    await reporter.dispose();
+      await reporter.start();
+      jest.advanceTimersByTime(25); // typing interval fires at 10ms and 20ms
+      await reporter.markTool("memoryRead", {});
+      await reporter.markTool("memoryRead", {});
+      await reporter.markThinking();
+      await reporter.markTool("calendarControl", { action: "create" });
+      await reporter.dispose();
+    } finally {
+      jest.useRealTimers();
+    }
 
-    expect(calls.filter((call) => call.type === "typing").length).toBeGreaterThanOrEqual(2);
+    // start() (1) + two interval ticks (2) = 3 typing actions.
+    expect(calls.filter((call) => call.type === "typing").length).toBe(3);
     expect(calls.filter((call) => call.type === "send")).toEqual([
       { type: "send", text: "Checking memory..." },
     ]);

--- a/tests/test-toast-action-button-theming.test.ts
+++ b/tests/test-toast-action-button-theming.test.ts
@@ -2,10 +2,15 @@ import { describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 
-const themesCss = readFileSync(
-  join(import.meta.dir, "../src/styles/themes.css"),
-  "utf8"
-);
+// themes.css is now just an aggregator of @imports; the macOS toast button
+// rules live in the split aqua (light) and dark-aqua (dark) theme files.
+const themesCss = [
+  readFileSync(join(import.meta.dir, "../src/styles/themes/aqua.css"), "utf8"),
+  readFileSync(
+    join(import.meta.dir, "../src/styles/themes/dark-aqua.css"),
+    "utf8"
+  ),
+].join("\n");
 const sonnerSource = readFileSync(
   join(import.meta.dir, "../src/components/ui/sonner.tsx"),
   "utf8"

--- a/tests/test-web-fetch.test.ts
+++ b/tests/test-web-fetch.test.ts
@@ -1,112 +1,19 @@
 /**
  * Unit tests for the webFetch tool's HTML-to-text extraction.
  *
- * These tests exercise the pure HTML→text logic that mirrors the executor's
- * internal helpers. No server or network access needed.
+ * These import the real helpers from api/chat/tools/htmlExtract.ts (the same
+ * module executors.ts uses), so the tests fail if the production logic changes.
+ * No server or network access needed.
  */
 
 import { describe, test, expect } from "bun:test";
 import { decodeHtmlEntitiesOnce } from "../api/_utils/html-entities";
-
-// ---------------------------------------------------------------------------
-// Inline copy of the stripping helpers (kept in sync with executors.ts)
-// ---------------------------------------------------------------------------
-
-const DANGEROUS_URL_SCHEMES = /^(?:javascript|data|vbscript|blob):/i;
-
-function stripTagsLoop(html: string, pattern: RegExp, maxPasses = 10): string {
-  let result = html;
-  for (let i = 0; i < maxPasses; i++) {
-    const next = result.replace(pattern, "");
-    if (next === result) break;
-    result = next;
-  }
-  return result;
-}
-
-function extractMainContent(html: string): string {
-  const mainPatterns = [
-    /<main[^>]*>([\s\S]*?)<\/main>/i,
-    /<article[^>]*>([\s\S]*?)<\/article>/i,
-    /<div[^>]*(?:id|class)=["'][^"']*(?:content|article|post|entry|main-body|main_content|page-content|post-content)[^"']*["'][^>]*>([\s\S]*?)<\/div>/i,
-    /<div[^>]*role=["']main["'][^>]*>([\s\S]*?)<\/div>/i,
-  ];
-
-  for (const pattern of mainPatterns) {
-    const match = html.match(pattern);
-    if (match) {
-      const content = match[1] || match[0];
-      if (content.length > 200) return content;
-    }
-  }
-
-  return html;
-}
-
-function stripHtmlToText(html: string, selector?: string): string {
-  let working = html;
-
-  if (!selector) {
-    working = extractMainContent(working);
-  }
-
-  working = stripTagsLoop(working, /<script\b[\s\S]*?<\/script[^>]*>/gi);
-  working = stripTagsLoop(working, /<style\b[\s\S]*?<\/style[^>]*>/gi);
-  working = stripTagsLoop(working, /<noscript\b[\s\S]*?<\/noscript[^>]*>/gi);
-  working = stripTagsLoop(working, /<nav\b[\s\S]*?<\/nav[^>]*>/gi);
-  working = stripTagsLoop(working, /<footer\b[\s\S]*?<\/footer[^>]*>/gi);
-  working = stripTagsLoop(working, /<header\b[\s\S]*?<\/header[^>]*>/gi);
-  working = stripTagsLoop(working, /<!--[\s\S]*?-->/g);
-  working = stripTagsLoop(working, /<svg\b[\s\S]*?<\/svg[^>]*>/gi);
-
-  working = working.replace(/<(h[1-6])[^>]*>([\s\S]*?)<\/\1>/gi, (_m, tag, inner) => {
-    const level = parseInt(tag.charAt(1), 10);
-    return "\n" + "#".repeat(level) + " " + inner.trim() + "\n";
-  });
-
-  working = working.replace(/<li[^>]*>/gi, "\n- ");
-  working = working.replace(/<\/li>/gi, "");
-  working = working.replace(/<br\s*\/?>/gi, "\n");
-  working = working.replace(/<\/p>/gi, "\n\n");
-  working = working.replace(/<\/div>/gi, "\n");
-  working = working.replace(/<\/tr>/gi, "\n");
-  working = working.replace(/<td[^>]*>/gi, "\t");
-
-  working = working.replace(/<a[^>]*href=["']([^"']+)["'][^>]*>([\s\S]*?)<\/a>/gi, (_m, href, text) => {
-    const linkText = stripTagsLoop(text, /<[^>]+>/g).trim();
-    if (!linkText) return "";
-    if (href.startsWith("#") || DANGEROUS_URL_SCHEMES.test(href)) return linkText;
-    return `${linkText} (${href})`;
-  });
-
-  working = stripTagsLoop(working, /<[^>]+>/g);
-
-  working = decodeHtmlEntitiesOnce(working);
-
-  working = working.replace(/[ \t]+/g, " ");
-  working = working.replace(/\n[ \t]+/g, "\n");
-  working = working.replace(/\n{3,}/g, "\n\n");
-  working = working.trim();
-
-  return working;
-}
-
-function extractMetadata(html: string) {
-  const result: { title?: string; description?: string; siteName?: string } = {};
-
-  const ogTitle = html.match(/<meta[^>]*property=["']og:title["'][^>]*content=["']([^"']+)["'][^>]*>/i);
-  const titleTag = html.match(/<title[^>]*>([\s\S]*?)<\/title>/i);
-  result.title = ogTitle?.[1]?.trim() || titleTag?.[1]?.trim().replace(/\s+/g, " ");
-
-  const ogDesc = html.match(/<meta[^>]*property=["']og:description["'][^>]*content=["']([^"']+)["'][^>]*>/i);
-  const metaDesc = html.match(/<meta[^>]*name=["']description["'][^>]*content=["']([^"']+)["'][^>]*>/i);
-  result.description = ogDesc?.[1]?.trim() || metaDesc?.[1]?.trim();
-
-  const ogSite = html.match(/<meta[^>]*property=["']og:site_name["'][^>]*content=["']([^"']+)["'][^>]*>/i);
-  result.siteName = ogSite?.[1]?.trim();
-
-  return result;
-}
+import {
+  DANGEROUS_URL_SCHEMES,
+  extractMetadata,
+  stripHtmlToText,
+  stripTagsLoop,
+} from "../api/chat/tools/htmlExtract";
 
 // ---------------------------------------------------------------------------
 // Tests


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Fixes the findings from the test-suite audit: tests that **always pass regardless of behavior**, mislabeled and weakly-asserted tests, and (in follow-up commits) the larger refactors that were originally deferred. Every change was verified end-to-end against a running API server (`bun run dev:api`, all secrets present) and the unit suite.

## Fixes (all verified)

**Tier 1 — tests that asserted nothing / always passed**
- `test-ryos-fullscreen`: Bun has no DOM, so all 5 tests took the `if (typeof document === "undefined") { expect(true).toBe(true) }` no-op branch and verified nothing. Now registers `happy-dom` (scoped `beforeAll`/`afterAll`) so all 5 exercise the real fullscreen logic.
- `test-iframe-check`: replaced `expect(title !== null || true)` and `expect(!html.includes("Geneva-12") || html.includes("Geneva-12"))` (both always true) and `typeof boolean` checks with concrete assertions verified against the endpoint.
- `test-ai` / `test-media` / `test-speech`: removed the literal `expect(true)` terminators and per-branch `expect(true)` acknowledgements; each conditional test now asserts a recognized status up front while keeping deep checks for 200/429/503.

**Tier 2 — assertions that passed on failure**
- `test-ai` `ryo-reply` validation tests used an invalid token, so they only ever hit 401. They now authenticate with a real per-run user and assert the real `400` paths.
- `test-link-preview` "Cache headers" `expect(cacheControl !== null || true)` → asserts `200` + a present `Cache-Control: …max-age…`.

**Tier 3/4 — bad methods, mislabeled, stale**
- Converted `expect(a === b).toBeTruthy()` / `expect(x !== null).toBe(true)` / `expect(status >= 400).toBe(true)` to idiomatic matchers for real failure diagnostics.
- `test-chat-streaming-perf`: replaced the `decodeHtmlEntities` source-grep with a behavioral tag-stripping assertion.
- Fixed mislabeled titles (prompt-caching "two"→"three" system messages; background-hook lifecycle test name).
- `test-auth-ban-lockout`: idiomatic `toContain` for the threshold-boundary status.

## Follow-up (previously "out of scope", now resolved)

- **Circular-import quirk** (`Export named 'supportsRedisPubSub' not found` when `test-redis-*` / `*-cutover` run together): the offending suites replaced the whole `redis.js` / `redis-helpers.js` modules via `mock.module`. They now spread the real module (`...actual`) and restore it in `afterAll`, so the global Bun mock no longer leaks an incomplete shape. Verified by running the cutover suites together.
- **`test-link-preview` external host**: dropped the flaky `httpstat.us` "404" case for deterministic SSRF-guard coverage (`127.0.0.1`, `169.254.169.254` → `400`) and added per-request rate-limit-bypass headers.
- **Mirrored-logic tests**: exported the real production functions and made the tests import them — `mapWordTimingsToFurigana`/`getTrailingWhitespace` (furigana), and a new `api/chat/tools/htmlExtract.ts` module that both `executors.ts` and `test-web-fetch` consume.
- **Sleep-based timing tests**: converted to fake timers (`jest.useFakeTimers`) for debounce/background-task/telegram-status, and to `waitFor`/microtask-flush polling for the IRC-bridge and sync-v2 e2e flows.
- **Silent-`return`-on-missing-setup suites**: `test-share-applet` now throws in `beforeAll` on auth failure; `test-admin` and the `sync-maintenance` cron test use `test.skipIf` so missing prerequisites are visibly skipped instead of silently passing. (Surfaced + fixed a real object-shaped persisted maintenance cursor bug in `api/sync/v2/_maintenance.ts`.)
- **~22 source-string "wiring" suites**: converted the pure-logic ones to behavioral tests — exported `getPusherConstructor` and exercised its module-default/global-fallback/throw branches; the analytics + auth "exports" checks now import the modules and assert `typeof === "function"`. The remaining genuine structural guards (import graph, composition, CSS) stay source-based but had their weak `expect(regex.test(src)).toBe(true)` / `expect(x >= n).toBe(true)` matchers replaced with `toMatch` / `toBeGreaterThanOrEqual`.
- **Stale CSS guard**: `test-toast-action-button-theming` read the now-aggregator-only `themes.css`; it now reads the split `themes/aqua.css` + `themes/dark-aqua.css` where the macOS toast-button rules actually live.

## Verification
- `bun run test:unit`: **372 pass / 0 fail**.
- All PR-touched API suites pass individually against `dev:api`: `new-api` (30), `link-preview` (12), `media` (18), `speech` (13), `iframe-check` (14), `ai` (40), `share-applet` (18), `admin` (15), `auth-ban-lockout` (7), `sync-v2-api` (10), `sync-v2-engine-e2e` (7), `irc-bridge` (29).
- Note: running all 196 files (`bun test`) or the full `test:api` batch at once overwhelms the single shared API server + slow shared Upstash Redis (a single `/api/rooms` call takes ~4s), so AI/songs/speech tests exceed the 5000ms per-test timeout. These are environmental timeouts, not regressions — the same suites pass when run individually or in small batches.

## Dependencies
- Adds `happy-dom` + `@happy-dom/global-registrator` as devDependencies (DOM for the fullscreen + decode tests).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019edbaa-617d-7e19-bafb-26f0f773bcd7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019edbaa-617d-7e19-bafb-26f0f773bcd7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

