### PR TITLE
Make IE loading bar dark-mode aware

### DIFF
--- a/src/apps/internet-explorer/components/internet-explorer-app/InternetExplorerContentPane.tsx
+++ b/src/apps/internet-explorer/components/internet-explorer-app/InternetExplorerContentPane.tsx
@@ -153,7 +153,7 @@ export function InternetExplorerContentPane({
             isAiLoading ||
             isFetchingWebsiteContent) && (
             <motion.div
-              className="absolute top-0 left-0 right-0 bg-white/75 dark:bg-neutral-900/75 backdrop-blur-sm overflow-hidden z-40"
+              className="absolute top-0 left-0 right-0 bg-transparent backdrop-blur-sm overflow-hidden z-40"
               variants={loadingBarVariants}
               initial="hidden"
               animate="visible"

--- a/src/apps/internet-explorer/components/internet-explorer-app/InternetExplorerContentPane.tsx
+++ b/src/apps/internet-explorer/components/internet-explorer-app/InternetExplorerContentPane.tsx
@@ -153,7 +153,7 @@ export function InternetExplorerContentPane({
             isAiLoading ||
             isFetchingWebsiteContent) && (
             <motion.div
-              className="absolute top-0 left-0 right-0 bg-white/75 backdrop-blur-sm overflow-hidden z-40"
+              className="absolute top-0 left-0 right-0 bg-white/75 dark:bg-neutral-900/75 backdrop-blur-sm overflow-hidden z-40"
               variants={loadingBarVariants}
               initial="hidden"
               animate="visible"
@@ -188,10 +188,10 @@ export function InternetExplorerContentPane({
             animate={{ opacity: 1, y: 0 }}
             exit={{ opacity: 0, y: 20 }}
             transition={{ duration: 0.15 }}
-            className={`os-status-bar os-status-bar-text font-geneva-12 absolute bottom-0 left-0 right-0 bg-neutral-100 text-[10px] px-2 py-1 flex items-center z-50 ${
+            className={`os-status-bar os-status-bar-text font-geneva-12 absolute bottom-0 left-0 right-0 bg-neutral-100 dark:bg-neutral-900 text-[10px] px-2 py-1 flex items-center z-50 ${
               currentTheme === "system7"
                 ? "border-t border-black"
-                : "border-t border-neutral-300"
+                : "border-t border-neutral-300 dark:border-white/10"
             }`}
           >
             <div className="flex-1 truncate">{getDebugStatusMessage()}</div>

--- a/src/index.css
+++ b/src/index.css
@@ -385,6 +385,38 @@ button.piano-key.piano-key[class*="bg-[#ff33ff]"] {
   width: 100%;
 }
 
+/* Dark-mode (Aqua) IE loading bar — lift the moving band so it reads against
+   the dark progress track (.dark lives on <html> only when Aqua dark is on). */
+.dark .animate-progress-indeterminate,
+.dark .animate-progress-indeterminate-reverse {
+  background: linear-gradient(
+    90deg,
+    transparent 20%,
+    #60a5fa 50%,
+    transparent 80%
+  );
+}
+
+.dark .animate-progress-indeterminate-green,
+.dark .animate-progress-indeterminate-green-reverse {
+  background: linear-gradient(
+    90deg,
+    transparent 20%,
+    #4ade80 50%,
+    transparent 80%
+  );
+}
+
+.dark .animate-progress-indeterminate-orange,
+.dark .animate-progress-indeterminate-orange-reverse {
+  background: linear-gradient(
+    90deg,
+    transparent 20%,
+    #fb923c 50%,
+    transparent 80%
+  );
+}
+
 .animate-progress-indeterminate-yellow {
   animation: progress-indeterminate 2.5s linear infinite;
   background: linear-gradient(

--- a/src/index.css
+++ b/src/index.css
@@ -385,38 +385,6 @@ button.piano-key.piano-key[class*="bg-[#ff33ff]"] {
   width: 100%;
 }
 
-/* Dark-mode (Aqua) IE loading bar — lift the moving band so it reads against
-   the dark progress track (.dark lives on <html> only when Aqua dark is on). */
-.dark .animate-progress-indeterminate,
-.dark .animate-progress-indeterminate-reverse {
-  background: linear-gradient(
-    90deg,
-    transparent 20%,
-    #60a5fa 50%,
-    transparent 80%
-  );
-}
-
-.dark .animate-progress-indeterminate-green,
-.dark .animate-progress-indeterminate-green-reverse {
-  background: linear-gradient(
-    90deg,
-    transparent 20%,
-    #4ade80 50%,
-    transparent 80%
-  );
-}
-
-.dark .animate-progress-indeterminate-orange,
-.dark .animate-progress-indeterminate-orange-reverse {
-  background: linear-gradient(
-    90deg,
-    transparent 20%,
-    #fb923c 50%,
-    transparent 80%
-  );
-}
-
 .animate-progress-indeterminate-yellow {
   animation: progress-indeterminate 2.5s linear infinite;
   background: linear-gradient(

--- a/tests/test-ie-loading-bar-dark.test.ts
+++ b/tests/test-ie-loading-bar-dark.test.ts
@@ -28,8 +28,12 @@ function extractRuleBlock(css: string, selector: string): string {
 }
 
 describe("internet explorer loading bar dark mode", () => {
-  test("loading bar track has a dark-mode surface instead of a fixed white bar", () => {
-    expect(contentPaneSource).toContain("bg-white/75 dark:bg-neutral-900/75");
+  test("loading bar track is transparent so it works in light and dark", () => {
+    expect(contentPaneSource).toContain(
+      "bg-transparent backdrop-blur-sm"
+    );
+    // No fixed white track that would look wrong in dark mode.
+    expect(contentPaneSource).not.toContain("bg-white/75");
   });
 
   test("loading status bar gets a dark surface and divider", () => {
@@ -39,30 +43,12 @@ describe("internet explorer loading bar dark mode", () => {
     );
   });
 
-  test("dark progress sweep lifts the blue band for the dark track", () => {
-    const block = extractRuleBlock(
-      indexCss,
-      ".dark .animate-progress-indeterminate,"
-    );
-    expect(block.length).toBeGreaterThan(0);
-    expect(block).toContain("#60a5fa");
-  });
-
-  test("dark progress sweep tunes the green (content fetch) band", () => {
-    const block = extractRuleBlock(
-      indexCss,
-      ".dark .animate-progress-indeterminate-green,"
-    );
-    expect(block.length).toBeGreaterThan(0);
-    expect(block).toContain("#4ade80");
-  });
-
-  test("dark progress sweep tunes the orange (AI) band", () => {
-    const block = extractRuleBlock(
-      indexCss,
-      ".dark .animate-progress-indeterminate-orange,"
-    );
-    expect(block.length).toBeGreaterThan(0);
-    expect(block).toContain("#fb923c");
+  test("indeterminate sweep keeps the background-size needed to animate", () => {
+    // Regression guard: the sweep animates background-position over a
+    // 200% 100% gradient; a `background:` shorthand override would reset
+    // background-size and stop the animation.
+    const block = extractRuleBlock(indexCss, ".animate-progress-indeterminate {");
+    expect(block).toContain("background-size: 200% 100%");
+    expect(block).toContain("progress-indeterminate 2.5s linear infinite");
   });
 });

--- a/tests/test-ie-loading-bar-dark.test.ts
+++ b/tests/test-ie-loading-bar-dark.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const indexCss = readFileSync(join(import.meta.dir, "../src/index.css"), "utf8");
+const contentPaneSource = readFileSync(
+  join(
+    import.meta.dir,
+    "../src/apps/internet-explorer/components/internet-explorer-app/InternetExplorerContentPane.tsx"
+  ),
+  "utf8"
+);
+
+function extractRuleBlock(css: string, selector: string): string {
+  const start = css.indexOf(selector);
+  if (start === -1) return "";
+  const braceStart = css.indexOf("{", start);
+  if (braceStart === -1) return "";
+  let depth = 0;
+  for (let i = braceStart; i < css.length; i++) {
+    if (css[i] === "{") depth++;
+    else if (css[i] === "}") {
+      depth--;
+      if (depth === 0) return css.slice(start, i + 1);
+    }
+  }
+  return "";
+}
+
+describe("internet explorer loading bar dark mode", () => {
+  test("loading bar track has a dark-mode surface instead of a fixed white bar", () => {
+    expect(contentPaneSource).toContain("bg-white/75 dark:bg-neutral-900/75");
+  });
+
+  test("loading status bar gets a dark surface and divider", () => {
+    expect(contentPaneSource).toContain("bg-neutral-100 dark:bg-neutral-900");
+    expect(contentPaneSource).toContain(
+      "border-t border-neutral-300 dark:border-white/10"
+    );
+  });
+
+  test("dark progress sweep lifts the blue band for the dark track", () => {
+    const block = extractRuleBlock(
+      indexCss,
+      ".dark .animate-progress-indeterminate,"
+    );
+    expect(block.length).toBeGreaterThan(0);
+    expect(block).toContain("#60a5fa");
+  });
+
+  test("dark progress sweep tunes the green (content fetch) band", () => {
+    const block = extractRuleBlock(
+      indexCss,
+      ".dark .animate-progress-indeterminate-green,"
+    );
+    expect(block.length).toBeGreaterThan(0);
+    expect(block).toContain("#4ade80");
+  });
+
+  test("dark progress sweep tunes the orange (AI) band", () => {
+    const block = extractRuleBlock(
+      indexCss,
+      ".dark .animate-progress-indeterminate-orange,"
+    );
+    expect(block.length).toBeGreaterThan(0);
+    expect(block).toContain("#fb923c");
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The Internet Explorer page-loading bar used a hardcoded `bg-white/75` track that looked wrong in dark mode. Instead of swapping in a dark track color, the track is now **transparent in both light and dark**, so the animated colored sweep reads cleanly over the page content in either theme.

- Loading bar track: `bg-white/75` → `bg-transparent` (keeps `backdrop-blur-sm`), so the same component works in light and dark without a fixed light/dark surface.
- Loading status bar at the bottom now gets `dark:bg-neutral-900` plus a `dark:border-white/10` divider for non–System 7 themes (text/border tokens were already handled by `.os-status-bar` in dark Aqua).
- The indeterminate sweep itself is unchanged — an earlier attempt added `.dark` overrides with a `background:` shorthand that reset `background-size` and stopped the animation; that has been removed/avoided, and a test now guards the `background-size: 200% 100%` that the animation depends on.

Dark mode is only active for the macOS Aqua theme, but the transparent track needs no theme branching at all.

## Testing

- `bun test tests/test-ie-loading-bar-dark.test.ts` (all pass)
- `bun run build` (succeeds)
- Manual: opened IE in macOS Aqua **dark** mode and navigated several sites — the thin top loading bar shows an animated blue sweep over the content in dark mode (verified on video).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ee219-b4a1-7bd7-a6d5-1018e4b19f04"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ee219-b4a1-7bd7-a6d5-1018e4b19f04"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

