### PR TITLE
Change 'View Changelog' label to 'Changelog' in all locales

### DIFF
--- a/src/lib/locales/de/translation.json
+++ b/src/lib/locales/de/translation.json
@@ -1602,7 +1602,7 @@
       "ui": "UI",
       "uiSounds": "UI Töne",
       "uiVolume": "UI-Lautstärke",
-      "viewChangelog": "Änderungsprotokoll anzeigen",
+      "viewChangelog": "Änderungsprotokoll",
       "wallpaperCategories": {
         "aqua": "Aqua",
         "black_and_white": "Schwarzweiß",
@@ -3899,7 +3899,7 @@
       "system": "System",
       "termsOfService": "Nutzungsbedingungen",
       "title": "Über diesen Computer",
-      "viewChangelog": "Änderungsprotokoll anzeigen",
+      "viewChangelog": "Änderungsprotokoll",
       "virtualMemory": "Virtueller Speicher",
       "virtualMemoryOff": "Aus"
     },
@@ -4060,7 +4060,7 @@
         "shareLinkOrScanToOpen": "Link teilen oder scannen, um diesen {{itemType}} zu öffnen"
       },
       "version": "Version",
-      "viewChangelog": "Änderungsprotokoll anzeigen",
+      "viewChangelog": "Änderungsprotokoll",
       "viewDocs": "Dokumentation anzeigen",
       "welcomeTo": "Willkommen bei {{appName}}"
     },

--- a/src/lib/locales/en/translation.json
+++ b/src/lib/locales/en/translation.json
@@ -84,7 +84,7 @@
       "version": "Version",
       "madeBy": "Made by",
       "openInGitHub": "Open in GitHub",
-      "viewChangelog": "View Changelog",
+      "viewChangelog": "Changelog",
       "informationAboutApp": "Information about the application",
       "viewDocs": "View Docs",
       "emoji": {
@@ -216,7 +216,7 @@
       "system": "System",
       "mb": "MB",
       "clickToToggle": "Click to toggle",
-      "viewChangelog": "View Changelog",
+      "viewChangelog": "Changelog",
       "privacyPolicy": "Privacy Policy",
       "termsOfService": "Terms of Service"
     },
@@ -2970,7 +2970,7 @@
       },
       "checkForUpdates": "Check for Updates",
       "downloadMacApp": "Download Mac App",
-      "viewChangelog": "View Changelog",
+      "viewChangelog": "Changelog",
       "privacyPolicy": "Privacy Policy",
       "termsOfService": "Terms of Service",
       "backup": "Backup",

--- a/src/lib/locales/es/translation.json
+++ b/src/lib/locales/es/translation.json
@@ -1602,7 +1602,7 @@
       "ui": "Interfaz",
       "uiSounds": "Sonidos de UI",
       "uiVolume": "Volumen de la interfaz",
-      "viewChangelog": "Ver registro de cambios",
+      "viewChangelog": "Registro de cambios",
       "wallpaperCategories": {
         "aqua": "Aqua",
         "black_and_white": "Blanco y negro",
@@ -3899,7 +3899,7 @@
       "system": "Sistema",
       "termsOfService": "Términos de servicio",
       "title": "Acerca de Este Equipo",
-      "viewChangelog": "Ver registro de cambios",
+      "viewChangelog": "Registro de cambios",
       "virtualMemory": "Memoria Virtual",
       "virtualMemoryOff": "Desactivado"
     },
@@ -4060,7 +4060,7 @@
         "shareLinkOrScanToOpen": "Compartir enlace o escanear para abrir este {{itemType}}"
       },
       "version": "Versión",
-      "viewChangelog": "Ver registro de cambios",
+      "viewChangelog": "Registro de cambios",
       "viewDocs": "Ver documentación",
       "welcomeTo": "Bienvenido a {{appName}}"
     },

--- a/src/lib/locales/fr/translation.json
+++ b/src/lib/locales/fr/translation.json
@@ -1602,7 +1602,7 @@
       "ui": "Interface utilisateur",
       "uiSounds": "Sons de l'interface utilisateur",
       "uiVolume": "Volume de l'interface utilisateur",
-      "viewChangelog": "Voir les changements",
+      "viewChangelog": "Journal des modifications",
       "wallpaperCategories": {
         "aqua": "Aqua",
         "black_and_white": "Noir et blanc",
@@ -3899,7 +3899,7 @@
       "system": "Système",
       "termsOfService": "Conditions d'utilisation",
       "title": "À propos de cet ordinateur",
-      "viewChangelog": "Voir le journal des modifications",
+      "viewChangelog": "Journal des modifications",
       "virtualMemory": "Mémoire virtuelle",
       "virtualMemoryOff": "Désactivé"
     },
@@ -4060,7 +4060,7 @@
         "shareLinkOrScanToOpen": "Partager le lien ou scanner pour ouvrir ce {{itemType}}"
       },
       "version": "Version",
-      "viewChangelog": "Voir le journal des modifications",
+      "viewChangelog": "Journal des modifications",
       "viewDocs": "Voir la documentation",
       "welcomeTo": "Bienvenue dans {{appName}}"
     },

--- a/src/lib/locales/it/translation.json
+++ b/src/lib/locales/it/translation.json
@@ -1602,7 +1602,7 @@
       "ui": "Interfaccia",
       "uiSounds": "Suoni UI",
       "uiVolume": "Volume interfaccia",
-      "viewChangelog": "Visualizza changelog",
+      "viewChangelog": "Registro modifiche",
       "wallpaperCategories": {
         "aqua": "Aqua",
         "black_and_white": "Bianco e nero",
@@ -3899,7 +3899,7 @@
       "system": "Sistema",
       "termsOfService": "Termini di servizio",
       "title": "Informazioni su questo computer",
-      "viewChangelog": "Visualizza registro modifiche",
+      "viewChangelog": "Registro modifiche",
       "virtualMemory": "Memoria virtuale",
       "virtualMemoryOff": "Disattivato"
     },
@@ -4060,7 +4060,7 @@
         "shareLinkOrScanToOpen": "Condividi il link o scansiona per aprire questo/a {{itemType}}"
       },
       "version": "Versione",
-      "viewChangelog": "Visualizza registro modifiche",
+      "viewChangelog": "Registro modifiche",
       "viewDocs": "Visualizza documentazione",
       "welcomeTo": "Benvenuto in {{appName}}"
     },

--- a/src/lib/locales/ja/translation.json
+++ b/src/lib/locales/ja/translation.json
@@ -1602,7 +1602,7 @@
       "ui": "UI",
       "uiSounds": "UI サウンド",
       "uiVolume": "UI 音量",
-      "viewChangelog": "変更履歴を見る",
+      "viewChangelog": "変更履歴",
       "wallpaperCategories": {
         "aqua": "アクア",
         "black_and_white": "白黒",
@@ -3899,7 +3899,7 @@
       "system": "システム",
       "termsOfService": "利用規約",
       "title": "このコンピュータについて",
-      "viewChangelog": "変更履歴を見る",
+      "viewChangelog": "変更履歴",
       "virtualMemory": "仮想メモリ",
       "virtualMemoryOff": "オフ"
     },
@@ -4060,7 +4060,7 @@
         "shareLinkOrScanToOpen": "リンクを共有するか、スキャンしてこの {{itemType}} を開く"
       },
       "version": "バージョン",
-      "viewChangelog": "変更履歴を見る",
+      "viewChangelog": "変更履歴",
       "viewDocs": "ドキュメント",
       "welcomeTo": "{{appName}}へようこそ"
     },

--- a/src/lib/locales/ko/translation.json
+++ b/src/lib/locales/ko/translation.json
@@ -1602,7 +1602,7 @@
       "ui": "UI",
       "uiSounds": "UI 소리",
       "uiVolume": "UI 음량",
-      "viewChangelog": "변경 로그 보기",
+      "viewChangelog": "변경 내역",
       "wallpaperCategories": {
         "aqua": "아쿠아",
         "black_and_white": "흑백",
@@ -3899,7 +3899,7 @@
       "system": "시스템",
       "termsOfService": "이용 약관",
       "title": "이 컴퓨터에 관하여",
-      "viewChangelog": "변경 내역 보기",
+      "viewChangelog": "변경 내역",
       "virtualMemory": "가상 메모리",
       "virtualMemoryOff": "끔"
     },
@@ -4060,7 +4060,7 @@
         "shareLinkOrScanToOpen": "링크를 공유하거나 스캔하여 이 {{itemType}}을(를) 여세요."
       },
       "version": "버전",
-      "viewChangelog": "변경 내역 보기",
+      "viewChangelog": "변경 내역",
       "viewDocs": "문서 보기",
       "welcomeTo": "{{appName}}에 오신 것을 환영합니다"
     },

--- a/src/lib/locales/pt/translation.json
+++ b/src/lib/locales/pt/translation.json
@@ -1602,7 +1602,7 @@
       "ui": "UI",
       "uiSounds": "Sons da UI",
       "uiVolume": "Volume da UI",
-      "viewChangelog": "Ver registro de alterações",
+      "viewChangelog": "Registro de alterações",
       "wallpaperCategories": {
         "aqua": "Aqua",
         "black_and_white": "Preto e branco",
@@ -3899,7 +3899,7 @@
       "system": "Sistema",
       "termsOfService": "Termos de Serviço",
       "title": "Sobre Este Computador",
-      "viewChangelog": "Ver registro de alterações",
+      "viewChangelog": "Registro de alterações",
       "virtualMemory": "Memória Virtual",
       "virtualMemoryOff": "Desativado"
     },
@@ -4060,7 +4060,7 @@
         "shareLinkOrScanToOpen": "Compartilhe o link ou escaneie para abrir este {{itemType}}"
       },
       "version": "Versão",
-      "viewChangelog": "Ver registro de alterações",
+      "viewChangelog": "Registro de alterações",
       "viewDocs": "Ver documentação",
       "welcomeTo": "Bem-vindo ao {{appName}}"
     },

--- a/src/lib/locales/ru/translation.json
+++ b/src/lib/locales/ru/translation.json
@@ -1602,7 +1602,7 @@
       "ui": "Интерфейс",
       "uiSounds": "Звуки интерфейса",
       "uiVolume": "Громкость интерфейса",
-      "viewChangelog": "Просмотреть журнал изменений",
+      "viewChangelog": "Журнал изменений",
       "wallpaperCategories": {
         "aqua": "Аква",
         "black_and_white": "Чёрно-белое",
@@ -3899,7 +3899,7 @@
       "system": "Система",
       "termsOfService": "Условия использования",
       "title": "Об этом компьютере",
-      "viewChangelog": "Просмотреть журнал изменений",
+      "viewChangelog": "Журнал изменений",
       "virtualMemory": "Виртуальная память",
       "virtualMemoryOff": "Выкл."
     },
@@ -4060,7 +4060,7 @@
         "shareLinkOrScanToOpen": "Поделитесь ссылкой или отсканируйте, чтобы открыть этот {{itemType}}"
       },
       "version": "Версия",
-      "viewChangelog": "Просмотр журнала изменений",
+      "viewChangelog": "Журнал изменений",
       "viewDocs": "Смотреть документацию",
       "welcomeTo": "Добро пожаловать в {{appName}}"
     },

--- a/src/lib/locales/zh-TW/translation.json
+++ b/src/lib/locales/zh-TW/translation.json
@@ -1602,7 +1602,7 @@
       "ui": "使用者介面",
       "uiSounds": "UI 音效",
       "uiVolume": "使用者介面音量",
-      "viewChangelog": "查看更新日誌",
+      "viewChangelog": "更新日誌",
       "wallpaperCategories": {
         "aqua": "水藍",
         "black_and_white": "黑白",
@@ -3899,7 +3899,7 @@
       "system": "系統",
       "termsOfService": "服務條款",
       "title": "關於此電腦",
-      "viewChangelog": "查看變更記錄",
+      "viewChangelog": "更新日誌",
       "virtualMemory": "虛擬記憶體",
       "virtualMemoryOff": "關閉"
     },
@@ -4060,7 +4060,7 @@
         "shareLinkOrScanToOpen": "分享連結或掃描以開啟此{{itemType}}"
       },
       "version": "版本",
-      "viewChangelog": "查看更新日誌",
+      "viewChangelog": "更新日誌",
       "viewDocs": "查看文檔",
       "welcomeTo": "歡迎使用{{appName}}"
     },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates the `viewChangelog` UI label from verb phrases (e.g. "View Changelog") to noun forms (e.g. "Changelog") across all 10 locale files. Each locale now uses a consistent short label in all three key locations:

- `common.aboutThisMac.viewChangelog` (About This Mac / About Finder dialog)
- `apps.control-panels.viewChangelog` (Control Panels version display and settings)

Behavior, links, styling, and accessibility are unchanged — only displayed strings are shortened.

## Locale updates

| Locale | New label |
|--------|-----------|
| en | Changelog |
| de | Änderungsprotokoll |
| es | Registro de cambios |
| fr | Journal des modifications |
| it | Registro modifiche |
| ja | 変更履歴 |
| ko | 변경 내역 |
| pt | Registro de alterações |
| ru | Журнал изменений |
| zh-TW | 更新日誌 |

## Testing

- No tests or snapshots reference this string.
- Change is limited to `src/lib/locales/*/translation.json` (27 string values across 9 non-English files, plus the prior English update).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ff6b954a-0bd7-432d-a472-ed5a1c3f603e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ff6b954a-0bd7-432d-a472-ed5a1c3f603e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

