### PR TITLE
fix: use versioned GitHub release tags for desktop download URLs

### DIFF
--- a/src/utils/desktopDownload.ts
+++ b/src/utils/desktopDownload.ts
@@ -1,4 +1,3 @@
-export const RYOS_DESKTOP_RELEASE_TAG = "desktop";
 export const RYOS_DESKTOP_RELEASE_BASE_URL =
   "https://github.com/ryokun6/ryos/releases/download";
 
@@ -131,5 +130,6 @@ export function getDesktopDownloadUrl(
     return null;
   }
 
-  return `${RYOS_DESKTOP_RELEASE_BASE_URL}/${RYOS_DESKTOP_RELEASE_TAG}/${assetName}`;
+  const releaseTag = version.startsWith("v") ? version : `v${version}`;
+  return `${RYOS_DESKTOP_RELEASE_BASE_URL}/${releaseTag}/${assetName}`;
 }

--- a/tests/test-desktop-download.test.ts
+++ b/tests/test-desktop-download.test.ts
@@ -11,7 +11,7 @@ describe("desktop download URLs", () => {
     expect(
       getDesktopDownloadUrl("1.0.5", { platform: "mac", arch: "aarch64" })
     ).toBe(
-      "https://github.com/ryokun6/ryos/releases/download/desktop/ryOS_1.0.5_aarch64.dmg"
+      "https://github.com/ryokun6/ryos/releases/download/v1.0.5/ryOS_1.0.5_aarch64.dmg"
     );
   });
 
@@ -19,7 +19,7 @@ describe("desktop download URLs", () => {
     expect(
       getDesktopDownloadUrl("1.0.5", { platform: "windows", arch: "x64" })
     ).toBe(
-      "https://github.com/ryokun6/ryos/releases/download/desktop/ryOS_1.0.5_x64.exe"
+      "https://github.com/ryokun6/ryos/releases/download/v1.0.5/ryOS_1.0.5_x64.exe"
     );
   });
 
@@ -32,7 +32,7 @@ describe("desktop download URLs", () => {
       platformLabel: "Mac",
     });
     expect(target && getDesktopDownloadUrl("1.0.5", target)).toBe(
-      "https://github.com/ryokun6/ryos/releases/download/desktop/ryOS_1.0.5_aarch64.dmg"
+      "https://github.com/ryokun6/ryos/releases/download/v1.0.5/ryOS_1.0.5_aarch64.dmg"
     );
   });
 
@@ -51,7 +51,7 @@ describe("desktop download URLs", () => {
         platformLabel: "Windows",
       });
       expect(target && getDesktopDownloadUrl("1.0.5", target)).toBe(
-        "https://github.com/ryokun6/ryos/releases/download/desktop/ryOS_1.0.5_x64.exe"
+        "https://github.com/ryokun6/ryos/releases/download/v1.0.5/ryOS_1.0.5_x64.exe"
       );
     }
   });
@@ -117,7 +117,7 @@ describe("desktop download URLs", () => {
     expect(
       getDesktopDownloadUrl("2.3.4", { platform: "mac", arch: "aarch64" })
     ).toBe(
-      "https://github.com/ryokun6/ryos/releases/download/desktop/ryOS_2.3.4_aarch64.dmg"
+      "https://github.com/ryokun6/ryos/releases/download/v2.3.4/ryOS_2.3.4_aarch64.dmg"
     );
   });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Desktop download links were pointing at a static `desktop` GitHub release tag, which no longer matches how releases are published. This updates URL generation to use per-version tags (e.g. `v1.0.8`).

## Changes

- Updated `getDesktopDownloadUrl()` in `src/utils/desktopDownload.ts` to build URLs like:
  - Mac: `https://github.com/ryokun6/ryos/releases/download/v1.0.8/ryOS_1.0.8_aarch64.dmg`
  - Windows: `https://github.com/ryokun6/ryos/releases/download/v1.0.8/ryOS_1.0.8_x64.exe`
- Removed the obsolete `RYOS_DESKTOP_RELEASE_TAG = "desktop"` constant
- Updated unit test expectations in `tests/test-desktop-download.test.ts`

## Affected UI

This fixes download links surfaced in:
- First-visit / update toasts in `App.tsx` ("ryOS is available as a Mac or Windows app")
- About Finder dialog Mac download CTA

## Testing

- `bun test tests/test-desktop-download.test.ts` — all 8 tests pass
- Verified v1.0.8 URLs match the expected GitHub release asset paths exactly
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6b9699dd-5bff-4087-835f-a949288fa6da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6b9699dd-5bff-4087-835f-a949288fa6da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

