### PR TITLE
fix(control-panels): fix build by removing unused props

### DIFF
--- a/src/apps/control-panels/components/control-panels-app/AccountProfileHeader.tsx
+++ b/src/apps/control-panels/components/control-panels-app/AccountProfileHeader.tsx
@@ -27,7 +27,6 @@ export function AccountProfileHeader({
   username,
   myContact,
   accountAvatarLabel,
-  accountAvatarInitials,
   realtimeStatus,
   accountJoinedAt,
   locale,

--- a/src/apps/control-panels/components/control-panels-app/AccountsPaneContent.tsx
+++ b/src/apps/control-panels/components/control-panels-app/AccountsPaneContent.tsx
@@ -85,7 +85,6 @@ type AccountsPaneTab = "accounts" | "security" | "debug";
 
 export function AccountsPaneContent({
   t,
-  tabStyles,
   username,
   myContact,
   accountAvatarLabel,

--- a/src/apps/control-panels/components/control-panels-app/AppearancePaneContent.tsx
+++ b/src/apps/control-panels/components/control-panels-app/AppearancePaneContent.tsx
@@ -48,7 +48,6 @@ export function AppearancePaneContent({
   accentChrome,
   setAccent,
   wallpaperAccentColor,
-  tabStyles,
 }: AppearancePaneContentProps) {
   const themeOptions = useMemo(() => buildThemeSelectOptions(t), [t]);
   const selectedThemeValue = getSelectedThemeSelectValue(currentTheme, aquaMaterial);

--- a/src/apps/control-panels/components/control-panels-app/SystemTabContent.tsx
+++ b/src/apps/control-panels/components/control-panels-app/SystemTabContent.tsx
@@ -90,7 +90,6 @@ export function SystemTabContent({
   username,
   myContact,
   accountAvatarLabel,
-  accountAvatarInitials,
   realtimeStatus,
   debugMode,
   isAdmin,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`bun run build` was failing during `tsc -b` with four `TS6133` "declared but its value is never read" errors, introduced by the recent control-panels Aqua redesign (`a68ab33`).

Removed the unused destructured props from the affected components (the props remain in the type definitions, so callers are unaffected):

- `AccountProfileHeader.tsx` — `accountAvatarInitials`
- `AccountsPaneContent.tsx` — `tabStyles`
- `AppearancePaneContent.tsx` — `tabStyles`
- `SystemTabContent.tsx` — `accountAvatarInitials`

## Testing

- `bun run build` now completes successfully.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ee49f-3944-7a8e-88e4-58c51b1eaffe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ee49f-3944-7a8e-88e4-58c51b1eaffe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

