### PR TITLE
Narrow shader "off" tier to really-bad devices

### DIFF
--- a/src/stores/useDisplaySettingsStore.ts
+++ b/src/stores/useDisplaySettingsStore.ts
@@ -129,9 +129,13 @@ interface DisplaySettingsState {
   bumpCustomWallpapersRevision: () => void;
 }
 
-const STORE_VERSION = 1;
+// Bumped to 2 to re-evaluate the shader default for existing users: the old
+// strict heuristic auto-disabled shaders on phones / mid-range devices, and
+// that `false` was persisted. The migration below re-enables them on any device
+// that now classifies above the "off" tier.
+const STORE_VERSION = 2;
 // Default the master shader toggle on for every device except the "off" tier
-// (extremely low-end / low-power). Reduced-tier devices still default on and
+// (genuinely incapable hardware). Reduced-tier devices still default on and
 // simply render at lower quality (see useReducedGraphics).
 const initialShaderState = getPerformanceTier() !== "off";
 
@@ -336,6 +340,26 @@ export const useDisplaySettingsStore = create<DisplaySettingsState>()(
     {
       name: "ryos:display-settings",
       version: STORE_VERSION,
+      migrate: (persistedState, fromVersion) => {
+        const state = persistedState as
+          | Partial<DisplaySettingsState>
+          | undefined;
+        if (!state) return persistedState as DisplaySettingsState;
+        // v1 → v2: the old heuristic disabled shaders on phones / mid devices.
+        // Re-enable them wherever the device now classifies above "off"; leave
+        // truly low-end ("off") devices and any other choices untouched.
+        if (
+          fromVersion < 2 &&
+          state.shaderEffectEnabled === false &&
+          getPerformanceTier() !== "off"
+        ) {
+          return {
+            ...state,
+            shaderEffectEnabled: true,
+          } as unknown as DisplaySettingsState;
+        }
+        return state as unknown as DisplaySettingsState;
+      },
       partialize: (state) => ({
         displayMode: state.displayMode,
         shaderEffectEnabled: state.shaderEffectEnabled,

--- a/src/utils/performanceTier.ts
+++ b/src/utils/performanceTier.ts
@@ -4,10 +4,11 @@
  * A single 3-tier signal replaces the two previously independent heuristics
  * (the boot-time on/off probe and the per-component "reduced graphics" check):
  *
- * - `"off"`     — extremely low-end / low-power devices that can't render
- *                 shaders acceptably even at reduced quality (no WebGL, no
- *                 high-precision floats, tiny GPU limits, or very few cores /
- *                 very little RAM). Shaders default OFF here.
+ * - `"off"`     — only genuinely incapable / really-bad devices: no WebGL at
+ *                 all, a single CPU core, or extremely little RAM (≤512MB).
+ *                 Everything that can plausibly render a shader lands in
+ *                 `"reduced"` instead, so phones and mid-range hardware are NOT
+ *                 cut off. Shaders default OFF only here.
  * - `"reduced"` — phones, tablets, and low-/mid-performance PCs. Shaders run in
  *                 their reduced-quality tier (lower internal resolution / frame
  *                 rate / backing-buffer size).
@@ -20,12 +21,16 @@
  */
 export type PerformanceTier = "off" | "reduced" | "full";
 
-/** Cores at/below this count are treated as extremely low-end (→ off). */
-const OFF_MAX_CORES = 2;
-/** Device memory (GB) at/below this is treated as extremely low-end (→ off). */
-const OFF_MAX_MEMORY_GB = 1;
-/** GPUs reporting a smaller max texture size are treated as too weak (→ off). */
-const OFF_MIN_TEXTURE_SIZE = 4096;
+// "off" is intentionally a very small set — only genuinely unusable hardware.
+// Quality signals that used to force "off" (high-precision floats, max texture
+// size) now only gate the full-vs-reduced decision, so capable-but-modest
+// devices (phones, tablets, budget laptops) get reduced-quality shaders rather
+// than nothing.
+
+/** A device with at most this many CPU cores is treated as really bad (→ off). */
+const OFF_MAX_CORES = 1;
+/** Device memory (GB) at/below this is treated as really bad (→ off). */
+const OFF_MAX_MEMORY_GB = 0.5;
 
 /** Non-mobile devices need at least this many cores for the full tier. */
 const FULL_MIN_CORES = 8;
@@ -159,11 +164,8 @@ export function getPerformanceTier(): PerformanceTier {
 
   const caps = getHardwareCapabilities();
 
-  // --- "off": extremely low-end / low-power, can't render shaders acceptably.
+  // --- "off": only genuinely incapable / really-bad devices.
   if (!caps.webglSupported) return "off";
-  if (!caps.highpSupported) return "off";
-  if (caps.maxTextureSize > 0 && caps.maxTextureSize < OFF_MIN_TEXTURE_SIZE)
-    return "off";
   if (caps.cores > 0 && caps.cores <= OFF_MAX_CORES) return "off";
   if (caps.memory !== null && caps.memory <= OFF_MAX_MEMORY_GB) return "off";
 
@@ -172,13 +174,14 @@ export function getPerformanceTier(): PerformanceTier {
   if (
     !mobile &&
     caps.cores >= FULL_MIN_CORES &&
+    caps.highpSupported &&
     caps.maxAnisotropy >= FULL_MIN_ANISOTROPY &&
     caps.maxTextureSize >= FULL_MIN_TEXTURE_SIZE
   ) {
     return "full";
   }
 
-  // --- "reduced": phones, tablets, low-/mid-performance PCs.
+  // --- "reduced": everything else — phones, tablets, low-/mid-performance PCs.
   return "reduced";
 }
 

--- a/tests/test-performance-tier.test.ts
+++ b/tests/test-performance-tier.test.ts
@@ -117,29 +117,19 @@ afterEach(() => {
   __resetPerformanceTierCacheForTests();
 });
 
-describe("getPerformanceTier — off tier (extremely low-end / low-power)", () => {
+describe("getPerformanceTier — off tier (only really-bad devices)", () => {
   test("no WebGL support → off", () => {
     applyEnv({ webgl: false, cores: 8 });
     expect(getPerformanceTier()).toBe("off");
   });
 
-  test("no high-precision floats → off", () => {
-    applyEnv({ highp: false, cores: 8 });
+  test("single CPU core → off", () => {
+    applyEnv({ cores: 1 });
     expect(getPerformanceTier()).toBe("off");
   });
 
-  test("tiny max texture size → off", () => {
-    applyEnv({ textureSize: 2048, cores: 8 });
-    expect(getPerformanceTier()).toBe("off");
-  });
-
-  test("very low core count → off", () => {
-    applyEnv({ cores: 2 });
-    expect(getPerformanceTier()).toBe("off");
-  });
-
-  test("very low device memory → off", () => {
-    applyEnv({ cores: 8, memory: 1 });
+  test("extremely low device memory (≤512MB) → off", () => {
+    applyEnv({ cores: 8, memory: 0.5 });
     expect(getPerformanceTier()).toBe("off");
   });
 });
@@ -167,6 +157,33 @@ describe("getPerformanceTier — reduced tier (phones, tablets, mid PCs)", () =>
     expect(getPerformanceTier()).toBe("reduced");
   });
 
+  test("phone without fragment highp is still reduced, not off", () => {
+    applyEnv({
+      cores: 6,
+      maxTouchPoints: 5,
+      coarsePointer: true,
+      highp: false,
+      anisotropy: 16,
+      textureSize: 8192,
+    });
+    expect(getPerformanceTier()).toBe("reduced");
+  });
+
+  test("budget phone reporting 2GB memory → reduced, not off", () => {
+    applyEnv({
+      cores: 4,
+      memory: 2,
+      maxTouchPoints: 5,
+      coarsePointer: true,
+    });
+    expect(getPerformanceTier()).toBe("reduced");
+  });
+
+  test("low core count (2) is reduced, not off", () => {
+    applyEnv({ cores: 2, anisotropy: 16, textureSize: 16384 });
+    expect(getPerformanceTier()).toBe("reduced");
+  });
+
   test("mid desktop with too few cores for full → reduced", () => {
     applyEnv({ cores: 4, anisotropy: 16, textureSize: 16384 });
     expect(getPerformanceTier()).toBe("reduced");
@@ -174,6 +191,18 @@ describe("getPerformanceTier — reduced tier (phones, tablets, mid PCs)", () =>
 
   test("desktop with weak GPU anisotropy → reduced", () => {
     applyEnv({ cores: 8, anisotropy: 2, textureSize: 16384 });
+    expect(getPerformanceTier()).toBe("reduced");
+  });
+
+  test("desktop without high-precision floats → reduced, not full", () => {
+    applyEnv({
+      cores: 12,
+      highp: false,
+      anisotropy: 16,
+      textureSize: 16384,
+      coarsePointer: false,
+      maxTouchPoints: 0,
+    });
     expect(getPerformanceTier()).toBe("reduced");
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Follow-up to #1540 (already merged), rebased on the latest `main`.

## Why

After the 3-tier classifier landed, phones and reasonable mid-range devices were still getting shaders disabled. The `off` tier was too broad: GPU-quality signals (`highp`, `maxTextureSize`) and modest CPU/RAM cutoffs were forcing capable devices to `off` instead of `reduced`.

## What

Restricts `off` to genuinely incapable hardware and moves the quality signals into the `full` gate.

- **`off`** now only when: no WebGL at all, a single CPU core (`<= 1`), or ≤512MB RAM (`<= 0.5GB`).
- **High-precision floats (`highp`) and `maxTextureSize` no longer force `off`** — they only gate `full` vs `reduced`. A phone whose GPU reports no fragment `highp` now gets reduced-quality shaders instead of nothing.
- Lowered CPU/RAM cutoffs (`cores <= 2` → `<= 1`; `memory <= 1GB` → `<= 0.5GB`) so 2-core / 2GB devices land in `reduced`.
- Bumped the display-settings store to **v2** with a `migrate` that re-enables shaders for existing users whose old strict heuristic had persisted `off`, on any device now classified above `off` (so returning users actually see the change rather than keeping the stale persisted `false`).

## Net effect

Phones and reasonable mid-range devices now default to reduced-quality shaders; only genuinely incapable hardware defaults off.

## Testing
- `bun run test:unit` — 388 pass (incl. 16 tier tests: phone-without-highp, 2GB phone, 2-core all → `reduced`)
- `bunx tsc -b` — clean
- `bun run lint` (changed files) — clean
- `bun run build` — succeeds
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ee007-b8a7-72c6-860f-c69ee8c4da20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ee007-b8a7-72c6-860f-c69ee8c4da20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

