### PR TITLE
Match Aqua slider track styling to switches with orientation-aware highlight

### DIFF
--- a/src/styles/themes/aqua.css
+++ b/src/styles/themes/aqua.css
@@ -2512,18 +2512,41 @@
   margin: 0 auto;
 }
 
-/* Slider track */
+/* Slider track — same recessed glossy channel as the switch track so sliders
+   and switches read as one cohesive set. The top white shine highlight + base
+   gradient mirror `.os-switch` (unchecked). The shine runs across the track's
+   short axis: top→down for a horizontal track. */
 :root[data-os-theme="macosx"] .os-slider-track {
   background: linear-gradient(
-    to bottom,
-    #d0d0d0,
-    #f5f5f5
-  ) !important; /* vertical for horizontal track = 3D bevel */
-  border: 1px solid rgba(0, 0, 0, 0.35);
+        to bottom,
+        rgba(255, 255, 255, 0.55) 0%,
+        rgba(255, 255, 255, 0.18) 60%,
+        rgba(255, 255, 255, 0) 100%
+      )
+      top / 100% 50% no-repeat,
+    linear-gradient(rgba(188, 188, 188, 0.34), rgba(255, 255, 255, 0.3)) !important;
+  border: 1px solid rgba(0, 0, 0, 0.22);
   border-radius: 9999px;
-  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.12),
-    inset 0 2px 3px rgba(255, 255, 255, 0.45);
+  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.2),
+    inset 0 -1px 1px rgba(255, 255, 255, 0.35),
+    0 1px 0 rgba(255, 255, 255, 0.5);
   position: relative;
+}
+
+/* Vertical track — rotate the shine + bevel to the short (horizontal) axis so
+   the highlight sits on the leading (left) edge and reads correctly. */
+:root[data-os-theme="macosx"] .os-slider-track[data-orientation="vertical"] {
+  background: linear-gradient(
+        to right,
+        rgba(255, 255, 255, 0.55) 0%,
+        rgba(255, 255, 255, 0.18) 60%,
+        rgba(255, 255, 255, 0) 100%
+      )
+      left / 50% 100% no-repeat,
+    linear-gradient(to right, rgba(188, 188, 188, 0.34), rgba(255, 255, 255, 0.3)) !important;
+  box-shadow: inset 1px 0 2px rgba(0, 0, 0, 0.2),
+    inset -1px 0 1px rgba(255, 255, 255, 0.35),
+    1px 0 0 rgba(255, 255, 255, 0.5);
 }
 
 /* Filled portion of the track uses the same glossy accent gradient as the
@@ -2542,6 +2565,30 @@
   box-shadow: inset 0 1px 1px rgba(255, 255, 255, 0.4),
     inset 0 -1px 1px rgba(0, 0, 0, 0.18),
     0 1px 1px var(--os-accent-button-edge, rgba(0, 78, 187, 0.4));
+}
+
+/* Vertical filled range — the shared accent gradient (`--os-accent-button-bg`)
+   is a fixed top→bottom gloss, so layer a left→right white highlight on top of
+   it and flip the bevel insets to the short (horizontal) axis. */
+:root[data-os-theme="macosx"] .os-slider-range[data-orientation="vertical"] {
+  background: linear-gradient(
+        to right,
+        rgba(255, 255, 255, 0.45) 0%,
+        rgba(255, 255, 255, 0.05) 55%,
+        rgba(255, 255, 255, 0) 100%
+      ),
+    var(
+      --os-accent-button-bg,
+      linear-gradient(
+        to right,
+        rgba(0, 65, 184, 0.625),
+        rgba(45, 115, 199, 0.625),
+        rgba(33, 160, 196, 0.625)
+      )
+    ) !important;
+  box-shadow: inset 1px 0 1px rgba(255, 255, 255, 0.4),
+    inset -1px 0 1px rgba(0, 0, 0, 0.18),
+    1px 0 1px var(--os-accent-button-edge, rgba(0, 78, 187, 0.4));
 }
 
 /* Slider tick/label text - preserve explicit sizes */

--- a/src/styles/themes/aqua.css
+++ b/src/styles/themes/aqua.css
@@ -2554,29 +2554,35 @@
    switches read as one cohesive accent-driven set. Falls back to the classic
    Aqua blue gloss when no accent override is set. */
 :root[data-os-theme="macosx"] .os-slider-range {
-  background: var(
-    --os-accent-button-bg,
-    linear-gradient(
-      rgba(0, 65, 184, 0.625),
-      rgba(45, 115, 199, 0.625),
-      rgba(33, 160, 196, 0.625)
-    )
-  ) !important;
-  box-shadow: inset 0 1px 1px rgba(255, 255, 255, 0.4),
-    inset 0 -1px 1px rgba(0, 0, 0, 0.18),
+  background: linear-gradient(
+        to bottom,
+        rgba(255, 255, 255, 0.55) 0%,
+        rgba(255, 255, 255, 0.18) 60%,
+        rgba(255, 255, 255, 0) 100%
+      )
+      top / 100% 50% no-repeat,
+    var(
+      --os-accent-button-bg,
+      linear-gradient(
+        rgba(0, 65, 184, 0.625),
+        rgba(45, 115, 199, 0.625),
+        rgba(33, 160, 196, 0.625)
+      )
+    ) !important;
+  box-shadow: inset 0 -1px 1px rgba(0, 0, 0, 0.18),
     0 1px 1px var(--os-accent-button-edge, rgba(0, 78, 187, 0.4));
 }
 
-/* Vertical filled range — the shared accent gradient (`--os-accent-button-bg`)
-   is a fixed top→bottom gloss, so layer a left→right white highlight on top of
-   it and flip the bevel insets to the short (horizontal) axis. */
+/* Vertical filled range — the shine + bevel run across the short (horizontal)
+   axis, so the highlight sits on the leading (left) edge. */
 :root[data-os-theme="macosx"] .os-slider-range[data-orientation="vertical"] {
   background: linear-gradient(
         to right,
-        rgba(255, 255, 255, 0.45) 0%,
-        rgba(255, 255, 255, 0.05) 55%,
+        rgba(255, 255, 255, 0.55) 0%,
+        rgba(255, 255, 255, 0.18) 60%,
         rgba(255, 255, 255, 0) 100%
-      ),
+      )
+      left / 50% 100% no-repeat,
     var(
       --os-accent-button-bg,
       linear-gradient(
@@ -2586,8 +2592,7 @@
         rgba(33, 160, 196, 0.625)
       )
     ) !important;
-  box-shadow: inset 1px 0 1px rgba(255, 255, 255, 0.4),
-    inset -1px 0 1px rgba(0, 0, 0, 0.18),
+  box-shadow: inset -1px 0 1px rgba(0, 0, 0, 0.18),
     1px 0 1px var(--os-accent-button-edge, rgba(0, 78, 187, 0.4));
 }
 

--- a/src/styles/themes/dark-aqua.css
+++ b/src/styles/themes/dark-aqua.css
@@ -1027,6 +1027,60 @@
     inset 0 -1px 1px rgba(0, 0, 0, 0.4);
 }
 
+/* Vertical filled range (dark) — layer a left→right highlight over the fixed
+   top→bottom accent gloss and flip the bevel insets to the short axis. */
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"]
+  .os-slider-range[data-orientation="vertical"] {
+  background: linear-gradient(
+        to right,
+        rgba(255, 255, 255, 0.16) 0%,
+        rgba(255, 255, 255, 0.02) 55%,
+        rgba(255, 255, 255, 0) 100%
+      ),
+    var(
+      --os-accent-button-bg,
+      linear-gradient(
+        to right,
+        rgba(0, 50, 130, 0.7),
+        rgba(40, 95, 165, 0.7),
+        rgba(70, 135, 195, 0.7)
+      )
+    ) !important;
+  box-shadow: inset 1px 0 1px rgba(255, 255, 255, 0.12),
+    inset -1px 0 1px rgba(0, 0, 0, 0.4);
+}
+
+/* Slider track (dark) — match the dark switch track so the recessed channel
+   reads dark in dark mode instead of falling back to the light Aqua track. */
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"] .os-slider-track {
+  background: linear-gradient(
+        to bottom,
+        rgba(255, 255, 255, 0.12),
+        rgba(255, 255, 255, 0.03)
+      )
+      top / 100% 50% no-repeat,
+    linear-gradient(to bottom, rgba(34, 34, 38, 0.42), rgba(72, 72, 78, 0.42)) !important;
+  border-color: rgba(255, 255, 255, 0.14);
+  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.5),
+    inset 0 -1px 1px rgba(255, 255, 255, 0.06),
+    0 1px 0 rgba(255, 255, 255, 0.05);
+}
+
+/* Vertical slider track (dark) — rotate the shine + bevel to the short axis. */
+:root[data-os-theme="macosx"][data-os-color-scheme="dark"]
+  .os-slider-track[data-orientation="vertical"] {
+  background: linear-gradient(
+        to right,
+        rgba(255, 255, 255, 0.12),
+        rgba(255, 255, 255, 0.03)
+      )
+      left / 50% 100% no-repeat,
+    linear-gradient(to right, rgba(34, 34, 38, 0.42), rgba(72, 72, 78, 0.42)) !important;
+  box-shadow: inset 1px 0 2px rgba(0, 0, 0, 0.5),
+    inset -1px 0 1px rgba(255, 255, 255, 0.06),
+    1px 0 0 rgba(255, 255, 255, 0.05);
+}
+
 /* Dark mode switch track */
 :root[data-os-theme="macosx"][data-os-color-scheme="dark"] .os-switch {
   --os-glass-switch-track-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.5),

--- a/src/styles/themes/dark-aqua.css
+++ b/src/styles/themes/dark-aqua.css
@@ -1015,28 +1015,34 @@
    (`--os-accent-button-bg`) with a dimmer blue fallback so the default accent
    doesn't glow against the dark window. */
 :root[data-os-theme="macosx"][data-os-color-scheme="dark"] .os-slider-range {
-  background: var(
-    --os-accent-button-bg,
-    linear-gradient(
-      rgba(0, 50, 130, 0.7),
-      rgba(40, 95, 165, 0.7),
-      rgba(70, 135, 195, 0.7)
-    )
-  ) !important;
-  box-shadow: inset 0 1px 1px rgba(255, 255, 255, 0.12),
-    inset 0 -1px 1px rgba(0, 0, 0, 0.4);
+  background: linear-gradient(
+        to bottom,
+        rgba(255, 255, 255, 0.16) 0%,
+        rgba(255, 255, 255, 0.04) 60%,
+        rgba(255, 255, 255, 0) 100%
+      )
+      top / 100% 50% no-repeat,
+    var(
+      --os-accent-button-bg,
+      linear-gradient(
+        rgba(0, 50, 130, 0.7),
+        rgba(40, 95, 165, 0.7),
+        rgba(70, 135, 195, 0.7)
+      )
+    ) !important;
+  box-shadow: inset 0 -1px 1px rgba(0, 0, 0, 0.4);
 }
 
-/* Vertical filled range (dark) — layer a left→right highlight over the fixed
-   top→bottom accent gloss and flip the bevel insets to the short axis. */
+/* Vertical filled range (dark) — shine + bevel on the short (horizontal) axis. */
 :root[data-os-theme="macosx"][data-os-color-scheme="dark"]
   .os-slider-range[data-orientation="vertical"] {
   background: linear-gradient(
         to right,
         rgba(255, 255, 255, 0.16) 0%,
-        rgba(255, 255, 255, 0.02) 55%,
+        rgba(255, 255, 255, 0.04) 60%,
         rgba(255, 255, 255, 0) 100%
-      ),
+      )
+      left / 50% 100% no-repeat,
     var(
       --os-accent-button-bg,
       linear-gradient(
@@ -1046,8 +1052,7 @@
         rgba(70, 135, 195, 0.7)
       )
     ) !important;
-  box-shadow: inset 1px 0 1px rgba(255, 255, 255, 0.12),
-    inset -1px 0 1px rgba(0, 0, 0, 0.4);
+  box-shadow: inset -1px 0 1px rgba(0, 0, 0, 0.4);
 }
 
 /* Slider track (dark) — match the dark switch track so the recessed channel


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Reworks the macOS **Aqua** and **Aqua Glass** `Slider` styling so the track *and* the filled bar read as the same glossy material as the toggle `Switch`, and fixes the gloss/bevel direction for horizontal vs vertical sliders.

### Changes
- **Slider track** now uses the same recessed glossy channel as `.os-switch` (top white shine highlight layer + base gradient + matching border/inset shadows) instead of the flat `#d0d0d0 → #f5f5f5` gradient.
- **Filled range** now carries the same shine highlight on top of the accent gloss, so the filled portion looks like a glossy gel matching the switch's checked track (previously it was flat/matte and lost the highlight the empty track had).
- **Orientation-aware direction**: the shine + bevel run across the track's short axis — top→down for horizontal, left→right for vertical. Added `[data-orientation="vertical"]` overrides for both the track and the filled range so vertical sliders (e.g. the volume mixer) get the highlight on the leading edge rather than along their length.
- **Dark mode** (`dark-aqua.css`): added a dark slider-track override matching the dark switch track (previously the slider track fell back to the light Aqua gradient in dark mode), plus dimmer dark shine on the filled range, with vertical-orientation variants.

### Files
- `src/styles/themes/aqua.css`
- `src/styles/themes/dark-aqua.css`

Aqua Glass inherits these rules (it keys on `data-os-theme="macosx"` and does not restyle sliders).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ee320-bf60-771e-87b4-4b4502c96d8d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ee320-bf60-771e-87b4-4b4502c96d8d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

