### PR TITLE
feat(ipod): add Aqua Glass UI variant tinted by cover-art accent

### DIFF
--- a/src/apps/ipod/components/brick-game/useBrickGame.ts
+++ b/src/apps/ipod/components/brick-game/useBrickGame.ts
@@ -1,7 +1,10 @@
 import { useEffect, useRef, useState, useImperativeHandle, useCallback } from "react";
 import { useTranslation } from "react-i18next";
 import { useIpodStore } from "@/stores/useIpodStore";
-import { IPOD_MODERN_TITLEBAR_HEIGHT_PX } from "../../constants";
+import {
+  IPOD_MODERN_TITLEBAR_HEIGHT_PX,
+  isModernIpodUiVariant,
+} from "../../constants";
 import {
   BALL_RADIUS,
   GAME_HEIGHT,
@@ -28,7 +31,7 @@ export function useBrickGame({
 }: BrickGameProps & { ref?: React.Ref<BrickGameRef> }) {
   const { t } = useTranslation();
   const uiVariant = useIpodStore((s) => s.uiVariant ?? "modern");
-  const isModernUi = uiVariant === "modern";
+  const isModernUi = isModernIpodUiVariant(uiVariant);
   const bodyTopOffsetPx = isModernUi ? IPOD_MODERN_TITLEBAR_HEIGHT_PX : 26;
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const stateRef = useRef<GameState>(initialState());

--- a/src/apps/ipod/components/cover-flow/useCoverFlowController.ts
+++ b/src/apps/ipod/components/cover-flow/useCoverFlowController.ts
@@ -11,6 +11,7 @@ import type { Track } from "@/stores/useIpodStore";
 import { useIpodStore } from "@/stores/useIpodStore";
 import { useThemeFlags } from "@/hooks/useThemeFlags";
 import { useEventListener } from "@/hooks/useEventListener";
+import { isModernIpodUiVariant } from "../../constants";
 import { LONG_PRESS_DELAY } from "./constants";
 import { coverFlowUiReducer } from "./coverFlowUiReducer";
 import type { CoverFlowComponentProps } from "./types";
@@ -79,7 +80,7 @@ export function useCoverFlowController({
   const containerRef = useRef<HTMLDivElement>(null);
   const { isMacOSTheme: isMacTheme } = useThemeFlags();
   const uiVariant = useIpodStore((s) => s.uiVariant);
-  const isModernIpodCoverFlow = ipodMode && uiVariant === "modern";
+  const isModernIpodCoverFlow = ipodMode && isModernIpodUiVariant(uiVariant);
 
   const swipeStartX = useRef<number | null>(null);
   const lastMoveX = useRef<number | null>(null);

--- a/src/apps/ipod/components/ipod-app/useIpodAppController.tsx
+++ b/src/apps/ipod/components/ipod-app/useIpodAppController.tsx
@@ -12,6 +12,7 @@ import {
 } from "@/hooks/useDisplayModeMenu";
 import { IpodMenuBar } from "../ipod-menu-bar/IpodMenuBar";
 import { useIpodLogic } from "../../hooks/useIpodLogic";
+import { isModernIpodUiVariant } from "../../constants";
 
 export type UseIpodAppControllerArgs = Pick<
   AppProps<IpodInitialData>,
@@ -58,7 +59,7 @@ export function useIpodAppController({
     (s) => s.setAppleMusicKitNowPlaying
   );
   const uiVariant = useIpodStore((s) => s.uiVariant);
-  const isModernIpodUi = uiVariant === "modern";
+  const isModernIpodUi = isModernIpodUiVariant(uiVariant);
   const finalIpodVolume = useAudioSettingsStore(selectEffectiveIpodVolume);
 
   const handleClose = useCallback(() => {

--- a/src/apps/ipod/components/ipod-menu-bar/IpodMenuBarViewMenu.tsx
+++ b/src/apps/ipod/components/ipod-menu-bar/IpodMenuBarViewMenu.tsx
@@ -92,7 +92,7 @@ export function IpodMenuBarViewMenu({ vm }: { vm: IpodMenuBarViewModel }) {
               <MenubarRadioGroup
                 value={vm.uiVariant}
                 onValueChange={(value) =>
-                  vm.setUiVariant(value as "classic" | "modern")
+                  vm.setUiVariant(value as "classic" | "modern" | "aqua")
                 }
               >
                 <MenubarRadioItem value="classic" className="text-md h-6 pr-3">
@@ -100,6 +100,9 @@ export function IpodMenuBarViewMenu({ vm }: { vm: IpodMenuBarViewModel }) {
                 </MenubarRadioItem>
                 <MenubarRadioItem value="modern" className="text-md h-6 pr-3">
                   {vm.t("apps.ipod.menu.screenModern")}
+                </MenubarRadioItem>
+                <MenubarRadioItem value="aqua" className="text-md h-6 pr-3">
+                  {vm.t("apps.ipod.menu.screenAqua", "Aqua Glass")}
                 </MenubarRadioItem>
               </MenubarRadioGroup>
             </MenubarSubContent>

--- a/src/apps/ipod/components/ipod-screen/IpodScreen.tsx
+++ b/src/apps/ipod/components/ipod-screen/IpodScreen.tsx
@@ -6,6 +6,7 @@ import {
   useReducer,
   useState,
   useCallback,
+  type CSSProperties,
 } from "react";
 import { cn } from "@/lib/utils";
 import {
@@ -19,7 +20,10 @@ import {
   IPOD_MODERN_MENU_BODY_HEIGHT_PX,
   IPOD_MODERN_SCREEN_HEIGHT_PX,
   IPOD_NOW_PLAYING_SONG_MENU_KEY,
+  isModernIpodUiVariant,
+  isAquaIpodUiVariant,
 } from "../../constants";
+import { useCoverGlowColor } from "@/hooks/useCoverGlowColor";
 import { youtubeThumbnailUrl } from "@/utils/youtubeUrl";
 import { DisplayMode } from "@/types/lyrics";
 import type { IpodScreenProps } from "../../types";
@@ -149,7 +153,8 @@ export function IpodScreen({
   // the store so the parent doesn't have to thread one more prop, and so
   // toggling from the menubar updates the screen instantly.
   const uiVariant = useIpodStore((s) => s.uiVariant);
-  const isModernUi = uiVariant === "modern";
+  const isModernUi = isModernIpodUiVariant(uiVariant);
+  const isAquaUi = isAquaIpodUiVariant(uiVariant);
   const currentMenuModernMediaList = useMemo(() => {
     if (!menuMode || menuHistory.length === 0) return false;
     return Boolean(menuHistory[menuHistory.length - 1].modernMediaList);
@@ -240,6 +245,19 @@ export function IpodScreen({
       formatKugouImageUrl(nowPlayingDisplayTrack.cover, 400) ?? youtubeThumbnail
     );
   }, [isAppleMusicTrack, nowPlayingDisplayTrack]);
+
+  // Aqua Glass skin: derive a vivid accent from the current track's cover
+  // art (cached `coverColor` when available, otherwise extracted from the
+  // image). Drives the titlebar tint, row-selection highlight, and the
+  // now-playing progress fill via the `--ipod-aqua-accent` CSS variable.
+  // The hook always runs (rules of hooks) but only extracts when aqua is
+  // active. Falls back to a neutral Aqua blue while loading / when off.
+  const aquaAccentColor = useCoverGlowColor({
+    coverUrl,
+    coverColor: nowPlayingDisplayTrack?.coverColor,
+    enabled: isAquaUi,
+  });
+  const aquaAccent = isAquaUi ? aquaAccentColor : null;
 
   // Current menu items (the deepest menu in the history stack).
   const currentMenuItems = useMemo(
@@ -553,7 +571,8 @@ export function IpodScreen({
         lcdFilterOn && !isModernUi ? "lcd-screen" : "",
         isModernUi
           ? cn(
-              "ipod-modern-screen bg-white",
+              "ipod-modern-screen",
+              isAquaUi ? "ipod-aqua-screen" : "bg-white",
               !backlightOn && "ipod-modern-backlight-off"
             )
           : backlightOn
@@ -574,6 +593,11 @@ export function IpodScreen({
         contain: "layout style paint",
         WebkitUserSelect: "none",
         WebkitTouchCallout: "none",
+        ...(aquaAccent
+          ? ({
+              "--ipod-aqua-accent": aquaAccent,
+            } as CSSProperties)
+          : null),
       }}
     >
       {lcdFilterOn && !isModernUi && (

--- a/src/apps/ipod/components/ipod-screen/IpodScreenMediaOverlay.tsx
+++ b/src/apps/ipod/components/ipod-screen/IpodScreenMediaOverlay.tsx
@@ -45,7 +45,7 @@ export interface IpodScreenMediaOverlayProps {
   statusMessage: string | null;
   isAnyActivityActive: boolean;
   activityState: ActivityInfo;
-  uiVariant: "classic" | "modern";
+  uiVariant: "classic" | "modern" | "aqua";
   playerRef: IpodScreenProps["playerRef"];
   handleTrackEnd: IpodScreenProps["handleTrackEnd"];
   handleProgress: IpodScreenProps["handleProgress"];

--- a/src/apps/ipod/components/ipod-screen/IpodScreenMenuChrome.tsx
+++ b/src/apps/ipod/components/ipod-screen/IpodScreenMenuChrome.tsx
@@ -30,7 +30,7 @@ export interface IpodScreenMenuChromeProps {
   modernScrollingMarqueeAllowed: boolean;
   isPlaying: boolean;
   backlightOn: boolean;
-  uiVariant: "classic" | "modern";
+  uiVariant: "classic" | "modern" | "aqua";
   menuMode: boolean;
   appleMusicMenuTitlebarLoading: boolean;
   showVideo: boolean;

--- a/src/apps/ipod/components/lyrics-display/useLyricsDisplaySettings.ts
+++ b/src/apps/ipod/components/lyrics-display/useLyricsDisplaySettings.ts
@@ -8,9 +8,9 @@ import type { LyricsDisplayProps } from "./types";
 
 /** Small iPod LCD lyrics always use sans-serif; ignore stored lyric style. */
 export function getIpodSmallScreenLyricsFontClassName(
-  uiVariant: "classic" | "modern"
+  uiVariant: "classic" | "modern" | "aqua"
 ): string {
-  return uiVariant === "modern"
+  return uiVariant !== "classic"
     ? "font-ipod-modern-ui font-semibold"
     : "font-geneva-12";
 }
@@ -35,7 +35,7 @@ export function useLyricsDisplaySettings({
 
   const fontClassName =
     fontClassNameFromProp ??
-    (storeUiVariant === "modern"
+    (storeUiVariant !== "classic"
       ? storeLyricsFont === LyricsFont.SansSerif
         ? "font-ipod-modern-ui font-semibold"
         : getLyricsFontClassName(storeLyricsFont)

--- a/src/apps/ipod/components/music-quiz/useMusicQuiz.ts
+++ b/src/apps/ipod/components/music-quiz/useMusicQuiz.ts
@@ -26,6 +26,7 @@ import {
   isIOSSafari,
 } from "./constants";
 import { initialQuizUiState, quizUiReducer } from "./quizState";
+import { isModernIpodUiVariant } from "../../constants";
 import { pickRound } from "./utils";
 import type { MusicQuizProps, MusicQuizRef, MusicQuizRound, Phase } from "./types";
 
@@ -44,7 +45,7 @@ export function useMusicQuiz(
     s.librarySource === "appleMusic" ? s.appleMusicTracks : s.tracks
   );
   const uiVariant = useIpodStore((s) => s.uiVariant ?? "modern");
-  const isModernUi = uiVariant === "modern";
+  const isModernUi = isModernIpodUiVariant(uiVariant);
   const bodyTopOffsetPx = isModernUi ? 17 : 26;
   const finalVolume = useAudioSettingsStore(selectEffectiveIpodVolume);
 

--- a/src/apps/ipod/components/screen/BatteryIndicator.tsx
+++ b/src/apps/ipod/components/screen/BatteryIndicator.tsx
@@ -1,11 +1,12 @@
 import { useCallback, useEffect, useReducer } from "react";
 import { cn } from "@/lib/utils";
+import { isModernIpodUiVariant } from "../../constants";
 import type { BatteryManager } from "../../types";
 
 interface BatteryIndicatorProps {
   backlightOn: boolean;
-  /** Classic = monochrome blue 4-bar; modern = continuous green fill. */
-  variant?: "classic" | "modern";
+  /** Classic = monochrome blue 4-bar; modern/aqua = continuous green fill. */
+  variant?: "classic" | "modern" | "aqua";
 }
 
 interface BatteryIndicatorState {
@@ -58,7 +59,7 @@ export function BatteryIndicator({
   backlightOn,
   variant = "classic",
 }: BatteryIndicatorProps) {
-  const isModern = variant === "modern";
+  const isModern = isModernIpodUiVariant(variant);
   const [state, dispatch] = useReducer(reducer, initialState);
   const { batteryLevel, isCharging, animationFrame } = state;
   const setBatteryLevel = useCallback((value: number | null) => {

--- a/src/apps/ipod/components/screen/MenuListItem.tsx
+++ b/src/apps/ipod/components/screen/MenuListItem.tsx
@@ -1,6 +1,9 @@
 import { cn } from "@/lib/utils";
 import { useImageLoaded } from "../../hooks/useImageLoaded";
-import { IPOD_MODERN_MEDIA_THUMB_PX } from "../../constants";
+import {
+  IPOD_MODERN_MEDIA_THUMB_PX,
+  isModernIpodUiVariant,
+} from "../../constants";
 import { IpodArtworkPlaceholder, type IpodEmptyArtworkKind } from "./IpodArtworkPlaceholder";
 import { ScrollingText } from "./ScrollingText";
 
@@ -26,9 +29,11 @@ interface MenuListItemProps {
    * Chicago-font row from the original 1st-gen LCD. `"modern"` switches
    * to an iOS 6 UITableViewCell look — Helvetica Neue, white background
    * with a 1px hairline separator, and a glossy blue gradient
-   * selection highlight with white text.
+   * selection highlight with white text. `"aqua"` shares the modern
+   * layout but recolors the chrome from the cover-art accent (handled
+   * via the `.ipod-aqua-screen` ancestor CSS).
    */
-  variant?: "classic" | "modern";
+  variant?: "classic" | "modern" | "aqua";
   /**
    * Modern media rows only: second line (caption). Single-line ellipsis;
    * omit or pass empty to show only the primary line.
@@ -68,7 +73,7 @@ export function MenuListItem({
     CJK_TEXT_PATTERN.test(text) ||
     (value ? CJK_TEXT_PATTERN.test(value) : false) ||
     (subtitle ? CJK_TEXT_PATTERN.test(subtitle) : false);
-  const isModern = variant === "modern";
+  const isModern = isModernIpodUiVariant(variant);
   const thumbSrc = isModern && mediaRow ? (thumbnailUrl ?? null) : null;
   const thumb = useImageLoaded(thumbSrc);
   const showThumbImage = Boolean(thumbSrc) && !thumb.failed;

--- a/src/apps/ipod/components/screen/Scrollbar.tsx
+++ b/src/apps/ipod/components/screen/Scrollbar.tsx
@@ -1,5 +1,6 @@
 import { useRef, useLayoutEffect } from "react";
 import { cn } from "@/lib/utils";
+import { isModernIpodUiVariant } from "../../constants";
 
 interface ScrollbarProps {
   containerRef:
@@ -7,8 +8,8 @@ interface ScrollbarProps {
     | React.MutableRefObject<HTMLDivElement | null>;
   backlightOn: boolean;
   menuMode: boolean;
-  /** Classic = monochrome blue track; modern = thin iOS 6 indicator. */
-  variant?: "classic" | "modern";
+  /** Classic = monochrome blue track; modern/aqua = thin iOS 6 indicator. */
+  variant?: "classic" | "modern" | "aqua";
 }
 
 export function Scrollbar({
@@ -17,7 +18,7 @@ export function Scrollbar({
   menuMode,
   variant = "classic",
 }: ScrollbarProps) {
-  const isModern = variant === "modern";
+  const isModern = isModernIpodUiVariant(variant);
   const thumbRef = useRef<HTMLDivElement>(null);
   const trackRef = useRef<HTMLDivElement>(null);
 

--- a/src/apps/ipod/components/screen/StatusDisplay.tsx
+++ b/src/apps/ipod/components/screen/StatusDisplay.tsx
@@ -12,7 +12,7 @@ import {
 
 interface StatusDisplayProps {
   message: string;
-  variant?: "classic" | "modern";
+  variant?: "classic" | "modern" | "aqua";
 }
 
 // Maps the leading playback glyph used in `showStatus(...)` calls to a
@@ -57,7 +57,7 @@ export function StatusDisplay({
   message,
   variant = "classic",
 }: StatusDisplayProps) {
-  const isModern = variant === "modern";
+  const isModern = variant !== "classic";
 
   return (
     <div className="absolute top-4 left-4 pointer-events-none">

--- a/src/apps/ipod/constants.ts
+++ b/src/apps/ipod/constants.ts
@@ -74,6 +74,34 @@ export const IPOD_NOW_PLAYING_SONG_MENU_KEY = "__nowPlayingSongMenu__";
 export const IPOD_THEMES = ["classic", "black", "u2"] as const;
 export type IpodTheme = (typeof IPOD_THEMES)[number];
 
+// On-screen UI variants for the iPod LCD.
+// - "classic": monochrome 1st-gen iPod LCD.
+// - "modern": iOS 6 inspired color skin (glossy blue gradients).
+// - "aqua": Aqua Glass variant of the modern skin — translucent frosted
+//   chrome whose accent (titlebar tint, selection highlight, progress
+//   fill) is derived from the current track's cover-art dominant color.
+export const IPOD_UI_VARIANTS = ["classic", "modern", "aqua"] as const;
+export type IpodUiVariant = (typeof IPOD_UI_VARIANTS)[number];
+
+/**
+ * Whether a UI variant uses the modern (color-screen) layout. Both the
+ * iOS-6 "modern" skin and the "aqua" glass skin share the same layout,
+ * geometry, and markup — only their CSS styling differs — so every
+ * layout branch treats them identically.
+ */
+export function isModernIpodUiVariant(
+  variant: IpodUiVariant | string | null | undefined
+): boolean {
+  return variant === "modern" || variant === "aqua";
+}
+
+/** Whether a UI variant is the cover-art-tinted Aqua Glass skin. */
+export function isAquaIpodUiVariant(
+  variant: IpodUiVariant | string | null | undefined
+): boolean {
+  return variant === "aqua";
+}
+
 // Timing constants
 export const BACKLIGHT_TIMEOUT_MS = 5000;
 export const STATUS_MESSAGE_DURATION_MS = 2000;

--- a/src/apps/ipod/hooks/useIpodLogic.ts
+++ b/src/apps/ipod/hooks/useIpodLogic.ts
@@ -766,12 +766,21 @@ export function useIpodLogic({
 
   const memoizedHandleUiThemeChange = useCallback(() => {
     const currentVariant = useIpodStore.getState().uiVariant;
-    const nextVariant = currentVariant === "modern" ? "classic" : "modern";
+    // Cycle classic → modern → aqua → classic so the menubar shortcut
+    // can reach every on-screen skin.
+    const nextVariant =
+      currentVariant === "classic"
+        ? "modern"
+        : currentVariant === "modern"
+          ? "aqua"
+          : "classic";
     setUiVariant(nextVariant);
     showStatus(
       nextVariant === "modern"
         ? t("apps.ipod.menu.screenModern")
-        : t("apps.ipod.menu.screenClassic")
+        : nextVariant === "aqua"
+          ? t("apps.ipod.menu.screenAqua", "Aqua Glass")
+          : t("apps.ipod.menu.screenClassic")
     );
     registerActivity();
   }, [setUiVariant, showStatus, registerActivity, menuLocale]);
@@ -2449,7 +2458,9 @@ export function useIpodLogic({
         value:
           uiVariant === "modern"
             ? t("apps.ipod.menu.screenModern")
-            : t("apps.ipod.menu.screenClassic"),
+            : uiVariant === "aqua"
+              ? t("apps.ipod.menu.screenAqua", "Aqua Glass")
+              : t("apps.ipod.menu.screenClassic"),
       },
       {
         label: t("apps.ipod.menuItems.librarySource", "Library"),

--- a/src/apps/ipod/utils/appleMusicMenuLoading.ts
+++ b/src/apps/ipod/utils/appleMusicMenuLoading.ts
@@ -3,7 +3,7 @@ import type { MenuItem } from "../types";
 export function shouldUseModernAppleMusicTitlebarLoading(
   uiVariant: string | undefined
 ): boolean {
-  return (uiVariant ?? "modern") === "modern";
+  return (uiVariant ?? "modern") !== "classic";
 }
 
 export function resolveAppleMusicMenuTitlebarLoading(options: {

--- a/src/index.css
+++ b/src/index.css
@@ -1815,6 +1815,136 @@ button.piano-key.piano-key[class*="bg-[#ff33ff]"] {
   }
 }
 
+/* =========================================================================
+ * iPod "Aqua Glass" skin
+ *
+ * A glassy, translucent reskin of the modern (color-screen) iPod layout.
+ * Shares ALL of the modern skin's geometry and markup — it only restyles
+ * the chrome — and tints the titlebar, row-selection highlight, and the
+ * now-playing progress fill from `--ipod-aqua-accent`, a vivid color
+ * derived from the current track's cover art (see `useCoverGlowColor` in
+ * `IpodScreen.tsx`). When no cover accent is resolved yet, the variable
+ * falls back to a neutral Aqua blue so the skin always reads as "aqua".
+ *
+ * Accent shades are derived live with `color-mix()` so a single hex var
+ * drives the whole palette: lighter mixes (toward white) for gloss
+ * highlights, darker mixes (toward black) for the lozenge base.
+ * ========================================================================= */
+.ipod-aqua-screen {
+  --ipod-aqua-accent: #3aa0ff;
+  /* Frosted, faintly accent-tinted glass surface. */
+  background-color: #f4f7fb;
+  background-image: linear-gradient(
+      180deg,
+      color-mix(in srgb, var(--ipod-aqua-accent) 16%, white) 0%,
+      color-mix(in srgb, var(--ipod-aqua-accent) 7%, white) 42%,
+      color-mix(in srgb, var(--ipod-aqua-accent) 12%, white) 100%
+    ),
+    radial-gradient(
+      120% 70% at 50% -10%,
+      rgba(255, 255, 255, 0.85) 0%,
+      rgba(255, 255, 255, 0) 60%
+    );
+}
+
+/* Glass titlebar: blurs the menu content scrolling beneath it (the
+ * titlebar is sticky), tinted by the cover accent with a bright top
+ * gloss and an accent-colored bottom hairline. */
+.ipod-aqua-screen .ipod-modern-titlebar {
+  background-color: color-mix(in srgb, var(--ipod-aqua-accent) 24%, white);
+  background-image: linear-gradient(
+    180deg,
+    rgba(255, 255, 255, 0.9) 0%,
+    color-mix(in srgb, var(--ipod-aqua-accent) 22%, rgba(255, 255, 255, 0.72))
+      55%,
+    color-mix(in srgb, var(--ipod-aqua-accent) 34%, rgba(255, 255, 255, 0.55))
+      100%
+  );
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.85),
+    inset 0 -1px 0 color-mix(in srgb, var(--ipod-aqua-accent) 55%, transparent);
+  -webkit-backdrop-filter: saturate(1.6) blur(6px);
+  backdrop-filter: saturate(1.6) blur(6px);
+}
+
+/* Menu rows are translucent so the tinted glass surface shows through. */
+.ipod-aqua-screen .ipod-modern-row {
+  background-color: transparent;
+}
+
+.ipod-aqua-screen .ipod-modern-row:hover:not(.ipod-modern-row-selected) {
+  background-color: color-mix(in srgb, var(--ipod-aqua-accent) 14%, transparent);
+}
+
+/* Selection highlight: glossy accent lozenge (top gloss → accent → darker
+ * base) with white text, mirroring the classic Aqua "blue gel" button. */
+.ipod-aqua-screen .ipod-modern-row-selected {
+  background-image: linear-gradient(
+    180deg,
+    color-mix(in srgb, var(--ipod-aqua-accent) 55%, white) 0%,
+    var(--ipod-aqua-accent) 48%,
+    color-mix(in srgb, var(--ipod-aqua-accent) 82%, black) 100%
+  );
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6),
+    inset 0 -1px 0 rgba(0, 0, 0, 0.18);
+  color: #ffffff;
+  text-shadow: 0 1px 1px rgba(0, 0, 0, 0.28);
+}
+
+/* Cover Flow flipped-album header picks up the accent too. */
+.ipod-aqua-screen .ipod-modern-album-header {
+  background-color: color-mix(in srgb, var(--ipod-aqua-accent) 70%, white);
+  background-image: linear-gradient(
+    180deg,
+    color-mix(in srgb, var(--ipod-aqua-accent) 42%, white) 0%,
+    var(--ipod-aqua-accent) 52%,
+    color-mix(in srgb, var(--ipod-aqua-accent) 80%, black) 100%
+  );
+  box-shadow: inset 0 -1px 0 rgba(0, 0, 0, 0.18);
+  color: #ffffff;
+}
+
+/* Now-playing progress fill: accent gel with a top specular gloss and the
+ * same soft vertical sheen bands as the macOS Aqua progress bar. The
+ * compound `.ipod-modern-screen.ipod-aqua-screen` selector (0,3,0) wins
+ * over the shared `.ipod-modern-screen .aqua-progress-fill` rule in
+ * `themes/aqua.css` (0,2,0) regardless of stylesheet order. */
+.ipod-modern-screen.ipod-aqua-screen .aqua-progress-fill {
+  background:
+    repeating-linear-gradient(
+      to right,
+      transparent 0px,
+      rgba(255, 255, 255, 0.18) 10px,
+      rgba(255, 255, 255, 0.24) 15px,
+      rgba(255, 255, 255, 0.18) 20px,
+      transparent 30px
+    ),
+    linear-gradient(
+      to bottom,
+      color-mix(in srgb, var(--ipod-aqua-accent) 30%, white) 0%,
+      var(--ipod-aqua-accent) 52%,
+      color-mix(in srgb, var(--ipod-aqua-accent) 80%, black) 100%
+    );
+  box-shadow: inset 0 0 0 0.5px rgba(0, 0, 0, 0.35),
+    inset 0 1px 0 rgba(255, 255, 255, 0.5),
+    inset 0 -1px 0 rgba(0, 0, 0, 0.28);
+}
+
+.ipod-modern-screen.ipod-aqua-screen .aqua-progress {
+  background:
+    linear-gradient(
+      to bottom,
+      rgba(255, 255, 255, 0.85) 0%,
+      rgba(255, 255, 255, 0.3) 30%,
+      transparent 55%
+    ),
+    color-mix(in srgb, var(--ipod-aqua-accent) 12%, white);
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--ipod-aqua-accent) 32%, transparent),
+    inset 0 1px 2px rgba(0, 0, 0, 0.14);
+}
+
+/* When the LCD backlight times out the shared `.ipod-modern-backlight-off`
+ * dimming filter already applies (the aqua screen keeps that class). */
+
 /* macOS theme override: the `.ipod-force-font *` rule in themes.css sets
  * `font-family: inherit !important`, which would clobber Helvetica Neue.
  * Restore it for the modern skin classes — same approach used for

--- a/src/lib/locales/de/translation.json
+++ b/src/lib/locales/de/translation.json
@@ -2426,6 +2426,7 @@
         "screen": "Bildschirm",
         "screenClassic": "Klassisch",
         "screenModern": "Modern",
+        "screenAqua": "Aqua Glass",
         "searchSongs": "Lieder suchen",
         "shareApp": "App teilen...",
         "shareSong": "Titel teilen...",

--- a/src/lib/locales/en/translation.json
+++ b/src/lib/locales/en/translation.json
@@ -1847,6 +1847,7 @@
         "screen": "Screen",
         "screenClassic": "Classic",
         "screenModern": "Modern",
+        "screenAqua": "Aqua Glass",
         "uiTheme": "UI Theme",
         "deviceTheme": "Device Theme",
         "fullScreen": "Full Screen",

--- a/src/lib/locales/es/translation.json
+++ b/src/lib/locales/es/translation.json
@@ -2426,6 +2426,7 @@
         "screen": "Pantalla",
         "screenClassic": "Clásico",
         "screenModern": "Moderno",
+        "screenAqua": "Aqua Glass",
         "searchSongs": "Buscar canciones",
         "shareApp": "Compartir aplicación...",
         "shareSong": "Compartir canción...",

--- a/src/lib/locales/fr/translation.json
+++ b/src/lib/locales/fr/translation.json
@@ -2426,6 +2426,7 @@
         "screen": "Écran",
         "screenClassic": "Classique",
         "screenModern": "Moderne",
+        "screenAqua": "Aqua Glass",
         "searchSongs": "Rechercher des morceaux",
         "shareApp": "Partager l'app...",
         "shareSong": "Partager le morceau...",

--- a/src/lib/locales/it/translation.json
+++ b/src/lib/locales/it/translation.json
@@ -2426,6 +2426,7 @@
         "screen": "Schermo",
         "screenClassic": "Classico",
         "screenModern": "Moderno",
+        "screenAqua": "Aqua Glass",
         "searchSongs": "Cerca brani",
         "shareApp": "Condividi app...",
         "shareSong": "Condividi brano...",

--- a/src/lib/locales/ja/translation.json
+++ b/src/lib/locales/ja/translation.json
@@ -2426,6 +2426,7 @@
         "screen": "画面",
         "screenClassic": "クラシック",
         "screenModern": "モダン",
+        "screenAqua": "アクアグラス",
         "searchSongs": "曲を検索",
         "shareApp": "アプリを共有...",
         "shareSong": "曲を共有...",

--- a/src/lib/locales/ko/translation.json
+++ b/src/lib/locales/ko/translation.json
@@ -2426,6 +2426,7 @@
         "screen": "화면",
         "screenClassic": "클래식",
         "screenModern": "모던",
+        "screenAqua": "아쿠아 글래스",
         "searchSongs": "노래 검색",
         "shareApp": "앱 공유...",
         "shareSong": "노래 공유...",

--- a/src/lib/locales/pt/translation.json
+++ b/src/lib/locales/pt/translation.json
@@ -2426,6 +2426,7 @@
         "screen": "Tela",
         "screenClassic": "Clássico",
         "screenModern": "Moderno",
+        "screenAqua": "Aqua Glass",
         "searchSongs": "Pesquisar Músicas",
         "shareApp": "Compartilhar App...",
         "shareSong": "Compartilhar Música...",

--- a/src/lib/locales/ru/translation.json
+++ b/src/lib/locales/ru/translation.json
@@ -2426,6 +2426,7 @@
         "screen": "Экран",
         "screenClassic": "Классический",
         "screenModern": "Современный",
+        "screenAqua": "Aqua Glass",
         "searchSongs": "Поиск песен",
         "shareApp": "Поделиться приложением...",
         "shareSong": "Поделиться песней...",

--- a/src/lib/locales/zh-TW/translation.json
+++ b/src/lib/locales/zh-TW/translation.json
@@ -2426,6 +2426,7 @@
         "screen": "螢幕",
         "screenClassic": "經典",
         "screenModern": "現代",
+        "screenAqua": "水玻璃",
         "searchSongs": "搜尋歌曲",
         "shareApp": "分享應用程式…",
         "shareSong": "分享歌曲...",

--- a/src/stores/useIpodStore.ts
+++ b/src/stores/useIpodStore.ts
@@ -212,10 +212,15 @@ interface IpodData {
    *   hardware (click wheel, body) is unchanged — only the contents of
    *   the 150px LCD swap.
    *
+   * - `"aqua"` is an Aqua Glass take on the modern skin: the same layout
+   *   and geometry, but with translucent frosted chrome whose accent
+   *   color (titlebar tint, row-selection highlight, progress fill) is
+   *   derived from the current track's cover-art dominant color.
+   *
    * Persisted across reloads. Defaults to **`"modern"`**; existing saved
    * preferences (including **`"classic"`**) are kept on rehydrate.
    */
-  uiVariant: "classic" | "modern";
+  uiVariant: "classic" | "modern" | "aqua";
   lcdFilterOn: boolean;
   showLyrics: boolean;
   lyricsAlignment: LyricsAlignment;
@@ -489,7 +494,7 @@ export interface IpodState extends IpodData {
   toggleFullScreen: () => void;
   setTheme: (theme: "classic" | "black" | "u2") => void;
   /** Switch between the monochrome classic LCD and the iOS-6 modern skin. */
-  setUiVariant: (variant: "classic" | "modern") => void;
+  setUiVariant: (variant: "classic" | "modern" | "aqua") => void;
   addTrack: (track: Track) => void;
   /** Cache a resolved cover glow color on any local copy of a track. */
   setTrackCoverColor: (trackId: string, coverColor: string) => void;
@@ -2551,7 +2556,9 @@ export const useIpodStore = create<IpodState>()(
               : "2s",
           theme: state.theme,
           uiVariant:
-            state.uiVariant === "modern" || state.uiVariant === "classic"
+            state.uiVariant === "modern" ||
+            state.uiVariant === "classic" ||
+            state.uiVariant === "aqua"
               ? state.uiVariant
               : "modern",
           lcdFilterOn: state.lcdFilterOn,

--- a/tests/test-ipod-apple-music-menu-loading.test.ts
+++ b/tests/test-ipod-apple-music-menu-loading.test.ts
@@ -6,8 +6,10 @@ import {
 } from "../src/apps/ipod/utils/appleMusicMenuLoading";
 
 describe("appleMusicMenuLoading", () => {
-  test("shouldUseModernAppleMusicTitlebarLoading is true only for modern uiVariant", () => {
+  test("shouldUseModernAppleMusicTitlebarLoading is false only for the classic uiVariant", () => {
     expect(shouldUseModernAppleMusicTitlebarLoading("modern")).toBe(true);
+    // Aqua Glass shares the modern color-screen layout (titlebar spinner).
+    expect(shouldUseModernAppleMusicTitlebarLoading("aqua")).toBe(true);
     expect(shouldUseModernAppleMusicTitlebarLoading("classic")).toBe(false);
     expect(shouldUseModernAppleMusicTitlebarLoading(undefined)).toBe(true);
   });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a third on-screen UI variant to the iPod app — **Aqua Glass** — alongside the existing **Classic** (monochrome 1st-gen LCD) and **Modern** (iOS 6 color skin) variants.

Aqua Glass reuses the modern color-screen layout/geometry/markup verbatim and only restyles the chrome:
- Frosted, translucent titlebar (`backdrop-filter` blur) with a bright top gloss.
- Glossy "gel" row-selection highlight lozenge.
- Tinted glass screen background and now-playing progress fill.

Critically, the accent color is **derived live from the current track's cover art** (cached `coverColor` when available, otherwise extracted from the image via the existing `useCoverPalette` / `useCoverGlowColor` pipeline) and exposed through the `--ipod-aqua-accent` CSS variable. All accent shades (gloss highlights, lozenge base) are derived from that single hex with `color-mix()`. When no accent is resolved yet, it falls back to a neutral Aqua blue.

## Walkthrough

Switching the iPod UI theme from Modern (silver titlebar + blue progress) to Aqua Glass (frosted titlebar, progress fill, and selection highlight all tinted to the album-art accent — green here, matching the green cover):

<a href="https://cursor.com/agents/bc-019ee323-a0f8-7d0b-8922-4873980de99d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fipod_aqua_glass_switch.mp4"><img src="https://cursor.com/artifacts/c/art-e3061341-781e-48fe-952d-098ab11d5d6d" alt="ipod_aqua_glass_switch.mp4" /></a>

Aqua Glass menu — frosted green-tinted titlebar and a glossy green selection lozenge, both derived from the now-playing cover art:

![iPod Aqua Glass menu with cover-art-tinted titlebar and selection highlight](https://cursor.com/artifacts/c/art-109ba355-0528-4c6b-8ce3-6621086ca5a5)

## Changes

- `useIpodStore`: widen `uiVariant` to `"classic" | "modern" | "aqua"` (+ `setUiVariant`, persistence/migration).
- `apps/ipod/constants.ts`: add `IpodUiVariant`, `isModernIpodUiVariant()`, `isAquaIpodUiVariant()` helpers; aqua shares the modern layout everywhere.
- Update all `uiVariant === "modern"` layout consumers to treat aqua as modern (screen, chrome, media overlay, menu rows, scrollbar, battery, status, lyrics, cover flow, brick game, music quiz, Apple Music menu loading).
- `IpodScreen`: compute the cover-art accent and inject `--ipod-aqua-accent`; add the `ipod-aqua-screen` class.
- `index.css`: add `.ipod-aqua-screen` Aqua Glass styling (titlebar, rows, selection, album header, progress bar).
- View menu: add the **Aqua Glass** radio item; the menubar UI-theme shortcut now cycles Classic → Modern → Aqua → Classic.
- Locales: add `apps.ipod.menu.screenAqua` to all 10 languages.
- Test: extend `test-ipod-apple-music-menu-loading` to cover the aqua variant.

## Testing

- `bun run test:unit` — 390 pass / 0 fail.
- `bun run build` — succeeds with no type errors.
- `bun run lint` — no new issues in changed files (only pre-existing warnings).
- Manual GUI verification in the iPod app, confirmed via screen recording (above): selecting Aqua Glass tints the titlebar, selection highlight, and progress fill to the cover-art accent; switching to Modern restores the silver/blue look. No layout glitches.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ee323-a0f8-7d0b-8922-4873980de99d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ee323-a0f8-7d0b-8922-4873980de99d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

